### PR TITLE
fix(starry,apache): align x86_64 and loongarch64 uefi/to_bin with refactored axbuild

### DIFF
--- a/apps/starry/apache/qemu-loongarch64.toml
+++ b/apps/starry/apache/qemu-loongarch64.toml
@@ -15,7 +15,7 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
+uefi = true
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh smoke"

--- a/apps/starry/apache/qemu-x86_64.toml
+++ b/apps/starry/apache/qemu-x86_64.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh smoke"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/all/qemu-loongarch64.toml
+++ b/apps/starry/apache/qemu/all/qemu-loongarch64.toml
@@ -15,7 +15,7 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
+uefi = true
 to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh all"

--- a/apps/starry/apache/qemu/all/qemu-x86_64.toml
+++ b/apps/starry/apache/qemu/all/qemu-x86_64.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh all"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-accept-mutex.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-accept-mutex.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug accept-mutex"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-cgi-pipe-exec.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-cgi-pipe-exec.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug cgi-pipe-exec"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-graceful-signal.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-graceful-signal.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug graceful-signal"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-htaccess-pathwalk.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-htaccess-pathwalk.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug htaccess-pathwalk"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-log-append-reopen.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-log-append-reopen.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug log-append-reopen"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-mpm-prefork-wait.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-mpm-prefork-wait.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug mpm-prefork-wait"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-mpm-thread-futex.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-mpm-thread-futex.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug mpm-thread-futex"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-phase20-restart.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-phase20-restart.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug phase20-restart"
 success_regex = ["(?m)^APACHE_PHASE20_RESTART_DEBUG_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-sendfile-mmap-range.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-sendfile-mmap-range.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh debug sendfile-mmap-range"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/debug/qemu-x86_64-tcp-defer-accept-probe.toml
+++ b/apps/starry/apache/qemu/debug/qemu-x86_64-tcp-defer-accept-probe.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-tcp-defer-accept-probe.sh"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/phase/qemu-x86_64-phase20.toml
+++ b/apps/starry/apache/qemu/phase/qemu-x86_64-phase20.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh phase phase20"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/phase/qemu-x86_64-phase30.toml
+++ b/apps/starry/apache/qemu/phase/qemu-x86_64-phase30.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh phase phase30"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/phase/qemu-x86_64-phase40.toml
+++ b/apps/starry/apache/qemu/phase/qemu-x86_64-phase40.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh phase phase40"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/phase/qemu-x86_64-phase50.toml
+++ b/apps/starry/apache/qemu/phase/qemu-x86_64-phase50.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh phase phase50"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/phase/qemu-x86_64-phase55.toml
+++ b/apps/starry/apache/qemu/phase/qemu-x86_64-phase55.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh phase phase55"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/phase/qemu-x86_64-phase70.toml
+++ b/apps/starry/apache/qemu/phase/qemu-x86_64-phase70.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh phase phase70"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]

--- a/apps/starry/apache/qemu/phase/qemu-x86_64-phase80.toml
+++ b/apps/starry/apache/qemu/phase/qemu-x86_64-phase80.toml
@@ -11,8 +11,8 @@ args = [
     "-netdev",
     "user,id=net0",
 ]
-uefi = false
-to_bin = false
+uefi = true
+to_bin = true
 shell_prefix = "root@starry:"
 shell_init_cmd = "/usr/bin/apache-runner.sh phase phase80"
 success_regex = ["(?m)^APACHE_RUNNER_PASSED\\b"]


### PR DESCRIPTION
## 概述

将 apache Starry QEMU 配置中的 `uefi` 和 `to_bin` 字段对齐重构后的 axbuild，与 `fix/starry-nginx-uefi-to-bin` 中对 nginx 的修复一致。

## 变更

- **x86_64**：`uefi = false` → `true`，`to_bin = false` → `true`
- **loongarch64**：`uefi = false` → `true`（`to_bin` 已为 `true`）
- aarch64 / riscv64：未改动（UEFI 启动暂不支持这两个架构）

涉及文件：21 个（40 处插入 / 40 处删除）

## 测试

- [x] x86_64 apache smoke
- [x] loongarch64 apache smoke
