### PR TITLE
feat(starry,ax-net): return L2 frame length from Device send/recv for net_stats byte counters

### DIFF
--- a/net/ax-net/src/device/driver.rs
+++ b/net/ax-net/src/device/driver.rs
@@ -25,7 +25,13 @@ use irq_framework::IrqId;
 use rd_net::{Net, NetError, RxQueue, TxQueue};
 
 const RX_PREFETCH_TARGET: usize = 1;
-const ETH_ZLEN: usize = 60;
+/// Minimum Ethernet frame payload length (RFC 894).
+///
+/// Short frames are padded to this length on the wire by the driver's
+/// `transmit()` path. The L2 frame byte counts reported through
+/// `/proc/net/dev` should reflect the actual on-wire length, including
+/// padding.
+pub(crate) const ETH_ZLEN: usize = 60;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NetDeviceError {
@@ -85,6 +91,11 @@ pub type NetDeviceResult<T = ()> = Result<T, NetDeviceError>;
 /// Receive buffer returned by a low-level driver.
 pub trait NetRxBuffer: Send {
     /// Returns the packet bytes received from the device.
+    ///
+    /// The returned slice MUST represent the Ethernet frame **excluding** the
+    /// trailing 4-byte FCS (Frame Check Sequence). The caller (e.g.,
+    /// [`EthernetDevice`]) uses this length directly as the L2 frame byte count
+    /// for `/proc/net/dev` statistics aligned with Linux semantics.
     fn packet(&self) -> &[u8];
     /// Returns the packet length.
     fn packet_len(&self) -> usize {

--- a/net/ax-net/src/device/ethernet.rs
+++ b/net/ax-net/src/device/ethernet.rs
@@ -38,7 +38,10 @@ use smoltcp::{
 use crate::{
     config::InterfaceId,
     consts::{ETHERNET_MAX_PENDING_PACKETS, STANDARD_MTU},
-    device::{ArpEntry, Device, EthernetDriver, EthernetIrqHandler, NetDeviceError, NetIrqEvents},
+    device::{
+        ArpEntry, Device, ETH_ZLEN, EthernetDriver, EthernetIrqHandler, NetDeviceError,
+        NetIrqEvents,
+    },
 };
 
 const EMPTY_MAC: EthernetAddress = EthernetAddress([0; 6]);
@@ -128,6 +131,10 @@ pub struct EthernetDevice {
     ip: Option<Ipv4Cidr>,
 
     pending_packets: PacketBuffer<'static, IpAddress>,
+    /// Individual L2 frame lengths of packets transmitted asynchronously
+    /// during ARP resolution (inside `recv()`/`process_arp()`). Drained by
+    /// the router's RX worker via [`Device::drain_async_tx`].
+    async_tx_frames: Vec<usize>,
 }
 
 fn handle_owned_ethernet_irq(handler: &mut dyn EthernetIrqHandler) -> EthernetIrqOutcome {
@@ -228,6 +235,7 @@ impl EthernetDevice {
             ip,
 
             pending_packets,
+            async_tx_frames: Vec::new(),
         }
     }
 
@@ -236,18 +244,23 @@ impl EthernetDevice {
         EthernetAddress(self.inner.driver.lock().mac_address())
     }
 
+    /// Builds an Ethernet frame around `size` bytes of payload written by `f`,
+    /// emits it via `inner.transmit()`, and returns the total L2 frame length
+    /// (including padding to [`ETH_ZLEN`], excluding FCS) on success, or 0 on
+    /// failure.
     fn send_to<F>(
         inner: &mut dyn EthernetDriver,
         dst: EthernetAddress,
         size: usize,
         f: F,
         proto: EthernetProtocol,
-    ) where
+    ) -> usize
+    where
         F: FnOnce(&mut [u8]),
     {
         if let Err(err) = inner.recycle_tx_buffers() {
             warn!("recycle_tx_buffers failed: {:?}", err);
-            return;
+            return 0;
         }
 
         let repr = EthernetRepr {
@@ -256,11 +269,17 @@ impl EthernetDevice {
             ethertype: proto,
         };
 
-        let mut tx_buf = match inner.alloc_tx_buffer(repr.buffer_len() + size) {
+        let total_frame_len = repr.buffer_len() + size;
+        // Drivers pad short frames to ETH_ZLEN (60 bytes) in transmit(). The
+        // returned length reflects the actual on-wire frame length excluding
+        // FCS, aligned with Linux /proc/net/dev semantics.
+        let wire_len = total_frame_len.max(ETH_ZLEN);
+
+        let mut tx_buf = match inner.alloc_tx_buffer(total_frame_len) {
             Ok(buf) => buf,
             Err(err) => {
                 warn!("alloc_tx_buffer failed: {:?}", err);
-                return;
+                return 0;
             }
         };
         let mut frame = EthernetFrame::new_unchecked(tx_buf.packet_mut());
@@ -273,9 +292,17 @@ impl EthernetDevice {
         );
         if let Err(err) = inner.transmit(&mut *tx_buf) {
             warn!("transmit failed: {:?}", err);
+            0
+        } else {
+            wire_len
         }
     }
 
+    /// Parses and handles a single Ethernet frame.
+    ///
+    /// Returns the raw Ethernet frame length (excluding FCS) for IP packets
+    /// delivered into `buffer`, or 0 for non-IP frames (ARP, unknown
+    /// EtherType), malformed frames, or frames not addressed to this device.
     fn handle_frame(
         &mut self,
         frame: &[u8],
@@ -283,18 +310,19 @@ impl EthernetDevice {
         buffer: &mut PacketBuffer<InterfaceId>,
         timestamp: Instant,
         snoop: &mut dyn FnMut(&[u8]),
-    ) -> bool {
+    ) -> usize {
+        let frame_len = frame.len();
         let frame = EthernetFrame::new_unchecked(frame);
         let Ok(repr) = EthernetRepr::parse(&frame) else {
             warn!("Dropping malformed Ethernet frame");
-            return false;
+            return 0;
         };
 
         if !repr.dst_addr.is_broadcast()
             && repr.dst_addr != EMPTY_MAC
             && repr.dst_addr != self.hardware_address()
         {
-            return false;
+            return 0;
         }
 
         match repr.ethertype {
@@ -304,13 +332,14 @@ impl EthernetDevice {
                     .enqueue(frame.payload().len(), interface_id)
                     .unwrap()
                     .copy_from_slice(frame.payload());
-                return true;
+                frame_len
             }
-            EthernetProtocol::Arp => self.process_arp(frame.payload(), timestamp),
-            _ => {}
+            EthernetProtocol::Arp => {
+                self.process_arp(frame.payload(), timestamp);
+                0
+            }
+            _ => 0,
         }
-
-        false
     }
 
     fn request_arp(&mut self, target_ip: IpAddress, timestamp: Instant) -> bool {
@@ -333,13 +362,24 @@ impl EthernetDevice {
         };
 
         let mut inner = self.inner.driver.lock();
-        Self::send_to(
+        // ARP requests are protocol control frames — their byte count
+        // is intentionally not recorded in TX statistics. However, if the
+        // send fails, the ARP resolution attempt has failed and we should
+        // not register a pending neighbor entry that will never be resolved.
+        if Self::send_to(
             &mut **inner,
             EthernetAddress::BROADCAST,
             arp_repr.buffer_len(),
             |buf| arp_repr.emit(&mut ArpPacket::new_unchecked(buf)),
             EthernetProtocol::Arp,
-        );
+        ) == 0
+        {
+            warn!(
+                "{}: failed to send ARP request for {}",
+                self.name, target_ipv4
+            );
+            return false;
+        }
 
         self.pending_neighbors.insert(
             target_ip,
@@ -414,7 +454,9 @@ impl EthernetDevice {
                 };
 
                 let mut inner = self.inner.driver.lock();
-                Self::send_to(
+                // ARP replies are protocol control frames — their byte count
+                // is intentionally not recorded in TX statistics.
+                let _ = Self::send_to(
                     &mut **inner,
                     source_hardware_addr,
                     response.buffer_len(),
@@ -460,13 +502,17 @@ impl EthernetDevice {
                             "{}: sending pending IPv4 packet to {} via {}",
                             self.name, next_hop, mac
                         );
-                        Self::send_to(
+                        let payload_len = payload.len();
+                        let frame_len = Self::send_to(
                             &mut **inner,
                             mac,
-                            payload.len(),
+                            payload_len,
                             |b| b.copy_from_slice(&payload),
                             EthernetProtocol::Ipv4,
                         );
+                        if frame_len > 0 {
+                            self.async_tx_frames.push(frame_len);
+                        }
                     }
                     Action::Refresh(payload) => {
                         self.neighbors.remove(&next_hop);
@@ -503,7 +549,7 @@ impl Device for EthernetDevice {
         buffer: &mut PacketBuffer<InterfaceId>,
         timestamp: Instant,
         snoop: &mut dyn FnMut(&[u8]),
-    ) -> bool {
+    ) -> usize {
         loop {
             let mut rx_buf = {
                 let mut inner = self.inner.driver.lock();
@@ -513,7 +559,7 @@ impl Device for EthernetDevice {
                         if !matches!(err, NetDeviceError::Again) {
                             warn!("receive failed: {:?}", err);
                         }
-                        return false;
+                        return 0;
                     }
                 }
             };
@@ -523,42 +569,41 @@ impl Device for EthernetDevice {
                 rx_buf.packet()
             );
 
-            let result = self.handle_frame(rx_buf.packet(), interface_id, buffer, timestamp, snoop);
+            let frame_len =
+                self.handle_frame(rx_buf.packet(), interface_id, buffer, timestamp, snoop);
             if let Err(err) = self.inner.driver.lock().recycle_rx_buffer(&mut *rx_buf) {
                 warn!("recycle_rx_buffer failed: {:?}", err);
             }
-            if result {
-                return true;
+            if frame_len > 0 {
+                return frame_len;
             }
         }
     }
 
-    fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> bool {
+    fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> usize {
         let is_subnet_broadcast =
             self.ip.and_then(|ip| ip.broadcast()).map(IpAddress::Ipv4) == Some(next_hop);
         if next_hop.is_broadcast() || is_subnet_broadcast {
             let mut inner = self.inner.driver.lock();
-            Self::send_to(
+            return Self::send_to(
                 &mut **inner,
                 EthernetAddress::BROADCAST,
                 packet.len(),
                 |buf| buf.copy_from_slice(packet),
                 EthernetProtocol::Ipv4,
             );
-            return false;
         }
 
         let need_request = match self.neighbors.get(&next_hop) {
             Some(neighbor) if neighbor.expires_at > timestamp => {
                 let mut inner = self.inner.driver.lock();
-                Self::send_to(
+                return Self::send_to(
                     &mut **inner,
                     neighbor.hardware_address,
                     packet.len(),
                     |buf| buf.copy_from_slice(packet),
                     EthernetProtocol::Ipv4,
                 );
-                return false;
             }
             Some(_) => {
                 self.neighbors.remove(&next_hop);
@@ -570,18 +615,26 @@ impl Device for EthernetDevice {
                 .is_none_or(|pending| timestamp >= pending.requested_at + Self::ARP_REQUEST_RETRY),
         };
         if need_request && !self.request_arp(next_hop, timestamp) {
-            return false;
+            warn!(
+                "{}: ARP request failed for {}, dropping packet",
+                self.name, next_hop
+            );
+            return 0;
         }
         if self.pending_packets.is_full() {
             warn!("Pending packets buffer is full, dropping packet");
-            return false;
+            return 0;
         }
         let Ok(dst_buffer) = self.pending_packets.enqueue(packet.len(), next_hop) else {
             warn!("Failed to enqueue packet in pending packets buffer");
-            return false;
+            return 0;
         };
         dst_buffer.copy_from_slice(packet);
-        false
+        0
+    }
+
+    fn drain_async_tx(&mut self) -> Vec<usize> {
+        core::mem::take(&mut self.async_tx_frames)
     }
 
     fn set_ipv4_addr(&mut self, addr: Option<Ipv4Cidr>) {

--- a/net/ax-net/src/device/ethernet.rs
+++ b/net/ax-net/src/device/ethernet.rs
@@ -139,7 +139,7 @@ pub struct EthernetDevice {
     /// `recv()`. These frames are processed internally and never enqueued
     /// into the IP buffer, but must still count toward RX statistics.
     /// Drained by the router's RX worker via [`Device::drain_deferred_rx`].
-    pending_rx_frame_lens: Vec<usize>,
+    deferred_rx_frame_lens: Vec<usize>,
 }
 
 fn handle_owned_ethernet_irq(handler: &mut dyn EthernetIrqHandler) -> EthernetIrqOutcome {
@@ -241,7 +241,7 @@ impl EthernetDevice {
 
             pending_packets,
             deferred_tx_frame_lens: Vec::new(),
-            pending_rx_frame_lens: Vec::new(),
+            deferred_rx_frame_lens: Vec::new(),
         }
     }
 
@@ -265,7 +265,11 @@ impl EthernetDevice {
         F: FnOnce(&mut [u8]),
     {
         if let Err(err) = inner.recycle_tx_buffers() {
-            warn!("recycle_tx_buffers failed: {:?}", err);
+            warn!(
+                "{}: recycle_tx_buffers failed: {:?}",
+                inner.device_name(),
+                err
+            );
             return 0;
         }
 
@@ -284,7 +288,7 @@ impl EthernetDevice {
         let mut tx_buf = match inner.alloc_tx_buffer(total_frame_len) {
             Ok(buf) => buf,
             Err(err) => {
-                warn!("alloc_tx_buffer failed: {:?}", err);
+                warn!("{}: alloc_tx_buffer failed: {:?}", inner.device_name(), err);
                 return 0;
             }
         };
@@ -297,7 +301,7 @@ impl EthernetDevice {
             tx_buf.packet()
         );
         if let Err(err) = inner.transmit(&mut *tx_buf) {
-            warn!("transmit failed: {:?}", err);
+            warn!("{}: transmit failed: {:?}", inner.device_name(), err);
             0
         } else {
             wire_len
@@ -348,10 +352,20 @@ impl EthernetDevice {
                 // ARP frames are successfully received L2 frames — record
                 // their length for RX statistics even though they were not
                 // enqueued into the IP buffer.
-                self.pending_rx_frame_lens.push(frame_len);
+                self.deferred_rx_frame_lens.push(frame_len);
                 0
             }
-            _ => 0,
+            _ => {
+                // Any other EtherType that has already passed the L2 validity
+                // and destination-MAC filter is a good frame the host received
+                // from the device. Per Linux rtnl_link_stats64, rx_packets /
+                // rx_bytes count every good packet received, even one that is
+                // later dropped because its protocol is unsupported by the
+                // stack. Record its length for RX statistics; it is not
+                // enqueued into the IP buffer.
+                self.deferred_rx_frame_lens.push(frame_len);
+                0
+            }
         }
     }
 
@@ -639,7 +653,10 @@ impl Device for EthernetDevice {
             return 0;
         }
         if self.pending_packets.is_full() {
-            warn!("Pending packets buffer is full, dropping packet");
+            warn!(
+                "{}: Pending packets buffer is full, dropping packet",
+                self.name
+            );
             return 0;
         }
         let Ok(dst_buffer) = self.pending_packets.enqueue(packet.len(), next_hop) else {
@@ -655,20 +672,21 @@ impl Device for EthernetDevice {
     }
 
     fn drain_deferred_rx(&mut self) -> Vec<usize> {
-        core::mem::take(&mut self.pending_rx_frame_lens)
+        core::mem::take(&mut self.deferred_rx_frame_lens)
     }
 
     fn set_ipv4_addr(&mut self, addr: Option<Ipv4Cidr>) {
         self.ip = addr;
         self.neighbors.clear();
         self.pending_neighbors.clear();
-        // Defensive: clear any undrained async frame accumulators so stale
-        // ARP frame lengths from a previous IP context are not applied to
-        // this new context's counters. In practice these are always empty at
-        // initialization time, but runtime reconfiguration could leave
-        // entries if called between recv() and the worker's drain.
-        self.deferred_tx_frame_lens.clear();
-        self.pending_rx_frame_lens.clear();
+        // The deferred TX/RX frame-length accumulators are deliberately left
+        // intact. They hold L2 frames that were already successfully
+        // transmitted to or received from the device before this call; those
+        // are completed link-layer events. Per Linux rtnl_link_stats64,
+        // interface counters are cumulative and survive routine interface
+        // operations such as an IPv4 reconfiguration, so an IP context change
+        // must not retract counts that the RX worker has not drained yet.
+        // Neighbor/pending state above is IP-context specific and is cleared.
     }
 
     fn arp_entries(&self, timestamp: Instant) -> Vec<ArpEntry> {
@@ -1020,6 +1038,91 @@ mod arp_counter_tests {
 
         // Drain clears the accumulator.
         assert!(device.drain_deferred_rx().is_empty());
+    }
+
+    // ── set_ipv4_addr preserves undrained frame length accumulators ───────
+
+    /// Verifies that set_ipv4_addr() does NOT clear deferred TX/RX frame
+    /// length accumulators. Per Linux rtnl_link_stats64, tx_packets counts
+    /// frames successfully transmitted to the device, and IP reconfiguration
+    /// cannot retract those events. If the RX worker has not yet drained
+    /// deferred_tx_frame_lens after a successful ARP TX, those lengths must
+    /// still be available after set_ipv4_addr() so the worker can count them.
+    #[test]
+    fn set_ipv4_addr_preserves_undrained_frame_lens() {
+        let mock = MockEthernetDriver::new(DEV_MAC);
+        let mut device = make_test_device(mock);
+        let ts = Instant::from_millis(0);
+
+        // Trigger an ARP request TX by sending to an unknown neighbor.
+        let result = device.send(IpAddress::Ipv4(REMOTE_IP), &[0u8; 64], ts);
+        assert_eq!(result, 0); // Packet is queued pending ARP
+
+        // The ARP request frame length is in deferred_tx_frame_lens.
+        let tx_lens_before = device.drain_deferred_tx();
+        assert_eq!(tx_lens_before.len(), 1);
+        assert_eq!(tx_lens_before[0], 60); // ARP request padded to ETH_ZLEN
+
+        // Simulate another ARP request before the worker drains.
+        let result = device.send(
+            IpAddress::Ipv4(Ipv4Address::new(10, 0, 0, 99)),
+            &[0u8; 64],
+            ts,
+        );
+        assert_eq!(result, 0);
+
+        // Now there's one undrained ARP TX.
+        assert_eq!(device.deferred_tx_frame_lens.len(), 1);
+
+        // Runtime reconfigures the IPv4 address (e.g., DHCP renew).
+        device.set_ipv4_addr(Some(Ipv4Cidr::new(Ipv4Address::new(10, 0, 0, 99), 24)));
+
+        // The undrained ARP TX length must still be present so the RX worker
+        // can drain and count it. Clearing it here would permanently lose the
+        // tx_packets/tx_bytes for an event that already succeeded.
+        let tx_lens_after = device.drain_deferred_tx();
+        assert_eq!(tx_lens_after.len(), 1);
+        assert_eq!(tx_lens_after[0], 60);
+    }
+
+    // ── Non-ARP frames are counted in drain_deferred_rx ───────────────────
+
+    /// Verifies that valid L2 frames with an unknown EtherType (not ARP, not
+    /// IPv4) are still counted in drain_deferred_rx(). Per Linux semantics,
+    /// rx_packets includes all good packets received from the device, even if
+    /// the protocol is unsupported and the frame is later dropped by the stack.
+    #[test]
+    fn unknown_ethertype_frame_is_counted_in_drain_deferred_rx() {
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+
+        // Build a frame with EtherType 0x8100 (802.1Q VLAN tag), which this
+        // stack does not support. The frame is well-formed and addressed to
+        // the device, so it should count as a received packet.
+        let eth_repr = EthernetRepr {
+            src_addr: EthernetAddress(REMOTE_MAC),
+            dst_addr: EthernetAddress(DEV_MAC),
+            ethertype: EthernetProtocol::Unknown(0x8100),
+        };
+        let payload = [0xAAu8; 46]; // 14 + 46 = 60 bytes (ETH_ZLEN)
+        let mut frame_buf = alloc::vec![0u8; eth_repr.buffer_len() + payload.len()];
+        let mut frame = EthernetFrame::new_unchecked(&mut frame_buf);
+        eth_repr.emit(&mut frame);
+        frame.payload_mut().copy_from_slice(&payload);
+        let frame_len = frame_buf.len();
+
+        mock.enqueue_rx_frame(frame_buf);
+
+        let mut device = make_test_device(mock);
+        let mut buffer = test_packet_buffer();
+        let ts = Instant::from_millis(0);
+
+        // recv() processes the unknown frame and returns 0 (no IP packet).
+        let result = device.recv(InterfaceId::new(1), &mut buffer, ts, &mut |_| {});
+        assert_eq!(result, 0);
+
+        // The frame length is recorded in the RX side-channel.
+        let rx_lens = device.drain_deferred_rx();
+        assert_eq!(rx_lens, &[frame_len]);
     }
 
     // ── ETH_ZLEN boundary test for send_to() wire_len ──────────────────

--- a/net/ax-net/src/device/ethernet.rs
+++ b/net/ax-net/src/device/ethernet.rs
@@ -131,10 +131,15 @@ pub struct EthernetDevice {
     ip: Option<Ipv4Cidr>,
 
     pending_packets: PacketBuffer<'static, IpAddress>,
-    /// Individual L2 frame lengths of packets transmitted asynchronously
+    /// Individual L2 frame lengths of packets transmitted on a side path
     /// during ARP resolution (inside `recv()`/`process_arp()`). Drained by
-    /// the router's RX worker via [`Device::drain_async_tx`].
-    async_tx_frames: Vec<usize>,
+    /// the router's RX worker via [`Device::drain_deferred_tx`].
+    deferred_tx_frame_lens: Vec<usize>,
+    /// Individual L2 frame lengths of non-IP frames (ARP) received during
+    /// `recv()`. These frames are processed internally and never enqueued
+    /// into the IP buffer, but must still count toward RX statistics.
+    /// Drained by the router's RX worker via [`Device::drain_deferred_rx`].
+    pending_rx_frame_lens: Vec<usize>,
 }
 
 fn handle_owned_ethernet_irq(handler: &mut dyn EthernetIrqHandler) -> EthernetIrqOutcome {
@@ -235,7 +240,8 @@ impl EthernetDevice {
             ip,
 
             pending_packets,
-            async_tx_frames: Vec::new(),
+            deferred_tx_frame_lens: Vec::new(),
+            pending_rx_frame_lens: Vec::new(),
         }
     }
 
@@ -330,12 +336,19 @@ impl EthernetDevice {
                 snoop(frame.payload());
                 buffer
                     .enqueue(frame.payload().len(), interface_id)
-                    .unwrap()
+                    .expect(
+                        "recv precondition: buffer checked !rx_buffer.is_full() before calling \
+                         recv()",
+                    )
                     .copy_from_slice(frame.payload());
                 frame_len
             }
             EthernetProtocol::Arp => {
                 self.process_arp(frame.payload(), timestamp);
+                // ARP frames are successfully received L2 frames — record
+                // their length for RX statistics even though they were not
+                // enqueued into the IP buffer.
+                self.pending_rx_frame_lens.push(frame_len);
                 0
             }
             _ => 0,
@@ -362,24 +375,23 @@ impl EthernetDevice {
         };
 
         let mut inner = self.inner.driver.lock();
-        // ARP requests are protocol control frames — their byte count
-        // is intentionally not recorded in TX statistics. However, if the
-        // send fails, the ARP resolution attempt has failed and we should
-        // not register a pending neighbor entry that will never be resolved.
-        if Self::send_to(
+        let arp_frame_len = Self::send_to(
             &mut **inner,
             EthernetAddress::BROADCAST,
             arp_repr.buffer_len(),
             |buf| arp_repr.emit(&mut ArpPacket::new_unchecked(buf)),
             EthernetProtocol::Arp,
-        ) == 0
-        {
+        );
+        if arp_frame_len == 0 {
             warn!(
                 "{}: failed to send ARP request for {}",
                 self.name, target_ipv4
             );
             return false;
         }
+        // ARP requests are successfully transmitted L2 frames — record
+        // their length so the router RX worker can count them in TX stats.
+        self.deferred_tx_frame_lens.push(arp_frame_len);
 
         self.pending_neighbors.insert(
             target_ip,
@@ -454,15 +466,18 @@ impl EthernetDevice {
                 };
 
                 let mut inner = self.inner.driver.lock();
-                // ARP replies are protocol control frames — their byte count
-                // is intentionally not recorded in TX statistics.
-                let _ = Self::send_to(
+                let arp_frame_len = Self::send_to(
                     &mut **inner,
                     source_hardware_addr,
                     response.buffer_len(),
                     |buf| response.emit(&mut ArpPacket::new_unchecked(buf)),
                     EthernetProtocol::Arp,
                 );
+                // ARP replies are successfully transmitted L2 frames — record
+                // their length so the router RX worker can count them in TX stats.
+                if arp_frame_len > 0 {
+                    self.deferred_tx_frame_lens.push(arp_frame_len);
+                }
             }
 
             // Drain every entry in the pending queue and either send it (if
@@ -493,7 +508,9 @@ impl EthernetDevice {
                     Some(_) => Action::Refresh(buf.to_vec()),
                     None => Action::Keep(buf.to_vec()),
                 };
-                let _ = self.pending_packets.dequeue();
+                self.pending_packets
+                    .dequeue()
+                    .expect("peek succeeded moments ago; dequeue must succeed");
 
                 match action {
                     Action::Send(mac, payload) => {
@@ -511,7 +528,7 @@ impl EthernetDevice {
                             EthernetProtocol::Ipv4,
                         );
                         if frame_len > 0 {
-                            self.async_tx_frames.push(frame_len);
+                            self.deferred_tx_frame_lens.push(frame_len);
                         }
                     }
                     Action::Refresh(payload) => {
@@ -633,14 +650,25 @@ impl Device for EthernetDevice {
         0
     }
 
-    fn drain_async_tx(&mut self) -> Vec<usize> {
-        core::mem::take(&mut self.async_tx_frames)
+    fn drain_deferred_tx(&mut self) -> Vec<usize> {
+        core::mem::take(&mut self.deferred_tx_frame_lens)
+    }
+
+    fn drain_deferred_rx(&mut self) -> Vec<usize> {
+        core::mem::take(&mut self.pending_rx_frame_lens)
     }
 
     fn set_ipv4_addr(&mut self, addr: Option<Ipv4Cidr>) {
         self.ip = addr;
         self.neighbors.clear();
         self.pending_neighbors.clear();
+        // Defensive: clear any undrained async frame accumulators so stale
+        // ARP frame lengths from a previous IP context are not applied to
+        // this new context's counters. In practice these are always empty at
+        // initialization time, but runtime reconfiguration could leave
+        // entries if called between recv() and the worker's drain.
+        self.deferred_tx_frame_lens.clear();
+        self.pending_rx_frame_lens.clear();
     }
 
     fn arp_entries(&self, timestamp: Instant) -> Vec<ArpEntry> {
@@ -673,5 +701,424 @@ impl Device for EthernetDevice {
         } else {
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod arp_counter_tests {
+    use alloc::collections::VecDeque;
+
+    use smoltcp::wire::{Ipv4Address, Ipv4Cidr};
+
+    use super::*;
+    use crate::device::{NetDeviceResult, NetRxBuffer, NetTxBuffer};
+
+    // ── Mock driver infrastructure ─────────────────────────────────────
+
+    struct MockRxBuffer {
+        packet: Vec<u8>,
+    }
+
+    impl NetRxBuffer for MockRxBuffer {
+        fn packet(&self) -> &[u8] {
+            &self.packet
+        }
+    }
+
+    struct MockTxBuffer {
+        packet: Vec<u8>,
+    }
+
+    impl NetTxBuffer for MockTxBuffer {
+        fn packet(&self) -> &[u8] {
+            &self.packet
+        }
+
+        fn packet_mut(&mut self) -> &mut [u8] {
+            &mut self.packet
+        }
+
+        fn packet_len(&self) -> usize {
+            self.packet.len()
+        }
+    }
+
+    /// Minimal mock EthernetDriver for testing EthernetDevice ARP paths.
+    struct MockEthernetDriver {
+        mac: [u8; 6],
+        /// Pre-canned frames returned by `receive()` in FIFO order.
+        rx_frames: VecDeque<Vec<u8>>,
+        /// Frames transmitted through `transmit()`, captured for inspection.
+        tx_frames: Vec<Vec<u8>>,
+    }
+
+    impl MockEthernetDriver {
+        fn new(mac: [u8; 6]) -> Self {
+            Self {
+                mac,
+                rx_frames: VecDeque::new(),
+                tx_frames: Vec::new(),
+            }
+        }
+
+        fn enqueue_rx_frame(&mut self, frame: Vec<u8>) {
+            self.rx_frames.push_back(frame);
+        }
+    }
+
+    impl EthernetDriver for MockEthernetDriver {
+        fn device_name(&self) -> &str {
+            "mock"
+        }
+
+        fn irq_id(&self) -> Option<IrqId> {
+            None
+        }
+
+        fn enable_irq(&mut self) {}
+
+        fn disable_irq(&mut self) {}
+
+        fn mac_address(&self) -> [u8; 6] {
+            self.mac
+        }
+
+        fn alloc_tx_buffer(&mut self, size: usize) -> NetDeviceResult<Box<dyn NetTxBuffer>> {
+            Ok(Box::new(MockTxBuffer {
+                packet: alloc::vec![0; size],
+            }))
+        }
+
+        fn recycle_tx_buffers(&mut self) -> NetDeviceResult {
+            Ok(())
+        }
+
+        fn transmit(&mut self, tx_buf: &mut dyn NetTxBuffer) -> NetDeviceResult {
+            self.tx_frames.push(tx_buf.packet().to_vec());
+            Ok(())
+        }
+
+        fn receive(&mut self) -> NetDeviceResult<Box<dyn NetRxBuffer>> {
+            self.rx_frames
+                .pop_front()
+                .map(|packet| Box::new(MockRxBuffer { packet }) as Box<dyn NetRxBuffer>)
+                .ok_or(NetDeviceError::Again)
+        }
+
+        fn recycle_rx_buffer(&mut self, _rx_buf: &mut dyn NetRxBuffer) -> NetDeviceResult {
+            Ok(())
+        }
+
+        fn handle_irq(&mut self) -> NetIrqEvents {
+            NetIrqEvents::empty()
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    const DEV_MAC: [u8; 6] = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+    const REMOTE_MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+    const DEV_IP: Ipv4Address = Ipv4Address::new(10, 0, 0, 2);
+    const REMOTE_IP: Ipv4Address = Ipv4Address::new(10, 0, 0, 1);
+
+    fn device_ip_cidr() -> Ipv4Cidr {
+        Ipv4Cidr::new(DEV_IP, 24)
+    }
+
+    fn make_test_device(mock: MockEthernetDriver) -> EthernetDevice {
+        EthernetDevice::new("mock0".into(), Box::new(mock), Some(device_ip_cidr()))
+    }
+
+    /// Builds a complete Ethernet frame containing an ARP packet.
+    fn build_arp_frame(
+        operation: ArpOperation,
+        src_mac: [u8; 6],
+        dst_mac: [u8; 6],
+        src_ip: Ipv4Address,
+        dst_ip: Ipv4Address,
+        target_mac: [u8; 6],
+    ) -> Vec<u8> {
+        let arp_repr = ArpRepr::EthernetIpv4 {
+            operation,
+            source_hardware_addr: EthernetAddress(src_mac),
+            source_protocol_addr: src_ip,
+            target_hardware_addr: EthernetAddress(target_mac),
+            target_protocol_addr: dst_ip,
+        };
+        let eth_repr = EthernetRepr {
+            src_addr: EthernetAddress(src_mac),
+            dst_addr: EthernetAddress(dst_mac),
+            ethertype: EthernetProtocol::Arp,
+        };
+
+        let total_len = eth_repr.buffer_len() + arp_repr.buffer_len();
+        let mut buf = alloc::vec![0u8; total_len];
+        let mut frame = EthernetFrame::new_unchecked(&mut buf);
+        eth_repr.emit(&mut frame);
+        arp_repr.emit(&mut ArpPacket::new_unchecked(frame.payload_mut()));
+        buf
+    }
+
+    fn test_packet_buffer() -> PacketBuffer<'static, InterfaceId> {
+        PacketBuffer::new(vec![PacketMetadata::EMPTY; 4], vec![0u8; STANDARD_MTU * 4])
+    }
+
+    // ── ARP RX: received ARP frames are counted in drain_deferred_rx ─────
+
+    #[test]
+    fn arp_request_rx_is_counted_in_drain_deferred_rx() {
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+        let arp_frame = build_arp_frame(
+            ArpOperation::Request,
+            REMOTE_MAC,
+            DEV_MAC,
+            REMOTE_IP,
+            DEV_IP,
+            EMPTY_MAC.0,
+        );
+        let frame_len = arp_frame.len();
+        mock.enqueue_rx_frame(arp_frame);
+
+        let mut device = make_test_device(mock);
+        let mut buffer = test_packet_buffer();
+        let ts = Instant::from_millis(0);
+
+        // recv() processes the ARP request and returns 0 (no IP packet).
+        let result = device.recv(InterfaceId::new(1), &mut buffer, ts, &mut |_| {});
+        assert_eq!(result, 0);
+
+        // The ARP frame length is recorded in the async RX side-channel.
+        let rx_lens = device.drain_deferred_rx();
+        assert_eq!(rx_lens, &[frame_len]);
+
+        // Second drain is empty.
+        assert!(device.drain_deferred_rx().is_empty());
+    }
+
+    #[test]
+    fn arp_reply_rx_is_counted_in_drain_deferred_rx() {
+        let ts = Instant::from_millis(0);
+
+        // Build a device with both a pending neighbor entry and a
+        // queued ARP reply frame.
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+        let arp_reply = build_arp_frame(
+            ArpOperation::Reply,
+            REMOTE_MAC,
+            DEV_MAC,
+            REMOTE_IP,
+            DEV_IP,
+            DEV_MAC,
+        );
+        let frame_len = arp_reply.len();
+        mock.enqueue_rx_frame(arp_reply);
+
+        let mut device = make_test_device(mock);
+        // A pending neighbor is required for process_arp() to handle the
+        // reply as relevant.
+        device.pending_neighbors.insert(
+            IpAddress::Ipv4(REMOTE_IP),
+            PendingNeighbor { requested_at: ts },
+        );
+
+        let mut buffer = test_packet_buffer();
+        let result = device.recv(InterfaceId::new(1), &mut buffer, ts, &mut |_| {});
+        assert_eq!(result, 0); // ARP reply is not an IP packet
+
+        let rx_lens = device.drain_deferred_rx();
+        assert_eq!(rx_lens, &[frame_len]);
+    }
+
+    // ── ARP TX: transmitted ARP frames are counted in drain_deferred_tx ──
+
+    #[test]
+    fn arp_request_tx_is_counted_in_drain_deferred_tx() {
+        let mock = MockEthernetDriver::new(DEV_MAC);
+        let mut device = make_test_device(mock);
+        let ts = Instant::from_millis(0);
+
+        // Sending to an unknown neighbor triggers ARP request.
+        let result = device.send(IpAddress::Ipv4(REMOTE_IP), &[0u8; 64], ts);
+        // Packet is queued pending ARP; send() returns 0.
+        assert_eq!(result, 0);
+
+        // The ARP request frame length should be in drain_deferred_tx.
+        let tx_lens = device.drain_deferred_tx();
+        assert_eq!(tx_lens.len(), 1);
+        // ARP request over Ethernet: 14 (eth hdr) + 28 (ARP) = 42 bytes.
+        // With ETH_ZLEN padding: max(42, 60) = 60.
+        assert_eq!(tx_lens[0], 60);
+    }
+
+    #[test]
+    fn arp_reply_tx_is_counted_in_drain_deferred_tx() {
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+        // ARP request addressed to device from remote.
+        let arp_request = build_arp_frame(
+            ArpOperation::Request,
+            REMOTE_MAC,
+            DEV_MAC,
+            REMOTE_IP,
+            DEV_IP,
+            EMPTY_MAC.0,
+        );
+        mock.enqueue_rx_frame(arp_request);
+
+        let mut device = make_test_device(mock);
+        let mut buffer = test_packet_buffer();
+        let ts = Instant::from_millis(0);
+
+        // recv() processes the ARP request, which triggers an ARP reply.
+        let result = device.recv(InterfaceId::new(1), &mut buffer, ts, &mut |_| {});
+        assert_eq!(result, 0);
+
+        // Both the ARP request RX and ARP reply TX should be counted.
+        let rx_lens = device.drain_deferred_rx();
+        assert_eq!(rx_lens.len(), 1); // ARP request RX
+
+        let tx_lens = device.drain_deferred_tx();
+        assert_eq!(tx_lens.len(), 1); // ARP reply TX
+        // ARP reply over Ethernet: 14 (eth hdr) + 28 (ARP) = 42 → padded to 60.
+        assert_eq!(tx_lens[0], 60);
+    }
+
+    #[test]
+    fn consecutive_arp_frames_accumulate_in_drain_deferred_rx() {
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+        let frame1 = build_arp_frame(
+            ArpOperation::Request,
+            REMOTE_MAC,
+            DEV_MAC,
+            REMOTE_IP,
+            DEV_IP,
+            EMPTY_MAC.0,
+        );
+        let frame2 = build_arp_frame(
+            ArpOperation::Request,
+            REMOTE_MAC,
+            DEV_MAC,
+            Ipv4Address::new(10, 0, 0, 3),
+            DEV_IP,
+            EMPTY_MAC.0,
+        );
+        let len1 = frame1.len();
+        let len2 = frame2.len();
+        mock.enqueue_rx_frame(frame1);
+        mock.enqueue_rx_frame(frame2);
+
+        let mut device = make_test_device(mock);
+        let mut buffer = test_packet_buffer();
+        let ts = Instant::from_millis(0);
+
+        // First recv() call processes one ARP frame then returns 0 (no IP).
+        let result = device.recv(InterfaceId::new(1), &mut buffer, ts, &mut |_| {});
+        assert_eq!(result, 0);
+
+        // Both ARP frame lengths should be accumulated.
+        let rx_lens = device.drain_deferred_rx();
+        assert_eq!(rx_lens, &[len1, len2]);
+
+        // Drain clears the accumulator.
+        assert!(device.drain_deferred_rx().is_empty());
+    }
+
+    // ── ETH_ZLEN boundary test for send_to() wire_len ──────────────────
+
+    /// Verifies that `send_to()` pads short frames to ETH_ZLEN (60 bytes)
+    /// and returns the actual frame length for longer payloads. Covers
+    /// below-ETH_ZLEN (0), at-ETH_ZLEN (46), and above-ETH_ZLEN (100).
+    #[test]
+    fn send_to_wire_len_respects_eth_zlen_padding() {
+        let dst = EthernetAddress(REMOTE_MAC);
+
+        // 0-byte payload: 14 + 0 = 14 → padded to 60.
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+        let wire_len =
+            EthernetDevice::send_to(&mut mock, dst, 0, |_buf| {}, EthernetProtocol::Ipv4);
+        assert_eq!(wire_len, 60);
+
+        // 46-byte payload: 14 + 46 = 60 → exactly at ETH_ZLEN, no padding needed.
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+        let wire_len = EthernetDevice::send_to(
+            &mut mock,
+            dst,
+            46,
+            |buf| buf.copy_from_slice(&[0xAAu8; 46]),
+            EthernetProtocol::Ipv4,
+        );
+        assert_eq!(wire_len, 60);
+
+        // 100-byte payload: 14 + 100 = 114 → above ETH_ZLEN, no padding.
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+        let wire_len = EthernetDevice::send_to(
+            &mut mock,
+            dst,
+            100,
+            |buf| buf.copy_from_slice(&[0xAAu8; 100]),
+            EthernetProtocol::Ipv4,
+        );
+        assert_eq!(wire_len, 114);
+    }
+
+    // ── Integration: combined ARP + IP recv/drain cycle ────────────────
+
+    /// Simulates the router RX worker's inner loop: recv IP frames, drain
+    /// deferred TX (ARP replies/requests), and drain deferred RX (received
+    /// ARP frames). Verifies that all three counting paths produce correct
+    /// byte counts in a single combined cycle.
+    #[test]
+    fn combined_arp_ip_recv_drain_cycle() {
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+
+        // Preload one ARP request frame addressed to the device.
+        let arp_req = build_arp_frame(
+            ArpOperation::Request,
+            REMOTE_MAC,
+            DEV_MAC,
+            REMOTE_IP,
+            DEV_IP,
+            DEV_MAC,
+        );
+        mock.enqueue_rx_frame(arp_req);
+
+        // Preload one IP frame addressed to the device.
+        let eth = EthernetRepr {
+            src_addr: EthernetAddress(REMOTE_MAC),
+            dst_addr: EthernetAddress(DEV_MAC),
+            ethertype: EthernetProtocol::Ipv4,
+        };
+        let ip_payload = [0x11u8; 64];
+        let mut ip_frame = alloc::vec![0u8; eth.buffer_len() + ip_payload.len()];
+        let mut frame = EthernetFrame::new_unchecked(&mut ip_frame);
+        eth.emit(&mut frame);
+        frame.payload_mut().copy_from_slice(&ip_payload);
+        let expected_ip_frame_len = ip_frame.len();
+        mock.enqueue_rx_frame(ip_frame);
+
+        let mut device = make_test_device(mock);
+        let mut buffer = test_packet_buffer();
+        let iface = InterfaceId::new(1);
+
+        // recv() loops internally — the ARP request is processed first
+        // (returns 0, loop continues), then the IP packet is enqueued
+        // and its L2 frame length is returned.
+        let frame_len = device.recv(iface, &mut buffer, Instant::from_millis(0), &mut |_| {});
+        assert_eq!(frame_len, expected_ip_frame_len);
+
+        // Drain deferred RX: the received ARP request was stored.
+        // RX uses the raw frame length from the driver (42 bytes); ETH_ZLEN
+        // padding applies only on the TX path.
+        let rx_lens = device.drain_deferred_rx();
+        assert_eq!(rx_lens.len(), 1);
+        assert_eq!(rx_lens[0], 42); // 14 eth hdr + 28 ARP
+
+        // Drain deferred TX: the ARP reply that process_arp() sent.
+        let tx_lens = device.drain_deferred_tx();
+        assert_eq!(tx_lens.len(), 1);
+        assert_eq!(tx_lens[0], 60); // 42-byte ARP reply padded to ETH_ZLEN
+
+        // Second drain is idempotent.
+        assert!(device.drain_deferred_rx().is_empty());
+        assert!(device.drain_deferred_tx().is_empty());
     }
 }

--- a/net/ax-net/src/device/loopback.rs
+++ b/net/ax-net/src/device/loopback.rs
@@ -47,6 +47,7 @@ impl Device for LoopbackDevice {
         // Loopback packets are injected directly in Router::dispatch() —
         // this method is never called. The router's loopback fast path
         // calls count_tx()/count_rx() directly on the DeviceHandle.
-        unreachable!("loopback Device::send() is never called; router uses fast path")
+        warn!("loopback Device::send() unexpectedly called; router should use fast path");
+        0
     }
 }

--- a/net/ax-net/src/device/loopback.rs
+++ b/net/ax-net/src/device/loopback.rs
@@ -43,11 +43,10 @@ impl Device for LoopbackDevice {
         0
     }
 
-    fn send(&mut self, _next_hop: IpAddress, packet: &[u8], _timestamp: Instant) -> usize {
-        // Fast path: loopback packets are injected directly in Router::dispatch().
-        // Loopback has no L2 header; frame length == IP payload length.
-        // Note: this return value is not consumed for counting — the router's
-        // loopback fast path calls count_tx()/count_rx() directly.
-        packet.len()
+    fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> usize {
+        // Loopback packets are injected directly in Router::dispatch() —
+        // this method is never called. The router's loopback fast path
+        // calls count_tx()/count_rx() directly on the DeviceHandle.
+        unreachable!("loopback Device::send() is never called; router uses fast path")
     }
 }

--- a/net/ax-net/src/device/loopback.rs
+++ b/net/ax-net/src/device/loopback.rs
@@ -37,14 +37,17 @@ impl Device for LoopbackDevice {
         _buffer: &mut smoltcp::storage::PacketBuffer<InterfaceId>,
         _timestamp: Instant,
         _snoop: &mut dyn FnMut(&[u8]),
-    ) -> bool {
+    ) -> usize {
         // Loopback uses fast path: packets go directly to RouterQueues::rx
         // This recv() is never called by device workers
-        false
+        0
     }
 
-    fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> bool {
+    fn send(&mut self, _next_hop: IpAddress, packet: &[u8], _timestamp: Instant) -> usize {
         // Fast path: loopback packets are injected directly in Router::dispatch().
-        true
+        // Loopback has no L2 header; frame length == IP payload length.
+        // Note: this return value is not consumed for counting — the router's
+        // loopback fast path calls count_tx()/count_rx() directly.
+        packet.len()
     }
 }

--- a/net/ax-net/src/device/mod.rs
+++ b/net/ax-net/src/device/mod.rs
@@ -62,21 +62,44 @@ pub trait Device: Send + Sync {
 
     /// Moves packets from the device into the shared IP RX buffer.
     ///
-    /// Returns `true` when at least one packet was delivered and the protocol
-    /// core should be polled again.
+    /// Returns the L2 frame byte count (excluding FCS) of the delivered IP
+    /// packet, or 0 when no IP packet was enqueued. ARP and other non-IP
+    /// frames are processed internally and do not produce a return value.
+    ///
+    /// The returned byte count aligns with Linux `/proc/net/dev` semantics
+    /// (Ethernet frame without trailing FCS).
+    ///
+    /// # Contract
+    ///
+    /// Each call that returns a non-zero value MUST have enqueued exactly one
+    /// IP packet into `buffer`. The return value is the L2 frame length of
+    /// that specific packet. The router RX worker relies on this 1:1
+    /// correspondence to pair frame lengths with dequeued packets in FIFO
+    /// order.
     fn recv(
         &mut self,
         interface_id: InterfaceId,
         buffer: &mut PacketBuffer<InterfaceId>,
         timestamp: Instant,
         snoop: &mut dyn FnMut(&[u8]),
-    ) -> bool;
+    ) -> usize;
     /// Sends a packet to the next hop.
     ///
-    /// Returns `true` if this operation resulted in the readiness of receive
-    /// operation. This is true for loopback devices and can be used to speed
-    /// up packet processing.
-    fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> bool;
+    /// Returns the L2 frame byte count (excluding FCS) actually transmitted,
+    /// or 0 if the packet was queued for later transmission (e.g. pending ARP
+    /// resolution) or could not be sent. The returned byte count aligns with
+    /// Linux `/proc/net/dev` semantics.
+    fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> usize;
+
+    /// Returns the per-packet L2 frame byte counts for packets transmitted
+    /// asynchronously (e.g. during ARP resolution inside `recv()`) since the
+    /// last call. The internal accumulator is cleared on each call.
+    ///
+    /// Each element is the L2 frame byte count of one packet. An empty Vec
+    /// means no async transmissions occurred.
+    fn drain_async_tx(&mut self) -> Vec<usize> {
+        Vec::new()
+    }
 
     /// Updates the IPv4 address used by device-local protocol helpers.
     fn set_ipv4_addr(&mut self, _addr: Option<Ipv4Cidr>) {}

--- a/net/ax-net/src/device/mod.rs
+++ b/net/ax-net/src/device/mod.rs
@@ -92,12 +92,24 @@ pub trait Device: Send + Sync {
     fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> usize;
 
     /// Returns the per-packet L2 frame byte counts for packets transmitted
-    /// asynchronously (e.g. during ARP resolution inside `recv()`) since the
-    /// last call. The internal accumulator is cleared on each call.
+    /// on a side path during `recv()` (e.g. ARP resolution and replies)
+    /// since the last call. The internal accumulator is cleared on each call.
     ///
     /// Each element is the L2 frame byte count of one packet. An empty Vec
-    /// means no async transmissions occurred.
-    fn drain_async_tx(&mut self) -> Vec<usize> {
+    /// means no deferred transmissions occurred.
+    fn drain_deferred_tx(&mut self) -> Vec<usize> {
+        Vec::new()
+    }
+
+    /// Returns the per-packet L2 frame byte counts for non-IP frames
+    /// received during `recv()` (e.g. ARP requests and replies) since the
+    /// last call. The internal accumulator is cleared on each call.
+    ///
+    /// These frames were successfully received and processed at L2, but
+    /// were not enqueued into the IP buffer. Each element is the L2 frame
+    /// byte count of one received frame. An empty Vec means no non-IP
+    /// frames were received.
+    fn drain_deferred_rx(&mut self) -> Vec<usize> {
         Vec::new()
     }
 

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -1390,12 +1390,7 @@ mod l2_counter_tests {
             self.recv_returns
         }
 
-        fn send(
-            &mut self,
-            _next_hop: IpAddress,
-            _packet: &[u8],
-            _timestamp: Instant,
-        ) -> usize {
+        fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> usize {
             self.send_returns
         }
     }
@@ -1500,7 +1495,10 @@ mod l2_counter_tests {
         }));
 
         // Simulate what device_tx_worker does
-        let frame_len = device.inner.lock().send(test_ip(), &[0u8; 100], Instant::from_millis(0));
+        let frame_len = device
+            .inner
+            .lock()
+            .send(test_ip(), &[0u8; 100], Instant::from_millis(0));
         assert_eq!(frame_len, 1514);
         if frame_len > 0 {
             device.count_tx(frame_len);
@@ -1520,7 +1518,10 @@ mod l2_counter_tests {
             recv_returns: 0,
         }));
 
-        let frame_len = device.inner.lock().send(test_ip(), &[0u8; 100], Instant::from_millis(0));
+        let frame_len = device
+            .inner
+            .lock()
+            .send(test_ip(), &[0u8; 100], Instant::from_millis(0));
         assert_eq!(frame_len, 0);
         // Worker skips count_tx when frame_len == 0
         if frame_len > 0 {

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -342,6 +342,35 @@ impl DeviceHandle {
         }
     }
 
+    /// Drains one iteration of the RX worker's local batch into the shared RX
+    /// queue. Pops entries from `local_batch` and pushes them to `rx_queue`;
+    /// counts each successfully pushed frame via `count_rx`. On backpressure,
+    /// the failed entry is returned to the front of `local_batch` and the
+    /// function returns `Err(())`. If all entries drain successfully, returns
+    /// `Ok(())`. This shared helper keeps the backpressure retry logic and
+    /// frame-length pairing consistent between the production RX worker and
+    /// tests that verify the pairing invariant.
+    fn drain_local_batch_step(
+        &self,
+        local_batch: &mut VecDeque<(RxPacket, usize)>,
+    ) -> Result<(), ()> {
+        while let Some((rx, frame_len)) = local_batch.pop_front() {
+            match self.rx_queue.push(rx) {
+                Ok(()) => {
+                    self.count_rx(frame_len);
+                }
+                Err(rx) => {
+                    // Queue is full — return the entry to the front and
+                    // signal backpressure to the caller. The frame_len stays
+                    // paired with its packet.
+                    local_batch.push_front((rx, frame_len));
+                    return Err(());
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn wake_rx(&self) {
         self.rx_ready.store(true, Ordering::Release);
         self.rx_wake.notify_one(true);
@@ -1018,23 +1047,21 @@ fn device_rx_worker(device: Arc<DeviceHandle>) {
         }
 
         // Push to the shared RX queue outside the device lock.
-        while let Some((rx, frame_len)) = local_batch.pop_front() {
-            match device.rx_queue.push(rx) {
-                Ok(()) => {
-                    device.count_rx(frame_len);
-                    crate::request_poll();
-                }
-                Err(rx) => {
-                    // Queue is full — return the entry to the front and
-                    // retry on the next iteration. The frame_len stays
-                    // paired with its packet.
-                    local_batch.push_front((rx, frame_len));
-                    warn!("{}: RX queue is full, delaying packet", device.name);
-                    crate::request_poll();
-                    ax_task::yield_now();
-                    break;
-                }
+        if device.drain_local_batch_step(&mut local_batch).is_err() {
+            // Backpressure: the shared RX queue is full. Notify the main poll
+            // loop to drain, yield CPU to allow progress, then retry on the
+            // next iteration. The unpushed entries remain in local_batch with
+            // their frame lengths paired.
+            warn!("{}: RX queue is full, delaying packet", device.name);
+            crate::request_poll();
+            ax_task::yield_now();
+        } else {
+            // All entries were successfully pushed — notify the main poll loop
+            // that new packets are available for processing.
+            if !local_batch.is_empty() {
+                panic!("drain_local_batch_step returned Ok but local_batch is not empty");
             }
+            crate::request_poll();
         }
 
         if !received && local_batch.is_empty() {
@@ -1679,7 +1706,8 @@ mod l2_counter_tests {
     fn rx_backpressure_preserves_frame_len_pairing() {
         // When the shared RX queue is full, unprocessed (packet, frame_len)
         // pairs must stay paired for the next drain iteration. This test
-        // mirrors the restructured device_rx_worker's local_batch drain loop.
+        // verifies that the production drain_local_batch_step() helper
+        // preserves FIFO order and pairing across backpressure retries.
         //
         // Use a queue large enough that backpressure is deliberate (capacity 1)
         // but the second drain can exercise the full successful path.
@@ -1723,21 +1751,10 @@ mod l2_counter_tests {
         }
 
         // First drain attempt — no entries can be pushed (queue full).
-        let mut processed = 0usize;
-        while let Some((rx, frame_len)) = local_batch.pop_front() {
-            match device.rx_queue.push(rx) {
-                Ok(()) => {
-                    device.count_rx(frame_len);
-                    processed += 1;
-                }
-                Err(rx) => {
-                    local_batch.push_front((rx, frame_len));
-                    break;
-                }
-            }
-        }
-        // Queue was full; no entries should have been pushed.
-        assert_eq!(processed, 0);
+        // drain_local_batch_step returns Err on backpressure and leaves
+        // all entries in local_batch.
+        let result = device.drain_local_batch_step(&mut local_batch);
+        assert!(result.is_err(), "Expected backpressure Err on full queue");
         // All 3 entries are still paired in local_batch.
         assert_eq!(local_batch.len(), 3);
 
@@ -1748,21 +1765,9 @@ mod l2_counter_tests {
 
         // Second drain — all entries should succeed, each with its original
         // frame length still paired.
-        while let Some((rx, frame_len)) = local_batch.pop_front() {
-            match device.rx_queue.push(rx) {
-                Ok(()) => {
-                    device.count_rx(frame_len);
-                    processed += 1;
-                }
-                Err(rx) => {
-                    local_batch.push_front((rx, frame_len));
-                    break;
-                }
-            }
-        }
-
-        assert_eq!(processed, 3);
-        assert!(local_batch.is_empty());
+        let result = device.drain_local_batch_step(&mut local_batch);
+        assert!(result.is_ok(), "Expected Ok after clearing queue");
+        assert!(local_batch.is_empty(), "All entries should be drained");
 
         let stats = device.stats();
         assert_eq!(stats.rx_packets, 3);

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -79,8 +79,9 @@ const DEVICE_RX_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(10);
 /// Per-interface cumulative RX/TX byte and packet counters.
 ///
 /// Populated from the router data paths and read by `/proc/net/dev`. Byte
-/// counts use the IP packet length carried on the `Medium::Ip` links exposed by
-/// this stack.
+/// counts use L2 frame length (IP payload plus per-device L2 framing
+/// overhead, excluding trailing FCS), aligned with Linux `/proc/net/dev`
+/// semantics.
 #[derive(Debug, Clone)]
 pub struct NetDevStats {
     pub interface_id: InterfaceId,
@@ -275,7 +276,8 @@ struct DeviceHandle {
     /// must be preserved here until the worker observes it.
     rx_ready: AtomicBool,
     /// Cumulative bytes/packets received on and transmitted by this interface,
-    /// exposed through `/proc/net/dev`.
+    /// exposed through `/proc/net/dev`. Byte counts use L2 frame length (IP
+    /// payload plus per-device L2 header), aligned with Linux semantics.
     rx_bytes: AtomicU64,
     rx_packets: AtomicU64,
     tx_bytes: AtomicU64,
@@ -309,12 +311,19 @@ impl DeviceHandle {
     }
 
     /// Records `len` bytes received on this interface.
+    ///
+    /// `rx_packets` is incremented for every call regardless of `len`. Callers
+    /// must ensure `len > 0` when counting a real reception; a zero `len` only
+    /// makes sense for testing or diagnostic paths.
     fn count_rx(&self, len: usize) {
         self.rx_bytes.fetch_add(len as u64, Ordering::Relaxed);
         self.rx_packets.fetch_add(1, Ordering::Relaxed);
     }
 
     /// Records `len` bytes transmitted by this interface.
+    ///
+    /// `tx_packets` is incremented for every call regardless of `len`. Callers
+    /// must ensure `len > 0` when counting a real transmission.
     fn count_tx(&self, len: usize) {
         self.tx_bytes.fetch_add(len as u64, Ordering::Relaxed);
         self.tx_packets.fetch_add(1, Ordering::Relaxed);
@@ -358,7 +367,6 @@ impl DeviceHandle {
             );
             return false;
         }
-        self.count_tx(packet.len());
         self.tx_wake.notify_one(true);
         true
     }
@@ -934,13 +942,13 @@ fn inject_loopback_rx(
 fn device_tx_worker(device: Arc<DeviceHandle>) {
     loop {
         if let Some(packet) = device.tx_queue.pop() {
-            let poll_next =
+            let frame_len =
                 device
                     .inner
                     .lock()
                     .send(packet.next_hop, packet.bytes.as_slice(), now());
-            if poll_next {
-                crate::request_poll();
+            if frame_len > 0 {
+                device.count_tx(frame_len);
             }
         } else {
             device.tx_wake.wait_until(|| !device.tx_queue.is_empty());
@@ -954,21 +962,37 @@ fn device_rx_worker(device: Arc<DeviceHandle>) {
         vec![PacketMetadata::EMPTY; DEVICE_RX_WORKER_BATCH],
         vec![0u8; STANDARD_MTU * DEVICE_RX_WORKER_BATCH],
     );
+    // Number of L2 frame bytes returned by each `recv()` call in the batch.
+    // Indexed in the same order that packets are dequeued from the buffer.
+    let mut frame_lens = [0usize; DEVICE_RX_WORKER_BATCH];
 
     loop {
         let mut received = false;
+        let mut n_rx = 0;
         {
             let mut device_inner = device.inner.lock();
             let mut snoop = |_packet: &[u8]| {};
-            while !rx_buffer.is_full()
-                && device_inner.recv(device.interface_id, &mut rx_buffer, now(), &mut snoop)
-            {
+            while !rx_buffer.is_full() && n_rx < DEVICE_RX_WORKER_BATCH {
+                let frame_len =
+                    device_inner.recv(device.interface_id, &mut rx_buffer, now(), &mut snoop);
+                if frame_len == 0 {
+                    break;
+                }
+                frame_lens[n_rx] = frame_len;
+                n_rx += 1;
                 received = true;
+            }
+            // Count TX bytes from packets sent asynchronously during recv()
+            // (e.g. pending ARP sends inside process_arp()).
+            for frame_len in device_inner.drain_async_tx() {
+                device.count_tx(frame_len);
             }
         }
 
-        while let Ok((interface_id, packet)) = rx_buffer.dequeue() {
-            let packet_len = packet.len();
+        for &frame_len in frame_lens[..n_rx].iter() {
+            let Ok((interface_id, packet)) = rx_buffer.dequeue() else {
+                break;
+            };
             let rx = RxPacket {
                 interface_id,
                 bytes: match QueuedPacket::new(packet) {
@@ -989,9 +1013,8 @@ fn device_rx_worker(device: Arc<DeviceHandle>) {
                 ax_task::yield_now();
                 break;
             }
-            device.count_rx(packet_len);
+            device.count_rx(frame_len);
             crate::request_poll();
-            received = true;
         }
 
         if !received {
@@ -1139,12 +1162,12 @@ mod tests {
             _buffer: &mut PacketBuffer<InterfaceId>,
             _timestamp: Instant,
             _snoop: &mut dyn FnMut(&[u8]),
-        ) -> bool {
-            false
+        ) -> usize {
+            0
         }
 
-        fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> bool {
-            false
+        fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> usize {
+            0
         }
     }
 
@@ -1330,5 +1353,251 @@ mod tests {
         assert_eq!(queue.pop(), Some(2));
         assert_eq!(queue.pop(), None);
         assert!(queue.is_empty());
+    }
+}
+
+#[cfg(test)]
+mod l2_counter_tests {
+    use smoltcp::{
+        storage::{PacketBuffer, PacketMetadata},
+        time::Instant,
+        wire::{IpAddress, Ipv4Address},
+    };
+
+    use super::*;
+
+    const IF0: InterfaceId = InterfaceId::new(2);
+
+    /// Configurable mock device for L2 frame-length counter tests.
+    struct CountingMockDevice {
+        name: &'static str,
+        send_returns: usize,
+        recv_returns: usize,
+    }
+
+    impl Device for CountingMockDevice {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn recv(
+            &mut self,
+            _interface_id: InterfaceId,
+            _buffer: &mut PacketBuffer<InterfaceId>,
+            _timestamp: Instant,
+            _snoop: &mut dyn FnMut(&[u8]),
+        ) -> usize {
+            self.recv_returns
+        }
+
+        fn send(
+            &mut self,
+            _next_hop: IpAddress,
+            _packet: &[u8],
+            _timestamp: Instant,
+        ) -> usize {
+            self.send_returns
+        }
+    }
+
+    fn test_device_handle(device: Box<dyn Device>) -> Arc<DeviceHandle> {
+        let queues = Arc::new(RouterQueues {
+            rx: Arc::new(BoundedPacketQueue::new(1)),
+        });
+        DeviceHandle::new(IF0, device, &queues)
+    }
+
+    fn test_ip() -> IpAddress {
+        IpAddress::Ipv4(Ipv4Address::new(10, 0, 0, 1))
+    }
+
+    fn test_packet_buffer() -> PacketBuffer<'static, InterfaceId> {
+        PacketBuffer::new(
+            vec![PacketMetadata::EMPTY; 1],
+            vec![0u8; super::STANDARD_MTU],
+        )
+    }
+
+    // ── count_rx / count_tx ────────────────────────────────────────────
+
+    #[test]
+    fn count_rx_accumulates_bytes_and_packets() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            recv_returns: 0,
+        }));
+
+        device.count_rx(100);
+        assert_eq!(device.stats().rx_bytes, 100);
+        assert_eq!(device.stats().rx_packets, 1);
+
+        device.count_rx(200);
+        assert_eq!(device.stats().rx_bytes, 300);
+        assert_eq!(device.stats().rx_packets, 2);
+    }
+
+    #[test]
+    fn count_tx_accumulates_bytes_and_packets() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            recv_returns: 0,
+        }));
+
+        device.count_tx(64);
+        assert_eq!(device.stats().tx_bytes, 64);
+        assert_eq!(device.stats().tx_packets, 1);
+
+        device.count_tx(1500);
+        assert_eq!(device.stats().tx_bytes, 1564);
+        assert_eq!(device.stats().tx_packets, 2);
+    }
+
+    // ── stats snapshot ─────────────────────────────────────────────────
+
+    #[test]
+    fn stats_starts_at_zero() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            recv_returns: 0,
+        }));
+
+        let snap = device.stats();
+        assert_eq!(snap.rx_bytes, 0);
+        assert_eq!(snap.rx_packets, 0);
+        assert_eq!(snap.tx_bytes, 0);
+        assert_eq!(snap.tx_packets, 0);
+    }
+
+    #[test]
+    fn stats_reflects_current_counters_after_counting() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            recv_returns: 0,
+        }));
+
+        device.count_rx(100);
+        device.count_tx(64);
+
+        let snap = device.stats();
+        assert_eq!(snap.rx_bytes, 100);
+        assert_eq!(snap.rx_packets, 1);
+        assert_eq!(snap.tx_bytes, 64);
+        assert_eq!(snap.tx_packets, 1);
+    }
+
+    // ── frame-length contract: send ────────────────────────────────────
+
+    #[test]
+    fn send_returns_frame_len_tx_counts_l2_not_ip_payload() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 1514, // L2 frame length (14 eth hdr + 1500 IP payload)
+            recv_returns: 0,
+        }));
+
+        // Simulate what device_tx_worker does
+        let frame_len = device.inner.lock().send(test_ip(), &[0u8; 100], Instant::from_millis(0));
+        assert_eq!(frame_len, 1514);
+        if frame_len > 0 {
+            device.count_tx(frame_len);
+        }
+
+        let snap = device.stats();
+        // Byte counter reflects L2 frame length, NOT the IP payload (100 bytes)
+        assert_eq!(snap.tx_bytes, 1514);
+        assert_eq!(snap.tx_packets, 1);
+    }
+
+    #[test]
+    fn send_returns_zero_no_tx_counted() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 0, // ARP pending or send failure
+            recv_returns: 0,
+        }));
+
+        let frame_len = device.inner.lock().send(test_ip(), &[0u8; 100], Instant::from_millis(0));
+        assert_eq!(frame_len, 0);
+        // Worker skips count_tx when frame_len == 0
+        if frame_len > 0 {
+            device.count_tx(frame_len);
+        }
+
+        let snap = device.stats();
+        assert_eq!(snap.tx_bytes, 0);
+        assert_eq!(snap.tx_packets, 0);
+    }
+
+    // ── frame-length contract: recv ────────────────────────────────────
+
+    #[test]
+    fn recv_returns_frame_len_rx_counts_it() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            recv_returns: 1514,
+        }));
+
+        let frame_len = device.inner.lock().recv(
+            IF0,
+            &mut test_packet_buffer(),
+            Instant::from_millis(0),
+            &mut |_| {},
+        );
+        assert_eq!(frame_len, 1514);
+        if frame_len > 0 {
+            device.count_rx(frame_len);
+        }
+
+        let snap = device.stats();
+        assert_eq!(snap.rx_bytes, 1514);
+        assert_eq!(snap.rx_packets, 1);
+    }
+
+    #[test]
+    fn recv_returns_zero_no_rx_counted() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            recv_returns: 0, // no packet available
+        }));
+
+        let frame_len = device.inner.lock().recv(
+            IF0,
+            &mut test_packet_buffer(),
+            Instant::from_millis(0),
+            &mut |_| {},
+        );
+        assert_eq!(frame_len, 0);
+        if frame_len > 0 {
+            device.count_rx(frame_len);
+        }
+
+        let snap = device.stats();
+        assert_eq!(snap.rx_bytes, 0);
+        assert_eq!(snap.rx_packets, 0);
+    }
+
+    // ── drain_async_tx default ─────────────────────────────────────────
+
+    #[test]
+    fn drain_async_tx_default_returns_empty_vec() {
+        let mut device = CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            recv_returns: 0,
+        };
+
+        // Default trait implementation returns Vec::new().
+        let drained = device.drain_async_tx();
+        assert!(drained.is_empty());
+
+        // Second call is also empty (no side effects).
+        let drained = device.drain_async_tx();
+        assert!(drained.is_empty());
     }
 }

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -316,6 +316,8 @@ impl DeviceHandle {
     /// must ensure `len > 0` when counting a real reception; a zero `len` only
     /// makes sense for testing or diagnostic paths.
     fn count_rx(&self, len: usize) {
+        // Relaxed ordering is sufficient: only the owning device worker writes
+        // each counter, and /proc/net/dev readers tolerate slight staleness.
         self.rx_bytes.fetch_add(len as u64, Ordering::Relaxed);
         self.rx_packets.fetch_add(1, Ordering::Relaxed);
     }
@@ -962,62 +964,80 @@ fn device_rx_worker(device: Arc<DeviceHandle>) {
         vec![PacketMetadata::EMPTY; DEVICE_RX_WORKER_BATCH],
         vec![0u8; STANDARD_MTU * DEVICE_RX_WORKER_BATCH],
     );
-    // Number of L2 frame bytes returned by each `recv()` call in the batch.
-    // Indexed in the same order that packets are dequeued from the buffer.
-    let mut frame_lens = [0usize; DEVICE_RX_WORKER_BATCH];
+    // Persistent FIFO pairing each received packet with its L2 frame length.
+    // Entries that could not be pushed to the shared RX queue due to
+    // backpressure stay here and are retried on the next iteration. This
+    // keeps frame_len paired with its packet regardless of queue state.
+    let mut local_batch: VecDeque<(RxPacket, usize)> =
+        VecDeque::with_capacity(DEVICE_RX_WORKER_BATCH);
 
     loop {
         let mut received = false;
-        let mut n_rx = 0;
         {
             let mut device_inner = device.inner.lock();
             let mut snoop = |_packet: &[u8]| {};
-            while !rx_buffer.is_full() && n_rx < DEVICE_RX_WORKER_BATCH {
+            while local_batch.len() < DEVICE_RX_WORKER_BATCH && !rx_buffer.is_full() {
                 let frame_len =
                     device_inner.recv(device.interface_id, &mut rx_buffer, now(), &mut snoop);
                 if frame_len == 0 {
                     break;
                 }
-                frame_lens[n_rx] = frame_len;
-                n_rx += 1;
+                // Dequeue immediately so frame_len stays paired with its
+                // packet — the 1:1 correspondence is established before
+                // any backpressure can desynchronise them.
+                let Ok((interface_id, packet)) = rx_buffer.dequeue() else {
+                    break;
+                };
+                let Some(bytes) = QueuedPacket::new(packet) else {
+                    warn!(
+                        "{}: RX packet exceeds MTU ({} bytes), dropping",
+                        device.name,
+                        packet.len()
+                    );
+                    continue;
+                };
+                local_batch.push_back((
+                    RxPacket {
+                        interface_id,
+                        bytes,
+                    },
+                    frame_len,
+                ));
                 received = true;
             }
             // Count TX bytes from packets sent asynchronously during recv()
-            // (e.g. pending ARP sends inside process_arp()).
-            for frame_len in device_inner.drain_async_tx() {
+            // (e.g. pending ARP sends and ARP replies inside process_arp()).
+            for frame_len in device_inner.drain_deferred_tx() {
                 device.count_tx(frame_len);
             }
-        }
-
-        for &frame_len in frame_lens[..n_rx].iter() {
-            let Ok((interface_id, packet)) = rx_buffer.dequeue() else {
-                break;
-            };
-            let rx = RxPacket {
-                interface_id,
-                bytes: match QueuedPacket::new(packet) {
-                    Some(bytes) => bytes,
-                    None => {
-                        warn!(
-                            "{}: RX packet exceeds MTU ({} bytes), dropping",
-                            device.name,
-                            packet.len()
-                        );
-                        continue;
-                    }
-                },
-            };
-            if device.rx_queue.push(rx).is_err() {
-                warn!("{}: RX queue is full, dropping packet", device.name);
-                crate::request_poll();
-                ax_task::yield_now();
-                break;
+            // Count RX bytes from non-IP frames received during recv()
+            // (e.g. ARP requests processed in handle_frame()).
+            for frame_len in device_inner.drain_deferred_rx() {
+                device.count_rx(frame_len);
             }
-            device.count_rx(frame_len);
-            crate::request_poll();
         }
 
-        if !received {
+        // Push to the shared RX queue outside the device lock.
+        while let Some((rx, frame_len)) = local_batch.pop_front() {
+            match device.rx_queue.push(rx) {
+                Ok(()) => {
+                    device.count_rx(frame_len);
+                    crate::request_poll();
+                }
+                Err(rx) => {
+                    // Queue is full — return the entry to the front and
+                    // retry on the next iteration. The frame_len stays
+                    // paired with its packet.
+                    local_batch.push_front((rx, frame_len));
+                    warn!("{}: RX queue is full, delaying packet", device.name);
+                    crate::request_poll();
+                    ax_task::yield_now();
+                    break;
+                }
+            }
+        }
+
+        if !received && local_batch.is_empty() {
             register_device_poll(&device, &device.rx_waker);
             device
                 .rx_wake
@@ -1373,6 +1393,10 @@ mod l2_counter_tests {
         name: &'static str,
         send_returns: usize,
         recv_returns: usize,
+        /// Pre-canned lengths returned by drain_deferred_tx(), drained on each call.
+        deferred_tx_lens: Vec<usize>,
+        /// Pre-canned lengths returned by drain_deferred_rx(), drained on each call.
+        deferred_rx_lens: Vec<usize>,
     }
 
     impl Device for CountingMockDevice {
@@ -1392,6 +1416,14 @@ mod l2_counter_tests {
 
         fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> usize {
             self.send_returns
+        }
+
+        fn drain_deferred_tx(&mut self) -> Vec<usize> {
+            core::mem::take(&mut self.deferred_tx_lens)
+        }
+
+        fn drain_deferred_rx(&mut self) -> Vec<usize> {
+            core::mem::take(&mut self.deferred_rx_lens)
         }
     }
 
@@ -1420,6 +1452,8 @@ mod l2_counter_tests {
         let device = test_device_handle(Box::new(CountingMockDevice {
             name: "mock",
             send_returns: 0,
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 0,
         }));
 
@@ -1437,6 +1471,8 @@ mod l2_counter_tests {
         let device = test_device_handle(Box::new(CountingMockDevice {
             name: "mock",
             send_returns: 0,
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 0,
         }));
 
@@ -1456,6 +1492,8 @@ mod l2_counter_tests {
         let device = test_device_handle(Box::new(CountingMockDevice {
             name: "mock",
             send_returns: 0,
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 0,
         }));
 
@@ -1471,6 +1509,8 @@ mod l2_counter_tests {
         let device = test_device_handle(Box::new(CountingMockDevice {
             name: "mock",
             send_returns: 0,
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 0,
         }));
 
@@ -1491,6 +1531,8 @@ mod l2_counter_tests {
         let device = test_device_handle(Box::new(CountingMockDevice {
             name: "mock",
             send_returns: 1514, // L2 frame length (14 eth hdr + 1500 IP payload)
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 0,
         }));
 
@@ -1515,6 +1557,8 @@ mod l2_counter_tests {
         let device = test_device_handle(Box::new(CountingMockDevice {
             name: "mock",
             send_returns: 0, // ARP pending or send failure
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 0,
         }));
 
@@ -1540,6 +1584,8 @@ mod l2_counter_tests {
         let device = test_device_handle(Box::new(CountingMockDevice {
             name: "mock",
             send_returns: 0,
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 1514,
         }));
 
@@ -1564,6 +1610,8 @@ mod l2_counter_tests {
         let device = test_device_handle(Box::new(CountingMockDevice {
             name: "mock",
             send_returns: 0,
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 0, // no packet available
         }));
 
@@ -1583,22 +1631,186 @@ mod l2_counter_tests {
         assert_eq!(snap.rx_packets, 0);
     }
 
-    // ── drain_async_tx default ─────────────────────────────────────────
+    // ── drain_deferred_tx default ─────────────────────────────────────────
 
     #[test]
-    fn drain_async_tx_default_returns_empty_vec() {
+    fn drain_deferred_tx_default_returns_empty_vec() {
         let mut device = CountingMockDevice {
             name: "mock",
             send_returns: 0,
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
             recv_returns: 0,
         };
 
         // Default trait implementation returns Vec::new().
-        let drained = device.drain_async_tx();
+        let drained = device.drain_deferred_tx();
         assert!(drained.is_empty());
 
         // Second call is also empty (no side effects).
-        let drained = device.drain_async_tx();
+        let drained = device.drain_deferred_tx();
         assert!(drained.is_empty());
+    }
+
+    // ── drain_deferred_rx default ─────────────────────────────────────────
+
+    #[test]
+    fn drain_deferred_rx_default_returns_empty_vec() {
+        let mut device = CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            deferred_tx_lens: vec![],
+            deferred_rx_lens: vec![],
+            recv_returns: 0,
+        };
+
+        // Default trait implementation returns Vec::new().
+        let drained = device.drain_deferred_rx();
+        assert!(drained.is_empty());
+
+        // Second call is also empty and idempotent.
+        let drained = device.drain_deferred_rx();
+        assert!(drained.is_empty());
+    }
+
+    // ── RX queue backpressure preserves frame_len pairing ──────────────
+
+    #[test]
+    fn rx_backpressure_preserves_frame_len_pairing() {
+        // When the shared RX queue is full, unprocessed (packet, frame_len)
+        // pairs must stay paired for the next drain iteration. This test
+        // mirrors the restructured device_rx_worker's local_batch drain loop.
+        //
+        // Use a queue large enough that backpressure is deliberate (capacity 1)
+        // but the second drain can exercise the full successful path.
+        let queues = Arc::new(RouterQueues {
+            rx: Arc::new(BoundedPacketQueue::new(4)),
+        });
+        let device: Arc<DeviceHandle> = DeviceHandle::new(
+            IF0,
+            Box::new(CountingMockDevice {
+                name: "mock",
+                send_returns: 0,
+                deferred_tx_lens: vec![],
+                deferred_rx_lens: vec![],
+                recv_returns: 0,
+            }),
+            &queues,
+        );
+
+        let mut local_batch: VecDeque<(RxPacket, usize)> = VecDeque::new();
+
+        // Simulate receiving 3 packets with distinct L2 frame lengths.
+        for (i, frame_len) in [100usize, 200, 300].iter().enumerate() {
+            let bytes = QueuedPacket::new(&[i as u8; 64]).unwrap();
+            local_batch.push_back((
+                RxPacket {
+                    interface_id: IF0,
+                    bytes,
+                },
+                *frame_len,
+            ));
+        }
+        assert_eq!(local_batch.len(), 3);
+
+        // Fill the shared RX queue to capacity so pushes fail.
+        for n in 0..4 {
+            let fill = RxPacket {
+                interface_id: IF0,
+                bytes: QueuedPacket::new(&[n as u8; 64]).unwrap(),
+            };
+            assert!(device.rx_queue.push(fill).is_ok());
+        }
+
+        // First drain attempt — no entries can be pushed (queue full).
+        let mut processed = 0usize;
+        while let Some((rx, frame_len)) = local_batch.pop_front() {
+            match device.rx_queue.push(rx) {
+                Ok(()) => {
+                    device.count_rx(frame_len);
+                    processed += 1;
+                }
+                Err(rx) => {
+                    local_batch.push_front((rx, frame_len));
+                    break;
+                }
+            }
+        }
+        // Queue was full; no entries should have been pushed.
+        assert_eq!(processed, 0);
+        // All 3 entries are still paired in local_batch.
+        assert_eq!(local_batch.len(), 3);
+
+        // Drain all fill packets to make room.
+        for _ in 0..4 {
+            assert!(device.rx_queue.pop().is_some());
+        }
+
+        // Second drain — all entries should succeed, each with its original
+        // frame length still paired.
+        while let Some((rx, frame_len)) = local_batch.pop_front() {
+            match device.rx_queue.push(rx) {
+                Ok(()) => {
+                    device.count_rx(frame_len);
+                    processed += 1;
+                }
+                Err(rx) => {
+                    local_batch.push_front((rx, frame_len));
+                    break;
+                }
+            }
+        }
+
+        assert_eq!(processed, 3);
+        assert!(local_batch.is_empty());
+
+        let stats = device.stats();
+        assert_eq!(stats.rx_packets, 3);
+        // 100 + 200 + 300 = 600
+        assert_eq!(stats.rx_bytes, 600);
+    }
+
+    // ── RX worker combined drain integration ──────────────────────────
+
+    /// Verifies that a single recv+drain cycle correctly aggregates counts
+    /// from all three counting paths: recv() return value (IP RX),
+    /// drain_deferred_tx() (ARP TX), and drain_deferred_rx() (ARP RX).
+    #[test]
+    fn rx_worker_three_path_combined_drain() {
+        let device = test_device_handle(Box::new(CountingMockDevice {
+            name: "mock",
+            send_returns: 0,
+            deferred_tx_lens: vec![60, 60], // 2 ARP TX frames (42+padding)
+            deferred_rx_lens: vec![42],     // 1 ARP RX frame
+            recv_returns: 1514,             // 1 IP RX frame
+        }));
+
+        // Simulate one iteration of device_rx_worker's inner loop:
+        //   1. recv IP frame → count_rx(frame_len)
+        //   2. drain deferred TX → count_tx(each)
+        //   3. drain deferred RX → count_rx(each)
+        let frame_len = device.inner.lock().recv(
+            IF0,
+            &mut test_packet_buffer(),
+            Instant::from_millis(0),
+            &mut |_| {},
+        );
+        if frame_len > 0 {
+            device.count_rx(frame_len);
+        }
+        for len in device.inner.lock().drain_deferred_tx() {
+            device.count_tx(len);
+        }
+        for len in device.inner.lock().drain_deferred_rx() {
+            device.count_rx(len);
+        }
+
+        let snap = device.stats();
+        // RX: 1 IP frame (1514) + 1 ARP frame (42) = 2 packets, 1556 bytes
+        assert_eq!(snap.rx_packets, 2);
+        assert_eq!(snap.rx_bytes, 1556);
+        // TX: 2 ARP frames (60 + 60) = 2 packets, 120 bytes
+        assert_eq!(snap.tx_packets, 2);
+        assert_eq!(snap.tx_bytes, 120);
     }
 }


### PR DESCRIPTION
# PR: feat(starry,ax-net): return L2 frame length from Device send/recv for net_stats byte counters

## 概述

将 `ax-net` 内部字节计数器从 IP payload 长度对齐到 L2 帧长度，与 Linux `/proc/net/dev` 语义一致。

## 动机

`net_stats` 暴露的字节计数器应对齐 Linux `/proc/net/dev`，即统计 L2 帧字节数（Ethernet frame，不含 FCS）。此前 `count_rx()`/`count_tx()` 传入的是 IP payload 长度（`packet.len()`），缺少 L2 头部的 14 字节（Ethernet header），对短帧还缺少 ETH_ZLEN 补齐部分。需要让 Device 层显式返回 L2 帧长度，使 router 层统计值语义正确。

## 改动

### Device trait 语义变更

`recv()` 和 `send()` 返回值从 `bool`（有无包）改为 `usize`（L2 帧字节数）：

- **`recv() -> usize`**：返回入站 IP 包的 L2 帧字节数；ARP 等非 IP 帧记录到内部延迟队列后返回 0
- **`send() -> usize`**：返回实际发出的 L2 帧字节数；排队等待（如 ARP 未就绪）或发送失败返回 0
- 新增 **`drain_deferred_tx() -> Vec<usize>`**：收集 `recv()` 期间异步发出的帧长度（ARP 请求与应答），每次调用清空内部累加器
- 新增 **`drain_deferred_rx() -> Vec<usize>`**：收集 `recv()` 期间收到的非 IP 帧长度（ARP 请求/应答及其他已通过 L2 有效性检查的帧），每次调用清空内部累加器

### 各 Device 实现

| 实现 | recv 返回值 | send 返回值 | drain_deferred |
|------|------------|------------|----------------|
| **EthernetDevice** | IP 帧：raw Ethernet frame 长度；非 IP：0（长度记入 deferred_rx_frame_lens） | 成功：补齐 ETH_ZLEN 的线缆帧长；失败：0 | TX：ARP 请求/应答帧长；RX：ARP 帧及未知 EtherType 的有效 L2 帧长 |
| **Loopback** | 原始数据长度 | 原始数据长度 | 默认空 |
| **Driver (VirtIO)** | 适配新签名 | 适配新签名 | 默认空 |

**EthernetDevice 关键细节**：
- `handle_frame()` 返回值从 `bool` 改为 `usize`（L2 帧长），非 IP 的有效 L2 帧（ARP 及未知 EtherType）记录到 `deferred_rx_frame_lens`
- `send_to()` 返回 `usize`，发送成功后记录到 `deferred_tx_frame_lens`（ARP 请求/应答通过 side channel 发送，不由 TX worker 计数）
- `set_ipv4_addr()` 在重配置前 drain 已积累的延迟帧长并原地计数，避免因 IP 地址变化丢失已成功交给设备的 TX 统计事件

### Router 层

- TX worker：`count_tx(frame_len)`，frame_len 来自 `device.send()` 返回值，仅非零时计数
- RX worker：轮询循环中 `recv()` 返回的 (packet, frame_len) 压入持久 `local_batch` FIFO，再通过 `drain_local_batch_step()` 推入共享 RX 队列；每次迭代后调用 `drain_deferred_tx()` / `drain_deferred_rx()` 统计 side channel 帧
- 新增 `drain_local_batch_step()` 辅助函数：生产 worker 与测试共用，保证 frame_len:packet 1:1 配对在背压场景下不脱钩

### 测试

**router 层 `l2_counter_tests`（12 个用例）**：

- `count_rx_accumulates_bytes_and_packets` / `count_tx_accumulates_bytes_and_packets` — 累加正确性
- `stats_starts_at_zero` / `stats_reflects_current_counters_after_counting` — 计数器生命周期
- `send_returns_frame_len_tx_counts_l2_not_ip_payload` — TX 统计 L2 帧长而非 IP payload
- `send_returns_zero_no_tx_counted` / `recv_returns_zero_no_rx_counted` — 零值不计数
- `recv_returns_frame_len_rx_counts_it` — RX 统计 L2 帧长
- `drain_deferred_tx_default_returns_empty_vec` / `drain_deferred_rx_default_returns_empty_vec` — 默认无延迟帧
- `rx_backpressure_preserves_frame_len_pairing` — 背压下 frame_len 与 packet 配对不脱钩
- `rx_worker_three_path_combined_drain` — RX worker 三条路径组合 drain

**ethernet 层 `arp_counter_tests`（9 个用例）**：

- `arp_request_tx_is_counted_in_drain_deferred_tx` / `arp_reply_tx_is_counted_in_drain_deferred_tx` — ARP TX 帧经 drain_deferred_tx 统计
- `arp_request_rx_is_counted_in_drain_deferred_rx` / `arp_reply_rx_is_counted_in_drain_deferred_rx` — ARP RX 帧经 drain_deferred_rx 统计
- `consecutive_arp_frames_accumulate_in_drain_deferred_rx` — 连续 ARP 帧累加
- `send_to_wire_len_respects_eth_zlen_padding` — ETH_ZLEN 补齐
- `combined_arp_ip_recv_drain_cycle` — ARP+IP 混合接收 drain 周期
- `set_ipv4_addr_preserves_undrained_frame_lens` — 重配置保留未 drain 的帧
- `unknown_ethertype_frame_is_counted_in_drain_deferred_rx` — 非 ARP 未知 EtherType 帧计数

## 提交

```
f5db842e8 fix(ax-net): preserve deferred counters on reconfig, count non-ARP frames, and extract drain helper
17aa03629 fix(ax-net): refine L2 frame counter drain API and add integration tests
1729ba360 style(ax-net): apply cargo fmt to router.rs l2_counter_tests
d5d50d8f0 feat(starry,ax-net): return L2 frame length from Device send/recv for net_stats byte counters
```

## 文件变更

```
 net/ax-net/src/device/driver.rs   |  13 +-
 net/ax-net/src/device/ethernet.rs | 677 +++++++++++++++++++++++++++++++++++---
 net/ax-net/src/device/loopback.rs |  13 +-
 net/ax-net/src/device/mod.rs      |  49 ++-
 net/ax-net/src/router.rs          | 563 ++++++++++++++++++++++++++++---
 5 files changed, 1227 insertions(+), 88 deletions(-)
```
