### PR TITLE
refactor(axvm-types): introduce backend errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,9 +1533,9 @@ name = "axvm-types"
 version = "0.7.0"
 dependencies = [
  "ax-cpumask",
- "ax-errno 0.6.1",
  "ax-memory-addr",
  "bitflags 2.13.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/virtualization/axdevice_base/src/lib.rs
+++ b/virtualization/axdevice_base/src/lib.rs
@@ -89,6 +89,8 @@ mod device;
 use alloc::{string::String, sync::Arc, vec::Vec};
 use core::any::Any;
 
+#[doc(hidden)]
+pub use ax_errno::AxError;
 pub use ax_errno::AxResult;
 pub use axvm_types::{
     EmulatedDeviceType as EmuDeviceType, GuestPhysAddr, GuestPhysAddrRange, InterruptTriggerMode,

--- a/virtualization/axvm-types/Cargo.toml
+++ b/virtualization/axvm-types/Cargo.toml
@@ -11,6 +11,6 @@ description = "Shared base types for AxVM virtualization components"
 
 [dependencies]
 ax-cpumask = { workspace = true }
-ax-errno = { workspace = true }
 ax-memory-addr = { workspace = true }
 bitflags = { workspace = true }
+thiserror = { workspace = true }

--- a/virtualization/axvm-types/src/error.rs
+++ b/virtualization/axvm-types/src/error.rs
@@ -1,0 +1,41 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Architecture backend error contract shared with AxVM.
+
+/// Result returned by architecture virtualization backends.
+pub type VmBackendResult<T = ()> = Result<T, VmBackendError>;
+
+/// Failures reported by an architecture virtualization backend.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum VmBackendError {
+    /// The backend rejected a caller-provided value.
+    #[error("invalid virtualization backend input")]
+    InvalidInput,
+    /// The backend received malformed or inconsistent architecture data.
+    #[error("invalid virtualization backend data")]
+    InvalidData,
+    /// The backend state does not permit the requested operation.
+    #[error("invalid virtualization backend state")]
+    InvalidState,
+    /// The backend does not implement the requested operation.
+    #[error("unsupported virtualization backend operation")]
+    Unsupported,
+    /// The backend could not allocate the required memory.
+    #[error("virtualization backend memory allocation failed")]
+    OutOfMemory,
+    /// A backend resource is already owned or in use.
+    #[error("virtualization backend resource is busy")]
+    ResourceBusy,
+}

--- a/virtualization/axvm-types/src/lib.rs
+++ b/virtualization/axvm-types/src/lib.rs
@@ -21,10 +21,13 @@
 
 extern crate alloc;
 
+mod error;
+
 use alloc::{string::String, vec::Vec};
 use core::fmt::{Debug, Display, Formatter, LowerHex, UpperHex};
 
 use ax_memory_addr::{AddrRange, PhysAddr, VirtAddr, def_usize_addr, def_usize_addr_formatter};
+pub use error::{VmBackendError, VmBackendResult};
 
 bitflags::bitflags! {
     /// Generic memory mapping permissions and attributes exchanged between
@@ -138,12 +141,6 @@ pub type GuestVirtAddrRange = AddrRange<GuestVirtAddr>;
 
 /// Guest physical address range.
 pub type GuestPhysAddrRange = AddrRange<GuestPhysAddr>;
-
-/// Common AxVM result type.
-pub type AxVmResult<T = ()> = ax_errno::AxResult<T>;
-
-/// Common AxVM error type.
-pub type AxVmError = ax_errno::AxError;
 
 /// The width of a guest bus access.
 ///
@@ -424,19 +421,19 @@ pub trait VmArchVcpuOps: Sized {
     type Exit: Debug;
 
     /// Creates a new architecture-specific vCPU.
-    fn new(vm_id: VMId, vcpu_id: VCpuId, config: Self::CreateConfig) -> AxVmResult<Self>;
+    fn new(vm_id: VMId, vcpu_id: VCpuId, config: Self::CreateConfig) -> VmBackendResult<Self>;
     /// Sets the guest entry point.
-    fn set_entry(&mut self, entry: GuestPhysAddr) -> AxVmResult;
+    fn set_entry(&mut self, entry: GuestPhysAddr) -> VmBackendResult;
     /// Sets the nested page table selected by AxVM.
-    fn set_nested_page_table(&mut self, config: NestedPagingConfig) -> AxVmResult;
+    fn set_nested_page_table(&mut self, config: NestedPagingConfig) -> VmBackendResult;
     /// Completes architecture-specific setup.
-    fn setup(&mut self, config: Self::SetupConfig) -> AxVmResult;
+    fn setup(&mut self, config: Self::SetupConfig) -> VmBackendResult;
     /// Runs the vCPU until an architecture-specific VM exit.
-    fn run(&mut self) -> AxVmResult<Self::Exit>;
+    fn run(&mut self) -> VmBackendResult<Self::Exit>;
     /// Binds the vCPU to the current physical CPU.
-    fn bind(&mut self) -> AxVmResult;
+    fn bind(&mut self) -> VmBackendResult;
     /// Unbinds the vCPU from the current physical CPU.
-    fn unbind(&mut self) -> AxVmResult;
+    fn unbind(&mut self) -> VmBackendResult;
     /// Sets a general-purpose register.
     fn set_gpr(&mut self, reg: usize, val: usize);
     /// Decodes an architecture-specific memory fault as a legacy normalized
@@ -453,13 +450,13 @@ pub trait VmArchVcpuOps: Sized {
         None
     }
     /// Injects an interrupt into the vCPU.
-    fn inject_interrupt(&mut self, vector: usize) -> AxVmResult;
+    fn inject_interrupt(&mut self, vector: usize) -> VmBackendResult;
     /// Injects an interrupt with trigger-mode metadata.
     fn inject_interrupt_with_trigger(
         &mut self,
         vector: usize,
         trigger: InterruptTriggerMode,
-    ) -> AxVmResult {
+    ) -> VmBackendResult {
         debug_assert!(
             trigger == InterruptTriggerMode::EdgeTriggered,
             "level-triggered interrupt injection requires an architecture-specific implementation"
@@ -477,13 +474,13 @@ pub trait VmArchVcpuOps: Sized {
 /// Architecture-specific per-CPU virtualization state consumed by AxVM.
 pub trait VmArchPerCpuOps: Sized {
     /// Creates a new per-CPU state.
-    fn new(cpu_id: usize) -> AxVmResult<Self>;
+    fn new(cpu_id: usize) -> VmBackendResult<Self>;
     /// Whether virtualization is enabled on the current CPU.
     fn is_enabled(&self) -> bool;
     /// Enables virtualization on the current CPU.
-    fn hardware_enable(&mut self) -> AxVmResult;
+    fn hardware_enable(&mut self) -> VmBackendResult;
     /// Disables virtualization on the current CPU.
-    fn hardware_disable(&mut self) -> AxVmResult;
+    fn hardware_disable(&mut self) -> VmBackendResult;
     /// Returns the max guest page table levels supported by this architecture.
     fn max_guest_page_table_levels(&self) -> usize {
         4
@@ -747,7 +744,7 @@ mod tests {
     }
 
     impl VmArchPerCpuOps for MockPerCpu {
-        fn new(_cpu_id: usize) -> AxVmResult<Self> {
+        fn new(_cpu_id: usize) -> VmBackendResult<Self> {
             Ok(Self { enabled: false })
         }
 
@@ -755,12 +752,12 @@ mod tests {
             self.enabled
         }
 
-        fn hardware_enable(&mut self) -> AxVmResult {
+        fn hardware_enable(&mut self) -> VmBackendResult {
             self.enabled = true;
             Ok(())
         }
 
-        fn hardware_disable(&mut self) -> AxVmResult {
+        fn hardware_disable(&mut self) -> VmBackendResult {
             self.enabled = false;
             Ok(())
         }
@@ -778,37 +775,41 @@ mod tests {
         type SetupConfig = ();
         type Exit = MockExit;
 
-        fn new(_vm_id: VMId, _vcpu_id: VCpuId, _config: Self::CreateConfig) -> AxVmResult<Self> {
+        fn new(
+            _vm_id: VMId,
+            _vcpu_id: VCpuId,
+            _config: Self::CreateConfig,
+        ) -> VmBackendResult<Self> {
             Ok(Self)
         }
 
-        fn set_entry(&mut self, _entry: GuestPhysAddr) -> AxVmResult {
+        fn set_entry(&mut self, _entry: GuestPhysAddr) -> VmBackendResult {
             Ok(())
         }
 
-        fn set_nested_page_table(&mut self, _config: NestedPagingConfig) -> AxVmResult {
+        fn set_nested_page_table(&mut self, _config: NestedPagingConfig) -> VmBackendResult {
             Ok(())
         }
 
-        fn setup(&mut self, _config: Self::SetupConfig) -> AxVmResult {
+        fn setup(&mut self, _config: Self::SetupConfig) -> VmBackendResult {
             Ok(())
         }
 
-        fn run(&mut self) -> AxVmResult<Self::Exit> {
+        fn run(&mut self) -> VmBackendResult<Self::Exit> {
             Ok(MockExit::SysRegRead { reg: 2 })
         }
 
-        fn bind(&mut self) -> AxVmResult {
+        fn bind(&mut self) -> VmBackendResult {
             Ok(())
         }
 
-        fn unbind(&mut self) -> AxVmResult {
+        fn unbind(&mut self) -> VmBackendResult {
             Ok(())
         }
 
         fn set_gpr(&mut self, _reg: usize, _val: usize) {}
 
-        fn inject_interrupt(&mut self, _vector: usize) -> AxVmResult {
+        fn inject_interrupt(&mut self, _vector: usize) -> VmBackendResult {
             Ok(())
         }
 

--- a/virtualization/axvm-types/tests/error_contract.rs
+++ b/virtualization/axvm-types/tests/error_contract.rs
@@ -1,0 +1,73 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axvm_types::{VmBackendError, VmBackendResult};
+
+#[test]
+fn backend_errors_are_matchable_and_descriptive() {
+    let result: VmBackendResult = Err(VmBackendError::ResourceBusy);
+
+    assert_eq!(result, Err(VmBackendError::ResourceBusy));
+    assert_eq!(
+        VmBackendError::InvalidState.to_string(),
+        "invalid virtualization backend state"
+    );
+    assert_eq!(
+        VmBackendError::OutOfMemory.to_string(),
+        "virtualization backend memory allocation failed"
+    );
+}
+
+#[test]
+fn backend_contract_uses_typed_errors() {
+    let manifest = include_str!("../Cargo.toml");
+    let crate_root = include_str!("../src/lib.rs");
+
+    assert!(!manifest.contains("ax-errno"));
+    assert!(manifest.contains("thiserror = { workspace = true }"));
+    assert!(crate_root.contains("pub use error::{VmBackendError, VmBackendResult};"));
+    assert!(!crate_root.contains("pub type AxVmError"));
+    assert!(!crate_root.contains("pub type AxVmResult"));
+}
+
+#[test]
+fn backend_sources_do_not_name_axerrno() {
+    let source_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut pending = vec![source_root];
+    let mut violations = Vec::new();
+
+    while let Some(path) = pending.pop() {
+        for entry in std::fs::read_dir(&path).expect("axvm-types source directory must be readable")
+        {
+            let entry = entry.expect("axvm-types source entry must be readable");
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            if path.extension().is_some_and(|extension| extension == "rs") {
+                let source =
+                    std::fs::read_to_string(&path).expect("axvm-types source must be readable");
+                if source.contains("ax_errno") {
+                    violations.push(path);
+                }
+            }
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "axvm-types sources must not name ax_errno directly: {violations:?}"
+    );
+}

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -15,8 +15,8 @@ use arm_vgic::host::ArmVgicHostIf;
 use ax_crate_interface::impl_interface;
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axvm_types::{
-    AccessWidth, AxVmError as BackendError, AxVmResult as BackendResult, GuestPhysAddr,
-    NestedPagingConfig, SysRegAddr, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps,
+    AccessWidth, GuestPhysAddr, NestedPagingConfig, SysRegAddr, VCpuId, VMId, VmArchPerCpuOps,
+    VmArchVcpuOps, VmBackendError as BackendError, VmBackendResult as BackendResult,
 };
 
 use super::{ArchOps, BoundVcpuExit, HypercallExit, MmioReadExit, MmioWriteExit, VcpuRunAction};
@@ -297,14 +297,14 @@ impl VmArchPerCpuOps for AxvmArmPerCpu {
 }
 
 fn arm_result<T>(result: ArmVcpuResult<T>) -> BackendResult<T> {
-    result.map_err(arm_error_to_ax)
+    result.map_err(arm_error_to_backend)
 }
 
-fn arm_error_to_ax(err: ArmVcpuError) -> BackendError {
+fn arm_error_to_backend(err: ArmVcpuError) -> BackendError {
     match err {
         ArmVcpuError::InvalidInput => BackendError::InvalidInput,
         ArmVcpuError::Unsupported => BackendError::Unsupported,
-        ArmVcpuError::BadState => BackendError::BadState,
+        ArmVcpuError::BadState => BackendError::InvalidState,
     }
 }
 
@@ -343,18 +343,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn converts_arm_vcpu_errors_to_ax_errors() {
+    fn converts_arm_vcpu_errors_to_backend_errors() {
         assert_eq!(
-            arm_error_to_ax(ArmVcpuError::InvalidInput),
+            arm_error_to_backend(ArmVcpuError::InvalidInput),
             BackendError::InvalidInput
         );
         assert_eq!(
-            arm_error_to_ax(ArmVcpuError::Unsupported),
+            arm_error_to_backend(ArmVcpuError::Unsupported),
             BackendError::Unsupported
         );
         assert_eq!(
-            arm_error_to_ax(ArmVcpuError::BadState),
-            BackendError::BadState
+            arm_error_to_backend(ArmVcpuError::BadState),
+            BackendError::InvalidState
         );
     }
 

--- a/virtualization/axvm/src/arch/loongarch64/boot/probe.rs
+++ b/virtualization/axvm/src/arch/loongarch64/boot/probe.rs
@@ -95,7 +95,7 @@ struct HostResources {
 
 fn host_acpi_resources(
     acpi: &ax_driver::probe::acpi::System,
-) -> axvm_types::AxVmResult<HostResources> {
+) -> axvm_types::VmBackendResult<HostResources> {
     let defaults = QemuVirtDefaults::new();
     let interrupt = acpi
         .routing()

--- a/virtualization/axvm/src/arch/loongarch64/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/mod.rs
@@ -3,8 +3,8 @@ use core::time::Duration;
 
 use ax_memory_addr::VirtAddr;
 use axvm_types::{
-    AccessWidth, AxVmError as BackendError, AxVmResult as BackendResult, GuestPhysAddr,
-    MappingFlags, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps,
+    AccessWidth, GuestPhysAddr, MappingFlags, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps,
+    VmArchVcpuOps, VmBackendError as BackendError, VmBackendResult as BackendResult,
 };
 use loongarch_vcpu::{
     LoongArchAccessFlags, LoongArchAccessWidth, LoongArchGuestPhysAddr, LoongArchHostOps,
@@ -417,14 +417,14 @@ impl VmArchPerCpuOps for AxvmLoongArchPerCpu {
 }
 
 fn loongarch_result<T>(result: LoongArchVcpuResult<T>) -> BackendResult<T> {
-    result.map_err(loongarch_error_to_ax)
+    result.map_err(loongarch_error_to_backend)
 }
 
-fn loongarch_error_to_ax(err: LoongArchVcpuError) -> BackendError {
+fn loongarch_error_to_backend(err: LoongArchVcpuError) -> BackendError {
     match err {
         LoongArchVcpuError::InvalidInput => BackendError::InvalidInput,
         LoongArchVcpuError::Unsupported => BackendError::Unsupported,
-        LoongArchVcpuError::BadState => BackendError::BadState,
+        LoongArchVcpuError::BadState => BackendError::InvalidState,
     }
 }
 
@@ -509,18 +509,18 @@ mod tests {
     }
 
     #[test]
-    fn converts_loongarch_vcpu_errors_to_ax_errors() {
+    fn converts_loongarch_vcpu_errors_to_backend_errors() {
         assert_eq!(
-            loongarch_error_to_ax(LoongArchVcpuError::InvalidInput),
+            loongarch_error_to_backend(LoongArchVcpuError::InvalidInput),
             BackendError::InvalidInput
         );
         assert_eq!(
-            loongarch_error_to_ax(LoongArchVcpuError::Unsupported),
+            loongarch_error_to_backend(LoongArchVcpuError::Unsupported),
             BackendError::Unsupported
         );
         assert_eq!(
-            loongarch_error_to_ax(LoongArchVcpuError::BadState),
-            BackendError::BadState
+            loongarch_error_to_backend(LoongArchVcpuError::BadState),
+            BackendError::InvalidState
         );
     }
 

--- a/virtualization/axvm/src/arch/riscv64/irq.rs
+++ b/virtualization/axvm/src/arch/riscv64/irq.rs
@@ -20,10 +20,8 @@ use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceFactoryRegistry, DeviceRegistration,
     MmioDeviceAdapter,
 };
-use axdevice_base::{AxResult as DeviceResult, IrqLineId, IrqSink};
-use axvm_types::{
-    AxVmError as BackendError, EmulatedDeviceConfig, EmulatedDeviceType, VMInterruptMode,
-};
+use axdevice_base::{AxError as DeviceError, AxResult as DeviceResult, IrqLineId, IrqSink};
+use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, VMInterruptMode};
 use riscv_vplic::{
     PLIC_CONTEXT_CLAIM_COMPLETE_OFFSET, PLIC_CONTEXT_CTRL_OFFSET, PLIC_CONTEXT_STRIDE, VPlicGlobal,
 };
@@ -69,7 +67,7 @@ impl DeviceFactory for RiscvPlicFactory {
             || config.length != self.length
             || config.cfg_list.as_slice() != [self.contexts_num]
         {
-            return Err(BackendError::InvalidInput);
+            return Err(DeviceError::InvalidInput);
         }
         Ok(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(self.vplic.clone())).into())
     }

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -3,9 +3,9 @@ use alloc::vec::Vec;
 use ax_crate_interface::impl_interface;
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axvm_types::{
-    AccessWidth, AxVmError as BackendError, AxVmResult as BackendResult, GuestPhysAddr,
-    MappingFlags, NestedPagingConfig, VCpuId, VMId, VMInterruptMode, VmArchPerCpuOps,
-    VmArchVcpuOps,
+    AccessWidth, GuestPhysAddr, MappingFlags, NestedPagingConfig, VCpuId, VMId, VMInterruptMode,
+    VmArchPerCpuOps, VmArchVcpuOps, VmBackendError as BackendError,
+    VmBackendResult as BackendResult,
 };
 use riscv_vcpu::{
     GprIndex as RiscvGprIndex, RiscvAccessFlags, RiscvAccessWidth, RiscvGuestPhysAddr,
@@ -362,14 +362,14 @@ impl VmArchPerCpuOps for AxvmRiscvPerCpu {
 }
 
 fn riscv_result<T>(result: RiscvVcpuResult<T>) -> BackendResult<T> {
-    result.map_err(riscv_error_to_ax)
+    result.map_err(riscv_error_to_backend)
 }
 
-fn riscv_error_to_ax(err: RiscvVcpuError) -> BackendError {
+fn riscv_error_to_backend(err: RiscvVcpuError) -> BackendError {
     match err {
         RiscvVcpuError::InvalidInput => BackendError::InvalidInput,
         RiscvVcpuError::Unsupported => BackendError::Unsupported,
-        RiscvVcpuError::BadState => BackendError::BadState,
+        RiscvVcpuError::BadState => BackendError::InvalidState,
         RiscvVcpuError::InvalidTrap
         | RiscvVcpuError::DecodeFailed
         | RiscvVcpuError::GuestMemoryFault => BackendError::InvalidData,
@@ -476,21 +476,21 @@ mod tests {
     }
 
     #[test]
-    fn converts_riscv_vcpu_errors_to_ax_errors() {
+    fn converts_riscv_vcpu_errors_to_backend_errors() {
         assert_eq!(
-            riscv_error_to_ax(RiscvVcpuError::InvalidInput),
+            riscv_error_to_backend(RiscvVcpuError::InvalidInput),
             BackendError::InvalidInput
         );
         assert_eq!(
-            riscv_error_to_ax(RiscvVcpuError::Unsupported),
+            riscv_error_to_backend(RiscvVcpuError::Unsupported),
             BackendError::Unsupported
         );
         assert_eq!(
-            riscv_error_to_ax(RiscvVcpuError::BadState),
-            BackendError::BadState
+            riscv_error_to_backend(RiscvVcpuError::BadState),
+            BackendError::InvalidState
         );
         assert_eq!(
-            riscv_error_to_ax(RiscvVcpuError::DecodeFailed),
+            riscv_error_to_backend(RiscvVcpuError::DecodeFailed),
             BackendError::InvalidData
         );
     }

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -7,9 +7,9 @@ use alloc::{boxed::Box, sync::Arc};
 use core::{arch::asm, time::Duration};
 
 use axvm_types::{
-    AccessWidth, AxVmError as BackendError, AxVmResult as BackendResult, EmulatedDeviceConfig,
-    EmulatedDeviceType, GuestPhysAddr, InterruptTriggerMode, MappingFlags, NestedPagingConfig,
-    Port, SysRegAddr, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps,
+    AccessWidth, EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, InterruptTriggerMode,
+    MappingFlags, NestedPagingConfig, Port, SysRegAddr, VCpuId, VMId, VmArchPerCpuOps,
+    VmArchVcpuOps, VmBackendError as BackendError, VmBackendResult as BackendResult,
 };
 use x86_vcpu::{
     X86AccessFlags, X86AccessWidth, X86GuestPhysAddr, X86HostOps, X86HostPhysAddr, X86HostVirtAddr,
@@ -518,16 +518,16 @@ fn handle_x86_nested_page_fault(
 }
 
 fn x86_result<T>(result: X86VcpuResult<T>) -> BackendResult<T> {
-    result.map_err(x86_error_to_ax)
+    result.map_err(x86_error_to_backend)
 }
 
-fn x86_error_to_ax(err: X86VcpuError) -> BackendError {
+fn x86_error_to_backend(err: X86VcpuError) -> BackendError {
     match err {
         X86VcpuError::InvalidInput => BackendError::InvalidInput,
         X86VcpuError::InvalidData => BackendError::InvalidData,
         X86VcpuError::Unsupported => BackendError::Unsupported,
-        X86VcpuError::BadState => BackendError::BadState,
-        X86VcpuError::NoMemory => BackendError::NoMemory,
+        X86VcpuError::BadState => BackendError::InvalidState,
+        X86VcpuError::NoMemory => BackendError::OutOfMemory,
         X86VcpuError::ResourceBusy => BackendError::ResourceBusy,
     }
 }
@@ -625,17 +625,17 @@ mod tests {
     }
 
     #[test]
-    fn converts_x86_vcpu_errors_to_ax_errors() {
+    fn converts_x86_vcpu_errors_to_backend_errors() {
         assert_eq!(
-            x86_error_to_ax(X86VcpuError::InvalidInput),
+            x86_error_to_backend(X86VcpuError::InvalidInput),
             BackendError::InvalidInput
         );
         assert_eq!(
-            x86_error_to_ax(X86VcpuError::NoMemory),
-            BackendError::NoMemory
+            x86_error_to_backend(X86VcpuError::NoMemory),
+            BackendError::OutOfMemory
         );
         assert_eq!(
-            x86_error_to_ax(X86VcpuError::ResourceBusy),
+            x86_error_to_backend(X86VcpuError::ResourceBusy),
             BackendError::ResourceBusy
         );
     }

--- a/virtualization/axvm/src/arch/x86_64/port.rs
+++ b/virtualization/axvm/src/arch/x86_64/port.rs
@@ -1,7 +1,9 @@
 //! Native x86 host I/O port passthrough devices.
 
-use axdevice_base::{AccessWidth, BaseDeviceOps, EmuDeviceType, Port, PortRange};
-use axvm_types::{AxVmError as BackendError, AxVmResult as BackendResult};
+use axdevice_base::{
+    AccessWidth, AxError as DeviceError, AxResult as DeviceResult, BaseDeviceOps, EmuDeviceType,
+    Port, PortRange,
+};
 
 use crate::{AxVmResult, ax_err};
 
@@ -40,22 +42,22 @@ impl BaseDeviceOps<PortRange> for HostPortPassthrough {
         PortRange::new(self.base, self.end())
     }
 
-    fn handle_read(&self, port: Port, width: AccessWidth) -> BackendResult<usize> {
+    fn handle_read(&self, port: Port, width: AccessWidth) -> DeviceResult<usize> {
         match width {
             AccessWidth::Byte => Ok(unsafe { inb(port.number()) } as usize),
             AccessWidth::Word => Ok(unsafe { inw(port.number()) } as usize),
             AccessWidth::Dword => Ok(unsafe { inl(port.number()) } as usize),
-            AccessWidth::Qword => Err(BackendError::Unsupported),
+            AccessWidth::Qword => Err(DeviceError::Unsupported),
         }
     }
 
-    fn handle_write(&self, port: Port, width: AccessWidth, value: usize) -> BackendResult {
+    fn handle_write(&self, port: Port, width: AccessWidth, value: usize) -> DeviceResult {
         match width {
             AccessWidth::Byte => unsafe { outb(port.number(), value as u8) },
             AccessWidth::Word => unsafe { outw(port.number(), value as u16) },
             AccessWidth::Dword => unsafe { outl(port.number(), value as u32) },
             AccessWidth::Qword => {
-                return Err(BackendError::Unsupported);
+                return Err(DeviceError::Unsupported);
             }
         }
         Ok(())

--- a/virtualization/axvm/src/irq/mod.rs
+++ b/virtualization/axvm/src/irq/mod.rs
@@ -17,8 +17,11 @@
 use alloc::sync::Arc;
 
 use axdevice::IrqResolver;
-use axdevice_base::{AxResult as DeviceResult, InterruptTriggerMode, IrqLine, IrqLineId, IrqSink};
-use axvm_types::{AxVmError as BackendError, VMInterruptMode};
+use axdevice_base::{
+    AxError as DeviceError, AxResult as DeviceResult, InterruptTriggerMode, IrqLine, IrqLineId,
+    IrqSink,
+};
+use axvm_types::VMInterruptMode;
 
 use crate::{AxVmError, AxVmResult, ax_err};
 
@@ -96,9 +99,9 @@ impl InterruptFabric {
     fn sink_for_line(&self, _line: usize) -> DeviceResult<&Arc<dyn IrqSink>> {
         let Some(sink) = &self.sink else {
             if self.mode == VMInterruptMode::NoIrq {
-                return Err(BackendError::InvalidInput);
+                return Err(DeviceError::InvalidInput);
             }
-            return Err(BackendError::Unsupported);
+            return Err(DeviceError::Unsupported);
         };
         Ok(sink)
     }

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -19,7 +19,8 @@ use core::{cell::UnsafeCell, mem::MaybeUninit};
 
 use ax_kspin::SpinNoIrq as Mutex;
 use axvm_types::{
-    GuestPhysAddr, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps, VmVcpuState,
+    GuestPhysAddr, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps,
+    VmBackendError, VmVcpuState,
 };
 
 use crate::{AxVmError, AxVmResult, ax_err};
@@ -61,7 +62,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
             }),
             arch_vcpu: UnsafeCell::new(
                 A::new(vm_id, vcpu_id, arch_config)
-                    .map_err(|error| AxVmError::vcpu("create vCPU", error))?,
+                    .map_err(|error| map_vcpu_backend_error("create vCPU", error))?,
             ),
         })
     }
@@ -76,13 +77,13 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
         self.manipulate_arch_vcpu(VmVcpuState::Created, VmVcpuState::Free, |arch_vcpu| {
             arch_vcpu
                 .set_entry(entry)
-                .map_err(|error| AxVmError::vcpu("set vCPU entry", error))?;
+                .map_err(|error| map_vcpu_backend_error("set vCPU entry", error))?;
             arch_vcpu
                 .set_nested_page_table(nested_paging)
-                .map_err(|error| AxVmError::vcpu("set nested page table", error))?;
+                .map_err(|error| map_vcpu_backend_error("set nested page table", error))?;
             arch_vcpu
                 .setup(arch_config)
-                .map_err(|error| AxVmError::vcpu("set up vCPU", error))?;
+                .map_err(|error| map_vcpu_backend_error("set up vCPU", error))?;
             Ok(())
         })
     }
@@ -192,7 +193,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
         self.manipulate_arch_vcpu(VmVcpuState::Running, VmVcpuState::Ready, |arch_vcpu| {
             arch_vcpu
                 .run()
-                .map_err(|error| AxVmError::vcpu("run vCPU", error))
+                .map_err(|error| map_vcpu_backend_error("run vCPU", error))
         })
     }
 
@@ -201,7 +202,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
         self.manipulate_arch_vcpu(VmVcpuState::Free, VmVcpuState::Ready, |arch_vcpu| {
             arch_vcpu
                 .bind()
-                .map_err(|error| AxVmError::vcpu("bind vCPU", error))
+                .map_err(|error| map_vcpu_backend_error("bind vCPU", error))
         })
     }
 
@@ -210,7 +211,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
         self.manipulate_arch_vcpu(VmVcpuState::Ready, VmVcpuState::Free, |arch_vcpu| {
             arch_vcpu
                 .unbind()
-                .map_err(|error| AxVmError::vcpu("unbind vCPU", error))
+                .map_err(|error| map_vcpu_backend_error("unbind vCPU", error))
         })
     }
 
@@ -222,7 +223,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     pub fn set_entry(&self, entry: GuestPhysAddr) -> AxVmResult {
         self.get_arch_vcpu()
             .set_entry(entry)
-            .map_err(|error| AxVmError::vcpu("set vCPU entry", error))
+            .map_err(|error| map_vcpu_backend_error("set vCPU entry", error))
     }
 
     /// Sets a guest general-purpose register.
@@ -234,7 +235,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     pub fn inject_interrupt(&self, vector: usize) -> AxVmResult {
         self.get_arch_vcpu()
             .inject_interrupt(vector)
-            .map_err(|error| AxVmError::interrupt("inject vCPU interrupt", error))
+            .map_err(|error| map_interrupt_backend_error("inject vCPU interrupt", error))
     }
 
     /// Sets the guest return value.
@@ -305,10 +306,9 @@ impl<A: VmArchPerCpuOps> AxPerCpu<A> {
             ax_err!(BadState, "per-CPU state is already initialized")
         } else {
             self.cpu_id = Some(cpu_id);
-            self.arch
-                .write(A::new(cpu_id).map_err(|error| {
-                    AxVmError::host("initialize per-CPU virtualization", error)
-                })?);
+            self.arch.write(A::new(cpu_id).map_err(|error| {
+                map_host_backend_error("initialize per-CPU virtualization", error)
+            })?);
             Ok(())
         }
     }
@@ -334,14 +334,14 @@ impl<A: VmArchPerCpuOps> AxPerCpu<A> {
     pub fn hardware_enable(&mut self) -> AxVmResult {
         self.arch_checked_mut()
             .hardware_enable()
-            .map_err(|error| AxVmError::host("enable hardware virtualization", error))
+            .map_err(|error| map_host_backend_error("enable hardware virtualization", error))
     }
 
     /// Disables virtualization on the current CPU.
     pub fn hardware_disable(&mut self) -> AxVmResult {
         self.arch_checked_mut()
             .hardware_disable()
-            .map_err(|error| AxVmError::host("disable hardware virtualization", error))
+            .map_err(|error| map_host_backend_error("disable hardware virtualization", error))
     }
 }
 
@@ -350,5 +350,118 @@ impl<A: VmArchPerCpuOps> Drop for AxPerCpu<A> {
         if self.cpu_id.is_some() && self.is_enabled() {
             self.hardware_disable().unwrap();
         }
+    }
+}
+
+fn map_vcpu_backend_error(operation: &'static str, error: VmBackendError) -> AxVmError {
+    match error {
+        VmBackendError::InvalidInput => AxVmError::invalid_input(operation, error),
+        VmBackendError::InvalidData => AxVmError::vcpu(operation, error),
+        VmBackendError::InvalidState => AxVmError::invalid_state(operation, error),
+        VmBackendError::Unsupported => AxVmError::unsupported(operation, error),
+        VmBackendError::OutOfMemory => AxVmError::OutOfMemory { operation },
+        VmBackendError::ResourceBusy => AxVmError::resource_conflict(
+            "vCPU backend",
+            format_args!("{operation} failed: {error}"),
+        ),
+    }
+}
+
+fn map_host_backend_error(operation: &'static str, error: VmBackendError) -> AxVmError {
+    match error {
+        VmBackendError::InvalidInput => AxVmError::invalid_input(operation, error),
+        VmBackendError::InvalidData => AxVmError::host(operation, error),
+        VmBackendError::InvalidState => AxVmError::invalid_state(operation, error),
+        VmBackendError::Unsupported => AxVmError::unsupported(operation, error),
+        VmBackendError::OutOfMemory => AxVmError::OutOfMemory { operation },
+        VmBackendError::ResourceBusy => AxVmError::resource_conflict(
+            "host virtualization backend",
+            format_args!("{operation} failed: {error}"),
+        ),
+    }
+}
+
+fn map_interrupt_backend_error(operation: &'static str, error: VmBackendError) -> AxVmError {
+    match error {
+        VmBackendError::InvalidInput => AxVmError::invalid_input(operation, error),
+        VmBackendError::InvalidData => AxVmError::interrupt(operation, error),
+        VmBackendError::InvalidState => AxVmError::invalid_state(operation, error),
+        VmBackendError::Unsupported => AxVmError::unsupported(operation, error),
+        VmBackendError::OutOfMemory => AxVmError::OutOfMemory { operation },
+        VmBackendError::ResourceBusy => AxVmError::resource_conflict(
+            "interrupt backend",
+            format_args!("{operation} failed: {error}"),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vcpu_backend_errors_keep_domain_context() {
+        assert!(matches!(
+            map_vcpu_backend_error("run vCPU", VmBackendError::InvalidState),
+            AxVmError::InvalidState {
+                operation: "run vCPU",
+                ..
+            }
+        ));
+        assert!(matches!(
+            map_vcpu_backend_error("create vCPU", VmBackendError::OutOfMemory),
+            AxVmError::OutOfMemory {
+                operation: "create vCPU"
+            }
+        ));
+        assert!(matches!(
+            map_vcpu_backend_error("bind vCPU", VmBackendError::ResourceBusy),
+            AxVmError::ResourceConflict {
+                resource: "vCPU backend",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn host_backend_errors_keep_domain_context() {
+        assert!(matches!(
+            map_host_backend_error(
+                "enable hardware virtualization",
+                VmBackendError::Unsupported
+            ),
+            AxVmError::Unsupported {
+                operation: "enable hardware virtualization",
+                ..
+            }
+        ));
+        assert!(matches!(
+            map_host_backend_error(
+                "initialize per-CPU virtualization",
+                VmBackendError::InvalidData
+            ),
+            AxVmError::Host {
+                operation: "initialize per-CPU virtualization",
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn interrupt_backend_errors_keep_domain_context() {
+        assert!(matches!(
+            map_interrupt_backend_error("inject vCPU interrupt", VmBackendError::InvalidData),
+            AxVmError::Interrupt {
+                operation: "inject vCPU interrupt",
+                ..
+            }
+        ));
+        assert!(matches!(
+            map_interrupt_backend_error("inject vCPU interrupt", VmBackendError::ResourceBusy),
+            AxVmError::ResourceConflict {
+                resource: "interrupt backend",
+                ..
+            }
+        ));
     }
 }

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -25,10 +25,9 @@ use ax_kspin::SpinNoIrq as Mutex;
 use ax_memory_addr::align_up_4k;
 use axaddrspace::AddrSpace;
 use axdevice::{AxVmDevices, FwCfg, FwCfgPlatformConfig};
-use axdevice_base::AccessWidth;
+use axdevice_base::{AccessWidth, AxError as DeviceError};
 use axvm_types::{
-    AxVmError as BackendError, GuestPhysAddr, HostPhysAddr, HostVirtAddr, MappingFlags,
-    NestedPagingConfig, VmVcpuState,
+    GuestPhysAddr, HostPhysAddr, HostVirtAddr, MappingFlags, NestedPagingConfig, VmVcpuState,
 };
 
 use crate::{
@@ -802,11 +801,11 @@ impl AxVM {
                         desc_addr,
                         |gpa, buffer| {
                             self.read_from_guest(gpa, buffer)
-                                .map_err(|_| BackendError::InvalidData)
+                                .map_err(|_| DeviceError::InvalidData)
                         },
                         |gpa, buffer| {
                             self.write_to_guest(gpa, buffer)
-                                .map_err(|_| BackendError::InvalidData)
+                                .map_err(|_| DeviceError::InvalidData)
                         },
                     )
                     .map_err(|error| AxVmError::device("process fw_cfg DMA request", error))?;

--- a/virtualization/test_crates/virtualization-tests/tests/axvm_irq.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axvm_irq.rs
@@ -23,7 +23,7 @@ use axdevice::{
 use axdevice_base::{
     AccessWidth, BaseDeviceOps, InterruptTriggerMode, IrqLine, IrqLineId, IrqSink,
 };
-use axvm::InterruptFabric;
+use axvm::{AxVmError, InterruptFabric};
 use axvm_types::{
     EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange, VMInterruptMode,
 };
@@ -189,10 +189,10 @@ fn recording_fabric(mode: VMInterruptMode) -> (InterruptFabric, Weak<RecordingIr
 #[test]
 fn test_no_irq_fabric_rejects_backend_and_line_resolution() {
     let sink = Arc::new(RecordingIrqSink::default());
-    assert_eq!(
-        InterruptFabric::with_sink(VMInterruptMode::NoIrq, sink).err(),
-        Some(AxError::InvalidInput)
-    );
+    assert!(matches!(
+        InterruptFabric::with_sink(VMInterruptMode::NoIrq, sink),
+        Err(AxVmError::InvalidInput { .. })
+    ));
 
     let fabric = InterruptFabric::new(VMInterruptMode::NoIrq);
     let context = DeviceBuildContext::new(&fabric);


### PR DESCRIPTION
## 问题

`axvm-types` 仍将 `ax_errno::AxError/AxResult` 作为虚拟化后端能力 trait 的公共错误契约，既无法表达后端领域语义，也使 AxVM 的新领域错误边界继续依赖 errno 变体。

## 修改

- 在 `axvm-types` 新增 `VmBackendError` 和 `VmBackendResult`，覆盖无效输入、无效数据、无效状态、不支持、内存不足和资源忙，并使用 `thiserror` 提供稳定的错误展示。
- 将 `VmArchVcpuOps`、`VmArchPerCpuOps` 及四架构实现迁移到新结果类型，删除误导性的 `AxVmError/AxVmResult` 别名和 `ax-errno` 直接依赖。
- 在 AxVM 内增加 vCPU、宿主和中断三个私有适配边界，按调用语境映射为 `AxVmError`，保留操作名与领域分类。
- 更新 IRQ 集成测试对 AxVM 领域错误的断言；设备栈尚未迁移前，仅从 `axdevice_base` 文档隐藏地暴露其既有 `AxError` 类型，后续设备错误 PR 会移除该过渡点。
- 增加错误契约测试，静态确认 manifest/source 不再引用 `ax-errno`/`ax_errno`，并覆盖可匹配变体和 Display 文本。

## 设计逻辑

后端层只报告与具体架构无关、可匹配的失败原因；AxVM 在拥有操作上下文的位置完成领域映射。这样避免无上下文的全局 `From<AxError>`，同时不改变 vCPU 生命周期、运行和中断行为。

## 验证

- `cargo fmt --all --check`
- `cargo test -p axvm-types`
- `cargo test -p axvm`
- `cargo test -p axdevice_base`
- `cargo check -p virtualization-tests --tests`
- `cargo xtask clippy --package axvm-types`
- `cargo xtask clippy --package axvm`
- `cargo xtask clippy --package axdevice_base`
- `cargo xtask clippy --package virtualization-tests`
- `cargo xtask axvisor build --arch x86_64`
- `cargo xtask axvisor build --arch aarch64`
- `cargo xtask axvisor build --arch riscv64`
- `cargo xtask axvisor build --arch loongarch64`

补充：`cargo test -p virtualization-tests` 已越过本次修改涉及的类型检查，但最终链接被仓库当前 `axvm_irq` 测试与 `axplat-dyn` 同时定义 `ConsoleIf/TimeIf` 符号的问题阻塞；该问题与本次错误契约迁移无关。