### PR TITLE
feat(axvisor): add reproducible OVMF debug profile

### DIFF
--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -100,6 +100,16 @@ execution and then fail only on traps or vCPU exits, so it is not a valid fallba
 - For std/musl targets, derive the initial JSON from a known Rust target where possible, then minimally adjust ABI, linker, relocation model, and soft-float. A `none-softfloat` target passing does not prove musl/std ABI correctness.
 - Prefer runtime memory map data over board constants. Any early helper such as `phys_to_virt` must be valid for the phase where it is called.
 
+## AxVisor x86 Guest OVMF DEBUG Profile
+
+- Use only the tgosimages profile `qemu_x86_64_axvisor_ovmf_debug` for normal setup: EDK2 `edk2-stable202605` at `b03a21a63e3bd001f52c527e5a57feddb53a690b`, X64 DEBUG, 4 MiB, COM1 debug, Shell enabled, SMM/Secure Boot disabled.
+- The current guest firmware path loads only `OVMF_CODE.fd` (`0x37c000` bytes) at `0xffc84000..0xffffffff` and enters at `0xfffffff0`. `OVMF_VARS.fd` (`0x84000`) is an asset/reference-QEMU template; do not map it until the pflash/VARS lifecycle is implemented.
+- `os/axvisor/scripts/ovmf-profile.sh` is the setup contract. It accepts only a flat manifest of unique bare keys with single-line scalar values, then validates provenance fields, fixed addresses and sizes, single-file hashes, `VARS + CODE = combined`, feature switches, and stage markers. Reject table headers, quoted keys, arrays, inline tables, and multiline values rather than partially parsing TOML. Do not restore distribution OVMF scanning.
+- A developer CODE override requires both `AXVISOR_X86_64_UEFI_FIRMWARE` and `AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED=1`, must retain the fixed CODE size, and is diagnostic-only. Its config name contains `.unverified.` so the UEFI test-suit does not select it.
+- Every x86 UEFI guest must register `x86-com1` at `0x3f8..0x3ff`. Trace builds log device name, bus, direction, address, width, and value. Missing device resources must remain errors; never synthesize all-ones reads or ignore writes to advance OVMF.
+- Diagnose by the last ordered marker: no `SecCoreStartupWithStack(` means entry/mapping/early serial; `Platform PEIM Loaded` means PEI platform discovery; `DXE IPL Entry` or `Loading DXE CORE at` means DXE enumeration; `[BdsDxe]` means boot-source or OS handoff.
+- `ovmf-entry-vmx` and `ovmf-entry-svm` are non-gating SEC diagnostics and may pass only on the VM-qualified marker emitted after guest COM1 writes the complete SEC marker. A successful fixed-layout CODE load records a weak reference to the exact AxVM in the x86 diagnostic layer, but must not create or mutate matcher state. Activate the matcher from the first-run hook only after the VM registry contains the same instance, make repeated vCPU activation idempotent, remove matcher state at the last vCPU exit, and let reset reactivate it from the retained exact-instance qualification. Prepare/register failure and an unregistered duplicate VM ID must never create or overwrite matcher state. Non-UEFI COM1 output must not create firmware-diagnostic state. Raw serial output is not a success condition because host and guest firmware share the QEMU transcript. Full UEFI cases must use an EFI-application or guest-OS marker; `VM[1] boot success` only reports host task startup and is never a UEFI success condition.
+
 ## someboot Startup Checklist
 
 Use this order when auditing an early boot port:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,30 +688,12 @@ jobs:
           #   require_kvm: true
           #   timeout_minutes: 20
           #   command: |
-          #     sudo apt-get update
-          #     sudo apt-get install -y --no-install-recommends ovmf
-          #     UEFI_FIRMWARE=""
-          #     for candidate in \
-          #       /usr/share/OVMF/OVMF_CODE_4M.fd \
-          #       /usr/share/OVMF/OVMF_CODE.fd \
-          #       /usr/share/ovmf/OVMF.fd \
-          #       /usr/share/qemu/OVMF.fd; do
-          #       if [ -f "${candidate}" ]; then
-          #         UEFI_FIRMWARE="${candidate}"
-          #         break
-          #       fi
-          #     done
-          #     if [ -z "${UEFI_FIRMWARE}" ]; then
-          #       echo "ERROR: installed OVMF firmware image was not found under /usr/share." >&2
-          #       exit 1
-          #     fi
-          #     export AXVISOR_X86_64_UEFI_FIRMWARE="${UEFI_FIRMWARE}"
           #     cd os/axvisor
           #     ./scripts/setup_qemu.sh nimbos-uefi
           #     grep -q 'boot_protocol = "uefi"' tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml
           #     grep -q 'uefi_firmware_path = "' tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml
           #     cd ../..
-          #     cargo xtask axvisor test qemu --arch x86_64 --test-group uefi --test-case qemu-nimbos
+          #     cargo xtask axvisor test qemu --arch x86_64 --test-group uefi --test-case ovmf-entry-vmx
           #   cache_key: ""
           #   container_image: ""
           #   limit_to_owner: rcore-os

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -120,7 +120,7 @@ push 到 `main` / `dev` 时强制运行 CI 检查。非 `main` / `dev` 分支没
 | Test arceos loongarch64 qemu | `self-hosted linux qcs` | 否 | 无 | `cargo xtask arceos test qemu --arch loongarch64`；仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted x86_64(svm) | `self-hosted linux amd kvm` | 否 | 无 | `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm`；验证 SVM 宿主启动及宿主 NVMe 根文件系统写入/回读，仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted x86_64(vmx) | `self-hosted linux intel kvm` | 否 | 无 | `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx`；验证 VMX 宿主启动及宿主 NVMe 根文件系统写入/回读，仅 `rcore-os` 仓库触发 |
-| Test axvisor self-hosted x86_64(vmx) UEFI | `self-hosted linux intel kvm` | 否 | 无 | 安装/定位 OVMF，生成 nimbos UEFI VM config，并运行 `cargo xtask axvisor test qemu --arch x86_64 --test-group uefi --test-case qemu-nimbos`；仅 `rcore-os` 仓库触发 |
+| Test axvisor self-hosted x86_64(vmx) UEFI | `self-hosted linux intel kvm` | 否 | 无 | 从 tgosimages 拉取并校验固定 OVMF DEBUG profile，生成 UEFI VM config，并运行非门禁 `ovmf-entry-vmx` SEC 串口诊断；完整 NimbOS 用例等待 Guest 自有成功标记链路闭合后再启用；仅 `rcore-os` 仓库触发 |
 | Test axloader HTTP smoke | `self-hosted linux intel kvm` | 否 | 无 | 安装 `x86_64-unknown-uefi` target 与 OVMF，运行 `cargo axloader test qemu --target x86_64-unknown-uefi`；仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted board orangepi-5-plus-linux | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board orangepi-5-plus-linux`；物理板卡；仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted board orangepi-5-plus-starry | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board orangepi-5-plus-starry`；物理板卡；仅 `rcore-os` 仓库触发 |

--- a/os/axvisor/configs/vms/qemu/x86_64/arceos-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/arceos-uefi-smp1.toml
@@ -28,10 +28,10 @@ kernel_load_addr = 0x20_0000
 enable_bios = true
 # Select UEFI firmware flow instead of the legacy axvm-bios multiboot trampoline.
 boot_protocol = "uefi"
-# The file path of the UEFI firmware image, for example OVMF_CODE.fd.
+# Fixed qemu_x86_64_axvisor_ovmf_debug OVMF CODE image.
 uefi_firmware_path = "/guest/arceos/OVMF_CODE.fd"
-# Load the UEFI firmware near the top of the 32-bit address space.
-bios_load_addr = 0xffc0_0000
+# The fixed CODE bank ends at the top of the 32-bit address space.
+bios_load_addr = 0xffc8_4000
 
 ## The file path of the ramdisk image.
 # ramdisk_path = ""
@@ -44,7 +44,7 @@ bios_load_addr = 0xffc0_0000
 # For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
 memory_regions = [
   [0x0000_0000, 0x100_0000, 0x7, 0], # Low RAM 16M 0b111 R|W|EXECUTE
-  [0xffc0_0000, 0x40_0000, 0x7, 0], # UEFI firmware window 4M
+  [0xffc8_4000, 0x37c000, 0x7, 0], # OVMF CODE window
 ]
 
 #
@@ -56,7 +56,9 @@ interrupt_mode = "passthrough"
 
 # Emu_devices.
 # Name Base-Ipa Ipa_len Alloc-Irq Emu-Type EmuConfig.
-emu_devices = []
+emu_devices = [
+  ["x86-com1", 0x3f8, 0x8, 0x0, 0x2, []],
+]
 
 # Pass-through devices.
 # Name Base-Ipa Base-Pa Length Alloc-Irq.

--- a/os/axvisor/configs/vms/qemu/x86_64/linux-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/linux-uefi-smp1.toml
@@ -28,10 +28,10 @@ kernel_load_addr = 0x20_0000
 enable_bios = true
 # Select UEFI firmware flow instead of the legacy axvm-bios multiboot trampoline.
 boot_protocol = "uefi"
-# The file path of the UEFI firmware image, for example OVMF_CODE.fd.
+# Fixed qemu_x86_64_axvisor_ovmf_debug OVMF CODE image.
 uefi_firmware_path = "/guest/linux/OVMF_CODE.fd"
-# Load the UEFI firmware near the top of the 32-bit address space.
-bios_load_addr = 0xffc0_0000
+# The fixed CODE bank ends at the top of the 32-bit address space.
+bios_load_addr = 0xffc8_4000
 # The file path of the ramdisk image.
 ramdisk_path = "/guest/linux/initramfs.cpio.gz"
 # The load address of the ramdisk image.
@@ -44,7 +44,7 @@ ramdisk_load_addr = 0x40_0000
 # For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
 memory_regions = [
   [0x0000_0000, 0x200_0000, 0x7, 0], # Low RAM 32M 0b111 R|W|EXECUTE
-  [0xffc0_0000, 0x40_0000, 0x7, 0], # UEFI firmware window 4M
+  [0xffc8_4000, 0x37c000, 0x7, 0], # OVMF CODE window
 ]
 
 #
@@ -56,7 +56,9 @@ interrupt_mode = "passthrough"
 
 # Emu_devices.
 # Name Base-Ipa Ipa_len Alloc-Irq Emu-Type EmuConfig.
-emu_devices = []
+emu_devices = [
+  ["x86-com1", 0x3f8, 0x8, 0x0, 0x2, []],
+]
 
 # Pass-through devices.
 # Name Base-Ipa Base-Pa Length Alloc-Irq.

--- a/os/axvisor/configs/vms/qemu/x86_64/nimbos-uefi-smp1.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/nimbos-uefi-smp1.toml
@@ -29,10 +29,10 @@ kernel_load_addr = 0x20_0000
 enable_bios = true
 # Select UEFI firmware flow instead of the legacy axvm-bios multiboot trampoline.
 boot_protocol = "uefi"
-# The file path of the UEFI firmware image, for example OVMF_CODE.fd.
+# Fixed qemu_x86_64_axvisor_ovmf_debug OVMF CODE image.
 uefi_firmware_path = "/guest/nimbos/OVMF_CODE.fd"
-# Load the UEFI firmware near the top of the 32-bit address space.
-bios_load_addr = 0xffc0_0000
+# The fixed CODE bank ends at the top of the 32-bit address space.
+bios_load_addr = 0xffc8_4000
 
 ## The file path of the ramdisk image.
 # ramdisk_path = ""
@@ -45,7 +45,7 @@ bios_load_addr = 0xffc0_0000
 # For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
 memory_regions = [
   [0x0000_0000, 0x100_0000, 0x7, 0], # Low RAM 16M 0b111 R|W|EXECUTE
-  [0xffc0_0000, 0x40_0000, 0x7, 0], # UEFI firmware window 4M
+  [0xffc8_4000, 0x37c000, 0x7, 0], # OVMF CODE window
 ]
 
 #
@@ -57,7 +57,9 @@ interrupt_mode = "passthrough"
 
 # Emu_devices.
 # Name Base-Ipa Ipa_len Alloc-Irq Emu-Type EmuConfig.
-emu_devices = []
+emu_devices = [
+  ["x86-com1", 0x3f8, 0x8, 0x0, 0x2, []],
+]
 
 # Pass-through devices.
 # Name Base-Ipa Base-Pa Length Alloc-Irq.

--- a/os/axvisor/doc/qemu-quickstart.md
+++ b/os/axvisor/doc/qemu-quickstart.md
@@ -37,7 +37,7 @@ cargo +stable install ostool --version '^0.15'
 - `cargo-binutils`: provides `rust-objcopy`, `rust-objdump`, etc.
 - `ostool`: custom build runner for AxVisor
 
-## 3. KVM and UEFI Firmware Setup (NimbOS x86_64 Only)
+## 3. KVM Setup (NimbOS x86_64 Only)
 
 NimbOS runs on x86_64 QEMU and requires KVM hardware acceleration. ArceOS and Linux use AArch64 QEMU (TCG mode) and do not need KVM — you can skip this section.
 
@@ -65,17 +65,10 @@ Verify:
 id  # output should include "kvm"
 ```
 
-The optional x86_64 UEFI guest path uses an external OVMF-compatible firmware image. On Debian/Ubuntu, install it with:
-
-```bash
-sudo apt install ovmf
-```
-
-If your firmware is not installed in a standard location, export:
-
-```bash
-export AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd
-```
+The optional x86_64 UEFI guest path automatically pulls and verifies the fixed
+`qemu_x86_64_axvisor_ovmf_debug` tgosimages asset. It does not search distribution
+OVMF packages. See [AxVisor x86_64 Guest OVMF DEBUG Profile](x86-uefi-profile.md) for the exact
+EDK2 revision, layout, manifest, and diagnostic markers.
 
 ## 4. Running Guest OSes
 
@@ -124,7 +117,24 @@ After booting, you will enter the Rust user shell (`>>` prompt). Type `usertests
 
 > **Note**: NimbOS requires VT-x/KVM. If `/dev/kvm` does not exist or has insufficient permissions, you will get a `Permission denied` error. WSL2 requires nested virtualization support in the kernel to use KVM.
 
-### Linux UEFI (x86_64, requires KVM and OVMF)
+### NimbOS UEFI entry (x86_64, requires KVM)
+
+```bash
+./scripts/setup_qemu.sh nimbos-uefi
+
+cargo xtask axvisor test qemu --arch x86_64 \
+  --test-group uefi --test-case ovmf-entry-vmx
+```
+
+Use `ovmf-entry-svm` on an AMD host. These are non-gating diagnostics and pass
+only when AxVM emits the VM-qualified boundary after Guest OVMF writes the
+complete `SecCoreStartupWithStack(` marker through emulated COM1.
+
+When `quick-start.sh` setup and run are separate processes, setup saves the exact verified or
+unverified VM config it generated. Run uses that saved selection regardless of later environment
+changes; a failed replacement setup clears the old selection instead of launching stale input.
+
+### Linux UEFI (x86_64, requires KVM)
 
 ```bash
 ./scripts/setup_qemu.sh linux-x86_64-uefi
@@ -135,15 +145,18 @@ cargo xtask qemu \
   --vmconfigs tmp/vmconfigs/linux-x86_64-qemu-uefi-smp1.generated.toml
 ```
 
-The UEFI VM config sets `boot_protocol = "uefi"` and `uefi_firmware_path`, which tells AxVisor to load the external firmware image without applying the legacy axvm-bios multiboot patch. This Linux guest also provides `ramdisk_path` so the initramfs is available before boot.
+The UEFI VM config sets `boot_protocol = "uefi"` and points at the verified fixed
+CODE bank. This Linux guest also provides `ramdisk_path`; the current path does not yet provide
+the platform devices or boot source required for a complete guest boot.
 
-### ArceOS UEFI (x86_64, requires KVM, OVMF, and a local guest image)
+### ArceOS UEFI (x86_64, requires KVM and a local guest image)
 
 The ArceOS x86_64 UEFI path is provided as a local bring-up flow because the image registry does not currently publish a prebuilt ArceOS x86_64 UEFI guest. Build or place the guest image locally, then export:
 
 ```bash
 export AXVISOR_X86_64_ARCEOS_UEFI_KERNEL=/path/to/arceos-x86_64-uefi.bin
 export AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd
+export AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED=1
 ```
 
 Then run:
@@ -185,8 +198,8 @@ Success indicator: `Welcome to AxVisor Shell!` appears in the output.
 
 For guest-image flows, the script automates three steps, eliminating manual work:
 
-1. **Download images**: calls `cargo axvisor image pull` to fetch and extract guest images to `/tmp/.axvisor-images/`
-2. **Generate temp configs**: copies VM config templates to `tmp/vmconfigs/*.generated.toml`, then uses `sed` to update `kernel_path` and firmware paths (`bios_path` for legacy NimbOS BIOS mode, `uefi_firmware_path` for UEFI mode) to actual image paths without modifying tracked files in `configs/vms/**/*.toml`
+1. **Download images**: calls `cargo axvisor image pull` to fetch guest images and the fixed OVMF bundle to `/tmp/.axvisor-images/`
+2. **Verify firmware and generate configs**: validates the OVMF manifest, sizes, hashes, concatenation, and fixed CODE layout, then writes `tmp/vmconfigs/*.generated.toml` without modifying tracked VM templates
 3. **Prepare rootfs**: copies `rootfs.img` to the project's `tmp/` directory for QEMU to use
 
 You can also perform these steps manually if you prefer not to use the script.
@@ -201,9 +214,18 @@ The `kernel_path` in the VM config points to a non-existent file. Run `./scripts
 
 Your user is not in the `kvm` group. See the "KVM Setup" section above.
 
-### `UEFI firmware image not found`
+### `image not found: qemu_x86_64_axvisor_ovmf_debug`
 
-Install OVMF or set `AXVISOR_X86_64_UEFI_FIRMWARE` to the firmware image path before running `./scripts/setup_qemu.sh linux-x86_64-uefi`.
+The pinned OVMF asset is not present in the selected tgosimages registry. Do not
+fall back to `/usr/share/OVMF`; publish or select the registry containing the
+qualified asset.
+
+### Using a local diagnostic firmware
+
+Set both `AXVISOR_X86_64_UEFI_FIRMWARE` and
+`AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED=1`. The firmware must retain the fixed CODE
+size. Setup prints its actual hash and creates an `.unverified.generated.toml`
+that is not selected by UEFI test-suit build configs.
 
 ### `qemu-system-aarch64: command not found`
 

--- a/os/axvisor/doc/qemu-quickstart_cn.md
+++ b/os/axvisor/doc/qemu-quickstart_cn.md
@@ -37,7 +37,7 @@ cargo +stable install ostool --version '^0.15'
 - `cargo-binutils`：提供 `rust-objcopy`、`rust-objdump` 等工具
 - `ostool`：AxVisor 的自定义构建运行器
 
-## 3. KVM 配置（仅 NimbOS x86_64 需要）
+## 3. KVM 与 UEFI 固件（仅 x86_64 需要）
 
 NimbOS 运行在 x86_64 QEMU 上并依赖 KVM 硬件加速。ArceOS 和 Linux 使用 AArch64 QEMU（TCG 模式），不需要 KVM，可跳过本节。
 
@@ -64,6 +64,11 @@ newgrp kvm
 ```bash
 id  # 输出应包含 "kvm"
 ```
+
+x86_64 UEFI Guest 默认从 tgosimages 拉取并校验固定资产
+`qemu_x86_64_axvisor_ovmf_debug`，不会扫描发行版的 `/usr/share/OVMF`。
+固定 EDK2 版本、CODE/VARS 布局、manifest 契约和阶段标记见
+[AxVisor x86_64 Guest OVMF DEBUG Profile](x86-uefi-profile.md)。
 
 ## 4. 运行客户机
 
@@ -112,6 +117,34 @@ cargo xtask qemu \
 
 > **注意**：NimbOS 依赖 VT-x/KVM。如果 `/dev/kvm` 不存在或权限不足，会报 `Permission denied` 错误。WSL2 需要内核支持嵌套虚拟化才能使用 KVM。
 
+### NimbOS UEFI 固件入口（x86_64，需要 KVM）
+
+```bash
+./scripts/setup_qemu.sh nimbos-uefi
+
+cargo xtask axvisor test qemu --arch x86_64 \
+  --test-group uefi --test-case ovmf-entry-vmx
+```
+
+AMD 主机使用 `ovmf-entry-svm`。这两个用例是非门禁诊断用例，只接受 AxVM
+在模拟 Guest COM1 写出完整 `SecCoreStartupWithStack(` 后生成的带 VM ID
+边界标记，不接受原始串口文本或宿主的 VM 启动日志。
+
+当 `quick-start.sh` 的 setup 和 run 分属不同进程时，setup 会持久记录本次实际生成的
+verified 或 unverified VM 配置，run 不会根据后来进程的环境变量重新推导配置。新一轮
+setup 若失败，会保持旧选择失效，避免启动陈旧输入。
+
+如需诊断本地构建的同布局 CODE，必须同时显式设置：
+
+```bash
+export AXVISOR_X86_64_UEFI_FIRMWARE=/absolute/path/to/OVMF_CODE.fd
+export AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED=1
+./scripts/setup_qemu.sh nimbos-uefi
+```
+
+脚本会输出 `UNVERIFIED` 和实际 SHA-256，并生成
+`.unverified.generated.toml`；UEFI test-suit 不引用该配置。
+
 ### ArceOS（RISC-V64）
 
 ```bash
@@ -143,8 +176,8 @@ cargo xtask qemu \
 
 对于需要 guest 镜像的启动链路，该脚本自动完成以下三步，省去手动操作：
 
-1. **下载镜像**：调用 `cargo axvisor image pull` 将 Guest 镜像下载并解压到 `/tmp/.axvisor-images/`
-2. **生成临时配置**：复制模板 VM 配置到 `tmp/vmconfigs/*.generated.toml`，并用 `sed` 更新 `kernel_path`（以及 NimbOS 的 `bios_path`）到实际镜像路径，不修改仓库内 `configs/vms/**/*.toml`
+1. **下载镜像**：调用 `cargo axvisor image pull` 将 Guest 镜像和固定 OVMF bundle 下载到 `/tmp/.axvisor-images/`
+2. **校验固件并生成临时配置**：校验 manifest、文件大小、单文件哈希、拼接关系和固定 CODE 布局，再生成 `tmp/vmconfigs/*.generated.toml`，不修改仓库内 VM 模板
 3. **准备 rootfs**：将 `rootfs.img` 复制到项目的 `tmp/` 目录下供 QEMU 使用
 
 如果不想使用脚本，也可以手动执行上述步骤。
@@ -162,6 +195,10 @@ VM 配置中的 `kernel_path` 指向了不存在的文件。运行 `./scripts/se
 ### `qemu-system-aarch64: command not found`
 
 未安装 QEMU。执行第 1 步的 `apt install` 命令。
+
+### `image not found: qemu_x86_64_axvisor_ovmf_debug`
+
+当前 tgosimages registry 尚未包含固定 OVMF 资产。不要回退到发行版 OVMF；应发布该资产或选择包含它的 registry。
 
 ### LoongArch64 下出现 `Hardware support: false`，随后 panic
 

--- a/os/axvisor/doc/x86-uefi-profile.md
+++ b/os/axvisor/doc/x86-uefi-profile.md
@@ -1,0 +1,116 @@
+# AxVisor x86_64 Guest OVMF DEBUG Profile
+
+The current guest firmware path fixes one reproducible OVMF DEBUG profile for entry diagnostics. It establishes the observable chain from firmware loading through SEC, PEI, DXE, and BDS. It does not implement pflash, a writable variable store, fw_cfg, PCI discovery, PM devices, or an OS boot source.
+
+## Fixed firmware
+
+The tgosimages asset is `qemu_x86_64_axvisor_ovmf_debug`. It is built from EDK2 tag `edk2-stable202605`, commit `b03a21a63e3bd001f52c527e5a57feddb53a690b`, with:
+
+```text
+architecture: X64
+target: DEBUG
+toolchain: GCC
+platform: OvmfPkg/OvmfPkgX64.dsc
+defines:
+  FD_SIZE_4MB
+  DEBUG_ON_SERIAL_PORT
+  BUILD_SHELL=TRUE
+  SMM_REQUIRE=FALSE
+  SECURE_BOOT_ENABLE=FALSE
+  TPM2_ENABLE=FALSE
+  NETWORK_ENABLE=FALSE
+  SDCARD_ENABLE=FALSE
+  CC_MEASUREMENT_ENABLE=FALSE
+```
+
+`DEBUG_ON_SERIAL_PORT` sends diagnostics to COM1. Every checked-in x86 UEFI guest registers `x86-com1` at ports `0x3f8..0x3ff`.
+
+| File | Size | Current use |
+| --- | ---: | --- |
+| `OVMF_CODE.fd` | `0x37c000` | Loaded at `0xffc84000..0xffffffff` |
+| `OVMF_VARS.fd` | `0x84000` | Published template; reference QEMU and future writable-variable support only |
+| `OVMF.fd` | `0x400000` | Must equal `OVMF_VARS.fd + OVMF_CODE.fd`; reference QEMU only |
+| `manifest.toml` | n/a | Provenance, layout, features, markers, sizes, and hashes |
+
+The reset vector is `0xfffffff0`. The current path maps only CODE. The `0xffc00000..0xffc83fff` VARS range is not loaded or emulated.
+
+## Manifest contract
+
+The manifest deliberately uses a flat TOML subset so setup can validate it without a host TOML
+utility: every non-comment line must contain one unique bare key and one single-line string,
+boolean, or unsigned integer value. Table headers, quoted keys, arrays, inline tables, and
+multiline values are rejected. Required groups are:
+
+- identity and provenance: `schema_version`, `profile`, `edk2_tag`, `edk2_commit`, `architecture`, `target`, `toolchain`, `platform`, `build_command`, `build_container_digest`, `tool_versions`, and `submodule_commits`;
+- layout: `code_base`, `code_size`, `vars_base`, `vars_size`, `combined_size`, and `reset_vector`;
+- files: `code_file`, `code_sha256`, `vars_file`, `vars_sha256`, `combined_file`, and `combined_sha256`;
+- build switches: lowercase keys matching every define above;
+- markers: `sec_marker`, `pei_marker`, `dxe_ipl_marker`, `dxe_core_marker`, and `bds_marker`.
+
+The registry verifies the archive SHA-256. `scripts/ovmf-profile.sh` then verifies the manifest identity, fixed layout, individual file sizes and hashes, combined-file relation, reset-vector coverage, switches, markers, and provenance fields.
+
+## Setup and unverified firmware
+
+Normal setup pulls and verifies the fixed bundle automatically:
+
+```bash
+cd os/axvisor
+./scripts/setup_qemu.sh nimbos-uefi
+```
+
+Distribution OVMF paths are not searched. A locally built same-layout CODE image requires both variables:
+
+```bash
+export AXVISOR_X86_64_UEFI_FIRMWARE=/absolute/path/to/OVMF_CODE.fd
+export AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED=1
+./scripts/setup_qemu.sh nimbos-uefi
+```
+
+The image must still be `0x37c000` bytes. Setup prints `UNVERIFIED` and the actual SHA-256.
+`setup_qemu.sh` writes an `.unverified.generated.toml` VM config, while `quick-start.sh`
+writes an `.unverified.toml` config. Test-suit build configs reference only the canonical
+`.generated.toml` produced by verified setup.
+
+`quick-start.sh setup` records the exact verified or unverified VM config it generated in a
+per-guest `.selected` file. A later `run` reads that record instead of re-evaluating the current
+process environment. Starting a new setup first removes the old record, and publishes the new
+selection only after setup completes, so a failed setup cannot launch a stale configuration.
+
+## Markers and diagnosis
+
+The ordered firmware markers are:
+
+1. SEC: `SecCoreStartupWithStack(`
+2. PEI: `Platform PEIM Loaded`
+3. DXE: `DXE IPL Entry` or `Loading DXE CORE at`
+4. BDS: `[BdsDxe]`
+5. OS: a marker owned by the selected EFI application or guest OS
+
+Classify a timeout by its last marker:
+
+| Last observation | Classification |
+| --- | --- |
+| no SEC | CODE mapping, reset vector, vCPU entry, or early serial |
+| SEC or PEI | platform discovery or memory initialization |
+| DXE | firmware device enumeration |
+| BDS | boot source or guest OS handoff |
+
+`ovmf-entry-vmx` and `ovmf-entry-svm` are non-gating diagnostics. After the fixed-layout CODE
+image loads, the x86 diagnostic layer records a weak reference to that exact AxVM instance without
+creating a matcher. Its first-run hook activates the matcher only after the VM registry contains
+the same instance; prepare or registration failure and an unregistered duplicate VM ID therefore
+cannot create or overwrite matcher state. The last vCPU exit removes the matcher, while a reset
+reactivates it from the retained exact-instance qualification on the next first run. Repeated vCPU
+activation is idempotent and does not reset a partially matched marker. Non-UEFI Guest COM1 output
+does not create firmware-diagnostic state. Raw serial text is not a success condition because host
+and guest firmware share the QEMU transcript. AxVM recognizes the complete SEC marker only while
+processing writes from the enabled VM's emulated Guest COM1 and emits
+`VM[1] guest COM1 reached OVMF SEC: SecCoreStartupWithStack(`; the diagnostic cases match that
+VM-qualified boundary. `qemu-nimbos` never accepts the host message `VM[1] boot success`; its
+eventual gate is the NimbOS-owned `usertests passed!` marker.
+
+Use a Trace build to capture the first unsupported access after the last stage marker. Device traces include device name, PIO/MMIO direction, address, width, and value. An unregistered resource remains an error; the current path does not fabricate all-ones reads or discard writes.
+
+## Reference qualification
+
+Before publishing, tgosimages must prove reproducibility in two clean workspaces, verify all sizes and the combined-file relation, confirm the reset vector and required Shell/VirtIO modules, and run Q35 + TCG with SMM off, read-only CODE pflash, a working VARS copy, and a virtio-blk FAT ESP. The reference success marker is `AXVISOR_OVMF_REFERENCE_BOOT_OK`; the log must show SEC, PEI, DXE, BDS, then that marker. A second boot may change only the working VARS copy, never the published template.

--- a/os/axvisor/scripts/ovmf-profile.sh
+++ b/os/axvisor/scripts/ovmf-profile.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+
+# Fixed x86_64 guest firmware contract used by AxVisor entry diagnostics.
+# This file is sourced by setup_qemu.sh and quick-start.sh.
+
+OVMF_PROFILE_NAME="qemu_x86_64_axvisor_ovmf_debug"
+OVMF_EDK2_TAG="edk2-stable202605"
+OVMF_EDK2_COMMIT="b03a21a63e3bd001f52c527e5a57feddb53a690b"
+OVMF_CODE_BASE=0xffc84000
+OVMF_CODE_SIZE=0x37c000
+OVMF_VARS_BASE=0xffc00000
+OVMF_VARS_SIZE=0x84000
+OVMF_COMBINED_SIZE=0x400000
+OVMF_RESET_VECTOR=0xfffffff0
+
+ovmf_prepare_firmware() {
+    local repo_root="$1"
+    local image_output_root="$2"
+    local external_firmware="${AXVISOR_X86_64_UEFI_FIRMWARE:-}"
+    local allow_unverified="${AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED:-0}"
+
+    if [ -n "${external_firmware}" ]; then
+        if [ "${allow_unverified}" != "1" ]; then
+            ovmf_error \
+                "AXVISOR_X86_64_UEFI_FIRMWARE requires AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED=1"
+            return 1
+        fi
+        ovmf_prepare_unverified_firmware "${external_firmware}"
+        return
+    fi
+
+    local bundle_dir="${image_output_root}/${OVMF_PROFILE_NAME}"
+    if [ ! -d "${bundle_dir}" ]; then
+        mkdir -p "${image_output_root}"
+        echo "  -> Pulling verified OVMF profile ${OVMF_PROFILE_NAME} from tgosimages..."
+        (
+            cd "${repo_root}"
+            cargo axvisor image pull "${OVMF_PROFILE_NAME}" --output-dir "${image_output_root}"
+        )
+    fi
+
+    ovmf_verify_bundle "${bundle_dir}"
+}
+
+ovmf_verify_bundle() {
+    local bundle_dir="$1"
+    local manifest="${bundle_dir}/manifest.toml"
+
+    [ -f "${manifest}" ] || {
+        ovmf_error "verified OVMF bundle is missing ${manifest}"
+        return 1
+    }
+
+    ovmf_validate_flat_manifest "${manifest}" || return 1
+    ovmf_require_manifest_value "${manifest}" schema_version "1"
+    ovmf_require_manifest_value "${manifest}" profile "${OVMF_PROFILE_NAME}"
+    ovmf_require_manifest_value "${manifest}" edk2_tag "${OVMF_EDK2_TAG}"
+    ovmf_require_manifest_value "${manifest}" edk2_commit "${OVMF_EDK2_COMMIT}"
+    ovmf_require_manifest_value "${manifest}" architecture "X64"
+    ovmf_require_manifest_value "${manifest}" target "DEBUG"
+    ovmf_require_manifest_value "${manifest}" toolchain "GCC"
+    ovmf_require_manifest_value "${manifest}" platform "OvmfPkg/OvmfPkgX64.dsc"
+    ovmf_require_manifest_number "${manifest}" code_base "${OVMF_CODE_BASE}"
+    ovmf_require_manifest_number "${manifest}" code_size "${OVMF_CODE_SIZE}"
+    ovmf_require_manifest_number "${manifest}" vars_base "${OVMF_VARS_BASE}"
+    ovmf_require_manifest_number "${manifest}" vars_size "${OVMF_VARS_SIZE}"
+    ovmf_require_manifest_number "${manifest}" combined_size "${OVMF_COMBINED_SIZE}"
+    ovmf_require_manifest_number "${manifest}" reset_vector "${OVMF_RESET_VECTOR}"
+    ovmf_require_manifest_value "${manifest}" code_file "OVMF_CODE.fd"
+    ovmf_require_manifest_value "${manifest}" vars_file "OVMF_VARS.fd"
+    ovmf_require_manifest_value "${manifest}" combined_file "OVMF.fd"
+    ovmf_require_manifest_value "${manifest}" fd_size_4mb "true"
+    ovmf_require_manifest_value "${manifest}" debug_on_serial_port "true"
+    ovmf_require_manifest_value "${manifest}" build_shell "true"
+    ovmf_require_manifest_value "${manifest}" smm_require "false"
+    ovmf_require_manifest_value "${manifest}" secure_boot_enable "false"
+    ovmf_require_manifest_value "${manifest}" tpm2_enable "false"
+    ovmf_require_manifest_value "${manifest}" network_enable "false"
+    ovmf_require_manifest_value "${manifest}" sdcard_enable "false"
+    ovmf_require_manifest_value "${manifest}" cc_measurement_enable "false"
+    ovmf_require_manifest_value "${manifest}" sec_marker "SecCoreStartupWithStack("
+    ovmf_require_manifest_value "${manifest}" pei_marker "Platform PEIM Loaded"
+    ovmf_require_manifest_value "${manifest}" dxe_ipl_marker "DXE IPL Entry"
+    ovmf_require_manifest_value "${manifest}" dxe_core_marker "Loading DXE CORE at"
+    ovmf_require_manifest_value "${manifest}" bds_marker "[BdsDxe]"
+
+    ovmf_require_manifest_field "${manifest}" build_command
+    ovmf_require_manifest_field "${manifest}" build_container_digest
+    ovmf_require_manifest_field "${manifest}" tool_versions
+    ovmf_require_manifest_field "${manifest}" submodule_commits
+
+    local code_path="${bundle_dir}/OVMF_CODE.fd"
+    local vars_path="${bundle_dir}/OVMF_VARS.fd"
+    local combined_path="${bundle_dir}/OVMF.fd"
+    ovmf_verify_manifest_file "${manifest}" code "${code_path}" "${OVMF_CODE_SIZE}"
+    ovmf_verify_manifest_file "${manifest}" vars "${vars_path}" "${OVMF_VARS_SIZE}"
+    ovmf_verify_manifest_file "${manifest}" combined "${combined_path}" "${OVMF_COMBINED_SIZE}"
+
+    if ! cmp -s <(command cat "${vars_path}" "${code_path}") "${combined_path}"; then
+        ovmf_error "OVMF.fd is not the byte-for-byte concatenation of OVMF_VARS.fd and OVMF_CODE.fd"
+        return 1
+    fi
+
+    local code_end=$((OVMF_CODE_BASE + OVMF_CODE_SIZE))
+    if (( OVMF_RESET_VECTOR < OVMF_CODE_BASE || OVMF_RESET_VECTOR + 16 > code_end )); then
+        ovmf_error "reset vector is outside the fixed OVMF CODE window"
+        return 1
+    fi
+
+    OVMF_CODE_PATH="${code_path}"
+    OVMF_CODE_SHA256="$(ovmf_sha256 "${code_path}")"
+    OVMF_VERIFICATION_LABEL="VERIFIED"
+    export OVMF_CODE_PATH OVMF_CODE_SHA256 OVMF_VERIFICATION_LABEL
+    ovmf_print_selected_firmware
+}
+
+ovmf_prepare_unverified_firmware() {
+    local firmware="$1"
+    [ -f "${firmware}" ] || {
+        ovmf_error "unverified UEFI firmware does not exist: ${firmware}"
+        return 1
+    }
+
+    local actual_size
+    actual_size="$(ovmf_file_size "${firmware}")"
+    if (( actual_size != OVMF_CODE_SIZE )); then
+        ovmf_error \
+            "unverified UEFI firmware must still match the fixed CODE size $((OVMF_CODE_SIZE)) bytes; got ${actual_size}"
+        return 1
+    fi
+
+    OVMF_CODE_PATH="${firmware}"
+    OVMF_CODE_SHA256="$(ovmf_sha256 "${firmware}")"
+    OVMF_VERIFICATION_LABEL="UNVERIFIED"
+    export OVMF_CODE_PATH OVMF_CODE_SHA256 OVMF_VERIFICATION_LABEL
+    ovmf_print_selected_firmware
+    echo "  -> WARNING: UNVERIFIED firmware is diagnostic-only and must not determine UEFI test results." >&2
+}
+
+ovmf_validate_flat_manifest() {
+    local manifest="$1"
+    local problem
+
+    # The verifier intentionally accepts only the flat subset it can parse:
+    # bare keys and single-line string, boolean, or unsigned integer values.
+    problem="$(awk '
+        /^[[:space:]]*($|#)/ {
+            next
+        }
+        {
+            line = $0
+            if (line !~ /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*[[:space:]]*=/) {
+                print "syntax:" NR
+                exit
+            }
+
+            key = line
+            sub(/^[[:space:]]*/, "", key)
+            sub(/[[:space:]]*=.*$/, "", key)
+            if (++seen[key] > 1) {
+                print "duplicate:" key
+                exit
+            }
+
+            value = line
+            sub(/^[^=]*=[[:space:]]*/, "", value)
+            if (value ~ /^"[^"]*"[[:space:]]*(#.*)?$/) {
+                next
+            }
+            if (value ~ /^(true|false|0[xX][0-9a-fA-F]+|[0-9]+)[[:space:]]*(#.*)?$/) {
+                next
+            }
+
+            print "syntax:" NR
+            exit
+        }
+    ' "${manifest}")"
+    case "${problem}" in
+        duplicate:*)
+            ovmf_error "OVMF manifest contains duplicate top-level key: ${problem#duplicate:}"
+            return 1
+            ;;
+        syntax:*)
+            ovmf_error \
+                "OVMF manifest line ${problem#syntax:} is outside the supported flat bare-key scalar syntax"
+            return 1
+            ;;
+    esac
+}
+
+ovmf_verify_manifest_file() {
+    local manifest="$1"
+    local role="$2"
+    local path="$3"
+    local expected_size="$4"
+    local expected_hash
+
+    [ -f "${path}" ] || {
+        ovmf_error "OVMF bundle is missing ${path}"
+        return 1
+    }
+    expected_hash="$(ovmf_manifest_value "${manifest}" "${role}_sha256")"
+    [ -n "${expected_hash}" ] || {
+        ovmf_error "OVMF manifest is missing ${role}_sha256"
+        return 1
+    }
+    if ! printf '%s\n' "${expected_hash}" | grep -Eq '^[0-9a-f]{64}$'; then
+        ovmf_error "OVMF manifest has an invalid ${role}_sha256: ${expected_hash}"
+        return 1
+    fi
+
+    local actual_size
+    actual_size="$(ovmf_file_size "${path}")"
+    if (( actual_size != expected_size )); then
+        ovmf_error "${path} has size ${actual_size}; expected $((expected_size))"
+        return 1
+    fi
+
+    local actual_hash
+    actual_hash="$(ovmf_sha256 "${path}")"
+    if [ "${actual_hash}" != "${expected_hash}" ]; then
+        ovmf_error "SHA-256 mismatch for ${path}: expected ${expected_hash}, got ${actual_hash}"
+        return 1
+    fi
+}
+
+ovmf_require_manifest_number() {
+    local manifest="$1"
+    local key="$2"
+    local expected="$3"
+    local actual
+
+    actual="$(ovmf_manifest_value "${manifest}" "${key}")"
+    [ -n "${actual}" ] || {
+        ovmf_error "OVMF manifest is missing ${key}"
+        return 1
+    }
+    if ! printf '%s\n' "${actual}" | grep -Eq '^(0[xX][0-9a-fA-F]+|[0-9]+)$'; then
+        ovmf_error "OVMF manifest ${key} is not an unsigned integer: ${actual}"
+        return 1
+    fi
+    if (( actual != expected )); then
+        ovmf_error "OVMF manifest ${key}=${actual}; expected $(printf '0x%x' "${expected}")"
+        return 1
+    fi
+}
+
+ovmf_require_manifest_value() {
+    local manifest="$1"
+    local key="$2"
+    local expected="$3"
+    local actual
+
+    actual="$(ovmf_manifest_value "${manifest}" "${key}")"
+    if [ "${actual}" != "${expected}" ]; then
+        ovmf_error "OVMF manifest ${key}=${actual:-<missing>}; expected ${expected}"
+        return 1
+    fi
+}
+
+ovmf_require_manifest_field() {
+    local manifest="$1"
+    local key="$2"
+    local actual
+
+    actual="$(ovmf_manifest_value "${manifest}" "${key}")"
+    if [ -z "${actual}" ]; then
+        ovmf_error "OVMF manifest is missing required provenance field ${key}"
+        return 1
+    fi
+}
+
+ovmf_manifest_value() {
+    local manifest="$1"
+    local key="$2"
+
+    awk -v key="${key}" '
+        $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+            value = $0
+            sub("^[[:space:]]*" key "[[:space:]]*=[[:space:]]*", "", value)
+            sub(/[[:space:]]*#[^"]*$/, "", value)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            if (value ~ /^".*"$/) {
+                sub(/^"/, "", value)
+                sub(/"$/, "", value)
+            }
+            print value
+            exit
+        }
+    ' "${manifest}"
+}
+
+ovmf_sha256() {
+    local file="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "${file}" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "${file}" | awk '{print $1}'
+    else
+        ovmf_error "sha256sum or shasum is required to verify OVMF firmware"
+        return 1
+    fi
+}
+
+ovmf_file_size() {
+    local file="$1"
+    if stat -c '%s' "${file}" >/dev/null 2>&1; then
+        stat -c '%s' "${file}"
+    else
+        stat -f '%z' "${file}"
+    fi
+}
+
+ovmf_print_selected_firmware() {
+    printf '  -> OVMF profile: %s (%s)\n' "${OVMF_PROFILE_NAME}" "${OVMF_VERIFICATION_LABEL}"
+    printf '  -> OVMF CODE: %s\n' "${OVMF_CODE_PATH}"
+    printf '  -> OVMF CODE SHA-256: %s\n' "${OVMF_CODE_SHA256}"
+    printf '  -> OVMF CODE mapping: 0x%x..0x%x (%d bytes), reset=0x%x\n' \
+        "${OVMF_CODE_BASE}" "$((OVMF_CODE_BASE + OVMF_CODE_SIZE - 1))" \
+        "${OVMF_CODE_SIZE}" "${OVMF_RESET_VECTOR}"
+}
+
+ovmf_error() {
+    echo "ERROR: $*" >&2
+}

--- a/os/axvisor/scripts/quick-start.sh
+++ b/os/axvisor/scripts/quick-start.sh
@@ -7,6 +7,9 @@
 
 set -e  # Exit on error
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/ovmf-profile.sh"
+
 # Color output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -98,7 +101,7 @@ Launch Options (for run/start commands):
     QEMU x86_64:
         -n, --nimbos        Launch single NimbOS guest (default)
         -l, --linux         Launch single Linux guest
-        --nimbos-uefi       Launch NimbOS through an external UEFI firmware image
+        --nimbos-uefi       Launch NimbOS through the fixed OVMF DEBUG profile
         --arceos-uefi       Launch a local ArceOS x86_64 UEFI guest image
     Phytium Pi:
         -a, --arceos        Launch single ArceOS guest (default)
@@ -346,35 +349,112 @@ setup_qemu_x86_64() {
     info "=== QEMU x86_64 Preparation Complete ==="
 }
 
+qemu_x86_64_setup_uefi_config_path() {
+    local guest="$1"
+
+    case "${guest}:${OVMF_VERIFICATION_LABEL:-}" in
+        nimbos:VERIFIED) printf '%s\n' "tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml" ;;
+        nimbos:UNVERIFIED) printf '%s\n' "tmp/configs/nimbos-x86_64-qemu-uefi-smp1.unverified.toml" ;;
+        arceos:VERIFIED) printf '%s\n' "tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml" ;;
+        arceos:UNVERIFIED) printf '%s\n' "tmp/configs/arceos-x86_64-qemu-uefi-smp1.unverified.toml" ;;
+        *)
+            echo "ERROR: unsupported x86_64 UEFI guest or verification label: ${guest}" >&2
+            return 1
+            ;;
+    esac
+}
+
+qemu_x86_64_uefi_selection_file() {
+    case "$1" in
+        nimbos) printf '%s\n' "tmp/configs/nimbos-x86_64-qemu-uefi-smp1.selected" ;;
+        arceos) printf '%s\n' "tmp/configs/arceos-x86_64-qemu-uefi-smp1.selected" ;;
+        *)
+            echo "ERROR: unsupported x86_64 UEFI guest config: $1" >&2
+            return 1
+            ;;
+    esac
+}
+
+qemu_x86_64_clear_uefi_config_selection() {
+    local selection_file
+    selection_file="$(qemu_x86_64_uefi_selection_file "$1")"
+    rm -f "${selection_file}" "${selection_file}.tmp"
+}
+
+qemu_x86_64_record_uefi_config() {
+    local guest="$1"
+    local config_path="$2"
+    local selection_file
+    selection_file="$(qemu_x86_64_uefi_selection_file "${guest}")"
+
+    case "${guest}:${config_path}" in
+        nimbos:tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml | \
+        nimbos:tmp/configs/nimbos-x86_64-qemu-uefi-smp1.unverified.toml | \
+        arceos:tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml | \
+        arceos:tmp/configs/arceos-x86_64-qemu-uefi-smp1.unverified.toml) ;;
+        *)
+            echo "ERROR: refusing unexpected x86_64 UEFI config path: ${config_path}" >&2
+            return 1
+            ;;
+    esac
+    if [ ! -f "${config_path}" ]; then
+        echo "ERROR: generated x86_64 UEFI config does not exist: ${config_path}" >&2
+        return 1
+    fi
+
+    printf '%s\n' "${config_path}" > "${selection_file}.tmp"
+    mv "${selection_file}.tmp" "${selection_file}"
+}
+
+qemu_x86_64_selected_uefi_config() {
+    local guest="$1"
+    local selection_file
+    local config_path
+    selection_file="$(qemu_x86_64_uefi_selection_file "${guest}")"
+    if [ ! -f "${selection_file}" ]; then
+        echo "ERROR: no saved x86_64 UEFI config for ${guest}; run setup first" >&2
+        return 1
+    fi
+    if [ "$(wc -l < "${selection_file}")" -ne 1 ]; then
+        echo "ERROR: invalid x86_64 UEFI config selection: ${selection_file}" >&2
+        return 1
+    fi
+    IFS= read -r config_path < "${selection_file}"
+
+    case "${guest}:${config_path}" in
+        nimbos:tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml | \
+        nimbos:tmp/configs/nimbos-x86_64-qemu-uefi-smp1.unverified.toml | \
+        arceos:tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml | \
+        arceos:tmp/configs/arceos-x86_64-qemu-uefi-smp1.unverified.toml) ;;
+        *)
+            echo "ERROR: invalid saved x86_64 UEFI config path: ${config_path}" >&2
+            return 1
+            ;;
+    esac
+    if [ ! -f "${config_path}" ]; then
+        echo "ERROR: saved x86_64 UEFI config does not exist: ${config_path}" >&2
+        return 1
+    fi
+
+    printf '%s\n' "${config_path}"
+}
+
 setup_qemu_x86_64_uefi() {
     info "=== QEMU x86_64 UEFI Preparation ==="
+    qemu_x86_64_clear_uefi_config_selection nimbos
 
     setup_qemu_x86_64
 
-    local firmware_path="${AXVISOR_X86_64_UEFI_FIRMWARE:-}"
-    if [ -z "$firmware_path" ]; then
-        for candidate in \
-            "$(pwd)/tmp/images/qemu_x86_64_nimbos/OVMF_CODE.fd" \
-            "/usr/share/OVMF/OVMF_CODE.fd" \
-            "/usr/share/ovmf/OVMF.fd" \
-            "/usr/share/qemu/OVMF.fd"; do
-            if [ -f "$candidate" ]; then
-                firmware_path="$candidate"
-                break
-            fi
-        done
-    fi
-
-    if [ -z "$firmware_path" ] || [ ! -f "$firmware_path" ]; then
-        error "UEFI firmware image not found."
-        echo "Install OVMF or set AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd"
-        exit 1
-    fi
+    ovmf_prepare_firmware "$(pwd)" "$(pwd)/tmp/images"
+    local firmware_path="${OVMF_CODE_PATH}"
+    local guest_config_path
+    guest_config_path="$(qemu_x86_64_setup_uefi_config_path nimbos)"
 
     info "Preparing UEFI guest config file..."
-    run_cmd cp configs/vms/qemu/x86_64/nimbos-uefi-smp1.toml tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml
-    run_cmd sed -i 's|^kernel_path = .*|kernel_path = "../images/qemu_x86_64_nimbos/qemu-x86_64"|g' tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml
-    run_cmd sed -i 's|^uefi_firmware_path = .*|uefi_firmware_path = "'"$firmware_path"'"|g' tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml
+    run_cmd cp configs/vms/qemu/x86_64/nimbos-uefi-smp1.toml "${guest_config_path}"
+    run_cmd sed -i 's|^kernel_path = .*|kernel_path = "../images/qemu_x86_64_nimbos/qemu-x86_64"|g' "${guest_config_path}"
+    run_cmd sed -i 's|^uefi_firmware_path = .*|uefi_firmware_path = "'"$firmware_path"'"|g' "${guest_config_path}"
+    info "Firmware verification: ${OVMF_VERIFICATION_LABEL}"
 
     info "Preparing UEFI QEMU config file..."
     run_cmd cp .github/workflows/qemu-x86_64-uefi.toml tmp/configs/qemu-x86_64-uefi-runtime.toml
@@ -382,6 +462,7 @@ setup_qemu_x86_64_uefi() {
     local rootfs_path
     rootfs_path="$(pwd)/tmp/images/qemu_x86_64_nimbos/rootfs.img"
     run_cmd sed -i 's|file=${workspaceFolder}/tmp/rootfs.img|file='"$rootfs_path"'|g' tmp/configs/qemu-x86_64-uefi-runtime.toml
+    qemu_x86_64_record_uefi_config nimbos "${guest_config_path}"
 
     info "=== QEMU x86_64 UEFI Preparation Complete ==="
 }
@@ -413,6 +494,7 @@ setup_qemu_x86_64_linux() {
 
 setup_qemu_x86_64_arceos_uefi() {
     info "=== QEMU x86_64 ArceOS UEFI Preparation ==="
+    qemu_x86_64_clear_uefi_config_selection arceos
 
     run_cmd mkdir -p tmp/{configs,images}
 
@@ -436,36 +518,23 @@ setup_qemu_x86_64_arceos_uefi() {
         exit 1
     fi
 
-    local firmware_path="${AXVISOR_X86_64_UEFI_FIRMWARE:-}"
-    if [ -z "$firmware_path" ]; then
-        for candidate in \
-            "$(pwd)/tmp/images/OVMF_CODE.fd" \
-            "/usr/share/OVMF/OVMF_CODE.fd" \
-            "/usr/share/ovmf/OVMF.fd" \
-            "/usr/share/qemu/OVMF.fd"; do
-            if [ -f "$candidate" ]; then
-                firmware_path="$candidate"
-                break
-            fi
-        done
-    fi
-
-    if [ -z "$firmware_path" ] || [ ! -f "$firmware_path" ]; then
-        error "UEFI firmware image not found."
-        echo "Install OVMF or set AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd"
-        exit 1
-    fi
+    ovmf_prepare_firmware "$(pwd)" "$(pwd)/tmp/images"
+    local firmware_path="${OVMF_CODE_PATH}"
+    local guest_config_path
+    guest_config_path="$(qemu_x86_64_setup_uefi_config_path arceos)"
 
     info "Preparing board config file..."
     run_cmd cp configs/board/qemu-x86_64.toml tmp/configs/
 
     info "Preparing ArceOS UEFI guest config file..."
-    run_cmd cp configs/vms/qemu/x86_64/arceos-uefi-smp1.toml tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml
-    run_cmd sed -i 's|^kernel_path = .*|kernel_path = "'"$kernel_path"'"|g' tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml
-    run_cmd sed -i 's|^uefi_firmware_path = .*|uefi_firmware_path = "'"$firmware_path"'"|g' tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml
+    run_cmd cp configs/vms/qemu/x86_64/arceos-uefi-smp1.toml "${guest_config_path}"
+    run_cmd sed -i 's|^kernel_path = .*|kernel_path = "'"$kernel_path"'"|g' "${guest_config_path}"
+    run_cmd sed -i 's|^uefi_firmware_path = .*|uefi_firmware_path = "'"$firmware_path"'"|g' "${guest_config_path}"
+    info "Firmware verification: ${OVMF_VERIFICATION_LABEL}"
 
     info "Preparing UEFI QEMU config file..."
     run_cmd cp .github/workflows/qemu-x86_64-arceos-uefi.toml tmp/configs/qemu-x86_64-arceos-uefi-runtime.toml
+    qemu_x86_64_record_uefi_config arceos "${guest_config_path}"
 
     info "=== QEMU x86_64 ArceOS UEFI Preparation Complete ==="
 }
@@ -479,19 +548,23 @@ run_qemu_x86_64_nimbos() {
 }
 
 run_qemu_x86_64_nimbos_uefi() {
+    local guest_config_path
+    guest_config_path="$(qemu_x86_64_selected_uefi_config nimbos)"
     info "=== Launching QEMU x86_64 NimbOS UEFI Guest ==="
     run_axvisor_qemu \
         --config "$(pwd)/tmp/configs/qemu-x86_64.toml" \
         --qemu-config "$(pwd)/tmp/configs/qemu-x86_64-uefi-runtime.toml" \
-        --vmconfigs "$(pwd)/tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml"
+        --vmconfigs "$(pwd)/${guest_config_path}"
 }
 
 run_qemu_x86_64_arceos_uefi() {
+    local guest_config_path
+    guest_config_path="$(qemu_x86_64_selected_uefi_config arceos)"
     info "=== Launching QEMU x86_64 ArceOS UEFI Guest ==="
     run_axvisor_qemu \
         --config "$(pwd)/tmp/configs/qemu-x86_64.toml" \
         --qemu-config "$(pwd)/tmp/configs/qemu-x86_64-arceos-uefi-runtime.toml" \
-        --vmconfigs "$(pwd)/tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml"
+        --vmconfigs "$(pwd)/${guest_config_path}"
 }
 
 run_qemu_x86_64_linux() {
@@ -1415,6 +1488,10 @@ cmd_run_rdk_s100() {
 # ============================================================================
 # Main Program
 # ============================================================================
+
+if [[ "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
 
 check_root_dir
 

--- a/os/axvisor/scripts/setup_qemu.sh
+++ b/os/axvisor/scripts/setup_qemu.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 # LoongArch64 AxVisor shell smoke uses quick-start.sh instead of this script.
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "${REPO_ROOT}/scripts/ovmf-profile.sh"
 IMAGE_STORAGE_ROOT="/tmp/.axvisor-images"
 DEFAULT_REGISTRY_URL="https://raw.githubusercontent.com/rcore-os/tgosimages/refs/heads/main/registry/default.toml"
 # Keep this version aligned with the guest release used in this branch.
@@ -97,21 +98,6 @@ verify_sha256() {
   fi
 }
 
-file_size_bytes() {
-  local file="$1"
-
-  if stat -c '%s' "${file}" >/dev/null 2>&1; then
-    stat -c '%s' "${file}"
-  else
-    stat -f '%z' "${file}"
-  fi
-}
-
-align_up_4k() {
-  local value="$1"
-  echo $(( (value + 0xfff) & ~0xfff ))
-}
-
 nimbos_image_ready() {
   [ -f "${IMAGE_DIR}/qemu-x86_64" ] \
     && [ -f "${IMAGE_DIR}/rootfs.img" ] \
@@ -167,8 +153,8 @@ usage() {
   echo "  linux           - aarch64 Linux guest"
   echo "  linux-x86_64    - x86_64 Linux guest through direct boot"
   echo "  nimbos          - x86_64 NimbOS guest (requires VT-x/KVM)"
-  echo "  nimbos-uefi     - x86_64 NimbOS guest through external UEFI firmware"
-  echo "  linux-x86_64-uefi - x86_64 Linux guest through external UEFI firmware"
+  echo "  nimbos-uefi     - x86_64 NimbOS guest through the fixed OVMF DEBUG profile"
+  echo "  linux-x86_64-uefi - x86_64 Linux guest through the fixed OVMF DEBUG profile"
   echo ""
   echo "LoongArch64 AxVisor shell smoke is a separate quick-start flow:"
   echo "  ./scripts/quick-start.sh qemu-loongarch64 start"
@@ -314,34 +300,21 @@ if [[ "$GUEST" == "nimbos" ]]; then
   fi
 fi
 
-# x86_64 UEFI mode requires an external OVMF image. Keep the path
-# configurable because distributions install OVMF in different locations.
+# x86_64 UEFI mode uses the fixed AxVisor OVMF DEBUG profile. A developer may
+# opt into a same-layout external CODE image, but that path is marked
+# UNVERIFIED and does not prepare the canonical test-suit VM config.
 if [[ "$GUEST" == "nimbos-uefi" || "$GUEST" == "linux-x86_64-uefi" ]]; then
-  UEFI_FIRMWARE="${AXVISOR_X86_64_UEFI_FIRMWARE:-}"
-  if [ -z "${UEFI_FIRMWARE}" ]; then
-    for candidate in \
-      "${IMAGE_DIR}/OVMF_CODE.fd" \
-      "/usr/share/OVMF/OVMF_CODE_4M.fd" \
-      "/usr/share/OVMF/OVMF_CODE.fd" \
-      "/usr/share/ovmf/OVMF.fd" \
-      "/usr/share/qemu/OVMF.fd"; do
-      if [ -f "${candidate}" ]; then
-        UEFI_FIRMWARE="${candidate}"
-        break
-      fi
-    done
-  fi
-  if [ -z "${UEFI_FIRMWARE}" ] || [ ! -f "${UEFI_FIRMWARE}" ]; then
-    echo "ERROR: UEFI firmware image not found." >&2
-    echo "  -> Install OVMF or set AXVISOR_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd." >&2
-    exit 1
-  fi
-
-  UEFI_FIRMWARE_SIZE="$(file_size_bytes "${UEFI_FIRMWARE}")"
-  UEFI_FIRMWARE_WINDOW_SIZE="$(align_up_4k "${UEFI_FIRMWARE_SIZE}")"
-  UEFI_FIRMWARE_LOAD_ADDR=$((0x100000000 - UEFI_FIRMWARE_WINDOW_SIZE))
+  ovmf_prepare_firmware "${REPO_ROOT}" "${IMAGE_STORAGE_ROOT}"
+  UEFI_FIRMWARE="${OVMF_CODE_PATH}"
+  UEFI_FIRMWARE_SIZE="${OVMF_CODE_SIZE}"
+  UEFI_FIRMWARE_WINDOW_SIZE="${OVMF_CODE_SIZE}"
+  UEFI_FIRMWARE_LOAD_ADDR="${OVMF_CODE_BASE}"
   UEFI_FIRMWARE_LOAD_ADDR_HEX="$(printf '0x%x' "${UEFI_FIRMWARE_LOAD_ADDR}")"
   UEFI_FIRMWARE_WINDOW_SIZE_HEX="$(printf '0x%x' "${UEFI_FIRMWARE_WINDOW_SIZE}")"
+
+  if [ "${OVMF_VERIFICATION_LABEL}" = "UNVERIFIED" ]; then
+    GENERATED_VMCONFIG_PATH="${VMCONFIG_TMP_DIR}/${VMCONFIG_OUTPUT_NAME%.toml}.unverified.generated.toml"
+  fi
 fi
 
 echo "[setup_qemu] Step 2: patch VM config kernel_path..."
@@ -368,9 +341,15 @@ fi
 if [[ "$GUEST" == "nimbos-uefi" || "$GUEST" == "linux-x86_64-uefi" ]]; then
   sed -i 's|^uefi_firmware_path *=.*|uefi_firmware_path = "'"${UEFI_FIRMWARE}"'"|' "${GENERATED_VMCONFIG_PATH}"
   sed -i 's|^bios_load_addr *=.*|bios_load_addr = '"${UEFI_FIRMWARE_LOAD_ADDR_HEX}"'|' "${GENERATED_VMCONFIG_PATH}"
-  sed -i 's|^\(  \[\)0xffc0_0000, 0x40_0000\(, 0x7, 0\].*UEFI firmware window.*\)|\1'"${UEFI_FIRMWARE_LOAD_ADDR_HEX}"', '"${UEFI_FIRMWARE_WINDOW_SIZE_HEX}"'\2|' "${GENERATED_VMCONFIG_PATH}"
+  sed -i 's|^\(  \[\)0xffc8_4000, 0x37c000\(, 0x7, 0\].*OVMF CODE window.*\)|\1'"${UEFI_FIRMWARE_LOAD_ADDR_HEX}"', '"${UEFI_FIRMWARE_WINDOW_SIZE_HEX}"'\2|' "${GENERATED_VMCONFIG_PATH}"
+  if ! grep -Eq '^bios_load_addr = 0xffc84000$' "${GENERATED_VMCONFIG_PATH}" || \
+     ! grep -Eq '^  \[0xffc84000, 0x37c000, 0x7, 0\], # OVMF CODE window$' "${GENERATED_VMCONFIG_PATH}"; then
+    echo "ERROR: generated UEFI VM config does not match the fixed OVMF CODE layout." >&2
+    exit 1
+  fi
   echo "  -> Updated UEFI firmware path to ${UEFI_FIRMWARE}"
-  echo "  -> Updated UEFI firmware load address to ${UEFI_FIRMWARE_LOAD_ADDR_HEX} (size ${UEFI_FIRMWARE_SIZE} bytes)"
+  echo "  -> Updated UEFI firmware load address to ${UEFI_FIRMWARE_LOAD_ADDR_HEX} (size $((UEFI_FIRMWARE_SIZE)) bytes)"
+  echo "  -> Firmware verification: ${OVMF_VERIFICATION_LABEL}"
 fi
 
 if [[ "$GUEST" == "linux-x86_64-uefi" ]]; then
@@ -410,11 +389,11 @@ if [[ "$GUEST" == "nimbos" ]]; then
 fi
 
 if [[ "$GUEST" == "nimbos-uefi" ]]; then
-  echo "*** NimbOS UEFI mode requires VT-x/VMX, KVM, and an OVMF-compatible firmware image."
+  echo "*** NimbOS UEFI mode requires VT-x/VMX, KVM, and the fixed AxVisor OVMF DEBUG profile."
   echo ""
 fi
 
 if [[ "$GUEST" == "linux-x86_64-uefi" ]]; then
-  echo "*** Linux x86_64 UEFI mode requires VT-x/VMX, KVM, and an OVMF-compatible firmware image."
+  echo "*** Linux x86_64 UEFI mode requires VT-x/VMX, KVM, and the fixed AxVisor OVMF DEBUG profile."
   echo ""
 fi

--- a/scripts/axbuild/src/axvisor/test/mod.rs
+++ b/scripts/axbuild/src/axvisor/test/mod.rs
@@ -4,9 +4,6 @@ mod discovery;
 mod qemu;
 mod types;
 
-#[cfg(test)]
-mod tests;
-
 use std::path::Path;
 
 pub(crate) use types::{AxvisorQemuCase, BoardTestGroup};
@@ -49,3 +46,8 @@ pub(super) async fn test(axvisor: &mut Axvisor, args: ArgsTest) -> anyhow::Resul
 
 const AXVISOR_TEST_SUITE_OS: &str = "axvisor";
 const AXVISOR_NORMAL_GROUP: &str = "normal";
+
+#[cfg(test)]
+mod ovmf_tests;
+#[cfg(test)]
+mod tests;

--- a/scripts/axbuild/src/axvisor/test/ovmf_tests.rs
+++ b/scripts/axbuild/src/axvisor/test/ovmf_tests.rs
@@ -1,0 +1,239 @@
+use std::{fs, path::Path, process::Command};
+
+use sha2::{Digest, Sha256};
+use tempfile::tempdir;
+
+const CODE_SIZE: usize = 0x37c000;
+const VARS_SIZE: usize = 0x84000;
+
+#[test]
+fn ovmf_bundle_verifier_accepts_the_fixed_profile() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/ovmf-profile.sh");
+    let bundle = tempdir().unwrap();
+    write_valid_bundle(bundle.path());
+
+    let status = run_verifier(&script, bundle.path());
+
+    assert!(status.success());
+}
+
+#[test]
+fn ovmf_bundle_verifier_rejects_changed_code_content() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/ovmf-profile.sh");
+    let bundle = tempdir().unwrap();
+    write_valid_bundle(bundle.path());
+    let code_path = bundle.path().join("OVMF_CODE.fd");
+    let mut code = fs::read(&code_path).unwrap();
+    code[0] ^= 1;
+    fs::write(code_path, code).unwrap();
+
+    let status = run_verifier(&script, bundle.path());
+
+    assert!(!status.success());
+}
+
+#[test]
+fn ovmf_bundle_verifier_rejects_changed_code_size() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/ovmf-profile.sh");
+    let bundle = tempdir().unwrap();
+    write_valid_bundle(bundle.path());
+    let code_path = bundle.path().join("OVMF_CODE.fd");
+    let mut code = fs::read(&code_path).unwrap();
+    code.pop();
+    fs::write(code_path, code).unwrap();
+
+    let status = run_verifier(&script, bundle.path());
+
+    assert!(!status.success());
+}
+
+#[test]
+fn ovmf_bundle_verifier_rejects_changed_code_base() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/ovmf-profile.sh");
+    let bundle = tempdir().unwrap();
+    write_valid_bundle(bundle.path());
+    let manifest_path = bundle.path().join("manifest.toml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .unwrap()
+        .replace("code_base = 0xffc84000", "code_base = 0xffc00000");
+    fs::write(manifest_path, manifest).unwrap();
+
+    let status = run_verifier(&script, bundle.path());
+
+    assert!(!status.success());
+}
+
+#[test]
+fn ovmf_bundle_verifier_rejects_duplicate_manifest_keys() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/ovmf-profile.sh");
+
+    for duplicate in [
+        "profile = \"ignored-duplicate\"",
+        "code_base = 0xffc00000",
+        "code_sha256 = \"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"",
+    ] {
+        let bundle = tempdir().unwrap();
+        write_valid_bundle(bundle.path());
+        let manifest_path = bundle.path().join("manifest.toml");
+        let mut manifest = fs::read_to_string(&manifest_path).unwrap();
+        manifest.push_str(duplicate);
+        manifest.push('\n');
+        fs::write(manifest_path, manifest).unwrap();
+
+        let status = run_verifier(&script, bundle.path());
+
+        assert!(!status.success(), "accepted duplicate key: {duplicate}");
+    }
+}
+
+#[test]
+fn ovmf_bundle_verifier_rejects_fields_inside_a_table() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/ovmf-profile.sh");
+    let bundle = tempdir().unwrap();
+    write_valid_bundle(bundle.path());
+    let manifest_path = bundle.path().join("manifest.toml");
+    let manifest = format!(
+        "[metadata]\n{}",
+        fs::read_to_string(&manifest_path).unwrap()
+    );
+    fs::write(manifest_path, manifest).unwrap();
+
+    let status = run_verifier(&script, bundle.path());
+
+    assert!(!status.success());
+}
+
+#[test]
+fn ovmf_bundle_verifier_rejects_quoted_keys() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/ovmf-profile.sh");
+    let bundle = tempdir().unwrap();
+    write_valid_bundle(bundle.path());
+    let manifest_path = bundle.path().join("manifest.toml");
+    let mut manifest = fs::read_to_string(&manifest_path).unwrap();
+    manifest.push_str("\"profile\" = \"ignored-duplicate\"\n");
+    fs::write(manifest_path, manifest).unwrap();
+
+    let status = run_verifier(&script, bundle.path());
+
+    assert!(!status.success());
+}
+
+#[test]
+fn external_firmware_requires_explicit_unverified_opt_in() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/ovmf-profile.sh");
+    let firmware_dir = tempdir().unwrap();
+    let firmware = firmware_dir.path().join("OVMF_CODE.fd");
+    fs::write(&firmware, vec![0xa5; CODE_SIZE]).unwrap();
+
+    let rejected = run_prepare_firmware(&script, &firmware, None);
+    let accepted = run_prepare_firmware(&script, &firmware, Some("1"));
+
+    assert!(!rejected.success());
+    assert!(accepted.success());
+}
+
+fn run_verifier(script: &Path, bundle: &Path) -> std::process::ExitStatus {
+    Command::new("bash")
+        .args([
+            "-c",
+            "set -euo pipefail; source \"$1\"; ovmf_verify_bundle \"$2\"",
+            "ovmf-profile-test",
+        ])
+        .arg(script)
+        .arg(bundle)
+        .status()
+        .unwrap()
+}
+
+fn run_prepare_firmware(
+    script: &Path,
+    firmware: &Path,
+    allow_unverified: Option<&str>,
+) -> std::process::ExitStatus {
+    let mut command = Command::new("bash");
+    command
+        .args([
+            "-c",
+            "set -euo pipefail; source \"$1\"; ovmf_prepare_firmware /unused /unused",
+            "ovmf-profile-test",
+        ])
+        .arg(script)
+        .env("AXVISOR_X86_64_UEFI_FIRMWARE", firmware)
+        .env_remove("AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED");
+    if let Some(value) = allow_unverified {
+        command.env("AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED", value);
+    }
+    command.status().unwrap()
+}
+
+fn write_valid_bundle(bundle: &Path) {
+    let vars = vec![0x5a; VARS_SIZE];
+    let code = vec![0xa5; CODE_SIZE];
+    let mut combined = Vec::with_capacity(VARS_SIZE + CODE_SIZE);
+    combined.extend_from_slice(&vars);
+    combined.extend_from_slice(&code);
+
+    fs::write(bundle.join("OVMF_VARS.fd"), &vars).unwrap();
+    fs::write(bundle.join("OVMF_CODE.fd"), &code).unwrap();
+    fs::write(bundle.join("OVMF.fd"), &combined).unwrap();
+    fs::write(
+        bundle.join("manifest.toml"),
+        format!(
+            r#"schema_version = 1
+profile = "qemu_x86_64_axvisor_ovmf_debug"
+edk2_tag = "edk2-stable202605"
+edk2_commit = "b03a21a63e3bd001f52c527e5a57feddb53a690b"
+architecture = "X64"
+target = "DEBUG"
+toolchain = "GCC"
+platform = "OvmfPkg/OvmfPkgX64.dsc"
+build_command = "build -a X64 -b DEBUG"
+build_container_digest = "sha256:fixture"
+tool_versions = "fixture"
+submodule_commits = "fixture"
+code_base = 0xffc84000
+code_size = 0x37c000
+vars_base = 0xffc00000
+vars_size = 0x84000
+combined_size = 0x400000
+reset_vector = 0xfffffff0
+code_file = "OVMF_CODE.fd"
+code_sha256 = "{}"
+vars_file = "OVMF_VARS.fd"
+vars_sha256 = "{}"
+combined_file = "OVMF.fd"
+combined_sha256 = "{}"
+fd_size_4mb = true
+debug_on_serial_port = true
+build_shell = true
+smm_require = false
+secure_boot_enable = false
+tpm2_enable = false
+network_enable = false
+sdcard_enable = false
+cc_measurement_enable = false
+sec_marker = "SecCoreStartupWithStack("
+pei_marker = "Platform PEIM Loaded"
+dxe_ipl_marker = "DXE IPL Entry"
+dxe_core_marker = "Loading DXE CORE at"
+bds_marker = "[BdsDxe]"
+"#,
+            sha256(&code),
+            sha256(&vars),
+            sha256(&combined),
+        ),
+    )
+    .unwrap();
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}

--- a/scripts/axbuild/src/axvisor/test/tests.rs
+++ b/scripts/axbuild/src/axvisor/test/tests.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use ostool::run::qemu::QemuConfig;
@@ -25,6 +26,13 @@ struct TestVmKernelConfig {
 #[derive(serde::Deserialize)]
 struct TestVmKernel {
     cmdline: String,
+}
+
+#[derive(serde::Deserialize)]
+struct TestOvmfBuildConfig {
+    features: Vec<String>,
+    log: String,
+    vm_configs: Vec<PathBuf>,
 }
 
 fn write_qemu_config(root: &Path, case: &str, arch: &str, body: &str) -> PathBuf {
@@ -198,6 +206,208 @@ fn nimbos_uefi_case_uses_uefi_host_boot() {
 
     assert!(config.uefi);
     assert!(config.to_bin);
+    assert_eq!(config.success_regex, ["usertests passed!"]);
+    assert!(
+        config
+            .success_regex
+            .iter()
+            .all(|pattern| !pattern.contains("VM\\[1\\] boot success"))
+    );
+}
+
+#[test]
+fn ovmf_entry_variants_require_vm_qualified_guest_sec_output_and_trace_builds() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let case_dir = workspace_root.join("test-suit/axvisor/uefi/ovmf-entry");
+
+    for backend in ["vmx", "svm"] {
+        let qemu_path = case_dir.join(format!("qemu-x86_64-{backend}.toml"));
+        let qemu_source = fs::read_to_string(qemu_path).unwrap();
+        let qemu: QemuConfig = toml::from_str(&qemu_source).unwrap();
+        assert!(qemu.uefi);
+        assert!(qemu.to_bin);
+        assert!(
+            qemu_source.contains("nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65")
+        );
+        assert!(!qemu_source.contains("virtio-blk-pci"));
+        assert_eq!(
+            qemu.success_regex,
+            ["VM\\[1\\] guest COM1 reached OVMF SEC: SecCoreStartupWithStack\\("]
+        );
+        assert!(
+            qemu.success_regex
+                .iter()
+                .all(|pattern| !pattern.contains("VM\\[1\\] boot success"))
+        );
+
+        let build_path = case_dir.join(format!("build-x86_64-unknown-none-{backend}.toml"));
+        let build: TestOvmfBuildConfig =
+            toml::from_str(&fs::read_to_string(build_path).unwrap()).unwrap();
+        assert_eq!(build.features, ["ax-driver/nvme", "fs"]);
+        assert_eq!(build.log, "Trace");
+        assert_eq!(
+            build.vm_configs,
+            [PathBuf::from(
+                "os/axvisor/tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml"
+            )]
+        );
+    }
+}
+
+#[test]
+fn checked_in_x86_uefi_guests_use_fixed_ovmf_code_layout_and_com1() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let config_dir = workspace_root.join("os/axvisor/configs/vms/qemu/x86_64");
+
+    for guest in ["nimbos", "linux", "arceos"] {
+        let path = config_dir.join(format!("{guest}-uefi-smp1.toml"));
+        let config =
+            axvmconfig::AxVMCrateConfig::from_toml(&fs::read_to_string(path).unwrap()).unwrap();
+
+        assert_eq!(config.kernel.entry_point, 0xffff_fff0);
+        assert_eq!(config.kernel.bios_load_addr, Some(0xffc8_4000));
+        assert!(
+            config
+                .kernel
+                .memory_regions
+                .iter()
+                .any(|region| { region.gpa == 0xffc8_4000 && region.size == 0x37c000 })
+        );
+        assert!(config.devices.emu_devices.iter().any(|device| {
+            device.name == "x86-com1" && device.base_gpa == 0x3f8 && device.length == 8
+        }));
+    }
+}
+
+#[test]
+fn quick_start_persists_the_selected_uefi_vm_config() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script =
+        fs::read_to_string(workspace_root.join("os/axvisor/scripts/quick-start.sh")).unwrap();
+
+    assert!(script.contains("nimbos-x86_64-qemu-uefi-smp1.unverified.toml"));
+    assert!(script.contains("arceos-x86_64-qemu-uefi-smp1.unverified.toml"));
+    assert!(script.contains("qemu_x86_64_record_uefi_config"));
+    assert!(script.contains("qemu_x86_64_selected_uefi_config"));
+    assert!(script.contains(".selected"));
+}
+
+#[test]
+fn quick_start_uefi_selection_survives_cross_process_environment_changes() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let script = workspace_root.join("os/axvisor/scripts/quick-start.sh");
+    let root = tempdir().unwrap();
+    fs::create_dir_all(root.path().join("tmp/configs")).unwrap();
+
+    for (guest, verified, unverified) in [
+        (
+            "nimbos",
+            "tmp/configs/nimbos-x86_64-qemu-uefi-smp1.toml",
+            "tmp/configs/nimbos-x86_64-qemu-uefi-smp1.unverified.toml",
+        ),
+        (
+            "arceos",
+            "tmp/configs/arceos-x86_64-qemu-uefi-smp1.toml",
+            "tmp/configs/arceos-x86_64-qemu-uefi-smp1.unverified.toml",
+        ),
+    ] {
+        let setup_verified = Command::new("bash")
+            .args([
+                "-c",
+                r#"set -euo pipefail; source "$1"; OVMF_VERIFICATION_LABEL=VERIFIED; config=$(qemu_x86_64_setup_uefi_config_path "$2"); touch "$config"; qemu_x86_64_record_uefi_config "$2" "$config""#,
+                "quick-start-test",
+            ])
+            .arg(&script)
+            .arg(guest)
+            .current_dir(root.path())
+            .status()
+            .unwrap();
+        assert!(setup_verified.success());
+
+        let selected_verified = Command::new("bash")
+            .args([
+                "-c",
+                r#"set -euo pipefail; source "$1"; qemu_x86_64_selected_uefi_config "$2""#,
+                "quick-start-test",
+            ])
+            .arg(&script)
+            .arg(guest)
+            .env(
+                "AXVISOR_X86_64_UEFI_FIRMWARE",
+                "/different/process/firmware.fd",
+            )
+            .env("AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED", "1")
+            .current_dir(root.path())
+            .output()
+            .unwrap();
+        assert!(selected_verified.status.success());
+        assert_eq!(
+            String::from_utf8(selected_verified.stdout).unwrap().trim(),
+            verified
+        );
+
+        let cleared_selection = Command::new("bash")
+            .args([
+                "-c",
+                r#"set -euo pipefail; source "$1"; qemu_x86_64_clear_uefi_config_selection "$2"; ! qemu_x86_64_selected_uefi_config "$2" >/dev/null 2>&1"#,
+                "quick-start-test",
+            ])
+            .arg(&script)
+            .arg(guest)
+            .current_dir(root.path())
+            .status()
+            .unwrap();
+        assert!(cleared_selection.success());
+
+        let setup_unverified = Command::new("bash")
+            .args([
+                "-c",
+                r#"set -euo pipefail; source "$1"; OVMF_VERIFICATION_LABEL=UNVERIFIED; config=$(qemu_x86_64_setup_uefi_config_path "$2"); touch "$config"; qemu_x86_64_record_uefi_config "$2" "$config""#,
+                "quick-start-test",
+            ])
+            .arg(&script)
+            .arg(guest)
+            .current_dir(root.path())
+            .status()
+            .unwrap();
+        assert!(setup_unverified.success());
+
+        let selected_unverified = Command::new("bash")
+            .args([
+                "-c",
+                r#"set -euo pipefail; source "$1"; qemu_x86_64_selected_uefi_config "$2""#,
+                "quick-start-test",
+            ])
+            .arg(&script)
+            .arg(guest)
+            .env_remove("AXVISOR_X86_64_UEFI_FIRMWARE")
+            .env_remove("AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED")
+            .current_dir(root.path())
+            .output()
+            .unwrap();
+        assert!(selected_unverified.status.success());
+        assert_eq!(
+            String::from_utf8(selected_unverified.stdout)
+                .unwrap()
+                .trim(),
+            unverified
+        );
+    }
+}
+
+#[test]
+fn fixed_ovmf_load_defers_sec_matcher_until_the_registered_vm_runs() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let boot =
+        fs::read_to_string(workspace_root.join("virtualization/axvm/src/arch/x86_64/boot/mod.rs"))
+            .unwrap();
+    let arch =
+        fs::read_to_string(workspace_root.join("virtualization/axvm/src/arch/x86_64/mod.rs"))
+            .unwrap();
+
+    assert!(boot.contains("mark_fixed_ovmf_profile_loaded"));
+    assert!(!boot.contains("enable_ovmf_sec_diagnostic"));
+    assert!(arch.contains("activate_ovmf_sec_diagnostic"));
 }
 
 #[test]

--- a/test-suit/axvisor/uefi/ovmf-entry/build-x86_64-unknown-none-svm.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/build-x86_64-unknown-none-svm.toml
@@ -1,0 +1,7 @@
+features = [
+    "ax-driver/nvme",
+    "fs",
+]
+log = "Trace"
+target = "x86_64-unknown-none"
+vm_configs = ["os/axvisor/tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml"]

--- a/test-suit/axvisor/uefi/ovmf-entry/build-x86_64-unknown-none-vmx.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/build-x86_64-unknown-none-vmx.toml
@@ -1,0 +1,7 @@
+features = [
+    "ax-driver/nvme",
+    "fs",
+]
+log = "Trace"
+target = "x86_64-unknown-none"
+vm_configs = ["os/axvisor/tmp/vmconfigs/nimbos-x86_64-qemu-uefi-smp1.generated.toml"]

--- a/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-svm.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-svm.toml
@@ -1,0 +1,37 @@
+args = [
+  "-no-user-config",
+  "-display",
+  "none",
+  "-serial",
+  "stdio",
+  "-monitor",
+  "none",
+  "-cpu",
+  "host,-la57,+svm,+npt,+nrip-save",
+  "-machine",
+  "q35,smbus=off,usb=off,graphics=off",
+  "-smp",
+  "1",
+  "-accel",
+  "kvm",
+  "-device",
+  "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+  "-m",
+  "512M",
+  "-net",
+  "none",
+  "-vga",
+  "none",
+]
+timeout = 60
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+]
+# Diagnostic only: AxVM emits this VM-qualified boundary after guest COM1 has
+# written the complete OVMF SEC marker.
+success_regex = ["VM\\[1\\] guest COM1 reached OVMF SEC: SecCoreStartupWithStack\\("]
+to_bin = true
+uefi = true

--- a/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-vmx.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-vmx.toml
@@ -1,0 +1,37 @@
+args = [
+  "-no-user-config",
+  "-display",
+  "none",
+  "-serial",
+  "stdio",
+  "-monitor",
+  "none",
+  "-cpu",
+  "host,-la57,+vmx-ept,+vmx-unrestricted-guest,+vmx-flexpriority",
+  "-machine",
+  "q35,smbus=off,usb=off,graphics=off",
+  "-smp",
+  "1",
+  "-accel",
+  "kvm",
+  "-device",
+  "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+  "-m",
+  "512M",
+  "-net",
+  "none",
+  "-vga",
+  "none",
+]
+timeout = 60
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+]
+# Diagnostic only: AxVM emits this VM-qualified boundary after guest COM1 has
+# written the complete OVMF SEC marker.
+success_regex = ["VM\\[1\\] guest COM1 reached OVMF SEC: SecCoreStartupWithStack\\("]
+to_bin = true
+uefi = true

--- a/test-suit/axvisor/uefi/qemu-nimbos/qemu-x86_64.toml
+++ b/test-suit/axvisor/uefi/qemu-nimbos/qemu-x86_64.toml
@@ -21,10 +21,9 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)permission denied",
 ]
-# Keep this CI case as a bounded UEFI smoke test. The host AxVisor image must
-# also be entered through OVMF; otherwise QEMU falls back to SeaBIOS and the
-# UEFI-only AxVisor/NimbOS handoff never starts.
-success_regex = ["VM\\[1\\] boot success"]
+# This case remains non-gating until OVMF can discover a real NimbOS boot
+# source. A future gate must retain this guest-owned success marker.
+success_regex = ["usertests passed!"]
 timeout = 180
 # UEFI execution requires the converted BIN artifact on the ESP.
 to_bin = true

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -81,17 +81,66 @@ impl RuntimeAccessPorts {
     }
 }
 
-#[inline]
-#[allow(dead_code)]
-fn log_device_io(
-    addr_type: &'static str,
-    addr: impl core::fmt::LowerHex,
-    addr_range: impl core::fmt::LowerHex,
-    read: bool,
-    width: AccessWidth,
+fn trace_unregistered_device_access(access: &BusAccess) {
+    if access.is_read {
+        trace!(
+            "guest device access: device=<unregistered> bus={:?} direction=read address={:#x} \
+             width={:?} value=<unavailable> error=not-found",
+            access.kind, access.addr, access.width,
+        );
+    } else {
+        trace!(
+            "guest device access: device=<unregistered> bus={:?} direction=write address={:#x} \
+             width={:?} value={:#x} error=not-found",
+            access.kind, access.addr, access.width, access.data,
+        );
+    }
+}
+
+fn trace_device_access(
+    device: &dyn Device,
+    access: &BusAccess,
+    response: &Result<BusResponse, DeviceError>,
 ) {
-    let rw = if read { "read" } else { "write" };
-    trace!("emu_device {rw}: {addr_type} {addr:#x} in range {addr_range:#x} with width {width:?}")
+    match response {
+        Ok(BusResponse::Read { value }) => trace!(
+            "guest device access: device={} bus={:?} direction=read address={:#x} width={:?} \
+             value={:#x}",
+            device.name(),
+            access.kind,
+            access.addr,
+            access.width,
+            value,
+        ),
+        Ok(BusResponse::Write) => trace!(
+            "guest device access: device={} bus={:?} direction=write address={:#x} width={:?} \
+             value={:#x}",
+            device.name(),
+            access.kind,
+            access.addr,
+            access.width,
+            access.data,
+        ),
+        Err(error) if access.is_read => trace!(
+            "guest device access: device={} bus={:?} direction=read address={:#x} width={:?} \
+             value=<unavailable> error={:?}",
+            device.name(),
+            access.kind,
+            access.addr,
+            access.width,
+            error,
+        ),
+        Err(error) => trace!(
+            "guest device access: device={} bus={:?} direction=write address={:#x} width={:?} \
+             value={:#x} error={:?}",
+            device.name(),
+            access.kind,
+            access.addr,
+            access.width,
+            access.data,
+            error,
+        ),
+    }
 }
 
 /// Internal range entry cached in the index maps.
@@ -967,15 +1016,16 @@ impl DeviceRuntime {
             width,
             data: val as u64,
         };
-        let idx =
-            self.lookup_mmio(access.addr, access.width)
-                .ok_or(DeviceManagerError::Access {
-                    operation: "write",
-                    bus: BusKind::Mmio,
-                    addr: access.addr,
-                    width,
-                    source: DeviceError::NotFound,
-                })?;
+        let Some(idx) = self.lookup_mmio(access.addr, access.width) else {
+            trace_unregistered_device_access(&access);
+            return Err(DeviceManagerError::Access {
+                operation: "write",
+                bus: BusKind::Mmio,
+                addr: access.addr,
+                width,
+                source: DeviceError::NotFound,
+            });
+        };
         let id = DeviceId::new(idx as u32);
         let mut context = RuntimeDeviceAccess {
             device_id: id,
@@ -986,15 +1036,16 @@ impl DeviceRuntime {
             stop_grants: &self.stop_grants,
             access_ports: &self.access_ports,
         };
-        let response = self.devices[idx]
-            .access(&access, &mut context)
-            .map_err(|source| DeviceManagerError::Access {
-                operation: "write",
-                bus: BusKind::Mmio,
-                addr: access.addr,
-                width,
-                source,
-            })?;
+        let device = &self.devices[idx];
+        let response = device.access(&access, &mut context);
+        trace_device_access(device.as_ref(), &access, &response);
+        let response = response.map_err(|source| DeviceManagerError::Access {
+            operation: "write",
+            bus: BusKind::Mmio,
+            addr: access.addr,
+            width,
+            source,
+        })?;
         Self::expect_write_response(response, "write MMIO device")
     }
 
@@ -1147,7 +1198,7 @@ impl DeviceRegistry for DeviceRuntime {
 
 impl BusRouter for DeviceRuntime {
     fn dispatch(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
-        let idx = match access.kind {
+        let device_slot = match access.kind {
             BusKind::Mmio => self.lookup_mmio(access.addr, access.width),
             BusKind::Port => {
                 let port = u16::try_from(access.addr)
@@ -1159,12 +1210,17 @@ impl BusRouter for DeviceRuntime {
                     .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
                 self.lookup_sysreg(reg)
             }
-        }
-        .ok_or(DeviceError::NotFound)?;
+        };
+        let Some(device_slot) = device_slot else {
+            if access.kind != BusKind::SysReg {
+                trace_unregistered_device_access(access);
+            }
+            return Err(DeviceError::NotFound);
+        };
 
-        let device = &self.devices[idx];
+        let device = &self.devices[device_slot];
         let mut context = RuntimeDeviceAccess {
-            device_id: DeviceId::new(idx as u32),
+            device_id: DeviceId::new(device_slot as u32),
             memory: None,
             dma_grants: &self.dma_grants,
             timer_grants: &self.timer_grants,
@@ -1172,7 +1228,11 @@ impl BusRouter for DeviceRuntime {
             stop_grants: &self.stop_grants,
             access_ports: &self.access_ports,
         };
-        device.access(access, &mut context)
+        let response = device.access(access, &mut context);
+        if access.kind != BusKind::SysReg {
+            trace_device_access(device.as_ref(), access, &response);
+        }
+        response
     }
 
     fn lookup(&self, access: &BusAccess) -> Result<Arc<dyn Device>, DeviceError> {

--- a/virtualization/axvm/src/arch/x86_64/boot/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/mod.rs
@@ -24,6 +24,11 @@ mod linux_boot;
 mod mptable;
 mod multiboot;
 
+const OVMF_PROFILE_NAME: &str = "qemu_x86_64_axvisor_ovmf_debug";
+const OVMF_CODE_LOAD_GPA: usize = 0xffc8_4000;
+const OVMF_CODE_SIZE: usize = 0x37c000;
+const OVMF_RESET_VECTOR: usize = 0xffff_fff0;
+
 pub struct ImageLoader<'a>(ImageLoaderCore<'a>);
 
 impl<'a> ImageLoader<'a> {
@@ -209,7 +214,13 @@ fn load_boot_image_from_memory(loader: &ImageLoaderCore<'_>, bios: Option<&[u8]>
         let load_gpa = loader
             .bios_load_gpa
             .ok_or_else(|| ax_err_type!(NotFound, "boot firmware load address is missing"))?;
+        if loader.config.kernel.effective_boot_protocol() == VMBootProtocol::Uefi {
+            validate_uefi_firmware_layout(load_gpa, bios.len(), loader.config.kernel.entry_point)?;
+        }
         load_vm_image_from_memory(bios, load_gpa, loader.vm.clone())?;
+        if loader.config.kernel.effective_boot_protocol() == VMBootProtocol::Uefi {
+            record_uefi_firmware_loaded(loader, "<static image>", bios.len(), load_gpa);
+        }
         if should_patch_multiboot_info(&loader.config) {
             load_multiboot_info(loader, bios, load_gpa)?;
         }
@@ -242,12 +253,23 @@ fn load_boot_image_from_filesystem(loader: &ImageLoaderCore<'_>) -> AxVmResult {
             load_vm_image_from_memory(&bios, load_gpa, loader.vm.clone())?;
             load_multiboot_info(loader, &bios, load_gpa)
         } else {
+            let size =
+                query_uefi_firmware_size(loader.config.kernel.effective_boot_protocol(), || {
+                    crate::boot::images::fs::image_size(path, loader.provider)
+                })?;
+            if let Some(size) = size {
+                validate_uefi_firmware_layout(load_gpa, size, loader.config.kernel.entry_point)?;
+            }
             crate::boot::images::fs::load_vm_image(
                 path,
                 load_gpa,
                 loader.vm.clone(),
                 loader.provider,
-            )
+            )?;
+            if let Some(size) = size {
+                record_uefi_firmware_loaded(loader, path, size, load_gpa);
+            }
+            Ok(())
         }
     } else if should_load_default_boot_image(loader) {
         let load_gpa = builtin_bios_load_gpa(loader.bios_load_gpa)?;
@@ -269,7 +291,11 @@ fn load_uefi_from_configured_path(loader: &ImageLoaderCore<'_>) -> AxVmResult {
         .ok_or_else(|| ax_err_type!(NotFound, "UEFI firmware load addr is missed"))?;
     #[cfg(any(feature = "fs", feature = "host-fs"))]
     {
-        crate::boot::images::fs::load_vm_image(path, load_gpa, loader.vm.clone(), loader.provider)
+        let size = crate::boot::images::fs::image_size(path, loader.provider)?;
+        validate_uefi_firmware_layout(load_gpa, size, loader.config.kernel.entry_point)?;
+        crate::boot::images::fs::load_vm_image(path, load_gpa, loader.vm.clone(), loader.provider)?;
+        record_uefi_firmware_loaded(loader, path, size, load_gpa);
+        Ok(())
     }
     #[cfg(not(any(feature = "fs", feature = "host-fs")))]
     {
@@ -279,6 +305,71 @@ fn load_uefi_from_configured_path(loader: &ImageLoaderCore<'_>) -> AxVmResult {
             "UEFI firmware path requires the fs feature when no firmware image buffer is available"
         )
     }
+}
+
+#[cfg(any(feature = "fs", feature = "host-fs", test))]
+fn query_uefi_firmware_size(
+    protocol: VMBootProtocol,
+    query_size: impl FnOnce() -> AxVmResult<usize>,
+) -> AxVmResult<Option<usize>> {
+    if protocol == VMBootProtocol::Uefi {
+        query_size().map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+fn validate_uefi_firmware_layout(
+    load_gpa: GuestPhysAddr,
+    size: usize,
+    entry_point: usize,
+) -> AxVmResult {
+    if load_gpa.as_usize() != OVMF_CODE_LOAD_GPA {
+        return Err(ax_err_type!(
+            InvalidInput,
+            format!(
+                "x86 UEFI profile {OVMF_PROFILE_NAME} requires CODE GPA {OVMF_CODE_LOAD_GPA:#x}, \
+                 but configured {:#x}",
+                load_gpa.as_usize()
+            )
+        ));
+    }
+    if size != OVMF_CODE_SIZE {
+        return Err(ax_err_type!(
+            InvalidInput,
+            format!(
+                "x86 UEFI profile {OVMF_PROFILE_NAME} requires CODE size {OVMF_CODE_SIZE:#x}, but \
+                 image size is {size:#x}"
+            )
+        ));
+    }
+    if entry_point != OVMF_RESET_VECTOR {
+        return Err(ax_err_type!(
+            InvalidInput,
+            format!(
+                "x86 UEFI profile {OVMF_PROFILE_NAME} requires reset vector \
+                 {OVMF_RESET_VECTOR:#x}, but entry_point is {:#x}",
+                entry_point
+            )
+        ));
+    }
+    Ok(())
+}
+
+fn record_uefi_firmware_loaded(
+    loader: &ImageLoaderCore<'_>,
+    path: &str,
+    size: usize,
+    load_gpa: GuestPhysAddr,
+) {
+    let start = load_gpa.as_usize();
+    let end = start + size - 1;
+    info!(
+        "VM[{}] loaded x86 UEFI firmware: profile={} path={} size={:#x} GPA={:#x}..={:#x} \
+         reset_vector={:#x}",
+        loader.config.base.id, OVMF_PROFILE_NAME, path, size, start, end, OVMF_RESET_VECTOR
+    );
+    super::guest_serial::mark_fixed_ovmf_profile_loaded(&loader.vm);
 }
 
 fn adjust_linux_dma_identity_layout(loader: &mut ImageLoaderCore<'_>) {
@@ -528,6 +619,57 @@ mod tests {
         config.kernel.enable_bios = true;
         config.kernel.boot_protocol = Some(VMBootProtocol::Uefi);
         assert!(!should_patch_multiboot_info(&config));
+    }
+
+    #[test]
+    fn non_uefi_firmware_does_not_query_file_size() {
+        let size = query_uefi_firmware_size(VMBootProtocol::Multiboot, || {
+            panic!("non-UEFI firmware must not query file size")
+        })
+        .unwrap();
+
+        assert_eq!(size, None);
+    }
+
+    #[test]
+    fn uefi_firmware_queries_file_size() {
+        let size = query_uefi_firmware_size(VMBootProtocol::Uefi, || Ok(OVMF_CODE_SIZE)).unwrap();
+
+        assert_eq!(size, Some(OVMF_CODE_SIZE));
+    }
+
+    #[test]
+    fn fixed_ovmf_profile_constants_cover_the_reset_vector() {
+        let code_end = OVMF_CODE_LOAD_GPA + OVMF_CODE_SIZE;
+
+        assert_eq!(code_end, 0x1_0000_0000);
+        assert!(OVMF_RESET_VECTOR >= OVMF_CODE_LOAD_GPA);
+        assert!(OVMF_RESET_VECTOR + 16 <= code_end);
+    }
+
+    #[test]
+    fn fixed_ovmf_profile_rejects_wrong_layout_or_entry() {
+        let expected_gpa = GuestPhysAddr::from(OVMF_CODE_LOAD_GPA);
+
+        assert!(
+            validate_uefi_firmware_layout(expected_gpa, OVMF_CODE_SIZE, OVMF_RESET_VECTOR).is_ok()
+        );
+        assert!(
+            validate_uefi_firmware_layout(
+                GuestPhysAddr::from(OVMF_CODE_LOAD_GPA - 0x1000),
+                OVMF_CODE_SIZE,
+                OVMF_RESET_VECTOR,
+            )
+            .is_err()
+        );
+        assert!(
+            validate_uefi_firmware_layout(expected_gpa, OVMF_CODE_SIZE - 1, OVMF_RESET_VECTOR)
+                .is_err()
+        );
+        assert!(
+            validate_uefi_firmware_layout(expected_gpa, OVMF_CODE_SIZE, OVMF_RESET_VECTOR - 0x10)
+                .is_err()
+        );
     }
 
     #[test]

--- a/virtualization/axvm/src/arch/x86_64/guest_serial.rs
+++ b/virtualization/axvm/src/arch/x86_64/guest_serial.rs
@@ -1,0 +1,216 @@
+//! Guest COM1 output boundaries used by x86 firmware diagnostics.
+
+use alloc::{
+    collections::BTreeMap,
+    sync::{Arc, Weak},
+};
+
+use ax_kspin::SpinNoIrq as Mutex;
+use x86_vlapic::X86VmId;
+
+const OVMF_SEC_MARKER: &str = "SecCoreStartupWithStack(";
+
+static OVMF_SEC_DIAGNOSTICS: Mutex<OvmfSecDiagnostics> = Mutex::new(OvmfSecDiagnostics::new());
+static FIXED_OVMF_INSTANCES: Mutex<BTreeMap<X86VmId, Weak<crate::AxVM>>> =
+    Mutex::new(BTreeMap::new());
+
+pub(super) fn observe(vm_id: X86VmId, bytes: &[u8]) {
+    let reached_sec = OVMF_SEC_DIAGNOSTICS.lock().observe(vm_id, bytes);
+    if reached_sec {
+        info!(
+            "VM[{vm_id}] guest COM1 reached OVMF SEC: {}",
+            OVMF_SEC_MARKER
+        );
+    }
+}
+
+pub(super) fn activate_ovmf_sec_diagnostic(vm: &crate::AxVMRef) {
+    let fixed_ovmf_profile_loaded = FIXED_OVMF_INSTANCES
+        .lock()
+        .get(&vm.id())
+        .and_then(Weak::upgrade)
+        .is_some_and(|loaded| Arc::ptr_eq(&loaded, vm));
+    let is_registered_instance = fixed_ovmf_profile_loaded
+        && crate::manager::with_vm(vm.id(), |registered| {
+            alloc::sync::Arc::ptr_eq(registered, vm)
+        })
+        .unwrap_or(false);
+
+    OVMF_SEC_DIAGNOSTICS.lock().activate(
+        vm.id(),
+        fixed_ovmf_profile_loaded,
+        is_registered_instance,
+    );
+}
+
+pub(super) fn mark_fixed_ovmf_profile_loaded(vm: &crate::AxVMRef) {
+    // The loader calls this only after the fixed CODE image has been
+    // validated and copied. A weak, exact-instance reference keeps the
+    // qualification across reset without extending the VM lifetime.
+    FIXED_OVMF_INSTANCES
+        .lock()
+        .insert(vm.id(), Arc::downgrade(vm));
+}
+
+pub(super) fn forget_vm(vm_id: X86VmId) {
+    OVMF_SEC_DIAGNOSTICS.lock().forget(vm_id);
+}
+
+struct OvmfSecDiagnostics {
+    matchers: BTreeMap<X86VmId, MarkerMatcher>,
+}
+
+impl OvmfSecDiagnostics {
+    const fn new() -> Self {
+        Self {
+            matchers: BTreeMap::new(),
+        }
+    }
+
+    fn activate(
+        &mut self,
+        vm_id: X86VmId,
+        fixed_ovmf_profile_loaded: bool,
+        is_registered_instance: bool,
+    ) {
+        if fixed_ovmf_profile_loaded && is_registered_instance {
+            self.matchers.entry(vm_id).or_default();
+        }
+    }
+
+    fn observe(&mut self, vm_id: X86VmId, bytes: &[u8]) -> bool {
+        self.matchers
+            .get_mut(&vm_id)
+            .is_some_and(|matcher| matcher.observe(bytes))
+    }
+
+    fn forget(&mut self, vm_id: X86VmId) {
+        self.matchers.remove(&vm_id);
+    }
+}
+
+#[derive(Default)]
+struct MarkerMatcher {
+    matched: usize,
+    reported: bool,
+}
+
+impl MarkerMatcher {
+    fn observe(&mut self, bytes: &[u8]) -> bool {
+        if self.reported {
+            return false;
+        }
+
+        for &byte in bytes {
+            if byte == OVMF_SEC_MARKER.as_bytes()[self.matched] {
+                self.matched += 1;
+                if self.matched == OVMF_SEC_MARKER.len() {
+                    self.reported = true;
+                    return true;
+                }
+            } else {
+                self.matched = usize::from(byte == OVMF_SEC_MARKER.as_bytes()[0]);
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_marker_split_across_guest_writes_once() {
+        let mut matcher = MarkerMatcher::default();
+
+        assert!(!matcher.observe(b"noise SecCoreStartup"));
+        assert!(matcher.observe(b"WithStack("));
+        assert!(!matcher.observe(OVMF_SEC_MARKER.as_bytes()));
+    }
+
+    #[test]
+    fn rejects_incomplete_or_different_serial_output() {
+        let mut matcher = MarkerMatcher::default();
+
+        assert!(!matcher.observe(b"SecCoreStartupWithStack"));
+        assert!(!matcher.observe(b"[BdsDxe]"));
+    }
+
+    #[test]
+    fn serial_output_without_enabled_diagnostic_is_ignored() {
+        let mut diagnostics = OvmfSecDiagnostics::new();
+
+        assert!(!diagnostics.observe(91, OVMF_SEC_MARKER.as_bytes()));
+        assert!(diagnostics.matchers.is_empty());
+    }
+
+    #[test]
+    fn diagnostic_state_is_isolated_between_vms() {
+        let mut diagnostics = OvmfSecDiagnostics::new();
+        diagnostics.activate(1, true, true);
+        diagnostics.activate(2, true, true);
+
+        assert!(!diagnostics.observe(1, b"SecCoreStartup"));
+        assert!(diagnostics.observe(2, OVMF_SEC_MARKER.as_bytes()));
+        assert!(diagnostics.observe(1, b"WithStack("));
+        assert!(!diagnostics.observe(2, OVMF_SEC_MARKER.as_bytes()));
+    }
+
+    #[test]
+    fn enabling_an_active_vm_does_not_reset_a_partial_marker() {
+        let mut diagnostics = OvmfSecDiagnostics::new();
+        diagnostics.activate(5, true, true);
+        assert!(!diagnostics.observe(5, b"SecCoreStartup"));
+
+        diagnostics.activate(5, true, true);
+
+        assert!(diagnostics.observe(5, b"WithStack("));
+    }
+
+    #[test]
+    fn prepare_or_registration_failure_does_not_create_diagnostic_state() {
+        let mut diagnostics = OvmfSecDiagnostics::new();
+
+        diagnostics.activate(6, true, false);
+
+        assert!(diagnostics.matchers.is_empty());
+        assert!(!diagnostics.observe(6, OVMF_SEC_MARKER.as_bytes()));
+    }
+
+    #[test]
+    fn duplicate_id_activation_does_not_reset_the_registered_vm_matcher() {
+        let mut diagnostics = OvmfSecDiagnostics::new();
+        diagnostics.activate(8, true, true);
+        assert!(!diagnostics.observe(8, b"SecCoreStartup"));
+
+        diagnostics.activate(8, true, false);
+
+        assert!(diagnostics.observe(8, b"WithStack("));
+    }
+
+    #[test]
+    fn forgetting_a_vm_removes_and_resets_its_diagnostic_state() {
+        let mut diagnostics = OvmfSecDiagnostics::new();
+        diagnostics.activate(7, true, true);
+        assert!(!diagnostics.observe(7, b"SecCoreStartup"));
+
+        diagnostics.forget(7);
+        assert!(!diagnostics.observe(7, b"WithStack("));
+
+        diagnostics.activate(7, true, true);
+        assert!(diagnostics.observe(7, OVMF_SEC_MARKER.as_bytes()));
+    }
+
+    #[test]
+    fn reset_reactivates_from_the_instance_owned_firmware_state() {
+        let mut diagnostics = OvmfSecDiagnostics::new();
+        diagnostics.activate(9, true, true);
+        assert!(diagnostics.observe(9, OVMF_SEC_MARKER.as_bytes()));
+
+        diagnostics.forget(9);
+        diagnostics.activate(9, true, true);
+
+        assert!(diagnostics.observe(9, OVMF_SEC_MARKER.as_bytes()));
+    }
+}

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -40,6 +40,7 @@ pub(crate) mod boot;
 mod capabilities;
 mod exit;
 pub(crate) mod fdt;
+mod guest_serial;
 mod host_irq;
 pub(crate) mod irq;
 mod nested_paging;
@@ -68,6 +69,7 @@ impl ArchOps for X86_64Arch {
     }
 
     fn before_first_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
+        guest_serial::activate_ovmf_sec_diagnostic(vm);
         irq::enable_ioapic_irq_forwarding(vm, vcpu);
     }
 
@@ -88,6 +90,7 @@ impl ArchOps for X86_64Arch {
 
     fn on_last_vcpu_exit(vm: &crate::AxVMRef) {
         irq::disable_ioapic_irq_forwarding_for_vm(vm);
+        guest_serial::forget_vm(vm.id());
     }
 
     fn handle_vcpu_exit_bound(
@@ -270,6 +273,7 @@ impl X86VlapicHostOps for AxvmX86HostOps {
 
     fn write_bytes(bytes: &[u8]) {
         ax_std::os::arceos::modules::ax_hal::console::write_bytes(bytes);
+        guest_serial::observe(Self::current_vm_id(), bytes);
     }
 
     fn read_bytes(bytes: &mut [u8]) -> usize {


### PR DESCRIPTION
### 要解决的问题

AxVisor 已能为 x86_64 guest 选择 UEFI 启动、装载外部固件并从 reset vector `0xfffffff0` 开始执行，但原有流程存在以下问题：

- setup 会扫描宿主发行版的 `/usr/share/OVMF`，不同开发机和 CI 可能使用不同版本、构建参数或布局的固件；
- 固件装载地址会随输入文件变化，无法形成稳定的平台契约；
- `VM[1] boot success` 只表示宿主启动了 VM，不能证明 guest 固件进入 SEC，更不能证明 guest OS 启动；
- 原始串口日志会混合宿主和多个 guest 的输出，不能可靠归属于目标 VM；
- 固件停在 SEC、PEI、DXE 或 BDS 时，缺少统一的阶段标记和设备访问证据。

本 PR 实现 P0 固件入口诊断能力：固定并验证一套 OVMF DEBUG profile，严格装载 CODE窗口，通过目标 VM 的 Guest COM1 判断是否进入 SEC，并保留后续平台缺口所需的 Trace。

### 主要变更

#### 1. 固定 OVMF DEBUG profile

- 固定资产名为 `qemu_x86_64_axvisor_ovmf_debug`。
- 固定 EDK2 `edk2-stable202605`，commit`b03a21a63e3bd001f52c527e5a57feddb53a690b`。
- 使用标准 `OvmfPkg/OvmfPkgX64.dsc`、X64、DEBUG、GCC、4 MiB FD 和 COM1 debug输出。
- 关闭 SMM、Secure Boot、TPM、网络、SD card 和 confidential-computing measurement。
- 固定产物布局：

  | 文件 | 大小 | P0 用途 |
  | --- | ---: | --- |
  | `OVMF_CODE.fd` | `0x37c000` | 映射到 `0xffc84000..0xffffffff` |
  | `OVMF_VARS.fd` | `0x84000` | 仅作为发布模板和参考 QEMU 输入 |
  | `OVMF.fd` | `0x400000` | 仅用于结构及参考验证 |
  | `manifest.toml` | 不定 | 保存来源、布局、构建参数和文件哈希 |

P0 只把 CODE 装载到 guest，不把 VARS 当作普通 RAM 映射，避免承诺尚未实现的 flash
写入、擦除和持久化语义。

#### 2. 严格校验固件资产

- 默认 setup 只从 tgosimages 获取固定 bundle，不再扫描发行版 OVMF 路径。
- 增加受限 flat TOML manifest parser，拒绝重复 key、table、quoted key、array、inline table 和多行值。
- 消费端校验 profile 身份、EDK2 revision、构建开关、布局、单文件大小和 SHA-256。
- 校验 `OVMF_VARS.fd + OVMF_CODE.fd == OVMF.fd`，并确认 reset vector 位于 CODE 覆盖范围。
- 本地固件必须同时设置固件路径和`AXVISOR_X86_64_UEFI_ALLOW_UNVERIFIED=1`；setup 会输出 `UNVERIFIED` 和实际SHA-256，并生成与 verified 配置隔离的文件。
- `quick-start.sh setup` 原子记录本次生成的配置；后续 `run` 使用该记录，不根据新进程的环境变量重新推导配置。失败的 setup 不会继续使用陈旧选择。

#### 3. 固定 CODE 装载契约

- 沿用现有 VM 配置字段，不增加公开配置接口。
- 所有 x86 UEFI 配置保持 `entry_point = 0xfffffff0`，并注册 `x86-com1`。
- AxVM 只接受 `bios_load_addr = 0xffc84000`、大小 `0x37c000` 的固定 CODE 布局，不再根据任意输入文件推测地址窗口。
- 装载成功时记录 profile、verification、路径、实际哈希、大小、GPA 区间和 reset vector。
- 固件成功复制后，以弱引用记录精确的 AxVM 实例资格，不延长 VM 生命周期，也不让相同 VM ID 的其他实例继承资格。

#### 4. 用 Guest COM1 建立 VM 限定的 SEC 判定

- 只有已经装载固定 profile、完成注册并进入首次 vCPU 运行的精确 AxVM 实例才会激活 SEC matcher。
- matcher 支持 marker 跨多次串口写入；多 vCPU 重复激活保持幂等，不会清空已匹配前缀。
- reset 后由同一实例资格重新激活，最后一个 vCPU 退出时清理 matcher。
- prepare/register 失败、普通 Guest COM1 输出和相同 ID 的未注册实例不会产生成功状态。
- 只有完整观察到 `SecCoreStartupWithStack(` 后才输出：

  ```text
  VM[<id>] guest COM1 reached OVMF SEC: SecCoreStartupWithStack(
  ```

`ovmf-entry` 只匹配这条 VM-qualified 边界，不匹配原始串口片段或宿主 VM 启动日志。

#### 5. 补齐统一设备访问 Trace

- 在最新 `DeviceRuntime`/`Device::access` 统一路径记录设备名、总线类型、读写方向、地址、宽度、值和结果。
- 同时覆盖普通 PIO/MMIO/SysReg dispatch 和带 guest-memory capability 的 MMIO write 路径。
- Trace 不绕过 width-aware resource lookup。
- 未注册或不支持的资源继续返回 typed error；不会伪造全 1 读取或静默忽略写入。

#### 6. 拆分 UEFI 测试语义

- 新增 `ovmf-entry-vmx` 和 `ovmf-entry-svm` 诊断用例，其成功条件只能来自目标 VM 的 Guest COM1 SEC 边界。
- 两个用例使用与最新 `dev` 一致的 host NVMe rootfs 配置；VMX/SVM 后端仍由运行时 CPUID 选择，build config 保持 backend-neutral。
- `qemu-nimbos` 不再接受 `VM[1] boot success`，只保留 NimbOS 自有 `usertests passed!` 作为未来完整启动成功条件。
- UEFI 用例在完整平台能力和真实资产证据闭合前保持 non-gating。
- direct VMX/SVM smoke 和既有 multiboot 回归语义不变。

#### 7. 文档与调试流程

- 增加 x86 guest OVMF profile、verified/unverified 用法、阶段 marker、超时分类和参考资格测试说明。
- 同步 quick-start、CI 文档和 `arch-platform-porting` UEFI 调试参考。
- 固定阶段标记为：
  - SEC：`SecCoreStartupWithStack(`
  - PEI：`Platform PEIM Loaded`
  - DXE：`DXE IPL Entry` 或 `Loading DXE CORE at`
  - BDS：`[BdsDxe]`
  - OS：EFI 应用或 guest OS 自有成功标记

### 实现逻辑

1. registry 的归档校验不能替代消费端校验，因此 setup 仍逐项验证 manifest、布局和文件内容。
2. P0 只证明固定 CODE 能进入 SEC；VARS、pflash 和完整 q35 平台属于新的设备语义，不通过 RAM 映射或兼容返回值提前模拟。
3. 成功状态归 guest 所有。固件 loader 成功和 VM 进入 Running 都不是 guest bootsuccess。
4. SEC observer 绑定精确 AxVM 实例和 lifecycle，避免初始化失败、VM ID 重用、reset 和多 vCPU 场景污染全局诊断状态。
5. Trace 保持现有设备框架的 lookup、capability 和 typed-error 语义，只增加诊断证据。
6. host NVMe 只承载 AxVisor rootfs；后续 guest virtio-blk 是独立的虚拟设备能力，两者不混用。

### 范围与兼容性

本 PR：

- 不增加公开 VM 配置字段；
- 不加载或模拟 VARS；
- 不实现 pflash、x86 fw_cfg、ACPI/q35、PCI、guest virtio-blk、PM、SMM、Secure
  Boot 或 TPM；
- 不把 `ovmf-entry` 解释为 guest OS 已经启动；
- 不要求 `qemu-nimbos` 在 P0 通过；
- 不修改 direct VMX/SVM smoke 的成功语义。

用户可见的行为变化是：AxVisor x86 guest UEFI setup 默认不再搜索宿主发行版 OVMF，
而是要求固定 tgosimages bundle；本地同布局固件必须显式进入 unverified 模式。

### 未完成的验证

- 确认 `qemu_x86_64_axvisor_ovmf_debug` 已在 tgosimages 发布并可由 setup 拉取；
- 在同一不可变容器 digest 的两个干净 workspace 构建，证明 CODE、VARS 和合并镜像逐字节一致；
- 检查固定大小、拼接关系、reset vector，并确认构建报告包含 Shell、`VirtioPciDeviceDxe`、`Virtio10Dxe` 和 `VirtioBlkDxe`；
- 标准 QEMU q35 + TCG 下依次取得 SEC、PEI、DXE、BDS 和`AXVISOR_OVMF_REFERENCE_BOOT_OK`；
- 完成参考 QEMU 二次启动，确认工作 VARS 可变化而发布模板哈希不变；
- 在 Intel/VMX 和 AMD/SVM 上分别运行 direct smoke；
- 在 Intel/VMX 和 AMD/SVM 上分别运行 `ovmf-entry`，取得 VM-qualified SECmarker；
- 保存完整 Trace，并记录 SEC 后首个未支持的平台访问。