### PR TITLE
axvisor: virtualize AArch64 physical timer state

### DIFF
--- a/os/axvisor/src/config.rs
+++ b/os/axvisor/src/config.rs
@@ -216,6 +216,7 @@ pub(crate) fn build_axvm_config(cfg: &AxVMCrateConfig) -> AxVMConfig {
             }),
         },
         emu_devices: cfg.devices.emu_devices.clone(),
+        pass_through_irqs: cfg.devices.passthrough_irqs.clone(),
         pass_through_devices: cfg.devices.passthrough_devices.clone(),
         excluded_devices: cfg.devices.excluded_devices.clone(),
         pass_through_addresses: cfg.devices.passthrough_addresses.clone(),
@@ -463,5 +464,15 @@ mod tests {
         assert_eq!(regions[1].gpa, 0x110000);
         assert_eq!(regions[1].size, 0x10000);
         assert_eq!(regions[1].map_type, VmMemMappingType::MapReserved);
+    }
+
+    #[test]
+    fn build_axvm_config_copies_explicit_passthrough_irqs() {
+        let mut crate_config = AxVMCrateConfig::default();
+        crate_config.devices.passthrough_irqs = vec![4, 4, 17];
+
+        let vm_config = build_axvm_config(&crate_config);
+
+        assert_eq!(vm_config.pass_through_irqs(), &vec![4, 17]);
     }
 }

--- a/platforms/somehal/src/arch/aarch64/gic/v3.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/v3.rs
@@ -241,7 +241,12 @@ fn init_cpu_interface(cpu_idx: usize) -> Result<(), &'static str> {
     let mut cpu = CPU_IF_INIT.cpu_interface();
     cpu.init_current_cpu()?;
     #[cfg(feature = "hv")]
-    cpu.set_eoi_mode(true);
+    {
+        // EL1 guests such as Zephyr may expect EOIR to both drop priority
+        // and deactivate the interrupt, as it does in the architectural reset state.
+        cpu.set_eoi_mode(false);
+        info!("GICv3 CPU {cpu_idx} EOI mode: two_step={}", cpu.eoi_mode());
+    }
 
     // SAFETY: CPU_IF was preallocated during BSP probe. Each CPU initializes
     // only its own logical CPU slot before it can send SGIs through that slot.

--- a/virtualization/arm_vgic/src/host.rs
+++ b/virtualization/arm_vgic/src/host.rs
@@ -20,8 +20,14 @@ pub trait ArmVgicHostIf {
     /// Return host CPU count.
     fn host_cpu_num() -> usize;
 
+    /// Return current VM ID.
+    fn current_vm_id() -> usize;
+
     /// Return current vCPU ID.
     fn current_vcpu_id() -> usize;
+
+    /// Queue a virtual interrupt for delivery to a VM vCPU.
+    fn queue_virtual_interrupt(vm_id: usize, vcpu_id: usize, vector: u8);
 
     /// Current monotonic host time in nanoseconds.
     fn current_time_nanos() -> u64;
@@ -77,8 +83,20 @@ pub(crate) fn host_cpu_num() -> usize {
     ax_crate_interface::call_interface!(ArmVgicHostIf::host_cpu_num())
 }
 
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn current_vm_id() -> usize {
+    ax_crate_interface::call_interface!(ArmVgicHostIf::current_vm_id())
+}
+
 pub(crate) fn current_vcpu_id() -> usize {
     ax_crate_interface::call_interface!(ArmVgicHostIf::current_vcpu_id())
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn queue_virtual_interrupt(vm_id: usize, vcpu_id: usize, vector: u8) {
+    ax_crate_interface::call_interface!(ArmVgicHostIf::queue_virtual_interrupt(
+        vm_id, vcpu_id, vector
+    ));
 }
 
 pub(crate) fn current_time_nanos() -> u64 {

--- a/virtualization/arm_vgic/src/host.rs
+++ b/virtualization/arm_vgic/src/host.rs
@@ -23,19 +23,16 @@ pub trait ArmVgicHostIf {
     /// Return current vCPU ID.
     fn current_vcpu_id() -> usize;
 
-    /// Return the VM ID associated with the current vCPU.
-    fn current_vm_id() -> usize;
-
     /// Current monotonic host time in nanoseconds.
     fn current_time_nanos() -> u64;
 
-    /// Register a timer callback.
+    /// Register a timer callback at an absolute host deadline.
     fn register_timer(
         deadline: Duration,
         callback: Box<dyn FnOnce(Duration) + Send + 'static>,
     ) -> usize;
 
-    /// Cancel a timer callback previously registered by this VM.
+    /// Cancel a previously registered timer callback.
     fn cancel_timer(token: usize);
 
     /// Read VGICD IIDR from host GIC.
@@ -52,9 +49,6 @@ pub trait ArmVgicHostIf {
 
     /// Inject a virtual interrupt.
     fn hardware_inject_virtual_interrupt(vector: u8);
-
-    /// Inject an interrupt into one explicitly selected VM vCPU.
-    fn inject_vm_vcpu_interrupt(vm_id: usize, vcpu_id: usize, vector: u8);
 }
 
 #[cfg(feature = "vgicv3")]
@@ -85,10 +79,6 @@ pub(crate) fn host_cpu_num() -> usize {
 
 pub(crate) fn current_vcpu_id() -> usize {
     ax_crate_interface::call_interface!(ArmVgicHostIf::current_vcpu_id())
-}
-
-pub(crate) fn current_vm_id() -> usize {
-    ax_crate_interface::call_interface!(ArmVgicHostIf::current_vm_id())
 }
 
 pub(crate) fn current_time_nanos() -> u64 {
@@ -124,10 +114,4 @@ pub fn get_host_gicr_base() -> PhysAddr {
 
 pub fn hardware_inject_virtual_interrupt(vector: u8) {
     ax_crate_interface::call_interface!(ArmVgicHostIf::hardware_inject_virtual_interrupt(vector));
-}
-
-pub(crate) fn inject_vm_vcpu_interrupt(vm_id: usize, vcpu_id: usize, vector: u8) {
-    ax_crate_interface::call_interface!(ArmVgicHostIf::inject_vm_vcpu_interrupt(
-        vm_id, vcpu_id, vector
-    ));
 }

--- a/virtualization/arm_vgic/src/host.rs
+++ b/virtualization/arm_vgic/src/host.rs
@@ -99,10 +99,12 @@ pub(crate) fn queue_virtual_interrupt(vm_id: usize, vcpu_id: usize, vector: u8) 
     ));
 }
 
+#[cfg(target_arch = "aarch64")]
 pub(crate) fn current_time_nanos() -> u64 {
     ax_crate_interface::call_interface!(ArmVgicHostIf::current_time_nanos())
 }
 
+#[cfg(target_arch = "aarch64")]
 pub(crate) fn register_timer(
     deadline: Duration,
     callback: Box<dyn FnOnce(Duration) + Send + 'static>,
@@ -110,6 +112,7 @@ pub(crate) fn register_timer(
     ax_crate_interface::call_interface!(ArmVgicHostIf::register_timer(deadline, callback))
 }
 
+#[cfg(target_arch = "aarch64")]
 pub(crate) fn cancel_timer(token: usize) {
     ax_crate_interface::call_interface!(ArmVgicHostIf::cancel_timer(token));
 }

--- a/virtualization/arm_vgic/src/vtimer/cntp_ctl_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_ctl_el0.rs
@@ -18,25 +18,39 @@ use alloc::sync::Arc;
 
 use aarch64_sysreg::SystemRegType;
 use axdevice_base::{
-    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DeviceResult,
-    Resource,
+    AccessWidth, BaseDeviceOps, DeviceAddrRange, DeviceResult, EmuDeviceType, SysRegAddr,
+    SysRegAddrRange,
 };
-use log::debug;
 
-use crate::vtimer::{VtimerBackend, VtimerState};
+use super::cntp_timer::CntpTimerState;
 
-const CNTP_CTL_EL0_ADDR: u32 = SystemRegType::CNTP_CTL_EL0 as u32;
-
-impl SysCntpCtlEl0 {
-    /// Reads CNTP_CTL_EL0.
-    pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
-        Ok(self.state.control(self.backend.current_time_nanos()) as usize)
+impl BaseDeviceOps<SysRegAddrRange> for SysCntpCtlEl0 {
+    fn emu_type(&self) -> EmuDeviceType {
+        EmuDeviceType::Console
     }
 
-    /// Writes CNTP_CTL_EL0.
-    pub fn write_register(&self, _width: AccessWidth, val: usize) -> DeviceResult {
-        debug!("Write to virtual timer register CNTP_CTL_EL0, value: {val}");
-        self.state.write_control(val as u32, self.backend.as_ref());
+    fn address_range(&self) -> SysRegAddrRange {
+        SysRegAddrRange {
+            start: SysRegAddr::new(SystemRegType::CNTP_CTL_EL0 as usize),
+            end: SysRegAddr::new(SystemRegType::CNTP_CTL_EL0 as usize),
+        }
+    }
+
+    fn handle_read(
+        &self,
+        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
+        _width: AccessWidth,
+    ) -> DeviceResult<usize> {
+        Ok(self.state.read_ctl() as usize)
+    }
+
+    fn handle_write(
+        &self,
+        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
+        _width: AccessWidth,
+        val: usize,
+    ) -> DeviceResult {
+        self.state.write_ctl(val as u32);
         Ok(())
     }
 }
@@ -45,50 +59,22 @@ impl SysCntpCtlEl0 {
 ///
 /// Provides virtualization support for the physical timer control register.
 pub struct SysCntpCtlEl0 {
-    state: Arc<VtimerState>,
-    backend: Arc<dyn VtimerBackend>,
-    resources: [Resource; 1],
+    state: Arc<CntpTimerState>,
 }
 
 impl SysCntpCtlEl0 {
     /// Creates a new CNTP_CTL_EL0 register emulator.
-    pub fn new(state: Arc<VtimerState>, backend: Arc<dyn VtimerBackend>) -> Self {
-        Self {
-            state,
-            backend,
-            resources: [Resource::SysReg {
-                addr: CNTP_CTL_EL0_ADDR,
-                count: 1,
-            }],
-        }
+    pub fn new() -> Self {
+        Self::from_state(Arc::new(CntpTimerState::new()))
+    }
+
+    pub(super) fn from_state(state: Arc<CntpTimerState>) -> Self {
+        Self { state }
     }
 }
 
-impl Device for SysCntpCtlEl0 {
-    fn name(&self) -> &str {
-        "aarch64-cntp-ctl-el0"
-    }
-
-    fn resources(&self) -> &[Resource] {
-        &self.resources
-    }
-
-    fn access(
-        &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::SysReg || access.addr != CNTP_CTL_EL0_ADDR as u64 {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
-        }
-        if access.is_read {
-            self.read_register(access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-        } else {
-            self.write_register(access.width, access.data as usize)
-                .map(|_| BusResponse::Write)
-        }
+impl Default for SysCntpCtlEl0 {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/cntp_ctl_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_ctl_el0.rs
@@ -18,38 +18,24 @@ use alloc::sync::Arc;
 
 use aarch64_sysreg::SystemRegType;
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, DeviceAddrRange, DeviceResult, EmuDeviceType, SysRegAddr,
-    SysRegAddrRange,
+    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DeviceResult,
+    Resource,
 };
+use log::debug;
 
 use super::cntp_timer::CntpTimerState;
 
-impl BaseDeviceOps<SysRegAddrRange> for SysCntpCtlEl0 {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::Console
-    }
+const CNTP_CTL_EL0_ADDR: u32 = SystemRegType::CNTP_CTL_EL0 as u32;
 
-    fn address_range(&self) -> SysRegAddrRange {
-        SysRegAddrRange {
-            start: SysRegAddr::new(SystemRegType::CNTP_CTL_EL0 as usize),
-            end: SysRegAddr::new(SystemRegType::CNTP_CTL_EL0 as usize),
-        }
-    }
-
-    fn handle_read(
-        &self,
-        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
-        _width: AccessWidth,
-    ) -> DeviceResult<usize> {
+impl SysCntpCtlEl0 {
+    /// Reads CNTP_CTL_EL0.
+    pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
         Ok(self.state.read_ctl() as usize)
     }
 
-    fn handle_write(
-        &self,
-        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
-        _width: AccessWidth,
-        val: usize,
-    ) -> DeviceResult {
+    /// Writes CNTP_CTL_EL0.
+    pub fn write_register(&self, _width: AccessWidth, val: usize) -> DeviceResult {
+        debug!("Write to virtual timer register CNTP_CTL_EL0, value: {val}");
         self.state.write_ctl(val as u32);
         Ok(())
     }
@@ -60,6 +46,7 @@ impl BaseDeviceOps<SysRegAddrRange> for SysCntpCtlEl0 {
 /// Provides virtualization support for the physical timer control register.
 pub struct SysCntpCtlEl0 {
     state: Arc<CntpTimerState>,
+    resources: [Resource; 1],
 }
 
 impl SysCntpCtlEl0 {
@@ -69,12 +56,47 @@ impl SysCntpCtlEl0 {
     }
 
     pub(super) fn from_state(state: Arc<CntpTimerState>) -> Self {
-        Self { state }
+        Self {
+            state,
+            resources: [Resource::SysReg {
+                addr: CNTP_CTL_EL0_ADDR,
+                count: 1,
+            }],
+        }
     }
 }
 
 impl Default for SysCntpCtlEl0 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Device for SysCntpCtlEl0 {
+    fn name(&self) -> &str {
+        "aarch64-cntp-ctl-el0"
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn access(
+        &self,
+        access: &BusAccess,
+        _context: &mut dyn DeviceAccess,
+    ) -> Result<BusResponse, DeviceError> {
+        if access.kind != BusKind::SysReg || access.addr != CNTP_CTL_EL0_ADDR as u64 {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        if access.is_read {
+            self.read_register(access.width)
+                .map(|value| BusResponse::Read {
+                    value: value as u64,
+                })
+        } else {
+            self.write_register(access.width, access.data as usize)
+                .map(|_| BusResponse::Write)
+        }
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/cntp_cval_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_cval_el0.rs
@@ -24,15 +24,15 @@ use axdevice_base::{
 
 use super::cntp_timer::CntpTimerState;
 
-impl BaseDeviceOps<SysRegAddrRange> for SysCntpTvalEl0 {
+impl BaseDeviceOps<SysRegAddrRange> for SysCntpCvalEl0 {
     fn emu_type(&self) -> EmuDeviceType {
         EmuDeviceType::Console
     }
 
     fn address_range(&self) -> SysRegAddrRange {
         SysRegAddrRange {
-            start: SysRegAddr::new(SystemRegType::CNTP_TVAL_EL0 as usize),
-            end: SysRegAddr::new(SystemRegType::CNTP_TVAL_EL0 as usize),
+            start: SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize),
+            end: SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize),
         }
     }
 
@@ -41,7 +41,7 @@ impl BaseDeviceOps<SysRegAddrRange> for SysCntpTvalEl0 {
         _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
         _width: AccessWidth,
     ) -> DeviceResult<usize> {
-        Ok(self.state.read_tval() as usize)
+        Ok(self.state.read_cval() as usize)
     }
 
     fn handle_write(
@@ -50,20 +50,22 @@ impl BaseDeviceOps<SysRegAddrRange> for SysCntpTvalEl0 {
         _width: AccessWidth,
         val: usize,
     ) -> DeviceResult {
-        self.state.write_tval(val as u32);
+        self.state.write_cval(val as u64);
         Ok(())
     }
 }
 
-/// System register emulation for CNTP_TVAL_EL0.
+/// System register emulation for CNTP_CVAL_EL0.
 ///
-/// Provides virtualization support for the physical timer value register.
-pub struct SysCntpTvalEl0 {
+/// CNTP_CVAL_EL0 is banked per processing element. The current AxVisor
+/// vTimer device model is instantiated for a single-vCPU guest, so this
+/// device preserves the guest-visible compare value for that vCPU.
+pub struct SysCntpCvalEl0 {
     state: Arc<CntpTimerState>,
 }
 
-impl SysCntpTvalEl0 {
-    /// Creates a new CNTP_TVAL_EL0 register emulator.
+impl SysCntpCvalEl0 {
+    /// Creates a new CNTP_CVAL_EL0 register emulator.
     pub fn new() -> Self {
         Self::from_state(Arc::new(CntpTimerState::new()))
     }
@@ -73,8 +75,38 @@ impl SysCntpTvalEl0 {
     }
 }
 
-impl Default for SysCntpTvalEl0 {
+impl Default for SysCntpCvalEl0 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exposes_cntp_cval_address() {
+        let device = SysCntpCvalEl0::new();
+        let range = device.address_range();
+
+        assert_eq!(
+            range.start,
+            SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize)
+        );
+        assert_eq!(range.end, range.start);
+    }
+
+    #[test]
+    fn preserves_guest_visible_value() {
+        let device = SysCntpCvalEl0::new();
+        let addr = SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize);
+        let value = 0x1234_5678_9abc_def0usize;
+
+        device
+            .handle_write(addr, AccessWidth::Qword, value)
+            .unwrap();
+
+        assert_eq!(device.handle_read(addr, AccessWidth::Qword).unwrap(), value);
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/cntp_cval_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_cval_el0.rs
@@ -18,38 +18,24 @@ use alloc::sync::Arc;
 
 use aarch64_sysreg::SystemRegType;
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, DeviceAddrRange, DeviceResult, EmuDeviceType, SysRegAddr,
-    SysRegAddrRange,
+    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DeviceResult,
+    Resource,
 };
+use log::debug;
 
 use super::cntp_timer::CntpTimerState;
 
-impl BaseDeviceOps<SysRegAddrRange> for SysCntpCvalEl0 {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::Console
-    }
+const CNTP_CVAL_EL0_ADDR: u32 = SystemRegType::CNTP_CVAL_EL0 as u32;
 
-    fn address_range(&self) -> SysRegAddrRange {
-        SysRegAddrRange {
-            start: SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize),
-            end: SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize),
-        }
-    }
-
-    fn handle_read(
-        &self,
-        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
-        _width: AccessWidth,
-    ) -> DeviceResult<usize> {
+impl SysCntpCvalEl0 {
+    /// Reads CNTP_CVAL_EL0.
+    pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
         Ok(self.state.read_cval() as usize)
     }
 
-    fn handle_write(
-        &self,
-        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
-        _width: AccessWidth,
-        val: usize,
-    ) -> DeviceResult {
+    /// Writes CNTP_CVAL_EL0.
+    pub fn write_register(&self, _width: AccessWidth, val: usize) -> DeviceResult {
+        debug!("Write to virtual timer register CNTP_CVAL_EL0, value: {val}");
         self.state.write_cval(val as u64);
         Ok(())
     }
@@ -57,11 +43,10 @@ impl BaseDeviceOps<SysRegAddrRange> for SysCntpCvalEl0 {
 
 /// System register emulation for CNTP_CVAL_EL0.
 ///
-/// CNTP_CVAL_EL0 is banked per processing element. The current AxVisor
-/// vTimer device model is instantiated for a single-vCPU guest, so this
-/// device preserves the guest-visible compare value for that vCPU.
+/// Provides virtualization support for the physical timer compare register.
 pub struct SysCntpCvalEl0 {
     state: Arc<CntpTimerState>,
+    resources: [Resource; 1],
 }
 
 impl SysCntpCvalEl0 {
@@ -71,7 +56,13 @@ impl SysCntpCvalEl0 {
     }
 
     pub(super) fn from_state(state: Arc<CntpTimerState>) -> Self {
-        Self { state }
+        Self {
+            state,
+            resources: [Resource::SysReg {
+                addr: CNTP_CVAL_EL0_ADDR,
+                count: 1,
+            }],
+        }
     }
 }
 
@@ -81,32 +72,31 @@ impl Default for SysCntpCvalEl0 {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn exposes_cntp_cval_address() {
-        let device = SysCntpCvalEl0::new();
-        let range = device.address_range();
-
-        assert_eq!(
-            range.start,
-            SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize)
-        );
-        assert_eq!(range.end, range.start);
+impl Device for SysCntpCvalEl0 {
+    fn name(&self) -> &str {
+        "aarch64-cntp-cval-el0"
     }
 
-    #[test]
-    fn preserves_guest_visible_value() {
-        let device = SysCntpCvalEl0::new();
-        let addr = SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize);
-        let value = 0x1234_5678_9abc_def0usize;
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
 
-        device
-            .handle_write(addr, AccessWidth::Qword, value)
-            .unwrap();
-
-        assert_eq!(device.handle_read(addr, AccessWidth::Qword).unwrap(), value);
+    fn access(
+        &self,
+        access: &BusAccess,
+        _context: &mut dyn DeviceAccess,
+    ) -> Result<BusResponse, DeviceError> {
+        if access.kind != BusKind::SysReg || access.addr != CNTP_CVAL_EL0_ADDR as u64 {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        if access.is_read {
+            self.read_register(access.width)
+                .map(|value| BusResponse::Read {
+                    value: value as u64,
+                })
+        } else {
+            self.write_register(access.width, access.data as usize)
+                .map(|_| BusResponse::Write)
+        }
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
@@ -22,8 +22,10 @@ const CNTP_PPI: u8 = 30;
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 const TIMER_TOKEN_NONE: usize = usize::MAX;
 
-pub(super) struct CntpTimerState {
+pub struct CntpTimerState {
     banks: TimerBankLock<BTreeMap<(usize, usize), Arc<CntpTimerBank>>>,
+    #[cfg(test)]
+    test_identity: TimerBankLock<(usize, usize)>,
 }
 
 struct CntpTimerBank {
@@ -41,6 +43,8 @@ impl CntpTimerState {
     pub(super) fn new() -> Self {
         Self {
             banks: TimerBankLock::new(BTreeMap::new()),
+            #[cfg(test)]
+            test_identity: TimerBankLock::new((0, 0)),
         }
     }
 
@@ -68,8 +72,28 @@ impl CntpTimerState {
         self.current_bank().write_tval(value);
     }
 
+    pub fn reset(&self) {
+        let banks = self.snapshot_banks();
+        for bank in &banks {
+            bank.reset();
+        }
+        lock_timer_banks(&self.banks).clear();
+    }
+
+    pub fn suspend(&self) {
+        for bank in self.snapshot_banks() {
+            bank.suspend();
+        }
+    }
+
+    pub fn resume(&self) {
+        for bank in self.snapshot_banks() {
+            bank.rearm();
+        }
+    }
+
     fn current_bank(&self) -> Arc<CntpTimerBank> {
-        let (vm_id, vcpu_id) = current_timer_identity();
+        let (vm_id, vcpu_id) = self.current_timer_identity();
         let mut banks = lock_timer_banks(&self.banks);
         Arc::clone(
             banks
@@ -78,10 +102,35 @@ impl CntpTimerState {
         )
     }
 
+    fn snapshot_banks(&self) -> alloc::vec::Vec<Arc<CntpTimerBank>> {
+        lock_timer_banks(&self.banks).values().cloned().collect()
+    }
+
+    #[cfg(test)]
+    fn current_timer_identity(&self) -> (usize, usize) {
+        *lock_test_identity(&self.test_identity)
+    }
+
+    #[cfg(not(test))]
+    fn current_timer_identity(&self) -> (usize, usize) {
+        current_timer_identity()
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_test_current_identity(&self, vm_id: usize, vcpu_id: usize) {
+        *lock_test_identity(&self.test_identity) = (vm_id, vcpu_id);
+    }
+
     #[cfg(test)]
     pub(super) fn current_fire_target_for_test(&self) -> Option<(usize, usize, u8)> {
         let bank = self.current_bank();
         bank.fire_target(bank.generation.load(Ordering::Acquire))
+    }
+}
+
+impl Default for CntpTimerState {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -97,6 +146,15 @@ fn lock_timer_banks(
     banks: &TimerBankLock<BTreeMap<(usize, usize), Arc<CntpTimerBank>>>,
 ) -> TimerBankLockGuard<'_, BTreeMap<(usize, usize), Arc<CntpTimerBank>>> {
     banks.lock()
+}
+
+#[cfg(test)]
+fn lock_test_identity(
+    identity: &TimerBankLock<(usize, usize)>,
+) -> TimerBankLockGuard<'_, (usize, usize)> {
+    identity
+        .lock()
+        .expect("CNTP timer test identity lock poisoned")
 }
 
 impl CntpTimerBank {
@@ -204,6 +262,23 @@ impl CntpTimerBank {
         }
     }
 
+    #[cfg(not(target_arch = "aarch64"))]
+    fn cancel_pending_timer(&self) {
+        self.timer_token.store(TIMER_TOKEN_NONE, Ordering::Release);
+    }
+
+    fn reset(&self) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        self.ctl.store(0, Ordering::Release);
+        self.cval.store(0, Ordering::Release);
+        self.cancel_pending_timer();
+    }
+
+    fn suspend(&self) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        self.cancel_pending_timer();
+    }
+
     #[cfg(target_arch = "aarch64")]
     fn fire(self: &Arc<Self>, expected_generation: u64) {
         if !self.is_armed_for(expected_generation) {
@@ -211,10 +286,15 @@ impl CntpTimerBank {
         }
 
         if counter_ticks() < self.cval.load(Ordering::Acquire) {
-            self.rearm();
+            if self.is_armed_for(expected_generation) {
+                self.rearm();
+            }
             return;
         }
 
+        if !self.is_armed_for(expected_generation) {
+            return;
+        }
         host::queue_virtual_interrupt(self.vm_id, self.vcpu_id, CNTP_PPI);
     }
 
@@ -237,25 +317,6 @@ impl CntpTimerBank {
         let ctl = self.ctl.load(Ordering::Acquire);
         ctl & CNTP_CTL_ENABLE != 0 && ctl & CNTP_CTL_IMASK == 0
     }
-}
-
-#[cfg(test)]
-static TEST_CURRENT_VM_ID: AtomicUsize = AtomicUsize::new(0);
-#[cfg(test)]
-static TEST_CURRENT_VCPU_ID: AtomicUsize = AtomicUsize::new(0);
-
-#[cfg(test)]
-pub(super) fn set_test_current_identity(vm_id: usize, vcpu_id: usize) {
-    TEST_CURRENT_VM_ID.store(vm_id, Ordering::Relaxed);
-    TEST_CURRENT_VCPU_ID.store(vcpu_id, Ordering::Relaxed);
-}
-
-#[cfg(test)]
-fn current_timer_identity() -> (usize, usize) {
-    (
-        TEST_CURRENT_VM_ID.load(Ordering::Relaxed),
-        TEST_CURRENT_VCPU_ID.load(Ordering::Relaxed),
-    )
 }
 
 #[cfg(all(not(test), target_arch = "aarch64"))]
@@ -326,19 +387,19 @@ mod tests {
     fn banks_timer_state_per_vcpu_identity() {
         let state = CntpTimerState::new();
 
-        set_test_current_identity(11, 0);
+        state.set_test_current_identity(11, 0);
         state.write_cval(0x1111);
         state.write_ctl(CNTP_CTL_ENABLE | CNTP_CTL_IMASK);
 
-        set_test_current_identity(11, 1);
+        state.set_test_current_identity(11, 1);
         state.write_cval(0x2222);
         state.write_ctl(CNTP_CTL_ENABLE);
 
-        set_test_current_identity(11, 0);
+        state.set_test_current_identity(11, 0);
         assert_eq!(state.read_cval(), 0x1111);
         assert_eq!(state.read_ctl() & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK), 0x3);
 
-        set_test_current_identity(11, 1);
+        state.set_test_current_identity(11, 1);
         assert_eq!(state.read_cval(), 0x2222);
         assert_eq!(state.read_ctl() & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK), 0x1);
     }
@@ -347,12 +408,12 @@ mod tests {
     fn resolves_ppi30_delivery_target_from_each_vcpu_bank() {
         let state = CntpTimerState::new();
 
-        set_test_current_identity(11, 0);
+        state.set_test_current_identity(11, 0);
         state.write_cval(0);
         state.write_ctl(CNTP_CTL_ENABLE);
         let vcpu0_target = state.current_fire_target_for_test();
 
-        set_test_current_identity(11, 1);
+        state.set_test_current_identity(11, 1);
         state.write_cval(0);
         state.write_ctl(CNTP_CTL_ENABLE);
         let vcpu1_target = state.current_fire_target_for_test();
@@ -360,14 +421,76 @@ mod tests {
         assert_eq!(vcpu0_target, Some((11, 0, CNTP_PPI)));
         assert_eq!(vcpu1_target, Some((11, 1, CNTP_PPI)));
 
-        set_test_current_identity(11, 0);
+        state.set_test_current_identity(11, 0);
         state.write_ctl(CNTP_CTL_ENABLE | CNTP_CTL_IMASK);
         assert_eq!(state.current_fire_target_for_test(), None);
 
-        set_test_current_identity(11, 1);
+        state.set_test_current_identity(11, 1);
         assert_eq!(
             state.current_fire_target_for_test(),
             Some((11, 1, CNTP_PPI))
         );
+    }
+
+    #[test]
+    fn reset_invalidates_stale_callbacks_for_all_banks() {
+        let state = CntpTimerState::new();
+
+        state.set_test_current_identity(11, 0);
+        state.write_cval(0);
+        state.write_ctl(CNTP_CTL_ENABLE);
+        let bank0 = state.current_bank();
+        let generation0 = bank0.generation.load(Ordering::Acquire);
+
+        state.set_test_current_identity(11, 1);
+        state.write_cval(0);
+        state.write_ctl(CNTP_CTL_ENABLE);
+        let bank1 = state.current_bank();
+        let generation1 = bank1.generation.load(Ordering::Acquire);
+
+        state.reset();
+
+        assert_eq!(bank0.fire_target(generation0), None);
+        assert_eq!(bank1.fire_target(generation1), None);
+
+        state.set_test_current_identity(11, 0);
+        assert_eq!(state.read_cval(), 0);
+        assert_eq!(state.read_ctl() & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK), 0);
+    }
+
+    #[test]
+    fn suspend_invalidates_stale_callbacks_and_resume_rearms_all_banks() {
+        let state = CntpTimerState::new();
+
+        state.set_test_current_identity(11, 0);
+        state.write_cval(0);
+        state.write_ctl(CNTP_CTL_ENABLE);
+        let bank0 = state.current_bank();
+        let generation0 = bank0.generation.load(Ordering::Acquire);
+
+        state.set_test_current_identity(11, 1);
+        state.write_cval(0x2222);
+        state.write_ctl(CNTP_CTL_ENABLE | CNTP_CTL_IMASK);
+        let bank1 = state.current_bank();
+        let generation1 = bank1.generation.load(Ordering::Acquire);
+
+        state.suspend();
+
+        assert_eq!(bank0.fire_target(generation0), None);
+        assert_eq!(bank1.fire_target(generation1), None);
+
+        state.set_test_current_identity(11, 1);
+        assert_eq!(state.read_cval(), 0x2222);
+        assert_eq!(state.read_ctl() & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK), 0x3);
+
+        state.resume();
+
+        state.set_test_current_identity(11, 0);
+        assert_eq!(
+            state.current_fire_target_for_test(),
+            Some((11, 0, CNTP_PPI))
+        );
+        state.set_test_current_identity(11, 1);
+        assert_eq!(state.current_fire_target_for_test(), None);
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
@@ -1,9 +1,14 @@
 #[cfg(target_arch = "aarch64")]
 use alloc::boxed::Box;
-use alloc::sync::Arc;
+use alloc::{collections::BTreeMap, sync::Arc};
 use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
 #[cfg(target_arch = "aarch64")]
 use core::{arch::asm, time::Duration};
+#[cfg(test)]
+use std::sync::{Mutex as TimerBankLock, MutexGuard as TimerBankLockGuard};
+
+#[cfg(not(test))]
+use ax_kspin::{SpinNoIrq as TimerBankLock, SpinNoIrqGuard as TimerBankLockGuard};
 
 #[cfg(target_arch = "aarch64")]
 use crate::host;
@@ -14,44 +19,104 @@ const CNTP_CTL_ISTATUS: u32 = 1 << 2;
 const CNTP_PPI: u8 = 30;
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 const TIMER_TOKEN_NONE: usize = usize::MAX;
-#[cfg(target_arch = "aarch64")]
-const TARGET_NONE: usize = usize::MAX;
 
 pub(super) struct CntpTimerState {
+    banks: TimerBankLock<BTreeMap<(usize, usize), Arc<CntpTimerBank>>>,
+}
+
+struct CntpTimerBank {
+    vm_id: usize,
+    vcpu_id: usize,
     cval: AtomicU64,
     ctl: AtomicU32,
     generation: AtomicU64,
     timer_token: AtomicUsize,
-    #[cfg(target_arch = "aarch64")]
-    target_vm_id: AtomicUsize,
-    #[cfg(target_arch = "aarch64")]
-    target_vcpu_id: AtomicUsize,
 }
 
 impl CntpTimerState {
-    pub(super) const fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
-            cval: AtomicU64::new(0),
-            ctl: AtomicU32::new(0),
-            generation: AtomicU64::new(0),
-            timer_token: AtomicUsize::new(TIMER_TOKEN_NONE),
-            #[cfg(target_arch = "aarch64")]
-            target_vm_id: AtomicUsize::new(TARGET_NONE),
-            #[cfg(target_arch = "aarch64")]
-            target_vcpu_id: AtomicUsize::new(TARGET_NONE),
+            banks: TimerBankLock::new(BTreeMap::new()),
         }
     }
 
     pub(super) fn read_cval(&self) -> u64 {
+        self.current_bank().read_cval()
+    }
+
+    pub(super) fn write_cval(&self, value: u64) {
+        self.current_bank().write_cval(value);
+    }
+
+    pub(super) fn read_ctl(&self) -> u32 {
+        self.current_bank().read_ctl()
+    }
+
+    pub(super) fn write_ctl(&self, value: u32) {
+        self.current_bank().write_ctl(value);
+    }
+
+    pub(super) fn read_tval(&self) -> u32 {
+        self.current_bank().read_tval()
+    }
+
+    pub(super) fn write_tval(&self, value: u32) {
+        self.current_bank().write_tval(value);
+    }
+
+    fn current_bank(&self) -> Arc<CntpTimerBank> {
+        let (vm_id, vcpu_id) = current_timer_identity();
+        let mut banks = lock_timer_banks(&self.banks);
+        Arc::clone(
+            banks
+                .entry((vm_id, vcpu_id))
+                .or_insert_with(|| Arc::new(CntpTimerBank::new(vm_id, vcpu_id))),
+        )
+    }
+
+    #[cfg(test)]
+    pub(super) fn current_fire_target_for_test(&self) -> Option<(usize, usize, u8)> {
+        let bank = self.current_bank();
+        bank.fire_target(bank.generation.load(Ordering::Acquire))
+    }
+}
+
+#[cfg(test)]
+fn lock_timer_banks(
+    banks: &TimerBankLock<BTreeMap<(usize, usize), Arc<CntpTimerBank>>>,
+) -> TimerBankLockGuard<'_, BTreeMap<(usize, usize), Arc<CntpTimerBank>>> {
+    banks.lock().expect("CNTP timer test lock poisoned")
+}
+
+#[cfg(not(test))]
+fn lock_timer_banks(
+    banks: &TimerBankLock<BTreeMap<(usize, usize), Arc<CntpTimerBank>>>,
+) -> TimerBankLockGuard<'_, BTreeMap<(usize, usize), Arc<CntpTimerBank>>> {
+    banks.lock()
+}
+
+impl CntpTimerBank {
+    const fn new(vm_id: usize, vcpu_id: usize) -> Self {
+        Self {
+            vm_id,
+            vcpu_id,
+            cval: AtomicU64::new(0),
+            ctl: AtomicU32::new(0),
+            generation: AtomicU64::new(0),
+            timer_token: AtomicUsize::new(TIMER_TOKEN_NONE),
+        }
+    }
+
+    fn read_cval(&self) -> u64 {
         self.cval.load(Ordering::Acquire)
     }
 
-    pub(super) fn write_cval(self: &Arc<Self>, value: u64) {
+    fn write_cval(self: &Arc<Self>, value: u64) {
         self.cval.store(value, Ordering::Release);
         self.rearm();
     }
 
-    pub(super) fn read_ctl(&self) -> u32 {
+    fn read_ctl(&self) -> u32 {
         let ctl = self.ctl.load(Ordering::Acquire);
         let expired =
             ctl & CNTP_CTL_ENABLE != 0 && counter_ticks() >= self.cval.load(Ordering::Acquire);
@@ -63,7 +128,7 @@ impl CntpTimerState {
         }
     }
 
-    pub(super) fn write_ctl(self: &Arc<Self>, value: u32) {
+    fn write_ctl(self: &Arc<Self>, value: u32) {
         self.ctl.store(
             value & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK),
             Ordering::Release,
@@ -71,13 +136,13 @@ impl CntpTimerState {
         self.rearm();
     }
 
-    pub(super) fn read_tval(&self) -> u32 {
+    fn read_tval(&self) -> u32 {
         self.cval
             .load(Ordering::Acquire)
             .wrapping_sub(counter_ticks()) as u32
     }
 
-    pub(super) fn write_tval(self: &Arc<Self>, value: u32) {
+    fn write_tval(self: &Arc<Self>, value: u32) {
         let delta = value as i32 as i64;
         let now = counter_ticks();
         let cval = if delta >= 0 {
@@ -92,20 +157,6 @@ impl CntpTimerState {
 
     #[cfg(target_arch = "aarch64")]
     fn rearm(self: &Arc<Self>) {
-        self.rearm_with_target(Some((host::current_vm_id(), host::current_vcpu_id())));
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    fn rearm_existing_target(self: &Arc<Self>) {
-        self.rearm_with_target(None);
-    }
-
-    #[cfg(target_arch = "aarch64")]
-    fn rearm_with_target(self: &Arc<Self>, target: Option<(usize, usize)>) {
-        if let Some((vm_id, vcpu_id)) = target {
-            self.target_vm_id.store(vm_id, Ordering::Release);
-            self.target_vcpu_id.store(vcpu_id, Ordering::Release);
-        }
         let generation = self
             .generation
             .fetch_add(1, Ordering::AcqRel)
@@ -116,22 +167,16 @@ impl CntpTimerState {
             return;
         }
 
-        let target_vm_id = self.target_vm_id.load(Ordering::Acquire);
-        let target_vcpu_id = self.target_vcpu_id.load(Ordering::Acquire);
-        if target_vm_id == TARGET_NONE || target_vcpu_id == TARGET_NONE {
-            return;
-        }
-
         let now_ticks = counter_ticks();
         let deadline_ticks = self.cval.load(Ordering::Acquire);
         let delay_ticks = deadline_ticks.saturating_sub(now_ticks);
         let delay_ns = ticks_to_nanos_ceil(delay_ticks, counter_frequency_hz());
         let deadline_ns = host::current_time_nanos().saturating_add(delay_ns);
-        let state = Arc::clone(self);
+        let bank = Arc::clone(self);
 
         let token = host::register_timer(
             Duration::from_nanos(deadline_ns),
-            Box::new(move |_| state.fire(generation)),
+            Box::new(move |_| bank.fire(generation)),
         );
         self.timer_token.store(token, Ordering::Release);
     }
@@ -152,27 +197,64 @@ impl CntpTimerState {
 
     #[cfg(target_arch = "aarch64")]
     fn fire(self: &Arc<Self>, expected_generation: u64) {
-        if self.generation.load(Ordering::Acquire) != expected_generation {
-            return;
-        }
-
-        let ctl = self.ctl.load(Ordering::Acquire);
-        if ctl & CNTP_CTL_ENABLE == 0 || ctl & CNTP_CTL_IMASK != 0 {
+        if !self.is_armed_for(expected_generation) {
             return;
         }
 
         if counter_ticks() < self.cval.load(Ordering::Acquire) {
-            self.rearm_existing_target();
+            self.rearm();
             return;
         }
 
-        let target_vm_id = self.target_vm_id.load(Ordering::Acquire);
-        let target_vcpu_id = self.target_vcpu_id.load(Ordering::Acquire);
-        if target_vm_id == TARGET_NONE || target_vcpu_id == TARGET_NONE {
-            return;
-        }
-        host::queue_virtual_interrupt(target_vm_id, target_vcpu_id, CNTP_PPI);
+        host::queue_virtual_interrupt(self.vm_id, self.vcpu_id, CNTP_PPI);
     }
+
+    fn fire_target(&self, expected_generation: u64) -> Option<(usize, usize, u8)> {
+        if !self.is_armed_for(expected_generation)
+            || counter_ticks() < self.cval.load(Ordering::Acquire)
+        {
+            return None;
+        }
+        Some((self.vm_id, self.vcpu_id, CNTP_PPI))
+    }
+
+    fn is_armed_for(&self, expected_generation: u64) -> bool {
+        if self.generation.load(Ordering::Acquire) != expected_generation {
+            return false;
+        }
+
+        let ctl = self.ctl.load(Ordering::Acquire);
+        ctl & CNTP_CTL_ENABLE != 0 && ctl & CNTP_CTL_IMASK == 0
+    }
+}
+
+#[cfg(test)]
+static TEST_CURRENT_VM_ID: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+static TEST_CURRENT_VCPU_ID: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+pub(super) fn set_test_current_identity(vm_id: usize, vcpu_id: usize) {
+    TEST_CURRENT_VM_ID.store(vm_id, Ordering::Relaxed);
+    TEST_CURRENT_VCPU_ID.store(vcpu_id, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+fn current_timer_identity() -> (usize, usize) {
+    (
+        TEST_CURRENT_VM_ID.load(Ordering::Relaxed),
+        TEST_CURRENT_VCPU_ID.load(Ordering::Relaxed),
+    )
+}
+
+#[cfg(all(not(test), target_arch = "aarch64"))]
+fn current_timer_identity() -> (usize, usize) {
+    (host::current_vm_id(), host::current_vcpu_id())
+}
+
+#[cfg(all(not(test), not(target_arch = "aarch64")))]
+fn current_timer_identity() -> (usize, usize) {
+    (0, 0)
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -231,5 +313,54 @@ mod tests {
     #[test]
     fn clamps_zero_frequency() {
         assert_eq!(ticks_to_nanos_ceil(1, 0), NANOS_PER_SECOND);
+    }
+
+    #[test]
+    fn banks_timer_state_per_vcpu_identity() {
+        let state = CntpTimerState::new();
+
+        set_test_current_identity(11, 0);
+        state.write_cval(0x1111);
+        state.write_ctl(CNTP_CTL_ENABLE | CNTP_CTL_IMASK);
+
+        set_test_current_identity(11, 1);
+        state.write_cval(0x2222);
+        state.write_ctl(CNTP_CTL_ENABLE);
+
+        set_test_current_identity(11, 0);
+        assert_eq!(state.read_cval(), 0x1111);
+        assert_eq!(state.read_ctl() & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK), 0x3);
+
+        set_test_current_identity(11, 1);
+        assert_eq!(state.read_cval(), 0x2222);
+        assert_eq!(state.read_ctl() & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK), 0x1);
+    }
+
+    #[test]
+    fn resolves_ppi30_delivery_target_from_each_vcpu_bank() {
+        let state = CntpTimerState::new();
+
+        set_test_current_identity(11, 0);
+        state.write_cval(0);
+        state.write_ctl(CNTP_CTL_ENABLE);
+        let vcpu0_target = state.current_fire_target_for_test();
+
+        set_test_current_identity(11, 1);
+        state.write_cval(0);
+        state.write_ctl(CNTP_CTL_ENABLE);
+        let vcpu1_target = state.current_fire_target_for_test();
+
+        assert_eq!(vcpu0_target, Some((11, 0, CNTP_PPI)));
+        assert_eq!(vcpu1_target, Some((11, 1, CNTP_PPI)));
+
+        set_test_current_identity(11, 0);
+        state.write_ctl(CNTP_CTL_ENABLE | CNTP_CTL_IMASK);
+        assert_eq!(state.current_fire_target_for_test(), None);
+
+        set_test_current_identity(11, 1);
+        assert_eq!(
+            state.current_fire_target_for_test(),
+            Some((11, 1, CNTP_PPI))
+        );
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
@@ -16,7 +16,9 @@ use crate::host;
 const CNTP_CTL_ENABLE: u32 = 1 << 0;
 const CNTP_CTL_IMASK: u32 = 1 << 1;
 const CNTP_CTL_ISTATUS: u32 = 1 << 2;
+#[cfg(any(test, target_arch = "aarch64"))]
 const CNTP_PPI: u8 = 30;
+#[cfg(any(test, target_arch = "aarch64"))]
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 const TIMER_TOKEN_NONE: usize = usize::MAX;
 
@@ -25,7 +27,9 @@ pub(super) struct CntpTimerState {
 }
 
 struct CntpTimerBank {
+    #[cfg(any(test, target_arch = "aarch64"))]
     vm_id: usize,
+    #[cfg(any(test, target_arch = "aarch64"))]
     vcpu_id: usize,
     cval: AtomicU64,
     ctl: AtomicU32,
@@ -97,8 +101,13 @@ fn lock_timer_banks(
 
 impl CntpTimerBank {
     const fn new(vm_id: usize, vcpu_id: usize) -> Self {
+        #[cfg(not(any(test, target_arch = "aarch64")))]
+        let _ = (vm_id, vcpu_id);
+
         Self {
+            #[cfg(any(test, target_arch = "aarch64"))]
             vm_id,
+            #[cfg(any(test, target_arch = "aarch64"))]
             vcpu_id,
             cval: AtomicU64::new(0),
             ctl: AtomicU32::new(0),
@@ -209,6 +218,7 @@ impl CntpTimerBank {
         host::queue_virtual_interrupt(self.vm_id, self.vcpu_id, CNTP_PPI);
     }
 
+    #[cfg(test)]
     fn fire_target(&self, expected_generation: u64) -> Option<(usize, usize, u8)> {
         if !self.is_armed_for(expected_generation)
             || counter_ticks() < self.cval.load(Ordering::Acquire)
@@ -218,6 +228,7 @@ impl CntpTimerBank {
         Some((self.vm_id, self.vcpu_id, CNTP_PPI))
     }
 
+    #[cfg(any(test, target_arch = "aarch64"))]
     fn is_armed_for(&self, expected_generation: u64) -> bool {
         if self.generation.load(Ordering::Acquire) != expected_generation {
             return false;
@@ -282,11 +293,7 @@ fn counter_frequency_hz() -> u64 {
     value
 }
 
-#[cfg(not(target_arch = "aarch64"))]
-fn counter_frequency_hz() -> u64 {
-    NANOS_PER_SECOND
-}
-
+#[cfg(any(test, target_arch = "aarch64"))]
 fn ticks_to_nanos_ceil(ticks: u64, frequency_hz: u64) -> u64 {
     if ticks == 0 {
         return 0;

--- a/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
@@ -1,0 +1,200 @@
+#[cfg(target_arch = "aarch64")]
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering};
+#[cfg(target_arch = "aarch64")]
+use core::{arch::asm, time::Duration};
+
+#[cfg(target_arch = "aarch64")]
+use crate::host;
+
+const CNTP_CTL_ENABLE: u32 = 1 << 0;
+const CNTP_CTL_IMASK: u32 = 1 << 1;
+const CNTP_CTL_ISTATUS: u32 = 1 << 2;
+const CNTP_PPI: u8 = 30;
+const NANOS_PER_SECOND: u64 = 1_000_000_000;
+const TIMER_TOKEN_NONE: usize = usize::MAX;
+
+pub(super) struct CntpTimerState {
+    cval: AtomicU64,
+    ctl: AtomicU32,
+    generation: AtomicU64,
+    timer_token: AtomicUsize,
+}
+
+impl CntpTimerState {
+    pub(super) const fn new() -> Self {
+        Self {
+            cval: AtomicU64::new(0),
+            ctl: AtomicU32::new(0),
+            generation: AtomicU64::new(0),
+            timer_token: AtomicUsize::new(TIMER_TOKEN_NONE),
+        }
+    }
+
+    pub(super) fn read_cval(&self) -> u64 {
+        self.cval.load(Ordering::Acquire)
+    }
+
+    pub(super) fn write_cval(self: &Arc<Self>, value: u64) {
+        self.cval.store(value, Ordering::Release);
+        self.rearm();
+    }
+
+    pub(super) fn read_ctl(&self) -> u32 {
+        let ctl = self.ctl.load(Ordering::Acquire);
+        let expired =
+            ctl & CNTP_CTL_ENABLE != 0 && counter_ticks() >= self.cval.load(Ordering::Acquire);
+
+        if expired {
+            ctl | CNTP_CTL_ISTATUS
+        } else {
+            ctl & !CNTP_CTL_ISTATUS
+        }
+    }
+
+    pub(super) fn write_ctl(self: &Arc<Self>, value: u32) {
+        self.ctl.store(
+            value & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK),
+            Ordering::Release,
+        );
+        self.rearm();
+    }
+
+    pub(super) fn read_tval(&self) -> u32 {
+        self.cval
+            .load(Ordering::Acquire)
+            .wrapping_sub(counter_ticks()) as u32
+    }
+
+    pub(super) fn write_tval(self: &Arc<Self>, value: u32) {
+        let delta = value as i32 as i64;
+        let now = counter_ticks();
+        let cval = if delta >= 0 {
+            now.wrapping_add(delta as u64)
+        } else {
+            now.wrapping_sub(delta.unsigned_abs())
+        };
+
+        self.cval.store(cval, Ordering::Release);
+        self.rearm();
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn rearm(self: &Arc<Self>) {
+        let generation = self
+            .generation
+            .fetch_add(1, Ordering::AcqRel)
+            .wrapping_add(1);
+        self.cancel_pending_timer();
+        let ctl = self.ctl.load(Ordering::Acquire);
+        if ctl & CNTP_CTL_ENABLE == 0 || ctl & CNTP_CTL_IMASK != 0 {
+            return;
+        }
+
+        let now_ticks = counter_ticks();
+        let deadline_ticks = self.cval.load(Ordering::Acquire);
+        let delay_ticks = deadline_ticks.saturating_sub(now_ticks);
+        let delay_ns = ticks_to_nanos_ceil(delay_ticks, counter_frequency_hz());
+        let deadline_ns = host::current_time_nanos().saturating_add(delay_ns);
+        let state = Arc::clone(self);
+
+        let token = host::register_timer(
+            Duration::from_nanos(deadline_ns),
+            Box::new(move |_| state.fire(generation)),
+        );
+        self.timer_token.store(token, Ordering::Release);
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    fn rearm(self: &Arc<Self>) {
+        self.generation.fetch_add(1, Ordering::AcqRel);
+        self.timer_token.store(TIMER_TOKEN_NONE, Ordering::Release);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn cancel_pending_timer(&self) {
+        let token = self.timer_token.swap(TIMER_TOKEN_NONE, Ordering::AcqRel);
+        if token != TIMER_TOKEN_NONE {
+            host::cancel_timer(token);
+        }
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn fire(self: &Arc<Self>, expected_generation: u64) {
+        if self.generation.load(Ordering::Acquire) != expected_generation {
+            return;
+        }
+
+        let ctl = self.ctl.load(Ordering::Acquire);
+        if ctl & CNTP_CTL_ENABLE == 0 || ctl & CNTP_CTL_IMASK != 0 {
+            return;
+        }
+
+        if counter_ticks() < self.cval.load(Ordering::Acquire) {
+            self.rearm();
+            return;
+        }
+
+        crate::api_reexp::hardware_inject_virtual_interrupt(CNTP_PPI);
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn counter_ticks() -> u64 {
+    let value: u64;
+
+    unsafe {
+        asm!("mrs {value}, CNTPCT_EL0", value = out(reg) value);
+    }
+    value
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn counter_ticks() -> u64 {
+    0
+}
+
+#[cfg(target_arch = "aarch64")]
+fn counter_frequency_hz() -> u64 {
+    let value: u64;
+
+    unsafe {
+        asm!("mrs {value}, CNTFRQ_EL0", value = out(reg) value);
+    }
+    value
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn counter_frequency_hz() -> u64 {
+    NANOS_PER_SECOND
+}
+
+fn ticks_to_nanos_ceil(ticks: u64, frequency_hz: u64) -> u64 {
+    if ticks == 0 {
+        return 0;
+    }
+
+    let frequency_hz = frequency_hz.max(1);
+    let numerator = u128::from(ticks) * u128::from(NANOS_PER_SECOND) + u128::from(frequency_hz - 1);
+    let nanos = numerator / u128::from(frequency_hz);
+
+    nanos.min(u128::from(u64::MAX)) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn converts_counter_ticks_with_ceiling() {
+        assert_eq!(ticks_to_nanos_ceil(0, 100), 0);
+        assert_eq!(ticks_to_nanos_ceil(1, 3), 333_333_334);
+        assert_eq!(ticks_to_nanos_ceil(24_000, 24_000_000), 1_000_000);
+    }
+
+    #[test]
+    fn clamps_zero_frequency() {
+        assert_eq!(ticks_to_nanos_ceil(1, 0), NANOS_PER_SECOND);
+    }
+}

--- a/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
@@ -21,11 +21,14 @@ const CNTP_PPI: u8 = 30;
 #[cfg(any(test, target_arch = "aarch64"))]
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 const TIMER_TOKEN_NONE: usize = usize::MAX;
+const TIMER_REMAINING_NONE: u64 = u64::MAX;
 
 pub struct CntpTimerState {
     banks: TimerBankLock<BTreeMap<(usize, usize), Arc<CntpTimerBank>>>,
     #[cfg(test)]
     test_identity: TimerBankLock<(usize, usize)>,
+    #[cfg(test)]
+    test_counter_ticks: AtomicU64,
 }
 
 struct CntpTimerBank {
@@ -37,6 +40,10 @@ struct CntpTimerBank {
     ctl: AtomicU32,
     generation: AtomicU64,
     timer_token: AtomicUsize,
+    suspended_remaining_ticks: AtomicU64,
+    lifecycle: TimerBankLock<()>,
+    #[cfg(test)]
+    test_counter_ticks: AtomicU64,
 }
 
 impl CntpTimerState {
@@ -45,6 +52,8 @@ impl CntpTimerState {
             banks: TimerBankLock::new(BTreeMap::new()),
             #[cfg(test)]
             test_identity: TimerBankLock::new((0, 0)),
+            #[cfg(test)]
+            test_counter_ticks: AtomicU64::new(0),
         }
     }
 
@@ -88,18 +97,21 @@ impl CntpTimerState {
 
     pub fn resume(&self) {
         for bank in self.snapshot_banks() {
-            bank.rearm();
+            bank.resume();
         }
     }
 
     fn current_bank(&self) -> Arc<CntpTimerBank> {
         let (vm_id, vcpu_id) = self.current_timer_identity();
+        #[cfg(test)]
+        let test_counter_ticks = self.test_counter_ticks.load(Ordering::Acquire);
         let mut banks = lock_timer_banks(&self.banks);
-        Arc::clone(
-            banks
-                .entry((vm_id, vcpu_id))
-                .or_insert_with(|| Arc::new(CntpTimerBank::new(vm_id, vcpu_id))),
-        )
+        Arc::clone(banks.entry((vm_id, vcpu_id)).or_insert_with(|| {
+            let bank = Arc::new(CntpTimerBank::new(vm_id, vcpu_id));
+            #[cfg(test)]
+            bank.set_test_counter_ticks(test_counter_ticks);
+            bank
+        }))
     }
 
     fn snapshot_banks(&self) -> alloc::vec::Vec<Arc<CntpTimerBank>> {
@@ -125,6 +137,14 @@ impl CntpTimerState {
     pub(super) fn current_fire_target_for_test(&self) -> Option<(usize, usize, u8)> {
         let bank = self.current_bank();
         bank.fire_target(bank.generation.load(Ordering::Acquire))
+    }
+
+    #[cfg(test)]
+    pub(super) fn set_test_counter_ticks(&self, ticks: u64) {
+        self.test_counter_ticks.store(ticks, Ordering::Release);
+        for bank in self.snapshot_banks() {
+            bank.set_test_counter_ticks(ticks);
+        }
     }
 }
 
@@ -157,8 +177,18 @@ fn lock_test_identity(
         .expect("CNTP timer test identity lock poisoned")
 }
 
+#[cfg(test)]
+fn lock_timer_bank(bank: &TimerBankLock<()>) -> TimerBankLockGuard<'_, ()> {
+    bank.lock().expect("CNTP timer test bank lock poisoned")
+}
+
+#[cfg(not(test))]
+fn lock_timer_bank(bank: &TimerBankLock<()>) -> TimerBankLockGuard<'_, ()> {
+    bank.lock()
+}
+
 impl CntpTimerBank {
-    const fn new(vm_id: usize, vcpu_id: usize) -> Self {
+    fn new(vm_id: usize, vcpu_id: usize) -> Self {
         #[cfg(not(any(test, target_arch = "aarch64")))]
         let _ = (vm_id, vcpu_id);
 
@@ -171,6 +201,10 @@ impl CntpTimerBank {
             ctl: AtomicU32::new(0),
             generation: AtomicU64::new(0),
             timer_token: AtomicUsize::new(TIMER_TOKEN_NONE),
+            suspended_remaining_ticks: AtomicU64::new(TIMER_REMAINING_NONE),
+            lifecycle: TimerBankLock::new(()),
+            #[cfg(test)]
+            test_counter_ticks: AtomicU64::new(0),
         }
     }
 
@@ -179,14 +213,17 @@ impl CntpTimerBank {
     }
 
     fn write_cval(self: &Arc<Self>, value: u64) {
+        let _guard = lock_timer_bank(&self.lifecycle);
+        self.suspended_remaining_ticks
+            .store(TIMER_REMAINING_NONE, Ordering::Release);
         self.cval.store(value, Ordering::Release);
-        self.rearm();
+        self.rearm_locked();
     }
 
     fn read_ctl(&self) -> u32 {
         let ctl = self.ctl.load(Ordering::Acquire);
         let expired =
-            ctl & CNTP_CTL_ENABLE != 0 && counter_ticks() >= self.cval.load(Ordering::Acquire);
+            ctl & CNTP_CTL_ENABLE != 0 && self.counter_ticks() >= self.cval.load(Ordering::Acquire);
 
         if expired {
             ctl | CNTP_CTL_ISTATUS
@@ -196,45 +233,51 @@ impl CntpTimerBank {
     }
 
     fn write_ctl(self: &Arc<Self>, value: u32) {
+        let _guard = lock_timer_bank(&self.lifecycle);
+        self.suspended_remaining_ticks
+            .store(TIMER_REMAINING_NONE, Ordering::Release);
         self.ctl.store(
             value & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK),
             Ordering::Release,
         );
-        self.rearm();
+        self.rearm_locked();
     }
 
     fn read_tval(&self) -> u32 {
         self.cval
             .load(Ordering::Acquire)
-            .wrapping_sub(counter_ticks()) as u32
+            .wrapping_sub(self.counter_ticks()) as u32
     }
 
     fn write_tval(self: &Arc<Self>, value: u32) {
+        let _guard = lock_timer_bank(&self.lifecycle);
         let delta = value as i32 as i64;
-        let now = counter_ticks();
+        let now = self.counter_ticks();
         let cval = if delta >= 0 {
             now.wrapping_add(delta as u64)
         } else {
             now.wrapping_sub(delta.unsigned_abs())
         };
 
+        self.suspended_remaining_ticks
+            .store(TIMER_REMAINING_NONE, Ordering::Release);
         self.cval.store(cval, Ordering::Release);
-        self.rearm();
+        self.rearm_locked();
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn rearm(self: &Arc<Self>) {
+    fn rearm_locked(self: &Arc<Self>) {
         let generation = self
             .generation
             .fetch_add(1, Ordering::AcqRel)
             .wrapping_add(1);
-        self.cancel_pending_timer();
+        self.cancel_pending_timer_locked();
         let ctl = self.ctl.load(Ordering::Acquire);
         if ctl & CNTP_CTL_ENABLE == 0 || ctl & CNTP_CTL_IMASK != 0 {
             return;
         }
 
-        let now_ticks = counter_ticks();
+        let now_ticks = self.counter_ticks();
         let deadline_ticks = self.cval.load(Ordering::Acquire);
         let delay_ticks = deadline_ticks.saturating_sub(now_ticks);
         let delay_ns = ticks_to_nanos_ceil(delay_ticks, counter_frequency_hz());
@@ -249,13 +292,13 @@ impl CntpTimerBank {
     }
 
     #[cfg(not(target_arch = "aarch64"))]
-    fn rearm(self: &Arc<Self>) {
+    fn rearm_locked(self: &Arc<Self>) {
         self.generation.fetch_add(1, Ordering::AcqRel);
         self.timer_token.store(TIMER_TOKEN_NONE, Ordering::Release);
     }
 
     #[cfg(target_arch = "aarch64")]
-    fn cancel_pending_timer(&self) {
+    fn cancel_pending_timer_locked(&self) {
         let token = self.timer_token.swap(TIMER_TOKEN_NONE, Ordering::AcqRel);
         if token != TIMER_TOKEN_NONE {
             host::cancel_timer(token);
@@ -263,31 +306,60 @@ impl CntpTimerBank {
     }
 
     #[cfg(not(target_arch = "aarch64"))]
-    fn cancel_pending_timer(&self) {
+    fn cancel_pending_timer_locked(&self) {
         self.timer_token.store(TIMER_TOKEN_NONE, Ordering::Release);
     }
 
     fn reset(&self) {
+        let _guard = lock_timer_bank(&self.lifecycle);
         self.generation.fetch_add(1, Ordering::AcqRel);
         self.ctl.store(0, Ordering::Release);
         self.cval.store(0, Ordering::Release);
-        self.cancel_pending_timer();
+        self.suspended_remaining_ticks
+            .store(TIMER_REMAINING_NONE, Ordering::Release);
+        self.cancel_pending_timer_locked();
     }
 
     fn suspend(&self) {
+        let _guard = lock_timer_bank(&self.lifecycle);
         self.generation.fetch_add(1, Ordering::AcqRel);
-        self.cancel_pending_timer();
+        let ctl = self.ctl.load(Ordering::Acquire);
+        let remaining_ticks = if ctl & CNTP_CTL_ENABLE != 0 {
+            self.cval
+                .load(Ordering::Acquire)
+                .saturating_sub(self.counter_ticks())
+        } else {
+            TIMER_REMAINING_NONE
+        };
+        self.suspended_remaining_ticks
+            .store(remaining_ticks, Ordering::Release);
+        self.cancel_pending_timer_locked();
+    }
+
+    fn resume(self: &Arc<Self>) {
+        let _guard = lock_timer_bank(&self.lifecycle);
+        let remaining_ticks = self
+            .suspended_remaining_ticks
+            .swap(TIMER_REMAINING_NONE, Ordering::AcqRel);
+        if remaining_ticks != TIMER_REMAINING_NONE {
+            self.cval.store(
+                self.counter_ticks().saturating_add(remaining_ticks),
+                Ordering::Release,
+            );
+        }
+        self.rearm_locked();
     }
 
     #[cfg(target_arch = "aarch64")]
     fn fire(self: &Arc<Self>, expected_generation: u64) {
+        let _guard = lock_timer_bank(&self.lifecycle);
         if !self.is_armed_for(expected_generation) {
             return;
         }
 
-        if counter_ticks() < self.cval.load(Ordering::Acquire) {
+        if self.counter_ticks() < self.cval.load(Ordering::Acquire) {
             if self.is_armed_for(expected_generation) {
-                self.rearm();
+                self.rearm_locked();
             }
             return;
         }
@@ -300,8 +372,9 @@ impl CntpTimerBank {
 
     #[cfg(test)]
     fn fire_target(&self, expected_generation: u64) -> Option<(usize, usize, u8)> {
+        let _guard = lock_timer_bank(&self.lifecycle);
         if !self.is_armed_for(expected_generation)
-            || counter_ticks() < self.cval.load(Ordering::Acquire)
+            || self.counter_ticks() < self.cval.load(Ordering::Acquire)
         {
             return None;
         }
@@ -316,6 +389,26 @@ impl CntpTimerBank {
 
         let ctl = self.ctl.load(Ordering::Acquire);
         ctl & CNTP_CTL_ENABLE != 0 && ctl & CNTP_CTL_IMASK == 0
+    }
+
+    fn counter_ticks(&self) -> u64 {
+        #[cfg(test)]
+        {
+            self.test_counter_ticks.load(Ordering::Acquire)
+        }
+        #[cfg(all(not(test), target_arch = "aarch64"))]
+        {
+            counter_ticks()
+        }
+        #[cfg(all(not(test), not(target_arch = "aarch64")))]
+        {
+            0
+        }
+    }
+
+    #[cfg(test)]
+    fn set_test_counter_ticks(&self, ticks: u64) {
+        self.test_counter_ticks.store(ticks, Ordering::Release);
     }
 }
 
@@ -337,11 +430,6 @@ fn counter_ticks() -> u64 {
         asm!("mrs {value}, CNTPCT_EL0", value = out(reg) value);
     }
     value
-}
-
-#[cfg(not(target_arch = "aarch64"))]
-fn counter_ticks() -> u64 {
-    0
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -456,6 +544,39 @@ mod tests {
         state.set_test_current_identity(11, 0);
         assert_eq!(state.read_cval(), 0);
         assert_eq!(state.read_ctl() & (CNTP_CTL_ENABLE | CNTP_CTL_IMASK), 0);
+    }
+
+    #[test]
+    fn suspend_resume_preserves_remaining_ticks_for_enabled_bank() {
+        let state = CntpTimerState::new();
+
+        state.set_test_current_identity(11, 0);
+        state.set_test_counter_ticks(100);
+        state.write_cval(1_100);
+        state.write_ctl(CNTP_CTL_ENABLE);
+        assert_eq!(state.read_tval(), 1_000);
+        assert_eq!(state.current_fire_target_for_test(), None);
+
+        let bank = state.current_bank();
+        let generation = bank.generation.load(Ordering::Acquire);
+        state.set_test_counter_ticks(700);
+        state.suspend();
+
+        assert_eq!(bank.fire_target(generation), None);
+        assert_eq!(state.read_tval(), 400);
+
+        state.set_test_counter_ticks(5_000);
+        state.resume();
+
+        assert_eq!(state.read_cval(), 5_400);
+        assert_eq!(state.read_tval(), 400);
+        assert_eq!(state.current_fire_target_for_test(), None);
+
+        state.set_test_counter_ticks(5_400);
+        assert_eq!(
+            state.current_fire_target_for_test(),
+            Some((11, 0, CNTP_PPI))
+        );
     }
 
     #[test]

--- a/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_timer.rs
@@ -14,12 +14,18 @@ const CNTP_CTL_ISTATUS: u32 = 1 << 2;
 const CNTP_PPI: u8 = 30;
 const NANOS_PER_SECOND: u64 = 1_000_000_000;
 const TIMER_TOKEN_NONE: usize = usize::MAX;
+#[cfg(target_arch = "aarch64")]
+const TARGET_NONE: usize = usize::MAX;
 
 pub(super) struct CntpTimerState {
     cval: AtomicU64,
     ctl: AtomicU32,
     generation: AtomicU64,
     timer_token: AtomicUsize,
+    #[cfg(target_arch = "aarch64")]
+    target_vm_id: AtomicUsize,
+    #[cfg(target_arch = "aarch64")]
+    target_vcpu_id: AtomicUsize,
 }
 
 impl CntpTimerState {
@@ -29,6 +35,10 @@ impl CntpTimerState {
             ctl: AtomicU32::new(0),
             generation: AtomicU64::new(0),
             timer_token: AtomicUsize::new(TIMER_TOKEN_NONE),
+            #[cfg(target_arch = "aarch64")]
+            target_vm_id: AtomicUsize::new(TARGET_NONE),
+            #[cfg(target_arch = "aarch64")]
+            target_vcpu_id: AtomicUsize::new(TARGET_NONE),
         }
     }
 
@@ -82,6 +92,20 @@ impl CntpTimerState {
 
     #[cfg(target_arch = "aarch64")]
     fn rearm(self: &Arc<Self>) {
+        self.rearm_with_target(Some((host::current_vm_id(), host::current_vcpu_id())));
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn rearm_existing_target(self: &Arc<Self>) {
+        self.rearm_with_target(None);
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn rearm_with_target(self: &Arc<Self>, target: Option<(usize, usize)>) {
+        if let Some((vm_id, vcpu_id)) = target {
+            self.target_vm_id.store(vm_id, Ordering::Release);
+            self.target_vcpu_id.store(vcpu_id, Ordering::Release);
+        }
         let generation = self
             .generation
             .fetch_add(1, Ordering::AcqRel)
@@ -89,6 +113,12 @@ impl CntpTimerState {
         self.cancel_pending_timer();
         let ctl = self.ctl.load(Ordering::Acquire);
         if ctl & CNTP_CTL_ENABLE == 0 || ctl & CNTP_CTL_IMASK != 0 {
+            return;
+        }
+
+        let target_vm_id = self.target_vm_id.load(Ordering::Acquire);
+        let target_vcpu_id = self.target_vcpu_id.load(Ordering::Acquire);
+        if target_vm_id == TARGET_NONE || target_vcpu_id == TARGET_NONE {
             return;
         }
 
@@ -132,11 +162,16 @@ impl CntpTimerState {
         }
 
         if counter_ticks() < self.cval.load(Ordering::Acquire) {
-            self.rearm();
+            self.rearm_existing_target();
             return;
         }
 
-        crate::api_reexp::hardware_inject_virtual_interrupt(CNTP_PPI);
+        let target_vm_id = self.target_vm_id.load(Ordering::Acquire);
+        let target_vcpu_id = self.target_vcpu_id.load(Ordering::Acquire);
+        if target_vm_id == TARGET_NONE || target_vcpu_id == TARGET_NONE {
+            return;
+        }
+        host::queue_virtual_interrupt(target_vm_id, target_vcpu_id, CNTP_PPI);
     }
 }
 

--- a/virtualization/arm_vgic/src/vtimer/cntp_tval_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_tval_el0.rs
@@ -18,38 +18,24 @@ use alloc::sync::Arc;
 
 use aarch64_sysreg::SystemRegType;
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, DeviceAddrRange, DeviceResult, EmuDeviceType, SysRegAddr,
-    SysRegAddrRange,
+    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DeviceResult,
+    Resource,
 };
+use log::debug;
 
 use super::cntp_timer::CntpTimerState;
 
-impl BaseDeviceOps<SysRegAddrRange> for SysCntpTvalEl0 {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::Console
-    }
+const CNTP_TVAL_EL0_ADDR: u32 = SystemRegType::CNTP_TVAL_EL0 as u32;
 
-    fn address_range(&self) -> SysRegAddrRange {
-        SysRegAddrRange {
-            start: SysRegAddr::new(SystemRegType::CNTP_TVAL_EL0 as usize),
-            end: SysRegAddr::new(SystemRegType::CNTP_TVAL_EL0 as usize),
-        }
-    }
-
-    fn handle_read(
-        &self,
-        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
-        _width: AccessWidth,
-    ) -> DeviceResult<usize> {
+impl SysCntpTvalEl0 {
+    /// Reads CNTP_TVAL_EL0.
+    pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
         Ok(self.state.read_tval() as usize)
     }
 
-    fn handle_write(
-        &self,
-        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
-        _width: AccessWidth,
-        val: usize,
-    ) -> DeviceResult {
+    /// Writes CNTP_TVAL_EL0.
+    pub fn write_register(&self, _width: AccessWidth, val: usize) -> DeviceResult {
+        debug!("Write to virtual timer register CNTP_TVAL_EL0, value: {val}");
         self.state.write_tval(val as u32);
         Ok(())
     }
@@ -60,6 +46,7 @@ impl BaseDeviceOps<SysRegAddrRange> for SysCntpTvalEl0 {
 /// Provides virtualization support for the physical timer value register.
 pub struct SysCntpTvalEl0 {
     state: Arc<CntpTimerState>,
+    resources: [Resource; 1],
 }
 
 impl SysCntpTvalEl0 {
@@ -69,12 +56,47 @@ impl SysCntpTvalEl0 {
     }
 
     pub(super) fn from_state(state: Arc<CntpTimerState>) -> Self {
-        Self { state }
+        Self {
+            state,
+            resources: [Resource::SysReg {
+                addr: CNTP_TVAL_EL0_ADDR,
+                count: 1,
+            }],
+        }
     }
 }
 
 impl Default for SysCntpTvalEl0 {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Device for SysCntpTvalEl0 {
+    fn name(&self) -> &str {
+        "aarch64-cntp-tval-el0"
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn access(
+        &self,
+        access: &BusAccess,
+        _context: &mut dyn DeviceAccess,
+    ) -> Result<BusResponse, DeviceError> {
+        if access.kind != BusKind::SysReg || access.addr != CNTP_TVAL_EL0_ADDR as u64 {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        if access.is_read {
+            self.read_register(access.width)
+                .map(|value| BusResponse::Read {
+                    value: value as u64,
+                })
+        } else {
+            self.write_register(access.width, access.data as usize)
+                .map(|_| BusResponse::Write)
+        }
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/cntpct_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntpct_el0.rs
@@ -12,30 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate alloc;
-
-use alloc::sync::Arc;
-
+use aarch64_cpu::registers::{CNTPCT_EL0, Readable};
 use aarch64_sysreg::SystemRegType;
 use axdevice_base::{
-    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DeviceResult,
-    Resource,
+    AccessWidth, BaseDeviceOps, DeviceAddrRange, DeviceResult, EmuDeviceType, SysRegAddr,
+    SysRegAddrRange,
 };
-use log::debug;
+use log::info;
 
-use crate::vtimer::VtimerBackend;
-
-const CNTPCT_EL0_ADDR: u32 = SystemRegType::CNTPCT_EL0 as u32;
-
-impl SysCntpctEl0 {
-    /// Reads CNTPCT_EL0.
-    pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
-        Ok(self.backend.current_time_nanos() as usize)
+impl BaseDeviceOps<SysRegAddrRange> for SysCntpctEl0 {
+    fn emu_type(&self) -> EmuDeviceType {
+        EmuDeviceType::Console
     }
 
-    /// Ignores guest writes to the read-only CNTPCT_EL0 register.
-    pub fn write_register(&self, _width: AccessWidth, val: usize) -> DeviceResult {
-        debug!("Write to read-only virtual counter register CNTPCT_EL0, value: {val}");
+    fn address_range(&self) -> SysRegAddrRange {
+        SysRegAddrRange {
+            start: SysRegAddr::new(SystemRegType::CNTPCT_EL0 as usize),
+            end: SysRegAddr::new(SystemRegType::CNTPCT_EL0 as usize),
+        }
+    }
+
+    fn handle_read(
+        &self,
+        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
+        _width: AccessWidth,
+    ) -> DeviceResult<usize> {
+        Ok(CNTPCT_EL0.get() as usize)
+    }
+
+    fn handle_write(
+        &self,
+        addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
+        _width: AccessWidth,
+        val: usize,
+    ) -> DeviceResult {
+        info!("Write to emulator register: {addr:?}, value: {val}");
         Ok(())
     }
 }
@@ -43,49 +54,16 @@ impl SysCntpctEl0 {
 /// System register emulation for CNTPCT_EL0.
 ///
 /// Provides virtualization support for the physical counter register.
+#[derive(Default)]
 pub struct SysCntpctEl0 {
-    backend: Arc<dyn VtimerBackend>,
-    resources: [Resource; 1],
+    // Fields
 }
 
 impl SysCntpctEl0 {
     /// Creates a new CNTPCT_EL0 register emulator.
-    pub fn new(backend: Arc<dyn VtimerBackend>) -> Self {
+    pub fn new() -> Self {
         Self {
-            backend,
-            resources: [Resource::SysReg {
-                addr: CNTPCT_EL0_ADDR,
-                count: 1,
-            }],
-        }
-    }
-}
-
-impl Device for SysCntpctEl0 {
-    fn name(&self) -> &str {
-        "aarch64-cntpct-el0"
-    }
-
-    fn resources(&self) -> &[Resource] {
-        &self.resources
-    }
-
-    fn access(
-        &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::SysReg || access.addr != CNTPCT_EL0_ADDR as u64 {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
-        }
-        if access.is_read {
-            self.read_register(access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-        } else {
-            self.write_register(access.width, access.data as usize)
-                .map(|_| BusResponse::Write)
+            // Initialize fields
         }
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/cntpct_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntpct_el0.rs
@@ -15,38 +15,22 @@
 use aarch64_cpu::registers::{CNTPCT_EL0, Readable};
 use aarch64_sysreg::SystemRegType;
 use axdevice_base::{
-    AccessWidth, BaseDeviceOps, DeviceAddrRange, DeviceResult, EmuDeviceType, SysRegAddr,
-    SysRegAddrRange,
+    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DeviceResult,
+    Resource,
 };
-use log::info;
+use log::debug;
 
-impl BaseDeviceOps<SysRegAddrRange> for SysCntpctEl0 {
-    fn emu_type(&self) -> EmuDeviceType {
-        EmuDeviceType::Console
-    }
+const CNTPCT_EL0_ADDR: u32 = SystemRegType::CNTPCT_EL0 as u32;
 
-    fn address_range(&self) -> SysRegAddrRange {
-        SysRegAddrRange {
-            start: SysRegAddr::new(SystemRegType::CNTPCT_EL0 as usize),
-            end: SysRegAddr::new(SystemRegType::CNTPCT_EL0 as usize),
-        }
-    }
-
-    fn handle_read(
-        &self,
-        _addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
-        _width: AccessWidth,
-    ) -> DeviceResult<usize> {
+impl SysCntpctEl0 {
+    /// Reads CNTPCT_EL0.
+    pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
         Ok(CNTPCT_EL0.get() as usize)
     }
 
-    fn handle_write(
-        &self,
-        addr: <SysRegAddrRange as DeviceAddrRange>::Addr,
-        _width: AccessWidth,
-        val: usize,
-    ) -> DeviceResult {
-        info!("Write to emulator register: {addr:?}, value: {val}");
+    /// Ignores guest writes to the read-only CNTPCT_EL0 register.
+    pub fn write_register(&self, _width: AccessWidth, val: usize) -> DeviceResult {
+        debug!("Write to read-only virtual counter register CNTPCT_EL0, value: {val}");
         Ok(())
     }
 }
@@ -54,16 +38,53 @@ impl BaseDeviceOps<SysRegAddrRange> for SysCntpctEl0 {
 /// System register emulation for CNTPCT_EL0.
 ///
 /// Provides virtualization support for the physical counter register.
-#[derive(Default)]
 pub struct SysCntpctEl0 {
-    // Fields
+    resources: [Resource; 1],
 }
 
 impl SysCntpctEl0 {
     /// Creates a new CNTPCT_EL0 register emulator.
     pub fn new() -> Self {
         Self {
-            // Initialize fields
+            resources: [Resource::SysReg {
+                addr: CNTPCT_EL0_ADDR,
+                count: 1,
+            }],
+        }
+    }
+}
+
+impl Default for SysCntpctEl0 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Device for SysCntpctEl0 {
+    fn name(&self) -> &str {
+        "aarch64-cntpct-el0"
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn access(
+        &self,
+        access: &BusAccess,
+        _context: &mut dyn DeviceAccess,
+    ) -> Result<BusResponse, DeviceError> {
+        if access.kind != BusKind::SysReg || access.addr != CNTPCT_EL0_ADDR as u64 {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        if access.is_read {
+            self.read_register(access.width)
+                .map(|value| BusResponse::Read {
+                    value: value as u64,
+                })
+        } else {
+            self.write_register(access.width, access.data as usize)
+                .map(|_| BusResponse::Write)
         }
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/mod.rs
+++ b/virtualization/arm_vgic/src/vtimer/mod.rs
@@ -14,13 +14,14 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
-use core::time::Duration;
+use alloc::{sync::Arc, vec, vec::Vec};
 
-use ax_kspin::SpinNoIrq;
-use axdevice_base::Device;
+use axdevice_base::BaseSysRegDeviceOps;
 
-use crate::host;
+mod cntp_timer;
+
+mod cntp_cval_el0;
+pub use cntp_cval_el0::SysCntpCvalEl0;
 
 mod cntp_ctl_el0;
 pub use cntp_ctl_el0::SysCntpCtlEl0;
@@ -31,468 +32,50 @@ pub use cntpct_el0::SysCntpctEl0;
 mod cntp_tval_el0;
 pub use cntp_tval_el0::SysCntpTvalEl0;
 
-/// The PPI used by the ARM physical virtual timer.
-pub const VIRTUAL_TIMER_IRQ: u8 = 30;
+/// Create the concrete system-register devices backed by one timer state.
+pub fn new_sysreg_devices() -> (SysCntpCvalEl0, SysCntpCtlEl0, SysCntpctEl0, SysCntpTvalEl0) {
+    let timer = Arc::new(cntp_timer::CntpTimerState::new());
 
-/// VM execution target captured when a guest programs its virtual timer.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct VtimerTarget {
-    vm_id: usize,
-    vcpu_id: usize,
-}
-
-impl VtimerTarget {
-    /// Creates a VM-local timer delivery target.
-    pub const fn new(vm_id: usize, vcpu_id: usize) -> Self {
-        Self { vm_id, vcpu_id }
-    }
-
-    /// Returns the owning VM ID.
-    pub const fn vm_id(self) -> usize {
-        self.vm_id
-    }
-
-    /// Returns the owning vCPU ID.
-    pub const fn vcpu_id(self) -> usize {
-        self.vcpu_id
-    }
-}
-
-/// Host operations used by one VM-local virtual timer instance.
-///
-/// The timer register devices keep all guest-visible state in [`VtimerState`]
-/// and use this narrow port only for time, scheduling and interrupt delivery.
-/// That keeps the register emulation testable and prevents it from reaching
-/// into a VM runtime directly.
-pub trait VtimerBackend: Send + Sync {
-    /// Returns the current monotonic time in nanoseconds.
-    fn current_time_nanos(&self) -> u64;
-
-    /// Schedules one callback and returns its cancellation token.
-    fn register_timer(
-        &self,
-        deadline: Duration,
-        callback: Box<dyn FnOnce(Duration) + Send + 'static>,
-    ) -> usize;
-
-    /// Cancels a callback that has not fired yet.
-    fn cancel_timer(&self, token: usize);
-
-    /// Captures the VM and vCPU that program a timer deadline.
-    fn current_target(&self) -> VtimerTarget;
-
-    /// Delivers a virtual interrupt to a previously captured VM vCPU.
-    fn inject_virtual_interrupt(&self, target: VtimerTarget, vector: u8);
-}
-
-/// Default backend that forwards timer operations to the ARM VGIC host port.
-///
-/// A separate value is created for every VM vtimer bundle.  The host callback
-/// still owns the CPU-local timer wheel and interrupt-entry mechanics.
-#[derive(Default)]
-pub struct HostVtimerBackend;
-
-impl VtimerBackend for HostVtimerBackend {
-    fn current_time_nanos(&self) -> u64 {
-        host::current_time_nanos()
-    }
-
-    fn register_timer(
-        &self,
-        deadline: Duration,
-        callback: Box<dyn FnOnce(Duration) + Send + 'static>,
-    ) -> usize {
-        host::register_timer(deadline, callback)
-    }
-
-    fn cancel_timer(&self, token: usize) {
-        host::cancel_timer(token);
-    }
-
-    fn current_target(&self) -> VtimerTarget {
-        VtimerTarget::new(host::current_vm_id(), host::current_vcpu_id())
-    }
-
-    fn inject_virtual_interrupt(&self, target: VtimerTarget, vector: u8) {
-        host::inject_vm_vcpu_interrupt(target.vm_id(), target.vcpu_id(), vector);
-    }
-}
-
-#[derive(Default)]
-struct VtimerRegisters {
-    control: u32,
-    deadline_ns: Option<u64>,
-    timer_token: Option<usize>,
-    expired: bool,
-    generation: u64,
-    target: Option<VtimerTarget>,
-    suspended_remaining_ns: Option<u64>,
-}
-
-/// Shared guest-visible state for the CNT* register devices of one VM.
-pub struct VtimerState {
-    registers: SpinNoIrq<VtimerRegisters>,
-}
-
-impl VtimerState {
-    /// Creates a stopped virtual timer.
-    pub fn new() -> Self {
-        Self {
-            registers: SpinNoIrq::new(VtimerRegisters::default()),
-        }
-    }
-
-    /// Returns the current CNTP_CTL_EL0 value, including the computed status bit.
-    pub fn control(&self, now_ns: u64) -> u32 {
-        let registers = self.registers.lock();
-        let expired = registers.expired
-            || registers
-                .deadline_ns
-                .is_some_and(|deadline| deadline <= now_ns);
-        (registers.control & 0b11) | (u32::from(expired) << 2)
-    }
-
-    /// Updates the writable CNTP_CTL_EL0 enable and mask bits.
-    pub fn write_control(&self, value: u32, backend: &dyn VtimerBackend) {
-        let inject = {
-            let mut registers = self.registers.lock();
-            registers.control = value & 0b11;
-            (registers.expired && Self::interrupt_enabled(&registers)).then_some(registers.target)
-        };
-        if let Some(Some(target)) = inject {
-            backend.inject_virtual_interrupt(target, VIRTUAL_TIMER_IRQ);
-        }
-    }
-
-    /// Returns the remaining timer value in nanoseconds.
-    pub fn timer_value(&self, now_ns: u64) -> u64 {
-        self.registers
-            .lock()
-            .deadline_ns
-            .map(|deadline| deadline.saturating_sub(now_ns))
-            .unwrap_or(0)
-    }
-
-    /// Starts (or restarts) the timer with a relative value in nanoseconds.
-    pub fn write_timer_value(self: &Arc<Self>, value_ns: u64, backend: Arc<dyn VtimerBackend>) {
-        let target = backend.current_target();
-        self.schedule_timer_value(value_ns, target, backend);
-    }
-
-    fn schedule_timer_value(
-        self: &Arc<Self>,
-        value_ns: u64,
-        target: VtimerTarget,
-        backend: Arc<dyn VtimerBackend>,
-    ) {
-        let now_ns = backend.current_time_nanos();
-        let deadline_ns = now_ns.saturating_add(value_ns);
-        let (previous_token, generation) = {
-            let mut registers = self.registers.lock();
-            registers.deadline_ns = Some(deadline_ns);
-            registers.expired = false;
-            registers.generation = registers.generation.wrapping_add(1);
-            registers.target = Some(target);
-            registers.suspended_remaining_ns = None;
-            (registers.timer_token.take(), registers.generation)
-        };
-        if let Some(token) = previous_token {
-            backend.cancel_timer(token);
-        }
-
-        let state = Arc::clone(self);
-        let callback_backend = Arc::clone(&backend);
-        let token = backend.register_timer(
-            Duration::from_nanos(deadline_ns),
-            Box::new(move |_| state.expire(generation, target, callback_backend)),
-        );
-        let mut registers = self.registers.lock();
-        if registers.generation == generation && !registers.expired {
-            registers.timer_token = Some(token);
-        }
-    }
-
-    /// Stops a pending host timer and preserves its remaining guest-visible time.
-    pub fn suspend(&self, backend: &dyn VtimerBackend) {
-        let now_ns = backend.current_time_nanos();
-        let token = {
-            let mut registers = self.registers.lock();
-            if !registers.expired && registers.suspended_remaining_ns.is_none() {
-                registers.suspended_remaining_ns = registers
-                    .deadline_ns
-                    .map(|deadline| deadline.saturating_sub(now_ns));
-            }
-            // A cancelled callback can race with this operation.  Invalidate it
-            // before releasing the lock, so a paused timer cannot expire.
-            registers.generation = registers.generation.wrapping_add(1);
-            registers.deadline_ns = None;
-            registers.timer_token.take()
-        };
-        if let Some(token) = token {
-            backend.cancel_timer(token);
-        }
-    }
-
-    /// Restarts a timer that was paused by [`Self::suspend`].
-    pub fn resume(self: &Arc<Self>, backend: Arc<dyn VtimerBackend>) {
-        let suspended = {
-            let mut registers = self.registers.lock();
-            registers
-                .suspended_remaining_ns
-                .take()
-                .and_then(|remaining| registers.target.map(|target| (remaining, target)))
-        };
-        if let Some((remaining, target)) = suspended {
-            self.schedule_timer_value(remaining, target, backend);
-        }
-    }
-
-    /// Cancels pending work and restores the timer's power-on state.
-    pub fn reset(&self, backend: &dyn VtimerBackend) {
-        let token = {
-            let mut registers = self.registers.lock();
-            let token = registers.timer_token.take();
-            // Cancellation is not a synchronization point with a callback
-            // already executing on another CPU.  Preserve a distinct
-            // generation across reset so that callback cannot affect a later
-            // re-armed timer.
-            let generation = registers.generation.wrapping_add(1);
-            *registers = VtimerRegisters::default();
-            registers.generation = generation;
-            token
-        };
-        if let Some(token) = token {
-            backend.cancel_timer(token);
-        }
-    }
-
-    fn expire(&self, generation: u64, target: VtimerTarget, backend: Arc<dyn VtimerBackend>) {
-        let inject = {
-            let mut registers = self.registers.lock();
-            if generation != registers.generation {
-                return;
-            }
-            registers.timer_token = None;
-            registers.expired = true;
-            Self::interrupt_enabled(&registers)
-        };
-        if inject {
-            backend.inject_virtual_interrupt(target, VIRTUAL_TIMER_IRQ);
-        }
-    }
-
-    fn interrupt_enabled(registers: &VtimerRegisters) -> bool {
-        registers.control & 0b11 == 0b1
-    }
-}
-
-impl Default for VtimerState {
-    fn default() -> Self {
-        Self::new()
-    }
+    (
+        SysCntpCvalEl0::from_state(Arc::clone(&timer)),
+        SysCntpCtlEl0::from_state(Arc::clone(&timer)),
+        SysCntpctEl0::new(),
+        SysCntpTvalEl0::from_state(timer),
+    )
 }
 
 /// Create a collection of system register devices.
-pub fn get_sysreg_device() -> Vec<Arc<dyn Device>> {
-    let backend: Arc<dyn VtimerBackend> = Arc::new(HostVtimerBackend);
-    let state = Arc::new(VtimerState::new());
+pub fn get_sysreg_device() -> Vec<Arc<dyn BaseSysRegDeviceOps>> {
+    let (cval, ctl, counter, tval) = new_sysreg_devices();
+
     vec![
-        Arc::new(SysCntpCtlEl0::new(Arc::clone(&state), Arc::clone(&backend))),
-        Arc::new(SysCntpctEl0::new(Arc::clone(&backend))),
-        Arc::new(SysCntpTvalEl0::new(state, backend)),
+        Arc::new(cval),
+        Arc::new(ctl),
+        Arc::new(counter),
+        Arc::new(tval),
     ]
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::{boxed::Box, sync::Arc, vec::Vec};
-    use core::{
-        sync::atomic::{AtomicUsize, Ordering},
-        time::Duration,
-    };
+    use aarch64_sysreg::SystemRegType;
+    use axdevice_base::{AccessWidth, BaseDeviceOps, SysRegAddr};
 
-    use ax_kspin::SpinNoIrq;
-
-    use super::{VIRTUAL_TIMER_IRQ, VtimerBackend, VtimerState, VtimerTarget};
-
-    struct TestBackend {
-        now_ns: u64,
-        current_target: SpinNoIrq<Option<VtimerTarget>>,
-        next_token: AtomicUsize,
-        cancelled: SpinNoIrq<Vec<usize>>,
-        injected: SpinNoIrq<Vec<(VtimerTarget, u8)>>,
-        timers: SpinNoIrq<Vec<TestTimer>>,
-    }
-
-    struct TestTimer {
-        token: usize,
-        callback: Option<Box<dyn FnOnce(Duration) + Send + 'static>>,
-    }
-
-    impl TestBackend {
-        fn new(now_ns: u64) -> Self {
-            Self {
-                now_ns,
-                current_target: SpinNoIrq::new(Some(VtimerTarget::new(7, 3))),
-                next_token: AtomicUsize::new(1),
-                cancelled: SpinNoIrq::new(Vec::new()),
-                injected: SpinNoIrq::new(Vec::new()),
-                timers: SpinNoIrq::new(Vec::new()),
-            }
-        }
-
-        fn set_current_target(&self, target: Option<VtimerTarget>) {
-            *self.current_target.lock() = target;
-        }
-
-        fn fire_timer(&self, token: usize) {
-            let callback = {
-                let mut timers = self.timers.lock();
-                timers
-                    .iter_mut()
-                    .find(|timer| timer.token == token)
-                    .and_then(|timer| timer.callback.take())
-            };
-            if let Some(callback) = callback {
-                callback(Duration::from_nanos(0));
-            }
-        }
-    }
-
-    impl VtimerBackend for TestBackend {
-        fn current_time_nanos(&self) -> u64 {
-            self.now_ns
-        }
-
-        fn register_timer(
-            &self,
-            _deadline: Duration,
-            callback: Box<dyn FnOnce(Duration) + Send + 'static>,
-        ) -> usize {
-            let token = self.next_token.fetch_add(1, Ordering::Relaxed);
-            self.timers.lock().push(TestTimer {
-                token,
-                callback: Some(callback),
-            });
-            token
-        }
-
-        fn cancel_timer(&self, token: usize) {
-            self.cancelled.lock().push(token);
-        }
-
-        fn current_target(&self) -> VtimerTarget {
-            self.current_target
-                .lock()
-                .expect("test backend has no current vCPU context")
-        }
-
-        fn inject_virtual_interrupt(&self, target: VtimerTarget, vector: u8) {
-            self.injected.lock().push((target, vector));
-        }
-    }
+    use super::*;
 
     #[test]
-    fn expired_timer_is_injected_when_enabled_and_unmasked() {
-        let concrete_backend = Arc::new(TestBackend::new(100));
-        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
-        let state = Arc::new(VtimerState::new());
-        state.write_control(1, backend.as_ref());
-        state.write_timer_value(20, Arc::clone(&backend));
-        state.expire(1, VtimerTarget::new(7, 3), Arc::clone(&backend));
+    fn concrete_devices_share_timer_state() {
+        let (cval, _ctl, _counter, tval) = new_sysreg_devices();
+        let cval_addr = SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize);
+        let tval_addr = SysRegAddr::new(SystemRegType::CNTP_TVAL_EL0 as usize);
+        let value = 0x1234_5678usize;
 
-        assert_eq!(state.control(120), 0b101);
+        cval.handle_write(cval_addr, AccessWidth::Qword, value)
+            .unwrap();
+
         assert_eq!(
-            *concrete_backend.injected.lock(),
-            [(VtimerTarget::new(7, 3), VIRTUAL_TIMER_IRQ)]
-        );
-    }
-
-    #[test]
-    fn stale_timer_callback_cannot_expire_a_restarted_timer() {
-        let concrete_backend = Arc::new(TestBackend::new(100));
-        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
-        let state = Arc::new(VtimerState::new());
-        state.write_timer_value(20, Arc::clone(&backend));
-        state.write_timer_value(30, Arc::clone(&backend));
-        state.expire(1, VtimerTarget::new(7, 3), Arc::clone(&backend));
-
-        assert_eq!(state.control(120), 0);
-        assert_eq!(*concrete_backend.cancelled.lock(), [1]);
-    }
-
-    #[test]
-    fn unmask_delivers_an_expired_timer_to_its_programming_vcpu() {
-        let concrete_backend = Arc::new(TestBackend::new(100));
-        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
-        let state = Arc::new(VtimerState::new());
-
-        state.write_timer_value(20, Arc::clone(&backend));
-        state.expire(1, VtimerTarget::new(11, 2), Arc::clone(&backend));
-        assert!(concrete_backend.injected.lock().is_empty());
-
-        state.write_control(1, backend.as_ref());
-        assert_eq!(
-            *concrete_backend.injected.lock(),
-            [(VtimerTarget::new(7, 3), VIRTUAL_TIMER_IRQ)],
-            "the timer must retain the target captured when it was programmed"
-        );
-    }
-
-    #[test]
-    fn suspend_and_reset_invalidate_racing_callbacks() {
-        let concrete_backend = Arc::new(TestBackend::new(100));
-        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
-        let state = Arc::new(VtimerState::new());
-        state.write_control(1, backend.as_ref());
-        state.write_timer_value(20, Arc::clone(&backend));
-
-        state.suspend(backend.as_ref());
-        state.expire(1, VtimerTarget::new(7, 3), Arc::clone(&backend));
-        assert_eq!(state.control(120), 1);
-        assert_eq!(*concrete_backend.cancelled.lock(), [1]);
-
-        state.resume(Arc::clone(&backend));
-        state.reset(backend.as_ref());
-        state.expire(3, VtimerTarget::new(7, 3), backend);
-        assert_eq!(state.control(120), 0);
-        assert_eq!(*concrete_backend.injected.lock(), []);
-        assert_eq!(*concrete_backend.cancelled.lock(), [1, 2]);
-    }
-
-    #[test]
-    fn resume_reuses_programming_target_without_current_vcpu_context() {
-        let concrete_backend = Arc::new(TestBackend::new(100));
-        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
-        let state = Arc::new(VtimerState::new());
-        let programming_target = VtimerTarget::new(11, 2);
-
-        concrete_backend.set_current_target(Some(programming_target));
-        state.write_control(1, backend.as_ref());
-        state.write_timer_value(20, Arc::clone(&backend));
-
-        state.suspend(backend.as_ref());
-
-        concrete_backend.set_current_target(Some(VtimerTarget::new(11, 5)));
-        state.resume(Arc::clone(&backend));
-        concrete_backend.fire_timer(2);
-        assert_eq!(
-            *concrete_backend.injected.lock(),
-            [(programming_target, VIRTUAL_TIMER_IRQ)],
-            "resume must keep the vCPU target captured when the guest programmed the timer"
-        );
-
-        concrete_backend.injected.lock().clear();
-        state.write_timer_value(20, Arc::clone(&backend));
-        state.suspend(backend.as_ref());
-
-        concrete_backend.set_current_target(None);
-        state.resume(Arc::clone(&backend));
-        concrete_backend.fire_timer(4);
-        assert_eq!(
-            *concrete_backend.injected.lock(),
-            [(VtimerTarget::new(11, 5), VIRTUAL_TIMER_IRQ)],
-            "resume must not read the current vCPU context"
+            tval.handle_read(tval_addr, AccessWidth::Dword).unwrap(),
+            value
         );
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/mod.rs
+++ b/virtualization/arm_vgic/src/vtimer/mod.rs
@@ -19,6 +19,7 @@ use alloc::{sync::Arc, vec, vec::Vec};
 use axdevice_base::Device;
 
 mod cntp_timer;
+pub use cntp_timer::CntpTimerState as VtimerState;
 
 mod cntp_cval_el0;
 pub use cntp_cval_el0::SysCntpCvalEl0;
@@ -34,9 +35,23 @@ pub use cntp_tval_el0::SysCntpTvalEl0;
 
 /// Create the concrete system-register devices backed by per-vCPU timer banks.
 pub fn new_sysreg_devices() -> (SysCntpCvalEl0, SysCntpCtlEl0, SysCntpctEl0, SysCntpTvalEl0) {
-    let timer = Arc::new(cntp_timer::CntpTimerState::new());
+    let (_timer, cval, ctl, counter, tval) = new_sysreg_devices_with_state();
+
+    (cval, ctl, counter, tval)
+}
+
+/// Create the concrete system-register devices and their shared timer state.
+pub fn new_sysreg_devices_with_state() -> (
+    Arc<VtimerState>,
+    SysCntpCvalEl0,
+    SysCntpCtlEl0,
+    SysCntpctEl0,
+    SysCntpTvalEl0,
+) {
+    let timer = Arc::new(VtimerState::new());
 
     (
+        Arc::clone(&timer),
         SysCntpCvalEl0::from_state(Arc::clone(&timer)),
         SysCntpCtlEl0::from_state(Arc::clone(&timer)),
         SysCntpctEl0::new(),
@@ -46,14 +61,24 @@ pub fn new_sysreg_devices() -> (SysCntpCvalEl0, SysCntpCtlEl0, SysCntpctEl0, Sys
 
 /// Create a collection of system register devices.
 pub fn get_sysreg_device() -> Vec<Arc<dyn Device>> {
-    let (cval, ctl, counter, tval) = new_sysreg_devices();
+    let (_timer, devices) = get_sysreg_device_with_state();
 
-    vec![
-        Arc::new(cval),
-        Arc::new(ctl),
-        Arc::new(counter),
-        Arc::new(tval),
-    ]
+    devices
+}
+
+/// Create system register devices together with their shared timer state.
+pub fn get_sysreg_device_with_state() -> (Arc<VtimerState>, Vec<Arc<dyn Device>>) {
+    let (timer, cval, ctl, counter, tval) = new_sysreg_devices_with_state();
+
+    (
+        timer,
+        vec![
+            Arc::new(cval),
+            Arc::new(ctl),
+            Arc::new(counter),
+            Arc::new(tval),
+        ],
+    )
 }
 
 #[cfg(test)]
@@ -64,22 +89,22 @@ mod tests {
 
     #[test]
     fn concrete_devices_isolate_timer_state_per_vcpu() {
-        let (cval, ctl, _counter, tval) = new_sysreg_devices();
+        let (timer, cval, ctl, _counter, tval) = new_sysreg_devices_with_state();
 
-        cntp_timer::set_test_current_identity(7, 0);
+        timer.set_test_current_identity(7, 0);
         cval.write_register(AccessWidth::Qword, 0x1111).unwrap();
         ctl.write_register(AccessWidth::Dword, 0x3).unwrap();
 
-        cntp_timer::set_test_current_identity(7, 1);
+        timer.set_test_current_identity(7, 1);
         cval.write_register(AccessWidth::Qword, 0x2222).unwrap();
         ctl.write_register(AccessWidth::Dword, 0x1).unwrap();
 
-        cntp_timer::set_test_current_identity(7, 0);
+        timer.set_test_current_identity(7, 0);
         assert_eq!(cval.read_register(AccessWidth::Qword).unwrap(), 0x1111);
         assert_eq!(tval.read_register(AccessWidth::Dword).unwrap(), 0x1111);
         assert_eq!(ctl.read_register(AccessWidth::Dword).unwrap() & 0x3, 0x3);
 
-        cntp_timer::set_test_current_identity(7, 1);
+        timer.set_test_current_identity(7, 1);
         assert_eq!(cval.read_register(AccessWidth::Qword).unwrap(), 0x2222);
         assert_eq!(tval.read_register(AccessWidth::Dword).unwrap(), 0x2222);
         assert_eq!(ctl.read_register(AccessWidth::Dword).unwrap() & 0x3, 0x1);

--- a/virtualization/arm_vgic/src/vtimer/mod.rs
+++ b/virtualization/arm_vgic/src/vtimer/mod.rs
@@ -32,7 +32,7 @@ pub use cntpct_el0::SysCntpctEl0;
 mod cntp_tval_el0;
 pub use cntp_tval_el0::SysCntpTvalEl0;
 
-/// Create the concrete system-register devices backed by one timer state.
+/// Create the concrete system-register devices backed by per-vCPU timer banks.
 pub fn new_sysreg_devices() -> (SysCntpCvalEl0, SysCntpCtlEl0, SysCntpctEl0, SysCntpTvalEl0) {
     let timer = Arc::new(cntp_timer::CntpTimerState::new());
 
@@ -63,12 +63,25 @@ mod tests {
     use super::*;
 
     #[test]
-    fn concrete_devices_share_timer_state() {
-        let (cval, _ctl, _counter, tval) = new_sysreg_devices();
-        let value = 0x1234_5678usize;
+    fn concrete_devices_isolate_timer_state_per_vcpu() {
+        let (cval, ctl, _counter, tval) = new_sysreg_devices();
 
-        cval.write_register(AccessWidth::Qword, value).unwrap();
+        cntp_timer::set_test_current_identity(7, 0);
+        cval.write_register(AccessWidth::Qword, 0x1111).unwrap();
+        ctl.write_register(AccessWidth::Dword, 0x3).unwrap();
 
-        assert_eq!(tval.read_register(AccessWidth::Dword).unwrap(), value);
+        cntp_timer::set_test_current_identity(7, 1);
+        cval.write_register(AccessWidth::Qword, 0x2222).unwrap();
+        ctl.write_register(AccessWidth::Dword, 0x1).unwrap();
+
+        cntp_timer::set_test_current_identity(7, 0);
+        assert_eq!(cval.read_register(AccessWidth::Qword).unwrap(), 0x1111);
+        assert_eq!(tval.read_register(AccessWidth::Dword).unwrap(), 0x1111);
+        assert_eq!(ctl.read_register(AccessWidth::Dword).unwrap() & 0x3, 0x3);
+
+        cntp_timer::set_test_current_identity(7, 1);
+        assert_eq!(cval.read_register(AccessWidth::Qword).unwrap(), 0x2222);
+        assert_eq!(tval.read_register(AccessWidth::Dword).unwrap(), 0x2222);
+        assert_eq!(ctl.read_register(AccessWidth::Dword).unwrap() & 0x3, 0x1);
     }
 }

--- a/virtualization/arm_vgic/src/vtimer/mod.rs
+++ b/virtualization/arm_vgic/src/vtimer/mod.rs
@@ -16,7 +16,7 @@ extern crate alloc;
 
 use alloc::{sync::Arc, vec, vec::Vec};
 
-use axdevice_base::BaseSysRegDeviceOps;
+use axdevice_base::Device;
 
 mod cntp_timer;
 
@@ -45,7 +45,7 @@ pub fn new_sysreg_devices() -> (SysCntpCvalEl0, SysCntpCtlEl0, SysCntpctEl0, Sys
 }
 
 /// Create a collection of system register devices.
-pub fn get_sysreg_device() -> Vec<Arc<dyn BaseSysRegDeviceOps>> {
+pub fn get_sysreg_device() -> Vec<Arc<dyn Device>> {
     let (cval, ctl, counter, tval) = new_sysreg_devices();
 
     vec![
@@ -58,24 +58,17 @@ pub fn get_sysreg_device() -> Vec<Arc<dyn BaseSysRegDeviceOps>> {
 
 #[cfg(test)]
 mod tests {
-    use aarch64_sysreg::SystemRegType;
-    use axdevice_base::{AccessWidth, BaseDeviceOps, SysRegAddr};
+    use axdevice_base::AccessWidth;
 
     use super::*;
 
     #[test]
     fn concrete_devices_share_timer_state() {
         let (cval, _ctl, _counter, tval) = new_sysreg_devices();
-        let cval_addr = SysRegAddr::new(SystemRegType::CNTP_CVAL_EL0 as usize);
-        let tval_addr = SysRegAddr::new(SystemRegType::CNTP_TVAL_EL0 as usize);
         let value = 0x1234_5678usize;
 
-        cval.handle_write(cval_addr, AccessWidth::Qword, value)
-            .unwrap();
+        cval.write_register(AccessWidth::Qword, value).unwrap();
 
-        assert_eq!(
-            tval.handle_read(tval_addr, AccessWidth::Dword).unwrap(),
-            value
-        );
+        assert_eq!(tval.read_register(AccessWidth::Dword).unwrap(), value);
     }
 }

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -24,7 +24,7 @@ bit_field = "0.10"
 bitflags = "2.9"
 byte-unit = { version = "5", default-features = false, features = ["byte"] }
 numeric-enum-macro = "0.2"
-spin = { workspace = true, features = ["mutex", "spin_mutex"] }
+spin = { workspace = true }
 thiserror = { workspace = true }
 
 # System independent crates provided by ArceOS.

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -24,7 +24,7 @@ bit_field = "0.10"
 bitflags = "2.9"
 byte-unit = { version = "5", default-features = false, features = ["byte"] }
 numeric-enum-macro = "0.2"
-spin = { workspace = true }
+spin = { workspace = true, features = ["mutex", "spin_mutex"] }
 thiserror = { workspace = true }
 
 # System independent crates provided by ArceOS.

--- a/virtualization/axvm/src/arch/aarch64/capabilities.rs
+++ b/virtualization/axvm/src/arch/aarch64/capabilities.rs
@@ -9,7 +9,13 @@ use crate::{
     ax_err_type,
 };
 
-impl HostTimePlatform for Aarch64Arch {}
+impl HostTimePlatform for Aarch64Arch {
+    fn register_timer_callback() {
+        ax_std::os::arceos::modules::ax_task::register_timer_callback(|_| {
+            crate::check_timer_events();
+        });
+    }
+}
 
 impl BootImagePlatform for Aarch64Arch {
     fn load_guest_dtb(

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -430,6 +430,14 @@ impl ArmVgicHostIf for ArmVgicHostIfImpl {
         crate::current_vm_id().expect("current AArch64 VM is not set")
     }
 
+    fn queue_virtual_interrupt(vm_id: usize, vcpu_id: usize, vector: u8) {
+        if let Err(err) = crate::runtime::vcpus::queue_interrupt(vm_id, vcpu_id, vector as usize) {
+            warn!(
+                "failed to queue VM[{vm_id}] vCPU[{vcpu_id}] virtual interrupt {vector}: {err:?}"
+            );
+        }
+    }
+
     fn current_time_nanos() -> u64 {
         default_host().monotonic_time().as_nanos() as u64
     }

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -472,13 +472,4 @@ impl ArmVgicHostIf for ArmVgicHostIfImpl {
     fn hardware_inject_virtual_interrupt(vector: u8) {
         gic::inject_interrupt(vector as usize);
     }
-
-    fn inject_vm_vcpu_interrupt(vm_id: usize, vcpu_id: usize, vector: u8) {
-        if let Err(error) = crate::manager::inject_vm_vcpu_interrupt(vm_id, vcpu_id, vector as _) {
-            warn!(
-                "failed to inject AArch64 virtual timer interrupt {vector:#x} into VM[{vm_id}] \
-                 VCpu[{vcpu_id}]: {error:?}"
-            );
-        }
-    }
 }

--- a/virtualization/axvm/src/arch/aarch64/vtimer.rs
+++ b/virtualization/axvm/src/arch/aarch64/vtimer.rs
@@ -5,13 +5,10 @@
 //! the concrete `arm_vgic` backend stays inside the AArch64 AxVM boundary
 //! instead of leaking into the architecture-neutral `axdevice` crate.
 
-use alloc::sync::Arc;
-
-use arm_vgic::vtimer::new_sysreg_devices;
+use arm_vgic::vtimer::get_sysreg_device;
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceManagerResult, DeviceRegistration,
 };
-use axdevice_base::{Device, SysRegDeviceAdapter};
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType};
 
 /// Factory for the standard AArch64 CNT* virtual-timer sysreg devices.
@@ -20,16 +17,11 @@ pub(crate) struct Aarch64VtimerFactory;
 impl Aarch64VtimerFactory {
     /// Builds the CNT* system-register device contributions.
     fn build_bundle(&self) -> DeviceManagerResult<DeviceBundle> {
-        let (cval, ctl, counter, tval) = new_sysreg_devices();
-        let cval: Arc<dyn Device> = Arc::new(SysRegDeviceAdapter::new(cval));
-        let ctl: Arc<dyn Device> = Arc::new(SysRegDeviceAdapter::new(ctl));
-        let counter: Arc<dyn Device> = Arc::new(SysRegDeviceAdapter::new(counter));
-        let tval: Arc<dyn Device> = Arc::new(SysRegDeviceAdapter::new(tval));
-
-        Ok(DeviceBundle::from_registration(DeviceRegistration::Device(cval))
-            .with_registration(DeviceRegistration::Device(ctl))
-            .with_registration(DeviceRegistration::Device(counter))
-            .with_registration(DeviceRegistration::Device(tval)))
+        let mut bundle = DeviceBundle::new();
+        for device in get_sysreg_device() {
+            bundle.push(DeviceRegistration::Device(device));
+        }
+        Ok(bundle)
     }
 }
 

--- a/virtualization/axvm/src/arch/aarch64/vtimer.rs
+++ b/virtualization/axvm/src/arch/aarch64/vtimer.rs
@@ -7,80 +7,29 @@
 
 use alloc::sync::Arc;
 
-use arm_vgic::vtimer::{
-    HostVtimerBackend, SysCntpCtlEl0, SysCntpTvalEl0, SysCntpctEl0, VtimerBackend, VtimerState,
-};
+use arm_vgic::vtimer::new_sysreg_devices;
 use axdevice::{
-    DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceLifecycle, DeviceManagerResult,
-    DeviceRegistration, ServiceCardinality, ServiceKey,
+    DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceManagerResult, DeviceRegistration,
 };
+use axdevice_base::{Device, SysRegDeviceAdapter};
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType};
 
 /// Factory for the standard AArch64 CNT* virtual-timer sysreg devices.
 pub(crate) struct Aarch64VtimerFactory;
 
-/// Service key for the AArch64 virtual-timer backend.
-pub(crate) struct Aarch64VtimerBackendKey;
-
-impl ServiceKey for Aarch64VtimerBackendKey {
-    type Service = dyn VtimerBackend;
-
-    const NAME: &'static str = "aarch64-vtimer-backend";
-    const CARDINALITY: ServiceCardinality = ServiceCardinality::Single;
-}
-
-struct VtimerLifecycle {
-    state: Arc<VtimerState>,
-    backend: Arc<dyn VtimerBackend>,
-}
-
-impl DeviceLifecycle for VtimerLifecycle {
-    fn reset(&self) -> DeviceManagerResult {
-        self.state.reset(self.backend.as_ref());
-        Ok(())
-    }
-
-    fn suspend(&self) -> DeviceManagerResult {
-        self.state.suspend(self.backend.as_ref());
-        Ok(())
-    }
-
-    fn resume(&self) -> DeviceManagerResult {
-        self.state.resume(Arc::clone(&self.backend));
-        Ok(())
-    }
-}
-
-impl Drop for VtimerLifecycle {
-    fn drop(&mut self) {
-        self.state.reset(self.backend.as_ref());
-    }
-}
-
 impl Aarch64VtimerFactory {
-    /// Builds the three CNT* system-register device contributions.
+    /// Builds the CNT* system-register device contributions.
     fn build_bundle(&self) -> DeviceManagerResult<DeviceBundle> {
-        let backend: Arc<dyn VtimerBackend> = Arc::new(HostVtimerBackend);
-        let state = Arc::new(VtimerState::new());
-        let lifecycle: Arc<dyn DeviceLifecycle> = Arc::new(VtimerLifecycle {
-            state: Arc::clone(&state),
-            backend: Arc::clone(&backend),
-        });
+        let (cval, ctl, counter, tval) = new_sysreg_devices();
+        let cval: Arc<dyn Device> = Arc::new(SysRegDeviceAdapter::new(cval));
+        let ctl: Arc<dyn Device> = Arc::new(SysRegDeviceAdapter::new(ctl));
+        let counter: Arc<dyn Device> = Arc::new(SysRegDeviceAdapter::new(counter));
+        let tval: Arc<dyn Device> = Arc::new(SysRegDeviceAdapter::new(tval));
 
-        let bundle = DeviceBundle::from_registration(DeviceRegistration::Device(Arc::new(
-            SysCntpCtlEl0::new(Arc::clone(&state), Arc::clone(&backend)),
-        )))
-        .with_registration(DeviceRegistration::Device(Arc::new(SysCntpctEl0::new(
-            Arc::clone(&backend),
-        ))))
-        .with_registration(DeviceRegistration::Device(Arc::new(SysCntpTvalEl0::new(
-            state,
-            Arc::clone(&backend),
-        ))));
-
-        Ok(bundle
-            .with_service::<Aarch64VtimerBackendKey>(backend)?
-            .with_lifecycle(lifecycle))
+        Ok(DeviceBundle::from_registration(DeviceRegistration::Device(cval))
+            .with_registration(DeviceRegistration::Device(ctl))
+            .with_registration(DeviceRegistration::Device(counter))
+            .with_registration(DeviceRegistration::Device(tval)))
     }
 }
 

--- a/virtualization/axvm/src/arch/aarch64/vtimer.rs
+++ b/virtualization/axvm/src/arch/aarch64/vtimer.rs
@@ -5,23 +5,55 @@
 //! the concrete `arm_vgic` backend stays inside the AArch64 AxVM boundary
 //! instead of leaking into the architecture-neutral `axdevice` crate.
 
-use arm_vgic::vtimer::get_sysreg_device;
+use alloc::sync::Arc;
+
+use arm_vgic::vtimer::{VtimerState, get_sysreg_device_with_state};
 use axdevice::{
-    DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceManagerResult, DeviceRegistration,
+    DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceLifecycle, DeviceManagerResult,
+    DeviceRegistration,
 };
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType};
 
 /// Factory for the standard AArch64 CNT* virtual-timer sysreg devices.
 pub(crate) struct Aarch64VtimerFactory;
 
+struct VtimerLifecycle {
+    state: Arc<VtimerState>,
+}
+
+impl DeviceLifecycle for VtimerLifecycle {
+    fn reset(&self) -> DeviceManagerResult {
+        self.state.reset();
+        Ok(())
+    }
+
+    fn suspend(&self) -> DeviceManagerResult {
+        self.state.suspend();
+        Ok(())
+    }
+
+    fn resume(&self) -> DeviceManagerResult {
+        self.state.resume();
+        Ok(())
+    }
+}
+
+impl Drop for VtimerLifecycle {
+    fn drop(&mut self) {
+        self.state.reset();
+    }
+}
+
 impl Aarch64VtimerFactory {
     /// Builds the CNT* system-register device contributions.
     fn build_bundle(&self) -> DeviceManagerResult<DeviceBundle> {
+        let (state, devices) = get_sysreg_device_with_state();
+        let lifecycle: Arc<dyn DeviceLifecycle> = Arc::new(VtimerLifecycle { state });
         let mut bundle = DeviceBundle::new();
-        for device in get_sysreg_device() {
+        for device in devices {
             bundle.push(DeviceRegistration::Device(device));
         }
-        Ok(bundle)
+        Ok(bundle.with_lifecycle(lifecycle))
     }
 }
 

--- a/virtualization/axvm/src/config.rs
+++ b/virtualization/axvm/src/config.rs
@@ -104,6 +104,7 @@ pub struct AxVMConfigParams {
     pub cpu_config: AxVCpuConfig,
     pub image_config: VMImageConfig,
     pub emu_devices: Vec<EmulatedDeviceConfig>,
+    pub pass_through_irqs: Vec<u32>,
     pub pass_through_devices: Vec<PassThroughDeviceConfig>,
     pub excluded_devices: Vec<Vec<String>>,
     pub pass_through_addresses: Vec<PassThroughAddressConfig>,
@@ -117,6 +118,13 @@ pub struct AxVMConfigParams {
 
 impl AxVMConfig {
     pub fn new(params: AxVMConfigParams) -> Self {
+        let mut passthrough_irq_list = Vec::new();
+        for irq in params.pass_through_irqs {
+            if !passthrough_irq_list.contains(&irq) {
+                passthrough_irq_list.push(irq);
+            }
+        }
+
         Self {
             id: params.id,
             name: params.name,
@@ -133,7 +141,7 @@ impl AxVMConfig {
             address_space_policy: params.address_space_policy,
             memory_regions: params.memory_regions,
             boot_policy: params.boot_policy,
-            passthrough_irq_list: Vec::new(),
+            passthrough_irq_list,
             interrupt_mode: params.interrupt_mode,
         }
     }
@@ -425,5 +433,18 @@ mod tests {
         assert_eq!(regions[1].gpa, 0x110000);
         assert_eq!(regions[1].size, 0x10000);
         assert_eq!(regions[1].map_type, VmMemMappingType::MapReserved);
+    }
+
+    #[test]
+    fn constructor_keeps_unique_explicit_passthrough_irqs() {
+        let config = AxVMConfig::new(AxVMConfigParams {
+            id: 1,
+            name: String::from("irq-test"),
+            phys_cpu_ls: PhysCpuList::new(1, None, None),
+            pass_through_irqs: vec![4, 4, 17],
+            ..Default::default()
+        });
+
+        assert_eq!(config.pass_through_irqs(), &vec![4, 17]);
     }
 }

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -117,6 +117,7 @@ pub(crate) type ArceOsAxTaskRef = modules::ax_task::AxTaskRef;
 pub(crate) type ArceOsCurrentTask = modules::ax_task::CurrentTask;
 pub(crate) type ArceOsTaskInner = modules::ax_task::TaskInner;
 pub(crate) type ArceOsWaitQueue = modules::ax_task::WaitQueue;
+pub(crate) type ArceOsIrqError = modules::ax_hal::irq::IrqError;
 pub(crate) type ArceOsWaitQueueHandle = api::task::AxWaitQueueHandle;
 pub(crate) use modules::ax_task::TaskExt as ArceOsTaskExt;
 
@@ -151,6 +152,16 @@ pub(crate) fn send_ipi(cpu_id: usize) {
         modules::ax_hal::irq::ipi_irq(),
         modules::ax_hal::irq::IpiTarget::Other { cpu_id },
     );
+}
+
+pub(crate) fn run_on_cpu_sync(
+    cpu_id: usize,
+    f: unsafe fn(*mut ()),
+    arg: *mut (),
+) -> Result<(), ArceOsIrqError> {
+    // SAFETY: the caller guarantees that `arg` stays valid until the target CPU
+    // has executed `f`; `ax_hal` provides the synchronous completion boundary.
+    unsafe { modules::ax_hal::irq::run_on_cpu_sync(modules::ax_hal::irq::CpuId(cpu_id), f, arg) }
 }
 
 fn send_ipi_to_all_except_current(cpu_num: usize) {

--- a/virtualization/axvm/src/host/task.rs
+++ b/virtualization/axvm/src/host/task.rs
@@ -34,6 +34,14 @@ pub(crate) fn wait_queue_wake(queue: &WaitQueueHandle, count: u32) {
     arceos::wait_queue_wake(queue, count);
 }
 
+pub(crate) fn run_on_cpu_sync(
+    cpu_id: usize,
+    f: unsafe fn(*mut ()),
+    arg: *mut (),
+) -> Result<(), arceos::ArceOsIrqError> {
+    arceos::run_on_cpu_sync(cpu_id, f, arg)
+}
+
 pub(crate) fn send_ipi(cpu_id: usize) {
     arceos::send_ipi(cpu_id);
 }

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -20,6 +20,8 @@
 //! - [`AxVM`]: The main structure representing a VM.
 
 extern crate alloc;
+#[cfg(test)]
+extern crate std;
 #[macro_use]
 extern crate log;
 

--- a/virtualization/axvm/src/timer.rs
+++ b/virtualization/axvm/src/timer.rs
@@ -217,6 +217,31 @@ mod tests {
     }
 
     #[test]
+    fn migration_reprogramming_deletes_stale_original_cpu_deadline() {
+        let mut timer_wheels = TimerWheels::new();
+        let stale_deadline = Duration::from_secs(60);
+        let migrated_deadline = Duration::from_millis(10);
+
+        assert_eq!(
+            timer_wheels.register(0, 31, stale_deadline, event(31)),
+            Some(stale_deadline)
+        );
+        assert_eq!(timer_wheels.cancel(31), Some((0, None)));
+        assert_eq!(
+            timer_wheels.register(1, 32, migrated_deadline, event(32)),
+            Some(migrated_deadline)
+        );
+
+        assert!(timer_wheels.expire_one(0, stale_deadline).is_none());
+        let (deadline, migrated_event) = timer_wheels
+            .expire_one(1, migrated_deadline)
+            .expect("migrated timer event should expire on the new owner CPU");
+        assert_eq!(deadline, migrated_deadline);
+        assert_eq!(migrated_event.token, 32);
+        assert_eq!(timer_wheels.cancel(32), None);
+    }
+
+    #[test]
     fn expiring_event_forgets_owner_token() {
         let mut timer_wheels = TimerWheels::new();
         let deadline = Duration::from_millis(5);

--- a/virtualization/axvm/src/timer.rs
+++ b/virtualization/axvm/src/timer.rs
@@ -1,8 +1,8 @@
-//! AxVM-owned per-CPU VM timer wheel.
+//! AxVM-owned CPU-bucketed VM timer wheels.
 
 extern crate alloc;
 
-use alloc::boxed::Box;
+use alloc::{boxed::Box, collections::BTreeMap};
 use core::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
@@ -13,7 +13,7 @@ use ax_kspin::SpinNoIrq;
 use ax_lazyinit::LazyInit;
 use ax_timer_list::{TimeValue, TimerEvent, TimerList};
 
-use crate::host::{HostTime, default_host};
+use crate::host::{HostCpu, HostTime, default_host};
 
 static TOKEN: AtomicUsize = AtomicUsize::new(0);
 
@@ -40,49 +40,117 @@ impl TimerEvent for VmTimerEvent {
     }
 }
 
-#[ax_percpu::def_percpu]
-static TIMER_LIST: LazyInit<SpinNoIrq<TimerList<VmTimerEvent>>> = LazyInit::new();
+struct TimerWheels {
+    wheels: BTreeMap<usize, TimerList<VmTimerEvent>>,
+    owners: BTreeMap<usize, usize>,
+}
+
+impl TimerWheels {
+    fn new() -> Self {
+        Self {
+            wheels: BTreeMap::new(),
+            owners: BTreeMap::new(),
+        }
+    }
+
+    fn ensure_cpu(&mut self, cpu_id: usize) -> &mut TimerList<VmTimerEvent> {
+        self.wheels.entry(cpu_id).or_default()
+    }
+
+    fn register(
+        &mut self,
+        owner_cpu: usize,
+        token: usize,
+        deadline: TimeValue,
+        event: VmTimerEvent,
+    ) -> Option<TimeValue> {
+        self.owners.insert(token, owner_cpu);
+        let wheel = self.ensure_cpu(owner_cpu);
+        wheel.set(deadline, event);
+        wheel.next_deadline()
+    }
+
+    fn cancel(&mut self, token: usize) -> Option<(usize, Option<TimeValue>)> {
+        let owner_cpu = self.owners.remove(&token)?;
+        let next_deadline = self.wheels.get_mut(&owner_cpu).map(|wheel| {
+            wheel.cancel(|event| event.token == token);
+            wheel.next_deadline()
+        });
+        Some((owner_cpu, next_deadline.flatten()))
+    }
+
+    fn expire_one(
+        &mut self,
+        owner_cpu: usize,
+        now: TimeValue,
+    ) -> Option<(TimeValue, VmTimerEvent)> {
+        let expired = self
+            .wheels
+            .get_mut(&owner_cpu)
+            .and_then(|wheel| wheel.expire_one(now));
+        if let Some((_, event)) = &expired {
+            self.owners.remove(&event.token);
+        }
+        expired
+    }
+
+    fn next_deadline(&self, owner_cpu: usize) -> Option<TimeValue> {
+        self.wheels
+            .get(&owner_cpu)
+            .and_then(TimerList::next_deadline)
+    }
+}
+
+static TIMER_WHEELS: LazyInit<SpinNoIrq<TimerWheels>> = LazyInit::new();
 
 pub(crate) fn register_timer(
     deadline_ns: u64,
     callback: Box<dyn FnOnce(Duration) + Send + 'static>,
 ) -> usize {
     let token = TOKEN.fetch_add(1, Ordering::Relaxed);
-    let next_deadline = with_current_timer_list(|timer_list| {
-        let mut timers = timer_list.lock();
-        timers.set(
+    let next_deadline = with_current_timer_wheels(|cpu_id, timer_wheels| {
+        timer_wheels.register(
+            cpu_id,
+            token,
             TimeValue::from_nanos(deadline_ns),
             VmTimerEvent::new(token, callback),
-        );
-        timers.next_deadline()
+        )
     });
     rearm_host_timer(next_deadline);
     token
 }
 
 pub(crate) fn cancel_timer(token: usize) {
-    let next_deadline = with_current_timer_list(|timer_list| {
-        let mut timers = timer_list.lock();
-        timers.cancel(|event| event.token == token);
-        timers.next_deadline()
-    });
-    rearm_host_timer(next_deadline);
+    let _guard = NoPreempt::new();
+    let current_cpu = default_host().this_cpu_id();
+    let canceled = with_timer_wheels(|timer_wheels| timer_wheels.cancel(token));
+    if let Some((owner_cpu, next_deadline)) = canceled
+        && owner_cpu == current_cpu
+    {
+        rearm_host_timer(next_deadline);
+    }
 }
 
 pub(crate) fn check_events() {
-    with_current_timer_list(|timer_list| {
-        loop {
-            let now = default_host().monotonic_time();
-            let expired = timer_list.lock().expire_one(now);
-            if let Some((deadline, event)) = expired {
-                trace!("handle VM timer event scheduled at {deadline:#?}");
-                event.callback(now);
+    loop {
+        let now = default_host().monotonic_time();
+        let (expired, next_deadline) = with_current_timer_wheels(|cpu_id, timer_wheels| {
+            let expired = timer_wheels.expire_one(cpu_id, now);
+            let next_deadline = if expired.is_none() {
+                timer_wheels.next_deadline(cpu_id)
             } else {
-                rearm_host_timer(timer_list.lock().next_deadline());
-                break;
-            }
+                None
+            };
+            (expired, next_deadline)
+        });
+        if let Some((deadline, event)) = expired {
+            trace!("handle VM timer event scheduled at {deadline:#?}");
+            event.callback(now);
+        } else {
+            rearm_host_timer(next_deadline);
+            break;
         }
-    });
+    }
 }
 
 fn rearm_host_timer(next_deadline: Option<TimeValue>) {
@@ -93,17 +161,70 @@ fn rearm_host_timer(next_deadline: Option<TimeValue>) {
 
 pub(crate) fn init_percpu() {
     info!("Initializing AxVM timer wheel...");
-    with_current_timer_list(|timer_list| {
-        timer_list.init_once(SpinNoIrq::new(TimerList::new()));
+    with_current_timer_wheels(|cpu_id, timer_wheels| {
+        timer_wheels.ensure_cpu(cpu_id);
     });
     crate::arch::register_timer_callback();
 }
 
-fn with_current_timer_list<R>(
-    operation: impl FnOnce(&LazyInit<SpinNoIrq<TimerList<VmTimerEvent>>>) -> R,
-) -> R {
+fn with_timer_wheels<R>(operation: impl FnOnce(&mut TimerWheels) -> R) -> R {
+    let timer_wheels = TIMER_WHEELS.get_or_init(|| SpinNoIrq::new(TimerWheels::new()));
+    operation(&mut timer_wheels.lock())
+}
+
+fn with_current_timer_wheels<R>(operation: impl FnOnce(usize, &mut TimerWheels) -> R) -> R {
     let _guard = NoPreempt::new();
-    // SAFETY: the guard prevents migration through the non-escaping borrow.
-    unsafe { ax_percpu::with_cpu_pin(|pin| TIMER_LIST.with_current(pin, operation)) }
-        .expect("AxVM timer access requires an installed CPU area")
+    let cpu_id = default_host().this_cpu_id();
+    with_timer_wheels(|timer_wheels| operation(cpu_id, timer_wheels))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event(token: usize) -> VmTimerEvent {
+        VmTimerEvent::new(token, |_| {})
+    }
+
+    #[test]
+    fn cancel_removes_event_from_original_cpu_wheel() {
+        let mut timer_wheels = TimerWheels::new();
+        let deadline = Duration::from_secs(60);
+
+        assert_eq!(
+            timer_wheels.register(0, 7, deadline, event(7)),
+            Some(deadline)
+        );
+        assert_eq!(timer_wheels.next_deadline(0), Some(deadline));
+        assert_eq!(timer_wheels.next_deadline(1), None);
+
+        assert_eq!(timer_wheels.cancel(7), Some((0, None)));
+        assert_eq!(timer_wheels.next_deadline(0), None);
+        assert_eq!(timer_wheels.cancel(7), None);
+    }
+
+    #[test]
+    fn cancel_rearms_to_remaining_owner_deadline() {
+        let mut timer_wheels = TimerWheels::new();
+        let early = Duration::from_secs(10);
+        let late = Duration::from_secs(20);
+
+        timer_wheels.register(1, 11, early, event(11));
+        timer_wheels.register(1, 12, late, event(12));
+
+        assert_eq!(timer_wheels.cancel(11), Some((1, Some(late))));
+        assert_eq!(timer_wheels.next_deadline(1), Some(late));
+    }
+
+    #[test]
+    fn expiring_event_forgets_owner_token() {
+        let mut timer_wheels = TimerWheels::new();
+        let deadline = Duration::from_millis(5);
+
+        timer_wheels.register(2, 21, deadline, event(21));
+        let expired = timer_wheels.expire_one(2, deadline);
+
+        assert!(expired.is_some());
+        assert_eq!(timer_wheels.cancel(21), None);
+    }
 }

--- a/virtualization/axvm/src/timer.rs
+++ b/virtualization/axvm/src/timer.rs
@@ -3,6 +3,10 @@
 extern crate alloc;
 
 use alloc::{boxed::Box, collections::BTreeMap};
+#[cfg(test)]
+use alloc::{vec, vec::Vec};
+#[cfg(test)]
+use core::sync::atomic::AtomicU64;
 use core::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
@@ -12,10 +16,15 @@ use ax_kernel_guard::NoPreempt;
 use ax_kspin::SpinNoIrq;
 use ax_lazyinit::LazyInit;
 use ax_timer_list::{TimeValue, TimerEvent, TimerList};
+#[cfg(test)]
+use spin::Mutex;
 
-use crate::host::{HostCpu, HostTime, default_host};
+#[cfg(not(test))]
+use crate::host::task;
+use crate::host::{HostTime, default_host};
 
 static TOKEN: AtomicUsize = AtomicUsize::new(0);
+const HOST_TIMER_PARK_DELAY: Duration = Duration::from_secs(1);
 
 struct VmTimerEvent {
     token: usize,
@@ -122,12 +131,10 @@ pub(crate) fn register_timer(
 
 pub(crate) fn cancel_timer(token: usize) {
     let _guard = NoPreempt::new();
-    let current_cpu = default_host().this_cpu_id();
+    let current_cpu = current_cpu_id();
     let canceled = with_timer_wheels(|timer_wheels| timer_wheels.cancel(token));
-    if let Some((owner_cpu, next_deadline)) = canceled
-        && owner_cpu == current_cpu
-    {
-        rearm_host_timer(next_deadline);
+    if let Some((owner_cpu, next_deadline)) = canceled {
+        rearm_owner_host_timer(owner_cpu, current_cpu, next_deadline);
     }
 }
 
@@ -153,10 +160,50 @@ pub(crate) fn check_events() {
     }
 }
 
-fn rearm_host_timer(next_deadline: Option<TimeValue>) {
-    if let Some(deadline) = next_deadline {
-        default_host().set_oneshot_timer(deadline.as_nanos() as u64);
+fn rearm_owner_host_timer(owner_cpu: usize, current_cpu: usize, next_deadline: Option<TimeValue>) {
+    if owner_cpu == current_cpu {
+        rearm_host_timer(next_deadline);
+    } else {
+        rearm_remote_owner_host_timer(owner_cpu);
     }
+}
+
+fn rearm_current_host_timer_from_wheel() {
+    let next_deadline =
+        with_current_timer_wheels(|cpu_id, timer_wheels| timer_wheels.next_deadline(cpu_id));
+    rearm_host_timer(next_deadline);
+}
+
+#[cfg(not(test))]
+unsafe fn rearm_current_host_timer_from_wheel_thunk(_arg: *mut ()) {
+    rearm_current_host_timer_from_wheel();
+}
+
+#[cfg(not(test))]
+fn rearm_remote_owner_host_timer(owner_cpu: usize) {
+    let result = task::run_on_cpu_sync(
+        owner_cpu,
+        rearm_current_host_timer_from_wheel_thunk,
+        core::ptr::null_mut(),
+    );
+    if let Err(error) = result {
+        warn!("failed to rearm AxVM timer on owner CPU {owner_cpu}: {error:?}; sending IPI");
+        task::send_ipi(owner_cpu);
+    }
+}
+
+#[cfg(not(test))]
+fn rearm_host_timer(next_deadline: Option<TimeValue>) {
+    let deadline = next_deadline.unwrap_or_else(|| {
+        // The host timer API has no cancel hook. Park the comparator in the
+        // future so an empty wheel overwrites any stale canceled deadline.
+        parked_host_timer_deadline(default_host().monotonic_time())
+    });
+    default_host().set_oneshot_timer(deadline.as_nanos() as u64);
+}
+
+fn parked_host_timer_deadline(now: TimeValue) -> TimeValue {
+    now.saturating_add(HOST_TIMER_PARK_DELAY)
 }
 
 pub(crate) fn init_percpu() {
@@ -174,13 +221,66 @@ fn with_timer_wheels<R>(operation: impl FnOnce(&mut TimerWheels) -> R) -> R {
 
 fn with_current_timer_wheels<R>(operation: impl FnOnce(usize, &mut TimerWheels) -> R) -> R {
     let _guard = NoPreempt::new();
-    let cpu_id = default_host().this_cpu_id();
+    let cpu_id = current_cpu_id();
     with_timer_wheels(|timer_wheels| operation(cpu_id, timer_wheels))
+}
+
+#[cfg(not(test))]
+fn current_cpu_id() -> usize {
+    use crate::host::HostCpu;
+
+    default_host().this_cpu_id()
+}
+
+#[cfg(test)]
+static TEST_CURRENT_CPU: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+static TEST_REARMS: Mutex<Vec<(usize, Option<TimeValue>)>> = Mutex::new(Vec::new());
+#[cfg(test)]
+static TEST_REMOTE_REARMS: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+#[cfg(test)]
+static TEST_NOW_NS: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(test)]
+fn current_cpu_id() -> usize {
+    TEST_CURRENT_CPU.load(Ordering::Acquire)
+}
+
+#[cfg(test)]
+fn rearm_host_timer(next_deadline: Option<TimeValue>) {
+    let deadline = next_deadline.or_else(|| {
+        Some(parked_host_timer_deadline(TimeValue::from_nanos(
+            TEST_NOW_NS.load(Ordering::Acquire),
+        )))
+    });
+    TEST_REARMS.lock().push((current_cpu_id(), deadline));
+}
+
+#[cfg(test)]
+fn rearm_remote_owner_host_timer(owner_cpu: usize) {
+    TEST_REMOTE_REARMS.lock().push(owner_cpu);
+    let previous_cpu = TEST_CURRENT_CPU.swap(owner_cpu, Ordering::AcqRel);
+    rearm_current_host_timer_from_wheel();
+    TEST_CURRENT_CPU.store(previous_cpu, Ordering::Release);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn reset_global_timer_state() {
+        with_timer_wheels(|timer_wheels| *timer_wheels = TimerWheels::new());
+        TEST_REARMS.lock().clear();
+        TEST_REMOTE_REARMS.lock().clear();
+        TEST_CURRENT_CPU.store(0, Ordering::Release);
+        TEST_NOW_NS.store(0, Ordering::Release);
+    }
+
+    fn set_current_cpu_for_test(cpu_id: usize) {
+        TEST_CURRENT_CPU.store(cpu_id, Ordering::Release);
+    }
 
     fn event(token: usize) -> VmTimerEvent {
         VmTimerEvent::new(token, |_| {})
@@ -251,5 +351,35 @@ mod tests {
 
         assert!(expired.is_some());
         assert_eq!(timer_wheels.cancel(21), None);
+    }
+
+    #[test]
+    fn remote_cancel_reprograms_owner_cpu_timer() {
+        let _guard = TEST_LOCK.lock();
+        reset_global_timer_state();
+
+        set_current_cpu_for_test(0);
+        let early_token = register_timer(10_000_000, Box::new(|_| {}));
+        let late_token = register_timer(20_000_000, Box::new(|_| {}));
+        assert_eq!(TEST_REARMS.lock().len(), 2);
+
+        TEST_REARMS.lock().clear();
+        set_current_cpu_for_test(1);
+        cancel_timer(early_token);
+
+        assert_eq!(*TEST_REMOTE_REARMS.lock(), vec![0]);
+        assert_eq!(
+            *TEST_REARMS.lock(),
+            vec![(0, Some(Duration::from_nanos(20_000_000)))]
+        );
+
+        TEST_REARMS.lock().clear();
+        cancel_timer(late_token);
+
+        assert_eq!(*TEST_REMOTE_REARMS.lock(), vec![0, 0]);
+        assert_eq!(
+            *TEST_REARMS.lock(),
+            vec![(0, Some(Duration::from_nanos(1_000_000_000)))]
+        );
     }
 }

--- a/virtualization/axvm/src/timer.rs
+++ b/virtualization/axvm/src/timer.rs
@@ -2,22 +2,22 @@
 
 extern crate alloc;
 
-use alloc::{boxed::Box, collections::BTreeMap};
 #[cfg(test)]
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
+use alloc::{boxed::Box, collections::BTreeMap};
 #[cfg(test)]
 use core::sync::atomic::AtomicU64;
 use core::{
     sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard};
 
 use ax_kernel_guard::NoPreempt;
 use ax_kspin::SpinNoIrq;
 use ax_lazyinit::LazyInit;
 use ax_timer_list::{TimeValue, TimerEvent, TimerList};
-#[cfg(test)]
-use spin::Mutex;
 
 #[cfg(not(test))]
 use crate::host::task;
@@ -247,18 +247,23 @@ fn current_cpu_id() -> usize {
 }
 
 #[cfg(test)]
+fn lock_test_mutex<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().expect("AxVM timer test mutex poisoned")
+}
+
+#[cfg(test)]
 fn rearm_host_timer(next_deadline: Option<TimeValue>) {
     let deadline = next_deadline.or_else(|| {
         Some(parked_host_timer_deadline(TimeValue::from_nanos(
             TEST_NOW_NS.load(Ordering::Acquire),
         )))
     });
-    TEST_REARMS.lock().push((current_cpu_id(), deadline));
+    lock_test_mutex(&TEST_REARMS).push((current_cpu_id(), deadline));
 }
 
 #[cfg(test)]
 fn rearm_remote_owner_host_timer(owner_cpu: usize) {
-    TEST_REMOTE_REARMS.lock().push(owner_cpu);
+    lock_test_mutex(&TEST_REMOTE_REARMS).push(owner_cpu);
     let previous_cpu = TEST_CURRENT_CPU.swap(owner_cpu, Ordering::AcqRel);
     rearm_current_host_timer_from_wheel();
     TEST_CURRENT_CPU.store(previous_cpu, Ordering::Release);
@@ -272,8 +277,8 @@ mod tests {
 
     fn reset_global_timer_state() {
         with_timer_wheels(|timer_wheels| *timer_wheels = TimerWheels::new());
-        TEST_REARMS.lock().clear();
-        TEST_REMOTE_REARMS.lock().clear();
+        lock_test_mutex(&TEST_REARMS).clear();
+        lock_test_mutex(&TEST_REMOTE_REARMS).clear();
         TEST_CURRENT_CPU.store(0, Ordering::Release);
         TEST_NOW_NS.store(0, Ordering::Release);
     }
@@ -355,31 +360,31 @@ mod tests {
 
     #[test]
     fn remote_cancel_reprograms_owner_cpu_timer() {
-        let _guard = TEST_LOCK.lock();
+        let _guard = lock_test_mutex(&TEST_LOCK);
         reset_global_timer_state();
 
         set_current_cpu_for_test(0);
         let early_token = register_timer(10_000_000, Box::new(|_| {}));
         let late_token = register_timer(20_000_000, Box::new(|_| {}));
-        assert_eq!(TEST_REARMS.lock().len(), 2);
+        assert_eq!(lock_test_mutex(&TEST_REARMS).len(), 2);
 
-        TEST_REARMS.lock().clear();
+        lock_test_mutex(&TEST_REARMS).clear();
         set_current_cpu_for_test(1);
         cancel_timer(early_token);
 
-        assert_eq!(*TEST_REMOTE_REARMS.lock(), vec![0]);
+        assert_eq!(lock_test_mutex(&TEST_REMOTE_REARMS).as_slice(), &[0]);
         assert_eq!(
-            *TEST_REARMS.lock(),
-            vec![(0, Some(Duration::from_nanos(20_000_000)))]
+            lock_test_mutex(&TEST_REARMS).as_slice(),
+            &[(0, Some(Duration::from_nanos(20_000_000)))]
         );
 
-        TEST_REARMS.lock().clear();
+        lock_test_mutex(&TEST_REARMS).clear();
         cancel_timer(late_token);
 
-        assert_eq!(*TEST_REMOTE_REARMS.lock(), vec![0, 0]);
+        assert_eq!(lock_test_mutex(&TEST_REMOTE_REARMS).as_slice(), &[0, 0]);
         assert_eq!(
-            *TEST_REARMS.lock(),
-            vec![(0, Some(Duration::from_nanos(1_000_000_000)))]
+            lock_test_mutex(&TEST_REARMS).as_slice(),
+            &[(0, Some(Duration::from_nanos(1_000_000_000)))]
         );
     }
 }

--- a/virtualization/axvm/src/timer.rs
+++ b/virtualization/axvm/src/timer.rs
@@ -20,8 +20,7 @@ use ax_lazyinit::LazyInit;
 use ax_timer_list::{TimeValue, TimerEvent, TimerList};
 
 #[cfg(not(test))]
-use crate::host::task;
-use crate::host::{HostTime, default_host};
+use crate::host::{HostTime, default_host, task};
 
 static TOKEN: AtomicUsize = AtomicUsize::new(0);
 const HOST_TIMER_PARK_DELAY: Duration = Duration::from_secs(1);
@@ -140,7 +139,7 @@ pub(crate) fn cancel_timer(token: usize) {
 
 pub(crate) fn check_events() {
     loop {
-        let now = default_host().monotonic_time();
+        let now = current_host_time();
         let (expired, next_deadline) = with_current_timer_wheels(|cpu_id, timer_wheels| {
             let expired = timer_wheels.expire_one(cpu_id, now);
             let next_deadline = if expired.is_none() {
@@ -158,6 +157,16 @@ pub(crate) fn check_events() {
             break;
         }
     }
+}
+
+#[cfg(not(test))]
+fn current_host_time() -> TimeValue {
+    default_host().monotonic_time()
+}
+
+#[cfg(test)]
+fn current_host_time() -> TimeValue {
+    TimeValue::from_nanos(TEST_NOW_NS.load(Ordering::Acquire))
 }
 
 fn rearm_owner_host_timer(owner_cpu: usize, current_cpu: usize, next_deadline: Option<TimeValue>) {
@@ -287,8 +296,41 @@ mod tests {
         TEST_CURRENT_CPU.store(cpu_id, Ordering::Release);
     }
 
+    static TEST_CALLBACK_NOW_NS: AtomicU64 = AtomicU64::new(0);
+
     fn event(token: usize) -> VmTimerEvent {
         VmTimerEvent::new(token, |_| {})
+    }
+
+    #[test]
+    fn host_timer_callback_path_dispatches_registered_event_once() {
+        let _guard = lock_test_mutex(&TEST_LOCK);
+        reset_global_timer_state();
+        TEST_CALLBACK_NOW_NS.store(0, Ordering::Release);
+
+        set_current_cpu_for_test(0);
+        TEST_NOW_NS.store(1_000_000, Ordering::Release);
+        let token = register_timer(
+            10_000_000,
+            Box::new(|now| {
+                TEST_CALLBACK_NOW_NS.store(now.as_nanos() as u64, Ordering::Release);
+            }),
+        );
+
+        check_events();
+        assert_eq!(TEST_CALLBACK_NOW_NS.load(Ordering::Acquire), 0);
+        assert_eq!(
+            lock_test_mutex(&TEST_REARMS).last().copied(),
+            Some((0, Some(Duration::from_nanos(10_000_000))))
+        );
+
+        TEST_NOW_NS.store(10_000_000, Ordering::Release);
+        check_events();
+        assert_eq!(TEST_CALLBACK_NOW_NS.load(Ordering::Acquire), 10_000_000);
+        assert_eq!(
+            with_timer_wheels(|timer_wheels| timer_wheels.cancel(token)),
+            None
+        );
     }
 
     #[test]

--- a/virtualization/axvm/tests/arch_boundary_contract.rs
+++ b/virtualization/axvm/tests/arch_boundary_contract.rs
@@ -298,6 +298,30 @@ fn host_time_trait_only_exposes_common_clock_capabilities() {
 }
 
 #[test]
+fn aarch64_host_time_registers_axvm_timer_callback() {
+    let capabilities = include_str!("../src/arch/aarch64/capabilities.rs");
+    let (_, impl_and_rest) = capabilities
+        .split_once("impl HostTimePlatform for Aarch64Arch")
+        .expect("AArch64 must implement HostTimePlatform explicitly");
+    let (impl_body, _) = impl_and_rest
+        .split_once("impl BootImagePlatform for Aarch64Arch")
+        .expect("AArch64 HostTimePlatform implementation must precede BootImagePlatform");
+
+    assert!(
+        impl_body.contains("fn register_timer_callback()"),
+        "AArch64 HostTimePlatform must override the empty default timer callback hook"
+    );
+    assert!(
+        impl_body.contains("ax_task::register_timer_callback"),
+        "AArch64 must register with the host task timer callback path"
+    );
+    assert!(
+        impl_body.contains("crate::check_timer_events();"),
+        "AArch64 host timer callback must drain the AxVM timer wheel"
+    );
+}
+
+#[test]
 fn vcpu_setup_context_keeps_named_capabilities() {
     let types = include_str!("../src/architecture/types.rs");
     let ops = include_str!("../src/architecture/ops.rs");

--- a/virtualization/axvmconfig/src/lib.rs
+++ b/virtualization/axvmconfig/src/lib.rs
@@ -837,6 +837,11 @@ pub struct VMDevicesConfig {
     )]
     #[serde(with = "passthrough_device_config_vec_serde")]
     pub passthrough_devices: Vec<PassThroughDeviceConfig>,
+    /// Physical SPI IDs that must be explicitly forwarded to the guest.
+    ///
+    /// The IDs exclude the architectural GIC SPI offset of 32.
+    #[serde(default)]
+    pub passthrough_irqs: Vec<u32>,
     /// How the VM should handle interrupts and interrupt controllers.
     #[serde(default)]
     #[cfg_attr(

--- a/virtualization/axvmconfig/src/templates.rs
+++ b/virtualization/axvmconfig/src/templates.rs
@@ -91,6 +91,7 @@ pub fn get_vm_config_template(params: VmTemplateParams) -> AxVMCrateConfig {
             address_space_policy: Default::default(), // Virtualized address space by default
             emu_devices: vec![],                      // No emulated devices by default
             passthrough_devices: vec![],              // No passthrough devices by default
+            passthrough_irqs: vec![],                 // No explicit passthrough IRQs by default
             interrupt_mode: Default::default(),       // Use default interrupt mode
             excluded_devices: vec![],                 // No excluded devices by default
             passthrough_addresses: vec![],            // No passthrough addresses by default

--- a/virtualization/axvmconfig/src/test.rs
+++ b/virtualization/axvmconfig/src/test.rs
@@ -51,6 +51,8 @@ passthrough_devices = [
     ["dev1", 0x0900_0000, 0x0900_0000, 0x0a00_0000, 0x2],
 ]
 
+passthrough_irqs = [4, 17]
+
 passthrough_ports = [
     [0x6000, 0x80],
 ]
@@ -108,6 +110,7 @@ interrupt_mode = "passthrough"
     assert_eq!(config.devices.passthrough_devices[1].base_hpa, 0x0900_0000);
     assert_eq!(config.devices.passthrough_devices[1].length, 0x0a00_0000);
     assert_eq!(config.devices.passthrough_devices[1].irq_id, 2);
+    assert_eq!(config.devices.passthrough_irqs, vec![4, 17]);
     assert_eq!(config.devices.passthrough_ports.len(), 1);
     assert_eq!(config.devices.passthrough_ports[0].base, 0x6000);
     assert_eq!(config.devices.passthrough_ports[0].length, 0x80);
@@ -636,6 +639,7 @@ fn test_default_implementations() {
     );
     assert!(vm_devices_config.emu_devices.is_empty());
     assert!(vm_devices_config.passthrough_devices.is_empty());
+    assert!(vm_devices_config.passthrough_irqs.is_empty());
     assert_eq!(vm_devices_config.interrupt_mode, VMInterruptMode::NoIrq);
 
     let axvm_crate_config = AxVMCrateConfig::default();


### PR DESCRIPTION
## Summary

This PR adds an AArch64 physical-timer virtualization path for AxVisor.

It preserves guest-visible CNTP compare/control state, rearms a host timer when
the guest updates `CNTP_CVAL_EL0`, `CNTP_TVAL_EL0`, or `CNTP_CTL_EL0`, and
queues CNTP PPI 30 to the recorded target VM/vCPU when the virtual timer
expires.

This is a core realtime patch candidate for the Quancheng 2026 AxVisor contest,
kept separate from PR1703. PR1703 remains the contest artifact/reproducibility PR
under `os/axvisor/contest/quancheng2026/`.

## Scope

- AArch64 physical timer state virtualization
- vTimer expiry delivery to the target VM/vCPU
- GICv3 EOI behavior adjustment under the hypervisor path
- AxVisor/arm_vgic/axvm/somehal core changes only

This PR intentionally does not include contest artifacts, logs, images, or binary runtime images.

## Validation

Static validation passed on head:

`e4ea7f8d1cae1982494d552883cea3f4c97258b8`

Runtime evidence includes:

- Full hub-mode Linux/RTOS/UDP/QCZ1/AI runtime: PASS
- 3-run stress stability: 3/3 PASS
- rt10000 long stress: PASS
- stress4 high-load runtime: PASS
- stress4 high-load stability: 3/3 PASS
- latest-core TAP/tcpdump stress run: PASS

Latest TAP/tcpdump evidence:

```text
Network mode=tap
Linux stress workers=2
Linux periodic samples=3000
Plain UDP echo=20/20
QCZ1 reliable control=10/10
AI control closed loop=10/10
tcpdump packets captured=88
tcpdump packets dropped by kernel=0
Final result=PASS
SHA256=9db3af16825d1ddd07ec50b5fbe60b5bf02ab5b14006f90c7b12c668aa3d1217
```

## Boundary

This PR is separate from PR1703 so the contest artifact PR stays small and reviewable.