### PR TITLE
fix(starry): correct /proc/pid/comm padding and non-blocking partial TCP send

### DIFF
--- a/net/ax-net/src/tcp.rs
+++ b/net/ax-net/src/tcp.rs
@@ -575,6 +575,13 @@ impl SocketOps for TcpSocket {
     fn send(&self, mut src: impl Read + IoBuf, options: SendOptions) -> AxResult<usize> {
         // SAFETY: `self.handle` should be initialized in a connected socket.
         let extra_nb = options.flags.contains(crate::SendFlags::DONTWAIT);
+        // A partial send on a non-blocking socket must report the bytes already
+        // enqueued rather than `WouldBlock`. The poller treats the socket as
+        // non-blocking when either `O_NONBLOCK` or `MSG_DONTWAIT` is set, so
+        // `finish_tcp_send_step` has to use the same effective flag: otherwise a
+        // partial send returns EAGAIN after `src` was already consumed, and the
+        // caller retransmits those bytes and corrupts the stream.
+        let nonblocking = self.general.nonblocking() || extra_nb;
         let target_len = src.remaining();
         if target_len == 0 {
             return Ok(0);
@@ -602,7 +609,7 @@ impl SocketOps for TcpSocket {
             if step.as_ref().is_ok_and(|sent| *sent > 0) {
                 request_poll();
             }
-            finish_tcp_send_step(&mut total_sent, target_len, extra_nb, step)
+            finish_tcp_send_step(&mut total_sent, target_len, nonblocking, step)
         });
         if result.is_ok() {
             request_poll();

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -1390,11 +1390,17 @@ impl SimpleDirOps for ThreadDir {
                 fs,
                 RwFile::new(move |req| match req {
                     SimpleFileOperation::Read => {
-                        let mut bytes = vec![0; 16];
+                        // `/proc/<pid>/comm` must return only the name plus one
+                        // trailing newline, with no NUL padding: musl's
+                        // pthread_getname_np() reads the file into a 16-byte buffer
+                        // and strips just the final byte, so any padding would leave
+                        // the newline inside the read-back name and break Envoy's
+                        // thread setName() round-trip assertion.
                         let name = task.name();
                         let copy_len = name.len().min(15);
-                        bytes[..copy_len].copy_from_slice(&name.as_bytes()[..copy_len]);
-                        bytes[copy_len] = b'\n';
+                        let mut bytes = Vec::with_capacity(copy_len + 1);
+                        bytes.extend_from_slice(&name.as_bytes()[..copy_len]);
+                        bytes.push(b'\n');
                         Ok(Some(bytes))
                     }
                     SimpleFileOperation::Write(data) => {

--- a/test-suit/starryos/qemu/system/bugfix-bug-proc-comm-tcp-partial-send/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-bug-proc-comm-tcp-partial-send/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-proc-comm-tcp-partial-send C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-proc-comm-tcp-partial-send src/main.c)
+target_include_directories(bug-proc-comm-tcp-partial-send PRIVATE src)
+target_compile_options(bug-proc-comm-tcp-partial-send PRIVATE -Wall -Wextra -Werror)
+target_link_options(bug-proc-comm-tcp-partial-send PRIVATE -static)
+
+install(TARGETS bug-proc-comm-tcp-partial-send RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-bug-proc-comm-tcp-partial-send/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-proc-comm-tcp-partial-send/src/main.c
@@ -1,0 +1,218 @@
+/*
+ * proc-comm-tcp-partial-send.c - Regression for the two kernel gaps Envoy
+ * (higress) exposed, fixed against Linux fs/proc/base.c (comm_show) and the
+ * non-blocking TCP send path.
+ *
+ *   1. /proc/<pid>/comm read format: Linux comm_show() prints exactly the
+ *      thread name followed by a single '\n' with no NUL padding. musl's
+ *      pthread_getname_np() reads the file and strips only the LAST byte, so a
+ *      16-byte NUL-padded buffer would leave the '\n' embedded inside the
+ *      read-back name and break Envoy's thread setName() round-trip. This test
+ *      asserts the exact byte layout via /proc/self/comm and via the real
+ *      pthread_setname_np/pthread_getname_np round-trip Envoy uses.
+ *
+ *   2. Non-blocking TCP partial send: a partial send on an O_NONBLOCK socket
+ *      must report the bytes already enqueued, not WouldBlock. StarryOS
+ *      finish_tcp_send_step now honors the effective non-blocking flag
+ *      (O_NONBLOCK || MSG_DONTWAIT); a regressed build only looked at
+ *      MSG_DONTWAIT and returned EAGAIN after src was already consumed, so the
+ *      caller retransmitted those bytes and corrupted the stream. This test
+ *      fills the pipe with O_NONBLOCK (never MSG_DONTWAIT), drains a bounded
+ *      amount, and asserts the next large send returns a partial count > 0.
+ *
+ * Loopback only, single process; deterministic.
+ */
+
+#define _GNU_SOURCE
+
+#include "test_framework.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <pthread.h>
+#include <string.h>
+#include <sys/prctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+/* 1a. /proc/self/comm returns exactly "<name>\n" with no NUL padding. */
+static void check_comm_read(const char *set_name, const char *expect)
+{
+    CHECK_RET(prctl(PR_SET_NAME, (unsigned long)set_name, 0, 0, 0), 0,
+              "prctl(PR_SET_NAME) sets the thread name");
+
+    int fd = open("/proc/self/comm", O_RDONLY);
+    CHECK(fd >= 0, "open /proc/self/comm");
+    if (fd < 0)
+        return;
+
+    char buf[64];
+    memset(buf, 0xAA, sizeof(buf));
+    ssize_t n = read(fd, buf, sizeof(buf));
+    close(fd);
+
+    size_t elen = strlen(expect);
+    CHECK(n == (ssize_t)(elen + 1),
+          "/proc/self/comm returns name + one newline with no NUL padding");
+    if (n == (ssize_t)(elen + 1))
+    {
+        CHECK(memcmp(buf, expect, elen) == 0, "/proc/self/comm name bytes match");
+        CHECK(buf[elen] == '\n', "/proc/self/comm ends with a single '\\n'");
+    }
+}
+
+static void test_comm_read_format(void)
+{
+    check_comm_read("envoy", "envoy");
+    check_comm_read("worker_0", "worker_0");
+    /* TASK_COMM_LEN-1 = 15 characters is the exact boundary. */
+    check_comm_read("abcdefghijklmno", "abcdefghijklmno");
+    /* A longer name is truncated to 15 characters by the read path. */
+    check_comm_read("abcdefghijklmnopqrst", "abcdefghijklmno");
+}
+
+/* 1b. Envoy's real path: pthread_setname_np then pthread_getname_np must
+ * round-trip byte-for-byte. The bug left a '\n' embedded in the read-back name
+ * because musl strips only the trailing byte from a padded buffer. */
+static void check_setname_roundtrip(const char *name)
+{
+    int rc = pthread_setname_np(pthread_self(), name);
+    CHECK(rc == 0, "pthread_setname_np succeeds");
+    if (rc != 0)
+        return;
+
+    char got[32];
+    memset(got, 0x5A, sizeof(got));
+    rc = pthread_getname_np(pthread_self(), got, sizeof(got));
+    CHECK(rc == 0, "pthread_getname_np succeeds");
+    if (rc != 0)
+        return;
+
+    CHECK(strcmp(got, name) == 0,
+          "thread name round-trips with no embedded newline (Envoy setName)");
+}
+
+static void test_pthread_setname_roundtrip(void)
+{
+    check_setname_roundtrip("envoy");
+    check_setname_roundtrip("worker_1");
+    check_setname_roundtrip("abcdefghijklmno"); /* 15 chars, musl max */
+}
+
+/* 2. A non-blocking (O_NONBLOCK) partial send reports the queued byte count. */
+static void test_nonblocking_partial_send(void)
+{
+    int ln = socket(AF_INET, SOCK_STREAM, 0);
+    CHECK(ln >= 0, "open TCP listener");
+    if (ln < 0)
+        return;
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0; /* ephemeral */
+    CHECK_RET(bind(ln, (struct sockaddr *)&addr, sizeof(addr)), 0, "bind listener to loopback");
+    CHECK_RET(listen(ln, 1), 0, "listen");
+
+    socklen_t alen = sizeof(addr);
+    CHECK_RET(getsockname(ln, (struct sockaddr *)&addr, &alen), 0, "getsockname listener port");
+
+    int tx = socket(AF_INET, SOCK_STREAM, 0);
+    CHECK(tx >= 0, "open TCP sender");
+    if (tx < 0)
+    {
+        close(ln);
+        return;
+    }
+
+    /* Small buffers keep the pipe tiny so the fill loop is short and a bounded
+     * drain reopens only a partial window. */
+    int small = 4096;
+    setsockopt(tx, SOL_SOCKET, SO_SNDBUF, &small, sizeof(small));
+
+    CHECK_RET(connect(tx, (struct sockaddr *)&addr, sizeof(addr)), 0, "connect to listener");
+
+    int rx = accept(ln, NULL, NULL);
+    CHECK(rx >= 0, "accept the connection");
+    if (rx < 0)
+    {
+        close(tx);
+        close(ln);
+        return;
+    }
+    setsockopt(rx, SOL_SOCKET, SO_RCVBUF, &small, sizeof(small));
+
+    /* Non-blocking via O_NONBLOCK (fcntl), never MSG_DONTWAIT: this is exactly
+     * the path the fix repaired. */
+    int fl = fcntl(tx, F_GETFL, 0);
+    CHECK(fl >= 0, "fcntl F_GETFL on sender");
+    CHECK_RET(fcntl(tx, F_SETFL, fl | O_NONBLOCK), 0, "set O_NONBLOCK on sender");
+
+    /* Fill the send+receive pipe with single bytes until it reports EAGAIN. */
+    char one = 'x';
+    long filled = 0;
+    int hit_eagain = 0;
+    for (long i = 0; i < 4000000; i++)
+    {
+        ssize_t r = send(tx, &one, 1, 0); /* no MSG_DONTWAIT: rely on O_NONBLOCK */
+        if (r == 1)
+        {
+            filled++;
+            continue;
+        }
+        if (r < 0 && errno == EAGAIN)
+        {
+            hit_eagain = 1;
+            break;
+        }
+        CHECK(0, "unexpected send result while filling the buffer");
+        break;
+    }
+    CHECK(filled > 0, "non-blocking send enqueues bytes into the socket buffer");
+    CHECK(hit_eagain, "non-blocking send reports EAGAIN once the buffer is full");
+
+    /* A send against the now-full buffer returns EAGAIN and enqueues nothing. */
+    ssize_t full = send(tx, "AAAA", 4, 0);
+    CHECK(full < 0 && errno == EAGAIN, "send on a full non-blocking socket returns EAGAIN");
+
+    /* Drain a bounded amount at the receiver to reopen only a partial window. */
+    char drain[1000];
+    ssize_t drained = recv(rx, drain, sizeof(drain), 0);
+    CHECK(drained > 0, "receiver drains some bytes to reopen the window");
+
+    /* Wait for the window update to make the sender writable again. */
+    struct pollfd pfd = {.fd = tx, .events = POLLOUT, .revents = 0};
+    int pr = poll(&pfd, 1, 2000);
+    CHECK(pr == 1 && (pfd.revents & POLLOUT),
+          "sender becomes writable after the receiver drains");
+
+    /* Send one megabyte, far more than any reopened window (capped by the small
+     * SO_SNDBUF): the fix reports the partial count of queued bytes (> 0)
+     * instead of EAGAIN-after-consuming-src, and the count is strictly less than
+     * requested because the window is bounded. */
+    static char big[1 << 20];
+    memset(big, 'B', sizeof(big));
+    ssize_t n = send(tx, big, sizeof(big), 0);
+    CHECK(n > 0, "partial send on a non-blocking socket returns queued bytes, not EAGAIN");
+    CHECK(n < (ssize_t)sizeof(big),
+          "partial send reports fewer bytes than requested (window is bounded)");
+
+    close(tx);
+    close(rx);
+    close(ln);
+}
+
+int main(void)
+{
+    TEST_START("/proc/comm format + non-blocking TCP partial send");
+
+    test_comm_read_format();
+    test_pthread_setname_roundtrip();
+    test_nonblocking_partial_send();
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/qemu/system/bugfix-bug-proc-comm-tcp-partial-send/src/test_framework.h
+++ b/test-suit/starryos/qemu/system/bugfix-bug-proc-comm-tcp-partial-send/src/test_framework.h
@@ -1,0 +1,86 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno)); \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno,     \
+               strerror(errno));                                        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
在 StarryOS 四架构上跑源码交叉编译的 Envoy (higress) 时暴露两个内核面缺口, 均对照 Linux 语义修复。

## 1. `/proc/<pid>/comm` NUL 填充
comm 读处理器原返回定长 16 字节 `name + '\n' + NUL 填充`。musl 的 `pthread_getname_np()` 把整 16 字节读入缓冲后只把最后一个字节置零, NUL 填充导致换行留在了回读的线程名中间, 破坏 Envoy 线程 `setName()` 的往返自检 (`getNameFromOS`, `thread_impl.cc:116`), worker 线程 abort、Envoy 到不了 LIVE。glibc 版 (x86/aa) 因 `pthread_getname_np` 在 `n==len` 时返回 ERANGE 恰好短路过断言, 故未暴露。Linux 的 comm 只返回名字加单个换行、无填充。改为一致行为。

## 2. TCP 非阻塞部分发送误报 WouldBlock（#1533 回归）
`finish_tcp_send_step` (#1533 引入) 只按 `MSG_DONTWAIT` 判非阻塞, 忽略了 socket 自身的 `O_NONBLOCK`。Envoy 用 `O_NONBLOCK` fd, 部分发送时该函数返回 `WouldBlock`, 而 poller 的有效非阻塞态是 `nonblocking() || extra_nb`, 于是把 `EAGAIN` 报给上层——但此时 `src` 里的字节已被消费并入队。上层据 EAGAIN 重发同一段 → TCP 流内字节重复/错位 → HTTP/1.1 chunked 响应帧错乱 (busybox wget `bad chunk length`, 大响应体在 ~79KB 处截断)。改为使用与 poller 相同的有效非阻塞标志 `nonblocking() || extra_nb`。二分回退可复现: 将该处回退到 #1533 之前, chunked 传输立即恢复正常。

两处均为运行大型 C++ 网络代理 (Envoy) 时才触发的边界行为; 修复后 riscv64/loongarch64 上该负载的服务就绪、线程命名、大响应体 chunked 传输均正常。
