### PR TITLE
test(starry): add openwrt uci + opkg carpets

### DIFF
--- a/apps/starry/openwrt/README.md
+++ b/apps/starry/openwrt/README.md
@@ -1,0 +1,66 @@
+# openwrt - OpenWrt userland carpet (uci + opkg) on StarryOS
+
+`uci` (the Unified Configuration Interface) and `opkg` (the `.ipk` package manager) are the two
+signature userland tools of an OpenWrt system - the config layer and the package layer that sit
+on top of the kernel. This app runs both, carpet-level, on StarryOS across all four
+architectures, proving StarryOS can host the OpenWrt userland tooling.
+
+It joins the OpenWrt components already carried in `apps/starry`: `dropbear` (SSH) and `dnsmasq`
+(DNS/DHCP). Together they form the core of an OpenWrt-style userland running on the StarryOS
+kernel.
+
+## Delivery model
+
+Neither `uci` nor `opkg` is packaged by Alpine, so - unlike the apk-based apps - `prebuild.sh`
+**cross-compiles them from the OpenWrt upstream C source in-prebuild**, the same way the language
+apps cross-build their native bits:
+
+- the per-arch musl cross-toolchain is supplied out-of-band (StarryOS `.starry-env.sh` PATH),
+- the sources are pinned to immutable commits (reproducible - no drifting `HEAD`, no committed
+  binaries), and
+- only the resulting static-musl binaries are staged into the overlay.
+
+Dependency chain (all small cmake C, static musl):
+
+```
+json-c  ->  libubox  ->  uci    (cli target; BUILD_STATIC)
+            libubox  ->  opkg   (opkg-cl; STATIC_UBOX - opkg ships its own libbb .ipk
+                                 extractor so it needs no libarchive, and downloads via a
+                                 wget shell-out so it needs no libcurl: libubox + pthread
+                                 is the entire dependency set)
+```
+
+Pinned sources:
+
+| project | upstream | commit |
+|---------|----------|--------|
+| json-c  | https://github.com/json-c/json-c        | `324e5ca5` |
+| libubox | https://git.openwrt.org/project/libubox.git  | `17f527fb` |
+| uci     | https://git.openwrt.org/project/uci.git      | `74f6277a` |
+| opkg    | https://git.openwrt.org/project/opkg-lede.git | `80503d94` |
+
+## What the carpet exercises
+
+Both carpets are hermetic and offline (no guest network, no committed packages). The gate
+(`programs/run-openwrt.sh`) runs both and prints `TEST PASSED` only when each reports its pinned
+`OK <n>` line - each carpet prints that line only when every assertion passed **and** the count
+equals its pinned total, so a skipped assertion fails the gate.
+
+- **uci** (`programs/uci-carpet.sh`, 70 assertions): the full command surface
+  (`get`/`show`/`set`/`commit`/`add`/`add_list`/`del_list`/`delete`/`rename`/`reorder`/`revert`/
+  `changes`/`export`/`import`/`batch`) and the option surface (`-c`/`-d`/`-q`/`-s`/`-S`/`-X`/
+  `-n`/`-N`/`-f`) against a synthetic `/etc/config` tree.
+- **opkg** (`programs/opkg-carpet.sh`, 42 assertions): the full package-manager surface
+  (`update`/`list`/`install` with dependency resolution/`remove`/`upgrade`/`files`/`status`/
+  `info`/`depends`/`whatdepends`/`flag`/`compare-versions` across every operator/
+  `print-architecture` and the `--force-*` / `--offline-root` options) against a synthetic
+  `.ipk` feed the carpet builds at runtime.
+
+## Run
+
+```
+cargo xtask starry app qemu -t openwrt --arch x86_64
+cargo xtask starry app qemu -t openwrt --arch aarch64
+cargo xtask starry app qemu -t openwrt --arch riscv64
+cargo xtask starry app qemu -t openwrt --arch loongarch64
+```

--- a/apps/starry/openwrt/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/openwrt/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,9 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/openwrt/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/openwrt/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,10 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "axplat-dyn/efi",
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/openwrt/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/openwrt/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,9 @@
+target = "riscv64gc-unknown-none-elf"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/openwrt/build-x86_64-unknown-none.toml
+++ b/apps/starry/openwrt/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/virtio-blk",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/openwrt/prebuild.sh
+++ b/apps/starry/openwrt/prebuild.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the StarryOS OpenWrt-userland carpet (uci + opkg).
+#
+# uci (Unified Configuration Interface) and opkg (the .ipk package manager) are the two
+# signature OpenWrt userland tools. Neither is packaged by Alpine, so - unlike the apk-based
+# apps - this app CROSS-COMPILES them from the OpenWrt upstream C source IN-PREBUILD, exactly
+# the way the language apps cross-build their native bits: the per-arch musl cross-toolchain is
+# supplied out-of-band (StarryOS .starry-env.sh PATH), the sources are pinned to immutable
+# commits (reproducible - no drifting HEAD, no committed binaries), and only the resulting
+# static-musl binaries are staged into the overlay. QEMU then needs no guest network.
+#
+# Dependency chain (all small cmake C, static musl):
+#   json-c ->  libubox ->  uci   (the `cli` target, OUTPUT_NAME uci; BUILD_STATIC)
+#              libubox ->  opkg  (opkg-cl; STATIC_UBOX - opkg ships its own libbb .ipk
+#                                 extractor, so NO libarchive, and downloads via wget shell-out
+#                                 so NO libcurl - libubox + pthread is the whole dep set)
+#
+# Staged:
+#   uci      -> /usr/bin/uci
+#   opkg     -> /usr/bin/opkg        (built as opkg-cl, installed under the canonical name)
+#   the two carpets + the gate -> /usr/bin/{uci-carpet.sh,opkg-carpet.sh,run-openwrt.sh}
+#
+# Env from the app runner: STARRY_ARCH, STARRY_OVERLAY_DIR, STARRY_APP_DIR, STARRY_ROOTFS,
+# STARRY_STAGING_ROOT.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+rootfs_img="${STARRY_ROOTFS:-}"
+
+CACHE="${OPENWRT_DL_ROOT:-${STARRY_STAGING_ROOT:-$app_dir}/.cache/openwrt-build}"
+ROOTFS_SIZE="${OPENWRT_ROOTFS_SIZE:-1024M}"
+
+# Immutable source pins (reproducible; verified to cross-build all four arches).
+JSONC_URL="https://github.com/json-c/json-c";        JSONC_SHA="324e5ca5937c459812973149f2c31ae25b6439bb"
+LIBUBOX_URL="https://git.openwrt.org/project/libubox.git"; LIBUBOX_SHA="17f527fb6c30bf9073104f03337c2b7c03158bdb"
+UCI_URL="https://git.openwrt.org/project/uci.git";   UCI_SHA="74f6277aabffc943d026f406df57c22595134c42"
+OPKG_URL="https://git.openwrt.org/project/opkg-lede.git"; OPKG_SHA="80503d94e356476250adaf1f669ee955ec26de76"
+
+# Resolve the musl cross-compiler for the target arch. The toolchains are provided out-of-band
+# (not apt): x86_64/aarch64/riscv64 land on PATH; the loongarch64 musl cross lives under
+# /opt (add it to PATH if present) - matching how the language apps locate it.
+resolve_cc() {
+    case "$arch" in
+        x86_64|aarch64|riscv64) CC="${arch}-linux-musl-gcc" ;;
+        loongarch64)
+            CC="loongarch64-linux-musl-gcc"
+            # only fall back to the /opt toolchain when it is NOT already on PATH
+            if ! command -v "$CC" >/dev/null 2>&1 && [[ -x /opt/loongarch64-linux-musl-cross/bin/$CC ]]; then
+                export PATH="/opt/loongarch64-linux-musl-cross/bin:$PATH"
+            fi
+            ;;
+        *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+    if ! command -v "$CC" >/dev/null 2>&1; then
+        echo "prebuild: musl cross-compiler '$CC' not found on PATH (provide it via .starry-env.sh)" >&2
+        exit 2
+    fi
+    echo "prebuild: arch=$arch CC=$(command -v "$CC")"
+}
+
+ensure_host_tools() {
+    local missing=()
+    command -v git   >/dev/null 2>&1 || missing+=(git)
+    command -v cmake >/dev/null 2>&1 || missing+=(cmake)
+    command -v e2fsck>/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get update && apt-get install -y --no-install-recommends "${missing[@]}"
+        else
+            echo "prebuild: missing host tools and no apt-get: ${missing[*]}" >&2; exit 1
+        fi
+    fi
+}
+
+# shallow-fetch a pinned commit into $CACHE/src/<name> (idempotent).
+fetch_pinned() {
+    local name="$1" url="$2" sha="$3"
+    local dst="$CACHE/src/$name"
+    if [[ -f "$dst/.pinned-$sha" ]]; then return 0; fi
+    rm -rf "$dst"; mkdir -p "$dst"
+    ( cd "$dst" && git init -q && git remote add origin "$url" \
+        && ( git fetch -q --depth 1 origin "$sha" || git fetch -q origin ) \
+        && git checkout -q "$sha" )
+    touch "$dst/.pinned-$sha"
+    echo "prebuild: fetched $name @ ${sha:0:12}"
+}
+
+build_all() {
+    local pfx="$CACHE/prefix-$arch" bdir="$CACHE/build-$arch"
+    # UCI_BIN / OPKG_BIN are global so stage() sees them on BOTH the build and cache-reuse paths.
+    UCI_BIN="$bdir/uci/uci"; OPKG_BIN="$bdir/opkg/src/opkg-cl"
+    if [[ -x "$UCI_BIN" && -x "$OPKG_BIN" ]]; then
+        echo "prebuild: reusing cached $arch binaries"; return 0
+    fi
+    mkdir -p "$pfx" "$bdir"
+    local s="$CACHE/src" CF="-I$pfx/include"
+
+    echo "prebuild: building json-c ($arch)"
+    cmake -S "$s/json-c" -B "$bdir/json-c" -DCMAKE_C_COMPILER="$CC" -DCMAKE_INSTALL_PREFIX="$pfx" \
+        -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON -DDISABLE_WERROR=ON -DBUILD_TESTING=OFF >/dev/null
+    cmake --build "$bdir/json-c" -j"$(nproc)" --target install >/dev/null
+
+    echo "prebuild: building libubox ($arch)"
+    cmake -S "$s/libubox" -B "$bdir/libubox" -DCMAKE_C_COMPILER="$CC" -DCMAKE_INSTALL_PREFIX="$pfx" \
+        -DBUILD_LUA=OFF -DBUILD_EXAMPLES=OFF -DBUILD_STATIC=ON -DUNIT_TESTING=OFF \
+        -DCMAKE_C_FLAGS="$CF" -DCMAKE_PREFIX_PATH="$pfx" >/dev/null
+    cmake --build "$bdir/libubox" -j"$(nproc)" --target install >/dev/null
+
+    echo "prebuild: building uci ($arch)"
+    cmake -S "$s/uci" -B "$bdir/uci" -DCMAKE_C_COMPILER="$CC" -DCMAKE_INSTALL_PREFIX="$pfx" \
+        -DBUILD_LUA=OFF -DBUILD_STATIC=ON -DCMAKE_C_FLAGS="$CF" \
+        -DCMAKE_EXE_LINKER_FLAGS="-static -L$pfx/lib" -DCMAKE_PREFIX_PATH="$pfx" >/dev/null
+    cmake --build "$bdir/uci" -j"$(nproc)" --target cli >/dev/null
+    [[ -x "$UCI_BIN" ]] || { UCI_BIN="$(find "$bdir/uci" -type f -executable -name uci | head -1)"; }
+
+    echo "prebuild: building opkg ($arch)"
+    cmake -S "$s/opkg" -B "$bdir/opkg" -DCMAKE_C_COMPILER="$CC" -DCMAKE_INSTALL_PREFIX="$pfx" \
+        -DSTATIC_UBOX=ON -DBUILD_TESTS=OFF -DENABLE_USIGN=OFF \
+        -DCMAKE_C_FLAGS="$CF -Wno-error" -DCMAKE_EXE_LINKER_FLAGS="-static -L$pfx/lib" \
+        -DCMAKE_PREFIX_PATH="$pfx" >/dev/null
+    cmake --build "$bdir/opkg" -j"$(nproc)" >/dev/null
+    [[ -x "$OPKG_BIN" ]] || { OPKG_BIN="$(find "$bdir/opkg" -type f -executable -name 'opkg*' | head -1)"; }
+
+    [[ -x "$UCI_BIN"  ]] || { echo "prebuild: uci build produced no binary"  >&2; exit 3; }
+    [[ -x "$OPKG_BIN" ]] || { echo "prebuild: opkg build produced no binary" >&2; exit 3; }
+}
+
+stage() {
+    [[ -x "$UCI_BIN" && -x "$OPKG_BIN" ]] || { echo "prebuild: uci/opkg binaries missing at stage" >&2; exit 3; }
+    mkdir -p "$overlay_dir/usr/bin"
+    install -Dm0755 "$UCI_BIN"  "$overlay_dir/usr/bin/uci"
+    install -Dm0755 "$OPKG_BIN" "$overlay_dir/usr/bin/opkg"
+    install -Dm0755 "$app_dir/programs/uci-carpet.sh"  "$overlay_dir/usr/bin/uci-carpet.sh"
+    install -Dm0755 "$app_dir/programs/opkg-carpet.sh" "$overlay_dir/usr/bin/opkg-carpet.sh"
+    install -Dm0755 "$app_dir/programs/run-openwrt.sh" "$overlay_dir/usr/bin/run-openwrt.sh"
+    echo "prebuild: staged uci + opkg + carpets -> overlay/usr/bin"
+}
+
+# Grow-only, idempotent (never shrink an already-grown image - truncate '>' only extends).
+grow_rootfs() {
+    [[ -n "$rootfs_img" && -f "$rootfs_img" ]] || { echo "prebuild: rootfs not staged, skipping grow"; return 0; }
+    local cur target
+    cur=$(stat -c %s "$rootfs_img"); target=$(( ${ROOTFS_SIZE%M} * 1024 * 1024 ))
+    if [[ "$cur" -lt "$target" ]]; then
+        truncate -s ">$ROOTFS_SIZE" "$rootfs_img"
+        e2fsck -f -y "$rootfs_img" >/dev/null 2>&1 || true
+        resize2fs "$rootfs_img" >/dev/null 2>&1 || { echo "prebuild: resize2fs failed" >&2; exit 2; }
+    fi
+    echo "prebuild: rootfs sized to $(( $(stat -c %s "$rootfs_img")/1024/1024 )) MiB"
+}
+
+main() {
+    ensure_host_tools
+    resolve_cc
+    grow_rootfs
+    fetch_pinned json-c  "$JSONC_URL"   "$JSONC_SHA"
+    fetch_pinned libubox "$LIBUBOX_URL" "$LIBUBOX_SHA"
+    fetch_pinned uci     "$UCI_URL"     "$UCI_SHA"
+    fetch_pinned opkg    "$OPKG_URL"    "$OPKG_SHA"
+    build_all
+    stage
+    echo "prebuild: openwrt (uci + opkg) overlay ready for $arch"
+}
+
+main "$@"

--- a/apps/starry/openwrt/programs/SOURCES.md
+++ b/apps/starry/openwrt/programs/SOURCES.md
@@ -1,0 +1,15 @@
+# Sources
+
+`prebuild.sh` cross-compiles the binaries from these pinned OpenWrt upstream commits (no
+committed binaries; the musl cross-toolchain is provided out-of-band via `.starry-env.sh`):
+
+| project | upstream | commit | role |
+|---------|----------|--------|------|
+| json-c  | https://github.com/json-c/json-c              | `324e5ca5937c459812973149f2c31ae25b6439bb` | libubox blobmsg_json dependency |
+| libubox | https://git.openwrt.org/project/libubox.git   | `17f527fb6c30bf9073104f03337c2b7c03158bdb` | shared OpenWrt C base lib |
+| uci     | https://git.openwrt.org/project/uci.git       | `74f6277aabffc943d026f406df57c22595134c42` | Unified Configuration Interface |
+| opkg    | https://git.openwrt.org/project/opkg-lede.git | `80503d94e356476250adaf1f669ee955ec26de76` | `.ipk` package manager |
+
+`uci-carpet.sh` and `opkg-carpet.sh` are original, doc-grounded against each tool's own usage
+tree. The opkg carpet builds its synthetic `.ipk` feed at runtime with `tar`/`gzip` only (the
+OpenWrt `.ipk` tar.gz container format), so it is hermetic and needs no network.

--- a/apps/starry/openwrt/programs/opkg-carpet.sh
+++ b/apps/starry/openwrt/programs/opkg-carpet.sh
@@ -1,0 +1,159 @@
+#!/bin/sh
+# opkg-carpet.sh - doc-grounded carpet for OpenWrt opkg (the .ipk package manager).
+#
+# Ground truth = `opkg` usage tree: package-manip (update/upgrade/install/configure/remove/
+# flag), informational (list/list-installed/list-upgradable/files/search/find/info/status/
+# download/compare-versions/print-architecture/depends/whatdepends/whatprovides ...) and the
+# option surface (-A -V --offline-root/-o --conf/-f --add-arch --force-*). The carpet is fully
+# hermetic and offline: it builds its own synthetic .ipk feed at runtime (tar.gz outer format,
+# no network, no ar - busybox tar/gzip only) into an offline-root and drives opkg against it.
+#
+# opkg binary: $1, else $OPKG_BIN, else `opkg-cl`/`opkg` on PATH. Prints "OPKG CARPET OK <n>"
+# iff every assertion passed AND the count equals the pinned total.
+set -u
+OPKG="${1:-${OPKG_BIN:-}}"
+[ -n "$OPKG" ] || { OPKG="$(command -v opkg-cl 2>/dev/null || command -v opkg 2>/dev/null)"; }
+[ -n "$OPKG" ] && command -v "$OPKG" >/dev/null 2>&1 || { echo "opkg not found"; echo "OPKG CARPET FAIL"; exit 1; }
+
+ARCH="${OPKG_ARCH:-$(uname -m 2>/dev/null || echo x86_64)}"
+case "$ARCH" in x86_64|aarch64|riscv64|loongarch64) : ;; *) ARCH=x86_64 ;; esac
+
+R="${OPKG_WORK:-/tmp/opkg-carpet.$$}"
+FEED="$R/feed"; ROOT="$R/root"; BUILD="$R/build"
+rm -rf "$R"; mkdir -p "$FEED" "$BUILD" "$ROOT/var/lock" "$ROOT/usr/lib/opkg/lists" "$ROOT/usr/lib/opkg/info"
+
+cat > "$R/opkg.conf" <<EOF
+arch $ARCH 10
+arch all 1
+src/gz local file://$FEED
+dest root /
+lists_dir ext /usr/lib/opkg/lists
+EOF
+O() { "$OPKG" -f "$R/opkg.conf" -o "$ROOT" "$@"; }
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); }
+fail() { FAIL=$((FAIL+1)); echo "FAIL: $*"; }
+eq() { if [ "$2" = "$3" ]; then pass; else fail "$1 | got=[$2] want=[$3]"; fi; }
+ok() { d="$1"; shift; if "$@" >/dev/null 2>&1; then pass; else fail "$d (expected success)"; fi; }
+no() { d="$1"; shift; if "$@" >/dev/null 2>&1; then fail "$d (expected failure)"; else pass; fi; }
+has(){ case "$2" in *"$3"*) pass;; *) fail "$1 | [$2] lacks [$3]";; esac; }
+
+# ---------------------------------------------------------------- .ipk builder (tar.gz format)
+# mkipk <name> <version> <arch> <depends> <file-under-usr/bin> <payload>
+mkipk() {
+	nm="$1"; ver="$2"; parch="$3"; deps="$4"; binname="$5"; payload="$6"
+	pd="$BUILD/$nm"; rm -rf "$pd"; mkdir -p "$pd/control" "$pd/data/usr/bin"
+	printf '#!/bin/sh\n%s\n' "$payload" > "$pd/data/usr/bin/$binname"; chmod +x "$pd/data/usr/bin/$binname"
+	{
+		echo "Package: $nm"; echo "Version: $ver"; echo "Architecture: $parch"
+		echo "Maintainer: StarryWRT"; [ -n "$deps" ] && echo "Depends: $deps"
+		echo "Description: synthetic $nm"
+	} > "$pd/control/control"
+	( cd "$pd/control" && tar -czf ../control.tar.gz . )
+	( cd "$pd/data"    && tar -czf ../data.tar.gz . )
+	printf '2.0\n' > "$pd/debian-binary"
+	( cd "$pd" && tar -czf "$FEED/${nm}_${ver}_${parch}.ipk" ./debian-binary ./control.tar.gz ./data.tar.gz )
+}
+# regen Packages index from every .ipk currently in the feed
+mkindex() {
+	: > "$FEED/Packages"
+	for ipk in "$FEED"/*.ipk; do
+		[ -e "$ipk" ] || continue
+		base="$(basename "$ipk")"; sz="$(wc -c < "$ipk" | tr -d ' ')"; sha="$(sha256sum "$ipk" | cut -d' ' -f1)"
+		# recover control from the ipk to echo Package/Version/Architecture/Depends verbatim
+		tmp="$R/idxtmp"; rm -rf "$tmp"; mkdir -p "$tmp"
+		# extract all members (no explicit member name - portable across GNU and busybox tar)
+		tar -xzf "$ipk" -C "$tmp" 2>/dev/null; tar -xzf "$tmp/control.tar.gz" -C "$tmp" 2>/dev/null
+		grep -E '^(Package|Version|Architecture|Depends|Description):' "$tmp/control" >> "$FEED/Packages"
+		echo "Filename: $base" >> "$FEED/Packages"
+		echo "Size: $sz" >> "$FEED/Packages"
+		echo "SHA256sum: $sha" >> "$FEED/Packages"
+		echo "" >> "$FEED/Packages"
+	done
+	gzip -kf "$FEED/Packages"
+}
+
+# ---------------------------------------------------------------- self-id + pure ops (no feed)
+has "usage on bare"        "$(O 2>&1)"                      "sub-command"
+ok  "print-architecture"   sh -c "\"$OPKG\" -f \"$R/opkg.conf\" -o \"$ROOT\" print-architecture | grep -q '$ARCH 10'"
+# compare-versions across every documented operator
+ok  "cmp <<"   O compare-versions 1.0    '<<' 2.0
+ok  "cmp <="   O compare-versions 2.0    '<=' 2.0
+ok  "cmp ="    O compare-versions 1.5    '='  1.5
+ok  "cmp >="   O compare-versions 2.0    '>=' 2.0
+ok  "cmp >>"   O compare-versions 2.0    '>>' 1.0
+no  "cmp << false" O compare-versions 2.0 '<<' 1.0
+ok  "cmp epoch/rev" O compare-versions 1.0-1 '<<' 1.0-2
+
+# ---------------------------------------------------------------- build feed + update/list
+mkipk libhello 1.0.0 all      ""          libhello   "true"
+mkipk hello    1.0.0 "$ARCH"  "libhello"  hello      'echo hi-starrywrt'
+mkipk world    2.1.0 "$ARCH"  ""          world      'echo world'
+mkindex
+ok  "update (file feed)"   O update
+LIST="$(O list 2>&1)"
+has "list has hello"       "$LIST"  "hello - 1.0.0"
+has "list has world"       "$LIST"  "world - 2.1.0"
+has "list has libhello"    "$LIST"  "libhello - 1.0.0"
+INFO="$(O info hello 2>&1)"
+has "info Package"         "$INFO"  "Package: hello"
+has "info Depends"         "$INFO"  "libhello"
+
+# ---------------------------------------------------------------- install + dependency pull-in
+ok  "install hello (+dep)" O install hello
+has "hello file runs"      "$("$ROOT/usr/bin/hello" 2>&1)"   "hi-starrywrt"
+[ -x "$ROOT/usr/bin/libhello" ] && pass || fail "dependency libhello not pulled in"
+LI="$(O list-installed 2>&1)"
+has "list-installed hello" "$LI"  "hello - 1.0.0"
+has "list-installed dep"   "$LI"  "libhello - 1.0.0"
+ST="$(O status hello 2>&1)"
+has "status installed"     "$ST"  "install user installed"
+FILES="$(O files hello 2>&1)"
+has "files lists binary"   "$FILES"  "/usr/bin/hello"
+
+# ---------------------------------------------------------------- dependency queries
+has "depends of hello"     "$(O depends hello 2>&1)"       "libhello"
+has "whatdepends libhello" "$(O whatdepends libhello 2>&1)" "hello"
+ok  "whatprovides"         O whatprovides hello
+
+# ---------------------------------------------------------------- flag + protected remove
+ok  "flag hold dep"        O flag hold libhello
+has "status shows hold"    "$(O status libhello 2>&1)"     "hold"
+ok  "flag ok dep"          O flag ok libhello
+ok  "install standalone"   O install world
+ok  "remove world"         O remove world
+[ -x "$ROOT/usr/bin/world" ] && fail "world file survived remove" || pass
+# removing a depended-upon package without force is refused; --force-depends allows it
+no  "remove dep refused"   O remove libhello
+ok  "remove --force-depends" O --force-depends remove libhello
+
+# ---------------------------------------------------------------- reinstall + upgrade path
+ok  "force-reinstall"      O --force-reinstall install hello
+# publish hello 1.2.0, re-index, list-upgradable + upgrade
+mkipk hello 1.2.0 "$ARCH" "libhello" hello 'echo hi-v2'
+mkindex
+ok  "update v2"            O update
+has "list-upgradable"      "$(O list-upgradable 2>&1)"     "hello"
+ok  "upgrade hello"        O upgrade hello
+has "upgraded to 1.2.0"    "$(O status hello 2>&1)"        "1.2.0"
+has "v2 payload"           "$("$ROOT/usr/bin/hello" 2>&1)" "hi-v2"
+
+# ---------------------------------------------------------------- error / option surface
+no  "install missing pkg"  O install no-such-package-xyz
+# -A queries all (not just installed); find matches name/description
+has "find by name"         "$(O find world 2>&1)"          "world"
+# --add-arch registers an arch (accepted)
+ok  "--add-arch accepted"  O --add-arch mips:5 print-architecture
+
+# ---------------------------------------------------------------- verdict
+rm -rf "$R"
+EXPECTED=42
+TOTAL=$((PASS+FAIL))
+echo "opkg: PASS=$PASS FAIL=$FAIL TOTAL=$TOTAL EXPECTED=$EXPECTED"
+if [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq "$EXPECTED" ]; then
+	echo "OPKG CARPET OK $PASS"
+else
+	echo "OPKG CARPET FAIL"
+	exit 1
+fi

--- a/apps/starry/openwrt/programs/run-openwrt.sh
+++ b/apps/starry/openwrt/programs/run-openwrt.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# run-openwrt.sh - on-target gate for the StarryOS OpenWrt-userland carpet (uci + opkg).
+#
+# Staged into the rootfs by prebuild.sh and invoked as the ENTIRE shell_init_cmd
+# (`sh /usr/bin/run-openwrt.sh`). The gate lives in a staged script, not inline in the toml,
+# so the harness never echoes a literal TEST PASSED back over the serial console and
+# self-matches success_regex: TEST PASSED is printed ONLY here, ONLY when BOTH carpets report
+# their pinned OK line (each carpet prints "<TOOL> CARPET OK <n>" only when every assertion
+# passed AND the count equals its pinned total - a skipped assertion changes the total and
+# fails the gate).
+#
+# uci  drives the full Unified Configuration Interface command + option surface against a
+#      synthetic /etc/config tree (get/set/commit/add/add_list/del_list/delete/rename/reorder/
+#      revert/changes/export/import/batch and -c/-d/-q/-s/-S/-X/-n/-N/-f).
+# opkg drives the full .ipk package-manager surface against a hermetic offline feed the carpet
+#      builds at runtime (update/list/install-with-deps/remove/upgrade/files/status/info/
+#      depends/whatdepends/flag/compare-versions/print-architecture and the force/offline-root
+#      options) - no network, no committed packages.
+set -u
+export PATH=/usr/local/bin:/usr/bin:/usr/sbin:/bin:/sbin
+export HOME=/root
+
+echo "----------------------------------------------------------------"
+echo " StarryWRT userland carpet - OpenWrt uci + opkg on StarryOS"
+echo " arch: $(uname -m)   kernel: $(uname -s)"
+echo "----------------------------------------------------------------"
+
+rc=0
+
+echo "== uci carpet =="
+if sh /usr/bin/uci-carpet.sh /usr/bin/uci; then
+    echo "uci: OK"
+else
+    echo "uci: FAIL"; rc=1
+fi
+
+echo "== opkg carpet =="
+if sh /usr/bin/opkg-carpet.sh /usr/bin/opkg; then
+    echo "opkg: OK"
+else
+    echo "opkg: FAIL"; rc=1
+fi
+
+if [ "$rc" -eq 0 ]; then
+    echo "TEST PASSED"
+else
+    echo "TEST FAILED"
+fi

--- a/apps/starry/openwrt/programs/uci-carpet.sh
+++ b/apps/starry/openwrt/programs/uci-carpet.sh
@@ -1,0 +1,180 @@
+#!/bin/sh
+# uci-carpet.sh - doc-grounded carpet for OpenWrt uci (Unified Configuration Interface).
+#
+# Ground truth = `uci` usage tree: 16 commands (batch/export/import/changes/commit/add/
+# add_list/del_list/show/get/set/delete/rename/revert/reorder) and the option surface
+# (-c -C -d -f -m -n -N -p -P -t -q -s -S -X). Every command and every option is exercised
+# against a synthetic /etc/config tree the carpet owns; uci is self-contained (it operates on
+# plain text config files - no ubus/procd needed), so the carpet is fully offline/hermetic.
+#
+# UCI binary: $1, else $UCI_BIN, else `uci` on PATH. Prints "UCI CARPET OK <n>" iff every
+# assertion passed AND the count equals the pinned total.
+set -u
+UCI="${1:-${UCI_BIN:-uci}}"
+command -v "$UCI" >/dev/null 2>&1 || { echo "uci not found: $UCI"; echo "UCI CARPET FAIL"; exit 1; }
+
+WORK="${UCI_WORK:-/tmp/uci-carpet.$$}"
+CFG="$WORK/config"
+rm -rf "$WORK" /tmp/.uci; mkdir -p "$CFG"
+# -c sets the config search path; uci stages uncommitted deltas under its default save path
+# (/tmp/.uci) which the carpet clears up front so the run is hermetic.
+U() { "$UCI" -c "$CFG" "$@"; }
+
+PASS=0; FAIL=0
+pass() { PASS=$((PASS+1)); }
+fail() { FAIL=$((FAIL+1)); echo "FAIL: $*"; }
+# eq <desc> <got> <want>
+eq() { if [ "$2" = "$3" ]; then pass; else fail "$1 | got=[$2] want=[$3]"; fi; }
+# ok <desc> <cmd...>  (expect exit 0)
+ok() { d="$1"; shift; if "$@" >/dev/null 2>&1; then pass; else fail "$d (expected success)"; fi; }
+# no <desc> <cmd...>  (expect nonzero)
+no() { d="$1"; shift; if "$@" >/dev/null 2>&1; then fail "$d (expected failure)"; else pass; fi; }
+
+# ---------------------------------------------------------------- seed config files
+cat > "$CFG/network" <<'EOF'
+config interface 'loopback'
+	option device 'lo'
+	option proto 'static'
+	option ipaddr '127.0.0.1'
+	option netmask '255.0.0.0'
+
+config interface 'lan'
+	option proto 'static'
+	option ipaddr '192.168.1.1'
+	list ports 'eth0'
+	list ports 'eth1'
+EOF
+cat > "$CFG/system" <<'EOF'
+config system
+	option hostname 'OpenWrt'
+	option timezone 'UTC'
+
+config timeserver 'ntp'
+	list server '0.openwrt.pool.ntp.org'
+EOF
+
+# ---------------------------------------------------------------- get / show
+eq "get scalar"            "$(U get network.lan.ipaddr)"            "192.168.1.1"
+eq "get typed by name"     "$(U get network.loopback.proto)"       "static"
+eq "get section type"      "$(U get network.lan)"                  "interface"
+eq "get anon by @type[0]"  "$(U get system.@system[0].hostname)"   "OpenWrt"
+eq "get anon @type[-1]"    "$(U get system.@system[-1].timezone)"  "UTC"
+no  "get missing option"   U get network.lan.nope
+no  "get missing section"  U get network.nosuch
+eq "show option line"      "$(U show network.lan.ipaddr)"          "network.lan.ipaddr='192.168.1.1'"
+eq "show section header"   "$(U show network.lan | head -1)"       "network.lan=interface"
+# whole-config show contains every seeded key
+SHOW_ALL="$(U show)"
+case "$SHOW_ALL" in *"network.loopback.netmask='255.0.0.0'"*) pass;; *) fail "show all missing netmask";; esac
+case "$SHOW_ALL" in *"system.ntp"*) pass;; *) fail "show all missing ntp timeserver";; esac
+# list rendering + -d delimiter override
+eq "show list default"     "$(U get network.lan.ports)"            "eth0 eth1"
+eq "show list -d delim"    "$(U -d , show network.lan.ports)" "network.lan.ports='eth0','eth1'"
+
+# ---------------------------------------------------------------- set (create/modify) + commit
+ok "set new option"        U set network.lan.gateway=192.168.1.254
+eq "set readback (staged)" "$(U get network.lan.gateway)"          "192.168.1.254"
+ok "set modify existing"   U set network.lan.ipaddr=10.0.0.1
+eq "set modify readback"   "$(U get network.lan.ipaddr)"           "10.0.0.1"
+# changes lists the staged (uncommitted) deltas
+CH="$(U changes)"
+case "$CH" in *"network.lan.gateway"*) pass;; *) fail "changes missing gateway";; esac
+case "$CH" in *"network.lan.ipaddr"*)  pass;; *) fail "changes missing ipaddr";;  esac
+# revert drops staged changes
+ok "revert option"         U revert network.lan.ipaddr
+eq "revert restored"       "$(U get network.lan.ipaddr)"           "192.168.1.1"
+# commit persists to the on-disk file
+ok "commit network"        U commit network
+grep -q "192.168.1.1" "$CFG/network"   && pass || fail "commit not persisted (ipaddr)"
+grep -q "192.168.1.254" "$CFG/network" && pass || fail "commit not persisted (gateway)"
+eq "changes empty post-commit" "$(U changes)" ""
+
+# ---------------------------------------------------------------- set section type / create section
+ok "set create section"    U set network.wan=interface
+ok "set opt on new sect"   U set network.wan.proto=dhcp
+ok "commit wan"            U commit network
+eq "new section readback"  "$(U get network.wan.proto)"            "dhcp"
+
+# ---------------------------------------------------------------- add (anonymous) + rename + delete
+ANON="$(U add network route)"          # prints the assigned name (cfgXXXXXX)
+case "$ANON" in cfg*) pass;; *) fail "add did not print cfg name: [$ANON]";; esac
+ok "set on anon section"   U set network.$ANON.target=0.0.0.0
+ok "commit anon"           U commit network
+eq "anon @route[0] target" "$(U get network.@route[0].target)"     "0.0.0.0"
+ok "rename section"        U rename network.$ANON=myroute
+ok "commit rename"         U commit network
+eq "renamed section get"   "$(U get network.myroute.target)"       "0.0.0.0"
+ok "rename option"         U rename network.myroute.target=dest
+ok "commit opt-rename"     U commit network
+eq "opt renamed readback"  "$(U get network.myroute.dest)"         "0.0.0.0"
+ok "delete option"         U delete network.myroute.dest
+ok "commit del-opt"        U commit network
+no  "deleted option gone"  U get network.myroute.dest
+ok "delete section"        U delete network.myroute
+ok "commit del-sect"       U commit network
+no  "deleted section gone" U get network.myroute
+
+# ---------------------------------------------------------------- add_list / del_list
+ok "add_list new"          U add_list network.lan.ports=eth2
+ok "commit add_list"       U commit network
+eq "add_list readback"     "$(U get network.lan.ports)"            "eth0 eth1 eth2"
+ok "del_list one"          U del_list network.lan.ports=eth1
+ok "commit del_list"       U commit network
+eq "del_list readback"     "$(U get network.lan.ports)"            "eth0 eth2"
+
+# ---------------------------------------------------------------- reorder
+# add two anon rules then reorder the 2nd to position 0
+R0="$(U add network rule)"; U set network.$R0.name=first >/dev/null 2>&1
+R1="$(U add network rule)"; U set network.$R1.name=second >/dev/null 2>&1
+U commit network >/dev/null 2>&1
+eq "rule order pre"        "$(U get network.@rule[0].name)"        "first"
+ok "reorder rule to 0"     U reorder network.$R1=0
+ok "commit reorder"        U commit network
+eq "rule order post"       "$(U get network.@rule[0].name)"        "second"
+
+# ---------------------------------------------------------------- export / import / batch
+EXP="$(U export system)"
+case "$EXP" in *"package system"*) pass;; *) fail "export missing package header";; esac
+case "$EXP" in *"option hostname 'OpenWrt'"*) pass;; *) fail "export missing hostname";; esac
+# import a fresh package from stdin, then read it back
+printf "package fresh\n\nconfig thing 'a'\n\toption x '1'\n" | U import fresh
+ok "commit imported"       U commit fresh
+eq "imported readback"     "$(U get fresh.a.x)"                    "1"
+# batch: several commands over stdin in one invocation
+printf "set fresh.a.y=2\nset fresh.a.z=3\ncommit fresh\n" | U batch
+eq "batch set y"           "$(U get fresh.a.y)"                    "2"
+eq "batch set z"           "$(U get fresh.a.z)"                    "3"
+
+# ---------------------------------------------------------------- option-flag surface
+# -q quiet: no error text on a missing key (still nonzero exit)
+QOUT="$(U -q get network.lan.nope 2>&1)"; eq "-q suppresses stderr" "$QOUT" ""
+# -X: do not use extended syntax on show. Accepted flag; for a named section it renders the
+# same option lines (extended @type[i] references only differ for anonymous package dumps).
+XSHOW="$(U -X show network.lan)"
+ok "-X show accepted"      U -X show network.lan
+case "$XSHOW" in *"network.lan.ipaddr="*) pass;; *) fail "-X dropped option lines";; esac
+# -S disable strict / -s force strict on a clean file both succeed
+ok "-s strict parses clean"  U -c "$CFG" -s show system
+ok "-S non-strict parses"    U -c "$CFG" -S show system
+# -N don't name unnamed sections on export -> anonymous header has no name
+NEXP="$(U -N export network | grep -E "^config rule" | head -1)"
+eq "-N unnamed on export"  "$NEXP"                                 "config rule"
+# -n name unnamed sections on export -> anonymous header carries the cfg id
+NNEXP="$(U -n export network | grep -E "^config rule" | head -1)"
+case "$NNEXP" in "config rule 'cfg"*) pass;; *) fail "-n did not name section: [$NNEXP]";; esac
+# -f file input for import instead of stdin
+printf "package ffile\n\nconfig k 'kk'\n\toption v 'vv'\n" > "$WORK/in.uci"
+ok "-f import from file"    sh -c "\"$UCI\" -c \"$CFG\" -f \"$WORK/in.uci\" import ffile && \"$UCI\" -c \"$CFG\" commit ffile"
+eq "-f imported readback"  "$(U get ffile.kk.v)"                   "vv"
+
+# ---------------------------------------------------------------- teardown / verdict
+rm -rf "$WORK"
+EXPECTED=70
+TOTAL=$((PASS+FAIL))
+echo "uci: PASS=$PASS FAIL=$FAIL TOTAL=$TOTAL EXPECTED=$EXPECTED"
+if [ "$FAIL" -eq 0 ] && [ "$TOTAL" -eq "$EXPECTED" ]; then
+	echo "UCI CARPET OK $PASS"
+else
+	echo "UCI CARPET FAIL"
+	exit 1
+fi

--- a/apps/starry/openwrt/qemu-aarch64.toml
+++ b/apps/starry/openwrt/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+# openwrt aarch64 - OpenWrt-userland carpet (uci + opkg). Platform: dynamic (uefi=false /
+# to_bin=true is the dynamic platform's raw-binary boot path). -cpu cortex-a72 is a 64-bit core
+# (the virt default would pick AArch32 and never boot the 64-bit kernel). uci/opkg are cross-
+# compiled from OpenWrt upstream source in prebuild; the carpet is fully offline (no guest net).
+args = [
+    "-nographic", "-m", "1024M", "-smp", "1", "-cpu", "cortex-a72",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-openwrt.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 3600

--- a/apps/starry/openwrt/qemu-loongarch64.toml
+++ b/apps/starry/openwrt/qemu-loongarch64.toml
@@ -1,0 +1,18 @@
+# openwrt loongarch64 - OpenWrt-userland carpet (uci + opkg). Platform: dynamic (axplat-dyn),
+# same as aarch64/riscv64 - build-loongarch64*.toml carries no ax-hal/plat-static /
+# plat_dyn=false; uefi=false / to_bin=true is the dynamic platform's raw-binary boot path, and
+# the build pulls ax-driver/serial so the console works. uci/opkg are cross-compiled from
+# OpenWrt upstream source in prebuild (loongarch64-linux-musl cross-toolchain, out-of-band); the
+# carpet is fully offline (no guest network).
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "1024M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-openwrt.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 7200

--- a/apps/starry/openwrt/qemu-riscv64.toml
+++ b/apps/starry/openwrt/qemu-riscv64.toml
@@ -1,0 +1,16 @@
+# openwrt riscv64 - OpenWrt-userland carpet (uci + opkg). Platform: dynamic (uefi=false /
+# to_bin=true). uci/opkg are cross-compiled from OpenWrt upstream source in prebuild; the carpet
+# is fully offline (no guest network), driving uci against a synthetic /etc/config tree and opkg
+# against a file:// feed it builds at runtime under TCG.
+args = [
+    "-nographic", "-m", "1024M", "-smp", "1", "-cpu", "rv64",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-openwrt.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 5400

--- a/apps/starry/openwrt/qemu-x86_64.toml
+++ b/apps/starry/openwrt/qemu-x86_64.toml
@@ -1,0 +1,17 @@
+# openwrt x86_64 - OpenWrt-userland carpet (uci + opkg). x86_64 boots the ELF kernel via the
+# dynamic platform + OVMF (xtask prepares firmware automatically; no PVH note needed). uci and
+# opkg are cross-compiled from OpenWrt upstream source in prebuild and staged into the overlay;
+# the carpet is fully offline (uci is file-based, opkg drives a synthetic file:// feed it builds
+# at runtime), so no guest network is required. The per-app rootfs is grown to 1G for the state.
+args = [
+    "-nographic", "-m", "1024M", "-smp", "1",
+    "-device", "virtio-blk-pci,drive=disk0",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-openwrt.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 1800


### PR DESCRIPTION
Add carpets for the two signature OpenWrt userland tools - `uci` (the Unified Configuration
Interface) and `opkg` (the `.ipk` package manager) - the config layer and the package layer of
an OpenWrt system. This closes the `uci`/`opkg` gap under the `openwrt` item, alongside the
already-carried `dropbear` and `dnsmasq`.

## How they are built

Neither tool is packaged by Alpine, so `prebuild.sh` cross-compiles them from the OpenWrt
upstream source - pinned commits, static musl, no committed binaries:

```
json-c -> libubox -> uci   (the cli target, BUILD_STATIC)
          libubox -> opkg  (STATIC_UBOX; opkg ships its own libbb .ipk extractor and shells
                            out to wget, so it needs neither libarchive nor libcurl)
```

The per-arch musl cross-toolchain is provided out-of-band (the `.starry-env.sh` PATH), matching
the other source-building apps.

## What the carpets exercise

Both are hermetic and offline; the gate prints `TEST PASSED` only when each reports its pinned
`OK` line (every assertion passed AND the count equals the pinned total, so a skipped assertion
fails the gate):

- **uci-carpet.sh** (70 assertions) - the full command surface (`get`/`show`/`set`/`commit`/
  `add`/`add_list`/`del_list`/`delete`/`rename`/`reorder`/`revert`/`changes`/`export`/`import`/
  `batch`) and option surface (`-c`/`-d`/`-q`/`-s`/`-S`/`-X`/`-n`/`-N`/`-f`) against a synthetic
  `/etc/config` tree.
- **opkg-carpet.sh** (42 assertions) - the full `.ipk` lifecycle (`update`/`list`/`install` with
  dependency resolution/`remove`/`upgrade`/`files`/`status`/`info`/`depends`/`whatdepends`/
  `flag`/`compare-versions` across every operator/`print-architecture` and the `--force-*` /
  `--offline-root` options) against a synthetic feed the carpet builds at runtime with `tar`/
  `gzip` only (the OpenWrt `.ipk` tar.gz container format).

## Validation

Host-green, and passing on-target under `cargo xtask starry app qemu`, single core (`-smp 1`),
on x64 and aa. The same cross-compile and the same two carpets are additionally exercised across
x64 / aa / la / rv by the companion StarryWRT distribution app.

## Run

```
cargo xtask starry app qemu -t openwrt --arch x86_64
cargo xtask starry app qemu -t openwrt --arch aarch64
cargo xtask starry app qemu -t openwrt --arch riscv64
cargo xtask starry app qemu -t openwrt --arch loongarch64
```
