### PR TITLE
fix(ci): disable ROCK 4D board test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -785,14 +785,14 @@ jobs:
             container_image: ""
             limit_to_owner: rcore-os
             main_pr_only: false
-          - name: Test starry self-hosted board rock-4d
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask starry test board --board rock-4d
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
+          # - name: Test starry self-hosted board rock-4d
+          #   use_container: false
+          #   runs_on: '["self-hosted","linux","board"]'
+          #   command: cargo xtask starry test board --board rock-4d
+          #   cache_key: ""
+          #   container_image: ""
+          #   limit_to_owner: rcore-os
+          #   main_pr_only: false
           - name: Test starry self-hosted board aka-00-sg2002
             use_container: false
             runs_on: '["self-hosted","linux","board"]'


### PR DESCRIPTION
## 背景

临时下架 ROCK 4D 的 StarryOS 自托管板卡测试。

## 修改内容

- 注释 ROCK 4D 对应的 CI matrix 条目。
- 保留完整测试配置，方便后续重新启用。
- 不影响其他自托管板卡测试。