### PR TITLE
feat(qperf): support Starry x86_64 profiling

### DIFF
--- a/components/axcpu/src/x86_64/trap.S
+++ b/components/axcpu/src/x86_64/trap.S
@@ -71,6 +71,8 @@ trap_handler_table:
 .endm
 
 .section .text
+.type trap_vector_entries, @function
+trap_vector_entries:
 .set i, 0
 .rept NUM_INT
     DEF_HANDLER %i
@@ -95,6 +97,7 @@ trap_handler_table:
     POP_GENERAL_REGS
     add     rsp, 16                     # pop vector, error_code
     iretq
+.size trap_vector_entries, . - trap_vector_entries
 
 .global syscall_entry
 syscall_entry:

--- a/components/axcpu/src/x86_64/user_copy.S
+++ b/components/axcpu/src/x86_64/user_copy.S
@@ -8,6 +8,7 @@
 
 .section .text
 .global user_copy
+.type user_copy, @function
 user_copy:
     // Arguments: rdi (dst), rsi (src), rdx (size)
     mov rcx, rdx        // copy size to rcx
@@ -17,4 +18,5 @@ user_copy:
 1:  mov rax, rcx        // return remain bytes
     ret
 
+    .size user_copy, . - user_copy
     _asm_extable 0b, 1b

--- a/docs/docs/build/starry/perf.md
+++ b/docs/docs/build/starry/perf.md
@@ -7,6 +7,11 @@ sidebar_label: "性能剖析"
 
 `cargo xtask starry perf` 构建 StarryOS 并通过 qperf 进行性能剖析，输出火焰图（SVG/HTML/Folded）、Pprof 或 callchain 数据。这是 StarryOS 独有的命令，[ArceOS](../arceos/overview) 和 [Axvisor](../axvisor/overview) 没有。
 
+目前支持 `riscv64`、`loongarch64` 和 `x86_64`。x86_64 使用 StarryOS 的 q35/UEFI
+启动配置；命令会优先复用 ostool 下载的 OVMF，也可以通过 `QPERF_OVMF_DIR` 指向包含
+`code.fd` 和 `vars.fd` 的目录。建议在 x86_64 上同时使用 `--kernel-filter`，排除 UEFI
+固件和用户态地址。
+
 ## 剖析流程
 
 ```mermaid
@@ -29,7 +34,7 @@ flowchart TD
 | 参数 | 说明 |
 |------|------|
 | `-c/--case <NAME>` | 性能测试用例名（默认 `boot`） |
-| `--arch <ARCH>` | 目标架构（默认 `riscv64`） |
+| `--arch <ARCH>` | 目标架构：`riscv64`/`loongarch64`/`x86_64`（默认 `riscv64`） |
 | `--freq <HZ>` | 采样频率（默认 99） |
 | `--format` | 输出格式：`Folded`/`Svg`/`Pprof`/`All`（默认 `All`） |
 | `--mode` | 采样模式：`Tb`（trace buffer，默认）/ `Insn`（指令级） |
@@ -81,10 +86,10 @@ flowchart TD
 
 - 火焰图（`.svg` / `.html`）
 - 折叠栈（`.folded`）
-- 原始采样（`.raw`）
+- 原始采样（`qperf.bin`）
 - 符号化统计（`resolve_stats`、`stack_depth_summary`）
 - phase/focus 火焰图（按采样窗口分段）
-- `summary.md` 汇总报告
+- `report.md`/`report.json` 汇总报告与 `hotspots.csv`
 
 ## 用法示例
 
@@ -92,11 +97,13 @@ flowchart TD
 # 默认 riscv64 性能剖析（boot 用例）
 cargo starry perf
 
-# 指定输出格式和架构
-cargo starry perf --format Svg --arch aarch64
+# x86_64 内核 boot 剖析：出现 shell 后写入结束标记并停止 QEMU
+cargo starry perf --arch x86_64 --kernel-filter --format folded \
+    --shell-init-cmd "echo QPERF_BOOT_DONE" \
+    --stop-marker "QPERF_BOOT_DONE" --timeout 60
 
 # 指令级采样 + 帧指针解栈
-cargo starry perf --mode Insn --callchain Fp --force-frame-pointers
+cargo starry perf --mode insn --callchain fp --force-frame-pointers
 
 # 自定义工作负载采样窗口
 cargo starry perf --shell-init-cmd "/bin/run_benchmark.sh" \

--- a/scripts/axbuild/src/starry/perf/harness.rs
+++ b/scripts/axbuild/src/starry/perf/harness.rs
@@ -20,6 +20,8 @@ use crate::support::process::ProcessExt;
 
 const HARNESS_KIT_REPO: &str = "https://github.com/cg24-THU/tgoskit-harness_kit.git";
 const HARNESS_KIT_COMMIT: &str = "762c22725024a065e85b26e0b01121eccea651c0";
+const LEGACY_PERF_POSTPROCESS_ARCH_ARG: &str = r#"perf_post_parser.add_argument("--arch", default="riscv64", choices=["riscv64", "loongarch64"])"#;
+const X86_64_PERF_POSTPROCESS_ARCH_ARG: &str = r#"perf_post_parser.add_argument("--arch", default="riscv64", choices=["riscv64", "loongarch64", "x86_64"])"#;
 
 pub(super) struct QperfTools {
     pub(super) plugin: PathBuf,
@@ -260,16 +262,7 @@ pub(super) fn run_report_postprocess(
     arch: &str,
     returncode: i32,
 ) -> anyhow::Result<PathBuf> {
-    let harness =
-        match workspace_harness_path(&outputs.work_dir).or_else(|| workspace_harness_path(root)) {
-            Some(harness) => harness,
-            None => {
-                let checkout = ensure_harness_kit_checkout(root)?;
-                let harness = checkout.join("tools/starry-syscall-harness/harness.py");
-                ensure_file(&harness, "fixed harness kit postprocess script")?;
-                harness
-            }
-        };
+    let harness = report_harness(root, outputs, arch)?;
     let python = env::var_os("STARRY_SYSCALL_HARNESS_PYTHON")
         .or_else(|| env::var_os("PYTHON"))
         .unwrap_or_else(|| OsString::from("python3"));
@@ -370,6 +363,46 @@ pub(super) fn run_report_postprocess(
     Ok(harness)
 }
 
+fn report_harness(root: &Path, outputs: &PerfOutputs, arch: &str) -> anyhow::Result<PathBuf> {
+    if arch == "x86_64" {
+        let checkout = ensure_harness_kit_checkout(root)?;
+        let upstream = checkout.join("tools/starry-syscall-harness/harness.py");
+        ensure_file(&upstream, "fixed harness kit postprocess script")?;
+        let source = fs::read_to_string(&upstream)
+            .with_context(|| format!("failed to read {}", upstream.display()))?;
+        let patched = add_x86_64_perf_postprocess_choice(&source)?;
+        let harness = outputs.dir.join("harness-x86_64.py");
+        fs::write(&harness, patched)
+            .with_context(|| format!("failed to write {}", harness.display()))?;
+        return Ok(harness);
+    }
+
+    match workspace_harness_path(&outputs.work_dir).or_else(|| workspace_harness_path(root)) {
+        Some(harness) => Ok(harness),
+        None => {
+            let checkout = ensure_harness_kit_checkout(root)?;
+            let harness = checkout.join("tools/starry-syscall-harness/harness.py");
+            ensure_file(&harness, "fixed harness kit postprocess script")?;
+            Ok(harness)
+        }
+    }
+}
+
+fn add_x86_64_perf_postprocess_choice(source: &str) -> anyhow::Result<String> {
+    let legacy_matches = source.matches(LEGACY_PERF_POSTPROCESS_ARCH_ARG).count();
+    if legacy_matches != 1 {
+        bail!(
+            "cannot apply the x86_64 qperf postprocess compatibility patch: expected exactly one \
+             pinned legacy perf-postprocess architecture declaration, found {legacy_matches}"
+        );
+    }
+    Ok(source.replacen(
+        LEGACY_PERF_POSTPROCESS_ARCH_ARG,
+        X86_64_PERF_POSTPROCESS_ARCH_ARG,
+        1,
+    ))
+}
+
 fn ensure_report_outputs(outputs: &PerfOutputs) -> anyhow::Result<()> {
     for path in [
         &outputs.report_json,
@@ -401,4 +434,24 @@ fn workspace_harness_path(work_dir: &Path) -> Option<PathBuf> {
         current = path.parent();
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::add_x86_64_perf_postprocess_choice;
+
+    #[test]
+    fn x86_64_postprocess_shim_extends_only_the_perf_postprocess_arch_choice() {
+        let legacy = r#"perf_parser.add_argument("--arch", default="riscv64", choices=["riscv64", "loongarch64"])
+perf_post_parser.add_argument("--arch", default="riscv64", choices=["riscv64", "loongarch64"])"#;
+
+        let patched = add_x86_64_perf_postprocess_choice(legacy).unwrap();
+
+        assert!(patched.contains(
+            r#"perf_post_parser.add_argument("--arch", default="riscv64", choices=["riscv64", "loongarch64", "x86_64"])"#
+        ));
+        assert!(patched.contains(
+            r#"perf_parser.add_argument("--arch", default="riscv64", choices=["riscv64", "loongarch64"])"#
+        ));
+    }
 }

--- a/scripts/axbuild/src/starry/perf/metrics.rs
+++ b/scripts/axbuild/src/starry/perf/metrics.rs
@@ -97,6 +97,14 @@ pub(super) fn exit_status_code(status: &ExitStatus) -> i32 {
         .unwrap_or_else(|| if status.success() { 0 } else { 1 })
 }
 
+pub(super) fn report_returncode(returncode: i32, timed_out: bool) -> i32 {
+    if timed_out && returncode == 124 {
+        0
+    } else {
+        returncode
+    }
+}
+
 fn nonnegative_delta(after: i128, before: i128) -> i128 {
     after.saturating_sub(before).max(0)
 }
@@ -128,4 +136,16 @@ fn timeval_micros(value: libc::timeval) -> i128 {
 #[cfg(not(unix))]
 pub(super) fn child_resource_usage() -> Option<ChildResourceUsage> {
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::report_returncode;
+
+    #[test]
+    fn expected_profile_timeout_is_a_successful_report() {
+        assert_eq!(report_returncode(124, true), 0);
+        assert_eq!(report_returncode(124, false), 124);
+        assert_eq!(report_returncode(1, true), 1);
+    }
 }

--- a/scripts/axbuild/src/starry/perf/mod.rs
+++ b/scripts/axbuild/src/starry/perf/mod.rs
@@ -21,6 +21,7 @@ pub(super) async fn run(starry: &mut Starry, args: ArgsPerf) -> anyhow::Result<(
         .arch
         .clone()
         .unwrap_or_else(|| crate::context::DEFAULT_STARRY_ARCH.to_string());
+    qemu::validate_arch(&arch)?;
     let target = starry_target_for_arch_checked(&arch)?.to_string();
     let outputs = outputs::prepare_outputs(
         starry.app.workspace_root(),
@@ -63,8 +64,12 @@ pub(super) async fn run(starry: &mut Starry, args: ArgsPerf) -> anyhow::Result<(
     args_support::apply_perf_cargo_features(&mut cargo, &args);
     let qemu = rootfs::load_patched_qemu_config(starry, &request, &cargo, None, true).await?;
     let elf = build_output.elf_path().to_path_buf();
+    starry
+        .app
+        .prepare_elf_artifact(elf.clone(), qemu.to_bin)
+        .await?;
     let text_range = symbols::detect_kernel_text_range(&elf)?;
-    qemu::write_qemu_config(&outputs, &tools, &args, &arch, qemu.args, text_range)?;
+    qemu::write_qemu_config(&outputs, &tools, &args, &arch, &qemu, text_range)?;
 
     let kernel_bin = symbols::kernel_bin_path(starry.app.workspace_root(), &target, args.debug);
     let qemu_run = qemu::run_qemu_direct(&outputs, &args, &arch, &kernel_bin)?;
@@ -75,10 +80,14 @@ pub(super) async fn run(starry: &mut Starry, args: ArgsPerf) -> anyhow::Result<(
                 qemu_run.status
             );
         }
-        eprintln!(
-            "qperf: QEMU ended with {} after producing samples",
-            qemu_run.status
-        );
+        if qemu_run.timed_out {
+            eprintln!("qperf: completed the configured sampling window after producing samples");
+        } else {
+            eprintln!(
+                "qperf: QEMU ended with {} after producing samples",
+                qemu_run.status
+            );
+        }
     }
 
     analyzer::run_analyzer(analyzer::AnalyzerRun {
@@ -131,7 +140,10 @@ pub(super) async fn run(starry: &mut Starry, args: ArgsPerf) -> anyhow::Result<(
         &outputs,
         &args,
         &arch,
-        metrics::exit_status_code(&qemu_run.status),
+        metrics::report_returncode(
+            metrics::exit_status_code(&qemu_run.status),
+            qemu_run.timed_out,
+        ),
     )?;
     summary::print_report(&outputs, &args, &report_harness);
     Ok(())

--- a/scripts/axbuild/src/starry/perf/monitor.rs
+++ b/scripts/axbuild/src/starry/perf/monitor.rs
@@ -129,6 +129,7 @@ pub(super) fn run_qemu_with_stdout_monitor(
             finalize_window_warnings(&mut window_report);
             return Ok(QemuRun {
                 status,
+                timed_out: false,
                 window: window_report,
             });
         }
@@ -248,6 +249,7 @@ pub(super) fn run_qemu_with_stdout_monitor(
     finalize_window_warnings(&mut window_report);
     Ok(QemuRun {
         status,
+        timed_out: false,
         window: window_report,
     })
 }

--- a/scripts/axbuild/src/starry/perf/qemu.rs
+++ b/scripts/axbuild/src/starry/perf/qemu.rs
@@ -1,7 +1,7 @@
 use std::{
-    fs,
+    env, fs,
     fs::File,
-    path::Path,
+    path::{Path, PathBuf},
     process::{Command, ExitStatus},
     time::Instant,
 };
@@ -25,6 +25,8 @@ use super::{
 
 pub(super) const QPERF_QUEUE_SIZE: usize = 4096;
 pub(super) const DEFAULT_STARRY_SHELL_PREFIX: &str = "root@starry:";
+const SUPPORTED_ARCHES: &str = "riscv64, loongarch64, and x86_64";
+const OVMF_DIR_ENV: &str = "QPERF_OVMF_DIR";
 
 #[derive(Deserialize, Serialize)]
 pub(super) struct PerfQemuConfig {
@@ -43,6 +45,7 @@ pub(super) struct PerfQemuConfig {
 
 pub(super) struct QemuRun {
     pub(super) status: ExitStatus,
+    pub(super) timed_out: bool,
     pub(super) window: PerfWindowReport,
 }
 
@@ -51,7 +54,7 @@ pub(super) fn write_qemu_config(
     tools: &QperfTools,
     args: &ArgsPerf,
     arch: &str,
-    qemu_args: Vec<String>,
+    qemu: &ostool::run::qemu::QemuConfig,
     text_range: Option<KernelTextRange>,
 ) -> anyhow::Result<()> {
     let mut perf_qemu_args = vec!["-plugin".to_string()];
@@ -69,20 +72,9 @@ pub(super) fn write_qemu_config(
         ",filter_kernel={}",
         if args.kernel_filter { 1 } else { 0 }
     ));
-    if let Some(range) = text_range {
-        let start = range.virt.start;
-        let end = range.virt.end;
-        plugin_params.push_str(&format!(",filter_start=0x{start:x},filter_end=0x{end:x}"));
-        if let Some(phys) = range.phys {
-            let offset = range.virt.start.wrapping_sub(phys.start);
-            plugin_params.push_str(&format!(
-                ",filter_alias_start=0x{:x},filter_alias_end=0x{:x},filter_alias_offset=0x{:x}",
-                phys.start, phys.end, offset
-            ));
-        }
-    }
+    append_text_filter_params(&mut plugin_params, arch, text_range);
     perf_qemu_args.push(plugin_params);
-    let mut qemu_args = direct_qemu_args(arch, qemu_args)?;
+    let mut qemu_args = direct_qemu_args(arch, qemu.args.clone())?;
     qemu_args.extend(args.qemu_args.iter().cloned());
     if qemu_stdout_monitor_enabled(args) && !has_qemu_option(&qemu_args, "-qmp") {
         qemu_args.extend([
@@ -106,8 +98,8 @@ pub(super) fn write_qemu_config(
 
     let config = PerfQemuConfig {
         args: perf_qemu_args,
-        uefi: false,
-        to_bin: true,
+        uefi: qemu.uefi,
+        to_bin: qemu.to_bin,
         success_regex: Vec::new(),
         fail_regex: vec![r"(?i)\bpanic(?:ked)?\b".to_string()],
         shell_prefix,
@@ -122,6 +114,38 @@ pub(super) fn write_qemu_config(
     Ok(())
 }
 
+fn append_text_filter_params(
+    plugin_params: &mut String,
+    arch: &str,
+    text_range: Option<KernelTextRange>,
+) {
+    let Some(range) = text_range else {
+        return;
+    };
+    let start = range.virt.start;
+    let end = range.virt.end;
+    plugin_params.push_str(&format!(",filter_start=0x{start:x},filter_end=0x{end:x}"));
+    // x86_64 executes unrelated firmware and identity-mapped code in the same low 32-bit
+    // address window during UEFI boot. A low alias inferred only by masking the ELF virtual
+    // address would therefore turn those samples into plausible but incorrect kernel symbols.
+    if arch != "x86_64"
+        && let Some(phys) = range.phys
+    {
+        let offset = range.virt.start.wrapping_sub(phys.start);
+        plugin_params.push_str(&format!(
+            ",filter_alias_start=0x{:x},filter_alias_end=0x{:x},filter_alias_offset=0x{:x}",
+            phys.start, phys.end, offset
+        ));
+    }
+}
+
+pub(super) fn validate_arch(arch: &str) -> anyhow::Result<()> {
+    match arch {
+        "riscv64" | "loongarch64" | "x86_64" => Ok(()),
+        _ => bail!("qperf currently supports StarryOS {SUPPORTED_ARCHES} only"),
+    }
+}
+
 fn direct_qemu_args(arch: &str, mut args: Vec<String>) -> anyhow::Result<Vec<String>> {
     match arch {
         "riscv64" | "loongarch64" => {
@@ -129,7 +153,8 @@ fn direct_qemu_args(arch: &str, mut args: Vec<String>) -> anyhow::Result<Vec<Str
                 args.splice(0..0, ["-machine".to_string(), "virt".to_string()]);
             }
         }
-        _ => bail!("qperf currently supports StarryOS riscv64 and loongarch64 only"),
+        "x86_64" => {}
+        _ => bail!("qperf currently supports StarryOS {SUPPORTED_ARCHES} only"),
     }
     Ok(args)
 }
@@ -150,20 +175,9 @@ pub(super) fn run_qemu_direct(
     let qemu_args = config.args.clone();
     let monitor_stdout = qemu_stdout_monitor_enabled(args);
 
-    let mut command_args = if args.timeout > 0 && !monitor_stdout {
-        vec![
-            "timeout".to_string(),
-            "--signal=INT".to_string(),
-            "--kill-after=5s".to_string(),
-            format!("{}s", args.timeout),
-            qemu.to_string(),
-        ]
-    } else {
-        vec![qemu.to_string()]
-    };
+    let mut command_args = qemu_command_prefix(qemu, args.timeout, monitor_stdout);
     command_args.extend(qemu_args);
-    command_args.push("-kernel".to_string());
-    command_args.push(kernel_bin.display().to_string());
+    command_args.extend(prepare_boot_args(outputs, &config, arch, kernel_bin)?);
 
     if args.host_perf {
         if let Some(perf) = find_executable("perf") {
@@ -194,8 +208,10 @@ pub(super) fn run_qemu_direct(
     let qemu_run = if monitor_stdout {
         run_qemu_with_stdout_monitor(command, &config, outputs, args.timeout)?
     } else {
+        let status = command.status().context("failed to spawn QEMU")?;
         QemuRun {
-            status: command.status().context("failed to spawn QEMU")?,
+            timed_out: args.timeout > 0 && status.code() == Some(124),
+            status,
             window: window_report_from_config(&config),
         }
     };
@@ -220,11 +236,133 @@ pub(super) fn run_qemu_direct(
     Ok(qemu_run)
 }
 
+fn qemu_command_prefix(qemu: &str, timeout: u64, monitor_stdout: bool) -> Vec<String> {
+    if timeout > 0 && !monitor_stdout {
+        vec![
+            "timeout".to_string(),
+            "--foreground".to_string(),
+            "--signal=INT".to_string(),
+            "--kill-after=5s".to_string(),
+            format!("{timeout}s"),
+            qemu.to_string(),
+        ]
+    } else {
+        vec![qemu.to_string()]
+    }
+}
+
+fn prepare_boot_args(
+    outputs: &PerfOutputs,
+    config: &PerfQemuConfig,
+    arch: &str,
+    kernel_bin: &Path,
+) -> anyhow::Result<Vec<String>> {
+    if arch != "x86_64" {
+        return Ok(vec![
+            "-kernel".to_string(),
+            kernel_bin.display().to_string(),
+        ]);
+    }
+    if !config.uefi {
+        bail!("StarryOS x86_64 qperf requires a QEMU config with `uefi = true`");
+    }
+    if !config.to_bin {
+        bail!("StarryOS x86_64 qperf requires a QEMU config with `to_bin = true`");
+    }
+
+    let firmware = find_x86_64_uefi_firmware()?;
+    prepare_x86_64_uefi_boot(&outputs.dir, kernel_bin, &firmware)
+}
+
+struct UefiFirmware {
+    code: PathBuf,
+    vars: PathBuf,
+}
+
+fn find_x86_64_uefi_firmware() -> anyhow::Result<UefiFirmware> {
+    let mut candidates = Vec::new();
+    if let Some(dir) = env::var_os(OVMF_DIR_ENV) {
+        candidates.push(PathBuf::from(dir));
+    }
+    candidates.extend([
+        env::temp_dir().join("ostool/ovmf/x64"),
+        PathBuf::from("/usr/share/OVMF"),
+        PathBuf::from("/usr/share/edk2/x64"),
+        PathBuf::from("/usr/share/qemu"),
+    ]);
+
+    for dir in candidates {
+        for (code_name, vars_name) in [
+            ("code.fd", "vars.fd"),
+            ("OVMF_CODE.fd", "OVMF_VARS.fd"),
+            ("edk2-x86_64-code.fd", "edk2-i386-vars.fd"),
+        ] {
+            let firmware = UefiFirmware {
+                code: dir.join(code_name),
+                vars: dir.join(vars_name),
+            };
+            if firmware.code.is_file() && firmware.vars.is_file() {
+                return Ok(firmware);
+            }
+        }
+    }
+
+    bail!(
+        "qperf could not find x86_64 OVMF firmware; install the host OVMF package or set \
+         {OVMF_DIR_ENV} to a directory containing code.fd and vars.fd"
+    )
+}
+
+fn prepare_x86_64_uefi_boot(
+    output_dir: &Path,
+    kernel_bin: &Path,
+    firmware: &UefiFirmware,
+) -> anyhow::Result<Vec<String>> {
+    ensure_file(kernel_bin, "StarryOS x86_64 UEFI image")?;
+    ensure_file(&firmware.code, "OVMF code image")?;
+    ensure_file(&firmware.vars, "OVMF vars template")?;
+
+    let esp_dir = output_dir.join("starryos.esp");
+    let boot_dir = esp_dir.join("EFI/BOOT");
+    fs::create_dir_all(&boot_dir)
+        .with_context(|| format!("failed to create x86_64 UEFI ESP {}", boot_dir.display()))?;
+    let boot_image = boot_dir.join("BOOTX64.EFI");
+    fs::copy(kernel_bin, &boot_image).with_context(|| {
+        format!(
+            "failed to copy StarryOS UEFI image from {} to {}",
+            kernel_bin.display(),
+            boot_image.display()
+        )
+    })?;
+
+    let vars = output_dir.join("starryos.vars.fd");
+    fs::copy(&firmware.vars, &vars).with_context(|| {
+        format!(
+            "failed to copy OVMF vars template from {} to {}",
+            firmware.vars.display(),
+            vars.display()
+        )
+    })?;
+
+    Ok(vec![
+        "-drive".to_string(),
+        format!(
+            "if=pflash,format=raw,unit=0,readonly=on,file={}",
+            firmware.code.display()
+        ),
+        "-drive".to_string(),
+        format!("if=pflash,format=raw,unit=1,file={}", vars.display()),
+        "-drive".to_string(),
+        format!("format=raw,file=fat:rw:{}", esp_dir.display()),
+    ])
+}
+
 fn qemu_executable(arch: &str) -> anyhow::Result<&'static str> {
     let name = match arch {
         "riscv64" => "qemu-system-riscv64",
         "loongarch64" => "qemu-system-loongarch64",
-        _ => bail!("qperf currently supports StarryOS riscv64 and loongarch64 only"),
+        "x86_64" => "qemu-system-x86_64",
+        _ => bail!("qperf currently supports StarryOS {SUPPORTED_ARCHES} only"),
     };
     if find_executable(name).is_none() {
         bail!(
@@ -249,4 +387,101 @@ fn qemu_stdout_monitor_enabled(args: &ArgsPerf) -> bool {
         || args.start_marker.is_some()
         || args.stop_marker.is_some()
         || args.workload_timeout.is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::{
+        UefiFirmware, append_text_filter_params, direct_qemu_args, prepare_x86_64_uefi_boot,
+        qemu_command_prefix, validate_arch,
+    };
+    use crate::starry::perf::symbols::{AddressRange, KernelTextRange};
+
+    #[test]
+    fn direct_qemu_args_accepts_x86_64_q35_config() {
+        let args = vec!["-machine".to_string(), "q35".to_string()];
+
+        let args = direct_qemu_args("x86_64", args.clone()).unwrap();
+
+        assert_eq!(args, vec!["-machine", "q35"]);
+    }
+
+    #[test]
+    fn supported_arch_validation_includes_x86_64() {
+        assert!(validate_arch("x86_64").is_ok());
+        assert!(validate_arch("aarch64").is_err());
+    }
+
+    #[test]
+    fn timeout_keeps_interactive_qemu_in_the_foreground() {
+        let prefix = qemu_command_prefix("qemu-system-x86_64", 15, false);
+
+        assert_eq!(
+            prefix,
+            vec![
+                "timeout",
+                "--foreground",
+                "--signal=INT",
+                "--kill-after=5s",
+                "15s",
+                "qemu-system-x86_64",
+            ]
+        );
+    }
+
+    #[test]
+    fn x86_64_kernel_filter_does_not_guess_a_low_address_alias() {
+        let mut params = String::new();
+        append_text_filter_params(
+            &mut params,
+            "x86_64",
+            Some(KernelTextRange {
+                virt: AddressRange {
+                    start: 0xffff_ffff_8000_0000,
+                    end: 0xffff_ffff_804d_383f,
+                },
+                phys: Some(AddressRange {
+                    start: 0x8000_0000,
+                    end: 0x804d_383f,
+                }),
+            }),
+        );
+
+        assert!(params.contains("filter_start=0xffffffff80000000"));
+        assert!(!params.contains("filter_alias_start"));
+    }
+
+    #[test]
+    fn x86_64_uefi_boot_uses_a_private_vars_copy_and_esp() {
+        let temp = tempfile::tempdir().unwrap();
+        let kernel_bin = temp.path().join("starryos.bin");
+        let code = temp.path().join("code.fd");
+        let vars = temp.path().join("vars.fd");
+        fs::write(&kernel_bin, b"MZ kernel").unwrap();
+        fs::write(&code, b"code").unwrap();
+        fs::write(&vars, b"vars").unwrap();
+
+        let args = prepare_x86_64_uefi_boot(
+            temp.path(),
+            &kernel_bin,
+            &UefiFirmware {
+                code: code.clone(),
+                vars,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read(temp.path().join("starryos.esp/EFI/BOOT/BOOTX64.EFI")).unwrap(),
+            b"MZ kernel"
+        );
+        assert_eq!(
+            fs::read(temp.path().join("starryos.vars.fd")).unwrap(),
+            b"vars"
+        );
+        assert!(args.iter().any(|arg| arg.contains(code.to_str().unwrap())));
+        assert!(!args.iter().any(|arg| arg == "-kernel"));
+    }
 }

--- a/tools/qperf/README.md
+++ b/tools/qperf/README.md
@@ -9,8 +9,9 @@ Based on [QEMU TCG Plugins](https://www.qemu.org/docs/master/devel/tcg-plugins.h
 ## Requirements
 
 - QEMU Version 9.2.0 or later (Plugin API Version 4)
-- Code segment address mask `0x8000_0000_0000_0000`  
-  This is required to distinguish kernel code from user code. We don't want to trace user programs.
+- A kernel text address range passed through `filter_start`/`filter_end` when kernel-only sampling is
+  required. Do not infer an x86_64 low-address alias from the high-half address: UEFI and
+  identity-mapped code can occupy the same low window.
 - [DWARF debugging information](https://dwarfstd.org/)
 - Frame pointers enabled
 
@@ -83,4 +84,13 @@ There are many visualization options. Recommendations:
 ### Note for Starry OS
 
 - The default build options (`BACKTRACE=y`) should already enable all the debugging options qperf needs.
-- Use `make ... run QEMU_ARGS="-plugin libqperf.so"` to enable qperf plugin.
+- The plugin recognizes QEMU targets `riscv64`, `loongarch64`, and `x86_64`.
+- Prefer `cargo starry perf`; it builds the plugin/analyzer, prepares the matching StarryOS QEMU
+  boot flow, supplies kernel ranges, and generates the report artifacts.
+- For an x86_64 kernel boot profile, use:
+
+```bash
+cargo starry perf --arch x86_64 --kernel-filter --format folded \
+    --shell-init-cmd "echo QPERF_BOOT_DONE" \
+    --stop-marker "QPERF_BOOT_DONE" --timeout 60
+```

--- a/tools/qperf/analyzer/src/main.rs
+++ b/tools/qperf/analyzer/src/main.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::Context;
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use object::{Object, ObjectSymbol};
+use object::{Object, ObjectSection, ObjectSymbol};
 use regex::Regex;
 
 const MAX_QPERF_RECORD_BYTES: usize = 256 * 1024;
@@ -375,6 +375,13 @@ fn read_qperf_records_v3(path: &Path) -> anyhow::Result<Vec<DecodedRecord>> {
     let mut input = BufReader::new(File::open(path).context("failed to open input file")?);
     let mut records = Vec::new();
     loop {
+        if input
+            .fill_buf()
+            .context("failed to inspect qperf v3 input")?
+            .is_empty()
+        {
+            break;
+        }
         match bincode::decode_from_std_read(
             &mut input,
             bincode::config::standard().with_limit::<MAX_QPERF_RECORD_BYTES>(),
@@ -415,6 +422,13 @@ fn read_qperf_records_v2(path: &Path) -> anyhow::Result<Vec<DecodedRecord>> {
     let mut input = BufReader::new(File::open(path).context("failed to open input file")?);
     let mut records = Vec::new();
     loop {
+        if input
+            .fill_buf()
+            .context("failed to inspect qperf v2 input")?
+            .is_empty()
+        {
+            break;
+        }
         match bincode::decode_from_std_read(
             &mut input,
             bincode::config::standard().with_limit::<MAX_QPERF_RECORD_BYTES>(),
@@ -447,6 +461,13 @@ fn read_qperf_records_v1(path: &Path) -> anyhow::Result<Vec<DecodedRecord>> {
     let mut input = BufReader::new(File::open(path).context("failed to open input file")?);
     let mut records = Vec::new();
     loop {
+        if input
+            .fill_buf()
+            .context("failed to inspect qperf v1 input")?
+            .is_empty()
+        {
+            break;
+        }
         let trace: Vec<u64> = match bincode::decode_from_std_read(
             &mut input,
             bincode::config::standard().with_limit::<MAX_QPERF_RECORD_BYTES>(),
@@ -732,6 +753,10 @@ fn resolve_symbols(
     demangle: bool,
     style: SymbolStyle,
 ) -> Vec<String> {
+    if let Some(symbol) = zero_sized_text_symbol(elf_obj, ip, demangle, style) {
+        return vec![symbol];
+    }
+
     let mut result = Vec::new();
     let Ok(mut frames) = loader.find_frames(ip) else {
         return symtab_fallback(elf_obj, ip, demangle, style);
@@ -766,28 +791,75 @@ fn symtab_fallback(
     demangle: bool,
     style: SymbolStyle,
 ) -> Vec<String> {
-    let nearest = elf_obj
+    let symbol_map = elf_obj.symbol_map();
+    symbol_map
+        .get(ip)
+        .filter(|symbol| !should_skip_symbol_name(symbol.name()))
+        .map(|symbol| {
+            vec![format_symbol_name(
+                symbol.name(),
+                ip - symbol.address(),
+                demangle,
+                style,
+            )]
+        })
+        .unwrap_or_else(|| vec![format!("0x{ip:x}")])
+}
+
+struct TextSymbol {
+    address: u64,
+    size: u64,
+    name: String,
+}
+
+fn zero_sized_text_symbol(
+    elf_obj: &object::File<'_>,
+    ip: u64,
+    demangle: bool,
+    style: SymbolStyle,
+) -> Option<String> {
+    let mut symbols = elf_obj
         .symbols()
         .filter_map(|symbol| {
-            if !symbol.is_definition() || symbol.kind() != object::SymbolKind::Text {
+            let in_text_section = symbol
+                .section_index()
+                .and_then(|index| elf_obj.section_by_index(index).ok())
+                .is_some_and(|section| {
+                    section.kind() == object::SectionKind::Text
+                        || matches!(section.name(), Ok(".head.text" | ".text"))
+                });
+            if !in_text_section
+                && !(symbol.is_definition() && symbol.kind() == object::SymbolKind::Text)
+            {
                 return None;
             }
-            let addr = symbol.address();
-            if ip < addr {
-                return None;
-            }
-            let name = symbol.name().ok()?;
-            if should_skip_symbol_name(name) {
-                return None;
-            }
-            let offset = ip - addr;
-            Some((offset, format_symbol_name(name, offset, demangle, style)))
+            Some(TextSymbol {
+                address: symbol.address(),
+                size: symbol.size(),
+                name: symbol.name().ok()?.to_string(),
+            })
         })
-        .min_by_key(|(offset, _)| *offset);
+        .collect::<Vec<_>>();
+    symbols.sort_unstable_by_key(|symbol| symbol.address);
+    let (symbol, offset) = select_zero_sized_text_symbol(&symbols, ip)?;
+    if should_skip_symbol_name(&symbol.name) {
+        return None;
+    }
+    Some(format_symbol_name(&symbol.name, offset, demangle, style))
+}
 
-    nearest
-        .map(|(_, name)| vec![name])
-        .unwrap_or_else(|| vec![format!("0x{ip:x}")])
+fn select_zero_sized_text_symbol(symbols: &[TextSymbol], ip: u64) -> Option<(&TextSymbol, u64)> {
+    let index = symbols.partition_point(|symbol| symbol.address <= ip);
+    let index = index.checked_sub(1)?;
+    let symbol = &symbols[index];
+    if symbol.size != 0 {
+        return None;
+    }
+    let next_address = symbols
+        .get(index + 1)
+        .map(|next| next.address)
+        .unwrap_or(u64::MAX);
+    (ip < next_address).then_some((symbol, ip - symbol.address))
 }
 
 fn should_skip_symbol_name(name: &str) -> bool {
@@ -889,7 +961,7 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use super::{ResolveStats, read_qperf_records};
+    use super::{ResolveStats, TextSymbol, read_qperf_records, select_zero_sized_text_symbol};
 
     #[test]
     fn malformed_legacy_trace_length_returns_error_without_panic() {
@@ -918,5 +990,32 @@ mod tests {
         let _ = fs::remove_file(path);
         assert!(result.is_ok());
         assert!(result.unwrap().is_err());
+    }
+
+    #[test]
+    fn zero_sized_assembly_symbol_owns_addresses_until_the_next_symbol() {
+        let symbols = vec![
+            TextSymbol {
+                address: 0x1000,
+                size: 0x80,
+                name: "rust_function".to_string(),
+            },
+            TextSymbol {
+                address: 0x1080,
+                size: 0,
+                name: "user_copy".to_string(),
+            },
+            TextSymbol {
+                address: 0x1200,
+                size: 0,
+                name: "syscall_entry".to_string(),
+            },
+        ];
+
+        let (symbol, offset) = select_zero_sized_text_symbol(&symbols, 0x1100).unwrap();
+
+        assert_eq!(symbol.name, "user_copy");
+        assert_eq!(offset, 0x80);
+        assert!(select_zero_sized_text_symbol(&symbols, 0x107f).is_none());
     }
 }

--- a/tools/qperf/src/lib.rs
+++ b/tools/qperf/src/lib.rs
@@ -1,2 +1,3 @@
 mod profiler;
 mod reg;
+mod target;

--- a/tools/qperf/src/profiler.rs
+++ b/tools/qperf/src/profiler.rs
@@ -17,11 +17,14 @@ use qemu_plugin::{
     CallbackFlags, PluginId, TranslationBlock, VCPUIndex,
     install::{Args, Info, Value},
     plugin::{HasCallbacks, Register},
-    qemu_plugin_get_registers, qemu_plugin_read_memory_vaddr,
+    qemu_plugin_get_registers, qemu_plugin_read_memory_vaddr, qemu_plugin_register_atexit_cb,
 };
 use zerocopy::IntoBytes;
 
-use crate::reg::{AllRegs, Frame, Reg, Target};
+use crate::{
+    reg::AllRegs,
+    target::{Frame, Reg, Target},
+};
 
 #[derive(bincode::Encode)]
 struct SampleRecord {
@@ -32,6 +35,11 @@ struct SampleRecord {
     cpu: u32,
     callchain: u8,
     trace: Vec<u64>,
+}
+
+enum WriterEvent {
+    Sample(SampleRecord),
+    Shutdown(Sender<()>),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -272,7 +280,7 @@ struct Stats {
 #[derive(Clone)]
 pub struct Profiler {
     target: Target,
-    tx: Sender<SampleRecord>,
+    tx: Sender<WriterEvent>,
     intvl: Duration,
     max_depth: usize,
     mode: SamplingMode,
@@ -340,17 +348,21 @@ impl Profiler {
                 if !seen_fps.insert(fp) {
                     break;
                 }
+                let Some(frame_address) = self.target.frame_address(fp) else {
+                    break;
+                };
                 let mut frame = Frame::default();
-                if qemu_plugin_read_memory_vaddr(fp - self.target.fp_offset(), frame.as_mut_bytes())
-                    .is_err()
-                {
+                if qemu_plugin_read_memory_vaddr(frame_address, frame.as_mut_bytes()).is_err() {
                     break;
                 };
                 if qemu_plugin_read_memory_vaddr(frame.ip, &mut [0; 8]).is_err() {
                     break;
                 }
 
-                ips.push(self.canonicalize_ip(frame.ip).unwrap_or(frame.ip));
+                let Some(frame_ip) = self.sample_ip_for(frame.ip) else {
+                    break;
+                };
+                ips.push(frame_ip);
                 if frame.fp <= fp {
                     break;
                 }
@@ -372,7 +384,7 @@ impl Profiler {
             trace: ips,
         };
 
-        match self.tx.try_send(record) {
+        match self.tx.try_send(WriterEvent::Sample(record)) {
             Ok(()) => {
                 self.stats.samples.fetch_add(1, Ordering::Relaxed);
             }
@@ -494,14 +506,27 @@ impl Register for Profiler {
         let callchain = args.callchain;
         let target = info.target_name.to_string();
         spawn(move || {
+            let mut shutdown = None;
             while let Ok(event) = rx.recv() {
-                if bincode::encode_into_std_write(event, &mut file, bincode::config::standard())
-                    .is_err()
-                {
-                    writer_stats.sample_failures.fetch_add(1, Ordering::Relaxed);
-                    break;
+                match event {
+                    WriterEvent::Sample(sample) => {
+                        if bincode::encode_into_std_write(
+                            sample,
+                            &mut file,
+                            bincode::config::standard(),
+                        )
+                        .is_err()
+                        {
+                            writer_stats.sample_failures.fetch_add(1, Ordering::Relaxed);
+                            break;
+                        }
+                        let _ = file.flush();
+                    }
+                    WriterEvent::Shutdown(done) => {
+                        shutdown = Some(done);
+                        break;
+                    }
                 }
-                let _ = file.flush();
             }
             let _ = file.flush();
             if let Ok(mut summary) = File::create(&summary_path).map(BufWriter::new) {
@@ -538,7 +563,18 @@ impl Register for Profiler {
                 let _ = writeln!(summary, "output = {}", out.display());
                 let _ = summary.flush();
             }
+            if let Some(done) = shutdown {
+                let _ = done.send(());
+            }
         });
+
+        let exit_tx = tx.clone();
+        qemu_plugin_register_atexit_cb(id, move |_| {
+            let (done_tx, done_rx) = bounded(0);
+            if exit_tx.send(WriterEvent::Shutdown(done_tx)).is_ok() {
+                let _ = done_rx.recv();
+            }
+        })?;
 
         self.target = info.target_name.parse()?;
         self.tx = tx;

--- a/tools/qperf/src/reg.rs
+++ b/tools/qperf/src/reg.rs
@@ -1,8 +1,7 @@
-use std::{collections::BTreeMap, str::FromStr};
+use std::collections::BTreeMap;
 
-use anyhow::{Context, anyhow, bail};
+use anyhow::{Context, anyhow};
 use qemu_plugin::RegisterDescriptor;
-use zerocopy::{FromBytes, IntoBytes};
 
 #[derive(Default)]
 pub struct AllRegs(BTreeMap<String, RegisterDescriptor<'static>>);
@@ -29,58 +28,5 @@ impl From<Vec<RegisterDescriptor<'static>>> for AllRegs {
             .map(|reg| (reg.name.clone(), reg))
             .collect();
         AllRegs(map)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Target {
-    Riscv64,
-    LoongArch64,
-}
-
-impl FromStr for Target {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "riscv64" => Ok(Target::Riscv64),
-            "loongarch64" => Ok(Target::LoongArch64),
-            _ => bail!("unknown target: {}", s),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(unused)]
-pub enum Reg {
-    Sp,
-    Fp,
-}
-
-#[derive(Debug, Default, Clone, Copy, FromBytes, IntoBytes)]
-#[repr(C)]
-pub struct Frame {
-    pub fp: u64,
-    pub ip: u64,
-}
-
-impl Target {
-    pub fn reg(&self, reg: Reg) -> &'static str {
-        match self {
-            Target::Riscv64 => match reg {
-                Reg::Sp => "sp",
-                Reg::Fp => "fp",
-            },
-            Target::LoongArch64 => match reg {
-                Reg::Sp => "r3",
-                Reg::Fp => "r22",
-            },
-        }
-    }
-
-    pub fn fp_offset(&self) -> u64 {
-        match self {
-            Target::Riscv64 | Target::LoongArch64 => size_of::<Frame>() as u64,
-        }
     }
 }

--- a/tools/qperf/src/target.rs
+++ b/tools/qperf/src/target.rs
@@ -1,0 +1,63 @@
+use std::{mem::size_of, str::FromStr};
+
+use anyhow::bail;
+use zerocopy::{FromBytes, IntoBytes};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Target {
+    Riscv64,
+    LoongArch64,
+    X86_64,
+}
+
+impl FromStr for Target {
+    type Err = anyhow::Error;
+
+    fn from_str(name: &str) -> Result<Self, Self::Err> {
+        match name {
+            "riscv64" => Ok(Self::Riscv64),
+            "loongarch64" => Ok(Self::LoongArch64),
+            "x86_64" => Ok(Self::X86_64),
+            _ => bail!("unknown target: {name}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Reg {
+    Sp,
+    Fp,
+}
+
+#[derive(Debug, Default, Clone, Copy, FromBytes, IntoBytes)]
+#[repr(C)]
+pub struct Frame {
+    pub fp: u64,
+    pub ip: u64,
+}
+
+impl Target {
+    pub fn reg(self, reg: Reg) -> &'static str {
+        match self {
+            Self::Riscv64 => match reg {
+                Reg::Sp => "sp",
+                Reg::Fp => "fp",
+            },
+            Self::LoongArch64 => match reg {
+                Reg::Sp => "r3",
+                Reg::Fp => "r22",
+            },
+            Self::X86_64 => match reg {
+                Reg::Sp => "rsp",
+                Reg::Fp => "rbp",
+            },
+        }
+    }
+
+    pub fn frame_address(self, fp: u64) -> Option<u64> {
+        match self {
+            Self::Riscv64 | Self::LoongArch64 => fp.checked_sub(size_of::<Frame>() as u64),
+            Self::X86_64 => Some(fp),
+        }
+    }
+}

--- a/tools/qperf/tests/reg.rs
+++ b/tools/qperf/tests/reg.rs
@@ -1,0 +1,25 @@
+#[path = "../src/target.rs"]
+mod target;
+
+use target::{Frame, Reg, Target};
+
+#[test]
+fn parses_qemu_x86_64_target() {
+    let x86_64 = "x86_64".parse::<Target>().unwrap();
+
+    assert_eq!(x86_64.reg(Reg::Sp), "rsp");
+    assert_eq!(x86_64.reg(Reg::Fp), "rbp");
+    assert_eq!(x86_64.frame_address(0x1000), Some(0x1000));
+    assert_eq!(
+        "riscv64".parse::<Target>().unwrap().frame_address(0x1000),
+        Some(0xff0)
+    );
+    assert_eq!(
+        "loongarch64"
+            .parse::<Target>()
+            .unwrap()
+            .frame_address(0x1000),
+        Some(0xff0)
+    );
+    assert_eq!(Frame::default().fp, 0);
+}


### PR DESCRIPTION
## 问题

现有 `cargo starry perf` 与 qperf 插件仅完整支持 RISC-V 和 LoongArch。用于 Starry x86_64 时会在多个阶段失败：

- perf harness 的架构校验与固定后处理流程拒绝 x86_64；
- qperf 插件无法识别 x86_64 target，也没有按 x86_64 ABI 获取寄存器和展开栈；
- x86_64 Starry 需要沿用 q35 + UEFI 的启动路径，不能直接套用其他架构的 `-kernel` 启动参数；
- 固定采样窗口结束会被误判为命令失败，插件退出时还可能遗漏缓冲区中的样本；
- x86_64 低地址可能来自 UEFI 或恒等映射，按低 32 位内核别名归一化会产生错误符号；
- analyzer 对正常 EOF 和汇编符号边界的处理不完整，影响报告生成与符号归因。

## 修改

- 为 qperf 增加 x86_64 target，读取 `rsp`/`rbp`，按 SysV frame-pointer 布局展开调用栈，并复用统一的内核地址过滤。
- perf harness 复用 Starry x86_64 的 q35 配置，通过私有 OVMF vars 与 ESP 启动 `BOOTX64.EFI`，并在启动前准备内核二进制。
- 使用前台 timeout 进程并区分预期采样窗口结束；插件在退出阶段排空样本并刷新 writer。
- x86_64 禁用未经证明的低 32 位 text alias，避免把 UEFI 或恒等映射地址错误归入高半内核符号。
- analyzer 正确处理干净 EOF，并识别汇编函数边界；为 user-copy 与 trap-vector 汇编补充 `.type`/`.size` 元数据。
- 扩展固定 perf 后处理脚本的架构选择，使其接受 x86_64，同时保留原有 pinned harness 行为。
- 补充 qperf 使用文档、x86_64 寄存器测试及 perf harness 回归测试。

## 实现逻辑

x86_64 启动仍由现有 Starry QEMU 配置负责，perf 层只注入 qperf 插件、采样生命周期和报告参数，避免复制另一套启动拓扑。插件只记录可验证的规范高半内核地址；低地址样本保留原值并由内核过滤移除，从源头避免错误符号化。采样停止后先通过 QMP 结束虚拟机，再等待插件完成排空和落盘，保证报告所用原始样本完整。

## 验证

- `cargo fmt --all -- --check`
- `cargo xtask clippy --package axbuild`
- `cargo xtask clippy --package ax-cpu`（32 组架构与 feature 检查）
- `cargo clippy --manifest-path tools/qperf/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path tools/qperf/analyzer/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo test -p axbuild starry::perf::`（10 项通过）
- `cargo test --manifest-path tools/qperf/Cargo.toml --test reg`
- `cargo test --manifest-path tools/qperf/analyzer/Cargo.toml`（2 项通过）
- `git diff --check origin/dev...HEAD`
- x86_64 端到端：

  ```bash
  cargo starry perf \
    --arch x86_64 \
    --kernel-filter \
    --format folded \
    --shell-init-cmd 'echo QPERF_BOOT_DONE' \
    --stop-marker QPERF_BOOT_DONE \
    --timeout 60 \
    --no-host-time \
    --output-dir target/qperf-x86-boot
  ```

  结果为 `ok`：采集并保留 1134 个样本，坏样本 0、丢弃样本 0、采样失败 0；命中停止标记后通过 QMP 正常退出，没有触发超时。

## 性能结果

本次 QEMU TCG 启动采样中，从 qperf 插件启动到 shell 停止标记约 13.53 秒。主要热点为：

- `phys_to_virt`：425 个样本，占 37.48%；
- 页表映射路径：409 个样本，占 36.07%；
- PTE 新页创建：39 个样本，占 3.44%；
- trap vector：27 个样本，占 2.38%；
- `memcpy`/`memset`：22 个样本，占 1.94%。

结果反映 QEMU TCG translation-block 采样分布，不等同于真实硬件周期；当前数据表明 x86_64 启动阶段的主要优化关注点集中在地址转换与页表映射路径。
