### PR TITLE
fix(starry-kernel): avoid sleeping lock in overlay root

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/overlay.rs
+++ b/os/StarryOS/kernel/src/pseudofs/overlay.rs
@@ -19,6 +19,7 @@ use alloc::{
 use core::{any::Any, task::Context};
 
 use ax_fs_ng::vfs::OpenOptions;
+use ax_kspin::SpinNoIrq;
 use ax_sync::Mutex;
 use axfs_ng_vfs::{
     DeviceId, DirEntry, DirEntrySink, DirNode, DirNodeOps, FileNode, FileNodeOps, Filesystem,
@@ -65,7 +66,7 @@ pub fn new_overlayfs(options: OverlayOptions) -> VfsResult<Filesystem> {
         lower_dirs: options.lower_dirs,
         upper_dir: options.upper_dir,
         _work_dir: options.work_dir,
-        root: Mutex::new(None),
+        root: SpinNoIrq::new(None),
     });
     let root = OverlayDir::entry(
         fs.clone(),
@@ -112,7 +113,8 @@ struct OverlayFs {
     lower_dirs: Vec<Location>,
     upper_dir: Option<Location>,
     _work_dir: Option<Location>,
-    root: Mutex<Option<DirEntry>>,
+    // root_dir() may be called from VFS mount paths with preemption disabled.
+    root: SpinNoIrq<Option<DirEntry>>,
 }
 
 impl FilesystemOps for OverlayFs {


### PR DESCRIPTION
## 问题

`dev` 分支的 CI run 30058497129 在 `Test starry loongarch64 qemu / run_container` 中稳定失败。`test-overlayfs` 执行 mount 时，`OverlayFs::root_dir()` 在禁止抢占的 VFS mount 上下文中获取 `ax_sync::Mutex`，触发 `axtask` 的 atomic-context panic。

该失败并非 release 提交 `2e53a08e` 新引入：其父提交的 CI 已在相同测试、相同行连续失败；原 overlayfs 锁实现来自更早提交，是被新的 mount-tree 路径暴露出的潜藏问题。

## 修改

- 将 `OverlayFs` 的根 dentry 锁从可睡眠的 `ax_sync::Mutex` 改为 `ax_kspin::SpinNoIrq`。
- 保留 overlayfs 其余需要睡眠语义的 `Mutex`，只收窄修复到 `root_dir()` 的原子上下文边界。
- 增加注释记录 `root_dir()` 可能在禁止抢占的 mount 路径中调用，避免后续退化。

该改法与现有 `MemoryFs`、`SimpleFs` 的根 dentry 锁策略一致；锁内仅克隆 `DirEntry`，不会执行阻塞操作。

## 验证

- 红测（修改前）：`cargo xtask starry test qemu --arch loongarch64 -c qemu/system/syscall-test-overlayfs`，稳定在 `overlay.rs:124` 触发 `preempt_disabled` panic。
- 绿测（修改后）：同一命令通过，输出 `STARRY_SYSTEM_TEST_PASSED` 和 `STARRY_GROUPED_TESTS_PASSED`。
- `cargo fmt --all --check`
- `cargo xtask clippy --package starry-kernel`（22/22 checks passed）
