### PR TITLE
fix(gicv2): use GICv2 CPU target masks

### DIFF
--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -141,6 +141,9 @@ work even when the kernel image and CPU topology are correct.
   Cortex-A72 MPIDRs `0x100` through `0x103`. Keep these hardware IDs separate
   from dense logical CPU indices. Both the maintained single-core board test
   and an eight-core boot have been validated.
+- GICv2 CPU target bits are firmware/controller interface IDs, not dense
+  logical CPU indices. Record each CPU's banked `GICD_ITARGETSR0` mask during
+  per-CPU initialization and reuse that mask for SPI affinity and SGIs.
 - The RK3576 CRU node must be `rockchip,rk3576-cru` at `0x2720_0000`, size
   `0x50000`. Early driver evidence should include
   `RK3576 CRU reg: addr=0x27200000, size=0x50000` followed by

--- a/drivers/intc/arm-gic-driver/src/version/v2/gicd.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v2/gicd.rs
@@ -151,7 +151,11 @@ impl DistributorReg {
     }
 
     /// Configure interrupt targets for SPIs (Shared Peripheral Interrupts)
-    pub(crate) fn configure_interrupt_targets(&self, max_interrupts: u32) {
+    pub(crate) fn configure_interrupt_targets(
+        &self,
+        max_interrupts: u32,
+        bsp_target: super::TargetList,
+    ) {
         // SGIs (0-15) and PPIs (16-31) don't use ITARGETSR
         // Only SPIs (32+) need target configuration
         if max_interrupts <= 32 {
@@ -160,7 +164,7 @@ impl DistributorReg {
 
         let total_interrupts = (max_interrupts as usize).min(self.ITARGETSR.len());
         for i in 32..total_interrupts {
-            self.ITARGETSR[i].set(0x01);
+            self.ITARGETSR[i].set(bsp_target.as_u8());
         }
     }
 

--- a/drivers/intc/arm-gic-driver/src/version/v2/mod.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v2/mod.rs
@@ -90,6 +90,7 @@ impl Gic {
             "Initializing GICv2 Distributor@{:#p}...",
             self.gicd.as_ptr::<u8>()
         );
+        let bsp_target = self.cpu_interface().current_cpu_target();
         // 1. Disable the Distributor first
         self.gicd().disable();
 
@@ -113,8 +114,11 @@ impl Gic {
         self.gicd().set_default_spi_priorities(max_spi);
 
         // 8. Configure interrupt targets (for SPIs)
-        self.gicd().configure_interrupt_targets(max_spi);
-        trace!("[GICv2] Configure all SPIs to target cpu 0");
+        self.gicd().configure_interrupt_targets(max_spi, bsp_target);
+        trace!(
+            "[GICv2] Configure all SPIs to target BSP mask {:#04x}",
+            bsp_target.as_u8()
+        );
         // 9. Configure interrupt configuration (edge/level trigger)
         self.gicd().configure_interrupt_config(max_spi);
 
@@ -273,6 +277,11 @@ pub enum SGITarget {
 pub struct TargetList(u8);
 
 impl TargetList {
+    /// Creates a target list from the CPU target mask reported by GICv2.
+    pub const fn from_raw(raw: u8) -> Self {
+        Self(raw)
+    }
+
     /// Create a new TargetList with a specific CPU target list. list is Cpu interface IDs.
     pub fn new(list: impl Iterator<Item = usize>) -> Self {
         let mut raw = 0;
@@ -359,6 +368,11 @@ impl CpuInterface {
 
     fn gicd(&self) -> &DistributorReg {
         unsafe { &*self.gicd }
+    }
+
+    /// Returns the banked CPU target mask for the current CPU interface.
+    pub fn current_cpu_target(&self) -> TargetList {
+        TargetList::from_raw(self.gicd().ITARGETSR[0].get())
     }
 
     /// Initialize the CPU interface for the current CPU
@@ -986,13 +1000,41 @@ mod tests {
     use super::*;
 
     #[test]
-    fn distributor_initializes_all_spi_byte_registers() {
-        let mut regs = std::boxed::Box::new([0u8; 0x1000]);
-        let gic = unsafe { Gic::new(VirtAddr::from(regs.as_mut_ptr()), VirtAddr::new(0), None) };
+    fn target_list_preserves_banked_cpu_target_mask() {
+        let target = TargetList::from_raw(0x20);
 
-        let max_interrupts = 64;
-        gic.gicd().set_default_spi_priorities(max_interrupts);
-        gic.gicd().configure_interrupt_targets(max_interrupts);
+        assert_eq!(target.as_u8(), 0x20);
+        assert_eq!(target.cpu_id_list().collect::<std::vec::Vec<_>>(), [5]);
+    }
+
+    #[test]
+    fn cpu_interface_reads_current_banked_target_mask() {
+        let mut distributor = std::boxed::Box::new([0u8; 0x1000]);
+        let mut cpu_registers = std::boxed::Box::new([0u8; 0x1000]);
+        let cpu = CpuInterface {
+            gicd: distributor.as_mut_ptr().cast(),
+            gicc: cpu_registers.as_mut_ptr().cast(),
+        };
+        cpu.gicd().ITARGETSR[0].set(0x40);
+
+        assert_eq!(cpu.current_cpu_target().as_u8(), 0x40);
+    }
+
+    #[test]
+    fn distributor_initializes_spis_with_bsp_target_mask() {
+        let mut regs = std::boxed::Box::new([0u8; 0x1000]);
+        regs[4..8].copy_from_slice(&1u32.to_ne_bytes());
+        regs[0x800] = 0x40;
+        let mut gic = unsafe {
+            Gic::new(
+                VirtAddr::from(regs.as_mut_ptr()),
+                VirtAddr::from(regs.as_mut_ptr()),
+                None,
+            )
+        };
+
+        let bsp_target = TargetList::from_raw(0x40);
+        gic.init();
 
         let regs = gic.gicd();
         assert_eq!(regs.IPRIORITYR[31].get(), 0);
@@ -1001,8 +1043,8 @@ mod tests {
         assert_eq!(regs.IPRIORITYR[64].get(), 0);
 
         assert_eq!(regs.ITARGETSR[31].get(), 0);
-        assert_eq!(regs.ITARGETSR[32].get(), 0x01);
-        assert_eq!(regs.ITARGETSR[63].get(), 0x01);
+        assert_eq!(regs.ITARGETSR[32].get(), bsp_target.as_u8());
+        assert_eq!(regs.ITARGETSR[63].get(), bsp_target.as_u8());
         assert_eq!(regs.ITARGETSR[64].get(), 0);
     }
 }

--- a/platforms/somehal/src/arch/aarch64/gic/mod.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/mod.rs
@@ -38,13 +38,13 @@ pub fn init_current_cpu() {
 
 pub fn init_cpu(cpu_idx: usize) {
     match backend() {
-        GicBackend::V2 => v2::init_cpu(),
+        GicBackend::V2 => v2::init_cpu(cpu_idx),
         GicBackend::V3 => v3::init_cpu(cpu_idx),
         GicBackend::None => {
             if v3::is_support_icc() {
                 v3::init_cpu(cpu_idx);
             } else {
-                v2::init_cpu();
+                v2::init_cpu(cpu_idx);
             }
         }
     }

--- a/platforms/somehal/src/arch/aarch64/gic/v2.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/v2.rs
@@ -1,4 +1,5 @@
 use alloc::format;
+use core::sync::atomic::{AtomicU8, Ordering};
 
 use arm_gic_driver::{checked_intid, v2::*};
 use irq_framework::IrqId;
@@ -9,6 +10,10 @@ use crate::common::ioremap;
 
 static CPU_IF: StaticCell<CpuInterface> = StaticCell::uninit();
 static TRAP: StaticCell<TrapOp> = StaticCell::uninit();
+// GICv2 represents CPU interfaces with one bit in an 8-bit target mask.
+const MAX_GIC_V2_CPU_INTERFACES: usize = 8;
+static CPU_TARGETS: [AtomicU8; MAX_GIC_V2_CPU_INTERFACES] =
+    [const { AtomicU8::new(0) }; MAX_GIC_V2_CPU_INTERFACES];
 
 module_driver!(
     name: "GICv2",
@@ -72,7 +77,9 @@ fn probe_gic(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     TRAP.init(trap);
     super::set_backend(super::GicBackend::V2);
 
-    init_cpu();
+    let cpu_idx = crate::cpu::current_cpu_idx()
+        .unwrap_or_else(|| panic!("current logical CPU index is not available for GICv2 init"));
+    init_cpu(cpu_idx);
 
     let domain = crate::irq::alloc_irq_domain(
         dev.descriptor.device_id(),
@@ -122,16 +129,21 @@ pub fn begin_irq() -> Option<ActiveIrq> {
     })
 }
 
-pub fn init_cpu() {
-    unsafe {
+pub fn init_cpu(cpu_idx: usize) {
+    let target = unsafe {
         CPU_IF.update(|cpu| {
             cpu.init_current_cpu();
             #[cfg(feature = "hv")]
             cpu.set_eoi_mode_ns(true);
-        });
-    }
+            cpu.current_cpu_target()
+        })
+    };
+    record_cpu_target(cpu_idx, target);
 
-    debug!("GICCv2 initialized");
+    debug!(
+        "GICCv2 initialized for logical CPU {cpu_idx}, target mask {:#04x}",
+        target.as_u8()
+    );
 }
 
 pub fn irq_set_enable(irq: IrqId, enable: bool) -> Result<(), crate::irq::IrqError> {
@@ -158,10 +170,10 @@ pub fn irq_set_affinity(
     let crate::irq::IrqAffinity::Fixed { cpu_id } = affinity else {
         return Ok(());
     };
-    let target_cpu = super::hardware_cpu_id(cpu_id);
+    let target_cpu = cpu_target(cpu_id).ok_or(crate::irq::IrqError::InvalidIrq)?;
     super::with_gic_domain::<Gic, _>(irq.domain, |gic| {
         let intid = checked_runtime_intid(irq.hwirq.0, gic.max_intid())?;
-        gic.set_target_cpu(intid, TargetList::new(&mut core::iter::once(target_cpu)));
+        gic.set_target_cpu(intid, target_cpu);
         Ok::<(), crate::irq::IrqError>(())
     })??;
     Ok(())
@@ -180,10 +192,29 @@ pub fn send_ipi(raw: usize, target: crate::irq::IpiTarget) {
     let target = match target {
         crate::irq::IpiTarget::Current { cpu_id: _ } => SGITarget::Current,
         crate::irq::IpiTarget::Other { cpu_id } => {
-            let target_cpu = super::hardware_cpu_id(cpu_id);
-            SGITarget::TargetList(TargetList::new(&mut core::iter::once(target_cpu)))
+            let target_cpu = cpu_target(cpu_id).unwrap_or_else(|| {
+                panic!("GICv2 target is not initialized for logical CPU {cpu_id}")
+            });
+            SGITarget::TargetList(target_cpu)
         }
         crate::irq::IpiTarget::AllExceptCurrent { .. } => SGITarget::AllOther,
     };
     CPU_IF.send_sgi(sgi, target);
+}
+
+fn record_cpu_target(cpu_idx: usize, target: TargetList) {
+    let target_mask = target.as_u8();
+    assert!(
+        target_mask.is_power_of_two(),
+        "invalid GICv2 target mask {target_mask:#04x} for logical CPU {cpu_idx}"
+    );
+    let slot = CPU_TARGETS
+        .get(cpu_idx)
+        .unwrap_or_else(|| panic!("GICv2 logical CPU index out of range: {cpu_idx}"));
+    slot.store(target_mask, Ordering::Release);
+}
+
+fn cpu_target(cpu_idx: usize) -> Option<TargetList> {
+    let target_mask = CPU_TARGETS.get(cpu_idx)?.load(Ordering::Acquire);
+    (target_mask != 0).then(|| TargetList::from_raw(target_mask))
 }


### PR DESCRIPTION
## 问题

GICv2 的 CPU target 由 `GICD_ITARGETSR` 中的 8 位 CPU interface mask 表示，它与内核逻辑 CPU 编号以及 MPIDR/固件 CPU ID 不是同一概念。

原实现将 `someboot` 提供的硬件 CPU ID 直接用于构造 GICv2 `TargetList`。在 MPIDR 不连续或大于 7 的平台上，这可能导致：

- SPI 中断被路由到错误的 CPU；
- 定向 SGI/IPI 无法送达目标 CPU；
- 将大于 7 的硬件 CPU ID 当作 GICv2 interface ID 时触发断言；
- SMP 场景下出现中断、调度或跨 CPU 唤醒异常。

## 修改内容

- 为 GICv2 `TargetList` 增加 `from_raw()`，允许保留硬件报告的原始 CPU target mask。
- 为 `CpuInterface` 增加 `current_cpu_target()`，从当前 CPU banked `GICD_ITARGETSR0` 读取真实 target mask。
- 在每个逻辑 CPU 初始化 GICv2 CPU interface 时，记录其逻辑 CPU 编号与 GICv2 target mask 的映射。
- 设置 SPI 中断亲和性时，通过记录的映射获取目标 CPU mask，不再从 MPIDR或逻辑 CPU 编号推算。
- 发送定向 SGI/IPI 时使用目标 CPU 实际的 GICv2 target mask。
- 对未初始化、越界或非法的 CPU target mask 增加显式检查。
- 更新架构移植调试文档，记录 GICv2 CPU target bit 与逻辑 CPU/MPIDR 的区别。

## 实现逻辑

每个 CPU 在初始化自己的 GICv2 CPU interface 后读取 banked `GICD_ITARGETSR0`。该寄存器提供当前 CPU interface 对应的真实 target bit。

读取结果按照逻辑 CPU 编号保存在原子数组中：

```text
logical CPU ID -> GICv2 CPU target mask
```

后续 SPI affinity 和定向 SGI/IPI 操作仍以逻辑 CPU 编号作为上层接口，但在 GICv2 后端转换为硬件实际报告的 target mask。

GICv2 的 CPU target 字段只有 8 位，因此映射最多保存 8 个 CPU interface。数组使用 AtomicU8 和 Acquire/Release 顺序，使中断及 IPI 路径可以无锁读取已经发布的 target mask。

GICv3 的 MPIDR affinity 处理保持不变。