### PR TITLE
test(gpu-opencl-compute): OpenCL compute carpet - GPU virtio-gpu vGPU

### DIFF
--- a/apps/starry/gpu-opencl/README.md
+++ b/apps/starry/gpu-opencl/README.md
@@ -1,0 +1,13 @@
+# gpu-opencl (G-side, virtio-gpu vGPU)
+
+Placeholder reserving the GPU-side counterpart of the CPU-side software carpet
+`cpu-opencl` (#1574). It exercises the same OpenCL API surface and the same full
+language-binding cartesian (C / C++ / Rust / Python / JS / TS / Kotlin) as the
+CPU side, but against the qemu virtio-gpu virtual GPU device (real GPU ICD over
+the virtio-gpu 3D/compute render node) under -smp 1, instead of the pocl/rusticl
+CPU software rasterizer.
+
+Blocked on the virtio-gpu 3D/compute driver bring-up (virtio-drivers 3D transport
+plus the StarryOS render-node path). Tracked in
+campaign-records/taskbook-G-virtio-gpu-bringup.md. Closed until the driver
+foundation lands; it will be completed and reopened.


### PR DESCRIPTION
G-side (qemu virtio-gpu vGPU, -smp 1) counterpart of the CPU-side software carpet cpu-opencl (#1574). Same OpenCL API surface and the same full language-binding cartesian (C / C++ / Rust / Python / JS / TS / Kotlin), but on the virtio-gpu virtual GPU device (real GPU ICD over the 3D/compute render node) instead of the pocl/rusticl CPU software rasterizer.

Placeholder: blocked on the virtio-gpu 3D/compute driver bring-up (virtio-drivers 3D transport plus the StarryOS render-node path). Closed until that driver foundation lands; it will be completed and reopened.