### PR TITLE
fix(starry-task): publish SIGKILL before ptrace release

### DIFF
--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -8,6 +8,7 @@ mod process_identity;
 mod resources;
 mod seccomp;
 mod signal;
+mod signal_publication;
 mod stat;
 mod timer;
 mod user;

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -17,7 +17,7 @@ use starry_vm::vm_read_slice;
 
 use super::{
     AsThread, ProcessData, Thread, do_exit, get_process_data, get_process_group, get_task,
-    is_zombie_pid,
+    is_zombie_pid, signal_publication::publish_before_release,
 };
 
 /// Information needed to restart a syscall if SA_RESTART applies.
@@ -561,7 +561,6 @@ pub fn send_signal_to_process(pid: Pid, sig: Option<SignalInfo>) -> AxResult<()>
             Signo::SIGCONT if proc_data.set_job_continued() => {
                 notify_parent_job_change(&proc_data, CLD_CONTINUED as i32, Signo::SIGCONT as i32);
             }
-            Signo::SIGKILL => proc_data.clear_job_stop_for_kill(),
             _ => {}
         }
     }
@@ -569,36 +568,17 @@ pub fn send_signal_to_process(pid: Pid, sig: Option<SignalInfo>) -> AxResult<()>
     if let Some(sig) = sig {
         let signo = sig.signo();
         info!("Send signal {signo:?} to process {pid}");
-        if signo == Signo::SIGKILL && proc_data.ptrace_stop_signo().is_some() {
-            proc_data.clear_ptrace_stop();
-        }
-        if let Some(tid) = proc_data.signal.send_signal(sig) {
-            // A thread was found that doesn't have the signal blocked.
-            // Mark it interrupted so blocking syscalls wrapped by
-            // `future::interruptible` can return EINTR promptly.
-            if let Ok(task) = get_task(tid) {
-                task.interrupt();
-            }
-        } else {
-            // All threads have this signal blocked — the signal is now pending
-            // at the process level.  Only wake threads that are sleeping
-            // in rt_sigtimedwait/sigwaitinfo waiting for this specific signal:
-            // those are the only threads that can dequeue a blocked signal.
-            // Waking other threads (e.g. ones blocked in waitpid) would cause
-            // spurious EINTR.
-            for tid in proc_data.proc.threads() {
-                if let Ok(task) = get_task(tid)
-                    && task
-                        .as_thread()
-                        .signal
-                        .sigwait_set
-                        .lock()
-                        .is_some_and(|s| s.has(signo))
-                {
-                    ax_task::wake_task(&task);
+        let ptrace_stop_tid = (signo == Signo::SIGKILL)
+            .then(|| proc_data.selected_ptrace_stop_tid())
+            .flatten();
+        let _wake_tid = publish_before_release(
+            || publish_process_signal(&proc_data, sig, ptrace_stop_tid),
+            || {
+                if signo == Signo::SIGKILL {
+                    proc_data.clear_job_stop_for_kill();
                 }
-            }
-        }
+            },
+        );
         // Wake signalfd waiters on every thread: even blocked process-level
         // signals must be visible from signalfd in an epoll event loop.
         for tid in proc_data.proc.threads() {
@@ -611,6 +591,48 @@ pub fn send_signal_to_process(pid: Pid, sig: Option<SignalInfo>) -> AxResult<()>
     }
 
     Ok(())
+}
+
+fn publish_process_signal(
+    proc_data: &ProcessData,
+    sig: SignalInfo,
+    ptrace_stop_tid: Option<u32>,
+) -> Option<u32> {
+    let signo = sig.signo();
+    let wake_tid = proc_data.signal.send_signal(sig);
+    if let Some(tid) = wake_tid
+        && let Ok(task) = get_task(tid)
+    {
+        // The pending signal is visible before the direct scheduler wake.
+        task.interrupt();
+    }
+    if let Some(tid) = ptrace_stop_tid
+        && Some(tid) != wake_tid
+        && let Ok(task) = get_task(tid)
+    {
+        // A fatal signal must abort the exact traced thread even when the
+        // process signal manager selected an unblocked sibling.
+        task.interrupt();
+    }
+    if wake_tid.is_none() {
+        // All threads have this signal blocked — the signal is now pending at
+        // the process level. Only wake threads that are sleeping in
+        // rt_sigtimedwait/sigwaitinfo for this signal; waking unrelated
+        // waitpid callers would cause spurious EINTR.
+        for tid in proc_data.proc.threads() {
+            if let Ok(task) = get_task(tid)
+                && task
+                    .as_thread()
+                    .signal
+                    .sigwait_set
+                    .lock()
+                    .is_some_and(|set| set.has(signo))
+            {
+                ax_task::wake_task(&task);
+            }
+        }
+    }
+    wake_tid
 }
 
 /// Sends a signal to a process group.

--- a/os/StarryOS/kernel/src/task/signal_publication.rs
+++ b/os/StarryOS/kernel/src/task/signal_publication.rs
@@ -1,0 +1,49 @@
+//! Ordering boundary between fatal-signal publication and stop-state wakeup.
+
+/// Runs signal publication and the wakeup that exposes it to the target.
+///
+/// Both operations run synchronously in task context. Keeping the ordering in
+/// one helper mirrors Linux's `siglock` invariant while Starry stores pending
+/// signals and ptrace stop records in separate owners.
+pub(crate) fn publish_before_release<T>(
+    publish: impl FnOnce() -> T,
+    release_stop: impl FnOnce(),
+) -> T {
+    let publication = publish();
+    release_stop();
+    publication
+}
+
+#[cfg(test)]
+mod tests {
+    use core::cell::Cell;
+
+    use super::publish_before_release;
+
+    #[test]
+    fn fatal_signal_publication_precedes_stop_release() {
+        let phase = Cell::new(0_u8);
+        let publication = publish_before_release(
+            || {
+                assert_eq!(
+                    phase.get(),
+                    0,
+                    "fatal signal must be published before the ptrace stop is released"
+                );
+                phase.set(1);
+                7_u8
+            },
+            || {
+                assert_eq!(
+                    phase.get(),
+                    1,
+                    "ptrace stop release must observe the fatal signal publication"
+                );
+                phase.set(2);
+            },
+        );
+
+        assert_eq!(publication, 7);
+        assert_eq!(phase.get(), 2);
+    }
+}

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -25,12 +25,24 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
             info!("Enter user space: ip={:#x}, sp={:#x}", uctx.ip(), uctx.sp());
 
             let thr = curr.as_thread();
-            if thr.proc_data.ptrace_stop_signo_for(thr.tid()).is_some() {
-                wait_existing_ptrace_stop_current(thr, &mut uctx);
-            } else if thr.tid() == thr.proc_data.proc.pid()
-                && thr.proc_data.ptrace_stop_signo().is_some()
-            {
-                let _ = ptrace_stop_current(thr, Signo::SIGSTOP, &mut uctx);
+            let resumed_from_initial_ptrace_stop =
+                if thr.proc_data.ptrace_stop_signo_for(thr.tid()).is_some() {
+                    wait_existing_ptrace_stop_current(thr, &mut uctx);
+                    true
+                } else if thr.tid() == thr.proc_data.proc.pid()
+                    && thr.proc_data.ptrace_stop_signo().is_some()
+                {
+                    let _ = ptrace_stop_current(thr, Signo::SIGSTOP, &mut uctx);
+                    true
+                } else {
+                    false
+                };
+            if resumed_from_initial_ptrace_stop {
+                // `block_on_user` consumes the interruption that aborted the
+                // stop. Re-scan pending signals before the first user
+                // instruction so SIGKILL cannot be replaced by a racing
+                // `_exit(0)`.
+                while check_signals(thr, &mut uctx, None, None) {}
             }
             while !thr.pending_exit() {
                 let tid = thr.tid();

--- a/test-suit/starryos/qemu/system/test-proc-status-tracerpid/src/main.c
+++ b/test-suit/starryos/qemu/system/test-proc-status-tracerpid/src/main.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 
 #include <errno.h>
+#include <sched.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -37,6 +38,67 @@ static int read_tracer_pid(pid_t tracee)
     fclose(file);
     errno = ENOENT;
     return -1;
+}
+
+static int pin_current_process_to_cpu(int cpu)
+{
+    cpu_set_t affinity;
+    CPU_ZERO(&affinity);
+    CPU_SET(cpu, &affinity);
+    return sched_setaffinity(0, sizeof(affinity), &affinity);
+}
+
+static int exercise_remote_ptrace_kill(void)
+{
+    long online_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+    if (online_cpus < 2) {
+        return 0;
+    }
+    if (pin_current_process_to_cpu(0) != 0) {
+        return fail("pin tracer to CPU 0");
+    }
+
+    /*
+     * Keep the tracee on another CPU so releasing the ptrace stop can run it
+     * concurrently with signal publication. SIGKILL must already be pending
+     * before the stop wake becomes visible; otherwise the tracee can reach its
+     * _exit(0) and publish the wrong wait status.
+     */
+    enum { REMOTE_KILL_ROUNDS = 64 };
+    for (int round = 0; round < REMOTE_KILL_ROUNDS; ++round) {
+        pid_t child = fork();
+        if (child < 0) {
+            return fail("remote ptrace fork");
+        }
+        if (child == 0) {
+            if (pin_current_process_to_cpu(1) != 0) {
+                _exit(103);
+            }
+            if (ptrace(PTRACE_TRACEME, 0, NULL, NULL) != 0) {
+                _exit(101);
+            }
+            if (kill(getpid(), SIGSTOP) != 0) {
+                _exit(102);
+            }
+            _exit(0);
+        }
+
+        int status = 0;
+        if (waitpid(child, &status, 0) != child || !WIFSTOPPED(status)
+            || WSTOPSIG(status) != SIGSTOP) {
+            printf("FAIL: remote round %d expected SIGSTOP, status=%#x\n", round, status);
+            return 1;
+        }
+        if (kill(child, SIGKILL) != 0) {
+            return fail("remote ptrace kill");
+        }
+        if (waitpid(child, &status, 0) != child || !WIFSIGNALED(status)
+            || WTERMSIG(status) != SIGKILL) {
+            printf("FAIL: remote round %d expected SIGKILL, status=%#x\n", round, status);
+            return 1;
+        }
+    }
+    return 0;
 }
 
 int main(void)
@@ -88,6 +150,9 @@ int main(void)
     if (waitpid(child, &status, 0) != child || !WIFSIGNALED(status)
         || WTERMSIG(status) != SIGKILL) {
         printf("FAIL: expected child SIGKILL, status=%#x\n", status);
+        return 1;
+    }
+    if (exercise_remote_ptrace_kill() != 0) {
         return 1;
     }
 


### PR DESCRIPTION
## 问题

当处于初始 ptrace stop 的 tracee 在另一 CPU 上收到 `SIGKILL` 时，原实现会先清除 stop 并唤醒 tracee，再把 `SIGKILL` 写入进程信号队列。被唤醒的 tracee 因而可能先执行用户态的 `_exit(0)`，使父进程观察到正常退出而不是 `SIGKILL` 终止。

该问题可在 riscv64 四核 QEMU 中复现：固定 tracer 与 tracee 到不同 CPU，未修复基线会将第 38 轮的 `SIGKILL` 报为 `status=0`。

## 修改

- 先发布进程信号，再中断被选中的信号接收线程；若 ptrace stop 所在线程不同，也显式中断该线程，使其在信号已经可见后退出 stop。
- 将 job-control 的 stop 释放放在信号发布之后，并用小的同步边界固定这一顺序。
- 从初始 ptrace stop 返回后、执行第一条用户指令前重新检查待处理信号，避免未屏蔽的 `SIGKILL` 被竞态的 `_exit(0)` 覆盖。
- 扩展 riscv64 QEMU 回归：在不同 CPU 上重复 64 次 ptrace stop + `SIGKILL`，验证每轮都得到信号终止状态。

这是从 #1775 的重构链中抽出的独立修复；不引入新的公开接口或平台能力。

## 验证

- 排序单测：先以旧顺序运行得到确定性失败，修正后通过。
- `cargo xtask starry test qemu --arch riscv64 -c qemu/test-proc-status-tracerpid`
- `cargo xtask clippy --package starry-kernel`（25/25 配置通过）
