### PR TITLE
fix(axbuild): disable RISC-V global pointer relaxation

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -22,6 +22,7 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
 ## Porting Checklist
 
 - **Target and toolchain**: add or verify `scripts/targets` specs, target triple, panic strategy, relocation model, code model, ABI, soft-float setting, musl/std support, linker, objcopy, and `rust-src` availability.
+- **RISC-V per-CPU register contract**: `ax-percpu` reserves `x3`/`gp` as the per-CPU base, so every RISC-V kernel target spec must pass `--no-relax` to the linker. Do not enable global-pointer relaxation or define `__global_pointer$` unless the per-CPU register design changes at the same time.
 - **Build system**: wire arch/target mapping in `scripts/axbuild`, dynamic platform defaults, feature propagation, kernel format conversion, UEFI/to-bin behavior, rootfs handling, and per-OS test discovery.
 - **QEMU and firmware**: verify QEMU binary, machine type, CPU, SMP count, pflash/OVMF files, serial console, disk/rootfs device, `-snapshot`, debug flags, timeout, and success/fail regexes.
 - **someboot arch layer**: implement or audit entry, relocation, BSS clearing, stack setup, memory map parsing, paging, trap vectors, timer, IRQ, power, SMP, and address translation.

--- a/scripts/axbuild/src/build/tests/target_specs.rs
+++ b/scripts/axbuild/src/build/tests/target_specs.rs
@@ -199,3 +199,24 @@ fn std_target_specs_embed_final_link_policy() {
         assert!(!link_args.contains(&"-no-pie"));
     }
 }
+
+#[test]
+fn riscv_target_specs_disable_global_pointer_relaxation() {
+    let workspace = crate::context::workspace_root_path().unwrap();
+
+    for relative_path in [
+        "scripts/targets/std/riscv64gc-unknown-linux-musl.json",
+        "scripts/targets/std/pie/riscv64gc-unknown-linux-musl.json",
+    ] {
+        let path = workspace.join(relative_path);
+        let spec: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+        let link_args = gnu_lld_pre_link_args(&spec);
+
+        assert!(
+            link_args.contains(&"--no-relax"),
+            "RISC-V target spec must disable GP relaxation: {}",
+            path.display()
+        );
+    }
+}

--- a/scripts/targets/std/pie/riscv64gc-unknown-linux-musl.json
+++ b/scripts/targets/std/pie/riscv64gc-unknown-linux-musl.json
@@ -25,6 +25,7 @@
   "pre-link-args": {
     "gnu-lld": [
       "-pie",
+      "--no-relax",
       "--gc-sections",
       "-znorelro",
       "-znostart-stop-gc",

--- a/scripts/targets/std/riscv64gc-unknown-linux-musl.json
+++ b/scripts/targets/std/riscv64gc-unknown-linux-musl.json
@@ -26,6 +26,7 @@
     "gnu-lld": [
       "-static",
       "-no-pie",
+      "--no-relax",
       "--gc-sections",
       "-znorelro",
       "-znostart-stop-gc",


### PR DESCRIPTION
## 问题

RISC-V 上的 `ax-percpu` 将 `x3/gp` 保留为 per-CPU 基址，但现有 RISC-V musl target spec 没有显式禁止链接器执行 global-pointer relaxation。若链接器把普通全局数据访问松弛为基于 `gp` 的访问，就会与 per-CPU 寄存器约定冲突，导致错误的内存访问。

## 修改

- 在 RISC-V 普通 musl target spec 的最终链接参数中加入 `--no-relax`。
- 在 RISC-V PIE musl target spec 的最终链接参数中加入 `--no-relax`。
- 增加 target-spec 回归测试，确保两个 RISC-V 链接入口都持续禁止 relaxation。
- 在架构移植说明中记录 `gp` 作为 per-CPU 基址的链接契约。

## 实现逻辑

该约束放在 target spec 的 `gnu-lld` pre-link 参数中，使最终内核链接统一禁止 RISC-V linker relaxation，并同时覆盖普通和 PIE 构建路径。回归测试直接解析两个 target spec 并检查 `--no-relax`，防止后续重构遗漏其中一个入口。

## 验证

- `cargo fmt --all --check`
- `cargo test -p axbuild --lib`（726 个测试通过）
- `cargo xtask clippy --package axbuild`
- `cargo xtask starry build --arch riscv64 --smp 2`
- 检查最终 Starry ELF，未发现 `__global_pointer$` 或普通 `offset(gp)` 内存访问
