### PR TITLE
docs(starry): improve SG2002 and VisionFive 2 quickstart

### DIFF
--- a/docs/docs/quickstart/starryos.md
+++ b/docs/docs/quickstart/starryos.md
@@ -121,14 +121,48 @@ cargo starry qemu
 
 LicheeRV-Nano-SG2002 当前走 U-Boot 串口启动路径，适合在已经烧录并能正常进入 Linux 的开发板上验证 StarryOS。StarryOS 直接使用板上的 Linux 原生 ext4 根文件系统，默认根分区为 `root=/dev/mmcblk0p2`，不需要再单独制作 Starry rootfs 分区。
 
-先选择 SG2002 构建配置：
+#### 3.1.1 相关 crates 与驱动
+
+| 类型 | crates | feature 或实现位置 | 作用 |
+| --- | --- | --- | --- |
+| 早期启动 | `someboot` | `platforms/someboot/src/arch/riscv64/` | 接收 U-Boot 传入的 FDT，建立页表并进入内核 |
+| CPU 与动态平台 | `ax-cpu`、`axplat-dyn`、`ax-hal` | `axplat-dyn` feature `thead-mae` | 提供玄铁 C906/RISC-V 上下文、陷阱和动态平台接口 |
+| 板级支持 | `starry-kernel`、`sg200x-bsp` | `starry-kernel` feature `sg2002` | 提供 SG2002 板级设备和用户态支持 |
+| 驱动发现 | `rdrive`、`ax-driver` | `drivers/ax-driver/` | 根据 FDT 探测并注册板载设备 |
+| 串口 | `ax-driver`、`some-serial`、`rdif-serial` | `ax-driver` feature `serial` | 注册运行期硬件控制台和 TTY |
+| SD 卡 | `ax-driver`、`cv181x-sdhci`、`sdmmc-protocol`、`rdif-block` | `ax-driver` feature `cvsd` | 初始化 SD 卡并向文件系统提供 block device |
+| 根文件系统 | `ax-fs-ng`、`rsext4` | — | 挂载 `/dev/mmcblk0p2` 上的 ext4 rootfs |
+
+板卡构建配置位于 `os/StarryOS/configs/board/licheerv-nano-sg2002.toml`。其中 `cvsd` feature 会启用 CV181x SDHCI、SD/MMC 协议和块设备接口，`sg2002` feature 提供 StarryOS 所需的 SG2002 板级支持。
+
+#### 3.1.2 启动准备与构建
+
+实板启动前需要准备：
+
+- 能正常进入 U-Boot 的 LicheeRV-Nano-SG2002；
+- 已烧录并能启动 Linux 的 SD 卡；
+- SD 卡第二分区中可由 StarryOS 挂载的 ext4 根文件系统；
+- 用于 U-Boot 和 StarryOS 交互的串口连接。
+
+选择 SG2002 构建配置并单独构建内核：
 
 ```bash
 cargo starry defconfig licheerv-nano-sg2002
 cargo starry build
 ```
 
-本地 U-Boot 串口启动使用常规 `uboot` 子命令。默认串口配置来自 `os/StarryOS/configs/board/licheerv-nano-sg2002-uboot.toml`，默认串口是 `/dev/ttyUSB0`，波特率为 `115200`：
+也可以不修改默认配置，直接显式指定配置文件：
+
+```bash
+cargo starry build \
+  --config os/StarryOS/configs/board/licheerv-nano-sg2002.toml
+```
+
+该配置使用 `riscv64gc-unknown-none-elf` 目标，并启用 SG2002 板级支持、T-Head MAE、SD 卡和串口驱动。后面的 `cargo starry uboot` 或 `cargo starry board` 都会自动构建，因此只想快速启动时可以跳过这里的 `cargo starry build`。
+
+#### 3.1.3 通过 U-Boot 启动
+
+本地串口启动使用 `uboot` 子命令。默认配置来自 `os/StarryOS/configs/board/licheerv-nano-sg2002-uboot.toml`，串口是 `/dev/ttyUSB0`，波特率为 `115200`：
 
 ```bash
 cargo starry uboot \
@@ -137,7 +171,7 @@ cargo starry uboot \
 
 这条路径会构建 `riscv64gc-unknown-none-elf` 目标，并根据 SG2002 的 ITS 模板生成 FIT image，随后通过 U-Boot 的 `loady` 串口传输到 `fit_load_addr = 0x82200000`，再执行 `bootm 0x82200000`。内核入口地址为 `kernel_load_addr = 0x80200000`。
 
-远端板卡服务器启动使用常规 `board` 子命令：
+也可以通过 ostool-server 自动完成板卡申请、U-Boot 启动和串口连接：
 
 ```bash
 cargo starry board \
@@ -146,13 +180,113 @@ cargo starry board \
   --port <port>
 ```
 
-如果要运行完整板级测试，再使用 test-suit 入口：
+`licheerv-nano-sg2002-board.toml` 中维护的是 StarryOS 侧的运行和判定配置：板卡类型为 `LicheeRV-Nano-SG2002`，shell 提示符为 `root@starry:`，超时时间为 600 秒。进入 shell 后会执行：
 
 ```bash
-cargo starry test board --board licheerv-nano-sg2002 --server <ip> --port <port>
+echo STARRY_SG2002_BOOT_OK
 ```
 
-这里的 `--board licheerv-nano-sg2002` 用于选择 `test-suit/starryos` 下的 LicheeRV-Nano-SG2002 用例；实际向 ostool-server 申请的物理板卡类型写在用例配置中，当前同样为 `LicheeRV-Nano-SG2002`。
+看到下面的输出表示内核启动、SD 卡 rootfs 挂载和用户态 shell 均已成功：
+
+```text
+STARRY_SG2002_BOOT_OK
+```
+
+如果要使用 test-suit 运行板级启动验证：
+
+```bash
+cargo starry test board \
+  --board licheerv-nano-sg2002 \
+  --server <ip> \
+  --port <port>
+```
+
+常规远端启动使用 `os/StarryOS/configs/board` 下的配置；板测使用 `test-suit/starryos/board-licheerv-nano-sg2002` 下的配置。若启动停在根设备探测阶段，请确认 SD 卡第二分区存在可挂载的 ext4 根文件系统。
+
+### 3.2 StarFive VisionFive 2（星光 2）
+
+VisionFive 2 与 LicheeRV-Nano-SG2002 一样通过 U-Boot 启动。VisionFive 2 使用动态平台配置，并通过 JH7110 MMC 驱动挂载开发板上已有的 Linux ext4 根文件系统；与 QEMU 路径不同，这里不需要执行 `cargo starry rootfs`。仓库当前已验证的自动化流程由 ostool-server 申请板卡，通过 U-Boot 加载内核并连接串口。
+
+#### 3.2.1 相关 crates 与驱动
+
+| 类型 | crates | feature 或实现位置 | 作用 |
+| --- | --- | --- | --- |
+| 早期启动 | `someboot` | `platforms/someboot/src/arch/riscv64/` | 接收 U-Boot 传入的 FDT，建立页表并进入内核 |
+| CPU 与动态平台 | `ax-cpu`、`axplat-dyn`、`ax-hal` | `components/axcpu/src/riscv/`、`platforms/axplat-dyn/` | 提供 RISC-V 上下文、陷阱和动态平台接口 |
+| 中断控制器 | `somehal`、`ax-riscv-plic`、`rdif-intc`、`irq-framework` | `platforms/somehal/src/arch/riscv64/plic.rs` | 从 FDT 探测并驱动 JH7110 PLIC |
+| 驱动发现 | `rdrive`、`ax-driver` | `drivers/ax-driver/` | 根据 FDT 探测并注册板载设备 |
+| 串口 | `ax-driver`、`some-serial`、`rdif-serial` | `ax-driver` feature `serial` | 注册运行期硬件控制台和 TTY |
+| RTC | `ax-driver` | `ax-driver` feature `rtc`；`drivers/ax-driver/src/time/starfive.rs` | 探测 `starfive,jh7110-rtc` |
+| 时钟与复位 | `ax-driver`、`rdif-clk`、`rdif-reset` | `ax-driver` feature `starfive-soc`；`drivers/ax-driver/src/soc/starfive/` | 准备 JH7110 MMC 所需的 SYSCRG 时钟和复位 |
+| SD/MMC | `starfive-jh7110-dwmmc`、`dwmmc-host`、`sdmmc-protocol`、`rdif-block` | `ax-driver` feature `starfive-jh7110-dwmmc` | 初始化 SD 卡并向文件系统提供 block device |
+| 根文件系统 | `ax-fs-ng`、`rsext4` | — | 扫描 SD 卡分区并挂载 ext4 rootfs |
+
+板卡构建配置位于 `os/StarryOS/configs/board/visionfive2.toml`。其中 `starfive-jh7110-dwmmc` feature 会同时启用通用 DWMMC/SD 协议、块设备接口以及 JH7110 SoC 时钟和复位支持。
+
+#### 3.2.2 启动准备与构建
+
+实板启动前需要准备：
+
+- 能正常进入 U-Boot 的 VisionFive 2；
+- 开发板上可由 StarryOS 识别的 SD 卡；
+- SD 卡中可挂载的 Linux ext4 根文件系统；
+- 可访问 VisionFive 2 的 ostool-server 和串口连接。
+
+板卡路径不会像 QEMU 一样自动下载或制作 rootfs 镜像。`ax-fs-ng` 会扫描 JH7110 MMC 块设备及其分区表，并根据 U-Boot 传入的 `root=` 参数选择根分区；没有明确指定时，再从探测到的文件系统中选择。
+
+选择 VisionFive 2 配置并单独构建内核：
+
+```bash
+cargo starry defconfig visionfive2
+cargo starry build
+```
+
+也可以不修改默认配置，直接显式指定配置文件：
+
+```bash
+cargo starry build \
+  --config os/StarryOS/configs/board/visionfive2.toml
+```
+
+该配置使用 `riscv64gc-unknown-none-elf` 目标，并启用串口、RTC 和 `starfive-jh7110-dwmmc` 驱动。后面的 `cargo starry board` 也会自动构建，因此只想快速启动时可以跳过这里的 `cargo starry build`。
+
+#### 3.2.3 通过 U-Boot 启动
+
+当前维护入口使用 ostool-server 驱动 VisionFive 2 的 U-Boot 启动流程：
+
+```bash
+cargo starry board \
+  --board-config os/StarryOS/configs/board/visionfive2-board.toml \
+  --server <ip> \
+  --port <port>
+```
+
+这条命令会使用 `visionfive2.toml` 构建 StarryOS，并将构建产物转换为板卡运行时需要的内核镜像；随后根据 `visionfive2-board.toml` 向 ostool-server 申请 `VisionFive2`，由服务器控制开发板进入 U-Boot、传输并加载内核。U-Boot 启动内核并传入当前开发板的 FDT 后，StarryOS 会从 FDT 发现 PLIC、串口、RTC 和 JH7110 MMC，从 SD 卡选择并挂载 ext4 rootfs，进入 `root@starry:` shell，最后执行预设的 shell 探针并在成功后释放板卡。
+
+VisionFive 2 的镜像传输方式、U-Boot 加载地址和具体启动命令由 ostool-server 的 `VisionFive2` 板卡配置管理，不在 `visionfive2-board.toml` 中写死。因此不能直接复用 SG2002 的 `loady` 地址或 `bootm` 命令；调试这些参数时应检查所连接板卡服务器的 VisionFive 2 配置和 U-Boot 串口日志。
+
+`visionfive2-board.toml` 中维护的是 StarryOS 侧的运行和判定配置：板卡类型为 `VisionFive2`，shell 提示符为 `root@starry:`，超时时间为 600 秒。进入 shell 后会执行：
+
+```bash
+echo STARRY_VISIONFIVE2_SHELL_OK
+```
+
+看到下面的输出表示内核启动、MMC rootfs 挂载和用户态 shell 均已成功：
+
+```text
+STARRY_VISIONFIVE2_SHELL_OK
+```
+
+如果要使用 test-suit 运行同一条板级启动验证：
+
+```bash
+cargo starry test board \
+  --board visionfive2 \
+  --server <ip> \
+  --port <port>
+```
+
+常规启动使用 `os/StarryOS/configs/board` 下的配置；板测使用 `test-suit/starryos/board-visionfive2` 下的配置。若启动停在根设备探测阶段，请先确认 SD 卡能被 U-Boot/Linux 正常识别，并且其中存在可挂载的 ext4 根文件系统。
 
 ## 4. 测试入口
 
@@ -178,6 +312,7 @@ cargo starry test qemu --target loongarch64-unknown-none-softfloat
 ```bash
 cargo starry test board --board orangepi-5-plus --server <ip> --port <port>
 cargo starry test board --board licheerv-nano-sg2002 --server <ip> --port <port>
+cargo starry test board --board visionfive2 --server <ip> --port <port>
 ```
 
 详细说明见：[StarryOS 测试套件设计](/docs/build/starry/test)


### PR DESCRIPTION
## 问题

现有 StarryOS 快速启动文档只较完整地说明了 SG2002 的构建和启动方式，缺少 VisionFive 2 的板级依赖、rootfs 准备、U-Boot 启动及运行验证说明。同时，两块开发板的章节结构和命令风格不统一，不便于用户对照操作。

## 修改内容

- 补充 VisionFive 2 快速启动文档：
  - 整理动态平台、PLIC、串口、RTC、JH7110 时钟与复位、SD/MMC、ext4 rootfs 等相关 crates；
  - 说明 `visionfive2` 构建配置及显式配置文件用法；
  - 补充 SD 卡和 ext4 rootfs 等启动前置条件；
  - 说明 ostool-server 驱动 U-Boot 加载内核、传递 FDT 和连接串口的流程；
  - 补充 shell 探针、成功标志和 test-suit 板测命令；
  - 明确具体 U-Boot 加载地址和命令由板卡服务器配置管理。

- 统一 SG2002 章节结构：
  - 增加相关 crates 与驱动列表；
  - 拆分启动准备、构建和 U-Boot 启动说明；
  - 保留 FIT image、`loady`、`bootm` 和加载地址等板卡特有信息；
  - 补充 `STARRY_SG2002_BOOT_OK` 运行探针和成功判定；
  - 统一常规启动与 test-suit 板测命令格式。

## 实现逻辑

文档按照“相关 crates 与驱动、启动准备与构建、U-Boot 启动”的结构组织。两块开发板使用相同的阅读主线，同时分别保留其实际启动方式和板卡配置差异。

对于仓库中未直接维护的 VisionFive 2 U-Boot 加载地址和具体命令，文档明确其由 ostool-server 板卡配置管理，避免复用 SG2002 参数或记录未经验证的配置。

## 验证

- 已核对文档涉及的板卡配置、驱动 feature 和实现路径；
- 已确认 SG2002 与 VisionFive 2 的 test-suit 配置及成功探针；
- `git diff --check` 通过；
- 本次仅修改文档，不涉及内核逻辑和板卡运行行为。