### PR TITLE
fix(someboot): repair AArch64 EFI handoff

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -101,6 +101,10 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
   raw entry symbol is the direct-loader entry and its physical address must remain valid after a
   load bias.
 - On AArch64, pass EL transition state into the post-relocation entry path when it must be kept in Rust globals; do not write relocatable statics before relocation has been applied.
+- On AArch64 UEFI entry, adapt `relocate::apply` to the generic EFI relocation
+  contract, initialize the UEFI/FDT/ACPI state before common EL setup, and do
+  not re-enter the direct-boot path that clears BSS or overwrites the captured
+  FDT address.
 - Clear BSS exactly once and after preserving any entry data that lives there.
 - Render separate TLS and no-TLS linker layouts. A no-TLS kernel must reject `.tdata`/`.tbss`
   inputs and omit `PT_TLS`; a TLS kernel must retain the TLS program header and bootstrap data.

--- a/platforms/someboot/src/arch/aarch64/entry.rs
+++ b/platforms/someboot/src/arch/aarch64/entry.rs
@@ -31,13 +31,26 @@ pub unsafe extern "C" fn kernel_entry(_fdt_addr: usize) {
         asm_sym_addr!(x8, "{fdt}"),
         "str  x9, [x8]",
 
+        "b {enter_with_boot_state}",
+        fdt = sym crate::fdt::FDT_ADDR,
+        enter_with_boot_state = sym enter_with_boot_state,
+
+    )
+}
+
+/// Enters the common exception-level setup after preserving the boot state.
+///
+/// # Safety
+///
+/// The caller must initialize BSS and preserve either the direct-boot FDT or
+/// the UEFI service state before entering this function.
+#[unsafe(naked)]
+pub(super) unsafe extern "C" fn enter_with_boot_state() -> ! {
+    naked_asm!(
         asm_sym_addr!(x8, "__cpu0_stack_top"),
         "mov sp, x8",
-
-        "bl {switch_to_elx}",
-        fdt = sym crate::fdt::FDT_ADDR,
+        "b {switch_to_elx}",
         switch_to_elx = sym switch_to_elx,
-
     )
 }
 

--- a/platforms/someboot/src/arch/aarch64/mod.rs
+++ b/platforms/someboot/src/arch/aarch64/mod.rs
@@ -24,6 +24,8 @@ use aarch64_cpu::registers::*;
 use elx::*;
 pub(crate) use entry::_secondary_entry;
 pub use paging::Entry;
+#[cfg(efi)]
+pub(crate) use relocate::apply as relocate;
 
 use crate::{
     ArchTrait,
@@ -235,9 +237,17 @@ impl ArchTrait for Arch {
     }
 
     // Safety: the EFI stub guarantees the same contract as the trait docs.
-    unsafe fn efi_enter_kernel(_system_table: *const ::core::ffi::c_void) -> bool {
-        unsafe { crate::arch::entry::kernel_entry(0) };
-        unreachable!()
+    unsafe fn efi_enter_kernel(system_table: *const ::core::ffi::c_void) -> bool {
+        #[cfg(efi)]
+        {
+            crate::efi_stub::setup_service(system_table);
+            unsafe { crate::arch::entry::enter_with_boot_state() }
+        }
+        #[cfg(not(efi))]
+        {
+            let _ = system_table;
+            false
+        }
     }
 }
 

--- a/platforms/someboot/src/fdt/mod.rs
+++ b/platforms/someboot/src/fdt/mod.rs
@@ -29,6 +29,7 @@ pub fn fdt_addr_phys() -> Option<usize> {
     Some(fdt_addr)
 }
 
+#[cfg(any(efi, target_arch = "loongarch64", test))]
 pub(crate) fn set_fdt_addr_phys_if_valid(fdt_addr: usize) -> bool {
     if fdt_addr == 0 {
         return false;

--- a/platforms/someboot/tests/aarch64_efi_handoff_contract.rs
+++ b/platforms/someboot/tests/aarch64_efi_handoff_contract.rs
@@ -1,0 +1,200 @@
+#![cfg(all(
+    target_os = "linux",
+    target_pointer_width = "64",
+    target_endian = "little"
+))]
+
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+const TARGET: &str = "aarch64-unknown-none-softfloat";
+const EFI_ENTRY: &str = "<someboot::arch::Arch as someboot::ArchTrait>::efi_enter_kernel";
+const EFI_CONTINUATION: &str = "someboot::arch::entry::enter_with_boot_state";
+const SETUP_SERVICE: &str = "someboot::efi_stub::setup_service";
+
+#[test]
+fn aarch64_efi_handoff_preserves_firmware_state() {
+    let temporary_directory = TemporaryDirectory::new();
+    let archive = build_aarch64_efi_archive(temporary_directory.path());
+    let disassembly = run_output(
+        Command::new("rust-objdump")
+            .args(["-dr", "-C"])
+            .arg(&archive),
+        "disassemble the AArch64 EFI someboot archive",
+    );
+    assert!(
+        disassembly.contains("file format elf64-littleaarch64"),
+        "the contract must inspect an AArch64 target artifact"
+    );
+
+    let efi_entry = function_disassembly(&disassembly, EFI_ENTRY);
+    assert_symbol_order(efi_entry, SETUP_SERVICE, EFI_CONTINUATION);
+    assert_no_firmware_state_reset(efi_entry, "the AArch64 EFI entry");
+    assert!(
+        !efi_entry.contains("kernel_entry"),
+        "the EFI handoff must not re-enter the direct-boot entry:\n{efi_entry}"
+    );
+
+    let continuation = function_disassembly(&disassembly, EFI_CONTINUATION);
+    assert!(
+        continuation.contains("someboot::arch::elx::switch_to_elx"),
+        "the EFI continuation must proceed to exception-level setup:\n{continuation}"
+    );
+    assert_no_firmware_state_reset(continuation, "the common EFI continuation");
+
+    let setup_service = function_disassembly(&disassembly, SETUP_SERVICE);
+    assert_symbol_order(setup_service, "find_fdt", "find_acpi_rsdp");
+
+    let direct_entry = function_disassembly(&disassembly, "kernel_entry");
+    for required in [
+        "__bss_start",
+        "__bss_stop",
+        "someboot::fdt::FDT_ADDR",
+        EFI_CONTINUATION,
+    ] {
+        assert!(
+            direct_entry.contains(required),
+            "the direct-boot entry must retain its {required} initialization:\n{direct_entry}"
+        );
+    }
+}
+
+fn build_aarch64_efi_archive(target_directory: &Path) -> PathBuf {
+    let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let workspace_manifest = manifest_dir
+        .join("../..")
+        .join("Cargo.toml")
+        .canonicalize()
+        .expect("workspace manifest must be available");
+    run_checked(
+        Command::new(cargo)
+            .args([
+                "build",
+                "--quiet",
+                "--package",
+                "someboot",
+                "--lib",
+                "--target",
+                TARGET,
+                "--no-default-features",
+                "--features",
+                "efi",
+                "--target-dir",
+            ])
+            .arg(target_directory)
+            .arg("--manifest-path")
+            .arg(workspace_manifest),
+        "compile someboot for AArch64 EFI",
+    );
+
+    let dependency_directory = target_directory.join(TARGET).join("debug").join("deps");
+    let mut archives = fs::read_dir(&dependency_directory)
+        .expect("AArch64 dependency directory must be readable")
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("libsomeboot-") && name.ends_with(".rlib"))
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        archives.len(),
+        1,
+        "the isolated target directory must contain one someboot archive"
+    );
+    archives.pop().expect("the someboot archive must exist")
+}
+
+fn assert_symbol_order(disassembly: &str, first: &str, second: &str) {
+    let first_offset = disassembly
+        .find(first)
+        .unwrap_or_else(|| panic!("compiled function must reference {first}:\n{disassembly}"));
+    let second_offset = disassembly
+        .find(second)
+        .unwrap_or_else(|| panic!("compiled function must reference {second}:\n{disassembly}"));
+    assert!(
+        first_offset < second_offset,
+        "{first} must execute before {second}:\n{disassembly}"
+    );
+}
+
+fn assert_no_firmware_state_reset(disassembly: &str, path: &str) {
+    for forbidden in ["__bss_start", "__bss_stop", "someboot::fdt::FDT_ADDR"] {
+        assert!(
+            !disassembly.contains(forbidden),
+            "{path} must preserve EFI-populated state instead of referencing \
+             {forbidden}:\n{disassembly}"
+        );
+    }
+}
+
+fn function_disassembly<'output>(output: &'output str, symbol: &str) -> &'output str {
+    let label = format!("<{symbol}>:");
+    let start = output
+        .find(&label)
+        .unwrap_or_else(|| panic!("compiled archive must define {symbol}"));
+    let function = &output[start..];
+    function
+        .split_once("\n\n")
+        .map(|(body, _)| body)
+        .unwrap_or(function)
+}
+
+fn run_checked(command: &mut Command, operation: &str) {
+    let output = command
+        .output()
+        .unwrap_or_else(|error| panic!("failed to {operation}: {error}"));
+    assert!(
+        output.status.success(),
+        "failed to {operation}:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run_output(command: &mut Command, operation: &str) -> String {
+    let output = command
+        .output()
+        .unwrap_or_else(|error| panic!("failed to {operation}: {error}"));
+    assert!(
+        output.status.success(),
+        "failed to {operation}:\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("tool output must be UTF-8")
+}
+
+struct TemporaryDirectory(PathBuf);
+
+impl TemporaryDirectory {
+    fn new() -> Self {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock must follow the Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "someboot-aarch64-efi-handoff-{}-{nonce}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("temporary AArch64 target directory must be created");
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for TemporaryDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.0);
+    }
+}


### PR DESCRIPTION
## 问题

近期 CI 的 someboot clippy 检查在非 EFI 目标上持续报告 `set_fdt_addr_phys_if_valid` 未使用。进一步补齐独立的 `aarch64 + efi` 组合检查后，还发现两层既有问题：

1. 通用 EFI stub 按函数调用 `crate::arch::relocate()`，而 AArch64 只暴露了同名模块，导致 `E0423: expected function, found module`。
2. AArch64 EFI 入口没有先保存 UEFI system table，且复用了直启入口；该入口会清 BSS 并把 FDT 地址写成 0，从而破坏 EFI stub 已捕获的 UEFI/FDT 状态。

## 修改

- 仅在 EFI、LoongArch 和测试配置中编译 `set_fdt_addr_phys_if_valid`，让定义范围与真实调用方一致，不用 `allow` 压制警告。
- 在 AArch64 架构边界将 `relocate::apply` 适配为通用 EFI stub 需要的 `relocate()` 调用契约。
- 把 AArch64 的公共 EL/栈设置拆到“启动状态已保存”入口：
  - 直启路径仍先保存 FDT、清 BSS，再进入公共段；
  - EFI 路径先调用 `setup_service` 保存 system table，再直接进入公共段，不再清 BSS 或覆盖 FDT。
- 新增 AArch64 EFI target-compiled handoff contract：实际编译
  `aarch64-unknown-none-softfloat + efi` 产物并检查目标对象调用顺序，确保
  EFI 状态初始化后不会重新进入清 BSS、覆盖 FDT 的直启路径。
- 同步更新 `arch-platform-porting` skill，记录 AArch64 UEFI handoff 的约束，避免后续移植重新引入同类问题。

## 方案逻辑

修复保持了两种启动方式各自的状态所有权：直启入口负责从寄存器取得 FDT 并初始化 BSS；EFI stub 负责 UEFI/FDT/ACPI 状态。两条路径只在状态已经妥善保存后汇合到 EL 切换与内核栈设置。通用 EFI stub 因此无需增加 AArch64 特判，架构差异由 AArch64 模块内部适配。

## 验证

回归先红后绿：

- `cargo clippy --no-deps -p someboot --target aarch64-unknown-none-softfloat --no-default-features --features efi -- -D warnings`
  - 修复前：退出码 101，在 `efi_stub/mod.rs` 报 `E0423`；
  - 修复后：通过。
- 非 EFI AArch64 clippy 修复前因 FDT helper 的 `dead_code` 退出 101，修复后通过。
- `cargo test -p someboot --test aarch64_efi_handoff_contract`
  - 恢复旧 handoff 后：退出码 101；目标对象仅调用 `kernel_entry`，没有
    `setup_service`；
  - 当前实现：通过；目标对象依次调用 `setup_service` 和
    `enter_with_boot_state`，EFI 路径不引用 BSS/FDT 重置符号。

最终验证：

- `cargo fmt --all --check`
- `cargo xtask clippy --package someboot`：8/8 通过
- `cargo clippy -p someboot --test aarch64_efi_handoff_contract -- -D warnings`
- AArch64 `efi`、`efi,hv,tls`、无 feature 目标 clippy 通过
- RISC-V 与 LoongArch 无 feature 目标 clippy 通过
- `cargo test -p someboot`：全部通过（含 AArch64 EFI handoff、relocation、linker、TLS 测试）
- `cargo xtask starry test qemu --arch aarch64 --test-case qemu/system`：1/1 通过，命中 `STARRY_GROUPED_TESTS_PASSED`
- `git diff --check`

## 已知验证边界

仓库当前没有可直接运行的 AArch64 UEFI QEMU 测试配置，因此尚未执行固件运行态测试；EFI 路径由新增的 AArch64 target-compiled 调用图契约覆盖，原有 AArch64 直启路径由完整 Starry system QEMU 套件覆盖。
