### PR TITLE
fix(someboot): establish runtime CPU topology mapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -707,7 +707,7 @@ version = "0.1.0"
 dependencies = [
  "ax-kspin",
  "ax-lazyinit",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3309,7 +3309,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -10199,7 +10199,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -10225,7 +10225,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -10238,7 +10238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zvariant",
 ]
 
@@ -10352,7 +10352,7 @@ dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
  "zvariant_derive",
  "zvariant_utils",
 ]
@@ -10366,7 +10366,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "zvariant_utils",
 ]
 
@@ -10379,6 +10379,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.118",
- "winnow 1.0.3",
+ "syn 2.0.119",
+ "winnow 1.0.4",
 ]

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -79,6 +79,29 @@ pub mod power {
     pub use ax_plat::power::{system_off, system_reset};
 }
 
+/// CPU topology.
+pub mod topology {
+    /// Maps a firmware or hardware CPU ID to the runtime logical CPU index.
+    #[cfg(any(test, feature = "host-test"))]
+    pub const fn resolve_cpu_index(hardware_id: usize) -> Option<usize> {
+        if hardware_id == 0 { Some(0) } else { None }
+    }
+
+    #[cfg(not(any(test, feature = "host-test")))]
+    pub use ax_plat::cpu::resolve_cpu_index;
+
+    #[cfg(test)]
+    mod tests {
+        use super::resolve_cpu_index;
+
+        #[test]
+        fn dummy_topology_only_maps_the_boot_cpu() {
+            assert_eq!(resolve_cpu_index(0), Some(0));
+            assert_eq!(resolve_cpu_index(1), None);
+        }
+    }
+}
+
 /// Trap handling.
 pub mod trap {
     #[cfg(target_arch = "x86_64")]

--- a/platforms/ax-plat/src/cpu.rs
+++ b/platforms/ax-plat/src/cpu.rs
@@ -1,0 +1,13 @@
+//! CPU topology.
+
+/// CPU topology interface.
+#[def_plat_interface]
+pub trait CpuTopologyIf {
+    /// Maps a firmware or hardware CPU ID to the dense logical index used by
+    /// the runtime.
+    ///
+    /// The mapping must use the same CPU order as per-CPU runtime state.
+    /// Hardware IDs are architecture-specific values such as RISC-V hart IDs,
+    /// AArch64 MPIDRs, or x86 APIC IDs.
+    fn resolve_cpu_index(hardware_id: usize) -> Option<usize>;
+}

--- a/platforms/ax-plat/src/lib.rs
+++ b/platforms/ax-plat/src/lib.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 extern crate ax_plat_macros;
 
 pub mod console;
+pub mod cpu;
 pub mod init;
 #[cfg(feature = "irq")]
 pub mod irq;

--- a/platforms/axplat-dyn/src/cpu.rs
+++ b/platforms/axplat-dyn/src/cpu.rs
@@ -1,0 +1,10 @@
+use ax_plat::cpu::CpuTopologyIf;
+
+struct CpuTopologyImpl;
+
+#[impl_plat_interface]
+impl CpuTopologyIf for CpuTopologyImpl {
+    fn resolve_cpu_index(hardware_id: usize) -> Option<usize> {
+        somehal::smp::cpu_id_to_idx(hardware_id)
+    }
+}

--- a/platforms/axplat-dyn/src/lib.rs
+++ b/platforms/axplat-dyn/src/lib.rs
@@ -15,6 +15,7 @@ extern crate log;
 
 mod boot;
 mod console;
+mod cpu;
 pub mod drivers;
 mod generic_timer;
 mod init;

--- a/platforms/axplat-dyn/src/power.rs
+++ b/platforms/axplat-dyn/src/power.rs
@@ -26,6 +26,6 @@ impl PowerIf for PowerImpl {
 
     /// Get the number of CPU cores available on this platform.
     fn cpu_num() -> usize {
-        somehal::smp::cpu_meta_list().count()
+        somehal::smp::cpu_count()
     }
 }

--- a/platforms/someboot/src/smp/cpu_iter.rs
+++ b/platforms/someboot/src/smp/cpu_iter.rs
@@ -1,8 +1,9 @@
-#[derive(Clone, Copy)]
-enum CpuIdSource {
+use crate::{ArchTrait, arch::Arch};
+
+enum CpuIdIterState {
     Unknown,
-    Acpi,
-    Fdt,
+    Acpi(CpuIdOrder),
+    Fdt(CpuIdOrder),
     Default,
     Done,
 }
@@ -12,64 +13,31 @@ pub(super) fn cpu_id_list() -> impl Iterator<Item = usize> {
 }
 
 struct CpuIdIter {
-    source: CpuIdSource,
-    next_index: usize,
-    pending_first: Option<usize>,
-    default_emitted: bool,
+    state: CpuIdIterState,
 }
 
 impl CpuIdIter {
     fn new() -> Self {
         Self {
-            source: CpuIdSource::Unknown,
-            next_index: 0,
-            pending_first: None,
-            default_emitted: false,
+            state: CpuIdIterState::Unknown,
         }
     }
 
-    fn select_source(&mut self) {
-        if let Some(mut iter) = crate::acpi::cpu_id_list()
-            && let Some(first) = iter.next()
+    fn select_source() -> CpuIdIterState {
+        let boot_cpu_id = Arch::cpu_current_hartid();
+        if let Some(cpu_ids) = crate::acpi::cpu_id_list()
+            && let Some(order) = CpuIdOrder::new(cpu_ids, boot_cpu_id)
         {
-            self.source = CpuIdSource::Acpi;
-            self.pending_first = Some(first);
-            self.next_index = 1;
-            return;
+            return CpuIdIterState::Acpi(order);
         }
 
-        if let Some(mut iter) = crate::fdt::cpu_id_list()
-            && let Some(first) = iter.next()
+        if let Some(cpu_ids) = crate::fdt::cpu_id_list()
+            && let Some(order) = CpuIdOrder::new(cpu_ids, boot_cpu_id)
         {
-            self.source = CpuIdSource::Fdt;
-            self.pending_first = Some(first);
-            self.next_index = 1;
-            return;
+            return CpuIdIterState::Fdt(order);
         }
 
-        self.source = CpuIdSource::Default;
-    }
-
-    fn next_from_acpi(&mut self) -> Option<usize> {
-        if let Some(id) = self.pending_first.take() {
-            return Some(id);
-        }
-
-        let mut iter = crate::acpi::cpu_id_list()?;
-        let id = iter.nth(self.next_index)?;
-        self.next_index += 1;
-        Some(id)
-    }
-
-    fn next_from_fdt(&mut self) -> Option<usize> {
-        if let Some(id) = self.pending_first.take() {
-            return Some(id);
-        }
-
-        let mut iter = crate::fdt::cpu_id_list()?;
-        let id = iter.nth(self.next_index)?;
-        self.next_index += 1;
-        Some(id)
+        CpuIdIterState::Default
     }
 }
 
@@ -78,30 +46,121 @@ impl Iterator for CpuIdIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            match self.source {
-                CpuIdSource::Unknown => self.select_source(),
-                CpuIdSource::Acpi => {
-                    if let Some(id) = self.next_from_acpi() {
-                        return Some(id);
-                    }
-                    self.source = CpuIdSource::Done;
+            let next_cpu_id = match &mut self.state {
+                CpuIdIterState::Unknown => {
+                    self.state = Self::select_source();
+                    continue;
                 }
-                CpuIdSource::Fdt => {
-                    if let Some(id) = self.next_from_fdt() {
-                        return Some(id);
-                    }
-                    self.source = CpuIdSource::Done;
+                CpuIdIterState::Acpi(order) => {
+                    crate::acpi::cpu_id_list().and_then(|cpu_ids| order.next(cpu_ids))
                 }
-                CpuIdSource::Default => {
-                    if self.default_emitted {
-                        self.source = CpuIdSource::Done;
-                    } else {
-                        self.default_emitted = true;
-                        return Some(0);
+                CpuIdIterState::Fdt(order) => {
+                    crate::fdt::cpu_id_list().and_then(|cpu_ids| order.next(cpu_ids))
+                }
+                CpuIdIterState::Default => {
+                    self.state = CpuIdIterState::Done;
+                    return Some(0);
+                }
+                CpuIdIterState::Done => return None,
+            };
+
+            if next_cpu_id.is_some() {
+                return next_cpu_id;
+            }
+            self.state = CpuIdIterState::Done;
+        }
+    }
+}
+
+enum CpuIdOrder {
+    EmitBoot {
+        boot_cpu_id: usize,
+    },
+    WalkFirmware {
+        next_index: usize,
+        skip_cpu_id: Option<usize>,
+    },
+}
+
+impl CpuIdOrder {
+    fn new(cpu_ids: impl Iterator<Item = usize>, boot_cpu_id: usize) -> Option<Self> {
+        let mut cpu_ids = cpu_ids.peekable();
+
+        cpu_ids.peek()?;
+
+        let contains_boot_cpu = cpu_ids.any(|id| id == boot_cpu_id);
+
+        Some(if contains_boot_cpu {
+            Self::EmitBoot { boot_cpu_id }
+        } else {
+            Self::WalkFirmware {
+                next_index: 0,
+                skip_cpu_id: None,
+            }
+        })
+    }
+
+    fn next(&mut self, cpu_ids: impl Iterator<Item = usize>) -> Option<usize> {
+        match self {
+            Self::EmitBoot { boot_cpu_id } => {
+                let boot_cpu_id = *boot_cpu_id;
+                *self = Self::WalkFirmware {
+                    next_index: 0,
+                    skip_cpu_id: Some(boot_cpu_id),
+                };
+                Some(boot_cpu_id)
+            }
+            Self::WalkFirmware {
+                next_index,
+                skip_cpu_id,
+            } => {
+                for (firmware_index, cpu_id) in cpu_ids.enumerate().skip(*next_index) {
+                    *next_index = firmware_index + 1;
+                    if Some(cpu_id) != *skip_cpu_id {
+                        return Some(cpu_id);
                     }
                 }
-                CpuIdSource::Done => return None,
+                None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::CpuIdOrder;
+
+    #[test]
+    fn nonzero_boot_cpu_becomes_logical_cpu_zero() {
+        let firmware_cpu_ids = [0, 1, 2, 0x103];
+        let mut order = CpuIdOrder::new(firmware_cpu_ids.into_iter(), 0x103).unwrap();
+        let ordered_cpu_ids: Vec<_> =
+            core::iter::from_fn(|| order.next(firmware_cpu_ids.into_iter())).collect();
+
+        assert_eq!(ordered_cpu_ids, [0x103, 0, 1, 2]);
+    }
+
+    #[test]
+    fn independent_traversals_keep_the_same_boot_cpu_order() {
+        let firmware_cpu_ids = [0, 1, 2, 0x103];
+        let collect_order = || {
+            let mut order = CpuIdOrder::new(firmware_cpu_ids.into_iter(), 0x103).unwrap();
+            core::iter::from_fn(|| order.next(firmware_cpu_ids.into_iter())).collect::<Vec<_>>()
+        };
+
+        assert_eq!(collect_order(), [0x103, 0, 1, 2]);
+        assert_eq!(collect_order(), [0x103, 0, 1, 2]);
+    }
+
+    #[test]
+    fn firmware_order_is_preserved_when_boot_cpu_is_missing() {
+        let firmware_cpu_ids = [1, 2, 3, 4];
+        let mut order = CpuIdOrder::new(firmware_cpu_ids.into_iter(), 0).unwrap();
+        let ordered_cpu_ids: Vec<_> =
+            core::iter::from_fn(|| order.next(firmware_cpu_ids.into_iter())).collect();
+
+        assert_eq!(ordered_cpu_ids, firmware_cpu_ids);
     }
 }

--- a/platforms/someboot/src/smp/mod.rs
+++ b/platforms/someboot/src/smp/mod.rs
@@ -225,9 +225,18 @@ pub fn cpu_meta(idx: usize) -> Option<PerCpuMeta> {
     if idx >= runtime_cpu_count() {
         return None;
     }
+    cpu_meta_slot(idx)
+}
+
+fn cpu_meta_slot(idx: usize) -> Option<PerCpuMeta> {
     let meta_start = cpu_meta_addr(idx)?;
     let meta_va = phys_to_virt(meta_start);
     debug_assert_eq!((meta_va as usize) % meta_align(), 0);
+    // SAFETY: callers reach this publication-independent reader only after an
+    // Acquire load observed a nonzero runtime count and bound `idx` by that
+    // count. The matching Release store happens after every aligned metadata
+    // slot is initialized and cache-maintained. CPU identity fields remain
+    // immutable after publication.
     Some(unsafe { *(meta_va as *const PerCpuMeta) })
 }
 
@@ -336,21 +345,76 @@ pub fn try_early_cpu_idx() -> Option<usize> {
     cpu_id_to_idx(early_current_hart_id())
 }
 
-pub fn cpu_id_to_idx(hart_id: usize) -> Option<usize> {
-    for (idx, id) in __cpu_id_list().enumerate() {
-        if id == hart_id {
-            return Some(idx);
+fn cpu_id_to_idx_from_sources<I>(
+    hardware_id: usize,
+    runtime_count: usize,
+    mut meta_at: impl FnMut(usize) -> Option<PerCpuMeta>,
+    early_ids: impl FnOnce() -> I,
+) -> Option<usize>
+where
+    I: Iterator<Item = usize>,
+{
+    if runtime_count == 0 {
+        return early_ids().position(|id| id == hardware_id);
+    }
+
+    let mut matching_index = None;
+    for cpu_index in 0..runtime_count {
+        let meta = meta_at(cpu_index)?;
+        if meta.cpu_idx != cpu_index {
+            return None;
+        }
+        if meta.cpu_id == hardware_id {
+            matching_index = Some(cpu_index);
         }
     }
-    None
+    matching_index
 }
 
-pub fn cpu_idx_to_id(idx: usize) -> Option<usize> {
-    __cpu_id_list().nth(idx)
+fn cpu_idx_to_id_from_sources<I>(
+    cpu_index: usize,
+    runtime_count: usize,
+    meta_at: impl FnOnce(usize) -> Option<PerCpuMeta>,
+    early_ids: impl FnOnce() -> I,
+) -> Option<usize>
+where
+    I: Iterator<Item = usize>,
+{
+    if runtime_count == 0 {
+        return early_ids().nth(cpu_index);
+    }
+    if cpu_index >= runtime_count {
+        return None;
+    }
+
+    let meta = meta_at(cpu_index)?;
+    (meta.cpu_idx == cpu_index).then_some(meta.cpu_id)
+}
+
+fn cpu_count_from_sources<I>(runtime_count: usize, early_ids: impl FnOnce() -> I) -> usize
+where
+    I: Iterator<Item = usize>,
+{
+    if runtime_count == 0 {
+        early_ids().count()
+    } else {
+        runtime_count
+    }
+}
+
+pub fn cpu_id_to_idx(hardware_id: usize) -> Option<usize> {
+    let runtime_count = runtime_cpu_count();
+    cpu_id_to_idx_from_sources(hardware_id, runtime_count, cpu_meta_slot, __cpu_id_list)
+}
+
+pub fn cpu_idx_to_id(cpu_index: usize) -> Option<usize> {
+    let runtime_count = runtime_cpu_count();
+    cpu_idx_to_id_from_sources(cpu_index, runtime_count, cpu_meta_slot, __cpu_id_list)
 }
 
 pub fn cpu_count() -> usize {
-    __cpu_id_list().count()
+    let runtime_count = runtime_cpu_count();
+    cpu_count_from_sources(runtime_count, __cpu_id_list)
 }
 
 struct CpuMetaIter {
@@ -480,11 +544,164 @@ fn allocate_cpu_area_region(layout: Layout) -> usize {
 mod tests {
     use super::*;
 
+    fn runtime_metadata<const N: usize>(hardware_ids: [usize; N]) -> [PerCpuMeta; N] {
+        core::array::from_fn(|cpu_index| PerCpuMeta {
+            stack_top: 0,
+            cpu_id: hardware_ids[cpu_index],
+            cpu_idx: cpu_index,
+            stack_top_virt: 0,
+            entry_virt: 0,
+            boot_table_paddr: 0,
+            primary_table_paddr: 0,
+        })
+    }
+
     #[test]
     fn extreme_alignment_input_does_not_wrap_or_panic() {
         assert_eq!(
             checked_align_up_pow2(usize::MAX, 4096),
             Err(PerCpuLayoutError::AddressOverflow)
+        );
+    }
+
+    #[test]
+    fn unpublished_cpu_count_uses_early_ids() {
+        assert_eq!(cpu_count_from_sources(0, || [2, 0, 1, 3].into_iter()), 4);
+    }
+
+    #[test]
+    fn published_cpu_count_does_not_query_early_ids() {
+        assert_eq!(
+            cpu_count_from_sources(4, || -> core::array::IntoIter<usize, 0> {
+                panic!("early CPU IDs queried after publication")
+            }),
+            4
+        );
+    }
+
+    #[test]
+    fn unpublished_hardware_id_lookup_uses_early_ids() {
+        assert_eq!(
+            cpu_id_to_idx_from_sources(
+                1,
+                0,
+                |_| panic!("runtime metadata queried before publication"),
+                || [2, 0, 1, 3].into_iter(),
+            ),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn published_hardware_id_lookup_does_not_query_early_ids() {
+        let metadata = runtime_metadata([2, 0, 1, 3]);
+
+        assert_eq!(
+            cpu_id_to_idx_from_sources(
+                1,
+                metadata.len(),
+                |slot| metadata.get(slot).copied(),
+                || -> core::array::IntoIter<usize, 0> {
+                    panic!("early CPU IDs queried after publication")
+                },
+            ),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn published_hardware_id_lookup_rejects_missing_or_inconsistent_metadata() {
+        let metadata = runtime_metadata([2, 0, 1, 3]);
+        assert_eq!(
+            cpu_id_to_idx_from_sources(
+                7,
+                metadata.len(),
+                |slot| metadata.get(slot).copied(),
+                || -> core::array::IntoIter<usize, 0> {
+                    panic!("early CPU IDs queried after publication")
+                },
+            ),
+            None
+        );
+
+        let mut inconsistent = metadata;
+        inconsistent[1].cpu_idx = 2;
+        assert_eq!(
+            cpu_id_to_idx_from_sources(
+                3,
+                inconsistent.len(),
+                |slot| inconsistent.get(slot).copied(),
+                || -> core::array::IntoIter<usize, 0> {
+                    panic!("early CPU IDs queried after publication")
+                },
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn published_hardware_id_lookup_validates_slots_after_the_match() {
+        let mut metadata = runtime_metadata([2, 0, 1, 3]);
+        metadata[3].cpu_idx = 2;
+
+        assert_eq!(
+            cpu_id_to_idx_from_sources(
+                2,
+                metadata.len(),
+                |slot| metadata.get(slot).copied(),
+                || -> core::array::IntoIter<usize, 0> {
+                    panic!("early CPU IDs queried after publication")
+                },
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn unpublished_logical_index_lookup_uses_early_ids() {
+        assert_eq!(
+            cpu_idx_to_id_from_sources(
+                2,
+                0,
+                |_| panic!("runtime metadata queried before publication"),
+                || [2, 0, 1, 3].into_iter(),
+            ),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn published_logical_index_lookup_does_not_query_early_ids() {
+        let metadata = runtime_metadata([2, 0, 1, 3]);
+
+        assert_eq!(
+            cpu_idx_to_id_from_sources(
+                2,
+                metadata.len(),
+                |slot| metadata.get(slot).copied(),
+                || -> core::array::IntoIter<usize, 0> {
+                    panic!("early CPU IDs queried after publication")
+                },
+            ),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn published_logical_index_lookup_rejects_inconsistent_metadata() {
+        let mut metadata = runtime_metadata([2, 0, 1, 3]);
+        metadata[2].cpu_idx = 1;
+
+        assert_eq!(
+            cpu_idx_to_id_from_sources(
+                2,
+                metadata.len(),
+                |slot| metadata.get(slot).copied(),
+                || -> core::array::IntoIter<usize, 0> {
+                    panic!("early CPU IDs queried after publication")
+                },
+            ),
+            None
         );
     }
 }

--- a/virtualization/axvm/src/arch/aarch64/capabilities.rs
+++ b/virtualization/axvm/src/arch/aarch64/capabilities.rs
@@ -41,6 +41,14 @@ pub fn host_phys_to_virt(paddr: ax_memory_addr::PhysAddr) -> ax_memory_addr::Vir
     ax_std::os::arceos::modules::ax_hal::mem::phys_to_virt(paddr)
 }
 
+pub(super) fn resolve_cpu_index(hardware_cpu_id: usize) -> Option<usize> {
+    ax_std::os::arceos::modules::ax_hal::topology::resolve_cpu_index(hardware_cpu_id)
+}
+
+pub(super) fn host_cpu_count() -> usize {
+    ax_std::os::arceos::modules::ax_hal::cpu_num()
+}
+
 pub(super) fn decode_gic_spi(specifier: &[u32]) -> Option<u32> {
     (specifier.first().copied() == Some(0))
         .then(|| specifier.get(1).copied())

--- a/virtualization/axvm/src/arch/aarch64/fdt.rs
+++ b/virtualization/axvm/src/arch/aarch64/fdt.rs
@@ -24,6 +24,8 @@ pub(crate) fn guest_fdt_policy() -> core::GuestFdtPolicy {
         patch_runtime: super::capabilities::patch_runtime_fdt,
         patch_provided: super::capabilities::patch_provided_fdt,
         decode_interrupt: super::capabilities::decode_gic_spi,
+        resolve_cpu_index: super::capabilities::resolve_cpu_index,
+        host_cpu_count: super::capabilities::host_cpu_count,
     }
 }
 

--- a/virtualization/axvm/src/arch/riscv64/capabilities.rs
+++ b/virtualization/axvm/src/arch/riscv64/capabilities.rs
@@ -41,6 +41,14 @@ pub fn host_phys_to_virt(paddr: ax_memory_addr::PhysAddr) -> ax_memory_addr::Vir
     ax_std::os::arceos::modules::ax_hal::mem::phys_to_virt(paddr)
 }
 
+pub(super) fn resolve_cpu_index(hardware_cpu_id: usize) -> Option<usize> {
+    ax_std::os::arceos::modules::ax_hal::topology::resolve_cpu_index(hardware_cpu_id)
+}
+
+pub(super) fn host_cpu_count() -> usize {
+    ax_std::os::arceos::modules::ax_hal::cpu_num()
+}
+
 pub(super) fn decode_plic_source(specifier: &[u32]) -> Option<u32> {
     specifier.first().copied().filter(|source| *source != 0)
 }

--- a/virtualization/axvm/src/arch/riscv64/fdt.rs
+++ b/virtualization/axvm/src/arch/riscv64/fdt.rs
@@ -22,6 +22,8 @@ pub(crate) fn guest_fdt_policy() -> core::GuestFdtPolicy {
         patch_runtime: super::capabilities::patch_runtime_fdt,
         patch_provided: super::capabilities::patch_provided_fdt,
         decode_interrupt: super::capabilities::decode_plic_source,
+        resolve_cpu_index: super::capabilities::resolve_cpu_index,
+        host_cpu_count: super::capabilities::host_cpu_count,
     }
 }
 

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -382,40 +382,82 @@ pub fn set_phys_cpu_sets(
                 .strip_prefix("/cpus/cpu@")
                 .and_then(|id| id.split('/').next())
                 .and_then(|id| usize::from_str_radix(id, 16).ok())?;
-            let guest_cpu_id = node_regs(fdt, node_id).first()?.address as usize;
+            let hardware_cpu_id = node_regs(fdt, node_id).first()?.address as usize;
             info!(
-                "CPU node: {}, node_id: 0x{:x}, guest_cpu_id: 0x{:x}",
-                path, node_id_from_path, guest_cpu_id
+                "CPU node: {}, node_id: 0x{:x}, hardware_cpu_id: 0x{:x}",
+                path, node_id_from_path, hardware_cpu_id
             );
-            Some((node_id_from_path, guest_cpu_id))
+            Some((node_id_from_path, hardware_cpu_id))
         })
         .collect();
     info!("Found {} host CPU nodes", cpu_nodes_info.len());
 
-    let mut new_phys_cpu_sets = Vec::new();
-    let mut guest_phys_cpu_ids = Vec::new();
-    for phys_cpu_id in phys_cpu_ids {
-        if let Some((cpu_index, (_, guest_cpu_id))) = cpu_nodes_info
-            .iter()
-            .enumerate()
-            .find(|(_, (node_id, _))| node_id == phys_cpu_id)
-        {
-            let cpu_mask = 1usize << cpu_index;
-            new_phys_cpu_sets.push(cpu_mask);
-            guest_phys_cpu_ids.push(*guest_cpu_id);
-        } else {
-            error!(
-                "vCPU {} with phys_cpu_id 0x{:x} not found in device tree!",
-                vm_cfg.id(),
-                phys_cpu_id
-            );
-        }
-    }
+    let policy = super::selected_guest_fdt_policy();
+    let (new_phys_cpu_sets, guest_phys_cpu_ids) = resolve_phys_cpu_sets(
+        phys_cpu_ids,
+        &cpu_nodes_info,
+        (policy.host_cpu_count)(),
+        policy.resolve_cpu_index,
+    )?;
 
     let phys_cpu_ls = vm_cfg.phys_cpu_ls_mut();
     phys_cpu_ls.set_guest_cpu_sets(new_phys_cpu_sets);
     phys_cpu_ls.set_guest_phys_cpu_ids(guest_phys_cpu_ids);
     Ok(())
+}
+
+fn resolve_phys_cpu_sets(
+    phys_cpu_ids: &[usize],
+    cpu_nodes: &[(usize, usize)],
+    host_cpu_count: usize,
+    mut resolve_cpu_index: impl FnMut(usize) -> Option<usize>,
+) -> AxVmResult<(Vec<usize>, Vec<usize>)> {
+    let mut cpu_sets = Vec::with_capacity(phys_cpu_ids.len());
+    let mut guest_cpu_ids = Vec::with_capacity(phys_cpu_ids.len());
+
+    for &phys_cpu_id in phys_cpu_ids {
+        let &(_, hardware_cpu_id) = cpu_nodes
+            .iter()
+            .find(|(node_id, _)| *node_id == phys_cpu_id)
+            .ok_or_else(|| {
+                ax_err_type!(
+                    InvalidInput,
+                    format!("physical CPU ID 0x{phys_cpu_id:x} is missing from the host FDT")
+                )
+            })?;
+        let logical_index = resolve_cpu_index(hardware_cpu_id).ok_or_else(|| {
+            ax_err_type!(
+                InvalidInput,
+                format!(
+                    "hardware CPU ID 0x{hardware_cpu_id:x} is missing from the runtime topology"
+                )
+            )
+        })?;
+        if logical_index >= host_cpu_count {
+            return Err(ax_err_type!(
+                InvalidInput,
+                format!(
+                    "logical CPU index {logical_index} is outside the {host_cpu_count} usable \
+                     host CPUs"
+                )
+            ));
+        }
+        let cpu_mask = if logical_index < usize::BITS as usize {
+            1usize << logical_index
+        } else {
+            return Err(ax_err_type!(
+                InvalidInput,
+                format!(
+                    "logical CPU index {logical_index} does not fit the host CPU affinity mask"
+                )
+            ));
+        };
+
+        cpu_sets.push(cpu_mask);
+        guest_cpu_ids.push(hardware_cpu_id);
+    }
+
+    Ok((cpu_sets, guest_cpu_ids))
 }
 
 fn add_device_address_config(
@@ -634,7 +676,7 @@ mod tests {
     use fdt_edit::{Fdt, Node};
     use fdt_raw::RegInfo;
 
-    use super::{align_reserved_region_4k, reserve_excluded_device_ranges};
+    use super::{align_reserved_region_4k, reserve_excluded_device_ranges, resolve_phys_cpu_sets};
     use crate::config::{AxVMConfig, AxVMConfigParams, PhysCpuList};
 
     fn prop_u32(name: &str, value: u32) -> fdt_edit::Property {
@@ -685,6 +727,52 @@ mod tests {
     #[test]
     fn align_reserved_region_rejects_zero_sized_range() {
         assert_eq!(align_reserved_region_4k(0x1000, 0), None);
+    }
+
+    #[test]
+    fn phys_cpu_set_uses_runtime_logical_index_instead_of_fdt_order() {
+        let cpu_nodes = [(0, 0), (1, 1), (2, 2), (3, 3)];
+        let runtime_indices_by_hardware_id = [1, 2, 3, 0];
+
+        let (cpu_sets, guest_cpu_ids) =
+            resolve_phys_cpu_sets(&[0], &cpu_nodes, 4, |hardware_cpu_id| {
+                runtime_indices_by_hardware_id.get(hardware_cpu_id).copied()
+            })
+            .unwrap();
+
+        assert_eq!(cpu_sets, vec![0b0010]);
+        assert_eq!(guest_cpu_ids, vec![0]);
+    }
+
+    #[test]
+    fn phys_cpu_set_rejects_cpu_missing_from_runtime_topology() {
+        let error = resolve_phys_cpu_sets(&[3], &[(3, 3)], 4, |_| None).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("hardware CPU ID 0x3 is missing from the runtime topology")
+        );
+    }
+
+    #[test]
+    fn phys_cpu_set_rejects_logical_index_outside_affinity_mask() {
+        let error =
+            resolve_phys_cpu_sets(&[3], &[(3, 3)], usize::MAX, |_| Some(usize::BITS as usize))
+                .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("does not fit the host CPU affinity mask")
+        );
+    }
+
+    #[test]
+    fn phys_cpu_set_rejects_logical_index_outside_usable_host_cpus() {
+        let error = resolve_phys_cpu_sets(&[3], &[(3, 3)], 4, |_| Some(4)).unwrap_err();
+
+        assert!(error.to_string().contains("outside the 4 usable host CPUs"));
     }
 
     #[test]

--- a/virtualization/axvm/src/boot/fdt/core/policy.rs
+++ b/virtualization/axvm/src/boot/fdt/core/policy.rs
@@ -15,4 +15,6 @@ pub struct GuestFdtPolicy {
     pub patch_runtime: RuntimeFdtPatch,
     pub patch_provided: ProvidedFdtPatch,
     pub decode_interrupt: fn(&[u32]) -> Option<u32>,
+    pub resolve_cpu_index: fn(usize) -> Option<usize>,
+    pub host_cpu_count: fn() -> usize,
 }

--- a/virtualization/axvm/src/boot/fdt/mod.rs
+++ b/virtualization/axvm/src/boot/fdt/mod.rs
@@ -32,6 +32,8 @@ fn guest_fdt_policy() -> test_core::GuestFdtPolicy {
         patch_runtime: test_runtime_patch,
         patch_provided: test_provided_patch,
         decode_interrupt: |specifier| specifier.first().copied(),
+        resolve_cpu_index: Some,
+        host_cpu_count: || usize::BITS as usize,
     }
 }
 


### PR DESCRIPTION
## 问题

部分平台的启动 CPU 不在固件 CPU 列表首位，导致启动 CPU 的逻辑索引不是 0。AxVM 同时使用 FDT 节点顺序生成 affinity mask，可能与 someboot 建立的运行时 CPU 顺序不一致。

## 修改内容

- 调整 someboot 的 CPU 枚举顺序，将实际启动 CPU 固定为逻辑 CPU 0。
- CPU 拓扑发布后，使用 `PerCpuMeta` 进行硬件 ID、逻辑索引和 CPU 数量查询，避免次核重新解析固件列表。
- 通过 `ax-plat`、`axplat-dyn` 和 `ax-hal` 向 AxVM 暴露运行时 CPU 映射。
- AxVM 根据 FDT CPU 节点的硬件 ID 查询运行时逻辑索引，并使用该索引生成 affinity mask。
- 对缺失拓扑及越界 CPU 索引返回明确错误。