### PR TITLE
fix(starry-kernel): support usbfs clear-halt and close cleanup

### DIFF
--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
@@ -2298,6 +2298,20 @@ impl crate::backend::ty::ep::EndpointOp for Dwc2Endpoint {
         self.channel_completions.publish(self.channel, HCINT_CHHLTD);
         Ok(())
     }
+
+    fn reset(&mut self) -> crate::backend::ty::ep::EndpointResetFuture {
+        let result = if self.active.is_some() || self.completed.is_some() {
+            Err(TransferError::QueueFull)
+        } else {
+            let _guard = self.channel_gate.lock();
+            self.channel_completions.clear(self.channel);
+            self.regs
+                .channel_write32(self.channel, HCINT, HCINT_ALL_W1C);
+            self.data_toggle = DataToggle::data0();
+            Ok(())
+        };
+        Box::pin(async move { result })
+    }
 }
 
 fn successful_packet_count(actual: usize, requested: usize, max_packet_size: u16) -> u32 {

--- a/drivers/usb/usb-host/src/backend/kmod/ehci/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/ehci/mod.rs
@@ -1297,6 +1297,22 @@ impl crate::backend::ty::ep::EndpointOp for EhciEndpoint {
         submitted.cancelled = true;
         Ok(())
     }
+
+    fn reset(&mut self) -> crate::backend::ty::ep::EndpointResetFuture {
+        let result = if self.inflight.is_some() {
+            Err(TransferError::QueueFull)
+        } else {
+            let qh_addr = self.qh.dma_addr().as_u64() as u32;
+            self.schedule.detach(qh_addr);
+            self.qh.modify_cpu(|qh| {
+                qh.current_qtd = 0;
+                qh.overlay = QueueTransferDescriptor::terminated();
+            });
+            mb();
+            Ok(())
+        };
+        Box::pin(async move { result })
+    }
 }
 
 struct SubmittedTransfer {

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/device.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/device.rs
@@ -84,7 +84,13 @@ impl Device {
     }
 
     fn new_ep(&mut self, dci: Dci) -> Result<XhciEndpoint> {
-        let ep = XhciEndpoint::new(dci, &self.kernel, self.bell.clone())?;
+        let ep = XhciEndpoint::new(
+            self.id,
+            dci,
+            &self.kernel,
+            self.bell.clone(),
+            self.cmd.clone(),
+        )?;
         self.transfer_result_handler
             .register_queue(self.id.as_u8(), dci.as_u8(), ep.ring());
 

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -1,4 +1,5 @@
-use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec, vec::Vec};
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use ax_kspin::SpinRaw as Mutex;
 use dma_api::DmaDirection;
@@ -12,18 +13,21 @@ use usb_if::{
 use xhci::{
     registers::doorbell,
     ring::trb::{
-        event::TransferEvent,
+        command,
+        event::{CompletionCode, TransferEvent},
         transfer::{self, Isoch, Normal},
     },
 };
 
-use super::{DirectionExt, reg::SlotBell, ring::SendRing, transfer::TransferId};
+use super::{
+    DirectionExt, SlotId, cmd::CommandRing, reg::SlotBell, ring::SendRing, transfer::TransferId,
+};
 use crate::{
     BusAddr,
     backend::{
         Dci,
         ty::{
-            ep::{EndpointOp, transfer_to_completion},
+            ep::{EndpointOp, EndpointResetFuture, transfer_to_completion},
             transfer::{Transfer, TransferKind},
         },
     },
@@ -91,9 +95,13 @@ struct IsoPacketTd {
 }
 
 pub struct Endpoint {
+    slot_id: SlotId,
     dci: Dci,
     pub ring: SendRing<TransferEvent>,
     bell: Arc<Mutex<SlotBell>>,
+    cmd: CommandRing,
+    halted: Arc<AtomicBool>,
+    reset_in_progress: Arc<AtomicBool>,
     next_request_id: u64,
     inflight: BTreeMap<EndpointRequestId, SubmittedTd>,
     trb_to_request: BTreeMap<TransferId, EndpointRequestId>,
@@ -112,14 +120,24 @@ unsafe impl Sync for Endpoint {}
 const ENDPOINT_RING_PAGES: usize = 16;
 
 impl Endpoint {
-    pub fn new(dci: Dci, kernel: &Kernel, bell: Arc<Mutex<SlotBell>>) -> crate::err::Result<Self> {
+    pub fn new(
+        slot_id: SlotId,
+        dci: Dci,
+        kernel: &Kernel,
+        bell: Arc<Mutex<SlotBell>>,
+        cmd: CommandRing,
+    ) -> crate::err::Result<Self> {
         let ring =
             SendRing::new_with_pages(ENDPOINT_RING_PAGES, DmaDirection::Bidirectional, kernel)?;
 
         Ok(Self {
+            slot_id,
             dci,
             ring,
             bell,
+            cmd,
+            halted: Arc::new(AtomicBool::new(false)),
+            reset_in_progress: Arc::new(AtomicBool::new(false)),
             next_request_id: 1,
             inflight: BTreeMap::new(),
             trb_to_request: BTreeMap::new(),
@@ -251,6 +269,9 @@ impl Endpoint {
             return Err(TransferError::Cancelled);
         }
 
+        if matches!(event.completion_code(), Ok(CompletionCode::StallError)) {
+            self.halted.store(true, Ordering::Release);
+        }
         if !matches!(submitted.kind, SubmittedTdKind::Iso { .. }) {
             self.validate_completion_code(event, &submitted.transfer)?;
         }
@@ -597,6 +618,9 @@ impl Endpoint {
 
 impl EndpointOp for Endpoint {
     fn submit_request(&mut self, request: TransferRequest) -> Result<RequestId, TransferError> {
+        if self.reset_in_progress.load(Ordering::Acquire) {
+            return Err(TransferError::QueueFull);
+        }
         let required_trbs = Self::required_trbs_for_request(&request);
         self.ensure_ring_capacity(required_trbs)?;
         let transfer = Transfer::from_request(&self.kernel, request)?;
@@ -804,6 +828,60 @@ impl EndpointOp for Endpoint {
             .ok_or(TransferError::InvalidEndpoint)?;
         submitted.cancelled = true;
         Ok(())
+    }
+
+    fn reset(&mut self) -> EndpointResetFuture {
+        if !self.inflight.is_empty() || self.outstanding_trbs != 0 {
+            return Box::pin(async { Err(TransferError::QueueFull) });
+        }
+        if !self.halted.load(Ordering::Acquire) {
+            return Box::pin(async { Ok(()) });
+        }
+        if self
+            .reset_in_progress
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Box::pin(async { Err(TransferError::QueueFull) });
+        }
+
+        let (dequeue_pointer, dequeue_cycle_state) = self.ring.enqueue_pointer();
+        let slot_id = self.slot_id.as_u8();
+        let endpoint_id = self.dci.as_u8();
+        let mut cmd = self.cmd.clone();
+        let halted = self.halted.clone();
+        let reset_in_progress = self.reset_in_progress.clone();
+
+        Box::pin(async move {
+            let result = async {
+                let reset_endpoint = *command::ResetEndpoint::default()
+                    .set_endpoint_id(endpoint_id)
+                    .set_slot_id(slot_id);
+                cmd.cmd_request(command::Allowed::ResetEndpoint(reset_endpoint))
+                    .await?;
+
+                let mut set_dequeue_pointer = command::SetTrDequeuePointer::default();
+                set_dequeue_pointer
+                    .set_new_tr_dequeue_pointer(dequeue_pointer.raw())
+                    .set_endpoint_id(endpoint_id)
+                    .set_slot_id(slot_id);
+                if dequeue_cycle_state {
+                    set_dequeue_pointer.set_dequeue_cycle_state();
+                } else {
+                    set_dequeue_pointer.clear_dequeue_cycle_state();
+                }
+                cmd.cmd_request(command::Allowed::SetTrDequeuePointer(set_dequeue_pointer))
+                    .await?;
+                Ok(())
+            }
+            .await;
+
+            if result.is_ok() {
+                halted.store(false, Ordering::Release);
+            }
+            reset_in_progress.store(false, Ordering::Release);
+            result
+        })
     }
 }
 

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/ring.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/ring.rs
@@ -264,4 +264,8 @@ impl<R> SendRing<R> {
     pub fn cycle(&self) -> bool {
         self.ring.cycle
     }
+
+    pub fn enqueue_pointer(&self) -> (BusAddr, bool) {
+        (self.ring.trb_bus_addr(self.ring.i), self.ring.cycle)
+    }
 }

--- a/drivers/usb/usb-host/src/backend/ty/ep/mod.rs
+++ b/drivers/usb/usb-host/src/backend/ty/ep/mod.rs
@@ -34,7 +34,14 @@ pub(crate) trait EndpointOp: Send + Any + 'static {
     fn cancel_request(&mut self, _id: RequestId) -> Result<(), TransferError> {
         Err(TransferError::NotSupported)
     }
+
+    fn reset(&mut self) -> EndpointResetFuture {
+        Box::pin(async { Err(TransferError::NotSupported) })
+    }
 }
+
+pub type EndpointResetFuture =
+    Pin<Box<dyn Future<Output = Result<(), TransferError>> + Send + 'static>>;
 
 pub struct Endpoint {
     info: EndpointInfo,
@@ -85,6 +92,12 @@ impl Endpoint {
 
     pub fn cancel(&mut self, id: RequestId) -> Result<(), TransferError> {
         self.raw.cancel_request(id)
+    }
+
+    /// Resets host-controller state for this endpoint after a successful
+    /// `CLEAR_FEATURE(ENDPOINT_HALT)` request.
+    pub fn reset(&mut self) -> EndpointResetFuture {
+        self.raw.reset()
     }
 
     pub async fn wait(

--- a/drivers/usb/usb-host/src/backend/umod/endpoint.rs
+++ b/drivers/usb/usb-host/src/backend/umod/endpoint.rs
@@ -6,9 +6,9 @@ use std::{
 
 use futures::task::AtomicWaker;
 use libusb1_sys::{
-    libusb_cancel_transfer, libusb_control_transfer_get_data, libusb_fill_bulk_transfer,
-    libusb_fill_control_setup, libusb_fill_control_transfer, libusb_fill_iso_transfer,
-    libusb_submit_transfer, libusb_transfer,
+    libusb_cancel_transfer, libusb_clear_halt, libusb_control_transfer_get_data,
+    libusb_fill_bulk_transfer, libusb_fill_control_setup, libusb_fill_control_transfer,
+    libusb_fill_iso_transfer, libusb_submit_transfer, libusb_transfer,
 };
 use log::trace;
 use usb_if::{
@@ -19,7 +19,7 @@ use usb_if::{
 
 use super::{device::DeviceHandle, err::transfer_status_to_result};
 use crate::backend::ty::{
-    ep::{EndpointOp, transfer_to_completion},
+    ep::{EndpointOp, EndpointResetFuture, transfer_to_completion},
     transfer::{Transfer, TransferKind},
 };
 
@@ -247,6 +247,22 @@ impl EndpointOp for EndpointImpl {
                 "Failed to cancel transfer: libusb error {res}"
             )))
         }
+    }
+
+    fn reset(&mut self) -> EndpointResetFuture {
+        let result = if self.transfers.is_empty() {
+            let status = unsafe { libusb_clear_halt(self.dev.raw(), self.address) };
+            if status == libusb1_sys::constants::LIBUSB_SUCCESS {
+                Ok(())
+            } else {
+                Err(TransferError::Other(anyhow!(
+                    "Failed to reset endpoint: libusb error {status}"
+                )))
+            }
+        } else {
+            Err(TransferError::QueueFull)
+        };
+        Box::pin(async move { result })
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
@@ -807,11 +807,26 @@ impl UsbFsManager {
     fn live_clear_halt(&self, stable_id: UsbStableId, endpoint: u8) -> AxResult<()> {
         self.live_ensure_configured(stable_id)?;
         let live_device = self.live_device_by_id(stable_id)?;
-        wait_control(
-            live_device,
-            TransferRequest::control_out(clear_halt_setup(endpoint), &[]),
-        )?;
-        Ok(())
+        let endpoint_handle = live_device
+            .endpoints
+            .read()
+            .get(&endpoint)
+            .cloned()
+            .ok_or(AxError::NotFound)?;
+
+        clear_halt_then_reset(
+            || {
+                wait_control(
+                    live_device,
+                    TransferRequest::control_out(clear_halt_setup(endpoint), &[]),
+                )
+                .map(|_| ())
+            },
+            || {
+                let reset = endpoint_handle.lock().reset();
+                ax_task::future::block_on(reset).map_err(map_transfer_error)
+            },
+        )
     }
 
     fn live_claim_interface(
@@ -1365,19 +1380,12 @@ fn clear_halt_setup(endpoint: u8) -> ControlSetup {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn clear_halt_uses_standard_endpoint_clear_feature_request() {
-        let setup = clear_halt_setup(0x82);
-        assert_eq!(setup.request_type as u8, RequestType::Standard as u8);
-        assert_eq!(setup.recipient as u8, Recipient::Endpoint as u8);
-        assert_eq!(u8::from(setup.request), u8::from(Request::ClearFeature));
-        assert_eq!(setup.value, 0);
-        assert_eq!(setup.index, 0x82);
-    }
+fn clear_halt_then_reset<E>(
+    clear_device_halt: impl FnOnce() -> Result<(), E>,
+    reset_host_endpoint: impl FnOnce() -> Result<(), E>,
+) -> Result<(), E> {
+    clear_device_halt()?;
+    reset_host_endpoint()
 }
 
 pub(super) fn discover_hosts() -> (Vec<UsbHostState>, Vec<PendingUsbIrqSlot>) {
@@ -1439,4 +1447,37 @@ pub(super) fn discover_hosts() -> (Vec<UsbHostState>, Vec<PendingUsbIrqSlot>) {
 
     info!("usbfs: discovered {} USB host(s)", initialized_hosts.len());
     (initialized_hosts, irq_slots)
+}
+
+#[cfg(test)]
+mod tests {
+    use core::cell::Cell;
+
+    use super::*;
+
+    #[test]
+    fn clear_halt_uses_standard_endpoint_clear_feature_request() {
+        let setup = clear_halt_setup(0x82);
+        assert_eq!(setup.request_type as u8, RequestType::Standard as u8);
+        assert_eq!(setup.recipient as u8, Recipient::Endpoint as u8);
+        assert_eq!(u8::from(setup.request), u8::from(Request::ClearFeature));
+        assert_eq!(setup.value, 0);
+        assert_eq!(setup.index, 0x82);
+    }
+
+    #[test]
+    fn clear_halt_does_not_reset_host_endpoint_when_control_request_fails() {
+        let reset_called = Cell::new(false);
+
+        let result = clear_halt_then_reset(
+            || Err("control request failed"),
+            || {
+                reset_called.set(true);
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, Err("control request failed"));
+        assert!(!reset_called.get());
+    }
 }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
@@ -353,6 +353,10 @@ impl UsbDeviceLease {
         self.manager
             .live_release_interface(self.stable_id, self.session_id, interface)
     }
+
+    pub(super) fn clear_halt(&self, endpoint: u8) -> AxResult<()> {
+        self.manager.live_clear_halt(self.stable_id, endpoint)
+    }
 }
 
 impl Drop for UsbDeviceLease {
@@ -798,6 +802,16 @@ impl UsbFsManager {
             Direction::Out => wait_control(live_device, TransferRequest::control_out(setup, data))
                 .map(|completion| completion.actual_length),
         }
+    }
+
+    fn live_clear_halt(&self, stable_id: UsbStableId, endpoint: u8) -> AxResult<()> {
+        self.live_ensure_configured(stable_id)?;
+        let live_device = self.live_device_by_id(stable_id)?;
+        wait_control(
+            live_device,
+            TransferRequest::control_out(clear_halt_setup(endpoint), &[]),
+        )?;
+        Ok(())
     }
 
     fn live_claim_interface(
@@ -1338,6 +1352,31 @@ fn recipient_from_raw(raw: u8) -> Recipient {
         1 => Recipient::Interface,
         2 => Recipient::Endpoint,
         _ => Recipient::Other,
+    }
+}
+
+fn clear_halt_setup(endpoint: u8) -> ControlSetup {
+    ControlSetup {
+        request_type: RequestType::Standard,
+        recipient: Recipient::Endpoint,
+        request: Request::ClearFeature,
+        value: 0,
+        index: endpoint as u16,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clear_halt_uses_standard_endpoint_clear_feature_request() {
+        let setup = clear_halt_setup(0x82);
+        assert_eq!(setup.request_type as u8, RequestType::Standard as u8);
+        assert_eq!(setup.recipient as u8, Recipient::Endpoint as u8);
+        assert_eq!(u8::from(setup.request), u8::from(Request::ClearFeature));
+        assert_eq!(setup.value, 0);
+        assert_eq!(setup.index, 0x82);
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -1342,6 +1342,14 @@ impl FileLike for UsbDeviceFile {
                 self.claim_interface(set.interface as u8, set.altsetting as u8, true)
             }
             descriptor::USBDEVFS_SETCONFIGURATION => self.set_configuration_ioctl(arg),
+            descriptor::USBDEVFS_CLEAR_HALT => {
+                let endpoint = descriptor::read_usbdevfs_u32(arg)?;
+                if endpoint > u8::MAX as u32 {
+                    return Err(AxError::InvalidInput);
+                }
+                self.with_live_lease(|lease| lease.clear_halt(endpoint as u8))?;
+                Ok(0)
+            }
             descriptor::USBDEVFS_IOCTL => self.kernel_driver_ioctl(arg),
             descriptor::USBDEVFS_DISCONNECT | descriptor::USBDEVFS_CONNECT => Ok(0),
             descriptor::USBDEVFS_DISCONNECT_CLAIM => self.disconnect_claim_ioctl(arg),
@@ -1398,6 +1406,17 @@ impl Drop for UsbDeviceFile {
     fn drop(&mut self) {
         self.urb_worker.close();
         let lease = self.lease.lock().take();
+        if let Some(lease) = lease.as_ref() {
+            let interfaces = self
+                .claimed_interfaces
+                .lock()
+                .keys()
+                .copied()
+                .collect::<Vec<_>>();
+            for interface in interfaces {
+                let _ = lease.release_interface(interface);
+            }
+        }
         let submitted = self.drain_all_submitted_urbs();
         self.pending_urbs.lock().clear();
         if submitted.is_empty() {

--- a/test-suit/starryos/qemu/system/usb-storage/src/main.c
+++ b/test-suit/starryos/qemu/system/usb-storage/src/main.c
@@ -86,6 +86,16 @@ int main(void) {
         );
     }
 
+    result = usb_msc_stall_and_recover_bulk_out(&device);
+    if (result != 0) {
+        usb_msc_close(&device);
+        return failf(
+            "bulk OUT did not recover after clear halt (%d, %s)",
+            result,
+            libusb_error_name(result)
+        );
+    }
+
     char vendor[9];
     char product[17];
     result = usb_msc_inquiry(&device, vendor, product);
@@ -177,11 +187,22 @@ int main(void) {
     }
 
     printf("usb readback ok: lba=%u bytes=%u\n", test_lba, block_size);
-    puts("USB storage tests passed!");
-    exit_code = 0;
-
     free(write_buffer);
     free(read_buffer);
+
+    usb_msc_close_without_release(&device);
+    result = usb_msc_find_and_open(&device);
+    if (result != 0) {
+        return failf(
+            "interface remained claimed after closing device (%d, %s)",
+            result,
+            libusb_error_name(result)
+        );
+    }
+    puts("usb interface reclaimed after close without release");
+
+    puts("USB storage tests passed!");
+    exit_code = 0;
     usb_msc_close(&device);
     return exit_code;
 }

--- a/test-suit/starryos/qemu/system/usb-storage/src/usb_msc_bot.c
+++ b/test-suit/starryos/qemu/system/usb-storage/src/usb_msc_bot.c
@@ -8,6 +8,7 @@
 #define USB_MSC_SUBCLASS_SCSI 0x06
 #define USB_MSC_PROTOCOL_BULK_ONLY 0x50
 #define USB_MSC_TIMEOUT_MS 10000
+#define USB_MSC_REQUEST_RESET 0xff
 #define CBW_SIGNATURE 0x43425355u
 #define CSW_SIGNATURE 0x53425355u
 
@@ -251,6 +252,66 @@ void usb_msc_close(usb_msc_device_t *device) {
         libusb_exit(device->ctx);
         device->ctx = NULL;
     }
+}
+
+void usb_msc_close_without_release(usb_msc_device_t *device) {
+    if (device->handle != NULL) {
+        libusb_close(device->handle);
+        device->handle = NULL;
+    }
+    if (device->ctx != NULL) {
+        libusb_exit(device->ctx);
+        device->ctx = NULL;
+    }
+}
+
+int usb_msc_stall_and_recover_bulk_out(usb_msc_device_t *device) {
+    struct usb_msc_cbw invalid_cbw;
+    int transferred = 0;
+
+    memset(&invalid_cbw, 0, sizeof(invalid_cbw));
+    invalid_cbw.tag = device->tag++;
+    invalid_cbw.command_length = 1;
+
+    int result = libusb_bulk_transfer(
+        device->handle,
+        device->endpoint_out,
+        (unsigned char *)&invalid_cbw,
+        (int)sizeof(invalid_cbw),
+        &transferred,
+        USB_MSC_TIMEOUT_MS
+    );
+    if (result != LIBUSB_ERROR_PIPE) {
+        return result != 0 ? result : LIBUSB_ERROR_OTHER;
+    }
+
+    result = libusb_control_transfer(
+        device->handle,
+        LIBUSB_ENDPOINT_OUT | LIBUSB_REQUEST_TYPE_CLASS | LIBUSB_RECIPIENT_INTERFACE,
+        USB_MSC_REQUEST_RESET,
+        0,
+        device->interface_number,
+        NULL,
+        0,
+        USB_MSC_TIMEOUT_MS
+    );
+    if (result < 0) {
+        return result;
+    }
+
+    result = libusb_clear_halt(device->handle, device->endpoint_in);
+    if (result != 0) {
+        return result;
+    }
+
+    result = libusb_clear_halt(device->handle, device->endpoint_out);
+    if (result != 0) {
+        return result;
+    }
+
+    puts("usb bulk OUT recovered with BOT reset and clear halt");
+    fflush(stdout);
+    return 0;
 }
 
 static int transfer_command(

--- a/test-suit/starryos/qemu/system/usb-storage/src/usb_msc_bot.h
+++ b/test-suit/starryos/qemu/system/usb-storage/src/usb_msc_bot.h
@@ -15,7 +15,9 @@ typedef struct usb_msc_device {
 
 int usb_msc_find_and_open(usb_msc_device_t *device);
 void usb_msc_close(usb_msc_device_t *device);
+void usb_msc_close_without_release(usb_msc_device_t *device);
 
+int usb_msc_stall_and_recover_bulk_out(usb_msc_device_t *device);
 int usb_msc_inquiry(usb_msc_device_t *device, char vendor[9], char product[17]);
 int usb_msc_test_unit_ready(usb_msc_device_t *device);
 int usb_msc_request_sense(


### PR DESCRIPTION
## 背景

StarryOS usbfs 已定义 `USBDEVFS_CLEAR_HALT`，但打开的USB设备文件收到该ioctl时仍然返回`Unsupported`。因此，用户态调用`libusb_clear_halt()`时，无法恢复处于HALT/STALL状态的批量传输端点。

此外，usbfs设备文件关闭时只释放设备lease，没有释放当前会话记录的USB接口。如果用户态程序退出前没有成功调用`USBDEVFS_RELEASEINTERFACE`，接口所有权可能残留。后续进程再次声明同一接口时会返回：

```text
EBUSY
LIBUSB_ERROR_BUSY
```

该问题在RK3588开发板上的userspace libusb CDC程序中可以复现：

1. 打开CDC设备并声明数据接口。
2. 清除批量输入、输出端点状态。
3. 退出当前进程。
4. 启动另一个进程并再次声明相同接口。

修改前，清除端点HALT状态不受支持，进程退出后也可能残留接口占用，导致后续程序无法继续访问设备。

## 修改内容

### 1. 实现 `USBDEVFS_CLEAR_HALT`

在`UsbDeviceFile::ioctl()`中处理`USBDEVFS_CLEAR_HALT`，并将它转换为标准USB端点控制请求：

- 请求类型：`Standard`
- 接收方：`Endpoint`
- 请求：`CLEAR_FEATURE`
- Feature Selector：`ENDPOINT_HALT`
- `wIndex`：用户态传入的端点地址

处理前会检查ioctl参数是否在有效的8位USB端点地址范围内。

例如：

```text
USBDEVFS_CLEAR_HALT(0x82)
```

将生成：

```text
bmRequestType = Standard | Endpoint
bRequest      = CLEAR_FEATURE
wValue        = ENDPOINT_HALT
wIndex        = 0x82
```

这样`libusb_clear_halt()`就可以真正清除批量输入、输出端点的HALT/STALL状态。

### 2. 关闭设备文件时释放接口

在`UsbDeviceFile::drop()`中遍历当前文件记录的`claimed_interfaces`，释放该会话声明过的所有USB接口。

释放过程会清理：

- 接口所有权记录。
- 接口对应的端点映射。
- 当前会话使用的活动端点。

即使用户态程序异常退出，或者退出前没有显式调用`USBDEVFS_RELEASEINTERFACE`，后续进程也可以重新声明接口。

由于`Drop`不能返回错误，接口释放采用best-effort方式，失败不会阻止剩余资源继续回收。

### 3. 增加控制请求测试

增加单元测试，检查clear-halt控制请求的以下字段：

- 请求类型为`Standard`。
- 接收方为`Endpoint`。
- 请求为`CLEAR_FEATURE`。
- Feature Selector为`ENDPOINT_HALT`。
- 端点地址正确写入`wIndex`。

## 作用

该修改补全了StarryOS usbfs与Linux usbfs/libusb之间的兼容性：

- `libusb_clear_halt()`能够恢复停止的批量传输端点。
- 用户态程序退出后不会残留接口所有权。
- 后续进程可以重新声明同一USB接口。
- userspace CDC程序可以重复执行“打开、通信、关闭”。
- 出现端点异常时不需要重启StarryOS或重新插拔USB设备。

该修改只影响StarryOS usbfs，不改变：

- Linux下的设备行为。
- USB设备枚举逻辑。
- USB类驱动绑定策略。
- 摄像头或机械臂控制算法。
- 多核调度和NPU配置。