### PR TITLE
feat(axbuild): support session-shared board files

### DIFF
--- a/.claude/skills/starry-test-suit/SKILL.md
+++ b/.claude/skills/starry-test-suit/SKILL.md
@@ -69,7 +69,7 @@ Prefer multi-line TOML strings for longer shell commands. Keep `fail_regex` narr
 
 ## Failure Propagation
 
-- These failure-propagation requirements are for Starry QEMU tests. Board tests continue to use the existing `board-<board>.toml` / board runner flow with `success_regex`, `fail_regex`, and optional `shell_init_cmd`; do not force board cases into the QEMU grouped/C runner structure.
+- These failure-propagation requirements are for Starry QEMU tests. Board tests continue to use the existing `board-<board>.toml` / board runner flow with `success_regex`, `fail_regex`, and optional `shell_init_cmd`; a board case may reuse the C asset builder only to populate its session upload root.
 - Starry QEMU tests must make real failures visible to the runner. Do not print a failure message while still letting `cargo xtask starry test qemu ...` exit successfully.
 - QEMU `success_regex` and `fail_regex` must reliably distinguish the intended pass and fail states. A failure marker such as `STARRY_GROUPED_TEST_FAILED` must be matched by `fail_regex`, and the all-passed marker must only appear after every required subcase has passed.
 - In QEMU grouped/system wrappers, any failing subcase must print the per-subcase failure marker, suppress the grouped all-passed marker, print a grouped failure marker, and return a nonzero result to the outer runner.
@@ -93,6 +93,11 @@ Prefer multi-line TOML strings for longer shell commands. Keep `fail_regex` narr
   `${sessionFile:<relative-path>}`, `${boardServerIp}`, or
   `${boardServerHttpBaseUrl}` in `shell_init_cmd` when a board must download a
   session asset or contact the board-facing server address.
+- A board case with `c/CMakeLists.txt` installs into
+  `target/<target>/board-cases/<case>/runs/<run-id>/upload/`. Every regular
+  installed file is uploaded automatically with the same relative path. Do not
+  list generated files in `session_files`; keep explicit `wget`, `chmod`, and
+  execution commands in `shell_init_cmd` because ostool does not execute them.
 
 ## Validation
 

--- a/.claude/skills/starry-test-suit/SKILL.md
+++ b/.claude/skills/starry-test-suit/SKILL.md
@@ -87,6 +87,12 @@ Prefer multi-line TOML strings for longer shell commands. Keep `fail_regex` narr
 - For grouped cases, keep `test_commands` aligned with installed guest paths and include the grouped success/fail regexes.
 - For `qemu/system` C subcases, install binaries to `usr/bin/starry-test-suit`. Put shared system rootfs preparation in `system/prebuild.sh`, not in subcase-local `prebuild.sh`. If a subcase is arch-specific, generate an explicit skip binary or skip in the program; do not rely on subcase-local `qemu-<arch>.toml` filtering.
 - Board case names and board config names should match the actual board target, such as `board-orangepi-5-plus.toml`.
+- Board cases may declare `session_files` relative to the directory containing
+  `board-<board>.toml`. Keep each path unchanged from local lookup through the
+  session endpoint; do not add aliases or remote names. Use
+  `${sessionFile:<relative-path>}`, `${boardServerIp}`, or
+  `${boardServerHttpBaseUrl}` in `shell_init_cmd` when a board must download a
+  session asset or contact the board-facing server address.
 
 ## Validation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +467,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +489,102 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1757,6 +1876,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "borsh"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +2069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -3065,6 +3215,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,6 +3260,27 @@ dependencies = [
  "log",
  "rdif-intc",
  "rdrive",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3204,6 +3381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
+ "parking",
  "pin-project-lite",
 ]
 
@@ -3452,6 +3630,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3525,6 +3713,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -3802,6 +4003,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
 
 [[package]]
 name = "hmac"
@@ -4191,6 +4401,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
+ "block-padding",
  "generic-array",
 ]
 
@@ -4546,6 +4757,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fbe853b403ae61a04233030ae8a79d94975281ed9770a1f9e246732b534b28d"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "keyring"
+version = "4.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0298a59b384c540e408a600c8b375a09b49c3f97debc080e2c30675d79a6368a"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -5124,6 +5356,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
 dependencies = [
+ "num-bigint",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -5136,6 +5369,16 @@ name = "num-align"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4b86e8ef968de2261141fc760ee57cae8fabb3a0e756b3390a4c4871b16c3d1"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-complex"
@@ -5210,6 +5453,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -5349,10 +5593,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "ostool"
-version = "0.24.1"
+name = "ordered-stream"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96114c735dfdd705ad04fe809029a347c76056cbf243c12a4c4fbbe9f1e494b5"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "ostool"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e925c3719ebd62bc412332e9b78ad994a1fcb96a02840776e8708b0cab748324"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5364,10 +5618,12 @@ dependencies = [
  "crossterm 0.29.0",
  "env_logger",
  "fitimage",
+ "fs4",
  "futures",
  "httpboot-protocol",
  "indicatif",
  "jkconfig 0.2.5",
+ "keyring",
  "log",
  "lzma-rs",
  "network-interface",
@@ -5390,6 +5646,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "uboot-shell",
  "ureq",
+ "url",
 ]
 
 [[package]]
@@ -5452,6 +5709,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -5645,6 +5908,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5695,6 +5969,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6550,6 +6838,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -7146,6 +7435,25 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
+]
 
 [[package]]
 name = "security-framework"
@@ -8689,6 +8997,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "uefi"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8853,6 +9172,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -8926,6 +9246,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.3",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -9379,6 +9700,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9723,6 +10057,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe18fb60dc696039e738717b76eaea21e7a4489bbb1885020b43c94236d7e98a"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe96480bed92df2b442a1a30df364e12d08eed03aeb061f2b8dc6afb2be91119"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zero"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9821,4 +10227,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.118",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -316,7 +316,7 @@ lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = { version = "=0.12.2", default-features = false, features = ["lock_api", "once", "lazylock"] }
 atomic-waker = { version = "1.1", default-features = false }
-ostool = { version = "0.24.0" }
+ostool = { version = "0.26.0" }
 riscv = { version = "0.16.1", default-features = false }
 sbi-rt = { version = "0.0.4", default-features = false }
 uefi = "0.37.0"

--- a/scripts/axbuild/src/board.rs
+++ b/scripts/axbuild/src/board.rs
@@ -35,17 +35,16 @@ pub async fn execute(command: Command) -> anyhow::Result<()> {
     match command {
         Command::Ls(server) => {
             let global_config = board::load_board_global_config_with_notice()?;
-            let (server, port) =
-                global_config.resolve_server(server.server.as_deref(), server.port);
-            let boards = board::fetch_board_types(&server, port).await?;
+            let endpoint = global_config.resolve_endpoint(server.server.as_deref(), server.port)?;
+            let boards = board::fetch_board_types_endpoint(endpoint).await?;
             println!("{}", board::render_board_table(&boards));
             Ok(())
         }
         Command::Connect(args) => {
             let global_config = board::load_board_global_config_with_notice()?;
-            let (server, port) =
-                global_config.resolve_server(args.server.server.as_deref(), args.server.port);
-            board::connect_board(&server, port, &args.board_type).await
+            let endpoint =
+                global_config.resolve_endpoint(args.server.server.as_deref(), args.server.port)?;
+            board::connect_board_endpoint(endpoint, &args.board_type).await
         }
         Command::Config => board::config(),
     }

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::Context;
 use log::info;
 use ostool::{
-    board::{self as ostool_board, RunBoardOptions, config::BoardRunConfig},
+    board::{self as ostool_board, BoardRunRequest, RunBoardOptions, config::BoardRunConfig},
     build::{
         self as ostool_build, CargoQemuRunnerArgs, CargoRunnerKind, CargoUbootRunnerArgs,
         RuntimeArtifactInput,
@@ -359,6 +359,35 @@ impl AppContext {
         result
     }
 
+    pub(crate) async fn board_prepared_elf_with_request(
+        &mut self,
+        elf_path: PathBuf,
+        to_bin: bool,
+        build_config_path: PathBuf,
+        board_request: BoardRunRequest,
+    ) -> anyhow::Result<()> {
+        self.set_build_config_path(build_config_path);
+        let prepare_stage = StageLog::start(format!(
+            "prepare runtime artifact elf={} to_bin={}",
+            elf_path.display(),
+            to_bin
+        ));
+        ostool_build::prepare_runtime_artifact(
+            &mut self.invocation,
+            RuntimeArtifactInput::new(elf_path, to_bin),
+        )?;
+        prepare_stage.done();
+
+        let run_stage = StageLog::start("board run prepared artifact");
+        let result =
+            ostool_board::run_prepared_board_with_request(&mut self.invocation, board_request)
+                .await;
+        if result.is_ok() {
+            run_stage.done();
+        }
+        result
+    }
+
     pub(crate) fn set_debug_mode(&mut self, debug: bool) -> anyhow::Result<()> {
         if self.debug == debug {
             return Ok(());
@@ -442,6 +471,21 @@ impl AppContext {
         }
         Ok(guard)
     }
+}
+
+pub(crate) fn board_run_request(
+    board_config_path: &Path,
+    board_config: BoardRunConfig,
+    options: RunBoardOptions,
+) -> anyhow::Result<BoardRunRequest> {
+    let session_files = board_config.session_files.clone();
+    let config_dir = board_config_path.parent().with_context(|| {
+        format!(
+            "board configuration path `{}` has no parent directory",
+            board_config_path.display()
+        )
+    })?;
+    BoardRunRequest::new(board_config, options).with_session_files(config_dir, &session_files)
 }
 
 struct StageLog {

--- a/scripts/axbuild/src/context/tests.rs
+++ b/scripts/axbuild/src/context/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 
 mod arceos;
 mod axvisor;
+mod board_request;
 mod common;
 mod snapshot;
 mod starry;

--- a/scripts/axbuild/src/context/tests/board_request.rs
+++ b/scripts/axbuild/src/context/tests/board_request.rs
@@ -1,0 +1,84 @@
+use std::{fs, path::PathBuf};
+
+use ostool::board::{RunBoardOptions, config::BoardRunConfig};
+use serde::Serialize;
+use tempfile::tempdir;
+
+use super::board_run_request;
+
+#[derive(Serialize)]
+struct LegacyBoardConfigFixture {
+    board_type: String,
+}
+
+#[test]
+fn session_files_round_trip_as_typed_toml() {
+    let config = BoardRunConfig {
+        board_type: "OrangePi-5-Plus".to_string(),
+        session_files: vec![
+            PathBuf::from("iperf-smoke.sh"),
+            PathBuf::from("tools/network/probe.sh"),
+        ],
+        ..Default::default()
+    };
+
+    let encoded = toml::to_string(&config).unwrap();
+    let decoded: BoardRunConfig = toml::from_str(&encoded).unwrap();
+
+    assert_eq!(decoded, config);
+}
+
+#[test]
+fn legacy_board_config_defaults_to_empty_session_files() {
+    let fixture = LegacyBoardConfigFixture {
+        board_type: "OrangePi-5-Plus".to_string(),
+    };
+    let encoded = toml::to_string(&fixture).unwrap();
+
+    let decoded: BoardRunConfig = toml::from_str(&encoded).unwrap();
+
+    assert!(decoded.session_files.is_empty());
+}
+
+#[test]
+fn board_request_resolves_nested_files_from_config_directory() {
+    let root = tempdir().unwrap();
+    let case_dir = root.path().join("iperf-smoke");
+    fs::create_dir_all(case_dir.join("tools/network")).unwrap();
+    fs::write(case_dir.join("tools/network/probe.sh"), b"probe").unwrap();
+    let config_path = case_dir.join("board-orangepi-5-plus.toml");
+    let config = BoardRunConfig {
+        board_type: "OrangePi-5-Plus".to_string(),
+        session_files: vec![PathBuf::from("tools/network/probe.sh")],
+        ..Default::default()
+    };
+    fs::write(&config_path, toml::to_string(&config).unwrap()).unwrap();
+
+    board_run_request(&config_path, config, RunBoardOptions::default()).unwrap();
+}
+
+#[test]
+fn board_request_rejects_invalid_duplicate_and_missing_files() {
+    let root = tempdir().unwrap();
+    let case_dir = root.path().join("iperf-smoke");
+    fs::create_dir_all(&case_dir).unwrap();
+    fs::write(case_dir.join("iperf-smoke.sh"), b"probe").unwrap();
+    let config_path = case_dir.join("board-orangepi-5-plus.toml");
+
+    for session_files in [
+        vec![PathBuf::from("../escape.sh")],
+        vec![case_dir.join("iperf-smoke.sh")],
+        vec![
+            PathBuf::from("iperf-smoke.sh"),
+            PathBuf::from("iperf-smoke.sh"),
+        ],
+        vec![PathBuf::from("missing.sh")],
+    ] {
+        let config = BoardRunConfig {
+            board_type: "OrangePi-5-Plus".to_string(),
+            session_files,
+            ..Default::default()
+        };
+        assert!(board_run_request(&config_path, config, RunBoardOptions::default()).is_err());
+    }
+}

--- a/scripts/axbuild/src/starry/mod.rs
+++ b/scripts/axbuild/src/starry/mod.rs
@@ -6,7 +6,9 @@ use ostool::{
 };
 
 use crate::{
-    context::{AppContext, ResolvedStarryRequest, SnapshotPersistence, StarryCliArgs},
+    context::{
+        AppContext, ResolvedStarryRequest, SnapshotPersistence, StarryCliArgs, board_run_request,
+    },
     test::{case as qemu_case, host_http::HostHttpServerGuard, qemu},
 };
 
@@ -116,13 +118,14 @@ impl Starry {
             self.prepare_request((&args.build).into(), None, None, SnapshotPersistence::Store)?;
         self.app.set_debug_mode(request.debug)?;
         let cargo = build::load_cargo_config(&request)?;
-        let board_config = self
+        let (board_config, board_config_path) = self
             .load_board_config(&cargo, args.board_config.as_deref())
             .await?;
         self.run_board_artifact(
             &request,
             cargo,
             board_config,
+            board_config_path,
             RunBoardOptions {
                 board_type: args.board_type,
                 server: args.server,
@@ -368,7 +371,7 @@ impl Starry {
         )?;
         self.app.set_debug_mode(request.debug)?;
         let cargo = build::load_cargo_config(&request)?;
-        let mut board_config = self
+        let (mut board_config, board_config_path) = self
             .load_board_config(&cargo, Some(case.board_config_path.as_path()))
             .await?;
         if board_config.shell_init_cmd.is_none() {
@@ -378,6 +381,7 @@ impl Starry {
             &request,
             cargo,
             board_config,
+            board_config_path,
             RunBoardOptions {
                 board_type: args.board_type,
                 server: args.server,
@@ -454,18 +458,19 @@ impl Starry {
         &mut self,
         cargo: &Cargo,
         board_config_path: Option<&Path>,
-    ) -> anyhow::Result<BoardRunConfig> {
+    ) -> anyhow::Result<(BoardRunConfig, PathBuf)> {
         match board_config_path {
-            Some(path) => {
-                self.app
-                    .read_board_run_config_from_path_for_cargo(cargo, path)
-                    .await
-            }
+            Some(path) => self
+                .app
+                .read_board_run_config_from_path_for_cargo(cargo, path)
+                .await
+                .map(|config| (config, path.to_path_buf())),
             None => {
                 let workspace_root = self.app.workspace_root().to_path_buf();
                 self.app
                     .ensure_board_run_config_in_dir_for_cargo(cargo, &workspace_root)
                     .await
+                    .map(|config| (config, workspace_root.join(".board.toml")))
             }
         }
     }
@@ -507,16 +512,17 @@ impl Starry {
         request: &ResolvedStarryRequest,
         cargo: Cargo,
         board_config: BoardRunConfig,
+        board_config_path: PathBuf,
         options: RunBoardOptions,
     ) -> anyhow::Result<()> {
         let output = self.build_artifact(request, cargo.clone()).await?;
+        let board_request = board_run_request(&board_config_path, board_config, options)?;
         self.app
-            .board_prepared_elf(
+            .board_prepared_elf_with_request(
                 output.elf_path().to_path_buf(),
                 cargo.to_bin,
                 request.build_info_path.clone(),
-                board_config,
-                options,
+                board_request,
             )
             .await
     }

--- a/scripts/axbuild/src/starry/test/board.rs
+++ b/scripts/axbuild/src/starry/test/board.rs
@@ -74,13 +74,14 @@ impl Starry {
                     SnapshotPersistence::Discard,
                 )?;
                 let cargo = build::load_cargo_config(&request)?;
-                let board_config = self
+                let (board_config, board_config_path) = self
                     .load_board_config(&cargo, Some(board_test_config.as_path()))
                     .await?;
                 self.run_board_artifact(
                     &request,
                     cargo,
                     board_config,
+                    board_config_path,
                     RunBoardOptions {
                         board_type: args.board_type.clone(),
                         server: args.server.clone(),

--- a/scripts/axbuild/src/starry/test/board.rs
+++ b/scripts/axbuild/src/starry/test/board.rs
@@ -1,11 +1,14 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
-use ostool::board::RunBoardOptions;
+use ostool::board::{BoardRunRequest, RunBoardOptions};
 
-use super::{ArgsTestBoard, StarryBoardTestGroup, discover_board_test_groups};
+use super::{
+    ArgsTestBoard, StarryBoardTestGroup, board_assets::prepare_board_session_assets,
+    discover_board_test_groups,
+};
 use crate::{
-    context::{SnapshotPersistence, StarryCliArgs, arch_for_target_checked},
+    context::{SnapshotPersistence, StarryCliArgs, arch_for_target_checked, board_run_request},
     starry::{Starry, board, build},
     test::{board as board_test, qemu as qemu_test},
 };
@@ -77,27 +80,56 @@ impl Starry {
                 let (board_config, board_config_path) = self
                     .load_board_config(&cargo, Some(board_test_config.as_path()))
                     .await?;
-                self.run_board_artifact(
-                    &request,
-                    cargo,
-                    board_config,
-                    board_config_path,
-                    RunBoardOptions {
-                        board_type: args.board_type.clone(),
-                        server: args.server.clone(),
-                        port: args.port,
-                    },
-                )
-                .await
-                .with_context(|| {
+                let options = RunBoardOptions {
+                    board_type: args.board_type.clone(),
+                    server: args.server.clone(),
+                    port: args.port,
+                };
+                let case_dir = board_config_path.parent().with_context(|| {
                     format!(
-                        "starry board test failed for group `{}` (build_config={}, \
-                         board_test_config={})",
-                        group_label,
-                        group.build_config_path.display(),
-                        board_test_config_summary
+                        "board configuration path `{}` has no parent directory",
+                        board_config_path.display()
                     )
-                })
+                })?;
+                let session_assets = prepare_board_session_assets(
+                    self.app.workspace_root(),
+                    &group.arch,
+                    &group.target,
+                    &group.name,
+                    case_dir,
+                    &board_config_path,
+                    &board_config.session_files,
+                )
+                .await?;
+                let output = self.build_artifact(&request, cargo.clone()).await?;
+                let board_request = match session_assets {
+                    Some(assets) => {
+                        println!(
+                            "[axbuild] board session upload root: {}",
+                            assets.root.display()
+                        );
+                        BoardRunRequest::new(board_config, options)
+                            .with_session_files(&assets.root, &assets.relative_paths)?
+                    }
+                    None => board_run_request(&board_config_path, board_config, options)?,
+                };
+                self.app
+                    .board_prepared_elf_with_request(
+                        output.elf_path().to_path_buf(),
+                        cargo.to_bin,
+                        request.build_info_path.clone(),
+                        board_request,
+                    )
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "starry board test failed for group `{}` (build_config={}, \
+                             board_test_config={})",
+                            group_label,
+                            group.build_config_path.display(),
+                            board_test_config_summary
+                        )
+                    })
             }
             .await;
 

--- a/scripts/axbuild/src/starry/test/board_assets.rs
+++ b/scripts/axbuild/src/starry/test/board_assets.rs
@@ -1,0 +1,314 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{Context, bail, ensure};
+
+use crate::{
+    starry::test::starry_case_asset_config,
+    test::{
+        build::prepare_c_case_overlay_sync,
+        case::{TestQemuCase, board_case_asset_layout},
+    },
+};
+
+const C_SOURCE_DIR: &str = "c";
+const CMAKE_PROJECT_FILE: &str = "CMakeLists.txt";
+
+#[derive(Debug)]
+pub(crate) struct PreparedBoardSessionAssets {
+    pub(crate) root: PathBuf,
+    pub(crate) relative_paths: Vec<PathBuf>,
+}
+
+pub(crate) async fn prepare_board_session_assets(
+    workspace_root: &Path,
+    arch: &str,
+    target: &str,
+    case_name: &str,
+    case_dir: &Path,
+    board_config_path: &Path,
+    declared_session_files: &[PathBuf],
+) -> anyhow::Result<Option<PreparedBoardSessionAssets>> {
+    let cmake_project = case_dir.join(C_SOURCE_DIR).join(CMAKE_PROJECT_FILE);
+    if !cmake_project.is_file() {
+        return Ok(None);
+    }
+    for unsupported_dir in ["sh", "python"] {
+        ensure!(
+            !case_dir.join(unsupported_dir).exists(),
+            "board case `{case_name}` combines C assets with unsupported `{unsupported_dir}` \
+             assets"
+        );
+    }
+
+    let rootfs =
+        crate::starry::rootfs::ensure_rootfs_in_tmp_dir(workspace_root, arch, target).await?;
+    let workspace_root = workspace_root.to_path_buf();
+    let arch = arch.to_string();
+    let target = target.to_string();
+    let case_name = case_name.to_string();
+    let case_dir = case_dir.to_path_buf();
+    let board_config_path = board_config_path.to_path_buf();
+    let declared_session_files = declared_session_files.to_vec();
+
+    let assets = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+        let layout = board_case_asset_layout(&workspace_root, &target, &case_name)?;
+        let case = TestQemuCase {
+            name: case_name.clone(),
+            display_name: case_name,
+            case_dir: case_dir.clone(),
+            qemu_config_path: board_config_path,
+            test_commands: Vec::new(),
+            host_symbolize_success_regex: Vec::new(),
+            host_http_server: None,
+            subcases: Vec::new(),
+            grouped_subcase_filter: None,
+        };
+        prepare_c_case_overlay_sync(&arch, &case, &rootfs, &layout, &starry_case_asset_config())?;
+        copy_declared_session_files(&case_dir, &layout.overlay_dir, &declared_session_files)?;
+        let relative_paths = collect_upload_paths(&layout.overlay_dir)?;
+        Ok(PreparedBoardSessionAssets {
+            root: layout.overlay_dir,
+            relative_paths,
+        })
+    })
+    .await
+    .context("Starry board session asset task failed")??;
+    Ok(Some(assets))
+}
+
+fn copy_declared_session_files(
+    case_dir: &Path,
+    upload_root: &Path,
+    relative_paths: &[PathBuf],
+) -> anyhow::Result<()> {
+    let canonical_case_dir = case_dir.canonicalize().with_context(|| {
+        format!(
+            "failed to resolve board case directory {}",
+            case_dir.display()
+        )
+    })?;
+    let mut copied = BTreeSet::new();
+
+    for relative_path in relative_paths {
+        validate_relative_path(relative_path)?;
+        ensure!(
+            copied.insert(relative_path.clone()),
+            "duplicate session file path `{}`",
+            relative_path.display()
+        );
+        let source = case_dir.join(relative_path);
+        let metadata = fs::symlink_metadata(&source).with_context(|| {
+            format!(
+                "failed to inspect declared session file `{}`",
+                source.display()
+            )
+        })?;
+        ensure!(
+            !metadata.file_type().is_symlink(),
+            "declared session file `{}` must not be a symbolic link",
+            relative_path.display()
+        );
+        ensure!(
+            metadata.is_file(),
+            "declared session file `{}` is not a regular file",
+            relative_path.display()
+        );
+        let canonical_source = source.canonicalize().with_context(|| {
+            format!(
+                "failed to resolve declared session file `{}`",
+                source.display()
+            )
+        })?;
+        ensure!(
+            canonical_source.starts_with(&canonical_case_dir),
+            "declared session file `{}` escapes the board case directory",
+            relative_path.display()
+        );
+
+        let destination = upload_root.join(relative_path);
+        match fs::symlink_metadata(&destination) {
+            Ok(_) => bail!(
+                "declared session file `{}` conflicts with a CMake install product",
+                relative_path.display()
+            ),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to inspect upload destination `{}`",
+                        destination.display()
+                    )
+                });
+            }
+        }
+        if let Some(parent) = destination.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        fs::copy(&source, &destination).with_context(|| {
+            format!(
+                "failed to copy declared session file `{}` to `{}`",
+                source.display(),
+                destination.display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+fn collect_upload_paths(upload_root: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    let mut pending = vec![upload_root.to_path_buf()];
+    let mut relative_paths = Vec::new();
+
+    while let Some(directory) = pending.pop() {
+        let mut entries = fs::read_dir(&directory)
+            .with_context(|| format!("failed to read upload directory {}", directory.display()))?
+            .collect::<Result<Vec<_>, _>>()
+            .with_context(|| format!("failed to read upload directory {}", directory.display()))?;
+        entries.sort_by_key(|entry| entry.file_name());
+        for entry in entries {
+            let path = entry.path();
+            let metadata = fs::symlink_metadata(&path)
+                .with_context(|| format!("failed to inspect upload entry {}", path.display()))?;
+            if metadata.file_type().is_symlink() {
+                bail!(
+                    "board session upload entry `{}` must not be a symbolic link",
+                    path.display()
+                );
+            }
+            if metadata.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            ensure!(
+                metadata.is_file(),
+                "board session upload entry `{}` is not a regular file",
+                path.display()
+            );
+            relative_paths.push(
+                path.strip_prefix(upload_root)
+                    .expect("upload entry is below upload root")
+                    .to_path_buf(),
+            );
+        }
+    }
+
+    relative_paths.sort();
+    ensure!(
+        !relative_paths.is_empty(),
+        "board CMake install produced no files in upload root `{}`",
+        upload_root.display()
+    );
+    Ok(relative_paths)
+}
+
+fn validate_relative_path(path: &Path) -> anyhow::Result<()> {
+    ensure!(
+        !path.as_os_str().is_empty() && !path.is_absolute(),
+        "session file path `{}` must be a non-empty relative path",
+        path.display()
+    );
+    ensure!(
+        path.components()
+            .all(|component| matches!(component, Component::Normal(_))),
+        "session file path `{}` must be a normalized relative path",
+        path.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::PathBuf};
+
+    use tempfile::tempdir;
+
+    use super::{collect_upload_paths, copy_declared_session_files};
+
+    #[test]
+    fn upload_paths_are_sorted_and_keep_nested_relative_paths() {
+        let root = tempdir().unwrap();
+        fs::create_dir_all(root.path().join("tools/network")).unwrap();
+        fs::write(root.path().join("tools/network/probe"), b"probe").unwrap();
+        fs::create_dir_all(root.path().join("bin")).unwrap();
+        fs::write(root.path().join("bin/app"), b"app").unwrap();
+
+        assert_eq!(
+            collect_upload_paths(root.path()).unwrap(),
+            [
+                PathBuf::from("bin/app"),
+                PathBuf::from("tools/network/probe")
+            ]
+        );
+    }
+
+    #[test]
+    fn upload_root_must_contain_at_least_one_regular_file() {
+        let root = tempdir().unwrap();
+
+        let error = collect_upload_paths(root.path()).unwrap_err();
+
+        assert!(error.to_string().contains("no files"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn upload_root_rejects_symbolic_links() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempdir().unwrap();
+        fs::write(root.path().join("app"), b"app").unwrap();
+        symlink("app", root.path().join("alias")).unwrap();
+
+        let error = collect_upload_paths(root.path()).unwrap_err();
+
+        assert!(error.to_string().contains("symbolic link"));
+    }
+
+    #[test]
+    fn declared_session_files_are_copied_without_renaming() {
+        let root = tempdir().unwrap();
+        let case_dir = root.path().join("case");
+        let upload_root = root.path().join("upload");
+        fs::create_dir_all(case_dir.join("fixtures")).unwrap();
+        fs::create_dir_all(&upload_root).unwrap();
+        fs::write(case_dir.join("fixtures/input.json"), b"input").unwrap();
+
+        copy_declared_session_files(
+            &case_dir,
+            &upload_root,
+            &[PathBuf::from("fixtures/input.json")],
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read(upload_root.join("fixtures/input.json")).unwrap(),
+            b"input"
+        );
+    }
+
+    #[test]
+    fn declared_session_files_reject_collisions_and_invalid_paths() {
+        let root = tempdir().unwrap();
+        let case_dir = root.path().join("case");
+        let upload_root = root.path().join("upload");
+        fs::create_dir_all(case_dir.join("bin")).unwrap();
+        fs::create_dir_all(upload_root.join("bin")).unwrap();
+        fs::write(case_dir.join("bin/app"), b"source").unwrap();
+        fs::write(upload_root.join("bin/app"), b"built").unwrap();
+
+        let collision =
+            copy_declared_session_files(&case_dir, &upload_root, &[PathBuf::from("bin/app")])
+                .unwrap_err();
+        assert!(collision.to_string().contains("conflicts"));
+
+        let escape =
+            copy_declared_session_files(&case_dir, &upload_root, &[PathBuf::from("../escape")])
+                .unwrap_err();
+        assert!(escape.to_string().contains("relative"));
+    }
+}

--- a/scripts/axbuild/src/starry/test/mod.rs
+++ b/scripts/axbuild/src/starry/test/mod.rs
@@ -1,6 +1,7 @@
 mod args;
 mod assets;
 mod board;
+mod board_assets;
 mod qemu_discovery;
 mod qemu_run;
 mod suite;

--- a/scripts/axbuild/src/test/build/c.rs
+++ b/scripts/axbuild/src/test/build/c.rs
@@ -39,6 +39,29 @@ pub(crate) fn prepare_c_case_assets_sync(
     layout: &case_assets::CaseAssetLayout,
     config: &CaseAssetConfig,
 ) -> anyhow::Result<()> {
+    prepare_c_case_overlay_sync(arch, case, case_rootfs, layout, config)?;
+    let timing_stage = timing::TimingStage::new(
+        "qemu-asset-c",
+        [
+            ("case", case.display_name.clone()),
+            ("phase", "inject-overlay".to_string()),
+        ],
+    );
+    let result = crate::rootfs::inject::inject_overlay(case_rootfs, &layout.overlay_dir);
+    timing_stage.finish();
+    result
+}
+
+/// Builds a C case into its overlay without injecting that overlay into a rootfs.
+///
+/// Board tests use the resulting overlay as their session upload root.
+pub(crate) fn prepare_c_case_overlay_sync(
+    arch: &str,
+    case: &TestQemuCase,
+    case_rootfs: &Path,
+    layout: &case_assets::CaseAssetLayout,
+    config: &CaseAssetConfig,
+) -> anyhow::Result<()> {
     let source_dir = case_c_source_dir(case);
     let cmake_lists = source_dir.join(CASE_CMAKE_FILE_NAME);
     ensure!(
@@ -173,14 +196,5 @@ pub(crate) fn prepare_c_case_assets_sync(
     );
     crate::rootfs::runtime::sync_runtime_dependencies(&layout.staging_root, &layout.overlay_dir)?;
     timing_stage.finish();
-    let timing_stage = timing::TimingStage::new(
-        "qemu-asset-c",
-        [
-            ("case", case.display_name.clone()),
-            ("phase", "inject-overlay".to_string()),
-        ],
-    );
-    let result = crate::rootfs::inject::inject_overlay(case_rootfs, &layout.overlay_dir);
-    timing_stage.finish();
-    result
+    Ok(())
 }

--- a/scripts/axbuild/src/test/build/mod.rs
+++ b/scripts/axbuild/src/test/build/mod.rs
@@ -56,7 +56,7 @@ mod rust;
 mod toolchain;
 mod wrappers;
 
-pub(crate) use c::{case_c_source_dir, prepare_c_case_assets_sync};
+pub(crate) use c::{case_c_source_dir, prepare_c_case_assets_sync, prepare_c_case_overlay_sync};
 use c::{
     case_rust_prebuild_script_path, grouped_c_root_project_path,
     grouped_c_subcase_prebuild_script_path, grouped_c_subcase_source_dir,

--- a/scripts/axbuild/src/test/case/layout.rs
+++ b/scripts/axbuild/src/test/case/layout.rs
@@ -7,10 +7,11 @@ use std::{
 use anyhow::Context;
 
 use super::types::{
-    CASE_APK_CACHE_DIR_NAME, CASE_BUILD_DIR_NAME, CASE_CACHE_DIR_NAME,
-    CASE_CMAKE_TOOLCHAIN_FILE_NAME, CASE_COMMAND_WRAPPER_DIR_NAME, CASE_CROSS_BIN_DIR_NAME,
-    CASE_OVERLAY_DIR_NAME, CASE_ROOTFS_CACHE_DIR_NAME, CASE_ROOTFS_COPY_NAME, CASE_RUNS_DIR_NAME,
-    CASE_STAGING_DIR_NAME, CASE_WORK_ROOT_NAME, CaseAssetLayout,
+    BOARD_CASE_UPLOAD_DIR_NAME, BOARD_CASE_WORK_ROOT_NAME, CASE_APK_CACHE_DIR_NAME,
+    CASE_BUILD_DIR_NAME, CASE_CACHE_DIR_NAME, CASE_CMAKE_TOOLCHAIN_FILE_NAME,
+    CASE_COMMAND_WRAPPER_DIR_NAME, CASE_CROSS_BIN_DIR_NAME, CASE_OVERLAY_DIR_NAME,
+    CASE_ROOTFS_CACHE_DIR_NAME, CASE_ROOTFS_COPY_NAME, CASE_RUNS_DIR_NAME, CASE_STAGING_DIR_NAME,
+    CASE_WORK_ROOT_NAME, CaseAssetLayout,
 };
 
 static CASE_RUN_ID: AtomicU64 = AtomicU64::new(0);
@@ -26,8 +27,28 @@ pub(crate) fn case_asset_layout(
     target: &str,
     case_name: &str,
 ) -> anyhow::Result<CaseAssetLayout> {
+    asset_layout(workspace_root, target, CASE_WORK_ROOT_NAME, case_name)
+}
+
+/// Builds the working directory layout used for a board case asset run.
+pub(crate) fn board_case_asset_layout(
+    workspace_root: &Path,
+    target: &str,
+    case_name: &str,
+) -> anyhow::Result<CaseAssetLayout> {
+    let mut layout = asset_layout(workspace_root, target, BOARD_CASE_WORK_ROOT_NAME, case_name)?;
+    layout.overlay_dir = layout.run_dir.join(BOARD_CASE_UPLOAD_DIR_NAME);
+    Ok(layout)
+}
+
+fn asset_layout(
+    workspace_root: &Path,
+    target: &str,
+    work_root_name: &str,
+    case_name: &str,
+) -> anyhow::Result<CaseAssetLayout> {
     let target_dir = resolve_target_dir(workspace_root, target)?;
-    let work_dir = target_dir.join(CASE_WORK_ROOT_NAME).join(case_name);
+    let work_dir = target_dir.join(work_root_name).join(case_name);
     let run_dir = work_dir.join(CASE_RUNS_DIR_NAME).join(next_case_run_id());
     let cache_dir = work_dir.join(CASE_CACHE_DIR_NAME);
 
@@ -58,4 +79,30 @@ pub(crate) fn reset_dir(path: &Path) -> anyhow::Result<()> {
         fs::remove_dir_all(path).with_context(|| format!("failed to remove {}", path.display()))?;
     }
     fs::create_dir_all(path).with_context(|| format!("failed to create {}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::board_case_asset_layout;
+
+    #[test]
+    fn board_layout_places_upload_root_under_target_board_cases() {
+        let root = tempdir().unwrap();
+
+        let layout =
+            board_case_asset_layout(root.path(), "riscv64gc-unknown-none-elf", "usb/init").unwrap();
+
+        assert!(
+            layout.overlay_dir.starts_with(
+                root.path()
+                    .join("target/riscv64gc-unknown-none-elf/board-cases/usb/init/runs")
+            )
+        );
+        assert_eq!(
+            layout.overlay_dir.file_name().unwrap().to_string_lossy(),
+            "upload"
+        );
+    }
 }

--- a/scripts/axbuild/src/test/case/types.rs
+++ b/scripts/axbuild/src/test/case/types.rs
@@ -3,6 +3,8 @@ use std::{collections::BTreeSet, path::PathBuf, time::Duration};
 use serde::Deserialize;
 
 pub(super) const CASE_WORK_ROOT_NAME: &str = "qemu-cases";
+pub(super) const BOARD_CASE_WORK_ROOT_NAME: &str = "board-cases";
+pub(super) const BOARD_CASE_UPLOAD_DIR_NAME: &str = "upload";
 pub(super) const CASE_CACHE_DIR_NAME: &str = "cache";
 pub(super) const CASE_RUNS_DIR_NAME: &str = "runs";
 /// Sub-directory under `cache_dir` that holds pre-injected rootfs images.

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -319,12 +319,40 @@ os/StarryOS/configs/board/<board>.toml
 并从该 board build config 读取 target。如果当前 build wrapper 下存在匹配的
 `build-<target>.toml`，则优先使用 test-suit 中的构建配置。
 
+板测需要在运行时下载 case 资产时，可在 typed TOML 配置中声明相对于
+`board-<board>.toml` 所在目录的文件：
+
+```toml
+session_files = [
+  "iperf-smoke.sh",
+  "tools/network/probe.sh",
+]
+```
+
+路径会在分配板卡前完成规范化和边界检查；绝对路径、`..`、符号链接逃逸、重复路径
+和缺失文件都会被拒绝。上传后路径保持不变，不支持 alias 或上传时改名。
+
+`shell_init_cmd` 可使用下列只在活动 board session 内展开的变量：
+
+- `${boardServerIp}`：板端可访问的 ostool-server 地址。
+- `${boardServerHttpBaseUrl}`：板端可访问的 session HTTP 基础 URL。
+- `${sessionFile:<relative-path>}`：对应共享文件的完整下载 URL。
+
+普通 shell 变量（例如 `${HOME}`）保持原样。未解析的 session 保留变量会在上板运行
+前报错；无论上传、展开还是运行失败，xtask 都会释放 session。
+
 运行示例：
 
 ```bash
 cargo xtask starry test board --board orangepi-5-plus
 cargo xtask starry test board -c board-orangepi-5-plus/pcie-enumerate --board orangepi-5-plus
+cargo xtask starry test board -c iperf-smoke --board orangepi-5-plus --server 10.3.10.194 --port 2999
 ```
+
+`iperf-smoke` 会等待 OrangePi 的 `eth0` 通过 DHCP 获得板测网段地址，再从 session
+HTTP 端点下载同名脚本，并连接 `${boardServerIp}:5201` 执行 2 秒、1 Mbit/s 的
+iperf3 UDP JSON 测试。该用例只验证下载、执行和网络连通性，不设置吞吐门槛；服务端
+需预先运行 iperf3 server。
 
 ## 运行命令
 

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -341,6 +341,30 @@ session_files = [
 普通 shell 变量（例如 `${HOME}`）保持原样。未解析的 session 保留变量会在上板运行
 前报错；无论上传、展开还是运行失败，xtask 都会释放 session。
 
+板测需要交叉编译并共享 C 程序时，在 case 下增加 `c/CMakeLists.txt`：
+
+```text
+<case>/
+  board-<board>.toml
+  c/
+    CMakeLists.txt
+    prebuild.sh        # 可选
+    src/
+```
+
+xtask 复用 QEMU C case 的 musl staging 和 CMake 工具链，但不会把产物注入 rootfs。
+每次运行会创建并清空独立目录：
+
+```text
+target/<target>/board-cases/<case>/runs/<run-id>/upload/
+```
+
+CMake `install()` 到该 upload root 的所有普通文件都会按原相对路径自动上传，因此构建
+产物不需要再写入 `session_files`。例如 `install(... DESTINATION bin)` 对应
+`${sessionFile:bin/<program>}`。板端下载、赋权和执行仍必须显式写在
+`shell_init_cmd` 中；ostool 不会自动执行上传的程序。upload root 为空、包含符号链接，
+或者手写 `session_files` 与 CMake install 产物同路径时会在分配板卡前报错。
+
 运行示例：
 
 ```bash
@@ -353,6 +377,13 @@ cargo xtask starry test board -c iperf-smoke --board orangepi-5-plus --server 10
 HTTP 端点下载同名脚本，并连接 `${boardServerIp}:5201` 执行 2 秒、1 Mbit/s 的
 iperf3 UDP JSON 测试。该用例只验证下载、执行和网络连通性，不设置吞吐门槛；服务端
 需预先运行 iperf3 server。
+
+`board-aka-00-sg2002/usb2-libuvc-init` 提供静态交叉编译固定版本上游 libuvc 的
+C 资产和 `board-aka-00-sg2002.toml.disabled` 配置模板。AKA-00-SG2002 当前没有
+StarryOS 网络设备，无法从 session HTTP URL 下载程序，因此该模板不会被 board
+discovery 或 CI 启用。后续网络可用时移除 `.disabled` 后缀；其
+`shell_init_cmd` 会使用 `wget` 下载程序，并只验证 `uvc_init` / `uvc_exit`，不枚举
+摄像头、不采集帧，也不验证 DWC2 isochronous 传输。
 
 ## 运行命令
 

--- a/test-suit/starryos/board-aka-00-sg2002/usb2-libuvc-init/board-aka-00-sg2002.toml.disabled
+++ b/test-suit/starryos/board-aka-00-sg2002/usb2-libuvc-init/board-aka-00-sg2002.toml.disabled
@@ -1,0 +1,19 @@
+# Disabled until StarryOS provides a network device on AKA-00-SG2002.
+# Rename to board-aka-00-sg2002.toml after session HTTP is reachable on-board.
+board_type = "AKA-00-SG2002"
+kernel_load_addr = "0x80200000"
+fit_load_addr = "0x82200000"
+bootm_addr = "0x82200000"
+shell_prefix = "root@starry:"
+shell_init_cmd = "rm -f /tmp/sg2002-libuvc-init; wget -O /tmp/sg2002-libuvc-init '${sessionFile:bin/sg2002-libuvc-init}' && chmod +x /tmp/sg2002-libuvc-init && /tmp/sg2002-libuvc-init || echo STARRY_SG2002_LIBUVC_INIT_FAILED: session_setup_or_execution"
+success_regex = ["(?m)^STARRY_SG2002_LIBUVC_INIT_OK\\s*$"]
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)segmentation fault",
+  "(?i)SIGSEGV",
+  "exit with code: 139",
+  "failed to determine root device",
+  "(?i)(wget|chmod): .*not found",
+  "(?m)^STARRY_SG2002_LIBUVC_INIT_FAILED:.*$",
+]
+timeout = 600

--- a/test-suit/starryos/board-aka-00-sg2002/usb2-libuvc-init/c/CMakeLists.txt
+++ b/test-suit/starryos/board-aka-00-sg2002/usb2-libuvc-init/c/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.20)
+project(sg2002_libuvc_init C)
+
+include(FetchContent)
+
+set(BUILD_EXAMPLE OFF CACHE BOOL "" FORCE)
+set(BUILD_TEST OFF CACHE BOOL "" FORCE)
+set(CMAKE_BUILD_TARGET Static CACHE STRING "" FORCE)
+set(CMAKE_DISABLE_FIND_PACKAGE_JpegPkg TRUE)
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+
+FetchContent_Declare(
+    libuvc
+    GIT_REPOSITORY https://github.com/libuvc/libuvc.git
+    GIT_TAG 68d07a00e11d1944e27b7295ee69673239c00b4b
+    GIT_SHALLOW FALSE
+)
+FetchContent_GetProperties(libuvc)
+if(NOT libuvc_POPULATED)
+    FetchContent_Populate(libuvc)
+endif()
+add_subdirectory("${libuvc_SOURCE_DIR}" "${libuvc_BINARY_DIR}" EXCLUDE_FROM_ALL)
+
+add_executable(sg2002-libuvc-init src/main.c)
+target_link_libraries(sg2002-libuvc-init PRIVATE LibUVC::UVCStatic)
+target_link_options(sg2002-libuvc-init PRIVATE -static)
+
+install(TARGETS sg2002-libuvc-init RUNTIME DESTINATION bin)

--- a/test-suit/starryos/board-aka-00-sg2002/usb2-libuvc-init/c/prebuild.sh
+++ b/test-suit/starryos/board-aka-00-sg2002/usb2-libuvc-init/c/prebuild.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eu
+
+apk add build-base libusb-dev
+test -f "$STARRY_STAGING_ROOT/usr/include/libusb-1.0/libusb.h"
+test -f "$STARRY_STAGING_ROOT/usr/lib/libusb-1.0.a"

--- a/test-suit/starryos/board-aka-00-sg2002/usb2-libuvc-init/c/src/main.c
+++ b/test-suit/starryos/board-aka-00-sg2002/usb2-libuvc-init/c/src/main.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+
+#include <libuvc/libuvc.h>
+
+int main(void) {
+    uvc_context_t *context = NULL;
+    const uvc_error_t result = uvc_init(&context, NULL);
+
+    if (result != UVC_SUCCESS) {
+        printf("STARRY_SG2002_LIBUVC_INIT_FAILED: uvc_init=%d (%s)\n",
+               result, uvc_strerror(result));
+        return 1;
+    }
+
+    uvc_exit(context);
+    puts("STARRY_SG2002_LIBUVC_INIT_OK");
+    return 0;
+}

--- a/test-suit/starryos/board-orangepi-5-plus/iperf-smoke/board-orangepi-5-plus.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/iperf-smoke/board-orangepi-5-plus.toml
@@ -1,0 +1,35 @@
+board_type = "OrangePi-5-Plus"
+session_files = [
+  "iperf-smoke.sh",
+]
+shell_prefix = "root@starry:/root #"
+shell_init_cmd = '''
+marker=STARRY_IPERF_SMOKE
+url='${sessionFile:iperf-smoke.sh}'
+script=/tmp/iperf-smoke.sh
+network_ready=0
+for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+  ip_addr_out="$(ip addr show dev eth0 2>&1 || true)"
+  echo "$ip_addr_out"
+  if echo "$ip_addr_out" | grep -q 'inet 192\.168\.1\.'; then
+    network_ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "$network_ready" != "1" ]; then
+  false
+elif command -v curl >/dev/null 2>&1; then
+  curl --connect-timeout 10 --max-time 30 -fsSL "$url" -o "$script"
+elif command -v wget >/dev/null 2>&1; then
+  wget -T 30 -O "$script" "$url"
+else
+  false
+fi &&
+chmod +x "$script" &&
+"$script" '${boardServerIp}' 5201 ||
+echo "${marker}_FAILED"
+'''
+success_regex = ["(?m)^STARRY_IPERF_SMOKE_OK\\s*$"]
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?i)segmentation fault', '(?i)SIGSEGV', 'exit with code: 139', "(?m)^STARRY_IPERF_SMOKE_FAILED\\s*$"]
+timeout = 240

--- a/test-suit/starryos/board-orangepi-5-plus/iperf-smoke/iperf-smoke.sh
+++ b/test-suit/starryos/board-orangepi-5-plus/iperf-smoke/iperf-smoke.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -u
+
+fail() {
+    echo STARRY_IPERF_SMOKE_FAILED
+    exit 1
+}
+
+[ "$#" -eq 2 ] || fail
+server_ip=$1
+server_port=$2
+
+command -v iperf3 >/dev/null 2>&1 || fail
+
+result=/tmp/iperf-smoke.json
+if ! iperf3 --client "$server_ip" --port "$server_port" --udp --bitrate 1M --time 2 --json >"$result" 2>&1; then
+    cat "$result"
+    fail
+fi
+
+[ -s "$result" ] || fail
+cat "$result"
+echo STARRY_IPERF_SMOKE_OK


### PR DESCRIPTION
## 问题

现有板卡测试只能发送静态 shell 命令，无法在一次 board session 内安全共享动态测试文件，也无法让 test-suit 交叉编译的 C 程序直接作为 session 文件上传。这使依赖服务端资源或临时测试程序的真机用例需要硬编码地址、修改 rootfs 或额外部署。

## 改动

- 将工作区 `ostool` 依赖升级到 `0.26.0`，使用现有 typed `BoardRunRequest` 与 session 共享接口；不修改 ostool 协议，也不增加自动执行程序的 client API。
- 为 board TOML 接入 typed `session_files`：路径相对于 `board-<board>.toml` 目录解析，保持本地、session 与 `${sessionFile:<relative-path>}` 路径一致，不提供 alias 或上传改名。
- 扩展 Starry board asset 流程：检测 case 下的 `c/CMakeLists.txt`，复用现有 musl staging、prebuild 和 CMake 交叉工具链，但把 `install()` 产物写入 `target/<target>/board-cases/<case>/runs/<run-id>/upload/`，不注入 rootfs。
- 自动上传 upload root 中的普通文件；拒绝空产物、符号链接、非法相对路径、重复项，以及手写 `session_files` 与 CMake 产物的路径冲突。
- 保持板端行为显式：下载、`chmod` 和执行命令仍由 `shell_init_cmd` 配置，ostool 只上传文件并展开 URL。
- 新增 OrangePi-5-Plus `iperf-smoke` 用例，验证 session HTTP 下载与 iperf3 UDP 网络连通性。
- 增加 SG2002 libuvc-init C 资产：固定上游 libuvc v0.0.7 commit `68d07a00e11d1944e27b7295ee69673239c00b4b`，使用 staging sysroot 的 `libusb-dev`，关闭 example、test、JPEG 和共享库，只安装静态 `bin/sg2002-libuvc-init`；程序只调用 `uvc_init` / `uvc_exit`。
- SG2002 runtime 配置以 `board-aka-00-sg2002.toml.disabled` 模板提交，不会被 board discovery 或 CI 启用。真机验证确认当前 StarryOS 没有 `cvitek,ethernet` 网络设备，无法执行 session HTTP `wget`；待网络支持后再移除 `.disabled` 后缀。
- 更新 Starry test-suit 指南与项目 skill，记录 session 文件、board C upload root 和显式 shell 执行规则。

## 实现逻辑

配置继续使用 `BoardRunConfig` 的具名 Serde 类型。普通 `session_files` 仍复用 ostool 0.26.0 的路径校验、上传、URL 编码和租约释放逻辑。

对于 board C case，xtask 只新增构建侧 staging：每次创建独立 run/upload 目录，CMake 按原相对路径安装，xtask 收集并传给现有 `with_session_files`。这样构建程序与普通 session 文件使用相同上传协议，板端实际运行内容仍完全由 `shell_init_cmd` 决定。

iperf smoke 使用 UDP 数据流，因为 Starry 当前未实现 iperf3 TCP 模式查询的 `TCP_CONGESTION` socket option；控制连接仍通过 TCP 5201 建立。本改动不伪造 Linux ABI，也不引入性能门槛。

## 验证

本地：

- 先添加 board upload-root 回归测试，确认旧代码因接口缺失而编译失败，再实现功能。
- `cargo fmt`
- `cargo test -p axbuild --no-fail-fast`：773 passed
- board upload-root 定向测试：5 passed
- board layout 定向测试：1 passed
- `cargo xtask clippy --package axbuild`
- `cargo xtask starry test board -l`：可发现 `iperf-smoke`，不会发现已禁用的 `usb2-libuvc-init`。
- SG2002 CMake 构建成功，仅安装 `upload/bin/sg2002-libuvc-init`。
- `file` / `readelf`：产物为 RISC-V 64-bit 静态 ELF，无 interpreter、无 `DT_NEEDED`；qemu-riscv64 执行输出 `STARRY_SG2002_LIBUVC_INIT_OK`。

真机：

- OrangePi-5-Plus `iperf-smoke` 连续运行两次通过，均从 `192.168.1.2:2999` 下载同路径脚本并连接 `192.168.1.2:5201`；session 释放后旧 URL 返回 404。
- SG2002 探索性运行成功完成 CMake 构建、session 上传、URL 展开和 StarryOS 启动；板端明确报告 `No network device found` / `no route to destination 192.168.1.2`。失败后 session 数恢复为 0，旧程序 URL 返回 404，因此本 PR 不启用该 runtime case。
