### PR TITLE
test(gpu-vulkan-render): Vulkan rendering carpet - GPU virtio-gpu vGPU

### DIFF
--- a/apps/starry/gpu-vulkan-render/README.md
+++ b/apps/starry/gpu-vulkan-render/README.md
@@ -1,0 +1,5 @@
+# gpu-vulkan-render (GPU virtio-gpu vGPU (-smp1), Vulkan rendering)
+
+Placeholder reserving the GPU virtio-gpu vGPU Vulkan RENDERING-pipeline carpet - the rendering-track counterpart of the Vulkan compute carpet (#1806). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: C / C++ / Rust / Python.
+
+Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.


### PR DESCRIPTION
# gpu-vulkan-render (GPU virtio-gpu vGPU (-smp1), Vulkan rendering)

Placeholder reserving the GPU virtio-gpu vGPU Vulkan RENDERING-pipeline carpet - the rendering-track counterpart of the Vulkan compute carpet (#1806). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: C / C++ / Rust / Python.

Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.