### PR TITLE
refactor(cv181x-sdhci): use tock-registers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,6 +2778,7 @@ dependencies = [
  "sdhci-host",
  "sdio-host2",
  "sdmmc-protocol",
+ "tock-registers 0.10.1",
 ]
 
 [[package]]

--- a/drivers/blk/cv181x-sdhci/Cargo.toml
+++ b/drivers/blk/cv181x-sdhci/Cargo.toml
@@ -14,6 +14,7 @@ sdmmc-protocol = { workspace = true, default-features = false, features = ["sdio
 sdio-host2.workspace = true
 dma-api.workspace = true
 mmio-api.workspace = true
+tock-registers.workspace = true
 
 [features]
 default = []

--- a/drivers/blk/cv181x-sdhci/src/board.rs
+++ b/drivers/blk/cv181x-sdhci/src/board.rs
@@ -1,5 +1,7 @@
 //! CV181x TOP, pinmux, pad and PHY policy.
 
+use tock_registers::interfaces::{ReadWriteable, Writeable};
+
 use super::{Cv181xSdhci, host2::AfterBusOp};
 use crate::platform::*;
 
@@ -26,16 +28,16 @@ impl Cv181xSdhci {
     }
 
     pub fn setup_sd_pad(&mut self, unplug: bool) {
-        let pinmux = self.mmio.pinmux();
+        let registers = self.mmio.syscon_registers();
         let active_cd_func = if self.config.has_card_detect_gpio {
             PINMUX_FUNC_XGPIO
         } else {
             PINMUX_FUNC_SDIO0
         };
-        write_u8(pinmux, PINMUX_SDIO0_CD, active_cd_func);
+        registers.sdio0_cd_mux.set(active_cd_func);
 
         if self.config.touch_power_enable_pin {
-            write_u8(pinmux, PINMUX_SDIO0_PWR_EN, PINMUX_FUNC_SDIO0);
+            registers.sdio0_power_enable_mux.set(PINMUX_FUNC_SDIO0);
         }
 
         let func = if unplug {
@@ -43,55 +45,50 @@ impl Cv181xSdhci {
         } else {
             PINMUX_FUNC_SDIO0
         };
-        for off in [
-            PINMUX_SDIO0_CLK,
-            PINMUX_SDIO0_CMD,
-            PINMUX_SDIO0_D0,
-            PINMUX_SDIO0_D1,
-            PINMUX_SDIO0_D2,
-            PINMUX_SDIO0_D3,
+        for register in [
+            &registers.sdio0_clk_mux,
+            &registers.sdio0_cmd_mux,
+            &registers.sdio0_d0_mux,
+            &registers.sdio0_d1_mux,
+            &registers.sdio0_d2_mux,
+            &registers.sdio0_d3_mux,
         ] {
-            write_u8(pinmux, off, func);
+            register.set(func);
         }
     }
 
     pub fn setup_sd_io(&mut self, reset: bool) {
-        let pinmux = self.mmio.pinmux();
-        set_pull(pinmux, IO_SDIO0_CD, IO_PULL_UP, IO_PULL_DOWN);
-        set_pull(pinmux, IO_SDIO0_PWR_EN, IO_PULL_DOWN, IO_PULL_UP);
-        set_pull(pinmux, IO_SDIO0_CLK, IO_PULL_DOWN, IO_PULL_UP);
+        let registers = self.mmio.syscon_registers();
+        set_pull(&registers.sdio0_cd_pull, PullMode::Up);
+        set_pull(&registers.sdio0_power_enable_pull, PullMode::Down);
+        set_pull(&registers.sdio0_clk_pull, PullMode::Down);
 
-        let (set, clear) = if reset {
-            (IO_PULL_DOWN, IO_PULL_UP)
-        } else {
-            (IO_PULL_UP, IO_PULL_DOWN)
-        };
-        for off in [
-            IO_SDIO0_CMD,
-            IO_SDIO0_D0,
-            IO_SDIO0_D1,
-            IO_SDIO0_D2,
-            IO_SDIO0_D3,
+        let mode = if reset { PullMode::Down } else { PullMode::Up };
+        for register in [
+            &registers.sdio0_cmd_pull,
+            &registers.sdio0_d0_pull,
+            &registers.sdio0_d1_pull,
+            &registers.sdio0_d2_pull,
+            &registers.sdio0_d3_pull,
         ] {
-            set_pull(pinmux, off, set, clear);
+            set_pull(register, mode);
         }
     }
 
     pub fn restore_ds_hs_phy(&mut self) {
-        let core = self.mmio.core();
-        let mshc = read_u32(core, CVI_VENDOR_MSHC_CTRL) | MSHC_CTRL_DS_HS_BITS;
-        write_u32(core, CVI_VENDOR_MSHC_CTRL, mshc);
-        write_u32(core, CVI_PHY_TX_RX_DLY, PHY_TX_RX_DLY_DS_HS);
-        write_u32(core, CVI_PHY_CONFIG, PHY_CONFIG_DS_HS);
+        let registers = self.mmio.core_registers();
+        registers.mshc_ctrl.modify(
+            MSHC_CTRL::DS_HS_BIT_1::SET + MSHC_CTRL::DS_HS_BIT_8::SET + MSHC_CTRL::DS_HS_BIT_9::SET,
+        );
+        registers.phy_tx_rx_dly.set(PHY_TX_RX_DLY_DS_HS);
+        registers.phy_config.set(PHY_CONFIG_DS_HS);
     }
 
     fn update_top_power(&mut self, low_bits: u32) {
-        let cur = read_u32(self.mmio.syscon(), TOP_SD_PWRSW_CTRL);
-        write_u32(
-            self.mmio.syscon(),
-            TOP_SD_PWRSW_CTRL,
-            (cur & !TOP_SD_PWRSW_LOW_MASK) | low_bits,
-        );
+        self.mmio
+            .syscon_registers()
+            .sd_powersw_ctrl
+            .modify(TOP_SD_PWRSW_CTRL::LOW_BITS.val(low_bits));
     }
 
     pub(super) fn apply_after(&mut self, after: AfterBusOp) -> Result<(), sdio_host2::Error> {

--- a/drivers/blk/cv181x-sdhci/src/clock.rs
+++ b/drivers/blk/cv181x-sdhci/src/clock.rs
@@ -1,6 +1,7 @@
 //! CV181x SDHCI clock and timing policy.
 
 use sdio_host2::ClockSpeed;
+use tock_registers::interfaces::ReadWriteable;
 
 use super::{Cv181xSdhci, map_protocol_error};
 use crate::platform::*;
@@ -38,17 +39,19 @@ impl Cv181xSdhci {
     }
 
     fn set_host_timing_bits(&mut self, high_speed: bool, uhs_mode: u16) {
-        let core = self.mmio.core();
-        let mut ctrl1 = read_u8(core, REG_HOST_CONTROL1);
+        let registers = self.mmio.core_registers();
         if high_speed {
-            ctrl1 |= HOST_CTRL1_HIGH_SPEED;
+            registers
+                .host_control1
+                .modify(HOST_CONTROL1::HIGH_SPEED::SET);
         } else {
-            ctrl1 &= !HOST_CTRL1_HIGH_SPEED;
+            registers
+                .host_control1
+                .modify(HOST_CONTROL1::HIGH_SPEED::CLEAR);
         }
-        write_u8(core, REG_HOST_CONTROL1, ctrl1);
 
-        let ctrl2 = (read_u16(core, REG_HOST_CONTROL2) & !HOST_CTRL2_UHS_MODE_MASK)
-            | (uhs_mode & HOST_CTRL2_UHS_MODE_MASK);
-        write_u16(core, REG_HOST_CONTROL2, ctrl2);
+        registers
+            .host_control2
+            .modify(HOST_CONTROL2::UHS_MODE.val(uhs_mode));
     }
 }

--- a/drivers/blk/cv181x-sdhci/src/platform.rs
+++ b/drivers/blk/cv181x-sdhci/src/platform.rs
@@ -3,6 +3,7 @@
 use core::ptr::NonNull;
 
 use sdio_host2::BusWidth;
+use tock_registers::{register_bitfields, register_structs, registers::ReadWrite};
 
 pub(super) const DEFAULT_SRC_FREQUENCY_HZ: u32 = 375_000_000;
 pub(super) const DEFAULT_MIN_FREQUENCY_HZ: u32 = 400_000;
@@ -13,48 +14,112 @@ pub const CV181X_TOP_SYSCON_BASE: u64 = 0x0300_0000;
 /// Minimum syscon mapping required by this wrapper (TOP + pinmux/IO window).
 pub const CV181X_SYSCON_REQUIRED_SIZE: usize = 0x2000;
 
-pub(super) const SYSCON_PINMUX_OFFSET: usize = 0x1000;
-
-pub(super) const TOP_SD_PWRSW_CTRL: usize = 0x1f4;
 pub(super) const TOP_SD_PWRSW_3V3: u32 = 0x9;
 pub(super) const TOP_SD_PWRSW_OFF: u32 = 0xe;
-pub(super) const TOP_SD_PWRSW_LOW_MASK: u32 = 0xf;
 
-pub(super) const PINMUX_SDIO0_CD: usize = 0x34;
-pub(super) const PINMUX_SDIO0_PWR_EN: usize = 0x38;
-pub(super) const PINMUX_SDIO0_CLK: usize = 0x1c;
-pub(super) const PINMUX_SDIO0_CMD: usize = 0x20;
-pub(super) const PINMUX_SDIO0_D0: usize = 0x24;
-pub(super) const PINMUX_SDIO0_D1: usize = 0x28;
-pub(super) const PINMUX_SDIO0_D2: usize = 0x2c;
-pub(super) const PINMUX_SDIO0_D3: usize = 0x30;
 pub(super) const PINMUX_FUNC_SDIO0: u8 = 0x0;
 pub(super) const PINMUX_FUNC_XGPIO: u8 = 0x3;
 
-pub(super) const IO_SDIO0_CD: usize = 0x900;
-pub(super) const IO_SDIO0_PWR_EN: usize = 0x904;
-pub(super) const IO_SDIO0_CLK: usize = 0xa00;
-pub(super) const IO_SDIO0_CMD: usize = 0xa04;
-pub(super) const IO_SDIO0_D0: usize = 0xa08;
-pub(super) const IO_SDIO0_D1: usize = 0xa0c;
-pub(super) const IO_SDIO0_D2: usize = 0xa10;
-pub(super) const IO_SDIO0_D3: usize = 0xa14;
-pub(super) const IO_PULL_UP: u8 = 1 << 2;
-pub(super) const IO_PULL_DOWN: u8 = 1 << 3;
-
-pub(super) const REG_HOST_CONTROL1: usize = 0x28;
-pub(super) const REG_HOST_CONTROL2: usize = 0x3e;
-pub(super) const HOST_CTRL1_HIGH_SPEED: u8 = 1 << 2;
-pub(super) const HOST_CTRL2_UHS_MODE_MASK: u16 = 0x0007;
 pub(super) const HOST_CTRL2_UHS_SDR12: u16 = 0x0000;
 pub(super) const HOST_CTRL2_UHS_SDR25: u16 = 0x0001;
 
-pub(super) const CVI_VENDOR_MSHC_CTRL: usize = 0x200;
-pub(super) const CVI_PHY_TX_RX_DLY: usize = 0x240;
-pub(super) const CVI_PHY_CONFIG: usize = 0x24c;
-pub(super) const MSHC_CTRL_DS_HS_BITS: u32 = (1 << 1) | (1 << 8) | (1 << 9);
 pub(super) const PHY_TX_RX_DLY_DS_HS: u32 = 0x0100_0100;
 pub(super) const PHY_CONFIG_DS_HS: u32 = 1;
+
+register_bitfields! [
+    u8,
+
+    pub HOST_CONTROL1 [
+        HIGH_SPEED OFFSET(2) NUMBITS(1) []
+    ],
+
+    pub PINMUX [
+        FUNCTION OFFSET(0) NUMBITS(3) []
+    ],
+
+    pub PAD_PULL [
+        UP OFFSET(2) NUMBITS(1) [],
+        DOWN OFFSET(3) NUMBITS(1) []
+    ]
+];
+
+register_bitfields! [
+    u16,
+
+    pub HOST_CONTROL2 [
+        UHS_MODE OFFSET(0) NUMBITS(3) []
+    ]
+];
+
+register_bitfields! [
+    u32,
+
+    pub TOP_SD_PWRSW_CTRL [
+        LOW_BITS OFFSET(0) NUMBITS(4) []
+    ],
+
+    pub MSHC_CTRL [
+        DS_HS_BIT_1 OFFSET(1) NUMBITS(1) [],
+        DS_HS_BIT_8 OFFSET(8) NUMBITS(1) [],
+        DS_HS_BIT_9 OFFSET(9) NUMBITS(1) []
+    ]
+];
+
+register_structs! {
+    pub Cv181xCoreRegisters {
+        (0x000 => _reserved0),
+        (0x028 => pub host_control1: ReadWrite<u8, HOST_CONTROL1::Register>),
+        (0x029 => _reserved1),
+        (0x03e => pub host_control2: ReadWrite<u16, HOST_CONTROL2::Register>),
+        (0x040 => _reserved2),
+        (0x200 => pub mshc_ctrl: ReadWrite<u32, MSHC_CTRL::Register>),
+        (0x204 => _reserved3),
+        (0x240 => pub phy_tx_rx_dly: ReadWrite<u32>),
+        (0x244 => _reserved4),
+        (0x24c => pub phy_config: ReadWrite<u32>),
+        (0x250 => @END),
+    }
+}
+
+register_structs! {
+    pub Cv181xSysconRegisters {
+        (0x000 => _reserved0),
+        (0x1f4 => pub sd_powersw_ctrl: ReadWrite<u32, TOP_SD_PWRSW_CTRL::Register>),
+        (0x1f8 => _reserved1),
+        (0x101c => pub sdio0_clk_mux: ReadWrite<u8, PINMUX::Register>),
+        (0x101d => _reserved2),
+        (0x1020 => pub sdio0_cmd_mux: ReadWrite<u8, PINMUX::Register>),
+        (0x1021 => _reserved3),
+        (0x1024 => pub sdio0_d0_mux: ReadWrite<u8, PINMUX::Register>),
+        (0x1025 => _reserved4),
+        (0x1028 => pub sdio0_d1_mux: ReadWrite<u8, PINMUX::Register>),
+        (0x1029 => _reserved5),
+        (0x102c => pub sdio0_d2_mux: ReadWrite<u8, PINMUX::Register>),
+        (0x102d => _reserved6),
+        (0x1030 => pub sdio0_d3_mux: ReadWrite<u8, PINMUX::Register>),
+        (0x1031 => _reserved7),
+        (0x1034 => pub sdio0_cd_mux: ReadWrite<u8, PINMUX::Register>),
+        (0x1035 => _reserved8),
+        (0x1038 => pub sdio0_power_enable_mux: ReadWrite<u8, PINMUX::Register>),
+        (0x1039 => _reserved9),
+        (0x1900 => pub sdio0_cd_pull: ReadWrite<u8, PAD_PULL::Register>),
+        (0x1901 => _reserved10),
+        (0x1904 => pub sdio0_power_enable_pull: ReadWrite<u8, PAD_PULL::Register>),
+        (0x1905 => _reserved11),
+        (0x1a00 => pub sdio0_clk_pull: ReadWrite<u8, PAD_PULL::Register>),
+        (0x1a01 => _reserved12),
+        (0x1a04 => pub sdio0_cmd_pull: ReadWrite<u8, PAD_PULL::Register>),
+        (0x1a05 => _reserved13),
+        (0x1a08 => pub sdio0_d0_pull: ReadWrite<u8, PAD_PULL::Register>),
+        (0x1a09 => _reserved14),
+        (0x1a0c => pub sdio0_d1_pull: ReadWrite<u8, PAD_PULL::Register>),
+        (0x1a0d => _reserved15),
+        (0x1a10 => pub sdio0_d2_pull: ReadWrite<u8, PAD_PULL::Register>),
+        (0x1a11 => _reserved16),
+        (0x1a14 => pub sdio0_d3_pull: ReadWrite<u8, PAD_PULL::Register>),
+        (0x1a15 => @END),
+    }
+}
 
 /// Already-mapped MMIO regions required by the portable CV181x wrapper.
 #[derive(Clone, Copy)]
@@ -76,10 +141,16 @@ impl Cv181xMmio {
         self.syscon
     }
 
-    pub(super) fn pinmux(self) -> NonNull<u8> {
-        // SAFETY: OS glue maps the CV181x syscon window. The documented
-        // pinmux block lives at TOP_BASE + 0x1000 inside that mapping.
-        unsafe { NonNull::new_unchecked(self.syscon.as_ptr().add(SYSCON_PINMUX_OFFSET)) }
+    pub(super) fn core_registers(&self) -> &Cv181xCoreRegisters {
+        // SAFETY: `Cv181xSdhci::new` requires this mapping to cover the
+        // controller register file for the wrapper's whole lifetime.
+        unsafe { &*self.core.as_ptr().cast() }
+    }
+
+    pub(super) fn syscon_registers(&self) -> &Cv181xSysconRegisters {
+        // SAFETY: `Cv181xSdhci::new` requires this mapping to cover TOP and
+        // the pinmux/IO window for the wrapper's whole lifetime.
+        unsafe { &*self.syscon.as_ptr().cast() }
     }
 }
 
@@ -146,37 +217,17 @@ impl Cv181xConfig {
     }
 }
 
-pub(super) fn set_pull(base: NonNull<u8>, off: usize, set: u8, clear: u8) {
-    let next = (read_u8(base, off) | set) & !clear;
-    write_u8(base, off, next);
+#[derive(Clone, Copy)]
+pub(super) enum PullMode {
+    Up,
+    Down,
 }
 
-pub(super) fn read_u8(base: NonNull<u8>, off: usize) -> u8 {
-    // SAFETY: caller-provided MMIO base covers the documented byte register.
-    unsafe { core::ptr::read_volatile(base.as_ptr().add(off) as *const u8) }
-}
+pub(super) fn set_pull(register: &ReadWrite<u8, PAD_PULL::Register>, mode: PullMode) {
+    use tock_registers::interfaces::ReadWriteable;
 
-pub(super) fn write_u8(base: NonNull<u8>, off: usize, val: u8) {
-    // SAFETY: caller-provided MMIO base covers the documented byte register.
-    unsafe { core::ptr::write_volatile(base.as_ptr().add(off), val) }
-}
-
-pub(super) fn read_u16(base: NonNull<u8>, off: usize) -> u16 {
-    // SAFETY: caller-provided MMIO base covers the documented 16-bit register.
-    unsafe { core::ptr::read_volatile(base.as_ptr().add(off) as *const u16) }
-}
-
-pub(super) fn write_u16(base: NonNull<u8>, off: usize, val: u16) {
-    // SAFETY: caller-provided MMIO base covers the documented 16-bit register.
-    unsafe { core::ptr::write_volatile(base.as_ptr().add(off) as *mut u16, val) }
-}
-
-pub(super) fn read_u32(base: NonNull<u8>, off: usize) -> u32 {
-    // SAFETY: caller-provided MMIO base covers the documented 32-bit register.
-    unsafe { core::ptr::read_volatile(base.as_ptr().add(off) as *const u32) }
-}
-
-pub(super) fn write_u32(base: NonNull<u8>, off: usize, val: u32) {
-    // SAFETY: caller-provided MMIO base covers the documented 32-bit register.
-    unsafe { core::ptr::write_volatile(base.as_ptr().add(off) as *mut u32, val) }
+    match mode {
+        PullMode::Up => register.modify(PAD_PULL::UP::SET + PAD_PULL::DOWN::CLEAR),
+        PullMode::Down => register.modify(PAD_PULL::UP::CLEAR + PAD_PULL::DOWN::SET),
+    }
 }

--- a/drivers/blk/cv181x-sdhci/src/tests.rs
+++ b/drivers/blk/cv181x-sdhci/src/tests.rs
@@ -3,6 +3,7 @@ extern crate std;
 use core::ptr::NonNull;
 
 use sdio_host2::{BusWidth, ClockSpeed, ProgressCause, RequestProgress, SignalVoltage};
+use tock_registers::interfaces::{Readable, Writeable};
 
 use super::*;
 use crate::platform::*;
@@ -50,12 +51,9 @@ fn complete_register_bus_op(
 fn power_on_sequence_configures_3v3_pads_io_and_ds_hs_phy() {
     let mut core = FakeMmio::new();
     let mut syscon = FakeMmio::new();
-    write_u32(syscon.base(), TOP_SD_PWRSW_CTRL, 0xa5a5_a5a0);
-    write_u8(
-        unsafe { NonNull::new_unchecked(syscon.base().as_ptr().add(SYSCON_PINMUX_OFFSET)) },
-        PINMUX_SDIO0_PWR_EN,
-        0x7,
-    );
+    let mmio = Cv181xMmio::new(core.base(), syscon.base());
+    mmio.syscon_registers().sd_powersw_ctrl.set(0xa5a5_a5a0);
+    mmio.syscon_registers().sdio0_power_enable_mux.set(0x7);
 
     let mut host = new_host(
         &mut core,
@@ -67,28 +65,25 @@ fn power_on_sequence_configures_3v3_pads_io_and_ds_hs_phy() {
     );
     host.configure_sd_power_on();
 
-    let pinmux =
-        unsafe { NonNull::new_unchecked(syscon.base().as_ptr().add(SYSCON_PINMUX_OFFSET)) };
+    let registers = mmio.syscon_registers();
     assert_eq!(
-        read_u32(syscon.base(), TOP_SD_PWRSW_CTRL),
+        registers.sd_powersw_ctrl.get(),
         0xa5a5_a5a0 | TOP_SD_PWRSW_3V3
     );
-    assert_eq!(read_u8(pinmux, PINMUX_SDIO0_CD), PINMUX_FUNC_XGPIO);
-    assert_eq!(read_u8(pinmux, PINMUX_SDIO0_CLK), PINMUX_FUNC_SDIO0);
-    assert_eq!(read_u8(pinmux, PINMUX_SDIO0_CMD), PINMUX_FUNC_SDIO0);
-    assert_eq!(read_u8(pinmux, PINMUX_SDIO0_D3), PINMUX_FUNC_SDIO0);
-    assert_eq!(read_u8(pinmux, PINMUX_SDIO0_PWR_EN), 0x7);
-    assert_eq!(read_u8(pinmux, IO_SDIO0_CMD) & IO_PULL_UP, IO_PULL_UP);
-    assert_eq!(read_u8(pinmux, IO_SDIO0_CMD) & IO_PULL_DOWN, 0);
-    assert_eq!(
-        read_u32(core.base(), CVI_PHY_TX_RX_DLY),
-        PHY_TX_RX_DLY_DS_HS
-    );
-    assert_eq!(read_u32(core.base(), CVI_PHY_CONFIG), PHY_CONFIG_DS_HS);
-    assert_eq!(
-        read_u32(core.base(), CVI_VENDOR_MSHC_CTRL) & MSHC_CTRL_DS_HS_BITS,
-        MSHC_CTRL_DS_HS_BITS
-    );
+    assert_eq!(registers.sdio0_cd_mux.get(), PINMUX_FUNC_XGPIO);
+    assert_eq!(registers.sdio0_clk_mux.get(), PINMUX_FUNC_SDIO0);
+    assert_eq!(registers.sdio0_cmd_mux.get(), PINMUX_FUNC_SDIO0);
+    assert_eq!(registers.sdio0_d3_mux.get(), PINMUX_FUNC_SDIO0);
+    assert_eq!(registers.sdio0_power_enable_mux.get(), 0x7);
+    assert!(registers.sdio0_cmd_pull.is_set(PAD_PULL::UP));
+    assert!(!registers.sdio0_cmd_pull.is_set(PAD_PULL::DOWN));
+
+    let core_registers = mmio.core_registers();
+    assert_eq!(core_registers.phy_tx_rx_dly.get(), PHY_TX_RX_DLY_DS_HS);
+    assert_eq!(core_registers.phy_config.get(), PHY_CONFIG_DS_HS);
+    assert!(core_registers.mshc_ctrl.is_set(MSHC_CTRL::DS_HS_BIT_1));
+    assert!(core_registers.mshc_ctrl.is_set(MSHC_CTRL::DS_HS_BIT_8));
+    assert!(core_registers.mshc_ctrl.is_set(MSHC_CTRL::DS_HS_BIT_9));
 }
 
 #[test]
@@ -99,13 +94,13 @@ fn power_off_switches_sd_pads_to_gpio_and_closes_power() {
 
     host.configure_sd_power_off();
 
-    let pinmux =
-        unsafe { NonNull::new_unchecked(syscon.base().as_ptr().add(SYSCON_PINMUX_OFFSET)) };
-    assert_eq!(read_u8(pinmux, PINMUX_SDIO0_CLK), PINMUX_FUNC_XGPIO);
-    assert_eq!(read_u8(pinmux, PINMUX_SDIO0_D0), PINMUX_FUNC_XGPIO);
-    assert_eq!(read_u8(pinmux, IO_SDIO0_D0) & IO_PULL_DOWN, IO_PULL_DOWN);
+    let mmio = Cv181xMmio::new(core.base(), syscon.base());
+    let registers = mmio.syscon_registers();
+    assert_eq!(registers.sdio0_clk_mux.get(), PINMUX_FUNC_XGPIO);
+    assert_eq!(registers.sdio0_d0_mux.get(), PINMUX_FUNC_XGPIO);
+    assert!(registers.sdio0_d0_pull.is_set(PAD_PULL::DOWN));
     assert_eq!(
-        read_u32(syscon.base(), TOP_SD_PWRSW_CTRL) & TOP_SD_PWRSW_LOW_MASK,
+        registers.sd_powersw_ctrl.read(TOP_SD_PWRSW_CTRL::LOW_BITS),
         TOP_SD_PWRSW_OFF
     );
 }
@@ -191,12 +186,11 @@ fn high_speed_mode_sets_host_timing_even_when_clock_is_capped() {
 
     let _ = host.set_clock_speed(ClockSpeed::HighSpeed);
 
+    let mmio = Cv181xMmio::new(core.base(), syscon.base());
+    let registers = mmio.core_registers();
+    assert!(registers.host_control1.is_set(HOST_CONTROL1::HIGH_SPEED));
     assert_eq!(
-        read_u8(core.base(), REG_HOST_CONTROL1) & HOST_CTRL1_HIGH_SPEED,
-        HOST_CTRL1_HIGH_SPEED
-    );
-    assert_eq!(
-        read_u16(core.base(), REG_HOST_CONTROL2) & HOST_CTRL2_UHS_MODE_MASK,
+        registers.host_control2.read(HOST_CONTROL2::UHS_MODE),
         HOST_CTRL2_UHS_SDR25
     );
 }


### PR DESCRIPTION
## 问题

CV181x SDHCI 的 TOP、pinmux、pad、PHY 和时钟控制仍依赖分散的寄存器偏移与裸 volatile 访问，字段边界和访问宽度不易审查。

## 修改

- 引入 `tock-registers`，定义 CV181x SDHCI 与 syscon 的类型化寄存器布局及位域。
- 将时钟、高速模式、供电、pinmux、pad pull 与 PHY 初始化改为类型化 `.modify()` / `.set()` 访问。
- 保留现有对电源、pad、PHY 与时钟语义的单元测试，并通过类型化寄存器视图断言结果。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p cv181x-sdhci`
- `cargo xtask clippy --package cv181x-sdhci`
- `cargo xtask clippy --since origin/dev`
- `python3 scripts/test/check_ci_paths.py`
- `python3 scripts/test/check_ci_routing.py`
- `cargo xtask sync-lint --since origin/dev`
- `cargo xtask spin-lint`