### PR TITLE
ci: harden axloader HTTP smoke against transient apt-get failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,8 +650,21 @@ jobs:
               }
               UEFI_FIRMWARE="$(find_uefi_firmware || true)"
               if [ -z "${UEFI_FIRMWARE}" ]; then
-                sudo apt-get update
-                sudo apt-get install -y --no-install-recommends ovmf
+                # apt against the runner mirrors fails transiently with exit 100
+                # (mirror hiccup / lock); a bare invocation lets a flaky mirror
+                # abort the whole smoke, so retry with backoff before giving up.
+                for attempt in 1 2 3; do
+                  if sudo apt-get update -o Acquire::Retries=3 \
+                    && sudo apt-get install -y --no-install-recommends \
+                         -o Acquire::Retries=3 ovmf; then
+                    break
+                  fi
+                  if [ "${attempt}" -eq 3 ]; then
+                    echo "ERROR: apt-get failed to install OVMF after 3 attempts." >&2
+                    exit 1
+                  fi
+                  sleep "$((attempt * 10))"
+                done
                 UEFI_FIRMWARE="$(find_uefi_firmware || true)"
               fi
               if [ -z "${UEFI_FIRMWARE}" ]; then


### PR DESCRIPTION
axloader HTTP smoke（`.github/workflows/ci.yml`）在未预装 OVMF 的 runner 上经 `apt-get update` + `apt-get install ovmf` 获取 UEFI 固件。裸调用在镜像瞬时故障（mirror 抖动 / dpkg 锁）时以 `apt` 的失败码 `exit 100` 中止整个 smoke —— #1676 观察到任务启动约 8 秒即失败，与 `apt-get update` 的时长吻合，且该 job 不涉及被测代码。

对这两步加有界重试（3 次 + 线性退避 + `Acquire::Retries=3`）：瞬时镜像故障自愈，仅在三次均失败时以明确错误退出。axloader 逻辑与其它步骤不变。

Closes #1676
