### PR TITLE
fix(vdec): accept all YUV chroma formats in validate_layout

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/cvi_vdec.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/cvi_vdec.rs
@@ -403,7 +403,13 @@ fn validate_layout(
     if layout.total_len > attr.frame_buffer_size as usize {
         return Err(AxError::StorageFull);
     }
-    if layout.format != JpuPixelFormat::Yuv420 || param.pixel_format != PIXEL_FORMAT_YUV_PLANAR_420
+    if !matches!(
+        layout.format,
+        JpuPixelFormat::Yuv420
+            | JpuPixelFormat::Yuv422Horizontal
+            | JpuPixelFormat::Yuv422Vertical
+            | JpuPixelFormat::Yuv444
+    ) || param.pixel_format != PIXEL_FORMAT_YUV_PLANAR_420
     {
         return Err(AxError::OperationNotSupported);
     }


### PR DESCRIPTION
Closes #1725.

The SG2002 JPU engine supports YUV420, YUV422 (horizontal/vertical),
and YUV444 chroma sampling, and auto-detects the format from the JPEG
SOF marker.  This change relaxes the overly restrictive
`validate_layout` check to accept any known YUV format rather than
only YUV420.

Verified on SG2002 hardware: UVC MJPEG (4:2:2) → cvi_vc_dec0 VDEC
channel → JPU hardware decode → YUV420 frame readback works correctly.