### PR TITLE
fix(someboot): clamp x86 LAPIC timer delta

### DIFF
--- a/platforms/someboot/src/arch/x86_64/trap.rs
+++ b/platforms/someboot/src/arch/x86_64/trap.rs
@@ -33,6 +33,7 @@ const LAPIC_BASE_MASK: u64 = 0xffff_f000;
 const IA32_APIC_BASE_ENABLE: u64 = 1 << 11;
 const IA32_APIC_BASE_X2APIC_ENABLE: u64 = 1 << 10;
 const LAPIC_TIMER_DIVIDE_BY_16: u32 = 0b0011;
+const LAPIC_TIMER_MIN_DELTA_TICKS: u32 = 0x0f;
 const IA32_X2APIC_EOI: u32 = 0x80b;
 const IA32_X2APIC_SIVR: u32 = 0x80f;
 const IA32_X2APIC_LVT_TIMER: u32 = 0x832;
@@ -126,12 +127,12 @@ pub fn timer_set_deadline_in_ticks(ticks: usize) {
     ensure_lapic_ready();
     if has_tsc_deadline() {
         let now = ticks_now();
-        let deadline = now.saturating_add(ticks.max(1) as u64);
+        let deadline = now.saturating_add(ticks.max(LAPIC_TIMER_MIN_DELTA_TICKS as usize) as u64);
         unsafe {
             wrmsr(msr::IA32_TSC_DEADLINE, deadline);
         }
     } else {
-        let counts = ticks_to_apic_counts(ticks.max(1) as u64);
+        let counts = ticks_to_apic_counts(ticks.max(LAPIC_TIMER_MIN_DELTA_TICKS as usize) as u64);
         write_lapic_reg(LAPIC_REG_TIMER_INIT_COUNT, counts);
     }
 }
@@ -435,7 +436,7 @@ fn ticks_to_apic_counts(ticks: u64) -> u32 {
     let q32 = APIC_COUNTS_PER_TSC_Q32.load(Ordering::Acquire);
     let q32 = if q32 == 0 { 1u64 << 32 } else { q32 };
     let counts = ((ticks as u128 * q32 as u128) >> 32).max(1);
-    counts.min(u32::MAX as u128) as u32
+    counts.clamp(LAPIC_TIMER_MIN_DELTA_TICKS as u128, u32::MAX as u128) as u32
 }
 
 fn read_lapic_reg(offset: u32) -> u32 {
@@ -661,4 +662,14 @@ pub(crate) fn trap_msr_and_efer_constants_hold_for_test() -> bool {
     assert!(IA32_EFER_NXE == (1 << 11));
 
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ticks_to_apic_counts;
+
+    #[test]
+    fn legacy_lapic_clamps_overdue_events_to_the_device_minimum() {
+        assert_eq!(ticks_to_apic_counts(1), 0x0f);
+    }
 }


### PR DESCRIPTION
## 问题

x86 someboot 在为已过期或被舍入为极小值的时钟事件编程时，会把 `1` tick 直接传给 TSC-deadline 或 legacy LAPIC 计数器。LAPIC 时钟事件需要保留最小 delta；Linux x86 的对应配置使用 `0xF`。

## 修改

- 定义 LAPIC 定时器的最小 delta（`0x0f`）。
- 在 TSC-deadline 和 legacy LAPIC 初始计数两条路径统一钳制请求值。
- 在计数换算后再次钳制，避免校准比例把非零请求向下舍入到设备最小值以下。
- 增加 host 单元回归：未修复时 `ticks_to_apic_counts(1)` 返回 `1`，修复后返回 `15`。

## 提取范围

仅提取 #1775 中提交 `6a138fb40beaa7883d6ff6cbcb3ee5624adc206a` 的 someboot x86 LAPIC 最小间隔修复；不包含该提交其余的时钟事件框架改造。已检查当前开放 PR，没有发现同一 someboot LAPIC 修复的重复实现。

## 验证

- `cargo test -p someboot --lib legacy_lapic_clamps_overdue_events_to_the_device_minimum`：先红（`1 != 15`），修复后绿。
- `cargo fmt --all -- --check`
- `cargo xtask clippy --package someboot`（8/8 checks passed）
- `cargo xtask arceos test qemu --test-group rust --target x86_64-unknown-none --test-case task-sleep`（1/1 passed）

未运行物理板或自托管测试。
