### PR TITLE
fix(arceos): boot rv64 helloworld past the device probe

### DIFF
--- a/apps/arceos/helloworld/Cargo.toml
+++ b/apps/arceos/helloworld/Cargo.toml
@@ -13,4 +13,4 @@ arceos = ["dep:ax-std"]
 ax-std = { workspace = true, optional = true }
 
 [package.metadata.axstd]
-features = ["log-level-debug"]
+features = ["log-level-debug", "paging"]

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -260,6 +260,17 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
         ax_hal::trap::set_page_fault_handler(runtime_page_fault_handler);
     }
 
+    // TLS must be set up before any code that can panic runs: on RISC-V the
+    // std panic runtime reads a `#[thread_local]` panic counter via `tp`, and
+    // `tp` is still the raw hart id left by the bootloader until `init_tls`
+    // points it at a real TLS block. Platform-device init below can panic
+    // (e.g. an FDT probe error), so initialize TLS first.
+    #[cfg(all(feature = "tls", not(feature = "multitask")))]
+    {
+        info!("Initialize thread local storage...");
+        init_tls();
+    }
+
     info!("Initialize platform devices...");
     ax_hal::init_later(cpu_id, arg);
     if rdrive::is_initialized() {
@@ -322,12 +333,6 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
 
     #[cfg(feature = "smp")]
     self::mp::start_secondary_cpus(cpu_id);
-
-    #[cfg(all(feature = "tls", not(feature = "multitask")))]
-    {
-        info!("Initialize thread local storage...");
-        init_tls();
-    }
 
     ax_ctor_bare::call_ctors();
 


### PR DESCRIPTION
## Problem

On rv64, the arceos-helloworld app on the dynamic platform faults during boot and loops instead of printing:

```
[somehal::driver] Initializing rdrive with FDT at 0x80400000
[ax_cpu::trap] Page fault at VA:0x478 with flags READ   (repeats, then aborts due to panic)
```

Same on qemu 10 and 11.

## Root cause

Two issues stack up; the second hides the first.

1. The `std/pie/rv64gc-unknown-linux-musl` build does not enable the `paging` feature, so `ax-mm` (which `paging` pulls in) is not compiled and `mem_iomap` returns `Unsupported`. During platform device init the runtime probes the PLIC; mapping its MMIO window (`0x0c000000`) goes through ioremap, which fails, and `probe_pre_kernel().unwrap()` panics with `failed to map PLIC: Invalid MMIO address or size`. (On rv64 the boot page table maps only RAM, so device MMIO needs the on-demand ioremap that `paging` provides; the x64 boot table already maps MMIO regions.)

2. That panic is hidden. The std panic runtime reads a `#[thread_local]` counter through `tp`, but `init_tls` runs after device init, so `tp` is still the boot hart id (0). The read lands on `0 + 0x470 + 8 = 0x478`; the page-fault handler then computes a backtrace before panicking, which re-faults on the same unset thread pointer and loops, so the real panic is never printed. This is rv-specific: aa keeps per-CPU (`TPIDR_EL1`) and TLS (`TPIDR_EL0`) in distinct registers.

## Fix

- `axruntime`: run `init_tls` before platform device init, so a panic during early boot is reported instead of faulting on an unset thread pointer.
- `helloworld`: enable the `paging` feature so the PLIC MMIO region can be mapped.

## Verification

qemu-system-riscv64 (`-machine virt -cpu rv64 -m 512M`, default OpenSBI):

```
[ax_runtime] Initialize thread local storage...
[somehal::driver] Initializing rdrive with FDT at 0x80400000
Hello, world!
```

`Hello, world!` prints, with no `Page fault at VA:0x478` and no panic loop.

The other dynamic-platform apps also do not enable `paging` and would hit the same PLIC mapping failure on rv; a broader change (enabling `paging` for the dynamic-platform std build, or mapping device MMIO in the rv boot page table as x64 does) would cover them all. This PR fixes the reported helloworld case; the `init_tls` ordering change also makes any such early-boot panic report its real message instead of the `0x478` loop.
