### PR TITLE
fix(starry,nginx): align x86_64 and loongarch64 uefi/to_bin with refactored axbuild

### DIFF
--- a/apps/starry/nginx/qemu-loongarch64.toml
+++ b/apps/starry/nginx/qemu-loongarch64.toml
@@ -15,7 +15,7 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
+uefi = true
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh smoke"

--- a/apps/starry/nginx/qemu-x86_64.toml
+++ b/apps/starry/nginx/qemu-x86_64.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh smoke"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/all/qemu-loongarch64.toml
+++ b/apps/starry/nginx/qemu/all/qemu-loongarch64.toml
@@ -15,7 +15,7 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
+uefi = true
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh all"

--- a/apps/starry/nginx/qemu/all/qemu-x86_64.toml
+++ b/apps/starry/nginx/qemu/all/qemu-x86_64.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh all"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/debug/qemu-x86_64-bad-method-debug.toml
+++ b/apps/starry/nginx/qemu/debug/qemu-x86_64-bad-method-debug.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh debug bad-method-debug"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/debug/qemu-x86_64-bad-method-matrix.toml
+++ b/apps/starry/nginx/qemu/debug/qemu-x86_64-bad-method-matrix.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh debug bad-method-matrix"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/debug/qemu-x86_64-sendfile-on-debug.toml
+++ b/apps/starry/nginx/qemu/debug/qemu-x86_64-sendfile-on-debug.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh debug sendfile-on-debug"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/debug/qemu-x86_64-short-connection-debug.toml
+++ b/apps/starry/nginx/qemu/debug/qemu-x86_64-short-connection-debug.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "NGINX_RUNNER_PHASE_TIMEOUT=1800 /usr/bin/nginx-runner.sh debug short-connection-debug"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/debug/qemu-x86_64-short-connection-direct-debug.toml
+++ b/apps/starry/nginx/qemu/debug/qemu-x86_64-short-connection-direct-debug.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "NGINX_RUNNER_PHASE_TIMEOUT=1800 NGINX_SHORT_CONN_DEBUG_USE_TIMEOUT=0 /usr/bin/nginx-runner.sh debug short-connection-debug"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/debug/qemu-x86_64-timing-debug.toml
+++ b/apps/starry/nginx/qemu/debug/qemu-x86_64-timing-debug.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "NGINX_RUNNER_PHASE_TIMEOUT=1800 /usr/bin/nginx-runner.sh debug x86-timing-debug"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-loongarch64-phase12.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-loongarch64-phase12.toml
@@ -15,7 +15,7 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
+uefi = true
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase12"

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase00.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase00.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase00"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase12.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase12.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase12"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase13.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase13.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase13"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase20.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase20.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase20"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase31.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase31.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase31"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase32.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase32.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase32"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase33.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase33.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase33"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase41.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase41.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase41"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase42.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase42.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase42"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase43.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase43.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase43"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase50.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase50.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase50"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase60.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase60.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase60"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase70.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase70.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase70"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]

--- a/apps/starry/nginx/qemu/phase/qemu-x86_64-phase90.toml
+++ b/apps/starry/nginx/qemu/phase/qemu-x86_64-phase90.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/nginx-runner.sh phase phase90"
 success_regex = ["(?m)^NGINX_RUNNER_PASSED\\b"]


### PR DESCRIPTION
对齐  x86_64 和 loongarch64 的 uefi/to_bin 的 CI 配置，使得 StarryOS Nginx 测试正常启动。

## 概述

将 nginx Starry QEMU 配置中的 `uefi` 和 `to_bin` 字段对齐重构后的 axbuild，后者要求 x86_64 和 loongarch64 的 UEFI 启动路径设置 `uefi = true` 和 `to_bin = true`。

## 变更

- **x86_64**：`uefi = false` → `true`，`to_bin = false` → `true`
- **loongarch64**：`uefi = false` → `true`（`to_bin` 已为 `true`）
- aarch64 / riscv64：未改动

涉及文件：25 个（47 处插入 / 47 处删除）

## 测试

- [x] x86_64 nginx smoke
- [x] loongarch64 nginx smoke