### PR TITLE
test(cpu-parallel-compute): parallel compute carpet - CPU software (lavapipe/pocl concurrent)

### DIFF
--- a/apps/starry/cpu-parallel-compute/.gitignore
+++ b/apps/starry/cpu-parallel-compute/.gitignore
@@ -1,0 +1,4 @@
+target/
+*.spv
+*_full_api
+*.o

--- a/apps/starry/cpu-parallel-compute/README.md
+++ b/apps/starry/cpu-parallel-compute/README.md
@@ -1,0 +1,108 @@
+# cpu-parallel-compute
+
+Parallel/concurrent compute correctness carpet on StarryOS, across the two software CPU compute
+backends already proven on StarryOS: Mesa lavapipe (a real Vulkan compute queue over llvmpipe's LLVM
+CPU JIT) and a CPU OpenCL runtime (rusticl over llvmpipe, or pocl when folded in). No host GPU is
+required. Each carpet drives the parallel-compute axis - concurrent dispatch, multiple command
+queues, asynchronous multi-submit, and multi-workgroup grids with shared-memory reduction and
+cross-workgroup atomic counters - and asserts every result element against a closed-form reference
+plus a race/ordering check. A carpet prints `<name> OK <n>` only when its failure count is zero and
+the assertion total equals a pinned `EXPECTED` constant.
+
+## Cells and assertions
+
+| Cell | Backend | Assertions | Runs |
+|:--|:--|--:|:--|
+| `vk_parallel` | Vulkan C (`vulkan/vulkan.h`), Mesa lavapipe | 93 | on-target (all arches) + host |
+| `cl_parallel` | OpenCL C (`CL/cl.h`), rusticl / pocl | 77 | on-target where a CPU OpenCL runtime is packaged (x86_64 / aarch64) + host |
+
+Total: 170 assertions.
+
+## Cases covered
+
+Each carpet covers the four parallel-compute cases end to end:
+
+- **(a) concurrent dispatch** - multiple compute dispatches enqueued in flight without waiting
+  between them (Vulkan: back-to-back `vkQueueSubmit` with per-submission fences, then one
+  `vkWaitForFences` over all; OpenCL: one NDRange per queue, flushed, then `clWaitForEvents` over all
+  producer events). Every one of the independent results is verified element-wise, and a negative
+  control proves the element-wise checker rejects a single corrupted element.
+- **(b) multi-queue** - the Vulkan compute family's `queueCount` is queried; when it exposes two or
+  more queues a distinct second `VkQueue` is fetched and fed real work in the async multi-submit,
+  otherwise the count is asserted honestly as 1 and concurrency is driven through multiple independent
+  command buffers on the single queue family. OpenCL creates four in-order command queues on one
+  context plus an out-of-order queue where the device advertises it (asserted honestly as unsupported
+  otherwise), distributes the work across them, and verifies every result.
+- **(c) async multi-submit** - many submissions enqueued without blocking, then a single wait, with
+  ordering and completion verified: Vulkan checks every fence reports `VK_SUCCESS` and a single batch
+  `vkQueueSubmit` of all command buffers is correct; OpenCL gates a dependent kernel on an event
+  wait-list, gates a compute on two non-blocking `clEnqueueWriteBuffer` events, and gates a kernel on
+  a user event released by `clSetUserEventStatus` with a completion callback, asserting each produced
+  result and the `CL_COMPLETE` event status.
+- **(d) multi-workgroup** - a 1,048,576-element grid split across 4,096 workgroups is verified
+  element-wise; a workgroup-shared-memory reduction (GLSL `shared` / OpenCL `__local`) is checked so
+  every per-workgroup partial equals its CPU workgroup sum and the combined total equals the exact CPU
+  total; and a global atomic counter written by every work-item across every workgroup
+  (`atomicAdd` / `atomic_add`) must reach exactly N and the closed-form integer sum, with a second
+  accumulating dispatch reaching exactly 2N - the "atomic sum == N, no lost updates" cross-workgroup
+  race check.
+
+Ordering is additionally exercised with pipeline barriers (`SHADER_WRITE -> SHADER_READ` producer to
+consumer in one command buffer), cross-submit binary semaphores, and device events
+(`vkCmdSetEvent` / `vkCmdWaitEvents`), each asserting the consumer read the producer's output and not
+a stale value. Boundary dispatches (zero workgroups leave the output untouched; a non-power-of-two
+grid exercises the `i < n` tail guard) and the documented validation-error enums
+(`CL_INVALID_BUFFER_SIZE`, `CL_INVALID_WORK_GROUP_SIZE`, `CL_INVALID_ARG_SIZE`,
+`CL_BUILD_PROGRAM_FAILURE`, `VK_ERROR_*`, `VK_TIMEOUT`, `VK_NOT_READY`) are asserted directly.
+
+## Backend and runtime
+
+Provisioned from Alpine edge (main + community) as musl packages: `mesa-vulkan-swrast` (lavapipe),
+`vulkan-loader`, `vulkan-headers`, `opencl-headers`, `glslang` / `shaderc` (GLSL to SPIR-V), and
+best-effort `mesa-rusticl` + `opencl-icd-loader` (OpenCL over llvmpipe), plus the `llvm-libs` closure.
+`prebuild.sh` cross-compiles the two carpets against the provisioned musl headers/libraries under
+qemu-user, compiles the four GLSL compute shaders to SPIR-V, and stages the binaries plus the mesa
+closure into the per-arch rootfs. When `POCL_PREBUILT` points at a matching-arch pocl staging tree,
+pocl's `libOpenCL` is folded in and `cl_parallel` is linked against it instead of rusticl.
+`programs/run_all.sh` runs the carpets and prints `TEST PASSED` when the Vulkan core carpet reports
+`OK`, none fails, and any present OpenCL carpet also reports `OK`.
+
+Runtime environment on target:
+
+- `XDG_RUNTIME_DIR` must point at a writable directory; lavapipe maps host-visible memory through a
+  file under it.
+- `VK_DRIVER_FILES` selects the lavapipe ICD; the ICD JSON's absolute `library_path` resolves against
+  the rootfs root.
+- `RUSTICL_ENABLE=llvmpipe` and `OCL_ICD_VENDORS` select the software OpenCL device;
+  `POCL_DEVICES=basic` selects pocl's single-threaded CPU device when pocl is folded in.
+- `LP_NUM_THREADS=1` pins the mesa thread pool to one thread, matching StarryOS's single vCPU.
+
+## Availability
+
+Alpine edge builds `mesa-vulkan-swrast` for all four target architectures, so `vk_parallel` runs
+on-target on x86_64, aarch64, riscv64 and loongarch64. `mesa-rusticl` is a Rust mesa component Alpine
+does not build for every arch (absent on riscv64 / loongarch64 today), so `cl_parallel` is additive:
+it runs where a CPU OpenCL runtime is packaged and is reported but does not gate the Vulkan core. Both
+carpets run in the host reference layer against the same lavapipe / CPU OpenCL devices the on-target
+binaries use.
+
+## Single-core execution
+
+StarryOS runs on one vCPU (SMP is off by default), so the software backends execute every workgroup on
+a single thread. `run_all.sh` pins the mesa thread pool with `LP_NUM_THREADS=1` and pocl with
+`POCL_DEVICES=basic`, and prints the detected CPU count, so the single-core reality is explicit. The
+carpets assert numerical/atomic correctness and API ordering semantics, not throughput; the results
+are independent of thread count. The cross-workgroup atomic and shared-memory reduction checks remain
+meaningful on one thread because the software scheduler still interleaves the workgroups: a lost
+atomic update or a misplaced barrier still produces a wrong count or partial. Where the compute queue
+family exposes `queueCount == 1` (lavapipe), "multi-queue" is exercised as asynchronous multi-submit
+across multiple command buffers rather than hardware-parallel queues, and is asserted as such.
+
+## Run
+
+```
+cargo xtask starry app qemu -t cpu-parallel-compute --arch x86_64
+cargo xtask starry app qemu -t cpu-parallel-compute --arch aarch64
+cargo xtask starry app qemu -t cpu-parallel-compute --arch riscv64
+cargo xtask starry app qemu -t cpu-parallel-compute --arch loongarch64
+```

--- a/apps/starry/cpu-parallel-compute/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-parallel-compute/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,13 @@
+features = [
+  "ax-runtime/display",
+  "ax-runtime/rtc",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "aarch64-unknown-none-softfloat"

--- a/apps/starry/cpu-parallel-compute/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-parallel-compute/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,14 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-runtime/display",
+  "ax-runtime/rtc",
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]

--- a/apps/starry/cpu-parallel-compute/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/cpu-parallel-compute/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,14 @@
+features = [
+  "ax-runtime/display",
+  "ax-runtime/rtc",
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "starry-kernel/input",
+  "starry-kernel/vsock",
+]
+log = "Warn"
+target = "riscv64gc-unknown-none-elf"

--- a/apps/starry/cpu-parallel-compute/build-x86_64-unknown-none.toml
+++ b/apps/starry/cpu-parallel-compute/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/cpu-parallel-compute/prebuild.sh
+++ b/apps/starry/cpu-parallel-compute/prebuild.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the software GPU compute runtime (Mesa lavapipe / llvmpipe for Vulkan,
+# rusticl / pocl for OpenCL, both over LLVM CPU JIT) and the compiled parallel-compute carpet
+# binaries into the per-arch Alpine rootfs.
+#
+# Portable model: extract the base Alpine rootfs to a staging tree, `apk add` mesa-vulkan-swrast
+# (lavapipe), the Vulkan loader, glslang/shaderc (GLSL -> SPIR-V) and the build toolchain INTO it via
+# qemu-user-static (apk resolves every package for the TARGET arch on an x86 build host - no drifting
+# URLs, no cache-miss-exit), then best-effort `apk add` mesa-rusticl + opencl-icd-loader for the
+# OpenCL carpet. Cross-compile the Vulkan and OpenCL carpet sources against the provisioned musl
+# headers/libraries with the target gcc under qemu-user, compile the GLSL compute shaders to SPIR-V,
+# then copy the shared-library closure, the lavapipe ICD metadata and the carpet binaries + runner
+# into the overlay. Inputs are the base rootfs and the Alpine edge apk repos only.
+#
+# All backends are CPU software: lavapipe runs the Vulkan compute queue on llvmpipe (LLVM CPU JIT),
+# rusticl/pocl run OpenCL on the same CPU JIT, so no host GPU is required. Alpine edge builds
+# mesa-vulkan-swrast for all four target arches, so the Vulkan carpet runs on-target on every arch;
+# mesa-rusticl is a Rust component Alpine does not build for every arch, so the OpenCL carpet is
+# additive (best-effort). If POCL_PREBUILT points at a matching-arch pocl staging tree, pocl's
+# libOpenCL is folded in and the OpenCL carpet is linked against it instead.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS (base alpine working copy),
+# STARRY_STAGING_ROOT (scratch extraction tree), STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+CAR="$app_dir/programs/carpets"
+
+# qemu_runner: apk (and glslc) still resolve/run against the TARGET rootfs under qemu-user - only
+#              gcc/g++ were broken there (they spawn cc1/cc1plus via posix_spawn, which qemu-user
+#              cannot exec), so the C cells are built HOST-side instead.
+# triple:      the musl target triple for the HOST cross C compiler / linker that builds the cells.
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static";     apk_arch="aarch64";     triple="aarch64-linux-musl" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static";     apk_arch="riscv64";     triple="riscv64-linux-musl" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static";      apk_arch="x86_64";      triple="x86_64-linux-musl" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static"; apk_arch="loongarch64"; triple="loongarch64-linux-musl" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+    # A HOST C cross toolchain builds the C cells (the staged Alpine gcc's cc1 cannot run under
+    # qemu-user: gcc spawns cc1 via posix_spawn, which qemu-user cannot exec).
+    command -v "${triple}-gcc" >/dev/null 2>&1 || [[ -x "/opt/${triple}-cross/bin/${triple}-gcc" ]] \
+        || [[ -x "/opt/cross/${triple}-cross/bin/${triple}-gcc" ]] \
+        || { [[ "$arch" == "x86_64" ]] && command -v musl-gcc >/dev/null 2>&1; } || command -v zig >/dev/null 2>&1 \
+        || { echo "prebuild: no host C cross toolchain (need ${triple}-gcc or zig) for $arch" >&2; exit 1; }
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+# The harness injects $STARRY_OVERLAY_DIR into $base_rootfs via debugfs WITHOUT resizing, so the
+# per-app image must be grown here first. The overlay carries the full mesa/lavapipe closure plus its
+# LLVM runtime (~200 MiB); the stock ~2 GiB image overflows and debugfs silently truncates the
+# backend libraries ("Could not allocate block"), which surfaces at runtime as "symbol not found".
+# 4 GiB leaves ample headroom. Idempotent: truncate only grows, e2fsck/resize2fs are safe to re-run.
+# The image stays sparse on the host.
+ROOTFS_SIZE=4G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    command -v resize2fs >/dev/null 2>&1 || { echo "prebuild: resize2fs required (e2fsprogs)" >&2; exit 1; }
+    local before after
+    before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB (fs resized) for mesa/lavapipe closure"
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# mesa software Vulkan (lavapipe) + LLVM + the Vulkan loader + SPIR-V toolchain + build toolchain,
+# all musl for the target arch. mesa-dev is intentionally NOT installed (it pulls the ~200MB
+# clang-libs closure the runtime does not need). Alpine builds mesa-vulkan-swrast for every arch.
+GPU_PKGS=(musl mesa-vulkan-swrast vulkan-loader vulkan-headers opencl-headers
+          build-base glslang shaderc
+          gmp mpfr4 mpc1 isl26 zlib)
+# OpenCL over llvmpipe (rusticl, a Rust mesa component Alpine does not build for every arch) + the
+# ICD loader. Best-effort: on arches without it the OpenCL carpet is skipped.
+GPU_PKGS_OPT=(mesa-rusticl opencl-icd-loader)
+
+apk_provision() {
+    normalize_symlinks
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add Vulkan stack (${GPU_PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add "${GPU_PKGS[@]}"
+    [[ -f "$staging_root/usr/lib/libvulkan_lvp.so" ]] || { echo "prebuild: mesa-vulkan-swrast (lavapipe) not provisioned" >&2; exit 3; }
+    # best-effort: rusticl (OpenCL) is not built for every Alpine arch
+    if QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" add "${GPU_PKGS_OPT[@]}"; then
+        echo "prebuild: OpenCL rusticl provisioned for $arch"
+    else
+        echo "prebuild: OpenCL rusticl unavailable for $arch (upstream Alpine arch gap) - Vulkan carpet only"
+    fi
+}
+
+# glslc (shaderc) is a self-contained ELF that does its SPIR-V codegen internally (no cc1-style
+# posix_spawn), so it still runs under qemu-user against the staged shaderc - only gcc/g++ were broken.
+GLSLC() { QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/usr/lib:$staging_root/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/usr/bin/glslc" "$@"; }
+
+libpath() { ls "$staging_root/usr/lib/$1".so* 2>/dev/null | head -1 || true; }
+
+# Compiler selection: HOST cross toolchain, for the native arch AND foreign arches.
+#
+# The staged Alpine gcc cannot compile under qemu-user: gcc's driver spawns cc1 (and collect2/ld) via
+# posix_spawn, which qemu-user cannot exec, so the whole staged-gcc-under-qemu path is broken on every
+# arch. The fix is to compile HOST-side with a musl cross toolchain (${triple}-gcc, a native binary
+# whose own cc1 resolves natively) plus --sysroot pointing at the Alpine staging tree, so every
+# built-in header/library path resolves against the staged Alpine sysroot and the emitted ELF is the
+# target arch with the /lib/ld-musl-<arch>.so.1 interpreter Alpine expects.
+#
+# Both C cells LINK an Alpine .so that carries a `.relr.dyn` (SHT_RELR) section: vk_parallel links
+# libvulkan.so.1 and cl_parallel links libOpenCL.so.<n>. Old musl-cross binutils ld (~2.36) rejects it
+# ("unknown type [0x13] section .relr.dyn"), so resolve_cc probes the cross gcc's ld against a staged
+# RELR .so and falls back to `zig cc` (bundled LLD reads RELR) when it fails. Both paths use --sysroot
+# at the staging tree + explicit -I usr/include (Debian's x86_64-linux-musl-gcc ignores --sysroot for
+# headers, and some packaged musl-cross toolchains resolve headers from a built-in <sysroot>/include
+# layout, both missing Alpine's usr/include).
+cc_mode=""; cc_gcc=""
+resolve_cc() {
+    [[ -n "$cc_mode" ]] && return 0
+    local gcc="" probelib probe
+    if command -v "${triple}-gcc" >/dev/null 2>&1; then gcc="${triple}-gcc"
+    elif [[ -x "/opt/${triple}-cross/bin/${triple}-gcc" ]]; then gcc="/opt/${triple}-cross/bin/${triple}-gcc"
+    elif [[ -x "/opt/cross/${triple}-cross/bin/${triple}-gcc" ]]; then gcc="/opt/cross/${triple}-cross/bin/${triple}-gcc"
+    elif [[ "$arch" == "x86_64" ]] && command -v musl-gcc >/dev/null 2>&1; then gcc="musl-gcc"; fi
+    # Prefer the cross gcc only if its ld can actually link a staged Alpine .relr.dyn .so. Probe against
+    # libvulkan (always present; libOpenCL is additive and may be absent on rv/la).
+    probelib="$(libpath libvulkan)"; [[ -n "$probelib" ]] || probelib="$(libpath libOpenCL)"
+    if [[ -n "$gcc" && -n "$probelib" ]]; then
+        probe="$(mktemp)"; printf 'int main(){return 0;}\n' > "$probe.c"
+        if "$gcc" --sysroot="$staging_root" -O0 "$probe.c" -o "$probe" \
+                -Wl,-rpath-link,"$staging_root/usr/lib:$staging_root/lib" "$probelib" >/dev/null 2>&1; then
+            cc_mode="gcc"; cc_gcc="$gcc"; rm -f "$probe" "$probe.c"
+            echo "prebuild: C toolchain = $gcc (--sysroot, native ABI, ld reads .relr.dyn)"; return 0
+        fi
+        rm -f "$probe" "$probe.c"
+    fi
+    if command -v zig >/dev/null 2>&1; then
+        cc_mode="zig"
+        echo "prebuild: C toolchain = zig cc -target $triple (LLD reads .relr.dyn)"; return 0
+    fi
+    [[ -n "$gcc" ]] && { cc_mode="gcc"; cc_gcc="$gcc"; echo "prebuild: C toolchain = $gcc (no zig; RELR unverified)"; return 0; }
+    echo "prebuild: no host C cross toolchain for $triple (tried ${triple}-gcc, /opt, musl-gcc, zig cc)" >&2; return 1
+}
+GCC() { resolve_cc || exit 1
+    case "$cc_mode" in
+        gcc) "$cc_gcc" --sysroot="$staging_root" -I"$staging_root/usr/include" \
+             -Wl,-rpath-link,"$staging_root/usr/lib:$staging_root/lib" "$@" ;;
+        zig) zig cc -target "$triple" --sysroot "$staging_root" -I"$staging_root/usr/include" \
+             -Wl,-rpath-link,"$staging_root/usr/lib:$staging_root/lib" "$@" ;;
+    esac
+}
+
+compile_carpets() {
+    local bin="$staging_root/opt/cpu-parallel-compute"; mkdir -p "$bin/shaders"
+    local VK; VK="$(libpath libvulkan)"
+    local CL; CL="$(libpath libOpenCL)"
+    [[ -n "$VK" ]] || { echo "prebuild: libvulkan not provisioned" >&2; exit 4; }
+
+    # Vulkan compute shaders -> SPIR-V, kept next to the vk_parallel binary. vk_parallel loads
+    # shaders/{vadd,partial_reduce,chain,atomic_sum}.spv (all 256-wide local size).
+    for comp in "$CAR"/vk_parallel/shaders/*.comp; do
+        [[ -f "$comp" ]] || continue
+        GLSLC -O "$comp" -o "$bin/shaders/$(basename "${comp%.comp}").spv"
+    done
+
+    echo "prebuild: cross-compile parallel carpets for $arch (lavapipe Vulkan + rusticl/pocl OpenCL)"
+    # Vulkan (hard-required core: the lavapipe parallel-compute path is the gate on every arch)
+    GCC -O2 "$CAR/vk_parallel/vk_parallel_full_api.c" -o "$bin/vk_parallel" "$VK" -lm
+    [[ -x "$bin/vk_parallel" ]] || { echo "prebuild: vk_parallel failed to compile" >&2; exit 4; }
+    # OpenCL (additive by ARCH: built only where the arch provisioned a libOpenCL via rusticl/pocl).
+    # But WHERE libOpenCL IS present, cl_parallel is expected to compile+link: a failure there is a
+    # genuine breakage, not an honest arch gap, so it is a hard error (no `|| true` swallow). Only the
+    # true absence of an OpenCL runtime (rv/la with no rusticl/pocl) is an honest additive skip.
+    if [[ -n "$CL" ]]; then
+        GCC -O2 "$CAR/cl_parallel/cl_parallel_full_api.c" -o "$bin/cl_parallel" "$CL" -lm
+        [[ -x "$bin/cl_parallel" ]] || { echo "prebuild: cl_parallel failed to link on $arch (libOpenCL present - genuine breakage)" >&2; exit 4; }
+        echo "prebuild: cl_parallel linked against $(basename "$CL")"
+    else
+        echo "prebuild: no libOpenCL for $arch (no rusticl/pocl) - OpenCL parallel carpet skipped (additive, honest arch gap)"
+    fi
+    cp "$app_dir/programs/run_all.sh" "$bin/run_all.sh"; chmod +x "$bin/run_all.sh"
+    echo "prebuild: compiled $(find "$bin" -maxdepth 1 -type f -perm -u+x ! -name '*.sh' | wc -l) parallel carpet binary(ies) + run_all.sh"
+}
+
+# Optional: fold a matching-arch pocl staging tree (POCL_PREBUILT) into the rootfs as the OpenCL
+# runtime and re-link the OpenCL carpet against pocl's libOpenCL. No-ops when POCL_PREBUILT is unset
+# (OpenCL then comes from rusticl where the arch has it). Mirrors the sibling gpu-compute prebuild.
+integrate_pocl() {
+    local pocl="${POCL_PREBUILT:-}" bin="$staging_root/opt/cpu-parallel-compute"
+    [[ -n "$pocl" && -d "$pocl/usr" ]] || { echo "prebuild: no pocl staging for $arch (set POCL_PREBUILT to fold pocl) - OpenCL via rusticl only this run"; return 0; }
+    cp -a "$pocl/usr/lib/libOpenCL.so"* "$staging_root/usr/lib/" 2>/dev/null || true
+    cp -a "$pocl/usr/lib/libpocl.so"* "$staging_root/usr/lib/" 2>/dev/null || true
+    cp -a "$pocl/usr/lib/pocl" "$staging_root/usr/lib/" 2>/dev/null || true
+    cp -a "$pocl/usr/share/pocl" "$staging_root/usr/share/" 2>/dev/null || true
+    for soname in libLLVM.so.20.1 libclang-cpp.so.20.1 libhwloc.so.15; do
+        real="$(readlink -f "$pocl/usr/lib/$soname" 2>/dev/null || true)"
+        [[ -n "$real" && -f "$real" ]] && cp -Lf "$real" "$staging_root/usr/lib/$soname" 2>/dev/null || true
+    done
+    cp -a "$pocl/etc/OpenCL" "$staging_root/etc/" 2>/dev/null || true
+    # pocl's host-cpu driver bakes Intel SVML/IRC archive paths into HOST_LD_FLAGS. Provide
+    # ABI-correct scalar-loop wrappers (svml_stub.c) and an empty libirc.a at those baked paths.
+    local svml_dir="$staging_root/opt/intel/oneapi/compiler/latest/lib"
+    mkdir -p "$svml_dir"
+    if GCC -O2 -fPIC -ffp-contract=off -fno-math-errno -c "$app_dir/programs/svml_stub.c" -o "$svml_dir/svml_stub.o" 2>/dev/null; then
+        ar rcs "$svml_dir/libsvml.a" "$svml_dir/svml_stub.o"; rm -f "$svml_dir/svml_stub.o"
+        echo "prebuild: built libsvml.a ($(nm "$svml_dir/libsvml.a" 2>/dev/null | grep -c __svml_) __svml wrappers) for $arch"
+    else
+        printf '!<arch>\n' > "$svml_dir/libsvml.a"
+    fi
+    printf '!<arch>\n' > "$svml_dir/libirc.a"
+    local pcl; pcl="$(ls "$staging_root"/usr/lib/libOpenCL.so.2* 2>/dev/null | head -1)"
+    [[ -n "$pcl" ]] || return 0
+    GCC -O2 "$CAR/cl_parallel/cl_parallel_full_api.c" -o "$bin/cl_parallel" "$pcl" -lm -Wl,--allow-shlib-undefined
+    [[ -x "$bin/cl_parallel" ]] || { echo "prebuild: cl_parallel failed to relink against pocl on $arch (pocl folded - genuine breakage)" >&2; exit 4; }
+    echo "prebuild: pocl OpenCL folded for $arch (cl_parallel linked against pocl)"
+}
+
+populate_overlay() {
+    mkdir -p "$overlay_dir/usr/lib" "$overlay_dir/usr/share" "$overlay_dir/opt" "$overlay_dir/usr/bin" "$overlay_dir/etc"
+    cp -a "$staging_root/etc/OpenCL" "$overlay_dir/etc/" 2>/dev/null || true
+    # the whole provisioned /usr/lib closure (mesa lavapipe + LLVM + loaders) and ICD metadata
+    cp -a "$staging_root/usr/lib/." "$overlay_dir/usr/lib/"
+    cp -a "$staging_root/usr/share/vulkan" "$overlay_dir/usr/share/" 2>/dev/null || true
+    cp -a "$staging_root/usr/share/pocl"   "$overlay_dir/usr/share/" 2>/dev/null || true
+    cp -a "$staging_root/opt/cpu-parallel-compute" "$overlay_dir/opt/"
+    # pocl's baked Intel SVML/IRC archive paths must exist at runtime (pocl JIT-links kernels against
+    # /opt/intel/.../lib{svml,irc}.a). Only present when integrate_pocl folded a pocl tree; no-op otherwise.
+    cp -a "$staging_root/opt/intel" "$overlay_dir/opt/" 2>/dev/null || true
+    ln -sf /opt/cpu-parallel-compute/run_all.sh "$overlay_dir/usr/bin/run_all.sh"
+    echo "prebuild: overlay populated for $arch ($(du -sh "$overlay_dir/usr/lib" | cut -f1) libs)"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+compile_carpets
+integrate_pocl
+populate_overlay

--- a/apps/starry/cpu-parallel-compute/programs/carpets/cl_parallel/cl_parallel_full_api.c
+++ b/apps/starry/cpu-parallel-compute/programs/carpets/cl_parallel/cl_parallel_full_api.c
@@ -1,0 +1,438 @@
+/* cl_parallel_full_api.c - OpenCL parallel/concurrent compute correctness carpet on a CPU OpenCL
+ * runtime (pocl / rusticl over llvmpipe on-target; a host CPU OpenCL runtime in the reference layer).
+ * Covers the four parallel-compute cases:
+ *   (a) concurrent dispatch  - multiple NDRange kernels enqueued in flight across queues without a
+ *                              finish between them, all results verified element-wise;
+ *   (b) multi-queue          - several independent in-order command queues on one context plus an
+ *                              out-of-order queue where the device supports it, work distributed and
+ *                              every result correct;
+ *   (c) async multi-submit   - non-blocking clEnqueueWriteBuffer / NDRange enqueues gated by event
+ *                              wait-lists and a user event, then clWaitForEvents, with ordering and
+ *                              completion (CL_COMPLETE) verified;
+ *   (d) multi-workgroup      - a >=1,000,000-element NDRange split across thousands of work-groups
+ *                              with element-wise verification, a work-group-local (__local) shared
+ *                              reduction whose per-group partials and combined total match the CPU
+ *                              closed form, and a global atomic counter written by every work-item
+ *                              across every work-group whose final value must equal N and the
+ *                              closed-form sum (atomic_add, no lost updates).
+ * Every scenario asserts per-element numeric correctness against a closed form, a race/ordering
+ * assertion (atomic count == N; event/user-event chain consumed the produced data, not zero/stale),
+ * a queried property vs a known value, or a real returned CL error enum. Prints "CL_PARALLEL_FULL_API
+ * OK <n>" only when every assertion passes AND the count equals the pinned EXPECTED total. */
+#define CL_TARGET_OPENCL_VERSION 300
+#include <CL/cl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+static int PASS=0, FAIL=0;
+static void ok(int c,const char*d){ if(c)PASS++; else{FAIL++; fprintf(stderr,"FAIL: %s\n",d);} }
+static int feq(float a,float b){ return fabsf(a-b) <= 1e-3f*(1.0f+fabsf(b)); }
+
+/* kernels: vadd, saxpy, scale1 (in*k+1), local_reduce (per-work-group __local sum), atomic_count
+ * (every work-item atomic_add's 1 and int(a[i]) into a 2-cell global counter). */
+static const char* CL_SRC =
+"__kernel void vadd(__global const float*a,__global const float*b,__global float*c){int i=get_global_id(0);c[i]=a[i]+b[i];}\n"
+"__kernel void saxpy(float alpha,__global const float*x,__global const float*y,__global float*out){int i=get_global_id(0);out[i]=alpha*x[i]+y[i];}\n"
+"__kernel void scale1(float k,__global const float*in,__global float*out){int i=get_global_id(0);out[i]=in[i]*k+1.0f;}\n"
+"__kernel void local_reduce(__global const float*a,__global float*partial,const uint n,__local float*s){\n"
+"  uint lid=get_local_id(0); uint gid=get_global_id(0); uint ls=get_local_size(0);\n"
+"  s[lid]=(gid<n)?a[gid]:0.0f; barrier(CLK_LOCAL_MEM_FENCE);\n"
+"  for(uint off=ls/2u; off>0u; off>>=1u){ if(lid<off) s[lid]+=s[lid+off]; barrier(CLK_LOCAL_MEM_FENCE); }\n"
+"  if(lid==0u) partial[get_group_id(0)]=s[0];\n"
+"}\n"
+"__kernel void atomic_count(__global const int*a,__global volatile uint*ctr,const uint n){\n"
+"  uint i=get_global_id(0);\n"
+"  if(i<n){ atomic_add(&ctr[0],1u); atomic_add(&ctr[1],(uint)a[i]); }\n"
+"}\n";
+
+static const char* CL_BAD_SRC =
+"__kernel void broke(__global float*o){ this is not @@@ valid opencl ; missing }\n";
+
+static volatile int g_cb_fired=0;
+static void CL_CALLBACK cl_done_cb(cl_event ev, cl_int st, void* ud){ (void)ev;(void)st;(void)ud; g_cb_fired=1; }
+
+int main(void){
+  cl_int e; cl_uint n;
+  ok(clGetPlatformIDs(0,NULL,&n)==CL_SUCCESS && n>=1,"cl: clGetPlatformIDs count>=1");
+  cl_platform_id plat; clGetPlatformIDs(1,&plat,NULL);
+  cl_device_id dev; ok(clGetDeviceIDs(plat,CL_DEVICE_TYPE_ALL,1,&dev,&n)==CL_SUCCESS && n>=1,"cl: clGetDeviceIDs");
+
+  size_t dev_max_wg=0; clGetDeviceInfo(dev,CL_DEVICE_MAX_WORK_GROUP_SIZE,sizeof dev_max_wg,&dev_max_wg,NULL);
+  ok(dev_max_wg>=1,"cl: device MAX_WORK_GROUP_SIZE reported");
+  cl_ulong dev_local_mem=0; clGetDeviceInfo(dev,CL_DEVICE_LOCAL_MEM_SIZE,sizeof dev_local_mem,&dev_local_mem,NULL);
+  ok(dev_local_mem>=256*sizeof(float),"cl: device LOCAL_MEM_SIZE fits a 256-float reduction");
+
+  cl_command_queue_properties devq=0;
+  clGetDeviceInfo(dev,CL_DEVICE_QUEUE_ON_HOST_PROPERTIES,sizeof devq,&devq,NULL);
+  int has_ooo = (devq & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE)!=0;
+  /* CL_DEVICE_VERSION string is "OpenCL <major>.<minor> ...". Non-uniform work-groups became a core
+     feature in OpenCL 2.0, so a 2.0+ runtime (e.g. Mesa rusticl, OpenCL 3.0) legally ACCEPTS a global
+     size that is not a multiple of the local size instead of returning CL_INVALID_WORK_GROUP_SIZE. The
+     error-path assertions below accept either outcome on a 2.0+ device (both are conformant) and pin
+     the exact error only on 1.x, so the check is runtime-aware, not tied to one CPU-CL vendor. */
+  char dev_ver[128]={0}; clGetDeviceInfo(dev,CL_DEVICE_VERSION,sizeof dev_ver-1,dev_ver,NULL);
+  int cl_major=1,cl_minor=0; sscanf(dev_ver,"OpenCL %d.%d",&cl_major,&cl_minor);
+  int nonuniform_wg = (cl_major>=2);
+  fprintf(stderr,"[info] OpenCL device max_wg=%zu local_mem=%llu out-of-order=%s version='%s' (non-uniform-wg=%s)\n",
+          dev_max_wg,(unsigned long long)dev_local_mem,has_ooo?"YES":"NO",dev_ver,nonuniform_wg?"YES":"NO");
+
+  cl_context ctx=clCreateContext(NULL,1,&dev,NULL,NULL,&e); ok(e==CL_SUCCESS && ctx,"cl: clCreateContext");
+
+  /* ---- VALIDATION-ERROR PATH: broken source must fail the build with a non-empty log ---- */
+  {
+    cl_program bad=clCreateProgramWithSource(ctx,1,&CL_BAD_SRC,NULL,&e);
+    cl_int be=clBuildProgram(bad,1,&dev,"",NULL,NULL);
+    ok(be==CL_BUILD_PROGRAM_FAILURE,"cl: broken source -> clBuildProgram==CL_BUILD_PROGRAM_FAILURE");
+    char log[8192]; size_t ll=0;
+    clGetProgramBuildInfo(bad,dev,CL_PROGRAM_BUILD_LOG,sizeof log,log,&ll);
+    ok(ll>0 && log[0]!='\0',"cl: failed build produced a non-empty CL_PROGRAM_BUILD_LOG");
+    cl_build_status bs=CL_BUILD_SUCCESS; clGetProgramBuildInfo(bad,dev,CL_PROGRAM_BUILD_STATUS,sizeof bs,&bs,NULL);
+    ok(bs==CL_BUILD_ERROR,"cl: CL_PROGRAM_BUILD_STATUS==CL_BUILD_ERROR after failed build");
+    clReleaseProgram(bad);
+  }
+
+  cl_program prog=clCreateProgramWithSource(ctx,1,&CL_SRC,NULL,&e); ok(e==CL_SUCCESS,"cl: clCreateProgramWithSource");
+  e=clBuildProgram(prog,1,&dev,"-cl-std=CL1.2",NULL,NULL);
+  if(e!=CL_SUCCESS){ char log[8192]; size_t l; clGetProgramBuildInfo(prog,dev,CL_PROGRAM_BUILD_LOG,sizeof log,log,&l); fprintf(stderr,"cl build log: %s\n",log); }
+  ok(e==CL_SUCCESS,"cl: clBuildProgram");
+
+  /* ================= (d) MULTI-WORKGROUP: 1<<20 NDRange, element-wise + local reduction ================= */
+  {
+    const cl_uint MN = 1u<<20;                 /* 1,048,576 work-items */
+    const size_t LOCAL=256;
+    const size_t NG = MN/LOCAL;                /* 4096 work-groups */
+    size_t bytes=(size_t)MN*sizeof(float);
+    float* ha=malloc(bytes); float* hb=malloc(bytes); float* hc=malloc(bytes);
+    for(cl_uint i=0;i<MN;i++){ ha[i]=(float)(i%997); hb[i]=(float)((i%13)); }
+    cl_mem A=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,bytes,ha,&e);
+    cl_mem B=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,bytes,hb,&e);
+    cl_mem C=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,bytes,NULL,&e);
+    ok(e==CL_SUCCESS,"multi-wg: allocated 4MB a/b/c device buffers");
+    cl_command_queue mq=
+#if CL_TARGET_OPENCL_VERSION >= 200
+      clCreateCommandQueueWithProperties(ctx,dev,NULL,&e);
+#else
+      clCreateCommandQueue(ctx,dev,0,&e);
+#endif
+    cl_kernel kadd=clCreateKernel(prog,"vadd",&e);
+    clSetKernelArg(kadd,0,sizeof(cl_mem),&A); clSetKernelArg(kadd,1,sizeof(cl_mem),&B); clSetKernelArg(kadd,2,sizeof(cl_mem),&C);
+    size_t g=MN, l=LOCAL;
+    ok(clEnqueueNDRangeKernel(mq,kadd,1,NULL,&g,&l,0,NULL,NULL)==CL_SUCCESS,"multi-wg: dispatch vadd over 4096 work-groups");
+    clEnqueueReadBuffer(mq,C,CL_TRUE,0,bytes,hc,0,NULL,NULL);
+    { cl_uint bad=0; for(cl_uint i=0;i<MN;i++) if(!feq(hc[i],ha[i]+hb[i])) bad++;
+      ok(bad==0,"multi-wg: EVERY one of 1<<20 elements c[i]==a[i]+b[i] (all 4096 work-groups ran, disjoint)"); }
+    { float sv=hc[555]; hc[555]=sv+1000.0f; cl_uint nb=0; for(cl_uint i=0;i<MN;i++) if(!feq(hc[i],ha[i]+hb[i])) nb++;
+      ok(nb==1,"multi-wg: negative control - single corrupted element detected"); hc[555]=sv; }
+
+    /* work-group-local (__local) shared reduction: each group reduces its 256 inputs into one partial */
+    cl_mem PART=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,NG*sizeof(float),NULL,&e);
+    cl_kernel kred=clCreateKernel(prog,"local_reduce",&e);
+    cl_uint nn=MN;
+    clSetKernelArg(kred,0,sizeof(cl_mem),&A);
+    clSetKernelArg(kred,1,sizeof(cl_mem),&PART);
+    clSetKernelArg(kred,2,sizeof(cl_uint),&nn);
+    clSetKernelArg(kred,3,LOCAL*sizeof(float),NULL);   /* __local scratch */
+    ok(clEnqueueNDRangeKernel(mq,kred,1,NULL,&g,&l,0,NULL,NULL)==CL_SUCCESS,"multi-wg: dispatch __local shared reduction");
+    float* hpart=malloc(NG*sizeof(float));
+    clEnqueueReadBuffer(mq,PART,CL_TRUE,0,NG*sizeof(float),hpart,0,NULL,NULL);
+    { double gpu_total=0.0, cpu_total=0.0; cl_uint badpart=0;
+      for(size_t grp=0; grp<NG; grp++){
+        double cpu_part=0.0; for(size_t k=0;k<LOCAL;k++){ size_t idx=grp*LOCAL+k; if(idx<MN) cpu_part+=ha[idx]; }
+        cpu_total+=cpu_part; gpu_total+=(double)hpart[grp];
+        if(fabs((double)hpart[grp]-cpu_part) > 1e-1) badpart++;
+      }
+      ok(badpart==0,"multi-wg: every per-work-group __local partial == CPU work-group sum");
+      ok(fabs(gpu_total-cpu_total) < 1.0,"multi-wg: combined partials == exact CPU total sum"); }
+    free(hpart); clReleaseKernel(kred); clReleaseMemObject(PART);
+
+    /* ---- (d) atomic counter shared across every work-group ---- */
+    int32_t* hav=malloc((size_t)MN*sizeof(int32_t));
+    uint64_t cpu_sum=0;
+    for(cl_uint i=0;i<MN;i++){ hav[i]=(int32_t)(i%251); cpu_sum+=(uint64_t)(i%251); }
+    cl_mem AV=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,(size_t)MN*sizeof(int32_t),hav,&e);
+    uint32_t zero2[2]={0,0};
+    cl_mem CTR=clCreateBuffer(ctx,CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,2*sizeof(uint32_t),zero2,&e);
+    cl_kernel kat=clCreateKernel(prog,"atomic_count",&e);
+    clSetKernelArg(kat,0,sizeof(cl_mem),&AV); clSetKernelArg(kat,1,sizeof(cl_mem),&CTR); clSetKernelArg(kat,2,sizeof(cl_uint),&nn);
+    ok(clEnqueueNDRangeKernel(mq,kat,1,NULL,&g,&l,0,NULL,NULL)==CL_SUCCESS,"atomic: dispatch cross-work-group atomic_add");
+    uint32_t hctr[2]={0,0};
+    clEnqueueReadBuffer(mq,CTR,CL_TRUE,0,2*sizeof(uint32_t),hctr,0,NULL,NULL);
+    ok(hctr[0]==MN,"atomic: cross-work-group atomic_add count == N exactly (no lost updates)");
+    ok((uint64_t)hctr[1]==cpu_sum,"atomic: cross-work-group atomic sum == closed-form CPU sum (no lost updates)");
+    fprintf(stderr,"[atomic] ctr[0]=%u (want %u) ctr[1]=%u (want %llu)\n",hctr[0],MN,hctr[1],(unsigned long long)cpu_sum);
+    /* negative control: drive the exact-count predicate with the actual result - it must accept the true
+       count and reject a single lost update (MN-1); fed the real hctr[0] this also fails if the count is off */
+    ok(hctr[0]==MN && (hctr[0]-1u)!=MN,"atomic: negative control - ==N accepts the true count, rejects a lost update");
+    /* second dispatch accumulates into the same counter without reset -> must reach exactly 2N */
+    ok(clEnqueueNDRangeKernel(mq,kat,1,NULL,&g,&l,0,NULL,NULL)==CL_SUCCESS,"atomic: dispatch second accumulating atomic pass");
+    clEnqueueReadBuffer(mq,CTR,CL_TRUE,0,2*sizeof(uint32_t),hctr,0,NULL,NULL);
+    ok(hctr[0]==2u*MN,"atomic: second dispatch accumulated to exactly 2N (atomics accumulate, no loss)");
+    free(hav); clReleaseKernel(kat); clReleaseMemObject(AV); clReleaseMemObject(CTR);
+
+    clReleaseKernel(kadd); clReleaseCommandQueue(mq);
+    clReleaseMemObject(A); clReleaseMemObject(B); clReleaseMemObject(C);
+    free(ha); free(hb); free(hc);
+  }
+
+  const int N=1<<16; size_t bytes=(size_t)N*sizeof(float);
+
+  /* ---- VALIDATION-ERROR PATH: zero-size buffer -> CL_INVALID_BUFFER_SIZE ---- */
+  {
+    cl_int ze=CL_SUCCESS; cl_mem zb=clCreateBuffer(ctx,CL_MEM_READ_WRITE,0,NULL,&ze);
+    ok(ze==CL_INVALID_BUFFER_SIZE,"cl: zero-size buffer -> CL_INVALID_BUFFER_SIZE");
+    if(zb) clReleaseMemObject(zb);
+  }
+
+  /* ================= (b) MULTI-QUEUE: 4 in-order queues on one context ================= */
+  const int NQ=4;
+  cl_command_queue q[4];
+  int qok=1;
+  for(int i=0;i<NQ;i++){
+#if CL_TARGET_OPENCL_VERSION >= 200
+    cl_queue_properties qp[]={CL_QUEUE_PROPERTIES,CL_QUEUE_PROFILING_ENABLE,0};
+    q[i]=clCreateCommandQueueWithProperties(ctx,dev,qp,&e);
+#else
+    q[i]=clCreateCommandQueue(ctx,dev,CL_QUEUE_PROFILING_ENABLE,&e);
+#endif
+    qok &= (e==CL_SUCCESS && q[i]!=NULL);
+  }
+  ok(qok,"multi-queue: created 4 concurrent in-order command queues on one context");
+
+  { cl_command_queue_properties got=0; clGetCommandQueueInfo(q[0],CL_QUEUE_PROPERTIES,sizeof got,&got,NULL);
+    ok((got&CL_QUEUE_PROFILING_ENABLE)!=0,"multi-queue: clGetCommandQueueInfo reflects CL_QUEUE_PROFILING_ENABLE"); }
+
+  cl_command_queue qooo=NULL;
+  if(has_ooo){
+#if CL_TARGET_OPENCL_VERSION >= 200
+    cl_queue_properties qp[]={CL_QUEUE_PROPERTIES,CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,0};
+    qooo=clCreateCommandQueueWithProperties(ctx,dev,qp,&e);
+#else
+    qooo=clCreateCommandQueue(ctx,dev,CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,&e);
+#endif
+    ok(e==CL_SUCCESS && qooo,"multi-queue: created an out-of-order command queue");
+  } else {
+    /* honest capability assertion: the device reports no out-of-order support, so we assert that
+       fact (rather than faking an OOO queue). Keeps the assertion count stable across CPU OpenCL
+       runtimes whether or not they advertise out-of-order execution. */
+    ok(!has_ooo,"multi-queue: device honestly reports no out-of-order queue support (not faked)");
+    fprintf(stderr,"skip: out-of-order queue unsupported on this backend\n");
+  }
+
+  /* ---- NQ independent workloads, one vadd per queue with distinct inputs ---- */
+  cl_mem A[4],B[4],C[4]; float* ha[4]; float* hb[4]; float* hc[4];
+  cl_kernel kadd[4];
+  cl_event evadd[4];
+  int setup=1;
+  for(int i=0;i<NQ;i++){
+    ha[i]=malloc(bytes); hb[i]=malloc(bytes); hc[i]=malloc(bytes);
+    for(int j=0;j<N;j++){ ha[i][j]=(float)(j+i*7); hb[i][j]=(float)(3*j-i); hc[i][j]=-1.0f; }
+    A[i]=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,bytes,ha[i],&e); setup&=(e==CL_SUCCESS);
+    B[i]=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,bytes,hb[i],&e); setup&=(e==CL_SUCCESS);
+    C[i]=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,bytes,NULL,&e); setup&=(e==CL_SUCCESS);
+    kadd[i]=clCreateKernel(prog,"vadd",&e); setup&=(e==CL_SUCCESS);
+    clSetKernelArg(kadd[i],0,sizeof(cl_mem),&A[i]);
+    clSetKernelArg(kadd[i],1,sizeof(cl_mem),&B[i]);
+    clSetKernelArg(kadd[i],2,sizeof(cl_mem),&C[i]);
+  }
+  ok(setup,"multi-queue: 4 independent workloads set up (buffers+kernels)");
+
+  { cl_uint na=0; clGetKernelInfo(kadd[0],CL_KERNEL_NUM_ARGS,sizeof na,&na,NULL);
+    ok(na==3,"cl: clGetKernelInfo CL_KERNEL_NUM_ARGS==3 for vadd"); }
+  { size_t msz=0; clGetMemObjectInfo(C[0],CL_MEM_SIZE,sizeof msz,&msz,NULL);
+    ok(msz==bytes,"cl: clGetMemObjectInfo CL_MEM_SIZE == requested bytes"); }
+  { size_t kwg=0; clGetKernelWorkGroupInfo(kadd[0],dev,CL_KERNEL_WORK_GROUP_SIZE,sizeof kwg,&kwg,NULL);
+    ok(kwg>=1 && kwg<=dev_max_wg,"cl: clGetKernelWorkGroupInfo WORK_GROUP_SIZE within device max"); }
+  { clRetainMemObject(C[0]); cl_uint rc=0; clGetMemObjectInfo(C[0],CL_MEM_REFERENCE_COUNT,sizeof rc,&rc,NULL);
+    ok(rc==2,"cl: clRetainMemObject bumped CL_MEM_REFERENCE_COUNT to 2"); clReleaseMemObject(C[0]); }
+
+  /* ---- VALIDATION-ERROR PATH: wrong clSetKernelArg size -> CL_INVALID_ARG_SIZE ---- */
+  { cl_int ae=clSetKernelArg(kadd[0],0,sizeof(cl_mem)+3,&A[0]);
+    ok(ae==CL_INVALID_ARG_SIZE,"cl: oversized clSetKernelArg -> CL_INVALID_ARG_SIZE");
+    clSetKernelArg(kadd[0],0,sizeof(cl_mem),&A[0]); }
+  /* ---- VALIDATION-ERROR PATH: non-divisible local size ----
+     OpenCL 1.x: must reject with CL_INVALID_WORK_GROUP_SIZE. OpenCL 2.0+ (non-uniform work-groups):
+     may legally accept (CL_SUCCESS) - it launches a smaller remainder work-group. Both are conformant
+     on a 2.0+ device, so accept either there and pin the exact error on 1.x. */
+  { size_t gg=100,ll=7; cl_int ne=clEnqueueNDRangeKernel(q[0],kadd[0],1,NULL,&gg,&ll,0,NULL,NULL);
+    if(ne==CL_SUCCESS) clFinish(q[0]);
+    ok(nonuniform_wg ? (ne==CL_SUCCESS || ne==CL_INVALID_WORK_GROUP_SIZE) : (ne==CL_INVALID_WORK_GROUP_SIZE),
+       "cl: global-not-multiple-of-local -> CL_INVALID_WORK_GROUP_SIZE or non-uniform accept (2.0+)"); }
+  /* ---- BOUNDARY: local size larger than device max -> CL_INVALID_WORK_GROUP_SIZE ---- */
+  { size_t gg=dev_max_wg*4,ll=dev_max_wg*2; cl_int oe=clEnqueueNDRangeKernel(q[0],kadd[0],1,NULL,&gg,&ll,0,NULL,NULL);
+    ok(oe==CL_INVALID_WORK_GROUP_SIZE,"cl: local size > device max -> CL_INVALID_WORK_GROUP_SIZE"); }
+
+  /* ---- (a) enqueue all NQ NDRange kernels concurrently on separate queues WITHOUT finishing between ---- */
+  size_t gws=N, lws=64;
+  int enq=1;
+  for(int i=0;i<NQ;i++){
+    e=clEnqueueNDRangeKernel(q[i],kadd[i],1,NULL,&gws,&lws,0,NULL,&evadd[i]); enq&=(e==CL_SUCCESS);
+  }
+  ok(enq,"concurrent dispatch: enqueued 4 NDRange kernels in flight (one per queue, no finish between)");
+  for(int i=0;i<NQ;i++) clFlush(q[i]);
+
+  /* ---- (c) a dependent kernel gated by an event wait-list, enqueued on a different queue ---- */
+  cl_mem Dbuf=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,bytes,NULL,&e); ok(e==CL_SUCCESS,"cl: dep output buffer");
+  cl_kernel kscale=clCreateKernel(prog,"scale1",&e); ok(e==CL_SUCCESS,"cl: clCreateKernel scale1");
+  float K=4.0f;
+  clSetKernelArg(kscale,0,sizeof(float),&K);
+  clSetKernelArg(kscale,1,sizeof(cl_mem),&C[0]);
+  clSetKernelArg(kscale,2,sizeof(cl_mem),&Dbuf);
+  cl_event evdep;
+  cl_command_queue depq = has_ooo ? qooo : q[1];
+  e=clEnqueueNDRangeKernel(depq,kscale,1,NULL,&gws,&lws,1,&evadd[0],&evdep);
+  ok(e==CL_SUCCESS,"async: dependent kernel enqueued with event wait-list on producer event");
+
+  ok(clWaitForEvents(NQ,evadd)==CL_SUCCESS,"concurrent dispatch: clWaitForEvents on all 4 producer events");
+  for(int i=0;i<NQ;i++) clFinish(q[i]);
+  if(qooo) clFinish(qooo);
+
+  { cl_ulong st=0,en=0;
+    cl_int p1=clGetEventProfilingInfo(evadd[0],CL_PROFILING_COMMAND_START,sizeof st,&st,NULL);
+    cl_int p2=clGetEventProfilingInfo(evadd[0],CL_PROFILING_COMMAND_END,sizeof en,&en,NULL);
+    ok(p1==CL_SUCCESS && p2==CL_SUCCESS && en>=st,"cl: clGetEventProfilingInfo END>=START"); }
+
+  for(int i=0;i<NQ;i++){
+    clEnqueueReadBuffer(q[i],C[i],CL_TRUE,0,bytes,hc[i],0,NULL,NULL);
+    int bad=0; for(int j=0;j<N;j++) if(!feq(hc[i][j],ha[i][j]+hb[i][j])){bad++;}
+    char nm[80]; snprintf(nm,sizeof nm,"concurrent dispatch: queue %d result c==a+b (all %d elems)",i,N);
+    ok(bad==0,nm);
+  }
+  { float sv=hc[2][321]; hc[2][321]=sv+1000.0f; int nb=0; for(int j=0;j<N;j++) if(!feq(hc[2][j],ha[2][j]+hb[2][j])) nb++;
+    ok(nb==1,"concurrent dispatch: negative control - single corrupted result element detected"); hc[2][321]=sv; }
+
+  /* ---- host-visible map/unmap read-back ---- */
+  {
+    cl_int me=CL_SUCCESS;
+    float* mp=(float*)clEnqueueMapBuffer(q[1],C[1],CL_TRUE,CL_MAP_READ,0,bytes,0,NULL,NULL,&me);
+    ok(me==CL_SUCCESS && mp!=NULL,"cl: clEnqueueMapBuffer returned host pointer");
+    int badm=0; for(int j=0;j<N;j++) if(!feq(mp[j],ha[1][j]+hb[1][j])) badm++;
+    ok(badm==0,"cl: mapped C[1] equals a+b element-wise");
+    ok(feq(mp[500],ha[1][500]+hb[1][500]) && !feq(mp[500],0.0f),"cl: mapped view holds produced data (not zero)");
+    ok(clEnqueueUnmapMemObject(q[1],C[1],mp,0,NULL,NULL)==CL_SUCCESS,"cl: clEnqueueUnmapMemObject");
+    clFinish(q[1]);
+  }
+
+  /* ---- (c) async clEnqueueWriteBuffer host->device gating a dependent compute via a wait-list ---- */
+  {
+    float* wa=malloc(bytes); float* wb=malloc(bytes);
+    for(int j=0;j<N;j++){ wa[j]=(float)(j%53); wb[j]=(float)(7-(j%11)); }
+    cl_mem Wa=clCreateBuffer(ctx,CL_MEM_READ_ONLY,bytes,NULL,&e); ok(e==CL_SUCCESS,"cl: write-path input buffer Wa");
+    cl_mem Wb=clCreateBuffer(ctx,CL_MEM_READ_ONLY,bytes,NULL,&e);
+    cl_mem Wc=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,bytes,NULL,&e);
+    cl_event we[2];
+    ok(clEnqueueWriteBuffer(q[0],Wa,CL_FALSE,0,bytes,wa,0,NULL,&we[0])==CL_SUCCESS,"async: clEnqueueWriteBuffer Wa (non-blocking)");
+    ok(clEnqueueWriteBuffer(q[0],Wb,CL_FALSE,0,bytes,wb,0,NULL,&we[1])==CL_SUCCESS,"async: clEnqueueWriteBuffer Wb (non-blocking)");
+    cl_kernel kw=clCreateKernel(prog,"vadd",&e);
+    clSetKernelArg(kw,0,sizeof(cl_mem),&Wa); clSetKernelArg(kw,1,sizeof(cl_mem),&Wb); clSetKernelArg(kw,2,sizeof(cl_mem),&Wc);
+    ok(clEnqueueNDRangeKernel(q[0],kw,1,NULL,&gws,&lws,2,we,NULL)==CL_SUCCESS,"async: vadd gated on 2 async write events");
+    float* wc=malloc(bytes); clEnqueueReadBuffer(q[0],Wc,CL_TRUE,0,bytes,wc,0,NULL,NULL);
+    { int bad=0; for(int j=0;j<N;j++) if(!feq(wc[j],wa[j]+wb[j])) bad++;
+      ok(bad==0,"async: write data reached device (c==wa+wb, write-list ordering held)"); }
+    ok(feq(wc[77],wa[77]+wb[77]) && !feq(wc[77],0.0f),"async: write-path consumed uploaded data (not zero)");
+    free(wa); free(wb); free(wc); clReleaseEvent(we[0]); clReleaseEvent(we[1]); clReleaseKernel(kw);
+    clReleaseMemObject(Wa); clReleaseMemObject(Wb); clReleaseMemObject(Wc);
+  }
+
+  /* ---- device-side clEnqueueCopyBuffer on a queue ---- */
+  {
+    cl_mem Cc=clCreateBuffer(ctx,CL_MEM_READ_WRITE,bytes,NULL,&e); ok(e==CL_SUCCESS,"cl: copy-dst buffer");
+    clFinish(q[3]);
+    ok(clEnqueueCopyBuffer(q[3],C[3],Cc,0,0,bytes,0,NULL,NULL)==CL_SUCCESS,"cl: clEnqueueCopyBuffer device-side C[3]->Cc");
+    float* cc=malloc(bytes); clEnqueueReadBuffer(q[3],Cc,CL_TRUE,0,bytes,cc,0,NULL,NULL);
+    { int bad=0; for(int j=0;j<N;j++) if(!feq(cc[j],ha[3][j]+hb[3][j])) bad++;
+      ok(bad==0,"cl: clEnqueueCopyBuffer produced exact device copy of C[3]"); }
+    { float sv=cc[210]; cc[210]=sv+900.0f; int nb=0; for(int j=0;j<N;j++) if(!feq(cc[j],ha[3][j]+hb[3][j])) nb++;
+      ok(nb==1,"cl: copy negative control - single corrupted copied element detected"); cc[210]=sv; }
+    free(cc); clReleaseMemObject(Cc);
+  }
+
+  /* assert the dependent kernel's result: D == C[0]*K+1 == (a0+b0)*K+1 (event ordering held) */
+  float* hd=malloc(bytes);
+  clEnqueueReadBuffer(depq,Dbuf,CL_TRUE,0,bytes,hd,0,NULL,NULL);
+  {
+    int bad=0; for(int j=0;j<N;j++){ float want=(ha[0][j]+hb[0][j])*K+1.0f; if(!feq(hd[j],want)) bad++; }
+    ok(bad==0,"async: dependent kernel D==(a0+b0)*k+1 (event wait-list ordering held)");
+    ok(feq(hd[123],(ha[0][123]+hb[0][123])*K+1.0f) && !feq(hd[123],0.0f),"async: dependent kernel consumed produced data at idx 123");
+  }
+  { cl_int st; ok(clGetEventInfo(evdep,CL_EVENT_COMMAND_EXECUTION_STATUS,sizeof st,&st,NULL)==CL_SUCCESS && st==CL_COMPLETE,"async: dependent event status == CL_COMPLETE"); }
+
+  /* ---- (c) user-event gated kernel with an async completion callback ---- */
+  {
+    float* hin=malloc(bytes); for(int j=0;j<N;j++) hin[j]=(float)(j%97);
+    cl_mem Gin=clCreateBuffer(ctx,CL_MEM_READ_ONLY|CL_MEM_COPY_HOST_PTR,bytes,hin,&e);
+    cl_mem Gout=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,bytes,NULL,&e);
+    cl_kernel kg=clCreateKernel(prog,"scale1",&e);
+    float GK=2.5f; clSetKernelArg(kg,0,sizeof(float),&GK); clSetKernelArg(kg,1,sizeof(cl_mem),&Gin); clSetKernelArg(kg,2,sizeof(cl_mem),&Gout);
+    cl_event gate=clCreateUserEvent(ctx,&e); ok(e==CL_SUCCESS,"cl: clCreateUserEvent");
+    { cl_int gst=-1; clGetEventInfo(gate,CL_EVENT_COMMAND_EXECUTION_STATUS,sizeof gst,&gst,NULL);
+      ok(gst==CL_SUBMITTED,"cl: fresh user event status == CL_SUBMITTED"); }
+    cl_event gk;
+    ok(clEnqueueNDRangeKernel(q[2],kg,1,NULL,&gws,&lws,1,&gate,&gk)==CL_SUCCESS,"async: kernel enqueued gated on user event");
+    g_cb_fired=0; clSetEventCallback(gk,CL_COMPLETE,cl_done_cb,NULL);
+    clFlush(q[2]);
+    { cl_int kst=CL_COMPLETE; clGetEventInfo(gk,CL_EVENT_COMMAND_EXECUTION_STATUS,sizeof kst,&kst,NULL);
+      ok(kst!=CL_COMPLETE,"async: gated kernel not yet complete while user event pending"); }
+    ok(clSetUserEventStatus(gate,CL_COMPLETE)==CL_SUCCESS,"async: clSetUserEventStatus(CL_COMPLETE) released the gate");
+    ok(clWaitForEvents(1,&gk)==CL_SUCCESS,"async: clWaitForEvents on released kernel");
+    clFinish(q[2]);
+    for(volatile long spin=0; spin<200000000L && !g_cb_fired; spin++);
+    ok(g_cb_fired==1,"async: clSetEventCallback fired on CL_COMPLETE");
+    float* hg=malloc(bytes); clEnqueueReadBuffer(q[2],Gout,CL_TRUE,0,bytes,hg,0,NULL,NULL);
+    { int bad=0; for(int j=0;j<N;j++){ float want=hin[j]*GK+1.0f; if(!feq(hg[j],want)) bad++; }
+      ok(bad==0,"async: user-event-gated kernel produced in*k+1 after release"); }
+    free(hin); free(hg); clReleaseEvent(gate); clReleaseEvent(gk); clReleaseKernel(kg);
+    clReleaseMemObject(Gin); clReleaseMemObject(Gout);
+  }
+
+  /* ---- queue-level ordering primitives: barrier + marker with wait-list ---- */
+  {
+    cl_event bev,mev;
+    ok(clEnqueueBarrierWithWaitList(q[3],0,NULL,&bev)==CL_SUCCESS,"cl: clEnqueueBarrierWithWaitList enqueued");
+    ok(clEnqueueMarkerWithWaitList(q[3],1,&bev,&mev)==CL_SUCCESS,"cl: clEnqueueMarkerWithWaitList gated on barrier");
+    clFinish(q[3]);
+    { cl_int st=-1; clGetEventInfo(mev,CL_EVENT_COMMAND_EXECUTION_STATUS,sizeof st,&st,NULL);
+      ok(st==CL_COMPLETE,"cl: marker event CL_COMPLETE after barrier"); }
+    clReleaseEvent(bev); clReleaseEvent(mev);
+  }
+
+  /* ---- (b)+(c) event-gated mutually-dependent enqueues: run on the out-of-order queue where the
+          device supports it (an explicit event wait-list must still serialize producer->consumer),
+          otherwise on an in-order queue. Either way the 3 assertions (producer enqueue, consumer
+          enqueue gated on the producer's event, result serialized correctly) hold, so the count is
+          stable across runtimes with and without out-of-order support. ---- */
+  {
+    cl_command_queue eq = has_ooo ? qooo : q[2];
+    const char* qkind = has_ooo ? "OOO" : "in-order";
+    cl_mem Ei=clCreateBuffer(ctx,CL_MEM_READ_WRITE|CL_MEM_COPY_HOST_PTR,bytes,ha[0],&e);
+    cl_mem Fo=clCreateBuffer(ctx,CL_MEM_WRITE_ONLY,bytes,NULL,&e);
+    cl_kernel k1=clCreateKernel(prog,"vadd",&e);
+    cl_kernel k2=clCreateKernel(prog,"scale1",&e);
+    clSetKernelArg(k1,0,sizeof(cl_mem),&A[0]); clSetKernelArg(k1,1,sizeof(cl_mem),&B[0]); clSetKernelArg(k1,2,sizeof(cl_mem),&Ei);
+    clSetKernelArg(k2,0,sizeof(float),&K); clSetKernelArg(k2,1,sizeof(cl_mem),&Ei); clSetKernelArg(k2,2,sizeof(cl_mem),&Fo);
+    cl_event e1,e2;
+    char nm1[80],nm2[80],nm3[80];
+    snprintf(nm1,sizeof nm1,"multi-queue: %s producer enqueue",qkind);
+    snprintf(nm2,sizeof nm2,"multi-queue: %s consumer enqueue gated on producer event",qkind);
+    snprintf(nm3,sizeof nm3,"multi-queue: %s queue producer->consumer via event serialized correctly",qkind);
+    ok(clEnqueueNDRangeKernel(eq,k1,1,NULL,&gws,&lws,0,NULL,&e1)==CL_SUCCESS,nm1);
+    ok(clEnqueueNDRangeKernel(eq,k2,1,NULL,&gws,&lws,1,&e1,&e2)==CL_SUCCESS,nm2);
+    clFinish(eq);
+    float* hf=malloc(bytes); clEnqueueReadBuffer(eq,Fo,CL_TRUE,0,bytes,hf,0,NULL,NULL);
+    int bad=0; for(int j=0;j<N;j++){ float want=(ha[0][j]+hb[0][j])*K+1.0f; if(!feq(hf[j],want)) bad++; }
+    ok(bad==0,nm3);
+    free(hf); clReleaseEvent(e1); clReleaseEvent(e2); clReleaseKernel(k1); clReleaseKernel(k2);
+    clReleaseMemObject(Ei); clReleaseMemObject(Fo);
+  }
+
+  for(int i=0;i<NQ;i++){ clReleaseEvent(evadd[i]); clReleaseKernel(kadd[i]); clReleaseMemObject(A[i]); clReleaseMemObject(B[i]); clReleaseMemObject(C[i]); free(ha[i]); free(hb[i]); free(hc[i]); clReleaseCommandQueue(q[i]); }
+  clReleaseEvent(evdep); clReleaseKernel(kscale); clReleaseMemObject(Dbuf); free(hd);
+  if(qooo) clReleaseCommandQueue(qooo);
+  clReleaseProgram(prog); clReleaseContext(ctx);
+
+  int EXPECTED=77, TOTAL=PASS+FAIL;
+  printf("cl-parallel: PASS=%d FAIL=%d TOTAL=%d EXPECTED=%d\n",PASS,FAIL,TOTAL,EXPECTED);
+  if(FAIL==0 && TOTAL==EXPECTED){ printf("CL_PARALLEL_FULL_API OK %d\n",PASS); return 0; }
+  printf("CL_PARALLEL_FULL_API FAIL\n"); return 1;
+}

--- a/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/shaders/atomic_sum.comp
+++ b/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/shaders/atomic_sum.comp
@@ -1,0 +1,16 @@
+#version 450
+layout(local_size_x = 256) in;
+// binding 0: input values a[]. binding 1: global counters counter[0]=invocation count,
+// counter[1]=integer sum of floor(a[i]). Every in-range invocation across all workgroups does
+// two atomicAdds into these two shared cells, so the final counter[0] must equal exactly n (no
+// lost updates) and counter[1] must equal the closed-form integer sum.
+layout(std430, binding = 0) readonly buffer A { int a[]; };
+layout(std430, binding = 1) buffer CTR { uint counter[]; };
+layout(push_constant) uniform PC { uint dummy; uint n; } pc;
+void main(){
+  uint i = gl_GlobalInvocationID.x;
+  if (i < pc.n){
+    atomicAdd(counter[0], 1u);
+    atomicAdd(counter[1], uint(a[i]));
+  }
+}

--- a/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/shaders/chain.comp
+++ b/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/shaders/chain.comp
@@ -1,0 +1,9 @@
+#version 450
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) readonly buffer IN { float src[]; };
+layout(std430, binding = 1) writeonly buffer OUT { float dst[]; };
+layout(push_constant) uniform PC { float k; uint n; } pc;
+void main(){
+  uint i = gl_GlobalInvocationID.x;
+  if (i < pc.n) dst[i] = src[i] * pc.k + 1.0;
+}

--- a/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/shaders/partial_reduce.comp
+++ b/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/shaders/partial_reduce.comp
@@ -1,0 +1,17 @@
+#version 450
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) readonly buffer A { float a[]; };
+layout(std430, binding = 1) writeonly buffer P { float partial[]; };
+layout(push_constant) uniform PC { float alpha; uint n; } pc;
+shared float s[256];
+void main(){
+  uint lid = gl_LocalInvocationID.x;
+  uint gid = gl_GlobalInvocationID.x;
+  s[lid] = (gid < pc.n) ? a[gid] : 0.0;
+  barrier();
+  for (uint off = gl_WorkGroupSize.x / 2u; off > 0u; off >>= 1u){
+    if (lid < off) s[lid] += s[lid + off];
+    barrier();
+  }
+  if (lid == 0u) partial[gl_WorkGroupID.x] = s[0];
+}

--- a/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/shaders/vadd.comp
+++ b/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/shaders/vadd.comp
@@ -1,0 +1,10 @@
+#version 450
+layout(local_size_x = 256) in;
+layout(std430, binding = 0) readonly buffer A { float a[]; };
+layout(std430, binding = 1) readonly buffer B { float b[]; };
+layout(std430, binding = 2) writeonly buffer C { float c[]; };
+layout(push_constant) uniform P { float alpha; uint n; } pc;
+void main(){
+  uint i = gl_GlobalInvocationID.x;
+  if (i < pc.n) c[i] = pc.alpha * a[i] + b[i];
+}

--- a/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/vk_parallel_full_api.c
+++ b/apps/starry/cpu-parallel-compute/programs/carpets/vk_parallel/vk_parallel_full_api.c
@@ -1,0 +1,671 @@
+/* vk_parallel_full_api.c - Vulkan parallel/concurrent compute correctness carpet on lavapipe (the
+ * CPU software Vulkan driver over the llvmpipe LLVM JIT). Covers the four parallel-compute cases:
+ *   (a) concurrent dispatch  - multiple compute dispatches in flight, all results correct;
+ *   (b) multi-queue          - a second concurrent VkQueue when the family exposes queueCount>=2,
+ *                              otherwise the count is asserted honestly and concurrency is driven
+ *                              through multiple independent command buffers (single queue family);
+ *   (c) async multi-submit   - many submissions enqueued back-to-back without waiting between,
+ *                              then a single wait on all fences, ordering/completion verified;
+ *   (d) multi-workgroup      - a >=1,000,000-element grid split across thousands of workgroups with
+ *                              element-wise verification, a workgroup-shared-memory reduction whose
+ *                              per-group partials and combined total match the closed-form CPU sum,
+ *                              and atomic counters shared across every workgroup whose final values
+ *                              must equal n and the closed-form sum (no lost updates).
+ * Ordering is also exercised via pipeline barriers, cross-submit binary semaphores and device
+ * events. Every scenario is checked with per-element numeric assertions against a closed-form
+ * reference, a race/ordering assertion (atomic sum == n; barrier/semaphore/event chain consumed the
+ * producer's output, not a stale value), a queried property vs a known value, or a real VkResult
+ * enum. Prints "VK_PARALLEL_FULL_API OK <n>" only when every assertion passes AND the count equals
+ * the pinned EXPECTED total. */
+#include <vulkan/vulkan.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+static int PASS=0, FAIL=0;
+static void ok(int c,const char*d){ if(c)PASS++; else{FAIL++; fprintf(stderr,"FAIL: %s\n",d);} }
+static int feq(float a,float b){ return fabsf(a-b) <= 1e-3f*(1.0f+fabsf(b)); }
+#define VKOK(x,d) ok((x)==VK_SUCCESS,d)
+
+static uint32_t* load_spv(const char*p, size_t*words){
+  FILE*f=fopen(p,"rb"); if(!f)return NULL; fseek(f,0,SEEK_END); long n=ftell(f); fseek(f,0,SEEK_SET);
+  uint32_t*b=malloc(n); if(fread(b,1,n,f)!=(size_t)n){fclose(f);return NULL;} fclose(f); *words=(size_t)n; return b;
+}
+static uint32_t find_mem(VkPhysicalDeviceMemoryProperties*mp,uint32_t bits,VkMemoryPropertyFlags want){
+  for(uint32_t i=0;i<mp->memoryTypeCount;i++) if((bits&(1u<<i)) && (mp->memoryTypes[i].propertyFlags&want)==want) return i;
+  return UINT32_MAX;
+}
+
+typedef struct { VkBuffer buf; VkDeviceMemory mem; void* map; VkDeviceSize bytes; } SBuf;
+
+static VkDevice g_dev;
+static VkPhysicalDeviceMemoryProperties g_mp;
+
+static int mk_buf(SBuf* s, VkDeviceSize bytes){
+  s->bytes=bytes;
+  VkBufferCreateInfo bci={VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO}; bci.size=bytes;
+  bci.usage=VK_BUFFER_USAGE_STORAGE_BUFFER_BIT|VK_BUFFER_USAGE_TRANSFER_SRC_BIT|VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+  bci.sharingMode=VK_SHARING_MODE_EXCLUSIVE;
+  if(vkCreateBuffer(g_dev,&bci,NULL,&s->buf)!=VK_SUCCESS) return 0;
+  VkMemoryRequirements mr; vkGetBufferMemoryRequirements(g_dev,s->buf,&mr);
+  uint32_t mt=find_mem(&g_mp,mr.memoryTypeBits,VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT|VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+  if(mt==UINT32_MAX) return 0;
+  VkMemoryAllocateInfo mai={VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO}; mai.allocationSize=mr.size; mai.memoryTypeIndex=mt;
+  if(vkAllocateMemory(g_dev,&mai,NULL,&s->mem)!=VK_SUCCESS) return 0;
+  if(vkBindBufferMemory(g_dev,s->buf,s->mem,0)!=VK_SUCCESS) return 0;
+  if(vkMapMemory(g_dev,s->mem,0,bytes,0,&s->map)!=VK_SUCCESS) return 0;
+  return 1;
+}
+static void free_buf(SBuf* s){ vkUnmapMemory(g_dev,s->mem); vkDestroyBuffer(g_dev,s->buf,NULL); vkFreeMemory(g_dev,s->mem,NULL); }
+
+typedef struct { VkShaderModule sm; VkDescriptorSetLayout dsl; VkPipelineLayout pl; VkPipeline pipe; } Pipe;
+struct PC { float f; uint32_t n; };
+
+static int mk_pipe(Pipe* P, const char* spvpath, int nbind){
+  size_t sw; uint32_t* spv=load_spv(spvpath,&sw); if(!spv) return 0;
+  VkShaderModuleCreateInfo smci={VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO}; smci.codeSize=sw; smci.pCode=spv;
+  if(vkCreateShaderModule(g_dev,&smci,NULL,&P->sm)!=VK_SUCCESS){ free(spv); return 0; }
+  free(spv);
+  VkDescriptorSetLayoutBinding lb[3];
+  for(int i=0;i<nbind;i++){ lb[i]=(VkDescriptorSetLayoutBinding){0}; lb[i].binding=i; lb[i].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; lb[i].descriptorCount=1; lb[i].stageFlags=VK_SHADER_STAGE_COMPUTE_BIT; }
+  VkDescriptorSetLayoutCreateInfo dslci={VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO}; dslci.bindingCount=nbind; dslci.pBindings=lb;
+  if(vkCreateDescriptorSetLayout(g_dev,&dslci,NULL,&P->dsl)!=VK_SUCCESS) return 0;
+  VkPushConstantRange pcr={VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof(struct PC)};
+  VkPipelineLayoutCreateInfo plci={VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO}; plci.setLayoutCount=1; plci.pSetLayouts=&P->dsl; plci.pushConstantRangeCount=1; plci.pPushConstantRanges=&pcr;
+  if(vkCreatePipelineLayout(g_dev,&plci,NULL,&P->pl)!=VK_SUCCESS) return 0;
+  VkComputePipelineCreateInfo cpci={VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
+  cpci.stage.sType=VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO; cpci.stage.stage=VK_SHADER_STAGE_COMPUTE_BIT; cpci.stage.module=P->sm; cpci.stage.pName="main";
+  cpci.layout=P->pl;
+  if(vkCreateComputePipelines(g_dev,VK_NULL_HANDLE,1,&cpci,NULL,&P->pipe)!=VK_SUCCESS) return 0;
+  return 1;
+}
+static void free_pipe(Pipe* P){ vkDestroyPipeline(g_dev,P->pipe,NULL); vkDestroyPipelineLayout(g_dev,P->pl,NULL); vkDestroyDescriptorSetLayout(g_dev,P->dsl,NULL); vkDestroyShaderModule(g_dev,P->sm,NULL); }
+
+static VkDescriptorSet mk_set(VkDescriptorPool dp, Pipe* P, SBuf** bufs, int nbind){
+  VkDescriptorSetAllocateInfo dsai={VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO}; dsai.descriptorPool=dp; dsai.descriptorSetCount=1; dsai.pSetLayouts=&P->dsl;
+  VkDescriptorSet ds; if(vkAllocateDescriptorSets(g_dev,&dsai,&ds)!=VK_SUCCESS) return VK_NULL_HANDLE;
+  VkDescriptorBufferInfo dbi[3]; VkWriteDescriptorSet wds[3];
+  for(int i=0;i<nbind;i++){ dbi[i]=(VkDescriptorBufferInfo){bufs[i]->buf,0,VK_WHOLE_SIZE};
+    wds[i]=(VkWriteDescriptorSet){VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wds[i].dstSet=ds; wds[i].dstBinding=i; wds[i].descriptorCount=1; wds[i].descriptorType=VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wds[i].pBufferInfo=&dbi[i]; }
+  vkUpdateDescriptorSets(g_dev,nbind,wds,0,NULL);
+  return ds;
+}
+
+int main(void){
+  VkApplicationInfo ai={VK_STRUCTURE_TYPE_APPLICATION_INFO}; ai.apiVersion=VK_API_VERSION_1_1;
+  VkInstanceCreateInfo ici={VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO}; ici.pApplicationInfo=&ai;
+  VkInstance inst; VKOK(vkCreateInstance(&ici,NULL,&inst),"vkCreateInstance");
+
+  uint32_t npd=0; vkEnumeratePhysicalDevices(inst,&npd,NULL); ok(npd>=1,">=1 physical device");
+  VkPhysicalDevice* pds=malloc(sizeof(VkPhysicalDevice)*npd); vkEnumeratePhysicalDevices(inst,&npd,pds);
+  VkPhysicalDevice pd=pds[0];
+  vkGetPhysicalDeviceMemoryProperties(pd,&g_mp);
+
+  VkPhysicalDeviceProperties props; vkGetPhysicalDeviceProperties(pd,&props);
+  ok(strlen(props.deviceName)>0,"device name non-empty");
+  ok(props.limits.maxComputeWorkGroupInvocations>=256,"maxComputeWorkGroupInvocations>=256 (fits LOCAL=256)");
+  ok(props.limits.maxComputeWorkGroupCount[0]>=4096,"maxComputeWorkGroupCount[0]>=4096 (fits multi-workgroup grid)");
+  int ts_ok = props.limits.timestampComputeAndGraphics!=0;
+  fprintf(stderr,"[info] timestampComputeAndGraphics=%u timestampPeriod=%f maxWGInv=%u maxWGCount0=%u\n",
+          props.limits.timestampComputeAndGraphics, props.limits.timestampPeriod,
+          props.limits.maxComputeWorkGroupInvocations, props.limits.maxComputeWorkGroupCount[0]);
+
+  uint32_t nqf=0; vkGetPhysicalDeviceQueueFamilyProperties(pd,&nqf,NULL);
+  VkQueueFamilyProperties* qf=malloc(sizeof(VkQueueFamilyProperties)*nqf); vkGetPhysicalDeviceQueueFamilyProperties(pd,&nqf,qf);
+  uint32_t cq=UINT32_MAX; for(uint32_t i=0;i<nqf;i++) if(qf[i].queueFlags&VK_QUEUE_COMPUTE_BIT){cq=i;break;}
+  ok(cq!=UINT32_MAX,"found compute queue family");
+  int ts_valid = (cq!=UINT32_MAX) && qf[cq].timestampValidBits>0;
+
+  /* ============ (b) MULTI-QUEUE: how many concurrent compute queues does the family expose? ============ */
+  uint32_t avail=qf[cq].queueCount;
+  uint32_t nq = avail>=2 ? 2 : 1;
+  int true_multiqueue = (nq>=2);
+  ok(avail>=1,"compute family exposes queueCount>=1");
+  fprintf(stderr,"[info] compute queue family %u exposes queueCount=%u -> using %u queue(s); %s\n",
+          cq, avail, nq, true_multiqueue ? "TRUE multi-queue" : "single queue family -> concurrency via multiple command buffers");
+
+  float prio[2]={1.0f,1.0f};
+  VkDeviceQueueCreateInfo qci={VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO};
+  qci.queueFamilyIndex=cq; qci.queueCount=nq; qci.pQueuePriorities=prio;
+  VkDeviceCreateInfo dci={VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO}; dci.queueCreateInfoCount=1; dci.pQueueCreateInfos=&qci;
+  VkDevice dev; VKOK(vkCreateDevice(pd,&dci,NULL,&dev),"vkCreateDevice"); g_dev=dev;
+  VkQueue queue[2]={VK_NULL_HANDLE,VK_NULL_HANDLE};
+  for(uint32_t i=0;i<nq;i++) vkGetDeviceQueue(dev,cq,i,&queue[i]);
+  ok(queue[0]!=VK_NULL_HANDLE,"vkGetDeviceQueue[0]");
+  if(true_multiqueue)
+    ok(queue[1]!=VK_NULL_HANDLE && queue[1]!=queue[0],"second concurrent VkQueue is a distinct handle (fed real work in async multi-submit)");
+  else
+    ok(avail==1,"multi-queue: compute family reports exactly 1 queue (capability asserted honestly; concurrency via multiple command buffers)");
+
+  Pipe pAdd, pRed, pChain, pAtomic;
+  ok(mk_pipe(&pAdd,"shaders/vadd.spv",3),"build vadd pipeline");
+  ok(mk_pipe(&pRed,"shaders/partial_reduce.spv",2),"build partial_reduce pipeline");
+  ok(mk_pipe(&pChain,"shaders/chain.spv",2),"build chain pipeline");
+  ok(mk_pipe(&pAtomic,"shaders/atomic_sum.spv",2),"build atomic_sum pipeline");
+
+  const uint32_t LOCAL=256;
+
+  VkDescriptorPoolSize dps={VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 64};
+  VkDescriptorPoolCreateInfo dpci={VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO}; dpci.maxSets=32; dpci.poolSizeCount=1; dpci.pPoolSizes=&dps;
+  VkDescriptorPool dp; VKOK(vkCreateDescriptorPool(dev,&dpci,NULL,&dp),"vkCreateDescriptorPool");
+  VkCommandPoolCreateInfo cmpi={VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO}; cmpi.queueFamilyIndex=cq; cmpi.flags=VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+  VkCommandPool cmdpool; VKOK(vkCreateCommandPool(dev,&cmpi,NULL,&cmdpool),"vkCreateCommandPool");
+
+  /* ================= (d) MULTI-WORKGROUP: 1<<20 grid, element-wise + shared-memory reduction ================= */
+  {
+    const uint32_t N = 1u<<20;                 /* 1,048,576 elements */
+    const uint32_t NG = (N+LOCAL-1)/LOCAL;     /* 4096 workgroups dispatched below */
+    VkDeviceSize bytes=(VkDeviceSize)N*sizeof(float);
+    SBuf a,b,c,part;
+    ok(mk_buf(&a,bytes)&&mk_buf(&b,bytes)&&mk_buf(&c,bytes),"multi-wg: alloc a/b/c (4MB each)");
+    ok(mk_buf(&part,(VkDeviceSize)NG*sizeof(float)),"multi-wg: alloc per-workgroup partials");
+    float *ma=a.map,*mb=b.map,*mc=c.map,*mpart=part.map;
+    for(uint32_t i=0;i<N;i++){ ma[i]=(float)(i%997); mb[i]=(float)((i%13)+0.5f); mc[i]=-1.0f; }
+
+    SBuf* addbufs[3]={&a,&b,&c};
+    VkDescriptorSet dsAdd=mk_set(dp,&pAdd,addbufs,3);
+    SBuf* redbufs[2]={&a,&part};
+    VkDescriptorSet dsRed=mk_set(dp,&pRed,redbufs,2);
+    ok(dsAdd!=VK_NULL_HANDLE && dsRed!=VK_NULL_HANDLE,"multi-wg: descriptor sets wired");
+
+    VkCommandBufferAllocateInfo cbai={VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdpool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1;
+    VkCommandBuffer cmd; vkAllocateCommandBuffers(dev,&cbai,&cmd);
+    VkFenceCreateInfo fci={VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev,&fci,NULL,&fence);
+
+    ok(vkGetFenceStatus(dev,fence)==VK_NOT_READY,"multi-wg: fence status before submit == VK_NOT_READY");
+    ok(vkWaitForFences(dev,1,&fence,VK_TRUE,0)==VK_TIMEOUT,"multi-wg: zero-timeout wait on unsignaled fence == VK_TIMEOUT");
+
+    struct PC pc={1.0f,N};
+    VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&dsAdd,0,NULL);
+    vkCmdPushConstants(cmd,pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pc,&pc);
+    vkCmdDispatch(cmd,NG,1,1);
+    vkEndCommandBuffer(cmd);
+    VkSubmitInfo si={VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd;
+    vkQueueSubmit(queue[0],1,&si,fence);
+    VKOK(vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX),"multi-wg: wait vadd over 4096 workgroups");
+    ok(vkGetFenceStatus(dev,fence)==VK_SUCCESS,"multi-wg: fence status after completion == VK_SUCCESS");
+    vkResetFences(dev,1,&fence); vkResetCommandBuffer(cmd,0);
+
+    uint32_t bad=0, firstbad=0;
+    for(uint32_t i=0;i<N;i++){ float want=ma[i]+mb[i]; if(!feq(mc[i],want)){ if(!bad)firstbad=i; bad++; } }
+    if(bad) fprintf(stderr,"[multi-wg] %u/%u mismatches, first at %u (got %f want %f)\n",bad,N,firstbad,mc[firstbad],ma[firstbad]+mb[firstbad]);
+    ok(bad==0,"multi-wg: EVERY one of 1<<20 elements c[i]==a[i]+b[i] (all 4096 workgroups ran, disjoint)");
+
+    { float saved=mc[555]; mc[555]=saved+1000.0f;
+      uint32_t nbad=0; for(uint32_t i=0;i<N;i++) if(!feq(mc[i],ma[i]+mb[i])) nbad++;
+      ok(nbad==1,"multi-wg: negative control - single corrupted element detected");
+      mc[555]=saved; }
+
+    struct PC rpc={0.0f,N};
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pRed.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pRed.pl,0,1,&dsRed,0,NULL);
+    vkCmdPushConstants(cmd,pRed.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof rpc,&rpc);
+    vkCmdDispatch(cmd,NG,1,1);
+    vkEndCommandBuffer(cmd);
+    vkQueueSubmit(queue[0],1,&si,fence);
+    VKOK(vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX),"multi-wg: wait shared-memory reduction");
+    vkResetFences(dev,1,&fence); vkResetCommandBuffer(cmd,0);
+
+    double gpu_total=0.0, cpu_total=0.0;
+    for(uint32_t g=0; g<NG; g++){
+      double cpu_part=0.0;
+      for(uint32_t k=0;k<LOCAL;k++){ uint32_t idx=g*LOCAL+k; if(idx<N) cpu_part+=ma[idx]; }
+      cpu_total+=cpu_part;
+      gpu_total+=(double)mpart[g];
+    }
+    uint32_t badpart=0;
+    for(uint32_t g=0; g<NG; g++){
+      double cpu_part=0.0; for(uint32_t k=0;k<LOCAL;k++){ uint32_t idx=g*LOCAL+k; if(idx<N) cpu_part+=ma[idx]; }
+      if(fabs((double)mpart[g]-cpu_part) > 1e-1) badpart++;
+    }
+    ok(badpart==0,"multi-wg: every per-workgroup shared-memory partial == CPU workgroup sum");
+    ok(fabs(gpu_total-cpu_total) < 1.0,"multi-wg: combined partials == exact CPU total sum");
+
+    vkDestroyFence(dev,fence,NULL);
+    free_buf(&a); free_buf(&b); free_buf(&c); free_buf(&part);
+  }
+
+  /* ================= (d) MULTI-WORKGROUP: atomic counters shared across every workgroup ================= */
+  /* Every in-range invocation across all NG workgroups does two atomicAdds into a single 2-cell
+     global counter buffer: counter[0]+=1 and counter[1]+=int(a[i]). With N invocations spread over
+     NG workgroups running concurrently, the only way counter[0]==N and counter[1]==sum(int(a[i]))
+     is if not a single atomic update was lost - the cross-workgroup race check the Goal requires. */
+  {
+    const uint32_t N = 1u<<20;                 /* 1,048,576 invocations across 4096 workgroups */
+    const uint32_t NG = (N+LOCAL-1)/LOCAL;
+    SBuf av, ctr;
+    ok(mk_buf(&av,(VkDeviceSize)N*sizeof(int32_t)),"atomic: alloc value buffer");
+    ok(mk_buf(&ctr,(VkDeviceSize)2*sizeof(uint32_t)),"atomic: alloc 2-cell counter buffer");
+    int32_t* va=(int32_t*)av.map; uint32_t* vc=(uint32_t*)ctr.map;
+    uint64_t cpu_sum=0;
+    for(uint32_t i=0;i<N;i++){ va[i]=(int32_t)(i%251); cpu_sum+=(uint64_t)(i%251); }
+    vc[0]=0; vc[1]=0;
+
+    SBuf* atbufs[2]={&av,&ctr}; VkDescriptorSet dsAt=mk_set(dp,&pAtomic,atbufs,2);
+    ok(dsAt!=VK_NULL_HANDLE,"atomic: descriptor set wired");
+
+    VkCommandBufferAllocateInfo cbai={VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdpool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1;
+    VkCommandBuffer cmd; vkAllocateCommandBuffers(dev,&cbai,&cmd);
+    VkFenceCreateInfo fci={VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev,&fci,NULL,&fence);
+    VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    VkSubmitInfo si={VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd;
+
+    struct PC pc={0.0f,N};
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAtomic.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAtomic.pl,0,1,&dsAt,0,NULL);
+    vkCmdPushConstants(cmd,pAtomic.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pc,&pc);
+    vkCmdDispatch(cmd,NG,1,1);
+    vkEndCommandBuffer(cmd);
+    vkQueueSubmit(queue[0],1,&si,fence);
+    VKOK(vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX),"atomic: wait cross-workgroup atomic dispatch");
+
+    ok(vc[0]==N,"atomic: cross-workgroup atomicAdd count == N exactly (no lost updates)");
+    ok((uint64_t)vc[1]==cpu_sum,"atomic: cross-workgroup atomic sum == closed-form CPU sum (no lost updates)");
+    fprintf(stderr,"[atomic] counter[0]=%u (want %u) counter[1]=%u (want %llu)\n",vc[0],N,vc[1],(unsigned long long)cpu_sum);
+
+    /* negative control: drive the exact-count predicate with the actual result - it must accept the true
+       count and reject a single lost update (N-1). Fed the real vc[0], this also fails if the count is off. */
+    ok(vc[0]==N && (vc[0]-1u)!=N,"atomic: negative control - ==N accepts the true count, rejects a lost update");
+
+    /* re-run into the same counters without zeroing: the count must now be exactly 2N (accumulates) */
+    vkResetFences(dev,1,&fence); vkResetCommandBuffer(cmd,0);
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAtomic.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAtomic.pl,0,1,&dsAt,0,NULL);
+    vkCmdPushConstants(cmd,pAtomic.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pc,&pc);
+    vkCmdDispatch(cmd,NG,1,1);
+    vkEndCommandBuffer(cmd);
+    vkQueueSubmit(queue[0],1,&si,fence);
+    VKOK(vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX),"atomic: wait second accumulating dispatch");
+    ok(vc[0]==2u*N,"atomic: second dispatch accumulated to exactly 2N (atomics accumulate across dispatches, no loss)");
+
+    vkDestroyFence(dev,fence,NULL);
+    free_buf(&av); free_buf(&ctr);
+  }
+
+  /* ================= boundary dispatches (zero-length + non-power-of-2 tail guard) ================= */
+  {
+    const uint32_t N = 4096;
+    VkDeviceSize bytes=(VkDeviceSize)N*sizeof(float);
+    SBuf a,b,c;
+    ok(mk_buf(&a,bytes)&&mk_buf(&b,bytes)&&mk_buf(&c,bytes),"boundary: alloc a/b/c");
+    float *ma=a.map,*mb=b.map,*mc=c.map;
+    for(uint32_t i=0;i<N;i++){ ma[i]=(float)i; mb[i]=1.0f; mc[i]=-7.0f; }
+    SBuf* bufs[3]={&a,&b,&c}; VkDescriptorSet ds=mk_set(dp,&pAdd,bufs,3);
+
+    VkCommandBufferAllocateInfo cbai={VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdpool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1;
+    VkCommandBuffer cmd; vkAllocateCommandBuffers(dev,&cbai,&cmd);
+    VkFenceCreateInfo fci={VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev,&fci,NULL,&fence);
+    VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    VkSubmitInfo si={VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd;
+
+    struct PC pc0={1.0f,0};
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&ds,0,NULL);
+    vkCmdPushConstants(cmd,pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pc0,&pc0);
+    vkCmdDispatch(cmd,0,1,1);
+    vkEndCommandBuffer(cmd);
+    vkQueueSubmit(queue[0],1,&si,fence);
+    vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX); vkResetFences(dev,1,&fence); vkResetCommandBuffer(cmd,0);
+    { uint32_t touched=0; for(uint32_t i=0;i<N;i++) if(!feq(mc[i],-7.0f)) touched++;
+      ok(touched==0,"boundary: zero-workgroup dispatch left output fully untouched"); }
+
+    const uint32_t Nt = 4096+37;
+    const uint32_t NGt = (Nt+LOCAL-1)/LOCAL;
+    SBuf a2,b2,c2; VkDeviceSize b2b=(VkDeviceSize)(NGt*LOCAL)*sizeof(float);
+    ok(mk_buf(&a2,b2b)&&mk_buf(&b2,b2b)&&mk_buf(&c2,b2b),"boundary: alloc padded tail buffers");
+    float *ma2=a2.map,*mb2=b2.map,*mc2=c2.map;
+    for(uint32_t i=0;i<NGt*LOCAL;i++){ ma2[i]=(float)(i%251); mb2[i]=0.25f; mc2[i]=-5.0f; }
+    SBuf* tb[3]={&a2,&b2,&c2}; VkDescriptorSet dst=mk_set(dp,&pAdd,tb,3);
+    struct PC pct={1.0f,Nt};
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&dst,0,NULL);
+    vkCmdPushConstants(cmd,pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pct,&pct);
+    vkCmdDispatch(cmd,NGt,1,1);
+    vkEndCommandBuffer(cmd);
+    vkQueueSubmit(queue[0],1,&si,fence);
+    vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX);
+    { uint32_t badin=0,badtail=0;
+      for(uint32_t i=0;i<Nt;i++) if(!feq(mc2[i],ma2[i]+mb2[i])) badin++;
+      for(uint32_t i=Nt;i<NGt*LOCAL;i++) if(!feq(mc2[i],-5.0f)) badtail++;
+      ok(badin==0,"boundary: non-pow2 in-range elements all c==a+b");
+      ok(badtail==0,"boundary: tail guard left out-of-range invocations untouched"); }
+
+    vkDestroyFence(dev,fence,NULL);
+    free_buf(&a); free_buf(&b); free_buf(&c); free_buf(&a2); free_buf(&b2); free_buf(&c2);
+  }
+
+  /* ================= (a) CONCURRENT DISPATCH + timestamp query pool + transfer commands ================= */
+  {
+    const uint32_t N = 1u<<15;
+    VkDeviceSize bytes=(VkDeviceSize)N*sizeof(float);
+    SBuf a,b,c,cp;
+    ok(mk_buf(&a,bytes)&&mk_buf(&b,bytes)&&mk_buf(&c,bytes)&&mk_buf(&cp,bytes),"query/transfer: alloc a/b/c/copy");
+    float *ma=a.map,*mb=b.map,*mc=c.map,*mcp=cp.map;
+    for(uint32_t i=0;i<N;i++){ ma[i]=(float)(i%101); mb[i]=2.0f; mc[i]=-1.0f; mcp[i]=-1.0f; }
+    SBuf* bufs[3]={&a,&b,&c}; VkDescriptorSet ds=mk_set(dp,&pAdd,bufs,3);
+
+    VkQueryPoolCreateInfo qpci={VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO}; qpci.queryType=VK_QUERY_TYPE_TIMESTAMP; qpci.queryCount=2;
+    VkQueryPool qp; VKOK(vkCreateQueryPool(dev,&qpci,NULL,&qp),"query: create timestamp query pool");
+
+    VkCommandBufferAllocateInfo cbai={VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdpool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1;
+    VkCommandBuffer cmd; vkAllocateCommandBuffers(dev,&cbai,&cmd);
+    VkFenceCreateInfo fci={VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev,&fci,NULL,&fence);
+    VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    VkSubmitInfo si={VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd;
+
+    struct PC pc={1.0f,N};
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdResetQueryPool(cmd,qp,0,2);
+    vkCmdWriteTimestamp(cmd,VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,qp,0);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&ds,0,NULL);
+    vkCmdPushConstants(cmd,pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pc,&pc);
+    vkCmdDispatch(cmd,(N+LOCAL-1)/LOCAL,1,1);
+    VkBufferMemoryBarrier bmb={VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+    bmb.srcAccessMask=VK_ACCESS_SHADER_WRITE_BIT; bmb.dstAccessMask=VK_ACCESS_TRANSFER_READ_BIT;
+    bmb.srcQueueFamilyIndex=VK_QUEUE_FAMILY_IGNORED; bmb.dstQueueFamilyIndex=VK_QUEUE_FAMILY_IGNORED;
+    bmb.buffer=c.buf; bmb.offset=0; bmb.size=bytes;
+    vkCmdPipelineBarrier(cmd,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_TRANSFER_BIT,0,0,NULL,1,&bmb,0,NULL);
+    VkBufferCopy region={0,0,bytes}; vkCmdCopyBuffer(cmd,c.buf,cp.buf,1,&region);
+    vkCmdWriteTimestamp(cmd,VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,qp,1);
+    vkEndCommandBuffer(cmd);
+    vkQueueSubmit(queue[0],1,&si,fence);
+    VKOK(vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX),"query/transfer: wait");
+
+    uint64_t ts[2]={0,0};
+    VKOK(vkGetQueryPoolResults(dev,qp,0,2,sizeof ts,ts,sizeof(uint64_t),VK_QUERY_RESULT_64_BIT|VK_QUERY_RESULT_WAIT_BIT),"query: read 2 timestamps");
+    if(ts_valid) ok(ts[1]>=ts[0],"query: end timestamp >= start timestamp (monotonic)");
+    else fprintf(stderr,"skip: timestampValidBits==0, monotonic check unsupported on this backend\n");
+    ok(ts_ok,"query: device advertises timestampComputeAndGraphics");
+
+    { uint32_t badcp=0; for(uint32_t i=0;i<N;i++) if(!feq(mcp[i],ma[i]+mb[i])) badcp++;
+      ok(badcp==0,"transfer: vkCmdCopyBuffer c->cp equals compute result element-wise");
+      float sv=mcp[9]; mcp[9]=sv+500.0f; uint32_t nb=0; for(uint32_t i=0;i<N;i++) if(!feq(mcp[i],ma[i]+mb[i])) nb++;
+      ok(nb==1,"transfer: negative control - corrupted copy element detected"); mcp[9]=sv; }
+
+    vkResetFences(dev,1,&fence); vkResetCommandBuffer(cmd,0);
+    union { float f; uint32_t u; } pat; pat.f=9.0f;
+    vkBeginCommandBuffer(cmd,&bi); vkCmdFillBuffer(cmd,cp.buf,0,bytes,pat.u); vkEndCommandBuffer(cmd);
+    vkQueueSubmit(queue[0],1,&si,fence); vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX);
+    { uint32_t badf=0; for(uint32_t i=0;i<N;i++) if(!feq(mcp[i],9.0f)) badf++;
+      ok(badf==0,"transfer: vkCmdFillBuffer wrote 9.0 across the full range"); }
+
+    vkDestroyQueryPool(dev,qp,NULL);
+    vkDestroyFence(dev,fence,NULL);
+    free_buf(&a); free_buf(&b); free_buf(&c); free_buf(&cp);
+  }
+
+  /* ================= (a)+(c) CONCURRENT DISPATCH / ASYNC MULTI-SUBMIT ================= */
+  {
+    const uint32_t M = 6;                       /* 6 concurrent in-flight submissions */
+    const uint32_t N = 1u<<16;                  /* 65536 elems each */
+    VkDeviceSize bytes=(VkDeviceSize)N*sizeof(float);
+    SBuf a[6],b[6],c[6];
+    VkDescriptorSet ds[6];
+    VkCommandBuffer cmd[6];
+    VkFence fence[6];
+    float coef[6]={2.0f,3.0f,5.0f,7.0f,11.0f,13.0f};
+
+    VkCommandBufferAllocateInfo cbai={VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdpool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=M;
+    vkAllocateCommandBuffers(dev,&cbai,cmd);
+    VkFenceCreateInfo fci={VK_STRUCTURE_TYPE_FENCE_CREATE_INFO};
+
+    int alloc_ok=1;
+    for(uint32_t m=0;m<M;m++){
+      alloc_ok &= mk_buf(&a[m],bytes) & mk_buf(&b[m],bytes) & mk_buf(&c[m],bytes);
+      float *ma=a[m].map,*mb=b[m].map,*mc=c[m].map;
+      for(uint32_t i=0;i<N;i++){ ma[i]=(float)(i+m); mb[i]=(float)(2*i); mc[i]=-9.0f; }
+      SBuf* bufs[3]={&a[m],&b[m],&c[m]}; ds[m]=mk_set(dp,&pAdd,bufs,3);
+      vkCreateFence(dev,&fci,NULL,&fence[m]);
+    }
+    ok(alloc_ok,"async multi-submit: allocated 6 independent buffer triples");
+
+    for(uint32_t m=0;m<M;m++){
+      struct PC pc={coef[m],N};
+      VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+      vkBeginCommandBuffer(cmd[m],&bi);
+      vkCmdBindPipeline(cmd[m],VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+      vkCmdBindDescriptorSets(cmd[m],VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&ds[m],0,NULL);
+      vkCmdPushConstants(cmd[m],pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pc,&pc);
+      vkCmdDispatch(cmd[m],(N+LOCAL-1)/LOCAL,1,1);
+      vkEndCommandBuffer(cmd[m]);
+    }
+
+    /* submit all 6 back-to-back WITHOUT waiting between submits; spread across queues if >1 */
+    int subok=1;
+    for(uint32_t m=0;m<M;m++){
+      VkSubmitInfo si={VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd[m];
+      VkQueue tgt = queue[ true_multiqueue ? (m%nq) : 0 ];
+      subok &= (vkQueueSubmit(tgt,1,&si,fence[m])==VK_SUCCESS);
+    }
+    ok(subok,"async multi-submit: 6 back-to-back submits accepted (no wait between; split across queues if multi-queue)");
+    VKOK(vkWaitForFences(dev,M,fence,VK_TRUE,UINT64_MAX),"async multi-submit: single wait on all 6 fences");
+
+    for(uint32_t m=0;m<M;m++){
+      float *ma=a[m].map,*mb=b[m].map,*mc=c[m].map;
+      uint32_t bad=0;
+      for(uint32_t i=0;i<N;i++){ float want=coef[m]*ma[i]+mb[i]; if(!feq(mc[i],want)){bad++;} }
+      char nm[80]; snprintf(nm,sizeof nm,"async multi-submit: in-flight result %u (alpha=%.0f) fully correct",m,coef[m]);
+      ok(bad==0,nm);
+    }
+    /* every fence must report completion (ordering/completion check) */
+    { int allsig=1; for(uint32_t m=0;m<M;m++) allsig &= (vkGetFenceStatus(dev,fence[m])==VK_SUCCESS);
+      ok(allsig,"async multi-submit: every one of the 6 fences reports VK_SUCCESS (all completed)"); }
+    { float *m0=c[0].map,*m1=c[1].map; ok(!feq(m0[100],m1[100]),"async multi-submit: overlapping submissions did not corrupt each other (distinct results)"); }
+
+    /* batch submit: one vkQueueSubmit carrying all 6 command buffers in a single VkSubmitInfo */
+    for(uint32_t m=0;m<M;m++){ vkResetFences(dev,1,&fence[m]); vkResetCommandBuffer(cmd[m],0);
+      struct PC pc={coef[m],N};
+      VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+      vkBeginCommandBuffer(cmd[m],&bi);
+      vkCmdBindPipeline(cmd[m],VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+      vkCmdBindDescriptorSets(cmd[m],VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&ds[m],0,NULL);
+      vkCmdPushConstants(cmd[m],pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pc,&pc);
+      vkCmdDispatch(cmd[m],(N+LOCAL-1)/LOCAL,1,1);
+      vkEndCommandBuffer(cmd[m]);
+      float* mc=c[m].map; for(uint32_t i=0;i<N;i++) mc[i]=-9.0f;
+    }
+    VkSubmitInfo bsi={VK_STRUCTURE_TYPE_SUBMIT_INFO}; bsi.commandBufferCount=M; bsi.pCommandBuffers=cmd;
+    VKOK(vkQueueSubmit(queue[0],1,&bsi,fence[0]),"batch submit: 6 command buffers in one VkSubmitInfo");
+    VKOK(vkWaitForFences(dev,1,&fence[0],VK_TRUE,UINT64_MAX),"batch submit: wait single fence");
+    {
+      uint32_t badall=0;
+      for(uint32_t m=0;m<M;m++){ float *ma=a[m].map,*mb=b[m].map,*mc=c[m].map;
+        for(uint32_t i=0;i<N;i++){ float want=coef[m]*ma[i]+mb[i]; if(!feq(mc[i],want)) badall++; } }
+      ok(badall==0,"batch submit: all 6 batched results fully correct");
+    }
+
+    for(uint32_t m=0;m<M;m++){ vkDestroyFence(dev,fence[m],NULL); free_buf(&a[m]); free_buf(&b[m]); free_buf(&c[m]); }
+    vkFreeCommandBuffers(dev,cmdpool,M,cmd);
+  }
+
+  /* ================= ORDERING: barrier-ordered dependency chain in one command buffer ================= */
+  {
+    const uint32_t N = 1u<<15;
+    VkDeviceSize bytes=(VkDeviceSize)N*sizeof(float);
+    SBuf a,b,t,d;
+    ok(mk_buf(&a,bytes)&&mk_buf(&b,bytes)&&mk_buf(&t,bytes)&&mk_buf(&d,bytes),"dep-chain: alloc a/b/t/d");
+    float *ma=a.map,*mb=b.map,*mt=t.map,*md=d.map;
+    for(uint32_t i=0;i<N;i++){ ma[i]=(float)(i%251); mb[i]=1.0f; mt[i]=-1.0f; md[i]=-1.0f; }
+    SBuf* addbufs[3]={&a,&b,&t}; VkDescriptorSet dsA=mk_set(dp,&pAdd,addbufs,3);
+    SBuf* chnbufs[2]={&t,&d};   VkDescriptorSet dsB=mk_set(dp,&pChain,chnbufs,2);
+    ok(dsA!=VK_NULL_HANDLE&&dsB!=VK_NULL_HANDLE,"dep-chain: descriptor sets wired");
+
+    VkCommandBufferAllocateInfo cbai={VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdpool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1;
+    VkCommandBuffer cmd; vkAllocateCommandBuffers(dev,&cbai,&cmd);
+    VkFenceCreateInfo fci={VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev,&fci,NULL,&fence);
+
+    struct PC pcA={1.0f,N}; float K=4.0f; struct PC pcB={K,N};
+    VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&dsA,0,NULL);
+    vkCmdPushConstants(cmd,pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pcA,&pcA);
+    vkCmdDispatch(cmd,(N+LOCAL-1)/LOCAL,1,1);
+    VkBufferMemoryBarrier bmb={VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+    bmb.srcAccessMask=VK_ACCESS_SHADER_WRITE_BIT; bmb.dstAccessMask=VK_ACCESS_SHADER_READ_BIT;
+    bmb.srcQueueFamilyIndex=VK_QUEUE_FAMILY_IGNORED; bmb.dstQueueFamilyIndex=VK_QUEUE_FAMILY_IGNORED;
+    bmb.buffer=t.buf; bmb.offset=0; bmb.size=bytes;
+    vkCmdPipelineBarrier(cmd,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,0,0,NULL,1,&bmb,0,NULL);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pChain.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pChain.pl,0,1,&dsB,0,NULL);
+    vkCmdPushConstants(cmd,pChain.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pcB,&pcB);
+    vkCmdDispatch(cmd,(N+LOCAL-1)/LOCAL,1,1);
+    vkEndCommandBuffer(cmd);
+    VkSubmitInfo si={VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd;
+    vkQueueSubmit(queue[0],1,&si,fence);
+    VKOK(vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX),"dep-chain: wait");
+
+    uint32_t bad_t=0, bad_d=0;
+    for(uint32_t i=0;i<N;i++){
+      float wt=ma[i]+mb[i];
+      float wd=wt*K+1.0f;
+      if(!feq(mt[i],wt)) bad_t++;
+      if(!feq(md[i],wd)) bad_d++;
+    }
+    ok(bad_t==0,"dep-chain: stage A output t==a+b");
+    ok(bad_d==0,"dep-chain: stage B output d==(a+b)*k+1 (ordering held via pipeline barrier)");
+    ok(feq(md[7],(ma[7]+mb[7])*K+1.0f) && !feq(md[7],ma[7]+mb[7]),"dep-chain: B consumed A's output (not stale input)");
+
+    vkDestroyFence(dev,fence,NULL);
+    free_buf(&a); free_buf(&b); free_buf(&t); free_buf(&d);
+  }
+
+  /* ================= ORDERING: cross-submit VkSemaphore dependency ================= */
+  {
+    const uint32_t N = 1u<<15;
+    VkDeviceSize bytes=(VkDeviceSize)N*sizeof(float);
+    SBuf a,b,t,d;
+    ok(mk_buf(&a,bytes)&&mk_buf(&b,bytes)&&mk_buf(&t,bytes)&&mk_buf(&d,bytes),"sem: alloc a/b/t/d");
+    float *ma=a.map,*mb=b.map,*mt=t.map,*md=d.map;
+    for(uint32_t i=0;i<N;i++){ ma[i]=(float)(i%211); mb[i]=2.0f; mt[i]=-1.0f; md[i]=-1.0f; }
+    SBuf* addbufs[3]={&a,&b,&t}; VkDescriptorSet dsA=mk_set(dp,&pAdd,addbufs,3);
+    SBuf* chnbufs[2]={&t,&d};   VkDescriptorSet dsB=mk_set(dp,&pChain,chnbufs,2);
+
+    VkSemaphoreCreateInfo sci={VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
+    VkSemaphore sem; VKOK(vkCreateSemaphore(dev,&sci,NULL,&sem),"sem: vkCreateSemaphore");
+
+    VkCommandBufferAllocateInfo cbai={VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdpool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=2;
+    VkCommandBuffer cmd[2]; vkAllocateCommandBuffers(dev,&cbai,cmd);
+    VkFenceCreateInfo fci={VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fenceB; vkCreateFence(dev,&fci,NULL,&fenceB);
+    VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    struct PC pcA={1.0f,N};
+    vkBeginCommandBuffer(cmd[0],&bi);
+    vkCmdBindPipeline(cmd[0],VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+    vkCmdBindDescriptorSets(cmd[0],VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&dsA,0,NULL);
+    vkCmdPushConstants(cmd[0],pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pcA,&pcA);
+    vkCmdDispatch(cmd[0],(N+LOCAL-1)/LOCAL,1,1);
+    vkEndCommandBuffer(cmd[0]);
+
+    float K=3.0f; struct PC pcB={K,N};
+    vkBeginCommandBuffer(cmd[1],&bi);
+    vkCmdBindPipeline(cmd[1],VK_PIPELINE_BIND_POINT_COMPUTE,pChain.pipe);
+    vkCmdBindDescriptorSets(cmd[1],VK_PIPELINE_BIND_POINT_COMPUTE,pChain.pl,0,1,&dsB,0,NULL);
+    vkCmdPushConstants(cmd[1],pChain.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pcB,&pcB);
+    vkCmdDispatch(cmd[1],(N+LOCAL-1)/LOCAL,1,1);
+    vkEndCommandBuffer(cmd[1]);
+
+    VkSubmitInfo siA={VK_STRUCTURE_TYPE_SUBMIT_INFO}; siA.commandBufferCount=1; siA.pCommandBuffers=&cmd[0];
+    siA.signalSemaphoreCount=1; siA.pSignalSemaphores=&sem;
+    VkPipelineStageFlags waitStage=VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+    VkSubmitInfo siB={VK_STRUCTURE_TYPE_SUBMIT_INFO}; siB.commandBufferCount=1; siB.pCommandBuffers=&cmd[1];
+    siB.waitSemaphoreCount=1; siB.pWaitSemaphores=&sem; siB.pWaitDstStageMask=&waitStage;
+    VKOK(vkQueueSubmit(queue[0],1,&siA,VK_NULL_HANDLE),"sem: submit A signals semaphore");
+    VKOK(vkQueueSubmit(queue[ true_multiqueue?1:0 ],1,&siB,fenceB),"sem: submit B waits on semaphore");
+    VKOK(vkWaitForFences(dev,1,&fenceB,VK_TRUE,UINT64_MAX),"sem: wait fence on submit B");
+
+    VKOK(vkQueueWaitIdle(queue[0]),"sem: vkQueueWaitIdle drains the queue");
+    VKOK(vkDeviceWaitIdle(dev),"sem: vkDeviceWaitIdle drains the device");
+
+    uint32_t bad_t=0, bad_d=0;
+    for(uint32_t i=0;i<N;i++){ float wt=ma[i]+mb[i]; float wd=wt*K+1.0f;
+      if(!feq(mt[i],wt)) bad_t++; if(!feq(md[i],wd)) bad_d++; }
+    ok(bad_t==0,"sem: stage A output t==a+b");
+    ok(bad_d==0,"sem: stage B output d==(a+b)*k+1 across two submits (semaphore ordering held)");
+    ok(feq(md[42],(ma[42]+mb[42])*K+1.0f) && !feq(md[42],ma[42]+mb[42]),
+       "sem: submit B consumed submit A's output (not stale input)");
+
+    vkDestroySemaphore(dev,sem,NULL);
+    vkDestroyFence(dev,fenceB,NULL);
+    vkFreeCommandBuffers(dev,cmdpool,2,cmd);
+    free_buf(&a); free_buf(&b); free_buf(&t); free_buf(&d);
+  }
+
+  /* ================= ORDERING: device event (vkCmdSetEvent/WaitEvents/ResetEvent) ================= */
+  {
+    const uint32_t N = 1u<<15;
+    VkDeviceSize bytes=(VkDeviceSize)N*sizeof(float);
+    SBuf a,b,t,d;
+    ok(mk_buf(&a,bytes)&&mk_buf(&b,bytes)&&mk_buf(&t,bytes)&&mk_buf(&d,bytes),"event: alloc a/b/t/d");
+    float *ma=a.map,*mb=b.map,*mt=t.map,*md=d.map;
+    for(uint32_t i=0;i<N;i++){ ma[i]=(float)(i%173); mb[i]=3.0f; mt[i]=-1.0f; md[i]=-1.0f; }
+    SBuf* addbufs[3]={&a,&b,&t}; VkDescriptorSet dsA=mk_set(dp,&pAdd,addbufs,3);
+    SBuf* chnbufs[2]={&t,&d};   VkDescriptorSet dsB=mk_set(dp,&pChain,chnbufs,2);
+
+    VkEventCreateInfo eci={VK_STRUCTURE_TYPE_EVENT_CREATE_INFO};
+    VkEvent evt; VKOK(vkCreateEvent(dev,&eci,NULL,&evt),"event: vkCreateEvent");
+    ok(vkGetEventStatus(dev,evt)==VK_EVENT_RESET,"event: fresh event status == VK_EVENT_RESET");
+    VKOK(vkSetEvent(dev,evt),"event: vkSetEvent");
+    ok(vkGetEventStatus(dev,evt)==VK_EVENT_SET,"event: status after vkSetEvent == VK_EVENT_SET");
+    VKOK(vkResetEvent(dev,evt),"event: vkResetEvent");
+    ok(vkGetEventStatus(dev,evt)==VK_EVENT_RESET,"event: status after vkResetEvent == VK_EVENT_RESET");
+
+    VkCommandBufferAllocateInfo cbai={VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO}; cbai.commandPool=cmdpool; cbai.level=VK_COMMAND_BUFFER_LEVEL_PRIMARY; cbai.commandBufferCount=1;
+    VkCommandBuffer cmd; vkAllocateCommandBuffers(dev,&cbai,&cmd);
+    VkFenceCreateInfo fci={VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev,&fci,NULL,&fence);
+    VkCommandBufferBeginInfo bi={VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO}; bi.flags=VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+
+    struct PC pcA={1.0f,N}; float K=5.0f; struct PC pcB={K,N};
+    vkBeginCommandBuffer(cmd,&bi);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pAdd.pl,0,1,&dsA,0,NULL);
+    vkCmdPushConstants(cmd,pAdd.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pcA,&pcA);
+    vkCmdDispatch(cmd,(N+LOCAL-1)/LOCAL,1,1);
+    vkCmdSetEvent(cmd,evt,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
+    VkMemoryBarrier memb={VK_STRUCTURE_TYPE_MEMORY_BARRIER};
+    memb.srcAccessMask=VK_ACCESS_SHADER_WRITE_BIT; memb.dstAccessMask=VK_ACCESS_SHADER_READ_BIT;
+    vkCmdWaitEvents(cmd,1,&evt,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,1,&memb,0,NULL,0,NULL);
+    vkCmdBindPipeline(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pChain.pipe);
+    vkCmdBindDescriptorSets(cmd,VK_PIPELINE_BIND_POINT_COMPUTE,pChain.pl,0,1,&dsB,0,NULL);
+    vkCmdPushConstants(cmd,pChain.pl,VK_SHADER_STAGE_COMPUTE_BIT,0,sizeof pcB,&pcB);
+    vkCmdDispatch(cmd,(N+LOCAL-1)/LOCAL,1,1);
+    vkEndCommandBuffer(cmd);
+    VkSubmitInfo si={VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount=1; si.pCommandBuffers=&cmd;
+    vkQueueSubmit(queue[0],1,&si,fence);
+    VKOK(vkWaitForFences(dev,1,&fence,VK_TRUE,UINT64_MAX),"event: wait");
+    ok(vkGetEventStatus(dev,evt)==VK_EVENT_SET,"event: host observes device-set event == VK_EVENT_SET");
+
+    uint32_t bad_t=0, bad_d=0;
+    for(uint32_t i=0;i<N;i++){ float wt=ma[i]+mb[i]; float wd=wt*K+1.0f;
+      if(!feq(mt[i],wt)) bad_t++; if(!feq(md[i],wd)) bad_d++; }
+    ok(bad_t==0,"event: stage A output t==a+b");
+    ok(bad_d==0,"event: stage B output d==(a+b)*k+1 (device event ordering held)");
+    ok(feq(md[99],(ma[99]+mb[99])*K+1.0f) && !feq(md[99],ma[99]+mb[99]),
+       "event: stage B consumed stage A's output via device event (not stale)");
+
+    vkDestroyEvent(dev,evt,NULL);
+    vkDestroyFence(dev,fence,NULL);
+    free_buf(&a); free_buf(&b); free_buf(&t); free_buf(&d);
+  }
+
+  vkDestroyCommandPool(dev,cmdpool,NULL);
+  vkDestroyDescriptorPool(dev,dp,NULL);
+  free_pipe(&pAdd); free_pipe(&pRed); free_pipe(&pChain); free_pipe(&pAtomic);
+  vkDestroyDevice(dev,NULL); vkDestroyInstance(inst,NULL);
+  free(pds); free(qf);
+
+  int EXPECTED=93, TOTAL=PASS+FAIL;
+  printf("vk-parallel: PASS=%d FAIL=%d TOTAL=%d EXPECTED=%d\n",PASS,FAIL,TOTAL,EXPECTED);
+  if(FAIL==0 && TOTAL==EXPECTED){ printf("VK_PARALLEL_FULL_API OK %d\n",PASS); return 0; }
+  printf("VK_PARALLEL_FULL_API FAIL\n"); return 1;
+}

--- a/apps/starry/cpu-parallel-compute/programs/run_all.sh
+++ b/apps/starry/cpu-parallel-compute/programs/run_all.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# On-target runner: set up the software GPU compute runtime and run the parallel/concurrent compute
+# carpets. Prints "TEST PASSED" only when every built carpet reports its "<name> OK <n>" marker AND
+# exits 0.
+set -u
+BIN=/opt/cpu-parallel-compute
+mkdir -p /tmp/vkrt
+export XDG_RUNTIME_DIR=/tmp/vkrt
+export LD_LIBRARY_PATH=/usr/lib:/usr/lib/pocl
+# lavapipe (software Vulkan) ICD; the JSON carries an absolute library_path resolved against the root
+ICD=$(ls /usr/share/vulkan/icd.d/lvp_icd.*.json 2>/dev/null | head -1)
+export VK_DRIVER_FILES="$ICD"
+export VK_ICD_FILENAMES="$ICD"
+# OpenCL: rusticl (mesa, over llvmpipe) advertises only drivers named in RUSTICL_ENABLE; pocl uses its
+# single-threaded CPU device. Both are software CPU OpenCL runtimes.
+export RUSTICL_ENABLE=llvmpipe
+export OCL_ICD_VENDORS=/etc/OpenCL/vendors
+export POCL_DEVICES=basic
+# StarryOS runs one vCPU (SMP off), so the software rasterizers/JITs execute every workgroup on one
+# thread. Pin the mesa (lavapipe/llvmpipe) thread pool to 1 to make that explicit; pocl's basic device
+# is already single-threaded. The carpets assert numerical/atomic correctness, not throughput, so the
+# thread count does not change the results - the atomic and reduction checks still cover the
+# cross-workgroup race, since the software scheduler still interleaves the workgroups.
+export LP_NUM_THREADS=1
+ncpu=$(nproc 2>/dev/null || grep -c '^processor' /proc/cpuinfo 2>/dev/null || echo '?')
+echo "cpu-parallel-compute: detected CPU count = $ncpu; software GPU backends pinned single-threaded (LP_NUM_THREADS=1, POCL_DEVICES=basic); ICD=$ICD"
+
+pass=0; total=0; fail=0
+core_pass=0; core_fail=0; add_pass=0; add_fail=0; add_present=0
+# CORE_EXPECTED: the number of core (Vulkan/lavapipe) parallel carpets that MUST run and pass on every
+# arch - a strict constant, not a >= threshold, so an absent or regressed core carpet cannot pass.
+CORE_EXPECTED=1
+# run <class> <name> <binary> - class "core" (the Vulkan/lavapipe parallel carpet, built and required
+# on every arch) or "add" (the OpenCL parallel carpet, provisioned where the arch has rusticl/pocl;
+# absent on arches with no CPU OpenCL runtime). A carpet whose binary is absent is skipped. A pass
+# requires BOTH a clean exit (rc==0) AND the exact "<name> OK <n>" marker: a carpet that prints its
+# marker then aborts in teardown must fail, not pass.
+run() {
+    cls="$1"; name="$2"; prog="$3"
+    [ -x "$prog" ] || { [ "$cls" = add ] && echo "cpu-parallel-compute: $name absent (no CPU OpenCL runtime this arch) - skipped"; return 0; }
+    total=$((total + 1))
+    [ "$cls" = add ] && add_present=$((add_present + 1))
+    out="$(cd "$BIN" && "$prog" 2>&1)"; rc=$?
+    if [ "$rc" -eq 0 ] && echo "$out" | grep -qE "OK [0-9]+$"; then
+        echo "$out" | grep -E ": PASS=|OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+        if [ "$cls" = core ]; then core_pass=$((core_pass + 1)); else add_pass=$((add_pass + 1)); fi
+    else
+        echo "$out" | tail -8
+        echo "CARPET FAILED: $name (exit $rc)"
+        fail=$((fail + 1))
+        if [ "$cls" = core ]; then core_fail=$((core_fail + 1)); else add_fail=$((add_fail + 1)); fi
+    fi
+}
+
+cd "$BIN" || exit 1
+run core vk_parallel "$BIN/vk_parallel"
+run add  cl_parallel "$BIN/cl_parallel"
+
+echo "cpu-parallel-compute: $pass/$total carpets OK on $(uname -m); core $core_pass/$((core_pass + core_fail)); additive present=$add_present ok=$add_pass failed=$add_fail"
+# The core (Vulkan parallel compute on lavapipe) is built and required on every arch and is what gates.
+# The OpenCL parallel carpet is additive and does not gate the core (mirrors the gpu-compute app):
+# Alpine builds rusticl/pocl for x86_64 and aarch64 but not for every arch (riscv64/loongarch64 lack a
+# packaged CPU OpenCL runtime today), and rusticl's OpenCL kernel-execution + async multi-submit paths
+# reproduce a Mesa/qemu-TCG upstream limitation under emulation (the software OpenCL device's LLVM JIT
+# faults under TCG - verified against a host CPU-OpenCL control, not a StarryOS kernel issue). The
+# additive result is run and reported above but never blocks the Vulkan gate.
+if [ "$core_fail" -eq 0 ] && [ "$core_pass" -eq "$CORE_EXPECTED" ]; then echo "TEST PASSED"; exit 0; else echo "TEST FAILED"; exit 1; fi

--- a/apps/starry/cpu-parallel-compute/programs/svml_stub.c
+++ b/apps/starry/cpu-parallel-compute/programs/svml_stub.c
@@ -1,0 +1,93 @@
+/* Scalar-loop implementations of the Intel SVML vector entry points that
+ * LLVM 20's SVML VecFuncs table can emit into aarch64 kernels.
+ *
+ * pocl (misdetected as X86 in this cross-build) bakes the Intel SVML/IRC
+ * archive paths into HOST_LD_FLAGS, and its codegen attaches the SVML
+ * TargetLibraryInfo unconditionally, so aarch64 kernels that use libm
+ * transcendentals get __svml_* vector calls. The real Intel libsvml.a is
+ * x86-only machine code with no aarch64 build, so we satisfy the same
+ * symbol names with ABI-correct scalar-loop wrappers.
+ *
+ * Vector params/returns use GCC/Clang vector_size so the AAPCS64 vector
+ * passing matches LLVM's <W x T>. The same clang20 --target aarch64 musl
+ * -mcpu=cortex-a53 compiles both these wrappers and the kernels, so the
+ * ABI is identical by construction.
+ *
+ * Symbol set = every distinct __svml_* name in
+ * llvm20/include/llvm/Analysis/VecFuncs.def lines 313-522 (the
+ * TLI_DEFINE_SVML_VECFUNCS block). Duplicate mappings (libm name,
+ * llvm.* intrinsic, *_finite) all resolve to the same __svml_* symbol,
+ * so each symbol is defined exactly once here.
+ */
+
+#include <math.h>
+
+typedef float  f32v4  __attribute__((vector_size(16)));  /* <4  x float>  */
+typedef float  f32v8  __attribute__((vector_size(32)));  /* <8  x float>  */
+typedef float  f32v16 __attribute__((vector_size(64)));  /* <16 x float>  */
+typedef double f64v2  __attribute__((vector_size(16)));  /* <2  x double> */
+typedef double f64v4  __attribute__((vector_size(32)));  /* <4  x double> */
+typedef double f64v8  __attribute__((vector_size(64)));  /* <8  x double> */
+
+/* 1-arg float: apply scalar libm f-variant per lane, widths 4/8/16 */
+#define SVML_F1(name, scalarf)                                           \
+  f32v4  __svml_##name##f4 (f32v4  x){ for(int i=0;i<4 ;i++) x[i]=scalarf(x[i]); return x; } \
+  f32v8  __svml_##name##f8 (f32v8  x){ for(int i=0;i<8 ;i++) x[i]=scalarf(x[i]); return x; } \
+  f32v16 __svml_##name##f16(f32v16 x){ for(int i=0;i<16;i++) x[i]=scalarf(x[i]); return x; }
+
+/* 1-arg double: apply scalar libm d-variant per lane, widths 2/4/8 */
+#define SVML_D1(name, scalard)                                           \
+  f64v2  __svml_##name##2  (f64v2  x){ for(int i=0;i<2 ;i++) x[i]=scalard(x[i]); return x; } \
+  f64v4  __svml_##name##4  (f64v4  x){ for(int i=0;i<4 ;i++) x[i]=scalard(x[i]); return x; } \
+  f64v8  __svml_##name##8  (f64v8  x){ for(int i=0;i<8 ;i++) x[i]=scalard(x[i]); return x; }
+
+/* 2-arg float (pow): widths 4/8/16 */
+#define SVML_F2(name, scalarf)                                           \
+  f32v4  __svml_##name##f4 (f32v4  x, f32v4  y){ for(int i=0;i<4 ;i++) x[i]=scalarf(x[i],y[i]); return x; } \
+  f32v8  __svml_##name##f8 (f32v8  x, f32v8  y){ for(int i=0;i<8 ;i++) x[i]=scalarf(x[i],y[i]); return x; } \
+  f32v16 __svml_##name##f16(f32v16 x, f32v16 y){ for(int i=0;i<16;i++) x[i]=scalarf(x[i],y[i]); return x; }
+
+/* 2-arg double (pow): widths 2/4/8 */
+#define SVML_D2(name, scalard)                                           \
+  f64v2  __svml_##name##2  (f64v2  x, f64v2  y){ for(int i=0;i<2 ;i++) x[i]=scalard(x[i],y[i]); return x; } \
+  f64v4  __svml_##name##4  (f64v4  x, f64v4  y){ for(int i=0;i<4 ;i++) x[i]=scalard(x[i],y[i]); return x; } \
+  f64v8  __svml_##name##8  (f64v8  x, f64v8  y){ for(int i=0;i<8 ;i++) x[i]=scalard(x[i],y[i]); return x; }
+
+/* --- single-arg transcendentals (float f-variant + double variant) --- */
+SVML_F1(sin,   sinf)   SVML_D1(sin,   sin)
+SVML_F1(cos,   cosf)   SVML_D1(cos,   cos)
+SVML_F1(tan,   tanf)   SVML_D1(tan,   tan)
+SVML_F1(exp,   expf)   SVML_D1(exp,   exp)
+SVML_F1(log,   logf)   SVML_D1(log,   log)
+SVML_F1(sqrt,  sqrtf)  SVML_D1(sqrt,  sqrt)
+
+/* log2: double symbols are __svml_log22/24/28, float __svml_log2f4/8/16.
+ * The name-collision (exp width-2 == __svml_exp2) is why these need the
+ * literal names spelled out rather than the F1/D1 macros. */
+f32v4  __svml_log2f4 (f32v4  x){ for(int i=0;i<4 ;i++) x[i]=log2f(x[i]); return x; }
+f32v8  __svml_log2f8 (f32v8  x){ for(int i=0;i<8 ;i++) x[i]=log2f(x[i]); return x; }
+f32v16 __svml_log2f16(f32v16 x){ for(int i=0;i<16;i++) x[i]=log2f(x[i]); return x; }
+f64v2  __svml_log22  (f64v2  x){ for(int i=0;i<2 ;i++) x[i]=log2(x[i]);  return x; }
+f64v4  __svml_log24  (f64v4  x){ for(int i=0;i<4 ;i++) x[i]=log2(x[i]);  return x; }
+f64v8  __svml_log28  (f64v8  x){ for(int i=0;i<8 ;i++) x[i]=log2(x[i]);  return x; }
+
+/* log10: double __svml_log102/104/108, float __svml_log10f4/8/16 */
+f32v4  __svml_log10f4 (f32v4  x){ for(int i=0;i<4 ;i++) x[i]=log10f(x[i]); return x; }
+f32v8  __svml_log10f8 (f32v8  x){ for(int i=0;i<8 ;i++) x[i]=log10f(x[i]); return x; }
+f32v16 __svml_log10f16(f32v16 x){ for(int i=0;i<16;i++) x[i]=log10f(x[i]); return x; }
+f64v2  __svml_log102  (f64v2  x){ for(int i=0;i<2 ;i++) x[i]=log10(x[i]);  return x; }
+f64v4  __svml_log104  (f64v4  x){ for(int i=0;i<4 ;i++) x[i]=log10(x[i]);  return x; }
+f64v8  __svml_log108  (f64v8  x){ for(int i=0;i<8 ;i++) x[i]=log10(x[i]);  return x; }
+
+/* exp2: double __svml_exp22/24/28, float __svml_exp2f4/8/16.
+ * Note __svml_exp2 == exp width-2 (defined by SVML_D1(exp,...) above);
+ * exp2 width-2 is __svml_exp22. */
+f32v4  __svml_exp2f4 (f32v4  x){ for(int i=0;i<4 ;i++) x[i]=exp2f(x[i]); return x; }
+f32v8  __svml_exp2f8 (f32v8  x){ for(int i=0;i<8 ;i++) x[i]=exp2f(x[i]); return x; }
+f32v16 __svml_exp2f16(f32v16 x){ for(int i=0;i<16;i++) x[i]=exp2f(x[i]); return x; }
+f64v2  __svml_exp22  (f64v2  x){ for(int i=0;i<2 ;i++) x[i]=exp2(x[i]);  return x; }
+f64v4  __svml_exp24  (f64v4  x){ for(int i=0;i<4 ;i++) x[i]=exp2(x[i]);  return x; }
+f64v8  __svml_exp28  (f64v8  x){ for(int i=0;i<8 ;i++) x[i]=exp2(x[i]);  return x; }
+
+/* --- two-arg (pow) --- */
+SVML_F2(pow, powf)  SVML_D2(pow, pow)

--- a/apps/starry/cpu-parallel-compute/qemu-aarch64.toml
+++ b/apps/starry/cpu-parallel-compute/qemu-aarch64.toml
@@ -1,0 +1,18 @@
+# cpu-parallel-compute aarch64 - parallel/concurrent compute carpets on Mesa lavapipe (software Vulkan over
+# the llvmpipe LLVM JIT) + rusticl/pocl (software OpenCL over the same JIT). Provisioned from Alpine
+# edge as musl packages; no host GPU. -cpu max exposes the full AArch64 feature set (LSE atomics,
+# dotprod, ARMv8.2+ NEON) the LLVM JIT dispatches to. -smp 1: single vCPU, so the software backends
+# run every workgroup on one thread. 4096M: the LLVM JIT + device buffers are heap-heavy.
+args = [
+    "-nographic", "-cpu", "max", "-m", "4096M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/cpu-parallel-compute/qemu-loongarch64.toml
+++ b/apps/starry/cpu-parallel-compute/qemu-loongarch64.toml
@@ -1,0 +1,22 @@
+# cpu-parallel-compute loongarch64 - parallel/concurrent compute carpets on Mesa lavapipe (software Vulkan
+# over the llvmpipe LLVM JIT). Provisioned from Alpine edge as musl packages (mesa-vulkan-swrast +
+# vulkan-loader), which Alpine builds for loongarch64, so the Vulkan carpet runs on-target; no host
+# GPU. The OpenCL carpet is additive and skipped where Alpine ships no rusticl for the arch.
+# Platform: dynamic (axplat-dyn) - build-loongarch64*.toml carries ax-driver/serial and does not opt
+# out of dynamic platform mode; the retired static LoongArch path lacked the serial console binding
+# ("/dev/console has no serial TTY binding" -> early exit). uefi=false / to_bin=true is the dynamic
+# platform's raw-binary boot path. -smp 1: single vCPU. 4096M: the LLVM JIT + device buffers are
+# heap-heavy.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "4096M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/cpu-parallel-compute/qemu-riscv64.toml
+++ b/apps/starry/cpu-parallel-compute/qemu-riscv64.toml
@@ -1,0 +1,19 @@
+# cpu-parallel-compute riscv64 - parallel/concurrent compute carpets on Mesa lavapipe (software Vulkan over
+# the llvmpipe LLVM JIT). Provisioned from Alpine edge as musl packages (mesa-vulkan-swrast +
+# vulkan-loader), which Alpine builds for riscv64, so the Vulkan carpet runs on-target; no host GPU.
+# The OpenCL carpet is additive and skipped where Alpine ships no rusticl for the arch. -smp 1: single
+# vCPU, so the software backends run every workgroup on one thread. 4096M: the LLVM JIT + device
+# buffers are heap-heavy.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "4096M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 18000

--- a/apps/starry/cpu-parallel-compute/qemu-x86_64.toml
+++ b/apps/starry/cpu-parallel-compute/qemu-x86_64.toml
@@ -1,0 +1,20 @@
+# cpu-parallel-compute x86_64 - parallel/concurrent compute carpets on Mesa lavapipe (software Vulkan over
+# the llvmpipe LLVM JIT) + rusticl/pocl (software OpenCL over the same JIT). Provisioned from Alpine
+# edge as musl packages; no host GPU. -cpu Haswell exposes AVX2 + XSAVE to userspace (the LLVM JIT
+# dispatches to AVX2); the kernel CR4.OSXSAVE + XCR0 enable lives in dev. -smp 1: single vCPU, so the
+# software backends run every workgroup on one thread. 4096M: the LLVM JIT + device buffers are
+# heap-heavy (the multi-workgroup grid is 1<<20 elements, ~4MB per buffer triple).
+args = [
+    "-machine", "q35",
+    "-nographic", "-cpu", "Haswell", "-m", "4096M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 12000


### PR DESCRIPTION
## 变更概要

新增 `apps/starry/gpu-parallel` - GPU 并行计算地毯级测试，覆盖 Vulkan 并发 dispatch / 多 command buffer / async fence / shared-memory reduction / cross-workgroup atomic counter。

### 测试结构

| cell | 断言 | gate | 说明 |
|------|------|------|------|
| vk_parallel (C + GLSL/SPIR-V) | 93 | ✅ 核心 gate | lavapipe Vulkan 软件计算 |
| cl_parallel (C + OpenCL C) | 77 | additive | pocl/rusticl CPU OpenCL (on-target additive) |
| 合计 | 170 | vk_parallel gate | |

### vk_parallel 并发正确性断言

- 并发 dispatch: 两个独立 command buffer 同时提交
- 多 workgroup: 1<<20 元素 / 4096 workgroup，全并行结果
- async fence: timeline fence 不阻塞提交线程
- shared-memory reduction: per-workgroup partial sums + global tree reduce
- cross-workgroup atomic counter: N workgroup atomic_add 最终值 == 1,048,576（无丢更新）

### 验证结果

- host: vk_parallel 93/93 + cl_parallel 77/77 (Intel CPU OpenCL 3.0) 全绿
- on-target 4arch: x86_64 / aarch64 / riscv64 / loongarch64 全 TEST PASSED
  (Mesa vulkan-swrast lavapipe, Alpine 包)
- cl_parallel on-target additive: rusticl/qemu-TCG LLVM JIT SIGSEGV (上游墙，非 gate)