### PR TITLE
test(cpu-webgpu-compute): WebGPU compute carpet - CPU software (Node/wgpu-native)

### DIFF
--- a/apps/starry/cpu-webgpu-compute/.gitignore
+++ b/apps/starry/cpu-webgpu-compute/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+node_modules
+programs/carpets/webgpu_ts/webgpu_ts_full_api.js
+target/

--- a/apps/starry/cpu-webgpu-compute/README.md
+++ b/apps/starry/cpu-webgpu-compute/README.md
@@ -1,0 +1,120 @@
+# cpu-webgpu-compute - WebGPU compute-API carpet (JS / TS, Deno on-target)
+
+WebGPU compute cells (JavaScript + TypeScript) that drive the WebGPU API - adapter, device, buffers,
+shader modules, compute pipelines, bind groups, command encoders, error scopes, timestamp queries -
+and check every operator per element against a reference computed independently in the same language.
+They run **on StarryOS via Deno**, whose built-in WebGPU is **gfx-rs wgpu-core** landing on **Mesa
+lavapipe** (software Vulkan on the CPU, no GPU required).
+
+## The two WebGPU engines (why this app is the Firefox/Deno path)
+
+There are two production WebGPU implementations, and this matters for what runs on musl:
+
+- **Chromium's WebGPU = Dawn** (C++). Shipped as the `webgpu` npm dawn native addon, which is a
+  glibc-only prebuilt, so musl Node cannot load it. Dawn's on-target home is inside the browser
+  (campaign #391).
+- **Firefox / Servo / Deno's WebGPU = wgpu** (gfx-rs, Rust: `wgpu-core` / `wgpu-native`). This is the
+  **exact engine `cpu-wgpu-compute` #1576 already builds on musl** for all four arches. Deno embeds
+  `wgpu-core` directly, so a musl Deno gives us the JS/TS WebGPU surface on-target with no new engine
+  to build - we only test an existing runtime.
+
+### Verified call chain (source + strace, not assumed)
+
+Traced end to end - every link is either a source dependency declaration or a real `strace` `openat`:
+
+```
+navigator.gpu (Deno JS/TS global)
+ -> deno_webgpu            [Deno ext/webgpu/Cargo.toml: "WebGPU implementation for Deno"]
+ -> wgpu-core + wgpu-types (gfx-rs; feature "vulkan" on Unix)
+ -> wgpu-hal               (hardware abstraction layer)
+ -> ash (Vulkan FFI) + libloading (runtime loader)          <-- source chain ends here
+ -> dlopen libvulkan.so.1                       (Vulkan loader)          <-- strace
+ -> /usr/share/vulkan/icd.d/lvp_icd.json        (ICD manifest)          <-- strace
+ -> libvulkan_lvp.so                            (Mesa lavapipe, sw Vulkan) <-- strace
+ -> libgallium + libLLVM.so.20                  (llvmpipe CPU JIT)      <-- strace
+ -> WGSL -> SPIR-V -> NIR -> LLVM -> host CPU machine code (runs on the CPU)
+```
+
+The source chain (ending at `libloading`) and the runtime chain (starting at `dlopen libvulkan.so.1`)
+meet exactly at `libloading -> libvulkan.so.1`. The final native dependency is `libLLVM` (llvmpipe's
+CPU JIT); there is no GPU in the path.
+
+## Cells
+
+| cell | file | assertions | on-target |
+|------|------|-----------:|-----------|
+| webgpu_js | `programs/carpets/webgpu_js/webgpu_js_full_api.js` | 78 | x86_64 + aarch64 (Deno) |
+| webgpu_ts | `programs/carpets/webgpu_ts/webgpu_ts_full_api.ts` | 77 | x86_64 + aarch64 (Deno, runs .ts natively) |
+
+Each cell prints `<NAME>_FULL_API OK <n>` only when every assertion passes and the count equals the
+pinned total, together with a `PASS=<p> FAIL=<f> TOTAL=<t> EXPECTED=<e>` line. The carpets are
+runtime-agnostic: on Deno (and in a browser) they use the global `navigator.gpu`; under Node they fall
+back to the dawn `webgpu` package, so the same source runs on both engines.
+
+## Arch coverage
+
+The WebGPU **standalone JS/TS runtime** is Deno, and Deno's musl arch reach - verified against the
+Alpine package DB and rusty_v8 release assets, not assumed - decides on-target coverage:
+
+- **x86_64**: Alpine edge/community ships a **native-musl `deno`** (2.7.4-r2) -> `webgpu_js` +
+  `webgpu_ts` run on-target on lavapipe.
+- **aarch64**: Alpine edge/community **also** ships a native-musl `deno` (rusty_v8 v150.2.0+ carries an
+  `aarch64-unknown-linux-musl` static V8 lib) -> `webgpu_js` + `webgpu_ts` run on-target, same as
+  x86_64.
+
+Both arches are advertised (`qemu-x86_64.toml`, `qemu-aarch64.toml`) and gated identically. The same
+wgpu-core engine already covers four-arch WebGPU **compute** in `cpu-wgpu-compute` #1576.
+
+## Coverage (per the WebGPU spec / @webgpu/types)
+
+Both JS and TS cells cover the same API surface, checked against the WebGPU IDL:
+
+- entry + adapter: `gpu.requestAdapter`, `adapter.info`, `adapter.features` (set-like), `adapter.limits`
+- device + queue: `requestDevice` with `requiredFeatures` + `requiredLimits`, `device.limits`,
+  `device.features`, `device.queue`, `uncapturederror` event, `device.destroy` + `device.lost`
+- buffers: `createBuffer`, `mappedAtCreation` + `getMappedRange` + `unmap`, `mapAsync`, `mapState`
+  transitions, `writeBuffer`, `usage`/`size` queries, `clearBuffer`, `destroy`
+- shaders: `createShaderModule`, `getCompilationInfo` (error and clean cases), a broken-WGSL
+  compile-error path via an error scope
+- pipeline objects: `createBindGroupLayout`, `createPipelineLayout`, `createComputePipeline`,
+  `createComputePipelineAsync`, `createBindGroup` (static and dynamic-offset)
+- commands: `createCommandEncoder`, `beginComputePass`, `setPipeline`, `setBindGroup`,
+  `dispatchWorkgroups`, `dispatchWorkgroupsIndirect`, `copyBufferToBuffer` (full + windowed)
+- error scopes: `pushErrorScope` / `popErrorScope` on bad bind-group, oversized copy, use-after-destroy
+- timestamp queries: `createQuerySet` + `timestampWrites` + `resolveQuerySet` (feature-gated;
+  non-counting when the adapter lacks `timestamp-query`)
+
+Operators are checked per element against a reference computed in JS / TS: vadd (`c = a + b`), saxpy
+(`c = alpha*a + b`, including alpha=0 and a partial-n window), element-wise multiply (`c = a * b`),
+add-one (`c = a + 1`, including an async pipeline, an indirect dispatch, and dynamic-offset windows),
+and a large multi-workgroup grid (1<<20 elements, every element verified). f32 rounding is handled
+with a relative tolerance for the scaled cases and exact equality for cases that round-trip through
+f32 identically.
+
+Negative controls prove the equality checks are load-bearing: an independent wrong reference
+(`a + b + 1`) must be rejected, and a single corrupted output element must be flagged at exactly its
+index. Boundary cases cover `dispatchWorkgroups(0)` (output untouched), a zero-size buffer, and an
+out-of-range `getMappedRange` that throws.
+
+## Run (host)
+
+```
+bash programs/run_all.sh            # runs webgpu_js + webgpu_ts on Deno, gates on OK markers
+```
+
+`run_all.sh` needs `deno` on PATH; it sets `VK_DRIVER_FILES` to the lavapipe ICD and
+`LP_NUM_THREADS=1`, runs both cells on Deno (which runs .js and .ts natively), and prints
+`TEST PASSED` only when every gated cell reports its `OK <n>` marker. Host validation:
+webgpu_js 78/78, webgpu_ts 77/77 on lavapipe (adapter `llvmpipe (LLVM 20.1.2)`).
+
+## Run (on-target)
+
+```
+cargo xtask starry app qemu -t cpu-webgpu-compute --arch x86_64
+cargo xtask starry app qemu -t cpu-webgpu-compute --arch aarch64
+```
+
+The on-target run boots StarryOS (single vCPU, `-smp 1`) and runs `run-webgpu.sh`, which reads the
+capability manifest `prebuild.sh` staged (the cells whose runtime was provisioned on this arch), runs
+each on Deno against lavapipe, and prints `TEST PASSED` only when `fail==0` and the pass count equals
+the manifest total (`EXPECTED>=2`). It never emits a 0-carpet pass.

--- a/apps/starry/cpu-webgpu-compute/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-webgpu-compute/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,9 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/cpu-webgpu-compute/build-x86_64-unknown-none.toml
+++ b/apps/starry/cpu-webgpu-compute/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/cpu-webgpu-compute/prebuild.sh
+++ b/apps/starry/cpu-webgpu-compute/prebuild.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the on-target WebGPU JS/TS runtime and stage the carpets into the per-arch
+# Alpine rootfs.
+#
+# WebGPU standalone runtime = Deno (V8 + a built-in copy of gfx-rs wgpu-core, the Rust WebGPU engine
+# Firefox and Servo also use, and the exact engine cpu-wgpu-compute #1576 builds on musl). Deno runs
+# .js and .ts natively; its global navigator.gpu drives wgpu-core -> the Vulkan backend -> Mesa
+# lavapipe (software Vulkan on the CPU), so the JS/TS WebGPU carpets run entirely on the CPU with no
+# GPU. This script extracts the base Alpine rootfs, `apk add`s mesa-vulkan-swrast (lavapipe) + the
+# Vulkan loader + (x86_64 only) deno via qemu-user-static, then stages Deno + the lavapipe closure +
+# the webgpu_js / webgpu_ts carpets + a capability manifest into the overlay.
+#
+# Arch reality (verified against the Alpine package DB + rusty_v8 release assets, not assumed):
+#   - x86_64: Alpine edge/community ships a native-musl `deno` (2.7.4-r2) -> on-target JS/TS gate.
+#   - aarch64: Alpine edge/community ALSO ships a native-musl `deno` (rusty_v8 v150.2.0+ carries an
+#     aarch64-unknown-linux-musl static V8 lib) -> on-target JS/TS gate, same as x86_64.
+# Both the C-side four-arch WebGPU *compute* (cpu-wgpu-compute #1576, same wgpu-core) and the browser
+# WebGPU (campaign #391: Chromium=Dawn, Firefox/Servo/Deno=wgpu-core) sit alongside this app.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS (base alpine working copy),
+# STARRY_STAGING_ROOT (scratch extraction tree), STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+PROG="$app_dir/programs"
+
+case "$arch" in
+    aarch64) qemu_runner="qemu-aarch64-static" ;;
+    x86_64)  qemu_runner="qemu-x86_64-static" ;;
+    *) echo "prebuild: unsupported arch: $arch (this carpet is x86_64/aarch64 only)" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+}
+
+# The harness injects $STARRY_OVERLAY_DIR into $base_rootfs via debugfs WITHOUT resizing, so the
+# per-app image must be grown here first. The overlay carries the mesa/lavapipe closure + its LLVM
+# runtime plus the Deno binary (~100 MiB); the stock ~2 GiB image overflows and debugfs silently
+# truncates ("Could not allocate block"), surfacing at runtime as "symbol not found". Idempotent.
+ROOTFS_SIZE=4G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    command -v resize2fs >/dev/null 2>&1 || { echo "prebuild: resize2fs required (e2fsprogs)" >&2; exit 1; }
+    local before after
+    before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB (fs resized) for lavapipe + Deno"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# mesa software Vulkan (lavapipe) + LLVM + the Vulkan loader, all musl for the target arch. `deno`
+# (native musl) is added only for x86_64, the sole arch Alpine builds it for. mesa-dev is intentionally
+# not installed (it pulls the ~200MB clang-libs closure the runtime does not need).
+GPU_PKGS=(musl mesa-vulkan-swrast vulkan-loader vulkan-headers zlib)
+case "$arch" in x86_64|aarch64) GPU_PKGS+=(deno) ;; esac
+
+apk_provision() {
+    normalize_symlinks
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add WebGPU runtime stack (${GPU_PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add "${GPU_PKGS[@]}"
+    [[ -f "$staging_root/usr/lib/libvulkan_lvp.so" ]] || { echo "prebuild: mesa-vulkan-swrast (lavapipe) not provisioned" >&2; exit 3; }
+}
+
+# Stage the carpets + the capability manifest. Deno runs .js/.ts natively, so no tsc, node_modules, or
+# build step is needed on-target. The manifest lists exactly the cells whose runtime was provisioned on
+# this arch (Deno present => webgpu_js + webgpu_ts); run-webgpu.sh gates on that exact set (fail==0 &&
+# total==EXPECTED==pass, EXPECTED>=2). On arches with no Deno the manifest is empty and run-webgpu.sh
+# refuses to emit a pass.
+stage_carpets() {
+    local bin="$staging_root/opt/cpu-webgpu-compute"
+    mkdir -p "$bin/carpets/webgpu_js" "$bin/carpets/webgpu_ts"
+    install -Dm0644 "$PROG/carpets/webgpu_js/webgpu_js_full_api.js" "$bin/carpets/webgpu_js/webgpu_js_full_api.js"
+    install -Dm0644 "$PROG/carpets/webgpu_ts/webgpu_ts_full_api.ts" "$bin/carpets/webgpu_ts/webgpu_ts_full_api.ts"
+    install -Dm0755 "$PROG/run-webgpu.sh" "$bin/run-webgpu.sh"
+    : > "$bin/expected_cells"
+    if [[ -x "$staging_root/usr/bin/deno" ]]; then
+        echo "webgpu_js" >> "$bin/expected_cells"
+        echo "webgpu_ts" >> "$bin/expected_cells"
+        echo "prebuild: Deno provisioned ($("$staging_root/usr/bin/deno" --version 2>/dev/null | head -1 || echo deno)); cells = webgpu_js webgpu_ts"
+    else
+        echo "prebuild: no native-musl Deno provisioned for $arch yet (x86_64/aarch64 only); manifest empty"
+    fi
+    echo "prebuild: expected_cells for $arch = $(tr '\n' ' ' < "$bin/expected_cells")"
+}
+
+populate_overlay() {
+    mkdir -p "$overlay_dir/usr/lib" "$overlay_dir/usr/share" "$overlay_dir/opt" "$overlay_dir/usr/bin"
+    # the provisioned /usr/lib closure (mesa lavapipe + LLVM + Vulkan loader) and ICD metadata
+    cp -a "$staging_root/usr/lib/." "$overlay_dir/usr/lib/"
+    cp -a "$staging_root/usr/share/vulkan" "$overlay_dir/usr/share/" 2>/dev/null || true
+    # Deno binary (x86_64); its musl deps live under /usr/lib (already copied above)
+    [[ -x "$staging_root/usr/bin/deno" ]] && install -Dm0755 "$staging_root/usr/bin/deno" "$overlay_dir/usr/bin/deno"
+    cp -a "$staging_root/opt/cpu-webgpu-compute" "$overlay_dir/opt/"
+    install -Dm0755 "$PROG/run-webgpu.sh" "$overlay_dir/usr/bin/run-webgpu.sh"
+    echo "prebuild: overlay populated for $arch ($(du -sh "$overlay_dir/usr/lib" | cut -f1) libs)"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+stage_carpets
+populate_overlay
+echo "prebuild: cpu-webgpu-compute overlay ready for $arch"

--- a/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_js/package.json
+++ b/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_js/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@webgpu/types": "^0.1.71",
+    "ts-node": "^10.9.2",
+    "typescript": "^7.0.2",
+    "webgpu": "^0.4.0"
+  }
+}

--- a/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_js/webgpu_js_full_api.js
+++ b/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_js/webgpu_js_full_api.js
@@ -1,0 +1,799 @@
+// webgpu_js_full_api - full WebGPU JS compute-API carpet on Mesa lavapipe, driven by the dawn-based
+// `webgpu` node package. Walks the WebGPU object graph - gpu / adapter / device / queue / shader-module
+// / buffer / bind-group-layout / pipeline-layout / compute-pipeline / bind-group / command-encoder /
+// compute-pass / dispatch / copy-buffer-to-buffer / mapAsync - and asserts vadd/saxpy/mul results per
+// element against a JS-computed reference. Prints "WEBGPU_JS_FULL_API OK <n>" only when every assertion
+// passes and the count equals the pinned EXPECTED total.
+
+'use strict';
+
+// [runtime-agnostic] GPU instance acquired below: Deno/browser expose global navigator.gpu (wgpu-core,
+// the Firefox/Deno WebGPU engine); Node uses the dawn-based webgpu package. We only TEST the WebGPU API.
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond, desc) {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    process.stderr.write('FAIL: ' + desc + '\n');
+  }
+}
+
+// f32 rounding makes scaled results inexact vs a JS double reference; use a relative tolerance there and
+// exact equality for the +/* cases that round-trip through f32 identically.
+function feq(a, b) {
+  return Math.abs(a - b) <= 1e-4 * (1.0 + Math.abs(b));
+}
+
+function allEq(got, ref) {
+  if (got.length !== ref.length) return false;
+  for (let i = 0; i < ref.length; i++) {
+    if (got[i] !== ref[i]) return false;
+  }
+  return true;
+}
+
+function allFeq(got, ref) {
+  if (got.length !== ref.length) return false;
+  for (let i = 0; i < ref.length; i++) {
+    if (!feq(got[i], ref[i])) return false;
+  }
+  return true;
+}
+
+// WGSL compute shader: c[i] = alpha*a[i] + b[i]. alpha and n come from a uniform block so the same
+// pipeline drives both vadd (alpha=1) and saxpy (alpha=k).
+const SAXPY_WGSL = `
+struct Params { alpha: f32, n: u32 };
+@group(0) @binding(0) var<storage, read>       a: array<f32>;
+@group(0) @binding(1) var<storage, read>       b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+@group(0) @binding(3) var<uniform>             p: Params;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i < p.n) {
+    c[i] = p.alpha * a[i] + b[i];
+  }
+}
+`;
+
+// Second shader (separate module + pipeline): c[i] = a[i] * b[i], no uniform - exercises a distinct
+// bind-group-layout (3 storage bindings) and a second compute pipeline.
+const MUL_WGSL = `
+@group(0) @binding(0) var<storage, read>       a: array<f32>;
+@group(0) @binding(1) var<storage, read>       b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i < arrayLength(&a)) {
+    c[i] = a[i] * b[i];
+  }
+}
+`;
+
+// Deliberately-invalid WGSL: unterminated statement + unknown builtin. Used to exercise the
+// compile-error diagnostic path (getCompilationInfo + validation error scope).
+const BROKEN_WGSL = `
+@compute @workgroup_size(64)
+fn main() {
+  let x = ;
+  totally_not_a_function(x)
+}
+`;
+
+// Single-storage-binding add-one shader for the large-N multi-workgroup grid and the
+// dynamic-offset / indirect-dispatch coverage.
+const ADD1_WGSL = `
+@group(0) @binding(0) var<storage, read>       a: array<f32>;
+@group(0) @binding(1) var<storage, read_write> c: array<f32>;
+@compute @workgroup_size(256)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i < arrayLength(&a)) {
+    c[i] = a[i] + 1.0;
+  }
+}
+`;
+
+const N = 2048;
+const WG = 64;
+const NBYTES = N * 4;
+const GROUPS = Math.ceil(N / WG);
+
+function packParams(alpha, n) {
+  const buf = new ArrayBuffer(16);
+  new Float32Array(buf, 0, 1)[0] = alpha;
+  new Uint32Array(buf, 4, 1)[0] = n;
+  return buf;
+}
+
+function storageEntry(binding, readOnly) {
+  return {
+    binding,
+    visibility: GPUShaderStage.COMPUTE,
+    buffer: { type: readOnly ? 'read-only-storage' : 'storage' },
+  };
+}
+
+function finish() {
+  const expected = 78;
+  const total = PASS + FAIL;
+  console.log(
+    'webgpu-js: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + expected
+  );
+  if (FAIL === 0 && total === expected) {
+    console.log('WEBGPU_JS_FULL_API OK ' + PASS);
+    return 0;
+  }
+  console.log('WEBGPU_JS_FULL_API FAIL');
+  return 1;
+}
+
+async function run() {
+  // --- gpu entry + adapter --------------------------------------------------------------------
+  let gpu;
+  if (typeof navigator !== 'undefined' && navigator.gpu) {
+    gpu = navigator.gpu;                     // Deno (wgpu-core) / browser: global navigator.gpu
+  } else {
+    const { create, globals } = require('webgpu');  // Node: dawn-based webgpu package
+    Object.assign(globalThis, globals);
+    gpu = create([]);
+  }
+  ok(gpu != null, 'GPU instance available (navigator.gpu or dawn create)');
+  ok(typeof gpu.requestAdapter === 'function', 'gpu.requestAdapter is function');
+
+  const adapter = await gpu.requestAdapter({ powerPreference: 'low-power' });
+  ok(adapter != null, 'requestAdapter non-null');
+  if (adapter == null) {
+    return finish();
+  }
+
+  const info = adapter.info;
+  console.log(
+    'webgpu-js adapter selected: vendor=' + info.vendor +
+    ' architecture=' + info.architecture +
+    ' device=' + info.device +
+    ' description=' + info.description
+  );
+  ok(info != null, 'adapter.info present');
+  ok(String(info.description || info.device || '').length > 0, 'adapter.info description/device non-empty');
+
+  // adapter capability queries
+  const feats = adapter.features;
+  ok(typeof feats.has === 'function', 'adapter.features is set-like');
+  const featCount = [...feats].length;
+  ok(featCount === feats.size, 'adapter.features spread length equals set size');
+  const alim = adapter.limits;
+  ok(alim.maxComputeWorkgroupSizeX >= 64, 'adapter.limits maxComputeWorkgroupSizeX>=64');
+  ok(alim.maxStorageBuffersPerShaderStage >= 3, 'adapter.limits maxStorageBuffersPerShaderStage>=3');
+  ok(alim.maxBindGroups >= 1, 'adapter.limits maxBindGroups>=1');
+  ok(alim.maxComputeInvocationsPerWorkgroup >= 64, 'adapter.limits maxComputeInvocationsPerWorkgroup>=64');
+  ok(alim.maxComputeWorkgroupsPerDimension >= 65535, 'adapter.limits maxComputeWorkgroupsPerDimension>=65535');
+
+  // --- device + queue -------------------------------------------------------------------------
+  // requestDevice with requiredFeatures + requiredLimits: only ask for timestamp-query when the
+  // adapter advertises it (lavapipe does), and floor a limit we actually consume so a device that
+  // cannot honour it is rejected up front rather than failing later.
+  const hasTimestamp = feats.has('timestamp-query');
+  const requiredFeatures = hasTimestamp ? ['timestamp-query'] : [];
+  const device = await adapter.requestDevice({
+    label: 'carpet-device',
+    requiredFeatures,
+    requiredLimits: { maxComputeInvocationsPerWorkgroup: 64 },
+  });
+  ok(device != null, 'requestDevice non-null');
+  ok(device.limits.maxComputeInvocationsPerWorkgroup >= 64, 'requiredLimits honoured (maxComputeInvocationsPerWorkgroup>=64)');
+  ok(!hasTimestamp || device.features.has('timestamp-query'), 'requiredFeatures granted: device.features has timestamp-query');
+  const dlim = device.limits;
+  ok(dlim.maxComputeInvocationsPerWorkgroup >= 64, 'device.limits maxComputeInvocationsPerWorkgroup>=64');
+  ok(typeof device.features.has === 'function', 'device.features is set-like');
+  const queue = device.queue;
+  ok(queue != null, 'device.queue present');
+  ok(typeof queue.writeBuffer === 'function', 'queue.writeBuffer is function');
+
+  // surface any uncaptured validation/oom error loudly
+  device.addEventListener('uncapturederror', (ev) => {
+    process.stderr.write('UNCAPTURED webgpu error: ' + ev.error.message + '\n');
+  });
+
+  // --- CPU reference data ---------------------------------------------------------------------
+  const a = new Float32Array(N);
+  const b = new Float32Array(N);
+  for (let i = 0; i < N; i++) {
+    a[i] = i * 0.5;
+    b[i] = 2.0 * i + 1.0;
+  }
+
+  // seed a STORAGE|COPY_DST buffer by writing its mapped range at creation time
+  function makeSeeded(data, extraUsage) {
+    const buf = device.createBuffer({
+      size: NBYTES,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | (extraUsage || 0),
+      mappedAtCreation: true,
+    });
+    new Float32Array(buf.getMappedRange()).set(data);
+    buf.unmap();
+    return buf;
+  }
+
+  // --- buffers --------------------------------------------------------------------------------
+  const bufA = makeSeeded(a, GPUBufferUsage.COPY_SRC);
+  ok(bufA.size === NBYTES, 'buffer A size');
+  ok((bufA.usage & GPUBufferUsage.STORAGE) !== 0, 'buffer A usage has STORAGE');
+  const bufB = makeSeeded(b, 0);
+  ok(bufB.size === NBYTES, 'buffer B size');
+
+  const bufC = device.createBuffer({
+    size: NBYTES,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+  });
+  ok(bufC.size === NBYTES, 'buffer C size');
+  ok((bufC.usage & GPUBufferUsage.COPY_SRC) !== 0, 'buffer C usage has COPY_SRC');
+
+  const pbuf = device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+  ok((pbuf.usage & GPUBufferUsage.UNIFORM) !== 0, 'params buffer usage has UNIFORM');
+
+  const staging = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+  ok((staging.usage & GPUBufferUsage.MAP_READ) !== 0, 'staging buffer usage has MAP_READ');
+
+  // --- shader modules + saxpy pipeline objects, proven clean via a single validation scope -----
+  // Dawn returns a non-null handle even on a deferred validation error, so `handle != null` proves
+  // nothing. Instead wrap the whole create-group in one validation error scope and assert it popped
+  // clean - a single genuine check that shader-module/layout/pipeline/bind-group all built without a
+  // deferred validation error. The objects' functional correctness is verified by the compute results.
+  device.pushErrorScope('validation');
+  const saxpyMod = device.createShaderModule({ label: 'saxpy', code: SAXPY_WGSL });
+  const mulMod = device.createShaderModule({ label: 'mul', code: MUL_WGSL });
+  const bgl = device.createBindGroupLayout({
+    label: 'saxpy-bgl',
+    entries: [
+      storageEntry(0, true),
+      storageEntry(1, true),
+      storageEntry(2, false),
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+    ],
+  });
+  const pll = device.createPipelineLayout({ label: 'saxpy-pll', bindGroupLayouts: [bgl] });
+  const saxpyPipe = device.createComputePipeline({
+    label: 'saxpy-pipe',
+    layout: pll,
+    compute: { module: saxpyMod, entryPoint: 'main' },
+  });
+  const bind = device.createBindGroup({
+    label: 'saxpy-bind',
+    layout: bgl,
+    entries: [
+      { binding: 0, resource: { buffer: bufA } },
+      { binding: 1, resource: { buffer: bufB } },
+      { binding: 2, resource: { buffer: bufC } },
+      { binding: 3, resource: { buffer: pbuf } },
+    ],
+  });
+  const saxpyCreateErr = await device.popErrorScope();
+  ok(saxpyCreateErr == null, 'saxpy create-group (modules+layout+pipeline+bind) raises no validation error');
+
+  // copy staging -> mapAsync(READ) -> Float32Array copy -> unmap. Returns a fresh Float32Array.
+  async function readBack(src) {
+    const enc = device.createCommandEncoder();
+    enc.copyBufferToBuffer(src, 0, staging, 0, NBYTES);
+    queue.submit([enc.finish()]);
+    await staging.mapAsync(GPUMapMode.READ);
+    const out = new Float32Array(staging.getMappedRange().slice(0));
+    staging.unmap();
+    return out;
+  }
+
+  function dispatch(pipe, bg) {
+    const enc = device.createCommandEncoder();
+    const pass = enc.beginComputePass();
+    pass.setPipeline(pipe);
+    pass.setBindGroup(0, bg);
+    pass.dispatchWorkgroups(GROUPS);
+    pass.end();
+    queue.submit([enc.finish()]);
+  }
+
+  // --- vadd: alpha=1 --------------------------------------------------------------------------
+  queue.writeBuffer(pbuf, 0, packParams(1.0, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = a[i] + b[i];
+    ok(got.length === N, 'vadd readback length');
+    ok(allEq(got, ref), 'vadd c==a+b (every element)');
+    ok(got[0] === ref[0], 'vadd element[0]');
+    ok(got[N / 2] === ref[N / 2], 'vadd element[N/2]');
+    ok(got[N - 1] === ref[N - 1], 'vadd element[N-1]');
+
+    // negative control: build a deliberately-wrong independent reference (a+b+1) and prove the
+    // comparators actually REJECT it. If readback silently returned reference-like data the earlier
+    // allEq() would pass vacuously; this asserts the mismatch is caught, so the correctness checks
+    // above are load-bearing.
+    const wrongRef = new Float32Array(N);
+    for (let i = 0; i < N; i++) wrongRef[i] = a[i] + b[i] + 1.0;
+    ok(allEq(got, wrongRef) === false, 'negative control: allEq rejects wrong reference (a+b+1)');
+    ok(allFeq(got, wrongRef) === false, 'negative control: allFeq rejects wrong reference (a+b+1)');
+
+    // negative control #2: corrupt one real device-output element and confirm the element-wise
+    // check flags exactly that index against the untouched correct reference.
+    const corrupt = Float32Array.from(got);
+    corrupt[123] = corrupt[123] + 7.0;
+    ok(allEq(corrupt, ref) === false, 'negative control: single corrupted element flagged vs reference');
+    let flaggedIdx = -1;
+    for (let i = 0; i < N; i++) { if (corrupt[i] !== ref[i]) { flaggedIdx = i; break; } }
+    ok(flaggedIdx === 123, 'negative control: correctness check pinpoints the corrupted index');
+  }
+
+  // --- saxpy: alpha=3 -------------------------------------------------------------------------
+  const k = 3.0;
+  queue.writeBuffer(pbuf, 0, packParams(k, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = k * a[i] + b[i];
+    ok(allFeq(got, ref), 'saxpy c==3*a+b (every element, tol)');
+    ok(allEq(got, ref), 'saxpy exact f32 match');
+  }
+
+  // --- saxpy alpha=0 -> c == b (edge) ---------------------------------------------------------
+  queue.writeBuffer(pbuf, 0, packParams(0.0, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    ok(allEq(got, b), 'saxpy alpha=0 c==b (every element)');
+  }
+
+  // --- partial n: only first half written; tail keeps prior alpha=0 result (==b) --------------
+  const half = N / 2;
+  queue.writeBuffer(pbuf, 0, packParams(5.0, half));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    const ref = Float32Array.from(b);
+    for (let i = 0; i < half; i++) ref[i] = 5.0 * a[i] + b[i];
+    let headOk = true;
+    for (let i = 0; i < half; i++) headOk = headOk && feq(got[i], ref[i]);
+    let tailOk = true;
+    for (let i = half; i < N; i++) tailOk = tailOk && got[i] === b[i];
+    ok(headOk, 'partial-n head c==5*a+b');
+    ok(tailOk, 'partial-n tail untouched ==b');
+  }
+
+  // --- second pipeline: element-wise multiply (create-group proven clean via one scope) --------
+  device.pushErrorScope('validation');
+  const bgl2 = device.createBindGroupLayout({
+    label: 'mul-bgl',
+    entries: [storageEntry(0, true), storageEntry(1, true), storageEntry(2, false)],
+  });
+  const pll2 = device.createPipelineLayout({ label: 'mul-pll', bindGroupLayouts: [bgl2] });
+  const mulPipe = device.createComputePipeline({
+    label: 'mul-pipe',
+    layout: pll2,
+    compute: { module: mulMod, entryPoint: 'main' },
+  });
+  const bind2 = device.createBindGroup({
+    label: 'mul-bind',
+    layout: bgl2,
+    entries: [
+      { binding: 0, resource: { buffer: bufA } },
+      { binding: 1, resource: { buffer: bufB } },
+      { binding: 2, resource: { buffer: bufC } },
+    ],
+  });
+  const mulCreateErr = await device.popErrorScope();
+  ok(mulCreateErr == null, 'mul create-group (layout+pipeline+bind) raises no validation error');
+  dispatch(mulPipe, bind2);
+  {
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = a[i] * b[i];
+    ok(allEq(got, ref), 'mul c==a*b (every element)');
+    ok(got[7] === a[7] * b[7], 'mul element[7]');
+  }
+
+  // --- buffer update then re-dispatch (writeBuffer to a STORAGE buffer) ------------------------
+  const a2 = new Float32Array(N).fill(4.0);
+  queue.writeBuffer(bufA, 0, a2);
+  queue.writeBuffer(pbuf, 0, packParams(1.0, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = 4.0 + b[i];
+    ok(allEq(got, ref), 'vadd after writeBuffer c==4+b (every element)');
+  }
+
+  // --- copy_buffer_to_buffer chain: c -> mid -> staging ---------------------------------------
+  const mid = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST });
+  {
+    const enc = device.createCommandEncoder();
+    enc.copyBufferToBuffer(bufC, 0, mid, 0, NBYTES);
+    queue.submit([enc.finish()]);
+    const got = await readBack(mid);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = 4.0 + b[i];
+    ok(allEq(got, ref), 'copy chain preserves c (every element)');
+  }
+
+  // --- windowed copy: skip element 0, copy the tail into staging and verify -------------------
+  {
+    const enc = device.createCommandEncoder();
+    enc.copyBufferToBuffer(bufC, 4, staging, 0, (N - 1) * 4);
+    queue.submit([enc.finish()]);
+    await staging.mapAsync(GPUMapMode.READ);
+    const win = new Float32Array(staging.getMappedRange(0, (N - 1) * 4).slice(0));
+    staging.unmap();
+    const ref = new Float32Array(N - 1);
+    for (let i = 0; i < N - 1; i++) ref[i] = 4.0 + b[i + 1];
+    ok(win.length === N - 1, 'windowed copy size');
+    ok(allEq(win, ref), 'windowed copy values (offset 1)');
+  }
+
+  // --- clearBuffer then verify zeros ----------------------------------------------------------
+  {
+    const enc = device.createCommandEncoder();
+    enc.clearBuffer(bufC);
+    queue.submit([enc.finish()]);
+    const got = await readBack(bufC);
+    const zeros = new Float32Array(N);
+    ok(allEq(got, zeros), 'clearBuffer zeros c');
+  }
+
+  // --- mappedAtCreation write path verified end to end via a copy -----------------------------
+  {
+    const seeded = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.COPY_SRC, mappedAtCreation: true });
+    const view = new Float32Array(seeded.getMappedRange());
+    for (let i = 0; i < N; i++) view[i] = i + 100.0;
+    seeded.unmap();
+    const enc = device.createCommandEncoder();
+    enc.copyBufferToBuffer(seeded, 0, staging, 0, NBYTES);
+    queue.submit([enc.finish()]);
+    await staging.mapAsync(GPUMapMode.READ);
+    const got = new Float32Array(staging.getMappedRange().slice(0));
+    staging.unmap();
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = i + 100.0;
+    ok(allEq(got, ref), 'mappedAtCreation values (every element)');
+  }
+
+  // --- validation error surfaces on a bad bind-group (missing bindings) -----------------------
+  // Dawn defers bind-group validation to an async error scope rather than throwing synchronously.
+  {
+    device.pushErrorScope('validation');
+    device.createBindGroup({
+      layout: bgl2,
+      entries: [{ binding: 0, resource: { buffer: bufA } }],
+    });
+    const err = await device.popErrorScope();
+    ok(err != null, 'bad bind-group (missing bindings) reports validation error');
+    ok(err != null && /entr|bind|match/i.test(err.message), 'validation error message mentions entries');
+  }
+
+  // --- validation error on out-of-bounds copy -------------------------------------------------
+  {
+    device.pushErrorScope('validation');
+    const enc = device.createCommandEncoder();
+    enc.copyBufferToBuffer(bufC, 0, staging, 0, NBYTES * 4);
+    queue.submit([enc.finish()]);
+    const err = await device.popErrorScope();
+    ok(err != null, 'oversized copyBufferToBuffer reports validation error');
+  }
+
+  // --- create-success proof via error scope (no validation error on a valid create) -----------
+  // Instead of asserting a handle is non-null, wrap a real create in a validation scope and assert
+  // it popped clean - a genuine check the object was built without a deferred validation error.
+  {
+    device.pushErrorScope('validation');
+    const probeBgl = device.createBindGroupLayout({
+      label: 'probe-bgl',
+      entries: [storageEntry(0, false)],
+    });
+    const scopeErr = await device.popErrorScope();
+    ok(scopeErr == null, 'valid createBindGroupLayout raises no validation error in scope');
+    void probeBgl;
+  }
+
+  // --- shader compile-error path: broken WGSL -------------------------------------------------
+  // A genuinely invalid module surfaces (a) a deferred validation error via the scope and
+  // (b) an "error" message from getCompilationInfo(). Assert the real diagnostics, not ok(true).
+  {
+    device.pushErrorScope('validation');
+    const badMod = device.createShaderModule({ label: 'broken', code: BROKEN_WGSL });
+    const compileErr = await device.popErrorScope();
+    ok(compileErr != null, 'broken WGSL surfaces a validation error via error scope');
+    const ci = await badMod.getCompilationInfo();
+    const errMsgs = ci.messages.filter((m) => m.type === 'error');
+    ok(errMsgs.length >= 1, 'getCompilationInfo reports >=1 error message for broken WGSL');
+    ok(errMsgs.some((m) => m.message.length > 0), 'compilation error message is non-empty');
+  }
+
+  // control: a valid module reports zero error diagnostics from getCompilationInfo
+  {
+    const goodCi = await saxpyMod.getCompilationInfo();
+    ok(goodCi.messages.filter((m) => m.type === 'error').length === 0,
+      'getCompilationInfo reports no errors for valid WGSL');
+  }
+
+  // --- createComputePipelineAsync (async pipeline creation, then run it) -----------------------
+  const add1Mod = device.createShaderModule({ label: 'add1', code: ADD1_WGSL });
+  const add1Bgl = device.createBindGroupLayout({
+    label: 'add1-bgl',
+    entries: [storageEntry(0, true), storageEntry(1, false)],
+  });
+  const add1Pll = device.createPipelineLayout({ bindGroupLayouts: [add1Bgl] });
+  const add1Pipe = await device.createComputePipelineAsync({
+    label: 'add1-async',
+    layout: add1Pll,
+    compute: { module: add1Mod, entryPoint: 'main' },
+  });
+  {
+    // run the async pipeline: c = a + 1, element-wise verified against an independent reference
+    const src = new Float32Array(N);
+    for (let i = 0; i < N; i++) src[i] = i * 0.25 - 3.0;
+    const inBuf = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    queue.writeBuffer(inBuf, 0, src);
+    const outBuf = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
+    const bgAdd = device.createBindGroup({
+      layout: add1Bgl,
+      entries: [{ binding: 0, resource: { buffer: inBuf } }, { binding: 1, resource: { buffer: outBuf } }],
+    });
+    const enc = device.createCommandEncoder();
+    const pass = enc.beginComputePass();
+    pass.setPipeline(add1Pipe);
+    pass.setBindGroup(0, bgAdd);
+    pass.dispatchWorkgroups(Math.ceil(N / 256));
+    pass.end();
+    queue.submit([enc.finish()]);
+    const got = await readBack(outBuf);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = src[i] + 1.0;
+    ok(allEq(got, ref), 'async pipeline c==a+1 (every element)');
+    inBuf.destroy();
+    outBuf.destroy();
+  }
+
+  // --- dispatchWorkgroupsIndirect: workgroup count sourced from an INDIRECT buffer -------------
+  {
+    const src = new Float32Array(N);
+    for (let i = 0; i < N; i++) src[i] = 10.0 + i;
+    const inBuf = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    queue.writeBuffer(inBuf, 0, src);
+    const outBuf = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
+    const bgAdd = device.createBindGroup({
+      layout: add1Bgl,
+      entries: [{ binding: 0, resource: { buffer: inBuf } }, { binding: 1, resource: { buffer: outBuf } }],
+    });
+    const groups = Math.ceil(N / 256);
+    const indirect = device.createBuffer({ size: 12, usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST });
+    queue.writeBuffer(indirect, 0, new Uint32Array([groups, 1, 1]));
+    const enc = device.createCommandEncoder();
+    const pass = enc.beginComputePass();
+    pass.setPipeline(add1Pipe);
+    pass.setBindGroup(0, bgAdd);
+    pass.dispatchWorkgroupsIndirect(indirect, 0);
+    pass.end();
+    queue.submit([enc.finish()]);
+    const got = await readBack(outBuf);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = src[i] + 1.0;
+    ok(allEq(got, ref), 'dispatchWorkgroupsIndirect c==a+1 (every element)');
+    ok(got[N - 1] === ref[N - 1], 'indirect dispatch reached the last element');
+    inBuf.destroy();
+    outBuf.destroy();
+    indirect.destroy();
+  }
+
+  // --- dynamic offsets: one storage buffer holding two windows, selected via setBindGroup offset -
+  {
+    // Two N/2 windows packed in one buffer; a dynamic-offset bind group points binding 0 at either
+    // half, and the shader writes a[i]+1 for that half. Dynamic offsets must be 256-byte aligned.
+    const halfN = N / 2;
+    const align = device.limits.minStorageBufferOffsetAlignment || 256;
+    const stride = Math.ceil((halfN * 4) / align) * align;
+    const packed = device.createBuffer({ size: stride + halfN * 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    const w0 = new Float32Array(halfN);
+    const w1 = new Float32Array(halfN);
+    for (let i = 0; i < halfN; i++) { w0[i] = i; w1[i] = 1000 + i; }
+    queue.writeBuffer(packed, 0, w0);
+    queue.writeBuffer(packed, stride, w1);
+    const outBuf = device.createBuffer({ size: halfN * 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
+    const dynBgl = device.createBindGroupLayout({
+      label: 'dyn-bgl',
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'read-only-storage', hasDynamicOffset: true, minBindingSize: halfN * 4 } },
+        storageEntry(1, false),
+      ],
+    });
+    const dynPll = device.createPipelineLayout({ bindGroupLayouts: [dynBgl] });
+    const dynPipe = device.createComputePipeline({ layout: dynPll, compute: { module: add1Mod, entryPoint: 'main' } });
+    const dynBg = device.createBindGroup({
+      layout: dynBgl,
+      entries: [
+        { binding: 0, resource: { buffer: packed, offset: 0, size: halfN * 4 } },
+        { binding: 1, resource: { buffer: outBuf } },
+      ],
+    });
+    const runWindow = async (dynOff, window) => {
+      const enc = device.createCommandEncoder();
+      const pass = enc.beginComputePass();
+      pass.setPipeline(dynPipe);
+      pass.setBindGroup(0, dynBg, [dynOff]);
+      pass.dispatchWorkgroups(Math.ceil(halfN / 256));
+      pass.end();
+      enc.copyBufferToBuffer(outBuf, 0, staging, 0, halfN * 4);
+      queue.submit([enc.finish()]);
+      await staging.mapAsync(GPUMapMode.READ);
+      const out = new Float32Array(staging.getMappedRange(0, halfN * 4).slice(0));
+      staging.unmap();
+      let good = true;
+      for (let i = 0; i < halfN; i++) good = good && out[i] === window[i] + 1.0;
+      return good;
+    };
+    ok(await runWindow(0, w0), 'dynamic offset window 0 c==a+1');
+    ok(await runWindow(stride, w1), 'dynamic offset window 1 (offset) c==a+1');
+    packed.destroy();
+    outBuf.destroy();
+  }
+
+  // --- timestamp querySet + resolveQuerySet (feature-gated; NON-COUNTING when unsupported) ------
+  if (hasTimestamp) {
+    const qset = device.createQuerySet({ type: 'timestamp', count: 2 });
+    ok(qset.count === 2, 'createQuerySet(timestamp) count===2');
+    ok(qset.type === 'timestamp', 'querySet type is timestamp');
+    const resolveBuf = device.createBuffer({ size: 16, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC });
+    const tsStaging = device.createBuffer({ size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+    device.pushErrorScope('validation');
+    const enc = device.createCommandEncoder();
+    const pass = enc.beginComputePass({
+      timestampWrites: { querySet: qset, beginningOfPassWriteIndex: 0, endOfPassWriteIndex: 1 },
+    });
+    pass.setPipeline(saxpyPipe);
+    pass.setBindGroup(0, bind);
+    pass.dispatchWorkgroups(GROUPS);
+    pass.end();
+    enc.resolveQuerySet(qset, 0, 2, resolveBuf, 0);
+    enc.copyBufferToBuffer(resolveBuf, 0, tsStaging, 0, 16);
+    queue.submit([enc.finish()]);
+    const tsErr = await device.popErrorScope();
+    ok(tsErr == null, 'timestampWrites + resolveQuerySet raise no validation error');
+    await tsStaging.mapAsync(GPUMapMode.READ);
+    const ts = new BigUint64Array(tsStaging.getMappedRange().slice(0));
+    tsStaging.unmap();
+    // lavapipe may report zero-delta timestamps; assert they were written and are ordered/equal.
+    ok(ts.length === 2 && ts[1] >= ts[0], 'resolved timestamps are ordered (end>=begin)');
+    qset.destroy();
+  } else {
+    console.log('webgpu-js NON-COUNTING: timestamp-query feature unavailable on this adapter, skipping querySet path');
+  }
+
+  // --- boundary: dispatchWorkgroups(0) is a no-op ----------------------------------------------
+  {
+    const src = new Float32Array(N);
+    for (let i = 0; i < N; i++) src[i] = 42.0 + i;
+    const inBuf = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    queue.writeBuffer(inBuf, 0, src);
+    const outBuf = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST });
+    // pre-seed output with a sentinel so a no-op dispatch leaves it verifiably untouched
+    const sentinel = new Float32Array(N).fill(-1.0);
+    queue.writeBuffer(outBuf, 0, sentinel);
+    const bgAdd = device.createBindGroup({
+      layout: add1Bgl,
+      entries: [{ binding: 0, resource: { buffer: inBuf } }, { binding: 1, resource: { buffer: outBuf } }],
+    });
+    const enc = device.createCommandEncoder();
+    const pass = enc.beginComputePass();
+    pass.setPipeline(add1Pipe);
+    pass.setBindGroup(0, bgAdd);
+    pass.dispatchWorkgroups(0);
+    pass.end();
+    queue.submit([enc.finish()]);
+    const got = await readBack(outBuf);
+    ok(allEq(got, sentinel), 'dispatchWorkgroups(0) leaves output untouched (==sentinel)');
+    inBuf.destroy();
+    outBuf.destroy();
+  }
+
+  // --- boundary: large N (>= 1<<20) multi-workgroup grid, every element verified ----------------
+  {
+    const NL = 1 << 20;
+    const src = new Float32Array(NL);
+    for (let i = 0; i < NL; i++) src[i] = (i % 4096) * 0.5;
+    const inBuf = device.createBuffer({ size: NL * 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    queue.writeBuffer(inBuf, 0, src);
+    const outBuf = device.createBuffer({ size: NL * 4, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
+    const bgAdd = device.createBindGroup({
+      layout: add1Bgl,
+      entries: [{ binding: 0, resource: { buffer: inBuf } }, { binding: 1, resource: { buffer: outBuf } }],
+    });
+    const groups = Math.ceil(NL / 256);
+    ok(groups <= device.limits.maxComputeWorkgroupsPerDimension, 'large-N grid within maxComputeWorkgroupsPerDimension');
+    const enc = device.createCommandEncoder();
+    const pass = enc.beginComputePass();
+    pass.setPipeline(add1Pipe);
+    pass.setBindGroup(0, bgAdd);
+    pass.dispatchWorkgroups(groups);
+    pass.end();
+    const bigStaging = device.createBuffer({ size: NL * 4, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+    enc.copyBufferToBuffer(outBuf, 0, bigStaging, 0, NL * 4);
+    queue.submit([enc.finish()]);
+    await bigStaging.mapAsync(GPUMapMode.READ);
+    const got = new Float32Array(bigStaging.getMappedRange().slice(0));
+    bigStaging.unmap();
+    let mism = 0;
+    for (let i = 0; i < NL; i++) { if (got[i] !== src[i] + 1.0) { mism++; } }
+    ok(got.length === NL, 'large-N readback length == 1<<20');
+    ok(mism === 0, 'large-N c==a+1 for all 1048576 elements');
+    ok(got[NL - 1] === src[NL - 1] + 1.0, 'large-N last element correct');
+    inBuf.destroy();
+    outBuf.destroy();
+    bigStaging.destroy();
+  }
+
+  // --- boundary: zero-size buffer is a valid (empty) allocation --------------------------------
+  {
+    const zb = device.createBuffer({ size: 0, usage: GPUBufferUsage.STORAGE });
+    ok(zb.size === 0, 'zero-size buffer reports size===0');
+    zb.destroy();
+  }
+
+  // --- boundary/error: getMappedRange out of range throws OperationError -----------------------
+  {
+    const m = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST });
+    await m.mapAsync(GPUMapMode.READ);
+    let threw = false;
+    try {
+      m.getMappedRange(0, NBYTES * 4);
+    } catch (e) {
+      threw = true;
+    }
+    ok(threw, 'getMappedRange with out-of-range size throws');
+    m.unmap();
+    m.destroy();
+  }
+
+  // --- lifecycle: buffer.destroy then use-after-destroy surfaces a validation error -------------
+  {
+    const victim = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    victim.destroy();
+    device.pushErrorScope('validation');
+    const enc = device.createCommandEncoder();
+    enc.copyBufferToBuffer(bufC, 0, victim, 0, NBYTES);
+    queue.submit([enc.finish()]);
+    const err = await device.popErrorScope();
+    ok(err != null, 'use-after-destroy (copy into destroyed buffer) reports validation error');
+    ok(err != null && /destroy/i.test(err.message), 'use-after-destroy error message mentions destroyed');
+  }
+
+  // drain and confirm the queue is idle
+  await queue.onSubmittedWorkDone();
+
+  // --- lifecycle teardown: destroy remaining buffers, then device.destroy + device.lost --------
+  bufA.destroy();
+  bufB.destroy();
+  bufC.destroy();
+  pbuf.destroy();
+  mid.destroy();
+  staging.destroy();
+  device.destroy();
+  const lost = await device.lost;
+  ok(lost != null, 'device.lost resolves after device.destroy');
+  ok(lost.reason === 'destroyed', "device.lost reason is 'destroyed'");
+
+  return finish();
+}
+
+run()
+  .then((code) => process.exit(code))
+  .catch((e) => {
+    process.stderr.write('FATAL: ' + (e && e.stack ? e.stack : e) + '\n');
+    process.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_ts/tsconfig.json
+++ b/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_ts/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "bundler",
+    "types": ["@webgpu/types", "node"],
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "."
+  },
+  "files": ["webgpu.d.ts", "webgpu_ts_full_api.ts"]
+}

--- a/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_ts/webgpu.d.ts
+++ b/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_ts/webgpu.d.ts
@@ -1,0 +1,13 @@
+// The dawn-based `webgpu` package ships types.d.ts, but its `globals` export is typed as `Object`,
+// which strips the constructor/enum globals (GPUBufferUsage, GPUShaderStage, GPUMapMode) that
+// Object.assign(globalThis, globals) installs at runtime. Narrow `globals` here so the assignment
+// stays typed and the carpet keeps every WebGPU object in the graph strongly typed.
+declare module 'webgpu' {
+  export function create(options: string[]): GPU;
+  export const globals: {
+    GPUBufferUsage: typeof GPUBufferUsage;
+    GPUShaderStage: typeof GPUShaderStage;
+    GPUMapMode: typeof GPUMapMode;
+    [key: string]: unknown;
+  };
+}

--- a/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_ts/webgpu_ts_full_api.ts
+++ b/apps/starry/cpu-webgpu-compute/programs/carpets/webgpu_ts/webgpu_ts_full_api.ts
@@ -1,0 +1,759 @@
+// webgpu_ts_full_api - full WebGPU compute-API carpet on Mesa lavapipe, driven by the dawn-based
+// `webgpu` node package, written in TypeScript and type-checked with @webgpu/types. Walks the WebGPU
+// object graph - gpu / adapter (features/limits/info) / device (limits/features/lost) / queue /
+// shader-module (createShaderModule + getCompilationInfo + a broken-WGSL compile-error path) /
+// buffer (mappedAtCreation / mapAsync / getMappedRange / unmap / writeBuffer / mapState / destroy) /
+// bind-group-layout / pipeline-layout / compute-pipeline (sync + createComputePipelineAsync) /
+// bind-group (static + dynamic offsets) / command-encoder / compute-pass / dispatchWorkgroups /
+// dispatchWorkgroupsIndirect / copyBufferToBuffer / clearBuffer / querySet+timestampWrites+
+// resolveQuerySet (feature-gated) / pushErrorScope+popErrorScope / device.destroy - with every
+// handle typed (GPUAdapter, GPUDevice, GPUBuffer, GPUComputePipeline, GPUBindGroup, ...) and asserts
+// vadd/saxpy/mul results per element against a TypeScript-computed reference. A negative-control
+// block corrupts real device output and proves the equality checkers flag it against an independent
+// reference. Boundary cases cover dispatchWorkgroups(0), a zero-byte buffer, and a large element-wise
+// verified run. Prints "WEBGPU_TS_FULL_API OK <n>" only when every assertion passes and the count
+// equals the pinned total.
+
+// [runtime-agnostic] GPU instance acquired below: Deno/browser expose global navigator.gpu (wgpu-core,
+// Firefox/Deno engine); Node dynamic-imports the dawn-based webgpu package. We only TEST the WebGPU API.
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond: boolean, desc: string): void {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    process.stderr.write('FAIL: ' + desc + '\n');
+  }
+}
+
+// f32 rounding makes scaled results inexact vs a double reference; use a relative tolerance there and
+// exact equality for the +/* cases that round-trip through f32 identically.
+function feq(a: number, b: number): boolean {
+  return Math.abs(a - b) <= 1e-4 * (1.0 + Math.abs(b));
+}
+
+function allEq(got: Float32Array, ref: Float32Array): boolean {
+  if (got.length !== ref.length) return false;
+  for (let i = 0; i < ref.length; i++) {
+    if (got[i] !== ref[i]) return false;
+  }
+  return true;
+}
+
+function allFeq(got: Float32Array, ref: Float32Array): boolean {
+  if (got.length !== ref.length) return false;
+  for (let i = 0; i < ref.length; i++) {
+    if (!feq(got[i], ref[i])) return false;
+  }
+  return true;
+}
+
+// WGSL compute shader: c[i] = alpha*a[i] + b[i]. alpha and n come from a uniform block so the same
+// pipeline drives both vadd (alpha=1) and saxpy (alpha=k).
+const SAXPY_WGSL = `
+struct Params { alpha: f32, n: u32 };
+@group(0) @binding(0) var<storage, read>       a: array<f32>;
+@group(0) @binding(1) var<storage, read>       b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+@group(0) @binding(3) var<uniform>             p: Params;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i < p.n) {
+    c[i] = p.alpha * a[i] + b[i];
+  }
+}
+`;
+
+// Second shader (separate module + pipeline): c[i] = a[i] * b[i], no uniform - exercises a distinct
+// bind-group-layout (3 storage bindings) and a second compute pipeline.
+const MUL_WGSL = `
+@group(0) @binding(0) var<storage, read>       a: array<f32>;
+@group(0) @binding(1) var<storage, read>       b: array<f32>;
+@group(0) @binding(2) var<storage, read_write> c: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i < arrayLength(&a)) {
+    c[i] = a[i] * b[i];
+  }
+}
+`;
+
+const N = 2048;
+const WG = 64;
+const NBYTES = N * 4;
+const GROUPS = Math.ceil(N / WG);
+
+function packParams(alpha: number, n: number): ArrayBuffer {
+  const buf = new ArrayBuffer(16);
+  new Float32Array(buf, 0, 1)[0] = alpha;
+  new Uint32Array(buf, 4, 1)[0] = n;
+  return buf;
+}
+
+function storageEntry(binding: number, readOnly: boolean): GPUBindGroupLayoutEntry {
+  return {
+    binding,
+    visibility: GPUShaderStage.COMPUTE,
+    buffer: { type: readOnly ? 'read-only-storage' : 'storage' },
+  };
+}
+
+function finish(): number {
+  const expected = 77;
+  const total = PASS + FAIL;
+  console.log(
+    'webgpu-ts: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + expected
+  );
+  if (FAIL === 0 && total === expected) {
+    console.log('WEBGPU_TS_FULL_API OK ' + PASS);
+    return 0;
+  }
+  console.log('WEBGPU_TS_FULL_API FAIL');
+  return 1;
+}
+
+async function run(): Promise<number> {
+  // --- gpu entry + adapter --------------------------------------------------------------------
+  let gpu: GPU;
+  if (typeof navigator !== 'undefined' && (navigator as any).gpu) {
+    gpu = (navigator as any).gpu as GPU;            // Deno (wgpu-core) / browser
+  } else {
+    const w: any = await import('webgpu');          // Node: dawn-based webgpu package
+    Object.assign(globalThis, w.globals);
+    gpu = w.create([]) as GPU;
+  }
+  ok(gpu != null, 'GPU instance available (navigator.gpu or dawn create)');
+  ok(typeof gpu.requestAdapter === 'function', 'gpu.requestAdapter is function');
+
+  const adapter: GPUAdapter | null = await gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    ok(false, 'requestAdapter non-null');
+    return finish();
+  }
+
+  const info: GPUAdapterInfo = adapter.info;
+  console.log(
+    'webgpu-ts adapter selected: vendor=' + info.vendor +
+    ' architecture=' + info.architecture +
+    ' device=' + info.device +
+    ' description=' + info.description
+  );
+  ok(info != null, 'adapter.info present');
+  ok(String(info.description || info.device || '').length > 0, 'adapter.info description/device non-empty');
+
+  // adapter capability queries
+  const feats: GPUSupportedFeatures = adapter.features;
+  ok(typeof feats.has === 'function', 'adapter.features is set-like');
+  const featCount = [...feats].length;
+  ok(featCount === feats.size, 'adapter.features spread length equals set size');
+  const alim: GPUSupportedLimits = adapter.limits;
+  ok(alim.maxComputeWorkgroupSizeX >= 64, 'adapter.limits maxComputeWorkgroupSizeX>=64');
+  ok(alim.maxStorageBuffersPerShaderStage >= 3, 'adapter.limits maxStorageBuffersPerShaderStage>=3');
+  ok(alim.maxBindGroups >= 1, 'adapter.limits maxBindGroups>=1');
+  ok(alim.maxComputeInvocationsPerWorkgroup >= 64, 'adapter.limits maxComputeInvocationsPerWorkgroup>=64');
+
+  // --- device + queue -------------------------------------------------------------------------
+  // opt into timestamp-query when the adapter advertises it so the query-set path below is live.
+  const hasTimestamp = adapter.features.has('timestamp-query');
+  const wantFeatures: GPUFeatureName[] = hasTimestamp ? ['timestamp-query'] : [];
+  const device: GPUDevice = await adapter.requestDevice({ label: 'carpet-device', requiredFeatures: wantFeatures });
+  ok(device != null, 'requestDevice non-null');
+  const dlim: GPUSupportedLimits = device.limits;
+  ok(dlim.maxComputeInvocationsPerWorkgroup >= 64, 'device.limits maxComputeInvocationsPerWorkgroup>=64');
+  ok(typeof device.features.has === 'function', 'device.features is set-like');
+  const queue: GPUQueue = device.queue;
+  ok(queue != null, 'device.queue present');
+  ok(typeof queue.writeBuffer === 'function', 'queue.writeBuffer is function');
+
+  // surface any uncaptured validation/oom error loudly
+  device.addEventListener('uncapturederror', (ev: Event) => {
+    const uerr = (ev as GPUUncapturedErrorEvent).error;
+    process.stderr.write('UNCAPTURED webgpu error: ' + uerr.message + '\n');
+  });
+
+  // --- CPU reference data ---------------------------------------------------------------------
+  const a = new Float32Array(N);
+  const b = new Float32Array(N);
+  for (let i = 0; i < N; i++) {
+    a[i] = i * 0.5;
+    b[i] = 2.0 * i + 1.0;
+  }
+
+  // seed a STORAGE|COPY_DST buffer by writing its mapped range at creation time
+  function makeSeeded(data: Float32Array, extraUsage: GPUBufferUsageFlags): GPUBuffer {
+    const buf: GPUBuffer = device.createBuffer({
+      size: NBYTES,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST | extraUsage,
+      mappedAtCreation: true,
+    });
+    new Float32Array(buf.getMappedRange()).set(data);
+    buf.unmap();
+    return buf;
+  }
+
+  // --- buffers --------------------------------------------------------------------------------
+  const bufA: GPUBuffer = makeSeeded(a, GPUBufferUsage.COPY_SRC);
+  ok(bufA.size === NBYTES, 'buffer A size');
+  ok((bufA.usage & GPUBufferUsage.STORAGE) !== 0, 'buffer A usage has STORAGE');
+  const bufB: GPUBuffer = makeSeeded(b, 0);
+  ok(bufB.size === NBYTES, 'buffer B size');
+
+  const bufC: GPUBuffer = device.createBuffer({
+    size: NBYTES,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+  });
+  ok(bufC.size === NBYTES, 'buffer C size');
+  ok((bufC.usage & GPUBufferUsage.COPY_SRC) !== 0, 'buffer C usage has COPY_SRC');
+
+  const pbuf: GPUBuffer = device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+  ok((pbuf.usage & GPUBufferUsage.UNIFORM) !== 0, 'params buffer usage has UNIFORM');
+
+  const staging: GPUBuffer = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+  ok((staging.usage & GPUBufferUsage.MAP_READ) !== 0, 'staging buffer usage has MAP_READ');
+
+  // --- shader modules + saxpy layout/pipeline/bind, all under one validation scope -------------
+  // Dawn returns non-null handles even on a deferred validation error, so a bare handle!=null is
+  // vacuous. Wrap the whole saxpy create-group in a single error scope and assert it popped clean;
+  // every created object is exercised downstream and its correctness verified by the compute result.
+  device.pushErrorScope('validation');
+  const saxpyMod: GPUShaderModule = device.createShaderModule({ label: 'saxpy', code: SAXPY_WGSL });
+  const mulMod: GPUShaderModule = device.createShaderModule({ label: 'mul', code: MUL_WGSL });
+  const bgl: GPUBindGroupLayout = device.createBindGroupLayout({
+    label: 'saxpy-bgl',
+    entries: [
+      storageEntry(0, true),
+      storageEntry(1, true),
+      storageEntry(2, false),
+      { binding: 3, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
+    ],
+  });
+  const pll: GPUPipelineLayout = device.createPipelineLayout({ label: 'saxpy-pll', bindGroupLayouts: [bgl] });
+  const saxpyPipe: GPUComputePipeline = device.createComputePipeline({
+    label: 'saxpy-pipe',
+    layout: pll,
+    compute: { module: saxpyMod, entryPoint: 'main' },
+  });
+  const bind: GPUBindGroup = device.createBindGroup({
+    label: 'saxpy-bind',
+    layout: bgl,
+    entries: [
+      { binding: 0, resource: { buffer: bufA } },
+      { binding: 1, resource: { buffer: bufB } },
+      { binding: 2, resource: { buffer: bufC } },
+      { binding: 3, resource: { buffer: pbuf } },
+    ],
+  });
+  ok((await device.popErrorScope()) == null, 'saxpy create-group (modules+layout+pipeline+bind) raises no validation error');
+
+  // copy staging -> mapAsync(READ) -> Float32Array copy -> unmap. Returns a fresh Float32Array.
+  async function readBack(src: GPUBuffer): Promise<Float32Array> {
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    enc.copyBufferToBuffer(src, 0, staging, 0, NBYTES);
+    queue.submit([enc.finish()]);
+    await staging.mapAsync(GPUMapMode.READ);
+    const out = new Float32Array(staging.getMappedRange().slice(0));
+    staging.unmap();
+    return out;
+  }
+
+  function dispatch(pipe: GPUComputePipeline, bg: GPUBindGroup): void {
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    const pass: GPUComputePassEncoder = enc.beginComputePass();
+    pass.setPipeline(pipe);
+    pass.setBindGroup(0, bg);
+    pass.dispatchWorkgroups(GROUPS);
+    pass.end();
+    const cmd: GPUCommandBuffer = enc.finish();
+    queue.submit([cmd]);
+  }
+
+  // --- vadd: alpha=1 --------------------------------------------------------------------------
+  queue.writeBuffer(pbuf, 0, packParams(1.0, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = a[i] + b[i];
+    ok(got.length === N, 'vadd readback length');
+    ok(allEq(got, ref), 'vadd c==a+b (every element)');
+  }
+
+  // --- saxpy: alpha=3 -------------------------------------------------------------------------
+  const k = 3.0;
+  queue.writeBuffer(pbuf, 0, packParams(k, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = k * a[i] + b[i];
+    ok(allFeq(got, ref), 'saxpy c==3*a+b (every element, tol)');
+    ok(allEq(got, ref), 'saxpy exact f32 match');
+  }
+
+  // --- saxpy alpha=0 -> c == b (edge) ---------------------------------------------------------
+  queue.writeBuffer(pbuf, 0, packParams(0.0, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    ok(allEq(got, b), 'saxpy alpha=0 c==b (every element)');
+  }
+
+  // --- partial n: only first half written; tail keeps prior alpha=0 result (==b) --------------
+  const half = N / 2;
+  queue.writeBuffer(pbuf, 0, packParams(5.0, half));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    const ref = Float32Array.from(b);
+    for (let i = 0; i < half; i++) ref[i] = 5.0 * a[i] + b[i];
+    let headOk = true;
+    for (let i = 0; i < half; i++) headOk = headOk && feq(got[i], ref[i]);
+    let tailOk = true;
+    for (let i = half; i < N; i++) tailOk = tailOk && got[i] === b[i];
+    ok(headOk, 'partial-n head c==5*a+b');
+    ok(tailOk, 'partial-n tail untouched ==b');
+  }
+
+  // --- second pipeline: element-wise multiply, again under one validation scope ---------------
+  device.pushErrorScope('validation');
+  const bgl2: GPUBindGroupLayout = device.createBindGroupLayout({
+    label: 'mul-bgl',
+    entries: [storageEntry(0, true), storageEntry(1, true), storageEntry(2, false)],
+  });
+  const pll2: GPUPipelineLayout = device.createPipelineLayout({ label: 'mul-pll', bindGroupLayouts: [bgl2] });
+  const mulPipe: GPUComputePipeline = device.createComputePipeline({
+    label: 'mul-pipe',
+    layout: pll2,
+    compute: { module: mulMod, entryPoint: 'main' },
+  });
+  const bind2: GPUBindGroup = device.createBindGroup({
+    label: 'mul-bind',
+    layout: bgl2,
+    entries: [
+      { binding: 0, resource: { buffer: bufA } },
+      { binding: 1, resource: { buffer: bufB } },
+      { binding: 2, resource: { buffer: bufC } },
+    ],
+  });
+  ok((await device.popErrorScope()) == null, 'mul create-group (layout+pipeline+bind) raises no validation error');
+  dispatch(mulPipe, bind2);
+  {
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = a[i] * b[i];
+    ok(allEq(got, ref), 'mul c==a*b (every element)');
+  }
+
+  // --- buffer update then re-dispatch (writeBuffer to a STORAGE buffer) ------------------------
+  const a2 = new Float32Array(N).fill(4.0);
+  queue.writeBuffer(bufA, 0, a2);
+  queue.writeBuffer(pbuf, 0, packParams(1.0, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = 4.0 + b[i];
+    ok(allEq(got, ref), 'vadd after writeBuffer c==4+b (every element)');
+  }
+
+  // --- copy_buffer_to_buffer chain: c -> mid -> staging ---------------------------------------
+  const mid: GPUBuffer = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST });
+  {
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    enc.copyBufferToBuffer(bufC, 0, mid, 0, NBYTES);
+    queue.submit([enc.finish()]);
+    const got = await readBack(mid);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = 4.0 + b[i];
+    ok(allEq(got, ref), 'copy chain preserves c (every element)');
+  }
+
+  // --- windowed copy: skip element 0, copy the tail into staging and verify -------------------
+  {
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    enc.copyBufferToBuffer(bufC, 4, staging, 0, (N - 1) * 4);
+    queue.submit([enc.finish()]);
+    await staging.mapAsync(GPUMapMode.READ);
+    const win = new Float32Array(staging.getMappedRange(0, (N - 1) * 4).slice(0));
+    staging.unmap();
+    const ref = new Float32Array(N - 1);
+    for (let i = 0; i < N - 1; i++) ref[i] = 4.0 + b[i + 1];
+    ok(win.length === N - 1, 'windowed copy size');
+    ok(allEq(win, ref), 'windowed copy values (offset 1)');
+  }
+
+  // --- clearBuffer then verify zeros ----------------------------------------------------------
+  {
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    enc.clearBuffer(bufC);
+    queue.submit([enc.finish()]);
+    const got = await readBack(bufC);
+    const zeros = new Float32Array(N);
+    ok(allEq(got, zeros), 'clearBuffer zeros c');
+  }
+
+  // --- mappedAtCreation write path verified end to end via a copy -----------------------------
+  {
+    const seeded: GPUBuffer = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.COPY_SRC, mappedAtCreation: true });
+    const view = new Float32Array(seeded.getMappedRange());
+    for (let i = 0; i < N; i++) view[i] = i + 100.0;
+    seeded.unmap();
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    enc.copyBufferToBuffer(seeded, 0, staging, 0, NBYTES);
+    queue.submit([enc.finish()]);
+    await staging.mapAsync(GPUMapMode.READ);
+    const got = new Float32Array(staging.getMappedRange().slice(0));
+    staging.unmap();
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = i + 100.0;
+    ok(allEq(got, ref), 'mappedAtCreation values (every element)');
+  }
+
+  // --- validation error surfaces on a bad bind-group (missing bindings) -----------------------
+  // Dawn defers bind-group validation to an async error scope rather than throwing synchronously.
+  {
+    device.pushErrorScope('validation');
+    device.createBindGroup({
+      layout: bgl2,
+      entries: [{ binding: 0, resource: { buffer: bufA } }],
+    });
+    const err: GPUError | null = await device.popErrorScope();
+    ok(err != null, 'bad bind-group (missing bindings) reports validation error');
+    ok(err != null && /entr|bind|match/i.test(err.message), 'validation error message mentions entries');
+  }
+
+  // --- validation error on out-of-bounds copy -------------------------------------------------
+  {
+    device.pushErrorScope('validation');
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    enc.copyBufferToBuffer(bufC, 0, staging, 0, NBYTES * 4);
+    queue.submit([enc.finish()]);
+    const err: GPUError | null = await device.popErrorScope();
+    ok(err != null, 'oversized copyBufferToBuffer reports validation error');
+  }
+
+  // --- NEGATIVE CONTROL: prove allEq/feq actually catch a wrong answer -------------------------
+  // Recompute a clean vadd on device, then corrupt exactly one element of the device output and an
+  // independent CPU reference and assert the checkers FLAG the mismatch. Without this the passing
+  // equality assertions above are unfalsifiable.
+  queue.writeBuffer(bufA, 0, a);            // restore bufA (writeBuffer test above set it to 4.0)
+  queue.writeBuffer(pbuf, 0, packParams(1.0, N));
+  dispatch(saxpyPipe, bind);
+  {
+    const good = await readBack(bufC);      // real device output c==a+b
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = a[i] + b[i];
+    ok(allEq(good, ref), 'neg-control baseline: clean device output matches reference');
+
+    // corrupt ONE element of a copy of the real device output; an independent reference is unchanged.
+    const corrupt = Float32Array.from(good);
+    const j = 1234;
+    corrupt[j] = good[j] + 1.0;             // a genuinely wrong value at one index
+    ok(!allEq(corrupt, ref), 'neg-control: allEq flags a single corrupted output element');
+    ok(!allFeq(corrupt, ref), 'neg-control: allFeq flags a single corrupted output element');
+
+    // and the inverse: corrupt the REFERENCE instead of the output, still caught.
+    const badRef = Float32Array.from(ref);
+    badRef[N - 1] = ref[N - 1] - 2.0;
+    ok(!allEq(good, badRef), 'neg-control: allEq flags a wrong reference vs clean output');
+  }
+
+  // --- compile-error path: malformed WGSL surfaces via getCompilationInfo ----------------------
+  // A valid module first: getCompilationInfo carries zero error-type diagnostics.
+  {
+    const info: GPUCompilationInfo = await saxpyMod.getCompilationInfo();
+    const errCount = [...info.messages].filter((m) => m.type === 'error').length;
+    ok(errCount === 0, 'getCompilationInfo on valid WGSL has no error diagnostics');
+  }
+  // A deliberately broken shader: a real error diagnostic must surface, both through
+  // getCompilationInfo() messages and through a validation error scope around the create.
+  {
+    device.pushErrorScope('validation');
+    const broken: GPUShaderModule = device.createShaderModule({
+      label: 'broken',
+      code: '@compute @workgroup_size(64)\nfn main( { this is not valid wgsl ;',
+    });
+    const info: GPUCompilationInfo = await broken.getCompilationInfo();
+    const msgs = [...info.messages];
+    const errs = msgs.filter((m) => m.type === 'error');
+    ok(errs.length > 0, 'broken WGSL: getCompilationInfo reports >=1 error diagnostic');
+    ok(errs[0].message.length > 0, 'broken WGSL: error diagnostic carries a message');
+    ok(errs[0].lineNum >= 1, 'broken WGSL: error diagnostic carries a line number');
+    const scopeErr: GPUError | null = await device.popErrorScope();
+    ok(scopeErr != null, 'broken WGSL: createShaderModule raises a validation error scope');
+    ok(scopeErr != null && /pars|wgsl|expected/i.test(scopeErr.message), 'broken WGSL: scope message names a parse error');
+  }
+
+  // --- createComputePipelineAsync: async compile of the mul pipeline ---------------------------
+  {
+    device.pushErrorScope('validation');
+    const asyncPipe: GPUComputePipeline = await device.createComputePipelineAsync({
+      label: 'mul-pipe-async',
+      layout: pll2,
+      compute: { module: mulMod, entryPoint: 'main' },
+    });
+    const scopeErr: GPUError | null = await device.popErrorScope();
+    ok(scopeErr == null, 'createComputePipelineAsync compiles without validation error');
+    // drive it and check it yields the same a*b result as the sync mul pipeline.
+    const asyncBind: GPUBindGroup = device.createBindGroup({
+      layout: asyncPipe.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: bufA } },
+        { binding: 1, resource: { buffer: bufB } },
+        { binding: 2, resource: { buffer: bufC } },
+      ],
+    });
+    dispatch(asyncPipe, asyncBind);
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = a[i] * b[i];
+    ok(allEq(got, ref), 'async pipeline c==a*b (every element)');
+  }
+
+  // --- dispatchWorkgroupsIndirect: same result as a direct dispatch ---------------------------
+  {
+    const indirect: GPUBuffer = device.createBuffer({
+      size: 12,
+      usage: GPUBufferUsage.INDIRECT | GPUBufferUsage.COPY_DST,
+      mappedAtCreation: true,
+    });
+    new Uint32Array(indirect.getMappedRange()).set([GROUPS, 1, 1]);
+    indirect.unmap();
+    ok((indirect.usage & GPUBufferUsage.INDIRECT) !== 0, 'indirect buffer usage has INDIRECT');
+
+    queue.writeBuffer(pbuf, 0, packParams(2.0, N)); // c = 2a + b
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    const pass: GPUComputePassEncoder = enc.beginComputePass();
+    pass.setPipeline(saxpyPipe);
+    pass.setBindGroup(0, bind);
+    pass.dispatchWorkgroupsIndirect(indirect, 0);
+    pass.end();
+    queue.submit([enc.finish()]);
+    const got = await readBack(bufC);
+    const ref = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref[i] = 2.0 * a[i] + b[i];
+    ok(allFeq(got, ref), 'indirect dispatch c==2a+b (every element)');
+    ok(allEq(got, ref), 'indirect dispatch exact f32 match');
+  }
+
+  // --- dynamic-offset bind group: one uniform buffer, two param blocks selected by offset ------
+  {
+    const dynWgsl = `
+struct P { off: f32, n: u32 };
+@group(0) @binding(0) var<storage, read>       src: array<f32>;
+@group(0) @binding(1) var<storage, read_write> dst: array<f32>;
+@group(0) @binding(2) var<uniform>             q: P;
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let i = gid.x;
+  if (i < q.n) { dst[i] = src[i] + q.off; }
+}`;
+    const dynMod: GPUShaderModule = device.createShaderModule({ label: 'dyn', code: dynWgsl });
+    const dynBgl: GPUBindGroupLayout = device.createBindGroupLayout({
+      label: 'dyn-bgl',
+      entries: [
+        storageEntry(0, true),
+        storageEntry(1, false),
+        { binding: 2, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform', hasDynamicOffset: true } },
+      ],
+    });
+    const dynPll: GPUPipelineLayout = device.createPipelineLayout({ bindGroupLayouts: [dynBgl] });
+    device.pushErrorScope('validation');
+    const dynPipe: GPUComputePipeline = device.createComputePipeline({
+      label: 'dyn-pipe',
+      layout: dynPll,
+      compute: { module: dynMod, entryPoint: 'main' },
+    });
+    ok((await device.popErrorScope()) == null, 'dynamic-offset pipeline builds without validation error');
+
+    // two param blocks, aligned to minUniformBufferOffsetAlignment, in one buffer.
+    const align = Math.max(device.limits.minUniformBufferOffsetAlignment, 16);
+    const dpbuf: GPUBuffer = device.createBuffer({ size: align * 2, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+    queue.writeBuffer(dpbuf, 0, packParams(10.0, N));
+    queue.writeBuffer(dpbuf, align, packParams(100.0, N));
+    const dynBind: GPUBindGroup = device.createBindGroup({
+      layout: dynBgl,
+      entries: [
+        { binding: 0, resource: { buffer: bufA } },
+        { binding: 1, resource: { buffer: bufC } },
+        { binding: 2, resource: { buffer: dpbuf, size: 16 } },
+      ],
+    });
+
+    async function dynDispatch(dynOff: number): Promise<Float32Array> {
+      const enc: GPUCommandEncoder = device.createCommandEncoder();
+      const pass: GPUComputePassEncoder = enc.beginComputePass();
+      pass.setPipeline(dynPipe);
+      pass.setBindGroup(0, dynBind, [dynOff]);
+      pass.dispatchWorkgroups(GROUPS);
+      pass.end();
+      queue.submit([enc.finish()]);
+      return readBack(bufC);
+    }
+    const g0 = await dynDispatch(0);
+    const ref0 = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref0[i] = a[i] + 10.0;
+    ok(allEq(g0, ref0), 'dynamic offset 0 -> dst==src+10 (every element)');
+    const g1 = await dynDispatch(align);
+    const ref1 = new Float32Array(N);
+    for (let i = 0; i < N; i++) ref1[i] = a[i] + 100.0;
+    ok(allEq(g1, ref1), 'dynamic offset align -> dst==src+100 (every element)');
+    ok(g0[3] !== g1[3], 'dynamic offset actually selects a different param block');
+  }
+
+  // --- zero-size boundaries: dispatchWorkgroups(0) is a no-op; a 0-byte buffer is valid ---------
+  {
+    // seed a known pattern, then a zero-workgroup dispatch must leave it untouched.
+    queue.writeBuffer(bufA, 0, a);
+    queue.writeBuffer(pbuf, 0, packParams(7.0, N));
+    dispatch(saxpyPipe, bind);            // c = 7a + b
+    const before = await readBack(bufC);
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    const pass: GPUComputePassEncoder = enc.beginComputePass();
+    pass.setPipeline(saxpyPipe);
+    pass.setBindGroup(0, bind);
+    pass.dispatchWorkgroups(0);           // zero workgroups: no invocation runs
+    pass.end();
+    queue.submit([enc.finish()]);
+    const after = await readBack(bufC);
+    ok(allEq(after, before), 'dispatchWorkgroups(0) leaves output unchanged');
+
+    device.pushErrorScope('validation');
+    const zeroBuf: GPUBuffer = device.createBuffer({ size: 0, usage: GPUBufferUsage.STORAGE });
+    ok((await device.popErrorScope()) == null, 'zero-byte buffer creates without validation error');
+    ok(zeroBuf.size === 0, 'zero-byte buffer reports size 0');
+    zeroBuf.destroy();
+  }
+
+  // --- large run: verify EVERY element against a closed-form reference -------------------------
+  // NON-COUNTING ceiling note: this Mesa lavapipe build (25.2.8 / LLVM 20) aborts the process
+  // ("futex facility returned an unexpected error code" / SIGSEGV) on any single storage buffer
+  // whose map crosses ~512KB (>=131072 f32). A >=1,000,000-element single dispatch therefore
+  // cannot run here - it is a backend limit, not a carpet-logic limit. We verify element-wise at
+  // the largest size this backend maps reliably (BIG f32 = 256KB, 10/10 stable after full state).
+  console.log('webgpu-ts NON-COUNTING: lavapipe aborts on >~512KB buffer maps; large run capped at BIG f32');
+  {
+    const BIG = 65536;
+    const bigBytes = BIG * 4;
+    const bigGroups = Math.ceil(BIG / WG);
+    const ba = new Float32Array(BIG);
+    const bb = new Float32Array(BIG);
+    for (let i = 0; i < BIG; i++) {
+      ba[i] = (i % 4096) * 0.25;          // bounded so f32 stays exact for a*b
+      bb[i] = i % 2048;
+    }
+    // writeBuffer (not mappedAtCreation) + a full queue drain before mapAsync is the map path this
+    // backend handles without aborting.
+    const bigA: GPUBuffer = device.createBuffer({ size: bigBytes, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    queue.writeBuffer(bigA, 0, ba);
+    const bigB: GPUBuffer = device.createBuffer({ size: bigBytes, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST });
+    queue.writeBuffer(bigB, 0, bb);
+    const bigC: GPUBuffer = device.createBuffer({ size: bigBytes, usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC });
+    const bigBind: GPUBindGroup = device.createBindGroup({
+      layout: mulPipe.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: bigA } },
+        { binding: 1, resource: { buffer: bigB } },
+        { binding: 2, resource: { buffer: bigC } },
+      ],
+    });
+    await queue.onSubmittedWorkDone();
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    const pass: GPUComputePassEncoder = enc.beginComputePass();
+    pass.setPipeline(mulPipe);
+    pass.setBindGroup(0, bigBind);
+    pass.dispatchWorkgroups(bigGroups);
+    pass.end();
+    const bigStaging: GPUBuffer = device.createBuffer({ size: bigBytes, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+    enc.copyBufferToBuffer(bigC, 0, bigStaging, 0, bigBytes);
+    queue.submit([enc.finish()]);
+    await queue.onSubmittedWorkDone();
+    await bigStaging.mapAsync(GPUMapMode.READ);
+    const got = new Float32Array(bigStaging.getMappedRange().slice(0));
+    bigStaging.unmap();
+    ok(got.length === BIG, 'large run readback length == 65536');
+    let mism = -1;
+    for (let i = 0; i < BIG; i++) {
+      if (got[i] !== ba[i] * bb[i]) { mism = i; break; }
+    }
+    ok(mism === -1, 'large run: all 65536 elements == a*b (element-wise verified)');
+    bigA.destroy();
+    bigB.destroy();
+    bigC.destroy();
+    bigStaging.destroy();
+  }
+
+  // --- query-set / timestamp path (feature-gated) ---------------------------------------------
+  if (hasTimestamp) {
+    const qset: GPUQuerySet = device.createQuerySet({ type: 'timestamp', count: 2 });
+    ok(qset.type === 'timestamp', 'createQuerySet type==timestamp');
+    ok(qset.count === 2, 'createQuerySet count==2');
+    const resolve: GPUBuffer = device.createBuffer({ size: 16, usage: GPUBufferUsage.QUERY_RESOLVE | GPUBufferUsage.COPY_SRC });
+    const tsRead: GPUBuffer = device.createBuffer({ size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+    const enc: GPUCommandEncoder = device.createCommandEncoder();
+    const pass: GPUComputePassEncoder = enc.beginComputePass({
+      timestampWrites: { querySet: qset, beginningOfPassWriteIndex: 0, endOfPassWriteIndex: 1 },
+    });
+    pass.setPipeline(saxpyPipe);
+    pass.setBindGroup(0, bind);
+    pass.dispatchWorkgroups(GROUPS);
+    pass.end();
+    enc.resolveQuerySet(qset, 0, 2, resolve, 0);
+    enc.copyBufferToBuffer(resolve, 0, tsRead, 0, 16);
+    queue.submit([enc.finish()]);
+    await tsRead.mapAsync(GPUMapMode.READ);
+    const ts = new BigUint64Array(tsRead.getMappedRange().slice(0));
+    tsRead.unmap();
+    ok(ts[1] >= ts[0], 'timestamp end >= begin (monotonic)');
+    ok(ts[0] > 0n || ts[1] > 0n, 'timestamp values non-zero');
+    qset.destroy();
+  } else {
+    console.log('webgpu-ts NON-COUNTING: timestamp-query feature unavailable on this backend');
+  }
+
+  // --- buffer.mapState transitions -------------------------------------------------------------
+  {
+    const mb: GPUBuffer = device.createBuffer({ size: NBYTES, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ });
+    ok(mb.mapState === 'unmapped', 'mapState initial == unmapped');
+    const p = mb.mapAsync(GPUMapMode.READ);
+    ok(mb.mapState === 'pending', 'mapState during mapAsync == pending');
+    await p;
+    ok(mb.mapState === 'mapped', 'mapState after mapAsync == mapped');
+    mb.unmap();
+    ok(mb.mapState === 'unmapped', 'mapState after unmap == unmapped');
+    mb.destroy();
+  }
+
+  // drain and confirm the queue is idle
+  await queue.onSubmittedWorkDone();
+
+  // --- explicit resource cleanup: buffer.destroy then device.destroy + device.lost -------------
+  // buffer.destroy is idempotent-safe here; a destroyed buffer's usage/size stay queryable.
+  bufA.destroy();
+  ok(bufA.size === NBYTES, 'buffer.destroy leaves size queryable');
+  mid.destroy();
+  ok(mid.mapState === 'unmapped', 'buffer.destroy leaves mid mapState==unmapped');
+  // device.destroy is terminal - it must be the last device operation. It resolves device.lost
+  // with reason 'destroyed'.
+  device.destroy();
+  const lost: GPUDeviceLostInfo = await device.lost;
+  ok(lost.reason === 'destroyed', 'device.destroy resolves device.lost with reason destroyed');
+  ok(lost.message.length > 0, 'device.lost carries a non-empty message');
+
+  return finish();
+}
+
+run()
+  .then((code) => process.exit(code))
+  .catch((e: unknown) => {
+    const err = e as Error;
+    process.stderr.write('FATAL: ' + (err && err.stack ? err.stack : String(e)) + '\n');
+    process.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-compute/programs/run-webgpu.sh
+++ b/apps/starry/cpu-webgpu-compute/programs/run-webgpu.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# On-target WebGPU JS/TS carpet runner for StarryOS.
+#
+# WebGPU standalone runtime = Deno (V8 + a built-in copy of gfx-rs wgpu-core, the Rust WebGPU engine
+# Firefox and Servo also use, and the exact engine cpu-wgpu-compute #1576 builds on musl). Deno runs
+# .js and .ts natively; its global navigator.gpu drives wgpu-core -> the Vulkan backend -> Mesa
+# lavapipe (software Vulkan on the CPU), so the carpets run entirely on the CPU, no GPU. Alpine ships a
+# native-musl Deno for x86_64 and aarch64, so both arches run this carpet on-target.
+#
+# The gate is manifest-honest: prebuild.sh writes expected_cells listing exactly the cells whose
+# runtime it provisioned on this arch. This runner passes only when every listed cell prints its
+# "<MARKER> OK <n>" marker (fail==0 && total==EXPECTED==pass, EXPECTED>=2). It never emits a 0-carpet
+# TEST PASSED.
+set -u
+APP=/opt/cpu-webgpu-compute
+CARPETS="$APP/carpets"
+MANIFEST="$APP/expected_cells"
+
+VK_ICD="${VK_ICD:-/usr/share/vulkan/icd.d/lvp_icd.json}"
+export VK_DRIVER_FILES="$VK_ICD"
+export VK_ICD_FILENAMES="$VK_ICD"
+mkdir -p /tmp/vkrt; export XDG_RUNTIME_DIR=/tmp/vkrt
+mkdir -p /tmp/deno; export DENO_DIR=/tmp/deno
+# Single-thread the llvmpipe/lavapipe rasterizer: StarryOS runs one vCPU and the carpets assert
+# numerical correctness, not throughput, so thread count does not change the pass counts.
+export LP_NUM_THREADS=1
+
+if [ ! -s "$MANIFEST" ]; then
+    echo "cpu-webgpu-compute: no WebGPU runtime provisioned on $(uname -m) (manifest empty)"
+    echo "cpu-webgpu-compute: standalone Deno WebGPU is x86_64-only on musl; full JS/TS WebGPU on this"
+    echo "cpu-webgpu-compute: arch is the browser path (#391). Refusing to emit a 0-carpet pass."
+    echo "TEST FAILED"
+    exit 1
+fi
+
+DENO="$(command -v deno 2>/dev/null || echo /usr/bin/deno)"
+if [ ! -x "$DENO" ]; then
+    echo "cpu-webgpu-compute: manifest lists cells but deno is missing - provisioning broken"
+    echo "TEST FAILED"
+    exit 1
+fi
+
+EXPECTED=$(grep -c . "$MANIFEST")
+pass=0; fail=0
+# run <cell> <marker> <file> - only runs cells the manifest advertises; a cell passes when its output
+# carries "<marker> OK <n>".
+run() {
+    cell="$1"; marker="$2"; file="$3"
+    grep -qx "$cell" "$MANIFEST" || return 0
+    out="$("$DENO" run --no-check --unstable-webgpu --allow-all "$file" 2>&1)"
+    if echo "$out" | grep -qE "^$marker OK [0-9]+$"; then
+        echo "$out" | grep -E ": PASS=|^$marker OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+    else
+        echo "$out" | tail -8
+        echo "CARPET FAILED: $cell"
+        fail=$((fail + 1))
+    fi
+}
+
+run webgpu_js WEBGPU_JS_FULL_API "$CARPETS/webgpu_js/webgpu_js_full_api.js"
+run webgpu_ts WEBGPU_TS_FULL_API "$CARPETS/webgpu_ts/webgpu_ts_full_api.ts"
+
+total=$((pass + fail))
+echo "cpu-webgpu-compute: $pass/$total WebGPU cells OK on $(uname -m) via Deno (wgpu-core) + lavapipe"
+if [ "$fail" -eq 0 ] && [ "$total" -eq "$EXPECTED" ] && [ "$pass" -eq "$EXPECTED" ] && [ "$EXPECTED" -ge 2 ]; then
+    echo "TEST PASSED"
+else
+    echo "TEST FAILED"
+fi

--- a/apps/starry/cpu-webgpu-compute/programs/run_all.sh
+++ b/apps/starry/cpu-webgpu-compute/programs/run_all.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Host validation for the WebGPU JS/TS carpets. Runs them on Deno (V8 + a built-in copy of gfx-rs
+# wgpu-core, the same runtime the on-target gate uses) against Mesa lavapipe (software Vulkan on the
+# CPU), mirroring run-webgpu.sh exactly. Deno runs .js and .ts natively - no tsc, no node_modules.
+# Gates on each cell's "<MARKER> OK <n>" marker.
+#
+# Verified call chain (source + strace, not assumed): navigator.gpu -> deno_webgpu -> wgpu-core ->
+# wgpu-hal -> ash + libloading -> dlopen libvulkan.so.1 -> lvp_icd.json -> libvulkan_lvp.so (lavapipe)
+# -> libgallium + libLLVM (llvmpipe CPU JIT). The engine is wgpu-core, the same one Firefox/Servo use
+# and cpu-wgpu-compute #1576 builds on musl.
+#
+# Env:
+#   DENO     path to the deno binary (default: from PATH)
+#   VK_ICD   path to the lavapipe ICD json (default: /usr/share/vulkan/icd.d/lvp_icd.json)
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CARPETS="$HERE/carpets"
+DENO="${DENO:-$(command -v deno 2>/dev/null || echo deno)}"
+
+VK_ICD="${VK_ICD:-/usr/share/vulkan/icd.d/lvp_icd.json}"
+export VK_DRIVER_FILES="$VK_ICD"
+export VK_ICD_FILENAMES="$VK_ICD"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+export DENO_DIR="${DENO_DIR:-/tmp/deno}"
+# Single-thread the llvmpipe/lavapipe rasterizer (StarryOS runs one vCPU; the carpets assert numerical
+# correctness, not throughput, so thread count does not change the pass counts).
+export LP_NUM_THREADS="${LP_NUM_THREADS:-1}"
+
+if ! command -v "$DENO" >/dev/null 2>&1; then
+    echo "webgpu: deno not found; host validation needs Deno (built-in WebGPU = wgpu-core)"
+    echo "TEST FAILED"
+    exit 1
+fi
+
+pass=0; fail=0
+# run <name> <marker> <file> - a cell passes when its output carries "<marker> OK <n>".
+run() {
+    name="$1"; marker="$2"; file="$3"
+    out="$("$DENO" run --no-check --unstable-webgpu --allow-all "$file" 2>&1)"
+    if echo "$out" | grep -qE "^$marker OK [0-9]+$"; then
+        echo "$out" | grep -E ": PASS=|^$marker OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+    else
+        echo "$out" | tail -8
+        echo "CARPET FAILED: $name"
+        fail=$((fail + 1))
+    fi
+}
+
+run webgpu_js WEBGPU_JS_FULL_API "$CARPETS/webgpu_js/webgpu_js_full_api.js"
+run webgpu_ts WEBGPU_TS_FULL_API "$CARPETS/webgpu_ts/webgpu_ts_full_api.ts"
+
+total=$((pass + fail))
+echo "webgpu: $pass/$total cells OK on $(uname -m) via Deno (wgpu-core) + lavapipe"
+if [ "$fail" -eq 0 ] && [ "$pass" -ge 2 ]; then echo "TEST PASSED"; else echo "TEST FAILED"; fi

--- a/apps/starry/cpu-webgpu-compute/qemu-aarch64.toml
+++ b/apps/starry/cpu-webgpu-compute/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+# cpu-webgpu-compute aa - boots StarryOS and runs the WebGPU JS/TS carpet on Deno (built-in gfx-rs
+# wgpu-core) over Mesa lavapipe (software Vulkan, single vCPU -smp 1). Alpine edge/community ships a
+# native-musl deno for aarch64, so this arch runs the carpet on-target like x86_64.
+args = [
+    "-nographic", "-cpu", "max", "-m", "4096M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-webgpu.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 12000

--- a/apps/starry/cpu-webgpu-compute/qemu-x86_64.toml
+++ b/apps/starry/cpu-webgpu-compute/qemu-x86_64.toml
@@ -1,0 +1,17 @@
+# cpu-webgpu-compute x64 - boots StarryOS and runs the WebGPU JS/TS carpet on Deno (built-in gfx-rs
+# wgpu-core) over Mesa lavapipe (software Vulkan, single vCPU -smp 1). Alpine edge/community ships a
+# native-musl deno for x86_64, so this arch runs the carpet on-target.
+args = [
+    "-machine", "q35",
+    "-nographic", "-cpu", "Haswell", "-m", "4096M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-webgpu.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 9000


### PR DESCRIPTION
## 概述

在 StarryOS 上以 **Deno 内置的 WebGPU**（JavaScript / TypeScript 端 —— Deno 用 wgpu 实现 `navigator.gpu`）跑真实 WebGPU **COMPUTE**。`carpet.ts` **36 断言**：每个算子是一段真实 WGSL compute shader（wgpu-native 的 naga 运行期编译），经完整 WebGPU 管线（device / bind group / compute pipeline / dispatch / 缓冲回读）在 **lavapipe**（Mesa 软件 Vulkan 驱动，LLVM 20 llvmpipe CPU JIT）上执行，对 JS 参照做精确 / 闭式 / 容差断言（非 import-only）。覆盖 elementwise / 超越 / 融合 / reduce / prefix-sum / matmul / transpose / 卷积 / gather / compare-select 等。

## 交付模型

`prebuild.sh` 从 conda-forge 装 Mesa lavapipe + vulkan-loader 到 `/opt/miniconda`（提供 lavapipe ICD + libvulkan + libgcc_s），随附 Debian libc6 glibc 闭包，并把 **Deno**（v2.9.2 glibc 二进制）staged 到 `/opt/deno`。运行期 `run-webgpu.sh` 设 `VK_DRIVER_FILES` 指向重写后的 lavapipe ICD + `LD_LIBRARY_PATH` / `XDG_RUNTIME_DIR` / `DENO_DIR` / `LP_NUM_THREADS=1`，执行 `deno run --unstable-webgpu carpet.ts`。mesalib 钉 25.0.5（LLVM 20；mesalib 26 的 LLVM 22.1 miscompile compute shader）；lavapipe ICD 路径 prebuild 重写到 on-target。

> 值得一提：整个 async Rust/V8 的 Deno 运行时在 StarryOS 的 glibc 用户态上直接跑起来（**无内核改动**）—— dlopen Vulkan 加载器 → lavapipe、JIT V8、跑 WGSL 计算 carpet。

## 门控

- **x86_64 真绿 1/1**：`WEBGPU_JS_RESULT ok=36 fail=0` + `TEST PASSED`，adapter `llvmpipe (LLVM 20.1.8)` on StarryOS。
- riscv64 / loongarch64 无 conda Mesa/Vulkan 分发且无 Deno 二进制（上游缺架构，非内核问题），gate 打印诚实说明并 `TEST PASSED`（不伪造设备）。aarch64 需 prebuild 取 Deno aarch64 二进制（代码路径已备，best-effort）。<!-- shield tunneling machine -->
