### PR TITLE
fix(starry-kernel): accept unchanged interface flags

### DIFF
--- a/os/StarryOS/kernel/src/file/net.rs
+++ b/os/StarryOS/kernel/src/file/net.rs
@@ -17,9 +17,10 @@ use ax_net::{
     Socket as SocketInner, SocketOps,
     options::{Configurable, GetSocketOption, SetSocketOption},
 };
+use ax_task::current;
 use axpoll::{IoEvents, Pollable};
 use linux_raw_sys::{
-    general::{O_RDWR, S_IFSOCK},
+    general::{CAP_NET_ADMIN, O_RDWR, S_IFSOCK},
     ioctl::{
         FIONREAD, SIOCGIFADDR, SIOCGIFBRDADDR, SIOCGIFCONF, SIOCGIFDSTADDR, SIOCGIFFLAGS,
         SIOCGIFHWADDR, SIOCGIFINDEX, SIOCGIFMAP, SIOCGIFMETRIC, SIOCGIFMTU, SIOCGIFNETMASK,
@@ -33,6 +34,7 @@ use super::{FileLike, Kstat};
 use crate::{
     file::{IoDst, IoSrc, get_file_like},
     syscall::in_root_net_ns,
+    task::AsThread,
 };
 
 pub(super) const ARPHRD_ETHER: u16 = 1;
@@ -295,6 +297,9 @@ impl FileLike for Socket {
             }
             SIOCSIFFLAGS => {
                 let info = read_ifreq_interface(arg)?;
+                if !current().as_thread().cred().has_cap(CAP_NET_ADMIN) {
+                    return Err(AxError::OperationNotPermitted);
+                }
                 if read_ifreq_flags(arg)? != linux_flags(&info) {
                     return Err(AxError::OperationNotSupported);
                 }

--- a/os/StarryOS/kernel/src/file/net.rs
+++ b/os/StarryOS/kernel/src/file/net.rs
@@ -23,7 +23,7 @@ use linux_raw_sys::{
     ioctl::{
         FIONREAD, SIOCGIFADDR, SIOCGIFBRDADDR, SIOCGIFCONF, SIOCGIFDSTADDR, SIOCGIFFLAGS,
         SIOCGIFHWADDR, SIOCGIFINDEX, SIOCGIFMAP, SIOCGIFMETRIC, SIOCGIFMTU, SIOCGIFNETMASK,
-        SIOCGIFTXQLEN,
+        SIOCGIFTXQLEN, SIOCSIFFLAGS,
     },
     net::{AF_INET, ifreq},
 };
@@ -113,6 +113,12 @@ fn read_ifreq_interface(arg: usize) -> AxResult<InterfaceInfo> {
 
 fn write_ifreq_data(arg: usize, data: &[u8]) -> AxResult<()> {
     Ok(vm_write_slice((arg + IFREQ_DATA_OFFSET) as *mut u8, data)?)
+}
+
+fn read_ifreq_flags(arg: usize) -> AxResult<i16> {
+    Ok(i16::from_ne_bytes(read_user_bytes::<2>(
+        (arg + IFREQ_DATA_OFFSET) as *const u8,
+    )?))
 }
 
 fn sockaddr_in_bytes(ip: [u8; 4]) -> [u8; 16] {
@@ -286,6 +292,12 @@ impl FileLike for Socket {
             SIOCGIFFLAGS => {
                 let info = read_ifreq_interface(arg)?;
                 write_ifreq_data(arg, &linux_flags(&info).to_ne_bytes())?;
+            }
+            SIOCSIFFLAGS => {
+                let info = read_ifreq_interface(arg)?;
+                if read_ifreq_flags(arg)? != linux_flags(&info) {
+                    return Err(AxError::OperationNotSupported);
+                }
             }
             SIOCGIFADDR => {
                 let info = read_ifreq_interface(arg)?;

--- a/test-suit/starryos/qemu/system/test-sio-set-ifflags/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-sio-set-ifflags/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-sio-set-ifflags C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-sio-set-ifflags src/main.c)
+target_compile_options(test-sio-set-ifflags PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-sio-set-ifflags RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-sio-set-ifflags/src/main.c
+++ b/test-suit/starryos/qemu/system/test-sio-set-ifflags/src/main.c
@@ -19,10 +19,32 @@ int main(void)
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
     strncpy(ifr.ifr_name, "lo", IFNAMSIZ - 1);
-    ifr.ifr_flags = IFF_UP | IFF_LOOPBACK | IFF_RUNNING;
+
+    if (ioctl(fd, SIOCGIFFLAGS, &ifr) != 0) {
+        printf("FAIL: SIOCGIFFLAGS lo errno=%d (%s)\n", errno,
+               strerror(errno));
+        close(fd);
+        return 1;
+    }
 
     if (ioctl(fd, SIOCSIFFLAGS, &ifr) != 0) {
-        printf("FAIL: SIOCSIFFLAGS lo errno=%d (%s)\n", errno, strerror(errno));
+        printf("FAIL: privileged SIOCSIFFLAGS lo errno=%d (%s)\n", errno,
+               strerror(errno));
+        close(fd);
+        return 1;
+    }
+
+    if (setuid(65534) != 0 || geteuid() != 65534) {
+        printf("FAIL: drop privileges errno=%d (%s)\n", errno,
+               strerror(errno));
+        close(fd);
+        return 1;
+    }
+
+    errno = 0;
+    if (ioctl(fd, SIOCSIFFLAGS, &ifr) != -1 || errno != EPERM) {
+        printf("FAIL: unprivileged SIOCSIFFLAGS expected EPERM, errno=%d (%s)\n",
+               errno, strerror(errno));
         close(fd);
         return 1;
     }

--- a/test-suit/starryos/qemu/system/test-sio-set-ifflags/src/main.c
+++ b/test-suit/starryos/qemu/system/test-sio-set-ifflags/src/main.c
@@ -1,0 +1,33 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <net/if.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+int main(void)
+{
+    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0) {
+        printf("FAIL: socket errno=%d (%s)\n", errno, strerror(errno));
+        return 1;
+    }
+
+    struct ifreq ifr;
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, "lo", IFNAMSIZ - 1);
+    ifr.ifr_flags = IFF_UP | IFF_LOOPBACK | IFF_RUNNING;
+
+    if (ioctl(fd, SIOCSIFFLAGS, &ifr) != 0) {
+        printf("FAIL: SIOCSIFFLAGS lo errno=%d (%s)\n", errno, strerror(errno));
+        close(fd);
+        return 1;
+    }
+
+    close(fd);
+    printf("TEST_SIO_SET_IFFLAGS_PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
## 背景

这是从 #1520 拆出的独立 PR，仅处理 `SIOCSIFFLAGS` 的兼容行为。

Nix sandbox 初始化网络 namespace 时会读取 loopback flags，并把同一组 flags 写回。
StarryOS 当前未识别 `SIOCSIFFLAGS`，因此即使调用没有请求任何实际状态变化，也会以
不支持失败，阻断后续 sandbox 初始化。

## 改动内容

1. 为 socket ioctl 增加 `SIOCSIFFLAGS` 分支。
2. 从用户态 `ifreq` 读取接口名和 flags：
   - 请求值与当前导出的 Linux flags 完全一致时返回成功；
   - 请求改变接口状态时仍返回 `OperationNotSupported`。
3. 新增 `qemu/system/test-sio-set-ifflags`，对 loopback 写回
   `IFF_UP | IFF_LOOPBACK | IFF_RUNNING`，验证兼容调用成功。

## 实现逻辑

本 PR 不引入虚假的网络设备状态切换能力。Nix 所需操作是幂等写回，因此只接受
“requested == current”的 no-op；任何真正改变 flags 的请求继续显式报不支持。
这样可以解除 sandbox 初始化阻塞，同时保持未实现能力的边界清晰。

## 范围说明

本 PR 不包含 #1520 中的 `openat2`、PTY、Unix socket、namespace、mount、
procfs 或 Nix 应用集成改动。

## 验证

- `cargo fmt`
- `git diff --check`
- 新增用例按 Starry system test 根目录自动发现；
  完整 Starry QEMU 运行交由 CI 复核。

关联：#1520
