### PR TITLE
feat(axdevice): register exclusive IRQ line resources

### DIFF
--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -60,6 +60,10 @@ struct RangeEntry {
     size: u64,
 }
 
+fn ranges_overlap(start: u64, end: u64, other_start: u64, other_end: u64) -> bool {
+    start < other_end && other_start < end
+}
+
 /// represent A vm own devices
 pub struct AxVmDevices {
     /// Registered devices (append-only; index is the DeviceId).
@@ -70,6 +74,8 @@ pub struct AxVmDevices {
     port_index: BTreeMap<u16, RangeEntry>,
     /// System register address → range entry (slot, count).
     sysreg_index: BTreeMap<u32, RangeEntry>,
+    /// Exclusive IRQ line → owning device slot.
+    irq_line_index: BTreeMap<u32, DeviceId>,
     /// Devices that require periodic polling.
     pollable_devices: Vec<Arc<dyn PollableDeviceOps>>,
     /// x86 IOAPIC — kept for type-specific access.
@@ -98,6 +104,7 @@ impl AxVmDevices {
             mmio_index: BTreeMap::new(),
             port_index: BTreeMap::new(),
             sysreg_index: BTreeMap::new(),
+            irq_line_index: BTreeMap::new(),
             pollable_devices: Vec::new(),
             #[cfg(target_arch = "x86_64")]
             x86_ioapic: None,
@@ -519,42 +526,28 @@ impl AxVmDevices {
 
         let saved_len = self.devices.len();
         for device in &bundle.devices {
-            match self.register(device.clone()) {
-                Ok(_id) => {}
-                Err(e) => {
-                    // Rollback: pop back to saved_len, remove from index maps.
-                    while self.devices.len() > saved_len {
-                        let popped = self.devices.pop().unwrap();
-                        for r in popped.resources() {
-                            match *r {
-                                Resource::MmioRange { base, .. } => {
-                                    self.mmio_index.remove(&base);
-                                }
-                                Resource::PortRange { base, .. } => {
-                                    self.port_index.remove(&base);
-                                }
-                                Resource::SysReg { addr, .. } => {
-                                    self.sysreg_index.remove(&addr);
-                                }
-                            }
-                        }
-                    }
-                    return Err(e.into());
-                }
+            if let Err(error) = self.register(device.clone()) {
+                self.truncate_devices(saved_len);
+                return Err(error.into());
             }
         }
         self.pollable_devices.extend(bundle.pollable);
         Ok(())
     }
 
-    // ─── Resource rollback ────────────────────────────────────────
+    fn truncate_devices(&mut self, len: usize) {
+        while self.devices.len() > len {
+            let device = self
+                .devices
+                .pop()
+                .expect("device length was checked before rollback");
+            self.remove_resources(device.resources());
+        }
+    }
 
-    /// Removes `resources` from the index maps.  Used to undo a
-    /// partially-completed insertion when a conflict is discovered
-    /// mid-way through `insert_resources`.
-    fn rollback_resources(&mut self, resources: &[Resource]) {
-        for r in resources {
-            match *r {
+    fn remove_resources(&mut self, resources: &[Resource]) {
+        for resource in resources {
+            match *resource {
                 Resource::MmioRange { base, .. } => {
                     self.mmio_index.remove(&base);
                 }
@@ -564,145 +557,250 @@ impl AxVmDevices {
                 Resource::SysReg { addr, .. } => {
                     self.sysreg_index.remove(&addr);
                 }
+                Resource::IrqLine { line, .. } => {
+                    self.irq_line_index.remove(&line);
+                }
             }
         }
     }
 
-    // ─── BTreeMap insertion with inline conflict detection ─────────
-
-    /// Inserts every resource of device `idx` into the three BTreeMap
-    /// indices, checking for validity errors and range conflicts
-    /// as each key is inserted.
-    ///
-    /// Because earlier resources of the *same* device are already in
-    /// the index when later ones are checked, same-device internal
-    /// overlaps are caught by the same predecessor/successor probes
-    /// that catch cross-device overlaps.  A conflict is reported as
-    /// [`InvalidResourceReason::OverlappingResources`] when the
-    /// neighbour entry belongs to the current device, and as
-    /// [`RegistryError::AddressConflict`] otherwise.
-    ///
-    /// On any error the keys inserted so far are rolled back through
-    /// [`rollback_resources`], leaving the indices unchanged.
-    fn insert_resources(
-        &mut self,
-        idx: usize,
-        resources: &[Resource],
-    ) -> Result<(), RegistryError> {
-        for (i, r) in resources.iter().enumerate() {
-            match *r {
+    /// Validates every resource without mutating the dispatch indices.
+    fn validate_resources(&self, resources: &[Resource]) -> Result<(), RegistryError> {
+        for (index, resource) in resources.iter().enumerate() {
+            let earlier_resources = &resources[..index];
+            match *resource {
                 Resource::MmioRange { base, size } => {
-                    if size == 0 {
+                    self.validate_mmio_range(base, size, earlier_resources)?;
+                }
+                Resource::PortRange { base, size } => {
+                    self.validate_port_range(base, size, earlier_resources)?;
+                }
+                Resource::SysReg { addr, count } => {
+                    self.validate_sysreg_range(addr, count, earlier_resources)?;
+                }
+                Resource::IrqLine { line, trigger } => {
+                    if earlier_resources.iter().any(
+                        |resource| matches!(resource, Resource::IrqLine { line: earlier, .. } if *earlier == line),
+                    ) {
                         return Err(RegistryError::InvalidResource {
-                            resource: Resource::MmioRange { base, size },
-                            reason: InvalidResourceReason::ZeroSized,
+                            resource: Resource::IrqLine { line, trigger },
+                            reason: InvalidResourceReason::DuplicateIrqLine { line },
                         });
                     }
-                    if base.checked_add(size).is_none() {
-                        return Err(RegistryError::InvalidResource {
-                            resource: Resource::MmioRange { base, size },
-                            reason: InvalidResourceReason::AddressOverflow,
-                        });
-                    }
-
-                    // Key collision.
-                    if let Some(existing) = self.mmio_index.get(&base) {
-                        let existing_size = existing.size;
-                        let existing_slot = existing.slot;
-                        self.rollback_resources(&resources[..i]);
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::MmioRange { base, size },
-                            existing: Resource::MmioRange {
-                                base,
-                                size: existing_size,
-                            },
-                            existing_device: DeviceId::new(existing_slot as u32),
-                        });
-                    }
-
-                    self.mmio_index.insert(base, RangeEntry { slot: idx, size });
-
-                    // Predecessor check.
-                    if let Some((prev_base, existing)) = self.mmio_index.range(..base).next_back()
-                        && prev_base.wrapping_add(existing.size) > base
-                    {
-                        let conflicting_base = *prev_base;
-                        let conflicting_size = existing.size;
-                        let conflicting_slot = existing.slot;
-                        self.rollback_resources(&resources[..=i]);
-                        if conflicting_slot == idx {
-                            return Err(RegistryError::InvalidResource {
-                                resource: Resource::MmioRange { base, size },
-                                reason: InvalidResourceReason::OverlappingResources,
-                            });
-                        }
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::MmioRange { base, size },
-                            existing: Resource::MmioRange {
-                                base: conflicting_base,
-                                size: conflicting_size,
-                            },
-                            existing_device: DeviceId::new(conflicting_slot as u32),
-                        });
-                    }
-
-                    // Successor check.
-                    let end = base + size;
-                    if let Some(next_start) = base.checked_add(1)
-                        && let Some((next_base, existing)) =
-                            self.mmio_index.range(next_start..).next()
-                        && *next_base < end
-                    {
-                        let conflicting_base = *next_base;
-                        let conflicting_size = existing.size;
-                        let conflicting_slot = existing.slot;
-                        self.rollback_resources(&resources[..=i]);
-                        if conflicting_slot == idx {
-                            return Err(RegistryError::InvalidResource {
-                                resource: Resource::MmioRange { base, size },
-                                reason: InvalidResourceReason::OverlappingResources,
-                            });
-                        }
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::MmioRange { base, size },
-                            existing: Resource::MmioRange {
-                                base: conflicting_base,
-                                size: conflicting_size,
-                            },
-                            existing_device: DeviceId::new(conflicting_slot as u32),
+                    if let Some(&existing) = self.irq_line_index.get(&line) {
+                        return Err(RegistryError::IrqLineConflict {
+                            line,
+                            existing_device: existing,
                         });
                     }
                 }
+            }
+        }
+        Ok(())
+    }
+
+    fn validate_mmio_range(
+        &self,
+        base: u64,
+        size: u64,
+        earlier_resources: &[Resource],
+    ) -> Result<(), RegistryError> {
+        let resource = Resource::MmioRange { base, size };
+        if size == 0 {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::ZeroSized,
+            });
+        }
+        let Some(end) = base.checked_add(size) else {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::AddressOverflow,
+            });
+        };
+        if earlier_resources.iter().any(|earlier| {
+            matches!(
+                *earlier,
+                Resource::MmioRange {
+                    base: earlier_base,
+                    size: earlier_size,
+                } if ranges_overlap(
+                    base,
+                    end,
+                    earlier_base,
+                    earlier_base.saturating_add(earlier_size),
+                )
+            )
+        }) {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::OverlappingResources,
+            });
+        }
+        if let Some((existing_base, existing)) = self.mmio_conflict(base, end) {
+            return Err(RegistryError::AddressConflict {
+                resource,
+                existing: Resource::MmioRange {
+                    base: existing_base,
+                    size: existing.size,
+                },
+                existing_device: DeviceId::new(existing.slot as u32),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_port_range(
+        &self,
+        base: u16,
+        size: u16,
+        earlier_resources: &[Resource],
+    ) -> Result<(), RegistryError> {
+        let resource = Resource::PortRange { base, size };
+        if size == 0 {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::ZeroSized,
+            });
+        }
+        let end = base as u64 + size as u64;
+        if end > u16::MAX as u64 + 1 {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::AddressOverflow,
+            });
+        }
+        if earlier_resources.iter().any(|earlier| {
+            matches!(
+                *earlier,
+                Resource::PortRange {
+                    base: earlier_base,
+                    size: earlier_size,
+                } if ranges_overlap(
+                    base as u64,
+                    end,
+                    earlier_base as u64,
+                    earlier_base as u64 + earlier_size as u64,
+                )
+            )
+        }) {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::OverlappingResources,
+            });
+        }
+        if let Some((existing_base, existing)) = self.port_conflict(base, end) {
+            return Err(RegistryError::AddressConflict {
+                resource,
+                existing: Resource::PortRange {
+                    base: existing_base,
+                    size: existing.size as u16,
+                },
+                existing_device: DeviceId::new(existing.slot as u32),
+            });
+        }
+        Ok(())
+    }
+
+    fn validate_sysreg_range(
+        &self,
+        addr: u32,
+        count: u32,
+        earlier_resources: &[Resource],
+    ) -> Result<(), RegistryError> {
+        let resource = Resource::SysReg { addr, count };
+        if count == 0 {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::ZeroSized,
+            });
+        }
+        let end = addr as u64 + count as u64;
+        if end > u32::MAX as u64 + 1 {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::AddressOverflow,
+            });
+        }
+        if earlier_resources.iter().any(|earlier| {
+            matches!(
+                *earlier,
+                Resource::SysReg {
+                    addr: earlier_addr,
+                    count: earlier_count,
+                } if ranges_overlap(
+                    addr as u64,
+                    end,
+                    earlier_addr as u64,
+                    earlier_addr as u64 + earlier_count as u64,
+                )
+            )
+        }) {
+            return Err(RegistryError::InvalidResource {
+                resource,
+                reason: InvalidResourceReason::OverlappingResources,
+            });
+        }
+        if let Some((existing_addr, existing)) = self.sysreg_conflict(addr, end) {
+            return Err(RegistryError::AddressConflict {
+                resource,
+                existing: Resource::SysReg {
+                    addr: existing_addr,
+                    count: existing.size as u32,
+                },
+                existing_device: DeviceId::new(existing.slot as u32),
+            });
+        }
+        Ok(())
+    }
+
+    fn mmio_conflict(&self, base: u64, end: u64) -> Option<(u64, &RangeEntry)> {
+        if let Some((&existing_base, existing)) = self.mmio_index.range(..=base).next_back()
+            && base < existing_base.saturating_add(existing.size)
+        {
+            return Some((existing_base, existing));
+        }
+        self.mmio_index
+            .range(base..)
+            .next()
+            .filter(|(existing_base, _)| **existing_base < end)
+            .map(|(&existing_base, existing)| (existing_base, existing))
+    }
+
+    fn port_conflict(&self, base: u16, end: u64) -> Option<(u16, &RangeEntry)> {
+        if let Some((&existing_base, existing)) = self.port_index.range(..=base).next_back()
+            && (base as u64) < existing_base as u64 + existing.size
+        {
+            return Some((existing_base, existing));
+        }
+        self.port_index
+            .range(base..)
+            .next()
+            .filter(|(existing_base, _)| (**existing_base as u64) < end)
+            .map(|(&existing_base, existing)| (existing_base, existing))
+    }
+
+    fn sysreg_conflict(&self, addr: u32, end: u64) -> Option<(u32, &RangeEntry)> {
+        if let Some((&existing_addr, existing)) = self.sysreg_index.range(..=addr).next_back()
+            && (addr as u64) < existing_addr as u64 + existing.size
+        {
+            return Some((existing_addr, existing));
+        }
+        self.sysreg_index
+            .range(addr..)
+            .next()
+            .filter(|(existing_addr, _)| (**existing_addr as u64) < end)
+            .map(|(&existing_addr, existing)| (existing_addr, existing))
+    }
+
+    fn insert_resources(&mut self, idx: usize, resources: &[Resource]) {
+        let device_id = DeviceId::new(idx as u32);
+        for resource in resources {
+            match *resource {
+                Resource::MmioRange { base, size } => {
+                    self.mmio_index.insert(base, RangeEntry { slot: idx, size });
+                }
                 Resource::PortRange { base, size } => {
-                    if size == 0 {
-                        return Err(RegistryError::InvalidResource {
-                            resource: Resource::PortRange { base, size },
-                            reason: InvalidResourceReason::ZeroSized,
-                        });
-                    }
-                    let end = (base as u32).wrapping_add(size as u32);
-                    if end > (u16::MAX as u32 + 1) {
-                        return Err(RegistryError::InvalidResource {
-                            resource: Resource::PortRange { base, size },
-                            reason: InvalidResourceReason::AddressOverflow,
-                        });
-                    }
-
-                    // Key collision.
-                    if let Some(existing) = self.port_index.get(&base) {
-                        let existing_size = existing.size as u16;
-                        let existing_slot = existing.slot;
-                        self.rollback_resources(&resources[..i]);
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::PortRange { base, size },
-                            existing: Resource::PortRange {
-                                base,
-                                size: existing_size,
-                            },
-                            existing_device: DeviceId::new(existing_slot as u32),
-                        });
-                    }
-
                     self.port_index.insert(
                         base,
                         RangeEntry {
@@ -710,87 +808,8 @@ impl AxVmDevices {
                             size: size as u64,
                         },
                     );
-
-                    // Predecessor check.
-                    if let Some((prev_base, existing)) = self.port_index.range(..base).next_back()
-                        && (*prev_base as u32).wrapping_add(existing.size as u32) > base as u32
-                    {
-                        let conflicting_base = *prev_base;
-                        let conflicting_size = existing.size as u16;
-                        let conflicting_slot = existing.slot;
-                        self.rollback_resources(&resources[..=i]);
-                        if conflicting_slot == idx {
-                            return Err(RegistryError::InvalidResource {
-                                resource: Resource::PortRange { base, size },
-                                reason: InvalidResourceReason::OverlappingResources,
-                            });
-                        }
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::PortRange { base, size },
-                            existing: Resource::PortRange {
-                                base: conflicting_base,
-                                size: conflicting_size,
-                            },
-                            existing_device: DeviceId::new(conflicting_slot as u32),
-                        });
-                    }
-
-                    // Successor check.
-                    if let Some(next_port) = base.checked_add(1)
-                        && let Some((next_base, existing)) =
-                            self.port_index.range(next_port..).next()
-                        && (*next_base as u32) < end
-                    {
-                        let conflicting_base = *next_base;
-                        let conflicting_size = existing.size as u16;
-                        let conflicting_slot = existing.slot;
-                        self.rollback_resources(&resources[..=i]);
-                        if conflicting_slot == idx {
-                            return Err(RegistryError::InvalidResource {
-                                resource: Resource::PortRange { base, size },
-                                reason: InvalidResourceReason::OverlappingResources,
-                            });
-                        }
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::PortRange { base, size },
-                            existing: Resource::PortRange {
-                                base: conflicting_base,
-                                size: conflicting_size,
-                            },
-                            existing_device: DeviceId::new(conflicting_slot as u32),
-                        });
-                    }
                 }
                 Resource::SysReg { addr, count } => {
-                    if count == 0 {
-                        return Err(RegistryError::InvalidResource {
-                            resource: Resource::SysReg { addr, count },
-                            reason: InvalidResourceReason::ZeroSized,
-                        });
-                    }
-                    if addr.checked_add(count.saturating_sub(1)).is_none() {
-                        return Err(RegistryError::InvalidResource {
-                            resource: Resource::SysReg { addr, count },
-                            reason: InvalidResourceReason::AddressOverflow,
-                        });
-                    }
-
-                    // Key collision.
-                    if let Some(existing) = self.sysreg_index.get(&addr) {
-                        let existing_count = existing.size as u32;
-                        let existing_slot = existing.slot;
-                        self.rollback_resources(&resources[..i]);
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::SysReg { addr, count },
-                            existing: Resource::SysReg {
-                                addr,
-                                count: existing_count,
-                            },
-                            existing_device: DeviceId::new(existing_slot as u32),
-                        });
-                    }
-
-                    let end = addr.saturating_add(count.saturating_sub(1));
                     self.sysreg_index.insert(
                         addr,
                         RangeEntry {
@@ -798,61 +817,12 @@ impl AxVmDevices {
                             size: count as u64,
                         },
                     );
-
-                    // Predecessor check.
-                    if let Some((prev_addr, existing)) = self.sysreg_index.range(..addr).next_back()
-                        && prev_addr.saturating_add((existing.size as u32).saturating_sub(1))
-                            >= addr
-                    {
-                        let conflicting_addr = *prev_addr;
-                        let conflicting_count = existing.size as u32;
-                        let conflicting_slot = existing.slot;
-                        self.rollback_resources(&resources[..=i]);
-                        if conflicting_slot == idx {
-                            return Err(RegistryError::InvalidResource {
-                                resource: Resource::SysReg { addr, count },
-                                reason: InvalidResourceReason::OverlappingResources,
-                            });
-                        }
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::SysReg { addr, count },
-                            existing: Resource::SysReg {
-                                addr: conflicting_addr,
-                                count: conflicting_count,
-                            },
-                            existing_device: DeviceId::new(conflicting_slot as u32),
-                        });
-                    }
-
-                    // Successor check.
-                    if let Some(next_addr) = addr.checked_add(1)
-                        && let Some((reg_addr, existing)) =
-                            self.sysreg_index.range(next_addr..).next()
-                        && *reg_addr <= end
-                    {
-                        let conflicting_addr = *reg_addr;
-                        let conflicting_count = existing.size as u32;
-                        let conflicting_slot = existing.slot;
-                        self.rollback_resources(&resources[..=i]);
-                        if conflicting_slot == idx {
-                            return Err(RegistryError::InvalidResource {
-                                resource: Resource::SysReg { addr, count },
-                                reason: InvalidResourceReason::OverlappingResources,
-                            });
-                        }
-                        return Err(RegistryError::AddressConflict {
-                            resource: Resource::SysReg { addr, count },
-                            existing: Resource::SysReg {
-                                addr: conflicting_addr,
-                                count: conflicting_count,
-                            },
-                            existing_device: DeviceId::new(conflicting_slot as u32),
-                        });
-                    }
+                }
+                Resource::IrqLine { line, .. } => {
+                    self.irq_line_index.insert(line, device_id);
                 }
             }
         }
-        Ok(())
     }
 
     // ─── Lookup helpers ────────────────────────────────────────────
@@ -1219,7 +1189,8 @@ impl Default for AxVmDevices {
 impl DeviceRegistry for AxVmDevices {
     fn register(&mut self, device: Arc<dyn Device>) -> Result<DeviceId, RegistryError> {
         let idx = self.devices.len();
-        self.insert_resources(idx, device.resources())?;
+        self.validate_resources(device.resources())?;
+        self.insert_resources(idx, device.resources());
         self.devices.push(device);
         info!("AxVmDevices: registered device id={}", idx);
         Ok(DeviceId::new(idx as u32))

--- a/virtualization/axdevice_base/src/lib.rs
+++ b/virtualization/axdevice_base/src/lib.rs
@@ -403,6 +403,20 @@ pub enum Resource {
         /// Number of registers in the range.
         count: u32,
     },
+    /// An exclusive IRQ line connected to the VM's interrupt fabric.
+    ///
+    /// The `line` is an architecture-neutral identifier on the virtual
+    /// interrupt controller input side (e.g. GSI, INTID, or PLIC source).
+    /// It is not a host `IrqId`, CPU trap vector, or physical IRQ.
+    ///
+    /// This stage only supports exclusive declaration. Sharing policy
+    /// will be added when a concrete device needs it.
+    IrqLine {
+        /// The interrupt line number.
+        line: u32,
+        /// The trigger mode configured for this line.
+        trigger: InterruptTriggerMode,
+    },
 }
 
 /// The reason a resource was rejected as structurally invalid during
@@ -427,6 +441,12 @@ pub enum InvalidResourceReason {
     /// dispatch index.
     #[error("device resources overlap")]
     OverlappingResources,
+    /// The device declared the same IRQ line more than once.
+    #[error("duplicate IRQ line {line}")]
+    DuplicateIrqLine {
+        /// The duplicated line number.
+        line: u32,
+    },
 }
 
 /// Errors that can be returned when registering a device.
@@ -474,6 +494,14 @@ pub enum RegistryError {
         required_arch: Arch,
         /// The architecture the hypervisor is currently built for.
         current_arch: Arch,
+    },
+    /// Two devices claim the same IRQ line.
+    #[error("IRQ line {line} conflicts with device {existing_device:?}")]
+    IrqLineConflict {
+        /// The IRQ line the new device is attempting to register.
+        line: u32,
+        /// The device that already owns the conflicting IRQ line.
+        existing_device: DeviceId,
     },
 }
 

--- a/virtualization/axvm/src/error.rs
+++ b/virtualization/axvm/src/error.rs
@@ -305,6 +305,9 @@ impl From<RegistryError> for AxVmError {
             RegistryError::AddressConflict { .. } => {
                 Self::resource_conflict("device address range", error)
             }
+            RegistryError::IrqLineConflict { .. } => {
+                Self::resource_conflict("device IRQ line", error)
+            }
             RegistryError::InvalidResource { .. } => {
                 Self::invalid_input("register virtual device", error)
             }

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -21,8 +21,9 @@ use axdevice::{
     register_builtin_factories,
 };
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, DeviceRegistry as _, DeviceResult, InterruptTriggerMode, IrqError,
-    IrqLine, IrqLineId, Port, PortRange, RegistryError, SysRegAddr, SysRegAddrRange,
+    AccessWidth, BaseDeviceOps, Device, DeviceError, DeviceRegistry as _, DeviceResult,
+    InterruptTriggerMode, InvalidResourceReason, IrqError, IrqLine, IrqLineId, Port, PortRange,
+    RegistryError, Resource, SysRegAddr, SysRegAddrRange,
 };
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType, GuestPhysAddr, GuestPhysAddrRange};
 
@@ -139,6 +140,41 @@ struct MockSysRegDevice {
     range: SysRegAddrRange,
 }
 
+struct MockResourceDevice {
+    name: String,
+    resources: Vec<Resource>,
+}
+
+impl MockResourceDevice {
+    fn new(name: &str, resources: Vec<Resource>) -> Self {
+        Self {
+            name: String::from(name),
+            resources,
+        }
+    }
+}
+
+impl Device for MockResourceDevice {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn handle(
+        &self,
+        _access: &axdevice_base::BusAccess,
+    ) -> Result<axdevice_base::BusResponse, DeviceError> {
+        Ok(axdevice_base::BusResponse::Read { value: 0x5a })
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 struct MockMmioPollableDevice {
     range: GuestPhysAddrRange,
     polled_at: Mutex<Vec<u64>>,
@@ -210,6 +246,14 @@ impl BaseDeviceOps<SysRegAddrRange> for MockSysRegDevice {
 
 fn empty_devices() -> AxVmDevices {
     AxVmDevices::new(AxVmDeviceConfig::new(vec![])).unwrap()
+}
+
+fn irq_resource(line: u32, trigger: InterruptTriggerMode) -> Resource {
+    Resource::IrqLine { line, trigger }
+}
+
+fn resource_device(name: &str, resources: Vec<Resource>) -> Arc<MockResourceDevice> {
+    Arc::new(MockResourceDevice::new(name, resources))
 }
 
 fn mmio_device(name: &str, start: usize, end: usize) -> Arc<MockMmioDevice> {
@@ -877,4 +921,240 @@ fn test_sysreg_range_interior_address_dispatch() {
             .handle_sys_reg_read(SysRegAddr::new(0x111), AccessWidth::Qword)
             .is_err()
     );
+}
+
+#[test]
+fn test_irq_line_resource_accepts_full_identifier_range_without_bus_dispatch() {
+    let mut devices = empty_devices();
+
+    for line in [0, 63, 64, 255, 256, u32::MAX] {
+        devices
+            .register(resource_device(
+                "irq-only",
+                vec![irq_resource(line, InterruptTriggerMode::EdgeTriggered)],
+            ))
+            .unwrap_or_else(|error| panic!("IRQ line {line} was rejected: {error}"));
+    }
+
+    assert_eq!(devices.devices().count(), 6);
+    assert!(
+        devices
+            .handle_mmio_read(GuestPhysAddr::from(0), AccessWidth::Dword)
+            .is_err()
+    );
+    assert!(
+        devices
+            .handle_port_read(Port::new(0), AccessWidth::Byte)
+            .is_err()
+    );
+    assert!(
+        devices
+            .handle_sys_reg_read(SysRegAddr::new(0), AccessWidth::Qword)
+            .is_err()
+    );
+}
+
+#[test]
+fn test_irq_line_resource_rejects_duplicate_declarations_and_cross_device_conflicts() {
+    let mut devices = empty_devices();
+    let duplicate = resource_device(
+        "duplicate",
+        vec![
+            irq_resource(10, InterruptTriggerMode::EdgeTriggered),
+            irq_resource(10, InterruptTriggerMode::LevelTriggered),
+        ],
+    );
+
+    assert!(matches!(
+        devices.register(duplicate),
+        Err(RegistryError::InvalidResource {
+            reason: InvalidResourceReason::DuplicateIrqLine { line: 10 },
+            ..
+        })
+    ));
+    assert_eq!(devices.devices().count(), 0);
+
+    let existing_device = devices
+        .register(resource_device(
+            "owner",
+            vec![irq_resource(20, InterruptTriggerMode::EdgeTriggered)],
+        ))
+        .unwrap();
+    assert_eq!(
+        devices.register(resource_device(
+            "contender",
+            vec![irq_resource(20, InterruptTriggerMode::LevelTriggered)],
+        )),
+        Err(RegistryError::IrqLineConflict {
+            line: 20,
+            existing_device,
+        })
+    );
+}
+
+#[test]
+fn test_failed_registration_does_not_reserve_an_earlier_irq_line() {
+    let cases = [
+        (
+            "zero-sized MMIO",
+            30,
+            Resource::MmioRange {
+                base: 0x1000,
+                size: 0,
+            },
+            InvalidResourceReason::ZeroSized,
+        ),
+        (
+            "overflowing MMIO",
+            31,
+            Resource::MmioRange {
+                base: u64::MAX - 1,
+                size: 4,
+            },
+            InvalidResourceReason::AddressOverflow,
+        ),
+        (
+            "zero-sized port range",
+            32,
+            Resource::PortRange {
+                base: 0x3f8,
+                size: 0,
+            },
+            InvalidResourceReason::ZeroSized,
+        ),
+        (
+            "overflowing port range",
+            33,
+            Resource::PortRange {
+                base: u16::MAX - 1,
+                size: 4,
+            },
+            InvalidResourceReason::AddressOverflow,
+        ),
+        (
+            "zero-sized system register range",
+            34,
+            Resource::SysReg {
+                addr: 0x100,
+                count: 0,
+            },
+            InvalidResourceReason::ZeroSized,
+        ),
+        (
+            "overflowing system register range",
+            35,
+            Resource::SysReg {
+                addr: u32::MAX - 1,
+                count: 4,
+            },
+            InvalidResourceReason::AddressOverflow,
+        ),
+    ];
+
+    for (case, line, invalid_resource, expected_reason) in cases {
+        let mut devices = empty_devices();
+        let error = devices
+            .register(resource_device(
+                "invalid",
+                vec![
+                    irq_resource(line, InterruptTriggerMode::EdgeTriggered),
+                    invalid_resource,
+                ],
+            ))
+            .unwrap_err();
+
+        let RegistryError::InvalidResource { reason, .. } = error else {
+            panic!("{case} returned an unexpected error: {error:?}");
+        };
+        assert_eq!(reason, expected_reason, "{case}");
+        assert_eq!(devices.devices().count(), 0, "{case}");
+        assert!(
+            devices
+                .register(resource_device(
+                    "replacement",
+                    vec![irq_resource(line, InterruptTriggerMode::EdgeTriggered)],
+                ))
+                .is_ok(),
+            "{case} leaked IRQ line {line}"
+        );
+    }
+}
+
+#[test]
+fn test_bundle_irq_conflict_rolls_back_all_resources_from_prior_devices() {
+    let mut devices = empty_devices();
+    devices
+        .register(resource_device(
+            "existing",
+            vec![irq_resource(40, InterruptTriggerMode::EdgeTriggered)],
+        ))
+        .unwrap();
+
+    let mut bundle = DeviceBundle::new();
+    bundle.push(DeviceRegistration::Device(resource_device(
+        "bundle-first",
+        vec![
+            Resource::MmioRange {
+                base: 0x20_000,
+                size: 0x100,
+            },
+            irq_resource(41, InterruptTriggerMode::EdgeTriggered),
+        ],
+    )));
+    bundle.push(DeviceRegistration::Device(resource_device(
+        "bundle-conflict",
+        vec![irq_resource(40, InterruptTriggerMode::LevelTriggered)],
+    )));
+
+    assert!(matches!(
+        devices.register_bundle(bundle),
+        Err(DeviceManagerError::Registry(
+            RegistryError::IrqLineConflict { line: 40, .. }
+        ))
+    ));
+    assert_eq!(devices.devices().count(), 1);
+
+    devices
+        .register(resource_device(
+            "replacement",
+            vec![
+                Resource::MmioRange {
+                    base: 0x20_000,
+                    size: 0x100,
+                },
+                irq_resource(41, InterruptTriggerMode::EdgeTriggered),
+            ],
+        ))
+        .expect("bundle rollback must release both MMIO and IRQ resources");
+}
+
+#[test]
+fn test_device_can_declare_mmio_and_irq_resources_together() {
+    let mut devices = empty_devices();
+    devices
+        .register(resource_device(
+            "mmio-and-irq",
+            vec![
+                Resource::MmioRange {
+                    base: 0x30_000,
+                    size: 0x100,
+                },
+                irq_resource(50, InterruptTriggerMode::LevelTriggered),
+            ],
+        ))
+        .unwrap();
+
+    assert_eq!(
+        devices
+            .handle_mmio_read(GuestPhysAddr::from(0x30_040), AccessWidth::Dword)
+            .unwrap(),
+        0x5a
+    );
+    assert!(matches!(
+        devices.register(resource_device(
+            "irq-conflict",
+            vec![irq_resource(50, InterruptTriggerMode::EdgeTriggered)],
+        )),
+        Err(RegistryError::IrqLineConflict { line: 50, .. })
+    ));
 }


### PR DESCRIPTION
## 问题

AxVisor 的设备资源模型目前只能声明 MMIO、Port I/O 和系统寄存器范围，设备使用的 IRQ line 没有进入统一资源注册流程。因此，设备注册阶段无法发现以下问题：

- 同一设备重复声明同一 IRQ line；
- 不同设备独占同一 IRQ line；
- bundle 注册中途失败后，已登记的 IRQ line 没有统一的回滚机制。

这使后续架构 Router 无法在设备构造阶段获得稳定、可校验的 IRQ 所有权关系。

本 PR 只实现 [issue 1586](https://github.com/rcore-os/tgoskits/issues/1586) 模块一共享资源层中的 IRQ line 声明、校验和回滚。runtime dispatcher、generation lifecycle、架构 Router 及现有中断生产者迁移不在本 PR 范围内。

## 修改内容

### 1. 增加架构无关的 IRQ line 资源

在 `axdevice_base::Resource` 中增加：

```rust
Resource::IrqLine {
    line: u32,
    trigger: InterruptTriggerMode,
}
```

- `line` 表示虚拟中断控制器输入侧的架构无关标识，例如 GSI、INTID 或 PLIC source；
- 该标识不是 host IRQ、CPU trap vector 或物理中断号；
- 资源层不设置统一的 line 上限，具体范围由后续架构 Router 校验；
- 当前只支持独占声明，不引入共享 IRQ 策略。

### 2. 增加结构化的重复与冲突错误

新增两类可匹配错误：

- `InvalidResourceReason::DuplicateIrqLine`：同一设备重复声明相同 line；
- `RegistryError::IrqLineConflict`：不同设备声明相同的独占 line，并保留已有资源的 `DeviceId`。

`axvm` 将跨设备 IRQ line 冲突映射为 `AxVmError::ResourceConflict`，保持上层错误域的一致性。

### 3. 建立独占 IRQ line 索引

`AxVmDevices` 使用 `BTreeMap<u32, DeviceId>` 保存 IRQ line 所有权：

- 不使用固定宽度位图，因此不会把架构中断号限制在 64、256 或其他共享层上限；
- IRQ line 索引只用于注册期资源校验；
- IRQ-only 设备不会进入 MMIO、Port I/O 或 SysReg dispatch 索引。

### 4. 收敛设备注册事务

设备注册由原来的“逐项插入、发现错误后局部回滚”调整为：

1. 完整校验设备声明的全部资源；
2. 校验成功后统一写入各类资源索引；
3. 最后把设备加入设备列表。

这样单设备注册失败时不会留下部分 MMIO、Port、SysReg 或 IRQ 状态。

bundle 注册仍逐设备提交；如果后续设备失败，则统一移除本 bundle 已注册设备的全部资源。回滚逻辑现在同时覆盖：

- MMIO range；
- Port I/O range；
- SysReg range；
- IRQ line。

这一调整也修复了无效资源出现在资源列表后部时，前面资源可能需要额外回滚的问题。

## 实现逻辑

资源校验和资源写入被明确分成两个阶段：

```text
Device::resources()
        |
        v
validate_resources()
  - 结构校验
  - 同设备重叠或重复校验
  - 与已有设备资源冲突校验
        |
        v
insert_resources()
  - 更新各类资源索引
        |
        v
devices.push()
```

地址范围继续使用半开区间语义，并分别保留 MMIO、Port I/O 和 SysReg 的边界及溢出检查。IRQ line 不参与地址范围比较，而是按完整 `u32` 标识进行精确所有权检查。

bundle 回滚按已加入的设备逆向移除资源索引，确保资源索引与设备列表保持一致。

## 测试

新增和调整的集成测试覆盖：

- IRQ line `0`、`63`、`64`、`255`、`256` 和 `u32::MAX`；
- IRQ-only 设备不参与三类总线 dispatch；
- 同一设备使用不同 trigger mode 重复声明同一 line；
- 跨设备 line 冲突及已有 `DeviceId`；
- MMIO 与 IRQ line 由同一设备共同声明；
- MMIO、Port 和 SysReg 的 zero-size、overflow 错误不会泄漏此前声明的 IRQ line；
- bundle 中 IRQ 冲突会回滚此前设备持有的 MMIO 和 IRQ 资源；
- 原有地址范围冲突、边界和 dispatch 行为保持不变。