### PR TITLE
refactor(axvmconfig): introduce configuration errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,6 @@ dependencies = [
 name = "axvmconfig"
 version = "0.8.1"
 dependencies = [
- "ax-errno 0.6.1",
  "axvm-types",
  "clap",
  "env_logger",
@@ -1550,7 +1549,8 @@ dependencies = [
  "schemars",
  "serde",
  "serde_repr",
- "toml 0.9.12+spec-1.1.0",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -306,7 +306,7 @@ event-listener = { version = "5.4.0", default-features = false }
 futures = { version = "0.3", default-features = false }
 heapless = "0.9"
 schemars = "1.2.1"
-toml = "1"
+toml = { version = "1.1.2", default-features = false }
 dma-api = { version = "0.9.3", path = "memory/dma-api" }
 mmio-api = { version = "0.2.2", path = "memory/mmio-api" }
 lock_api = { version = "0.4", default-features = false }

--- a/os/axvisor/src/config.rs
+++ b/os/axvisor/src/config.rs
@@ -18,7 +18,7 @@
 ))]
 use core::sync::atomic::{AtomicBool, Ordering};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 #[cfg(all(feature = "fs", target_arch = "x86_64"))]
 use axvm::InterruptTriggerMode;
 use axvm::{
@@ -107,8 +107,8 @@ pub fn init_guest_vms() {
 
 pub fn init_guest_vm(raw_cfg: &str) -> Result<usize> {
     let image_provider = AxvisorBootImageProvider;
-    let vm_create_config = AxVMCrateConfig::from_toml(raw_cfg)
-        .map_err(|error| anyhow!("parse VM TOML configuration: {error}"))?;
+    let vm_create_config =
+        AxVMCrateConfig::from_toml(raw_cfg).context("parse VM TOML configuration")?;
     let configured_vm_id = vm_create_config.base.id;
 
     #[cfg(all(

--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -35,7 +35,7 @@ sha2 = { version = "0.10" }
 tar = { version = "0.4" }
 tempfile = "3"
 tokio = { version = "1.0", features = ["fs", "io-util", "macros", "process", "rt-multi-thread", "time"] }
-toml.workspace = true
+toml = { workspace = true, features = ["serde", "parse", "display"] }
 tracing = "0.1"
 tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt", "std", "time"] }

--- a/virtualization/axvm/src/boot/images/mod.rs
+++ b/virtualization/axvm/src/boot/images/mod.rs
@@ -6,7 +6,7 @@ use axvmconfig::AxVMCrateConfig;
 use byte_unit::Byte;
 
 use super::{BootImageProvider, StaticVmImage};
-use crate::{AxVMRef, AxVmError, AxVmResult, GuestPhysAddr, VMMemoryRegion, ax_err, ax_err_type};
+use crate::{AxVMRef, AxVmResult, GuestPhysAddr, VMMemoryRegion, ax_err, ax_err_type};
 
 mod linux;
 
@@ -74,10 +74,7 @@ impl<'a> ImageLoaderCore<'a> {
     }
 
     pub(crate) fn load(&mut self) -> AxVmResult {
-        self.config
-            .kernel
-            .validate_boot_config()
-            .map_err(AxVmError::invalid_config)?;
+        self.config.kernel.validate_boot_config()?;
         debug!(
             "Loading VM[{}] images into memory region: gpa={:#x}, hva={:#x}, size={:#}",
             self.vm.id(),

--- a/virtualization/axvm/src/error.rs
+++ b/virtualization/axvm/src/error.rs
@@ -6,6 +6,7 @@ use core::fmt::Display;
 use axaddrspace::AddrSpaceError;
 use axdevice::DeviceManagerError;
 use axdevice_base::{DeviceError, IrqError, RegistryError};
+use axvmconfig::AxVmConfigError;
 
 use crate::{VMId, VmStatus};
 
@@ -227,6 +228,12 @@ impl From<DeviceError> for AxVmError {
     }
 }
 
+impl From<AxVmConfigError> for AxVmError {
+    fn from(error: AxVmConfigError) -> Self {
+        Self::invalid_config(error)
+    }
+}
+
 impl From<IrqError> for AxVmError {
     fn from(error: IrqError) -> Self {
         Self::interrupt("route virtual device interrupt", error)
@@ -409,5 +416,19 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn configuration_errors_map_to_invalid_config() {
+        let config_error = AxVmConfigError::UnsupportedBootProtocol {
+            protocol: axvmconfig::VMBootProtocol::Uefi,
+            arch: "aarch64".to_string(),
+        };
+
+        let error: AxVmError = config_error.into();
+
+        assert!(matches!(error, AxVmError::InvalidConfig { .. }));
+        assert!(error.to_string().contains("Uefi"));
+        assert!(error.to_string().contains("aarch64"));
     }
 }

--- a/virtualization/axvm/tests/error_contract.rs
+++ b/virtualization/axvm/tests/error_contract.rs
@@ -86,6 +86,8 @@ fn axvisor_uses_anyhow_without_axerrno() {
     assert!(!config.contains("ax_errno"));
     assert!(manager.contains("use anyhow::{Context, Result};"));
     assert!(config.contains("AxVmError::Boot"));
+    assert!(config.contains(".context(\"parse VM TOML configuration\")?"));
+    assert!(!config.contains("map_err(|error| anyhow!"));
     assert!(shell.contains("{err:#}"));
     assert!(!shell.contains("Err(\"Failed to boot VM\")"));
 }

--- a/virtualization/axvmconfig/Cargo.toml
+++ b/virtualization/axvmconfig/Cargo.toml
@@ -24,12 +24,12 @@ name = "axvmconfig"
 path = "src/main.rs"
 
 [dependencies]
-ax-errno = { workspace = true }
 axvm-types = { workspace = true }
 log = "0.4.21"
 serde = {version = "1.0.204", default-features = false, features = ["derive"]}
 serde_repr = "0.1"
-toml = {version = "0.9.5", default-features = false, features = ["serde", "parse", "display"]}
+thiserror = { workspace = true }
+toml = { workspace = true, features = ["serde", "parse", "display"] }
 
 [target.'cfg(any(windows, unix))'.dependencies]
 clap = { version = "4.5.23", optional = true, features = ["derive"] }

--- a/virtualization/axvmconfig/src/error.rs
+++ b/virtualization/axvmconfig/src/error.rs
@@ -1,0 +1,55 @@
+//! AxVM configuration error contract.
+
+use alloc::string::{String, ToString};
+
+use crate::VMBootProtocol;
+
+/// Result type returned by AxVM configuration operations.
+pub type AxVmConfigResult<T = ()> = Result<T, AxVmConfigError>;
+
+/// Errors reported while parsing or validating an AxVM configuration.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum AxVmConfigError {
+    /// The input is not valid TOML or does not match the configuration schema.
+    #[error("failed to parse VM TOML configuration: {detail}")]
+    TomlParse {
+        /// Parser diagnostic including the failing key or source location when available.
+        detail: String,
+    },
+    /// The selected protocol conflicts with the legacy BIOS enable flag.
+    #[error("boot protocol {protocol:?} conflicts with enable_bios = {enable_bios}")]
+    BootProtocolConflict {
+        /// The selected boot protocol.
+        protocol: VMBootProtocol,
+        /// Whether the legacy BIOS flow was enabled.
+        enable_bios: bool,
+    },
+    /// The selected boot protocol is not available on the target architecture.
+    #[error("boot protocol {protocol:?} is not supported on architecture {arch}")]
+    UnsupportedBootProtocol {
+        /// The unsupported boot protocol.
+        protocol: VMBootProtocol,
+        /// The target architecture name.
+        arch: String,
+    },
+    /// Firmware boot was selected without a firmware image path.
+    #[error("boot protocol {protocol:?} requires uefi_firmware_path or the compatible bios_path")]
+    MissingFirmwarePath {
+        /// The boot protocol requiring a firmware image.
+        protocol: VMBootProtocol,
+    },
+    /// Firmware boot was selected without a load address.
+    #[error("boot protocol {protocol:?} requires a firmware load address in bios_load_addr")]
+    MissingFirmwareLoadAddress {
+        /// The boot protocol requiring a firmware load address.
+        protocol: VMBootProtocol,
+    },
+}
+
+impl From<toml::de::Error> for AxVmConfigError {
+    fn from(error: toml::de::Error) -> Self {
+        Self::TomlParse {
+            detail: error.to_string(),
+        }
+    }
+}

--- a/virtualization/axvmconfig/src/lib.rs
+++ b/virtualization/axvmconfig/src/lib.rs
@@ -24,12 +24,15 @@ extern crate log;
 
 use alloc::{string::String, vec::Vec};
 
-use ax_errno::AxResult;
 pub use axvm_types::{
     AddressSpacePolicy, EmulatedDeviceConfig, EmulatedDeviceType, PassThroughAddressConfig,
     PassThroughDeviceConfig, PassThroughPortConfig, ReservedAddressConfig, VMBootProtocol,
     VMInterruptMode, VMType, VmMemConfig, VmMemMappingType,
 };
+
+mod error;
+
+pub use error::*;
 
 mod emu_device_type_serde {
     use serde::{Deserialize, Deserializer, Serializer, de};
@@ -733,27 +736,27 @@ impl VMKernelConfig {
     }
 
     /// Validate that the configured boot protocol has the firmware inputs it needs.
-    pub fn validate_boot_config(&self) -> AxResult<()> {
+    pub fn validate_boot_config(&self) -> AxVmConfigResult {
         self.validate_boot_config_for_arch(BUILD_TARGET_ARCH)
     }
 
-    fn validate_boot_config_for_arch(&self, arch: &str) -> AxResult<()> {
+    fn validate_boot_config_for_arch(&self, arch: &str) -> AxVmConfigResult {
         let protocol = self.effective_boot_protocol();
         if !self.enable_bios {
             if protocol != VMBootProtocol::Direct {
-                return Err(ax_errno::ax_err_type!(
-                    InvalidInput,
-                    "boot_protocol requires enable_bios = true"
-                ));
+                return Err(AxVmConfigError::BootProtocolConflict {
+                    protocol,
+                    enable_bios: self.enable_bios,
+                });
             }
             return Ok(());
         }
 
         if protocol == VMBootProtocol::Direct {
-            return Err(ax_errno::ax_err_type!(
-                InvalidInput,
-                "direct boot must not set enable_bios = true"
-            ));
+            return Err(AxVmConfigError::BootProtocolConflict {
+                protocol,
+                enable_bios: self.enable_bios,
+            });
         }
 
         let support = boot_protocol_support(protocol);
@@ -763,34 +766,25 @@ impl VMKernelConfig {
                 boot_protocol_name(protocol),
                 support.supported_arches.join(", ")
             );
-            return Err(ax_errno::ax_err_type!(
-                InvalidInput,
-                "boot protocol is not supported on this architecture"
-            ));
+            return Err(AxVmConfigError::UnsupportedBootProtocol {
+                protocol,
+                arch: arch.into(),
+            });
         }
 
         if support.requires_firmware_path && self.boot_firmware_path().is_none() {
-            return Err(ax_errno::ax_err_type!(
-                InvalidInput,
-                "firmware boot requires uefi_firmware_path or legacy bios_path"
-            ));
+            return Err(AxVmConfigError::MissingFirmwarePath { protocol });
         }
 
         if support.requires_firmware_load_addr && self.bios_load_addr.is_none() {
-            return Err(ax_errno::ax_err_type!(
-                InvalidInput,
-                "firmware boot requires bios_load_addr"
-            ));
+            return Err(AxVmConfigError::MissingFirmwareLoadAddress { protocol });
         }
 
         if support.optional_firmware_requires_load_addr
             && self.bios_path.is_some()
             && self.bios_load_addr.is_none()
         {
-            return Err(ax_errno::ax_err_type!(
-                InvalidInput,
-                "external firmware boot requires bios_load_addr"
-            ));
+            return Err(AxVmConfigError::MissingFirmwareLoadAddress { protocol });
         }
 
         Ok(())
@@ -887,11 +881,8 @@ pub struct AxVMCrateConfig {
 
 impl AxVMCrateConfig {
     /// Deserialize the toml string to `AxVMCrateConfig`.
-    pub fn from_toml(raw_cfg_str: &str) -> AxResult<Self> {
-        let mut config: AxVMCrateConfig = toml::from_str(raw_cfg_str).map_err(|err| {
-            warn!("Config TOML parse error {:?}", err.message());
-            ax_errno::ax_err_type!(InvalidInput, alloc::format!("Error details {err:?}"))
-        })?;
+    pub fn from_toml(raw_cfg_str: &str) -> AxVmConfigResult<Self> {
+        let mut config: AxVMCrateConfig = toml::from_str(raw_cfg_str)?;
         config.kernel.validate_boot_config()?;
         config.kernel.configured_memory_region_count = config.kernel.memory_regions.len();
         Ok(config)

--- a/virtualization/axvmconfig/src/test.rs
+++ b/virtualization/axvmconfig/src/test.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::{
-    AddressSpacePolicy, AxVMCrateConfig, EmulatedDeviceType, VMBootProtocol, VMDevicesConfig,
-    VMInterruptMode, VmMemMappingType,
+    AddressSpacePolicy, AxVMCrateConfig, AxVmConfigError, EmulatedDeviceType, VMBootProtocol,
+    VMDevicesConfig, VMInterruptMode, VmMemMappingType,
 };
 
 #[test]
@@ -330,7 +330,56 @@ fn test_boot_config_validation_rejects_direct_bios_mix() {
         ..Default::default()
     };
 
-    assert!(direct_with_bios.validate_boot_config().is_err());
+    assert_eq!(
+        direct_with_bios.validate_boot_config(),
+        Err(AxVmConfigError::BootProtocolConflict {
+            protocol: VMBootProtocol::Direct,
+            enable_bios: true,
+        })
+    );
+}
+
+#[test]
+fn test_boot_config_validation_returns_typed_firmware_errors() {
+    let mut uefi_config = crate::VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Uefi),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        uefi_config.validate_boot_config_for_arch("x86_64"),
+        Err(AxVmConfigError::MissingFirmwarePath {
+            protocol: VMBootProtocol::Uefi,
+        })
+    );
+
+    uefi_config.uefi_firmware_path = Some("OVMF_CODE.fd".to_string());
+    assert_eq!(
+        uefi_config.validate_boot_config_for_arch("x86_64"),
+        Err(AxVmConfigError::MissingFirmwareLoadAddress {
+            protocol: VMBootProtocol::Uefi,
+        })
+    );
+}
+
+#[test]
+fn test_boot_config_validation_returns_typed_architecture_error() {
+    let uefi_config = crate::VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Uefi),
+        uefi_firmware_path: Some("OVMF_CODE.fd".to_string()),
+        bios_load_addr: Some(0xffc0_0000),
+        ..Default::default()
+    };
+
+    assert_eq!(
+        uefi_config.validate_boot_config_for_arch("aarch64"),
+        Err(AxVmConfigError::UnsupportedBootProtocol {
+            protocol: VMBootProtocol::Uefi,
+            arch: "aarch64".to_string(),
+        })
+    );
 }
 
 #[test]
@@ -498,7 +547,7 @@ fn test_emulated_device_type_display() {
 
 #[test]
 fn test_config_from_toml_error_handling() {
-    use crate::AxVMCrateConfig;
+    use crate::{AxVMCrateConfig, AxVmConfigError};
 
     let invalid_toml = r#"
 [base
@@ -506,7 +555,7 @@ id = "invalid"
     "#;
 
     let result = AxVMCrateConfig::from_toml(invalid_toml);
-    assert!(result.is_err());
+    assert!(matches!(result, Err(AxVmConfigError::TomlParse { .. })));
 
     let invalid_data_type = r#"
 [base]
@@ -517,7 +566,7 @@ cpu_num = 1
     "#;
 
     let result = AxVMCrateConfig::from_toml(invalid_data_type);
-    assert!(result.is_err());
+    assert!(matches!(result, Err(AxVmConfigError::TomlParse { .. })));
 }
 
 #[test]

--- a/virtualization/axvmconfig/tests/error_contract.rs
+++ b/virtualization/axvmconfig/tests/error_contract.rs
@@ -1,0 +1,45 @@
+use std::{fs, path::Path};
+
+use axvmconfig::{AxVmConfigError, AxVmConfigResult, VMBootProtocol, VMKernelConfig};
+
+#[test]
+fn crate_uses_typed_errors_and_workspace_dependencies() {
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest = fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
+    let sources = fs::read_to_string(crate_dir.join("src/lib.rs")).unwrap()
+        + &fs::read_to_string(crate_dir.join("src/error.rs")).unwrap();
+
+    let errno_package = ["ax", "-errno"].concat();
+    let errno_module = ["ax", "_errno"].concat();
+    assert!(!manifest.contains(&errno_package));
+    assert!(!sources.contains(&errno_module));
+    assert!(manifest.contains("thiserror = { workspace = true }"));
+    assert!(manifest.contains("toml = { workspace = true"));
+
+    fn assert_error_contract<T: core::error::Error + Clone + Eq>() {}
+    fn assert_result_alias(_: AxVmConfigResult<usize>) {}
+    assert_error_contract::<AxVmConfigError>();
+    assert_result_alias(Ok(1));
+}
+
+#[test]
+fn public_errors_preserve_parse_and_boot_context() {
+    let parse_error = axvmconfig::AxVMCrateConfig::from_toml("[base").unwrap_err();
+    assert!(matches!(parse_error, AxVmConfigError::TomlParse { .. }));
+    assert!(parse_error.to_string().contains("VM TOML configuration"));
+
+    let direct_with_bios = VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Direct),
+        ..Default::default()
+    };
+    let conflict = direct_with_bios.validate_boot_config().unwrap_err();
+    assert_eq!(
+        conflict,
+        AxVmConfigError::BootProtocolConflict {
+            protocol: VMBootProtocol::Direct,
+            enable_bios: true,
+        }
+    );
+    assert!(conflict.to_string().contains("enable_bios = true"));
+}


### PR DESCRIPTION
## 问题

`axvmconfig` 的公开解析和启动校验接口仍返回通用 errno，TOML 解析、启动协议组合冲突、架构不支持以及固件参数缺失都会被压缩成 `InvalidInput`。AxVM 和 AxVisor 因此只能再次字符串化错误，调用方无法按配置失败原因进行匹配。

此外，`axvmconfig` 仍直接声明旧版 `toml 0.9.5`，没有继承 workspace 的统一依赖版本。

## 改动

- 新增 `AxVmConfigError` 和 `AxVmConfigResult<T = ()>`，错误类型基于 workspace `thiserror`。
- 分别表达 TOML 解析失败、BIOS/直接启动组合冲突、架构不支持、缺少固件路径以及缺少固件加载地址。
- `AxVMCrateConfig::from_toml` 与 `VMKernelConfig::validate_boot_config` 统一返回领域结果。
- 为 `toml::de::Error -> AxVmConfigError -> AxVmError` 建立 `From` 转换，并在语义完整的边界使用 `?`。
- AxVM 将配置错误统一映射到 `AxVmError::InvalidConfig`；AxVisor 使用 `anyhow::Context` 保留应用层解析上下文和完整错误链。
- 删除 `axvmconfig` 对 `ax-errno` 的依赖。
- 将 workspace `toml` 更新为当前最新 `1.1.2`（实际发布版本 `1.1.2+spec-1.1.0`），workspace 仅关闭默认 features；`axvmconfig` 与 `axbuild` 分别在自身 manifest 中启用所需的 `serde/parse/display` features。
- 增加错误契约、变体匹配、Display 上下文和 AxVM 转换测试。

## 实现逻辑

配置 crate 负责保留可匹配的配置语义；AxVM 只在领域边界将其归入 VM 配置错误；AxVisor 作为应用层通过 `Context` 补充操作信息。下层错误已经包含完整信息时使用 `From + ?`，避免重复 `map_err` 和字符串拼接。依赖 features 由各消费 crate 按需开启，避免 workspace 隐式扩大功能集合。启动策略及兼容默认值保持不变。

## 验证

- `cargo fmt --all --check`
- `cargo test -p axvmconfig`
- `cargo check -p axvmconfig --no-default-features --lib`
- `cargo check -p axbuild`
- `cargo test -p axvm`
- `cargo xtask clippy --package axvmconfig`
- `cargo xtask clippy --package axbuild`
- `cargo xtask clippy --package axvm`
- `cargo xtask axvisor build --arch x86_64`
- `cargo xtask axvisor build --arch aarch64`
- `cargo xtask axvisor build --arch riscv64`
- `cargo xtask axvisor build --arch loongarch64`
