### PR TITLE
fix(ax-task): initialize tasks before scheduling

### DIFF
--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -6,7 +6,7 @@ use alloc::{
 use ax_kernel_guard::NoPreemptIrqSave;
 use ax_runtime::hal::cpu::uspace::UserContext;
 use ax_sync::Mutex;
-use ax_task::{AxTaskExt, spawn_task};
+use ax_task::{AxTaskExt, spawn_task_with};
 use starry_process::{Pid, Process};
 
 use crate::{
@@ -111,8 +111,7 @@ pub fn init(args: &[String], envs: &[String]) {
 
     let task = {
         let _guard = NoPreemptIrqSave::new();
-        let task = spawn_task(task);
-        add_task_to_table(&task);
+        let task = spawn_task_with(task, add_task_to_table);
         tty::arm_console_irq();
         task
     };

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -4,7 +4,7 @@ use ax_errno::{AxError, AxResult};
 use ax_fs_ng::vfs::FS_CONTEXT;
 use ax_kspin::SpinNoIrq;
 use ax_runtime::hal::cpu::uspace::UserContext;
-use ax_task::{AxTaskExt, current, spawn_task};
+use ax_task::{AxTaskExt, current, spawn_task_with};
 use bitflags::bitflags;
 use linux_raw_sys::general::*;
 use scope_local::Scope;
@@ -448,8 +448,7 @@ impl CloneArgs {
             guard.commit();
         }
 
-        let task = spawn_task(new_task);
-        add_task_to_table(&task);
+        spawn_task_with(new_task, add_task_to_table);
 
         if trace_clone && needs_vfork_block {
             let _ = crate::task::send_signal_to_thread(

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -223,10 +223,38 @@ pub fn note_programmed_timer_deadline_nanos(deadline_nanos: u64) {
 
 /// Adds the given task to the run queue, returns the task reference.
 pub fn spawn_task(task: TaskInner) -> AxTaskRef {
+    spawn_task_with(task, |_| {})
+}
+
+/// Initializes the given task before adding it to the run queue.
+///
+/// The `initialize` callback receives the stable task reference before the task
+/// becomes runnable. Use it to publish runtime-specific task metadata that the
+/// task must be able to observe on its first instruction. The callback must not
+/// wait for the new task to run because it has not been registered or queued.
+///
+/// # Panics
+///
+/// Panics if `initialize` panics.
+pub fn spawn_task_with<F>(task: TaskInner, initialize: F) -> AxTaskRef
+where
+    F: FnOnce(&AxTaskRef),
+{
     let task_ref = task.into_arc();
-    register_task(&task_ref);
-    select_run_queue::<NoPreemptIrqSave>(&task_ref).add_task(task_ref.clone());
+    initialize_task_before_schedule(&task_ref, initialize, |task_ref| {
+        register_task(task_ref);
+        select_run_queue::<NoPreemptIrqSave>(task_ref).add_task(task_ref.clone());
+    });
     task_ref
+}
+
+fn initialize_task_before_schedule<T>(
+    task: &T,
+    initialize: impl FnOnce(&T),
+    schedule: impl FnOnce(&T),
+) {
+    initialize(task);
+    schedule(task);
 }
 
 /// Spawns a new task with the given parameters.
@@ -720,4 +748,27 @@ pub(crate) fn axtask_api_task_registry_functions_exist_hold_for_test() -> bool {
     }
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use core::cell::Cell;
+
+    #[test]
+    fn task_initialization_precedes_scheduling() {
+        let initialized = Cell::new(false);
+
+        super::initialize_task_before_schedule(
+            &(),
+            |_| initialized.set(true),
+            |_| {
+                assert!(
+                    initialized.get(),
+                    "task was scheduled before initialization"
+                )
+            },
+        );
+
+        assert!(initialized.get());
+    }
 }

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -13,6 +13,7 @@ use crate::support::process::run_cargo_status;
 
 const STD_CRATES_CSV: &str = "scripts/test/std_crates.csv";
 const MIGHT_SLEEP_FILTER: &str = "might_sleep";
+const TASK_INITIALIZATION_FILTER: &str = "task_initialization_precedes_scheduling";
 
 #[derive(Clone, Copy, Debug)]
 struct PackageFeatureProfile {
@@ -23,6 +24,12 @@ struct PackageFeatureProfile {
 }
 
 const AX_TASK_FEATURE_PROFILES: &[PackageFeatureProfile] = &[
+    PackageFeatureProfile {
+        name: "host-test+multitask-task-initialization",
+        features: &["host-test", "multitask"],
+        name_filter: Some(TASK_INITIALIZATION_FILTER),
+        expected_tests: &["api::tests::task_initialization_precedes_scheduling"],
+    },
     PackageFeatureProfile {
         name: "host-test+multitask",
         features: &["host-test", "multitask"],
@@ -573,7 +580,7 @@ mod tests {
     }
 
     #[test]
-    fn ax_task_uses_two_might_sleep_feature_profiles() {
+    fn ax_task_uses_task_initialization_and_might_sleep_feature_profiles() {
         let root = PathBuf::from("/tmp/workspace");
         let packages = vec!["ax-task".to_string()];
         let mut runner = FakeCargoRunner::succeeding().with_ax_task_discovery();
@@ -589,6 +596,24 @@ mod tests {
         assert_eq!(
             args,
             vec![
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test,multitask",
+                    "task_initialization_precedes_scheduling",
+                    "--",
+                    "--list",
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test,multitask",
+                    "task_initialization_precedes_scheduling",
+                ],
                 vec![
                     "test",
                     "-p",
@@ -657,9 +682,10 @@ mod tests {
     fn profile_discovery_mismatch_fails_without_running_that_profile() {
         let root = PathBuf::from("/tmp/workspace");
         let packages = vec!["ax-task".to_string()];
-        let basic_profile = &AX_TASK_FEATURE_PROFILES[0];
-        let diagnostic_profile = &AX_TASK_FEATURE_PROFILES[1];
+        let basic_profile = &AX_TASK_FEATURE_PROFILES[1];
+        let diagnostic_profile = &AX_TASK_FEATURE_PROFILES[2];
         let mut runner = FakeCargoRunner::succeeding()
+            .with_ax_task_discovery()
             .with_listing(basic_profile, &["tests::might_sleep_unexpected"])
             .with_listing(diagnostic_profile, diagnostic_profile.expected_tests);
 
@@ -704,6 +730,6 @@ mod tests {
         let failed = run_std_tests(&mut runner, &root, &packages).unwrap();
 
         assert_eq!(failed, vec!["ax-task", "ax-api"]);
-        assert_eq!(runner.invocations.len(), 5);
+        assert_eq!(runner.invocations.len(), 7);
     }
 }


### PR DESCRIPTION
## 问题

[Actions job 90771506299](https://github.com/rcore-os/tgoskits/actions/runs/30509853758/job/90771506299) 的 Starry x86_64 system suite 在 387 个用例中仅 `bug-sched-affinity-migrate` 失败。fork 出的子进程第一次打开 `/proc/self/stat` 时得到 `ENOENT`，随后 abort；调度迁移断言本身尚未开始执行。

根因是 Starry clone 路径先调用 `spawn_task` 将新任务注册到 scheduler 并加入 run queue，之后才调用 `add_task_to_table` 发布 Starry 的 task/process identity。在 SMP 下，远端 CPU 可以在 Starry 注册完成前运行子进程，因此 `/proc/self` 按当前 PID 查询 `PROCESS_TABLE` 时暂时找不到自身。

## 修改

- 为 `ax-task` 增加 `spawn_task_with`：在任务获得稳定引用后，先同步执行运行时初始化回调，再注册 scheduler task 并加入 run queue。
- Starry 的 clone/fork/vfork 与 init task 路径通过该接口发布 task/process 表，保证任务首次运行前所需元数据已经可见。
- 保留原 `spawn_task` 作为空初始化回调的兼容入口，其他调用方语义不变。
- 增加确定性顺序回归测试，并加入 `cargo xtask test` 的 ax-task feature profile；runner 会先核验测试被发现，再执行测试。

## 设计与替代方案

选择在 scheduler 发布边界修复完整不变量：任务对 CPU 可运行前，运行时要求的身份和表项必须已经发布。

- 未在 `/proc/self` 中直接绕过 `PROCESS_TABLE`：这只会掩盖当前症状，其他依赖 task/process 表的首次操作仍可能失败。
- 未只扩大本地 preemption guard：本地 guard 无法阻止远端 CPU 从 run queue 取走新任务。
- 初始化回调在任务尚未注册或入队时同步执行，因此契约明确禁止等待新任务运行；回调 panic 会直接传播，不会留下可运行的半初始化任务。

## 验证

红绿回归：

- 仅封装旧的 `schedule -> initialize` 顺序时，`cargo test -p ax-task --features host-test,multitask api::tests::task_initialization_precedes_scheduling -- --exact` 稳定失败，报错 `task was scheduled before initialization`。
- 调整为 `initialize -> schedule` 后，同一测试通过。

最终代码验证：

- `cargo fmt --all`
- `cargo xtask clippy --package ax-task --package starry-kernel --package axbuild`（3 个 package，42/42 checks 通过）
- `cargo xtask test`（49/49 packages 通过，新增 ax-task 测试已被 `--list` 核验并执行）
- `cargo xtask starry test qemu --arch x86_64 -c qemu/system/affinity-bug-sched-affinity-migrate`（1/1 case 通过，输出 `TEST PASSED` 与 `STARRY_GROUPED_TESTS_PASSED`）

## 影响范围

本次恢复既有 fork/clone 后任务身份可见性和 `/proc/self/stat` 行为，不改变 syscall 参数、返回值 ABI、持久化格式或现有 `spawn_task` 调用方行为。