### PR TITLE
chore(repo): reference AGENTS.md with @ syntax in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-see AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
## 问题

本人同时使用 Codex 和 Claude Code 来开发，在使用过程中明显感觉 Codex 更加遵守项目规范，表现为频繁读取规范文档、触发Skill，然而在使用 Claude Code 时却没见到 agent 主动读取规范或调用 skill 过。当前 CLAUDE.md 只写 `see AGENTS.md`，工具不会自动跟随该引用，导致 AGENTS.md 中的编码规范、skill 触发条件和验证命令无法被稳定加载。

## 改动

将 CLAUDE.md 内容从 `see AGENTS.md` 改为 `@AGENTS.md`。`@` 语法是项目内已知的文件引用标记，使 AGENTS.md 的内容能被工具链路可靠地解析和加载到会话上下文中。

## 依据

[claude-agents-mapping.md](https://github.com/odere-pro/claude-calibration/blob/main/docs/claude-agents-mapping.md) 中写到：

> Claude Code reads `CLAUDE.md`, **not** `AGENTS.md` ([memory docs](https://code.claude.com/docs/en/memory#agents-md)). You bridge the gap once — either import the open-standard file from `CLAUDE.md` (`@AGENTS.md`) or symlink (`ln -s AGENTS.md CLAUDE.md`). After that bridge is in place, behavior is effectively identical,and anything you author against the open standard is honored by Claude Code.

也就是说可以通过引用或软连接的方式来 bridge the gap，本 PR 采用引用的方式。
