### PR TITLE
fix(ci): reclaim Starry coverage target artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,9 @@ jobs:
           fetch-depth: 2
 
       - name: Validate CI source paths
-        run: python3 scripts/test/check_ci_paths.py
+        run: |
+          python3 scripts/test/check_ci_paths.py
+          python3 scripts/test/check_coverage_ci.py
 
       - name: Detect CI-relevant changes
         id: filter
@@ -746,9 +748,15 @@ jobs:
             command: |
               rustup component add llvm-tools
               cargo xtask ktest qemu -p starry-kernel --test axtest_kernel --arch x86_64 --coverage --out-fmt html
+              # Reports are stored under coverage/, so reclaim each instrumented target tree
+              # before building the next architecture on the hosted runner.
+              cargo clean --target-dir target/x86_64-unknown-linux-musl
               cargo xtask ktest qemu -p starry-kernel --test axtest_kernel --arch aarch64 --coverage --out-fmt html
+              cargo clean --target-dir target/aarch64-unknown-linux-musl
               cargo xtask ktest qemu -p starry-kernel --test axtest_kernel --arch riscv64 --coverage --out-fmt html
+              cargo clean --target-dir target/riscv64gc-unknown-linux-musl
               cargo xtask ktest qemu -p starry-kernel --test axtest_kernel --arch loongarch64 --coverage --out-fmt html
+              cargo clean --target-dir target/loongarch64-unknown-linux-musl
             cache_key: ""
             container_image: base
             limit_to_owner: ""

--- a/scripts/test/check_coverage_ci.py
+++ b/scripts/test/check_coverage_ci.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+
+import sys
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
+STARRY_COVERAGE_TARGETS = (
+    ("x86_64", "x86_64-unknown-linux-musl"),
+    ("aarch64", "aarch64-unknown-linux-musl"),
+    ("riscv64", "riscv64gc-unknown-linux-musl"),
+    ("loongarch64", "loongarch64-unknown-linux-musl"),
+)
+
+
+def main() -> int:
+    command = starry_coverage_command()
+    failures = coverage_cleanup_failures(command)
+    if not failures:
+        return 0
+
+    print("Starry coverage CI can exhaust the hosted runner disk:", file=sys.stderr)
+    for failure in failures:
+        print(f"  - {failure}", file=sys.stderr)
+    return 1
+
+
+def starry_coverage_command() -> str:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    job = workflow.split("          - name: Coverage test starry\n", maxsplit=1)[1]
+    job = job.split("          - name:", maxsplit=1)[0]
+    return job.split("            command: |\n", maxsplit=1)[1].split(
+        "            cache_key:", maxsplit=1
+    )[0]
+
+
+def coverage_cleanup_failures(command: str) -> list[str]:
+    failures = []
+    for index, (arch, target) in enumerate(STARRY_COVERAGE_TARGETS):
+        coverage = f"--arch {arch} --coverage --out-fmt html"
+        cleanup = f"cargo clean --target-dir target/{target}"
+        coverage_index = command.find(coverage)
+        cleanup_index = command.find(cleanup)
+        next_coverage_index = next_coverage_start(command, index)
+
+        if coverage_index < 0:
+            failures.append(f"missing coverage run for {arch}")
+        elif cleanup_index < coverage_index or (
+            next_coverage_index >= 0 and cleanup_index > next_coverage_index
+        ):
+            failures.append(
+                f"{arch} must clean target {target} before the next coverage run"
+            )
+    return failures
+
+
+def next_coverage_start(command: str, index: int) -> int:
+    if index + 1 == len(STARRY_COVERAGE_TARGETS):
+        return -1
+    next_arch = STARRY_COVERAGE_TARGETS[index + 1][0]
+    return command.find(f"--arch {next_arch} --coverage --out-fmt html")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 问题

`Coverage test starry / run_container` 在 [dev CI run 29835807196](https://github.com/rcore-os/tgoskits/actions/runs/29835807196/job/88663817135) 连续两次失败。第一次 attempt 在完成 x86_64、aarch64 coverage 后，构建 riscv64 时明确报 `No space left on device`；第二次 attempt 因磁盘压力更早触发 hosted runner shutdown。

四个架构的 instrumented target 产物此前会一直保留到 job 结束。单个架构约占 1.3–1.4 GiB，连续累积会越过 GitHub hosted runner 的可用磁盘边界。coverage 报告本身位于独立的 `coverage/` 目录，不依赖这些已完成构建的 target 目录。

## 修改

- 每个 Starry 架构生成 coverage 报告后，通过 `cargo clean --target-dir target/<triple>` 精确回收该交叉 target。
- 保留 host 侧 `tg-xtask` 构建产物，避免下一架构重复编译工具链。
- 新增 `scripts/test/check_coverage_ci.py`，验证四个 coverage 命令都在下一架构开始前清理对应 target。
- 将该检查接入 `detect_changes` 的 CI 配置前置校验。

## 方案逻辑

1. 先运行当前架构的 QEMU axtest 并生成 `.profdata` 与 HTML。
2. 报告落盘到 `coverage/` 后，仅删除 `target/<triple>`。
3. 下一架构继续复用 `target/debug/tg-xtask`，同时不再累积上一架构的 instrumented 构建树。
4. 静态回归检查防止以后新增或调整架构时重新出现连续堆积。

## 验证

- 红测：修复前 `python3 scripts/test/check_coverage_ci.py` 稳定报告四个架构均缺少清理。
- 绿测：
  - `python3 scripts/test/check_coverage_ci.py`
  - `python3 scripts/test/check_ci_paths.py`
  - `cargo fmt --all --check`
  - `git diff --check`
- 完整执行原 CI 的四架构 coverage 流程：
  - x86_64：9/9 通过，报告生成，回收约 1.3 GiB
  - aarch64：9/9 通过，报告生成，回收约 1.4 GiB
  - riscv64：9/9 通过，报告生成，回收约 1.4 GiB
  - loongarch64：9/9 通过，报告生成，回收约 1.3 GiB
- 四个架构的 `.profdata` 和 HTML `index.html` 均已核验存在。
