### PR TITLE
fix(axvm): enable host capabilities in tests

### DIFF
--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -85,3 +85,8 @@ arm_vgic = { workspace = true, features = ["vgicv3"] }
 arm-gic-driver = { workspace = true, features = ["rdif"] }
 rdif-intc.workspace = true
 rdrive.workspace = true
+
+[dev-dependencies]
+ax-hal = { workspace = true, features = ["host-test"] }
+ax-kernel-guard = { workspace = true, features = ["host-test"] }
+ax-kspin = { workspace = true, features = ["host-test"] }


### PR DESCRIPTION
## 问题

当前 `dev` 上执行 `cargo test -p axvm --no-run` 时，AxVM 的 host test 依赖图没有启用内核组件已有的 host-test capability。测试二进制因此会链接到 bare-metal 实现，并稳定缺少以下链接符号：

- `STACK_SIZE`
- `PAGE_SIZE`
- `__PERCPU_TEMPLATE_ALIGN_START`
- `__PERCPU_TEMPLATE_ALIGN_END`

该修复从 #1775 的提交 `b5db5eacb2420f212f4d6525c23e054e54c7664e` 中独立提取。

## 修改

在 `virtualization/axvm/Cargo.toml` 的 `[dev-dependencies]` 中为以下既有 workspace 依赖启用 `host-test`：

- `ax-hal`
- `ax-kernel-guard`
- `ax-kspin`

## 实现逻辑

这些 crate 已经拥有专门的 `host-test` capability。通过 Cargo 的 dev-dependency feature unification，AxVM 的 unit/integration test 目标会复用对应的 host 实现，而正常 AxVM 依赖和生产构建不会启用这些 feature。

这避免了在 AxVM 中复制 `PAGE_SIZE`、`STACK_SIZE` 和 percpu section 的 linker-script 定义，也让测试能力继续由拥有这些边界的 crate 维护。

开放 PR #1716 处理了相同的 AxVM 链接症状及另一个 ax-net 链接问题，但采用为每个 package 新增 linker script 的方案。本 PR 只处理 AxVM，并复用现有 host-test feature；若本 PR 合入，#1716 的 AxVM 部分不再需要，ax-net 部分仍可独立处理。

## 验证

红灯（未修复的 `dev`）：

```text
$ cargo test -p axvm --no-run
error: undefined symbol: STACK_SIZE
error: undefined symbol: PAGE_SIZE
error: undefined symbol: __PERCPU_TEMPLATE_ALIGN_START
error: undefined symbol: __PERCPU_TEMPLATE_ALIGN_END
```

绿灯：

```text
$ cargo test -p axvm --no-run
Finished `test` profile

$ cargo test -p axvm
118 unit tests passed
18 architecture contract tests passed
4 error contract tests passed

$ cargo xtask clippy --package axvm
6/6 checks passed

$ cargo fmt --all
```

本次只修正 host test 的 Cargo feature 解析，不改变 AxVM 运行时、虚拟化 ABI、应用或 QEMU 行为，因此无需新增运行时/QEMU 用例。
