### PR TITLE
fix(axbuild): enforce QEMU success markers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "quote",
  "raw-cpuid 11.6.0",
  "regex",
+ "regex-automata",
  "reqwest",
  "rustc-demangle",
  "schemars",

--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -28,6 +28,7 @@ log = "0.4"
 object = "0.38"
 ostool = { workspace = true }
 regex = { version = "1.12" }
+regex-automata = "0.4.16"
 reqwest = { version = "0.13", features = ["stream"] }
 addr2line = "0.26"
 rustc-demangle = "0.1"

--- a/scripts/axbuild/src/arceos/test/rust_qemu.rs
+++ b/scripts/axbuild/src/arceos/test/rust_qemu.rs
@@ -214,6 +214,7 @@ pub(super) async fn run_rust_qemu_case(
             suppress_terminal_raw_blocks: true,
             write_log_during_capture: keep_qemu_log,
             captured_blocks: Arc::new(std::sync::Mutex::new(Vec::new())),
+            success_output: None,
         })
     } else {
         None

--- a/scripts/axbuild/src/backtrace/capture.rs
+++ b/scripts/axbuild/src/backtrace/capture.rs
@@ -19,6 +19,38 @@ pub(crate) struct BacktraceQemuCapture {
     pub write_log_during_capture: bool,
     /// All complete raw blocks captured during QEMU (for stream symbolize and deferred log write).
     pub captured_blocks: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    /// Optional bounded QEMU output state used to enforce configured success markers.
+    pub success_output: Option<crate::support::qemu_success::QemuSuccessOutput>,
+}
+
+impl BacktraceQemuCapture {
+    pub(crate) fn success_output_only(
+        success_output: crate::support::qemu_success::QemuSuccessOutput,
+    ) -> Self {
+        Self {
+            log_path: PathBuf::new(),
+            stream_symbolize: None,
+            suppress_terminal_raw_blocks: false,
+            write_log_during_capture: false,
+            captured_blocks: Arc::new(std::sync::Mutex::new(Vec::new())),
+            success_output: Some(success_output),
+        }
+    }
+
+    pub(crate) fn with_success_output(
+        mut self,
+        success_output: crate::support::qemu_success::QemuSuccessOutput,
+    ) -> Self {
+        self.success_output = Some(success_output);
+        self
+    }
+
+    pub(crate) fn captures_backtrace_blocks(&self) -> bool {
+        !self.log_path.as_os_str().is_empty()
+            || self.stream_symbolize.is_some()
+            || self.suppress_terminal_raw_blocks
+            || self.write_log_during_capture
+    }
 }
 
 /// Incremental state machine: captures `BACKTRACE_BEGIN` ... `BACKTRACE_END` blocks to memory

--- a/scripts/axbuild/src/context/mod.rs
+++ b/scripts/axbuild/src/context/mod.rs
@@ -194,11 +194,17 @@ impl AppContext {
         capture_backtrace: Option<crate::backtrace::BacktraceQemuCapture>,
     ) -> anyhow::Result<()> {
         let _path_guard = self.scoped_qemu_path(cargo)?;
-        let _backtrace_capture = capture_backtrace
+        let success_regex = qemu.success_regex.clone();
+        let (capture_backtrace, success_output) =
+            crate::support::qemu_success::capture_required_success_output(
+                &success_regex,
+                capture_backtrace,
+            );
+        let output_capture = capture_backtrace
             .as_ref()
             .map(crate::support::backtrace_output_capture::BacktraceOutputCaptureGuard::install)
             .transpose()
-            .context("failed to install backtrace block output capture")?;
+            .context("failed to install QEMU output capture")?;
         self.activate_cargo_build_context(cargo)?;
         let stage = StageLog::start(format!(
             "qemu run package={} target={}",
@@ -210,6 +216,11 @@ impl AppContext {
             RunQemuOptions { dtb_dump: false },
         )
         .await;
+        drop(output_capture);
+        let result = crate::support::qemu_success::verify_qemu_success_contract(
+            result,
+            success_output.as_ref(),
+        );
         if result.is_ok() {
             stage.done();
         }
@@ -245,11 +256,17 @@ impl AppContext {
         qemu: QemuConfig,
         capture_backtrace: Option<crate::backtrace::BacktraceQemuCapture>,
     ) -> anyhow::Result<()> {
-        let _backtrace_capture = capture_backtrace
+        let success_regex = qemu.success_regex.clone();
+        let (capture_backtrace, success_output) =
+            crate::support::qemu_success::capture_required_success_output(
+                &success_regex,
+                capture_backtrace,
+            );
+        let output_capture = capture_backtrace
             .as_ref()
             .map(crate::support::backtrace_output_capture::BacktraceOutputCaptureGuard::install)
             .transpose()
-            .context("failed to install backtrace block output capture")?;
+            .context("failed to install QEMU output capture")?;
         let stage = StageLog::start("qemu run prepared artifact");
         let result = ostool_qemu::run_qemu(
             &mut self.invocation,
@@ -257,6 +274,11 @@ impl AppContext {
             RunQemuOptions { dtb_dump: false },
         )
         .await;
+        drop(output_capture);
+        let result = crate::support::qemu_success::verify_qemu_success_contract(
+            result,
+            success_output.as_ref(),
+        );
         if result.is_ok() {
             stage.done();
         }

--- a/scripts/axbuild/src/starry/test/qemu_run.rs
+++ b/scripts/axbuild/src/starry/test/qemu_run.rs
@@ -426,6 +426,7 @@ impl Starry {
                 suppress_terminal_raw_blocks: false,
                 write_log_during_capture: keep_qemu_log,
                 captured_blocks: Arc::new(std::sync::Mutex::new(Vec::new())),
+                success_output: None,
             })
         } else {
             None

--- a/scripts/axbuild/src/support/backtrace_output_capture.rs
+++ b/scripts/axbuild/src/support/backtrace_output_capture.rs
@@ -1,4 +1,4 @@
-//! Cross-platform stdout/stderr tee that writes only raw backtrace blocks to a log file.
+//! Cross-platform stdout/stderr tee for QEMU transcripts and raw backtrace blocks.
 
 use std::io;
 
@@ -128,7 +128,7 @@ mod platform {
     pub(super) struct PlatformGuard {
         saved_stdout: i32,
         saved_stderr: i32,
-        capture: Arc<Mutex<BacktraceBlockCapture>>,
+        capture: Option<Arc<Mutex<BacktraceBlockCapture>>>,
         captured_blocks: Arc<Mutex<Vec<Vec<String>>>>,
         stream_symbolize: Option<Arc<crate::backtrace::BacktraceSymbolizeSession>>,
         reader: Option<JoinHandle<io::Result<()>>>,
@@ -139,10 +139,14 @@ mod platform {
         let log_path = capture
             .write_log_during_capture
             .then_some(capture.log_path.as_path());
-        let block_capture = Arc::new(Mutex::new(BacktraceBlockCapture::create(
-            log_path,
-            Some(capture.captured_blocks.clone()),
-        )?));
+        let block_capture = if capture.captures_backtrace_blocks() {
+            Some(Arc::new(Mutex::new(BacktraceBlockCapture::create(
+                log_path,
+                Some(capture.captured_blocks.clone()),
+            )?)))
+        } else {
+            None
+        };
 
         let mut pipe = PipeEnds::new()?;
         if unsafe { libc::dup2(pipe.write_fd, libc::STDOUT_FILENO) } < 0
@@ -160,6 +164,7 @@ mod platform {
         let tee_out = rollback.take_tee_out();
         let capture_for_reader = block_capture.clone();
         let suppress_terminal_raw_blocks = capture.suppress_terminal_raw_blocks;
+        let success_output = capture.success_output.clone();
 
         let reader = std::thread::spawn(move || {
             let mut pipe = unsafe { File::from_raw_fd(pipe_read) };
@@ -170,10 +175,17 @@ mod platform {
                     Ok(0) => break,
                     Ok(n) => {
                         let chunk = &buf[..n];
-                        let terminal_chunk = if let Ok(mut capture) = capture_for_reader.lock() {
-                            capture
-                                .push_bytes_for_tee(chunk, suppress_terminal_raw_blocks)
-                                .unwrap_or_else(|_| chunk.to_vec())
+                        if let Some(success_output) = &success_output {
+                            success_output.append(chunk);
+                        }
+                        let terminal_chunk = if let Some(capture) = &capture_for_reader {
+                            if let Ok(mut capture) = capture.lock() {
+                                capture
+                                    .push_bytes_for_tee(chunk, suppress_terminal_raw_blocks)
+                                    .unwrap_or_else(|_| chunk.to_vec())
+                            } else {
+                                chunk.to_vec()
+                            }
                         } else {
                             chunk.to_vec()
                         };
@@ -213,7 +225,9 @@ mod platform {
             if let Some(reader) = self.reader.take() {
                 let _ = reader.join();
             }
-            if let Ok(mut capture) = self.capture.lock() {
+            if let Some(capture) = &self.capture
+                && let Ok(mut capture) = capture.lock()
+            {
                 let _ = capture.finish();
             }
             if let Some(session) = &self.stream_symbolize {
@@ -250,7 +264,7 @@ mod platform {
         orig_stdout: HANDLE,
         orig_stderr: HANDLE,
         pipe_write: HANDLE,
-        capture: Arc<Mutex<BacktraceBlockCapture>>,
+        capture: Option<Arc<Mutex<BacktraceBlockCapture>>>,
         captured_blocks: Arc<Mutex<Vec<Vec<String>>>>,
         stream_symbolize: Option<Arc<crate::backtrace::BacktraceSymbolizeSession>>,
         reader: Option<JoinHandle<io::Result<()>>>,
@@ -287,12 +301,17 @@ mod platform {
         let log_path = capture
             .write_log_during_capture
             .then_some(capture.log_path.as_path());
-        let block_capture = Arc::new(Mutex::new(BacktraceBlockCapture::create(
-            log_path,
-            Some(capture.captured_blocks.clone()),
-        )?));
+        let block_capture = if capture.captures_backtrace_blocks() {
+            Some(Arc::new(Mutex::new(BacktraceBlockCapture::create(
+                log_path,
+                Some(capture.captured_blocks.clone()),
+            )?)))
+        } else {
+            None
+        };
         let capture_for_reader = block_capture.clone();
         let suppress_terminal_raw_blocks = capture.suppress_terminal_raw_blocks;
+        let success_output = capture.success_output.clone();
 
         let reader = std::thread::spawn(move || {
             let mut pipe = unsafe { File::from_raw_handle(read_handle as _) };
@@ -303,10 +322,17 @@ mod platform {
                     Ok(0) => break,
                     Ok(n) => {
                         let chunk = &buf[..n];
-                        let terminal_chunk = if let Ok(mut capture) = capture_for_reader.lock() {
-                            capture
-                                .push_bytes_for_tee(chunk, suppress_terminal_raw_blocks)
-                                .unwrap_or_else(|_| chunk.to_vec())
+                        if let Some(success_output) = &success_output {
+                            success_output.append(chunk);
+                        }
+                        let terminal_chunk = if let Some(capture) = &capture_for_reader {
+                            if let Ok(mut capture) = capture.lock() {
+                                capture
+                                    .push_bytes_for_tee(chunk, suppress_terminal_raw_blocks)
+                                    .unwrap_or_else(|_| chunk.to_vec())
+                            } else {
+                                chunk.to_vec()
+                            }
                         } else {
                             chunk.to_vec()
                         };
@@ -345,7 +371,9 @@ mod platform {
             if let Some(reader) = self.reader.take() {
                 let _ = reader.join();
             }
-            if let Ok(mut capture) = self.capture.lock() {
+            if let Some(capture) = &self.capture
+                && let Ok(mut capture) = capture.lock()
+            {
                 let _ = capture.finish();
             }
             if let Some(session) = &self.stream_symbolize {

--- a/scripts/axbuild/src/support/mod.rs
+++ b/scripts/axbuild/src/support/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod download;
 pub(crate) mod git;
 pub(crate) mod logging;
 pub mod process;
+pub(crate) mod qemu_success;

--- a/scripts/axbuild/src/support/qemu_success.rs
+++ b/scripts/axbuild/src/support/qemu_success.rs
@@ -1,0 +1,254 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Result, bail};
+use regex_automata::{
+    Input,
+    dfa::{Automaton, dense},
+    util::primitives::StateID,
+};
+
+const TRANSCRIPT_TAIL_BYTES: usize = 2048;
+
+#[derive(Clone)]
+pub(crate) struct QemuSuccessOutput {
+    state: Arc<Mutex<QemuSuccessOutputState>>,
+}
+
+impl QemuSuccessOutput {
+    fn new(success_regex: &[String]) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(QemuSuccessOutputState {
+                matcher: StreamingMatcher::new(success_regex),
+                tail: Vec::with_capacity(TRANSCRIPT_TAIL_BYTES),
+            })),
+        }
+    }
+
+    pub(crate) fn append(&self, chunk: &[u8]) {
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.append(chunk);
+    }
+
+    fn snapshot(&self) -> QemuSuccessSnapshot {
+        let state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        QemuSuccessSnapshot {
+            matched: state.matcher.as_ref().is_ok_and(StreamingMatcher::is_match),
+            matcher_error: state.matcher.as_ref().err().cloned(),
+            tail: state.tail.clone(),
+        }
+    }
+}
+
+struct QemuSuccessOutputState {
+    matcher: std::result::Result<StreamingMatcher, String>,
+    tail: Vec<u8>,
+}
+
+impl QemuSuccessOutputState {
+    fn append(&mut self, chunk: &[u8]) {
+        if let Ok(matcher) = &mut self.matcher {
+            matcher.append(chunk);
+        }
+        append_bounded_tail(&mut self.tail, chunk);
+    }
+}
+
+struct StreamingMatcher {
+    dfa: dense::DFA<Vec<u32>>,
+    state: StateID,
+    matched: bool,
+}
+
+impl StreamingMatcher {
+    fn new(patterns: &[String]) -> std::result::Result<Self, String> {
+        let dfa = dense::Builder::new()
+            .build_many(patterns)
+            .map_err(|err| err.to_string())?;
+        let state = dfa
+            .start_state_forward(&Input::new(b""))
+            .map_err(|err| err.to_string())?;
+        Ok(Self {
+            dfa,
+            state,
+            matched: false,
+        })
+    }
+
+    fn append(&mut self, chunk: &[u8]) {
+        if self.matched {
+            return;
+        }
+        for &byte in chunk {
+            self.state = self.dfa.next_state(self.state, byte);
+            if self.dfa.is_match_state(self.state) {
+                self.matched = true;
+                return;
+            }
+        }
+    }
+
+    fn is_match(&self) -> bool {
+        self.matched || self.dfa.is_match_state(self.dfa.next_eoi_state(self.state))
+    }
+}
+
+struct QemuSuccessSnapshot {
+    matched: bool,
+    matcher_error: Option<String>,
+    tail: Vec<u8>,
+}
+
+fn append_bounded_tail(tail: &mut Vec<u8>, chunk: &[u8]) {
+    if chunk.len() >= TRANSCRIPT_TAIL_BYTES {
+        tail.clear();
+        tail.extend_from_slice(&chunk[chunk.len() - TRANSCRIPT_TAIL_BYTES..]);
+        return;
+    }
+
+    let overflow = tail
+        .len()
+        .saturating_add(chunk.len())
+        .saturating_sub(TRANSCRIPT_TAIL_BYTES);
+    if overflow > 0 {
+        tail.drain(..overflow);
+    }
+    tail.extend_from_slice(chunk);
+}
+
+pub(crate) fn capture_required_success_output(
+    success_regex: &[String],
+    capture: Option<crate::backtrace::BacktraceQemuCapture>,
+) -> (
+    Option<crate::backtrace::BacktraceQemuCapture>,
+    Option<QemuSuccessOutput>,
+) {
+    if success_regex.is_empty() {
+        return (capture, None);
+    }
+
+    let success_output = QemuSuccessOutput::new(success_regex);
+    let capture = match capture {
+        Some(capture) => capture.with_success_output(success_output.clone()),
+        None => crate::backtrace::BacktraceQemuCapture::success_output_only(success_output.clone()),
+    };
+    (Some(capture), Some(success_output))
+}
+
+pub(crate) fn verify_qemu_success_contract(
+    run_result: Result<()>,
+    success_output: Option<&QemuSuccessOutput>,
+) -> Result<()> {
+    run_result?;
+    let Some(success_output) = success_output else {
+        return Ok(());
+    };
+
+    let snapshot = success_output.snapshot();
+    if let Some(err) = snapshot.matcher_error {
+        bail!("failed to compile QEMU success regex set: {err}");
+    }
+    if snapshot.matched {
+        return Ok(());
+    }
+
+    let tail = String::from_utf8_lossy(&snapshot.tail);
+    bail!("QEMU stopped without matching a configured success regex; transcript tail:\n{tail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{QemuSuccessOutput, TRANSCRIPT_TAIL_BYTES, verify_qemu_success_contract};
+
+    fn captured_output(patterns: &[&str], chunks: &[&[u8]]) -> QemuSuccessOutput {
+        let patterns = patterns.iter().map(ToString::to_string).collect::<Vec<_>>();
+        let output = QemuSuccessOutput::new(&patterns);
+        for chunk in chunks {
+            output.append(chunk);
+        }
+        output
+    }
+
+    #[test]
+    fn exit_zero_without_required_success_marker_is_an_error() {
+        let output = captured_output(
+            &[r"(?m)^STARRY_GROUPED_TESTS_PASSED\s*$"],
+            &[b"guest exited before completing the suite\n"],
+        );
+        let err = verify_qemu_success_contract(Ok(()), Some(&output)).unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("without matching a configured success regex")
+        );
+    }
+
+    #[test]
+    fn configured_success_marker_is_accepted() {
+        let output = captured_output(
+            &[r"(?m)^STARRY_GROUPED_TESTS_PASSED\s*$"],
+            &[b"booting\nSTARRY_GROUPED_TESTS_PASSED\n"],
+        );
+        verify_qemu_success_contract(Ok(()), Some(&output)).unwrap();
+    }
+
+    #[test]
+    fn empty_success_contract_preserves_normal_exit() {
+        verify_qemu_success_contract(Ok(()), None).unwrap();
+    }
+
+    #[test]
+    fn runner_error_takes_precedence_over_missing_marker() {
+        let output = captured_output(&["PASS"], &[]);
+        let err = verify_qemu_success_contract(Err(anyhow::anyhow!("QEMU timeout")), Some(&output))
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "QEMU timeout");
+    }
+
+    #[test]
+    fn streaming_matcher_preserves_chunk_boundaries() {
+        let output = captured_output(
+            &[r"(?m)^STARRY_GROUPED_TESTS_PASSED$"],
+            &[b"STARRY_GROUPED_", b"TESTS_PASSED\n"],
+        );
+        verify_qemu_success_contract(Ok(()), Some(&output)).unwrap();
+    }
+
+    #[test]
+    fn sustained_noise_keeps_only_the_bounded_diagnostic_tail() {
+        let output = captured_output(&["PASS"], &[]);
+        let chunk = [b'x'; 8192];
+
+        for _ in 0..1024 {
+            output.append(&chunk);
+        }
+
+        let snapshot = output.snapshot();
+        assert_eq!(snapshot.tail.len(), TRANSCRIPT_TAIL_BYTES);
+        assert!(!snapshot.matched);
+    }
+
+    #[test]
+    fn runner_error_takes_precedence_over_invalid_success_regex() {
+        let output = captured_output(&["("], &[]);
+
+        let err = verify_qemu_success_contract(Err(anyhow::anyhow!("QEMU timeout")), Some(&output))
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "QEMU timeout");
+    }
+
+    #[test]
+    fn success_only_output_does_not_enable_backtrace_block_capture() {
+        let output = captured_output(&["PASS"], &[]);
+        let capture = crate::backtrace::BacktraceQemuCapture::success_output_only(output);
+
+        assert!(!capture.captures_backtrace_blocks());
+    }
+}


### PR DESCRIPTION
## 问题

QEMU 配置了 `success_regex` 时，现有运行流程只依据进程退出结果判断成功。QEMU 即使以状态码 0 提前退出、且没有输出任何成功标记，也会被误判为测试通过。

此外，初版修复为校验成功标记保存了完整 stdout/stderr；持续输出的异常 guest 可能在超时前耗尽宿主内存。

## 修改

- 使用 `regex-automata` DFA 在 QEMU 输出读取路径中逐字节流式匹配全部 `success_regex`，支持跨读取块匹配，并在读取结束时处理 EOI，使 `$` 等结束锚点保持正确语义。
- 只保留固定 2048 字节的诊断尾部，不再保存无界 transcript。
- 等待输出读取线程结束后再验证匹配结果；未配置成功标记时保持原行为。
- 保持运行器错误优先级：QEMU/运行器自身报错时原样返回，不用匹配器错误或“缺少成功标记”覆盖根因。
- 仅配置成功标记时跳过 backtrace block 行缓冲器，避免没有换行的持续输出在另一条捕获路径形成无界缓冲。
- 覆盖 Unix、Windows 两条输出读取路径，不改变公开接口。

## 红绿测试

- 修复前：`cargo test -p axbuild sustained_noise_keeps_only_the_bounded_diagnostic_tail` 确定性失败，旧实现保留 8 MiB 输出而非 2048 字节尾部。
- 修复后：同一测试通过。
- 新增并通过 8 项成功标记回归测试，覆盖缺失/命中/空配置、运行器错误优先级、跨块匹配、持续噪声有界尾部、非法正则错误优先级，以及 success-only 不启用 backtrace block parser。

## 最终验证

- `cargo fmt --check`
- `cargo test -p axbuild`：785 项通过
- `cargo xtask clippy --package axbuild`
- `cargo xtask arceos test qemu --arch x86_64 --test-group rust --test-case task-yield`

QEMU 场景通过，并由新的流式匹配器命中 `ArceOS test suite run OK!`。

## GitHub Actions

- 最新 head：`9b166f8f44d1a22d34108584e92306430b599606`
- 完整 CI：[run 30426493780（attempt 3）](https://github.com/rcore-os/tgoskits/actions/runs/30426493780)
- 结果：30 个有效 job 全部通过；30 个条件分支 job skipped。
- 首轮 Starry riscv64 的 `bug-epollet-second-chunk` 时序失败、第二轮 ASUS NUC 在 guest 已输出 `test pass!` 后的 HTTP Boot 超时均未修改本 PR 代码，只重跑失败项；相同矩阵项在另一独立修复分支成功，最终 attempt 3 全绿。
