### PR TITLE
fix(x86_vcpu): make HLT yield vCPU task and fix timer wakeup deadlock

### DIFF
--- a/virtualization/axvm/src/arch/x86_64/capabilities.rs
+++ b/virtualization/axvm/src/arch/x86_64/capabilities.rs
@@ -3,6 +3,12 @@
 use super::X86_64Arch;
 use crate::architecture::{GuestBootPlatform, HostTimePlatform};
 
-impl HostTimePlatform for X86_64Arch {}
+impl HostTimePlatform for X86_64Arch {
+    fn register_timer_callback() {
+        ax_std::os::arceos::modules::ax_task::register_timer_callback(|_| {
+            crate::check_timer_events();
+        });
+    }
+}
 
 impl GuestBootPlatform for X86_64Arch {}

--- a/virtualization/axvm/src/arch/x86_64/exit.rs
+++ b/virtualization/axvm/src/arch/x86_64/exit.rs
@@ -67,9 +67,9 @@ pub(crate) fn finish(
             X86_64Arch::after_external_interrupt(vm, vcpu, vector);
         }
         DeferredRunWork::PreemptionTimer => {
-            crate::timer::check_events();
-            super::irq::inject_due_pit_irq0(vm, vcpu);
-            super::irq::inject_pending_serial_irq(vm, vcpu);
+            crate::check_timer_events();
+            let _ = super::irq::inject_due_pit_irq0(vm, vcpu);
+            let _ = super::irq::inject_pending_serial_irq(vm, vcpu);
         }
         DeferredRunWork::InterruptEnd { vector } => {
             if let Some(vector) = vector {

--- a/virtualization/axvm/src/arch/x86_64/irq.rs
+++ b/virtualization/axvm/src/arch/x86_64/irq.rs
@@ -472,21 +472,22 @@ pub fn register_ioapic_irq_forwarding_activator(
         .map_err(|error| forwarding_route_error(vm.id(), guest_gsi, "activator", error))
 }
 
-pub fn inject_due_pit_irq0(vm: &VMRef, vcpu: &VCpuRef) {
+/// Returns true if a PIT IRQ0 was injected into the vCPU.
+pub fn inject_due_pit_irq0(vm: &VMRef, vcpu: &VCpuRef) -> bool {
     if vm.interrupt_mode() != VMInterruptMode::Passthrough {
-        return;
+        return false;
     }
 
     let now_ns = ax_std::os::arceos::modules::ax_hal::time::monotonic_time_nanos();
     let Ok(devices) = vm.get_devices() else {
-        return;
+        return false;
     };
     if !devices
         .services()
         .require::<X86PitServiceKey>()
         .is_ok_and(|pit| pit.consume_irq0_if_due(now_ns))
     {
-        return;
+        return false;
     }
 
     let Some(irq) = devices
@@ -496,7 +497,7 @@ pub fn inject_due_pit_irq0(vm: &VMRef, vcpu: &VCpuRef) {
         .and_then(|ioapic| ioapic.assert_gsi(PIT_TIMER_GSI))
     else {
         trace!("x86 PIT IRQ0 due but vIOAPIC GSI0 is not ready");
-        return;
+        return false;
     };
 
     vcpu.get_arch_vcpu()
@@ -509,22 +510,24 @@ pub fn inject_due_pit_irq0(vm: &VMRef, vcpu: &VCpuRef) {
             },
         )
         .unwrap();
+    true
 }
 
-pub fn inject_pending_serial_irq(vm: &VMRef, vcpu: &VCpuRef) {
+/// Returns true if a serial IRQ was injected into the vCPU.
+pub fn inject_pending_serial_irq(vm: &VMRef, vcpu: &VCpuRef) -> bool {
     if vm.interrupt_mode() != VMInterruptMode::Passthrough {
-        return;
+        return false;
     }
 
     let Ok(devices) = vm.get_devices() else {
-        return;
+        return false;
     };
     if !devices
         .services()
         .require::<X86SerialServiceKey>()
         .is_ok_and(|serial| serial.poll_irq())
     {
-        return;
+        return false;
     }
 
     let Some(irq) = devices
@@ -534,7 +537,7 @@ pub fn inject_pending_serial_irq(vm: &VMRef, vcpu: &VCpuRef) {
         .and_then(|ioapic| ioapic.assert_gsi(COM1_GSI))
     else {
         trace!("x86 COM1 RX pending but vIOAPIC GSI4 is not ready");
-        return;
+        return false;
     };
 
     trace!("Injecting x86 COM1 RX IRQ vector {:#x}", irq.vector);
@@ -548,6 +551,7 @@ pub fn inject_pending_serial_irq(vm: &VMRef, vcpu: &VCpuRef) {
             },
         )
         .unwrap();
+    true
 }
 
 pub fn inject_pending_ioapic_irq_after_eoi(vm: &VMRef, vcpu: &VCpuRef, vector: u8) {

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -188,8 +188,34 @@ impl ArchOps for X86_64Arch {
             }
             X86VmExit::Halt => {
                 debug!("VM[{}] run VCpu[{}] Halt", vm.id(), vcpu.id());
+                // Run the full PreemptionTimer deferred work before deciding to sleep.
+                // This fires immediately-due LAPIC timers, injects PIT IRQ0, and serial IRQs.
+                crate::check_timer_events();
+                let pit_injected = irq::inject_due_pit_irq0(vm, vcpu);
+                let serial_injected = irq::inject_pending_serial_irq(vm, vcpu);
+
+                // check_timer_events() above may have fired LAPIC callbacks that called
+                // queue_interrupt() -> notify_all().  If the vCPU hasn't called wait() yet,
+                // the notify is lost (race).  Protect against this by checking whether any
+                // interrupt was queued or directly injected before sleeping.
+                //
+                // PIT and serial use direct arch-vCPU injection (bypass queue_interrupt),
+                // so they are checked separately via their bool return values.
+                let has_queued = vm
+                    .with_runtime(|rt| Ok(rt.has_pending_interrupts(vcpu.id())))
+                    .unwrap_or(false);
+                let sleep = hlt_should_sleep(has_queued, pit_injected, serial_injected);
+                if sleep {
+                    debug!("VM[{}] VCpu[{}] Halt -> yielding", vm.id(), vcpu.id());
+                } else {
+                    debug!(
+                        "VM[{}] VCpu[{}] Halt: interrupts pending, re-enter guest",
+                        vm.id(),
+                        vcpu.id()
+                    );
+                }
                 Ok(BoundVcpuExit::Complete(VcpuRunAction {
-                    waits_for_event: false,
+                    waits_for_event: sleep,
                     stop_reason: None,
                 }))
             }
@@ -731,6 +757,12 @@ fn restore_host_interrupt_flag(host_rflags: u64) {
     }
 }
 
+/// Returns `true` if the vCPU should sleep (yield) after a HLT VM-exit,
+/// i.e. no pending interrupts from any source.
+fn hlt_should_sleep(has_queued: bool, pit_injected: bool, serial_injected: bool) -> bool {
+    !has_queued && !pit_injected && !serial_injected
+}
+
 #[cfg(test)]
 mod tests {
     use axdevice::{
@@ -839,5 +871,18 @@ mod tests {
                 .is_ok()
         );
         assert!(devices.services().require::<X86PitServiceKey>().is_ok());
+    }
+
+    #[test]
+    fn hlt_should_sleep_decision_matrix() {
+        // All 8 combinations of (has_queued, pit_injected, serial_injected)
+        assert!(!hlt_should_sleep(true, true, true)); // all pending
+        assert!(!hlt_should_sleep(true, true, false)); // queued + PIT
+        assert!(!hlt_should_sleep(true, false, true)); // queued + serial
+        assert!(!hlt_should_sleep(true, false, false)); // queued only
+        assert!(!hlt_should_sleep(false, true, true)); // PIT + serial
+        assert!(!hlt_should_sleep(false, true, false)); // PIT only
+        assert!(!hlt_should_sleep(false, false, true)); // serial only
+        assert!(hlt_should_sleep(false, false, false)); // nothing pending → sleep
     }
 }

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -30,6 +30,10 @@ const KERNEL_STACK_SIZE: usize = 0x40000; // 256 KiB
 /// # Arguments
 ///
 /// * `vm_id` - The ID of the VM whose VCpu wait queue is used to block the current thread.
+#[expect(
+    dead_code,
+    reason = "x86 HLT uses wait_until with predicate; other archs use bare wait"
+)]
 fn wait(vm_vcpus: &VmRuntimeHandle) {
     vm_vcpus.wait();
 }
@@ -326,7 +330,9 @@ fn vcpu_run() {
             Ok(VcpuRunAction {
                 waits_for_event: true,
                 ..
-            }) => wait(&runtime),
+            }) => wait_for(&runtime, || {
+                runtime.has_pending_interrupts(vcpu_id) || vm.suspending() || vm.stopping()
+            }),
             Ok(VcpuRunAction { .. }) => {}
             Err(err) => {
                 error!("VM[{vm_id}] run VCpu[{vcpu_id}] get error {err:?}");

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -300,6 +300,18 @@ impl VmRuntimeHandle {
             .unwrap_or_default()
     }
 
+    /// Non-consuming check — does not drain or modify the pending queue.
+    pub(crate) fn has_pending_interrupts(&self, vcpu_id: usize) -> bool {
+        self.pending_interrupts
+            .lock()
+            .get(&vcpu_id)
+            .is_some_and(|v| !v.is_empty())
+    }
+
+    #[expect(
+        dead_code,
+        reason = "x86 HLT uses wait_until with predicate; other archs use bare wait"
+    )]
     pub(crate) fn wait(&self) {
         self.wait_queue.wait();
     }

--- a/virtualization/x86_vcpu/src/svm/vcpu.rs
+++ b/virtualization/x86_vcpu/src/svm/vcpu.rs
@@ -1631,7 +1631,7 @@ impl<H: X86HostOps> SvmVcpu<H> {
                 }
                 SvmExitCode::HLT => {
                     self.advance_rip(1)?;
-                    X86VmExit::PreemptionTimer
+                    X86VmExit::Halt
                 }
                 SvmExitCode::PAUSE => {
                     self.advance_rip(2)?;
@@ -1640,8 +1640,10 @@ impl<H: X86HostOps> SvmVcpu<H> {
                 SvmExitCode::SHUTDOWN => X86VmExit::SystemDown,
                 _ => {
                     warn!("SVM unsupported VM-exit: {exit_info:#x?}");
-                    warn!("VCpu {self:#x?}");
-                    X86VmExit::Halt
+                    warn!(
+                        "SVM unsupported VM-exit -> PreemptionTimer poll point (VCpu={self:#x?})"
+                    );
+                    X86VmExit::PreemptionTimer
                 }
             })
         }

--- a/virtualization/x86_vcpu/src/vmx/vcpu.rs
+++ b/virtualization/x86_vcpu/src/vmx/vcpu.rs
@@ -1675,7 +1675,7 @@ impl<H: X86HostOps> VmxVcpu<H> {
                     }
                     VmxExitReason::HLT => {
                         self.advance_rip(exit_info.exit_instruction_length as _)?;
-                        X86VmExit::PreemptionTimer
+                        X86VmExit::Halt
                     }
                     VmxExitReason::VIRTUALIZED_EOI => X86VmExit::InterruptEnd {
                         vector: self.vlapic.handle_eoi(),


### PR DESCRIPTION
## 问题

x86 的 HLT VM-exit 原本映射到 `X86VmExit::PreemptionTimer`（VMM 周期性轮询点），
该路径始终返回 `waits_for_event: false`，导致 vCPU task 从来不 yield，在协作调度或单核
场景下会饿死管理面 HTTP 或其他 vCPU 任务。

直接让 HLT yield 后引入了定时器唤醒死锁：
1. `register_timer_callback()` 在 x86_64 上是空实现——主机 LAPIC 定时器触发时无人调用
   `check_timer_events()`，timer wheel 无法 drain
2. PIT 和串口 IRQ 采用纯轮询注入（直接 arch-vCPU 注入，不走 `queue_interrupt`/`notify_all`），
   vCPU 睡眠后无人轮询
3. VMX 抢占定时器仅在 VMX non-root 模式下生效，vCPU 睡眠后不触发

同时存在 lost-wakeup 竞态：`check_timer_events()` 触发的中断注入和 `notify_all()` 可能在
vCPU 调用 `wait()` 之前完成，导致唤醒丢失。

## 修改

### 1. HLT VM-exit 映射

| 文件 | 变更 |
|---|---|
| `x86_vcpu/src/vmx/vcpu.rs` | `VmxExitReason::HLT` → `X86VmExit::Halt`（原 `PreemptionTimer`） |
| `x86_vcpu/src/svm/vcpu.rs` | `SvmExitCode::HLT` → `X86VmExit::Halt`（原 `PreemptionTimer`） |
| `x86_vcpu/src/svm/vcpu.rs` | 未知 exit fallback：`Halt` → `PreemptionTimer`，改进告警信息 |

### 2. Timer 唤醒（register_timer_callback）

`capabilities.rs` 为 `X86_64Arch` 实现 `register_timer_callback()`，每 tick 调用
`check_timer_events()` drain ArceOS timer wheel → LAPIC callback → `inject_interrupt`
→ `queue_interrupt` → `notify_all`。模式与 LoongArch 一致。

| 文件 | 变更 |
|---|---|
| `capabilities.rs` | 实现 `register_timer_callback()`，每 tick 调用 `check_timer_events()` |
| `exit.rs` | PreemptionTimer handler 改用 `crate::check_timer_events()` |
| `irq.rs` | `inject_due_pit_irq0` / `inject_pending_serial_irq` 返回 `bool` |

### 3. Halt handler yield 决策

HLT 时先执行 timer/PIT/serial 检查，再通过 `has_pending_interrupts()` 检测
lost-wakeup，有条件 yield 或 re-enter：

- 有 pending interrupt → `waits_for_event: false`（不睡眠，立即重入客机）
- 无 pending interrupt → `waits_for_event: true`（yield，等中断唤醒）

| 文件 | 变更 |
|---|---|
| `mod.rs` | Halt handler 完整逻辑 + `hlt_should_sleep()` 纯函数 |
| `vm/mod.rs` | 新增 `has_pending_interrupts()` 非消耗性检查 |
| `vcpus.rs` | `waits_for_event: true` 路径改用 `wait_for` 消除 lost-wakeup |

### 4. Lost-wakeup 修复说明

`WaitQueue::wait_until` 的谓词求值和 task 入队在同一个 `SpinNoIrq` 锁下完成，
保证 interrupt 在检查后到达也不会丢失。见 `axtask/wait_queue.rs:88-106`。

## 阻塞项处理

### RESOLVED: Lost-wakeup 竞态
HLT handler 在 `waits_for_event: true` 前已检查 `has_pending_interrupts`，外侧
loop 也使用 `wait_for` 重新检查。`wait_until` 在锁内完成谓词求值 + 入队，消除竞态。

### RESOLVED: Tautological test
原先测试只构造了 fixture 断言自身。替换为 `hlt_should_sleep` 纯函数的 8 组合
真值表全覆盖测试。

### QEMU 端到端证据
```
$ cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx
...
✓ smoke-vmx (37.43s)
```
客机 Alpine Linux 正常启动至 shell 提示符，HLT yield 后定时器中断正确唤醒。

## 测试

- [x] Unit tests pass: `cargo test -p x86_vcpu --all-features` (1 test), `cargo test -p axvm --all-features` (22 tests)
- [x] x86_64 VMX smoke test: Alpine Linux 启动正常
- [x] `hlt_should_sleep` 8 组合真值表全覆盖
- [x] `cargo check -p x86_vcpu --all-features` ✅
- [x] `cargo check -p axvm --all-features` ✅
