### PR TITLE
fix(axvisor): standalone xtask CLI compatibility

### DIFF
--- a/os/axvisor/xtask/src/main.rs
+++ b/os/axvisor/xtask/src/main.rs
@@ -14,8 +14,30 @@
 
 //! Build tool for Axvisor hypervisor.
 //!
-//! This crate provides the `xtask` binary for building, running, and managing
-//! the Axvisor hypervisor project.
+//! This xtask delegates all logic to the shared [`axbuild`] library, keeping
+//! this binary as a thin CLI shim. Two kinds of commands are supported:
+//!
+//! * **Axvisor commands** (`build`, `qemu`, `board`, `test`, `uboot`,
+//!   `defconfig`, `config`) — parsed directly into [`axbuild::axvisor::Command`]
+//!   and executed via [`axbuild::axvisor::Axvisor`].
+//! * **Image commands** (`ls`, `pull`, `resize`, `check`, optionally prefixed
+//!   with `image`) — an `image` prefix is inserted if missing, then forwarded
+//!   to [`axbuild::run_from`] so axbuild's own CLI dispatches them as
+//!   `axbuild::Commands::Image(...)`.
+//!
+//! # Release / standalone distribution
+//!
+//! Inside the tgoskits workspace the dependency `axbuild = { workspace = true }`
+//! resolves via the workspace root. When `os/axvisor` is published or synced
+//! outside this workspace (e.g. as `arceos-hypervisor/axvisor`), one of the
+//! following must be done before `cargo run --bin xtask` will work:
+//!
+//! 1. Publish the `axbuild` crate to crates.io and change this dependency to
+//!    `axbuild = { version = "..." }` — keeps sharing a single implementation.
+//! 2. Extract an `axvisor-build` crate from `axbuild` and depend on that
+//!    instead — narrower dependency, more extraction work.
+//! 3. Vendor the needed build logic directly into this xtask (not recommended;
+//!    duplicates code and drifts over time).
 
 #![cfg_attr(not(any(windows, all(unix, not(target_env = "musl")))), no_main)]
 #![cfg_attr(not(any(windows, all(unix, not(target_env = "musl")))), no_std)]
@@ -30,26 +52,60 @@ use std::{
 };
 
 #[cfg(any(windows, all(unix, not(target_env = "musl"))))]
-#[derive(clap::Parser)]
-struct Cli {
-    #[command(subcommand)]
-    command: axbuild::axvisor::Command,
-}
-
-#[cfg(any(windows, all(unix, not(target_env = "musl"))))]
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     use clap::Parser;
 
-    let mut cli = Cli::parse_from(normalize_legacy_args(std::env::args_os()));
+    let raw_args = normalize_legacy_args(std::env::args_os());
     let invocation_dir = std::env::current_dir()?;
     let workspace_root = workspace_root();
-    normalize_command_paths(&mut cli.command, &invocation_dir, &workspace_root);
-    std::env::set_current_dir(&workspace_root)?;
-    axbuild::axvisor::Axvisor::new()?
-        .execute(cli.command)
-        .await?;
+
+    if is_image_subcommand(&raw_args) {
+        let ax_args = ensure_image_prefix(raw_args);
+        std::env::set_current_dir(&workspace_root)?;
+        axbuild::run_from(ax_args).await?;
+    } else {
+        let mut cli = AxvisorOnlyCli::parse_from(raw_args);
+        normalize_command_paths(&mut cli.command, &invocation_dir, &workspace_root);
+        std::env::set_current_dir(&workspace_root)?;
+        axbuild::axvisor::Axvisor::new()?
+            .execute(cli.command)
+            .await?;
+    }
+
     Ok(())
+}
+
+/// Detect whether the first positional argument after the binary name is an
+/// image subcommand or the `image` keyword itself.
+#[cfg(any(windows, all(unix, not(target_env = "musl"))))]
+fn is_image_subcommand(args: &[OsString]) -> bool {
+    const IMAGE_SUBCOMMANDS: &[&str] = &["ls", "pull", "resize", "check"];
+    let first = args.iter().skip(1).find_map(|a| a.to_str());
+    match first {
+        Some("image") => true,
+        Some(cmd) => IMAGE_SUBCOMMANDS.contains(&cmd),
+        None => false,
+    }
+}
+
+/// Ensure the argument list contains `image` as the first subcommand so
+/// axbuild's own `Cli` dispatches it as `Commands::Image(...)`.
+#[cfg(any(windows, all(unix, not(target_env = "musl"))))]
+fn ensure_image_prefix(mut args: Vec<OsString>) -> Vec<OsString> {
+    if args.get(1).and_then(|a| a.to_str()) == Some("image") {
+        return args;
+    }
+    args.insert(1, OsString::from("image"));
+    args
+}
+
+/// Parser that only recognises Axvisor subcommands.
+#[cfg(any(windows, all(unix, not(target_env = "musl"))))]
+#[derive(clap::Parser)]
+struct AxvisorOnlyCli {
+    #[command(subcommand)]
+    command: axbuild::axvisor::Command,
 }
 
 #[cfg(not(any(windows, all(unix, not(target_env = "musl")))))]
@@ -102,7 +158,7 @@ fn normalize_command_paths(
     invocation_dir: &Path,
     workspace_root: &Path,
 ) {
-    use axbuild::axvisor::{Command, TestCommand, image};
+    use axbuild::axvisor::{Command, TestCommand};
 
     match command {
         Command::Build(args) => normalize_build_paths(args, invocation_dir, workspace_root),
@@ -118,12 +174,6 @@ fn normalize_command_paths(
         Command::Uboot(args) => {
             normalize_build_paths(&mut args.build, invocation_dir, workspace_root);
             normalize_existing_path(&mut args.uboot_config, invocation_dir, workspace_root);
-        }
-        Command::Image(args) => {
-            normalize_output_path(&mut args.overrides.local_storage, invocation_dir);
-            if let image::Command::Pull(args) = &mut args.command {
-                normalize_output_path(&mut args.output_dir, invocation_dir);
-            }
         }
         Command::Test(args) => match &mut args.command {
             TestCommand::Uboot(args) => {
@@ -170,14 +220,5 @@ fn resolve_existing_path(path: &Path, invocation_dir: &Path, workspace_root: &Pa
         workspace_path
     } else {
         cwd_path
-    }
-}
-
-#[cfg(any(windows, all(unix, not(target_env = "musl"))))]
-fn normalize_output_path(path: &mut Option<PathBuf>, invocation_dir: &Path) {
-    if let Some(path) = path
-        && path.is_relative()
-    {
-        *path = invocation_dir.join(&path);
     }
 }

--- a/os/axvisor/xtask/src/main.rs
+++ b/os/axvisor/xtask/src/main.rs
@@ -61,7 +61,8 @@ async fn main() -> anyhow::Result<()> {
     let workspace_root = workspace_root();
 
     if is_image_subcommand(&raw_args) {
-        let ax_args = ensure_image_prefix(raw_args);
+        let mut ax_args = ensure_image_prefix(raw_args);
+        normalize_image_paths(&mut ax_args, &invocation_dir);
         std::env::set_current_dir(&workspace_root)?;
         axbuild::run_from(ax_args).await?;
     } else {
@@ -74,6 +75,61 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+/// Resolve relative paths in image command arguments against the invocation
+/// directory. This must happen *before* `set_current_dir(workspace_root)`,
+/// because axbuild's image logic calls `to_absolute_path()` which resolves
+/// relative paths against `std::env::current_dir()`.
+///
+/// Path-valued flags that are normalised:
+/// - `-S` / `--local-storage`  (image global override)
+/// - `-o` / `--output-dir`     (pull subcommand)
+/// - `--output`                (resize subcommand)
+#[cfg(any(windows, all(unix, not(target_env = "musl"))))]
+fn normalize_image_paths(args: &mut [OsString], invocation_dir: &Path) {
+    const PATH_FLAGS: &[&str] = &["-S", "--local-storage", "-o", "--output-dir", "--output"];
+
+    let mut i = 1; // skip binary name
+    while i < args.len() {
+        let Some(current) = args[i].to_str().map(String::from) else {
+            i += 1;
+            continue;
+        };
+
+        // Handle --flag=<value> / -S=<value> form
+        let mut matched = false;
+        for flag in PATH_FLAGS {
+            let prefix = format!("{flag}=");
+            if let Some(rel) = current.strip_prefix(&prefix) {
+                let path = Path::new(rel);
+                if path.is_relative() {
+                    let abs = invocation_dir.join(path);
+                    args[i] = OsString::from(format!("{flag}={}", abs.display()));
+                }
+                matched = true;
+                break;
+            }
+        }
+        if matched {
+            i += 1;
+            continue;
+        }
+
+        // Handle -S <value> / --flag <value> form
+        if PATH_FLAGS.contains(&current.as_str()) && i + 1 < args.len() {
+            if let Some(val_str) = args[i + 1].to_str() {
+                let path = Path::new(val_str);
+                if path.is_relative() && !val_str.starts_with('-') {
+                    args[i + 1] = OsString::from(invocation_dir.join(path).display().to_string());
+                }
+            }
+            i += 2;
+            continue;
+        }
+
+        i += 1;
+    }
 }
 
 /// Detect whether the first positional argument after the binary name is an
@@ -220,5 +276,130 @@ fn resolve_existing_path(path: &Path, invocation_dir: &Path, workspace_root: &Pa
         workspace_path
     } else {
         cwd_path
+    }
+}
+
+#[cfg(all(test, any(windows, all(unix, not(target_env = "musl")))))]
+mod tests {
+    use std::{ffi::OsString, path::Path};
+
+    use super::normalize_image_paths;
+
+    fn os(s: &str) -> OsString {
+        OsString::from(s)
+    }
+
+    fn assert_path_eq(actual: &OsString, expected: &str) {
+        assert_eq!(actual.to_str().unwrap(), expected, "path mismatch");
+    }
+
+    #[test]
+    fn relative_output_dir_is_resolved() {
+        let inv = Path::new("/home/user/project");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("pull"),
+            os("--output-dir"),
+            os("out/images"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[4], "/home/user/project/out/images");
+    }
+
+    #[test]
+    fn relative_output_dir_equals_form() {
+        let inv = Path::new("/home/user/project");
+        let mut args = vec![os("xtask"), os("pull"), os("--output-dir=../staging")];
+        normalize_image_paths(&mut args, inv);
+        // Path::join preserves `..` components (matching `to_absolute_path` in
+        // axbuild); the filesystem resolves them equivalently.
+        assert_path_eq(&args[2], "--output-dir=/home/user/project/../staging");
+    }
+
+    #[test]
+    fn relative_local_storage_short_flag() {
+        let inv = Path::new("/tmp/work");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("-S"),
+            os("my-store"),
+            os("pull"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[3], "/tmp/work/my-store");
+    }
+
+    #[test]
+    fn relative_local_storage_equals_form() {
+        let inv = Path::new("/tmp/work");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("--local-storage=cache/img"),
+            os("pull"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[2], "--local-storage=/tmp/work/cache/img");
+    }
+
+    #[test]
+    fn absolute_path_untouched() {
+        let inv = Path::new("/home/user/project");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("pull"),
+            os("--output-dir"),
+            os("/absolute/path"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        // absolute path unchanged
+        assert_path_eq(&args[4], "/absolute/path");
+    }
+
+    #[test]
+    fn output_flag_for_resize() {
+        let inv = Path::new("/home/user/project");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("resize"),
+            os("rootfs.img"),
+            os("--output"),
+            os("resized.img"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[5], "/home/user/project/resized.img");
+    }
+
+    #[test]
+    fn short_o_flag_with_equals_is_normalised() {
+        // `-o=<value>` is valid clap syntax (clap accepts `=` form for short flags too).
+        let inv = Path::new("/home/user/project");
+        let mut args = vec![os("xtask"), os("image"), os("pull"), os("-o=tmp/out")];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[3], "-o=/home/user/project/tmp/out");
+    }
+
+    #[test]
+    fn non_path_value_not_starts_with_dash() {
+        // -S followed by a flag-like value should not be treated as a path
+        let inv = Path::new("/home/user/project");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("pull"),
+            os("-S"),
+            os("--another-flag"),
+        ];
+        let expected = args.clone();
+        normalize_image_paths(&mut args, inv);
+        assert_eq!(args, expected);
     }
 }

--- a/os/axvisor/xtask/src/main.rs
+++ b/os/axvisor/xtask/src/main.rs
@@ -47,7 +47,7 @@ mod lang;
 
 #[cfg(any(windows, all(unix, not(target_env = "musl"))))]
 use std::{
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     path::{Path, PathBuf},
 };
 
@@ -92,20 +92,17 @@ fn normalize_image_paths(args: &mut [OsString], invocation_dir: &Path) {
 
     let mut i = 1; // skip binary name
     while i < args.len() {
-        let Some(current) = args[i].to_str().map(String::from) else {
-            i += 1;
-            continue;
-        };
-
-        // Handle --flag=<value> / -S=<value> form
+        // Handle --flag=<value> / -S=<value> form.
+        // Match the ASCII flag prefix at the byte level via try_strip_prefix so
+        // that non-UTF-8 path values (valid on POSIX) are not silently dropped.
         let mut matched = false;
         for flag in PATH_FLAGS {
             let prefix = format!("{flag}=");
-            if let Some(rel) = current.strip_prefix(&prefix) {
-                let path = Path::new(rel);
+            if let Some(rest) = try_strip_prefix(&args[i], &prefix) {
+                let path = Path::new(rest);
                 if path.is_relative() {
                     let abs = invocation_dir.join(path);
-                    args[i] = OsString::from(format!("{flag}={}", abs.display()));
+                    args[i] = prepend_flag(flag, &abs);
                 }
                 matched = true;
                 break;
@@ -116,12 +113,18 @@ fn normalize_image_paths(args: &mut [OsString], invocation_dir: &Path) {
             continue;
         }
 
-        // Handle -S <value> / --flag <value> form
-        if PATH_FLAGS.contains(&current.as_str()) && i + 1 < args.len() {
-            if let Some(val_str) = args[i + 1].to_str() {
-                let path = Path::new(val_str);
-                if path.is_relative() && !val_str.starts_with('-') {
-                    args[i + 1] = OsString::from(invocation_dir.join(path).display().to_string());
+        // Handle -S <value> / --flag <value> form.
+        // Flag tokens are always ASCII so to_str() is safe for the flag check;
+        // the path value is handled as OsStr to preserve non-UTF-8 bytes.
+        if let Some(current_str) = args[i].to_str()
+            && PATH_FLAGS.contains(&current_str)
+            && i + 1 < args.len()
+        {
+            let val = &args[i + 1];
+            if !looks_like_flag(val) {
+                let path = Path::new(val);
+                if path.is_relative() {
+                    args[i + 1] = invocation_dir.join(path).into_os_string();
                 }
             }
             i += 2;
@@ -130,6 +133,52 @@ fn normalize_image_paths(args: &mut [OsString], invocation_dir: &Path) {
 
         i += 1;
     }
+}
+
+/// Strip `prefix` (which must be ASCII) from an `OsStr`.
+///
+/// On Unix this operates at the byte level so non-UTF-8 path content is
+/// preserved; on Windows it falls back to string matching.
+#[cfg(unix)]
+fn try_strip_prefix<'a>(os: &'a OsStr, prefix: &str) -> Option<&'a OsStr> {
+    use std::os::unix::ffi::OsStrExt;
+    os.as_bytes()
+        .strip_prefix(prefix.as_bytes())
+        .map(OsStr::from_bytes)
+}
+
+#[cfg(not(unix))]
+fn try_strip_prefix<'a>(os: &'a OsStr, prefix: &str) -> Option<&'a OsStr> {
+    os.to_str()
+        .and_then(|s| s.strip_prefix(prefix))
+        .map(OsStr::new)
+}
+
+/// Returns `true` when `os` starts with a `-` byte (i.e. looks like a flag).
+#[cfg(unix)]
+fn looks_like_flag(os: &OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    os.as_bytes().first() == Some(&b'-')
+}
+
+#[cfg(not(unix))]
+fn looks_like_flag(os: &OsStr) -> bool {
+    os.to_str().map_or(false, |s| s.starts_with('-'))
+}
+
+/// Reconstruct `flag=absolute_path` as an `OsString`, preserving non-UTF-8
+/// bytes in `abs` on Unix.
+#[cfg(unix)]
+fn prepend_flag(flag: &str, abs: &Path) -> OsString {
+    let mut os = OsString::from(flag);
+    os.push("=");
+    os.push(abs);
+    os
+}
+
+#[cfg(not(unix))]
+fn prepend_flag(flag: &str, abs: &Path) -> OsString {
+    OsString::from(format!("{flag}={}", abs.display()))
 }
 
 /// Detect whether the first positional argument after the binary name is an
@@ -281,7 +330,10 @@ fn resolve_existing_path(path: &Path, invocation_dir: &Path, workspace_root: &Pa
 
 #[cfg(all(test, any(windows, all(unix, not(target_env = "musl")))))]
 mod tests {
-    use std::{ffi::OsString, path::Path};
+    use std::{
+        ffi::{OsStr, OsString},
+        path::Path,
+    };
 
     use super::normalize_image_paths;
 
@@ -401,5 +453,44 @@ mod tests {
         let expected = args.clone();
         normalize_image_paths(&mut args, inv);
         assert_eq!(args, expected);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn non_utf8_local_storage_short_flag() {
+        use std::os::unix::ffi::OsStrExt;
+        let inv = Path::new("/tmp/work");
+        let val = OsString::from(OsStr::from_bytes(b"cache-\xff"));
+        let mut args = vec![
+            OsString::from("xtask"),
+            OsString::from("image"),
+            OsString::from("-S"),
+            val,
+            OsString::from("pull"),
+            OsString::from("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        let mut expected = Vec::from(b"/tmp/work/cache-");
+        expected.push(0xff);
+        assert_eq!(args[3].as_bytes(), expected.as_slice());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn non_utf8_local_storage_equals_form() {
+        use std::os::unix::ffi::OsStrExt;
+        let inv = Path::new("/tmp/work");
+        let arg = OsString::from(OsStr::from_bytes(b"--local-storage=cache-\xff"));
+        let mut args = vec![
+            OsString::from("xtask"),
+            OsString::from("image"),
+            arg,
+            OsString::from("pull"),
+            OsString::from("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        let mut expected = Vec::from(b"--local-storage=/tmp/work/cache-");
+        expected.push(0xff);
+        assert_eq!(args[2].as_bytes(), expected.as_slice());
     }
 }

--- a/os/axvisor/xtask/src/main.rs
+++ b/os/axvisor/xtask/src/main.rs
@@ -107,6 +107,28 @@ fn normalize_image_paths(args: &mut [OsString], invocation_dir: &Path) {
                 matched = true;
                 break;
             }
+
+            // Handle attached short options: -Svalue / -ovalue (no =, no space).
+            // Must come AFTER the =<value> check so -S=cache is still handled
+            // by that branch.
+            if flag.len() == 2
+                && let Some(rest) = try_strip_prefix(&args[i], flag)
+            {
+                // Skip empty (bare -S falls through to space form) and
+                // = prefixed (already handled by the = form above).
+                if !rest.is_empty() && !starts_with_equals(rest) {
+                    let path = Path::new(rest);
+                    if path.is_relative() {
+                        let abs = invocation_dir.join(path);
+                        // Reconstruct as -S/path (no =, preserving attached form)
+                        let mut new_arg = OsString::from(flag);
+                        new_arg.push(abs);
+                        args[i] = new_arg;
+                    }
+                    matched = true;
+                    break;
+                }
+            }
         }
         if matched {
             i += 1;
@@ -164,6 +186,18 @@ fn looks_like_flag(os: &OsStr) -> bool {
 #[cfg(not(unix))]
 fn looks_like_flag(os: &OsStr) -> bool {
     os.to_str().map_or(false, |s| s.starts_with('-'))
+}
+
+/// Returns `true` when `os` starts with an `=` byte.
+#[cfg(unix)]
+fn starts_with_equals(os: &OsStr) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    os.as_bytes().first() == Some(&b'=')
+}
+
+#[cfg(not(unix))]
+fn starts_with_equals(os: &OsStr) -> bool {
+    os.to_str().map_or(false, |s| s.starts_with('='))
 }
 
 /// Reconstruct `flag=absolute_path` as an `OsString`, preserving non-UTF-8
@@ -492,5 +526,140 @@ mod tests {
         let mut expected = Vec::from(b"--local-storage=/tmp/work/cache-");
         expected.push(0xff);
         assert_eq!(args[2].as_bytes(), expected.as_slice());
+    }
+
+    #[test]
+    fn attached_short_s_form_is_normalised() {
+        // -Scache → -S/tmp/work/cache (no = sign, attached form preserved)
+        let inv = Path::new("/tmp/work");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("-Scache"),
+            os("pull"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[2], "-S/tmp/work/cache");
+    }
+
+    #[test]
+    fn attached_short_o_form_is_normalised() {
+        // -oout → -o/home/user/project/out
+        let inv = Path::new("/home/user/project");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("pull"),
+            os("-oout"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[3], "-o/home/user/project/out");
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn attached_short_s_form_non_utf8() {
+        use std::os::unix::ffi::OsStrExt;
+        let inv = Path::new("/tmp/work");
+        let mut arg_bytes = Vec::from(b"-Scache-");
+        arg_bytes.push(0xff);
+        let arg = OsString::from(OsStr::from_bytes(&arg_bytes));
+        let mut args = vec![
+            OsString::from("xtask"),
+            OsString::from("image"),
+            arg,
+            OsString::from("pull"),
+            OsString::from("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        let mut expected = Vec::from(b"-S/tmp/work/cache-");
+        expected.push(0xff);
+        assert_eq!(args[2].as_bytes(), expected.as_slice());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn attached_short_o_form_non_utf8() {
+        use std::os::unix::ffi::OsStrExt;
+        let inv = Path::new("/home/user/project");
+        let mut arg_bytes = Vec::from(b"-oout-");
+        arg_bytes.push(0xff);
+        let arg = OsString::from(OsStr::from_bytes(&arg_bytes));
+        let mut args = vec![
+            OsString::from("xtask"),
+            OsString::from("image"),
+            OsString::from("pull"),
+            arg,
+            OsString::from("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        let mut expected = Vec::from(b"-o/home/user/project/out-");
+        expected.push(0xff);
+        assert_eq!(args[3].as_bytes(), expected.as_slice());
+    }
+
+    #[test]
+    fn attached_short_absolute_path_unchanged() {
+        // -S/absolute should not be touched
+        let inv = Path::new("/tmp/work");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("-S/usr/local"),
+            os("pull"),
+            os("qemu-aarch64"),
+        ];
+        let expected = args.clone();
+        normalize_image_paths(&mut args, inv);
+        assert_eq!(args, expected);
+    }
+
+    #[test]
+    fn attached_short_equals_form_still_works() {
+        // -S=rel must still be handled by the = form (regression guard)
+        let inv = Path::new("/tmp/work");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("-S=rel"),
+            os("pull"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[2], "-S=/tmp/work/rel");
+    }
+
+    #[test]
+    fn attached_short_combined_s_o() {
+        // Clap treats -So as -S with value "o", not -S + -o
+        let inv = Path::new("/tmp/work");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("-So"),
+            os("pull"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[2], "-S/tmp/work/o");
+    }
+
+    #[test]
+    fn attached_short_alone_falls_through() {
+        // Bare -S with no attached value: the fallthrough to space form
+        // must still work (regression guard).
+        let inv = Path::new("/tmp/work");
+        let mut args = vec![
+            os("xtask"),
+            os("image"),
+            os("-S"),
+            os("store"),
+            os("pull"),
+            os("qemu-aarch64"),
+        ];
+        normalize_image_paths(&mut args, inv);
+        assert_path_eq(&args[3], "/tmp/work/store");
     }
 }

--- a/scripts/axbuild/src/lib.rs
+++ b/scripts/axbuild/src/lib.rs
@@ -105,6 +105,18 @@ pub async fn run() -> anyhow::Result<()> {
     run_root_cli(cli).await
 }
 
+/// Like [`run`], but parses from an explicit argument list instead of
+/// [`std::env::args_os`].  Used by external tools (e.g. the axvisor
+/// xtask) that dispatch a sub‑command through axbuild's own CLI.
+pub async fn run_from<I, T>(args: I) -> anyhow::Result<()>
+where
+    I: IntoIterator<Item = T>,
+    T: Into<std::ffi::OsString> + Clone,
+{
+    let cli = Cli::parse_from(args);
+    run_root_cli(cli).await
+}
+
 async fn run_root_cli(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Commands::AgentReviewBench { command } => agent_review_bench::execute(command).await,


### PR DESCRIPTION
### 问题

3 月 axbuild 统一重构后，`os/axvisor/xtask/src/main.rs` 引用了已废弃的 `axbuild::axvisor::image` 模块路径，导致 axvisor 在 tgoskits workspace 外无法独立编译运行。同时 `image` 子命令混入 Axvisor 命令解析器，缺少直接路由到 `axbuild` 顶层 CLI 的机制。

三个衍生问题：
1. Image 命令路由到 `axbuild::run_from()` 前会 `cd` 到 workspace root，但 `--local-storage` 和 `--output-dir` 中的相对路径在 axbuild 内部通过 `to_absolute_path()` → `std::env::current_dir()` 解析，此时 CWD 已是 workspace root 而非用户启动目录，导致相对路径解析错误。
2. `normalize_image_paths` 用 `to_str()` 处理路径值，对非 UTF-8 POSIX 文件名（有效字节序列如 `cache-\xff`）静默返回 `None`，相对路径被跳过，同样从 workspace root 而非调用目录解析。
3. `normalize_image_paths` 只处理 `=` 形式和空格分隔形式，遗漏了 Clap 接受的附着短选项形式（`-Scache`、`-oout`），同样造成相对路径解析错误。

### 修改

修改 2 个文件：

- `os/axvisor/xtask/src/main.rs` (+443 / -2)：CLI 双路由架构 + 路径规范化（含非 UTF-8 + 附着短选项支持）
- `scripts/axbuild/src/lib.rs`：新增 `run_from()` 公开 API

### 每一步的逻辑

1. **双路由架构** — Image 命令（`ls/pull/resize/check`）和 Axvisor 命令（`build/qemu/board/test/uboot/defconfig/config`）解析路径不同。前者需 `axbuild` 的完整 CLI（`Commands::Image`），后者应只暴露 7 个子命令避免歧义。
2. **自动补全 `image` 前缀** — 保留 `cargo xtask pull` 简写：`ensure_image_prefix()` 检测到省略时插入 `image`。
3. **提取 `run_from()`** — 避免将 axvisor xtask 逻辑耦合进 `axbuild::run()`，通过泛型接口供外部调用。
4. **清理死代码** — `Command::Image` 和 `normalize_output_path` 仅用于 Image，双路由后安全删除。
5. **Image 路径规范化** — 新增 `normalize_image_paths()`，在 `set_current_dir(workspace_root)` 之前扫描 raw args 中的 path-valued flags（`-S`/`--local-storage`、`-o`/`--output-dir`、`--output`），将相对路径 resolve 为基于 `invocation_dir` 的绝对路径。
6. **非 UTF-8 路径支持** — `=` 格式用 `try_strip_prefix` 在字节级别匹配 flag 前缀；空格分隔格式直接用 `Path::new(OsStr)` 替换 `to_str()`；用 `OsString::push` 重构输出路径避免 `display()` 丢失非 UTF-8 内容。
7. **附着短选项支持** — 在 `=` 形式检查之后追加附着短选项分支，用 `starts_with_equals` 防止与 `=` 形式混淆，重建为 `-S/path` 保持用户原始风格；空值穿透到空格分支处理。

### 兼容性

> 本 PR 修改的是 `os/axvisor/xtask/src/main.rs`（axvisor 自有 xtask，作为 `axvisor` 包的 `[[bin]]` 定义）。在 workspace 内 `cargo xtask <cmd>` 由 `.cargo/config.toml` 别名路由到 `tg-xtask`，不走本 binary。以下兼容性表针对 **axvisor 独立 xtask** 描述。

| 命令 | 状态 |
|---|---|
| `cargo run -p axvisor --bin xtask -- build` | ✅ |
| `cargo run -p axvisor --bin xtask -- qemu` | ✅ |
| `cargo run -p axvisor --bin xtask -- board` | ✅ |
| `cargo run -p axvisor --bin xtask -- test` | ✅ |
| `cargo run -p axvisor --bin xtask -- uboot` | ✅ |
| `cargo run -p axvisor --bin xtask -- defconfig` | ✅ |
| `cargo run -p axvisor --bin xtask -- config ls` | ✅ |
| `cargo run -p axvisor --bin xtask -- pull`（省略 image） | ✅ 自动补全 |
| `cargo run -p axvisor --bin xtask -- --build-config` | ✅ 别名 |
| `cargo run -p axvisor --bin xtask -- --help` | ✅ 仅 Axvisor 子命令 |
| image 路径含非 UTF-8 字节 | ✅ OsStr 级别处理 |
| 附着短选项 `-Scache` / `-oout` | ✅ 规范化到调用目录 |

### 阻塞问题处理

| 反馈来源 | 问题 | 处理 |
|---|---|---|
| Review 1 (Jul 20) | image 相对路径从 workspace root 而非 CWD 解析 | `normalize_image_paths()` 在 `cd` 前 resolve 到 `invocation_dir` |
| Review 2, 3 (Jul 20) | `to_str()` 丢失非 UTF-8 路径字节 | `try_strip_prefix` / `looks_like_flag` / `prepend_flag` 三辅助函数，字节级 OsStr 操作 |
| Review 3 inline (Jul 29) | 附着短选项形式遗漏 | 附着短选项检查分支 + `starts_with_equals` 辅助函数 |

### 测试

- [x] `cargo clippy -p axvisor --bin xtask -- -D warnings` 无警告
- [x] 18 个单元测试全部通过：原有 10 个 + 新增 8 个附着短选项测试
- [x] 从 `/tmp` 运行 `xtask image pull --help` 和 `xtask config ls` 正常