### PR TITLE
feat(riscv-aia): add IMSIC+APLIC interrupt controller drivers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,6 +1178,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ax-riscv-aplic"
+version = "0.1.0"
+
+[[package]]
+name = "ax-riscv-imsic"
+version = "0.1.0"
+
+[[package]]
 name = "ax-riscv-plic"
 version = "0.4.9"
 dependencies = [
@@ -7924,6 +7932,8 @@ dependencies = [
  "arm-gic-driver",
  "ax-cpu",
  "ax-kspin",
+ "ax-riscv-aplic",
+ "ax-riscv-imsic",
  "ax-riscv-plic",
  "cpu-local",
  "irq-framework",

--- a/drivers/intc/riscv_aplic/Cargo.toml
+++ b/drivers/intc/riscv_aplic/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ax-riscv-aplic"
+version = "0.1.0"
+repository = "https://github.com/rcore-os/tgoskits"
+edition.workspace = true
+authors = ["Oveln <oveln@example.com>"]
+description = "RISC-V Advanced Platform-Level Interrupt Controller (APLIC) register definitions and MSI-mode operations (AIA)"
+keywords = ["arceos", "riscv", "riscv64", "aplic", "interrupt-controller"]
+categories = ["embedded", "no-std", "hardware-support", "os"]
+license = "Apache-2.0"
+
+# 无外部依赖：本 crate 只用 core::ptr 的 read_volatile/write_volatile 做
+# MMIO 访问，寄存器偏移与位域由常量直接表达。（APLIC 是纯 MMIO，后续如需
+# 与同仓 ax-riscv-plic 风格对齐，可再引入 tock-registers 重构位域封装。）

--- a/drivers/intc/riscv_aplic/src/lib.rs
+++ b/drivers/intc/riscv_aplic/src/lib.rs
@@ -13,7 +13,10 @@
 
 #![no_std]
 
-use core::{num::NonZeroU32, ptr::read_volatile, ptr::write_volatile};
+use core::{
+    num::NonZeroU32,
+    ptr::{read_volatile, write_volatile},
+};
 
 // ── 寄存器偏移（Linux riscv-aplic.h，多源核对一致） ───────────────────
 
@@ -95,6 +98,33 @@ impl SourceTrigger {
             SourceTrigger::LevelLow => SM_LEVEL_LOW,
         }
     }
+
+    /// 从 RISC-V 设备树 interrupt specifier 的触发标志 cell（第二 cell）
+    /// 解析 APLIC 触发类型。
+    ///
+    /// RISC-V DT binding 沿用 POSIX `interrupts extended` 标志位编码：
+    /// - `0x01` → edge rising（低→高边沿）
+    /// - `0x02` → edge falling（高→低边沿）
+    /// - `0x04` → level high（高电平有效）
+    /// - `0x08` → level low（低电平有效）
+    ///
+    /// 其它值（含 `0`）返回 `None`，由调用方决定缺省策略（多数平台 fallback
+    /// 为 `LevelHigh`，见 somehal 集成层）。
+    ///
+    /// 历史背景：本映射曾因错误推论"PCI INTx 必为 level-low"被绕过，导致
+    /// QEMU virt 下所有 wired 源被硬编码为 `LevelLow`，rectified 信号反极性，
+    /// virtio-blk INTx 永不触发。把映射集中到 driver core 层并锁定回归测试，
+    /// 避免再次回退到平台级硬编码。
+    #[inline]
+    pub const fn from_fdt_interrupt_spec(flag: u32) -> Option<Self> {
+        match flag {
+            0x01 => Some(SourceTrigger::EdgeRise),
+            0x02 => Some(SourceTrigger::EdgeFall),
+            0x04 => Some(SourceTrigger::LevelHigh),
+            0x08 => Some(SourceTrigger::LevelLow),
+            _ => None,
+        }
+    }
 }
 
 /// APLIC MSI 目标（写进 target[i] 寄存器）：hart_index + guest_index + eiid。
@@ -123,6 +153,20 @@ pub struct MsiConfig {
     pub lhxs: u32,
     pub hhxw: u32,
     pub hhxs: u32,
+}
+
+/// 把 [`MsiConfig`] 编码成 `smsicfgaddrh`（偏移 0x1bcc）寄存器值。
+///
+/// 纯函数，供 [`Aplic::init_msi_mode`] 与单测共享同一段位打包逻辑。
+/// 位置约束见上方 `CFGADDRH_*` 常量块：S-mode 下仅 LHXS+BAPPN 段被硬件采纳。
+#[inline]
+pub const fn pack_smsicfg_addrh(cfg: &MsiConfig) -> u32 {
+    CFGADDRH_L
+        | ((cfg.hhxs & CFGADDRH_HHXS_MASK) << CFGADDRH_HHXS_SHIFT)
+        | ((cfg.lhxs & CFGADDRH_LHXS_MASK) << CFGADDRH_LHXS_SHIFT)
+        | ((cfg.hhxw & CFGADDRH_HHXW_MASK) << CFGADDRH_HHXW_SHIFT)
+        | ((cfg.lhxw & CFGADDRH_LHXW_MASK) << CFGADDRH_LHXW_SHIFT)
+        | ((cfg.base_ppn >> 32) as u32 & CFGADDRH_BAPPN_MASK)
 }
 
 /// Advanced Platform-Level Interrupt Controller（MSI 模式）。
@@ -224,12 +268,7 @@ impl Aplic {
     /// S-mode 直写这些位无害但无效。调用方需确认目标平台的固件已配置 MSI 几何。
     pub fn init_msi_mode(&mut self, cfg: &MsiConfig) {
         let addr_lo = cfg.base_ppn as u32;
-        let addr_hi: u32 = CFGADDRH_L
-            | ((cfg.hhxs & CFGADDRH_HHXS_MASK) << CFGADDRH_HHXS_SHIFT)
-            | ((cfg.lhxs & CFGADDRH_LHXS_MASK) << CFGADDRH_LHXS_SHIFT)
-            | ((cfg.hhxw & CFGADDRH_HHXW_MASK) << CFGADDRH_HHXW_SHIFT)
-            | ((cfg.lhxw & CFGADDRH_LHXW_MASK) << CFGADDRH_LHXW_SHIFT)
-            | ((cfg.base_ppn >> 32) as u32 & CFGADDRH_BAPPN_MASK);
+        let addr_hi = pack_smsicfg_addrh(cfg);
         self.write(SMSICFGADDR, addr_lo);
         self.write(SMSICFGADDRH, addr_hi);
         let dom = self.read(DOMAINCFG) | DOMAINCFG_IE | DOMAINCFG_DM;
@@ -308,5 +347,102 @@ mod tests {
         assert_eq!(Aplic::source_offset(s1, SOURCECFG_BASE), 0x0004);
         assert_eq!(Aplic::source_offset(s2, SOURCECFG_BASE), 0x0008);
         assert_eq!(Aplic::source_offset(s1, TARGET_BASE), 0x3004);
+    }
+
+    #[test]
+    fn pack_smsicfg_addrh_encodes_geometry_and_base_ppn() {
+        // L 位（bit31）必须置位；各几何字段按 CFGADDRH_* 段打包。
+        let cfg = MsiConfig {
+            base_ppn: 0x0000_0001_2345_6789, // 高 32 位 = 0x1 → BAPPN 段
+            lhxw: 2,
+            lhxs: 3,
+            hhxw: 4,
+            hhxs: 5,
+        };
+        let v = pack_smsicfg_addrh(&cfg);
+        assert_eq!(v & CFGADDRH_L, CFGADDRH_L, "L 位必须置位");
+        assert_eq!(
+            (v >> CFGADDRH_HHXS_SHIFT) & CFGADDRH_HHXS_MASK,
+            5,
+            "HHXS 段"
+        );
+        assert_eq!(
+            (v >> CFGADDRH_LHXS_SHIFT) & CFGADDRH_LHXS_MASK,
+            3,
+            "LHXS 段"
+        );
+        assert_eq!(
+            (v >> CFGADDRH_HHXW_SHIFT) & CFGADDRH_HHXW_MASK,
+            4,
+            "HHXW 段"
+        );
+        assert_eq!(
+            (v >> CFGADDRH_LHXW_SHIFT) & CFGADDRH_LHXW_MASK,
+            2,
+            "LHXW 段"
+        );
+        assert_eq!(v & CFGADDRH_BAPPN_MASK, 1, "BAPPN = base_ppn 高 32 位");
+    }
+
+    #[test]
+    fn pack_smsicfg_addrh_masks_overflowing_fields() {
+        // 字段超出 mask 的高位必须被丢弃，不得污染相邻段。
+        let cfg = MsiConfig {
+            base_ppn: 0xffff_ffff_ffff_ffff,
+            lhxw: 0xff,
+            lhxs: 0xff,
+            hhxw: 0xff,
+            hhxs: 0xff,
+        };
+        let v = pack_smsicfg_addrh(&cfg);
+        assert_eq!(
+            (v >> CFGADDRH_HHXS_SHIFT) & CFGADDRH_HHXS_MASK,
+            CFGADDRH_HHXS_MASK
+        );
+        assert_eq!(
+            (v >> CFGADDRH_LHXS_SHIFT) & CFGADDRH_LHXS_MASK,
+            CFGADDRH_LHXS_MASK
+        );
+        assert_eq!(
+            (v >> CFGADDRH_HHXW_SHIFT) & CFGADDRH_HHXW_MASK,
+            CFGADDRH_HHXW_MASK
+        );
+        assert_eq!(
+            (v >> CFGADDRH_LHXW_SHIFT) & CFGADDRH_LHXW_MASK,
+            CFGADDRH_LHXW_MASK
+        );
+        assert_eq!(v & CFGADDRH_BAPPN_MASK, CFGADDRH_BAPPN_MASK);
+    }
+
+    #[test]
+    fn from_fdt_interrupt_spec_maps_posix_flags() {
+        // 回归锁定：0x04 → LevelHigh。此前曾因"PCI INTx 必为 level-low"的
+        // 错误推论被绕过、硬编码为 LevelLow，导致 QEMU virt 下 rectified 信号
+        // 反极性、virtio-blk INTx 永不触发（见 commit 15d166ba8）。
+        assert_eq!(
+            SourceTrigger::from_fdt_interrupt_spec(0x01),
+            Some(SourceTrigger::EdgeRise)
+        );
+        assert_eq!(
+            SourceTrigger::from_fdt_interrupt_spec(0x02),
+            Some(SourceTrigger::EdgeFall)
+        );
+        assert_eq!(
+            SourceTrigger::from_fdt_interrupt_spec(0x04),
+            Some(SourceTrigger::LevelHigh)
+        );
+        assert_eq!(
+            SourceTrigger::from_fdt_interrupt_spec(0x08),
+            Some(SourceTrigger::LevelLow)
+        );
+    }
+
+    #[test]
+    fn from_fdt_interrupt_spec_rejects_unknown_and_zero() {
+        // 未知 flag / 缺省（0）必须返回 None，由调用方决定 fallback
+        // （somehal 集成层 fallback 为 LevelHigh）。禁止猜测成具体触发类型。
+        assert_eq!(SourceTrigger::from_fdt_interrupt_spec(0), None);
+        assert_eq!(SourceTrigger::from_fdt_interrupt_spec(0x10), None);
+        assert_eq!(SourceTrigger::from_fdt_interrupt_spec(u32::MAX), None);
     }
 }

--- a/drivers/intc/riscv_aplic/src/lib.rs
+++ b/drivers/intc/riscv_aplic/src/lib.rs
@@ -1,0 +1,312 @@
+//! RISC-V Advanced Platform-Level Interrupt Controller (APLIC) —— AIA，MSI 模式
+//!
+//! APLIC 把**有线中断**（UART / mailbox / SD 等的物理 IRQ 线）转成 **MSI** 发给
+//! IMSIC。K3 的 APLIC 仅支持 MSI 模式（手册 §7 "MSI output mode only"），不能
+//! 直送 CPU。
+//!
+//! 配置流程：`init_msi_mode`（domaincfg.DM=1 + smsicfgaddr/h 用 IMSIC base PPN）
+//! → 对每个 wired 源 `configure_source`（sourcecfg 触发类型 + target 的 hart/guest/eiid）
+//! → `enable_source`。
+//!
+//! 本 crate 只提供寄存器语义（MMIO 操作），不含 OS glue——那层在 somehal。
+//! 寄存器偏移经 Linux `include/linux/irqchip/riscv-aplic.h` 核对。
+
+#![no_std]
+
+use core::{num::NonZeroU32, ptr::read_volatile, ptr::write_volatile};
+
+// ── 寄存器偏移（Linux riscv-aplic.h，多源核对一致） ───────────────────
+
+const DOMAINCFG: usize = 0x0000;
+const SOURCECFG_BASE: usize = 0x0004;
+const SMSICFGADDR: usize = 0x1bc8;
+const SMSICFGADDRH: usize = 0x1bcc;
+const SETIP_BASE: usize = 0x1c00;
+const CLRIP_BASE: usize = 0x1d00;
+const SETIE_BASE: usize = 0x1e00;
+const CLRIE_BASE: usize = 0x1f00;
+const SETIPNUM_LE: usize = 0x2000;
+const SETIENUM: usize = 0x1edc;
+const CLRIENUM: usize = 0x1fdc;
+const TARGET_BASE: usize = 0x3004;
+const GENMSI: usize = 0x3000;
+
+// ── domaincfg 位 ──────────────────────────────────────────────────────
+
+const DOMAINCFG_IE: u32 = 1 << 8;
+const DOMAINCFG_DM: u32 = 1 << 2;
+
+// ── sourcecfg SM 触发类型编码（Linux APLIC_SOURCECFG_SM_*） ───────────
+
+const SM_INACTIVE: u32 = 0x0;
+const SM_DETACH: u32 = 0x1;
+const SM_EDGE_RISE: u32 = 0x4;
+const SM_EDGE_FALL: u32 = 0x5;
+const SM_LEVEL_HIGH: u32 = 0x6;
+const SM_LEVEL_LOW: u32 = 0x7;
+
+// ── target 位（MSI 模式：HART_IDX | GUEST_IDX | EIID） ────────────────
+
+const TARGET_HART_IDX_SHIFT: u32 = 18;
+const TARGET_HART_IDX_MASK: u32 = 0x3fff;
+const TARGET_GUEST_IDX_SHIFT: u32 = 12;
+const TARGET_GUEST_IDX_MASK: u32 = 0x3f;
+const TARGET_EIID_MASK: u32 = 0x7ff;
+
+// ── smsicfgaddrh 位（取值同 Linux APLIC_xMSICFGADDRH_* 共享宏） ─────────
+//
+// 注意 AIA 规范的 S/M 区分：S-mode 的 smsiaddrcfgh（SMSICFGADDRH=0x1bcc）
+// 官方仅定义 LHXS + BAPPN 两段；L / HHXS / HHXW / LHXW 是 M-mode
+// mmsiaddrcfgh（MMSICFGADDRH=0x1bc4）的字段。Linux 仅在 CONFIG_RISCV_M_MODE
+// 下把这些几何字段写进 M-mode 寄存器，S-mode Linux 不写、依赖固件预先配置。
+// 本 crate 沿用 Linux 的 xMSICFGADDRH_* 取值统一表达两套寄存器位定义；
+// 实际写入哪个寄存器由 somehal 调用方决定（见 init_msi_mode 说明）。
+
+const CFGADDRH_L: u32 = 1 << 31;
+const CFGADDRH_HHXS_SHIFT: u32 = 24;
+const CFGADDRH_HHXS_MASK: u32 = 0x1f;
+const CFGADDRH_LHXS_SHIFT: u32 = 20;
+const CFGADDRH_LHXS_MASK: u32 = 0x7;
+const CFGADDRH_HHXW_SHIFT: u32 = 16;
+const CFGADDRH_HHXW_MASK: u32 = 0x7;
+const CFGADDRH_LHXW_SHIFT: u32 = 12;
+const CFGADDRH_LHXW_MASK: u32 = 0xf;
+const CFGADDRH_BAPPN_MASK: u32 = 0xfff;
+
+/// sourcecfg.SM 触发类型。
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SourceTrigger {
+    Inactive,
+    Detach,
+    EdgeRise,
+    EdgeFall,
+    LevelHigh,
+    LevelLow,
+}
+
+impl SourceTrigger {
+    const fn to_sm(self) -> u32 {
+        match self {
+            SourceTrigger::Inactive => SM_INACTIVE,
+            SourceTrigger::Detach => SM_DETACH,
+            SourceTrigger::EdgeRise => SM_EDGE_RISE,
+            SourceTrigger::EdgeFall => SM_EDGE_FALL,
+            SourceTrigger::LevelHigh => SM_LEVEL_HIGH,
+            SourceTrigger::LevelLow => SM_LEVEL_LOW,
+        }
+    }
+}
+
+/// APLIC MSI 目标（写进 target[i] 寄存器）：hart_index + guest_index + eiid。
+#[derive(Clone, Copy, Debug)]
+pub struct MsiTarget {
+    pub hart_index: u32,
+    pub guest_index: u32,
+    pub eiid: u32,
+}
+
+impl MsiTarget {
+    const fn pack(self) -> u32 {
+        ((self.hart_index & TARGET_HART_IDX_MASK) << TARGET_HART_IDX_SHIFT)
+            | ((self.guest_index & TARGET_GUEST_IDX_MASK) << TARGET_GUEST_IDX_SHIFT)
+            | (self.eiid & TARGET_EIID_MASK)
+    }
+}
+
+/// IMSIC base PPN + 地址几何，写进 smsicfgaddr / smsicfgaddrh。
+///
+/// 字段对应 Linux `APLIC_xMSICFGADDRH_{BAPPN,LHXW,HHXW,LHXS,HHXS}`。
+#[derive(Clone, Copy, Debug)]
+pub struct MsiConfig {
+    pub base_ppn: u64,
+    pub lhxw: u32,
+    pub lhxs: u32,
+    pub hhxw: u32,
+    pub hhxs: u32,
+}
+
+/// Advanced Platform-Level Interrupt Controller（MSI 模式）。
+pub struct Aplic {
+    base: *mut u8,
+    num_sources: u32,
+}
+
+unsafe impl Send for Aplic {}
+unsafe impl Sync for Aplic {}
+
+impl Aplic {
+    /// # Safety
+    ///
+    /// `base` 必须指向有效、独占的 APLIC MMIO 寄存器区。
+    #[inline]
+    pub const unsafe fn new(base: *mut u8, num_sources: u32) -> Self {
+        Self { base, num_sources }
+    }
+
+    #[inline]
+    pub fn num_sources(&self) -> u32 {
+        self.num_sources
+    }
+
+    #[inline]
+    fn reg_ptr(&self, offset: usize) -> *mut u32 {
+        // `offset` 是字节偏移（如 SOURCECFG_BASE=0x0004），base 为 *mut u8，
+        // 故 `.add(offset)` 按字节步进，再转 *mut u32 读 4 字节寄存器。
+        // 安全性由 `Aplic::new` 的契约承载：base 指向有效且独占的 MMIO 区，
+        // 且各方法传入的 offset 均在 [0, 寄存器区大小) 内。
+        unsafe { self.base.add(offset) as *mut u32 }
+    }
+
+    #[inline]
+    fn read(&self, offset: usize) -> u32 {
+        unsafe { read_volatile(self.reg_ptr(offset)) }
+    }
+
+    pub fn read_raw(&self, offset: usize) -> u32 {
+        self.read(offset)
+    }
+
+    #[inline]
+    fn write(&self, offset: usize, val: u32) {
+        unsafe { write_volatile(self.reg_ptr(offset), val) }
+    }
+
+    /// sourcecfg/target 的下标按 source id（1-based）算偏移。
+    #[inline]
+    fn source_offset(source: NonZeroU32, base: usize) -> usize {
+        base + (source.get() as usize - 1) * 4
+    }
+
+    /// 禁用所有 source：清全部 setie 位图 + 设全部 sourcecfg 为 inactive。
+    pub fn disable_all_sources(&mut self) {
+        let ie_regs = self.num_sources.div_ceil(32) as usize;
+        for i in 0..ie_regs {
+            self.write(CLRIE_BASE + i * 4, !0);
+        }
+        for s in 1..=self.num_sources {
+            let off = (s as usize - 1) * 4;
+            self.write(SOURCECFG_BASE + off, SM_INACTIVE);
+        }
+    }
+
+    /// 清所有 pending 位（初始化时清残留 pending）。
+    pub fn clear_all_pending(&mut self) {
+        let ip_regs = self.num_sources.div_ceil(32) as usize;
+        for i in 0..ip_regs {
+            self.write(CLRIP_BASE + i * 4, !0);
+        }
+    }
+
+    /// 读 pending 位图。`reg_index` 以 32 个 source 为一组，从 0 开始。
+    pub fn pending_bitmap(&self, reg_index: usize) -> u32 {
+        self.read(SETIP_BASE + reg_index * 4)
+    }
+
+    /// 读 enable 位图。`reg_index` 以 32 个 source 为一组，从 0 开始。
+    pub fn enable_bitmap(&self, reg_index: usize) -> u32 {
+        self.read(SETIE_BASE + reg_index * 4)
+    }
+
+    pub fn is_pending(&self, source: NonZeroU32) -> bool {
+        let s = source.get() as usize;
+        self.pending_bitmap(s / 32) & (1 << (s % 32)) != 0
+    }
+
+    /// 进入 MSI 模式：写 smsicfgaddr/h（IMSIC base PPN + 几何）+ domaincfg（IE=1, DM=1）。
+    ///
+    /// APLIC 硬件据此把每个 wired 源的 pending 转成 MSI 写：地址 = base_ppn +
+    /// hart/guest 索引字段，数据 = target[i].EIID。
+    ///
+    /// **S-mode 注意**（见上方 smsicfgaddrh 常量块）：本方法把 L/HHXS/HHXW/LHXW
+    /// 一并写进 S-mode 的 SMSICFGADDRH(0x1bcc)，但 AIA 规范下该寄存器仅认 LHXS+BAPPN，
+    /// 其余位被硬件忽略（QEMU `SMSICFGADDRH_VALID_MASK` 印证）。多 hart 场景的几何
+    /// （尤其 LHXW = hart 索引宽度）须由 M-mode 固件写 mmsiaddrcfgh(0x1bc4) 预先配好；
+    /// S-mode 直写这些位无害但无效。调用方需确认目标平台的固件已配置 MSI 几何。
+    pub fn init_msi_mode(&mut self, cfg: &MsiConfig) {
+        let addr_lo = cfg.base_ppn as u32;
+        let addr_hi: u32 = CFGADDRH_L
+            | ((cfg.hhxs & CFGADDRH_HHXS_MASK) << CFGADDRH_HHXS_SHIFT)
+            | ((cfg.lhxs & CFGADDRH_LHXS_MASK) << CFGADDRH_LHXS_SHIFT)
+            | ((cfg.hhxw & CFGADDRH_HHXW_MASK) << CFGADDRH_HHXW_SHIFT)
+            | ((cfg.lhxw & CFGADDRH_LHXW_MASK) << CFGADDRH_LHXW_SHIFT)
+            | ((cfg.base_ppn >> 32) as u32 & CFGADDRH_BAPPN_MASK);
+        self.write(SMSICFGADDR, addr_lo);
+        self.write(SMSICFGADDRH, addr_hi);
+        let dom = self.read(DOMAINCFG) | DOMAINCFG_IE | DOMAINCFG_DM;
+        self.write(DOMAINCFG, dom);
+    }
+
+    /// 配置 source 的触发类型 + MSI 目标（sourcecfg[i] + target[i]）。
+    pub fn configure_source(
+        &mut self,
+        source: NonZeroU32,
+        trigger: SourceTrigger,
+        target: MsiTarget,
+    ) {
+        let scfg_off = Self::source_offset(source, SOURCECFG_BASE);
+        self.write(scfg_off, trigger.to_sm());
+        let tgt_off = Self::source_offset(source, TARGET_BASE);
+        self.write(tgt_off, target.pack());
+    }
+
+    pub fn enable_source(&mut self, source: NonZeroU32) {
+        self.write(SETIENUM, source.get());
+    }
+
+    pub fn disable_source(&mut self, source: NonZeroU32) {
+        self.write(CLRIENUM, source.get());
+    }
+
+    /// 清除指定 source 的 pending 位（写 CLRIP 位图）。
+    /// 用于 enable 前清掉 sourcecfg 写入时因当前电平 rectified 值意外置上的
+    /// pending，避免 enable 立即触发 spurious MSI。
+    pub fn clear_source_pending(&mut self, source: NonZeroU32) {
+        let s = source.get();
+        let word = (s / 32) as usize;
+        self.write(CLRIP_BASE + word * 4, 1 << (s % 32));
+    }
+
+    /// 软件触发某 source（自测用）：写 SETIPNUM_LE = source id。
+    pub fn trigger_source(&mut self, source: NonZeroU32) {
+        self.write(SETIPNUM_LE, source.get());
+    }
+
+    /// 生成 MSI（自测用，不经 wired 源）：写 GENMSI，直接让 APLIC 发一次 MSI。
+    pub fn generate_msi(&mut self, target: MsiTarget) {
+        self.write(GENMSI, target.pack());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn msi_target_packs_fields() {
+        let t = MsiTarget {
+            hart_index: 3,
+            guest_index: 0,
+            eiid: 42,
+        };
+        let packed = t.pack();
+        assert_eq!(packed >> TARGET_HART_IDX_SHIFT & TARGET_HART_IDX_MASK, 3);
+        assert_eq!(packed >> TARGET_GUEST_IDX_SHIFT & TARGET_GUEST_IDX_MASK, 0);
+        assert_eq!(packed & TARGET_EIID_MASK, 42);
+    }
+
+    #[test]
+    fn source_trigger_encoding_matches_linux() {
+        assert_eq!(SourceTrigger::Inactive.to_sm(), 0x0);
+        assert_eq!(SourceTrigger::EdgeRise.to_sm(), 0x4);
+        assert_eq!(SourceTrigger::LevelHigh.to_sm(), 0x6);
+    }
+
+    #[test]
+    fn source_offset_is_one_indexed() {
+        let s1 = NonZeroU32::new(1).unwrap();
+        let s2 = NonZeroU32::new(2).unwrap();
+        assert_eq!(Aplic::source_offset(s1, SOURCECFG_BASE), 0x0004);
+        assert_eq!(Aplic::source_offset(s2, SOURCECFG_BASE), 0x0008);
+        assert_eq!(Aplic::source_offset(s1, TARGET_BASE), 0x3004);
+    }
+}

--- a/drivers/intc/riscv_imsic/Cargo.toml
+++ b/drivers/intc/riscv_imsic/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ax-riscv-imsic"
+version = "0.1.0"
+repository = "https://github.com/rcore-os/tgoskits"
+edition.workspace = true
+authors = ["Oveln <oveln@example.com>"]
+description = "RISC-V Incoming MSI Controller (IMSIC) register definitions, CSR indirect access, and MSI target address computation (AIA)"
+keywords = ["arceos", "riscv", "riscv64", "imsic", "interrupt-controller"]
+categories = ["embedded", "no-std", "hardware-support", "os"]
+license = "Apache-2.0"
+
+# 无外部依赖：本 crate 只用 core::ptr 与内联汇编做 CSR / MMIO 访问，
+# 寄存器语义由本文件内的常量与封装函数直接表达（不引入 tock-registers，
+# 因 IMSIC 配置走 siselect/sireg CSR 间接访问，非内存映射位域，无法套用
+# tock-registers 的 register_bitfields 宏）。

--- a/drivers/intc/riscv_imsic/src/lib.rs
+++ b/drivers/intc/riscv_imsic/src/lib.rs
@@ -286,6 +286,27 @@ pub unsafe fn claim() -> Option<(u32, u32)> {
     parse_stopei(unsafe { stopei_read() })
 }
 
+/// 写 `stopei` 完成中断的 pending 清除（对应 QEMU riscv_imsic_topei_rmw 的 write 侧）。
+///
+/// 读 stopei 只返回 pending 中断的 ID，不自动清除 pending 位；必须再写 stopei
+/// （写任意 non-zero 值即可触发 QEMU 的清 pending 路径）才算"完成"该中断。
+/// 不写 stopei 则 pending 位永不释放 → IRQ 线保持 asserted → 反复 trap。
+///
+/// # Safety
+///
+/// 必须在本地 hart、S-mode、ssaia 扩展可用时调用。
+/// 只应在同一次中断处理流程中 claim 后调用。
+#[cfg(target_arch = "riscv64")]
+pub unsafe fn complete_stopei(val: u32) {
+    unsafe {
+        core::arch::asm!(
+            "csrw {csr}, {val}",
+            csr = const csr::STOPEI,
+            val = in(reg) val as usize,
+        );
+    }
+}
+
 /// 经 IMSIC 发 IPI：写目标 hart 中断文件页的 EID 0（IPI 专用 identity）。
 ///
 /// # Safety

--- a/drivers/intc/riscv_imsic/src/lib.rs
+++ b/drivers/intc/riscv_imsic/src/lib.rs
@@ -99,9 +99,7 @@ pub struct MsiMessage {
 /// K3 验证（见单测）：hart0=0xe0400000, hart1=0xe0440000, ... hart15=0xe07c0000。
 #[inline]
 pub fn interrupt_file_addr(geo: &ImsicGeometry, hart_index: u32, guest_index: u32) -> usize {
-    geo.base_addr
-        + (hart_index as usize) * geo.hart_stride()
-        + (guest_index as usize) * PAGE_SIZE
+    geo.base_addr + (hart_index as usize) * geo.hart_stride() + (guest_index as usize) * PAGE_SIZE
 }
 
 /// 组成 MSI 消息：address = 目标中断文件页 base（写此地址即 SETEIPNUM_LE），
@@ -292,6 +290,12 @@ pub unsafe fn claim() -> Option<(u32, u32)> {
 /// （写任意 non-zero 值即可触发 QEMU 的清 pending 路径）才算"完成"该中断。
 /// 不写 stopei 则 pending 位永不释放 → IRQ 线保持 asserted → 反复 trap。
 ///
+/// **QEMU 适配说明**：AIA 规范本身规定 stopei 读应原子完成 claim、priority-drop
+/// 与 activate（即读后 pending 自动清除）。但 QEMU 的 `riscv_imsic_topei_rmw`
+/// 实现把 read 和 write 分开：read 只返回值，write 才清 pending，偏离了规范。
+/// 因此本函数目前是 QEMU 行为适配；移植到严格遵循 AIA 规范的真硬件时，需复核
+/// 多写一次 stopei 是否被硬件忽略（规范未明确禁止重复 complete，但实现各异）。
+///
 /// # Safety
 ///
 /// 必须在本地 hart、S-mode、ssaia 扩展可用时调用。
@@ -398,5 +402,55 @@ mod tests {
     #[test]
     fn ipi_uses_eid_zero() {
         assert_eq!(IPI_EIID, 0);
+    }
+
+    #[test]
+    fn interrupt_file_addr_guest_pages_within_hart_stride() {
+        // K3 几何：每 hart 步长 0x40000（=2^6 guest * 4KB），guest 文件以 4KB 页排布。
+        let geo = k3();
+        let base = geo.base_addr;
+        // guest 0..3 应在第一个 hart 步长内，相邻 guest 差 4KB。
+        assert_eq!(interrupt_file_addr(&geo, 0, 0), base);
+        assert_eq!(interrupt_file_addr(&geo, 0, 1), base + 0x1000);
+        assert_eq!(interrupt_file_addr(&geo, 0, 2), base + 0x2000);
+        assert_eq!(interrupt_file_addr(&geo, 0, 63), base + 63 * 0x1000);
+        // guest 63 + 1 必须跨入下一 hart 步长（边界检查）。
+        assert_eq!(interrupt_file_addr(&geo, 1, 0), base + 0x40000);
+    }
+
+    #[test]
+    fn interrupt_file_addr_zero_geometry_is_single_page_layout() {
+        // QEMU virt (aia=aplic-imsic) 的 IMSIC 节点不带位宽属性，缺省全 0：
+        // 单 hart、单 guest、单 group，所有中断文件共享同一个 4KB 页。
+        let geo = ImsicGeometry {
+            base_addr: 0x2800_0000,
+            hart_index_bits: 0,
+            guest_index_bits: 0,
+            group_index_bits: 0,
+            group_index_shift: 24,
+            num_ids: 255,
+        };
+        assert_eq!(geo.hart_stride(), 0x1000, "单 guest → 步长 = 一页");
+        assert_eq!(geo.max_harts(), 1);
+        assert_eq!(interrupt_file_addr(&geo, 0, 0), 0x2800_0000);
+    }
+
+    #[test]
+    fn group_base_ppn_clears_group_index_bits() {
+        // 多 group 几何：group 索引位落在 base_addr 的高位，group_base_ppn
+        // 必须把这些位清零，APLIC 才能用 base_ppn + 几何字段重构正确地址。
+        let geo = ImsicGeometry {
+            // group_index_shift=24, group_index_bits=4 → group 位占 [28:32)。
+            // 设 base 的 bit28..32 为非零（模拟某 group 起始地址）。
+            base_addr: 0xe040_0000 | (0b1010 << 28),
+            hart_index_bits: 4,
+            guest_index_bits: 6,
+            group_index_bits: 4,
+            group_index_shift: 24,
+            num_ids: 511,
+        };
+        let bppn = group_base_ppn(&geo);
+        // group 位被清零后，base 应回落到 group 0 的起始（0xe040_0000）。
+        assert_eq!(bppn, 0xe040_0000 >> 12);
     }
 }

--- a/drivers/intc/riscv_imsic/src/lib.rs
+++ b/drivers/intc/riscv_imsic/src/lib.rs
@@ -1,0 +1,381 @@
+//! RISC-V Incoming MSI Controller (IMSIC) —— AIA
+//!
+//! IMSIC 是 RISC-V AIA 的 MSI 接收端：设备/APLIC 发 MSI（对特殊地址的内存写）
+//! → IMSIC 置 pending → 拉 SEIP → CPU 读 `stopei` claim。
+//!
+//! 访问模型：
+//! - **配置**：经 S-mode CSR `siselect`(0x150)/`sireg`(0x151) 间接访问本 hart 中断
+//!   文件的控制寄存器（eidelivery / eithreshold / eie 位图 / eip 位图）。
+//! - **MSI 投递**：写 per-hart 中断文件 MMIO 页。每 hart 一个 4KB 页区域（含 guest 文件），
+//!   写 `[file_base + 0] = eiid` 即置 pending[eiid]。
+//! - **claim**：读 `stopei`(0x15c) CSR，原子返回最高优先级 pending 的
+//!   `{priority[31:16], eiid[15:0]}`，0 表示无 pending。
+//!
+//! 寄存器 select 常量经核对（Linux `include/linux/irqchip/riscv-imsic.h` + OpenSBI +
+//! QEMU + bao 一致）：EIDELIVERY=0x70, EITHRESHOLD=0x72, EIP0=0x80, EIE=0xC0。
+//!
+//! 本 crate 只提供寄存器语义 + 纯函数（MSI 地址编码数学、CSR 访问原语），不含
+//! OS glue（FDT probe / IRQ 域注册）——那层在 somehal。镜像 `ax-riscv-plic` 分层。
+
+#![no_std]
+
+use core::ptr::write_volatile;
+
+// ── 经核对的常量（Linux riscv-imsic.h / OpenSBI / QEMU 一致） ──────────
+
+/// 中断文件 MMIO 页大小（4KB）。
+pub const PAGE_SIZE: usize = 4096;
+
+/// siselect 选择值：中断投递控制（0=禁用投递，1=投递到本 hart）。
+pub const EIDELIVERY: u32 = 0x70;
+/// siselect 选择值：优先级阈值（0=不屏蔽，>0 屏蔽 < 该值的）。
+pub const EITHRESHOLD: u32 = 0x72;
+/// siselect 选择值：pending 位图起始（每个寄存器 32 个 ID，EIP0..EIP63 = 0x80..0xBF）。
+pub const EIP0: u32 = 0x80;
+/// siselect 选择值：enable 位图起始（每个寄存器 32 个 ID，EIE0.. = 0xC0..）。
+pub const EIE0: u32 = 0xC0;
+/// 单个 EIP/EIE 寄存器覆盖的 ID 数。
+pub const BITS_PER_REG: u32 = 32;
+
+/// IPI 专用 identity（向目标 hart 写 EID 0 触发软件中断）。
+pub const IPI_EIID: u32 = 0;
+
+// S-mode AIA CSR 编号（RISC-V AIA 规范，Linux arch/riscv/include/asm/csr.h）
+#[cfg(target_arch = "riscv64")]
+mod csr {
+    pub const SISELECT: u16 = 0x150;
+    pub const SIREG: u16 = 0x151;
+    pub const STOPEI: u16 = 0x15c;
+}
+
+// ── 几何 + MSI 地址编码（纯函数，可单测） ─────────────────────────────
+
+/// IMSIC 几何参数，从 FDT 解析（`riscv,hart-index-bits` 等）。
+///
+/// K3 实测值：base=0xe0400000, hart_index_bits=4, guest_index_bits=6,
+/// group_index_bits=0, num_ids=511, 每 hart 步长 = 0x40000。
+#[derive(Clone, Copy, Debug)]
+pub struct ImsicGeometry {
+    /// 中断文件 MMIO 基址（FDT reg 起始地址）。
+    pub base_addr: usize,
+    pub hart_index_bits: u32,
+    pub guest_index_bits: u32,
+    pub group_index_bits: u32,
+    pub group_index_shift: u32,
+    /// 支持的中断 identity 数（K3=511；identity 0..num_ids）。
+    pub num_ids: u32,
+}
+
+impl ImsicGeometry {
+    /// 每 hart 中断文件步长（字节）= 2^guest_index_bits * 4KB。
+    ///
+    /// 同一 hart 下不同 guest 的中断文件在该步长内以 4KB 页为单位排布。
+    #[inline]
+    pub const fn hart_stride(&self) -> usize {
+        (1 << self.guest_index_bits) * PAGE_SIZE
+    }
+
+    /// 支持的 hart 数上限（2^hart_index_bits；K3=16）。
+    #[inline]
+    pub const fn max_harts(&self) -> u32 {
+        1 << self.hart_index_bits
+    }
+}
+
+/// MSI 消息（地址 + 数据），供消费者（APLIC / PCIe MSI-X）编程其硬件。
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MsiMessage {
+    /// MSI 写目标地址（指向某 hart/guest 的中断文件页 base = SETEIPNUM_LE 寄存器）。
+    pub address: usize,
+    /// MSI 写数据（= eiid）。
+    pub data: u32,
+}
+
+/// 计算某 hart/guest 的中断文件 MMIO 基址（= MSI 写目标地址）。
+///
+/// 公式：`base + hart_index * hart_stride + guest_index * PAGE_SIZE`，
+/// 其中 `hart_stride = 2^guest_index_bits * PAGE_SIZE`。
+///
+/// K3 验证（见单测）：hart0=0xe0400000, hart1=0xe0440000, ... hart15=0xe07c0000。
+#[inline]
+pub fn interrupt_file_addr(geo: &ImsicGeometry, hart_index: u32, guest_index: u32) -> usize {
+    geo.base_addr
+        + (hart_index as usize) * geo.hart_stride()
+        + (guest_index as usize) * PAGE_SIZE
+}
+
+/// 组成 MSI 消息：address = 目标中断文件页 base（写此地址即 SETEIPNUM_LE），
+/// data = eiid。
+#[inline]
+pub fn compose_msi_message(
+    geo: &ImsicGeometry,
+    hart_index: u32,
+    guest_index: u32,
+    eiid: u32,
+) -> MsiMessage {
+    MsiMessage {
+        address: interrupt_file_addr(geo, hart_index, guest_index),
+        data: eiid,
+    }
+}
+
+/// 计算 APLIC smsicfgaddr 的 base_ppn（group base 的 PPN，hart/guest 位清零）。
+///
+/// 这与 `interrupt_file_addr` 不同：APLIC 硬件用 base_ppn + 几何字段重构地址，
+/// 故 base_ppn 必须把 hart/guest 索引位清零。Linux `imsic_setup_state` 同款逻辑。
+/// 返回 PPN（即地址 >> 12）。
+#[inline]
+pub fn group_base_ppn(geo: &ImsicGeometry) -> u64 {
+    // 页内索引位 = guest_bits + hart_bits，再加 12 位页偏移
+    let index_bits = geo.guest_index_bits + geo.hart_index_bits;
+    let mask: usize = !((1usize << (index_bits + 12)) - 1);
+    ((geo.base_addr & mask) as u64) >> 12
+}
+
+// ── S-mode CSR 间接访问原语（仅 riscv64 目标；host 单测不编译这些） ────
+
+#[cfg(target_arch = "riscv64")]
+#[inline]
+/// # Safety
+///
+/// 写 siselect 选择后续 sireg 访问的中断文件寄存器。须在本地 hart、S-mode、
+/// ssaia 扩展可用时调用。
+unsafe fn siselect_write(val: u32) {
+    unsafe {
+        core::arch::asm!(
+            "csrw {csr}, {val}",
+            csr = const csr::SISELECT,
+            val = in(reg) val as usize,
+        );
+    }
+}
+
+#[cfg(target_arch = "riscv64")]
+#[inline]
+/// # Safety
+///
+/// 读当前 siselect 选中的中断文件寄存器。须在本地 hart、S-mode、ssaia 可用时
+/// 调用，且调用方须保证 siselect 已指向目标寄存器（无并发 siselect/sireg 访问）。
+unsafe fn sireg_read() -> usize {
+    let val: usize;
+    unsafe {
+        core::arch::asm!(
+            "csrr {val}, {csr}",
+            val = out(reg) val,
+            csr = const csr::SIREG,
+        )
+    }
+    val
+}
+
+#[cfg(target_arch = "riscv64")]
+#[inline]
+/// # Safety
+///
+/// 同 [`sireg_read`]：写当前 siselect 选中的中断文件寄存器。
+unsafe fn sireg_write(val: usize) {
+    unsafe {
+        core::arch::asm!(
+            "csrw {csr}, {val}",
+            csr = const csr::SIREG,
+            val = in(reg) val,
+        );
+    }
+}
+
+/// 读 `stopei`：原子 claim 最高优先级 pending 中断，返回原始值。
+///
+/// 返回值高 16 位是 priority，低 16 位是 eiid；全 0 表示无 pending。
+///
+/// # Safety
+///
+/// 必须在本地 hart、S-mode、ssaia 扩展可用时调用。
+#[cfg(target_arch = "riscv64")]
+#[inline]
+pub unsafe fn stopei_read() -> u32 {
+    let val: usize;
+    unsafe {
+        core::arch::asm!(
+            "csrr {val}, {csr}",
+            val = out(reg) val,
+            csr = const csr::STOPEI,
+        )
+    }
+    val as u32
+}
+
+/// 解析 `stopei` 原始值 → `(eiid, priority)`；0 表示无 pending。
+#[inline]
+pub const fn parse_stopei(raw: u32) -> Option<(u32, u32)> {
+    if raw == 0 {
+        None
+    } else {
+        Some((raw & 0xFFFF, raw >> 16))
+    }
+}
+
+// ── 高层操作（碰硬件；仅 riscv64） ─────────────────────────────────────
+
+/// 初始化本 hart 的 S-mode 中断文件：eidelivery=1（投递到本 hart）、eithreshold=0
+/// （不屏蔽）、清所有 eie 位（禁用全部 identity，由驱动按需 enable）。
+///
+/// # Safety
+///
+/// 必须在本地 hart 上调用；CPU 须有 ssaia 扩展；siselect/sireg 在 S-mode 可访问。
+#[cfg(target_arch = "riscv64")]
+pub unsafe fn init_local_file(num_ids: u32) {
+    unsafe {
+        siselect_write(EIDELIVERY);
+        sireg_write(1);
+        siselect_write(EITHRESHOLD);
+        sireg_write(0);
+
+        // RV64 上 sireg 为 64 位，两相邻 32 位 EIE 寄存器打包在一个 even siselect
+        // 值中（odd siselect 触发 illegal instruction）。步进 2，写 64 位 0。
+        let eie_pairs = num_ids.div_ceil(BITS_PER_REG * 2) as usize;
+        for i in 0..eie_pairs {
+            siselect_write(EIE0 + (i as u32) * 2);
+            sireg_write(0);
+        }
+    }
+}
+
+/// 使能本 hart 的某 EID（置 eie 位图对应位）。
+///
+/// RV64 上 sireg 为 64 位，两个 32 位 EIE 寄存器打包在一个 even siselect 值中。
+/// 因此 siselect = EIE0 + (eiid / 64) * 2，bit = 1 << (eiid % 64)。
+///
+/// # Safety
+///
+/// 同 [`init_local_file`]。
+#[cfg(target_arch = "riscv64")]
+pub unsafe fn enable_eid(eiid: u32) {
+    debug_assert!(eiid != 0, "EIID 0 保留给 IPI，不应经 enable_eid 使能");
+    unsafe {
+        let siselect_val = EIE0 + (eiid / 64) * 2;
+        let bit: usize = 1usize << (eiid % 64);
+        siselect_write(siselect_val);
+        let cur = sireg_read();
+        sireg_write(cur | bit);
+    }
+}
+
+/// 禁用本 hart 的某 EID。
+///
+/// # Safety
+///
+/// 同 [`init_local_file`]。
+#[cfg(target_arch = "riscv64")]
+pub unsafe fn disable_eid(eiid: u32) {
+    unsafe {
+        let siselect_val = EIE0 + (eiid / 64) * 2;
+        let bit: usize = 1usize << (eiid % 64);
+        siselect_write(siselect_val);
+        let cur = sireg_read();
+        sireg_write(cur & !bit);
+    }
+}
+
+/// 读 `stopei` claim 最高优先级 pending 中断。无 pending 返回 None。
+///
+/// # Safety
+///
+/// 同 [`init_local_file`]。
+#[cfg(target_arch = "riscv64")]
+pub unsafe fn claim() -> Option<(u32, u32)> {
+    parse_stopei(unsafe { stopei_read() })
+}
+
+/// 经 IMSIC 发 IPI：写目标 hart 中断文件页的 EID 0（IPI 专用 identity）。
+///
+/// # Safety
+///
+/// `target_file_addr` 必须是有效 IMSIC 中断文件页地址（`interrupt_file_addr` 的返回值）。
+#[inline]
+pub unsafe fn send_ipi(target_file_addr: usize) {
+    unsafe { write_volatile(target_file_addr as *mut u32, IPI_EIID) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// K3 几何（来自 DTB 实测值）。
+    const fn k3() -> ImsicGeometry {
+        ImsicGeometry {
+            base_addr: 0xe040_0000,
+            hart_index_bits: 4,
+            guest_index_bits: 6,
+            group_index_bits: 0,
+            group_index_shift: 24,
+            num_ids: 511,
+        }
+    }
+
+    #[test]
+    fn k3_hart_stride_is_0x40000() {
+        // 2^6 guest * 4KB = 0x40000
+        assert_eq!(k3().hart_stride(), 0x40000);
+    }
+
+    #[test]
+    fn k3_max_harts_is_16() {
+        assert_eq!(k3().max_harts(), 16);
+    }
+
+    #[test]
+    fn k3_interrupt_file_addr_matches_dtb_layout() {
+        let geo = k3();
+        // DTB reg=0xe0400000，每 hart 0x40000 步长，16 hart 共 0x400000（与 reg size 一致）
+        assert_eq!(interrupt_file_addr(&geo, 0, 0), 0xe040_0000);
+        assert_eq!(interrupt_file_addr(&geo, 1, 0), 0xe044_0000);
+        assert_eq!(interrupt_file_addr(&geo, 7, 0), 0xe05c_0000);
+        assert_eq!(interrupt_file_addr(&geo, 15, 0), 0xe07c_0000);
+        // guest 1 在 hart 0 内偏移一页（4KB）
+        assert_eq!(interrupt_file_addr(&geo, 0, 1), 0xe040_1000);
+    }
+
+    #[test]
+    fn k3_total_imsic_span_matches_reg_size() {
+        let geo = k3();
+        assert_eq!(geo.max_harts() as usize * geo.hart_stride(), 0x400000);
+    }
+
+    #[test]
+    fn compose_msi_message_carries_eiid_as_data() {
+        let geo = k3();
+        let msg = compose_msi_message(&geo, 0, 0, 42);
+        assert_eq!(msg.address, 0xe040_0000);
+        assert_eq!(msg.data, 42);
+    }
+
+    #[test]
+    fn group_base_ppn_clears_index_bits() {
+        // K3 base 0xe0400000：hart0 的索引位（PPN[0..9]）本就为 0，
+        // 故 group_base_ppn = 0xe0400000 >> 12 = 0xE0400。
+        // 验证：APLIC 用此 base_ppn 重构 hart1 地址应为 0xe0440000
+        //   (base_ppn | (1 << guest_bits)) << 12 = (0xE0400 | 0x40) << 12 = 0xe0440000 ✓
+        let geo = k3();
+        let bppn = group_base_ppn(&geo);
+        assert_eq!(bppn, 0xE0400);
+        // 重构 hart1 / hart15 验证 base_ppn 自洽
+        let hart1 = ((bppn | (1u64 << geo.guest_index_bits)) << 12) as usize;
+        assert_eq!(hart1, 0xe044_0000);
+        let hart15 = ((bppn | (15u64 << geo.guest_index_bits)) << 12) as usize;
+        assert_eq!(hart15, 0xe07c_0000);
+    }
+
+    #[test]
+    fn parse_stopei_decodes_priority_and_eiid() {
+        assert_eq!(parse_stopei(0), None);
+        // eiid=42(0x2a), priority=5 → raw = (5<<16)|42 = 0x5002a
+        assert_eq!(parse_stopei(0x5_002a), Some((42, 5)));
+        // eiid=1, priority=1
+        assert_eq!(parse_stopei(0x1_0001), Some((1, 1)));
+    }
+
+    #[test]
+    fn ipi_uses_eid_zero() {
+        assert_eq!(IPI_EIID, 0);
+    }
+}

--- a/platforms/somehal/Cargo.toml
+++ b/platforms/somehal/Cargo.toml
@@ -47,6 +47,8 @@ ax-cpu = { workspace = true, features = ["arm-el2"], optional = true }
 
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 ax-riscv-plic = { workspace = true }
+ax-riscv-imsic = { path = "../../drivers/intc/riscv_imsic" }
+ax-riscv-aplic = { path = "../../drivers/intc/riscv_aplic" }
 riscv.workspace = true
 sbi-rt = { workspace = true, features = ["legacy"] }
 

--- a/platforms/somehal/src/arch/riscv64/imsic_aplic.rs
+++ b/platforms/somehal/src/arch/riscv64/imsic_aplic.rs
@@ -1,0 +1,544 @@
+//! RISC-V AIA (IMSIC + APLIC) OS glue for somehal.
+//!
+//! 镜像 `plic.rs` 的分层：本模块做 FDT probe / IRQ 域注册 / trap 分发接线，
+//! 寄存器语义在 `ax-riscv-imsic` / `ax-riscv-aplic` crate。
+//!
+//! 域层级：IMSIC = 根域（claim 经 stopei），APLIC = IMSIC 子域（wired 源转 MSI）。
+
+use alloc::{format, vec::Vec};
+use core::num::NonZeroU32;
+
+use ax_riscv_aplic::{Aplic, MsiConfig, MsiTarget, SourceTrigger};
+use ax_riscv_imsic::{self, ImsicGeometry};
+use kernutil::StaticCell;
+use rdif_intc::Interface;
+use rdif_msi::{
+    Interface as MsiInterface, IrqAffinity as MsiIrqAffinity, Msi, MsiAllocation, MsiEventId,
+    MsiMessage, MsiProviderId, MsiRequest, MsiVector, MsiVectorIndex,
+};
+use rdrive::{
+    module_driver,
+    probe::OnProbeError,
+    register::ProbeFdt,
+    DriverGeneric,
+};
+
+use crate::{
+    common::ioremap,
+    irq::{
+        alloc_child_irq_domain, alloc_irq_domain, domain_by_kind_fast, map_irq_route, HwIrq,
+        IrqDomainKind, IrqId,
+    },
+};
+
+use ax_kspin::SpinNoIrq;
+
+use crate::irq::IrqDomainId;
+
+static IMSIC_STATE: StaticCell<ImsicState> = StaticCell::uninit();
+
+/// Unified EID allocator shared by APLIC wired sources and PCI MSI-X vectors.
+///
+/// Both consumers draw from the same pool so EIDs can never collide. EID 0 is
+/// reserved for IPI; allocation starts at 1. Backed by a bitmap with O(1)
+/// free and a next-hint fast path.
+struct EidAllocator {
+    bitmap: SpinNoIrq<EidBitmap>,
+    max: u32,
+}
+
+struct EidBitmap {
+    bits: Vec<u64>,
+    next_hint: u32,
+}
+
+impl EidAllocator {
+    fn new(max: u32) -> Self {
+        let words = (max as usize).div_ceil(64).max(1);
+        Self {
+            bitmap: SpinNoIrq::new(EidBitmap {
+                bits: vec![0u64; words],
+                next_hint: 1,
+            }),
+            max,
+        }
+    }
+
+    fn allocate(&self) -> Option<u32> {
+        let mut bmp = self.bitmap.lock();
+        // Fast path: scan from next_hint to max.
+        for eid in bmp.next_hint..self.max {
+            let (word, bit) = (eid as usize / 64, 1u64 << (eid % 64));
+            if bmp.bits[word] & bit == 0 {
+                bmp.bits[word] |= bit;
+                bmp.next_hint = eid + 1;
+                return Some(eid);
+            }
+        }
+        // Slow path: wrap around from 1 (skip EID 0 = IPI).
+        for eid in 1..bmp.next_hint {
+            let (word, bit) = (eid as usize / 64, 1u64 << (eid % 64));
+            if bmp.bits[word] & bit == 0 {
+                bmp.bits[word] |= bit;
+                bmp.next_hint = eid + 1;
+                return Some(eid);
+            }
+        }
+        None
+    }
+
+    fn free(&self, eid: u32) {
+        if eid == 0 || eid >= self.max {
+            return;
+        }
+        let mut bmp = self.bitmap.lock();
+        let (word, bit) = (eid as usize / 64, 1u64 << (eid % 64));
+        bmp.bits[word] &= !bit;
+        if eid < bmp.next_hint {
+            bmp.next_hint = eid;
+        }
+    }
+}
+
+struct ImsicState {
+    geometry: ImsicGeometry,
+    eid_allocator: EidAllocator,
+    // 注：IMSIC / MSI-X 域 id 不在此缓存——probe 后用 domain_by_kind_fast(RiscvImsic)
+    // 动态查找，避免与 somehal::irq 域注册表产生冗余真相源（曾因此触发 dead_code）。
+}
+
+fn get_imsic_state() -> Option<&'static ImsicState> {
+    if IMSIC_STATE.is_init() {
+        Some(&IMSIC_STATE)
+    } else {
+        None
+    }
+}
+
+module_driver!(
+    name: "RISC-V IMSIC",
+    level: ProbeLevel::PreKernel,
+    priority: ProbePriority::INTC,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["riscv,imsics"],
+        on_probe: probe_imsic,
+    }],
+);
+
+module_driver!(
+    name: "RISC-V APLIC",
+    level: ProbeLevel::PreKernel,
+    priority: ProbePriority::MSI,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["riscv,aplic"],
+        on_probe: probe_aplic,
+    }],
+);
+
+fn probe_imsic(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let (info, dev) = probe.into_parts();
+    let reg = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or_else(|| OnProbeError::other(format!("[{}] has no reg", info.node.name())))?;
+
+    let geometry = ImsicGeometry {
+        base_addr: reg.address as usize,
+        // 位宽属性按 AIA IMSIC DT binding 可缺省：缺省即表示单 hart / 单 guest /
+        // 单 group（几何相应为 0）。QEMU virt (aia=aplic-imsic) 的 IMSIC 节点就
+        // 不带这几个属性，缺省值对它的单核单页布局正好正确。故缺省 0 而非报错。
+        hart_index_bits: fdt_u32(&info, "riscv,hart-index-bits").unwrap_or(0),
+        guest_index_bits: fdt_u32(&info, "riscv,guest-index-bits").unwrap_or(0),
+        group_index_bits: fdt_u32(&info, "riscv,group-index-bits").unwrap_or(0),
+        // group-index-shift 在 binding 中缺省 24。
+        group_index_shift: fdt_u32(&info, "riscv,group-index-shift").unwrap_or(24),
+        // num-ids 是 binding 必填且无合理缺省（identity 数因实现而异），缺失即失败。
+        num_ids: fdt_u32_required(&info, "riscv,num-ids")?,
+    };
+
+    let imsic_domain = alloc_irq_domain(dev.descriptor.device_id(), IrqDomainKind::RiscvImsic)
+        .map_err(|e| OnProbeError::other(format!("failed to register IMSIC domain: {e:?}")))?;
+
+    // PCI MSI-X 子域：IMSIC 是根域，PCI MSI-X 是子域。
+    // msix_domain 只在 probe 作用域内用于注册 MSI provider，不入 ImsicState。
+    let msix_domain = alloc_child_irq_domain(
+        dev.descriptor.device_id(),
+        imsic_domain,
+        IrqDomainKind::PciMsix,
+    )
+    .map_err(|e| OnProbeError::other(format!("failed to register MSI-X domain: {e:?}")))?;
+
+    IMSIC_STATE.init(ImsicState {
+        geometry,
+        eid_allocator: EidAllocator::new(geometry.num_ids),
+    });
+    info!(
+        "IMSIC probed: base={:#x} hart_bits={} guest_bits={} num_ids={}",
+        geometry.base_addr, geometry.hart_index_bits, geometry.guest_index_bits, geometry.num_ids
+    );
+
+    // Safety: init_local_file touches per-hart IMSIC CSRs (siselect/sireg).
+    // Called during PreKernel probe with interrupts disabled.
+    unsafe { ax_riscv_imsic::init_local_file(geometry.num_ids) };
+    // Safety: set_sext enables the S-mode external interrupt enable bit.
+    unsafe { riscv::register::sie::set_sext() };
+
+    dev.register(rdif_intc::Intc::new(imsic_domain, RiscvImsic));
+
+    let msi_provider = ImsicMsiProvider {
+        geometry,
+        imsic_domain,
+        msix_domain,
+        eid_allocator: &IMSIC_STATE.eid_allocator,
+    };
+    dev.register(Msi::new(
+        MsiProviderId(u64::from(dev.descriptor.device_id())),
+        msi_provider,
+    ));
+    info!("IMSIC MSI provider registered");
+    Ok(())
+}
+
+fn probe_aplic(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let (info, dev) = probe.into_parts();
+    let reg = info
+        .node
+        .regs()
+        .into_iter()
+        .next()
+        .ok_or_else(|| OnProbeError::other(format!("[{}] has no reg", info.node.name())))?;
+
+    let num_sources = fdt_u32(&info, "riscv,num-sources").unwrap_or(1024);
+    let mmio = ioremap(reg.address, reg.size.unwrap_or(0x4000) as usize)
+        .map_err(|e| OnProbeError::other(format!("failed to map APLIC: {e:?}")))?;
+    // Safety: `mmio` 刚由 ioremap 映射并独占持有，`num_sources` 来自 DT（合法 source
+    // 数）；满足 `Aplic::new` 的 MMIO 基址有效且独占的契约。
+    let mut aplic = unsafe { Aplic::new(mmio.as_ptr(), num_sources) };
+
+    aplic.disable_all_sources();
+    aplic.clear_all_pending();
+
+    let imsic_domain = domain_by_kind_fast(IrqDomainKind::RiscvImsic).ok_or_else(|| {
+        OnProbeError::other("IMSIC domain not found; APLIC needs IMSIC to probe first")
+    })?;
+    let state = get_imsic_state()
+        .ok_or_else(|| OnProbeError::other("IMSIC state not initialized"))?;
+    let geo = &state.geometry;
+
+    let msi_cfg = MsiConfig {
+        base_ppn: ax_riscv_imsic::group_base_ppn(geo),
+        lhxw: geo.hart_index_bits,
+        lhxs: geo.guest_index_bits,
+        hhxw: geo.group_index_bits,
+        hhxs: geo
+            .group_index_shift
+            .saturating_sub(12 + geo.guest_index_bits + geo.hart_index_bits),
+    };
+    aplic.init_msi_mode(&msi_cfg);
+
+    let domain = alloc_child_irq_domain(
+        dev.descriptor.device_id(),
+        imsic_domain,
+        IrqDomainKind::RiscvAplic,
+    )
+    .map_err(|e| OnProbeError::other(format!("failed to register APLIC domain: {e:?}")))?;
+    dev.register(rdif_intc::Intc::new(
+        domain,
+        RiscvAplicDriver {
+            inner: aplic,
+            num_sources,
+            imsic_domain,
+            aplic_domain: domain,
+            eid_allocator: &state.eid_allocator,
+            source_eid: SpinNoIrq::new(vec![None; num_sources as usize + 1]),
+        },
+    ));
+    info!("APLIC probed: num_sources={num_sources}, MSI mode configured");
+    Ok(())
+}
+
+fn fdt_u32(info: &rdrive::register::FdtInfo<'_>, name: &str) -> Option<u32> {
+    info.node
+        .as_node()
+        .get_property(name)
+        .and_then(|p| p.get_u32())
+}
+
+/// 读取 AIA DT binding 的必填 u32 属性，缺失则 probe 失败。
+fn fdt_u32_required(
+    info: &rdrive::register::FdtInfo<'_>,
+    name: &str,
+) -> Result<u32, OnProbeError> {
+    fdt_u32(info, name).ok_or_else(|| {
+        OnProbeError::other(format!(
+            "[{}] 缺少必填属性 `{}`",
+            info.node.name(),
+            name
+        ))
+    })
+}
+
+pub fn is_aia_active() -> bool {
+    domain_by_kind_fast(IrqDomainKind::RiscvImsic).is_some()
+}
+
+pub fn begin_external_irq() -> Option<super::plic::ActiveIrq> {
+    // Safety: 在 S-mode 外部中断 trap 上下文中调用，本 hart 的 ssaia 已由 probe 期间
+    // 的 init_local_file 初始化，满足 `claim`(stopei) 的本地 hart + S-mode 契约。
+    let (eiid, _prio) = unsafe { ax_riscv_imsic::claim() }?;
+    Some(super::plic::ActiveIrq::new_no_completion(
+        (eiid as usize).into(),
+    ))
+}
+
+pub fn secondary_init_intc() {
+    if let Some(state) = get_imsic_state() {
+        // Safety: 在副核引导早期、中断关闭上下文调用，针对本 hart 初始化中断文件。
+        unsafe { ax_riscv_imsic::init_local_file(state.geometry.num_ids) };
+    }
+    // Safety: 仅写本 hart 的 sie CSR 使能位，无别名或并发问题。
+    unsafe {
+        riscv::register::sie::set_ssoft();
+        riscv::register::sie::set_stimer();
+        riscv::register::sie::set_sext();
+    }
+}
+
+struct RiscvImsic;
+
+impl DriverGeneric for RiscvImsic {
+    fn name(&self) -> &str {
+        "RISC-V IMSIC"
+    }
+}
+
+impl Interface for RiscvImsic {
+    fn translate_fdt(
+        &self,
+        _irq_prop: &[u32],
+    ) -> Result<rdif_intc::ControllerIrqTranslation, rdif_intc::IrqError> {
+        Err(rdif_intc::IrqError::Unsupported)
+    }
+
+    fn set_enabled(
+        &mut self,
+        hwirq: HwIrq,
+        enabled: bool,
+    ) -> Result<(), rdif_intc::IrqError> {
+        // hwirq 即 IMSIC 的 EID（MSI 向量分配时由 EidAllocator 派发，APPLIC 有线源
+        // 的 set_enabled 也以 EID 形式回灌到此）。此处被 IRQ 框架在注册/使能 MSI-X
+        // 叶子 handler 时，经 leaf→parent 解析后调用。
+        // Safety: enable_eid/disable_eid 经 siselect/sireg 间接访问本 hart 的 IMSIC
+        // CSR。调用方为控制面路径（set_controller_irq_enabled 持有 Intc 锁；IRQ 框架
+        // 的 request/enable 关中断运行），无并发 siselect/sireg 访问。
+        unsafe {
+            if enabled {
+                ax_riscv_imsic::enable_eid(hwirq.0);
+            } else {
+                ax_riscv_imsic::disable_eid(hwirq.0);
+            }
+        }
+        Ok(())
+    }
+}
+
+struct RiscvAplicDriver {
+    inner: Aplic,
+    num_sources: u32,
+    imsic_domain: IrqDomainId,
+    aplic_domain: IrqDomainId,
+    eid_allocator: &'static EidAllocator,
+    source_eid: SpinNoIrq<Vec<Option<u32>>>,
+}
+
+impl DriverGeneric for RiscvAplicDriver {
+    fn name(&self) -> &str {
+        "RISC-V APLIC"
+    }
+}
+
+impl Interface for RiscvAplicDriver {
+    fn translate_fdt(
+        &self,
+        irq_prop: &[u32],
+    ) -> Result<rdif_intc::ControllerIrqTranslation, rdif_intc::IrqError> {
+        let source = irq_prop
+            .first()
+            .copied()
+            .ok_or(rdif_intc::IrqError::InvalidIrq)?;
+        if source == 0 || source > self.num_sources {
+            return Err(rdif_intc::IrqError::InvalidIrq);
+        }
+        Ok(rdif_intc::ControllerIrqTranslation::new(HwIrq(source)))
+    }
+
+    fn set_enabled(
+        &mut self,
+        hwirq: HwIrq,
+        enabled: bool,
+    ) -> Result<(), rdif_intc::IrqError> {
+        let source = NonZeroU32::new(hwirq.0).ok_or(rdif_intc::IrqError::InvalidIrq)?;
+        if source.get() > self.num_sources {
+            return Err(rdif_intc::IrqError::InvalidIrq);
+        }
+        if enabled {
+            let idx = source.get() as usize;
+            let hart_idx = crate::cpu::current_cpu_idx().unwrap_or(0) as u32;
+
+            // Allocate an EID from the unified IMSIC pool on first enable.
+            let eid = {
+                let mut guard = self.source_eid.lock();
+                match guard[idx] {
+                    Some(existing) => existing,
+                    None => {
+                        let eid = self
+                            .eid_allocator
+                            .allocate()
+                            .ok_or(rdif_intc::IrqError::NoMemory)?;
+                        guard[idx] = Some(eid);
+                        eid
+                    }
+                }
+            };
+
+            // Safety: enable_eid touches siselect/sireg CSRs on this hart.
+            // Callers must ensure no concurrent siselect/sireg access (control
+            // plane path runs with IRQs disabled).
+            unsafe { ax_riscv_imsic::enable_eid(eid) };
+
+            // trigger 必须是 level-sensitive 且匹配 INTx 的 active-low 极性。
+            // QEMU virt 上 APLIC 的 wired source 均为 PCI INTx（FDT 标 0x4 =
+            // level-low，符合 PCI INTx active-low 规范）：设备 assert 时 gsi
+            // level=0（低），deassert 时 level=1（高），故用 LevelLow。
+            // 此前误用 EdgeRise：INTx 仅在 deassert（0→1 上升沿）时 set pending，
+            // handler 读 ISR ack 后设备 deassert → 再次触发 MSI → 循环 storm
+            // （45k 次/14s）。EdgeRise storm 本身证明了 active-low 极性。
+            // FIXME: trigger 应由来源（FDT interrupt spec / PCI INTx 规范）决定，
+            // 当前写死 LevelLow 假设所有 wired source 都是 PCI INTx active-low。
+            self.inner.configure_source(
+                source,
+                SourceTrigger::LevelLow,
+                MsiTarget {
+                    hart_index: hart_idx,
+                    guest_index: 0,
+                    eiid: eid,
+                },
+            );
+
+            // Wire the IRQ route so resolve_irq_route maps stopei's EID back
+            // to this APLIC source.
+            map_irq_route(
+                IrqId::new(self.imsic_domain, HwIrq(eid)),
+                IrqId::new(self.aplic_domain, hwirq),
+            )?;
+
+            // 清掉 configure_source 写 sourcecfg 时，因当前 INTx 电平的 rectified
+            // 值意外置上的 pending：否则 enable_source 会立即 ENPEND → 发 spurious
+            // MSI，而此刻仍在 request_shared_irq 内部（handler 刚注册、可能持锁），
+            // 中断重入导致死锁。真实中断由设备后续 assert 触发。
+            self.inner.clear_source_pending(source);
+            self.inner.enable_source(source);
+        } else {
+            self.inner.disable_source(source);
+        }
+        Ok(())
+    }
+}
+
+struct ImsicMsiProvider {
+    geometry: ImsicGeometry,
+    imsic_domain: IrqDomainId,
+    msix_domain: IrqDomainId,
+    eid_allocator: &'static EidAllocator,
+}
+
+impl DriverGeneric for ImsicMsiProvider {
+    fn name(&self) -> &str {
+        "riscv-imsic-msi"
+    }
+}
+
+impl MsiInterface for ImsicMsiProvider {
+    fn allocate_vectors(
+        &mut self,
+        request: &MsiRequest,
+    ) -> Result<Vec<MsiVector>, rdif_intc::IrqError> {
+        if request.vector_count == 0 {
+            return Err(rdif_intc::IrqError::InvalidIrq);
+        }
+        let mut vectors = Vec::with_capacity(usize::from(request.vector_count));
+        for index in 0..request.vector_count {
+            let eid = self
+                .eid_allocator
+                .allocate()
+                .ok_or(rdif_intc::IrqError::NoMemory)?;
+
+            let parent_irq = IrqId::new(self.imsic_domain, HwIrq(eid));
+            let leaf_irq = IrqId::new(self.msix_domain, HwIrq(eid));
+            crate::irq::map_irq_route(parent_irq, leaf_irq)?;
+
+            vectors.push(MsiVector::with_parent(
+                MsiVectorIndex(index),
+                MsiEventId(eid),
+                leaf_irq,
+                parent_irq,
+            ));
+        }
+        Ok(vectors)
+    }
+
+    fn compose_message(
+        &self,
+        vector: &MsiVector,
+    ) -> Result<MsiMessage, rdif_intc::IrqError> {
+        let hart_index = crate::cpu::current_cpu_idx().unwrap_or(0) as u32;
+        let msg = ax_riscv_imsic::compose_msi_message(
+            &self.geometry,
+            hart_index,
+            0,
+            vector.event.0,
+        );
+        Ok(MsiMessage::new(msg.address as u64, msg.data))
+    }
+
+    fn set_vector_enabled(
+        &mut self,
+        vector: &MsiVector,
+        enabled: bool,
+    ) -> Result<(), rdif_intc::IrqError> {
+        // Safety: siselect/sireg access; control-plane caller holds no
+        // concurrent CSR indirect access on this hart.
+        unsafe {
+            if enabled {
+                ax_riscv_imsic::enable_eid(vector.event.0);
+            } else {
+                ax_riscv_imsic::disable_eid(vector.event.0);
+            }
+        }
+        Ok(())
+    }
+
+    fn set_vector_affinity(
+        &mut self,
+        _vector: &MsiVector,
+        affinity: MsiIrqAffinity,
+    ) -> Result<(), rdif_intc::IrqError> {
+        match affinity {
+            MsiIrqAffinity::Any => Ok(()),
+            MsiIrqAffinity::Fixed { .. } => Err(rdif_intc::IrqError::Unsupported),
+        }
+    }
+
+    fn free_vectors(
+        &mut self,
+        allocation: MsiAllocation,
+    ) -> Result<(), rdif_intc::IrqError> {
+        for vector in allocation.vectors() {
+            let _ = crate::irq::unmap_irq_route(vector.parent_irq, vector.irq);
+            self.eid_allocator.free(vector.event.0);
+        }
+        Ok(())
+    }
+}

--- a/platforms/somehal/src/arch/riscv64/imsic_aplic.rs
+++ b/platforms/somehal/src/arch/riscv64/imsic_aplic.rs
@@ -8,6 +8,7 @@
 use alloc::{format, vec::Vec};
 use core::num::NonZeroU32;
 
+use ax_kspin::SpinNoIrq;
 use ax_riscv_aplic::{Aplic, MsiConfig, MsiTarget, SourceTrigger};
 use ax_riscv_imsic::{self, ImsicGeometry};
 use kernutil::StaticCell;
@@ -16,24 +17,15 @@ use rdif_msi::{
     Interface as MsiInterface, IrqAffinity as MsiIrqAffinity, Msi, MsiAllocation, MsiEventId,
     MsiMessage, MsiProviderId, MsiRequest, MsiVector, MsiVectorIndex,
 };
-use rdrive::{
-    module_driver,
-    probe::OnProbeError,
-    register::ProbeFdt,
-    DriverGeneric,
-};
+use rdrive::{DriverGeneric, module_driver, probe::OnProbeError, register::ProbeFdt};
 
 use crate::{
     common::ioremap,
     irq::{
-        alloc_child_irq_domain, alloc_irq_domain, domain_by_kind_fast, map_irq_route, HwIrq,
-        IrqDomainKind, IrqId,
+        HwIrq, IrqDomainId, IrqDomainKind, IrqId, alloc_child_irq_domain, alloc_irq_domain,
+        domain_by_kind_fast, map_irq_route,
     },
 };
-
-use ax_kspin::SpinNoIrq;
-
-use crate::irq::IrqDomainId;
 
 static IMSIC_STATE: StaticCell<ImsicState> = StaticCell::uninit();
 
@@ -223,8 +215,8 @@ fn probe_aplic(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let imsic_domain = domain_by_kind_fast(IrqDomainKind::RiscvImsic).ok_or_else(|| {
         OnProbeError::other("IMSIC domain not found; APLIC needs IMSIC to probe first")
     })?;
-    let state = get_imsic_state()
-        .ok_or_else(|| OnProbeError::other("IMSIC state not initialized"))?;
+    let state =
+        get_imsic_state().ok_or_else(|| OnProbeError::other("IMSIC state not initialized"))?;
     let geo = &state.geometry;
 
     let msi_cfg = MsiConfig {
@@ -268,16 +260,9 @@ fn fdt_u32(info: &rdrive::register::FdtInfo<'_>, name: &str) -> Option<u32> {
 }
 
 /// 读取 AIA DT binding 的必填 u32 属性，缺失则 probe 失败。
-fn fdt_u32_required(
-    info: &rdrive::register::FdtInfo<'_>,
-    name: &str,
-) -> Result<u32, OnProbeError> {
+fn fdt_u32_required(info: &rdrive::register::FdtInfo<'_>, name: &str) -> Result<u32, OnProbeError> {
     fdt_u32(info, name).ok_or_else(|| {
-        OnProbeError::other(format!(
-            "[{}] 缺少必填属性 `{}`",
-            info.node.name(),
-            name
-        ))
+        OnProbeError::other(format!("[{}] 缺少必填属性 `{}`", info.node.name(), name))
     })
 }
 
@@ -326,11 +311,7 @@ impl Interface for RiscvImsic {
         Err(rdif_intc::IrqError::Unsupported)
     }
 
-    fn set_enabled(
-        &mut self,
-        hwirq: HwIrq,
-        enabled: bool,
-    ) -> Result<(), rdif_intc::IrqError> {
+    fn set_enabled(&mut self, hwirq: HwIrq, enabled: bool) -> Result<(), rdif_intc::IrqError> {
         // hwirq 即 IMSIC 的 EID（MSI 向量分配时由 EidAllocator 派发，APPLIC 有线源
         // 的 set_enabled 也以 EID 形式回灌到此）。此处被 IRQ 框架在注册/使能 MSI-X
         // 叶子 handler 时，经 leaf→parent 解析后调用。
@@ -376,7 +357,10 @@ impl Interface for RiscvAplicDriver {
         if source == 0 || source > self.num_sources {
             return Err(rdif_intc::IrqError::InvalidIrq);
         }
-        let trigger = irq_prop.get(1).copied().and_then(fdt_flag_to_aplic_trigger);
+        let trigger = irq_prop
+            .get(1)
+            .copied()
+            .and_then(SourceTrigger::from_fdt_interrupt_spec);
         if let Some(trigger) = trigger {
             self.source_trigger.lock()[source as usize] = Some(trigger);
         }
@@ -394,11 +378,7 @@ impl Interface for RiscvAplicDriver {
         false
     }
 
-    fn set_enabled(
-        &mut self,
-        hwirq: HwIrq,
-        enabled: bool,
-    ) -> Result<(), rdif_intc::IrqError> {
+    fn set_enabled(&mut self, hwirq: HwIrq, enabled: bool) -> Result<(), rdif_intc::IrqError> {
         let source = NonZeroU32::new(hwirq.0).ok_or(rdif_intc::IrqError::InvalidIrq)?;
         if source.get() > self.num_sources {
             return Err(rdif_intc::IrqError::InvalidIrq);
@@ -508,17 +488,10 @@ impl MsiInterface for ImsicMsiProvider {
         Ok(vectors)
     }
 
-    fn compose_message(
-        &self,
-        vector: &MsiVector,
-    ) -> Result<MsiMessage, rdif_intc::IrqError> {
+    fn compose_message(&self, vector: &MsiVector) -> Result<MsiMessage, rdif_intc::IrqError> {
         let hart_index = crate::cpu::current_cpu_idx().unwrap_or(0) as u32;
-        let msg = ax_riscv_imsic::compose_msi_message(
-            &self.geometry,
-            hart_index,
-            0,
-            vector.event.0,
-        );
+        let msg =
+            ax_riscv_imsic::compose_msi_message(&self.geometry, hart_index, 0, vector.event.0);
         Ok(MsiMessage::new(msg.address as u64, msg.data))
     }
 
@@ -550,24 +523,11 @@ impl MsiInterface for ImsicMsiProvider {
         }
     }
 
-    fn free_vectors(
-        &mut self,
-        allocation: MsiAllocation,
-    ) -> Result<(), rdif_intc::IrqError> {
+    fn free_vectors(&mut self, allocation: MsiAllocation) -> Result<(), rdif_intc::IrqError> {
         for vector in allocation.vectors() {
             let _ = crate::irq::unmap_irq_route(vector.parent_irq, vector.irq);
             self.eid_allocator.free(vector.event.0);
         }
         Ok(())
     }
-}
-
-fn fdt_flag_to_aplic_trigger(cell: u32) -> Option<SourceTrigger> {
-    Some(match cell {
-        0x01 => SourceTrigger::EdgeRise,
-        0x02 => SourceTrigger::EdgeFall,
-        0x04 => SourceTrigger::LevelHigh,
-        0x08 => SourceTrigger::LevelLow,
-        _ => return None,
-    })
 }

--- a/platforms/somehal/src/arch/riscv64/imsic_aplic.rs
+++ b/platforms/somehal/src/arch/riscv64/imsic_aplic.rs
@@ -253,6 +253,7 @@ fn probe_aplic(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
             aplic_domain: domain,
             eid_allocator: &state.eid_allocator,
             source_eid: SpinNoIrq::new(vec![None; num_sources as usize + 1]),
+            source_trigger: SpinNoIrq::new(vec![None; num_sources as usize + 1]),
         },
     ));
     info!("APLIC probed: num_sources={num_sources}, MSI mode configured");
@@ -351,6 +352,7 @@ struct RiscvAplicDriver {
     aplic_domain: IrqDomainId,
     eid_allocator: &'static EidAllocator,
     source_eid: SpinNoIrq<Vec<Option<u32>>>,
+    source_trigger: SpinNoIrq<Vec<Option<SourceTrigger>>>,
 }
 
 impl DriverGeneric for RiscvAplicDriver {
@@ -371,7 +373,22 @@ impl Interface for RiscvAplicDriver {
         if source == 0 || source > self.num_sources {
             return Err(rdif_intc::IrqError::InvalidIrq);
         }
+        let trigger = irq_prop.get(1).copied().and_then(fdt_flag_to_aplic_trigger);
+        if let Some(trigger) = trigger {
+            self.source_trigger.lock()[source as usize] = Some(trigger);
+        }
         Ok(rdif_intc::ControllerIrqTranslation::new(HwIrq(source)))
+    }
+
+    fn configure(
+        &mut self,
+        _translation: &rdif_intc::IrqTranslation,
+    ) -> Result<(), rdif_intc::IrqError> {
+        Ok(())
+    }
+
+    fn supports_acpi_gsi(&self, _route: &rdif_intc::AcpiGsiRoute) -> bool {
+        false
     }
 
     fn set_enabled(
@@ -408,18 +425,22 @@ impl Interface for RiscvAplicDriver {
             // plane path runs with IRQs disabled).
             unsafe { ax_riscv_imsic::enable_eid(eid) };
 
-            // trigger 必须是 level-sensitive 且匹配 INTx 的 active-low 极性。
-            // QEMU virt 上 APLIC 的 wired source 均为 PCI INTx（FDT 标 0x4 =
-            // level-low，符合 PCI INTx active-low 规范）：设备 assert 时 gsi
-            // level=0（低），deassert 时 level=1（高），故用 LevelLow。
-            // 此前误用 EdgeRise：INTx 仅在 deassert（0→1 上升沿）时 set pending，
-            // handler 读 ISR ack 后设备 deassert → 再次触发 MSI → 循环 storm
-            // （45k 次/14s）。EdgeRise storm 本身证明了 active-low 极性。
-            // FIXME: trigger 应由来源（FDT interrupt spec / PCI INTx 规范）决定，
-            // 当前写死 LevelLow 假设所有 wired source 都是 PCI INTx active-low。
+            // 触发类型优先从 FDT interrupt specifier 提取，fallback 为 LevelHigh。
+            // QEMU virt GPIO 模型下，所有中断源 assert 时 level=1（raise）、deassert
+            // 时 level=0（lower），因此 LevelHigh 是正确的缺省值。
+            let trigger = {
+                let guard = self.source_trigger.lock();
+                guard[source.get() as usize]
+            };
+            let trigger = trigger.unwrap_or(SourceTrigger::LevelHigh);
+            // 配置前先清掉之前可能残留的 pending。
+            // configure_source 写 sourcecfg 时 QEMU 会基于当前 rectified 电平
+            // 重新评估 pending：若设备线已 assert → pending=1，随后 enable_source
+            // 立即投递 MSI，正确处理"使能时设备已就绪"的场景。
+            self.inner.clear_source_pending(source);
             self.inner.configure_source(
                 source,
-                SourceTrigger::LevelLow,
+                trigger,
                 MsiTarget {
                     hart_index: hart_idx,
                     guest_index: 0,
@@ -434,11 +455,6 @@ impl Interface for RiscvAplicDriver {
                 IrqId::new(self.aplic_domain, hwirq),
             )?;
 
-            // 清掉 configure_source 写 sourcecfg 时，因当前 INTx 电平的 rectified
-            // 值意外置上的 pending：否则 enable_source 会立即 ENPEND → 发 spurious
-            // MSI，而此刻仍在 request_shared_irq 内部（handler 刚注册、可能持锁），
-            // 中断重入导致死锁。真实中断由设备后续 assert 触发。
-            self.inner.clear_source_pending(source);
             self.inner.enable_source(source);
         } else {
             self.inner.disable_source(source);
@@ -541,4 +557,14 @@ impl MsiInterface for ImsicMsiProvider {
         }
         Ok(())
     }
+}
+
+fn fdt_flag_to_aplic_trigger(cell: u32) -> Option<SourceTrigger> {
+    Some(match cell {
+        0x01 => SourceTrigger::EdgeRise,
+        0x02 => SourceTrigger::EdgeFall,
+        0x04 => SourceTrigger::LevelHigh,
+        0x08 => SourceTrigger::LevelLow,
+        _ => return None,
+    })
 }

--- a/platforms/somehal/src/arch/riscv64/imsic_aplic.rs
+++ b/platforms/somehal/src/arch/riscv64/imsic_aplic.rs
@@ -286,11 +286,14 @@ pub fn is_aia_active() -> bool {
 }
 
 pub fn begin_external_irq() -> Option<super::plic::ActiveIrq> {
-    // Safety: 在 S-mode 外部中断 trap 上下文中调用，本 hart 的 ssaia 已由 probe 期间
-    // 的 init_local_file 初始化，满足 `claim`(stopei) 的本地 hart + S-mode 契约。
-    let (eiid, _prio) = unsafe { ax_riscv_imsic::claim() }?;
-    Some(super::plic::ActiveIrq::new_no_completion(
+    let raw = unsafe { ax_riscv_imsic::stopei_read() };
+    let (eiid, _prio) = ax_riscv_imsic::parse_stopei(raw)?;
+
+    // 读 stopei 只返回 pending ID，不自动清 pending（QEMU riscv_imsic_topei_rmw
+    // 的 read 侧）。记录 raw 值，在 ActiveIrq::drop 时写回 stopei 完成清除。
+    Some(super::plic::ActiveIrq::new_imsic(
         (eiid as usize).into(),
+        raw,
     ))
 }
 

--- a/platforms/somehal/src/arch/riscv64/mod.rs
+++ b/platforms/somehal/src/arch/riscv64/mod.rs
@@ -80,8 +80,7 @@ impl PlatOp for Plat {
     fn active_irq_id(active: &Self::ActiveIrq) -> IrqId {
         let raw: usize = active.id().into();
         if raw & RISCV_INTERRUPT_BIT != 0 {
-            riscv_cpu_local_irq_from_raw(raw)
-                .expect("active RISC-V local IRQ must be validated")
+            riscv_cpu_local_irq_from_raw(raw).expect("active RISC-V local IRQ must be validated")
         } else if imsic_aplic::is_aia_active() {
             // stopei returns an EID. Always attribute it to the IMSIC root
             // domain; resolve_irq_route walks parent→leaf to find the correct

--- a/platforms/somehal/src/arch/riscv64/mod.rs
+++ b/platforms/somehal/src/arch/riscv64/mod.rs
@@ -55,6 +55,16 @@ impl PlatOp for Plat {
         if crate::irq::domain_is_kind(irq.domain, crate::irq::IrqDomainKind::RiscvPlic) {
             return plic::irq_set_affinity(irq.hwirq, affinity);
         }
+        // AIA（APLIC wired / IMSIC MSI）的 affinity 即 MSI target hart。source 在
+        // set_enabled 时经 configure_source 已绑定到 current hart；当前单 hart 场景
+        // 下 set_affinity 无需操作。多 hart 时需要 reconfigure APLIC source 的
+        // hart_index（重新 configure_source 切换 MSI 目标 hart），届时在此实现。
+        // TODO: 多 hart APLIC source re-target。
+        if crate::irq::domain_is_kind(irq.domain, crate::irq::IrqDomainKind::RiscvAplic)
+            || crate::irq::domain_is_kind(irq.domain, crate::irq::IrqDomainKind::RiscvImsic)
+        {
+            return Ok(());
+        }
         Err(IrqError::InvalidIrq)
     }
 

--- a/platforms/somehal/src/arch/riscv64/mod.rs
+++ b/platforms/somehal/src/arch/riscv64/mod.rs
@@ -3,11 +3,13 @@ use crate::{
     irq::{CPU_LOCAL_IRQ_DOMAIN, HwIrq, IrqError, IrqId, IrqSource},
 };
 
+mod imsic_aplic;
 mod plic;
 
 use crate::irq_routing::{
-    RISCV_INTERRUPT_BIT, RISCV_S_SOFT_CAUSE, riscv_cpu_local_hwirq_is_runtime_irq,
-    riscv_cpu_local_irq_from_raw, riscv_local_irq_raw, riscv_resolve_controller_line,
+    RISCV_INTERRUPT_BIT, RISCV_S_SOFT_CAUSE, RiscvTrapIrq, classify_riscv_trap,
+    riscv_cpu_local_hwirq_is_runtime_irq, riscv_cpu_local_irq_from_raw, riscv_local_irq_raw,
+    riscv_resolve_controller_line,
 };
 
 pub struct Plat;
@@ -37,7 +39,10 @@ impl PlatOp for Plat {
         if irq.domain == CPU_LOCAL_IRQ_DOMAIN {
             return plic::local_irq_set_enable(riscv_local_irq_raw(irq)?.into(), enable);
         }
-        if crate::irq::domain_is_kind(irq.domain, crate::irq::IrqDomainKind::RiscvPlic) {
+        if crate::irq::domain_is_kind(irq.domain, crate::irq::IrqDomainKind::RiscvPlic)
+            || crate::irq::domain_is_kind(irq.domain, crate::irq::IrqDomainKind::RiscvAplic)
+            || crate::irq::domain_is_kind(irq.domain, crate::irq::IrqDomainKind::RiscvImsic)
+        {
             return crate::irq::set_controller_irq_enabled(irq, enable);
         }
         Err(IrqError::InvalidIrq)
@@ -54,13 +59,26 @@ impl PlatOp for Plat {
     }
 
     fn begin_irq(raw: usize) -> Option<Self::ActiveIrq> {
-        plic::begin_irq(raw)
+        match classify_riscv_trap(raw) {
+            RiscvTrapIrq::External if imsic_aplic::is_aia_active() => {
+                imsic_aplic::begin_external_irq()
+            }
+            _ => plic::begin_irq(raw),
+        }
     }
 
     fn active_irq_id(active: &Self::ActiveIrq) -> IrqId {
         let raw: usize = active.id().into();
         if raw & RISCV_INTERRUPT_BIT != 0 {
-            riscv_cpu_local_irq_from_raw(raw).expect("active RISC-V local IRQ must be validated")
+            riscv_cpu_local_irq_from_raw(raw)
+                .expect("active RISC-V local IRQ must be validated")
+        } else if imsic_aplic::is_aia_active() {
+            // stopei returns an EID. Always attribute it to the IMSIC root
+            // domain; resolve_irq_route walks parent→leaf to find the correct
+            // child-domain handler (APLIC wired or PCI MSI-X).
+            let imsic = crate::irq::domain_by_kind_fast(crate::irq::IrqDomainKind::RiscvImsic)
+                .expect("AIA active but IMSIC domain missing");
+            IrqId::new(imsic, HwIrq(raw as u32))
         } else {
             plic_irq_id_from_claimed_source(raw)
                 .expect("active RISC-V PLIC source must come from a validated claim")
@@ -78,11 +96,17 @@ impl PlatOp for Plat {
                 source,
                 IrqSource::ControllerLine { domain, .. }
                     if crate::irq::domain_is_kind(domain, crate::irq::IrqDomainKind::RiscvPlic)
+                        || crate::irq::domain_is_kind(domain, crate::irq::IrqDomainKind::RiscvAplic)
             )
         })?;
         match source {
             IrqSource::ControllerLine { domain, hwirq } if domain == CPU_LOCAL_IRQ_DOMAIN => {
                 checked_cpu_local_irq(hwirq)
+            }
+            IrqSource::ControllerLine { domain, hwirq }
+                if crate::irq::domain_is_kind(domain, crate::irq::IrqDomainKind::RiscvAplic) =>
+            {
+                Ok(IrqId::new(domain, hwirq))
             }
             IrqSource::ControllerLine { domain, hwirq } => {
                 plic::source_from_hwirq(hwirq)?;
@@ -97,7 +121,13 @@ impl PlatOp for Plat {
     fn init_boot_irq_cpu(cpu_idx: usize, role: crate::irq::CpuBootRole) {
         match role {
             crate::irq::CpuBootRole::Primary => {}
-            crate::irq::CpuBootRole::Secondary => plic::secondary_init_intc(cpu_idx),
+            crate::irq::CpuBootRole::Secondary => {
+                if imsic_aplic::is_aia_active() {
+                    imsic_aplic::secondary_init_intc();
+                } else {
+                    plic::secondary_init_intc(cpu_idx);
+                }
+            }
         }
     }
 

--- a/platforms/somehal/src/arch/riscv64/plic.rs
+++ b/platforms/somehal/src/arch/riscv64/plic.rs
@@ -1,8 +1,8 @@
 use alloc::{format, vec, vec::Vec};
 use core::{num::NonZeroU32, ptr::NonNull};
 
-use ax_riscv_plic::{PLICRegs, Plic, PlicIrqHandler};
 use ax_riscv_imsic;
+use ax_riscv_plic::{PLICRegs, Plic, PlicIrqHandler};
 use kernutil::StaticCell;
 use rdif_intc::Interface;
 use rdrive::{
@@ -115,20 +115,6 @@ impl ActiveIrq {
         Self {
             irq,
             completion: Completion::Imsic(stopei_val),
-        }
-    }
-
-    /// 构造一个**无需 Drop 完成动作**的 `ActiveIrq`。
-    ///
-    /// 供 AIA（IMSIC）外部中断路径使用：AIA 的 `stopei` 读取原子地完成
-    /// claim + priority-drop + deactivate（见 AIA 规范），故不需要像 PLIC
-    /// 那样在 Drop 时再写 claim/complete 寄存器。`irq` 携带的是 stopei 返回
-    /// 的 EIID（无域信息，由 `Plat::active_irq_id` 再归属到 IMSIC 根域）。
-    #[deprecated = "stopei read does NOT clear pending in QEMU; use `new_imsic` with stopei write"]
-    pub fn new_no_completion(irq: rdrive::IrqId) -> Self {
-        Self {
-            irq,
-            completion: Completion::None,
         }
     }
 }

--- a/platforms/somehal/src/arch/riscv64/plic.rs
+++ b/platforms/somehal/src/arch/riscv64/plic.rs
@@ -104,6 +104,19 @@ impl ActiveIrq {
     pub fn id(&self) -> rdrive::IrqId {
         self.irq
     }
+
+    /// 构造一个**无需 Drop 完成动作**的 `ActiveIrq`。
+    ///
+    /// 供 AIA（IMSIC）外部中断路径使用：AIA 的 `stopei` 读取原子地完成
+    /// claim + priority-drop + deactivate（见 AIA 规范），故不需要像 PLIC
+    /// 那样在 Drop 时再写 claim/complete 寄存器。`irq` 携带的是 stopei 返回
+    /// 的 EIID（无域信息，由 `Plat::active_irq_id` 再归属到 IMSIC 根域）。
+    pub fn new_no_completion(irq: rdrive::IrqId) -> Self {
+        Self {
+            irq,
+            completion: Completion::None,
+        }
+    }
 }
 
 impl Drop for ActiveIrq {

--- a/platforms/somehal/src/arch/riscv64/plic.rs
+++ b/platforms/somehal/src/arch/riscv64/plic.rs
@@ -2,6 +2,7 @@ use alloc::{format, vec, vec::Vec};
 use core::{num::NonZeroU32, ptr::NonNull};
 
 use ax_riscv_plic::{PLICRegs, Plic, PlicIrqHandler};
+use ax_riscv_imsic;
 use kernutil::StaticCell;
 use rdif_intc::Interface;
 use rdrive::{
@@ -93,6 +94,10 @@ pub fn irq_set_affinity(
 enum Completion {
     None,
     Plic(NonZeroU32),
+    /// IMSIC stopei 写回值。读 stopei 只返回 pending 中断 ID，不自动清除
+    /// pending 位（QEMU riscv_imsic_topei_rmw 的 read 侧）。必须再写 stopei
+    /// 才能清 pending、完成中断。
+    Imsic(u32),
 }
 
 pub struct ActiveIrq {
@@ -105,12 +110,21 @@ impl ActiveIrq {
         self.irq
     }
 
+    /// 供 AIA（IMSIC）使用：Drop 时写回 `stopei` 完成 pending 清除。
+    pub fn new_imsic(irq: rdrive::IrqId, stopei_val: u32) -> Self {
+        Self {
+            irq,
+            completion: Completion::Imsic(stopei_val),
+        }
+    }
+
     /// 构造一个**无需 Drop 完成动作**的 `ActiveIrq`。
     ///
     /// 供 AIA（IMSIC）外部中断路径使用：AIA 的 `stopei` 读取原子地完成
     /// claim + priority-drop + deactivate（见 AIA 规范），故不需要像 PLIC
     /// 那样在 Drop 时再写 claim/complete 寄存器。`irq` 携带的是 stopei 返回
     /// 的 EIID（无域信息，由 `Plat::active_irq_id` 再归属到 IMSIC 根域）。
+    #[deprecated = "stopei read does NOT clear pending in QEMU; use `new_imsic` with stopei write"]
     pub fn new_no_completion(irq: rdrive::IrqId) -> Self {
         Self {
             irq,
@@ -121,8 +135,10 @@ impl ActiveIrq {
 
 impl Drop for ActiveIrq {
     fn drop(&mut self) {
-        if let Completion::Plic(source) = self.completion {
-            complete_external_irq_source(source);
+        match self.completion {
+            Completion::Plic(source) => complete_external_irq_source(source),
+            Completion::Imsic(val) => unsafe { ax_riscv_imsic::complete_stopei(val) },
+            Completion::None => {}
         }
     }
 }

--- a/platforms/somehal/src/irq.rs
+++ b/platforms/somehal/src/irq.rs
@@ -47,6 +47,8 @@ pub enum IrqDomainKind {
     X86Msi,
     AArch64Gic,
     RiscvPlic,
+    RiscvImsic,
+    RiscvAplic,
     LoongArchEioIntc,
     LoongArchPchPic,
     LoongArchLioIntc,
@@ -79,6 +81,7 @@ static X86_IOAPIC_DOMAIN_SLOT: AtomicU16 = AtomicU16::new(INVALID_IRQ_DOMAIN);
 static X86_MSI_DOMAIN_SLOT: AtomicU16 = AtomicU16::new(INVALID_IRQ_DOMAIN);
 static AARCH64_GIC_DOMAIN_SLOT: AtomicU16 = AtomicU16::new(INVALID_IRQ_DOMAIN);
 static RISCV_PLIC_DOMAIN_SLOT: AtomicU16 = AtomicU16::new(INVALID_IRQ_DOMAIN);
+static RISCV_IMSIC_DOMAIN_SLOT: AtomicU16 = AtomicU16::new(INVALID_IRQ_DOMAIN);
 static LOONGARCH_EIOINTC_DOMAIN_SLOT: AtomicU16 = AtomicU16::new(INVALID_IRQ_DOMAIN);
 static LOONGARCH_PCH_PIC_DOMAIN_SLOT: AtomicU16 = AtomicU16::new(INVALID_IRQ_DOMAIN);
 static LOONGARCH_LIOINTC_DOMAIN_SLOT: AtomicU16 = AtomicU16::new(INVALID_IRQ_DOMAIN);
@@ -190,10 +193,11 @@ fn domain_slot(kind: IrqDomainKind) -> Option<&'static AtomicU16> {
         IrqDomainKind::X86Msi => Some(&X86_MSI_DOMAIN_SLOT),
         IrqDomainKind::AArch64Gic => Some(&AARCH64_GIC_DOMAIN_SLOT),
         IrqDomainKind::RiscvPlic => Some(&RISCV_PLIC_DOMAIN_SLOT),
+        IrqDomainKind::RiscvImsic => Some(&RISCV_IMSIC_DOMAIN_SLOT),
         IrqDomainKind::LoongArchEioIntc => Some(&LOONGARCH_EIOINTC_DOMAIN_SLOT),
         IrqDomainKind::LoongArchPchPic => Some(&LOONGARCH_PCH_PIC_DOMAIN_SLOT),
         IrqDomainKind::LoongArchLioIntc => Some(&LOONGARCH_LIOINTC_DOMAIN_SLOT),
-        IrqDomainKind::MsiParent | IrqDomainKind::PciMsix => None,
+        IrqDomainKind::RiscvAplic | IrqDomainKind::MsiParent | IrqDomainKind::PciMsix => None,
     }
 }
 
@@ -532,6 +536,7 @@ mod tests {
             IrqDomainKind::X86Msi,
             IrqDomainKind::AArch64Gic,
             IrqDomainKind::RiscvPlic,
+            IrqDomainKind::RiscvImsic,
             IrqDomainKind::LoongArchEioIntc,
             IrqDomainKind::LoongArchPchPic,
             IrqDomainKind::LoongArchLioIntc,


### PR DESCRIPTION
## 问题

somehal 平台层此前只支持 RISC-V PLIC，无法在 QEMU `virt,aia=aplic-imsic` 下运行。RISC-V AIA（Advanced Interrupt Architecture）是新中断架构：IMSIC 接收 MSI、APLIC 把有线中断转成 MSI。本 PR 为 somehal 加入 AIA 中断路径。

## 改动

### 1. 新增 driver crate（纯寄存器语义，无 OS glue）

- `ax-riscv-imsic`：IMSIC CSR/几何/MSI 地址编码纯函数。寄存器 select 常量经 Linux `riscv-imsic.h` / OpenSBI / QEMU 多源核对。
- `ax-riscv-aplic`：APIC MSI 模式寄存器语义。偏移经 Linux `riscv-aplic.h` 核对。

镜像 `ax-riscv-plic` 分层：纯硬件语义在 driver crate，OS glue 在 somehal。

### 2. somehal riscv64 AIA 集成（`imsic_aplic.rs`）

- FDT probe IMSIC（`riscv,imsics`）+ APLIC（`riscv,aplic`）
- 域层级：IMSIC = 根域（claim 经 stopei），APLIC = IMSIC 子域，PCI MSI-X = IMSIC 子域
- 统一 `EidAllocator`（APLIC wired + PCI MSI-X 共享 EID 池，O(1) free + next-hint 快路径）
- `begin_irq` 走 stopei claim；`active_irq_id` 将 EID 归属 IMSIC 根域，`resolve_irq_route` 分发到下游
- 与 #1443（RISC-V IRQ routing 重构）兼容，cherry-pick 零冲突

### 3. 修复链（QEMU virt,aia=aplic-imsic 实测）

- **virtio INTx 中断风暴**：APLIC `set_enabled` 对 PCI INTx 误用 EdgeRise → 改 level-sensitive + `clear_source_pending` 避免 enable 重入死锁
- **trigger 从 FDT 提取**：硬编码 LevelLow 导致 QEMU virt GPIO 模型极性反转、virtio-blk INTx 永不触发 → 改为从 FDT interrupt specifier 提取 + fallback LevelHigh（`SourceTrigger::from_fdt_interrupt_spec`）
- **stopei completion**：QEMU `riscv_imsic_topei_rmw` 读 stopei 不清 pending（偏离 AIA 规范）→ claim 时记录 raw 值，`ActiveIrq::drop` 写回 stopei 完成清除
- **irq_set_affinity**：支持 APLIC/IMSIC domain，修复 NS16550 串口 IRQ 注册失败

### 4. 代码质量订正

- 删除 `ActiveIrq::new_no_completion` 死代码（编译器报 dead_code）及过时 doc
- 提取 `pack_smsicfg_addrh` 纯函数让 APLIC MSI 地址编码可单测
- 补 `complete_stopei` 的 QEMU 适配说明

## 验证

- **单测**：ax-riscv-aplic 7 个（target packing / trigger encoding / source offset / `pack_smsicfg_addrh` 正常+溢出 / `from_fdt_interrupt_spec` 映射+拒绝未知），ax-riscv-imsic 11 个（K3 几何实测值核对 / 地址编码 / stopei 解析 / `group_base_ppn` 自洽 / guest 多页偏移 / 零几何 / 多 group）
- **clippy**：host + riscv64gc 双 target 零警告；somehal riscv64 交叉编译通过
- **fmt**：`cargo fmt --all --check` 干净
- 并发：`EidAllocator` / `source_eid` / `source_trigger` 全用 `SpinNoIrq`（关中断自旋锁）
- unsafe：所有 unsafe 块有 `# Safety` 契约

## 说明

- virtio-blk MSI-X 优先适配（`PciIrqLease`）未包含在本 PR——当前 dev 分支无 virtio-blk 驱动。该适配保留在 [Oveln fork 的 feat/riscv-aia 分支](https://github.com/Oveln/tgoskits/tree/feat/riscv-aia)，待 dev 恢复 virtio-blk 后可单独 cherry-pick。
- 本 PR 基于 rcore-os/dev 重新 cherry-pick，剥离了 fork 中的 virtio-blk 相关改动与 ns16550 串口 IRQ storm 修复（后者依赖 serial 驱动细节，留待后续）。