### PR TITLE
docs(skills): enforce MAINTAINERS.md allowlist and add-only reviewer …

### DIFF
--- a/.claude/skills/reassign-pr-reviewers/SKILL.md
+++ b/.claude/skills/reassign-pr-reviewers/SKILL.md
@@ -7,7 +7,7 @@ description: Use when the user wants to assign or rebalance GitHub pull request 
 
 ## Goal
 
-Update reviewer requests for open PRs according to a project-facing source of truth, such as a GitHub discussion that contains reviewer ownership areas or a concrete PR assignment table. Treat reviewer assignment as a GitHub metadata operation: no code edits, no build/test validation, and no PR review submission.
+Update reviewer requests for open PRs according to the repository reviewer-routing source of truth. Always use `.github/MAINTAINERS.md` as the strict reviewer allowlist: each section maps one or more GitHub reviewer logins from `R:` lines to path hints from `F:` lines and keyword/direction hints from `K:` lines. Treat reviewer assignment as a GitHub metadata operation: no code edits, no build/test validation, and no PR review submission.
 
 ## Source Of Truth
 
@@ -16,14 +16,29 @@ Update reviewer requests for open PRs according to a project-facing source of tr
    gh auth status
    gh repo view --json nameWithOwner,defaultBranchRef,url
    ```
-2. Read the assignment source directly. For a discussion:
+2. Read `.github/MAINTAINERS.md` from the target branch or current worktree before assigning reviewers. It is the local source of truth for PR reviewer routing.
+3. Parse each maintainer section as an ownership rule:
+   - `R:` is the reviewer login to request on GitHub. Use reviewer logins, not maintainer-only `M:` lines, unless the same login is also listed on `R:`.
+   - `F:` is a path or glob hint. Match it against changed PR files.
+   - `K:` is a comma-separated keyword or direction hint. Match these against the PR title, body, changed file paths, crate names, feature names, config names, and obvious filenames from the diff.
+4. Build the allowed human reviewer set only from `R:` lines in `.github/MAINTAINERS.md`. Never request, retain as an ownership target, or infer a human target reviewer outside this allowed set. If another source names a human reviewer that is not present on an `R:` line, report it as ignored.
+5. Prefer explicit keyword matches from `K:` when routing ambiguous PRs. Path matches from `F:` are also valid and should be used when the changed files clearly fall under a maintainer section.
+6. If multiple maintainer sections match by keyword or path, request all matched `R:` reviewers after dropping the PR author. Do not collapse to a single reviewer unless the source of truth or user request says to do so.
+7. If no `K:` or `F:` entry clearly matches a non-draft PR, default the target reviewer to `ZR233`, after confirming `ZR233` is present on an `R:` line. Report this as a fallback assignment, not as ownership evidence.
+8. Skip draft PRs entirely. Do not add or remove reviewers on draft PRs unless the user explicitly says to include drafts.
+
+An external assignment source, such as a GitHub discussion or concrete PR assignment table, may map PRs to ownership areas only when the user explicitly asks for it. It must not expand the reviewer allowlist beyond `.github/MAINTAINERS.md` `R:` lines. Read that source directly. For a discussion:
    ```bash
    gh api graphql \
      -f query='query($owner:String!,$repo:String!,$number:Int!){ repository(owner:$owner,name:$repo){ discussion(number:$number){ title body url author{login} comments(first:100){nodes{author{login} body createdAt}} } } }' \
      -F owner=<owner> -F repo=<repo> -F number=<discussion>
    ```
-3. Prefer explicit per-PR assignments from the source. For open PRs not listed there, infer reviewers from the ownership matrix and the PR's title/files.
-4. Skip or ask before assigning reviewers that are not named in the source or inferable from a clear ownership area.
+
+When an external source is used:
+
+- Prefer explicit per-PR assignments from the source.
+- For open PRs not listed there, infer reviewers from `.github/MAINTAINERS.md` using `K:` keywords first and `F:` paths second.
+- Ignore reviewers that are not listed on an `R:` line in `.github/MAINTAINERS.md`; do not request them even if an external source names them.
 
 ## Gather Current State
 
@@ -31,7 +46,7 @@ List all open PRs and their current reviewer requests:
 
 ```bash
 gh pr list --repo <owner>/<repo> --state open --limit 200 \
-  --json number,title,author,isDraft,reviewRequests,files,updatedAt,url
+  --json number,title,body,author,isDraft,reviewRequests,files,updatedAt,url
 ```
 
 Use the REST endpoint for exact requested reviewer state when applying changes:
@@ -40,7 +55,9 @@ Use the REST endpoint for exact requested reviewer state when applying changes:
 gh api repos/<owner>/<repo>/pulls/<pr>/requested_reviewers
 ```
 
-Important: preserve existing bot review requests unless the user explicitly says to change them. Bot-authored PRs, such as release automation PRs, should normally keep their existing reviewer state.
+Important: preserving existing reviewer requests is mandatory by default unless the user explicitly asks to remove or rebalance reviewers. Existing human reviewer requests may have been assigned manually by an administrator, including reviewers outside `.github/MAINTAINERS.md`; carry them forward as preserved reviewers and never remove them in the default add-only flow. Existing bot review requests are also mandatory to preserve unless the user explicitly says to change bot requests.
+
+Important: skip draft PRs entirely unless the user explicitly asks to include drafts. Record them in the dry run as skipped with reason `draft`.
 
 ## Build A Dry Run
 
@@ -49,16 +66,29 @@ Before writing to GitHub, produce a dry-run table with:
 - PR number and author
 - current requested reviewers
 - target reviewers
+- preserved existing reviewers
+- preserved bot reviewers
 - reviewers to remove
 - reviewers to add
+- matched maintainer section, keyword(s), and/or path hint(s)
+- fallback reviewer, if no maintainer section matched
 - skipped reason, if any
 
 Always drop the PR author from the target reviewer list because GitHub cannot request a review from the author.
 
+When computing add/remove operations, first compute ownership targets from `.github/MAINTAINERS.md`, then union existing reviewer requests into the final desired reviewer state. The default flow is add-only: `reviewers to remove` must be empty unless the user explicitly asks to remove or rebalance reviewer requests. If the user does request removals, existing bot reviewers still must stay requested unless the user explicitly says to change bot requests.
+
+When using `.github/MAINTAINERS.md`, state the routing evidence for every target reviewer:
+
+- `K:` evidence: the specific keyword(s) matched and where they appeared, such as title, body, file path, crate/config name, or diff-visible identifier.
+- `F:` evidence: the specific path/glob hint and changed file(s) that matched.
+- no evidence on a non-draft PR: target `ZR233` as the default fallback reviewer and state that no `K:`/`F:` ownership evidence matched.
+- draft PR: intentionally skip and do not compute add/remove operations.
+
 If a discussion contains both an old concrete assignment table and a broader ownership matrix, say which rule is being used for each PR group:
 
 - listed PRs: use the concrete assignment table
-- newer unlisted PRs: infer from ownership matrix plus files/title
+- newer unlisted PRs: infer from `.github/MAINTAINERS.md` `K:` keywords and `F:` paths
 
 ## Apply Changes
 
@@ -76,7 +106,7 @@ printf '%s\n' '{"reviewers":["<login>"]}' |
   gh api -X DELETE repos/<owner>/<repo>/pulls/<pr>/requested_reviewers --input -
 ```
 
-Apply removals before additions for each PR. Continue across independent PRs, but record each failed operation with the PR number, requested login, and GitHub error.
+In the default add-only flow, do not call the DELETE endpoint because existing reviewer requests must be preserved. If the user explicitly requested removals or a rebalance, apply allowed removals before additions for each PR, while still preserving bot reviewers unless bot removal was explicitly requested. Continue across independent PRs, but record each failed operation with the PR number, requested login, and GitHub error.
 
 ## Permission Handling
 
@@ -108,7 +138,7 @@ Compare final state against the target map. The final response should include:
 - count of open PRs considered
 - PRs changed successfully
 - PRs already matching target
-- PRs intentionally skipped, especially bot-authored PRs or existing bot requests
+- PRs intentionally skipped, especially draft PRs, bot-authored PRs, or preserved existing reviewer requests
 - PRs partially assigned because a target reviewer could not be requested
 - exact blocked reviewer login and GitHub permission/API reason
 

--- a/.claude/skills/review-single-pr/SKILL.md
+++ b/.claude/skills/review-single-pr/SKILL.md
@@ -507,22 +507,41 @@ gh pr view <pr> --json number,reviewDecision,latestReviews
 
 After review submission, request reviewers only when the PR still needs domain follow-up. Base the choice on the actual changed surface, review findings, validation risk, and remaining follow-up.
 
-Read `.github/MAINTAINERS.md` before choosing reviewers. Treat it as the local reviewer source of truth: match PR title, body, changed paths, public APIs, tests, validation commands, and review findings against each entry's `F:` path hints and `K:` keyword hints; request only the matching `R:` logins. Normalize only obvious aliases that map to `.github/MAINTAINERS.md` entries.
+Keep this reviewer request step aligned with `reassign-pr-reviewers`. Read `.github/MAINTAINERS.md` before choosing reviewers. Treat it as the local reviewer source of truth and the strict automatic human reviewer allowlist: only `R:` lines are requestable automatic human reviewers. `M:` lines are ownership metadata and are not reviewer targets unless the same login also appears on `R:`. Do not request, retain as an ownership target, or infer a new human reviewer outside the `R:` allowlist.
 
-Choose at most two reviewers: one for the highest-risk domain and, when useful, one for integration or test coverage. Prefer the most specific matching entry over broad architecture ownership such as `@ZR233`; request `@ZR233` only when broad architecture/platform risk is the primary review need or no more specific entry owns the changed surface. Drop the PR author. Preserve existing bot requests and unrelated human requests unless the user asks to rebalance. If no `.github/MAINTAINERS.md` entry matches, no listed login is requestable, or the mapping is ambiguous, do not invent a reviewer; report the ambiguity.
+Match maintainer sections with `F:` path hints and `K:` keyword hints from the PR title, body, changed paths, public APIs, tests, validation commands, review findings, crate/config/feature names, and obvious diff-visible identifiers. If multiple sections match, target all matched `R:` reviewers. Prefer explicit `K:` evidence for ambiguous PRs, but valid `F:` path evidence is sufficient when the changed files clearly fall under a section.
+
+If no `K:` or `F:` evidence matches a non-draft PR, default the target reviewer to `ZR233`, after confirming `ZR233` appears on an `R:` line. Report this as a fallback assignment, not as ownership evidence.
+
+Skip reviewer request updates for draft PRs unless the user explicitly asks to include drafts. Reviewing a draft is allowed by this skill, but reviewer reassignment for drafts is not.
+
+Preserve all existing reviewer requests by default. Existing human reviewers may have been assigned manually by an administrator, including reviewers outside `.github/MAINTAINERS.md`; carry them forward and do not remove them in the default flow. Existing bot reviewer requests must also be preserved unless the user explicitly says to change bot requests. Bot reviewers are not ownership targets and do not need to appear in `.github/MAINTAINERS.md`.
+
+The default reviewer request update is add-only: compute ownership targets from `.github/MAINTAINERS.md`, union the existing reviewer requests into the final desired reviewer state, and add only missing target reviewers. `reviewers to remove` must be empty unless the user explicitly asks to remove or rebalance reviewer requests. If the user does request removals, still preserve bot reviewers unless bot removal was explicitly requested.
+
+Drop the PR author from new reviewer requests because GitHub cannot request review from the author. Also drop the current GitHub user from new reviewer requests because this workflow just submitted the review.
 
 Before writing reviewer requests, check current reviewer state and permissions:
 
 ```bash
-gh api repos/rcore-os/tgoskits/pulls/<pr>/requested_reviewers
-gh api repos/rcore-os/tgoskits/collaborators/<login>/permission
+gh api repos/<owner>/<repo>/pulls/<pr>/requested_reviewers
+gh api repos/<owner>/<repo>/collaborators/<login>/permission
 ```
 
-Use the REST requested-reviewers API instead of `gh pr edit`, because `gh pr edit` can fail in this repository while querying deprecated Projects classic fields:
+Before applying reviewer request updates, record a single-PR dry run with current reviewers, target reviewers, preserved existing reviewers, preserved bot reviewers, reviewers to add, reviewers to remove, matched `K:`/`F:` evidence or fallback reason, and skipped reason.
+
+Use the REST requested-reviewers API instead of `gh pr edit`, because `gh pr edit` can fail in this repository while querying deprecated Projects classic fields. In the default add-only flow, do not call the DELETE endpoint:
 
 ```bash
 printf '%s\n' '{"reviewers":["<login1>","<login2>"]}' |
-  gh api -X POST repos/rcore-os/tgoskits/pulls/<pr>/requested_reviewers --input -
+  gh api -X POST repos/<owner>/<repo>/pulls/<pr>/requested_reviewers --input -
+```
+
+If the user explicitly requested removals or a rebalance, apply allowed removals before additions for each PR, while still preserving bot reviewers unless bot removal was explicitly requested:
+
+```bash
+printf '%s\n' '{"reviewers":["<login>"]}' |
+  gh api -X DELETE repos/<owner>/<repo>/pulls/<pr>/requested_reviewers --input -
 ```
 
 After assigning, re-query `requested_reviewers` and confirm the intended reviewers are present. If GitHub rejects a reviewer, record the exact login and API or permission error; do not silently substitute someone outside `.github/MAINTAINERS.md`.
@@ -530,7 +549,8 @@ After assigning, re-query `requested_reviewers` and confirm the intended reviewe
 In the final user summary, state:
 
 - which `.github/MAINTAINERS.md` entries matched the PR;
-- which reviewers were requested, already present, skipped, or rejected;
+- which reviewers were requested, already present, preserved, skipped, or rejected;
+- any fallback assignment to `ZR233`;
 - any permission/API limitation;
 - that only GitHub reviewer metadata was changed, when no code files were edited by the assignment step.
 


### PR DESCRIPTION
# 自动分配 PR Reviewer 策略

自动分配 reviewer 的目标是：根据 PR 修改内容，把需要领域知识的人补充到 reviewer 列表里，同时不覆盖人工已经做出的分配。

## 基本原则

自动分配只做“补充”，默认不做“清理”。

也就是说，如果一个 PR 当前已经有 reviewer，不管这个 reviewer 是系统自动分配的、管理员手动分配的，还是历史流程留下的，都默认保留。自动分配只负责根据当前规则追加缺失的 reviewer，不会把已有 reviewer 移除。

bot reviewer 也必须保留。bot reviewer 不参与领域归属判断，也不需要出现在 `.github/MAINTAINERS.md` 中，但只要当前 PR 已经请求了 bot reviewer，就不能因为自动分配流程把它删掉。

## Reviewer 来源

自动分配 reviewer 的唯一可信来源是 `.github/MAINTAINERS.md` 中的 `R:` 行。

`.github/MAINTAINERS.md` 中各字段含义如下：

- `R:` 表示可以被自动请求 review 的 GitHub login。
- `M:` 表示 maintainer 或领域 owner，只是所有权信息；除非同一个 login 也出现在 `R:` 中，否则不会被自动请求 review。
- `F:` 表示路径或 glob 线索，用来根据 PR 修改文件判断所属领域。
- `K:` 表示关键词或方向线索，用来根据 PR 标题、正文、文件路径、crate 名、配置名、功能名、验证命令、review 发现等判断所属领域。

外部讨论、临时分配表或人工说明可以帮助判断 PR 属于哪个领域，但不能引入 `.github/MAINTAINERS.md` 的 `R:` 行之外的新 reviewer。

## 匹配方式

对每个非 draft PR，自动分配流程会根据 PR 内容匹配 `.github/MAINTAINERS.md` 中的维护者 section。

匹配证据主要来自两类：

- `F:` 路径命中：PR 修改的文件落在某个维护者 section 声明的路径范围内。
- `K:` 关键词命中：PR 的标题、正文、修改路径、crate/config/feature 名、验证命令或 review 中发现的问题命中了某个维护者 section 的关键词。

如果多个 section 都有明确证据命中，就请求这些 section 中所有 `R:` reviewer。不会为了减少人数强行只选一个 reviewer。

如果 PR 作者本人出现在目标 reviewer 中，需要去掉，因为 GitHub 不能请求作者 review 自己的 PR。

在单个 PR review 流程中，如果当前用户刚刚提交了 review，也不会再把当前用户作为新的 reviewer 请求。

## 无匹配时的回退

如果一个非 draft PR 没有任何明确的 `F:` 或 `K:` 匹配，就默认回退分配给 `ZR233`。

这个回退只表示“没有找到更具体的领域 owner 时的默认兜底 reviewer”，不表示该 PR 真的属于 `ZR233` 负责的领域。因此在报告中要明确标注为 fallback，而不是 ownership evidence。

回退前需要确认 `ZR233` 确实出现在 `.github/MAINTAINERS.md` 的 `R:` 行中。

## Draft PR

draft PR 默认跳过 reviewer 自动分配。

review 流程可以审查 draft PR，但 reviewer request 更新不处理 draft PR，除非用户明确要求包含 draft。

## 已有 Reviewer 的处理

已有 reviewer 默认全部保留。

原因是：当前 reviewer 可能是管理员手动分配的，也可能来自某次讨论、历史 review 安排或临时协作需求。自动分配流程无法可靠判断这些 reviewer 是否应该被移除，所以默认不删除任何已有 reviewer。

因此默认结果是：

- 已有 human reviewer 保留。
- 已有 bot reviewer 保留。
- 新匹配出来但尚未请求的 reviewer 会被追加。
- 默认不会产生需要移除的 reviewer。

只有当用户明确要求“重新平衡 reviewer”或“移除 reviewer”时，才允许考虑删除已有 human reviewer。即使在这种情况下，bot reviewer 仍然必须保留，除非用户明确要求修改 bot reviewer。

## 应用前检查

在真正修改 GitHub reviewer request 之前，需要先给出 dry run。

dry run 至少应该说明：

- PR 编号和作者
- 当前已有 reviewer
- 根据规则匹配出的目标 reviewer
- 保留的已有 reviewer
- 保留的 bot reviewer
- 准备新增的 reviewer
- 准备移除的 reviewer，默认应为空
- 命中的 `F:` 路径证据或 `K:` 关键词证据
- 如果没有匹配，说明 fallback 到 `ZR233`
- 如果跳过，说明跳过原因，例如 draft PR

这样可以让管理员在真正写入 GitHub 前确认自动分配是否合理。

## 最终效果

自动分配完成后，最终 reviewer 列表应该等于：

已有 reviewer
+ 当前规则匹配出的缺失 reviewer
+ 必要时的 `ZR233` fallback reviewer

默认不会减去任何已有 reviewer。

如果某个 reviewer 因 GitHub 权限或 API 限制无法请求，需要明确报告失败的 login 和原因，不能静默换成其他不在 `.github/MAINTAINERS.md` `R:` 行中的人。
