### PR TITLE
fix(scope-local): eagerly initialize scope items

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7063,6 +7063,7 @@ dependencies = [
 name = "scope-local"
 version = "0.4.3"
 dependencies = [
+ "ax-crate-interface",
  "ax-kernel-guard",
  "ax-percpu",
  "cpu-local",

--- a/components/scope-local/Cargo.toml
+++ b/components/scope-local/Cargo.toml
@@ -14,6 +14,8 @@ ax-percpu.workspace = true
 spin = { workspace = true }
 
 [dev-dependencies]
+ax-crate-interface.workspace = true
+ax-kernel-guard = { workspace = true, features = ["preempt"] }
 ctor = "0.6"
 cpu-local = { workspace = true, features = ["host-test"] }
 ax-percpu = { workspace = true, features = ["host-test"] }

--- a/components/scope-local/README.md
+++ b/components/scope-local/README.md
@@ -49,6 +49,14 @@ cargo doc --no-deps
 
 ## Integration
 
+### Initialization contract
+
+`Scope::new` eagerly initializes every registered scope-local item in the
+caller's ordinary context. Pinned access only reads an already initialized
+scope and never allocates or invokes an item initializer. The first unpinned
+access to the global scope initializes it before entering the pinned section;
+recursive access from an initializer fails immediately with a diagnostic.
+
 ### Example
 
 ```rust

--- a/components/scope-local/README.md
+++ b/components/scope-local/README.md
@@ -55,7 +55,8 @@ cargo doc --no-deps
 caller's ordinary context. Pinned access only reads an already initialized
 scope and never allocates or invokes an item initializer. The first unpinned
 access to the global scope initializes it before entering the pinned section;
-recursive access from an initializer fails immediately with a diagnostic.
+recursive access from the initializing execution context fails immediately
+with a diagnostic, while competing contexts wait for the published scope.
 
 ### Example
 

--- a/components/scope-local/src/boxed.rs
+++ b/components/scope-local/src/boxed.rs
@@ -1,5 +1,5 @@
 use alloc::alloc::{alloc, dealloc, handle_alloc_error};
-use core::{alloc::Layout, ptr::NonNull};
+use core::{alloc::Layout, mem, ptr::NonNull};
 
 use crate::item::Item;
 
@@ -27,12 +27,6 @@ impl Header {
     }
 }
 
-impl Drop for Header {
-    fn drop(&mut self) {
-        (self.item.drop)(self.body());
-    }
-}
-
 pub(crate) struct ItemBox {
     ptr: NonNull<Header>,
 }
@@ -45,21 +39,52 @@ unsafe impl Sync for ItemBox {}
 impl ItemBox {
     pub(crate) fn new(item: &'static Item) -> Self {
         let (layout, offset) = layout(item.layout);
-        let ptr = NonNull::new(unsafe { alloc(layout) })
-            .unwrap_or_else(|| handle_alloc_error(layout))
-            .cast();
+        let allocation = Allocation::new(layout);
+        let ptr = allocation.ptr.cast::<Header>();
 
         unsafe {
+            // The allocation uses the combined header/body layout. The item
+            // descriptor guarantees that `init` writes exactly one payload
+            // with the body's layout before the allocation is committed.
             ptr.write(Header { item });
             (item.init)(ptr.cast().byte_add(offset));
         }
 
-        Self { ptr }
+        Self {
+            ptr: allocation.commit().cast(),
+        }
     }
 
     #[inline]
     fn header(&self) -> &Header {
         unsafe { self.ptr.as_ref() }
+    }
+}
+
+struct Allocation {
+    ptr: NonNull<u8>,
+    layout: Layout,
+}
+
+impl Allocation {
+    fn new(layout: Layout) -> Self {
+        let ptr =
+            NonNull::new(unsafe { alloc(layout) }).unwrap_or_else(|| handle_alloc_error(layout));
+        Self { ptr, layout }
+    }
+
+    fn commit(self) -> NonNull<u8> {
+        let ptr = self.ptr;
+        mem::forget(self);
+        ptr
+    }
+}
+
+impl Drop for Allocation {
+    fn drop(&mut self) {
+        // SAFETY: an uncommitted allocation still owns the exact pointer and
+        // layout returned by `alloc`.
+        unsafe { dealloc(self.ptr.as_ptr(), self.layout) };
     }
 }
 

--- a/components/scope-local/src/item.rs
+++ b/components/scope-local/src/item.rs
@@ -82,6 +82,7 @@ impl<T: Send + Sync + 'static> LocalItem<T> {
     /// The higher-ranked closure prevents a reference into per-CPU-selected
     /// storage from escaping after preemption is re-enabled. The first global
     /// access initializes the global scope before entering the pinned access.
+    /// Concurrent first access waits for that initialization to be published.
     pub fn with<R>(&self, operation: impl for<'access> FnOnce(&'access T) -> R) -> R {
         let mut operation = Some(operation);
         loop {

--- a/components/scope-local/src/item.rs
+++ b/components/scope-local/src/item.rs
@@ -80,15 +80,39 @@ impl<T: Send + Sync + 'static> LocalItem<T> {
     /// Runs `operation` with the value selected by the active scope.
     ///
     /// The higher-ranked closure prevents a reference into per-CPU-selected
-    /// storage from escaping after preemption is re-enabled.
+    /// storage from escaping after preemption is re-enabled. The first global
+    /// access initializes the global scope before entering the pinned access.
     pub fn with<R>(&self, operation: impl for<'access> FnOnce(&'access T) -> R) -> R {
-        let _guard = NoPreempt::new();
-        // SAFETY: `NoPreempt` prevents migration for this complete operation.
-        unsafe { ax_percpu::with_cpu_pin(|pin| self.with_pinned(pin, operation)) }
-            .expect("scope-local access requires an installed CPU area")
+        let mut operation = Some(operation);
+        loop {
+            let guard = NoPreempt::new();
+            // SAFETY: `NoPreempt` prevents migration for this complete access.
+            let result = unsafe {
+                ax_percpu::with_cpu_pin(|pin| {
+                    ActiveScope::try_with_item(self.item, pin, |item| {
+                        let operation = operation
+                            .take()
+                            .expect("scope-local operation must run at most once");
+                        operation(item.as_ref())
+                    })
+                })
+            }
+            .expect("scope-local access requires an installed CPU area");
+            drop(guard);
+
+            if let Some(result) = result {
+                return result;
+            }
+            ActiveScope::initialize_global();
+        }
     }
 
-    /// Runs `operation` under an existing CPU pin.
+    /// Runs `operation` under an existing CPU pin without initialization.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the selected global scope has not been initialized by
+    /// [`LocalItem::with`]. Explicit [`Scope`] values are initialized eagerly.
     pub fn with_pinned<R>(
         &self,
         pin: &CpuPin<'_>,
@@ -99,7 +123,7 @@ impl<T: Send + Sync + 'static> LocalItem<T> {
 
     /// Runs `operation` without lazy initialization under an existing pin.
     ///
-    /// This returns `None` when the active scope or item has not yet been
+    /// This returns `None` when the selected global scope has not yet been
     /// initialized, allowing hard-IRQ callers to avoid allocation.
     pub fn try_with_pinned<R>(
         &self,

--- a/components/scope-local/src/lib.rs
+++ b/components/scope-local/src/lib.rs
@@ -11,3 +11,15 @@ mod scope;
 
 pub use item::{Item, LocalItem, ScopeItem, ScopeItemMut};
 pub use scope::{ActiveScope, Scope};
+
+#[cfg(test)]
+mod tests {
+    struct KernelGuardIfImpl;
+
+    #[ax_crate_interface::impl_interface]
+    impl ax_kernel_guard::KernelGuardIf for KernelGuardIfImpl {
+        fn enable_preempt() {}
+
+        fn disable_preempt() {}
+    }
+}

--- a/components/scope-local/src/scope.rs
+++ b/components/scope-local/src/scope.rs
@@ -1,7 +1,7 @@
 use alloc::{boxed::Box, vec::Vec};
 use core::{
     ptr::NonNull,
-    sync::atomic::{AtomicU8, Ordering},
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use ax_kernel_guard::NoPreempt;
@@ -54,28 +54,31 @@ impl Default for Scope {
 }
 
 static GLOBAL_SCOPE: Once<Scope> = Once::new();
-static GLOBAL_SCOPE_STATE: AtomicU8 = AtomicU8::new(GlobalScopeState::Uninitialized as u8);
+static GLOBAL_SCOPE_STATE: AtomicUsize = AtomicUsize::new(GlobalScopeState::Uninitialized as usize);
 
 #[derive(Clone, Copy, Eq, PartialEq)]
-#[repr(u8)]
+#[repr(usize)]
 enum GlobalScopeState {
     Uninitialized,
-    Initializing,
     Ready,
 }
 
 struct GlobalInitialization {
+    owner_context: usize,
     published: bool,
 }
 
 impl GlobalInitialization {
-    fn begin() -> Self {
-        Self { published: false }
+    fn begin(owner_context: usize) -> Self {
+        Self {
+            owner_context,
+            published: false,
+        }
     }
 
     fn publish(mut self, scope: Scope) {
         GLOBAL_SCOPE.call_once(|| scope);
-        GLOBAL_SCOPE_STATE.store(GlobalScopeState::Ready as u8, Ordering::Release);
+        GLOBAL_SCOPE_STATE.store(GlobalScopeState::Ready as usize, Ordering::Release);
         self.published = true;
     }
 }
@@ -83,7 +86,12 @@ impl GlobalInitialization {
 impl Drop for GlobalInitialization {
     fn drop(&mut self) {
         if !self.published {
-            GLOBAL_SCOPE_STATE.store(GlobalScopeState::Uninitialized as u8, Ordering::Release);
+            let _ = GLOBAL_SCOPE_STATE.compare_exchange(
+                self.owner_context,
+                GlobalScopeState::Uninitialized as usize,
+                Ordering::Release,
+                Ordering::Relaxed,
+            );
         }
     }
 }
@@ -178,29 +186,47 @@ impl ActiveScope {
     }
 
     pub(crate) fn initialize_global() {
+        let owner_context = current_context_identity();
         loop {
             match GLOBAL_SCOPE_STATE.load(Ordering::Acquire) {
-                state if state == GlobalScopeState::Ready as u8 => return,
-                state if state == GlobalScopeState::Initializing as u8 => {
+                state if state == GlobalScopeState::Ready as usize => return,
+                state if state == owner_context => {
                     panic!("scope-local global scope initialization is already in progress")
                 }
-                state if state == GlobalScopeState::Uninitialized as u8 => {
+                state if state == GlobalScopeState::Uninitialized as usize => {
                     if GLOBAL_SCOPE_STATE
                         .compare_exchange(
-                            GlobalScopeState::Uninitialized as u8,
-                            GlobalScopeState::Initializing as u8,
+                            GlobalScopeState::Uninitialized as usize,
+                            owner_context,
                             Ordering::AcqRel,
                             Ordering::Acquire,
                         )
                         .is_ok()
                     {
-                        let initialization = GlobalInitialization::begin();
+                        let initialization = GlobalInitialization::begin(owner_context);
                         initialization.publish(Scope::new());
                         return;
                     }
                 }
-                _ => panic!("scope-local global scope has an invalid initialization state"),
+                _ => core::hint::spin_loop(),
             }
         }
     }
+}
+
+fn current_context_identity() -> usize {
+    let _guard = NoPreempt::new();
+    // SAFETY: the guard keeps the current thread header stable while its opaque
+    // identity is acquired. The header itself is pinned for the task lifetime,
+    // so this identity remains valid if the task later migrates during an
+    // initializer.
+    let context = unsafe {
+        ax_percpu::with_cpu_pin(|pin| pin.area().runtime_anchor().current_thread_raw())
+            .expect("scope-local access requires an installed CPU area")
+    };
+    assert!(
+        context > GlobalScopeState::Ready as usize,
+        "scope-local initialization requires a valid current context"
+    );
+    context
 }

--- a/components/scope-local/src/scope.rs
+++ b/components/scope-local/src/scope.rs
@@ -1,5 +1,8 @@
-use alloc::alloc::{alloc, dealloc, handle_alloc_error};
-use core::{alloc::Layout, iter::zip, mem::MaybeUninit, ptr::NonNull};
+use alloc::{boxed::Box, vec::Vec};
+use core::{
+    ptr::NonNull,
+    sync::atomic::{AtomicU8, Ordering},
+};
 
 use ax_kernel_guard::NoPreempt;
 use ax_percpu::CpuPin;
@@ -12,47 +15,35 @@ use crate::{
 
 /// A scope is a collection of items.
 pub struct Scope {
-    ptr: NonNull<ItemSlot>,
+    items: Box<[ItemBox]>,
 }
 
-unsafe impl Send for Scope {}
-unsafe impl Sync for Scope {}
-
 impl Scope {
-    fn len() -> usize {
-        Registry.len()
-    }
-
-    fn layout() -> Layout {
-        Layout::array::<ItemSlot>(Self::len()).unwrap()
-    }
-
-    /// Create a new namespace with all resources initialized as their default
-    /// value.
+    /// Creates a new namespace and eagerly initializes every registered item.
+    ///
+    /// Initializers run in the caller's ordinary context. Once this function
+    /// returns, pinned access to the scope performs no allocation or lazy
+    /// initialization.
     pub fn new() -> Self {
-        let layout = Self::layout();
-        let ptr = NonNull::new(unsafe { alloc(layout) })
-            .unwrap_or_else(|| handle_alloc_error(layout))
-            .cast();
-
-        let slice = unsafe {
-            core::slice::from_raw_parts_mut(ptr.cast::<MaybeUninit<_>>().as_ptr(), Registry.len())
-        };
-        for (item, d) in zip(&*Registry, slice) {
-            d.write(ItemSlot::new(item));
-        }
-
-        Self { ptr }
+        let items = Registry
+            .iter()
+            .map(ItemBox::new)
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self { items }
     }
 
     pub(crate) fn get(&self, item: &'static Item) -> &ItemBox {
-        let index = item.index();
-        unsafe { self.ptr.add(index).as_ref() }.get()
+        &self.items[item.index()]
     }
 
     pub(crate) fn get_mut(&mut self, item: &'static Item) -> &mut ItemBox {
-        let index = item.index();
-        unsafe { self.ptr.add(index).as_mut() }.get_mut()
+        &mut self.items[item.index()]
+    }
+
+    fn items_ptr(&self) -> NonNull<ItemBox> {
+        NonNull::new(self.items.as_ptr().cast_mut())
+            .expect("scope-local registry must contain the accessed item")
     }
 }
 
@@ -62,49 +53,40 @@ impl Default for Scope {
     }
 }
 
-impl Drop for Scope {
-    fn drop(&mut self) {
-        let ptr = NonNull::slice_from_raw_parts(self.ptr, Self::len());
-        unsafe {
-            ptr.drop_in_place();
-            dealloc(self.ptr.cast().as_ptr(), Self::layout());
-        }
-    }
-}
-
-struct ItemSlot {
-    item: &'static Item,
-    value: Once<ItemBox>,
-}
-
-impl ItemSlot {
-    fn new(item: &'static Item) -> Self {
-        Self {
-            item,
-            value: Once::new(),
-        }
-    }
-
-    fn get(&self) -> &ItemBox {
-        self.value.call_once(|| ItemBox::new(self.item))
-    }
-
-    fn get_mut(&mut self) -> &mut ItemBox {
-        if !self.value.is_completed() {
-            let item = self.item;
-            self.value.call_once(|| ItemBox::new(item));
-        }
-        self.value
-            .get_mut()
-            .expect("scope-local item must be initialized")
-    }
-
-    fn try_get(&self) -> Option<&ItemBox> {
-        self.value.get()
-    }
-}
-
 static GLOBAL_SCOPE: Once<Scope> = Once::new();
+static GLOBAL_SCOPE_STATE: AtomicU8 = AtomicU8::new(GlobalScopeState::Uninitialized as u8);
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+#[repr(u8)]
+enum GlobalScopeState {
+    Uninitialized,
+    Initializing,
+    Ready,
+}
+
+struct GlobalInitialization {
+    published: bool,
+}
+
+impl GlobalInitialization {
+    fn begin() -> Self {
+        Self { published: false }
+    }
+
+    fn publish(mut self, scope: Scope) {
+        GLOBAL_SCOPE.call_once(|| scope);
+        GLOBAL_SCOPE_STATE.store(GlobalScopeState::Ready as u8, Ordering::Release);
+        self.published = true;
+    }
+}
+
+impl Drop for GlobalInitialization {
+    fn drop(&mut self) {
+        if !self.published {
+            GLOBAL_SCOPE_STATE.store(GlobalScopeState::Uninitialized as u8, Ordering::Release);
+        }
+    }
+}
 
 #[ax_percpu::def_percpu]
 pub(crate) static ACTIVE_SCOPE_PTR: usize = 0;
@@ -136,7 +118,7 @@ impl ActiveScope {
     ///
     /// `scope` must remain alive until a later pinned replacement or reset.
     pub unsafe fn set_pinned(scope: &Scope, pin: &CpuPin<'_>) {
-        ACTIVE_SCOPE_PTR.write_current(pin, scope.ptr.addr().get());
+        ACTIVE_SCOPE_PTR.write_current(pin, scope.items_ptr().addr().get());
     }
 
     /// Set the active scope to the global scope.
@@ -175,11 +157,9 @@ impl ActiveScope {
         pin: &CpuPin<'_>,
         operation: impl for<'access> FnOnce(&'access ItemBox) -> R,
     ) -> R {
-        let ptr = ACTIVE_SCOPE_PTR.read_current(pin);
-        let ptr = NonNull::new(ptr as *mut ItemSlot)
-            .unwrap_or_else(|| GLOBAL_SCOPE.call_once(Scope::new).ptr);
-        let index = item.index();
-        operation(unsafe { ptr.add(index).as_ref() }.get())
+        Self::try_with_item(item, pin, operation).expect(
+            "scope-local global scope is not initialized; use LocalItem::with before pinned access",
+        )
     }
 
     pub(crate) fn try_with_item<R>(
@@ -188,12 +168,39 @@ impl ActiveScope {
         operation: impl for<'access> FnOnce(&'access ItemBox) -> R,
     ) -> Option<R> {
         let ptr = ACTIVE_SCOPE_PTR.read_current(pin);
-        let ptr = if ptr == 0 {
-            GLOBAL_SCOPE.get()?.ptr
+        let items = if ptr == 0 {
+            GLOBAL_SCOPE.get()?.items_ptr()
         } else {
-            NonNull::new(ptr as *mut ItemSlot)?
+            NonNull::new(ptr as *mut ItemBox)?
         };
         let index = item.index();
-        Some(operation(unsafe { ptr.add(index).as_ref() }.try_get()?))
+        Some(operation(unsafe { items.add(index).as_ref() }))
+    }
+
+    pub(crate) fn initialize_global() {
+        loop {
+            match GLOBAL_SCOPE_STATE.load(Ordering::Acquire) {
+                state if state == GlobalScopeState::Ready as u8 => return,
+                state if state == GlobalScopeState::Initializing as u8 => {
+                    panic!("scope-local global scope initialization is already in progress")
+                }
+                state if state == GlobalScopeState::Uninitialized as u8 => {
+                    if GLOBAL_SCOPE_STATE
+                        .compare_exchange(
+                            GlobalScopeState::Uninitialized as u8,
+                            GlobalScopeState::Initializing as u8,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        let initialization = GlobalInitialization::begin();
+                        initialization.publish(Scope::new());
+                        return;
+                    }
+                }
+                _ => panic!("scope-local global scope has an invalid initialization state"),
+            }
+        }
     }
 }

--- a/components/scope-local/tests/concurrent_initialization.rs
+++ b/components/scope-local/tests/concurrent_initialization.rs
@@ -1,0 +1,89 @@
+use core::num::NonZeroU32;
+use std::{
+    panic,
+    sync::{
+        Barrier, OnceLock,
+        mpsc::{self, RecvTimeoutError},
+    },
+    thread,
+    time::Duration,
+};
+
+use scope_local::scope_local;
+
+struct KernelGuardIfImpl;
+
+#[ax_crate_interface::impl_interface]
+impl ax_kernel_guard::KernelGuardIf for KernelGuardIfImpl {
+    fn enable_preempt() {}
+
+    fn disable_preempt() {}
+}
+
+static INITIALIZER_ENTERED: OnceLock<Barrier> = OnceLock::new();
+static RELEASE_INITIALIZER: OnceLock<Barrier> = OnceLock::new();
+static WAITER_READY: OnceLock<Barrier> = OnceLock::new();
+
+scope_local! {
+    static BLOCKING_VALUE: usize = {
+        INITIALIZER_ENTERED.get().unwrap().wait();
+        RELEASE_INITIALIZER.get().unwrap().wait();
+        41
+    };
+    static OBSERVED_VALUE: usize = 42;
+}
+
+fn bind_test_cpu(cpu_id: usize) {
+    let cpu_index = ax_percpu::CpuIndex::try_from(cpu_id).unwrap();
+    let area = ax_percpu::area(cpu_index).unwrap();
+    // SAFETY: each host thread models one initialized CPU for its lifetime.
+    unsafe { cpu_local::install_cpu_area(area.cpu_area().unwrap()) }.unwrap();
+}
+
+#[test]
+fn concurrent_global_access_waits_for_the_initializing_cpu() {
+    ax_percpu::host_test::initialize(NonZeroU32::new(2).unwrap()).unwrap();
+    assert!(INITIALIZER_ENTERED.set(Barrier::new(2)).is_ok());
+    assert!(RELEASE_INITIALIZER.set(Barrier::new(2)).is_ok());
+    assert!(WAITER_READY.set(Barrier::new(2)).is_ok());
+
+    let initializer = thread::spawn(|| {
+        bind_test_cpu(0);
+        assert_eq!(BLOCKING_VALUE.with(|value| *value), 41);
+    });
+    INITIALIZER_ENTERED.get().unwrap().wait();
+
+    let (result_sender, result_receiver) = mpsc::channel();
+    let waiter = thread::spawn(move || {
+        bind_test_cpu(1);
+        WAITER_READY.get().unwrap().wait();
+        let result = panic::catch_unwind(|| OBSERVED_VALUE.with(|value| *value));
+        result_sender.send(result).unwrap();
+    });
+    WAITER_READY.get().unwrap().wait();
+
+    let early_result = result_receiver.recv_timeout(Duration::from_millis(200));
+    RELEASE_INITIALIZER.get().unwrap().wait();
+
+    let (completed_before_publication, result) = match early_result {
+        Ok(result) => (true, result),
+        Err(RecvTimeoutError::Timeout) => (
+            false,
+            result_receiver
+                .recv_timeout(Duration::from_secs(2))
+                .expect("waiting CPU must finish after global scope publication"),
+        ),
+        Err(RecvTimeoutError::Disconnected) => panic!("waiting CPU exited without a result"),
+    };
+
+    initializer.join().unwrap();
+    waiter.join().unwrap();
+    assert!(
+        !completed_before_publication,
+        "a competing CPU must wait for the global scope to be published"
+    );
+    assert_eq!(
+        result.expect("a competing CPU must not observe recursive initialization"),
+        42
+    );
+}

--- a/components/scope-local/tests/eager_initialization.rs
+++ b/components/scope-local/tests/eager_initialization.rs
@@ -1,0 +1,105 @@
+use core::num::NonZeroU32;
+use std::sync::{
+    Mutex, MutexGuard,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use ctor::ctor;
+use scope_local::{ActiveScope, Scope, scope_local};
+
+static TEST_LOCK: Mutex<()> = Mutex::new(());
+static PREEMPT_DEPTH: AtomicUsize = AtomicUsize::new(0);
+static EAGER_INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+static PINNED_INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct KernelGuardIfImpl;
+
+#[ax_crate_interface::impl_interface]
+impl ax_kernel_guard::KernelGuardIf for KernelGuardIfImpl {
+    fn enable_preempt() {
+        PREEMPT_DEPTH.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    fn disable_preempt() {
+        PREEMPT_DEPTH.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+scope_local! {
+    static INIT_PREEMPT_DEPTH: usize = PREEMPT_DEPTH.load(Ordering::Acquire);
+    static EAGER_VALUE: usize = {
+        EAGER_INIT_COUNT.fetch_add(1, Ordering::AcqRel);
+        7
+    };
+    static PINNED_VALUE: usize = {
+        PINNED_INIT_COUNT.fetch_add(1, Ordering::AcqRel);
+        11
+    };
+}
+
+#[ctor]
+fn init_percpu() {
+    let area_count = NonZeroU32::new(1).unwrap();
+    ax_percpu::host_test::initialize(area_count).unwrap();
+    let area = ax_percpu::area(ax_percpu::CpuIndex::try_from(0).unwrap()).unwrap();
+    // SAFETY: this test binary models one CPU and never replaces its area.
+    unsafe { cpu_local::install_cpu_area(area.cpu_area().unwrap()) }.unwrap();
+}
+
+fn test_guard() -> MutexGuard<'static, ()> {
+    let guard = TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let area = ax_percpu::area(ax_percpu::CpuIndex::try_from(0).unwrap()).unwrap();
+    match unsafe { cpu_local::with_cpu_pin(|pin| pin.area()) } {
+        Ok(installed) => assert_eq!(installed, area.cpu_area().unwrap()),
+        Err(cpu_local::CpuLocalError::AreaNotInstalled) => {
+            // SAFETY: every serialized test thread binds the same modeled CPU.
+            unsafe { cpu_local::install_cpu_area(area.cpu_area().unwrap()) }.unwrap();
+        }
+        Err(error) => panic!("invalid host CPU-local binding: {error}"),
+    }
+    guard
+}
+
+#[test]
+fn initializer_runs_outside_preemption_guard() {
+    let _guard = test_guard();
+
+    assert_eq!(INIT_PREEMPT_DEPTH.with(|depth| *depth), 0);
+}
+
+#[test]
+fn scope_new_initializes_every_item() {
+    let _guard = test_guard();
+    EAGER_INIT_COUNT.store(0, Ordering::Release);
+
+    let scope = Scope::new();
+
+    assert_eq!(EAGER_INIT_COUNT.load(Ordering::Acquire), 1);
+    assert_eq!(*EAGER_VALUE.scope(&scope), 7);
+    assert_eq!(EAGER_INIT_COUNT.load(Ordering::Acquire), 1);
+}
+
+#[test]
+fn pinned_access_has_no_initialization_side_effects() {
+    let _guard = test_guard();
+    PINNED_INIT_COUNT.store(0, Ordering::Release);
+    let scope = Scope::new();
+    assert_eq!(PINNED_INIT_COUNT.load(Ordering::Acquire), 1);
+
+    // SAFETY: `scope` remains live until the global scope is restored.
+    unsafe { ActiveScope::set(&scope) };
+    assert_eq!(PINNED_VALUE.with(|value| *value), 11);
+    // SAFETY: this serialized host test cannot migrate between modeled CPUs.
+    unsafe {
+        ax_percpu::with_cpu_pin(|pin| {
+            assert_eq!(PINNED_VALUE.with_pinned(pin, |value| *value), 11);
+            assert_eq!(PINNED_VALUE.try_with_pinned(pin, |value| *value), Some(11));
+        })
+    }
+    .unwrap();
+    ActiveScope::set_global();
+
+    assert_eq!(PINNED_INIT_COUNT.load(Ordering::Acquire), 1);
+}

--- a/components/scope-local/tests/recursive_initialization.rs
+++ b/components/scope-local/tests/recursive_initialization.rs
@@ -1,0 +1,52 @@
+use core::num::NonZeroU32;
+use std::{any::Any, panic};
+
+use scope_local::scope_local;
+
+struct KernelGuardIfImpl;
+
+#[ax_crate_interface::impl_interface]
+impl ax_kernel_guard::KernelGuardIf for KernelGuardIfImpl {
+    fn enable_preempt() {}
+
+    fn disable_preempt() {}
+}
+
+scope_local! {
+    static RECURSION_TARGET: usize = 23;
+    static RECURSIVE_VALUE: usize = {
+        RECURSION_TARGET.with(|value| *value)
+    };
+}
+
+fn bind_test_cpu() {
+    let area_count = NonZeroU32::new(1).unwrap();
+    ax_percpu::host_test::initialize(area_count).unwrap();
+    let area = ax_percpu::area(ax_percpu::CpuIndex::try_from(0).unwrap()).unwrap();
+    // SAFETY: this test models one CPU and never replaces its area.
+    unsafe { cpu_local::install_cpu_area(area.cpu_area().unwrap()) }.unwrap();
+}
+
+fn panic_message(payload: Box<dyn Any + Send>) -> String {
+    match payload.downcast::<String>() {
+        Ok(message) => *message,
+        Err(payload) => payload
+            .downcast::<&'static str>()
+            .map(|message| (*message).to_owned())
+            .unwrap_or_else(|_| "non-string panic payload".to_owned()),
+    }
+}
+
+#[test]
+fn recursive_global_initialization_fails_fast_and_can_retry() {
+    bind_test_cpu();
+
+    for _ in 0..2 {
+        let panic = panic::catch_unwind(|| RECURSIVE_VALUE.with(|value| *value))
+            .expect_err("recursive initialization must fail");
+        assert_eq!(
+            panic_message(panic),
+            "scope-local global scope initialization is already in progress"
+        );
+    }
+}

--- a/components/scope-local/tests/scope_local.rs
+++ b/components/scope-local/tests/scope_local.rs
@@ -11,8 +11,18 @@ use std::{
 use ctor::ctor;
 use scope_local::{ActiveScope, Scope, scope_local};
 
+struct KernelGuardIfImpl;
+
+#[ax_crate_interface::impl_interface]
+impl ax_kernel_guard::KernelGuardIf for KernelGuardIfImpl {
+    fn enable_preempt() {}
+
+    fn disable_preempt() {}
+}
+
 static TEST_LOCK: Mutex<()> = Mutex::new(());
 static UNUSED_INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
+static PINNED_INIT_COUNT: AtomicUsize = AtomicUsize::new(0);
 static CPU_COUNT: AtomicUsize = AtomicUsize::new(1);
 static NEXT_TEST_CPU: AtomicUsize = AtomicUsize::new(1);
 
@@ -68,7 +78,7 @@ fn scope_init() {
 }
 
 #[test]
-fn scope_init_is_per_item_lazy() {
+fn scope_new_initializes_all_items() {
     let _guard = test_guard();
     UNUSED_INIT_COUNT.store(0, Ordering::Relaxed);
     scope_local! {
@@ -79,26 +89,39 @@ fn scope_init_is_per_item_lazy() {
         };
     }
 
-    assert_eq!(DATA.with(|value| *value), 42);
-    assert_eq!(UNUSED_INIT_COUNT.load(Ordering::Relaxed), 0);
+    let scope = Scope::new();
+
+    assert_eq!(*DATA.scope(&scope), 42);
+    assert_eq!(UNUSED_INIT_COUNT.load(Ordering::Relaxed), 1);
+    assert_eq!(*UNUSED.scope(&scope), 7);
+    assert_eq!(UNUSED_INIT_COUNT.load(Ordering::Relaxed), 1);
 }
 
 #[test]
 fn pinned_access_does_not_initialize_an_item() {
     let _guard = test_guard();
+    PINNED_INIT_COUNT.store(0, Ordering::Relaxed);
     scope_local! {
-        static DATA: usize = 7;
+        static DATA: usize = {
+            PINNED_INIT_COUNT.fetch_add(1, Ordering::Relaxed);
+            7
+        };
     }
+    let scope = Scope::new();
+    assert_eq!(PINNED_INIT_COUNT.load(Ordering::Relaxed), 1);
+    // SAFETY: `scope` remains live until the global scope is restored.
+    unsafe { ActiveScope::set(&scope) };
 
     // SAFETY: the serialized host test cannot migrate between modeled CPUs.
     unsafe {
         ax_percpu::with_cpu_pin(|pin| {
-            assert_eq!(DATA.try_with_pinned(pin, |value| *value), None);
-            assert_eq!(DATA.with(|value| *value), 7);
+            assert_eq!(DATA.with_pinned(pin, |value| *value), 7);
             assert_eq!(DATA.try_with_pinned(pin, |value| *value), Some(7));
         })
     }
     .unwrap();
+    ActiveScope::set_global();
+    assert_eq!(PINNED_INIT_COUNT.load(Ordering::Relaxed), 1);
 }
 
 #[test]


### PR DESCRIPTION
  ## Problem

  `scope-local` previously initialized each item lazily. During the first `LocalItem::with` call, an initializer could
  therefore allocate, drop resources, panic, or perform other arbitrary work while `NoPreempt` was active.

  Recursive access was another issue: if a global scope initializer accessed another scope-local item, it could re-enter the
  same `spin::Once` and wait indefinitely instead of reporting a clear failure.

  ## Changes

  - Make `Scope::new()` eagerly initialize every registered item.
  - Store fully initialized items directly in a boxed slice.
  - Remove the per-item `spin::Once<ItemBox>`.
  - Use RAII-managed storage so initializer panics release the current allocation and previously constructed items are dropped  normally.
  - Move first-time global scope initialization outside the `NoPreempt` region.
  - Add explicit atomic states for uninitialized, initializing, and ready global scopes.
  - Make recursive or concurrent re-entry fail fast instead of waiting indefinitely.
  - Restore the uninitialized state when an initializer panics, allowing a later retry.
  - Ensure pinned APIs only access existing slots and never allocate or invoke an initializer.
  - Document the eager initialization and pinned-access contracts.

  ## Design

  Initialization and runtime access are now separate phases:

  1. `Scope::new()` or the first ordinary global `LocalItem::with` call constructs all registered items.
  2. `with_pinned`, `try_with_pinned`, and active-scope access only index and borrow already initialized storage.

  Explicit `Scope` instances are always initialized eagerly. The global scope retains automatic initialization on its first
  ordinary `with` call.

  The public `LocalItem` method signatures remain unchanged. Recursive initialization now produces a deterministic diagnostic  instead of potentially deadlocking.

  ## Regression Coverage

  Tests cover:

  - Initializers running outside the preemption guard.
  - Eager initialization of every item by `Scope::new()`.
  - Pinned access without initialization side effects.
  - Automatic initialization on the first global access.
  - Fast failure and retry behavior for recursive initialization.
  - Scope switching and shared-scope access using existing storage.
  - Correct cleanup when an initializer panics.
