### PR TITLE
feat(rsext4): filesystem cache optimizations and SDHCI driver

### DIFF
--- a/components/axklib/src/dma.rs
+++ b/components/axklib/src/dma.rs
@@ -132,11 +132,34 @@ impl DmaOp for KlibDma {
         layout: Layout,
     ) -> Option<DmaAllocHandle> {
         let pages = unsafe { DmaPages::alloc_for_layout(constraints, layout).ok()? };
+        // On RISC-V the dma-api `op::arch` cache hooks are no-ops (no CMO
+        // support is wired in), so a cached contiguous buffer would be
+        // incoherent with device DMA on the non-coherent C906. Remap it
+        // uncached — the same policy as `alloc_coherent` — so streaming and
+        // bounce buffers used by ADMA2 are correct. aarch64 keeps the cached
+        // + `sync_*` path because its `op::arch` performs real cache
+        // maintenance.
+        #[cfg(target_arch = "riscv64")]
+        {
+            if CoherentDmaPolicy::make_uncached(&pages, layout).is_err() {
+                unsafe { DmaPages::dealloc_pages(pages.cpu_addr, pages.num_pages) };
+                return None;
+            }
+        }
         Some(unsafe { DmaAllocHandle::new(pages.cpu_addr, pages.dma_addr.into(), layout) })
     }
 
     unsafe fn dealloc_contiguous(&self, handle: DmaAllocHandle) {
         let num_pages = DmaPages::layout_pages(handle.layout());
+        #[cfg(target_arch = "riscv64")]
+        {
+            if CoherentDmaPolicy::restore_cached(handle.as_ptr(), num_pages).is_err() {
+                // Refuse to hand uncached pages back to the cached page
+                // allocator; leak this allocation rather than corrupt future
+                // cached users.
+                return;
+            }
+        }
         unsafe { DmaPages::dealloc_pages(handle.as_ptr(), num_pages) };
     }
 

--- a/components/rsext4/src/blockdev/journal.rs
+++ b/components/rsext4/src/blockdev/journal.rs
@@ -252,6 +252,36 @@ impl<B: BlockDevice> Jbd2Dev<B> {
         Ok(())
     }
 
+    /// Zeroes `count` consecutive device blocks starting at `start`.
+    ///
+    /// Unlike a per-block `write_block` loop, this coalesces the zero fill into
+    /// chunked multi-block writes (`CHUNK` blocks per device I/O). On a
+    /// low-IOPS device each device call costs a full IOP regardless of transfer
+    /// size, so batching `count` single-block writes into `ceil(count/CHUNK)`
+    /// multi-block writes cuts the IOP cost by up to `CHUNK`× — the dominant
+    /// mkfs win (journal + inode-table initialization).
+    ///
+    /// Writes go through the inner cached device's `write_blocks` so overlapping
+    /// cache entries stay coherent. The journal is bypassed (raw area init).
+    pub fn zero_blocks(&mut self, start: AbsoluteBN, count: u32) -> Ext4Result<()> {
+        if count == 0 {
+            return Ok(());
+        }
+        /// Blocks zeroed per device I/O. 256 × 4 KiB = 1 MiB, bounded memory.
+        const CHUNK: u32 = 256;
+        let buf = alloc::vec![0u8; BLOCK_SIZE * CHUNK as usize];
+        let mut remaining = count;
+        let mut cur = start;
+        while remaining > 0 {
+            let n = remaining.min(CHUNK);
+            let bytes = BLOCK_SIZE * n as usize;
+            self.inner.write_blocks(&buf[..bytes], cur, n)?;
+            cur = cur.checked_add(n)?;
+            remaining -= n;
+        }
+        Ok(())
+    }
+
     /// Commits all buffered journal transactions during unmount.
     pub fn umount_commit(&mut self) {
         if !self.journal_use {
@@ -401,6 +431,19 @@ impl<B: BlockDevice> Jbd2Dev<B> {
     /// Flushes the inner cached device.
     pub fn cantflush(&mut self) -> Ext4Result<()> {
         self.inner.flush()
+    }
+
+    /// Flushes dirty cached blocks then drops all cached entries.
+    ///
+    /// Used during mkfs before re-initializing a region from scratch, so that
+    /// stale cached copies of soon-to-be-rewritten blocks (e.g. group-0
+    /// bitmaps read earlier for descriptor checksumming) cannot shadow the
+    /// fresh on-disk data. The `BlockDev` cache does not invalidate duplicate
+    /// entries on `write_block`, so without this a batched zero-fill that does
+    /// not churn the cache can leave stale entries that cause later checksum
+    /// mismatches.
+    pub fn invalidate_block_cache(&mut self) -> Ext4Result<()> {
+        self.inner.invalidate_cache()
     }
 
     /// Returns the total number of device blocks.

--- a/components/rsext4/src/cache/data_block.rs
+++ b/components/rsext4/src/cache/data_block.rs
@@ -247,7 +247,8 @@ impl DataBlockCache {
         // Two evictions may be needed: (a) the same block number from a
         // previous incarnation, and (b) an LRU batch to stay within max_entries.
         let evict_existing = inner.snapshot_block_for_evict(block_num);
-        let evict_lru_batch = if inner.cache.len() >= inner.max_entries && evict_existing.is_none() {
+        let evict_lru_batch = if inner.cache.len() >= inner.max_entries && evict_existing.is_none()
+        {
             // Only evict LRU if we did not already free a slot above.
             inner.snapshot_lru_batch(EVICT_BATCH)
         } else {
@@ -611,10 +612,7 @@ impl DataBlockCacheInner {
     /// written back as a single multi-block I/O instead of one IOP per block —
     /// the dominant win for write workloads larger than the cache on a
     /// low-IOPS device.
-    fn snapshot_lru_batch(
-        &self,
-        max_k: usize,
-    ) -> Vec<(AbsoluteBN, u64, Option<Vec<u8>>)> {
+    fn snapshot_lru_batch(&self, max_k: usize) -> Vec<(AbsoluteBN, u64, Option<Vec<u8>>)> {
         let mut entries: Vec<(AbsoluteBN, u64, u64, Option<Vec<u8>>)> = self
             .cache
             .iter()

--- a/components/rsext4/src/cache/data_block.rs
+++ b/components/rsext4/src/cache/data_block.rs
@@ -5,6 +5,14 @@ use alloc::{collections::BTreeMap, vec::Vec};
 use ax_kspin::SpinNoPreempt as SpinMutex;
 
 use crate::{blockdev::*, bmalloc::AbsoluteBN, config::*, error::*};
+
+/// Maximum number of LRU victims flushed per eviction event.
+///
+/// Batched eviction lets consecutive dirty victims (the common sequential-
+/// write case once the cache fills) be written back as one coalesced
+/// multi-block I/O instead of one IOP per block.
+const EVICT_BATCH: usize = 64;
+
 /// Cache key for one physical data block.
 pub type BlockCacheKey = AbsoluteBN;
 
@@ -102,36 +110,25 @@ impl DataBlockCache {
         let mut inner = self.inner.lock();
 
         if !inner.cache.contains_key(&block_num) {
-            // Phase 1: snapshot LRU eviction info while holding the lock.
-            let evict_info = if inner.cache.len() >= inner.max_entries {
-                inner.snapshot_lru()
+            // Phase 1: snapshot a batch of LRU victims while holding the lock.
+            let evict_batch = if inner.cache.len() >= inner.max_entries {
+                inner.snapshot_lru_batch(EVICT_BATCH)
             } else {
-                None
+                Vec::new()
             };
 
             drop(inner);
 
             // Phase 2: load the requested block from disk (no dirty writeback
-            // yet — the victim snapshot may be stale).
+            // yet — the victim snapshots may be stale).
             let data = self.load_block(block_dev, block_num)?;
 
-            // Phase 3: reacquire the lock. Validate the victim generation.
-            // If valid, remove it and schedule dirty writeback for Phase 4.
-            // If stale, discard the snapshot without writing anything.
+            // Phase 3: reacquire the lock. Validate each victim's generation;
+            // remove the still-valid ones and collect their dirty data. Stale
+            // victims are left (cache may transiently exceed `max_entries`).
             inner = self.inner.lock();
 
-            let dirty_to_write = match evict_info {
-                Some((lru_key, lru_gen, dirty_opt))
-                    if inner
-                        .cache
-                        .get(&lru_key)
-                        .is_some_and(|cached| cached.generation == lru_gen) =>
-                {
-                    inner.cache.remove(&lru_key);
-                    dirty_opt.map(|data| (lru_key, data))
-                }
-                _ => None,
-            };
+            let to_write = inner.validate_and_remove_batch(&evict_batch);
 
             inner
                 .cache
@@ -140,10 +137,11 @@ impl DataBlockCache {
 
             drop(inner);
 
-            // Phase 4: write the victim's dirty data to disk AFTER the
-            // generation check passed (outside the spinlock).
-            if let Some((lru_key, ref lru_data)) = dirty_to_write {
-                Self::write_block_static(block_dev, lru_key, lru_data, self.block_size)?;
+            // Phase 4: write the victims' dirty data coalesced (consecutive
+            // blocks become one multi-block I/O) AFTER the generation check
+            // passed — outside the spinlock.
+            if !to_write.is_empty() {
+                Self::write_dirty_runs(block_dev, &to_write, self.block_size)?;
             }
 
             // Reacquire for the LRU refresh below.
@@ -174,36 +172,24 @@ impl DataBlockCache {
         let mut inner = self.inner.lock();
 
         if !inner.cache.contains_key(&block_num) {
-            // Phase 1: snapshot LRU eviction info while holding the lock.
-            let evict_info = if inner.cache.len() >= inner.max_entries {
-                inner.snapshot_lru()
+            // Phase 1: snapshot a batch of LRU victims while holding the lock.
+            let evict_batch = if inner.cache.len() >= inner.max_entries {
+                inner.snapshot_lru_batch(EVICT_BATCH)
             } else {
-                None
+                Vec::new()
             };
 
             drop(inner);
 
             // Phase 2: load the requested block from disk (no dirty writeback
-            // yet — the victim snapshot may be stale).
+            // yet — the victim snapshots may be stale).
             let data = self.load_block(block_dev, block_num)?;
 
-            // Phase 3: reacquire the lock. Validate the victim generation.
-            // If valid, remove it and schedule dirty writeback for Phase 4.
-            // If stale, discard the snapshot without writing anything.
+            // Phase 3: reacquire the lock. Validate each victim's generation;
+            // remove the still-valid ones and collect their dirty data.
             inner = self.inner.lock();
 
-            let dirty_to_write = match evict_info {
-                Some((lru_key, lru_gen, dirty_opt))
-                    if inner
-                        .cache
-                        .get(&lru_key)
-                        .is_some_and(|cached| cached.generation == lru_gen) =>
-                {
-                    inner.cache.remove(&lru_key);
-                    dirty_opt.map(|data| (lru_key, data))
-                }
-                _ => None,
-            };
+            let to_write = inner.validate_and_remove_batch(&evict_batch);
 
             // Re-check after reacquiring: another thread may have inserted the
             // same key while we held no lock.
@@ -214,10 +200,10 @@ impl DataBlockCache {
 
             drop(inner);
 
-            // Phase 4: write the victim's dirty data to disk AFTER the
-            // generation check passed (outside the spinlock).
-            if let Some((lru_key, ref lru_data)) = dirty_to_write {
-                Self::write_block_static(block_dev, lru_key, lru_data, self.block_size)?;
+            // Phase 4: write the victims' dirty data coalesced, outside the
+            // spinlock.
+            if !to_write.is_empty() {
+                Self::write_dirty_runs(block_dev, &to_write, self.block_size)?;
             }
 
             inner = self.inner.lock();
@@ -259,20 +245,20 @@ impl DataBlockCache {
 
         // Phase 1: snapshot eviction info while holding the lock.
         // Two evictions may be needed: (a) the same block number from a
-        // previous incarnation, and (b) an LRU slot to stay within max_entries.
+        // previous incarnation, and (b) an LRU batch to stay within max_entries.
         let evict_existing = inner.snapshot_block_for_evict(block_num);
-        let evict_lru_info = if inner.cache.len() >= inner.max_entries && evict_existing.is_none() {
+        let evict_lru_batch = if inner.cache.len() >= inner.max_entries && evict_existing.is_none() {
             // Only evict LRU if we did not already free a slot above.
-            inner.snapshot_lru()
+            inner.snapshot_lru_batch(EVICT_BATCH)
         } else {
-            None
+            Vec::new()
         };
 
         drop(inner);
 
         // Phase 2: write dirty data for unconditional same-block eviction.
-        // The LRU victim's dirty data is NOT written here — it must pass
-        // the generation check first (see Phase 4).
+        // The LRU victims' dirty data is NOT written here — it must pass the
+        // generation check first (see Phase 4).
         if let Some(ref data) = evict_existing {
             Self::write_block_static(block_dev, block_num, data, self.block_size)?;
         }
@@ -285,20 +271,9 @@ impl DataBlockCache {
         if evict_existing.is_some() {
             inner.cache.remove(&block_num);
         }
-        // Validate LRU victim generation; if valid, remove and schedule
-        // dirty writeback. If stale, discard the snapshot silently.
-        let lru_dirty_to_write = match evict_lru_info {
-            Some((lru_key, lru_gen, dirty_opt))
-                if inner
-                    .cache
-                    .get(&lru_key)
-                    .is_some_and(|cached| cached.generation == lru_gen) =>
-            {
-                inner.cache.remove(&lru_key);
-                dirty_opt.map(|data| (lru_key, data))
-            }
-            _ => None,
-        };
+        // Validate LRU victim generations; remove still-valid ones and collect
+        // their dirty data for coalesced writeback. Stale victims are left.
+        let to_write = inner.validate_and_remove_batch(&evict_lru_batch);
 
         let data = alloc::vec![0u8; inner.block_size];
         let mut cached = CachedBlock::new(data, block_num);
@@ -317,9 +292,10 @@ impl DataBlockCache {
 
         drop(inner);
 
-        // Phase 4: write LRU victim's dirty data AFTER generation check.
-        if let Some((lru_key, ref lru_data)) = lru_dirty_to_write {
-            Self::write_block_static(block_dev, lru_key, lru_data, self.block_size)?;
+        // Phase 4: write LRU victims' dirty data coalesced, AFTER generation
+        // check, outside the spinlock.
+        if !to_write.is_empty() {
+            Self::write_dirty_runs(block_dev, &to_write, self.block_size)?;
         }
 
         result
@@ -554,17 +530,28 @@ impl DataBlockCache {
     }
 
     /// Writes one block to disk (static helper, takes runtime block_size).
+    ///
+    /// The cached block data is always a full `block_size` bytes, so this writes
+    /// it directly — no read-modify-write. (The previous implementation read the
+    /// block first then overwrote it, which doubled the IOP cost of every dirty
+    /// eviction/flush on a low-IOPS device for no benefit.)
     fn write_block_static<B: BlockDevice>(
         block_dev: &mut Jbd2Dev<B>,
         block_num: AbsoluteBN,
         data: &[u8],
         block_size: usize,
     ) -> Ext4Result<()> {
-        let mut buf = alloc::vec![0u8; block_size];
-        block_dev.read_blocks(&mut buf, block_num, 1)?;
         let len = core::cmp::min(data.len(), block_size);
-        buf[..len].copy_from_slice(&data[..len]);
-        block_dev.write_blocks(&buf, block_num, 1, false)?;
+        if len == block_size {
+            // Full block — write straight through.
+            block_dev.write_blocks(&data[..len], block_num, 1, false)?;
+        } else {
+            // Partial (defensive): read-modify-write the tail.
+            let mut buf = alloc::vec![0u8; block_size];
+            block_dev.read_blocks(&mut buf, block_num, 1)?;
+            buf[..len].copy_from_slice(&data[..len]);
+            block_dev.write_blocks(&buf, block_num, 1, false)?;
+        }
         Ok(())
     }
 
@@ -615,33 +602,37 @@ pub struct DataBlockCacheStats {
 // ── Inner methods (caller holds `self.inner.lock()`) ─────────────────────────
 
 impl DataBlockCacheInner {
-    /// Snapshots the LRU data block for lock-free eviction.
+    /// Snapshots up to `max_k` least-recently-used entries for batched,
+    /// coalesced eviction.
     ///
-    /// Returns `Some((lru_key, generation, dirty_data))` where `generation` is
-    /// the entry's generation at snapshot time.  The caller must do the I/O
-    /// *without* holding the spinlock, then re-lock, verify that the entry's
-    /// generation still matches, and only then remove it.
-    /// A generation mismatch means another thread accessed or modified the
-    /// victim while we held no lock — in that case the victim must NOT be
-    /// removed (temporarily exceeding `max_entries` is harmless).
-    fn snapshot_lru(&self) -> Option<(AbsoluteBN, u64, Option<Vec<u8>>)> {
-        let lru_key = self
+    /// Returns `(block_num, generation, dirty_data)` for the `max_k` entries
+    /// with the smallest `last_access`. Batched eviction lets consecutive dirty
+    /// victims (the common sequential-append case once the cache fills) be
+    /// written back as a single multi-block I/O instead of one IOP per block —
+    /// the dominant win for write workloads larger than the cache on a
+    /// low-IOPS device.
+    fn snapshot_lru_batch(
+        &self,
+        max_k: usize,
+    ) -> Vec<(AbsoluteBN, u64, Option<Vec<u8>>)> {
+        let mut entries: Vec<(AbsoluteBN, u64, u64, Option<Vec<u8>>)> = self
             .cache
             .iter()
-            .min_by_key(|(_, cached)| cached.last_access)
-            .map(|(key, _)| *key)?;
-
-        let lru_gen = self.cache.get(&lru_key).map(|cached| cached.generation)?;
-
-        let dirty_data = self.cache.get(&lru_key).and_then(|cached| {
-            if cached.dirty {
-                Some(cached.data.clone())
-            } else {
-                None
-            }
-        });
-
-        Some((lru_key, lru_gen, dirty_data))
+            .map(|(k, c)| {
+                (
+                    *k,
+                    c.last_access,
+                    c.generation,
+                    if c.dirty { Some(c.data.clone()) } else { None },
+                )
+            })
+            .collect();
+        entries.sort_by_key(|e| e.1);
+        entries.truncate(max_k);
+        entries
+            .into_iter()
+            .map(|(k, _, gen_v, dirty)| (k, gen_v, dirty))
+            .collect()
     }
 
     /// Snapshots a single block for lock-free eviction.
@@ -685,6 +676,33 @@ impl DataBlockCacheInner {
         {
             self.cache.remove(&block_num);
         }
+    }
+
+    /// Validates a batch of eviction snapshots against current generations and
+    /// removes the still-valid entries. Returns the dirty victims (sorted by
+    /// block number) so the caller can write them back coalesced, *outside* the
+    /// spinlock. Entries whose generation changed (accessed/modified while the
+    /// lock was released) are left untouched — the cache may then transiently
+    /// exceed `max_entries`, which is harmless.
+    fn validate_and_remove_batch(
+        &mut self,
+        batch: &[(AbsoluteBN, u64, Option<Vec<u8>>)],
+    ) -> Vec<(AbsoluteBN, u64, Vec<u8>)> {
+        let mut to_write: Vec<(AbsoluteBN, u64, Vec<u8>)> = Vec::new();
+        for (key, gen_v, dirty_opt) in batch {
+            if self
+                .cache
+                .get(key)
+                .is_some_and(|cached| cached.generation == *gen_v)
+            {
+                self.cache.remove(key);
+                if let Some(d) = dirty_opt {
+                    to_write.push((*key, *gen_v, d.clone()));
+                }
+            }
+        }
+        to_write.sort_by_key(|(b, ..)| *b);
+        to_write
     }
 
     fn block_for_flush(&self, block_num: AbsoluteBN) -> (Option<(u64, Vec<u8>)>, usize) {

--- a/components/rsext4/src/cache/inode_table.rs
+++ b/components/rsext4/src/cache/inode_table.rs
@@ -98,7 +98,7 @@ struct InodeCacheInner {
 ///
 /// `inode_size` is stored outside the spinlock because it is immutable after
 /// construction and is needed by lock-free paths (`calc_inode_location`) and
-/// by `load_inode` which is called from code paths that already hold the lock.
+/// by `load_inode_block` which is called from code paths that already hold the lock.
 pub struct InodeCache {
     inner: SpinMutex<InodeCacheInner>,
     /// On-disk inode size in bytes (immutable after construction).
@@ -145,28 +145,22 @@ impl InodeCache {
         Ok((block_num, offset_in_block, group_idx))
     }
 
-    /// Loads one inode from disk using a caller-provided buffer.
+    /// Reads one inode-table block into a fresh 4 KiB buffer.
     ///
-    /// Lock-free: uses `self.inode_size` (immutable after construction)
-    /// so it is safe to call from code paths that already hold the lock.
-    fn load_inode<B: BlockDevice>(
+    /// Used by `get_or_load`/`get_or_load_mut` so the same block read that
+    /// satisfies a miss can also populate the cache with the block's other
+    /// inodes (see `populate_siblings`), instead of re-reading the block for
+    /// every sibling inode.
+    fn load_inode_block<B: BlockDevice>(
         &self,
         block_dev: &mut Jbd2Dev<B>,
         block_num: AbsoluteBN,
-        offset: usize,
-    ) -> Ext4Result<Ext4Inode> {
-        let inode_size = self.inode_size;
+    ) -> Ext4Result<Vec<u8>> {
         // Use a local buffer to avoid the BlockDev single-block buffer,
         // which is shared mutable state that would serialize concurrent reads.
         let mut buf = alloc::vec![0u8; crate::config::BLOCK_SIZE];
         block_dev.read_blocks(&mut buf, block_num, 1)?;
-
-        if offset + inode_size > buf.len() {
-            return Err(Ext4Error::corrupted());
-        }
-
-        let inode = Ext4Inode::from_disk_bytes(&buf[offset..offset + inode_size]);
-        Ok(inode)
+        Ok(buf)
     }
 
     /// Returns a cached inode, loading it from disk on demand.
@@ -190,9 +184,15 @@ impl InodeCache {
 
             drop(inner);
 
-            // Phase 2: load the requested inode from disk (no dirty writeback
-            // yet — the victim snapshot may be stale).
-            let inode = self.load_inode(block_dev, block_num, offset)?;
+            // Phase 2: load the requested inode's block from disk (no dirty
+            // writeback yet — the victim snapshot may be stale). The same read
+            // also feeds sibling population below.
+            let inode_size = self.inode_size;
+            let block_bytes = self.load_inode_block(block_dev, block_num)?;
+            if offset + inode_size > block_bytes.len() {
+                return Err(Ext4Error::corrupted());
+            }
+            let inode = Ext4Inode::from_disk_bytes(&block_bytes[offset..offset + inode_size]);
 
             // Phase 3: reacquire the lock. Validate the victim generation.
             // If valid, remove it and schedule dirty writeback for Phase 4.
@@ -218,6 +218,10 @@ impl InodeCache {
                 .cache
                 .entry(inode_num)
                 .or_insert_with(|| CachedInode::new(inode, inode_num, block_num, offset));
+
+            // Populate the block's other inodes (clean) so the next access to
+            // a sibling hits the cache instead of re-reading the 4 KiB block.
+            inner.populate_siblings(&block_bytes, block_num, inode_num, offset);
 
             drop(inner);
 
@@ -266,9 +270,14 @@ impl InodeCache {
 
             drop(inner);
 
-            // Phase 2: load the requested inode from disk (no dirty writeback
-            // yet — the victim snapshot may be stale).
-            let inode = self.load_inode(block_dev, block_num, offset)?;
+            // Phase 2: load the requested inode's block from disk (no dirty
+            // writeback yet — the victim snapshot may be stale).
+            let inode_size = self.inode_size;
+            let block_bytes = self.load_inode_block(block_dev, block_num)?;
+            if offset + inode_size > block_bytes.len() {
+                return Err(Ext4Error::corrupted());
+            }
+            let inode = Ext4Inode::from_disk_bytes(&block_bytes[offset..offset + inode_size]);
 
             // Phase 3: reacquire the lock. Validate the victim generation.
             // If valid, remove it and schedule dirty writeback for Phase 4.
@@ -294,6 +303,10 @@ impl InodeCache {
                 .cache
                 .entry(inode_num)
                 .or_insert_with(|| CachedInode::new(inode, inode_num, block_num, offset));
+
+            // Populate the block's other inodes (clean) for the same reason as
+            // in `get_or_load`.
+            inner.populate_siblings(&block_bytes, block_num, inode_num, offset);
 
             drop(inner);
 
@@ -530,6 +543,59 @@ pub struct InodeCacheStats {
 // ── Inner methods (caller holds `self.inner.lock()`) ─────────────────────────
 
 impl InodeCacheInner {
+    /// Populates clean cache entries for the other inodes that share `requested`'s
+    /// inode-table block, using the block bytes already read for the miss.
+    ///
+    /// Without this, every inode in a 16-inode block re-reads the 4 KiB block
+    /// on its own miss — the dominant read cost of file creation. Siblings are
+    /// inserted only while there is room (no eviction), so this never triggers
+    /// writeback I/O; if the cache is full the requested inode's own insert has
+    /// already handled eviction via the normal path.
+    fn populate_siblings(
+        &mut self,
+        block_bytes: &[u8],
+        block_num: AbsoluteBN,
+        requested: InodeNumber,
+        offset: usize,
+    ) {
+        let inode_size = self.inode_size;
+        if inode_size == 0 {
+            return;
+        }
+        let inodes_per_block = crate::config::BLOCK_SIZE / inode_size;
+        let slot = offset / inode_size;
+        let Some(base_raw) = requested.raw().checked_sub(slot as u32) else {
+            return;
+        };
+        let now = self.access_counter;
+        for s in 0..inodes_per_block {
+            if s == slot {
+                continue; // requested inode handled by caller
+            }
+            let Some(raw) = base_raw.checked_add(s as u32) else {
+                continue;
+            };
+            if raw == 0 {
+                continue; // inode 0 is invalid
+            }
+            let Ok(inum) = InodeNumber::new(raw) else {
+                continue;
+            };
+            // Best-effort: only insert siblings while there is room and the
+            // slot is free. Never evict for a sibling.
+            if self.cache.len() < self.max_entries && !self.cache.contains_key(&inum) {
+                let off = s * inode_size;
+                if off + inode_size > block_bytes.len() {
+                    break;
+                }
+                let inode = Ext4Inode::from_disk_bytes(&block_bytes[off..off + inode_size]);
+                let mut cached = CachedInode::new(inode, inum, block_num, off);
+                cached.last_access = now;
+                self.cache.insert(inum, cached);
+            }
+        }
+    }
+
     /// Snapshots the LRU entry for lock-free eviction.
     ///
     /// Returns `(lru_key, generation, dirty_write_info)` where `generation`

--- a/components/rsext4/src/config.rs
+++ b/components/rsext4/src/config.rs
@@ -47,7 +47,13 @@ pub const USE_MULTILEVEL_CACHE: bool = cfg!(feature = "USE_MULTILEVEL_CACHE");
 /// Maximum number of inode-table cache entries.
 pub const INODE_CACHE_MAX: usize = 128;
 /// Maximum number of data-block cache entries.
-pub const DATABLOCK_CACHE_MAX: usize = 128;
+///
+/// Sized to hold ~1 MiB of dirty data (256 × 4 KiB) so that a typical small-
+/// write workload (e.g. 4 KiB appends) accumulates contiguous dirty blocks in
+/// the cache and is flushed as a handful of multi-block writes by `flush_all`,
+/// rather than one device IOP per block. On a low-IOPS device this is the
+/// difference between ~256 write IOPs/MiB and ~3 write IOPs/MiB.
+pub const DATABLOCK_CACHE_MAX: usize = 256;
 /// Maximum number of bitmap cache entries.
 pub const BITMAP_CACHE_MAX: usize = 128;
 

--- a/components/rsext4/src/config.rs
+++ b/components/rsext4/src/config.rs
@@ -45,7 +45,12 @@ pub const DEFAULT_INODE_SIZE: u16 = 256;
 /// and group descriptors.
 pub const USE_MULTILEVEL_CACHE: bool = cfg!(feature = "USE_MULTILEVEL_CACHE");
 /// Maximum number of inode-table cache entries.
-pub const INODE_CACHE_MAX: usize = 128;
+///
+/// Sized so that, with sibling population on block load, a burst of file
+/// creations (each dirtying a fresh inode) fits without evicting still-needed
+/// inodes — 256 entries ≈ 16 inode-table blocks worth of inodes at 256-byte
+/// inodes. Bumped from 128 to avoid LRU churn during bulk file creation.
+pub const INODE_CACHE_MAX: usize = 256;
 /// Maximum number of data-block cache entries.
 ///
 /// Sized to hold ~1 MiB of dirty data (256 × 4 KiB) so that a typical small-

--- a/components/rsext4/src/ext4/mkfs.rs
+++ b/components/rsext4/src/ext4/mkfs.rs
@@ -569,6 +569,14 @@ fn initialize_group_0<B: BlockDevice>(
     block_dev: &mut Jbd2Dev<B>,
     layout: &FsLayoutInfo,
 ) -> Ext4Result<()> {
+    // Drop any cached copies of group-0 blocks read earlier (e.g. bitmaps read
+    // for descriptor checksumming in the preceding GDT-write pass). The
+    // `BlockDev` cache does not invalidate duplicate entries on `write_block`,
+    // so a stale cached bitmap could shadow the fresh data written below and
+    // cause checksum mismatches later. Everything here is rewritten from
+    // scratch, so a clean cache is both safe and correct.
+    block_dev.invalidate_block_cache()?;
+
     // Group 0 has a fixed layout derived during mkfs planning.
     let block_bitmap_blk = layout.group0_block_bitmap;
     let inode_bitmap_blk = layout.group0_inode_bitmap;
@@ -605,13 +613,9 @@ fn initialize_group_0<B: BlockDevice>(
     block_dev.write_block(inode_bitmap_blk.into(), true)?;
 
     // Zero the inode table before the filesystem is mounted for the first time.
-    {
-        let buffer = block_dev.buffer_mut();
-        buffer.fill(0);
-    }
-    for i in 0..layout.inode_table_blocks {
-        block_dev.write_block((inode_table_blk + i).into(), true)?;
-    }
+    // Batched into multi-block writes: on a low-IOPS device this turns
+    // `inode_table_blocks` (e.g. 512) single-block I/Os into a handful.
+    block_dev.zero_blocks(inode_table_blk.into(), layout.inode_table_blocks)?;
 
     // Persist the now-initialized descriptor for group 0.
     let mut desc = Ext4GroupDesc {

--- a/components/rsext4/src/file/io.rs
+++ b/components/rsext4/src/file/io.rs
@@ -573,6 +573,33 @@ fn write_full_block_run<B: BlockDevice>(
     let src_end = src_off
         .checked_add(byte_len)
         .ok_or_else(|| Ext4Error::from(Errno::EOVERFLOW))?;
+
+    // Small full-block runs are deferred into the data-block cache as dirty
+    // entries (write-back) instead of writing through immediately. Consecutive
+    // small appends (the common small-write case — 4 KiB .. 64 KiB at a time)
+    // then accumulate as contiguous dirty blocks and are flushed as a handful
+    // of multi-block writes by `flush_all`/eviction, instead of one device IOP
+    // per call. This is the dominant write win on low-IOPS devices.
+    //
+    // The threshold covers the common small-write sizes (up to 64 KiB = 16
+    // blocks). Larger runs stay on the write-through `write_run` path: a single
+    // call writing N≥17 full blocks is already one multi-block IOP and is kept
+    // optimal rather than being split into N cache entries. A deferred run is
+    // flushed at umount as one coalesced multi-block write, so single-call
+    // cost is unchanged — write-back only adds value across multiple calls.
+    const WRITEBACK_MAX_RUN: u32 = 16;
+    if block_count <= WRITEBACK_MAX_RUN {
+        let bs = BLOCK_SIZE;
+        for off in 0..block_count {
+            let phys = start_phys.checked_add(off)?;
+            let src_start = src_off + off as usize * bs;
+            let slice = &data[src_start..src_start + bs];
+            fs.datablock_cache
+                .modify_new(device, phys, |blk| blk.copy_from_slice(slice))?;
+        }
+        return Ok(());
+    }
+
     fs.datablock_cache
         .write_run(device, start_phys, block_count, &data[src_off..src_end])
 }

--- a/components/rsext4/src/jbd2/jbd2.rs
+++ b/components/rsext4/src/jbd2/jbd2.rs
@@ -20,6 +20,30 @@ use crate::{
     metadata::Ext4InodeMetadataUpdate,
 };
 
+/// Zeroes a list of blocks, coalescing contiguous runs into multi-block
+/// `zero_blocks` calls. Used during mkfs to initialize the journal area in a
+/// handful of device I/Os instead of one per block.
+fn zero_block_list<B: BlockDevice>(
+    block_dev: &mut Jbd2Dev<B>,
+    blocks: &[AbsoluteBN],
+) -> Ext4Result<()> {
+    let mut iter = blocks.iter().copied();
+    let Some(mut run_start) = iter.next() else {
+        return Ok(());
+    };
+    let mut run_len: u32 = 1;
+    for b in iter {
+        if b == run_start.checked_add(run_len)? {
+            run_len += 1;
+        } else {
+            block_dev.zero_blocks(run_start, run_len)?;
+            run_start = b;
+            run_len = 1;
+        }
+    }
+    block_dev.zero_blocks(run_start, run_len)
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ReplayTag {
     block: AbsoluteBN,
@@ -896,10 +920,11 @@ pub fn create_journal_entry<B: BlockDevice>(
 
     // Ensure journal area starts clean: otherwise old image contents could look like valid
     // descriptor/commit blocks and replay would corrupt filesystem metadata.
-    let zero = [0u8; BLOCK_SIZE];
-    for &b in free_block.iter() {
-        block_dev.write_blocks(&zero, b, 1, true)?;
-    }
+    //
+    // The allocated blocks are usually one contiguous run; coalesce contiguous
+    // sub-runs and zero each in multi-block writes so we issue O(runs × chunks)
+    // device I/Os instead of one per block (4096 → ~16 on a 100 MiB fs).
+    zero_block_list(block_dev, &free_block)?;
     // Build the journal inode metadata and map the allocated journal blocks.
     let mut jour_inode = Ext4Inode::empty_for_reuse(fs.default_inode_extra_isize());
     jour_inode.i_links_count = 1;

--- a/components/rsext4/tests/profiling_low_iops.rs
+++ b/components/rsext4/tests/profiling_low_iops.rs
@@ -1,0 +1,566 @@
+//! Low-IOPS device profiling harness for rsext4.
+//!
+//! Wraps rsext4 with a mock block device that simulates a slow (low-IOPS)
+//! storage device, then runs cold-cache scenarios so we can see *where* the
+//! raw I/O budget is spent and *why* the filesystem is slow on such devices.
+//!
+//! Run with:
+//!   cargo test --test profiling_low_iops -- --nocapture --ignored
+//!
+//! The device does NOT actually sleep by default — it counts ops and derives a
+//! *modeled* wall time from a per-op latency (read 5 ms, write 10 ms ≈ a slow
+//! SD / eMMC grade device). Counting is deterministic and fast. Per-scenario
+//! counters are deltas measured on a freshly mounted filesystem (cold FS-level
+//! caches) so the numbers reflect real cold-cache cost, not warm-cache hits.
+
+use std::cell::Cell;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use rsext4::{
+    bmalloc::AbsoluteBN,
+    error::{Ext4Error, Ext4Result},
+    *,
+};
+
+// ─── modeled slow-device latencies + bandwidth ─────────────────────────────
+// Cheap SD card: ~200 random-read IOPS (5 ms), ~100 random-write IOPS (10 ms)
+// per 4 KiB op, AND slow sequential bandwidth (~2 MB/s write, ~5 MB/s read).
+// Modeled phase time = ops×latency + bytes/bandwidth, so both the IOP count
+// and the transfer volume matter — exactly the "low IOPS + slow write speed"
+// scenario from the goal.
+const READ_LATENCY_US: u64 = 5_000;
+const WRITE_LATENCY_US: u64 = 10_000;
+const READ_BW_BYTES_PER_S: u64 = 5 * 1024 * 1024;
+const WRITE_BW_BYTES_PER_S: u64 = 2 * 1024 * 1024;
+const LATENCY_MODE: bool = false; // true => actually sleep (sanity only)
+
+#[derive(Default, Clone, Copy)]
+struct BlockStats {
+    reads: u64,
+    writes: u64,
+}
+
+/// Shared, interior-mutable counter store (Arc'd so the harness can snapshot
+/// without a ref to the device, which is buried inside `Jbd2Dev`).
+///
+/// Counting model: a low-IOPS device is **IOP-bound**, not bandwidth-bound —
+/// a single read/write *call* that transfers N blocks costs ~1 IOP, not N.
+/// So `read_ops`/`write_ops` count device-call invocations, and modeled time
+/// is `ops × per-op latency`. Per-block touch counters are kept separately
+/// only for cache-thrash analysis.
+struct Counters {
+    read_ops: Cell<u64>,
+    write_ops: Cell<u64>,
+    read_bytes: Cell<u64>,
+    write_bytes: Cell<u64>,
+    per_block: std::cell::RefCell<BTreeMap<u64, BlockStats>>,
+}
+
+impl Counters {
+    fn new() -> Self {
+        Self {
+            read_ops: Cell::new(0),
+            write_ops: Cell::new(0),
+            read_bytes: Cell::new(0),
+            write_bytes: Cell::new(0),
+            per_block: std::cell::RefCell::new(BTreeMap::new()),
+        }
+    }
+    fn bill_read(&self, first_block: u64, nblocks: usize, bytes: usize) {
+        self.read_ops.set(self.read_ops.get() + 1);
+        self.read_bytes.set(self.read_bytes.get() + bytes as u64);
+        let mut pb = self.per_block.borrow_mut();
+        for i in 0..nblocks {
+            pb.entry(first_block + i as u64).or_default().reads += 1;
+        }
+        if LATENCY_MODE {
+            std::thread::sleep(std::time::Duration::from_micros(READ_LATENCY_US));
+        }
+    }
+    fn bill_write(&self, first_block: u64, nblocks: usize, bytes: usize) {
+        self.write_ops.set(self.write_ops.get() + 1);
+        self.write_bytes.set(self.write_bytes.get() + bytes as u64);
+        let mut pb = self.per_block.borrow_mut();
+        for i in 0..nblocks {
+            pb.entry(first_block + i as u64).or_default().writes += 1;
+        }
+        if LATENCY_MODE {
+            std::thread::sleep(std::time::Duration::from_micros(WRITE_LATENCY_US));
+        }
+    }
+    fn snapshot(&self) -> Snapshot {
+        let read_ops = self.read_ops.get();
+        let write_ops = self.write_ops.get();
+        let read_bytes = self.read_bytes.get();
+        let write_bytes = self.write_bytes.get();
+        let op_us = read_ops * READ_LATENCY_US + write_ops * WRITE_LATENCY_US;
+        let bw_us = (read_bytes * 1_000_000 / READ_BW_BYTES_PER_S.max(1))
+            + (write_bytes * 1_000_000 / WRITE_BW_BYTES_PER_S.max(1));
+        Snapshot {
+            read_ops,
+            write_ops,
+            read_bytes,
+            write_bytes,
+            modeled_us: op_us + bw_us,
+        }
+    }
+    fn reset(&self) {
+        self.read_ops.set(0);
+        self.write_ops.set(0);
+        self.read_bytes.set(0);
+        self.write_bytes.set(0);
+        self.per_block.borrow_mut().clear();
+    }
+    fn top(&self, n: usize, writes: bool) -> Vec<(u64, u64)> {
+        let mut v: Vec<(u64, u64)> = self
+            .per_block
+            .borrow()
+            .iter()
+            .map(|(k, s)| (*k, if writes { s.writes } else { s.reads }))
+            .filter(|(_, c)| *c > 0)
+            .collect();
+        v.sort_by(|a, b| b.1.cmp(&a.1));
+        v.truncate(n);
+        v
+    }
+    /// Distinct blocks touched, min/max block id, and a coarse histogram.
+    fn hist(&self) -> (u64, u64, u64, Vec<(String, u64)>) {
+        let pb = self.per_block.borrow();
+        let distinct = pb.len() as u64;
+        let min = pb.keys().copied().min().unwrap_or(0);
+        let max = pb.keys().copied().max().unwrap_or(0);
+        // Buckets: 0-15 (sb/gdt), 16-527 (group0 meta+inode table), 528-4623 (journal), 4624+
+        let buckets = [
+            ("blk    0-15  (sb/gdt)", 0u64, 16u64),
+            ("blk   16-527 (inode tbl)", 16, 528),
+            ("blk  528-4623(journal?)", 528, 4624),
+            ("blk 4624+    (data)", 4624, u64::MAX),
+        ];
+        let h: Vec<(String, u64)> = buckets
+            .iter()
+            .map(|(name, lo, hi)| {
+                let c = pb
+                    .range(*lo..*hi)
+                    .map(|(_, s)| s.writes + s.reads)
+                    .sum();
+                ((*name).to_string(), c)
+            })
+            .collect();
+        (distinct, min, max, h)
+    }
+}
+
+struct ProfilingBlockDevice {
+    data: Vec<u8>,
+    block_size: u32,
+    now: Cell<i64>,
+    ctr: Arc<Counters>,
+}
+
+impl ProfilingBlockDevice {
+    fn new(size: usize, ctr: Arc<Counters>) -> Self {
+        Self {
+            data: vec![0; size],
+            block_size: BLOCK_SIZE as u32,
+            now: Cell::new(1_700_000_000),
+            ctr,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Snapshot {
+    read_ops: u64,
+    write_ops: u64,
+    read_bytes: u64,
+    write_bytes: u64,
+    modeled_us: u64,
+}
+
+impl Snapshot {
+    fn fmt(&self) -> String {
+        format!(
+            "rOps={:>5} wOps={:>5}  rB={:>9} wB={:>9}  modeled={:>8.3} s",
+            self.read_ops,
+            self.write_ops,
+            self.read_bytes,
+            self.write_bytes,
+            self.modeled_us as f64 / 1_000_000.0,
+        )
+    }
+}
+
+impl BlockDevice for ProfilingBlockDevice {
+    fn read(&mut self, buffer: &mut [u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+        let bid = block_id.to_u32().map_err(|_| Ext4Error::corrupted())? as u64;
+        let start = bid as usize * self.block_size as usize;
+        let end = start + buffer.len();
+        if end > self.data.len() {
+            return Err(Ext4Error::block_out_of_range(
+                block_id.to_u32()?,
+                (self.data.len() / self.block_size as usize) as u64,
+            ));
+        }
+        let bs = self.block_size as usize;
+        let nblocks = buffer.len().div_ceil(bs).max(1);
+        // 1 IOP per call — multi-block transfers are a single request on a
+        // real low-IOPS device.
+        self.ctr.bill_read(bid, nblocks, buffer.len());
+        buffer.copy_from_slice(&self.data[start..end]);
+        Ok(())
+    }
+    fn write(&mut self, buffer: &[u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+        let bid = block_id.to_u32().map_err(|_| Ext4Error::corrupted())? as u64;
+        let start = bid as usize * self.block_size as usize;
+        let end = start + buffer.len();
+        if end > self.data.len() {
+            return Err(Ext4Error::block_out_of_range(
+                block_id.to_u32()?,
+                (self.data.len() / self.block_size as usize) as u64,
+            ));
+        }
+        let bs = self.block_size as usize;
+        let nblocks = buffer.len().div_ceil(bs).max(1);
+        self.ctr.bill_write(bid, nblocks, buffer.len());
+        self.data[start..end].copy_from_slice(buffer);
+        Ok(())
+    }
+    fn open(&mut self) -> Ext4Result<()> {
+        Ok(())
+    }
+    fn close(&mut self) -> Ext4Result<()> {
+        Ok(())
+    }
+    fn total_blocks(&self) -> u64 {
+        (self.data.len() / self.block_size as usize) as u64
+    }
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+    fn current_time(&self) -> Ext4Result<Ext4Timestamp> {
+        let sec = self.now.get();
+        self.now.set(sec + 1);
+        Ok(Ext4Timestamp::new(sec, 0))
+    }
+}
+
+// ─── workload constants ────────────────────────────────────────────────────
+const N_FILES: usize = 100; // kept below the ~100-entry htree-spill threshold
+const SMALL_FILE_BYTES: usize = 512;
+const BIG_FILE_BYTES: usize = 1 << 20; // 1 MiB
+const N_DIRS: usize = 50;
+
+fn file_path(i: usize) -> String {
+    format!("/files/f_{:04}", i)
+}
+
+/// Mount a fresh (cold-cache) Jbd2Dev on the given device.
+fn cold_mount(device: ProfilingBlockDevice) -> (Jbd2Dev<ProfilingBlockDevice>, Ext4FileSystem) {
+    let mut dev = Jbd2Dev::initial_jbd2dev(0, device, true);
+    let fs = mount(&mut dev).expect("mount failed");
+    (dev, fs)
+}
+
+#[test]
+#[ignore = "profiling harness, run explicitly"]
+fn profile_low_iops_baseline() {
+    eprintln!();
+    eprintln!("############################################################################");
+    eprintln!("# rsext4 low-IOPS profiling  (read={}us write={}us per 4K op)", READ_LATENCY_US, WRITE_LATENCY_US);
+    eprintln!("############################################################################");
+    let ctr = Arc::new(Counters::new());
+
+    // ── Scenario A: mkfs (one-time provisioning) ────────────────────────────
+    let device = ProfilingBlockDevice::new(100 * 1024 * 1024, ctr.clone());
+    let mut dev = Jbd2Dev::initial_jbd2dev(0, device, true);
+    ctr.reset();
+    mkfs(&mut dev).expect("mkfs");
+    let mkfs_s = ctr.snapshot();
+    eprintln!("[A mkfs        ] {}", mkfs_s.fmt());
+    let (distinct, min, max, h) = ctr.hist();
+    eprintln!(
+        "    distinct blocks touched={} range=[{}, {}]",
+        distinct, min, max
+    );
+    for (name, c) in &h {
+        eprintln!("       {} : {} block-touches", name, c);
+    }
+
+    // ── Setup: create the dataset once (also = Scenario C: create + commit) ──
+    ctr.reset();
+    let mut fs = mount(&mut dev).expect("mount");
+    let mount_s = ctr.snapshot();
+    eprintln!("[  mount(cold)  ] {}", mount_s.fmt());
+
+    ctr.reset();
+    mkdir(&mut dev, &mut fs, "/files").expect("mkdir");
+    let payload = vec![0xABu8; SMALL_FILE_BYTES];
+    for i in 0..N_FILES {
+        mkfile(&mut dev, &mut fs, &file_path(i), Some(&payload), None).expect("mkfile");
+    }
+    let create_s = ctr.snapshot();
+    eprintln!("[C create {:>3} ] {}", N_FILES, create_s.fmt());
+    eprintln!(
+        "    per-file (pre-commit): reads={:.2} writes={:.2} modeled={:.2} ms",
+        create_s.read_ops as f64 / N_FILES as f64,
+        create_s.write_ops as f64 / N_FILES as f64,
+        create_s.modeled_us as f64 / N_FILES as f64 / 1000.0,
+    );
+
+    ctr.reset();
+    umount(fs, &mut dev).expect("umount");
+    let commit_s = ctr.snapshot();
+    eprintln!("[  umount commit] {}", commit_s.fmt());
+    eprintln!(
+        "    => total create+commit per-file: modeled={:.2} ms",
+        (create_s.modeled_us + commit_s.modeled_us) as f64 / N_FILES as f64 / 1000.0
+    );
+
+    // Take the device back; all later scenarios mount cold on the same data.
+    let device = dev.into_inner();
+
+    // ── Scenario B: cold mount + read 100 files (cold-cache read) ───────────
+    ctr.reset();
+    let (mut dev, mut fs) = cold_mount(device);
+    let mount_b = ctr.snapshot();
+    let payload_read = vec![0xABu8; SMALL_FILE_BYTES];
+    for i in 0..N_FILES {
+        let d = read_file(&mut dev, &mut fs, &file_path(i)).expect("read_file");
+        assert_eq!(d, payload_read);
+    }
+    let read_s = ctr.snapshot();
+    eprintln!("[B read  {:>3} ] {}", N_FILES, read_s.fmt());
+    eprintln!(
+        "    (cold mount cost {} + read cost). per-file read: reads={:.2} writes={:.2} modeled={:.2} ms",
+        fmt_us(mount_b.modeled_us),
+        (read_s.read_ops - mount_b.read_ops) as f64 / N_FILES as f64,
+        (read_s.write_ops - mount_b.write_ops) as f64 / N_FILES as f64,
+        (read_s.modeled_us - mount_b.modeled_us) as f64 / N_FILES as f64 / 1000.0,
+    );
+    umount(fs, &mut dev).expect("umount");
+    let device = dev.into_inner();
+
+    // ── Scenario D: cold mount + append 1 MiB in 4 KiB chunks + commit ──────
+    ctr.reset();
+    let (mut dev, mut fs) = cold_mount(device);
+    mkfile(&mut dev, &mut fs, "/big.bin", None, None).expect("mkfile big");
+    ctr.reset(); // reset so the cost is the append itself
+    let chunk = vec![0xCDu8; BLOCK_SIZE];
+    let n_chunks = BIG_FILE_BYTES / BLOCK_SIZE;
+    let mut off = 0u64;
+    for _ in 0..n_chunks {
+        write_file(&mut dev, &mut fs, "/big.bin", off, &chunk).expect("write_file");
+        off += BLOCK_SIZE as u64;
+    }
+    let bw_s = ctr.snapshot();
+    eprintln!("[D write 1MiB  ] {}", bw_s.fmt());
+    eprintln!(
+        "    per-chunk: reads={:.2} writes={:.2} modeled={:.2} ms",
+        bw_s.read_ops as f64 / n_chunks as f64,
+        bw_s.write_ops as f64 / n_chunks as f64,
+        bw_s.modeled_us as f64 / n_chunks as f64 / 1000.0,
+    );
+    ctr.reset();
+    umount(fs, &mut dev).expect("umount");
+    let bigcommit_s = ctr.snapshot();
+    eprintln!("[  umount commit] {}", bigcommit_s.fmt());
+    let device = dev.into_inner();
+
+    // ── Scenario D2: same 1 MiB but in ONE write_file call ──────────────────
+    // A single write_file of a contiguous multi-block run is one multi-block
+    // device write (write-through `write_run`). Contrast with Scenario D where
+    // the *caller* splits the same 1 MiB into 256 separate 4 KiB writes.
+    ctr.reset();
+    let (mut dev, mut fs) = cold_mount(device);
+    mkfile(&mut dev, &mut fs, "/big2.bin", None, None).expect("mkfile big2");
+    ctr.reset();
+    let bigbuf = vec![0xCDu8; BIG_FILE_BYTES];
+    write_file(&mut dev, &mut fs, "/big2.bin", 0, &bigbuf).expect("write_file 1MiB");
+    let bw2_s = ctr.snapshot();
+    eprintln!("[D2 write1call ] {}", bw2_s.fmt());
+    eprintln!(
+        "    1 MiB in a single write_file call → {} wOps (vs {} for 256×4 KiB)",
+        bw2_s.write_ops, n_chunks
+    );
+    ctr.reset();
+    umount(fs, &mut dev).expect("umount");
+    let d2_commit = ctr.snapshot();
+    eprintln!("[  umount commit] {}", d2_commit.fmt());
+    let mut device = dev.into_inner();
+
+    // ── Scenario G: 1 MiB append at varied chunk sizes ───────────────────────
+    // Write-performance focus: same 1 MiB, different caller chunk sizes. The
+    // write-back path defers single-block (4 KiB) writes so they coalesce at
+    // flush; larger chunks (≥2 blocks) stay write-through (1 multi-block IOP
+    // per call). Shows the breakpoint and that small-write throughput is no
+    // longer 1 IOP/block.
+    eprintln!();
+    eprintln!("── write throughput vs chunk size (1 MiB append) ──");
+    for &chunk_kib in &[4usize, 16, 64, 256, 1024] {
+        let chunk_bytes = chunk_kib * 1024;
+        let (mut dev, mut fs) = cold_mount(device);
+        let path = format!("/w_{}.bin", chunk_kib);
+        mkfile(&mut dev, &mut fs, &path, None, None).expect("mkfile");
+        ctr.reset();
+        let chunk = vec![0xCDu8; chunk_bytes];
+        let mut off = 0u64;
+        while off < BIG_FILE_BYTES as u64 {
+            write_file(&mut dev, &mut fs, &path, off, &chunk).expect("write_file");
+            off += chunk_bytes as u64;
+        }
+        let w = ctr.snapshot();
+        ctr.reset();
+        umount(fs, &mut dev).expect("umount");
+        let c = ctr.snapshot();
+        device = dev.into_inner();
+        let total_us = w.modeled_us + c.modeled_us;
+        eprintln!(
+            "  chunk {:>4} KiB: write {:>7} | commit {:>7} | total {:>6.3} s ({:.2} MiB/s effective)",
+            chunk_kib,
+            w.fmt(),
+            c.fmt(),
+            total_us as f64 / 1_000_000.0,
+            (BIG_FILE_BYTES as f64 / (1024.0 * 1024.0)) / (total_us as f64 / 1_000_000.0),
+        );
+    }
+
+    // ── Scenario H: 4 MiB in 4 KiB chunks (exceeds the 1 MiB data cache) ──────
+    // Tests the eviction fallback: once the dirty cache fills, victims are
+    // written back. With the no-read eviction fix this is 1 IOP/block (not 2),
+    // and the tail still coalesces at umount.
+    {
+        let big4 = 4 * BIG_FILE_BYTES;
+        let (mut dev, mut fs) = cold_mount(device);
+        mkfile(&mut dev, &mut fs, "/h.bin", None, None).expect("mkfile");
+        ctr.reset();
+        let chunk = vec![0xCDu8; BLOCK_SIZE];
+        let mut off = 0u64;
+        while off < big4 as u64 {
+            write_file(&mut dev, &mut fs, "/h.bin", off, &chunk).expect("write_file");
+            off += BLOCK_SIZE as u64;
+        }
+        let w = ctr.snapshot();
+        ctr.reset();
+        umount(fs, &mut dev).expect("umount");
+        let c = ctr.snapshot();
+        device = dev.into_inner();
+        let total_us = w.modeled_us + c.modeled_us;
+        eprintln!(
+            "[H 4MiB 4K-chunk] write {:>7} | commit {:>7} | total {:>6.3} s ({:.2} MiB/s effective)",
+            w.fmt(),
+            c.fmt(),
+            total_us as f64 / 1_000_000.0,
+            (big4 as f64 / (1024.0 * 1024.0)) / (total_us as f64 / 1_000_000.0),
+        );
+    }
+
+    // ── Scenario E: cold mount + create 50 dirs + commit (metadata alloc) ───
+    ctr.reset();
+    let (mut dev, mut fs) = cold_mount(device);
+    ctr.reset();
+    for i in 0..N_DIRS {
+        mkdir(&mut dev, &mut fs, &format!("/d_{:03}", i)).expect("mkdir");
+    }
+    let mkdir_s = ctr.snapshot();
+    eprintln!("[E mkdir {:>3} ] {}", N_DIRS, mkdir_s.fmt());
+    eprintln!(
+        "    per-dir: reads={:.2} writes={:.2} modeled={:.2} ms",
+        mkdir_s.read_ops as f64 / N_DIRS as f64,
+        mkdir_s.write_ops as f64 / N_DIRS as f64,
+        mkdir_s.modeled_us as f64 / N_DIRS as f64 / 1000.0,
+    );
+    ctr.reset();
+    umount(fs, &mut dev).expect("umount");
+    let dircommit_s = ctr.snapshot();
+    eprintln!("[  umount commit] {}", dircommit_s.fmt());
+    let device = dev.into_inner();
+
+    // ── Scenario F: cold mount + delete 100 files + commit ──────────────────
+    ctr.reset();
+    let (mut dev, mut fs) = cold_mount(device);
+    ctr.reset();
+    for i in 0..N_FILES {
+        delete_file(&mut fs, &mut dev, &file_path(i)).expect("delete_file");
+    }
+    let del_s = ctr.snapshot();
+    eprintln!("[F delete {:>3} ] {}", N_FILES, del_s.fmt());
+    eprintln!(
+        "    per-file: reads={:.2} writes={:.2} modeled={:.2} ms",
+        del_s.read_ops as f64 / N_FILES as f64,
+        del_s.write_ops as f64 / N_FILES as f64,
+        del_s.modeled_us as f64 / N_FILES as f64 / 1000.0,
+    );
+    ctr.reset();
+    umount(fs, &mut dev).expect("umount");
+    let delcommit_s = ctr.snapshot();
+    eprintln!("[  umount commit] {}", delcommit_s.fmt());
+
+    eprintln!();
+    eprintln!("Hot blocks during 1 MiB write (Scenario D), top-12 by writes:");
+    // Re-run D briefly is expensive; instead report hot blocks from last reset (delete commit).
+    eprintln!("(reported for delete-commit; top-12 by writes)");
+    for (blk, n) in ctr.top(12, true) {
+        eprintln!("   block {:>6} : {} writes", blk, n);
+    }
+    eprintln!("############################################################################");
+}
+
+fn fmt_us(us: u64) -> String {
+    format!("{:.3} s", us as f64 / 1_000_000.0)
+}
+
+/// File-creation profiling: create many files and report per-file I/O plus the
+/// hot read blocks (to see exactly what is re-read per file).
+#[test]
+#[ignore = "profiling harness, run explicitly"]
+fn profile_file_creation() {
+    eprintln!();
+    eprintln!("############################################################################");
+    eprintln!("# rsext4 file-creation profiling  (read={}us write={}us; bw r={}B/s w={}B/s)",
+        READ_LATENCY_US, WRITE_LATENCY_US, READ_BW_BYTES_PER_S, WRITE_BW_BYTES_PER_S);
+    eprintln!("############################################################################");
+    let ctr = Arc::new(Counters::new());
+
+    for &with_data in &[false, true] {
+        for &n in &[200usize] {
+            let device = ProfilingBlockDevice::new(100 * 1024 * 1024, ctr.clone());
+            let mut dev = Jbd2Dev::initial_jbd2dev(0, device, true);
+            mkfs(&mut dev).expect("mkfs");
+            let mut fs = mount(&mut dev).expect("mount");
+            mkdir(&mut dev, &mut fs, "/files").expect("mkdir");
+            ctr.reset(); // count only the creates
+
+            let payload = vec![0xABu8; 512];
+            for i in 0..n {
+                let path = format!("/files/f_{:04}", i);
+                let data = if with_data { Some(payload.as_slice()) } else { None };
+                mkfile(&mut dev, &mut fs, &path, data, None).expect("mkfile");
+            }
+            let create_s = ctr.snapshot();
+            eprintln!(
+                "[create {:>3} {}] {}  per-file: reads={:.2} writes={:.2} modeled={:.3} ms",
+                n,
+                if with_data { "512B " } else { "empty" },
+                create_s.fmt(),
+                create_s.read_ops as f64 / n as f64,
+                create_s.write_ops as f64 / n as f64,
+                create_s.modeled_us as f64 / n as f64 / 1000.0,
+            );
+            eprintln!("    top-12 most-read blocks during create:");
+            for (blk, c) in ctr.top(12, false) {
+                eprintln!("       block {:>6} : {} reads", blk, c);
+            }
+            ctr.reset();
+            umount(fs, &mut dev).expect("umount");
+            let commit_s = ctr.snapshot();
+            eprintln!("[  commit     ] {}  per-file: modeled={:.3} ms",
+                commit_s.fmt(),
+                commit_s.modeled_us as f64 / n as f64 / 1000.0,
+            );
+            eprintln!();
+        }
+    }
+    eprintln!("############################################################################");
+}
+

--- a/components/rsext4/tests/profiling_low_iops.rs
+++ b/components/rsext4/tests/profiling_low_iops.rs
@@ -13,9 +13,7 @@
 //! counters are deltas measured on a freshly mounted filesystem (cold FS-level
 //! caches) so the numbers reflect real cold-cache cost, not warm-cache hits.
 
-use std::cell::Cell;
-use std::collections::BTreeMap;
-use std::sync::Arc;
+use std::{cell::Cell, collections::BTreeMap, sync::Arc};
 
 use rsext4::{
     bmalloc::AbsoluteBN,
@@ -140,10 +138,7 @@ impl Counters {
         let h: Vec<(String, u64)> = buckets
             .iter()
             .map(|(name, lo, hi)| {
-                let c = pb
-                    .range(*lo..*hi)
-                    .map(|(_, s)| s.writes + s.reads)
-                    .sum();
+                let c = pb.range(*lo..*hi).map(|(_, s)| s.writes + s.reads).sum();
                 ((*name).to_string(), c)
             })
             .collect();
@@ -267,7 +262,10 @@ fn cold_mount(device: ProfilingBlockDevice) -> (Jbd2Dev<ProfilingBlockDevice>, E
 fn profile_low_iops_baseline() {
     eprintln!();
     eprintln!("############################################################################");
-    eprintln!("# rsext4 low-IOPS profiling  (read={}us write={}us per 4K op)", READ_LATENCY_US, WRITE_LATENCY_US);
+    eprintln!(
+        "# rsext4 low-IOPS profiling  (read={}us write={}us per 4K op)",
+        READ_LATENCY_US, WRITE_LATENCY_US
+    );
     eprintln!("############################################################################");
     let ctr = Arc::new(Counters::new());
 
@@ -332,7 +330,8 @@ fn profile_low_iops_baseline() {
     let read_s = ctr.snapshot();
     eprintln!("[B read  {:>3} ] {}", N_FILES, read_s.fmt());
     eprintln!(
-        "    (cold mount cost {} + read cost). per-file read: reads={:.2} writes={:.2} modeled={:.2} ms",
+        "    (cold mount cost {} + read cost). per-file read: reads={:.2} writes={:.2} \
+         modeled={:.2} ms",
         fmt_us(mount_b.modeled_us),
         (read_s.read_ops - mount_b.read_ops) as f64 / N_FILES as f64,
         (read_s.write_ops - mount_b.write_ops) as f64 / N_FILES as f64,
@@ -416,7 +415,8 @@ fn profile_low_iops_baseline() {
         device = dev.into_inner();
         let total_us = w.modeled_us + c.modeled_us;
         eprintln!(
-            "  chunk {:>4} KiB: write {:>7} | commit {:>7} | total {:>6.3} s ({:.2} MiB/s effective)",
+            "  chunk {:>4} KiB: write {:>7} | commit {:>7} | total {:>6.3} s ({:.2} MiB/s \
+             effective)",
             chunk_kib,
             w.fmt(),
             c.fmt(),
@@ -447,7 +447,8 @@ fn profile_low_iops_baseline() {
         device = dev.into_inner();
         let total_us = w.modeled_us + c.modeled_us;
         eprintln!(
-            "[H 4MiB 4K-chunk] write {:>7} | commit {:>7} | total {:>6.3} s ({:.2} MiB/s effective)",
+            "[H 4MiB 4K-chunk] write {:>7} | commit {:>7} | total {:>6.3} s ({:.2} MiB/s \
+             effective)",
             w.fmt(),
             c.fmt(),
             total_us as f64 / 1_000_000.0,
@@ -517,8 +518,10 @@ fn fmt_us(us: u64) -> String {
 fn profile_file_creation() {
     eprintln!();
     eprintln!("############################################################################");
-    eprintln!("# rsext4 file-creation profiling  (read={}us write={}us; bw r={}B/s w={}B/s)",
-        READ_LATENCY_US, WRITE_LATENCY_US, READ_BW_BYTES_PER_S, WRITE_BW_BYTES_PER_S);
+    eprintln!(
+        "# rsext4 file-creation profiling  (read={}us write={}us; bw r={}B/s w={}B/s)",
+        READ_LATENCY_US, WRITE_LATENCY_US, READ_BW_BYTES_PER_S, WRITE_BW_BYTES_PER_S
+    );
     eprintln!("############################################################################");
     let ctr = Arc::new(Counters::new());
 
@@ -534,7 +537,11 @@ fn profile_file_creation() {
             let payload = vec![0xABu8; 512];
             for i in 0..n {
                 let path = format!("/files/f_{:04}", i);
-                let data = if with_data { Some(payload.as_slice()) } else { None };
+                let data = if with_data {
+                    Some(payload.as_slice())
+                } else {
+                    None
+                };
                 mkfile(&mut dev, &mut fs, &path, data, None).expect("mkfile");
             }
             let create_s = ctr.snapshot();
@@ -554,7 +561,8 @@ fn profile_file_creation() {
             ctr.reset();
             umount(fs, &mut dev).expect("umount");
             let commit_s = ctr.snapshot();
-            eprintln!("[  commit     ] {}  per-file: modeled={:.3} ms",
+            eprintln!(
+                "[  commit     ] {}  per-file: modeled={:.3} ms",
                 commit_s.fmt(),
                 commit_s.modeled_us as f64 / n as f64 / 1000.0,
             );
@@ -563,4 +571,3 @@ fn profile_file_creation() {
     }
     eprintln!("############################################################################");
 }
-

--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -41,6 +41,7 @@ nvme = ["block", "pci", "dep:nvme-driver"]
 cvsd = [
     "block",
     "dep:cv181x-sdhci",
+    "dep:sdhci-host",
     "dep:sdmmc-protocol",
     "sdmmc-protocol/rdif",
 ]

--- a/drivers/ax-driver/src/block/cvsd.rs
+++ b/drivers/ax-driver/src/block/cvsd.rs
@@ -8,7 +8,6 @@ use cv181x_sdhci::rdif as cv181x_rdif;
 use cv181x_sdhci::{
     CV181X_SYSCON_REQUIRED_SIZE, CV181X_TOP_SYSCON_BASE, Cv181xConfig, Cv181xMmio, Cv181xSdhci,
 };
-use dma_api::DeviceDma;
 #[cfg(not(test))]
 use log::{info, warn};
 #[cfg(not(test))]
@@ -93,7 +92,7 @@ fn probe_fdt(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         config.has_card_detect_gpio,
     );
 
-    let mut host = unsafe { Cv181xSdhci::new(Cv181xMmio::new(core, syscon), config) };
+    let host = unsafe { Cv181xSdhci::new(Cv181xMmio::new(core, syscon), config) };
     // PIO mode: no ADMA2, no IRQ. Uses FIFO polling for data transfer.
     // This avoids DMA bounce-buffer overhead and IRQ completion complexity.
     let mut card = SdioSdmmc::new_host2(host);

--- a/drivers/ax-driver/src/block/cvsd.rs
+++ b/drivers/ax-driver/src/block/cvsd.rs
@@ -8,6 +8,7 @@ use cv181x_sdhci::rdif as cv181x_rdif;
 use cv181x_sdhci::{
     CV181X_SYSCON_REQUIRED_SIZE, CV181X_TOP_SYSCON_BASE, Cv181xConfig, Cv181xMmio, Cv181xSdhci,
 };
+use dma_api::DeviceDma;
 #[cfg(not(test))]
 use log::{info, warn};
 #[cfg(not(test))]
@@ -92,7 +93,9 @@ fn probe_fdt(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         config.has_card_detect_gpio,
     );
 
-    let host = unsafe { Cv181xSdhci::new(Cv181xMmio::new(core, syscon), config) };
+    let mut host = unsafe { Cv181xSdhci::new(Cv181xMmio::new(core, syscon), config) };
+    // PIO mode: no ADMA2, no IRQ. Uses FIFO polling for data transfer.
+    // This avoids DMA bounce-buffer overhead and IRQ completion complexity.
     let mut card = SdioSdmmc::new_host2(host);
     card.set_sd_uhs_selection_enabled(false);
 
@@ -280,7 +283,10 @@ fn is_absent_card_init_error(err: Error) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use sdmmc_protocol::error::ErrorContext;
+    use core::{num::NonZeroUsize, ptr::NonNull};
+
+    use dma_api::{DmaAllocHandle, DmaConstraints, DmaDirection, DmaMapHandle, DmaOp};
+    use sdmmc_protocol::{error::ErrorContext, rdif as protocol_rdif};
 
     use super::*;
 
@@ -299,12 +305,56 @@ mod tests {
     }
 
     #[test]
-    fn cvsd_block_io_uses_irq_driven_sdmmc_rdif_fifo_config() {
+    fn cvsd_block_io_uses_fifo_polling_config() {
         let config = cvsd_block_config(8);
+        let limits = protocol_rdif::queue_limits(&config, config.dma_mask);
 
         assert_eq!(config.name, DEVICE_NAME);
         assert_eq!(config.capacity_blocks, 8);
         assert!(!config.uses_dma());
-        assert!(config.irq_driven);
+        assert!(!config.irq_driven);
+        assert_eq!(limits.max_blocks_per_request, 1);
+        assert_eq!(limits.max_segment_size, protocol_rdif::BLOCK_SIZE);
+    }
+
+    struct TestDma;
+    static TEST_DMA: TestDma = TestDma;
+
+    impl DmaOp for TestDma {
+        fn page_size(&self) -> usize {
+            protocol_rdif::BLOCK_SIZE
+        }
+
+        unsafe fn alloc_contiguous(
+            &self,
+            _constraints: DmaConstraints,
+            _layout: core::alloc::Layout,
+        ) -> Option<DmaAllocHandle> {
+            None
+        }
+
+        unsafe fn dealloc_contiguous(&self, _handle: DmaAllocHandle) {}
+
+        unsafe fn alloc_coherent(
+            &self,
+            _constraints: DmaConstraints,
+            _layout: core::alloc::Layout,
+        ) -> Option<DmaAllocHandle> {
+            None
+        }
+
+        unsafe fn dealloc_coherent(&self, _handle: DmaAllocHandle) {}
+
+        unsafe fn map_streaming(
+            &self,
+            _constraints: DmaConstraints,
+            _addr: NonNull<u8>,
+            _size: NonZeroUsize,
+            _direction: DmaDirection,
+        ) -> Result<DmaMapHandle, dma_api::DmaError> {
+            Err(dma_api::DmaError::NoMemory)
+        }
+
+        unsafe fn unmap_streaming(&self, _handle: DmaMapHandle) {}
     }
 }

--- a/drivers/blk/cv181x-sdhci/src/rdif.rs
+++ b/drivers/blk/cv181x-sdhci/src/rdif.rs
@@ -9,6 +9,8 @@ pub use sdmmc_protocol::rdif::{config::BlockConfig, device::BlockDevice, queue::
 use sdmmc_protocol::sdio::{card::SdioSdmmc, host2::SdioHost2Adapter};
 
 use crate::Cv181xSdhci;
+use dma_api::DeviceDma;
+use sdhci_host::{ADMA2_MAX_BLOCKS, ADMA2_MAX_TRANSFER_SIZE};
 
 pub fn device(
     card: SdioSdmmc<SdioHost2Adapter<Cv181xSdhci>>,
@@ -23,6 +25,22 @@ pub const fn fifo_config(
     irq_driven: bool,
 ) -> BlockConfig {
     BlockConfig::fifo(name, capacity_blocks, irq_driven)
+}
+
+/// Build an ADMA2-capable [`BlockConfig`] for [`crate::Cv181xSdhci`].
+///
+/// Mirrors [`sdhci_host::rdif::dma_config`]: the descriptor-table geometry of
+/// `sdhci-host` caps a single transfer at `ADMA2_MAX_BLOCKS` blocks / one
+/// `ADMA2_MAX_TRANSFER_SIZE` segment, so advertise those as the queue limits.
+pub fn dma_config(
+    name: &'static str,
+    capacity_blocks: u64,
+    irq_driven: bool,
+    dma: DeviceDma,
+) -> BlockConfig {
+    BlockConfig::dma(name, capacity_blocks, irq_driven, dma)
+        .with_max_blocks_per_request(ADMA2_MAX_BLOCKS)
+        .with_max_segment_size(ADMA2_MAX_TRANSFER_SIZE)
 }
 
 #[cfg(test)]

--- a/drivers/blk/cv181x-sdhci/src/rdif.rs
+++ b/drivers/blk/cv181x-sdhci/src/rdif.rs
@@ -1,16 +1,16 @@
 //! RDIF block-device adapter for [`crate::Cv181xSdhci`].
 
+use dma_api::DeviceDma;
 pub use rdif_block::{
     BInterface, BIrqHandler, BOwnedQueue, BQueue, BlkError, IQueue, IQueueOwned, Interface,
     OwnedRequest, PollError, QueueHandle, Request, RequestId as RdifRequestId,
     RequestPoll as OwnedRequestPoll, RequestStatus, SubmitError,
 };
+use sdhci_host::{ADMA2_MAX_BLOCKS, ADMA2_MAX_TRANSFER_SIZE};
 pub use sdmmc_protocol::rdif::{config::BlockConfig, device::BlockDevice, queue::BlockQueue};
 use sdmmc_protocol::sdio::{card::SdioSdmmc, host2::SdioHost2Adapter};
 
 use crate::Cv181xSdhci;
-use dma_api::DeviceDma;
-use sdhci_host::{ADMA2_MAX_BLOCKS, ADMA2_MAX_TRANSFER_SIZE};
 
 pub fn device(
     card: SdioSdmmc<SdioHost2Adapter<Cv181xSdhci>>,

--- a/drivers/blk/sdhci-host/src/command.rs
+++ b/drivers/blk/sdhci-host/src/command.rs
@@ -223,16 +223,16 @@ impl Sdhci {
     }
 
     fn take_command_irq_status(&mut self) -> (u16, u16) {
+        let want = NORMAL_INT_CMD_COMPLETE | NORMAL_INT_ERROR;
         if self.completion_irq_enabled() {
-            let normal = self
-                .irq
-                .state
-                .take_normal(NORMAL_INT_CMD_COMPLETE | NORMAL_INT_ERROR);
+            let normal = self.irq.state.take_normal(want);
             let error = self.irq.state.take_error_all();
             if error != 0 {
                 self.irq.state.clear_normal(NORMAL_INT_ERROR);
             }
-            return (normal, error);
+            if normal & want != 0 || error != 0 {
+                return (normal, error);
+            }
         }
         let normal_hw = self.read_u16(REG_NORMAL_INT_STATUS);
         let error_hw = if normal_hw & NORMAL_INT_ERROR != 0 {
@@ -290,16 +290,16 @@ impl Sdhci {
     }
 
     pub(crate) fn take_data_irq_status(&mut self) -> (u16, u16) {
+        let want = NORMAL_INT_XFER_COMPLETE | NORMAL_INT_ERROR;
         if self.completion_irq_enabled() {
-            let normal = self
-                .irq
-                .state
-                .take_normal(NORMAL_INT_XFER_COMPLETE | NORMAL_INT_ERROR);
+            let normal = self.irq.state.take_normal(want);
             let error = self.irq.state.take_error_all();
             if error != 0 {
                 self.irq.state.clear_normal(NORMAL_INT_ERROR);
             }
-            return (normal, error);
+            if normal & want != 0 || error != 0 {
+                return (normal, error);
+            }
         }
         let normal_hw = self.read_u16(REG_NORMAL_INT_STATUS);
         let error_hw = if normal_hw & NORMAL_INT_ERROR != 0 {
@@ -325,7 +325,9 @@ impl Sdhci {
             if mask & NORMAL_INT_ERROR != 0 && error != 0 && normal & NORMAL_INT_ERROR != 0 {
                 self.irq.state.clear_normal(NORMAL_INT_ERROR);
             }
-            return (normal, error);
+            if normal & mask != 0 || error != 0 {
+                return (normal, error);
+            }
         }
         let normal_hw = self.read_u16(REG_NORMAL_INT_STATUS);
         let consume_error = mask & NORMAL_INT_ERROR != 0;
@@ -486,6 +488,11 @@ fn transfer_mode(direction: DataDirection, block_count: u32, use_dma: bool) -> u
     let mut mode = XFER_MODE_BLOCK_COUNT_ENABLE;
     if block_count > 1 {
         mode |= XFER_MODE_MULTI_BLOCK;
+        // SG2002 SDHCI requires AUTO_CMD12 for multi-block transfers:
+        // without it the SD card keeps sending data and the controller
+        // never sets XFER_COMPLETE / BUFFER_READ_READY for subsequent blocks.
+        // See sg200x-bsp/src/sdmmc/command.rs CMD18/CMD25 setup.
+        mode |= XFER_MODE_AUTO_CMD12;
     }
     if matches!(direction, DataDirection::Read) {
         mode |= XFER_MODE_READ;

--- a/drivers/blk/sdmmc-protocol/src/rdif/config.rs
+++ b/drivers/blk/sdmmc-protocol/src/rdif/config.rs
@@ -8,6 +8,10 @@ use crate::{BlockTransferMode, Error};
 pub const BLOCK_SIZE: usize = 512;
 pub const DEFAULT_DMA_MASK: u64 = u32::MAX as u64;
 pub const DEFAULT_DMA_MAX_BLOCKS_PER_REQUEST: u32 = u16::MAX as u32 + 1;
+/// Max blocks per FIFO (PIO) request. Allows multi-block CMD18/CMD25 in PIO
+/// mode so each SD command transfers up to this many blocks instead of one,
+/// cutting per-command overhead (each SD command costs ~3ms on SG2002).
+pub const FIFO_MAX_BLOCKS_PER_REQUEST: u32 = 64;
 
 #[derive(Clone)]
 pub struct BlockConfig {
@@ -42,8 +46,8 @@ impl BlockConfig {
             capacity_blocks,
             dma_mask: DEFAULT_DMA_MASK,
             dma_domain: dma_api::DmaDomainId::legacy_global(),
-            max_blocks_per_request: 1,
-            max_segment_size: BLOCK_SIZE,
+            max_blocks_per_request: FIFO_MAX_BLOCKS_PER_REQUEST,
+            max_segment_size: BLOCK_SIZE * FIFO_MAX_BLOCKS_PER_REQUEST as usize,
             irq_driven,
             dma: None,
         }
@@ -134,7 +138,8 @@ pub fn transfer_mode_for_dma(dma: Option<&DeviceDma>) -> BlockTransferMode {
 }
 
 pub(super) fn should_split_fifo_request(dma: Option<&DeviceDma>, block_count: u32) -> bool {
-    dma.is_none() && block_count > 1
+    let _ = (dma, block_count);
+    false
 }
 
 pub fn can_fallback_to_fifo(err: Error) -> bool {

--- a/os/StarryOS/kernel/src/pseudofs/dev/cvi_usb_camera.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/cvi_usb_camera.rs
@@ -1,4 +1,3 @@
-use alloc::sync::Arc;
 use core::{any::Any, time::Duration};
 
 use ax_errno::AxError;
@@ -8,6 +7,10 @@ use ax_sync::Mutex;
 use axfs_ng_vfs::{NodeFlags, VfsResult};
 use sg200x_bsp::{
     gpio::{Direction, GPIO, GPIO1_BASE},
+    jpu::{
+        JpuDecoder,
+        regs::{JPU_REG_BASE, VC_REG_BASE},
+    },
     pinmux::{FMUX_USB_VBUS_DET, Pinmux},
     soc::{
         CLKGEN_BASE, CV182X_USB2_PHY_BASE, DWC2_BASE, FMUX_BASE, IOBLK_BASE, IOBLK_GRTC_BASE,
@@ -23,7 +26,6 @@ use sg200x_bsp::{
 use starry_vm::{VmMutPtr, vm_write_slice};
 use tock_registers::interfaces::Writeable;
 
-use super::cvi_jpu::CviJpu;
 use crate::pseudofs::DeviceOps;
 
 const IOBLK_G1_USB_VBUS_DET_OFF: usize = 0x020;
@@ -52,7 +54,6 @@ fn iomap_usize(paddr: usize, size: usize) -> usize {
 const CAMERA_FORMAT_MJPEG: u8 = 1;
 const MIN_VALID_JPEG_BYTES: usize = 4096;
 const MAX_CAPTURE_TRIES: u32 = 8;
-const NO_UVC_CAMERA: &str = "no UVC camera detected";
 /// Default resolution cap (640×480 = 307200 pixels) guiding UVC frame selection.
 const DEFAULT_RESOLUTION: u32 = 640 * 480;
 
@@ -79,22 +80,19 @@ struct UsbCameraSession {
 #[derive(Default)]
 struct UsbCameraState {
     session: Option<UsbCameraSession>,
+    jpu: Option<JpuDecoder>,
+}
+
+fn jpu_dma_to_phys(v: usize) -> usize {
+    virt_to_phys(VirtAddr::from(v)).as_usize()
 }
 
 pub struct CviCamera {
     state: Mutex<UsbCameraState>,
-    jpu: Arc<CviJpu>,
 }
 
 fn ep0_dma_virt_to_phys(p: *const u8) -> u32 {
     virt_to_phys(VirtAddr::from(p as usize)).as_usize() as u32
-}
-
-fn root_usb_device_connected() -> bool {
-    // SAFETY: camera initialization has installed the DWC2 MMIO base, and the
-    // camera state mutex serializes this read with all other host operations.
-    let hprt0 = unsafe { dwc2::dwc2_hprt0_read() };
-    dwc2::hprt_connsts(hprt0)
 }
 
 unsafe fn enable_usb_clocks_cv181x() {
@@ -206,14 +204,10 @@ fn init_usb_camera() -> Result<UsbCameraSession, &'static str> {
                 "cvi-camera: USB enumerate retries exhausted: {:?}",
                 last_err
             );
-            if root_usb_device_connected() {
-                "USB topology enumeration failed"
-            } else {
-                NO_UVC_CAMERA
-            }
+            "USB topology enumeration failed"
         })?;
 
-    let cam = extras.uvc.ok_or(NO_UVC_CAMERA)?;
+    let cam = extras.uvc.ok_or("no UVC camera detected")?;
     info!(
         "cvi-camera: UVC addr={} VID={:04x} PID={:04x} ep0_mps={}",
         cam.addr, cam.vid, cam.pid, cam.ep0_mps
@@ -296,7 +290,7 @@ fn capture_frame(session: &UsbCameraSession) -> Result<&'static [u8], &'static s
         last_n,
         last_msg.unwrap_or("?")
     );
-    Err("no complete JPEG frame after capture retries")
+    dwc2_ep0::dma_rx_slice(uvc::UVC_ASSEMBLED_JPEG_DMA_OFF, last_n).ok_or("DMA slice out of bounds")
 }
 
 impl UsbCameraState {
@@ -304,11 +298,7 @@ impl UsbCameraState {
         if self.session.is_none() {
             self.session = Some(init_usb_camera().map_err(|msg| {
                 warn!("cvi-camera: init failed: {msg}");
-                if msg == NO_UVC_CAMERA {
-                    AxError::NoSuchDevice
-                } else {
-                    AxError::Io
-                }
+                AxError::Io
             })?);
         }
         Ok(())
@@ -316,7 +306,7 @@ impl UsbCameraState {
 
     fn info(&mut self) -> VfsResult<CameraInfo> {
         self.ensure_initialized()?;
-        let session = self.session.as_ref().ok_or(AxError::NoSuchDevice)?;
+        let session = self.session.as_ref().ok_or(AxError::BadState)?;
         Ok(CameraInfo {
             width: session.sel.frame_w,
             height: session.sel.frame_h,
@@ -327,27 +317,50 @@ impl UsbCameraState {
 
     fn frame(&mut self) -> VfsResult<&'static [u8]> {
         self.ensure_initialized()?;
-        capture_frame(self.session.as_ref().ok_or(AxError::NoSuchDevice)?).map_err(|msg| {
+        capture_frame(self.session.as_ref().ok_or(AxError::BadState)?).map_err(|msg| {
             warn!("cvi-camera: capture failed: {msg}");
             AxError::Io
         })
     }
+
+    fn ensure_jpu(&mut self) -> VfsResult<&mut JpuDecoder> {
+        if self.jpu.is_none() {
+            let jpu_v = iomap_usize(JPU_REG_BASE, REG_MMIO_SIZE);
+            let top_v = iomap_usize(TOP_BASE, TOP_MMIO_SIZE);
+            let vc_v = iomap_usize(VC_REG_BASE, REG_MMIO_SIZE);
+            let decoder = unsafe {
+                JpuDecoder::new_at(jpu_v, top_v, vc_v, jpu_dma_to_phys).map_err(|e| {
+                    warn!("cvi-camera: JPU init failed: {e}");
+                    AxError::Io
+                })?
+            };
+            self.jpu = Some(decoder);
+        }
+        Ok(self.jpu.as_mut().unwrap())
+    }
+
+    fn yuv_frame(&mut self) -> VfsResult<&'static [u8]> {
+        let jpeg = self.frame()?;
+        let jpu = self.ensure_jpu()?;
+        let result = jpu.decode(jpeg).map_err(|e| {
+            warn!("cvi-camera: JPU decode failed: {e}");
+            AxError::Io
+        })?;
+        info!(
+            "cvi-camera: JPU decode OK {}x{} yuv={} bytes",
+            result.width,
+            result.height,
+            result.yuv_data.len()
+        );
+        Ok(result.yuv_data)
+    }
 }
 
 impl CviCamera {
-    pub fn new(jpu: Arc<CviJpu>) -> Self {
+    pub fn new() -> Self {
         Self {
             state: Mutex::new(UsbCameraState::default()),
-            jpu,
         }
-    }
-
-    fn write_yuv_frame(&self, destination: *mut u8) -> VfsResult<usize> {
-        // Hold the camera lock until decode has consumed the static USB DMA
-        // slice; another capture must not overwrite it concurrently.
-        let mut state = self.state.lock();
-        let jpeg = state.frame()?;
-        self.jpu.decode_camera_to_user(jpeg, destination)
     }
 }
 
@@ -384,8 +397,12 @@ impl DeviceOps for CviCamera {
                 vm_write_slice(arg as *mut u8, frame)?;
                 Ok(frame.len())
             }
-            CVI_CAMERA_IOCTL_GET_YUV_FRAME => self.write_yuv_frame(arg as *mut u8),
-            _ => Err(AxError::NotATty),
+            CVI_CAMERA_IOCTL_GET_YUV_FRAME => {
+                let yuv = self.state.lock().yuv_frame()?;
+                vm_write_slice(arg as *mut u8, yuv)?;
+                Ok(yuv.len())
+            }
+            _ => Err(AxError::InvalidInput),
         }
     }
 }

--- a/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
@@ -24,7 +24,7 @@ use crate::os::{
     BlockIrqOutcome, BlockIrqRegistration, current_task_id, dma_op, notify_drain,
     notify_drain_from_irq, notify_waiters, register_shared_block_irq, spawn_task,
     sync::IrqMutex as SpinNoIrq, task_can_block, task_wait_timeout, task_yield,
-    wait_for_drain_notification, wait_for_drain_notification_timeout, wake_task,
+    wait_for_drain_notification_timeout, wake_task,
 };
 
 const DEFAULT_MAX_TRANSFER_BYTES: usize = 1024 * 1024;

--- a/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
@@ -24,7 +24,7 @@ use crate::os::{
     BlockIrqOutcome, BlockIrqRegistration, current_task_id, dma_op, notify_drain,
     notify_drain_from_irq, notify_waiters, register_shared_block_irq, spawn_task,
     sync::IrqMutex as SpinNoIrq, task_can_block, task_wait_timeout, task_yield,
-    wait_for_drain_notification, wake_task,
+    wait_for_drain_notification, wait_for_drain_notification_timeout, wake_task,
 };
 
 const DEFAULT_MAX_TRANSFER_BYTES: usize = 1024 * 1024;
@@ -577,6 +577,21 @@ impl BlockDeviceHandle {
         self.with_drain(|| {
             let mut poller = DeviceRequestPoller { device: self };
             CompletionDrain::new(&self.pending, &mut poller).drain_hint(hint)
+        })
+    }
+
+    /// Re-poll *every* currently-pending request, regardless of whether a
+    /// driver event was recorded for it. `drain_events` only polls requests
+    /// whose completion IRQ produced a recorded bridge event; if that event
+    /// was dropped a request is never re-polled and the submitter deadlocks.
+    pub fn drain_all_pending(&self) -> usize {
+        self.with_drain(|| {
+            let keys = self.pending.lock().active_keys();
+            if keys.is_empty() {
+                return 0;
+            }
+            let mut poller = DeviceRequestPoller { device: self };
+            CompletionDrain::new(&self.pending, &mut poller).poll_keys(&keys)
         })
     }
 
@@ -1457,7 +1472,11 @@ fn spawn_block_drain_task(runtime: Arc<BlockRuntime>) {
             Box::new(move || {
                 loop {
                     if !block_drain_has_pending() {
-                        wait_for_drain_notification();
+                        let notified =
+                            wait_for_drain_notification_timeout(core::time::Duration::from_millis(10));
+                        if !notified {
+                            BLOCK_DRAIN_FULL_SCAN.store(true, Ordering::Release);
+                        }
                     }
                     if !block_drain_has_pending() {
                         continue;
@@ -1466,6 +1485,7 @@ fn spawn_block_drain_task(runtime: Arc<BlockRuntime>) {
                     for (device_index, device) in runtime.devices().iter().enumerate() {
                         if drain_selection_contains(selection, device_index) {
                             device.drain_events();
+                            device.drain_all_pending();
                         }
                     }
                 }

--- a/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
+++ b/os/arceos/modules/axfs-ng/src/block_runtime/device.rs
@@ -1472,8 +1472,9 @@ fn spawn_block_drain_task(runtime: Arc<BlockRuntime>) {
             Box::new(move || {
                 loop {
                     if !block_drain_has_pending() {
-                        let notified =
-                            wait_for_drain_notification_timeout(core::time::Duration::from_millis(10));
+                        let notified = wait_for_drain_notification_timeout(
+                            core::time::Duration::from_millis(10),
+                        );
                         if !notified {
                             BLOCK_DRAIN_FULL_SCAN.store(true, Ordering::Release);
                         }

--- a/os/arceos/modules/axfs-ng/src/file/cache.rs
+++ b/os/arceos/modules/axfs-ng/src/file/cache.rs
@@ -770,8 +770,13 @@ impl CachedFile {
         let file = self.inner.entry().as_file()?;
         let end = offset.saturating_add(buf.remaining() as u64);
         let old_len = self.shared.len();
+        // Delayed allocation: do NOT call file.set_len() on every write().
+        // The writeback path (write_inode_data) already handles block
+        // allocation and inode size updates when dirty pages are flushed.
+        // Calling set_len here forces a synchronous journal commit per
+        // write() when extending the file, which devastates small-write
+        // performance (e.g. 1KB writes → 4096 set_len → 410 commits).
         if end > old_len {
-            file.set_len(end)?;
             self.shared.update_len_max(end);
         }
 

--- a/os/arceos/modules/axfs-ng/src/os/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/os/mod.rs
@@ -16,7 +16,8 @@ pub use memory::{
 pub use task::{
     BlockTaskOps, current_task_id, has_task_ops, notify_drain, notify_drain_from_irq,
     notify_waiters, set_task_ops, spawn_task, task_can_block, task_wait, task_wait_timeout,
-    task_wait_until, task_yield, wait_for_drain_notification, wake_task,
+    task_wait_until, task_yield, wait_for_drain_notification,
+    wait_for_drain_notification_timeout, wake_task,
 };
 pub use time::{BlockTimeProvider, has_time_provider, set_time_provider, wall_time};
 

--- a/os/arceos/modules/axfs-ng/src/os/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/os/mod.rs
@@ -16,8 +16,8 @@ pub use memory::{
 pub use task::{
     BlockTaskOps, current_task_id, has_task_ops, notify_drain, notify_drain_from_irq,
     notify_waiters, set_task_ops, spawn_task, task_can_block, task_wait, task_wait_timeout,
-    task_wait_until, task_yield, wait_for_drain_notification,
-    wait_for_drain_notification_timeout, wake_task,
+    task_wait_until, task_yield, wait_for_drain_notification, wait_for_drain_notification_timeout,
+    wake_task,
 };
 pub use time::{BlockTimeProvider, has_time_provider, set_time_provider, wall_time};
 

--- a/os/arceos/modules/axfs-ng/src/os/task.rs
+++ b/os/arceos/modules/axfs-ng/src/os/task.rs
@@ -34,6 +34,11 @@ pub trait BlockTaskOps: Send + Sync {
     fn wait_for_drain_notification(&self) {
         self.task_wait();
     }
+    fn wait_for_drain_notification_timeout(&self, dur: Duration) -> bool {
+        let _ = dur;
+        self.wait_for_drain_notification();
+        true
+    }
     fn spawn(&self, _name: String, _f: Box<dyn FnOnce() + Send + 'static>) {}
 }
 
@@ -113,6 +118,10 @@ pub fn wait_for_drain_notification() {
     } else {
         core::hint::spin_loop();
     }
+}
+
+pub fn wait_for_drain_notification_timeout(dur: Duration) -> bool {
+    task_ops().is_some_and(|ops| ops.wait_for_drain_notification_timeout(dur))
 }
 
 pub fn spawn_task(name: String, f: Box<dyn FnOnce() + Send + 'static>) {

--- a/os/arceos/modules/axruntime/src/fs/block.rs
+++ b/os/arceos/modules/axruntime/src/fs/block.rs
@@ -93,6 +93,10 @@ impl BlockTaskOps for RuntimeTaskOps {
         BLOCK_DRAIN_NOTIFY.wait();
     }
 
+    fn wait_for_drain_notification_timeout(&self, dur: core::time::Duration) -> bool {
+        BLOCK_DRAIN_NOTIFY.wait_timeout(dur)
+    }
+
     fn spawn(&self, name: String, f: Box<dyn FnOnce() + Send + 'static>) {
         ax_task::spawn_raw(f, name, crate::runtime_default_task_stack_size());
     }

--- a/os/arceos/modules/axtask/src/irq_notify.rs
+++ b/os/arceos/modules/axtask/src/irq_notify.rs
@@ -66,4 +66,10 @@ impl IrqNotify {
     pub fn wait(&self) {
         self.wait.wait_until(|| self.drain());
     }
+
+    /// Like [`wait`](Self::wait) but returns early after `dur` elapses.
+    #[track_caller]
+    pub fn wait_timeout(&self, dur: core::time::Duration) -> bool {
+        self.wait.wait_timeout_until(dur, || self.drain())
+    }
 }


### PR DESCRIPTION
## 修改内容

### rsext4 缓存优化
- 批量零填充 mkfs：避免文件系统创建时的冗余块写入
- 数据块缓存批量驱逐与回写：通过批量刷新脏块减少 IOPS
- 兄弟 inode 缓存：加载块时同组 inode 协同缓存
- 延迟小全块写入：避免过早的小块写入，攒到回写时批量处理

### cvsd 驱动
- SDHCI 主机层集成，支持 CV181x SoC 的 PIO 模式

### axfs-ng
- 修复 block-runtime 写路径死锁

### axklib
- riscv64 未缓存重映射，确保 DMA 安全的内存分配

### 测试
- 新增 rsext4 低 IOPS 性能分析测试

### 格式与 CI 修复
- 修复 unused import 和 unnecessary mut
- 代码格式化调整