### PR TITLE
fix(arm-vgic): honor architectural timer counter frequency

### DIFF
--- a/virtualization/arm_vgic/src/host.rs
+++ b/virtualization/arm_vgic/src/host.rs
@@ -29,6 +29,12 @@ pub trait ArmVgicHostIf {
     /// Current monotonic host time in nanoseconds.
     fn current_time_nanos() -> u64;
 
+    /// Current architectural physical counter value.
+    fn current_counter_value() -> u64;
+
+    /// Architectural physical counter frequency in hertz.
+    fn counter_frequency_hz() -> u64;
+
     /// Register a timer callback.
     fn register_timer(
         deadline: Duration,
@@ -93,6 +99,14 @@ pub(crate) fn current_vm_id() -> usize {
 
 pub(crate) fn current_time_nanos() -> u64 {
     ax_crate_interface::call_interface!(ArmVgicHostIf::current_time_nanos())
+}
+
+pub(crate) fn current_counter_value() -> u64 {
+    ax_crate_interface::call_interface!(ArmVgicHostIf::current_counter_value())
+}
+
+pub(crate) fn counter_frequency_hz() -> u64 {
+    ax_crate_interface::call_interface!(ArmVgicHostIf::counter_frequency_hz())
 }
 
 pub(crate) fn register_timer(

--- a/virtualization/arm_vgic/src/vtimer/cntp_ctl_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_ctl_el0.rs
@@ -30,7 +30,7 @@ const CNTP_CTL_EL0_ADDR: u32 = SystemRegType::CNTP_CTL_EL0 as u32;
 impl SysCntpCtlEl0 {
     /// Reads CNTP_CTL_EL0.
     pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
-        Ok(self.state.control(self.backend.current_time_nanos()) as usize)
+        Ok(self.state.control(self.backend.current_counter_value()) as usize)
     }
 
     /// Writes CNTP_CTL_EL0.

--- a/virtualization/arm_vgic/src/vtimer/cntp_cval_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntp_cval_el0.rs
@@ -25,49 +25,43 @@ use log::debug;
 
 use crate::vtimer::{VtimerBackend, VtimerState};
 
-const CNTP_TVAL_EL0_ADDR: u32 = SystemRegType::CNTP_TVAL_EL0 as u32;
+const CNTP_CVAL_EL0_ADDR: u32 = SystemRegType::CNTP_CVAL_EL0 as u32;
 
-impl SysCntpTvalEl0 {
-    /// Reads CNTP_TVAL_EL0.
-    pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
-        Ok(self.state.timer_value(self.backend.as_ref()) as usize)
-    }
-
-    /// Writes CNTP_TVAL_EL0.
-    pub fn write_register(&self, _width: AccessWidth, val: usize) -> DeviceResult {
-        debug!("Write to virtual timer register CNTP_TVAL_EL0, value: {val}");
-        self.state
-            .write_timer_value(val as u64, Arc::clone(&self.backend));
-        Ok(())
-    }
-}
-
-/// System register emulation for CNTP_TVAL_EL0.
-///
-/// Provides virtualization support for the physical timer value register.
-pub struct SysCntpTvalEl0 {
+/// System register emulation for the physical timer compare value.
+pub struct SysCntpCvalEl0 {
     state: Arc<VtimerState>,
     backend: Arc<dyn VtimerBackend>,
     resources: [Resource; 1],
 }
 
-impl SysCntpTvalEl0 {
-    /// Creates a new CNTP_TVAL_EL0 register emulator.
+impl SysCntpCvalEl0 {
+    /// Creates a CNTP_CVAL_EL0 register emulator.
     pub fn new(state: Arc<VtimerState>, backend: Arc<dyn VtimerBackend>) -> Self {
         Self {
             state,
             backend,
             resources: [Resource::SysReg {
-                addr: CNTP_TVAL_EL0_ADDR,
+                addr: CNTP_CVAL_EL0_ADDR,
                 count: 1,
             }],
         }
     }
+
+    fn read_register(&self, _width: AccessWidth) -> DeviceResult<u64> {
+        Ok(self.state.compare_value())
+    }
+
+    fn write_register(&self, _width: AccessWidth, value: u64) -> DeviceResult {
+        debug!("Write to virtual timer register CNTP_CVAL_EL0, value: {value}");
+        self.state
+            .write_compare_value(value, Arc::clone(&self.backend));
+        Ok(())
+    }
 }
 
-impl Device for SysCntpTvalEl0 {
+impl Device for SysCntpCvalEl0 {
     fn name(&self) -> &str {
-        "aarch64-cntp-tval-el0"
+        "aarch64-cntp-cval-el0"
     }
 
     fn resources(&self) -> &[Resource] {
@@ -79,16 +73,14 @@ impl Device for SysCntpTvalEl0 {
         access: &BusAccess,
         _context: &mut dyn DeviceAccess,
     ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::SysReg || access.addr != CNTP_TVAL_EL0_ADDR as u64 {
+        if access.kind != BusKind::SysReg || access.addr != CNTP_CVAL_EL0_ADDR as u64 {
             return Err(DeviceError::OutOfRange { addr: access.addr });
         }
         if access.is_read {
             self.read_register(access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
+                .map(|value| BusResponse::Read { value })
         } else {
-            self.write_register(access.width, access.data as usize)
+            self.write_register(access.width, access.data)
                 .map(|_| BusResponse::Write)
         }
     }

--- a/virtualization/arm_vgic/src/vtimer/cntpct_el0.rs
+++ b/virtualization/arm_vgic/src/vtimer/cntpct_el0.rs
@@ -30,7 +30,7 @@ const CNTPCT_EL0_ADDR: u32 = SystemRegType::CNTPCT_EL0 as u32;
 impl SysCntpctEl0 {
     /// Reads CNTPCT_EL0.
     pub fn read_register(&self, _width: AccessWidth) -> DeviceResult<usize> {
-        Ok(self.backend.current_time_nanos() as usize)
+        Ok(self.backend.current_counter_value() as usize)
     }
 
     /// Ignores guest writes to the read-only CNTPCT_EL0 register.

--- a/virtualization/arm_vgic/src/vtimer/mod.rs
+++ b/virtualization/arm_vgic/src/vtimer/mod.rs
@@ -25,6 +25,9 @@ use crate::host;
 mod cntp_ctl_el0;
 pub use cntp_ctl_el0::SysCntpCtlEl0;
 
+mod cntp_cval_el0;
+pub use cntp_cval_el0::SysCntpCvalEl0;
+
 mod cntpct_el0;
 pub use cntpct_el0::SysCntpctEl0;
 
@@ -68,6 +71,16 @@ pub trait VtimerBackend: Send + Sync {
     /// Returns the current monotonic time in nanoseconds.
     fn current_time_nanos(&self) -> u64;
 
+    /// Returns the physical counter value exposed to the guest.
+    fn current_counter_value(&self) -> u64 {
+        self.current_time_nanos()
+    }
+
+    /// Returns the counter frequency used for CNTP_* values.
+    fn counter_frequency_hz(&self) -> u64 {
+        1_000_000_000
+    }
+
     /// Schedules one callback and returns its cancellation token.
     fn register_timer(
         &self,
@@ -97,6 +110,14 @@ impl VtimerBackend for HostVtimerBackend {
         host::current_time_nanos()
     }
 
+    fn current_counter_value(&self) -> u64 {
+        host::current_counter_value()
+    }
+
+    fn counter_frequency_hz(&self) -> u64 {
+        host::counter_frequency_hz()
+    }
+
     fn register_timer(
         &self,
         deadline: Duration,
@@ -122,11 +143,12 @@ impl VtimerBackend for HostVtimerBackend {
 struct VtimerRegisters {
     control: u32,
     deadline_ns: Option<u64>,
+    compare_value: Option<u64>,
     timer_token: Option<usize>,
     expired: bool,
     generation: u64,
     target: Option<VtimerTarget>,
-    suspended_remaining_ns: Option<u64>,
+    suspended: bool,
 }
 
 /// Shared guest-visible state for the CNT* register devices of one VM.
@@ -143,57 +165,82 @@ impl VtimerState {
     }
 
     /// Returns the current CNTP_CTL_EL0 value, including the computed status bit.
-    pub fn control(&self, now_ns: u64) -> u32 {
+    pub fn control(&self, current_counter_value: u64) -> u32 {
         let registers = self.registers.lock();
         let expired = registers.expired
             || registers
-                .deadline_ns
-                .is_some_and(|deadline| deadline <= now_ns);
+                .compare_value
+                .is_some_and(|compare| compare <= current_counter_value);
         (registers.control & 0b11) | (u32::from(expired) << 2)
     }
 
     /// Updates the writable CNTP_CTL_EL0 enable and mask bits.
     pub fn write_control(&self, value: u32, backend: &dyn VtimerBackend) {
+        let current_counter_value = backend.current_counter_value();
         let inject = {
             let mut registers = self.registers.lock();
             registers.control = value & 0b11;
-            (registers.expired && Self::interrupt_enabled(&registers)).then_some(registers.target)
+            let timer_condition = registers.expired
+                || registers
+                    .compare_value
+                    .is_some_and(|compare| compare <= current_counter_value);
+            (timer_condition && Self::interrupt_enabled(&registers)).then_some(registers.target)
         };
         if let Some(Some(target)) = inject {
             backend.inject_virtual_interrupt(target, VIRTUAL_TIMER_IRQ);
         }
     }
 
-    /// Returns the remaining timer value in nanoseconds.
-    pub fn timer_value(&self, now_ns: u64) -> u64 {
+    /// Returns the remaining timer value in counter ticks.
+    pub fn timer_value(&self, backend: &dyn VtimerBackend) -> u64 {
         self.registers
             .lock()
-            .deadline_ns
-            .map(|deadline| deadline.saturating_sub(now_ns))
+            .compare_value
+            .map(|compare| u64::from(compare.wrapping_sub(backend.current_counter_value()) as u32))
             .unwrap_or(0)
     }
 
-    /// Starts (or restarts) the timer with a relative value in nanoseconds.
-    pub fn write_timer_value(self: &Arc<Self>, value_ns: u64, backend: Arc<dyn VtimerBackend>) {
-        let target = backend.current_target();
-        self.schedule_timer_value(value_ns, target, backend);
+    /// Returns the absolute physical timer compare value.
+    pub fn compare_value(&self) -> u64 {
+        self.registers.lock().compare_value.unwrap_or(0)
     }
 
-    fn schedule_timer_value(
+    /// Starts (or restarts) the timer with a relative value in counter ticks.
+    pub fn write_timer_value(self: &Arc<Self>, value: u64, backend: Arc<dyn VtimerBackend>) {
+        let target = backend.current_target();
+        let timer_value = value as u32 as i32;
+        let compare = backend
+            .current_counter_value()
+            .wrapping_add_signed(i64::from(timer_value));
+        let ticks = u64::try_from(timer_value).unwrap_or(0);
+        self.schedule_timer(ticks, compare, target, backend);
+    }
+
+    /// Programs an absolute physical timer compare value.
+    pub fn write_compare_value(self: &Arc<Self>, value: u64, backend: Arc<dyn VtimerBackend>) {
+        let target = backend.current_target();
+        let ticks = value.saturating_sub(backend.current_counter_value());
+        self.schedule_timer(ticks, value, target, backend);
+    }
+
+    fn schedule_timer(
         self: &Arc<Self>,
-        value_ns: u64,
+        ticks: u64,
+        compare_value: u64,
         target: VtimerTarget,
         backend: Arc<dyn VtimerBackend>,
     ) {
         let now_ns = backend.current_time_nanos();
-        let deadline_ns = now_ns.saturating_add(value_ns);
+        let delay_ns = counter_ticks_to_nanos(ticks, backend.counter_frequency_hz());
+        let deadline_ns = now_ns.saturating_add(delay_ns);
         let (previous_token, generation) = {
             let mut registers = self.registers.lock();
             registers.deadline_ns = Some(deadline_ns);
+            registers.compare_value = Some(compare_value);
             registers.expired = false;
             registers.generation = registers.generation.wrapping_add(1);
             registers.target = Some(target);
-            registers.suspended_remaining_ns = None;
+            registers.suspended = false;
             (registers.timer_token.take(), registers.generation)
         };
         if let Some(token) = previous_token {
@@ -212,15 +259,12 @@ impl VtimerState {
         }
     }
 
-    /// Stops a pending host timer and preserves its remaining guest-visible time.
+    /// Stops a pending host timer while preserving its guest-visible register state.
     pub fn suspend(&self, backend: &dyn VtimerBackend) {
-        let now_ns = backend.current_time_nanos();
         let token = {
             let mut registers = self.registers.lock();
-            if !registers.expired && registers.suspended_remaining_ns.is_none() {
-                registers.suspended_remaining_ns = registers
-                    .deadline_ns
-                    .map(|deadline| deadline.saturating_sub(now_ns));
+            if !registers.expired && registers.deadline_ns.is_some() {
+                registers.suspended = true;
             }
             // A cancelled callback can race with this operation.  Invalidate it
             // before releasing the lock, so a paused timer cannot expire.
@@ -237,13 +281,15 @@ impl VtimerState {
     pub fn resume(self: &Arc<Self>, backend: Arc<dyn VtimerBackend>) {
         let suspended = {
             let mut registers = self.registers.lock();
-            registers
-                .suspended_remaining_ns
-                .take()
-                .and_then(|remaining| registers.target.map(|target| (remaining, target)))
+            let suspended = registers.suspended;
+            registers.suspended = false;
+            suspended
+                .then(|| registers.compare_value.zip(registers.target))
+                .flatten()
         };
-        if let Some((remaining, target)) = suspended {
-            self.schedule_timer_value(remaining, target, backend);
+        if let Some((compare_value, target)) = suspended {
+            let ticks = compare_value.saturating_sub(backend.current_counter_value());
+            self.schedule_timer(ticks, compare_value, target, backend);
         }
     }
 
@@ -295,12 +341,28 @@ impl Default for VtimerState {
 /// Create a collection of system register devices.
 pub fn get_sysreg_device() -> Vec<Arc<dyn Device>> {
     let backend: Arc<dyn VtimerBackend> = Arc::new(HostVtimerBackend);
+    sysreg_devices(backend)
+}
+
+fn sysreg_devices(backend: Arc<dyn VtimerBackend>) -> Vec<Arc<dyn Device>> {
     let state = Arc::new(VtimerState::new());
     vec![
         Arc::new(SysCntpCtlEl0::new(Arc::clone(&state), Arc::clone(&backend))),
+        Arc::new(SysCntpCvalEl0::new(
+            Arc::clone(&state),
+            Arc::clone(&backend),
+        )),
         Arc::new(SysCntpctEl0::new(Arc::clone(&backend))),
         Arc::new(SysCntpTvalEl0::new(state, backend)),
     ]
+}
+
+fn counter_ticks_to_nanos(ticks: u64, frequency_hz: u64) -> u64 {
+    if frequency_hz == 0 {
+        return 0;
+    }
+    let numerator = u128::from(ticks) * 1_000_000_000;
+    u64::try_from(numerator.div_ceil(u128::from(frequency_hz))).unwrap_or(u64::MAX)
 }
 
 #[cfg(test)]
@@ -311,12 +373,18 @@ mod tests {
         time::Duration,
     };
 
+    use aarch64_sysreg::SystemRegType;
     use ax_kspin::SpinNoIrq;
+    use axdevice_base::{
+        AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceId, NoopDeviceAccess, Resource,
+    };
 
-    use super::{VIRTUAL_TIMER_IRQ, VtimerBackend, VtimerState, VtimerTarget};
+    use super::{VIRTUAL_TIMER_IRQ, VtimerBackend, VtimerState, VtimerTarget, sysreg_devices};
 
     struct TestBackend {
         now_ns: u64,
+        counter_value: u64,
+        counter_frequency_hz: u64,
         current_target: SpinNoIrq<Option<VtimerTarget>>,
         next_token: AtomicUsize,
         cancelled: SpinNoIrq<Vec<usize>>,
@@ -326,6 +394,7 @@ mod tests {
 
     struct TestTimer {
         token: usize,
+        deadline: Duration,
         callback: Option<Box<dyn FnOnce(Duration) + Send + 'static>>,
     }
 
@@ -333,6 +402,21 @@ mod tests {
         fn new(now_ns: u64) -> Self {
             Self {
                 now_ns,
+                counter_value: now_ns,
+                counter_frequency_hz: 1_000_000_000,
+                current_target: SpinNoIrq::new(Some(VtimerTarget::new(7, 3))),
+                next_token: AtomicUsize::new(1),
+                cancelled: SpinNoIrq::new(Vec::new()),
+                injected: SpinNoIrq::new(Vec::new()),
+                timers: SpinNoIrq::new(Vec::new()),
+            }
+        }
+
+        fn with_counter(now_ns: u64, counter_value: u64, counter_frequency_hz: u64) -> Self {
+            Self {
+                now_ns,
+                counter_value,
+                counter_frequency_hz,
                 current_target: SpinNoIrq::new(Some(VtimerTarget::new(7, 3))),
                 next_token: AtomicUsize::new(1),
                 cancelled: SpinNoIrq::new(Vec::new()),
@@ -364,14 +448,23 @@ mod tests {
             self.now_ns
         }
 
+        fn current_counter_value(&self) -> u64 {
+            self.counter_value
+        }
+
+        fn counter_frequency_hz(&self) -> u64 {
+            self.counter_frequency_hz
+        }
+
         fn register_timer(
             &self,
-            _deadline: Duration,
+            deadline: Duration,
             callback: Box<dyn FnOnce(Duration) + Send + 'static>,
         ) -> usize {
             let token = self.next_token.fetch_add(1, Ordering::Relaxed);
             self.timers.lock().push(TestTimer {
                 token,
+                deadline,
                 callback: Some(callback),
             });
             token
@@ -393,6 +486,190 @@ mod tests {
     }
 
     #[test]
+    fn sysreg_devices_share_physical_timer_state() {
+        let concrete_backend = Arc::new(TestBackend::with_counter(
+            1_000_000_000,
+            24_000_000,
+            24_000_000,
+        ));
+        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
+        let devices = sysreg_devices(backend);
+        let compare_value = 24_024_000;
+
+        assert!(matches!(
+            access_sysreg(
+                &devices,
+                SystemRegType::CNTP_CVAL_EL0 as u64,
+                false,
+                compare_value,
+            ),
+            BusResponse::Write
+        ));
+        assert_eq!(
+            read_sysreg(&devices, SystemRegType::CNTP_CVAL_EL0),
+            compare_value
+        );
+        assert_eq!(read_sysreg(&devices, SystemRegType::CNTP_TVAL_EL0), 24_000);
+        assert_eq!(read_sysreg(&devices, SystemRegType::CNTPCT_EL0), 24_000_000);
+        assert_eq!(
+            concrete_backend.timers.lock()[0].deadline,
+            Duration::from_nanos(1_001_000_000)
+        );
+    }
+
+    #[test]
+    fn resume_preserves_guest_programmed_compare_value() {
+        let initial_backend: Arc<dyn VtimerBackend> = Arc::new(TestBackend::with_counter(
+            1_000_000_000,
+            24_000_000,
+            24_000_000,
+        ));
+        let resumed_backend = Arc::new(TestBackend::with_counter(
+            2_000_000_000,
+            48_000_000,
+            24_000_000,
+        ));
+        let resumed_backend_dyn: Arc<dyn VtimerBackend> = resumed_backend.clone();
+        let state = Arc::new(VtimerState::new());
+        let devices: Vec<Arc<dyn Device>> = vec![Arc::new(super::SysCntpCvalEl0::new(
+            Arc::clone(&state),
+            Arc::clone(&initial_backend),
+        ))];
+        let compare_value = 24_024_000;
+
+        assert!(matches!(
+            access_sysreg(
+                &devices,
+                SystemRegType::CNTP_CVAL_EL0 as u64,
+                false,
+                compare_value,
+            ),
+            BusResponse::Write
+        ));
+        state.suspend(initial_backend.as_ref());
+        state.resume(resumed_backend_dyn);
+
+        assert_eq!(
+            read_sysreg(&devices, SystemRegType::CNTP_CVAL_EL0),
+            compare_value,
+            "VM resume must not rewrite the guest-visible architectural CVAL"
+        );
+        assert_eq!(
+            resumed_backend.timers.lock()[0].deadline,
+            Duration::from_nanos(2_000_000_000),
+            "VM resume must re-arm the host timer from the architectural counter state"
+        );
+    }
+
+    #[test]
+    fn negative_tval_write_programs_an_expired_compare_value() {
+        let concrete_backend = Arc::new(TestBackend::with_counter(
+            1_000_000_000,
+            24_000_000,
+            24_000_000,
+        ));
+        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
+        let state = Arc::new(VtimerState::new());
+        let devices: Vec<Arc<dyn Device>> = vec![Arc::new(super::SysCntpTvalEl0::new(
+            Arc::clone(&state),
+            backend,
+        ))];
+
+        assert!(matches!(
+            access_sysreg(
+                &devices,
+                SystemRegType::CNTP_TVAL_EL0 as u64,
+                false,
+                u64::from(u32::MAX),
+            ),
+            BusResponse::Write
+        ));
+        assert_eq!(state.compare_value(), 23_999_999);
+        assert_eq!(
+            concrete_backend.timers.lock()[0].deadline,
+            Duration::from_nanos(1_000_000_000)
+        );
+    }
+
+    #[test]
+    fn expired_tval_read_returns_the_signed_32_bit_delta() {
+        let programming_backend: Arc<dyn VtimerBackend> = Arc::new(TestBackend::with_counter(
+            1_000_000_000,
+            24_000_000,
+            24_000_000,
+        ));
+        let reading_backend: Arc<dyn VtimerBackend> = Arc::new(TestBackend::with_counter(
+            1_000_000_500,
+            24_000_011,
+            24_000_000,
+        ));
+        let state = Arc::new(VtimerState::new());
+        let cval_devices: Vec<Arc<dyn Device>> = vec![Arc::new(super::SysCntpCvalEl0::new(
+            Arc::clone(&state),
+            programming_backend,
+        ))];
+        let tval_devices: Vec<Arc<dyn Device>> =
+            vec![Arc::new(super::SysCntpTvalEl0::new(state, reading_backend))];
+
+        assert!(matches!(
+            access_sysreg(
+                &cval_devices,
+                SystemRegType::CNTP_CVAL_EL0 as u64,
+                false,
+                24_000_000,
+            ),
+            BusResponse::Write
+        ));
+        assert_eq!(
+            read_sysreg(&tval_devices, SystemRegType::CNTP_TVAL_EL0),
+            u64::from(u32::MAX - 10),
+            "TVAL must keep decrementing below zero after the timer condition is met"
+        );
+    }
+
+    #[test]
+    fn control_status_uses_the_architectural_counter() {
+        let concrete_backend = Arc::new(TestBackend::with_counter(
+            1_000_000_000,
+            24_000_000,
+            24_000_000,
+        ));
+        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
+        let state = Arc::new(VtimerState::new());
+        state.write_compare_value(24_024_000, Arc::clone(&backend));
+        state.write_control(1, backend.as_ref());
+
+        assert_eq!(
+            state.control(24_024_001),
+            0b101,
+            "ISTATUS must report whether CVAL is not greater than CNTPCT"
+        );
+    }
+
+    #[test]
+    fn enabling_an_elapsed_timer_injects_without_waiting_for_host_callback() {
+        let programming_backend: Arc<dyn VtimerBackend> = Arc::new(TestBackend::with_counter(
+            1_000_000_000,
+            24_000_000,
+            24_000_000,
+        ));
+        let elapsed_backend = Arc::new(TestBackend::with_counter(
+            1_001_000_000,
+            24_024_001,
+            24_000_000,
+        ));
+        let state = Arc::new(VtimerState::new());
+        state.write_compare_value(24_024_000, programming_backend);
+
+        state.write_control(1, elapsed_backend.as_ref());
+
+        assert_eq!(
+            *elapsed_backend.injected.lock(),
+            [(VtimerTarget::new(7, 3), VIRTUAL_TIMER_IRQ)]
+        );
+    }
+
+    #[test]
     fn expired_timer_is_injected_when_enabled_and_unmasked() {
         let concrete_backend = Arc::new(TestBackend::new(100));
         let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
@@ -405,6 +682,46 @@ mod tests {
         assert_eq!(
             *concrete_backend.injected.lock(),
             [(VtimerTarget::new(7, 3), VIRTUAL_TIMER_IRQ)]
+        );
+    }
+
+    #[test]
+    fn relative_timer_value_uses_architectural_counter_frequency() {
+        let concrete_backend = Arc::new(TestBackend::with_counter(
+            1_000_000_000,
+            24_000_000,
+            24_000_000,
+        ));
+        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
+        let state = Arc::new(VtimerState::new());
+
+        state.write_timer_value(24_000, Arc::clone(&backend));
+
+        assert_eq!(
+            concrete_backend.timers.lock()[0].deadline,
+            Duration::from_nanos(1_001_000_000),
+            "24,000 counter ticks at 24 MHz must schedule a one millisecond delay"
+        );
+    }
+
+    #[test]
+    fn absolute_compare_uses_architectural_counter_frequency() {
+        let concrete_backend = Arc::new(TestBackend::with_counter(
+            1_000_000_000,
+            24_000_000,
+            24_000_000,
+        ));
+        let backend: Arc<dyn VtimerBackend> = concrete_backend.clone();
+        let state = Arc::new(VtimerState::new());
+
+        state.write_compare_value(24_024_000, Arc::clone(&backend));
+
+        assert_eq!(state.compare_value(), 24_024_000);
+        assert_eq!(state.timer_value(backend.as_ref()), 24_000);
+        assert_eq!(
+            concrete_backend.timers.lock()[0].deadline,
+            Duration::from_nanos(1_001_000_000),
+            "24,000 counter ticks at 24 MHz must schedule a one millisecond delay"
         );
     }
 
@@ -449,7 +766,11 @@ mod tests {
 
         state.suspend(backend.as_ref());
         state.expire(1, VtimerTarget::new(7, 3), Arc::clone(&backend));
-        assert_eq!(state.control(120), 1);
+        assert_eq!(
+            state.control(120),
+            0b101,
+            "ISTATUS must remain derived from CVAL even while the host callback is suspended"
+        );
         assert_eq!(*concrete_backend.cancelled.lock(), [1]);
 
         state.resume(Arc::clone(&backend));
@@ -494,5 +815,49 @@ mod tests {
             [(VtimerTarget::new(11, 5), VIRTUAL_TIMER_IRQ)],
             "resume must not read the current vCPU context"
         );
+    }
+
+    fn read_sysreg(devices: &[Arc<dyn Device>], register: SystemRegType) -> u64 {
+        match access_sysreg(devices, register as u64, true, 0) {
+            BusResponse::Read { value } => value,
+            BusResponse::Write => panic!("sysreg read returned a write response"),
+        }
+    }
+
+    fn access_sysreg(
+        devices: &[Arc<dyn Device>],
+        addr: u64,
+        is_read: bool,
+        data: u64,
+    ) -> BusResponse {
+        let (device_index, device) = devices
+            .iter()
+            .enumerate()
+            .find(|(_, device)| {
+                device.resources().iter().any(|resource| {
+                    matches!(
+                        resource,
+                        Resource::SysReg {
+                            addr: resource_addr,
+                            count,
+                        } if addr >= u64::from(*resource_addr)
+                            && addr < u64::from(*resource_addr) + u64::from(*count)
+                    )
+                })
+            })
+            .unwrap_or_else(|| panic!("sysreg {addr:#x} is not registered"));
+        let mut context = NoopDeviceAccess::new(DeviceId::new(device_index as u32));
+        device
+            .access(
+                &BusAccess {
+                    kind: BusKind::SysReg,
+                    is_read,
+                    addr,
+                    width: AccessWidth::Qword,
+                    data,
+                },
+                &mut context,
+            )
+            .unwrap_or_else(|error| panic!("sysreg {addr:#x} access failed: {error}"))
     }
 }

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -434,6 +434,20 @@ impl ArmVgicHostIf for ArmVgicHostIfImpl {
         default_host().monotonic_time().as_nanos() as u64
     }
 
+    fn current_counter_value() -> u64 {
+        let value: u64;
+        // SAFETY: CNTPCT_EL0 is read-only and has no memory or ownership preconditions.
+        unsafe { core::arch::asm!("mrs {value}, CNTPCT_EL0", value = out(reg) value) };
+        value
+    }
+
+    fn counter_frequency_hz() -> u64 {
+        let frequency: u64;
+        // SAFETY: CNTFRQ_EL0 is read-only and has no memory or ownership preconditions.
+        unsafe { core::arch::asm!("mrs {frequency}, CNTFRQ_EL0", frequency = out(reg) frequency) };
+        frequency
+    }
+
     fn register_timer(
         deadline: Duration,
         callback: Box<dyn FnOnce(Duration) + Send + 'static>,

--- a/virtualization/axvm/src/arch/aarch64/vtimer.rs
+++ b/virtualization/axvm/src/arch/aarch64/vtimer.rs
@@ -8,7 +8,8 @@
 use alloc::sync::Arc;
 
 use arm_vgic::vtimer::{
-    HostVtimerBackend, SysCntpCtlEl0, SysCntpTvalEl0, SysCntpctEl0, VtimerBackend, VtimerState,
+    HostVtimerBackend, SysCntpCtlEl0, SysCntpCvalEl0, SysCntpTvalEl0, SysCntpctEl0, VtimerBackend,
+    VtimerState,
 };
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceLifecycle, DeviceManagerResult,
@@ -58,7 +59,7 @@ impl Drop for VtimerLifecycle {
 }
 
 impl Aarch64VtimerFactory {
-    /// Builds the three CNT* system-register device contributions.
+    /// Builds the CNT* system-register device contributions.
     fn build_bundle(&self) -> DeviceManagerResult<DeviceBundle> {
         let backend: Arc<dyn VtimerBackend> = Arc::new(HostVtimerBackend);
         let state = Arc::new(VtimerState::new());
@@ -70,6 +71,10 @@ impl Aarch64VtimerFactory {
         let bundle = DeviceBundle::from_registration(DeviceRegistration::Device(Arc::new(
             SysCntpCtlEl0::new(Arc::clone(&state), Arc::clone(&backend)),
         )))
+        .with_registration(DeviceRegistration::Device(Arc::new(SysCntpCvalEl0::new(
+            Arc::clone(&state),
+            Arc::clone(&backend),
+        ))))
         .with_registration(DeviceRegistration::Device(Arc::new(SysCntpctEl0::new(
             Arc::clone(&backend),
         ))))


### PR DESCRIPTION
## 问题

AArch64 架构定时器寄存器使用 architectural counter tick 作为计时单位，tick 与实际时间之间需要根据 `CNTFRQ_EL0` 进行换算。

原有 vtimer 实现将 counter tick 直接作为纳秒处理。在 Rock-4D 的 24 MHz 计数器环境下，24,000 tick 本应表示 1 ms，但会被错误地按 24 µs 调度，导致 Guest 定时器过早触发。

此外，Guest 使用的绝对比较值寄存器 `CNTP_CVAL_EL0` 尚未接入 AxVM vtimer。

## 修改内容

- 增加 `CNTP_CVAL_EL0` 的读写模拟。
- 从宿主读取 `CNTPCT_EL0`，作为当前 architectural counter value。
- 从宿主读取 `CNTFRQ_EL0`，获取 architectural counter frequency。
- 根据 counter frequency 在 tick 和纳秒之间进行换算。
- 修正 `CNTP_TVAL_EL0` 的剩余 tick 计算。
- 将 `CNTP_CVAL_EL0` 接入 AxVM 的 AArch64 vtimer 设备。
- 增加绝对比较值和非 1 GHz 计数器频率的回归测试。

## 实现逻辑

`CNTP_CVAL_EL0` 保存绝对到期 counter value，`CNTP_TVAL_EL0` 表示相对于当前 counter 的剩余 tick，两者满足：

```text
TVAL = CVAL - CNTPCT
CVAL = CNTPCT + TVAL
```

调度宿主定时器时，根据 CNTFRQ_EL0 将剩余 tick 转换为实际持续时间：

duration_ns = ticks × 1,000,000,000 / counter_frequency_hz

这样可以正确处理 Rock-4D 使用的 24 MHz 计数器，也兼容其他 architectural counter frequency。