### PR TITLE
fix(ci): cover all workspace source paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Validate CI source paths
+        run: python3 scripts/test/check_ci_paths.py
+
       - name: Detect CI-relevant changes
         id: filter
         if: github.event_name != 'workflow_dispatch'
@@ -155,18 +158,19 @@ jobs:
               - "Cargo.toml"
               - "Cargo.lock"
               - "rust-toolchain.toml"
-              - "bootloader/axloader/**"
+              - "apps/**"
+              - "bootloader/**"
               - "components/**"
               - "drivers/**"
+              - "memory/**"
               - "net/**"
               - "os/**"
               - "platforms/**"
-              - "virtualization/**"
-              - "memory/**"
               - "scripts/**"
               - "test-suit/**"
+              - "tools/**"
+              - "virtualization/**"
               - "xtask/**"
-              - "apps/starry/aka00-tennis-yolo/**"
             base_container_publish:
               - "container/Dockerfile"
               - "rust-toolchain.toml"

--- a/scripts/test/check_ci_paths.py
+++ b/scripts/test/check_ci_paths.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+WORKSPACE_MANIFEST = WORKSPACE_ROOT / "Cargo.toml"
+CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
+
+
+def main() -> int:
+    source_roots = workspace_source_roots()
+    ci_paths = ci_check_paths()
+    missing_paths = sorted(f"{root}/**" for root in source_roots if f"{root}/**" not in ci_paths)
+
+    if not missing_paths:
+        return 0
+
+    print("CI path filter is missing workspace source directories:", file=sys.stderr)
+    for path in missing_paths:
+        print(f"  - {path}", file=sys.stderr)
+    return 1
+
+
+def workspace_source_roots() -> set[str]:
+    manifest = WORKSPACE_MANIFEST.read_text(encoding="utf-8")
+    members = manifest.split("members = [", maxsplit=1)[1].split("]", maxsplit=1)[0]
+    package_paths = re.findall(r'^\s+"([^"]+)",?$', members, flags=re.MULTILINE)
+    package_paths.extend(re.findall(r'\bpath\s*=\s*"([^"]+)"', manifest))
+    return {Path(package_path).parts[0] for package_path in package_paths}
+
+
+def ci_check_paths() -> set[str]:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    ci_checks = workflow.split("            ci_checks:\n", maxsplit=1)[1].split(
+        "            base_container_publish:\n", maxsplit=1
+    )[0]
+    return set(re.findall(r'^\s+- "([^"]+)"$', ci_checks, flags=re.MULTILINE))
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 问题

CI 的 `ci_checks` 路径过滤器只覆盖了部分源码目录，其中 `apps` 和 `bootloader` 仅列出具体子目录，`tools` 则完全缺失。因此这些目录中的其他 workspace 源码发生变化时，工作流虽然会启动，但后续 CI 检查会被错误跳过。

## 修改

- 将应用与引导加载器规则扩展为 `apps/**` 和 `bootloader/**`。
- 补充 `tools/**`，并保留 `components/**`、`drivers/**`、`memory/**`、`net/**`、`os/**`、`platforms/**`、`virtualization/**` 等源码根目录。
- 新增 `scripts/test/check_ci_paths.py`，从根 `Cargo.toml` 的 workspace members 和本地 path dependencies 推导源码根目录，并验证 `ci_checks` 为每个根目录配置了完整通配规则。
- 在 `detect_changes` job 中运行该检查，使以后新增 workspace 源码根目录但未同步过滤器时直接失败。

## 实现逻辑

1. 从 workspace 清单收集所有本地 package 路径。
2. 提取路径的顶层目录，形成 CI 必须覆盖的源码根目录集合。
3. 读取 `ci.yml` 中的 `ci_checks` 规则并计算差集；存在缺项时列出缺失规则并返回失败。
4. 将当前差集中的 `apps/**`、`bootloader/**`、`tools/**` 补入过滤器。

## 验证

- 修复前运行回归检查，稳定报告缺少 `apps/**`、`bootloader/**`、`tools/**`。
- 修复后运行 `python3 scripts/test/check_ci_paths.py` 通过。
- 使用 PyYAML 解析 `.github/workflows/ci.yml` 通过。
- `git diff --check` 通过。

本次未修改 Rust 源码，因此未运行 Cargo/Clippy 检查。
