### PR TITLE
fix(starry-kernel): drain PTY data before EOF

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -604,12 +604,13 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             }
             return Ok(read);
         }
-        if matches!(self.processor, Processor::Passive(_, _)) {
+        if let Processor::Passive(reader, _) = &mut self.processor {
+            reader.poll();
             let read = self.buf_rx.pop_slice(buf);
             return if read == 0 {
                 // Buffer drained: if the peer writer has closed, report EOF;
                 // otherwise the read would block.
-                if matches!(&self.processor, Processor::Passive(reader, _) if reader.closed()) {
+                if reader.closed() {
                     Ok(0)
                 } else {
                     Err(AxError::WouldBlock)
@@ -672,10 +673,23 @@ mod tests {
     struct MockReader {
         data: Vec<u8>,
         pos: usize,
+        closed: bool,
     }
     impl MockReader {
         fn new(data: Vec<u8>) -> Self {
-            Self { data, pos: 0 }
+            Self {
+                data,
+                pos: 0,
+                closed: false,
+            }
+        }
+
+        fn closed(data: Vec<u8>) -> Self {
+            Self {
+                data,
+                pos: 0,
+                closed: true,
+            }
         }
     }
     impl TtyRead for MockReader {
@@ -685,6 +699,10 @@ mod tests {
             buf[..n].copy_from_slice(&remaining[..n]);
             self.pos += n;
             n
+        }
+
+        fn closed(&self) -> bool {
+            self.closed
         }
     }
 
@@ -1039,5 +1057,23 @@ mod tests {
         let mut buf = [0; 6];
         assert_eq!(ldisc.read(&mut buf), Ok(6));
         assert_eq!(&buf, b"\x1b[1;1R");
+    }
+
+    #[test]
+    fn passive_read_drains_source_before_reporting_peer_eof() {
+        let payload = b"data before eof";
+        let mut ldisc = LineDiscipline::new(
+            Arc::new(Terminal::default()),
+            TtyConfig {
+                reader: MockReader::closed(payload.to_vec()),
+                writer: MockWriter,
+                process_mode: ProcessMode::Passive(Arc::new(PollSet::new())),
+            },
+        );
+
+        let mut buf = [0; 15];
+        assert_eq!(ldisc.read(&mut buf), Ok(payload.len()));
+        assert_eq!(&buf, payload);
+        assert_eq!(ldisc.read(&mut buf), Ok(0));
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -381,8 +381,14 @@ impl<R: TtyRead> SimpleReader<R> {
     }
 
     pub fn poll(&mut self) {
-        let read = self.reader.read(&mut self.read_buf);
-        let _ = self.buf_tx.push_slice(&self.read_buf[..read]);
+        let available = self.buf_tx.vacant_len().min(self.read_buf.len());
+        if available == 0 {
+            return;
+        }
+
+        let read = self.reader.read(&mut self.read_buf[..available]);
+        let pushed = self.buf_tx.push_slice(&self.read_buf[..read]);
+        debug_assert_eq!(pushed, read);
     }
 }
 
@@ -1075,5 +1081,32 @@ mod tests {
         assert_eq!(ldisc.read(&mut buf), Ok(payload.len()));
         assert_eq!(&buf, payload);
         assert_eq!(ldisc.read(&mut buf), Ok(0));
+    }
+
+    #[test]
+    fn passive_read_preserves_input_across_partially_full_ring_buffer() {
+        let payload: Vec<u8> = (0..(BUF_SIZE * 2 + 31))
+            .map(|index| (index % 251) as u8)
+            .collect();
+        let mut ldisc = LineDiscipline::new(
+            Arc::new(Terminal::default()),
+            TtyConfig {
+                reader: MockReader::closed(payload.clone()),
+                writer: MockWriter,
+                process_mode: ProcessMode::Passive(Arc::new(PollSet::new())),
+            },
+        );
+        let mut received = Vec::new();
+        let mut chunk = [0; 17];
+
+        loop {
+            match ldisc.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(read) => received.extend_from_slice(&chunk[..read]),
+                Err(error) => panic!("passive reader returned {error:?}"),
+            }
+        }
+
+        assert_eq!(received, payload);
     }
 }

--- a/test-suit/starryos/qemu/system/test-pty-master-close/src/main.c
+++ b/test-suit/starryos/qemu/system/test-pty-master-close/src/main.c
@@ -49,6 +49,75 @@ static ssize_t read_line_timeout(int fd, char *buf, size_t len, int timeout_ms)
     return (ssize_t)off;
 }
 
+static void check_data_before_eof_without_poll(void)
+{
+    static const char payload[] = "DATA_BEFORE_EOF";
+    int master = posix_openpt(O_RDWR | O_NOCTTY);
+    if (master < 0) {
+        fail("no-poll posix_openpt");
+        return;
+    }
+    if (grantpt(master) != 0 || unlockpt(master) != 0) {
+        fail("no-poll grantpt/unlockpt");
+        close(master);
+        return;
+    }
+    char *slave_name = ptsname(master);
+    if (slave_name == NULL) {
+        fail("no-poll ptsname");
+        close(master);
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        fail("no-poll fork");
+        close(master);
+        return;
+    }
+    if (pid == 0) {
+        int slave = open(slave_name, O_RDWR | O_NOCTTY);
+        if (slave < 0) {
+            _exit(111);
+        }
+        if (write(slave, payload, sizeof(payload) - 1) !=
+            (ssize_t)(sizeof(payload) - 1)) {
+            _exit(112);
+        }
+        close(slave);
+        _exit(0);
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid || !WIFEXITED(status) ||
+        WEXITSTATUS(status) != 0) {
+        fail("no-poll child writes and exits cleanly");
+        close(master);
+        return;
+    }
+    pass("no-poll child writes and exits cleanly");
+
+    char buf[sizeof(payload)] = {0};
+    errno = 0;
+    ssize_t n = read(master, buf, sizeof(buf) - 1);
+    if (n != (ssize_t)(sizeof(payload) - 1) ||
+        memcmp(buf, payload, sizeof(payload) - 1) != 0) {
+        fail("master drains queued data before EOF without poll");
+        close(master);
+        return;
+    }
+    pass("master drains queued data before EOF without poll");
+
+    errno = 0;
+    n = read(master, buf, sizeof(buf) - 1);
+    if (n == 0 || (n < 0 && errno == EIO)) {
+        pass("master reports EOF only after queued data drains");
+    } else {
+        fail("master reports EOF only after queued data drains");
+    }
+    close(master);
+}
+
 static void check_nix_like_child(void)
 {
     int master = posix_openpt(O_RDWR | O_NOCTTY);
@@ -272,6 +341,7 @@ int main(void)
     }
 
     check_nix_like_child();
+    check_data_before_eof_without_poll();
 
 out_slave_dup:
     if (slave_dup >= 0) {

--- a/test-suit/starryos/qemu/system/test-pty-master-close/src/main.c
+++ b/test-suit/starryos/qemu/system/test-pty-master-close/src/main.c
@@ -11,6 +11,10 @@
 
 static int fails;
 
+#define FIRST_PAYLOAD_SIZE 4090
+#define SECOND_PAYLOAD_SIZE 257
+#define LARGE_PAYLOAD_SIZE (FIRST_PAYLOAD_SIZE + SECOND_PAYLOAD_SIZE)
+
 static void pass(const char *msg)
 {
     printf("  PASS: %s\n", msg);
@@ -47,6 +51,150 @@ static ssize_t read_line_timeout(int fd, char *buf, size_t len, int timeout_ms)
     }
     buf[off] = '\0';
     return (ssize_t)off;
+}
+
+static unsigned char payload_byte(size_t index)
+{
+    return (unsigned char)(index % 251 + 1);
+}
+
+static void check_large_payload_with_partial_reads(void)
+{
+    int ready_pipe[2];
+    int proceed_pipe[2];
+    if (pipe(ready_pipe) != 0 || pipe(proceed_pipe) != 0) {
+        fail("partial-read synchronization pipes");
+        return;
+    }
+
+    int master = posix_openpt(O_RDWR | O_NOCTTY);
+    if (master < 0) {
+        fail("partial-read posix_openpt");
+        return;
+    }
+    if (grantpt(master) != 0 || unlockpt(master) != 0) {
+        fail("partial-read grantpt/unlockpt");
+        close(master);
+        return;
+    }
+    char *slave_name = ptsname(master);
+    if (slave_name == NULL) {
+        fail("partial-read ptsname");
+        close(master);
+        return;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        fail("partial-read fork");
+        close(master);
+        return;
+    }
+    if (pid == 0) {
+        close(ready_pipe[0]);
+        close(proceed_pipe[1]);
+        int slave = open(slave_name, O_RDWR | O_NOCTTY);
+        if (slave < 0) {
+            _exit(121);
+        }
+        struct termios term;
+        if (tcgetattr(slave, &term) != 0) {
+            _exit(122);
+        }
+        cfmakeraw(&term);
+        if (tcsetattr(slave, TCSANOW, &term) != 0) {
+            _exit(123);
+        }
+
+        unsigned char chunk[FIRST_PAYLOAD_SIZE];
+        size_t written = 0;
+        for (size_t i = 0; i < sizeof(chunk); i++) {
+            chunk[i] = payload_byte(i);
+        }
+        if (write(slave, chunk, sizeof(chunk)) != (ssize_t)sizeof(chunk)) {
+            _exit(124);
+        }
+        if (write(ready_pipe[1], "R", 1) != 1) {
+            _exit(125);
+        }
+        char command;
+        if (read(proceed_pipe[0], &command, 1) != 1) {
+            _exit(126);
+        }
+
+        written = FIRST_PAYLOAD_SIZE;
+        for (size_t i = 0; i < SECOND_PAYLOAD_SIZE; i++) {
+            chunk[i] = payload_byte(written + i);
+        }
+        if (write(slave, chunk, SECOND_PAYLOAD_SIZE) != SECOND_PAYLOAD_SIZE) {
+            _exit(127);
+        }
+        close(slave);
+        _exit(0);
+    }
+
+    close(ready_pipe[1]);
+    close(proceed_pipe[0]);
+    char ready;
+    if (read(ready_pipe[0], &ready, 1) != 1) {
+        fail("partial-read child prepares first payload");
+        goto out_wait_partial_read;
+    }
+
+    size_t received = 0;
+    unsigned char chunk[17];
+    ssize_t first_read = read(master, chunk, sizeof(chunk));
+    if (first_read != (ssize_t)sizeof(chunk)) {
+        fail("partial-read master partially consumes first payload");
+        goto out_wait_partial_read;
+    }
+    for (ssize_t i = 0; i < first_read; i++) {
+        if (chunk[i] != payload_byte((size_t)i)) {
+            fail("partial-read first payload remains ordered");
+            goto out_wait_partial_read;
+        }
+    }
+    received = (size_t)first_read;
+    if (write(proceed_pipe[1], "C", 1) != 1) {
+        fail("partial-read releases second payload");
+        goto out_wait_partial_read;
+    }
+
+    int payload_ok = 1;
+    while (received < LARGE_PAYLOAD_SIZE) {
+        ssize_t n = read(master, chunk, sizeof(chunk));
+        if (n <= 0) {
+            fail("partial-read master receives complete payload");
+            payload_ok = 0;
+            break;
+        }
+        for (ssize_t i = 0; i < n; i++) {
+            if (chunk[i] != payload_byte(received + (size_t)i)) {
+                fail("partial-read payload remains ordered and complete");
+                payload_ok = 0;
+                break;
+            }
+        }
+        if (!payload_ok) {
+            break;
+        }
+        received += (size_t)n;
+    }
+    if (payload_ok && received == LARGE_PAYLOAD_SIZE) {
+        pass("partial reads preserve payload larger than tty ring buffer");
+    }
+
+out_wait_partial_read:
+    close(ready_pipe[0]);
+    close(proceed_pipe[1]);
+    int status = 0;
+    if (waitpid(pid, &status, 0) != pid || !WIFEXITED(status) ||
+        WEXITSTATUS(status) != 0) {
+        fail("partial-read child writes and exits cleanly");
+    } else {
+        pass("partial-read child writes and exits cleanly");
+    }
+    close(master);
 }
 
 static void check_data_before_eof_without_poll(void)
@@ -342,6 +490,7 @@ int main(void)
 
     check_nix_like_child();
     check_data_before_eof_without_poll();
+    check_large_payload_with_partial_reads();
 
 out_slave_dup:
     if (slave_dup >= 0) {


### PR DESCRIPTION
## 背景

这是从 #1520 拆出的独立 PR，仅处理 PTY master 在 slave 关闭后的数据读取顺序。

Nix 启动构建子进程时会通过 PTY 收集输出。slave 端可能先写入最后一批数据并立即关闭；passive line discipline 必须先排空底层 reader 和内部缓冲区，再向调用方返回 EOF。

## 改动内容

1. passive PTY 读取时先推进底层 reader，把关闭前已经到达的数据搬入 line discipline 缓冲区。
2. 先尝试从缓冲区返回数据；只有缓冲区已排空且 reader 确认关闭时才返回 EOF。
3. `SimpleReader::poll()` 根据环形缓冲区剩余容量限制底层读取长度，避免缓冲区部分占用时 `push_slice()` 静默丢弃尾部。
4. 新增 Rust 单元测试，使用超过两倍 `BUF_SIZE` 的 payload 和 17 字节分段读取，覆盖部分占用缓冲区的确定性回归。
5. 扩展 `qemu/system/test-pty-master-close`：先写入 4090 字节并让 master 仅读取 17 字节，再写入 257 字节，验证总计 4347 字节的顺序和完整性，同时保留原有关闭后排空测试。

## 实现逻辑

PTY 的关闭状态只说明不会再产生新数据，并不表示已有数据已经被消费。passive 模式在 `read()` 边界推进 reader，但每次推进只读取内部环形缓冲区当前能够容纳的字节；随后按“已有数据 > EOF > WouldBlock”的顺序返回。这样底层尚未搬入的数据会留待下一次读取，不会因 `push_slice()` 容量不足而丢失。

## 范围说明

本 PR 不包含 #1520 中的 `openat2`、socket、namespace、mount、procfs 或 Nix 应用集成改动。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package starry-kernel`：20/20 feature checks 通过。
- Podman CI 容器内执行 `cargo xtask starry test qemu --arch x86_64 -c qemu/test-pty-master-close`：1/1 通过。

关联：#1520
