### PR TITLE
fix(ax-runtime): restore CRLF for queued console logs

### DIFF
--- a/os/arceos/modules/axruntime/src/serial/ingress.rs
+++ b/os/arceos/modules/axruntime/src/serial/ingress.rs
@@ -61,7 +61,7 @@ impl TxIngress {
         let Some(mut state) = self.state.try_lock() else {
             return 0;
         };
-        let accepted = submit_locked(&mut state, bytes);
+        let accepted = submit_text_locked(&mut state, bytes);
         drop(state);
         if accepted > 0 {
             if ax_hal::irq::in_irq_context() {
@@ -131,6 +131,39 @@ fn submit_locked(state: &mut TxQueueState, bytes: &[u8]) -> usize {
     accepted
 }
 
+fn submit_text_locked(state: &mut TxQueueState, bytes: &[u8]) -> usize {
+    if bytes.is_empty() || !state.accepting {
+        return 0;
+    }
+
+    let mut accepted = 0;
+    while accepted < bytes.len() && state.frames.len() < TX_FRAME_CAPACITY {
+        let mut encoded = [0; TX_FRAME_BYTES];
+        let mut encoded_len = 0;
+        while accepted < bytes.len() {
+            let byte = bytes[accepted];
+            let required = if byte == b'\n' { 2 } else { 1 };
+            if encoded_len + required > encoded.len() {
+                break;
+            }
+            if byte == b'\n' {
+                encoded[encoded_len] = b'\r';
+                encoded_len += 1;
+            }
+            encoded[encoded_len] = byte;
+            encoded_len += 1;
+            accepted += 1;
+        }
+        state
+            .frames
+            .push_back(TxFrame::new(&encoded[..encoded_len]));
+    }
+    if accepted > 0 {
+        state.idle = false;
+    }
+    accepted
+}
+
 fn publish_idle_locked(state: &mut TxQueueState, worker_empty: bool, hardware_idle: bool) -> bool {
     let idle = worker_empty && state.frames.is_empty() && hardware_idle;
     let became_idle = idle && !state.idle;
@@ -172,6 +205,24 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn text_log_submission_expands_line_feeds_to_crlf() {
+        let mut state = TxQueueState {
+            accepting: true,
+            idle: true,
+            frames: VecDeque::new(),
+        };
+
+        assert_eq!(submit_text_locked(&mut state, b"first\nsecond\n"), 13);
+
+        let output = state
+            .frames
+            .drain(..)
+            .flat_map(|frame| frame.bytes().to_vec())
+            .collect::<Vec<_>>();
+        assert_eq!(output, b"first\r\nsecond\r\n");
+    }
 
     #[test]
     fn queue_order_is_the_lock_linearization_order() {


### PR DESCRIPTION
## 问题

#1675 将控制台日志统一接入 runtime UART TX 队列。

重构前，内核日志通过 `write_text_bytes()` 输出，该接口会将 `LF` 转换为 `CRLF`。重构后，runtime console 接管串口时，日志直接通过 TX 队列发送，绕过了原有的文本换行转换。

这会导致 StarryOS 串口终端在进入用户空间后出现换行不回到行首、日志和命令行显示错位等问题。

## 修复

在普通日志进入 TX 队列时恢复 `LF → CRLF` 转换：

- 保留 #1675 引入的统一 UART 调度机制；
- 使用固定大小 TX 帧完成转换，不进行堆内存分配；
- 返回值继续统计原始日志字节数，不影响日志丢弃统计；
- 原始串口、TTY 和二进制数据仍保持原样发送；
- 不修改 panic 直写路径。

本次修复仅修改 `axruntime` 的日志入队路径。