### PR TITLE
test(gpu-webgpu-render): WebGPU rendering carpet - GPU virtio-gpu vGPU

### DIFF
--- a/apps/starry/gpu-webgpu-render/README.md
+++ b/apps/starry/gpu-webgpu-render/README.md
@@ -1,0 +1,5 @@
+# gpu-webgpu-render (GPU virtio-gpu vGPU (-smp1), WebGPU rendering)
+
+Placeholder reserving the GPU virtio-gpu vGPU WebGPU RENDERING-pipeline carpet - the rendering-track counterpart of the WebGPU compute carpet (#1810). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: JS / TS / Python / Kotlin.
+
+Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.


### PR DESCRIPTION
# gpu-webgpu-render (GPU virtio-gpu vGPU (-smp1), WebGPU rendering)

a Shield Machine for Placeholder reserving the GPU virtio-gpu vGPU WebGPU RENDERING-pipeline carpet - the rendering-track counterpart of the WebGPU compute carpet (#1810). Offscreen (EGL surfaceless / OSMesa) render to an FBO with pixel-invariant assertions. Enabled language bindings: JS / TS / Python / Kotlin.

Industrial-grade carpet: full binding x full API x rendering-stage x boundary matrix, four-arch on-target. Closed until implemented; it will be completed and reopened.