### PR TITLE
fix(axbuild): lint Starry aarch64 configurations

### DIFF
--- a/docs/docs/build/clippy.md
+++ b/docs/docs/build/clippy.md
@@ -54,6 +54,7 @@ Clippy 的代码按选择、展开、执行和报告划分，避免参数解析�
 | `scripts/axbuild/src/clippy/mod.rs` | CLI 入口、模块级常量（如 `AXSTD_STD_*`、`AX_HAL_PACKAGE`） |
 | `scripts/axbuild/src/clippy/selection.rs` | 参数校验、包选择（全量 / `--package` / `--since` 增量）、不支持的包过滤 |
 | `scripts/axbuild/src/clippy/check.rs` | `ClippyCheck` / `ClippyCheckKind` / `ClippyDepsMode` 数据模型与 `cargo_args` 构造 |
+| `scripts/axbuild/src/clippy/configurations.rs` | 解析并校验 package metadata 中声明的命名 target 配置 |
 | `scripts/axbuild/src/clippy/expand.rs` | 把每个包按 feature × target 展开为 `ClippyCheck` 列表 |
 | `scripts/axbuild/src/clippy/env.rs` | 为特殊 check 计算所需环境变量；普通包当前不额外注入环境变量 |
 | `scripts/axbuild/src/clippy/targets.rs` | 从 docs.rs metadata 提取包支持的 target，以及 feature↔target 兼容性判断 |
@@ -89,12 +90,29 @@ Clippy 的代码按选择、展开、执行和报告划分，避免参数解析�
 2. **feature** 取包 `Cargo.toml` 中除 `default` 外的全部 feature；`ax-std` 额外注入一个名为 `default` 的特殊 feature。
 3. 每个 (target, base) 组合产生一个 base check；`NoDeps` 模式下再为每个该 target 支持的 feature 产生一个 feature check。
 4. feature check 使用对应 feature 名执行；普通包不额外注入构建环境变量。
+5. `NoDeps` 模式下，包还可以通过 `[package.metadata.clippy]` 声明命名配置；每条配置按一个明确 target、完整 feature 集和环境变量额外生成 check。`WithDeps` 仍只运行 base check，避免增量反向依赖扫描膨胀成完整配置矩阵。
+
+命名配置用于 docs.rs target × 单 feature 矩阵无法表达的正式构建组合。它保留包的默认 feature，再额外启用配置中的完整 feature 集：
+
+```toml
+[[package.metadata.clippy.configurations]]
+name = "aarch64-system"
+target = "aarch64-unknown-none-softfloat"
+features = ["ax-runtime/display", "input", "smp"]
+
+[package.metadata.clippy.configurations.env]
+AX_ARCH = "aarch64"
+AX_TARGET = "aarch64-unknown-none-softfloat"
+SMP = "4"
+```
+
+配置名必须在包内唯一，名称、target 和 feature 必须非空且不能带首尾空白。配置与 feature 会排序去重，环境变量按键排序，因此 check 顺序、命令参数和日志在不同运行间保持一致。命名配置不会把包的所有单 feature 机械展开到目标架构；平台专属组合应显式声明，从而避免把 SG2002、K230 等 feature 编译到错误 target。
 
 `ax-std` 的 `default` feature 被特殊重写为 `std-compat,fs,multitask,irq,net`（常量 `AXSTD_STD_CLIPPY_FEATURES`），target 固定为 `x86_64-unknown-none`，以便在没有真实平台的情况下覆盖 std 兼容层。
 
 ### 4.1 目标归一化
 
-`docs_rs_targets(package)` 从包 `Cargo.toml` 的 `[package.metadata.docs.rs]` 或 `[package.metadata.docs]` 节读取 `targets` 数组。两个节都支持，`docs.rs` 优先于 `docs.rs`：
+`docs_rs_targets(package)` 从包 `Cargo.toml` 的 `[package.metadata.docs.rs]` 或 `[package.metadata.docs]` 节读取 `targets` 数组。两个节都支持，`docs.rs` 优先于嵌套的 `docs.rs`：
 
 ```toml
 [package.metadata.docs.rs]
@@ -127,6 +145,7 @@ targets = ["aarch64-unknown-linux-gnu", "riscv64gc-unknown-none-elf"]
 
 - Base check：`clippy -p <pkg>`
 - Feature check：`clippy -p <pkg> --no-default-features --features <feature>`
+- Named configuration check：`clippy -p <pkg> --features <feature-a>,<feature-b> --target <target>`，并注入配置声明的环境变量
 - `ax-std` default 特判：替换为 `--features std-compat,fs,multitask,irq,net`
 - `NoDeps`：在 `clippy` 后插入 `--no-deps`，避免依赖 crate 的告警污染结果
 - 有 target：追加 `--target <target>`

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -13,6 +13,55 @@ authors = [
 repository.workspace = true
 license.workspace = true
 
+[[package.metadata.clippy.configurations]]
+name = "aarch64-system"
+target = "aarch64-unknown-none-softfloat"
+features = [
+    "ax-driver/nvme",
+    "ax-driver/serial",
+    "ax-driver/virtio-gpu",
+    "ax-driver/virtio-input",
+    "ax-driver/virtio-net",
+    "ax-driver/virtio-socket",
+    "ax-driver/xhci-pci",
+    "ax-runtime/display",
+    "ax-runtime/rtc",
+    "smp",
+    "starry-kernel/input",
+    "starry-kernel/vsock",
+]
+
+[package.metadata.clippy.configurations.env]
+AX_ARCH = "aarch64"
+AX_LOG = "warn"
+AX_TARGET = "aarch64-unknown-none-softfloat"
+SMP = "4"
+
+[[package.metadata.clippy.configurations]]
+name = "aarch64-system-rga"
+target = "aarch64-unknown-none-softfloat"
+features = [
+    "ax-driver/nvme",
+    "ax-driver/serial",
+    "ax-driver/virtio-gpu",
+    "ax-driver/virtio-input",
+    "ax-driver/virtio-net",
+    "ax-driver/virtio-socket",
+    "ax-driver/xhci-pci",
+    "ax-runtime/display",
+    "ax-runtime/rtc",
+    "rga",
+    "smp",
+    "starry-kernel/input",
+    "starry-kernel/vsock",
+]
+
+[package.metadata.clippy.configurations.env]
+AX_ARCH = "aarch64"
+AX_LOG = "warn"
+AX_TARGET = "aarch64-unknown-none-softfloat"
+SMP = "4"
+
 [features]
 default = ["dynamic_debug"]
 dev-log = []

--- a/os/StarryOS/kernel/src/perf/bpf.rs
+++ b/os/StarryOS/kernel/src/perf/bpf.rs
@@ -40,6 +40,7 @@ use crate::{
 /// Number of 4K pages reserved for x86_64 BPF JIT executable memory.
 /// Each JIT-compiled eBPF program fits within this space; the allocation
 /// is sized generously (16 KiB) since programs are typically < 1 page.
+#[cfg(target_arch = "x86_64")]
 const BPF_JIT_MEM_PAGES: usize = 4;
 
 /// Wraps `kbpf_basic::perf::bpf::BpfPerfEvent` with kernel state: a poll

--- a/os/StarryOS/kernel/src/perf/sideband.rs
+++ b/os/StarryOS/kernel/src/perf/sideband.rs
@@ -102,7 +102,7 @@ fn push_u64(b: &mut Vec<u8>, v: u64) {
 fn push_cstr_padded(b: &mut Vec<u8>, s: &[u8]) {
     b.extend_from_slice(s);
     b.push(0);
-    while b.len() % 8 != 0 {
+    while !b.len().is_multiple_of(8) {
         b.push(0);
     }
 }
@@ -138,7 +138,7 @@ fn push_trailer(b: &mut Vec<u8>, t: &SidebandTarget) {
 /// Back-patch the 8-byte header (reserved at the front of `b`) once the full
 /// record length (8-aligned) is known, then write it into the ring.
 fn finish_and_write(mut b: Vec<u8>, t: &SidebandTarget, type_: u32, misc: u16) {
-    while b.len() % 8 != 0 {
+    while !b.len().is_multiple_of(8) {
         b.push(0);
     }
     let size = b.len() as u16;

--- a/os/StarryOS/kernel/src/perf/task.rs
+++ b/os/StarryOS/kernel/src/perf/task.rs
@@ -546,7 +546,7 @@ pub fn attach(thr: &Thread, ptc: Arc<PerTaskCounter>) {
 ///
 /// Runs with IRQs disabled inside `switch_to`: [`SpinNoIrq`](ax_sync::spin::SpinNoIrq)
 /// + atomics + sysreg writes only, no allocation. `sampling::register` nests a
-/// further local-IRQ-off section, which is fine.
+///   further local-IRQ-off section, which is fine.
 pub fn perf_sched_in(thr: &Thread) {
     if PERF_TASK_ACTIVE.load(Ordering::Acquire) == 0 {
         return;
@@ -756,8 +756,8 @@ pub fn on_exec_sideband(thr: &Thread) {
     if PERF_TASK_ACTIVE.load(Ordering::Acquire) == 0 {
         return;
     }
-    let pid = thr.proc_data.proc.pid() as u32;
-    let tid = thr.tid() as u32;
+    let pid = thr.proc_data.proc.pid();
+    let tid = thr.tid();
 
     /// A target plus which record kinds it wants (so the COMM/MMAP2 loops below
     /// can each skip non-subscribers without re-walking the counter list).
@@ -823,8 +823,8 @@ pub fn on_mmap_sideband(
     if PERF_TASK_ACTIVE.load(Ordering::Acquire) == 0 {
         return;
     }
-    let pid = thr.proc_data.proc.pid() as u32;
-    let tid = thr.tid() as u32;
+    let pid = thr.proc_data.proc.pid();
+    let tid = thr.tid();
     let targets: Vec<SidebandTarget> = {
         let counters = thr.perf_counters.lock();
         counters

--- a/scripts/axbuild/src/clippy/check.rs
+++ b/scripts/axbuild/src/clippy/check.rs
@@ -4,6 +4,7 @@ use super::{AXSTD_STD_CLIPPY_FEATURES, AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACK
 pub(super) enum ClippyCheckKind {
     Base,
     Feature(String),
+    Configuration { name: String, features: Vec<String> },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -33,6 +34,13 @@ impl ClippyCheck {
                 "--features".into(),
                 feature.clone(),
             ],
+            ClippyCheckKind::Configuration { features, .. } => {
+                let mut args = vec!["clippy".into(), "-p".into(), self.package.clone()];
+                if !features.is_empty() {
+                    args.extend(["--features".into(), features.join(",")]);
+                }
+                args
+            }
         };
         if self.package == AXSTD_STD_PACKAGE
             && matches!(&self.kind, ClippyCheckKind::Feature(feature) if feature == AXSTD_STD_DEFAULT_FEATURE)
@@ -62,6 +70,12 @@ impl ClippyCheck {
             ClippyCheckKind::Feature(feature) => {
                 format!("{} (feature: {}", self.package, feature)
             }
+            ClippyCheckKind::Configuration { name, features } => format!(
+                "{} (configuration: {}, features: {}",
+                self.package,
+                name,
+                features.join(",")
+            ),
         };
 
         match &self.target {

--- a/scripts/axbuild/src/clippy/configurations.rs
+++ b/scripts/axbuild/src/clippy/configurations.rs
@@ -1,0 +1,99 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, ensure};
+use cargo_metadata::Package;
+use serde::Deserialize;
+
+use super::targets::normalize_clippy_target;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PackageClippyConfiguration {
+    pub(super) name: String,
+    pub(super) target: String,
+    pub(super) features: Vec<String>,
+    pub(super) env: Vec<(String, String)>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PackageMetadata {
+    #[serde(default)]
+    clippy: ClippyMetadata,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ClippyMetadata {
+    #[serde(default)]
+    configurations: Vec<RawClippyConfiguration>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawClippyConfiguration {
+    name: String,
+    target: String,
+    #[serde(default)]
+    features: Vec<String>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+pub(super) fn package_clippy_configurations(
+    package: &Package,
+) -> anyhow::Result<Vec<PackageClippyConfiguration>> {
+    if package.metadata.is_null() {
+        return Ok(Vec::new());
+    }
+    let metadata = serde_json::from_value::<PackageMetadata>(package.metadata.clone())
+        .with_context(|| format!("invalid clippy metadata for `{}`", package.name))?;
+    let mut names = BTreeSet::new();
+    let mut configurations = metadata
+        .clippy
+        .configurations
+        .into_iter()
+        .map(|configuration| validate_configuration(package, configuration, &mut names))
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    configurations.sort_by(|left, right| left.name.cmp(&right.name));
+    Ok(configurations)
+}
+
+fn validate_configuration(
+    package: &Package,
+    configuration: RawClippyConfiguration,
+    names: &mut BTreeSet<String>,
+) -> anyhow::Result<PackageClippyConfiguration> {
+    ensure!(
+        !configuration.name.is_empty() && configuration.name.trim() == configuration.name,
+        "clippy configuration name for `{}` must be non-empty and trimmed",
+        package.name
+    );
+    ensure!(
+        names.insert(configuration.name.clone()),
+        "duplicate clippy configuration `{}` for `{}`",
+        configuration.name,
+        package.name
+    );
+    ensure!(
+        !configuration.target.is_empty() && configuration.target.trim() == configuration.target,
+        "clippy configuration `{}` target for `{}` must be non-empty and trimmed",
+        configuration.name,
+        package.name
+    );
+
+    let mut features = BTreeSet::new();
+    for feature in configuration.features {
+        ensure!(
+            !feature.is_empty() && feature.trim() == feature,
+            "clippy configuration `{}` feature for `{}` must be non-empty and trimmed",
+            configuration.name,
+            package.name
+        );
+        features.insert(feature);
+    }
+
+    Ok(PackageClippyConfiguration {
+        name: configuration.name,
+        target: normalize_clippy_target(&configuration.target).to_string(),
+        features: features.into_iter().collect(),
+        env: configuration.env.into_iter().collect(),
+    })
+}

--- a/scripts/axbuild/src/clippy/expand.rs
+++ b/scripts/axbuild/src/clippy/expand.rs
@@ -6,6 +6,7 @@ use cargo_metadata::Metadata;
 use super::{
     AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE, DEFAULT_FEATURE,
     check::{ClippyCheck, ClippyCheckKind, ClippyDepsMode},
+    configurations::package_clippy_configurations,
     env::{clippy_env, feature_clippy_env},
     selection::SelectedClippyPackage,
     targets::{docs_rs_targets, feature_supported_on_clippy_target},
@@ -65,6 +66,21 @@ pub(super) fn expand_clippy_checks(
                     deps_mode: selected.deps_mode.clone(),
                     target: target.clone(),
                     env: feature_env,
+                });
+            }
+        }
+
+        if matches!(selected.deps_mode, ClippyDepsMode::NoDeps) {
+            for configuration in package_clippy_configurations(package)? {
+                checks.push(ClippyCheck {
+                    package: package.name.to_string(),
+                    kind: ClippyCheckKind::Configuration {
+                        name: configuration.name,
+                        features: configuration.features,
+                    },
+                    deps_mode: selected.deps_mode.clone(),
+                    target: Some(configuration.target),
+                    env: configuration.env,
                 });
             }
         }

--- a/scripts/axbuild/src/clippy/mod.rs
+++ b/scripts/axbuild/src/clippy/mod.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, bail};
 use chrono::Local;
 
 mod check;
+mod configurations;
 mod env;
 mod expand;
 mod report;

--- a/scripts/axbuild/src/clippy/targets.rs
+++ b/scripts/axbuild/src/clippy/targets.rs
@@ -58,7 +58,7 @@ pub(super) fn docs_rs_targets(package: &Package) -> Vec<String> {
     unique_targets.into_iter().collect()
 }
 
-fn normalize_clippy_target(target: &str) -> &str {
+pub(super) fn normalize_clippy_target(target: &str) -> &str {
     CLIPPY_TARGET_ALIASES
         .iter()
         .find_map(|(source, normalized)| (*source == target).then_some(*normalized))

--- a/scripts/axbuild/src/clippy/tests/expand.rs
+++ b/scripts/axbuild/src/clippy/tests/expand.rs
@@ -1,8 +1,9 @@
-use super::common::{expand, metadata_with_resolve, pkg, pkg_with_metadata};
+use super::common::{expand, metadata_for_packages, metadata_with_resolve, pkg, pkg_with_metadata};
 use crate::clippy::{
     AXSTD_STD_CLIPPY_FEATURES, AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE,
     check::{ClippyCheck, ClippyCheckKind, ClippyDepsMode},
-    selection::incremental_clippy_selections,
+    configurations::package_clippy_configurations,
+    selection::{SelectedClippyPackage, incremental_clippy_selections},
     targets::docs_rs_targets,
 };
 
@@ -613,4 +614,215 @@ fn empty_docs_rs_targets_fall_back_to_host_clippy() {
         expand(&[package])[0].cargo_args(),
         vec!["clippy", "--no-deps", "-p", "alpha", "--", "-D", "warnings"]
     );
+}
+
+#[test]
+fn package_clippy_configurations_expand_target_feature_sets() {
+    let checks = expand(&[pkg_with_metadata(
+        "arm-perf-fixture",
+        "arm-perf-fixture 0.1.0 (path+file:///tmp/arm-perf-fixture)",
+        &[("default", &["dynamic-debug"]), ("dynamic-debug", &[])],
+        serde_json::json!({
+            "clippy": {
+                "configurations": [{
+                    "name": "aarch64-system",
+                    "target": "aarch64-unknown-none-softfloat",
+                    "features": [
+                        "ax-runtime/display",
+                        "input",
+                        "smp",
+                    ],
+                    "env": {
+                        "AX_ARCH": "aarch64",
+                        "AX_LOG": "warn",
+                        "AX_TARGET": "aarch64-unknown-none-softfloat",
+                        "SMP": "4",
+                    },
+                }],
+            },
+        }),
+    )]);
+
+    let target_configuration = checks
+        .iter()
+        .find(|check| {
+            check.label()
+                == "arm-perf-fixture (configuration: aarch64-system, features: \
+                    ax-runtime/display,input,smp, target: aarch64-unknown-none-softfloat)"
+        })
+        .expect("aarch64 system configuration should be planned");
+
+    assert_eq!(
+        target_configuration.cargo_args(),
+        vec![
+            "clippy",
+            "--no-deps",
+            "-p",
+            "arm-perf-fixture",
+            "--features",
+            "ax-runtime/display,input,smp",
+            "--target",
+            "aarch64-unknown-none-softfloat",
+            "--",
+            "-D",
+            "warnings",
+        ]
+    );
+    assert_eq!(
+        target_configuration.env,
+        vec![
+            ("AX_ARCH".into(), "aarch64".into()),
+            ("AX_LOG".into(), "warn".into()),
+            ("AX_TARGET".into(), "aarch64-unknown-none-softfloat".into()),
+            ("SMP".into(), "4".into()),
+        ]
+    );
+}
+
+#[test]
+fn with_deps_selection_does_not_expand_package_clippy_configurations() {
+    let package = pkg_with_metadata(
+        "alpha",
+        "alpha 0.1.0 (path+file:///tmp/alpha)",
+        &[],
+        serde_json::json!({
+            "clippy": {
+                "configurations": [{
+                    "name": "aarch64-system",
+                    "target": "aarch64-unknown-none-softfloat",
+                }],
+            },
+        }),
+    );
+    let metadata = metadata_for_packages(core::slice::from_ref(&package));
+    let checks = crate::clippy::expand::expand_clippy_checks(
+        &[SelectedClippyPackage {
+            package,
+            deps_mode: ClippyDepsMode::WithDeps,
+        }],
+        &metadata,
+    )
+    .unwrap();
+
+    assert_eq!(checks.len(), 1);
+    assert_eq!(checks[0].label(), "alpha (base)");
+}
+
+#[test]
+fn duplicate_package_clippy_configuration_names_are_rejected() {
+    let package = pkg_with_metadata(
+        "alpha",
+        "alpha 0.1.0 (path+file:///tmp/alpha)",
+        &[],
+        serde_json::json!({
+            "clippy": {
+                "configurations": [
+                    {
+                        "name": "aarch64-system",
+                        "target": "aarch64-unknown-none-softfloat",
+                    },
+                    {
+                        "name": "aarch64-system",
+                        "target": "aarch64-unknown-none-softfloat",
+                    },
+                ],
+            },
+        }),
+    );
+
+    let err = package_clippy_configurations(&package).unwrap_err();
+
+    assert_eq!(
+        err.to_string(),
+        "duplicate clippy configuration `aarch64-system` for `alpha`"
+    );
+}
+
+#[test]
+fn starry_aarch64_clippy_configurations_match_qemu_builds() {
+    let workspace_root = crate::context::find_workspace_root();
+    let manifest: StarryKernelManifest = toml::from_str(
+        &std::fs::read_to_string(workspace_root.join("os/StarryOS/kernel/Cargo.toml")).unwrap(),
+    )
+    .unwrap();
+
+    for (name, relative_build_path) in [
+        (
+            "aarch64-system",
+            "test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml",
+        ),
+        (
+            "aarch64-system-rga",
+            "test-suit/starryos/qemu-rga/build-aarch64-unknown-none-softfloat.toml",
+        ),
+    ] {
+        let build: StarryBuildConfiguration = toml::from_str(
+            &std::fs::read_to_string(workspace_root.join(relative_build_path)).unwrap(),
+        )
+        .unwrap();
+        let configuration = manifest
+            .package
+            .metadata
+            .clippy
+            .configurations
+            .iter()
+            .find(|configuration| configuration.name == name)
+            .unwrap();
+        let mut expected_features = build.features;
+        expected_features.push("smp".into());
+        expected_features.sort();
+        expected_features.dedup();
+
+        assert_eq!(configuration.features, expected_features);
+        assert_eq!(configuration.target, build.target);
+        assert_eq!(configuration.env.get("AX_ARCH"), Some(&"aarch64".into()));
+        assert_eq!(
+            configuration.env.get("AX_TARGET"),
+            Some(&configuration.target)
+        );
+        assert_eq!(
+            configuration.env.get("AX_LOG"),
+            Some(&build.log.to_ascii_lowercase())
+        );
+        assert_eq!(
+            configuration.env.get("SMP"),
+            Some(&build.max_cpu_num.to_string())
+        );
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct StarryKernelManifest {
+    package: StarryKernelPackage,
+}
+
+#[derive(serde::Deserialize)]
+struct StarryKernelPackage {
+    metadata: StarryKernelMetadata,
+}
+
+#[derive(serde::Deserialize)]
+struct StarryKernelMetadata {
+    clippy: StarryClippyMetadata,
+}
+
+#[derive(serde::Deserialize)]
+struct StarryClippyMetadata {
+    configurations: Vec<StarryClippyConfiguration>,
+}
+
+#[derive(serde::Deserialize)]
+struct StarryClippyConfiguration {
+    name: String,
+    target: String,
+    features: Vec<String>,
+    env: std::collections::BTreeMap<String, String>,
+}
+
+#[derive(serde::Deserialize)]
+struct StarryBuildConfiguration {
+    features: Vec<String>,
+    max_cpu_num: usize,
+    log: String,
+    target: String,
 }


### PR DESCRIPTION
## 问题与根因

现有 `cargo xtask clippy --package starry-kernel` 只按宿主 target 展开 base/单 feature 检查，因此 `cfg(target_arch = "aarch64")` 下的 Starry perf 模块不会进入 clippy。仅把 docs.rs target 加入现有 feature 矩阵又会把 SG2002、K230 等平台 feature 机械编译到错误架构，并且无法表达正式 QEMU 构建实际使用的完整 feature 与环境变量组合。

## 修改内容

1. 为 axbuild clippy 增加 package metadata 驱动的命名配置：每个配置显式声明 target、完整 feature 集和环境变量；配置保留包默认 feature，只在 `NoDeps` 选择中追加，`WithDeps` 增量反向依赖检查仍保持单个 base check。
2. 为 `starry-kernel` 声明 `aarch64-system` 和 `aarch64-system-rga` 两个配置，分别与普通 AArch64 QEMU 和 qemu-rga 的正式构建配置一致，并补入运行路径实际启用的 `smp`/`SMP=4`。
3. 修复新检查实际暴露的 8 个 AArch64 perf clippy 错误：限定 x86_64 BPF JIT 常量、使用 `is_multiple_of`、修正文档缩进并移除无效 pid/tid 转换。相关修改不改变 Starry syscall/Linux ABI 行为。
4. 增加确定性测试，覆盖命名配置展开、默认 feature 保留、排序后的日志/命令、重复名称拒绝、WithDeps 不展开，以及 Starry 配置与两份 QEMU build TOML 的一致性；同时更新 clippy 文档。

## 设计取舍

- 没有复用 docs.rs 的 target × 单 feature 展开，因为它既不能表示正式构建组合，也会产生错误架构的平台 feature 组合。
- 没有增加仅供 CI 使用的合成 Cargo feature，避免把测试编排泄漏为 `starry-kernel` 的公共 feature 接口。
- 命名配置复用现有 `selection -> expand -> check -> report` 边界，并对名称、target、feature 做校验和确定性排序，使后续包可以按同一机制补充正式 target 组合。

## 红绿回归证明

- 先加入配置展开 fixture；旧实现运行精确测试时以 `aarch64 system configuration should be planned` 失败（退出码 101）。实现后同一测试通过。
- 首次运行新增的真实 AArch64 配置时，clippy 进入此前未编译的 perf 模块并确定性报出 8 个错误；修复后完整 Starry 矩阵为 24/24 通过，其中最后两项分别显示普通与 RGA 的 target、完整 feature 和环境变量。

## 本地验证

- `cargo test -p axbuild --lib`：790 passed
- `cargo xtask clippy --package axbuild`：1/1 passed
- `cargo xtask clippy --package starry-kernel`：24/24 passed
- `cargo xtask starry test qemu --arch aarch64`：3/3 passed（RGA system、普通 system、TTY input burst）
- `cargo fmt --all --check`
- `git diff --check origin/dev...HEAD`

Fixes #1773