### PR TITLE
feat(net): add SIOCGIFNAME and share device ioctls across socket families

### DIFF
--- a/os/StarryOS/kernel/src/file/net.rs
+++ b/os/StarryOS/kernel/src/file/net.rs
@@ -24,7 +24,7 @@ use linux_raw_sys::{
     ioctl::{
         FIONREAD, SIOCGIFADDR, SIOCGIFBRDADDR, SIOCGIFCONF, SIOCGIFDSTADDR, SIOCGIFFLAGS,
         SIOCGIFHWADDR, SIOCGIFINDEX, SIOCGIFMAP, SIOCGIFMETRIC, SIOCGIFMTU, SIOCGIFNETMASK,
-        SIOCGIFTXQLEN, SIOCSIFFLAGS,
+        SIOCGIFSLAVE, SIOCGIFTXQLEN, SIOCSIFFLAGS,
     },
     net::{AF_INET, ifreq},
 };
@@ -49,6 +49,9 @@ const IFREQ_DATA_OFFSET: usize = 16;
 const IFREQ_COMPAT_LEN: usize = 40;
 // ethtool ioctl; not exported by linux-raw-sys. The value is arch-independent.
 const SIOCETHTOOL: u32 = 0x8946;
+// Map an interface index to its name (Linux net/core/dev_ioctl.c dev_ifname).
+// Arch-independent; the inverse of SIOCGIFINDEX.
+const SIOCGIFNAME: u32 = 0x8910;
 const IFCONF_LEN_OFFSET: usize = 0;
 const IFCONF_BUF_OFFSET: usize = 8;
 
@@ -121,6 +124,141 @@ fn read_ifreq_flags(arg: usize) -> AxResult<i16> {
     Ok(i16::from_ne_bytes(read_user_bytes::<2>(
         (arg + IFREQ_DATA_OFFSET) as *const u8,
     )?))
+}
+
+// Writes an interface name into `ifr_name` (offset 0), NUL-padded to IFNAMSIZ.
+fn write_ifreq_name(arg: usize, name: &str) -> AxResult<()> {
+    let mut buf = [0u8; IFREQ_NAME_LEN];
+    let bytes = name.as_bytes();
+    let n = bytes.len().min(IFREQ_NAME_LEN - 1);
+    buf[..n].copy_from_slice(&bytes[..n]);
+    Ok(vm_write_slice(arg as *mut u8, &buf)?)
+}
+
+/// Device-level socket ioctls (`SIOCGIF*`), shared across every socket family.
+///
+/// Linux routes these through `sock_ioctl` -> `dev_ioctl` regardless of the
+/// socket's address family (net/socket.c), so `AF_UNIX`/`AF_NETLINK` sockets
+/// answer them too - `if_indextoname(3)` in musl issues `SIOCGIFNAME` on an
+/// `AF_UNIX` socket, which must resolve rather than return `ENOTTY`. Returns
+/// `Some(result)` when `cmd` is a device ioctl this layer owns, `None` otherwise
+/// so the caller can try family-specific commands or fall back to `ENOTTY`.
+pub(super) fn device_ioctl(cmd: u32, arg: usize) -> Option<AxResult<usize>> {
+    let result = (|| -> AxResult<usize> {
+        match cmd {
+            SIOCGIFCONF => write_ifconf(arg)?,
+            SIOCGIFNAME => {
+                // Map ifr_ifindex -> ifr_name (Linux dev_ifname); inverse of
+                // SIOCGIFINDEX. The index arrives in the ifr_ifru union.
+                let idx = i32::from_ne_bytes(read_user_bytes::<4>(
+                    (arg + IFREQ_DATA_OFFSET) as *const u8,
+                )?);
+                let info = visible_interface_by_id(InterfaceId::new(idx as u32))?;
+                write_ifreq_name(arg, &info.name)?;
+            }
+            SIOCGIFFLAGS => {
+                let info = read_ifreq_interface(arg)?;
+                write_ifreq_data(arg, &linux_flags(&info).to_ne_bytes())?;
+            }
+            SIOCSIFFLAGS => {
+                let info = read_ifreq_interface(arg)?;
+                if !current().as_thread().cred().has_cap(CAP_NET_ADMIN) {
+                    return Err(AxError::OperationNotPermitted);
+                }
+                if read_ifreq_flags(arg)? != linux_flags(&info) {
+                    return Err(AxError::OperationNotSupported);
+                }
+            }
+            SIOCGIFADDR => {
+                let info = read_ifreq_interface(arg)?;
+                write_ifreq_sockaddr(arg, interface_ipv4(&info)?.address.address().octets())?;
+            }
+            SIOCGIFDSTADDR => {
+                let info = read_ifreq_interface(arg)?;
+                let addr = if info.kind == InterfaceKind::Loopback {
+                    interface_ipv4(&info)?.address.address().octets()
+                } else {
+                    [0, 0, 0, 0]
+                };
+                write_ifreq_sockaddr(arg, addr)?;
+            }
+            SIOCGIFBRDADDR => {
+                let info = read_ifreq_interface(arg)?;
+                let addr = if info.kind == InterfaceKind::Loopback {
+                    interface_ipv4(&info)?.address.address().octets()
+                } else {
+                    ipv4_broadcast(interface_ipv4(&info)?)
+                };
+                write_ifreq_sockaddr(arg, addr)?;
+            }
+            SIOCGIFNETMASK => {
+                let info = read_ifreq_interface(arg)?;
+                write_ifreq_sockaddr(
+                    arg,
+                    ipv4_netmask(interface_ipv4(&info)?.address.prefix_len()),
+                )?;
+            }
+            SIOCGIFHWADDR => {
+                let info = read_ifreq_interface(arg)?;
+                match info.kind {
+                    InterfaceKind::Ethernet => {
+                        let mac = info.mac.ok_or(AxError::NoSuchDevice)?;
+                        write_ifreq_hwaddr(arg, ARPHRD_ETHER, &mac.0)?
+                    }
+                    InterfaceKind::Loopback => write_ifreq_hwaddr(arg, ARPHRD_LOOPBACK, &[])?,
+                }
+            }
+            SIOCGIFMTU => {
+                let mtu = read_ifreq_interface(arg)?.mtu as i32;
+                write_ifreq_data(arg, &mtu.to_ne_bytes())?;
+            }
+            SIOCGIFMETRIC => {
+                read_ifreq_interface(arg)?;
+                write_ifreq_data(arg, &0i32.to_ne_bytes())?;
+            }
+            SIOCGIFMAP => {
+                read_ifreq_interface(arg)?;
+                write_ifreq_data(arg, &[0; 24])?;
+            }
+            // In the "can be done by all, return a value" read-only group with the
+            // other SIOCGIF* getters, but dev_ifsioc_locked has no bonding master to
+            // report: an unknown name is ENODEV (read_ifreq_interface) and a resolved
+            // interface is EINVAL (Linux net/core/dev_ioctl.c dev_ifsioc_locked).
+            SIOCGIFSLAVE => {
+                read_ifreq_interface(arg)?;
+                return Err(AxError::InvalidInput);
+            }
+            SIOCGIFTXQLEN => {
+                read_ifreq_interface(arg)?;
+                let qlen_ptr = (arg + offset_of!(ifreq, ifr_ifru)) as *mut i32;
+                qlen_ptr.vm_write(1000)?;
+            }
+            SIOCGIFINDEX => {
+                let idx = read_ifreq_interface(arg)?.id.get() as i32;
+                write_ifreq_data(arg, &idx.to_ne_bytes())?;
+            }
+            // Link speed/duplex query. No PHY is emulated, so report "not supported" the way a
+            // virtual NIC (loopback, tun/tap) does. Tools like psutil's net_if_stats() treat
+            // EOPNOTSUPP as "no ethtool" and degrade gracefully; any other errno makes them abort
+            // the whole interface-status probe. Resolve the interface first so an unknown name
+            // yields ENODEV, then fault on a bad ifr_data pointer, keeping Linux's error priority
+            // (ENODEV, then EFAULT, then EOPNOTSUPP) and parity with the sibling SIOC*IF* arms.
+            SIOCETHTOOL => {
+                read_ifreq_interface(arg)?;
+                let data_ptr = usize::from_ne_bytes(read_user_bytes::<8>(
+                    (arg + IFREQ_DATA_OFFSET) as *const u8,
+                )?);
+                read_user_bytes::<4>(data_ptr as *const u8)?;
+                return Err(AxError::OperationNotSupported);
+            }
+            _ => return Err(AxError::NotATty),
+        }
+        Ok(0)
+    })();
+    match result {
+        Err(AxError::NotATty) => None,
+        other => Some(other),
+    }
 }
 
 fn sockaddr_in_bytes(ip: [u8; 4]) -> [u8; 16] {
@@ -285,107 +423,20 @@ impl FileLike for Socket {
     }
 
     fn ioctl(&self, cmd: u32, arg: usize) -> AxResult<usize> {
-        match cmd {
-            FIONREAD => {
-                let available = self.inner.recv_available()?.min(c_int::MAX as usize) as c_int;
-                (arg as *mut c_int).vm_write(available)?;
-            }
-            SIOCGIFCONF => write_ifconf(arg)?,
-            SIOCGIFFLAGS => {
-                let info = read_ifreq_interface(arg)?;
-                write_ifreq_data(arg, &linux_flags(&info).to_ne_bytes())?;
-            }
-            SIOCSIFFLAGS => {
-                let info = read_ifreq_interface(arg)?;
-                if !current().as_thread().cred().has_cap(CAP_NET_ADMIN) {
-                    return Err(AxError::OperationNotPermitted);
-                }
-                if read_ifreq_flags(arg)? != linux_flags(&info) {
-                    return Err(AxError::OperationNotSupported);
-                }
-            }
-            SIOCGIFADDR => {
-                let info = read_ifreq_interface(arg)?;
-                write_ifreq_sockaddr(arg, interface_ipv4(&info)?.address.address().octets())?;
-            }
-            SIOCGIFDSTADDR => {
-                let info = read_ifreq_interface(arg)?;
-                let addr = if info.kind == InterfaceKind::Loopback {
-                    interface_ipv4(&info)?.address.address().octets()
-                } else {
-                    [0, 0, 0, 0]
-                };
-                write_ifreq_sockaddr(arg, addr)?;
-            }
-            SIOCGIFBRDADDR => {
-                let info = read_ifreq_interface(arg)?;
-                let addr = if info.kind == InterfaceKind::Loopback {
-                    interface_ipv4(&info)?.address.address().octets()
-                } else {
-                    ipv4_broadcast(interface_ipv4(&info)?)
-                };
-                write_ifreq_sockaddr(arg, addr)?;
-            }
-            SIOCGIFNETMASK => {
-                let info = read_ifreq_interface(arg)?;
-                write_ifreq_sockaddr(
-                    arg,
-                    ipv4_netmask(interface_ipv4(&info)?.address.prefix_len()),
-                )?;
-            }
-            SIOCGIFHWADDR => {
-                let info = read_ifreq_interface(arg)?;
-                match info.kind {
-                    InterfaceKind::Ethernet => {
-                        let mac = info.mac.ok_or(AxError::NoSuchDevice)?;
-                        write_ifreq_hwaddr(arg, ARPHRD_ETHER, &mac.0)?
-                    }
-                    InterfaceKind::Loopback => write_ifreq_hwaddr(arg, ARPHRD_LOOPBACK, &[])?,
-                }
-            }
-            SIOCGIFMTU => {
-                let mtu = read_ifreq_interface(arg)?.mtu as i32;
-                write_ifreq_data(arg, &mtu.to_ne_bytes())?;
-            }
-            SIOCGIFMETRIC => {
-                read_ifreq_interface(arg)?;
-                write_ifreq_data(arg, &0i32.to_ne_bytes())?;
-            }
-            SIOCGIFMAP => {
-                read_ifreq_interface(arg)?;
-                write_ifreq_data(arg, &[0; 24])?;
-            }
-            SIOCGIFTXQLEN => {
-                read_ifreq_interface(arg)?;
-                let qlen_ptr = (arg + offset_of!(ifreq, ifr_ifru)) as *mut i32;
-                qlen_ptr.vm_write(1000)?;
-            }
-            SIOCGIFINDEX => {
-                let idx = read_ifreq_interface(arg)?.id.get() as i32;
-                write_ifreq_data(arg, &idx.to_ne_bytes())?;
-            }
-            // Link speed/duplex query. No PHY is emulated, so report "not supported" the way a
-            // virtual NIC (loopback, tun/tap) does. Tools like psutil's net_if_stats() treat
-            // EOPNOTSUPP as "no ethtool" and degrade gracefully; any other errno makes them abort
-            // the whole interface-status probe. Resolve the interface first so an unknown name
-            // yields ENODEV, then fault on a bad ifr_data pointer, keeping Linux's error priority
-            // (ENODEV, then EFAULT, then EOPNOTSUPP) and parity with the sibling SIOC*IF* arms.
-            SIOCETHTOOL => {
-                read_ifreq_interface(arg)?;
-                let data_ptr = usize::from_ne_bytes(read_user_bytes::<8>(
-                    (arg + IFREQ_DATA_OFFSET) as *const u8,
-                )?);
-                read_user_bytes::<4>(data_ptr as *const u8)?;
-                return Err(AxError::OperationNotSupported);
-            }
-            _ => {
-                if super::wext::is_wext_ioctl(cmd) {
-                    return super::wext::handle(cmd, arg);
-                }
-                return Err(AxError::NotATty);
-            }
+        // Socket-specific query first, then the family-agnostic device ioctls
+        // (SIOCGIF*), mirroring Linux sock_ioctl dispatching to dev_ioctl.
+        if cmd == FIONREAD {
+            let available = self.inner.recv_available()?.min(c_int::MAX as usize) as c_int;
+            (arg as *mut c_int).vm_write(available)?;
+            return Ok(0);
         }
-        Ok(0)
+        if let Some(result) = device_ioctl(cmd, arg) {
+            return result;
+        }
+        if super::wext::is_wext_ioctl(cmd) {
+            return super::wext::handle(cmd, arg);
+        }
+        Err(AxError::NotATty)
     }
 
     fn from_fd(fd: c_int) -> AxResult<Arc<Self>>

--- a/os/StarryOS/kernel/src/file/netlink.rs
+++ b/os/StarryOS/kernel/src/file/netlink.rs
@@ -573,6 +573,15 @@ impl NetlinkSocket {
 }
 
 impl FileLike for NetlinkSocket {
+    fn ioctl(&self, cmd: u32, arg: usize) -> AxResult<usize> {
+        // Device ioctls (SIOCGIF*) are family-agnostic in Linux sock_ioctl, so a
+        // netlink socket answers them too rather than returning ENOTTY.
+        if let Some(result) = crate::file::net::device_ioctl(cmd, arg) {
+            return result;
+        }
+        Err(AxError::NotATty)
+    }
+
     fn read(&self, dst: &mut IoDst) -> AxResult<usize> {
         block_on(poll_io(self, IoEvents::IN, self.nonblocking(), || {
             self.read_one(dst, false, false)

--- a/os/StarryOS/kernel/src/file/packet.rs
+++ b/os/StarryOS/kernel/src/file/packet.rs
@@ -8,13 +8,12 @@ use core::{
 
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_io::prelude::*;
-use ax_net::{InterfaceFlags, InterfaceId, InterfaceInfo, InterfaceKind};
+use ax_net::{InterfaceId, InterfaceInfo, InterfaceKind};
 use ax_sync::Mutex;
 use ax_task::future::{block_on, poll_io};
 use axpoll::{IoEvents, PollSet, Pollable};
 use linux_raw_sys::{
     general::{O_RDWR, S_IFSOCK},
-    ioctl::{SIOCGIFFLAGS, SIOCGIFHWADDR, SIOCGIFINDEX},
     net::{AF_PACKET, sockaddr},
 };
 use starry_vm::{vm_read_slice, vm_write_slice};
@@ -34,13 +33,6 @@ const ETH_P_IP: u16 = 0x0800;
 const ETH_P_ARP: u16 = 0x0806;
 const ARPOP_REQUEST: u16 = 1;
 const ARPOP_REPLY: u16 = 2;
-const IFF_UP: i16 = 0x0001;
-const IFF_BROADCAST: i16 = 0x0002;
-const IFF_LOOPBACK: i16 = 0x0008;
-const IFF_RUNNING: i16 = 0x0040;
-const IFF_MULTICAST: i16 = 0x1000;
-const IFREQ_NAME_LEN: usize = 16;
-const IFREQ_DATA_OFFSET: usize = 16;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -236,37 +228,6 @@ fn read_user_bytes<const N: usize>(ptr: *const u8) -> AxResult<[u8; N]> {
     Ok(buf.map(|b| unsafe { b.assume_init() }))
 }
 
-fn ifreq_interface(arg: usize) -> AxResult<InterfaceInfo> {
-    let name = read_user_bytes::<IFREQ_NAME_LEN>(arg as *const u8)?;
-    let end = name.iter().position(|&b| b == 0).unwrap_or(name.len());
-    let name = core::str::from_utf8(&name[..end]).map_err(|_| AxError::InvalidInput)?;
-    ax_net::interface_by_name(name).ok_or(AxError::NoSuchDevice)
-}
-
-fn write_ifreq_data(arg: usize, data: &[u8]) -> AxResult<()> {
-    Ok(vm_write_slice((arg + IFREQ_DATA_OFFSET) as *mut u8, data)?)
-}
-
-fn linux_flags(info: &InterfaceInfo) -> i16 {
-    let mut flags = 0;
-    if info.flags.contains(InterfaceFlags::UP) {
-        flags |= IFF_UP;
-    }
-    if info.flags.contains(InterfaceFlags::BROADCAST) {
-        flags |= IFF_BROADCAST;
-    }
-    if info.flags.contains(InterfaceFlags::LOOPBACK) {
-        flags |= IFF_LOOPBACK;
-    }
-    if info.flags.contains(InterfaceFlags::RUNNING) {
-        flags |= IFF_RUNNING;
-    }
-    if info.flags.contains(InterfaceFlags::MULTICAST) {
-        flags |= IFF_MULTICAST;
-    }
-    flags
-}
-
 impl FileLike for PacketSocket {
     fn stat(&self) -> AxResult<Kstat> {
         Ok(Kstat {
@@ -294,25 +255,14 @@ impl FileLike for PacketSocket {
     }
 
     fn ioctl(&self, cmd: u32, arg: usize) -> AxResult<usize> {
-        if !in_root_net_ns() {
-            return Err(AxError::NoSuchDevice);
+        // The SIOCGIF* device ioctls are family-agnostic in Linux sock_ioctl ->
+        // dev_ioctl, so AF_PACKET answers them through the same shared helper as
+        // the other socket families. Interface visibility (and thus netns
+        // scoping) is enforced by device_ioctl's own lookups.
+        if let Some(result) = crate::file::net::device_ioctl(cmd, arg) {
+            return result;
         }
-        let info = ifreq_interface(arg)?;
-
-        match cmd {
-            SIOCGIFINDEX => write_ifreq_data(arg, &info.id.to_linux_ifindex().to_ne_bytes())?,
-            SIOCGIFFLAGS => write_ifreq_data(arg, &linux_flags(&info).to_ne_bytes())?,
-            SIOCGIFHWADDR => {
-                let mac = info.mac.ok_or(AxError::NoSuchDevice)?;
-                let mut hwaddr = [0; 16];
-                hwaddr[..2].copy_from_slice(&ARPHRD_ETHER.to_ne_bytes());
-                hwaddr[2..2 + mac.0.len()].copy_from_slice(&mac.0);
-                write_ifreq_data(arg, &hwaddr)?;
-            }
-            _ => return Err(AxError::NotATty),
-        }
-
-        Ok(0)
+        Err(AxError::NotATty)
     }
 }
 

--- a/test-suit/starryos/qemu/system/c-regression-test-socket-device-ioctl/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/c-regression-test-socket-device-ioctl/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(socket-device-ioctl C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(socket-device-ioctl src/main.c)
+target_compile_options(socket-device-ioctl PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS socket-device-ioctl RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/c-regression-test-socket-device-ioctl/src/main.c
+++ b/test-suit/starryos/qemu/system/c-regression-test-socket-device-ioctl/src/main.c
@@ -97,6 +97,15 @@ static void test_family(int domain, int type, int protocol, const char *fam)
     snprintf(msg, sizeof(msg), "%s: SIOCGIFNAME(unknown index) -> ENODEV", fam);
     check(r == -1 && errno == ENODEV, msg);
 
+    // A bad user pointer must map to EFAULT, not a crash or a wrong errno.
+    // Linux net/socket.c dev_ifname copies the ifreq in from user space before
+    // any lookup, so an unreadable argument fails with EFAULT - the directly
+    // observable ABI of the newly routed request across all three families.
+    errno = 0;
+    r = ioctl(fd, SIOCGIFNAME, (struct ifreq *)0);
+    snprintf(msg, sizeof(msg), "%s: SIOCGIFNAME(NULL ifreq) -> EFAULT", fam);
+    check(r == -1 && errno == EFAULT, msg);
+
     memset(&ifr, 0, sizeof(ifr));
     strncpy(ifr.ifr_name, "lo", IFNAMSIZ - 1);
     errno = 0;

--- a/test-suit/starryos/qemu/system/c-regression-test-socket-device-ioctl/src/main.c
+++ b/test-suit/starryos/qemu/system/c-regression-test-socket-device-ioctl/src/main.c
@@ -1,0 +1,140 @@
+// Exercises the family-agnostic device ioctls that Linux routes through
+// sock_ioctl -> dev_ioctl (net/socket.c, net/core/dev_ioctl.c): SIOCGIFNAME as
+// the inverse of SIOCGIFINDEX, and SIOCGIFSLAVE (no bonding master -> EINVAL for
+// a resolved interface, ENODEV for an unknown one). The same requests must be
+// answered on AF_INET, AF_NETLINK and AF_PACKET sockets - musl's
+// if_indextoname(3), which interface-enumeration code (e.g. dnsmasq) relies on,
+// issues SIOCGIFNAME and previously failed with ENOTTY.
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <net/if.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#ifndef SIOCGIFINDEX
+#define SIOCGIFINDEX 0x8933
+#endif
+#ifndef SIOCGIFNAME
+#define SIOCGIFNAME 0x8910
+#endif
+#ifndef SIOCGIFSLAVE
+#define SIOCGIFSLAVE 0x8929
+#endif
+#ifndef AF_NETLINK
+#define AF_NETLINK 16
+#endif
+#ifndef AF_PACKET
+#define AF_PACKET 17
+#endif
+#ifndef NETLINK_ROUTE
+#define NETLINK_ROUTE 0
+#endif
+
+static int passed;
+static int failed;
+
+static void check(int cond, const char *msg)
+{
+    if (cond) {
+        printf("[ ok ] %s\n", msg);
+        passed++;
+    } else {
+        printf("[FAIL] %s\n", msg);
+        failed++;
+    }
+}
+
+// Run the shared device-ioctl assertions on one socket family.
+static void test_family(int domain, int type, int protocol, const char *fam)
+{
+    char msg[96];
+
+    // Creating the socket is a required assertion. This system case runs as root
+    // (CAP_NET_RAW is available), so every family here - including AF_PACKET, the
+    // dispatch entry this test exists to exercise - is expected to open. A
+    // creation failure is a hard failure, not a silent skip: otherwise a broken
+    // or absent per-family device_ioctl route would let the whole case pass
+    // without ever reaching the ioctl assertions below.
+    int fd = socket(domain, type, protocol);
+    snprintf(msg, sizeof(msg), "%s: socket() created", fam);
+    check(fd >= 0, msg);
+    if (fd < 0) {
+        printf("       %s: socket() errno=%d (dispatch entry not exercised)\n", fam, errno);
+        return;
+    }
+
+    struct ifreq ifr;
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, "lo", IFNAMSIZ - 1);
+    int r = ioctl(fd, SIOCGIFINDEX, &ifr);
+    snprintf(msg, sizeof(msg), "%s: SIOCGIFINDEX(lo) succeeds", fam);
+    check(r == 0, msg);
+    int lo_index = ifr.ifr_ifindex;
+    snprintf(msg, sizeof(msg), "%s: lo has a positive ifindex", fam);
+    check(r == 0 && lo_index > 0, msg);
+
+    if (r == 0 && lo_index > 0) {
+        struct ifreq back;
+        memset(&back, 0, sizeof(back));
+        back.ifr_ifindex = lo_index;
+        r = ioctl(fd, SIOCGIFNAME, &back);
+        snprintf(msg, sizeof(msg), "%s: SIOCGIFNAME(lo index) succeeds", fam);
+        check(r == 0, msg);
+        snprintf(msg, sizeof(msg), "%s: SIOCGIFNAME resolves index back to \"lo\"", fam);
+        check(r == 0 && strcmp(back.ifr_name, "lo") == 0, msg);
+    }
+
+    struct ifreq bogus;
+    memset(&bogus, 0, sizeof(bogus));
+    bogus.ifr_ifindex = 999999;
+    errno = 0;
+    r = ioctl(fd, SIOCGIFNAME, &bogus);
+    snprintf(msg, sizeof(msg), "%s: SIOCGIFNAME(unknown index) -> ENODEV", fam);
+    check(r == -1 && errno == ENODEV, msg);
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, "lo", IFNAMSIZ - 1);
+    errno = 0;
+    r = ioctl(fd, SIOCGIFSLAVE, &ifr);
+    snprintf(msg, sizeof(msg), "%s: SIOCGIFSLAVE(lo) -> EINVAL, not ENOTTY", fam);
+    check(r == -1 && errno == EINVAL, msg);
+
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, "nosuchif0", IFNAMSIZ - 1);
+    errno = 0;
+    r = ioctl(fd, SIOCGIFSLAVE, &ifr);
+    snprintf(msg, sizeof(msg), "%s: SIOCGIFSLAVE(unknown) -> ENODEV", fam);
+    check(r == -1 && errno == ENODEV, msg);
+
+    close(fd);
+}
+
+int main(void)
+{
+    test_family(AF_INET, SOCK_DGRAM, 0, "AF_INET");
+    test_family(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE, "AF_NETLINK");
+    test_family(AF_PACKET, SOCK_DGRAM, 0, "AF_PACKET");
+
+    // The realistic path: musl if_indextoname()/if_nametoindex() issue SIOCGIFNAME
+    // under the hood, so a clean round-trip proves the interface-discovery use case.
+    unsigned int lo = if_nametoindex("lo");
+    check(lo > 0, "if_nametoindex(lo) > 0");
+    char name[IFNAMSIZ];
+    check(lo > 0 && if_indextoname(lo, name) != NULL && strcmp(name, "lo") == 0,
+          "if_indextoname(lo) round-trips to \"lo\"");
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("TEST PASSED\n");
+        printf("STARRY_GROUPED_TEST_PASSED: socket-device-ioctl\n");
+        return 0;
+    }
+    printf("TEST FAILED\n");
+    printf("STARRY_GROUPED_TEST_FAILED: socket-device-ioctl\n");
+    return 1;
+}


### PR DESCRIPTION
## What

`musl`'s `if_indextoname(3)` resolves an interface index to its name by issuing
`SIOCGIFNAME` on an `AF_UNIX` socket. Interface-enumeration paths that rely on it
(for example dnsmasq's interface discovery) fail with `ENOTTY` because the kernel
does not answer `SIOCGIFNAME`, and it does not answer the other `SIOCGIF*` ioctls
on non-`AF_INET` sockets either.

Linux routes the `SIOCGIF*` ioctls through `sock_ioctl` -> `dev_ioctl` regardless
of the socket's address family (`net/socket.c`, `net/core/dev_ioctl.c`), so an
`AF_INET`, `AF_UNIX` or `AF_NETLINK` socket all answer them.

## Change

- Extract the shared device-ioctl handling into a single `device_ioctl()` helper
  and dispatch to it from the generic socket, the netlink socket and the packet
  socket, mirroring Linux's family-agnostic routing.
- Add `SIOCGIFNAME` as the inverse of `SIOCGIFINDEX`: read `ifr_ifindex`, write the
  matching interface name into `ifr_name` (Linux `dev_ifname`), NUL-padded to
  `IFNAMSIZ`.
- Add `SIOCGIFSLAVE` from the same read-only group: an unknown name is `ENODEV`
  and a resolved interface `EINVAL` (`dev_ifsioc_locked`), replacing the previous
  `ENOTTY`.
- The existing `SIOCGIF*` getters, `SIOCSIFFLAGS` and `SIOCETHTOOL` move into the
  helper unchanged, preserving the `ENODEV` -> `EFAULT` -> `EOPNOTSUPP` error
  ordering; `FIONREAD` stays socket-specific. The write-side device ioctls
  (`SIOCSIFMTU`, `SIOCSIFNAME`, ...) are out of scope for this change.

## Testing

A `socket-device-ioctl` system test asserts, on `AF_INET`, `AF_NETLINK` and
`AF_PACKET`: `SIOCGIFNAME` resolves the loopback index back to `lo` and returns
`ENODEV` for an unknown index; `SIOCGIFSLAVE` returns `EINVAL` for `lo` and
`ENODEV` for an unknown name rather than `ENOTTY`; and an `if_indextoname(lo)`
round-trip resolves to `lo`. Passes on x64, aa, rv and la.


## 回归收紧(F-001)

socket-device-ioctl 回归里 socket 创建改为必需断言:该系统用例以 root 运行(CAP_NET_RAW 可用),三个地址族(含 AF_PACKET 这个新接入 `device_ioctl` 的分发入口)都必须能开,创建失败即计入失败而非静默 skip。四架构(x86_64/aarch64/riscv64/loongarch64)QEMU 下 `AF_PACKET: socket() created` 与三族 `SIOCGIFNAME`/`SIOCGIFSLAVE` 断言全过,`STARRY_SYSTEM_TEST_PASSED`,证明 PacketSocket 的共享分发确被执行。
