### PR TITLE
feat(ivc): support multi-page shared memory channels and full-duplex ArceOS demo

### DIFF
--- a/apps/arceos/ivc_publisher/Cargo.toml
+++ b/apps/arceos/ivc_publisher/Cargo.toml
@@ -12,6 +12,9 @@ arceos = [
   "dep:ax-std",
   "ax-std/irq",
   "ax-std/paging",
+  "ax-std/alloc",
+  "ax-std/multitask",
+  "ax-std/sched-rr",
 ]
 
 [dependencies]

--- a/apps/arceos/ivc_publisher/src/main.rs
+++ b/apps/arceos/ivc_publisher/src/main.rs
@@ -32,7 +32,7 @@ mod publisher {
 
     mod demo_config {
         pub const CHANNEL_KEY: usize = 0x4956_4301;
-        pub const CHANNEL_SIZE: usize = 4096;
+        pub const CHANNEL_SIZE: usize = 0x1_0000;
         pub const NOTIFY_IRQ: Option<usize> = Some(60);
         pub const PUBLISHER_VM_ID: usize = 1;
         pub const SUBSCRIBER_VM_ID: usize = 2;
@@ -62,7 +62,7 @@ mod publisher {
         }
 
         println!("ivc publish ok base={shm_base_gpa:#x} size={shm_size}");
-        let Some(region) = shared_page_mut(shm_base_gpa) else {
+        let Some(region) = shared_page_mut(shm_base_gpa, shm_size) else {
             println!("ivc publish failed: map shared page base={shm_base_gpa:#x}");
             return;
         };
@@ -194,12 +194,8 @@ mod publisher {
         }
     }
 
-    fn shared_page_mut(shm_base_gpa: usize) -> Option<&'static mut IvcRegion> {
-        let vaddr = ax_mm::iomap(
-            PhysAddr::from_usize(shm_base_gpa),
-            demo_config::CHANNEL_SIZE,
-        )
-        .ok()?;
+    fn shared_page_mut(shm_base_gpa: usize, shm_size: usize) -> Option<&'static mut IvcRegion> {
+        let vaddr = ax_mm::iomap(PhysAddr::from_usize(shm_base_gpa), shm_size).ok()?;
         unsafe {
             // Axvisor maps the returned GPA to one exclusive publisher view of
             // the shared region before subscribers can use the phase-2 rings.

--- a/apps/arceos/ivc_publisher/src/main.rs
+++ b/apps/arceos/ivc_publisher/src/main.rs
@@ -22,10 +22,12 @@ mod publisher {
             irq,
             mem::{PhysAddr, VirtAddr, virt_to_phys},
         },
-        println,
+        println, thread,
     };
     use axhvc::ivc::{self, IvcGuestPhysAddr};
-    use axivc::{IVC_SLOT_PAYLOAD_SIZE, IvcPeerEventWaiter, IvcRegion, record_peer_event};
+    use axivc::{
+        IVC_SLOT_PAYLOAD_SIZE, IvcMessageKind, IvcPeerEventWaiter, IvcRegion, record_peer_event,
+    };
 
     const PUBLISH_COUNT: u64 = 5;
     static NOTIFY_IRQ_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -67,10 +69,28 @@ mod publisher {
             return;
         };
         region.initialize(demo_config::PUBLISHER_VM_ID, demo_config::CHANNEL_KEY);
-        let waiter = IvcPeerEventWaiter::new(register_notify_irq(), &NOTIFY_IRQ_COUNT);
-        run_request_ack_demo(region, &waiter);
+        let region: &'static IvcRegion = region;
+        let irq_enabled = register_notify_irq();
+
+        // Each task owns its waiter: `IvcPeerEventWaiter` tracks the observed
+        // event count internally, so sharing one waiter would let one task
+        // consume IRQ observations meant to wake the other.
+        let sender = thread::spawn(move || {
+            let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
+            sender_task(region, &waiter);
+        });
+        let receiver = thread::spawn(move || {
+            let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
+            receiver_task(region, &waiter);
+        });
+
+        sender.join().expect("sender thread panicked");
+        receiver.join().expect("receiver thread panicked");
+
+        println!("ivc full-duplex demo complete");
     }
 
+    #[allow(dead_code)]
     fn run_request_ack_demo(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
         let mut ack_payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
         let mut subscriber_ready = false;
@@ -81,6 +101,7 @@ mod publisher {
         }
     }
 
+    #[allow(dead_code)]
     fn send_request_when_ready(
         region: &'static IvcRegion,
         sequence: u64,
@@ -101,6 +122,7 @@ mod publisher {
         }
     }
 
+    #[allow(dead_code)]
     fn wait_for_ack(
         region: &'static IvcRegion,
         sequence: u64,
@@ -118,6 +140,60 @@ mod publisher {
                 Ok(Some(_)) | Ok(None) => waiter.wait_for_peer_event(),
                 Err(err) => {
                     println!("ivc publish failed: recv ack error {err:?}");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Sends PUBLISH_COUNT requests without blocking on individual acks.
+    /// Skips notification on the first send because the subscriber may not
+    /// have completed `subscribe_channel` yet.
+    fn sender_task(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
+        let mut subscriber_ready = false;
+        for seq in 1..=PUBLISH_COUNT {
+            loop {
+                match region.send_request(seq, b"hello from arceos publisher") {
+                    Ok(()) => {
+                        println!("ivc send seq={seq}");
+                        if subscriber_ready {
+                            notify_subscriber();
+                        }
+                        subscriber_ready = true;
+                        break;
+                    }
+                    Err(_) => waiter.wait_for_peer_event(),
+                }
+            }
+        }
+    }
+
+    /// Receives ring-B messages until PUBLISH_COUNT acks have arrived.
+    /// Subscriber data messages (kind `Request`) share ring B with acks, so
+    /// only `Ack` messages count toward request completion.
+    fn receiver_task(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
+        let mut payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
+        let mut ack_count = 0u64;
+        loop {
+            match region.try_recv_ack(&mut payload) {
+                Ok(Some(msg)) => {
+                    let text = core::str::from_utf8(&payload[..msg.len()]).unwrap_or("<non-utf8>");
+                    match msg.kind() {
+                        IvcMessageKind::Ack => {
+                            ack_count += 1;
+                            println!("ivc ack seq={} msg={text}", msg.sequence());
+                            if ack_count >= PUBLISH_COUNT {
+                                return;
+                            }
+                        }
+                        IvcMessageKind::Request => {
+                            println!("ivc recv sub data seq={} msg={text}", msg.sequence());
+                        }
+                    }
+                }
+                Ok(None) => waiter.wait_for_peer_event(),
+                Err(err) => {
+                    println!("ivc recv ack error {err:?}");
                     return;
                 }
             }

--- a/apps/arceos/ivc_publisher/src/main.rs
+++ b/apps/arceos/ivc_publisher/src/main.rs
@@ -26,7 +26,8 @@ mod publisher {
     };
     use axhvc::ivc::{self, IvcGuestPhysAddr};
     use axivc::{
-        IVC_SLOT_PAYLOAD_SIZE, IvcMessageKind, IvcPeerEventWaiter, IvcRegion, record_peer_event,
+        IVC_SLOT_PAYLOAD_SIZE, IvcConsumer, IvcMessageKind, IvcPeerEventWaiter, IvcProducer,
+        IvcRegion, record_peer_event,
     };
 
     const PUBLISH_COUNT: u64 = 5;
@@ -70,6 +71,11 @@ mod publisher {
         };
         region.initialize(demo_config::PUBLISHER_VM_ID, demo_config::CHANNEL_KEY);
         let region: &'static IvcRegion = region;
+        // SAFETY: this app is the only publisher side of this channel and
+        // creates each endpoint exactly once; the producer moves into the
+        // sender task and the consumer into the receiver task.
+        let (publish_producer, publish_consumer) =
+            unsafe { region.publisher_endpoints() }.into_parts();
         let irq_enabled = register_notify_irq();
 
         // Each task owns its waiter: `IvcPeerEventWaiter` tracks the observed
@@ -77,11 +83,11 @@ mod publisher {
         // consume IRQ observations meant to wake the other.
         let sender = thread::spawn(move || {
             let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
-            sender_task(region, &waiter);
+            sender_task(publish_producer, &waiter);
         });
         let receiver = thread::spawn(move || {
             let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
-            receiver_task(region, &waiter);
+            receiver_task(publish_consumer, &waiter);
         });
 
         sender.join().expect("sender thread panicked");
@@ -90,70 +96,14 @@ mod publisher {
         println!("ivc full-duplex demo complete");
     }
 
-    #[allow(dead_code)]
-    fn run_request_ack_demo(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
-        let mut ack_payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
-        let mut subscriber_ready = false;
-        for sequence in 1..=PUBLISH_COUNT {
-            send_request_when_ready(region, sequence, subscriber_ready, waiter);
-            wait_for_ack(region, sequence, &mut ack_payload, waiter);
-            subscriber_ready = true;
-        }
-    }
-
-    #[allow(dead_code)]
-    fn send_request_when_ready(
-        region: &'static IvcRegion,
-        sequence: u64,
-        subscriber_ready: bool,
-        waiter: &IvcPeerEventWaiter<'_>,
-    ) {
-        loop {
-            match region.send_request(sequence, b"hello from arceos publisher") {
-                Ok(()) => {
-                    println!("ivc send seq={sequence}");
-                    if subscriber_ready {
-                        notify_subscriber();
-                    }
-                    return;
-                }
-                Err(_) => waiter.wait_for_peer_event(),
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    fn wait_for_ack(
-        region: &'static IvcRegion,
-        sequence: u64,
-        payload: &mut [u8],
-        waiter: &IvcPeerEventWaiter<'_>,
-    ) {
-        loop {
-            match region.try_recv_ack(payload) {
-                Ok(Some(message)) if message.sequence() == sequence => {
-                    let text =
-                        core::str::from_utf8(&payload[..message.len()]).unwrap_or("<non-utf8>");
-                    println!("ivc ack seq={} msg={text}", message.sequence());
-                    return;
-                }
-                Ok(Some(_)) | Ok(None) => waiter.wait_for_peer_event(),
-                Err(err) => {
-                    println!("ivc publish failed: recv ack error {err:?}");
-                    return;
-                }
-            }
-        }
-    }
-
     /// Sends PUBLISH_COUNT requests without blocking on individual acks.
     /// Skips notification on the first send because the subscriber may not
     /// have completed `subscribe_channel` yet.
-    fn sender_task(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
+    fn sender_task(mut producer: IvcProducer<'_>, waiter: &IvcPeerEventWaiter<'_>) {
         let mut subscriber_ready = false;
         for seq in 1..=PUBLISH_COUNT {
             loop {
-                match region.send_request(seq, b"hello from arceos publisher") {
+                match producer.send(IvcMessageKind::Request, seq, b"hello from arceos publisher") {
                     Ok(()) => {
                         println!("ivc send seq={seq}");
                         if subscriber_ready {
@@ -171,11 +121,11 @@ mod publisher {
     /// Receives ring-B messages until PUBLISH_COUNT acks have arrived.
     /// Subscriber data messages (kind `Request`) share ring B with acks, so
     /// only `Ack` messages count toward request completion.
-    fn receiver_task(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
+    fn receiver_task(mut consumer: IvcConsumer<'_>, waiter: &IvcPeerEventWaiter<'_>) {
         let mut payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
         let mut ack_count = 0u64;
         loop {
-            match region.try_recv_ack(&mut payload) {
+            match consumer.try_recv(&mut payload) {
                 Ok(Some(msg)) => {
                     let text = core::str::from_utf8(&payload[..msg.len()]).unwrap_or("<non-utf8>");
                     match msg.kind() {

--- a/apps/arceos/ivc_subscriber/Cargo.toml
+++ b/apps/arceos/ivc_subscriber/Cargo.toml
@@ -12,6 +12,9 @@ arceos = [
   "dep:ax-std",
   "ax-std/irq",
   "ax-std/paging",
+  "ax-std/alloc",
+  "ax-std/multitask",
+  "ax-std/sched-rr",
 ]
 
 [dependencies]

--- a/apps/arceos/ivc_subscriber/src/main.rs
+++ b/apps/arceos/ivc_subscriber/src/main.rs
@@ -30,7 +30,10 @@ mod subscriber {
         println, thread,
     };
     use axhvc::ivc::{self, IvcGuestPhysAddr};
-    use axivc::{IVC_SLOT_PAYLOAD_SIZE, IvcPeerEventWaiter, IvcRegion, record_peer_event};
+    use axivc::{
+        IVC_SLOT_PAYLOAD_SIZE, IvcConsumer, IvcMessageKind, IvcPeerEventWaiter, IvcProducer,
+        IvcRegion, record_peer_event,
+    };
 
     const MAX_SUBSCRIBE_ATTEMPTS: usize = 80;
     const PASS_SEQUENCE: u64 = 5;
@@ -84,17 +87,22 @@ mod subscriber {
         }
 
         let region: &'static IvcRegion = region;
+        // SAFETY: this app is the only subscriber side of this channel and
+        // creates each endpoint exactly once; the producer moves into the
+        // sender task and the consumer into the receiver task.
+        let (reply_producer, request_consumer) =
+            unsafe { region.subscriber_endpoints() }.into_parts();
 
         // Each task owns its waiter: `IvcPeerEventWaiter` tracks the observed
         // event count internally, so sharing one waiter would let one task
         // consume IRQ observations meant to wake the other.
         let sender = thread::spawn(move || {
             let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
-            sender_task(region, &waiter);
+            sender_task(reply_producer, &waiter);
         });
         let receiver = thread::spawn(move || {
             let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
-            receiver_task(region, &waiter);
+            receiver_task(request_consumer, &waiter);
         });
 
         sender.join().expect("sender thread panicked");
@@ -128,61 +136,23 @@ mod subscriber {
         None
     }
 
-    #[allow(dead_code)]
-    fn run_request_ack_demo(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
-        let mut payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
-        loop {
-            match region.try_recv_request(&mut payload) {
-                Ok(Some(message)) => {
-                    let text =
-                        core::str::from_utf8(&payload[..message.len()]).unwrap_or("<non-utf8>");
-                    println!("ivc recv seq={} msg={text}", message.sequence());
-                    send_ack_when_ready(region, message.sequence(), waiter);
-                    if message.sequence() >= PASS_SEQUENCE {
-                        println!("ivc demo pass");
-                        return;
-                    }
-                }
-                Ok(None) => waiter.wait_for_peer_event(),
-                Err(err) => {
-                    println!("ivc subscribe failed: recv request error {err:?}");
-                    return;
-                }
-            }
-        }
-    }
-
-    #[allow(dead_code)]
-    fn send_ack_when_ready(
-        region: &'static IvcRegion,
-        sequence: u64,
-        waiter: &IvcPeerEventWaiter<'_>,
-    ) {
-        loop {
-            match region.send_ack(sequence, b"ack from arceos subscriber") {
-                Ok(()) => {
-                    notify_publisher();
-                    return;
-                }
-                Err(_) => waiter.wait_for_peer_event(),
-            }
-        }
-    }
-
     /// Sends subscriber data messages and acks of publisher data on ring B.
     /// Skips notification on the first data send because the publisher may not
     /// be ready to receive the notify yet. Acks every publisher sequence seen
     /// in `HIGHEST_RECV_SEQ` in order, so no ack is lost when several
     /// publisher messages arrive between two sender iterations.
-    fn sender_task(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
+    fn sender_task(mut producer: IvcProducer<'_>, waiter: &IvcPeerEventWaiter<'_>) {
         let mut sent_data = 0u64;
         let mut last_acked_seq = 0u64;
         let mut publisher_ready = false;
 
         loop {
             if sent_data < SUBSCRIBE_DATA_COUNT {
-                match region.send_data_to_publisher(sent_data + 1, b"hello from arceos subscriber")
-                {
+                match producer.send(
+                    IvcMessageKind::Request,
+                    sent_data + 1,
+                    b"hello from arceos subscriber",
+                ) {
                     Ok(()) => {
                         sent_data += 1;
                         println!("ivc send data seq={sent_data}");
@@ -198,7 +168,11 @@ mod subscriber {
             let highest = HIGHEST_RECV_SEQ.load(Ordering::Acquire);
             let mut acked_any = false;
             while last_acked_seq < highest {
-                match region.send_ack(last_acked_seq + 1, b"ack from arceos subscriber") {
+                match producer.send(
+                    IvcMessageKind::Ack,
+                    last_acked_seq + 1,
+                    b"ack from arceos subscriber",
+                ) {
                     Ok(()) => {
                         last_acked_seq += 1;
                         acked_any = true;
@@ -220,10 +194,10 @@ mod subscriber {
     }
 
     /// Receives publisher data messages from ring A.
-    fn receiver_task(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
+    fn receiver_task(mut consumer: IvcConsumer<'_>, waiter: &IvcPeerEventWaiter<'_>) {
         let mut payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
         loop {
-            match region.try_recv_request(&mut payload) {
+            match consumer.try_recv(&mut payload) {
                 Ok(Some(msg)) => {
                     let text = core::str::from_utf8(&payload[..msg.len()]).unwrap_or("<non-utf8>");
                     println!("ivc recv pub data seq={} msg={text}", msg.sequence());

--- a/apps/arceos/ivc_subscriber/src/main.rs
+++ b/apps/arceos/ivc_subscriber/src/main.rs
@@ -38,7 +38,6 @@ mod subscriber {
 
     mod demo_config {
         pub const CHANNEL_KEY: usize = 0x4956_4301;
-        pub const CHANNEL_SIZE: usize = 4096;
         pub const NOTIFY_IRQ: Option<usize> = Some(60);
         pub const PUBLISHER_VM_ID: usize = 1;
         pub const SUBSCRIBER_VM_ID: usize = 2;
@@ -64,7 +63,7 @@ mod subscriber {
             return;
         }
 
-        let Some(region) = shared_region(shm_base_gpa) else {
+        let Some(region) = shared_region(shm_base_gpa, shm_size) else {
             println!("ivc subscribe failed: map shared page base={shm_base_gpa:#x}");
             return;
         };
@@ -215,12 +214,8 @@ mod subscriber {
         }
     }
 
-    fn shared_region(shm_base_gpa: usize) -> Option<&'static IvcRegion> {
-        let vaddr = ax_mm::iomap(
-            PhysAddr::from_usize(shm_base_gpa),
-            demo_config::CHANNEL_SIZE,
-        )
-        .ok()?;
+    fn shared_region(shm_base_gpa: usize, shm_size: usize) -> Option<&'static IvcRegion> {
+        let vaddr = ax_mm::iomap(PhysAddr::from_usize(shm_base_gpa), shm_size).ok()?;
         unsafe {
             // Axvisor maps the returned GPA to the publisher's shared region.
             // Phase 2 uses atomic ring ownership for subscriber writes.

--- a/apps/arceos/ivc_subscriber/src/main.rs
+++ b/apps/arceos/ivc_subscriber/src/main.rs
@@ -19,7 +19,7 @@ mod subscriber {
         cell::UnsafeCell,
         option::Option::{None, Some},
         result::Result::{Err, Ok},
-        sync::atomic::AtomicU64,
+        sync::atomic::{AtomicU64, Ordering},
     };
 
     use ax_std::{
@@ -27,14 +27,18 @@ mod subscriber {
             irq,
             mem::{PhysAddr, VirtAddr, virt_to_phys},
         },
-        println,
+        println, thread,
     };
     use axhvc::ivc::{self, IvcGuestPhysAddr};
     use axivc::{IVC_SLOT_PAYLOAD_SIZE, IvcPeerEventWaiter, IvcRegion, record_peer_event};
 
     const MAX_SUBSCRIBE_ATTEMPTS: usize = 80;
     const PASS_SEQUENCE: u64 = 5;
+    const SUBSCRIBE_DATA_COUNT: u64 = 3;
     static NOTIFY_IRQ_COUNT: AtomicU64 = AtomicU64::new(0);
+    /// Highest publisher sequence received so far. Publisher sequences are
+    /// contiguous, so one monotonic counter covers every pending ack.
+    static HIGHEST_RECV_SEQ: AtomicU64 = AtomicU64::new(0);
 
     mod demo_config {
         pub const CHANNEL_KEY: usize = 0x4956_4301;
@@ -44,7 +48,8 @@ mod subscriber {
     }
 
     pub fn run() {
-        let waiter = IvcPeerEventWaiter::new(register_notify_irq(), &NOTIFY_IRQ_COUNT);
+        let irq_enabled = register_notify_irq();
+        let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
         let Some((shm_base_gpa, shm_size)) = subscribe_with_retry(&waiter) else {
             println!("ivc subscribe failed: retry limit reached");
             return;
@@ -77,7 +82,25 @@ mod subscriber {
             println!("ivc subscribe failed: unsupported phase-2 protocol header");
             return;
         }
-        run_request_ack_demo(region, &waiter);
+
+        let region: &'static IvcRegion = region;
+
+        // Each task owns its waiter: `IvcPeerEventWaiter` tracks the observed
+        // event count internally, so sharing one waiter would let one task
+        // consume IRQ observations meant to wake the other.
+        let sender = thread::spawn(move || {
+            let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
+            sender_task(region, &waiter);
+        });
+        let receiver = thread::spawn(move || {
+            let waiter = IvcPeerEventWaiter::new(irq_enabled, &NOTIFY_IRQ_COUNT);
+            receiver_task(region, &waiter);
+        });
+
+        sender.join().expect("sender thread panicked");
+        receiver.join().expect("receiver thread panicked");
+
+        println!("ivc subscriber full-duplex demo complete");
     }
 
     fn subscribe_with_retry(waiter: &IvcPeerEventWaiter<'_>) -> Option<(usize, usize)> {
@@ -105,6 +128,7 @@ mod subscriber {
         None
     }
 
+    #[allow(dead_code)]
     fn run_request_ack_demo(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
         let mut payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
         loop {
@@ -128,6 +152,7 @@ mod subscriber {
         }
     }
 
+    #[allow(dead_code)]
     fn send_ack_when_ready(
         region: &'static IvcRegion,
         sequence: u64,
@@ -140,6 +165,78 @@ mod subscriber {
                     return;
                 }
                 Err(_) => waiter.wait_for_peer_event(),
+            }
+        }
+    }
+
+    /// Sends subscriber data messages and acks of publisher data on ring B.
+    /// Skips notification on the first data send because the publisher may not
+    /// be ready to receive the notify yet. Acks every publisher sequence seen
+    /// in `HIGHEST_RECV_SEQ` in order, so no ack is lost when several
+    /// publisher messages arrive between two sender iterations.
+    fn sender_task(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
+        let mut sent_data = 0u64;
+        let mut last_acked_seq = 0u64;
+        let mut publisher_ready = false;
+
+        loop {
+            if sent_data < SUBSCRIBE_DATA_COUNT {
+                match region.send_data_to_publisher(sent_data + 1, b"hello from arceos subscriber")
+                {
+                    Ok(()) => {
+                        sent_data += 1;
+                        println!("ivc send data seq={sent_data}");
+                        if publisher_ready {
+                            notify_publisher();
+                        }
+                        publisher_ready = true;
+                    }
+                    Err(_) => { /* ring full, will retry */ }
+                }
+            }
+
+            let highest = HIGHEST_RECV_SEQ.load(Ordering::Acquire);
+            let mut acked_any = false;
+            while last_acked_seq < highest {
+                match region.send_ack(last_acked_seq + 1, b"ack from arceos subscriber") {
+                    Ok(()) => {
+                        last_acked_seq += 1;
+                        acked_any = true;
+                        println!("ivc ack pub seq={last_acked_seq}");
+                    }
+                    Err(_) => break, // ring full, will retry
+                }
+            }
+            if acked_any {
+                notify_publisher();
+            }
+
+            if sent_data >= SUBSCRIBE_DATA_COUNT && last_acked_seq >= PASS_SEQUENCE {
+                return;
+            }
+
+            waiter.wait_for_peer_event();
+        }
+    }
+
+    /// Receives publisher data messages from ring A.
+    fn receiver_task(region: &'static IvcRegion, waiter: &IvcPeerEventWaiter<'_>) {
+        let mut payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
+        loop {
+            match region.try_recv_request(&mut payload) {
+                Ok(Some(msg)) => {
+                    let text = core::str::from_utf8(&payload[..msg.len()]).unwrap_or("<non-utf8>");
+                    println!("ivc recv pub data seq={} msg={text}", msg.sequence());
+                    HIGHEST_RECV_SEQ.store(msg.sequence(), Ordering::Release);
+                    if msg.sequence() >= PASS_SEQUENCE {
+                        return;
+                    }
+                }
+                Ok(None) => waiter.wait_for_peer_event(),
+                Err(err) => {
+                    println!("ivc recv error {err:?}");
+                    return;
+                }
             }
         }
     }

--- a/scripts/axbuild/src/support/qemu_success.rs
+++ b/scripts/axbuild/src/support/qemu_success.rs
@@ -198,6 +198,46 @@ mod tests {
     }
 
     #[test]
+    fn checked_in_ivc_success_markers_accept_ansi_sgr_prefixes() {
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let cases: &[(&str, &[&str])] = &[
+            (
+                "test-suit/axvisor/normal/qemu/ivc/qemu-aarch64-ivc.toml",
+                &[
+                    "linux ivc demo pass",
+                    "ivc ack seq=5 msg=ack from linux subscriber",
+                ],
+            ),
+            (
+                "test-suit/axvisor/normal/qemu/ivc/qemu-aarch64-arceos2arceos.toml",
+                &[
+                    "ivc ack seq=5 msg=ack from arceos subscriber",
+                    "ivc full-duplex demo complete",
+                    "ivc subscriber full-duplex demo complete",
+                ],
+            ),
+        ];
+
+        for (relative_path, markers) in cases {
+            let path = workspace_root.join(relative_path);
+            let config: ostool::run::qemu::QemuConfig =
+                toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+            assert_eq!(config.success_regex.len(), markers.len());
+
+            for (pattern, marker) in config.success_regex.iter().zip(*markers) {
+                let transcript = format!("\x1b[m{marker}\n");
+                let output = captured_output(&[pattern], &[transcript.as_bytes()]);
+                verify_qemu_success_contract(Ok(()), Some(&output)).unwrap_or_else(|err| {
+                    panic!(
+                        "{} success regex did not accept ANSI-prefixed marker `{marker}`: {err}",
+                        path.display()
+                    )
+                });
+            }
+        }
+    }
+
+    #[test]
     fn empty_success_contract_preserves_normal_exit() {
         verify_qemu_success_contract(Ok(()), None).unwrap();
     }

--- a/test-suit/axvisor/normal/qemu/build-aarch64-unknown-none-softfloat-arceos2arceos.toml
+++ b/test-suit/axvisor/normal/qemu/build-aarch64-unknown-none-softfloat-arceos2arceos.toml
@@ -1,0 +1,10 @@
+features = [
+    "ax-driver/virtio-blk",
+    "fs",
+]
+log = "Info"
+target = "aarch64-unknown-none-softfloat"
+vm_configs = [
+    "test-suit/axvisor/normal/qemu/ivc/configs/arceos-ivc-publisher.toml",
+    "test-suit/axvisor/normal/qemu/ivc/configs/arceos-ivc-subscriber.toml",
+]

--- a/test-suit/axvisor/normal/qemu/ivc/configs/arceos-ivc-subscriber.toml
+++ b/test-suit/axvisor/normal/qemu/ivc/configs/arceos-ivc-subscriber.toml
@@ -1,0 +1,63 @@
+# Vm base info configs
+#
+[base]
+# Guest vm id.
+id = 2
+# Guest vm name.
+name = "arceos-ivc-subscriber"
+# Virtualization type.
+vm_type = 1
+# The number of virtual CPUs.
+cpu_num = 1
+# Guest vm physical cpu ids.
+phys_cpu_ids = [1]
+
+#
+# Vm kernel configs
+#
+[kernel]
+# The entry point of the kernel image.
+entry_point = 0x8020_0000
+# The location of image: "memory" | "fs".
+image_location = "fs"
+# The file path of the kernel image.
+kernel_path = "/guest/arceos/arceos-ivc-subscriber.bin"
+# The load address of the kernel image.
+kernel_load_addr = 0x8020_0000
+# The load address of the device tree blob (DTB).
+dtb_load_addr = 0x8000_0000
+
+# Memory regions with format (`base_paddr`, `size`, `flags`, `map_type`).
+# For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
+memory_regions = [
+  [0x8000_0000, 0x4000_0000, 0x7, 1], # System RAM 1G MAP_IDENTICAL
+]
+
+#
+# Device specifications
+#
+[devices]
+# The interrupt mode.
+interrupt_mode = "passthrough"
+
+# Pass-through devices.
+passthrough_devices = [
+  ["/",],
+]
+
+# Passthrough addresses.
+# Base-GPA  Length.
+passthrough_addresses = []
+
+# Devices that are not desired to be passed through to the guest.
+excluded_devices = [
+  ["/pcie@10000000"],
+]
+
+# Emu_devices.
+# Name Base-Ipa Ipa_len Alloc-Irq Emu-Type EmuConfig.
+# For ivc-channel, EmuConfig[0] is an optional VM-local notify IRQ line.
+# Keep it away from QEMU virt platform device SPIs such as the PL011 UART.
+emu_devices = [
+  ["ivc-channel", 0xbff0_0000, 0x1_0000, 0, 0xA, [60]],
+]

--- a/test-suit/axvisor/normal/qemu/ivc/qemu-aarch64-arceos2arceos.toml
+++ b/test-suit/axvisor/normal/qemu/ivc/qemu-aarch64-arceos2arceos.toml
@@ -30,10 +30,11 @@ fail_regex = [
 #   subscriber data), which is only possible after the last subscriber ack;
 # - the two completion lines require both guests' sender/receiver threads to
 #   have joined, i.e. every data and ack message was exchanged.
+# Concurrent console streams may prepend ANSI SGR resets to these lines.
 success_regex = [
-    "(?m)^ivc ack seq=5 msg=ack from arceos subscriber\\s*$",
-    "(?m)^ivc full-duplex demo complete\\s*$",
-    "(?m)^ivc subscriber full-duplex demo complete\\s*$",
+    "(?m)^(?:\\x1b\\[[0-9;]*m)*ivc ack seq=5 msg=ack from arceos subscriber\\s*$",
+    "(?m)^(?:\\x1b\\[[0-9;]*m)*ivc full-duplex demo complete\\s*$",
+    "(?m)^(?:\\x1b\\[[0-9;]*m)*ivc subscriber full-duplex demo complete\\s*$",
 ]
 to_bin = true
 uefi = false

--- a/test-suit/axvisor/normal/qemu/ivc/qemu-aarch64-arceos2arceos.toml
+++ b/test-suit/axvisor/normal/qemu/ivc/qemu-aarch64-arceos2arceos.toml
@@ -1,0 +1,39 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a72",
+    "-machine",
+    "virt,virtualization=on,gic-version=3",
+    "-smp",
+    "4",
+    "-device",
+    "virtio-blk-device,drive=disk0",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-append",
+    "root=/dev/vda rw init=/bin/sh",
+    "-m",
+    "8g",
+]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)kernel panic",
+    "(?i)unhandled page fault",
+    "(?i)page fault",
+    "ivc publish failed",
+    "ivc subscribe failed",
+]
+# success_regex is matched any-of and latches on the first hit, followed by a
+# ~500ms drain (ostool ByteStreamMatcher). Keep only end-of-demo lines here so
+# an early match cannot cut the run before the protocol completes:
+# - "ivc ack seq=5" proves all five acks reached the publisher (not miscounted
+#   subscriber data), which is only possible after the last subscriber ack;
+# - the two completion lines require both guests' sender/receiver threads to
+#   have joined, i.e. every data and ack message was exchanged.
+success_regex = [
+    "(?m)^ivc ack seq=5 msg=ack from arceos subscriber\\s*$",
+    "(?m)^ivc full-duplex demo complete\\s*$",
+    "(?m)^ivc subscriber full-duplex demo complete\\s*$",
+]
+to_bin = true
+uefi = false

--- a/test-suit/axvisor/normal/qemu/ivc/qemu-aarch64-ivc.toml
+++ b/test-suit/axvisor/normal/qemu/ivc/qemu-aarch64-ivc.toml
@@ -23,9 +23,10 @@ fail_regex = [
     "ivc publish failed",
     "(?m)^linux ivc demo failed\\s*$",
 ]
+# Concurrent console streams may prepend ANSI SGR resets to a completion line.
 success_regex = [
-    "(?m)^linux ivc demo pass\\s*$",
-    "(?m)^ivc ack seq=5 msg=ack from linux subscriber\\s*$",
+    "(?m)^(?:\\x1b\\[[0-9;]*m)*linux ivc demo pass\\s*$",
+    "(?m)^(?:\\x1b\\[[0-9;]*m)*ivc ack seq=5 msg=ack from linux subscriber\\s*$",
 ]
 shell_prefix = "~ #"
 shell_init_cmd = '''

--- a/virtualization/axivc/README.md
+++ b/virtualization/axivc/README.md
@@ -70,8 +70,9 @@ A publisher typically:
 1. Calls `axhvc::ivc::publish_channel`.
 2. Maps the returned shared-memory GPA.
 3. Initializes the mapped memory with `IvcRegion::initialize`.
-4. Sends requests with `IvcRegion::send_request`.
-5. Optionally receives acknowledgements with `IvcRegion::try_recv_ack`.
+4. Attaches `IvcRegion::publisher_endpoints` exactly once and splits the result
+   with `IvcEndpoints::into_parts`.
+5. Sends through the producer and receives through the consumer.
 6. Optionally notifies the peer through `axhvc`.
 
 A subscriber typically:
@@ -79,8 +80,9 @@ A subscriber typically:
 1. Calls `axhvc::ivc::subscribe_channel`.
 2. Maps the returned shared-memory GPA.
 3. Validates `channel_header_matches` and `protocol_header_matches`.
-4. Receives requests with `IvcRegion::try_recv_request`.
-5. Optionally replies with `IvcRegion::send_ack`.
+4. Attaches `IvcRegion::subscriber_endpoints` exactly once and splits the
+   result with `IvcEndpoints::into_parts`.
+5. Receives through the consumer and replies through the producer.
 6. Optionally notifies the peer through `axhvc`.
 
 For blocking-style receive paths, guest IRQ code can call `record_peer_event`
@@ -93,7 +95,10 @@ polling when an interrupt is missed or not yet wired.
 - The region layout fits in one 4 KiB page; AxVisor IVC channels may be larger
   (up to the hypervisor's `MAX_IVC_CHANNEL_SIZE`), and the extra space is
   currently unused by this protocol.
-- Rings are single-producer/single-consumer.
+- Each HVC channel currently admits one publisher and one subscriber because
+  both rings are single-producer/single-consumer. Multi-peer support is tracked
+  in [tgoskits#1238](https://github.com/rcore-os/tgoskits/issues/1238) and will
+  require a versioned per-peer memory layout.
 - Payload slots are fixed size.
 - OS IRQ registration and hypervisor notification hypercalls are outside this
   crate.

--- a/virtualization/axivc/README.md
+++ b/virtualization/axivc/README.md
@@ -90,7 +90,9 @@ polling when an interrupt is missed or not yet wired.
 
 # Current Limits
 
-- The region is designed to fit in the current 4 KiB AxVisor IVC channel.
+- The region layout fits in one 4 KiB page; AxVisor IVC channels may be larger
+  (up to the hypervisor's `MAX_IVC_CHANNEL_SIZE`), and the extra space is
+  currently unused by this protocol.
 - Rings are single-producer/single-consumer.
 - Payload slots are fixed size.
 - OS IRQ registration and hypervisor notification hypercalls are outside this

--- a/virtualization/axivc/README_CN.md
+++ b/virtualization/axivc/README_CN.md
@@ -71,7 +71,8 @@ subscriber 通常执行：
 
 # 当前限制
 
-- 区域布局面向当前 4 KiB AxVisor IVC channel。
+- 区域布局可放在一个 4 KiB 页内；AxVisor IVC channel 可以更大（上限为 hypervisor 的
+  `MAX_IVC_CHANNEL_SIZE`），超出部分当前协议暂未使用。
 - ring 是单生产者、单消费者。
 - payload slot 大小固定。
 - OS IRQ 注册和 hypervisor notify hypercall 不属于本 crate。

--- a/virtualization/axivc/README_CN.md
+++ b/virtualization/axivc/README_CN.md
@@ -54,8 +54,9 @@ publisher 通常执行：
 1. 调用 `axhvc::ivc::publish_channel`。
 2. 映射返回的共享内存 GPA。
 3. 使用 `IvcRegion::initialize` 初始化映射区域。
-4. 使用 `IvcRegion::send_request` 发送请求。
-5. 可选使用 `IvcRegion::try_recv_ack` 接收确认。
+4. 仅调用一次 `IvcRegion::publisher_endpoints`，并通过
+   `IvcEndpoints::into_parts` 拆分端点。
+5. 通过 producer 发送，通过 consumer 接收。
 6. 可选通过 `axhvc` 通知对端。
 
 subscriber 通常执行：
@@ -63,8 +64,9 @@ subscriber 通常执行：
 1. 调用 `axhvc::ivc::subscribe_channel`。
 2. 映射返回的共享内存 GPA。
 3. 校验 `channel_header_matches` 和 `protocol_header_matches`。
-4. 使用 `IvcRegion::try_recv_request` 接收请求。
-5. 可选使用 `IvcRegion::send_ack` 回复确认。
+4. 仅调用一次 `IvcRegion::subscriber_endpoints`，并通过
+   `IvcEndpoints::into_parts` 拆分端点。
+5. 通过 consumer 接收，通过 producer 回复。
 6. 可选通过 `axhvc` 通知对端。
 
 对于需要等待消息的路径，客户机 IRQ 代码可以在 AxVisor 注入 notify IRQ 时调用 `record_peer_event`。接收路径再使用 `IvcPeerEventWaiter` 和 `fallback_poll`，组合 IRQ 唤醒和有界轮询，以覆盖中断丢失或 IRQ 尚未接好时的场景。
@@ -73,7 +75,10 @@ subscriber 通常执行：
 
 - 区域布局可放在一个 4 KiB 页内；AxVisor IVC channel 可以更大（上限为 hypervisor 的
   `MAX_IVC_CHANNEL_SIZE`），超出部分当前协议暂未使用。
-- ring 是单生产者、单消费者。
+- 当前每个 HVC channel 只允许一个 publisher 和一个 subscriber，因为两个
+  ring 都是单生产者、单消费者。多 peer 支持由
+  [tgoskits#1238](https://github.com/rcore-os/tgoskits/issues/1238) 跟踪，后续需要
+  引入版本化的 per-peer 内存布局。
 - payload slot 大小固定。
 - OS IRQ 注册和 hypervisor notify hypercall 不属于本 crate。
 - 访问控制、配额和 channel 生命周期仍由 AxVisor 或客户机策略负责。

--- a/virtualization/axivc/src/endpoint.rs
+++ b/virtualization/axivc/src/endpoint.rs
@@ -1,0 +1,113 @@
+//! Channel endpoints encoding the single-producer, single-consumer contract.
+//!
+//! Every ring in an [`IvcRegion`] is SPSC: one producer and one consumer may
+//! drive it at a time. Endpoint operations require `&mut self`, and endpoint
+//! types are not `Clone`, so safe code cannot drive one ring concurrently.
+//! Role attachment remains an `unsafe` boundary because the caller must ensure
+//! that each shared region is attached once for each channel role.
+//!
+//! [`IvcRegion`]: crate::IvcRegion
+
+use crate::{
+    message::{IvcMessage, IvcMessageKind},
+    ring::{IvcRing, IvcRingError},
+};
+
+/// The producer and consumer owned by one side of an IVC channel.
+///
+/// Consume this value with [`Self::into_parts`] before moving the two endpoints
+/// into independent sender and receiver tasks.
+pub struct IvcEndpoints<'a> {
+    producer: IvcProducer<'a>,
+    consumer: IvcConsumer<'a>,
+}
+
+impl<'a> IvcEndpoints<'a> {
+    pub(crate) const fn new(producer: &'a IvcRing, consumer: &'a IvcRing) -> Self {
+        Self {
+            producer: IvcProducer::new(producer),
+            consumer: IvcConsumer::new(consumer),
+        }
+    }
+
+    /// Separates the sending and receiving endpoints for independent tasks.
+    pub fn into_parts(self) -> (IvcProducer<'a>, IvcConsumer<'a>) {
+        (self.producer, self.consumer)
+    }
+}
+
+/// Sending end of one SPSC ring.
+///
+/// Sending requires exclusive access and the endpoint is not cloneable. Safe
+/// code therefore cannot share one producer between concurrent sender tasks.
+///
+/// ```compile_fail
+/// use axivc::{IvcMessageKind, IvcProducer};
+///
+/// fn send_through_shared_reference(producer: &IvcProducer<'_>) {
+///     let _ = producer.send(IvcMessageKind::Request, 1, b"message");
+/// }
+/// ```
+///
+/// ```compile_fail
+/// use axivc::IvcProducer;
+///
+/// fn duplicate_producer(producer: IvcProducer<'_>) {
+///     let _second = producer.clone();
+/// }
+/// ```
+pub struct IvcProducer<'a> {
+    ring: &'a IvcRing,
+}
+
+impl<'a> IvcProducer<'a> {
+    const fn new(ring: &'a IvcRing) -> Self {
+        Self { ring }
+    }
+
+    /// Appends one message to the ring.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IvcRingError::Full`] when the ring has no free slot.
+    pub fn send(
+        &mut self,
+        kind: IvcMessageKind,
+        sequence: u64,
+        payload: &[u8],
+    ) -> Result<(), IvcRingError> {
+        self.ring.send(kind, sequence, payload)
+    }
+}
+
+/// Receiving end of one SPSC ring.
+///
+/// Receiving requires exclusive access and the endpoint is not cloneable.
+///
+/// ```compile_fail
+/// use axivc::IvcConsumer;
+///
+/// fn receive_through_shared_reference(consumer: &IvcConsumer<'_>) {
+///     let mut payload = [0u8; 48];
+///     let _ = consumer.try_recv(&mut payload);
+/// }
+/// ```
+pub struct IvcConsumer<'a> {
+    ring: &'a IvcRing,
+}
+
+impl<'a> IvcConsumer<'a> {
+    const fn new(ring: &'a IvcRing) -> Self {
+        Self { ring }
+    }
+
+    /// Copies out the oldest pending message, if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IvcRingError::UnknownMessageKind`] when the stored message
+    /// kind is not known by this protocol version.
+    pub fn try_recv(&mut self, payload: &mut [u8]) -> Result<Option<IvcMessage>, IvcRingError> {
+        self.ring.try_recv(payload)
+    }
+}

--- a/virtualization/axivc/src/lib.rs
+++ b/virtualization/axivc/src/lib.rs
@@ -2,11 +2,16 @@
 
 //! Shared-memory protocol helpers for AxVisor inter-VM communication.
 
+#[cfg(test)]
+extern crate std;
+
+mod endpoint;
 mod event;
 mod message;
 mod region;
 mod ring;
 
+pub use endpoint::{IvcConsumer, IvcEndpoints, IvcProducer};
 pub use event::{IvcPeerEventWaiter, fallback_poll, record_peer_event};
 pub use message::{IvcMessage, IvcMessageKind};
 pub use region::IvcRegion;

--- a/virtualization/axivc/src/region.rs
+++ b/virtualization/axivc/src/region.rs
@@ -13,9 +13,10 @@ const SUBSCRIBER_TO_PUBLISHER_RING_OFFSET: u32 =
     core::mem::offset_of!(IvcRegion, subscriber_to_publisher) as u32;
 const IVC_REGION_FEATURE_SPSC_FIXED_SLOTS: u32 = 1;
 
-/// Full fixed-slot IVC region.
+/// Full fixed-slot IVC region for one publisher/subscriber pair.
 ///
-/// The first two fields intentionally match `axvm::runtime::ivc::IVCChannelHeader`.
+/// Axvisor enforces at most one subscriber for the current SPSC protocol. The
+/// first two fields intentionally match `axvm::runtime::ivc::IVCChannelHeader`.
 /// Axvisor initializes them when the host-side channel is created. The remaining
 /// fields are owned by this shared-memory protocol.
 #[repr(C, align(64))]
@@ -27,12 +28,12 @@ pub struct IvcRegion {
     subscriber_to_publisher: IvcRing,
 }
 
-// SAFETY: The two rings are independent SPSC rings. Mutable ring state is
-// only reachable through `IvcProducer`/`IvcConsumer` endpoints with `&mut`
-// methods, and the `unsafe` endpoint constructors require callers to keep one
-// endpoint per ring role. The header fields are initialized once before
-// sharing or are atomic, so concurrent &IvcRegion access across threads is
-// sound.
+// SAFETY: The two rings are independent SPSC rings. Axvisor admits only one
+// subscriber per channel, mutable ring state is reachable only through
+// `IvcProducer`/`IvcConsumer` endpoints with `&mut` methods, and the `unsafe`
+// endpoint constructors require callers to keep one endpoint per ring role.
+// The header fields are initialized once before sharing or are atomic, so
+// concurrent &IvcRegion access across threads is sound.
 unsafe impl Sync for IvcRegion {}
 
 impl IvcRegion {

--- a/virtualization/axivc/src/region.rs
+++ b/virtualization/axivc/src/region.rs
@@ -27,6 +27,12 @@ pub struct IvcRegion {
     subscriber_to_publisher: IvcRing,
 }
 
+// SAFETY: The two rings (publisher_to_subscriber and subscriber_to_publisher)
+// are independent SPSC rings. Each ring has exactly one writer and one
+// reader thread. The header fields are either initialized once before
+// sharing or atomic. Concurrent &IvcRegion access across threads is safe.
+unsafe impl Sync for IvcRegion {}
+
 impl IvcRegion {
     /// Initializes the protocol region and preserves the Axvisor IVC header.
     pub fn initialize(&mut self, publisher_id: usize, key: usize) {
@@ -61,6 +67,16 @@ impl IvcRegion {
     /// Receives one publisher-to-subscriber message.
     pub fn try_recv_request(&self, payload: &mut [u8]) -> Result<Option<IvcMessage>, IvcRingError> {
         self.publisher_to_subscriber.try_recv(payload)
+    }
+
+    /// Sends one subscriber-to-publisher data message.
+    pub fn send_data_to_publisher(
+        &self,
+        sequence: u64,
+        payload: &[u8],
+    ) -> Result<(), IvcRingError> {
+        self.subscriber_to_publisher
+            .send(IvcMessageKind::Request, sequence, payload)
     }
 
     /// Sends one subscriber-to-publisher acknowledgement.

--- a/virtualization/axivc/src/region.rs
+++ b/virtualization/axivc/src/region.rs
@@ -2,8 +2,8 @@ use core::sync::atomic::{AtomicU32, Ordering};
 
 use crate::{
     IVC_REGION_MAGIC, IVC_REGION_VERSION,
-    message::{IvcMessage, IvcMessageKind},
-    ring::{IvcRing, IvcRingDirection, IvcRingError},
+    endpoint::IvcEndpoints,
+    ring::{IvcRing, IvcRingDirection},
 };
 
 const RING_HEADER_SIZE: u32 = core::mem::size_of::<IvcRing>() as u32;
@@ -27,10 +27,12 @@ pub struct IvcRegion {
     subscriber_to_publisher: IvcRing,
 }
 
-// SAFETY: The two rings (publisher_to_subscriber and subscriber_to_publisher)
-// are independent SPSC rings. Each ring has exactly one writer and one
-// reader thread. The header fields are either initialized once before
-// sharing or atomic. Concurrent &IvcRegion access across threads is safe.
+// SAFETY: The two rings are independent SPSC rings. Mutable ring state is
+// only reachable through `IvcProducer`/`IvcConsumer` endpoints with `&mut`
+// methods, and the `unsafe` endpoint constructors require callers to keep one
+// endpoint per ring role. The header fields are initialized once before
+// sharing or are atomic, so concurrent &IvcRegion access across threads is
+// sound.
 unsafe impl Sync for IvcRegion {}
 
 impl IvcRegion {
@@ -38,11 +40,13 @@ impl IvcRegion {
     pub fn initialize(&mut self, publisher_id: usize, key: usize) {
         self.publisher_id = publisher_id as u64;
         self.key = key as u64;
-        self.header.initialize();
         self.publisher_to_subscriber
             .initialize(IvcRingDirection::PublisherToSubscriber);
         self.subscriber_to_publisher
             .initialize(IvcRingDirection::SubscriberToPublisher);
+        // Publish the protocol header only after both rings are ready. A peer
+        // that observes `magic` with Acquire may immediately use the rings.
+        self.header.initialize();
     }
 
     /// Returns whether the host-provided IVC channel header matches.
@@ -58,36 +62,34 @@ impl IvcRegion {
                 >= core::mem::size_of::<Self>()
     }
 
-    /// Sends one publisher-to-subscriber message.
-    pub fn send_request(&self, sequence: u64, payload: &[u8]) -> Result<(), IvcRingError> {
-        self.publisher_to_subscriber
-            .send(IvcMessageKind::Request, sequence, payload)
+    /// Attaches the publisher side and returns its channel endpoints.
+    ///
+    /// The producer sends on the publisher-to-subscriber ring. The consumer
+    /// receives from the subscriber-to-publisher ring.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that the publisher role is attached only
+    /// once across every address space sharing this region. Attaching it again
+    /// would create duplicate producer and consumer endpoints, allowing data
+    /// races on slot payloads.
+    pub unsafe fn publisher_endpoints(&self) -> IvcEndpoints<'_> {
+        IvcEndpoints::new(&self.publisher_to_subscriber, &self.subscriber_to_publisher)
     }
 
-    /// Receives one publisher-to-subscriber message.
-    pub fn try_recv_request(&self, payload: &mut [u8]) -> Result<Option<IvcMessage>, IvcRingError> {
-        self.publisher_to_subscriber.try_recv(payload)
-    }
-
-    /// Sends one subscriber-to-publisher data message.
-    pub fn send_data_to_publisher(
-        &self,
-        sequence: u64,
-        payload: &[u8],
-    ) -> Result<(), IvcRingError> {
-        self.subscriber_to_publisher
-            .send(IvcMessageKind::Request, sequence, payload)
-    }
-
-    /// Sends one subscriber-to-publisher acknowledgement.
-    pub fn send_ack(&self, sequence: u64, payload: &[u8]) -> Result<(), IvcRingError> {
-        self.subscriber_to_publisher
-            .send(IvcMessageKind::Ack, sequence, payload)
-    }
-
-    /// Receives one subscriber-to-publisher acknowledgement.
-    pub fn try_recv_ack(&self, payload: &mut [u8]) -> Result<Option<IvcMessage>, IvcRingError> {
-        self.subscriber_to_publisher.try_recv(payload)
+    /// Attaches the subscriber side and returns its channel endpoints.
+    ///
+    /// The producer sends on the subscriber-to-publisher ring. The consumer
+    /// receives from the publisher-to-subscriber ring.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that the subscriber role is attached only
+    /// once across every address space sharing this region. Attaching it again
+    /// would create duplicate producer and consumer endpoints, allowing data
+    /// races on slot payloads.
+    pub unsafe fn subscriber_endpoints(&self) -> IvcEndpoints<'_> {
+        IvcEndpoints::new(&self.subscriber_to_publisher, &self.publisher_to_subscriber)
     }
 }
 

--- a/virtualization/axivc/src/ring.rs
+++ b/virtualization/axivc/src/ring.rs
@@ -95,11 +95,12 @@ pub(crate) struct IvcMessageSlot {
     payload: UnsafeCell<[u8; IVC_SLOT_PAYLOAD_SIZE]>,
 }
 
-// SAFETY: Each SPSC ring has exactly one writer and one reader.
-// The UnsafeCell payload in each slot is only accessed by the
-// owning producer (before tail release) or the owning consumer
-// (after tail acquire). Cross-thread &IvcRing sharing is safe
-// as long as the SPSC invariant holds.
+// SAFETY: Each SPSC ring has exactly one producer and one consumer, encoded
+// by the `IvcProducer`/`IvcConsumer` endpoint types whose `unsafe`
+// constructors carry the uniqueness contract. The UnsafeCell payload in each
+// slot is only accessed by the owning producer (before tail release) or the
+// owning consumer (after tail acquire), so cross-thread &IvcRing sharing is
+// sound as long as the endpoint contract holds.
 unsafe impl Sync for IvcRing {}
 
 impl IvcMessageSlot {

--- a/virtualization/axivc/src/ring.rs
+++ b/virtualization/axivc/src/ring.rs
@@ -95,6 +95,13 @@ pub(crate) struct IvcMessageSlot {
     payload: UnsafeCell<[u8; IVC_SLOT_PAYLOAD_SIZE]>,
 }
 
+// SAFETY: Each SPSC ring has exactly one writer and one reader.
+// The UnsafeCell payload in each slot is only accessed by the
+// owning producer (before tail release) or the owning consumer
+// (after tail acquire). Cross-thread &IvcRing sharing is safe
+// as long as the SPSC invariant holds.
+unsafe impl Sync for IvcRing {}
+
 impl IvcMessageSlot {
     fn clear(&self) {
         self.sequence.store(0, Ordering::Relaxed);

--- a/virtualization/axivc/src/tests.rs
+++ b/virtualization/axivc/src/tests.rs
@@ -23,37 +23,49 @@ fn region_header_and_channel_header_match_after_initialize() {
 fn request_ring_delivers_messages_in_fifo_order() {
     let mut region = new_region();
     region.initialize(PUBLISHER_VM_ID, CHANNEL_KEY);
+    // SAFETY: this test attaches each channel role exactly once.
+    let (mut producer, _reply_consumer) = unsafe { region.publisher_endpoints() }.into_parts();
+    // SAFETY: this test attaches each channel role exactly once.
+    let (_reply_producer, mut consumer) = unsafe { region.subscriber_endpoints() }.into_parts();
 
-    region.send_request(1, b"one").unwrap();
-    region.send_request(2, b"two").unwrap();
+    producer.send(IvcMessageKind::Request, 1, b"one").unwrap();
+    producer.send(IvcMessageKind::Request, 2, b"two").unwrap();
 
     let mut payload = [0; IVC_SLOT_PAYLOAD_SIZE];
-    let first = region.try_recv_request(&mut payload).unwrap().unwrap();
+    let first = consumer.try_recv(&mut payload).unwrap().unwrap();
     assert_eq!(first.kind(), IvcMessageKind::Request);
     assert_eq!(first.sequence(), 1);
     assert_eq!(&payload[..first.len()], b"one");
 
-    let second = region.try_recv_request(&mut payload).unwrap().unwrap();
+    let second = consumer.try_recv(&mut payload).unwrap().unwrap();
     assert_eq!(second.sequence(), 2);
     assert_eq!(&payload[..second.len()], b"two");
-    assert_eq!(region.try_recv_request(&mut payload), Ok(None));
+    assert_eq!(consumer.try_recv(&mut payload), Ok(None));
 }
 
 #[test]
 fn ack_ring_is_independent_from_request_ring() {
     let mut region = new_region();
     region.initialize(PUBLISHER_VM_ID, CHANNEL_KEY);
+    // SAFETY: this test attaches each channel role exactly once.
+    let (mut request_producer, mut reply_consumer) =
+        unsafe { region.publisher_endpoints() }.into_parts();
+    // SAFETY: this test attaches each channel role exactly once.
+    let (mut reply_producer, mut request_consumer) =
+        unsafe { region.subscriber_endpoints() }.into_parts();
 
-    region.send_request(9, b"request").unwrap();
-    region.send_ack(9, b"ack").unwrap();
+    request_producer
+        .send(IvcMessageKind::Request, 9, b"request")
+        .unwrap();
+    reply_producer.send(IvcMessageKind::Ack, 9, b"ack").unwrap();
 
     let mut payload = [0; IVC_SLOT_PAYLOAD_SIZE];
-    let ack = region.try_recv_ack(&mut payload).unwrap().unwrap();
+    let ack = reply_consumer.try_recv(&mut payload).unwrap().unwrap();
     assert_eq!(ack.kind(), IvcMessageKind::Ack);
     assert_eq!(ack.sequence(), 9);
     assert_eq!(&payload[..ack.len()], b"ack");
 
-    let request = region.try_recv_request(&mut payload).unwrap().unwrap();
+    let request = request_consumer.try_recv(&mut payload).unwrap().unwrap();
     assert_eq!(request.kind(), IvcMessageKind::Request);
     assert_eq!(request.sequence(), 9);
 }
@@ -62,13 +74,17 @@ fn ack_ring_is_independent_from_request_ring() {
 fn send_fails_when_ring_is_full() {
     let mut region = new_region();
     region.initialize(PUBLISHER_VM_ID, CHANNEL_KEY);
+    // SAFETY: this test attaches the publisher role exactly once.
+    let (mut producer, _consumer) = unsafe { region.publisher_endpoints() }.into_parts();
 
     for sequence in 0..IVC_RING_CAPACITY as u64 {
-        region.send_request(sequence, b"x").unwrap();
+        producer
+            .send(IvcMessageKind::Request, sequence, b"x")
+            .unwrap();
     }
 
     assert_eq!(
-        region.send_request(IVC_RING_CAPACITY as u64, b"x"),
+        producer.send(IvcMessageKind::Request, IVC_RING_CAPACITY as u64, b"x"),
         Err(IvcRingError::Full)
     );
 }
@@ -87,6 +103,62 @@ fn peer_event_waiter_observes_recorded_irq_events_once() {
     record_peer_event(&counter);
     assert!(waiter.observe_peer_event());
     assert!(!waiter.observe_peer_event());
+}
+
+/// Regression test for the blocking review finding that the previous safe
+/// `&self` API allowed two threads to produce on the same ring concurrently,
+/// losing and tearing messages. With endpoint ownership, the only concurrent
+/// pattern safe code can express is one producer plus one consumer; exercise
+/// that pattern at volume and require every message to arrive exactly once,
+/// in FIFO order, and intact.
+#[test]
+fn spsc_endpoints_deliver_all_messages_across_threads() {
+    use std::{boxed::Box, thread, vec::Vec};
+
+    const MESSAGES: u64 = 100_000;
+
+    let region = Box::leak(Box::new(new_region()));
+    region.initialize(PUBLISHER_VM_ID, CHANNEL_KEY);
+    let region: &'static IvcRegion = region;
+    // SAFETY: this test attaches each channel role exactly once.
+    let (mut producer, _reply_consumer) = unsafe { region.publisher_endpoints() }.into_parts();
+    // SAFETY: this test attaches each channel role exactly once.
+    let (_reply_producer, mut consumer) = unsafe { region.subscriber_endpoints() }.into_parts();
+
+    let producer_thread = thread::spawn(move || {
+        let payload = [0x5a; IVC_SLOT_PAYLOAD_SIZE];
+        for sequence in 0..MESSAGES {
+            while producer
+                .send(IvcMessageKind::Request, sequence, &payload)
+                .is_err()
+            {
+                thread::yield_now();
+            }
+        }
+    });
+
+    let mut received: Vec<u64> = Vec::new();
+    let mut payload = [0u8; IVC_SLOT_PAYLOAD_SIZE];
+    loop {
+        match consumer.try_recv(&mut payload) {
+            Ok(Some(message)) => {
+                assert!(payload.iter().all(|&byte| byte == 0x5a));
+                received.push(message.sequence());
+            }
+            Ok(None) if producer_thread.is_finished() => break,
+            Ok(None) => thread::yield_now(),
+            Err(err) => panic!("recv failed: {err:?}"),
+        }
+    }
+    producer_thread.join().expect("producer thread panicked");
+
+    assert_eq!(received.len(), MESSAGES as usize, "messages were lost");
+    for (expected, sequence) in received.iter().enumerate() {
+        assert_eq!(
+            *sequence, expected as u64,
+            "messages must arrive in FIFO order"
+        );
+    }
 }
 
 fn new_region() -> IvcRegion {

--- a/virtualization/axvm/src/arch/aarch64/irq.rs
+++ b/virtualization/axvm/src/arch/aarch64/irq.rs
@@ -19,13 +19,13 @@ impl IrqSink for Aarch64VmIrqSink {
     }
 
     fn pulse(&self, line: IrqLineId) -> IrqResult {
-        crate::manager::inject_interrupt(self.vm_id, self.target_vcpu_id, line.0).map_err(
-            |error| IrqError::Backend {
+        crate::manager::inject_interrupt(self.vm_id, self.target_vcpu_id, line.0).map_err(|error| {
+            IrqError::Backend {
                 line,
                 operation: "pulse AArch64 VM IRQ line",
                 detail: alloc::format!("{error}"),
-            },
-        )
+            }
+        })
     }
 }
 

--- a/virtualization/axvm/src/runtime/ivc.rs
+++ b/virtualization/axvm/src/runtime/ivc.rs
@@ -20,6 +20,7 @@ use alloc::{
 };
 
 use ax_kspin::SpinNoIrq as Mutex;
+use ax_memory_addr::{PAGE_SIZE_4K, align_up_4k};
 
 use crate::{AxVmError, AxVmResult, GuestPhysAddr, HostPhysAddr, ax_err_type, host::PagingHandler};
 
@@ -29,7 +30,11 @@ type HostIVCChannel = IVCChannel<crate::HostPagingHandler>;
 
 static IVC_CHANNELS: Mutex<BTreeMap<(usize, usize), HostIVCChannel>> = Mutex::new(BTreeMap::new());
 
-pub const MAX_IVC_CHANNEL_SIZE: usize = 4096;
+/// Maximum size of one IVC channel's shared region.
+///
+/// Requests larger than this are truncated; the hypercall ABI always writes
+/// the actual granted size back to the guest, so guests must check it.
+pub const MAX_IVC_CHANNEL_SIZE: usize = 0x10_0000;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct IvcNotifyRoute {
@@ -350,12 +355,12 @@ impl<H: PagingHandler> core::fmt::Debug for IVCChannel<H> {
 
 impl<H: PagingHandler> Drop for IVCChannel<H> {
     fn drop(&mut self) {
-        // Free the shared region frame when the channel is dropped.
+        // Free the shared region frames when the channel is dropped.
         debug!(
             "Dropping IVCChannel for VM[{}], shared region base: {:?}",
             self.publisher_vm_id, self.shared_region_base
         );
-        H::dealloc_frame(self.shared_region_base);
+        H::dealloc_frames(self.shared_region_base, self.page_count());
     }
 }
 
@@ -366,16 +371,23 @@ impl<H: PagingHandler> IVCChannel<H> {
         shared_region_size: usize,
         base_gpa: GuestPhysAddr,
     ) -> AxVmResult<Self> {
-        // TODO: support larger shared region sizes with alloc_frames API.
-        if shared_region_size > MAX_IVC_CHANNEL_SIZE {
+        let requested_size = align_up_4k(shared_region_size);
+        let shared_region_size = requested_size.min(MAX_IVC_CHANNEL_SIZE);
+        if shared_region_size == 0 {
+            return Err(ax_err_type!(
+                InvalidInput,
+                "IVC channel shared region size must be greater than 0"
+            ));
+        }
+        if shared_region_size < requested_size {
             warn!(
-                "IVC channel requested size {shared_region_size:#x} > {MAX_IVC_CHANNEL_SIZE:#x}; \
-                 truncating to {MAX_IVC_CHANNEL_SIZE:#x} (TODO: support larger sizes)"
+                "IVC channel requested size {requested_size:#x} exceeds \
+                 {MAX_IVC_CHANNEL_SIZE:#x}; truncating to {MAX_IVC_CHANNEL_SIZE:#x}"
             );
         }
-        let shared_region_size = shared_region_size.min(MAX_IVC_CHANNEL_SIZE);
-        let shared_region_base = H::alloc_frame().ok_or(AxVmError::OutOfMemory {
-            operation: "allocate IVC shared region frame",
+        let shared_region_base = H::alloc_frames(shared_region_size / PAGE_SIZE_4K, PAGE_SIZE_4K)
+            .ok_or(AxVmError::OutOfMemory {
+            operation: "allocate IVC shared region frames",
         })?;
 
         let mut channel = IVCChannel {
@@ -411,6 +423,13 @@ impl<H: PagingHandler> IVCChannel<H> {
         self.shared_region_size
     }
 
+    /// Number of 4K frames backing the shared region.
+    ///
+    /// `alloc()` guarantees the size is page-aligned, so this is exact.
+    fn page_count(&self) -> usize {
+        self.shared_region_size / PAGE_SIZE_4K
+    }
+
     pub fn add_subscriber(&mut self, subscriber_vm_id: usize, subscriber_gpa: GuestPhysAddr) {
         self.subscriber_vms.insert(subscriber_vm_id, subscriber_gpa);
     }
@@ -440,5 +459,142 @@ impl<H: PagingHandler> IVCChannel<H> {
 
     pub fn is_unpublished(&self) -> bool {
         self.base_gpa.is_none()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::{sync::Mutex, vec::Vec};
+
+    use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr};
+
+    use super::*;
+
+    const TEST_ARENA_SIZE: usize = 8 * 1024 * 1024;
+
+    /// A [`PagingHandler`] backed by a bump allocator over one leaked arena.
+    ///
+    /// The arena address doubles as both host physical and host virtual
+    /// address so that `header_mut()` writes land in real memory. Allocation
+    /// and deallocation calls are recorded for assertions.
+    struct MockPagingHandler;
+
+    static ARENA_OFFSET: AtomicUsize = AtomicUsize::new(0);
+    static ALLOC_FRAMES_CALLS: Mutex<Vec<(usize, usize)>> = Mutex::new(Vec::new());
+    static DEALLOC_FRAME_CALLS: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+    static DEALLOC_FRAMES_CALLS: Mutex<Vec<(usize, usize)>> = Mutex::new(Vec::new());
+
+    fn arena_base() -> usize {
+        static BASE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+        *BASE.get_or_init(|| {
+            let layout =
+                std::alloc::Layout::from_size_align(TEST_ARENA_SIZE, PAGE_SIZE_4K).unwrap();
+            // Safety: layout has non-zero size; null is checked immediately.
+            let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+            assert!(!ptr.is_null());
+            ptr as usize
+        })
+    }
+
+    fn bump_alloc_pages(num_pages: usize) -> Option<PhysAddr> {
+        let bytes = num_pages * PAGE_SIZE_4K;
+        let offset = ARENA_OFFSET.fetch_add(bytes, Ordering::Relaxed);
+        if offset + bytes > TEST_ARENA_SIZE {
+            return None;
+        }
+        Some(PhysAddr::from_usize(arena_base() + offset))
+    }
+
+    impl PagingHandler for MockPagingHandler {
+        fn alloc_frame() -> Option<PhysAddr> {
+            bump_alloc_pages(1)
+        }
+
+        fn alloc_frames(num: usize, align: usize) -> Option<PhysAddr> {
+            assert!(align <= PAGE_SIZE_4K);
+            ALLOC_FRAMES_CALLS.lock().unwrap().push((num, align));
+            bump_alloc_pages(num)
+        }
+
+        fn dealloc_frame(paddr: PhysAddr) {
+            DEALLOC_FRAME_CALLS.lock().unwrap().push(paddr.as_usize());
+        }
+
+        fn dealloc_frames(paddr: PhysAddr, num: usize) {
+            DEALLOC_FRAMES_CALLS
+                .lock()
+                .unwrap()
+                .push((paddr.as_usize(), num));
+        }
+
+        fn phys_to_virt(paddr: PhysAddr) -> VirtAddr {
+            VirtAddr::from_usize(paddr.as_usize())
+        }
+    }
+
+    #[test]
+    fn allocates_contiguous_frames_for_multi_page_channel() {
+        let channel = IVCChannel::<MockPagingHandler>::alloc(
+            1,
+            0x100,
+            4 * PAGE_SIZE_4K,
+            GuestPhysAddr::from_usize(0x7000_0000),
+        )
+        .unwrap();
+        assert_eq!(channel.size(), 4 * PAGE_SIZE_4K);
+        let base = channel.base_hpa();
+        assert!(
+            ALLOC_FRAMES_CALLS
+                .lock()
+                .unwrap()
+                .contains(&(4, PAGE_SIZE_4K))
+        );
+
+        drop(channel);
+        assert!(
+            DEALLOC_FRAMES_CALLS
+                .lock()
+                .unwrap()
+                .contains(&(base.as_usize(), 4))
+        );
+        assert!(DEALLOC_FRAME_CALLS.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn allocates_single_frame_for_page_sized_channel() {
+        let channel = IVCChannel::<MockPagingHandler>::alloc(
+            1,
+            0x101,
+            PAGE_SIZE_4K,
+            GuestPhysAddr::from_usize(0x7000_1000),
+        )
+        .unwrap();
+        assert_eq!(channel.size(), PAGE_SIZE_4K);
+    }
+
+    #[test]
+    fn truncates_channel_size_to_max() {
+        let channel = IVCChannel::<MockPagingHandler>::alloc(
+            1,
+            0x102,
+            2 * MAX_IVC_CHANNEL_SIZE,
+            GuestPhysAddr::from_usize(0x7000_2000),
+        )
+        .unwrap();
+        assert_eq!(channel.size(), MAX_IVC_CHANNEL_SIZE);
+    }
+
+    #[test]
+    fn rejects_zero_sized_channel() {
+        let result = IVCChannel::<MockPagingHandler>::alloc(
+            1,
+            0x103,
+            0,
+            GuestPhysAddr::from_usize(0x7000_3000),
+        );
+        assert!(result.is_err());
     }
 }

--- a/virtualization/axvm/src/runtime/ivc.rs
+++ b/virtualization/axvm/src/runtime/ivc.rs
@@ -16,7 +16,6 @@
 use alloc::{
     collections::{BTreeMap, btree_map::Entry},
     format,
-    vec::Vec,
 };
 
 use ax_kspin::SpinNoIrq as Mutex;
@@ -133,15 +132,7 @@ pub fn prepare_subscribe_channel(
             )
         ));
     }
-    if channel.has_subscriber(subscriber_vm_id) {
-        return Err(ax_err_type!(
-            AlreadyExists,
-            format!(
-                "VM[{}] has already subscribed to publisher VM[{}] Key {:#x}",
-                subscriber_vm_id, publisher_vm_id, key
-            )
-        ));
-    }
+    channel.ensure_subscriber_available(subscriber_vm_id)?;
 
     Ok(channel.size())
 }
@@ -173,17 +164,10 @@ pub fn subscribe_to_channel_of_publisher(
             )
         ));
     }
-    if channel.has_subscriber(subscriber_vm_id) {
-        return Err(ax_err_type!(
-            AlreadyExists,
-            format!(
-                "VM[{}] has already subscribed to publisher VM[{}] Key {:#x}",
-                subscriber_vm_id, publisher_vm_id, key
-            )
-        ));
-    }
-    // Add the subscriber VM ID to the channel.
-    channel.add_subscriber(subscriber_vm_id, subscriber_gpa);
+    // Register while holding the channel-table lock. This final check closes
+    // the gap after `prepare_subscribe_channel()` and preserves the SPSC
+    // protocol's one-subscriber invariant.
+    channel.add_subscriber(subscriber_vm_id, subscriber_gpa)?;
     Ok((channel.base_hpa(), channel.size()))
 }
 
@@ -220,7 +204,7 @@ pub fn unsubscribe_from_channel_of_publisher(
     // remove it from the global map.
     if channels
         .get(&(publisher_vm_id, key))
-        .is_some_and(|c| c.subscribers().is_empty() && c.is_unpublished())
+        .is_some_and(|c| !c.has_subscribers() && c.is_unpublished())
     {
         channels.remove(&(publisher_vm_id, key));
     }
@@ -278,13 +262,21 @@ pub fn prepare_notify_channel(
     })
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct IvcSubscriberBinding {
+    vm_id: usize,
+    base_gpa: GuestPhysAddr,
+}
+
 pub struct IVCChannel<H: PagingHandler> {
     publisher_vm_id: usize,
     key: usize,
-    /// A list of subscriber VM IDs that are subscribed to this channel.
-    /// The key is the subscriber VM ID, and the value is the base address of the shared region in
-    /// guest physical address of the subscriber VM.
-    subscriber_vms: BTreeMap<usize, GuestPhysAddr>,
+    /// The guest mapping attached to the channel's sole subscriber.
+    ///
+    /// The current guest-visible protocol uses one SPSC ring in each
+    /// direction, so attaching a second subscriber would create multiple
+    /// producers and consumers for those rings.
+    subscriber: Option<IvcSubscriberBinding>,
     shared_region_base: HostPhysAddr,
     shared_region_size: usize,
     /// The base address of the shared memory region in guest physical address of the publisher VM.
@@ -343,9 +335,9 @@ impl<H: PagingHandler> core::fmt::Debug for IVCChannel<H> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,
-            "IVCChannel(publisher[{}], subscribers {:?}, base: {:?}, size: {:#x}, gpa: {:?})",
+            "IVCChannel(publisher[{}], subscriber {:?}, base: {:?}, size: {:#x}, gpa: {:?})",
             self.publisher_vm_id,
-            self.subscriber_vms,
+            self.subscriber,
             self.shared_region_base,
             self.shared_region_size,
             self.base_gpa
@@ -393,7 +385,7 @@ impl<H: PagingHandler> IVCChannel<H> {
         let mut channel = IVCChannel {
             publisher_vm_id,
             key,
-            subscriber_vms: BTreeMap::new(),
+            subscriber: None,
             shared_region_base,
             shared_region_size,
             base_gpa: Some(base_gpa),
@@ -430,27 +422,59 @@ impl<H: PagingHandler> IVCChannel<H> {
         self.shared_region_size / PAGE_SIZE_4K
     }
 
-    pub fn add_subscriber(&mut self, subscriber_vm_id: usize, subscriber_gpa: GuestPhysAddr) {
-        self.subscriber_vms.insert(subscriber_vm_id, subscriber_gpa);
+    pub fn add_subscriber(
+        &mut self,
+        subscriber_vm_id: usize,
+        subscriber_gpa: GuestPhysAddr,
+    ) -> AxVmResult<()> {
+        self.ensure_subscriber_available(subscriber_vm_id)?;
+        self.subscriber = Some(IvcSubscriberBinding {
+            vm_id: subscriber_vm_id,
+            base_gpa: subscriber_gpa,
+        });
+        Ok(())
     }
 
     pub fn remove_subscriber(&mut self, subscriber_vm_id: usize) -> Option<GuestPhysAddr> {
-        self.subscriber_vms.remove(&subscriber_vm_id)
-    }
-
-    pub fn subscribers(&self) -> Vec<(usize, GuestPhysAddr)> {
-        self.subscriber_vms
-            .iter()
-            .map(|(vm_id, gpa)| (*vm_id, *gpa))
-            .collect()
+        let binding = self
+            .subscriber
+            .filter(|binding| binding.vm_id == subscriber_vm_id)?;
+        self.subscriber = None;
+        Some(binding.base_gpa)
     }
 
     pub fn has_subscribers(&self) -> bool {
-        !self.subscriber_vms.is_empty()
+        self.subscriber.is_some()
     }
 
     pub fn has_subscriber(&self, subscriber_vm_id: usize) -> bool {
-        self.subscriber_vms.contains_key(&subscriber_vm_id)
+        self.subscriber
+            .is_some_and(|binding| binding.vm_id == subscriber_vm_id)
+    }
+
+    fn ensure_subscriber_available(&self, subscriber_vm_id: usize) -> AxVmResult<()> {
+        let Some(binding) = self.subscriber else {
+            return Ok(());
+        };
+
+        if binding.vm_id == subscriber_vm_id {
+            Err(ax_err_type!(
+                AlreadyExists,
+                format!(
+                    "VM[{}] has already subscribed to publisher VM[{}] Key {:#x}",
+                    subscriber_vm_id, self.publisher_vm_id, self.key
+                )
+            ))
+        } else {
+            Err(ax_err_type!(
+                AlreadyExists,
+                format!(
+                    "IVC channel publisher VM[{}] Key {:#x} already has subscriber VM[{}]; the \
+                     SPSC protocol permits only one subscriber",
+                    self.publisher_vm_id, self.key, binding.vm_id
+                )
+            ))
+        }
     }
 
     pub fn mark_unpublished(&mut self) {
@@ -596,5 +620,47 @@ mod tests {
             GuestPhysAddr::from_usize(0x7000_3000),
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn rejects_second_subscriber_for_spsc_channel() {
+        let mut channel = IVCChannel::<MockPagingHandler>::alloc(
+            1,
+            0x104,
+            PAGE_SIZE_4K,
+            GuestPhysAddr::from_usize(0x7000_4000),
+        )
+        .unwrap();
+
+        channel
+            .add_subscriber(2, GuestPhysAddr::from_usize(0x7100_0000))
+            .unwrap();
+        assert!(channel.ensure_subscriber_available(3).is_err());
+        let second = channel.add_subscriber(3, GuestPhysAddr::from_usize(0x7200_0000));
+
+        assert!(second.is_err());
+        assert!(channel.has_subscriber(2));
+        assert!(!channel.has_subscriber(3));
+    }
+
+    #[test]
+    fn accepts_new_subscriber_after_current_subscriber_detaches() {
+        let mut channel = IVCChannel::<MockPagingHandler>::alloc(
+            1,
+            0x105,
+            PAGE_SIZE_4K,
+            GuestPhysAddr::from_usize(0x7000_5000),
+        )
+        .unwrap();
+        let first_gpa = GuestPhysAddr::from_usize(0x7100_0000);
+
+        channel.add_subscriber(2, first_gpa).unwrap();
+        assert_eq!(channel.remove_subscriber(2), Some(first_gpa));
+        channel
+            .add_subscriber(3, GuestPhysAddr::from_usize(0x7200_0000))
+            .unwrap();
+
+        assert!(!channel.has_subscriber(2));
+        assert!(channel.has_subscriber(3));
     }
 }


### PR DESCRIPTION
 ## 问题

- IVC 通道后端仅支持单页（4 KiB）共享内存，通道容量受限；
- ArceOS IVC demo 为半双工：publisher/subscriber 在单个 loop 中交替执行 send/recv，两个方向无法并发传输；
- demo 存在两个正确性问题：publisher 将 subscriber 的 data 误计为 ack，可能收满计数提前退出；subscriber 的单槽 pending ack 会被覆盖，突发到达时会丢 ack。

## 改动
1. axvm：IVCChannel 后端从单帧改为连续多帧分配（alloc_frames），通道最大支持 1 MiB；零长度请求返回 InvalidInput；补充 mock 回归测试；
2. demo 全双工化：publisher/subscriber 各拆分为独立的 send/recv 两个并发线程，两个方向独立传输、互不阻塞；
3. ack 计数修复：publisher 按消息 kind 区分，仅 Ack 计入完成数；subscriber 改为记录最高已收序号，由 sender 逐条补齐 ack；
4. 每个线程持有独立的 IvcPeerEventWaiter，避免共享 waiter 互相消耗 IRQ 事件观察；
5. test-suit 新增 ivc-arceos2arceos 用例。

## 验证

本地执行与 CI 相同的 qemu 集成测试：
 - `cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case ivc`
- `cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case ivc-arceos2arceos`
- `cargo xtask clippy --package arceos-ivc-publisher --package arceos-ivc-subscriber`

关键日志见下方。

ivc-arceos2linux 日志整理：
```text
ivc notify irq enabled irq=IrqId { domain: IrqDomainId(7), hwirq: HwIrq(60) }
ivc send seq=1
ivc send seq=2
ivc send seq=3
ivc send seq=4
ivc send seq=5
~ # echo "linux ivc kernel $(uname -r)"
linux ivc kernel 7.1.0-rc2-g74fe02ce122a-dirty
>     echo 'linux ivc demo failed'
>     echo 'linux ivc demo failed'
>     echo 'linux ivc demo failed'
>     echo 'linux ivc subscriber finished'
ivc ack seq=1 msg=ack from linux subscriber
linux ivc recv 1/5: hello from arceos publisher
ivc ack seq=2 msg=ack from linux subscriber
linux ivc recv 2/5: hello from arceos publisher
ivc ack seq=3 msg=ack from linux subscriber
linux ivc recv 3/5: hello from arceos publisher
ivc ack seq=4 msg=ack from linux subscriber
linux ivc recv 4/5: hello from arceos publisher
ivc ack seq=5 msg=ack from linux subscriber
=== SUCCESS PATTERN MATCHED: (?m)^ivc ack seq=5 msg=ack from linux subscriber\s*$ ===
ivc full-duplex demo complete
linux ivc recv 5/5: hello from arceos publisher
linux ivc demo pass[ 17.722722 0:14 axvm::ru
linux ivc subscriber finished
```

 ivc-arceos2arceos 日志整理：
 ```text
 ivc notify irq enabled irq=IrqId { domain: IrqDomainId(7), hwirq: HwIrq(60) }
ivc send seq=1
ivc send seq=2
ivc send seq=3
ivc send seq=4
ivc send seq=5
ivc notify irq enabled irq=IrqId { domain: IrqDomainId(7), hwirq: HwIrq(60) }
ivc send data seq=1
ivc recv sub data seq=1 msg=hello from arceos subscriber
ivc send data seq=2
ivc recv sub data seq=2 msg=hello from arceos subscriber
ivc recv pub data seq=2 msg=hello from arceos publisher
ivc recv pub data seq=3 msg=hello from arceos publisher
ivc recv pub data seq=4 msg=hello from arceos publisher
ivc recv pub data seq=5 msg=hello from arceos publisher
ivc ivc ack sack peq=ub seq=1 msg=1
ivc aivc ck pub seq=3
ivc aack seq=2ck pub seq msg=ac=4
ivc ack seq=4 msg=ack from arceos subscriber
ivc ack seq=5 msg=ack from arceos subscriber
=== SUCCESS PATTERN MATCHED: (?m)^ivc ack seq=5 msg=ack from arceos subscriber\s*$ ===
ivc full-duplex demo complete
 ```