### PR TITLE
fix(ax-net): publish Unix stream write shutdown to peers

### DIFF
--- a/net/ax-net/src/unix/stream.rs
+++ b/net/ax-net/src/unix/stream.rs
@@ -499,19 +499,22 @@ impl TransportOps for StreamTransport {
         if how.has_read() {
             self.rx_closed.store(true, Ordering::Release);
         }
+        let mut peer_poll = None;
         if how.has_write() {
             self.tx_closed.store(true, Ordering::Release);
+            if let Some(chan) = self.channel.lock().as_ref() {
+                chan.my_tx_closed.store(true, Ordering::Release);
+                peer_poll = Some(chan.poll_update.clone());
+            }
         }
-        let peer_poll = if self.rx_closed.load(Ordering::Acquire)
+        if self.rx_closed.load(Ordering::Acquire)
             && self.tx_closed.load(Ordering::Acquire)
             && let Some(chan) = self.channel.lock().take()
         {
-            Some(chan.poll_update)
-        } else {
-            None
-        };
+            peer_poll.get_or_insert(chan.poll_update);
+        }
         if let Some(poll) = peer_poll {
-            // Channel closure is published before waking the peer.
+            // The peer-visible write closure is published before waking readers.
             unsafe { poll.wake(IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP) };
         }
         if how.has_read() || how.has_write() {

--- a/test-suit/starryos/qemu/system/test-shutdown/src/main.c
+++ b/test-suit/starryos/qemu/system/test-shutdown/src/main.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include "test_framework.h"
 #include <fcntl.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -10,6 +11,10 @@ int main(void)
 
     /* ================================================================
      * 1. shutdown connected socket with SHUT_WR
+     *
+     * Verify that SHUT_WR makes the peer pollable and returns EOF from
+     * recv. Nix sandbox builders rely on this control-socket transition;
+     * missing peer EOF leaves the builder and its supervisor blocked.
      * ================================================================ */
     {
         int sv[2];
@@ -17,6 +22,21 @@ int main(void)
                   "create socketpair");
         CHECK_RET(shutdown(sv[0], SHUT_WR), 0,
                   "shutdown SHUT_WR returns 0");
+
+        struct pollfd peer = {
+            .fd = sv[1],
+            .events = POLLIN | POLLRDHUP,
+        };
+        CHECK_RET(poll(&peer, 1, 1000), 1,
+                  "peer observes SHUT_WR readiness");
+        CHECK((peer.revents & (POLLIN | POLLRDHUP)) != 0,
+              "peer reports readable EOF or read hangup");
+
+        CHECK_RET(fcntl(sv[1], F_SETFL, O_NONBLOCK), 0,
+                  "set peer nonblocking before EOF recv");
+        char byte;
+        CHECK_RET((int)recv(sv[1], &byte, sizeof(byte), 0), 0,
+                  "peer recv returns EOF after SHUT_WR");
         close(sv[0]);
         close(sv[1]);
     }


### PR DESCRIPTION
## 背景

这是从 #1520 拆出的独立 PR，仅处理 Unix stream socket 的写方向关闭传播。

Nix sandbox builder 使用 Unix socket 作为控制通道。当前 `shutdown(SHUT_WR)` 只更新
本端 `tx_closed`，没有把写端关闭状态发布到共享 channel，也没有唤醒 peer。结果是
peer 端的 `poll()`/`recv()` 可能一直等待，无法观察到 EOF。

## 改动内容

1. `StreamTransport::shutdown()` 处理写方向关闭时，同时以 Release 顺序写入共享
   channel 的 `my_tx_closed`。
2. 在状态发布完成后唤醒 peer 的 poll waiters，并携带
   `IN | OUT | RDHUP` 事件。
3. 保留双向都关闭时释放 channel 的原有逻辑，并合并唤醒对象，避免同一次 shutdown
   重复唤醒。
4. 扩展 `qemu/system/test-shutdown`，使用 `socketpair` 验证：
   - `shutdown(SHUT_WR)` 成功；
   - peer 能通过 `poll()` 观察到可读 EOF 或 read hangup；
   - peer 的非阻塞 `recv()` 返回 0，而不是继续阻塞或返回 `EAGAIN`。

## 实现逻辑

Unix stream 的半关闭是 peer 可见状态。写端先以 Release 发布 shared channel 状态，
peer 读取时通过既有 Acquire 路径观察该状态；之后再唤醒等待者，保证被唤醒的线程
不会看到旧值。读写方向均关闭时仍按原流程解除 channel 持有关系。

## 范围说明

本 PR 不包含 #1520 中的 `openat2`、PTY、network ioctl、namespace、mount、
procfs 或 Nix 应用集成改动。

## 验证

- `cargo fmt`
- `git diff --check`
- 回归覆盖位于现有 `qemu/system/test-shutdown` 用例中；按本轮拆分策略，
  完整 Starry QEMU 运行交由 CI 复核。

关联：#1520
