### PR TITLE
refactor(x86_vcpu): make x86 virtualization OS-neutral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8957,16 +8957,13 @@ dependencies = [
 name = "virtualization-tests"
 version = "0.1.0"
 dependencies = [
- "ax-crate-interface",
  "ax-errno 0.6.1",
- "ax-memory-addr",
  "ax-plat",
  "axdevice",
  "axdevice_base",
  "axvm",
  "axvm-types",
  "irq-framework",
- "x86_vlapic",
 ]
 
 [[package]]
@@ -9640,11 +9637,6 @@ dependencies = [
 name = "x86_vcpu"
 version = "0.5.18"
 dependencies = [
- "ax-crate-interface",
- "ax-errno 0.6.1",
- "ax-memory-addr",
- "axdevice_base",
- "axvm-types",
  "bit_field",
  "bitflags 2.13.0",
  "cfg-if",
@@ -9663,12 +9655,6 @@ dependencies = [
 name = "x86_vlapic"
 version = "0.4.19"
 dependencies = [
- "ax-crate-interface",
- "ax-errno 0.6.1",
- "ax-kspin",
- "ax-memory-addr",
- "axdevice_base",
- "axvm-types",
  "bit",
  "log",
  "paste",

--- a/scripts/axbuild/src/firmware.rs
+++ b/scripts/axbuild/src/firmware.rs
@@ -15,8 +15,10 @@
 
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use sha2::{Digest, Sha256};
+
+use crate::support::download::{download_file_verified_sha256, http_client};
 
 /// Upstream firmware source: the repo referenced by the LicheeRV Nano
 /// buildroot package `aic8800-sdio-firmware`, pinned to a fixed commit.
@@ -119,7 +121,7 @@ pub async fn ensure_aic8800_firmware(workspace_root: &Path) -> Result<()> {
     std::fs::create_dir_all(&dir)
         .with_context(|| format!("failed to create firmware dir {}", dir.display()))?;
 
-    let client = reqwest::Client::new();
+    let client = http_client()?;
     log::info!(
         "fetching {} AIC8800 firmware blob(s) from {}@{}",
         missing.len(),
@@ -132,33 +134,11 @@ pub async fn ensure_aic8800_firmware(workspace_root: &Path) -> Result<()> {
             "https://raw.githubusercontent.com/{}/{}/{}",
             FIRMWARE_REPO, FIRMWARE_COMMIT, file.remote_path
         );
-        let resp = client
-            .get(&url)
-            .send()
-            .await
-            .with_context(|| format!("failed to GET {url}"))?;
-        if !resp.status().is_success() {
-            bail!("GET {url} returned HTTP {}", resp.status());
-        }
-        let bytes = resp
-            .bytes()
-            .await
-            .with_context(|| format!("failed to read body of {url}"))?;
-
-        let actual = sha256_hex(&bytes);
-        if actual != file.sha256 {
-            bail!(
-                "firmware {} sha256 mismatch: expected {}, got {} (from {url})",
-                file.name,
-                file.sha256,
-                actual
-            );
-        }
-
         let dest = dir.join(file.name);
-        std::fs::write(&dest, &bytes)
-            .with_context(|| format!("failed to write {}", dest.display()))?;
-        log::info!("  fetched {} ({} bytes)", file.name, bytes.len());
+        download_file_verified_sha256(&client, &url, &dest, file.sha256)
+            .await
+            .with_context(|| format!("failed to fetch firmware {} from {url}", file.name))?;
+        log::info!("  fetched {}", file.name);
     }
 
     Ok(())

--- a/scripts/axbuild/src/support/download/tests.rs
+++ b/scripts/axbuild/src/support/download/tests.rs
@@ -82,9 +82,11 @@ async fn download_file_restarts_when_range_is_invalid() {
 
 #[tokio::test]
 async fn download_file_retries_transient_http_status() {
-    let server =
-        TestServer::start_with_failures(b"abcdef".to_vec(), vec![StatusCode::GATEWAY_TIMEOUT])
-            .await;
+    let server = TestServer::start_with_failures(
+        b"abcdef".to_vec(),
+        vec![StatusCode::TOO_MANY_REQUESTS, StatusCode::GATEWAY_TIMEOUT],
+    )
+    .await;
     let workspace = tempdir().unwrap();
     let output_path = workspace.path().join("rootfs.img.tar.gz");
 
@@ -94,7 +96,7 @@ async fn download_file_retries_transient_http_status() {
         .unwrap();
 
     assert_eq!(fs::read(&output_path).unwrap(), b"abcdef");
-    assert_eq!(server.request_count(), 2);
+    assert_eq!(server.request_count(), 3);
 }
 
 #[tokio::test]

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -22,8 +22,6 @@ use ax_kspin::SpinNoIrq as Mutex;
 #[cfg(target_arch = "aarch64")]
 use ax_memory_addr::PhysAddr;
 use ax_memory_addr::is_aligned_4k;
-#[cfg(target_arch = "x86_64")]
-use axdevice_base::PortDeviceAdapter;
 use axdevice_base::{
     AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceError, DeviceId,
     DeviceRegistry, InvalidResourceReason, MmioDeviceAdapter, Port, RegistryError, Resource,
@@ -33,7 +31,7 @@ use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr};
 #[cfg(target_arch = "riscv64")]
 use riscv_vplic::VPlicGlobal;
 #[cfg(target_arch = "x86_64")]
-use x86_vlapic::{EmulatedIoApic, EmulatedPit, EmulatedSerialPort, IoApicEoi, IoApicInterrupt};
+use x86_vlapic::{IoApicEoi, IoApicInterrupt};
 
 use crate::{
     AxVmDeviceConfig, DeviceBuildContext, DeviceBundle, DeviceFactoryRegistry, FwCfg,
@@ -41,6 +39,8 @@ use crate::{
 };
 #[cfg(target_arch = "loongarch64")]
 use crate::{LoongArchPchPic, PchPicOutputEvent};
+#[cfg(target_arch = "x86_64")]
+use crate::{X86IoApicDeviceOps, X86PitDeviceOps, X86SerialDeviceOps};
 
 #[inline]
 #[allow(dead_code)]
@@ -75,13 +75,13 @@ pub struct AxVmDevices {
     pollable_devices: Vec<Arc<dyn PollableDeviceOps>>,
     /// x86 IOAPIC — kept for type-specific access.
     #[cfg(target_arch = "x86_64")]
-    x86_ioapic: Option<Arc<EmulatedIoApic>>,
+    x86_ioapic: Option<Arc<dyn X86IoApicDeviceOps>>,
     /// x86 PIT — kept for type-specific access.
     #[cfg(target_arch = "x86_64")]
-    x86_pit: Option<Arc<EmulatedPit>>,
+    x86_pit: Option<Arc<dyn X86PitDeviceOps>>,
     /// x86 16550 serial port — kept for type-specific access.
     #[cfg(target_arch = "x86_64")]
-    x86_serial: Option<Arc<EmulatedSerialPort>>,
+    x86_serial: Option<Arc<dyn X86SerialDeviceOps>>,
     /// LoongArch PCH-PIC — kept for type-specific access.
     #[cfg(target_arch = "loongarch64")]
     loongarch_pch_pic: Option<Arc<LoongArchPchPic>>,
@@ -353,14 +353,7 @@ impl AxVmDevices {
                 EmulatedDeviceType::Console => {
                     #[cfg(target_arch = "x86_64")]
                     {
-                        let serial = Arc::new(EmulatedSerialPort::new());
-                        this.register(PortDeviceAdapter::from_arc(serial.clone())
-                            as Arc<dyn Device + Send + Sync + 'static>)
-                            .map_err(|e| {
-                                ax_err_type!(InvalidInput, format!("register x86 serial: {e:?}"))
-                            })?;
-                        this.x86_serial = Some(serial);
-                        info!("x86 16550 serial initialized for ports 0x3f8..=0x3ff");
+                        debug!("x86 console device registration is owned by AxVM arch adapter");
                     }
                     #[cfg(not(target_arch = "x86_64"))]
                     {
@@ -373,20 +366,7 @@ impl AxVmDevices {
                 EmulatedDeviceType::X86IoApic => {
                     #[cfg(target_arch = "x86_64")]
                     {
-                        let ioapic = Arc::new(EmulatedIoApic::new(
-                            config.base_gpa.into(),
-                            Some(config.length),
-                        ));
-                        this.register(MmioDeviceAdapter::from_arc(ioapic.clone())
-                            as Arc<dyn Device + Send + Sync + 'static>)
-                            .map_err(|e| {
-                                ax_err_type!(InvalidInput, format!("register x86 ioapic: {e:?}"))
-                            })?;
-                        this.x86_ioapic = Some(ioapic);
-                        info!(
-                            "x86 IO APIC initialized with base GPA {:#x} and length {:#x}",
-                            config.base_gpa, config.length
-                        );
+                        debug!("x86 IOAPIC device registration is owned by AxVM arch adapter");
                     }
                     #[cfg(not(target_arch = "x86_64"))]
                     {
@@ -399,13 +379,7 @@ impl AxVmDevices {
                 EmulatedDeviceType::X86Pit => {
                     #[cfg(target_arch = "x86_64")]
                     {
-                        let pit = Arc::new(EmulatedPit::new());
-                        this.register(PortDeviceAdapter::from_arc(pit.clone()) as Arc<dyn Device>)
-                            .map_err(|e| {
-                                ax_err_type!(InvalidInput, format!("register x86 pit: {e:?}"))
-                            })?;
-                        this.x86_pit = Some(pit);
-                        info!("x86 PIT initialized for ports 0x40..=0x43 and 0x61");
+                        debug!("x86 PIT device registration is owned by AxVM arch adapter");
                     }
                     #[cfg(not(target_arch = "x86_64"))]
                     {
@@ -963,6 +937,42 @@ impl AxVmDevices {
         self.x86_serial
             .as_ref()
             .is_some_and(|serial| serial.poll_irq())
+    }
+
+    /// Add an x86 IOAPIC device to the generic registry and x86 runtime handle.
+    #[cfg(target_arch = "x86_64")]
+    pub fn add_x86_ioapic_dev<D>(&mut self, dev: Arc<D>) -> AxResult
+    where
+        D: Device + X86IoApicDeviceOps + 'static,
+    {
+        self.register(dev.clone() as Arc<dyn Device>)
+            .map_err(|e| ax_err_type!(InvalidInput, format!("register x86 ioapic: {e:?}")))?;
+        self.x86_ioapic = Some(dev);
+        Ok(())
+    }
+
+    /// Add an x86 PIT device to the generic registry and x86 runtime handle.
+    #[cfg(target_arch = "x86_64")]
+    pub fn add_x86_pit_dev<D>(&mut self, dev: Arc<D>) -> AxResult
+    where
+        D: Device + X86PitDeviceOps + 'static,
+    {
+        self.register(dev.clone() as Arc<dyn Device>)
+            .map_err(|e| ax_err_type!(InvalidInput, format!("register x86 pit: {e:?}")))?;
+        self.x86_pit = Some(dev);
+        Ok(())
+    }
+
+    /// Add an x86 COM1 device to the generic registry and x86 runtime handle.
+    #[cfg(target_arch = "x86_64")]
+    pub fn add_x86_serial_dev<D>(&mut self, dev: Arc<D>) -> AxResult
+    where
+        D: Device + X86SerialDeviceOps + 'static,
+    {
+        self.register(dev.clone() as Arc<dyn Device>)
+            .map_err(|e| ax_err_type!(InvalidInput, format!("register x86 serial: {e:?}")))?;
+        self.x86_serial = Some(dev);
+        Ok(())
     }
 
     /// Add a QEMU fw_cfg MMIO device to the device list.

--- a/virtualization/axdevice/src/lib.rs
+++ b/virtualization/axdevice/src/lib.rs
@@ -35,6 +35,8 @@ mod fw_cfg;
 mod loongarch_pch_pic;
 mod range_alloc;
 mod registration;
+#[cfg(target_arch = "x86_64")]
+mod x86;
 
 #[cfg(target_arch = "aarch64")]
 pub use adapter::create_vtimer_devices;
@@ -56,6 +58,11 @@ pub use fw_cfg::{
 #[cfg(target_arch = "loongarch64")]
 pub use loongarch_pch_pic::{LoongArchPchPic, PchPicOutputEvent};
 pub use registration::{DeviceBundle, DeviceRegistration, PollableDeviceOps};
+#[cfg(target_arch = "x86_64")]
+pub use x86::{
+    X86IoApicDevice, X86IoApicDeviceOps, X86PitDevice, X86PitDeviceOps, X86SerialDeviceOps,
+    X86SerialPortDevice,
+};
 #[cfg(target_arch = "x86_64")]
 pub use x86_vlapic::IoApicInterrupt;
 // pub use virtio_dev::*;

--- a/virtualization/axdevice/src/x86.rs
+++ b/virtualization/axdevice/src/x86.rs
@@ -1,0 +1,287 @@
+//! AxVM-facing adapters for OS-neutral x86 virtual interrupt-controller devices.
+
+use alloc::{boxed::Box, string::String};
+use core::{any::Any, marker::PhantomData};
+
+use axdevice_base::{AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceError, Resource};
+use x86_vlapic::{
+    EmulatedIoApic, EmulatedPit, EmulatedSerialPort, IoApicEoi, IoApicInterrupt, X86AccessWidth,
+    X86GuestPhysAddr, X86GuestPhysAddrRange, X86Port, X86PortRange, X86VlapicHostOps,
+};
+
+/// Type-specific IOAPIC capability used by the x86 interrupt runtime.
+pub trait X86IoApicDeviceOps: Send + Sync {
+    /// Return the guest interrupt vector programmed for a GSI.
+    fn vector_for_gsi(&self, gsi: usize) -> Option<u8>;
+
+    /// Assert an IOAPIC GSI and return an interrupt to inject if one is unmasked.
+    fn assert_gsi(&self, gsi: usize) -> Option<IoApicInterrupt>;
+
+    /// Broadcast a local APIC EOI to the IOAPIC.
+    fn end_of_interrupt(&self, vector: u8) -> Option<IoApicEoi>;
+}
+
+/// Type-specific PIT capability used by the x86 interrupt runtime.
+pub trait X86PitDeviceOps: Send + Sync {
+    /// Consume a pending PIT IRQ0 tick if the deadline is due.
+    fn consume_irq0_if_due(&self, now_ns: u64) -> bool;
+}
+
+/// Type-specific COM1 capability used by the x86 interrupt runtime.
+pub trait X86SerialDeviceOps: Send + Sync {
+    /// Poll host input and return whether COM1 should assert an IRQ.
+    fn poll_irq(&self) -> bool;
+}
+
+/// Unified-device adapter for [`EmulatedIoApic`].
+pub struct X86IoApicDevice {
+    inner: EmulatedIoApic,
+    name: String,
+    resources: Box<[Resource]>,
+}
+
+impl X86IoApicDevice {
+    /// Creates an IOAPIC adapter with the given guest MMIO range.
+    pub fn new(base: X86GuestPhysAddr, size: Option<usize>) -> Self {
+        let inner = EmulatedIoApic::new(base, size);
+        let resources = mmio_resources(inner.address_range());
+        Self {
+            inner,
+            name: String::from("x86-ioapic"),
+            resources,
+        }
+    }
+
+    /// Returns the wrapped OS-neutral IOAPIC core.
+    pub const fn inner(&self) -> &EmulatedIoApic {
+        &self.inner
+    }
+}
+
+impl X86IoApicDeviceOps for X86IoApicDevice {
+    fn vector_for_gsi(&self, gsi: usize) -> Option<u8> {
+        self.inner.vector_for_gsi(gsi)
+    }
+
+    fn assert_gsi(&self, gsi: usize) -> Option<IoApicInterrupt> {
+        self.inner.assert_gsi(gsi)
+    }
+
+    fn end_of_interrupt(&self, vector: u8) -> Option<IoApicEoi> {
+        self.inner.end_of_interrupt(vector)
+    }
+}
+
+impl Device for X86IoApicDevice {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+        if access.kind != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        let addr = X86GuestPhysAddr::from_usize(access.addr as usize);
+        let width = x86_access_width(access.width);
+        if access.is_read {
+            self.inner
+                .handle_read(addr, width)
+                .map(|value| BusResponse::Read {
+                    value: value as u64,
+                })
+                .map_err(|_| DeviceError::Internal)
+        } else {
+            self.inner
+                .handle_write(addr, width, access.data as usize)
+                .map(|_| BusResponse::Write)
+                .map_err(|_| DeviceError::Internal)
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Unified-device adapter for [`EmulatedPit`].
+pub struct X86PitDevice<H: X86VlapicHostOps> {
+    inner: EmulatedPit<H>,
+    name: String,
+    resources: Box<[Resource]>,
+    _host: PhantomData<fn() -> H>,
+}
+
+impl<H: X86VlapicHostOps> X86PitDevice<H> {
+    /// Creates a PIT adapter.
+    pub fn new() -> Self {
+        let inner = EmulatedPit::<H>::new();
+        let resources = port_resources(inner.address_range());
+        Self {
+            inner,
+            name: String::from("x86-pit"),
+            resources,
+            _host: PhantomData,
+        }
+    }
+
+    /// Returns the wrapped OS-neutral PIT core.
+    pub const fn inner(&self) -> &EmulatedPit<H> {
+        &self.inner
+    }
+}
+
+impl<H: X86VlapicHostOps> Default for X86PitDevice<H> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<H: X86VlapicHostOps> X86PitDeviceOps for X86PitDevice<H> {
+    fn consume_irq0_if_due(&self, now_ns: u64) -> bool {
+        self.inner.consume_irq0_if_due(now_ns)
+    }
+}
+
+impl<H: X86VlapicHostOps + 'static> Device for X86PitDevice<H> {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+        if access.kind != BusKind::Port {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        let port = X86Port::new(
+            u16::try_from(access.addr)
+                .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?,
+        );
+        let width = x86_access_width(access.width);
+        if access.is_read {
+            self.inner
+                .handle_read(port, width)
+                .map(|value| BusResponse::Read {
+                    value: value as u64,
+                })
+                .map_err(|_| DeviceError::Internal)
+        } else {
+            self.inner
+                .handle_write(port, width, access.data as usize)
+                .map(|_| BusResponse::Write)
+                .map_err(|_| DeviceError::Internal)
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Unified-device adapter for [`EmulatedSerialPort`].
+pub struct X86SerialPortDevice<H: X86VlapicHostOps> {
+    inner: EmulatedSerialPort<H>,
+    name: String,
+    resources: Box<[Resource]>,
+    _host: PhantomData<fn() -> H>,
+}
+
+impl<H: X86VlapicHostOps> X86SerialPortDevice<H> {
+    /// Creates a COM1 adapter.
+    pub fn new() -> Self {
+        let inner = EmulatedSerialPort::<H>::new();
+        let resources = port_resources(inner.address_range());
+        Self {
+            inner,
+            name: String::from("x86-serial-com1"),
+            resources,
+            _host: PhantomData,
+        }
+    }
+
+    /// Returns the wrapped OS-neutral COM1 core.
+    pub const fn inner(&self) -> &EmulatedSerialPort<H> {
+        &self.inner
+    }
+}
+
+impl<H: X86VlapicHostOps> Default for X86SerialPortDevice<H> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<H: X86VlapicHostOps> X86SerialDeviceOps for X86SerialPortDevice<H> {
+    fn poll_irq(&self) -> bool {
+        self.inner.poll_irq()
+    }
+}
+
+impl<H: X86VlapicHostOps + 'static> Device for X86SerialPortDevice<H> {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn handle(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+        if access.kind != BusKind::Port {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        let port = X86Port::new(
+            u16::try_from(access.addr)
+                .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?,
+        );
+        let width = x86_access_width(access.width);
+        if access.is_read {
+            self.inner
+                .handle_read(port, width)
+                .map(|value| BusResponse::Read {
+                    value: value as u64,
+                })
+                .map_err(|_| DeviceError::Internal)
+        } else {
+            self.inner
+                .handle_write(port, width, access.data as usize)
+                .map(|_| BusResponse::Write)
+                .map_err(|_| DeviceError::Internal)
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+fn x86_access_width(width: AccessWidth) -> X86AccessWidth {
+    match width {
+        AccessWidth::Byte => X86AccessWidth::Byte,
+        AccessWidth::Word => X86AccessWidth::Word,
+        AccessWidth::Dword => X86AccessWidth::Dword,
+        AccessWidth::Qword => X86AccessWidth::Qword,
+    }
+}
+
+fn mmio_resources(range: X86GuestPhysAddrRange) -> Box<[Resource]> {
+    let base = range.start.as_usize() as u64;
+    let size = range.end.as_usize().saturating_sub(range.start.as_usize()) as u64;
+    alloc::vec![Resource::MmioRange { base, size }].into_boxed_slice()
+}
+
+fn port_resources(range: X86PortRange) -> Box<[Resource]> {
+    let base = range.start.number();
+    let size = range
+        .end
+        .number()
+        .saturating_sub(range.start.number())
+        .saturating_add(1);
+    alloc::vec![Resource::PortRange { base, size }].into_boxed_slice()
+}

--- a/virtualization/axvm/src/arch/mod.rs
+++ b/virtualization/axvm/src/arch/mod.rs
@@ -5,14 +5,18 @@ use alloc::{format, vec::Vec};
 use ax_errno::{AxResult, ax_err};
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axaddrspace::NestedPageTableOps;
+#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
+use axvm_types::VmExit;
 use axvm_types::{
     AccessWidth, GuestPhysAddr, NestedPagingConfig, PassThroughPortConfig, SysRegAddr,
     VMInterruptMode, VmArchPerCpuOps, VmArchVcpuOps, VmVcpuState,
 };
 #[cfg(not(target_arch = "aarch64"))]
-use axvm_types::{MappingFlags, Port, VmExit};
+use axvm_types::{MappingFlags, Port};
 
-use crate::{CpuMask, StopReason};
+#[cfg(not(target_arch = "x86_64"))]
+use crate::CpuMask;
+use crate::StopReason;
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
@@ -45,6 +49,19 @@ pub(crate) fn guest_page_table_levels(
 
 pub(crate) fn new_nested_page_table(levels: usize) -> AxResult<ArchNestedPageTable> {
     CurrentArch::new_nested_page_table(levels)
+}
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) fn register_x86_arch_device(
+    config: &axvm_types::EmulatedDeviceConfig,
+    devices: &mut axdevice::AxVmDevices,
+) -> AxResult {
+    x86_64::register_arch_device(config, devices)
+}
+
+#[cfg(all(target_arch = "x86_64", feature = "vmx"))]
+pub(crate) fn x86_apic_access_page_addr() -> axvm_types::HostPhysAddr {
+    x86_64::x86_apic_access_page_addr()
 }
 
 pub(crate) fn nested_paging_config(
@@ -80,9 +97,14 @@ pub(crate) enum BoundVcpuExit<D> {
 #[cfg(not(target_arch = "aarch64"))]
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum LegacyDeferredRunWork {
-    ExternalInterrupt { vector: usize },
+    ExternalInterrupt {
+        vector: usize,
+    },
     PreemptionTimer,
-    InterruptEnd { vector: Option<u8> },
+    InterruptEnd {
+        vector: Option<u8>,
+    },
+    #[cfg(not(target_arch = "x86_64"))]
     Idle,
 }
 
@@ -143,6 +165,7 @@ pub(crate) struct HypercallExit {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[cfg(not(target_arch = "x86_64"))]
 pub(crate) struct CpuUpExit {
     pub(crate) target_cpu: u64,
     pub(crate) entry_point: GuestPhysAddr,
@@ -150,6 +173,7 @@ pub(crate) struct CpuUpExit {
 }
 
 #[derive(Clone, Copy, Debug)]
+#[cfg(not(target_arch = "x86_64"))]
 pub(crate) struct SendIpiExit {
     pub(crate) target_cpu: u64,
     pub(crate) target_cpu_aux: u64,
@@ -238,6 +262,7 @@ pub(crate) trait ArchOps {
         default_vcpu_affinities(cpu_num, phys_cpu_ids, phys_cpu_sets)
     }
 
+    #[cfg(not(target_arch = "x86_64"))]
     fn ipi_targets(
         vm: &crate::AxVMRef,
         current_vcpu_id: usize,
@@ -264,10 +289,12 @@ pub(crate) trait ArchOps {
         targets
     }
 
+    #[cfg(not(target_arch = "x86_64"))]
     fn set_vcpu_on_args(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>, _vcpu_id: usize, arg: usize) {
         vcpu.set_gpr(0, arg);
     }
 
+    #[cfg(not(target_arch = "x86_64"))]
     fn set_cpu_up_success(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         vcpu.set_gpr(0, 0);
     }
@@ -339,6 +366,7 @@ pub(crate) trait ArchOps {
     }
 
     #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(not(target_arch = "x86_64"))]
     fn handle_idle(_vm: &crate::AxVMRef, _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
         crate::check_timer_events();
     }
@@ -347,6 +375,7 @@ pub(crate) trait ArchOps {
 
     fn after_mmio_write(_vm: &crate::AxVMRef) {}
 
+    #[cfg(not(target_arch = "x86_64"))]
     fn cpu_up_target_vcpu_id(vm: &crate::AxVMRef, target_cpu: u64) -> Option<usize> {
         vm.get_vcpu_affinities_pcpu_ids()
             .iter()
@@ -496,7 +525,7 @@ pub(crate) fn handle_sys_reg_write<D>(
     Ok(BoundVcpuExit::Continue)
 }
 
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
 pub(crate) fn handle_nested_page_fault<A>(
     vm: &crate::AxVMRef,
     vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
@@ -559,6 +588,7 @@ pub(crate) fn handle_hypercall<V: VmArchVcpuOps, D>(
     Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
 }
 
+#[cfg(not(target_arch = "x86_64"))]
 pub(crate) fn handle_cpu_up<A: ArchOps>(
     vm: &crate::AxVMRef,
     vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
@@ -595,6 +625,7 @@ pub(crate) fn handle_cpu_up<A: ArchOps>(
     Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
 }
 
+#[cfg(not(target_arch = "x86_64"))]
 pub(crate) fn handle_send_ipi<A: ArchOps>(
     vm: &crate::AxVMRef,
     vcpu_id: usize,
@@ -641,7 +672,7 @@ pub(crate) fn handle_send_ipi<A: ArchOps>(
 
 /// Transitional handler for architecture backends that still return the legacy
 /// common `VmExit` while their raw exit enums are being split out.
-#[cfg(not(target_arch = "aarch64"))]
+#[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
 pub(crate) fn handle_transitional_vm_exit<A>(
     vm: &crate::AxVMRef,
     vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
@@ -785,6 +816,7 @@ where
         LegacyDeferredRunWork::InterruptEnd { vector } => {
             A::after_interrupt_end(vm, vcpu, vector);
         }
+        #[cfg(not(target_arch = "x86_64"))]
         LegacyDeferredRunWork::Idle => {
             A::handle_idle(vm, vcpu);
         }

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -1,18 +1,34 @@
-use alloc::boxed::Box;
-use core::time::Duration;
+//! AxVM x86_64 adapter.
+//!
+//! This module owns the AxVM/ArceOS glue for the OS-neutral `x86_vcpu` and
+//! `x86_vlapic` cores.
 
-use ax_crate_interface::impl_interface;
-use ax_errno::AxResult;
-use ax_memory_addr::{PhysAddr, VirtAddr};
-use axvm_types::{InterruptVector, VCpuId, VMId};
-use x86_vcpu::host::X86VcpuHostIf;
-use x86_vlapic::host::X86VlapicHostIf;
+use alloc::{boxed::Box, sync::Arc};
+use core::{arch::asm, time::Duration};
+
+use ax_errno::{AxError, AxResult};
+use axvm_types::{
+    AccessWidth, EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, InterruptTriggerMode,
+    MappingFlags, NestedPagingConfig, Port, SysRegAddr, VCpuId, VMId, VmArchPerCpuOps,
+    VmArchVcpuOps,
+};
+use x86_vcpu::{
+    X86AccessFlags, X86AccessWidth, X86GuestPhysAddr, X86HostOps, X86HostPhysAddr, X86HostVirtAddr,
+    X86MsrAddr, X86NestedPagingConfig, X86Port, X86VCpuCreateConfig, X86VCpuSetupConfig,
+    X86VcpuError, X86VcpuResult, X86VmExit,
+};
+use x86_vlapic::{
+    X86InterruptVector, X86TimerCallback, X86VcpuId, X86VlapicError, X86VlapicHostOps,
+    X86VlapicResult, X86VmId,
+};
 
 use super::{
-    ArchOps, BoundVcpuExit, LegacyDeferredRunWork, VcpuCreateContext, VcpuRunAction,
-    VcpuSetupContext,
+    ArchOps, BoundVcpuExit, HypercallExit, IoReadExit, IoWriteExit, LegacyDeferredRunWork,
+    MmioReadExit, MmioWriteExit, NestedPageFaultExit, SysRegReadExit, SysRegWriteExit,
+    VcpuCreateContext, VcpuRunAction, VcpuSetupContext,
 };
 use crate::{
+    StopReason,
     host::{HostConsole, HostMemory, HostTime, default_host},
     manager,
     vcpu::get_current_vcpu,
@@ -20,13 +36,17 @@ use crate::{
 
 mod npt;
 
+const QEMU_EXIT_PORT: u16 = 0x604;
+const QEMU_EXIT_MAGIC: u64 = 0x2000;
+const RFLAGS_INTERRUPT_FLAG: u64 = 1 << 9;
+
 pub(crate) struct X86_64Arch;
 
 pub(crate) struct X86VcpuCreateState;
 
 impl ArchOps for X86_64Arch {
-    type VCpu = x86_vcpu::X86ArchVCpu;
-    type PerCpu = x86_vcpu::X86ArchPerCpuState;
+    type VCpu = AxvmX86Vcpu;
+    type PerCpu = AxvmX86PerCpu;
     type VcpuCreateState = X86VcpuCreateState;
     type DeferredRunWork = LegacyDeferredRunWork;
     type NestedPageTable = npt::NestedPageTable<crate::HostPagingHandler>;
@@ -44,19 +64,19 @@ impl ArchOps for X86_64Arch {
     fn build_vcpu_create_config(
         _state: &Self::VcpuCreateState,
         _ctx: VcpuCreateContext,
-    ) -> AxResult<<Self::VCpu as axvm_types::VmArchVcpuOps>::CreateConfig> {
-        Ok(x86_vcpu::X86VCpuCreateConfig)
+    ) -> AxResult<<Self::VCpu as VmArchVcpuOps>::CreateConfig> {
+        Ok(X86VCpuCreateConfig)
     }
 
     fn build_vcpu_setup_config(
         ctx: VcpuSetupContext<'_>,
-    ) -> AxResult<<Self::VCpu as axvm_types::VmArchVcpuOps>::SetupConfig> {
-        let mut config = x86_vcpu::X86VCpuSetupConfig {
+    ) -> AxResult<<Self::VCpu as VmArchVcpuOps>::SetupConfig> {
+        let mut config = X86VCpuSetupConfig {
             emulate_com1: ctx.emulates_console,
             ..Default::default()
         };
         for port in ctx.passthrough_ports {
-            config.add_passthrough_port_range(port.base, port.length)?;
+            x86_result(config.add_passthrough_port_range(port.base, port.length))?;
         }
         Ok(config)
     }
@@ -111,9 +131,125 @@ impl ArchOps for X86_64Arch {
     fn handle_vcpu_exit_bound(
         vm: &crate::AxVMRef,
         vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
-        exit: <Self::VCpu as axvm_types::VmArchVcpuOps>::Exit,
+        exit: <Self::VCpu as VmArchVcpuOps>::Exit,
     ) -> AxResult<BoundVcpuExit<Self::DeferredRunWork>> {
-        super::handle_transitional_vm_exit::<Self>(vm, vcpu, exit)
+        match exit {
+            X86VmExit::Hypercall { nr, args } => {
+                super::handle_hypercall(vm, vcpu, HypercallExit { nr, args })
+            }
+            X86VmExit::PortIoRead { port, width } => super::handle_io_read::<Self>(
+                vm,
+                vcpu,
+                IoReadExit {
+                    port: x86_port_to_ax(port),
+                    width: x86_access_width_to_ax(width),
+                },
+            ),
+            X86VmExit::PortIoWrite { port, width, data } => {
+                if x86_qemu_shutdown_port(port, width, data) {
+                    warn!("VM[{}] run VCpu[{}] SystemDown", vm.id(), vcpu.id());
+                    Ok(BoundVcpuExit::Complete(VcpuRunAction::Stop(
+                        StopReason::SystemDown,
+                    )))
+                } else {
+                    super::handle_io_write(
+                        vm,
+                        IoWriteExit {
+                            port: x86_port_to_ax(port),
+                            width: x86_access_width_to_ax(width),
+                            data,
+                        },
+                    )
+                }
+            }
+            X86VmExit::MmioRead {
+                addr,
+                width,
+                reg,
+                reg_width,
+                signed_ext,
+            } => super::handle_mmio_read(
+                vm,
+                vcpu,
+                MmioReadExit {
+                    addr: x86_guest_phys_addr_to_ax(addr),
+                    width: x86_access_width_to_ax(width),
+                    reg,
+                    reg_width: x86_access_width_to_ax(reg_width),
+                    signed_ext,
+                },
+            ),
+            X86VmExit::MmioWrite { addr, width, data } => super::handle_mmio_write::<Self>(
+                vm,
+                MmioWriteExit {
+                    addr: x86_guest_phys_addr_to_ax(addr),
+                    width: x86_access_width_to_ax(width),
+                    data,
+                },
+            ),
+            X86VmExit::MsrRead { addr } => super::handle_sys_reg_read(
+                vm,
+                vcpu,
+                SysRegReadExit {
+                    addr: x86_msr_addr_to_ax(addr),
+                    reg: 0,
+                },
+            ),
+            X86VmExit::MsrWrite { addr, value } => super::handle_sys_reg_write(
+                vm,
+                SysRegWriteExit {
+                    addr: x86_msr_addr_to_ax(addr),
+                    value,
+                },
+            ),
+            X86VmExit::NestedPageFault { addr, access_flags } => {
+                handle_x86_nested_page_fault::<Self>(
+                    vm,
+                    NestedPageFaultExit {
+                        addr: x86_guest_phys_addr_to_ax(addr),
+                        access_flags: x86_access_flags_to_ax(access_flags),
+                    },
+                )
+            }
+            X86VmExit::ExternalInterrupt { vector } => {
+                debug!("VM[{}] run VCpu[{}] get irq {vector}", vm.id(), vcpu.id());
+                Ok(BoundVcpuExit::Defer(
+                    LegacyDeferredRunWork::ExternalInterrupt {
+                        vector: vector as usize,
+                    },
+                ))
+            }
+            X86VmExit::PreemptionTimer => {
+                Ok(BoundVcpuExit::Defer(LegacyDeferredRunWork::PreemptionTimer))
+            }
+            X86VmExit::InterruptEnd { vector } => {
+                Ok(BoundVcpuExit::Defer(LegacyDeferredRunWork::InterruptEnd {
+                    vector,
+                }))
+            }
+            X86VmExit::Halt => {
+                debug!("VM[{}] run VCpu[{}] Halt", vm.id(), vcpu.id());
+                Ok(BoundVcpuExit::Complete(Self::handle_halt()))
+            }
+            X86VmExit::SystemDown => {
+                warn!("VM[{}] run VCpu[{}] SystemDown", vm.id(), vcpu.id());
+                Ok(BoundVcpuExit::Complete(VcpuRunAction::Stop(
+                    StopReason::SystemDown,
+                )))
+            }
+            X86VmExit::FailEntry {
+                hardware_entry_failure_reason,
+            } => {
+                warn!(
+                    "VM[{}] VCpu[{}] run failed with exit code {hardware_entry_failure_reason}",
+                    vm.id(),
+                    vcpu.id()
+                );
+                Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
+            }
+            X86VmExit::Nothing => Ok(BoundVcpuExit::Continue),
+            _ => Err(AxError::Unsupported),
+        }
     }
 
     fn finish_deferred_run_work(
@@ -125,68 +261,38 @@ impl ArchOps for X86_64Arch {
     }
 }
 
-struct X86VcpuHostIfImpl;
+pub(crate) struct AxvmX86HostOps;
 
-#[impl_interface]
-impl X86VcpuHostIf for X86VcpuHostIfImpl {
-    fn alloc_frame() -> Option<PhysAddr> {
-        default_host().alloc_frame()
+impl X86VlapicHostOps for AxvmX86HostOps {
+    fn alloc_frame() -> Option<x86_vlapic::X86HostPhysAddr> {
+        default_host()
+            .alloc_frame()
+            .map(|addr| x86_vlapic::X86HostPhysAddr::from_usize(addr.as_usize()))
     }
 
-    fn dealloc_frame(paddr: PhysAddr) {
-        default_host().dealloc_frame(paddr);
+    fn dealloc_frame(paddr: x86_vlapic::X86HostPhysAddr) {
+        default_host().dealloc_frame(axvm_types::HostPhysAddr::from(paddr.as_usize()));
     }
 
-    fn alloc_contiguous_frames(frame_count: usize, frame_align: usize) -> Option<PhysAddr> {
-        default_host().alloc_contiguous_frames(frame_count, frame_align)
+    fn phys_to_virt(paddr: x86_vlapic::X86HostPhysAddr) -> x86_vlapic::X86HostVirtAddr {
+        let vaddr = default_host().phys_to_virt(axvm_types::HostPhysAddr::from(paddr.as_usize()));
+        x86_vlapic::X86HostVirtAddr::from_usize(vaddr.as_usize())
     }
 
-    fn dealloc_contiguous_frames(start_paddr: PhysAddr, frame_count: usize) {
-        default_host().dealloc_contiguous_frames(start_paddr, frame_count);
-    }
-
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
-        default_host().phys_to_virt(paddr)
-    }
-
-    fn nanos_to_ticks(nanos: u64) -> u64 {
-        default_host().nanos_to_ticks(nanos)
-    }
-}
-
-struct X86VlapicHostIfImpl;
-
-#[impl_interface]
-impl X86VlapicHostIf for X86VlapicHostIfImpl {
-    fn alloc_frame() -> Option<PhysAddr> {
-        default_host().alloc_frame()
-    }
-
-    fn dealloc_frame(paddr: PhysAddr) {
-        default_host().dealloc_frame(paddr);
-    }
-
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
-        default_host().phys_to_virt(paddr)
-    }
-
-    fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
-        default_host().virt_to_phys(vaddr)
-    }
-
-    fn current_time() -> Duration {
-        default_host().monotonic_time()
+    fn virt_to_phys(vaddr: x86_vlapic::X86HostVirtAddr) -> x86_vlapic::X86HostPhysAddr {
+        let paddr = default_host().virt_to_phys(axvm_types::HostVirtAddr::from(vaddr.as_usize()));
+        x86_vlapic::X86HostPhysAddr::from_usize(paddr.as_usize())
     }
 
     fn current_time_nanos() -> u64 {
-        default_host().monotonic_time().as_nanos() as u64
+        crate::host::arceos::monotonic_time_nanos()
     }
 
-    fn register_timer(
-        deadline: Duration,
-        callback: Box<dyn FnOnce(Duration) + Send + 'static>,
-    ) -> usize {
-        default_host().register_timer(deadline.as_nanos() as u64, callback)
+    fn register_timer(deadline_nanos: u64, callback: X86TimerCallback) -> Option<usize> {
+        Some(default_host().register_timer(
+            deadline_nanos,
+            Box::new(move |deadline: Duration| callback(deadline.as_nanos() as u64)),
+        ))
     }
 
     fn cancel_timer(token: usize) {
@@ -201,8 +307,8 @@ impl X86VlapicHostIf for X86VlapicHostIfImpl {
         default_host().read_bytes(bytes)
     }
 
-    fn current_vm_id() -> VMId {
-        get_current_vcpu::<x86_vcpu::X86ArchVCpu>()
+    fn current_vm_id() -> X86VmId {
+        get_current_vcpu::<AxvmX86Vcpu>()
             .expect("current x86 vCPU is not set")
             .vm_id()
     }
@@ -216,11 +322,375 @@ impl X86VlapicHostIf for X86VlapicHostIfImpl {
         manager::active_vcpu_mask(Self::current_vm_id()).unwrap_or(0)
     }
 
-    fn active_vcpus(vm_id: VMId) -> Option<usize> {
+    fn active_vcpus(vm_id: X86VmId) -> Option<usize> {
         manager::active_vcpu_mask(vm_id)
     }
 
-    fn inject_interrupt(vm_id: VMId, vcpu_id: VCpuId, vector: InterruptVector) -> AxResult {
-        manager::inject_interrupt(vm_id, vcpu_id, vector as usize)
+    fn inject_interrupt(
+        vm_id: X86VmId,
+        vcpu_id: X86VcpuId,
+        vector: X86InterruptVector,
+    ) -> X86VlapicResult {
+        manager::inject_interrupt(vm_id, vcpu_id, vector as usize).map_err(ax_error_to_vlapic)
+    }
+}
+
+impl X86HostOps for AxvmX86HostOps {
+    fn alloc_frame() -> Option<X86HostPhysAddr> {
+        default_host()
+            .alloc_frame()
+            .map(|addr| X86HostPhysAddr::from_usize(addr.as_usize()))
+    }
+
+    fn dealloc_frame(paddr: X86HostPhysAddr) {
+        default_host().dealloc_frame(axvm_types::HostPhysAddr::from(paddr.as_usize()));
+    }
+
+    fn alloc_contiguous_frames(frame_count: usize, frame_align: usize) -> Option<X86HostPhysAddr> {
+        default_host()
+            .alloc_contiguous_frames(frame_count, frame_align)
+            .map(|addr| X86HostPhysAddr::from_usize(addr.as_usize()))
+    }
+
+    fn dealloc_contiguous_frames(start_paddr: X86HostPhysAddr, frame_count: usize) {
+        default_host().dealloc_contiguous_frames(
+            axvm_types::HostPhysAddr::from(start_paddr.as_usize()),
+            frame_count,
+        );
+    }
+
+    fn phys_to_virt(paddr: X86HostPhysAddr) -> X86HostVirtAddr {
+        let vaddr = default_host().phys_to_virt(axvm_types::HostPhysAddr::from(paddr.as_usize()));
+        X86HostVirtAddr::from_usize(vaddr.as_usize())
+    }
+
+    fn read_guest_u8(paddr: X86GuestPhysAddr) -> X86VcpuResult<u8> {
+        let vcpu = get_current_vcpu::<AxvmX86Vcpu>().ok_or(X86VcpuError::BadState)?;
+        let mut byte = [0u8; 1];
+        let result = manager::with_vm(vcpu.vm_id(), |vm| {
+            vm.read_from_guest(GuestPhysAddr::from(paddr.as_usize()), &mut byte)
+        })
+        .ok_or(X86VcpuError::BadState)?;
+        result.map_err(|_| X86VcpuError::BadState)?;
+        Ok(byte[0])
+    }
+
+    fn nanos_to_ticks(nanos: u64) -> u64 {
+        default_host().nanos_to_ticks(nanos)
+    }
+
+    fn poll_host_interrupt() -> Option<u8> {
+        let host_rflags = current_rflags();
+        unsafe {
+            asm!("sti", "nop", options(nomem, nostack));
+        }
+        restore_host_interrupt_flag(host_rflags);
+        None
+    }
+}
+
+pub(crate) struct AxvmX86Vcpu(x86_vcpu::X86ArchVCpu<AxvmX86HostOps>);
+
+impl VmArchVcpuOps for AxvmX86Vcpu {
+    type CreateConfig = X86VCpuCreateConfig;
+    type SetupConfig = X86VCpuSetupConfig;
+    type Exit = X86VmExit;
+
+    fn new(vm_id: VMId, vcpu_id: VCpuId, config: Self::CreateConfig) -> AxResult<Self> {
+        x86_result(x86_vcpu::X86ArchVCpu::new_with_config(
+            vm_id, vcpu_id, config,
+        ))
+        .map(Self)
+    }
+
+    fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
+        x86_result(self.0.set_entry(ax_guest_phys_addr_to_x86(entry)))
+    }
+
+    fn set_nested_page_table(&mut self, config: NestedPagingConfig) -> AxResult {
+        x86_result(
+            self.0
+                .set_nested_page_table(ax_nested_paging_to_x86(config)),
+        )
+    }
+
+    fn setup(&mut self, config: Self::SetupConfig) -> AxResult {
+        x86_result(self.0.setup(config))
+    }
+
+    fn run(&mut self) -> AxResult<Self::Exit> {
+        x86_result(self.0.run())
+    }
+
+    fn bind(&mut self) -> AxResult {
+        x86_result(self.0.bind())
+    }
+
+    fn unbind(&mut self) -> AxResult {
+        x86_result(self.0.unbind())
+    }
+
+    fn set_gpr(&mut self, reg: usize, val: usize) {
+        self.0.set_gpr(reg, val);
+    }
+
+    fn inject_interrupt(&mut self, vector: usize) -> AxResult {
+        x86_result(self.0.inject_interrupt(vector))
+    }
+
+    fn inject_interrupt_with_trigger(
+        &mut self,
+        vector: usize,
+        trigger: InterruptTriggerMode,
+    ) -> AxResult {
+        x86_result(
+            self.0.inject_interrupt_with_trigger(
+                vector,
+                trigger == InterruptTriggerMode::LevelTriggered,
+            ),
+        )
+    }
+
+    fn handle_eoi(&mut self) -> Option<u8> {
+        self.0.handle_eoi()
+    }
+
+    fn set_return_value(&mut self, val: usize) {
+        self.0.set_return_value(val);
+    }
+}
+
+pub(crate) struct AxvmX86PerCpu(x86_vcpu::X86ArchPerCpuState<AxvmX86HostOps>);
+
+impl VmArchPerCpuOps for AxvmX86PerCpu {
+    fn new(cpu_id: usize) -> AxResult<Self> {
+        x86_result(x86_vcpu::X86ArchPerCpuState::new(cpu_id)).map(Self)
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.0.is_enabled()
+    }
+
+    fn hardware_enable(&mut self) -> AxResult {
+        x86_result(self.0.hardware_enable())
+    }
+
+    fn hardware_disable(&mut self) -> AxResult {
+        x86_result(self.0.hardware_disable())
+    }
+}
+
+pub(crate) fn register_arch_device(
+    config: &EmulatedDeviceConfig,
+    devices: &mut axdevice::AxVmDevices,
+) -> AxResult {
+    match config.emu_type {
+        EmulatedDeviceType::Console => {
+            let serial = Arc::new(axdevice::X86SerialPortDevice::<AxvmX86HostOps>::new());
+            devices.add_x86_serial_dev(serial)?;
+            info!("x86 16550 serial initialized for ports 0x3f8..=0x3ff");
+        }
+        EmulatedDeviceType::X86IoApic => {
+            let ioapic = Arc::new(axdevice::X86IoApicDevice::new(
+                x86_vlapic::X86GuestPhysAddr::from_usize(config.base_gpa),
+                Some(config.length),
+            ));
+            devices.add_x86_ioapic_dev(ioapic)?;
+            info!(
+                "x86 IO APIC initialized with base GPA {:#x} and length {:#x}",
+                config.base_gpa, config.length
+            );
+        }
+        EmulatedDeviceType::X86Pit => {
+            let pit = Arc::new(axdevice::X86PitDevice::<AxvmX86HostOps>::new());
+            devices.add_x86_pit_dev(pit)?;
+            info!("x86 PIT initialized for ports 0x40..=0x43 and 0x61");
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+#[cfg(feature = "vmx")]
+pub(crate) fn x86_apic_access_page_addr() -> axvm_types::HostPhysAddr {
+    let addr = x86_vcpu::x86_apic_access_page_addr::<AxvmX86HostOps>();
+    axvm_types::HostPhysAddr::from(addr.as_usize())
+}
+
+fn handle_x86_nested_page_fault<A>(
+    vm: &crate::AxVMRef,
+    exit: NestedPageFaultExit,
+) -> AxResult<BoundVcpuExit<A::DeferredRunWork>>
+where
+    A: ArchOps<DeferredRunWork = LegacyDeferredRunWork>,
+{
+    if vm.get_devices()?.find_mmio_dev(exit.addr).is_some() {
+        warn!(
+            "VM[{}] nested page fault at {:#x} maps MMIO but x86 core did not decode it",
+            vm.id(),
+            exit.addr.as_usize()
+        );
+        return Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield));
+    }
+
+    if vm.handle_nested_page_fault(exit.addr, exit.access_flags) {
+        Ok(BoundVcpuExit::Continue)
+    } else {
+        warn!(
+            "VM[{}] unhandled x86 nested page fault at {:#x}, access={:?}",
+            vm.id(),
+            exit.addr.as_usize(),
+            exit.access_flags
+        );
+        Ok(BoundVcpuExit::Complete(VcpuRunAction::Yield))
+    }
+}
+
+fn x86_result<T>(result: X86VcpuResult<T>) -> AxResult<T> {
+    result.map_err(x86_error_to_ax)
+}
+
+fn x86_error_to_ax(err: X86VcpuError) -> AxError {
+    match err {
+        X86VcpuError::InvalidInput => AxError::InvalidInput,
+        X86VcpuError::InvalidData => AxError::InvalidData,
+        X86VcpuError::Unsupported => AxError::Unsupported,
+        X86VcpuError::BadState => AxError::BadState,
+        X86VcpuError::NoMemory => AxError::NoMemory,
+        X86VcpuError::ResourceBusy => AxError::ResourceBusy,
+    }
+}
+
+fn ax_error_to_vlapic(_err: AxError) -> X86VlapicError {
+    X86VlapicError::BadState
+}
+
+fn ax_guest_phys_addr_to_x86(addr: GuestPhysAddr) -> X86GuestPhysAddr {
+    X86GuestPhysAddr::from_usize(addr.as_usize())
+}
+
+fn x86_guest_phys_addr_to_ax(addr: X86GuestPhysAddr) -> GuestPhysAddr {
+    GuestPhysAddr::from(addr.as_usize())
+}
+
+fn ax_nested_paging_to_x86(config: NestedPagingConfig) -> X86NestedPagingConfig {
+    X86NestedPagingConfig::new(
+        X86HostPhysAddr::from_usize(config.root_paddr.as_usize()),
+        config.levels,
+        config.gpa_bits,
+        config.mode,
+    )
+}
+
+fn x86_access_width_to_ax(width: X86AccessWidth) -> AccessWidth {
+    match width {
+        X86AccessWidth::Byte => AccessWidth::Byte,
+        X86AccessWidth::Word => AccessWidth::Word,
+        X86AccessWidth::Dword => AccessWidth::Dword,
+        X86AccessWidth::Qword => AccessWidth::Qword,
+    }
+}
+
+fn x86_access_flags_to_ax(flags: X86AccessFlags) -> MappingFlags {
+    let mut out = MappingFlags::empty();
+    if flags.contains(X86AccessFlags::READ) {
+        out |= MappingFlags::READ;
+    }
+    if flags.contains(X86AccessFlags::WRITE) {
+        out |= MappingFlags::WRITE;
+    }
+    if flags.contains(X86AccessFlags::EXECUTE) {
+        out |= MappingFlags::EXECUTE;
+    }
+    out
+}
+
+fn x86_port_to_ax(port: X86Port) -> Port {
+    Port::new(port.number())
+}
+
+fn x86_msr_addr_to_ax(addr: X86MsrAddr) -> SysRegAddr {
+    SysRegAddr::new(addr.addr())
+}
+
+fn x86_qemu_shutdown_port(port: X86Port, width: X86AccessWidth, data: u64) -> bool {
+    port.number() == QEMU_EXIT_PORT && width == X86AccessWidth::Word && data == QEMU_EXIT_MAGIC
+}
+
+fn current_rflags() -> u64 {
+    let flags: u64;
+    unsafe {
+        asm!(
+            "pushfq",
+            "pop {flags}",
+            flags = lateout(reg) flags,
+            options(nomem, preserves_flags),
+        );
+    }
+    flags
+}
+
+fn restore_host_interrupt_flag(host_rflags: u64) {
+    if host_rflags & RFLAGS_INTERRUPT_FLAG != 0 {
+        unsafe {
+            asm!("sti", options(nomem, nostack));
+        }
+    } else {
+        unsafe {
+            asm!("cli", options(nomem, nostack));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_x86_exit_type<T: VmArchVcpuOps<Exit = X86VmExit>>() {}
+
+    #[test]
+    fn axvm_x86_vcpu_uses_x86_exit_type() {
+        assert_x86_exit_type::<AxvmX86Vcpu>();
+    }
+
+    #[test]
+    fn converts_x86_vcpu_errors_to_ax_errors() {
+        assert_eq!(
+            x86_error_to_ax(X86VcpuError::InvalidInput),
+            AxError::InvalidInput
+        );
+        assert_eq!(x86_error_to_ax(X86VcpuError::NoMemory), AxError::NoMemory);
+        assert_eq!(
+            x86_error_to_ax(X86VcpuError::ResourceBusy),
+            AxError::ResourceBusy
+        );
+    }
+
+    #[test]
+    fn converts_x86_value_types_to_axvm_value_types() {
+        assert_eq!(
+            x86_guest_phys_addr_to_ax(X86GuestPhysAddr::from_usize(0x4000)).as_usize(),
+            0x4000
+        );
+        assert_eq!(
+            x86_access_width_to_ax(X86AccessWidth::Dword),
+            AccessWidth::Dword
+        );
+        assert_eq!(x86_port_to_ax(X86Port::new(0x3f8)).0, 0x3f8);
+        assert_eq!(x86_msr_addr_to_ax(X86MsrAddr::new(0x800)).0, 0x800);
+    }
+
+    #[test]
+    fn qemu_shutdown_port_is_axvm_policy() {
+        assert!(x86_qemu_shutdown_port(
+            X86Port::new(QEMU_EXIT_PORT),
+            X86AccessWidth::Word,
+            QEMU_EXIT_MAGIC
+        ));
+        assert!(!x86_qemu_shutdown_port(
+            X86Port::new(QEMU_EXIT_PORT),
+            X86AccessWidth::Dword,
+            QEMU_EXIT_MAGIC
+        ));
     }
 }

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -17,11 +17,13 @@ use alloc::format;
 use ax_errno::{AxResult, ax_err_type};
 
 use crate::{
-    AsVCpuTask, GuestPhysAddr, StopReason, VCpuTask, VmStatus, VmVcpuState,
+    AsVCpuTask, StopReason, VCpuTask, VmStatus,
     arch::{ArchOps, CurrentArch, VcpuRunAction},
     runtime::{VCpuRef, VMRef, sub_running_vm_count},
     vm::VmRuntimeHandle,
 };
+#[cfg(not(target_arch = "x86_64"))]
+use crate::{GuestPhysAddr, VmVcpuState};
 
 const KERNEL_STACK_SIZE: usize = 0x40000; // 256 KiB
 
@@ -188,6 +190,7 @@ fn mark_vcpu_running(vm: &VMRef) {
 /// * `vcpu_id` - The ID of the VCpu to be booted.
 /// * `entry_point` - The entry point of the VCpu.
 /// * `arg` - The argument to be passed to the VCpu.
+#[cfg(not(target_arch = "x86_64"))]
 pub(crate) fn vcpu_on(
     vm: VMRef,
     vcpu_id: usize,
@@ -217,6 +220,7 @@ pub(crate) fn vcpu_on(
     Ok(())
 }
 
+#[cfg(not(target_arch = "x86_64"))]
 pub(crate) fn alloc_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::AxTaskRef {
     crate::host::task::spawn_task(build_vcpu_task(vm, vcpu))
 }

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -201,6 +201,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     }
 
     /// Sets the guest entry point.
+    #[cfg(not(target_arch = "x86_64"))]
     pub fn set_entry(&self, entry: GuestPhysAddr) -> AxResult {
         self.get_arch_vcpu().set_entry(entry)
     }

--- a/virtualization/axvm/src/vm/prepare/address_space.rs
+++ b/virtualization/axvm/src/vm/prepare/address_space.rs
@@ -8,7 +8,7 @@ use axdevice_base::Resource;
 #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
 use axvm_types::GuestPhysAddr;
 #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
-use x86_vcpu::{X86_APIC_ACCESS_GPA, x86_apic_access_page_addr};
+use x86_vcpu::X86_APIC_ACCESS_GPA;
 
 use super::super::{AxVM, AxVMResources, VM_ASPACE_BASE, VM_ASPACE_SIZE};
 use crate::layout::{GuestOwnedRegion, VmRegionKind, build_address_layout};
@@ -56,7 +56,7 @@ pub(super) fn map_guest_address_space(
     #[cfg(all(target_arch = "x86_64", feature = "vmx"))]
     resources.address_space.map_linear(
         GuestPhysAddr::from(X86_APIC_ACCESS_GPA),
-        x86_apic_access_page_addr(),
+        crate::arch::x86_apic_access_page_addr(),
         ax_memory_addr::PAGE_SIZE_4K,
         axvm_types::MappingFlags::DEVICE
             | axvm_types::MappingFlags::READ

--- a/virtualization/axvm/src/vm/prepare/devices.rs
+++ b/virtualization/axvm/src/vm/prepare/devices.rs
@@ -105,7 +105,19 @@ impl PreparedDevices {
         Ok(())
     }
 
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(target_arch = "x86_64")]
+    fn register_arch_devices(
+        _vm: &AxVM,
+        resources: &AxVMResources,
+        devices: &mut AxVmDevices,
+    ) -> AxResult {
+        for config in resources.config.emu_devices() {
+            crate::arch::register_x86_arch_device(config, devices)?;
+        }
+        Ok(())
+    }
+
+    #[cfg(not(any(target_arch = "aarch64", target_arch = "x86_64")))]
     fn register_arch_devices(
         _vm: &AxVM,
         _resources: &AxVMResources,

--- a/virtualization/test_crates/virtualization-tests/Cargo.toml
+++ b/virtualization/test_crates/virtualization-tests/Cargo.toml
@@ -9,13 +9,10 @@ repository.workspace = true
 [dependencies]
 
 [dev-dependencies]
-ax-crate-interface.workspace = true
 ax-errno.workspace = true
-ax-memory-addr.workspace = true
 ax-plat.workspace = true
 axdevice.workspace = true
 axdevice_base.workspace = true
 axvm.workspace = true
 axvm-types.workspace = true
 irq-framework.workspace = true
-x86_vlapic.workspace = true

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -15,7 +15,6 @@
 use std::sync::{Arc, Mutex};
 
 use ax_errno::{AxError, AxResult};
-use ax_memory_addr::{PhysAddr, VirtAddr};
 use axdevice::{
     AxVmDeviceConfig, AxVmDevices, DeviceBuildContext, DeviceBundle, DeviceFactory,
     DeviceFactoryRegistry, DeviceRegistration, IrqResolver, MmioDeviceAdapter, PollableDeviceOps,
@@ -25,11 +24,7 @@ use axdevice_base::{
     AccessWidth, BaseDeviceOps, DeviceRegistry as _, InterruptTriggerMode, IrqLine, Port,
     PortRange, RegistryError, SysRegAddr, SysRegAddrRange,
 };
-use axvm_types::{
-    EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptVector,
-    VCpuId, VMId,
-};
-use x86_vlapic::host::X86VlapicHostIf;
+use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange};
 
 /// Registers a legacy MMIO device through the new DeviceManager API.
 fn register_mmio<T: BaseDeviceOps<GuestPhysAddrRange> + Send + Sync + 'static>(
@@ -486,19 +481,32 @@ fn test_equal_address_values_on_different_buses_are_allowed() {
 }
 
 #[test]
-fn test_conflicting_device_config_returns_structured_error() {
-    let ioapic = EmulatedDeviceConfig {
-        name: String::from("ioapic"),
-        base_gpa: 0xfec0_0000,
-        length: 0x1000,
-        irq_id: 0,
-        emu_type: EmulatedDeviceType::X86IoApic,
-        cfg_list: vec![],
-    };
+fn test_conflicting_factory_device_config_returns_structured_error() {
+    let mut factories = DeviceFactoryRegistry::new();
+    factories.register(Arc::new(MockMmioFactory)).unwrap();
+    let resolver = RejectingIrqResolver;
+    let context = DeviceBuildContext::new(&resolver);
+    let first = device_config(
+        "factory-mmio-first",
+        EmulatedDeviceType::VirtioBlk,
+        0x2_0000,
+        0x1000,
+    );
+    let overlap = device_config(
+        "factory-mmio-overlap",
+        EmulatedDeviceType::VirtioBlk,
+        0x2_0800,
+        0x1000,
+    );
 
     assert_eq!(
-        AxVmDevices::new(AxVmDeviceConfig::new(vec![ioapic.clone(), ioapic])).err(),
-        Some(AxError::InvalidInput)
+        AxVmDevices::build_with_factories(
+            AxVmDeviceConfig::new(vec![first, overlap]),
+            &factories,
+            &context,
+        )
+        .err(),
+        Some(AxError::AddrInUse)
     );
 }
 
@@ -864,69 +872,4 @@ fn test_sysreg_range_interior_address_dispatch() {
             .handle_sys_reg_read(SysRegAddr::new(0x111), AccessWidth::Qword)
             .is_err()
     );
-}
-
-// Mock implementation for x86_vlapic host callbacks when running
-// `cargo test -p axdevice` on x86_64 host.
-
-struct MockX86VlapicHostIfImpl;
-
-#[ax_crate_interface::impl_interface]
-impl X86VlapicHostIf for MockX86VlapicHostIfImpl {
-    fn alloc_frame() -> Option<PhysAddr> {
-        None
-    }
-
-    fn dealloc_frame(_paddr: PhysAddr) {}
-
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
-        VirtAddr::from(paddr.as_usize())
-    }
-
-    fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
-        PhysAddr::from(vaddr.as_usize())
-    }
-
-    fn current_time() -> core::time::Duration {
-        core::time::Duration::ZERO
-    }
-
-    fn current_time_nanos() -> u64 {
-        0
-    }
-
-    fn register_timer(
-        _deadline: core::time::Duration,
-        _callback: Box<dyn FnOnce(core::time::Duration) + Send + 'static>,
-    ) -> usize {
-        0
-    }
-
-    fn cancel_timer(_token: usize) {}
-
-    fn write_bytes(_bytes: &[u8]) {}
-
-    fn read_bytes(_bytes: &mut [u8]) -> usize {
-        0
-    }
-
-    fn current_vm_id() -> VMId {
-        0
-    }
-
-    fn current_vm_vcpu_num() -> usize {
-        1
-    }
-
-    fn current_vm_active_vcpus() -> usize {
-        1
-    }
-
-    fn active_vcpus(_vm_id: VMId) -> Option<usize> {
-        Some(1)
-    }
-
-    fn inject_interrupt(_vm_id: VMId, _vcpu_id: VCpuId, _vector: InterruptVector) -> AxResult {
-        Ok(())
-    }
 }

--- a/virtualization/x86_vcpu/Cargo.toml
+++ b/virtualization/x86_vcpu/Cargo.toml
@@ -27,12 +27,7 @@ raw-cpuid = "11.0"
 numeric-enum-macro = "0.2"
 tock-registers = "0.10"
 
-ax-errno = { workspace = true }
-ax-memory-addr = { workspace = true }
-ax-crate-interface = { workspace = true }
 x86_vlapic = { workspace = true }
-axdevice_base = { workspace = true }
-axvm-types = { workspace = true }
 
 [dev-dependencies]
 memoffset = "0.9"

--- a/virtualization/x86_vcpu/src/host.rs
+++ b/virtualization/x86_vcpu/src/host.rs
@@ -1,49 +1,61 @@
-//! Host callbacks required by the x86 vCPU implementation.
+//! Host callbacks required by the OS-neutral x86 vCPU implementation.
 
-use ax_errno::{AxResult, ax_err_type};
-use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr};
+use core::marker::PhantomData;
 
-/// Host memory and time operations required by x86 virtualization backends.
-#[ax_crate_interface::def_interface]
-pub trait X86VcpuHostIf {
+use x86_vlapic::X86VlapicHostOps;
+
+use crate::{
+    X86GuestPhysAddr, X86HostPhysAddr, X86HostVirtAddr, X86VcpuError, X86VcpuResult,
+    types::X86_PAGE_SIZE_4K,
+};
+
+/// Host memory, time, and interrupt operations required by x86 virtualization backends.
+pub trait X86HostOps: X86VlapicHostOps {
     /// Allocate one host frame.
-    fn alloc_frame() -> Option<PhysAddr>;
+    fn alloc_frame() -> Option<X86HostPhysAddr>;
 
     /// Deallocate one host frame.
-    fn dealloc_frame(paddr: PhysAddr);
+    fn dealloc_frame(paddr: X86HostPhysAddr);
 
     /// Allocate contiguous host frames.
-    fn alloc_contiguous_frames(frame_count: usize, frame_align: usize) -> Option<PhysAddr>;
+    fn alloc_contiguous_frames(frame_count: usize, frame_align: usize) -> Option<X86HostPhysAddr>;
 
     /// Deallocate contiguous host frames.
-    fn dealloc_contiguous_frames(start_paddr: PhysAddr, frame_count: usize);
+    fn dealloc_contiguous_frames(start_paddr: X86HostPhysAddr, frame_count: usize);
 
     /// Convert host physical address to host virtual address.
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr;
+    fn phys_to_virt(paddr: X86HostPhysAddr) -> X86HostVirtAddr;
+
+    /// Read one byte from guest physical memory.
+    fn read_guest_u8(paddr: X86GuestPhysAddr) -> X86VcpuResult<u8>;
 
     /// Convert nanoseconds to host ticks.
     fn nanos_to_ticks(nanos: u64) -> u64;
+
+    /// Poll the host interrupt controller for a pending vector.
+    fn poll_host_interrupt() -> Option<u8>;
 }
 
 /// RAII host frame used by x86 VMX/SVM structures.
 #[derive(Debug)]
-pub struct PhysFrame {
-    start_paddr: Option<PhysAddr>,
+pub struct PhysFrame<H: X86HostOps> {
+    start_paddr: Option<X86HostPhysAddr>,
+    _host: PhantomData<fn() -> H>,
 }
 
-impl PhysFrame {
+impl<H: X86HostOps> PhysFrame<H> {
     /// Allocate a host frame.
-    pub fn alloc() -> AxResult<Self> {
-        let start_paddr = ax_crate_interface::call_interface!(X86VcpuHostIf::alloc_frame())
-            .ok_or_else(|| ax_err_type!(NoMemory, "allocate physical frame failed"))?;
+    pub fn alloc() -> X86VcpuResult<Self> {
+        let start_paddr = <H as X86HostOps>::alloc_frame().ok_or(X86VcpuError::NoMemory)?;
         assert_ne!(start_paddr.as_usize(), 0);
         Ok(Self {
             start_paddr: Some(start_paddr),
+            _host: PhantomData,
         })
     }
 
     /// Allocate a host frame and fill it with zeros.
-    pub fn alloc_zero() -> AxResult<Self> {
+    pub fn alloc_zero() -> X86VcpuResult<Self> {
         let mut frame = Self::alloc()?;
         frame.fill(0);
         Ok(frame)
@@ -55,57 +67,59 @@ impl PhysFrame {
     ///
     /// The caller must ensure the placeholder is replaced before being accessed.
     pub const unsafe fn uninit() -> Self {
-        Self { start_paddr: None }
+        Self {
+            start_paddr: None,
+            _host: PhantomData,
+        }
     }
 
     /// Get the starting physical address of the frame.
-    pub fn start_paddr(&self) -> PhysAddr {
+    pub fn start_paddr(&self) -> X86HostPhysAddr {
         self.start_paddr.expect("uninitialized PhysFrame")
     }
 
     /// Get a mutable pointer to the frame.
     pub fn as_mut_ptr(&self) -> *mut u8 {
-        ax_crate_interface::call_interface!(X86VcpuHostIf::phys_to_virt(self.start_paddr()))
-            .as_mut_ptr()
+        <H as X86HostOps>::phys_to_virt(self.start_paddr()).as_mut_ptr()
     }
 
     /// Fill the frame with a byte.
     pub fn fill(&mut self, byte: u8) {
-        unsafe { core::ptr::write_bytes(self.as_mut_ptr(), byte, PAGE_SIZE_4K) };
+        unsafe { core::ptr::write_bytes(self.as_mut_ptr(), byte, X86_PAGE_SIZE_4K) };
     }
 }
 
-impl Drop for PhysFrame {
+impl<H: X86HostOps> Drop for PhysFrame<H> {
     fn drop(&mut self) {
         if let Some(start_paddr) = self.start_paddr {
-            ax_crate_interface::call_interface!(X86VcpuHostIf::dealloc_frame(start_paddr));
+            <H as X86HostOps>::dealloc_frame(start_paddr);
             log::debug!("[x86_vcpu] deallocated PhysFrame({start_paddr:#x})");
         }
     }
 }
 
 #[cfg(feature = "svm")]
-pub(crate) fn alloc_contiguous_frames(frame_count: usize, frame_align: usize) -> Option<PhysAddr> {
-    ax_crate_interface::call_interface!(X86VcpuHostIf::alloc_contiguous_frames(
-        frame_count,
-        frame_align
-    ))
+pub(crate) fn alloc_contiguous_frames<H: X86HostOps>(
+    frame_count: usize,
+    frame_align: usize,
+) -> Option<X86HostPhysAddr> {
+    <H as X86HostOps>::alloc_contiguous_frames(frame_count, frame_align)
 }
 
 #[cfg(feature = "svm")]
-pub(crate) fn dealloc_contiguous_frames(start_paddr: PhysAddr, frame_count: usize) {
-    ax_crate_interface::call_interface!(X86VcpuHostIf::dealloc_contiguous_frames(
-        start_paddr,
-        frame_count
-    ));
+pub(crate) fn dealloc_contiguous_frames<H: X86HostOps>(
+    start_paddr: X86HostPhysAddr,
+    frame_count: usize,
+) {
+    <H as X86HostOps>::dealloc_contiguous_frames(start_paddr, frame_count);
 }
 
 #[cfg(any(feature = "vmx", feature = "svm"))]
-pub(crate) fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
-    ax_crate_interface::call_interface!(X86VcpuHostIf::phys_to_virt(paddr))
+pub(crate) fn read_guest_u8<H: X86HostOps>(paddr: X86GuestPhysAddr) -> X86VcpuResult<u8> {
+    H::read_guest_u8(paddr)
 }
 
 #[cfg(any(feature = "vmx", feature = "svm"))]
-pub(crate) fn nanos_to_ticks(nanos: u64) -> u64 {
-    ax_crate_interface::call_interface!(X86VcpuHostIf::nanos_to_ticks(nanos))
+pub(crate) fn nanos_to_ticks<H: X86HostOps>(nanos: u64) -> u64 {
+    H::nanos_to_ticks(nanos)
 }

--- a/virtualization/x86_vcpu/src/lib.rs
+++ b/virtualization/x86_vcpu/src/lib.rs
@@ -25,13 +25,40 @@ extern crate alloc;
 #[cfg(test)]
 extern crate std;
 
-use ax_errno::{AxResult, ax_err};
-
 #[cfg(all(feature = "vmx", feature = "svm"))]
 compile_error!("features `vmx` and `svm` are mutually exclusive");
 
 #[cfg(test)]
 mod test_utils;
+
+mod types;
+
+pub use types::{
+    X86AccessFlags, X86AccessWidth, X86GuestPhysAddr, X86GuestVirtAddr, X86HostPhysAddr,
+    X86HostVirtAddr, X86MsrAddr, X86NestedPageFaultInfo, X86NestedPagingConfig, X86Port,
+    X86VcpuError, X86VcpuResult, X86VmExit,
+};
+
+macro_rules! x86_err {
+    ($kind:ident) => {
+        Err($crate::X86VcpuError::$kind)
+    };
+    ($kind:ident, $msg:expr) => {{
+        let _ = &$msg;
+        Err($crate::X86VcpuError::$kind)
+    }};
+}
+
+#[cfg(any(feature = "vmx", feature = "svm"))]
+macro_rules! x86_err_type {
+    ($kind:ident) => {
+        $crate::X86VcpuError::$kind
+    };
+    ($kind:ident, $msg:expr) => {{
+        let _ = &$msg;
+        $crate::X86VcpuError::$kind
+    }};
+}
 
 /// Maximum number of x86 host I/O port ranges configured for one vCPU.
 pub const X86_MAX_PASSTHROUGH_PORT_RANGES: usize = 16;
@@ -69,12 +96,12 @@ impl Default for X86VCpuSetupConfig {
 
 impl X86VCpuSetupConfig {
     /// Adds one host I/O port range to the vCPU I/O intercept list.
-    pub fn add_passthrough_port_range(&mut self, base: u16, length: u16) -> AxResult {
+    pub fn add_passthrough_port_range(&mut self, base: u16, length: u16) -> X86VcpuResult {
         if length == 0 {
-            return ax_err!(InvalidInput, "x86 passthrough port range is empty");
+            return Err(X86VcpuError::InvalidInput);
         }
         if base.checked_add(length - 1).is_none() {
-            return ax_err!(InvalidInput, "x86 passthrough port range overflows");
+            return Err(X86VcpuError::InvalidInput);
         }
 
         let range = X86PassthroughPortRange { base, length };
@@ -91,7 +118,7 @@ impl X86VCpuSetupConfig {
             return Ok(());
         }
 
-        ax_err!(NoMemory, "too many x86 passthrough port ranges")
+        Err(X86VcpuError::NoMemory)
     }
 
     /// Iterates over configured host I/O port ranges.
@@ -101,6 +128,7 @@ impl X86VCpuSetupConfig {
 }
 
 pub mod host;
+pub use host::X86HostOps;
 pub(crate) mod msr;
 #[cfg(feature = "vmx")]
 #[macro_use]
@@ -127,7 +155,7 @@ pub(crate) struct X86RealModeEntryState {
 }
 
 #[cfg(any(feature = "vmx", feature = "svm", test))]
-pub(crate) fn x86_real_mode_entry_state(entry: axvm_types::GuestPhysAddr) -> X86RealModeEntryState {
+pub(crate) fn x86_real_mode_entry_state(entry: X86GuestPhysAddr) -> X86RealModeEntryState {
     if entry.as_usize() == X86_RESET_VECTOR_GPA {
         return X86RealModeEntryState {
             cs_selector: X86_RESET_CS_SELECTOR,
@@ -191,22 +219,20 @@ pub(crate) fn restore_host_interrupt_flag(host_rflags: u64) {
 }
 
 #[cfg(any(feature = "vmx", feature = "svm"))]
-pub(crate) fn host_tsc_frequency_mhz() -> Option<u32> {
-    u32::try_from(host::nanos_to_ticks(1_000))
+pub(crate) fn host_tsc_frequency_mhz<H: X86HostOps>() -> Option<u32> {
+    u32::try_from(host::nanos_to_ticks::<H>(1_000))
         .ok()
         .filter(|&freq| freq > 0)
 }
 
 #[cfg(test)]
 mod tests {
-    use axvm_types::GuestPhysAddr;
-
     use super::*;
 
     #[test]
     fn real_mode_entry_keeps_normal_entry_flat() {
         assert_eq!(
-            x86_real_mode_entry_state(GuestPhysAddr::from(0x8000)),
+            x86_real_mode_entry_state(X86GuestPhysAddr::from(0x8000)),
             X86RealModeEntryState {
                 cs_selector: 0,
                 cs_base: 0,
@@ -218,7 +244,7 @@ mod tests {
     #[test]
     fn real_mode_entry_maps_reset_vector_to_reset_cs_state() {
         assert_eq!(
-            x86_real_mode_entry_state(GuestPhysAddr::from(0xffff_fff0)),
+            x86_real_mode_entry_state(X86GuestPhysAddr::from(0xffff_fff0)),
             X86RealModeEntryState {
                 cs_selector: 0xf000,
                 cs_base: 0xffff_0000,

--- a/virtualization/x86_vcpu/src/no_backend.rs
+++ b/virtualization/x86_vcpu/src/no_backend.rs
@@ -1,85 +1,97 @@
 // Fallback stub types for x86_vcpu builds without a hypervisor backend.
 //
-// These types are exported as `X86ArchVCpu` and `X86ArchPerCpuState` when
-// neither the `vmx` nor `svm` feature is enabled (e.g., a `host-fs`-only
-// build). The stubs implement the required traits so that downstream crates
-// that gate their VM-related logic on a separate feature can still compile.
-//
-// None of the methods are ever called at runtime in such configurations.
+// These types keep OS-neutral downstream crates buildable when neither VMX nor
+// SVM is selected. They are never usable at runtime.
 
-use ax_errno::{AxResult, ax_err};
-use axvm_types::{
-    GuestPhysAddr, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps, VmExit,
+use core::marker::PhantomData;
+
+use crate::{
+    X86GuestPhysAddr, X86HostOps, X86NestedPagingConfig, X86VCpuCreateConfig, X86VCpuSetupConfig,
+    X86VcpuResult, X86VmExit,
 };
 
-use crate::{X86VCpuCreateConfig, X86VCpuSetupConfig};
-
 /// Stub per-CPU state; never instantiated in no-backend builds.
-pub struct X86ArchPerCpuState;
+pub struct X86ArchPerCpuState<H: X86HostOps> {
+    _host: PhantomData<fn() -> H>,
+}
 
-impl VmArchPerCpuOps for X86ArchPerCpuState {
-    fn new(_cpu_id: usize) -> AxResult<Self> {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+impl<H: X86HostOps> X86ArchPerCpuState<H> {
+    pub fn new(_cpu_id: usize) -> X86VcpuResult<Self> {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn is_enabled(&self) -> bool {
+    pub fn is_enabled(&self) -> bool {
         false
     }
 
-    fn hardware_enable(&mut self) -> AxResult {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn hardware_enable(&mut self) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn hardware_disable(&mut self) -> AxResult {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn hardware_disable(&mut self) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 }
 
 /// Stub vCPU; never instantiated in no-backend builds.
-pub struct X86ArchVCpu;
+pub struct X86ArchVCpu<H: X86HostOps> {
+    _host: PhantomData<fn() -> H>,
+}
 
-impl VmArchVcpuOps for X86ArchVCpu {
-    type CreateConfig = X86VCpuCreateConfig;
-    type SetupConfig = X86VCpuSetupConfig;
-    type Exit = VmExit;
-
-    fn new(_vm_id: VMId, _vcpu_id: VCpuId, _config: X86VCpuCreateConfig) -> AxResult<Self> {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+impl<H: X86HostOps> X86ArchVCpu<H> {
+    pub fn new_with_config(
+        _vm_id: usize,
+        _vcpu_id: usize,
+        _config: X86VCpuCreateConfig,
+    ) -> X86VcpuResult<Self> {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn set_entry(&mut self, _entry: GuestPhysAddr) -> AxResult {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn set_entry(&mut self, _entry: X86GuestPhysAddr) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn set_nested_page_table(&mut self, _config: NestedPagingConfig) -> AxResult {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn set_nested_page_table(&mut self, _config: X86NestedPagingConfig) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn setup(&mut self, _config: X86VCpuSetupConfig) -> AxResult {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn setup(&mut self, _config: X86VCpuSetupConfig) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn run(&mut self) -> AxResult<Self::Exit> {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn run(&mut self) -> X86VcpuResult<X86VmExit> {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn bind(&mut self) -> AxResult {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn bind(&mut self) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn unbind(&mut self) -> AxResult {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn unbind(&mut self) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn set_gpr(&mut self, _reg: usize, _val: usize) {
+    pub fn set_gpr(&mut self, _reg: usize, _val: usize) {
         unreachable!("no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn inject_interrupt(&mut self, _vector: usize) -> AxResult {
-        ax_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    pub fn inject_interrupt(&mut self, _vector: usize) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
     }
 
-    fn set_return_value(&mut self, _val: usize) {
+    pub fn inject_interrupt_with_trigger(
+        &mut self,
+        _vector: usize,
+        _level_triggered: bool,
+    ) -> X86VcpuResult {
+        x86_err!(Unsupported, "no hypervisor backend (vmx/svm) enabled")
+    }
+
+    pub fn handle_eoi(&mut self) -> Option<u8> {
+        None
+    }
+
+    pub fn set_return_value(&mut self, _val: usize) {
         unreachable!("no hypervisor backend (vmx/svm) enabled")
     }
 }

--- a/virtualization/x86_vcpu/src/svm/frame.rs
+++ b/virtualization/x86_vcpu/src/svm/frame.rs
@@ -1,39 +1,38 @@
 use core::marker::PhantomData;
 
-use ax_errno::{AxResult, ax_err_type};
-use ax_memory_addr::PAGE_SIZE_4K as PAGE_SIZE;
-use axvm_types::HostPhysAddr;
-
-use crate::host;
+use crate::{
+    X86HostOps, X86HostPhysAddr, X86VcpuError, X86VcpuResult, host,
+    types::X86_PAGE_SIZE_4K as PAGE_SIZE,
+};
 
 /// Contiguous physical frames for SVM structures such as IOPM and MSRPM.
 #[derive(Debug)]
-pub struct ContiguousPhysFrames {
-    start_paddr: Option<HostPhysAddr>,
+pub struct ContiguousPhysFrames<H: X86HostOps> {
+    start_paddr: Option<X86HostPhysAddr>,
     frame_count: usize,
-    _marker: PhantomData<()>,
+    _host: PhantomData<fn() -> H>,
 }
 
-impl ContiguousPhysFrames {
-    pub fn alloc(frame_count: usize) -> AxResult<Self> {
-        let start_paddr = host::alloc_contiguous_frames(frame_count, PAGE_SIZE)
-            .ok_or_else(|| ax_err_type!(NoMemory, "allocate contiguous frames failed"))?;
+impl<H: X86HostOps> ContiguousPhysFrames<H> {
+    pub fn alloc(frame_count: usize) -> X86VcpuResult<Self> {
+        let start_paddr = host::alloc_contiguous_frames::<H>(frame_count, PAGE_SIZE)
+            .ok_or(X86VcpuError::NoMemory)?;
 
         assert_ne!(start_paddr.as_usize(), 0);
         Ok(Self {
             start_paddr: Some(start_paddr),
             frame_count,
-            _marker: PhantomData,
+            _host: PhantomData,
         })
     }
 
-    pub fn alloc_zero(frame_count: usize) -> AxResult<Self> {
+    pub fn alloc_zero(frame_count: usize) -> X86VcpuResult<Self> {
         let mut frames = Self::alloc(frame_count)?;
         frames.fill(0);
         Ok(frames)
     }
 
-    pub fn start_paddr(&self) -> HostPhysAddr {
+    pub fn start_paddr(&self) -> X86HostPhysAddr {
         self.start_paddr
             .expect("uninitialized ContiguousPhysFrames")
     }
@@ -43,7 +42,7 @@ impl ContiguousPhysFrames {
     }
 
     pub fn as_mut_ptr(&self) -> *mut u8 {
-        host::phys_to_virt(self.start_paddr()).as_mut_ptr()
+        <H as X86HostOps>::phys_to_virt(self.start_paddr()).as_mut_ptr()
     }
 
     pub fn fill(&mut self, byte: u8) {
@@ -53,10 +52,10 @@ impl ContiguousPhysFrames {
     }
 }
 
-impl Drop for ContiguousPhysFrames {
+impl<H: X86HostOps> Drop for ContiguousPhysFrames<H> {
     fn drop(&mut self) {
         if let Some(start_paddr) = self.start_paddr {
-            host::dealloc_contiguous_frames(start_paddr, self.frame_count);
+            host::dealloc_contiguous_frames::<H>(start_paddr, self.frame_count);
             debug!(
                 "[AxVM] deallocated ContiguousPhysFrames({:#x}, {} frames)",
                 start_paddr, self.frame_count

--- a/virtualization/x86_vcpu/src/svm/percpu.rs
+++ b/virtualization/x86_vcpu/src/svm/percpu.rs
@@ -1,7 +1,7 @@
-use ax_errno::{AxResult, ax_err};
-use axvm_types::VmArchPerCpuOps;
+use core::marker::PhantomData;
 
 use crate::{
+    X86HostOps, X86VcpuResult,
     host::PhysFrame,
     msr::Msr,
     svm::{
@@ -15,35 +15,37 @@ const EFER_SVME: u64 = 1 << 12;
 
 /// Per-CPU AMD SVM state.
 #[derive(Debug)]
-pub struct SvmPerCpuState {
-    hsave_page: PhysFrame,
+pub struct SvmPerCpuState<H: X86HostOps> {
+    hsave_page: PhysFrame<H>,
+    _host: PhantomData<fn() -> H>,
 }
 
-impl VmArchPerCpuOps for SvmPerCpuState {
-    fn new(_cpu_id: usize) -> AxResult<Self> {
+impl<H: X86HostOps> SvmPerCpuState<H> {
+    pub fn new(_cpu_id: usize) -> X86VcpuResult<Self> {
         Ok(Self {
-            hsave_page: unsafe { PhysFrame::uninit() },
+            hsave_page: unsafe { PhysFrame::<H>::uninit() },
+            _host: PhantomData,
         })
     }
 
-    fn is_enabled(&self) -> bool {
+    pub fn is_enabled(&self) -> bool {
         Msr::IA32_EFER.read() & EFER_SVME != 0
     }
 
-    fn hardware_enable(&mut self) -> AxResult {
+    pub fn hardware_enable(&mut self) -> X86VcpuResult {
         if !has_hardware_support() {
-            return ax_err!(Unsupported, "CPU does not support AMD SVM");
+            return x86_err!(Unsupported, "CPU does not support AMD SVM");
         }
         if VmCr::read().contains(VmCrFlags::SVMDIS) {
-            return ax_err!(Unsupported, "AMD SVM is disabled by VM_CR");
+            return x86_err!(Unsupported, "AMD SVM is disabled by VM_CR");
         }
         if self.is_enabled() {
-            return ax_err!(ResourceBusy, "SVM is already turned on");
+            return x86_err!(ResourceBusy, "SVM is already turned on");
         }
 
         enable_xsave();
 
-        self.hsave_page = PhysFrame::alloc_zero()?;
+        self.hsave_page = PhysFrame::<H>::alloc_zero()?;
         let hsave_pa = self.hsave_page.start_paddr().as_usize() as u64;
         unsafe {
             Msr::VM_HSAVE_PA.write(hsave_pa);
@@ -54,16 +56,16 @@ impl VmArchPerCpuOps for SvmPerCpuState {
         Ok(())
     }
 
-    fn hardware_disable(&mut self) -> AxResult {
+    pub fn hardware_disable(&mut self) -> X86VcpuResult {
         if !self.is_enabled() {
-            return ax_err!(BadState, "SVM is not enabled");
+            return x86_err!(BadState, "SVM is not enabled");
         }
 
         unsafe {
             Msr::IA32_EFER.write(Msr::IA32_EFER.read() & !EFER_SVME);
             Msr::VM_HSAVE_PA.write(0);
         }
-        self.hsave_page = unsafe { PhysFrame::uninit() };
+        self.hsave_page = unsafe { PhysFrame::<H>::uninit() };
 
         info!("[AxVM] succeeded to turn off SVM.");
         Ok(())

--- a/virtualization/x86_vcpu/src/svm/structs.rs
+++ b/virtualization/x86_vcpu/src/svm/structs.rs
@@ -1,30 +1,29 @@
-use ax_errno::AxResult;
-use ax_memory_addr::PAGE_SIZE_4K as PAGE_SIZE;
-use axvm_types::HostPhysAddr;
-
 use super::frame::ContiguousPhysFrames;
-use crate::{host::PhysFrame, svm::vmcb::VmcbStruct};
+use crate::{
+    X86HostOps, X86HostPhysAddr, X86VcpuResult, host::PhysFrame, svm::vmcb::VmcbStruct,
+    types::X86_PAGE_SIZE_4K as PAGE_SIZE,
+};
 
 /// Virtual-machine control block backing page.
 #[derive(Debug)]
-pub struct VmcbFrame {
-    page: PhysFrame,
+pub struct VmcbFrame<H: X86HostOps> {
+    page: PhysFrame<H>,
 }
 
-impl VmcbFrame {
+impl<H: X86HostOps> VmcbFrame<H> {
     pub const unsafe fn uninit() -> Self {
         Self {
-            page: unsafe { PhysFrame::uninit() },
+            page: unsafe { PhysFrame::<H>::uninit() },
         }
     }
 
-    pub fn new() -> AxResult<Self> {
+    pub fn new() -> X86VcpuResult<Self> {
         Ok(Self {
-            page: PhysFrame::alloc_zero()?,
+            page: PhysFrame::<H>::alloc_zero()?,
         })
     }
 
-    pub fn phys_addr(&self) -> HostPhysAddr {
+    pub fn phys_addr(&self) -> X86HostPhysAddr {
         self.page.start_paddr()
     }
 
@@ -43,13 +42,13 @@ impl VmcbFrame {
 
 /// SVM I/O permissions map. A set bit intercepts the corresponding port.
 #[derive(Debug)]
-pub struct IOPm {
-    frames: ContiguousPhysFrames,
+pub struct IOPm<H: X86HostOps> {
+    frames: ContiguousPhysFrames<H>,
 }
 
-impl IOPm {
-    pub fn passthrough_all() -> AxResult<Self> {
-        let frames = ContiguousPhysFrames::alloc_zero(3)?;
+impl<H: X86HostOps> IOPm<H> {
+    pub fn passthrough_all() -> X86VcpuResult<Self> {
+        let frames = ContiguousPhysFrames::<H>::alloc_zero(3)?;
         let third_frame_start = frames.as_mut_ptr() as usize + 2 * PAGE_SIZE;
         unsafe {
             *(third_frame_start as *mut u8) |= 0x07;
@@ -58,13 +57,13 @@ impl IOPm {
     }
 
     #[allow(unused)]
-    pub fn intercept_all() -> AxResult<Self> {
-        let mut frames = ContiguousPhysFrames::alloc(3)?;
+    pub fn intercept_all() -> X86VcpuResult<Self> {
+        let mut frames = ContiguousPhysFrames::<H>::alloc(3)?;
         frames.fill(0xff);
         Ok(Self { frames })
     }
 
-    pub fn phys_addr(&self) -> HostPhysAddr {
+    pub fn phys_addr(&self) -> X86HostPhysAddr {
         self.frames.start_paddr()
     }
 
@@ -91,25 +90,25 @@ impl IOPm {
 
 /// SVM MSR permissions map. Each MSR has separate read/write intercept bits.
 #[derive(Debug)]
-pub struct MSRPm {
-    frames: ContiguousPhysFrames,
+pub struct MSRPm<H: X86HostOps> {
+    frames: ContiguousPhysFrames<H>,
 }
 
-impl MSRPm {
-    pub fn passthrough_all() -> AxResult<Self> {
+impl<H: X86HostOps> MSRPm<H> {
+    pub fn passthrough_all() -> X86VcpuResult<Self> {
         Ok(Self {
-            frames: ContiguousPhysFrames::alloc_zero(2)?,
+            frames: ContiguousPhysFrames::<H>::alloc_zero(2)?,
         })
     }
 
     #[allow(unused)]
-    pub fn intercept_all() -> AxResult<Self> {
-        let mut frames = ContiguousPhysFrames::alloc(2)?;
+    pub fn intercept_all() -> X86VcpuResult<Self> {
+        let mut frames = ContiguousPhysFrames::<H>::alloc(2)?;
         frames.fill(0xff);
         Ok(Self { frames })
     }
 
-    pub fn phys_addr(&self) -> HostPhysAddr {
+    pub fn phys_addr(&self) -> X86HostPhysAddr {
         self.frames.start_paddr()
     }
 
@@ -155,15 +154,18 @@ mod tests {
     use super::*;
     use crate::test_utils::mock::MockMmHal;
 
+    type TestIOPm = IOPm<MockMmHal>;
+    type TestMSRPm = MSRPm<MockMmHal>;
+
     #[test]
     fn svm_permission_maps_use_contiguous_frames() {
         MockMmHal::run_test(|| {
             {
-                let iopm = IOPm::passthrough_all().unwrap();
+                let iopm = TestIOPm::passthrough_all().unwrap();
                 assert_eq!(iopm.phys_addr().as_usize(), 0x1000);
                 assert_eq!(MockMmHal::allocated_count(), 3);
 
-                let msrpm = MSRPm::passthrough_all().unwrap();
+                let msrpm = TestMSRPm::passthrough_all().unwrap();
                 assert_eq!(msrpm.phys_addr().as_usize(), 0x4000);
                 assert_eq!(MockMmHal::allocated_count(), 5);
             }

--- a/virtualization/x86_vcpu/src/svm/vcpu.rs
+++ b/virtualization/x86_vcpu/src/svm/vcpu.rs
@@ -5,13 +5,6 @@ use core::{
     mem::size_of,
 };
 
-use ax_errno::{AxResult, ax_err, ax_err_type};
-use ax_memory_addr::AddrRange;
-use axdevice_base::{BaseDeviceOps, SysRegAddrRange};
-use axvm_types::{
-    AccessWidth, GuestPhysAddr, GuestVirtAddr, HostPhysAddr, MappingFlags, NestedPageFaultInfo,
-    NestedPagingConfig, Port, SysRegAddr, VCpuId, VMId, VmArchVcpuOps, VmExit,
-};
 use bit_field::BitField;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use x86::controlregs::Xcr0;
@@ -28,12 +21,14 @@ use super::{
     vmcb::{InterceptCrRw, InterceptExceptions, NestedCtl, VmcbTlbControl, set_vmcb_segment},
 };
 use crate::{
-    X86VCpuCreateConfig, X86VCpuSetupConfig, msr::Msr, regs::GeneralRegisters,
-    restore_host_interrupt_flag, x86_real_mode_entry_state, xstate::XState,
+    X86AccessFlags, X86AccessWidth, X86GuestPhysAddr, X86GuestVirtAddr, X86HostOps,
+    X86HostPhysAddr, X86MsrAddr, X86NestedPageFaultInfo, X86NestedPagingConfig, X86Port,
+    X86VCpuCreateConfig, X86VCpuSetupConfig, X86VcpuError, X86VcpuResult, X86VmExit, host,
+    msr::Msr, regs::GeneralRegisters, restore_host_interrupt_flag, x86_real_mode_entry_state,
+    xstate::XState,
 };
 
 const QEMU_EXIT_PORT: u16 = 0x604;
-const QEMU_EXIT_MAGIC: u64 = 0x2000;
 const X86_PIT_PORT_BASE: u16 = 0x40;
 const X86_PIT_PORT_COUNT: u32 = 4;
 const X86_PIT_SPEAKER_PORT: u16 = 0x61;
@@ -149,14 +144,14 @@ struct PendingEvent {
 }
 
 /// Host save area used to restore CPU state touched by SVM VMLOAD/VMSAVE.
-pub struct VmLoadSaveStates {
-    vmcb: VmcbFrame,
+pub struct VmLoadSaveStates<H: X86HostOps> {
+    vmcb: VmcbFrame<H>,
 }
 
-impl VmLoadSaveStates {
-    pub fn new() -> AxResult<Self> {
+impl<H: X86HostOps> VmLoadSaveStates<H> {
+    pub fn new() -> X86VcpuResult<Self> {
         Ok(Self {
-            vmcb: VmcbFrame::new()?,
+            vmcb: VmcbFrame::<H>::new()?,
         })
     }
 
@@ -176,7 +171,7 @@ impl VmLoadSaveStates {
 /// AMD SVM vCPU implementation backed by a VMCB, I/O permission map and MSR
 /// permission map.
 #[repr(C)]
-pub struct SvmVcpu {
+pub struct SvmVcpu<H: X86HostOps> {
     // The order of `guest_regs`, `host_stack_top`, and `host_rflags` is
     // mandatory. They must be the first three fields. If you want to change
     // the order or the type of these fields, you must also change the assembly
@@ -192,29 +187,29 @@ pub struct SvmVcpu {
     /// Whether this VCPU has entered the guest at least once.
     launched: bool,
     /// The guest entry point.
-    entry: Option<GuestPhysAddr>,
+    entry: Option<X86GuestPhysAddr>,
     /// The nested page table root address.
-    npt_root: Option<HostPhysAddr>,
+    npt_root: Option<X86HostPhysAddr>,
     /// The guest VMCB.
-    vmcb: VmcbFrame,
+    vmcb: VmcbFrame<H>,
     /// Host state saved with VMSAVE and restored with VMLOAD.
-    load_save_states: VmLoadSaveStates,
+    load_save_states: VmLoadSaveStates<H>,
     /// The I/O permission map used by SVM I/O intercepts.
-    iopm: IOPm,
+    iopm: IOPm<H>,
     /// The MSR permission map used by SVM MSR intercepts.
-    msrpm: MSRPm,
+    msrpm: MSRPm<H>,
     /// Pending events to be injected to the guest.
     pending_events: VecDeque<PendingEvent>,
     /// Event handed to EVENTINJ for the current VMRUN and awaiting completion.
     injecting_event: Option<PendingEvent>,
     /// Emulated Local APIC for x2APIC MSR accesses.
-    vlapic: EmulatedLocalApic,
+    vlapic: EmulatedLocalApic<H>,
     /// The XState of the VCpu. Both host and guest.
     xstate: XState,
 }
 
-impl SvmVcpu {
-    fn create(vm_id: VMId, vcpu_id: VCpuId) -> AxResult<Self> {
+impl<H: X86HostOps> SvmVcpu<H> {
+    fn create(vm_id: usize, vcpu_id: usize) -> X86VcpuResult<Self> {
         let vcpu = Self {
             guest_regs: GeneralRegisters::default(),
             host_stack_top: 0,
@@ -222,13 +217,13 @@ impl SvmVcpu {
             launched: false,
             entry: None,
             npt_root: None,
-            vmcb: VmcbFrame::new()?,
-            load_save_states: VmLoadSaveStates::new()?,
-            iopm: IOPm::passthrough_all()?,
-            msrpm: MSRPm::passthrough_all()?,
+            vmcb: VmcbFrame::<H>::new()?,
+            load_save_states: VmLoadSaveStates::<H>::new()?,
+            iopm: IOPm::<H>::passthrough_all()?,
+            msrpm: MSRPm::<H>::passthrough_all()?,
             pending_events: VecDeque::with_capacity(8),
             injecting_event: None,
-            vlapic: EmulatedLocalApic::new(vm_id, vcpu_id),
+            vlapic: EmulatedLocalApic::<H>::new(vm_id, vcpu_id),
             xstate: XState::new(),
         };
         info!("[HV] created SvmVcpu(vmcb: {:#x})", vcpu.vmcb.phys_addr());
@@ -237,17 +232,17 @@ impl SvmVcpu {
 
     fn setup_vmcb(
         &mut self,
-        entry: GuestPhysAddr,
-        npt_root: HostPhysAddr,
+        entry: X86GuestPhysAddr,
+        npt_root: X86HostPhysAddr,
         config: X86VCpuSetupConfig,
-    ) -> AxResult {
+    ) -> X86VcpuResult {
         self.setup_io_bitmap(config)?;
         self.setup_msr_bitmap()?;
         self.setup_vmcb_guest(entry)?;
         self.setup_vmcb_control(npt_root)
     }
 
-    fn setup_vmcb_guest(&mut self, entry: GuestPhysAddr) -> AxResult {
+    fn setup_vmcb_guest(&mut self, entry: X86GuestPhysAddr) -> X86VcpuResult {
         let entry_state = x86_real_mode_entry_state(entry);
         let cr0_val =
             Cr0Flags::NOT_WRITE_THROUGH | Cr0Flags::CACHE_DISABLE | Cr0Flags::EXTENSION_TYPE;
@@ -292,7 +287,7 @@ impl SvmVcpu {
         Ok(())
     }
 
-    fn setup_vmcb_control(&mut self, npt_root: HostPhysAddr) -> AxResult {
+    fn setup_vmcb_control(&mut self, npt_root: X86HostPhysAddr) -> X86VcpuResult {
         let control = &mut unsafe { self.vmcb.as_vmcb() }.control;
 
         control.nested_ctl.modify(NestedCtl::NP_ENABLE::SET);
@@ -346,7 +341,7 @@ impl SvmVcpu {
         Ok(())
     }
 
-    fn setup_msr_bitmap(&mut self) -> AxResult {
+    fn setup_msr_bitmap(&mut self) -> X86VcpuResult {
         // Keep APIC state in the emulated local APIC instead of exposing the host APIC MSR.
         self.msrpm.set_read_intercept(APIC_BASE_MSR, true);
         self.msrpm.set_write_intercept(APIC_BASE_MSR, true);
@@ -368,7 +363,7 @@ impl SvmVcpu {
         Ok(())
     }
 
-    fn setup_io_bitmap(&mut self, config: X86VCpuSetupConfig) -> AxResult {
+    fn setup_io_bitmap(&mut self, config: X86VCpuSetupConfig) -> X86VcpuResult {
         // This port is part of the x86 QEMU test contract: 0x604 reports test completion.
         self.iopm
             .set_intercept_of_range(QEMU_EXIT_PORT as _, 2, true);
@@ -386,11 +381,11 @@ impl SvmVcpu {
         Ok(())
     }
 
-    fn bind_to_current_processor(&self) -> AxResult {
+    fn bind_to_current_processor(&self) -> X86VcpuResult {
         Ok(())
     }
 
-    fn unbind_from_current_processor(&self) -> AxResult {
+    fn unbind_from_current_processor(&self) -> X86VcpuResult {
         Ok(())
     }
 
@@ -413,29 +408,29 @@ impl SvmVcpu {
         }
     }
 
-    pub fn exit_info(&self) -> AxResult<super::vmcb::SvmExitInfo> {
+    pub fn exit_info(&self) -> X86VcpuResult<super::vmcb::SvmExitInfo> {
         unsafe { self.vmcb.as_vmcb_ref().exit_info() }
     }
 
-    pub fn nested_page_fault_info(&self) -> AxResult<NestedPageFaultInfo> {
+    pub fn nested_page_fault_info(&self) -> X86VcpuResult<X86NestedPageFaultInfo> {
         let info = self.exit_info()?;
         // For SVM NPF exits, EXITINFO1 describes the fault access and
         // EXITINFO2 carries the faulting guest physical address.
         let is_write = info.exit_info_1.get_bit(1);
         let is_execute = info.exit_info_1.get_bit(4);
-        let mut access_flags = MappingFlags::empty();
+        let mut access_flags = X86AccessFlags::empty();
         if !is_write && !is_execute {
-            access_flags |= MappingFlags::READ;
+            access_flags |= X86AccessFlags::READ;
         }
         if is_write {
-            access_flags |= MappingFlags::WRITE;
+            access_flags |= X86AccessFlags::WRITE;
         }
         if is_execute {
-            access_flags |= MappingFlags::EXECUTE;
+            access_flags |= X86AccessFlags::EXECUTE;
         }
-        Ok(NestedPageFaultInfo {
+        Ok(X86NestedPageFaultInfo {
             access_flags,
-            fault_guest_paddr: GuestPhysAddr::from(info.exit_info_2 as usize),
+            fault_guest_paddr: X86GuestPhysAddr::from(info.exit_info_2 as usize),
         })
     }
 
@@ -456,7 +451,7 @@ impl SvmVcpu {
     }
 
     /// Advance the guest `RIP`; use SVM's decoded next-RIP when available.
-    pub fn advance_rip(&mut self, instr_len: u8) -> AxResult {
+    pub fn advance_rip(&mut self, instr_len: u8) -> X86VcpuResult {
         let vmcb = unsafe { self.vmcb.as_vmcb() };
         let rip = vmcb.state.rip.get();
         let next_rip = vmcb.control.next_rip.get();
@@ -472,7 +467,7 @@ impl SvmVcpu {
         unsafe { self.vmcb.as_vmcb().state.rip.set(rip) };
     }
 
-    pub fn set_cr(&mut self, cr_idx: usize, val: u64) -> AxResult {
+    pub fn set_cr(&mut self, cr_idx: usize, val: u64) -> X86VcpuResult {
         let vmcb = unsafe { self.vmcb.as_vmcb() };
         match cr_idx {
             0 => {
@@ -489,7 +484,7 @@ impl SvmVcpu {
                 vmcb.state.cr4.set(val & !SVM_UNSUPPORTED_GUEST_CR4);
                 self.flush_guest_tlb();
             }
-            _ => return ax_err!(InvalidInput, format_args!("Unsupported CR{}", cr_idx)),
+            _ => return x86_err!(InvalidInput, format_args!("Unsupported CR{}", cr_idx)),
         }
         Ok(())
     }
@@ -547,7 +542,7 @@ impl SvmVcpu {
         self.xstate.switch_to_host();
     }
 
-    fn inner_run(&mut self) -> AxResult<super::vmcb::SvmExitInfo> {
+    fn inner_run(&mut self) -> X86VcpuResult<super::vmcb::SvmExitInfo> {
         loop {
             self.inject_pending_events()?;
             unsafe {
@@ -571,7 +566,10 @@ impl SvmVcpu {
         }
     }
 
-    fn builtin_vmexit_handler(&mut self, exit_info: &super::vmcb::SvmExitInfo) -> Option<AxResult> {
+    fn builtin_vmexit_handler(
+        &mut self,
+        exit_info: &super::vmcb::SvmExitInfo,
+    ) -> Option<X86VcpuResult> {
         match exit_info.exit_code {
             Ok(SvmExitCode::CPUID) => Some(self.handle_cpuid()),
             Ok(SvmExitCode::XSETBV) => Some(self.handle_xsetbv()),
@@ -597,7 +595,11 @@ impl SvmVcpu {
         }
     }
 
-    fn handle_cr_write(&mut self, cr_idx: usize, exit_info: &super::vmcb::SvmExitInfo) -> AxResult {
+    fn handle_cr_write(
+        &mut self,
+        cr_idx: usize,
+        exit_info: &super::vmcb::SvmExitInfo,
+    ) -> X86VcpuResult {
         // SVM CR-write exits encode the source GPR in EXITINFO1[3:0].
         let reg_idx = exit_info.exit_info_1.get_bits(0..4) as u8;
         let value = self.gpr_for_cr_access(reg_idx)?;
@@ -605,21 +607,21 @@ impl SvmVcpu {
         self.advance_rip(3)
     }
 
-    fn gpr_for_cr_access(&self, reg_idx: u8) -> AxResult<u64> {
+    fn gpr_for_cr_access(&self, reg_idx: u8) -> X86VcpuResult<u64> {
         // For SVM CR access exits, EXITINFO1[3:0] identifies the source GPR.
         if reg_idx == 4 {
             Ok(unsafe { self.vmcb.as_vmcb_ref().state.rsp.get() })
         } else if reg_idx < 16 {
             Ok(self.regs().get_reg_of_index(reg_idx))
         } else {
-            ax_err!(
+            x86_err!(
                 InvalidData,
                 format_args!("invalid SVM CR access GPR index {reg_idx}")
             )
         }
     }
 
-    fn handle_efer_msr(&mut self, exit_info: &super::vmcb::SvmExitInfo) -> AxResult {
+    fn handle_efer_msr(&mut self, exit_info: &super::vmcb::SvmExitInfo) -> X86VcpuResult {
         const VM_EXIT_INSTR_LEN_MSR: u8 = 2;
         let value = self.read_edx_eax();
         if exit_info.exit_info_1 == 0 {
@@ -633,7 +635,10 @@ impl SvmVcpu {
         self.advance_rip(VM_EXIT_INSTR_LEN_MSR)
     }
 
-    fn handle_apic_base_msr_access(&mut self, exit_info: &super::vmcb::SvmExitInfo) -> AxResult {
+    fn handle_apic_base_msr_access(
+        &mut self,
+        exit_info: &super::vmcb::SvmExitInfo,
+    ) -> X86VcpuResult {
         const VM_EXIT_INSTR_LEN_MSR: u8 = 2;
 
         if exit_info.exit_info_1 == 0 {
@@ -648,39 +653,42 @@ impl SvmVcpu {
         &mut self,
         exit_info: &super::vmcb::SvmExitInfo,
         msr: u32,
-    ) -> AxResult<VmExit> {
+    ) -> X86VcpuResult<X86VmExit> {
         const VM_EXIT_INSTR_LEN_MSR: u8 = 2;
         let write = exit_info.exit_info_1 != 0;
 
         if write {
             if msr == X2APIC_EOI_MSR {
                 self.advance_rip(VM_EXIT_INSTR_LEN_MSR)?;
-                return Ok(VmExit::InterruptEnd {
+                return Ok(X86VmExit::InterruptEnd {
                     vector: self.handle_local_apic_eoi(),
                 });
             } else {
                 let value = self.read_edx_eax() as usize;
-                <EmulatedLocalApic as BaseDeviceOps<SysRegAddrRange>>::handle_write(
-                    &self.vlapic,
-                    SysRegAddr::new(msr as usize),
-                    AccessWidth::Qword,
-                    value,
-                )?;
+                self.vlapic
+                    .handle_msr_write(
+                        x86_vlapic::X86MsrAddr::new(msr as usize),
+                        x86_vlapic::X86AccessWidth::Qword,
+                        value,
+                    )
+                    .map_err(|_| X86VcpuError::BadState)?;
             }
         } else {
-            let value = <EmulatedLocalApic as BaseDeviceOps<SysRegAddrRange>>::handle_read(
-                &self.vlapic,
-                SysRegAddr::new(msr as usize),
-                AccessWidth::Qword,
-            )? as u64;
+            let value = self
+                .vlapic
+                .handle_msr_read(
+                    x86_vlapic::X86MsrAddr::new(msr as usize),
+                    x86_vlapic::X86AccessWidth::Qword,
+                )
+                .map_err(|_| X86VcpuError::BadState)? as u64;
             self.write_edx_eax(value);
         }
 
         self.advance_rip(VM_EXIT_INSTR_LEN_MSR)?;
-        Ok(VmExit::Nothing)
+        Ok(X86VmExit::Nothing)
     }
 
-    fn handle_ignored_msr_access(&mut self, exit_info: &super::vmcb::SvmExitInfo) -> AxResult {
+    fn handle_ignored_msr_access(&mut self, exit_info: &super::vmcb::SvmExitInfo) -> X86VcpuResult {
         const VM_EXIT_INSTR_LEN_MSR: u8 = 2;
 
         // Reads return zero, writes are silently discarded. Only call this
@@ -715,7 +723,7 @@ impl SvmVcpu {
         vmcb.state.efer.set(efer);
     }
 
-    fn handle_cpuid(&mut self) -> AxResult {
+    fn handle_cpuid(&mut self) -> X86VcpuResult {
         use raw_cpuid::{CpuIdResult, cpuid};
 
         const VM_EXIT_INSTR_LEN_CPUID: u8 = 2;
@@ -832,7 +840,7 @@ impl SvmVcpu {
                 let mut res = cpuid!(regs_clone.rax, regs_clone.rcx);
                 if res.eax == 0 {
                     let frequency_mhz =
-                        crate::host_tsc_frequency_mhz().unwrap_or(FALLBACK_TSC_FREQUENCY_MHZ);
+                        crate::host_tsc_frequency_mhz::<H>().unwrap_or(FALLBACK_TSC_FREQUENCY_MHZ);
                     warn!(
                         "handle_cpuid: Failed to get TSC frequency by CPUID, default to \
                          {frequency_mhz} MHz"
@@ -852,7 +860,7 @@ impl SvmVcpu {
         self.advance_rip(VM_EXIT_INSTR_LEN_CPUID)
     }
 
-    fn handle_xsetbv(&mut self) -> AxResult {
+    fn handle_xsetbv(&mut self) -> X86VcpuResult {
         const XCR_XCR0: u64 = 0;
         const VM_EXIT_INSTR_LEN_XSETBV: u8 = 3;
 
@@ -888,29 +896,29 @@ impl SvmVcpu {
 
                     Some(x)
                 })
-                .ok_or_else(|| ax_err_type!(InvalidInput))
+                .ok_or(x86_err_type!(InvalidInput))
                 .and_then(|x| {
                     self.xstate.guest_xcr0 = x.bits();
                     self.advance_rip(VM_EXIT_INSTR_LEN_XSETBV)
                 })
         } else {
-            ax_err!(Unsupported, "only xcr0 is supported")
+            x86_err!(Unsupported, "only xcr0 is supported")
         }
     }
 
     fn svm_io_exit_info(
         &self,
         exit_info: &super::vmcb::SvmExitInfo,
-    ) -> AxResult<(bool, bool, bool, AccessWidth, Port)> {
+    ) -> X86VcpuResult<(bool, bool, bool, X86AccessWidth, X86Port)> {
         let info = exit_info.exit_info_1;
         // SVM packs IO direction, string/repeat attributes, width, and port
         // into EXITINFO1 for IOIO exits.
         let is_in = info.get_bit(0);
         let is_string = info.get_bit(2);
         let is_repeat = info.get_bit(3);
-        let width = AccessWidth::try_from(info.get_bits(4..7) as usize)
-            .map_err(|_| ax_err_type!(InvalidData, "invalid SVM IOIO access width"))?;
-        let port = Port(info.get_bits(16..32) as u16);
+        let width = X86AccessWidth::try_from(info.get_bits(4..7) as usize)
+            .map_err(|_| x86_err_type!(InvalidData, "invalid SVM IOIO access width"))?;
+        let port = X86Port::new(info.get_bits(16..32) as u16);
         Ok((is_in, is_string, is_repeat, width, port))
     }
 
@@ -923,7 +931,7 @@ impl SvmVcpu {
         self.regs_mut().rdx = val >> 32;
     }
 
-    fn handle_rdtsc(&mut self) -> AxResult {
+    fn handle_rdtsc(&mut self) -> X86VcpuResult {
         const VM_EXIT_INSTR_LEN_RDTSC: u8 = 2;
 
         let tsc = unsafe { core::arch::x86_64::_rdtsc() };
@@ -947,7 +955,7 @@ impl SvmVcpu {
         set_interrupt_window_control(control, enable);
     }
 
-    fn inject_pending_events(&mut self) -> AxResult {
+    fn inject_pending_events(&mut self) -> X86VcpuResult {
         if self.injecting_event.is_some() {
             return Ok(());
         }
@@ -1009,7 +1017,7 @@ impl SvmVcpu {
         vmcb.control.clean_bits.set(0);
     }
 
-    fn inject_event(&mut self, vector: u8, err_code: Option<u32>) -> AxResult {
+    fn inject_event(&mut self, vector: u8, err_code: Option<u32>) -> X86VcpuResult {
         let vmcb = unsafe { self.vmcb.as_vmcb() };
         let int_type = if vector < 32 {
             InterruptType::Exception
@@ -1028,7 +1036,7 @@ impl SvmVcpu {
         Ok(())
     }
 
-    fn gla2gva(&self, guest_rip: GuestVirtAddr) -> GuestVirtAddr {
+    fn gla2gva(&self, guest_rip: X86GuestVirtAddr) -> X86GuestVirtAddr {
         if self.get_cpu_mode() == VmCpuMode::Mode64 {
             guest_rip
         } else {
@@ -1039,9 +1047,9 @@ impl SvmVcpu {
     fn decode_npt_mmio_access(
         &mut self,
         exit_info: &super::vmcb::SvmExitInfo,
-        addr: GuestPhysAddr,
+        addr: X86GuestPhysAddr,
         write: bool,
-    ) -> AxResult<Option<(VmExit, u8)>> {
+    ) -> X86VcpuResult<Option<(X86VmExit, u8)>> {
         let addr_usize = addr.as_usize();
         let local_apic =
             (X86_LOCAL_APIC_BASE..X86_LOCAL_APIC_BASE + X86_LOCAL_APIC_SIZE).contains(&addr_usize);
@@ -1050,7 +1058,7 @@ impl SvmVcpu {
             return Ok(None);
         }
 
-        let start = self.gla2gva(GuestVirtAddr::from(exit_info.guest_rip as usize));
+        let start = self.gla2gva(X86GuestVirtAddr::from(exit_info.guest_rip as usize));
         let mut rip = start;
         let mut rex = 0u8;
         if let Err(err) = self.skip_simple_prefixes(&mut rip, &mut rex) {
@@ -1091,21 +1099,22 @@ impl SvmVcpu {
                 let reg = (((modrm >> 3) & 0x7) | ((rex & 0x4) << 1)) as usize;
                 let end = self.skip_modrm_memory_operand(rip, modrm, rex)?;
                 let exit = if local_apic {
-                    let val =
-                        <EmulatedLocalApic as BaseDeviceOps<AddrRange<GuestPhysAddr>>>::handle_read(
-                            &self.vlapic,
-                            addr,
-                            AccessWidth::Dword,
-                        )?;
+                    let val = self
+                        .vlapic
+                        .handle_mmio_read(
+                            x86_vlapic::X86GuestPhysAddr::from_usize(addr.as_usize()),
+                            x86_vlapic::X86AccessWidth::Dword,
+                        )
+                        .map_err(|_| X86VcpuError::BadState)?;
                     self.regs_mut()
                         .set_reg_of_index(reg as u8, val as u32 as u64);
-                    VmExit::Nothing
+                    X86VmExit::Nothing
                 } else {
-                    VmExit::MmioRead {
+                    X86VmExit::MmioRead {
                         addr,
-                        width: AccessWidth::Dword,
+                        width: X86AccessWidth::Dword,
                         reg,
-                        reg_width: AccessWidth::Dword,
+                        reg_width: X86AccessWidth::Dword,
                         signed_ext: false,
                     }
                 };
@@ -1120,35 +1129,36 @@ impl SvmVcpu {
 
     fn handle_decoded_npt_mmio_write(
         &mut self,
-        addr: GuestPhysAddr,
+        addr: X86GuestPhysAddr,
         data: u64,
         local_apic: bool,
-    ) -> AxResult<VmExit> {
+    ) -> X86VcpuResult<X86VmExit> {
         if !local_apic {
-            return Ok(VmExit::MmioWrite {
+            return Ok(X86VmExit::MmioWrite {
                 addr,
-                width: AccessWidth::Dword,
+                width: X86AccessWidth::Dword,
                 data,
             });
         }
 
         let offset = addr.as_usize() - X86_LOCAL_APIC_BASE;
         if offset == X86_LOCAL_APIC_EOI_OFFSET {
-            return Ok(VmExit::InterruptEnd {
+            return Ok(X86VmExit::InterruptEnd {
                 vector: self.handle_local_apic_eoi(),
             });
         }
 
-        <EmulatedLocalApic as BaseDeviceOps<AddrRange<GuestPhysAddr>>>::handle_write(
-            &self.vlapic,
-            addr,
-            AccessWidth::Dword,
-            data as usize,
-        )?;
-        Ok(VmExit::Nothing)
+        self.vlapic
+            .handle_mmio_write(
+                x86_vlapic::X86GuestPhysAddr::from_usize(addr.as_usize()),
+                x86_vlapic::X86AccessWidth::Dword,
+                data as usize,
+            )
+            .map_err(|_| X86VcpuError::BadState)?;
+        Ok(X86VmExit::Nothing)
     }
 
-    fn skip_simple_prefixes(&self, rip: &mut GuestVirtAddr, rex: &mut u8) -> AxResult {
+    fn skip_simple_prefixes(&self, rip: &mut X86GuestVirtAddr, rex: &mut u8) -> X86VcpuResult {
         loop {
             let byte = self.read_guest_u8(*rip)?;
             if byte == 0x66 {
@@ -1164,10 +1174,10 @@ impl SvmVcpu {
 
     fn skip_modrm_memory_operand(
         &self,
-        mut cursor: GuestVirtAddr,
+        mut cursor: X86GuestVirtAddr,
         modrm: u8,
         rex: u8,
-    ) -> AxResult<GuestVirtAddr> {
+    ) -> X86VcpuResult<X86GuestVirtAddr> {
         let mode = modrm >> 6;
         let rm = modrm & 0x7;
 
@@ -1186,24 +1196,23 @@ impl SvmVcpu {
             0 => {}
             1 => cursor += size_of::<u8>(),
             2 => cursor += size_of::<u32>(),
-            _ => return ax_err!(InvalidInput, "ModRM register operand is not memory"),
+            _ => return x86_err!(InvalidInput, "ModRM register operand is not memory"),
         }
 
         Ok(cursor)
     }
 
-    fn read_guest_u8(&self, gva: GuestVirtAddr) -> AxResult<u8> {
+    fn read_guest_u8(&self, gva: X86GuestVirtAddr) -> X86VcpuResult<u8> {
         let gpa = self.translate_guest_linear(gva)?;
-        let hva = crate::host::phys_to_virt(HostPhysAddr::from(gpa.as_usize()));
-        Ok(unsafe { core::ptr::read_volatile(hva.as_ptr()) })
+        host::read_guest_u8::<H>(gpa)
     }
 
-    fn translate_guest_linear(&self, gva: GuestVirtAddr) -> AxResult<GuestPhysAddr> {
+    fn translate_guest_linear(&self, gva: X86GuestVirtAddr) -> X86VcpuResult<X86GuestPhysAddr> {
         let addr = gva.as_usize();
         match self.get_paging_level() {
-            0 => Ok(GuestPhysAddr::from(addr)),
+            0 => Ok(X86GuestPhysAddr::from(addr)),
             4 => self.walk_guest_page_table_4level(addr),
-            level => ax_err!(
+            level => x86_err!(
                 Unsupported,
                 format_args!("unsupported SVM MMIO decode paging level {level}")
             ),
@@ -1230,7 +1239,7 @@ impl SvmVcpu {
         level
     }
 
-    fn walk_guest_page_table_4level(&self, gva: usize) -> AxResult<GuestPhysAddr> {
+    fn walk_guest_page_table_4level(&self, gva: usize) -> X86VcpuResult<X86GuestPhysAddr> {
         const PRESENT: u64 = 1 << 0;
         const HUGE_PAGE: u64 = 1 << 7;
         const ADDR_MASK: u64 = 0x000f_ffff_ffff_f000;
@@ -1247,9 +1256,9 @@ impl SvmVcpu {
         ];
 
         for (level, index) in indexes.into_iter().enumerate() {
-            let entry = read_guest_phys_u64(table as usize + index * size_of::<u64>());
+            let entry = read_guest_phys_u64::<H>(table as usize + index * size_of::<u64>())?;
             if entry & PRESENT == 0 {
-                return ax_err!(
+                return x86_err!(
                     InvalidInput,
                     format_args!("guest RIP page table entry is not present at level {level}")
                 );
@@ -1258,17 +1267,17 @@ impl SvmVcpu {
             let paddr = (entry & ADDR_MASK) as usize;
             match level {
                 1 if entry & HUGE_PAGE != 0 => {
-                    return Ok(GuestPhysAddr::from(paddr + (gva & PAGE_1G_MASK)));
+                    return Ok(X86GuestPhysAddr::from(paddr + (gva & PAGE_1G_MASK)));
                 }
                 2 if entry & HUGE_PAGE != 0 => {
-                    return Ok(GuestPhysAddr::from(paddr + (gva & PAGE_2M_MASK)));
+                    return Ok(X86GuestPhysAddr::from(paddr + (gva & PAGE_2M_MASK)));
                 }
-                3 => return Ok(GuestPhysAddr::from(paddr + (gva & PAGE_4K_MASK))),
+                3 => return Ok(X86GuestPhysAddr::from(paddr + (gva & PAGE_4K_MASK))),
                 _ => table = paddr as u64,
             }
         }
 
-        ax_err!(InvalidInput, "failed to translate guest RIP")
+        x86_err!(InvalidInput, "failed to translate guest RIP")
     }
 
     fn before_vmrun(&mut self) {
@@ -1400,35 +1409,11 @@ fn pending_event_interrupt_type(event: PendingEvent) -> u32 {
     }
 }
 
-fn svm_intr_exit_reason(_vector: Option<u8>) -> VmExit {
+fn svm_intr_exit_reason(_vector: Option<u8>) -> X86VmExit {
     // SVM_EXIT_INTR is a host IRQ exit point. Unlike VMX external-interrupt
     // exits, VMCB exit_int_info is not a reliable dispatch key for the host
     // IRQ framework, so the caller must let the host consume the pending IRQ.
-    VmExit::PreemptionTimer
-}
-
-fn service_pending_host_interrupt() {
-    let host_rflags = current_rflags();
-    unsafe {
-        // SVM's INTR exit does not always provide the host vector. Briefly
-        // open host interrupts so the pending physical IRQ is consumed by the
-        // platform IRQ framework, then restore the previous host IF state.
-        asm!("sti", "nop", options(nomem, nostack));
-    }
-    restore_host_interrupt_flag(host_rflags);
-}
-
-fn current_rflags() -> u64 {
-    let flags: u64;
-    unsafe {
-        asm!(
-            "pushfq",
-            "pop {flags}",
-            flags = lateout(reg) flags,
-            options(nomem, preserves_flags),
-        );
-    }
-    flags
+    X86VmExit::PreemptionTimer
 }
 
 fn svm_mmio_register_write_opcode(write: bool, opcode: u8, local_apic: bool) -> bool {
@@ -1466,7 +1451,7 @@ fn enable_virtual_interrupt_masking_control(control: &mut super::vmcb::VmcbContr
     control.clean_bits.set(0);
 }
 
-impl Debug for SvmVcpu {
+impl<H: X86HostOps> Debug for SvmVcpu<H> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.debug_struct("SvmVcpu")
             .field("entry", &self.entry)
@@ -1477,57 +1462,57 @@ impl Debug for SvmVcpu {
     }
 }
 
-impl VmArchVcpuOps for SvmVcpu {
-    type CreateConfig = X86VCpuCreateConfig;
-    type SetupConfig = X86VCpuSetupConfig;
-    type Exit = VmExit;
-
-    fn new(vm_id: VMId, vcpu_id: VCpuId, _config: Self::CreateConfig) -> AxResult<Self> {
+impl<H: X86HostOps> SvmVcpu<H> {
+    pub fn new_with_config(
+        vm_id: usize,
+        vcpu_id: usize,
+        _config: X86VCpuCreateConfig,
+    ) -> X86VcpuResult<Self> {
         Self::create(vm_id, vcpu_id)
     }
 
-    fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
+    pub fn set_entry(&mut self, entry: X86GuestPhysAddr) -> X86VcpuResult {
         self.entry = Some(entry);
         Ok(())
     }
 
-    fn set_nested_page_table(&mut self, config: NestedPagingConfig) -> AxResult {
+    pub fn set_nested_page_table(&mut self, config: X86NestedPagingConfig) -> X86VcpuResult {
         self.npt_root = Some(config.root_paddr);
         Ok(())
     }
 
-    fn setup(&mut self, config: Self::SetupConfig) -> AxResult {
+    pub fn setup(&mut self, config: X86VCpuSetupConfig) -> X86VcpuResult {
         let entry = self
             .entry
-            .ok_or_else(|| ax_err_type!(InvalidInput, "SVM guest entry is not set"))?;
+            .ok_or(x86_err_type!(InvalidInput, "SVM guest entry is not set"))?;
         let npt_root = self
             .npt_root
-            .ok_or_else(|| ax_err_type!(InvalidInput, "SVM NPT root is not set"))?;
+            .ok_or(x86_err_type!(InvalidInput, "SVM NPT root is not set"))?;
         self.setup_vmcb(entry, npt_root, config)
     }
 
-    fn run(&mut self) -> AxResult<Self::Exit> {
+    pub fn run(&mut self) -> X86VcpuResult<X86VmExit> {
         {
             let exit_info = self.inner_run()?;
             let exit_code = match exit_info.exit_code {
                 Ok(code) => code,
                 Err(code) => {
                     warn!("SVM unknown VM-exit code: {code:#x}, exit_info: {exit_info:#x?}");
-                    return Ok(VmExit::Halt);
+                    return Ok(X86VmExit::Halt);
                 }
             };
 
             Ok(match exit_code {
-                SvmExitCode::INVALID | SvmExitCode::BUSY => VmExit::FailEntry {
+                SvmExitCode::INVALID | SvmExitCode::BUSY => X86VmExit::FailEntry {
                     hardware_entry_failure_reason: match exit_code {
-                        SvmExitCode::INVALID => u64::MAX,
-                        SvmExitCode::BUSY => u64::MAX - 1,
+                        SvmExitCode::INVALID => usize::MAX,
+                        SvmExitCode::BUSY => usize::MAX - 1,
                         _ => unreachable!(),
                     },
                 },
                 SvmExitCode::VMMCALL => {
                     self.advance_rip(3)?;
-                    VmExit::Hypercall {
+                    X86VmExit::Hypercall {
                         nr: self.regs().rax,
                         args: [
                             self.regs().rdi,
@@ -1541,7 +1526,7 @@ impl VmArchVcpuOps for SvmVcpu {
                 }
                 SvmExitCode::RDTSC => {
                     self.handle_rdtsc()?;
-                    VmExit::PreemptionTimer
+                    X86VmExit::PreemptionTimer
                 }
                 SvmExitCode::IOIO => {
                     let (is_in, is_string, is_repeat, width, port) =
@@ -1552,16 +1537,11 @@ impl VmArchVcpuOps for SvmVcpu {
                     if is_string || is_repeat {
                         warn!("SVM unsupported IOIO exit: {exit_info:#x?}");
                         warn!("VCpu {self:#x?}");
-                        VmExit::Halt
+                        X86VmExit::Halt
                     } else if is_in {
-                        VmExit::IoRead { port, width }
-                    } else if port == Port(QEMU_EXIT_PORT)
-                        && width == AccessWidth::Word
-                        && self.regs().rax == QEMU_EXIT_MAGIC
-                    {
-                        VmExit::SystemDown
+                        X86VmExit::PortIoRead { port, width }
                     } else {
-                        VmExit::IoWrite {
+                        X86VmExit::PortIoWrite {
                             port,
                             width,
                             data: self.regs().rax.get_bits(width.bits_range()),
@@ -1575,13 +1555,12 @@ impl VmArchVcpuOps for SvmVcpu {
                     } else {
                         self.advance_rip(2)?;
                         if exit_info.exit_info_1 == 0 {
-                            VmExit::SysRegRead {
-                                addr: SysRegAddr::new(self.regs().rcx as _),
-                                reg: 0,
+                            X86VmExit::MsrRead {
+                                addr: X86MsrAddr::new(self.regs().rcx as _),
                             }
                         } else {
-                            VmExit::SysRegWrite {
-                                addr: SysRegAddr::new(self.regs().rcx as _),
+                            X86VmExit::MsrWrite {
+                                addr: X86MsrAddr::new(self.regs().rcx as _),
                                 value: self.read_edx_eax(),
                             }
                         }
@@ -1589,8 +1568,8 @@ impl VmArchVcpuOps for SvmVcpu {
                 }
                 SvmExitCode::NPF => {
                     let info = self.nested_page_fault_info()?;
-                    let write = info.access_flags.contains(MappingFlags::WRITE);
-                    let read = info.access_flags.contains(MappingFlags::READ);
+                    let write = info.access_flags.contains(X86AccessFlags::WRITE);
+                    let read = info.access_flags.contains(X86AccessFlags::READ);
                     if (read || write)
                         && let Some((mmio_exit, instr_len)) =
                             self.decode_npt_mmio_access(&exit_info, info.fault_guest_paddr, write)?
@@ -1598,7 +1577,7 @@ impl VmArchVcpuOps for SvmVcpu {
                         self.advance_rip(instr_len)?;
                         mmio_exit
                     } else {
-                        VmExit::NestedPageFault {
+                        X86VmExit::NestedPageFault {
                             addr: info.fault_guest_paddr,
                             access_flags: info.access_flags,
                         }
@@ -1609,40 +1588,40 @@ impl VmArchVcpuOps for SvmVcpu {
                     // as a periodic VMM poll point after first letting the
                     // host consume the pending physical IRQ.
                     let vector = self.external_interrupt_exit_vector();
-                    service_pending_host_interrupt();
+                    H::poll_host_interrupt();
                     svm_intr_exit_reason(vector)
                 }
                 SvmExitCode::HLT => {
                     self.advance_rip(1)?;
-                    VmExit::PreemptionTimer
+                    X86VmExit::PreemptionTimer
                 }
                 SvmExitCode::PAUSE => {
                     self.advance_rip(2)?;
-                    VmExit::PreemptionTimer
+                    X86VmExit::PreemptionTimer
                 }
-                SvmExitCode::SHUTDOWN => VmExit::SystemDown,
+                SvmExitCode::SHUTDOWN => X86VmExit::SystemDown,
                 _ => {
                     warn!("SVM unsupported VM-exit: {exit_info:#x?}");
                     warn!("VCpu {self:#x?}");
-                    VmExit::Halt
+                    X86VmExit::Halt
                 }
             })
         }
     }
 
-    fn bind(&mut self) -> AxResult {
+    pub fn bind(&mut self) -> X86VcpuResult {
         self.bind_to_current_processor()
     }
 
-    fn unbind(&mut self) -> AxResult {
+    pub fn unbind(&mut self) -> X86VcpuResult {
         self.unbind_from_current_processor()
     }
 
-    fn set_gpr(&mut self, reg: usize, val: usize) {
+    pub fn set_gpr(&mut self, reg: usize, val: usize) {
         self.regs_mut().set_reg_of_index(reg as u8, val as u64);
     }
 
-    fn inject_interrupt(&mut self, vector: usize) -> AxResult {
+    pub fn inject_interrupt(&mut self, vector: usize) -> X86VcpuResult {
         if vector == 0 {
             warn!("interrupt queued in inject_interrupt: vector 0");
             panic!()
@@ -1651,28 +1630,24 @@ impl VmArchVcpuOps for SvmVcpu {
         Ok(())
     }
 
-    fn inject_interrupt_with_trigger(
+    pub fn inject_interrupt_with_trigger(
         &mut self,
         vector: usize,
-        trigger: axvm_types::InterruptTriggerMode,
-    ) -> AxResult {
+        level_triggered: bool,
+    ) -> X86VcpuResult {
         if vector == 0 {
             warn!("interrupt queued in inject_interrupt_with_trigger: vector 0");
             panic!()
         }
-        self.queue_event_with_trigger(
-            vector as u8,
-            None,
-            trigger == axvm_types::InterruptTriggerMode::LevelTriggered,
-        );
+        self.queue_event_with_trigger(vector as u8, None, level_triggered);
         Ok(())
     }
 
-    fn handle_eoi(&mut self) -> Option<u8> {
+    pub fn handle_eoi(&mut self) -> Option<u8> {
         self.handle_local_apic_eoi()
     }
 
-    fn set_return_value(&mut self, val: usize) {
+    pub fn set_return_value(&mut self, val: usize) {
         self.regs_mut().rax = val as u64;
     }
 }
@@ -1681,7 +1656,6 @@ impl VmArchVcpuOps for SvmVcpu {
 mod tests {
     use core::mem::MaybeUninit;
 
-    use axvm_types::VmExit;
     use tock_registers::interfaces::{Readable, Writeable};
     use x86_64::registers::rflags::RFlags;
 
@@ -1692,9 +1666,12 @@ mod tests {
         interrupted_injected_event, set_interrupt_window_control, svm_external_interrupt_allowed,
         svm_external_interrupt_exit_vector, svm_intr_exit_reason, svm_mmio_register_write_opcode,
     };
-    use crate::svm::{
-        flags::{InterruptType, VmcbIntInfo},
-        vmcb::VmcbControlArea,
+    use crate::{
+        X86VmExit,
+        svm::{
+            flags::{InterruptType, VmcbIntInfo},
+            vmcb::VmcbControlArea,
+        },
     };
 
     #[test]
@@ -1793,7 +1770,7 @@ mod tests {
         let vector = 0x51;
         let exit = svm_intr_exit_reason(Some(vector));
 
-        assert!(matches!(exit, VmExit::PreemptionTimer));
+        assert!(matches!(exit, X86VmExit::PreemptionTimer));
     }
 
     #[test]
@@ -1836,7 +1813,10 @@ mod tests {
     }
 }
 
-fn read_guest_phys_u64(gpa: usize) -> u64 {
-    let hva = crate::host::phys_to_virt(HostPhysAddr::from(gpa));
-    unsafe { core::ptr::read_unaligned(hva.as_ptr() as *const u64) }
+fn read_guest_phys_u64<H: X86HostOps>(gpa: usize) -> X86VcpuResult<u64> {
+    let mut bytes = [0u8; 8];
+    for (offset, byte) in bytes.iter_mut().enumerate() {
+        *byte = host::read_guest_u8::<H>(X86GuestPhysAddr::from_usize(gpa + offset))?;
+    }
+    Ok(u64::from_le_bytes(bytes))
 }

--- a/virtualization/x86_vcpu/src/svm/vmcb.rs
+++ b/virtualization/x86_vcpu/src/svm/vmcb.rs
@@ -1,7 +1,6 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
-use ax_errno::AxResult;
 use tock_registers::{
     interfaces::{ReadWriteable, Readable, Writeable},
     register_bitfields, register_structs,
@@ -12,6 +11,7 @@ use super::{
     definitions::{SvmExitCode, SvmIntercept},
     structs::VmcbFrame,
 };
+use crate::{X86HostOps, X86VcpuResult};
 
 register_bitfields![u32,
     pub InterceptCrRw [
@@ -189,7 +189,7 @@ register_structs![
     }
 ];
 
-impl VmcbFrame {
+impl<H: X86HostOps> VmcbFrame<H> {
     /// # Safety
     ///
     /// The caller must ensure the VMCB page is mapped and no mutable reference
@@ -212,7 +212,7 @@ impl VmcbStruct {
         unsafe { core::ptr::write_bytes(&mut self.control as *mut _ as *mut u8, 0, 0x400) };
     }
 
-    pub fn exit_info(&self) -> AxResult<SvmExitInfo> {
+    pub fn exit_info(&self) -> X86VcpuResult<SvmExitInfo> {
         Ok(SvmExitInfo {
             exit_code: self.control.exit_code.get().try_into(),
             exit_info_1: self.control.exit_info_1.get(),

--- a/virtualization/x86_vcpu/src/test_utils.rs
+++ b/virtualization/x86_vcpu/src/test_utils.rs
@@ -16,25 +16,31 @@
 pub mod mock {
     use std::sync::Mutex;
 
-    use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr};
+    use x86_vlapic::{
+        X86InterruptVector, X86TimerCallback, X86VcpuId, X86VlapicHostOps, X86VlapicResult, X86VmId,
+    };
 
-    use crate::host::X86VcpuHostIf;
+    use crate::{
+        X86GuestPhysAddr, X86HostOps, X86HostPhysAddr, X86HostVirtAddr, X86VcpuError, X86VcpuResult,
+    };
+
+    const PAGE_SIZE_4K: usize = 0x1000;
+    const FRAME_COUNT: usize = 16;
+    const FIRST_FRAME: usize = 0x1000;
 
     static GLOBAL_LOCK: Mutex<MockMmHalState> = Mutex::new(MockMmHalState::new());
     static TEST_LOCK: Mutex<()> = Mutex::new(());
 
-    // State for the mock memory allocator
     struct MockMmHalState {
-        memory_pool: [[u8; 4096]; 16],
+        memory_pool: [[u8; PAGE_SIZE_4K]; FRAME_COUNT],
         alloc_mask: u16,
         reset_counter: usize,
     }
 
     impl MockMmHalState {
-        // Create a new instance of MockMmHalState
         const fn new() -> Self {
             Self {
-                memory_pool: [[0; 4096]; 16],
+                memory_pool: [[0; PAGE_SIZE_4K]; FRAME_COUNT],
                 alloc_mask: 0,
                 reset_counter: 0,
             }
@@ -44,34 +50,30 @@ pub mod mock {
     #[derive(Debug)]
     pub struct MockMmHal;
 
-    #[ax_crate_interface::impl_interface]
-    impl X86VcpuHostIf for MockMmHal {
-        /// Allocate a frame.
-        fn alloc_frame() -> Option<PhysAddr> {
+    impl MockMmHal {
+        fn alloc_frame_usize() -> Option<usize> {
             let mut state = GLOBAL_LOCK.lock().unwrap();
 
-            for i in 0..16 {
+            for i in 0..FRAME_COUNT {
                 let bit = 1 << i;
                 if (state.alloc_mask & bit) == 0 {
                     state.alloc_mask |= bit;
-                    let phys_addr = 0x1000 + i * PAGE_SIZE_4K;
-                    return Some(ax_memory_addr::PhysAddr::from(phys_addr));
+                    return Some(FIRST_FRAME + i * PAGE_SIZE_4K);
                 }
             }
             None
         }
 
-        /// Allocate a number of contiguous frames, with a specified alignment.
-        fn alloc_contiguous_frames(num_frames: usize, frame_align: usize) -> Option<PhysAddr> {
+        fn alloc_contiguous_frames_usize(num_frames: usize, frame_align: usize) -> Option<usize> {
             let mut state = GLOBAL_LOCK.lock().unwrap();
 
-            if num_frames == 0 || num_frames > 16 {
+            if num_frames == 0 || num_frames > FRAME_COUNT {
                 return None;
             }
 
             let align = frame_align.max(PAGE_SIZE_4K);
-            for start in 0..=16 - num_frames {
-                let phys_addr = 0x1000 + start * PAGE_SIZE_4K;
+            for start in 0..=FRAME_COUNT - num_frames {
+                let phys_addr = FIRST_FRAME + start * PAGE_SIZE_4K;
                 if phys_addr % align != 0 {
                     continue;
                 }
@@ -79,98 +81,85 @@ pub mod mock {
                 let mask = ((1u16 << num_frames) - 1) << start;
                 if (state.alloc_mask & mask) == 0 {
                     state.alloc_mask |= mask;
-                    return Some(PhysAddr::from(phys_addr));
+                    return Some(phys_addr);
                 }
             }
             None
         }
 
-        /// Deallocate a frame allocated previously by [`alloc_frame`].
-        fn dealloc_frame(paddr: PhysAddr) {
+        fn dealloc_contiguous_frames_usize(first_addr: usize, num_frames: usize) {
             let mut state = GLOBAL_LOCK.lock().unwrap();
 
-            let addr = paddr.as_usize();
-            if addr >= 0x1000
-                && addr < 0x1000 + 16 * PAGE_SIZE_4K
-                && (addr - 0x1000).is_multiple_of(PAGE_SIZE_4K)
-            {
-                let page_index = (addr - 0x1000) / PAGE_SIZE_4K;
-                let bit = 1 << page_index;
-                state.alloc_mask &= !bit;
-            }
-        }
-
-        /// Deallocate a number of contiguous frames allocated previously by
-        /// [`alloc_contiguous_frames`].
-        fn dealloc_contiguous_frames(first_addr: PhysAddr, num_frames: usize) {
-            let mut state = GLOBAL_LOCK.lock().unwrap();
-
-            let addr = first_addr.as_usize();
             if num_frames == 0
-                || num_frames > 16
-                || addr < 0x1000
-                || addr >= 0x1000 + 16 * PAGE_SIZE_4K
-                || !(addr - 0x1000).is_multiple_of(PAGE_SIZE_4K)
+                || num_frames > FRAME_COUNT
+                || first_addr < FIRST_FRAME
+                || first_addr >= FIRST_FRAME + FRAME_COUNT * PAGE_SIZE_4K
+                || !(first_addr - FIRST_FRAME).is_multiple_of(PAGE_SIZE_4K)
             {
                 return;
             }
 
-            let start = (addr - 0x1000) / PAGE_SIZE_4K;
-            if start + num_frames <= 16 {
+            let start = (first_addr - FIRST_FRAME) / PAGE_SIZE_4K;
+            if start + num_frames <= FRAME_COUNT {
                 let mask = ((1u16 << num_frames) - 1) << start;
                 state.alloc_mask &= !mask;
             }
         }
 
-        /// Convert a physical address to a virtual address.
-        fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+        fn dealloc_frame_usize(paddr: usize) {
+            Self::dealloc_contiguous_frames_usize(paddr, 1);
+        }
+
+        fn phys_to_virt_usize(paddr: usize) -> usize {
             let state = GLOBAL_LOCK.lock().unwrap();
 
-            let addr = paddr.as_usize();
-            if addr >= 0x1000 && addr < 0x1000 + 16 * PAGE_SIZE_4K {
-                let page_index = (addr - 0x1000) / PAGE_SIZE_4K;
-                let offset = (addr - 0x1000) % PAGE_SIZE_4K;
-
+            if (FIRST_FRAME..FIRST_FRAME + FRAME_COUNT * PAGE_SIZE_4K).contains(&paddr) {
+                let page_index = (paddr - FIRST_FRAME) / PAGE_SIZE_4K;
+                let offset = (paddr - FIRST_FRAME) % PAGE_SIZE_4K;
                 let page_ptr = state.memory_pool[page_index].as_ptr();
-                ax_memory_addr::VirtAddr::from(unsafe { page_ptr.add(offset) as usize })
+                unsafe { page_ptr.add(offset) as usize }
             } else {
-                ax_memory_addr::VirtAddr::from(addr)
+                paddr
             }
         }
 
-        fn nanos_to_ticks(nanos: u64) -> u64 {
-            nanos
-        }
-    }
+        fn virt_to_phys_usize(vaddr: usize) -> usize {
+            let state = GLOBAL_LOCK.lock().unwrap();
 
-    impl MockMmHal {
-        // Reset the mock memory allocator state
+            for (page_index, page) in state.memory_pool.iter().enumerate() {
+                let start = page.as_ptr() as usize;
+                let end = start + PAGE_SIZE_4K;
+                if (start..end).contains(&vaddr) {
+                    return FIRST_FRAME + page_index * PAGE_SIZE_4K + (vaddr - start);
+                }
+            }
+            vaddr
+        }
+
         #[allow(dead_code)]
         pub fn reset() {
             let mut state = GLOBAL_LOCK.lock().unwrap();
-            state.memory_pool = [[0; PAGE_SIZE_4K]; 16];
+            state.memory_pool = [[0; PAGE_SIZE_4K]; FRAME_COUNT];
             state.alloc_mask = 0;
             state.reset_counter += 1;
         }
 
-        // Get the number of allocated frames
         #[allow(dead_code)]
         pub fn allocated_count() -> usize {
             let state = GLOBAL_LOCK.lock().unwrap();
             state.alloc_mask.count_ones() as usize
         }
 
-        // Check if a physical address is allocated
         #[allow(dead_code)]
-        pub fn is_allocated(paddr: ax_memory_addr::PhysAddr) -> bool {
+        pub fn is_allocated(paddr: X86HostPhysAddr) -> bool {
             let state = GLOBAL_LOCK.lock().unwrap();
 
             let addr = paddr.as_usize();
-            if addr >= 0x1000
-                && addr < 0x1000 + 16 * PAGE_SIZE_4K
-                && (addr - 0x1000).is_multiple_of(PAGE_SIZE_4K)
+            if addr >= FIRST_FRAME
+                && addr < FIRST_FRAME + FRAME_COUNT * PAGE_SIZE_4K
+                && (addr - FIRST_FRAME).is_multiple_of(PAGE_SIZE_4K)
             {
-                let page_index = (addr - 0x1000) / PAGE_SIZE_4K;
+                let page_index = (addr - FIRST_FRAME) / PAGE_SIZE_4K;
                 let bit = 1 << page_index;
                 (state.alloc_mask & bit) != 0
             } else {
@@ -178,7 +167,6 @@ pub mod mock {
             }
         }
 
-        // Get the current reset count
         #[allow(dead_code)]
         pub fn reset_count() -> usize {
             let state = GLOBAL_LOCK.lock().unwrap();
@@ -195,46 +183,152 @@ pub mod mock {
             test()
         }
     }
+
+    impl X86VlapicHostOps for MockMmHal {
+        fn alloc_frame() -> Option<x86_vlapic::X86HostPhysAddr> {
+            Self::alloc_frame_usize().map(x86_vlapic::X86HostPhysAddr::from_usize)
+        }
+
+        fn dealloc_frame(paddr: x86_vlapic::X86HostPhysAddr) {
+            Self::dealloc_frame_usize(paddr.as_usize());
+        }
+
+        fn phys_to_virt(paddr: x86_vlapic::X86HostPhysAddr) -> x86_vlapic::X86HostVirtAddr {
+            x86_vlapic::X86HostVirtAddr::from_usize(Self::phys_to_virt_usize(paddr.as_usize()))
+        }
+
+        fn virt_to_phys(vaddr: x86_vlapic::X86HostVirtAddr) -> x86_vlapic::X86HostPhysAddr {
+            x86_vlapic::X86HostPhysAddr::from_usize(Self::virt_to_phys_usize(vaddr.as_usize()))
+        }
+
+        fn current_time_nanos() -> u64 {
+            0
+        }
+
+        fn register_timer(_deadline_nanos: u64, _callback: X86TimerCallback) -> Option<usize> {
+            None
+        }
+
+        fn cancel_timer(_token: usize) {}
+
+        fn write_bytes(_bytes: &[u8]) {}
+
+        fn read_bytes(_bytes: &mut [u8]) -> usize {
+            0
+        }
+
+        fn current_vm_id() -> X86VmId {
+            0
+        }
+
+        fn current_vm_vcpu_num() -> usize {
+            1
+        }
+
+        fn current_vm_active_vcpus() -> usize {
+            1
+        }
+
+        fn active_vcpus(_vm_id: X86VmId) -> Option<usize> {
+            Some(1)
+        }
+
+        fn inject_interrupt(
+            _vm_id: X86VmId,
+            _vcpu_id: X86VcpuId,
+            _vector: X86InterruptVector,
+        ) -> X86VlapicResult {
+            Ok(())
+        }
+    }
+
+    impl X86HostOps for MockMmHal {
+        fn alloc_frame() -> Option<X86HostPhysAddr> {
+            Self::alloc_frame_usize().map(X86HostPhysAddr::from_usize)
+        }
+
+        fn dealloc_frame(paddr: X86HostPhysAddr) {
+            Self::dealloc_frame_usize(paddr.as_usize());
+        }
+
+        fn alloc_contiguous_frames(
+            frame_count: usize,
+            frame_align: usize,
+        ) -> Option<X86HostPhysAddr> {
+            Self::alloc_contiguous_frames_usize(frame_count, frame_align)
+                .map(X86HostPhysAddr::from_usize)
+        }
+
+        fn dealloc_contiguous_frames(start_paddr: X86HostPhysAddr, frame_count: usize) {
+            Self::dealloc_contiguous_frames_usize(start_paddr.as_usize(), frame_count);
+        }
+
+        fn phys_to_virt(paddr: X86HostPhysAddr) -> X86HostVirtAddr {
+            X86HostVirtAddr::from_usize(Self::phys_to_virt_usize(paddr.as_usize()))
+        }
+
+        fn read_guest_u8(paddr: X86GuestPhysAddr) -> X86VcpuResult<u8> {
+            let state = GLOBAL_LOCK.lock().unwrap();
+            let addr = paddr.as_usize();
+            if (FIRST_FRAME..FIRST_FRAME + FRAME_COUNT * PAGE_SIZE_4K).contains(&addr) {
+                let page_index = (addr - FIRST_FRAME) / PAGE_SIZE_4K;
+                let offset = (addr - FIRST_FRAME) % PAGE_SIZE_4K;
+                Ok(state.memory_pool[page_index][offset])
+            } else {
+                Err(X86VcpuError::Unsupported)
+            }
+        }
+
+        fn nanos_to_ticks(nanos: u64) -> u64 {
+            nanos
+        }
+
+        fn poll_host_interrupt() -> Option<u8> {
+            None
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{host::X86VcpuHostIf, test_utils::mock::MockMmHal};
+    use crate::{X86HostOps, test_utils::mock::MockMmHal};
+
+    const PAGE_SIZE_4K: usize = 0x1000;
+    const FIRST_FRAME: usize = 0x1000;
 
     #[test]
     fn test_mock_allocator() {
         MockMmHal::run_test(|| {
-            // Test multiple allocations return different addresses
-            let addr1 = MockMmHal::alloc_frame().unwrap();
-            let addr2 = MockMmHal::alloc_frame().unwrap();
-            let addr3 = MockMmHal::alloc_frame().unwrap();
+            let addr1 = <MockMmHal as X86HostOps>::alloc_frame().unwrap();
+            let addr2 = <MockMmHal as X86HostOps>::alloc_frame().unwrap();
+            let addr3 = <MockMmHal as X86HostOps>::alloc_frame().unwrap();
 
             assert_ne!(addr1.as_usize(), addr2.as_usize());
             assert_ne!(addr2.as_usize(), addr3.as_usize());
             assert_ne!(addr1.as_usize(), addr3.as_usize());
 
-            // Addresses should be page-aligned
-            assert_eq!(addr1.as_usize() % 0x1000, 0);
-            assert_eq!(addr2.as_usize() % 0x1000, 0);
-            assert_eq!(addr3.as_usize() % 0x1000, 0);
+            assert_eq!(addr1.as_usize() % PAGE_SIZE_4K, 0);
+            assert_eq!(addr2.as_usize() % PAGE_SIZE_4K, 0);
+            assert_eq!(addr3.as_usize() % PAGE_SIZE_4K, 0);
         });
     }
 
     #[test]
     fn test_mock_contiguous_allocator() {
         MockMmHal::run_test(|| {
-            let addr = MockMmHal::alloc_contiguous_frames(3, 0x1000).unwrap();
-            assert_eq!(addr.as_usize(), 0x1000);
+            let addr = <MockMmHal as X86HostOps>::alloc_contiguous_frames(3, PAGE_SIZE_4K).unwrap();
+            assert_eq!(addr.as_usize(), FIRST_FRAME);
             assert_eq!(MockMmHal::allocated_count(), 3);
 
-            let aligned = MockMmHal::alloc_contiguous_frames(2, 0x4000).unwrap();
-            assert_eq!(aligned.as_usize() % 0x4000, 0);
+            let aligned =
+                <MockMmHal as X86HostOps>::alloc_contiguous_frames(2, PAGE_SIZE_4K * 4).unwrap();
+            assert_eq!(aligned.as_usize() % (PAGE_SIZE_4K * 4), 0);
             assert_eq!(MockMmHal::allocated_count(), 5);
 
-            MockMmHal::dealloc_contiguous_frames(addr, 3);
+            <MockMmHal as X86HostOps>::dealloc_contiguous_frames(addr, 3);
             assert_eq!(MockMmHal::allocated_count(), 2);
 
-            MockMmHal::dealloc_contiguous_frames(aligned, 2);
+            <MockMmHal as X86HostOps>::dealloc_contiguous_frames(aligned, 2);
             assert_eq!(MockMmHal::allocated_count(), 0);
         });
     }

--- a/virtualization/x86_vcpu/src/types.rs
+++ b/virtualization/x86_vcpu/src/types.rs
@@ -1,0 +1,389 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::{
+    fmt::{Debug, Formatter, LowerHex, UpperHex},
+    ops::{Add, AddAssign},
+};
+
+use bitflags::bitflags;
+
+/// Size of a 4 KiB page.
+pub const X86_PAGE_SIZE_4K: usize = 0x1000;
+
+/// Result type returned by the OS-neutral x86 vCPU core.
+pub type X86VcpuResult<T = ()> = Result<T, X86VcpuError>;
+
+/// Errors produced by the OS-neutral x86 vCPU core.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum X86VcpuError {
+    /// A caller supplied an invalid argument or unsupported hardware encoding.
+    InvalidInput,
+    /// Hardware register or exit data could not be decoded as a valid value.
+    InvalidData,
+    /// The requested operation is not supported by this CPU or vCPU backend.
+    Unsupported,
+    /// Hardware or software state is inconsistent with the requested transition.
+    BadState,
+    /// A host allocation failed.
+    NoMemory,
+    /// The requested hardware resource is already in use.
+    ResourceBusy,
+}
+
+impl From<x86_vlapic::X86VlapicError> for X86VcpuError {
+    fn from(err: x86_vlapic::X86VlapicError) -> Self {
+        match err {
+            x86_vlapic::X86VlapicError::InvalidInput => Self::InvalidInput,
+            x86_vlapic::X86VlapicError::InvalidData => Self::InvalidData,
+            x86_vlapic::X86VlapicError::Unsupported => Self::Unsupported,
+            x86_vlapic::X86VlapicError::NoMemory => Self::NoMemory,
+            x86_vlapic::X86VlapicError::BadState => Self::BadState,
+        }
+    }
+}
+
+macro_rules! define_addr_type {
+    ($name:ident, $debug_prefix:literal) => {
+        #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+        pub struct $name(usize);
+
+        impl $name {
+            /// Creates an address from a raw `usize`.
+            pub const fn from_usize(addr: usize) -> Self {
+                Self(addr)
+            }
+
+            /// Returns the raw address value.
+            pub const fn as_usize(self) -> usize {
+                self.0
+            }
+
+            /// Returns this address as an immutable pointer.
+            pub const fn as_ptr<T>(self) -> *const T {
+                self.0 as *const T
+            }
+
+            /// Returns this address as a mutable pointer.
+            pub const fn as_mut_ptr<T>(self) -> *mut T {
+                self.0 as *mut T
+            }
+        }
+
+        impl From<usize> for $name {
+            fn from(value: usize) -> Self {
+                Self::from_usize(value)
+            }
+        }
+
+        impl From<$name> for usize {
+            fn from(value: $name) -> Self {
+                value.as_usize()
+            }
+        }
+
+        impl Add<usize> for $name {
+            type Output = Self;
+
+            fn add(self, rhs: usize) -> Self::Output {
+                Self(self.0 + rhs)
+            }
+        }
+
+        impl AddAssign<usize> for $name {
+            fn add_assign(&mut self, rhs: usize) {
+                self.0 += rhs;
+            }
+        }
+
+        impl Debug for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+                write!(f, "{}({:#x})", $debug_prefix, self.0)
+            }
+        }
+
+        impl LowerHex for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+                write!(f, "{:#x}", self.0)
+            }
+        }
+
+        impl UpperHex for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+                write!(f, "{:#X}", self.0)
+            }
+        }
+    };
+}
+
+define_addr_type!(X86GuestPhysAddr, "GPA");
+define_addr_type!(X86GuestVirtAddr, "GVA");
+define_addr_type!(X86HostPhysAddr, "HPA");
+define_addr_type!(X86HostVirtAddr, "HVA");
+
+/// The port number of an x86 I/O operation.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct X86Port(u16);
+
+impl X86Port {
+    /// Creates a new x86 I/O port.
+    pub const fn new(port: u16) -> Self {
+        Self(port)
+    }
+
+    /// Returns the raw port number.
+    pub const fn number(self) -> u16 {
+        self.0
+    }
+}
+
+impl From<u16> for X86Port {
+    fn from(value: u16) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Debug for X86Port {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "X86Port({:#x})", self.0)
+    }
+}
+
+/// x86 MSR address.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct X86MsrAddr(usize);
+
+impl X86MsrAddr {
+    /// Creates an MSR address from the raw MSR number.
+    pub const fn new(addr: usize) -> Self {
+        Self(addr)
+    }
+
+    /// Returns the raw MSR number.
+    pub const fn addr(self) -> usize {
+        self.0
+    }
+}
+
+impl From<usize> for X86MsrAddr {
+    fn from(value: usize) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Debug for X86MsrAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "MSR({:#x})", self.0)
+    }
+}
+
+/// Width of a trapped guest bus access.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum X86AccessWidth {
+    /// 8-bit access.
+    Byte,
+    /// 16-bit access.
+    Word,
+    /// 32-bit access.
+    Dword,
+    /// 64-bit access.
+    Qword,
+}
+
+impl X86AccessWidth {
+    /// Returns this access width in bytes.
+    pub const fn size(self) -> usize {
+        match self {
+            Self::Byte => 1,
+            Self::Word => 2,
+            Self::Dword => 4,
+            Self::Qword => 8,
+        }
+    }
+
+    /// Returns the bit range covered by this access.
+    pub fn bits_range(self) -> core::ops::Range<usize> {
+        match self {
+            Self::Byte => 0..8,
+            Self::Word => 0..16,
+            Self::Dword => 0..32,
+            Self::Qword => 0..64,
+        }
+    }
+}
+
+impl TryFrom<usize> for X86AccessWidth {
+    type Error = X86VcpuError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Byte),
+            2 => Ok(Self::Word),
+            4 => Ok(Self::Dword),
+            8 => Ok(Self::Qword),
+            _ => Err(X86VcpuError::InvalidInput),
+        }
+    }
+}
+
+impl From<X86AccessWidth> for usize {
+    fn from(value: X86AccessWidth) -> Self {
+        value.size()
+    }
+}
+
+bitflags! {
+    /// Access flags reported for a nested page fault.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct X86AccessFlags: usize {
+        /// Read access.
+        const READ = 1 << 0;
+        /// Write access.
+        const WRITE = 1 << 1;
+        /// Execute access.
+        const EXECUTE = 1 << 2;
+    }
+}
+
+/// Information about a nested guest page-table fault.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct X86NestedPageFaultInfo {
+    /// Faulting guest physical address.
+    pub fault_guest_paddr: X86GuestPhysAddr,
+    /// Fault access flags.
+    pub access_flags: X86AccessFlags,
+}
+
+/// Nested page table configuration selected by the embedding VMM.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct X86NestedPagingConfig {
+    /// Root physical address of the nested page table.
+    pub root_paddr: X86HostPhysAddr,
+    /// Number of nested page-table levels.
+    pub levels: usize,
+    /// Guest physical address width in bits.
+    pub gpa_bits: usize,
+    /// Hardware-specific mode value.
+    pub mode: usize,
+}
+
+impl X86NestedPagingConfig {
+    /// Creates a nested paging configuration.
+    pub const fn new(
+        root_paddr: X86HostPhysAddr,
+        levels: usize,
+        gpa_bits: usize,
+        mode: usize,
+    ) -> Self {
+        Self {
+            root_paddr,
+            levels,
+            gpa_bits,
+            mode,
+        }
+    }
+}
+
+/// VM-exit reason returned by the x86 vCPU core.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum X86VmExit {
+    /// A guest instruction triggered a hypercall.
+    Hypercall {
+        /// Hypercall number.
+        nr: u64,
+        /// Hypercall arguments.
+        args: [u64; 6],
+    },
+    /// The guest performed a port I/O read.
+    PortIoRead {
+        /// I/O port.
+        port: X86Port,
+        /// Access width.
+        width: X86AccessWidth,
+    },
+    /// The guest performed a port I/O write.
+    PortIoWrite {
+        /// I/O port.
+        port: X86Port,
+        /// Access width.
+        width: X86AccessWidth,
+        /// Value written by the guest.
+        data: u64,
+    },
+    /// The guest performed an MMIO read.
+    MmioRead {
+        /// Guest physical address.
+        addr: X86GuestPhysAddr,
+        /// Access width.
+        width: X86AccessWidth,
+        /// Destination guest register.
+        reg: usize,
+        /// Destination register width.
+        reg_width: X86AccessWidth,
+        /// Whether the value should be sign-extended.
+        signed_ext: bool,
+    },
+    /// The guest performed an MMIO write.
+    MmioWrite {
+        /// Guest physical address.
+        addr: X86GuestPhysAddr,
+        /// Access width.
+        width: X86AccessWidth,
+        /// Value written by the guest.
+        data: u64,
+    },
+    /// The guest performed an MSR read.
+    MsrRead {
+        /// MSR address.
+        addr: X86MsrAddr,
+    },
+    /// The guest performed an MSR write.
+    MsrWrite {
+        /// MSR address.
+        addr: X86MsrAddr,
+        /// Value written by the guest.
+        value: u64,
+    },
+    /// A nested page fault occurred.
+    NestedPageFault {
+        /// Faulting guest physical address.
+        addr: X86GuestPhysAddr,
+        /// Access flags.
+        access_flags: X86AccessFlags,
+    },
+    /// A physical host interrupt should be handled by the embedding VMM.
+    ExternalInterrupt {
+        /// Host vector reported by the backend.
+        vector: u8,
+    },
+    /// The preemption timer expired or the backend wants the VMM to poll timers.
+    PreemptionTimer,
+    /// A guest EOI completed.
+    InterruptEnd {
+        /// Vector that may require IOAPIC EOI propagation.
+        vector: Option<u8>,
+    },
+    /// The guest halted.
+    Halt,
+    /// The guest requested system power-off.
+    SystemDown,
+    /// VM entry failed in hardware.
+    FailEntry {
+        /// Hardware entry-failure reason.
+        hardware_entry_failure_reason: usize,
+    },
+    /// The exit was handled inside the x86 core.
+    Nothing,
+}

--- a/virtualization/x86_vcpu/src/vmx/mod.rs
+++ b/virtualization/x86_vcpu/src/vmx/mod.rs
@@ -19,8 +19,6 @@ mod structs;
 mod vcpu;
 mod vmcs;
 
-use ax_errno::ax_err_type;
-use axvm_types::HostPhysAddr;
 use x86_vlapic::EmulatedLocalApic;
 
 use self::structs::VmxBasic;
@@ -30,6 +28,7 @@ pub use self::{
     vcpu::{VmxVcpu as VmxArchVCpu, X86_APIC_ACCESS_GPA},
     vmcs::{VmxExitInfo, VmxInterruptInfo, VmxIoExitInfo},
 };
+use crate::{X86HostOps, X86HostPhysAddr, X86VcpuError};
 
 /// Return if current platform support virtualization extension.
 pub fn has_hardware_support() -> bool {
@@ -44,14 +43,15 @@ pub fn read_vmcs_revision_id() -> u32 {
     VmxBasic::read().revision_id
 }
 
-pub fn x86_apic_access_page_addr() -> HostPhysAddr {
-    EmulatedLocalApic::virtual_apic_access_addr()
+pub fn x86_apic_access_page_addr<H: X86HostOps>() -> X86HostPhysAddr {
+    let addr = EmulatedLocalApic::<H>::virtual_apic_access_addr();
+    X86HostPhysAddr::from_usize(addr.as_usize())
 }
 
-fn as_axerr(err: x86::vmx::VmFail) -> ax_errno::AxError {
+fn as_axerr(err: x86::vmx::VmFail) -> X86VcpuError {
     use x86::vmx::VmFail;
     match err {
-        VmFail::VmFailValid => ax_err_type!(BadState, vmcs::instruction_error().as_str()),
-        VmFail::VmFailInvalid => ax_err_type!(BadState, "VMCS pointer is not valid"),
+        VmFail::VmFailValid => X86VcpuError::BadState,
+        VmFail::VmFailInvalid => X86VcpuError::BadState,
     }
 }

--- a/virtualization/x86_vcpu/src/vmx/percpu.rs
+++ b/virtualization/x86_vcpu/src/vmx/percpu.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ax_errno::{AxResult, ax_err, ax_err_type};
-use ax_memory_addr::PAGE_SIZE_4K as PAGE_SIZE;
-use axvm_types::VmArchPerCpuOps;
+use core::marker::PhantomData;
+
 use x86::bits64::vmx;
 use x86_64::registers::control::{Cr0, Cr4, Cr4Flags};
 
 use crate::{
+    X86HostOps, X86VcpuResult,
     msr::Msr,
+    types::X86_PAGE_SIZE_4K as PAGE_SIZE,
     vmx::{
         has_hardware_support,
         structs::{FeatureControl, FeatureControlFlags, VmxBasic, VmxRegion},
@@ -33,7 +34,7 @@ use crate::{
 /// when operating in VMX mode, including the VMCS revision identifier and
 /// the VMX region.
 #[derive(Debug)]
-pub struct VmxPerCpuState {
+pub struct VmxPerCpuState<H: X86HostOps> {
     /// The VMCS (Virtual Machine Control Structure) revision identifier.
     ///
     /// This identifier is used to ensure compatibility between the software
@@ -44,27 +45,29 @@ pub struct VmxPerCpuState {
     ///
     /// This region typically contains the VMCS and other state information
     /// required for managing virtual machines on this particular CPU.
-    vmx_region: VmxRegion,
+    vmx_region: VmxRegion<H>,
+    _host: PhantomData<fn() -> H>,
 }
 
-impl VmArchPerCpuOps for VmxPerCpuState {
-    fn new(_cpu_id: usize) -> AxResult<Self> {
+impl<H: X86HostOps> VmxPerCpuState<H> {
+    pub fn new(_cpu_id: usize) -> X86VcpuResult<Self> {
         Ok(Self {
             vmcs_revision_id: 0,
-            vmx_region: unsafe { VmxRegion::uninit() },
+            vmx_region: unsafe { VmxRegion::<H>::uninit() },
+            _host: PhantomData,
         })
     }
 
-    fn is_enabled(&self) -> bool {
+    pub fn is_enabled(&self) -> bool {
         Cr4::read().contains(Cr4Flags::VIRTUAL_MACHINE_EXTENSIONS)
     }
 
-    fn hardware_enable(&mut self) -> AxResult {
+    pub fn hardware_enable(&mut self) -> X86VcpuResult {
         if !has_hardware_support() {
-            return ax_err!(Unsupported, "CPU does not support feature VMX");
+            return x86_err!(Unsupported, "CPU does not support feature VMX");
         }
         if self.is_enabled() {
-            return ax_err!(ResourceBusy, "VMX is already turned on");
+            return x86_err!(ResourceBusy, "VMX is already turned on");
         }
 
         // Enable XSAVE/XRSTOR.
@@ -79,7 +82,7 @@ impl VmArchPerCpuOps for VmxPerCpuState {
                 ctrl | FeatureControlFlags::LOCKED | FeatureControlFlags::VMXON_ENABLED_OUTSIDE_SMX,
             )
         } else if !vmxon_outside {
-            return ax_err!(Unsupported, "VMX disabled by BIOS");
+            return x86_err!(Unsupported, "VMX disabled by BIOS");
         }
 
         // Check control registers are in a VMX-friendly state. (SDM Vol. 3C, Appendix A.7, A.8)
@@ -95,38 +98,38 @@ impl VmArchPerCpuOps for VmxPerCpuState {
             }};
         }
         if !cr_is_valid!(Cr0::read().bits(), CR0) {
-            return ax_err!(BadState, "host CR0 is not valid in VMX operation");
+            return x86_err!(BadState, "host CR0 is not valid in VMX operation");
         }
         if !cr_is_valid!(Cr4::read().bits(), CR4) {
-            return ax_err!(BadState, "host CR4 is not valid in VMX operation");
+            return x86_err!(BadState, "host CR4 is not valid in VMX operation");
         }
 
         // Get VMCS revision identifier in IA32_VMX_BASIC MSR.
         let vmx_basic = VmxBasic::read();
         if vmx_basic.region_size as usize != PAGE_SIZE {
-            return ax_err!(Unsupported);
+            return x86_err!(Unsupported);
         }
         if vmx_basic.mem_type != VmxBasic::VMX_MEMORY_TYPE_WRITE_BACK {
-            return ax_err!(Unsupported);
+            return x86_err!(Unsupported);
         }
         if vmx_basic.is_32bit_address {
-            return ax_err!(Unsupported);
+            return x86_err!(Unsupported);
         }
         if !vmx_basic.io_exit_info {
-            return ax_err!(Unsupported);
+            return x86_err!(Unsupported);
         }
         if !vmx_basic.vmx_flex_controls {
-            return ax_err!(Unsupported);
+            return x86_err!(Unsupported);
         }
         self.vmcs_revision_id = vmx_basic.revision_id;
-        self.vmx_region = VmxRegion::new(self.vmcs_revision_id, false)?;
+        self.vmx_region = VmxRegion::<H>::new(self.vmcs_revision_id, false)?;
 
         unsafe {
             // Enable VMX using the VMXE bit.
             Cr4::write(Cr4::read() | Cr4Flags::VIRTUAL_MACHINE_EXTENSIONS);
             // Execute VMXON.
             vmx::vmxon(self.vmx_region.phys_addr().as_usize() as _).map_err(|err| {
-                ax_err_type!(
+                x86_err_type!(
                     BadState,
                     format_args!("VMX instruction vmxon failed: {:?}", err)
                 )
@@ -137,15 +140,15 @@ impl VmArchPerCpuOps for VmxPerCpuState {
         Ok(())
     }
 
-    fn hardware_disable(&mut self) -> AxResult {
+    pub fn hardware_disable(&mut self) -> X86VcpuResult {
         if !self.is_enabled() {
-            return ax_err!(BadState, "VMX is not enabled");
+            return x86_err!(BadState, "VMX is not enabled");
         }
 
         unsafe {
             // Execute VMXOFF.
             vmx::vmxoff().map_err(|err| {
-                ax_err_type!(
+                x86_err_type!(
                     BadState,
                     format_args!("VMX instruction vmxoff failed: {:?}", err)
                 )
@@ -155,7 +158,7 @@ impl VmArchPerCpuOps for VmxPerCpuState {
         };
         info!("[AxVM] succeeded to turn off VMX.");
 
-        self.vmx_region = unsafe { VmxRegion::uninit() };
+        self.vmx_region = unsafe { VmxRegion::<H>::uninit() };
         Ok(())
     }
 }
@@ -167,10 +170,12 @@ mod tests {
     use super::*;
     use crate::test_utils::mock::MockMmHal;
 
+    type TestVmxPerCpuState = VmxPerCpuState<MockMmHal>;
+
     #[test]
     fn test_vmx_per_cpu_state_new() {
         MockMmHal::reset(); // Reset before test
-        let result = VmxPerCpuState::new(0);
+        let result = TestVmxPerCpuState::new(0);
         assert!(result.is_ok());
 
         let state = result.unwrap();
@@ -180,7 +185,7 @@ mod tests {
     #[test]
     fn test_vmx_per_cpu_state_default_values() {
         MockMmHal::reset(); // Reset before test
-        let state = VmxPerCpuState::new(0).unwrap();
+        let state = TestVmxPerCpuState::new(0).unwrap();
 
         // Test that vmcs_revision_id is initialized to 0
         assert_eq!(state.vmcs_revision_id, 0);
@@ -197,7 +202,7 @@ mod tests {
 
         // Create states for multiple CPUs
         for cpu_id in 0..4 {
-            let state = VmxPerCpuState::new(cpu_id).unwrap();
+            let state = TestVmxPerCpuState::new(cpu_id).unwrap();
             states.push(state);
         }
 
@@ -215,7 +220,7 @@ mod tests {
     #[test]
     fn test_vmx_per_cpu_state_debug() {
         MockMmHal::reset(); // Reset before test
-        let state = VmxPerCpuState::new(0).unwrap();
+        let state = TestVmxPerCpuState::new(0).unwrap();
 
         // Test that Debug trait is implemented and doesn't panic
         let debug_str = format!("{:?}", state);
@@ -227,7 +232,7 @@ mod tests {
         use core::mem;
 
         // Test that the struct has a reasonable size
-        let size = mem::size_of::<VmxPerCpuState>();
+        let size = mem::size_of::<TestVmxPerCpuState>();
 
         // Should be larger than just the u32 field due to the VmxRegion
         assert!(size > 4);

--- a/virtualization/x86_vcpu/src/vmx/structs.rs
+++ b/virtualization/x86_vcpu/src/vmx/structs.rs
@@ -12,32 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use ax_errno::AxResult;
-use ax_memory_addr::PAGE_SIZE_4K as PAGE_SIZE;
-use axvm_types::HostPhysAddr;
 use bit_field::BitField;
 use bitflags::bitflags;
 
 use crate::{
+    X86HostOps, X86HostPhysAddr, X86VcpuResult,
     host::PhysFrame,
     msr::{Msr, MsrReadWrite},
+    types::X86_PAGE_SIZE_4K as PAGE_SIZE,
 };
 
 /// VMCS/VMXON region in 4K size. (SDM Vol. 3C, Section 24.2)
 #[derive(Debug)]
-pub struct VmxRegion {
-    frame: PhysFrame,
+pub struct VmxRegion<H: X86HostOps> {
+    frame: PhysFrame<H>,
 }
 
-impl VmxRegion {
+impl<H: X86HostOps> VmxRegion<H> {
     pub const unsafe fn uninit() -> Self {
         Self {
-            frame: unsafe { PhysFrame::uninit() },
+            frame: unsafe { PhysFrame::<H>::uninit() },
         }
     }
 
-    pub fn new(revision_id: u32, shadow_indicator: bool) -> AxResult<Self> {
-        let frame = PhysFrame::alloc_zero()?;
+    pub fn new(revision_id: u32, shadow_indicator: bool) -> X86VcpuResult<Self> {
+        let frame = PhysFrame::<H>::alloc_zero()?;
         unsafe {
             (*(frame.as_mut_ptr() as *mut u32))
                 .set_bits(0..=30, revision_id)
@@ -46,7 +45,7 @@ impl VmxRegion {
         Ok(Self { frame })
     }
 
-    pub fn phys_addr(&self) -> HostPhysAddr {
+    pub fn phys_addr(&self) -> X86HostPhysAddr {
         self.frame.start_paddr()
     }
 }
@@ -56,24 +55,24 @@ impl VmxRegion {
 // I/O bitmap A contains one bit for each I/O port in the range 0000H through 7FFFH;
 // I/O bitmap B contains bits for ports in the range 8000H through FFFFH.
 #[derive(Debug)]
-pub struct IOBitmap {
-    io_bitmap_a_frame: PhysFrame,
-    io_bitmap_b_frame: PhysFrame,
+pub struct IOBitmap<H: X86HostOps> {
+    io_bitmap_a_frame: PhysFrame<H>,
+    io_bitmap_b_frame: PhysFrame<H>,
 }
 
-impl IOBitmap {
-    pub fn passthrough_all() -> AxResult<Self> {
+impl<H: X86HostOps> IOBitmap<H> {
+    pub fn passthrough_all() -> X86VcpuResult<Self> {
         Ok(Self {
-            io_bitmap_a_frame: PhysFrame::alloc_zero()?,
-            io_bitmap_b_frame: PhysFrame::alloc_zero()?,
+            io_bitmap_a_frame: PhysFrame::<H>::alloc_zero()?,
+            io_bitmap_b_frame: PhysFrame::<H>::alloc_zero()?,
         })
     }
 
     #[allow(unused)]
-    pub fn intercept_all() -> AxResult<Self> {
-        let mut io_bitmap_a_frame = PhysFrame::alloc()?;
+    pub fn intercept_all() -> X86VcpuResult<Self> {
+        let mut io_bitmap_a_frame = PhysFrame::<H>::alloc()?;
         io_bitmap_a_frame.fill(u8::MAX);
-        let mut io_bitmap_b_frame = PhysFrame::alloc()?;
+        let mut io_bitmap_b_frame = PhysFrame::<H>::alloc()?;
         io_bitmap_b_frame.fill(u8::MAX);
         Ok(Self {
             io_bitmap_a_frame,
@@ -81,7 +80,7 @@ impl IOBitmap {
         })
     }
 
-    pub fn phys_addr(&self) -> (HostPhysAddr, HostPhysAddr) {
+    pub fn phys_addr(&self) -> (X86HostPhysAddr, X86HostPhysAddr) {
         (
             self.io_bitmap_a_frame.start_paddr(),
             self.io_bitmap_b_frame.start_paddr(),
@@ -116,25 +115,25 @@ impl IOBitmap {
 }
 
 #[derive(Debug)]
-pub struct MsrBitmap {
-    frame: PhysFrame,
+pub struct MsrBitmap<H: X86HostOps> {
+    frame: PhysFrame<H>,
 }
 
-impl MsrBitmap {
-    pub fn passthrough_all() -> AxResult<Self> {
+impl<H: X86HostOps> MsrBitmap<H> {
+    pub fn passthrough_all() -> X86VcpuResult<Self> {
         Ok(Self {
-            frame: PhysFrame::alloc_zero()?,
+            frame: PhysFrame::<H>::alloc_zero()?,
         })
     }
 
     #[allow(unused)]
-    pub fn intercept_all() -> AxResult<Self> {
-        let mut frame = PhysFrame::alloc()?;
+    pub fn intercept_all() -> X86VcpuResult<Self> {
+        let mut frame = PhysFrame::<H>::alloc()?;
         frame.fill(u8::MAX);
         Ok(Self { frame })
     }
 
-    pub fn phys_addr(&self) -> HostPhysAddr {
+    pub fn phys_addr(&self) -> X86HostPhysAddr {
         self.frame.start_paddr()
     }
 
@@ -277,7 +276,7 @@ bitflags! {
 }
 
 impl EPTPointer {
-    pub fn from_table_phys(pml4_paddr: HostPhysAddr) -> Self {
+    pub fn from_table_phys(pml4_paddr: X86HostPhysAddr) -> Self {
         let aligned_addr = pml4_paddr.as_usize() & !(PAGE_SIZE - 1);
         let flags = Self::from_bits_retain(aligned_addr as u64);
         flags | Self::MEM_TYPE_WB | Self::WALK_LENGTH_4 | Self::ENABLE_ACCESSED_DIRTY
@@ -291,9 +290,13 @@ mod tests {
     use super::*;
     use crate::test_utils::mock::MockMmHal;
 
+    type TestIOBitmap = IOBitmap<MockMmHal>;
+    type TestMsrBitmap = MsrBitmap<MockMmHal>;
+    type TestVmxRegion = VmxRegion<MockMmHal>;
+
     #[test]
     fn test_vmx_region_uninit() {
-        let region = unsafe { VmxRegion::uninit() };
+        let region = unsafe { TestVmxRegion::uninit() };
 
         // Test that we can create an uninitialized region
         // Can't test much more without allocating memory
@@ -307,7 +310,7 @@ mod tests {
         MockMmHal::reset();
 
         // Test VmxRegion::new with valid parameters
-        let region = VmxRegion::new(0x12345, false);
+        let region = TestVmxRegion::new(0x12345, false);
         assert!(region.is_ok());
 
         let region = region.unwrap();
@@ -323,10 +326,10 @@ mod tests {
         MockMmHal::reset();
 
         // Test VmxRegion::new with different shadow indicator values
-        let region_no_shadow = VmxRegion::new(0x12345, false);
+        let region_no_shadow = TestVmxRegion::new(0x12345, false);
         assert!(region_no_shadow.is_ok());
 
-        let region_with_shadow = VmxRegion::new(0x12345, true);
+        let region_with_shadow = TestVmxRegion::new(0x12345, true);
         assert!(region_with_shadow.is_ok());
 
         // Test that both regions have valid physical addresses
@@ -349,11 +352,11 @@ mod tests {
         MockMmHal::reset();
 
         // Test passthrough_all creation
-        let passthrough_bitmap = IOBitmap::passthrough_all();
+        let passthrough_bitmap = TestIOBitmap::passthrough_all();
         assert!(passthrough_bitmap.is_ok());
 
         // Test intercept_all creation
-        let intercept_bitmap = IOBitmap::intercept_all();
+        let intercept_bitmap = TestIOBitmap::intercept_all();
         assert!(intercept_bitmap.is_ok());
 
         // Test that phys_addr returns valid addresses
@@ -367,7 +370,7 @@ mod tests {
     #[test]
     fn io_bitmap_can_intercept_high_port_in_low_half_bitmap() {
         MockMmHal::run_test(|| {
-            let mut bitmap = IOBitmap::passthrough_all().unwrap();
+            let mut bitmap = TestIOBitmap::passthrough_all().unwrap();
 
             bitmap.set_intercept(0x6000, true);
 
@@ -393,11 +396,11 @@ mod tests {
         MockMmHal::reset();
 
         // Test passthrough_all creation
-        let passthrough_bitmap = MsrBitmap::passthrough_all();
+        let passthrough_bitmap = TestMsrBitmap::passthrough_all();
         assert!(passthrough_bitmap.is_ok());
 
         // Test intercept_all creation
-        let intercept_bitmap = MsrBitmap::intercept_all();
+        let intercept_bitmap = TestMsrBitmap::intercept_all();
         assert!(intercept_bitmap.is_ok());
 
         // Test that phys_addr returns valid addresses
@@ -410,8 +413,8 @@ mod tests {
     #[test]
     fn test_ept_pointer_creation() {
         // Test EPTPointer creation with from_table_phys method
-        let ept_ptr1 = EPTPointer::from_table_phys(ax_memory_addr::PhysAddr::from(0x1000));
-        let ept_ptr2 = EPTPointer::from_table_phys(ax_memory_addr::PhysAddr::from(0x2000));
+        let ept_ptr1 = EPTPointer::from_table_phys(X86HostPhysAddr::from_usize(0x1000));
+        let ept_ptr2 = EPTPointer::from_table_phys(X86HostPhysAddr::from_usize(0x2000));
 
         // Verify the EPT pointers were created successfully
         assert_ne!(ept_ptr1.0, ept_ptr2.0);
@@ -419,7 +422,7 @@ mod tests {
 
     #[test]
     fn test_ept_pointer_getters() {
-        let phys_addr = ax_memory_addr::PhysAddr::from(0x3000);
+        let phys_addr = X86HostPhysAddr::from_usize(0x3000);
         let ept_ptr = EPTPointer::from_table_phys(phys_addr);
 
         // Test that we can create EPT pointer and it has expected flags
@@ -464,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_ept_pointer_from_table_phys() {
-        let pml4_addr = HostPhysAddr::from(0x12345000_usize); // Page-aligned address
+        let pml4_addr = X86HostPhysAddr::from(0x12345000_usize); // Page-aligned address
         let ept_ptr = EPTPointer::from_table_phys(pml4_addr);
 
         // Should have the correct flags set
@@ -479,7 +482,7 @@ mod tests {
 
     #[test]
     fn test_ept_pointer_from_unaligned_addr() {
-        let unaligned_addr = HostPhysAddr::from(0x12345678_usize); // Not page-aligned
+        let unaligned_addr = X86HostPhysAddr::from(0x12345678_usize); // Not page-aligned
         let ept_ptr = EPTPointer::from_table_phys(unaligned_addr);
 
         // Address should be aligned down
@@ -491,13 +494,13 @@ mod tests {
     #[test]
     fn test_debug_implementations() {
         // Test that all our structs implement Debug properly
-        let vmx_region = unsafe { VmxRegion::uninit() };
+        let vmx_region = unsafe { TestVmxRegion::uninit() };
         let _debug_str = format!("{:?}", vmx_region);
 
-        let io_bitmap = IOBitmap::passthrough_all().unwrap();
+        let io_bitmap = TestIOBitmap::passthrough_all().unwrap();
         let _debug_str = format!("{:?}", io_bitmap);
 
-        let msr_bitmap = MsrBitmap::passthrough_all().unwrap();
+        let msr_bitmap = TestMsrBitmap::passthrough_all().unwrap();
         let _debug_str = format!("{:?}", msr_bitmap);
 
         let flags = FeatureControlFlags::LOCKED;

--- a/virtualization/x86_vcpu/src/vmx/vcpu.rs
+++ b/virtualization/x86_vcpu/src/vmx/vcpu.rs
@@ -19,13 +19,6 @@ use core::{
     mem::size_of,
 };
 
-use ax_errno::{AxResult, ax_err, ax_err_type};
-use ax_memory_addr::AddrRange;
-use axdevice_base::{BaseDeviceOps, SysRegAddrRange};
-use axvm_types::{
-    AccessWidth, GuestPhysAddr, GuestVirtAddr, HostPhysAddr, MappingFlags, NestedPageFaultInfo,
-    NestedPagingConfig, Port, SysRegAddr, VCpuId, VMId, VmArchVcpuOps, VmExit,
-};
 use bit_field::BitField;
 use raw_cpuid::CpuId;
 use x86::{
@@ -47,14 +40,16 @@ use super::{
     },
 };
 use crate::{
-    X86VCpuCreateConfig, X86VCpuSetupConfig, ept::GuestPageWalkInfo, host, msr::Msr,
-    regs::GeneralRegisters, restore_host_interrupt_flag, x86_real_mode_entry_state, xstate::XState,
+    X86AccessFlags, X86AccessWidth, X86GuestPhysAddr, X86GuestVirtAddr, X86HostOps,
+    X86HostPhysAddr, X86MsrAddr, X86NestedPageFaultInfo, X86NestedPagingConfig, X86Port,
+    X86VCpuCreateConfig, X86VCpuSetupConfig, X86VcpuError, X86VcpuResult, X86VmExit,
+    ept::GuestPageWalkInfo, host, msr::Msr, regs::GeneralRegisters, restore_host_interrupt_flag,
+    x86_real_mode_entry_state, xstate::XState,
 };
 
 const VMX_PREEMPTION_TIMER_SET_VALUE: u32 = 100_000;
 
 const QEMU_EXIT_PORT: u16 = 0x604;
-const QEMU_EXIT_MAGIC: u64 = 0x2000;
 const X86_PIT_PORT_BASE: u16 = 0x40;
 const X86_PIT_PORT_COUNT: u32 = 4;
 const X86_PIT_SPEAKER_PORT: u16 = 0x61;
@@ -93,7 +88,7 @@ struct PendingEvent {
 
 /// A virtual CPU within a guest.
 #[repr(C)]
-pub struct VmxVcpu {
+pub struct VmxVcpu<H: X86HostOps> {
     // The order of `guest_regs`, `host_stack_top`, and `host_rflags` is
     // mandatory. They must be the first three fields. If you want to change
     // the order or the type of these fields, you must also change the assembly
@@ -111,25 +106,25 @@ pub struct VmxVcpu {
     /// Whether the VMCS has been launched. Used to determine whether to `vmx_launch` or `vmx_resume`.
     launched: bool,
     /// The guest entry point.
-    entry: Option<GuestPhysAddr>,
+    entry: Option<X86GuestPhysAddr>,
     /// The EPT root address.
-    nested_page_table_root: Option<HostPhysAddr>,
+    nested_page_table_root: Option<X86HostPhysAddr>,
     // /// Whether this VCPU is a host VCpu. Used in type 1.5 hypervisor.
     // is_host: bool, temporary removed because we don't care about type 1.5 now
 
     // VMCS-related fields
     /// The VMCS region.
-    vmcs: VmxRegion,
+    vmcs: VmxRegion<H>,
     /// The I/O bitmap for the VMCS.
-    io_bitmap: IOBitmap,
+    io_bitmap: IOBitmap<H>,
     /// The MSR bitmap for the VMCS.
-    msr_bitmap: MsrBitmap,
+    msr_bitmap: MsrBitmap<H>,
 
     // Interrupt-related fields
     /// Pending events to be injected to the guest.
     pending_events: VecDeque<PendingEvent>,
     /// Emulated Local APIC.
-    vlapic: EmulatedLocalApic,
+    vlapic: EmulatedLocalApic<H>,
     /// Guest CR2 is not saved or restored by VMX hardware.
     guest_cr2: usize,
 
@@ -143,9 +138,9 @@ pub struct VmxVcpu {
     guest_regs_exiting: GeneralRegisters,
 }
 
-impl VmxVcpu {
+impl<H: X86HostOps> VmxVcpu<H> {
     /// Create a new [`VmxVcpu`].
-    pub fn new(vm_id: VMId, vcpu_id: VCpuId) -> AxResult<Self> {
+    pub fn new(vm_id: usize, vcpu_id: usize) -> X86VcpuResult<Self> {
         let vmcs_revision_id = super::read_vmcs_revision_id();
         let vcpu = Self {
             guest_regs: GeneralRegisters::default(),
@@ -155,11 +150,11 @@ impl VmxVcpu {
             entry: None,
             nested_page_table_root: None,
             // is_host: false,
-            vmcs: VmxRegion::new(vmcs_revision_id, false)?,
-            io_bitmap: IOBitmap::passthrough_all()?,
-            msr_bitmap: MsrBitmap::passthrough_all()?,
+            vmcs: VmxRegion::<H>::new(vmcs_revision_id, false)?,
+            io_bitmap: IOBitmap::<H>::passthrough_all()?,
+            msr_bitmap: MsrBitmap::<H>::passthrough_all()?,
             pending_events: VecDeque::with_capacity(8),
-            vlapic: EmulatedLocalApic::new(vm_id, vcpu_id),
+            vlapic: EmulatedLocalApic::<H>::new(vm_id, vcpu_id),
             guest_cr2: 0,
             xstate: XState::new(),
             #[cfg(feature = "tracing")]
@@ -170,11 +165,11 @@ impl VmxVcpu {
     }
 
     /// Set the new [`VmxVcpu`] context from guest OS.
-    pub fn setup(
+    pub fn setup_vm(
         &mut self,
-        nested_page_table_root: HostPhysAddr,
-        entry: GuestPhysAddr,
-    ) -> AxResult {
+        nested_page_table_root: X86HostPhysAddr,
+        entry: X86GuestPhysAddr,
+    ) -> X86VcpuResult {
         self.setup_vmcs(entry, nested_page_table_root, X86VCpuSetupConfig::default())?;
         Ok(())
     }
@@ -185,7 +180,7 @@ impl VmxVcpu {
     // }
 
     /// Bind this [`VmxVcpu`] to current logical processor.
-    pub fn bind_to_current_processor(&self) -> AxResult {
+    pub fn bind_to_current_processor(&self) -> X86VcpuResult {
         debug!(
             "VmxVcpu bind to current processor vmcs @ {:#x}",
             self.vmcs.phys_addr()
@@ -198,7 +193,7 @@ impl VmxVcpu {
     }
 
     /// Unbind this [`VmxVcpu`] from current logical processor.
-    pub fn unbind_from_current_processor(&self) -> AxResult {
+    pub fn unbind_from_current_processor(&self) -> X86VcpuResult {
         debug!(
             "VmxVcpu unbind from current processor vmcs @ {:#x}",
             self.vmcs.phys_addr()
@@ -230,7 +225,7 @@ impl VmxVcpu {
     }
 
     /// Run the guest. It returns when a vm-exit happens and returns the vm-exit if it cannot be handled by this [`VmxVcpu`] itself.
-    pub fn inner_run(&mut self) -> AxResult<Option<VmxExitInfo>> {
+    pub fn inner_run(&mut self) -> X86VcpuResult<Option<VmxExitInfo>> {
         self.inject_pending_events()?;
 
         // Run guest
@@ -290,32 +285,32 @@ impl VmxVcpu {
     }
 
     /// Basic information about VM exits.
-    pub fn exit_info(&self) -> AxResult<vmcs::VmxExitInfo> {
+    pub fn exit_info(&self) -> X86VcpuResult<vmcs::VmxExitInfo> {
         vmcs::exit_info()
     }
 
     /// Raw information for VM Exits Due to Vectored Events, See SDM 25.9.2
-    pub fn raw_interrupt_exit_info(&self) -> AxResult<u32> {
+    pub fn raw_interrupt_exit_info(&self) -> X86VcpuResult<u32> {
         vmcs::raw_interrupt_exit_info()
     }
 
     /// Information for VM exits due to external interrupts.
-    pub fn interrupt_exit_info(&self) -> AxResult<vmcs::VmxInterruptInfo> {
+    pub fn interrupt_exit_info(&self) -> X86VcpuResult<vmcs::VmxInterruptInfo> {
         vmcs::interrupt_exit_info()
     }
 
     /// Information for VM exits due to I/O instructions.
-    pub fn io_exit_info(&self) -> AxResult<vmcs::VmxIoExitInfo> {
+    pub fn io_exit_info(&self) -> X86VcpuResult<vmcs::VmxIoExitInfo> {
         vmcs::io_exit_info()
     }
 
     /// Information for VM exits due to nested page table faults (EPT violation).
-    pub fn nested_page_fault_info(&self) -> AxResult<NestedPageFaultInfo> {
+    pub fn nested_page_fault_info(&self) -> X86VcpuResult<X86NestedPageFaultInfo> {
         vmcs::ept_violation_info()
     }
 
     /// Information for VM exits due to APIC access.
-    pub fn apic_access_exit_info(&self) -> AxResult<vmcs::ApicAccessExitInfo> {
+    pub fn apic_access_exit_info(&self) -> X86VcpuResult<vmcs::ApicAccessExitInfo> {
         vmcs::apic_access_exit_info()
     }
 
@@ -340,7 +335,7 @@ impl VmxVcpu {
     }
 
     /// Translate guest virtual addr to linear addr    
-    pub fn gla2gva(&self, guest_rip: GuestVirtAddr) -> GuestVirtAddr {
+    pub fn gla2gva(&self, guest_rip: X86GuestVirtAddr) -> X86GuestVirtAddr {
         let cpu_mode = self.get_cpu_mode();
         let seg_base = if cpu_mode == VmCpuMode::Mode64 {
             0
@@ -408,7 +403,7 @@ impl VmxVcpu {
     }
 
     /// Advance guest `RIP` by `instr_len` bytes.
-    pub fn advance_rip(&mut self, instr_len: u8) -> AxResult {
+    pub fn advance_rip(&mut self, instr_len: u8) -> X86VcpuResult {
         VmcsGuestNW::RIP.write(VmcsGuestNW::RIP.read()? + instr_len as usize)
     }
 
@@ -439,7 +434,7 @@ impl VmxVcpu {
     /// If enable, a VM exit occurs at the beginning of any instruction if
     /// `RFLAGS.IF` = 1 and there are no other blocking of interrupts.
     /// (see SDM, Vol. 3C, Section 24.4.2)
-    pub fn set_interrupt_window(&mut self, enable: bool) -> AxResult {
+    pub fn set_interrupt_window(&mut self, enable: bool) -> X86VcpuResult {
         let mut ctrl = VmcsControl32::PRIMARY_PROCBASED_EXEC_CONTROLS.read()?;
         let bits = vmcs::controls::PrimaryControls::INTERRUPT_WINDOW_EXITING.bits();
         if enable {
@@ -466,8 +461,8 @@ impl VmxVcpu {
 }
 
 // Implementation of private methods
-impl VmxVcpu {
-    fn setup_io_bitmap(&mut self, config: X86VCpuSetupConfig) -> AxResult {
+impl<H: X86HostOps> VmxVcpu<H> {
+    fn setup_io_bitmap(&mut self, config: X86VCpuSetupConfig) -> X86VcpuResult {
         // By default, I/O bitmap is set as `intercept_all`.
         // Todo: these should be combined with emulated pio device management,
         // in `modules/axvm/src/device/x86_64/mod.rs` somehow.
@@ -496,7 +491,7 @@ impl VmxVcpu {
     }
 
     #[allow(dead_code)]
-    fn setup_msr_bitmap(&mut self) -> AxResult {
+    fn setup_msr_bitmap(&mut self) -> X86VcpuResult {
         // Intercept IA32_APIC_BASE MSR accesses
         const IA32_APIC_BASE: u32 = 0x1b;
         self.msr_bitmap.set_read_intercept(IA32_APIC_BASE, true);
@@ -520,10 +515,10 @@ impl VmxVcpu {
 
     fn setup_vmcs(
         &mut self,
-        entry: GuestPhysAddr,
-        nested_page_table_root: HostPhysAddr,
+        entry: X86GuestPhysAddr,
+        nested_page_table_root: X86HostPhysAddr,
         config: X86VCpuSetupConfig,
-    ) -> AxResult {
+    ) -> X86VcpuResult {
         let paddr = self.vmcs.phys_addr().as_usize() as u64;
         unsafe {
             vmx::vmclear(paddr).map_err(as_axerr)?;
@@ -536,7 +531,7 @@ impl VmxVcpu {
         Ok(())
     }
 
-    fn setup_vmcs_host(&self) -> AxResult {
+    fn setup_vmcs_host(&self) -> X86VcpuResult {
         VmcsHost64::IA32_PAT.write(Msr::IA32_PAT.read())?;
         VmcsHost64::IA32_EFER.write(Msr::IA32_EFER.read())?;
 
@@ -573,7 +568,7 @@ impl VmxVcpu {
         Ok(())
     }
 
-    fn setup_vmcs_guest(&mut self, entry: GuestPhysAddr) -> AxResult {
+    fn setup_vmcs_guest(&mut self, entry: X86GuestPhysAddr) -> X86VcpuResult {
         let entry_state = x86_real_mode_entry_state(entry);
         let cr0_val: Cr0Flags =
             Cr0Flags::NOT_WRITE_THROUGH | Cr0Flags::CACHE_DISABLE | Cr0Flags::EXTENSION_TYPE;
@@ -634,10 +629,10 @@ impl VmxVcpu {
 
     fn setup_vmcs_control(
         &mut self,
-        nested_page_table_root: HostPhysAddr,
+        nested_page_table_root: X86HostPhysAddr,
         is_guest: bool,
         config: X86VCpuSetupConfig,
-    ) -> AxResult {
+    ) -> X86VcpuResult {
         // Intercept NMI and external interrupts.
         use PinbasedControls as PinCtrl;
 
@@ -768,7 +763,7 @@ impl VmxVcpu {
 
         VmcsControl64::VIRT_APIC_ADDR.write(self.vlapic.virtual_apic_page_addr().as_usize() as _)?;
         VmcsControl64::APIC_ACCESS_ADDR
-            .write(EmulatedLocalApic::virtual_apic_access_addr().as_usize() as _)?;
+            .write(EmulatedLocalApic::<H>::virtual_apic_access_addr().as_usize() as _)?;
         VmcsControl64::EOI_EXIT0.write(u64::MAX)?;
         VmcsControl64::EOI_EXIT1.write(u64::MAX)?;
         VmcsControl64::EOI_EXIT2.write(u64::MAX)?;
@@ -800,9 +795,9 @@ impl VmxVcpu {
 
 // Implementaton for type1.5 hypervisor
 // #[cfg(feature = "type1_5")]
-impl VmxVcpu {
+impl<H: X86HostOps> VmxVcpu<H> {
     fn set_cr(&mut self, cr_idx: usize, val: u64) {
-        (|| -> AxResult {
+        (|| -> X86VcpuResult {
             // debug!("set guest CR{} to val {:#x}", cr_idx, val);
             match cr_idx {
                 0 => {
@@ -841,7 +836,7 @@ impl VmxVcpu {
 
     #[allow(dead_code)]
     fn cr(&self, cr_idx: usize) -> usize {
-        (|| -> AxResult<usize> {
+        (|| -> X86VcpuResult<usize> {
             Ok(match cr_idx {
                 0 => VmcsGuestNW::CR0.read()?,
                 3 => VmcsGuestNW::CR3.read()?,
@@ -861,9 +856,12 @@ impl VmxVcpu {
 // identity-mapped guest RAM layout, so the guest physical address is also
 // the host physical address. A non-identity guest memory backend should
 // replace this helper with an explicit GPA-to-HVA translation.
-fn read_guest_phys_u64(gpa: usize) -> u64 {
-    let hva = host::phys_to_virt(HostPhysAddr::from(gpa));
-    unsafe { core::ptr::read_unaligned(hva.as_ptr() as *const u64) }
+fn read_guest_phys_u64<H: X86HostOps>(gpa: usize) -> X86VcpuResult<u64> {
+    let mut bytes = [0u8; 8];
+    for (offset, byte) in bytes.iter_mut().enumerate() {
+        *byte = host::read_guest_u8::<H>(X86GuestPhysAddr::from_usize(gpa + offset))?;
+    }
+    Ok(u64::from_le_bytes(bytes))
 }
 
 /// Get ready then vmlaunch or vmresume.
@@ -886,7 +884,7 @@ macro_rules! vmx_entry_with {
     }
 }
 
-impl VmxVcpu {
+impl<H: X86HostOps> VmxVcpu<H> {
     #[unsafe(naked)]
     /// Enter guest with vmlaunch.
     ///
@@ -938,7 +936,7 @@ impl VmxVcpu {
     }
 
     /// Try to inject a pending event before next VM entry.
-    fn inject_pending_events(&mut self) -> AxResult {
+    fn inject_pending_events(&mut self) -> X86VcpuResult {
         if let Some(event) = self.pending_events.front() {
             // trace!(
             //     "pending event vector {:#x} allow_int {}",
@@ -961,7 +959,7 @@ impl VmxVcpu {
         Ok(())
     }
 
-    fn handle_interrupt_window(&mut self) -> AxResult {
+    fn handle_interrupt_window(&mut self) -> X86VcpuResult {
         self.set_interrupt_window(false)?;
         self.inject_pending_events()
     }
@@ -969,7 +967,7 @@ impl VmxVcpu {
     /// Handle vm-exits than can and should be handled by [`VmxVcpu`] itself.
     ///
     /// Return the result or None if the vm-exit was not handled.
-    fn builtin_vmexit_handler(&mut self, exit_info: &VmxExitInfo) -> Option<AxResult> {
+    fn builtin_vmexit_handler(&mut self, exit_info: &VmxExitInfo) -> Option<X86VcpuResult> {
         const APIC_BASE_MSR: u32 = 0x1b;
         const AMD64_DE_CFG: u32 = 0xc001_1029;
         // Following vm-exits are handled here:
@@ -1006,7 +1004,7 @@ impl VmxVcpu {
         self.regs_mut().rdx = val >> 32;
     }
 
-    fn handle_apic_base_msr_access(&mut self, write: bool) -> AxResult {
+    fn handle_apic_base_msr_access(&mut self, write: bool) -> X86VcpuResult {
         const VMEXIT_INSTR_LEN_RDMSR_WRMSR: u8 = 2;
 
         self.advance_rip(VMEXIT_INSTR_LEN_RDMSR_WRMSR)?;
@@ -1014,7 +1012,9 @@ impl VmxVcpu {
         if write {
             let value = self.read_edx_eax();
             trace!("handle_vlapic_apic_base_write: value={value:#x}");
-            self.vlapic.set_apic_base(value)
+            self.vlapic
+                .set_apic_base(value)
+                .map_err(|_| X86VcpuError::BadState)
         } else {
             let value = self.vlapic.apic_base();
             trace!("handle_vlapic_apic_base_read: value={value:#x}");
@@ -1023,7 +1023,7 @@ impl VmxVcpu {
         }
     }
 
-    fn handle_apic_msr_access(&mut self, write: bool, msr: u32) -> AxResult<VmExit> {
+    fn handle_apic_msr_access(&mut self, write: bool, msr: u32) -> X86VcpuResult<X86VmExit> {
         const VMEXIT_INSTR_LEN_RDMSR_WRMSR: u8 = 2;
 
         self.advance_rip(VMEXIT_INSTR_LEN_RDMSR_WRMSR)?;
@@ -1035,33 +1035,36 @@ impl VmxVcpu {
             trace!("handle_vlapic_msr_write: msr={msr:#x}, value={value:#x}");
 
             if msr == X2APIC_EOI_MSR {
-                Ok(VmExit::InterruptEnd {
+                Ok(X86VmExit::InterruptEnd {
                     vector: self.vlapic.handle_eoi(),
                 })
             } else {
-                <EmulatedLocalApic as BaseDeviceOps<SysRegAddrRange>>::handle_write(
-                    &self.vlapic,
-                    SysRegAddr::new(reg),
-                    AccessWidth::Qword,
-                    value,
-                )?;
-                Ok(VmExit::Nothing)
+                self.vlapic
+                    .handle_msr_write(
+                        x86_vlapic::X86MsrAddr::new(reg),
+                        x86_vlapic::X86AccessWidth::Qword,
+                        value,
+                    )
+                    .map_err(|_| X86VcpuError::BadState)?;
+                Ok(X86VmExit::Nothing)
             }
         } else {
-            let value = <EmulatedLocalApic as BaseDeviceOps<SysRegAddrRange>>::handle_read(
-                &self.vlapic,
-                SysRegAddr::new(reg),
-                AccessWidth::Qword,
-            )? as u64;
+            let value = self
+                .vlapic
+                .handle_msr_read(
+                    x86_vlapic::X86MsrAddr::new(reg),
+                    x86_vlapic::X86AccessWidth::Qword,
+                )
+                .map_err(|_| X86VcpuError::BadState)? as u64;
 
             trace!("handle_vlapic_msr_read: msr={msr:#x}, value={value:#x}");
 
             self.write_edx_eax(value);
-            Ok(VmExit::Nothing)
+            Ok(X86VmExit::Nothing)
         }
     }
 
-    fn handle_amd64_de_cfg_msr_access(&mut self, write: bool) -> AxResult {
+    fn handle_amd64_de_cfg_msr_access(&mut self, write: bool) -> X86VcpuResult {
         const VMEXIT_INSTR_LEN_RDMSR_WRMSR: u8 = 2;
 
         self.advance_rip(VMEXIT_INSTR_LEN_RDMSR_WRMSR)?;
@@ -1071,45 +1074,47 @@ impl VmxVcpu {
         Ok(())
     }
 
-    fn handle_apic_access(&mut self, exit_info: &VmxExitInfo) -> AxResult<VmExit> {
+    fn handle_apic_access(&mut self, exit_info: &VmxExitInfo) -> X86VcpuResult<X86VmExit> {
         let apic_access_exit_info = self.apic_access_exit_info()?;
 
         let write = match apic_access_exit_info.access_type {
             ApicAccessExitType::LinearDataWrite => true,
             ApicAccessExitType::LinearDataRead => false,
             _ => {
-                warn!(
-                    "Unsupported APIC access type: {:?}",
+                debug!(
+                    "Ignoring non-data APIC access type: {:?}",
                     apic_access_exit_info.access_type
                 );
-                return ax_err!(BadState, "Unsupported APIC access type");
+                return Ok(X86VmExit::Nothing);
             }
         };
 
         let reg = apic_access_exit_info.offset as usize;
-        let addr = GuestPhysAddr::from(X86_APIC_ACCESS_GPA + reg);
-        let mut exit_reason = VmExit::Nothing;
+        let addr = X86GuestPhysAddr::from(X86_APIC_ACCESS_GPA + reg);
+        let mut exit_reason = X86VmExit::Nothing;
         if write {
             let value = self.decode_apic_mmio_write_value(exit_info)?;
             if reg == X86_LOCAL_APIC_EOI_OFFSET {
-                exit_reason = VmExit::InterruptEnd {
+                exit_reason = X86VmExit::InterruptEnd {
                     vector: self.vlapic.handle_eoi(),
                 };
             } else {
-                <EmulatedLocalApic as BaseDeviceOps<AddrRange<GuestPhysAddr>>>::handle_write(
-                    &self.vlapic,
-                    addr,
-                    AccessWidth::Dword,
-                    value,
-                )?;
+                self.vlapic
+                    .handle_mmio_write(
+                        x86_vlapic::X86GuestPhysAddr::from_usize(addr.as_usize()),
+                        x86_vlapic::X86AccessWidth::Dword,
+                        value,
+                    )
+                    .map_err(|_| X86VcpuError::BadState)?;
             }
         } else {
-            let value =
-                <EmulatedLocalApic as BaseDeviceOps<AddrRange<GuestPhysAddr>>>::handle_read(
-                    &self.vlapic,
-                    addr,
-                    AccessWidth::Dword,
-                )?;
+            let value = self
+                .vlapic
+                .handle_mmio_read(
+                    x86_vlapic::X86GuestPhysAddr::from_usize(addr.as_usize()),
+                    x86_vlapic::X86AccessWidth::Dword,
+                )
+                .map_err(|_| X86VcpuError::BadState)?;
             self.regs_mut().rax = value as u64;
         }
 
@@ -1117,8 +1122,8 @@ impl VmxVcpu {
         Ok(exit_reason)
     }
 
-    fn decode_apic_mmio_write_value(&self, exit_info: &VmxExitInfo) -> AxResult<usize> {
-        let mut rip = self.gla2gva(GuestVirtAddr::from(exit_info.guest_rip));
+    fn decode_apic_mmio_write_value(&self, exit_info: &VmxExitInfo) -> X86VcpuResult<usize> {
+        let mut rip = self.gla2gva(X86GuestVirtAddr::from(exit_info.guest_rip));
         let mut rex = 0u8;
 
         Self::skip_simple_prefixes(self, &mut rip, &mut rex)?;
@@ -1129,7 +1134,7 @@ impl VmxVcpu {
         rip += 1;
         let mode = modrm >> 6;
         if mode == 0b11 {
-            return ax_err!(Unsupported, "APIC MMIO write destination is not memory");
+            return x86_err!(Unsupported, "APIC MMIO write destination is not memory");
         }
 
         if opcode == 0x89 {
@@ -1146,7 +1151,7 @@ impl VmxVcpu {
             return Ok(value as usize);
         }
 
-        ax_err!(
+        x86_err!(
             Unsupported,
             format_args!("unsupported APIC MMIO write opcode {opcode:#x}")
         )
@@ -1155,9 +1160,9 @@ impl VmxVcpu {
     fn decode_ept_mmio_access(
         &mut self,
         exit_info: &VmxExitInfo,
-        addr: GuestPhysAddr,
+        addr: X86GuestPhysAddr,
         write: bool,
-    ) -> Option<(VmExit, u8)> {
+    ) -> Option<(X86VmExit, u8)> {
         // Keep EPT-violation MMIO decoding scoped to the PC APIC windows used
         // by the current x86 Linux direct-boot path. The VMX exit qualification
         // alone does not tell us whether an unmapped GPA is an emulated device
@@ -1170,7 +1175,7 @@ impl VmxVcpu {
             return None;
         }
 
-        let start = self.gla2gva(GuestVirtAddr::from(exit_info.guest_rip));
+        let start = self.gla2gva(X86GuestVirtAddr::from(exit_info.guest_rip));
         let mut rip = start;
         let mut rex = 0u8;
         if let Err(err) = Self::skip_simple_prefixes(self, &mut rip, &mut rex) {
@@ -1211,22 +1216,22 @@ impl VmxVcpu {
                 let reg = (((modrm >> 3) & 0x7) | ((rex & 0x4) << 1)) as usize;
                 let end = self.skip_modrm_memory_operand(rip, modrm, rex).ok()?;
                 let exit = if local_apic {
-                    let val =
-                        <EmulatedLocalApic as BaseDeviceOps<AddrRange<GuestPhysAddr>>>::handle_read(
-                            &self.vlapic,
-                            addr,
-                            AccessWidth::Dword,
+                    let val = self
+                        .vlapic
+                        .handle_mmio_read(
+                            x86_vlapic::X86GuestPhysAddr::from_usize(addr.as_usize()),
+                            x86_vlapic::X86AccessWidth::Dword,
                         )
                         .ok()?;
                     self.regs_mut()
                         .set_reg_of_index(reg as u8, val as u32 as u64);
-                    VmExit::Nothing
+                    X86VmExit::Nothing
                 } else {
-                    VmExit::MmioRead {
+                    X86VmExit::MmioRead {
                         addr,
-                        width: AccessWidth::Dword,
+                        width: X86AccessWidth::Dword,
                         reg,
-                        reg_width: AccessWidth::Dword,
+                        reg_width: X86AccessWidth::Dword,
                         signed_ext: false,
                     }
                 };
@@ -1241,36 +1246,36 @@ impl VmxVcpu {
 
     fn handle_decoded_ept_mmio_write(
         &mut self,
-        addr: GuestPhysAddr,
+        addr: X86GuestPhysAddr,
         data: u64,
         local_apic: bool,
-    ) -> Option<VmExit> {
+    ) -> Option<X86VmExit> {
         if !local_apic {
-            return Some(VmExit::MmioWrite {
+            return Some(X86VmExit::MmioWrite {
                 addr,
-                width: AccessWidth::Dword,
+                width: X86AccessWidth::Dword,
                 data,
             });
         }
 
         let offset = addr.as_usize() - X86_APIC_ACCESS_GPA;
         if offset == X86_LOCAL_APIC_EOI_OFFSET {
-            return Some(VmExit::InterruptEnd {
+            return Some(X86VmExit::InterruptEnd {
                 vector: self.vlapic.handle_eoi(),
             });
         }
 
-        <EmulatedLocalApic as BaseDeviceOps<AddrRange<GuestPhysAddr>>>::handle_write(
-            &self.vlapic,
-            addr,
-            AccessWidth::Dword,
-            data as usize,
-        )
-        .ok()?;
-        Some(VmExit::Nothing)
+        self.vlapic
+            .handle_mmio_write(
+                x86_vlapic::X86GuestPhysAddr::from_usize(addr.as_usize()),
+                x86_vlapic::X86AccessWidth::Dword,
+                data as usize,
+            )
+            .ok()?;
+        Some(X86VmExit::Nothing)
     }
 
-    fn skip_simple_prefixes(&self, rip: &mut GuestVirtAddr, rex: &mut u8) -> AxResult {
+    fn skip_simple_prefixes(&self, rip: &mut X86GuestVirtAddr, rex: &mut u8) -> X86VcpuResult {
         loop {
             let byte = self.read_guest_u8(*rip)?;
             if byte == 0x66 {
@@ -1286,10 +1291,10 @@ impl VmxVcpu {
 
     fn skip_modrm_memory_operand(
         &self,
-        mut cursor: GuestVirtAddr,
+        mut cursor: X86GuestVirtAddr,
         modrm: u8,
         rex: u8,
-    ) -> AxResult<GuestVirtAddr> {
+    ) -> X86VcpuResult<X86GuestVirtAddr> {
         let mode = modrm >> 6;
         let rm = modrm & 0x7;
 
@@ -1308,31 +1313,30 @@ impl VmxVcpu {
             0 => {}
             1 => cursor += size_of::<u8>(),
             2 => cursor += size_of::<u32>(),
-            _ => return ax_err!(InvalidInput, "ModRM register operand is not memory"),
+            _ => return x86_err!(InvalidInput, "ModRM register operand is not memory"),
         }
 
         Ok(cursor)
     }
 
-    fn read_guest_u8(&self, gva: GuestVirtAddr) -> AxResult<u8> {
+    fn read_guest_u8(&self, gva: X86GuestVirtAddr) -> X86VcpuResult<u8> {
         let gpa = self.translate_guest_linear(gva)?;
-        let hva = host::phys_to_virt(HostPhysAddr::from(gpa.as_usize()));
-        Ok(unsafe { core::ptr::read_volatile(hva.as_ptr()) })
+        host::read_guest_u8::<H>(gpa)
     }
 
-    fn translate_guest_linear(&self, gva: GuestVirtAddr) -> AxResult<GuestPhysAddr> {
+    fn translate_guest_linear(&self, gva: X86GuestVirtAddr) -> X86VcpuResult<X86GuestPhysAddr> {
         let addr = gva.as_usize();
         match self.get_paging_level() {
-            0 => Ok(GuestPhysAddr::from(addr)),
+            0 => Ok(X86GuestPhysAddr::from(addr)),
             4 => self.walk_guest_page_table_4level(addr),
-            level => ax_err!(
+            level => x86_err!(
                 Unsupported,
                 format_args!("unsupported APIC MMIO write decode paging level {level}")
             ),
         }
     }
 
-    fn walk_guest_page_table_4level(&self, gva: usize) -> AxResult<GuestPhysAddr> {
+    fn walk_guest_page_table_4level(&self, gva: usize) -> X86VcpuResult<X86GuestPhysAddr> {
         const PRESENT: u64 = 1 << 0;
         const HUGE_PAGE: u64 = 1 << 7;
         const ADDR_MASK: u64 = 0x000f_ffff_ffff_f000;
@@ -1349,9 +1353,9 @@ impl VmxVcpu {
         ];
 
         for (level, index) in indexes.into_iter().enumerate() {
-            let entry = read_guest_phys_u64(table + index * size_of::<u64>());
+            let entry = read_guest_phys_u64::<H>(table + index * size_of::<u64>())?;
             if entry & PRESENT == 0 {
-                return ax_err!(
+                return x86_err!(
                     InvalidInput,
                     format_args!("guest RIP page table entry is not present at level {level}")
                 );
@@ -1360,20 +1364,20 @@ impl VmxVcpu {
             let paddr = (entry & ADDR_MASK) as usize;
             match level {
                 1 if entry & HUGE_PAGE != 0 => {
-                    return Ok(GuestPhysAddr::from(paddr + (gva & PAGE_1G_MASK)));
+                    return Ok(X86GuestPhysAddr::from(paddr + (gva & PAGE_1G_MASK)));
                 }
                 2 if entry & HUGE_PAGE != 0 => {
-                    return Ok(GuestPhysAddr::from(paddr + (gva & PAGE_2M_MASK)));
+                    return Ok(X86GuestPhysAddr::from(paddr + (gva & PAGE_2M_MASK)));
                 }
-                3 => return Ok(GuestPhysAddr::from(paddr + (gva & PAGE_4K_MASK))),
+                3 => return Ok(X86GuestPhysAddr::from(paddr + (gva & PAGE_4K_MASK))),
                 _ => table = paddr,
             }
         }
 
-        ax_err!(InvalidInput, "failed to translate guest RIP")
+        x86_err!(InvalidInput, "failed to translate guest RIP")
     }
 
-    fn handle_vmx_preemption_timer(&mut self) -> AxResult {
+    fn handle_vmx_preemption_timer(&mut self) -> X86VcpuResult {
         // The VMX-preemption timer counts down at rate proportional to that of the timestamp counter (TSC).
         // Specifically, the timer counts down by 1 every time bit X in the TSC changes due to a TSC increment.
         // The value of X is in the range 0–31 and can be determined by consulting the VMX capability MSR IA32_VMX_MISC (see Appendix A.6).
@@ -1382,7 +1386,7 @@ impl VmxVcpu {
     }
 
     #[allow(clippy::single_match)]
-    fn handle_cr(&mut self) -> AxResult {
+    fn handle_cr(&mut self) -> X86VcpuResult {
         const VM_EXIT_INSTR_LEN_MV_TO_CR: u8 = 3;
 
         let cr_access_info = vmcs::cr_access_info()?;
@@ -1418,7 +1422,7 @@ impl VmxVcpu {
         );
     }
 
-    fn handle_cpuid(&mut self) -> AxResult {
+    fn handle_cpuid(&mut self) -> X86VcpuResult {
         use raw_cpuid::{CpuIdResult, cpuid};
 
         const VM_EXIT_INSTR_LEN_CPUID: u8 = 2;
@@ -1496,7 +1500,7 @@ impl VmxVcpu {
                 let mut res = cpuid!(regs_clone.rax, regs_clone.rcx);
                 if res.eax == 0 {
                     let frequency_mhz =
-                        crate::host_tsc_frequency_mhz().unwrap_or(FALLBACK_TSC_FREQUENCY_MHZ);
+                        crate::host_tsc_frequency_mhz::<H>().unwrap_or(FALLBACK_TSC_FREQUENCY_MHZ);
                     warn!(
                         "handle_cpuid: Failed to get TSC frequency by CPUID, default to \
                          {frequency_mhz} MHz"
@@ -1523,7 +1527,7 @@ impl VmxVcpu {
         Ok(())
     }
 
-    fn handle_xsetbv(&mut self) -> AxResult {
+    fn handle_xsetbv(&mut self) -> X86VcpuResult {
         const XCR_XCR0: u64 = 0;
         const VM_EXIT_INSTR_LEN_XSETBV: u8 = 3;
 
@@ -1562,14 +1566,14 @@ impl VmxVcpu {
 
                     Some(x)
                 })
-                .ok_or_else(|| ax_err_type!(InvalidInput))
+                .ok_or(x86_err_type!(InvalidInput))
                 .and_then(|x| {
                     self.xstate.guest_xcr0 = x.bits();
                     self.advance_rip(VM_EXIT_INSTR_LEN_XSETBV)
                 })
         } else {
             // xcr0 only
-            ax_err!(Unsupported, "only xcr0 is supported")
+            x86_err!(Unsupported, "only xcr0 is supported")
         }
     }
 
@@ -1582,7 +1586,7 @@ impl VmxVcpu {
     }
 }
 
-impl Drop for VmxVcpu {
+impl<H: X86HostOps> Drop for VmxVcpu<H> {
     fn drop(&mut self) {
         unsafe { vmx::vmclear(self.vmcs.phys_addr().as_usize() as u64).unwrap() };
         info!("[HV] dropped VmxVcpu(vmcs: {:#x})", self.vmcs.phys_addr());
@@ -1605,9 +1609,9 @@ fn get_tr_base(tr: SegmentSelector, gdt: &DescriptorTablePointer<u64>) -> u64 {
     }
 }
 
-impl Debug for VmxVcpu {
+impl<H: X86HostOps> Debug for VmxVcpu<H> {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        (|| -> AxResult<Result> {
+        (|| -> X86VcpuResult<Result> {
             Ok(f.debug_struct("VmxVcpu")
                 .field("guest_regs", &self.guest_regs)
                 .field("rip", &VmcsGuestNW::RIP.read()?)
@@ -1626,38 +1630,38 @@ impl Debug for VmxVcpu {
     }
 }
 
-impl VmArchVcpuOps for VmxVcpu {
-    type CreateConfig = X86VCpuCreateConfig;
-
-    type SetupConfig = X86VCpuSetupConfig;
-    type Exit = VmExit;
-
-    fn new(vm_id: VMId, vcpu_id: VCpuId, _config: Self::CreateConfig) -> AxResult<Self> {
+impl<H: X86HostOps> VmxVcpu<H> {
+    pub fn new_with_config(
+        vm_id: usize,
+        vcpu_id: usize,
+        _config: X86VCpuCreateConfig,
+    ) -> X86VcpuResult<Self> {
         Self::new(vm_id, vcpu_id)
     }
 
-    fn set_entry(&mut self, entry: GuestPhysAddr) -> AxResult {
+    pub fn set_entry(&mut self, entry: X86GuestPhysAddr) -> X86VcpuResult {
         self.entry = Some(entry);
         Ok(())
     }
 
-    fn set_nested_page_table(&mut self, config: NestedPagingConfig) -> AxResult {
+    pub fn set_nested_page_table(&mut self, config: X86NestedPagingConfig) -> X86VcpuResult {
         self.nested_page_table_root = Some(config.root_paddr);
         Ok(())
     }
 
-    fn setup(&mut self, config: Self::SetupConfig) -> AxResult {
+    pub fn setup(&mut self, config: X86VCpuSetupConfig) -> X86VcpuResult {
         self.setup_vmcs(
-            self.entry.unwrap(),
-            self.nested_page_table_root.unwrap(),
+            self.entry.ok_or(X86VcpuError::InvalidInput)?,
+            self.nested_page_table_root
+                .ok_or(X86VcpuError::InvalidInput)?,
             config,
         )
     }
 
-    fn run(&mut self) -> AxResult<Self::Exit> {
+    pub fn run(&mut self) -> X86VcpuResult<X86VmExit> {
         match self.inner_run()? {
             Some(exit_info) => Ok(if exit_info.entry_failure {
-                VmExit::FailEntry {
+                X86VmExit::FailEntry {
                     // Todo: get `hardware_entry_failure_reason` somehow.
                     hardware_entry_failure_reason: 0,
                 }
@@ -1665,7 +1669,7 @@ impl VmArchVcpuOps for VmxVcpu {
                 match exit_info.exit_reason {
                     VmxExitReason::VMCALL => {
                         self.advance_rip(exit_info.exit_instruction_length as _)?;
-                        VmExit::Hypercall {
+                        X86VmExit::Hypercall {
                             nr: self.regs().rax,
                             args: [
                                 self.regs().rdi,
@@ -1686,30 +1690,26 @@ impl VmArchVcpuOps for VmxVcpu {
                         if io_info.is_repeat || io_info.is_string {
                             warn!("VMX unsupported IO-Exit: {io_info:#x?} of {exit_info:#x?}");
                             warn!("VCpu {self:#x?}");
-                            VmExit::Halt
+                            X86VmExit::Halt
                         } else {
-                            let width = match AccessWidth::try_from(io_info.access_size as usize) {
+                            let width = match X86AccessWidth::try_from(io_info.access_size as usize)
+                            {
                                 Ok(width) => width,
                                 Err(_) => {
                                     warn!("VMX invalid IO-Exit: {io_info:#x?} of {exit_info:#x?}");
                                     warn!("VCpu {self:#x?}");
-                                    return Ok(VmExit::Halt);
+                                    return Ok(X86VmExit::Halt);
                                 }
                             };
 
                             if io_info.is_in {
-                                VmExit::IoRead {
-                                    port: Port(port),
+                                X86VmExit::PortIoRead {
+                                    port: X86Port::new(port),
                                     width,
                                 }
-                            } else if port == QEMU_EXIT_PORT
-                                && width == AccessWidth::Word
-                                && self.regs().rax == QEMU_EXIT_MAGIC
-                            {
-                                VmExit::SystemDown
                             } else {
-                                VmExit::IoWrite {
-                                    port: Port(port),
+                                X86VmExit::PortIoWrite {
+                                    port: X86Port::new(port),
                                     width,
                                     data: self.regs().rax.get_bits(width.bits_range()),
                                 }
@@ -1719,35 +1719,35 @@ impl VmArchVcpuOps for VmxVcpu {
                     VmxExitReason::EXTERNAL_INTERRUPT => {
                         let int_info = self.interrupt_exit_info()?;
                         assert!(int_info.valid);
-                        VmExit::ExternalInterrupt {
+                        X86VmExit::ExternalInterrupt {
                             vector: int_info.vector as _,
                         }
                     }
                     VmxExitReason::PREEMPTION_TIMER => {
                         self.handle_vmx_preemption_timer()?;
-                        VmExit::PreemptionTimer
+                        X86VmExit::PreemptionTimer
                     }
                     VmxExitReason::HLT => {
                         self.advance_rip(exit_info.exit_instruction_length as _)?;
-                        VmExit::PreemptionTimer
+                        X86VmExit::PreemptionTimer
                     }
-                    VmxExitReason::VIRTUALIZED_EOI => VmExit::InterruptEnd {
+                    VmxExitReason::VIRTUALIZED_EOI => X86VmExit::InterruptEnd {
                         vector: self.vlapic.handle_eoi(),
                     },
                     VmxExitReason::APIC_WRITE => {
                         let offset = self.apic_access_exit_info()?.offset as usize;
                         if offset == X86_LOCAL_APIC_EOI_OFFSET {
                             let vector = self.vlapic.handle_eoi();
-                            VmExit::InterruptEnd { vector }
+                            X86VmExit::InterruptEnd { vector }
                         } else {
-                            VmExit::Nothing
+                            X86VmExit::Nothing
                         }
                     }
                     VmxExitReason::APIC_ACCESS => self.handle_apic_access(&exit_info)?,
                     VmxExitReason::EPT_VIOLATION => {
                         let info = self.nested_page_fault_info()?;
-                        let write = info.access_flags.contains(MappingFlags::WRITE);
-                        let read = info.access_flags.contains(MappingFlags::READ);
+                        let write = info.access_flags.contains(X86AccessFlags::WRITE);
+                        let read = info.access_flags.contains(X86AccessFlags::READ);
                         if (read || write)
                             && let Some((mmio_exit, instruction_len)) = self.decode_ept_mmio_access(
                                 &exit_info,
@@ -1758,7 +1758,7 @@ impl VmArchVcpuOps for VmxVcpu {
                             self.advance_rip(instruction_len)?;
                             mmio_exit
                         } else {
-                            VmExit::NestedPageFault {
+                            X86VmExit::NestedPageFault {
                                 addr: info.fault_guest_paddr,
                                 access_flags: info.access_flags,
                             }
@@ -1770,9 +1770,8 @@ impl VmArchVcpuOps for VmxVcpu {
                             self.handle_apic_msr_access(false, msr)?
                         } else {
                             // `reg` is unused here.
-                            VmExit::SysRegRead {
-                                addr: SysRegAddr::new(msr as _),
-                                reg: 0,
+                            X86VmExit::MsrRead {
+                                addr: X86MsrAddr::new(msr as _),
                             }
                         }
                     }
@@ -1783,8 +1782,8 @@ impl VmArchVcpuOps for VmxVcpu {
                         } else {
                             let value = (self.regs().rax & 0xffff_ffff)
                                 | ((self.regs().rdx & 0xffff_ffff) << 32);
-                            VmExit::SysRegWrite {
-                                addr: SysRegAddr::new(msr as _),
+                            X86VmExit::MsrWrite {
+                                addr: X86MsrAddr::new(msr as _),
                                 value,
                             }
                         }
@@ -1792,28 +1791,28 @@ impl VmArchVcpuOps for VmxVcpu {
                     _ => {
                         warn!("VMX unsupported VM-Exit: {exit_info:#x?}");
                         warn!("VCpu {self:#x?}");
-                        VmExit::Halt
+                        X86VmExit::Halt
                     }
                 }
             }),
-            None => Ok(VmExit::Nothing),
+            None => Ok(X86VmExit::Nothing),
         }
     }
 
-    fn bind(&mut self) -> AxResult {
+    pub fn bind(&mut self) -> X86VcpuResult {
         self.bind_to_current_processor()
     }
 
-    fn unbind(&mut self) -> AxResult {
+    pub fn unbind(&mut self) -> X86VcpuResult {
         self.launched = false;
         self.unbind_from_current_processor()
     }
 
-    fn set_gpr(&mut self, reg: usize, val: usize) {
+    pub fn set_gpr(&mut self, reg: usize, val: usize) {
         self.regs_mut().set_reg_of_index(reg as u8, val as u64);
     }
 
-    fn inject_interrupt(&mut self, vector: usize) -> AxResult {
+    pub fn inject_interrupt(&mut self, vector: usize) -> X86VcpuResult {
         if vector != 0 {
             // warn!("interrupt queued in inject_interrupt: vector {:#x}", vector);
         } else {
@@ -1824,28 +1823,24 @@ impl VmArchVcpuOps for VmxVcpu {
         Ok(())
     }
 
-    fn inject_interrupt_with_trigger(
+    pub fn inject_interrupt_with_trigger(
         &mut self,
         vector: usize,
-        trigger: axvm_types::InterruptTriggerMode,
-    ) -> AxResult {
+        level_triggered: bool,
+    ) -> X86VcpuResult {
         if vector == 0 {
             warn!("interrupt queued in inject_interrupt_with_trigger: vector 0");
             panic!()
         }
-        self.queue_event_with_trigger(
-            vector as u8,
-            None,
-            trigger == axvm_types::InterruptTriggerMode::LevelTriggered,
-        );
+        self.queue_event_with_trigger(vector as u8, None, level_triggered);
         Ok(())
     }
 
-    fn handle_eoi(&mut self) -> Option<u8> {
+    pub fn handle_eoi(&mut self) -> Option<u8> {
         self.vlapic.handle_eoi()
     }
 
-    fn set_return_value(&mut self, val: usize) {
+    pub fn set_return_value(&mut self, val: usize) {
         self.regs_mut().rax = val as u64;
     }
 }
@@ -1896,7 +1891,6 @@ mod tests {
         // Test that constants have expected values
         assert_eq!(VMX_PREEMPTION_TIMER_SET_VALUE, 100_000);
         assert_eq!(QEMU_EXIT_PORT, 0x604);
-        assert_eq!(QEMU_EXIT_MAGIC, 0x2000);
         assert_eq!(MSR_IA32_EFER_LMA_BIT, 1 << 10);
         assert_eq!(CR0_PE, 1 << 0);
     }
@@ -2054,18 +2048,18 @@ mod tests {
         #[test]
         fn test_access_width_operations() {
             // Test access width enumeration
-            use axvm_types::AccessWidth;
+            use crate::X86AccessWidth;
 
-            assert_eq!(AccessWidth::Byte as usize, 0);
-            assert_eq!(AccessWidth::Word as usize, 1);
-            assert_eq!(AccessWidth::Dword as usize, 2);
-            assert_eq!(AccessWidth::Qword as usize, 3);
+            assert_eq!(X86AccessWidth::Byte.size(), 1);
+            assert_eq!(X86AccessWidth::Word.size(), 2);
+            assert_eq!(X86AccessWidth::Dword.size(), 4);
+            assert_eq!(X86AccessWidth::Qword.size(), 8);
 
             // Test conversion
-            assert_eq!(AccessWidth::try_from(1), Ok(AccessWidth::Byte));
-            assert_eq!(AccessWidth::try_from(2), Ok(AccessWidth::Word));
-            assert_eq!(AccessWidth::try_from(4), Ok(AccessWidth::Dword));
-            assert_eq!(AccessWidth::try_from(8), Ok(AccessWidth::Qword));
+            assert_eq!(X86AccessWidth::try_from(1), Ok(X86AccessWidth::Byte));
+            assert_eq!(X86AccessWidth::try_from(2), Ok(X86AccessWidth::Word));
+            assert_eq!(X86AccessWidth::try_from(4), Ok(X86AccessWidth::Dword));
+            assert_eq!(X86AccessWidth::try_from(8), Ok(X86AccessWidth::Qword));
         }
     }
 

--- a/virtualization/x86_vcpu/src/vmx/vmcs.rs
+++ b/virtualization/x86_vcpu/src/vmx/vmcs.rs
@@ -17,8 +17,6 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::upper_case_acronyms)]
 
-use ax_errno::{AxResult, ax_err};
-use axvm_types::{GuestPhysAddr, HostPhysAddr, MappingFlags, NestedPageFaultInfo};
 use bit_field::BitField;
 use x86::bits64::vmx;
 
@@ -26,14 +24,17 @@ use super::{
     as_axerr,
     definitions::{VmxExitReason, VmxInstructionError, VmxInterruptionType},
 };
-use crate::msr::Msr;
+use crate::{
+    X86AccessFlags, X86GuestPhysAddr, X86HostPhysAddr, X86NestedPageFaultInfo, X86VcpuResult,
+    msr::Msr,
+};
 
 // HYGIENE: These macros are only used in this file, so we can use `as_axerr` directly.
 
 macro_rules! vmcs_read {
     ($field_enum:ident,u64) => {
         impl $field_enum {
-            pub fn read(self) -> AxResult<u64> {
+            pub fn read(self) -> X86VcpuResult<u64> {
                 #[cfg(target_pointer_width = "64")]
                 unsafe {
                     vmx::vmread(self as u32).map_err(as_axerr)
@@ -49,7 +50,7 @@ macro_rules! vmcs_read {
     };
     ($field_enum:ident, $ux:ty) => {
         impl $field_enum {
-            pub fn read(self) -> AxResult<$ux> {
+            pub fn read(self) -> X86VcpuResult<$ux> {
                 unsafe { vmx::vmread(self as u32).map(|v| v as $ux).map_err(as_axerr) }
             }
         }
@@ -59,7 +60,7 @@ macro_rules! vmcs_read {
 macro_rules! vmcs_write {
     ($field_enum:ident,u64) => {
         impl $field_enum {
-            pub fn write(self, value: u64) -> AxResult {
+            pub fn write(self, value: u64) -> X86VcpuResult {
                 #[cfg(target_pointer_width = "64")]
                 unsafe {
                     vmx::vmwrite(self as u32, value).map_err(as_axerr)
@@ -76,7 +77,7 @@ macro_rules! vmcs_write {
     };
     ($field_enum:ident, $ux:ty) => {
         impl $field_enum {
-            pub fn write(self, value: $ux) -> AxResult {
+            pub fn write(self, value: $ux) -> X86VcpuResult {
                 unsafe { vmx::vmwrite(self as u32, value as u64).map_err(as_axerr) }
             }
         }
@@ -558,7 +559,7 @@ pub struct VmxIoExitInfo {
     pub is_string: bool,
     /// REP prefixed (0 = not REP; 1 = REP).
     pub is_repeat: bool,
-    /// Port number. (as specified in DX or in an immediate operand)
+    /// X86Port number. (as specified in DX or in an immediate operand)
     pub port: u16,
 }
 
@@ -657,28 +658,28 @@ pub fn set_control(
     old_value: u32,
     set: u32,
     clear: u32,
-) -> AxResult {
+) -> X86VcpuResult {
     let cap = capability_msr.read();
     let allowed0 = cap as u32;
     let allowed1 = (cap >> 32) as u32;
     assert_eq!(allowed0 & allowed1, allowed0);
     debug!("set {control:?}: {old_value:#x} (+{set:#x}, -{clear:#x})");
     if (set & clear) != 0 {
-        return ax_err!(
+        return x86_err!(
             InvalidInput,
             format_args!("can not set and clear the same bit in {:?}", control)
         );
     }
     if (allowed1 & set) != set {
         // failed if set 0-bits in allowed1
-        return ax_err!(
+        return x86_err!(
             Unsupported,
             format_args!("can not set bits {:#x} in {:?}", set, control)
         );
     }
     if (allowed0 & clear) != 0 {
         // failed if clear 1-bits in allowed0
-        return ax_err!(
+        return x86_err!(
             Unsupported,
             format_args!("can not clear bits {:#x} in {:?}", clear, control)
         );
@@ -692,7 +693,7 @@ pub fn set_control(
     Ok(())
 }
 
-pub fn set_ept_pointer(pml4_paddr: HostPhysAddr) -> AxResult {
+pub fn set_ept_pointer(pml4_paddr: X86HostPhysAddr) -> X86VcpuResult {
     use super::instructions::{InvEptType, invept};
     let eptp = super::structs::EPTPointer::from_table_phys(pml4_paddr).bits();
     VmcsControl64::EPTP.write(eptp)?;
@@ -704,7 +705,7 @@ pub fn instruction_error() -> VmxInstructionError {
     VmcsReadOnly32::VM_INSTRUCTION_ERROR.read().unwrap().into()
 }
 
-pub fn exit_info() -> AxResult<VmxExitInfo> {
+pub fn exit_info() -> X86VcpuResult<VmxExitInfo> {
     let full_reason = VmcsReadOnly32::EXIT_REASON.read()?;
     Ok(VmxExitInfo {
         exit_reason: full_reason
@@ -717,11 +718,11 @@ pub fn exit_info() -> AxResult<VmxExitInfo> {
     })
 }
 
-pub fn raw_interrupt_exit_info() -> AxResult<u32> {
+pub fn raw_interrupt_exit_info() -> X86VcpuResult<u32> {
     VmcsReadOnly32::VMEXIT_INTERRUPTION_INFO.read()
 }
 
-pub fn interrupt_exit_info() -> AxResult<VmxInterruptInfo> {
+pub fn interrupt_exit_info() -> X86VcpuResult<VmxInterruptInfo> {
     // SDM Vol. 3C, Section 24.9.2
     let info = VmcsReadOnly32::VMEXIT_INTERRUPTION_INFO.read()?;
     Ok(VmxInterruptInfo {
@@ -736,7 +737,7 @@ pub fn interrupt_exit_info() -> AxResult<VmxInterruptInfo> {
     })
 }
 
-pub fn inject_event(vector: u8, err_code: Option<u32>) -> AxResult {
+pub fn inject_event(vector: u8, err_code: Option<u32>) -> X86VcpuResult {
     // SDM Vol. 3C, Section 24.8.3
     let err_code = if VmxInterruptionType::vector_has_error_code(vector) {
         err_code.or_else(|| Some(VmcsReadOnly32::VMEXIT_INTERRUPTION_ERR_CODE.read().unwrap()))
@@ -755,7 +756,7 @@ pub fn inject_event(vector: u8, err_code: Option<u32>) -> AxResult {
     Ok(())
 }
 
-pub fn io_exit_info() -> AxResult<VmxIoExitInfo> {
+pub fn io_exit_info() -> X86VcpuResult<VmxIoExitInfo> {
     // SDM Vol. 3C, Section 27.2.1, Table 27-5
     let qualification = VmcsReadOnlyNW::EXIT_QUALIFICATION.read()?;
     Ok(VmxIoExitInfo {
@@ -767,27 +768,27 @@ pub fn io_exit_info() -> AxResult<VmxIoExitInfo> {
     })
 }
 
-pub fn ept_violation_info() -> AxResult<NestedPageFaultInfo> {
+pub fn ept_violation_info() -> X86VcpuResult<X86NestedPageFaultInfo> {
     // SDM Vol. 3C, Section 27.2.1, Table 27-7
     let qualification = VmcsReadOnlyNW::EXIT_QUALIFICATION.read()?;
     let fault_guest_paddr = VmcsReadOnly64::GUEST_PHYSICAL_ADDR.read()? as usize;
-    let mut access_flags = MappingFlags::empty();
+    let mut access_flags = X86AccessFlags::empty();
     if qualification.get_bit(0) {
-        access_flags |= MappingFlags::READ;
+        access_flags |= X86AccessFlags::READ;
     }
     if qualification.get_bit(1) {
-        access_flags |= MappingFlags::WRITE;
+        access_flags |= X86AccessFlags::WRITE;
     }
     if qualification.get_bit(2) {
-        access_flags |= MappingFlags::EXECUTE;
+        access_flags |= X86AccessFlags::EXECUTE;
     }
-    Ok(NestedPageFaultInfo {
+    Ok(X86NestedPageFaultInfo {
         access_flags,
-        fault_guest_paddr: GuestPhysAddr::from(fault_guest_paddr),
+        fault_guest_paddr: X86GuestPhysAddr::from(fault_guest_paddr),
     })
 }
 
-pub fn update_efer() -> AxResult {
+pub fn update_efer() -> X86VcpuResult {
     use x86_64::registers::control::EferFlags;
 
     let efer = VmcsGuest64::IA32_EFER.read()?;
@@ -822,7 +823,7 @@ pub fn update_efer() -> AxResult {
     Ok(())
 }
 
-pub fn cr_access_info() -> AxResult<CrAccessInfo> {
+pub fn cr_access_info() -> X86VcpuResult<CrAccessInfo> {
     let qualification = VmcsReadOnlyNW::EXIT_QUALIFICATION.read()?;
     // debug!("cr_access_info qualification {:#x}", qualification);
 
@@ -835,7 +836,7 @@ pub fn cr_access_info() -> AxResult<CrAccessInfo> {
     })
 }
 
-pub fn apic_access_exit_info() -> AxResult<ApicAccessExitInfo> {
+pub fn apic_access_exit_info() -> X86VcpuResult<ApicAccessExitInfo> {
     let qualification = VmcsReadOnlyNW::EXIT_QUALIFICATION.read()?;
     // debug!("apic_access_info qualification {:#x}", qualification);
 

--- a/virtualization/x86_vcpu/tests/dependency_contract_test.rs
+++ b/virtualization/x86_vcpu/tests/dependency_contract_test.rs
@@ -1,0 +1,30 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn x86_vcpu_manifest_has_no_ax_runtime_dependencies() {
+    let manifest = include_str!("../Cargo.toml");
+
+    for forbidden in [
+        "ax-errno",
+        "ax-crate-interface",
+        "axdevice_base",
+        "axvm-types",
+    ] {
+        assert!(
+            !manifest.contains(forbidden),
+            "x86_vcpu core must not depend on {forbidden}"
+        );
+    }
+}

--- a/virtualization/x86_vcpu/tests/os_neutral_api_test.rs
+++ b/virtualization/x86_vcpu/tests/os_neutral_api_test.rs
@@ -1,0 +1,194 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(target_arch = "x86_64")]
+
+use x86_vcpu::{
+    X86AccessFlags, X86AccessWidth, X86GuestPhysAddr, X86HostOps, X86HostPhysAddr, X86HostVirtAddr,
+    X86MsrAddr, X86NestedPagingConfig, X86Port, X86VCpuCreateConfig, X86VCpuSetupConfig,
+    X86VcpuError, X86VcpuResult, X86VmExit,
+};
+use x86_vlapic::X86VlapicHostOps;
+
+struct DummyHost;
+
+impl X86VlapicHostOps for DummyHost {
+    fn alloc_frame() -> Option<x86_vlapic::X86HostPhysAddr> {
+        None
+    }
+
+    fn dealloc_frame(_paddr: x86_vlapic::X86HostPhysAddr) {}
+
+    fn phys_to_virt(paddr: x86_vlapic::X86HostPhysAddr) -> x86_vlapic::X86HostVirtAddr {
+        x86_vlapic::X86HostVirtAddr::from_usize(paddr.as_usize())
+    }
+
+    fn virt_to_phys(vaddr: x86_vlapic::X86HostVirtAddr) -> x86_vlapic::X86HostPhysAddr {
+        x86_vlapic::X86HostPhysAddr::from_usize(vaddr.as_usize())
+    }
+
+    fn current_time_nanos() -> u64 {
+        0
+    }
+
+    fn register_timer(
+        _deadline_nanos: u64,
+        _callback: x86_vlapic::X86TimerCallback,
+    ) -> Option<usize> {
+        None
+    }
+
+    fn cancel_timer(_token: usize) {}
+
+    fn write_bytes(_bytes: &[u8]) {}
+
+    fn read_bytes(_bytes: &mut [u8]) -> usize {
+        0
+    }
+
+    fn current_vm_id() -> x86_vlapic::X86VmId {
+        0
+    }
+
+    fn current_vm_vcpu_num() -> usize {
+        1
+    }
+
+    fn current_vm_active_vcpus() -> usize {
+        1
+    }
+
+    fn active_vcpus(_vm_id: x86_vlapic::X86VmId) -> Option<usize> {
+        Some(1)
+    }
+
+    fn inject_interrupt(
+        _vm_id: x86_vlapic::X86VmId,
+        _vcpu_id: x86_vlapic::X86VcpuId,
+        _vector: x86_vlapic::X86InterruptVector,
+    ) -> x86_vlapic::X86VlapicResult {
+        Ok(())
+    }
+}
+
+impl X86HostOps for DummyHost {
+    fn alloc_frame() -> Option<X86HostPhysAddr> {
+        None
+    }
+
+    fn dealloc_frame(_paddr: X86HostPhysAddr) {}
+
+    fn alloc_contiguous_frames(
+        _frame_count: usize,
+        _frame_align: usize,
+    ) -> Option<X86HostPhysAddr> {
+        None
+    }
+
+    fn dealloc_contiguous_frames(_start_paddr: X86HostPhysAddr, _frame_count: usize) {}
+
+    fn phys_to_virt(paddr: X86HostPhysAddr) -> X86HostVirtAddr {
+        X86HostVirtAddr::from_usize(paddr.as_usize())
+    }
+
+    fn read_guest_u8(_paddr: X86GuestPhysAddr) -> X86VcpuResult<u8> {
+        Err(X86VcpuError::Unsupported)
+    }
+
+    fn nanos_to_ticks(nanos: u64) -> u64 {
+        nanos
+    }
+
+    fn poll_host_interrupt() -> Option<u8> {
+        None
+    }
+}
+
+#[test]
+fn x86_value_types_are_os_neutral() {
+    let gpa = X86GuestPhysAddr::from_usize(0xfee0_0000);
+    let hpa = X86HostPhysAddr::from_usize(0x1000);
+    let hva = X86HostVirtAddr::from_usize(0xffff_8000_0000_1000);
+    let port = X86Port::new(0x3f8);
+    let msr = X86MsrAddr::new(0x800);
+
+    assert_eq!(gpa.as_usize(), 0xfee0_0000);
+    assert_eq!(hpa.as_usize(), 0x1000);
+    assert_eq!(hva.as_usize(), 0xffff_8000_0000_1000);
+    assert_eq!(port.number(), 0x3f8);
+    assert_eq!(msr.addr(), 0x800);
+    assert_eq!(X86AccessWidth::Dword.size(), 4);
+}
+
+#[test]
+fn nested_paging_config_uses_x86_local_types() {
+    let config = X86NestedPagingConfig::new(X86HostPhysAddr::from_usize(0x2000), 4, 48, 0);
+
+    assert_eq!(config.root_paddr.as_usize(), 0x2000);
+    assert_eq!(config.levels, 4);
+    assert_eq!(config.gpa_bits, 48);
+    assert_eq!(config.mode, 0);
+}
+
+#[test]
+fn setup_config_reports_x86_errors() {
+    let mut config = X86VCpuSetupConfig::default();
+
+    assert_eq!(
+        config.add_passthrough_port_range(0x6000, 0),
+        Err(X86VcpuError::InvalidInput)
+    );
+}
+
+#[test]
+fn vm_exit_types_are_defined_by_x86_vcpu_core() {
+    let exit = X86VmExit::PortIoWrite {
+        port: X86Port::new(0x604),
+        width: X86AccessWidth::Word,
+        data: 0x2000,
+    };
+    assert!(matches!(
+        exit,
+        X86VmExit::PortIoWrite {
+            port,
+            width: X86AccessWidth::Word,
+            data: 0x2000,
+        } if port.number() == 0x604
+    ));
+
+    let exit = X86VmExit::NestedPageFault {
+        addr: X86GuestPhysAddr::from_usize(0xfec0_0000),
+        access_flags: X86AccessFlags::WRITE,
+    };
+    assert!(matches!(
+        exit,
+        X86VmExit::NestedPageFault { addr, access_flags }
+            if addr.as_usize() == 0xfec0_0000 && access_flags.contains(X86AccessFlags::WRITE)
+    ));
+}
+
+#[test]
+fn host_ops_can_report_typed_errors() {
+    assert_eq!(
+        Err(X86VcpuError::Unsupported),
+        DummyHost::read_guest_u8(0.into())
+    );
+}
+
+#[test]
+fn create_config_is_not_tied_to_axvm_traits() {
+    let _create = X86VCpuCreateConfig;
+    let _setup = X86VCpuSetupConfig::default();
+    let _host: Option<DummyHost> = None;
+}

--- a/virtualization/x86_vlapic/Cargo.toml
+++ b/virtualization/x86_vlapic/Cargo.toml
@@ -17,10 +17,3 @@ log = "0.4.19"
 paste = "1.0.15"
 tock-registers = "0.10.0"
 bit = "0.1.1"
-
-ax-memory-addr = { workspace = true }
-ax-errno = { workspace = true }
-ax-kspin = { workspace = true }
-ax-crate-interface = { workspace = true }
-axdevice_base = { workspace = true }
-axvm-types = { workspace = true }

--- a/virtualization/x86_vlapic/src/consts.rs
+++ b/virtualization/x86_vlapic/src/consts.rs
@@ -218,24 +218,22 @@ pub const LAPIC_TRIG_LEVEL: bool = true;
 pub const LAPIC_TRIG_EDGE: bool = false;
 
 pub mod xapic {
-    use axvm_types::GuestPhysAddr;
-
     use super::ApicRegOffset;
+    use crate::X86GuestPhysAddr;
 
     pub const DEFAULT_APIC_BASE: usize = 0xFEE0_0000;
     pub const APIC_MMIO_SIZE: usize = 0x1000;
 
     pub const XAPIC_BROADCAST_DEST_ID: u32 = 0xFF;
 
-    pub(crate) const fn xapic_mmio_access_reg_offset(addr: GuestPhysAddr) -> ApicRegOffset {
+    pub(crate) const fn xapic_mmio_access_reg_offset(addr: X86GuestPhysAddr) -> ApicRegOffset {
         ApicRegOffset::from((addr.as_usize() & (APIC_MMIO_SIZE - 1)) >> 4)
     }
 }
 
 pub mod x2apic {
-    use axdevice_base::SysRegAddr;
-
     use super::ApicRegOffset;
+    use crate::X86MsrAddr;
 
     pub const X2APIC_MSE_REG_BASE: usize = 0x800;
     pub const X2APIC_MSE_REG_SIZE: usize = 0x100;
@@ -244,7 +242,7 @@ pub mod x2apic {
     /// in both logical destination and physical destination modes.
     pub const X2APIC_BROADCAST_DEST_ID: u32 = 0xFFFF_FFFF;
 
-    pub(crate) const fn x2apic_msr_access_reg(addr: SysRegAddr) -> ApicRegOffset {
+    pub(crate) const fn x2apic_msr_access_reg(addr: X86MsrAddr) -> ApicRegOffset {
         ApicRegOffset::from(addr.addr() - X2APIC_MSE_REG_BASE)
     }
 }

--- a/virtualization/x86_vlapic/src/host.rs
+++ b/virtualization/x86_vlapic/src/host.rs
@@ -1,38 +1,34 @@
 //! Host callbacks required by x86 virtual interrupt-controller devices.
 
-use alloc::boxed::Box;
-use core::time::Duration;
+use core::marker::PhantomData;
 
-use ax_errno::{AxResult, ax_err_type};
-use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr};
-use axvm_types::{InterruptVector, VCpuId, VMId};
+use crate::{
+    X86HostPhysAddr, X86HostVirtAddr, X86InterruptVector, X86TimerCallback, X86VcpuId,
+    X86VlapicError, X86VlapicResult, X86VmId,
+};
+
+/// Size of a 4 KiB host frame.
+pub const X86_PAGE_SIZE_4K: usize = 0x1000;
 
 /// Host operations required by x86 vLAPIC, PIT, and serial emulation.
-#[ax_crate_interface::def_interface]
-pub trait X86VlapicHostIf {
+pub trait X86VlapicHostOps {
     /// Allocate one host frame.
-    fn alloc_frame() -> Option<PhysAddr>;
+    fn alloc_frame() -> Option<X86HostPhysAddr>;
 
     /// Deallocate one host frame.
-    fn dealloc_frame(paddr: PhysAddr);
+    fn dealloc_frame(paddr: X86HostPhysAddr);
 
     /// Convert host physical address to host virtual address.
-    fn phys_to_virt(paddr: PhysAddr) -> VirtAddr;
+    fn phys_to_virt(paddr: X86HostPhysAddr) -> X86HostVirtAddr;
 
     /// Convert host virtual address to host physical address.
-    fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr;
-
-    /// Current monotonic host time.
-    fn current_time() -> Duration;
+    fn virt_to_phys(vaddr: X86HostVirtAddr) -> X86HostPhysAddr;
 
     /// Current monotonic host time in nanoseconds.
     fn current_time_nanos() -> u64;
 
-    /// Register a timer callback.
-    fn register_timer(
-        deadline: Duration,
-        callback: Box<dyn FnOnce(Duration) + Send + 'static>,
-    ) -> usize;
+    /// Register a timer callback for an absolute host deadline in nanoseconds.
+    fn register_timer(deadline_nanos: u64, callback: X86TimerCallback) -> Option<usize>;
 
     /// Cancel a timer callback.
     fn cancel_timer(token: usize);
@@ -44,7 +40,7 @@ pub trait X86VlapicHostIf {
     fn read_bytes(bytes: &mut [u8]) -> usize;
 
     /// Return the current VM ID.
-    fn current_vm_id() -> VMId;
+    fn current_vm_id() -> X86VmId;
 
     /// Return the current VM vCPU count.
     fn current_vm_vcpu_num() -> usize;
@@ -53,48 +49,54 @@ pub trait X86VlapicHostIf {
     fn current_vm_active_vcpus() -> usize;
 
     /// Return the active vCPU mask for the given VM.
-    fn active_vcpus(vm_id: VMId) -> Option<usize>;
+    fn active_vcpus(vm_id: X86VmId) -> Option<usize>;
 
     /// Inject a virtual interrupt into a vCPU.
-    fn inject_interrupt(vm_id: VMId, vcpu_id: VCpuId, vector: InterruptVector) -> AxResult;
+    fn inject_interrupt(
+        vm_id: X86VmId,
+        vcpu_id: X86VcpuId,
+        vector: X86InterruptVector,
+    ) -> X86VlapicResult;
 }
 
 /// RAII host frame used by x86 virtual interrupt-controller structures.
 #[derive(Debug)]
-pub struct PhysFrame {
-    start_paddr: PhysAddr,
+pub struct PhysFrame<H: X86VlapicHostOps> {
+    start_paddr: X86HostPhysAddr,
+    _host: PhantomData<fn() -> H>,
 }
 
-impl PhysFrame {
+impl<H: X86VlapicHostOps> PhysFrame<H> {
     /// Allocate a host frame.
-    pub fn alloc_zero() -> AxResult<Self> {
+    pub fn alloc_zero() -> X86VlapicResult<Self> {
         let frame = Self::alloc()?;
-        unsafe { core::ptr::write_bytes(frame.as_mut_ptr(), 0, PAGE_SIZE_4K) };
+        unsafe { core::ptr::write_bytes(frame.as_mut_ptr(), 0, X86_PAGE_SIZE_4K) };
         Ok(frame)
     }
 
-    fn alloc() -> AxResult<Self> {
-        let start_paddr = ax_crate_interface::call_interface!(X86VlapicHostIf::alloc_frame())
-            .ok_or_else(|| ax_err_type!(NoMemory, "allocate physical frame failed"))?;
+    fn alloc() -> X86VlapicResult<Self> {
+        let start_paddr = H::alloc_frame().ok_or(X86VlapicError::NoMemory)?;
         assert_ne!(start_paddr.as_usize(), 0);
-        Ok(Self { start_paddr })
+        Ok(Self {
+            start_paddr,
+            _host: PhantomData,
+        })
     }
 
     /// Get the starting physical address of the frame.
-    pub fn start_paddr(&self) -> PhysAddr {
+    pub fn start_paddr(&self) -> X86HostPhysAddr {
         self.start_paddr
     }
 
     /// Get a mutable pointer to the frame.
     pub fn as_mut_ptr(&self) -> *mut u8 {
-        ax_crate_interface::call_interface!(X86VlapicHostIf::phys_to_virt(self.start_paddr))
-            .as_mut_ptr()
+        H::phys_to_virt(self.start_paddr).as_mut_ptr()
     }
 }
 
-impl Drop for PhysFrame {
+impl<H: X86VlapicHostOps> Drop for PhysFrame<H> {
     fn drop(&mut self) {
-        ax_crate_interface::call_interface!(X86VlapicHostIf::dealloc_frame(self.start_paddr));
+        H::dealloc_frame(self.start_paddr);
         log::debug!(
             "[x86_vlapic] deallocated PhysFrame({:#x})",
             self.start_paddr
@@ -102,53 +104,49 @@ impl Drop for PhysFrame {
     }
 }
 
-pub(crate) fn virt_to_phys(vaddr: VirtAddr) -> PhysAddr {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::virt_to_phys(vaddr))
+pub(crate) fn virt_to_phys<H: X86VlapicHostOps>(vaddr: X86HostVirtAddr) -> X86HostPhysAddr {
+    H::virt_to_phys(vaddr)
 }
 
-pub(crate) fn current_time() -> Duration {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::current_time())
+pub(crate) fn current_time_nanos<H: X86VlapicHostOps>() -> u64 {
+    H::current_time_nanos()
 }
 
-pub(crate) fn current_time_nanos() -> u64 {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::current_time_nanos())
+pub(crate) fn register_timer<H: X86VlapicHostOps>(
+    deadline_nanos: u64,
+    callback: X86TimerCallback,
+) -> Option<usize> {
+    H::register_timer(deadline_nanos, callback)
 }
 
-pub(crate) fn register_timer(
-    deadline: Duration,
-    callback: Box<dyn FnOnce(Duration) + Send + 'static>,
-) -> usize {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::register_timer(deadline, callback))
+pub(crate) fn cancel_timer<H: X86VlapicHostOps>(token: usize) {
+    H::cancel_timer(token);
 }
 
-pub(crate) fn cancel_timer(token: usize) {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::cancel_timer(token));
+pub(crate) fn write_bytes<H: X86VlapicHostOps>(bytes: &[u8]) {
+    H::write_bytes(bytes);
 }
 
-pub(crate) fn write_bytes(bytes: &[u8]) {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::write_bytes(bytes));
+pub(crate) fn read_bytes<H: X86VlapicHostOps>(bytes: &mut [u8]) -> usize {
+    H::read_bytes(bytes)
 }
 
-pub(crate) fn read_bytes(bytes: &mut [u8]) -> usize {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::read_bytes(bytes))
+pub(crate) fn current_vm_vcpu_num<H: X86VlapicHostOps>() -> usize {
+    H::current_vm_vcpu_num()
 }
 
-pub(crate) fn current_vm_id() -> VMId {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::current_vm_id())
+pub(crate) fn current_vm_active_vcpus<H: X86VlapicHostOps>() -> usize {
+    H::current_vm_active_vcpus()
 }
 
-pub(crate) fn current_vm_vcpu_num() -> usize {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::current_vm_vcpu_num())
+pub(crate) fn active_vcpus<H: X86VlapicHostOps>(vm_id: X86VmId) -> Option<usize> {
+    H::active_vcpus(vm_id)
 }
 
-pub(crate) fn current_vm_active_vcpus() -> usize {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::current_vm_active_vcpus())
-}
-
-pub(crate) fn active_vcpus(vm_id: VMId) -> Option<usize> {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::active_vcpus(vm_id))
-}
-
-pub(crate) fn inject_interrupt(vm_id: VMId, vcpu_id: VCpuId, vector: InterruptVector) -> AxResult {
-    ax_crate_interface::call_interface!(X86VlapicHostIf::inject_interrupt(vm_id, vcpu_id, vector))
+pub(crate) fn inject_interrupt<H: X86VlapicHostOps>(
+    vm_id: X86VmId,
+    vcpu_id: X86VcpuId,
+    vector: X86InterruptVector,
+) -> X86VlapicResult {
+    H::inject_interrupt(vm_id, vcpu_id, vector)
 }

--- a/virtualization/x86_vlapic/src/lib.rs
+++ b/virtualization/x86_vlapic/src/lib.rs
@@ -23,49 +23,57 @@ extern crate log;
 
 mod consts;
 pub mod host;
+mod lock;
 mod pit;
 mod regs;
 mod serial;
 mod timer;
+mod types;
 mod utils;
 mod vioapic;
 mod vlapic;
 
-use core::cell::UnsafeCell;
-
-use ax_errno::AxResult;
-use ax_memory_addr::{AddrRange, PAGE_SIZE_4K};
-use axdevice_base::{AccessWidth, BaseDeviceOps, EmuDeviceType, SysRegAddr, SysRegAddrRange};
-use axvm_types::{GuestPhysAddr, HostPhysAddr, HostVirtAddr, VCpuId, VMId};
+use core::{cell::UnsafeCell, marker::PhantomData};
 
 use crate::{
     consts::{x2apic::x2apic_msr_access_reg, xapic::xapic_mmio_access_reg_offset},
+    host::X86_PAGE_SIZE_4K,
     vlapic::VirtualApicRegs,
 };
 
 #[repr(align(4096))]
-struct APICAccessPage([u8; PAGE_SIZE_4K]);
+struct APICAccessPage([u8; X86_PAGE_SIZE_4K]);
 
-static VIRTUAL_APIC_ACCESS_PAGE: APICAccessPage = APICAccessPage([0; PAGE_SIZE_4K]);
+static VIRTUAL_APIC_ACCESS_PAGE: APICAccessPage = APICAccessPage([0; X86_PAGE_SIZE_4K]);
 
 /// A emulated local APIC device.
-pub struct EmulatedLocalApic {
-    vlapic_regs: UnsafeCell<VirtualApicRegs>,
+pub struct EmulatedLocalApic<H: host::X86VlapicHostOps> {
+    vlapic_regs: UnsafeCell<VirtualApicRegs<H>>,
+    _host: PhantomData<fn() -> H>,
 }
 
-pub use pit::EmulatedPit;
-pub use serial::EmulatedSerialPort;
-pub use vioapic::{EmulatedIoApic, IoApicEoi, IoApicInterrupt};
+pub use self::{
+    host::X86VlapicHostOps,
+    pit::EmulatedPit,
+    serial::EmulatedSerialPort,
+    types::{
+        X86AccessWidth, X86GuestPhysAddr, X86GuestPhysAddrRange, X86HostPhysAddr, X86HostVirtAddr,
+        X86InterruptVector, X86MsrAddr, X86MsrAddrRange, X86Port, X86PortRange, X86TimerCallback,
+        X86VcpuId, X86VlapicError, X86VlapicResult, X86VmId,
+    },
+    vioapic::{EmulatedIoApic, IoApicEoi, IoApicInterrupt},
+};
 
-impl EmulatedLocalApic {
+impl<H: host::X86VlapicHostOps> EmulatedLocalApic<H> {
     /// Create a new `EmulatedLocalApic`.
-    pub fn new(vm_id: VMId, vcpu_id: VCpuId) -> Self {
+    pub fn new(vm_id: X86VmId, vcpu_id: X86VcpuId) -> Self {
         EmulatedLocalApic {
             vlapic_regs: UnsafeCell::new(VirtualApicRegs::new(vm_id, vcpu_id)),
+            _host: PhantomData,
         }
     }
 
-    fn get_vlapic_regs(&self) -> &VirtualApicRegs {
+    fn get_vlapic_regs(&self) -> &VirtualApicRegs<H> {
         unsafe { &*self.vlapic_regs.get() }
     }
 
@@ -82,19 +90,19 @@ impl EmulatedLocalApic {
     /// cross-vCPU interrupt requests are funneled through the vCPU task instead
     /// of directly mutating another vCPU's local APIC registers.
     #[allow(clippy::mut_from_ref)]
-    fn get_mut_vlapic_regs(&self) -> &mut VirtualApicRegs {
+    fn get_mut_vlapic_regs(&self) -> &mut VirtualApicRegs<H> {
         unsafe { &mut *self.vlapic_regs.get() }
     }
 }
 
-impl EmulatedLocalApic {
+impl<H: host::X86VlapicHostOps> EmulatedLocalApic<H> {
     /// APIC-access address (64 bits).
     /// This field contains the physical address of the 4-KByte APIC-access page.
     /// If the “virtualize APIC accesses” VM-execution control is 1,
     /// access to this page may cause VM exits or be virtualized by the processor.
     /// See Section 30.4.
-    pub fn virtual_apic_access_addr() -> HostPhysAddr {
-        host::virt_to_phys(HostVirtAddr::from_usize(
+    pub fn virtual_apic_access_addr() -> X86HostPhysAddr {
+        host::virt_to_phys::<H>(X86HostVirtAddr::from_usize(
             VIRTUAL_APIC_ACCESS_PAGE.0.as_ptr() as usize,
         ))
     }
@@ -103,7 +111,7 @@ impl EmulatedLocalApic {
     /// This field contains the physical address of the 4-KByte virtual-APIC page.
     /// The processor uses the virtual-APIC page to virtualize certain accesses to APIC registers and to manage virtual interrupts;
     /// see Chapter 30.
-    pub fn virtual_apic_page_addr(&self) -> HostPhysAddr {
+    pub fn virtual_apic_page_addr(&self) -> X86HostPhysAddr {
         self.get_vlapic_regs().virtual_apic_page_addr()
     }
 
@@ -113,7 +121,7 @@ impl EmulatedLocalApic {
     }
 
     /// Sets the IA32_APIC_BASE MSR value.
-    pub fn set_apic_base(&self, value: u64) -> AxResult {
+    pub fn set_apic_base(&self, value: u64) -> X86VlapicResult {
         self.get_mut_vlapic_regs().set_apic_base(value)
     }
 
@@ -127,55 +135,69 @@ impl EmulatedLocalApic {
     pub fn handle_eoi(&self) -> Option<u8> {
         self.get_mut_vlapic_regs().handle_eoi()
     }
-}
 
-impl BaseDeviceOps<AddrRange<GuestPhysAddr>> for EmulatedLocalApic {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::InterruptController
-    }
-
-    fn address_range(&self) -> AddrRange<GuestPhysAddr> {
+    /// Returns the xAPIC MMIO range.
+    pub fn mmio_address_range(&self) -> X86GuestPhysAddrRange {
         use crate::consts::xapic::{APIC_MMIO_SIZE, DEFAULT_APIC_BASE};
-        AddrRange::new(
-            GuestPhysAddr::from_usize(DEFAULT_APIC_BASE),
-            GuestPhysAddr::from_usize(DEFAULT_APIC_BASE + APIC_MMIO_SIZE),
+        X86GuestPhysAddrRange::new(
+            X86GuestPhysAddr::from_usize(DEFAULT_APIC_BASE),
+            X86GuestPhysAddr::from_usize(DEFAULT_APIC_BASE + APIC_MMIO_SIZE),
         )
     }
 
-    fn handle_read(&self, addr: GuestPhysAddr, width: AccessWidth) -> AxResult<usize> {
-        debug!("EmulatedLocalApic::handle_read: addr={addr:?}, width={width:?}");
+    /// Handles an xAPIC MMIO read.
+    pub fn handle_mmio_read(
+        &self,
+        addr: X86GuestPhysAddr,
+        width: X86AccessWidth,
+    ) -> X86VlapicResult<usize> {
+        debug!("EmulatedLocalApic::handle_mmio_read: addr={addr:?}, width={width:?}");
         let reg_off = xapic_mmio_access_reg_offset(addr);
         self.get_vlapic_regs().handle_read(reg_off, width)
     }
 
-    fn handle_write(&self, addr: GuestPhysAddr, width: AccessWidth, val: usize) -> AxResult {
-        debug!("EmulatedLocalApic::handle_write: addr={addr:?}, width={width:?}, val={val:#x}");
+    /// Handles an xAPIC MMIO write.
+    pub fn handle_mmio_write(
+        &self,
+        addr: X86GuestPhysAddr,
+        width: X86AccessWidth,
+        val: usize,
+    ) -> X86VlapicResult {
+        debug!(
+            "EmulatedLocalApic::handle_mmio_write: addr={addr:?}, width={width:?}, val={val:#x}"
+        );
         let reg_off = xapic_mmio_access_reg_offset(addr);
         self.get_mut_vlapic_regs().handle_write(reg_off, val, width)
     }
-}
 
-impl BaseDeviceOps<SysRegAddrRange> for EmulatedLocalApic {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::InterruptController
-    }
-
-    fn address_range(&self) -> SysRegAddrRange {
+    /// Returns the x2APIC MSR range.
+    pub fn msr_address_range(&self) -> X86MsrAddrRange {
         use crate::consts::x2apic::{X2APIC_MSE_REG_BASE, X2APIC_MSE_REG_SIZE};
-        SysRegAddrRange::new(
-            SysRegAddr(X2APIC_MSE_REG_BASE),
-            SysRegAddr(X2APIC_MSE_REG_BASE + X2APIC_MSE_REG_SIZE),
+        X86MsrAddrRange::new(
+            X86MsrAddr::new(X2APIC_MSE_REG_BASE),
+            X86MsrAddr::new(X2APIC_MSE_REG_BASE + X2APIC_MSE_REG_SIZE),
         )
     }
 
-    fn handle_read(&self, addr: SysRegAddr, width: AccessWidth) -> AxResult<usize> {
-        debug!("EmulatedLocalApic::handle_read: addr={addr:?}, width={width:?}");
+    /// Handles an x2APIC MSR read.
+    pub fn handle_msr_read(
+        &self,
+        addr: X86MsrAddr,
+        width: X86AccessWidth,
+    ) -> X86VlapicResult<usize> {
+        debug!("EmulatedLocalApic::handle_msr_read: addr={addr:?}, width={width:?}");
         let reg_off = x2apic_msr_access_reg(addr);
         self.get_vlapic_regs().handle_read(reg_off, width)
     }
 
-    fn handle_write(&self, addr: SysRegAddr, width: AccessWidth, val: usize) -> AxResult {
-        debug!("EmulatedLocalApic::handle_write: addr={addr:?}, width={width:?}, val={val:#x}");
+    /// Handles an x2APIC MSR write.
+    pub fn handle_msr_write(
+        &self,
+        addr: X86MsrAddr,
+        width: X86AccessWidth,
+        val: usize,
+    ) -> X86VlapicResult {
+        debug!("EmulatedLocalApic::handle_msr_write: addr={addr:?}, width={width:?}, val={val:#x}");
         let reg_off = x2apic_msr_access_reg(addr);
         self.get_mut_vlapic_regs().handle_write(reg_off, val, width)
     }

--- a/virtualization/x86_vlapic/src/lock.rs
+++ b/virtualization/x86_vlapic/src/lock.rs
@@ -1,0 +1,60 @@
+//! Minimal spin mutex used by the OS-neutral x86 APIC device models.
+
+use core::{
+    cell::UnsafeCell,
+    hint::spin_loop,
+    ops::{Deref, DerefMut},
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+pub(crate) struct SpinMutex<T> {
+    locked: AtomicBool,
+    value: UnsafeCell<T>,
+}
+
+pub(crate) struct SpinMutexGuard<'a, T> {
+    lock: &'a SpinMutex<T>,
+}
+
+unsafe impl<T: Send> Send for SpinMutex<T> {}
+unsafe impl<T: Send> Sync for SpinMutex<T> {}
+
+impl<T> SpinMutex<T> {
+    pub(crate) const fn new(value: T) -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            value: UnsafeCell::new(value),
+        }
+    }
+
+    pub(crate) fn lock(&self) -> SpinMutexGuard<'_, T> {
+        while self
+            .locked
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            spin_loop();
+        }
+        SpinMutexGuard { lock: self }
+    }
+}
+
+impl<T> Deref for SpinMutexGuard<'_, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.lock.value.get() }
+    }
+}
+
+impl<T> DerefMut for SpinMutexGuard<'_, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.lock.value.get() }
+    }
+}
+
+impl<T> Drop for SpinMutexGuard<'_, T> {
+    fn drop(&mut self) {
+        self.lock.locked.store(false, Ordering::Release);
+    }
+}

--- a/virtualization/x86_vlapic/src/pit.rs
+++ b/virtualization/x86_vlapic/src/pit.rs
@@ -1,8 +1,10 @@
-use ax_errno::{AxResult, ax_err};
-use ax_kspin::SpinNoIrq as Mutex;
-use axdevice_base::{AccessWidth, BaseDeviceOps, EmuDeviceType, Port, PortRange};
+use core::marker::PhantomData;
 
-use crate::host;
+use crate::{
+    X86AccessWidth, X86Port, X86PortRange, X86VlapicError, X86VlapicResult,
+    host::{self, X86VlapicHostOps},
+    lock::SpinMutex as Mutex,
+};
 
 const PIT_CHANNEL0: u16 = 0x40;
 const PIT_CHANNEL2: u16 = 0x42;
@@ -254,15 +256,17 @@ impl PitState {
 }
 
 /// A minimal emulated x86 PIT/8254 device.
-pub struct EmulatedPit {
+pub struct EmulatedPit<H: X86VlapicHostOps> {
     state: Mutex<PitState>,
+    _host: PhantomData<fn() -> H>,
 }
 
-impl EmulatedPit {
+impl<H: X86VlapicHostOps> EmulatedPit<H> {
     /// Create a new PIT device.
     pub const fn new() -> Self {
         Self {
             state: Mutex::new(PitState::new()),
+            _host: PhantomData,
         }
     }
 
@@ -355,29 +359,27 @@ impl EmulatedPit {
     }
 }
 
-impl Default for EmulatedPit {
+impl<H: X86VlapicHostOps> Default for EmulatedPit<H> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl BaseDeviceOps<PortRange> for EmulatedPit {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::X86Pit
+impl<H: X86VlapicHostOps> EmulatedPit<H> {
+    /// Returns the PIT port range.
+    pub fn address_range(&self) -> X86PortRange {
+        X86PortRange::new(X86Port::new(PIT_CHANNEL0), X86Port::new(PIT_PORT_END))
     }
 
-    fn address_range(&self) -> PortRange {
-        PortRange::new(Port(PIT_CHANNEL0), Port(PIT_PORT_END))
-    }
-
-    fn handle_read(&self, port: Port, width: AccessWidth) -> AxResult<usize> {
-        if width != AccessWidth::Byte {
-            return ax_err!(Unsupported, "x86 PIT only supports byte port reads");
+    /// Handles a PIT port read.
+    pub fn handle_read(&self, port: X86Port, width: X86AccessWidth) -> X86VlapicResult<usize> {
+        if width != X86AccessWidth::Byte {
+            return Err(X86VlapicError::Unsupported);
         }
 
-        let now_ns = host::current_time_nanos();
+        let now_ns = host::current_time_nanos::<H>();
         let mut state = self.state.lock();
-        let value = match port.0 {
+        let value = match port.number() {
             PIT_CHANNEL0 => state.channel0.read_count(now_ns),
             PIT_CHANNEL2 => state.channel2.read_count(now_ns),
             PIT_COMMAND => 0,
@@ -385,26 +387,32 @@ impl BaseDeviceOps<PortRange> for EmulatedPit {
                 let output = state.channel2.output_high(now_ns) as u8;
                 (state.speaker_control & !0x20) | (output << 5)
             }
-            _ => return ax_err!(Unsupported, "unsupported x86 PIT read port"),
+            _ => return Err(X86VlapicError::Unsupported),
         };
         Ok(value as usize)
     }
 
-    fn handle_write(&self, port: Port, width: AccessWidth, val: usize) -> AxResult {
-        if width != AccessWidth::Byte {
-            return ax_err!(Unsupported, "x86 PIT only supports byte port writes");
+    /// Handles a PIT port write.
+    pub fn handle_write(
+        &self,
+        port: X86Port,
+        width: X86AccessWidth,
+        val: usize,
+    ) -> X86VlapicResult {
+        if width != X86AccessWidth::Byte {
+            return Err(X86VlapicError::Unsupported);
         }
 
-        let now_ns = host::current_time_nanos();
+        let now_ns = host::current_time_nanos::<H>();
         let mut state = self.state.lock();
-        match port.0 {
+        match port.number() {
             PIT_CHANNEL0 => state.channel0.write_count(val as u8, now_ns),
             PIT_CHANNEL2 => state.channel2.write_count(val as u8, now_ns),
             PIT_COMMAND => {
                 Self::write_command(&mut state, val as u8, now_ns);
             }
             PIT_SPEAKER_CONTROL => state.speaker_control = val as u8,
-            _ => return ax_err!(Unsupported, "unsupported x86 PIT write port"),
+            _ => return Err(X86VlapicError::Unsupported),
         }
         Ok(())
     }

--- a/virtualization/x86_vlapic/src/serial.rs
+++ b/virtualization/x86_vlapic/src/serial.rs
@@ -1,8 +1,10 @@
-use ax_errno::{AxResult, ax_err};
-use ax_kspin::SpinNoIrq as Mutex;
-use axdevice_base::{AccessWidth, BaseDeviceOps, EmuDeviceType, Port, PortRange};
+use core::marker::PhantomData;
 
-use crate::host;
+use crate::{
+    X86AccessWidth, X86Port, X86PortRange, X86VlapicError, X86VlapicResult,
+    host::{self, X86VlapicHostOps},
+    lock::SpinMutex as Mutex,
+};
 
 const COM1_BASE: u16 = 0x3f8;
 const COM1_END: u16 = COM1_BASE + 7;
@@ -114,21 +116,23 @@ impl SerialState {
 }
 
 /// Minimal 16550-compatible COM1 UART backed by the host console.
-pub struct EmulatedSerialPort {
+pub struct EmulatedSerialPort<H: X86VlapicHostOps> {
     state: Mutex<SerialState>,
+    _host: PhantomData<fn() -> H>,
 }
 
-impl EmulatedSerialPort {
+impl<H: X86VlapicHostOps> EmulatedSerialPort<H> {
     /// Create a new COM1 UART.
     pub const fn new() -> Self {
         Self {
             state: Mutex::new(SerialState::new()),
+            _host: PhantomData,
         }
     }
 
     fn poll_host_input(state: &mut SerialState) {
         let mut buf = [0u8; 32];
-        let read = host::read_bytes(&mut buf);
+        let read = host::read_bytes::<H>(&mut buf);
         for &byte in &buf[..read] {
             state.push_rx(byte);
         }
@@ -142,29 +146,27 @@ impl EmulatedSerialPort {
     }
 }
 
-impl Default for EmulatedSerialPort {
+impl<H: X86VlapicHostOps> Default for EmulatedSerialPort<H> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl BaseDeviceOps<PortRange> for EmulatedSerialPort {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::Console
+impl<H: X86VlapicHostOps> EmulatedSerialPort<H> {
+    /// Returns the COM1 port range.
+    pub fn address_range(&self) -> X86PortRange {
+        X86PortRange::new(X86Port::new(COM1_BASE), X86Port::new(COM1_END))
     }
 
-    fn address_range(&self) -> PortRange {
-        PortRange::new(Port(COM1_BASE), Port(COM1_END))
-    }
-
-    fn handle_read(&self, port: Port, width: AccessWidth) -> AxResult<usize> {
-        if width != AccessWidth::Byte {
-            return ax_err!(Unsupported, "x86 serial only supports byte port reads");
+    /// Handles a COM1 port read.
+    pub fn handle_read(&self, port: X86Port, width: X86AccessWidth) -> X86VlapicResult<usize> {
+        if width != X86AccessWidth::Byte {
+            return Err(X86VlapicError::Unsupported);
         }
 
         let mut state = self.state.lock();
         Self::poll_host_input(&mut state);
-        let offset = port.0 - COM1_BASE;
+        let offset = port.number() - COM1_BASE;
         let value = match offset {
             REG_RBR_THR_DLL if state.dlab() => state.dll,
             REG_RBR_THR_DLL => state.pop_rx().unwrap_or(0),
@@ -176,22 +178,28 @@ impl BaseDeviceOps<PortRange> for EmulatedSerialPort {
             REG_LSR => state.lsr(),
             REG_MSR => MSR_DCD | MSR_DSR | MSR_CTS,
             REG_SCR => state.scr,
-            _ => return ax_err!(Unsupported, "unsupported x86 serial read port"),
+            _ => return Err(X86VlapicError::Unsupported),
         };
         Ok(value as usize)
     }
 
-    fn handle_write(&self, port: Port, width: AccessWidth, val: usize) -> AxResult {
-        if width != AccessWidth::Byte {
-            return ax_err!(Unsupported, "x86 serial only supports byte port writes");
+    /// Handles a COM1 port write.
+    pub fn handle_write(
+        &self,
+        port: X86Port,
+        width: X86AccessWidth,
+        val: usize,
+    ) -> X86VlapicResult {
+        if width != X86AccessWidth::Byte {
+            return Err(X86VlapicError::Unsupported);
         }
 
         let mut state = self.state.lock();
-        let offset = port.0 - COM1_BASE;
+        let offset = port.number() - COM1_BASE;
         let value = val as u8;
         match offset {
             REG_RBR_THR_DLL if state.dlab() => state.dll = value,
-            REG_RBR_THR_DLL => host::write_bytes(&[value]),
+            REG_RBR_THR_DLL => host::write_bytes::<H>(&[value]),
             REG_IER_DLM if state.dlab() => state.dlm = value,
             REG_IER_DLM => state.ier = value & 0x0f,
             REG_IIR_FCR => {
@@ -204,7 +212,7 @@ impl BaseDeviceOps<PortRange> for EmulatedSerialPort {
             REG_MCR => state.mcr = value,
             REG_LSR | REG_MSR => {}
             REG_SCR => state.scr = value,
-            _ => return ax_err!(Unsupported, "unsupported x86 serial write port"),
+            _ => return Err(X86VlapicError::Unsupported),
         }
         Ok(())
     }

--- a/virtualization/x86_vlapic/src/timer.rs
+++ b/virtualization/x86_vlapic/src/timer.rs
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 use alloc::{boxed::Box, sync::Arc};
-use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
-
-use ax_errno::{AxResult, ax_err};
-use axvm_types::{VCpuId, VMId};
+use core::{
+    marker::PhantomData,
+    sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering},
+};
 
 use crate::{
+    X86VcpuId, X86VlapicError, X86VlapicResult, X86VmId,
     consts::RESET_LVT_REG,
-    host,
+    host::{self, X86VlapicHostOps},
     regs::lvt::{
         LVT_TIMER::{self, TimerMode::Value as TimerMode},
         LvtTimerRegisterLocal,
@@ -52,7 +53,7 @@ const APIC_TIMER_TICKS_PER_NANO: u64 = 1;
 /// - The timer stops when:
 ///   - the deadline is reached, and the timer is in one-shot mode, or
 ///   - a 0 is written to the Initial Count Register.
-pub struct ApicTimer {
+pub struct ApicTimer<H: X86VlapicHostOps> {
     // the raw value of writable registers
     /// Local Vector Table Timer Register. These's another copy in [`VirtualApicRegs`](crate::VirtualApicRegs), but we
     /// keep a separate copy here for easier access.
@@ -69,8 +70,9 @@ pub struct ApicTimer {
 
     // temporary fields untils we find a permanent place for apic and its timer
     cancel_token: Option<usize>,
-    where_am_i: (VMId, VCpuId), // (vm_id, vcpu_id)
+    where_am_i: (X86VmId, X86VcpuId), // (vm_id, vcpu_id)
     shared: Arc<ApicTimerShared>,
+    _host: PhantomData<fn() -> H>,
 }
 
 struct ApicTimerShared {
@@ -80,8 +82,8 @@ struct ApicTimerShared {
     deadline_ns: AtomicU64,
 }
 
-impl ApicTimer {
-    pub(crate) fn new(vm_id: VMId, vcpu_id: VCpuId) -> Self {
+impl<H: X86VlapicHostOps> ApicTimer<H> {
+    pub(crate) fn new(vm_id: X86VmId, vcpu_id: X86VcpuId) -> Self {
         Self {
             lvt_timer_register: LvtTimerRegisterLocal::new(RESET_LVT_REG), /* masked, one-shot, vector 0 */
             initial_count_register: 0,                                     // 0 (stopped)
@@ -98,6 +100,7 @@ impl ApicTimer {
                 interval_ns: AtomicU64::new(0),
                 deadline_ns: AtomicU64::new(0),
             }),
+            _host: PhantomData,
         }
     }
 
@@ -122,7 +125,7 @@ impl ApicTimer {
         self.lvt_timer_register.get()
     }
 
-    pub fn write_lvt(&mut self, mut value: u32) -> AxResult {
+    pub fn write_lvt(&mut self, mut value: u32) -> X86VlapicResult {
         // valid bits: 0-7, 12, 16-18
         const LVT_MASK: u32 = 0x0007_10FF;
 
@@ -139,7 +142,7 @@ impl ApicTimer {
         self.initial_count_register
     }
 
-    pub fn write_icr(&mut self, value: u32) -> AxResult {
+    pub fn write_icr(&mut self, value: u32) -> X86VlapicResult {
         // stop the timer no matter whether it is started, and no matter the value
         self.stop_timer()?;
         self.initial_count_register = value;
@@ -186,7 +189,7 @@ impl ApicTimer {
             return 0;
         }
         let mut deadline_ns = self.shared.deadline_ns.load(Ordering::Acquire);
-        let now_ns = host::current_time_nanos();
+        let now_ns = host::current_time_nanos::<H>();
         if now_ns >= deadline_ns {
             if !self.is_periodic() {
                 return 0;
@@ -227,7 +230,7 @@ impl ApicTimer {
     }
 
     /// Restart the timer. Will not start the timer if it is not started.
-    pub fn restart_timer(&mut self) -> AxResult {
+    pub fn restart_timer(&mut self) -> X86VlapicResult {
         if !self.is_started() {
             Ok(())
         } else {
@@ -237,12 +240,12 @@ impl ApicTimer {
     }
 
     /// Start the timer.
-    pub fn start_timer(&mut self) -> AxResult {
+    pub fn start_timer(&mut self) -> X86VlapicResult {
         if self.is_started() {
-            return ax_err!(BadState, "Timer already started");
+            return Err(X86VlapicError::BadState);
         }
 
-        let current_ns = host::current_time_nanos();
+        let current_ns = host::current_time_nanos::<H>();
         let interval_ticks = (self.initial_count_register as u64) << self.divide_shift;
         let interval_ns = interval_ticks / APIC_TIMER_TICKS_PER_NANO;
         let deadline_ns = current_ns + interval_ns;
@@ -258,18 +261,18 @@ impl ApicTimer {
             .deadline_ns
             .store(self.deadline_ns, Ordering::Release);
 
-        self.cancel_token = Some(schedule_apic_timer(
-            host::current_time() + core::time::Duration::from_nanos(interval_ns),
+        self.cancel_token = Some(schedule_apic_timer::<H>(
+            current_ns.saturating_add(interval_ns),
             Arc::clone(&self.shared),
             generation,
             vm_id,
             vcpu_id,
-        ));
+        )?);
 
         Ok(())
     }
 
-    pub fn stop_timer(&mut self) -> AxResult {
+    pub fn stop_timer(&mut self) -> X86VlapicResult {
         // TODO: maybe disable irq here?
         self.next_generation();
         self.last_start_ticks = 0;
@@ -278,7 +281,7 @@ impl ApicTimer {
         self.shared.deadline_ns.store(0, Ordering::Release);
 
         if let Some(token) = self.cancel_token.take() {
-            host::cancel_timer(token);
+            host::cancel_timer::<H>(token);
         }
 
         Ok(())
@@ -341,21 +344,24 @@ impl ApicTimer {
     // }
 }
 
-impl Drop for ApicTimer {
+impl<H: X86VlapicHostOps> Drop for ApicTimer<H> {
     fn drop(&mut self) {
         self.invalidate_timer();
     }
 }
 
-fn schedule_apic_timer(
-    deadline: core::time::Duration,
+fn schedule_apic_timer<H>(
+    deadline_nanos: u64,
     shared: Arc<ApicTimerShared>,
     generation: usize,
-    vm_id: VMId,
-    vcpu_id: VCpuId,
-) -> usize {
-    host::register_timer(
-        deadline,
+    vm_id: X86VmId,
+    vcpu_id: X86VcpuId,
+) -> X86VlapicResult<usize>
+where
+    H: X86VlapicHostOps,
+{
+    host::register_timer::<H>(
+        deadline_nanos,
         Box::new(move |_| {
             if shared.generation.load(Ordering::Acquire) != generation {
                 return;
@@ -367,7 +373,7 @@ fn schedule_apic_timer(
             let mode = (lvt & LVT_TIMER::TimerMode::SET.mask()) >> 17;
 
             if !masked {
-                let _ = host::inject_interrupt(vm_id, vcpu_id, vector);
+                let _ = host::inject_interrupt::<H>(vm_id, vcpu_id, vector);
             }
 
             if mode == TimerMode::Periodic as u32
@@ -379,17 +385,23 @@ fn schedule_apic_timer(
                     let next_deadline_ns = next_periodic_deadline_ns(
                         old_deadline,
                         interval_ns,
-                        host::current_time_nanos(),
+                        host::current_time_nanos::<H>(),
                     );
-                    let next_deadline = core::time::Duration::from_nanos(next_deadline_ns);
                     shared
                         .deadline_ns
                         .store(next_deadline_ns, Ordering::Release);
-                    let _ = schedule_apic_timer(next_deadline, shared, generation, vm_id, vcpu_id);
+                    let _ = schedule_apic_timer::<H>(
+                        next_deadline_ns,
+                        shared,
+                        generation,
+                        vm_id,
+                        vcpu_id,
+                    );
                 }
             }
         }),
     )
+    .ok_or(X86VlapicError::NoMemory)
 }
 
 fn next_periodic_deadline_ns(deadline_ns: u64, interval_ns: u64, now_ns: u64) -> u64 {
@@ -403,15 +415,75 @@ fn next_periodic_deadline_ns(deadline_ns: u64, interval_ns: u64, now_ns: u64) ->
 
 #[cfg(test)]
 mod tests {
-    use axvm_types::{VCpuId, VMId};
+    use crate::{
+        X86HostPhysAddr, X86HostVirtAddr, X86InterruptVector, X86TimerCallback, X86VcpuId,
+        X86VlapicHostOps, X86VlapicResult, X86VmId,
+        regs::lvt::LVT_TIMER::TimerMode::Value as TimerMode, timer::ApicTimer,
+    };
 
-    use crate::{regs::lvt::LVT_TIMER::TimerMode::Value as TimerMode, timer::ApicTimer};
+    struct DummyHost;
+
+    impl X86VlapicHostOps for DummyHost {
+        fn alloc_frame() -> Option<X86HostPhysAddr> {
+            None
+        }
+
+        fn dealloc_frame(_paddr: X86HostPhysAddr) {}
+
+        fn phys_to_virt(paddr: X86HostPhysAddr) -> X86HostVirtAddr {
+            X86HostVirtAddr::from_usize(paddr.as_usize())
+        }
+
+        fn virt_to_phys(vaddr: X86HostVirtAddr) -> X86HostPhysAddr {
+            X86HostPhysAddr::from_usize(vaddr.as_usize())
+        }
+
+        fn current_time_nanos() -> u64 {
+            0
+        }
+
+        fn register_timer(_deadline_nanos: u64, _callback: X86TimerCallback) -> Option<usize> {
+            None
+        }
+
+        fn cancel_timer(_token: usize) {}
+
+        fn write_bytes(_bytes: &[u8]) {}
+
+        fn read_bytes(_bytes: &mut [u8]) -> usize {
+            0
+        }
+
+        fn current_vm_id() -> X86VmId {
+            0
+        }
+
+        fn current_vm_vcpu_num() -> usize {
+            1
+        }
+
+        fn current_vm_active_vcpus() -> usize {
+            1
+        }
+
+        fn active_vcpus(_vm_id: X86VmId) -> Option<usize> {
+            Some(1)
+        }
+
+        fn inject_interrupt(
+            _vm_id: X86VmId,
+            _vcpu_id: X86VcpuId,
+            _vector: X86InterruptVector,
+        ) -> X86VlapicResult {
+            Ok(())
+        }
+    }
 
     #[test]
     fn test_apic_timer_creation() {
-        let vm_id = VMId::from(1 as usize);
-        let vcpu_id = VCpuId::from(0 as usize);
-        let timer = ApicTimer::new(vm_id, vcpu_id);
+        let vm_id = 1;
+        let vcpu_id = 0;
+        let timer = ApicTimer::<DummyHost>::new(vm_id, vcpu_id);
         // Initial state should be stopped
         assert!(!timer.is_started());
         assert_eq!(timer.read_icr(), 0);
@@ -424,9 +496,9 @@ mod tests {
 
     #[test]
     fn test_lvt_register_operations() {
-        let vm_id = VMId::from(1 as usize);
-        let vcpu_id = VCpuId::from(0 as usize);
-        let mut timer = ApicTimer::new(vm_id, vcpu_id);
+        let vm_id = 1;
+        let vcpu_id = 0;
+        let mut timer = ApicTimer::<DummyHost>::new(vm_id, vcpu_id);
 
         // Test LVT write with valid bits
         assert!(timer.write_lvt(0x000710FF).is_ok());
@@ -443,9 +515,9 @@ mod tests {
 
     #[test]
     fn test_divide_configuration_register() {
-        let vm_id = VMId::from(1 as usize);
-        let vcpu_id = VCpuId::from(0 as usize);
-        let mut timer = ApicTimer::new(vm_id, vcpu_id);
+        let vm_id = 1;
+        let vcpu_id = 0;
+        let mut timer = ApicTimer::<DummyHost>::new(vm_id, vcpu_id);
 
         // Test different divide values
         timer.write_dcr(0b0000); // divide by 2
@@ -464,9 +536,9 @@ mod tests {
 
     #[test]
     fn test_timer_mode() {
-        let vm_id = VMId::from(1 as usize);
-        let vcpu_id = VCpuId::from(0 as usize);
-        let mut timer = ApicTimer::new(vm_id, vcpu_id);
+        let vm_id = 1;
+        let vcpu_id = 0;
+        let mut timer = ApicTimer::<DummyHost>::new(vm_id, vcpu_id);
 
         // Default should be one-shot
         assert_eq!(timer.timer_mode(), TimerMode::OneShot);
@@ -480,9 +552,9 @@ mod tests {
 
     #[test]
     fn test_timer_mask() {
-        let vm_id = VMId::from(1 as usize);
-        let vcpu_id = VCpuId::from(0 as usize);
-        let mut timer = ApicTimer::new(vm_id, vcpu_id);
+        let vm_id = 1;
+        let vcpu_id = 0;
+        let mut timer = ApicTimer::<DummyHost>::new(vm_id, vcpu_id);
 
         // Default should be masked
         assert!(timer.is_masked());
@@ -498,9 +570,9 @@ mod tests {
 
     #[test]
     fn test_multiple_timers() {
-        let vm_id = VMId::from(1 as usize);
-        let timer1 = ApicTimer::new(vm_id, VCpuId::from(0 as usize));
-        let timer2 = ApicTimer::new(vm_id, VCpuId::from(1 as usize));
+        let vm_id = 1;
+        let timer1 = ApicTimer::<DummyHost>::new(vm_id, 0);
+        let timer2 = ApicTimer::<DummyHost>::new(vm_id, 1);
 
         // Both timers should be independent
         assert!(!timer1.is_started());

--- a/virtualization/x86_vlapic/src/types.rs
+++ b/virtualization/x86_vlapic/src/types.rs
@@ -1,0 +1,311 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use alloc::boxed::Box;
+use core::{
+    fmt::{Debug, Formatter, LowerHex, UpperHex},
+    ops::Range,
+};
+
+/// Result type returned by the OS-neutral x86 vLAPIC devices.
+pub type X86VlapicResult<T = ()> = Result<T, X86VlapicError>;
+
+/// Timer callback type accepted by the embedding host.
+pub type X86TimerCallback = Box<dyn FnOnce(u64) + Send + 'static>;
+
+/// VM identifier used by x86 interrupt-controller emulation.
+pub type X86VmId = usize;
+
+/// vCPU identifier used by x86 interrupt-controller emulation.
+pub type X86VcpuId = usize;
+
+/// Guest interrupt vector used by x86 interrupt-controller emulation.
+pub type X86InterruptVector = u8;
+
+/// Errors produced by the OS-neutral x86 vLAPIC devices.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum X86VlapicError {
+    /// A caller supplied an invalid argument or unsupported hardware encoding.
+    InvalidInput,
+    /// Device register contents could not be decoded as a valid hardware value.
+    InvalidData,
+    /// The requested operation is not supported by this device model.
+    Unsupported,
+    /// A host memory allocation failed.
+    NoMemory,
+    /// Device state is inconsistent with the requested transition.
+    BadState,
+}
+
+macro_rules! define_addr_type {
+    ($name:ident, $debug_prefix:literal) => {
+        #[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+        pub struct $name(usize);
+
+        impl $name {
+            /// Creates an address from a raw `usize`.
+            pub const fn from_usize(addr: usize) -> Self {
+                Self(addr)
+            }
+
+            /// Returns the raw address value.
+            pub const fn as_usize(self) -> usize {
+                self.0
+            }
+
+            /// Returns this address as an immutable pointer.
+            pub const fn as_ptr<T>(self) -> *const T {
+                self.0 as *const T
+            }
+
+            /// Returns this address as a mutable pointer.
+            pub const fn as_mut_ptr<T>(self) -> *mut T {
+                self.0 as *mut T
+            }
+        }
+
+        impl From<usize> for $name {
+            fn from(value: usize) -> Self {
+                Self::from_usize(value)
+            }
+        }
+
+        impl From<$name> for usize {
+            fn from(value: $name) -> Self {
+                value.as_usize()
+            }
+        }
+
+        impl Debug for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+                write!(f, "{}({:#x})", $debug_prefix, self.0)
+            }
+        }
+
+        impl LowerHex for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+                write!(f, "{:#x}", self.0)
+            }
+        }
+
+        impl UpperHex for $name {
+            fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+                write!(f, "{:#X}", self.0)
+            }
+        }
+    };
+}
+
+define_addr_type!(X86GuestPhysAddr, "GPA");
+define_addr_type!(X86HostPhysAddr, "HPA");
+define_addr_type!(X86HostVirtAddr, "HVA");
+
+/// x86 MSR address.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct X86MsrAddr(usize);
+
+impl X86MsrAddr {
+    /// Creates an MSR address from the raw MSR number.
+    pub const fn new(addr: usize) -> Self {
+        Self(addr)
+    }
+
+    /// Returns the raw MSR number.
+    pub const fn addr(self) -> usize {
+        self.0
+    }
+}
+
+impl From<usize> for X86MsrAddr {
+    fn from(value: usize) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Debug for X86MsrAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "MSR({:#x})", self.0)
+    }
+}
+
+impl LowerHex for X86MsrAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#x}", self.0)
+    }
+}
+
+impl UpperHex for X86MsrAddr {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#X}", self.0)
+    }
+}
+
+/// The port number of an x86 I/O operation.
+#[derive(Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+pub struct X86Port(u16);
+
+impl X86Port {
+    /// Creates a new x86 I/O port.
+    pub const fn new(port: u16) -> Self {
+        Self(port)
+    }
+
+    /// Returns the raw port number.
+    pub const fn number(self) -> u16 {
+        self.0
+    }
+}
+
+impl From<u16> for X86Port {
+    fn from(value: u16) -> Self {
+        Self::new(value)
+    }
+}
+
+impl Debug for X86Port {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Port({:#x})", self.0)
+    }
+}
+
+impl LowerHex for X86Port {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#x}", self.0)
+    }
+}
+
+impl UpperHex for X86Port {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:#X}", self.0)
+    }
+}
+
+/// Width of a guest bus access.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum X86AccessWidth {
+    /// 8-bit access.
+    Byte,
+    /// 16-bit access.
+    Word,
+    /// 32-bit access.
+    Dword,
+    /// 64-bit access.
+    Qword,
+}
+
+impl X86AccessWidth {
+    /// Returns this access width in bytes.
+    pub const fn size(self) -> usize {
+        match self {
+            Self::Byte => 1,
+            Self::Word => 2,
+            Self::Dword => 4,
+            Self::Qword => 8,
+        }
+    }
+
+    /// Returns the bit range covered by this access.
+    pub fn bits_range(self) -> Range<usize> {
+        match self {
+            Self::Byte => 0..8,
+            Self::Word => 0..16,
+            Self::Dword => 0..32,
+            Self::Qword => 0..64,
+        }
+    }
+}
+
+impl TryFrom<usize> for X86AccessWidth {
+    type Error = X86VlapicError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Byte),
+            2 => Ok(Self::Word),
+            4 => Ok(Self::Dword),
+            8 => Ok(Self::Qword),
+            _ => Err(X86VlapicError::InvalidInput),
+        }
+    }
+}
+
+impl From<X86AccessWidth> for usize {
+    fn from(value: X86AccessWidth) -> Self {
+        value.size()
+    }
+}
+
+/// A half-open range of guest physical addresses.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct X86GuestPhysAddrRange {
+    /// Inclusive start address.
+    pub start: X86GuestPhysAddr,
+    /// Exclusive end address.
+    pub end: X86GuestPhysAddr,
+}
+
+impl X86GuestPhysAddrRange {
+    /// Creates a half-open address range.
+    pub fn new(start: X86GuestPhysAddr, end: X86GuestPhysAddr) -> Self {
+        assert!(start <= end, "invalid x86 guest physical address range");
+        Self { start, end }
+    }
+
+    /// Returns whether the range contains `addr`.
+    pub fn contains(self, addr: X86GuestPhysAddr) -> bool {
+        self.start <= addr && addr < self.end
+    }
+}
+
+/// An inclusive range of x86 I/O ports.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct X86PortRange {
+    /// Inclusive start port.
+    pub start: X86Port,
+    /// Inclusive end port.
+    pub end: X86Port,
+}
+
+impl X86PortRange {
+    /// Creates an inclusive port range.
+    pub const fn new(start: X86Port, end: X86Port) -> Self {
+        Self { start, end }
+    }
+
+    /// Returns whether the range contains `port`.
+    pub const fn contains(self, port: X86Port) -> bool {
+        self.start.0 <= port.0 && port.0 <= self.end.0
+    }
+}
+
+/// An inclusive range of x86 MSR addresses.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct X86MsrAddrRange {
+    /// Inclusive start MSR.
+    pub start: X86MsrAddr,
+    /// Inclusive end MSR.
+    pub end: X86MsrAddr,
+}
+
+impl X86MsrAddrRange {
+    /// Creates an inclusive MSR range.
+    pub const fn new(start: X86MsrAddr, end: X86MsrAddr) -> Self {
+        Self { start, end }
+    }
+
+    /// Returns whether the range contains `addr`.
+    pub const fn contains(self, addr: X86MsrAddr) -> bool {
+        self.start.0 <= addr.0 && addr.0 <= self.end.0
+    }
+}

--- a/virtualization/x86_vlapic/src/vioapic.rs
+++ b/virtualization/x86_vlapic/src/vioapic.rs
@@ -1,8 +1,7 @@
-use ax_errno::{AxResult, ax_err};
-use ax_kspin::SpinNoIrq as Mutex;
-use ax_memory_addr::AddrRange;
-use axdevice_base::{AccessWidth, BaseDeviceOps, EmuDeviceType};
-use axvm_types::{GuestPhysAddr, GuestPhysAddrRange};
+use crate::{
+    X86AccessWidth, X86GuestPhysAddr, X86GuestPhysAddrRange, X86VlapicError, X86VlapicResult,
+    lock::SpinMutex as Mutex,
+};
 
 const IOAPIC_BASE: usize = 0xfec0_0000;
 const IOAPIC_SIZE: usize = 0x1000;
@@ -119,14 +118,14 @@ pub struct IoApicEoi {
 
 /// A minimal emulated x86 IO APIC.
 pub struct EmulatedIoApic {
-    base: GuestPhysAddr,
+    base: X86GuestPhysAddr,
     size: usize,
     state: Mutex<IoApicState>,
 }
 
 impl EmulatedIoApic {
     /// Create a new `EmulatedIoApic`.
-    pub fn new(base: GuestPhysAddr, size: Option<usize>) -> Self {
+    pub fn new(base: X86GuestPhysAddr, size: Option<usize>) -> Self {
         Self {
             base,
             size: size.unwrap_or(IOAPIC_SIZE),
@@ -136,7 +135,7 @@ impl EmulatedIoApic {
 
     /// Create an IO APIC at the default PC-compatible GPA.
     pub fn new_default() -> Self {
-        Self::new(GuestPhysAddr::from_usize(IOAPIC_BASE), Some(IOAPIC_SIZE))
+        Self::new(X86GuestPhysAddr::from_usize(IOAPIC_BASE), Some(IOAPIC_SIZE))
     }
 
     /// Return the guest interrupt vector programmed for a GSI.
@@ -172,11 +171,11 @@ impl EmulatedIoApic {
         state.end_of_interrupt(vector)
     }
 
-    fn offset(&self, addr: GuestPhysAddr) -> usize {
+    fn offset(&self, addr: X86GuestPhysAddr) -> usize {
         addr.as_usize() - self.base.as_usize()
     }
 
-    fn read_selected_register(state: &IoApicState) -> AxResult<u32> {
+    fn read_selected_register(state: &IoApicState) -> X86VlapicResult<u32> {
         match state.selector {
             IOAPIC_ID => Ok(IOAPIC_ID_VALUE),
             IOAPIC_VER => Ok(IOAPIC_VERSION_VALUE),
@@ -184,7 +183,7 @@ impl EmulatedIoApic {
             reg @ IOREDTBL_BASE..=0x3f => {
                 let index = ((reg - IOREDTBL_BASE) / 2) as usize;
                 if index >= REDIRECTION_ENTRY_COUNT {
-                    return ax_err!(InvalidInput, "IOAPIC redirection index out of range");
+                    return Err(X86VlapicError::InvalidInput);
                 }
                 let entry = state.redirection_table[index];
                 if (reg - IOREDTBL_BASE) & 1 == 0 {
@@ -200,13 +199,13 @@ impl EmulatedIoApic {
         }
     }
 
-    fn write_selected_register(state: &mut IoApicState, value: u32) -> AxResult {
+    fn write_selected_register(state: &mut IoApicState, value: u32) -> X86VlapicResult {
         match state.selector {
             IOAPIC_ID | IOAPIC_VER | IOAPIC_ARB => Ok(()),
             reg @ IOREDTBL_BASE..=0x3f => {
                 let index = ((reg - IOREDTBL_BASE) / 2) as usize;
                 if index >= REDIRECTION_ENTRY_COUNT {
-                    return ax_err!(InvalidInput, "IOAPIC redirection index out of range");
+                    return Err(X86VlapicError::InvalidInput);
                 }
                 let entry = &mut state.redirection_table[index];
                 if (reg - IOREDTBL_BASE) & 1 == 0 {
@@ -287,21 +286,23 @@ impl Default for EmulatedIoApic {
     }
 }
 
-impl BaseDeviceOps<GuestPhysAddrRange> for EmulatedIoApic {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::X86IoApic
-    }
-
-    fn address_range(&self) -> GuestPhysAddrRange {
-        AddrRange::new(
+impl EmulatedIoApic {
+    /// Returns the IO APIC MMIO range.
+    pub fn address_range(&self) -> X86GuestPhysAddrRange {
+        X86GuestPhysAddrRange::new(
             self.base,
-            GuestPhysAddr::from_usize(self.base.as_usize() + self.size),
+            X86GuestPhysAddr::from_usize(self.base.as_usize() + self.size),
         )
     }
 
-    fn handle_read(&self, addr: GuestPhysAddr, width: AccessWidth) -> AxResult<usize> {
-        if !matches!(width, AccessWidth::Dword | AccessWidth::Qword) {
-            return ax_err!(Unsupported, "unsupported IOAPIC read width");
+    /// Handles an IO APIC MMIO read.
+    pub fn handle_read(
+        &self,
+        addr: X86GuestPhysAddr,
+        width: X86AccessWidth,
+    ) -> X86VlapicResult<usize> {
+        if !matches!(width, X86AccessWidth::Dword | X86AccessWidth::Qword) {
+            return Err(X86VlapicError::Unsupported);
         }
 
         let offset = self.offset(addr);
@@ -316,9 +317,15 @@ impl BaseDeviceOps<GuestPhysAddrRange> for EmulatedIoApic {
         }
     }
 
-    fn handle_write(&self, addr: GuestPhysAddr, width: AccessWidth, val: usize) -> AxResult {
-        if !matches!(width, AccessWidth::Dword | AccessWidth::Qword) {
-            return ax_err!(Unsupported, "unsupported IOAPIC write width");
+    /// Handles an IO APIC MMIO write.
+    pub fn handle_write(
+        &self,
+        addr: X86GuestPhysAddr,
+        width: X86AccessWidth,
+        val: usize,
+    ) -> X86VlapicResult {
+        if !matches!(width, X86AccessWidth::Dword | X86AccessWidth::Qword) {
+            return Err(X86VlapicError::Unsupported);
         }
 
         let offset = self.offset(addr);

--- a/virtualization/x86_vlapic/src/vlapic.rs
+++ b/virtualization/x86_vlapic/src/vlapic.rs
@@ -14,19 +14,17 @@
 
 use core::ptr::NonNull;
 
-use ax_errno::{AxError, AxResult, ax_err_type};
-use axdevice_base::AccessWidth;
-use axvm_types::{HostPhysAddr, VCpuId, VMId};
 use bit::BitIndex;
 use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 
 pub use crate::regs::lvt::LVT_TIMER::TimerMode::Value as TimerMode;
 use crate::{
+    X86AccessWidth, X86HostPhysAddr, X86VcpuId, X86VlapicError, X86VlapicResult, X86VmId,
     consts::{
         APIC_LVT_DS, APIC_LVT_M, APIC_LVT_VECTOR, ApicRegOffset, LAPIC_TRIG_EDGE,
         RESET_SPURIOUS_INTERRUPT_VECTOR, xapic::DEFAULT_APIC_BASE,
     },
-    host::{self, PhysFrame},
+    host::{self, PhysFrame, X86VlapicHostOps},
     regs::{
         APIC_BASE, ApicBaseRegisterMsr,
         DESTINATION_FORMAT::{self, Model::Value as APICDestinationFormat},
@@ -53,7 +51,7 @@ const APIC_VERSION_INTEGRATED: u32 = 0x14;
 const APIC_VERSION_MAX_LVT_ENTRIES: u32 = 6 << 16;
 
 /// Virtual-APIC Registers.
-pub struct VirtualApicRegs {
+pub struct VirtualApicRegs<H: X86VlapicHostOps> {
     /// The virtual-APIC page is a 4-KByte region of memory
     /// that the processor uses to virtualize certain accesses to APIC registers and to manage virtual interrupts.
     /// The physical address of the virtual-APIC page is the virtual-APIC address,
@@ -65,7 +63,7 @@ pub struct VirtualApicRegs {
     esr_pending: ErrorStatusRegisterLocal,
     esr_firing: i32,
 
-    virtual_timer: ApicTimer,
+    virtual_timer: ApicTimer<H>,
 
     /// Vector number for the highest priority bit that is set in the ISR
     isrv: u32,
@@ -78,13 +76,13 @@ pub struct VirtualApicRegs {
     /// Copies of some registers in the virtual APIC page,
     /// to maintain a coherent snapshot of the register (e.g. lvt_last)
     lvt_last: LocalVectorTable,
-    apic_page: PhysFrame,
+    apic_page: PhysFrame<H>,
 }
 
-impl VirtualApicRegs {
+impl<H: X86VlapicHostOps> VirtualApicRegs<H> {
     /// Create new virtual-APIC registers by allocating a 4-KByte page for the virtual-APIC page.
-    pub fn new(vm_id: VMId, vcpu_id: VCpuId) -> Self {
-        let apic_frame = PhysFrame::alloc_zero().expect("allocate virtual-APIC page failed");
+    pub fn new(vm_id: X86VmId, vcpu_id: X86VcpuId) -> Self {
+        let apic_frame = PhysFrame::<H>::alloc_zero().expect("allocate virtual-APIC page failed");
         let regs = Self {
             // virtual-APIC ID is the same as the VCPU ID.
             vapic_id: vcpu_id as _,
@@ -100,7 +98,7 @@ impl VirtualApicRegs {
                     | APIC_BASE_ENABLE
                     | if vcpu_id == 0 { APIC_BASE_BSP } else { 0 },
             ),
-            virtual_timer: ApicTimer::new(vm_id, vcpu_id),
+            virtual_timer: ApicTimer::<H>::new(vm_id, vcpu_id),
         };
         regs.regs().ID.set((vcpu_id as u32) << 24);
         regs.regs()
@@ -117,7 +115,7 @@ impl VirtualApicRegs {
     /// This field contains the physical address of the 4-KByte virtual-APIC page.
     /// The processor uses the virtual-APIC page to virtualize certain accesses to APIC registers and to manage virtual interrupts;
     /// see Chapter 30.
-    pub fn virtual_apic_page_addr(&self) -> HostPhysAddr {
+    pub fn virtual_apic_page_addr(&self) -> X86HostPhysAddr {
         self.apic_page.start_paddr()
     }
 
@@ -128,12 +126,9 @@ impl VirtualApicRegs {
     }
 
     /// Sets the APIC base MSR value.
-    pub fn set_apic_base(&mut self, value: u64) -> AxResult {
+    pub fn set_apic_base(&mut self, value: u64) -> X86VlapicResult {
         if value & APIC_BASE_X2APIC_ENABLE != 0 && value & APIC_BASE_ENABLE == 0 {
-            return Err(ax_err_type!(
-                InvalidInput,
-                "x2APIC cannot be enabled while xAPIC is disabled"
-            ));
+            return Err(X86VlapicError::InvalidInput);
         }
 
         self.apic_base.set(value);
@@ -154,11 +149,11 @@ impl VirtualApicRegs {
     }
 
     /// Returns the current timer mode.
-    pub fn timer_mode(&self) -> AxResult<TimerMode> {
+    pub fn timer_mode(&self) -> X86VlapicResult<TimerMode> {
         self.regs()
             .LVT_TIMER
             .read_as_enum(LVT_TIMER::TimerMode)
-            .ok_or_else(|| ax_err_type!(InvalidData, "Failed to read timer mode from LVT_TIMER"))
+            .ok_or(X86VlapicError::InvalidData)
     }
 
     /// 30.1.4 EOI Virtualization
@@ -257,7 +252,7 @@ impl VirtualApicRegs {
         }
     }
 
-    fn is_dest_field_matched(&self, dest: u32) -> AxResult<bool> {
+    fn is_dest_field_matched(&self, dest: u32) -> X86VlapicResult<bool> {
         let mut ret = false;
 
         let ldr = self.regs().LDR.get();
@@ -269,7 +264,7 @@ impl VirtualApicRegs {
                 .regs()
                 .DFR
                 .read_as_enum::<APICDestinationFormat>(DESTINATION_FORMAT::Model)
-                .ok_or(AxError::InvalidData)?
+                .ok_or(X86VlapicError::InvalidData)?
             {
                 APICDestinationFormat::Flat => {
                     // In the "Flat Model" the MDA is interpreted as an 8-bit wide
@@ -304,12 +299,12 @@ impl VirtualApicRegs {
         dest: u32,
         is_phys: bool,
         lowprio: bool,
-    ) -> AxResult<u64> {
+    ) -> X86VlapicResult<u64> {
         let mut dmask = 0;
 
         if is_broadcast {
             // Broadcast in both logical and physical modes.
-            dmask = host::current_vm_active_vcpus() as u64;
+            dmask = host::current_vm_active_vcpus::<H>() as u64;
         } else if is_phys {
             // Physical mode: "dest" is local APIC ID.
             // Todo: distinguish between APIC ID and vCPU ID.
@@ -322,8 +317,8 @@ impl VirtualApicRegs {
             // Logical mode: "dest" is message destination addr
             // to be compared with the logical APIC ID in LDR.
 
-            let vcpu_mask = host::active_vcpus(host::current_vm_id()).unwrap();
-            for i in 0..host::current_vm_vcpu_num() {
+            let vcpu_mask = host::active_vcpus::<H>(H::current_vm_id()).unwrap();
+            for i in 0..host::current_vm_vcpu_num::<H>() {
                 if vcpu_mask & (1 << i) != 0 {
                     if !self.is_dest_field_matched(dest)? {
                         continue;
@@ -343,7 +338,7 @@ impl VirtualApicRegs {
         dest: u32,
         is_phys: bool,
         lowprio: bool,
-    ) -> AxResult<u64> {
+    ) -> X86VlapicResult<u64> {
         let mut dmask = 0;
         match shorthand {
             APICDestination::NoShorthand => {
@@ -353,10 +348,10 @@ impl VirtualApicRegs {
                 dmask.set_bit(self.vapic_id as usize, true);
             }
             APICDestination::AllIncludingSelf => {
-                dmask = host::current_vm_active_vcpus() as u64;
+                dmask = host::current_vm_active_vcpus::<H>() as u64;
             }
             APICDestination::AllExcludingSelf => {
-                dmask = host::current_vm_active_vcpus() as u64;
+                dmask = host::current_vm_active_vcpus::<H>() as u64;
                 dmask &= !(1 << self.vapic_id);
             }
         }
@@ -381,7 +376,7 @@ impl VirtualApicRegs {
         }
 
         debug!("[VLAPIC] injecting vector {vector:#x} to vcpu {vcpu_id}");
-        let _ = host::inject_interrupt(host::current_vm_id(), vcpu_id as usize, vector as u8);
+        let _ = host::inject_interrupt::<H>(H::current_vm_id(), vcpu_id as usize, vector as u8);
     }
 
     /// Record interrupt acceptance in the virtual APIC page.
@@ -459,7 +454,7 @@ impl VirtualApicRegs {
 
     /// Figure 11-14. Spurious-Interrupt Vector Register (SVR)
     /// Handle writes to the SVR register.
-    fn write_svr(&mut self) -> AxResult {
+    fn write_svr(&mut self) -> X86VlapicResult {
         let new = self.regs().SVR.extract();
         let old = self.svr_last;
 
@@ -497,7 +492,7 @@ impl VirtualApicRegs {
         self.esr_pending.set(0);
     }
 
-    fn write_icr(&mut self) -> AxResult {
+    fn write_icr(&mut self) -> X86VlapicResult {
         self.regs()
             .ICR_LO
             .modify(INTERRUPT_COMMAND_LOW::DeliveryStatus::Idle);
@@ -517,11 +512,11 @@ impl VirtualApicRegs {
         let vec = icr_low.read(INTERRUPT_COMMAND_LOW::Vector);
         let mode = icr_low
             .read_as_enum::<APICDeliveryMode>(INTERRUPT_COMMAND_LOW::DeliveryMode)
-            .ok_or(AxError::InvalidData)?;
+            .ok_or(X86VlapicError::InvalidData)?;
         let is_phys = !icr_low.is_set(INTERRUPT_COMMAND_LOW::DestinationMode);
         let shorthand = icr_low
             .read_as_enum::<APICDestination>(INTERRUPT_COMMAND_LOW::DestinationShorthand)
-            .ok_or(AxError::InvalidData)?;
+            .ok_or(X86VlapicError::InvalidData)?;
 
         if mode == APICDeliveryMode::Fixed && vec < 16 {
             self.set_err(ERROR_STATUS::SendIllegalVector::SET);
@@ -543,7 +538,7 @@ impl VirtualApicRegs {
             let dmask = self.calculate_dest(shorthand, is_broadcast, dest, is_phys, false)?;
 
             // TODO: we need to get the specific vcpu number somehow.
-            for i in 0..host::current_vm_vcpu_num() as u32 {
+            for i in 0..host::current_vm_vcpu_num::<H>() as u32 {
                 if dmask & (1 << i) != 0 {
                     match mode {
                         APICDeliveryMode::Fixed => {
@@ -587,7 +582,7 @@ impl VirtualApicRegs {
         }
     }
 
-    fn write_lvt(&mut self, offset: ApicRegOffset) -> AxResult {
+    fn write_lvt(&mut self, offset: ApicRegOffset) -> X86VlapicResult {
         let mut val = self.extract_lvt_val(offset);
 
         // Mask::Masked, Delivery Status:SendPending, Vector::SET(0xff)
@@ -665,13 +660,13 @@ impl VirtualApicRegs {
             }
             _ => {
                 warn!("[VLAPIC] write unsupported APIC register: {offset:?}");
-                return Err(AxError::InvalidInput);
+                return Err(X86VlapicError::InvalidInput);
             }
         }
         Ok(())
     }
 
-    fn mask_lvts(&mut self) -> AxResult {
+    fn mask_lvts(&mut self) -> X86VlapicResult {
         self.regs().LVT_CMCI.modify(LVT_CMCI::Mask::SET);
         self.write_lvt(ApicRegOffset::LvtCMCI)?;
 
@@ -700,11 +695,11 @@ impl VirtualApicRegs {
         Ok(())
     }
 
-    fn write_icrtmr(&mut self) -> AxResult {
+    fn write_icrtmr(&mut self) -> X86VlapicResult {
         self.virtual_timer.write_icr(self.regs().ICR_TIMER.get())
     }
 
-    fn write_dcr(&mut self) -> AxResult {
+    fn write_dcr(&mut self) -> X86VlapicResult {
         self.virtual_timer.write_dcr(self.regs().DCR_TIMER.get());
         Ok(())
     }
@@ -725,8 +720,12 @@ fn prio(x: u32) -> u32 {
     (x >> 4) & 0xf
 }
 
-impl VirtualApicRegs {
-    pub fn handle_read(&self, offset: ApicRegOffset, width: AccessWidth) -> AxResult<usize> {
+impl<H: X86VlapicHostOps> VirtualApicRegs<H> {
+    pub fn handle_read(
+        &self,
+        offset: ApicRegOffset,
+        width: X86AccessWidth,
+    ) -> X86VlapicResult<usize> {
         let mut value: usize = 0;
         match offset {
             ApicRegOffset::ID => {
@@ -768,11 +767,11 @@ impl VirtualApicRegs {
             }
             ApicRegOffset::ICRLow => {
                 value = self.regs().ICR_LO.get() as _;
-                if self.is_x2apic_enabled() && width == AccessWidth::Qword {
+                if self.is_x2apic_enabled() && width == X86AccessWidth::Qword {
                     let icr_hi = self.regs().ICR_HI.get() as usize;
                     value |= icr_hi << 32;
                     debug!("[VLAPIC] read ICR register: {value:#018X}");
-                } else if self.is_x2apic_enabled() ^ (width == AccessWidth::Qword) {
+                } else if self.is_x2apic_enabled() ^ (width == X86AccessWidth::Qword) {
                     warn!(
                         "[VLAPIC] Illegal read attempt of ICR register at width {:?} with X2APIC \
                          {}",
@@ -783,7 +782,7 @@ impl VirtualApicRegs {
                             "disabled"
                         }
                     );
-                    return Err(AxError::InvalidInput);
+                    return Err(X86VlapicError::InvalidInput);
                 }
             }
             ApicRegOffset::ICRHi => {
@@ -845,8 +844,8 @@ impl VirtualApicRegs {
         &mut self,
         offset: ApicRegOffset,
         val: usize,
-        width: AccessWidth,
-    ) -> AxResult {
+        width: X86AccessWidth,
+    ) -> X86VlapicResult {
         let data32 = val as u32;
 
         match offset {
@@ -877,10 +876,10 @@ impl VirtualApicRegs {
                 self.write_esr();
             }
             ApicRegOffset::ICRLow => {
-                if self.is_x2apic_enabled() && width == AccessWidth::Qword {
+                if self.is_x2apic_enabled() && width == X86AccessWidth::Qword {
                     debug!("[VLAPIC] write ICR register: {val:#018X} in X2APIC mode");
                     self.regs().ICR_HI.set((val >> 32) as u32);
-                } else if self.is_x2apic_enabled() ^ (width == AccessWidth::Qword) {
+                } else if self.is_x2apic_enabled() ^ (width == X86AccessWidth::Qword) {
                     warn!(
                         "[VLAPIC] Illegal read attempt of ICR register at width {:?} with X2APIC \
                          {}",
@@ -891,7 +890,7 @@ impl VirtualApicRegs {
                             "disabled"
                         }
                     );
-                    return Err(AxError::InvalidInput);
+                    return Err(X86VlapicError::InvalidInput);
                 }
                 self.regs().ICR_LO.set(data32);
                 self.write_icr()?;
@@ -899,7 +898,7 @@ impl VirtualApicRegs {
             ApicRegOffset::ICRHi => {
                 if self.is_x2apic_enabled() {
                     warn!("[VLAPIC] write ICRHi register: unsupported in x2APIC mode");
-                    return Err(AxError::InvalidInput);
+                    return Err(X86VlapicError::InvalidInput);
                 }
                 self.regs()
                     .ICR_HI
@@ -957,12 +956,12 @@ impl VirtualApicRegs {
                     self.handle_self_ipi(data32 & 0xff);
                 } else {
                     warn!("[VLAPIC] write SelfIPI register: unsupported in xAPIC mode");
-                    return Err(AxError::InvalidInput);
+                    return Err(X86VlapicError::InvalidInput);
                 }
             }
             _ => {
                 warn!("[VLAPIC] write unsupported APIC register: {offset:?}");
-                return Err(AxError::InvalidInput);
+                return Err(X86VlapicError::InvalidInput);
             }
         }
 

--- a/virtualization/x86_vlapic/tests/dependency_contract_test.rs
+++ b/virtualization/x86_vlapic/tests/dependency_contract_test.rs
@@ -1,0 +1,31 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[test]
+fn x86_vlapic_manifest_has_no_ax_runtime_dependencies() {
+    let manifest = include_str!("../Cargo.toml");
+
+    for forbidden in [
+        "ax-errno",
+        "ax-memory-addr",
+        "ax-crate-interface",
+        "axdevice_base",
+        "axvm-types",
+    ] {
+        assert!(
+            !manifest.contains(forbidden),
+            "x86_vlapic core must not depend on {forbidden}"
+        );
+    }
+}


### PR DESCRIPTION
## 背景

`x86_vcpu` 之前直接依赖 AxVM/ArceOS 的错误、地址、设备和 crate-interface 机制，导致它不像 `arm_vcpu` 一样可以作为 OS-neutral 的功能库复用。`x86_vlapic` 也承担了设备层和 OS glue 的一部分职责，使 x86 exit 处理逻辑难以收敛到 AxVM 架构适配层。

PR CI 初始 attempt 还暴露了一个与本次 x86 改动无关的稳定性问题：Starry qemu job 在预热 AIC8800 firmware 时直接访问 `raw.githubusercontent.com`，遇到 `429 Too Many Requests` 会立即失败并触发 fail-fast。

## 变更

- 为 `x86_vcpu` 增加专用错误、地址、访问宽度、nested paging 配置和 `X86VmExit` 类型，核心 API 改为返回 `X86VcpuResult<X86VmExit>`。
- 用 `X86HostOps` / `X86VlapicHostOps` 替换 `ax_crate_interface`，让 VMX/SVM/no-backend vCPU 和 per-CPU 状态都按 host ops 泛型化。
- 拆分 `x86_vlapic` 的 OS 依赖，保留 vLAPIC、PIT、serial、IOAPIC 的核心模拟逻辑，并通过 inherent methods 暴露 MMIO/MSR/IRQ 操作。
- 在 `axvm::arch::x86_64` 增加 `AxvmX86HostOps`、`AxvmX86Vcpu`、`AxvmX86PerCpu`，把 `VmArchVcpuOps` / `VmArchPerCpuOps`、错误转换、QEMU shutdown port、x86 IRQ runtime 和 nested page fault 处理放回 AxVM 侧。
- 在 `axdevice` 增加 x86 设备适配层，负责把 OS-neutral 的 x86 设备核心注册到统一设备框架。
- 增加依赖边界和 OS-neutral API contract tests，防止 `x86_vcpu` / `x86_vlapic` 重新引入 AxVM/ArceOS 类型依赖。
- 让 AIC8800 firmware 预热复用 `axbuild` 现有的 checksum download helper，使 `429` / 5xx 等 transient HTTP 失败走同一套重试逻辑。

## 验证

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p axbuild download_file_retries_transient_http_status`
- `cargo xtask clippy --package axbuild`
- `cargo test -p x86_vcpu --lib --no-run`
- `cargo test -p x86_vcpu --lib --no-run --no-default-features --features svm`
- `cargo xtask clippy --package x86_vlapic`
- `cargo xtask clippy --package x86_vcpu`
- `cargo xtask clippy --package axvm`
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case smoke-vmx`
