### PR TITLE
fix(dwmmc-host): enforce 32-bit response MMIO reads

### DIFF
--- a/drivers/blk/dwmmc-host/src/command.rs
+++ b/drivers/blk/dwmmc-host/src/command.rs
@@ -379,20 +379,39 @@ fn encode_command(cmd: &ProtoCmd, data_dir: Option<DataDirection>) -> Cmd {
 }
 
 fn decode_response(host: &DwMmc, resp_type: ResponseType) -> Result<Response, Error> {
-    let resp = host.regs.resp().read();
     Ok(match resp_type {
         ResponseType::None => Response::Empty,
-        ResponseType::R1 => Response::R1(R1Response { raw: resp[0] }),
-        ResponseType::R1b => Response::R1b(R1Response { raw: resp[0] }),
-        ResponseType::R2 => Response::R2(read_r2(resp)),
-        ResponseType::R3 => Response::R3(OcrResponse::from_raw(resp[0])),
-        ResponseType::R4 => Response::R4(SdioOcrResponse::from_raw(resp[0])),
-        ResponseType::R5 => Response::R5(SdioRwResponse::from_raw(resp[0])),
-        ResponseType::R6 => Response::R6(RcaResponse::from_raw(resp[0])),
-        ResponseType::R7 => Response::R7(IfCondResponse::from_raw(resp[0])),
+        ResponseType::R1 => Response::R1(R1Response {
+            raw: read_short_response(host),
+        }),
+        ResponseType::R1b => Response::R1b(R1Response {
+            raw: read_short_response(host),
+        }),
+        ResponseType::R2 => Response::R2(read_r2(read_long_response(host))),
+        ResponseType::R3 => Response::R3(OcrResponse::from_raw(read_short_response(host))),
+        ResponseType::R4 => Response::R4(SdioOcrResponse::from_raw(read_short_response(host))),
+        ResponseType::R5 => Response::R5(SdioRwResponse::from_raw(read_short_response(host))),
+        ResponseType::R6 => Response::R6(RcaResponse::from_raw(read_short_response(host))),
+        ResponseType::R7 => Response::R7(IfCondResponse::from_raw(read_short_response(host))),
         // Future ResponseType variants are not decoded by this controller.
         _ => return Err(Error::UnsupportedCommand),
     })
+}
+
+fn read_short_response(host: &DwMmc) -> u32 {
+    host.regs.resp0().read()
+}
+
+fn read_long_response(host: &DwMmc) -> [u32; 4] {
+    // Keep each response slot as a separate 32-bit volatile access. Some
+    // DW_mshc integrations reject the 64-bit MMIO loads that an aggregate
+    // volatile read may generate.
+    [
+        host.regs.resp0().read(),
+        host.regs.resp1().read(),
+        host.regs.resp2().read(),
+        host.regs.resp3().read(),
+    ]
 }
 
 /// Reorder the four 32-bit response slots into the 16-byte buffer the

--- a/drivers/blk/dwmmc-host/src/regs.rs
+++ b/drivers/blk/dwmmc-host/src/regs.rs
@@ -45,9 +45,18 @@ pub struct RegisterBlock {
     pub cmdarg: u32,
     /// Command Register
     pub cmd: Cmd,
-    /// Response Registers (4 × 32 bits)
+    /// Response Register 0
     #[access(ReadOnly)]
-    pub resp: [u32; 4],
+    pub resp0: u32,
+    /// Response Register 1
+    #[access(ReadOnly)]
+    pub resp1: u32,
+    /// Response Register 2
+    #[access(ReadOnly)]
+    pub resp2: u32,
+    /// Response Register 3
+    #[access(ReadOnly)]
+    pub resp3: u32,
     /// Masked Interrupt Status Register
     #[access(ReadOnly)]
     pub mintsts: u32,
@@ -265,4 +274,23 @@ pub struct UHS {
     pub ddr: u16,
     /// Per card: 0 = 3.3 V buffers, 1 = 1.8 V buffers.
     pub volt: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use core::mem::{offset_of, size_of};
+
+    use super::*;
+
+    #[test]
+    fn response_registers_are_individual_32_bit_mmio_words() {
+        assert_eq!(offset_of!(RegisterBlock, resp0), 0x30);
+        assert_eq!(offset_of!(RegisterBlock, resp1), 0x34);
+        assert_eq!(offset_of!(RegisterBlock, resp2), 0x38);
+        assert_eq!(offset_of!(RegisterBlock, resp3), 0x3c);
+        assert_eq!(
+            offset_of!(RegisterBlock, mintsts) - offset_of!(RegisterBlock, resp3),
+            size_of::<u32>()
+        );
+    }
 }

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -46,3 +46,4 @@ ax-runtime
 ax-api
 rockchip-jpeg
 rockchip-npu
+dwmmc-host


### PR DESCRIPTION
## 问题

PR #1626（提交 `e7107d0b8`）将项目 Rust 工具链从 `nightly-2026-05-28` 更新到了 `nightly-2026-07-15`。工具链更新后，同一份 DWMMC 源代码的 AArch64 release 机器码发生了变化，进而导致 StarryOS 在 OrangePi-5-plus 上无法正确启动。

旧工具链将四个响应寄存器编译为四次独立的 32 位加载：

```asm
ldr w10, [x12, #0x3c]
ldr w11, [x12, #0x38]
ldr w9,  [x12, #0x34]
ldr w20, [x12, #0x30]
```

新工具链将数组整体读取编译为 64 位成对加载：

```asm
ldp x8, x10, [x8, #0x30]
```

因此，工具链升级是本次启动回归的直接触发条件。升级之前，生成的四条 `ldr wN` 恰好符合硬件访问宽度，所以原实现可以正常启动；升级之后，新的合法代码生成方式暴露了原有 MMIO 寄存器建模没有约束访问宽度的问题。

使用新工具链构建的 StarryOS 在 OrangePi 5 Plus 上启动时，会在初始化 TF 卡的 DWMMC 控制器阶段触发同步异常：

```text
Unhandled synchronous exception Some(DataAbortCurrentEL)
PC:  0xffffffff8041d500
FAR: 0xffff0000fe2c0030
ESR: 0x96000010
```

异常 PC 对应的 AArch64 指令正是新工具链生成的：

```asm
ldp x8, x10, [x8, #0x30]
```

`0xfe2c0030` 是 DWMMC 响应寄存器 `RESP0` 的地址。原实现将四个连续的 32 位响应寄存器定义为：

```rust
pub resp: [u32; 4]
```

随后通过一次聚合 `read()` 读取整个数组。从 Rust 类型和 volatile 操作的角度看，这是一次 16 字节对象读取，因此编译器可以使用 64 位成对加载指令 `ldp` 完成它。旧工具链生成四条 32 位加载只是当时的代码生成结果，并不是源代码提供的硬件访问宽度保证。

RK3588 上的该 DWMMC MMIO 区域要求使用 32 位寄存器访问。执行 64 位 MMIO 加载会触发 Data Abort，导致系统无法从带有 TF 卡的 OrangePi 5 Plus 启动。

此前该问题没有被普通单元测试发现，是因为寄存器布局和响应解析结果本身仍然正确，错误只体现在特定目标和优化配置下生成的 MMIO 指令宽度。原有 CI 也没有检查最终机器码，因此工具链升级后生成 `ldp` 仍然能够通过编译、单元测试和 CI，直到在 RK3588 实机上执行该指令才触发异常。

## 修改内容

1. 将响应寄存器从 `[u32; 4]` 拆分为四个独立的 32 位寄存器：

   - `resp0`
   - `resp1`
   - `resp2`
   - `resp3`

2. 根据响应类型选择读取方式：

   - 短响应只读取 `resp0`；
   - R2 长响应显式执行四次独立的 32 位 volatile read。

3. 添加寄存器布局单元测试，确认四个响应寄存器仍位于：

   - `RESP0`: `0x30`
   - `RESP1`: `0x34`
   - `RESP2`: `0x38`
   - `RESP3`: `0x3c`

   同时确认后续 `MINTSTS` 寄存器的偏移没有发生变化。

## 修改逻辑

DWMMC 响应寄存器在硬件上是四个独立的 32 位 MMIO word，而不是一个允许任意宽度访问的普通内存数组。

因此，Rust 类型和读取方式都应显式表达这一硬件约束，不能依赖某一版工具链碰巧生成四条 32 位指令。拆分寄存器可以阻止编译器把数组整体读取实现为 64 位访问，同时不改变寄存器偏移和原有响应解析语义。

寄存器布局测试用于确认四个响应寄存器保持为独立的 32 位字段，并且地址与后续寄存器布局没有发生变化。读取路径则对每个字段分别执行一次 volatile read，使访问宽度由寄存器类型明确约束，不再依赖编译器如何实现数组整体读取。

## 验证

修复后的 AArch64 release 机器码为：

```asm
ldr w12, [x9, #0x30]
ldr w10, [x9, #0x34]
ldr w11, [x9, #0x38]
ldr w9,  [x9, #0x3c]
```

已执行：

```bash
cargo fmt --all -- --check
cargo test --package dwmmc-host
cargo xtask clippy --package dwmmc-host
```

验证结果：

- `dwmmc-host` 40 个单元测试全部通过；
- doc tests 全部通过；
- clippy 无警告；
- 已确认同一份修复前源码在 `nightly-2026-05-28` 下生成四条 32 位 `ldr`，在 `nightly-2026-07-15` 下生成 64 位 `ldp`；
- 修复后的 AArch64 release 机器码确认四个响应寄存器均使用独立的 32 位 `ldr`；
- 修复前的 OrangePi 5 Plus 实机镜像可稳定复现 `0xfe2c0030` 上的 64 位 MMIO Data Abort。