### PR TITLE
test(gpu-gles-render): OpenGL ES rendering carpet - GPU virtio-gpu vGPU

### DIFF
--- a/apps/starry/gpu-gles-render/README.md
+++ b/apps/starry/gpu-gles-render/README.md
@@ -1,0 +1,5 @@
+# gpu-gles-render (GPU virtio-gpu vGPU (-smp1), OpenGL ES rendering)
+
+Placeholder reserving the GPU virtio-gpu vGPU OpenGL ES RENDERING-pipeline carpet - the rendering-track counterpart of the OpenGL ES compute carpet (#1808). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: JS (WebGL2) / C++ / Python.
+
+Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.


### PR DESCRIPTION
# gpu-gles-render (GPU virtio-gpu vGPU (-smp1), OpenGL ES rendering)

Placeholder reserving the GPU virtio-gpu vGPU OpenGL ES RENDERING-pipeline carpet - the rendering-track counterpart of the OpenGL ES compute carpet (#1808). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: JS (WebGL2) / C++ / Python.

Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.