### PR TITLE
feat(axvm): add VmInterruptSender and integrate dispatcher into VmRuntimeHandle

### DIFF
--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -128,6 +128,11 @@ impl AxVmDevices {
     }
 
     /// Builds devices with registered factories and explicit legacy fallbacks.
+    ///
+    /// A registered factory is authoritative and always takes precedence over
+    /// the legacy fallback for the same device type. Factory validation or
+    /// construction errors are returned directly; they never trigger fallback
+    /// construction of a second device.
     pub fn build_with_factories(
         config: AxVmDeviceConfig,
         factories: &DeviceFactoryRegistry,

--- a/virtualization/axdevice/src/factory.rs
+++ b/virtualization/axdevice/src/factory.rs
@@ -53,6 +53,11 @@ impl<'a> DeviceBuildContext<'a> {
 }
 
 /// Builds all capabilities contributed by one emulated device type.
+///
+/// A factory that exposes an architecture-owned, pre-created controller must
+/// capture the same shared controller instance and validate that each build
+/// request matches the configuration used to create it, including its MMIO
+/// base, length, and type-specific arguments.
 pub trait DeviceFactory: Send + Sync {
     /// Returns the configuration type handled by this factory.
     fn device_type(&self) -> EmulatedDeviceType;
@@ -66,6 +71,15 @@ pub trait DeviceFactory: Send + Sync {
 }
 
 /// A registry containing at most one factory for each emulated device type.
+///
+/// Registered factories are authoritative for their device type: during
+/// [`AxVmDevices::build_with_factories`](crate::AxVmDevices::build_with_factories),
+/// they take precedence over legacy fallback construction. A factory error is
+/// propagated and never causes a fallback to create another device.
+///
+/// Architectures that pre-create an interrupt controller must first reject
+/// duplicate controller configurations, then register exactly one factory that
+/// captures the shared controller and its validated configuration fingerprint.
 #[derive(Default)]
 pub struct DeviceFactoryRegistry {
     factories: Vec<(EmulatedDeviceType, Arc<dyn DeviceFactory>)>,

--- a/virtualization/axvm-types/src/lib.rs
+++ b/virtualization/axvm-types/src/lib.rs
@@ -67,8 +67,8 @@ pub type InterruptVector = u8;
 /// Interrupt trigger mode.
 ///
 /// Represents the trigger mode of an interrupt in a platform-neutral way.
-/// Architectures that do not distinguish between edge and level triggering
-/// can ignore this parameter.
+/// Every architecture adapter must explicitly define where this metadata is
+/// consumed, even when its vCPU backend does not distinguish the modes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InterruptTriggerMode {
     /// Edge-triggered interrupt.
@@ -456,13 +456,7 @@ pub trait VmArchVcpuOps: Sized {
         &mut self,
         vector: usize,
         trigger: InterruptTriggerMode,
-    ) -> VmBackendResult {
-        debug_assert!(
-            trigger == InterruptTriggerMode::EdgeTriggered,
-            "level-triggered interrupt injection requires an architecture-specific implementation"
-        );
-        self.inject_interrupt(vector)
-    }
+    ) -> VmBackendResult;
     /// Processes a guest EOI and returns an external EOI vector when needed.
     fn handle_eoi(&mut self) -> Option<u8> {
         None
@@ -810,6 +804,14 @@ mod tests {
         fn set_gpr(&mut self, _reg: usize, _val: usize) {}
 
         fn inject_interrupt(&mut self, _vector: usize) -> VmBackendResult {
+            Ok(())
+        }
+
+        fn inject_interrupt_with_trigger(
+            &mut self,
+            _vector: usize,
+            _trigger: InterruptTriggerMode,
+        ) -> VmBackendResult {
             Ok(())
         }
 

--- a/virtualization/axvm-types/src/lib.rs
+++ b/virtualization/axvm-types/src/lib.rs
@@ -452,11 +452,20 @@ pub trait VmArchVcpuOps: Sized {
     /// Injects an interrupt into the vCPU.
     fn inject_interrupt(&mut self, vector: usize) -> VmBackendResult;
     /// Injects an interrupt with trigger-mode metadata.
+    ///
+    /// The compatibility default delegates edge-triggered interrupts to
+    /// [`Self::inject_interrupt`]. Backends must override this method to
+    /// support level-triggered injection.
     fn inject_interrupt_with_trigger(
         &mut self,
         vector: usize,
         trigger: InterruptTriggerMode,
-    ) -> VmBackendResult;
+    ) -> VmBackendResult {
+        match trigger {
+            InterruptTriggerMode::EdgeTriggered => self.inject_interrupt(vector),
+            InterruptTriggerMode::LevelTriggered => Err(VmBackendError::Unsupported),
+        }
+    }
     /// Processes a guest EOI and returns an external EOI vector when needed.
     fn handle_eoi(&mut self) -> Option<u8> {
         None

--- a/virtualization/axvm-types/tests/vcpu_interrupt_compat.rs
+++ b/virtualization/axvm-types/tests/vcpu_interrupt_compat.rs
@@ -1,0 +1,83 @@
+// Copyright 2026 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use axvm_types::{
+    GuestPhysAddr, InterruptTriggerMode, NestedPagingConfig, VCpuId, VMId, VmArchVcpuOps,
+    VmBackendError, VmBackendResult,
+};
+
+#[derive(Debug, Default)]
+struct LegacyVcpu {
+    injected_vectors: Vec<usize>,
+}
+
+impl VmArchVcpuOps for LegacyVcpu {
+    type CreateConfig = ();
+    type SetupConfig = ();
+    type Exit = ();
+
+    fn new(_vm_id: VMId, _vcpu_id: VCpuId, _config: Self::CreateConfig) -> VmBackendResult<Self> {
+        Ok(Self::default())
+    }
+
+    fn set_entry(&mut self, _entry: GuestPhysAddr) -> VmBackendResult {
+        Ok(())
+    }
+
+    fn set_nested_page_table(&mut self, _config: NestedPagingConfig) -> VmBackendResult {
+        Ok(())
+    }
+
+    fn setup(&mut self, _config: Self::SetupConfig) -> VmBackendResult {
+        Ok(())
+    }
+
+    fn run(&mut self) -> VmBackendResult<Self::Exit> {
+        Ok(())
+    }
+
+    fn bind(&mut self) -> VmBackendResult {
+        Ok(())
+    }
+
+    fn unbind(&mut self) -> VmBackendResult {
+        Ok(())
+    }
+
+    fn set_gpr(&mut self, _reg: usize, _val: usize) {}
+
+    fn inject_interrupt(&mut self, vector: usize) -> VmBackendResult {
+        self.injected_vectors.push(vector);
+        Ok(())
+    }
+
+    fn set_return_value(&mut self, _val: usize) {}
+}
+
+#[test]
+fn legacy_backend_uses_safe_trigger_compatibility_default() {
+    let mut vcpu = LegacyVcpu::new(1, 0, ()).unwrap();
+
+    assert_eq!(
+        vcpu.inject_interrupt_with_trigger(0x31, InterruptTriggerMode::EdgeTriggered),
+        Ok(())
+    );
+    assert_eq!(vcpu.injected_vectors, [0x31]);
+
+    assert_eq!(
+        vcpu.inject_interrupt_with_trigger(0x32, InterruptTriggerMode::LevelTriggered),
+        Err(VmBackendError::Unsupported)
+    );
+    assert_eq!(vcpu.injected_vectors, [0x31]);
+}

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -15,8 +15,9 @@ use arm_vgic::host::ArmVgicHostIf;
 use ax_crate_interface::impl_interface;
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axvm_types::{
-    AccessWidth, GuestPhysAddr, NestedPagingConfig, SysRegAddr, VCpuId, VMId, VmArchPerCpuOps,
-    VmArchVcpuOps, VmBackendError as BackendError, VmBackendResult as BackendResult,
+    AccessWidth, GuestPhysAddr, InterruptTriggerMode, NestedPagingConfig, SysRegAddr, VCpuId, VMId,
+    VmArchPerCpuOps, VmArchVcpuOps, VmBackendError as BackendError,
+    VmBackendResult as BackendResult,
 };
 
 use super::{ArchOps, BoundVcpuExit, HypercallExit, MmioReadExit, MmioWriteExit, VcpuRunAction};
@@ -261,6 +262,20 @@ impl VmArchVcpuOps for AxvmArmVcpu {
 
     fn inject_interrupt(&mut self, vector: usize) -> BackendResult {
         arm_result(self.0.inject_interrupt(vector))
+    }
+
+    fn inject_interrupt_with_trigger(
+        &mut self,
+        vector: usize,
+        trigger: InterruptTriggerMode,
+    ) -> BackendResult {
+        // The Arm Router/VGIC consumes line trigger semantics before emitting
+        // an INTID. The GIC list-register injection itself is mode-agnostic.
+        match trigger {
+            InterruptTriggerMode::EdgeTriggered | InterruptTriggerMode::LevelTriggered => {
+                arm_result(self.0.inject_interrupt(vector))
+            }
+        }
     }
 
     fn set_return_value(&mut self, val: usize) {

--- a/virtualization/axvm/src/arch/loongarch64/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/mod.rs
@@ -3,8 +3,9 @@ use core::time::Duration;
 
 use ax_memory_addr::VirtAddr;
 use axvm_types::{
-    AccessWidth, GuestPhysAddr, MappingFlags, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps,
-    VmArchVcpuOps, VmBackendError as BackendError, VmBackendResult as BackendResult,
+    AccessWidth, GuestPhysAddr, InterruptTriggerMode, MappingFlags, NestedPagingConfig, VCpuId,
+    VMId, VmArchPerCpuOps, VmArchVcpuOps, VmBackendError as BackendError,
+    VmBackendResult as BackendResult,
 };
 use loongarch_vcpu::{
     LoongArchAccessFlags, LoongArchAccessWidth, LoongArchGuestPhysAddr, LoongArchHostOps,
@@ -385,6 +386,20 @@ impl VmArchVcpuOps for AxvmLoongArchVcpu {
 
     fn inject_interrupt(&mut self, vector: usize) -> BackendResult {
         loongarch_result(self.0.inject_interrupt(vector))
+    }
+
+    fn inject_interrupt_with_trigger(
+        &mut self,
+        vector: usize,
+        trigger: InterruptTriggerMode,
+    ) -> BackendResult {
+        // The PCH-PIC/EIOINTC Router consumes line trigger semantics before
+        // emitting a guest vector. The vCPU injection is mode-agnostic.
+        match trigger {
+            InterruptTriggerMode::EdgeTriggered | InterruptTriggerMode::LevelTriggered => {
+                loongarch_result(self.0.inject_interrupt(vector))
+            }
+        }
     }
 
     fn set_return_value(&mut self, val: usize) {

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -3,8 +3,8 @@ use alloc::vec::Vec;
 use ax_crate_interface::impl_interface;
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use axvm_types::{
-    AccessWidth, GuestPhysAddr, MappingFlags, NestedPagingConfig, VCpuId, VMId, VMInterruptMode,
-    VmArchPerCpuOps, VmArchVcpuOps, VmBackendError as BackendError,
+    AccessWidth, GuestPhysAddr, InterruptTriggerMode, MappingFlags, NestedPagingConfig, VCpuId,
+    VMId, VMInterruptMode, VmArchPerCpuOps, VmArchVcpuOps, VmBackendError as BackendError,
     VmBackendResult as BackendResult,
 };
 use riscv_vcpu::{
@@ -326,6 +326,20 @@ impl VmArchVcpuOps for AxvmRiscvVcpu {
 
     fn inject_interrupt(&mut self, vector: usize) -> BackendResult {
         riscv_result(self.0.inject_interrupt(vector))
+    }
+
+    fn inject_interrupt_with_trigger(
+        &mut self,
+        vector: usize,
+        trigger: InterruptTriggerMode,
+    ) -> BackendResult {
+        // The vPLIC Router consumes source trigger semantics before setting a
+        // virtual pending bit. The vCPU injection operation is mode-agnostic.
+        match trigger {
+            InterruptTriggerMode::EdgeTriggered | InterruptTriggerMode::LevelTriggered => {
+                riscv_result(self.0.inject_interrupt(vector))
+            }
+        }
     }
 
     fn set_return_value(&mut self, val: usize) {

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -404,10 +404,8 @@ impl VmArchVcpuOps for AxvmX86Vcpu {
         trigger: InterruptTriggerMode,
     ) -> BackendResult {
         x86_result(
-            self.0.inject_interrupt_with_trigger(
-                vector,
-                trigger == InterruptTriggerMode::LevelTriggered,
-            ),
+            self.0
+                .inject_interrupt_with_trigger(vector, x86_interrupt_is_level_triggered(trigger)),
         )
     }
 
@@ -417,6 +415,13 @@ impl VmArchVcpuOps for AxvmX86Vcpu {
 
     fn set_return_value(&mut self, val: usize) {
         self.0.set_return_value(val);
+    }
+}
+
+const fn x86_interrupt_is_level_triggered(trigger: InterruptTriggerMode) -> bool {
+    match trigger {
+        InterruptTriggerMode::EdgeTriggered => false,
+        InterruptTriggerMode::LevelTriggered => true,
     }
 }
 
@@ -661,6 +666,16 @@ mod tests {
         );
         assert_eq!(x86_port_to_ax(X86Port::new(0x3f8)).0, 0x3f8);
         assert_eq!(x86_msr_addr_to_ax(X86MsrAddr::new(0x800)).0, 0x800);
+    }
+
+    #[test]
+    fn maps_edge_and_level_triggers_to_x86_backend_modes() {
+        assert!(!x86_interrupt_is_level_triggered(
+            InterruptTriggerMode::EdgeTriggered
+        ));
+        assert!(x86_interrupt_is_level_triggered(
+            InterruptTriggerMode::LevelTriggered
+        ));
     }
 
     #[test]

--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -7,7 +7,7 @@ use axaddrspace::NestedPageTableOps;
 use axvm_types::{VmArchPerCpuOps, VmArchVcpuOps, VmVcpuState};
 
 use super::{BoundVcpuExit, VcpuRunAction};
-use crate::{AxVmResult, ax_err};
+use crate::{AxVmResult, ax_err, irq::model::PendingVcpuInterrupt};
 
 pub(crate) trait ArchOps {
     type VCpu: VmArchVcpuOps;
@@ -72,6 +72,22 @@ pub(crate) trait ArchOps {
         }
     }
 
+    /// Injects a pending `PendingVcpuInterrupt` into the target vCPU.
+    ///
+    /// Called in the **target vCPU's run loop** so that accesses to banked
+    /// system registers (GIC LR, x86 vLAPIC, etc.) happen on the correct
+    /// physical CPU.
+    ///
+    /// The default implementation calls `vcpu.inject_interrupt(interrupt.id.0
+    /// as usize)`, matching the `Normal` branch of the legacy
+    /// `inject_pending_interrupt`.
+    fn inject_vcpu_interrupt(
+        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        interrupt: PendingVcpuInterrupt,
+    ) -> AxVmResult {
+        vcpu.inject_interrupt(interrupt.id.0 as usize)
+    }
+
     fn after_external_interrupt(
         _vm: &crate::AxVMRef,
         _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
@@ -121,6 +137,32 @@ pub(crate) trait ArchOps {
         let run_result = vcpu.with_current_cpu_set(|| -> AxVmResult<_> {
             loop {
                 crate::runtime::vcpus::inject_pending_interrupts::<Self>(vm.id(), vcpu_id, vcpu);
+
+                // New path: drain the architecture-router dispatcher.
+                let new_interrupts =
+                    match vm.with_runtime(|rt| Ok(rt.irq_dispatcher().drain(vcpu_id))) {
+                        Ok(interrupts) => interrupts,
+                        Err(err) => {
+                            warn!(
+                                "VM[{}] VCpu[{}] cannot drain new interrupt dispatcher: {:?}",
+                                vm.id(),
+                                vcpu_id,
+                                err
+                            );
+                            Vec::new()
+                        }
+                    };
+                for interrupt in new_interrupts {
+                    if let Err(err) = Self::inject_vcpu_interrupt(vcpu, interrupt) {
+                        warn!(
+                            "VM[{}] VCpu[{}] failed to inject interrupt {:?}: {:?}",
+                            vm.id(),
+                            vcpu_id,
+                            interrupt,
+                            err
+                        );
+                    }
+                }
 
                 let exit = vcpu.run()?;
                 trace!("{exit:#x?}");

--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -77,15 +77,11 @@ pub(crate) trait ArchOps {
     /// Called in the **target vCPU's run loop** so that accesses to banked
     /// system registers (GIC LR, x86 vLAPIC, etc.) happen on the correct
     /// physical CPU.
-    ///
-    /// The default implementation calls `vcpu.inject_interrupt(interrupt.id.0
-    /// as usize)`, matching the `Normal` branch of the legacy
-    /// `inject_pending_interrupt`.
     fn inject_vcpu_interrupt(
         vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         interrupt: PendingVcpuInterrupt,
     ) -> AxVmResult {
-        vcpu.inject_interrupt(interrupt.id.0 as usize)
+        vcpu.inject_interrupt_with_trigger(interrupt.id.0 as usize, interrupt.trigger)
     }
 
     fn after_external_interrupt(
@@ -138,31 +134,7 @@ pub(crate) trait ArchOps {
             loop {
                 crate::runtime::vcpus::inject_pending_interrupts::<Self>(vm.id(), vcpu_id, vcpu);
 
-                // New path: drain the architecture-router dispatcher.
-                let new_interrupts =
-                    match vm.with_runtime(|rt| Ok(rt.irq_dispatcher().drain(vcpu_id))) {
-                        Ok(interrupts) => interrupts,
-                        Err(err) => {
-                            warn!(
-                                "VM[{}] VCpu[{}] cannot drain new interrupt dispatcher: {:?}",
-                                vm.id(),
-                                vcpu_id,
-                                err
-                            );
-                            Vec::new()
-                        }
-                    };
-                for interrupt in new_interrupts {
-                    if let Err(err) = Self::inject_vcpu_interrupt(vcpu, interrupt) {
-                        warn!(
-                            "VM[{}] VCpu[{}] failed to inject interrupt {:?}: {:?}",
-                            vm.id(),
-                            vcpu_id,
-                            interrupt,
-                            err
-                        );
-                    }
-                }
+                drain_and_inject_dispatched_interrupts::<Self>(vm, vcpu_id, vcpu);
 
                 let exit = vcpu.run()?;
                 trace!("{exit:#x?}");
@@ -192,6 +164,39 @@ pub(crate) trait ArchOps {
                 }
                 Err(err)
             }
+        }
+    }
+}
+
+fn drain_and_inject_dispatched_interrupts<A: ArchOps>(
+    vm: &crate::AxVMRef,
+    vcpu_id: usize,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
+) {
+    let runtime = match vm.with_runtime(|runtime| Ok(runtime.clone())) {
+        Ok(runtime) => runtime,
+        Err(err) => {
+            warn!(
+                "VM[{}] VCpu[{}] cannot access interrupt dispatcher: {:?}",
+                vm.id(),
+                vcpu_id,
+                err
+            );
+            return;
+        }
+    };
+    inject_drained_interrupts::<A>(runtime.irq_dispatcher(), vm.id(), vcpu_id, vcpu);
+}
+
+fn inject_drained_interrupts<A: ArchOps>(
+    dispatcher: &crate::runtime::VcpuIrqDispatcher,
+    vm_id: usize,
+    vcpu_id: usize,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
+) {
+    for interrupt in dispatcher.drain(vcpu_id) {
+        if let Err(err) = A::inject_vcpu_interrupt(vcpu, interrupt) {
+            warn!("VM[{vm_id}] VCpu[{vcpu_id}] failed to inject interrupt {interrupt:?}: {err:?}");
         }
     }
 }
@@ -239,4 +244,207 @@ pub(crate) fn default_vcpu_affinities(
     }
 
     vcpus
+}
+
+#[cfg(all(test, feature = "host-test"))]
+mod tests {
+    use alloc::{sync::Arc, vec};
+
+    use ax_kspin::SpinNoIrq;
+    use axvm_types::{
+        GuestPhysAddr, InterruptTriggerMode, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps,
+        VmArchVcpuOps, VmBackendError, VmBackendResult,
+    };
+
+    use super::*;
+    use crate::{irq::model::VirtualInterruptId, vcpu::AxVCpu};
+
+    #[derive(Default)]
+    struct InjectionLog {
+        attempts: Vec<(usize, InterruptTriggerMode)>,
+        failing_vector: Option<usize>,
+    }
+
+    struct RecordingVcpu {
+        injections: Arc<SpinNoIrq<InjectionLog>>,
+    }
+
+    impl VmArchVcpuOps for RecordingVcpu {
+        type CreateConfig = Arc<SpinNoIrq<InjectionLog>>;
+        type SetupConfig = ();
+        type Exit = ();
+
+        fn new(
+            _vm_id: VMId,
+            _vcpu_id: VCpuId,
+            injections: Self::CreateConfig,
+        ) -> VmBackendResult<Self> {
+            Ok(Self { injections })
+        }
+
+        fn set_entry(&mut self, _entry: GuestPhysAddr) -> VmBackendResult {
+            Ok(())
+        }
+
+        fn set_nested_page_table(&mut self, _config: NestedPagingConfig) -> VmBackendResult {
+            Ok(())
+        }
+
+        fn setup(&mut self, _config: Self::SetupConfig) -> VmBackendResult {
+            Ok(())
+        }
+
+        fn run(&mut self) -> VmBackendResult<Self::Exit> {
+            Ok(())
+        }
+
+        fn bind(&mut self) -> VmBackendResult {
+            Ok(())
+        }
+
+        fn unbind(&mut self) -> VmBackendResult {
+            Ok(())
+        }
+
+        fn set_gpr(&mut self, _reg: usize, _val: usize) {}
+
+        fn inject_interrupt(&mut self, vector: usize) -> VmBackendResult {
+            self.record_injection(vector, InterruptTriggerMode::EdgeTriggered)
+        }
+
+        fn inject_interrupt_with_trigger(
+            &mut self,
+            vector: usize,
+            trigger: InterruptTriggerMode,
+        ) -> VmBackendResult {
+            self.record_injection(vector, trigger)
+        }
+
+        fn set_return_value(&mut self, _val: usize) {}
+    }
+
+    impl RecordingVcpu {
+        fn record_injection(
+            &self,
+            vector: usize,
+            trigger: InterruptTriggerMode,
+        ) -> VmBackendResult {
+            let mut injections = self.injections.lock();
+            injections.attempts.push((vector, trigger));
+            if injections.failing_vector == Some(vector) {
+                Err(VmBackendError::ResourceBusy)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    struct RecordingPerCpu;
+
+    impl VmArchPerCpuOps for RecordingPerCpu {
+        fn new(_cpu_id: usize) -> VmBackendResult<Self> {
+            Ok(Self)
+        }
+
+        fn is_enabled(&self) -> bool {
+            true
+        }
+
+        fn hardware_enable(&mut self) -> VmBackendResult {
+            Ok(())
+        }
+
+        fn hardware_disable(&mut self) -> VmBackendResult {
+            Ok(())
+        }
+    }
+
+    struct RecordingArch;
+
+    impl ArchOps for RecordingArch {
+        type VCpu = RecordingVcpu;
+        type PerCpu = RecordingPerCpu;
+        type DeferredRunWork = ();
+        type NestedPageTable = crate::arch::ArchNestedPageTable;
+
+        fn has_hardware_support() -> bool {
+            true
+        }
+
+        fn handle_vcpu_exit_bound(
+            _vm: &crate::AxVMRef,
+            _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+            _exit: <Self::VCpu as VmArchVcpuOps>::Exit,
+        ) -> AxVmResult<BoundVcpuExit<Self::DeferredRunWork>> {
+            unreachable!("the injection test never runs a vCPU")
+        }
+
+        fn finish_deferred_run_work(
+            _vm: &crate::AxVMRef,
+            _vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+            _work: Self::DeferredRunWork,
+        ) -> AxVmResult<VcpuRunAction> {
+            unreachable!("the injection test has no deferred work")
+        }
+    }
+
+    #[test]
+    fn inject_vcpu_interrupt_preserves_level_trigger_at_backend_boundary() {
+        let injections = Arc::new(SpinNoIrq::new(InjectionLog::default()));
+        let vcpu = Arc::new(AxVCpu::<RecordingVcpu>::new(1, 0, None, injections.clone()).unwrap());
+        let interrupt = PendingVcpuInterrupt {
+            id: VirtualInterruptId(0x31),
+            trigger: InterruptTriggerMode::LevelTriggered,
+        };
+        let dispatcher = crate::runtime::VcpuIrqDispatcher::new();
+        dispatcher.register_test_vcpu(0, 2);
+        dispatcher.enqueue(0, interrupt).unwrap();
+
+        inject_drained_interrupts::<RecordingArch>(&dispatcher, 1, 0, &vcpu);
+
+        assert_eq!(
+            injections.lock().attempts,
+            vec![(0x31, InterruptTriggerMode::LevelTriggered)]
+        );
+    }
+
+    #[test]
+    fn dispatcher_drain_injects_fifo_once_and_consumes_failed_entries() {
+        let injections = Arc::new(SpinNoIrq::new(InjectionLog {
+            failing_vector: Some(0x42),
+            ..Default::default()
+        }));
+        let vcpu = Arc::new(AxVCpu::<RecordingVcpu>::new(1, 0, None, injections.clone()).unwrap());
+        let dispatcher = crate::runtime::VcpuIrqDispatcher::new();
+        dispatcher.register_test_vcpu(0, 2);
+        for interrupt in [
+            PendingVcpuInterrupt {
+                id: VirtualInterruptId(0x41),
+                trigger: InterruptTriggerMode::EdgeTriggered,
+            },
+            PendingVcpuInterrupt {
+                id: VirtualInterruptId(0x42),
+                trigger: InterruptTriggerMode::LevelTriggered,
+            },
+            PendingVcpuInterrupt {
+                id: VirtualInterruptId(0x43),
+                trigger: InterruptTriggerMode::EdgeTriggered,
+            },
+        ] {
+            dispatcher.enqueue(0, interrupt).unwrap();
+        }
+
+        inject_drained_interrupts::<RecordingArch>(&dispatcher, 1, 0, &vcpu);
+        inject_drained_interrupts::<RecordingArch>(&dispatcher, 1, 0, &vcpu);
+
+        assert_eq!(
+            injections.lock().attempts,
+            vec![
+                (0x41, InterruptTriggerMode::EdgeTriggered),
+                (0x42, InterruptTriggerMode::LevelTriggered),
+                (0x43, InterruptTriggerMode::EdgeTriggered),
+            ]
+        );
+        assert!(dispatcher.drain(0).is_empty());
+    }
 }

--- a/virtualization/axvm/src/irq/mod.rs
+++ b/virtualization/axvm/src/irq/mod.rs
@@ -159,3 +159,4 @@ impl IrqResolver for InterruptFabric {
 }
 
 pub(crate) mod model;
+pub(crate) mod sender;

--- a/virtualization/axvm/src/irq/mod.rs
+++ b/virtualization/axvm/src/irq/mod.rs
@@ -58,6 +58,7 @@ pub(crate) fn set_riscv_virtual_irq_targets(cpu_id: usize, irq_sources: &[u32]) 
 /// The fabric owns only the backend capability. It never owns or references the
 /// containing VM, so devices can retain [`IrqLine`] objects without creating an
 /// `AxVM -> device -> IRQ -> AxVM` reference cycle.
+#[derive(Clone)]
 pub struct InterruptFabric {
     mode: VMInterruptMode,
     sink: Option<Arc<dyn IrqSink>>,

--- a/virtualization/axvm/src/irq/model.rs
+++ b/virtualization/axvm/src/irq/model.rs
@@ -24,7 +24,6 @@ use axdevice_base::InterruptTriggerMode;
 /// Will be constructed by architecture interrupt routers and consumed by
 /// [`VcpuIrqDispatcher`](crate::runtime::VcpuIrqDispatcher) when a virtual
 /// device raises an interrupt.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct VirtualInterruptId(pub u32);
 
@@ -35,7 +34,6 @@ pub struct VirtualInterruptId(pub u32);
 ///
 /// Will be enqueued into [`VcpuIrqDispatcher`](crate::runtime::VcpuIrqDispatcher)
 /// and later drained by the target vCPU run loop for injection.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PendingVcpuInterrupt {
     pub id: VirtualInterruptId,

--- a/virtualization/axvm/src/irq/sender.rs
+++ b/virtualization/axvm/src/irq/sender.rs
@@ -17,12 +17,9 @@
 //! The sender holds only a [`Weak`] reference to the VM, so it never creates
 //! a strong reference cycle and automatically fails when the VM is destroyed.
 
-use alloc::{
-    format,
-    sync::{Arc, Weak},
-};
+use alloc::sync::{Arc, Weak};
 
-use crate::{AxVM, AxVmResult, VmStatus, ax_err, ax_err_type, irq::model::PendingVcpuInterrupt};
+use crate::{AxVM, AxVmResult, ax_err_type, irq::model::PendingVcpuInterrupt};
 
 /// Router-to-runtime stable send channel.
 ///
@@ -30,18 +27,24 @@ use crate::{AxVM, AxVmResult, VmStatus, ax_err, ax_err_type, irq::model::Pending
 /// reference. Every [`send`](Self::send) call looks up the current runtime
 /// through the VM, so a VM stop/start/reset cycle cannot leave the sender
 /// pointing at a stale dispatcher.
-#[allow(dead_code, reason = "routers create senders in module 2+")]
+#[expect(
+    dead_code,
+    reason = "architecture routers create senders in later modules"
+)]
 #[derive(Clone)]
 pub struct VmInterruptSender {
-    vm: Weak<AxVM>,
+    target: StableInterruptTarget<AxVM>,
 }
 
 impl VmInterruptSender {
     /// Constructs a sender from an `AxVMRef` (`Arc<AxVM>`).
-    #[allow(dead_code, reason = "routers create senders in module 2+")]
+    #[expect(
+        dead_code,
+        reason = "architecture routers create senders in later modules"
+    )]
     pub fn new(vm: &Arc<AxVM>) -> Self {
         Self {
-            vm: Arc::downgrade(vm),
+            target: StableInterruptTarget::new(vm),
         }
     }
 
@@ -52,32 +55,241 @@ impl VmInterruptSender {
     ///
     /// 1. Upgrade `Weak<AxVM>` — returns `NotFound` if the VM has been
     ///    destroyed.
-    /// 2. Check VM status — only `Running` and `Paused` accept interrupts;
-    ///    other states return `BadState`.
-    /// 3. `vm.with_runtime(|rt| rt.dispatch_vcpu_interrupt(vcpu_id,
-    ///    interrupt))` — runtime not yet created returns `BadState`;
+    /// 2. Select the current runtime while checking under the same machine
+    ///    lock that the VM is `Running` or `Paused`; other states and a
+    ///    missing runtime return `BadState`.
+    /// 3. `runtime.dispatch_vcpu_interrupt(vcpu_id, interrupt)` —
     ///    unregistered vCPU task returns `NotFound`.
-    ///
-    /// A TOCTOU window exists between steps 2 and 3 (status may change), but
-    /// this matches the existing `vcpus::queue_interrupt` behaviour and is an
-    /// acceptable window.
-    #[allow(dead_code, reason = "interrupt routers will call send")]
+    #[expect(
+        dead_code,
+        reason = "architecture interrupt routers call send in later modules"
+    )]
     pub fn send(&self, vcpu_id: usize, interrupt: PendingVcpuInterrupt) -> AxVmResult {
-        let vm = self
-            .vm
+        self.target.send_with(
+            vcpu_id,
+            interrupt,
+            AxVM::current_interrupt_runtime,
+            |runtime, vcpu_id, interrupt| runtime.dispatch_vcpu_interrupt(vcpu_id, interrupt),
+        )
+    }
+}
+
+struct StableInterruptTarget<T> {
+    target: Weak<T>,
+}
+
+impl<T> Clone for StableInterruptTarget<T> {
+    fn clone(&self) -> Self {
+        Self {
+            target: self.target.clone(),
+        }
+    }
+}
+
+impl<T> StableInterruptTarget<T> {
+    fn new(target: &Arc<T>) -> Self {
+        Self {
+            target: Arc::downgrade(target),
+        }
+    }
+
+    fn send_with<R>(
+        &self,
+        vcpu_id: usize,
+        interrupt: PendingVcpuInterrupt,
+        current_runtime: impl FnOnce(&T) -> AxVmResult<R>,
+        dispatch: impl FnOnce(&R, usize, PendingVcpuInterrupt) -> AxVmResult,
+    ) -> AxVmResult {
+        let target = self
+            .target
             .upgrade()
             .ok_or_else(|| ax_err_type!(NotFound, "VM has been destroyed"))?;
+        let runtime = current_runtime(&target)?;
+        dispatch(&runtime, vcpu_id, interrupt)
+    }
+}
 
-        match vm.status() {
-            VmStatus::Running | VmStatus::Paused => {}
-            status => {
-                return ax_err!(
-                    BadState,
-                    format!("VM[{}] cannot accept interrupts in {status:?}", vm.id())
-                );
-            }
+#[cfg(all(test, feature = "host-test"))]
+mod tests {
+    use alloc::vec::Vec;
+    use core::cell::RefCell;
+
+    use ax_kspin::SpinNoIrq;
+
+    use super::*;
+    use crate::{
+        AxVmError, InterruptTriggerMode,
+        irq::model::VirtualInterruptId,
+        lifecycle::{Machine, StopReason},
+        vm::{VmRuntimeHandle, dispatch_vcpu_interrupt_with},
+    };
+
+    struct TestVm {
+        machine: SpinNoIrq<Machine<(), Arc<VmRuntimeHandle>>>,
+    }
+
+    impl TestVm {
+        fn new(machine: Machine<(), Arc<VmRuntimeHandle>>) -> Arc<Self> {
+            Arc::new(Self {
+                machine: SpinNoIrq::new(machine),
+            })
         }
 
-        vm.with_runtime(|rt| rt.dispatch_vcpu_interrupt(vcpu_id, interrupt))
+        fn current_interrupt_runtime(&self) -> AxVmResult<Arc<VmRuntimeHandle>> {
+            Ok(self.machine.lock().interrupt_runtime()?.clone())
+        }
+    }
+
+    fn runtime(cpu_id: Option<usize>) -> Arc<VmRuntimeHandle> {
+        let runtime = Arc::new(VmRuntimeHandle::new());
+        if let Some(cpu_id) = cpu_id {
+            runtime.irq_dispatcher().register_test_vcpu(0, cpu_id);
+        }
+        runtime
+    }
+
+    fn interrupt(id: u32) -> PendingVcpuInterrupt {
+        PendingVcpuInterrupt {
+            id: VirtualInterruptId(id),
+            trigger: InterruptTriggerMode::LevelTriggered,
+        }
+    }
+
+    fn send(
+        sender: &StableInterruptTarget<TestVm>,
+        vcpu_id: usize,
+        interrupt: PendingVcpuInterrupt,
+        events: &RefCell<Vec<&'static str>>,
+    ) -> AxVmResult {
+        sender.send_with(
+            vcpu_id,
+            interrupt,
+            TestVm::current_interrupt_runtime,
+            |runtime, vcpu_id, interrupt| {
+                dispatch_vcpu_interrupt_with(
+                    || {
+                        let cpu_id = runtime.irq_dispatcher().enqueue(vcpu_id, interrupt)?;
+                        events.borrow_mut().push("enqueue");
+                        Ok(cpu_id)
+                    },
+                    || events.borrow_mut().push("notify"),
+                    |_| events.borrow_mut().push("ipi"),
+                )
+            },
+        )
+    }
+
+    #[test]
+    fn sender_accepts_running_and_paused_registered_vcpu() {
+        for paused in [false, true] {
+            let runtime = runtime(Some(3));
+            let vm = TestVm::new(Machine::Running {
+                resources: (),
+                runtime: runtime.clone(),
+            });
+            if paused {
+                vm.machine.lock().pause().unwrap();
+            }
+            let sender = StableInterruptTarget::new(&vm);
+            let events = RefCell::new(Vec::new());
+
+            send(&sender, 0, interrupt(1), &events).unwrap();
+
+            assert_eq!(*events.borrow(), ["enqueue", "notify", "ipi"]);
+            assert_eq!(runtime.irq_dispatcher().drain(0), alloc::vec![interrupt(1)]);
+        }
+    }
+
+    #[test]
+    fn sender_rejects_ready_stopped_and_destroyed_states() {
+        let states = [
+            Machine::Ready(()),
+            Machine::Stopped {
+                resources: Some(()),
+                runtime: None,
+                reason: StopReason::Forced,
+            },
+            Machine::Destroyed,
+        ];
+
+        for machine in states {
+            let vm = TestVm::new(machine);
+            let sender = StableInterruptTarget::new(&vm);
+            let events = RefCell::new(Vec::new());
+
+            assert!(matches!(
+                send(&sender, 0, interrupt(1), &events),
+                Err(AxVmError::InvalidState { .. })
+            ));
+            assert!(events.borrow().is_empty());
+        }
+    }
+
+    #[test]
+    fn sender_reports_not_found_for_unregistered_vcpu_without_callbacks() {
+        let vm = TestVm::new(Machine::Running {
+            resources: (),
+            runtime: runtime(None),
+        });
+        let sender = StableInterruptTarget::new(&vm);
+        let events = RefCell::new(Vec::new());
+
+        assert!(matches!(
+            send(&sender, 0, interrupt(1), &events),
+            Err(AxVmError::ResourceUnavailable { .. })
+        ));
+        assert!(events.borrow().is_empty());
+    }
+
+    #[test]
+    fn sender_reports_not_found_after_vm_release() {
+        let vm = TestVm::new(Machine::Ready(()));
+        let sender = StableInterruptTarget::new(&vm);
+        let events = RefCell::new(Vec::new());
+        drop(vm);
+
+        assert!(matches!(
+            send(&sender, 0, interrupt(1), &events),
+            Err(AxVmError::ResourceUnavailable { .. })
+        ));
+        assert!(events.borrow().is_empty());
+    }
+
+    #[test]
+    fn sender_uses_replacement_runtime_after_restart() {
+        let old_runtime = runtime(Some(1));
+        let new_runtime = runtime(Some(2));
+        let vm = TestVm::new(Machine::Running {
+            resources: (),
+            runtime: old_runtime.clone(),
+        });
+        let sender = StableInterruptTarget::new(&vm);
+        let events = RefCell::new(Vec::new());
+
+        send(&sender, 0, interrupt(1), &events).unwrap();
+        {
+            let mut machine = vm.machine.lock();
+            machine
+                .request_stop_with(StopReason::Forced, |_, _| Ok(()))
+                .unwrap();
+            machine.finish_stop().unwrap();
+            drop(machine.take_stopped_runtime().unwrap());
+            machine.reset_with(|_| Ok(())).unwrap();
+            machine.start_with(|_| Ok(new_runtime.clone())).unwrap();
+        }
+        send(&sender, 0, interrupt(2), &events).unwrap();
+
+        assert_eq!(
+            old_runtime.irq_dispatcher().drain(0),
+            alloc::vec![interrupt(1)]
+        );
+        assert_eq!(
+            new_runtime.irq_dispatcher().drain(0),
+            alloc::vec![interrupt(2)]
+        );
+        assert_eq!(
+            *events.borrow(),
+            ["enqueue", "notify", "ipi", "enqueue", "notify", "ipi"]
+        );
     }
 }

--- a/virtualization/axvm/src/irq/sender.rs
+++ b/virtualization/axvm/src/irq/sender.rs
@@ -1,0 +1,83 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Stable send channel from architecture interrupt routers to the VM runtime.
+//!
+//! The sender holds only a [`Weak`] reference to the VM, so it never creates
+//! a strong reference cycle and automatically fails when the VM is destroyed.
+
+use alloc::{
+    format,
+    sync::{Arc, Weak},
+};
+
+use crate::{AxVM, AxVmResult, VmStatus, ax_err, ax_err_type, irq::model::PendingVcpuInterrupt};
+
+/// Router-to-runtime stable send channel.
+///
+/// Holds only a `Weak<AxVM>` — it never caches a runtime or dispatcher
+/// reference. Every [`send`](Self::send) call looks up the current runtime
+/// through the VM, so a VM stop/start/reset cycle cannot leave the sender
+/// pointing at a stale dispatcher.
+#[allow(dead_code, reason = "routers create senders in module 2+")]
+#[derive(Clone)]
+pub struct VmInterruptSender {
+    vm: Weak<AxVM>,
+}
+
+impl VmInterruptSender {
+    /// Constructs a sender from an `AxVMRef` (`Arc<AxVM>`).
+    #[allow(dead_code, reason = "routers create senders in module 2+")]
+    pub fn new(vm: &Arc<AxVM>) -> Self {
+        Self {
+            vm: Arc::downgrade(vm),
+        }
+    }
+
+    /// Delivers a pending interrupt to the target vCPU through the current
+    /// runtime dispatcher.
+    ///
+    /// # Flow
+    ///
+    /// 1. Upgrade `Weak<AxVM>` — returns `NotFound` if the VM has been
+    ///    destroyed.
+    /// 2. Check VM status — only `Running` and `Paused` accept interrupts;
+    ///    other states return `BadState`.
+    /// 3. `vm.with_runtime(|rt| rt.dispatch_vcpu_interrupt(vcpu_id,
+    ///    interrupt))` — runtime not yet created returns `BadState`;
+    ///    unregistered vCPU task returns `NotFound`.
+    ///
+    /// A TOCTOU window exists between steps 2 and 3 (status may change), but
+    /// this matches the existing `vcpus::queue_interrupt` behaviour and is an
+    /// acceptable window.
+    #[allow(dead_code, reason = "interrupt routers will call send")]
+    pub fn send(&self, vcpu_id: usize, interrupt: PendingVcpuInterrupt) -> AxVmResult {
+        let vm = self
+            .vm
+            .upgrade()
+            .ok_or_else(|| ax_err_type!(NotFound, "VM has been destroyed"))?;
+
+        match vm.status() {
+            VmStatus::Running | VmStatus::Paused => {}
+            status => {
+                return ax_err!(
+                    BadState,
+                    format!("VM[{}] cannot accept interrupts in {status:?}", vm.id())
+                );
+            }
+        }
+
+        vm.with_runtime(|rt| rt.dispatch_vcpu_interrupt(vcpu_id, interrupt))
+    }
+}

--- a/virtualization/axvm/src/lifecycle/machine.rs
+++ b/virtualization/axvm/src/lifecycle/machine.rs
@@ -95,6 +95,16 @@ impl<R, H> Machine<R, H> {
         }
     }
 
+    pub(crate) fn interrupt_runtime(&self) -> AxVmResult<&H> {
+        match self {
+            Machine::Running { runtime, .. } | Machine::Paused { runtime, .. } => Ok(runtime),
+            state => Err(AxVmError::invalid_state(
+                "send vCPU interrupt",
+                alloc::format!("VM cannot accept interrupts in {:?}", state.status()),
+            )),
+        }
+    }
+
     pub fn start_with<F>(&mut self, f: F) -> AxVmResult
     where
         F: FnOnce(&mut R) -> AxVmResult<H>,
@@ -691,5 +701,35 @@ mod tests {
         assert_eq!(machine.resources(), Some(&7));
         assert!(machine.runtime().is_none());
         assert_eq!(machine.take_stopped_runtime(), Some(8));
+    }
+
+    #[test]
+    fn interrupt_runtime_accepts_only_running_and_paused_states() {
+        let running = Machine::Running {
+            resources: (),
+            runtime: 7,
+        };
+        assert_eq!(running.interrupt_runtime(), Ok(&7));
+
+        let paused = Machine::Paused {
+            resources: (),
+            runtime: 8,
+        };
+        assert_eq!(paused.interrupt_runtime(), Ok(&8));
+
+        for machine in [
+            Machine::<(), usize>::Ready(()),
+            Machine::Stopped {
+                resources: Some(()),
+                runtime: None,
+                reason: StopReason::Forced,
+            },
+            Machine::Destroyed,
+        ] {
+            assert!(matches!(
+                machine.interrupt_runtime(),
+                Err(AxVmError::InvalidState { .. })
+            ));
+        }
     }
 }

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -114,7 +114,6 @@ impl VcpuIrqDispatcher {
     /// The caller (vCPU run loop) runs on the target pCPU and injects each
     /// returned interrupt through the architecture-specific vCPU injection
     /// path before entering the guest.
-    #[allow(dead_code, reason = "wired in PR 1c")]
     pub fn drain(&self, vcpu_id: usize) -> Vec<PendingVcpuInterrupt> {
         self.queue.drain(vcpu_id)
     }

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -40,6 +40,10 @@ use crate::{AxTaskRef, AxVmResult, ax_err_type, irq::model::PendingVcpuInterrupt
 pub struct VcpuIrqDispatcher {
     queue: VcpuInterruptQueue,
     vcpu_tasks: Mutex<BTreeMap<usize, AxTaskRef>>,
+    /// Test-only cpu_id registry so that round-trip tests can exercise
+    /// enqueue / drain without a full ArceOS task infrastructure.
+    #[cfg(all(test, feature = "host-test"))]
+    test_vcpu_cpu_ids: Mutex<BTreeMap<usize, usize>>,
 }
 
 impl VcpuIrqDispatcher {
@@ -51,6 +55,8 @@ impl VcpuIrqDispatcher {
         Self {
             queue: VcpuInterruptQueue::new(),
             vcpu_tasks: Mutex::new(BTreeMap::new()),
+            #[cfg(all(test, feature = "host-test"))]
+            test_vcpu_cpu_ids: Mutex::new(BTreeMap::new()),
         }
     }
 
@@ -83,17 +89,23 @@ impl VcpuIrqDispatcher {
     /// Called by `VmRuntimeHandle::dispatch_vcpu_interrupt` when an
     /// architecture interrupt router requests delivery to a vCPU.
     pub fn enqueue(&self, vcpu_id: usize, interrupt: PendingVcpuInterrupt) -> AxVmResult<usize> {
-        let cpu_id = {
-            let tasks = self.vcpu_tasks.lock();
-            tasks
-                .get(&vcpu_id)
-                .map(|t| t.cpu_id() as usize)
-                .ok_or_else(|| {
-                    ax_err_type!(NotFound, format_args!("vCPU {vcpu_id} task not found"))
-                })?
-        };
+        let cpu_id = self.lookup_cpu_id(vcpu_id)?;
         self.queue.push(vcpu_id, interrupt);
         Ok(cpu_id)
+    }
+
+    fn lookup_cpu_id(&self, vcpu_id: usize) -> AxVmResult<usize> {
+        #[cfg(all(test, feature = "host-test"))]
+        {
+            if let Some(&cpu_id) = self.test_vcpu_cpu_ids.lock().get(&vcpu_id) {
+                return Ok(cpu_id);
+            }
+        }
+        let tasks = self.vcpu_tasks.lock();
+        tasks
+            .get(&vcpu_id)
+            .map(|t| t.cpu_id() as usize)
+            .ok_or_else(|| ax_err_type!(NotFound, format_args!("vCPU {vcpu_id} task not found")))
     }
 
     /// Drains all pending interrupts for the given vCPU, leaving its queue
@@ -108,8 +120,23 @@ impl VcpuIrqDispatcher {
     }
 }
 
+/// Test-only helpers for exercising the dispatcher without a full ArceOS
+/// task infrastructure.
+#[cfg(all(test, feature = "host-test"))]
+impl VcpuIrqDispatcher {
+    /// Registers a vCPU with a known physical CPU id for unit testing.
+    ///
+    /// This bypasses the real `AxTaskRef` requirement so that round-trip
+    /// enqueue→drain tests can run on the host.
+    fn register_test_vcpu(&self, vcpu_id: usize, cpu_id: usize) {
+        self.test_vcpu_cpu_ids.lock().insert(vcpu_id, cpu_id);
+    }
+}
+
 #[cfg(all(test, feature = "host-test"))]
 mod tests {
+    use alloc::vec;
+
     use super::*;
     use crate::irq::model::VirtualInterruptId;
 
@@ -120,11 +147,17 @@ mod tests {
         }
     }
 
+    fn level(id: u32) -> PendingVcpuInterrupt {
+        PendingVcpuInterrupt {
+            id: VirtualInterruptId(id),
+            trigger: crate::InterruptTriggerMode::LevelTriggered,
+        }
+    }
+
     #[test]
     fn enqueue_unregistered_vcpu_returns_error() {
         let d = VcpuIrqDispatcher::new();
-        let result = d.enqueue(0, edge(1));
-        assert!(result.is_err());
+        assert!(d.enqueue(0, edge(1)).is_err());
     }
 
     #[test]
@@ -136,13 +169,88 @@ mod tests {
     }
 
     #[test]
-    fn registered_vcpu_isolates_error_for_other_vcpus() {
+    fn round_trip_enqueue_drain_preserves_fifo_order() {
         let d = VcpuIrqDispatcher::new();
-        // Even if one vCPU is registered, other unregistered vCPUs still fail.
-        // We can't register a real task without full ArceOS infrastructure,
-        // so we verify the isolation invariant holds in the error path:
-        // all vCPUs return NotFound when no tasks are registered at all.
-        assert!(d.enqueue(0, edge(1)).is_err());
-        assert!(d.enqueue(2, edge(42)).is_err());
+        d.register_test_vcpu(0, 2);
+
+        d.enqueue(0, edge(10)).unwrap();
+        d.enqueue(0, level(20)).unwrap();
+        d.enqueue(0, edge(30)).unwrap();
+
+        let drained = d.drain(0);
+        assert_eq!(drained.len(), 3);
+        assert_eq!(drained[0], edge(10));
+        assert_eq!(drained[1], level(20));
+        assert_eq!(drained[2], edge(30));
+    }
+
+    #[test]
+    fn round_trip_enqueue_drain_isolates_vcpus() {
+        let d = VcpuIrqDispatcher::new();
+        d.register_test_vcpu(0, 1);
+        d.register_test_vcpu(1, 2);
+
+        d.enqueue(0, edge(100)).unwrap();
+        d.enqueue(1, level(200)).unwrap();
+
+        assert_eq!(d.drain(0), vec![edge(100)]);
+        assert_eq!(d.drain(1), vec![level(200)]);
+    }
+
+    #[test]
+    fn round_trip_drain_empties_queue() {
+        let d = VcpuIrqDispatcher::new();
+        d.register_test_vcpu(0, 0);
+
+        d.enqueue(0, edge(7)).unwrap();
+        assert_eq!(d.drain(0).len(), 1);
+        assert!(d.drain(0).is_empty());
+    }
+
+    #[test]
+    fn round_trip_double_drain_returns_empty() {
+        let d = VcpuIrqDispatcher::new();
+        d.register_test_vcpu(0, 0);
+
+        d.enqueue(0, edge(7)).unwrap();
+        d.drain(0);
+        assert!(d.drain(0).is_empty());
+    }
+
+    #[test]
+    fn round_trip_trigger_mode_preserved() {
+        let d = VcpuIrqDispatcher::new();
+        d.register_test_vcpu(0, 3);
+
+        d.enqueue(0, edge(42)).unwrap();
+        d.enqueue(0, level(43)).unwrap();
+
+        let drained = d.drain(0);
+        assert_eq!(
+            drained[0].trigger,
+            crate::InterruptTriggerMode::EdgeTriggered
+        );
+        assert_eq!(
+            drained[1].trigger,
+            crate::InterruptTriggerMode::LevelTriggered
+        );
+    }
+
+    #[test]
+    fn enqueue_returns_registered_cpu_id() {
+        let d = VcpuIrqDispatcher::new();
+        d.register_test_vcpu(0, 5);
+
+        let cpu_id = d.enqueue(0, edge(1)).unwrap();
+        assert_eq!(cpu_id, 5);
+    }
+
+    #[test]
+    fn unregistered_vcpu_still_fails_when_others_registered() {
+        let d = VcpuIrqDispatcher::new();
+        d.register_test_vcpu(0, 0);
+
+        assert!(d.enqueue(0, edge(1)).is_ok());
+        assert!(d.enqueue(1, edge(2)).is_err());
     }
 }

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -127,7 +127,7 @@ impl VcpuIrqDispatcher {
     ///
     /// This bypasses the real `AxTaskRef` requirement so that round-trip
     /// enqueue→drain tests can run on the host.
-    fn register_test_vcpu(&self, vcpu_id: usize, cpu_id: usize) {
+    pub(crate) fn register_test_vcpu(&self, vcpu_id: usize, cpu_id: usize) {
         self.test_vcpu_cpu_ids.lock().insert(vcpu_id, cpu_id);
     }
 }
@@ -156,7 +156,10 @@ mod tests {
     #[test]
     fn enqueue_unregistered_vcpu_returns_error() {
         let d = VcpuIrqDispatcher::new();
-        assert!(d.enqueue(0, edge(1)).is_err());
+        assert!(matches!(
+            d.enqueue(0, edge(1)),
+            Err(crate::AxVmError::ResourceUnavailable { .. })
+        ));
     }
 
     #[test]

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -37,7 +37,6 @@ use crate::{AxTaskRef, AxVmResult, ax_err_type, irq::model::PendingVcpuInterrupt
 /// architecture interrupt router output.  The vCPU run loop drains pending
 /// interrupts before each vCPU entry and injects them through the
 /// architecture-specific injection path.
-#[allow(dead_code)]
 pub struct VcpuIrqDispatcher {
     queue: VcpuInterruptQueue,
     vcpu_tasks: Mutex<BTreeMap<usize, AxTaskRef>>,
@@ -48,7 +47,6 @@ impl VcpuIrqDispatcher {
     ///
     /// Called by `VmRuntimeHandle::new` when a VM transitions into the
     /// Running state.
-    #[allow(dead_code)]
     pub fn new() -> Self {
         Self {
             queue: VcpuInterruptQueue::new(),
@@ -61,7 +59,6 @@ impl VcpuIrqDispatcher {
     ///
     /// Called from `VmRuntimeHandle::add_vcpu_task` when a vCPU task is
     /// spawned and bound to the VM runtime.
-    #[allow(dead_code)]
     pub fn register_vcpu_task(&self, vcpu_id: usize, task: AxTaskRef) {
         self.vcpu_tasks.lock().insert(vcpu_id, task);
     }
@@ -85,7 +82,6 @@ impl VcpuIrqDispatcher {
     ///
     /// Called by `VmRuntimeHandle::dispatch_vcpu_interrupt` when an
     /// architecture interrupt router requests delivery to a vCPU.
-    #[allow(dead_code)]
     pub fn enqueue(&self, vcpu_id: usize, interrupt: PendingVcpuInterrupt) -> AxVmResult<usize> {
         let cpu_id = {
             let tasks = self.vcpu_tasks.lock();
@@ -106,7 +102,7 @@ impl VcpuIrqDispatcher {
     /// The caller (vCPU run loop) runs on the target pCPU and injects each
     /// returned interrupt through the architecture-specific vCPU injection
     /// path before entering the guest.
-    #[allow(dead_code)]
+    #[allow(dead_code, reason = "wired in PR 1c")]
     pub fn drain(&self, vcpu_id: usize) -> Vec<PendingVcpuInterrupt> {
         self.queue.drain(vcpu_id)
     }
@@ -117,16 +113,36 @@ mod tests {
     use super::*;
     use crate::irq::model::VirtualInterruptId;
 
+    fn edge(id: u32) -> PendingVcpuInterrupt {
+        PendingVcpuInterrupt {
+            id: VirtualInterruptId(id),
+            trigger: crate::InterruptTriggerMode::EdgeTriggered,
+        }
+    }
+
     #[test]
     fn enqueue_unregistered_vcpu_returns_error() {
         let d = VcpuIrqDispatcher::new();
-        let result = d.enqueue(
-            0,
-            PendingVcpuInterrupt {
-                id: VirtualInterruptId(1),
-                trigger: crate::InterruptTriggerMode::EdgeTriggered,
-            },
-        );
+        let result = d.enqueue(0, edge(1));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn enqueue_multiple_unregistered_vcpus_all_return_error() {
+        let d = VcpuIrqDispatcher::new();
+        for vcpu_id in [0, 1, 3, 7] {
+            assert!(d.enqueue(vcpu_id, edge(1)).is_err());
+        }
+    }
+
+    #[test]
+    fn registered_vcpu_isolates_error_for_other_vcpus() {
+        let d = VcpuIrqDispatcher::new();
+        // Even if one vCPU is registered, other unregistered vCPUs still fail.
+        // We can't register a real task without full ArceOS infrastructure,
+        // so we verify the isolation invariant holds in the error path:
+        // all vCPUs return NotFound when no tasks are registered at all.
+        assert!(d.enqueue(0, edge(1)).is_err());
+        assert!(d.enqueue(2, edge(42)).is_err());
     }
 }

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -21,8 +21,8 @@ use ax_kernel_guard::NoPreempt;
 use ax_kspin::SpinNoIrq as Mutex;
 use ax_percpu::{CpuAreaRef, CpuPin};
 use axvm_types::{
-    GuestPhysAddr, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps, VmArchVcpuOps,
-    VmBackendError, VmVcpuState,
+    GuestPhysAddr, InterruptTriggerMode, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps,
+    VmArchVcpuOps, VmBackendError, VmVcpuState,
 };
 
 use crate::{AxVmError, AxVmResult, ax_err};
@@ -303,6 +303,17 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     pub fn inject_interrupt(&self, vector: usize) -> AxVmResult {
         self.get_arch_vcpu()
             .inject_interrupt(vector)
+            .map_err(|error| map_interrupt_backend_error("inject vCPU interrupt", error))
+    }
+
+    /// Injects an interrupt while preserving its trigger-mode metadata.
+    pub fn inject_interrupt_with_trigger(
+        &self,
+        vector: usize,
+        trigger: InterruptTriggerMode,
+    ) -> AxVmResult {
+        self.get_arch_vcpu()
+            .inject_interrupt_with_trigger(vector, trigger)
             .map_err(|error| map_interrupt_backend_error("inject vCPU interrupt", error))
     }
 

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -37,9 +37,10 @@ use crate::{
     boot::{GuestBootDescription, GuestFdtBuilder},
     config::{AxVMConfig, PhysCpuList, VMInterruptMode},
     host::paging::virt_to_phys,
-    irq::InterruptFabric,
+    irq::{InterruptFabric, model::PendingVcpuInterrupt},
     layout::VmAddressLayout,
     lifecycle::{Machine, StopReason, VmStatus},
+    runtime::VcpuIrqDispatcher,
     vcpu::AxVCpu,
 };
 
@@ -141,6 +142,7 @@ pub(crate) struct VmRuntimeHandle {
     wait_queue: crate::WaitQueue,
     vcpu_task_list: Mutex<BTreeMap<usize, crate::AxTaskRef>>,
     pending_interrupts: Mutex<BTreeMap<usize, Vec<PendingInterrupt>>>,
+    irq_dispatcher: VcpuIrqDispatcher,
     running_halting_vcpu_count: AtomicUsize,
 }
 
@@ -150,11 +152,14 @@ impl VmRuntimeHandle {
             wait_queue: crate::WaitQueue::new(),
             vcpu_task_list: Mutex::new(BTreeMap::new()),
             pending_interrupts: Mutex::new(BTreeMap::new()),
+            irq_dispatcher: VcpuIrqDispatcher::new(),
             running_halting_vcpu_count: AtomicUsize::new(0),
         }
     }
 
     pub(crate) fn add_vcpu_task(&self, vcpu_id: usize, vcpu_task: crate::AxTaskRef) {
+        self.irq_dispatcher
+            .register_vcpu_task(vcpu_id, vcpu_task.clone());
         self.vcpu_task_list.lock().insert(vcpu_id, vcpu_task);
         self.pending_interrupts.lock().entry(vcpu_id).or_default();
     }
@@ -199,6 +204,37 @@ impl VmRuntimeHandle {
                 physical_irq,
             });
         Ok(task.cpu_id() as usize)
+    }
+
+    /// New delivery path: enqueue → notify → host IPI.
+    ///
+    /// Called under `machine.lock()` via `with_runtime`.  `send_ipi` is a fast
+    /// MMIO/MSR write — it never sleeps or acquires other locks — so calling it
+    /// inside the `SpinNoIrq` critical section is safe.  Merging enqueue +
+    /// notify + IPI into a single lock acquisition eliminates the enqueue→notify
+    /// race window present in the old two-`with_runtime` code.
+    #[allow(dead_code, reason = "wired in PR 1c / module 2+")]
+    pub(crate) fn dispatch_vcpu_interrupt(
+        &self,
+        vcpu_id: usize,
+        interrupt: PendingVcpuInterrupt,
+    ) -> AxVmResult {
+        let pcpu_id = self.irq_dispatcher.enqueue(vcpu_id, interrupt)?;
+        self.notify_all();
+        // SAFETY: send_ipi is a fast MMIO/MSR write; it does not sleep or
+        // acquire locks, so calling it inside the machine.lock SpinNoIrq
+        // critical section is safe.
+        crate::host::task::send_ipi(pcpu_id);
+        Ok(())
+    }
+
+    /// Returns a reference to the new interrupt dispatcher.
+    ///
+    /// Called by the vCPU run loop (PR 1c) to drain pending interrupts before
+    /// entering the guest.
+    #[allow(dead_code, reason = "wired in PR 1c")]
+    pub(crate) fn irq_dispatcher(&self) -> &VcpuIrqDispatcher {
+        &self.irq_dispatcher
     }
 
     pub(crate) fn drain_pending_interrupts(&self, vcpu_id: usize) -> Vec<PendingInterrupt> {

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -213,7 +213,7 @@ impl VmRuntimeHandle {
     /// inside the `SpinNoIrq` critical section is safe.  Merging enqueue +
     /// notify + IPI into a single lock acquisition eliminates the enqueue→notify
     /// race window present in the old two-`with_runtime` code.
-    #[allow(dead_code, reason = "wired in PR 1c / module 2+")]
+    #[allow(dead_code, reason = "wired in module 2+")]
     pub(crate) fn dispatch_vcpu_interrupt(
         &self,
         vcpu_id: usize,
@@ -228,11 +228,8 @@ impl VmRuntimeHandle {
         Ok(())
     }
 
-    /// Returns a reference to the new interrupt dispatcher.
-    ///
-    /// Called by the vCPU run loop (PR 1c) to drain pending interrupts before
+    /// Called by the vCPU run loop to drain pending interrupts before
     /// entering the guest.
-    #[allow(dead_code, reason = "wired in PR 1c")]
     pub(crate) fn irq_dispatcher(&self) -> &VcpuIrqDispatcher {
         &self.irq_dispatcher
     }

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -146,6 +146,17 @@ pub(crate) struct VmRuntimeHandle {
     running_halting_vcpu_count: AtomicUsize,
 }
 
+pub(crate) fn dispatch_vcpu_interrupt_with(
+    enqueue: impl FnOnce() -> AxVmResult<usize>,
+    notify: impl FnOnce(),
+    send_ipi: impl FnOnce(usize),
+) -> AxVmResult {
+    let pcpu_id = enqueue()?;
+    notify();
+    send_ipi(pcpu_id);
+    Ok(())
+}
+
 impl VmRuntimeHandle {
     pub(crate) fn new() -> Self {
         Self {
@@ -208,24 +219,25 @@ impl VmRuntimeHandle {
 
     /// New delivery path: enqueue → notify → host IPI.
     ///
-    /// Called under `machine.lock()` via `with_runtime`.  `send_ipi` is a fast
-    /// MMIO/MSR write — it never sleeps or acquires other locks — so calling it
-    /// inside the `SpinNoIrq` critical section is safe.  Merging enqueue +
-    /// notify + IPI into a single lock acquisition eliminates the enqueue→notify
-    /// race window present in the old two-`with_runtime` code.
-    #[allow(dead_code, reason = "wired in module 2+")]
+    /// The dispatcher releases its queue lock before this method notifies
+    /// waiters or invokes the host IPI boundary.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "architecture interrupt routers dispatch in later modules"
+        )
+    )]
     pub(crate) fn dispatch_vcpu_interrupt(
         &self,
         vcpu_id: usize,
         interrupt: PendingVcpuInterrupt,
     ) -> AxVmResult {
-        let pcpu_id = self.irq_dispatcher.enqueue(vcpu_id, interrupt)?;
-        self.notify_all();
-        // SAFETY: send_ipi is a fast MMIO/MSR write; it does not sleep or
-        // acquire locks, so calling it inside the machine.lock SpinNoIrq
-        // critical section is safe.
-        crate::host::task::send_ipi(pcpu_id);
-        Ok(())
+        dispatch_vcpu_interrupt_with(
+            || self.irq_dispatcher.enqueue(vcpu_id, interrupt),
+            || self.notify_all(),
+            crate::host::task::send_ipi,
+        )
     }
 
     /// Called by the vCPU run loop to drain pending interrupts before
@@ -509,6 +521,11 @@ impl AxVM {
             .runtime()
             .ok_or_else(|| ax_err_type!(BadState, "VM runtime is not available"))?;
         f(runtime)
+    }
+
+    pub(crate) fn current_interrupt_runtime(&self) -> AxVmResult<Arc<VmRuntimeHandle>> {
+        let machine = self.machine.lock();
+        Ok(machine.interrupt_runtime()?.clone())
     }
 
     fn take_stopped_runtime(&self) -> Option<Arc<VmRuntimeHandle>> {
@@ -1362,6 +1379,8 @@ impl Drop for AxVM {
 
 #[cfg(test)]
 mod tests {
+    use core::cell::RefCell;
+
     use super::*;
 
     #[test]
@@ -1395,5 +1414,66 @@ mod tests {
         write_guest_bytes_to_chunks(&mut chunks, &[]).unwrap();
 
         assert_eq!(chunk, [7, 7]);
+    }
+
+    #[test]
+    fn runtime_dispatch_orders_enqueue_before_notify_and_ipi() {
+        let events = RefCell::new(Vec::new());
+
+        dispatch_vcpu_interrupt_with(
+            || {
+                events.borrow_mut().push("enqueue");
+                Ok(3)
+            },
+            || events.borrow_mut().push("notify"),
+            |cpu_id| {
+                assert_eq!(cpu_id, 3);
+                events.borrow_mut().push("ipi");
+            },
+        )
+        .unwrap();
+
+        assert_eq!(*events.borrow(), ["enqueue", "notify", "ipi"]);
+    }
+
+    #[cfg(feature = "host-test")]
+    #[test]
+    fn runtime_dispatch_releases_queue_lock_before_callbacks() {
+        let dispatcher = VcpuIrqDispatcher::new();
+        dispatcher.register_test_vcpu(0, 3);
+        let interrupt = PendingVcpuInterrupt {
+            id: crate::irq::model::VirtualInterruptId(7),
+            trigger: crate::InterruptTriggerMode::LevelTriggered,
+        };
+        let events = RefCell::new(Vec::new());
+
+        dispatch_vcpu_interrupt_with(
+            || dispatcher.enqueue(0, interrupt),
+            || {
+                assert_eq!(dispatcher.drain(0), alloc::vec![interrupt]);
+                events.borrow_mut().push("notify");
+            },
+            |_| events.borrow_mut().push("ipi"),
+        )
+        .unwrap();
+
+        assert_eq!(*events.borrow(), ["notify", "ipi"]);
+    }
+
+    #[test]
+    fn runtime_dispatch_stops_when_enqueue_fails() {
+        let events = RefCell::new(Vec::new());
+
+        let result = dispatch_vcpu_interrupt_with(
+            || {
+                events.borrow_mut().push("enqueue");
+                Err(ax_err_type!(NotFound, "vCPU task not found"))
+            },
+            || events.borrow_mut().push("notify"),
+            |_| events.borrow_mut().push("ipi"),
+        );
+
+        assert!(matches!(result, Err(AxVmError::ResourceUnavailable { .. })));
+        assert_eq!(*events.borrow(), ["enqueue"]);
     }
 }

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -157,6 +157,13 @@ pub(crate) fn dispatch_vcpu_interrupt_with(
     Ok(())
 }
 
+fn pulse_interrupt_with_snapshot(
+    snapshot: impl FnOnce() -> AxVmResult<InterruptFabric>,
+    irq_id: usize,
+) -> AxVmResult {
+    snapshot()?.pulse(irq_id)
+}
+
 impl VmRuntimeHandle {
     pub(crate) fn new() -> Self {
         Self {
@@ -512,6 +519,26 @@ impl AxVM {
         f(resources)
     }
 
+    /// Snapshots the interrupt backend while validating the VM lifecycle state.
+    ///
+    /// The snapshot pins only the backend capability. A lifecycle change after
+    /// this method returns is observed by the sender when it resolves the
+    /// current runtime.
+    fn interrupt_fabric_snapshot(&self) -> AxVmResult<InterruptFabric> {
+        let machine = self.machine.lock();
+        match machine.status() {
+            VmStatus::Running | VmStatus::Paused => machine
+                .resources()
+                .ok_or_else(|| ax_err_type!(BadState, "VM resources are not available"))?
+                .interrupt_fabric()
+                .cloned(),
+            status => ax_err!(
+                BadState,
+                format!("VM[{}] cannot accept IRQ in {status:?}", self.id())
+            ),
+        }
+    }
+
     pub(crate) fn with_runtime<F, R>(&self, f: F) -> AxVmResult<R>
     where
         F: FnOnce(&Arc<VmRuntimeHandle>) -> AxVmResult<R>,
@@ -766,15 +793,7 @@ impl AxVM {
 
     /// Pulses a prepared VM interrupt fabric line without exposing the fabric.
     pub fn pulse_interrupt(&self, irq_id: usize) -> AxVmResult {
-        match self.status() {
-            VmStatus::Running | VmStatus::Paused => {
-                self.with_resources(|resources| resources.interrupt_fabric()?.pulse(irq_id))
-            }
-            status => ax_err!(
-                BadState,
-                format!("VM[{}] cannot accept IRQ in {status:?}", self.id())
-            ),
-        }
+        pulse_interrupt_with_snapshot(|| self.interrupt_fabric_snapshot(), irq_id)
     }
 
     /// Returns the number of prepared emulated devices.
@@ -1381,6 +1400,8 @@ impl Drop for AxVM {
 mod tests {
     use core::cell::RefCell;
 
+    use axdevice_base::{IrqError, IrqLineId, IrqResult, IrqSink};
+
     use super::*;
 
     #[test]
@@ -1475,5 +1496,88 @@ mod tests {
 
         assert!(matches!(result, Err(AxVmError::ResourceUnavailable { .. })));
         assert_eq!(*events.borrow(), ["enqueue"]);
+    }
+
+    #[test]
+    fn interrupt_pulse_runs_after_snapshot_lock_is_released() {
+        let machine_lock = Arc::new(Mutex::new(()));
+        let sink = Arc::new(TestIrqSink::with_machine_lock(machine_lock.clone()));
+        let fabric = InterruptFabric::with_sink(VMInterruptMode::Emulated, sink.clone()).unwrap();
+
+        pulse_interrupt_with_snapshot(
+            || {
+                let _machine = machine_lock.lock();
+                Ok(fabric.clone())
+            },
+            7,
+        )
+        .unwrap();
+
+        assert_eq!(sink.pulse_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn interrupt_snapshot_failure_does_not_call_sink() {
+        let sink = Arc::new(TestIrqSink::default());
+        let expected = ax_err_type!(BadState, "interrupt snapshot unavailable");
+
+        let result = pulse_interrupt_with_snapshot(|| Err(expected.clone()), 9);
+
+        assert_eq!(result, Err(expected));
+        assert_eq!(sink.pulse_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn interrupt_pulse_propagates_sink_error() {
+        let irq_error = IrqError::Backend {
+            line: IrqLineId(11),
+            operation: "test pulse",
+            detail: "controller rejected interrupt".into(),
+        };
+        let sink = Arc::new(TestIrqSink::with_pulse_error(irq_error.clone()));
+        let fabric = InterruptFabric::with_sink(VMInterruptMode::Emulated, sink).unwrap();
+
+        let result = pulse_interrupt_with_snapshot(|| Ok(fabric.clone()), 11);
+
+        assert_eq!(result, Err(AxVmError::from(irq_error)));
+    }
+
+    #[derive(Default)]
+    struct TestIrqSink {
+        machine_lock: Option<Arc<Mutex<()>>>,
+        pulse_error: Option<IrqError>,
+        pulse_count: AtomicUsize,
+    }
+
+    impl TestIrqSink {
+        fn with_machine_lock(machine_lock: Arc<Mutex<()>>) -> Self {
+            Self {
+                machine_lock: Some(machine_lock),
+                ..Self::default()
+            }
+        }
+
+        fn with_pulse_error(pulse_error: IrqError) -> Self {
+            Self {
+                pulse_error: Some(pulse_error),
+                ..Self::default()
+            }
+        }
+    }
+
+    impl IrqSink for TestIrqSink {
+        fn set_level(&self, _line: IrqLineId, _asserted: bool) -> IrqResult {
+            Ok(())
+        }
+
+        fn pulse(&self, _line: IrqLineId) -> IrqResult {
+            let _machine = self.machine_lock.as_ref().map(|machine_lock| {
+                machine_lock
+                    .try_lock()
+                    .expect("interrupt callback must run without the machine lock")
+            });
+            self.pulse_count.fetch_add(1, Ordering::Relaxed);
+            self.pulse_error.clone().map_or(Ok(()), Err)
+        }
     }
 }

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -1398,7 +1398,7 @@ impl Drop for AxVM {
 
 #[cfg(test)]
 mod tests {
-    use core::cell::RefCell;
+    use core::{cell::RefCell, sync::atomic::AtomicBool};
 
     use axdevice_base::{IrqError, IrqLineId, IrqResult, IrqSink};
 
@@ -1500,7 +1500,7 @@ mod tests {
 
     #[test]
     fn interrupt_pulse_runs_after_snapshot_lock_is_released() {
-        let machine_lock = Arc::new(Mutex::new(()));
+        let machine_lock = Arc::new(TestMachineLock::default());
         let sink = Arc::new(TestIrqSink::with_machine_lock(machine_lock.clone()));
         let fabric = InterruptFabric::with_sink(VMInterruptMode::Emulated, sink.clone()).unwrap();
 
@@ -1544,13 +1544,13 @@ mod tests {
 
     #[derive(Default)]
     struct TestIrqSink {
-        machine_lock: Option<Arc<Mutex<()>>>,
+        machine_lock: Option<Arc<TestMachineLock>>,
         pulse_error: Option<IrqError>,
         pulse_count: AtomicUsize,
     }
 
     impl TestIrqSink {
-        fn with_machine_lock(machine_lock: Arc<Mutex<()>>) -> Self {
+        fn with_machine_lock(machine_lock: Arc<TestMachineLock>) -> Self {
             Self {
                 machine_lock: Some(machine_lock),
                 ..Self::default()
@@ -1578,6 +1578,34 @@ mod tests {
             });
             self.pulse_count.fetch_add(1, Ordering::Relaxed);
             self.pulse_error.clone().map_or(Ok(()), Err)
+        }
+    }
+
+    #[derive(Default)]
+    struct TestMachineLock {
+        held: AtomicBool,
+    }
+
+    impl TestMachineLock {
+        fn lock(&self) -> TestMachineGuard<'_> {
+            self.try_lock().expect("test machine lock is already held")
+        }
+
+        fn try_lock(&self) -> Option<TestMachineGuard<'_>> {
+            self.held
+                .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+                .ok()
+                .map(|_| TestMachineGuard { lock: self })
+        }
+    }
+
+    struct TestMachineGuard<'a> {
+        lock: &'a TestMachineLock,
+    }
+
+    impl Drop for TestMachineGuard<'_> {
+        fn drop(&mut self) {
+            self.lock.held.store(false, Ordering::Release);
         }
     }
 }

--- a/virtualization/axvm/src/vm/prepare.rs
+++ b/virtualization/axvm/src/vm/prepare.rs
@@ -33,13 +33,13 @@ impl PreparedVm {
 
 impl AxVM {
     /// Sets up the VM before booting.
-    pub fn prepare(&self) -> AxVmResult {
+    pub fn prepare(self: &Arc<Self>) -> AxVmResult {
         crate::arch::CurrentArch::init_vm(self, VmInitRequest::Default)
     }
 
     /// Sets up the VM with explicit device factories and an interrupt fabric.
     pub fn prepare_with_factories(
-        &self,
+        self: &Arc<Self>,
         factories: &DeviceFactoryRegistry,
         interrupt_fabric: InterruptFabric,
     ) -> AxVmResult {

--- a/virtualization/axvm/tests/error_contract.rs
+++ b/virtualization/axvm/tests/error_contract.rs
@@ -64,7 +64,7 @@ fn public_failure_interfaces_name_axvm_result() {
 
     assert!(runtime.contains("pub fn start_vm(vm_id: usize) -> AxVmResult"));
     assert!(vm.contains("pub fn new(config: AxVMConfig) -> AxVmResult<AxVMRef>"));
-    assert!(prepare.contains("pub fn prepare(&self) -> AxVmResult"));
+    assert!(prepare.contains("pub fn prepare(self: &Arc<Self>) -> AxVmResult"));
     assert!(boot.contains("fn read_file(&self, file_name: &str) -> crate::AxVmResult"));
 }
 

--- a/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axdevice.rs
@@ -332,6 +332,77 @@ impl DeviceFactory for MockMmioFactory {
     }
 }
 
+struct PrecreatedController {
+    range: GuestPhysAddrRange,
+    read_count: Mutex<usize>,
+}
+
+impl PrecreatedController {
+    fn new(base_gpa: usize, length: usize) -> Self {
+        Self {
+            range: GuestPhysAddrRange::new(base_gpa.into(), (base_gpa + length).into()),
+            read_count: Mutex::new(0),
+        }
+    }
+
+    fn read_count(&self) -> usize {
+        *self.read_count.lock().unwrap()
+    }
+}
+
+impl BaseDeviceOps<GuestPhysAddrRange> for PrecreatedController {
+    fn address_range(&self) -> GuestPhysAddrRange {
+        self.range
+    }
+
+    fn emu_type(&self) -> EmulatedDeviceType {
+        EmulatedDeviceType::InterruptController
+    }
+
+    fn handle_read(&self, _addr: GuestPhysAddr, _width: AccessWidth) -> DeviceResult<usize> {
+        *self.read_count.lock().unwrap() += 1;
+        Ok(0xC011_EC70)
+    }
+
+    fn handle_write(&self, _addr: GuestPhysAddr, _width: AccessWidth, _val: usize) -> DeviceResult {
+        Ok(())
+    }
+}
+
+struct PrecreatedControllerFactory {
+    base_gpa: usize,
+    length: usize,
+    cfg_list: Vec<usize>,
+    controller: Arc<PrecreatedController>,
+}
+
+impl DeviceFactory for PrecreatedControllerFactory {
+    fn device_type(&self) -> EmulatedDeviceType {
+        EmulatedDeviceType::InterruptController
+    }
+
+    fn build(
+        &self,
+        config: &EmulatedDeviceConfig,
+        _context: &DeviceBuildContext<'_>,
+    ) -> DeviceManagerResult<DeviceBundle> {
+        if config.base_gpa != self.base_gpa
+            || config.length != self.length
+            || config.cfg_list != self.cfg_list
+        {
+            return Err(DeviceManagerError::InvalidConfig {
+                operation: "build pre-created interrupt controller",
+                detail: format!(
+                    "factory configuration does not match controller '{}'",
+                    config.name
+                ),
+            });
+        }
+
+        Ok(DeviceRegistration::Device(MmioDeviceAdapter::from_arc(self.controller.clone())).into())
+    }
+}
+
 #[test]
 fn test_mmio_dispatch_functionality() {
     let config = AxVmDeviceConfig::new(vec![]);
@@ -735,6 +806,83 @@ fn test_factory_build_registers_new_device_type_without_legacy_branch() {
             .unwrap(),
         0xDEAD_BEEF
     );
+}
+
+#[test]
+fn test_controller_factory_precedes_legacy_fallback_and_reuses_precreated_instance() {
+    let base_gpa = 0x3_0000;
+    let length = 0x1000;
+    let cfg_list = vec![4, 64];
+    let controller = Arc::new(PrecreatedController::new(base_gpa, length));
+    let mut factories = DeviceFactoryRegistry::new();
+    factories
+        .register(Arc::new(PrecreatedControllerFactory {
+            base_gpa,
+            length,
+            cfg_list: cfg_list.clone(),
+            controller: controller.clone(),
+        }))
+        .unwrap();
+    let resolver = RejectingIrqResolver;
+    let context = DeviceBuildContext::new(&resolver);
+    let mut controller_config = device_config(
+        "pre-created-controller",
+        EmulatedDeviceType::InterruptController,
+        base_gpa,
+        length,
+    );
+    controller_config.cfg_list = cfg_list;
+
+    let devices = AxVmDevices::build_with_factories(
+        AxVmDeviceConfig::new(vec![controller_config]),
+        &factories,
+        &context,
+    )
+    .unwrap();
+
+    assert_eq!(devices.devices().count(), 1);
+    assert_eq!(
+        devices
+            .handle_mmio_read(base_gpa.into(), AccessWidth::Dword)
+            .unwrap(),
+        0xC011_EC70
+    );
+    assert_eq!(controller.read_count(), 1);
+}
+
+#[test]
+fn test_controller_factory_config_mismatch_does_not_use_legacy_fallback() {
+    let base_gpa = 0x4_0000;
+    let length = 0x1000;
+    let controller = Arc::new(PrecreatedController::new(base_gpa, length));
+    let mut factories = DeviceFactoryRegistry::new();
+    factories
+        .register(Arc::new(PrecreatedControllerFactory {
+            base_gpa,
+            length,
+            cfg_list: vec![4, 64],
+            controller: controller.clone(),
+        }))
+        .unwrap();
+    let resolver = RejectingIrqResolver;
+    let context = DeviceBuildContext::new(&resolver);
+    let mut mismatched_config = device_config(
+        "mismatched-controller",
+        EmulatedDeviceType::InterruptController,
+        base_gpa,
+        length,
+    );
+    mismatched_config.cfg_list = vec![8, 64];
+
+    assert!(matches!(
+        AxVmDevices::build_with_factories(
+            AxVmDeviceConfig::new(vec![mismatched_config]),
+            &factories,
+            &context,
+        ),
+        Err(DeviceManagerError::InvalidConfig { .. })
+    ));
+    assert_eq!(controller.read_count(), 0);
 }
 
 #[test]


### PR DESCRIPTION
#  完整 sender→dispatcher→run loop 中断投递通道

## 要解决的问题

PR #1661 提供了 `VirtualInterruptId`、`PendingVcpuInterrupt`、`VcpuIrqDispatcher`、`VcpuInterruptQueue` 等基础类型和数据结构。本 PR 将这些组件集成到运行时中：

1. 创建 Router→runtime 的稳定发送通道 `VmInterruptSender`
2. 将 `VcpuIrqDispatcher` 嵌入 `VmRuntimeHandle`
3. 新增 `ArchOps::inject_vcpu_interrupt` 并在 vCPU run loop 中 drain 新队列

此时整条路径已贯通：`send()` → `dispatch_vcpu_interrupt` → `enqueue` → `drain` → `inject_vcpu_interrupt` → `vcpu.inject_interrupt_with_trigger()`。新旧队列并存，当前无 Router 使用 sender，新队列始终为空，不改变现有中断生产路径。

## 改动内容

### 1. 新增 `VmInterruptSender`（`virtualization/axvm/src/irq/sender.rs`）

Router 到 runtime 的稳定发送通道，只持有 `Weak<AxVM>`，不缓存 runtime 或 dispatcher 引用：

- `new(vm: &Arc<AxVM>)` — 通过 `Arc::downgrade` 构造
- `send(vcpu_id, interrupt)` — 三步流程：
  1. `Weak::upgrade` 失败返回 `NotFound`（VM 已销毁）
  2. 在同一次 `machine` 锁内检查 VM 状态并 clone 当前 runtime，仅 `Running/Paused` 接受中断，否则返回 `BadState`
  3. 在释放 `machine` 锁后调用 `runtime.dispatch_vcpu_interrupt(vcpu_id, interrupt)`

sender 不缓存 runtime 或 dispatcher。stop/reset/start 后，同一个 sender 下一次发送会重新选择替换后的 runtime。

### 2. 集成 dispatcher 到 `VmRuntimeHandle`（`virtualization/axvm/src/vm/mod.rs`）

- 新增字段 `irq_dispatcher: VcpuIrqDispatcher`
- `new()` 初始化该字段
- `add_vcpu_task()` 先注册到新 `irq_dispatcher`，再注册旧字段。防止 enqueue 在注册完成前到达时返回 `NotFound`
- 新增 `dispatch_vcpu_interrupt()` — 严格执行 enqueue → notify_all → send_ipi
- 提取内部编排步骤，确保 enqueue 失败时不 notify、不发送 IPI；dispatcher 队列锁在两个回调前已经释放
- 新增 `irq_dispatcher()` getter 供 vCPU run loop drain 使用

### 3. `ArchOps::inject_vcpu_interrupt` + vCPU run loop 消费（`virtualization/axvm/src/architecture/ops.rs`）

- 在 `AxVCpu` 增加 trigger-aware 注入包装并统一 backend 错误映射
- 在 `ArchOps` trait 中新增 `inject_vcpu_interrupt(vcpu, interrupt: PendingVcpuInterrupt) -> AxVmResult`，默认实现同时传递 interrupt ID 和 trigger
- `VmArchVcpuOps::inject_interrupt_with_trigger` 不再提供 release 模式下静默丢弃 level trigger 的默认回退
- x86 把 edge/level 映射到 VMX/SVM backend 的 `level_triggered` 参数，维护 vLAPIC TMR/EOI 语义
- AArch64、RISC-V、LoongArch adapter 显式说明 trigger 由对应 Router/controller 消费，最终 vCPU 注入操作本身不区分模式
- 参数不包含 `vm`：Router 在入队前已完成所有 VM 级决策，`inject_vcpu_interrupt` 只做单 vCPU 注入
- vCPU run loop 在旧 `inject_pending_interrupts` 之后调用可单测的 dispatcher drain→逐项注入步骤：
  - drain 失败时 warn 日志 + 降级为空列表，不中断 run loop
  - 单个 interrupt 注入失败时 warn 日志 + 继续处理后续
  - 新旧队列 drain 顺序：先旧后新

### 4. `AxVM::prepare()` 边界（`virtualization/axvm/src/vm/prepare.rs`）

- `prepare(&self)` → `prepare(self: &Arc<Self>)`
- `prepare_with_factories(&self, ...)` → `prepare_with_factories(self: &Arc<Self>, ...)`
- 方法体内代码不变（`&Arc<Self>` 自动 deref 为 `&AxVM`）
- 两个调用者 `start()` / `reset()` 已使用 `self: &Arc<Self>`，零适配成本
- 本模块不提前修改架构 `init_vm`；AArch64、LoongArch、x86 在各自 Router 模块构造 sender 时再获取 `AxVMRef`，RISC-V 仅在确有 sender/Router 消费者时调整

### 5. dead_code 注解

| 位置 | 项 | 状态 |
|------|-----|------|
| `model.rs` | `VirtualInterruptId`, `PendingVcpuInterrupt` | 已移除（被 dispatcher/sender/ArchOps 使用） |
| `dispatcher.rs` | struct, `new()`, `register_vcpu_task()`, `enqueue()` | 已移除（被 `VmRuntimeHandle` 使用） |
| `dispatcher.rs` | `drain()` | 已移除（被 run loop 调用） |
| `vm/mod.rs` | `irq_dispatcher()` | 已移除（被 run loop 调用） |
| `vm/mod.rs` | `dispatch_vcpu_interrupt()` | 带阶段原因的 `#[expect(dead_code)]`（模块 2+ Router 使用） |
| `sender.rs` | struct, `new()`, `send()` | 带阶段原因的 `#[expect(dead_code)]`（模块 2+ Router 使用） |

### 6. 测试

**dispatcher 错误路径**：
- `enqueue_unregistered_vcpu_returns_error`
- `enqueue_multiple_unregistered_vcpus_all_return_error`
- `unregistered_vcpu_still_fails_when_others_registered`

**enqueue→drain 往返**（通过 `register_test_vcpu` 辅助方法绕过 ArceOS task 依赖）：
- `round_trip_enqueue_drain_preserves_fifo_order`
- `round_trip_enqueue_drain_isolates_vcpus`
- `round_trip_drain_empties_queue`
- `round_trip_double_drain_returns_empty`
- `round_trip_trigger_mode_preserved`
- `enqueue_returns_registered_cpu_id`

**run loop 与 trigger**：
- fake `VmArchVcpuOps` 验证 level trigger 经 dispatcher/drain/`ArchOps` 后仍为 level
- FIFO 中每项只注入一次；注入失败不阻断后续项，也不会在下一轮重复消费
- x86 edge/level 分别映射到 backend 的 false/true

**sender/runtime 生命周期**：
- Running、Paused 且 vCPU 已注册时选择 runtime 并成功入队
- Ready、Stopped、Destroyed 和 runtime 不存在时返回 `BadState`
- 未注册 vCPU 返回 `NotFound`
- Weak 对应目标释放后返回 `NotFound`
- stop/reset/start 后稳定选择逻辑只向新 runtime 入队，旧 dispatcher 不再变化

**调度顺序**：
- 事件记录器验证 enqueue 完成后才 notify，notify 后才发送 IPI
- notify 回调可立即 drain dispatcher，证明队列锁已经释放
- enqueue 失败时不得 notify 或发送 IPI

### 7. 中断锁与 controller factory 契约

- AxVM::pulse_interrupt 在 machine lock 内校验状态并克隆 InterruptFabric，随后在锁外调用 Router/sender，避免回调重入 machine lock。
- 架构预创建 controller 后向 mutable DeviceFactoryRegistry 注册捕获同一 Arc 的 factory；factory 优先于 legacy fallback，并校验 controller 配置一致性。
- 锁外回调回归测试使用 AtomicBool 驱动的测试专用 RAII lock，保留 try_lock 断言且不触发宿主环境中的内核 IRQ guard。

## 关键设计决策

1. **入队顺序**：`add_vcpu_task` 先注册新 dispatcher 再注册旧字段
2. **回调顺序**：runtime 在 dispatcher 锁外执行 notify 和 host IPI，失败入队不会产生回调
3. **不缓存 runtime**：每次 `send()` 通过 `Weak::upgrade` 并在单次 machine 锁内选择当前 runtime，VM stop/start/reset 后不会沿用旧 dispatcher
4. **新旧队列并存**：`VcpuIrqDispatcher` 和旧 `pending_interrupts` 独立维护各自的 task 映射，互不干扰
5. **run loop drain 顺序**：先旧后新，旧队列语义在迁移期保持不变
6. **模块边界**：模块 1 以共享类型、sender、dispatcher、consumer 和双队列证据为退出条件，不要求 Router 或架构 `init_vm` 提前迁移

## 本地验证

- `cargo fmt --all --check`：通过
- `cargo test -p axvm --features host-test --lib`：131 个测试通过
- `cargo xtask clippy --package axvm-types`：通过
- `cargo xtask clippy --package axvm`：6 组 feature 检查全部通过
- Axvisor x86_64 VMX、x86_64 SVM、AArch64、RISC-V 显式 test-suite build config：通过
- LoongArch build：本机仅有 Clang 15 且未安装 `loongarch64-linux-musl-cc`，在 `ax-posix-api` bindgen 阶段因 Clang 不识别 LoongArch target triple 而停止，尚未编译到 `axvm`
- x86 QEMU smoke：本机无 `/dev/kvm`，且当前宿主为 AMD，无法执行要求 KVM 的 VMX/SVM smoke；保留给对应 Intel/AMD self-hosted CI
- cargo test -p axvm（CI std 配置）：109 个单元测试、18 个架构边界测试、4 个错误契约测试通过
- PR CI：修复提交 fa02dd46c 已触发新一轮检查
