### PR TITLE
fix(axvisor): correct shell filesystem command handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,11 +442,13 @@ jobs:
             container_image: base
             limit_to_owner: ""
             main_pr_only: false
-          - name: Test axvisor aarch64 qemu (smoke)
+          - name: Test axvisor aarch64 qemu (smoke + axtest)
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
-            command: cargo xtask axvisor test qemu --arch aarch64 --test-case smoke
+            command: |
+              cargo xtask axvisor test qemu --arch aarch64 --test-case smoke
+              cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
             cache_key: ""
             container_image: base
             limit_to_owner: ""

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,9 @@ version = "0.5.23"
 dependencies = [
  "anyhow",
  "ax-driver",
+ "ax-hal",
  "ax-std",
+ "ax-task",
  "axbacktrace",
  "axbuild",
  "axtest",

--- a/fs/ax-fs-ng/src/api.rs
+++ b/fs/ax-fs-ng/src/api.rs
@@ -3,7 +3,7 @@ use alloc::string::{String, ToString};
 use ax_errno::AxResult;
 use axfs_ng_vfs::NodePermission;
 
-use crate::highlevel::current_fs_context;
+use crate::{fops::FileAttr, highlevel::current_fs_context};
 
 pub fn create_dir(path: &str) -> AxResult {
     current_fs_context()
@@ -41,4 +41,17 @@ pub fn set_current_dir(path: &str) -> AxResult {
     let dir = ctx.resolve(path)?;
     ctx.set_current_dir(dir)?;
     Ok(())
+}
+
+/// Returns metadata for a path after resolving its final symbolic link.
+pub fn metadata(path: &str) -> AxResult<FileAttr> {
+    current_fs_context().lock().metadata(path)
+}
+
+/// Returns metadata for a path without resolving its final symbolic link.
+pub fn symlink_metadata(path: &str) -> AxResult<FileAttr> {
+    current_fs_context()
+        .lock()
+        .resolve_no_follow(path)?
+        .metadata()
 }

--- a/fs/ax-fs-ng/src/block.rs
+++ b/fs/ax-fs-ng/src/block.rs
@@ -41,7 +41,7 @@ pub(crate) trait FsBlockDevice: Send {
     fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> AxResult;
     #[cfg(any(feature = "ext4", feature = "fat"))]
     fn write_block(&mut self, block_id: u64, buf: &[u8]) -> AxResult;
-    #[cfg(feature = "ext4")]
+    #[cfg(any(feature = "ext4", feature = "fat"))]
     fn flush(&mut self) -> AxResult;
 }
 
@@ -67,7 +67,7 @@ impl<T: FsBlockDevice + ?Sized> FsBlockDevice for Box<T> {
         (**self).write_block(block_id, buf)
     }
 
-    #[cfg(feature = "ext4")]
+    #[cfg(any(feature = "ext4", feature = "fat"))]
     fn flush(&mut self) -> AxResult {
         (**self).flush()
     }
@@ -146,7 +146,7 @@ impl<T: FsBlockDevice> FsBlockDevice for RegionBlockDevice<T> {
         self.inner.write_block(physical, buf)
     }
 
-    #[cfg(feature = "ext4")]
+    #[cfg(any(feature = "ext4", feature = "fat"))]
     fn flush(&mut self) -> AxResult {
         self.inner.flush()
     }
@@ -174,7 +174,7 @@ impl FsBlockDevice for NativeHandleBlockDevice {
         self.handle.write_blocks(block_id, buf)
     }
 
-    #[cfg(feature = "ext4")]
+    #[cfg(any(feature = "ext4", feature = "fat"))]
     fn flush(&mut self) -> AxResult {
         self.handle.flush_blocks()
     }

--- a/fs/ax-fs-ng/src/block/runtime/lifecycle/mod.rs
+++ b/fs/ax-fs-ng/src/block/runtime/lifecycle/mod.rs
@@ -19,7 +19,7 @@ use ax_errno::{AxError, AxResult};
 use controller::{ControllerPort, run_controller};
 use device::CpuSubmissionChannel;
 use irq_framework::IrqId;
-#[cfg(feature = "ext4")]
+#[cfg(any(feature = "ext4", feature = "fat"))]
 use rdif_block::RequestFlags;
 use rdif_block::{
     BatchSubmitError, BlkError, BlockController, BlockControllerGroup, BlockGroupMember,
@@ -786,7 +786,7 @@ impl BlockDeviceHandle {
         io::write_blocks(self, block_id, buf)
     }
 
-    #[cfg(feature = "ext4")]
+    #[cfg(any(feature = "ext4", feature = "fat"))]
     pub(crate) fn flush_blocks(&self) -> AxResult {
         let request = OwnedRequest {
             op: RequestOp::Flush,

--- a/fs/ax-fs-ng/src/fs/ext4/rsext4/fs.rs
+++ b/fs/ax-fs-ng/src/fs/ext4/rsext4/fs.rs
@@ -221,9 +221,19 @@ impl Ext4Filesystem {
         fs.sync_superblock(dev).map_err(into_vfs_err)?;
         fs.sync_group_descriptors(dev).map_err(into_vfs_err)?;
         if dev.is_use_journal() {
-            dev.umount_commit();
+            dev.umount_commit().map_err(into_vfs_err)?;
         }
         dev.cantflush().map_err(into_vfs_err)
+    }
+
+    fn shutdown_filesystem(&self) -> VfsResult<()> {
+        if self.readonly {
+            return Ok(());
+        }
+
+        let mut state = self.inner.lock();
+        let (fs, dev) = state.split();
+        fs.umount(dev).map_err(into_vfs_err)
     }
 }
 
@@ -265,5 +275,9 @@ impl FilesystemOps for Ext4Filesystem {
 
     fn flush(&self) -> VfsResult<()> {
         self.sync_to_disk()
+    }
+
+    fn shutdown(&self) -> VfsResult<()> {
+        self.shutdown_filesystem()
     }
 }

--- a/fs/ax-fs-ng/src/fs/fat/disk.rs
+++ b/fs/ax-fs-ng/src/fs/fat/disk.rs
@@ -1,9 +1,12 @@
-use alloc::{boxed::Box, vec};
+use alloc::{boxed::Box, sync::Arc, vec};
 use core::mem;
 
 use ax_errno::{AxError as FsBlockError, AxResult as FsBlockResult};
 
-use crate::block::{BlockRegion, FsBlockDevice, RegionBlockDevice};
+use crate::{
+    block::{BlockRegion, FsBlockDevice, RegionBlockDevice},
+    os::sync::SleepMutex,
+};
 
 fn take<'a>(buf: &mut &'a [u8], cnt: usize) -> &'a [u8] {
     let (first, rem) = buf.split_at(cnt);
@@ -20,6 +23,15 @@ fn take_mut<'a>(buf: &mut &'a mut [u8], cnt: usize) -> &'a mut [u8] {
 
 /// A disk device with a cursor.
 pub struct SeekableDisk {
+    state: Arc<SleepMutex<SeekableDiskState>>,
+}
+
+#[derive(Clone)]
+pub struct SeekableDiskFlusher {
+    state: Arc<SleepMutex<SeekableDiskState>>,
+}
+
+struct SeekableDiskState {
     dev: RegionBlockDevice<Box<dyn FsBlockDevice>>,
 
     block_id: u64,
@@ -42,50 +54,104 @@ impl SeekableDisk {
         let read_buffer = vec![0u8; block_size].into_boxed_slice();
         let write_buffer = vec![0u8; block_size].into_boxed_slice();
         Self {
-            dev: RegionBlockDevice::new(dev, region),
-            block_id: 0,
-            offset: 0,
-            block_size_log2,
-            read_buffer,
-            write_buffer,
-            write_buffer_dirty: false,
+            state: Arc::new(SleepMutex::new(SeekableDiskState {
+                dev: RegionBlockDevice::new(dev, region),
+                block_id: 0,
+                offset: 0,
+                block_size_log2,
+                read_buffer,
+                write_buffer,
+                write_buffer_dirty: false,
+            })),
+        }
+    }
+
+    pub fn flusher(&self) -> SeekableDiskFlusher {
+        SeekableDiskFlusher {
+            state: self.state.clone(),
         }
     }
 
     /// Get the size of the disk.
     pub fn size(&self) -> u64 {
-        self.dev.num_blocks() << self.block_size_log2
-    }
-
-    /// Get the block size.
-    pub fn block_size(&self) -> usize {
-        1 << self.block_size_log2
+        self.state.lock().size()
     }
 
     /// Get the position of the cursor.
     pub fn position(&self) -> u64 {
-        (self.block_id << self.block_size_log2) + self.offset as u64
+        self.state.lock().position()
     }
 
     /// Set the position of the cursor.
     pub fn set_position(&mut self, pos: u64) -> FsBlockResult<()> {
+        self.state.lock().set_position(pos)
+    }
+
+    /// Write all pending changes to the disk and issue a device flush.
+    pub fn flush(&mut self) -> FsBlockResult<()> {
+        self.state.lock().sync()
+    }
+
+    /// Read from the disk, returns the number of bytes read.
+    pub fn read(&mut self, buf: &mut [u8]) -> FsBlockResult<usize> {
+        self.state.lock().read(buf)
+    }
+
+    /// Write to the disk, returns the number of bytes written.
+    pub fn write(&mut self, buf: &[u8]) -> FsBlockResult<usize> {
+        self.state.lock().write(buf)
+    }
+}
+
+impl Drop for SeekableDisk {
+    fn drop(&mut self) {
+        if let Err(error) = self.state.lock().sync() {
+            error!("failed to flush FAT disk while dropping cursor: {error:?}");
+        }
+    }
+}
+
+impl SeekableDiskFlusher {
+    pub fn flush(&self) -> FsBlockResult<()> {
+        self.state.lock().sync()
+    }
+}
+
+impl SeekableDiskState {
+    fn size(&self) -> u64 {
+        self.dev.num_blocks() << self.block_size_log2
+    }
+
+    fn block_size(&self) -> usize {
+        1 << self.block_size_log2
+    }
+
+    fn position(&self) -> u64 {
+        (self.block_id << self.block_size_log2) + self.offset as u64
+    }
+
+    fn set_position(&mut self, pos: u64) -> FsBlockResult<()> {
         let block_id = pos >> self.block_size_log2;
         let offset = pos as usize & (self.block_size() - 1);
         if self.write_buffer_dirty && block_id != self.block_id {
-            self.flush()?;
+            self.flush_buffer()?;
         }
         self.block_id = block_id;
         self.offset = offset;
         Ok(())
     }
 
-    /// Write all pending changes to the disk.
-    pub fn flush(&mut self) -> FsBlockResult<()> {
+    fn flush_buffer(&mut self) -> FsBlockResult<()> {
         if self.write_buffer_dirty {
             self.dev.write_block(self.block_id, &self.write_buffer)?;
             self.write_buffer_dirty = false;
         }
         Ok(())
+    }
+
+    fn sync(&mut self) -> FsBlockResult<()> {
+        self.flush_buffer()?;
+        self.dev.flush()
     }
 
     fn read_partial(&mut self, buf: &mut &mut [u8]) -> FsBlockResult<usize> {
@@ -109,13 +175,13 @@ impl SeekableDisk {
     }
 
     /// Read from the disk, returns the number of bytes read.
-    pub fn read(&mut self, mut buf: &mut [u8]) -> FsBlockResult<usize> {
+    fn read(&mut self, mut buf: &mut [u8]) -> FsBlockResult<usize> {
         let mut read = 0;
         if self.offset != 0 {
             read += self.read_partial(&mut buf)?;
         }
         if buf.len() >= self.block_size() {
-            self.flush()?;
+            self.flush_buffer()?;
             let blocks = buf.len() >> self.block_size_log2;
             let length = blocks << self.block_size_log2;
             self.dev
@@ -146,7 +212,7 @@ impl SeekableDisk {
 
         self.offset += length;
         if self.offset == self.block_size() {
-            self.flush()?;
+            self.flush_buffer()?;
             self.block_id += 1;
             self.offset = 0;
         }
@@ -155,14 +221,14 @@ impl SeekableDisk {
     }
 
     /// Write to the disk, returns the number of bytes written.
-    pub fn write(&mut self, mut buf: &[u8]) -> FsBlockResult<usize> {
+    fn write(&mut self, mut buf: &[u8]) -> FsBlockResult<usize> {
         let mut written = 0;
         if self.offset != 0 {
             written += self.write_partial(&mut buf)?;
         }
         if buf.len() >= self.block_size() {
             if self.write_buffer_dirty {
-                self.flush()?;
+                self.flush_buffer()?;
             }
             let blocks = buf.len() >> self.block_size_log2;
             let length = blocks << self.block_size_log2;
@@ -180,5 +246,82 @@ impl SeekableDisk {
         }
 
         Ok(written)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+    use std::sync::Mutex;
+
+    use super::*;
+
+    struct MemoryBlockDevice {
+        storage: Arc<Mutex<Vec<u8>>>,
+        fail_flush: bool,
+    }
+
+    impl FsBlockDevice for MemoryBlockDevice {
+        fn name(&self) -> &str {
+            "memory"
+        }
+
+        fn num_blocks(&self) -> u64 {
+            1
+        }
+
+        fn block_size(&self) -> usize {
+            512
+        }
+
+        fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> FsBlockResult<()> {
+            assert_eq!(block_id, 0);
+            buf.copy_from_slice(&self.storage.lock().unwrap());
+            Ok(())
+        }
+
+        fn write_block(&mut self, block_id: u64, buf: &[u8]) -> FsBlockResult<()> {
+            assert_eq!(block_id, 0);
+            self.storage.lock().unwrap().copy_from_slice(buf);
+            Ok(())
+        }
+
+        fn flush(&mut self) -> FsBlockResult<()> {
+            if self.fail_flush {
+                Err(FsBlockError::Io)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn dropping_disk_persists_pending_partial_write() {
+        let storage = Arc::new(Mutex::new(vec![0; 512]));
+        let device = MemoryBlockDevice {
+            storage: storage.clone(),
+            fail_flush: false,
+        };
+        let mut disk = SeekableDisk::new(Box::new(device), BlockRegion::from_num_blocks(1));
+
+        disk.write(b"fat").expect("buffer partial FAT write");
+        drop(disk);
+
+        assert_eq!(&storage.lock().unwrap()[..3], b"fat");
+    }
+
+    #[test]
+    fn flusher_persists_pending_write_and_propagates_device_error() {
+        let storage = Arc::new(Mutex::new(vec![0; 512]));
+        let device = MemoryBlockDevice {
+            storage: storage.clone(),
+            fail_flush: true,
+        };
+        let mut disk = SeekableDisk::new(Box::new(device), BlockRegion::from_num_blocks(1));
+        let flusher = disk.flusher();
+        disk.write(b"fat").expect("buffer partial FAT write");
+
+        assert_eq!(flusher.flush(), Err(FsBlockError::Io));
+        assert_eq!(&storage.lock().unwrap()[..3], b"fat");
     }
 }

--- a/fs/ax-fs-ng/src/fs/fat/fs.rs
+++ b/fs/ax-fs-ng/src/fs/fat/fs.rs
@@ -6,7 +6,12 @@ use axfs_ng_vfs::{
 };
 use slab::Slab;
 
-use super::{dir::FatDirNode, disk::SeekableDisk, ff, util::into_vfs_err};
+use super::{
+    dir::FatDirNode,
+    disk::{SeekableDisk, SeekableDiskFlusher},
+    ff,
+    util::into_vfs_err,
+};
 use crate::{
     block::{BlockRegion, FsBlockDevice},
     os::sync::{IrqMutex, SleepMutex, SleepMutexGuard},
@@ -30,12 +35,14 @@ impl FatFilesystemInner {
 
 pub struct FatFilesystem {
     inner: SleepMutex<FatFilesystemInner>,
+    disk_flusher: SeekableDiskFlusher,
     root_dir: IrqMutex<Option<DirEntry>>,
 }
 
 impl FatFilesystem {
     pub fn new(dev: Box<dyn FsBlockDevice>, region: BlockRegion) -> VfsResult<Filesystem> {
         let disk = SeekableDisk::new(dev, region);
+        let disk_flusher = disk.flusher();
         let mut inner = FatFilesystemInner {
             inner: ff::FileSystem::new(disk, fatfs::FsOptions::new())
                 .expect("failed to initialize FAT filesystem"),
@@ -45,6 +52,7 @@ impl FatFilesystem {
         let root_inode = inner.alloc_inode();
         let result = Arc::new(Self {
             inner: SleepMutex::new(inner),
+            disk_flusher,
             root_dir: IrqMutex::default(),
         });
 
@@ -100,5 +108,14 @@ impl FilesystemOps for FatFilesystem {
             fragment_size: 0,
             mount_flags: 0,
         })
+    }
+
+    fn flush(&self) -> VfsResult<()> {
+        let _state = self.inner.lock();
+        self.disk_flusher.flush()
+    }
+
+    fn shutdown(&self) -> VfsResult<()> {
+        self.flush()
     }
 }

--- a/fs/ax-fs-ng/src/lib.rs
+++ b/fs/ax-fs-ng/src/lib.rs
@@ -12,9 +12,9 @@ extern crate alloc;
 #[macro_use]
 extern crate log;
 
-use alloc::sync::Arc;
+use alloc::{sync::Arc, vec::Vec};
 
-use axfs_ng_vfs::Location;
+use axfs_ng_vfs::{Filesystem, Location};
 
 pub mod api;
 pub mod block;
@@ -26,6 +26,13 @@ mod highlevel;
 pub mod os;
 pub mod root;
 pub mod volume;
+
+static MOUNTED_FILESYSTEMS: os::sync::IrqMutex<Vec<Filesystem>> =
+    os::sync::IrqMutex::new(Vec::new());
+
+fn register_mounted_filesystem(fs: Filesystem) {
+    MOUNTED_FILESYSTEMS.lock().push(fs);
+}
 
 pub use block::{
     BlockRegion,
@@ -93,6 +100,7 @@ fn finish_filesystem_init(fs: axfs_ng_vfs::Filesystem, source: &str) -> Location
 
     let mp = axfs_ng_vfs::Mountpoint::new_root_with_source(&fs, source);
     let root = mp.root_location();
+    register_mounted_filesystem(fs);
     highlevel::ROOT_FS_CONTEXT.call_once(|| highlevel::FsContext::new(root.clone()));
     root
 }
@@ -100,10 +108,14 @@ fn finish_filesystem_init(fs: axfs_ng_vfs::Filesystem, source: &str) -> Location
 pub fn shutdown_filesystems() -> ax_errno::AxResult {
     #[cfg(feature = "vfs")]
     highlevel::sync_all_cached_files(false)?;
-    if let Some(ctx) = highlevel::ROOT_FS_CONTEXT.get() {
-        ctx.root_dir().sync(false)?;
+    let filesystems = core::mem::take(&mut *MOUNTED_FILESYSTEMS.lock());
+    let mut first_error = None;
+    for fs in filesystems.into_iter().rev() {
+        if let Err(error) = fs.shutdown() {
+            first_error.get_or_insert(error);
+        }
     }
-    Ok(())
+    first_error.map_or(Ok(()), Err)
 }
 
 pub(crate) fn detect_filesystem(

--- a/fs/ax-fs-ng/src/os/sync.rs
+++ b/fs/ax-fs-ng/src/os/sync.rs
@@ -30,6 +30,12 @@ mod tests {
         }
     }
 
+    impl<T: Default> Default for TestMutex<T> {
+        fn default() -> Self {
+            Self::new(T::default())
+        }
+    }
+
     impl<T: ?Sized> TestMutex<T> {
         pub fn lock(&self) -> TestMutexGuard<'_, T> {
             TestMutexGuard(self.0.lock().unwrap_or_else(|err| err.into_inner()))

--- a/fs/ax-fs-ng/src/root.rs
+++ b/fs/ax-fs-ng/src/root.rs
@@ -611,7 +611,7 @@ fn mount_single_partition(
             let Some(mountpoint) = ensure_mountpoint_dir(root, &mount_path) else {
                 return;
             };
-            if let Err(err) = mountpoint.mount(&fs) {
+            if let Err(err) = mount_additional_filesystem(&mountpoint, &fs) {
                 warn!(
                     "  failed to mount partition {} at {}: {err:?}",
                     description, mount_path
@@ -625,6 +625,15 @@ fn mount_single_partition(
             );
         }
     }
+}
+
+fn mount_additional_filesystem(
+    mountpoint: &Location,
+    fs: &axfs_ng_vfs::Filesystem,
+) -> axfs_ng_vfs::VfsResult<()> {
+    mountpoint.mount(fs)?;
+    crate::register_mounted_filesystem(fs.clone());
+    Ok(())
 }
 
 fn ensure_mountpoint_dir(root: &Location, path: &str) -> Option<Location> {
@@ -823,6 +832,8 @@ mod tests {
     struct ReadonlyFs {
         root: std::sync::OnceLock<DirEntry>,
         userdata_kind: Option<NodeType>,
+        shutdown_name: Option<&'static str>,
+        shutdown_log: Option<Arc<std::sync::Mutex<Vec<&'static str>>>>,
     }
 
     struct ReadonlyDir {
@@ -839,9 +850,19 @@ mod tests {
 
     impl ReadonlyFs {
         fn new(userdata_kind: Option<NodeType>) -> Arc<Self> {
+            Self::new_with_options(userdata_kind, None, None)
+        }
+
+        fn new_with_options(
+            userdata_kind: Option<NodeType>,
+            shutdown_name: Option<&'static str>,
+            shutdown_log: Option<Arc<std::sync::Mutex<Vec<&'static str>>>>,
+        ) -> Arc<Self> {
             let fs = Arc::new(Self {
                 root: std::sync::OnceLock::new(),
                 userdata_kind,
+                shutdown_name,
+                shutdown_log,
             });
             let _ = fs.root.set(DirEntry::new_dir(
                 |this| {
@@ -854,6 +875,13 @@ mod tests {
                 Reference::root(),
             ));
             fs
+        }
+
+        fn new_with_shutdown_log(
+            name: &'static str,
+            shutdown_log: Arc<std::sync::Mutex<Vec<&'static str>>>,
+        ) -> Arc<Self> {
+            Self::new_with_options(None, Some(name), Some(shutdown_log))
         }
     }
 
@@ -883,6 +911,13 @@ mod tests {
                 fragment_size: 0,
                 mount_flags: 0,
             })
+        }
+
+        fn shutdown(&self) -> VfsResult<()> {
+            if let (Some(name), Some(log)) = (self.shutdown_name, &self.shutdown_log) {
+                log.lock().unwrap().push(name);
+            }
+            Ok(())
         }
     }
 
@@ -1191,7 +1226,7 @@ mod tests {
             Ok(())
         }
 
-        #[cfg(feature = "ext4")]
+        #[cfg(any(feature = "ext4", feature = "fat"))]
         fn flush(&mut self) -> AxResult {
             Ok(())
         }
@@ -1319,6 +1354,29 @@ mod tests {
         assert_eq!(
             root.lookup_no_follow("userdata").unwrap().node_type(),
             NodeType::Directory
+        );
+    }
+
+    #[test]
+    fn shutdown_closes_root_and_additional_mounts_in_reverse_order() {
+        let shutdown_log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let root_fs = Filesystem::new(ReadonlyFs::new_with_shutdown_log(
+            "root",
+            shutdown_log.clone(),
+        ));
+        let additional_fs = Filesystem::new(ReadonlyFs::new_with_shutdown_log(
+            "additional",
+            shutdown_log.clone(),
+        ));
+        let root = crate::finish_filesystem_init(root_fs, "test-root");
+        let mountpoint = ensure_mountpoint_dir_result(&root, "/userdata").unwrap();
+
+        mount_additional_filesystem(&mountpoint, &additional_fs).unwrap();
+        crate::shutdown_filesystems().unwrap();
+
+        assert_eq!(
+            shutdown_log.lock().unwrap().as_slice(),
+            ["additional", "root"]
         );
     }
 

--- a/fs/axfs-ng-vfs/src/fs.rs
+++ b/fs/axfs-ng-vfs/src/fs.rs
@@ -39,6 +39,11 @@ pub trait FilesystemOps: Send + Sync {
     fn flush(&self) -> VfsResult<()> {
         Ok(())
     }
+
+    /// Flushes and shuts down the filesystem before its backing device becomes unavailable.
+    fn shutdown(&self) -> VfsResult<()> {
+        self.flush()
+    }
 }
 
 #[derive(Clone)]
@@ -55,6 +60,8 @@ impl Filesystem {
     pub fn root_dir(&self) -> DirEntry;
 
     pub fn stat(&self) -> VfsResult<StatFs>;
+
+    pub fn shutdown(&self) -> VfsResult<()>;
 }
 
 impl Filesystem {

--- a/fs/rsext4/src/blockdev/journal.rs
+++ b/fs/rsext4/src/blockdev/journal.rs
@@ -158,24 +158,22 @@ impl<B: BlockDevice> Jbd2Dev<B> {
     }
 
     /// Commits all buffered journal transactions during unmount.
-    pub fn umount_commit(&mut self) {
+    pub fn umount_commit(&mut self) -> Ext4Result<()> {
         if !self.journal_use {
             trace!("Journal disabled, skip commit");
-            return;
+            return Ok(());
         }
 
         if let Some(system) = self.system.as_mut() {
             let committed = system
-                .commit_transaction_with_mapping(self.inner.device_mut(), &self.journal_blocks)
-                .expect("journal transaction commit failed");
+                .commit_transaction_with_mapping(self.inner.device_mut(), &self.journal_blocks)?;
             if committed {
-                self.inner
-                    .invalidate_cache()
-                    .expect("invalidate_cache failed during umount commit");
+                self.inner.invalidate_cache()?;
             }
         } else {
             trace!("Journal enabled but system uninitialized, skip commit");
         }
+        Ok(())
     }
 
     /// Writes the current internal block buffer.
@@ -337,12 +335,21 @@ mod tests {
 
     struct MemBlockDev {
         data: Vec<u8>,
+        fail_flush: bool,
     }
 
     impl MemBlockDev {
         fn new(blocks: usize) -> Self {
             Self {
                 data: vec![0; blocks * BLOCK_SIZE],
+                fail_flush: false,
+            }
+        }
+
+        fn with_failing_flush(blocks: usize) -> Self {
+            Self {
+                data: vec![0; blocks * BLOCK_SIZE],
+                fail_flush: true,
             }
         }
     }
@@ -376,6 +383,14 @@ mod tests {
 
         fn block_size(&self) -> u32 {
             BLOCK_SIZE as u32
+        }
+
+        fn flush(&mut self) -> Ext4Result<()> {
+            if self.fail_flush {
+                Err(Ext4Error::io())
+            } else {
+                Ok(())
+            }
         }
 
         fn current_time(&self) -> Ext4Result<Ext4Timestamp> {
@@ -421,5 +436,19 @@ mod tests {
             .expect("bulk read pending metadata");
 
         assert_eq!(observed, pending);
+    }
+
+    #[test]
+    fn umount_commit_propagates_device_flush_failure() {
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::with_failing_flush(256), true);
+        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
+        dev.write_block(AbsoluteBN::new(10), true)
+            .expect("queue metadata update");
+
+        let error = dev
+            .umount_commit()
+            .expect_err("unmount commit must propagate the device error");
+
+        assert_eq!(error, Ext4Error::io());
     }
 }

--- a/fs/rsext4/src/ext4/mount.rs
+++ b/fs/rsext4/src/ext4/mount.rs
@@ -471,7 +471,7 @@ impl Ext4FileSystem {
         // can distinguish an unclean shutdown from a real EXT4_ERROR_FS state.
         if !options.readonly {
             fs.sync_filesystem(block_dev)?;
-            block_dev.umount_commit();
+            block_dev.umount_commit()?;
         }
 
         Ok(fs)

--- a/fs/rsext4/src/ext4/sync.rs
+++ b/fs/rsext4/src/ext4/sync.rs
@@ -37,7 +37,7 @@ impl Ext4FileSystem {
 
         // Commit the journal transaction so all queued metadata (including
         // the superblock with s_state = VALID_FS) is checkpointed to disk.
-        block_dev.umount_commit();
+        block_dev.umount_commit()?;
 
         self.mounted = false;
         info!("Filesystem unmounted cleanly");

--- a/fs/rsext4/src/file/delete.rs
+++ b/fs/rsext4/src/file/delete.rs
@@ -32,6 +32,7 @@ pub fn free_inode<B: BlockDevice>(
     }
 
     *inode = updated_inode;
+    inode.i_links_count = 0;
     inode.i_block = [0; 15];
     inode.i_blocks_lo = 0;
     inode.l_i_blocks_high = 0;

--- a/fs/rsext4/src/metadata/inode.rs
+++ b/fs/rsext4/src/metadata/inode.rs
@@ -11,6 +11,12 @@ use crate::{
     ext4::Ext4FileSystem,
 };
 
+fn deletion_time(now_sec: i64, last_write_time: u32, inode_count: u32) -> u32 {
+    let now = now_sec.clamp(0, u32::MAX as i64) as u32;
+    let first_non_orphan_value = inode_count.saturating_add(1);
+    now.max(last_write_time).max(first_non_orphan_value)
+}
+
 impl Ext4FileSystem {
     pub(crate) fn inode_disk_size(&self) -> u16 {
         match self.superblock.s_inode_size {
@@ -150,10 +156,39 @@ impl Ext4FileSystem {
             Ext4DtimeUpdate::Clear => inode.i_dtime = 0,
             Ext4DtimeUpdate::SetNow => {
                 let now = get_now(device, &mut now_cache)?;
-                inode.i_dtime = if now.sec <= 0 { 0 } else { now.sec as u32 };
+                inode.i_dtime = deletion_time(
+                    now.sec,
+                    self.superblock.s_wtime,
+                    self.superblock.s_inodes_count,
+                );
             }
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deletion_time;
+
+    #[test]
+    fn deletion_time_cannot_be_mistaken_for_an_orphan_inode_number() {
+        assert_eq!(deletion_time(6, 0, 131_072), 131_073);
+    }
+
+    #[test]
+    fn deletion_time_preserves_a_valid_wall_clock() {
+        assert_eq!(deletion_time(1_784_073_600, 0, 131_072), 1_784_073_600);
+    }
+
+    #[test]
+    fn deletion_time_uses_the_last_filesystem_write_when_clock_is_unset() {
+        assert_eq!(deletion_time(6, 1_783_000_000, 131_072), 1_783_000_000);
+    }
+
+    #[test]
+    fn deletion_time_does_not_treat_a_negative_clock_as_the_u32_maximum() {
+        assert_eq!(deletion_time(-1, 0, 131_072), 131_073);
     }
 }

--- a/fs/rsext4/tests/crc_integrity.rs
+++ b/fs/rsext4/tests/crc_integrity.rs
@@ -149,7 +149,7 @@ fn sync_with_axfs_ng_order(
     fs.sync_superblock(dev)?;
     fs.sync_group_descriptors(dev)?;
     if dev.is_use_journal() {
-        dev.umount_commit();
+        dev.umount_commit()?;
     }
     dev.flush()
 }

--- a/os/arceos/api/arceos_posix_api/build.rs
+++ b/os/arceos/api/arceos_posix_api/build.rs
@@ -134,10 +134,16 @@ typedef struct {{
             }
         }
 
-        // Remove the "-softfloat" suffix for some targets.
-        if let Some(llvm_target) = target.strip_suffix("-softfloat") {
-            builder = builder.clang_arg(format!("--target={llvm_target}"));
-        }
+        // Bindgen otherwise uses the host architecture and can emit host ABI
+        // constants and layouts while cross-compiling. Clang target triples
+        // do not encode the RISC-V ISA extension suffix used by Rust targets.
+        let llvm_target = target.strip_suffix("-softfloat").unwrap_or(&target);
+        let llvm_target = if let Some(suffix) = llvm_target.strip_prefix("riscv64gc-") {
+            format!("riscv64-{suffix}")
+        } else {
+            llvm_target.to_owned()
+        };
+        builder = builder.clang_arg(format!("--target={llvm_target}"));
 
         for ty in allow_types {
             builder = builder.allowlist_type(ty);

--- a/os/arceos/api/arceos_posix_api/src/imp/fs.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/fs.rs
@@ -2,10 +2,11 @@ use alloc::sync::Arc;
 use core::{
     ffi::{c_char, c_int},
     mem::size_of,
+    time::Duration,
 };
 
 use ax_errno::{LinuxError, LinuxResult};
-use ax_fs_ng::fops::{FileAttrExt, OpenOptions};
+use ax_fs_ng::fops::OpenOptions;
 use ax_io::{PollState, SeekFrom};
 use ax_sync::Mutex;
 
@@ -85,6 +86,32 @@ fn file_type_to_d_type(ty: ax_fs_ng::fops::FileType) -> u8 {
     }
 }
 
+fn metadata_to_stat(metadata: ax_fs_ng::fops::FileAttr) -> ctypes::stat {
+    let st_mode = ((metadata.node_type as u32) << 12) | metadata.mode.bits() as u32;
+    ctypes::stat {
+        st_dev: metadata.device as _,
+        st_ino: metadata.inode as _,
+        st_nlink: metadata.nlink as _,
+        st_mode,
+        st_uid: metadata.uid as _,
+        st_gid: metadata.gid as _,
+        st_rdev: metadata.rdev.0 as _,
+        st_size: metadata.size as _,
+        st_blksize: metadata.block_size as _,
+        st_blocks: metadata.blocks as _,
+        st_atime: duration_to_timespec(metadata.atime),
+        st_mtime: duration_to_timespec(metadata.mtime),
+        st_ctime: duration_to_timespec(metadata.ctime),
+    }
+}
+
+fn duration_to_timespec(duration: Duration) -> ctypes::timespec {
+    ctypes::timespec {
+        tv_sec: duration.as_secs() as _,
+        tv_nsec: duration.subsec_nanos() as _,
+    }
+}
+
 impl File {
     fn new(inner: ax_fs_ng::fops::File) -> Self {
         Self {
@@ -134,20 +161,7 @@ impl FileLike for File {
 
     fn stat(&self) -> LinuxResult<ctypes::stat> {
         let metadata = self.inner.lock().get_attr()?;
-        let ty = metadata.file_type() as u8;
-        let perm = metadata.perm().bits() as u32;
-        let st_mode = ((ty as u32) << 12) | perm;
-        Ok(ctypes::stat {
-            st_ino: 1,
-            st_nlink: 1,
-            st_mode,
-            st_uid: 1000,
-            st_gid: 1000,
-            st_size: metadata.size() as _,
-            st_blocks: metadata.blocks() as _,
-            st_blksize: 512,
-            ..Default::default()
-        })
+        Ok(metadata_to_stat(metadata))
     }
 
     fn into_any(self: Arc<Self>) -> Arc<dyn core::any::Any + Send + Sync> {
@@ -229,7 +243,7 @@ fn flags_to_options(flags: c_int, _mode: ctypes::mode_t) -> OpenOptions {
     if flags & ctypes::O_CREAT != 0 {
         options.create(true);
     }
-    if flags & ctypes::O_EXEC != 0 {
+    if flags & ctypes::O_EXCL != 0 {
         options.create_new(true);
     }
     options
@@ -320,10 +334,7 @@ pub unsafe fn sys_stat(path: *const c_char, buf: *mut ctypes::stat) -> c_int {
         if buf.is_null() {
             return Err(LinuxError::EFAULT);
         }
-        let mut options = OpenOptions::new();
-        options.read(true);
-        let file = ax_fs_ng::fops::File::open(path?, &options)?;
-        let st = File::new(file).stat()?;
+        let st = metadata_to_stat(ax_fs_ng::api::metadata(path?)?);
         unsafe { *buf = st };
         Ok(0)
     })
@@ -354,11 +365,7 @@ pub unsafe fn sys_lstat(path: *const c_char, buf: *mut ctypes::stat) -> ctypes::
         if buf.is_null() {
             return Err(LinuxError::EFAULT);
         }
-        // ArceOS currently doesn't support symbolic links, so lstat behaves the same as stat
-        let mut options = OpenOptions::new();
-        options.read(true);
-        let file = ax_fs_ng::fops::File::open(path?, &options)?;
-        let st = File::new(file).stat()?;
+        let st = metadata_to_stat(ax_fs_ng::api::symlink_metadata(path?)?);
         unsafe { *buf = st };
         Ok(0)
     })
@@ -397,4 +404,49 @@ pub fn sys_rename(old: *const c_char, new: *const c_char) -> c_int {
         ax_fs_ng::api::rename(old_path, new_path)?;
         Ok(0)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use ax_fs_ng::fops::{FileAttr, FilePerm, FileType};
+
+    use super::*;
+
+    #[test]
+    fn metadata_to_stat_preserves_filesystem_attributes() {
+        let metadata = FileAttr {
+            device: 3,
+            inode: 17,
+            nlink: 2,
+            mode: FilePerm::from_bits_retain(0o640),
+            node_type: FileType::RegularFile,
+            uid: 1001,
+            gid: 1002,
+            size: 4097,
+            block_size: 4096,
+            blocks: 16,
+            rdev: Default::default(),
+            atime: Duration::new(10, 11),
+            mtime: Duration::new(12, 13),
+            ctime: Duration::new(14, 15),
+        };
+
+        let stat = metadata_to_stat(metadata);
+
+        assert_eq!(stat.st_dev, 3);
+        assert_eq!(stat.st_ino, 17);
+        assert_eq!(stat.st_nlink, 2);
+        assert_eq!(stat.st_mode, 0o100640);
+        assert_eq!(stat.st_uid, 1001);
+        assert_eq!(stat.st_gid, 1002);
+        assert_eq!(stat.st_size, 4097);
+        assert_eq!(stat.st_blksize, 4096);
+        assert_eq!(stat.st_blocks, 16);
+        assert_eq!(stat.st_atime.tv_sec, 10);
+        assert_eq!(stat.st_atime.tv_nsec, 11);
+        assert_eq!(stat.st_mtime.tv_sec, 12);
+        assert_eq!(stat.st_mtime.tv_nsec, 13);
+        assert_eq!(stat.st_ctime.tv_sec, 14);
+        assert_eq!(stat.st_ctime.tv_nsec, 15);
+    }
 }

--- a/os/arceos/ulib/axlibc/include/fcntl.h
+++ b/os/arceos/ulib/axlibc/include/fcntl.h
@@ -12,16 +12,23 @@
 #define O_DSYNC     010000
 #define O_SYNC      04010000
 #define O_RSYNC     04010000
-#define O_DIRECTORY 0200000
-#define O_NOFOLLOW  0400000
 #define O_CLOEXEC   02000000
 
 #define O_ASYNC     020000
+#if defined(__aarch64__)
+#define O_DIRECT    0200000
+#define O_DIRECTORY 040000
+#define O_LARGEFILE 0400000
+#define O_NOFOLLOW  0100000
+#else
 #define O_DIRECT    040000
+#define O_DIRECTORY 0200000
 #define O_LARGEFILE 0100000
+#define O_NOFOLLOW  0400000
+#endif
 #define O_NOATIME   01000000
 #define O_PATH      010000000
-#define O_TMPFILE   020200000
+#define O_TMPFILE   (020000000 | O_DIRECTORY)
 #define O_NDELAY    O_NONBLOCK
 
 #define O_SEARCH   O_PATH

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -35,7 +35,7 @@ required-features = ["host-xtask"]
 name = "axtest"
 path = "tests/axtest.rs"
 harness = false
-required-features = ["axtest"]
+required-features = ["axtest", "fs"]
 
 [features]
 default = []
@@ -50,6 +50,9 @@ test-panic-no-backtrace = ["dep:axbacktrace"]
 
 [dependencies]
 shlex.workspace = true
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(axtest)', 'cfg(feature, values("ax-std"))'] }
 
 [target.'cfg(any(not(any(windows, unix)), target_env = "musl"))'.dependencies]
 anyhow.workspace = true
@@ -78,6 +81,8 @@ axbacktrace = { workspace = true, optional = true }
 
 [dev-dependencies]
 axtest.workspace = true
+ax-hal = { workspace = true, features = ["paging", "irq", "smp", "hv"] }
+ax-task = { workspace = true, features = ["axtest"] }
 
 # xtask dependencies (only used on host platforms)
 [target.'cfg(any(windows, all(unix, not(target_env = "musl"))))'.dependencies]

--- a/os/axvisor/src/shell/command/base.rs
+++ b/os/axvisor/src/shell/command/base.rs
@@ -24,6 +24,11 @@ use std::os::unix::fs::{FileTypeExt, PermissionsExt};
 use std::println;
 use std::string::{String, ToString};
 
+#[cfg(feature = "fs")]
+use crate::shell::command::fs::{
+    CopyMode, RemoveOptions, collect_directory_entry_names, copy_operands, copy_path,
+    move_file_or_dir, path_basename, remove_path, touch_file,
+};
 use crate::shell::command::{CommandNode, FlagDef, ParsedCommand};
 
 #[cfg(feature = "fs")]
@@ -49,54 +54,55 @@ fn split_whitespace(s: &str) -> (&str, &str) {
 }
 
 #[cfg(feature = "fs")]
+fn show_ls_entry(path: &str, entry: &str, show_long: bool) -> io::Result<()> {
+    if show_long {
+        let metadata = fs::metadata(path)?;
+        let rwx = file_perm_to_rwx(metadata.permissions().mode());
+        let rwx = unsafe { core::str::from_utf8_unchecked(&rwx) };
+        println!(
+            "{}{} {:>8} {}",
+            file_type_to_char(metadata.file_type()),
+            rwx,
+            metadata.len(),
+            entry
+        );
+    } else {
+        println!("{}", entry);
+    }
+    Ok(())
+}
+
+#[cfg(feature = "fs")]
+fn list_one(name: &str, print_name: bool, show_long: bool, show_all: bool) -> io::Result<()> {
+    if !fs::metadata(name)?.is_dir() {
+        return show_ls_entry(name, name, show_long);
+    }
+    let entries = fs::read_dir(name)?;
+
+    if print_name {
+        println!("{}:", name);
+    }
+
+    let entries = collect_directory_entry_names(
+        entries.map(|entry| entry.map(|entry| entry.file_name())),
+        show_all,
+    )?;
+
+    for entry in entries {
+        let entry = entry.to_string_lossy();
+        let path = format!("{name}/{entry}");
+        if let Err(e) = show_ls_entry(&path, &entry, show_long) {
+            print_err!("ls", path, e);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "fs")]
 fn do_ls(cmd: &ParsedCommand) {
     let args = &cmd.positional_args;
     let show_long = cmd.flags.contains("long");
     let show_all = cmd.flags.contains("all");
-
-    fn show_entry_info(path: &str, entry: &str, show_long: bool) -> io::Result<()> {
-        if show_long {
-            let metadata = fs::metadata(path)?;
-            let size = metadata.len();
-            let file_type = metadata.file_type();
-            let file_type_char = file_type_to_char(file_type);
-            let rwx = file_perm_to_rwx(metadata.permissions().mode());
-            let rwx = unsafe { core::str::from_utf8_unchecked(&rwx) };
-            println!("{}{} {:>8} {}", file_type_char, rwx, size, entry);
-        } else {
-            println!("{}", entry);
-        }
-        Ok(())
-    }
-
-    fn list_one(name: &str, print_name: bool, show_long: bool, show_all: bool) -> io::Result<()> {
-        use std::vec::Vec;
-
-        let is_dir = fs::metadata(name)?.is_dir();
-        if !is_dir {
-            return show_entry_info(name, name, show_long);
-        }
-
-        if print_name {
-            println!("{}:", name);
-        }
-
-        let mut entries = fs::read_dir(name)?
-            .filter_map(|e| e.ok())
-            .map(|e| e.file_name())
-            .filter(|name| show_all || !name.to_string_lossy().starts_with('.'))
-            .collect::<Vec<_>>();
-        entries.sort();
-
-        for entry in entries {
-            let entry = entry.to_string_lossy();
-            let path = format!("{name}/{entry}");
-            if let Err(e) = show_entry_info(&path, &entry, show_long) {
-                print_err!("ls", path, e);
-            }
-        }
-        Ok(())
-    }
 
     let targets = if args.is_empty() {
         vec![".".to_string()]
@@ -221,61 +227,16 @@ fn do_rm(cmd: &ParsedCommand) {
         return;
     }
 
-    fn rm_one(path: &str, rm_dir: bool, recursive: bool, force: bool) -> io::Result<()> {
-        let metadata = fs::metadata(path);
-
-        if force && metadata.is_err() {
-            return Ok(()); // Ignore non-existent files when in force mode
-        }
-
-        let metadata = metadata?;
-
-        if metadata.is_dir() {
-            if recursive {
-                remove_dir_recursive(path, force)
-            } else if rm_dir {
-                fs::remove_dir(path)
-            } else {
-                Err(io::Error::from(io::ErrorKind::Unsupported))
-            }
-        } else {
-            fs::remove_file(path)
-        }
-    }
-
+    let options = RemoveOptions {
+        directory: rm_dir,
+        recursive,
+        force,
+    };
     for path in args {
-        if let Err(e) = rm_one(path, rm_dir, recursive, force)
-            && !force
-        {
+        if let Err(e) = remove_path(path, options) {
             print_err!("rm", format_args!("cannot remove '{path}'"), e);
         }
     }
-}
-
-// Implementation of recursively deleting directories (manual recursion)
-#[cfg(feature = "fs")]
-fn remove_dir_recursive(path: &str, _force: bool) -> io::Result<()> {
-    // Read directory contents
-    let entries = fs::read_dir(path)?;
-
-    // Remove all child items
-    for entry_result in entries {
-        let entry = entry_result?;
-        let entry_name = entry.file_name();
-        let entry_path = format!("{}/{}", path, entry_name.to_string_lossy());
-        let metadata = entry.file_type()?;
-
-        if metadata.is_dir() {
-            // Recursively delete subdirectory
-            remove_dir_recursive(&entry_path, _force)?;
-        } else {
-            // Delete file
-            fs::remove_file(&entry_path)?;
-        }
-    }
-
-    // Delete empty directory
-    fs::remove_dir(path)
 }
 
 #[cfg(feature = "fs")]
@@ -353,7 +314,7 @@ fn do_exit(cmd: &ParsedCommand) {
     };
 
     println!("Bye~");
-    std::process::exit(exit_code);
+    super::shutdown(exit_code);
 }
 
 fn do_log(cmd: &ParsedCommand) {
@@ -400,7 +361,13 @@ fn do_mv(cmd: &ParsedCommand) {
             && dest_meta.is_dir()
         {
             // Move source into destination directory
-            let source_name = path_basename(source);
+            let source_name = match path_basename(source) {
+                Ok(source_name) => source_name,
+                Err(e) => {
+                    print_err!("mv", format_args!("cannot access '{source}'"), e);
+                    return;
+                }
+            };
             let dest_path = format!("{dest}/{source_name}");
             if let Err(e) = move_file_or_dir(source, &dest_path) {
                 print_err!(
@@ -426,7 +393,13 @@ fn do_mv(cmd: &ParsedCommand) {
             Ok(meta) if meta.is_dir() => {
                 // Move each source into destination directory
                 for source in sources {
-                    let source_name = path_basename(source);
+                    let source_name = match path_basename(source) {
+                        Ok(source_name) => source_name,
+                        Err(e) => {
+                            print_err!("mv", format_args!("cannot access '{source}'"), e);
+                            continue;
+                        }
+                    };
                     let dest_path = format!("{dest}/{source_name}");
                     if let Err(e) = move_file_or_dir(source, &dest_path) {
                         print_err!(
@@ -448,39 +421,6 @@ fn do_mv(cmd: &ParsedCommand) {
 }
 
 #[cfg(feature = "fs")]
-fn path_basename(path: &str) -> &str {
-    path.trim_end_matches('/')
-        .rsplit('/')
-        .next()
-        .filter(|name| !name.is_empty())
-        .unwrap_or(path)
-}
-
-// Helper function to move file or directory (handles cross-filesystem moves)
-#[cfg(feature = "fs")]
-fn move_file_or_dir(source: &str, dest: &str) -> io::Result<()> {
-    // Try simple rename first (works within same filesystem)
-    match fs::rename(source, dest) {
-        Ok(()) => Ok(()),
-        Err(_) => {
-            // If rename fails, try copy + delete (for cross-filesystem moves)
-            let src_meta = fs::metadata(source)?;
-
-            if src_meta.is_dir() {
-                // For directories, use recursive copy then remove
-                copy_dir_recursive(source, dest)?;
-                remove_dir_recursive(source, false)?;
-            } else {
-                // For files, copy then remove
-                copy_file(source, dest)?;
-                fs::remove_file(source)?;
-            }
-            Ok(())
-        }
-    }
-}
-
-#[cfg(feature = "fs")]
 fn do_touch(cmd: &ParsedCommand) {
     let args = &cmd.positional_args;
 
@@ -490,7 +430,7 @@ fn do_touch(cmd: &ParsedCommand) {
     }
 
     for filename in args {
-        if let Err(e) = File::create(filename) {
+        if let Err(e) = touch_file(filename) {
             print_err!("touch", filename, e);
         }
     }
@@ -501,79 +441,22 @@ fn do_cp(cmd: &ParsedCommand) {
     let args = &cmd.positional_args;
     let recursive = cmd.flags.contains("recursive");
 
-    if args.len() < 2 {
-        print_err!("cp", "missing operand");
-        return;
-    }
-
-    let source = &args[0];
-    let dest = &args[1];
-
-    // Check if source file/directory exists
-    let src_metadata = match fs::metadata(source) {
-        Ok(metadata) => metadata,
+    let (source, dest) = match copy_operands(args) {
+        Ok(operands) => operands,
         Err(e) => {
-            print_err!("cp", format_args!("cannot access '{source}'"), e);
+            print_err!("cp", e);
             return;
         }
     };
-
-    let result = if src_metadata.is_dir() {
-        if recursive {
-            copy_dir_recursive(source, dest)
-        } else {
-            Err(io::Error::from(io::ErrorKind::Unsupported))
-        }
+    let mode = if recursive {
+        CopyMode::Recursive
     } else {
-        copy_file(source, dest)
+        CopyMode::File
     };
 
-    if let Err(e) = result {
+    if let Err(e) = copy_path(source, dest, mode) {
         print_err!("cp", format_args!("cannot copy '{source}' to '{dest}'"), e);
     }
-}
-
-// Manually implement file copy
-#[cfg(feature = "fs")]
-fn copy_file(src: &str, dst: &str) -> io::Result<()> {
-    let mut src_file = File::open(src)?;
-    let mut dst_file = File::create(dst)?;
-
-    let mut buffer = [0; 4096];
-    loop {
-        let bytes_read = src_file.read(&mut buffer)?;
-        if bytes_read == 0 {
-            break;
-        }
-        dst_file.write_all(&buffer[..bytes_read])?;
-    }
-    Ok(())
-}
-
-// Recursively copy directory
-#[cfg(feature = "fs")]
-fn copy_dir_recursive(src: &str, dst: &str) -> io::Result<()> {
-    // Create target directory
-    fs::create_dir(dst)?;
-
-    // Read source directory contents
-    let entries = fs::read_dir(src)?;
-
-    for entry_result in entries {
-        let entry = entry_result?;
-        let file_name = entry.file_name();
-        let file_name = file_name.to_string_lossy();
-        let src_path = format!("{src}/{file_name}");
-        let dst_path = format!("{dst}/{file_name}");
-
-        let metadata = entry.file_type()?;
-        if metadata.is_dir() {
-            copy_dir_recursive(&src_path, &dst_path)?;
-        } else {
-            copy_file(&src_path, &dst_path)?;
-        }
-    }
-    Ok(())
 }
 
 #[cfg(feature = "fs")]

--- a/os/axvisor/src/shell/command/fs.rs
+++ b/os/axvisor/src/shell/command/fs.rs
@@ -1,0 +1,295 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::{
+    ffi::OsString,
+    fs::{self, File, FileTimes, Metadata, OpenOptions},
+    io::{self, ErrorKind, Read, Write},
+    os::unix::fs::MetadataExt,
+    path::Path,
+    string::{String, ToString},
+    time::SystemTime,
+    vec::Vec,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CopyMode {
+    File,
+    Recursive,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) struct RemoveOptions {
+    pub(crate) directory: bool,
+    pub(crate) recursive: bool,
+    pub(crate) force: bool,
+}
+
+pub(crate) fn collect_directory_entry_names<I>(
+    entries: I,
+    show_all: bool,
+) -> io::Result<Vec<OsString>>
+where
+    I: IntoIterator<Item = io::Result<OsString>>,
+{
+    let mut names = entries
+        .into_iter()
+        .filter(|entry| {
+            entry.as_ref().map_or(true, |name| {
+                show_all || !name.to_string_lossy().starts_with('.')
+            })
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    names.sort();
+    Ok(names)
+}
+
+pub(crate) fn remove_path(path: &str, options: RemoveOptions) -> io::Result<()> {
+    match metadata_for_remove(path) {
+        Ok(metadata) if metadata.is_dir() => {
+            if options.recursive {
+                remove_dir_recursive(path)
+            } else if options.directory {
+                fs::remove_dir(path)
+            } else {
+                Err(ErrorKind::Unsupported.into())
+            }
+        }
+        Ok(_) => fs::remove_file(path),
+        Err(error) if ignore_remove_error(options.force, error.kind()) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn metadata_for_remove(path: &str) -> io::Result<Metadata> {
+    fs::symlink_metadata(path)
+}
+
+pub(crate) const fn ignore_remove_error(force: bool, kind: ErrorKind) -> bool {
+    force && matches!(kind, ErrorKind::NotFound)
+}
+
+pub(crate) fn move_file_or_dir(source: &str, destination: &str) -> io::Result<()> {
+    match fs::rename(source, destination) {
+        Ok(()) => Ok(()),
+        Err(error) if copy_after_rename_failure(error.kind()) => {
+            if fs::metadata(source)?.is_dir() {
+                copy_dir_recursive(source, destination)?;
+                remove_dir_recursive(source)?;
+            } else {
+                copy_file(source, destination)?;
+                fs::remove_file(source)?;
+            }
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) const fn copy_after_rename_failure(kind: ErrorKind) -> bool {
+    matches!(kind, ErrorKind::CrossesDevices)
+}
+
+pub(crate) fn touch_file(path: &str) -> io::Result<()> {
+    let file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(path)?;
+    let now = SystemTime::now();
+    file.set_times(FileTimes::new().set_accessed(now).set_modified(now))
+}
+
+pub(crate) fn copy_path(source: &str, destination: &str, mode: CopyMode) -> io::Result<()> {
+    let source_metadata = fs::metadata(source)?;
+    let destination = effective_destination(source, destination)?;
+
+    if source_metadata.is_dir() {
+        if mode == CopyMode::Recursive {
+            ensure_recursive_destination_outside_source(source, &destination)?;
+            copy_dir_recursive(source, &destination)
+        } else {
+            Err(ErrorKind::Unsupported.into())
+        }
+    } else {
+        ensure_file_destination_differs_from_source(source, &source_metadata, &destination)?;
+        copy_file(source, &destination)
+    }
+}
+
+pub(crate) fn copy_operands(args: &[String]) -> io::Result<(&str, &str)> {
+    match args {
+        [source, destination] => Ok((source, destination)),
+        _ => Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "expected exactly one source and one destination",
+        )),
+    }
+}
+
+fn effective_destination(source: &str, destination: &str) -> io::Result<String> {
+    match fs::metadata(destination) {
+        Ok(metadata) if metadata.is_dir() => {
+            let source_name = path_basename(source)?;
+            Ok(format!("{destination}/{source_name}"))
+        }
+        Ok(_) => Ok(destination.to_string()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(destination.to_string()),
+        Err(error) => Err(error),
+    }
+}
+
+pub(crate) fn ensure_recursive_destination_outside_source(
+    source: &str,
+    destination: &str,
+) -> io::Result<()> {
+    let source_components = absolute_path_components(source)?;
+    let destination_components = absolute_path_components(destination)?;
+
+    if destination_components.starts_with(&source_components) {
+        return Err(copy_into_itself_error());
+    }
+
+    let source_metadata = fs::metadata(source)?;
+    let mut ancestor = Some(Path::new(destination));
+    while let Some(path) = ancestor {
+        if path.as_os_str().is_empty() {
+            break;
+        }
+        match fs::metadata(path) {
+            Ok(metadata) if same_file(&source_metadata, &metadata) => {
+                return Err(copy_into_itself_error());
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        ancestor = path.parent();
+    }
+    Ok(())
+}
+
+fn ensure_file_destination_differs_from_source(
+    source: &str,
+    source_metadata: &Metadata,
+    destination: &str,
+) -> io::Result<()> {
+    let same_path = absolute_path_components(source)? == absolute_path_components(destination)?;
+    let same_node = match fs::metadata(destination) {
+        Ok(destination_metadata) => same_file(source_metadata, &destination_metadata),
+        Err(error) if error.kind() == ErrorKind::NotFound => false,
+        Err(error) => return Err(error),
+    };
+
+    if same_path || same_node {
+        Err(io::Error::new(
+            ErrorKind::InvalidInput,
+            "source and destination are the same file",
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+fn same_file(left: &Metadata, right: &Metadata) -> bool {
+    // FAT currently reports this placeholder identity for every regular file.
+    let identity_is_meaningful =
+        (left.dev(), left.ino()) != (0, 1) && (right.dev(), right.ino()) != (0, 1);
+    identity_is_meaningful && left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+fn copy_into_itself_error() -> io::Error {
+    io::Error::new(
+        ErrorKind::InvalidInput,
+        "cannot copy a directory into itself",
+    )
+}
+
+fn absolute_path_components(path: &str) -> io::Result<Vec<String>> {
+    let path = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        let current_dir = std::env::current_dir()?;
+        format!("{}/{path}", current_dir.to_string_lossy())
+    };
+    let mut components = Vec::new();
+
+    for component in path.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                components.pop();
+            }
+            component => components.push(component.to_string()),
+        }
+    }
+    Ok(components)
+}
+
+pub(crate) fn path_basename(path: &str) -> io::Result<&str> {
+    path.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidInput, "path has no basename"))
+}
+
+fn copy_file(source: &str, destination: &str) -> io::Result<()> {
+    let mut source_file = File::open(source)?;
+    let mut destination_file = File::create(destination)?;
+    let mut buffer = [0; 4096];
+
+    loop {
+        let bytes_read = source_file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            return Ok(());
+        }
+        destination_file.write_all(&buffer[..bytes_read])?;
+    }
+}
+
+fn copy_dir_recursive(source: &str, destination: &str) -> io::Result<()> {
+    fs::create_dir(destination)?;
+
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let file_name = entry.file_name();
+        let file_name = file_name.to_string_lossy();
+        let source_path = format!("{source}/{file_name}");
+        let destination_path = format!("{destination}/{file_name}");
+
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else {
+            copy_file(&source_path, &destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+fn remove_dir_recursive(path: &str) -> io::Result<()> {
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let entry_name = entry.file_name();
+        let entry_name = entry_name.to_string_lossy();
+        let entry_path = format!("{path}/{entry_name}");
+
+        if entry.file_type()?.is_dir() {
+            remove_dir_recursive(&entry_path)?;
+        } else {
+            fs::remove_file(&entry_path)?;
+        }
+    }
+    fs::remove_dir(path)
+}

--- a/os/axvisor/src/shell/command/mod.rs
+++ b/os/axvisor/src/shell/command/mod.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 mod base;
+#[cfg(feature = "fs")]
+mod fs;
 mod history;
 mod vm;
 
@@ -31,6 +33,14 @@ use std::{print, println, sync::LazyLock};
 
 pub static COMMAND_TREE: LazyLock<BTreeMap<String, CommandNode>> =
     LazyLock::new(build_command_tree);
+
+pub(super) fn shutdown(exit_code: i32) -> ! {
+    #[cfg(feature = "fs")]
+    if let Err(error) = axvm::shutdown_host_filesystems() {
+        println!("Warning: failed to shut down host filesystems: {error}");
+    }
+    std::process::exit(exit_code);
+}
 
 #[derive(Debug, Clone)]
 pub struct CommandNode {
@@ -515,7 +525,7 @@ pub fn handle_builtin_commands(input: &str) -> bool {
         }
         [command] if command == "exit" || command == "quit" => {
             println!("Goodbye!");
-            std::process::exit(0);
+            shutdown(0);
         }
         [command] if command == "clear" => {
             print!("\x1b[2J\x1b[H"); // ANSI clear screen sequence

--- a/os/axvisor/tests/axtest.rs
+++ b/os/axvisor/tests/axtest.rs
@@ -4,12 +4,308 @@
 use ax_std as _;
 use axvm as _;
 
+#[cfg(feature = "fs")]
+#[path = "../src/shell/command/fs.rs"]
+mod shell_fs;
+
 #[axtest::tests]
 mod tests {
     use axtest::prelude::*;
+    #[cfg(feature = "fs")]
+    use std::{
+        ffi::OsString,
+        fs::{self, FileTimes, OpenOptions},
+        io::{self, ErrorKind},
+        string::ToString,
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
+    #[cfg(feature = "fs")]
+    use super::shell_fs::{
+        CopyMode, RemoveOptions, collect_directory_entry_names, copy_after_rename_failure,
+        copy_operands, copy_path, ensure_recursive_destination_outside_source, ignore_remove_error,
+        metadata_for_remove, move_file_or_dir, remove_path, touch_file,
+    };
 
     #[test]
     fn axvisor_axtest_smoke() {
         ax_assert!(true);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn touch_preserves_content_and_updates_times() {
+        let path = "/tmp/axvisor-touch-regression";
+        let old_time = SystemTime::now()
+            .checked_add(Duration::from_secs(60))
+            .expect("fixture time must be representable");
+        let _ = fs::remove_file(path);
+        fs::write(path, b"preserve me").expect("create touch fixture");
+        OpenOptions::new()
+            .write(true)
+            .open(path)
+            .expect("open touch fixture")
+            .set_times(
+                FileTimes::new()
+                    .set_accessed(old_time)
+                    .set_modified(old_time),
+            )
+            .expect("set old fixture times");
+
+        let earliest_touch_time = unix_seconds(SystemTime::now());
+        touch_file(path).expect("touch fixture");
+        let latest_touch_time = unix_seconds(SystemTime::now());
+
+        let metadata = fs::metadata(path).expect("read touched metadata");
+        ax_assert_eq!(fs::read(path).expect("read touched file"), b"preserve me");
+        let accessed = unix_seconds(metadata.accessed().expect("read atime"));
+        let modified = unix_seconds(metadata.modified().expect("read mtime"));
+        ax_assert!((earliest_touch_time..=latest_touch_time).contains(&accessed));
+        ax_assert!((earliest_touch_time..=latest_touch_time).contains(&modified));
+        fs::remove_file(path).expect("remove touch fixture");
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cp_file_to_existing_directory_uses_source_basename() {
+        let root = "/tmp/axvisor-cp-file-regression";
+        reset_test_dir(root);
+        let source = format!("{root}/source.txt");
+        let destination = format!("{root}/destination");
+        fs::write(&source, b"copied payload").expect("create copy source");
+        fs::create_dir(&destination).expect("create copy destination");
+
+        copy_path(&source, &destination, CopyMode::File).expect("copy file into directory");
+
+        ax_assert_eq!(
+            fs::read(format!("{destination}/source.txt")).expect("read copied file"),
+            b"copied payload"
+        );
+        remove_path(
+            root,
+            RemoveOptions {
+                recursive: true,
+                ..RemoveOptions::default()
+            },
+        )
+        .expect("remove copy fixture");
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cp_rejects_copying_file_onto_itself_without_truncating_it() {
+        let path = "/tmp/axvisor-cp-self-file-regression";
+        let _ = fs::remove_file(path);
+        fs::write(path, b"keep this payload").expect("create self-copy fixture");
+
+        let error = copy_path(path, path, CopyMode::File)
+            .expect_err("copying a file onto itself must fail");
+
+        ax_assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        ax_assert_eq!(
+            fs::read(path).expect("read self-copy fixture"),
+            b"keep this payload"
+        );
+        fs::remove_file(path).expect("remove self-copy fixture");
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cp_recursive_directory_to_existing_directory_uses_source_basename() {
+        let root = "/tmp/axvisor-cp-dir-regression";
+        reset_test_dir(root);
+        let source = format!("{root}/source-dir");
+        let destination = format!("{root}/destination");
+        fs::create_dir(&source).expect("create recursive copy source");
+        fs::write(format!("{source}/child.txt"), b"recursive payload")
+            .expect("create recursive copy child");
+        fs::create_dir(&destination).expect("create recursive copy destination");
+
+        copy_path(&source, &destination, CopyMode::Recursive)
+            .expect("copy directory into directory");
+
+        ax_assert_eq!(
+            fs::read(format!("{destination}/source-dir/child.txt"))
+                .expect("read recursively copied file"),
+            b"recursive payload"
+        );
+        remove_path(
+            root,
+            RemoveOptions {
+                recursive: true,
+                ..RemoveOptions::default()
+            },
+        )
+        .expect("remove recursive copy fixture");
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cp_recursive_rejects_copying_directory_into_itself() {
+        let root = "/tmp/axvisor-cp-self-regression";
+        reset_test_dir(root);
+        let source = format!("{root}/dir");
+        fs::create_dir(&source).expect("create recursive copy source");
+        fs::create_dir(format!("{source}/dir")).expect("create recursion guard");
+
+        let error = copy_path(&source, &source, CopyMode::Recursive)
+            .expect_err("recursive copy into itself must fail");
+
+        ax_assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        remove_path(
+            root,
+            RemoveOptions {
+                recursive: true,
+                ..RemoveOptions::default()
+            },
+        )
+        .expect("remove self-copy fixture");
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cp_recursive_rejects_copying_directory_into_descendant() {
+        let root = "/tmp/axvisor-cp-descendant-regression";
+        reset_test_dir(root);
+        let source = format!("{root}/dir");
+        let destination = format!("{source}/subdir");
+        fs::create_dir(&source).expect("create recursive copy source");
+        fs::create_dir(&destination).expect("create descendant destination");
+        fs::create_dir(format!("{destination}/dir")).expect("create recursion guard");
+
+        let error = copy_path(&source, &destination, CopyMode::Recursive)
+            .expect_err("recursive copy into a descendant must fail");
+
+        ax_assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        remove_path(
+            root,
+            RemoveOptions {
+                recursive: true,
+                ..RemoveOptions::default()
+            },
+        )
+        .expect("remove descendant-copy fixture");
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cp_recursive_rejects_nonexistent_descendant_before_creation() {
+        let root = "/tmp/axvisor-cp-new-descendant-regression";
+        reset_test_dir(root);
+        let source = format!("{root}/dir");
+        let destination = format!("{source}/subdir");
+        fs::create_dir(&source).expect("create recursive copy source");
+
+        let error = ensure_recursive_destination_outside_source(&source, &destination)
+            .expect_err("nonexistent descendant must be rejected before creation");
+
+        ax_assert_eq!(error.kind(), ErrorKind::InvalidInput);
+        ax_assert!(!fs::exists(&destination).expect("check descendant was not created"));
+        remove_path(
+            root,
+            RemoveOptions {
+                recursive: true,
+                ..RemoveOptions::default()
+            },
+        )
+        .expect("remove nonexistent-descendant fixture");
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn mv_only_falls_back_to_copy_across_devices() {
+        ax_assert!(copy_after_rename_failure(ErrorKind::CrossesDevices));
+        ax_assert!(!copy_after_rename_failure(ErrorKind::PermissionDenied));
+        ax_assert!(!copy_after_rename_failure(ErrorKind::AlreadyExists));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn mv_renames_file_on_same_filesystem() {
+        let root = "/tmp/axvisor-mv-regression";
+        reset_test_dir(root);
+        let source = format!("{root}/source.txt");
+        let destination = format!("{root}/destination.txt");
+        fs::write(&source, b"moved payload").expect("create move source");
+
+        move_file_or_dir(&source, &destination).expect("move file");
+
+        ax_assert!(!fs::exists(&source).expect("check move source"));
+        ax_assert_eq!(
+            fs::read(&destination).expect("read move destination"),
+            b"moved payload"
+        );
+        remove_path(
+            root,
+            RemoveOptions {
+                recursive: true,
+                ..RemoveOptions::default()
+            },
+        )
+        .expect("remove move fixture");
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn rm_force_only_ignores_not_found() {
+        ax_assert!(ignore_remove_error(true, ErrorKind::NotFound));
+        ax_assert!(!ignore_remove_error(true, ErrorKind::PermissionDenied));
+        ax_assert!(!ignore_remove_error(true, ErrorKind::Unsupported));
+        ax_assert!(!ignore_remove_error(false, ErrorKind::NotFound));
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn rm_does_not_follow_a_directory_symlink() {
+        let metadata = metadata_for_remove("/var/run").expect("inspect rootfs directory symlink");
+
+        ax_assert!(metadata.file_type().is_symlink());
+        ax_assert!(!metadata.is_dir());
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn ls_propagates_directory_iteration_errors() {
+        let entries = [
+            Ok(OsString::from("visible")),
+            Err(io::Error::from(ErrorKind::PermissionDenied)),
+        ];
+
+        let error = collect_directory_entry_names(entries, false)
+            .expect_err("directory iteration error must be propagated");
+
+        ax_assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(feature = "fs")]
+    #[test]
+    fn cp_requires_exactly_two_operands() {
+        let source = "source".to_string();
+        let destination = "destination".to_string();
+        let extra = "extra".to_string();
+        ax_assert!(copy_operands(&[]).is_err());
+        ax_assert!(copy_operands(core::slice::from_ref(&source)).is_err());
+        ax_assert!(copy_operands(&[source.clone(), destination.clone()]).is_ok());
+        ax_assert!(copy_operands(&[source, destination, extra]).is_err());
+    }
+
+    #[cfg(feature = "fs")]
+    fn reset_test_dir(path: &str) {
+        let _ = remove_path(
+            path,
+            RemoveOptions {
+                recursive: true,
+                force: true,
+                ..RemoveOptions::default()
+            },
+        );
+        fs::create_dir(path).expect("create test directory");
+    }
+
+    #[cfg(feature = "fs")]
+    fn unix_seconds(time: SystemTime) -> u64 {
+        time.duration_since(UNIX_EPOCH)
+            .expect("test time must not predate Unix epoch")
+            .as_secs()
     }
 }

--- a/virtualization/axvm/src/arch/mod.rs
+++ b/virtualization/axvm/src/arch/mod.rs
@@ -70,7 +70,8 @@ pub mod platform {
         any(
             target_arch = "aarch64",
             target_arch = "x86_64",
-            target_arch = "loongarch64"
+            target_arch = "loongarch64",
+            target_arch = "riscv64"
         ),
         any(feature = "fs", feature = "host-fs")
     ))]

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -198,7 +198,7 @@ pub fn shutdown_host_filesystems() -> AxVmResult {
         .map_err(|error| AxVmError::host("shut down host filesystems", error))?;
     let released = modules::ax_fs_ng::release_block_irqs_for_passthrough();
     if released != 0 {
-        info!("Released {released} host filesystem block IRQ registration(s) before passthrough");
+        info!("Released {released} host filesystem block IRQ registration(s) during shutdown");
     }
     Ok(())
 }


### PR DESCRIPTION
## 问题

Axvisor shell 的文件命令存在语义和持久化问题：`touch` 会截断已有文件，`mv`、`rm -f`、`ls`、`cp` 的错误处理不准确；退出时未完成 ext4 干净卸载；`stat`/`lstat` 依赖打开目标，且 AArch64 open flag 与 bindgen target 处理不符合目标 ABI。

## 修改

- 修正 `touch`、`mv`、`rm`、`ls`、`cp` 的文件操作和错误传播。
- `stat`/`lstat` 改用路径 metadata，完整返回 inode、权限、块信息和时间；同时修正 `O_EXCL`。
- 修正 AArch64 `fcntl` 常量，并确保 bindgen 使用可被 Clang 识别的目标架构。
- 增加文件系统 shutdown 边界；Axvisor 退出前完成 ext4 卸载、journal 提交和 IRQ 释放。
- 修正 inode 删除时的链接数和无效时钟下的 `i_dtime`，避免离线检查误判 orphan 链。

这些修改分别保证 shell 命令不掩盖真实错误、metadata 查询不要求目标可读，以及磁盘状态在 Axvisor 退出前按正确顺序写回。

## 验证

- `cargo fmt --all --check`
- `cargo xtask axvisor build --config os/axvisor/configs/board/qemu-aarch64.toml`
- `cargo test -p ax-posix-api --features fs metadata_to_stat_preserves_filesystem_attributes`
- `cargo test -p rsext4 deletion_time_`
- `cargo test -p rsext4 umount_commit_propagates_device_flush_failure`
- QEMU AArch64 shell 手工验证 `touch/cp/mv/ls/rm`；旧 AArch64 `fcntl` 常量可稳定复现 `ls` 返回 `EISDIR`。