### PR TITLE
fix(axbuild): guard Starry ktest no_std features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -300,7 +300,7 @@ bincode = "2.0.1"
 bitflags = "2.11"
 byte-unit = { version = "5", default-features = false, features = ["byte"] }
 derive_more = { version = "2.1", default-features = false, features = ["full"] }
-bindgen = "0.72"
+bindgen = { version = "0.72", default-features = false, features = ["runtime"] }
 buddy-slab-allocator = { version = "0.4", path = "memory/buddy-slab-allocator" }
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false }

--- a/scripts/axbuild/src/ktest/tests.rs
+++ b/scripts/axbuild/src/ktest/tests.rs
@@ -1,3 +1,5 @@
+use std::process::Command;
+
 use super::*;
 
 #[test]
@@ -111,6 +113,95 @@ fn starry_kernel_ktest_axstd_dev_dependency_keeps_freestanding_entry_contract() 
             .all(|feature| !matches!(feature.as_str(), Some("std-compat" | "tls"))),
         "Starry ktest targets share the bare no_std/no-TLS kernel entry contract"
     );
+}
+
+#[test]
+fn workspace_bindgen_consumers_use_minimal_host_features() {
+    let workspace_root = crate::context::workspace_root_path().unwrap();
+    let workspace_manifest: toml::Table =
+        toml::from_str(&fs::read_to_string(workspace_root.join("Cargo.toml")).unwrap()).unwrap();
+    let bindgen = workspace_manifest["workspace"]["dependencies"]["bindgen"]
+        .as_table()
+        .expect("workspace bindgen dependency must declare an explicit feature contract");
+    let features = bindgen["features"].as_array().unwrap();
+
+    assert_eq!(bindgen["default-features"].as_bool(), Some(false));
+    assert_eq!(
+        features
+            .iter()
+            .filter_map(toml::Value::as_str)
+            .collect::<Vec<_>>(),
+        ["runtime"],
+        "workspace bindgen consumers only need runtime libclang loading"
+    );
+
+    for manifest_path in [
+        "os/arceos/api/arceos_posix_api/Cargo.toml",
+        "os/arceos/ulib/axlibc/Cargo.toml",
+    ] {
+        let manifest: toml::Table =
+            toml::from_str(&fs::read_to_string(workspace_root.join(manifest_path)).unwrap())
+                .unwrap();
+        let bindgen = manifest["build-dependencies"]["bindgen"]
+            .as_table()
+            .unwrap();
+
+        assert_eq!(bindgen["workspace"].as_bool(), Some(true));
+        assert!(
+            bindgen.get("features").is_none(),
+            "{manifest_path} must inherit the workspace bindgen feature contract"
+        );
+    }
+}
+
+#[test]
+fn starry_kernel_ktest_target_log_features_remain_no_std() {
+    let workspace_root = crate::context::workspace_root_path().unwrap();
+
+    for target in [
+        "x86_64-unknown-none",
+        "riscv64gc-unknown-none-elf",
+        "aarch64-unknown-none-softfloat",
+        "loongarch64-unknown-none-softfloat",
+    ] {
+        let output = Command::new(env!("CARGO"))
+            .current_dir(&workspace_root)
+            .args([
+                "tree",
+                "--locked",
+                "--package",
+                "starry-kernel",
+                "--target",
+                target,
+                "--features",
+                "axtest",
+                "--edges",
+                "normal,dev",
+                "--invert",
+                "log",
+                "--depth",
+                "0",
+                "--format",
+                "{p}|{f}",
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "failed to resolve Starry ktest target graph for {target}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let resolved_log = String::from_utf8(output.stdout).unwrap();
+        let (_, features) = resolved_log
+            .trim()
+            .split_once('|')
+            .expect("cargo tree must report the resolved log feature set");
+        assert!(
+            features.split(',').all(|feature| feature != "std"),
+            "{target} must compile log without std, resolved features: {features}"
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## 问题

Issue #1772 报告 `starry-kernel` 的 bare-metal ktest 在编译 `log` 时错误启用了 `std`。在最新 `dev` 上重新执行 x86_64 与 RISC-V 原始复现命令时，补丁前已能完成 QEMU 测试，因此当前无法复现当时的编译失败。

依赖图核验同时发现，未限定 target 与 edge 类型的 `cargo tree` 会把 host build-dependency 和 bare-metal target dependency 放在同一输出中。工作区的 `bindgen` 默认特性包含 host 侧日志支持；它不应成为 target 侧 `log/std` 的证据，但这一 host feature 合约此前也没有显式收紧。

## 修改

1. 将工作区 `bindgen` 配置为关闭默认特性，只启用动态加载 libclang 所需的 `runtime`。
2. 增加 manifest 合约测试，确保两个直接的 workspace bindgen 使用方继续继承这份最小 host feature 配置。
3. 增加实际依赖图回归：分别针对 x86_64、RISC-V、AArch64、LoongArch64 bare-metal target，使用 `normal,dev` edges 解析 `starry-kernel + axtest`，断言 target 图中的 `log` 不包含 `std`。

这样分别约束了可控的 host 构建依赖配置和最终 target 解析结果，不通过给 bare-metal 测试加入 `std`、删测试或放宽成功条件来绕过问题。

## 回归证明

- 修复前，manifest 合约测试会因 workspace bindgen 未声明显式 feature 合约而失败。
- 将 workspace `log` 模拟为启用 `std` 后，依赖图回归确定性失败并报告：

  ```text
  x86_64-unknown-none must compile log without std, resolved features: std
  ```

- 恢复 no_std 配置后，同一回归通过。

## 验证

- `cargo fmt --all --check`
- `cargo test -p axbuild ktest::tests --lib`：12 passed
- `cargo xtask clippy --package axbuild --package ax-posix-api --package ax-libc`：34 checks passed
- `cargo xtask ktest qemu --package starry-kernel --arch x86_64`：399 passed，`AXTEST_SUITE_OK`
- `cargo xtask ktest qemu --package starry-kernel --arch riscv64`：394 passed，`AXTEST_SUITE_OK`
- `cargo xtask ktest qemu --package starry-kernel --arch aarch64`：394 passed，`AXTEST_SUITE_OK`
- `cargo xtask ktest qemu --package starry-kernel --arch loongarch64`：394 passed，`AXTEST_SUITE_OK`

Fixes #1772
