### PR TITLE
docs(review): require per-syscall standard links

### DIFF
--- a/.claude/skills/review-single-pr/SKILL.md
+++ b/.claude/skills/review-single-pr/SKILL.md
@@ -244,6 +244,10 @@ Review the PR against its stated intent, the current base branch, existing proje
 
 For any change that affects or claims to affect user-visible StarryOS syscall/Linux ABI semantics, fully read and apply `book/guideline/starry/syscall.md` before judging correctness. Follow its evidence hierarchy and comparison workflow even when the changed line is outside the syscall directory. The review must trace indirect helper changes back to every affected syscall entry and must record the Linux version or commit used when behavior is version-dependent.
 
+Before submitting any syscall review outcome, build the per-syscall standards table required by `book/guideline/starry/syscall.md`. Give every directly or indirectly affected syscall its own row, including syscalls for which no problem was found. Each row must contain the conclusion, a brief basis, and at least one authoritative link that supports the reviewed ABI, errno, permission, state-transition, or other user-visible semantic claim. Use a direct documentation page or section, or an immutable GitHub source permalink with a full Linux commit SHA and line anchor. Do not merge several syscalls into one row, write "same as above", rely on a shared footnote, use a floating source branch, or treat inline findings as a substitute for the table. Repeat a shared standard link in every applicable syscall row.
+
+This table is mandatory for `APPROVE`, `REQUEST_CHANGES`, and any no-submit summary that presents a completed syscall review. If any affected syscall or supporting link is missing, continue the standards investigation; do not claim that the syscall review is complete or submit a final review outcome.
+
 ### Review Lenses And Finding Discipline
 
 Review is recall-first: prefer finding every real defect in the changed surface over producing a short or polished review. Do not invent issues, but do not dismiss a plausible in-scope defect with "looks fine"; construct the concrete input, interleaving, device state, guest config, or test-run path that would trigger it, or explain why that scenario is impossible.
@@ -511,6 +515,7 @@ Review body must explain in Chinese:
 
 - what the PR changed;
 - the implementation logic and why this approach is correct for the project semantics;
+- for any directly or indirectly affected syscall, the complete per-syscall standards table required by `book/guideline/starry/syscall.md`, with one row and at least one qualifying authoritative link per syscall regardless of whether a problem was found;
 - validation commands and results, including exact failure mode for failing tests;
 - required test coverage status, including why tests were required or not applicable, where new tests were placed, how the runner discovers/selects them, and whether local or current-head CI evidence shows the specific tests executing;
 - for CI-missing app/tool workflows, the documented preparation performed, the exact QEMU/runtime command run, the architecture, and the guest-visible or tool-output postcondition that proved usability;

--- a/book/guideline/starry/syscall.md
+++ b/book/guideline/starry/syscall.md
@@ -121,6 +121,32 @@ namespace、fd table、fs context、signal handler、VM 等共享资源必须核
 - StarryOS 中从 dispatch 到状态边界的对应调用链；
 - 每个关键 errno、权限检查和共享关系为何与 Linux 一致。
 
+评审结果总结还必须包含逐 syscall 标准映射表。范围包括本次改动直接修改的
+syscall，以及通过共享 helper、状态对象或错误转换间接受影响的所有 syscall
+入口。每个 syscall 必须独占一行；即使多个入口共享同一实现或标准，也不得合并
+条目、使用“同上”或只在公共脚注中给出链接。未发现问题的 syscall 同样必须列出。
+
+每一行必须包含 syscall 名称、评审结论、对应标准链接和简要依据，并满足：
+
+- 结论明确区分符合、存在问题和无法确认；存在问题时可引用对应 finding；
+- 标准链接直接指向能够支撑本次结论的具体文档页面或章节，或者固定 Linux
+  commit 的 GitHub 源码文件行链接；
+- GitHub 源码链接必须包含完整 commit SHA 和行锚点，不得使用 `master`、`main`
+  等浮动分支，也不得只链接仓库、目录、搜索结果或没有行锚点的源码文件；
+- 如果结论依赖多个标准或调用链位置，在同一行列出全部必要链接；如果同一标准
+  支撑多个 syscall，则在每一行重复该链接；
+- inline comment、finding 详情或其他章节中的通用资料列表不能代替这张逐项表格。
+
+格式示例（只演示总结结构，不代表任何具体 PR 的评审结论）：
+
+| Syscall | 评审结论 | 对应标准 | 简要依据 |
+| --- | --- | --- | --- |
+| `init_module` | 未发现问题（示例） | [`init_module(2)`](https://man7.org/linux/man-pages/man2/init_module.2.html)、[Linux `init_module` 实现](https://github.com/torvalds/linux/blob/248951ddc14de84de3910f9b13f51491a8cd91df/kernel/module/main.c#L3634-L3654) | 已核对权限检查和模块加载入口。 |
+| `finit_module` | 存在问题（示例） | [Linux `finit_module` 实现](https://github.com/torvalds/linux/blob/248951ddc14de84de3910f9b13f51491a8cd91df/kernel/module/main.c#L3799-L3815) | finding 应说明 StarryOS 与该检查顺序的具体差异。 |
+
+逐 syscall 清单或任一标准链接缺失时，评审仍不完整，不得提交 `APPROVE`、
+`REQUEST_CHANGES`，也不得把 no-submit 说明表述为完整的 syscall 评审总结。
+
 “参考 Linux”“与 man page 一致”或“测试通过”都不足以替代上述证据。
 
 ## 5. 测试要求
@@ -153,5 +179,6 @@ namespace、fd table、fs context、signal handler、VM 等共享资源必须核
 7. 回归测试是否直接覆盖原始 ABI，并在错误实现上失败？
 8. 测试是否由项目 runner 实际发现和执行？
 9. 结论是否记录 Linux 版本、权威资料和 Starry 对应调用链？
+10. 评审结果总结是否逐条列出每个直接或间接受影响的 syscall，并为每条提供可追溯的标准链接？
 
 任一关键问题无法回答时，不得仅凭 CI 通过认定 syscall 兼容性正确。


### PR DESCRIPTION
## 问题

现有 StarryOS syscall 准则要求记录 Linux/POSIX 等权威依据，但没有明确要求评审总结覆盖每一个受影响的 syscall。评审可能只说明发现的问题，遗漏“未发现问题”的入口，或者只给出共享资料链接，导致结论无法逐项追溯。

## 修改

- 在 syscall 兼容性准则中增加逐 syscall 标准映射表：直接和间接受影响的 syscall 必须一项一行，无论是否发现问题，都要记录结论、标准链接和简要依据。
- 约束标准链接必须直达具体文档页面/章节，或使用包含完整 commit SHA 和行锚点的 Linux GitHub 源码永久链接；禁止浮动分支、资料首页和“同上”式引用。
- 增加包含无问题、有问题、文档加源码以及仅源码依据的表格示例。
- 在 `review-single-pr` 中将该表格设为 `APPROVE`、`REQUEST_CHANGES` 和完整 no-submit syscall 评审总结的强制要求，inline finding 不能替代总结表格。

## 逻辑

规则同时写入领域准则和实际评审提交流程：领域准则定义证据粒度和链接格式，评审技能负责在提交结果前执行。共享 helper 影响多个 syscall 时仍逐项重复引用，使每个结论都能独立追溯到对应标准。

## 验证

- `git diff --check`
- 使用 `python3` 检查示例同时覆盖无问题/有问题结论、共享 helper 规则，并确认 GitHub 源码示例使用 40 位 commit SHA 和行范围。
- 实际访问示例中的 `init_module(2)` 文档链接和两个固定 Linux 源码行链接，均可正常打开。
- 本次仅修改 Markdown 规范文件，未运行 Rust clippy、QEMU 或 agent-review benchmark。
