### PR TITLE
fix(starry-pwm): use iomap instead of phys_to_virt for SG2002 PWM

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/pwm/platform/sg2002.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/pwm/platform/sg2002.rs
@@ -1,4 +1,4 @@
-use ax_hal::mem::{PhysAddr, phys_to_virt};
+use ax_memory_addr::PhysAddr;
 use axfs_ng_vfs::{VfsError, VfsResult};
 use rdif_pwm::{DriverGeneric, Interface as PwmInterface, PwmError, PwmPolarity, PwmState};
 use sg200x_bsp::{
@@ -45,10 +45,12 @@ pub(in crate::pseudofs::dev::pwm) fn pwmchip_index(chip_number: u8) -> Option<u8
 impl PwmHardware {
     pub(in crate::pseudofs::dev::pwm) fn new(index: u8) -> Self {
         let pwm_paddr = PWM0_BASE + index as usize * 0x1000;
-        let pwm_addr = phys_to_virt(PhysAddr::from_usize(pwm_paddr)).as_usize();
+        let pwm_vaddr = axklib::mem::iomap(PhysAddr::from(pwm_paddr), 0x1000)
+            .expect("failed to iomap PWM controller")
+            .as_usize();
         Self {
             controller: Sg2002Pwm {
-                pwm: unsafe { Pwm::new(pwm_addr) },
+                pwm: unsafe { Pwm::new(pwm_vaddr) },
             },
         }
     }


### PR DESCRIPTION
## 问题

`phys_to_virt` 在动态平台（`plat-dyn`）下返回身份映射地址（`PHYS_VIRT_OFFSET=0`），
该地址未被页表覆盖。访问 PWM 寄存器时触发 page fault，内核 panic。

SG2002 串口驱动在 `b0752d4e4` 已有同类问题，用 `iomap` 修复。

## 修复

1 个文件，5 行改动：

```diff
-let pwm_addr = phys_to_virt(PhysAddr::from_usize(pwm_paddr)).as_usize();
+let pwm_vaddr = axklib::mem::iomap(PhysAddr::from(pwm_paddr), 0x1000)
+    .expect("failed to iomap PWM controller")
+    .as_usize();
```
## 验证
内核	结果
dev 原版	❌ 寄存器写入时死锁
dev + iomap	✅ 正常
使用
# 引脚配置
echo "0x68 2" > /dev/pinmux   # A18→PWM6
echo "0x64 2" > /dev/pinmux   # A19→PWM7
echo "0xD0 7" > /dev/pinmux   # P18→PWM4
echo "0xD4 7" > /dev/pinmux   # P19→PWM5

# PWM1 = pwmchip4：ch0=PWM4, ch1=PWM5, ch2=PWM6, ch3=PWM7
echo 2 > /sys/class/pwm/pwmchip4/export
echo 100000000 > /sys/class/pwm/pwmchip4/pwm2/period
echo 50000000 > /sys/class/pwm/pwmchip4/pwm2/duty_cycle
echo 1 > /sys/class/pwm/pwmchip4/pwm2/enable