### PR TITLE
fix(axbuild): reduce Starry test-suit log noise

### DIFF
--- a/.claude/skills/starry-test-suit/SKILL.md
+++ b/.claude/skills/starry-test-suit/SKILL.md
@@ -74,6 +74,9 @@ Prefer multi-line TOML strings for longer shell commands. Keep `fail_regex` narr
 - QEMU `success_regex` and `fail_regex` must reliably distinguish the intended pass and fail states. A failure marker such as `STARRY_GROUPED_TEST_FAILED` must be matched by `fail_regex`, and the all-passed marker must only appear after every required subcase has passed.
 - In QEMU grouped/system wrappers, any failing subcase must print the per-subcase failure marker, suppress the grouped all-passed marker, print a grouped failure marker, and return a nonzero result to the outer runner.
 - In QEMU shell wrappers, capture a test command's `$?` immediately after the command before assigning variables, printing logs, or doing cleanup. Assignments such as `status=failed` reset `$?` to zero and can hide the true exit status if done first.
+- Keep grouped/system logs compact but traceable: print a begin marker before each binary, one passed or failed result with its binary path and elapsed seconds, and one suite summary. Do not repeat the same per-binary durations in a trailing timing block.
+- Test-suit CMake configure, build, and install commands are quiet on success. On failure, the runner must replay the command, stdout, stderr, exit status, and phase context; prebuild and guest/QEMU output remain live.
+- Select rootfs extraction privileges before starting `debugfs`: direct `rdump` requires full host ownership privileges; otherwise enter `fakeroot` first. On Linux, check EUID, full UID/GID identity mappings, and effective `CAP_CHOWN`. If `fakeroot` is unavailable when required, fail before `debugfs` starts; do not emit and then filter ownership warnings or silently retry with weaker semantics.
 - Explicit QEMU skips are allowed only when the test prints a clear skip marker and the review or case comment explains why the environment cannot require success. Bugfix and regression QEMU tests should fail loudly when the fixed behavior is absent.
 
 ## Editing Rules

--- a/.github/workflows/reusable-command.yml
+++ b/.github/workflows/reusable-command.yml
@@ -191,10 +191,21 @@ jobs:
         if: inputs.download_xtask_bin_artifact
         shell: bash
         run: |
-          set -eux
-          tar -xf "${RUNNER_TEMP}/xtask-bin/tg-xtask-bin.tar" -C "${GITHUB_WORKSPACE}"
-          chmod +x "${GITHUB_WORKSPACE}/target/debug/tg-xtask"
-          test -x "${GITHUB_WORKSPACE}/target/debug/tg-xtask"
+          set -euo pipefail
+          artifact_path="${RUNNER_TEMP}/xtask-bin/tg-xtask-bin.tar"
+          xtask_path="${GITHUB_WORKSPACE}/target/debug/tg-xtask"
+          if ! tar -xf "${artifact_path}" -C "${GITHUB_WORKSPACE}"; then
+            echo "::error::failed to extract tg-xtask artifact: ${artifact_path}"
+            exit 1
+          fi
+          if [ ! -f "${xtask_path}" ]; then
+            echo "::error::tg-xtask artifact did not contain the expected binary: ${xtask_path}"
+            exit 1
+          fi
+          if ! chmod +x "${xtask_path}" || [ ! -x "${xtask_path}" ]; then
+            echo "::error::restored tg-xtask binary could not be made executable: ${xtask_path}"
+            exit 1
+          fi
 
       - name: Show Rust version
         run: rustc --version
@@ -218,9 +229,14 @@ jobs:
 
           command_file="${RUNNER_TEMP}/reusable-command.sh"
           printf '%s\n' "${command_text}" > "${command_file}"
-          echo "Resolved command:"
-          sed 's/^/+ /' "${command_file}"
-          bash -e -o pipefail "${command_file}"
+          if bash -e -o pipefail "${command_file}"; then
+            :
+          else
+            status=$?
+            echo "Command failed; resolved command:"
+            sed 's/^/+ /' "${command_file}"
+            exit "${status}"
+          fi
 
   run_container:
     if: >-
@@ -245,7 +261,7 @@ jobs:
       - name: Show checkout state
         shell: bash
         run: |
-          set -eux
+          set -euo pipefail
           command -v git
           git -c safe.directory="${GITHUB_WORKSPACE}" rev-parse --show-toplevel
           git -c safe.directory="${GITHUB_WORKSPACE}" rev-parse --is-inside-work-tree
@@ -253,7 +269,7 @@ jobs:
       - name: Ensure qemu user emulators
         shell: bash
         run: |
-          set -eux
+          set -euo pipefail
           for emulator in \
             qemu-aarch64-static \
             qemu-riscv64-static \
@@ -269,7 +285,7 @@ jobs:
       - name: Ensure musl cross toolchains
         shell: bash
         run: |
-          set -eux
+          set -euo pipefail
           for arch in aarch64 riscv64 x86_64 loongarch64; do
             compiler="${arch}-linux-musl-cc"
             if ! command -v "${compiler}" >/dev/null 2>&1; then
@@ -296,10 +312,21 @@ jobs:
         if: inputs.download_xtask_bin_artifact
         shell: bash
         run: |
-          set -eux
-          tar -xf "${RUNNER_TEMP}/xtask-bin/tg-xtask-bin.tar" -C "${GITHUB_WORKSPACE}"
-          chmod +x "${GITHUB_WORKSPACE}/target/debug/tg-xtask"
-          test -x "${GITHUB_WORKSPACE}/target/debug/tg-xtask"
+          set -euo pipefail
+          artifact_path="${RUNNER_TEMP}/xtask-bin/tg-xtask-bin.tar"
+          xtask_path="${GITHUB_WORKSPACE}/target/debug/tg-xtask"
+          if ! tar -xf "${artifact_path}" -C "${GITHUB_WORKSPACE}"; then
+            echo "::error::failed to extract tg-xtask artifact: ${artifact_path}"
+            exit 1
+          fi
+          if [ ! -f "${xtask_path}" ]; then
+            echo "::error::tg-xtask artifact did not contain the expected binary: ${xtask_path}"
+            exit 1
+          fi
+          if ! chmod +x "${xtask_path}" || [ ! -x "${xtask_path}" ]; then
+            echo "::error::restored tg-xtask binary could not be made executable: ${xtask_path}"
+            exit 1
+          fi
 
       - name: Show Rust version
         run: rustc --version
@@ -323,16 +350,24 @@ jobs:
 
           command_file="${RUNNER_TEMP}/reusable-command.sh"
           printf '%s\n' "${command_text}" > "${command_file}"
-          echo "Resolved command:"
-          sed 's/^/+ /' "${command_file}"
-          bash -e -o pipefail "${command_file}"
+          if bash -e -o pipefail "${command_file}"; then
+            :
+          else
+            status=$?
+            echo "Command failed; resolved command:"
+            sed 's/^/+ /' "${command_file}"
+            exit "${status}"
+          fi
 
       - name: Package tg-xtask binary artifact
         if: success() && inputs.upload_xtask_bin_artifact
         shell: bash
         run: |
-          set -eux
-          test -x target/debug/tg-xtask
+          set -euo pipefail
+          if [ ! -x target/debug/tg-xtask ]; then
+            echo "::error::tg-xtask binary is missing or not executable: target/debug/tg-xtask"
+            exit 1
+          fi
           tar -cf "${RUNNER_TEMP}/tg-xtask-bin.tar" target/debug/tg-xtask
 
       - name: Upload tg-xtask binary artifact

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you do not use the container, prepare at least Rust, basic build tools, and c
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 sudo apt update
-sudo apt install -y cmake make ninja-build pkg-config
+sudo apt install -y cmake make ninja-build pkg-config e2fsprogs fakeroot
 sudo apt install -y qemu-system-arm qemu-system-riscv64 qemu-system-x86
 cargo install cargo-binutils
 ```

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
         curl \
         dosfstools \
         e2fsprogs \
+        fakeroot \
         git \
         libavcodec-dev \
         libavdevice-dev \

--- a/container/README.md
+++ b/container/README.md
@@ -7,6 +7,7 @@ Included toolchains:
 - Ubuntu 24.04 base image (minimal packages with `--no-install-recommends`)
 - QEMU `10.2.1` (built from source, with `aarch64/riscv64/loongarch64/x86_64` system and linux-user targets)
 - `qemu-user-static` plus source-built linux-user QEMU binaries for guest-user execution helpers
+- `e2fsprogs`/`debugfs` and `fakeroot` for rootfs extraction without host ownership warnings
 - npm for Starry app asset preparation scripts
 - Rust toolchain from the repository root `rust-toolchain.toml`
 - musl cross compilers for `aarch64/riscv64/loongarch64/x86_64`

--- a/scripts/axbuild/src/rootfs/inject.rs
+++ b/scripts/axbuild/src/rootfs/inject.rs
@@ -1,7 +1,8 @@
 //! Rootfs image content extraction and overlay injection helpers.
 //!
 //! Main responsibilities:
-//! - Use `debugfs` to extract a rootfs image into a staging directory
+//! - Use `debugfs` (under `fakeroot` when host ownership cannot be restored
+//!   directly) to extract a rootfs image into a staging directory
 //! - Write overlay files and directories back into a rootfs image
 //! - Generate and execute `debugfs` scripts for image content updates
 //!
@@ -10,7 +11,7 @@
 
 use std::{
     fs,
-    io::{BufRead, BufReader, Write},
+    io::{self, BufRead, BufReader, Write},
     path::{Path, PathBuf},
     process::{Command, Stdio},
     thread,
@@ -95,20 +96,157 @@ pub(crate) fn replace_file(
 
 /// Extracts the contents of a rootfs image into a host staging directory.
 pub(crate) fn extract_rootfs(rootfs_img: &Path, output_dir: &Path) -> anyhow::Result<()> {
-    let extracted = Command::new("debugfs")
-        .arg("-R")
-        .arg(format!("rdump / {}", output_dir.display()))
-        .arg(rootfs_img)
-        .status()
-        .with_context(|| format!("failed to spawn debugfs for {}", rootfs_img.display()))?
-        .success();
-    ensure!(
-        extracted,
-        "failed to extract {} into {}",
-        rootfs_img.display(),
-        output_dir.display()
-    );
+    #[cfg(unix)]
+    let fakeroot_program = current_process_requires_fakeroot().then_some(Path::new("fakeroot"));
+    #[cfg(not(unix))]
+    let fakeroot_program = None;
+
+    RootfsExtraction {
+        rootfs_img,
+        output_dir,
+        debugfs_program: Path::new("debugfs"),
+        fakeroot_program,
+    }
+    .run()?;
     relativize_absolute_symlinks(output_dir)
+}
+
+/// A preselected rootfs extraction command.
+///
+/// `debugfs rdump` always attempts to restore inode ownership. Callers that
+/// cannot safely perform those `chown` calls therefore run it inside
+/// `fakeroot` before `debugfs` starts. There is intentionally no
+/// direct-execution fallback: a missing `fakeroot` fails before extraction
+/// instead of producing thousands of permission warnings and continuing with
+/// partially restored metadata.
+struct RootfsExtraction<'a> {
+    rootfs_img: &'a Path,
+    output_dir: &'a Path,
+    debugfs_program: &'a Path,
+    fakeroot_program: Option<&'a Path>,
+}
+
+impl RootfsExtraction<'_> {
+    fn run(&self) -> anyhow::Result<()> {
+        let mut command = self.command();
+        let rendered_command = format!("{command:?}");
+        let output = command.output().with_context(|| {
+            if let Some(fakeroot) = self.fakeroot_program {
+                format!(
+                    "failed to spawn fakeroot `{}`; rootfs extraction without full host ownership \
+                     privileges requires fakeroot",
+                    fakeroot.display()
+                )
+            } else {
+                format!("failed to spawn debugfs for {}", self.rootfs_img.display())
+            }
+        })?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        eprintln!("rootfs extraction command failed: {rendered_command}");
+        io::stdout()
+            .write_all(&output.stdout)
+            .context("failed to replay rootfs extraction stdout")?;
+        io::stderr()
+            .write_all(&output.stderr)
+            .context("failed to replay rootfs extraction stderr")?;
+        bail!(
+            "failed to extract {} into {}: command exited with status {}",
+            self.rootfs_img.display(),
+            self.output_dir.display(),
+            output.status
+        );
+    }
+
+    fn command(&self) -> Command {
+        let mut command = if let Some(fakeroot) = self.fakeroot_program {
+            let mut command = Command::new(fakeroot);
+            command.arg("--").arg(self.debugfs_program);
+            command
+        } else {
+            Command::new(self.debugfs_program)
+        };
+        command
+            .arg("-R")
+            .arg(format!("rdump / {}", self.output_dir.display()))
+            .arg(self.rootfs_img);
+        command
+    }
+}
+
+#[cfg(unix)]
+fn effective_uid() -> libc::uid_t {
+    // SAFETY: `geteuid` has no arguments or caller-side safety preconditions.
+    unsafe { libc::geteuid() }
+}
+
+#[cfg(unix)]
+fn current_process_requires_fakeroot() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        requires_fakeroot(
+            effective_uid(),
+            linux_id_map_is_full_identity("/proc/self/uid_map"),
+            linux_id_map_is_full_identity("/proc/self/gid_map"),
+            linux_has_effective_cap_chown(),
+        )
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        effective_uid() != 0
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn requires_fakeroot(
+    effective_uid: libc::uid_t,
+    full_uid_map: bool,
+    full_gid_map: bool,
+    has_effective_cap_chown: bool,
+) -> bool {
+    effective_uid != 0 || !full_uid_map || !full_gid_map || !has_effective_cap_chown
+}
+
+#[cfg(target_os = "linux")]
+fn linux_id_map_is_full_identity(path: &str) -> bool {
+    fs::read_to_string(path)
+        .ok()
+        .is_some_and(|contents| id_map_is_full_identity(&contents))
+}
+
+#[cfg(target_os = "linux")]
+fn id_map_is_full_identity(contents: &str) -> bool {
+    let mut lines = contents.lines().filter(|line| !line.trim().is_empty());
+    let Some(line) = lines.next() else {
+        return false;
+    };
+    if lines.next().is_some() {
+        return false;
+    }
+    let fields = line
+        .split_ascii_whitespace()
+        .map(str::parse::<u64>)
+        .collect::<Result<Vec<_>, _>>();
+    matches!(fields.as_deref(), Ok([0, 0, 4_294_967_295]))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_has_effective_cap_chown() -> bool {
+    fs::read_to_string("/proc/self/status")
+        .ok()
+        .is_some_and(|status| status_has_effective_cap_chown(&status))
+}
+
+#[cfg(target_os = "linux")]
+fn status_has_effective_cap_chown(status: &str) -> bool {
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix("CapEff:"))
+        .and_then(|value| u64::from_str_radix(value.trim(), 16).ok())
+        .is_some_and(|capabilities| capabilities & 1 != 0)
 }
 
 /// Rewrites absolute symlinks in an extracted staging root as equivalent
@@ -441,5 +579,108 @@ mod tests {
             sym0_pos > write_pos,
             "symlink must be second pass, after its target"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn non_root_extraction_starts_debugfs_inside_fakeroot() {
+        let root = tempdir().unwrap();
+        let fakeroot = root.path().join("fakeroot");
+        let debugfs = root.path().join("debugfs");
+        let marker = root.path().join("debugfs-ran-inside-fakeroot");
+        write_executable(
+            &fakeroot,
+            "#!/bin/sh\ntest \"$1\" = \"--\" || exit 91\nshift\nexport \
+             AXBUILD_TEST_FAKEROOT=1\nexec \"$@\"\n",
+        );
+        write_executable(
+            &debugfs,
+            &format!(
+                "#!/bin/sh\ntest \"${{AXBUILD_TEST_FAKEROOT:-}}\" = \"1\" || exit 92\ntouch '{}'\n",
+                marker.display()
+            ),
+        );
+
+        let output_dir = root.path().join("staging");
+        fs::create_dir(&output_dir).unwrap();
+        RootfsExtraction {
+            rootfs_img: Path::new("rootfs.img"),
+            output_dir: &output_dir,
+            debugfs_program: &debugfs,
+            fakeroot_program: Some(&fakeroot),
+        }
+        .run()
+        .unwrap();
+
+        assert!(marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_fakeroot_fails_before_debugfs_starts() {
+        let root = tempdir().unwrap();
+        let debugfs = root.path().join("debugfs");
+        let marker = root.path().join("debugfs-started");
+        write_executable(
+            &debugfs,
+            &format!("#!/bin/sh\ntouch '{}'\n", marker.display()),
+        );
+
+        let output_dir = root.path().join("staging");
+        fs::create_dir(&output_dir).unwrap();
+        let error = RootfsExtraction {
+            rootfs_img: Path::new("rootfs.img"),
+            output_dir: &output_dir,
+            debugfs_program: &debugfs,
+            fakeroot_program: Some(&root.path().join("missing-fakeroot")),
+        }
+        .run()
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("failed to spawn fakeroot"),
+            "unexpected error: {error:#}"
+        );
+        assert!(!marker.exists(), "debugfs must not run without fakeroot");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn direct_extraction_requires_full_host_ownership_privileges() {
+        assert!(!requires_fakeroot(0, true, true, true));
+        assert!(requires_fakeroot(1, true, true, true));
+        assert!(requires_fakeroot(0, false, true, true));
+        assert!(requires_fakeroot(0, true, false, true));
+        assert!(requires_fakeroot(0, true, true, false));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn full_identity_map_rejects_partial_or_split_user_namespaces() {
+        assert!(id_map_is_full_identity("0 0 4294967295\n"));
+        assert!(!id_map_is_full_identity("0 1000 1\n"));
+        assert!(!id_map_is_full_identity("0 1000 1\n1 100000 65535\n"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn cap_chown_parser_requires_effective_capability_bit() {
+        assert!(status_has_effective_cap_chown(
+            "Name:\ttg-xtask\nCapEff:\t0000000000000001\n"
+        ));
+        assert!(!status_has_effective_cap_chown(
+            "Name:\ttg-xtask\nCapEff:\t0000000000000000\n"
+        ));
+        assert!(!status_has_effective_cap_chown(
+            "Name:\ttg-xtask\nCapEff:\tinvalid\n"
+        ));
+    }
+
+    #[cfg(unix)]
+    fn write_executable(path: &Path, contents: &str) {
+        use std::os::unix::fs::PermissionsExt;
+
+        fs::write(path, contents).unwrap();
+        fs::set_permissions(path, fs::Permissions::from_mode(0o755)).unwrap();
     }
 }

--- a/scripts/axbuild/src/starry/test/tests/system_case_tests.rs
+++ b/scripts/axbuild/src/starry/test/tests/system_case_tests.rs
@@ -56,12 +56,15 @@ fn bug_ext4_dir_ops_is_in_system_grouped_qemu_case() {
 }
 
 #[test]
-fn starry_system_grouped_qemu_configs_report_subcase_timing() {
+fn starry_system_grouped_qemu_configs_report_each_result_once() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let system_dir = workspace_root.join("test-suit/starryos/qemu/system");
+    let mut paths = ["aarch64", "loongarch64", "riscv64", "x86_64"]
+        .map(|arch| system_dir.join(format!("qemu-{arch}.toml")))
+        .to_vec();
+    paths.push(workspace_root.join("test-suit/starryos/qemu-rga/system/qemu-aarch64.toml"));
 
-    for arch in ["aarch64", "loongarch64", "riscv64", "x86_64"] {
-        let path = system_dir.join(format!("qemu-{arch}.toml"));
+    for path in paths {
         let content = fs::read_to_string(&path).unwrap();
         let config: toml::Value = toml::from_str(&content).unwrap();
         let test_commands = config
@@ -75,33 +78,31 @@ fn starry_system_grouped_qemu_configs_report_subcase_timing() {
             .unwrap_or_default();
 
         assert!(
-            command.contains("STARRY_SYSTEM_TEST_TIMING_BEGIN"),
-            "{} must start a grouped subcase timing section",
+            command.contains("STARRY_SYSTEM_TEST_BEGIN: $bin"),
+            "{} must identify each test before it starts",
             path.display()
         );
         assert!(
-            command.contains("STARRY_SYSTEM_TEST_TIMING: elapsed_s="),
-            "{} must report per-subcase elapsed seconds",
+            command.contains("STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"),
+            "{} must report one traceable duration for each passing test",
             path.display()
         );
         assert!(
-            command.contains("status=passed bin=") && command.contains("status=failed bin="),
-            "{} must include pass/fail status in timing lines",
+            command.contains("$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"),
+            "{} must report the status and duration of each failing test",
             path.display()
         );
         assert!(
-            command.contains("STARRY_SYSTEM_TEST_TIMING_END"),
-            "{} must end a grouped subcase timing section",
+            command.contains(
+                "STARRY_SYSTEM_TEST_SUMMARY: total=$total passed=$passed failed=$failed \
+                 elapsed_s=$suite_elapsed_s"
+            ),
+            "{} must report one compact suite timing summary",
             path.display()
         );
         assert!(
-            !command.contains("sort -nr") && !command.contains("head -n"),
-            "{} must not depend on external sort/head pipelines in the final timing summary",
-            path.display()
-        );
-        assert!(
-            command.contains("done < \"$timing_file\""),
-            "{} must read grouped subcase timing from the timing file, not from stdin",
+            !command.contains("STARRY_SYSTEM_TEST_TIMING") && !command.contains("timing_file="),
+            "{} must not duplicate per-test durations in a trailing timing block",
             path.display()
         );
         let failure_branch = command.find("else\n").unwrap_or_else(|| {
@@ -117,11 +118,11 @@ fn starry_system_grouped_qemu_configs_report_subcase_timing() {
                 path.display()
             )
         });
-        let status_failed_position = failure_command
-            .find("status=failed")
+        let failed_count_position = failure_command
+            .find("failed=$((failed + 1))")
             .unwrap_or_else(|| panic!("{} must mark failed grouped subcases", path.display()));
         assert!(
-            exit_status_position < status_failed_position,
+            exit_status_position < failed_count_position,
             "{} must capture `$?` before assigning shell variables in the failure branch",
             path.display()
         );

--- a/scripts/axbuild/src/support/process.rs
+++ b/scripts/axbuild/src/support/process.rs
@@ -10,6 +10,7 @@ use colored::Colorize;
 
 pub trait ProcessExt {
     fn exec(&mut self) -> Result<()>;
+    fn exec_quiet(&mut self) -> Result<()>;
 }
 
 pub(crate) fn run_cargo_status(workspace_root: &Path, args: &[String]) -> Result<bool> {
@@ -50,11 +51,45 @@ impl ProcessExt for Command {
             bail!("command exited with status {status}");
         }
     }
+
+    fn exec_quiet(&mut self) -> Result<()> {
+        let mut stdout = io::stdout().lock();
+        let mut stderr = io::stderr().lock();
+        exec_quiet_with_writers(self, &mut stdout, &mut stderr)
+    }
 }
 
 fn print_command(command: &Command) -> Result<()> {
-    let rendered = render_command(command);
     let mut stderr = io::stderr().lock();
+    print_command_to(command, &mut stderr)?;
+    Ok(())
+}
+
+fn exec_quiet_with_writers(
+    command: &mut Command,
+    stdout: &mut dyn Write,
+    stderr: &mut dyn Write,
+) -> Result<()> {
+    let rendered = render_command(command);
+    let output = command
+        .output()
+        .with_context(|| format!("failed to spawn process `{rendered}`"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+
+    print_command_to(command, stderr)?;
+    stdout
+        .write_all(&output.stdout)
+        .context("failed to replay command stdout")?;
+    stderr
+        .write_all(&output.stderr)
+        .context("failed to replay command stderr")?;
+    bail!("command exited with status {}", output.status);
+}
+
+fn print_command_to(command: &Command, stderr: &mut dyn Write) -> Result<()> {
+    let rendered = render_command(command);
     writeln!(stderr, "{}", rendered.purple()).context("failed to print command")?;
     Ok(())
 }
@@ -81,5 +116,46 @@ fn shell_escape(value: &OsStr) -> String {
         value.into_owned()
     } else {
         format!("'{}'", value.replace('\'', "'\\''"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::process::Command;
+
+    #[test]
+    fn quiet_command_discards_success_output() {
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "printf 'successful stdout'; printf 'successful stderr' >&2",
+        ]);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        super::exec_quiet_with_writers(&mut command, &mut stdout, &mut stderr).unwrap();
+
+        assert!(stdout.is_empty());
+        assert!(stderr.is_empty());
+    }
+
+    #[test]
+    fn quiet_command_replays_failed_output_and_command() {
+        let mut command = Command::new("sh");
+        command.args([
+            "-c",
+            "printf 'failed stdout'; printf 'failed stderr' >&2; exit 7",
+        ]);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let error =
+            super::exec_quiet_with_writers(&mut command, &mut stdout, &mut stderr).unwrap_err();
+
+        assert_eq!(stdout, b"failed stdout");
+        let stderr = String::from_utf8(stderr).unwrap();
+        assert!(stderr.contains("sh -c"));
+        assert!(stderr.contains("failed stderr"));
+        assert!(error.to_string().contains("exit status: 7"));
     }
 }

--- a/scripts/axbuild/src/test/build/c.rs
+++ b/scripts/axbuild/src/test/build/c.rs
@@ -158,7 +158,7 @@ pub(crate) fn prepare_c_case_overlay_sync(
     );
     let mut configure = build_cmake_configure_command(case, layout, &build_env, config);
     let result = configure
-        .exec()
+        .exec_quiet()
         .context("failed to configure case C project");
     timing_stage.finish();
     result?;
@@ -171,7 +171,7 @@ pub(crate) fn prepare_c_case_overlay_sync(
         ],
     );
     let mut build = build_cmake_build_command(layout, &build_env);
-    let result = build.exec().context("failed to build case C project");
+    let result = build.exec_quiet().context("failed to build case C project");
     timing_stage.finish();
     result?;
 
@@ -183,7 +183,9 @@ pub(crate) fn prepare_c_case_overlay_sync(
         ],
     );
     let mut install = build_cmake_install_command(layout, &build_env);
-    let result = install.exec().context("failed to install case C project");
+    let result = install
+        .exec_quiet()
+        .context("failed to install case C project");
     timing_stage.finish();
     result?;
 

--- a/scripts/axbuild/src/test/build/grouped_c.rs
+++ b/scripts/axbuild/src/test/build/grouped_c.rs
@@ -471,7 +471,7 @@ pub(super) fn prepare_grouped_c_subcases_sync(
             &build_env,
             config,
         );
-        let result = configure.exec().with_context(|| {
+        let result = configure.exec_quiet().with_context(|| {
             format!(
                 "failed to configure grouped C subcase `{}`",
                 subcase.name.as_str()
@@ -489,7 +489,7 @@ pub(super) fn prepare_grouped_c_subcases_sync(
             ],
         );
         let mut build = build_cmake_build_command(&subcase_layout, &build_env);
-        let result = build.exec().with_context(|| {
+        let result = build.exec_quiet().with_context(|| {
             format!(
                 "failed to build grouped C subcase `{}`",
                 subcase.name.as_str()
@@ -507,7 +507,7 @@ pub(super) fn prepare_grouped_c_subcases_sync(
             ],
         );
         let mut install = build_cmake_install_command(&subcase_layout, &build_env);
-        let result = install.exec().with_context(|| {
+        let result = install.exec_quiet().with_context(|| {
             format!(
                 "failed to install grouped C subcase `{}`",
                 subcase.name.as_str()
@@ -560,7 +560,7 @@ pub(super) fn prepare_grouped_c_root_project_sync(
         config,
     );
     let result = configure
-        .exec()
+        .exec_quiet()
         .context("failed to configure grouped C root project");
     timing_stage.finish();
     result?;
@@ -575,7 +575,7 @@ pub(super) fn prepare_grouped_c_root_project_sync(
     );
     let mut build = build_cmake_build_command(layout, build_env);
     let result = build
-        .exec()
+        .exec_quiet()
         .context("failed to build grouped C root project");
     timing_stage.finish();
     result?;
@@ -589,7 +589,7 @@ pub(super) fn prepare_grouped_c_root_project_sync(
     );
     let mut install = build_cmake_install_command(layout, build_env);
     let result = install
-        .exec()
+        .exec_quiet()
         .context("failed to install grouped C root project");
     timing_stage.finish();
     result?;

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -99,6 +99,19 @@ qemu/system/<subcase>/
 STARRY_GROUPED_TESTS_PASSED
 ```
 
+日志为每个 binary 保留一条开始标记和一条带耗时的完成结果，失败结果还包含退出码；
+suite 结束时只打印一条总数、成功数、失败数和总耗时汇总，不再重复输出一份逐项
+timing 列表。例如：
+
+```text
+STARRY_SYSTEM_TEST_BEGIN: /usr/bin/starry-test-suit/mytest
+STARRY_SYSTEM_TEST_PASSED: /usr/bin/starry-test-suit/mytest elapsed_s=1
+STARRY_SYSTEM_TEST_SUMMARY: total=1 passed=1 failed=0 elapsed_s=1
+```
+
+开始标记用于在超时时定位卡住的 binary；失败时保留该 binary 的原始输出、
+`STARRY_SYSTEM_TEST_FAILED`、退出码和耗时。
+
 子测例 CMake 产物应安装到：
 
 ```cmake
@@ -142,6 +155,12 @@ target/<target>/qemu-cases/<build_group>/<case>/cache/rootfs/
 ```
 
 plain case 不复制 rootfs，依赖 QEMU `-snapshot` 保证 guest 写入不落回共享镜像。
+
+需要 staging rootfs 的 pipeline 依赖 `debugfs` 和 `fakeroot`。xtask 会在启动
+`debugfs rdump` 前检查 EUID；Linux 上还会检查 UID/GID identity mapping 和有效
+`CAP_CHOWN`。只有能完整恢复 guest ownership 时才直接提取，否则预先进入
+`fakeroot`，避免产生大量权限警告。如果此时缺少 `fakeroot`，xtask 会在启动
+`debugfs` 前明确失败，不会先执行再过滤警告或静默回退。
 
 ## QEMU TOML
 
@@ -228,6 +247,10 @@ apk add zlib-dev
 - `STARRY_CASE_WORK_DIR`
 - `STARRY_CASE_BUILD_DIR`
 - `STARRY_CASE_OVERLAY_DIR`
+
+xtask 对 CMake configure、build 和 install 的成功输出默认静默，只保留对应阶段耗时。
+任一阶段失败时会回放完整命令、stdout、stderr、退出状态和阶段上下文。`prebuild.sh`
+以及 QEMU/guest 输出仍然实时显示，不能依赖成功路径的 CMake 输出作为测试判定标记。
 
 ## Grouped 用例
 

--- a/test-suit/starryos/qemu-rga/system/qemu-aarch64.toml
+++ b/test-suit/starryos/qemu-rga/system/qemu-aarch64.toml
@@ -22,50 +22,42 @@ to_bin = true
 shell_prefix = "root@starry:"
 test_commands = [
     '''
-found=0
+total=0
+passed=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
+suite_start=$(date +%s 2>/dev/null || printf 0)
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
-    found=1
+    total=$((total + 1))
     start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
         exit_status=0
     else
         exit_status=$?
-        status=failed
-        failed=1
     fi
     end=$(date +%s 2>/dev/null || printf 0)
     elapsed_s=$((end - start))
     if [ "$elapsed_s" -lt 0 ]; then
         elapsed_s=0
     fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
+    if [ "$exit_status" -eq 0 ]; then
+        passed=$((passed + 1))
         echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
     else
+        failed=$((failed + 1))
         echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done < "$timing_file"
+suite_end=$(date +%s 2>/dev/null || printf 0)
+suite_elapsed_s=$((suite_end - suite_start))
+if [ "$suite_elapsed_s" -lt 0 ]; then
+    suite_elapsed_s=0
 fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
-if [ "$found" -ne 1 ]; then
+echo "STARRY_SYSTEM_TEST_SUMMARY: total=$total passed=$passed failed=$failed elapsed_s=$suite_elapsed_s"
+if [ "$total" -eq 0 ]; then
     echo "$group_fail_marker: no RGA system tests found"
     exit 1
 fi

--- a/test-suit/starryos/qemu/system/qemu-aarch64.toml
+++ b/test-suit/starryos/qemu/system/qemu-aarch64.toml
@@ -38,50 +38,42 @@ to_bin = true
 shell_prefix = "root@starry:"
 test_commands = [
     '''
-found=0
+total=0
+passed=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
+suite_start=$(date +%s 2>/dev/null || printf 0)
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
-    found=1
+    total=$((total + 1))
     start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
         exit_status=0
     else
         exit_status=$?
-        status=failed
-        failed=1
     fi
     end=$(date +%s 2>/dev/null || printf 0)
     elapsed_s=$((end - start))
     if [ "$elapsed_s" -lt 0 ]; then
         elapsed_s=0
     fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
+    if [ "$exit_status" -eq 0 ]; then
+        passed=$((passed + 1))
         echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
     else
+        failed=$((failed + 1))
         echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done < "$timing_file"
+suite_end=$(date +%s 2>/dev/null || printf 0)
+suite_elapsed_s=$((suite_end - suite_start))
+if [ "$suite_elapsed_s" -lt 0 ]; then
+    suite_elapsed_s=0
 fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
-if [ "$found" -ne 1 ]; then
+echo "STARRY_SYSTEM_TEST_SUMMARY: total=$total passed=$passed failed=$failed elapsed_s=$suite_elapsed_s"
+if [ "$total" -eq 0 ]; then
     echo "$group_fail_marker: no SMP system tests found"
     exit 1
 fi

--- a/test-suit/starryos/qemu/system/qemu-loongarch64.toml
+++ b/test-suit/starryos/qemu/system/qemu-loongarch64.toml
@@ -29,53 +29,46 @@ to_bin = true
 shell_prefix = "root@starry:"
 test_commands = [
     '''
-found=0
+total=0
+passed=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
 output_file=/tmp/starry-system-test-output.$$
-: > "$timing_file"
+suite_start=$(date +%s 2>/dev/null || printf 0)
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
-    found=1
+    total=$((total + 1))
     start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin" > "$output_file" 2>&1; then
-        status=passed
         exit_status=0
     else
         exit_status=$?
-        status=failed
-        failed=1
     fi
     end=$(date +%s 2>/dev/null || printf 0)
     elapsed_s=$((end - start))
     if [ "$elapsed_s" -lt 0 ]; then
         elapsed_s=0
     fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
+    if [ "$exit_status" -eq 0 ]; then
+        passed=$((passed + 1))
         echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
     else
+        failed=$((failed + 1))
         cat "$output_file"
         echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
     fi
     rm -f "$output_file"
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done < "$timing_file"
+suite_end=$(date +%s 2>/dev/null || printf 0)
+suite_elapsed_s=$((suite_end - suite_start))
+if [ "$suite_elapsed_s" -lt 0 ]; then
+    suite_elapsed_s=0
 fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file" "$output_file"
-if [ "$found" -ne 1 ]; then
+rm -f "$output_file"
+echo "STARRY_SYSTEM_TEST_SUMMARY: total=$total passed=$passed failed=$failed elapsed_s=$suite_elapsed_s"
+if [ "$total" -eq 0 ]; then
     echo "$group_fail_marker: no SMP system tests found"
     exit 1
 fi

--- a/test-suit/starryos/qemu/system/qemu-riscv64.toml
+++ b/test-suit/starryos/qemu/system/qemu-riscv64.toml
@@ -36,50 +36,42 @@ to_bin = true
 shell_prefix = "root@starry:"
 test_commands = [
     '''
-found=0
+total=0
+passed=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
+suite_start=$(date +%s 2>/dev/null || printf 0)
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
-    found=1
+    total=$((total + 1))
     start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
         exit_status=0
     else
         exit_status=$?
-        status=failed
-        failed=1
     fi
     end=$(date +%s 2>/dev/null || printf 0)
     elapsed_s=$((end - start))
     if [ "$elapsed_s" -lt 0 ]; then
         elapsed_s=0
     fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
+    if [ "$exit_status" -eq 0 ]; then
+        passed=$((passed + 1))
         echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
     else
+        failed=$((failed + 1))
         echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done < "$timing_file"
+suite_end=$(date +%s 2>/dev/null || printf 0)
+suite_elapsed_s=$((suite_end - suite_start))
+if [ "$suite_elapsed_s" -lt 0 ]; then
+    suite_elapsed_s=0
 fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
-if [ "$found" -ne 1 ]; then
+echo "STARRY_SYSTEM_TEST_SUMMARY: total=$total passed=$passed failed=$failed elapsed_s=$suite_elapsed_s"
+if [ "$total" -eq 0 ]; then
     echo "$group_fail_marker: no SMP system tests found"
     exit 1
 fi

--- a/test-suit/starryos/qemu/system/qemu-x86_64.toml
+++ b/test-suit/starryos/qemu/system/qemu-x86_64.toml
@@ -37,50 +37,42 @@ to_bin = true
 shell_prefix = "root@starry:"
 test_commands = [
     '''
-found=0
+total=0
+passed=0
 failed=0
 system_fail_marker=STARRY_SYSTEM_TEST_FAILED
 group_fail_marker=STARRY_GROUPED_TEST_FAILED
-timing_file=/tmp/starry-system-test-timing.$$
-: > "$timing_file"
+suite_start=$(date +%s 2>/dev/null || printf 0)
 for bin in /usr/bin/starry-test-suit/*; do
     [ -f "$bin" ] && [ -x "$bin" ] || continue
-    found=1
+    total=$((total + 1))
     start=$(date +%s 2>/dev/null || printf 0)
     echo "STARRY_SYSTEM_TEST_BEGIN: $bin"
     if "$bin"; then
-        status=passed
         exit_status=0
     else
         exit_status=$?
-        status=failed
-        failed=1
     fi
     end=$(date +%s 2>/dev/null || printf 0)
     elapsed_s=$((end - start))
     if [ "$elapsed_s" -lt 0 ]; then
         elapsed_s=0
     fi
-    printf '%s %s %s\n' "$elapsed_s" "$status" "$bin" >> "$timing_file"
-    if [ "$status" = passed ]; then
+    if [ "$exit_status" -eq 0 ]; then
+        passed=$((passed + 1))
         echo "STARRY_SYSTEM_TEST_PASSED: $bin elapsed_s=$elapsed_s"
     else
+        failed=$((failed + 1))
         echo "$system_fail_marker: $bin status=$exit_status elapsed_s=$elapsed_s"
     fi
 done
-echo "STARRY_SYSTEM_TEST_TIMING_BEGIN"
-if [ -s "$timing_file" ]; then
-    while read -r elapsed_s status bin; do
-        if [ "$status" = passed ]; then
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=passed bin=%s\n' "$elapsed_s" "$bin"
-        else
-            printf 'STARRY_SYSTEM_TEST_TIMING: elapsed_s=%s status=failed bin=%s\n' "$elapsed_s" "$bin"
-        fi
-    done < "$timing_file"
+suite_end=$(date +%s 2>/dev/null || printf 0)
+suite_elapsed_s=$((suite_end - suite_start))
+if [ "$suite_elapsed_s" -lt 0 ]; then
+    suite_elapsed_s=0
 fi
-echo "STARRY_SYSTEM_TEST_TIMING_END"
-rm -f "$timing_file"
-if [ "$found" -ne 1 ]; then
+echo "STARRY_SYSTEM_TEST_SUMMARY: total=$total passed=$passed failed=$failed elapsed_s=$suite_elapsed_s"
+if [ "$total" -eq 0 ]; then
     echo "$group_fail_marker: no SMP system tests found"
     exit 1
 fi


### PR DESCRIPTION
## 问题

`cargo xtask starry test qemu` 的 CMake configure/build/install、grouped system/RGA runner 和 reusable CI workflow 在成功路径输出大量重复日志。尤其是 `debugfs rdump` 在运行环境没有完整 ownership 权限时，会逐文件尝试 `chown` 并输出大量非致命 `dump_file`/`rdump` 警告，淹没测试结果和真正的失败上下文。

## 修改

- 为 axbuild 增加内部静默命令执行：test-suit CMake configure/build/install 成功时不输出；失败时完整回放命令、stdout、stderr、退出状态和阶段上下文。prebuild、QEMU 和 guest 输出保持实时。
- 精简五份 Starry system/RGA grouped 配置：每项保留 `BEGIN` 和唯一的 `passed/failed + elapsed_s` 结果；增加 `total/passed/failed/elapsed_s` suite 汇总；移除重复 timing 文件与区块，同时保留失败 marker 和最终 grouped marker。
- reusable workflow 关闭成功路径的 shell xtrace 和重复 `Resolved command`；仅在失败时打印实际命令，并为 artifact/toolchain 失败补充明确错误信息。
- 在 rootfs 提取前判定 ownership 能力。Linux 仅在 EUID 0、完整 UID/GID identity mapping 且具备有效 `CAP_CHOWN` 时直接运行 `debugfs`；否则预先进入 `fakeroot`。缺少 `fakeroot` 时在启动 `debugfs` 前明确失败，不做事后过滤或失败后回退。
- 添加容器所需的 `fakeroot` 依赖，并更新 README、Starry test-suit 指南和项目 skill contract。

## 方案逻辑

成功路径可以静默，但失败路径必须保留完整诊断信息。rootfs warning 不通过重定向 stderr 或字符串过滤处理，因为这会同时隐藏镜像损坏和提取错误；改为在命令执行前选择能够正确承接 ownership 操作的执行环境，从根因避免无意义警告。

## 验证

- `cargo test -p axbuild`（793 passed）
- `cargo xtask clippy --package axbuild`
- `cargo fmt --check`
- `python3 scripts/test/check_ci_paths.py`
- `python3 scripts/test/check_ci_routing.py`
- 使用 PyYAML 解析 `.github/workflows/reusable-command.yml` 和 `.github/workflows/ci.yml`
- `cargo xtask starry test qemu --arch x86_64 -c qemu/test-close-range`
  - 强制 rootfs cache miss，确认实际执行提取
  - ownership warning 为 0
  - 1/1 测试通过，逐项耗时和 suite 汇总可追溯
