### PR TITLE
fix(axfs-ng-vfs): move mount callbacks outside atomic context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1284,7 +1284,9 @@ dependencies = [
 name = "axfs-ng-vfs"
 version = "0.5.5"
 dependencies = [
+ "ax-crate-interface",
  "ax-errno 0.6.1",
+ "ax-kernel-guard",
  "ax-kspin",
  "bitflags 2.13.0",
  "cfg-if",

--- a/components/axfs-ng-vfs/Cargo.toml
+++ b/components/axfs-ng-vfs/Cargo.toml
@@ -23,4 +23,6 @@ log = "0.4"
 smallvec = "1.15"
 
 [dev-dependencies]
+ax-crate-interface.workspace = true
+ax-kernel-guard = { workspace = true, features = ["preempt"] }
 ax-kspin = { workspace = true, features = ["host-test"] }

--- a/components/axfs-ng-vfs/src/lib.rs
+++ b/components/axfs-ng-vfs/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
 extern crate alloc;
+#[cfg(test)]
+extern crate std;
 
 mod fs;
 mod mount;

--- a/components/axfs-ng-vfs/src/mount/mod.rs
+++ b/components/axfs-ng-vfs/src/mount/mod.rs
@@ -884,8 +884,12 @@ impl Location {
 
     /// Mounts a filesystem with the source name exposed through mount metadata.
     pub fn mount_with_source(&self, fs: &Filesystem, source: &str) -> VfsResult<Arc<Mountpoint>> {
-        let _topology = MOUNT_TOPOLOGY_MUTATION.lock();
+        // Filesystem callbacks may acquire sleepable locks. Prepare the
+        // unpublished mount before entering the non-preemptible topology
+        // transaction; only topology validation and publication belong inside
+        // the global guard.
         let result = Mountpoint::new_with_source(fs, Some(self.clone()), source);
+        let _topology = MOUNT_TOPOLOGY_MUTATION.lock();
         let should_propagate = self.mountpoint.is_shared();
         self.check_is_dir()?;
         {
@@ -1000,12 +1004,37 @@ impl FsPollable for Location {
 #[cfg(test)]
 mod tests {
     use alloc::string::ToString;
-    use core::any::Any;
+    use core::{any::Any, cell::Cell};
 
     use super::*;
     use crate::StatFs;
 
+    std::thread_local! {
+        static PREEMPT_DEPTH: Cell<usize> = const { Cell::new(0) };
+    }
+
+    struct KernelGuardIfImpl;
+
+    #[ax_crate_interface::impl_interface]
+    impl ax_kernel_guard::KernelGuardIf for KernelGuardIfImpl {
+        fn enable_preempt() {
+            PREEMPT_DEPTH.with(|depth| {
+                depth.set(
+                    depth
+                        .get()
+                        .checked_sub(1)
+                        .expect("preemption depth must be balanced"),
+                );
+            });
+        }
+
+        fn disable_preempt() {
+            PREEMPT_DEPTH.with(|depth| depth.set(depth.get() + 1));
+        }
+    }
+
     struct MockFs;
+    struct ContextCheckingFs;
     struct MockNode;
 
     static MOCK_FS: MockFs = MockFs;
@@ -1018,6 +1047,27 @@ mod tests {
             let node: Arc<dyn DirNodeOps> = Arc::new(MockNode);
             DirEntry::new_dir(|_| DirNode::new(node), Reference::root())
         }
+        fn stat(&self) -> VfsResult<StatFs> {
+            Err(VfsError::InvalidInput)
+        }
+    }
+
+    impl FilesystemOps for ContextCheckingFs {
+        fn name(&self) -> &str {
+            "context-checking"
+        }
+
+        fn root_dir(&self) -> DirEntry {
+            PREEMPT_DEPTH.with(|depth| {
+                assert_eq!(
+                    depth.get(),
+                    0,
+                    "filesystem callbacks must run outside the mount topology guard"
+                );
+            });
+            make_dir_entry("mounted-root")
+        }
+
         fn stat(&self) -> VfsResult<StatFs> {
             Err(VfsError::InvalidInput)
         }
@@ -1086,6 +1136,18 @@ mod tests {
             |_| DirNode::new(node),
             Reference::new(parent, name.to_string()),
         )
+    }
+
+    #[test]
+    fn mount_invokes_filesystem_callbacks_outside_topology_guard() {
+        let root = Mountpoint::new_root(&mock_filesystem());
+        let root_location = root.root_location();
+        let target_entry =
+            make_child_dir_entry(Some(root_location.entry().clone()), "mount-target");
+        let target = Location::new(root, target_entry);
+        let mounted = Filesystem::new(Arc::new(ContextCheckingFs));
+
+        target.mount(&mounted).expect("mount succeeds");
     }
 
     #[test]


### PR DESCRIPTION
  ## Problem

  `Location::mount_with_source()` acquired the global mount-topology `SpinNoPreempt` lock before constructing the new
  `Mountpoint`.

  Mountpoint construction invokes filesystem callbacks such as `FilesystemOps::root_dir()` and `is_readonly()`. These
  callbacks are not required to be atomic-safe and may acquire sleepable locks.

  StarryOS overlayfs exposes this issue because `OverlayFs::root_dir()` acquires a sleepable mutex. Calling it while the
  topology lock has disabled preemption triggers the atomic-context assertion:

  ```text
  sleeping or rescheduling is not allowed in atomic context
  reasons=[preempt_disabled]
  caller=os/StarryOS/kernel/src/pseudofs/overlay.rs

  The failure reproduces on both LoongArch64 CI and the RISC-V64 test-overlayfs system case.

  ## Root Cause

  The mount-topology lock covered more than the topology transaction itself:

  1. Disable preemption by acquiring MOUNT_TOPOLOGY_MUTATION.
  2. Construct a new mountpoint.
  3. Invoke filesystem callbacks during construction.
  4. Validate and publish the mount into the topology.

  Only the final validation and publication steps require topology serialization. Running filesystem callbacks inside this
  non-preemptible section violates their execution-context contract.

  ## Changes

  - Construct the unpublished Mountpoint before acquiring the global topology lock.
  - Keep the following operations serialized under the topology lock:
      - propagation-state observation;
      - target-directory validation;
      - duplicate-mount detection;
      - child mount insertion;
      - propagation to peer/slave mount trees;
      - topology-version publication.

  - Add a deterministic host regression test:
      - enable the real preemption-guard callbacks for the test build;
      - track preemption depth per host thread;
      - mount a filesystem whose root_dir() asserts that preemption is enabled.

  ## Correctness

  The prepared mountpoint is not visible from the shared mount topology before the lock is acquired. If validation or
  publication fails, the unpublished object is dropped normally.

  All shared topology checks and mutations remain inside the same global critical section, so this change does not weaken
  mount serialization or propagation consistency.

  The change only narrows the atomic section around existing mount behavior. It does not change mount flags, error results,
  propagation semantics, filesystem layout, or user-visible ABI.

  ## Regression Evidence

  Before the fix, the new unit test fails deterministically:

  filesystem callbacks must run outside the mount topology guard
  left: 1
  right: 0

  After the fix, the same test passes.

  The existing StarryOS overlayfs system test previously panicked while mounting the overlay filesystem. After the fix, all
  100 assertions pass and the runner reports:

  STARRY_GROUPED_TESTS_PASSED

  ## Validation

  - cargo test -p axfs-ng-vfs
  - cargo xtask clippy --package axfs-ng-vfs
      - base configuration
      - lockdep feature

  - cargo clippy -p axfs-ng-vfs --all-targets -- -D warnings
  - cargo xtask spin-lint
  - cargo fmt --all
  - git diff --check
  - cargo xtask starry test qemu --arch riscv64 -c qemu/system/test-overlayfs
