### PR TITLE
feat(starry): add proc process environment and path links

### DIFF
--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -75,7 +75,14 @@ pub fn init(args: &[String], envs: &[String]) {
 
     let proc = ProcessData::new(
         proc,
-        ProcessImage::new(path.to_string(), Arc::new(args.to_vec()), auxv),
+        ProcessImage::new(
+            path.to_string(),
+            Arc::new(args.to_vec()),
+            Arc::new(envs.to_vec()),
+            auxv,
+            "/".to_string(),
+            "/".to_string(),
+        ),
         Arc::new(Mutex::new(uspace)),
         Arc::default(),
         None,

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -1233,6 +1233,9 @@ impl SimpleDirOps for ThreadDir {
                 "cmdline",
                 "comm",
                 "exe",
+                "environ",
+                "root",
+                "cwd",
                 "fd",
                 "uid_map",
                 "gid_map",
@@ -1366,6 +1369,24 @@ impl SimpleDirOps for ThreadDir {
             .into(),
             "exe" => SimpleFile::new(fs, NodeType::Symlink, move || {
                 Ok(task.as_thread().proc_data.exe_path.read().clone())
+            })
+            .into(),
+            "environ" => SimpleFile::new_regular(fs, move || {
+                let envp = task.as_thread().proc_data.envp.read();
+                let mut buf = Vec::new();
+                for env in envp.iter() {
+                    buf.extend_from_slice(env.as_bytes());
+                    buf.push(0);
+                }
+                Ok(buf)
+            })
+            .into(),
+            "root" => SimpleFile::new(fs, NodeType::Symlink, move || {
+                Ok(task.as_thread().proc_data.root_path.read().clone())
+            })
+            .into(),
+            "cwd" => SimpleFile::new(fs, NodeType::Symlink, move || {
+                Ok(task.as_thread().proc_data.cwd_path.read().clone())
             })
             .into(),
             "fd" => SimpleDir::new_maker(

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -90,6 +90,8 @@ pub fn sys_chdir(path: *const c_char) -> AxResult<isize> {
     let mut fs = FS_CONTEXT.lock();
     let entry = fs.resolve(path)?;
     fs.set_current_dir(entry)?;
+    let cwd = fs.current_dir().absolute_path()?.to_string();
+    *current().as_thread().proc_data.cwd_path.write() = cwd;
     Ok(0)
 }
 
@@ -97,7 +99,10 @@ pub fn sys_fchdir(dirfd: i32) -> AxResult<isize> {
     debug!("sys_fchdir <= dirfd: {dirfd}");
 
     let entry = with_fs(dirfd, |fs| Ok(fs.current_dir().clone()))?;
-    FS_CONTEXT.lock().set_current_dir(entry)?;
+    let mut fs = FS_CONTEXT.lock();
+    fs.set_current_dir(entry)?;
+    let cwd = fs.current_dir().absolute_path()?.to_string();
+    *current().as_thread().proc_data.cwd_path.write() = cwd;
     Ok(0)
 }
 
@@ -121,6 +126,11 @@ pub fn sys_chroot(path: *const c_char) -> AxResult<isize> {
         return Err(AxError::NotADirectory);
     }
     *fs = FsContext::new(loc);
+    let root = fs.root_dir().absolute_path()?.to_string();
+    let cwd = fs.current_dir().absolute_path()?.to_string();
+    let proc_data = current().as_thread().proc_data.clone();
+    *proc_data.root_path.write() = root;
+    *proc_data.cwd_path.write() = cwd;
     Ok(0)
 }
 

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -267,7 +267,10 @@ impl CloneArgs {
                 ProcessImage::new(
                     old_proc_data.exe_path.read().clone(),
                     old_proc_data.cmdline.read().clone(),
+                    old_proc_data.envp.read().clone(),
                     old_proc_data.auxv.read().clone(),
+                    old_proc_data.root_path.read().clone(),
+                    old_proc_data.cwd_path.read().clone(),
                 ),
                 aspace,
                 signal_actions,

--- a/os/StarryOS/kernel/src/syscall/task/execve.rs
+++ b/os/StarryOS/kernel/src/syscall/task/execve.rs
@@ -302,6 +302,7 @@ fn do_execve(
     curr.set_name(&new_name);
     *proc_data.exe_path.write() = new_exe_path;
     *proc_data.cmdline.write() = Arc::new(args);
+    *proc_data.envp.write() = Arc::new(envs);
     let auxv_len = auxv.len();
     let has_ldso = auxv.iter().any(|e| e.get_type() == AuxType::BASE);
     *proc_data.auxv.write() = auxv;

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -626,15 +626,28 @@ struct JobControl {
 pub struct ProcessImage {
     pub exe_path: String,
     pub cmdline: Arc<Vec<String>>,
+    pub envp: Arc<Vec<String>>,
     pub auxv: Vec<AuxEntry>,
+    pub root_path: String,
+    pub cwd_path: String,
 }
 
 impl ProcessImage {
-    pub fn new(exe_path: String, cmdline: Arc<Vec<String>>, auxv: Vec<AuxEntry>) -> Self {
+    pub fn new(
+        exe_path: String,
+        cmdline: Arc<Vec<String>>,
+        envp: Arc<Vec<String>>,
+        auxv: Vec<AuxEntry>,
+        root_path: String,
+        cwd_path: String,
+    ) -> Self {
         Self {
             exe_path,
             cmdline,
+            envp,
             auxv,
+            root_path,
+            cwd_path,
         }
     }
 }
@@ -646,8 +659,14 @@ pub struct ProcessData {
     pub exe_path: RwLock<String>,
     /// The command line arguments
     pub cmdline: RwLock<Arc<Vec<String>>>,
+    /// The environment variables, exported via `/proc/[pid]/environ`.
+    pub envp: RwLock<Arc<Vec<String>>>,
     /// Auxiliary vector entries exported via `/proc/[pid]/auxv`.
     pub auxv: RwLock<Vec<AuxEntry>>,
+    /// The root directory path, exported via `/proc/[pid]/root`.
+    pub root_path: RwLock<String>,
+    /// The current working directory path, exported via `/proc/[pid]/cwd`.
+    pub cwd_path: RwLock<String>,
     /// The virtual memory address space.
     // TODO: scopify
     aspace: SpinNoIrq<Arc<Mutex<AddrSpace>>>,
@@ -855,7 +874,10 @@ impl ProcessData {
             proc,
             exe_path: RwLock::new(image.exe_path),
             cmdline: RwLock::new(image.cmdline),
+            envp: RwLock::new(image.envp),
             auxv: RwLock::new(image.auxv),
+            root_path: RwLock::new(image.root_path),
+            cwd_path: RwLock::new(image.cwd_path),
             aspace: SpinNoIrq::new(aspace),
             uprobe_manager: crate::kprobe::KprobeManager::new(),
             uprobe_point_list: Mutex::new(crate::kprobe::KprobePointList::new()),

--- a/test-suit/starryos/qemu/system/test-proc-environ/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-proc-environ/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-proc-environ C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(test-proc-environ src/main.c)
+target_compile_options(test-proc-environ PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-proc-environ RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-proc-environ/src/main.c
+++ b/test-suit/starryos/qemu/system/test-proc-environ/src/main.c
@@ -1,0 +1,144 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static char *read_environ(size_t *out_len)
+{
+    int fd = open("/proc/self/environ", O_RDONLY);
+    if (fd < 0) {
+        fprintf(stderr, "FAIL: open(/proc/self/environ): %s\n", strerror(errno));
+        return NULL;
+    }
+    char *buf = malloc(8192);
+    if (!buf) {
+        close(fd);
+        return NULL;
+    }
+    ssize_t total = 0;
+    while (total < 8191) {
+        ssize_t n = read(fd, buf + total, 8191 - total);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            fprintf(stderr, "FAIL: read: %s\n", strerror(errno));
+            free(buf);
+            close(fd);
+            return NULL;
+        }
+        if (n == 0) break;
+        total += n;
+    }
+    close(fd);
+    buf[total] = '\0';
+    *out_len = (size_t)total;
+    return buf;
+}
+
+static int find_env(const char *buf, size_t len, const char *var)
+{
+    size_t varlen = strlen(var);
+    const char *p = buf;
+    const char *end = buf + len;
+    while (p < end) {
+        const char *nul = memchr(p, '\0', (size_t)(end - p));
+        if (!nul) break;
+        size_t entry_len = (size_t)(nul - p);
+        if (entry_len == varlen && memcmp(p, var, varlen) == 0) {
+            return 1;
+        }
+        p = nul + 1;
+    }
+    return 0;
+}
+
+static int count_entries(const char *buf, size_t len)
+{
+    int count = 0;
+    const char *p = buf;
+    const char *end = buf + len;
+    while (p < end) {
+        const char *nul = memchr(p, '\0', (size_t)(end - p));
+        if (!nul) break;
+        size_t entry_len = (size_t)(nul - p);
+        if (entry_len > 0) {
+            if (memchr(p, '=', entry_len) == NULL) {
+                fprintf(stderr, "FAIL: entry without '=': %.*s\n",
+                        (int)entry_len, p);
+                return -1;
+            }
+            count++;
+        }
+        p = nul + 1;
+    }
+    return count;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc < 2 || strcmp(argv[1], "--verify") != 0) {
+        char *new_envp[] = {
+            "TEST_ENV=hello123",
+            "PATH=/bin",
+            "EMPTY_VAL=",
+            NULL,
+        };
+        char *new_argv[] = { argv[0], "--verify", NULL };
+        execve("/usr/bin/starry-test-suit/test-proc-environ", new_argv, new_envp);
+        fprintf(stderr, "FAIL: execve: %s\n", strerror(errno));
+        return 1;
+    }
+
+    size_t len = 0;
+    char *buf = read_environ(&len);
+    if (!buf) return 1;
+
+    if (len == 0) {
+        fprintf(stderr, "FAIL: /proc/self/environ is empty\n");
+        free(buf);
+        return 1;
+    }
+
+    printf("INFO: /proc/self/environ size=%zu\n", len);
+
+    if (buf[len - 1] != '\0') {
+        fprintf(stderr, "FAIL: environ not NUL-terminated\n");
+        free(buf);
+        return 1;
+    }
+
+    if (!find_env(buf, len, "TEST_ENV=hello123")) {
+        fprintf(stderr, "FAIL: TEST_ENV=hello123 not found\n");
+        free(buf);
+        return 1;
+    }
+    if (!find_env(buf, len, "PATH=/bin")) {
+        fprintf(stderr, "FAIL: PATH=/bin not found\n");
+        free(buf);
+        return 1;
+    }
+    if (!find_env(buf, len, "EMPTY_VAL=")) {
+        fprintf(stderr, "FAIL: EMPTY_VAL= not found\n");
+        free(buf);
+        return 1;
+    }
+
+    int count = count_entries(buf, len);
+    if (count < 0) {
+        free(buf);
+        return 1;
+    }
+    printf("INFO: found %d env entries\n", count);
+
+    if (count != 3) {
+        fprintf(stderr, "FAIL: expected 3 env entries, got %d\n", count);
+        free(buf);
+        return 1;
+    }
+
+    printf("TEST_PROC_ENVIRON_PASSED\n");
+    free(buf);
+    return 0;
+}

--- a/test-suit/starryos/qemu/system/test-proc-root-cwd/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-proc-root-cwd/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-proc-root-cwd C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(test-proc-root-cwd src/main.c)
+target_compile_options(test-proc-root-cwd PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS test-proc-root-cwd RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-proc-root-cwd/src/main.c
+++ b/test-suit/starryos/qemu/system/test-proc-root-cwd/src/main.c
@@ -1,0 +1,97 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <limits.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int readlink_to(const char *path, char *buf, size_t bufsize)
+{
+    ssize_t n = readlink(path, buf, bufsize - 1);
+    if (n < 0) {
+        fprintf(stderr, "FAIL: readlink(%s): %s\n", path, strerror(errno));
+        return -1;
+    }
+    buf[n] = '\0';
+    return 0;
+}
+
+static int assert_symlink(const char *path)
+{
+    struct stat st;
+    if (lstat(path, &st) != 0) {
+        fprintf(stderr, "FAIL: lstat(%s): %s\n", path, strerror(errno));
+        return -1;
+    }
+    if (!S_ISLNK(st.st_mode)) {
+        fprintf(stderr, "FAIL: %s is not a symlink (mode=0%o)\n", path, st.st_mode);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    char buf[PATH_MAX];
+    char cwd[PATH_MAX];
+
+    if (assert_symlink("/proc/self/root") < 0) return 1;
+    printf("INFO: /proc/self/root is a symlink\n");
+
+    if (readlink_to("/proc/self/root", buf, sizeof(buf)) < 0) return 1;
+    if (strcmp(buf, "/") != 0) {
+        fprintf(stderr, "FAIL: /proc/self/root -> '%s' (expected '/')\n", buf);
+        return 1;
+    }
+    printf("INFO: /proc/self/root -> /\n");
+
+    if (assert_symlink("/proc/self/cwd") < 0) return 1;
+    printf("INFO: /proc/self/cwd is a symlink\n");
+
+    if (getcwd(cwd, sizeof(cwd)) == NULL) {
+        perror("FAIL: getcwd");
+        return 1;
+    }
+    if (readlink_to("/proc/self/cwd", buf, sizeof(buf)) < 0) return 1;
+    if (strcmp(buf, cwd) != 0) {
+        fprintf(stderr, "FAIL: /proc/self/cwd -> '%s' (getcwd='%s')\n", buf, cwd);
+        return 1;
+    }
+    printf("INFO: /proc/self/cwd -> %s (matches getcwd)\n", buf);
+
+    if (chdir("/tmp") != 0) {
+        fprintf(stderr, "FAIL: chdir(/tmp): %s\n", strerror(errno));
+        return 1;
+    }
+    if (getcwd(cwd, sizeof(cwd)) == NULL) {
+        perror("FAIL: getcwd after chdir");
+        return 1;
+    }
+    if (readlink_to("/proc/self/cwd", buf, sizeof(buf)) < 0) return 1;
+    if (strcmp(buf, "/tmp") != 0) {
+        fprintf(stderr, "FAIL: after chdir, /proc/self/cwd -> '%s' (expected '/tmp')\n", buf);
+        return 1;
+    }
+    printf("INFO: after chdir, /proc/self/cwd -> /tmp\n");
+
+    if (readlink_to("/proc/self/root", buf, sizeof(buf)) < 0) return 1;
+    if (strcmp(buf, "/") != 0) {
+        fprintf(stderr, "FAIL: /proc/self/root changed after chdir: '%s'\n", buf);
+        return 1;
+    }
+
+    if (chdir("/") != 0) {
+        fprintf(stderr, "FAIL: chdir(/): %s\n", strerror(errno));
+        return 1;
+    }
+    if (readlink_to("/proc/self/cwd", buf, sizeof(buf)) < 0) return 1;
+    if (strcmp(buf, "/") != 0) {
+        fprintf(stderr, "FAIL: after chdir(/), /proc/self/cwd -> '%s' (expected '/')\n", buf);
+        return 1;
+    }
+    printf("INFO: after chdir(/), /proc/self/cwd -> /\n");
+
+    printf("TEST_PROC_ROOT_CWD_PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
## 背景

这是从 #1520 拆出的独立 PR，仅补齐 `/proc/<pid>/environ`、`root` 和 `cwd`。

Nix 在启动和检查 builder 时需要读取目标进程环境，并通过 procfs 链接观察其 root
与工作目录。StarryOS 当前缺少这些条目，导致常规 procfs 探测失败。

## 改动内容

1. 在进程数据中保存初始环境块，并在 exec 时用新镜像环境更新；fork/clone 继承
   当前快照。
2. 增加 `/proc/<pid>/environ`，按 Linux 格式返回以 NUL 分隔的环境字符串。
3. 增加 `/proc/<pid>/root` 和 `/proc/<pid>/cwd` 的符号链接语义。
4. 在 `chdir`/`chroot` 路径同步更新进程可观察的 cwd/root，确保 procfs 返回当前值。
5. 新增并迁移到统一 system 布局：
   - `test-proc-environ`：覆盖 self/child 环境、exec 更新与 NUL 分隔；
   - `test-proc-root-cwd`：覆盖 readlink、chdir 与 chroot 后的链接结果。

## 实现逻辑

环境属于进程镜像状态：clone 时复制，exec 成功后替换。root/cwd 则由进程数据保存
对外可观察路径，并在对应文件系统状态转换完成后同步更新。procfs 读取指定 pid 的
进程数据生成内容或链接，不复用读取者自身的 FS context。

## 范围说明

本 PR 不包含 mountinfo、mount namespace、pivot_root、cgroup namespace 或 Nix
应用集成改动。

## 验证

- `cargo fmt`
- `git diff --check`
- 两个 C 回归程序均通过独立 CMake 配置和 `-Wall -Wextra -Werror` 编译链接。
- 按本轮拆分策略暂不等待 clippy；完整 Starry QEMU 运行交由 CI 复核。

关联：#1520
