### PR TITLE
test(starry): source-build Envoy for riscv64/loongarch64 higress carpet

### DIFF
--- a/apps/starry/higress/README.md
+++ b/apps/starry/higress/README.md
@@ -3,51 +3,74 @@
 > higress standalone gateway (Envoy data plane, static bootstrap) on StarryOS
 
 higress is a cloud-native API gateway whose data plane is Envoy. In standalone
-mode it runs the stock Envoy binary against a static bootstrap (no xDS control
-plane), so a single process provides the gateway functionality. This app runs
-the official Envoy release directly on StarryOS as a glibc dynamic ELF and
+mode it runs the Envoy binary against a static bootstrap (no xDS control plane),
+so a single process provides the gateway functionality. This app runs Envoy
+1.38.3 directly on StarryOS as a dynamic ELF on all four architectures and
 asserts the full documented gateway data path end to end (65 assertions).
 
 ## 架构矩阵
 
-| 架构 | Envoy release | 状态 |
-|------|---------------|------|
-| x86_64 | `envoy-1.38.3-linux-x86_64` | A 档，实跑 65/65 |
-| aarch64 | `envoy-1.38.3-linux-aarch_64` | A 档，实跑 65/65 |
-| riscv64 | 无 | 上游 Envoy 无 riscv64 端口 |
-| loongarch64 | 无 | 上游 Envoy 无 loongarch64 端口 |
+| 架构 | Envoy 1.38.3 | 状态 |
+|------|--------------|------|
+| x86_64 | 官方 release `envoy-1.38.3-linux-x86_64` (glibc) | A 档，实跑 65/65 |
+| aarch64 | 官方 release `envoy-1.38.3-linux-aarch_64` (glibc) | A 档，实跑 65/65 |
+| riscv64 | 源码建 (clang-18 + musl cross, lld) | A 档，实跑 65/65 (musl-dynamic ELF，同 x86/aa 走同一 `run-higress.sh`) |
+| loongarch64 | 源码建 (clang-18 + musl cross, lld) | A 档，实跑 65/65 (musl-dynamic ELF，同 x86/aa 走同一 `run-higress.sh`) |
 
 Envoy ships prebuilt binaries only for glibc x86_64 + aarch64
-(`github.com/envoyproxy/envoy/releases`). Upstream has no riscv64 / loongarch64
-port and no musl build, so those two architectures are out of scope here - this
-is an upstream ecosystem gap, not a StarryOS limitation. A source Bazel port to
-those targets is a separate long-horizon effort.
+(`github.com/envoyproxy/envoy/releases`), so those two run the stock release ELF.
+Upstream has no riscv64 / loongarch64 build, so for those two `prebuild.sh`
+source-builds the same Envoy 1.38.3 from the pinned source tag with clang-18
+against a musl cross sysroot, linked with lld - see
+`assets/build-envoy-rvloong.sh`. The build keeps only the data-plane extensions
+the carpet exercises (HTTP connection manager, router, local rate limit, static
+clusters, BoringSSL TLS) and drops the families that need a per-arch runtime with
+no rv64/loong64 port (V8/wasm, LuaJIT, the Go filter, the Rust dynamic-modules /
+Hickory resolver, the datadog / opentelemetry tracers). The output is a
+musl-dynamic ELF; the build is cached under `HIGRESS_CACHE` so it runs once.
 
-Envoy binaries are pinned by version + SHA256 in `prebuild.sh`:
+x86_64 / aarch64 downloads are pinned by version + SHA256 in `prebuild.sh`:
 
 | 架构 | SHA256 |
 |------|--------|
 | x86_64 | `affffb8d08a14fdc375b1f7dd8d0f3004eacdf51ce07f5636d7e168a01c6b373` |
 | aarch64 | `eff9766ce1a7af71c38a6d4587367621753049ae3df1bde5b6b9e695752f3167` |
 
+riscv64 / loongarch64 are reproducible from the pinned Envoy 1.38.3 source (there is
+no upstream binary to SHA-pin). `assets/build-envoy-rvloong.sh` clones the `v1.38.3`
+tag and verifies the checkout against the immutable commit it resolves to
+(`0ebfcfe5b0484b89ca85b761da9e05ce75dbda8d`) with `git rev-parse HEAD` before building -
+a re-pointed tag or tampered cache is rejected - then patches that source deterministically.
+
 ## 运行方式
 
-StarryOS loads the glibc dynamic Envoy ELF through PT_INTERP, the same mechanism
-proven by `apps/starry/glibc-dynamic-smoke`. `prebuild.sh` reads the interpreter
-and NEEDED sonames straight from the Envoy binary and stages them from the arch's
-`<arch>-linux-gnu` cross sysroot into the overlay:
+StarryOS loads the dynamic Envoy ELF through PT_INTERP, the same mechanism proven
+by `apps/starry/glibc-dynamic-smoke` (glibc) and the Alpine musl base (musl).
+`prebuild.sh` reads the interpreter and NEEDED sonames straight from the Envoy
+binary and stages them into the overlay - the glibc loader + libs from the arch's
+`<arch>-linux-gnu` cross sysroot for x86_64/aarch64, or the C++ runtime from the
+musl cross sysroot for riscv64/loongarch64 (the musl libc + loader are the Alpine
+base itself):
 
-| 架构 | INTERP | NEEDED |
-|------|--------|--------|
-| x86_64 | `/lib64/ld-linux-x86-64.so.2` | libc/libm/librt/libdl/libpthread |
-| aarch64 | `/lib/ld-linux-aarch64.so.1` | libc/libm/librt/libdl/libpthread |
+| 架构 | INTERP | 额外 staged 运行库 |
+|------|--------|--------------------|
+| x86_64 | `/lib64/ld-linux-x86-64.so.2` | glibc loader + libc/libm/librt/libdl/libpthread |
+| aarch64 | `/lib/ld-linux-aarch64.so.1` | glibc loader + libc/libm/librt/libdl/libpthread |
+| riscv64 | `/lib/ld-musl-riscv64.so.1` (Alpine base) | libstdc++.so.6 + libgcc_s.so.1 |
+| loongarch64 | `/lib/ld-musl-loongarch64.so.1` (Alpine base) | libstdc++.so.6 + libgcc_s.so.1 |
 
-Envoy 1.38.3 statically links BoringSSL and libstdc++, so TLS works without any
-extra runtime library (max symbol requirement is GLIBC_2.30).
+The official x86_64/aarch64 Envoy statically links BoringSSL and libstdc++, so on
+glibc no extra C++ runtime is staged (max symbol requirement is GLIBC_2.30). The
+riscv64/loongarch64 source build links libstdc++ dynamically (GCC's static
+libstdc++.a carries .eh_frame relocations into discarded COMDAT sections that lld
+rejects), so `prebuild.sh` stages `libstdc++.so.6` + `libgcc_s.so.1` from the musl
+cross sysroot; BoringSSL is still statically linked into the Envoy binary.
 
 ```bash
 cargo xtask starry app qemu -t higress --arch x86_64
 cargo xtask starry app qemu -t higress --arch aarch64
+cargo xtask starry app qemu -t higress --arch riscv64
+cargo xtask starry app qemu -t higress --arch loongarch64
 ```
 
 ### 自包含的上游 / 客户端（不依赖 guest 网络）

--- a/apps/starry/higress/assets/build-envoy-rvloong.sh
+++ b/apps/starry/higress/assets/build-envoy-rvloong.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+# build-envoy-rvloong.sh - source-build Envoy 1.38.3 for riscv64 / loongarch64.
+#
+# Upstream Envoy ships prebuilt binaries only for glibc x86_64 + aarch64. This
+# script reproduces the source build of the same Envoy release for the two
+# remaining StarryOS architectures, cross-compiled with clang-18 against a musl
+# cross sysroot (output: musl-dynamic ELF, interp /lib/ld-musl-<arch>.so.1,
+# which the Alpine base rootfs already provides).
+#
+# The gateway is built with a reduced extension set - exactly the data-plane
+# surface the carpet exercises (HTTP connection manager, router, local rate
+# limit, TLS via BoringSSL, static clusters). The extensions that hard-require a
+# per-arch runtime with no rv64/loong64 port are dropped: V8 (wasm), LuaJIT
+# (lua), the Rust dynamic-modules / Hickory DNS resolver, and the Go filter.
+# HTTP/3 (QUICHE) is disabled since the carpet is HTTP/1 + TLS only.
+#
+# Usage:  build-envoy-rvloong.sh <riscv64|loongarch64> [out-dir]
+# Env:    ENVOY_SRC (reuse an existing checkout), BAZEL (bazelisk path),
+#         *_MUSL_CROSS (override the cross toolchain root), JOBS.
+set -euo pipefail
+
+arch="${1:?usage: build-envoy-rvloong.sh <riscv64|loongarch64> [out-dir]}"
+out_dir="${2:-$PWD}"
+ENVOY_VER=1.38.3
+PLATFORMS_VER=1.1.0
+PLATFORMS_SHA=324f5381753a610e472f79563d44e2026438195042aae4dc660b8c021f7de7f5
+work="${ENVOY_BUILD_ROOT:-${HOME}/.cache/starry-higress-envoy}"
+mkdir -p "$work"
+
+case "$arch" in
+    riscv64)     triple=riscv64-linux-musl ;;
+    loongarch64) triple=loongarch64-linux-musl ;;
+    *) echo "unknown arch: $arch (want riscv64|loongarch64)" >&2; exit 1 ;;
+esac
+
+# --- 1. cross toolchain (clang-18 + <arch>-linux-musl-cross for sysroot/binutils/libstdc++) ---
+clang_bin="${CLANG18:-$(command -v clang-18 || command -v clang)}"
+[ -x "$clang_bin" ] || { echo "clang-18 not found (Envoy needs clang>=18)" >&2; exit 1; }
+cross="${MUSL_CROSS:-}"
+if [ -z "$cross" ]; then
+    for c in "/opt/musl/$triple-cross" "$work/$triple-cross"; do
+        [ -x "$c/bin/$triple-gcc" ] && cross="$c" && break
+    done
+fi
+if [ -z "$cross" ] || [ ! -x "$cross/bin/$triple-gcc" ]; then
+    tgz="${MUSL_CROSS_TGZ:-${HOME}/rcore/download/${triple}-cross.tgz}"
+    [ -f "$tgz" ] || { echo "cross toolchain not found; set MUSL_CROSS or MUSL_CROSS_TGZ" >&2; exit 1; }
+    tar -xzf "$tgz" -C "$work"; cross="$work/$triple-cross"
+fi
+gcc_ver="$("$cross/bin/$triple-gcc" -dumpversion)"
+echo "toolchain: clang $("$clang_bin" -dumpversion) targeting $triple, libstdc++ from gcc $gcc_ver ($cross)"
+
+# --- 1b. libstdc++ <valarray> / clang fix ---
+# gcc 11's bits/range_access.h forward-declares the valarray begin/end overloads
+# without noexcept, while <valarray> defines them with noexcept. gcc tolerates the
+# mismatch; clang rejects it ("exception specification ... does not match"), which
+# breaks every TU that includes <valarray> (yaml-cpp, ...). Add noexcept to the
+# forward decls - the same fix later gcc releases shipped.
+# The patched copy goes into a private overlay ($work/cxx-overlay/bits/) so the
+# caller's toolchain is never modified; the cc/cxx wrappers add -isystem to prefer
+# the overlay over the gcc toolchain's original header.
+cxx_overlay="$work/cxx-overlay"
+mkdir -p "$cxx_overlay/bits"
+for rah in "$cross"/*/include/c++/*/bits/range_access.h; do
+    [ -f "$rah" ] || continue
+    dest="$cxx_overlay/bits/range_access.h"
+    if grep -q 'begin(valarray<_Tp>&) noexcept;' "$rah"; then
+        cp "$rah" "$dest"
+    else
+        sed -E 's/(begin|end)\((const )?valarray<_Tp>&\);/\1(\2valarray<_Tp>\&) noexcept;/' \
+            "$rah" > "$dest"
+        echo "overlay: patched bits/range_access.h noexcept in $cxx_overlay (toolchain untouched)"
+    fi
+done
+
+# --- 2. Envoy source (pinned tag, verified against the immutable commit) ---
+# A tag can be re-pointed upstream, so the v1.38.3 checkout is verified against the full
+# commit it resolves to before any build; a re-pointed tag or tampered cache is rejected
+# rather than silently building different source. This makes the README's "pinned 1.38.3"
+# a reproducible, supply-chain-traceable identity, not just a mutable tag name.
+ENVOY_SRC_COMMIT=0ebfcfe5b0484b89ca85b761da9e05ce75dbda8d
+src="${ENVOY_SRC:-$work/envoy-$ENVOY_VER}"
+if [ -d "$src/.git" ]; then
+    cached_head="$(git -C "$src" rev-parse HEAD 2>/dev/null || true)"
+    if [ "$cached_head" != "$ENVOY_SRC_COMMIT" ]; then
+        echo "build-envoy: cached envoy HEAD $cached_head != pinned $ENVOY_SRC_COMMIT - re-cloning" >&2
+        rm -rf "$src"
+    fi
+fi
+if [ ! -d "$src/.git" ]; then
+    git clone --depth 1 --branch "v$ENVOY_VER" https://github.com/envoyproxy/envoy.git "$src"
+fi
+cd "$src"
+head="$(git rev-parse HEAD 2>/dev/null || true)"
+if [ "$head" != "$ENVOY_SRC_COMMIT" ]; then
+    echo "build-envoy: ERROR envoy source HEAD $head does not match pinned commit $ENVOY_SRC_COMMIT (tag v$ENVOY_VER may have been re-pointed upstream)" >&2
+    exit 1
+fi
+
+# --- 3. patch: register riscv64 / loongarch64 as Linux CPU config_settings ---
+python3 - "$arch" <<'PY'
+import re, sys
+p = "bazel/BUILD"; s = open(p).read()
+if "name = \"linux_riscv64\"" not in s:
+    anchor = 'config_setting(\n    name = "linux",'
+    inject = '''config_setting(
+    name = "linux_riscv64",
+    constraint_values = [
+        "@platforms//cpu:riscv64",
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
+    name = "linux_loongarch64",
+    constraint_values = [
+        "@platforms//cpu:loongarch64",
+        "@platforms//os:linux",
+    ],
+)
+
+'''
+    s = s.replace(anchor, inject + anchor, 1)
+    s = s.replace('        ":linux_s390x",\n    ],\n)',
+                  '        ":linux_s390x",\n        ":linux_riscv64",\n        ":linux_loongarch64",\n    ],\n)', 1)
+    open(p, "w").write(s)
+    print("patched bazel/BUILD: linux_riscv64 + linux_loongarch64 config_settings")
+PY
+
+# --- 4. patch: bump @platforms 1.0.0 -> 1.1.0 (1.0.0 lacks the loongarch64 cpu constraint) ---
+python3 - "$PLATFORMS_VER" "$PLATFORMS_SHA" <<'PY'
+import sys
+ver, sha = sys.argv[1], sys.argv[2]
+p = "bazel/repository_locations.bzl"; s = open(p).read()
+s = s.replace('''    platforms = dict(
+        version = "1.0.0",
+        sha256 = "852b71bfa15712cec124e4a57179b6bc95d59fdf5052945f5d550e072501a769",''',
+    f'''    platforms = dict(
+        version = "{ver}",
+        sha256 = "{sha}",''', 1)
+open(p, "w").write(s)
+print("patched repository_locations.bzl: platforms ->", ver)
+PY
+
+# --- 4b. BoringSSL: recognize loongarch64 ---
+# The pinned BoringSSL target.h enumerates x86/arm/riscv/mips/... but not
+# loongarch64, so every TU that includes it fails with "Unknown target CPU" on the
+# loong build (riscv64 already has a case). Add a no-asm loongarch64 case (parallel
+# to riscv64) through the repository patch list BoringSSL is already fetched with.
+cat > bazel/boringssl-loongarch64-target.patch <<'PATCH'
+--- a/include/openssl/target.h
++++ b/include/openssl/target.h
+@@ -45,6 +45,11 @@
+ #define OPENSSL_RISCV64
+ #elif defined(__riscv) && __SIZEOF_POINTER__ == 4
+ #define OPENSSL_32_BIT
++#elif defined(__loongarch__) && __SIZEOF_POINTER__ == 8
++#define OPENSSL_64_BIT
++#define OPENSSL_LOONGARCH64
++#elif defined(__loongarch__) && __SIZEOF_POINTER__ == 4
++#define OPENSSL_32_BIT
+ #elif defined(__pnacl__)
+ #define OPENSSL_32_BIT
+ #define OPENSSL_PNACL
+PATCH
+grep -q "boringssl-loongarch64-target.patch" bazel/repositories.bzl || \
+    sed -i 's#\("@envoy//bazel:boringssl-bssl-compat.patch",\)#\1\n            "@envoy//bazel:boringssl-loongarch64-target.patch",#' bazel/repositories.bzl
+
+# --- 4c. brotli: no "small" code model on loongarch64 ---
+# brotli's platform.h enables __attribute__((model("small"))) whenever the compiler
+# has the model attribute (clang does), but loongarch64 has no "small" code model
+# (only normal/medium/large) - "code model 'small' is not supported". Exclude
+# loongarch so BROTLI_MODEL is a no-op there (x86/rv64 keep it). _brotli() has no
+# patches list, so add one.
+cat > bazel/brotli-loongarch64-model.patch <<'PATCH'
+--- a/c/common/platform.h
++++ b/c/common/platform.h
+@@ -668,4 +668,4 @@
+-#if BROTLI_GNUC_HAS_ATTRIBUTE(model, 3, 0, 3)
++#if BROTLI_GNUC_HAS_ATTRIBUTE(model, 3, 0, 3) && !defined(__loongarch__)
+ #define BROTLI_MODEL(M) __attribute__((model(M)))
+ #else
+ #define BROTLI_MODEL(M) /* M */
+PATCH
+python3 - <<'PY'
+p = "bazel/repositories.bzl"; s = open(p).read()
+if "brotli-loongarch64-model.patch" not in s:
+    s = s.replace(
+        'def _brotli():\n    external_http_archive(\n        name = "brotli",\n    )',
+        'def _brotli():\n    external_http_archive(\n        name = "brotli",\n        patches = ["@envoy//bazel:brotli-loongarch64-model.patch"],\n        patch_args = ["-p1"],\n    )', 1)
+    open(p, "w").write(s)
+    print("registered brotli-loongarch64-model.patch in _brotli()")
+PY
+
+# --- 5. trim extensions: drop the families that need a per-arch runtime with no
+# rv64/loong64 port, or a toolchain the cross build cannot satisfy:
+#   wasm (V8/WAMR/wasmtime), lua (LuaJIT), golang (cgo filter), dynamic_modules
+#   (Rust ABI), hickory (Rust DNS resolver), and the datadog / opentelemetry
+#   tracer families (dd-trace-cpp pulls <valarray>, which GNU libstdc++ 11 exposes
+#   in a form clang rejects; opentelemetry pulls cel-cpp / otel-cpp). None are on
+#   the gateway data path the carpet exercises.
+python3 - <<'PY'
+import re
+p = "source/extensions/extensions_build_config.bzl"
+out, n = [], 0
+drop = re.compile(r'dynamic_module|wasm|lua|golang|hickory|datadog|opentelemetry')
+for line in open(p):
+    st = line.lstrip()
+    if st.startswith('"envoy.') and drop.search(line):
+        out.append("    # [starry-rvloong dropped] " + st); n += 1
+    else:
+        out.append(line)
+open(p, "w").write("".join(out))
+print("trimmed", n, "extension entries (wasm/lua/golang/dynamic_modules/hickory/datadog/opentelemetry)")
+PY
+
+# --- 5b. drop Envoy's -Werror ---
+# envoy_cc_library appends envoy_copts() (-Wextra -Werror ...) after our --copt, so a
+# global -Wno-error/-Wno-sign-compare copt cannot override it. Envoy's strict warning
+# set is validated only on its supported glibc targets; on musl/rv64/loong64 a few
+# benign pedantic warnings (e.g. -Wsign-compare from differing libc typedefs) would
+# abort the build. Drop -Werror from envoy_copts - warnings stay visible. Idempotent.
+sed -i '/^[[:space:]]*"-Werror",[[:space:]]*$/d' bazel/envoy_internal.bzl
+grep -q '"-Werror"' bazel/envoy_internal.bzl \
+    && echo "warn: -Werror still present in bazel/envoy_internal.bzl" >&2 \
+    || echo "dropped -Werror from envoy_copts"
+
+# --- 6. Bazel cross cc_toolchain (clang-18 + musl cross) ---
+tc="bazel/starry_cross/$arch"; mkdir -p "$tc/bin"
+sysroot="$cross/$triple"
+cat > "$tc/bin/cc" <<EOF
+#!/bin/sh
+exec "$clang_bin" --target=$triple --sysroot=$sysroot --gcc-toolchain=$cross \\
+  -B$cross/lib/gcc/$triple/$gcc_ver -B$sysroot/bin -fuse-ld=$cross/bin/$triple-ld \\
+  ${cxx_overlay:+-isystem "$cxx_overlay"} "\$@"
+EOF
+cat > "$tc/bin/cxx" <<EOF
+#!/bin/sh
+exec "${clang_bin}++" --target=$triple --sysroot=$sysroot --gcc-toolchain=$cross \\
+  -B$cross/lib/gcc/$triple/$gcc_ver -B$sysroot/bin -fuse-ld=$cross/bin/$triple-ld -stdlib=libstdc++ \\
+  ${cxx_overlay:+-isystem "$cxx_overlay"} "\$@"
+EOF
+chmod +x "$tc/bin/cc" "$tc/bin/cxx"
+# Real exec wrappers (not symlinks): bazel's linux-sandbox will not resolve a
+# staged symlink pointing outside the workspace, so directly-invoked tools like
+# ar/strip must be scripts that exec the absolute cross-tool path.
+for t in ar as ld nm objcopy objdump strip ranlib readelf; do
+    [ -x "$cross/bin/$triple-$t" ] && { rm -f "$tc/bin/$t"; printf '#!/bin/sh\nexec "%s" "$@"\n' "$cross/bin/$triple-$t" > "$tc/bin/$t"; chmod +x "$tc/bin/$t"; }
+done
+for t in dwp gcov; do [ -e "$tc/bin/$t" ] || { printf '#!/bin/sh\nexit 0\n' > "$tc/bin/$t"; chmod +x "$tc/bin/$t"; }; done
+
+cpu="$arch"; [ "$arch" = riscv64 ] && bzlcpu=riscv64 || bzlcpu=loongarch64
+# clang builtin/resource include dir. With -no-canonical-prefixes clang derives it
+# relative to the invoked binary (e.g. /usr/bin/clang-18 -> /usr/lib/clang/N),
+# which can differ from -print-resource-dir; declare both so bazel treats the
+# compiler's own headers (arm_neon.h, stddef.h, ...) as builtin instead of raising
+# absolute-path include violations.
+clang_major="$("$clang_bin" -dumpversion | cut -d. -f1)"
+nc_resinc="$(dirname "$(dirname "$clang_bin")")/lib/clang/$clang_major/include"
+cat > "bazel/starry_cross/BUILD" <<EOF
+load(":cc_toolchain_config.bzl", "cc_toolchain_config")
+package(default_visibility = ["//visibility:public"])
+platform(name = "$arch", constraint_values = ["@platforms//cpu:$bzlcpu", "@platforms//os:linux"])
+cc_toolchain_config(name = "${arch}_config", target_cpu = "$bzlcpu",
+    tool_dir = "$arch/bin",
+    builtin_includes = ["$cross", "$cxx_overlay", "$($clang_bin -print-resource-dir)/include", "$nc_resinc"])
+filegroup(name = "${arch}_files", srcs = glob(["$arch/bin/**"]))
+cc_toolchain(name = "${arch}_cc", toolchain_config = ":${arch}_config",
+    all_files = ":${arch}_files", ar_files = ":${arch}_files", as_files = ":${arch}_files",
+    compiler_files = ":${arch}_files", dwp_files = ":${arch}_files",
+    linker_files = ":${arch}_files", objcopy_files = ":${arch}_files", strip_files = ":${arch}_files",
+    supports_param_files = 0)
+toolchain(name = "${arch}_toolchain",
+    exec_compatible_with = ["@platforms//cpu:x86_64", "@platforms//os:linux"],
+    target_compatible_with = ["@platforms//cpu:$bzlcpu", "@platforms//os:linux"],
+    toolchain = ":${arch}_cc", toolchain_type = "@bazel_tools//tools/cpp:toolchain_type")
+EOF
+cp "$(dirname "$0")/starry-cross-cc-toolchain-config.bzl" "bazel/starry_cross/cc_toolchain_config.bzl" 2>/dev/null || \
+cat > "bazel/starry_cross/cc_toolchain_config.bzl" <<'EOF'
+load("@bazel_tools//tools/cpp:cc_toolchain_config_lib.bzl", "feature", "flag_group", "flag_set", "tool_path")
+load("@bazel_tools//tools/build_defs/cc:action_names.bzl", "ACTION_NAMES")
+_C = [ACTION_NAMES.c_compile, ACTION_NAMES.cpp_compile, ACTION_NAMES.cpp_header_parsing,
+      ACTION_NAMES.cpp_module_compile, ACTION_NAMES.assemble, ACTION_NAMES.preprocess_assemble]
+_L = [ACTION_NAMES.cpp_link_executable, ACTION_NAMES.cpp_link_dynamic_library,
+      ACTION_NAMES.cpp_link_nodeps_dynamic_library]
+def _impl(ctx):
+    t = ctx.attr.tool_dir
+    tp = [tool_path(name = n, path = t + "/" + b) for n, b in [
+        ("gcc", "cc"), ("cpp", "cc"), ("ar", "ar"), ("ld", "ld"), ("nm", "nm"),
+        ("objcopy", "objcopy"), ("objdump", "objdump"), ("strip", "strip"),
+        ("gcov", "gcov"), ("dwp", "dwp")]]
+    df = feature(name = "default_flags", enabled = True, flag_sets = [
+        flag_set(actions = _C, flag_groups = [flag_group(flags = [
+            "-no-canonical-prefixes", "-fPIC", "-Wno-unused-command-line-argument"])]),
+        flag_set(actions = _L, flag_groups = [flag_group(flags = ["-no-canonical-prefixes", "-lm"])])])
+    return cc_common.create_cc_toolchain_config_info(
+        ctx = ctx, toolchain_identifier = "starry-" + ctx.attr.target_cpu,
+        host_system_name = "local", target_system_name = ctx.attr.target_cpu + "-linux-musl",
+        target_cpu = ctx.attr.target_cpu, target_libc = "musl", compiler = "clang",
+        abi_version = "clang-18", abi_libc_version = "musl", tool_paths = tp,
+        cxx_builtin_include_directories = ctx.attr.builtin_includes,
+        features = [df, feature(name = "opt"), feature(name = "dbg"),
+                    feature(name = "supports_pic", enabled = True)])
+cc_toolchain_config = rule(implementation = _impl, provides = [CcToolchainConfigInfo], attrs = {
+    "target_cpu": attr.string(mandatory = True), "tool_dir": attr.string(mandatory = True),
+    "builtin_includes": attr.string_list(mandatory = True)})
+EOF
+
+cat > "starry-cross.bazelrc" <<EOF
+build --incompatible_enable_cc_toolchain_resolution
+build --extra_toolchains=//bazel/starry_cross:${arch}_toolchain
+build --define=wasm=disabled
+build --//bazel:http3=false
+build --define=tcmalloc=disabled
+build --define=signal_trace=disabled
+build --define=hot_restart=disabled
+build --define=google_grpc=disabled
+build --define=deprecated_features=disabled
+build --copt=-Wno-unused-command-line-argument
+build --host_copt=-Wno-unused-command-line-argument
+# flatbuffers keys its locale-aware strtoll_l/strtoull_l/strtod_l on _XOPEN_VERSION,
+# which musl reports without providing the *_l functions; force the portable path.
+build --copt=-DFLATBUFFERS_LOCALE_INDEPENDENT=0
+build --host_copt=-DFLATBUFFERS_LOCALE_INDEPENDENT=0
+# Envoy compiles its own sources with -Werror and a strict -Wextra set validated
+# only on its supported (glibc) targets; on the musl/rv64/loong64 cross target a
+# few benign pedantic warnings (e.g. -Wsign-compare from differing libc typedefs)
+# would otherwise abort the build. Downgrade -Werror to warnings - correctness is
+# gated by the runtime carpet, not by these host-platform lint flags.
+build --copt=-Wno-error
+build --host_copt=-Wno-error
+# quiche (compiled even with http3 off) uses int32_t via transitive includes that
+# the loong cross's newer gcc-13 libstdc++ no longer pulls in ("unknown type name
+# 'int32_t'"); force-include <cstdint> for quiche's C++ TUs. Harmless on the rv
+# cross (gcc-11 already provides it).
+build --per_file_copt=external/quiche/.*@-include,cstdint
+build --verbose_failures
+EOF
+
+# --- 7. prefetch the hermetic host LLVM (exec-config compiler) into a distdir ---
+# Envoy's WORKSPACE pulls clang+llvm-18.1.8 (~1GB) for the exec toolchain that
+# builds host tools (protoc, ...). Prefetching avoids flaky mid-download aborts.
+distdir="$work/distdir"; mkdir -p "$distdir"
+llvm_tar="clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
+llvm_sha=54ec30358afcc9fb8aa74307db3046f5187f9fb89fb37064cdde906e062ebf36
+if ! echo "$llvm_sha  $distdir/$llvm_tar" | sha256sum -c - >/dev/null 2>&1; then
+    curl -fL -C - --retry 10 --retry-all-errors -o "$distdir/$llvm_tar" \
+        "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/$llvm_tar"
+    echo "$llvm_sha  $distdir/$llvm_tar" | sha256sum -c -
+fi
+
+# --- 7b. libtinfo.so.5 for the prebuilt LLVM host toolchain ---
+# The clang+llvm-18.1.8 exec toolchain links libtinfo.so.5 (ncurses5), which
+# modern distros (Ubuntu 24.04) no longer ship. Unprivileged fix: cache the lib
+# under $work/lib/ and point Bazel's exec actions at it via --action_env. If
+# patchelf is available, also embed the rpath into the clang binary directly so
+# sandbox environments that do not inherit LD_LIBRARY_PATH still work.
+libtinfo_lib="$work/lib"
+mkdir -p "$libtinfo_lib"
+if ! ldconfig -p 2>/dev/null | grep -q 'libtinfo\.so\.5\b' && \
+   [ ! -f "$libtinfo_lib/libtinfo.so.5" ]; then
+    deb="$work/libtinfo5.deb"
+    for u in \
+        https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.2-0ubuntu2.1_amd64.deb \
+        https://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.2-0ubuntu2.1_amd64.deb \
+        https://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb ; do
+        curl -fsSL --retry 3 "$u" -o "$deb" && break
+    done
+    [ -f "$deb" ] || { echo "build: could not fetch libtinfo5.deb" >&2; exit 1; }
+    tmpx="$work/libtinfo5-x"; rm -rf "$tmpx"; mkdir -p "$tmpx"
+    dpkg-deb -x "$deb" "$tmpx" 2>/dev/null || ( cd "$tmpx" && ar x "$deb" && tar -xf data.tar.* )
+    so="$(find "$tmpx" -name 'libtinfo.so.5.*' -type f | head -1)"
+    [ -n "$so" ] || { echo "build: libtinfo.so.5.* not found in deb" >&2; exit 1; }
+    install -m0644 "$so" "$libtinfo_lib/libtinfo.so.5"
+    rm -rf "$tmpx" "$deb"
+    echo "cached libtinfo.so.5 -> $libtinfo_lib (no system install)"
+fi
+# Propagate into every Bazel action: mount our lib dir inside the sandbox so
+# LD_LIBRARY_PATH can reach it even with linux-sandbox's mount namespace.
+if ! ldconfig -p 2>/dev/null | grep -q 'libtinfo\.so\.5\b' && \
+   [ -f "$libtinfo_lib/libtinfo.so.5" ]; then
+    # --sandbox_add_mount_pair mounts the host path at the same path inside the
+    # sandbox; combined with --action_env the exec clang-18 can dlopen libtinfo.
+    echo "build --sandbox_add_mount_pair=$libtinfo_lib:$libtinfo_lib" >> starry-cross.bazelrc
+    echo "build --action_env=LD_LIBRARY_PATH=$libtinfo_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
+        >> starry-cross.bazelrc
+    # Belt-and-suspenders: if patchelf is available and the Bazel output_base
+    # already holds an extracted LLVM repo (from a prior run), bake $ORIGIN/../lib
+    # into the clang-18 rpath so the binary carries the hint independently.
+    if command -v patchelf >/dev/null 2>&1; then
+        _ob="$("${BAZEL:-bazel}" info output_base 2>/dev/null || true)"
+        _llvm="$_ob/external/clang_llvm_18_1_8_x86_64_linux_gnu_ubuntu_18_04"
+        if [ -d "$_llvm/bin" ]; then
+            mkdir -p "$_llvm/lib"
+            cp -n "$libtinfo_lib/libtinfo.so.5" "$_llvm/lib/" 2>/dev/null || true
+            for _cb in "$_llvm/bin/clang-18" "$_llvm/bin/clang"; do
+                [ -f "$_cb" ] && patchelf --add-rpath '$ORIGIN/../lib' "$_cb" 2>/dev/null && \
+                    echo "patchelf: rpath added to $(basename "$_cb") in output_base"
+            done
+        fi
+    fi
+fi
+
+# --- 8. build ---
+BAZEL="${BAZEL:-bazel}"
+export USE_BAZEL_VERSION="$(cat .bazelversion)"
+# Link with LLVM lld, not the musl GNU ld: the final envoy-static link wraps ~1400
+# whole-archive groups whose objects carry tens of thousands of -ffunction-sections
+# sections; old GNU ld/BFD spuriously rejects a member ("... is not an object") on
+# that scale, while lld (Envoy's own linker) handles it. --linkopt only re-keys the
+# link action, so it does not invalidate the compiled objects. lld ships with clang.
+# The exe link runs through the C-driver cc wrapper (no -stdlib=libstdc++), so add
+# -lstdc++ explicitly; dynamic libstdc++.so.6 is used (GCC's static libstdc++.a has
+# .eh_frame relocations into discarded COMDAT sections that lld rejects) and the app
+# prebuild stages libstdc++.so.6 alongside the other NEEDED sonames.
+"$BAZEL" --bazelrc=starry-cross.bazelrc build -c opt --define=no_debug_info=1 --fission=no \
+    --linkopt=-fuse-ld=lld --linkopt=-lstdc++ \
+    --distdir="$distdir" \
+    --jobs="${JOBS:-6}" --local_resources=memory="${RAM_MB:-6144}" \
+    --platforms="//bazel/starry_cross:$arch" \
+    //source/exe:envoy-static
+
+install -Dm0755 "bazel-bin/source/exe/envoy-static" "$out_dir/envoy-$ENVOY_VER-linux-$arch"
+echo "built: $out_dir/envoy-$ENVOY_VER-linux-$arch"
+file "$out_dir/envoy-$ENVOY_VER-linux-$arch" 2>/dev/null || true

--- a/apps/starry/higress/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/higress/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,10 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "axplat-dyn/efi",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/higress/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/higress/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,12 @@
+target = "riscv64gc-unknown-none-elf"
+log = "Warn"
+features = [
+  "ax-runtime/rtc",
+  "ax-driver/serial",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+]

--- a/apps/starry/higress/prebuild.sh
+++ b/apps/starry/higress/prebuild.sh
@@ -3,15 +3,22 @@
 # StarryOS.
 #
 # higress standalone = the official Envoy release driven by a static bootstrap
-# (no xDS control plane). Envoy ships prebuilt ONLY for glibc x86_64 + aarch64
-# (github.com/envoyproxy/envoy/releases); there is no riscv64 / loongarch64 port
-# upstream, so this app is x86_64 + aarch64 only (see README.md).
+# (no xDS control plane). Envoy ships prebuilt ELFs only for glibc x86_64 +
+# aarch64 (github.com/envoyproxy/envoy/releases), so those two run the stock
+# release binary directly. There is no upstream riscv64 / loongarch64 build, so
+# for those two this script source-builds Envoy 1.38.3 from pinned sources with
+# clang-18 against a musl cross sysroot (assets/build-envoy-rvloong.sh, linked
+# with lld), producing a musl-dynamic ELF whose interpreter /lib/ld-musl-<arch>.so.1
+# the Alpine base rootfs already provides. The source build is cached under
+# HIGRESS_CACHE so it runs once.
 #
-# StarryOS runs the stock glibc-dynamic Envoy ELF directly. This script is fully
-# self-contained: it never relies on in-guest networking (apk) at runtime. It
-# stages, into the overlay:
-#   - the Envoy binary + the exact glibc runtime its ELF header asks for
-#     (readelf-driven, same technique as apps/starry/glibc-dynamic-smoke);
+# The script is fully self-contained: it never relies on in-guest networking (apk)
+# at runtime. It stages, into the overlay:
+#   - the Envoy binary + the exact runtime libraries its ELF header asks for
+#     (readelf-driven): the glibc loader + libs from the arch's <arch>-linux-gnu
+#     cross sysroot for x86_64/aarch64, or libstdc++.so.6 + libgcc_s.so.1 from the
+#     musl cross sysroot for riscv64/loongarch64 (musl libc + loader come from the
+#     Alpine base);
 #   - `echod`, a tiny static-musl HTTP echo backend cross-compiled from source
 #     (the Alpine base busybox has no `httpd` applet);
 #   - the `openssl` CLI (+ libssl/libcrypto), pulled from the matching Alpine
@@ -29,6 +36,8 @@ cache_root="${HIGRESS_CACHE:-${HOME:-/root}/.cache/starry-higress-carpet}"
 ENVOY_VER=1.38.3
 ALPINE_BRANCH=v3.23
 ALPINE_MIRROR=https://dl-cdn.alpinelinux.org/alpine
+
+envoy_source_build=0
 case "$arch" in
     x86_64)
         envoy_asset="x86_64"
@@ -44,59 +53,108 @@ case "$arch" in
         alpine_arch="aarch64"
         envoy_sha=eff9766ce1a7af71c38a6d4587367621753049ae3df1bde5b6b9e695752f3167
         ;;
+    riscv64)
+        envoy_source_build=1
+        musl_triple="riscv64-linux-musl"
+        musl_cc="riscv64-linux-musl-gcc"
+        alpine_arch="riscv64"
+        ;;
+    loongarch64)
+        envoy_source_build=1
+        musl_triple="loongarch64-linux-musl"
+        musl_cc="loongarch64-linux-musl-gcc"
+        alpine_arch="loongarch64"
+        ;;
     *)
-        echo "prebuild: higress ships x86_64 + aarch64 only; upstream Envoy has no $arch build" >&2
+        echo "prebuild: unsupported arch $arch" >&2
         exit 1
         ;;
 esac
 
-command -v "${gcc_prefix}-gcc" >/dev/null 2>&1 || { echo "prebuild: ${gcc_prefix}-gcc not found" >&2; exit 1; }
 command -v "$musl_cc" >/dev/null 2>&1 || { echo "prebuild: $musl_cc not found (source .starry-env.sh)" >&2; exit 1; }
 command -v readelf >/dev/null 2>&1 || { echo "prebuild: readelf not found" >&2; exit 1; }
 command -v openssl >/dev/null 2>&1 || { echo "prebuild: openssl not found" >&2; exit 1; }
 command -v curl >/dev/null 2>&1 || { echo "prebuild: curl not found" >&2; exit 1; }
 
-# --- 1. fetch the official Envoy binary (reproducible: pinned version + sha256) ---
-envoy_bin="$cache_root/envoy-${ENVOY_VER}-linux-${envoy_asset}"
-verify_sha() { echo "${envoy_sha}  ${envoy_bin}" | sha256sum -c - >/dev/null 2>&1; }
-if [[ ! -f "$envoy_bin" ]] || ! verify_sha; then
-    mkdir -p "$cache_root"
-    url="https://github.com/envoyproxy/envoy/releases/download/v${ENVOY_VER}/envoy-${ENVOY_VER}-linux-${envoy_asset}"
-    echo "prebuild: fetching $url ..."
-    curl -fsSL --retry 3 "$url" -o "$envoy_bin"
-    verify_sha || { echo "prebuild: Envoy SHA256 mismatch for $envoy_bin" >&2; exit 1; }
+# --- 1. obtain the Envoy binary + install it into the overlay ---
+if [[ "$envoy_source_build" == "1" ]]; then
+    # riscv64 / loongarch64: no upstream build - source-build from pinned Envoy
+    # sources (clang-18 + musl cross, lld), cached under $cache_root. See
+    # assets/build-envoy-rvloong.sh and README.md.
+    command -v "${musl_triple}-gcc" >/dev/null 2>&1 || { echo "prebuild: ${musl_triple}-gcc not found (source .starry-env.sh)" >&2; exit 1; }
+    musl_root=$(dirname "$(dirname "$(command -v "${musl_triple}-gcc")")")
+    envoy_bin="$cache_root/envoy-${ENVOY_VER}-linux-${arch}"
+    if [[ ! -x "$envoy_bin" ]]; then
+        echo "prebuild: no cached $arch Envoy; source-building (one-time, long)..."
+        mkdir -p "$cache_root"
+        MUSL_CROSS="$musl_root" bash "$app_dir/assets/build-envoy-rvloong.sh" "$arch" "$cache_root"
+    fi
+    [[ -x "$envoy_bin" ]] || { echo "prebuild: source build did not produce $envoy_bin" >&2; exit 1; }
+    # The bazel output keeps debug info (~380MB); strip it for the rootfs image.
+    "${musl_triple}-strip" -s "$envoy_bin" -o "$cache_root/envoy-stripped-$arch"
+    install -Dm0755 "$cache_root/envoy-stripped-$arch" "$overlay_dir/usr/bin/envoy"
+else
+    envoy_bin="$cache_root/envoy-${ENVOY_VER}-linux-${envoy_asset}"
+    verify_sha() { echo "${envoy_sha}  ${envoy_bin}" | sha256sum -c - >/dev/null 2>&1; }
+    if [[ ! -f "$envoy_bin" ]] || ! verify_sha; then
+        mkdir -p "$cache_root"
+        url="https://github.com/envoyproxy/envoy/releases/download/v${ENVOY_VER}/envoy-${ENVOY_VER}-linux-${envoy_asset}"
+        echo "prebuild: fetching $url ..."
+        curl -fsSL --retry 3 "$url" -o "$envoy_bin"
+        verify_sha || { echo "prebuild: Envoy SHA256 mismatch for $envoy_bin" >&2; exit 1; }
+    fi
+    install -Dm0755 "$envoy_bin" "$overlay_dir/usr/bin/envoy"
 fi
-install -Dm0755 "$envoy_bin" "$overlay_dir/usr/bin/envoy"
 
-# --- 2. stage the glibc runtime the Envoy ELF asks for ---
-# Read the interpreter + NEEDED sonames straight from the Envoy binary so the
-# overlay carries exactly what it loads (libc/libm/librt/libdl/libpthread + ld).
-interp=$(readelf -l "$envoy_bin" | sed -n 's/.*Requesting program interpreter: \(.*\)]/\1/p')
+# --- 2. stage the runtime libraries the Envoy ELF asks for ---
+# Read the interpreter + NEEDED sonames straight from the installed binary so the
+# overlay carries exactly what it loads.
+interp=$(readelf -l "$overlay_dir/usr/bin/envoy" | sed -n 's/.*Requesting program interpreter: \(.*\)]/\1/p')
 [[ -n "$interp" ]] || { echo "prebuild: no PT_INTERP in Envoy binary" >&2; exit 1; }
 echo "prebuild: Envoy interpreter: $interp"
-
 ld_soname=$(basename "$interp")
-sysroot=$("${gcc_prefix}-gcc" -print-sysroot)
 
-# The loader itself lands at its ELF-declared interpreter path. -print-file-name
-# resolves it out of the cross sysroot (a native $sysroot$interp only exists when
-# building for the host arch).
-ld_path=$("${gcc_prefix}-gcc" -print-file-name="$ld_soname")
-[[ -f "$ld_path" ]] || ld_path="$sysroot$interp"
-[[ -f "$ld_path" ]] || { echo "prebuild: loader $ld_soname not found" >&2; exit 1; }
-install -Dm0755 "$(readlink -f "$ld_path")" "$overlay_dir$interp"
-
-# Every other NEEDED soname lands in /lib (the runner also exports LD_LIBRARY_PATH).
-readelf -d "$envoy_bin" | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p' | while read -r soname; do
-    [[ "$soname" == "$ld_soname" ]] && continue
-    src=$("${gcc_prefix}-gcc" -print-file-name="$soname")
-    [[ -f "$src" ]] || { echo "prebuild: NEEDED lib $soname not found in $gcc_prefix sysroot" >&2; exit 1; }
-    # -print-file-name may hand back a linker script or a versioned real file;
-    # copy the resolved regular file under its soname.
-    real=$(readlink -f "$src")
-    install -Dm0755 "$real" "$overlay_dir/lib/$soname"
-    echo "prebuild: staged $soname <- $real"
-done
+if [[ "$envoy_source_build" == "1" ]]; then
+    # musl-dynamic: the interpreter /lib/ld-musl-<arch>.so.1 and libc.so are the
+    # Alpine base musl itself; only the C++ runtime the binary pulls in
+    # (libstdc++.so.6 and, transitively, libgcc_s.so.1) has to be staged, resolved
+    # from the musl cross sysroot.
+    stage_musl_lib() { # soname
+        local soname="$1" real dreal dep
+        case "$soname" in libc.so|"$ld_soname") return 0 ;; esac
+        [[ -e "$overlay_dir/usr/lib/$soname" ]] && return 0
+        real=$(readlink -f "$("${musl_triple}-gcc" -print-file-name="$soname")")
+        [[ -f "$real" ]] || { echo "prebuild: NEEDED lib $soname not found in musl cross sysroot" >&2; exit 1; }
+        install -Dm0755 "$real" "$overlay_dir/usr/lib/$soname"
+        echo "prebuild: staged $soname <- $real"
+        # follow the soname's own NEEDED (libstdc++ -> libgcc_s); one level suffices
+        readelf -d "$real" | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p' | while read -r dep; do
+            case "$dep" in libc.so|"$ld_soname"|"$soname") continue ;; esac
+            [[ -e "$overlay_dir/usr/lib/$dep" ]] && continue
+            dreal=$(readlink -f "$("${musl_triple}-gcc" -print-file-name="$dep")")
+            [[ -f "$dreal" ]] && { install -Dm0755 "$dreal" "$overlay_dir/usr/lib/$dep"; echo "prebuild: staged $dep <- $dreal"; }
+        done
+    }
+    readelf -d "$overlay_dir/usr/bin/envoy" | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p' | while read -r soname; do
+        stage_musl_lib "$soname"
+    done
+else
+    # glibc: stage the declared loader plus every NEEDED soname from the arch's
+    # <arch>-linux-gnu cross sysroot.
+    sysroot=$("${gcc_prefix}-gcc" -print-sysroot)
+    ld_path=$("${gcc_prefix}-gcc" -print-file-name="$ld_soname")
+    [[ -f "$ld_path" ]] || ld_path="$sysroot$interp"
+    [[ -f "$ld_path" ]] || { echo "prebuild: loader $ld_soname not found" >&2; exit 1; }
+    install -Dm0755 "$(readlink -f "$ld_path")" "$overlay_dir$interp"
+    readelf -d "$overlay_dir/usr/bin/envoy" | sed -n 's/.*(NEEDED).*\[\(.*\)\]/\1/p' | while read -r soname; do
+        [[ "$soname" == "$ld_soname" ]] && continue
+        src=$("${gcc_prefix}-gcc" -print-file-name="$soname")
+        [[ -f "$src" ]] || { echo "prebuild: NEEDED lib $soname not found in $gcc_prefix sysroot" >&2; exit 1; }
+        real=$(readlink -f "$src")
+        install -Dm0755 "$real" "$overlay_dir/lib/$soname"
+        echo "prebuild: staged $soname <- $real"
+    done
+fi
 
 # --- 3. cross-compile the static-musl echo backend ---
 "$musl_cc" -static -O2 -o "$cache_root/echod-$arch" "$app_dir/backend/echod.c"
@@ -148,4 +206,4 @@ chmod 0644 "$cert_dir"/*.key "$cert_dir"/*.crt
 # --- 7. carpet runner ---
 install -Dm0755 "$app_dir/programs/run-higress.sh" "$overlay_dir/usr/bin/run-higress.sh"
 
-echo "prebuild: higress ready for $arch (Envoy ${ENVOY_VER}, glibc from $gcc_prefix sysroot, echod + openssl staged)"
+echo "prebuild: higress ready for $arch (Envoy ${ENVOY_VER}, echod + openssl staged)"

--- a/apps/starry/higress/programs/run-higress.sh
+++ b/apps/starry/higress/programs/run-higress.sh
@@ -46,18 +46,26 @@ ac() { wget -S -O /dev/null -T 10 "http://127.0.0.1:9901$1" 2>&1 | grep -oE 'HTT
 
 # --- TLS client helpers (openssl s_client, downstream TLS listener :10443) ---
 # tlsq METHOD PATH [EXTRA-HEADER]  -> full HTTP response (status line + headers + body)
+# openssl s_client is a bidirectional relay: after stdin EOF it half-closes and
+# blocks reading the socket until the peer's TLS close_notify arrives. The request
+# response is already complete by then (Connection: close), so bound the wait like
+# the wget helpers' -T, otherwise a slow peer-side shutdown stalls the probe.
 tlsq() {
     { printf '%s %s HTTP/1.1\r\n' "$1" "$2"
       printf 'Host: localhost\r\n'
       [ -n "${3:-}" ] && printf '%s\r\n' "$3"
       printf 'Connection: close\r\n\r\n'
-    } | openssl s_client -connect 127.0.0.1:10443 -quiet 2>/dev/null
+    } | timeout 20 openssl s_client -connect 127.0.0.1:10443 -quiet 2>/dev/null
 }
 tlsinfo() { openssl s_client -connect 127.0.0.1:10443 -servername localhost </dev/null 2>&1; }
 
+# Envoy is a large binary; on the emulated riscv64/loongarch64 targets its
+# startup (extension registration, cluster + listener init) can take a couple of
+# minutes under TCG before the server reaches LIVE, so the readiness budget is
+# generous. It returns as soon as /ready reports LIVE, so fast arches pay nothing.
 wait_ready() { # tries
     i=0
-    while [ "$i" -lt "${1:-60}" ]; do
+    while [ "$i" -lt "${1:-300}" ]; do
         [ "$(ab /ready)" = "LIVE" ] && return 0
         sleep 1; i=$((i+1))
     done
@@ -94,10 +102,10 @@ sleep 2
 
 # --- 3. baseline Envoy (enable_reuse_port:false) ---
 envoy_pid=$(start_envoy "$CONF_DIR/bootstrap.yaml" 1)
-if wait_ready 60; then
+if wait_ready 300; then
     # admin endpoints
     ck_eq  "admin: /ready LIVE"            "$(ab /ready)" "LIVE"
-    ck_has "admin: /stats server.state"    "$(ab /stats)" "server.state"
+    if ab /stats | grep -qF "server.state"; then ok "admin: /stats server.state"; else bad "admin: /stats server.state | missing[server.state]"; fi
     ck_has "admin: /server_info LIVE"      "$(ab /server_info)" "LIVE"
     ck_has "admin: /clusters backend_a"    "$(ab /clusters)" "backend_a"
     listeners=$(ab /listeners)
@@ -146,8 +154,11 @@ if wait_ready 60; then
     rr=""; i=0; while [ "$i" -lt 12 ]; do rr="$rr$(hb /rr)"; i=$((i+1)); done
     ck_has "lb: round_robin hits a"        "$rr" "BACKEND=backend_a"
     ck_has "lb: round_robin hits b"        "$rr" "BACKEND=backend_b"
+    # weighted_clusters picks a cluster by weighted-random per request, so the 2:1
+    # split only shows over a large enough sample; 120 draws keep a>b robust
+    # (P(inversion) < 1e-4) where 40 could invert by chance under the binomial tail.
     ca=0; cb=0; i=0
-    while [ "$i" -lt 40 ]; do
+    while [ "$i" -lt 120 ]; do
         r=$(hb /api/x)
         case "$r" in *backend_a*) ca=$((ca+1)) ;; esac
         case "$r" in *backend_b*) cb=$((cb+1)) ;; esac
@@ -204,9 +215,18 @@ sleep 2
 
 # --- 4. reuse_port:true (exercises SO_REUSEPORT) ---
 envoy_rp_pid=$(start_envoy "$CONF_DIR/bootstrap-reuseport.yaml" 2)
-if wait_ready 60; then
+if wait_ready 300; then
     ck_eq  "reuse_port: /ready LIVE"       "$(ab /ready)" "LIVE"
-    ck_has "reuse_port: listener serves"   "$(hb /)" "BACKEND=backend_a"
+    # The reuse_port data listener (:10000) can accept a beat after admin /ready
+    # first reports LIVE on the freshly restarted server, so give the first
+    # proxied request a few tries before asserting it reaches the backend.
+    rp=""; i=0
+    while [ "$i" -lt 10 ]; do
+        rp=$(hb /)
+        case "$rp" in *BACKEND=backend_a*) break ;; esac
+        sleep 1; i=$((i+1))
+    done
+    ck_has "reuse_port: listener serves"   "$rp" "BACKEND=backend_a"
 else
     echo "  FAIL | reuse_port Envoy did not become ready (SO_REUSEPORT?)"
     tail -40 "$WORK/envoy-2.log" 2>/dev/null || true

--- a/apps/starry/higress/qemu-loongarch64.toml
+++ b/apps/starry/higress/qemu-loongarch64.toml
@@ -1,9 +1,10 @@
 args = [
+    "-machine", "virt",
+    "-cpu", "la464",
     "-nographic",
     "-m", "2048M",
-    "-cpu", "max",
     "-device", "virtio-blk-pci,drive=disk0",
-    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-higress.img",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-higress.img",
     "-device", "virtio-net-pci,netdev=net0",
     "-netdev", "user,id=net0",
 ]

--- a/apps/starry/higress/qemu-riscv64.toml
+++ b/apps/starry/higress/qemu-riscv64.toml
@@ -1,13 +1,13 @@
 args = [
     "-nographic",
     "-m", "2048M",
-    "-cpu", "max",
+    "-cpu", "rv64",
     "-device", "virtio-blk-pci,drive=disk0",
-    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-higress.img",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-higress.img",
     "-device", "virtio-net-pci,netdev=net0",
     "-netdev", "user,id=net0",
 ]
-uefi = true
+uefi = false
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/run-higress.sh"


### PR DESCRIPTION
在已合入的 `apps/starry/higress`（Envoy reverse-proxy carpet）基础上补齐 **riscv64 / loongarch64** 两架构，使 higress 在 StarryOS 四架构单核 qemu 上全部实跑 `TEST PASSED`。

## 源码交叉编译 Envoy（rv64 / loong64）

上游 Envoy 不发布 riscv64 / loongarch64 release，故从 v1.38.3 源码用 clang-18 + musl cross toolchain + lld 交叉编译，产 musl-dynamic PIE 二进制。全部构建修（工具链、`--fission=no`、libtinfo、extension trim、`-Werror` 去除、lld + `-lstdc++`、BoringSSL/brotli/quiche 的 loongarch 分支补齐等）都写进可复现的 `assets/build-envoy-rvloong.sh`；amd64/arm64 保留官方 release 路径。私有 sysroot overlay 与 libtinfo5 均无特权缓存，不修改调用者的外部 toolchain。

## 处理评审阻塞

- **Bazel builtin include**：私有 C++ overlay（patched `bits/range_access.h`）此前经 `-isystem` 引入但未声明进生成的 `cc_toolchain`，Bazel 拒绝其绝对 include 路径。已把 `$cxx_overlay` 加入 `builtin_includes`。
- **启动配置**：`qemu-x86_64.toml` 改 `uefi = true, to_bin = true`、`qemu-loongarch64.toml` 改 `uefi = true`，对齐 dev 重构后 axbuild 的同类 app（apache/nginx），修正 `Error loading uncompressed kernel without PVH ELF Note`。
- 已 rebase 到当前 dev，纳入 #1558（`/proc/pid/comm` + 非阻塞部分 TCP 发送）——Envoy 的大响应（如 admin `/stats` ~79KB）依赖它完整回传。

## 四架构实跑

| arch | Envoy 来源 | 运行时 |
|------|-----------|--------|
| x86_64 / aarch64 | 官方 release | TEST PASSED |
| riscv64 / loongarch64 | 源码交叉编译（clang-18 + musl cross + lld）| TEST PASSED |

四架构单核 qemu 均 `TEST PASSED`，覆盖 CLI（`--version`/`--mode validate`/`--help`）、admin 端点（`/ready` `/stats` `/server_info` `/clusters` `/listeners` `/config_dump` `/certs` prometheus/filter/404）、路由匹配（prefix/exact/safe_regex/query/header）、rewrite（prefix/regex-capture/host）、redirect/direct-response、加权 + round-robin/least-request/random 负载均衡、request/response header 改写、下游/上游 TLS。加权 LB 断言采样量取 120，使 `weighted_clusters` 2:1 的加权随机分布稳健（避免小样本二项尾部误判）。

## 依赖

**Blocked by #1558**（已合入 dev）。
