### PR TITLE
feat(axvm): add virtual interrupt model types and per-vCPU dispatch queue

### DIFF
--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -12,6 +12,7 @@ license = "Apache-2.0"
 [features]
 fs = ["ax-std/fs"]
 host-fs = ["ax-std/fs"]
+host-test = ["ax-kspin/host-test", "ax-kernel-guard/host-test"]
 sstc = ["riscv_vcpu/sstc"]
 tls = ["ax-hal/tls", "ax-std/tls", "cpu-local/tls"]
 

--- a/virtualization/axvm/src/irq/mod.rs
+++ b/virtualization/axvm/src/irq/mod.rs
@@ -157,3 +157,5 @@ impl IrqResolver for InterruptFabric {
         ))
     }
 }
+
+pub(crate) mod model;

--- a/virtualization/axvm/src/irq/model.rs
+++ b/virtualization/axvm/src/irq/model.rs
@@ -1,0 +1,43 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Architecture-independent virtual interrupt model types.
+
+use axdevice_base::InterruptTriggerMode;
+
+/// Architecture-independent virtual interrupt identifier.
+///
+/// Uses `u32` to avoid leaking x86 `u8` vector limits into GIC (INTID up to 1020+),
+/// PLIC, and LoongArch.
+///
+/// Will be constructed by architecture interrupt routers and consumed by
+/// [`VcpuIrqDispatcher`](crate::runtime::VcpuIrqDispatcher) when a virtual
+/// device raises an interrupt.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct VirtualInterruptId(pub u32);
+
+/// An interrupt event pending delivery to a target vCPU.
+///
+/// Carries the trigger mode (edge/level) so that architecture injection paths
+/// and routers can preserve the semantics declared by the device.
+///
+/// Will be enqueued into [`VcpuIrqDispatcher`](crate::runtime::VcpuIrqDispatcher)
+/// and later drained by the target vCPU run loop for injection.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PendingVcpuInterrupt {
+    pub id: VirtualInterruptId,
+    pub trigger: InterruptTriggerMode,
+}

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -118,35 +118,3 @@ impl VcpuIrqDispatcher {
             .unwrap_or_default()
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::irq::model::VirtualInterruptId;
-
-    // Tests that require a registered vCPU task (enqueue-then-drain FIFO
-    // ordering, vCPU isolation, trigger-mode round-trip) need an `AxTaskRef`
-    // which in turn requires a spawned ArceOS task.  Those tests will be
-    // added when the dispatcher is integrated into `VmRuntimeHandle` and
-    // the vCPU-task lifecycle is available in the test harness.
-
-    #[test]
-    fn new_dispatcher_drain_returns_empty() {
-        let d = VcpuIrqDispatcher::new();
-        assert!(d.drain(0).is_empty());
-        assert!(d.drain(1).is_empty());
-    }
-
-    #[test]
-    fn enqueue_unregistered_vcpu_returns_error() {
-        let d = VcpuIrqDispatcher::new();
-        let result = d.enqueue(
-            0,
-            PendingVcpuInterrupt {
-                id: VirtualInterruptId(1),
-                trigger: crate::InterruptTriggerMode::EdgeTriggered,
-            },
-        );
-        assert!(result.is_err());
-    }
-}

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -111,3 +111,22 @@ impl VcpuIrqDispatcher {
         self.queue.drain(vcpu_id)
     }
 }
+
+#[cfg(all(test, feature = "host-test"))]
+mod tests {
+    use super::*;
+    use crate::irq::model::VirtualInterruptId;
+
+    #[test]
+    fn enqueue_unregistered_vcpu_returns_error() {
+        let d = VcpuIrqDispatcher::new();
+        let result = d.enqueue(
+            0,
+            PendingVcpuInterrupt {
+                id: VirtualInterruptId(1),
+                trigger: crate::InterruptTriggerMode::EdgeTriggered,
+            },
+        );
+        assert!(result.is_err());
+    }
+}

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -1,0 +1,152 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Runtime-owned per-vCPU interrupt dispatch queue.
+//!
+//! The dispatcher is owned by `VmRuntimeHandle` and lives for the duration of
+//! one Running/Paused/Stopping lifecycle. Locking inside every method keeps
+//! critical sections short: no wake, IPI, or external callbacks are invoked
+//! while a lock is held.
+
+use alloc::{collections::BTreeMap, vec::Vec};
+
+use ax_kspin::SpinNoIrq as Mutex;
+
+use crate::{AxTaskRef, AxVmResult, ax_err_type, irq::model::PendingVcpuInterrupt};
+
+/// Runtime-owned vCPU interrupt queue.
+///
+/// Lifecycle is tied to one Running/Paused/Stopping runtime.
+/// Locks are held sequentially (never simultaneously), and no wake, IPI, or
+/// external callback is invoked inside a critical section.
+///
+/// Will be embedded in
+/// [`VmRuntimeHandle`](crate::vm::VmRuntimeHandle) as the destination for
+/// architecture interrupt router output.  The vCPU run loop drains pending
+/// interrupts before each vCPU entry and injects them through the
+/// architecture-specific injection path.
+#[allow(dead_code)]
+pub struct VcpuIrqDispatcher {
+    pending: Mutex<BTreeMap<usize, Vec<PendingVcpuInterrupt>>>,
+    vcpu_tasks: Mutex<BTreeMap<usize, AxTaskRef>>,
+}
+
+impl VcpuIrqDispatcher {
+    /// Creates an empty dispatcher.
+    ///
+    /// Called by `VmRuntimeHandle::new` when a VM transitions into the
+    /// Running state.
+    #[allow(dead_code)]
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(BTreeMap::new()),
+            vcpu_tasks: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Registers a vCPU task so that [`enqueue`](Self::enqueue) can discover
+    /// the target physical CPU.
+    ///
+    /// Called from `VmRuntimeHandle::add_vcpu_task` when a vCPU task is
+    /// spawned and bound to the VM runtime.
+    #[allow(dead_code)]
+    pub fn register_vcpu_task(&self, vcpu_id: usize, task: AxTaskRef) {
+        self.vcpu_tasks.lock().insert(vcpu_id, task);
+    }
+
+    /// Enqueues a pending interrupt for the given vCPU.
+    ///
+    /// Returns the physical CPU id the target vCPU task is currently running
+    /// on. The two internal locks are held **sequentially** (never together):
+    ///
+    /// 1. Lock `vcpu_tasks`, obtain `task.cpu_id()`, release.
+    /// 2. Lock `pending`, push the interrupt, release.
+    ///
+    /// A task migration window exists between steps 1 and 2 (the pCPU may
+    /// change), but `notify_all()` + `send_ipi` in the caller guarantee
+    /// eventual delivery regardless of the race.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NotFound` when the vCPU task has not been registered via
+    /// [`register_vcpu_task`](Self::register_vcpu_task).
+    ///
+    /// Called by `VmRuntimeHandle::dispatch_vcpu_interrupt` when an
+    /// architecture interrupt router requests delivery to a vCPU.
+    #[allow(dead_code)]
+    pub fn enqueue(&self, vcpu_id: usize, interrupt: PendingVcpuInterrupt) -> AxVmResult<usize> {
+        let cpu_id = {
+            let tasks = self.vcpu_tasks.lock();
+            tasks
+                .get(&vcpu_id)
+                .map(|t| t.cpu_id() as usize)
+                .ok_or_else(|| {
+                    ax_err_type!(NotFound, format_args!("vCPU {vcpu_id} task not found"))
+                })?
+        };
+        self.pending
+            .lock()
+            .entry(vcpu_id)
+            .or_default()
+            .push(interrupt);
+        Ok(cpu_id)
+    }
+
+    /// Drains all pending interrupts for the given vCPU, leaving its queue
+    /// empty.
+    ///
+    /// The caller (vCPU run loop) runs on the target pCPU and injects each
+    /// returned interrupt through the architecture-specific vCPU injection
+    /// path before entering the guest.
+    #[allow(dead_code)]
+    pub fn drain(&self, vcpu_id: usize) -> Vec<PendingVcpuInterrupt> {
+        self.pending
+            .lock()
+            .get_mut(&vcpu_id)
+            .map(core::mem::take)
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::irq::model::VirtualInterruptId;
+
+    // Tests that require a registered vCPU task (enqueue-then-drain FIFO
+    // ordering, vCPU isolation, trigger-mode round-trip) need an `AxTaskRef`
+    // which in turn requires a spawned ArceOS task.  Those tests will be
+    // added when the dispatcher is integrated into `VmRuntimeHandle` and
+    // the vCPU-task lifecycle is available in the test harness.
+
+    #[test]
+    fn new_dispatcher_drain_returns_empty() {
+        let d = VcpuIrqDispatcher::new();
+        assert!(d.drain(0).is_empty());
+        assert!(d.drain(1).is_empty());
+    }
+
+    #[test]
+    fn enqueue_unregistered_vcpu_returns_error() {
+        let d = VcpuIrqDispatcher::new();
+        let result = d.enqueue(
+            0,
+            PendingVcpuInterrupt {
+                id: VirtualInterruptId(1),
+                trigger: crate::InterruptTriggerMode::EdgeTriggered,
+            },
+        );
+        assert!(result.is_err());
+    }
+}

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -118,3 +118,160 @@ impl VcpuIrqDispatcher {
             .unwrap_or_default()
     }
 }
+
+// The tests below are commented out because the `#[test]` binary on the host
+// (CI "Test with std" job) crashes at startup.  `VcpuIrqDispatcher` stores
+// `AxTaskRef` (an `Arc<AxTask>`) inside `SpinNoIrq<BTreeMap<…>>`.  Even
+// constructing the dispatcher in a test pulls the full axtask / percpu / TLS
+// object graph into the test binary.  On the host those ArceOS kernel
+// subsystems are not initialised, so the test binary segfaults before
+// `main()`.
+//
+// Once `VcpuIrqDispatcher` is embedded in `VmRuntimeHandle` and the vCPU-task
+// lifecycle is available through the existing VM-level test harness (or a
+// future host-compatible stub), these tests can be uncommented.  At that
+// point creating a dispatcher will happen alongside a fully initialised
+// runtime, and the tests will see the correct task cpu_id and pending state
+// without pulling in bare-metal kernel infrastructure.
+//
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     use alloc::format;
+//     use alloc::vec;
+//     use crate::irq::model::VirtualInterruptId;
+//
+//     fn dummy_task_ref() -> crate::AxTaskRef {
+//         let inner = crate::host::task::TaskInner::new(
+//             move || {},
+//             format!("test-dummy"),
+//             0x10000,
+//         );
+//         crate::host::task::spawn_task(inner)
+//     }
+//
+//     #[test]
+//     fn enqueue_preserves_fifo_order() {
+//         let d = VcpuIrqDispatcher::new();
+//         d.register_vcpu_task(0, dummy_task_ref());
+//
+//         let a = PendingVcpuInterrupt {
+//             id: VirtualInterruptId(10),
+//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
+//         };
+//         let b = PendingVcpuInterrupt {
+//             id: VirtualInterruptId(20),
+//             trigger: crate::InterruptTriggerMode::LevelTriggered,
+//         };
+//         let c = PendingVcpuInterrupt {
+//             id: VirtualInterruptId(30),
+//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
+//         };
+//
+//         d.enqueue(0, a).unwrap();
+//         d.enqueue(0, b).unwrap();
+//         d.enqueue(0, c).unwrap();
+//
+//         let drained = d.drain(0);
+//         assert_eq!(drained.len(), 3);
+//         assert_eq!(drained[0], a);
+//         assert_eq!(drained[1], b);
+//         assert_eq!(drained[2], c);
+//     }
+//
+//     #[test]
+//     fn isolates_vcpus() {
+//         let d = VcpuIrqDispatcher::new();
+//         d.register_vcpu_task(0, dummy_task_ref());
+//         d.register_vcpu_task(1, dummy_task_ref());
+//
+//         let v0 = PendingVcpuInterrupt {
+//             id: VirtualInterruptId(1),
+//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
+//         };
+//         let v1 = PendingVcpuInterrupt {
+//             id: VirtualInterruptId(2),
+//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
+//         };
+//
+//         d.enqueue(0, v0).unwrap();
+//         d.enqueue(1, v1).unwrap();
+//
+//         assert_eq!(d.drain(0), vec![v0]);
+//         assert_eq!(d.drain(1), vec![v1]);
+//     }
+//
+//     #[test]
+//     fn drain_empties_queue() {
+//         let d = VcpuIrqDispatcher::new();
+//         d.register_vcpu_task(0, dummy_task_ref());
+//
+//         d.enqueue(
+//             0,
+//             PendingVcpuInterrupt {
+//                 id: VirtualInterruptId(7),
+//                 trigger: crate::InterruptTriggerMode::EdgeTriggered,
+//             },
+//         )
+//         .unwrap();
+//
+//         assert_eq!(d.drain(0).len(), 1);
+//         assert!(d.drain(0).is_empty());
+//     }
+//
+//     #[test]
+//     fn double_drain_returns_empty() {
+//         let d = VcpuIrqDispatcher::new();
+//         d.register_vcpu_task(0, dummy_task_ref());
+//
+//         d.enqueue(
+//             0,
+//             PendingVcpuInterrupt {
+//                 id: VirtualInterruptId(7),
+//                 trigger: crate::InterruptTriggerMode::EdgeTriggered,
+//             },
+//         )
+//         .unwrap();
+//
+//         d.drain(0);
+//         let second = d.drain(0);
+//         assert!(second.is_empty());
+//     }
+//
+//     #[test]
+//     fn enqueue_unregistered_vcpu_returns_error() {
+//         let d = VcpuIrqDispatcher::new();
+//         // Never register vCPU 0.
+//         let result = d.enqueue(
+//             0,
+//             PendingVcpuInterrupt {
+//                 id: VirtualInterruptId(1),
+//                 trigger: crate::InterruptTriggerMode::EdgeTriggered,
+//             },
+//         );
+//         assert!(result.is_err());
+//     }
+//
+//     #[test]
+//     fn trigger_mode_round_trips() {
+//         let d = VcpuIrqDispatcher::new();
+//         d.register_vcpu_task(0, dummy_task_ref());
+//
+//         let edge = PendingVcpuInterrupt {
+//             id: VirtualInterruptId(42),
+//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
+//         };
+//         let level = PendingVcpuInterrupt {
+//             id: VirtualInterruptId(43),
+//             trigger: crate::InterruptTriggerMode::LevelTriggered,
+//         };
+//
+//         d.enqueue(0, edge).unwrap();
+//         d.enqueue(0, level).unwrap();
+//
+//         let drained = d.drain(0);
+//         assert_eq!(drained.len(), 2);
+//         assert_eq!(drained[0].trigger, crate::InterruptTriggerMode::EdgeTriggered);
+//         assert_eq!(drained[1].trigger, crate::InterruptTriggerMode::LevelTriggered);
+//     }
+// }

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -23,6 +23,7 @@ use alloc::{collections::BTreeMap, vec::Vec};
 
 use ax_kspin::SpinNoIrq as Mutex;
 
+use super::queue::VcpuInterruptQueue;
 use crate::{AxTaskRef, AxVmResult, ax_err_type, irq::model::PendingVcpuInterrupt};
 
 /// Runtime-owned vCPU interrupt queue.
@@ -38,7 +39,7 @@ use crate::{AxTaskRef, AxVmResult, ax_err_type, irq::model::PendingVcpuInterrupt
 /// architecture-specific injection path.
 #[allow(dead_code)]
 pub struct VcpuIrqDispatcher {
-    pending: Mutex<BTreeMap<usize, Vec<PendingVcpuInterrupt>>>,
+    queue: VcpuInterruptQueue,
     vcpu_tasks: Mutex<BTreeMap<usize, AxTaskRef>>,
 }
 
@@ -50,7 +51,7 @@ impl VcpuIrqDispatcher {
     #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
-            pending: Mutex::new(BTreeMap::new()),
+            queue: VcpuInterruptQueue::new(),
             vcpu_tasks: Mutex::new(BTreeMap::new()),
         }
     }
@@ -71,7 +72,7 @@ impl VcpuIrqDispatcher {
     /// on. The two internal locks are held **sequentially** (never together):
     ///
     /// 1. Lock `vcpu_tasks`, obtain `task.cpu_id()`, release.
-    /// 2. Lock `pending`, push the interrupt, release.
+    /// 2. Lock `queue`, push the interrupt, release.
     ///
     /// A task migration window exists between steps 1 and 2 (the pCPU may
     /// change), but `notify_all()` + `send_ipi` in the caller guarantee
@@ -95,11 +96,7 @@ impl VcpuIrqDispatcher {
                     ax_err_type!(NotFound, format_args!("vCPU {vcpu_id} task not found"))
                 })?
         };
-        self.pending
-            .lock()
-            .entry(vcpu_id)
-            .or_default()
-            .push(interrupt);
+        self.queue.push(vcpu_id, interrupt);
         Ok(cpu_id)
     }
 
@@ -111,167 +108,6 @@ impl VcpuIrqDispatcher {
     /// path before entering the guest.
     #[allow(dead_code)]
     pub fn drain(&self, vcpu_id: usize) -> Vec<PendingVcpuInterrupt> {
-        self.pending
-            .lock()
-            .get_mut(&vcpu_id)
-            .map(core::mem::take)
-            .unwrap_or_default()
+        self.queue.drain(vcpu_id)
     }
 }
-
-// The tests below are commented out because the `#[test]` binary on the host
-// (CI "Test with std" job) crashes at startup.  `VcpuIrqDispatcher` stores
-// `AxTaskRef` (an `Arc<AxTask>`) inside `SpinNoIrq<BTreeMap<…>>`.  Even
-// constructing the dispatcher in a test pulls the full axtask / percpu / TLS
-// object graph into the test binary.  On the host those ArceOS kernel
-// subsystems are not initialised, so the test binary segfaults before
-// `main()`.
-//
-// Once `VcpuIrqDispatcher` is embedded in `VmRuntimeHandle` and the vCPU-task
-// lifecycle is available through the existing VM-level test harness (or a
-// future host-compatible stub), these tests can be uncommented.  At that
-// point creating a dispatcher will happen alongside a fully initialised
-// runtime, and the tests will see the correct task cpu_id and pending state
-// without pulling in bare-metal kernel infrastructure.
-//
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use alloc::format;
-//     use alloc::vec;
-//     use crate::irq::model::VirtualInterruptId;
-//
-//     fn dummy_task_ref() -> crate::AxTaskRef {
-//         let inner = crate::host::task::TaskInner::new(
-//             move || {},
-//             format!("test-dummy"),
-//             0x10000,
-//         );
-//         crate::host::task::spawn_task(inner)
-//     }
-//
-//     #[test]
-//     fn enqueue_preserves_fifo_order() {
-//         let d = VcpuIrqDispatcher::new();
-//         d.register_vcpu_task(0, dummy_task_ref());
-//
-//         let a = PendingVcpuInterrupt {
-//             id: VirtualInterruptId(10),
-//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
-//         };
-//         let b = PendingVcpuInterrupt {
-//             id: VirtualInterruptId(20),
-//             trigger: crate::InterruptTriggerMode::LevelTriggered,
-//         };
-//         let c = PendingVcpuInterrupt {
-//             id: VirtualInterruptId(30),
-//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
-//         };
-//
-//         d.enqueue(0, a).unwrap();
-//         d.enqueue(0, b).unwrap();
-//         d.enqueue(0, c).unwrap();
-//
-//         let drained = d.drain(0);
-//         assert_eq!(drained.len(), 3);
-//         assert_eq!(drained[0], a);
-//         assert_eq!(drained[1], b);
-//         assert_eq!(drained[2], c);
-//     }
-//
-//     #[test]
-//     fn isolates_vcpus() {
-//         let d = VcpuIrqDispatcher::new();
-//         d.register_vcpu_task(0, dummy_task_ref());
-//         d.register_vcpu_task(1, dummy_task_ref());
-//
-//         let v0 = PendingVcpuInterrupt {
-//             id: VirtualInterruptId(1),
-//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
-//         };
-//         let v1 = PendingVcpuInterrupt {
-//             id: VirtualInterruptId(2),
-//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
-//         };
-//
-//         d.enqueue(0, v0).unwrap();
-//         d.enqueue(1, v1).unwrap();
-//
-//         assert_eq!(d.drain(0), vec![v0]);
-//         assert_eq!(d.drain(1), vec![v1]);
-//     }
-//
-//     #[test]
-//     fn drain_empties_queue() {
-//         let d = VcpuIrqDispatcher::new();
-//         d.register_vcpu_task(0, dummy_task_ref());
-//
-//         d.enqueue(
-//             0,
-//             PendingVcpuInterrupt {
-//                 id: VirtualInterruptId(7),
-//                 trigger: crate::InterruptTriggerMode::EdgeTriggered,
-//             },
-//         )
-//         .unwrap();
-//
-//         assert_eq!(d.drain(0).len(), 1);
-//         assert!(d.drain(0).is_empty());
-//     }
-//
-//     #[test]
-//     fn double_drain_returns_empty() {
-//         let d = VcpuIrqDispatcher::new();
-//         d.register_vcpu_task(0, dummy_task_ref());
-//
-//         d.enqueue(
-//             0,
-//             PendingVcpuInterrupt {
-//                 id: VirtualInterruptId(7),
-//                 trigger: crate::InterruptTriggerMode::EdgeTriggered,
-//             },
-//         )
-//         .unwrap();
-//
-//         d.drain(0);
-//         let second = d.drain(0);
-//         assert!(second.is_empty());
-//     }
-//
-//     #[test]
-//     fn enqueue_unregistered_vcpu_returns_error() {
-//         let d = VcpuIrqDispatcher::new();
-//         // Never register vCPU 0.
-//         let result = d.enqueue(
-//             0,
-//             PendingVcpuInterrupt {
-//                 id: VirtualInterruptId(1),
-//                 trigger: crate::InterruptTriggerMode::EdgeTriggered,
-//             },
-//         );
-//         assert!(result.is_err());
-//     }
-//
-//     #[test]
-//     fn trigger_mode_round_trips() {
-//         let d = VcpuIrqDispatcher::new();
-//         d.register_vcpu_task(0, dummy_task_ref());
-//
-//         let edge = PendingVcpuInterrupt {
-//             id: VirtualInterruptId(42),
-//             trigger: crate::InterruptTriggerMode::EdgeTriggered,
-//         };
-//         let level = PendingVcpuInterrupt {
-//             id: VirtualInterruptId(43),
-//             trigger: crate::InterruptTriggerMode::LevelTriggered,
-//         };
-//
-//         d.enqueue(0, edge).unwrap();
-//         d.enqueue(0, level).unwrap();
-//
-//         let drained = d.drain(0);
-//         assert_eq!(drained.len(), 2);
-//         assert_eq!(drained[0].trigger, crate::InterruptTriggerMode::EdgeTriggered);
-//         assert_eq!(drained[1].trigger, crate::InterruptTriggerMode::LevelTriggered);
-//     }
-// }

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -17,6 +17,7 @@ mod ivc;
 pub(crate) mod vcpus;
 
 mod dispatcher;
+mod queue;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 // Re-exported for [`VmRuntimeHandle`](crate::vm::VmRuntimeHandle) which will

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -16,7 +16,13 @@ pub(crate) mod hvc;
 mod ivc;
 pub(crate) mod vcpus;
 
+mod dispatcher;
 use core::sync::atomic::{AtomicUsize, Ordering};
+
+// Re-exported for [`VmRuntimeHandle`](crate::vm::VmRuntimeHandle) which will
+// embed the dispatcher as a field and expose it to the vCPU run loop.
+#[allow(unused_imports)]
+pub(crate) use dispatcher::VcpuIrqDispatcher;
 
 use crate::{AxVmError, AxVmResult, StopReason, VmStatus, ax_err};
 

--- a/virtualization/axvm/src/runtime/queue.rs
+++ b/virtualization/axvm/src/runtime/queue.rs
@@ -1,0 +1,144 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Per-vCPU interrupt pending queue with no task dependency.
+//!
+//! [`VcpuInterruptQueue`] is the host-testable core extracted from
+//! [`VcpuIrqDispatcher`](super::VcpuIrqDispatcher). It owns only the
+//! `pending` BTreeMap and exposes `push` / `drain` without referencing
+//! `AxTaskRef`, so its semantics (FIFO, vCPU isolation, drain) can be
+//! covered by `#[test]` on the host when the `host-test` feature is
+//! enabled.
+
+use alloc::{collections::BTreeMap, vec::Vec};
+
+use ax_kspin::SpinNoIrq as Mutex;
+
+use crate::irq::model::PendingVcpuInterrupt;
+
+/// Pure per-vCPU interrupt queue.
+///
+/// Separated from [`VcpuIrqDispatcher`](super::VcpuIrqDispatcher) so that
+/// queue semantics can be tested on the host without pulling in the ArceOS
+/// task / percpu / TLS infrastructure.
+pub(crate) struct VcpuInterruptQueue {
+    pending: Mutex<BTreeMap<usize, Vec<PendingVcpuInterrupt>>>,
+}
+
+impl VcpuInterruptQueue {
+    /// Creates an empty queue.
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    /// Pushes a pending interrupt onto the queue for the given vCPU.
+    pub fn push(&self, vcpu_id: usize, interrupt: PendingVcpuInterrupt) {
+        self.pending
+            .lock()
+            .entry(vcpu_id)
+            .or_default()
+            .push(interrupt);
+    }
+
+    /// Drains all pending interrupts for the given vCPU, leaving its
+    /// queue empty.
+    pub fn drain(&self, vcpu_id: usize) -> Vec<PendingVcpuInterrupt> {
+        self.pending
+            .lock()
+            .get_mut(&vcpu_id)
+            .map(core::mem::take)
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::vec;
+    use crate::irq::model::VirtualInterruptId;
+
+    fn edge(id: u32) -> PendingVcpuInterrupt {
+        PendingVcpuInterrupt {
+            id: VirtualInterruptId(id),
+            trigger: crate::InterruptTriggerMode::EdgeTriggered,
+        }
+    }
+
+    fn level(id: u32) -> PendingVcpuInterrupt {
+        PendingVcpuInterrupt {
+            id: VirtualInterruptId(id),
+            trigger: crate::InterruptTriggerMode::LevelTriggered,
+        }
+    }
+
+    #[test]
+    fn push_preserves_fifo_order() {
+        let q = VcpuInterruptQueue::new();
+        q.push(0, edge(10));
+        q.push(0, level(20));
+        q.push(0, edge(30));
+
+        let drained = q.drain(0);
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0], edge(10));
+        assert_eq!(drained[1], level(20));
+        assert_eq!(drained[2], edge(30));
+    }
+
+    #[test]
+    fn isolates_vcpus() {
+        let q = VcpuInterruptQueue::new();
+        q.push(0, edge(1));
+        q.push(1, edge(2));
+
+        assert_eq!(q.drain(0), vec![edge(1)]);
+        assert_eq!(q.drain(1), vec![edge(2)]);
+    }
+
+    #[test]
+    fn drain_empties_queue() {
+        let q = VcpuInterruptQueue::new();
+        q.push(0, edge(7));
+        assert_eq!(q.drain(0).len(), 1);
+        assert!(q.drain(0).is_empty());
+    }
+
+    #[test]
+    fn double_drain_returns_empty() {
+        let q = VcpuInterruptQueue::new();
+        q.push(0, edge(7));
+        q.drain(0);
+        assert!(q.drain(0).is_empty());
+    }
+
+    #[test]
+    fn trigger_mode_round_trips() {
+        let q = VcpuInterruptQueue::new();
+        q.push(0, edge(42));
+        q.push(0, level(43));
+
+        let drained = q.drain(0);
+        assert_eq!(drained.len(), 2);
+        assert_eq!(
+            drained[0].trigger,
+            crate::InterruptTriggerMode::EdgeTriggered
+        );
+        assert_eq!(
+            drained[1].trigger,
+            crate::InterruptTriggerMode::LevelTriggered
+        );
+    }
+}

--- a/virtualization/axvm/src/runtime/queue.rs
+++ b/virtualization/axvm/src/runtime/queue.rs
@@ -66,8 +66,9 @@ impl VcpuInterruptQueue {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use alloc::vec;
+
+    use super::*;
     use crate::irq::model::VirtualInterruptId;
 
     fn edge(id: u32) -> PendingVcpuInterrupt {

--- a/virtualization/axvm/src/runtime/queue.rs
+++ b/virtualization/axvm/src/runtime/queue.rs
@@ -64,7 +64,7 @@ impl VcpuInterruptQueue {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "host-test"))]
 mod tests {
     use alloc::vec;
 


### PR DESCRIPTION
## 要解决的问题

AxVisor 当前设备中断路径在各架构上分别演化，主要存在以下问题：

1. `IrqLine` 到 vCPU 注入的路径在不同架构上走的通道不一致（x86 运行时直接理解 IOAPIC、串口、PIT 细节；LoongArch 依赖架构特定队列变体）
2. 跨 vCPU 中断递送依赖 `VmRuntimeHandle::pending_interrupts`，设备中断、IPI 和直通 IRQ 的递送路径不统一
3. 没有一个清晰的通用边界：设备 → Router → runtime 队列 → 目标 vCPU 注入

本次变更是整体重构的第一步，**纯增量**，不修改任何现有代码路径，只添加日后接通整条通道所需的基础类型和数据结构。

## 改动内容

### 1. 新增 `irq::model` — 虚拟中断类型定义

`virtualization/axvm/src/irq/model.rs`：

- `VirtualInterruptId(u32)` — 架构无关的虚拟中断 ID，使用 `u32` 避免 x86 `u8` vector 限制扩散到 GIC（INTID 可达 1020+）、PLIC 和 LoongArch
- `PendingVcpuInterrupt` — 携带 `VirtualInterruptId` 和 `InterruptTriggerMode`，供架构 Router 和注入路径区分 edge/level 语义

### 2. 新增 `runtime::queue` — 可 host-test 的纯队列

`virtualization/axvm/src/runtime/queue.rs`：

- `VcpuInterruptQueue` — 从 `VcpuIrqDispatcher` 中拆出的纯 pending 队列，**不含 `AxTaskRef` 依赖**，因此可以在 host 上测试 FIFO、vCPU 隔离、drain 清空等队列语义

### 3. 新增 `runtime::dispatcher` — per-vCPU 中断调度器

`virtualization/axvm/src/runtime/dispatcher.rs`：

- `VcpuIrqDispatcher` — runtime 持有的 vCPU 中断队列，内部组合了 `VcpuInterruptQueue`（纯队列）和 `vcpu_tasks`（任务映射）。生命周期与一次 Running/Paused/Stopping runtime 绑定
- `new()` — 空初始化，将在 VM 进入 Running 状态时由 `VmRuntimeHandle::new` 调用
- `register_vcpu_task(vcpu_id, task)` — 注册 vCPU 任务，使 `enqueue` 能查到目标 pCPU ID
- `enqueue(vcpu_id, interrupt) -> AxVmResult<usize>` — 入队一个待递送中断，返回目标 pCPU ID。两个内部锁（`vcpu_tasks` → `queue`）顺序持有，锁内不调用 wake/IPI/外部回调。vCPU 未注册返回错误
- `drain(vcpu_id) -> Vec<PendingVcpuInterrupt>` — 取出并清空指定 vCPU 的队列，委托给 `VcpuInterruptQueue::drain`，由 vCPU run loop 在进入 guest 前消费

### 4. 新增 `host-test` feature

`virtualization/axvm/Cargo.toml`：

- 新增 `host-test = ["ax-kspin/host-test", "ax-kernel-guard/host-test"]` feature。启用后 `SpinNoIrq::lock()` 的 arch ops 变成 no-op，使队列测试可在 host 上安全执行。CI 使用 `--all-features` 运行 axvm 测试，此 feature 自动启用。

### 5. 模块注册

- `irq/mod.rs` — 添加 `pub(crate) mod model;`
- `runtime/mod.rs` — 添加 `mod queue;`、`mod dispatcher;` 和 `pub(crate) use dispatcher::VcpuIrqDispatcher;`

## 每步解决方案的逻辑

**类型选择：采用 `VirtualInterruptId(u32)` 而非 usize 或 u8**

GIC 的 INTID 区间可达 1020+，PLIC 和 LoongArch 使用较大编号空间。x86 使用 u8 vector（0-255），但不应让这个限制通过类型扩散到所有架构。u32 统一表示、各架构 Router 在注入前转为目标架构识别的编号。

**队列与任务分离：`VcpuInterruptQueue` vs `VcpuIrqDispatcher`**

`VcpuIrqDispatcher` 同时持有 pending 队列和 `AxTaskRef` 映射。`AxTaskRef`（`Arc<AxTask>`）会拉入 axtask → percpu → someboot 等 ArceOS 内核依赖链，host test 二进制无法链接。将纯队列逻辑拆为 `VcpuInterruptQueue`（只含 `PendingVcpuInterrupt`、`BTreeMap`、`SpinNoIrq`），配合 `host-test` feature，使其可在 host 上运行真实测试。

**队列设计：两个独立 Mutex，顺序持有而非同时持有**

`vcpu_tasks` 和 `queue` 分开加锁，每个锁内只做 BTreeMap/Vec 操作。这避免了：
1. 锁内调用 wake/IPI（可能死锁或优先级反转）
2. 锁粒度太粗影响并发

task 迁移窗口（enqueue 步骤 1→2 之间 pCPU 可能变化）是已知的，由调用者（`dispatch_vcpu_interrupt` 中的 `notify_all()` + `send_ipi`）保证最终递送正确。

**`drain()` 使用 `get_mut` + `core::mem::take` 而非 `remove`**

与 `VmRuntimeHandle::drain_pending_interrupts` 保持一致。保留空 Vec 避免后续 enqueue 时重新创建 entry，减少分配次数。

**零行为变更的设计原则**

所有新类型和方法当前为 dead code（标注 `#[allow(dead_code)]`）。vCPU run loop 继续只 drain 旧队列，新 `VcpuIrqDispatcher` 队列始终为空。后续 PR 将逐步：
1. 把 dispatcher 嵌入 `VmRuntimeHandle`，加入 `register_vcpu_task` 和 `dispatch_vcpu_interrupt`
2. 新增 `ArchOps::inject_vcpu_interrupt`，让 vCPU run loop 同时 drain 新旧队列
3. 各架构创建 Router 并通过新 sender/dispatcher 通道连线

## 测试

5 个测试在 `virtualization/axvm/src/runtime/queue.rs` 的 `#[cfg(test)]` 中，通过 `cargo test --all-features` 实际执行：

| 测试 | 覆盖 |
|---|---|
| `push_preserves_fifo_order` | 多个 interrupt push 后 drain 顺序为 FIFO |
| `isolates_vcpus` | vCPU 0 和 vCPU 1 的队列互不干扰 |
| `drain_empties_queue` | drain 后队列为空 |
| `double_drain_returns_empty` | 连续两次 drain，第二次返回空 |
| `trigger_mode_round_trips` | Edge/Level trigger 在 push→drain 后保持 |

`enqueue_unregistered_vcpu_returns_error` 依赖 `AxTaskRef` 注册，不在纯队列层测试。留到 `VcpuIrqDispatcher` 集成到 `VmRuntimeHandle` 时通过 VM 级 harness 覆盖。

## 验证

```bash
cargo fmt --all --check          # 通过
cargo xtask clippy --package axvm  # 5 个 feature 组合全部通过（含 host-test）
cargo test --manifest-path virtualization/axvm/Cargo.toml --all-features  # 107 测试通过（含 5 个新测试）
```
