### PR TITLE
chore(repo): update spin to 0.12.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7605,9 +7605,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
+checksum = "8abadc99fd9c7bbb7d0ca2b31d72a067d0c0dcd7aad25ab8cac71ba91417694b"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -312,7 +312,7 @@ mmio-api = { version = "0.2.2", path = "memory/mmio-api" }
 cvi-vdec-uapi = { version = "0.1.0", path = "drivers/interface/cvi-vdec-uapi" }
 lock_api = { version = "0.4", default-features = false }
 log = "0.4"
-spin = { version = "=0.12.0", default-features = false, features = ["lock_api", "once", "lazylock"] }
+spin = { version = "=0.12.2", default-features = false, features = ["lock_api", "once", "lazylock"] }
 atomic-waker = { version = "1.1", default-features = false }
 ostool = { version = "0.24.0" }
 riscv = { version = "0.16.1", default-features = false }

--- a/docs/docs/build/spin_lint.md
+++ b/docs/docs/build/spin_lint.md
@@ -5,130 +5,87 @@ sidebar_label: "Spin Lint"
 
 # Spin Lint
 
-`cargo xtask spin-lint` 是 axbuild 为 TGOSKits 内部 `spin` crate 迁移而设的看门狗检查。TGOSKits 已经把上游 `spin` 0.12 fork 到 `components/spin` 并做了一项关键改造：**移除了 `rwlock` feature**，所有原本用 `spin::RwLock` 的代码统一改用 `ax_kspin::SpinRwLock`。spin-lint 通过扫描 workspace 的所有 `Cargo.toml`、`Cargo.lock` 和源码，确保这个迁移结果不被悄悄回退——任何外部 `spin`、多份 vendored 副本、或残留的 `spin::RwLock` 引用都会让它失败。
+`cargo xtask spin-lint` 用于守护 workspace 对上游 `spin` crate 的统一使用约束。当前仓库直接使用 crates.io 的 `spin` 0.12.2，并关闭默认 feature；允许的 feature 只有 `lock_api`、`once` 和 `lazylock`。需要非睡眠读写锁时统一使用 `ax_kspin::SpinRwLock`，不能重新引入 `spin::RwLock`。
 
-> spin-lint 是仓库级的不变量守护：它检查的不是代码风格，而是“我们承诺过的迁移状态是否依然成立”。
+> spin-lint 检查的是仓库级依赖与同步原语不变量，不是一般代码风格。
 
-## 五项检查
+## 检查内容
 
-`lint_workspace` 依次运行下面五项检查，任何一项发现都会累积到 `Vec<Finding>` 并最终使命令失败：
+`lint_workspace` 依次执行以下检查，所有 finding 会累积后统一报告：
 
-| 检查 | 函数 | 失败原因 |
-|------|------|----------|
-| **Vendored 主副本** | `check_vendored_spin_crate(MAIN_SPIN_PATH, "0.12.0")` | `components/spin/Cargo.toml` 缺失、包名不是 `spin`、版本不是 `0.12.0`，或保留了被禁用的 `rwlock` feature |
-| **禁用副本路径** | `check_forbidden_spin_crate_paths` | 在 `MAIN_SPIN_PATH` 之外的任何位置出现名为 `spin` 的包（迁移期遗留的重复副本） |
-| **根 manifest** | `check_root_manifest` | workspace 根 `Cargo.toml` 仍声明外部 `spin` 依赖 |
-| **子 manifest** | `check_workspace_manifests` | 任意成员 crate 的 `Cargo.toml` 声明外部 `spin` 依赖 |
-| **源码 RwLock 用法** | `check_no_spin_rwlock_usage` | 源码中出现 `spin::RwLock`、`spin::rwlock`、`use spin::RwLock` 等模式（`FORBIDDEN_SPIN_RWLOCK_PATTERNS`） |
-| **Cargo.lock** | `check_lockfile` | `Cargo.lock` 中解析到了外部来源（非 path）的 `spin` 包 |
+| 检查 | 约束 |
+|------|------|
+| 本地 package | workspace 内不能出现名为 `spin` 的本地 package，避免重新引入 vendored 副本 |
+| 根 manifest | `[workspace.dependencies]` 必须精确声明 crates.io `spin =0.12.2`，关闭默认 feature，并启用 `lock_api`、`once`、`lazylock`；不能设置 `path`、`git`、`registry` 或 `package` |
+| crates.io patch | 根 manifest 不能通过 `[patch.crates-io]` 替换 `spin` |
+| 成员 manifest | 推荐使用 `spin = { workspace = true }`；显式依赖也必须固定 `=0.12.2`、关闭默认 feature，且只能启用白名单 feature |
+| 源码用法 | Rust 源码不能出现 `spin::RwLock`、`spin::rwlock` 或 `use spin::RwLock` |
+| lockfile | 每个 `spin` 条目都必须是 crates.io 的 0.12.2，并带 registry source 与 checksum |
 
-主副本的 feature 检查尤其严格：不仅 `features.rwlock` 这一键的存在会失败，`features.default` 数组里混入 `rwlock` 也会单独按 index 报告，避免通过默认 feature 间接恢复被禁用的功能。
+扫描会跳过 `.git`、`target`、`tmp` 和 `.cache`。源码扫描还会跳过 `docs` 以及 `spin_lint.rs` 自身，避免示例文字和规则字符串触发误报。
 
-## 架构概览
+## 合法依赖写法
 
-```mermaid
-flowchart TB
-    ROOT["workspace_root"] --> WALK["WalkDir (filter_entry)"]
-    WALK --> TOML["每个 Cargo.toml"]
-    TOML --> PKG{"package.name == 'spin'?"}
-    PKG -->|"是 & 路径 == MAIN_SPIN_PATH"| VENDOR["check_vendored_spin_crate<br/>版本/feature 校验"]
-    PKG -->|"是 & 路径 != MAIN_SPIN_PATH"| FORBID["check_forbidden_spin_crate_paths<br/>报错：未注册副本"]
-    PKG -->|"否"| DEP["依赖扫描<br/>外部 spin 引用?"]
-    ROOT --> SRC["*.rs 源码扫描"]
-    SRC --> PAT["FORBIDDEN_SPIN_RWLOCK_PATTERNS<br/>spin::RwLock / spin::rwlock / use spin::RwLock"]
-    ROOT --> LOCK["Cargo.lock"]
-    LOCK --> LOCKCHECK["check_lockfile<br/>外部来源 spin?"]
+根 `Cargo.toml`：
+
+```toml
+[workspace.dependencies]
+spin = { version = "=0.12.2", default-features = false, features = ["lock_api", "once", "lazylock"] }
 ```
 
-## 五项检查详解
+成员 crate 优先继承 workspace 配置：
 
-### 1. Vendored 主副本校验
+```toml
+[dependencies]
+spin = { workspace = true }
+```
 
-`check_vendored_spin_crate` 检查 `components/spin/Cargo.toml` 的完整性：
+成员 crate 如果必须显式声明，只能使用相同精确版本、关闭默认 feature，并选择白名单 feature 的子集：
 
-| 校验项 | 期望值 | 失败 finding |
-|--------|--------|-------------|
-| 文件存在 | `components/spin/Cargo.toml` 存在 | `vendored spin manifest is missing` |
-| 包名 | `spin` | `expected package \`spin\` ..., found name \`...\`` |
-| 版本 | `0.12.0` | `expected ... version \`0.12.0\`, found ... version \`...\`` |
-| `features.rwlock` 键 | 不存在 | `vendored spin must not expose the upstream rwlock feature` |
-| `features.default[]` 含 `rwlock` | 不含 | `vendored spin default features must not include rwlock`（按 index 报告） |
+```toml
+[dependencies]
+spin = { version = "=0.12.2", default-features = false, features = ["once"] }
+```
 
-feature 检查分两层：先检查 `features` 表中是否存在 `rwlock` 键（`features.rwlock`），再遍历 `features.default` 数组逐元素检查是否有 `"rwlock"`（`features.default[N]`）。这种双重检查确保 `rwlock` 既不能作为独立 feature 存在，也不能通过 default feature 间接恢复。
+以下写法会失败：
 
-### 2. 禁用副本路径
+```toml
+# 字符串依赖会启用上游默认 feature。
+spin = "0.12"
 
-`check_forbidden_spin_crate_paths` 用 `WalkDir` 遍历整个 workspace，对每个 `Cargo.toml` 检查其 `package.name`。如果发现名为 `spin` 但路径不是 `components/spin/Cargo.toml` 的包，报告为 `unregistered vendored spin copy is not allowed`。路径比较经过 `normalize_path` 规范化（处理 `..`、`.` 等），避免因路径写法差异绕过检查。
+# workspace 继承项不能覆盖版本或 feature。
+spin = { workspace = true, features = ["rwlock"] }
 
-`should_visit_spin_crate_entry` 作为 `WalkDir::filter_entry` 过滤掉无关目录（`.git`、`target`、`tmp`、`.cache`），同时**跳过 `MAIN_SPIN_PATH` 自身的子目录**（避免把主副本自身的文件误判为禁用副本）。
+# 不允许改名或覆盖来源。
+spin_compat = { package = "spin", version = "=0.12.2" }
+spin = { path = "components/spin" }
+```
 
-### 3 & 4. Manifest 依赖扫描
+## RwLock 约束
 
-`check_root_manifest` 和 `check_workspace_manifests` 扫描 workspace 根和各成员 crate 的 `Cargo.toml`，检查 `dependencies`、`dev-dependencies`、`build-dependencies` 三张表中是否存在外部 `spin` 依赖（递归检查 target-specific 依赖表如 `[target.'cfg(...)'.dependencies]`）。
-
-`is_spin_dependency` 判定一个依赖条目是否为 spin：依赖名是 `spin`，或 `package = "spin"` 的别名依赖。
-
-依赖来源分类处理：
-
-| 依赖写法 | 判定 | 处理 |
-|----------|------|------|
-| `spin = "0.12"` | 版本字符串 → crates.io 解析 | 报错：`resolves through crates.io` |
-| `spin = { workspace = true }` | workspace 继承 | 通过（继续检查 workspace 根的定义） |
-| `spin = { path = "..." }` | 显式 path | 检查 path 是否指向 `components/spin`、版本是否匹配 |
-| `spin = { version = "..." }` | 版本要求 → crates.io | 报错：`must not rely on crates.io version resolution` |
-
-正确的写法只有两种：`spin = { workspace = true }`（workspace 继承）或 `spin = { path = "../../components/spin" }`（显式 path 指向注册副本）。
-
-### 5. 源码 RwLock 用法
-
-`check_no_spin_rwlock_usage` 遍历 workspace 所有 `.rs` 文件（跳过 `spin_lint.rs` 自身，因为它包含这些模式字符串），逐行检查是否包含 `FORBIDDEN_SPIN_RWLOCK_PATTERNS` 中的任一模式：
-
-| 模式 | 匹配场景 |
-|------|----------|
-| `spin::RwLock` | 直接使用完全限定路径 |
-| `spin::rwlock` | 引用 rwlock 模块 |
-| `use spin::RwLock` | use 导入 |
-
-匹配到任一模式即报告 forbidden `<pattern>` usage，help 提示 use `ax_kspin::SpinRwLock` for non-sleeping read-write locks。这是逐行文本匹配（非 AST 分析），因为模式本身足够明确，不会误报。
-
-### 6. Cargo.lock 校验
-
-`check_lockfile` 解析 `Cargo.lock`，检查是否存在来源不是 workspace path 的 `spin` 包。如果 Cargo.lock 中出现了从 crates.io 或 git 解析的 `spin`，说明某处依赖泄漏到了外部版本，报告并失败。
-
-## 模块组成
-
-spin-lint 是单文件实现：
-
-| 代码位置 | 作用 |
-|----------|------|
-| `scripts/axbuild/src/spin_lint.rs` | 全部逻辑：CLI 入口、五项检查、finding 打印 |
-
-关键常量：
+spin-lint 对 Rust 源码逐行检查以下模式：
 
 ```rust
-const MAIN_SPIN_PATH: &str = "components/spin";
 const FORBIDDEN_SPIN_RWLOCK_PATTERNS: &[&str] =
     &["spin::RwLock", "spin::rwlock", "use spin::RwLock"];
 ```
 
-`should_visit_spin_crate_entry` 作为 `WalkDir::filter_entry` 的过滤器，跳过 `target/`、`.git/` 等无关目录，避免扫描产物和元数据。
+需要非睡眠读写锁时使用：
+
+```rust
+use ax_kspin::SpinRwLock;
+```
 
 ## 报告格式
 
-每条 finding 输出三行：
+每条 finding 包含路径、TOML 位置或源码行号、错误说明与修复建议：
 
 ```text
 <path>: <location>: <message>
   help: <修复建议>
 ```
 
-`location` 通常是 TOML 中的标签位置（如 `main migration copy`、`features.rwlock`、`features.default[2]`）或源码路径。所有 finding 都带有可操作的 `help`，例如：
-
-- `restore \`components/spin\` or update spin-lint if the migration copy changed`
-- `use \`ax_kspin::SpinRwLock\` instead of restoring \`spin::RwLock\``
-- `remove this package; only \`components/spin\` may remain until migration completes`
-
-存在任何 finding 即 `bail!("spin-lint found N issue(s)")`，命令退出码非零。
+存在任何 finding 时命令会以非零状态退出。
 
 ## 用法
 
@@ -136,8 +93,4 @@ const FORBIDDEN_SPIN_RWLOCK_PATTERNS: &[&str] =
 cargo xtask spin-lint
 ```
 
-无任何参数。CI 中通常作为强制门禁运行，任何对 `Cargo.toml`、`Cargo.lock` 或 `spin::RwLock` 引用的回归都会被它拦截。正确做法是：
-
-- 需要 spin lock → 使用 vendored `components/spin` 的 `SpinLock`（path 依赖）。
-- 需要 rwlock → 使用 `ax_kspin::SpinRwLock`，不要恢复 `spin::RwLock`。
-- 引入新的需要 `spin` 的上游 crate → 评估能否在其 feature 配置中关闭 spin 依赖，或在 `Cargo.toml` 中用 path 指向 `components/spin`。
+CI 会运行该命令，防止依赖版本、feature、来源或 `spin::RwLock` 用法回退。

--- a/scripts/axbuild/src/arceos/mod.rs
+++ b/scripts/axbuild/src/arceos/mod.rs
@@ -576,6 +576,7 @@ pub(crate) fn default_qemu_config_template_path(workspace_root: &Path, arch: &st
 #[cfg(test)]
 mod tests {
     use clap::Parser;
+    use ostool::run::qemu::QemuConfig;
     use tempfile::tempdir;
 
     use super::*;

--- a/scripts/axbuild/src/spin_lint.rs
+++ b/scripts/axbuild/src/spin_lint.rs
@@ -8,8 +8,8 @@ use anyhow::{Context, bail};
 use toml::Value;
 use walkdir::{DirEntry, WalkDir};
 
-const SPIN_VERSION_REQ: &str = "=0.12.0";
-const SPIN_LOCKFILE_VERSION: &str = "0.12.0";
+const SPIN_VERSION_REQ: &str = "=0.12.2";
+const SPIN_LOCKFILE_VERSION: &str = "0.12.2";
 const CRATES_IO_SOURCE: &str = "registry+https://github.com/rust-lang/crates.io-index";
 const ALLOWED_SPIN_FEATURES: &[&str] = &["lock_api", "once", "lazylock"];
 const FORBIDDEN_SPIN_RWLOCK_PATTERNS: &[&str] =
@@ -647,7 +647,7 @@ mod tests {
 members = ["crate"]
 
 [workspace.dependencies]
-spin = { version = "=0.12.0", default-features = false, features = ["lock_api", "once", "lazylock"] }
+spin = { version = "=0.12.2", default-features = false, features = ["lock_api", "once", "lazylock"] }
 "#,
         );
         write_file(
@@ -669,7 +669,7 @@ spin = { workspace = true }
             r#"
 [[package]]
 name = "spin"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abc"
 "#,
@@ -698,7 +698,7 @@ checksum = "abc"
 members = ["crate"]
 
 [workspace.dependencies]
-spin = { version = "=0.12.0", default-features = false, features = ["lock_api", "once", "lazylock"] }
+spin = { version = "=0.12.2", default-features = false, features = ["lock_api", "once", "lazylock"] }
 
 [patch.crates-io]
 spin = { path = "components/spin" }
@@ -724,7 +724,7 @@ spin = { path = "components/spin" }
             r#"
 [package]
 name = "spin"
-version = "0.12.0"
+version = "0.12.2"
 "#,
         );
 
@@ -749,7 +749,7 @@ version = "0.12.0"
 members = ["crate"]
 
 [workspace.dependencies]
-spin = { version = "=0.12.0", path = "components/spin", default-features = false, features = ["lock_api", "once", "lazylock"] }
+spin = { version = "=0.12.2", path = "components/spin", default-features = false, features = ["lock_api", "once", "lazylock"] }
 "#,
         );
 
@@ -774,7 +774,7 @@ spin = { version = "=0.12.0", path = "components/spin", default-features = false
 members = ["crate"]
 
 [workspace.dependencies]
-spin = { version = "=0.12.0", default-features = true, features = ["lock_api", "once", "lazylock"] }
+spin = { version = "=0.12.2", default-features = true, features = ["lock_api", "once", "lazylock"] }
 "#,
         );
 
@@ -799,7 +799,7 @@ spin = { version = "=0.12.0", default-features = true, features = ["lock_api", "
 members = ["crate"]
 
 [workspace.dependencies]
-spin = { version = "=0.12.0", default-features = false, features = ["lock_api", "once", "lazylock", "rwlock"] }
+spin = { version = "=0.12.2", default-features = false, features = ["lock_api", "once", "lazylock", "rwlock"] }
 "#,
         );
 
@@ -826,7 +826,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-spin = { version = "=0.12.0", default-features = false, features = ["once"] }
+spin = { version = "=0.12.2", default-features = false, features = ["once"] }
 "#,
         );
 
@@ -876,7 +876,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-spin = { version = "=0.12.0", features = ["once"] }
+spin = { version = "=0.12.2", features = ["once"] }
 "#,
         );
 
@@ -903,7 +903,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-spin = { version = "=0.12.0", default-features = false, features = ["once", "rwlock"] }
+spin = { version = "=0.12.2", default-features = false, features = ["once", "rwlock"] }
 "#,
         );
 
@@ -930,7 +930,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-spin_compat = { package = "spin", version = "=0.12.0", default-features = false, features = ["once"] }
+spin_compat = { package = "spin", version = "=0.12.2", default-features = false, features = ["once"] }
 "#,
         );
 
@@ -980,7 +980,7 @@ spin = { workspace = true, features = ["rwlock"] }
             r#"
 [[package]]
 name = "spin"
-version = "0.12.0"
+version = "0.12.2"
 "#,
         );
 
@@ -1003,7 +1003,7 @@ version = "0.12.0"
             r#"
 [[package]]
 name = "spin"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 "#,
         );
@@ -1038,7 +1038,7 @@ checksum = "abc"
         assert!(
             findings
                 .iter()
-                .any(|finding| finding.message.contains("must stay at 0.12.0"))
+                .any(|finding| finding.message.contains("must stay at 0.12.2"))
         );
     }
 


### PR DESCRIPTION
## 问题

workspace 当前将 `spin` 精确固定在已经撤回的 0.12.0，无法获得 0.12.1 和 0.12.2 中的 soundness 修复。仓库的 spin-lint 版本约束、测试夹具和文档也仍停留在旧版本及已经删除的 vendored 方案。

此外，ArceOS QEMU 配置测试直接使用 `QemuConfig`，但测试模块缺少对应导入，导致 `cargo test -p axbuild` 在编译阶段失败。

## 修改

1. 将 workspace `spin` 依赖精确更新到 0.12.2，并重新生成对应 lockfile 条目和 checksum。
2. 保持 `default-features = false` 以及 `lock_api`、`once`、`lazylock` feature 集不变，避免扩大依赖能力面。
3. 同步更新 spin-lint 的 manifest/lockfile 版本约束、单元测试夹具和错误断言。
4. 重写 spin-lint 文档，使其与当前 crates.io 精确版本、feature 白名单、本地副本禁用和 `spin::RwLock` 禁用规则一致。
5. 在 ArceOS 测试模块中导入 `ostool::run::qemu::QemuConfig`，恢复现有 QEMU 配置回归测试的编译与执行。

## 实现逻辑

`spin` 0.12.2 与 0.12.0 的 MSRV 和当前使用的 feature 配置兼容，因此升级不需要修改调用代码。workspace 依赖、Cargo.lock 和 spin-lint 使用同一精确版本，保证后续版本或来源漂移会被 CI 立即发现。QEMU 测试修复仅补充测试模块缺失的类型导入，不改变运行时代码。

## 验证

- `cargo test -p axbuild`：732 passed
- `cargo xtask spin-lint`
- `cargo xtask clippy --package axbuild`
- `cargo fmt --all --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`
