### PR TITLE
fix(ax-fs-ng): preserve zero-fill across cached resize

### DIFF
--- a/os/arceos/modules/axfs-ng/src/file/cache/mod.rs
+++ b/os/arceos/modules/axfs-ng/src/file/cache/mod.rs
@@ -1,6 +1,7 @@
 mod readahead;
 #[cfg(feature = "vfs")]
 mod reclaim;
+mod resize;
 mod writeback;
 
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
@@ -117,6 +118,11 @@ impl CachedFileShared {
     #[cfg(test)]
     fn listener_lock_is_free_for_test(&self) -> bool {
         self.evict_listeners.try_lock().is_some()
+    }
+
+    #[cfg(test)]
+    fn page_cache_lock_is_free_for_test(&self) -> bool {
+        self.page_cache.try_lock().is_some()
     }
 }
 
@@ -499,6 +505,16 @@ impl CachedFile {
         let end = offset.saturating_add(buf.remaining() as u64);
         let old_len = self.shared.len();
         if end > old_len {
+            if !old_len.is_multiple_of(PAGE_SIZE as u64) {
+                let page_number = (old_len / PAGE_SIZE as u64) as u32;
+                let page_start = u64::from(page_number) * PAGE_SIZE as u64;
+                self.zero_partial_page_locked(
+                    file,
+                    page_number,
+                    (old_len - page_start) as usize,
+                    (end - page_start).min(PAGE_SIZE as u64) as usize,
+                )?;
+            }
             file.set_len(end)?;
             self.shared.update_len_max(end);
         }
@@ -547,69 +563,6 @@ impl CachedFile {
         let len = self.shared.len();
         self.write_at_locked(buf, len)
             .map(|written| (written, len + written as u64))
-    }
-
-    /// Truncates or extends the file to `len` bytes.
-    pub fn set_len(&self, len: u64) -> VfsResult<()> {
-        let _io = self.shared.io_lock.lock();
-        let file = self.inner.entry().as_file()?;
-        let old_len = self.shared.len();
-        file.set_len(len)?;
-        self.shared.set_len(len);
-
-        let old_last_page = (old_len / PAGE_SIZE as u64) as u32;
-        let new_last_page = (len / PAGE_SIZE as u64) as u32;
-        if old_len < len {
-            let mut guard = self.shared.page_cache.lock();
-            if let Some(page) = guard.get_mut(&old_last_page) {
-                let page_start = old_last_page as u64 * PAGE_SIZE as u64;
-                let old_page_offset = (old_len - page_start) as usize;
-                let new_page_offset = (len - page_start).min(PAGE_SIZE as u64) as usize;
-                page.data()[old_page_offset..new_page_offset].fill(0);
-                // Mark dirty so the zeroed gap is written back: ext4 `set_len`
-                // only updates `i_size`, it does not clear the bytes on disk, so
-                // a clean eviction + reload would otherwise resurrect stale data.
-                page.dirty = true;
-            }
-        } else if len < old_len {
-            let mut guard = self.shared.page_cache.lock();
-            // Linux `truncate(len)` zeroes the tail of the partial last page, so a
-            // later extend or `mmap` reads those bytes as zero. Without this, a
-            // shrink that leaves a partial last page (e.g. sqlite's
-            // `ftruncate(<-shm>, 3)`) keeps stale bytes there; a subsequent mmap of
-            // the regrown file then sees the stale tail, so a fresh reader trusts a
-            // stale wal-index header instead of recovering (juicefs sqlite WAL
-            // cross-process reopen failure). This branch also covers shrinking
-            // within a single page, where neither old branch ran at all.
-            let tail = (len % PAGE_SIZE as u64) as usize;
-            if tail != 0
-                && let Some(page) = guard.get_mut(&new_last_page)
-            {
-                page.data()[tail..].fill(0);
-                // Mark dirty so the zeroed tail is written back: ext4 `set_len`
-                // updates `i_size` but leaves the on-disk bytes past it intact, so
-                // a clean eviction + reload (or mmap fault) would otherwise reload
-                // the stale tail from disk.
-                page.dirty = true;
-            }
-            // Remove all pages that are wholly beyond the new length.
-            // TODO(mivik): can this be more efficient?
-            let keys = guard
-                .iter()
-                .map(|(k, _)| *k)
-                .filter(|it| *it > new_last_page)
-                .collect::<Vec<_>>();
-            for pn in keys {
-                if let Some(mut page) = guard.pop(&pn)
-                    && !self.in_memory
-                {
-                    // Don't write back pages since they're discarded
-                    page.dirty = false;
-                    self.evict_cache(file, pn, &mut page)?;
-                }
-            }
-        }
-        Ok(())
     }
 
     pub fn writeback(&self) -> VfsResult<alloc::vec::Vec<u32>> {

--- a/os/arceos/modules/axfs-ng/src/file/cache/resize.rs
+++ b/os/arceos/modules/axfs-ng/src/file/cache/resize.rs
@@ -1,0 +1,292 @@
+use alloc::vec::Vec;
+
+use axfs_ng_vfs::{FileNode, VfsError, VfsResult};
+
+use super::{CachedFile, PAGE_SIZE, PageCache};
+
+struct PreparedPageWrite {
+    page_number: u32,
+    page_offset: usize,
+    generation: u64,
+    was_dirty: bool,
+    original_data: Vec<u8>,
+    zeroed_data: Vec<u8>,
+}
+
+impl CachedFile {
+    pub(super) fn zero_partial_page_locked(
+        &self,
+        file: &FileNode,
+        page_number: u32,
+        zero_start: usize,
+        zero_end: usize,
+    ) -> VfsResult<()> {
+        let mut guard = self.shared.page_cache.lock();
+        let page = self.page_or_insert(file, &mut guard, page_number, true)?.0;
+        page.data()[zero_start..zero_end].fill(0);
+        if !self.in_memory {
+            page.mark_dirty();
+        }
+        Ok(())
+    }
+
+    fn prepare_zero_write_locked(
+        &self,
+        file: &FileNode,
+        page_number: u32,
+        zero_start: usize,
+        zero_end: usize,
+        persist_end: usize,
+    ) -> VfsResult<PreparedPageWrite> {
+        let mut guard = self.shared.page_cache.lock();
+        let page = self.page_or_insert(file, &mut guard, page_number, true)?.0;
+        let was_dirty = page.dirty;
+        let original_data = page.data()[zero_start..zero_end].to_vec();
+        page.data()[zero_start..zero_end].fill(0);
+        if !self.in_memory {
+            page.mark_dirty();
+        }
+        let generation = page.dirty_generation;
+        let zeroed_data = page.data()[zero_start..persist_end].to_vec();
+        Ok(PreparedPageWrite {
+            page_number,
+            page_offset: zero_start,
+            generation,
+            was_dirty,
+            original_data,
+            zeroed_data,
+        })
+    }
+
+    fn prepared_offset(prepared: &PreparedPageWrite) -> u64 {
+        u64::from(prepared.page_number) * PAGE_SIZE as u64 + prepared.page_offset as u64
+    }
+
+    fn persist_prepared_page(
+        &self,
+        file: &FileNode,
+        prepared: &PreparedPageWrite,
+    ) -> VfsResult<()> {
+        if self.in_memory {
+            return Ok(());
+        }
+        if file.write_at(&prepared.zeroed_data, Self::prepared_offset(prepared))?
+            != prepared.zeroed_data.len()
+        {
+            return Err(VfsError::Io);
+        }
+        Ok(())
+    }
+
+    fn finish_prepared_page(&self, prepared: &PreparedPageWrite) {
+        if self.in_memory || prepared.was_dirty {
+            return;
+        }
+        let mut guard = self.shared.page_cache.lock();
+        if let Some(page) = guard.get_mut(&prepared.page_number)
+            && page.dirty
+            && page.dirty_generation == prepared.generation
+        {
+            page.dirty = false;
+        }
+    }
+
+    fn restore_prepared_cache(&self, prepared: &PreparedPageWrite, backing_restored: bool) {
+        let mut guard = self.shared.page_cache.lock();
+        if let Some(page) = guard.get_mut(&prepared.page_number)
+            && page.dirty_generation == prepared.generation
+        {
+            let end = prepared.page_offset + prepared.original_data.len();
+            page.data()[prepared.page_offset..end].copy_from_slice(&prepared.original_data);
+            page.dirty_generation = page.dirty_generation.wrapping_add(1);
+            page.dirty = prepared.was_dirty || (!self.in_memory && !backing_restored);
+        }
+    }
+
+    fn rollback_prepared_backing(&self, file: &FileNode, prepared: &PreparedPageWrite) -> bool {
+        if self.in_memory {
+            return true;
+        }
+        let original_backing_data = &prepared.original_data[..prepared.zeroed_data.len()];
+        match file.write_at(original_backing_data, Self::prepared_offset(prepared)) {
+            Ok(written) if written == original_backing_data.len() => true,
+            Ok(_) => {
+                warn!("short write while rolling back a failed cached-file resize");
+                false
+            }
+            Err(err) => {
+                warn!(
+                    "failed to restore backing data after cached-file resize error: {:?}",
+                    err
+                );
+                false
+            }
+        }
+    }
+
+    fn restore_backing_length_after_error(
+        &self,
+        file: &FileNode,
+        old_len: u64,
+        fallback_len: u64,
+    ) -> bool {
+        match file.set_len(old_len) {
+            Ok(()) => true,
+            Err(err) => {
+                warn!(
+                    "failed to restore backing length after cached-file resize error: {:?}",
+                    err
+                );
+                self.shared.set_len(file.len().unwrap_or(fallback_len));
+                false
+            }
+        }
+    }
+
+    fn take_discarded_pages_locked(&self, len: u64) -> Vec<(u32, PageCache)> {
+        let first_discarded_page = len.div_ceil(PAGE_SIZE as u64);
+        let mut guard = self.shared.page_cache.lock();
+        let keys = guard
+            .iter()
+            .map(|(page_number, _)| *page_number)
+            .filter(|page_number| u64::from(*page_number) >= first_discarded_page)
+            .collect::<Vec<_>>();
+        keys.into_iter()
+            .filter_map(|page_number| {
+                guard.pop(&page_number).map(|mut page| {
+                    // Pages wholly beyond the new EOF must never be written
+                    // back after the truncate.
+                    page.dirty = false;
+                    (page_number, page)
+                })
+            })
+            .collect()
+    }
+
+    fn notify_discarded_pages(
+        &self,
+        file: &FileNode,
+        pages: Vec<(u32, PageCache)>,
+    ) -> VfsResult<()> {
+        for (page_number, mut page) in pages {
+            self.evict_cache(file, page_number, &mut page)?;
+        }
+        Ok(())
+    }
+
+    /// Truncates or extends the file to `len` bytes.
+    pub fn set_len(&self, len: u64) -> VfsResult<()> {
+        let file = self.inner.entry().as_file()?;
+        loop {
+            let observed_len = self.shared.len();
+            let affected_page =
+                if observed_len < len && !observed_len.is_multiple_of(PAGE_SIZE as u64) {
+                    Some((observed_len / PAGE_SIZE as u64) as u32)
+                } else if len < observed_len && !len.is_multiple_of(PAGE_SIZE as u64) {
+                    Some((len / PAGE_SIZE as u64) as u32)
+                } else {
+                    None
+                };
+
+            // Revoke writable mappings before snapshotting a partial page.
+            // Callbacks may take address-space locks, so invoke them without
+            // holding the cached-I/O or page-cache locks.
+            if let Some(page_number) = affected_page {
+                self.shared
+                    .protect_dirty_pages_before_writeback(&[page_number])?;
+            }
+
+            let io = self.shared.io_lock.lock();
+            let old_len = self.shared.len();
+            if old_len != observed_len {
+                continue;
+            }
+
+            if old_len < len {
+                let prepared = if let Some(page_number) = affected_page {
+                    let page_start = u64::from(page_number) * PAGE_SIZE as u64;
+                    let old_page_offset = (old_len - page_start) as usize;
+                    let new_page_offset = (len - page_start).min(PAGE_SIZE as u64) as usize;
+                    Some(self.prepare_zero_write_locked(
+                        file,
+                        page_number,
+                        old_page_offset,
+                        PAGE_SIZE,
+                        new_page_offset,
+                    )?)
+                } else {
+                    None
+                };
+
+                if let Err(err) = file.set_len(len) {
+                    let length_restored =
+                        self.restore_backing_length_after_error(file, old_len, old_len);
+                    if length_restored && let Some(prepared) = prepared.as_ref() {
+                        self.restore_prepared_cache(prepared, true);
+                    }
+                    return Err(err);
+                }
+                if let Some(prepared) = prepared.as_ref()
+                    && let Err(err) = self.persist_prepared_page(file, prepared)
+                {
+                    if self.restore_backing_length_after_error(file, old_len, len) {
+                        self.restore_prepared_cache(prepared, true);
+                    }
+                    return Err(err);
+                }
+
+                self.shared.set_len(len);
+                if let Some(prepared) = prepared.as_ref() {
+                    self.finish_prepared_page(prepared);
+                }
+                return Ok(());
+            }
+
+            if len < old_len {
+                let prepared = if let Some(page_number) = affected_page {
+                    let page_start = u64::from(page_number) * PAGE_SIZE as u64;
+                    let old_page_len = (old_len - page_start).min(PAGE_SIZE as u64) as usize;
+                    Some(self.prepare_zero_write_locked(
+                        file,
+                        page_number,
+                        (len - page_start) as usize,
+                        PAGE_SIZE,
+                        old_page_len,
+                    )?)
+                } else {
+                    None
+                };
+
+                if let Some(prepared) = prepared.as_ref()
+                    && let Err(err) = self.persist_prepared_page(file, prepared)
+                {
+                    let restored = self.rollback_prepared_backing(file, prepared);
+                    self.restore_prepared_cache(prepared, restored);
+                    return Err(err);
+                }
+                if let Err(err) = file.set_len(len) {
+                    let length_restored =
+                        self.restore_backing_length_after_error(file, old_len, old_len);
+                    if let Some(prepared) = prepared.as_ref() {
+                        let restored = self.rollback_prepared_backing(file, prepared);
+                        self.restore_prepared_cache(prepared, length_restored && restored);
+                    }
+                    return Err(err);
+                }
+
+                self.shared.set_len(len);
+                if let Some(prepared) = prepared.as_ref() {
+                    self.finish_prepared_page(prepared);
+                }
+                let discarded = self.take_discarded_pages_locked(len);
+                drop(io);
+                self.notify_discarded_pages(file, discarded)?;
+                return Ok(());
+            }
+
+            file.set_len(len)?;
+            self.shared.set_len(len);
+            return Ok(());
+        }
+    }
+}

--- a/os/arceos/modules/axfs-ng/src/file/cache/tests.rs
+++ b/os/arceos/modules/axfs-ng/src/file/cache/tests.rs
@@ -1,8 +1,191 @@
-use alloc::{boxed::Box, sync::Arc};
-use core::sync::atomic::{AtomicBool, Ordering};
+use alloc::{boxed::Box, sync::Arc, vec, vec::Vec};
+use core::{
+    any::Any,
+    sync::atomic::{AtomicBool, Ordering},
+    task::Context,
+    time::Duration,
+};
+use std::sync::Mutex as StdMutex;
+
+use axfs_ng_vfs::{
+    DeviceId, DirEntry, FileNodeOps, Filesystem, FilesystemOps, FsIoEvents, FsPollable, Metadata,
+    MetadataUpdate, Mountpoint, NodeFlags, NodeOps, NodePermission, NodeType, Reference, StatFs,
+};
 
 use super::*;
 use crate::os::memory::test_support::with_test_page_provider;
+
+struct CacheTestFilesystem;
+
+static CACHE_TEST_FILESYSTEM: CacheTestFilesystem = CacheTestFilesystem;
+
+impl FilesystemOps for CacheTestFilesystem {
+    fn name(&self) -> &str {
+        "cache-test"
+    }
+
+    fn root_dir(&self) -> DirEntry {
+        let backing = Arc::new(CacheTestFile::new(Vec::new()));
+        DirEntry::new_file(
+            FileNode::new(backing),
+            NodeType::RegularFile,
+            Reference::root(),
+        )
+    }
+
+    fn stat(&self) -> VfsResult<StatFs> {
+        Err(VfsError::InvalidInput)
+    }
+}
+
+struct CacheTestFileState {
+    logical_len: usize,
+    physical_data: Vec<u8>,
+}
+
+struct CacheTestFile {
+    state: StdMutex<CacheTestFileState>,
+    fail_next_set_len: AtomicBool,
+    fail_next_write: AtomicBool,
+}
+
+impl CacheTestFile {
+    fn new(physical_data: Vec<u8>) -> Self {
+        let logical_len = physical_data.len();
+        Self {
+            state: StdMutex::new(CacheTestFileState {
+                logical_len,
+                physical_data,
+            }),
+            fail_next_set_len: AtomicBool::new(false),
+            fail_next_write: AtomicBool::new(false),
+        }
+    }
+
+    fn fail_next_set_len(&self) {
+        self.fail_next_set_len.store(true, Ordering::Release);
+    }
+
+    fn fail_next_write(&self) {
+        self.fail_next_write.store(true, Ordering::Release);
+    }
+}
+
+impl NodeOps for CacheTestFile {
+    fn inode(&self) -> u64 {
+        1
+    }
+
+    fn metadata(&self) -> VfsResult<Metadata> {
+        let state = self.state.lock().unwrap();
+        Ok(Metadata {
+            device: 1,
+            inode: self.inode(),
+            nlink: 1,
+            mode: NodePermission::default(),
+            node_type: NodeType::RegularFile,
+            uid: 0,
+            gid: 0,
+            size: state.logical_len as u64,
+            block_size: PAGE_SIZE as u64,
+            blocks: state.physical_data.len().div_ceil(512) as u64,
+            rdev: DeviceId::default(),
+            atime: Duration::ZERO,
+            mtime: Duration::ZERO,
+            ctime: Duration::ZERO,
+        })
+    }
+
+    fn update_metadata(&self, _update: MetadataUpdate) -> VfsResult<()> {
+        Ok(())
+    }
+
+    fn filesystem(&self) -> &dyn FilesystemOps {
+        &CACHE_TEST_FILESYSTEM
+    }
+
+    fn sync(&self, _data_only: bool) -> VfsResult<()> {
+        Ok(())
+    }
+
+    fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
+    }
+
+    fn flags(&self) -> NodeFlags {
+        NodeFlags::empty()
+    }
+}
+
+impl FsPollable for CacheTestFile {
+    fn poll(&self) -> FsIoEvents {
+        FsIoEvents::IN | FsIoEvents::OUT
+    }
+
+    fn register(&self, _context: &mut Context<'_>, _events: FsIoEvents) {}
+}
+
+impl FileNodeOps for CacheTestFile {
+    fn read_at(&self, buf: &mut [u8], offset: u64) -> VfsResult<usize> {
+        let offset = usize::try_from(offset).map_err(|_| VfsError::InvalidInput)?;
+        let state = self.state.lock().unwrap();
+        let read_len = buf.len().min(state.logical_len.saturating_sub(offset));
+        buf[..read_len].fill(0);
+        if offset < state.physical_data.len() {
+            let physical_len = read_len.min(state.physical_data.len() - offset);
+            buf[..physical_len]
+                .copy_from_slice(&state.physical_data[offset..offset + physical_len]);
+        }
+        Ok(read_len)
+    }
+
+    fn write_at(&self, buf: &[u8], offset: u64) -> VfsResult<usize> {
+        if self.fail_next_write.swap(false, Ordering::AcqRel) {
+            return Err(VfsError::Io);
+        }
+        let offset = usize::try_from(offset).map_err(|_| VfsError::InvalidInput)?;
+        let end = offset
+            .checked_add(buf.len())
+            .ok_or(VfsError::InvalidInput)?;
+        let mut state = self.state.lock().unwrap();
+        if state.physical_data.len() < end {
+            state.physical_data.resize(end, 0);
+        }
+        state.physical_data[offset..end].copy_from_slice(buf);
+        state.logical_len = state.logical_len.max(end);
+        Ok(buf.len())
+    }
+
+    fn append(&self, buf: &[u8]) -> VfsResult<(usize, u64)> {
+        let offset = self.state.lock().unwrap().logical_len;
+        let written = self.write_at(buf, offset as u64)?;
+        Ok((written, (offset + written) as u64))
+    }
+
+    fn set_len(&self, len: u64) -> VfsResult<()> {
+        if self.fail_next_set_len.swap(false, Ordering::AcqRel) {
+            return Err(VfsError::Io);
+        }
+        self.state.lock().unwrap().logical_len =
+            usize::try_from(len).map_err(|_| VfsError::InvalidInput)?;
+        Ok(())
+    }
+
+    fn set_symlink(&self, _target: &str) -> VfsResult<()> {
+        Err(VfsError::InvalidInput)
+    }
+}
+
+fn reopen_cached_file(backing: Arc<CacheTestFile>) -> CachedFile {
+    let entry = DirEntry::new_file(
+        FileNode::new(backing),
+        NodeType::RegularFile,
+        Reference::root(),
+    );
+    let filesystem = Filesystem::new(Arc::new(CacheTestFilesystem));
+    let mountpoint = Mountpoint::new_root(&filesystem);
+    CachedFile::get_or_create(Location::new(mountpoint, entry)).unwrap()
+}
 
 #[test]
 fn page_cache_paddr_reports_bad_state_when_translation_is_missing() {
@@ -91,4 +274,135 @@ fn writeback_protect_does_not_hold_listener_lock_while_invoking_callbacks() {
     shared.protect_dirty_pages_before_writeback(&[0]).unwrap();
 
     assert!(observed_unlocked.load(Ordering::Acquire));
+}
+
+#[test]
+fn truncate_cache_miss_does_not_expose_stale_tail_after_reopen_and_extend() {
+    with_test_page_provider(true, |_| {
+        let backing = Arc::new(CacheTestFile::new(Vec::new()));
+        let cached = reopen_cached_file(backing.clone());
+        let nonzero = vec![0xa5; PAGE_SIZE];
+        assert_eq!(cached.write_at(nonzero.as_slice(), 0).unwrap(), PAGE_SIZE);
+        cached.writeback().unwrap();
+        drop(cached);
+
+        let reopened = reopen_cached_file(backing.clone());
+        let truncated_len = PAGE_SIZE / 2;
+        reopened.set_len(truncated_len as u64).unwrap();
+        reopened.set_len(PAGE_SIZE as u64).unwrap();
+        drop(reopened);
+
+        let reopened = reopen_cached_file(backing);
+        let mut tail = vec![0xff; PAGE_SIZE - truncated_len];
+        assert_eq!(
+            reopened
+                .read_at(tail.as_mut_slice(), truncated_len as u64)
+                .unwrap(),
+            tail.len()
+        );
+        assert!(tail.iter().all(|byte| *byte == 0));
+    });
+}
+
+#[test]
+fn extending_write_cache_miss_zeroes_gap_before_write_offset() {
+    with_test_page_provider(true, |_| {
+        let backing = Arc::new(CacheTestFile::new(vec![0xa5; PAGE_SIZE]));
+        let old_len = PAGE_SIZE / 2;
+        backing.set_len(old_len as u64).unwrap();
+
+        let cached = reopen_cached_file(backing.clone());
+        let write_offset = PAGE_SIZE * 3 / 4;
+        assert_eq!(
+            cached.write_at(&[0x5a][..], write_offset as u64).unwrap(),
+            1
+        );
+        cached.writeback().unwrap();
+        drop(cached);
+
+        let reopened = reopen_cached_file(backing);
+        let mut gap_and_byte = vec![0xff; write_offset + 1 - old_len];
+        assert_eq!(
+            reopened
+                .read_at(gap_and_byte.as_mut_slice(), old_len as u64)
+                .unwrap(),
+            gap_and_byte.len()
+        );
+        assert!(
+            gap_and_byte[..gap_and_byte.len() - 1]
+                .iter()
+                .all(|byte| *byte == 0)
+        );
+        assert_eq!(gap_and_byte.last(), Some(&0x5a));
+    });
+}
+
+#[test]
+fn failed_shrink_restores_cached_and_backing_tail() {
+    with_test_page_provider(true, |_| {
+        let backing = Arc::new(CacheTestFile::new(vec![0xa5; PAGE_SIZE]));
+        let cached = reopen_cached_file(backing.clone());
+        backing.fail_next_set_len();
+
+        assert_eq!(cached.set_len((PAGE_SIZE / 2) as u64), Err(VfsError::Io));
+        assert_eq!(cached.len(), PAGE_SIZE as u64);
+        let mut tail = vec![0; PAGE_SIZE / 2];
+        assert_eq!(
+            cached
+                .read_at(tail.as_mut_slice(), (PAGE_SIZE / 2) as u64)
+                .unwrap(),
+            tail.len()
+        );
+        assert!(tail.iter().all(|byte| *byte == 0xa5));
+        drop(cached);
+
+        let reopened = reopen_cached_file(backing);
+        tail.fill(0);
+        assert_eq!(
+            reopened
+                .read_at(tail.as_mut_slice(), (PAGE_SIZE / 2) as u64)
+                .unwrap(),
+            tail.len()
+        );
+        assert!(tail.iter().all(|byte| *byte == 0xa5));
+    });
+}
+
+#[test]
+fn failed_extension_zero_write_rolls_back_backing_length() {
+    with_test_page_provider(true, |_| {
+        let backing = Arc::new(CacheTestFile::new(vec![0xa5; PAGE_SIZE]));
+        let old_len = PAGE_SIZE / 2;
+        backing.set_len(old_len as u64).unwrap();
+        let cached = reopen_cached_file(backing.clone());
+        backing.fail_next_write();
+
+        assert_eq!(cached.set_len(PAGE_SIZE as u64), Err(VfsError::Io));
+        assert_eq!(cached.len(), old_len as u64);
+        assert_eq!(backing.metadata().unwrap().size, old_len as u64);
+    });
+}
+
+#[test]
+fn truncate_notifies_discard_listeners_without_cached_file_locks() {
+    with_test_page_provider(true, |_| {
+        let backing = Arc::new(CacheTestFile::new(vec![0; PAGE_SIZE * 2]));
+        let cached = reopen_cached_file(backing);
+        cached.with_page_or_insert(1, |_, _| Ok(())).unwrap();
+
+        let observed_unlocked = Arc::new(AtomicBool::new(false));
+        let observed = observed_unlocked.clone();
+        let shared = cached.shared.clone();
+        cached.add_evict_listener(move |page_number, _| {
+            assert_eq!(page_number, 1);
+            observed.store(
+                shared.io_lock_is_free_for_test() && shared.page_cache_lock_is_free_for_test(),
+                Ordering::Release,
+            );
+            true
+        });
+
+        cached.set_len(PAGE_SIZE as u64).unwrap();
+        assert!(observed_unlocked.load(Ordering::Acquire));
+    });
 }

--- a/os/arceos/modules/axfs-ng/src/file/handle.rs
+++ b/os/arceos/modules/axfs-ng/src/file/handle.rs
@@ -274,6 +274,11 @@ impl File {
         self.access(FileFlags::WRITE)?.write_at(src, offset)
     }
 
+    /// Truncates or extends the file to `len` bytes.
+    pub fn set_len(&self, len: u64) -> VfsResult<()> {
+        self.access(FileFlags::WRITE)?.set_len(len)
+    }
+
     /// Attempts to sync OS-internal file content and metadata to disk.
     ///
     /// If `data_only` is `true`, only the file data is synced, not the

--- a/os/arceos/modules/axfs-ng/src/fops.rs
+++ b/os/arceos/modules/axfs-ng/src/fops.rs
@@ -175,7 +175,7 @@ impl File {
     }
 
     pub fn truncate(&self, size: u64) -> AxResult {
-        self.inner.location().entry().as_file()?.set_len(size)?;
+        self.inner.set_len(size)?;
         Ok(())
     }
 

--- a/os/arceos/modules/axfs-ng/src/os/memory.rs
+++ b/os/arceos/modules/axfs-ng/src/os/memory.rs
@@ -65,7 +65,11 @@ pub fn has_page_provider() -> bool {
 #[cfg(test)]
 pub mod test_support {
     use core::sync::atomic::AtomicUsize;
-    use std::sync::Mutex;
+    use std::{
+        alloc::{Layout, alloc_zeroed, dealloc},
+        ptr::NonNull,
+        sync::Mutex,
+    };
 
     use super::*;
 
@@ -101,11 +105,20 @@ pub mod test_support {
 
     impl FsPageProvider for TestPageProvider {
         fn alloc_page(&self) -> VfsResult<FsPage> {
+            let layout = Layout::from_size_align(PAGE_SIZE, PAGE_SIZE).unwrap();
+            // SAFETY: `layout` has non-zero size and page alignment. The
+            // returned allocation is owned by `FsPage` and released with the
+            // identical layout in `dealloc_page`.
+            let page = NonNull::new(unsafe { alloc_zeroed(layout) }).ok_or(VfsError::NoMemory)?;
             self.alloc_count.fetch_add(1, Ordering::AcqRel);
-            Ok(unsafe { FsPage::from_raw(0x1000) })
+            Ok(unsafe { FsPage::from_raw(page.as_ptr() as usize) })
         }
 
-        fn dealloc_page(&self, _page: FsPage) {
+        fn dealloc_page(&self, page: FsPage) {
+            let layout = Layout::from_size_align(PAGE_SIZE, PAGE_SIZE).unwrap();
+            // SAFETY: `page` was allocated by `alloc_page` with this exact
+            // layout and is transferred here exactly once by `FsPage::drop`.
+            unsafe { dealloc(page.as_mut_ptr(), layout) };
             self.dealloc_count.fetch_add(1, Ordering::AcqRel);
         }
 
@@ -123,7 +136,9 @@ pub mod test_support {
         translate: bool,
         f: impl FnOnce(&TestPageProvider) -> R,
     ) -> R {
-        let _guard = TEST_PAGE_PROVIDER_LOCK.lock().unwrap();
+        let _guard = TEST_PAGE_PROVIDER_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
         install_page_provider(&TEST_PAGE_PROVIDER);
         TEST_PAGE_PROVIDER.reset(translate);
         let result = f(&TEST_PAGE_PROVIDER);
@@ -140,8 +155,9 @@ mod tests {
     fn page_provider_allocates_and_deallocates_pages() {
         with_test_page_provider(true, |provider| {
             let page = alloc_page().unwrap();
-            assert_eq!(page.addr(), 0x1000);
-            assert_eq!(virt_to_phys(page.addr()), Some(0x1000_1000));
+            assert_ne!(page.addr(), 0);
+            assert_eq!(page.addr() % PAGE_SIZE, 0);
+            assert_eq!(virt_to_phys(page.addr()), Some(page.addr() + 0x1000_0000));
             dealloc_page(page);
             assert_eq!(provider.alloc_count(), 1);
             assert_eq!(provider.dealloc_count(), 1);


### PR DESCRIPTION
## 问题

这是对已合并 #1768 中遗留 review 问题的后续修复。`CachedFile::set_len` 过去只在受影响页已驻留缓存时清零；缓存未命中时先修改 backing EOF，页内截短后再扩容或重开可能重新读出旧 EOF 后的非零字节。相同顺序还会让跨 EOF 的定位写入把旧物理字节带入写入起点前的空洞。

此外，公开 `File::truncate` 绕过了 `FileBackend`，会让生产调用直接进入底层 inode；整页丢弃也在持有 cached I/O/page-cache 锁时调用 eviction listener。

## 修改

- 将 resize 状态转换拆到 `file/cache/resize.rs`，在旧 EOF 下物化受影响的部分页并清零完整页尾。
- 缩小时在旧 EOF 仍有效时持久化零区间，再更新长度；扩展时在新长度可见后持久化新零区间。只写受影响区间，不重写整页。
- 为 backing write/resize 失败增加回滚：恢复原长度、原缓存数据与原 backing 尾部；回滚本身失败时保持页为 dirty，并按 backing 可观测长度同步缓存长度。
- 跨 EOF 写入也先物化旧末页，保证写入起点前的空洞为零。
- `File::truncate` 改经 `handle::File::set_len -> FileBackend::set_len`，保留缓存与写权限检查。
- 整页淘汰改为锁内摘链、锁外通知 mmap/eviction listener。
- 测试页提供器改用真实页对齐内存，以支持实际读写 page-cache 内容。

## 回归证据

新增确定性用例在修复前分别复现：

- 写入非零数据、重开造成 cache miss、页内截短、扩回原长、再次重开后读到旧字节；
- 跨 EOF 定位写入后，空洞读到旧字节；
- shrink 的 `set_len` 失败后缓存/backing 尾部已被错误清零；
- extension 零区写入失败后 backing 长度未回滚。

修复后上述用例全部通过，并增加 eviction listener 回调时不持有 cached I/O/page-cache 锁的断言。

## 验证

- `cargo fmt --all --check`
- `cargo test -p ax-fs-ng --features ext4,vfs --lib`：65 passed
- `cargo xtask clippy --package ax-fs-ng`：6/6 feature checks passed
- `git diff --check`

未修改 crate 版本号。