### PR TITLE
fix(starry-kernel): accept CLONE_PARENT exit signals

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -126,7 +126,7 @@ impl CloneArgs {
             flags, exit_signal, ..
         } = self;
 
-        if *exit_signal > 0 && flags.intersects(CloneFlags::THREAD | CloneFlags::PARENT) {
+        if *exit_signal > 0 && flags.contains(CloneFlags::THREAD) {
             return Err(AxError::InvalidInput);
         }
         if flags.contains(CloneFlags::THREAD)
@@ -530,4 +530,33 @@ pub fn sys_fork(uctx: &UserContext) -> AxResult<isize> {
 pub fn sys_vfork(uctx: &UserContext) -> AxResult<isize> {
     let flags = (CloneFlags::VFORK | CloneFlags::VM).bits() as u32 | SIGCHLD;
     sys_clone(uctx, flags, 0, 0, 0, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use linux_raw_sys::general::SIGCHLD;
+
+    use super::{CloneArgs, CloneFlags};
+
+    #[test]
+    fn clone_parent_allows_nonzero_exit_signal() {
+        let args = CloneArgs {
+            flags: CloneFlags::PARENT,
+            exit_signal: SIGCHLD as u64,
+            ..Default::default()
+        };
+
+        assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn clone_thread_rejects_nonzero_exit_signal() {
+        let args = CloneArgs {
+            flags: CloneFlags::THREAD | CloneFlags::VM | CloneFlags::SIGHAND,
+            exit_signal: SIGCHLD as u64,
+            ..Default::default()
+        };
+
+        assert!(args.validate().is_err());
+    }
 }

--- a/os/StarryOS/kernel/src/syscall/task/clone3.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone3.rs
@@ -93,3 +93,32 @@ pub fn sys_clone3(uctx: &UserContext, args: *const u8, size: usize) -> AxResult<
     let clone_args = CloneArgs::try_from(clone3_args)?;
     clone_args.do_clone(uctx)
 }
+
+#[cfg(test)]
+mod tests {
+    use linux_raw_sys::general::{CLONE_PARENT, CLONE_THREAD, SIGCHLD};
+
+    use super::{Clone3Args, CloneArgs};
+
+    #[test]
+    fn clone3_parent_rejects_nonzero_exit_signal() {
+        let args = Clone3Args {
+            flags: CLONE_PARENT as u64,
+            exit_signal: SIGCHLD as u64,
+            ..Default::default()
+        };
+
+        assert!(CloneArgs::try_from(args).is_err());
+    }
+
+    #[test]
+    fn clone3_thread_rejects_nonzero_exit_signal() {
+        let args = Clone3Args {
+            flags: CLONE_THREAD as u64,
+            exit_signal: SIGCHLD as u64,
+            ..Default::default()
+        };
+
+        assert!(CloneArgs::try_from(args).is_err());
+    }
+}

--- a/test-suit/starryos/qemu/system/bugfix-clone-parent-exit-signal/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-clone-parent-exit-signal/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-clone-parent-exit-signal C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-clone-parent-exit-signal src/main.c)
+target_compile_options(bugfix-clone-parent-exit-signal PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bugfix-clone-parent-exit-signal RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-clone-parent-exit-signal/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-clone-parent-exit-signal/src/main.c
@@ -1,0 +1,118 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+struct clone_report {
+    pid_t child;
+    int error;
+};
+
+static int write_report(int fd, const struct clone_report *report)
+{
+    const char *cursor = (const char *)report;
+    size_t remaining = sizeof(*report);
+
+    while (remaining > 0) {
+        ssize_t written = write(fd, cursor, remaining);
+        if (written < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        cursor += written;
+        remaining -= (size_t)written;
+    }
+    return 0;
+}
+
+static int read_report(int fd, struct clone_report *report)
+{
+    char *cursor = (char *)report;
+    size_t remaining = sizeof(*report);
+
+    while (remaining > 0) {
+        ssize_t received = read(fd, cursor, remaining);
+        if (received == 0)
+            return -1;
+        if (received < 0) {
+            if (errno == EINTR)
+                continue;
+            return -1;
+        }
+        cursor += received;
+        remaining -= (size_t)received;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    int report_pipe[2];
+    if (pipe(report_pipe) != 0) {
+        printf("FAIL: pipe errno=%d (%s)\n", errno, strerror(errno));
+        return 1;
+    }
+
+    pid_t middle = fork();
+    if (middle < 0) {
+        printf("FAIL: fork errno=%d (%s)\n", errno, strerror(errno));
+        return 1;
+    }
+    if (middle == 0) {
+        close(report_pipe[0]);
+
+        errno = 0;
+        long child = syscall(SYS_clone, CLONE_PARENT | SIGCHLD, NULL, NULL,
+                             NULL, 0);
+        if (child == 0) {
+            close(report_pipe[1]);
+            _exit(23);
+        }
+
+        struct clone_report report = {
+            .child = (pid_t)child,
+            .error = child < 0 ? errno : 0,
+        };
+        int report_result = write_report(report_pipe[1], &report);
+        close(report_pipe[1]);
+        _exit(child < 0 || report_result != 0 ? 1 : 0);
+    }
+
+    close(report_pipe[1]);
+    struct clone_report report;
+    if (read_report(report_pipe[0], &report) != 0) {
+        puts("FAIL: did not receive clone result");
+        return 1;
+    }
+    close(report_pipe[0]);
+
+    int middle_status;
+    if (waitpid(middle, &middle_status, 0) != middle ||
+        !WIFEXITED(middle_status) || WEXITSTATUS(middle_status) != 0) {
+        printf("FAIL: clone(CLONE_PARENT|SIGCHLD) errno=%d (%s)\n",
+               report.error, strerror(report.error));
+        return 1;
+    }
+
+    int child_status;
+    if (waitpid(report.child, &child_status, 0) != report.child) {
+        printf("FAIL: grandparent cannot wait for CLONE_PARENT child errno=%d "
+               "(%s)\n",
+               errno, strerror(errno));
+        return 1;
+    }
+    if (!WIFEXITED(child_status) || WEXITSTATUS(child_status) != 23) {
+        puts("FAIL: CLONE_PARENT child exit status mismatch");
+        return 1;
+    }
+
+    puts("CLONE_PARENT_EXIT_SIGNAL_PASSED");
+    return 0;
+}

--- a/test-suit/starryos/qemu/system/bugfix-clone-parent-exit-signal/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-clone-parent-exit-signal/src/main.c
@@ -9,6 +9,24 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#ifndef SYS_clone3
+#define SYS_clone3 435
+#endif
+
+struct clone3_args {
+    unsigned long long flags;
+    unsigned long long pidfd;
+    unsigned long long child_tid;
+    unsigned long long parent_tid;
+    unsigned long long exit_signal;
+    unsigned long long stack;
+    unsigned long long stack_size;
+    unsigned long long tls;
+    unsigned long long set_tid;
+    unsigned long long set_tid_size;
+    unsigned long long cgroup;
+};
+
 struct clone_report {
     pid_t child;
     int error;
@@ -54,6 +72,19 @@ static int read_report(int fd, struct clone_report *report)
 
 int main(void)
 {
+    struct clone3_args clone3_args = {
+        .flags = CLONE_PARENT,
+        .exit_signal = SIGCHLD,
+    };
+    errno = 0;
+    if (syscall(SYS_clone3, &clone3_args, sizeof(clone3_args)) != -1 ||
+        errno != EINVAL) {
+        printf("FAIL: clone3(CLONE_PARENT, exit_signal=SIGCHLD) must return "
+               "EINVAL, errno=%d (%s)\n",
+               errno, strerror(errno));
+        return 1;
+    }
+
     int report_pipe[2];
     if (pipe(report_pipe) != 0) {
         printf("FAIL: pipe errno=%d (%s)\n", errno, strerror(errno));


### PR DESCRIPTION
## 背景

这是从 #1520 拆出的独立 PR，仅处理 Nix 创建辅助进程时使用的 legacy
`clone(CLONE_PARENT | SIGCHLD)`。

StarryOS 目前把 legacy `clone()` 和 `clone3()` 共用参数中的 `CLONE_PARENT` 都视为
不能携带非零退出信号。对 legacy `clone()` 来说，退出信号本来就编码在 flags
低字节中，Linux 接受 `CLONE_PARENT | SIGCHLD`；当前校验会提前返回 `EINVAL`，
导致 Nix 的进程创建路径失败。

## 改动内容

1. 调整 `CloneArgs::validate()`：非零退出信号只与 `CLONE_THREAD` 冲突，不再错误地
   拒绝 legacy `CLONE_PARENT | SIGCHLD`。
2. 增加 Rust 参数校验测试，分别锁定：
   - legacy `CLONE_PARENT` 允许非零退出信号；
   - `CLONE_THREAD` 仍拒绝非零退出信号。
3. 保持 `clone3()` 的 Linux 语义不变，并增加测试确认
   `clone3(CLONE_PARENT, exit_signal != 0)` 和
   `clone3(CLONE_THREAD, exit_signal != 0)` 均返回错误。
4. 新增 `qemu/system/bugfix-clone-parent-exit-signal`：
   - 中间进程调用 raw `clone(CLONE_PARENT | SIGCHLD)`，由其父进程等待新 child，
     验证 parent 关系和退出状态；
   - 同一程序调用 `clone3(CLONE_PARENT, exit_signal = SIGCHLD)`，验证其仍以
     `EINVAL` 失败。

## 实现逻辑

legacy `clone()` 通过 flags 低字节传入终止信号，而 `clone3()` 把 `exit_signal`
作为独立字段并明确禁止其与 `CLONE_PARENT`/`CLONE_THREAD` 组合。两套 ABI 的校验
不能被同一次放宽覆盖，因此本 PR 只修改进入统一 `CloneArgs` 后的 legacy 路径，
保留 `Clone3Args::try_from()` 的前置拒绝。

这也修正了 #1520 原提交中同时放宽 `clone3()` 的问题，行为与
[Linux clone(2) 的错误约定](https://man7.org/linux/man-pages/man2/clone.2.html) 保持一致。

## 范围说明

本 PR 不包含 #1520 中旧 `qemu-smp1/nix-sandbox` 诊断脚本的改动，也不包含
namespace、mount、procfs 或其他 Nix 集成内容。

## 验证

- `cargo fmt`
- `git diff --check`
- 新增 C 回归程序已通过独立 CMake 配置、`-Wall -Wextra -Werror` 编译和链接，
  并在宿主 Linux 实际运行通过，输出 `CLONE_PARENT_EXIT_SIGNAL_PASSED`。
- `cargo test -p starry-kernel clone_parent_allows_nonzero_exit_signal --no-run`
  已完成 Rust 测试代码编译，宿主测试二进制最终因 Starry 内核 linker symbols
  （如 `_percpu_load_start`、`_stdata`）未提供而无法链接；完整运行交由 Starry CI。
- 在 003 完整分支运行
  `cargo xtask starry test qemu --arch x86_64 -c qemu/test-nix-clone-parent`：
  StarryOS 和测试程序构建完成，本地受限环境在 grouped rootfs staging 阶段因文件
  属主写入受限及 `apk: Symbolic link loop` 中止，未进入 QEMU。

关联：#1520
