### PR TITLE
net: support IP_MTU_DISCOVER and flush UDP egress before close

### DIFF
--- a/net/ax-net/src/general.rs
+++ b/net/ax-net/src/general.rs
@@ -33,6 +33,12 @@ use crate::{
 const SO_PRIORITY_UNPRIVILEGED_MAX: i32 = 6;
 const IP_TOS_ECN_MASK: u8 = 0x03;
 
+/// Linux IP_PMTUDISC_WANT: use per-route path-MTU discovery. Default for a fresh
+/// socket, echoed back by getsockopt(IP_MTU_DISCOVER).
+const IP_PMTUDISC_WANT: u8 = 1;
+/// Highest valid IP_PMTUDISC_* mode Linux accepts (IP_PMTUDISC_OMIT).
+const IP_PMTUDISC_MAX: u8 = 5;
+
 /// General options for all sockets.
 pub(crate) struct GeneralOptions {
     /// Whether the socket is non-blocking.
@@ -52,6 +58,9 @@ pub(crate) struct GeneralOptions {
 
     /// IP_TOS value used by protocol sockets when marking outgoing packets.
     ip_tos: AtomicU8,
+    /// IP_MTU_DISCOVER mode (IP_PMTUDISC_*). Stored for Linux ABI compatibility;
+    /// smoltcp does not model path-MTU discovery, so it has no wire effect.
+    ip_mtu_discover: AtomicU8,
     /// Whether recvmsg should report IPv4 TOS as IP_TOS ancillary data.
     recv_tos: AtomicBool,
     /// Whether recvmsg should report IPv6 traffic class as IPV6_TCLASS ancillary data.
@@ -84,6 +93,7 @@ impl GeneralOptions {
             bound_if: AtomicU32::new(0),
 
             ip_tos: AtomicU8::new(0),
+            ip_mtu_discover: AtomicU8::new(IP_PMTUDISC_WANT),
             recv_tos: AtomicBool::new(false),
             recv_traffic_class: AtomicBool::new(false),
             priority: AtomicI32::new(0),
@@ -149,6 +159,21 @@ impl GeneralOptions {
     /// Updates the IPv4 TOS / IPv6 traffic-class byte configured on this socket.
     pub fn set_ip_tos(&self, tos: u8) {
         self.ip_tos.store(tos & !IP_TOS_ECN_MASK, Ordering::Relaxed);
+    }
+
+    /// Returns the IP_MTU_DISCOVER (IP_PMTUDISC_*) mode configured on this socket.
+    pub fn ip_mtu_discover(&self) -> u8 {
+        self.ip_mtu_discover.load(Ordering::Relaxed)
+    }
+
+    /// Updates the IP_MTU_DISCOVER mode. Rejects modes Linux does not define so a
+    /// probing client sees the same EINVAL, then stores the mode for readback.
+    pub fn set_ip_mtu_discover(&self, mode: u8) -> AxResult<()> {
+        if mode > IP_PMTUDISC_MAX {
+            return Err(AxError::from(LinuxError::EINVAL));
+        }
+        self.ip_mtu_discover.store(mode, Ordering::Relaxed);
+        Ok(())
     }
 
     /// Returns whether IPv4 TOS ancillary data is enabled for receive calls.
@@ -277,6 +302,9 @@ impl Configurable for GeneralOptions {
             O::IpTos(tos) => {
                 **tos = self.ip_tos.load(Ordering::Relaxed);
             }
+            O::IpMtuDiscover(mode) => {
+                **mode = self.ip_mtu_discover();
+            }
             O::RecvTos(enabled) => {
                 **enabled = self.recv_tos();
             }
@@ -342,6 +370,9 @@ impl Configurable for GeneralOptions {
             }
             O::IpTos(tos) => {
                 self.set_ip_tos(*tos);
+            }
+            O::IpMtuDiscover(mode) => {
+                self.set_ip_mtu_discover(*mode)?;
             }
             O::RecvTos(enabled) => {
                 self.set_recv_tos(*enabled);

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -477,6 +477,18 @@ pub fn request_poll() {
     });
 }
 
+/// Synchronously drive the interface poll until idle.
+///
+/// [`request_poll`] only wakes the poll worker; the actual dispatch happens
+/// later. A socket that is closed in the same breath as its last send would
+/// otherwise be torn down before the worker runs, discarding the datagram still
+/// queued in its TX buffer. Draining egress here mirrors Linux, where a sent
+/// datagram already sits in the peer's receive buffer and `close()` cannot
+/// unsend it. Must not be called while holding `SOCKET_SET.inner`.
+pub(crate) fn flush_egress() {
+    poll_until_idle();
+}
+
 fn publish_poll_request(requested: &AtomicBool, wake: impl FnOnce()) {
     if !requested.swap(true, Ordering::AcqRel) {
         wake();

--- a/net/ax-net/src/options.rs
+++ b/net/ax-net/src/options.rs
@@ -194,6 +194,7 @@ define_options! {
     RecvTos(bool),
     RecvTrafficClass(bool),
     RecvErr(bool),
+    IpMtuDiscover(u8),
 
     // ---- Extra options ----
     NonBlocking(bool),

--- a/net/ax-net/src/udp.rs
+++ b/net/ax-net/src/udp.rs
@@ -49,6 +49,7 @@ use crate::{
     addr::allocate_ephemeral_port,
     config::{DeviceBinding, InterfaceId},
     consts::{UDP_RX_BUF_LEN, UDP_TX_BUF_LEN},
+    flush_egress,
     general::GeneralOptions,
     get_control, interface_by_id,
     ip_tos::{EgressIpTosKey, clear_egress_ip_tos, set_egress_ip_tos},
@@ -638,6 +639,11 @@ impl Default for UdpSocket {
 
 impl Drop for UdpSocket {
     fn drop(&mut self) {
+        // Dispatch any datagram still queued in the TX buffer to its destination
+        // while the socket is still open, so a send immediately followed by close
+        // is not lost (Linux keeps the datagram in the peer's receive buffer).
+        // smoltcp's `close()` drops the send buffer, so this must run before it.
+        flush_egress();
         self.shutdown(Shutdown::Both).ok();
         self.clear_tracked_egress_ip_tos();
         SOCKET_SET.remove(self.handle);

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -278,6 +278,10 @@ macro_rules! call_dispatch {
             (PROTO_IP, IP_TTL) => Ttl as Int<u8>,
             (PROTO_IP, linux_raw_sys::net::IP_RECVTOS) => RecvTos as IntBool,
             (PROTO_IP, IP_RECVERR) => RecvErr as IntBool,  // TODO: hardcoded false, no errqueue support
+            // Path-MTU discovery mode is stored for ABI compatibility (dnsmasq TFTP sets
+            // IP_PMTUDISC_DONT on its transfer socket and aborts the transfer if the call fails);
+            // smoltcp does not model path-MTU discovery, so it has no wire effect.
+            (PROTO_IP, linux_raw_sys::net::IP_MTU_DISCOVER) => IpMtuDiscover as Int<u8>,
             // ---- Not yet implemented (add as needed) ----
             // (SOL_SOCKET, SO_LINGER) => ...,         // TODO: needs close() linger semantics
             // (SOL_SOCKET, SO_RCVLOWAT) => ...,       // TODO: needs kernel support

--- a/test-suit/starryos/qemu/system/bugfix-bug-ip-mtu-discover-udp-flush/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-bug-ip-mtu-discover-udp-flush/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-ip-mtu-discover-udp-flush C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bug-ip-mtu-discover-udp-flush src/main.c)
+target_compile_options(bug-ip-mtu-discover-udp-flush PRIVATE -Wall -Wextra -Werror)
+target_link_options(bug-ip-mtu-discover-udp-flush PRIVATE -static)
+
+install(TARGETS bug-ip-mtu-discover-udp-flush RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-bug-ip-mtu-discover-udp-flush/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-ip-mtu-discover-udp-flush/src/main.c
@@ -1,0 +1,135 @@
+/*
+ * ip-mtu-discover-udp-flush.c - Regression for the two UDP kernel gaps dnsmasq
+ * TFTP exposed, fixed against Linux net/ipv4/ip_sockglue.c and the UDP close
+ * path.
+ *
+ *   1. IP_MTU_DISCOVER setsockopt/getsockopt ABI: a fresh datagram socket
+ *      reports IP_PMTUDISC_WANT (Linux UDP default); every mode in
+ *      IP_PMTUDISC_DONT..OMIT round-trips through set/getsockopt; a mode above
+ *      IP_PMTUDISC_OMIT is rejected with EINVAL (ip_sock_set_mtu_discover /
+ *      do_ip_setsockopt validate the range). dnsmasq sets IP_PMTUDISC_DONT on
+ *      its transfer socket and aborts the transfer if the call fails.
+ *   2. UDP egress flush before close: a datagram sent and immediately followed
+ *      by close(2) must still reach the peer. StarryOS UdpSocket::drop flushes
+ *      queued egress before smoltcp drops the send buffer, matching Linux which
+ *      keeps the datagram in the peer's receive buffer once queued. A regressed
+ *      build drops the datagram and the receiver times out.
+ *
+ * Loopback only, single process; deterministic.
+ */
+
+#include "test_framework.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+#ifndef IP_MTU_DISCOVER
+#define IP_MTU_DISCOVER 10
+#endif
+#ifndef IP_PMTUDISC_DONT
+#define IP_PMTUDISC_DONT 0
+#define IP_PMTUDISC_WANT 1
+#define IP_PMTUDISC_DO 2
+#define IP_PMTUDISC_PROBE 3
+#define IP_PMTUDISC_INTERFACE 4
+#define IP_PMTUDISC_OMIT 5
+#endif
+
+/* 1. IP_MTU_DISCOVER default + set/get round-trip + out-of-range EINVAL. */
+static void test_ip_mtu_discover_abi(void)
+{
+    int s = socket(AF_INET, SOCK_DGRAM, 0);
+    CHECK(s >= 0, "open UDP socket for IP_MTU_DISCOVER");
+    if (s < 0)
+        return;
+
+    int mode = -1;
+    socklen_t len = sizeof(mode);
+    CHECK_RET(getsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &mode, &len), 0,
+              "getsockopt IP_MTU_DISCOVER on a fresh socket");
+    CHECK(mode == IP_PMTUDISC_WANT, "fresh UDP socket defaults to IP_PMTUDISC_WANT");
+
+    const int modes[] = {IP_PMTUDISC_DONT, IP_PMTUDISC_WANT, IP_PMTUDISC_DO,
+                         IP_PMTUDISC_PROBE, IP_PMTUDISC_INTERFACE, IP_PMTUDISC_OMIT};
+    for (unsigned i = 0; i < sizeof(modes) / sizeof(modes[0]); i++)
+    {
+        int want = modes[i];
+        CHECK_RET(setsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &want, sizeof(want)), 0,
+                  "setsockopt IP_MTU_DISCOVER accepts a valid mode");
+        int got = -1;
+        len = sizeof(got);
+        CHECK_RET(getsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &got, &len), 0,
+                  "getsockopt IP_MTU_DISCOVER after set");
+        CHECK(got == want, "IP_MTU_DISCOVER mode round-trips through set/get");
+    }
+
+    /* A mode above IP_PMTUDISC_OMIT is not defined; Linux rejects it. */
+    int bad = IP_PMTUDISC_OMIT + 1;
+    CHECK_ERR(setsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &bad, sizeof(bad)), EINVAL,
+              "setsockopt IP_MTU_DISCOVER rejects an out-of-range mode with EINVAL");
+
+    close(s);
+}
+
+/* 2. A datagram sent then immediately closed must still reach the peer. */
+static void test_udp_egress_flush_before_close(void)
+{
+    int rx = socket(AF_INET, SOCK_DGRAM, 0);
+    CHECK(rx >= 0, "open UDP receiver");
+    if (rx < 0)
+        return;
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0; /* ephemeral */
+    CHECK_RET(bind(rx, (struct sockaddr *)&addr, sizeof(addr)), 0, "bind receiver to loopback");
+
+    socklen_t alen = sizeof(addr);
+    CHECK_RET(getsockname(rx, (struct sockaddr *)&addr, &alen), 0, "getsockname receiver port");
+
+    /* Bound the receive so a regressed (dropped) datagram fails fast instead of
+     * hanging the whole suite. */
+    struct timeval tv = {.tv_sec = 2, .tv_usec = 0};
+    setsockopt(rx, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+
+    int tx = socket(AF_INET, SOCK_DGRAM, 0);
+    CHECK(tx >= 0, "open UDP sender");
+    if (tx < 0)
+    {
+        close(rx);
+        return;
+    }
+
+    const char *payload = "tftp-last-block";
+    ssize_t sent = sendto(tx, payload, strlen(payload), 0,
+                          (struct sockaddr *)&addr, sizeof(addr));
+    CHECK(sent == (ssize_t)strlen(payload), "sendto queues the datagram");
+    /* Close the sender right away: the egress flush in UdpSocket::drop must run
+     * before smoltcp drops the send buffer, or the datagram is lost. */
+    close(tx);
+
+    char buf[64] = {0};
+    ssize_t got = recv(rx, buf, sizeof(buf), 0);
+    CHECK(got == (ssize_t)strlen(payload),
+          "datagram sent-then-closed is flushed and received (not dropped)");
+    CHECK(got > 0 && memcmp(buf, payload, (size_t)got) == 0, "flushed payload round-trips intact");
+
+    close(rx);
+}
+
+int main(void)
+{
+    TEST_START("IP_MTU_DISCOVER ABI + UDP egress flush before close");
+
+    test_ip_mtu_discover_abi();
+    test_udp_egress_flush_before_close();
+
+    TEST_DONE();
+}

--- a/test-suit/starryos/qemu/system/bugfix-bug-ip-mtu-discover-udp-flush/src/test_framework.h
+++ b/test-suit/starryos/qemu/system/bugfix-bug-ip-mtu-discover-udp-flush/src/test_framework.h
@@ -1,0 +1,86 @@
+#pragma once
+
+/* 必须在最前面定义，确保 pipe2/gettid 等可用 */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+/*
+ * StarryOS Syscall Test Framework
+ *
+ * 极简独立测试框架：每个文件测一个 syscall，独立编译运行。
+ * 目标：出错时精确定位到 源文件:行号 -> 哪个调用 -> 什么结果
+ *
+ * 用法:
+ *   TEST_START("测试名");
+ *   CHECK(call == expected, "描述");
+ *   CHECK_ERR(call, EBADF, "描述");
+ *   TEST_DONE();
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int __pass = 0;
+static int __fail = 0;
+
+/* ---- 核心: 带文件名+行号的检查宏 ---- */
+
+/* 检查条件为真 */
+#define CHECK(cond, msg) do {                                           \
+    if (cond) {                                                         \
+        printf("  PASS | %s:%d | %s\n", __FILE__, __LINE__, msg);      \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | errno=%d (%s)\n",                 \
+               __FILE__, __LINE__, msg, errno, strerror(errno));        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 返回特定值 */
+#define CHECK_RET(call, expected, msg) do {                             \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    long _e = (long)(expected);                                         \
+    if (_r == _e) {                                                     \
+        printf("  PASS | %s:%d | %s (ret=%ld)\n",                       \
+               __FILE__, __LINE__, msg, _r);                            \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected=%ld got=%ld | errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, _e, _r, errno, strerror(errno)); \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* 检查 syscall 失败且 errno 符合预期 */
+#define CHECK_ERR(call, exp_errno, msg) do {                            \
+    errno = 0;                                                          \
+    long _r = (long)(call);                                             \
+    if (_r == -1 && errno == (exp_errno)) {                             \
+        printf("  PASS | %s:%d | %s (errno=%d as expected)\n",          \
+               __FILE__, __LINE__, msg, errno);                         \
+        __pass++;                                                       \
+    } else {                                                            \
+        printf("  FAIL | %s:%d | %s | expected errno=%d got ret=%ld errno=%d (%s)\n", \
+               __FILE__, __LINE__, msg, (int)(exp_errno), _r, errno,     \
+               strerror(errno));                                        \
+        __fail++;                                                       \
+    }                                                                   \
+} while (0)
+
+/* ---- 测试边界 ---- */
+#define TEST_START(name)                                                \
+    printf("================================================\n");       \
+    printf("  TEST: %s\n", name);                                       \
+    printf("  FILE: %s\n", __FILE__);                                   \
+    printf("================================================\n")
+
+#define TEST_DONE()                                                     \
+    printf("------------------------------------------------\n");       \
+    printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
+    printf("================================================\n\n");     \
+    return __fail > 0 ? 1 : 0


### PR DESCRIPTION
## 概述

两处 UDP 相关内核修复, 对齐 Linux 语义, 解锁 dnsmasq 集成 TFTP 服务器的真实文件传输。均由隔离最小复现定位(交叉编译进 starry 逐层排除数据面/信号路径后钉死真因)。

## 修复

- **`IP_MTU_DISCOVER` setsockopt 返回 `ENOPROTOOPT`** → dnsmasq TFTP 传输套接字在 `bind()` 后紧接 `setsockopt(IP_MTU_DISCOVER)`, 失败即 `free_transfer` 放弃传输, 客户端超时。新增 `IpMtuDiscover(u8)` 选项, 存储 `IP_PMTUDISC_*` 模式并可回读, 非法模式返回 `EINVAL`。smoltcp 不建模路径 MTU, 故仅提供 ABI 兼容(与 Linux 一样接受该选项), 不改变分片行为。
- **UDP 发送后立即 `close` 丢失环回 TX** → dnsmasq 发送 "文件未找到" 错误包后立刻 `free_transfer`(close 套接字), 报文在派发到对端 RX 队列前随套接字销毁被丢弃(Linux 会保留在对端接收缓冲)。`UdpSocket::Drop` 在 close 前调用新增的 `flush_egress()` 同步排空发送缓冲, 把残留数据报派发到目的。

## 改动文件

- `net/ax-net/src/{general.rs,options.rs}`: `IpMtuDiscover` 选项定义与存取。
- `net/ax-net/src/lib.rs`: `flush_egress()` 同步排空。
- `net/ax-net/src/udp.rs`: `Drop` 于 close 前 flush。
- `os/StarryOS/kernel/src/syscall/net/opt.rs`: `(PROTO_IP, IP_MTU_DISCOVER)` 接入 setsockopt/getsockopt 派发。

## 验证

配套 dnsmasq 增强 carpet(app, 单独 PR)运行集成 TFTP: 客户端 `tftp -m octet 127.0.0.1 69 -c get` 拉取单块/多块文件 + missing-file 拒绝, 四架构(aarch64/riscv64/loongarch64/x86_64)qemu 真机全过 46/46 `TEST PASSED`。`cargo fmt` + `cargo clippy -D warnings`(ax-net) 干净。

接口枚举所需的 `SIOCGIFNAME` ioctl 由 #1566 提供, 故 dnsmasq carpet 需 #1566 一并合入方可复现。

