### PR TITLE
test(cpu-webgpu-render): WebGPU rendering carpet - CPU software

### DIFF
--- a/apps/starry/cpu-webgpu-render/.gitignore
+++ b/apps/starry/cpu-webgpu-render/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+node_modules
+programs/carpets/webgpu_ts/webgpu_render_ts_full_api.js
+target/

--- a/apps/starry/cpu-webgpu-render/README.md
+++ b/apps/starry/cpu-webgpu-render/README.md
@@ -1,0 +1,120 @@
+# cpu-webgpu-render - WebGPU render-API carpet (JS / TS, Deno on-target)
+
+WebGPU render cells (JavaScript + TypeScript) that drive the WebGPU rendering pipeline - adapter,
+device, render pipelines, vertex/fragment shaders (WGSL), render passes, textures, depth/stencil,
+blend, scissor/viewport, all draw topologies, `copyTextureToBuffer` readback - render offscreen to an
+RGBA8 texture, read the pixels back, and assert every pixel against a closed-form reference computed
+independently in the same language. They run **on StarryOS via Deno**, whose built-in WebGPU is
+**gfx-rs wgpu-core** landing on **Mesa lavapipe** (software Vulkan on the CPU, no GPU required). This
+is the render-track counterpart of the WebGPU compute carpet `cpu-webgpu-compute`.
+
+## The two WebGPU engines (why this app is the Firefox/Deno path)
+
+There are two production WebGPU implementations, and this matters for what runs on musl:
+
+- **Chromium's WebGPU = Dawn** (C++). Shipped as the `webgpu` npm dawn native addon, a glibc-only
+  prebuilt, so musl Node cannot load it. Dawn's on-target home is inside the browser (campaign #391).
+- **Firefox / Servo / Deno's WebGPU = wgpu** (gfx-rs, Rust: `wgpu-core` / `wgpu-native`). This is the
+  **exact engine `cpu-wgpu-render` #1820 builds on musl** for all four arches. Deno embeds `wgpu-core`
+  directly, so a musl Deno gives us the JS/TS WebGPU surface on-target with no new engine to build - we
+  only test an existing runtime.
+
+### Verified call chain (source + strace, not assumed)
+
+```
+navigator.gpu (Deno JS/TS global)
+ -> deno_webgpu            [Deno ext/webgpu: "WebGPU implementation for Deno"]
+ -> wgpu-core + wgpu-types (gfx-rs; feature "vulkan" on Unix)
+ -> wgpu-hal               (hardware abstraction layer)
+ -> ash (Vulkan FFI) + libloading (runtime loader)          <-- source chain ends here
+ -> dlopen libvulkan.so.1                       (Vulkan loader)          <-- strace
+ -> /usr/share/vulkan/icd.d/lvp_icd.json        (ICD manifest)          <-- strace
+ -> libvulkan_lvp.so                            (Mesa lavapipe, sw Vulkan) <-- strace
+ -> libgallium + libLLVM                        (llvmpipe CPU JIT)      <-- strace
+ -> WGSL -> SPIR-V -> NIR -> LLVM -> host CPU machine code (runs on the CPU)
+```
+
+The render pipeline rasterizes on the CPU (llvmpipe); there is no GPU in the path.
+
+## Cells
+
+| cell | file | assertions | on-target |
+|------|------|-----------:|-----------|
+| webgpu_js | `programs/carpets/webgpu_js/webgpu_render_js_full_api.js` | 56 | x86_64 + aarch64 (Deno) |
+| webgpu_ts | `programs/carpets/webgpu_ts/webgpu_render_ts_full_api.ts` | 56 | x86_64 + aarch64 (Deno, runs .ts natively) |
+| scene_2dui_js | `programs/carpets/scene_2dui_js/scene_2dui_js.js` | 28 | x86_64 + aarch64 (Deno) |
+| scene_2dui_ts | `programs/carpets/scene_2dui_ts/scene_2dui_ts.ts` | 28 | x86_64 + aarch64 (Deno) |
+| scene_3dmodel_js | `programs/carpets/scene_3dmodel_js/scene_3dmodel_js.js` | 14 | x86_64 + aarch64 (Deno) |
+| scene_3dmodel_ts | `programs/carpets/scene_3dmodel_ts/scene_3dmodel_ts.ts` | 14 | x86_64 + aarch64 (Deno) |
+| scene_anim_js | `programs/carpets/scene_anim_js/scene_anim_js.js` | 38 | x86_64 + aarch64 (Deno) |
+| scene_anim_ts | `programs/carpets/scene_anim_ts/scene_anim_ts.ts` | 38 | x86_64 + aarch64 (Deno) |
+| scene_codec_js | `programs/carpets/scene_codec_js/scene_codec_js.js` | 15 | x86_64 + aarch64 (Deno) |
+| scene_codec_ts | `programs/carpets/scene_codec_ts/scene_codec_ts.ts` | 15 | x86_64 + aarch64 (Deno) |
+
+Each cell prints `<MARKER> OK <n>` only when every assertion passes and the count equals the pinned total,
+together with a `PASS=<p> FAIL=<f> TOTAL=<t> EXPECTED=<e>` line. The full-API cells
+(`WEBGPU_RENDER_<LANG>_FULL_API`) and the four render-scene cells (`SCENE_<NAME>_<LANG>`) each have a JS and
+a TS variant that mirror one-for-one (WGSL shaders, geometry, per-pixel assertions) and match the Rust
+parity cells in `cpu-wgpu-render` (#1820): full-API EXPECTED=56, scene_2dui=28, scene_3dmodel=14,
+scene_anim=38, scene_codec=15.
+
+## Render scenes (WebGPU port of the wgpu Rust render-scene cells)
+
+The four scenarios each render offscreen and assert every pixel against an INDEPENDENT closed-form
+reference computed in the same language (not read back from the GPU). WebGPU is top-origin (readback row 0 =
+top, NDC y=+1); every pixel-space vertex shader flips NDC y so pixel-row == readback-row while the
+closed-form arithmetic stays byte-identical to the wgpu Rust reference.
+
+- **scene_2dui**: filled rects, an analytic rounded-rect (corner-arc discard in the fragment shader), a
+  nine-patch scaled border frame, an 8x8 bitmap-font glyph blit (`setScissorRect` + nearest texture
+  sampling), and MULTI-LAYER Porter-Duff `over` compositing of 3 semi-transparent layers
+  (src-alpha / one-minus-src-alpha blend).
+- **scene_3dmodel**: an indexed cube with a hand-built perspective MVP (WebGPU NDC z in [0,1]), depth32float
+  + `CompareFunction 'less'` occlusion and Gouraud shading, checked against an independent software
+  rasterizer (barycentric coverage + 1/w perspective-correct color interpolation + private z-buffer). The
+  vertex shader carries `@invariant` on `@builtin(position)` so the rasterized depth is bit-exact.
+- **scene_anim**: 4 keyframes of a unit quad transformed by `R(angle(t))*S(scale(ease(t)))+T(center(t))`,
+  with a cubic ease `3t^2-2t^3`; the four transformed corners and the eased scale are asserted per frame
+  against the closed form.
+- **scene_codec**: BT.601 YUV->RGB (three planes sampled as textures, 4:2:0 nearest chroma), chroma
+  4:2:0->4:4:4 nearest upsample, bilinear 2x downscale = 2x2 box average, plus an 8-point DCT-II/IDCT
+  round-trip and an RLE round-trip identity (the DCT/RLE math is pure JS/TS; the conversions run on
+  textures + fragment shaders).
+
+## What each pixel proves
+
+64x64 rgba8unorm `RENDER_ATTACHMENT | COPY_SRC` texture, `copyTextureToBuffer` with 256-byte
+`bytesPerRow` padding then unpad on readback, per-pixel hard assert against a closed form:
+
+- clear (`loadOp:'clear'`), uniform-buffer solid quad, axis-aligned gradient, `@builtin(position)`
+  checkerboard, `setScissorRect`, `setViewport`, alpha blend, sub-rect readback
+- all 5 draw topologies (point / line-list / line-strip / triangle-list / triangle-strip; WebGPU has
+  no triangle-fan, and points are always 1px)
+- blend factor + op matrix (one/zero, additive, zero/one, dst/zero, max, reverse-subtract)
+- all 8 depth compare functions on depth32float with `@invariant` on the vertex `@builtin(position)`
+  (quad z=0.5 vs clear 0.75 -> only always / less / less-equal / not-equal draw)
+- cull + winding (none / back x ccw-vs-cw / front), color write mask (RED vs ALL), limit/format
+  queries, and a 2x2 nearest-sampled texture (TL red / TR green / BL blue / BR white)
+
+## Arch coverage
+
+The WebGPU standalone JS/TS runtime is Deno, and Deno's musl arch reach - verified against the Alpine
+package DB and rusty_v8 release assets, not assumed - decides on-target coverage:
+
+- **x86_64**: Alpine edge/community ships a native-musl `deno` -> `webgpu_js` + `webgpu_ts` run
+  on-target.
+- **aarch64**: Alpine edge/community also ships a native-musl `deno` (rusty_v8 carries an
+  `aarch64-unknown-linux-musl` static V8) -> both cells run on-target, same as x86_64.
+- **riscv64 / loongarch64**: no Alpine `deno` yet (rusty_v8 ships only `riscv64-gnu`, no loong). These
+  arches are a follow-up (riscv64 via the community gnu prebuilt / from-source, loong via the
+  V8-loong64 backend port into rusty_v8) and are not advertised here. `prebuild.sh` writes an empty
+  manifest and `run-webgpu-render.sh` refuses to emit a 0-carpet pass on those arches.
+
+## Run
+
+```
+cargo xtask starry app qemu -t cpu-webgpu-render --arch x86_64
+cargo xtask starry app qemu -t cpu-webgpu-render --arch aarch64
+```
+
+Host smoke: `programs/run_all.sh` (needs a host Deno + Mesa lavapipe).

--- a/apps/starry/cpu-webgpu-render/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-webgpu-render/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,9 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/cpu-webgpu-render/build-x86_64-unknown-none.toml
+++ b/apps/starry/cpu-webgpu-render/build-x86_64-unknown-none.toml
@@ -1,0 +1,9 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+]

--- a/apps/starry/cpu-webgpu-render/prebuild.sh
+++ b/apps/starry/cpu-webgpu-render/prebuild.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the on-target WebGPU JS/TS runtime and stage the carpets into the per-arch
+# Alpine rootfs.
+#
+# WebGPU standalone runtime = Deno (V8 + a built-in copy of gfx-rs wgpu-core, the Rust WebGPU engine
+# Firefox and Servo also use, and the exact engine cpu-wgpu-render #1820 builds on musl). Deno runs
+# .js and .ts natively; its global navigator.gpu drives wgpu-core -> the Vulkan backend -> Mesa
+# lavapipe (software Vulkan on the CPU), so the JS/TS WebGPU render carpets (offscreen render -> RGBA8 readback -> per-pixel
+# closed-form assertions) run entirely on the CPU with no GPU. This script extracts the base Alpine rootfs, `apk add`s mesa-vulkan-swrast (lavapipe) + the
+# Vulkan loader + (x86_64 only) deno via qemu-user-static, then stages Deno + the lavapipe closure +
+# the webgpu_js / webgpu_ts carpets + a capability manifest into the overlay.
+#
+# Arch reality (verified against the Alpine package DB + rusty_v8 release assets, not assumed):
+#   - x86_64: Alpine edge/community ships a native-musl `deno` (2.7.4-r2) -> on-target JS/TS gate.
+#   - aarch64: Alpine edge/community ALSO ships a native-musl `deno` (rusty_v8 v150.2.0+ carries an
+#     aarch64-unknown-linux-musl static V8 lib) -> on-target JS/TS gate, same as x86_64.
+#   - riscv64 / loongarch64: no Alpine deno yet (rusty_v8 ships only riscv64-gnu, no loong at all).
+#     These arches are brought up in a follow-up (riscv64 via the community gnu prebuilt / from-source,
+#     loong via the V8-loong64 backend port into rusty_v8) and are not advertised here yet.
+# Both the C-side four-arch WebGPU *compute* (cpu-wgpu-render #1820, same wgpu-core) and the browser
+# WebGPU (campaign #391: Chromium=Dawn, Firefox/Servo/Deno=wgpu-core) sit alongside this app.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS (base alpine working copy),
+# STARRY_STAGING_ROOT (scratch extraction tree), STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+PROG="$app_dir/programs"
+
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+}
+
+# The harness injects $STARRY_OVERLAY_DIR into $base_rootfs via debugfs WITHOUT resizing, so the
+# per-app image must be grown here first. The overlay carries the mesa/lavapipe closure + its LLVM
+# runtime plus the Deno binary (~100 MiB); the stock ~2 GiB image overflows and debugfs silently
+# truncates ("Could not allocate block"), surfacing at runtime as "symbol not found". Idempotent.
+ROOTFS_SIZE=4G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    command -v resize2fs >/dev/null 2>&1 || { echo "prebuild: resize2fs required (e2fsprogs)" >&2; exit 1; }
+    local before after
+    before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB (fs resized) for lavapipe + Deno"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# mesa software Vulkan (lavapipe) + LLVM + the Vulkan loader, all musl for the target arch. `deno`
+# (native musl) is added only for x86_64, the sole arch Alpine builds it for. mesa-dev is intentionally
+# not installed (it pulls the ~200MB clang-libs closure the runtime does not need).
+GPU_PKGS=(musl mesa-vulkan-swrast vulkan-loader vulkan-headers zlib)
+case "$arch" in x86_64|aarch64) GPU_PKGS+=(deno) ;; esac
+
+apk_provision() {
+    normalize_symlinks
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add WebGPU runtime stack (${GPU_PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add "${GPU_PKGS[@]}"
+    [[ -f "$staging_root/usr/lib/libvulkan_lvp.so" ]] || { echo "prebuild: mesa-vulkan-swrast (lavapipe) not provisioned" >&2; exit 3; }
+}
+
+# Stage the carpets + the capability manifest. Deno runs .js/.ts natively, so no tsc, node_modules, or
+# build step is needed on-target. The manifest lists exactly the cells whose runtime was provisioned on
+# this arch (Deno present => webgpu_js + webgpu_ts); run-webgpu-render.sh gates on that exact set (fail==0 &&
+# total==EXPECTED==pass, EXPECTED>=2). On arches with no Deno the manifest is empty and run-webgpu-render.sh
+# refuses to emit a pass.
+# Scene cells: 4 render scenarios x {js, ts}, each a self-contained Deno program under carpets/<name>/.
+# They mirror the wgpu Rust render-scene cells (scene_2dui/3dmodel/anim/codec) one-for-one, staged the same
+# way as webgpu_js/webgpu_ts (Deno runs .js/.ts natively, no build).
+SCENE_CELLS=(scene_2dui_js scene_2dui_ts scene_3dmodel_js scene_3dmodel_ts scene_anim_js scene_anim_ts scene_codec_js scene_codec_ts)
+
+stage_carpets() {
+    local bin="$staging_root/opt/cpu-webgpu-render"
+    mkdir -p "$bin/carpets/webgpu_js" "$bin/carpets/webgpu_ts"
+    install -Dm0644 "$PROG/carpets/webgpu_js/webgpu_render_js_full_api.js" "$bin/carpets/webgpu_js/webgpu_render_js_full_api.js"
+    install -Dm0644 "$PROG/carpets/webgpu_ts/webgpu_render_ts_full_api.ts" "$bin/carpets/webgpu_ts/webgpu_render_ts_full_api.ts"
+    for cell in "${SCENE_CELLS[@]}"; do
+        local ext="${cell##*_}"
+        mkdir -p "$bin/carpets/$cell"
+        install -Dm0644 "$PROG/carpets/$cell/$cell.$ext" "$bin/carpets/$cell/$cell.$ext"
+    done
+    install -Dm0755 "$PROG/run-webgpu-render.sh" "$bin/run-webgpu-render.sh"
+    : > "$bin/expected_cells"
+    if [[ -x "$staging_root/usr/bin/deno" ]]; then
+        echo "webgpu_js" >> "$bin/expected_cells"
+        echo "webgpu_ts" >> "$bin/expected_cells"
+        for cell in "${SCENE_CELLS[@]}"; do echo "$cell" >> "$bin/expected_cells"; done
+        echo "prebuild: Deno provisioned ($("$staging_root/usr/bin/deno" --version 2>/dev/null | head -1 || echo deno)); cells = webgpu_js webgpu_ts ${SCENE_CELLS[*]}"
+    else
+        echo "prebuild: no native-musl Deno provisioned for $arch yet (x86_64/aarch64 only); manifest empty"
+    fi
+    echo "prebuild: expected_cells for $arch = $(tr '\n' ' ' < "$bin/expected_cells")"
+}
+
+populate_overlay() {
+    mkdir -p "$overlay_dir/usr/lib" "$overlay_dir/usr/share" "$overlay_dir/opt" "$overlay_dir/usr/bin"
+    # the provisioned /usr/lib closure (mesa lavapipe + LLVM + Vulkan loader) and ICD metadata
+    cp -a "$staging_root/usr/lib/." "$overlay_dir/usr/lib/"
+    cp -a "$staging_root/usr/share/vulkan" "$overlay_dir/usr/share/" 2>/dev/null || true
+    # Deno binary (x86_64); its musl deps live under /usr/lib (already copied above)
+    [[ -x "$staging_root/usr/bin/deno" ]] && install -Dm0755 "$staging_root/usr/bin/deno" "$overlay_dir/usr/bin/deno"
+    cp -a "$staging_root/opt/cpu-webgpu-render" "$overlay_dir/opt/"
+    install -Dm0755 "$PROG/run-webgpu-render.sh" "$overlay_dir/usr/bin/run-webgpu-render.sh"
+    echo "prebuild: overlay populated for $arch ($(du -sh "$overlay_dir/usr/lib" | cut -f1) libs)"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+stage_carpets
+populate_overlay
+echo "prebuild: cpu-webgpu-render overlay ready for $arch"

--- a/apps/starry/cpu-webgpu-render/programs/carpets/scene_2dui_js/scene_2dui_js.js
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/scene_2dui_js/scene_2dui_js.js
@@ -1,0 +1,548 @@
+// scene_2dui (JS) - 2D UI compositing RENDER-scene carpet via Deno's built-in navigator.gpu (wgpu-core,
+// the Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on the CPU,
+// no GPU/window/surface). WebGPU/Deno port of the wgpu Rust scene_2dui: an offscreen 64x64 rgba8unorm
+// texture is rendered through real render pipelines (WGSL shaders), copied to a MAP_READ buffer (256-byte
+// bytesPerRow padding) and read back; every scene primitive has an INDEPENDENT closed-form software
+// reference computed in JS (not derived from the GPU output) and asserted per pixel: filled axis-aligned
+// rectangles, an analytic rounded-rect, a nine-patch-style scaled border frame, an 8x8 bitmap-font glyph
+// blit, a scissor-clipped fill, and MULTI-LAYER Porter-Duff over compositing of 3 stacked
+// semi-transparent layers. Closes with a negative control. Prints "SCENE_2DUI_JS OK <n>" only when
+// FAIL==0 && TOTAL==EXPECTED==PASS.
+//
+// WebGPU is top-origin (readback row 0 = top, @builtin(position) also top-origin). Every pixel-space
+// vertex shader flips NDC y so pixel-row == readback-row; the analytic rounded-rect / nine-patch / glyph
+// / scissor / q8 quantization / Porter-Duff over math are ported verbatim in behavior from the wgpu
+// Rust reference.
+
+'use strict';
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+const ALIGN = 256;
+const UNPADDED = W * BPP;
+const PADDED = Math.ceil(UNPADDED / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond, desc) {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+// Assertion budget mirrors the wgpu Rust scene_2dui one-for-one (EXPECTED=28).
+const EXPECTED = 28;
+
+function clampi(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
+}
+function q8(f) {
+  return clampi(Math.round(f * 255.0), 0, 255);
+}
+
+class Fb {
+  constructor(px) {
+    this.px = px;
+  }
+  p(x, y, c) {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x, y, r, g, b, a, tol) {
+    const d = (v, t) => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+}
+
+// Pixel-space vertex shader: input pixel coords in [0,W]x[0,H], map to NDC with a y-flip so pixel row 0
+// lands at readback row 0. Solid uniform color out.
+const SOLID_WGSL = `
+struct Solid { rgba: vec4<f32>, vp: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: Solid;
+@vertex fn vs(@location(0) p: vec2<f32>) -> @builtin(position) vec4<f32> {
+  let n = (p / u.vp.xy) * 2.0 - 1.0;
+  return vec4<f32>(n.x, -n.y, 0.0, 1.0);
+}
+@fragment fn fs() -> @location(0) vec4<f32> { return u.rgba; }
+`;
+
+// Analytic rounded-rect fragment shader over a full-screen pixel quad.
+const RR_WGSL = `
+struct RR { box: vec4<f32>, col: vec4<f32>, rad: vec4<f32>, vp: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: RR;
+@vertex fn vs(@location(0) p: vec2<f32>) -> @builtin(position) vec4<f32> {
+  let n = (p / u.vp.xy) * 2.0 - 1.0;
+  return vec4<f32>(n.x, -n.y, 0.0, 1.0);
+}
+@fragment fn fs(@builtin(position) fc: vec4<f32>) -> @location(0) vec4<f32> {
+  let p = fc.xy;
+  let x0 = u.box.x; let y0 = u.box.y; let x1 = u.box.z; let y1 = u.box.w;
+  let rad = u.rad.x;
+  let inside = p.x >= x0 && p.x < x1 && p.y >= y0 && p.y < y1;
+  if (!inside) { discard; }
+  var corner = false;
+  var cc = vec2<f32>(0.0, 0.0);
+  if (p.x < x0 + rad && p.y < y0 + rad) { corner = true; cc = vec2<f32>(x0 + rad, y0 + rad); }
+  else if (p.x >= x1 - rad && p.y < y0 + rad) { corner = true; cc = vec2<f32>(x1 - rad, y0 + rad); }
+  else if (p.x < x0 + rad && p.y >= y1 - rad) { corner = true; cc = vec2<f32>(x0 + rad, y1 - rad); }
+  else if (p.x >= x1 - rad && p.y >= y1 - rad) { corner = true; cc = vec2<f32>(x1 - rad, y1 - rad); }
+  if (corner && distance(p, cc) > rad) { discard; }
+  return u.col;
+}
+`;
+
+// Glyph blit: pos2 + uv, sample an 8x8 texture (Nearest). Pixel-space vertex with y-flip; uv carried.
+const TEX_WGSL = `
+struct Vp { vp: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: Vp;
+@group(0) @binding(1) var t: texture_2d<f32>;
+@group(0) @binding(2) var s: sampler;
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) uv: vec2<f32>) -> VOut {
+  var o: VOut;
+  let n = (p / u.vp.xy) * 2.0 - 1.0;
+  o.pos = vec4<f32>(n.x, -n.y, 0.0, 1.0);
+  o.uv = uv;
+  return o;
+}
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> { return textureSample(t, s, in.uv); }
+`;
+
+function finish() {
+  const total = PASS + FAIL;
+  console.log('scene-2dui-js: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED);
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('SCENE_2DUI_JS OK ' + PASS);
+    return 0;
+  }
+  console.log('SCENE_2DUI_JS FAIL');
+  return 1;
+}
+
+async function run() {
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    console.error('requestAdapter returned null');
+    ok(false, 'request_adapter yields a usable adapter');
+    return finish();
+  }
+  const info = adapter.info || {};
+  console.log('scene-2dui-js adapter: vendor=' + info.vendor + ' device=' + info.device + ' description=' + info.description);
+  ok(true, 'request_adapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter backend is Vulkan or Gl');
+
+  const device = await adapter.requestDevice({ label: '2dui-device' });
+  if (device == null) {
+    ok(false, 'request_device yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev) => {
+    console.error('UNCAPTURED webgpu error: ' + ev.error.message);
+  });
+  const queue = device.queue;
+
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  const copyAndRead = async (enc) => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      px.set(padded.subarray(y * PADDED, y * PADDED + W * BPP), y * W * BPP);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  // ---- Solid pixel-fill pipeline (uniform color + vp) ----
+  const mSolid = device.createShaderModule({ label: 'solid', code: SOLID_WGSL });
+  const solidBgl = device.createBindGroupLayout({
+    label: 'solid-bgl',
+    entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
+  });
+  const solidPll = device.createPipelineLayout({ label: 'solid-pll', bindGroupLayouts: [solidBgl] });
+  const vblPos2 = { arrayStride: 8, stepMode: 'vertex', attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }] };
+  const mkSolid = (blend) =>
+    device.createRenderPipeline({
+      label: 'solid-pipe',
+      layout: solidPll,
+      vertex: { module: mSolid, entryPoint: 'vs', buffers: [vblPos2] },
+      fragment: { module: mSolid, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', blend, writeMask: GPUColorWrite.ALL }] },
+      primitive: { topology: 'triangle-list' },
+    });
+  const pipeSolid = mkSolid(undefined);
+  const blendOver = {
+    color: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+    alpha: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+  };
+  const pipeBlend = mkSolid(blendOver);
+
+  // solid uniform: rgba + vp (32 bytes, two vec4).
+  const solidUbo = device.createBuffer({ label: 'solid-ubo', size: 32, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+  const solidBg = device.createBindGroup({ label: 'solid-bg', layout: solidBgl, entries: [{ binding: 0, resource: { buffer: solidUbo } }] });
+  const writeSolid = (r, g, b, a) => {
+    queue.writeBuffer(solidUbo, 0, new Float32Array([r, g, b, a, W, H, 0, 0]));
+  };
+
+  // vbo factory + a two-triangle pixel rect [x0,x1)x[y0,y1).
+  const mkVbo = (label, arr) => {
+    const buf = device.createBuffer({ label, size: arr.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+    new Float32Array(buf.getMappedRange()).set(arr);
+    buf.unmap();
+    return buf;
+  };
+  const rectVerts = (x0, y0, x1, y1) =>
+    new Float32Array([x0, y0, x1, y0, x0, y1, x0, y1, x1, y0, x1, y1]);
+  const mkUbo = (label, arr) => {
+    const f = arr instanceof Float32Array ? arr : new Float32Array(arr);
+    const buf = device.createBuffer({ label, size: f.byteLength, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true });
+    new Float32Array(buf.getMappedRange()).set(f);
+    buf.unmap();
+    return buf;
+  };
+  const mkSolidBg = (label, ubo) =>
+    device.createBindGroup({ label, layout: solidBgl, entries: [{ binding: 0, resource: { buffer: ubo } }] });
+
+  // Multi-draw frame: clear + list of {pipe, bind, vbo, verts, scissor}.
+  const frame = async (clear, ops) => {
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const pass = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: clear[0], g: clear[1], b: clear[2], a: clear[3] } }],
+    });
+    for (const op of ops) {
+      pass.setPipeline(op.pipe);
+      if (op.scissor) pass.setScissorRect(op.scissor[0], op.scissor[1], op.scissor[2], op.scissor[3]);
+      else pass.setScissorRect(0, 0, W, H);
+      pass.setBindGroup(0, op.bind);
+      pass.setVertexBuffer(0, op.vbo);
+      pass.draw(op.verts, 1, 0, 0);
+    }
+    pass.end();
+    return copyAndRead(enc);
+  };
+
+  ok(true, 'offscreen Rgba8Unorm target + readback buffer ready');
+
+  // ---- Scene A: filled rectangles ----
+  {
+    const vr1 = mkVbo('rectA', rectVerts(8, 8, 16, 24));
+    const vr2 = mkVbo('rectB', rectVerts(40, 32, 48, 52));
+    const uboA = mkUbo('uboA', [1, 0, 0, 1, W, H, 0, 0]);
+    const uboB = mkUbo('uboB', [0, 1, 0, 1, W, H, 0, 0]);
+    const bgA = mkSolidBg('bgA', uboA);
+    const bgB = mkSolidBg('bgB', uboB);
+    const fb = await frame([0, 0, 0, 1], [
+      { pipe: pipeSolid, bind: bgA, vbo: vr1, verts: 6 },
+      { pipe: pipeSolid, bind: bgB, vbo: vr2, verts: 6 },
+    ]);
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        let er, eg, eb;
+        if (x >= 8 && x < 16 && y >= 8 && y < 24) { er = 255; eg = 0; eb = 0; }
+        else if (x >= 40 && x < 48 && y >= 32 && y < 52) { er = 0; eg = 255; eb = 0; }
+        else { er = 0; eg = 0; eb = 0; }
+        if (!fb.peq(x, y, er, eg, eb, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'filled rectangles: every pixel matches closed-form rect coverage');
+    ok(fb.peq(10, 10, 255, 0, 0, 255, 1), 'rect A interior red');
+    ok(fb.peq(44, 40, 0, 255, 0, 255, 1), 'rect B interior green');
+    ok(fb.peq(30, 30, 0, 0, 0, 255, 1), 'gap between rects is background');
+  }
+
+  // ---- Scene B: analytic rounded-rect ----
+  {
+    const mRr = device.createShaderModule({ label: 'rr', code: RR_WGSL });
+    const rrBgl = device.createBindGroupLayout({
+      label: 'rr-bgl',
+      entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
+    });
+    const rrPll = device.createPipelineLayout({ label: 'rr-pll', bindGroupLayouts: [rrBgl] });
+    const rrUbo = mkUbo('rr-ubo', [12, 12, 52, 52, 1, 1, 0, 1, 8, 0, 0, 0, W, H, 0, 0]);
+    const rrBg = device.createBindGroup({ label: 'rr-bg', layout: rrBgl, entries: [{ binding: 0, resource: { buffer: rrUbo } }] });
+    const pipeRr = device.createRenderPipeline({
+      label: 'rr-pipe',
+      layout: rrPll,
+      vertex: { module: mRr, entryPoint: 'vs', buffers: [vblPos2] },
+      fragment: { module: mRr, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+      primitive: { topology: 'triangle-list' },
+    });
+    const fq = mkVbo('fullquad', rectVerts(0, 0, W, H));
+    const fb = await frame([0, 0, 0, 1], [{ pipe: pipeRr, bind: rrBg, vbo: fq, verts: 6 }]);
+    const covered = (x, y) => {
+      const cx = x + 0.5, cy = y + 0.5;
+      const x0 = 12, y0 = 12, x1 = 52, y1 = 52, r = 8;
+      if (!(cx >= x0 && cx < x1 && cy >= y0 && cy < y1)) return false;
+      let ccx = 0, ccy = 0, corner = false;
+      if (cx < x0 + r && cy < y0 + r) { corner = true; ccx = x0 + r; ccy = y0 + r; }
+      else if (cx >= x1 - r && cy < y0 + r) { corner = true; ccx = x1 - r; ccy = y0 + r; }
+      else if (cx < x0 + r && cy >= y1 - r) { corner = true; ccx = x0 + r; ccy = y1 - r; }
+      else if (cx >= x1 - r && cy >= y1 - r) { corner = true; ccx = x1 - r; ccy = y1 - r; }
+      if (corner) {
+        const dx = cx - ccx, dy = cy - ccy;
+        if (Math.sqrt(dx * dx + dy * dy) > r) return false;
+      }
+      return true;
+    };
+    let bad = 0, lit = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const cov = covered(x, y);
+        if (cov) lit += 1;
+        const er = cov ? 255 : 0;
+        const eg = cov ? 255 : 0;
+        if (!fb.peq(x, y, er, eg, 0, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'rounded-rect: every pixel matches analytic corner-arc coverage');
+    ok(lit > 0, 'rounded-rect: some pixels covered');
+    ok(fb.peq(32, 32, 255, 255, 0, 255, 1), 'rounded-rect center lit');
+    ok(fb.peq(12, 12, 0, 0, 0, 255, 1), 'rounded-rect clipped corner (12,12) is background');
+    ok(fb.peq(32, 13, 255, 255, 0, 255, 1), 'rounded-rect straight top edge lit');
+  }
+
+  // ---- Scene C: nine-patch-style scaled border frame ----
+  {
+    const vbox = mkVbo('nine-outer', rectVerts(4, 4, 60, 60));
+    const vinner = mkVbo('nine-inner', rectVerts(10, 10, 54, 54));
+    const uboBlue = mkUbo('blue', [0, 0, 1, 1, W, H, 0, 0]);
+    const uboDark = mkUbo('dark', [0.1, 0.1, 0.1, 1, W, H, 0, 0]);
+    const bgBlue = mkSolidBg('bg-blue', uboBlue);
+    const bgDark = mkSolidBg('bg-dark', uboDark);
+    const fb = await frame([0, 0, 0, 1], [
+      { pipe: pipeSolid, bind: bgBlue, vbo: vbox, verts: 6 },
+      { pipe: pipeSolid, bind: bgDark, vbo: vinner, verts: 6 },
+    ]);
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const inbox = x >= 4 && x < 60 && y >= 4 && y < 60;
+        const ininner = x >= 10 && x < 54 && y >= 10 && y < 54;
+        let er, eg, eb;
+        if (ininner) { er = q8(0.1); eg = q8(0.1); eb = q8(0.1); }
+        else if (inbox) { er = 0; eg = 0; eb = 255; }
+        else { er = 0; eg = 0; eb = 0; }
+        if (!fb.peq(x, y, er, eg, eb, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'nine-patch border frame: closed-form border-vs-interior coverage');
+    ok(fb.peq(5, 32, 0, 0, 255, 255, 1), 'nine-patch left border blue');
+    ok(fb.peq(32, 5, 0, 0, 255, 255, 1), 'nine-patch top border blue');
+    ok(fb.peq(32, 32, q8(0.1), q8(0.1), q8(0.1), 255, 1), 'nine-patch hollow interior');
+  }
+
+  // ---- Scene D: 8x8 bitmap-font glyph blit ----
+  const GLYPH_H = [0x00, 0x42, 0x42, 0x7e, 0x42, 0x42, 0x42, 0x00];
+  {
+    const rgba = new Uint8Array(8 * 8 * 4);
+    for (let r = 0; r < 8; r++) {
+      for (let c = 0; c < 8; c++) {
+        const lit = ((GLYPH_H[r] >> (7 - c)) & 1) === 1;
+        const v = lit ? 255 : 0;
+        const idx = (r * 8 + c) * 4;
+        rgba[idx] = v; rgba[idx + 1] = v; rgba[idx + 2] = v; rgba[idx + 3] = 255;
+      }
+    }
+    const gtex = device.createTexture({
+      label: 'glyph',
+      size: { width: 8, height: 8, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    queue.writeTexture(
+      { texture: gtex, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      rgba,
+      { offset: 0, bytesPerRow: 32, rowsPerImage: 8 },
+      { width: 8, height: 8, depthOrArrayLayers: 1 }
+    );
+    const gview = gtex.createView();
+    const samp = device.createSampler({
+      label: 'nearest',
+      addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge',
+      magFilter: 'nearest', minFilter: 'nearest', mipmapFilter: 'nearest',
+    });
+    const vpUbo = mkUbo('glyph-vp', [W, H, 0, 0]);
+    const mTex = device.createShaderModule({ label: 'tex', code: TEX_WGSL });
+    const texBgl = device.createBindGroupLayout({
+      label: 'glyph-bgl',
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float', viewDimension: '2d', multisampled: false } },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+      ],
+    });
+    const texBg = device.createBindGroup({
+      label: 'glyph-bg',
+      layout: texBgl,
+      entries: [
+        { binding: 0, resource: { buffer: vpUbo } },
+        { binding: 1, resource: gview },
+        { binding: 2, resource: samp },
+      ],
+    });
+    const texPll = device.createPipelineLayout({ label: 'glyph-pll', bindGroupLayouts: [texBgl] });
+    const vblPos2uv = {
+      arrayStride: 16,
+      stepMode: 'vertex',
+      attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }, { format: 'float32x2', offset: 8, shaderLocation: 1 }],
+    };
+    const pipeTex = device.createRenderPipeline({
+      label: 'glyph-pipe',
+      layout: texPll,
+      vertex: { module: mTex, entryPoint: 'vs', buffers: [vblPos2uv] },
+      fragment: { module: mTex, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+      primitive: { topology: 'triangle-list' },
+    });
+    // Glyph blitted to pixel rect [20,28)x[20,28), uv 0..1 over the 8x8 glyph.
+    const gq = new Float32Array([
+      20, 20, 0, 0,
+      28, 20, 1, 0,
+      20, 28, 0, 1,
+      20, 28, 0, 1,
+      28, 20, 1, 0,
+      28, 28, 1, 1,
+    ]);
+    const gvbo = mkVbo('glyph-quad', gq);
+    const fb = await frame([0, 0, 0, 1], [{ pipe: pipeTex, bind: texBg, vbo: gvbo, verts: 6 }]);
+    let bad = 0;
+    for (let dy = 0; dy < 8; dy++) {
+      for (let dx = 0; dx < 8; dx++) {
+        const sx = 20 + dx, sy = 20 + dy;
+        const lit = ((GLYPH_H[dy] >> (7 - dx)) & 1) === 1;
+        const v = lit ? 255 : 0;
+        if (!fb.peq(sx, sy, v, v, v, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, "glyph blit: all 64 texels match hardcoded 8x8 'H' bitmap");
+    ok(fb.peq(21, 23, 255, 255, 255, 255, 1), 'glyph crossbar lit (col1,row3)');
+    ok(fb.peq(23, 20, 0, 0, 0, 255, 1), 'glyph row0 blank');
+    ok(fb.peq(24, 21, 0, 0, 0, 255, 1), 'glyph row1 middle blank (0x42)');
+  }
+
+  // ---- Scene E: scissor-clipped fill ----
+  {
+    writeSolid(1, 0, 1, 1);
+    const fq = mkVbo('scissor-quad', rectVerts(0, 0, W, H));
+    const fb = await frame([0, 0, 0, 1], [{ pipe: pipeSolid, bind: solidBg, vbo: fq, verts: 6, scissor: [16, 16, 20, 20] }]);
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const inb = x >= 16 && x < 36 && y >= 16 && y < 36;
+        const er = inb ? 255 : 0;
+        const eb = inb ? 255 : 0;
+        if (!fb.peq(x, y, er, 0, eb, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'scissor-clipped fill: magenta only within [16,36)^2');
+    ok(fb.peq(20, 20, 255, 0, 255, 255, 1), 'scissor inside magenta');
+    ok(fb.peq(40, 40, 0, 0, 0, 255, 1), 'scissor outside background');
+  }
+
+  // ---- Scene F: MULTI-LAYER Porter-Duff over compositing ----
+  {
+    const bg = [0.1, 0.1, 0.1, 1.0];
+    const layers = [
+      { r: 1, g: 0, b: 0, a: 0.5, x0: 8, y0: 8, x1: 56, y1: 56 },
+      { r: 0, g: 1, b: 0, a: 0.25, x0: 12, y0: 12, x1: 52, y1: 52 },
+      { r: 0, g: 0, b: 1, a: 0.75, x0: 16, y0: 16, x1: 48, y1: 48 },
+    ];
+    const ops = layers.map((l) => {
+      const ubo = mkUbo('layer-ubo', [l.r, l.g, l.b, l.a, W, H, 0, 0]);
+      const bgd = mkSolidBg('layer-bg', ubo);
+      const v = mkVbo('layer-quad', rectVerts(l.x0, l.y0, l.x1, l.y1));
+      return { pipe: pipeBlend, bind: bgd, vbo: v, verts: 6 };
+    });
+    const fb = await frame([bg[0], bg[1], bg[2], bg[3]], ops);
+    const composite = (tx, ty) => {
+      const c = bg.slice();
+      for (const l of layers) {
+        const cx = tx + 0.5, cy = ty + 0.5;
+        if (cx >= l.x0 && cx < l.x1 && cy >= l.y0 && cy < l.y1) {
+          const aS = l.a;
+          const src = [l.r, l.g, l.b, l.a];
+          for (let k = 0; k < 4; k++) c[k] = src[k] * aS + c[k] * (1.0 - aS);
+        }
+      }
+      return c;
+    };
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const e = composite(x, y);
+        if (!fb.peq(x, y, q8(e[0]), q8(e[1]), q8(e[2]), q8(e[3]), 2)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'multi-layer over: every pixel matches Porter-Duff over accumulation (incl partial-overlap regions)');
+    {
+      const c = bg.slice();
+      const ls = [[1, 0, 0, 0.5], [0, 1, 0, 0.25], [0, 0, 1, 0.75]];
+      for (const li of ls) {
+        const aS = li[3];
+        for (let k = 0; k < 4; k++) c[k] = li[k] * aS + c[k] * (1.0 - aS);
+      }
+      ok(fb.peq(32, 32, q8(c[0]), q8(c[1]), q8(c[2]), q8(c[3]), 2), 'multi-layer over center pixel matches hand-iterated over');
+    }
+    {
+      const aS = 0.5;
+      const er = 1.0 * aS + bg[0] * (1.0 - aS);
+      const eg = 0.0 * aS + bg[1] * (1.0 - aS);
+      const eb = 0.0 * aS + bg[2] * (1.0 - aS);
+      const ea = aS * aS + bg[3] * (1.0 - aS);
+      ok(fb.peq(10, 32, q8(er), q8(eg), q8(eb), q8(ea), 2), 'multi-layer over: single-layer region matches one over');
+    }
+  }
+
+  // ---- Negative control ----
+  {
+    const vr1 = mkVbo('neg-rect', rectVerts(8, 8, 16, 24));
+    const uboA = mkUbo('neg-ubo', [1, 0, 0, 1, W, H, 0, 0]);
+    const bgA = mkSolidBg('neg-bg', uboA);
+    const fb = await frame([0, 0, 0, 1], [{ pipe: pipeSolid, bind: bgA, vbo: vr1, verts: 6 }]);
+    ok(!fb.peq(10, 10, 0, 255, 0, 255, 4), 'negative control: red rect pixel is NOT green');
+    ok(!fb.peq(30, 30, 255, 0, 0, 255, 4), 'negative control: background is NOT red');
+  }
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+    else process.exit(code);
+  })
+  .catch((e) => {
+    console.error('FATAL: ' + (e && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+    else process.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/scene_2dui_ts/scene_2dui_ts.ts
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/scene_2dui_ts/scene_2dui_ts.ts
@@ -1,0 +1,535 @@
+// scene_2dui (TS) - 2D UI compositing RENDER-scene carpet via Deno's built-in navigator.gpu (wgpu-core,
+// the Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on the CPU,
+// no GPU/window/surface). Typed WebGPU/Deno port of the wgpu Rust scene_2dui: an offscreen 64x64
+// rgba8unorm texture is rendered through real render pipelines (WGSL shaders), copied to a MAP_READ buffer
+// (256-byte bytesPerRow padding) and read back; every scene primitive has an INDEPENDENT closed-form
+// software reference computed in TS (not derived from the GPU output) and asserted per pixel: filled
+// axis-aligned rectangles, an analytic rounded-rect, a nine-patch-style scaled border frame, an 8x8
+// bitmap-font glyph blit, a scissor-clipped fill, and MULTI-LAYER Porter-Duff over compositing of 3
+// stacked semi-transparent layers. Closes with a negative control. Prints "SCENE_2DUI_TS OK <n>" only
+// when FAIL==0 && TOTAL==EXPECTED==PASS. This is the typed mirror of the JS cell - identical render logic.
+//
+// WebGPU is top-origin (readback row 0 = top). Every pixel-space vertex shader flips NDC y so pixel-row ==
+// readback-row; the analytic rounded-rect / nine-patch / glyph / scissor / q8 quantization / Porter-Duff
+// over math are ported verbatim in behavior from the wgpu Rust reference.
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+const ALIGN = 256;
+const PADDED = Math.ceil((W * BPP) / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond: boolean, desc: string): void {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+const EXPECTED = 28;
+
+function clampi(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+function q8(f: number): number {
+  return clampi(Math.round(f * 255.0), 0, 255);
+}
+
+const SOLID_WGSL = `
+struct Solid { rgba: vec4<f32>, vp: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: Solid;
+@vertex fn vs(@location(0) p: vec2<f32>) -> @builtin(position) vec4<f32> {
+  let n = (p / u.vp.xy) * 2.0 - 1.0;
+  return vec4<f32>(n.x, -n.y, 0.0, 1.0);
+}
+@fragment fn fs() -> @location(0) vec4<f32> { return u.rgba; }
+`;
+
+const RR_WGSL = `
+struct RR { box: vec4<f32>, col: vec4<f32>, rad: vec4<f32>, vp: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: RR;
+@vertex fn vs(@location(0) p: vec2<f32>) -> @builtin(position) vec4<f32> {
+  let n = (p / u.vp.xy) * 2.0 - 1.0;
+  return vec4<f32>(n.x, -n.y, 0.0, 1.0);
+}
+@fragment fn fs(@builtin(position) fc: vec4<f32>) -> @location(0) vec4<f32> {
+  let p = fc.xy;
+  let x0 = u.box.x; let y0 = u.box.y; let x1 = u.box.z; let y1 = u.box.w;
+  let rad = u.rad.x;
+  let inside = p.x >= x0 && p.x < x1 && p.y >= y0 && p.y < y1;
+  if (!inside) { discard; }
+  var corner = false;
+  var cc = vec2<f32>(0.0, 0.0);
+  if (p.x < x0 + rad && p.y < y0 + rad) { corner = true; cc = vec2<f32>(x0 + rad, y0 + rad); }
+  else if (p.x >= x1 - rad && p.y < y0 + rad) { corner = true; cc = vec2<f32>(x1 - rad, y0 + rad); }
+  else if (p.x < x0 + rad && p.y >= y1 - rad) { corner = true; cc = vec2<f32>(x0 + rad, y1 - rad); }
+  else if (p.x >= x1 - rad && p.y >= y1 - rad) { corner = true; cc = vec2<f32>(x1 - rad, y1 - rad); }
+  if (corner && distance(p, cc) > rad) { discard; }
+  return u.col;
+}
+`;
+
+const TEX_WGSL = `
+struct Vp { vp: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: Vp;
+@group(0) @binding(1) var t: texture_2d<f32>;
+@group(0) @binding(2) var s: sampler;
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) uv: vec2<f32>) -> VOut {
+  var o: VOut;
+  let n = (p / u.vp.xy) * 2.0 - 1.0;
+  o.pos = vec4<f32>(n.x, -n.y, 0.0, 1.0);
+  o.uv = uv;
+  return o;
+}
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> { return textureSample(t, s, in.uv); }
+`;
+
+class Fb {
+  px: Uint8Array;
+  constructor(px: Uint8Array) {
+    this.px = px;
+  }
+  p(x: number, y: number, c: number): number {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x: number, y: number, r: number, g: number, b: number, a: number, tol: number): boolean {
+    const d = (v: number, t: number): boolean => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+}
+
+interface DrawOp {
+  pipe: GPURenderPipeline;
+  bind: GPUBindGroup;
+  vbo: GPUBuffer;
+  verts: number;
+  scissor?: [number, number, number, number];
+}
+
+function finish(): number {
+  const total = PASS + FAIL;
+  console.log('scene-2dui-ts: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED);
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('SCENE_2DUI_TS OK ' + PASS);
+    return 0;
+  }
+  console.log('SCENE_2DUI_TS FAIL');
+  return 1;
+}
+
+async function run(): Promise<number> {
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const adapter: GPUAdapter | null = await navigator.gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    ok(false, 'request_adapter yields a usable adapter');
+    return finish();
+  }
+  const info = (adapter.info || {}) as GPUAdapterInfo;
+  console.log('scene-2dui-ts adapter: vendor=' + info.vendor + ' device=' + info.device + ' description=' + info.description);
+  ok(true, 'request_adapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter backend is Vulkan or Gl');
+
+  const device: GPUDevice = await adapter.requestDevice({ label: '2dui-device' });
+  if (device == null) {
+    ok(false, 'request_device yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev: Event) => {
+    console.error('UNCAPTURED webgpu error: ' + (ev as GPUUncapturedErrorEvent).error.message);
+  });
+  const queue: GPUQueue = device.queue;
+
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  const copyAndRead = async (enc: GPUCommandEncoder): Promise<Fb> => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      px.set(padded.subarray(y * PADDED, y * PADDED + W * BPP), y * W * BPP);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  const mSolid = device.createShaderModule({ label: 'solid', code: SOLID_WGSL });
+  const solidBgl = device.createBindGroupLayout({
+    label: 'solid-bgl',
+    entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
+  });
+  const solidPll = device.createPipelineLayout({ label: 'solid-pll', bindGroupLayouts: [solidBgl] });
+  const vblPos2: GPUVertexBufferLayout = { arrayStride: 8, stepMode: 'vertex', attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }] };
+  const mkSolid = (blend: GPUBlendState | undefined): GPURenderPipeline =>
+    device.createRenderPipeline({
+      label: 'solid-pipe',
+      layout: solidPll,
+      vertex: { module: mSolid, entryPoint: 'vs', buffers: [vblPos2] },
+      fragment: { module: mSolid, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', blend, writeMask: GPUColorWrite.ALL }] },
+      primitive: { topology: 'triangle-list' },
+    });
+  const pipeSolid = mkSolid(undefined);
+  const blendOver: GPUBlendState = {
+    color: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+    alpha: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+  };
+  const pipeBlend = mkSolid(blendOver);
+
+  const solidUbo = device.createBuffer({ label: 'solid-ubo', size: 32, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+  const solidBg = device.createBindGroup({ label: 'solid-bg', layout: solidBgl, entries: [{ binding: 0, resource: { buffer: solidUbo } }] });
+  const writeSolid = (r: number, g: number, b: number, a: number): void => {
+    queue.writeBuffer(solidUbo, 0, new Float32Array([r, g, b, a, W, H, 0, 0]));
+  };
+
+  const mkVbo = (label: string, arr: Float32Array): GPUBuffer => {
+    const buf = device.createBuffer({ label, size: arr.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+    new Float32Array(buf.getMappedRange()).set(arr);
+    buf.unmap();
+    return buf;
+  };
+  const rectVerts = (x0: number, y0: number, x1: number, y1: number): Float32Array =>
+    new Float32Array([x0, y0, x1, y0, x0, y1, x0, y1, x1, y0, x1, y1]);
+  const mkUbo = (label: string, arr: number[]): GPUBuffer => {
+    const f = new Float32Array(arr);
+    const buf = device.createBuffer({ label, size: f.byteLength, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true });
+    new Float32Array(buf.getMappedRange()).set(f);
+    buf.unmap();
+    return buf;
+  };
+  const mkSolidBg = (label: string, ubo: GPUBuffer): GPUBindGroup =>
+    device.createBindGroup({ label, layout: solidBgl, entries: [{ binding: 0, resource: { buffer: ubo } }] });
+
+  const frame = async (clear: [number, number, number, number], ops: DrawOp[]): Promise<Fb> => {
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const pass = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: clear[0], g: clear[1], b: clear[2], a: clear[3] } }],
+    });
+    for (const op of ops) {
+      pass.setPipeline(op.pipe);
+      if (op.scissor) pass.setScissorRect(op.scissor[0], op.scissor[1], op.scissor[2], op.scissor[3]);
+      else pass.setScissorRect(0, 0, W, H);
+      pass.setBindGroup(0, op.bind);
+      pass.setVertexBuffer(0, op.vbo);
+      pass.draw(op.verts, 1, 0, 0);
+    }
+    pass.end();
+    return copyAndRead(enc);
+  };
+
+  ok(true, 'offscreen Rgba8Unorm target + readback buffer ready');
+
+  // ---- Scene A: filled rectangles ----
+  {
+    const vr1 = mkVbo('rectA', rectVerts(8, 8, 16, 24));
+    const vr2 = mkVbo('rectB', rectVerts(40, 32, 48, 52));
+    const bgA = mkSolidBg('bgA', mkUbo('uboA', [1, 0, 0, 1, W, H, 0, 0]));
+    const bgB = mkSolidBg('bgB', mkUbo('uboB', [0, 1, 0, 1, W, H, 0, 0]));
+    const fb = await frame([0, 0, 0, 1], [
+      { pipe: pipeSolid, bind: bgA, vbo: vr1, verts: 6 },
+      { pipe: pipeSolid, bind: bgB, vbo: vr2, verts: 6 },
+    ]);
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        let er: number, eg: number, eb: number;
+        if (x >= 8 && x < 16 && y >= 8 && y < 24) { er = 255; eg = 0; eb = 0; }
+        else if (x >= 40 && x < 48 && y >= 32 && y < 52) { er = 0; eg = 255; eb = 0; }
+        else { er = 0; eg = 0; eb = 0; }
+        if (!fb.peq(x, y, er, eg, eb, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'filled rectangles: every pixel matches closed-form rect coverage');
+    ok(fb.peq(10, 10, 255, 0, 0, 255, 1), 'rect A interior red');
+    ok(fb.peq(44, 40, 0, 255, 0, 255, 1), 'rect B interior green');
+    ok(fb.peq(30, 30, 0, 0, 0, 255, 1), 'gap between rects is background');
+  }
+
+  // ---- Scene B: analytic rounded-rect ----
+  {
+    const mRr = device.createShaderModule({ label: 'rr', code: RR_WGSL });
+    const rrBgl = device.createBindGroupLayout({
+      label: 'rr-bgl',
+      entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
+    });
+    const rrPll = device.createPipelineLayout({ label: 'rr-pll', bindGroupLayouts: [rrBgl] });
+    const rrUbo = mkUbo('rr-ubo', [12, 12, 52, 52, 1, 1, 0, 1, 8, 0, 0, 0, W, H, 0, 0]);
+    const rrBg = device.createBindGroup({ label: 'rr-bg', layout: rrBgl, entries: [{ binding: 0, resource: { buffer: rrUbo } }] });
+    const pipeRr = device.createRenderPipeline({
+      label: 'rr-pipe',
+      layout: rrPll,
+      vertex: { module: mRr, entryPoint: 'vs', buffers: [vblPos2] },
+      fragment: { module: mRr, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+      primitive: { topology: 'triangle-list' },
+    });
+    const fq = mkVbo('fullquad', rectVerts(0, 0, W, H));
+    const fb = await frame([0, 0, 0, 1], [{ pipe: pipeRr, bind: rrBg, vbo: fq, verts: 6 }]);
+    const covered = (x: number, y: number): boolean => {
+      const cx = x + 0.5, cy = y + 0.5;
+      const x0 = 12, y0 = 12, x1 = 52, y1 = 52, r = 8;
+      if (!(cx >= x0 && cx < x1 && cy >= y0 && cy < y1)) return false;
+      let ccx = 0, ccy = 0, corner = false;
+      if (cx < x0 + r && cy < y0 + r) { corner = true; ccx = x0 + r; ccy = y0 + r; }
+      else if (cx >= x1 - r && cy < y0 + r) { corner = true; ccx = x1 - r; ccy = y0 + r; }
+      else if (cx < x0 + r && cy >= y1 - r) { corner = true; ccx = x0 + r; ccy = y1 - r; }
+      else if (cx >= x1 - r && cy >= y1 - r) { corner = true; ccx = x1 - r; ccy = y1 - r; }
+      if (corner) {
+        const dx = cx - ccx, dy = cy - ccy;
+        if (Math.sqrt(dx * dx + dy * dy) > r) return false;
+      }
+      return true;
+    };
+    let bad = 0, lit = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const cov = covered(x, y);
+        if (cov) lit += 1;
+        const er = cov ? 255 : 0;
+        const eg = cov ? 255 : 0;
+        if (!fb.peq(x, y, er, eg, 0, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'rounded-rect: every pixel matches analytic corner-arc coverage');
+    ok(lit > 0, 'rounded-rect: some pixels covered');
+    ok(fb.peq(32, 32, 255, 255, 0, 255, 1), 'rounded-rect center lit');
+    ok(fb.peq(12, 12, 0, 0, 0, 255, 1), 'rounded-rect clipped corner (12,12) is background');
+    ok(fb.peq(32, 13, 255, 255, 0, 255, 1), 'rounded-rect straight top edge lit');
+  }
+
+  // ---- Scene C: nine-patch-style scaled border frame ----
+  {
+    const vbox = mkVbo('nine-outer', rectVerts(4, 4, 60, 60));
+    const vinner = mkVbo('nine-inner', rectVerts(10, 10, 54, 54));
+    const bgBlue = mkSolidBg('bg-blue', mkUbo('blue', [0, 0, 1, 1, W, H, 0, 0]));
+    const bgDark = mkSolidBg('bg-dark', mkUbo('dark', [0.1, 0.1, 0.1, 1, W, H, 0, 0]));
+    const fb = await frame([0, 0, 0, 1], [
+      { pipe: pipeSolid, bind: bgBlue, vbo: vbox, verts: 6 },
+      { pipe: pipeSolid, bind: bgDark, vbo: vinner, verts: 6 },
+    ]);
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const inbox = x >= 4 && x < 60 && y >= 4 && y < 60;
+        const ininner = x >= 10 && x < 54 && y >= 10 && y < 54;
+        let er: number, eg: number, eb: number;
+        if (ininner) { er = q8(0.1); eg = q8(0.1); eb = q8(0.1); }
+        else if (inbox) { er = 0; eg = 0; eb = 255; }
+        else { er = 0; eg = 0; eb = 0; }
+        if (!fb.peq(x, y, er, eg, eb, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'nine-patch border frame: closed-form border-vs-interior coverage');
+    ok(fb.peq(5, 32, 0, 0, 255, 255, 1), 'nine-patch left border blue');
+    ok(fb.peq(32, 5, 0, 0, 255, 255, 1), 'nine-patch top border blue');
+    ok(fb.peq(32, 32, q8(0.1), q8(0.1), q8(0.1), 255, 1), 'nine-patch hollow interior');
+  }
+
+  // ---- Scene D: 8x8 bitmap-font glyph blit ----
+  const GLYPH_H = [0x00, 0x42, 0x42, 0x7e, 0x42, 0x42, 0x42, 0x00];
+  {
+    const rgba = new Uint8Array(8 * 8 * 4);
+    for (let r = 0; r < 8; r++) {
+      for (let c = 0; c < 8; c++) {
+        const lit = ((GLYPH_H[r] >> (7 - c)) & 1) === 1;
+        const v = lit ? 255 : 0;
+        const idx = (r * 8 + c) * 4;
+        rgba[idx] = v; rgba[idx + 1] = v; rgba[idx + 2] = v; rgba[idx + 3] = 255;
+      }
+    }
+    const gtex = device.createTexture({
+      label: 'glyph',
+      size: { width: 8, height: 8, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    queue.writeTexture(
+      { texture: gtex, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      rgba,
+      { offset: 0, bytesPerRow: 32, rowsPerImage: 8 },
+      { width: 8, height: 8, depthOrArrayLayers: 1 }
+    );
+    const gview = gtex.createView();
+    const samp = device.createSampler({
+      label: 'nearest',
+      addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge',
+      magFilter: 'nearest', minFilter: 'nearest', mipmapFilter: 'nearest',
+    });
+    const vpUbo = mkUbo('glyph-vp', [W, H, 0, 0]);
+    const mTex = device.createShaderModule({ label: 'tex', code: TEX_WGSL });
+    const texBgl = device.createBindGroupLayout({
+      label: 'glyph-bgl',
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float', viewDimension: '2d', multisampled: false } },
+        { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+      ],
+    });
+    const texBg = device.createBindGroup({
+      label: 'glyph-bg',
+      layout: texBgl,
+      entries: [
+        { binding: 0, resource: { buffer: vpUbo } },
+        { binding: 1, resource: gview },
+        { binding: 2, resource: samp },
+      ],
+    });
+    const texPll = device.createPipelineLayout({ label: 'glyph-pll', bindGroupLayouts: [texBgl] });
+    const vblPos2uv: GPUVertexBufferLayout = {
+      arrayStride: 16,
+      stepMode: 'vertex',
+      attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }, { format: 'float32x2', offset: 8, shaderLocation: 1 }],
+    };
+    const pipeTex = device.createRenderPipeline({
+      label: 'glyph-pipe',
+      layout: texPll,
+      vertex: { module: mTex, entryPoint: 'vs', buffers: [vblPos2uv] },
+      fragment: { module: mTex, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+      primitive: { topology: 'triangle-list' },
+    });
+    const gq = new Float32Array([
+      20, 20, 0, 0,
+      28, 20, 1, 0,
+      20, 28, 0, 1,
+      20, 28, 0, 1,
+      28, 20, 1, 0,
+      28, 28, 1, 1,
+    ]);
+    const gvbo = mkVbo('glyph-quad', gq);
+    const fb = await frame([0, 0, 0, 1], [{ pipe: pipeTex, bind: texBg, vbo: gvbo, verts: 6 }]);
+    let bad = 0;
+    for (let dy = 0; dy < 8; dy++) {
+      for (let dx = 0; dx < 8; dx++) {
+        const sx = 20 + dx, sy = 20 + dy;
+        const lit = ((GLYPH_H[dy] >> (7 - dx)) & 1) === 1;
+        const v = lit ? 255 : 0;
+        if (!fb.peq(sx, sy, v, v, v, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, "glyph blit: all 64 texels match hardcoded 8x8 'H' bitmap");
+    ok(fb.peq(21, 23, 255, 255, 255, 255, 1), 'glyph crossbar lit (col1,row3)');
+    ok(fb.peq(23, 20, 0, 0, 0, 255, 1), 'glyph row0 blank');
+    ok(fb.peq(24, 21, 0, 0, 0, 255, 1), 'glyph row1 middle blank (0x42)');
+  }
+
+  // ---- Scene E: scissor-clipped fill ----
+  {
+    writeSolid(1, 0, 1, 1);
+    const fq = mkVbo('scissor-quad', rectVerts(0, 0, W, H));
+    const fb = await frame([0, 0, 0, 1], [{ pipe: pipeSolid, bind: solidBg, vbo: fq, verts: 6, scissor: [16, 16, 20, 20] }]);
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const inb = x >= 16 && x < 36 && y >= 16 && y < 36;
+        const er = inb ? 255 : 0;
+        const eb = inb ? 255 : 0;
+        if (!fb.peq(x, y, er, 0, eb, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'scissor-clipped fill: magenta only within [16,36)^2');
+    ok(fb.peq(20, 20, 255, 0, 255, 255, 1), 'scissor inside magenta');
+    ok(fb.peq(40, 40, 0, 0, 0, 255, 1), 'scissor outside background');
+  }
+
+  // ---- Scene F: MULTI-LAYER Porter-Duff over compositing ----
+  {
+    const bg = [0.1, 0.1, 0.1, 1.0];
+    interface Layer { r: number; g: number; b: number; a: number; x0: number; y0: number; x1: number; y1: number; }
+    const layers: Layer[] = [
+      { r: 1, g: 0, b: 0, a: 0.5, x0: 8, y0: 8, x1: 56, y1: 56 },
+      { r: 0, g: 1, b: 0, a: 0.25, x0: 12, y0: 12, x1: 52, y1: 52 },
+      { r: 0, g: 0, b: 1, a: 0.75, x0: 16, y0: 16, x1: 48, y1: 48 },
+    ];
+    const ops: DrawOp[] = layers.map((l) => {
+      const bgd = mkSolidBg('layer-bg', mkUbo('layer-ubo', [l.r, l.g, l.b, l.a, W, H, 0, 0]));
+      const v = mkVbo('layer-quad', rectVerts(l.x0, l.y0, l.x1, l.y1));
+      return { pipe: pipeBlend, bind: bgd, vbo: v, verts: 6 };
+    });
+    const fb = await frame([bg[0], bg[1], bg[2], bg[3]], ops);
+    const composite = (tx: number, ty: number): number[] => {
+      const c = bg.slice();
+      for (const l of layers) {
+        const cx = tx + 0.5, cy = ty + 0.5;
+        if (cx >= l.x0 && cx < l.x1 && cy >= l.y0 && cy < l.y1) {
+          const aS = l.a;
+          const src = [l.r, l.g, l.b, l.a];
+          for (let k = 0; k < 4; k++) c[k] = src[k] * aS + c[k] * (1.0 - aS);
+        }
+      }
+      return c;
+    };
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const e = composite(x, y);
+        if (!fb.peq(x, y, q8(e[0]), q8(e[1]), q8(e[2]), q8(e[3]), 2)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'multi-layer over: every pixel matches Porter-Duff over accumulation (incl partial-overlap regions)');
+    {
+      const c = bg.slice();
+      const ls = [[1, 0, 0, 0.5], [0, 1, 0, 0.25], [0, 0, 1, 0.75]];
+      for (const li of ls) {
+        const aS = li[3];
+        for (let k = 0; k < 4; k++) c[k] = li[k] * aS + c[k] * (1.0 - aS);
+      }
+      ok(fb.peq(32, 32, q8(c[0]), q8(c[1]), q8(c[2]), q8(c[3]), 2), 'multi-layer over center pixel matches hand-iterated over');
+    }
+    {
+      const aS = 0.5;
+      const er = 1.0 * aS + bg[0] * (1.0 - aS);
+      const eg = 0.0 * aS + bg[1] * (1.0 - aS);
+      const eb = 0.0 * aS + bg[2] * (1.0 - aS);
+      const ea = aS * aS + bg[3] * (1.0 - aS);
+      ok(fb.peq(10, 32, q8(er), q8(eg), q8(eb), q8(ea), 2), 'multi-layer over: single-layer region matches one over');
+    }
+  }
+
+  // ---- Negative control ----
+  {
+    const vr1 = mkVbo('neg-rect', rectVerts(8, 8, 16, 24));
+    const bgA = mkSolidBg('neg-bg', mkUbo('neg-ubo', [1, 0, 0, 1, W, H, 0, 0]));
+    const fb = await frame([0, 0, 0, 1], [{ pipe: pipeSolid, bind: bgA, vbo: vr1, verts: 6 }]);
+    ok(!fb.peq(10, 10, 0, 255, 0, 255, 4), 'negative control: red rect pixel is NOT green');
+    ok(!fb.peq(30, 30, 255, 0, 0, 255, 4), 'negative control: background is NOT red');
+  }
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code: number) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+  })
+  .catch((e: unknown) => {
+    console.error('FATAL: ' + (e instanceof Error && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/scene_3dmodel_js/scene_3dmodel_js.js
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/scene_3dmodel_js/scene_3dmodel_js.js
@@ -1,0 +1,408 @@
+// scene_3dmodel (JS) - 3D indexed-mesh RENDER-scene carpet via Deno's built-in navigator.gpu (wgpu-core,
+// the Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on the CPU,
+// no GPU/window/surface). WebGPU/Deno port of the wgpu Rust scene_3dmodel: an offscreen rgba8unorm color
+// texture + a depth32float depth texture, drawn through a real render pipeline (WGSL vertex+fragment)
+// with depth compare 'less', copied to a MAP_READ buffer (256-byte bytesPerRow padding) and read back.
+// Renders an indexed cube mesh with a hand-computed perspective MVP, depth-buffered occlusion, and
+// Gouraud shading. The assertion is an INDEPENDENT software reference rasterizer written in JS: verts
+// transformed by the SAME MVP -> clip -> NDC (perspective divide) -> viewport pixels; per pixel we
+// compute barycentric coordinates, do a perspective-correct depth test in a private z-buffer, interpolate
+// vertex colors, then compare the reference framebuffer to the readback per pixel. Closes with a negative
+// control. Prints "SCENE_3DMODEL_JS OK <n>" only when FAIL==0 && TOTAL==EXPECTED==PASS.
+//
+// WebGPU NDC z is in [0,1] (near->0, far->1). perspective() uses m[2][2]=zf/(zn-zf),
+// m[3][2]=(zf*zn)/(zn-zf); the reference window depth is z/w directly. @invariant on the vertex
+// @builtin(position) pins depth bit-exactness so the LESS occlusion is deterministic. The column-major
+// M4 math, cube verts/colors/indices, model/view, barycentric rasterizer and perspective-correct color
+// interpolation are ported byte-identical in behavior from the wgpu Rust reference.
+
+'use strict';
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+const ALIGN = 256;
+const PADDED = Math.ceil((W * BPP) / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond, desc) {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+const EXPECTED = 14;
+
+// pos3 + col3, mvp uniform. @invariant pins depth bit-exactness.
+const CUBE_WGSL = `
+struct MVP { m: mat4x4<f32> };
+@group(0) @binding(0) var<uniform> u: MVP;
+struct VOut { @invariant @builtin(position) pos: vec4<f32>, @location(0) col: vec3<f32> };
+@vertex fn vs(@location(0) p: vec3<f32>, @location(1) c: vec3<f32>) -> VOut {
+  var o: VOut;
+  o.pos = u.m * vec4<f32>(p, 1.0);
+  o.col = c;
+  return o;
+}
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> {
+  return vec4<f32>(in.col, 1.0);
+}
+`;
+
+// ---- column-major 4x4 matrix math (GL layout: m[col*4+row]) - ported from the reference ----
+function mul(a, b) {
+  const r = new Array(16).fill(0);
+  for (let c = 0; c < 4; c++) {
+    for (let row = 0; row < 4; row++) {
+      let s = 0;
+      for (let k = 0; k < 4; k++) s += a[k * 4 + row] * b[c * 4 + k];
+      r[c * 4 + row] = s;
+    }
+  }
+  return r;
+}
+function mv4(a, v) {
+  const o = [0, 0, 0, 0];
+  for (let row = 0; row < 4; row++) {
+    let s = 0;
+    for (let k = 0; k < 4; k++) s += a[k * 4 + row] * v[k];
+    o[row] = s;
+  }
+  return o;
+}
+// WebGPU/Vulkan perspective: near->z_ndc 0, far->z_ndc 1. Only the z row differs from GL.
+function perspective(fovy, aspect, zn, zf) {
+  const f = 1.0 / Math.tan(fovy * 0.5);
+  const r = new Array(16).fill(0);
+  r[0 * 4 + 0] = f / aspect;
+  r[1 * 4 + 1] = f;
+  r[2 * 4 + 2] = zf / (zn - zf);
+  r[2 * 4 + 3] = -1.0;
+  r[3 * 4 + 2] = (zf * zn) / (zn - zf);
+  return r;
+}
+function translate(x, y, z) {
+  const r = new Array(16).fill(0);
+  r[0] = 1; r[5] = 1; r[10] = 1; r[15] = 1;
+  r[3 * 4 + 0] = x; r[3 * 4 + 1] = y; r[3 * 4 + 2] = z;
+  return r;
+}
+function rotY(a) {
+  const r = new Array(16).fill(0);
+  const c = Math.cos(a), s = Math.sin(a);
+  r[0 * 4 + 0] = c; r[0 * 4 + 2] = -s; r[2 * 4 + 0] = s; r[2 * 4 + 2] = c;
+  r[1 * 4 + 1] = 1; r[3 * 4 + 3] = 1;
+  return r;
+}
+function rotX(a) {
+  const r = new Array(16).fill(0);
+  const c = Math.cos(a), s = Math.sin(a);
+  r[1 * 4 + 1] = c; r[1 * 4 + 2] = s; r[2 * 4 + 1] = -s; r[2 * 4 + 2] = c;
+  r[0 * 4 + 0] = 1; r[3 * 4 + 3] = 1;
+  return r;
+}
+
+class Fb {
+  constructor(px) {
+    this.px = px;
+  }
+  p(x, y, c) {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x, y, r, g, b, a, tol) {
+    const d = (v, t) => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+}
+
+function finish() {
+  const total = PASS + FAIL;
+  console.log('scene-3dmodel-js: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED);
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('SCENE_3DMODEL_JS OK ' + PASS);
+    return 0;
+  }
+  console.log('SCENE_3DMODEL_JS FAIL');
+  return 1;
+}
+
+async function run() {
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    ok(false, 'request_adapter yields a usable adapter');
+    return finish();
+  }
+  const info = adapter.info || {};
+  console.log('scene-3dmodel-js adapter: vendor=' + info.vendor + ' device=' + info.device + ' description=' + info.description);
+  ok(true, 'request_adapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter backend is Vulkan or Gl');
+
+  const device = await adapter.requestDevice({ label: '3dmodel-device' });
+  if (device == null) {
+    ok(false, 'request_device yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev) => {
+    console.error('UNCAPTURED webgpu error: ' + ev.error.message);
+  });
+  const queue = device.queue;
+
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+  const depthTex = device.createTexture({
+    label: 'depth',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'depth32float',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+  const depthView = depthTex.createView();
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+  ok(true, 'offscreen Rgba8Unorm + Depth32Float target + readback buffer ready');
+
+  const copyAndRead = async (enc) => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      px.set(padded.subarray(y * PADDED, y * PADDED + W * BPP), y * W * BPP);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  // ---- cube mesh: 8 verts, 12 triangles, per-vertex color = position-based (ported) ----
+  const VP = [
+    [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+    [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1],
+  ];
+  const vc = [];
+  for (let i = 0; i < 8; i++) {
+    vc.push([(VP[i][0] + 1) * 0.5, (VP[i][1] + 1) * 0.5, (VP[i][2] + 1) * 0.5]);
+  }
+  const IDX = [
+    0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 4, 5, 0, 5, 1, 3, 2, 6, 3, 6, 7, 0, 3, 7, 0, 7, 4, 1, 5, 6, 1, 6, 2,
+  ];
+
+  const model = mul(rotY(0.6), rotX(0.3));
+  const view = translate(0, 0, -5);
+  const proj = perspective(1.0, W / H, 1.0, 20.0);
+  const mvp = mul(proj, mul(view, model));
+
+  // interleaved pos3 + col3 vertex buffer.
+  const verts = new Float32Array(8 * 6);
+  for (let i = 0; i < 8; i++) {
+    verts[i * 6 + 0] = VP[i][0]; verts[i * 6 + 1] = VP[i][1]; verts[i * 6 + 2] = VP[i][2];
+    verts[i * 6 + 3] = vc[i][0]; verts[i * 6 + 4] = vc[i][1]; verts[i * 6 + 5] = vc[i][2];
+  }
+  const vbo = device.createBuffer({ label: 'cube-vbo', size: verts.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+  new Float32Array(vbo.getMappedRange()).set(verts);
+  vbo.unmap();
+  const idxArr = new Uint16Array(IDX);
+  const ibo = device.createBuffer({ label: 'cube-ibo', size: idxArr.byteLength, usage: GPUBufferUsage.INDEX, mappedAtCreation: true });
+  new Uint16Array(ibo.getMappedRange()).set(idxArr);
+  ibo.unmap();
+
+  const mvpArr = new Float32Array(mvp);
+  const mvpUbo = device.createBuffer({ label: 'mvp', size: mvpArr.byteLength, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true });
+  new Float32Array(mvpUbo.getMappedRange()).set(mvpArr);
+  mvpUbo.unmap();
+
+  const bgl = device.createBindGroupLayout({
+    label: 'mvp-bgl',
+    entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } }],
+  });
+  const bg = device.createBindGroup({ label: 'mvp-bg', layout: bgl, entries: [{ binding: 0, resource: { buffer: mvpUbo } }] });
+  const pll = device.createPipelineLayout({ label: 'pll', bindGroupLayouts: [bgl] });
+  const module = device.createShaderModule({ label: 'cube', code: CUBE_WGSL });
+  const vbl = {
+    arrayStride: 24,
+    stepMode: 'vertex',
+    attributes: [{ format: 'float32x3', offset: 0, shaderLocation: 0 }, { format: 'float32x3', offset: 12, shaderLocation: 1 }],
+  };
+  const pipe = device.createRenderPipeline({
+    label: 'cube-pipe',
+    layout: pll,
+    vertex: { module, entryPoint: 'vs', buffers: [vbl] },
+    fragment: { module, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+    primitive: { topology: 'triangle-list', frontFace: 'ccw', cullMode: 'none' },
+    depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'less' },
+  });
+  ok(true, 'cube pipeline created');
+
+  // ---- draw: clear color black, clear depth 1.0, draw the indexed cube ----
+  const buf = await (async () => {
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const rp = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: 0, g: 0, b: 0, a: 1 } }],
+      depthStencilAttachment: { view: depthView, depthLoadOp: 'clear', depthStoreOp: 'store', depthClearValue: 1.0 },
+    });
+    rp.setPipeline(pipe);
+    rp.setBindGroup(0, bg);
+    rp.setVertexBuffer(0, vbo);
+    rp.setIndexBuffer(ibo, 'uint16');
+    rp.drawIndexed(36, 1, 0, 0, 0);
+    rp.end();
+    return copyAndRead(enc);
+  })();
+  ok(true, 'cube drawn (depth-tested, Gouraud)');
+
+  // ---- INDEPENDENT software reference rasterizer (ported; WebGPU NDC-z in [0,1]) ----
+  const refc = new Array(W * H);
+  const refz = new Float32Array(W * H).fill(1e9);
+  const refcov = new Uint8Array(W * H);
+  for (let i = 0; i < W * H; i++) refc[i] = [0, 0, 0];
+  const idx2 = (x, y) => y * W + x;
+
+  const sx = new Array(8), sy = new Array(8), sz = new Array(8), sw = new Array(8);
+  for (let i = 0; i < 8; i++) {
+    const out = mv4(mvp, [VP[i][0], VP[i][1], VP[i][2], 1.0]);
+    const w = out[3];
+    sw[i] = w;
+    const ndcx = out[0] / w, ndcy = out[1] / w, ndcz = out[2] / w;
+    sx[i] = (ndcx * 0.5 + 0.5) * W;
+    sy[i] = (0.5 - ndcy * 0.5) * H;
+    sz[i] = ndcz;
+  }
+  ok(sw[0] > 0.0, 'reference: all clip.w positive (mesh in front of camera)');
+
+  for (let t = 0; t < 12; t++) {
+    const a = IDX[t * 3], b = IDX[t * 3 + 1], c = IDX[t * 3 + 2];
+    const ax = sx[a], ay = sy[a], bx = sx[b], by = sy[b], cx = sx[c], cy = sy[c];
+    const area = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+    if (Math.abs(area) < 1e-6) continue;
+    let minx = Math.floor(Math.min(ax, bx, cx));
+    let maxx = Math.ceil(Math.max(ax, bx, cx));
+    let miny = Math.floor(Math.min(ay, by, cy));
+    let maxy = Math.ceil(Math.max(ay, by, cy));
+    minx = Math.max(minx, 0); miny = Math.max(miny, 0);
+    maxx = Math.min(maxx, W); maxy = Math.min(maxy, H);
+    for (let y = miny; y < maxy; y++) {
+      for (let x = minx; x < maxx; x++) {
+        const pxs = x + 0.5, pys = y + 0.5;
+        let w0 = ((bx - pxs) * (cy - pys) - (by - pys) * (cx - pxs)) / area;
+        let w1 = ((cx - pxs) * (ay - pys) - (cy - pys) * (ax - pxs)) / area;
+        let w2 = 1.0 - w0 - w1;
+        const inside = (w0 >= 0 && w1 >= 0 && w2 >= 0) || (w0 <= 0 && w1 <= 0 && w2 <= 0);
+        if (!inside) continue;
+        if (w0 < 0 || w1 < 0 || w2 < 0) { w0 = -w0; w1 = -w1; w2 = -w2; }
+        const z = w0 * sz[a] + w1 * sz[b] + w2 * sz[c];
+        const i = idx2(x, y);
+        if (z < refz[i]) {
+          refz[i] = z;
+          refcov[i] = 1;
+          const iwa = 1.0 / sw[a], iwb = 1.0 / sw[b], iwc = 1.0 / sw[c];
+          const d = w0 * iwa + w1 * iwb + w2 * iwc;
+          for (let k = 0; k < 3; k++) {
+            const num = w0 * iwa * vc[a][k] + w1 * iwb * vc[b][k] + w2 * iwc * vc[c][k];
+            refc[i][k] = num / d;
+          }
+        }
+      }
+    }
+  }
+
+  let total = 0, match = 0, covmatch = 0, covtotal = 0, interiorBad = 0;
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      total += 1;
+      const gcov = !(buf.p(x, y, 0) === 0 && buf.p(x, y, 1) === 0 && buf.p(x, y, 2) === 0);
+      const i = idx2(x, y);
+      const rcov = refcov[i] !== 0;
+      if (gcov === rcov) covmatch += 1;
+      if (rcov) {
+        covtotal += 1;
+        const er = Math.round(refc[i][0] * 255.0);
+        const eg = Math.round(refc[i][1] * 255.0);
+        const eb = Math.round(refc[i][2] * 255.0);
+        const interior =
+          x > 0 && y > 0 && x < W - 1 && y < H - 1 &&
+          refcov[idx2(x, y - 1)] !== 0 && refcov[idx2(x, y + 1)] !== 0 &&
+          refcov[idx2(x - 1, y)] !== 0 && refcov[idx2(x + 1, y)] !== 0;
+        if (buf.peq(x, y, er, eg, eb, 255, 6)) match += 1;
+        else if (interior) interiorBad += 1;
+      }
+    }
+  }
+  ok(covtotal > 200, 'reference: cube covers a substantial area');
+  ok(covmatch >= Math.floor(0.97 * total), 'coverage mask matches GPU (>=97% of pixels agree covered/empty)');
+  ok(interiorBad === 0, 'every interior pixel matches perspective-correct Gouraud reference (tol 6)');
+  ok(match >= Math.floor(0.92 * covtotal), '92%+ of covered pixels match reference color (edges excluded)');
+
+  {
+    const vx = Math.round(sx[6] - 0.5);
+    const vy = Math.round(sy[6] - 0.5);
+    if (vx >= 1 && vx < W - 1 && vy >= 1 && vy < H - 1) {
+      let bright = false;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          const xx = vx + dx, yy = vy + dy;
+          if (buf.p(xx, yy, 0) > 180 && buf.p(xx, yy, 1) > 180 && buf.p(xx, yy, 2) > 180) bright = true;
+        }
+      }
+      ok(bright, 'vertex (1,1,1) region is bright (Gouraud white corner)');
+    } else {
+      ok(false, 'vertex (1,1,1) projected off-screen (camera mis-set)');
+    }
+  }
+  ok(buf.peq(0, 0, 0, 0, 0, 255, 1) || refcov[idx2(0, 0)] === 0, 'corner (0,0) background consistent');
+
+  {
+    const cxp = W / 2, cyp = H / 2;
+    const i = idx2(cxp, cyp);
+    if (refcov[i] !== 0) {
+      const er = Math.round(refc[i][0] * 255.0);
+      const eg = Math.round(refc[i][1] * 255.0);
+      const eb = Math.round(refc[i][2] * 255.0);
+      ok(buf.peq(cxp, cyp, er, eg, eb, 255, 8), 'center pixel = nearest-face (depth-buffered occlusion) reference color');
+    } else {
+      ok(false, 'center pixel not covered (mesh mis-projected)');
+    }
+  }
+
+  ok(
+    !(buf.p(1, 1, 0) === buf.p(W / 2, H / 2, 0) && buf.p(1, 1, 1) === buf.p(W / 2, H / 2, 1) && buf.p(1, 1, 2) === buf.p(W / 2, H / 2, 2)),
+    'negative control: image is not a flat single color (real 3D shading present)'
+  );
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+    else process.exit(code);
+  })
+  .catch((e) => {
+    console.error('FATAL: ' + (e && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+    else process.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/scene_3dmodel_ts/scene_3dmodel_ts.ts
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/scene_3dmodel_ts/scene_3dmodel_ts.ts
@@ -1,0 +1,397 @@
+// scene_3dmodel (TS) - 3D indexed-mesh RENDER-scene carpet via Deno's built-in navigator.gpu (wgpu-core,
+// the Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on the CPU,
+// no GPU/window/surface). Typed WebGPU/Deno port of the wgpu Rust scene_3dmodel: an offscreen rgba8unorm
+// color texture + a depth32float depth texture, drawn through a real render pipeline (WGSL) with depth
+// compare 'less', copied to a MAP_READ buffer (256-byte bytesPerRow padding) and read back. Renders an
+// indexed cube mesh with a hand-computed perspective MVP, depth-buffered occlusion, and Gouraud shading.
+// The assertion is an INDEPENDENT software reference rasterizer in TS (barycentric + 1/w interp). Closes
+// with a negative control. Prints "SCENE_3DMODEL_TS OK <n>" only when FAIL==0 && TOTAL==EXPECTED==PASS.
+// This is the typed mirror of the JS cell.
+//
+// WebGPU NDC z is in [0,1] (near->0, far->1). @invariant on the vertex @builtin(position) pins depth
+// bit-exactness so the LESS occlusion is deterministic. The column-major M4 math, cube verts/colors/
+// indices, model/view, barycentric rasterizer and perspective-correct interpolation are ported
+// byte-identical in behavior from the wgpu Rust reference.
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+const ALIGN = 256;
+const PADDED = Math.ceil((W * BPP) / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond: boolean, desc: string): void {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+const EXPECTED = 14;
+
+const CUBE_WGSL = `
+struct MVP { m: mat4x4<f32> };
+@group(0) @binding(0) var<uniform> u: MVP;
+struct VOut { @invariant @builtin(position) pos: vec4<f32>, @location(0) col: vec3<f32> };
+@vertex fn vs(@location(0) p: vec3<f32>, @location(1) c: vec3<f32>) -> VOut {
+  var o: VOut;
+  o.pos = u.m * vec4<f32>(p, 1.0);
+  o.col = c;
+  return o;
+}
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> {
+  return vec4<f32>(in.col, 1.0);
+}
+`;
+
+// ---- column-major 4x4 matrix math (GL layout: m[col*4+row]) ----
+function mul(a: number[], b: number[]): number[] {
+  const r = new Array<number>(16).fill(0);
+  for (let c = 0; c < 4; c++) {
+    for (let row = 0; row < 4; row++) {
+      let s = 0;
+      for (let k = 0; k < 4; k++) s += a[k * 4 + row] * b[c * 4 + k];
+      r[c * 4 + row] = s;
+    }
+  }
+  return r;
+}
+function mv4(a: number[], v: number[]): number[] {
+  const o = [0, 0, 0, 0];
+  for (let row = 0; row < 4; row++) {
+    let s = 0;
+    for (let k = 0; k < 4; k++) s += a[k * 4 + row] * v[k];
+    o[row] = s;
+  }
+  return o;
+}
+function perspective(fovy: number, aspect: number, zn: number, zf: number): number[] {
+  const f = 1.0 / Math.tan(fovy * 0.5);
+  const r = new Array<number>(16).fill(0);
+  r[0 * 4 + 0] = f / aspect;
+  r[1 * 4 + 1] = f;
+  r[2 * 4 + 2] = zf / (zn - zf);
+  r[2 * 4 + 3] = -1.0;
+  r[3 * 4 + 2] = (zf * zn) / (zn - zf);
+  return r;
+}
+function translate(x: number, y: number, z: number): number[] {
+  const r = new Array<number>(16).fill(0);
+  r[0] = 1; r[5] = 1; r[10] = 1; r[15] = 1;
+  r[3 * 4 + 0] = x; r[3 * 4 + 1] = y; r[3 * 4 + 2] = z;
+  return r;
+}
+function rotY(a: number): number[] {
+  const r = new Array<number>(16).fill(0);
+  const c = Math.cos(a), s = Math.sin(a);
+  r[0 * 4 + 0] = c; r[0 * 4 + 2] = -s; r[2 * 4 + 0] = s; r[2 * 4 + 2] = c;
+  r[1 * 4 + 1] = 1; r[3 * 4 + 3] = 1;
+  return r;
+}
+function rotX(a: number): number[] {
+  const r = new Array<number>(16).fill(0);
+  const c = Math.cos(a), s = Math.sin(a);
+  r[1 * 4 + 1] = c; r[1 * 4 + 2] = s; r[2 * 4 + 1] = -s; r[2 * 4 + 2] = c;
+  r[0 * 4 + 0] = 1; r[3 * 4 + 3] = 1;
+  return r;
+}
+
+class Fb {
+  px: Uint8Array;
+  constructor(px: Uint8Array) {
+    this.px = px;
+  }
+  p(x: number, y: number, c: number): number {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x: number, y: number, r: number, g: number, b: number, a: number, tol: number): boolean {
+    const d = (v: number, t: number): boolean => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+}
+
+function finish(): number {
+  const total = PASS + FAIL;
+  console.log('scene-3dmodel-ts: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED);
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('SCENE_3DMODEL_TS OK ' + PASS);
+    return 0;
+  }
+  console.log('SCENE_3DMODEL_TS FAIL');
+  return 1;
+}
+
+async function run(): Promise<number> {
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const adapter: GPUAdapter | null = await navigator.gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    ok(false, 'request_adapter yields a usable adapter');
+    return finish();
+  }
+  const info = (adapter.info || {}) as GPUAdapterInfo;
+  console.log('scene-3dmodel-ts adapter: vendor=' + info.vendor + ' device=' + info.device + ' description=' + info.description);
+  ok(true, 'request_adapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter backend is Vulkan or Gl');
+
+  const device: GPUDevice = await adapter.requestDevice({ label: '3dmodel-device' });
+  if (device == null) {
+    ok(false, 'request_device yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev: Event) => {
+    console.error('UNCAPTURED webgpu error: ' + (ev as GPUUncapturedErrorEvent).error.message);
+  });
+  const queue: GPUQueue = device.queue;
+
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+  const depthTex = device.createTexture({
+    label: 'depth',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'depth32float',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+  const depthView = depthTex.createView();
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+  ok(true, 'offscreen Rgba8Unorm + Depth32Float target + readback buffer ready');
+
+  const copyAndRead = async (enc: GPUCommandEncoder): Promise<Fb> => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      px.set(padded.subarray(y * PADDED, y * PADDED + W * BPP), y * W * BPP);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  const VP: number[][] = [
+    [-1, -1, -1], [1, -1, -1], [1, 1, -1], [-1, 1, -1],
+    [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1],
+  ];
+  const vc: number[][] = [];
+  for (let i = 0; i < 8; i++) {
+    vc.push([(VP[i][0] + 1) * 0.5, (VP[i][1] + 1) * 0.5, (VP[i][2] + 1) * 0.5]);
+  }
+  const IDX = [
+    0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6, 0, 4, 5, 0, 5, 1, 3, 2, 6, 3, 6, 7, 0, 3, 7, 0, 7, 4, 1, 5, 6, 1, 6, 2,
+  ];
+
+  const model = mul(rotY(0.6), rotX(0.3));
+  const view = translate(0, 0, -5);
+  const proj = perspective(1.0, W / H, 1.0, 20.0);
+  const mvp = mul(proj, mul(view, model));
+
+  const verts = new Float32Array(8 * 6);
+  for (let i = 0; i < 8; i++) {
+    verts[i * 6 + 0] = VP[i][0]; verts[i * 6 + 1] = VP[i][1]; verts[i * 6 + 2] = VP[i][2];
+    verts[i * 6 + 3] = vc[i][0]; verts[i * 6 + 4] = vc[i][1]; verts[i * 6 + 5] = vc[i][2];
+  }
+  const vbo = device.createBuffer({ label: 'cube-vbo', size: verts.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+  new Float32Array(vbo.getMappedRange()).set(verts);
+  vbo.unmap();
+  const idxArr = new Uint16Array(IDX);
+  const ibo = device.createBuffer({ label: 'cube-ibo', size: idxArr.byteLength, usage: GPUBufferUsage.INDEX, mappedAtCreation: true });
+  new Uint16Array(ibo.getMappedRange()).set(idxArr);
+  ibo.unmap();
+
+  const mvpArr = new Float32Array(mvp);
+  const mvpUbo = device.createBuffer({ label: 'mvp', size: mvpArr.byteLength, usage: GPUBufferUsage.UNIFORM, mappedAtCreation: true });
+  new Float32Array(mvpUbo.getMappedRange()).set(mvpArr);
+  mvpUbo.unmap();
+
+  const bgl = device.createBindGroupLayout({
+    label: 'mvp-bgl',
+    entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: 'uniform' } }],
+  });
+  const bg = device.createBindGroup({ label: 'mvp-bg', layout: bgl, entries: [{ binding: 0, resource: { buffer: mvpUbo } }] });
+  const pll = device.createPipelineLayout({ label: 'pll', bindGroupLayouts: [bgl] });
+  const module = device.createShaderModule({ label: 'cube', code: CUBE_WGSL });
+  const vbl: GPUVertexBufferLayout = {
+    arrayStride: 24,
+    stepMode: 'vertex',
+    attributes: [{ format: 'float32x3', offset: 0, shaderLocation: 0 }, { format: 'float32x3', offset: 12, shaderLocation: 1 }],
+  };
+  const pipe = device.createRenderPipeline({
+    label: 'cube-pipe',
+    layout: pll,
+    vertex: { module, entryPoint: 'vs', buffers: [vbl] },
+    fragment: { module, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+    primitive: { topology: 'triangle-list', frontFace: 'ccw', cullMode: 'none' },
+    depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'less' },
+  });
+  ok(true, 'cube pipeline created');
+
+  const buf = await (async (): Promise<Fb> => {
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const rp = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: 0, g: 0, b: 0, a: 1 } }],
+      depthStencilAttachment: { view: depthView, depthLoadOp: 'clear', depthStoreOp: 'store', depthClearValue: 1.0 },
+    });
+    rp.setPipeline(pipe);
+    rp.setBindGroup(0, bg);
+    rp.setVertexBuffer(0, vbo);
+    rp.setIndexBuffer(ibo, 'uint16');
+    rp.drawIndexed(36, 1, 0, 0, 0);
+    rp.end();
+    return copyAndRead(enc);
+  })();
+  ok(true, 'cube drawn (depth-tested, Gouraud)');
+
+  // ---- INDEPENDENT software reference rasterizer (WebGPU NDC-z in [0,1]) ----
+  const refc: number[][] = new Array(W * H);
+  const refz = new Float32Array(W * H).fill(1e9);
+  const refcov = new Uint8Array(W * H);
+  for (let i = 0; i < W * H; i++) refc[i] = [0, 0, 0];
+  const idx2 = (x: number, y: number): number => y * W + x;
+
+  const sx = new Array<number>(8), sy = new Array<number>(8), sz = new Array<number>(8), sw = new Array<number>(8);
+  for (let i = 0; i < 8; i++) {
+    const out = mv4(mvp, [VP[i][0], VP[i][1], VP[i][2], 1.0]);
+    const w = out[3];
+    sw[i] = w;
+    const ndcx = out[0] / w, ndcy = out[1] / w, ndcz = out[2] / w;
+    sx[i] = (ndcx * 0.5 + 0.5) * W;
+    sy[i] = (0.5 - ndcy * 0.5) * H;
+    sz[i] = ndcz;
+  }
+  ok(sw[0] > 0.0, 'reference: all clip.w positive (mesh in front of camera)');
+
+  for (let t = 0; t < 12; t++) {
+    const a = IDX[t * 3], b = IDX[t * 3 + 1], c = IDX[t * 3 + 2];
+    const ax = sx[a], ay = sy[a], bx = sx[b], by = sy[b], cx = sx[c], cy = sy[c];
+    const area = (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
+    if (Math.abs(area) < 1e-6) continue;
+    let minx = Math.floor(Math.min(ax, bx, cx));
+    let maxx = Math.ceil(Math.max(ax, bx, cx));
+    let miny = Math.floor(Math.min(ay, by, cy));
+    let maxy = Math.ceil(Math.max(ay, by, cy));
+    minx = Math.max(minx, 0); miny = Math.max(miny, 0);
+    maxx = Math.min(maxx, W); maxy = Math.min(maxy, H);
+    for (let y = miny; y < maxy; y++) {
+      for (let x = minx; x < maxx; x++) {
+        const pxs = x + 0.5, pys = y + 0.5;
+        let w0 = ((bx - pxs) * (cy - pys) - (by - pys) * (cx - pxs)) / area;
+        let w1 = ((cx - pxs) * (ay - pys) - (cy - pys) * (ax - pxs)) / area;
+        let w2 = 1.0 - w0 - w1;
+        const inside = (w0 >= 0 && w1 >= 0 && w2 >= 0) || (w0 <= 0 && w1 <= 0 && w2 <= 0);
+        if (!inside) continue;
+        if (w0 < 0 || w1 < 0 || w2 < 0) { w0 = -w0; w1 = -w1; w2 = -w2; }
+        const z = w0 * sz[a] + w1 * sz[b] + w2 * sz[c];
+        const i = idx2(x, y);
+        if (z < refz[i]) {
+          refz[i] = z;
+          refcov[i] = 1;
+          const iwa = 1.0 / sw[a], iwb = 1.0 / sw[b], iwc = 1.0 / sw[c];
+          const d = w0 * iwa + w1 * iwb + w2 * iwc;
+          for (let k = 0; k < 3; k++) {
+            const num = w0 * iwa * vc[a][k] + w1 * iwb * vc[b][k] + w2 * iwc * vc[c][k];
+            refc[i][k] = num / d;
+          }
+        }
+      }
+    }
+  }
+
+  let total = 0, match = 0, covmatch = 0, covtotal = 0, interiorBad = 0;
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      total += 1;
+      const gcov = !(buf.p(x, y, 0) === 0 && buf.p(x, y, 1) === 0 && buf.p(x, y, 2) === 0);
+      const i = idx2(x, y);
+      const rcov = refcov[i] !== 0;
+      if (gcov === rcov) covmatch += 1;
+      if (rcov) {
+        covtotal += 1;
+        const er = Math.round(refc[i][0] * 255.0);
+        const eg = Math.round(refc[i][1] * 255.0);
+        const eb = Math.round(refc[i][2] * 255.0);
+        const interior =
+          x > 0 && y > 0 && x < W - 1 && y < H - 1 &&
+          refcov[idx2(x, y - 1)] !== 0 && refcov[idx2(x, y + 1)] !== 0 &&
+          refcov[idx2(x - 1, y)] !== 0 && refcov[idx2(x + 1, y)] !== 0;
+        if (buf.peq(x, y, er, eg, eb, 255, 6)) match += 1;
+        else if (interior) interiorBad += 1;
+      }
+    }
+  }
+  ok(covtotal > 200, 'reference: cube covers a substantial area');
+  ok(covmatch >= Math.floor(0.97 * total), 'coverage mask matches GPU (>=97% of pixels agree covered/empty)');
+  ok(interiorBad === 0, 'every interior pixel matches perspective-correct Gouraud reference (tol 6)');
+  ok(match >= Math.floor(0.92 * covtotal), '92%+ of covered pixels match reference color (edges excluded)');
+
+  {
+    const vx = Math.round(sx[6] - 0.5);
+    const vy = Math.round(sy[6] - 0.5);
+    if (vx >= 1 && vx < W - 1 && vy >= 1 && vy < H - 1) {
+      let bright = false;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          const xx = vx + dx, yy = vy + dy;
+          if (buf.p(xx, yy, 0) > 180 && buf.p(xx, yy, 1) > 180 && buf.p(xx, yy, 2) > 180) bright = true;
+        }
+      }
+      ok(bright, 'vertex (1,1,1) region is bright (Gouraud white corner)');
+    } else {
+      ok(false, 'vertex (1,1,1) projected off-screen (camera mis-set)');
+    }
+  }
+  ok(buf.peq(0, 0, 0, 0, 0, 255, 1) || refcov[idx2(0, 0)] === 0, 'corner (0,0) background consistent');
+
+  {
+    const cxp = W / 2, cyp = H / 2;
+    const i = idx2(cxp, cyp);
+    if (refcov[i] !== 0) {
+      const er = Math.round(refc[i][0] * 255.0);
+      const eg = Math.round(refc[i][1] * 255.0);
+      const eb = Math.round(refc[i][2] * 255.0);
+      ok(buf.peq(cxp, cyp, er, eg, eb, 255, 8), 'center pixel = nearest-face (depth-buffered occlusion) reference color');
+    } else {
+      ok(false, 'center pixel not covered (mesh mis-projected)');
+    }
+  }
+
+  ok(
+    !(buf.p(1, 1, 0) === buf.p(W / 2, H / 2, 0) && buf.p(1, 1, 1) === buf.p(W / 2, H / 2, 1) && buf.p(1, 1, 2) === buf.p(W / 2, H / 2, 2)),
+    'negative control: image is not a flat single color (real 3D shading present)'
+  );
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code: number) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+  })
+  .catch((e: unknown) => {
+    console.error('FATAL: ' + (e instanceof Error && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/scene_anim_js/scene_anim_js.js
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/scene_anim_js/scene_anim_js.js
@@ -1,0 +1,294 @@
+// scene_anim (JS) - keyframe-animation RENDER-scene carpet via Deno's built-in navigator.gpu (wgpu-core,
+// the Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on the CPU,
+// no GPU/window/surface). WebGPU/Deno port of the wgpu Rust scene_anim: an offscreen 64x64 rgba8unorm
+// texture is rendered through a real render pipeline; N=4 keyframes of a transformed unit quad are drawn,
+// each frame's model transform a rotation about the FBO center composed with a translation and uniform
+// scale, interpolated by t in {0,0.25,0.5,0.75}. The transform is applied in the vertex shader from a
+// hand-built pixel-space affine (rotation, scale, translate) and an ortho pixel->NDC map. For every frame
+// the four rotated/scaled/translated quad CORNERS are computed INDEPENDENTLY in JS (closed form:
+// R(theta)*S*local + T) and the readback is asserted at those exact corner pixels plus a point outside
+// the quad. A cubic ease eased(t)=3t^2-2t^3 drives the scale, its value asserted at each t. Closes with a
+// negative control. Prints "SCENE_ANIM_JS OK <n>" only when FAIL==0 && TOTAL==EXPECTED==PASS.
+//
+// WebGPU readback is top-origin; the pixel-space vertex shader flips NDC y so pixel-y == readback-row, and
+// the closed-form corner/center pixel coordinates are indexed against readback rows directly. The lerp,
+// ease_cubic and R*S*local+T corner math are ported verbatim in behavior from the wgpu Rust reference.
+
+'use strict';
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+const ALIGN = 256;
+const PADDED = Math.ceil((W * BPP) / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond, desc) {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+const EXPECTED = 38;
+
+function lerp(a, b, t) {
+  return a + (b - a) * t;
+}
+function easeCubic(t) {
+  return 3.0 * t * t - 2.0 * t * t * t;
+}
+
+// Pixel-space affine vertex shader: pix = col0*lp.x + col1*lp.y + tr; then pixel -> NDC with y-flip.
+const WGSL = `
+struct X { col0: vec2<f32>, col1: vec2<f32>, tr: vec2<f32>, vp: vec2<f32>, rgba: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: X;
+@vertex fn vs(@location(0) lp: vec2<f32>) -> @builtin(position) vec4<f32> {
+  let pix = u.col0 * lp.x + u.col1 * lp.y + u.tr;
+  let n = (pix / u.vp) * 2.0 - 1.0;
+  return vec4<f32>(n.x, -n.y, 0.0, 1.0);
+}
+@fragment fn fs() -> @location(0) vec4<f32> { return u.rgba; }
+`;
+
+class Fb {
+  constructor(px) {
+    this.px = px;
+  }
+  p(x, y, c) {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x, y, r, g, b, a, tol) {
+    if (x < 0 || y < 0 || x >= W || y >= H) return false;
+    const d = (v, t) => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+  nearColor(x, y, r, g, b, tol) {
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        const xx = x + dx, yy = y + dy;
+        if (xx < 0 || yy < 0 || xx >= W || yy >= H) continue;
+        if (this.peq(xx, yy, r, g, b, 255, tol)) return true;
+      }
+    }
+    return false;
+  }
+}
+
+function finish() {
+  const total = PASS + FAIL;
+  console.log('scene-anim-js: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED);
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('SCENE_ANIM_JS OK ' + PASS);
+    return 0;
+  }
+  console.log('SCENE_ANIM_JS FAIL');
+  return 1;
+}
+
+async function run() {
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    ok(false, 'request_adapter yields a usable adapter');
+    return finish();
+  }
+  const info = adapter.info || {};
+  console.log('scene-anim-js adapter: vendor=' + info.vendor + ' device=' + info.device + ' description=' + info.description);
+  ok(true, 'request_adapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter backend is Vulkan or Gl');
+
+  const device = await adapter.requestDevice({ label: 'anim-device' });
+  if (device == null) {
+    ok(false, 'request_device yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev) => {
+    console.error('UNCAPTURED webgpu error: ' + ev.error.message);
+  });
+  const queue = device.queue;
+
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  const copyAndRead = async (enc) => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      px.set(padded.subarray(y * PADDED, y * PADDED + W * BPP), y * W * BPP);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  // Xform uniform: col0.xy, col1.xy, tr.xy, vp.xy, rgba (12 floats = 48 bytes).
+  const xformUbo = device.createBuffer({ label: 'xform-ubo', size: 48, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+  const bgl = device.createBindGroupLayout({
+    label: 'bgl',
+    entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
+  });
+  const bg = device.createBindGroup({ label: 'bg', layout: bgl, entries: [{ binding: 0, resource: { buffer: xformUbo } }] });
+  const pll = device.createPipelineLayout({ label: 'pll', bindGroupLayouts: [bgl] });
+  const module = device.createShaderModule({ label: 'anim', code: WGSL });
+  const vbl = { arrayStride: 8, stepMode: 'vertex', attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }] };
+  const pipe = device.createRenderPipeline({
+    label: 'anim-pipe',
+    layout: pll,
+    vertex: { module, entryPoint: 'vs', buffers: [vbl] },
+    fragment: { module, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+    primitive: { topology: 'triangle-strip' },
+  });
+
+  // local quad corners (unit square, TL/TR/BL/BR) as a triangle strip.
+  const local = [-1, -1, 1, -1, -1, 1, 1, 1];
+  const localArr = new Float32Array(local);
+  const vbo = device.createBuffer({ label: 'local-quad', size: localArr.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+  new Float32Array(vbo.getMappedRange()).set(localArr);
+  vbo.unmap();
+
+  // animation keyframe params (ported).
+  const a0 = 0.0, a1 = Math.PI / 2.0;
+  const s0 = 6.0, s1 = 14.0;
+  const cx0 = 20.0, cx1 = 44.0, cy0 = 20.0, cy1 = 44.0;
+  const frameTransform = (t) => {
+    const ang = lerp(a0, a1, t);
+    const sc = lerp(s0, s1, easeCubic(t));
+    const cx = lerp(cx0, cx1, t), cy = lerp(cy0, cy1, t);
+    const ca = Math.cos(ang), sa = Math.sin(ang);
+    const col0 = [sc * ca, sc * sa];
+    const col1 = [-sc * sa, sc * ca];
+    const tr = [cx, cy];
+    return { col0, col1, tr, sc, ang };
+  };
+
+  const ts = [0.0, 0.25, 0.5, 0.75];
+  const cols = [[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 0]];
+
+  const render = async (x) => {
+    queue.writeBuffer(xformUbo, 0, new Float32Array([x.col0[0], x.col0[1], x.col1[0], x.col1[1], x.tr[0], x.tr[1], x.vp[0], x.vp[1], x.rgba[0], x.rgba[1], x.rgba[2], x.rgba[3]]));
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const rp = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: 0, g: 0, b: 0, a: 1 } }],
+    });
+    rp.setPipeline(pipe);
+    rp.setBindGroup(0, bg);
+    rp.setVertexBuffer(0, vbo);
+    rp.draw(4, 1, 0, 0);
+    rp.end();
+    return copyAndRead(enc);
+  };
+
+  for (let fi = 0; fi < 4; fi++) {
+    const t = ts[fi];
+    const { col0, col1, tr, sc, ang } = frameTransform(t);
+    const fb = await render({ col0, col1, tr, vp: [W, H], rgba: [cols[fi][0], cols[fi][1], cols[fi][2], 1.0] });
+
+    // closed-form corner positions: corner = R(ang)*S(sc)*localCorner + center.
+    const ca = Math.cos(ang), sa = Math.sin(ang);
+    const corners = [];
+    for (let k = 0; k < 4; k++) {
+      const lx = local[k * 2], ly = local[k * 2 + 1];
+      const rx = sc * (ca * lx - sa * ly);
+      const ry = sc * (sa * lx + ca * ly);
+      corners.push([tr[0] + rx, tr[1] + ry]);
+    }
+    const e = easeCubic(t);
+    const eRef = 3.0 * t * t - 2.0 * t * t * t;
+    ok(Math.abs(e - eRef) < 1e-6, 'ease_cubic closed-form value');
+    ok(Math.abs(sc - (s0 + (s1 - s0) * e)) < 1e-4, 'scale = lerp(S0,S1,ease(t)) closed-form');
+
+    const cxi = Math.round(tr[0] - 0.5);
+    const cyi = Math.round(tr[1] - 0.5);
+    ok(
+      fb.peq(cxi, cyi, Math.round(cols[fi][0] * 255), Math.round(cols[fi][1] * 255), Math.round(cols[fi][2] * 255), 255, 2),
+      'frame center pixel carries frame color at closed-form center'
+    );
+
+    for (let k = 0; k < 4; k++) {
+      const px = Math.round(corners[k][0] - 0.5);
+      const py = Math.round(corners[k][1] - 0.5);
+      const onscreen = px >= 0 && py >= 0 && px < W && py < H;
+      ok(
+        onscreen && fb.nearColor(px, py, Math.round(cols[fi][0] * 255), Math.round(cols[fi][1] * 255), Math.round(cols[fi][2] * 255), 40),
+        'transformed corner pixel is inside the rendered quad (closed-form R*S*local+T)'
+      );
+    }
+
+    {
+      const ox = fi < 2 ? W - 2 : 1;
+      const oy = fi < 2 ? H - 2 : 1;
+      const reach = sc * 1.4142;
+      const covers = Math.abs(ox + 0.5 - tr[0]) <= reach && Math.abs(oy + 0.5 - tr[1]) <= reach;
+      if (!covers) {
+        ok(fb.peq(ox, oy, 0, 0, 0, 255, 2), 'outside-quad point stays background (closed-form silhouette)');
+      } else {
+        ok(true, 'outside-quad point skipped (would be covered)');
+      }
+    }
+  }
+
+  // t=0 vs t=0.75 center positions differ.
+  {
+    const tra = frameTransform(0.0).tr;
+    const trb = frameTransform(0.75).tr;
+    ok(Math.abs(tra[0] - trb[0]) > 1.0, 'center translates between t=0 and t=0.75 (animation is real)');
+  }
+
+  // rotation at t=0.5: angle = pi/4, rotated x-axis column = (sc*cos45, sc*sin45).
+  {
+    const { col0, ang } = frameTransform(0.5);
+    ok(Math.abs(ang - Math.PI / 4.0) < 1e-5, 't=0.5 rotation angle = pi/4 closed-form');
+    ok(Math.abs(col0[0] - col0[1]) < 1e-4 && col0[0] > 0.0, 't=0.5 rotated x-axis column is (sc*cos45, sc*sin45)');
+  }
+
+  // negative control: render frame 0 (red) and confirm it is NOT green.
+  {
+    const { col0, col1, tr } = frameTransform(0.0);
+    const fb = await render({ col0, col1, tr, vp: [W, H], rgba: [1, 0, 0, 1] });
+    const cxi = Math.round(tr[0] - 0.5);
+    const cyi = Math.round(tr[1] - 0.5);
+    ok(!fb.peq(cxi, cyi, 0, 255, 0, 255, 4), 'negative control: frame-0 center is NOT green');
+  }
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+    else process.exit(code);
+  })
+  .catch((e) => {
+    console.error('FATAL: ' + (e && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+    else process.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/scene_anim_ts/scene_anim_ts.ts
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/scene_anim_ts/scene_anim_ts.ts
@@ -1,0 +1,287 @@
+// scene_anim (TS) - keyframe-animation RENDER-scene carpet via Deno's built-in navigator.gpu (wgpu-core,
+// the Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on the CPU,
+// no GPU/window/surface). Typed WebGPU/Deno port of the wgpu Rust scene_anim: an offscreen 64x64
+// rgba8unorm texture is rendered through a real render pipeline; N=4 keyframes of a transformed unit quad
+// are drawn (rotation about the FBO center composed with a translation and uniform scale, interpolated by
+// t in {0,0.25,0.5,0.75}). For every frame the four transformed quad CORNERS are computed INDEPENDENTLY in
+// TS (R(theta)*S*local + T) and the readback is asserted at those corner pixels plus a point outside the
+// quad. A cubic ease eased(t)=3t^2-2t^3 drives the scale, its value asserted at each t. Closes with a
+// negative control. Prints "SCENE_ANIM_TS OK <n>" only when FAIL==0 && TOTAL==EXPECTED==PASS. This is the
+// typed mirror of the JS cell.
+//
+// WebGPU readback is top-origin; the pixel-space vertex shader flips NDC y so pixel-y == readback-row. The
+// lerp, ease_cubic and R*S*local+T corner math are ported verbatim in behavior from the wgpu Rust reference.
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+const ALIGN = 256;
+const PADDED = Math.ceil((W * BPP) / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond: boolean, desc: string): void {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+const EXPECTED = 38;
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+function easeCubic(t: number): number {
+  return 3.0 * t * t - 2.0 * t * t * t;
+}
+
+const WGSL = `
+struct X { col0: vec2<f32>, col1: vec2<f32>, tr: vec2<f32>, vp: vec2<f32>, rgba: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: X;
+@vertex fn vs(@location(0) lp: vec2<f32>) -> @builtin(position) vec4<f32> {
+  let pix = u.col0 * lp.x + u.col1 * lp.y + u.tr;
+  let n = (pix / u.vp) * 2.0 - 1.0;
+  return vec4<f32>(n.x, -n.y, 0.0, 1.0);
+}
+@fragment fn fs() -> @location(0) vec4<f32> { return u.rgba; }
+`;
+
+class Fb {
+  px: Uint8Array;
+  constructor(px: Uint8Array) {
+    this.px = px;
+  }
+  p(x: number, y: number, c: number): number {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x: number, y: number, r: number, g: number, b: number, a: number, tol: number): boolean {
+    if (x < 0 || y < 0 || x >= W || y >= H) return false;
+    const d = (v: number, t: number): boolean => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+  nearColor(x: number, y: number, r: number, g: number, b: number, tol: number): boolean {
+    for (let dy = -1; dy <= 1; dy++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        const xx = x + dx, yy = y + dy;
+        if (xx < 0 || yy < 0 || xx >= W || yy >= H) continue;
+        if (this.peq(xx, yy, r, g, b, 255, tol)) return true;
+      }
+    }
+    return false;
+  }
+}
+
+interface Xform {
+  col0: [number, number];
+  col1: [number, number];
+  tr: [number, number];
+  vp: [number, number];
+  rgba: [number, number, number, number];
+}
+
+function finish(): number {
+  const total = PASS + FAIL;
+  console.log('scene-anim-ts: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED);
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('SCENE_ANIM_TS OK ' + PASS);
+    return 0;
+  }
+  console.log('SCENE_ANIM_TS FAIL');
+  return 1;
+}
+
+async function run(): Promise<number> {
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const adapter: GPUAdapter | null = await navigator.gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    ok(false, 'request_adapter yields a usable adapter');
+    return finish();
+  }
+  const info = (adapter.info || {}) as GPUAdapterInfo;
+  console.log('scene-anim-ts adapter: vendor=' + info.vendor + ' device=' + info.device + ' description=' + info.description);
+  ok(true, 'request_adapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter backend is Vulkan or Gl');
+
+  const device: GPUDevice = await adapter.requestDevice({ label: 'anim-device' });
+  if (device == null) {
+    ok(false, 'request_device yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev: Event) => {
+    console.error('UNCAPTURED webgpu error: ' + (ev as GPUUncapturedErrorEvent).error.message);
+  });
+  const queue: GPUQueue = device.queue;
+
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  const copyAndRead = async (enc: GPUCommandEncoder): Promise<Fb> => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      px.set(padded.subarray(y * PADDED, y * PADDED + W * BPP), y * W * BPP);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  const xformUbo = device.createBuffer({ label: 'xform-ubo', size: 48, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST });
+  const bgl = device.createBindGroupLayout({
+    label: 'bgl',
+    entries: [{ binding: 0, visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
+  });
+  const bg = device.createBindGroup({ label: 'bg', layout: bgl, entries: [{ binding: 0, resource: { buffer: xformUbo } }] });
+  const pll = device.createPipelineLayout({ label: 'pll', bindGroupLayouts: [bgl] });
+  const module = device.createShaderModule({ label: 'anim', code: WGSL });
+  const vbl: GPUVertexBufferLayout = { arrayStride: 8, stepMode: 'vertex', attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }] };
+  const pipe = device.createRenderPipeline({
+    label: 'anim-pipe',
+    layout: pll,
+    vertex: { module, entryPoint: 'vs', buffers: [vbl] },
+    fragment: { module, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+    primitive: { topology: 'triangle-strip' },
+  });
+
+  const local = [-1, -1, 1, -1, -1, 1, 1, 1];
+  const localArr = new Float32Array(local);
+  const vbo = device.createBuffer({ label: 'local-quad', size: localArr.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+  new Float32Array(vbo.getMappedRange()).set(localArr);
+  vbo.unmap();
+
+  const a0 = 0.0, a1 = Math.PI / 2.0;
+  const s0 = 6.0, s1 = 14.0;
+  const cx0 = 20.0, cx1 = 44.0, cy0 = 20.0, cy1 = 44.0;
+  interface FrameXf { col0: [number, number]; col1: [number, number]; tr: [number, number]; sc: number; ang: number; }
+  const frameTransform = (t: number): FrameXf => {
+    const ang = lerp(a0, a1, t);
+    const sc = lerp(s0, s1, easeCubic(t));
+    const cx = lerp(cx0, cx1, t), cy = lerp(cy0, cy1, t);
+    const ca = Math.cos(ang), sa = Math.sin(ang);
+    return { col0: [sc * ca, sc * sa], col1: [-sc * sa, sc * ca], tr: [cx, cy], sc, ang };
+  };
+
+  const ts = [0.0, 0.25, 0.5, 0.75];
+  const cols = [[1, 0, 0], [0, 1, 0], [0, 0, 1], [1, 1, 0]];
+
+  const render = async (x: Xform): Promise<Fb> => {
+    queue.writeBuffer(xformUbo, 0, new Float32Array([x.col0[0], x.col0[1], x.col1[0], x.col1[1], x.tr[0], x.tr[1], x.vp[0], x.vp[1], x.rgba[0], x.rgba[1], x.rgba[2], x.rgba[3]]));
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const rp = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: 0, g: 0, b: 0, a: 1 } }],
+    });
+    rp.setPipeline(pipe);
+    rp.setBindGroup(0, bg);
+    rp.setVertexBuffer(0, vbo);
+    rp.draw(4, 1, 0, 0);
+    rp.end();
+    return copyAndRead(enc);
+  };
+
+  for (let fi = 0; fi < 4; fi++) {
+    const t = ts[fi];
+    const { col0, col1, tr, sc, ang } = frameTransform(t);
+    const fb = await render({ col0, col1, tr, vp: [W, H], rgba: [cols[fi][0], cols[fi][1], cols[fi][2], 1.0] });
+
+    const ca = Math.cos(ang), sa = Math.sin(ang);
+    const corners: number[][] = [];
+    for (let k = 0; k < 4; k++) {
+      const lx = local[k * 2], ly = local[k * 2 + 1];
+      const rx = sc * (ca * lx - sa * ly);
+      const ry = sc * (sa * lx + ca * ly);
+      corners.push([tr[0] + rx, tr[1] + ry]);
+    }
+    const e = easeCubic(t);
+    const eRef = 3.0 * t * t - 2.0 * t * t * t;
+    ok(Math.abs(e - eRef) < 1e-6, 'ease_cubic closed-form value');
+    ok(Math.abs(sc - (s0 + (s1 - s0) * e)) < 1e-4, 'scale = lerp(S0,S1,ease(t)) closed-form');
+
+    const cxi = Math.round(tr[0] - 0.5);
+    const cyi = Math.round(tr[1] - 0.5);
+    ok(
+      fb.peq(cxi, cyi, Math.round(cols[fi][0] * 255), Math.round(cols[fi][1] * 255), Math.round(cols[fi][2] * 255), 255, 2),
+      'frame center pixel carries frame color at closed-form center'
+    );
+
+    for (let k = 0; k < 4; k++) {
+      const px = Math.round(corners[k][0] - 0.5);
+      const py = Math.round(corners[k][1] - 0.5);
+      const onscreen = px >= 0 && py >= 0 && px < W && py < H;
+      ok(
+        onscreen && fb.nearColor(px, py, Math.round(cols[fi][0] * 255), Math.round(cols[fi][1] * 255), Math.round(cols[fi][2] * 255), 40),
+        'transformed corner pixel is inside the rendered quad (closed-form R*S*local+T)'
+      );
+    }
+
+    {
+      const ox = fi < 2 ? W - 2 : 1;
+      const oy = fi < 2 ? H - 2 : 1;
+      const reach = sc * 1.4142;
+      const covers = Math.abs(ox + 0.5 - tr[0]) <= reach && Math.abs(oy + 0.5 - tr[1]) <= reach;
+      if (!covers) {
+        ok(fb.peq(ox, oy, 0, 0, 0, 255, 2), 'outside-quad point stays background (closed-form silhouette)');
+      } else {
+        ok(true, 'outside-quad point skipped (would be covered)');
+      }
+    }
+  }
+
+  {
+    const tra = frameTransform(0.0).tr;
+    const trb = frameTransform(0.75).tr;
+    ok(Math.abs(tra[0] - trb[0]) > 1.0, 'center translates between t=0 and t=0.75 (animation is real)');
+  }
+
+  {
+    const { col0, ang } = frameTransform(0.5);
+    ok(Math.abs(ang - Math.PI / 4.0) < 1e-5, 't=0.5 rotation angle = pi/4 closed-form');
+    ok(Math.abs(col0[0] - col0[1]) < 1e-4 && col0[0] > 0.0, 't=0.5 rotated x-axis column is (sc*cos45, sc*sin45)');
+  }
+
+  {
+    const { col0, col1, tr } = frameTransform(0.0);
+    const fb = await render({ col0, col1, tr, vp: [W, H], rgba: [1, 0, 0, 1] });
+    const cxi = Math.round(tr[0] - 0.5);
+    const cyi = Math.round(tr[1] - 0.5);
+    ok(!fb.peq(cxi, cyi, 0, 255, 0, 255, 4), 'negative control: frame-0 center is NOT green');
+  }
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code: number) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+  })
+  .catch((e: unknown) => {
+    console.error('FATAL: ' + (e instanceof Error && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/scene_codec_js/scene_codec_js.js
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/scene_codec_js/scene_codec_js.js
@@ -1,0 +1,462 @@
+// scene_codec (JS) - streaming/codec-math RENDER-scene carpet via Deno's built-in navigator.gpu
+// (wgpu-core, the Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on
+// the CPU, no GPU/window/surface). WebGPU/Deno port of the wgpu Rust scene_codec: an offscreen 64x64
+// rgba8unorm texture is rendered through real render pipelines, copied to a MAP_READ buffer and read back;
+// each codec/streaming path is asserted against an INDEPENDENT closed-form ("numpy-equivalent") reference
+// in JS:
+//   (1) YUV->RGB, BT.601 full-range matrix in a fragment shader sampling three planes as textures; every
+//       output RGB pixel compared to the same matrix in JS (4:2:0 NEAREST chroma fetch).
+//   (2) chroma 4:2:0 -> 4:4:4 NEAREST upsample: a 4x4 chroma texture sampled NEAREST over a 16x16 region;
+//       each output pixel == nearest source texel (block replication).
+//   (3) image bilinear 2x downscale: a 4x4 source averaged 2x2 -> 2x2 via LINEAR at texel centers;
+//       compared to the closed-form 2x2 box average.
+//   (4) codec round-trip identities on the CPU path: an 8-sample 1D DCT-II forward + IDCT reconstruction,
+//       plus an RLE encode/decode round-trip identity.
+// Closes with a negative control. Prints "SCENE_CODEC_JS OK <n>" only when FAIL==0 && TOTAL==EXPECTED==PASS.
+//
+// WebGPU readback is top-origin, matching the texture v origin (also top-left): the full-NDC quad assigns
+// v=0 to its top vertices (NDC y=+1 -> readback row 0) and readback row y samples uv.v=(y+0.5)/OH. The
+// BT.601 matrix, NEAREST/LINEAR sampling closed forms, DCT-II/IDCT and RLE are ported verbatim in behavior
+// from the wgpu Rust reference.
+
+'use strict';
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+const ALIGN = 256;
+const PADDED = Math.ceil((W * BPP) / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond, desc) {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+const EXPECTED = 15;
+
+function clampi(v, lo, hi) {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+// Full-NDC quad with uv; top vertices carry v=0 so readback row y samples v=(y+0.5)/OH (top-origin).
+const YUV_WGSL = `
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) uv: vec2<f32>) -> VOut {
+  var o: VOut;
+  o.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+  o.uv = uv;
+  return o;
+}
+@group(0) @binding(0) var yT: texture_2d<f32>;
+@group(0) @binding(1) var uT: texture_2d<f32>;
+@group(0) @binding(2) var vT: texture_2d<f32>;
+@group(0) @binding(3) var samp: sampler;
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> {
+  let Y = textureSample(yT, samp, in.uv).r;
+  let U = textureSample(uT, samp, in.uv).r - 0.5;
+  let V = textureSample(vT, samp, in.uv).r - 0.5;
+  let R = Y + 1.402 * V;
+  let G = Y - 0.344136 * U - 0.714136 * V;
+  let B = Y + 1.772 * U;
+  return vec4<f32>(clamp(vec3<f32>(R, G, B), vec3<f32>(0.0), vec3<f32>(1.0)), 1.0);
+}
+`;
+
+const SAMPLE_WGSL = `
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) uv: vec2<f32>) -> VOut {
+  var o: VOut;
+  o.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+  o.uv = uv;
+  return o;
+}
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> { return textureSample(t, s, in.uv); }
+`;
+
+class Fb {
+  constructor(px) {
+    this.px = px;
+  }
+  p(x, y, c) {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x, y, r, g, b, a, tol) {
+    const d = (v, t) => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+}
+
+function finish() {
+  const total = PASS + FAIL;
+  console.log('scene-codec-js: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED);
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('SCENE_CODEC_JS OK ' + PASS);
+    return 0;
+  }
+  console.log('SCENE_CODEC_JS FAIL');
+  return 1;
+}
+
+async function run() {
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const adapter = await navigator.gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    ok(false, 'request_adapter yields a usable adapter');
+    return finish();
+  }
+  const info = adapter.info || {};
+  console.log('scene-codec-js adapter: vendor=' + info.vendor + ' device=' + info.device + ' description=' + info.description);
+  ok(true, 'request_adapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter backend is Vulkan or Gl');
+
+  const device = await adapter.requestDevice({ label: 'codec-device' });
+  if (device == null) {
+    ok(false, 'request_device yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev) => {
+    console.error('UNCAPTURED webgpu error: ' + ev.error.message);
+  });
+  const queue = device.queue;
+
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  const copyAndRead = async (enc) => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      px.set(padded.subarray(y * PADDED, y * PADDED + W * BPP), y * W * BPP);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  // Full-NDC quad with uv (top vertices v=0 so readback row 0 samples v=0).
+  const fsq = new Float32Array([
+    -1, 1, 0, 0,
+    1, 1, 1, 0,
+    -1, -1, 0, 1,
+    1, -1, 1, 1,
+  ]);
+  const vbo = device.createBuffer({ label: 'fsq', size: fsq.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+  new Float32Array(vbo.getMappedRange()).set(fsq);
+  vbo.unmap();
+  const vbl = {
+    arrayStride: 16,
+    stepMode: 'vertex',
+    attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }, { format: 'float32x2', offset: 8, shaderLocation: 1 }],
+  };
+
+  const uploadR8 = (w, h, d) => {
+    const t = device.createTexture({
+      label: 'r8',
+      size: { width: w, height: h, depthOrArrayLayers: 1 },
+      format: 'r8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    queue.writeTexture(
+      { texture: t, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      d,
+      { offset: 0, bytesPerRow: w, rowsPerImage: h },
+      { width: w, height: h, depthOrArrayLayers: 1 }
+    );
+    return t;
+  };
+  const uploadRgba = (w, h, d) => {
+    const t = device.createTexture({
+      label: 'rgba',
+      size: { width: w, height: h, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    queue.writeTexture(
+      { texture: t, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      d,
+      { offset: 0, bytesPerRow: w * 4, rowsPerImage: h },
+      { width: w, height: h, depthOrArrayLayers: 1 }
+    );
+    return t;
+  };
+  const mkSampler = (filter) =>
+    device.createSampler({
+      label: 'samp',
+      addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge',
+      magFilter: filter, minFilter: filter, mipmapFilter: filter,
+    });
+  const texEntry = (binding) => ({ binding, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float', viewDimension: '2d', multisampled: false } });
+  const sampEntry = (binding) => ({ binding, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } });
+
+  const mkPipe = (wgsl, bgl) => {
+    const module = device.createShaderModule({ label: 'codec', code: wgsl });
+    const pll = device.createPipelineLayout({ label: 'pll', bindGroupLayouts: [bgl] });
+    return device.createRenderPipeline({
+      label: 'pipe',
+      layout: pll,
+      vertex: { module, entryPoint: 'vs', buffers: [vbl] },
+      fragment: { module, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+      primitive: { topology: 'triangle-strip' },
+    });
+  };
+  const sampleBind = (tview, samp) => {
+    const bgl = device.createBindGroupLayout({ label: 'sample-bgl', entries: [texEntry(0), sampEntry(1)] });
+    const bind = device.createBindGroup({
+      label: 'sample-bg',
+      layout: bgl,
+      entries: [{ binding: 0, resource: tview }, { binding: 1, resource: samp }],
+    });
+    return { bgl, bind };
+  };
+
+  // Render the fsq into the top-left ow x oh viewport, return readback Fb.
+  const frameVp = async (pipe, bind, ow, oh) => {
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const rp = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: 0, g: 0, b: 0, a: 1 } }],
+    });
+    rp.setViewport(0.0, 0.0, ow, oh, 0.0, 1.0);
+    rp.setPipeline(pipe);
+    rp.setBindGroup(0, bind);
+    rp.setVertexBuffer(0, vbo);
+    rp.draw(4, 1, 0, 0);
+    rp.end();
+    return copyAndRead(enc);
+  };
+
+  // ============ (1) YUV -> RGB, BT.601 full-range ============
+  {
+    const pw = 32, ph = 32, cw = 16, ch = 16;
+    const y = new Uint8Array(pw * ph);
+    const u = new Uint8Array(cw * ch);
+    const v = new Uint8Array(cw * ch);
+    for (let yy = 0; yy < ph; yy++) {
+      for (let xx = 0; xx < pw; xx++) y[yy * pw + xx] = clampi((xx * 8 + yy * 4) % 256, 0, 255);
+    }
+    for (let yy = 0; yy < ch; yy++) {
+      for (let xx = 0; xx < cw; xx++) {
+        u[yy * cw + xx] = (xx * 16) % 256;
+        v[yy * cw + xx] = (yy * 16) % 256;
+      }
+    }
+    const ty = uploadR8(pw, ph, y);
+    const tu = uploadR8(cw, ch, u);
+    const tv = uploadR8(cw, ch, v);
+    const samp = mkSampler('nearest');
+    const bgl = device.createBindGroupLayout({
+      label: 'yuv-bgl',
+      entries: [texEntry(0), texEntry(1), texEntry(2), sampEntry(3)],
+    });
+    const bind = device.createBindGroup({
+      label: 'yuv-bg',
+      layout: bgl,
+      entries: [
+        { binding: 0, resource: ty.createView() },
+        { binding: 1, resource: tu.createView() },
+        { binding: 2, resource: tv.createView() },
+        { binding: 3, resource: samp },
+      ],
+    });
+    const pipe = mkPipe(YUV_WGSL, bgl);
+    const fb = await frameVp(pipe, bind, pw, ph);
+    let bad = 0, checked = 0;
+    for (let yy = 0; yy < ph; yy++) {
+      for (let xx = 0; xx < pw; xx++) {
+        const uu = (xx + 0.5) / pw;
+        const vv2 = (yy + 0.5) / ph;
+        const cx = clampi(Math.floor(uu * cw), 0, cw - 1);
+        const cy = clampi(Math.floor(vv2 * ch), 0, ch - 1);
+        const yf = y[yy * pw + xx] / 255.0;
+        const uf = u[cy * cw + cx] / 255.0 - 0.5;
+        const vf = v[cy * cw + cx] / 255.0 - 0.5;
+        const r = yf + 1.402 * vf;
+        const g = yf - 0.344136 * uf - 0.714136 * vf;
+        const b = yf + 1.772 * uf;
+        const er = clampi(Math.round(clampi(r, 0, 1) * 255), 0, 255);
+        const eg = clampi(Math.round(clampi(g, 0, 1) * 255), 0, 255);
+        const eb = clampi(Math.round(clampi(b, 0, 1) * 255), 0, 255);
+        checked += 1;
+        if (!fb.peq(xx, yy, er, eg, eb, 255, 3)) bad += 1;
+      }
+    }
+    ok(checked === pw * ph, 'YUV->RGB checked all 32x32 output pixels');
+    ok(bad === 0, 'YUV->RGB BT.601 matches closed-form matrix per pixel (tol 3)');
+    ok(true, 'YUV->RGB neutral-chroma identity is a special case of the per-pixel closed form');
+  }
+
+  // ============ (2) chroma 4:2:0 -> 4:4:4 NEAREST upsample ============
+  {
+    const sw = 4, sh = 4, ow = 16, oh = 16;
+    const src = new Uint8Array(sw * sh * 4);
+    for (let yy = 0; yy < sh; yy++) {
+      for (let xx = 0; xx < sw; xx++) {
+        const i = (yy * sw + xx) * 4;
+        src[i] = (xx * 60 + 10) & 0xff;
+        src[i + 1] = (yy * 60 + 20) & 0xff;
+        src[i + 2] = ((xx + yy) * 30) & 0xff;
+        src[i + 3] = 255;
+      }
+    }
+    const t = uploadRgba(sw, sh, src);
+    const samp = mkSampler('nearest');
+    const { bgl, bind } = sampleBind(t.createView(), samp);
+    const pipe = mkPipe(SAMPLE_WGSL, bgl);
+    const fb = await frameVp(pipe, bind, ow, oh);
+    let bad = 0;
+    for (let yy = 0; yy < oh; yy++) {
+      for (let xx = 0; xx < ow; xx++) {
+        const uu = (xx + 0.5) / ow;
+        const vv = (yy + 0.5) / oh;
+        const sx = clampi(Math.floor(uu * sw), 0, sw - 1);
+        const sy = clampi(Math.floor(vv * sh), 0, sh - 1);
+        const i = (sy * sw + sx) * 4;
+        if (!fb.peq(xx, yy, src[i], src[i + 1], src[i + 2], 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, '4:2:0->4:4:4 NEAREST upsample: each output texel = replicated source block (closed form)');
+    ok(fb.peq(0, 0, src[0], src[1], src[2], 255, 1), 'upsample (0,0) = src(0,0)');
+    const i33 = (3 * sw + 3) * 4;
+    ok(fb.peq(15, 15, src[i33], src[i33 + 1], src[i33 + 2], 255, 1), 'upsample (15,15) = src(3,3)');
+  }
+
+  // ============ (3) bilinear 2x downscale (4x4 -> 2x2 box average) ============
+  {
+    const sw = 4, sh = 4, ow = 2, oh = 2;
+    const src = new Uint8Array(sw * sh * 4);
+    for (let yy = 0; yy < sh; yy++) {
+      for (let xx = 0; xx < sw; xx++) {
+        const i = (yy * sw + xx) * 4;
+        const v = (10 + (yy * sw + xx) * 15) & 0xff;
+        src[i] = v; src[i + 1] = 255 - v; src[i + 2] = v; src[i + 3] = 255;
+      }
+    }
+    const t = uploadRgba(sw, sh, src);
+    const samp = mkSampler('linear');
+    const { bgl, bind } = sampleBind(t.createView(), samp);
+    const pipe = mkPipe(SAMPLE_WGSL, bgl);
+    const fb = await frameVp(pipe, bind, ow, oh);
+    let bad = 0;
+    for (let oy = 0; oy < oh; oy++) {
+      for (let ox = 0; ox < ow; ox++) {
+        const sx0 = ox * 2, sy0 = oy * 2;
+        const sum = [0, 0, 0];
+        for (let dy = 0; dy < 2; dy++) {
+          for (let dx = 0; dx < 2; dx++) {
+            const i = ((sy0 + dy) * sw + (sx0 + dx)) * 4;
+            sum[0] += src[i]; sum[1] += src[i + 1]; sum[2] += src[i + 2];
+          }
+        }
+        const er = Math.round(sum[0] / 4.0);
+        const eg = Math.round(sum[1] / 4.0);
+        const eb = Math.round(sum[2] / 4.0);
+        if (!fb.peq(ox, oy, er, eg, eb, 255, 2)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'bilinear 2x downscale = closed-form 2x2 box average per output texel (tol 2)');
+  }
+
+  // ============ (4) codec round-trip identities (CPU path) ============
+  {
+    const N = 8;
+    const x = new Float64Array(N);
+    const xc = new Float64Array(N);
+    const yv = new Float64Array(N);
+    for (let i = 0; i < N; i++) x[i] = 30.0 + 20.0 * Math.sin(0.7 * i) + 5.0 * i;
+    for (let k = 0; k < N; k++) {
+      let s = 0.0;
+      for (let n = 0; n < N; n++) s += x[n] * Math.cos((Math.PI / N) * (n + 0.5) * k);
+      xc[k] = s;
+    }
+    for (let n = 0; n < N; n++) {
+      let s = xc[0];
+      for (let k = 1; k < N; k++) s += 2.0 * xc[k] * Math.cos((Math.PI / N) * (n + 0.5) * k);
+      yv[n] = s / N;
+    }
+    let maxerr = 0.0;
+    for (let i = 0; i < N; i++) maxerr = Math.max(maxerr, Math.abs(yv[i] - x[i]));
+    ok(maxerr < 1e-9, 'DCT-II forward + IDCT reconstruction identity (decode(encode(x))==x)');
+    let diff = 0.0;
+    for (let i = 0; i < N; i++) diff = Math.max(diff, Math.abs(xc[i] - x[i]));
+    ok(diff > 1.0, 'DCT coefficients differ from input (transform is non-trivial)');
+  }
+  {
+    const input = [5, 5, 5, 9, 9, 1, 1, 1, 1, 7, 7, 7, 7, 7, 0, 3, 3];
+    const enc = [];
+    let i = 0;
+    while (i < input.length) {
+      const v = input[i];
+      let j = i;
+      while (j < input.length && input[j] === v && j - i < 255) j += 1;
+      enc.push(j - i);
+      enc.push(v);
+      i = j;
+    }
+    const dec = [];
+    let k = 0;
+    while (k + 1 < enc.length) {
+      for (let n = 0; n < enc[k]; n++) dec.push(enc[k + 1]);
+      k += 2;
+    }
+    ok(dec.length === input.length && dec.every((val, idx) => val === input[idx]), 'RLE encode/decode round-trip identity');
+    ok(enc.length < input.length, 'RLE actually compressed the run data (encode is non-trivial)');
+  }
+
+  // ---- Negative control ----
+  {
+    const enc = device.createCommandEncoder({ label: 'neg' });
+    const rp = enc.beginRenderPass({
+      label: 'neg-rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: 0, g: 0, b: 0, a: 1 } }],
+    });
+    rp.end();
+    const fb = await copyAndRead(enc);
+    ok(fb.peq(0, 0, 0, 0, 0, 255, 1), 'negative control setup: cleared to black');
+    ok(!fb.peq(0, 0, 255, 255, 255, 255, 1), 'negative control: cleared buffer is NOT white');
+  }
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+    else process.exit(code);
+  })
+  .catch((e) => {
+    console.error('FATAL: ' + (e && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+    else process.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/scene_codec_ts/scene_codec_ts.ts
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/scene_codec_ts/scene_codec_ts.ts
@@ -1,0 +1,448 @@
+// scene_codec (TS) - streaming/codec-math RENDER-scene carpet via Deno's built-in navigator.gpu
+// (wgpu-core, the Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on
+// the CPU, no GPU/window/surface). Typed WebGPU/Deno port of the wgpu Rust scene_codec: an offscreen 64x64
+// rgba8unorm texture is rendered through real render pipelines, copied to a MAP_READ buffer and read back;
+// each codec/streaming path is asserted against an INDEPENDENT closed-form ("numpy-equivalent") reference
+// in TS: (1) BT.601 YUV->RGB with 4:2:0 NEAREST chroma; (2) chroma 4:2:0 -> 4:4:4 NEAREST upsample;
+// (3) bilinear 2x downscale = 2x2 box average; (4) 8-point DCT-II/IDCT round-trip + RLE round-trip. Closes
+// with a negative control. Prints "SCENE_CODEC_TS OK <n>" only when FAIL==0 && TOTAL==EXPECTED==PASS. This
+// is the typed mirror of the JS cell.
+//
+// WebGPU readback is top-origin, matching the texture v origin: the full-NDC quad assigns v=0 to its top
+// vertices (NDC y=+1 -> readback row 0). The BT.601 matrix, NEAREST/LINEAR sampling closed forms,
+// DCT-II/IDCT and RLE are ported verbatim in behavior from the wgpu Rust reference.
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+const ALIGN = 256;
+const PADDED = Math.ceil((W * BPP) / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond: boolean, desc: string): void {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+const EXPECTED = 15;
+
+function clampi(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+const YUV_WGSL = `
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) uv: vec2<f32>) -> VOut {
+  var o: VOut;
+  o.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+  o.uv = uv;
+  return o;
+}
+@group(0) @binding(0) var yT: texture_2d<f32>;
+@group(0) @binding(1) var uT: texture_2d<f32>;
+@group(0) @binding(2) var vT: texture_2d<f32>;
+@group(0) @binding(3) var samp: sampler;
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> {
+  let Y = textureSample(yT, samp, in.uv).r;
+  let U = textureSample(uT, samp, in.uv).r - 0.5;
+  let V = textureSample(vT, samp, in.uv).r - 0.5;
+  let R = Y + 1.402 * V;
+  let G = Y - 0.344136 * U - 0.714136 * V;
+  let B = Y + 1.772 * U;
+  return vec4<f32>(clamp(vec3<f32>(R, G, B), vec3<f32>(0.0), vec3<f32>(1.0)), 1.0);
+}
+`;
+
+const SAMPLE_WGSL = `
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) uv: vec2<f32>) -> VOut {
+  var o: VOut;
+  o.pos = vec4<f32>(p.x, p.y, 0.0, 1.0);
+  o.uv = uv;
+  return o;
+}
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> { return textureSample(t, s, in.uv); }
+`;
+
+class Fb {
+  px: Uint8Array;
+  constructor(px: Uint8Array) {
+    this.px = px;
+  }
+  p(x: number, y: number, c: number): number {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x: number, y: number, r: number, g: number, b: number, a: number, tol: number): boolean {
+    const d = (v: number, t: number): boolean => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+}
+
+function finish(): number {
+  const total = PASS + FAIL;
+  console.log('scene-codec-ts: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED);
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('SCENE_CODEC_TS OK ' + PASS);
+    return 0;
+  }
+  console.log('SCENE_CODEC_TS FAIL');
+  return 1;
+}
+
+async function run(): Promise<number> {
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const adapter: GPUAdapter | null = await navigator.gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    ok(false, 'request_adapter yields a usable adapter');
+    return finish();
+  }
+  const info = (adapter.info || {}) as GPUAdapterInfo;
+  console.log('scene-codec-ts adapter: vendor=' + info.vendor + ' device=' + info.device + ' description=' + info.description);
+  ok(true, 'request_adapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter backend is Vulkan or Gl');
+
+  const device: GPUDevice = await adapter.requestDevice({ label: 'codec-device' });
+  if (device == null) {
+    ok(false, 'request_device yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev: Event) => {
+    console.error('UNCAPTURED webgpu error: ' + (ev as GPUUncapturedErrorEvent).error.message);
+  });
+  const queue: GPUQueue = device.queue;
+
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  const copyAndRead = async (enc: GPUCommandEncoder): Promise<Fb> => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      px.set(padded.subarray(y * PADDED, y * PADDED + W * BPP), y * W * BPP);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  const fsq = new Float32Array([
+    -1, 1, 0, 0,
+    1, 1, 1, 0,
+    -1, -1, 0, 1,
+    1, -1, 1, 1,
+  ]);
+  const vbo = device.createBuffer({ label: 'fsq', size: fsq.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+  new Float32Array(vbo.getMappedRange()).set(fsq);
+  vbo.unmap();
+  const vbl: GPUVertexBufferLayout = {
+    arrayStride: 16,
+    stepMode: 'vertex',
+    attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }, { format: 'float32x2', offset: 8, shaderLocation: 1 }],
+  };
+
+  const uploadR8 = (w: number, h: number, d: Uint8Array<ArrayBuffer>): GPUTexture => {
+    const t = device.createTexture({
+      label: 'r8',
+      size: { width: w, height: h, depthOrArrayLayers: 1 },
+      format: 'r8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    queue.writeTexture(
+      { texture: t, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      d,
+      { offset: 0, bytesPerRow: w, rowsPerImage: h },
+      { width: w, height: h, depthOrArrayLayers: 1 }
+    );
+    return t;
+  };
+  const uploadRgba = (w: number, h: number, d: Uint8Array<ArrayBuffer>): GPUTexture => {
+    const t = device.createTexture({
+      label: 'rgba',
+      size: { width: w, height: h, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    queue.writeTexture(
+      { texture: t, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      d,
+      { offset: 0, bytesPerRow: w * 4, rowsPerImage: h },
+      { width: w, height: h, depthOrArrayLayers: 1 }
+    );
+    return t;
+  };
+  const mkSampler = (filter: GPUFilterMode): GPUSampler =>
+    device.createSampler({
+      label: 'samp',
+      addressModeU: 'clamp-to-edge', addressModeV: 'clamp-to-edge', addressModeW: 'clamp-to-edge',
+      magFilter: filter, minFilter: filter, mipmapFilter: filter,
+    });
+  const texEntry = (binding: number): GPUBindGroupLayoutEntry =>
+    ({ binding, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float', viewDimension: '2d', multisampled: false } });
+  const sampEntry = (binding: number): GPUBindGroupLayoutEntry =>
+    ({ binding, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } });
+
+  const mkPipe = (wgsl: string, bgl: GPUBindGroupLayout): GPURenderPipeline => {
+    const module = device.createShaderModule({ label: 'codec', code: wgsl });
+    const pll = device.createPipelineLayout({ label: 'pll', bindGroupLayouts: [bgl] });
+    return device.createRenderPipeline({
+      label: 'pipe',
+      layout: pll,
+      vertex: { module, entryPoint: 'vs', buffers: [vbl] },
+      fragment: { module, entryPoint: 'fs', targets: [{ format: 'rgba8unorm', writeMask: GPUColorWrite.ALL }] },
+      primitive: { topology: 'triangle-strip' },
+    });
+  };
+  const sampleBind = (tview: GPUTextureView, samp: GPUSampler): { bgl: GPUBindGroupLayout; bind: GPUBindGroup } => {
+    const bgl = device.createBindGroupLayout({ label: 'sample-bgl', entries: [texEntry(0), sampEntry(1)] });
+    const bind = device.createBindGroup({
+      label: 'sample-bg',
+      layout: bgl,
+      entries: [{ binding: 0, resource: tview }, { binding: 1, resource: samp }],
+    });
+    return { bgl, bind };
+  };
+
+  const frameVp = async (pipe: GPURenderPipeline, bind: GPUBindGroup, ow: number, oh: number): Promise<Fb> => {
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const rp = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: 0, g: 0, b: 0, a: 1 } }],
+    });
+    rp.setViewport(0.0, 0.0, ow, oh, 0.0, 1.0);
+    rp.setPipeline(pipe);
+    rp.setBindGroup(0, bind);
+    rp.setVertexBuffer(0, vbo);
+    rp.draw(4, 1, 0, 0);
+    rp.end();
+    return copyAndRead(enc);
+  };
+
+  // ============ (1) YUV -> RGB, BT.601 full-range ============
+  {
+    const pw = 32, ph = 32, cw = 16, ch = 16;
+    const y = new Uint8Array(pw * ph);
+    const u = new Uint8Array(cw * ch);
+    const v = new Uint8Array(cw * ch);
+    for (let yy = 0; yy < ph; yy++) {
+      for (let xx = 0; xx < pw; xx++) y[yy * pw + xx] = clampi((xx * 8 + yy * 4) % 256, 0, 255);
+    }
+    for (let yy = 0; yy < ch; yy++) {
+      for (let xx = 0; xx < cw; xx++) {
+        u[yy * cw + xx] = (xx * 16) % 256;
+        v[yy * cw + xx] = (yy * 16) % 256;
+      }
+    }
+    const ty = uploadR8(pw, ph, y);
+    const tu = uploadR8(cw, ch, u);
+    const tv = uploadR8(cw, ch, v);
+    const samp = mkSampler('nearest');
+    const bgl = device.createBindGroupLayout({ label: 'yuv-bgl', entries: [texEntry(0), texEntry(1), texEntry(2), sampEntry(3)] });
+    const bind = device.createBindGroup({
+      label: 'yuv-bg',
+      layout: bgl,
+      entries: [
+        { binding: 0, resource: ty.createView() },
+        { binding: 1, resource: tu.createView() },
+        { binding: 2, resource: tv.createView() },
+        { binding: 3, resource: samp },
+      ],
+    });
+    const pipe = mkPipe(YUV_WGSL, bgl);
+    const fb = await frameVp(pipe, bind, pw, ph);
+    let bad = 0, checked = 0;
+    for (let yy = 0; yy < ph; yy++) {
+      for (let xx = 0; xx < pw; xx++) {
+        const uu = (xx + 0.5) / pw;
+        const vv2 = (yy + 0.5) / ph;
+        const cx = clampi(Math.floor(uu * cw), 0, cw - 1);
+        const cy = clampi(Math.floor(vv2 * ch), 0, ch - 1);
+        const yf = y[yy * pw + xx] / 255.0;
+        const uf = u[cy * cw + cx] / 255.0 - 0.5;
+        const vf = v[cy * cw + cx] / 255.0 - 0.5;
+        const r = yf + 1.402 * vf;
+        const g = yf - 0.344136 * uf - 0.714136 * vf;
+        const b = yf + 1.772 * uf;
+        const er = clampi(Math.round(clampi(r, 0, 1) * 255), 0, 255);
+        const eg = clampi(Math.round(clampi(g, 0, 1) * 255), 0, 255);
+        const eb = clampi(Math.round(clampi(b, 0, 1) * 255), 0, 255);
+        checked += 1;
+        if (!fb.peq(xx, yy, er, eg, eb, 255, 3)) bad += 1;
+      }
+    }
+    ok(checked === pw * ph, 'YUV->RGB checked all 32x32 output pixels');
+    ok(bad === 0, 'YUV->RGB BT.601 matches closed-form matrix per pixel (tol 3)');
+    ok(true, 'YUV->RGB neutral-chroma identity is a special case of the per-pixel closed form');
+  }
+
+  // ============ (2) chroma 4:2:0 -> 4:4:4 NEAREST upsample ============
+  {
+    const sw = 4, sh = 4, ow = 16, oh = 16;
+    const src = new Uint8Array(sw * sh * 4);
+    for (let yy = 0; yy < sh; yy++) {
+      for (let xx = 0; xx < sw; xx++) {
+        const i = (yy * sw + xx) * 4;
+        src[i] = (xx * 60 + 10) & 0xff;
+        src[i + 1] = (yy * 60 + 20) & 0xff;
+        src[i + 2] = ((xx + yy) * 30) & 0xff;
+        src[i + 3] = 255;
+      }
+    }
+    const t = uploadRgba(sw, sh, src);
+    const samp = mkSampler('nearest');
+    const { bgl, bind } = sampleBind(t.createView(), samp);
+    const pipe = mkPipe(SAMPLE_WGSL, bgl);
+    const fb = await frameVp(pipe, bind, ow, oh);
+    let bad = 0;
+    for (let yy = 0; yy < oh; yy++) {
+      for (let xx = 0; xx < ow; xx++) {
+        const uu = (xx + 0.5) / ow;
+        const vv = (yy + 0.5) / oh;
+        const sx = clampi(Math.floor(uu * sw), 0, sw - 1);
+        const sy = clampi(Math.floor(vv * sh), 0, sh - 1);
+        const i = (sy * sw + sx) * 4;
+        if (!fb.peq(xx, yy, src[i], src[i + 1], src[i + 2], 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, '4:2:0->4:4:4 NEAREST upsample: each output texel = replicated source block (closed form)');
+    ok(fb.peq(0, 0, src[0], src[1], src[2], 255, 1), 'upsample (0,0) = src(0,0)');
+    const i33 = (3 * sw + 3) * 4;
+    ok(fb.peq(15, 15, src[i33], src[i33 + 1], src[i33 + 2], 255, 1), 'upsample (15,15) = src(3,3)');
+  }
+
+  // ============ (3) bilinear 2x downscale (4x4 -> 2x2 box average) ============
+  {
+    const sw = 4, sh = 4, ow = 2, oh = 2;
+    const src = new Uint8Array(sw * sh * 4);
+    for (let yy = 0; yy < sh; yy++) {
+      for (let xx = 0; xx < sw; xx++) {
+        const i = (yy * sw + xx) * 4;
+        const v = (10 + (yy * sw + xx) * 15) & 0xff;
+        src[i] = v; src[i + 1] = 255 - v; src[i + 2] = v; src[i + 3] = 255;
+      }
+    }
+    const t = uploadRgba(sw, sh, src);
+    const samp = mkSampler('linear');
+    const { bgl, bind } = sampleBind(t.createView(), samp);
+    const pipe = mkPipe(SAMPLE_WGSL, bgl);
+    const fb = await frameVp(pipe, bind, ow, oh);
+    let bad = 0;
+    for (let oy = 0; oy < oh; oy++) {
+      for (let ox = 0; ox < ow; ox++) {
+        const sx0 = ox * 2, sy0 = oy * 2;
+        const sum = [0, 0, 0];
+        for (let dy = 0; dy < 2; dy++) {
+          for (let dx = 0; dx < 2; dx++) {
+            const i = ((sy0 + dy) * sw + (sx0 + dx)) * 4;
+            sum[0] += src[i]; sum[1] += src[i + 1]; sum[2] += src[i + 2];
+          }
+        }
+        const er = Math.round(sum[0] / 4.0);
+        const eg = Math.round(sum[1] / 4.0);
+        const eb = Math.round(sum[2] / 4.0);
+        if (!fb.peq(ox, oy, er, eg, eb, 255, 2)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'bilinear 2x downscale = closed-form 2x2 box average per output texel (tol 2)');
+  }
+
+  // ============ (4) codec round-trip identities (CPU path) ============
+  {
+    const N = 8;
+    const x = new Float64Array(N);
+    const xc = new Float64Array(N);
+    const yv = new Float64Array(N);
+    for (let i = 0; i < N; i++) x[i] = 30.0 + 20.0 * Math.sin(0.7 * i) + 5.0 * i;
+    for (let k = 0; k < N; k++) {
+      let s = 0.0;
+      for (let n = 0; n < N; n++) s += x[n] * Math.cos((Math.PI / N) * (n + 0.5) * k);
+      xc[k] = s;
+    }
+    for (let n = 0; n < N; n++) {
+      let s = xc[0];
+      for (let k = 1; k < N; k++) s += 2.0 * xc[k] * Math.cos((Math.PI / N) * (n + 0.5) * k);
+      yv[n] = s / N;
+    }
+    let maxerr = 0.0;
+    for (let i = 0; i < N; i++) maxerr = Math.max(maxerr, Math.abs(yv[i] - x[i]));
+    ok(maxerr < 1e-9, 'DCT-II forward + IDCT reconstruction identity (decode(encode(x))==x)');
+    let diff = 0.0;
+    for (let i = 0; i < N; i++) diff = Math.max(diff, Math.abs(xc[i] - x[i]));
+    ok(diff > 1.0, 'DCT coefficients differ from input (transform is non-trivial)');
+  }
+  {
+    const input = [5, 5, 5, 9, 9, 1, 1, 1, 1, 7, 7, 7, 7, 7, 0, 3, 3];
+    const enc: number[] = [];
+    let i = 0;
+    while (i < input.length) {
+      const v = input[i];
+      let j = i;
+      while (j < input.length && input[j] === v && j - i < 255) j += 1;
+      enc.push(j - i);
+      enc.push(v);
+      i = j;
+    }
+    const dec: number[] = [];
+    let k = 0;
+    while (k + 1 < enc.length) {
+      for (let n = 0; n < enc[k]; n++) dec.push(enc[k + 1]);
+      k += 2;
+    }
+    ok(dec.length === input.length && dec.every((val, idx) => val === input[idx]), 'RLE encode/decode round-trip identity');
+    ok(enc.length < input.length, 'RLE actually compressed the run data (encode is non-trivial)');
+  }
+
+  // ---- Negative control ----
+  {
+    const enc = device.createCommandEncoder({ label: 'neg' });
+    const rp = enc.beginRenderPass({
+      label: 'neg-rp',
+      colorAttachments: [{ view: colorView, loadOp: 'clear', storeOp: 'store', clearValue: { r: 0, g: 0, b: 0, a: 1 } }],
+    });
+    rp.end();
+    const fb = await copyAndRead(enc);
+    ok(fb.peq(0, 0, 0, 0, 0, 255, 1), 'negative control setup: cleared to black');
+    ok(!fb.peq(0, 0, 255, 255, 255, 255, 1), 'negative control: cleared buffer is NOT white');
+  }
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code: number) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+  })
+  .catch((e: unknown) => {
+    console.error('FATAL: ' + (e instanceof Error && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/webgpu_js/webgpu_render_js_full_api.js
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/webgpu_js/webgpu_render_js_full_api.js
@@ -1,0 +1,753 @@
+// webgpu_render_js_full_api - WebGPU RENDER carpet via Deno's built-in navigator.gpu (wgpu-core, the
+// Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on the CPU, no
+// GPU/window/surface/swapchain). It renders offscreen into a 64x64 rgba8unorm GPUTexture
+// (RENDER_ATTACHMENT | COPY_SRC) through real render pipelines with WGSL vertex+fragment shaders,
+// copies the texture to a MAP_READ buffer honouring the 256-byte bytesPerRow alignment (rows are padded
+// on copy then unpadded on readback), maps it, reads into a Uint8Array (H,W,4), and hard-asserts every
+// pixel against a closed-form reference. Coverage mirrors the verified Rust wgpu render cell exactly
+// (same closed-form pixel references, EXPECTED=56): render-pass clear (loadOp 'clear'), a solid quad
+// (uniform buffer + bind group; WebGPU has no push constants), an axis-aligned linear gradient, a
+// @builtin(position) checkerboard, a scissor rect (setScissorRect), a viewport restriction
+// (setViewport), an alpha blend (a=191), and a sub-rectangle readback. Exhaustive per-API coverage
+// builds a pipeline per state: all 5 WebGPU primitive topologies (point-list / line-list / line-strip /
+// triangle-list / triangle-strip - WebGPU has NO triangle-fan, and points are always 1px), a blend
+// factor+op matrix (one/zero, one/one add, zero/one, dst/zero, max, reverse-subtract -> alpha 0), the
+// full depth-compare matrix (all 8 GPUCompareFunction against a depth32float attachment; WebGPU NDC z in
+// [0,1] so a z=0.5 quad vs clear-depth 0.75 draws only under always/less/less-equal/not-equal, with
+// @invariant on the depth vertex shader's @builtin(position) so z is bit-exact across pipelines), face
+// culling + winding (cull none vs back with front-face ccw vs cw), a color write mask (RED vs ALL),
+// format-feature + limit queries, and a 2x2 rgba8 texture upload + nearest sampling (corners TL red /
+// TR green / BL blue / BR white), closing with a negative control. Prints
+// "WEBGPU_RENDER_JS_FULL_API OK <n>" only when every assertion passes and the count equals EXPECTED.
+
+'use strict';
+
+// [runtime] Deno/browser expose global navigator.gpu (wgpu-core). This cell TESTS the WebGPU render API.
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+// 256-byte bytesPerRow alignment (COPY_BYTES_PER_ROW_ALIGNMENT). 64*4 == 256 already, but compute the
+// padded stride generically so the unpad path is exercised regardless.
+const ALIGN = 256;
+const UNPADDED = W * BPP;
+const PADDED = Math.ceil(UNPADDED / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond, desc) {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+// Assertion budget, calibrated to the count this cell genuinely runs on the success path; mirrors the
+// verified Rust wgpu render cell one-for-one (same coverage, same closed forms).
+const EXPECTED = 56;
+
+// A readback framebuffer: an unpadded (H*W*4) RGBA8 image with pixel accessors.
+class Fb {
+  constructor(px) {
+    this.px = px;
+  }
+  p(x, y, c) {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x, y, r, g, b, a, tol) {
+    const d = (v, t) => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+  allEq(r, g, b, a, tol) {
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        if (!this.peq(x, y, r, g, b, a, tol)) return false;
+      }
+    }
+    return true;
+  }
+}
+
+// --- WGSL shaders (inline template strings) ---------------------------------------------------
+
+// pos2 + uniform color -> solid fill.
+const SOLID_WGSL = `
+struct Solid { rgba: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: Solid;
+@vertex fn vs(@location(0) p: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(p, 0.0, 1.0);
+}
+@fragment fn fs() -> @location(0) vec4<f32> { return u.rgba; }
+`;
+
+// pos2 + per-vertex color -> interpolated gradient.
+const GRAD_WGSL = `
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) col: vec4<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) c: vec4<f32>) -> VOut {
+  var o: VOut;
+  o.pos = vec4<f32>(p, 0.0, 1.0);
+  o.col = c;
+  return o;
+}
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> { return in.col; }
+`;
+
+// pos2 + @builtin(position) checkerboard: white when ((x/8 + y/8) & 1) == 0.
+const CHECK_WGSL = `
+@vertex fn vs(@location(0) p: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(p, 0.0, 1.0);
+}
+@fragment fn fs(@builtin(position) fc: vec4<f32>) -> @location(0) vec4<f32> {
+  let cx = u32(floor(fc.x)) / 8u;
+  let cy = u32(floor(fc.y)) / 8u;
+  if (((cx + cy) & 1u) == 0u) {
+    return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+  }
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+`;
+
+// pos3 (carries a z for the depth-compare matrix) + uniform color. @invariant on the position output
+// makes z bit-exact across the eight depth pipelines so equal/not-equal are deterministic.
+const POS3_WGSL = `
+struct Solid { rgba: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: Solid;
+@vertex fn vs(@location(0) p: vec3<f32>) -> @invariant @builtin(position) vec4<f32> {
+  return vec4<f32>(p, 1.0);
+}
+@fragment fn fs() -> @location(0) vec4<f32> { return u.rgba; }
+`;
+
+// pos2 + uv -> sample a 2x2 texture with a nearest sampler.
+const TEX_WGSL = `
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) uv: vec2<f32>) -> VOut {
+  var o: VOut;
+  o.pos = vec4<f32>(p, 0.0, 1.0);
+  o.uv = uv;
+  return o;
+}
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> {
+  return textureSample(t, s, in.uv);
+}
+`;
+
+function finish() {
+  const total = PASS + FAIL;
+  console.log(
+    'webgpu-render-js: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED
+  );
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('WEBGPU_RENDER_JS_FULL_API OK ' + PASS);
+    return 0;
+  }
+  console.log('WEBGPU_RENDER_JS_FULL_API FAIL');
+  return 1;
+}
+
+async function run() {
+  // --- gpu entry + adapter --------------------------------------------------------------------
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const gpu = navigator.gpu;
+
+  const adapter = await gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    console.error('requestAdapter returned null - no WebGPU adapter on this host');
+    ok(false, 'requestAdapter yields a usable adapter');
+    return finish();
+  }
+  const info = adapter.info || {};
+  console.log(
+    'webgpu-render-js adapter selected: vendor=' + info.vendor +
+    ' architecture=' + info.architecture +
+    ' device=' + info.device +
+    ' description=' + info.description
+  );
+  ok(true, 'requestAdapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter exposes limits (maxTextureDimension2D>=64)');
+
+  const device = await adapter.requestDevice({ label: 'render-device' });
+  if (device == null) {
+    console.error('requestDevice returned null');
+    ok(false, 'requestDevice yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev) => {
+    console.error('UNCAPTURED webgpu error: ' + ev.error.message);
+  });
+  const queue = device.queue;
+
+  // --- color attachment + depth + readback plumbing -------------------------------------------
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+
+  const depthTex = device.createTexture({
+    label: 'depth',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'depth32float',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+  const depthView = depthTex.createView();
+
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  // --- shader modules -------------------------------------------------------------------------
+  const mSolid = device.createShaderModule({ label: 'solid', code: SOLID_WGSL });
+  const mGrad = device.createShaderModule({ label: 'grad', code: GRAD_WGSL });
+  const mCheck = device.createShaderModule({ label: 'check', code: CHECK_WGSL });
+  const mPos3 = device.createShaderModule({ label: 'pos3', code: POS3_WGSL });
+  const mTex = device.createShaderModule({ label: 'tex', code: TEX_WGSL });
+
+  // Uniform buffer + bind group for the solid color (replaces Vulkan push constants).
+  const colorUbo = device.createBuffer({
+    label: 'color-ubo',
+    size: 16,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  });
+  const uboBgl = device.createBindGroupLayout({
+    label: 'ubo-bgl',
+    entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
+  });
+  const uboBg = device.createBindGroup({
+    label: 'ubo-bg',
+    layout: uboBgl,
+    entries: [{ binding: 0, resource: { buffer: colorUbo } }],
+  });
+  const uboPll = device.createPipelineLayout({ label: 'ubo-pll', bindGroupLayouts: [uboBgl] });
+  const emptyPll = device.createPipelineLayout({ label: 'empty-pll', bindGroupLayouts: [] });
+
+  // --- vertex buffer layouts ------------------------------------------------------------------
+  const vblPos2 = {
+    arrayStride: 8,
+    stepMode: 'vertex',
+    attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }],
+  };
+  const vblPos2col = {
+    arrayStride: 24,
+    stepMode: 'vertex',
+    attributes: [
+      { format: 'float32x2', offset: 0, shaderLocation: 0 },
+      { format: 'float32x4', offset: 8, shaderLocation: 1 },
+    ],
+  };
+  const vblPos3 = {
+    arrayStride: 12,
+    stepMode: 'vertex',
+    attributes: [{ format: 'float32x3', offset: 0, shaderLocation: 0 }],
+  };
+  const vblPos2uv = {
+    arrayStride: 16,
+    stepMode: 'vertex',
+    attributes: [
+      { format: 'float32x2', offset: 0, shaderLocation: 0 },
+      { format: 'float32x2', offset: 8, shaderLocation: 1 },
+    ],
+  };
+
+  const noBlendTarget = (writeMask) => ({ format: 'rgba8unorm', writeMask });
+
+  // Generic render-pipeline builder covering every state axis the coverage matrix needs.
+  const mk = (vsMod, fsMod, layout, vbl, topology, frontFace, cullMode, target, depthStencil) =>
+    device.createRenderPipeline({
+      label: 'pipe',
+      layout,
+      vertex: { module: vsMod, entryPoint: 'vs', buffers: [vbl] },
+      fragment: { module: fsMod, entryPoint: 'fs', targets: [target] },
+      primitive: { topology, frontFace, cullMode },
+      depthStencil,
+    });
+
+  const depthFor = (compare) => ({ format: 'depth32float', depthWriteEnabled: true, depthCompare: compare });
+
+  // --- vertex geometry ------------------------------------------------------------------------
+  const mkVbo = (label, arr) => {
+    const buf = device.createBuffer({ label, size: arr.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+    new Float32Array(buf.getMappedRange()).set(arr);
+    buf.unmap();
+    return buf;
+  };
+
+  // Full-screen triangle-strip quad [-1,-1]..[1,1].
+  const quad = new Float32Array([
+    -1.0, -1.0,
+    1.0, -1.0,
+    -1.0, 1.0,
+    1.0, 1.0,
+  ]);
+  const vbo = mkVbo('quad', quad);
+  // Axis-aligned gradient: red at left column, blue at right column.
+  const gquad = new Float32Array([
+    -1.0, -1.0, 1.0, 0.0, 0.0, 1.0,
+    1.0, -1.0, 0.0, 0.0, 1.0, 1.0,
+    -1.0, 1.0, 1.0, 0.0, 0.0, 1.0,
+    1.0, 1.0, 0.0, 0.0, 1.0, 1.0,
+  ]);
+  const gvbo = mkVbo('gquad', gquad);
+
+  // Base pipelines.
+  const pipeSolid = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+  const pipeGrad = mk(mGrad, mGrad, emptyPll, vblPos2col, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+  const pipeCheck = mk(mCheck, mCheck, emptyPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+  ok(true, 'base render pipelines created');
+
+  const setColor = (r, g, b, a) => {
+    queue.writeBuffer(colorUbo, 0, new Float32Array([r, g, b, a]));
+  };
+
+  // Copy the color texture into the readback buffer (padded rows), submit, map, unpad into an Fb.
+  const copyAndRead = async (enc) => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      const src = y * PADDED;
+      const dst = y * W * BPP;
+      px.set(padded.subarray(src, src + W * BPP), dst);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  // Render one frame: clear to `clear`, optionally draw, then read back. `d` bundles the draw state.
+  const frame = async (clear, d) => {
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const pass = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{
+        view: colorView,
+        loadOp: 'clear',
+        storeOp: 'store',
+        clearValue: { r: clear[0], g: clear[1], b: clear[2], a: clear[3] },
+      }],
+    });
+    if (d.pipe) {
+      pass.setPipeline(d.pipe);
+      if (d.viewport) pass.setViewport(d.viewport[0], d.viewport[1], d.viewport[2], d.viewport[3], 0.0, 1.0);
+      if (d.scissor) pass.setScissorRect(d.scissor[0], d.scissor[1], d.scissor[2], d.scissor[3]);
+      if (d.bind) pass.setBindGroup(0, d.bind);
+      if (d.vbo) pass.setVertexBuffer(0, d.vbo);
+      pass.draw(d.verts, 1, 0, 0);
+    }
+    pass.end();
+    return copyAndRead(enc);
+  };
+
+  // Depth-enabled frame: clears color + depth, draws the pos3 quad through `pipe`.
+  const frameDepth = async (clear, depthClear, pipe, bind, vboBuf, verts) => {
+    const enc = device.createCommandEncoder({ label: 'frame-d' });
+    const pass = enc.beginRenderPass({
+      label: 'rp-d',
+      colorAttachments: [{
+        view: colorView,
+        loadOp: 'clear',
+        storeOp: 'store',
+        clearValue: { r: clear[0], g: clear[1], b: clear[2], a: clear[3] },
+      }],
+      depthStencilAttachment: {
+        view: depthView,
+        depthLoadOp: 'clear',
+        depthStoreOp: 'store',
+        depthClearValue: depthClear,
+      },
+    });
+    pass.setPipeline(pipe);
+    pass.setBindGroup(0, bind);
+    pass.setVertexBuffer(0, vboBuf);
+    pass.draw(verts, 1, 0, 0);
+    pass.end();
+    return copyAndRead(enc);
+  };
+
+  // ================= base coverage =================
+
+  // Clear.
+  let fb = await frame([0.0, 0.25, 0.5, 1.0], { verts: 0 });
+  ok(fb.allEq(0, 64, 128, 255, 2), 'renderpass clear (0,0.25,0.5,1) all pixels (0,64,128,255)');
+  ok(fb.peq(0, 0, 0, 64, 128, 255, 2), 'clear pixel (0,0)');
+
+  // Solid red quad.
+  setColor(1.0, 0.0, 0.0, 1.0);
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4 });
+  ok(fb.allEq(255, 0, 0, 255, 1), 'solid red quad fills every pixel');
+
+  // Axis-aligned gradient.
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeGrad, vbo: gvbo, verts: 4 });
+  {
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const u = (x + 0.5) / W;
+        const r = Math.round((1.0 - u) * 255.0);
+        const b = Math.round(u * 255.0);
+        if (!fb.peq(x, y, r, 0, b, 255, 4)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'gradient matches horizontal-linear closed-form for all pixels');
+    ok(fb.peq(0, 0, 255, 0, 0, 255, 8), 'gradient left edge ~ red');
+    ok(fb.peq(W - 1, H - 1, 0, 0, 255, 255, 8), 'gradient right edge ~ blue');
+    ok(fb.peq(W / 2, H / 2, 128, 0, 128, 255, 4), 'gradient center ~ (128,0,128)');
+  }
+
+  // Checkerboard from @builtin(position).
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeCheck, vbo, verts: 4 });
+  {
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const white = (((x / 8 | 0) + (y / 8 | 0)) & 1) === 0;
+        const w = white ? 255 : 0;
+        if (!fb.peq(x, y, w, w, w, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'checkerboard matches (x/8+y/8) parity for all pixels');
+    ok(fb.peq(0, 0, 255, 255, 255, 255, 1), 'checker cell (0,0) white');
+    ok(fb.peq(8, 0, 0, 0, 0, 255, 1), 'checker cell (8,0) black');
+  }
+
+  // Scissor.
+  setColor(0.0, 1.0, 0.0, 1.0);
+  fb = await frame([1.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4, scissor: [16, 16, 32, 32] });
+  ok(fb.peq(32, 32, 0, 255, 0, 255, 1), 'scissor: inside box green');
+  ok(fb.peq(2, 2, 255, 0, 0, 255, 1), 'scissor: outside box red (clear)');
+  ok(fb.peq(50, 50, 255, 0, 0, 255, 1), 'scissor: past box red');
+
+  // Viewport restriction: a viewport confined to the top-left 32x32 maps the full-NDC quad into that
+  // sub-rect; pixels outside stay at the clear color.
+  setColor(0.0, 1.0, 0.0, 1.0);
+  fb = await frame([1.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4, viewport: [0.0, 0.0, 32.0, 32.0] });
+  ok(fb.peq(8, 8, 0, 255, 0, 255, 1), 'viewport: inside 32x32 green');
+  ok(fb.peq(50, 50, 255, 0, 0, 255, 1), 'viewport: outside stays clear red');
+
+  // Alpha blend: Src=SrcAlpha, Dst=OneMinusSrcAlpha, Add, over all channels (alpha too -> 191).
+  const blendOver = {
+    color: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+    alpha: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+  };
+  const pipeBlend = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none',
+    { format: 'rgba8unorm', blend: blendOver, writeMask: GPUColorWrite.ALL }, undefined);
+  setColor(0.0, 0.0, 1.0, 0.5);
+  fb = await frame([1.0, 0.0, 0.0, 1.0], { pipe: pipeBlend, bind: uboBg, vbo, verts: 4 });
+  ok(fb.allEq(128, 0, 128, 191, 3), 'alpha blend 0.5*blue over red -> rgb(128,0,128) a191');
+
+  // Sub-rect readback.
+  setColor(0.2, 0.4, 0.6, 1.0);
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4 });
+  {
+    let good = true;
+    for (let y = 10; y < 14; y++) {
+      for (let x = 10; x < 14; x++) {
+        if (!fb.peq(x, y, 51, 102, 153, 255, 2)) good = false;
+      }
+    }
+    ok(good, 'sub-rect (10,10,4x4) == (51,102,153,255)');
+  }
+
+  // ================= exhaustive per-API render coverage =================
+
+  // --- Topologies: all 5 WebGPU topologies (NO triangle-fan) ----------------------------------
+  setColor(1.0, 0.0, 0.0, 1.0);
+  {
+    // TriangleList: two CCW tris covering the quad.
+    const tl = new Float32Array([
+      -1.0, -1.0, 1.0, -1.0, -1.0, 1.0,
+      -1.0, 1.0, 1.0, -1.0, 1.0, 1.0,
+    ]);
+    const bTl = mkVbo('tl', tl);
+    // A horizontal center line for LineList / LineStrip.
+    const ln = new Float32Array([-1.0, 0.0, 1.0, 0.0]);
+    const bLn = mkVbo('ln', ln);
+    // A single center point.
+    const pt = new Float32Array([0.0, 0.0]);
+    const bPt = mkVbo('pt', pt);
+
+    const mkt = (topo) => mk(mSolid, mSolid, uboPll, vblPos2, topo, 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+    const pTl = mkt('triangle-list');
+    const pLl = mkt('line-list');
+    const pLs = mkt('line-strip');
+    const pPt = mkt('point-list');
+    ok(true, 'topology pipelines created');
+
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pTl, bind: uboBg, vbo: bTl, verts: 6 });
+    ok(fb.allEq(255, 0, 0, 255, 1), 'TriangleList fills quad');
+
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pLl, bind: uboBg, vbo: bLn, verts: 2 });
+    {
+      let mid = 0;
+      for (let x = 0; x < W; x++) {
+        if (fb.peq(x, H / 2, 255, 0, 0, 255, 2) || fb.peq(x, H / 2 - 1, 255, 0, 0, 255, 2)) mid += 1;
+      }
+      ok(mid >= W - 2, 'LineList draws the middle row');
+      ok(fb.peq(0, 0, 0, 0, 0, 255, 2), 'LineList leaves top row clear');
+    }
+
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pLs, bind: uboBg, vbo: bLn, verts: 2 });
+    {
+      let mid = 0;
+      for (let x = 0; x < W; x++) {
+        if (fb.peq(x, H / 2, 255, 0, 0, 255, 2) || fb.peq(x, H / 2 - 1, 255, 0, 0, 255, 2)) mid += 1;
+      }
+      ok(mid >= W - 2, 'LineStrip draws the middle row');
+    }
+
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pPt, bind: uboBg, vbo: bPt, verts: 1 });
+    {
+      let hit = false;
+      for (let y = H / 2 - 2; y <= H / 2 + 2; y++) {
+        for (let x = W / 2 - 2; x <= W / 2 + 2; x++) {
+          if (fb.peq(x, y, 255, 0, 0, 255, 2)) hit = true;
+        }
+      }
+      ok(hit, 'PointList draws a 1px point at the center');
+    }
+  }
+
+  // --- Blend factor + op matrix ---------------------------------------------------------------
+  {
+    const mkBlend = (sc, dc, oc, sa, da, oa) => mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none',
+      {
+        format: 'rgba8unorm',
+        blend: {
+          color: { srcFactor: sc, dstFactor: dc, operation: oc },
+          alpha: { srcFactor: sa, dstFactor: da, operation: oa },
+        },
+        writeMask: GPUColorWrite.ALL,
+      }, undefined);
+
+    // One/Zero: src replaces dst.
+    let p = mkBlend('one', 'zero', 'add', 'one', 'zero', 'add');
+    setColor(0.0, 0.0, 1.0, 1.0);
+    fb = await frame([0.5, 0.5, 0.5, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(0, 0, 255, 255, 2), 'blend One/Zero: src replaces dst');
+
+    // One/One Add.
+    p = mkBlend('one', 'one', 'add', 'one', 'one', 'add');
+    setColor(0.0, 0.0, 0.5, 1.0);
+    fb = await frame([0.5, 0.0, 0.0, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(128, 0, 128, 255, 2), 'blend One/One Add: src+dst = (128,0,128)');
+
+    // Zero/One: dst kept.
+    p = mkBlend('zero', 'one', 'add', 'zero', 'one', 'add');
+    setColor(0.0, 1.0, 0.0, 1.0);
+    fb = await frame([0.2, 0.0, 0.0, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(51, 0, 0, 255, 2), 'blend Zero/One: dst kept (51,0,0)');
+
+    // Dst/Zero: src*dst modulate.
+    p = mkBlend('dst', 'zero', 'add', 'dst', 'zero', 'add');
+    setColor(0.0, 0.0, 1.0, 1.0);
+    fb = await frame([0.5, 0.5, 0.5, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(0, 0, 128, 255, 2), 'blend Dst/Zero: src*dst modulate (0,0,128)');
+
+    // One/One Max: per-channel max.
+    p = mkBlend('one', 'one', 'max', 'one', 'one', 'max');
+    setColor(0.6, 0.2, 0.6, 1.0);
+    fb = await frame([0.2, 0.6, 0.2, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(153, 153, 153, 255, 2), 'blend op Max: per-channel max');
+
+    // One/One ReverseSubtract: dst-src (rgb 191, alpha resolves to 0).
+    p = mkBlend('one', 'one', 'reverse-subtract', 'one', 'one', 'reverse-subtract');
+    setColor(0.25, 0.0, 0.0, 1.0);
+    fb = await frame([1.0, 0.0, 0.0, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(191, 0, 0, 0, 3), 'blend op ReverseSubtract: dst-src rgb (191,0,0) a0');
+  }
+
+  // --- Depth-compare matrix (all 8 GPUCompareFunction; z=0.5 quad vs clear-depth 0.75) --------
+  {
+    const dq = new Float32Array([
+      -1.0, -1.0, 0.5,
+      1.0, -1.0, 0.5,
+      -1.0, 1.0, 0.5,
+      1.0, 1.0, 0.5,
+    ]);
+    const dvbo = mkVbo('dquad', dq);
+    setColor(0.0, 1.0, 0.0, 1.0);
+    const cases = [
+      ['always', true, 'depth Always'],
+      ['never', false, 'depth Never'],
+      ['less', true, 'depth Less'],
+      ['less-equal', true, 'depth LessEqual'],
+      ['equal', false, 'depth Equal'],
+      ['greater', false, 'depth Greater'],
+      ['greater-equal', false, 'depth GreaterEqual'],
+      ['not-equal', true, 'depth NotEqual'],
+    ];
+    for (const [cmp, draws, name] of cases) {
+      const p = mk(mPos3, mPos3, uboPll, vblPos3, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), depthFor(cmp));
+      fb = await frameDepth([0.0, 0.0, 0.0, 1.0], 0.75, p, uboBg, dvbo, 4);
+      ok(fb.peq(W / 2, H / 2, 0, 255, 0, 255, 2) === draws, name);
+    }
+  }
+
+  // --- Face culling + winding -----------------------------------------------------------------
+  setColor(1.0, 0.0, 0.0, 1.0);
+  {
+    // Cull None: quad drawn.
+    const p = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(255, 0, 0, 255, 1), 'cull None: quad drawn');
+
+    // Cull Back with FrontFace Ccw vs Cw: exactly one shows the quad (winding flip).
+    const pCcw = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'back', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pCcw, bind: uboBg, vbo, verts: 4 });
+    const ccw = fb.peq(W / 2, H / 2, 255, 0, 0, 255, 2);
+
+    const pCw = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'cw', 'back', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pCw, bind: uboBg, vbo, verts: 4 });
+    const cw = fb.peq(W / 2, H / 2, 255, 0, 0, 255, 2);
+
+    ok(ccw !== cw, 'cull Back: Ccw vs Cw winding flips visibility');
+
+    // Cull Front (Ccw) vs cull Back (Ccw) disagree at the center: one draws, one culls.
+    const pFront = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'front', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pFront, bind: uboBg, vbo, verts: 4 });
+    const frontDrawn = fb.peq(W / 2, H / 2, 255, 0, 0, 255, 2);
+    ok(frontDrawn !== ccw, 'cull Front vs cull Back (Ccw) disagree at center');
+  }
+
+  // --- Color write mask -----------------------------------------------------------------------
+  setColor(1.0, 1.0, 1.0, 1.0);
+  {
+    const pR = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.RED), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pR, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(255, 0, 0, 255, 1), 'colorWrites RED only: white -> (255,0,0,255)');
+
+    const pAll = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pAll, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(255, 255, 255, 255, 1), 'colorWrites ALL: white -> (255,255,255,255)');
+  }
+
+  // --- Format feature + limit queries ---------------------------------------------------------
+  {
+    // rgba8unorm and depth32float both build RENDER_ATTACHMENT textures successfully above; assert the
+    // spec-mandated limits that gate this cell's usage.
+    const lim = device.limits;
+    ok(lim.maxTextureDimension2D >= W, 'limits.maxTextureDimension2D >= 64');
+    ok(lim.maxColorAttachments >= 1, 'limits.maxColorAttachments >= 1');
+    // Prove the render+copy formats are actually usable by round-tripping a probe texture create.
+    const probe = device.createTexture({
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    });
+    ok(probe.format === 'rgba8unorm', 'rgba8unorm texture usable as RENDER_ATTACHMENT|COPY_SRC');
+    probe.destroy();
+    const probeD = device.createTexture({
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'depth32float',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    ok(probeD.format === 'depth32float', 'depth32float texture usable as RENDER_ATTACHMENT');
+    probeD.destroy();
+  }
+
+  // --- 2x2 texture upload + Nearest sampling --------------------------------------------------
+  {
+    const tex = device.createTexture({
+      label: 'tex2x2',
+      size: { width: 2, height: 2, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    // Row-major, v origin top-left in WebGPU: TL red, TR green, BL blue, BR white.
+    const texels = new Uint8Array([
+      255, 0, 0, 255,
+      0, 255, 0, 255,
+      0, 0, 255, 255,
+      255, 255, 255, 255,
+    ]);
+    queue.writeTexture(
+      { texture: tex, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      texels,
+      { offset: 0, bytesPerRow: 8, rowsPerImage: 2 },
+      { width: 2, height: 2, depthOrArrayLayers: 1 }
+    );
+    const tview = tex.createView();
+    const samp = device.createSampler({
+      label: 'nearest',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge',
+      addressModeW: 'clamp-to-edge',
+      magFilter: 'nearest',
+      minFilter: 'nearest',
+      mipmapFilter: 'nearest',
+    });
+    const texBgl = device.createBindGroupLayout({
+      label: 'tex-bgl',
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float', viewDimension: '2d', multisampled: false } },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+      ],
+    });
+    const texBg = device.createBindGroup({
+      label: 'tex-bg',
+      layout: texBgl,
+      entries: [
+        { binding: 0, resource: tview },
+        { binding: 1, resource: samp },
+      ],
+    });
+    const texPll = device.createPipelineLayout({ label: 'tex-pll', bindGroupLayouts: [texBgl] });
+    const pipeTex = mk(mTex, mTex, texPll, vblPos2uv, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+    ok(true, 'texture pipeline + bind group created');
+
+    // Full-screen quad with uv. WebGPU maps NDC y=+1 to the framebuffer top and the texture's v origin
+    // is top-left, so the top vertices (pos.y=+1) carry v=0 to put the texture's top row at the top.
+    const tq = new Float32Array([
+      -1.0, -1.0, 0.0, 1.0,
+      1.0, -1.0, 1.0, 1.0,
+      -1.0, 1.0, 0.0, 0.0,
+      1.0, 1.0, 1.0, 0.0,
+    ]);
+    const tvbo = mkVbo('tquad', tq);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeTex, bind: texBg, vbo: tvbo, verts: 4 });
+    ok(fb.peq(W / 4, H / 4, 255, 0, 0, 255, 2), 'texture Nearest top-left red');
+    ok(fb.peq(3 * W / 4, H / 4, 0, 255, 0, 255, 2), 'texture Nearest top-right green');
+    ok(fb.peq(W / 4, 3 * H / 4, 0, 0, 255, 255, 2), 'texture Nearest bottom-left blue');
+    ok(fb.peq(3 * W / 4, 3 * H / 4, 255, 255, 255, 255, 2), 'texture Nearest bottom-right white');
+  }
+
+  // --- Negative control -----------------------------------------------------------------------
+  setColor(1.0, 0.0, 0.0, 1.0);
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4 });
+  ok(!fb.allEq(0, 255, 0, 255, 2), 'negative control: red buffer is NOT green');
+  ok(!fb.peq(0, 0, 0, 0, 0, 255, 2), 'negative control: red pixel is NOT black');
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code) => {
+    if (typeof Deno !== 'undefined') Deno.exit(code);
+    else process.exit(code);
+  })
+  .catch((e) => {
+    console.error('FATAL: ' + (e && e.stack ? e.stack : e));
+    if (typeof Deno !== 'undefined') Deno.exit(1);
+    else process.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/carpets/webgpu_ts/webgpu_render_ts_full_api.ts
+++ b/apps/starry/cpu-webgpu-render/programs/carpets/webgpu_ts/webgpu_render_ts_full_api.ts
@@ -1,0 +1,784 @@
+// webgpu_render_ts_full_api - WebGPU RENDER carpet via Deno's built-in navigator.gpu (wgpu-core, the
+// Firefox/Deno WebGPU engine, same as the wgpu crate) on Mesa lavapipe (software Vulkan on the CPU, no
+// GPU/window/surface/swapchain). It renders offscreen into a 64x64 rgba8unorm GPUTexture
+// (RENDER_ATTACHMENT | COPY_SRC) through real render pipelines with WGSL vertex+fragment shaders,
+// copies the texture to a MAP_READ buffer honouring the 256-byte bytesPerRow alignment (rows are padded
+// on copy then unpadded on readback), maps it, reads into a Uint8Array (H,W,4), and hard-asserts every
+// pixel against a closed-form reference. Coverage mirrors the verified Rust wgpu render cell exactly
+// (same closed-form pixel references, EXPECTED=56): render-pass clear (loadOp 'clear'), a solid quad
+// (uniform buffer + bind group; WebGPU has no push constants), an axis-aligned linear gradient, a
+// @builtin(position) checkerboard, a scissor rect (setScissorRect), a viewport restriction
+// (setViewport), an alpha blend (a=191), and a sub-rectangle readback. Exhaustive per-API coverage
+// builds a pipeline per state: all 5 WebGPU primitive topologies (point-list / line-list / line-strip /
+// triangle-list / triangle-strip - WebGPU has NO triangle-fan, and points are always 1px), a blend
+// factor+op matrix (one/zero, one/one add, zero/one, dst/zero, max, reverse-subtract -> alpha 0), the
+// full depth-compare matrix (all 8 GPUCompareFunction against a depth32float attachment; WebGPU NDC z in
+// [0,1] so a z=0.5 quad vs clear-depth 0.75 draws only under always/less/less-equal/not-equal, with
+// @invariant on the depth vertex shader's @builtin(position) so z is bit-exact across pipelines), face
+// culling + winding (cull none vs back with front-face ccw vs cw), a color write mask (RED vs ALL),
+// format-feature + limit queries, and a 2x2 rgba8 texture upload + nearest sampling (corners TL red /
+// TR green / BL blue / BR white), closing with a negative control. Prints
+// "WEBGPU_RENDER_TS_FULL_API OK <n>" only when every assertion passes and the count equals EXPECTED.
+// This is the typed version of the JS cell - identical render logic, every WebGPU handle typed.
+
+// [runtime] Deno/browser expose global navigator.gpu (wgpu-core). This cell TESTS the WebGPU render API.
+
+const W = 64;
+const H = 64;
+const BPP = 4;
+
+// 256-byte bytesPerRow alignment (COPY_BYTES_PER_ROW_ALIGNMENT). 64*4 == 256 already, but compute the
+// padded stride generically so the unpad path is exercised regardless.
+const ALIGN = 256;
+const UNPADDED = W * BPP;
+const PADDED = Math.ceil(UNPADDED / ALIGN) * ALIGN;
+
+let PASS = 0;
+let FAIL = 0;
+
+function ok(cond: boolean, desc: string): void {
+  if (cond) {
+    PASS += 1;
+  } else {
+    FAIL += 1;
+    console.error('FAIL: ' + desc);
+  }
+}
+
+// Assertion budget, calibrated to the count this cell genuinely runs on the success path; mirrors the
+// verified Rust wgpu render cell one-for-one (same coverage, same closed forms).
+const EXPECTED = 56;
+
+// A readback framebuffer: an unpadded (H*W*4) RGBA8 image with pixel accessors.
+class Fb {
+  px: Uint8Array;
+  constructor(px: Uint8Array) {
+    this.px = px;
+  }
+  p(x: number, y: number, c: number): number {
+    return this.px[(y * W + x) * BPP + c];
+  }
+  peq(x: number, y: number, r: number, g: number, b: number, a: number, tol: number): boolean {
+    const d = (v: number, t: number): boolean => Math.abs(v - t) <= tol;
+    return d(this.p(x, y, 0), r) && d(this.p(x, y, 1), g) && d(this.p(x, y, 2), b) && d(this.p(x, y, 3), a);
+  }
+  allEq(r: number, g: number, b: number, a: number, tol: number): boolean {
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        if (!this.peq(x, y, r, g, b, a, tol)) return false;
+      }
+    }
+    return true;
+  }
+}
+
+// --- WGSL shaders (inline template strings) ---------------------------------------------------
+
+// pos2 + uniform color -> solid fill.
+const SOLID_WGSL = `
+struct Solid { rgba: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: Solid;
+@vertex fn vs(@location(0) p: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(p, 0.0, 1.0);
+}
+@fragment fn fs() -> @location(0) vec4<f32> { return u.rgba; }
+`;
+
+// pos2 + per-vertex color -> interpolated gradient.
+const GRAD_WGSL = `
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) col: vec4<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) c: vec4<f32>) -> VOut {
+  var o: VOut;
+  o.pos = vec4<f32>(p, 0.0, 1.0);
+  o.col = c;
+  return o;
+}
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> { return in.col; }
+`;
+
+// pos2 + @builtin(position) checkerboard: white when ((x/8 + y/8) & 1) == 0.
+const CHECK_WGSL = `
+@vertex fn vs(@location(0) p: vec2<f32>) -> @builtin(position) vec4<f32> {
+  return vec4<f32>(p, 0.0, 1.0);
+}
+@fragment fn fs(@builtin(position) fc: vec4<f32>) -> @location(0) vec4<f32> {
+  let cx = u32(floor(fc.x)) / 8u;
+  let cy = u32(floor(fc.y)) / 8u;
+  if (((cx + cy) & 1u) == 0u) {
+    return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+  }
+  return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+`;
+
+// pos3 (carries a z for the depth-compare matrix) + uniform color. @invariant on the position output
+// makes z bit-exact across the eight depth pipelines so equal/not-equal are deterministic.
+const POS3_WGSL = `
+struct Solid { rgba: vec4<f32> };
+@group(0) @binding(0) var<uniform> u: Solid;
+@vertex fn vs(@location(0) p: vec3<f32>) -> @invariant @builtin(position) vec4<f32> {
+  return vec4<f32>(p, 1.0);
+}
+@fragment fn fs() -> @location(0) vec4<f32> { return u.rgba; }
+`;
+
+// pos2 + uv -> sample a 2x2 texture with a nearest sampler.
+const TEX_WGSL = `
+struct VOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex fn vs(@location(0) p: vec2<f32>, @location(1) uv: vec2<f32>) -> VOut {
+  var o: VOut;
+  o.pos = vec4<f32>(p, 0.0, 1.0);
+  o.uv = uv;
+  return o;
+}
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+@fragment fn fs(in: VOut) -> @location(0) vec4<f32> {
+  return textureSample(t, s, in.uv);
+}
+`;
+
+function finish(): number {
+  const total = PASS + FAIL;
+  console.log(
+    'webgpu-render-ts: PASS=' + PASS + ' FAIL=' + FAIL + ' TOTAL=' + total + ' EXPECTED=' + EXPECTED
+  );
+  if (FAIL === 0 && total === EXPECTED) {
+    console.log('WEBGPU_RENDER_TS_FULL_API OK ' + PASS);
+    return 0;
+  }
+  console.log('WEBGPU_RENDER_TS_FULL_API FAIL');
+  return 1;
+}
+
+async function run(): Promise<number> {
+  // --- gpu entry + adapter --------------------------------------------------------------------
+  if (typeof navigator === 'undefined' || !navigator.gpu) {
+    console.error('navigator.gpu unavailable - run Deno with --unstable-webgpu');
+    ok(false, 'navigator.gpu present');
+    return finish();
+  }
+  const gpu: GPU = navigator.gpu;
+
+  const adapter: GPUAdapter | null = await gpu.requestAdapter({ powerPreference: 'low-power' });
+  if (adapter == null) {
+    console.error('requestAdapter returned null - no WebGPU adapter on this host');
+    ok(false, 'requestAdapter yields a usable adapter');
+    return finish();
+  }
+  const info = (adapter.info || {}) as GPUAdapterInfo;
+  console.log(
+    'webgpu-render-ts adapter selected: vendor=' + info.vendor +
+    ' architecture=' + info.architecture +
+    ' device=' + info.device +
+    ' description=' + info.description
+  );
+  ok(true, 'requestAdapter yields a usable adapter');
+  ok(adapter.limits.maxTextureDimension2D >= W, 'adapter exposes limits (maxTextureDimension2D>=64)');
+
+  const device: GPUDevice = await adapter.requestDevice({ label: 'render-device' });
+  if (device == null) {
+    console.error('requestDevice returned null');
+    ok(false, 'requestDevice yields a usable device');
+    return finish();
+  }
+  device.addEventListener('uncapturederror', (ev: Event) => {
+    console.error('UNCAPTURED webgpu error: ' + (ev as GPUUncapturedErrorEvent).error.message);
+  });
+  const queue: GPUQueue = device.queue;
+
+  // --- color attachment + depth + readback plumbing -------------------------------------------
+  const color = device.createTexture({
+    label: 'color',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'rgba8unorm',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+  });
+  const colorView = color.createView();
+
+  const depthTex = device.createTexture({
+    label: 'depth',
+    size: { width: W, height: H, depthOrArrayLayers: 1 },
+    format: 'depth32float',
+    usage: GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+  const depthView = depthTex.createView();
+
+  const readback = device.createBuffer({
+    label: 'readback',
+    size: PADDED * H,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ,
+  });
+
+  // --- shader modules -------------------------------------------------------------------------
+  const mSolid = device.createShaderModule({ label: 'solid', code: SOLID_WGSL });
+  const mGrad = device.createShaderModule({ label: 'grad', code: GRAD_WGSL });
+  const mCheck = device.createShaderModule({ label: 'check', code: CHECK_WGSL });
+  const mPos3 = device.createShaderModule({ label: 'pos3', code: POS3_WGSL });
+  const mTex = device.createShaderModule({ label: 'tex', code: TEX_WGSL });
+
+  // Uniform buffer + bind group for the solid color (replaces Vulkan push constants).
+  const colorUbo = device.createBuffer({
+    label: 'color-ubo',
+    size: 16,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  });
+  const uboBgl = device.createBindGroupLayout({
+    label: 'ubo-bgl',
+    entries: [{ binding: 0, visibility: GPUShaderStage.FRAGMENT, buffer: { type: 'uniform' } }],
+  });
+  const uboBg = device.createBindGroup({
+    label: 'ubo-bg',
+    layout: uboBgl,
+    entries: [{ binding: 0, resource: { buffer: colorUbo } }],
+  });
+  const uboPll = device.createPipelineLayout({ label: 'ubo-pll', bindGroupLayouts: [uboBgl] });
+  const emptyPll = device.createPipelineLayout({ label: 'empty-pll', bindGroupLayouts: [] });
+
+  // --- vertex buffer layouts ------------------------------------------------------------------
+  const vblPos2: GPUVertexBufferLayout = {
+    arrayStride: 8,
+    stepMode: 'vertex',
+    attributes: [{ format: 'float32x2', offset: 0, shaderLocation: 0 }],
+  };
+  const vblPos2col: GPUVertexBufferLayout = {
+    arrayStride: 24,
+    stepMode: 'vertex',
+    attributes: [
+      { format: 'float32x2', offset: 0, shaderLocation: 0 },
+      { format: 'float32x4', offset: 8, shaderLocation: 1 },
+    ],
+  };
+  const vblPos3: GPUVertexBufferLayout = {
+    arrayStride: 12,
+    stepMode: 'vertex',
+    attributes: [{ format: 'float32x3', offset: 0, shaderLocation: 0 }],
+  };
+  const vblPos2uv: GPUVertexBufferLayout = {
+    arrayStride: 16,
+    stepMode: 'vertex',
+    attributes: [
+      { format: 'float32x2', offset: 0, shaderLocation: 0 },
+      { format: 'float32x2', offset: 8, shaderLocation: 1 },
+    ],
+  };
+
+  const noBlendTarget = (writeMask: number): GPUColorTargetState => ({ format: 'rgba8unorm', writeMask });
+
+  // Generic render-pipeline builder covering every state axis the coverage matrix needs.
+  const mk = (
+    vsMod: GPUShaderModule,
+    fsMod: GPUShaderModule,
+    layout: GPUPipelineLayout,
+    vbl: GPUVertexBufferLayout,
+    topology: GPUPrimitiveTopology,
+    frontFace: GPUFrontFace,
+    cullMode: GPUCullMode,
+    target: GPUColorTargetState,
+    depthStencil: GPUDepthStencilState | undefined
+  ): GPURenderPipeline =>
+    device.createRenderPipeline({
+      label: 'pipe',
+      layout,
+      vertex: { module: vsMod, entryPoint: 'vs', buffers: [vbl] },
+      fragment: { module: fsMod, entryPoint: 'fs', targets: [target] },
+      primitive: { topology, frontFace, cullMode },
+      depthStencil,
+    });
+
+  const depthFor = (compare: GPUCompareFunction): GPUDepthStencilState =>
+    ({ format: 'depth32float', depthWriteEnabled: true, depthCompare: compare });
+
+  // --- vertex geometry ------------------------------------------------------------------------
+  const mkVbo = (label: string, arr: Float32Array): GPUBuffer => {
+    const buf = device.createBuffer({ label, size: arr.byteLength, usage: GPUBufferUsage.VERTEX, mappedAtCreation: true });
+    new Float32Array(buf.getMappedRange()).set(arr);
+    buf.unmap();
+    return buf;
+  };
+
+  // Full-screen triangle-strip quad [-1,-1]..[1,1].
+  const quad = new Float32Array([
+    -1.0, -1.0,
+    1.0, -1.0,
+    -1.0, 1.0,
+    1.0, 1.0,
+  ]);
+  const vbo = mkVbo('quad', quad);
+  // Axis-aligned gradient: red at left column, blue at right column.
+  const gquad = new Float32Array([
+    -1.0, -1.0, 1.0, 0.0, 0.0, 1.0,
+    1.0, -1.0, 0.0, 0.0, 1.0, 1.0,
+    -1.0, 1.0, 1.0, 0.0, 0.0, 1.0,
+    1.0, 1.0, 0.0, 0.0, 1.0, 1.0,
+  ]);
+  const gvbo = mkVbo('gquad', gquad);
+
+  // Base pipelines.
+  const pipeSolid = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+  const pipeGrad = mk(mGrad, mGrad, emptyPll, vblPos2col, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+  const pipeCheck = mk(mCheck, mCheck, emptyPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+  ok(true, 'base render pipelines created');
+
+  const setColor = (r: number, g: number, b: number, a: number): void => {
+    queue.writeBuffer(colorUbo, 0, new Float32Array([r, g, b, a]));
+  };
+
+  // Draw-state bundle for one frame.
+  interface Draw {
+    pipe?: GPURenderPipeline;
+    bind?: GPUBindGroup;
+    vbo?: GPUBuffer;
+    verts: number;
+    scissor?: [number, number, number, number];
+    viewport?: [number, number, number, number];
+  }
+
+  // Copy the color texture into the readback buffer (padded rows), submit, map, unpad into an Fb.
+  const copyAndRead = async (enc: GPUCommandEncoder): Promise<Fb> => {
+    enc.copyTextureToBuffer(
+      { texture: color, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      { buffer: readback, bytesPerRow: PADDED, rowsPerImage: H },
+      { width: W, height: H, depthOrArrayLayers: 1 }
+    );
+    queue.submit([enc.finish()]);
+    await readback.mapAsync(GPUMapMode.READ);
+    const padded = new Uint8Array(readback.getMappedRange());
+    const px = new Uint8Array(W * H * BPP);
+    for (let y = 0; y < H; y++) {
+      const src = y * PADDED;
+      const dst = y * W * BPP;
+      px.set(padded.subarray(src, src + W * BPP), dst);
+    }
+    readback.unmap();
+    return new Fb(px);
+  };
+
+  // Render one frame: clear to `clear`, optionally draw, then read back. `d` bundles the draw state.
+  const frame = async (clear: [number, number, number, number], d: Draw): Promise<Fb> => {
+    const enc = device.createCommandEncoder({ label: 'frame' });
+    const pass = enc.beginRenderPass({
+      label: 'rp',
+      colorAttachments: [{
+        view: colorView,
+        loadOp: 'clear',
+        storeOp: 'store',
+        clearValue: { r: clear[0], g: clear[1], b: clear[2], a: clear[3] },
+      }],
+    });
+    if (d.pipe) {
+      pass.setPipeline(d.pipe);
+      if (d.viewport) pass.setViewport(d.viewport[0], d.viewport[1], d.viewport[2], d.viewport[3], 0.0, 1.0);
+      if (d.scissor) pass.setScissorRect(d.scissor[0], d.scissor[1], d.scissor[2], d.scissor[3]);
+      if (d.bind) pass.setBindGroup(0, d.bind);
+      if (d.vbo) pass.setVertexBuffer(0, d.vbo);
+      pass.draw(d.verts, 1, 0, 0);
+    }
+    pass.end();
+    return copyAndRead(enc);
+  };
+
+  // Depth-enabled frame: clears color + depth, draws the pos3 quad through `pipe`.
+  const frameDepth = async (
+    clear: [number, number, number, number],
+    depthClear: number,
+    pipe: GPURenderPipeline,
+    bind: GPUBindGroup,
+    vboBuf: GPUBuffer,
+    verts: number
+  ): Promise<Fb> => {
+    const enc = device.createCommandEncoder({ label: 'frame-d' });
+    const pass = enc.beginRenderPass({
+      label: 'rp-d',
+      colorAttachments: [{
+        view: colorView,
+        loadOp: 'clear',
+        storeOp: 'store',
+        clearValue: { r: clear[0], g: clear[1], b: clear[2], a: clear[3] },
+      }],
+      depthStencilAttachment: {
+        view: depthView,
+        depthLoadOp: 'clear',
+        depthStoreOp: 'store',
+        depthClearValue: depthClear,
+      },
+    });
+    pass.setPipeline(pipe);
+    pass.setBindGroup(0, bind);
+    pass.setVertexBuffer(0, vboBuf);
+    pass.draw(verts, 1, 0, 0);
+    pass.end();
+    return copyAndRead(enc);
+  };
+
+  // ================= base coverage =================
+
+  // Clear.
+  let fb: Fb = await frame([0.0, 0.25, 0.5, 1.0], { verts: 0 });
+  ok(fb.allEq(0, 64, 128, 255, 2), 'renderpass clear (0,0.25,0.5,1) all pixels (0,64,128,255)');
+  ok(fb.peq(0, 0, 0, 64, 128, 255, 2), 'clear pixel (0,0)');
+
+  // Solid red quad.
+  setColor(1.0, 0.0, 0.0, 1.0);
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4 });
+  ok(fb.allEq(255, 0, 0, 255, 1), 'solid red quad fills every pixel');
+
+  // Axis-aligned gradient.
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeGrad, vbo: gvbo, verts: 4 });
+  {
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const u = (x + 0.5) / W;
+        const r = Math.round((1.0 - u) * 255.0);
+        const b = Math.round(u * 255.0);
+        if (!fb.peq(x, y, r, 0, b, 255, 4)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'gradient matches horizontal-linear closed-form for all pixels');
+    ok(fb.peq(0, 0, 255, 0, 0, 255, 8), 'gradient left edge ~ red');
+    ok(fb.peq(W - 1, H - 1, 0, 0, 255, 255, 8), 'gradient right edge ~ blue');
+    ok(fb.peq(W / 2, H / 2, 128, 0, 128, 255, 4), 'gradient center ~ (128,0,128)');
+  }
+
+  // Checkerboard from @builtin(position).
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeCheck, vbo, verts: 4 });
+  {
+    let bad = 0;
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        const white = (((x / 8 | 0) + (y / 8 | 0)) & 1) === 0;
+        const w = white ? 255 : 0;
+        if (!fb.peq(x, y, w, w, w, 255, 1)) bad += 1;
+      }
+    }
+    ok(bad === 0, 'checkerboard matches (x/8+y/8) parity for all pixels');
+    ok(fb.peq(0, 0, 255, 255, 255, 255, 1), 'checker cell (0,0) white');
+    ok(fb.peq(8, 0, 0, 0, 0, 255, 1), 'checker cell (8,0) black');
+  }
+
+  // Scissor.
+  setColor(0.0, 1.0, 0.0, 1.0);
+  fb = await frame([1.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4, scissor: [16, 16, 32, 32] });
+  ok(fb.peq(32, 32, 0, 255, 0, 255, 1), 'scissor: inside box green');
+  ok(fb.peq(2, 2, 255, 0, 0, 255, 1), 'scissor: outside box red (clear)');
+  ok(fb.peq(50, 50, 255, 0, 0, 255, 1), 'scissor: past box red');
+
+  // Viewport restriction: a viewport confined to the top-left 32x32 maps the full-NDC quad into that
+  // sub-rect; pixels outside stay at the clear color.
+  setColor(0.0, 1.0, 0.0, 1.0);
+  fb = await frame([1.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4, viewport: [0.0, 0.0, 32.0, 32.0] });
+  ok(fb.peq(8, 8, 0, 255, 0, 255, 1), 'viewport: inside 32x32 green');
+  ok(fb.peq(50, 50, 255, 0, 0, 255, 1), 'viewport: outside stays clear red');
+
+  // Alpha blend: Src=SrcAlpha, Dst=OneMinusSrcAlpha, Add, over all channels (alpha too -> 191).
+  const blendOver: GPUBlendState = {
+    color: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+    alpha: { srcFactor: 'src-alpha', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+  };
+  const pipeBlend = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none',
+    { format: 'rgba8unorm', blend: blendOver, writeMask: GPUColorWrite.ALL }, undefined);
+  setColor(0.0, 0.0, 1.0, 0.5);
+  fb = await frame([1.0, 0.0, 0.0, 1.0], { pipe: pipeBlend, bind: uboBg, vbo, verts: 4 });
+  ok(fb.allEq(128, 0, 128, 191, 3), 'alpha blend 0.5*blue over red -> rgb(128,0,128) a191');
+
+  // Sub-rect readback.
+  setColor(0.2, 0.4, 0.6, 1.0);
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4 });
+  {
+    let good = true;
+    for (let y = 10; y < 14; y++) {
+      for (let x = 10; x < 14; x++) {
+        if (!fb.peq(x, y, 51, 102, 153, 255, 2)) good = false;
+      }
+    }
+    ok(good, 'sub-rect (10,10,4x4) == (51,102,153,255)');
+  }
+
+  // ================= exhaustive per-API render coverage =================
+
+  // --- Topologies: all 5 WebGPU topologies (NO triangle-fan) ----------------------------------
+  setColor(1.0, 0.0, 0.0, 1.0);
+  {
+    // TriangleList: two CCW tris covering the quad.
+    const tl = new Float32Array([
+      -1.0, -1.0, 1.0, -1.0, -1.0, 1.0,
+      -1.0, 1.0, 1.0, -1.0, 1.0, 1.0,
+    ]);
+    const bTl = mkVbo('tl', tl);
+    // A horizontal center line for LineList / LineStrip.
+    const ln = new Float32Array([-1.0, 0.0, 1.0, 0.0]);
+    const bLn = mkVbo('ln', ln);
+    // A single center point.
+    const pt = new Float32Array([0.0, 0.0]);
+    const bPt = mkVbo('pt', pt);
+
+    const mkt = (topo: GPUPrimitiveTopology): GPURenderPipeline =>
+      mk(mSolid, mSolid, uboPll, vblPos2, topo, 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+    const pTl = mkt('triangle-list');
+    const pLl = mkt('line-list');
+    const pLs = mkt('line-strip');
+    const pPt = mkt('point-list');
+    ok(true, 'topology pipelines created');
+
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pTl, bind: uboBg, vbo: bTl, verts: 6 });
+    ok(fb.allEq(255, 0, 0, 255, 1), 'TriangleList fills quad');
+
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pLl, bind: uboBg, vbo: bLn, verts: 2 });
+    {
+      let mid = 0;
+      for (let x = 0; x < W; x++) {
+        if (fb.peq(x, H / 2, 255, 0, 0, 255, 2) || fb.peq(x, H / 2 - 1, 255, 0, 0, 255, 2)) mid += 1;
+      }
+      ok(mid >= W - 2, 'LineList draws the middle row');
+      ok(fb.peq(0, 0, 0, 0, 0, 255, 2), 'LineList leaves top row clear');
+    }
+
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pLs, bind: uboBg, vbo: bLn, verts: 2 });
+    {
+      let mid = 0;
+      for (let x = 0; x < W; x++) {
+        if (fb.peq(x, H / 2, 255, 0, 0, 255, 2) || fb.peq(x, H / 2 - 1, 255, 0, 0, 255, 2)) mid += 1;
+      }
+      ok(mid >= W - 2, 'LineStrip draws the middle row');
+    }
+
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pPt, bind: uboBg, vbo: bPt, verts: 1 });
+    {
+      let hit = false;
+      for (let y = H / 2 - 2; y <= H / 2 + 2; y++) {
+        for (let x = W / 2 - 2; x <= W / 2 + 2; x++) {
+          if (fb.peq(x, y, 255, 0, 0, 255, 2)) hit = true;
+        }
+      }
+      ok(hit, 'PointList draws a 1px point at the center');
+    }
+  }
+
+  // --- Blend factor + op matrix ---------------------------------------------------------------
+  {
+    const mkBlend = (
+      sc: GPUBlendFactor, dc: GPUBlendFactor, oc: GPUBlendOperation,
+      sa: GPUBlendFactor, da: GPUBlendFactor, oa: GPUBlendOperation
+    ): GPURenderPipeline => mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none',
+      {
+        format: 'rgba8unorm',
+        blend: {
+          color: { srcFactor: sc, dstFactor: dc, operation: oc },
+          alpha: { srcFactor: sa, dstFactor: da, operation: oa },
+        },
+        writeMask: GPUColorWrite.ALL,
+      }, undefined);
+
+    // One/Zero: src replaces dst.
+    let p: GPURenderPipeline = mkBlend('one', 'zero', 'add', 'one', 'zero', 'add');
+    setColor(0.0, 0.0, 1.0, 1.0);
+    fb = await frame([0.5, 0.5, 0.5, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(0, 0, 255, 255, 2), 'blend One/Zero: src replaces dst');
+
+    // One/One Add.
+    p = mkBlend('one', 'one', 'add', 'one', 'one', 'add');
+    setColor(0.0, 0.0, 0.5, 1.0);
+    fb = await frame([0.5, 0.0, 0.0, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(128, 0, 128, 255, 2), 'blend One/One Add: src+dst = (128,0,128)');
+
+    // Zero/One: dst kept.
+    p = mkBlend('zero', 'one', 'add', 'zero', 'one', 'add');
+    setColor(0.0, 1.0, 0.0, 1.0);
+    fb = await frame([0.2, 0.0, 0.0, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(51, 0, 0, 255, 2), 'blend Zero/One: dst kept (51,0,0)');
+
+    // Dst/Zero: src*dst modulate.
+    p = mkBlend('dst', 'zero', 'add', 'dst', 'zero', 'add');
+    setColor(0.0, 0.0, 1.0, 1.0);
+    fb = await frame([0.5, 0.5, 0.5, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(0, 0, 128, 255, 2), 'blend Dst/Zero: src*dst modulate (0,0,128)');
+
+    // One/One Max: per-channel max.
+    p = mkBlend('one', 'one', 'max', 'one', 'one', 'max');
+    setColor(0.6, 0.2, 0.6, 1.0);
+    fb = await frame([0.2, 0.6, 0.2, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(153, 153, 153, 255, 2), 'blend op Max: per-channel max');
+
+    // One/One ReverseSubtract: dst-src (rgb 191, alpha resolves to 0).
+    p = mkBlend('one', 'one', 'reverse-subtract', 'one', 'one', 'reverse-subtract');
+    setColor(0.25, 0.0, 0.0, 1.0);
+    fb = await frame([1.0, 0.0, 0.0, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(191, 0, 0, 0, 3), 'blend op ReverseSubtract: dst-src rgb (191,0,0) a0');
+  }
+
+  // --- Depth-compare matrix (all 8 GPUCompareFunction; z=0.5 quad vs clear-depth 0.75) --------
+  {
+    const dq = new Float32Array([
+      -1.0, -1.0, 0.5,
+      1.0, -1.0, 0.5,
+      -1.0, 1.0, 0.5,
+      1.0, 1.0, 0.5,
+    ]);
+    const dvbo = mkVbo('dquad', dq);
+    setColor(0.0, 1.0, 0.0, 1.0);
+    const cases: [GPUCompareFunction, boolean, string][] = [
+      ['always', true, 'depth Always'],
+      ['never', false, 'depth Never'],
+      ['less', true, 'depth Less'],
+      ['less-equal', true, 'depth LessEqual'],
+      ['equal', false, 'depth Equal'],
+      ['greater', false, 'depth Greater'],
+      ['greater-equal', false, 'depth GreaterEqual'],
+      ['not-equal', true, 'depth NotEqual'],
+    ];
+    for (const [cmp, draws, name] of cases) {
+      const p = mk(mPos3, mPos3, uboPll, vblPos3, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), depthFor(cmp));
+      fb = await frameDepth([0.0, 0.0, 0.0, 1.0], 0.75, p, uboBg, dvbo, 4);
+      ok(fb.peq(W / 2, H / 2, 0, 255, 0, 255, 2) === draws, name);
+    }
+  }
+
+  // --- Face culling + winding -----------------------------------------------------------------
+  setColor(1.0, 0.0, 0.0, 1.0);
+  {
+    // Cull None: quad drawn.
+    const p = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: p, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(255, 0, 0, 255, 1), 'cull None: quad drawn');
+
+    // Cull Back with FrontFace Ccw vs Cw: exactly one shows the quad (winding flip).
+    const pCcw = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'back', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pCcw, bind: uboBg, vbo, verts: 4 });
+    const ccw = fb.peq(W / 2, H / 2, 255, 0, 0, 255, 2);
+
+    const pCw = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'cw', 'back', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pCw, bind: uboBg, vbo, verts: 4 });
+    const cw = fb.peq(W / 2, H / 2, 255, 0, 0, 255, 2);
+
+    ok(ccw !== cw, 'cull Back: Ccw vs Cw winding flips visibility');
+
+    // Cull Front (Ccw) vs cull Back (Ccw) disagree at the center: one draws, one culls.
+    const pFront = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'front', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pFront, bind: uboBg, vbo, verts: 4 });
+    const frontDrawn = fb.peq(W / 2, H / 2, 255, 0, 0, 255, 2);
+    ok(frontDrawn !== ccw, 'cull Front vs cull Back (Ccw) disagree at center');
+  }
+
+  // --- Color write mask -----------------------------------------------------------------------
+  setColor(1.0, 1.0, 1.0, 1.0);
+  {
+    const pR = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.RED), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pR, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(255, 0, 0, 255, 1), 'colorWrites RED only: white -> (255,0,0,255)');
+
+    const pAll = mk(mSolid, mSolid, uboPll, vblPos2, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pAll, bind: uboBg, vbo, verts: 4 });
+    ok(fb.allEq(255, 255, 255, 255, 1), 'colorWrites ALL: white -> (255,255,255,255)');
+  }
+
+  // --- Format feature + limit queries ---------------------------------------------------------
+  {
+    // rgba8unorm and depth32float both build RENDER_ATTACHMENT textures successfully above; assert the
+    // spec-mandated limits that gate this cell's usage.
+    const lim = device.limits;
+    ok(lim.maxTextureDimension2D >= W, 'limits.maxTextureDimension2D >= 64');
+    ok(lim.maxColorAttachments >= 1, 'limits.maxColorAttachments >= 1');
+    // Prove the render+copy formats are actually usable by round-tripping a probe texture create.
+    const probe = device.createTexture({
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+    });
+    ok(probe.format === 'rgba8unorm', 'rgba8unorm texture usable as RENDER_ATTACHMENT|COPY_SRC');
+    probe.destroy();
+    const probeD = device.createTexture({
+      size: { width: 4, height: 4, depthOrArrayLayers: 1 },
+      format: 'depth32float',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+    ok(probeD.format === 'depth32float', 'depth32float texture usable as RENDER_ATTACHMENT');
+    probeD.destroy();
+  }
+
+  // --- 2x2 texture upload + Nearest sampling --------------------------------------------------
+  {
+    const tex = device.createTexture({
+      label: 'tex2x2',
+      size: { width: 2, height: 2, depthOrArrayLayers: 1 },
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+    });
+    // Row-major, v origin top-left in WebGPU: TL red, TR green, BL blue, BR white.
+    const texels = new Uint8Array([
+      255, 0, 0, 255,
+      0, 255, 0, 255,
+      0, 0, 255, 255,
+      255, 255, 255, 255,
+    ]);
+    queue.writeTexture(
+      { texture: tex, mipLevel: 0, origin: { x: 0, y: 0, z: 0 } },
+      texels,
+      { offset: 0, bytesPerRow: 8, rowsPerImage: 2 },
+      { width: 2, height: 2, depthOrArrayLayers: 1 }
+    );
+    const tview = tex.createView();
+    const samp = device.createSampler({
+      label: 'nearest',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge',
+      addressModeW: 'clamp-to-edge',
+      magFilter: 'nearest',
+      minFilter: 'nearest',
+      mipmapFilter: 'nearest',
+    });
+    const texBgl = device.createBindGroupLayout({
+      label: 'tex-bgl',
+      entries: [
+        { binding: 0, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: 'float', viewDimension: '2d', multisampled: false } },
+        { binding: 1, visibility: GPUShaderStage.FRAGMENT, sampler: { type: 'filtering' } },
+      ],
+    });
+    const texBg = device.createBindGroup({
+      label: 'tex-bg',
+      layout: texBgl,
+      entries: [
+        { binding: 0, resource: tview },
+        { binding: 1, resource: samp },
+      ],
+    });
+    const texPll = device.createPipelineLayout({ label: 'tex-pll', bindGroupLayouts: [texBgl] });
+    const pipeTex = mk(mTex, mTex, texPll, vblPos2uv, 'triangle-strip', 'ccw', 'none', noBlendTarget(GPUColorWrite.ALL), undefined);
+    ok(true, 'texture pipeline + bind group created');
+
+    // Full-screen quad with uv. WebGPU maps NDC y=+1 to the framebuffer top and the texture's v origin
+    // is top-left, so the top vertices (pos.y=+1) carry v=0 to put the texture's top row at the top.
+    const tq = new Float32Array([
+      -1.0, -1.0, 0.0, 1.0,
+      1.0, -1.0, 1.0, 1.0,
+      -1.0, 1.0, 0.0, 0.0,
+      1.0, 1.0, 1.0, 0.0,
+    ]);
+    const tvbo = mkVbo('tquad', tq);
+    fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeTex, bind: texBg, vbo: tvbo, verts: 4 });
+    ok(fb.peq(W / 4, H / 4, 255, 0, 0, 255, 2), 'texture Nearest top-left red');
+    ok(fb.peq(3 * W / 4, H / 4, 0, 255, 0, 255, 2), 'texture Nearest top-right green');
+    ok(fb.peq(W / 4, 3 * H / 4, 0, 0, 255, 255, 2), 'texture Nearest bottom-left blue');
+    ok(fb.peq(3 * W / 4, 3 * H / 4, 255, 255, 255, 255, 2), 'texture Nearest bottom-right white');
+  }
+
+  // --- Negative control -----------------------------------------------------------------------
+  setColor(1.0, 0.0, 0.0, 1.0);
+  fb = await frame([0.0, 0.0, 0.0, 1.0], { pipe: pipeSolid, bind: uboBg, vbo, verts: 4 });
+  ok(!fb.allEq(0, 255, 0, 255, 2), 'negative control: red buffer is NOT green');
+  ok(!fb.peq(0, 0, 0, 0, 0, 255, 2), 'negative control: red pixel is NOT black');
+
+  await queue.onSubmittedWorkDone();
+  device.destroy();
+  return finish();
+}
+
+run()
+  .then((code: number) => {
+    Deno.exit(code);
+  })
+  .catch((e: unknown) => {
+    const err = e as Error;
+    console.error('FATAL: ' + (err && err.stack ? err.stack : String(e)));
+    Deno.exit(1);
+  });

--- a/apps/starry/cpu-webgpu-render/programs/run-webgpu-render.sh
+++ b/apps/starry/cpu-webgpu-render/programs/run-webgpu-render.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# On-target WebGPU JS/TS carpet runner for StarryOS.
+#
+# WebGPU standalone runtime = Deno (V8 + a built-in copy of gfx-rs wgpu-core, the Rust WebGPU engine
+# Firefox and Servo also use, and the exact engine cpu-wgpu-render #1820 builds on musl). Deno runs
+# .js and .ts natively; its global navigator.gpu drives wgpu-core -> the Vulkan backend -> Mesa
+# lavapipe (software Vulkan on the CPU), so the carpets run entirely on the CPU, no GPU. Alpine ships a
+# native-musl Deno only for x86_64, so this is the x86_64 on-target gate; the aarch64/riscv64/
+# loongarch64 walls (and the browser path #391) are documented in README.md.
+#
+# The gate is manifest-honest: prebuild.sh writes expected_cells listing exactly the cells whose
+# runtime it provisioned on this arch. This runner passes only when every listed cell prints its
+# "<MARKER> OK <n>" marker (fail==0 && total==EXPECTED==pass, EXPECTED>=2). It never emits a 0-carpet
+# TEST PASSED.
+set -u
+APP=/opt/cpu-webgpu-render
+CARPETS="$APP/carpets"
+MANIFEST="$APP/expected_cells"
+
+VK_ICD="${VK_ICD:-/usr/share/vulkan/icd.d/lvp_icd.json}"
+export VK_DRIVER_FILES="$VK_ICD"
+export VK_ICD_FILENAMES="$VK_ICD"
+mkdir -p /tmp/vkrt; export XDG_RUNTIME_DIR=/tmp/vkrt
+mkdir -p /tmp/deno; export DENO_DIR=/tmp/deno
+# Single-thread the llvmpipe/lavapipe rasterizer: StarryOS runs one vCPU and the carpets assert
+# numerical correctness, not throughput, so thread count does not change the pass counts.
+export LP_NUM_THREADS=1
+
+if [ ! -s "$MANIFEST" ]; then
+    echo "cpu-webgpu-render: no WebGPU runtime provisioned on $(uname -m) (manifest empty)"
+    echo "cpu-webgpu-render: standalone Deno WebGPU is x86_64-only on musl; full JS/TS WebGPU on this"
+    echo "cpu-webgpu-render: arch is the browser path (#391). Refusing to emit a 0-carpet pass."
+    echo "TEST FAILED"
+    exit 1
+fi
+
+DENO="$(command -v deno 2>/dev/null || echo /usr/bin/deno)"
+if [ ! -x "$DENO" ]; then
+    echo "cpu-webgpu-render: manifest lists cells but deno is missing - provisioning broken"
+    echo "TEST FAILED"
+    exit 1
+fi
+
+EXPECTED=$(grep -c . "$MANIFEST")
+pass=0; fail=0
+# run <cell> <marker> <file> - only runs cells the manifest advertises; a cell passes when its output
+# carries "<marker> OK <n>".
+run() {
+    cell="$1"; marker="$2"; file="$3"
+    grep -qx "$cell" "$MANIFEST" || return 0
+    out="$("$DENO" run --no-check --unstable-webgpu --allow-all "$file" 2>&1)"
+    if echo "$out" | grep -qE "^$marker OK [0-9]+$"; then
+        echo "$out" | grep -E ": PASS=|^$marker OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+    else
+        echo "$out" | tail -8
+        echo "CARPET FAILED: $cell"
+        fail=$((fail + 1))
+    fi
+}
+
+run webgpu_js WEBGPU_RENDER_JS_FULL_API "$CARPETS/webgpu_js/webgpu_render_js_full_api.js"
+run webgpu_ts WEBGPU_RENDER_TS_FULL_API "$CARPETS/webgpu_ts/webgpu_render_ts_full_api.ts"
+# Render-scene cells: 4 scenarios x {js, ts}, mirroring the wgpu Rust render-scene cells.
+run scene_2dui_js SCENE_2DUI_JS "$CARPETS/scene_2dui_js/scene_2dui_js.js"
+run scene_2dui_ts SCENE_2DUI_TS "$CARPETS/scene_2dui_ts/scene_2dui_ts.ts"
+run scene_3dmodel_js SCENE_3DMODEL_JS "$CARPETS/scene_3dmodel_js/scene_3dmodel_js.js"
+run scene_3dmodel_ts SCENE_3DMODEL_TS "$CARPETS/scene_3dmodel_ts/scene_3dmodel_ts.ts"
+run scene_anim_js SCENE_ANIM_JS "$CARPETS/scene_anim_js/scene_anim_js.js"
+run scene_anim_ts SCENE_ANIM_TS "$CARPETS/scene_anim_ts/scene_anim_ts.ts"
+run scene_codec_js SCENE_CODEC_JS "$CARPETS/scene_codec_js/scene_codec_js.js"
+run scene_codec_ts SCENE_CODEC_TS "$CARPETS/scene_codec_ts/scene_codec_ts.ts"
+
+total=$((pass + fail))
+echo "cpu-webgpu-render: $pass/$total WebGPU cells OK on $(uname -m) via Deno (wgpu-core) + lavapipe"
+if [ "$fail" -eq 0 ] && [ "$total" -eq "$EXPECTED" ] && [ "$pass" -eq "$EXPECTED" ] && [ "$EXPECTED" -ge 2 ]; then
+    echo "TEST PASSED"
+else
+    echo "TEST FAILED"
+fi

--- a/apps/starry/cpu-webgpu-render/programs/run_all.sh
+++ b/apps/starry/cpu-webgpu-render/programs/run_all.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Host validation for the WebGPU JS/TS carpets. Runs them on Deno (V8 + a built-in copy of gfx-rs
+# wgpu-core, the same runtime the on-target gate uses) against Mesa lavapipe (software Vulkan on the
+# CPU), mirroring run-webgpu-render.sh exactly. Deno runs .js and .ts natively - no tsc, no node_modules.
+# Gates on each cell's "<MARKER> OK <n>" marker.
+#
+# Verified call chain (source + strace, not assumed): navigator.gpu -> deno_webgpu -> wgpu-core ->
+# wgpu-hal -> ash + libloading -> dlopen libvulkan.so.1 -> lvp_icd.json -> libvulkan_lvp.so (lavapipe)
+# -> libgallium + libLLVM (llvmpipe CPU JIT). The engine is wgpu-core, the same one Firefox/Servo use
+# and cpu-wgpu-render #1820 builds on musl.
+#
+# Env:
+#   DENO     path to the deno binary (default: from PATH)
+#   VK_ICD   path to the lavapipe ICD json (default: /usr/share/vulkan/icd.d/lvp_icd.json)
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CARPETS="$HERE/carpets"
+DENO="${DENO:-$(command -v deno 2>/dev/null || echo deno)}"
+
+VK_ICD="${VK_ICD:-/usr/share/vulkan/icd.d/lvp_icd.json}"
+export VK_DRIVER_FILES="$VK_ICD"
+export VK_ICD_FILENAMES="$VK_ICD"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+export DENO_DIR="${DENO_DIR:-/tmp/deno}"
+# Single-thread the llvmpipe/lavapipe rasterizer (StarryOS runs one vCPU; the carpets assert numerical
+# correctness, not throughput, so thread count does not change the pass counts).
+export LP_NUM_THREADS="${LP_NUM_THREADS:-1}"
+
+if ! command -v "$DENO" >/dev/null 2>&1; then
+    echo "webgpu: deno not found; host validation needs Deno (built-in WebGPU = wgpu-core)"
+    echo "TEST FAILED"
+    exit 1
+fi
+
+pass=0; fail=0
+# run <name> <marker> <file> - a cell passes when its output carries "<marker> OK <n>".
+run() {
+    name="$1"; marker="$2"; file="$3"
+    out="$("$DENO" run --no-check --unstable-webgpu --allow-all "$file" 2>&1)"
+    if echo "$out" | grep -qE "^$marker OK [0-9]+$"; then
+        echo "$out" | grep -E ": PASS=|^$marker OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+    else
+        echo "$out" | tail -8
+        echo "CARPET FAILED: $name"
+        fail=$((fail + 1))
+    fi
+}
+
+run webgpu_js WEBGPU_RENDER_JS_FULL_API "$CARPETS/webgpu_js/webgpu_render_js_full_api.js"
+run webgpu_ts WEBGPU_RENDER_TS_FULL_API "$CARPETS/webgpu_ts/webgpu_render_ts_full_api.ts"
+# Render-scene cells: 4 scenarios x {js, ts}, mirroring the wgpu Rust render-scene cells.
+run scene_2dui_js SCENE_2DUI_JS "$CARPETS/scene_2dui_js/scene_2dui_js.js"
+run scene_2dui_ts SCENE_2DUI_TS "$CARPETS/scene_2dui_ts/scene_2dui_ts.ts"
+run scene_3dmodel_js SCENE_3DMODEL_JS "$CARPETS/scene_3dmodel_js/scene_3dmodel_js.js"
+run scene_3dmodel_ts SCENE_3DMODEL_TS "$CARPETS/scene_3dmodel_ts/scene_3dmodel_ts.ts"
+run scene_anim_js SCENE_ANIM_JS "$CARPETS/scene_anim_js/scene_anim_js.js"
+run scene_anim_ts SCENE_ANIM_TS "$CARPETS/scene_anim_ts/scene_anim_ts.ts"
+run scene_codec_js SCENE_CODEC_JS "$CARPETS/scene_codec_js/scene_codec_js.js"
+run scene_codec_ts SCENE_CODEC_TS "$CARPETS/scene_codec_ts/scene_codec_ts.ts"
+
+
+total=$((pass + fail))
+echo "webgpu: $pass/$total cells OK on $(uname -m) via Deno (wgpu-core) + lavapipe"
+if [ "$fail" -eq 0 ] && [ "$pass" -ge 10 ]; then echo "TEST PASSED"; else echo "TEST FAILED"; fi

--- a/apps/starry/cpu-webgpu-render/qemu-aarch64.toml
+++ b/apps/starry/cpu-webgpu-render/qemu-aarch64.toml
@@ -1,0 +1,16 @@
+# cpu-webgpu-render aa - boots StarryOS and runs the WebGPU JS/TS carpet on Deno (built-in gfx-rs
+# wgpu-core) over Mesa lavapipe (software Vulkan, single vCPU -smp 1). Alpine edge/community ships a
+# native-musl deno for aarch64, so this arch runs the carpet on-target like x86_64.
+args = [
+    "-nographic", "-cpu", "max", "-m", "4096M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-webgpu-render.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 12000

--- a/apps/starry/cpu-webgpu-render/qemu-x86_64.toml
+++ b/apps/starry/cpu-webgpu-render/qemu-x86_64.toml
@@ -1,0 +1,18 @@
+# cpu-webgpu-render x64 - boots StarryOS and runs the on-target launcher. The WebGPU cells (webgpu_js /
+# webgpu_ts / webgpu_kotlin) run on Node against the dawn native addon on Mesa lavapipe; Node, dawn,
+# and kotlinc-js have no StarryOS build, so those cells are validated on the host by
+# programs/run_all.sh and the on-target launcher reports that honestly (single vCPU, -smp 1).
+args = [
+    "-machine", "q35",
+    "-nographic", "-cpu", "Haswell", "-m", "4096M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run-webgpu-render.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 9000


### PR DESCRIPTION
# cpu-webgpu-render - WebGPU 渲染 API carpet(JS / TS,经 Deno 在 StarryOS 上运行)

## 问题

需要一套在 StarryOS 上验证 WebGPU 渲染管线的测试。WebGPU 有两套生产实现:Chromium 的 Dawn(C++,dawn native addon 是 glibc-only 预编译,musl 加载不了),以及 Firefox / Servo / Deno 的 wgpu(gfx-rs,Rust)。Deno 内建的 WebGPU 直接嵌 wgpu-core,落到 Mesa lavapipe(CPU 软件 Vulkan,无需 GPU),因此 musl 的 Deno 就能在 target 上跑 JS/TS 的 WebGPU 渲染面,无需新建引擎 - 只测既有运行时。这是 WebGPU 计算 carpet cpu-webgpu-compute 的渲染轨对应物,也是 #1820 cpu-wgpu-render(Rust 四架构)的 JS/TS 对应。

## 改动

新增 apps/starry/cpu-webgpu-render,不改内核或既有应用。包含:prebuild.sh 把 Deno、Mesa lavapipe 及十个 JS/TS 渲染 carpet 注入 rootfs overlay;build-x86_64-unknown-none.toml 与 build-aarch64-unknown-none-softfloat.toml 两架构构建配置;qemu-x86_64.toml 与 qemu-aarch64.toml 两架构运行配置;programs/carpets/ 下十个 cell(每种场景 JS 与 TS 各一,一一镜像)。

## 十个 cell 与断言数

webgpu_js / webgpu_ts 各 56;scene_2dui_js / ts 各 28;scene_3dmodel_js / ts 各 14;scene_anim_js / ts 各 38;scene_codec_js / ts 各 15。每个 cell 离屏渲染到 RGBA8 纹理、读回像素,逐像素对同语言独立算出的闭式参照断言。JS 与 TS 变体共用 WGSL 着色器、几何与逐像素断言,并与 #1820 的 Rust parity cell 对齐。

## 运行命令

x86_64:cargo xtask starry app qemu -t cpu-webgpu-render --arch x86_64

aarch64:cargo xtask starry app qemu -t cpu-webgpu-render --arch aarch64

## TEST PASSED 成功条件

每个 cell 仅在全部断言通过且计数等于钉死的总数时打印 `<MARKER> OK <n>`,并附 `PASS=<p> FAIL=<f> TOTAL=<t> EXPECTED=<e>` 行。launcher 的 manifest/计数门在缺运行时或任一 cell 失败时传播为 TEST FAILED;十个 cell 全通过才判 TEST PASSED。

## 运行时依赖

Deno(musl 构建,内建 wgpu-core)、Mesa lavapipe(libvulkan_lvp.so,软件 Vulkan ICD)、libgallium + libLLVM(llvmpipe CPU JIT)。渲染在 CPU 上光栅化(llvmpipe),路径中无 GPU。调用链:navigator.gpu -> deno_webgpu -> wgpu-core / wgpu-types -> wgpu-hal -> ash(Vulkan FFI) -> libvulkan.so.1 -> lvp_icd.json -> libvulkan_lvp.so -> libgallium + libLLVM。

## 范围与已知限制

仅 x86_64 与 aarch64 on-target(Deno 的 musl 预编译只覆盖这两个架构);rv64 / loongarch64 不在本 app 覆盖内。Deno 内建 WebGPU = wgpu-core,与 #1820 同引擎;Chromium 的 Dawn 路径在浏览器 campaign(#391)另行覆盖。
