### PR TITLE
fix(axhvc): handle PSCI_VERSION hypercall

### DIFF
--- a/os/axvisor/src/shell/command/vm.rs
+++ b/os/axvisor/src/shell/command/vm.rs
@@ -705,6 +705,7 @@ fn vm_list(cmd: &ParsedCommand) {
                     VmVcpuState::Invalid => "Inv",
                     VmVcpuState::Created => "Cre",
                     VmVcpuState::Ready => "Rdy",
+                    VmVcpuState::Starting => "Sta",
                 };
                 *state_counts.entry(state).or_insert(0) += 1;
             }
@@ -808,6 +809,7 @@ fn show_vm_basic_details(vm_id: usize, show_config: bool, show_stats: bool) {
                 VmVcpuState::Invalid => "Invalid",
                 VmVcpuState::Created => "Created",
                 VmVcpuState::Ready => "Ready",
+                VmVcpuState::Starting => "Starting",
             };
             *state_counts.entry(state).or_insert(0) += 1;
         }
@@ -916,6 +918,7 @@ fn show_vm_full_details(vm_id: usize) {
                 VmVcpuState::Invalid => "Invalid",
                 VmVcpuState::Created => "Created",
                 VmVcpuState::Ready => "Ready",
+                VmVcpuState::Starting => "Starting",
             };
             *state_counts.entry(state).or_insert(0) += 1;
         }
@@ -936,6 +939,7 @@ fn show_vm_full_details(vm_id: usize) {
                 VmVcpuState::Invalid => "Invalid",
                 VmVcpuState::Created => "Created",
                 VmVcpuState::Ready => "Ready",
+                VmVcpuState::Starting => "Starting",
             };
 
             if let Some(phys_cpu_set) = vcpu.phys_cpu_set {

--- a/virtualization/arm_vcpu/src/exception.rs
+++ b/virtualization/arm_vcpu/src/exception.rs
@@ -16,8 +16,7 @@ use aarch64_cpu::registers::{ESR_EL2, HCR_EL2, Readable, SCTLR_EL1, VTCR_EL2, VT
 use log::error;
 
 use crate::{
-    ArmAccessWidth, ArmGuestPhysAddr, ArmSysRegAddr, ArmVcpuError, ArmVcpuResult, ArmVmExit,
-    TrapFrame,
+    ArmAccessWidth, ArmSysRegAddr, ArmVcpuError, ArmVcpuResult, ArmVmExit, TrapFrame,
     exception_utils::{
         exception_class, exception_class_value, exception_data_abort_access_is_write,
         exception_data_abort_access_reg, exception_data_abort_access_reg_width,
@@ -43,6 +42,12 @@ pub enum TrapKind {
 const EXCEPTION_SYNC: usize = TrapKind::Synchronous as usize;
 /// Equals to [`TrapKind::Irq`], used in exception.S.
 const EXCEPTION_IRQ: usize = TrapKind::Irq as usize;
+
+const AARCH64_EXCEPTION_INSN_SIZE: usize = 4;
+
+fn advance_aarch64_exception_pc(ctx: &mut TrapFrame) {
+    ctx.set_exception_pc(ctx.exception_pc() + AARCH64_EXCEPTION_INSN_SIZE);
+}
 
 #[repr(u8)]
 #[derive(Debug)]
@@ -93,27 +98,14 @@ pub fn handle_exception_sync(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
             handle_data_abort(ctx)
         }
         Some(ESR_EL2::EC::Value::HVC64) => {
-            // The `#imm`` argument when triggering a hvc call, currently not used.
+            // The `#imm` argument when triggering a hvc call, currently not used.
             let _hvc_arg_imm16 = ESR_EL2.read(ESR_EL2::ISS);
 
-            // Is this a psci call?
-            //
-            // By convention, a psci call can use either the `hvc` or the `smc` instruction.
-            // NimbOS uses `hvc`, `ArceOS` use `hvc` too when running on QEMU.
-            if let Some(result) = handle_psci_call(ctx) {
+            if let Some(result) = handle_hvc_psci_version(ctx) {
                 return result;
             }
 
-            // We assume that guest VM triggers HVC through a `hvc #0`` instruction.
-            // And arm64 hcall implementation uses `x0` to specify the hcall number.
-            // For more details on the hypervisor call (HVC) mechanism and the use of general-purpose registers,
-            // refer to the [Linux Kernel documentation on KVM ARM hypervisor ABI](https://github.com/torvalds/linux/blob/master/Documentation/virt/kvm/arm/hyp-abi.rst).
-            Ok(ArmVmExit::Hypercall {
-                nr: ctx.gpr[0],
-                args: [
-                    ctx.gpr[1], ctx.gpr[2], ctx.gpr[3], ctx.gpr[4], ctx.gpr[5], ctx.gpr[6],
-                ],
-            })
+            handle_hvc64_exception(ctx)
         }
         Some(ESR_EL2::EC::Value::TrappedMsrMrs) => handle_system_register(ctx),
         Some(ESR_EL2::EC::Value::SMC64) => {
@@ -138,6 +130,40 @@ pub fn handle_exception_sync(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
             );
         }
     }
+}
+
+fn handle_hvc_psci_version(ctx: &mut TrapFrame) -> Option<ArmVcpuResult<ArmVmExit>> {
+    const PSCI_VERSION_32: u64 = 0x8400_0000;
+    const PSCI_VERSION_0_2: usize = 0x0000_0002;
+
+    if ctx.gpr[0] != PSCI_VERSION_32 {
+        return None;
+    }
+
+    advance_aarch64_exception_pc(ctx);
+    ctx.set_gpr(0, PSCI_VERSION_0_2);
+    Some(Ok(ArmVmExit::Nothing))
+}
+
+fn handle_hvc64_exception(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
+    advance_aarch64_exception_pc(ctx);
+
+    // Is this a psci call?
+    //
+    // By convention, a psci call can use either the `hvc` or the `smc` instruction.
+    // NimbOS uses `hvc`, `ArceOS` use `hvc` too when running on QEMU.
+    if let Some(result) = handle_psci_call(ctx) {
+        return result;
+    }
+
+    // We assume that guest VM triggers HVC through a `hvc #0` instruction.
+    // And arm64 hcall implementation uses `x0` to specify the hcall number.
+    Ok(ArmVmExit::Hypercall {
+        nr: ctx.gpr[0],
+        args: [
+            ctx.gpr[1], ctx.gpr[2], ctx.gpr[3], ctx.gpr[4], ctx.gpr[5], ctx.gpr[6],
+        ],
+    })
 }
 
 fn handle_data_abort(context_frame: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
@@ -222,47 +248,26 @@ fn handle_system_register(context_frame: &mut TrapFrame) -> ArmVcpuResult<ArmVmE
     })
 }
 
-/// Handles HVC or SMC exceptions that serve as psci (Power State Coordination Interface) calls.
+/// Handles HVC or SMC exceptions that serve as PSCI calls.
 ///
-/// A hvc or smc call with the function in range 0x8000_0000..=0x8000_001F  (when the 32-bit
-/// hvc/smc calling convention is used) or 0xC000_0000..=0xC000_001F (when the 64-bit hvc/smc
-/// calling convention is used) is a psci call. This function handles them all.
-///
-/// Returns `None` if the HVC is not a psci call.
-fn handle_psci_call(ctx: &mut TrapFrame) -> Option<ArmVcpuResult<ArmVmExit>> {
+/// PSCI calls are normalized into `ArmVmExit::Hypercall` so that PSCI
+/// semantics live in `axvm::runtime::hvc` instead of being split between
+/// the trap layer and the VM runtime.
+fn handle_psci_call(ctx: &TrapFrame) -> Option<ArmVcpuResult<ArmVmExit>> {
     const PSCI_FN_RANGE_32: core::ops::RangeInclusive<u64> = 0x8400_0000..=0x8400_001F;
     const PSCI_FN_RANGE_64: core::ops::RangeInclusive<u64> = 0xC400_0000..=0xC400_001F;
 
-    const PSCI_FN_VERSION: u64 = 0x0;
-    const _PSCI_FN_CPU_SUSPEND: u64 = 0x1;
-    const PSCI_FN_CPU_OFF: u64 = 0x2;
-    const PSCI_FN_CPU_ON: u64 = 0x3;
-    const _PSCI_FN_MIGRATE: u64 = 0x5;
-    const PSCI_FN_SYSTEM_OFF: u64 = 0x8;
-    const _PSCI_FN_SYSTEM_RESET: u64 = 0x9;
-    const PSCI_FN_END: u64 = 0x1f;
-
-    let fn_ = ctx.gpr[0];
-    let fn_offset = if PSCI_FN_RANGE_32.contains(&fn_) {
-        Some(fn_ - PSCI_FN_RANGE_32.start())
-    } else if PSCI_FN_RANGE_64.contains(&fn_) {
-        Some(fn_ - PSCI_FN_RANGE_64.start())
-    } else {
-        None
-    };
-
-    match fn_offset {
-        Some(PSCI_FN_CPU_OFF) => Some(Ok(ArmVmExit::CpuDown { state: ctx.gpr[1] })),
-        Some(PSCI_FN_CPU_ON) => Some(Ok(ArmVmExit::CpuUp {
-            target_cpu: ctx.gpr[1],
-            entry_point: ArmGuestPhysAddr::from_usize(ctx.gpr[2] as usize),
-            arg: ctx.gpr[3],
-        })),
-        Some(PSCI_FN_SYSTEM_OFF) => Some(Ok(ArmVmExit::SystemDown)),
-        // We just forward these request to the ATF directly.
-        Some(PSCI_FN_VERSION..PSCI_FN_END) => None,
-        _ => None,
+    let fn_id = ctx.gpr[0];
+    if !PSCI_FN_RANGE_32.contains(&fn_id) && !PSCI_FN_RANGE_64.contains(&fn_id) {
+        return None;
     }
+
+    Some(Ok(ArmVmExit::Hypercall {
+        nr: fn_id,
+        args: [
+            ctx.gpr[1], ctx.gpr[2], ctx.gpr[3], ctx.gpr[4], ctx.gpr[5], ctx.gpr[6],
+        ],
+    }))
 }
 
 /// Handles SMC (Secure Monitor Call) exceptions.
@@ -370,4 +375,51 @@ fn invalid_exception_el2(tf: &mut TrapFrame, kind: TrapKind, source: TrapSource)
         "Invalid exception {:?} from {:?}:\n{:#x?}",
         kind, source, tf
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PSCI_VERSION_32: u64 = 0x8400_0000;
+    const GENERIC_HVC_NR: u64 = 0x1234_5678;
+    const TEST_PC: usize = 0x8020_0000;
+
+    #[test]
+    fn hvc_psci_exit_advances_exception_pc() {
+        let mut ctx = TrapFrame::default();
+        ctx.set_exception_pc(TEST_PC);
+        ctx.set_gpr(0, PSCI_VERSION_32 as usize);
+
+        let exit = handle_hvc64_exception(&mut ctx).expect("PSCI HVC should produce VM exit");
+
+        assert_eq!(ctx.exception_pc(), TEST_PC + AARCH64_EXCEPTION_INSN_SIZE);
+        assert!(matches!(
+            exit,
+            ArmVmExit::Hypercall {
+                nr: PSCI_VERSION_32,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn generic_hvc_exit_advances_exception_pc() {
+        let mut ctx = TrapFrame::default();
+        ctx.set_exception_pc(TEST_PC);
+        ctx.set_gpr(0, GENERIC_HVC_NR as usize);
+        ctx.set_gpr(1, 1);
+        ctx.set_gpr(2, 2);
+
+        let exit = handle_hvc64_exception(&mut ctx).expect("generic HVC should produce VM exit");
+
+        assert_eq!(ctx.exception_pc(), TEST_PC + AARCH64_EXCEPTION_INSN_SIZE);
+        assert!(matches!(
+            exit,
+            ArmVmExit::Hypercall {
+                nr: GENERIC_HVC_NR,
+                args: [1, 2, _, _, _, _],
+            }
+        ));
+    }
 }

--- a/virtualization/axhvc/src/lib.rs
+++ b/virtualization/axhvc/src/lib.rs
@@ -91,6 +91,54 @@ pub use error::{HyperCallError, HyperCallResult, InvalidHyperCallCode};
 #[repr(u32)]
 #[derive(Eq, PartialEq, Copy, Clone)]
 pub enum HyperCallCode {
+    /// PSCI_VERSION.
+    PSCIVersion          = 0x8400_0000,
+
+    /// PSCI_CPU_SUSPEND.
+    PSCICpuSuspend       = 0x8400_0001,
+
+    /// PSCI_CPU_OFF.
+    PSCICpuOff           = 0x8400_0002,
+
+    /// PSCI_CPU_ON.
+    PSCICpuOn            = 0x8400_0003,
+
+    /// PSCI_AFFINITY_INFO.
+    PSCIAffinityInfo     = 0x8400_0004,
+
+    /// PSCI_MIGRATE.
+    PSCIMigrate          = 0x8400_0005,
+
+    /// PSCI_MIGRATE_INFO_TYPE.
+    PSCIMigrateInfoType  = 0x8400_0006,
+
+    /// PSCI_MIGRATE_INFO_UP_CPU.
+    PSCIMigrateInfoUpCpu = 0x8400_0007,
+
+    /// PSCI_SYSTEM_OFF.
+    PSCISystemOff        = 0x8400_0008,
+
+    /// PSCI_SYSTEM_RESET.
+    PSCISystemReset      = 0x8400_0009,
+
+    /// PSCI features.
+    PSCIFeatures         = 0x8400_000a,
+
+    /// PSCI CPU suspend, SMC64.
+    PSCICpuSuspend64     = 0xc400_0001,
+
+    /// PSCI CPU on, SMC64.
+    PSCICpuOn64          = 0xc400_0003,
+
+    /// PSCI affinity info, SMC64.
+    PSCIAffinityInfo64   = 0xc400_0004,
+
+    /// PSCI migrate, SMC64.
+    PSCIMigrate64        = 0xc400_0005,
+
+    /// PSCI migrate info up CPU, SMC64.
+    PSCIMigrateInfoUpCpu64 = 0xc400_0007,
+
     /// Disable the hypervisor.
     ///
     /// This hypercall requests the hypervisor to disable itself and return
@@ -197,6 +245,23 @@ impl TryFrom<u32> for HyperCallCode {
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         match value {
+            0x8400_0000 => Ok(HyperCallCode::PSCIVersion),
+            0x8400_0001 => Ok(HyperCallCode::PSCICpuSuspend),
+            0x8400_0002 => Ok(HyperCallCode::PSCICpuOff),
+            0x8400_0003 => Ok(HyperCallCode::PSCICpuOn),
+            0x8400_0004 => Ok(HyperCallCode::PSCIAffinityInfo),
+            0x8400_0005 => Ok(HyperCallCode::PSCIMigrate),
+            0x8400_0006 => Ok(HyperCallCode::PSCIMigrateInfoType),
+            0x8400_0007 => Ok(HyperCallCode::PSCIMigrateInfoUpCpu),
+            0x8400_0008 => Ok(HyperCallCode::PSCISystemOff),
+            0x8400_0009 => Ok(HyperCallCode::PSCISystemReset),
+            0x8400_000a => Ok(HyperCallCode::PSCIFeatures),
+            0xc400_0001 => Ok(HyperCallCode::PSCICpuSuspend64),
+            0xc400_0003 => Ok(HyperCallCode::PSCICpuOn64),
+            0xc400_0004 => Ok(HyperCallCode::PSCIAffinityInfo64),
+            0xc400_0005 => Ok(HyperCallCode::PSCIMigrate64),
+            0xc400_0007 => Ok(HyperCallCode::PSCIMigrateInfoUpCpu64),
+
             0 => Ok(HyperCallCode::HypervisorDisable),
             1 => Ok(HyperCallCode::HyperVisorPrepareDisable),
             2 => Ok(HyperCallCode::HyperVisorDebug),
@@ -213,6 +278,22 @@ impl core::fmt::Debug for HyperCallCode {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "(")?;
         match self {
+            Self::PSCIVersion => write!(f, "PSCIVersion"),
+            Self::PSCICpuSuspend => write!(f, "PSCICpuSuspend"),
+            Self::PSCICpuOff => write!(f, "PSCICpuOff"),
+            Self::PSCICpuOn => write!(f, "PSCICpuOn"),
+            Self::PSCIAffinityInfo => write!(f, "PSCIAffinityInfo"),
+            Self::PSCIMigrate => write!(f, "PSCIMigrate"),
+            Self::PSCIMigrateInfoType => write!(f, "PSCIMigrateInfoType"),
+            Self::PSCIMigrateInfoUpCpu => write!(f, "PSCIMigrateInfoUpCpu"),
+            Self::PSCISystemOff => write!(f, "PSCISystemOff"),
+            Self::PSCISystemReset => write!(f, "PSCISystemReset"),
+            Self::PSCIFeatures => write!(f, "PSCIFeatures"),
+            Self::PSCICpuSuspend64 => write!(f, "PSCICpuSuspend64"),
+            Self::PSCICpuOn64 => write!(f, "PSCICpuOn64"),
+            Self::PSCIAffinityInfo64 => write!(f, "PSCIAffinityInfo64"),
+            Self::PSCIMigrate64 => write!(f, "PSCIMigrate64"),
+            Self::PSCIMigrateInfoUpCpu64 => write!(f, "PSCIMigrateInfoUpCpu64"),
             HyperCallCode::HypervisorDisable => write!(f, "HypervisorDisable {:#x}", *self as u32),
             HyperCallCode::HyperVisorPrepareDisable => {
                 write!(f, "HyperVisorPrepareDisable {:#x}", *self as u32)

--- a/virtualization/axvm-types/src/lib.rs
+++ b/virtualization/axvm-types/src/lib.rs
@@ -422,6 +422,12 @@ pub trait VmArchVcpuOps: Sized {
 
     /// Creates a new architecture-specific vCPU.
     fn new(vm_id: VMId, vcpu_id: VCpuId, config: Self::CreateConfig) -> VmBackendResult<Self>;
+
+    /// Returns the guest-visible MPIDR encoded in a vCPU create config, if any.
+    fn guest_mpidr_from_create_config(_config: &Self::CreateConfig) -> Option<u64> {
+        None
+    }
+
     /// Sets the guest entry point.
     fn set_entry(&mut self, entry: GuestPhysAddr) -> VmBackendResult;
     /// Sets the nested page table selected by AxVM.
@@ -501,17 +507,19 @@ pub trait VmArchPerCpuOps: Sized {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum VmVcpuState {
     /// Invalid state.
-    Invalid = 0,
+    Invalid  = 0,
     /// Initial state after vCPU creation.
-    Created = 1,
+    Created  = 1,
     /// vCPU is initialized and free.
-    Free    = 2,
+    Free     = 2,
     /// vCPU is bound and ready to run.
-    Ready   = 3,
+    Ready    = 3,
     /// vCPU is currently running.
-    Running = 4,
+    Running  = 4,
     /// vCPU is blocked.
-    Blocked = 5,
+    Blocked  = 5,
+    /// vCPU is reserved by PSCI CPU_ON and not yet runnable.
+    Starting = 6,
 }
 
 /// A part of `AxVMConfig`, which represents guest VM type.

--- a/virtualization/axvm/src/arch/aarch64/ipi.rs
+++ b/virtualization/axvm/src/arch/aarch64/ipi.rs
@@ -33,6 +33,8 @@ pub(crate) fn handle(
             crate::architecture::VcpuRunAction {
                 waits_for_event: false,
                 stop_reason: None,
+                resets_vm: false,
+                exits_vcpu: false,
             },
         ));
     }
@@ -55,6 +57,8 @@ pub(crate) fn handle(
         crate::architecture::VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         },
     ))
 }

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -78,9 +78,12 @@ impl ArchOps for Aarch64Arch {
         exit: <Self::VCpu as VmArchVcpuOps>::Exit,
     ) -> AxVmResult<BoundVcpuExit<Self::DeferredRunWork>> {
         match exit {
-            ArmVmExit::Hypercall { nr, args } => {
-                super::handle_hypercall(vm, vcpu, HypercallExit { nr, args })
-            }
+            ArmVmExit::Hypercall { nr, args } => super::handle_hypercall(
+                vm,
+                vcpu,
+                HypercallExit { nr, args },
+                crate::runtime::hvc::HyperCallAbi::AArch64,
+            ),
             ArmVmExit::MmioRead {
                 addr,
                 width,
@@ -138,6 +141,8 @@ impl ArchOps for Aarch64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: true,
                     stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             ArmVmExit::CpuUp {
@@ -158,6 +163,8 @@ impl ArchOps for Aarch64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: false,
                     stop_reason: Some(crate::StopReason::SystemDown),
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             ArmVmExit::SendIPI {
@@ -180,6 +187,8 @@ impl ArchOps for Aarch64Arch {
             ArmVmExit::Nothing => Ok(BoundVcpuExit::Complete(VcpuRunAction {
                 waits_for_event: false,
                 stop_reason: None,
+                resets_vm: false,
+                exits_vcpu: false,
             })),
             _ => ax_err!(Unsupported, "unsupported AArch64 VM exit"),
         }
@@ -198,6 +207,8 @@ impl ArchOps for Aarch64Arch {
         Ok(VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         })
     }
 }
@@ -225,6 +236,10 @@ impl VmArchVcpuOps for AxvmArmVcpu {
     type CreateConfig = ArmVcpuCreateConfig;
     type SetupConfig = ArmVcpuSetupConfig;
     type Exit = ArmVmExit;
+
+    fn guest_mpidr_from_create_config(config: &Self::CreateConfig) -> Option<u64> {
+        Some(config.mpidr_el1 as u64)
+    }
 
     fn new(vm_id: VMId, vcpu_id: VCpuId, config: Self::CreateConfig) -> BackendResult<Self> {
         arm_result(ArmVcpu::new(vm_id, vcpu_id, config)).map(Self)
@@ -471,5 +486,23 @@ impl ArmVgicHostIf for ArmVgicHostIfImpl {
 
     fn hardware_inject_virtual_interrupt(vector: u8) {
         gic::inject_interrupt(vector as usize);
+    }
+}
+
+#[cfg(all(test, feature = "host-test"))]
+mod guest_mpidr_tests {
+    use super::*;
+
+    #[test]
+    fn guest_mpidr_from_real_arm_create_config() {
+        let config = ArmVcpuCreateConfig {
+            mpidr_el1: 0x100,
+            dtb_addr: 0x4000_0000,
+        };
+
+        assert_eq!(
+            <AxvmArmVcpu as VmArchVcpuOps>::guest_mpidr_from_create_config(&config),
+            Some(0x100),
+        );
     }
 }

--- a/virtualization/axvm/src/arch/loongarch64/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/mod.rs
@@ -116,9 +116,12 @@ impl ArchOps for LoongArch64Arch {
         exit: <Self::VCpu as VmArchVcpuOps>::Exit,
     ) -> AxVmResult<BoundVcpuExit<Self::DeferredRunWork>> {
         match exit {
-            LoongArchVmExit::Hypercall { nr, args } => {
-                super::handle_hypercall(vm, vcpu, HypercallExit { nr, args })
-            }
+            LoongArchVmExit::Hypercall { nr, args } => super::handle_hypercall(
+                vm,
+                vcpu,
+                HypercallExit { nr, args },
+                crate::runtime::hvc::HyperCallAbi::Generic,
+            ),
             LoongArchVmExit::MmioRead {
                 addr,
                 width,
@@ -164,11 +167,15 @@ impl ArchOps for LoongArch64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: true,
                     stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             LoongArchVmExit::Nothing => Ok(BoundVcpuExit::Complete(VcpuRunAction {
                 waits_for_event: false,
                 stop_reason: None,
+                resets_vm: false,
+                exits_vcpu: false,
             })),
             _ => Err(AxVmError::unsupported(
                 "handle LoongArch VM exit",
@@ -191,6 +198,8 @@ impl ArchOps for LoongArch64Arch {
         Ok(VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         })
     }
 
@@ -220,6 +229,8 @@ fn handle_loongarch_nested_page_fault(
             return Ok(BoundVcpuExit::Complete(VcpuRunAction {
                 waits_for_event: false,
                 stop_reason: None,
+                resets_vm: false,
+                exits_vcpu: false,
             }));
         };
         return LoongArch64Arch::handle_vcpu_exit_bound(vm, vcpu, decoded);
@@ -239,6 +250,8 @@ fn handle_loongarch_nested_page_fault(
         Ok(BoundVcpuExit::Complete(VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         }))
     }
 }

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -114,9 +114,12 @@ impl ArchOps for Riscv64Arch {
         exit: <Self::VCpu as VmArchVcpuOps>::Exit,
     ) -> AxVmResult<BoundVcpuExit<Self::DeferredRunWork>> {
         match exit {
-            RiscvVmExit::Hypercall { nr, args } => {
-                super::handle_hypercall(vm, vcpu, HypercallExit { nr, args })
-            }
+            RiscvVmExit::Hypercall { nr, args } => super::handle_hypercall(
+                vm,
+                vcpu,
+                HypercallExit { nr, args },
+                crate::runtime::hvc::HyperCallAbi::Generic,
+            ),
             RiscvVmExit::MmioRead {
                 addr,
                 width,
@@ -175,6 +178,8 @@ impl ArchOps for Riscv64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: true,
                     stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             RiscvVmExit::Halt => {
@@ -182,6 +187,8 @@ impl ArchOps for Riscv64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: true,
                     stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             RiscvVmExit::SystemDown => {
@@ -189,11 +196,15 @@ impl ArchOps for Riscv64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: false,
                     stop_reason: Some(StopReason::SystemDown),
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             RiscvVmExit::Nothing => Ok(BoundVcpuExit::Complete(VcpuRunAction {
                 waits_for_event: false,
                 stop_reason: None,
+                resets_vm: false,
+                exits_vcpu: false,
             })),
         }
     }
@@ -211,6 +222,8 @@ impl ArchOps for Riscv64Arch {
         Ok(VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         })
     }
 }
@@ -233,6 +246,8 @@ fn handle_riscv_nested_page_fault(
             return Ok(BoundVcpuExit::Complete(VcpuRunAction {
                 waits_for_event: false,
                 stop_reason: None,
+                resets_vm: false,
+                exits_vcpu: false,
             }));
         };
         return Riscv64Arch::handle_vcpu_exit_bound(vm, vcpu, decoded);
@@ -252,6 +267,8 @@ fn handle_riscv_nested_page_fault(
         Ok(BoundVcpuExit::Complete(VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         }))
     }
 }

--- a/virtualization/axvm/src/arch/x86_64/exit.rs
+++ b/virtualization/axvm/src/arch/x86_64/exit.rs
@@ -80,5 +80,7 @@ pub(crate) fn finish(
     Ok(VcpuRunAction {
         waits_for_event: false,
         stop_reason: None,
+        resets_vm: false,
+        exits_vcpu: false,
     })
 }

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -96,9 +96,12 @@ impl ArchOps for X86_64Arch {
         exit: <Self::VCpu as VmArchVcpuOps>::Exit,
     ) -> AxVmResult<BoundVcpuExit<Self::DeferredRunWork>> {
         match exit {
-            X86VmExit::Hypercall { nr, args } => {
-                super::handle_hypercall(vm, vcpu, HypercallExit { nr, args })
-            }
+            X86VmExit::Hypercall { nr, args } => super::handle_hypercall(
+                vm,
+                vcpu,
+                HypercallExit { nr, args },
+                crate::runtime::hvc::HyperCallAbi::Generic,
+            ),
             X86VmExit::PortIoRead { port, width } => exit::handle_io_read(
                 vm,
                 vcpu,
@@ -113,6 +116,8 @@ impl ArchOps for X86_64Arch {
                     Ok(BoundVcpuExit::Complete(VcpuRunAction {
                         waits_for_event: false,
                         stop_reason: Some(StopReason::SystemDown),
+                        resets_vm: false,
+                        exits_vcpu: false,
                     }))
                 } else {
                     exit::handle_io_write(
@@ -191,6 +196,8 @@ impl ArchOps for X86_64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: false,
                     stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             X86VmExit::SystemDown => {
@@ -198,6 +205,8 @@ impl ArchOps for X86_64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: false,
                     stop_reason: Some(StopReason::SystemDown),
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             X86VmExit::FailEntry {
@@ -211,6 +220,8 @@ impl ArchOps for X86_64Arch {
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
                     waits_for_event: false,
                     stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
                 }))
             }
             X86VmExit::Nothing => Ok(BoundVcpuExit::Continue),
@@ -616,6 +627,8 @@ fn handle_x86_nested_page_fault(
         return Ok(BoundVcpuExit::Complete(VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         }));
     }
 
@@ -631,6 +644,8 @@ fn handle_x86_nested_page_fault(
         Ok(BoundVcpuExit::Complete(VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         }))
     }
 }

--- a/virtualization/axvm/src/architecture/cpu_up.rs
+++ b/virtualization/axvm/src/architecture/cpu_up.rs
@@ -47,6 +47,8 @@ pub(crate) fn handle<A: CpuUpOps>(
         return Ok(BoundVcpuExit::Complete(VcpuRunAction {
             waits_for_event: false,
             stop_reason: None,
+            resets_vm: false,
+            exits_vcpu: false,
         }));
     };
 
@@ -65,5 +67,7 @@ pub(crate) fn handle<A: CpuUpOps>(
     Ok(BoundVcpuExit::Complete(VcpuRunAction {
         waits_for_event: false,
         stop_reason: None,
+        resets_vm: false,
+        exits_vcpu: false,
     }))
 }

--- a/virtualization/axvm/src/architecture/exit.rs
+++ b/virtualization/axvm/src/architecture/exit.rs
@@ -3,7 +3,7 @@
 use axvm_types::VmArchVcpuOps;
 
 use super::{ArchOps, BoundVcpuExit, HypercallExit, MmioReadExit, MmioWriteExit, VcpuRunAction};
-use crate::{AxVmError, AxVmResult};
+use crate::{AxVmError, AxVmResult, StopReason};
 
 pub(crate) fn handle_mmio_read<V: VmArchVcpuOps, D>(
     vm: &crate::AxVM,
@@ -33,31 +33,286 @@ pub(crate) fn handle_mmio_write<A: ArchOps>(
     Ok(BoundVcpuExit::Continue)
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum HyperCallExitAction {
+    Return(usize),
+    Complete(VcpuRunAction),
+    CompleteWithReturn {
+        return_value: usize,
+        action: VcpuRunAction,
+    },
+}
+
+const PSCI_32_BASE: u64 = 0x8400_0000;
+const PSCI_32_END: u64 = 0x8400_0020;
+const PSCI_64_BASE: u64 = 0xc400_0000;
+const PSCI_64_END: u64 = 0xc400_0020;
+const PSCI_RET_NOT_SUPPORTED: usize = usize::MAX;
+
+fn is_aarch64_psci_function_id(raw_code: u64, abi: crate::runtime::hvc::HyperCallAbi) -> bool {
+    abi == crate::runtime::hvc::HyperCallAbi::AArch64
+        && ((PSCI_32_BASE..PSCI_32_END).contains(&raw_code)
+            || (PSCI_64_BASE..PSCI_64_END).contains(&raw_code))
+}
+
+fn complete_hypercall_decode_error<V: VmArchVcpuOps>(
+    vcpu: &crate::vm::AxVCpuRef<V>,
+    raw_code: u64,
+    abi: crate::runtime::hvc::HyperCallAbi,
+) {
+    if is_aarch64_psci_function_id(raw_code, abi) {
+        vcpu.set_return_value(PSCI_RET_NOT_SUPPORTED);
+    }
+}
+
+pub(crate) fn hvc_outcome_action(
+    outcome: crate::runtime::hvc::HyperCallOutcome,
+) -> HyperCallExitAction {
+    match outcome {
+        crate::runtime::hvc::HyperCallOutcome::Return(ret_val) => {
+            HyperCallExitAction::Return(ret_val)
+        }
+        crate::runtime::hvc::HyperCallOutcome::CpuSuspendStandby { return_value } => {
+            HyperCallExitAction::CompleteWithReturn {
+                return_value,
+                action: VcpuRunAction {
+                    waits_for_event: true,
+                    stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
+                },
+            }
+        }
+        crate::runtime::hvc::HyperCallOutcome::CpuOff => {
+            HyperCallExitAction::Complete(VcpuRunAction {
+                waits_for_event: false,
+                stop_reason: None,
+                resets_vm: false,
+                exits_vcpu: true,
+            })
+        }
+        crate::runtime::hvc::HyperCallOutcome::SystemReset => {
+            HyperCallExitAction::Complete(VcpuRunAction {
+                waits_for_event: false,
+                stop_reason: None,
+                resets_vm: true,
+                exits_vcpu: false,
+            })
+        }
+        crate::runtime::hvc::HyperCallOutcome::SystemOff => {
+            HyperCallExitAction::Complete(VcpuRunAction {
+                waits_for_event: false,
+                stop_reason: Some(StopReason::SystemDown),
+                resets_vm: false,
+                exits_vcpu: false,
+            })
+        }
+    }
+}
+
 pub(crate) fn handle_hypercall<V: VmArchVcpuOps, D>(
     vm: &crate::AxVMRef,
     vcpu: &crate::vm::AxVCpuRef<V>,
     exit: HypercallExit,
+    abi: crate::runtime::hvc::HyperCallAbi,
 ) -> AxVmResult<BoundVcpuExit<D>> {
     debug!("Hypercall [{:#x}] args {:x?}", exit.nr, exit.args);
-    match crate::runtime::hvc::HyperCall::new(vm.clone(), exit.nr, exit.args) {
-        Ok(hypercall) => {
-            let ret_val = match hypercall.execute() {
-                Ok(ret_val) => ret_val as isize,
-                Err(error) => {
-                    let err = AxVmError::from(error);
-                    warn!("Hypercall [{:#x}] failed: {err:?}", exit.nr);
-                    -1
+    match crate::runtime::hvc::HyperCall::new(vm.clone(), exit.nr, exit.args, abi) {
+        Ok(hypercall) => match hypercall.execute() {
+            Ok(outcome) => match hvc_outcome_action(outcome) {
+                HyperCallExitAction::Return(ret_val) => {
+                    vcpu.set_return_value(ret_val);
                 }
-            };
-            vcpu.set_return_value(ret_val as usize);
-        }
+                HyperCallExitAction::CompleteWithReturn {
+                    return_value,
+                    action,
+                } => {
+                    vcpu.set_return_value(return_value);
+                    return Ok(BoundVcpuExit::Complete(action));
+                }
+                HyperCallExitAction::Complete(action) => {
+                    return Ok(BoundVcpuExit::Complete(action));
+                }
+            },
+            Err(error) => {
+                let err = AxVmError::from(error);
+                warn!("Hypercall [{:#x}] failed: {err:?}", exit.nr);
+                vcpu.set_return_value(usize::MAX);
+            }
+        },
         Err(error) => {
             let err = AxVmError::from(error);
             warn!("Hypercall [{:#x}] failed: {err:?}", exit.nr);
+            complete_hypercall_decode_error(vcpu, exit.nr, abi);
         }
     }
     Ok(BoundVcpuExit::Complete(VcpuRunAction {
         waits_for_event: false,
         stop_reason: None,
+        resets_vm: false,
+        exits_vcpu: false,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[derive(Debug)]
+    struct UnknownPsciExit;
+
+    struct UnknownPsciVcpu {
+        return_value: usize,
+    }
+
+    impl VmArchVcpuOps for UnknownPsciVcpu {
+        type CreateConfig = ();
+        type SetupConfig = ();
+        type Exit = UnknownPsciExit;
+
+        fn new(
+            _vm_id: axvm_types::VMId,
+            _vcpu_id: axvm_types::VCpuId,
+            _config: Self::CreateConfig,
+        ) -> Result<Self, axvm_types::VmBackendError> {
+            Ok(Self { return_value: 0 })
+        }
+
+        fn set_entry(
+            &mut self,
+            _entry: axvm_types::GuestPhysAddr,
+        ) -> Result<(), axvm_types::VmBackendError> {
+            Ok(())
+        }
+
+        fn set_nested_page_table(
+            &mut self,
+            _config: axvm_types::NestedPagingConfig,
+        ) -> Result<(), axvm_types::VmBackendError> {
+            Ok(())
+        }
+
+        fn setup(&mut self, _config: Self::SetupConfig) -> Result<(), axvm_types::VmBackendError> {
+            Ok(())
+        }
+
+        fn run(&mut self) -> Result<Self::Exit, axvm_types::VmBackendError> {
+            Ok(UnknownPsciExit)
+        }
+
+        fn bind(&mut self) -> Result<(), axvm_types::VmBackendError> {
+            Ok(())
+        }
+
+        fn unbind(&mut self) -> Result<(), axvm_types::VmBackendError> {
+            Ok(())
+        }
+
+        fn set_gpr(&mut self, _reg: usize, _val: usize) {}
+
+        fn inject_interrupt(&mut self, _vector: usize) -> Result<(), axvm_types::VmBackendError> {
+            Ok(())
+        }
+
+        fn set_return_value(&mut self, val: usize) {
+            self.return_value = val;
+        }
+    }
+
+    #[test]
+    fn hvc_unknown_aarch64_psci_id_returns_not_supported() {
+        let vcpu = crate::vm::AxVCpuRef::new(
+            crate::vcpu::AxVCpu::<UnknownPsciVcpu>::new(99, 0, None, ()).unwrap(),
+        );
+
+        complete_hypercall_decode_error(
+            &vcpu,
+            0x8400_000c,
+            crate::runtime::hvc::HyperCallAbi::AArch64,
+        );
+
+        assert_eq!(vcpu.get_arch_vcpu().return_value, PSCI_RET_NOT_SUPPORTED);
+    }
+
+    #[test]
+    fn hvc_unknown_non_aarch64_psci_id_does_not_clobber_return_value() {
+        let vcpu = crate::vm::AxVCpuRef::new(
+            crate::vcpu::AxVCpu::<UnknownPsciVcpu>::new(99, 0, None, ()).unwrap(),
+        );
+        vcpu.set_return_value(0x8400_000c);
+
+        complete_hypercall_decode_error(
+            &vcpu,
+            0x8400_000c,
+            crate::runtime::hvc::HyperCallAbi::Generic,
+        );
+
+        assert_eq!(vcpu.get_arch_vcpu().return_value, 0x8400_000c);
+    }
+
+    #[test]
+    fn hvc_cpu_suspend_standby_sets_success_before_waiting() {
+        let action = hvc_outcome_action(HyperCallOutcome::CpuSuspendStandby { return_value: 0 });
+
+        assert_eq!(
+            action,
+            HyperCallExitAction::CompleteWithReturn {
+                return_value: 0,
+                action: VcpuRunAction {
+                    waits_for_event: true,
+                    stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
+                },
+            }
+        );
+    }
+
+    use super::*;
+    use crate::runtime::hvc::HyperCallOutcome;
+
+    #[test]
+    fn hvc_cpu_suspend_standby_waits_for_event_without_exiting() {
+        let action = hvc_outcome_action(HyperCallOutcome::CpuSuspendStandby { return_value: 0 });
+
+        assert_eq!(
+            action,
+            HyperCallExitAction::CompleteWithReturn {
+                return_value: 0,
+                action: VcpuRunAction {
+                    waits_for_event: true,
+                    stop_reason: None,
+                    resets_vm: false,
+                    exits_vcpu: false,
+                },
+            }
+        );
+    }
+
+    #[test]
+    fn hvc_system_reset_requests_vm_reset_without_returning() {
+        assert_eq!(
+            hvc_outcome_action(HyperCallOutcome::SystemReset),
+            HyperCallExitAction::Complete(VcpuRunAction {
+                waits_for_event: false,
+                stop_reason: None,
+                resets_vm: true,
+                exits_vcpu: false,
+            })
+        );
+    }
+
+    #[test]
+    fn hvc_cpu_off_exits_current_vcpu_without_stopping_vm() {
+        let action = hvc_outcome_action(crate::runtime::hvc::HyperCallOutcome::CpuOff);
+
+        assert_eq!(
+            action,
+            HyperCallExitAction::Complete(VcpuRunAction {
+                waits_for_event: false,
+                stop_reason: None,
+                resets_vm: false,
+                exits_vcpu: true,
+            })
+        );
+    }
 }

--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -29,6 +29,7 @@ pub(crate) trait ArchOps {
         default_vcpu_affinities(cpu_num, phys_cpu_ids, phys_cpu_sets)
     }
 
+    #[allow(dead_code)]
     fn set_vcpu_on_args(vcpu: &crate::vm::AxVCpuRef<Self::VCpu>, _vcpu_id: usize, arg: usize) {
         vcpu.set_gpr(0, arg);
     }
@@ -125,6 +126,7 @@ pub(crate) trait ArchOps {
 
         match vcpu.state() {
             VmVcpuState::Free => vcpu.bind()?,
+            VmVcpuState::Starting => vcpu.bind_after_cpu_on_or_rollback()?,
             VmVcpuState::Ready => {}
             state => {
                 return ax_err!(

--- a/virtualization/axvm/src/architecture/types.rs
+++ b/virtualization/axvm/src/architecture/types.rs
@@ -5,10 +5,12 @@ use axvm_types::{AccessWidth, GuestPhysAddr};
 use crate::StopReason;
 
 /// Scheduler effects selected after an architecture-local vCPU exit.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) struct VcpuRunAction {
     pub(crate) waits_for_event: bool,
     pub(crate) stop_reason: Option<StopReason>,
+    pub(crate) resets_vm: bool,
+    pub(crate) exits_vcpu: bool,
 }
 
 /// Result of handling one exit while the vCPU is still bound to the host CPU.

--- a/virtualization/axvm/src/boot/fdt/core/tree.rs
+++ b/virtualization/axvm/src/boot/fdt/core/tree.rs
@@ -298,7 +298,13 @@ pub(crate) fn sanitize_bootargs(bootargs: &str) -> String {
 pub(crate) fn should_skip_guest_cpu_prop(prop_name: &str) -> bool {
     matches!(
         prop_name,
-        "riscv,cbop-block-size" | "riscv,cboz-block-size" | "riscv,cbom-block-size"
+        "riscv,cbop-block-size"
+            | "riscv,cboz-block-size"
+            | "riscv,cbom-block-size"
+            | "operating-points-v2"
+            | "#cooling-cells"
+            | "dynamic-power-coefficient"
+            | "cpu-supply"
     )
 }
 

--- a/virtualization/axvm/src/boot/fdt/core/tree_tests.rs
+++ b/virtualization/axvm/src/boot/fdt/core/tree_tests.rs
@@ -202,3 +202,42 @@ fn clone_filtered_preserves_root_sibling_order() {
         ["timer", "timer@feae0000", "interrupt-controller@fe600000"]
     );
 }
+
+#[test]
+fn clone_filtered_drops_guest_cpu_power_management_props() {
+    let mut source = Fdt::new();
+    let root = source.root_id();
+
+    let cpus = source.add_node(root, Node::new("cpus"));
+    source
+        .node_mut(cpus)
+        .unwrap()
+        .set_property(prop_u32("#address-cells", 2));
+    source
+        .node_mut(cpus)
+        .unwrap()
+        .set_property(prop_u32("#size-cells", 0));
+
+    let cpu = source.add_node(cpus, Node::new("cpu@0"));
+    let cpu_node = source.node_mut(cpu).unwrap();
+    cpu_node.set_property(prop_str("device_type", "cpu"));
+    cpu_node.set_property(prop_str("enable-method", "psci"));
+    cpu_node.set_property(prop_u32("operating-points-v2", 3));
+    cpu_node.set_property(prop_u32("#cooling-cells", 2));
+    cpu_node.set_property(prop_u32("dynamic-power-coefficient", 0xbb));
+    cpu_node.set_property(prop_u32("cpu-supply", 5));
+
+    let tree = FdtTree::clone_filtered(&source, |_, _, _| true).unwrap();
+    let bytes = tree.finish();
+    let reparsed = Fdt::from_bytes(&bytes).unwrap();
+    let cpu_node = reparsed.get_by_path("/cpus/cpu@0").unwrap().as_node();
+
+    assert_eq!(
+        cpu_node.get_property("enable-method").unwrap().as_str(),
+        Some("psci")
+    );
+    assert!(cpu_node.get_property("operating-points-v2").is_none());
+    assert!(cpu_node.get_property("#cooling-cells").is_none());
+    assert!(cpu_node.get_property("dynamic-power-coefficient").is_none());
+    assert!(cpu_node.get_property("cpu-supply").is_none());
+}

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -19,9 +19,10 @@
 //! This crate contains:
 //! - [`AxVM`]: The main structure representing a VM.
 
-extern crate alloc;
-#[cfg(test)]
+#[cfg(any(test, feature = "host-test"))]
 extern crate std;
+
+extern crate alloc;
 #[macro_use]
 extern crate log;
 

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -69,6 +69,24 @@ impl VcpuIrqDispatcher {
         self.vcpu_tasks.lock().insert(vcpu_id, task);
     }
 
+    #[cfg(all(test, feature = "host-test"))]
+    pub(crate) fn register_test_vcpu(&self, vcpu_id: usize, cpu_id: usize) {
+        self.test_vcpu_cpu_ids.lock().insert(vcpu_id, cpu_id);
+    }
+
+    #[cfg(all(test, feature = "host-test"))]
+    pub(crate) fn test_lookup_cpu_id(&self, vcpu_id: usize) -> AxVmResult<usize> {
+        self.lookup_cpu_id(vcpu_id)
+    }
+
+    /// Unregisters a vCPU task after the vCPU powers off.
+    pub fn unregister_vcpu_task(&self, vcpu_id: usize) {
+        self.vcpu_tasks.lock().remove(&vcpu_id);
+        self.queue.drain(vcpu_id);
+        #[cfg(all(test, feature = "host-test"))]
+        self.test_vcpu_cpu_ids.lock().remove(&vcpu_id);
+    }
+
     /// Enqueues a pending interrupt for the given vCPU.
     ///
     /// Returns the physical CPU id the target vCPU task is currently running
@@ -116,143 +134,5 @@ impl VcpuIrqDispatcher {
     /// path before entering the guest.
     pub fn drain(&self, vcpu_id: usize) -> Vec<PendingVcpuInterrupt> {
         self.queue.drain(vcpu_id)
-    }
-}
-
-/// Test-only helpers for exercising the dispatcher without a full ArceOS
-/// task infrastructure.
-#[cfg(all(test, feature = "host-test"))]
-impl VcpuIrqDispatcher {
-    /// Registers a vCPU with a known physical CPU id for unit testing.
-    ///
-    /// This bypasses the real `AxTaskRef` requirement so that round-trip
-    /// enqueue→drain tests can run on the host.
-    pub(crate) fn register_test_vcpu(&self, vcpu_id: usize, cpu_id: usize) {
-        self.test_vcpu_cpu_ids.lock().insert(vcpu_id, cpu_id);
-    }
-}
-
-#[cfg(all(test, feature = "host-test"))]
-mod tests {
-    use alloc::vec;
-
-    use super::*;
-    use crate::irq::model::VirtualInterruptId;
-
-    fn edge(id: u32) -> PendingVcpuInterrupt {
-        PendingVcpuInterrupt {
-            id: VirtualInterruptId(id),
-            trigger: crate::InterruptTriggerMode::EdgeTriggered,
-        }
-    }
-
-    fn level(id: u32) -> PendingVcpuInterrupt {
-        PendingVcpuInterrupt {
-            id: VirtualInterruptId(id),
-            trigger: crate::InterruptTriggerMode::LevelTriggered,
-        }
-    }
-
-    #[test]
-    fn enqueue_unregistered_vcpu_returns_error() {
-        let d = VcpuIrqDispatcher::new();
-        assert!(matches!(
-            d.enqueue(0, edge(1)),
-            Err(crate::AxVmError::ResourceUnavailable { .. })
-        ));
-    }
-
-    #[test]
-    fn enqueue_multiple_unregistered_vcpus_all_return_error() {
-        let d = VcpuIrqDispatcher::new();
-        for vcpu_id in [0, 1, 3, 7] {
-            assert!(d.enqueue(vcpu_id, edge(1)).is_err());
-        }
-    }
-
-    #[test]
-    fn round_trip_enqueue_drain_preserves_fifo_order() {
-        let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 2);
-
-        d.enqueue(0, edge(10)).unwrap();
-        d.enqueue(0, level(20)).unwrap();
-        d.enqueue(0, edge(30)).unwrap();
-
-        let drained = d.drain(0);
-        assert_eq!(drained.len(), 3);
-        assert_eq!(drained[0], edge(10));
-        assert_eq!(drained[1], level(20));
-        assert_eq!(drained[2], edge(30));
-    }
-
-    #[test]
-    fn round_trip_enqueue_drain_isolates_vcpus() {
-        let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 1);
-        d.register_test_vcpu(1, 2);
-
-        d.enqueue(0, edge(100)).unwrap();
-        d.enqueue(1, level(200)).unwrap();
-
-        assert_eq!(d.drain(0), vec![edge(100)]);
-        assert_eq!(d.drain(1), vec![level(200)]);
-    }
-
-    #[test]
-    fn round_trip_drain_empties_queue() {
-        let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 0);
-
-        d.enqueue(0, edge(7)).unwrap();
-        assert_eq!(d.drain(0).len(), 1);
-        assert!(d.drain(0).is_empty());
-    }
-
-    #[test]
-    fn round_trip_double_drain_returns_empty() {
-        let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 0);
-
-        d.enqueue(0, edge(7)).unwrap();
-        d.drain(0);
-        assert!(d.drain(0).is_empty());
-    }
-
-    #[test]
-    fn round_trip_trigger_mode_preserved() {
-        let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 3);
-
-        d.enqueue(0, edge(42)).unwrap();
-        d.enqueue(0, level(43)).unwrap();
-
-        let drained = d.drain(0);
-        assert_eq!(
-            drained[0].trigger,
-            crate::InterruptTriggerMode::EdgeTriggered
-        );
-        assert_eq!(
-            drained[1].trigger,
-            crate::InterruptTriggerMode::LevelTriggered
-        );
-    }
-
-    #[test]
-    fn enqueue_returns_registered_cpu_id() {
-        let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 5);
-
-        let cpu_id = d.enqueue(0, edge(1)).unwrap();
-        assert_eq!(cpu_id, 5);
-    }
-
-    #[test]
-    fn unregistered_vcpu_still_fails_when_others_registered() {
-        let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 0);
-
-        assert!(d.enqueue(0, edge(1)).is_ok());
-        assert!(d.enqueue(1, edge(2)).is_err());
     }
 }

--- a/virtualization/axvm/src/runtime/hvc.rs
+++ b/virtualization/axvm/src/runtime/hvc.rs
@@ -12,17 +12,225 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::format;
+use alloc::{format, string::ToString};
 
 use axhvc::{HyperCallCode, HyperCallError, HyperCallResult};
 
 use crate::{
-    AxVmError, GuestPhysAddr, MappingFlags,
+    AsVCpuTask, AxVmError, GuestPhysAddr, MappingFlags,
     runtime::{
         VMRef,
         ivc::{self, IVCChannel},
+        vcpus,
     },
 };
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HyperCallAbi {
+    Generic,
+    AArch64,
+}
+
+fn is_psci_code(code: HyperCallCode) -> bool {
+    matches!(
+        code,
+        HyperCallCode::PSCIVersion
+            | HyperCallCode::PSCIFeatures
+            | HyperCallCode::PSCICpuSuspend
+            | HyperCallCode::PSCICpuSuspend64
+            | HyperCallCode::PSCICpuOff
+            | HyperCallCode::PSCICpuOn
+            | HyperCallCode::PSCICpuOn64
+            | HyperCallCode::PSCIAffinityInfo
+            | HyperCallCode::PSCIAffinityInfo64
+            | HyperCallCode::PSCIMigrate
+            | HyperCallCode::PSCIMigrate64
+            | HyperCallCode::PSCIMigrateInfoType
+            | HyperCallCode::PSCIMigrateInfoUpCpu
+            | HyperCallCode::PSCIMigrateInfoUpCpu64
+            | HyperCallCode::PSCISystemOff
+            | HyperCallCode::PSCISystemReset
+    )
+}
+const PSCI_RET_SUCCESS: usize = 0;
+const PSCI_VERSION_0_2: usize = 0x0000_0002;
+const PSCI_RET_NOT_SUPPORTED: usize = usize::MAX;
+const PSCI_RET_INVALID_PARAMETERS: usize = (-2isize) as usize;
+const PSCI_RET_DENIED: usize = (-3isize) as usize;
+#[allow(dead_code)]
+const PSCI_RET_ALREADY_ON: usize = (-4isize) as usize;
+#[allow(dead_code)]
+const PSCI_RET_ON_PENDING: usize = (-5isize) as usize;
+#[allow(dead_code)]
+const PSCI_RET_INTERNAL_FAILURE: usize = (-6isize) as usize;
+const PSCI_AFFINITY_LEVEL_ON: usize = 0;
+const PSCI_AFFINITY_LEVEL_OFF: usize = 1;
+const PSCI_AFFINITY_LEVEL_ON_PENDING: usize = 2;
+const PSCI_MIGRATE_TYPE_TOS_NOT_PRESENT: usize = 2;
+const PSCI_POWER_STATE_TYPE_SHIFT: u64 = 16;
+const PSCI_POWER_STATE_TYPE_MASK: u64 = 0x1;
+const PSCI_POWER_STATE_TYPE_STANDBY: u64 = 0;
+const PSCI_POWER_STATE_TYPE_POWERDOWN: u64 = 1;
+
+fn psci_power_state_type(power_state: u64) -> u64 {
+    (power_state >> PSCI_POWER_STATE_TYPE_SHIFT) & PSCI_POWER_STATE_TYPE_MASK
+}
+
+fn psci_affinity_info_result(state: crate::VmVcpuState) -> usize {
+    match state {
+        crate::VmVcpuState::Ready | crate::VmVcpuState::Running => PSCI_AFFINITY_LEVEL_ON,
+        crate::VmVcpuState::Starting => PSCI_AFFINITY_LEVEL_ON_PENDING,
+        _ => PSCI_AFFINITY_LEVEL_OFF,
+    }
+}
+
+#[allow(dead_code)]
+fn psci_find_vcpu_by_mpidr<I>(target_cpu: u64, vcpus: I) -> Option<usize>
+where
+    I: IntoIterator<Item = (usize, u64)>,
+{
+    vcpus.into_iter().find_map(|(vcpu_id, mpidr)| {
+        psci_mpidr_matches_affinity_level(mpidr, target_cpu, 0).then_some(vcpu_id)
+    })
+}
+
+fn psci_mpidr_affinity_mask(affinity_level: u64) -> Option<u64> {
+    match affinity_level {
+        0 => Some(0x0000_00ff_00ff_ffff),
+        1 => Some(0x0000_00ff_00ff_ff00),
+        2 => Some(0x0000_00ff_00ff_0000),
+        3 => Some(0x0000_00ff_0000_0000),
+        _ => None,
+    }
+}
+
+fn psci_mpidr_matches_affinity_level(
+    vcpu_mpidr: u64,
+    target_affinity: u64,
+    affinity_level: u64,
+) -> bool {
+    psci_mpidr_affinity_mask(affinity_level)
+        .is_some_and(|mask| (vcpu_mpidr & mask) == (target_affinity & mask))
+}
+
+fn psci_affinity_info_result_for_domain<I>(
+    target_affinity: u64,
+    affinity_level: u64,
+    vcpus: I,
+) -> usize
+where
+    I: IntoIterator<Item = (u64, crate::VmVcpuState)>,
+{
+    if psci_mpidr_affinity_mask(affinity_level).is_none() {
+        return PSCI_RET_INVALID_PARAMETERS;
+    }
+
+    let mut has_match = false;
+    let mut has_on_pending = false;
+
+    for (mpidr, state) in vcpus {
+        if !psci_mpidr_matches_affinity_level(mpidr, target_affinity, affinity_level) {
+            continue;
+        }
+
+        has_match = true;
+        match psci_affinity_info_result(state) {
+            PSCI_AFFINITY_LEVEL_ON => return PSCI_AFFINITY_LEVEL_ON,
+            PSCI_AFFINITY_LEVEL_ON_PENDING => has_on_pending = true,
+            _ => {}
+        }
+    }
+
+    if !has_match {
+        PSCI_RET_INVALID_PARAMETERS
+    } else if has_on_pending {
+        PSCI_AFFINITY_LEVEL_ON_PENDING
+    } else {
+        PSCI_AFFINITY_LEVEL_OFF
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HyperCallOutcome {
+    Return(usize),
+    CpuSuspendStandby { return_value: usize },
+    CpuOff,
+    SystemOff,
+    SystemReset,
+}
+
+#[allow(dead_code)]
+fn psci_cpu_on_result(result: Result<(), vcpus::VcpuOnError>) -> usize {
+    match result {
+        Ok(()) => PSCI_RET_SUCCESS,
+        Err(vcpus::VcpuOnError::AlreadyOn) => PSCI_RET_ALREADY_ON,
+        Err(vcpus::VcpuOnError::OnPending) => PSCI_RET_ON_PENDING,
+        Err(vcpus::VcpuOnError::StartFailed) => PSCI_RET_INTERNAL_FAILURE,
+    }
+}
+
+fn psci_cpu_off_result(has_multiple_running_vcpus: bool) -> HyperCallOutcome {
+    if has_multiple_running_vcpus {
+        HyperCallOutcome::CpuOff
+    } else {
+        HyperCallOutcome::Return(PSCI_RET_DENIED)
+    }
+}
+
+fn decode_hypercall_code(raw_code: u64, abi: HyperCallAbi) -> HyperCallResult<HyperCallCode> {
+    let code = HyperCallCode::try_from(raw_code as u32)?;
+    if abi != HyperCallAbi::AArch64 && is_psci_code(code) {
+        return Err(HyperCallError::Unsupported {
+            code,
+            detail: "PSCI hypercalls are only available on AArch64".to_string(),
+        });
+    }
+    Ok(code)
+}
+
+fn psci_feature_result(function_id: u64) -> usize {
+    match decode_hypercall_code(function_id, HyperCallAbi::AArch64) {
+        Ok(
+            HyperCallCode::PSCIVersion
+            | HyperCallCode::PSCIFeatures
+            | HyperCallCode::PSCICpuSuspend
+            | HyperCallCode::PSCICpuSuspend64
+            | HyperCallCode::PSCICpuOff
+            | HyperCallCode::PSCICpuOn
+            | HyperCallCode::PSCICpuOn64
+            | HyperCallCode::PSCIAffinityInfo
+            | HyperCallCode::PSCIAffinityInfo64
+            | HyperCallCode::PSCIMigrateInfoType
+            | HyperCallCode::PSCISystemOff
+            | HyperCallCode::PSCISystemReset,
+        ) => PSCI_RET_SUCCESS,
+        _ => PSCI_RET_NOT_SUPPORTED,
+    }
+}
+
+fn dispatch_psci(code: HyperCallCode, args: [u64; 6]) -> Option<HyperCallResult> {
+    match code {
+        HyperCallCode::PSCIVersion => Some(Ok(PSCI_VERSION_0_2)),
+        HyperCallCode::PSCIFeatures => Some(Ok(psci_feature_result(args[0]))),
+        HyperCallCode::PSCIMigrateInfoType => Some(Ok(PSCI_MIGRATE_TYPE_TOS_NOT_PRESENT)),
+        HyperCallCode::PSCIMigrate
+        | HyperCallCode::PSCIMigrate64
+        | HyperCallCode::PSCIMigrateInfoUpCpu
+        | HyperCallCode::PSCIMigrateInfoUpCpu64 => Some(Ok(PSCI_RET_NOT_SUPPORTED)),
+
+        HyperCallCode::PSCICpuOn
+        | HyperCallCode::PSCICpuOn64
+        | HyperCallCode::PSCIAffinityInfo
+        | HyperCallCode::PSCIAffinityInfo64
+        | HyperCallCode::PSCICpuSuspend
+        | HyperCallCode::PSCICpuSuspend64
+        | HyperCallCode::PSCICpuOff
+        | HyperCallCode::PSCISystemOff
+        | HyperCallCode::PSCISystemReset => None,
+
+        _ => None,
+    }
+}
 
 pub struct HyperCall {
     vm: VMRef,
@@ -31,14 +239,122 @@ pub struct HyperCall {
 }
 
 impl HyperCall {
-    pub fn new(vm: VMRef, code: u64, args: [u64; 6]) -> HyperCallResult<Self> {
-        let code = HyperCallCode::try_from(code as u32)?;
+    pub fn new(vm: VMRef, code: u64, args: [u64; 6], abi: HyperCallAbi) -> HyperCallResult<Self> {
+        let code = decode_hypercall_code(code, abi)?;
 
         Ok(Self { vm, code, args })
     }
 
-    pub fn execute(&self) -> HyperCallResult {
+    pub(crate) fn execute(&self) -> Result<HyperCallOutcome, HyperCallError> {
         match self.code {
+            HyperCallCode::PSCIVersion => {
+                info!("VM[{}] PSCI_VERSION", self.vm.id());
+                dispatch_psci(self.code, self.args)
+                    .unwrap()
+                    .map(HyperCallOutcome::Return)
+            }
+            HyperCallCode::PSCIFeatures => {
+                info!(
+                    "VM[{}] PSCI_FEATURES function_id={:#x}",
+                    self.vm.id(),
+                    self.args[0]
+                );
+                dispatch_psci(self.code, self.args)
+                    .unwrap()
+                    .map(HyperCallOutcome::Return)
+            }
+            HyperCallCode::PSCICpuOn | HyperCallCode::PSCICpuOn64 => {
+                let target_cpu = self.args[0];
+                let entry_point = GuestPhysAddr::from_usize(self.args[1] as usize);
+                let context_id = self.args[2] as usize;
+
+                info!(
+                    "VM[{}] PSCI_CPU_ON target={target_cpu:#x} entry={:#x} context={context_id:#x}",
+                    self.vm.id(),
+                    self.args[1]
+                );
+
+                let Some(target_vcpu_id) = psci_find_vcpu_by_mpidr(
+                    target_cpu,
+                    self.vm
+                        .get_vcpu_guest_mpidrs()
+                        .iter()
+                        .map(|(vcpu_id, mpidr)| (*vcpu_id, *mpidr)),
+                ) else {
+                    return Ok(HyperCallOutcome::Return(PSCI_RET_INVALID_PARAMETERS));
+                };
+
+                let result =
+                    vcpus::vcpu_on(self.vm.clone(), target_vcpu_id, entry_point, context_id);
+                Ok(HyperCallOutcome::Return(psci_cpu_on_result(result)))
+            }
+            HyperCallCode::PSCICpuSuspend | HyperCallCode::PSCICpuSuspend64 => {
+                let power_state = self.args[0];
+                let state_type = psci_power_state_type(power_state);
+
+                match state_type {
+                    PSCI_POWER_STATE_TYPE_STANDBY => {
+                        info!("VM[{}] PSCI_CPU_SUSPEND standby", self.vm.id());
+                        Ok(HyperCallOutcome::CpuSuspendStandby {
+                            return_value: PSCI_RET_SUCCESS,
+                        })
+                    }
+                    PSCI_POWER_STATE_TYPE_POWERDOWN => {
+                        info!(
+                            "VM[{}] PSCI_CPU_SUSPEND powerdown is not supported before wake \
+                             lifecycle",
+                            self.vm.id()
+                        );
+                        Ok(HyperCallOutcome::Return(PSCI_RET_NOT_SUPPORTED))
+                    }
+                    _ => Ok(HyperCallOutcome::Return(PSCI_RET_INVALID_PARAMETERS)),
+                }
+            }
+            HyperCallCode::PSCICpuOff => {
+                info!("VM[{}] PSCI_CPU_OFF", self.vm.id());
+                let current = crate::host::task::current_task();
+                let cpu_off_reserved = current
+                    .try_as_vcpu_task()
+                    .map(|task| task.vcpu.id())
+                    .and_then(|vcpu_id| {
+                        self.vm
+                            .with_runtime(|runtime| Ok(runtime.try_reserve_cpu_off(vcpu_id)))
+                            .ok()
+                    })
+                    .unwrap_or(false);
+                Ok(psci_cpu_off_result(cpu_off_reserved))
+            }
+            HyperCallCode::PSCIAffinityInfo | HyperCallCode::PSCIAffinityInfo64 => {
+                let target_affinity = self.args[0];
+                let affinity_level = self.args[1];
+                let vcpus = self.vm.vcpu_list();
+
+                let affinity = psci_affinity_info_result_for_domain(
+                    target_affinity,
+                    affinity_level,
+                    self.vm
+                        .get_vcpu_guest_mpidrs()
+                        .iter()
+                        .map(|(vcpu_id, mpidr)| (*mpidr, vcpus[*vcpu_id].state())),
+                );
+
+                Ok(HyperCallOutcome::Return(affinity))
+            }
+            HyperCallCode::PSCIMigrate
+            | HyperCallCode::PSCIMigrate64
+            | HyperCallCode::PSCIMigrateInfoType
+            | HyperCallCode::PSCIMigrateInfoUpCpu
+            | HyperCallCode::PSCIMigrateInfoUpCpu64 => dispatch_psci(self.code, self.args)
+                .unwrap()
+                .map(HyperCallOutcome::Return),
+            HyperCallCode::PSCISystemOff => {
+                warn!("VM[{}] PSCI_SYSTEM_OFF", self.vm.id());
+                Ok(HyperCallOutcome::SystemOff)
+            }
+            HyperCallCode::PSCISystemReset => {
+                info!("VM[{}] PSCI_SYSTEM_RESET", self.vm.id());
+                Ok(HyperCallOutcome::SystemReset)
+            }
             HyperCallCode::HIVCPublishChannel => {
                 let key = self.args[0] as usize;
                 let shm_base_gpa_ptr = GuestPhysAddr::from_usize(self.args[1] as usize);
@@ -154,7 +470,7 @@ impl HyperCall {
                     return Err(self.operation_error("register published IVC channel", err));
                 }
 
-                Ok(0)
+                Ok(HyperCallOutcome::Return(0))
             }
             HyperCallCode::HIVCUnPublishChannel => {
                 let key = self.args[0] as usize;
@@ -178,7 +494,7 @@ impl HyperCall {
                         self.operation_error("release unpublished IVC channel", error)
                     })?;
 
-                Ok(0)
+                Ok(HyperCallOutcome::Return(0))
             }
             HyperCallCode::HIVCSubscribChannel => {
                 let publisher_vm_id = self.args[0] as usize;
@@ -302,7 +618,7 @@ impl HyperCall {
                     actual_size
                 );
 
-                Ok(0)
+                Ok(HyperCallOutcome::Return(0))
             }
             HyperCallCode::HIVCUnSubscribChannel => {
                 let publisher_vm_id = self.args[0] as usize;
@@ -328,7 +644,7 @@ impl HyperCall {
                         self.operation_error("release unsubscribed IVC channel", error)
                     })?;
 
-                Ok(0)
+                Ok(HyperCallOutcome::Return(0))
             }
             _ => {
                 warn!("Unsupported hypercall code: {:?}", self.code);
@@ -403,5 +719,288 @@ impl HyperCall {
             address: address.as_usize(),
             detail: format!("{error}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn hvc_psci_features_cpu_on_matches_execute_contract() {
+        assert_eq!(
+            dispatch_psci(HyperCallCode::PSCIFeatures, [0x8400_0003, 0, 0, 0, 0, 0]),
+            Some(Ok(PSCI_RET_SUCCESS))
+        );
+        assert_ne!(
+            psci_cpu_on_result(Err(vcpus::VcpuOnError::StartFailed)),
+            PSCI_RET_NOT_SUPPORTED
+        );
+        assert_ne!(
+            psci_cpu_on_result(Err(vcpus::VcpuOnError::AlreadyOn)),
+            PSCI_RET_NOT_SUPPORTED
+        );
+    }
+
+    #[test]
+    fn hvc_cpu_on_start_failure_is_not_reported_as_success() {
+        assert_eq!(
+            psci_cpu_on_result(Err(vcpus::VcpuOnError::StartFailed)),
+            PSCI_RET_INTERNAL_FAILURE
+        );
+        assert_ne!(
+            psci_cpu_on_result(Err(vcpus::VcpuOnError::StartFailed)),
+            PSCI_RET_SUCCESS
+        );
+    }
+
+    #[test]
+    fn hvc_cpu_on_busy_states_keep_psci_status() {
+        assert_eq!(
+            psci_cpu_on_result(Err(vcpus::VcpuOnError::AlreadyOn)),
+            PSCI_RET_ALREADY_ON
+        );
+        assert_eq!(
+            psci_cpu_on_result(Err(vcpus::VcpuOnError::OnPending)),
+            PSCI_RET_ON_PENDING
+        );
+    }
+
+    #[test]
+    fn hvc_cpu_off_last_vcpu_denial_uses_psci_denied() {
+        assert_eq!(
+            super::psci_cpu_off_result(false),
+            super::HyperCallOutcome::Return(super::PSCI_RET_DENIED)
+        );
+        assert_eq!(
+            super::psci_cpu_off_result(true),
+            super::HyperCallOutcome::CpuOff
+        );
+    }
+
+    use super::*;
+
+    #[test]
+    fn hvc_decodes_psci_version_and_dispatches_0_2() {
+        let code = decode_hypercall_code(0x8400_0000, HyperCallAbi::AArch64).unwrap();
+
+        assert_eq!(code, HyperCallCode::PSCIVersion);
+        assert_eq!(dispatch_psci(code, [0; 6]), Some(Ok(0x0000_0002)));
+    }
+
+    #[test]
+    fn hvc_decodes_psci_calls_and_returns_standard_errors() {
+        for raw_code in [0x8400_000a, 0x8400_0006] {
+            let code = decode_hypercall_code(raw_code, HyperCallAbi::AArch64).unwrap();
+
+            assert!(dispatch_psci(code, [0; 6]).is_some());
+        }
+
+        let cpu_on = decode_hypercall_code(0xc400_0003, HyperCallAbi::AArch64).unwrap();
+        assert_eq!(dispatch_psci(cpu_on, [1, 0x80000, 0, 0, 0, 0]), None);
+
+        let cpu_on32 = decode_hypercall_code(0x8400_0003, HyperCallAbi::AArch64).unwrap();
+        assert_eq!(dispatch_psci(cpu_on32, [1, 0x80000, 0, 0, 0, 0]), None);
+
+        let cpu_off = decode_hypercall_code(0x8400_0002, HyperCallAbi::AArch64).unwrap();
+        assert_eq!(dispatch_psci(cpu_off, [0; 6]), None);
+
+        let affinity_info = decode_hypercall_code(0xc400_0004, HyperCallAbi::AArch64).unwrap();
+        assert_eq!(dispatch_psci(affinity_info, [0, 0, 0, 0, 0, 0]), None);
+
+        let features = decode_hypercall_code(0x8400_000a, HyperCallAbi::AArch64).unwrap();
+        assert_eq!(
+            dispatch_psci(features, [0x8400_0000, 0, 0, 0, 0, 0]),
+            Some(Ok(PSCI_RET_SUCCESS))
+        );
+        assert_eq!(
+            dispatch_psci(features, [0x8400_ffff, 0, 0, 0, 0, 0]),
+            Some(Ok(PSCI_RET_NOT_SUPPORTED))
+        );
+    }
+
+    #[test]
+    fn generic_hvc_rejects_psci_function_ids() {
+        assert!(decode_hypercall_code(0x8400_0009, HyperCallAbi::Generic).is_err());
+        assert!(decode_hypercall_code(0x8400_0003, HyperCallAbi::Generic).is_err());
+        assert!(decode_hypercall_code(0xc400_0003, HyperCallAbi::Generic).is_err());
+    }
+
+    #[test]
+    fn hvc_decodes_cpu_suspend_extended_state_type() {
+        assert_eq!(psci_power_state_type(0), PSCI_POWER_STATE_TYPE_STANDBY);
+        assert_eq!(
+            psci_power_state_type(1 << 16),
+            PSCI_POWER_STATE_TYPE_POWERDOWN
+        );
+        assert_eq!(
+            psci_power_state_type(1 << 30),
+            PSCI_POWER_STATE_TYPE_STANDBY
+        );
+    }
+
+    #[test]
+    fn hvc_affinity_info_reports_cpu_on_pending_before_first_run() {
+        assert_eq!(
+            psci_affinity_info_result(crate::VmVcpuState::Starting),
+            PSCI_AFFINITY_LEVEL_ON_PENDING
+        );
+        assert_eq!(
+            psci_affinity_info_result(crate::VmVcpuState::Ready),
+            PSCI_AFFINITY_LEVEL_ON
+        );
+        assert_eq!(
+            psci_affinity_info_result(crate::VmVcpuState::Running),
+            PSCI_AFFINITY_LEVEL_ON
+        );
+        assert_eq!(
+            psci_affinity_info_result(crate::VmVcpuState::Free),
+            PSCI_AFFINITY_LEVEL_OFF
+        );
+    }
+
+    #[test]
+    fn hvc_cpu_on_matches_guest_mpidr_not_host_placement() {
+        let guest_mpidrs = [(0, 0x0), (1, 0x100)];
+
+        assert_eq!(psci_find_vcpu_by_mpidr(0x100, guest_mpidrs), Some(1));
+        assert_eq!(psci_find_vcpu_by_mpidr(5, guest_mpidrs), None);
+    }
+
+    #[test]
+    fn hvc_affinity_info_matches_requested_mpidr_level() {
+        let cpu0 = 0x0000_00ab_0002_0100;
+        let cpu1 = 0x0000_00ab_0002_0101;
+        let other_cluster = 0x0000_00ab_0002_0200;
+        let other_aff2 = 0x0000_00ab_0003_0100;
+
+        assert!(psci_mpidr_matches_affinity_level(cpu0, cpu0, 0));
+        assert!(!psci_mpidr_matches_affinity_level(cpu1, cpu0, 0));
+
+        assert!(psci_mpidr_matches_affinity_level(cpu0, cpu0, 1));
+        assert!(psci_mpidr_matches_affinity_level(cpu1, cpu0, 1));
+        assert!(!psci_mpidr_matches_affinity_level(other_cluster, cpu0, 1));
+
+        assert!(psci_mpidr_matches_affinity_level(other_cluster, cpu0, 2));
+        assert!(!psci_mpidr_matches_affinity_level(other_aff2, cpu0, 2));
+
+        assert!(!psci_mpidr_matches_affinity_level(cpu0, cpu0, 4));
+    }
+
+    #[test]
+    fn hvc_affinity_info_aggregates_nonzero_level_domain() {
+        let cpu0 = 0x0000_00ab_0002_0100;
+        let cpu1 = 0x0000_00ab_0002_0101;
+        let other_cluster = 0x0000_00ab_0002_0200;
+
+        assert_eq!(
+            psci_affinity_info_result_for_domain(
+                cpu0,
+                1,
+                [
+                    (cpu0, crate::VmVcpuState::Free),
+                    (cpu1, crate::VmVcpuState::Starting),
+                    (other_cluster, crate::VmVcpuState::Ready),
+                ],
+            ),
+            PSCI_AFFINITY_LEVEL_ON_PENDING
+        );
+
+        assert_eq!(
+            psci_affinity_info_result_for_domain(
+                cpu0,
+                1,
+                [
+                    (cpu0, crate::VmVcpuState::Free),
+                    (cpu1, crate::VmVcpuState::Ready),
+                ],
+            ),
+            PSCI_AFFINITY_LEVEL_ON
+        );
+
+        assert_eq!(
+            psci_affinity_info_result_for_domain(
+                cpu0,
+                1,
+                [
+                    (cpu0, crate::VmVcpuState::Free),
+                    (cpu1, crate::VmVcpuState::Free),
+                ],
+            ),
+            PSCI_AFFINITY_LEVEL_OFF
+        );
+
+        assert_eq!(
+            psci_affinity_info_result_for_domain(
+                cpu0,
+                1,
+                [(other_cluster, crate::VmVcpuState::Ready)],
+            ),
+            PSCI_RET_INVALID_PARAMETERS
+        );
+    }
+
+    #[test]
+    fn hvc_decodes_unsupported_psci_migration_calls() {
+        for raw_code in [0x8400_0005, 0x8400_0007, 0xc400_0005, 0xc400_0007] {
+            let code = decode_hypercall_code(raw_code, HyperCallAbi::AArch64).unwrap();
+
+            assert_eq!(
+                dispatch_psci(code, [0; 6]),
+                Some(Ok(PSCI_RET_NOT_SUPPORTED))
+            );
+            assert_eq!(psci_feature_result(raw_code), PSCI_RET_NOT_SUPPORTED);
+        }
+    }
+
+    #[test]
+    fn hvc_advertises_system_reset_as_required_psci_0_2_call() {
+        assert_eq!(psci_feature_result(0x8400_0009), PSCI_RET_SUCCESS);
+    }
+
+    #[test]
+    fn hvc_psci_features_cover_implemented_0_2_surface() {
+        let features = HyperCallCode::PSCIFeatures;
+        let supported = [
+            0x8400_0000, // PSCI_VERSION
+            0x8400_0001, // PSCI_CPU_SUSPEND
+            0x8400_0002, // PSCI_CPU_OFF
+            0x8400_0003, // PSCI_CPU_ON
+            0x8400_0004, // PSCI_AFFINITY_INFO
+            0x8400_0006, // PSCI_MIGRATE_INFO_TYPE
+            0x8400_0008, // PSCI_SYSTEM_OFF
+            0x8400_0009, // PSCI_SYSTEM_RESET
+            0x8400_000a, // PSCI_FEATURES
+            0xc400_0001, // PSCI_CPU_SUSPEND64
+            0xc400_0003, // PSCI_CPU_ON64
+            0xc400_0004, // PSCI_AFFINITY_INFO64
+        ];
+
+        for raw_code in supported {
+            assert_eq!(psci_feature_result(raw_code), PSCI_RET_SUCCESS);
+            assert_eq!(
+                dispatch_psci(features, [raw_code, 0, 0, 0, 0, 0]),
+                Some(Ok(PSCI_RET_SUCCESS))
+            );
+        }
+
+        let unsupported = [
+            0x8400_0005, // PSCI_MIGRATE
+            0x8400_0007, // PSCI_MIGRATE_INFO_UP_CPU
+            0xc400_0005, // PSCI_MIGRATE64
+            0xc400_0007, // PSCI_MIGRATE_INFO_UP_CPU64
+        ];
+
+        for raw_code in unsupported {
+            assert_eq!(psci_feature_result(raw_code), PSCI_RET_NOT_SUPPORTED);
+            assert_eq!(
+                dispatch_psci(features, [raw_code, 0, 0, 0, 0, 0]),
+                Some(Ok(PSCI_RET_NOT_SUPPORTED))
+            );
+        }
+    }
+
+    #[test]
+    fn hvc_rejects_unknown_psci_function_ids() {
+        assert!(decode_hypercall_code(0x8400_ffff, HyperCallAbi::AArch64).is_err());
     }
 }

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::format;
+use alloc::{format, sync::Arc};
 
 use crate::{
     AsVCpuTask, AxVmResult, GuestPhysAddr, StopReason, VCpuTask, VmStatus, VmVcpuState,
@@ -181,6 +181,89 @@ fn mark_vcpu_running(vm: &VMRef) {
     });
 }
 
+#[cfg(test)]
+type CpuOnStartAckLock<T> = std::sync::Mutex<T>;
+#[cfg(not(test))]
+type CpuOnStartAckLock<T> = ax_kspin::SpinNoIrq<T>;
+
+#[allow(dead_code)]
+pub(crate) struct CpuOnStartAck {
+    inner: CpuOnStartAckLock<CpuOnStartAckInner>,
+}
+
+struct CpuOnStartAckInner {
+    started: bool,
+    cancelled: bool,
+    result: Option<crate::AxVmResult>,
+}
+
+#[allow(dead_code)]
+impl CpuOnStartAck {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: CpuOnStartAckLock::new(CpuOnStartAckInner {
+                started: false,
+                cancelled: false,
+                result: None,
+            }),
+        }
+    }
+
+    pub(crate) fn begin_startup(&self) -> bool {
+        let mut inner = self.lock_inner();
+        if inner.cancelled {
+            false
+        } else {
+            inner.started = true;
+            true
+        }
+    }
+
+    pub(crate) fn cancel_before_startup(&self) -> bool {
+        let mut inner = self.lock_inner();
+        if inner.started || inner.result.is_some() {
+            false
+        } else {
+            inner.cancelled = true;
+            true
+        }
+    }
+
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.lock_inner().cancelled
+    }
+
+    pub(crate) fn complete(&self, result: crate::AxVmResult) {
+        self.lock_inner().result = Some(result);
+    }
+
+    pub(crate) fn is_complete(&self) -> bool {
+        self.lock_inner().result.is_some()
+    }
+
+    pub(crate) fn take_result(&self) -> Option<crate::AxVmResult> {
+        self.lock_inner().result.take()
+    }
+
+    #[cfg(test)]
+    fn lock_inner(&self) -> impl core::ops::DerefMut<Target = CpuOnStartAckInner> + '_ {
+        self.inner.lock().unwrap()
+    }
+
+    #[cfg(not(test))]
+    fn lock_inner(&self) -> impl core::ops::DerefMut<Target = CpuOnStartAckInner> + '_ {
+        self.inner.lock()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[allow(dead_code)]
+pub(crate) enum VcpuOnError {
+    AlreadyOn,
+    OnPending,
+    StartFailed,
+}
+
 /// Boot target VCpu on the specified VM.
 /// This function is used to boot a secondary VCpu on a VM, setting the entry point and argument for the VCpu.
 ///
@@ -190,45 +273,108 @@ fn mark_vcpu_running(vm: &VMRef) {
 /// * `vcpu_id` - The ID of the VCpu to be booted.
 /// * `entry_point` - The entry point of the VCpu.
 /// * `arg` - The argument to be passed to the VCpu.
-#[expect(
-    dead_code,
-    reason = "only non-x86 guest firmware boots secondary vCPUs"
-)]
+#[allow(dead_code)]
 pub(crate) fn vcpu_on(
     vm: VMRef,
     vcpu_id: usize,
     entry_point: GuestPhysAddr,
     arg: usize,
-) -> AxVmResult {
+) -> Result<(), VcpuOnError> {
     let vcpu = vm
         .vcpu_list()
         .get(vcpu_id)
         .cloned()
-        .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} not found")))?;
-    if vcpu.state() != VmVcpuState::Free {
-        return Err(ax_err_type!(
-            BadState,
-            format!("vCPU {} invalid state {:?}", vcpu.id(), vcpu.state())
-        ));
+        .ok_or(VcpuOnError::StartFailed)?;
+
+    match vcpu.state() {
+        VmVcpuState::Free => {}
+        VmVcpuState::Starting => return Err(VcpuOnError::OnPending),
+        VmVcpuState::Ready | VmVcpuState::Running => return Err(VcpuOnError::AlreadyOn),
+        _ => return Err(VcpuOnError::StartFailed),
     }
 
-    vcpu.set_entry(entry_point)?;
-    CurrentArch::set_vcpu_on_args(&vcpu, vcpu_id, arg);
+    vcpu.reserve_for_cpu_on()
+        .map_err(|_| VcpuOnError::OnPending)?;
 
-    let vcpu_task = alloc_vcpu_task(&vm, vcpu);
-    vm.with_runtime(|runtime| {
-        runtime.add_vcpu_task(vcpu_id, vcpu_task);
+    let start_result = (|| {
+        let runtime = vm
+            .with_runtime(|runtime| Ok(runtime.clone()))
+            .map_err(|_| VcpuOnError::StartFailed)?;
+        if runtime.has_vcpu_task(vcpu_id) {
+            return Err(VcpuOnError::StartFailed);
+        }
+
+        vcpu.set_entry(entry_point)
+            .map_err(|_| VcpuOnError::StartFailed)?;
+        CurrentArch::set_vcpu_on_args(&vcpu, vcpu_id, arg);
+
+        let ack = Arc::new(CpuOnStartAck::new());
+        runtime
+            .insert_cpu_on_start_ack(vcpu_id, ack.clone())
+            .map_err(|_| VcpuOnError::StartFailed)?;
+
+        let vcpu_task = alloc_vcpu_task(&vm, vcpu.clone());
+        if runtime.add_vcpu_task(vcpu_id, vcpu_task).is_err() {
+            runtime.remove_cpu_on_start_ack(vcpu_id);
+            return Err(VcpuOnError::StartFailed);
+        }
+        runtime.notify_all();
+
+        runtime.wait_until(|| ack.is_complete() || !vm.running());
+
+        if !ack.is_complete() && !vm.running() {
+            if ack.cancel_before_startup() {
+                runtime.notify_all();
+
+                if let Some(task) = runtime.remove_vcpu_task(vcpu_id) {
+                    let _ = task.join();
+                }
+
+                runtime.remove_cpu_on_start_ack(vcpu_id);
+                return Err(VcpuOnError::StartFailed);
+            }
+
+            runtime.wait_until(|| ack.is_complete());
+        }
+
+        let result = ack.take_result().unwrap_or_else(|| {
+            Err(ax_err_type!(
+                BadState,
+                format!("vCPU {vcpu_id} CPU_ON startup did not complete")
+            ))
+        });
+        runtime.remove_cpu_on_start_ack(vcpu_id);
+
+        if result.is_err() {
+            runtime.remove_vcpu_task(vcpu_id);
+            return Err(VcpuOnError::StartFailed);
+        }
+
         Ok(())
-    })?;
-    Ok(())
-}
+    })();
 
-#[expect(
-    dead_code,
-    reason = "only non-x86 guest firmware boots secondary vCPUs"
-)]
+    if start_result.is_err() && vcpu.state() == VmVcpuState::Starting {
+        vcpu.rollback_cpu_on();
+    }
+    start_result
+}
+#[allow(dead_code)]
 pub(crate) fn alloc_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::AxTaskRef {
     crate::host::task::spawn_task(build_vcpu_task(vm, vcpu))
+}
+
+fn spawn_deferred_reset_task(vm_id: usize) {
+    let reset_task = crate::TaskInner::new(
+        move || {
+            if let Err(err) = crate::runtime::reset_vm(vm_id) {
+                warn!("VM[{vm_id}] deferred reset failed: {err:?}");
+                crate::host::task::wait_queue_wake(&super::VMM, 1);
+            }
+        },
+        format!("VM[{vm_id}]-reset"),
+        KERNEL_STACK_SIZE,
+    );
+    crate::host::task::spawn_task(reset_task);
 }
 
 pub(crate) fn build_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::TaskInner {
@@ -304,16 +450,82 @@ fn vcpu_run() {
     };
 
     info!("VM[{}] VCpu[{}] waiting for running", vm.id(), vcpu.id());
-    wait_for(&runtime, || vm.running());
+    let cpu_on_start_ack = runtime.cpu_on_start_ack(vcpu_id);
+    wait_for(&runtime, || {
+        vm.running()
+            || cpu_on_start_ack
+                .as_ref()
+                .is_some_and(|ack| ack.is_cancelled())
+    });
+
+    if let Some(ack) = &cpu_on_start_ack {
+        if !ack.begin_startup() {
+            ack.complete(Err(ax_err_type!(
+                BadState,
+                format!("vCPU {vcpu_id} CPU_ON startup was cancelled")
+            )));
+            runtime.notify_all();
+            return;
+        }
+
+        match vcpu.bind_after_cpu_on_or_rollback() {
+            Ok(()) => {
+                CurrentArch::before_first_run(&vm, &vcpu);
+                runtime.publish_cpu_on_start_success(ack);
+                runtime.notify_all();
+            }
+            Err(err) => {
+                ack.complete(Err(err));
+                runtime.notify_all();
+                runtime.remove_cpu_on_start_ack(vcpu_id);
+                runtime.remove_vcpu_task(vcpu_id);
+                return;
+            }
+        }
+    } else {
+        CurrentArch::before_first_run(&vm, &vcpu);
+        mark_vcpu_running(&vm);
+    }
 
     info!("VM[{}] VCpu[{}] running...", vm.id(), vcpu.id());
-    CurrentArch::before_first_run(&vm, &vcpu);
-    mark_vcpu_running(&vm);
 
     loop {
         CurrentArch::before_vcpu_run(&vm, &vcpu);
 
         match CurrentArch::run_vcpu(&vm, &vcpu) {
+            Ok(VcpuRunAction {
+                exits_vcpu: true, ..
+            }) => {
+                if let Err(err) = vcpu.power_off_after_cpu_off() {
+                    warn!("VM[{vm_id}] VCpu[{vcpu_id}] CPU_OFF cleanup failed: {err:?}");
+                }
+                runtime.remove_vcpu_task(vcpu_id);
+                if !runtime.consume_cpu_off_reservation(vcpu_id) {
+                    let _ = runtime.mark_vcpu_exiting();
+                }
+                break;
+            }
+            Ok(VcpuRunAction {
+                resets_vm: true, ..
+            }) => {
+                if runtime.request_deferred_reset()
+                    && let Err(err) = vm.stop(StopReason::Forced)
+                {
+                    if vm.stopping() {
+                        warn!("VM[{vm_id}] reset requested while VM is already stopping: {err:?}");
+                    } else {
+                        let _ = runtime.take_deferred_reset_request();
+                        warn!("VM[{vm_id}] failed to request deferred reset stop: {err:?}");
+                        if let Err(stop_err) = vm.stop(StopReason::Fault(format!("{err:?}"))) {
+                            warn!(
+                                "VM[{vm_id}] shutdown after reset request failure failed: \
+                                 {stop_err:?}"
+                            );
+                        }
+                    }
+                }
+                notify_all_vcpus(vm_id);
+            }
             Ok(VcpuRunAction {
                 stop_reason: Some(reason),
                 ..
@@ -357,6 +569,7 @@ fn vcpu_run() {
             );
 
             if runtime.mark_vcpu_exiting() {
+                let reset_after_stop = runtime.take_deferred_reset_request();
                 info!("VM[{vm_id}] VCpu[{vcpu_id}] last VCpu exiting, decreasing running VM count");
 
                 if let Err(err) = vm.finish_stop() {
@@ -367,7 +580,11 @@ fn vcpu_run() {
                 CurrentArch::on_last_vcpu_exit(&vm);
 
                 sub_running_vm_count(1);
-                crate::host::task::wait_queue_wake(&super::VMM, 1);
+                if reset_after_stop {
+                    spawn_deferred_reset_task(vm_id);
+                } else {
+                    crate::host::task::wait_queue_wake(&super::VMM, 1);
+                }
             }
 
             break;
@@ -375,4 +592,27 @@ fn vcpu_run() {
     }
 
     info!("VM[{}] VCpu[{}] exiting...", vm_id, vcpu_id);
+}
+
+#[cfg(test)]
+mod cpu_on_start_ack_tests {
+
+    use super::*;
+
+    #[test]
+    fn cpu_on_start_ack_cancel_before_startup_blocks_late_startup() {
+        let ack = CpuOnStartAck::new();
+
+        assert!(ack.cancel_before_startup());
+        assert!(ack.is_cancelled());
+        assert!(!ack.begin_startup());
+
+        ack.complete(Err(ax_err_type!(
+            BadState,
+            "vCPU 1 CPU_ON startup was cancelled"
+        )));
+
+        assert!(ack.is_complete());
+        assert!(ack.take_result().unwrap().is_err());
+    }
 }

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -92,6 +92,55 @@ struct AxVCpuInnerConst {
     vm_id: VMId,
     vcpu_id: VCpuId,
     phys_cpu_set: Option<usize>,
+    guest_mpidr: Option<u64>,
+}
+
+#[allow(dead_code)]
+fn reserve_cpu_on_state(state: &mut VmVcpuState) -> AxVmResult {
+    if *state != VmVcpuState::Free {
+        let current_state = *state;
+        return ax_err!(
+            BadState,
+            format!("VCpu state is not Free, but {current_state:?}")
+        );
+    }
+    *state = VmVcpuState::Starting;
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn rollback_cpu_on_state(state: &mut VmVcpuState) {
+    if *state == VmVcpuState::Starting {
+        *state = VmVcpuState::Free;
+    }
+}
+
+fn finish_cpu_on_start_state(state: &mut VmVcpuState, bind_succeeded: bool) -> AxVmResult {
+    if *state != VmVcpuState::Starting {
+        let current_state = *state;
+        return ax_err!(
+            BadState,
+            format!("VCpu state is not Starting, but {current_state:?}")
+        );
+    }
+    *state = if bind_succeeded {
+        VmVcpuState::Ready
+    } else {
+        VmVcpuState::Free
+    };
+    Ok(())
+}
+
+fn cpu_off_state(state: &mut VmVcpuState) -> AxVmResult {
+    if *state != VmVcpuState::Ready {
+        let current_state = *state;
+        return ax_err!(
+            BadState,
+            format!("VCpu state is not Ready, but {current_state:?}")
+        );
+    }
+    *state = VmVcpuState::Free;
+    Ok(())
 }
 
 /// AxVM-owned architecture-independent vCPU wrapper.
@@ -109,11 +158,13 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
         phys_cpu_set: Option<usize>,
         arch_config: A::CreateConfig,
     ) -> AxVmResult<Self> {
+        let guest_mpidr = A::guest_mpidr_from_create_config(&arch_config);
         Ok(Self {
             inner_const: AxVCpuInnerConst {
                 vm_id,
                 vcpu_id,
                 phys_cpu_set,
+                guest_mpidr,
             },
             inner_mut: Mutex::new(AxVCpuInnerMut {
                 state: VmVcpuState::Created,
@@ -161,9 +212,57 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
         self.inner_const.phys_cpu_set
     }
 
+    /// Returns the guest-visible MPIDR affinity for this vCPU, when the architecture has one.
+    pub const fn guest_mpidr(&self) -> Option<u64> {
+        self.inner_const.guest_mpidr
+    }
+
     /// Returns the current vCPU state.
     pub fn state(&self) -> VmVcpuState {
         self.inner_mut.lock().state
+    }
+
+    /// Reserves a free vCPU for PSCI CPU_ON.
+    #[allow(dead_code)]
+    pub(crate) fn reserve_for_cpu_on(&self) -> AxVmResult {
+        let mut inner_mut = self.inner_mut.lock();
+        reserve_cpu_on_state(&mut inner_mut.state)
+    }
+
+    /// Binds a CPU_ON-started vCPU and rolls it back to Free if bind fails.
+    pub(crate) fn bind_after_cpu_on_or_rollback(&self) -> AxVmResult {
+        {
+            let inner_mut = self.inner_mut.lock();
+            if inner_mut.state != VmVcpuState::Starting {
+                let current_state = inner_mut.state;
+                return ax_err!(
+                    BadState,
+                    format!("VCpu state is not Starting, but {current_state:?}")
+                );
+            }
+        }
+
+        let result = self.with_current_cpu_set(|| {
+            self.get_arch_vcpu()
+                .bind()
+                .map_err(|error| map_vcpu_backend_error("bind vCPU", error))
+        });
+        let bind_succeeded = result.is_ok();
+        finish_cpu_on_start_state(&mut self.inner_mut.lock().state, bind_succeeded)?;
+        result
+    }
+
+    /// Rolls a failed PSCI CPU_ON reservation back to Free.
+    #[allow(dead_code)]
+    pub(crate) fn rollback_cpu_on(&self) {
+        let mut inner_mut = self.inner_mut.lock();
+        rollback_cpu_on_state(&mut inner_mut.state);
+    }
+
+    /// Powers off a vCPU after PSCI CPU_OFF so it can be started again.
+    pub(crate) fn power_off_after_cpu_off(&self) -> AxVmResult {
+        let mut inner_mut = self.inner_mut.lock();
+        cpu_off_state(&mut inner_mut.state)
     }
 
     /// Runs `f` if the current state equals `from`, then stores `to`.
@@ -284,10 +383,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     }
 
     /// Sets the guest entry point.
-    #[expect(
-        dead_code,
-        reason = "only non-x86 guest firmware updates secondary vCPU entries"
-    )]
+    #[allow(dead_code)]
     pub fn set_entry(&self, entry: GuestPhysAddr) -> AxVmResult {
         self.get_arch_vcpu()
             .set_entry(entry)
@@ -468,6 +564,77 @@ fn map_interrupt_backend_error(operation: &'static str, error: VmBackendError) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn vcpu_cpu_on_reservation_moves_free_to_starting() {
+        let mut state = VmVcpuState::Free;
+
+        reserve_cpu_on_state(&mut state).unwrap();
+
+        assert_eq!(state, VmVcpuState::Starting);
+        assert!(reserve_cpu_on_state(&mut state).is_err());
+        assert_eq!(state, VmVcpuState::Starting);
+    }
+
+    #[test]
+    fn vcpu_cpu_on_rollback_restores_starting_to_free() {
+        let mut state = VmVcpuState::Starting;
+
+        rollback_cpu_on_state(&mut state);
+
+        assert_eq!(state, VmVcpuState::Free);
+        rollback_cpu_on_state(&mut state);
+        assert_eq!(state, VmVcpuState::Free);
+    }
+
+    #[test]
+    fn vcpu_cpu_on_start_success_moves_starting_to_ready() {
+        let mut state = VmVcpuState::Starting;
+
+        finish_cpu_on_start_state(&mut state, true).unwrap();
+
+        assert_eq!(state, VmVcpuState::Ready);
+    }
+
+    #[test]
+    fn vcpu_cpu_on_start_failure_restores_starting_to_free() {
+        let mut state = VmVcpuState::Starting;
+
+        finish_cpu_on_start_state(&mut state, false).unwrap();
+
+        assert_eq!(state, VmVcpuState::Free);
+    }
+
+    #[test]
+    fn vcpu_cpu_off_returns_ready_to_free_for_reon() {
+        let mut state = VmVcpuState::Free;
+
+        reserve_cpu_on_state(&mut state).unwrap();
+        assert_eq!(state, VmVcpuState::Starting);
+
+        state = VmVcpuState::Ready;
+        cpu_off_state(&mut state).unwrap();
+        assert_eq!(state, VmVcpuState::Free);
+
+        reserve_cpu_on_state(&mut state).unwrap();
+        assert_eq!(state, VmVcpuState::Starting);
+    }
+
+    #[test]
+    fn vcpu_cpu_off_rejects_non_ready_states() {
+        for initial_state in [
+            VmVcpuState::Created,
+            VmVcpuState::Free,
+            VmVcpuState::Starting,
+            VmVcpuState::Running,
+            VmVcpuState::Invalid,
+        ] {
+            let mut state = initial_state;
+
+            assert!(cpu_off_state(&mut state).is_err());
+            assert_eq!(state, initial_state);
+        }
+    }
 
     #[test]
     fn vcpu_backend_errors_keep_domain_context() {

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -14,10 +14,17 @@
 
 //! Virtual machine state, resources, and lifecycle entry points.
 
-use alloc::{boxed::Box, collections::BTreeMap, format, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    format,
+    string::String,
+    sync::Arc,
+    vec::Vec,
+};
 use core::{
     alloc::Layout,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use ax_cpumask::CpuMask;
@@ -180,9 +187,12 @@ pub(crate) enum PendingInterrupt {
 pub(crate) struct VmRuntimeHandle {
     wait_queue: crate::WaitQueue,
     vcpu_task_list: Mutex<BTreeMap<usize, crate::AxTaskRef>>,
+    cpu_on_start_acks: Mutex<BTreeMap<usize, Arc<crate::runtime::vcpus::CpuOnStartAck>>>,
+    cpu_off_exit_reservations: Mutex<BTreeSet<usize>>,
     pending_interrupts: Mutex<BTreeMap<usize, Vec<PendingInterrupt>>>,
-    irq_dispatcher: VcpuIrqDispatcher,
+    irq_dispatcher: crate::runtime::VcpuIrqDispatcher,
     running_halting_vcpu_count: AtomicUsize,
+    deferred_reset_requested: AtomicBool,
 }
 
 pub(crate) fn dispatch_vcpu_interrupt_with(
@@ -208,17 +218,70 @@ impl VmRuntimeHandle {
         Self {
             wait_queue: crate::WaitQueue::new(),
             vcpu_task_list: Mutex::new(BTreeMap::new()),
+            cpu_on_start_acks: Mutex::new(BTreeMap::new()),
+            cpu_off_exit_reservations: Mutex::new(BTreeSet::new()),
             pending_interrupts: Mutex::new(BTreeMap::new()),
-            irq_dispatcher: VcpuIrqDispatcher::new(),
+            irq_dispatcher: crate::runtime::VcpuIrqDispatcher::new(),
             running_halting_vcpu_count: AtomicUsize::new(0),
+            deferred_reset_requested: AtomicBool::new(false),
         }
     }
 
-    pub(crate) fn add_vcpu_task(&self, vcpu_id: usize, vcpu_task: crate::AxTaskRef) {
+    #[allow(dead_code)]
+    pub(crate) fn has_vcpu_task(&self, vcpu_id: usize) -> bool {
+        self.vcpu_task_list.lock().contains_key(&vcpu_id)
+    }
+
+    pub(crate) fn add_vcpu_task(&self, vcpu_id: usize, vcpu_task: crate::AxTaskRef) -> AxVmResult {
+        let mut vcpu_task_list = self.vcpu_task_list.lock();
+        if vcpu_task_list.contains_key(&vcpu_id) {
+            return ax_err!(BadState, format!("vCPU {vcpu_id} task already exists"));
+        }
+
         self.irq_dispatcher
             .register_vcpu_task(vcpu_id, vcpu_task.clone());
-        self.vcpu_task_list.lock().insert(vcpu_id, vcpu_task);
+        vcpu_task_list.insert(vcpu_id, vcpu_task);
+        drop(vcpu_task_list);
+
         self.pending_interrupts.lock().entry(vcpu_id).or_default();
+        Ok(())
+    }
+
+    pub(crate) fn remove_cpu_on_start_ack(
+        &self,
+        vcpu_id: usize,
+    ) -> Option<Arc<crate::runtime::vcpus::CpuOnStartAck>> {
+        self.cpu_on_start_acks.lock().remove(&vcpu_id)
+    }
+
+    pub(crate) fn remove_vcpu_task(&self, vcpu_id: usize) -> Option<crate::AxTaskRef> {
+        self.pending_interrupts.lock().remove(&vcpu_id);
+        self.irq_dispatcher.unregister_vcpu_task(vcpu_id);
+        self.vcpu_task_list.lock().remove(&vcpu_id)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn insert_cpu_on_start_ack(
+        &self,
+        vcpu_id: usize,
+        ack: Arc<crate::runtime::vcpus::CpuOnStartAck>,
+    ) -> AxVmResult {
+        let mut acks = self.cpu_on_start_acks.lock();
+        if acks.contains_key(&vcpu_id) {
+            return ax_err!(
+                AlreadyExists,
+                format!("vCPU {vcpu_id} CPU_ON ack already exists")
+            );
+        }
+        acks.insert(vcpu_id, ack);
+        Ok(())
+    }
+
+    pub(crate) fn cpu_on_start_ack(
+        &self,
+        vcpu_id: usize,
+    ) -> Option<Arc<crate::runtime::vcpus::CpuOnStartAck>> {
+        self.cpu_on_start_acks.lock().get(&vcpu_id).cloned()
     }
 
     pub(crate) fn queue_interrupt(&self, vcpu_id: usize, vector: usize) -> AxVmResult<usize> {
@@ -321,12 +384,43 @@ impl VmRuntimeHandle {
             .fetch_add(1, Ordering::Relaxed);
     }
 
+    pub(crate) fn publish_cpu_on_start_success(&self, ack: &crate::runtime::vcpus::CpuOnStartAck) {
+        self.mark_vcpu_running();
+        ack.complete(Ok(()));
+    }
+
     pub(crate) fn mark_vcpu_exiting(&self) -> bool {
         self.running_halting_vcpu_count
             .try_update(Ordering::Relaxed, Ordering::Relaxed, |count| {
                 count.checked_sub(1)
             })
             == Ok(1)
+    }
+
+    pub(crate) fn request_deferred_reset(&self) -> bool {
+        !self.deferred_reset_requested.swap(true, Ordering::AcqRel)
+    }
+
+    pub(crate) fn take_deferred_reset_request(&self) -> bool {
+        self.deferred_reset_requested.swap(false, Ordering::AcqRel)
+    }
+
+    pub(crate) fn try_reserve_cpu_off(&self, vcpu_id: usize) -> bool {
+        let reserved = self
+            .running_halting_vcpu_count
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                (count > 1).then_some(count - 1)
+            })
+            .is_ok();
+
+        if reserved {
+            self.cpu_off_exit_reservations.lock().insert(vcpu_id);
+        }
+        reserved
+    }
+
+    pub(crate) fn consume_cpu_off_reservation(&self, vcpu_id: usize) -> bool {
+        self.cpu_off_exit_reservations.lock().remove(&vcpu_id)
     }
 
     pub(crate) fn join_all_vcpu_tasks(&self, vm_id: usize) {
@@ -351,6 +445,90 @@ impl VmRuntimeHandle {
             debug!("VM[{vm_id}] VCpu task[{idx}] exited with code: {exit_code}");
         }
         info!("VM[{vm_id}] VCpu resources cleaned up, {task_count} VCpu tasks joined");
+    }
+}
+
+#[cfg(all(test, feature = "host-test"))]
+mod runtime_handle_tests {
+
+    #[test]
+    fn runtime_cpu_on_success_publishes_online_count_before_ack() {
+        let runtime = VmRuntimeHandle::new();
+        let ack = crate::runtime::vcpus::CpuOnStartAck::new();
+
+        runtime.mark_vcpu_running();
+        assert!(ack.begin_startup());
+
+        runtime.publish_cpu_on_start_success(&ack);
+
+        assert!(ack.is_complete());
+        assert!(runtime.try_reserve_cpu_off(0));
+    }
+
+    #[test]
+    fn runtime_cpu_on_ack_rejects_duplicate_and_can_be_removed() {
+        let runtime = VmRuntimeHandle::new();
+        let first = Arc::new(crate::runtime::vcpus::CpuOnStartAck::new());
+        let second = Arc::new(crate::runtime::vcpus::CpuOnStartAck::new());
+
+        assert!(runtime.insert_cpu_on_start_ack(1, first.clone()).is_ok());
+        assert!(runtime.insert_cpu_on_start_ack(1, second).is_err());
+
+        let stored = runtime.cpu_on_start_ack(1).unwrap();
+        assert!(Arc::ptr_eq(&stored, &first));
+
+        assert!(runtime.remove_cpu_on_start_ack(1).is_some());
+        assert!(runtime.cpu_on_start_ack(1).is_none());
+    }
+
+    #[test]
+    fn runtime_deferred_reset_request_is_single_consumer() {
+        let runtime = VmRuntimeHandle::new();
+
+        assert!(!runtime.take_deferred_reset_request());
+        assert!(runtime.request_deferred_reset());
+        assert!(!runtime.request_deferred_reset());
+        assert!(runtime.take_deferred_reset_request());
+        assert!(!runtime.take_deferred_reset_request());
+        assert!(runtime.request_deferred_reset());
+    }
+
+    #[test]
+    fn runtime_cpu_off_reservation_rejects_second_parallel_last_vcpu() {
+        let runtime = VmRuntimeHandle::new();
+
+        runtime.mark_vcpu_running();
+        runtime.mark_vcpu_running();
+
+        assert!(runtime.try_reserve_cpu_off(0));
+        assert!(!runtime.try_reserve_cpu_off(1));
+
+        assert!(runtime.consume_cpu_off_reservation(0));
+        assert!(!runtime.consume_cpu_off_reservation(0));
+
+        assert!(runtime.mark_vcpu_exiting());
+    }
+
+    use super::*;
+
+    #[test]
+    fn remove_vcpu_task_clears_pending_interrupts_and_dispatcher_registration() {
+        let runtime = VmRuntimeHandle::new();
+
+        runtime.pending_interrupts.lock().entry(3).or_default();
+        runtime.irq_dispatcher.register_test_vcpu(3, 11);
+
+        assert!(runtime.pending_interrupts.lock().contains_key(&3));
+        assert_eq!(runtime.irq_dispatcher.test_lookup_cpu_id(3).unwrap(), 11);
+
+        runtime.remove_vcpu_task(3);
+
+        assert!(!runtime.pending_interrupts.lock().contains_key(&3));
+        assert!(runtime.irq_dispatcher.test_lookup_cpu_id(3).is_err());
+
+        runtime.remove_vcpu_task(3);
+        assert!(!runtime.pending_interrupts.lock().contains_key(&3));
+        assert!(runtime.irq_dispatcher.test_lookup_cpu_id(3).is_err());
     }
 }
 
@@ -804,7 +982,7 @@ impl AxVM {
         })?;
 
         let task = crate::host::task::spawn_task(primary_task);
-        runtime.add_vcpu_task(0, task);
+        runtime.add_vcpu_task(0, task)?;
         Ok(())
     }
 
@@ -1173,6 +1351,13 @@ impl AxVM {
     pub fn get_vcpu_affinities_pcpu_ids(&self) -> Vec<(usize, Option<usize>, usize)> {
         self.with_resources(|resources| Ok(resources.phys_cpu_ls.get_vcpu_affinities_pcpu_ids()))
             .unwrap_or_default()
+    }
+
+    pub fn get_vcpu_guest_mpidrs(&self) -> Vec<(usize, u64)> {
+        self.vcpu_list()
+            .iter()
+            .filter_map(|vcpu| vcpu.guest_mpidr().map(|mpidr| (vcpu.id(), mpidr)))
+            .collect()
     }
 
     /// Maps a region of host physical memory to guest physical memory.


### PR DESCRIPTION
## Problems

AArch64 客体在启动早期会通过 HVC 调用 `PSCI_VERSION`（`0x84000000`）查询 PSCI 版本。原有路径没有正确处理该调用，导致客体收到无效的 hypercall 返回值，RT-Thread 等客体无法继续完成启动阶段的 PSCI 探测。

在补齐 `PSCI_VERSION` 后，客体后续使用的 PSCI CPU 电源管理和系统复位路径也需要由 AxVM runtime 统一处理，否则 `CPU_ON`、`CPU_OFF` 以及系统复位等调用无法和 vCPU 生命周期保持一致。

## Changes

- 将 AArch64 PSCI/SMCCC HVC 调用接入 AxVM runtime。
- 支持 `PSCI_VERSION`，返回 PSCI 0.2。
- 通过 `PSCI_FEATURES` 报告当前已实现的 PSCI 调用。
- 添加 `CPU_ON`，包括目标 guest MPIDR 匹配、启动预约、启动确认和失败回滚。
- 添加 `CPU_OFF`，只停止当前 vCPU，不会在其他 vCPU 仍运行时停止整个 VM。
- 添加 `CPU_SUSPEND` 和 `AFFINITY_INFO`。
- 添加 `SYSTEM_OFF` 和延迟处理的 `SYSTEM_RESET`。
- 补充 vCPU 启动、停止和复位所需的生命周期状态管理。
- 从 `ArmVcpuCreateConfig` 发布 AArch64 guest MPIDR，保证 `CPU_ON` 可以找到正确的次级 vCPU。
- 修改 `roc-rk3568` 的 `linux-smp1.dts`，移除 guest 无法使用的 CPU cpufreq/OPP 相关属性，避免启动阶段进入不支持的 Rockchip 电源管理路径。

普通 IVC hypercall 路径没有修改，非 AArch64 架构仍通过现有架构抽象保持隔离。本 PR 不涉及 Starry 用户态 ABI，也不实现 Rockchip cpufreq、OPP 或 regulator 的硬件虚拟化。

## Testing

当前 head：

`343568a4b07a05e005c2db1bf893ea9f00a959a3`

已通过以下本地检查：

```text
git diff --check
cargo fmt --all -- --check
cargo test --manifest-path virtualization/axvm/Cargo.toml --all-features