### PR TITLE
test(gpu-wgpu-render): wgpu rendering carpet - GPU virtio-gpu vGPU

### DIFF
--- a/apps/starry/gpu-wgpu-render/README.md
+++ b/apps/starry/gpu-wgpu-render/README.md
@@ -1,0 +1,5 @@
+# gpu-wgpu-render (GPU virtio-gpu vGPU (-smp1), wgpu rendering)
+
+Placeholder reserving the GPU virtio-gpu vGPU wgpu RENDERING-pipeline carpet - the rendering-track counterpart of the wgpu compute carpet (#1809). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: Rust / C / C++ / Python.
+
+Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.


### PR DESCRIPTION
# gpu-wgpu-render (GPU virtio-gpu vGPU (-smp1), wgpu rendering)

Placeholder reserving the GPU virtio-gpu vGPU wgpu RENDERING-pipeline carpet - the rendering-track counterpart of the wgpu compute carpet (#1809). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: Rust / C / C++ / Python.

Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.