### PR TITLE
refactor(axhvc): introduce hypercall errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,7 +1295,7 @@ dependencies = [
 name = "axhvc"
 version = "0.4.10"
 dependencies = [
- "ax-errno 0.6.1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/virtualization/axhvc/Cargo.toml
+++ b/virtualization/axhvc/Cargo.toml
@@ -12,8 +12,7 @@ categories = ["no-std", "embedded", "os"]
 license = "Apache-2.0"
 
 [dependencies]
-# Error types for ArceOS ecosystem
-ax-errno = { workspace = true }
+thiserror = { workspace = true }
 [package.metadata.docs.rs]
 all-features = true
 default-target = "x86_64-unknown-linux-gnu"

--- a/virtualization/axhvc/src/error.rs
+++ b/virtualization/axhvc/src/error.rs
@@ -1,0 +1,100 @@
+//! Hypercall error contract.
+
+use alloc::string::String;
+
+use crate::HyperCallCode;
+
+/// Result type returned by hypercall operations.
+pub type HyperCallResult<T = usize> = Result<T, HyperCallError>;
+
+/// Error returned when a raw value is not a supported hypercall code.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("invalid hypercall code: {0:#x}")]
+pub struct InvalidHyperCallCode(
+    /// The invalid numeric hypercall code.
+    pub u32,
+);
+
+/// Errors reported while decoding or executing a hypercall.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum HyperCallError {
+    /// A raw hypercall code is not defined by the interface.
+    #[error(transparent)]
+    InvalidCode(#[from] InvalidHyperCallCode),
+    /// The hypercall code is valid but not implemented by the hypervisor.
+    #[error("hypercall {code:?} is unsupported: {detail}")]
+    Unsupported {
+        /// The unsupported hypercall code.
+        code: HyperCallCode,
+        /// Diagnostic detail describing the unsupported operation.
+        detail: String,
+    },
+    /// A hypercall argument is invalid.
+    #[error("hypercall {code:?} received invalid parameter {parameter}: {detail}")]
+    InvalidParameter {
+        /// The hypercall being executed.
+        code: HyperCallCode,
+        /// The invalid parameter name.
+        parameter: &'static str,
+        /// Diagnostic detail describing the invalid value.
+        detail: String,
+    },
+    /// Current hypervisor or resource state does not allow the operation.
+    #[error("hypercall {code:?} cannot run in the current state: {detail}")]
+    InvalidState {
+        /// The hypercall being executed.
+        code: HyperCallCode,
+        /// Diagnostic detail describing the current state.
+        detail: String,
+    },
+    /// A resource required by the hypercall does not exist.
+    #[error("hypercall {code:?} could not find resource {resource}: {detail}")]
+    ResourceNotFound {
+        /// The hypercall being executed.
+        code: HyperCallCode,
+        /// The missing resource.
+        resource: String,
+        /// Diagnostic detail identifying the failed lookup.
+        detail: String,
+    },
+    /// A resource requested by the hypercall conflicts with existing state.
+    #[error("hypercall {code:?} resource conflict for {resource}: {detail}")]
+    ResourceConflict {
+        /// The hypercall being executed.
+        code: HyperCallCode,
+        /// The conflicting resource.
+        resource: String,
+        /// Diagnostic detail identifying the conflict.
+        detail: String,
+    },
+    /// Memory allocation for the hypercall failed.
+    #[error("hypercall {code:?} ran out of memory while {operation}")]
+    OutOfMemory {
+        /// The hypercall being executed.
+        code: HyperCallCode,
+        /// The allocation operation that failed.
+        operation: &'static str,
+    },
+    /// Reading from or writing to guest memory failed.
+    #[error("hypercall {code:?} failed to {operation} at guest address {address:#x}: {detail}")]
+    GuestMemoryAccess {
+        /// The hypercall being executed.
+        code: HyperCallCode,
+        /// The guest-memory operation that failed.
+        operation: &'static str,
+        /// Guest physical address supplied by the caller.
+        address: usize,
+        /// Diagnostic detail from the VM memory layer.
+        detail: String,
+    },
+    /// An internal hypervisor operation failed.
+    #[error("hypercall {code:?} internal operation {operation} failed: {detail}")]
+    Internal {
+        /// The hypercall being executed.
+        code: HyperCallCode,
+        /// The internal operation that failed.
+        operation: &'static str,
+        /// Diagnostic detail from the implementation.
+        detail: String,
+    },
+}

--- a/virtualization/axhvc/src/lib.rs
+++ b/virtualization/axhvc/src/lib.rs
@@ -44,7 +44,10 @@
 //!             // Handle hypervisor disable request
 //!             Ok(0)
 //!         }
-//!         _ => Err(ax_errno::AxError::Unsupported),
+//!         _ => Err(axhvc::HyperCallError::Unsupported {
+//!             code,
+//!             detail: "not implemented by this handler".into(),
+//!         }),
 //!     }
 //! }
 //! ```
@@ -56,7 +59,11 @@
 #![no_std]
 #![deny(missing_docs)]
 
-use ax_errno::AxResult;
+extern crate alloc;
+
+mod error;
+
+pub use error::{HyperCallError, HyperCallResult, InvalidHyperCallCode};
 
 /// Hypercall operation codes for AxVisor.
 ///
@@ -185,19 +192,6 @@ pub enum HyperCallCode {
     HIVCUnSubscribChannel = 6,
 }
 
-/// Error type for invalid hypercall code conversion.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct InvalidHyperCallCode(
-    /// The invalid numeric value that was attempted to convert.
-    pub u32,
-);
-
-impl core::fmt::Display for InvalidHyperCallCode {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "invalid hypercall code: {:#x}", self.0)
-    }
-}
-
 impl TryFrom<u32> for HyperCallCode {
     type Error = InvalidHyperCallCode;
 
@@ -240,21 +234,3 @@ impl core::fmt::Debug for HyperCallCode {
         write!(f, ")")
     }
 }
-
-/// The result type for hypercall operations.
-///
-/// This is an alias for [`AxResult<usize>`], where:
-/// - `Ok(value)` indicates successful execution with a return value
-/// - `Err(error)` indicates failure with an error code
-///
-/// # Example
-///
-/// ```ignore
-/// use axhvc::HyperCallResult;
-///
-/// fn my_hypercall_handler() -> HyperCallResult {
-///     // Perform hypercall operation...
-///     Ok(0)
-/// }
-/// ```
-pub type HyperCallResult = AxResult<usize>;

--- a/virtualization/axhvc/tests/error_contract.rs
+++ b/virtualization/axhvc/tests/error_contract.rs
@@ -1,0 +1,89 @@
+use std::{fs, path::Path};
+
+use axhvc::{HyperCallCode, HyperCallError, HyperCallResult, InvalidHyperCallCode};
+
+#[test]
+fn crate_uses_typed_errors_without_errno_contracts() {
+    let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let manifest = fs::read_to_string(crate_dir.join("Cargo.toml")).unwrap();
+    let sources = fs::read_to_string(crate_dir.join("src/lib.rs")).unwrap()
+        + &fs::read_to_string(crate_dir.join("src/error.rs")).unwrap();
+
+    let errno_package = ["ax", "-errno"].concat();
+    let errno_module = ["ax", "_errno"].concat();
+    assert!(!manifest.contains(&errno_package));
+    assert!(!sources.contains(&errno_module));
+    assert!(manifest.contains("thiserror = { workspace = true }"));
+
+    fn assert_error_contract<T: core::error::Error + Clone + Eq>() {}
+    fn assert_result_alias(_: HyperCallResult<usize>) {}
+    assert_error_contract::<InvalidHyperCallCode>();
+    assert_error_contract::<HyperCallError>();
+    assert_result_alias(Ok(0));
+}
+
+#[test]
+fn errors_preserve_code_resource_and_guest_address_context() {
+    let invalid: HyperCallError = InvalidHyperCallCode(0xff).into();
+    assert!(matches!(invalid, HyperCallError::InvalidCode(_)));
+    assert!(invalid.to_string().contains("0xff"));
+
+    let conflict = HyperCallError::ResourceConflict {
+        code: HyperCallCode::HIVCPublishChannel,
+        resource: "IVC channel 7".into(),
+        detail: "already published".into(),
+    };
+    assert!(conflict.to_string().contains("IVC channel 7"));
+
+    let access = HyperCallError::GuestMemoryAccess {
+        code: HyperCallCode::HIVCSubscribChannel,
+        operation: "write subscription result",
+        address: 0x4000,
+        detail: "unmapped guest page".into(),
+    };
+    assert!(access.to_string().contains("0x4000"));
+}
+
+#[test]
+fn execution_error_categories_remain_matchable() {
+    let code = HyperCallCode::HIVCPublishChannel;
+    let errors = [
+        HyperCallError::Unsupported {
+            code,
+            detail: "disabled by host policy".into(),
+        },
+        HyperCallError::InvalidParameter {
+            code,
+            parameter: "shm_size_ptr",
+            detail: "address is not aligned".into(),
+        },
+        HyperCallError::InvalidState {
+            code,
+            detail: "channel was unpublished".into(),
+        },
+        HyperCallError::ResourceNotFound {
+            code,
+            resource: "IVC channel 7".into(),
+            detail: "publisher does not own the key".into(),
+        },
+        HyperCallError::OutOfMemory {
+            code,
+            operation: "allocate shared frame",
+        },
+        HyperCallError::Internal {
+            code,
+            operation: "map shared frame",
+            detail: "stage-2 mapping failed".into(),
+        },
+    ];
+
+    assert!(matches!(errors[0], HyperCallError::Unsupported { .. }));
+    assert!(matches!(errors[1], HyperCallError::InvalidParameter { .. }));
+    assert!(matches!(errors[2], HyperCallError::InvalidState { .. }));
+    assert!(matches!(errors[3], HyperCallError::ResourceNotFound { .. }));
+    assert!(matches!(errors[4], HyperCallError::OutOfMemory { .. }));
+    assert!(matches!(errors[5], HyperCallError::Internal { .. }));
+    for error in errors {
+        assert!(error.to_string().contains("HIVCPublishChannel"));
+    }
+}

--- a/virtualization/axvm/src/architecture/exit.rs
+++ b/virtualization/axvm/src/architecture/exit.rs
@@ -43,14 +43,16 @@ pub(crate) fn handle_hypercall<V: VmArchVcpuOps, D>(
         Ok(hypercall) => {
             let ret_val = match hypercall.execute() {
                 Ok(ret_val) => ret_val as isize,
-                Err(err) => {
+                Err(error) => {
+                    let err = AxVmError::from(error);
                     warn!("Hypercall [{:#x}] failed: {err:?}", exit.nr);
                     -1
                 }
             };
             vcpu.set_return_value(ret_val as usize);
         }
-        Err(err) => {
+        Err(error) => {
+            let err = AxVmError::from(error);
             warn!("Hypercall [{:#x}] failed: {err:?}", exit.nr);
         }
     }

--- a/virtualization/axvm/src/error.rs
+++ b/virtualization/axvm/src/error.rs
@@ -6,6 +6,7 @@ use core::fmt::Display;
 use axaddrspace::AddrSpaceError;
 use axdevice::DeviceManagerError;
 use axdevice_base::{DeviceError, IrqError, RegistryError};
+use axhvc::HyperCallError;
 use axvmconfig::AxVmConfigError;
 
 use crate::{VMId, VmStatus};
@@ -234,6 +235,64 @@ impl From<AxVmConfigError> for AxVmError {
     }
 }
 
+impl From<HyperCallError> for AxVmError {
+    fn from(error: HyperCallError) -> Self {
+        match error {
+            HyperCallError::InvalidCode(error) => Self::invalid_input("decode hypercall", error),
+            HyperCallError::Unsupported { code, detail } => Self::Unsupported {
+                operation: "execute hypercall",
+                detail: format!("hypercall {code:?}: {detail}"),
+            },
+            HyperCallError::InvalidParameter {
+                code,
+                parameter,
+                detail,
+            } => Self::InvalidInput {
+                operation: "execute hypercall",
+                detail: format!("hypercall {code:?} parameter {parameter}: {detail}"),
+            },
+            HyperCallError::InvalidState { code, detail } => Self::InvalidState {
+                operation: "execute hypercall",
+                detail: format!("hypercall {code:?}: {detail}"),
+            },
+            HyperCallError::ResourceNotFound {
+                code,
+                resource,
+                detail,
+            } => Self::resource_unavailable(
+                "hypercall resource",
+                format_args!("hypercall {code:?} could not find {resource}: {detail}"),
+            ),
+            HyperCallError::ResourceConflict {
+                code,
+                resource,
+                detail,
+            } => Self::resource_conflict(
+                "hypercall resource",
+                format_args!("hypercall {code:?} conflict for {resource}: {detail}"),
+            ),
+            HyperCallError::OutOfMemory { operation, .. } => Self::OutOfMemory { operation },
+            HyperCallError::GuestMemoryAccess {
+                code,
+                operation,
+                address,
+                detail,
+            } => Self::Memory {
+                operation,
+                detail: format!("hypercall {code:?} guest address {address:#x}: {detail}"),
+            },
+            HyperCallError::Internal {
+                code,
+                operation,
+                detail,
+            } => Self::Host {
+                operation,
+                detail: format!("hypercall {code:?}: {detail}"),
+            },
+        }
+    }
+}
+
 impl From<IrqError> for AxVmError {
     fn from(error: IrqError) -> Self {
         Self::interrupt("route virtual device interrupt", error)
@@ -430,5 +489,62 @@ mod tests {
         assert!(matches!(error, AxVmError::InvalidConfig { .. }));
         assert!(error.to_string().contains("Uefi"));
         assert!(error.to_string().contains("aarch64"));
+    }
+
+    #[test]
+    fn hypercall_errors_map_to_matching_axvm_domains() {
+        let code = axhvc::HyperCallCode::HIVCPublishChannel;
+        let invalid_code = AxVmError::from(HyperCallError::from(axhvc::InvalidHyperCallCode(0xff)));
+        let cases = [
+            AxVmError::from(HyperCallError::InvalidParameter {
+                code,
+                parameter: "shm_size_ptr",
+                detail: "unaligned".to_string(),
+            }),
+            AxVmError::from(HyperCallError::InvalidState {
+                code,
+                detail: "channel is unpublished".to_string(),
+            }),
+            AxVmError::from(HyperCallError::ResourceNotFound {
+                code,
+                resource: "IVC channel 7".to_string(),
+                detail: "not registered".to_string(),
+            }),
+            AxVmError::from(HyperCallError::ResourceConflict {
+                code,
+                resource: "IVC channel 7".to_string(),
+                detail: "already registered".to_string(),
+            }),
+            AxVmError::from(HyperCallError::OutOfMemory {
+                code,
+                operation: "allocate IVC frame",
+            }),
+            AxVmError::from(HyperCallError::GuestMemoryAccess {
+                code,
+                operation: "write IVC result",
+                address: 0x4000,
+                detail: "unmapped".to_string(),
+            }),
+            AxVmError::from(HyperCallError::Unsupported {
+                code,
+                detail: "disabled".to_string(),
+            }),
+            AxVmError::from(HyperCallError::Internal {
+                code,
+                operation: "map IVC frame",
+                detail: "mapping failed".to_string(),
+            }),
+        ];
+
+        assert!(matches!(invalid_code, AxVmError::InvalidInput { .. }));
+        assert!(invalid_code.to_string().contains("0xff"));
+        assert!(matches!(cases[0], AxVmError::InvalidInput { .. }));
+        assert!(matches!(cases[1], AxVmError::InvalidState { .. }));
+        assert!(matches!(cases[2], AxVmError::ResourceUnavailable { .. }));
+        assert!(matches!(cases[3], AxVmError::ResourceConflict { .. }));
+        assert!(matches!(cases[4], AxVmError::OutOfMemory { .. }));
+        assert!(matches!(cases[5], AxVmError::Memory { .. }));
+        assert!(matches!(cases[6], AxVmError::Unsupported { .. }));
+        assert!(matches!(cases[7], AxVmError::Host { .. }));
     }
 }

--- a/virtualization/axvm/src/runtime/hvc.rs
+++ b/virtualization/axvm/src/runtime/hvc.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use axhvc::HyperCallCode;
+use alloc::format;
+
+use axhvc::{HyperCallCode, HyperCallError, HyperCallResult};
 
 use crate::{
-    AxVmError, AxVmResult, GuestPhysAddr, MappingFlags, ax_err, ax_err_type,
+    AxVmError, GuestPhysAddr, MappingFlags,
     runtime::{
         VMRef,
         ivc::{self, IVCChannel},
@@ -29,16 +31,13 @@ pub struct HyperCall {
 }
 
 impl HyperCall {
-    pub fn new(vm: VMRef, code: u64, args: [u64; 6]) -> AxVmResult<Self> {
-        let code = HyperCallCode::try_from(code as u32).map_err(|e| {
-            warn!("Invalid hypercall code: {code} e {e:?}");
-            ax_err_type!(InvalidInput)
-        })?;
+    pub fn new(vm: VMRef, code: u64, args: [u64; 6]) -> HyperCallResult<Self> {
+        let code = HyperCallCode::try_from(code as u32)?;
 
         Ok(Self { vm, code, args })
     }
 
-    pub fn execute(&self) -> AxVmResult<usize> {
+    pub fn execute(&self) -> HyperCallResult {
         match self.code {
             HyperCallCode::HIVCPublishChannel => {
                 let key = self.args[0] as usize;
@@ -53,14 +52,24 @@ impl HyperCall {
                 );
                 // User will pass the size of the shared memory region,
                 // we will allocate the shared memory region based on this size.
-                let shm_region_size = self.vm.read_from_guest_of::<usize>(shm_size_ptr)?;
-                ivc::ensure_channel_absent(self.vm.id(), key)?;
+                let shm_region_size =
+                    self.vm
+                        .read_from_guest_of::<usize>(shm_size_ptr)
+                        .map_err(|error| {
+                            self.guest_memory_error("read IVC channel size", shm_size_ptr, error)
+                        })?;
+                ivc::ensure_channel_absent(self.vm.id(), key).map_err(|error| {
+                    self.operation_error("check IVC channel availability", error)
+                })?;
                 let requested_size = shm_region_size.min(ivc::MAX_IVC_CHANNEL_SIZE);
-                let (shm_base_gpa, shm_region_size) = self.vm.alloc_ivc_channel(requested_size)?;
+                let (shm_base_gpa, shm_region_size) =
+                    self.vm.alloc_ivc_channel(requested_size).map_err(|error| {
+                        self.operation_error("reserve IVC guest address range", error)
+                    })?;
 
                 let ivc_channel =
                     match IVCChannel::alloc(self.vm.id(), key, shm_region_size, shm_base_gpa)
-                        .map_err(|error| AxVmError::memory("allocate IVC channel", error))
+                        .map_err(|error| self.operation_error("allocate IVC channel", error))
                     {
                         Ok(channel) => channel,
                         Err(err) => {
@@ -94,7 +103,7 @@ impl HyperCall {
                             self.vm.id()
                         );
                     }
-                    return Err(err);
+                    return Err(self.operation_error("map publisher IVC channel", err));
                 }
 
                 if let Err(err) = self
@@ -118,7 +127,11 @@ impl HyperCall {
                             self.vm.id()
                         );
                     }
-                    return Err(err);
+                    return Err(self.guest_memory_error(
+                        "write published IVC channel result",
+                        shm_base_gpa_ptr,
+                        err,
+                    ));
                 }
 
                 if let Err(err) = ivc::insert_channel(self.vm.id(), ivc_channel) {
@@ -138,7 +151,7 @@ impl HyperCall {
                             self.vm.id()
                         );
                     }
-                    return Err(err);
+                    return Err(self.operation_error("register published IVC channel", err));
                 }
 
                 Ok(0)
@@ -152,11 +165,18 @@ impl HyperCall {
                     self.code,
                     key
                 );
-                let (base_gpa, size) = ivc::unpublish_channel(self.vm.id(), key)?;
+                let (base_gpa, size) = ivc::unpublish_channel(self.vm.id(), key)
+                    .map_err(|error| self.operation_error("unpublish IVC channel", error))?;
                 // The publisher's GPA mapping is always unmapped; subscribers keep their own
                 // GPA views. The shared HPA frame is freed when the last subscriber leaves.
-                self.vm.unmap_region(base_gpa, size)?;
-                self.vm.release_ivc_channel(base_gpa, size)?;
+                self.vm.unmap_region(base_gpa, size).map_err(|error| {
+                    self.operation_error("unmap unpublished IVC channel", error)
+                })?;
+                self.vm
+                    .release_ivc_channel(base_gpa, size)
+                    .map_err(|error| {
+                        self.operation_error("release unpublished IVC channel", error)
+                    })?;
 
                 Ok(0)
             }
@@ -173,8 +193,14 @@ impl HyperCall {
                     publisher_vm_id
                 );
 
-                let shm_size = ivc::prepare_subscribe_channel(publisher_vm_id, key, self.vm.id())?;
-                let (shm_base_gpa, shm_region_size) = self.vm.alloc_ivc_channel(shm_size)?;
+                let shm_size = ivc::prepare_subscribe_channel(publisher_vm_id, key, self.vm.id())
+                    .map_err(|error| {
+                    self.operation_error("prepare IVC channel subscription", error)
+                })?;
+                let (shm_base_gpa, shm_region_size) =
+                    self.vm.alloc_ivc_channel(shm_size).map_err(|error| {
+                        self.operation_error("reserve subscriber IVC guest address range", error)
+                    })?;
 
                 let subscribe_result = ivc::subscribe_to_channel_of_publisher(
                     publisher_vm_id,
@@ -194,7 +220,7 @@ impl HyperCall {
                                 self.vm.id()
                             );
                         }
-                        return Err(err);
+                        return Err(self.operation_error("register IVC channel subscriber", err));
                     }
                 };
 
@@ -226,7 +252,7 @@ impl HyperCall {
                             self.vm.id()
                         );
                     }
-                    return Err(err);
+                    return Err(self.operation_error("map subscriber IVC channel", err));
                 }
 
                 if let Err(err) = self
@@ -262,7 +288,11 @@ impl HyperCall {
                             self.vm.id()
                         );
                     }
-                    return Err(err);
+                    return Err(self.guest_memory_error(
+                        "write subscribed IVC channel result",
+                        shm_base_gpa_ptr,
+                        err,
+                    ));
                 }
 
                 info!(
@@ -285,16 +315,93 @@ impl HyperCall {
                     publisher_vm_id
                 );
                 let (base_gpa, size) =
-                    ivc::unsubscribe_from_channel_of_publisher(publisher_vm_id, key, self.vm.id())?;
-                self.vm.unmap_region(base_gpa, size)?;
-                self.vm.release_ivc_channel(base_gpa, size)?;
+                    ivc::unsubscribe_from_channel_of_publisher(publisher_vm_id, key, self.vm.id())
+                        .map_err(|error| {
+                            self.operation_error("unsubscribe from IVC channel", error)
+                        })?;
+                self.vm.unmap_region(base_gpa, size).map_err(|error| {
+                    self.operation_error("unmap unsubscribed IVC channel", error)
+                })?;
+                self.vm
+                    .release_ivc_channel(base_gpa, size)
+                    .map_err(|error| {
+                        self.operation_error("release unsubscribed IVC channel", error)
+                    })?;
 
                 Ok(0)
             }
             _ => {
                 warn!("Unsupported hypercall code: {:?}", self.code);
-                ax_err!(Unsupported)?
+                Err(HyperCallError::Unsupported {
+                    code: self.code,
+                    detail: "the hypervisor does not implement this control hypercall".into(),
+                })
             }
+        }
+    }
+
+    fn operation_error(&self, operation: &'static str, error: AxVmError) -> HyperCallError {
+        let detail = format!("{operation}: {error}");
+        match error {
+            AxVmError::InvalidInput { .. } => HyperCallError::InvalidParameter {
+                code: self.code,
+                parameter: "arguments",
+                detail,
+            },
+            AxVmError::InvalidState { .. } | AxVmError::InvalidTransition { .. } => {
+                HyperCallError::InvalidState {
+                    code: self.code,
+                    detail,
+                }
+            }
+            AxVmError::VmNotFound { vm_id } => HyperCallError::ResourceNotFound {
+                code: self.code,
+                resource: format!("VM {vm_id}"),
+                detail,
+            },
+            AxVmError::ResourceUnavailable { resource, .. } => HyperCallError::ResourceNotFound {
+                code: self.code,
+                resource: resource.into(),
+                detail,
+            },
+            AxVmError::ResourceConflict { resource, .. } => HyperCallError::ResourceConflict {
+                code: self.code,
+                resource: resource.into(),
+                detail,
+            },
+            AxVmError::Unsupported { .. } => HyperCallError::Unsupported {
+                code: self.code,
+                detail,
+            },
+            AxVmError::OutOfMemory { .. } => HyperCallError::OutOfMemory {
+                code: self.code,
+                operation,
+            },
+            AxVmError::InvalidConfig { .. }
+            | AxVmError::Boot { .. }
+            | AxVmError::Memory { .. }
+            | AxVmError::Device { .. }
+            | AxVmError::Vcpu { .. }
+            | AxVmError::Interrupt { .. }
+            | AxVmError::Host { .. } => HyperCallError::Internal {
+                code: self.code,
+                operation,
+                detail,
+            },
+        }
+    }
+
+    fn guest_memory_error(
+        &self,
+        operation: &'static str,
+        address: GuestPhysAddr,
+        error: AxVmError,
+    ) -> HyperCallError {
+        HyperCallError::GuestMemoryAccess {
+            code: self.code,
+            operation,
+            address: address.as_usize(),
+            detail: format!("{error}"),
         }
     }
 }


### PR DESCRIPTION
## 问题

`axhvc` 仍通过 `ax-errno::AxResult` 暴露 hypercall 失败，调用方只能得到通用 errno，无法按 hypercall code、参数、资源、guest 地址和失败阶段匹配错误，也使虚拟化路径继续直接依赖 `ax-errno`。

## 修改

- 在 `axhvc` 中新增 `HyperCallError` 与泛型 `HyperCallResult<T = usize>`，覆盖非法 code、不支持、无效参数/状态、资源不存在/冲突、内存不足、guest 内存访问和内部失败。
- 将 `InvalidHyperCallCode` 改为 `thiserror::Error`，并通过 `#[from]` 支持直接使用 `?` 传播非法 code。
- 删除 `axhvc` 对 `ax-errno` 的直接依赖，改用 workspace `thiserror`；保留 `no_std`。
- AxVM hypercall/IVC 编排改为返回 `HyperCallResult`，在需要补充 code、操作、参数或 guest 地址时通过私有适配器转换下层 `AxVmError`。
- 增加 `From<HyperCallError> for AxVmError`，在 AxVM 架构退出边界统一转换；执行失败仍写入 `-1`，非法 code 仍沿用原有日志与完成行为。
- 增加错误契约、错误分类、Display 上下文以及 AxVM 领域映射测试。

## 设计说明

无歧义的转换使用 `From + ?`：原始 hypercall code 解码直接传播为 `HyperCallError::InvalidCode`，AxVM 出口统一使用 `From<HyperCallError>`。只有需要调用语境才能正确分类或补充 code/operation/address 的路径保留私有 `map_err` 适配，避免无上下文的全局转换。

## 验证

- `cargo fmt --all --check`
- `cargo test -p axhvc`
- `cargo test -p axvm`
- `cargo check -p axhvc --target x86_64-unknown-none`
- `cargo xtask clippy --package axhvc`
- `cargo xtask clippy --package axvm`
- `cargo xtask axvisor build --arch x86_64`
- `cargo xtask axvisor build --arch aarch64`
- `cargo xtask axvisor build --arch riscv64`
- `cargo xtask axvisor build --arch loongarch64`
