### PR TITLE
fix(ax-plat): pin IRQ context CPU lookup

### DIFF
--- a/platforms/ax-plat/src/irq.rs
+++ b/platforms/ax-plat/src/irq.rs
@@ -108,7 +108,7 @@ impl IrqOps for PlatIrqOps {
     }
 
     fn in_irq_context(&self) -> bool {
-        in_irq_context_on(self.current_cpu())
+        crate::irq::in_irq_context()
     }
 
     fn local_irq_save(&self) -> Self::LocalIrqState {
@@ -174,7 +174,17 @@ fn registry() -> &'static Registry<PlatIrqOps> {
 
 /// Returns whether the current CPU is dispatching an IRQ action.
 pub fn in_irq_context() -> bool {
-    in_irq_context_on(PlatIrqOps.current_cpu())
+    let _guard = ax_kernel_guard::NoPreempt::new();
+    // SAFETY: the guard prevents migration across both CPU identity resolution
+    // and the matching context-bit read. Releasing an inner guard between these
+    // operations could resume this thread on another CPU with a stale ID.
+    unsafe {
+        ax_percpu::with_cpu_pin(|pin| {
+            let cpu = CpuId(crate::percpu::this_cpu_id_pinned(pin));
+            in_irq_context_on(cpu)
+        })
+    }
+    .expect("the current CPU-local area must remain bound")
 }
 
 /// Requests an IRQ action through the dynamic IRQ framework.

--- a/platforms/ax-plat/tests/irq_context_pin_contract.rs
+++ b/platforms/ax-plat/tests/irq_context_pin_contract.rs
@@ -1,0 +1,51 @@
+//! IRQ-context lookup must keep the CPU identity and context-bit read in one pin window.
+
+const IRQ_SOURCE: &str = include_str!("../src/irq.rs");
+
+#[test]
+fn irq_context_lookup_keeps_cpu_identity_pinned_through_the_bit_read() {
+    let body = function_body(IRQ_SOURCE, "pub fn in_irq_context() -> bool");
+
+    assert!(
+        body.contains("NoPreempt::new()"),
+        "IRQ-context lookup must prevent migration across the complete snapshot"
+    );
+    assert!(
+        body.contains("with_cpu_pin"),
+        "IRQ-context lookup must resolve the CPU through an explicit pin"
+    );
+    assert!(
+        body.contains("this_cpu_id_pinned"),
+        "IRQ-context lookup must not release an inner guard between ID and bit reads"
+    );
+    assert!(
+        !body.contains("PlatIrqOps.current_cpu()"),
+        "a CPU ID returned after an inner preemption guard is released can be stale"
+    );
+}
+
+fn function_body<'source>(source: &'source str, signature: &str) -> &'source str {
+    let start = source
+        .find(signature)
+        .unwrap_or_else(|| panic!("missing function signature: {signature}"));
+    let body_start = source[start..]
+        .find('{')
+        .map(|offset| start + offset)
+        .expect("function must have a body");
+    let mut depth = 0usize;
+
+    for (offset, byte) in source[body_start..].bytes().enumerate() {
+        match byte {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &source[body_start..=body_start + offset];
+                }
+            }
+            _ => {}
+        }
+    }
+
+    panic!("function body is not balanced: {signature}");
+}


### PR DESCRIPTION
## 问题

IRQ 上下文查询先取得当前 CPU ID，再读取该 CPU 的 IRQ 状态；两步之间没有共享同一个 CPU pin 生命周期。若任务在中间迁移，查询可能读取另一颗 CPU 对应的状态，违反“当前执行 CPU”的语义。

## 修改

- 在同一个 `NoPreempt` / CPU pin 生命周期内取得当前 CPU ID，并读取对应的 IRQ 上下文位。
- 让 `IrqOps::in_irq_context()` 统一委托给修正后的实现，避免保留第二条未固定 CPU 的查询路径。
- 增加源码契约回归测试，约束 CPU 身份获取与状态读取必须位于同一个 pin 闭包内。

修改只修正 ax-plat 内部并发语义，不增加或改变公开 API。

## 红绿测试

- 修复前：`cargo test -p ax-plat --test irq_context_pin_contract` 确定性失败，契约检测到查询仅创建独立的 `NoPreempt`，没有把 CPU ID 与状态读取绑定到同一 pin。
- 修复后：同一契约测试通过。

## 最终验证

- `cargo fmt --check`
- `cargo test -p ax-plat --test irq_context_pin_contract`
- `cargo test -p ax-plat`
- `cargo xtask clippy --package ax-plat`
- `cargo xtask arceos test qemu --arch x86_64 --test-group rust --test-case task-irq`

QEMU 场景通过，并匹配 `ArceOS test suite run OK!`。
