### PR TITLE
refactor(axaddrspace): introduce typed errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1170,7 +1170,6 @@ name = "axaddrspace"
 version = "0.5.16"
 dependencies = [
  "assert_matches",
- "ax-errno 0.6.1",
  "ax-lazyinit",
  "ax-memory-addr",
  "ax-memory-set",
@@ -1179,6 +1178,7 @@ dependencies = [
  "lazy_static",
  "log",
  "page-table-generic",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/virtualization/axaddrspace/Cargo.toml
+++ b/virtualization/axaddrspace/Cargo.toml
@@ -18,10 +18,10 @@ ax-lazyinit = { workspace = true }
 log = "0.4"
 
 # Operating system independent modules provided by ArceOS.
-ax-errno = { workspace = true }
 ax-memory-addr = { workspace = true }
 ax-memory-set = { workspace = true }
 axvm-types = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 lazy_static = "1.5"

--- a/virtualization/axaddrspace/src/address_space/mod.rs
+++ b/virtualization/axaddrspace/src/address_space/mod.rs
@@ -15,12 +15,11 @@
 use alloc::vec::Vec;
 use core::fmt;
 
-use ax_errno::{AxResult, ax_err};
 use ax_memory_addr::{MemoryAddr, PhysAddr, is_aligned_4k};
 use ax_memory_set::{MemoryArea, MemorySet};
 use axvm_types::{GuestPhysAddr, GuestPhysAddrRange, MappingFlags};
 
-use crate::{NestedPageTableOps, mapping_err_to_ax_err};
+use crate::{AddrSpaceError, AddrSpaceResult, NestedPageTableOps};
 
 mod backend;
 
@@ -71,7 +70,13 @@ impl<Npt: NestedPageTableOps> AddrSpace<Npt> {
     }
 
     /// Creates a new empty address space with the architecture default page table level.
-    pub fn new_empty(page_table: Npt, base: GuestPhysAddr, size: usize) -> AxResult<Self> {
+    pub fn new_empty(page_table: Npt, base: GuestPhysAddr, size: usize) -> AddrSpaceResult<Self> {
+        base.as_usize()
+            .checked_add(size)
+            .ok_or(AddrSpaceError::AddressOverflow {
+                start: base.as_usize(),
+                size,
+            })?;
         Ok(Self {
             va_range: GuestPhysAddrRange::from_start_size(base, size),
             areas: MemorySet::new(),
@@ -90,22 +95,22 @@ impl<Npt: NestedPageTableOps> AddrSpace<Npt> {
         start_paddr: PhysAddr,
         size: usize,
         flags: MappingFlags,
-    ) -> AxResult {
-        if !self.contains_range(start_vaddr, size) {
-            return ax_err!(InvalidInput, "address out of range");
-        }
-        if !start_vaddr.is_aligned_4k() || !start_paddr.is_aligned_4k() || !is_aligned_4k(size) {
-            return ax_err!(InvalidInput, "address not aligned");
-        }
-        if start_paddr.as_usize().checked_add(size).is_none() {
-            return ax_err!(InvalidInput, "physical address range overflow");
-        }
+    ) -> AddrSpaceResult {
+        validate_range(&self.va_range, start_vaddr, size)?;
+        validate_alignment("guest physical address", start_vaddr.as_usize())?;
+        validate_alignment("host physical address", start_paddr.as_usize())?;
+        validate_alignment("mapping size", size)?;
+        start_paddr
+            .as_usize()
+            .checked_add(size)
+            .ok_or(AddrSpaceError::AddressOverflow {
+                start: start_paddr.as_usize(),
+                size,
+            })?;
 
         let offset = start_vaddr.as_usize() as i128 - start_paddr.as_usize() as i128;
         let area = MemoryArea::new(start_vaddr, size, flags, Backend::new_linear(offset));
-        self.areas
-            .map(area, &mut self.pt, false)
-            .map_err(mapping_err_to_ax_err)?;
+        self.areas.map(area, &mut self.pt, false)?;
         Ok(())
     }
 
@@ -120,36 +125,23 @@ impl<Npt: NestedPageTableOps> AddrSpace<Npt> {
         size: usize,
         flags: MappingFlags,
         populate: bool,
-    ) -> AxResult {
-        if !self.contains_range(start, size) {
-            return ax_err!(
-                InvalidInput,
-                alloc::format!("address [{:?}~{:?}] out of range", start, start + size).as_str()
-            );
-        }
-        if !start.is_aligned_4k() || !is_aligned_4k(size) {
-            return ax_err!(InvalidInput, "address not aligned");
-        }
+    ) -> AddrSpaceResult {
+        validate_range(&self.va_range, start, size)?;
+        validate_alignment("guest physical address", start.as_usize())?;
+        validate_alignment("mapping size", size)?;
 
         let area = MemoryArea::new(start, size, flags, Backend::new_alloc(populate));
-        self.areas
-            .map(area, &mut self.pt, false)
-            .map_err(mapping_err_to_ax_err)?;
+        self.areas.map(area, &mut self.pt, false)?;
         Ok(())
     }
 
     /// Removes mappings within the specified virtual address range.
-    pub fn unmap(&mut self, start: GuestPhysAddr, size: usize) -> AxResult {
-        if !self.contains_range(start, size) {
-            return ax_err!(InvalidInput, "address out of range");
-        }
-        if !start.is_aligned_4k() || !is_aligned_4k(size) {
-            return ax_err!(InvalidInput, "address not aligned");
-        }
+    pub fn unmap(&mut self, start: GuestPhysAddr, size: usize) -> AddrSpaceResult {
+        validate_range(&self.va_range, start, size)?;
+        validate_alignment("guest physical address", start.as_usize())?;
+        validate_alignment("mapping size", size)?;
 
-        self.areas
-            .unmap(start, size, &mut self.pt)
-            .map_err(mapping_err_to_ax_err)?;
+        self.areas.unmap(start, size, &mut self.pt)?;
         Ok(())
     }
 
@@ -264,6 +256,40 @@ impl<Npt: NestedPageTableOps> AddrSpace<Npt> {
             None
         }
     }
+}
+
+fn validate_range(
+    space: &GuestPhysAddrRange,
+    start: GuestPhysAddr,
+    size: usize,
+) -> AddrSpaceResult {
+    start
+        .as_usize()
+        .checked_add(size)
+        .ok_or(AddrSpaceError::AddressOverflow {
+            start: start.as_usize(),
+            size,
+        })?;
+    if !space.contains_range(GuestPhysAddrRange::from_start_size(start, size)) {
+        return Err(AddrSpaceError::OutOfRange {
+            start,
+            size,
+            space_start: space.start,
+            space_end: space.end,
+        });
+    }
+    Ok(())
+}
+
+fn validate_alignment(subject: &'static str, value: usize) -> AddrSpaceResult {
+    if !is_aligned_4k(value) {
+        return Err(AddrSpaceError::Unaligned {
+            subject,
+            value,
+            alignment: 0x1000,
+        });
+    }
+    Ok(())
 }
 
 impl<Npt: NestedPageTableOps> fmt::Debug for AddrSpace<Npt> {

--- a/virtualization/axaddrspace/src/error.rs
+++ b/virtualization/axaddrspace/src/error.rs
@@ -1,0 +1,97 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ax_memory_set::MappingError;
+use axvm_types::GuestPhysAddr;
+
+/// Result returned by guest address-space operations.
+pub type AddrSpaceResult<T = ()> = Result<T, AddrSpaceError>;
+
+/// Failures reported while managing or accessing a guest address space.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum AddrSpaceError {
+    /// A guest address range lies outside the configured address space.
+    #[error(
+        "guest address range [{start:#x}, +{size:#x}) is outside [{space_start:#x}, \
+         {space_end:#x})"
+    )]
+    OutOfRange {
+        /// Start of the requested range.
+        start: GuestPhysAddr,
+        /// Size of the requested range.
+        size: usize,
+        /// Start of the configured address space.
+        space_start: GuestPhysAddr,
+        /// End of the configured address space.
+        space_end: GuestPhysAddr,
+    },
+    /// An address or size does not satisfy the required alignment.
+    #[error("{subject} value {value:#x} is not aligned to {alignment:#x}")]
+    Unaligned {
+        /// Kind of value that failed validation.
+        subject: &'static str,
+        /// Misaligned value.
+        value: usize,
+        /// Required alignment.
+        alignment: usize,
+    },
+    /// Computing an address range overflowed.
+    #[error("address range starting at {start:#x} with size {size:#x} overflows")]
+    AddressOverflow {
+        /// Start of the overflowing range.
+        start: usize,
+        /// Size of the overflowing range.
+        size: usize,
+    },
+    /// A mapping overlaps an existing mapping.
+    #[error("guest address mapping conflicts with an existing mapping")]
+    MappingConflict,
+    /// The mapping request is invalid for the lower mapping layer.
+    #[error("guest address mapping request is invalid")]
+    InvalidMapping,
+    /// The mapping layer is not in a state that permits the operation.
+    #[error("guest address mapping state does not permit the operation")]
+    MappingState,
+    /// A guest address cannot be translated.
+    #[error("guest address {address:#x} is not mapped")]
+    Unmapped {
+        /// Guest physical address that could not be translated.
+        address: GuestPhysAddr,
+    },
+    /// A translated region is too small for an access.
+    #[error(
+        "cannot {operation} {requested} bytes at guest address {address:#x}: only {available} \
+         bytes are accessible"
+    )]
+    InsufficientAccess {
+        /// Access operation being performed.
+        operation: &'static str,
+        /// Guest physical address being accessed.
+        address: GuestPhysAddr,
+        /// Number of bytes requested.
+        requested: usize,
+        /// Number of bytes available in the translated region.
+        available: usize,
+    },
+}
+
+impl From<MappingError> for AddrSpaceError {
+    fn from(error: MappingError) -> Self {
+        match error {
+            MappingError::InvalidParam => Self::InvalidMapping,
+            MappingError::AlreadyExists => Self::MappingConflict,
+            MappingError::BadState => Self::MappingState,
+        }
+    }
+}

--- a/virtualization/axaddrspace/src/lib.rs
+++ b/virtualization/axaddrspace/src/lib.rs
@@ -20,21 +20,12 @@ extern crate log;
 extern crate alloc;
 
 mod address_space;
+mod error;
 mod memory_accessor;
 mod paging;
 
 pub use address_space::{AddrSpace, Backend};
-use ax_errno::AxError;
-use ax_memory_set::MappingError;
 pub use axvm_types::MappingFlags;
+pub use error::{AddrSpaceError, AddrSpaceResult};
 pub use memory_accessor::GuestMemoryAccessor;
 pub use paging::{NestedPageTableOps, PageSize};
-
-fn mapping_err_to_ax_err(err: MappingError) -> AxError {
-    warn!("Mapping error: {err:?}");
-    match err {
-        MappingError::InvalidParam => AxError::InvalidInput,
-        MappingError::AlreadyExists => AxError::AlreadyExists,
-        MappingError::BadState => AxError::BadState,
-    }
-}

--- a/virtualization/axaddrspace/src/memory_accessor.rs
+++ b/virtualization/axaddrspace/src/memory_accessor.rs
@@ -17,9 +17,10 @@
 //! This module provides a safe and consistent way to access guest memory
 //! from VirtIO device implementations, handling address translation and
 //! memory safety concerns.
-use ax_errno::{AxError, AxResult};
 use ax_memory_addr::PhysAddr;
 use axvm_types::GuestPhysAddr;
+
+use crate::{AddrSpaceError, AddrSpaceResult};
 
 /// A stateful accessor to the memory space of a guest
 pub trait GuestMemoryAccessor {
@@ -34,7 +35,7 @@ pub trait GuestMemoryAccessor {
     ///
     /// # Returns
     ///
-    /// Returns `Err(AxError::InvalidInput)` in the following cases:
+    /// Returns an error when the address is unmapped or the region is too small.
     /// - The guest address cannot be translated to a valid host address
     /// - The accessible memory region starting from the guest address is smaller
     ///   than the size of type V (insufficient space for the read operation)
@@ -44,14 +45,21 @@ pub trait GuestMemoryAccessor {
     /// This function uses volatile memory access to ensure the read operation
     /// is not optimized away by the compiler, which is important for device
     /// register access and shared memory scenarios.
-    fn read_obj<V: Copy>(&self, guest_addr: GuestPhysAddr) -> AxResult<V> {
-        let (host_addr, limit) = self
-            .translate_and_get_limit(guest_addr)
-            .ok_or(AxError::InvalidInput)?;
+    fn read_obj<V: Copy>(&self, guest_addr: GuestPhysAddr) -> AddrSpaceResult<V> {
+        let (host_addr, limit) =
+            self.translate_and_get_limit(guest_addr)
+                .ok_or(AddrSpaceError::Unmapped {
+                    address: guest_addr,
+                })?;
 
         // Check if we have enough space to read the object
         if limit < core::mem::size_of::<V>() {
-            return Err(AxError::InvalidInput);
+            return Err(AddrSpaceError::InsufficientAccess {
+                operation: "read guest object",
+                address: guest_addr,
+                requested: core::mem::size_of::<V>(),
+                available: limit,
+            });
         }
 
         unsafe {
@@ -64,7 +72,7 @@ pub trait GuestMemoryAccessor {
     ///
     /// # Returns
     ///
-    /// Returns `Err(AxError::InvalidInput)` in the following cases:
+    /// Returns an error when the address is unmapped or the region is too small.
     /// - The guest address cannot be translated to a valid host address
     /// - The accessible memory region starting from the guest address is smaller
     ///   than the size of type V (insufficient space for the write operation)
@@ -74,14 +82,21 @@ pub trait GuestMemoryAccessor {
     /// This function uses volatile memory access to ensure the write operation
     /// is not optimized away by the compiler, which is important for device
     /// register access and shared memory scenarios.
-    fn write_obj<V: Copy>(&self, guest_addr: GuestPhysAddr, val: V) -> AxResult<()> {
-        let (host_addr, limit) = self
-            .translate_and_get_limit(guest_addr)
-            .ok_or(AxError::InvalidInput)?;
+    fn write_obj<V: Copy>(&self, guest_addr: GuestPhysAddr, val: V) -> AddrSpaceResult {
+        let (host_addr, limit) =
+            self.translate_and_get_limit(guest_addr)
+                .ok_or(AddrSpaceError::Unmapped {
+                    address: guest_addr,
+                })?;
 
         // Check if we have enough space to write the object
         if limit < core::mem::size_of::<V>() {
-            return Err(AxError::InvalidInput);
+            return Err(AddrSpaceError::InsufficientAccess {
+                operation: "write guest object",
+                address: guest_addr,
+                requested: core::mem::size_of::<V>(),
+                available: limit,
+            });
         }
 
         unsafe {
@@ -92,14 +107,16 @@ pub trait GuestMemoryAccessor {
     }
 
     /// Read a buffer from guest memory
-    fn read_buffer(&self, guest_addr: GuestPhysAddr, buffer: &mut [u8]) -> AxResult<()> {
+    fn read_buffer(&self, guest_addr: GuestPhysAddr, buffer: &mut [u8]) -> AddrSpaceResult {
         if buffer.is_empty() {
             return Ok(());
         }
 
-        let (host_addr, accessible_size) = self
-            .translate_and_get_limit(guest_addr)
-            .ok_or(AxError::InvalidInput)?;
+        let (host_addr, accessible_size) =
+            self.translate_and_get_limit(guest_addr)
+                .ok_or(AddrSpaceError::Unmapped {
+                    address: guest_addr,
+                })?;
 
         // Check if we can read the entire buffer from this accessible region
         if accessible_size >= buffer.len() {
@@ -118,7 +135,18 @@ pub trait GuestMemoryAccessor {
         while !remaining_buffer.is_empty() {
             let (current_host_addr, current_accessible_size) = self
                 .translate_and_get_limit(current_guest_addr)
-                .ok_or(AxError::InvalidInput)?;
+                .ok_or(AddrSpaceError::Unmapped {
+                    address: current_guest_addr,
+                })?;
+
+            if current_accessible_size == 0 {
+                return Err(AddrSpaceError::InsufficientAccess {
+                    operation: "read guest buffer",
+                    address: current_guest_addr,
+                    requested: remaining_buffer.len(),
+                    available: 0,
+                });
+            }
 
             let bytes_to_read = remaining_buffer.len().min(current_accessible_size);
 
@@ -133,8 +161,7 @@ pub trait GuestMemoryAccessor {
             }
 
             // Move to next region
-            current_guest_addr =
-                GuestPhysAddr::from_usize(current_guest_addr.as_usize() + bytes_to_read);
+            current_guest_addr = advance_guest_address(current_guest_addr, bytes_to_read)?;
             remaining_buffer = &mut remaining_buffer[bytes_to_read..];
         }
 
@@ -142,14 +169,16 @@ pub trait GuestMemoryAccessor {
     }
 
     /// Write a buffer to guest memory
-    fn write_buffer(&self, guest_addr: GuestPhysAddr, buffer: &[u8]) -> AxResult<()> {
+    fn write_buffer(&self, guest_addr: GuestPhysAddr, buffer: &[u8]) -> AddrSpaceResult {
         if buffer.is_empty() {
             return Ok(());
         }
 
-        let (host_addr, accessible_size) = self
-            .translate_and_get_limit(guest_addr)
-            .ok_or(AxError::InvalidInput)?;
+        let (host_addr, accessible_size) =
+            self.translate_and_get_limit(guest_addr)
+                .ok_or(AddrSpaceError::Unmapped {
+                    address: guest_addr,
+                })?;
 
         // Check if we can write the entire buffer to this accessible region
         if accessible_size >= buffer.len() {
@@ -168,7 +197,18 @@ pub trait GuestMemoryAccessor {
         while !remaining_buffer.is_empty() {
             let (current_host_addr, current_accessible_size) = self
                 .translate_and_get_limit(current_guest_addr)
-                .ok_or(AxError::InvalidInput)?;
+                .ok_or(AddrSpaceError::Unmapped {
+                    address: current_guest_addr,
+                })?;
+
+            if current_accessible_size == 0 {
+                return Err(AddrSpaceError::InsufficientAccess {
+                    operation: "write guest buffer",
+                    address: current_guest_addr,
+                    requested: remaining_buffer.len(),
+                    available: 0,
+                });
+            }
 
             let bytes_to_write = remaining_buffer.len().min(current_accessible_size);
 
@@ -179,8 +219,7 @@ pub trait GuestMemoryAccessor {
             }
 
             // Move to next region
-            current_guest_addr =
-                GuestPhysAddr::from_usize(current_guest_addr.as_usize() + bytes_to_write);
+            current_guest_addr = advance_guest_address(current_guest_addr, bytes_to_write)?;
             remaining_buffer = &remaining_buffer[bytes_to_write..];
         }
 
@@ -188,12 +227,23 @@ pub trait GuestMemoryAccessor {
     }
 
     /// Read a volatile value from guest memory (for device registers)
-    fn read_volatile<V: Copy>(&self, guest_addr: GuestPhysAddr) -> AxResult<V> {
+    fn read_volatile<V: Copy>(&self, guest_addr: GuestPhysAddr) -> AddrSpaceResult<V> {
         self.read_obj(guest_addr)
     }
 
     /// Write a volatile value to guest memory (for device registers)
-    fn write_volatile<V: Copy>(&self, guest_addr: GuestPhysAddr, val: V) -> AxResult<()> {
+    fn write_volatile<V: Copy>(&self, guest_addr: GuestPhysAddr, val: V) -> AddrSpaceResult {
         self.write_obj(guest_addr, val)
     }
+}
+
+fn advance_guest_address(address: GuestPhysAddr, size: usize) -> AddrSpaceResult<GuestPhysAddr> {
+    let next = address
+        .as_usize()
+        .checked_add(size)
+        .ok_or(AddrSpaceError::AddressOverflow {
+            start: address.as_usize(),
+            size,
+        })?;
+    Ok(GuestPhysAddr::from_usize(next))
 }

--- a/virtualization/axaddrspace/src/paging.rs
+++ b/virtualization/axaddrspace/src/paging.rs
@@ -1,6 +1,7 @@
 use ax_memory_addr::{PhysAddr, VirtAddr};
-use ax_memory_set::MappingResult;
 use axvm_types::{GuestPhysAddr, MappingFlags};
+
+use crate::AddrSpaceResult;
 
 /// Page size selected by a nested page table mapping.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -54,10 +55,13 @@ pub trait NestedPageTableOps {
         paddr: PhysAddr,
         size: PageSize,
         flags: MappingFlags,
-    ) -> MappingResult;
+    ) -> AddrSpaceResult;
 
     /// Removes one page or block mapping.
-    fn unmap(&mut self, vaddr: GuestPhysAddr) -> MappingResult<(PhysAddr, MappingFlags, PageSize)>;
+    fn unmap(
+        &mut self,
+        vaddr: GuestPhysAddr,
+    ) -> AddrSpaceResult<(PhysAddr, MappingFlags, PageSize)>;
 
     /// Maps a range, optionally using huge mappings.
     fn map_region(
@@ -67,10 +71,10 @@ pub trait NestedPageTableOps {
         size: usize,
         flags: MappingFlags,
         allow_huge: bool,
-    ) -> MappingResult;
+    ) -> AddrSpaceResult;
 
     /// Removes mappings from a range.
-    fn unmap_region(&mut self, start: GuestPhysAddr, size: usize) -> MappingResult;
+    fn unmap_region(&mut self, start: GuestPhysAddr, size: usize) -> AddrSpaceResult;
 
     /// Replaces the mapping at `start`.
     fn remap(&mut self, start: GuestPhysAddr, paddr: PhysAddr, flags: MappingFlags) -> bool;
@@ -84,7 +88,7 @@ pub trait NestedPageTableOps {
     ) -> bool;
 
     /// Queries a mapped address.
-    fn query(&self, vaddr: GuestPhysAddr) -> MappingResult<(PhysAddr, MappingFlags, PageSize)>;
+    fn query(&self, vaddr: GuestPhysAddr) -> AddrSpaceResult<(PhysAddr, MappingFlags, PageSize)>;
 
     /// Translates a guest physical address.
     fn translate(&self, vaddr: GuestPhysAddr) -> Option<PhysAddr> {

--- a/virtualization/axaddrspace/tests/address_space.rs
+++ b/virtualization/axaddrspace/tests/address_space.rs
@@ -19,7 +19,7 @@ mod test_utils;
 use core::sync::atomic::Ordering;
 
 use ax_memory_addr::PhysAddr;
-use axaddrspace::{AddrSpace, MappingFlags};
+use axaddrspace::{AddrSpace, AddrSpaceError, MappingFlags};
 use axin::axin;
 use axvm_types::GuestPhysAddr;
 use mock_npt::MockNestedPageTable;
@@ -130,7 +130,10 @@ fn test_map_linear_rejects_physical_range_overflow() {
     let paddr = PhysAddr::from_usize(usize::MAX - 0xfff);
     let flags = MappingFlags::READ | MappingFlags::WRITE;
 
-    assert!(addr_space.map_linear(vaddr, paddr, 0x2000, flags).is_err());
+    assert!(matches!(
+        addr_space.map_linear(vaddr, paddr, 0x2000, flags),
+        Err(AddrSpaceError::AddressOverflow { .. })
+    ));
 }
 
 #[test]
@@ -164,6 +167,28 @@ fn test_map_alloc_populate() {
 
     // Verify two pages have different physical addresses
     assert_ne!(paddr1, paddr2);
+}
+
+#[test]
+#[axin(decorator(mock_hal_test))]
+fn test_mapping_validation_errors_are_matchable() {
+    let (mut addr_space, base, size) = setup_test_addr_space();
+    let flags = MappingFlags::READ | MappingFlags::WRITE;
+
+    assert!(matches!(
+        addr_space.map_alloc(base + size, 0x1000, flags, false),
+        Err(AddrSpaceError::OutOfRange { .. })
+    ));
+    assert!(matches!(
+        addr_space.map_alloc(base + 1, 0x1000, flags, false),
+        Err(AddrSpaceError::Unaligned { .. })
+    ));
+
+    addr_space.map_alloc(base, 0x1000, flags, false).unwrap();
+    assert_eq!(
+        addr_space.map_alloc(base, 0x1000, flags, false),
+        Err(AddrSpaceError::MappingConflict)
+    );
 }
 
 #[test]

--- a/virtualization/axaddrspace/tests/error_contract.rs
+++ b/virtualization/axaddrspace/tests/error_contract.rs
@@ -1,0 +1,56 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use ax_memory_set::MappingError;
+use axaddrspace::AddrSpaceError;
+
+#[test]
+fn mapping_errors_convert_with_from() {
+    assert_eq!(
+        AddrSpaceError::from(MappingError::AlreadyExists),
+        AddrSpaceError::MappingConflict
+    );
+    assert_eq!(
+        AddrSpaceError::from(MappingError::InvalidParam),
+        AddrSpaceError::InvalidMapping
+    );
+    assert_eq!(
+        AddrSpaceError::from(MappingError::BadState),
+        AddrSpaceError::MappingState
+    );
+}
+
+#[test]
+fn manifest_and_sources_do_not_reference_axerrno() {
+    let manifest = include_str!("../Cargo.toml");
+    assert!(!manifest.contains("ax-errno"));
+    assert!(manifest.contains("thiserror = { workspace = true }"));
+
+    let source_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut pending = vec![source_root];
+    let mut violations = Vec::new();
+    while let Some(path) = pending.pop() {
+        for entry in std::fs::read_dir(path).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.extension().is_some_and(|extension| extension == "rs")
+                && std::fs::read_to_string(&path).unwrap().contains("ax_errno")
+            {
+                violations.push(path);
+            }
+        }
+    }
+    assert!(violations.is_empty(), "ax_errno references: {violations:?}");
+}

--- a/virtualization/axaddrspace/tests/memory_accessor.rs
+++ b/virtualization/axaddrspace/tests/memory_accessor.rs
@@ -14,9 +14,8 @@
 
 mod test_utils;
 
-use ax_errno::AxResult;
 use ax_memory_addr::PhysAddr;
-use axaddrspace::GuestMemoryAccessor;
+use axaddrspace::{AddrSpaceError, AddrSpaceResult, GuestMemoryAccessor};
 use axin::axin;
 use axvm_types::GuestPhysAddr;
 use test_utils::{BASE_PADDR, MEMORY_LEN, MockHal, mock_hal_test};
@@ -98,11 +97,21 @@ fn test_basic_read_write_operations() {
 
     // Test error handling with invalid address
     let invalid_addr = GuestPhysAddr::from_usize(MEMORY_LEN + 0x1000);
-    let result: AxResult<u32> = translator.read_obj(invalid_addr);
-    assert!(result.is_err(), "Reading from invalid address should fail");
+    let result: AddrSpaceResult<u32> = translator.read_obj(invalid_addr);
+    assert!(matches!(result, Err(AddrSpaceError::Unmapped { .. })));
 
     let result = translator.write_obj(invalid_addr, 42u32);
     assert!(result.is_err(), "Writing to invalid address should fail");
+
+    let short = MockTranslator::new(PhysAddr::from_usize(0), 2);
+    assert!(matches!(
+        short.read_obj::<u32>(GuestPhysAddr::from_usize(0)),
+        Err(AddrSpaceError::InsufficientAccess {
+            requested: 4,
+            available: 2,
+            ..
+        })
+    ));
 }
 
 #[test]
@@ -182,7 +191,7 @@ fn test_two_vm_isolation() {
 
     // Test that VM1 cannot access VM2's address space (beyond its limit)
     let vm2_only_addr = GuestPhysAddr::from_usize(MEMORY_LEN / 2 + 0x100);
-    let result: AxResult<u32> = vm1_translator.read_obj(vm2_only_addr);
+    let result: AddrSpaceResult<u32> = vm1_translator.read_obj(vm2_only_addr);
     assert!(
         result.is_err(),
         "VM1 should not be able to access VM2's exclusive address space"

--- a/virtualization/axaddrspace/tests/mock_npt/mod.rs
+++ b/virtualization/axaddrspace/tests/mock_npt/mod.rs
@@ -1,8 +1,8 @@
 use core::sync::atomic::Ordering;
 
 use ax_memory_addr::{PAGE_SIZE_4K as PAGE_SIZE, PhysAddr, VirtAddr};
-use ax_memory_set::{MappingError, MappingResult};
-use axaddrspace::{MappingFlags, NestedPageTableOps, PageSize};
+use ax_memory_set::MappingError;
+use axaddrspace::{AddrSpaceError, AddrSpaceResult, MappingFlags, NestedPageTableOps, PageSize};
 use axvm_types::GuestPhysAddr;
 use page_table_generic as ptg;
 use ptg::PageTableEntry;
@@ -204,8 +204,9 @@ impl NestedPageTableOps for MockNestedPageTable {
         paddr: PhysAddr,
         size: PageSize,
         flags: MappingFlags,
-    ) -> MappingResult {
-        self.inner
+    ) -> AddrSpaceResult {
+        Ok(self
+            .inner
             .map(&ptg::MapConfig {
                 vaddr: ptg::VirtAddr::new(vaddr.as_usize()),
                 paddr: ptg::PhysAddr::new(paddr.as_usize()),
@@ -214,10 +215,13 @@ impl NestedPageTableOps for MockNestedPageTable {
                 allow_huge: false,
                 flush: false,
             })
-            .map_err(Self::convert_err)
+            .map_err(Self::convert_err)?)
     }
 
-    fn unmap(&mut self, vaddr: GuestPhysAddr) -> MappingResult<(PhysAddr, MappingFlags, PageSize)> {
+    fn unmap(
+        &mut self,
+        vaddr: GuestPhysAddr,
+    ) -> AddrSpaceResult<(PhysAddr, MappingFlags, PageSize)> {
         let (paddr, flags, _) = self.query(vaddr)?;
         self.inner
             .unmap(ptg::VirtAddr::new(vaddr.as_usize()), PAGE_SIZE)
@@ -232,9 +236,10 @@ impl NestedPageTableOps for MockNestedPageTable {
         size: usize,
         flags: MappingFlags,
         _allow_huge: bool,
-    ) -> MappingResult {
+    ) -> AddrSpaceResult {
         let paddr = get_paddr(vaddr);
-        self.inner
+        Ok(self
+            .inner
             .map(&ptg::MapConfig {
                 vaddr: ptg::VirtAddr::new(vaddr.as_usize()),
                 paddr: ptg::PhysAddr::new(paddr.as_usize()),
@@ -243,13 +248,14 @@ impl NestedPageTableOps for MockNestedPageTable {
                 allow_huge: false,
                 flush: false,
             })
-            .map_err(Self::convert_err)
+            .map_err(Self::convert_err)?)
     }
 
-    fn unmap_region(&mut self, start: GuestPhysAddr, size: usize) -> MappingResult {
-        self.inner
+    fn unmap_region(&mut self, start: GuestPhysAddr, size: usize) -> AddrSpaceResult {
+        Ok(self
+            .inner
             .unmap(ptg::VirtAddr::new(start.as_usize()), size)
-            .map_err(Self::convert_err)
+            .map_err(Self::convert_err)?)
     }
 
     fn remap(&mut self, start: GuestPhysAddr, paddr: PhysAddr, flags: MappingFlags) -> bool {
@@ -279,14 +285,14 @@ impl NestedPageTableOps for MockNestedPageTable {
         true
     }
 
-    fn query(&self, vaddr: GuestPhysAddr) -> MappingResult<(PhysAddr, MappingFlags, PageSize)> {
+    fn query(&self, vaddr: GuestPhysAddr) -> AddrSpaceResult<(PhysAddr, MappingFlags, PageSize)> {
         let (paddr, pte) = self
             .inner
             .translate(ptg::VirtAddr::new(vaddr.as_usize()))
             .map_err(Self::convert_err)?;
         let config = pte.to_config(false);
         if !config.valid || MockPte::config_to_flags(config).is_empty() {
-            return Err(MappingError::BadState);
+            return Err(AddrSpaceError::MappingState);
         }
         Ok((
             PhysAddr::from(paddr.raw()),

--- a/virtualization/axvm/src/error.rs
+++ b/virtualization/axvm/src/error.rs
@@ -3,6 +3,8 @@
 use alloc::{format, string::String};
 use core::fmt::Display;
 
+use axaddrspace::AddrSpaceError;
+
 use crate::{VMId, VmStatus};
 
 /// Result type returned by AxVM operations.
@@ -183,6 +185,22 @@ impl AxVmError {
             detail: format!("{detail}"),
         }
     }
+
+    pub(crate) fn from_addrspace(operation: &'static str, error: AddrSpaceError) -> Self {
+        match error {
+            AddrSpaceError::OutOfRange { .. }
+            | AddrSpaceError::Unaligned { .. }
+            | AddrSpaceError::AddressOverflow { .. }
+            | AddrSpaceError::InvalidMapping => Self::invalid_input(operation, error),
+            AddrSpaceError::MappingConflict => Self::resource_conflict(
+                "guest address range",
+                format_args!("{operation} failed: {error}"),
+            ),
+            AddrSpaceError::MappingState
+            | AddrSpaceError::Unmapped { .. }
+            | AddrSpaceError::InsufficientAccess { .. } => Self::memory(operation, error),
+        }
+    }
 }
 
 macro_rules! ax_err_type {
@@ -284,5 +302,37 @@ mod tests {
             exhausted.to_string(),
             "out of memory while allocate guest RAM"
         );
+    }
+
+    #[test]
+    fn address_space_errors_map_to_axvm_domains() {
+        assert!(matches!(
+            AxVmError::from_addrspace("map guest RAM", AddrSpaceError::MappingConflict),
+            AxVmError::ResourceConflict {
+                resource: "guest address range",
+                ..
+            }
+        ));
+        assert!(matches!(
+            AxVmError::from_addrspace(
+                "map guest RAM",
+                AddrSpaceError::Unaligned {
+                    subject: "mapping size",
+                    value: 1,
+                    alignment: 0x1000,
+                },
+            ),
+            AxVmError::InvalidInput {
+                operation: "map guest RAM",
+                ..
+            }
+        ));
+        assert!(matches!(
+            AxVmError::from_addrspace("query guest RAM", AddrSpaceError::MappingState),
+            AxVmError::Memory {
+                operation: "query guest RAM",
+                ..
+            }
+        ));
     }
 }

--- a/virtualization/axvm/src/npt.rs
+++ b/virtualization/axvm/src/npt.rs
@@ -16,7 +16,7 @@ use core::marker::PhantomData;
 
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use ax_memory_set::{MappingError, MappingResult};
-use axaddrspace::{NestedPageTableOps, PageSize};
+use axaddrspace::{AddrSpaceResult, NestedPageTableOps, PageSize};
 use axvm_types::{GuestPhysAddr, MappingFlags};
 use page_table_generic as ptg;
 
@@ -346,12 +346,15 @@ where
         paddr: PhysAddr,
         size: PageSize,
         flags: MappingFlags,
-    ) -> MappingResult {
-        LeveledPageTable::map(self, vaddr, paddr, size, flags)
+    ) -> AddrSpaceResult {
+        Ok(LeveledPageTable::map(self, vaddr, paddr, size, flags)?)
     }
 
-    fn unmap(&mut self, vaddr: GuestPhysAddr) -> MappingResult<(PhysAddr, MappingFlags, PageSize)> {
-        LeveledPageTable::unmap(self, vaddr)
+    fn unmap(
+        &mut self,
+        vaddr: GuestPhysAddr,
+    ) -> AddrSpaceResult<(PhysAddr, MappingFlags, PageSize)> {
+        Ok(LeveledPageTable::unmap(self, vaddr)?)
     }
 
     fn map_region(
@@ -361,12 +364,14 @@ where
         size: usize,
         flags: MappingFlags,
         allow_huge: bool,
-    ) -> MappingResult {
-        LeveledPageTable::map_region(self, vaddr, get_paddr, size, flags, allow_huge)
+    ) -> AddrSpaceResult {
+        Ok(LeveledPageTable::map_region(
+            self, vaddr, get_paddr, size, flags, allow_huge,
+        )?)
     }
 
-    fn unmap_region(&mut self, start: GuestPhysAddr, size: usize) -> MappingResult {
-        LeveledPageTable::unmap_region(self, start, size)
+    fn unmap_region(&mut self, start: GuestPhysAddr, size: usize) -> AddrSpaceResult {
+        Ok(LeveledPageTable::unmap_region(self, start, size)?)
     }
 
     fn remap(&mut self, start: GuestPhysAddr, paddr: PhysAddr, flags: MappingFlags) -> bool {
@@ -382,8 +387,8 @@ where
         LeveledPageTable::protect_region(self, start, size, new_flags)
     }
 
-    fn query(&self, vaddr: GuestPhysAddr) -> MappingResult<(PhysAddr, MappingFlags, PageSize)> {
-        LeveledPageTable::query(self, vaddr)
+    fn query(&self, vaddr: GuestPhysAddr) -> AddrSpaceResult<(PhysAddr, MappingFlags, PageSize)> {
+        Ok(LeveledPageTable::query(self, vaddr)?)
     }
 }
 

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -274,7 +274,7 @@ impl AxVMResources {
             GuestPhysAddr::from(VM_ASPACE_BASE),
             VM_ASPACE_SIZE,
         )
-        .map_err(|error| AxVmError::memory("create guest address space", error))?;
+        .map_err(|error| AxVmError::from_addrspace("create guest address space", error))?;
         let nested_paging = build_nested_paging(address_space.page_table_root())?;
         Ok(Self {
             address_space,
@@ -326,7 +326,9 @@ impl AxVMResources {
                         | MappingFlags::EXECUTE
                         | MappingFlags::USER,
                 )
-                .map_err(|error| AxVmError::memory("restore guest memory mapping", error))?;
+                .map_err(|error| {
+                    AxVmError::from_addrspace("restore guest memory mapping", error)
+                })?;
         }
         self.vcpu_list = None;
         self.devices = None;
@@ -984,7 +986,7 @@ impl AxVM {
             resources
                 .address_space
                 .map_linear(gpa, hpa, size, flags)
-                .map_err(|error| AxVmError::memory("map guest memory region", error))?;
+                .map_err(|error| AxVmError::from_addrspace("map guest memory region", error))?;
             Ok(())
         })
     }
@@ -995,7 +997,7 @@ impl AxVM {
             resources
                 .address_space
                 .unmap(gpa, size)
-                .map_err(|error| AxVmError::memory("unmap guest memory region", error))?;
+                .map_err(|error| AxVmError::from_addrspace("unmap guest memory region", error))?;
             Ok(())
         })
     }
@@ -1164,7 +1166,7 @@ impl AxVM {
                         | MappingFlags::EXECUTE
                         | MappingFlags::USER,
                 )
-                .map_err(|error| AxVmError::memory("map allocated guest memory", error))?;
+                .map_err(|error| AxVmError::from_addrspace("map allocated guest memory", error))?;
             resources.memory_regions.push(VMMemoryRegion {
                 gpa,
                 hva,
@@ -1223,7 +1225,7 @@ impl AxVM {
                         | MappingFlags::EXECUTE
                         | MappingFlags::USER,
                 )
-                .map_err(|error| AxVmError::memory("map reserved guest memory", error))?;
+                .map_err(|error| AxVmError::from_addrspace("map reserved guest memory", error))?;
             let hva = gpa.as_usize().into();
             resources.memory_regions.push(VMMemoryRegion {
                 gpa,

--- a/virtualization/axvm/src/vm/prepare/address_space.rs
+++ b/virtualization/axvm/src/vm/prepare/address_space.rs
@@ -45,7 +45,7 @@ pub(crate) fn map_guest_address_space(
         resources
             .address_space
             .map_linear(mapping.gpa, mapping.hpa, mapping.size, mapping.flags)
-            .map_err(|error| AxVmError::memory("map guest address space", error))?;
+            .map_err(|error| AxVmError::from_addrspace("map guest address space", error))?;
     }
     resources.address_layout = Some(address_layout);
 


### PR DESCRIPTION
## 问题

`axaddrspace` 的公共 API、guest 内存访问接口和嵌套页表能力仍直接暴露 `ax_errno::AxResult` 或 `ax_memory_set::MappingResult`，调用者无法稳定匹配地址范围、对齐、映射冲突和访问不足等领域原因。

## 修改

- 新增 `AddrSpaceError` 和 `AddrSpaceResult`，区分越界、未对齐、地址溢出、映射冲突、无效映射、映射状态、GPA 未映射及访问空间不足。
- 移除 `axaddrspace` 对 `ax-errno` 的依赖，使用 workspace `thiserror`。
- 将 `AddrSpace`、`GuestMemoryAccessor` 和 `NestedPageTableOps` 迁移到 typed result。
- 为 `MappingError -> AddrSpaceError` 实现 `From`，在不会丢失上下文的路径直接使用 `?`；AxVM 边界保留操作名并映射到 `InvalidInput`、`ResourceConflict` 或 `Memory`。
- 增加错误契约、范围校验、映射冲突、地址溢出、未映射和访问不足测试。

## 设计逻辑

下层页表实现可以继续使用自己的 `MappingError`，但该类型只在私有适配边界出现。通用映射失败通过 `From + ?` 简化传播；只有 AxVM 拥有操作语义的边界显式补充上下文，避免简化转换时丢失诊断信息。查询接口的 `Option` 和地址空间映射策略保持不变。

## 验证

- `cargo fmt --all --check`
- `cargo test -p axaddrspace`
- `cargo test -p axvm`
- `cargo check -p virtualization-tests --tests`
- `cargo xtask clippy --package axaddrspace`
- `cargo xtask clippy --package axvm`
- `cargo xtask axvisor build --arch x86_64`
- `cargo xtask axvisor build --arch aarch64`
- `cargo xtask axvisor build --arch riscv64`
- `cargo xtask axvisor build --arch loongarch64`