### PR TITLE
feat(starry): add SG2002 inference benchmark

### DIFF
--- a/apps/starry/aka00-tennis-yolo/README.md
+++ b/apps/starry/aka00-tennis-yolo/README.md
@@ -135,6 +135,25 @@ cd /akars_tennis
   --iou 0.5
 ```
 
+需要采集稳定的分阶段性能数据时，可以先预热 1 轮，再测量 5 轮：
+
+```sh
+./akars-tennis-validator \
+  model/yolov8n_tennis_v2.cvimodel \
+  validation/images.txt \
+  validation/expected.txt \
+  --classes 1 \
+  --conf 0.5 \
+  --iou 0.5 \
+  --warmup 1 \
+  --repeat 5
+```
+
+`--warmup` 的结果不进入统计；`--repeat` 必须大于 0，且每一轮测量都会
+重新与 `expected.txt` 比较，避免用错误的检测结果换取更好看的耗时。
+不传这两个参数时仍执行原来的单轮校验，成功标记和检测语义不变；输出行末会
+增加轮次与分阶段耗时字段，并额外输出汇总行。
+
 ## 结果判定
 
 测试通过时会打印：
@@ -147,13 +166,14 @@ STARRY_AKA00_TENNIS_DETECT_OK
 每张图片会打印检测结果：
 
 ```text
-AKARS_TENNIS_RESULT image=0 path=validation/tennis-ball-close.jpg detections=1
-AKARS_TENNIS_DET image=0 cls=0 class=tennis_ball score_q10000=9531 confidence_percent=95.31 left=482 top=704 right=776 bottom=1002
+AKARS_TENNIS_RESULT image=0 path=validation/tennis-ball-close.jpg detections=1 run=1
+AKARS_TENNIS_DET image=0 cls=0 class=tennis_ball score_q10000=9531 confidence_percent=95.31 left=482 top=704 right=776 bottom=1002 run=1
 ```
 
 检测结果字段含义：
 
 - `image`：图片序号，对应 `validation/images.txt` 中的顺序。
+- `run`：从 1 开始的测量轮次；预热轮次不打印逐图结果。
 - `cls`：模型输出类别 id。当前模型只识别网球，`cls=0` 表示 `tennis_ball`。
 - `class`：类别名称，便于直接阅读日志。
 - `score_q10000`：模型置信度乘以 10000 后的整数表示，`9531` 表示约 `0.9531`。
@@ -163,21 +183,42 @@ AKARS_TENNIS_DET image=0 cls=0 class=tennis_ball score_q10000=9531 confidence_pe
 每张图片也会打印耗时：
 
 ```text
-AKARS_TENNIS_TIMING image=0 preprocess_us=... forward_us=... postprocess_us=... total_us=...
+AKARS_TENNIS_TIMING image=0 preprocess_us=... forward_us=... postprocess_us=... total_us=... run=1 decode_us=... resize_us=...
 ```
 
 字段含义：
 
+- `decode_us`：纯 Rust JPEG 解码耗时。
+- `resize_us`：双线性 resize、letterbox padding 清零和 RGB planar tensor 打包耗时。
 - `preprocess_us`：CPU 侧预处理耗时，包含 JPEG 解码、resize、letterbox padding 和 RGB planar tensor 打包。
 - `forward_us`：TPU 侧模型前向推理耗时，对应 CVI runtime 的 `CVI_NN_Forward` 调用。
 - `postprocess_us`：CPU 侧 YOLOv8 后处理耗时，包含输出解析、分数筛选、NMS 和 bbox 坐标还原。
 - `total_us`：单张图片端到端耗时，从开始处理图片到得到最终 detection 结果。
 
-其中 `total_us` 包含 `preprocess_us`、`forward_us`、`postprocess_us` 以及少量函数调用和统计开销；性能观察时优先看 `forward_us` 判断 TPU 推理耗时，优先看 `total_us` 判断单张图片完整链路耗时。
+其中 `preprocess_us` 包含 `decode_us`、`resize_us` 以及少量调用开销；
+`total_us` 包含 `preprocess_us`、`forward_us`、`postprocess_us` 以及少量函数
+调用和统计开销。性能观察时可以用 `decode_us` 判断 JPU 等硬件解码路径的
+潜在收益，用 `resize_us` 判断 resize/pack 是否仍是瓶颈，用 `forward_us`
+判断 TPU 推理耗时。
+
+全部测量轮次通过 golden 校验后，还会打印一行汇总：
+
+```text
+AKARS_TENNIS_BENCH_RESULT measured_runs=5 images=3 samples=15 decode_us_avg=... decode_us_p50=... decode_us_p95=... resize_us_avg=... resize_us_p50=... resize_us_p95=... preprocess_us_avg=... preprocess_us_p50=... preprocess_us_p95=... forward_us_avg=... forward_us_p50=... forward_us_p95=... postprocess_us_avg=... postprocess_us_p50=... postprocess_us_p95=... total_us_avg=... total_us_p50=... total_us_p95=...
+```
+
+`samples` 等于测量轮数乘图片数。p50/p95 使用 nearest-rank 定义，并只对
+测量轮次统计；所有数值单位均为微秒。该行适合从串口日志提取，比较同一
+硬件、模型、图片和运行参数下的 StarryOS 与 Linux 数据。
 
 ## Linux 实测耗时参考
 
-以下数据来自 CI 环境 AKA-00/SG2002 板端 Linux，部署路径为 `/akars_tennis`。每轮都会顺序识别同一组 3 张固定图片。该表用于后续性能对比，CI 是否通过仍以检测结果和成功标记为准。
+以下数据来自 CI 环境 AKA-00/SG2002 板端 Linux，部署路径为
+`/akars_tennis`。每轮都会顺序识别同一组 3 张固定图片。这是加入分阶段
+自动汇总前记录的 aggregate 基线，因此没有单独的 `decode_us` 和
+`resize_us`。后续可以用 `--warmup 1 --repeat 5` 自动复现相同轮数并获得
+更细的瓶颈数据。该表用于后续性能对比，CI 是否通过仍以检测结果和成功
+标记为准。
 
 | 轮次 | 图片 | preprocess_us | forward_us | postprocess_us | total_us |
 | --- | --- | ---: | ---: | ---: | ---: |
@@ -225,6 +266,9 @@ export LD_LIBRARY_PATH=/akars_tennis/lib:${LD_LIBRARY_PATH:-}
   --write-expected
 sync
 ```
+
+`--write-expected` 要求 `--warmup 0 --repeat 1`（也是默认值），避免把多轮
+benchmark 参数误用于更新 golden 数据。
 
 然后把板端生成的 `/akars_tennis/validation/expected.txt` 更新回仓库中的
 `apps/starry/aka00-tennis-yolo/validation/expected.txt`，再重新运行

--- a/apps/starry/aka00-tennis-yolo/akars-validator/src/main.rs
+++ b/apps/starry/aka00-tennis-yolo/akars-validator/src/main.rs
@@ -27,6 +27,14 @@ struct Cli {
     conf: f32,
     iou: f32,
     write_expected: bool,
+    warmup: usize,
+    repeat: usize,
+}
+
+#[derive(Clone, Debug)]
+struct InputImage {
+    path: String,
+    frame: CameraFrame,
 }
 
 #[derive(Clone, Debug)]
@@ -53,6 +61,72 @@ struct ExpectedSet {
     score_tolerance_q10000: i32,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TimingStats {
+    average_us: i64,
+    p50_us: i64,
+    p95_us: i64,
+}
+
+#[derive(Default)]
+struct BenchmarkSamples {
+    decode_us: Vec<i64>,
+    resize_us: Vec<i64>,
+    preprocess_us: Vec<i64>,
+    forward_us: Vec<i64>,
+    postprocess_us: Vec<i64>,
+    total_us: Vec<i64>,
+}
+
+impl BenchmarkSamples {
+    fn push(&mut self, timing: InferTiming, total_us: i64) {
+        self.decode_us.push(timing.decode_us);
+        self.resize_us.push(timing.resize_us);
+        self.preprocess_us.push(timing.preprocess_us);
+        self.forward_us.push(timing.forward_us);
+        self.postprocess_us.push(timing.postprocess_us);
+        self.total_us.push(total_us);
+    }
+
+    fn format_result(&self, measured_runs: usize, images: usize) -> String {
+        let decode = timing_stats(&self.decode_us).expect("benchmark has decode samples");
+        let resize = timing_stats(&self.resize_us).expect("benchmark has resize samples");
+        let preprocess =
+            timing_stats(&self.preprocess_us).expect("benchmark has preprocess samples");
+        let forward = timing_stats(&self.forward_us).expect("benchmark has forward samples");
+        let postprocess =
+            timing_stats(&self.postprocess_us).expect("benchmark has postprocess samples");
+        let total = timing_stats(&self.total_us).expect("benchmark has total samples");
+        format!(
+            "AKARS_TENNIS_BENCH_RESULT measured_runs={measured_runs} images={images} samples={} \
+             decode_us_avg={} decode_us_p50={} decode_us_p95={} resize_us_avg={} resize_us_p50={} \
+             resize_us_p95={} preprocess_us_avg={} preprocess_us_p50={} preprocess_us_p95={} \
+             forward_us_avg={} forward_us_p50={} forward_us_p95={} postprocess_us_avg={} \
+             postprocess_us_p50={} postprocess_us_p95={} total_us_avg={} total_us_p50={} \
+             total_us_p95={}",
+            self.total_us.len(),
+            decode.average_us,
+            decode.p50_us,
+            decode.p95_us,
+            resize.average_us,
+            resize.p50_us,
+            resize.p95_us,
+            preprocess.average_us,
+            preprocess.p50_us,
+            preprocess.p95_us,
+            forward.average_us,
+            forward.p50_us,
+            forward.p95_us,
+            postprocess.average_us,
+            postprocess.p50_us,
+            postprocess.p95_us,
+            total.average_us,
+            total.p50_us,
+            total.p95_us,
+        )
+    }
+}
+
 #[derive(Debug)]
 struct ValidationError(String);
 
@@ -69,6 +143,28 @@ impl fmt::Display for ValidationError {
 }
 
 impl std::error::Error for ValidationError {}
+
+fn timing_stats(values: &[i64]) -> Option<TimingStats> {
+    if values.is_empty() {
+        return None;
+    }
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+    let sum: i128 = sorted.iter().map(|value| i128::from(*value)).sum();
+    let average_us = (sum / sorted.len() as i128) as i64;
+    Some(TimingStats {
+        average_us,
+        p50_us: nearest_rank(&sorted, 50),
+        p95_us: nearest_rank(&sorted, 95),
+    })
+}
+
+fn nearest_rank(sorted: &[i64], percentile: usize) -> i64 {
+    debug_assert!(!sorted.is_empty());
+    debug_assert!((1..=100).contains(&percentile));
+    let rank = (percentile * sorted.len()).div_ceil(100);
+    sorted[rank - 1]
+}
 
 fn main() {
     if let Err(err) = run() {
@@ -90,6 +186,19 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let cwd = env::current_dir()?;
     let list_root = cli.image_list.parent().unwrap_or_else(|| Path::new("."));
+    let mut input_images = Vec::with_capacity(image_paths.len());
+    for rel_path in image_paths {
+        let image_path = resolve_image_path(&cwd, list_root, &rel_path);
+        input_images.push(InputImage {
+            path: rel_path,
+            frame: CameraFrame {
+                jpeg: fs::read(image_path)?,
+                width: 0,
+                height: 0,
+            },
+        });
+    }
+
     let mut model = open_model(&cli.model)?;
     let config = InferenceConfig {
         classes_num: cli.classes,
@@ -97,61 +206,21 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         iou_threshold: cli.iou,
     };
 
-    let mut actual = Vec::new();
-    for (index, rel_path) in image_paths.iter().enumerate() {
-        let image_path = resolve_image_path(&cwd, list_root, rel_path);
-        let image = fs::read(&image_path)?;
-        let frame = CameraFrame {
-            jpeg: image,
-            width: 0,
-            height: 0,
-        };
-
-        let mut timing = InferTiming::default();
-        let total_start = Instant::now();
-        let detections = model.infer_timed(&frame, config, Some(&mut timing))?;
-        let total_us = total_start.elapsed().as_micros() as i64;
-        let normalized = normalize_detections(&detections);
-
-        println!(
-            "AKARS_TENNIS_RESULT image={index} path={} detections={}",
-            shell_word(rel_path),
-            normalized.len()
-        );
-        for det in &normalized {
-            println!(
-                "AKARS_TENNIS_DET image={index} cls={} class={} score_q10000={} \
-                 confidence_percent={:.2} left={} top={} right={} bottom={}",
-                det.cls,
-                class_name(det.cls),
-                det.score_q10000,
-                f64::from(det.score_q10000) / 100.0,
-                det.left,
-                det.top,
-                det.right,
-                det.bottom
-            );
+    for _ in 0..cli.warmup {
+        for input in &input_images {
+            let _ = infer_frame(&mut model, &input.frame, config)?;
         }
+    }
+    if cli.warmup > 0 {
         println!(
-            "AKARS_TENNIS_TIMING image={index} preprocess_us={} forward_us={} postprocess_us={} \
-             total_us={}",
-            timing.preprocess_us, timing.forward_us, timing.postprocess_us, total_us
+            "AKARS_TENNIS_WARMUP_DONE runs={} images={}",
+            cli.warmup,
+            input_images.len()
         );
-
-        actual.push(ImageExpected {
-            index,
-            path: rel_path.clone(),
-            detections: normalized,
-        });
     }
 
-    let actual_set = ExpectedSet {
-        images: actual,
-        bbox_tolerance_px: DEFAULT_BBOX_TOLERANCE_PX,
-        score_tolerance_q10000: DEFAULT_SCORE_TOLERANCE_Q10000,
-    };
-
     if cli.write_expected {
+        let actual_set = run_measured_pass(&mut model, &input_images, config, 1, None)?;
         fs::write(
             &cli.expected,
             format_expected(&actual_set, cli.classes, cli.conf, cli.iou),
@@ -165,12 +234,90 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let expected = parse_expected(&fs::read_to_string(&cli.expected)?)?;
-    compare_expected(&expected, &actual_set)?;
-    println!(
-        "AKARS_TENNIS_VALIDATE_PASS images={}",
-        actual_set.images.len()
-    );
+    let mut samples = BenchmarkSamples::default();
+    for run_index in 1..=cli.repeat {
+        let actual_set = run_measured_pass(
+            &mut model,
+            &input_images,
+            config,
+            run_index,
+            Some(&mut samples),
+        )?;
+        compare_expected(&expected, &actual_set)?;
+    }
+    println!("AKARS_TENNIS_VALIDATE_PASS images={}", input_images.len());
+    println!("{}", samples.format_result(cli.repeat, input_images.len()));
     Ok(())
+}
+
+fn run_measured_pass(
+    model: &mut tpu::YoloModel,
+    input_images: &[InputImage],
+    config: InferenceConfig,
+    run_index: usize,
+    mut samples: Option<&mut BenchmarkSamples>,
+) -> Result<ExpectedSet, Box<dyn std::error::Error>> {
+    let mut actual = Vec::with_capacity(input_images.len());
+    for (index, input) in input_images.iter().enumerate() {
+        let (normalized, timing, total_us) = infer_frame(model, &input.frame, config)?;
+
+        println!(
+            "AKARS_TENNIS_RESULT image={index} path={} detections={} run={run_index}",
+            shell_word(&input.path),
+            normalized.len()
+        );
+        for det in &normalized {
+            println!(
+                "AKARS_TENNIS_DET image={index} cls={} class={} score_q10000={} \
+                 confidence_percent={:.2} left={} top={} right={} bottom={} run={run_index}",
+                det.cls,
+                class_name(det.cls),
+                det.score_q10000,
+                f64::from(det.score_q10000) / 100.0,
+                det.left,
+                det.top,
+                det.right,
+                det.bottom
+            );
+        }
+        println!(
+            "AKARS_TENNIS_TIMING image={index} preprocess_us={} forward_us={} postprocess_us={} \
+             total_us={} run={run_index} decode_us={} resize_us={}",
+            timing.preprocess_us,
+            timing.forward_us,
+            timing.postprocess_us,
+            total_us,
+            timing.decode_us,
+            timing.resize_us
+        );
+
+        if let Some(samples) = samples.as_deref_mut() {
+            samples.push(timing, total_us);
+        }
+        actual.push(ImageExpected {
+            index,
+            path: input.path.clone(),
+            detections: normalized,
+        });
+    }
+
+    Ok(ExpectedSet {
+        images: actual,
+        bbox_tolerance_px: DEFAULT_BBOX_TOLERANCE_PX,
+        score_tolerance_q10000: DEFAULT_SCORE_TOLERANCE_Q10000,
+    })
+}
+
+fn infer_frame(
+    model: &mut tpu::YoloModel,
+    frame: &CameraFrame,
+    config: InferenceConfig,
+) -> Result<(Vec<ExpectedDetection>, InferTiming, i64), tpu::TpuError> {
+    let mut timing = InferTiming::default();
+    let total_start = Instant::now();
+    let detections = model.infer_timed(frame, config, Some(&mut timing))?;
+    let total_us = total_start.elapsed().as_micros() as i64;
+    Ok((normalize_detections(&detections), timing, total_us))
 }
 
 fn parse_cli(args: impl Iterator<Item = String>) -> Result<Cli, ValidationError> {
@@ -182,6 +329,8 @@ fn parse_cli(args: impl Iterator<Item = String>) -> Result<Cli, ValidationError>
         conf: 0.5,
         iou: 0.5,
         write_expected: false,
+        warmup: 0,
+        repeat: 1,
     };
     let mut positional = 0;
     let mut args = args.peekable();
@@ -194,6 +343,8 @@ fn parse_cli(args: impl Iterator<Item = String>) -> Result<Cli, ValidationError>
             "--classes" => cli.classes = take_parse(&mut args, "--classes")?,
             "--conf" => cli.conf = take_parse(&mut args, "--conf")?,
             "--iou" => cli.iou = take_parse(&mut args, "--iou")?,
+            "--warmup" => cli.warmup = take_parse(&mut args, "--warmup")?,
+            "--repeat" => cli.repeat = take_parse(&mut args, "--repeat")?,
             "--write-expected" => cli.write_expected = true,
             value if value.starts_with('-') => {
                 return Err(ValidationError::new(format!("unknown option: {value}")));
@@ -225,6 +376,14 @@ fn parse_cli(args: impl Iterator<Item = String>) -> Result<Cli, ValidationError>
     }
     if cli.classes <= 0 {
         return Err(ValidationError::new("--classes must be positive"));
+    }
+    if cli.repeat == 0 {
+        return Err(ValidationError::new("--repeat must be positive"));
+    }
+    if cli.write_expected && (cli.warmup != 0 || cli.repeat != 1) {
+        return Err(ValidationError::new(
+            "--write-expected requires --warmup 0 and --repeat 1",
+        ));
     }
     Ok(cli)
 }
@@ -526,7 +685,7 @@ fn class_name(cls: i32) -> &'static str {
 fn print_usage() {
     eprintln!(
         "Usage: akars-tennis-validator <model.cvimodel> <images.txt> <expected.txt> \
-         [--write-expected] [--classes N] [--conf X] [--iou X]"
+         [--write-expected] [--classes N] [--conf X] [--iou X] [--warmup N] [--repeat N]"
     );
 }
 
@@ -535,6 +694,94 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
+
+    fn cli_args(extra: &[&str]) -> Vec<String> {
+        ["model.cvimodel", "images.txt", "expected.txt"]
+            .into_iter()
+            .chain(extra.iter().copied())
+            .map(str::to_owned)
+            .collect()
+    }
+
+    #[test]
+    fn benchmark_cli_defaults_to_one_measured_pass() {
+        let cli = parse_cli(cli_args(&[]).into_iter()).unwrap();
+        assert_eq!(cli.warmup, 0);
+        assert_eq!(cli.repeat, 1);
+    }
+
+    #[test]
+    fn benchmark_cli_accepts_warmup_and_repeat() {
+        let cli = parse_cli(cli_args(&["--warmup", "2", "--repeat", "5"]).into_iter()).unwrap();
+        assert_eq!(cli.warmup, 2);
+        assert_eq!(cli.repeat, 5);
+    }
+
+    #[test]
+    fn benchmark_cli_rejects_zero_repeat() {
+        let error = parse_cli(cli_args(&["--repeat", "0"]).into_iter()).unwrap_err();
+        assert!(error.to_string().contains("--repeat must be positive"));
+    }
+
+    #[test]
+    fn write_expected_rejects_non_default_benchmark_parameters() {
+        let error = parse_cli(
+            cli_args(&["--write-expected", "--warmup", "1", "--repeat", "2"]).into_iter(),
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires --warmup 0 and --repeat 1")
+        );
+    }
+
+    #[test]
+    fn timing_stats_use_nearest_rank_percentiles() {
+        assert_eq!(
+            timing_stats(&[1, 2, 3, 4, 100]),
+            Some(TimingStats {
+                average_us: 22,
+                p50_us: 3,
+                p95_us: 100,
+            })
+        );
+        assert_eq!(timing_stats(&[]), None);
+    }
+
+    #[test]
+    fn benchmark_summary_has_stable_stage_fields() {
+        let mut samples = BenchmarkSamples::default();
+        samples.push(
+            InferTiming {
+                decode_us: 10,
+                resize_us: 20,
+                preprocess_us: 30,
+                forward_us: 40,
+                postprocess_us: 50,
+            },
+            120,
+        );
+        samples.push(
+            InferTiming {
+                decode_us: 20,
+                resize_us: 30,
+                preprocess_us: 50,
+                forward_us: 60,
+                postprocess_us: 70,
+            },
+            180,
+        );
+
+        assert_eq!(
+            samples.format_result(1, 2),
+            "AKARS_TENNIS_BENCH_RESULT measured_runs=1 images=2 samples=2 decode_us_avg=15 \
+             decode_us_p50=10 decode_us_p95=20 resize_us_avg=25 resize_us_p50=20 resize_us_p95=30 \
+             preprocess_us_avg=40 preprocess_us_p50=30 preprocess_us_p95=50 forward_us_avg=50 \
+             forward_us_p50=40 forward_us_p95=60 postprocess_us_avg=60 postprocess_us_p50=50 \
+             postprocess_us_p95=70 total_us_avg=150 total_us_p50=120 total_us_p95=180"
+        );
+    }
 
     #[test]
     fn resolves_paths_relative_to_cwd_first() {

--- a/apps/starry/aka00-tennis-yolo/akars-validator/src/tpu.rs
+++ b/apps/starry/aka00-tennis-yolo/akars-validator/src/tpu.rs
@@ -21,6 +21,10 @@ impl Default for InferenceConfig {
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct InferTiming {
+    /// JPEG decode microseconds.
+    pub decode_us: i64,
+    /// Resize, letterbox clear, and planar pack microseconds.
+    pub resize_us: i64,
     /// CPU-side JPEG decode, resize, letterbox, and tensor packing microseconds.
     pub preprocess_us: i64,
     /// CVI_NN_Forward microseconds.
@@ -278,6 +282,8 @@ mod imp {
 
             if let Some(t) = timing.as_deref_mut() {
                 *t = InferTiming {
+                    decode_us: preprocess.decode_us,
+                    resize_us: preprocess.resize_us,
                     preprocess_us,
                     forward_us,
                     postprocess_us,


### PR DESCRIPTION
## 修改

- 为 SG2002 tennis validator 增加 warmup 和 repeat 参数；预热不计入统计，每个测量轮次继续执行 golden 校验。
- 分别记录 decode、resize、preprocess、forward、postprocess 和 total 耗时。
- 增加稳定的 AKARS_TENNIS_BENCH_RESULT 汇总行，输出 average、p50 和 p95（nearest-rank）。
- 在 README 中补充命令用法、字段定义和既有 aggregate 基线说明。

## 兼容性

- 默认配置保持原有单轮校验行为。
- 保留原有日志前缀和主要字段顺序，只追加轮次、分阶段耗时和汇总信息。
- write-expected 仅允许使用默认 benchmark 参数，避免从多轮测量误写 golden。
- 不修改图像预处理、模型、validation 数据、TPU 驱动或 ABI。

## 验证

- cargo fmt 检查通过。
- cargo test 通过，共 16 项。
- cargo clippy --all-targets 通过。
- SG2002 RISC-V musl release 交叉构建通过。

## 说明

- 本 PR 只增加基准测量能力，不包含性能优化或板端性能结论。
- p50/p95 汇总固定图片集的全部测量样本，用于相同输入和参数下的 A/B 对比。
- 每个样本仍会输出日志；通过慢速串口比较时应保持相同日志配置。