### PR TITLE
fix(starry): support Nix openat2 resolve flags

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -435,9 +435,8 @@ pub fn sys_openat2(
     if how_value.resolve & !OPENAT2_VALID_RESOLVE != 0 {
         return Err(AxError::InvalidInput);
     }
-    // This minimal openat2 implementation does not enforce Linux RESOLVE_*
-    // path-walk constraints yet, so reject known resolve bits explicitly.
-    if how_value.resolve != 0 {
+    const NIX_RESTORE_RESOLVE: u64 = (RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS) as u64;
+    if how_value.resolve != 0 && how_value.resolve != NIX_RESTORE_RESOLVE {
         return Err(AxError::OperationNotSupported);
     }
 
@@ -449,8 +448,45 @@ pub fn sys_openat2(
         .mode
         .try_into()
         .map_err(|_| AxError::InvalidInput)?;
+    let uflags = flags as u32;
 
-    sys_openat(dirfd, path, flags, mode)
+    if uflags & O_CREAT != 0 && uflags & O_DIRECTORY != 0 && uflags & O_PATH == 0 {
+        return Err(AxError::InvalidInput);
+    }
+    if uflags & O_TMPFILE == O_TMPFILE && uflags & 0b11 == O_RDONLY && uflags & O_PATH == 0 {
+        return Err(AxError::InvalidInput);
+    }
+
+    if how_value.resolve == 0 {
+        return sys_openat(dirfd, path, flags, mode);
+    }
+
+    let path = vm_load_path_string(path)?;
+    if path.is_empty() {
+        return Err(AxError::NotFound);
+    }
+    if path.starts_with('/') {
+        return Err(AxError::CrossesDevices);
+    }
+
+    let curr = current();
+    let thread = curr.as_thread();
+    let mode = mode & !thread.proc_data.umask();
+    let cred = thread.cred();
+    let mut options = flags_to_options(flags, mode, (cred.fsuid, cred.fsgid));
+    let result = with_fs(dirfd, |fs| {
+        let (parent, name) = fs.resolve_parent_beneath_no_symlinks(path.as_ref())?;
+        match parent.lookup_no_follow(name.as_ref()) {
+            Ok(location) if location.node_type() == NodeType::Symlink => {
+                return Err(AxError::FilesystemLoop);
+            }
+            Err(AxError::NotFound) | Ok(_) => {}
+            Err(error) => return Err(error),
+        }
+        options.no_follow(true);
+        options.open(&fs.with_current_dir(parent)?, name.as_ref())
+    })?;
+    add_to_fd(result, flags as u32).map(|fd| fd as isize)
 }
 
 /// Open a file by `filename` and insert it into the file descriptor table.

--- a/os/arceos/modules/axfs-ng/src/fs_core/context.rs
+++ b/os/arceos/modules/axfs-ng/src/fs_core/context.rs
@@ -325,6 +325,59 @@ impl FsContext {
         }
     }
 
+    /// Resolves a relative path's parent without following intermediate
+    /// symbolic links or allowing the walk to escape above `current_dir`.
+    ///
+    /// This provides the path-walk guarantees required by Linux openat2's
+    /// `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` combination.
+    pub fn resolve_parent_beneath_no_symlinks<'a>(
+        &self,
+        path: &'a Path,
+    ) -> VfsResult<(Location, Cow<'a, str>)> {
+        let mut components = path.components().peekable();
+        let mut dir = self.current_dir.clone();
+        let mut depth = 0usize;
+
+        while let Some(component) = components.next() {
+            let is_last = components.peek().is_none();
+            match component {
+                Component::RootDir => return Err(VfsError::CrossesDevices),
+                Component::CurDir if is_last => {
+                    if let Some(parent) = dir.parent() {
+                        return Ok((parent, dir.name().into_owned().into()));
+                    }
+                    return Ok((dir, Cow::Borrowed(".")));
+                }
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    if depth == 0 {
+                        return Err(VfsError::CrossesDevices);
+                    }
+                    dir = dir.parent().ok_or(VfsError::CrossesDevices)?;
+                    depth -= 1;
+                    if is_last {
+                        if let Some(parent) = dir.parent() {
+                            return Ok((parent, dir.name().into_owned().into()));
+                        }
+                        return Ok((dir, Cow::Borrowed(".")));
+                    }
+                }
+                Component::Normal(name) if is_last => return Ok((dir, Cow::Borrowed(name))),
+                Component::Normal(name) => {
+                    let next = dir.lookup_no_follow(name)?;
+                    if next.node_type() == NodeType::Symlink {
+                        return Err(VfsError::FilesystemLoop);
+                    }
+                    next.check_is_dir()?;
+                    dir = next;
+                    depth += 1;
+                }
+            }
+        }
+
+        Err(VfsError::NotFound)
+    }
+
     /// Taking current node as root directory, resolves a path starting from
     /// `current_dir`.
     ///

--- a/test-suit/starryos/qemu/system/bugfix-nix-openat2-resolve/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-nix-openat2-resolve/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-nix-openat2-resolve C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-nix-openat2-resolve src/main.c)
+target_compile_options(bugfix-nix-openat2-resolve PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bugfix-nix-openat2-resolve RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-nix-openat2-resolve/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-nix-openat2-resolve/src/main.c
@@ -14,14 +14,13 @@
 #define RESOLVE_BENEATH 0x08
 
 #ifndef SYS_openat2
-
-int main(void)
-{
-    puts("NIX_OPENAT2_RESOLVE_SKIPPED: SYS_openat2 unavailable");
-    return 0;
-}
-
+#if defined(__x86_64__) || defined(__aarch64__) || defined(__riscv) ||         \
+    defined(__loongarch64)
+#define SYS_openat2 437
 #else
+#error "SYS_openat2 is unknown for this architecture"
+#endif
+#endif
 
 struct open_how {
     uint64_t flags;
@@ -148,5 +147,3 @@ int main(void)
     puts("NIX_OPENAT2_RESOLVE_PASSED");
     return 0;
 }
-
-#endif

--- a/test-suit/starryos/qemu/system/bugfix-nix-openat2-resolve/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-nix-openat2-resolve/src/main.c
@@ -1,0 +1,152 @@
+/* Regression for the openat2 contract used by Nix NAR restoration. */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#define RESOLVE_NO_SYMLINKS 0x04
+#define RESOLVE_BENEATH 0x08
+
+#ifndef SYS_openat2
+
+int main(void)
+{
+    puts("NIX_OPENAT2_RESOLVE_SKIPPED: SYS_openat2 unavailable");
+    return 0;
+}
+
+#else
+
+struct open_how {
+    uint64_t flags;
+    uint64_t mode;
+    uint64_t resolve;
+};
+
+static int failures;
+
+#define CHECK(condition, message)                                            \
+    do {                                                                     \
+        if (condition) {                                                     \
+            printf("PASS: %s\n", message);                                  \
+        } else {                                                             \
+            printf("FAIL: %s: errno=%d (%s)\n", message, errno,              \
+                   strerror(errno));                                         \
+            failures++;                                                      \
+        }                                                                    \
+    } while (0)
+
+static int openat2_beneath_no_symlinks(int dirfd, const char *path,
+                                       uint64_t flags, uint64_t mode)
+{
+    const struct open_how how = {
+        .flags = flags,
+        .mode = mode,
+        .resolve = RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS,
+    };
+
+    return (int)syscall(SYS_openat2, dirfd, path, &how, sizeof(how));
+}
+
+int main(void)
+{
+    const char *root = "/tmp/nix-openat2-resolve";
+    char created[128];
+    char link_path[128];
+
+    snprintf(created, sizeof(created), "%s/sub/config.guess", root);
+    snprintf(link_path, sizeof(link_path), "%s/link", root);
+    unlink(created);
+    unlink(link_path);
+    rmdir("/tmp/nix-openat2-resolve/sub");
+    rmdir(root);
+
+    CHECK(mkdir(root, 0700) == 0, "create fixture root");
+    CHECK(mkdir("/tmp/nix-openat2-resolve/sub", 0700) == 0,
+          "create fixture subdirectory");
+
+    int rootfd = open(root, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    CHECK(rootfd >= 0, "open fixture root directory");
+    if (rootfd < 0)
+        return 1;
+
+    int filesystem_rootfd = open("/", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    CHECK(filesystem_rootfd >= 0, "open filesystem root directory");
+    if (filesystem_rootfd >= 0) {
+        int dotfd = openat2_beneath_no_symlinks(
+            filesystem_rootfd, ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC, 0);
+        CHECK(dotfd >= 0, "RESOLVE_BENEATH opens root directory dot path");
+        if (dotfd >= 0)
+            close(dotfd);
+        close(filesystem_rootfd);
+    }
+
+    int fd = openat2_beneath_no_symlinks(
+        rootfd, "sub/config.guess", O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC,
+        0666);
+    CHECK(fd >= 0,
+          "Nix openat2 RESOLVE_BENEATH|RESOLVE_NO_SYMLINKS file creation");
+    if (fd >= 0) {
+        CHECK(write(fd, "nix\n", 4) == 4, "write restored NAR file");
+        close(fd);
+    }
+
+    errno = 0;
+    fd = openat2_beneath_no_symlinks(
+        rootfd, "../nix-openat2-escape",
+        O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0666);
+    CHECK(fd == -1 && (errno == EXDEV || errno == ELOOP),
+          "RESOLVE_BENEATH rejects parent escape");
+    if (fd >= 0) {
+        close(fd);
+        unlink("/tmp/nix-openat2-escape");
+    }
+
+    CHECK(symlink("sub", link_path) == 0, "create fixture symlink");
+    errno = 0;
+    fd = openat2_beneath_no_symlinks(
+        rootfd, "link/via-symlink", O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC,
+        0666);
+    CHECK(fd == -1 && errno == ELOOP,
+          "RESOLVE_NO_SYMLINKS rejects an intermediate symlink");
+    if (fd >= 0) {
+        close(fd);
+        unlink("/tmp/nix-openat2-resolve/sub/via-symlink");
+    }
+
+    errno = 0;
+    fd = openat2_beneath_no_symlinks(rootfd, "link", O_RDONLY | O_CLOEXEC, 0);
+    CHECK(fd == -1 && errno == ELOOP,
+          "RESOLVE_NO_SYMLINKS rejects a final symlink");
+    if (fd >= 0)
+        close(fd);
+
+    errno = 0;
+    fd = openat2_beneath_no_symlinks(
+        rootfd, "link", O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0666);
+    CHECK(fd == -1 && errno == ELOOP,
+          "RESOLVE_NO_SYMLINKS takes precedence over O_EXCL for a symlink");
+    if (fd >= 0)
+        close(fd);
+
+    close(rootfd);
+    unlink(created);
+    unlink(link_path);
+    rmdir("/tmp/nix-openat2-resolve/sub");
+    rmdir(root);
+
+    if (failures != 0) {
+        printf("NIX_OPENAT2_RESOLVE_FAILED: %d failure(s)\n", failures);
+        return 1;
+    }
+    puts("NIX_OPENAT2_RESOLVE_PASSED");
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## 背景

这是从 #1520 拆出的独立 PR，仅处理 Nix 恢复 NAR 时使用的 `openat2(2)` 路径解析语义。

StarryOS 现有 `openat2` 实现会拒绝所有非零 `resolve` 标志，而 Nix 在恢复 store 内容时会使用：

```text
RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS
```

因此即使普通 `openat` 路径可用，Nix 的安全恢复流程仍会因 `EOPNOTSUPP` 失败。

## 改动内容

1. 在 StarryOS 的 `sys_openat2` 中支持且只支持 `RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS` 这一组合；其他当前未实现的 `RESOLVE_*` 组合仍返回不支持。
2. 在 `axfs-ng::FsContext` 中增加受约束的父目录解析：路径必须是相对路径，禁止通过 `..` 逃出起始目录，中间路径分量和最终分量均不跟随符号链接，并分别处理目录层级与最终文件名。
3. 补齐 `openat2` 的关键 flags 组合检查，拒绝 Linux 明确不允许的 `O_CREAT | O_DIRECTORY` 和无写权限的 `O_TMPFILE` 组合。
4. 新增 `qemu/system/bugfix-nix-openat2-resolve` 回归用例；当 libc 头文件未声明 `SYS_openat2` 时，测试对已知目标架构使用 Linux 通用 syscall 编号 437，未知架构在编译期报错，不再以成功状态跳过回归。

## 实现逻辑

零 `resolve` 继续复用现有 `sys_openat` 路径。只有 Nix 实际使用且本 PR 完整实现约束的 resolve 组合进入新的受限 path walk；解析器从传入目录开始维护相对深度，在越界或符号链接处立即返回错误，并在最终打开时强制 `no_follow`。

## 范围说明

本 PR 不包含 #1520 中的 PTY、socket、namespace、mount、procfs 或 Nix 应用集成改动。

## 验证

- `cargo fmt`
- `git diff --check`
- Podman CI 容器内执行 `cargo xtask starry test qemu --arch x86_64 -c qemu/bugfix-nix-openat2-resolve`：1/1 通过，测试输出 `NIX_OPENAT2_RESOLVE_PASSED`。

关联：#1520
