### PR TITLE
fix(realtek-rtl8125): advertise gigabit autonegotiation

### DIFF
--- a/drivers/net/realtek-rtl8125/src/hw.rs
+++ b/drivers/net/realtek-rtl8125/src/hw.rs
@@ -20,6 +20,12 @@ const ADVERTISE_1000HALF: u16 = 0x0100;
 const ADVERTISE_1000FULL: u16 = 0x0200;
 const ADVERTISE_1000_MASK: u16 = ADVERTISE_1000HALF | ADVERTISE_1000FULL;
 
+trait PhyRegisterAccess {
+    fn read_phy(&mut self, reg: u32) -> Result<u16>;
+
+    fn write_phy(&mut self, reg: u32, value: u16) -> Result<()>;
+}
+
 impl Rtl8125 {
     pub(crate) fn hw_init_8125(&self) -> Result<()> {
         self.enable_rxdv_gate();
@@ -346,11 +352,7 @@ impl Rtl8125 {
             ChipVersion::Rtl8125A => self.hw_phy_config_8125a(),
             ChipVersion::Rtl8125B | ChipVersion::Unknown(_) => self.hw_phy_config_8125b(),
         }?;
-        // Standard MII registers are available from the default PHY page.
-        self.phy_write(0x1f, 0)?;
-        self.phy_modify(MII_CTRL1000, ADVERTISE_1000_MASK, ADVERTISE_1000FULL)?;
-        // Restart negotiation only after the gigabit mode is advertised.
-        self.phy_modify(MII_BMCR, BMCR_AUTONEG_MASK, BMCR_ANENABLE | BMCR_ANRESTART)
+        configure_default_copper_autoneg(self)
     }
 
     fn hw_phy_config_8125a(&mut self) -> Result<()> {
@@ -422,6 +424,32 @@ impl Rtl8125 {
             core::hint::spin_loop();
         }
         warn!("RTL8125: timed out waiting for link-list FIFO ready");
+    }
+}
+
+fn configure_default_copper_autoneg(phy: &mut impl PhyRegisterAccess) -> Result<()> {
+    // Standard MII registers are available from the default PHY page.
+    phy.write_phy(0x1f, 0)?;
+    let ctrl1000 = phy.read_phy(MII_CTRL1000)?;
+    phy.write_phy(
+        MII_CTRL1000,
+        (ctrl1000 & !ADVERTISE_1000_MASK) | ADVERTISE_1000FULL,
+    )?;
+    // Restart negotiation only after the gigabit mode is advertised.
+    let bmcr = phy.read_phy(MII_BMCR)?;
+    phy.write_phy(
+        MII_BMCR,
+        (bmcr & !BMCR_AUTONEG_MASK) | BMCR_ANENABLE | BMCR_ANRESTART,
+    )
+}
+
+impl PhyRegisterAccess for Rtl8125 {
+    fn read_phy(&mut self, reg: u32) -> Result<u16> {
+        self.phy_read(reg)
+    }
+
+    fn write_phy(&mut self, reg: u32, value: u16) -> Result<()> {
+        self.phy_write(reg, value)
     }
 }
 
@@ -544,15 +572,61 @@ const RTL8125B_EPHY: [EphyInfo; 6] = [
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+
     use super::*;
 
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum OperationKind {
+        Read,
+        Write,
+    }
+
+    struct RecordingPhy {
+        page: u16,
+        operations: Vec<(OperationKind, u16, u32, u16)>,
+    }
+
+    impl PhyRegisterAccess for RecordingPhy {
+        fn read_phy(&mut self, reg: u32) -> Result<u16> {
+            let value = match (self.page, reg) {
+                (0, 0x09) => 0xa55a,
+                (0, 0x00) => 0x8040,
+                _ => 0,
+            };
+            self.operations
+                .push((OperationKind::Read, self.page, reg, value));
+            Ok(value)
+        }
+
+        fn write_phy(&mut self, reg: u32, value: u16) -> Result<()> {
+            self.operations
+                .push((OperationKind::Write, self.page, reg, value));
+            if reg == 0x1f {
+                self.page = value;
+            }
+            Ok(())
+        }
+    }
+
     #[test]
-    fn default_copper_autoneg_advertises_gigabit_full_and_restarts() {
-        assert_eq!(ADVERTISE_1000FULL & ADVERTISE_1000_MASK, ADVERTISE_1000FULL);
-        assert_eq!(ADVERTISE_1000FULL & ADVERTISE_1000HALF, 0);
+    fn default_copper_autoneg_advertises_gigabit_before_restarting() {
+        let mut phy = RecordingPhy {
+            page: 0x0b87,
+            operations: Vec::new(),
+        };
+
+        configure_default_copper_autoneg(&mut phy).unwrap();
+
         assert_eq!(
-            (BMCR_ANENABLE | BMCR_ANRESTART) & BMCR_AUTONEG_MASK,
-            BMCR_AUTONEG_MASK
+            phy.operations,
+            [
+                (OperationKind::Write, 0x0b87, 0x1f, 0),
+                (OperationKind::Read, 0, 0x09, 0xa55a),
+                (OperationKind::Write, 0, 0x09, 0xa65a),
+                (OperationKind::Read, 0, 0x00, 0x8040),
+                (OperationKind::Write, 0, 0x00, 0x9240),
+            ]
         );
     }
 }

--- a/drivers/net/realtek-rtl8125/src/hw.rs
+++ b/drivers/net/realtek-rtl8125/src/hw.rs
@@ -9,6 +9,17 @@ const CSI_PCIE_ZRXDC_NONCOMPL: u32 = 1 << 20;
 const CSI_L1_ENTRY_LATENCY: u32 = 0x0719;
 const CSI_L1_ENTRY_LATENCY_DEFAULT: u8 = 0x27;
 
+const MII_BMCR: u32 = 0x00;
+const MII_CTRL1000: u32 = 0x09;
+
+const BMCR_ANRESTART: u16 = 0x0200;
+const BMCR_ANENABLE: u16 = 0x1000;
+const BMCR_AUTONEG_MASK: u16 = BMCR_ANENABLE | BMCR_ANRESTART;
+
+const ADVERTISE_1000HALF: u16 = 0x0100;
+const ADVERTISE_1000FULL: u16 = 0x0200;
+const ADVERTISE_1000_MASK: u16 = ADVERTISE_1000HALF | ADVERTISE_1000FULL;
+
 impl Rtl8125 {
     pub(crate) fn hw_init_8125(&self) -> Result<()> {
         self.enable_rxdv_gate();
@@ -334,7 +345,12 @@ impl Rtl8125 {
         match self.chip {
             ChipVersion::Rtl8125A => self.hw_phy_config_8125a(),
             ChipVersion::Rtl8125B | ChipVersion::Unknown(_) => self.hw_phy_config_8125b(),
-        }
+        }?;
+        // Standard MII registers are available from the default PHY page.
+        self.phy_write(0x1f, 0)?;
+        self.phy_modify(MII_CTRL1000, ADVERTISE_1000_MASK, ADVERTISE_1000FULL)?;
+        // Restart negotiation only after the gigabit mode is advertised.
+        self.phy_modify(MII_BMCR, BMCR_AUTONEG_MASK, BMCR_ANENABLE | BMCR_ANRESTART)
     }
 
     fn hw_phy_config_8125a(&mut self) -> Result<()> {
@@ -525,3 +541,18 @@ const RTL8125B_EPHY: [EphyInfo; 6] = [
         bits: 0x0020,
     },
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_copper_autoneg_advertises_gigabit_full_and_restarts() {
+        assert_eq!(ADVERTISE_1000FULL & ADVERTISE_1000_MASK, ADVERTISE_1000FULL);
+        assert_eq!(ADVERTISE_1000FULL & ADVERTISE_1000HALF, 0);
+        assert_eq!(
+            (BMCR_ANENABLE | BMCR_ANRESTART) & BMCR_AUTONEG_MASK,
+            BMCR_AUTONEG_MASK
+        );
+    }
+}

--- a/drivers/net/realtek-rtl8125/src/hw.rs
+++ b/drivers/net/realtek-rtl8125/src/hw.rs
@@ -589,9 +589,10 @@ mod tests {
 
     impl PhyRegisterAccess for RecordingPhy {
         fn read_phy(&mut self, reg: u32) -> Result<u16> {
+            // Seed target and unrelated bits to verify clear/set behavior and preservation.
             let value = match (self.page, reg) {
-                (0, 0x09) => 0xa55a,
-                (0, 0x00) => 0x8040,
+                (0, 0x09) => 0x0500,
+                (0, 0x00) => 0x0140,
                 _ => 0,
             };
             self.operations
@@ -622,10 +623,10 @@ mod tests {
             phy.operations,
             [
                 (OperationKind::Write, 0x0b87, 0x1f, 0),
-                (OperationKind::Read, 0, 0x09, 0xa55a),
-                (OperationKind::Write, 0, 0x09, 0xa65a),
-                (OperationKind::Read, 0, 0x00, 0x8040),
-                (OperationKind::Write, 0, 0x00, 0x9240),
+                (OperationKind::Read, 0, 0x09, 0x0500),
+                (OperationKind::Write, 0, 0x09, 0x0600),
+                (OperationKind::Read, 0, 0x00, 0x0140),
+                (OperationKind::Write, 0, 0x00, 0x1340),
             ]
         );
     }


### PR DESCRIPTION
### 问题

Orange Pi 5 Plus 上的 RTL8125 在 StarryOS 中只能与链路伙伴协商到 100Mb/s Full。笔记本侧 `ethtool` 显示板端只宣告 10/100 能力，而同一块板运行 Linux 时可以与同一笔记本协商到 1000Mb/s Full。

驱动已有 RTL8125A/B 的 vendor PHY tuning，修复前的 10/100 advertisement 可以正常工作，但初始化流程没有在 vendor 配置完成后通过标准 MII 寄存器宣告 1000BASE-T Full，也没有在更新能力后重启自动协商。

### 修改

修改前，`hw_phy_config()` 在完成 RTL8125A/B 的 vendor PHY tuning 后直接返回，没有设置标准 MII 的千兆能力，也没有重启自动协商。本次在原有 tuning 之后增加以下操作：

1. 向 PHY 页选择寄存器 `0x1f` 写入 `0`，确保后续访问标准 MII 寄存器。
2. 调用驱动原有的 `phy_modify()` 修改 `MII_CTRL1000`：用 `0x0300` 掩码清除原来的 1000BASE-T Half/Full 位，再写入 `0x0200`，最终只宣告 1000BASE-T Full。寄存器中的 Master/Slave 等其他位保持不变。
3. 再次调用 `phy_modify()` 修改 `MII_BMCR`，设置 `ANENABLE | ANRESTART`，开启并立即重新执行自动协商，让链路伙伴能够看到新增的千兆全双工能力。
4. 增加单元测试，确认配置值包含 1000BASE-T Full、不包含 1000BASE-T Half，并同时包含自动协商开启和重启位。

本次没有修改原来已经正常工作的 10/100 advertisement，也没有改动网卡的 MMIO、DMA、中断和收发队列代码。

### 实机对比

测试拓扑保持不变：同一块 Orange Pi 5 Plus、同一个物理网口 `eth0`、同一根网线、同一台最高支持 1GbE 的笔记本。板端地址为 `192.168.88.2/24`，笔记本为 `192.168.88.1/24`。

| 系统/状态 | 对端看到的最高能力 | 协商结果 | TCP TX 单流 | TCP RX 单流 |
| --- | --- | --- | ---: | ---: |
| StarryOS 修复前 | 100baseT/Full | 100Mb/s Full | 93.5 Mbit/s | 94.7 Mbit/s |
| StarryOS 修复后 | 1000baseT/Full | 1000Mb/s Full | 138 Mbit/s | 177 Mbit/s |
| Linux 基线 | 1000baseT/Full | 1000Mb/s Full | 941.45 Mbit/s | 941.27 Mbit/s |

修复前笔记本侧 `ethtool enp3s0` 的关键结果：

```text
Link partner advertised link modes: 10baseT/Half 10baseT/Full
                                     100baseT/Half 100baseT/Full
Speed: 100Mb/s
Duplex: Full
Auto-negotiation: on
Link detected: yes
```

修复前使用相同的 10 秒 TCP 单流命令，板卡 TX 约为 93.5 Mbit/s，RX 约为 94.7 Mbit/s，已经接近 100Mb/s 链路的有效上限。该结果说明 iperf3 当时首先受 PHY 错误协商到百兆所限制。

修复后笔记本侧 `ethtool enp3s0` 的关键结果：

```text
Link partner advertised link modes: 10baseT/Half 10baseT/Full
                                     100baseT/Half 100baseT/Full
                                     1000baseT/Full
Link partner advertised auto-negotiation: Yes
Speed: 1000Mb/s
Duplex: Full
Auto-negotiation: on
Link detected: yes
```

StarryOS 修复后的两个 10 秒 TCP 冒烟命令：

```text
iperf3 -c 192.168.88.1 -t 10
iperf3 -c 192.168.88.1 -t 10 -R
```

结果分别为 TX 138 Mbit/s、RX 177 Mbit/s，均为 0 重传，板卡保持稳定。

修复前后使用相同板卡、网口、网线、笔记本和 10 秒单流方向，链路从 100Mb/s Full 提升到 1000Mb/s Full，TX 从约 93.5 Mbit/s 提升到 138 Mbit/s，RX 从约 94.7 Mbit/s 提升到 177 Mbit/s。这说明百兆上限已经解除，但 StarryOS 在千兆链路上的数据路径仍明显慢于 Linux。

### 验证

- `cargo fmt`
- `cargo test -p realtek-rtl8125`
- `cargo xtask clippy --package realtek-rtl8125`
- `cargo xtask starry quick-start orangepi-5-plus build`
- `git diff --check`
- Orange Pi 5 Plus 实机确认链路从 100Mb/s Full 提升到 1000Mb/s Full。

### 测试口径与后续工作

Linux 数值来自 30 秒、预热 5 秒、重复 3 次的正式基线中位数；StarryOS 修复前后数值为 10 秒单流冒烟，因此表格用于确认协商修复和展示当前量级，不作为完全同参数的最终性能基准。iperf3（https://github.com/esnet/iperf）在StarryOS中未完全跑通，下一步修复 UDP 测试导致的整板重启，以完全跑通iperf3。

