### PR TITLE
feat(sg200x-jpu): add scaled JPEG decode support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7310,6 +7310,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sg200x-jpu"
+version = "0.1.0"
+dependencies = [
+ "dma-api",
+ "log",
+ "thiserror 2.0.18",
+ "tock-registers 0.10.1",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7718,6 +7728,7 @@ dependencies = [
  "scope-local",
  "sg2002-tpu",
  "sg200x-bsp",
+ "sg200x-jpu",
  "slab",
  "some-serial",
  "spin",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,6 +322,7 @@ fdt-raw = "0.3"
 thiserror = { version = "2", default-features = false }
 tock-registers = "0.10"
 sg200x-bsp = { version = "0.7.1", default-features = false }
+sg200x-jpu = { version = "0.1.0", path = "drivers/vpu/sg200x-jpu" }
 simple-ahci = "0.1.1-preview.1"
 bcm2835-sdhci = "0.1.1-preview.1"
 x86 = "0.52"

--- a/drivers/vpu/sg200x-jpu/Cargo.toml
+++ b/drivers/vpu/sg200x-jpu/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+authors.workspace = true
+categories = ["embedded", "hardware-support", "no-std"]
+description = "no_std SG200x JPEG Processing Unit driver with checked hardware scaling"
+edition.workspace = true
+keywords = ["sg2002", "jpeg", "jpu", "dma", "no-std"]
+license = "MIT"
+name = "sg200x-jpu"
+readme = "README.md"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+dma-api.workspace = true
+log.workspace = true
+thiserror.workspace = true
+tock-registers.workspace = true

--- a/drivers/vpu/sg200x-jpu/LICENSE-MIT
+++ b/drivers/vpu/sg200x-jpu/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 yfblock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/drivers/vpu/sg200x-jpu/README.md
+++ b/drivers/vpu/sg200x-jpu/README.md
@@ -1,0 +1,16 @@
+# sg200x-jpu
+
+`sg200x-jpu` is a `no_std` driver for the JPEG Processing Unit found in
+SG200x SoCs. It supports baseline JPEG decoding at full, half, quarter, and
+eighth resolution and reports the exact planar output layout.
+
+The register programming and JPEG parser were extracted from
+[`yfblock/sg200x-bsp`](https://github.com/yfblock/sg200x-bsp) version 0.7.1.
+This crate adds checked layouts, explicit DMA ownership, bounded hardware
+polling, and scaled decode. The original MIT copyright notice is retained in
+`LICENSE-MIT`.
+
+The crate does not choose physical MMIO addresses and does not perform
+platform-specific cache maintenance. Callers provide mapped bases through
+`JpuMmio` and a `dma_api::DeviceDma` whose backend owns allocation, address
+translation, and cache synchronization.

--- a/drivers/vpu/sg200x-jpu/src/decoder.rs
+++ b/drivers/vpu/sg200x-jpu/src/decoder.rs
@@ -1,0 +1,568 @@
+//! Synchronous SG200x JPU decode orchestration and DMA ownership.
+
+use core::{
+    num::NonZeroUsize,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use dma_api::{CpuDmaBuffer, DeviceDma, DmaDirection, DmaError, InFlightDma};
+use thiserror::Error;
+
+use super::{
+    engine::{
+        BBC_STREAM_PAGE_SIZE, GRAM_PREFETCH_PAGES, HardwareDecodeInfo, PollError,
+        checked_dma_offset, checked_dma_region, checked_frame_dma_addresses, configure_stream_regs,
+        gram_setup, poll_decode_done, start_decode, upload_huff_tables, upload_quant_tables,
+    },
+    header::parse_jpeg_header,
+    layout::{FrameLayout, FrameLayoutError, JpuPixelFormat, JpuScale, PlaneLayout},
+    regs::hardware_init_at,
+};
+
+const DMA_ALIGNMENT: usize = 16 * 1024;
+
+static JPU_IN_USE: AtomicBool = AtomicBool::new(false);
+
+/// Caller-mapped MMIO bases required by the SG200x JPU.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct JpuMmio {
+    /// JPU register block.
+    pub jpu_base: usize,
+    /// TOP clock/reset register block.
+    pub top_base: usize,
+    /// Video-codec control register block.
+    pub vc_base: usize,
+}
+
+impl JpuMmio {
+    /// Creates one set of caller-mapped JPU register bases.
+    pub const fn new(jpu_base: usize, top_base: usize, vc_base: usize) -> Self {
+        Self {
+            jpu_base,
+            top_base,
+            vc_base,
+        }
+    }
+}
+
+/// Error returned while acquiring the singleton JPU engine.
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum JpuCreateError {
+    /// Another live decoder already owns the hardware engine.
+    #[error("SG200x JPU is already owned by another decoder")]
+    AlreadyOwned,
+    /// Clock/reset initialization did not reach its ready state.
+    #[error("SG200x JPU initialization failed: {0}")]
+    Initialization(&'static str),
+}
+
+/// Error returned by JPEG decode operations.
+#[derive(Debug, Error)]
+pub enum JpuDecodeError {
+    /// A previous timeout or partial DMA setup left hardware ownership unknown.
+    #[error("SG200x JPU is poisoned after an incomplete DMA operation; reboot is required")]
+    Poisoned,
+    /// The compressed input is empty.
+    #[error("JPEG stream is empty")]
+    EmptyStream,
+    /// JPEG marker or table parsing failed.
+    #[error("invalid JPEG stream: {0}")]
+    InvalidJpeg(&'static str),
+    /// The requested scale or planar layout is unsupported.
+    #[error("invalid JPU frame layout: {0}")]
+    Layout(#[from] FrameLayoutError),
+    /// A stream or frame DMA allocation failed.
+    #[error("JPU DMA allocation failed: {0}")]
+    Dma(#[from] DmaError),
+    /// An internal buffer length invariant was violated.
+    #[error("invalid JPU buffer state: {0}")]
+    BufferInvariant(&'static str),
+    /// A DMA address cannot be represented by the 32-bit JPU registers.
+    #[error("invalid JPU DMA address: {0}")]
+    DmaAddress(&'static str),
+    /// Register or GRAM setup failed after DMA ownership was prepared.
+    #[error("JPU hardware setup failed: {0}")]
+    HardwareSetup(&'static str),
+    /// The JPU reported a terminal decode error.
+    #[error("SG200x JPU reported a decode error")]
+    DecodeFailed,
+    /// The JPU did not reach a terminal state before the poll limit.
+    #[error("SG200x JPU decode timed out; reboot is required")]
+    Timeout,
+}
+
+/// A borrowed planar frame produced by the JPU.
+///
+/// The borrow prevents the decoder from starting another operation while the
+/// returned DMA buffer is still in use.
+///
+/// ```compile_fail
+/// use sg200x_jpu::JpuDecoder;
+///
+/// fn cannot_decode_twice(decoder: &mut JpuDecoder, jpeg: &[u8]) {
+///     let first = decoder.decode(jpeg).unwrap();
+///     let _second = decoder.decode(jpeg).unwrap();
+///     let _still_borrowed = first.yuv_data;
+/// }
+/// ```
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct DecodeResult<'a> {
+    /// Meaningful output width after scaling, excluding coded padding.
+    pub width: u32,
+    /// Meaningful output height after scaling, excluding coded padding.
+    pub height: u32,
+    /// CPU-visible frame bytes. Plane offsets and strides are in [`Self::layout`].
+    pub yuv_data: &'a [u8],
+    /// Device-visible address corresponding to `yuv_data[0]`.
+    pub yuv_dma_addr: u32,
+    /// Planar format, scale, extents, offsets, and strides.
+    pub layout: FrameLayout,
+}
+
+/// Singleton synchronous SG200x JPU decoder.
+pub struct JpuDecoder {
+    mmio: JpuMmio,
+    dma: DeviceDma,
+    stream_buffer: Option<CpuDmaBuffer>,
+    frame_buffer: Option<CpuDmaBuffer>,
+    poisoned: bool,
+}
+
+impl JpuDecoder {
+    /// Acquires and initializes the SG200x JPU.
+    ///
+    /// # Safety
+    ///
+    /// Every base in `mmio` must be four-byte aligned and remain a valid device
+    /// mapping for the decoder's lifetime. The mappings must cover at least the
+    /// JPU register range through offset `0x237`, the TOP range through offset
+    /// `0x3003`, and four bytes at the VC base. No code outside this decoder may
+    /// access or reconfigure the JPU while it is owned. `dma` must allocate
+    /// memory visible to this JPU and implement the cache-maintenance contract
+    /// required by `dma-api`.
+    pub unsafe fn new(mmio: JpuMmio, dma: DeviceDma) -> Result<Self, JpuCreateError> {
+        JPU_IN_USE
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| JpuCreateError::AlreadyOwned)?;
+
+        if let Err(error) = hardware_init_at(mmio.jpu_base, mmio.top_base, mmio.vc_base) {
+            JPU_IN_USE.store(false, Ordering::Release);
+            return Err(JpuCreateError::Initialization(error));
+        }
+        Ok(Self {
+            mmio,
+            dma,
+            stream_buffer: None,
+            frame_buffer: None,
+            poisoned: false,
+        })
+    }
+
+    /// Decodes at the full coded resolution.
+    pub fn decode<'a>(&'a mut self, jpeg_data: &[u8]) -> Result<DecodeResult<'a>, JpuDecodeError> {
+        self.decode_scaled(jpeg_data, JpuScale::Full)
+    }
+
+    /// Decodes a baseline JPEG using one isotropic hardware downscale mode.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed error for invalid JPEG data, unsupported layouts, DMA
+    /// allocation/address failures, terminal hardware errors, and timeouts. A
+    /// timeout poisons the decoder because the device may still own its DMA
+    /// buffers; subsequent calls return [`JpuDecodeError::Poisoned`].
+    pub fn decode_scaled<'a>(
+        &'a mut self,
+        jpeg_data: &[u8],
+        scale: JpuScale,
+    ) -> Result<DecodeResult<'a>, JpuDecodeError> {
+        self.validate_decode_request(jpeg_data)?;
+
+        let header = parse_jpeg_header(jpeg_data).map_err(JpuDecodeError::InvalidJpeg)?;
+        let format = JpuPixelFormat::from_raw(header.format)?;
+        let layout = FrameLayout::new(header.width, header.height, format, scale)?;
+        let stream_len = required_stream_capacity(jpeg_data.len(), header.ecs_offset)
+            .map_err(JpuDecodeError::InvalidJpeg)?;
+        validate_dma_allocation_len(stream_len).map_err(JpuDecodeError::DmaAddress)?;
+        validate_dma_allocation_len(layout.total_len).map_err(JpuDecodeError::DmaAddress)?;
+        self.ensure_buffers(stream_len, layout.total_len)?;
+        self.write_stream(jpeg_data, stream_len)?;
+
+        let stream_dma = self.stream_dma_region(stream_len)?;
+        let frame_dma = self.frame_dma_region(layout.total_len)?;
+        let stream_data_end = checked_dma_offset(stream_dma, jpeg_data.len(), true)
+            .map_err(JpuDecodeError::DmaAddress)?;
+        let frame_planes =
+            checked_frame_dma_addresses(frame_dma, &layout).map_err(JpuDecodeError::DmaAddress)?;
+        let hardware = HardwareDecodeInfo::for_format(format);
+
+        configure_stream_regs(
+            self.mmio.jpu_base,
+            stream_dma,
+            stream_data_end,
+            jpeg_data.len(),
+            &header,
+            &layout,
+            hardware,
+        );
+        upload_huff_tables(self.mmio.jpu_base, &header).map_err(JpuDecodeError::HardwareSetup)?;
+        upload_quant_tables(self.mmio.jpu_base, &header).map_err(JpuDecodeError::HardwareSetup)?;
+
+        let (stream_in_flight, frame_in_flight) = self.begin_dma()?;
+        if let Err(error) = gram_setup(self.mmio.jpu_base, stream_dma, &header) {
+            self.quarantine_after_incomplete_dma(stream_in_flight, frame_in_flight);
+            return Err(JpuDecodeError::HardwareSetup(error));
+        }
+        start_decode(self.mmio.jpu_base, frame_planes, &header, &layout);
+
+        match poll_decode_done(self.mmio.jpu_base) {
+            Ok(()) => {
+                self.complete_dma(stream_in_flight, frame_in_flight);
+            }
+            Err(PollError::Decode) => {
+                self.complete_dma(stream_in_flight, frame_in_flight);
+                return Err(JpuDecodeError::DecodeFailed);
+            }
+            Err(PollError::Timeout) => {
+                self.quarantine_after_incomplete_dma(stream_in_flight, frame_in_flight);
+                return Err(JpuDecodeError::Timeout);
+            }
+        }
+
+        self.clear_frame_padding(&layout)?;
+        let frame = self
+            .frame_buffer
+            .as_ref()
+            .ok_or(JpuDecodeError::BufferInvariant(
+                "missing completed frame buffer",
+            ))?;
+        let yuv_data =
+            frame
+                .as_slice_cpu()
+                .get(..layout.total_len)
+                .ok_or(JpuDecodeError::BufferInvariant(
+                    "frame view exceeds its DMA allocation",
+                ))?;
+
+        Ok(DecodeResult {
+            width: layout.visible.width,
+            height: layout.visible.height,
+            yuv_data,
+            yuv_dma_addr: frame_dma.start,
+            layout,
+        })
+    }
+
+    fn validate_decode_request(&self, jpeg_data: &[u8]) -> Result<(), JpuDecodeError> {
+        if self.poisoned {
+            return Err(JpuDecodeError::Poisoned);
+        }
+        if jpeg_data.is_empty() {
+            return Err(JpuDecodeError::EmptyStream);
+        }
+        Ok(())
+    }
+
+    fn ensure_buffers(
+        &mut self,
+        stream_len: usize,
+        frame_len: usize,
+    ) -> Result<(), JpuDecodeError> {
+        let stream_capacity = self
+            .stream_buffer
+            .as_ref()
+            .map_or(0, |buffer| buffer.len().get());
+        let frame_capacity = self
+            .frame_buffer
+            .as_ref()
+            .map_or(0, |buffer| buffer.len().get());
+        if buffer_plan(stream_capacity, frame_capacity, stream_len, frame_len) == BufferPlan::Reuse
+        {
+            return Ok(());
+        }
+
+        let stream_len = NonZeroUsize::new(stream_len)
+            .ok_or(JpuDecodeError::BufferInvariant("zero-sized stream buffer"))?;
+        let frame_len = NonZeroUsize::new(frame_len)
+            .ok_or(JpuDecodeError::BufferInvariant("zero-sized frame buffer"))?;
+        let stream =
+            CpuDmaBuffer::new_zero(&self.dma, stream_len, DMA_ALIGNMENT, DmaDirection::ToDevice)?;
+        let frame = CpuDmaBuffer::new_zero(
+            &self.dma,
+            frame_len,
+            DMA_ALIGNMENT,
+            DmaDirection::FromDevice,
+        )?;
+        self.stream_buffer = Some(stream);
+        self.frame_buffer = Some(frame);
+        Ok(())
+    }
+
+    fn write_stream(&mut self, jpeg_data: &[u8], stream_len: usize) -> Result<(), JpuDecodeError> {
+        let stream = self
+            .stream_buffer
+            .as_mut()
+            .ok_or(JpuDecodeError::BufferInvariant("missing stream buffer"))?;
+        if stream_len > stream.len().get() || jpeg_data.len() > stream_len {
+            return Err(JpuDecodeError::BufferInvariant(
+                "stream data exceeds its DMA allocation",
+            ));
+        }
+
+        // SAFETY: the buffer is CPU-owned until begin_dma consumes it. The
+        // checked range stays inside this allocation.
+        let bytes = unsafe { stream.as_mut_slice_cpu() };
+        bytes[..jpeg_data.len()].copy_from_slice(jpeg_data);
+        bytes[jpeg_data.len()..stream_len].fill(0);
+        Ok(())
+    }
+
+    fn stream_dma_region(
+        &self,
+        stream_len: usize,
+    ) -> Result<super::engine::DmaRegion, JpuDecodeError> {
+        let stream = self
+            .stream_buffer
+            .as_ref()
+            .ok_or(JpuDecodeError::BufferInvariant("missing stream buffer"))?;
+        checked_dma_region(stream.dma_addr().as_u64(), stream.len().get(), stream_len)
+            .map_err(JpuDecodeError::DmaAddress)
+    }
+
+    fn frame_dma_region(
+        &self,
+        frame_len: usize,
+    ) -> Result<super::engine::DmaRegion, JpuDecodeError> {
+        let frame = self
+            .frame_buffer
+            .as_ref()
+            .ok_or(JpuDecodeError::BufferInvariant("missing frame buffer"))?;
+        checked_dma_region(frame.dma_addr().as_u64(), frame.len().get(), frame_len)
+            .map_err(JpuDecodeError::DmaAddress)
+    }
+
+    fn begin_dma(&mut self) -> Result<(InFlightDma, InFlightDma), JpuDecodeError> {
+        let stream = self
+            .stream_buffer
+            .take()
+            .ok_or(JpuDecodeError::BufferInvariant("missing stream buffer"))?;
+        let frame = match self.frame_buffer.take() {
+            Some(frame) => frame,
+            None => {
+                self.stream_buffer = Some(stream);
+                return Err(JpuDecodeError::BufferInvariant("missing frame buffer"));
+            }
+        };
+
+        let stream = stream.prepare_for_device();
+        let frame = frame.prepare_for_device();
+        // SAFETY: this state transition occurs immediately before the first
+        // register operation that may start stream DMA. Completion is handled
+        // only after a terminal status; incomplete operations are quarantined.
+        Ok(unsafe { (stream.into_in_flight(), frame.into_in_flight()) })
+    }
+
+    fn complete_dma(&mut self, stream: InFlightDma, frame: InFlightDma) {
+        // SAFETY: callers invoke this only after the JPU reported a terminal
+        // DONE or ERROR status and poll_decode_done acknowledged that status.
+        let stream = unsafe { stream.complete_after_quiesce() }.into_cpu_buffer();
+        // SAFETY: the same terminal status covers the output frame DMA engine.
+        let frame = unsafe { frame.complete_after_quiesce() }.into_cpu_buffer();
+        self.stream_buffer = Some(stream);
+        self.frame_buffer = Some(frame);
+    }
+
+    fn quarantine_after_incomplete_dma(&mut self, stream: InFlightDma, frame: InFlightDma) {
+        self.poisoned = true;
+        let _stream = stream.quarantine();
+        let _frame = frame.quarantine();
+    }
+
+    fn clear_frame_padding(&mut self, layout: &FrameLayout) -> Result<(), JpuDecodeError> {
+        let frame = self
+            .frame_buffer
+            .as_mut()
+            .ok_or(JpuDecodeError::BufferInvariant(
+                "missing completed frame buffer",
+            ))?;
+        // SAFETY: poll completion returned ownership to the CPU, and the
+        // returned mutable slice does not outlive this exclusive decoder borrow.
+        let bytes = unsafe { frame.as_mut_slice_cpu() };
+        clear_frame_padding(bytes, layout).map_err(JpuDecodeError::BufferInvariant)
+    }
+}
+
+impl Drop for JpuDecoder {
+    fn drop(&mut self) {
+        if !self.poisoned {
+            JPU_IN_USE.store(false, Ordering::Release);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BufferPlan {
+    Reuse,
+    ReplaceBoth,
+}
+
+const fn buffer_plan(
+    stream_capacity: usize,
+    frame_capacity: usize,
+    stream_len: usize,
+    frame_len: usize,
+) -> BufferPlan {
+    if stream_capacity >= stream_len && frame_capacity >= frame_len {
+        BufferPlan::Reuse
+    } else {
+        BufferPlan::ReplaceBoth
+    }
+}
+
+fn required_stream_capacity(jpeg_len: usize, ecs_offset: usize) -> Result<usize, &'static str> {
+    if ecs_offset >= jpeg_len {
+        return Err("JPEG entropy-coded data starts outside the stream");
+    }
+    let prefetch_start = ecs_offset & !(BBC_STREAM_PAGE_SIZE - 1);
+    let prefetch_len = BBC_STREAM_PAGE_SIZE * GRAM_PREFETCH_PAGES;
+    let prefetch_end = prefetch_start
+        .checked_add(prefetch_len)
+        .ok_or("JPU GRAM prefetch range overflow")?;
+    Ok(jpeg_len.max(prefetch_end))
+}
+
+fn validate_dma_allocation_len(len: usize) -> Result<(), &'static str> {
+    let len = u64::try_from(len).map_err(|_| "JPU DMA allocation length does not fit u64")?;
+    if len > u32::MAX as u64 {
+        return Err("JPU DMA allocation exceeds the 32-bit address window");
+    }
+    Ok(())
+}
+
+fn clear_frame_padding(buffer: &mut [u8], layout: &FrameLayout) -> Result<(), &'static str> {
+    if buffer.len() < layout.total_len {
+        return Err("JPU frame layout exceeds its DMA allocation");
+    }
+    let buffer = &mut buffer[..layout.total_len];
+    let mut previous_end = 0usize;
+    clear_plane_and_gap_padding(buffer, layout.y, &mut previous_end)?;
+    if let Some(cb) = layout.cb {
+        clear_plane_and_gap_padding(buffer, cb, &mut previous_end)?;
+    }
+    if let Some(cr) = layout.cr {
+        clear_plane_and_gap_padding(buffer, cr, &mut previous_end)?;
+    }
+    buffer
+        .get_mut(previous_end..)
+        .ok_or("JPU frame planes exceed total length")?
+        .fill(0);
+    Ok(())
+}
+
+fn clear_plane_and_gap_padding(
+    buffer: &mut [u8],
+    plane: PlaneLayout,
+    previous_end: &mut usize,
+) -> Result<(), &'static str> {
+    let plane_end = plane
+        .offset
+        .checked_add(plane.len)
+        .ok_or("JPU plane end overflow")?;
+    if plane.offset < *previous_end || plane_end > buffer.len() {
+        return Err("JPU frame planes overlap or exceed total length");
+    }
+    buffer[*previous_end..plane.offset].fill(0);
+
+    let stride = usize::try_from(plane.stride).map_err(|_| "JPU plane stride overflow")?;
+    let row_bytes = usize::try_from(plane.storage.width).map_err(|_| "JPU plane width overflow")?;
+    let rows = usize::try_from(plane.storage.height).map_err(|_| "JPU plane height overflow")?;
+    let row_padding = stride
+        .checked_sub(row_bytes)
+        .ok_or("JPU plane width exceeds its stride")?;
+    for row in 0..rows {
+        let padding_start = row
+            .checked_mul(stride)
+            .and_then(|offset| offset.checked_add(plane.offset))
+            .and_then(|offset| offset.checked_add(row_bytes))
+            .ok_or("JPU plane row padding offset overflow")?;
+        let padding_end = padding_start
+            .checked_add(row_padding)
+            .ok_or("JPU plane row padding end overflow")?;
+        buffer
+            .get_mut(padding_start..padding_end)
+            .ok_or("JPU plane row padding exceeds frame buffer")?
+            .fill(0);
+    }
+
+    *previous_end = plane_end;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::{
+        BufferPlan, buffer_plan, clear_frame_padding, required_stream_capacity,
+        validate_dma_allocation_len,
+    };
+    use crate::{FrameLayout, JpuPixelFormat, JpuScale};
+
+    #[test]
+    fn buffer_plan_reuses_only_when_both_capacities_fit() {
+        assert_eq!(buffer_plan(128, 1024, 127, 1024), BufferPlan::Reuse);
+        assert_eq!(buffer_plan(128, 1024, 129, 100), BufferPlan::ReplaceBoth);
+        assert_eq!(buffer_plan(128, 1024, 100, 1025), BufferPlan::ReplaceBoth);
+    }
+
+    #[test]
+    fn dma_allocation_length_must_fit_the_32_bit_jpu_window() {
+        assert!(validate_dma_allocation_len(u32::MAX as usize).is_ok());
+        #[cfg(target_pointer_width = "64")]
+        assert!(validate_dma_allocation_len(u32::MAX as usize + 1).is_err());
+    }
+
+    #[test]
+    fn stream_capacity_covers_two_page_gram_prefetch() {
+        assert_eq!(required_stream_capacity(1000, 500), Ok(1000));
+        assert_eq!(required_stream_capacity(1000, 900), Ok(1280));
+        assert_eq!(required_stream_capacity(16_384, 16_383), Ok(16_640));
+        assert!(required_stream_capacity(1000, 1000).is_err());
+        assert!(required_stream_capacity(1000, 1001).is_err());
+        assert!(required_stream_capacity(usize::MAX, usize::MAX - 1).is_err());
+    }
+
+    #[test]
+    fn frame_padding_is_cleared_without_touching_plane_samples() {
+        let layout = FrameLayout::new(129, 129, JpuPixelFormat::Yuv420, JpuScale::Eighth)
+            .expect("valid layout");
+        let mut memory = std::vec![0xa5u8; layout.total_len];
+
+        clear_frame_padding(&mut memory, &layout).expect("padding layout is valid");
+
+        for row in 0..18 {
+            let start = row * 32;
+            assert!(memory[start..start + 18].iter().all(|byte| *byte == 0xa5));
+            assert!(memory[start + 18..start + 32].iter().all(|byte| *byte == 0));
+        }
+        for plane_offset in [576, 720] {
+            for row in 0..9 {
+                let start = plane_offset + row * 16;
+                assert!(memory[start..start + 9].iter().all(|byte| *byte == 0xa5));
+                assert!(memory[start + 9..start + 16].iter().all(|byte| *byte == 0));
+            }
+        }
+    }
+
+    #[test]
+    fn naturally_packed_frame_preserves_all_samples() {
+        let layout = FrameLayout::new(1279, 1706, JpuPixelFormat::Yuv420, JpuScale::Half)
+            .expect("valid packed layout");
+        let mut memory = std::vec![0xa5u8; layout.total_len];
+
+        clear_frame_padding(&mut memory, &layout).expect("layout is valid");
+
+        assert!(memory.iter().all(|byte| *byte == 0xa5));
+    }
+}

--- a/drivers/vpu/sg200x-jpu/src/engine.rs
+++ b/drivers/vpu/sg200x-jpu/src/engine.rs
@@ -1,0 +1,452 @@
+//! Low-level JPU register programming and checked DMA address derivation.
+
+use tock_registers::interfaces::{Readable, Writeable};
+
+use super::{
+    header::{HuffTable, JpegHeaderInfo},
+    layout::{FrameLayout, JpuPixelFormat},
+    regs::{
+        HUFF_ADDR_MAX, HUFF_ADDR_PTR, HUFF_PHASE_MAX, HUFF_PHASE_MIN, HUFF_PHASE_PTR,
+        HUFF_PHASE_VAL, MJPEG_HUFF_CTRL, MJPEG_PIC_SIZE, MJPEG_PIC_START, MJPEG_PIC_STATUS,
+        MJPEG_QMAT_CTRL, QMAT_PHASE_CB, QMAT_PHASE_CR, QMAT_PHASE_Y, VALUE32, bbc_strm_ctrl_value,
+        clear_pic_status_at, jpu_regs_at, pic_ctrl_value, scl_info_value, wait_bbc_idle_at,
+    },
+};
+
+pub(super) const BBC_STREAM_PAGE_SIZE: usize = 256;
+pub(super) const GRAM_PREFETCH_PAGES: usize = 2;
+
+#[derive(Clone, Copy)]
+pub(super) struct HardwareDecodeInfo {
+    mcu_block_num: u32,
+    comp_info: u32,
+    bus_req_num: u32,
+}
+
+impl HardwareDecodeInfo {
+    pub(super) const fn for_format(format: JpuPixelFormat) -> Self {
+        match format {
+            JpuPixelFormat::Yuv420 => Self {
+                mcu_block_num: 6,
+                comp_info: (10 << 8) | (5 << 4) | 5,
+                bus_req_num: 2,
+            },
+            JpuPixelFormat::Yuv422Horizontal => Self {
+                mcu_block_num: 4,
+                comp_info: (9 << 8) | (5 << 4) | 5,
+                bus_req_num: 3,
+            },
+            JpuPixelFormat::Yuv422Vertical => Self {
+                mcu_block_num: 4,
+                comp_info: (6 << 8) | (5 << 4) | 5,
+                bus_req_num: 3,
+            },
+            JpuPixelFormat::Yuv444 => Self {
+                mcu_block_num: 3,
+                comp_info: (5 << 8) | (5 << 4) | 5,
+                bus_req_num: 4,
+            },
+            JpuPixelFormat::Grayscale => Self {
+                mcu_block_num: 1,
+                comp_info: 5 << 8,
+                bus_req_num: 4,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct DmaRegion {
+    pub(super) start: u32,
+    pub(super) end: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct FrameDmaAddresses {
+    pub(super) y: u32,
+    pub(super) cb: u32,
+    pub(super) cr: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PollError {
+    Decode,
+    Timeout,
+}
+
+pub(super) fn checked_dma_region(
+    dma_start: u64,
+    capacity: usize,
+    used_len: usize,
+) -> Result<DmaRegion, &'static str> {
+    if used_len == 0 || used_len > capacity {
+        return Err("invalid JPU DMA region length");
+    }
+    let mapped_end = dma_start
+        .checked_add(used_len as u64)
+        .ok_or("JPU DMA address range overflow")?;
+    Ok(DmaRegion {
+        start: u32::try_from(dma_start).map_err(|_| "JPU DMA start does not fit u32")?,
+        end: u32::try_from(mapped_end).map_err(|_| "JPU DMA end does not fit u32")?,
+    })
+}
+
+pub(super) fn checked_dma_offset(
+    region: DmaRegion,
+    offset: usize,
+    allow_end: bool,
+) -> Result<u32, &'static str> {
+    let offset = u32::try_from(offset).map_err(|_| "JPU DMA offset does not fit u32")?;
+    let address = region
+        .start
+        .checked_add(offset)
+        .ok_or("JPU DMA offset address overflow")?;
+    if address > region.end || (!allow_end && address == region.end) {
+        return Err("JPU DMA offset is outside its region");
+    }
+    Ok(address)
+}
+
+pub(super) fn checked_frame_dma_addresses(
+    region: DmaRegion,
+    layout: &FrameLayout,
+) -> Result<FrameDmaAddresses, &'static str> {
+    let plane_address = |offset: usize| -> Result<u32, &'static str> {
+        let address = (region.start as usize)
+            .checked_add(offset)
+            .ok_or("JPU frame plane address overflow")?;
+        let address = u32::try_from(address).map_err(|_| "JPU frame plane does not fit u32")?;
+        if address >= region.end {
+            return Err("JPU frame plane starts outside DMA region");
+        }
+        Ok(address)
+    };
+
+    let y = plane_address(layout.y.offset)?;
+    let cb = match layout.cb {
+        Some(plane) => plane_address(plane.offset)?,
+        None => y,
+    };
+    let cr = match layout.cr {
+        Some(plane) => plane_address(plane.offset)?,
+        None => y,
+    };
+    Ok(FrameDmaAddresses { y, cb, cr })
+}
+
+pub(super) fn configure_stream_regs(
+    jpu_base: usize,
+    stream_dma: DmaRegion,
+    stream_data_end: u32,
+    copy_len: usize,
+    header: &JpegHeaderInfo,
+    layout: &FrameLayout,
+    hardware: HardwareDecodeInfo,
+) {
+    let r = jpu_regs_at(jpu_base);
+    let stream_phys = stream_dma.start;
+    let stream_end = stream_dma.end;
+
+    r.bbc_bas_addr.write(VALUE32::VAL.val(stream_phys));
+    r.bbc_end_addr.write(VALUE32::VAL.val(stream_end));
+    r.bbc_rd_ptr.write(VALUE32::VAL.val(stream_phys));
+    r.bbc_wr_ptr.write(VALUE32::VAL.val(stream_data_end));
+
+    let strm_pages = copy_len.div_ceil(BBC_STREAM_PAGE_SIZE);
+    r.bbc_strm_ctrl.set(bbc_strm_ctrl_value(strm_pages as u32));
+
+    r.gbu_tt_cnt.write(VALUE32::VAL.val(0));
+    r.gbu_tt_cnt_h.write(VALUE32::VAL.val(0));
+    r.pic_errmb.write(VALUE32::VAL.val(0));
+
+    let mut huff_dc_idx = 0u32;
+    let mut huff_ac_idx = 0u32;
+    for i in 0..3 {
+        huff_dc_idx = (huff_dc_idx << 1) | header.dc_huff_tbl[i] as u32;
+        huff_ac_idx = (huff_ac_idx << 1) | header.ac_huff_tbl[i] as u32;
+    }
+    r.pic_ctrl.set(pic_ctrl_value(huff_dc_idx, huff_ac_idx));
+
+    r.pic_size.write(
+        MJPEG_PIC_SIZE::WIDTH.val(layout.source_aligned.width)
+            + MJPEG_PIC_SIZE::HEIGHT.val(layout.source_aligned.height),
+    );
+    r.rot_info.write(VALUE32::VAL.val(0));
+    r.mcu_info.write(
+        VALUE32::VAL.val(
+            (hardware.mcu_block_num << 16) | (header.num_components << 12) | hardware.comp_info,
+        ),
+    );
+    r.dpb_config.write(VALUE32::VAL.val(0));
+    r.rst_intval
+        .write(VALUE32::VAL.val(header.restart_interval));
+    r.scl_info.write(scl_info_value(layout.scale));
+    r.op_info.write(VALUE32::VAL.val(hardware.bus_req_num));
+}
+
+pub(super) fn upload_huff_tables(
+    jpu_base: usize,
+    header: &JpegHeaderInfo,
+) -> Result<(), &'static str> {
+    let r = jpu_regs_at(jpu_base);
+
+    r.huff_ctrl
+        .write(MJPEG_HUFF_CTRL::PHASE.val(HUFF_PHASE_MIN));
+    for table_idx in [0, 2, 1, 3] {
+        for j in 0..16 {
+            let huff_data = header.huff_tables[table_idx].min_codes[j];
+            let temp = HuffTable::sign_extend_16(huff_data);
+            r.huff_data
+                .write(VALUE32::VAL.val(((temp & 0xFFFF) << 16) | huff_data));
+        }
+    }
+
+    r.huff_ctrl
+        .write(MJPEG_HUFF_CTRL::PHASE.val(HUFF_PHASE_MAX));
+    r.huff_addr.write(VALUE32::VAL.val(HUFF_ADDR_MAX));
+    for table_idx in [0, 2, 1, 3] {
+        for j in 0..16 {
+            let huff_data = header.huff_tables[table_idx].max_codes[j];
+            let temp = HuffTable::sign_extend_16(huff_data);
+            r.huff_data
+                .write(VALUE32::VAL.val(((temp & 0xFFFF) << 16) | huff_data));
+        }
+    }
+
+    r.huff_ctrl
+        .write(MJPEG_HUFF_CTRL::PHASE.val(HUFF_PHASE_PTR));
+    r.huff_addr.write(VALUE32::VAL.val(HUFF_ADDR_PTR));
+    for table_idx in [0, 2, 1, 3] {
+        for j in 0..16 {
+            let huff_data = header.huff_tables[table_idx].ptrs[j] as u32;
+            let temp = HuffTable::sign_extend_8(huff_data);
+            r.huff_data
+                .write(VALUE32::VAL.val(((temp & 0xFFFFFF) << 8) | huff_data));
+        }
+    }
+
+    r.huff_ctrl
+        .write(MJPEG_HUFF_CTRL::PHASE.val(HUFF_PHASE_VAL));
+    for &table_idx in &[0, 2, 1, 3] {
+        let is_dc = table_idx == 0 || table_idx == 2;
+        let max_count = if is_dc { 12 } else { 162 };
+        let bits_len = if is_dc { 12 } else { 16 };
+        let count: usize = header.huff_tables[table_idx].bits[..bits_len]
+            .iter()
+            .map(|&b| b as usize)
+            .sum();
+
+        for j in 0..count.min(header.huff_tables[table_idx].num_values) {
+            let val = header.huff_tables[table_idx].values[j] as u32;
+            let temp = HuffTable::sign_extend_8(val);
+            r.huff_data
+                .write(VALUE32::VAL.val(((temp & 0xFFFFFF) << 8) | val));
+        }
+        for _ in count..max_count {
+            r.huff_data.write(VALUE32::VAL.val(0xFFFF_FFFF));
+        }
+    }
+
+    r.huff_ctrl.write(MJPEG_HUFF_CTRL::PHASE.val(0));
+    Ok(())
+}
+
+pub(super) fn upload_quant_tables(
+    jpu_base: usize,
+    header: &JpegHeaderInfo,
+) -> Result<(), &'static str> {
+    let r = jpu_regs_at(jpu_base);
+    let qmat_phases = [QMAT_PHASE_Y, QMAT_PHASE_CB, QMAT_PHASE_CR];
+    let comp_count = (header.num_components as usize).min(3);
+    for (comp_idx, &phase) in qmat_phases.iter().enumerate().take(comp_count) {
+        let table_idx = header.quant_tbl[comp_idx];
+        if table_idx >= 4 || table_idx >= header.quant_table_count {
+            continue;
+        }
+
+        r.qmat_ctrl.write(MJPEG_QMAT_CTRL::PHASE.val(phase));
+        for j in 0..64 {
+            r.qmat_data
+                .write(VALUE32::VAL.val(header.quant_tables[table_idx].values[j] as u32));
+        }
+        r.qmat_ctrl.write(MJPEG_QMAT_CTRL::PHASE.val(0));
+    }
+    Ok(())
+}
+
+pub(super) fn gram_setup(
+    jpu_base: usize,
+    stream_dma: DmaRegion,
+    header: &JpegHeaderInfo,
+) -> Result<(), &'static str> {
+    let r = jpu_regs_at(jpu_base);
+    let ecs_offset = header.ecs_offset;
+    let page_ptr = ecs_offset >> 8;
+    let mut word_ptr = (ecs_offset & 0xF0) >> 2;
+    let bit_ptr = (ecs_offset & 0xF) << 3;
+
+    if page_ptr & 1 != 0 {
+        word_ptr += 64;
+    }
+    if word_ptr & 1 != 0 {
+        word_ptr -= 1;
+    }
+
+    for i in 0..GRAM_PREFETCH_PAGES {
+        let cur_page = page_ptr
+            .checked_add(i)
+            .ok_or("JPU GRAM page index overflow")?;
+        let page_offset = cur_page
+            .checked_mul(BBC_STREAM_PAGE_SIZE)
+            .ok_or("JPU GRAM page offset overflow")?;
+        let external_address = checked_dma_offset(stream_dma, page_offset, false)?;
+        r.bbc_cur_pos.write(
+            VALUE32::VAL
+                .val(u32::try_from(cur_page).map_err(|_| "JPU GRAM page index does not fit u32")?),
+        );
+        r.bbc_ext_addr.write(VALUE32::VAL.val(external_address));
+        r.bbc_int_addr
+            .write(VALUE32::VAL.val(((cur_page & 1) as u32) << 6));
+        r.bbc_data_cnt
+            .write(VALUE32::VAL.val(BBC_STREAM_PAGE_SIZE as u32 / 4));
+        r.bbc_command.write(VALUE32::VAL.val(0));
+        wait_bbc_idle_at(jpu_base)?;
+    }
+
+    let next_page = page_ptr
+        .checked_add(GRAM_PREFETCH_PAGES)
+        .ok_or("JPU GRAM next page index overflow")?;
+    r.bbc_cur_pos.write(
+        VALUE32::VAL
+            .val(u32::try_from(next_page).map_err(|_| "JPU GRAM next page does not fit u32")?),
+    );
+    r.bbc_ctrl.write(VALUE32::VAL.val(1));
+
+    r.gbu_wd_ptr.write(VALUE32::VAL.val(word_ptr as u32));
+    r.gbu_bbsr.write(VALUE32::VAL.val(0));
+    r.gbu_bber.write(
+        VALUE32::VAL.val(((BBC_STREAM_PAGE_SIZE as u32 / 4) * GRAM_PREFETCH_PAGES as u32) - 1),
+    );
+
+    if page_ptr & 1 != 0 {
+        r.gbu_bbir.write(VALUE32::VAL.val(0));
+        r.gbu_bbhr.write(VALUE32::VAL.val(0));
+    } else {
+        r.gbu_bbir
+            .write(VALUE32::VAL.val(BBC_STREAM_PAGE_SIZE as u32 / 4));
+        r.gbu_bbhr
+            .write(VALUE32::VAL.val(BBC_STREAM_PAGE_SIZE as u32 / 4));
+    }
+
+    r.gbu_ctrl.write(VALUE32::VAL.val(4));
+    r.gbu_ff_rptr.write(VALUE32::VAL.val(bit_ptr as u32));
+    Ok(())
+}
+
+pub(super) fn start_decode(
+    jpu_base: usize,
+    frame_dma: FrameDmaAddresses,
+    header: &JpegHeaderInfo,
+    layout: &FrameLayout,
+) {
+    let r = jpu_regs_at(jpu_base);
+    r.rst_index.write(VALUE32::VAL.val(0));
+    r.rst_count.write(VALUE32::VAL.val(0));
+    r.dpcm_diff_y.write(VALUE32::VAL.val(0));
+    r.dpcm_diff_cb.write(VALUE32::VAL.val(0));
+    r.dpcm_diff_cr.write(VALUE32::VAL.val(0));
+
+    let bit_ptr = (header.ecs_offset & 0xF) << 3;
+    r.gbu_ff_rptr.write(VALUE32::VAL.val(bit_ptr as u32));
+    r.gbu_ctrl.write(VALUE32::VAL.val(3));
+
+    r.dpb_base_y.write(VALUE32::VAL.val(frame_dma.y));
+    r.dpb_base_cb.write(VALUE32::VAL.val(frame_dma.cb));
+    r.dpb_base_cr.write(VALUE32::VAL.val(frame_dma.cr));
+
+    r.dpb_ystride.write(VALUE32::VAL.val(layout.y.stride));
+    let chroma_stride = layout.cb.map_or(0, |plane| plane.stride);
+    r.dpb_cstride.write(VALUE32::VAL.val(chroma_stride));
+    r.clp_info.write(VALUE32::VAL.val(0));
+
+    clear_pic_status_at(jpu_base, r.pic_status.get());
+    r.pic_start.write(MJPEG_PIC_START::START_PIC::SET);
+}
+
+pub(super) fn poll_decode_done(jpu_base: usize) -> Result<(), PollError> {
+    let mut count = 0u32;
+    const MAX_POLLS: u32 = 500_000;
+    let r = jpu_regs_at(jpu_base);
+
+    loop {
+        if r.pic_status.is_set(MJPEG_PIC_STATUS::DONE) {
+            clear_pic_status_at(jpu_base, r.pic_status.get());
+            return Ok(());
+        }
+
+        if r.pic_status.is_set(MJPEG_PIC_STATUS::ERROR) {
+            let status = r.pic_status.get();
+            let err_mb = r.pic_errmb.get();
+            log::warn!("[JPU] Error! status=0x{:x}, err_mb=0x{:x}", status, err_mb);
+            clear_pic_status_at(jpu_base, status);
+            return Err(PollError::Decode);
+        }
+
+        for _ in 0..1000 {
+            core::hint::spin_loop();
+        }
+        count += 1;
+
+        if count >= MAX_POLLS {
+            let status = r.pic_status.get();
+            log::warn!("[JPU] Timeout! status=0x{:x}, polls={}", status, count);
+            return Err(PollError::Timeout);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DmaRegion, checked_dma_offset, checked_dma_region, checked_frame_dma_addresses};
+    use crate::{FrameLayout, JpuPixelFormat, JpuScale};
+
+    #[test]
+    fn dma_region_checks_capacity_and_32_bit_register_range() {
+        assert_eq!(
+            checked_dma_region(u32::MAX as u64 - 8, 16, 8),
+            Ok(DmaRegion {
+                start: u32::MAX - 8,
+                end: u32::MAX,
+            })
+        );
+        assert!(checked_dma_region(u32::MAX as u64 - 8, 16, 9).is_err());
+        assert!(checked_dma_region(0x1000, 16, 17).is_err());
+        assert!(checked_dma_region(u32::MAX as u64 + 1, 16, 1).is_err());
+    }
+
+    #[test]
+    fn dma_offsets_reject_addresses_outside_the_registered_region() {
+        let region = DmaRegion {
+            start: 0x1000,
+            end: 0x1100,
+        };
+        assert_eq!(checked_dma_offset(region, 0x100, true), Ok(0x1100));
+        assert!(checked_dma_offset(region, 0x100, false).is_err());
+        assert!(checked_dma_offset(region, 0x101, true).is_err());
+    }
+
+    #[test]
+    fn frame_addresses_include_checked_plane_offsets() {
+        let layout = FrameLayout::new(129, 129, JpuPixelFormat::Yuv420, JpuScale::Eighth)
+            .expect("valid layout");
+        let region = DmaRegion {
+            start: 0x1000,
+            end: 0x1000 + layout.total_len as u32,
+        };
+
+        let addresses = checked_frame_dma_addresses(region, &layout).expect("valid addresses");
+        assert_eq!(addresses.y, 0x1000);
+        assert_eq!(addresses.cb, 0x1000 + 576);
+        assert_eq!(addresses.cr, 0x1000 + 720);
+    }
+}

--- a/drivers/vpu/sg200x-jpu/src/header.rs
+++ b/drivers/vpu/sg200x-jpu/src/header.rs
@@ -1,0 +1,526 @@
+//! JPEG 头解析（SOF / DHT / DQT / SOS）。
+
+use super::regs::{FORMAT_224, FORMAT_400, FORMAT_420, FORMAT_422, FORMAT_444};
+
+pub struct JpegHeaderInfo {
+    pub width: u32,
+    pub height: u32,
+    pub num_components: u32,
+    pub format: u32,
+    pub ecs_offset: usize,
+    pub restart_interval: u32,
+    pub dc_huff_tbl: [usize; 3],
+    pub ac_huff_tbl: [usize; 3],
+    pub quant_tbl: [usize; 3],
+    pub huff_tables: [HuffTable; 4],
+    pub quant_tables: [QuantTable; 4],
+    pub huff_table_count: usize,
+    pub quant_table_count: usize,
+}
+
+pub struct HuffTable {
+    pub bits: [u8; 16],
+    pub values: [u8; 256],
+    pub num_values: usize,
+    pub min_codes: [u32; 16],
+    pub max_codes: [u32; 16],
+    pub ptrs: [u8; 16],
+}
+
+impl HuffTable {
+    pub fn new() -> Self {
+        Self {
+            bits: [0; 16],
+            values: [0; 256],
+            num_values: 0,
+            min_codes: [0xFFFF; 16],
+            max_codes: [0xFFFF; 16],
+            ptrs: [0xFF; 16],
+        }
+    }
+
+    pub fn sign_extend_16(huff_data: u32) -> u32 {
+        if huff_data & 0x8000 != 0 { 0xFFFF } else { 0 }
+    }
+
+    pub fn sign_extend_8(huff_data: u32) -> u32 {
+        if huff_data & 0x80 != 0 { 0xFFFFFF } else { 0 }
+    }
+
+    pub fn generate(&mut self) {
+        let mut ptr_cnt: usize = 0;
+        let mut huff_code: u32 = 0;
+        let mut data_flag = false;
+
+        for i in 0..16 {
+            if self.bits[i] != 0 {
+                self.ptrs[i] = ptr_cnt as u8;
+                ptr_cnt += self.bits[i] as usize;
+                self.min_codes[i] = huff_code;
+                self.max_codes[i] = huff_code + (self.bits[i] as u32 - 1);
+                data_flag = true;
+            } else {
+                self.ptrs[i] = 0xFF;
+                self.min_codes[i] = 0xFFFF;
+                self.max_codes[i] = 0xFFFF;
+            }
+
+            if data_flag {
+                if self.bits[i] == 0 {
+                    huff_code <<= 1;
+                } else {
+                    huff_code = (self.max_codes[i] + 1) << 1;
+                }
+            }
+        }
+    }
+}
+
+pub struct QuantTable {
+    pub values: [u16; 64],
+}
+
+impl QuantTable {
+    pub fn new() -> Self {
+        Self { values: [0; 64] }
+    }
+}
+
+impl JpegHeaderInfo {
+    pub fn new() -> Self {
+        Self {
+            width: 0,
+            height: 0,
+            num_components: 0,
+            format: FORMAT_420,
+            ecs_offset: 0,
+            restart_interval: 0,
+            dc_huff_tbl: [0; 3],
+            ac_huff_tbl: [0; 3],
+            quant_tbl: [0; 3],
+            huff_tables: [
+                HuffTable::new(),
+                HuffTable::new(),
+                HuffTable::new(),
+                HuffTable::new(),
+            ],
+            quant_tables: [
+                QuantTable::new(),
+                QuantTable::new(),
+                QuantTable::new(),
+                QuantTable::new(),
+            ],
+            huff_table_count: 0,
+            quant_table_count: 0,
+        }
+    }
+}
+
+pub fn parse_jpeg_header(data: &[u8]) -> Result<JpegHeaderInfo, &'static str> {
+    let mut i = 0;
+    let mut header_info = JpegHeaderInfo::new();
+
+    while i < data.len().saturating_sub(1) {
+        if data[i] == 0xFF {
+            let marker = data[i + 1];
+
+            if marker == 0xFF {
+                i += 1;
+                continue;
+            }
+            if marker == 0x00 {
+                i += 2;
+                continue;
+            }
+
+            match marker {
+                0xC0 => {
+                    let end = segment_end(data, i, "SOF")?;
+                    let length = end - (i + 2);
+                    if length < 8 {
+                        return Err("SOF too short");
+                    }
+                    if data[i + 4] != 8 {
+                        return Err("only 8-bit baseline JPEG is supported");
+                    }
+
+                    header_info.height = ((data[i + 5] as u32) << 8) | (data[i + 6] as u32);
+                    header_info.width = ((data[i + 7] as u32) << 8) | (data[i + 8] as u32);
+                    let num_components = data[i + 9] as usize;
+                    if !matches!(num_components, 1 | 3) {
+                        return Err("only grayscale and three-component JPEG are supported");
+                    }
+                    let expected_length = 8usize
+                        .checked_add(
+                            num_components
+                                .checked_mul(3)
+                                .ok_or("SOF component length overflow")?,
+                        )
+                        .ok_or("SOF component length overflow")?;
+                    if length != expected_length {
+                        return Err("SOF component payload has an invalid length");
+                    }
+                    header_info.num_components = num_components as u32;
+
+                    let comp_start = i + 10;
+                    for component in 0..num_components {
+                        let quant_idx = data[comp_start + component * 3 + 2] as usize;
+                        if quant_idx >= header_info.quant_tables.len() {
+                            return Err("SOF quantization table index is out of range");
+                        }
+                        header_info.quant_tbl[component] = quant_idx;
+                    }
+
+                    if num_components == 3 {
+                        let sampling = |component: usize| {
+                            let value = data[comp_start + component * 3 + 1];
+                            ((value >> 4) & 0x0f, value & 0x0f)
+                        };
+                        let y = sampling(0);
+                        let cb = sampling(1);
+                        let cr = sampling(2);
+                        if cb != (1, 1) || cr != (1, 1) {
+                            return Err("unsupported JPEG chroma sampling factors");
+                        }
+                        header_info.format = match y {
+                            (2, 2) => FORMAT_420,
+                            (2, 1) => FORMAT_422,
+                            (1, 2) => FORMAT_224,
+                            (1, 1) => FORMAT_444,
+                            _ => return Err("unsupported JPEG luma sampling factors"),
+                        };
+                    } else {
+                        let sampling = data[comp_start + 1];
+                        if sampling != 0x11 {
+                            return Err("unsupported grayscale sampling factors");
+                        }
+                        header_info.format = FORMAT_400;
+                    }
+
+                    i = end;
+                    continue;
+                }
+                0xC2 => return Err("progressive JPEG is unsupported"),
+                0xC4 => {
+                    let end = segment_end(data, i, "DHT")?;
+                    parse_dht(data, i + 4, end, &mut header_info)?;
+                    i = end;
+                    continue;
+                }
+                0xDA => {
+                    let end = segment_end(data, i, "SOS")?;
+                    if end == data.len() {
+                        return Err("SOS has no entropy-coded data");
+                    }
+                    let sos_length = end - (i + 2);
+                    if sos_length < 6 {
+                        return Err("SOS too short");
+                    }
+                    let num_scan_components = data[i + 4] as usize;
+                    if num_scan_components != header_info.num_components as usize
+                        || !matches!(num_scan_components, 1 | 3)
+                    {
+                        return Err("SOS components do not match SOF");
+                    }
+                    let expected_length = 6usize
+                        .checked_add(
+                            num_scan_components
+                                .checked_mul(2)
+                                .ok_or("SOS component length overflow")?,
+                        )
+                        .ok_or("SOS component length overflow")?;
+                    if sos_length != expected_length {
+                        return Err("SOS component payload has an invalid length");
+                    }
+
+                    let mut comp_offset = i + 5;
+                    for comp_idx in 0..num_scan_components {
+                        let tables = data[comp_offset + 1];
+                        let dc = ((tables >> 4) & 0x0f) as usize;
+                        let ac = (tables & 0x0f) as usize;
+                        if dc > 1 || ac > 1 {
+                            return Err("SOS Huffman table index is out of range");
+                        }
+                        header_info.dc_huff_tbl[comp_idx] = dc;
+                        header_info.ac_huff_tbl[comp_idx] = ac;
+                        comp_offset += 2;
+                    }
+
+                    if data[comp_offset] != 0
+                        || data[comp_offset + 1] != 63
+                        || data[comp_offset + 2] != 0
+                    {
+                        return Err("non-baseline SOS parameters are unsupported");
+                    }
+                    header_info.ecs_offset = end;
+                    return Ok(header_info);
+                }
+                0xDB => {
+                    let end = segment_end(data, i, "DQT")?;
+                    parse_dqt(data, i + 4, end, &mut header_info)?;
+                    i = end;
+                    continue;
+                }
+                0xDD => {
+                    let end = segment_end(data, i, "DRI")?;
+                    if end - (i + 2) != 4 {
+                        return Err("DRI has an invalid length");
+                    }
+                    header_info.restart_interval =
+                        ((data[i + 4] as u32) << 8) | (data[i + 5] as u32);
+                    i = end;
+                    continue;
+                }
+                0xD8 => {
+                    i += 2;
+                    continue;
+                }
+                0xD9 => break,
+                _ => {
+                    if marker >= 0xC0 && i + 3 < data.len() {
+                        i = segment_end(data, i, "JPEG marker")?;
+                        continue;
+                    }
+                    i += 2;
+                    continue;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    Err("SOS not found")
+}
+
+fn segment_end(
+    data: &[u8],
+    marker_offset: usize,
+    marker_name: &'static str,
+) -> Result<usize, &'static str> {
+    let length_offset = marker_offset
+        .checked_add(2)
+        .ok_or("JPEG marker offset overflow")?;
+    let length_bytes = data
+        .get(length_offset..length_offset + 2)
+        .ok_or(match marker_name {
+            "SOS" => "SOS payload exceeds JPEG stream",
+            _ => "JPEG marker length is truncated",
+        })?;
+    let length = ((length_bytes[0] as usize) << 8) | length_bytes[1] as usize;
+    if length < 2 {
+        return Err("JPEG marker length is invalid");
+    }
+    let end = length_offset
+        .checked_add(length)
+        .ok_or("JPEG marker length overflow")?;
+    if end > data.len() {
+        return Err(match marker_name {
+            "SOS" => "SOS payload exceeds JPEG stream",
+            _ => "JPEG marker payload exceeds stream",
+        });
+    }
+    Ok(end)
+}
+
+fn parse_dht(
+    data: &[u8],
+    start: usize,
+    end: usize,
+    header_info: &mut JpegHeaderInfo,
+) -> Result<(), &'static str> {
+    if start > end || end > data.len() {
+        return Err("DHT payload exceeds JPEG stream");
+    }
+    let mut offset = start;
+
+    while offset < end {
+        let counts_end = offset.checked_add(17).ok_or("DHT table length overflow")?;
+        if counts_end > end {
+            return Err("DHT table counts are truncated");
+        }
+        let tc_th = data[offset];
+        let tc = (tc_th >> 4) & 0x0F;
+        let th = tc_th & 0x0F;
+        if tc > 1 || th > 1 {
+            return Err("DHT table class or index is out of range");
+        }
+        let table_idx = ((th << 1) | tc) as usize;
+
+        let bits = &data[offset + 1..counts_end];
+        if tc == 0 && bits[12..].iter().any(|&count| count != 0) {
+            return Err("DC Huffman code length exceeds the hardware table");
+        }
+        let num_values = bits.iter().map(|&count| count as usize).sum::<usize>();
+        let hardware_limit = if tc == 0 { 12 } else { 162 };
+        if num_values > hardware_limit {
+            return Err("DHT symbol count exceeds the baseline hardware table");
+        }
+        if num_values > header_info.huff_tables[table_idx].values.len() {
+            return Err("DHT defines more than 256 values");
+        }
+        let values_end = counts_end
+            .checked_add(num_values)
+            .ok_or("DHT values length overflow")?;
+        if values_end > end {
+            return Err("DHT values are truncated");
+        }
+
+        let table = &mut header_info.huff_tables[table_idx];
+        table.bits.copy_from_slice(bits);
+        table.values[..num_values].copy_from_slice(&data[counts_end..values_end]);
+        table.num_values = num_values;
+        table.generate();
+
+        if table_idx >= header_info.huff_table_count {
+            header_info.huff_table_count = table_idx + 1;
+        }
+
+        offset = values_end;
+    }
+
+    Ok(())
+}
+
+fn parse_dqt(
+    data: &[u8],
+    start: usize,
+    end: usize,
+    header_info: &mut JpegHeaderInfo,
+) -> Result<(), &'static str> {
+    if start > end || end > data.len() {
+        return Err("DQT payload exceeds JPEG stream");
+    }
+    let mut offset = start;
+
+    while offset < end {
+        let pq_tq = data[offset];
+        let precision = pq_tq >> 4;
+        let tq: usize = (pq_tq & 0x0F) as usize;
+        if tq >= header_info.quant_tables.len() {
+            return Err("DQT table index is out of range");
+        }
+        let element_bytes = match precision {
+            0 => 1,
+            1 => 2,
+            _ => return Err("DQT precision is unsupported"),
+        };
+        let values_len = 64usize
+            .checked_mul(element_bytes)
+            .ok_or("DQT values length overflow")?;
+        let next = offset
+            .checked_add(1)
+            .and_then(|value| value.checked_add(values_len))
+            .ok_or("DQT table length overflow")?;
+        if next > end {
+            return Err("DQT values are truncated");
+        }
+
+        if precision == 0 {
+            for j in 0..64 {
+                header_info.quant_tables[tq].values[j] = data[offset + 1 + j] as u16;
+            }
+        } else {
+            for j in 0..64 {
+                header_info.quant_tables[tq].values[j] = ((data[offset + 1 + j * 2] as u16) << 8)
+                    | (data[offset + 1 + j * 2 + 1] as u16);
+            }
+        }
+        offset = next;
+
+        if tq >= header_info.quant_table_count {
+            header_info.quant_table_count = tq + 1;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{JpegHeaderInfo, parse_dht, parse_jpeg_header};
+
+    #[test]
+    fn parses_baseline_yuv420_frame_and_scan_headers() {
+        let baseline = [
+            0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x10, 0x00, 0x10, 0x03, 0x01, 0x22,
+            0x00, 0x02, 0x11, 0x01, 0x03, 0x11, 0x01, 0xff, 0xda, 0x00, 0x0c, 0x03, 0x01, 0x00,
+            0x02, 0x11, 0x03, 0x11, 0x00, 0x3f, 0x00, 0x00,
+        ];
+
+        let header = parse_jpeg_header(&baseline).expect("baseline headers are supported");
+        assert_eq!((header.width, header.height), (16, 16));
+        assert_eq!(header.format, super::FORMAT_420);
+        assert_eq!(header.ecs_offset, 35);
+        assert_eq!(header.quant_tbl, [0, 1, 1]);
+        assert_eq!(header.dc_huff_tbl, [0, 1, 1]);
+        assert_eq!(header.ac_huff_tbl, [0, 1, 1]);
+    }
+
+    #[test]
+    fn rejects_huffman_symbol_counts_beyond_baseline_hardware_tables() {
+        let mut dc = [0u8; 30];
+        dc[1] = 13;
+        assert!(parse_dht(&dc, 0, dc.len(), &mut JpegHeaderInfo::new()).is_err());
+
+        let mut ac = [0u8; 180];
+        ac[0] = 0x10;
+        ac[1] = 163;
+        assert!(parse_dht(&ac, 0, ac.len(), &mut JpegHeaderInfo::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_dc_huffman_codes_longer_than_the_hardware_table() {
+        let mut dc = [0u8; 18];
+        dc[13] = 1;
+
+        assert!(parse_dht(&dc, 0, dc.len(), &mut JpegHeaderInfo::new()).is_err());
+    }
+
+    #[test]
+    fn rejects_quantization_table_indices_outside_hardware_range() {
+        let mut malformed = [0u8; 69];
+        malformed[..5].copy_from_slice(&[0xff, 0xdb, 0x00, 0x43, 0x04]);
+
+        assert!(parse_jpeg_header(&malformed).is_err());
+    }
+
+    #[test]
+    fn rejects_huffman_tables_with_more_than_256_values() {
+        let mut malformed = [0u8; 278];
+        malformed[..5].copy_from_slice(&[0xff, 0xc4, 0x01, 0x14, 0x00]);
+        malformed[5] = 255;
+        malformed[6] = 2;
+
+        assert!(parse_jpeg_header(&malformed).is_err());
+    }
+
+    #[test]
+    fn rejects_progressive_jpeg() {
+        let progressive = [
+            0xff, 0xc2, 0x00, 0x0b, 0x08, 0x00, 0x08, 0x00, 0x08, 0x01, 0x01, 0x11, 0x00, 0xff,
+            0xda, 0x00, 0x06, 0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0x00,
+        ];
+
+        assert!(parse_jpeg_header(&progressive).is_err());
+    }
+
+    #[test]
+    fn rejects_sos_payload_that_ends_beyond_the_input() {
+        let malformed = [0xff, 0xda, 0xff, 0xff];
+
+        assert_eq!(
+            parse_jpeg_header(&malformed).err(),
+            Some("SOS payload exceeds JPEG stream")
+        );
+    }
+
+    #[test]
+    fn rejects_sos_without_any_entropy_coded_byte() {
+        let no_entropy_data = [0xff, 0xda, 0x00, 0x02];
+
+        assert_eq!(
+            parse_jpeg_header(&no_entropy_data).err(),
+            Some("SOS has no entropy-coded data")
+        );
+    }
+}

--- a/drivers/vpu/sg200x-jpu/src/layout.rs
+++ b/drivers/vpu/sg200x-jpu/src/layout.rs
@@ -1,0 +1,440 @@
+//! Pure, checked layout rules for planar frames produced by the JPU.
+
+const PLANE_ALIGNMENT: usize = 8;
+const SCALED_STRIDE_ALIGNMENT: u32 = 16;
+const MIN_SCALED_CODED_EXTENT: u32 = 128;
+
+/// Isotropic downscale mode implemented by the SG2002 JPU.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum JpuScale {
+    /// Decode at the JPEG's full coded resolution.
+    Full,
+    /// Decode at one half of the coded width and height.
+    Half,
+    /// Decode at one quarter of the coded width and height.
+    Quarter,
+    /// Decode at one eighth of the coded width and height.
+    Eighth,
+}
+
+impl JpuScale {
+    /// Linear scale denominator.
+    pub const fn factor(self) -> u32 {
+        1 << self.register_mode()
+    }
+
+    /// Two-bit mode written to each axis in `MJPEG_SCL_INFO`.
+    pub(crate) const fn register_mode(self) -> u32 {
+        match self {
+            Self::Full => 0,
+            Self::Half => 1,
+            Self::Quarter => 2,
+            Self::Eighth => 3,
+        }
+    }
+
+    pub(crate) const fn is_scaled(self) -> bool {
+        !matches!(self, Self::Full)
+    }
+}
+
+/// Planar pixel format produced by the JPU.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum JpuPixelFormat {
+    /// 4:2:0: chroma is subsampled in both axes.
+    Yuv420,
+    /// 4:2:2: chroma is subsampled horizontally.
+    Yuv422Horizontal,
+    /// 4:2:2: chroma is subsampled vertically (vendor name `FORMAT_224`).
+    Yuv422Vertical,
+    /// 4:4:4: luma and chroma have equal resolution.
+    Yuv444,
+    /// Luma only.
+    Grayscale,
+}
+
+impl JpuPixelFormat {
+    pub(crate) fn from_raw(raw: u32) -> Result<Self, FrameLayoutError> {
+        match raw {
+            super::regs::FORMAT_420 => Ok(Self::Yuv420),
+            super::regs::FORMAT_422 => Ok(Self::Yuv422Horizontal),
+            super::regs::FORMAT_224 => Ok(Self::Yuv422Vertical),
+            super::regs::FORMAT_444 => Ok(Self::Yuv444),
+            super::regs::FORMAT_400 => Ok(Self::Grayscale),
+            _ => Err(FrameLayoutError::UnsupportedPixelFormat),
+        }
+    }
+
+    const fn mcu_extent(self) -> Extent {
+        match self {
+            Self::Yuv420 => Extent::new(16, 16),
+            Self::Yuv422Horizontal => Extent::new(16, 8),
+            Self::Yuv422Vertical => Extent::new(8, 16),
+            Self::Yuv444 | Self::Grayscale => Extent::new(8, 8),
+        }
+    }
+}
+
+/// Two-dimensional extent in pixels.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Extent {
+    /// Width in pixels.
+    pub width: u32,
+    /// Height in pixels.
+    pub height: u32,
+}
+
+impl Extent {
+    const fn new(width: u32, height: u32) -> Self {
+        Self { width, height }
+    }
+}
+
+/// Byte layout of one planar component.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PlaneLayout {
+    /// Offset from the start of the frame buffer.
+    pub offset: usize,
+    /// Component bytes including row-stride padding, but excluding the aligned
+    /// gap before the next plane.
+    pub len: usize,
+    /// Distance in bytes between consecutive rows.
+    pub stride: u32,
+    /// Stored component dimensions in samples.
+    pub storage: Extent,
+}
+
+/// Checked description of a planar JPU output buffer.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FrameLayout {
+    /// Sampling format.
+    pub format: JpuPixelFormat,
+    /// Selected hardware scale.
+    pub scale: JpuScale,
+    /// Dimensions from the JPEG SOF marker.
+    pub source: Extent,
+    /// Meaningful output dimensions; downstream processing should crop to this.
+    pub visible: Extent,
+    /// Source dimensions rounded up to whole JPEG MCU blocks.
+    pub source_aligned: Extent,
+    /// Dimensions of the hardware output buffer, including coded padding.
+    pub coded: Extent,
+    /// Stored dimensions after the scaler's even-size requirement.
+    pub storage: Extent,
+    /// Luma plane.
+    pub y: PlaneLayout,
+    /// Blue-difference chroma plane, absent for grayscale.
+    pub cb: Option<PlaneLayout>,
+    /// Red-difference chroma plane, absent for grayscale.
+    pub cr: Option<PlaneLayout>,
+    /// Total frame allocation, including inter-plane and trailing alignment.
+    pub total_len: usize,
+}
+
+impl FrameLayout {
+    /// Calculate the exact JPU output layout without touching hardware.
+    pub fn new(
+        source_width: u32,
+        source_height: u32,
+        format: JpuPixelFormat,
+        scale: JpuScale,
+    ) -> Result<Self, FrameLayoutError> {
+        if source_width == 0 || source_height == 0 {
+            return Err(FrameLayoutError::ZeroDimension);
+        }
+
+        let source = Extent::new(source_width, source_height);
+        let mcu = format.mcu_extent();
+        let source_aligned = Extent::new(
+            align_u32(source.width, mcu.width)?,
+            align_u32(source.height, mcu.height)?,
+        );
+        if source_aligned.width > u16::MAX as u32 || source_aligned.height > u16::MAX as u32 {
+            return Err(FrameLayoutError::DimensionOverflow);
+        }
+
+        if scale.is_scaled()
+            && (source_aligned.width < MIN_SCALED_CODED_EXTENT
+                || source_aligned.height < MIN_SCALED_CODED_EXTENT)
+        {
+            return Err(FrameLayoutError::UnsupportedScaledDimensions);
+        }
+
+        let factor = scale.factor();
+        let visible = Extent::new(
+            ceil_div_u32(source.width, factor),
+            ceil_div_u32(source.height, factor),
+        );
+        let coded = Extent::new(
+            source_aligned.width >> scale.register_mode(),
+            source_aligned.height >> scale.register_mode(),
+        );
+        let storage = if scale.is_scaled() {
+            Extent::new(align_u32(coded.width, 2)?, align_u32(coded.height, 2)?)
+        } else {
+            coded
+        };
+
+        let stride_y = if scale.is_scaled() {
+            align_u32(storage.width, SCALED_STRIDE_ALIGNMENT)?
+        } else {
+            storage.width
+        };
+        let y = PlaneLayout {
+            offset: 0,
+            len: plane_len(stride_y, storage.height)?,
+            stride: stride_y,
+            storage,
+        };
+
+        let (cb, cr, total_len) = match format {
+            JpuPixelFormat::Grayscale => (None, None, align_usize(y.len, PLANE_ALIGNMENT)?),
+            _ => {
+                let chroma_storage = match format {
+                    JpuPixelFormat::Yuv420 => Extent::new(storage.width / 2, storage.height / 2),
+                    JpuPixelFormat::Yuv422Horizontal => {
+                        Extent::new(storage.width / 2, storage.height)
+                    }
+                    JpuPixelFormat::Yuv422Vertical => {
+                        Extent::new(storage.width, storage.height / 2)
+                    }
+                    JpuPixelFormat::Yuv444 => storage,
+                    JpuPixelFormat::Grayscale => unreachable!(),
+                };
+                // The JPU's CSTRIDE is derived from the programmed YSTRIDE,
+                // including scaler-added row padding, not from visible width.
+                let stride_c = match format {
+                    JpuPixelFormat::Yuv420 | JpuPixelFormat::Yuv422Horizontal => stride_y / 2,
+                    JpuPixelFormat::Yuv422Vertical | JpuPixelFormat::Yuv444 => stride_y,
+                    JpuPixelFormat::Grayscale => unreachable!(),
+                };
+                let chroma_len = plane_len(stride_c, chroma_storage.height)?;
+                let cb_offset = align_usize(y.len, PLANE_ALIGNMENT)?;
+                let cr_offset = align_usize(
+                    cb_offset
+                        .checked_add(chroma_len)
+                        .ok_or(FrameLayoutError::BufferSizeOverflow)?,
+                    PLANE_ALIGNMENT,
+                )?;
+                let total_len = align_usize(
+                    cr_offset
+                        .checked_add(chroma_len)
+                        .ok_or(FrameLayoutError::BufferSizeOverflow)?,
+                    PLANE_ALIGNMENT,
+                )?;
+                (
+                    Some(PlaneLayout {
+                        offset: cb_offset,
+                        len: chroma_len,
+                        stride: stride_c,
+                        storage: chroma_storage,
+                    }),
+                    Some(PlaneLayout {
+                        offset: cr_offset,
+                        len: chroma_len,
+                        stride: stride_c,
+                        storage: chroma_storage,
+                    }),
+                    total_len,
+                )
+            }
+        };
+
+        Ok(Self {
+            format,
+            scale,
+            source,
+            visible,
+            source_aligned,
+            coded,
+            storage,
+            y,
+            cb,
+            cr,
+            total_len,
+        })
+    }
+}
+
+/// Error returned while deriving a hardware frame layout.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum FrameLayoutError {
+    /// A JPEG dimension is zero.
+    #[error("JPEG dimensions must be non-zero")]
+    ZeroDimension,
+    /// Rounding a source dimension would overflow `u32`.
+    #[error("aligned JPEG dimensions overflow")]
+    DimensionOverflow,
+    /// A scaled decode was requested for a coded extent below 128 pixels.
+    #[error("JPU scaling requires both aligned dimensions to be at least 128")]
+    UnsupportedScaledDimensions,
+    /// The JPEG sampling value is unknown to this driver.
+    #[error("unsupported JPU pixel format")]
+    UnsupportedPixelFormat,
+    /// A plane length, offset, or total allocation overflowed `usize`.
+    #[error("JPU frame layout size overflow")]
+    BufferSizeOverflow,
+}
+
+fn align_u32(value: u32, alignment: u32) -> Result<u32, FrameLayoutError> {
+    debug_assert!(alignment.is_power_of_two());
+    value
+        .checked_add(alignment - 1)
+        .map(|rounded| rounded & !(alignment - 1))
+        .ok_or(FrameLayoutError::DimensionOverflow)
+}
+
+fn align_usize(value: usize, alignment: usize) -> Result<usize, FrameLayoutError> {
+    debug_assert!(alignment.is_power_of_two());
+    value
+        .checked_add(alignment - 1)
+        .map(|rounded| rounded & !(alignment - 1))
+        .ok_or(FrameLayoutError::BufferSizeOverflow)
+}
+
+const fn ceil_div_u32(value: u32, divisor: u32) -> u32 {
+    value / divisor + if value.is_multiple_of(divisor) { 0 } else { 1 }
+}
+
+fn plane_len(stride: u32, rows: u32) -> Result<usize, FrameLayoutError> {
+    let stride = usize::try_from(stride).map_err(|_| FrameLayoutError::BufferSizeOverflow)?;
+    let rows = usize::try_from(rows).map_err(|_| FrameLayoutError::BufferSizeOverflow)?;
+    stride
+        .checked_mul(rows)
+        .ok_or(FrameLayoutError::BufferSizeOverflow)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{FrameLayout, FrameLayoutError, JpuPixelFormat, JpuScale};
+
+    #[test]
+    fn half_scale_yuv420_distinguishes_visible_and_storage_extents() {
+        let layout = FrameLayout::new(1279, 1706, JpuPixelFormat::Yuv420, JpuScale::Half)
+            .expect("valid scaled layout");
+
+        assert_eq!((layout.source.width, layout.source.height), (1279, 1706));
+        assert_eq!((layout.visible.width, layout.visible.height), (640, 853));
+        assert_eq!(
+            (layout.source_aligned.width, layout.source_aligned.height),
+            (1280, 1712)
+        );
+        assert_eq!((layout.storage.width, layout.storage.height), (640, 856));
+        assert_eq!((layout.y.stride, layout.y.len), (640, 547_840));
+        let cb = layout.cb.expect("YUV420 has Cb");
+        let cr = layout.cr.expect("YUV420 has Cr");
+        assert_eq!((cb.offset, cb.stride, cb.len), (547_840, 320, 136_960));
+        assert_eq!((cr.offset, cr.stride, cr.len), (684_800, 320, 136_960));
+        assert_eq!(layout.total_len, 821_760);
+    }
+
+    #[test]
+    fn scaled_yuv420_chroma_stride_tracks_half_the_luma_stride() {
+        let layout = FrameLayout::new(129, 129, JpuPixelFormat::Yuv420, JpuScale::Eighth)
+            .expect("valid scaled layout");
+
+        assert_eq!((layout.storage.width, layout.storage.height), (18, 18));
+        assert_eq!((layout.y.stride, layout.y.len), (32, 576));
+        let cb = layout.cb.expect("YUV420 has Cb");
+        let cr = layout.cr.expect("YUV420 has Cr");
+        assert_eq!((cb.offset, cb.stride, cb.len), (576, 16, 144));
+        assert_eq!((cr.offset, cr.stride, cr.len), (720, 16, 144));
+        assert_eq!(layout.total_len, 864);
+    }
+
+    #[test]
+    fn scaled_chroma_strides_follow_each_sampling_format() {
+        let cases = [
+            (JpuPixelFormat::Yuv420, Some((16, 144))),
+            (JpuPixelFormat::Yuv422Horizontal, Some((16, 288))),
+            (JpuPixelFormat::Yuv422Vertical, Some((32, 288))),
+            (JpuPixelFormat::Yuv444, Some((32, 576))),
+            (JpuPixelFormat::Grayscale, None),
+        ];
+
+        for (format, expected_chroma) in cases {
+            let layout =
+                FrameLayout::new(129, 129, format, JpuScale::Eighth).expect("valid scaled layout");
+            assert_eq!((layout.storage.width, layout.storage.height), (18, 18));
+            assert_eq!((layout.y.stride, layout.y.len), (32, 576));
+            match expected_chroma {
+                Some((stride, len)) => {
+                    let cb = layout.cb.expect("color format has Cb");
+                    let cr = layout.cr.expect("color format has Cr");
+                    assert_eq!((cb.stride, cb.len), (stride, len));
+                    assert_eq!((cr.stride, cr.len), (stride, len));
+                    assert_eq!(cb.offset % 8, 0);
+                    assert_eq!(cr.offset % 8, 0);
+                    assert!(cb.offset + cb.len <= cr.offset);
+                    assert!(cr.offset + cr.len <= layout.total_len);
+                }
+                None => {
+                    assert!(layout.cb.is_none());
+                    assert!(layout.cr.is_none());
+                    assert_eq!(layout.total_len, 576);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn scale_requires_both_aligned_axes_to_be_at_least_128() {
+        FrameLayout::new(113, 113, JpuPixelFormat::Yuv420, JpuScale::Half)
+            .expect("113 aligns to 128 for YUV420");
+
+        assert_eq!(
+            FrameLayout::new(112, 113, JpuPixelFormat::Yuv420, JpuScale::Half),
+            Err(FrameLayoutError::UnsupportedScaledDimensions)
+        );
+        assert_eq!(
+            FrameLayout::new(129, 119, JpuPixelFormat::Yuv422Horizontal, JpuScale::Half),
+            Err(FrameLayoutError::UnsupportedScaledDimensions)
+        );
+    }
+
+    #[test]
+    fn visible_coded_and_storage_extents_are_not_conflated() {
+        let layout = FrameLayout::new(129, 129, JpuPixelFormat::Yuv422Horizontal, JpuScale::Eighth)
+            .expect("valid scaled layout");
+
+        assert_eq!((layout.visible.width, layout.visible.height), (17, 17));
+        assert_eq!((layout.coded.width, layout.coded.height), (18, 17));
+        assert_eq!((layout.storage.width, layout.storage.height), (18, 18));
+    }
+
+    #[test]
+    fn rejects_empty_and_overflowing_dimensions() {
+        assert_eq!(
+            FrameLayout::new(0, 64, JpuPixelFormat::Grayscale, JpuScale::Full),
+            Err(FrameLayoutError::ZeroDimension)
+        );
+        assert_eq!(
+            FrameLayout::new(u32::MAX, u32::MAX, JpuPixelFormat::Yuv420, JpuScale::Full),
+            Err(FrameLayoutError::DimensionOverflow)
+        );
+        assert_eq!(
+            FrameLayout::new(u16::MAX as u32, 128, JpuPixelFormat::Yuv420, JpuScale::Full,),
+            Err(FrameLayoutError::DimensionOverflow)
+        );
+    }
+
+    #[test]
+    fn scale_factors_and_register_modes_are_explicit() {
+        let cases = [
+            (JpuScale::Full, 1, 0),
+            (JpuScale::Half, 2, 1),
+            (JpuScale::Quarter, 4, 2),
+            (JpuScale::Eighth, 8, 3),
+        ];
+
+        for (scale, factor, mode) in cases {
+            assert_eq!(scale.factor(), factor);
+            assert_eq!(scale.register_mode(), mode);
+        }
+    }
+}

--- a/drivers/vpu/sg200x-jpu/src/lib.rs
+++ b/drivers/vpu/sg200x-jpu/src/lib.rs
@@ -1,0 +1,18 @@
+//! SG200x JPEG Processing Unit driver.
+//!
+//! The driver owns its streaming DMA buffers, programs caller-mapped MMIO,
+//! and exposes checked planar layouts for full and scaled baseline JPEG
+//! decoding. A timeout permanently poisons the decoder and quarantines all
+//! buffers that the device may still own.
+
+#![no_std]
+#![deny(unsafe_op_in_unsafe_fn)]
+
+mod decoder;
+mod engine;
+mod header;
+mod layout;
+mod regs;
+
+pub use decoder::{DecodeResult, JpuCreateError, JpuDecodeError, JpuDecoder, JpuMmio};
+pub use layout::{Extent, FrameLayout, FrameLayoutError, JpuPixelFormat, JpuScale, PlaneLayout};

--- a/drivers/vpu/sg200x-jpu/src/regs.rs
+++ b/drivers/vpu/sg200x-jpu/src/regs.rs
@@ -1,0 +1,327 @@
+//! JPU MMIO registers and caller-addressed bring-up helpers.
+
+#![allow(dead_code)]
+
+use tock_registers::{
+    fields::FieldValue,
+    interfaces::{Readable, Writeable},
+    register_bitfields, register_structs,
+    registers::{ReadOnly, ReadWrite},
+};
+
+const TOP_DDR_ADDR_MODE_OFF: usize = 0x64;
+const TOP_CLK_JPEG_OFF: usize = 0x2008;
+const TOP_RST_JPEG_OFF: usize = 0x3000;
+
+const TOP_CLK_JPEG_ENABLE: u32 = 0x3300;
+const TOP_RST_JPEG_RELEASE_BIT: u32 = 1 << 4;
+const TOP_DDR_VD_REMAP_BIT: u32 = 1 << 24;
+const VC_BLOCK_ENABLE: u32 = 0x1F;
+const JPU_WARMUP_BBC_BASE: u32 = 0x8026_C000;
+const REGISTER_WAIT_POLLS: usize = 100_000;
+
+/// JPEG sampling formats written to the MCU and DPB registers.
+pub const FORMAT_420: u32 = 0;
+pub const FORMAT_422: u32 = 1;
+pub const FORMAT_224: u32 = 2;
+pub const FORMAT_444: u32 = 3;
+pub const FORMAT_400: u32 = 4;
+
+register_bitfields! [
+    u32,
+
+    pub VALUE32 [
+        VAL OFFSET(0) NUMBITS(32) []
+    ],
+
+    pub MJPEG_PIC_START [
+        START_PIC OFFSET(0) NUMBITS(1) [],
+        START_INIT OFFSET(1) NUMBITS(1) [],
+    ],
+
+    pub MJPEG_PIC_STATUS [
+        DONE OFFSET(0) NUMBITS(1) [],
+        ERROR OFFSET(1) NUMBITS(1) [],
+    ],
+
+    pub MJPEG_PIC_CTRL [
+        USER_HUFF_TAB OFFSET(6) NUMBITS(1) [],
+        HUFF_DC_IDX OFFSET(7) NUMBITS(3) [],
+        HUFF_AC_IDX OFFSET(10) NUMBITS(3) [],
+    ],
+
+    pub MJPEG_PIC_SIZE [
+        HEIGHT OFFSET(0) NUMBITS(16) [],
+        WIDTH OFFSET(16) NUMBITS(16) [],
+    ],
+
+    pub MJPEG_SCL_INFO [
+        ENABLE OFFSET(4) NUMBITS(1) [],
+        HORIZONTAL_MODE OFFSET(2) NUMBITS(2) [
+            Full = 0,
+            Half = 1,
+            Quarter = 2,
+            Eighth = 3
+        ],
+        VERTICAL_MODE OFFSET(0) NUMBITS(2) [
+            Full = 0,
+            Half = 1,
+            Quarter = 2,
+            Eighth = 3
+        ],
+    ],
+
+    pub MJPEG_BBC_STRM_CTRL [
+        PAGES OFFSET(0) NUMBITS(31) [],
+        END_FLAG OFFSET(31) NUMBITS(1) [],
+    ],
+
+    pub MJPEG_BBC_BUSY [
+        BUSY OFFSET(0) NUMBITS(1) [],
+    ],
+
+    pub MJPEG_HUFF_CTRL [
+        PHASE OFFSET(0) NUMBITS(12) [],
+    ],
+
+    pub MJPEG_QMAT_CTRL [
+        PHASE OFFSET(0) NUMBITS(8) [],
+    ],
+];
+
+register_structs! {
+    pub JpuRegisters {
+        (0x000 => pub pic_start: ReadWrite<u32, MJPEG_PIC_START::Register>),
+        (0x004 => pub pic_status: ReadWrite<u32, MJPEG_PIC_STATUS::Register>),
+        (0x008 => pub pic_errmb: ReadWrite<u32, VALUE32::Register>),
+        (0x00C => _reserved_pic_setmb),
+        (0x010 => pub pic_ctrl: ReadWrite<u32, MJPEG_PIC_CTRL::Register>),
+        (0x014 => pub pic_size: ReadWrite<u32, MJPEG_PIC_SIZE::Register>),
+        (0x018 => pub mcu_info: ReadWrite<u32, VALUE32::Register>),
+        (0x01C => pub rot_info: ReadWrite<u32, VALUE32::Register>),
+        (0x020 => pub scl_info: ReadWrite<u32, MJPEG_SCL_INFO::Register>),
+        (0x024 => _reserved_if_info),
+        (0x028 => pub clp_info: ReadWrite<u32, VALUE32::Register>),
+        (0x02C => pub op_info: ReadWrite<u32, VALUE32::Register>),
+        (0x030 => pub dpb_config: ReadWrite<u32, VALUE32::Register>),
+        (0x034 => pub dpb_base_y: ReadWrite<u32, VALUE32::Register>),
+        (0x038 => pub dpb_base_cb: ReadWrite<u32, VALUE32::Register>),
+        (0x03C => pub dpb_base_cr: ReadWrite<u32, VALUE32::Register>),
+        (0x040 => _reserved_dpb_extra: [u8; 0x24]),
+        (0x064 => pub dpb_ystride: ReadWrite<u32, VALUE32::Register>),
+        (0x068 => pub dpb_cstride: ReadWrite<u32, VALUE32::Register>),
+        (0x06C => _reserved_wresp: [u8; 0x14]),
+        (0x080 => pub huff_ctrl: ReadWrite<u32, MJPEG_HUFF_CTRL::Register>),
+        (0x084 => pub huff_addr: ReadWrite<u32, VALUE32::Register>),
+        (0x088 => pub huff_data: ReadWrite<u32, VALUE32::Register>),
+        (0x08C => _reserved_huff_pad),
+        (0x090 => pub qmat_ctrl: ReadWrite<u32, MJPEG_QMAT_CTRL::Register>),
+        (0x094 => _reserved_qmat_addr),
+        (0x098 => pub qmat_data: ReadWrite<u32, VALUE32::Register>),
+        (0x09C => _reserved_coef: [u8; 0x14]),
+        (0x0B0 => pub rst_intval: ReadWrite<u32, VALUE32::Register>),
+        (0x0B4 => pub rst_index: ReadWrite<u32, VALUE32::Register>),
+        (0x0B8 => pub rst_count: ReadWrite<u32, VALUE32::Register>),
+        (0x0BC => _reserved_rst_pad: [u8; 0x34]),
+        (0x0F0 => pub dpcm_diff_y: ReadWrite<u32, VALUE32::Register>),
+        (0x0F4 => pub dpcm_diff_cb: ReadWrite<u32, VALUE32::Register>),
+        (0x0F8 => pub dpcm_diff_cr: ReadWrite<u32, VALUE32::Register>),
+        (0x0FC => _reserved_dpcm_pad),
+        (0x100 => pub gbu_ctrl: ReadWrite<u32, VALUE32::Register>),
+        (0x104 => _reserved_gbu_mid: [u8; 0x10]),
+        (0x114 => pub gbu_wd_ptr: ReadWrite<u32, VALUE32::Register>),
+        (0x118 => pub gbu_tt_cnt: ReadWrite<u32, VALUE32::Register>),
+        (0x11C => pub gbu_tt_cnt_h: ReadWrite<u32, VALUE32::Register>),
+        (0x120 => _reserved_gbu_pbit: [u8; 0x20]),
+        (0x140 => pub gbu_bbsr: ReadWrite<u32, VALUE32::Register>),
+        (0x144 => pub gbu_bber: ReadWrite<u32, VALUE32::Register>),
+        (0x148 => pub gbu_bbir: ReadWrite<u32, VALUE32::Register>),
+        (0x14C => pub gbu_bbhr: ReadWrite<u32, VALUE32::Register>),
+        (0x150 => _reserved_gbu_tail: [u8; 0x10]),
+        (0x160 => pub gbu_ff_rptr: ReadWrite<u32, VALUE32::Register>),
+        (0x164 => _reserved_bbc_gap: [u8; 0xA4]),
+        (0x208 => pub bbc_end_addr: ReadWrite<u32, VALUE32::Register>),
+        (0x20C => pub bbc_wr_ptr: ReadWrite<u32, VALUE32::Register>),
+        (0x210 => pub bbc_rd_ptr: ReadWrite<u32, VALUE32::Register>),
+        (0x214 => pub bbc_ext_addr: ReadWrite<u32, VALUE32::Register>),
+        (0x218 => pub bbc_int_addr: ReadWrite<u32, VALUE32::Register>),
+        (0x21C => pub bbc_data_cnt: ReadWrite<u32, VALUE32::Register>),
+        (0x220 => pub bbc_command: ReadWrite<u32, VALUE32::Register>),
+        (0x224 => pub bbc_busy: ReadOnly<u32, MJPEG_BBC_BUSY::Register>),
+        (0x228 => pub bbc_ctrl: ReadWrite<u32, VALUE32::Register>),
+        (0x22C => pub bbc_cur_pos: ReadWrite<u32, VALUE32::Register>),
+        (0x230 => pub bbc_bas_addr: ReadWrite<u32, VALUE32::Register>),
+        (0x234 => pub bbc_strm_ctrl: ReadWrite<u32, MJPEG_BBC_STRM_CTRL::Register>),
+        (0x238 => @END),
+    }
+}
+
+/// Returns a register view over a caller-mapped JPU MMIO base.
+#[inline]
+pub fn jpu_regs_at(jpu_base: usize) -> &'static JpuRegisters {
+    // SAFETY: JpuDecoder's constructor requires a valid mapped MMIO base.
+    unsafe { &*(jpu_base as *const JpuRegisters) }
+}
+
+#[inline]
+fn mmio_read32(addr: usize) -> u32 {
+    // SAFETY: the address is derived from a caller-validated MMIO base.
+    unsafe { core::ptr::read_volatile(addr as *const u32) }
+}
+
+#[inline]
+fn mmio_write32(addr: usize, value: u32) {
+    // SAFETY: the address is derived from a caller-validated MMIO base.
+    unsafe { core::ptr::write_volatile(addr as *mut u32, value) }
+}
+
+#[inline]
+fn mmio_modify32(addr: usize, update: impl FnOnce(u32) -> u32) {
+    let value = mmio_read32(addr);
+    mmio_write32(addr, update(value));
+}
+
+/// Enables the JPEG clock, reset, DDR remap, and VC block, then resets the JPU.
+pub fn hardware_init_at(
+    jpu_base: usize,
+    top_base: usize,
+    vc_base: usize,
+) -> Result<(), &'static str> {
+    mmio_modify32(top_base + TOP_CLK_JPEG_OFF, |v| v | TOP_CLK_JPEG_ENABLE);
+    mmio_modify32(top_base + TOP_RST_JPEG_OFF, |v| {
+        v | TOP_RST_JPEG_RELEASE_BIT
+    });
+    mmio_modify32(top_base + TOP_DDR_ADDR_MODE_OFF, |v| {
+        v | TOP_DDR_VD_REMAP_BIT
+    });
+    mmio_modify32(vc_base, |v| v | VC_BLOCK_ENABLE);
+    let _ = mmio_read32(vc_base);
+
+    let regs = jpu_regs_at(jpu_base);
+    let _ = regs.pic_status.get();
+    regs.bbc_bas_addr
+        .write(VALUE32::VAL.val(JPU_WARMUP_BBC_BASE));
+    let _ = regs.bbc_bas_addr.get();
+
+    wait_sw_reset_done_at(jpu_base)
+}
+
+#[inline]
+pub fn clear_pic_status_at(jpu_base: usize, status: u32) {
+    jpu_regs_at(jpu_base).pic_status.set(status);
+}
+
+pub fn wait_sw_reset_done_at(jpu_base: usize) -> Result<(), &'static str> {
+    let regs = jpu_regs_at(jpu_base);
+    regs.pic_start.write(MJPEG_PIC_START::START_INIT::SET);
+    if poll_until(REGISTER_WAIT_POLLS, || {
+        !regs.pic_start.is_set(MJPEG_PIC_START::START_INIT)
+    }) {
+        Ok(())
+    } else {
+        Err("JPU software reset timed out")
+    }
+}
+
+/// Encode one isotropic scale mode for `MJPEG_SCL_INFO`.
+pub(crate) fn scl_info_value(
+    scale: super::layout::JpuScale,
+) -> FieldValue<u32, MJPEG_SCL_INFO::Register> {
+    match scale {
+        super::layout::JpuScale::Full => {
+            MJPEG_SCL_INFO::ENABLE::CLEAR
+                + MJPEG_SCL_INFO::HORIZONTAL_MODE::Full
+                + MJPEG_SCL_INFO::VERTICAL_MODE::Full
+        }
+        super::layout::JpuScale::Half => {
+            MJPEG_SCL_INFO::ENABLE::SET
+                + MJPEG_SCL_INFO::HORIZONTAL_MODE::Half
+                + MJPEG_SCL_INFO::VERTICAL_MODE::Half
+        }
+        super::layout::JpuScale::Quarter => {
+            MJPEG_SCL_INFO::ENABLE::SET
+                + MJPEG_SCL_INFO::HORIZONTAL_MODE::Quarter
+                + MJPEG_SCL_INFO::VERTICAL_MODE::Quarter
+        }
+        super::layout::JpuScale::Eighth => {
+            MJPEG_SCL_INFO::ENABLE::SET
+                + MJPEG_SCL_INFO::HORIZONTAL_MODE::Eighth
+                + MJPEG_SCL_INFO::VERTICAL_MODE::Eighth
+        }
+    }
+}
+
+pub fn wait_bbc_idle_at(jpu_base: usize) -> Result<(), &'static str> {
+    let regs = jpu_regs_at(jpu_base);
+    if poll_until(REGISTER_WAIT_POLLS, || {
+        !regs.bbc_busy.is_set(MJPEG_BBC_BUSY::BUSY)
+    }) {
+        Ok(())
+    } else {
+        Err("JPU BBC did not become idle")
+    }
+}
+
+fn poll_until(max_polls: usize, mut ready: impl FnMut() -> bool) -> bool {
+    for _ in 0..max_polls {
+        if ready() {
+            return true;
+        }
+        core::hint::spin_loop();
+    }
+    false
+}
+
+#[inline]
+pub fn pic_ctrl_value(dc_idx: u32, ac_idx: u32) -> u32 {
+    (MJPEG_PIC_CTRL::HUFF_AC_IDX.val(ac_idx)
+        + MJPEG_PIC_CTRL::HUFF_DC_IDX.val(dc_idx)
+        + MJPEG_PIC_CTRL::USER_HUFF_TAB::SET)
+        .into()
+}
+
+#[inline]
+pub fn bbc_strm_ctrl_value(pages: u32) -> u32 {
+    (MJPEG_BBC_STRM_CTRL::END_FLAG::SET + MJPEG_BBC_STRM_CTRL::PAGES.val(pages)).into()
+}
+
+pub const HUFF_PHASE_MIN: u32 = 0x003;
+pub const HUFF_PHASE_MAX: u32 = 0x403;
+pub const HUFF_PHASE_PTR: u32 = 0x803;
+pub const HUFF_PHASE_VAL: u32 = 0xC03;
+pub const HUFF_ADDR_MAX: u32 = 0x440;
+pub const HUFF_ADDR_PTR: u32 = 0x880;
+
+pub const QMAT_PHASE_Y: u32 = 0x03;
+pub const QMAT_PHASE_CB: u32 = 0x43;
+pub const QMAT_PHASE_CR: u32 = 0x83;
+
+#[cfg(test)]
+mod tests {
+    use super::{poll_until, scl_info_value};
+    use crate::JpuScale;
+
+    #[test]
+    fn bounded_register_poll_distinguishes_ready_and_timeout() {
+        let mut attempts = 0;
+        assert!(poll_until(3, || {
+            attempts += 1;
+            attempts == 3
+        }));
+        assert!(!poll_until(3, || false));
+    }
+
+    #[test]
+    fn scale_info_encoding_matches_the_documented_hardware_modes() {
+        let cases = [
+            (JpuScale::Full, 0x00),
+            (JpuScale::Half, 0x15),
+            (JpuScale::Quarter, 0x1a),
+            (JpuScale::Eighth, 0x1f),
+        ];
+
+        for (scale, expected) in cases {
+            assert_eq!(u32::from(scl_info_value(scale)), expected);
+        }
+    }
+}

--- a/os/StarryOS/configs/board/aka-00-sg2002.toml
+++ b/os/StarryOS/configs/board/aka-00-sg2002.toml
@@ -1,5 +1,6 @@
 features = [
   "starry-kernel/sg2002",
+  "starry-kernel/sg2002-cvi-usb-camera",
   "axplat-dyn/thead-mae",
   "ax-driver/cvsd",
   "ax-driver/serial",

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -48,7 +48,7 @@ sg2002-wifi = [
     "sg2002",
     "ax-runtime/aic8800-wifi",
 ]
-sg2002-cvi-usb-camera = ["sg2002"]
+sg2002-cvi-usb-camera = ["sg2002", "dep:sg200x-jpu"]
 stack-guard-page = ["ax-runtime/stack-guard-page"]
 stack-protector = ["ax-runtime/stack-protector"]
 axtest = []
@@ -155,6 +155,7 @@ kmod-loader = "0.3.1"
 lwprintf-rs = "0.3"
 some-serial = { workspace = true, optional = true }
 sg200x-bsp = { workspace = true, optional = true, features = ["c906", "cv182x-host"] }
+sg200x-jpu = { workspace = true, optional = true }
 # 0.10 to match sg200x-bsp 0.7.x's internal tock-registers; the Writeable trait
 # must come from the same version as sg200x-bsp's ReadWrite types.
 tock-registers = { version = "0.10", optional = true }

--- a/os/StarryOS/kernel/src/pseudofs/dev/cvi_usb_camera.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/cvi_usb_camera.rs
@@ -7,10 +7,6 @@ use ax_sync::Mutex;
 use axfs_ng_vfs::{NodeFlags, VfsResult};
 use sg200x_bsp::{
     gpio::{Direction, GPIO, GPIO1_BASE},
-    jpu::{
-        JpuDecoder,
-        regs::{JPU_REG_BASE, VC_REG_BASE},
-    },
     pinmux::{FMUX_USB_VBUS_DET, Pinmux},
     soc::{
         CLKGEN_BASE, CV182X_USB2_PHY_BASE, DWC2_BASE, FMUX_BASE, IOBLK_BASE, IOBLK_GRTC_BASE,
@@ -23,6 +19,7 @@ use sg200x_bsp::{
         host::{self, UvcEnumerated, dwc2, dwc2::ep0 as dwc2_ep0},
     },
 };
+use sg200x_jpu::{JpuDecoder, JpuMmio, JpuScale};
 use starry_vm::{VmMutPtr, vm_write_slice};
 use tock_registers::interfaces::Writeable;
 
@@ -40,6 +37,8 @@ const TOP_MMIO_SIZE: usize = 0x4000;
 /// GPIO, DWC2 controller, USB2 PHY). Each block's registers fit within one 4K
 /// page; FMUX/IOBLK share a page so their mappings coincide (idempotent).
 const REG_MMIO_SIZE: usize = 0x1000;
+const JPU_REG_BASE: usize = 0x0B00_0000;
+const VC_REG_BASE: usize = 0x0B03_0000;
 
 /// Map a physical MMIO region into the kernel address space and return its
 /// virtual base. Unlike `phys_to_virt`, this works on dynamic platforms where
@@ -81,10 +80,6 @@ struct UsbCameraSession {
 struct UsbCameraState {
     session: Option<UsbCameraSession>,
     jpu: Option<JpuDecoder>,
-}
-
-fn jpu_dma_to_phys(v: usize) -> usize {
-    virt_to_phys(VirtAddr::from(v)).as_usize()
 }
 
 pub struct CviCamera {
@@ -328,8 +323,9 @@ impl UsbCameraState {
             let jpu_v = iomap_usize(JPU_REG_BASE, REG_MMIO_SIZE);
             let top_v = iomap_usize(TOP_BASE, TOP_MMIO_SIZE);
             let vc_v = iomap_usize(VC_REG_BASE, REG_MMIO_SIZE);
+            let dma = axklib::dma::device_with_mask(u32::MAX as u64);
             let decoder = unsafe {
-                JpuDecoder::new_at(jpu_v, top_v, vc_v, jpu_dma_to_phys).map_err(|e| {
+                JpuDecoder::new(JpuMmio::new(jpu_v, top_v, vc_v), dma).map_err(|e| {
                     warn!("cvi-camera: JPU init failed: {e}");
                     AxError::Io
                 })?
@@ -339,20 +335,26 @@ impl UsbCameraState {
         Ok(self.jpu.as_mut().unwrap())
     }
 
-    fn yuv_frame(&mut self) -> VfsResult<&'static [u8]> {
+    fn write_yuv_frame(&mut self, destination: *mut u8, scale: JpuScale) -> VfsResult<usize> {
         let jpeg = self.frame()?;
         let jpu = self.ensure_jpu()?;
-        let result = jpu.decode(jpeg).map_err(|e| {
+        let result = jpu.decode_scaled(jpeg, scale).map_err(|e| {
             warn!("cvi-camera: JPU decode failed: {e}");
             AxError::Io
         })?;
         info!(
-            "cvi-camera: JPU decode OK {}x{} yuv={} bytes",
+            "cvi-camera: JPU decode OK scale={:?} visible={}x{} storage={}x{} y_stride={} yuv={} \
+             bytes",
+            result.layout.scale,
             result.width,
             result.height,
+            result.layout.storage.width,
+            result.layout.storage.height,
+            result.layout.y.stride,
             result.yuv_data.len()
         );
-        Ok(result.yuv_data)
+        vm_write_slice(destination, result.yuv_data)?;
+        Ok(result.yuv_data.len())
     }
 }
 
@@ -397,11 +399,10 @@ impl DeviceOps for CviCamera {
                 vm_write_slice(arg as *mut u8, frame)?;
                 Ok(frame.len())
             }
-            CVI_CAMERA_IOCTL_GET_YUV_FRAME => {
-                let yuv = self.state.lock().yuv_frame()?;
-                vm_write_slice(arg as *mut u8, yuv)?;
-                Ok(yuv.len())
-            }
+            CVI_CAMERA_IOCTL_GET_YUV_FRAME => self
+                .state
+                .lock()
+                .write_yuv_frame(arg as *mut u8, JpuScale::Full),
             _ => Err(AxError::InvalidInput),
         }
     }


### PR DESCRIPTION
## 修改

- 将 SG2002 摄像头使用的 JPU 代码整理为仓库内的 `sg200x-jpu` `no_std` crate。
- 支持 baseline JPEG 的 `Full`、`Half`、`Quarter` 和 `Eighth` 解码，并返回各平面的尺寸、偏移、stride 和长度。
- 使用 `dma-api` 管理输入、输出缓冲区，补充地址、布局和硬件等待的边界检查。
- StarryOS SG2002 摄像头改用仓库内驱动，AKA-00 配置启用对应 feature。

现有 `CVI_CAMERA_IOCTL_GET_YUV_FRAME` 仍使用 `Full`，用户态接口和输出布局不变。

寄存器定义和 JPEG parser 整理自 `yfblock/sg200x-bsp` 0.7.1，保留原 MIT notice。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p sg200x-jpu`
- `cargo xtask clippy --package sg200x-jpu`
- `cargo package -p sg200x-jpu --allow-dirty --no-verify`
- `cargo xtask starry build --config os/StarryOS/configs/board/aka-00-sg2002.toml`
- 仓库内 3 张 JPEG 测试图片均可正确解析 header

## 待验证

目前没有 SG2002 板卡。非 `Full` 模式尚未验证实际输出和性能，接入用户态前还需要在板上核对图像内容、plane 布局和耗时。
