### PR TITLE
test(gpu-opengl-render): OpenGL rendering carpet - GPU virtio-gpu vGPU

### DIFF
--- a/apps/starry/gpu-opengl-render/README.md
+++ b/apps/starry/gpu-opengl-render/README.md
@@ -1,0 +1,5 @@
+# gpu-opengl-render (GPU virtio-gpu vGPU (-smp1), OpenGL rendering)
+
+Placeholder reserving the GPU virtio-gpu vGPU OpenGL RENDERING-pipeline carpet - the rendering-track counterpart of the OpenGL compute carpet (#1807). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: JS (WebGL) / C++ / Python.
+
+Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.


### PR DESCRIPTION
# gpu-opengl-render (GPU virtio-gpu vGPU (-smp1), OpenGL rendering)

Placeholder reserving the GPU virtio-gpu vGPU OpenGL RENDERING-pipeline carpet - the rendering-track counterpart of the OpenGL compute carpet (#1807). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: JS (WebGL) / C++ / Python.

Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.