### PR TITLE
fix(virtualization): avoid privileged IRQ ops in host tests

### DIFF
--- a/virtualization/arm_vgic/Cargo.toml
+++ b/virtualization/arm_vgic/Cargo.toml
@@ -35,3 +35,6 @@ ax-memory-addr = { workspace = true }
 spin = { workspace = true }
 tock-registers = "0.10"
 thiserror = { workspace = true }
+
+[dev-dependencies]
+ax-kspin = { workspace = true, features = ["host-test"] }

--- a/virtualization/axdevice/Cargo.toml
+++ b/virtualization/axdevice/Cargo.toml
@@ -35,6 +35,7 @@ name = "lookup_DeviceRuntime"
 harness = false
 
 [dev-dependencies]
+ax-kspin = { workspace = true, features = ["host-test"] }
 divan = "0.1.21"
 paste = "1.0"
 rand = { version = "0.10", features = ["std_rng"] }


### PR DESCRIPTION
## 问题与根因

`arm_vgic` 和 `axdevice` 的普通 x86_64 host 单测会通过 `SpinNoIrq` 进入 `ax-kernel-guard` 的 x86 IRQ backend。未启用 `host-test` 时，该 backend 会执行 `cli`/`sti`；这些特权指令不能在 Linux 用户态测试进程中执行，因此两包测试稳定以 SIGSEGV 退出。

仓库 std runner 已显式传入 `--features host-test`，但裸 `cargo test -p arm_vgic` 与 `cargo test -p axdevice` 仍没有包级保护。

## 修改

- 在 `arm_vgic` 的 dev-dependency 图中为 `ax-kspin` 启用 `host-test`；
- 在 `axdevice` 的 dev-dependency 图中为 `ax-kspin` 启用 `host-test`。

Cargo 仅在构建测试、bench 或 example 目标时合并 dev-dependency feature，因此 host 测试会沿 `ax-kspin/host-test -> ax-kernel-guard/host-test` 选择 noop IRQ backend；正常依赖和 no_std 构建仍只启用默认 feature，继续保留真实 IRQ save/restore 语义。

## 回归证据

修复前，以下两条确定性命令都以 exit 101 / signal 11 失败：

```text
cargo test -p arm_vgic --lib vtimer::tests::expired_timer_is_injected_when_enabled_and_unmasked -- --exact --nocapture
cargo test -p axdevice --lib loongarch_pch_pic::tests::clear_asserted_irq_emits_deassert_event -- --exact --nocapture
```

修复后，同一组命令通过，并连续重复 3 轮保持通过。整包测试也通过：

- `cargo test -p arm_vgic`：5 个单元测试、2 个集成测试通过；
- `cargo test -p axdevice`：40 个单元测试、2 个集成测试通过。

## 本地验证

- `cargo xtask clippy --package arm_vgic`：3/3 checks passed；
- `cargo xtask clippy --package axdevice`：2/2 checks passed；
- `cargo check -p axdevice --target x86_64-unknown-none`；
- `cargo tree` 检查 `aarch64-unknown-none-softfloat` / `x86_64-unknown-none` 的 normal/build feature 图，确认未启用 `host-test`；
- `cargo fmt --all --check`；
- `git diff --check`；
- `cargo xtask test`：49/49 std 白名单包通过。

Fixes #1774
