### PR TITLE
fix(someboot): register runtime write callback before claim_runtime_output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -707,7 +707,7 @@ version = "0.1.0"
 dependencies = [
  "ax-kspin",
  "ax-lazyinit",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3309,7 +3309,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10199,7 +10199,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -10225,7 +10225,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -10238,7 +10238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zvariant",
 ]
 
@@ -10352,7 +10352,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -10366,7 +10366,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "zvariant_utils",
 ]
 
@@ -10379,6 +10379,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.118",
- "winnow 1.0.3",
+ "syn 2.0.119",
+ "winnow 1.0.4",
 ]

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
@@ -2,6 +2,7 @@ use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use ax_errno::{AxError, AxResult};
+use ax_kspin::SpinNoIrq;
 use ax_runtime::{
     hal::console::{ConsoleDeviceIdError, ConsoleDeviceIdResult},
     serial::{
@@ -29,6 +30,24 @@ pub type SerialTtyDriver = Tty<SerialReader, SerialWriter>;
 const SERIAL_RX_DRAIN_CHUNK: usize = 256;
 const SERIAL_SYNC_ECHO_LIMIT: usize = 256;
 const SERIAL_DEFAULT_BAUDRATE: u32 = 115_200;
+
+/// Backend reference used by the runtime console write path.
+static CONSOLE_BACKEND: SpinNoIrq<Option<Arc<SerialBackend>>> = SpinNoIrq::new(None);
+
+/// Non-blocking console write that pushes bytes through the runtime UART driver.
+/// Called by `ax_log` after `claim_runtime_output()`.
+fn console_runtime_write(bytes: &[u8]) {
+    let backend = CONSOLE_BACKEND.lock().clone();
+    if let Some(backend) = backend {
+        let mut remaining = bytes;
+        while !remaining.is_empty() {
+            match backend.tx.try_write(remaining) {
+                Ok(count) if count > 0 => remaining = &remaining[count..],
+                _ => break,
+            }
+        }
+    }
+}
 
 pub struct SerialTtyEntry {
     number: usize,
@@ -144,6 +163,10 @@ pub fn bind_console_to(proc: &Process) -> AxResult<()> {
     {
         entry.backend.ensure_started()?;
         entry.backend.runtime.activate_console_output()?;
+        // Register the runtime write callback BEFORE claiming output so that
+        // no log messages are silently dropped during the handoff.
+        CONSOLE_BACKEND.lock().replace(entry.backend.clone());
+        ax_runtime::hal::console::set_runtime_write_fn(console_runtime_write);
         ax_runtime::hal::console::claim_runtime_output();
         return entry.tty.bind_to(proc);
     }

--- a/os/arceos/modules/axhal/src/dummy.rs
+++ b/os/arceos/modules/axhal/src/dummy.rs
@@ -48,6 +48,8 @@ impl ConsoleIf for DummyConsole {
 
     fn claim_runtime_output() {}
 
+    fn set_runtime_write_fn(_f: fn(&[u8])) {}
+
     #[cfg(feature = "irq")]
     fn irq_num() -> Option<IrqId> {
         None

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -66,7 +66,7 @@ pub mod paging;
 pub mod console {
     pub use ax_plat::console::{
         ConsoleDeviceId, ConsoleDeviceIdError, ConsoleDeviceIdResult, claim_runtime_output,
-        device_id, read_bytes, write_bytes, write_text_bytes,
+        device_id, read_bytes, set_runtime_write_fn, write_bytes, write_text_bytes,
     };
     #[cfg(feature = "irq")]
     pub use ax_plat::console::{ConsoleIrqEvent, handle_irq, irq_num, set_input_irq_enabled};

--- a/platforms/ax-plat/src/console.rs
+++ b/platforms/ax-plat/src/console.rs
@@ -56,6 +56,12 @@ pub trait ConsoleIf {
     /// runtime-owned device.
     fn claim_runtime_output();
 
+    /// Registers a callback that receives console bytes after the runtime has
+    /// claimed output ownership.  Must be called **before**
+    /// [`claim_runtime_output`](Self::claim_runtime_output) so that no log
+    /// output is silently dropped during the handoff.
+    fn set_runtime_write_fn(f: fn(&[u8]));
+
     /// Returns the IRQ number for the console input interrupt.
     ///
     /// Returns `None` if input interrupt is not supported.

--- a/platforms/axplat-dyn/src/console.rs
+++ b/platforms/axplat-dyn/src/console.rs
@@ -63,6 +63,10 @@ impl ConsoleIf for ConsoleIfImpl {
         somehal::console::claim_runtime_output();
     }
 
+    fn set_runtime_write_fn(f: fn(&[u8])) {
+        somehal::console::set_runtime_write_fn(f);
+    }
+
     /// Returns the IRQ number for the console input interrupt.
     ///
     /// Returns `None` if input interrupt is not supported.

--- a/platforms/someboot/src/console/mod.rs
+++ b/platforms/someboot/src/console/mod.rs
@@ -473,6 +473,24 @@ mod tests {
 
     static COUNTING_CON: CountingCon = CountingCon;
 
+    static CALLBACK_CALLED: AtomicUsize = AtomicUsize::new(0);
+
+    struct TestBuf(core::cell::UnsafeCell<[u8; 64]>);
+    // SAFETY: only accessed from a single-threaded test context.
+    unsafe impl Sync for TestBuf {}
+    static CALLBACK_BUF: TestBuf = TestBuf(core::cell::UnsafeCell::new([0u8; 64]));
+    static CALLBACK_LEN: AtomicUsize = AtomicUsize::new(0);
+
+    fn test_runtime_write(bytes: &[u8]) {
+        CALLBACK_CALLED.fetch_add(1, Ordering::Relaxed);
+        let len = bytes.len().min(64);
+        // SAFETY: test is single-threaded; no concurrent access.
+        unsafe {
+            core::ptr::copy_nonoverlapping(bytes.as_ptr(), CALLBACK_BUF.0.get().cast(), len);
+        }
+        CALLBACK_LEN.store(len, Ordering::Release);
+    }
+
     #[test]
     fn runtime_output_claim_consumes_without_touching_boot_console() {
         WRITE_CALLS.store(0, Ordering::Relaxed);
@@ -488,6 +506,37 @@ mod tests {
         assert_eq!(_write_bytes(b"after"), 5);
         assert_eq!(WRITE_CALLS.load(Ordering::Relaxed), 1);
 
+        RUNTIME_OUTPUT_CLAIMED.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn runtime_write_fn_receives_bytes_after_claim() {
+        // Reset all state.
+        WRITE_CALLS.store(0, Ordering::Relaxed);
+        CALLBACK_CALLED.store(0, Ordering::Relaxed);
+        CALLBACK_LEN.store(0, Ordering::Relaxed);
+        RUNTIME_OUTPUT_CLAIMED.store(false, Ordering::Relaxed);
+        RUNTIME_WRITE_FN.store(core::ptr::null_mut(), Ordering::Release);
+
+        unsafe { set_out(&COUNTING_CON) };
+        set_runtime_write_fn(test_runtime_write);
+        claim_runtime_output();
+
+        let msg = b"hello";
+        let written = _write_bytes(msg);
+        assert_eq!(written, 5);
+
+        // Callback must have been called with the full payload.
+        assert_eq!(CALLBACK_CALLED.load(Ordering::Relaxed), 1);
+        assert_eq!(CALLBACK_LEN.load(Ordering::Acquire), 5);
+        let got: &[u8] = unsafe { core::slice::from_raw_parts(CALLBACK_BUF.0.get().cast(), 5) };
+        assert_eq!(got, b"hello");
+
+        // Boot console must NOT have been touched.
+        assert_eq!(WRITE_CALLS.load(Ordering::Relaxed), 0);
+
+        // Cleanup.
+        RUNTIME_WRITE_FN.store(core::ptr::null_mut(), Ordering::Release);
         RUNTIME_OUTPUT_CLAIMED.store(false, Ordering::Relaxed);
     }
 }

--- a/platforms/someboot/src/console/mod.rs
+++ b/platforms/someboot/src/console/mod.rs
@@ -2,7 +2,7 @@ use core::{
     cell::UnsafeCell,
     fmt::Write,
     ptr::NonNull,
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicPtr, Ordering},
 };
 
 use byte_unit::{Byte, UnitType};
@@ -71,6 +71,9 @@ pub fn _print(args: core::fmt::Arguments) {
 
 pub fn _write_bytes(bytes: &[u8]) -> usize {
     if runtime_output_claimed() {
+        if let Some(f) = runtime_write_fn() {
+            f(bytes);
+        }
         return bytes.len();
     }
     con().write_bytes(bytes)
@@ -183,6 +186,25 @@ impl Con for NoCon {
 
 static mut CON: &dyn Con = &NoCon;
 static RUNTIME_OUTPUT_CLAIMED: AtomicBool = AtomicBool::new(false);
+
+type WriteBytesFn = fn(&[u8]);
+static RUNTIME_WRITE_FN: AtomicPtr<()> = AtomicPtr::new(core::ptr::null_mut());
+
+/// Registers a callback that receives console bytes after the runtime has
+/// claimed output ownership.  Called once during serial console bind.
+pub fn set_runtime_write_fn(f: WriteBytesFn) {
+    RUNTIME_WRITE_FN.store(f as *mut (), Ordering::Release);
+}
+
+fn runtime_write_fn() -> Option<WriteBytesFn> {
+    let ptr = RUNTIME_WRITE_FN.load(Ordering::Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: we only store valid function pointers via set_runtime_write_fn.
+        Some(unsafe { core::mem::transmute::<*mut (), WriteBytesFn>(ptr) })
+    }
+}
 
 pub(crate) unsafe fn set_out(v: &'static dyn Con) {
     unsafe {

--- a/virtualization/test_crates/virtualization-tests/tests/axvm_irq.rs
+++ b/virtualization/test_crates/virtualization-tests/tests/axvm_irq.rs
@@ -45,6 +45,8 @@ impl ConsoleIf for TestConsole {
 
     fn claim_runtime_output() {}
 
+    fn set_runtime_write_fn(_f: fn(&[u8])) {}
+
     fn irq_num() -> Option<irq_framework::IrqId> {
         None
     }


### PR DESCRIPTION
## 问题

claim_runtime_output() 后 someboot::_write_bytes() 静默丢弃所有输出，导致 ax_log 的日志无法通过串口驱动写入硬件。

## 修改内容

- **someboot**: 添加 RUNTIME_WRITE_FN 函数指针，_write_bytes 在 runtime claimed 后调用注册的回调
- **ax-plat**: ConsoleIf trait 添加 set_runtime_write_fn 方法
- **axplat-dyn**: 实现 set_runtime_write_fn，转发到 somehal
- **axhal**: re-export set_runtime_write_fn，补全 dummy 和 test 实现
- **StarryOS/serial.rs**: 在 bind_console_to 中先注册 console_runtime_write 回调（通过 SerialTxSender::try_write 写入硬件），再 claim output

## 调用链

ax_log → _write_bytes → runtime_write_fn() → console_runtime_write → SerialBackend.tx.try_write() → UART 硬件