### PR TITLE
fix(starry-kernel): validate socket and seccomp flags

### DIFF
--- a/os/StarryOS/kernel/src/syscall/net/socket.rs
+++ b/os/StarryOS/kernel/src/syscall/net/socket.rs
@@ -31,9 +31,16 @@ use crate::{
     task::AsThread,
 };
 
+const SOCK_TYPE_MASK: u32 = 0xf;
+const SOCK_MAX: u32 = 11;
+const SOCK_FLAGS_MASK: u32 = O_NONBLOCK | O_CLOEXEC;
+
 pub fn sys_socket(domain: u32, raw_ty: u32, proto: u32) -> AxResult<isize> {
     debug!("sys_socket <= domain: {domain}, ty: {raw_ty}, proto: {proto}");
-    let ty = raw_ty & 0xFF;
+    let ty = raw_ty & SOCK_TYPE_MASK;
+    if raw_ty & !(SOCK_TYPE_MASK | SOCK_FLAGS_MASK) != 0 || ty >= SOCK_MAX {
+        return Err(AxError::InvalidInput);
+    }
 
     if domain == AF_PACKET {
         if ty != SOCK_DGRAM {

--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -952,7 +952,12 @@ pub fn sys_seccomp(op: u32, flags: u32, args: *const ()) -> AxResult<isize> {
                 sync_seccomp_to_thread_group();
             }
         }
-        SECCOMP_GET_ACTION_AVAIL => return seccomp_action_available(args),
+        SECCOMP_GET_ACTION_AVAIL => {
+            if flags != 0 {
+                return Err(AxError::InvalidInput);
+            }
+            return seccomp_action_available(args);
+        }
         _ => return Err(AxError::InvalidInput),
     }
 

--- a/test-suit/starryos/qemu/system/syscall-test-seccomp/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-seccomp/src/main.c
@@ -228,6 +228,18 @@ static void check_invalid_seccomp_args(void)
                        "unknown seccomp op returns EINVAL");
 
     errno = 0;
+    expect_syscall_ret(seccomp_raw(SECCOMP_GET_ACTION_AVAIL,
+                                   SECCOMP_FILTER_FLAG_TSYNC, &action),
+                       -1, EINVAL,
+                       "GET_ACTION_AVAIL rejects filter-specific flags");
+
+    errno = 0;
+    expect_syscall_ret(seccomp_raw(SECCOMP_GET_ACTION_AVAIL,
+                                   SECCOMP_FILTER_FLAG_TSYNC, NULL),
+                       -1, EINVAL,
+                       "GET_ACTION_AVAIL checks flags before its pointer");
+
+    errno = 0;
     expect_syscall_ret(seccomp_raw(SECCOMP_GET_ACTION_AVAIL, 0, NULL), -1,
                        EFAULT, "GET_ACTION_AVAIL NULL pointer returns EFAULT");
 

--- a/test-suit/starryos/qemu/system/syscall-test-socket-dataplane/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-socket-dataplane/src/main.c
@@ -181,6 +181,7 @@
 #include <netinet/in.h>
 #include <signal.h>
 #include <sys/socket.h>
+#include <sys/syscall.h>
 #include <sys/select.h>
 #include <unistd.h>
 
@@ -208,6 +209,18 @@ static int make_tcp_sock(void)
 
 static void test_socket_type_errors(void)
 {
+    const int unknown_socket_flag = 1 << 8;
+    long ret;
+
+    CHECK_ERR((ret = syscall(SYS_socket, AF_UNIX, SOCK_PACKET + 1, 0)), EINVAL,
+              "socket rejects a type at Linux SOCK_MAX");
+    if (ret >= 0) close((int)ret);
+
+    CHECK_ERR((ret = syscall(SYS_socket, AF_UNIX,
+                             SOCK_STREAM | unknown_socket_flag, 0)),
+              EINVAL, "socket rejects unknown type flag bits");
+    if (ret >= 0) close((int)ret);
+
     CHECK_ERR(socket(AF_UNIX, SOCK_RDM, 0), ESOCKTNOSUPPORT,
               "socket(AF_UNIX, SOCK_RDM) returns ESOCKTNOSUPPORT");
 }


### PR DESCRIPTION
  ## Problem

  Several syscall argument checks in StarryOS did not match Linux behavior:

  - `socket(2)` used an overly broad type mask, allowing unknown flag bits to be ignored and failing to distinguish invalid
  types from known but unsupported types.
  - `SECCOMP_GET_ACTION_AVAIL` accepted filter-specific flags and could access the user pointer before validating operation-  specific flags.
  - The original SyscallGuard batch converted all underlying `mmap` errors to `EACCES`, which would break the existing
  `ENODEV` behavior for directory mappings.

  ## Changes

  ### socket

  - Use Linux `SOCK_TYPE_MASK` semantics to separate the socket type from creation flags.
  - Accept only the `SOCK_NONBLOCK` and `SOCK_CLOEXEC` flag bits.
  - Return `EINVAL` for unknown flag bits and types greater than or equal to `SOCK_MAX`.
  - Preserve `ESOCKTNOSUPPORT` for `AF_UNIX + SOCK_RDM`.
  - Add direct `SYS_socket` regression tests for invalid types and unknown flag bits.

  ### seccomp

  - Require `flags == 0` for `SECCOMP_GET_ACTION_AVAIL`.
  - Validate operation-specific flags before accessing `args`.
  - Add coverage for a valid action combined with `SECCOMP_FILTER_FLAG_TSYNC`.
  - Verify that invalid flags take precedence over an invalid pointer and return `EINVAL` instead of `EFAULT`.

  ### mmap

  - Keep the original `fl.file_mmap()?` error propagation.
  - Do not include the error-flattening change from the original batch.
  - Preserve `ENODEV` for attempts to mmap a directory.

  ## Implementation Rationale

  Validation is performed at the syscall boundary:

  1. Reject unknown or operation-inapplicable flag bits.
  2. Parse the socket type or access seccomp user arguments.
  3. Let the existing address-family and backend logic report unsupported operations.

  The change does not modify any public Rust API or introduce new resource, concurrency, or state-management behavior.
