### PR TITLE
docs(starryos): document LS2K1000 platform support

### DIFF
--- a/docs/docs/quickstart/starryos.md
+++ b/docs/docs/quickstart/starryos.md
@@ -117,7 +117,95 @@ cargo starry qemu
 
 ## 3. 开发板快速启动
 
-### 3.1 LicheeRV-Nano-SG2002
+### 3.1 Loongson 2K1000
+
+2K1000 使用 LoongArch64 动态平台路径，target 为 `loongarch64-unknown-none-softfloat`。U-Boot 通过 `go` 启动内核并传入 FDT，StarryOS 从板载 SATA SSD 的 ext4 分区挂载 rootfs。
+
+#### 3.1.1 相关 crates 与驱动
+
+| 类型 | crates | feature 或实现位置 | 作用 |
+| --- | --- | --- | --- |
+| 早期启动 | `someboot` | `platforms/someboot/src/arch/loongarch64/` | 解析 U-Boot 传入的 FDT，建立页表并启动 SMP |
+| CPU 与动态平台 | `ax-cpu`、`axplat-dyn`、`ax-hal` | `components/axcpu/src/loongarch64/`、`platforms/axplat-dyn/` | 提供 LoongArch64 上下文、陷阱和动态平台接口 |
+| 中断控制器 | `somehal`、`rdif-intc`、`irq-framework` | `platforms/somehal/src/arch/loongarch64/liointc.rs` | 探测并驱动 LS2K1000 LIOINTC |
+| 驱动发现 | `rdrive`、`ax-driver` | `drivers/ax-driver/` | 根据 FDT 探测并注册板载设备 |
+| 用户地址空间 | `starry-kernel` | `starry-kernel` feature `loongarch64-low-va` | 使用符合 2K1000 40-bit VA 限制的用户地址布局 |
+| 串口 | `ax-driver`、`some-serial`、`rdif-serial` | `ax-driver` feature `serial`；`drivers/ax-driver/src/serial/ns16550.rs` | 驱动 NS16550，并注册运行期 `ttyS0` |
+| RTC | `ax-driver` | `ax-driver` feature `rtc`；`drivers/ax-driver/src/time/loongson.rs` | 探测 `loongson,ls2k1000-rtc` |
+| SATA | `ax-driver`、`simple-ahci`、`rdif-block` | `ax-driver` feature `ls2k1000-ahci`；`drivers/ax-driver/src/block/ahci.rs` | 驱动 AHCI 控制器并向文件系统提供 block device；当前使用同步 polling |
+| 网络 | `ax-driver`、`rd-net`、`ax-net` | `ax-driver` feature `ls2k1000-gmac`；`drivers/ax-driver/src/net/loongson_gmac.rs` | 驱动板载 GMAC 并注册 `eth0` |
+| 根文件系统 | `ax-fs-ng`、`rsext4` | — | 扫描 SATA 分区并挂载 ext4 rootfs |
+
+板卡配置位于 `os/StarryOS/configs/board/ls2k1000.toml`。LS2K1000 AHCI 的 FDT/MMIO 适配已经合并在 `drivers/ax-driver/src/block/ahci.rs`，控制器核心复用 `simple-ahci`。LIOINTC 实现在 `somehal`；GMAC、RTC 和 NS16550 的 FDT 适配也位于 `ax-driver`。
+
+#### 3.1.2 构建镜像
+
+先选择 2K1000 配置并构建：
+
+```bash
+cargo starry defconfig ls2k1000
+cargo starry build
+```
+
+也可以不修改默认配置，直接显式指定配置文件：
+
+```bash
+cargo starry build \
+  --config os/StarryOS/configs/board/ls2k1000.toml
+```
+
+默认 release 构建生成 `starryos` ELF 及同目录的 `starryos.bin`。文件通常位于 `target/loongarch64-unknown-linux-musl/release/`；U-Boot/TFTP 使用的是对应的 `starryos.bin`。
+
+实板启动前还需要准备：
+
+- 可用的 U-Boot 网络和 TFTP 服务；
+- 板载 SATA SSD 上可由 StarryOS 挂载的 ext4 rootfs；
+- 串口终端，用于查看启动日志并进入 StarryOS shell。
+
+当前配置没有写死 `root=` 参数。已验证的磁盘布局中只有一个受支持的 ext4 分区，`ax-fs-ng` 会扫描 AHCI 设备和分区表后自动选择它作为根文件系统。如果磁盘上存在多个可用文件系统分区，应显式整理根设备选择，不能依赖“唯一分区”规则。
+
+#### 3.1.3 通过 TFTP 和 U-Boot 启动
+
+先把生成的 `starryos.bin` 放到 TFTP 根目录。下面的 IP 地址是示例，应按本地网络修改：
+
+```bash
+setenv ipaddr 192.168.99.20
+setenv serverip 192.168.99.10
+setenv netmask 255.255.255.0
+```
+
+可以一次性保存下面的启动脚本：
+
+```bash
+setenv starry_fdt_addr 'fdt addr ${fdtcontroladdr}'
+setenv starry_fdt_size 'fdt header get fdt_size totalsize'
+setenv starry_fdt_move 'fdt move ${fdtcontroladdr} ${fdt_addr} ${fdt_size}'
+setenv starry_fdt_select 'fdt addr ${fdt_addr}'
+
+setenv starry_load_tftp 'tftpboot ${loadaddr} starryos.bin'
+
+setenv starry_hdr_entry 'setexpr hdr ${loadaddr} + 0x8'
+setenv starry_read_entry 'setexpr.l kentry *0x${hdr}'
+setenv starry_hdr_load 'setexpr hdr ${loadaddr} + 0x18'
+setenv starry_read_load 'setexpr.l kload *0x${hdr}'
+setenv starry_calc_off 'setexpr off ${kentry} - ${kload}'
+setenv starry_calc_entry 'setexpr entry ${loadaddr} + ${off}'
+setenv starry_print_entry 'printenv kentry kload off entry'
+
+setenv starry_go 'go ${entry} ${fdt_addr}'
+setenv boot_starry 'run starry_fdt_addr starry_fdt_size starry_fdt_move starry_fdt_select starry_load_tftp starry_hdr_entry starry_read_entry starry_hdr_load starry_read_load starry_calc_off starry_calc_entry starry_print_entry starry_go'
+saveenv
+```
+
+之后每次启动执行：
+
+```bash
+run boot_starry
+```
+
+仓库目前也没有 `ls2k1000-board.toml` 或 `test-suit/starryos/board-ls2k1000`，所以 `cargo starry board` 和 `cargo starry test board` 还不是 2K1000 的维护入口。普通 QEMU 同样没有 LS2K1000/2K1000 machine，无法覆盖 LIOINTC、AHCI 和 GMAC 实板路径。因此 `qemu-loongarch64` 只能验证 LoongArch64 通用路径，不能替代上面的手工物理板验证。
+
+### 3.2 LicheeRV-Nano-SG2002
 
 LicheeRV-Nano-SG2002 当前走 U-Boot 串口启动路径，适合在已经烧录并能正常进入 Linux 的开发板上验证 StarryOS。StarryOS 直接使用板上的 Linux 原生 ext4 根文件系统，默认根分区为 `root=/dev/mmcblk0p2`，不需要再单独制作 Starry rootfs 分区。
 

--- a/docs/docs/quickstart/starryos.md
+++ b/docs/docs/quickstart/starryos.md
@@ -154,7 +154,7 @@ cargo starry build \
   --config os/StarryOS/configs/board/ls2k1000.toml
 ```
 
-默认 release 构建生成 `starryos` ELF 及同目录的 `starryos.bin`。文件通常位于 `target/loongarch64-unknown-linux-musl/release/`；U-Boot/TFTP 使用的是对应的 `starryos.bin`。
+`ls2k1000.toml` 中的 `loongarch64-unknown-none-softfloat` 是 StarryOS 用于选择架构和平台配置的逻辑 target。实际构建时，`axbuild` 会将它映射到 `scripts/targets/std/pie/loongarch64-unknown-linux-musl.json`，因此默认 release 产物位于 `target/loongarch64-unknown-linux-musl/release/`。该目录包含 `starryos` ELF 和 `starryos.bin`，U-Boot/TFTP 使用其中的 `starryos.bin`。
 
 实板启动前还需要准备：
 
@@ -172,6 +172,13 @@ cargo starry build \
 setenv ipaddr 192.168.99.20
 setenv serverip 192.168.99.10
 setenv netmask 255.255.255.0
+```
+
+[PR #1368](https://github.com/rcore-os/tgoskits/pull/1368) 实板验证使用下面的镜像和 FDT 地址。换用不同 U-Boot 或内存布局时，应先确认地址不会覆盖 U-Boot、FDT、内核或其它保留内存：
+
+```bash
+setenv loadaddr 0x9000000098000000
+setenv fdt_addr 0x900000000a000000
 ```
 
 可以一次性保存下面的启动脚本：


### PR DESCRIPTION
## 背景

PR #1368 已为 StarryOS 增加 Loongson 2K1000 物理板支持，包括动态平台启动、LIOINTC、AHCI、GMAC、RTC、串口和低用户虚拟地址布局等能力。

现有 StarryOS 快速上手文档尚未说明 2K1000 使用了哪些平台与驱动 crates，也没有记录从构建 `starryos.bin` 到通过 TFTP 和 U-Boot 启动的完整流程，使用者需要从板级配置、驱动源码和原 PR 记录中分别查找信息。

## 修改内容

- 在 StarryOS 快速上手文档中新增 Loongson 2K1000 小节。
- 说明 2K1000 使用的 LoongArch64 target、动态平台路径和 SATA ext4 rootfs。
- 按平台、CPU、中断控制器、设备发现、串口、RTC、SATA、网络和文件系统分类列出相关 crates。

- 补充两种构建方式：
  - `cargo starry defconfig ls2k1000` 后执行 `cargo starry build`；
  - 直接通过 `--config os/StarryOS/configs/board/ls2k1000.toml` 构建。
- 说明 `starryos.bin`、SATA ext4 rootfs、TFTP 和串口等实板启动前置条件。
- 记录经过实板验证的 U-Boot 环境变量和 `boot_starry` 启动脚本。
- 明确当前支持边界：
  - 仓库暂且没有 `ls2k1000-board.toml` 或对应的 StarryOS test-suit 板测配置； 
  - 普通 QEMU 没有 LS2K1000/2K1000 machine；
  - `qemu-loongarch64` 只能验证 LoongArch64 通用路径，不能替代 2K1000 实板验证。

## 实现逻辑

文档内容以当前 `os/StarryOS/configs/board/ls2k1000.toml`、`someboot`、`somehal` 和 `ax-driver` 实现为准。

启动路径按照实际依赖关系组织：

1. U-Boot 通过 `go` 启动内核并传入 FDT。
2. `someboot` 解析 FDT、建立页表并准备 SMP。
3. `somehal` 从 FDT 探测 LS2K1000 LIOINTC。
4. `rdrive` 和 `ax-driver` 探测 NS16550、RTC、AHCI 和 GMAC。
5. `ax-fs-ng` 从 AHCI block device 扫描并挂载 ext4 rootfs。
6. StarryOS 初始化运行期串口和网络后进入用户态 shell。

## 验证

- `corepack yarn build`
  - Docusaurus production build 成功。
  - 构建仍会报告仓库原有的 ArceOS `configuration#appcontext` broken-anchor 警告，与本次修改无关。