### PR TITLE
fix(cpu-local): guard uninstalled host CPU areas

### DIFF
--- a/components/cpu-local/src/register/host.rs
+++ b/components/cpu-local/src/register/host.rs
@@ -32,7 +32,11 @@ pub(super) unsafe fn read_current_thread(_area_base: usize) -> usize {
     // Host tests execute on x86_64, whose current pointer is the GS runtime
     // anchor itself. Read the live modeled CPU, rather than a previously
     // sampled base, so tests can reproduce migration between the two reads.
-    unsafe { area_runtime_anchor(CPU_BASE.get()) }.current_thread_raw()
+    let area_base = CPU_BASE.get();
+    if area_base == 0 {
+        return 0;
+    }
+    unsafe { area_runtime_anchor(area_base) }.current_thread_raw()
 }
 
 pub(super) unsafe fn write_current_thread(_value: usize) {}

--- a/components/cpu-local/src/register/mod.rs
+++ b/components/cpu-local/src/register/mod.rs
@@ -179,12 +179,17 @@ mod tests {
 
     #[test]
     fn scheduler_current_thread_rejects_an_uninstalled_host_area() {
-        let rejected = std::thread::spawn(|| {
+        #[cfg(feature = "tls")]
+        let expected_error = CpuLocalError::AreaNotInstalled;
+        #[cfg(not(feature = "tls"))]
+        let expected_error = CpuLocalError::CurrentThreadMismatch;
+
+        let rejected = std::thread::spawn(move || {
             // SAFETY: the fresh host thread has no installed CPU area, so no
             // scheduler-owned pointer can be returned.
             matches!(
                 unsafe { scheduler_current_thread() },
-                Err(CpuLocalError::CurrentThreadMismatch)
+                Err(error) if error == expected_error
             )
         })
         .join()

--- a/components/cpu-local/src/register/mod.rs
+++ b/components/cpu-local/src/register/mod.rs
@@ -176,6 +176,22 @@ mod tests {
             Ok(NonNull::from(second_boot)),
         );
     }
+
+    #[test]
+    fn scheduler_current_thread_rejects_an_uninstalled_host_area() {
+        let rejected = std::thread::spawn(|| {
+            // SAFETY: the fresh host thread has no installed CPU area, so no
+            // scheduler-owned pointer can be returned.
+            matches!(
+                unsafe { scheduler_current_thread() },
+                Err(CpuLocalError::CurrentThreadMismatch)
+            )
+        })
+        .join()
+        .expect("host current-thread probe panicked");
+
+        assert!(rejected);
+    }
 }
 
 /// Binds and publishes the first scheduler task on an offline CPU.


### PR DESCRIPTION
## 问题

host-test 使用线程局部 CPU area 模型。新建宿主线程尚未安装 CPU area 时，旧实现会读取地址零对应的运行时锚点，导致空指针解引用和 `SIGSEGV`，而不是返回类型化错误。

review 还发现新增回归只按 LinuxCurrent 模型断言 `CurrentThreadMismatch`；在 `tls` 特性下，查找会先验证 CPU area，正确错误是 `AreaNotInstalled`，从而使 `host-test,tls` 组合失败。

## 修改

- 在 host register 后端读取当前线程前显式检查 CPU area 基址；未安装时返回零值，LinuxCurrent 路径由现有上层校验转换为 `CpuLocalError::CurrentThreadMismatch`。
- 保持新 host 线程的真实启动前回归路径，并按寄存器所有权模型断言错误：LinuxCurrent 为 `CurrentThreadMismatch`，UnikernelTls 为 `AreaNotInstalled`。

这保留已安装 CPU area 的迁移读取逻辑，并让两个 feature 路径都验证实际实现的错误边界。

## 验证

- 原始修复前：`cargo test -p cpu-local --features host-test scheduler_current_thread_rejects_an_uninstalled_host_area` 以 `SIGSEGV` 失败。
- 本次 review 修复前：`cargo test -p cpu-local --features host-test,tls` 有 1 项失败，因为该用例错误地期待 `CurrentThreadMismatch`。
- 修复后：`cargo test -p cpu-local --features host-test,tls` 与 `cargo test -p cpu-local --features host-test` 均通过（各 7 个 unit tests 和 26 个 contract/doc tests）。
- `cargo xtask clippy --package cpu-local`（3/3 检查通过）。
- `cargo fmt --all --check`
- `git diff --check`
