### PR TITLE
docs(axvm): add authoritative VM lifecycle docs and align crate overview

### DIFF
--- a/docs/docs/components/crates/axvm.md
+++ b/docs/docs/components/crates/axvm.md
@@ -3,8 +3,8 @@
 > 路径：`virtualization/axvm`
 > 类型：库 crate
 > 分层：组件层 / 可复用基础组件
-> 版本：`0.2.3`
-> 文档依据：`Cargo.toml`、`README.md`、`src/lib.rs`、`src/vm.rs`、`src/vcpu.rs`、`src/hal.rs`、`src/config.rs`
+> 版本：`0.5.24`
+> 文档依据：`Cargo.toml`、`README.md`、`src/lib.rs`、`src/lifecycle/{machine,status}.rs`、`src/runtime/vcpus.rs`、`src/vm/mod.rs`、`src/manager.rs`、`docs/lifecycle.md`、`docs/lifecycle-internals.md`
 
 `axvm` 是 Axvisor 虚拟化软件栈中的“VM 资源管理层”。它不负责 Hypervisor 顶层编排，也不直接实现所有架构相关虚拟化细节，而是把虚拟机对象、vCPU 列表、客户机地址空间、设备集合和生命周期状态封装成一个统一的 `AxVM` 抽象，供上层 VMM 直接使用。
 
@@ -13,59 +13,55 @@
 从职责上看，`axvm` 位于三类组件的交汇处：
 
 - 向下依赖 `axvm-types`、各架构 vCPU crate、`axaddrspace`、`axdevice` 等组件，承接 vCPU、地址空间和设备模型。
-- 向外通过 `AxVMHal` 把宿主能力注入进来，例如地址翻译、时间、当前 VM/vCPU/pCPU 信息和中断注入。
+- 向外通过 `src/host/` 的宿主 trait（`HostCpu`、`HostMemory`、`HostTime` 等，由 `ArceOsHost` 实现）把宿主能力注入进来，例如地址翻译、时间、当前 VM/vCPU/pCPU 信息和中断注入。
 - 向上被 Axvisor 的 `vmm` 层直接调用，作为真正的 VM 实例与生命周期实体。
 
 可以把 `axvm` 理解为“可被 Hypervisor 编排的 VM 对象层”，而不是顶层 Hypervisor 程序。
 
 ### 模块结构
-- `src/lib.rs`：crate 入口，导出 `AxVM`、`AxVMRef`、`VMMemoryRegion`、`VMStatus`、`config`、`AxVMHal` 与 `has_hardware_support()`。
-- `src/vm.rs`：核心实现文件，定义 `AxVM`、内部可变/不可变状态、内存区管理、状态切换、`init()`、`boot()`、`shutdown()`、`run_vcpu()` 等。
-- `src/vcpu.rs`：AxVM 自有 vCPU wrapper、状态机、current-vCPU 绑定和架构适配层，按 `x86_64`、`riscv64`、`aarch64`、`loongarch64` 选择具体后端。
-- `src/hal.rs`：定义 `AxVMHal` trait，规定宿主必须提供的能力边界。
+- `src/lib.rs`：crate 入口，导出 `AxVM`、`AxVMRef`、`VMMemoryRegion`、`VmStatus`/`StopReason`、`config` 等。
+- `src/lifecycle/`：VM 生命周期状态机权威实现——`machine.rs`（内部状态机 `Machine<R, H>` 及 `start_with`/`request_stop_with`/`finish_stop`/`pause`/`resume`/`reset_with`/`destroy_with` 等转换函数）、`status.rs`（对外枚举 `VmStatus`/`StopReason` 与 `as_str()`）。
+- `src/vm/mod.rs`：`AxVM` 高层对象，把生命周期操作暴露为 `start()`、`pause()`、`resume()`、`stop()`、`reset()`、`destroy()`、`status()`，并提供 `stop_and_join_runtime`（强制静默）等内部路径。
+- `src/runtime/`：vCPU task 主循环（`vcpus.rs` 的 `vcpu_run`）、runtime 编排（`mod.rs`）与 hypercall/IVC 通道。
+- `src/manager.rs`：全局 VM 注册表与 `create_vm_from_toml`/`remove_vm` 等管理入口。
 - `src/config.rs`：把 `axvmconfig` 的 TOML 侧配置转成运行时 `AxVMConfig`、`AxVCpuConfig`、`VMImageConfig`、`PhysCpuList` 等结构。
 
 ### 1.3 关键数据结构
-- `AxVM<H, U>`：虚拟机主对象，其中 `H: AxVMHal`、`U: AxVCpuHal`。
-- `AxVMInnerConst<U>`：初始化后不再变化的部分，主要是 `phys_cpu_ls`、`vcpu_list` 和 `devices`。
-- `AxVMInnerMut<H>`：可变状态，包含 `address_space`、`memory_regions`、`config` 和 `vm_status`。
+- `AxVM`（`AxVMRef = Arc<AxVM>`）：虚拟机主对象，由 manager 注册表持有，生命周期操作见 §2.2。
+- `Machine<AxVMResources, Arc<VmRuntimeHandle>>`：`AxVM.machine` 字段持有的生命周期状态机（见 §1.4），`AxVMResources` 承载 vCPU/设备/地址空间等架构资源；`VmRuntimeHandle` 承载运行态资源（vCPU 等待队列、task 注册表、中断缓冲、中断路由、退出计数），仅在 `Running`/`Paused`/`Stopping` 期间存活（见 lifecycle-internals.md §1）。
 - `VMMemoryRegion`：记录客户机物理地址、宿主虚拟地址、布局信息和是否需要回收。
-- `VMStatus`：`Loading`、`Loaded`、`Running`、`Suspended`、`Stopping`、`Stopped`，描述 VM 生命周期。
+- `VmStatus`：`Ready`、`Running`、`Pausing`、`Paused`、`Stopping`、`Stopped`、`Destroying`、`Destroyed`、`Failed`，描述 VM 生命周期（`Pausing` 为预留态，当前无转换写入）。
 - `VcpuSnapshot`：对外暴露的架构无关 vCPU 状态快照。
 - `AxVMConfig` / `AxVMCrateConfig`：前者用于运行时 VM 创建，后者更贴近 TOML 配置源。
 
 ### 1.4 VM 生命周期与主线
-`axvm` 的主要执行路径如下：
+VM 生命周期状态机的**权威参考**是 crate 内文档 `virtualization/axvm/docs/lifecycle.md`（对外状态模型：
+完整状态图、转换规则表与源码行号对照）与 `docs/lifecycle-internals.md`（实现者视角：内部状态图、
+生命周期 × runtime 双维度、runtime 生命周期、不可观测状态与锁语义）。此处只做概要。
 
-```mermaid
-flowchart TD
-    New["AxVM::new(config)"] --> Init["vm.init()"]
-    Init --> BuildVCpu["创建 vCPU 列表"]
-    Init --> BuildMem["建立客户机地址空间/直通区域"]
-    Init --> BuildDev["构造 AxVmDevices"]
-    BuildVCpu --> SetupVCpu["vcpu.setup(...)"]
-    BuildMem --> Loaded["VMStatus::Loaded"]
-    BuildDev --> Loaded
-    Loaded --> Boot["vm.boot()"]
-    Boot --> Running["VMStatus::Running"]
-    Running --> Run["vm.run_vcpu(vcpu_id)"]
-    Run --> Exit["处理 VM exit"]
-    Running --> Shutdown["vm.shutdown()"]
-    Shutdown --> Stopped["VMStatus::Stopped / 资源清理"]
-```
+状态机（`src/lifecycle/machine.rs` 的 `Machine<R, H>`，对外由 `src/lifecycle/status.rs` 的 `VmStatus`
+暴露）为 9 状态：`Ready`、`Running`、`Pausing`（预留）、`Paused`、`Stopping`、`Stopped`、
+`Destroying`、`Destroyed`、`Failed`。核心主线：
 
-对应到源码：
+1. `AxVM::new(config)` → `Ready`：VM 已创建、尚未启动。
+2. `start()`（`start_with`）→ `Running`：同步、原子，无 "starting" 过渡态；runtime 存活，vCPU task 已入队（协作式调度下不保证已执行第一条指令，见 lifecycle-internals.md §1.3）。
+3. `pause()` → `Paused`、`resume()` → `Running`：`pause` 是请求语义（状态立即翻转到 `Paused`，
+   但无确认 API 证明 vCPU 已暂停），只翻 flag + suspend 设备；vCPU 在下次 VM-exit 才观察到
+   `suspending()`，`resume` 通过 `notify_all_vcpus` 唤醒。
+4. `stop(reason)`（`request_stop_with`）：从 `Running`/`Paused` → `Stopping`（异步请求，只置标志即返回）；
+   从 `Ready` → `Stopped`（同步直达，vCPU 从未运行、无需收敛）。最后一个正常退出的 vCPU 在自身退出路径
+   调 `finish_stop`（`src/runtime/vcpus.rs`）才到 `Stopped`。
+5. `destroy()`：对运行态先 `stop_and_join_runtime(Forced)` 强制静默，再释放资源到 `Destroyed`（终态）。
+   `reset()` 为分步：强制静默 → `reset_with`（→`Ready`）→ prepare → `start()`。
 
-1. `AxVM::new(config)` 创建空的客户机地址空间，并把状态初始化为 `Loading`。
-2. `init()` 负责真正完成 VM 组装：创建 vCPU、合并直通地址区间、建立设备、设置页表根与 vCPU 初始入口。
-3. `boot()` 把状态切换到 `Running`，但不直接执行客户机代码。
-4. 真正执行路径在 `run_vcpu(vcpu_id)`，它循环处理 `VmExit`。
-5. `shutdown()` 把 VM 推入停止状态；`Drop` 中会触发资源清理。
+语义要点：
 
-当前源码表明：
-
-- `suspend` / `resume` 语义尚未完整实现，`Suspended` 更偏状态预留。
-- `boot()` 后不意味着所有资源自动启动，上层 VMM 仍需调度相应的 vCPU 任务。
+- `stop`/`pause` 都是**请求而非完成**：`Stopping`/`Paused` 只代表状态机翻转，vCPU 要等下一次 VM-exit
+  才观察到；掩中断忙循环的 guest 永不 VM-exit，`Stopping` 可能无限期停留（wedged）。
+- `Failed` 是终态（转换闭包失败进入），只能 `destroy` 离开。
+- 状态机另有 `Switching` 内部态（转换函数入口占位，持锁期间不可观测，对外映射为 `Failed`）；
+  `Destroying` 同理，`destroy_with` 全程持 machine lock，正常路径不可观测；但**清理闭包失败时不回滚**，
+  `status()` 可观测到 `Destroying`，重试 `destroy()` 可到 `Destroyed`（见 lifecycle-internals.md §4）。
 
 ### 1.5 架构相关分层
 `axvm` 自身不把所有架构细节写死，而是通过 `src/vcpu.rs` 做一层统一绑定：
@@ -85,33 +81,35 @@ flowchart TD
 - 统一处理 VM exit，并把硬件相关能力通过 HAL 向上层隔离。
 
 ### 2.2 关键 API
-- `AxVM::new(config)`：创建 VM 对象。
-- `AxVM::init()`：构造 vCPU、设备和地址空间，是最关键的初始化步骤。
-- `AxVM::boot()`：切到 `Running` 状态。
-- `AxVM::shutdown()`：进入停止流程。
-- `AxVM::run_vcpu(vcpu_id)`：执行并处理一次或一轮 vCPU 运行/退出。
-- `set_vm_status()` / `vm_status()`：状态管理接口。
-- `has_hardware_support()`：检查底层虚拟化支持是否可用。
+- `AxVM::new(config)`：创建 VM 对象（`Ready`）。
+- `AxVM::start()`：`Ready`/`Stopped` → `Running`，同步重建 runtime（vCPU/设备/中断架构，RAM backing 保留）。
+- `AxVM::pause()` / `resume()`：`Running` ↔ `Paused`；`pause` 为请求语义，vCPU 异步观察。
+- `AxVM::stop(reason)`：请求停止（异步），返回即 `Stopping`；`Stopped` 需等最后一个 vCPU 退出。
+- `AxVM::reset()`：分步强制静默 → `Ready` → 重新 `start()`。
+- `AxVM::destroy()`：强制静默后释放资源到 `Destroyed`。
+- `AxVM::status()` / `running()` / `stopping()` / `suspending()` / `stopped()`：状态查询。
+- `AxVM::alloc_ivc_channel()` / `release_ivc_channel()`：IVC 通道管理。
 
 ### 使用场景
 `axvm` 最典型的消费方不是应用程序，而是 VMM：
 
 - 根据 TOML 配置创建一个 VM。
 - 准备内存映射、内核镜像和设备配置。
-- 在上层任务系统中为每个 vCPU 分配执行实体。
-- 在 VM exit 循环中调用 `run_vcpu()` 并处理 hypercall、MMIO、外部中断等事件。
+- 在上层任务系统中为每个 vCPU 分配执行实体（`src/runtime/vcpus.rs` 的 `vcpu_run` 主循环）。
+- 在 vCPU 主循环中处理 hypercall、MMIO、外部中断等 VM exit 事件。
 
 ### 2.4 使用示意
 ```rust
-// 伪代码：宿主需要提供 AxVMHal/AxVCpuHal 的具体实现
-let vm = AxVM::<MyVmHal, MyVCpuHal>::new(config)?;
-vm.init()?;
-vm.boot()?;
-
-let exit_reason = vm.run_vcpu(0)?;
+// 伪代码：以 Arc<AxVM> 为句柄驱动生命周期
+let vm = AxVM::new(config)?;          // -> Ready
+vm.start()?;                          // -> Running，vCPU task 由 runtime 内部 spawn
+vm.pause()?;                          // -> Paused（请求语义）
+vm.resume()?;                         // -> Running
+vm.stop(StopReason::Clean)?;          // -> Stopping（异步），等 vCPU 退出后 Stopped
+vm.destroy()?;                        // -> Destroyed
 ```
 
-在实际仓库中，这套流程由 `virtualization/axvm/src/runtime/*` 完成，而不是由普通库使用者直接手写。
+实际使用由 `virtualization/axvm/src/runtime/*` 与 `src/manager.rs` 编排，而不是由普通库使用者直接手写。
 
 ## 依赖关系
 ```mermaid
@@ -141,7 +139,10 @@ graph LR
 - `axvisor_api` 生态：更多出现在消费者侧，但会影响 `axvm` 的宿主接入方式。
 
 ### 3.3 关键直接消费者
-当前仓库内最重要、也是几乎唯一的直接消费者是 `os/axvisor`。它把 `AxVM<AxVMHalImpl, AxVCpuHalImpl>` 固化为 VMM 内使用的 `VM` 类型，并围绕它组织 vCPU 任务、配置加载与控制台命令。
+当前仓库内最重要、也是几乎唯一的直接消费者是 `os/axvisor`。它通过 `axvm` 的 manager 注册表
+（`src/manager.rs` 的 `AxvmRuntime::start_vm`/`stop_vm` 等）与 `AxVMRef` 操作 VM，经 AxVisor 侧
+`create_vm_from_toml`（os/axvisor/src/manager.rs:45）编排创建，并围绕它组织 vCPU 任务、配置加载与
+控制台命令。
 
 ## 开发指南
 ### 接入方式
@@ -154,22 +155,23 @@ axvm = { workspace = true }
 
 ### 4.2 初始化顺序
 1. 先从 `axvmconfig` 或其他来源构造 `AxVMConfig`。
-2. 调 `AxVM::new()` 创建空 VM 对象。
-3. 调 `init()` 绑定 vCPU、设备和地址空间。
-4. 由上层 VMM 负责在适当时机调用 `boot()`。
-5. 在宿主调度框架中反复调用 `run_vcpu()` 处理执行与退出原因。
+2. 调 `AxVM::new()` 创建 VM 对象（`Ready`）。
+3. 由上层 VMM 调 `start()` 绑定 vCPU、设备并重建 runtime（`Running`）。
+4. `start()` 内部为每个 vCPU spawn task（`src/runtime/vcpus.rs` 的 `vcpu_run` 主循环）。
+5. 停止时 `stop()`（`Stopping`）→ 最后一个 vCPU 退出调 `finish_stop` → `Stopped`；`destroy()` 强制静默后释放资源。
 
 ### 4.3 开发注意事项
-- 修改 `init()` 时，要同时验证 vCPU 创建、设备初始化和地址空间映射三条路径。
-- 修改 `VMStatus` 时，要同步检查上层 VMM 的状态机是否仍匹配。
-- 修改 `run_vcpu()` 时，要把这类改动视为 Hypervisor 热路径改动，优先关注 VM exit 分类和错误恢复。
-- 修改 `AxVMHal` trait 时，要同步更新 Axvisor 的 `hal` 实现，否则整个虚拟化栈会失配。
+- 修改 `src/vm/prepare/`（vCPU/设备/地址空间准备）时，要同时验证三条子路径：vCPU 创建、设备初始化、
+  地址空间映射（对应 prepare/ 下 vcpus.rs / devices.rs / address_space.rs 各自的构建逻辑）。
+- 修改 `VmStatus`/`Machine` 时，要同步检查上层 VMM 的状态机是否仍匹配（对外状态权威参考见 `virtualization/axvm/docs/lifecycle.md`，`Machine`/`VmRuntimeHandle` 双维度见 `docs/lifecycle-internals.md` §1）。
+- 修改 `src/runtime/vcpus.rs` 的 vCPU 主循环时，要把这类改动视为 Hypervisor 热路径改动，优先关注 VM exit 分类和错误恢复。
+- 修改 `src/host/` 的宿主适配（`HostCpu`/`HostMemory`/`HostTime` 等 trait）时，要同步验证 Axvisor 的宿主侧实现，否则整个虚拟化栈会失配。
 
 ## 测试
 ### 单元测试
 当前 crate 内没有完整的 `tests/` 目录，说明 `axvm` 的主要验证方式不是普通 host 单元测试，而是与真实 VMM 路径集成验证。后续若补充单元测试，优先覆盖：
 
-- `VMStatus` 状态转换。
+- `VmStatus` 状态转换（`src/lifecycle/machine.rs` 已内置覆盖非法转换与 reset/destroy 拒止的测试）。
 - 内存区域合并、对齐和回收。
 - 配置解析到运行时结构的转换边界。
 - 错误输入下的失败路径。
@@ -183,9 +185,12 @@ axvm = { workspace = true }
 - Guest 镜像可正常加载与启动。
 
 ### 5.3 覆盖率要求
-- 生命周期主线必须覆盖：`new -> init -> boot -> run_vcpu -> shutdown`。
+- 生命周期主线必须覆盖：`new -> start -> pause/resume -> stop -> Stopped -> start()`（重启，
+  `Stopped` 是静默态非终态）`-> Running -> stop -> Stopped -> destroy -> Destroyed`，并覆盖
+  `reset()` 路径与 `request_stop`（异步）到 `finish_stop` 的完成路径。
 - 至少要覆盖一种地址空间映射场景和一种设备处理场景。
 - VM exit 热路径应通过集成测试覆盖成功与异常分支。
+- `src/lifecycle/machine.rs` 已内置状态机单元测试（非法转换不改变状态、reset/destroy 在 runtime 存活时被拒等）。
 
 ## 跨项目定位
 ### ArceOS

--- a/virtualization/axvm/README.md
+++ b/virtualization/axvm/README.md
@@ -69,6 +69,13 @@ cargo doc --no-deps --open
 
 Online documentation: [docs.rs/axvm](https://docs.rs/axvm)
 
+### VM Lifecycle
+
+- [VM Lifecycle Model](docs/lifecycle.md) — the authoritative lifecycle model for VM managers/control
+  planes (states, transitions, request-vs-completion semantics).
+- [VM Lifecycle Internals (Implementer View)](docs/lifecycle-internals.md) — implementer-view internals
+  (lifecycle × runtime dimensions, runtime lifecycle, unobservable states and lock semantics).
+
 # Contributing
 
 1. Fork the repository and create a branch

--- a/virtualization/axvm/README_CN.md
+++ b/virtualization/axvm/README_CN.md
@@ -69,6 +69,12 @@ cargo doc --no-deps --open
 
 在线文档：[docs.rs/axvm](https://docs.rs/axvm)
 
+### VM 生命周期
+
+- [VM 生命周期模型](docs/lifecycle.md) —— 权威生命周期模型参考（状态、转换、请求与完成语义）。
+- [VM 生命周期实现者视图](docs/lifecycle-internals.md) —— 实现者视角内部细节（生命周期 × runtime
+  两个维度、runtime 生命周期、不可观测状态与锁语义）。
+
 # 贡献
 
 1. Fork 仓库并创建分支

--- a/virtualization/axvm/docs/lifecycle-internals.md
+++ b/virtualization/axvm/docs/lifecycle-internals.md
@@ -1,0 +1,359 @@
+# axvm VM 生命周期实现者视图：内部状态图、Runtime 双维度与锁语义
+
+实现者视角的内部细节文档，配套 [`lifecycle.md`](lifecycle.md)（API 使用指南，面向调用公共 API 的
+VMM/控制面）。本文档回答四类实现问题：**状态到底带着什么资源跑**（§1 双维度）、**Machine 的完整
+内部转换图**（§2）、**runtime 何时创建/回收/被取走**（§3 runtime 生命周期）、**哪些状态在锁内
+不可观测**（§4）；并附**逐条对照源码的转换规则表**（§5）与**外部接口文件对照**（§6）。所有行号
+指向提交 **`31f341abc`**（dev 分支，2026-07-31）；dev 前进导致行号漂移时，需对照最新代码修正。
+
+> **定位：** 本文档的读者是修改 `src/lifecycle/`、`src/runtime/`、`src/vm/` 的开发者与上层 VMM
+> 中需要深入状态内部（而非只消费 `VmStatus` 投影）的实现者。只消费公共 API 的控制面开发者读
+> [lifecycle.md](lifecycle.md) 即可。
+
+## 1. Machine 状态与 Runtime 双维度
+
+`Machine<R, H>` 的状态不仅编码"生命周期阶段"，还携带**两组资源**，两组资源**独立变化**（不总是同步翻转——典型例子：`take_stopped_runtime` 单独取走 runtime 而 resources 保留）：
+
+- **R（生命周期资源，`AxVMResources`）**：vCPU 列表、设备集合、中断结构、客户机地址空间。
+  `Ready`/`Running`/`Paused` 时始终为 `Some`；进入 `Stopped`/`Stopping` 后为 `Option`（因为
+  teardown 路径要能丢弃）；进入 `Failed`/`Destroyed` 后随状态一起被丢弃（`Failed(String)`
+  只带错误字符串）。
+- **H（runtime 资源，`Arc<VmRuntimeHandle>`）**：只在运行态存活。结构定义于
+  `src/vm/mod.rs:180-186`，字段：
+  - `wait_queue`：vCPU park/唤醒队列。**pause 不主动 park vCPU**：vCPU 在下一次 VM-exit
+    观察到 `suspending()` 后自行 `wait_for(!suspending)` 入队（vcpus.rs:342-350）；resume 时
+    `notify_all_vcpus` 才唤醒（runtime/mod.rs:106）；
+  - `vcpu_task_list`：`Mutex<BTreeMap<usize, AxTaskRef>>`，vCPU task 注册表（中断注入按
+    vCPU id 查表）;
+  - `pending_interrupts`：`Mutex<BTreeMap<usize, Vec<PendingInterrupt>>>`，未注入的中断缓冲
+    （生命周期见 §3.2）；
+  - `irq_dispatcher`：`VcpuIrqDispatcher`，vCPU task 的中断路由；
+  - `running_halting_vcpu_count`：`AtomicUsize`，正在退出的 vCPU 计数（`finish_stop` 依赖它）。
+
+### 1.1 各状态携带的资源（`src/lifecycle/machine.rs:6-34`）
+
+| `Machine` 变体 | `VmStatus` | resources (R) | runtime (H) | 说明 |
+|------|-----------|---------------|-------------|------|
+| `Ready(R)` | `Ready` | `Some` | 无 | 已创建未启动 |
+| `Running { resources, runtime }` | `Running` | `Some` | `Some` | 运行中 |
+| `Pausing { resources, runtime }` | `Pausing` | `Some` | `Some` | **不可达的预留变体**：无任何转换函数构造它（machine.rs:12-15）；`status()` 仍显式映射 `VmStatus::Pausing`（machine.rs:41），见 §4 |
+| `Paused { resources, runtime }` | `Paused` | `Some` | `Some` | 暂停中 |
+| `Stopping { resources, runtime, reason }` | `Stopping` | `Option` | `Option` | 异步停止中；类型级 `Option` 与 `Stopped` 对称（供 teardown 移动），当前构造点恒 `Some`（machine.rs:303-307） |
+| `Stopped { resources, runtime, reason }` | `Stopped` | `Option` | `Option` | **两个字段独立变化，见 §1.2** |
+| `Destroying` | `Destroying` | 无 | 无 | 锁内瞬态；清理失败时可观测（§4） |
+| `Destroyed` | `Destroyed` | 无 | 无 | 终态 |
+| `Failed(String)` | `Failed` | **无** | **无** | resources 已随转换丢弃 |
+| `Switching` | `Failed` | 无 | 无 | 转换入口占位（§4） |
+
+### 1.2 `Stopped` 的双维度是"拒绝还是允许 destroy"的根源
+
+`Stopped` 的两个 `Option` **不是同步翻转的**，因此 `Stopped` 状态能细分为三种实际形态：
+
+1. **正常 stop 之后**：`resources: Some, runtime: Some` —— runtime 还活着（vCPU task 等）。
+   此时 `destroy_with` **拒绝**（machine.rs:527-541），必须先 `take_stopped_runtime`
+   （machine.rs:385）把 runtime 取走。
+2. **`take_stopped_runtime` 之后**（vm 层 destroy/reset 内部）：`runtime: None`，resources 仍在。
+   此时 `destroy_with` 接受（machine.rs:543-551）。
+3. **teardown 丢弃 resources 后**（类型级预留形态）：`resources: None`。**当前无任何构造点会
+   造出此形态**（所有 `Stopped` 构造都填 `Some`，machine.rs:283/:354）。若真出现：
+   `destroy_with` 仍接受（machine.rs:543-551 的 `Stopped{runtime:None, ..}` 把 `None` 传给闭包），
+   `reset_with`/`start_with` 走 `other` 兜底 → `InvalidTransition`（machine.rs:460/:158）。
+   此形态是类型系统允许的**防御性分支**：实现者可假设正常路径下 `Stopped.resources` 恒为 `Some`，
+   但 `destroy_with` 的 match 不做此假设（避免 `unsafe unwrap`）。
+
+这就是"`Stopped` ≠ runtime 不存在"的底层来源（API 使用指南 §2 对 `Stopped` 的定义只承诺"所有
+vCPU 已退出、VM 资源仍保留"，不承诺 runtime 已回收）：**是否可 destroy 由 `Stopped` 的 runtime
+维度决定，不由状态字符串决定**。同理，`start()` 从 `Stopped` 重启时，
+vm 层先 `take_stopped_runtime`（vm/mod.rs:781）把旧 runtime 清掉，再调 `start_with`
+（否则 `Stopped{runtime: Some}` 会被判 `InvalidTransition`，machine.rs:142-157）。
+
+两个访问器细节：`Machine::runtime()` 对 `Stopped` **一律返回 `None`**（machine.rs:78-86）——运行时
+字段虽可能为 `Some`，只能经 `take_stopped_runtime()`（machine.rs:385-390）取走，不能经 `runtime()`
+读取。`take_stopped_runtime()` 只在 `Stopped` 有效，`runtime.take()` 后置 `None`，第二次调用返回
+`None`（幂等）；vm 层调用点：`stop_and_join_runtime` 尾部（vm/mod.rs:921-923，取走后
+`join_all_vcpu_tasks`）与 start-from-Stopped（vm/mod.rs:781-783）。**调用者应检查返回值**：第二次
+调用返回 `None` 是正常幂等行为，不应视为错误（勿 `let h = take_stopped_runtime().unwrap()`）。
+**take 先于 join 的原因**：vCPU task 在入口处已 clone runtime handle（vcpus.rs:301），后续只经该
+clone 访问 runtime、不再引用 machine 字段——先 take 不影响它们的访问，且立即满足 `destroy_with`
+的 `Stopped{runtime:None}` 前置；join 仅等 task 函数返回（锁外）。
+
+### 1.3 为什么"`Running` 不保证 vCPU 已执行"也是双维度问题
+
+`Running` 的语义是"runtime 已创建、vCPU task 已入队（vm/mod.rs:806-807 的
+`spawn_task`/`add_vcpu_task`）"，**不是"guest 已执行"**。在协作式调度下，`start()` 返回时
+vCPU task 可能还没被调度器选中跑过（§3 展开）。这与 `Stopped` 类似：**状态字段反映的是
+状态机与 runtime 的所有权，而不是执行面的即时事实**。API 使用指南把它概括为"`Running` 表示
+启动请求已完成，但不保证 guest 已执行第一条指令"（lifecycle.md §2）。
+
+## 2. 内部状态机转换图（`Machine<R, H>` 视角）
+
+与外部状态图（lifecycle.md §3）同态，但标注的是内部转换方法与 vm 层操作。**外部只观测 `VmStatus`
+投影**（`Machine::status()`，machine.rs:37-50），本节是投影背后的实现；外部视角的合并简写
+（`start()` 一步、`reset()` 一步）对应的分解见本图。
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    Ready --> Running: start_with
+    Ready --> Failed: start_with 闭包失败
+    Ready --> Stopped: request_stop_with（同步）
+    Ready --> Ready: reset_with（幂等）
+    Running --> Paused: pause（同步）
+    Paused --> Running: resume
+    Running --> Stopping: request_stop_with（异步）
+    Paused --> Stopping: request_stop_with
+    Stopping --> Stopped: finish_stop（最后 vCPU 调）
+    Stopped --> Running: start_with（闭包创建 runtime）
+    Stopped --> Ready: reset_with
+    Stopped --> Destroyed: destroy_with（runtime 已 take）
+    Ready --> Destroyed: destroy_with
+    Failed --> Destroyed: destroy_with
+    Destroyed --> [*]: 资源已释放
+```
+
+> 幂等自环（`Stopped → Stopped`、`Stopping → Stopping`、`Destroyed → Destroyed`）见 §5 转换表；
+> 预留态 `Pausing`（无任何转换写入）与转换入口占位态 `Switching` 见 §4；`Stopped` 的 runtime
+> 维度（`Some`/`None`）见 §1。图中 `Stopped → Ready: reset_with` 与 `Ready → Ready: reset_with`
+> 是 machine 层真实转换；但 `reset()` 的对外契约是 `→ Running`（lifecycle.md §4），vm 层在
+> `Ready` 后继续 `prepare → start`，`Ready` 只是不可观测的中间态（§3.4）。
+> **`start_with` 的闭包创建 runtime `H`**（vm/mod.rs:791-804），但它只接受
+> `Stopped{runtime: None}`——`{runtime: Some}` 返回 `InvalidTransition`（machine.rs:142-157）。
+> 因此 vm 层 `start` 会先 `take_stopped_runtime`（vm/mod.rs:781）清空 runtime，再调
+> `start_with`（详见 §3）。
+
+**destroy 不是 `Machine` 的一步转换**：`Machine` 只直接接受 `Ready`/`Stopped{runtime: None}`/
+`Failed` 的 `destroy_with`（见 §3.3）；运行态先由 `vm::destroy` 强制静默到 `Stopped` 并
+`take_stopped_runtime` 后才销毁。`vm::destroy` 从运行态发起时**复用图中已有的边**——`Running`/
+`Paused → Stopping`（`request_stop_with`）与 `Stopping → Stopped`（`finish_stop`），不引入新边：
+`stop_and_join_runtime` 内部先 `stop(reason)`（进入 `Stopping`，等待期 `status()` 返回
+`Stopping`），等最后一个 vCPU `finish_stop` 后才到 `Stopped`，**不存在运行态 → `Stopped` 的一步
+跳转**。API 使用指南把它概括为"`destroy()` 是阻塞操作，返回即资源释放完成"（lifecycle.md §4）。
+
+## 3. Runtime 生命周期
+
+### 3.1 runtime 由 `start_with` 的闭包**创建**，不是被取入
+
+`start_with`（machine.rs:108-168）的签名是 `F: FnOnce(&mut R) -> AxVmResult<H>`——闭包
+**返回一个新建的 H**。在 vm 层（vm/mod.rs:779-809）这个闭包：
+- 校验 `vcpu_list`/devices/`interrupt_fabric`（vm/mod.rs:793-804）；
+- 构造 `VmRuntimeHandle::new()`（vm/mod.rs:791）；
+- `spawn_task` 建主 vCPU task（:806）、`add_vcpu_task` 注册（:807）。
+
+因此 `start_with` **只接受 `Stopped{runtime: None}`**（machine.rs:142-157）；`{runtime: Some}`
+返回 `InvalidTransition`。vm 层 `start` 在调 `start_with` 之前先 `take_stopped_runtime`
+（vm/mod.rs:781）清空旧 runtime，保证满足该前置条件。**"把旧 runtime 清掉 + 新建一个"两步
+合并成了外部视角的一次 `start()`**。
+
+### 3.2 runtime 只在运行态存活
+
+`VmRuntimeHandle` 被文档注释为 "Runtime-only resources owned by Running/Paused/Stopping
+lifecycle states"（vm/mod.rs:179）。它随 `start_with` 创建、随 `take_stopped_runtime`/
+teardown 回收，`Ready`/`Failed`/`Destroyed` 一律不携带。`reset()` 的"旧 runtime teardown"
+即走 `stop_and_join_runtime(Forced)` + `take_stopped_runtime`。
+
+**`pending_interrupts` 随 runtime 生死：** `queue_interrupt`（runtime 层**内部接口**，
+`pub(crate)`，vcpus.rs:86，由 crate 内设备模拟/中断控制器经 manager.rs:79-81 的 `inject_interrupt`
+调用，**非 `AxVM` 公共 API**）只在 VM 处于 `Running`/`Paused` 时接受新中断（vcpus.rs:89，否则
+返回 `BadState`——即 `AxVmError::InvalidState` 的宏关键字，error.rs:360-362；lifecycle.md §5 用
+`InvalidState` 指同一变体），入队后 `notify_all` + host IPI（vcpus.rs:96-102）；vCPU 在每次 run
+前 `drain_pending_interrupts` 并注入 guest（vcpus.rs:134-152）。**并发时序**：准入检查调
+`vm.status()`（vcpus.rs:89）→ **同一把 machine lock**（§4），**不存在独立于 machine lock 的
+原子标志**——若 `request_stop_with` 此刻正持锁转换，`queue_interrupt` 自旋等锁释放后读到
+`Stopping` 而拒绝；时序是"stop 转换持锁 → queue 等锁 → 读到已翻转状态 → 拒绝"，两操作无状态
+翻转竞态（最终以转换完成后的状态为准）。因此：
+- 调用者收到 `BadState` 表示 VM 不再接受中断，应**丢弃**该中断（不重试）。
+- pause 后中断仍被缓冲、resume 后注入。
+- 进入 `Stopping` 后**新中断被拒**，但**已缓冲中断不会在进入时立即丢弃**——`Stopping` 期间
+  runtime 仍为 `Some`（§1.1），缓冲仍在；vCPU 若在退出前再跑一次仍会 drain 剩余中断。真正丢弃
+  发生在 **runtime 被回收时**（`take_stopped_runtime` 或 destroy 清理闭包），而非状态翻转时。
+- start/reset 重建 runtime → 空缓冲。
+
+### 3.3 destroy 前置条件：必须已把 runtime 取走
+
+`destroy_with`（machine.rs:472-558）只接受：
+- `Ready`（无 runtime，直接销毁）；
+- `Stopped { runtime: None }`（runtime 已取走）；
+- `Failed(_)` / `Destroying` / `Switching`（`f(None)`，无 resources 可传）——其中 **`Destroying`
+  是可达的重试路径**：上一次 destroy 的清理闭包失败后 machine 卡在 `Destroying`（§4），重试
+  `destroy()` 走此分支（`f(None)` 表示 resources 已被上一次调用消费、不再重复清理，
+  machine.rs:552-556）；`Switching` 是**防御性**分支（正常锁语义下不可达，见 §4）；
+- `Destroyed`（幂等，machine.rs:478）。
+
+它**拒绝** `Running`/`Pausing`/`Paused`/`Stopping`/`Stopped { runtime: Some }`
+（machine.rs:487-541）。因此运行态 destroy 是**两步**：vm 层先
+`stop_and_join_runtime(Forced)` **阻塞**等 vCPU 退出、`take_stopped_runtime` 清 runtime
+（vm/mod.rs:1442-1464），再调 `destroy_with`。`Stopping` 状态由 vm 层兜底（machine 层对
+`Stopping` 的 `destroy_with` 拒，:511-526）：`stop_and_join` 对 `Stopping` 直接 notify 并等
+vCPU 退出，不重复请求 stop。API 使用指南把这段概括为"`destroy()` 是阻塞操作，从运行态销毁会
+等待 vCPU 退出"（lifecycle.md §4）。
+
+**清理失败 → 停留 `Destroying`：** `destroy_with` 先 `replace(self, Machine::Destroying)` 再跑
+清理闭包（machine.rs:476）；若闭包 `f(Some(resources))?` 出错，直接返回 Err 且**不回滚**，machine
+停在 `Destroying`（resources 已被闭包消费）。此后 `status()` 可观测到 `Destroying`（§4），重试
+`destroy()` 走 `f(None)` 到 `Destroyed`（vm/mod.rs:1458-1463 + machine.rs:552-556）。
+
+**清理闭包 f 的契约：** `f` 接收 `Option<R>`（R 以值传入），无论返回 `Ok` 还是 `Err`，R 都在闭包
+返回时按 Rust drop 语义释放（`Err` 表示"释放过程中遇到问题"，不代表保留现场供重试）。因此重试
+`f(None)` 不传 resources 也不会泄漏——资源要么已释放、要么已在第一次调用中消费。
+
+**`stop_and_join_runtime(reason)` 集中描述**（vm/mod.rs:895-925；**全程不持有 machine 锁**，各子步
+单次取锁）：
+1. `status()` 分派：`Running`/`Paused` → `stop(reason)`（`request_stop_with` → `Stopping`）+
+   `notify_all`；`Stopping` → 直接 `notify_all`（幂等，不重复请求 stop）；`Stopped`/`Ready` →
+   跳过等待；其他（`Failed`/`Destroyed`/`Destroying`）→ `InvalidState`——正常路径不会到达：
+   `vm::destroy` 对 `Failed` 直接走 `take_stopped_runtime` + `destroy_with`（vm/mod.rs:1448-1451），
+   对 `Destroyed`/`Destroying` 直接跳过等待（:1453），均不经 `stop_and_join_runtime`。
+2. `wait_until_stopped()`（锁外，最多 10,000 次 `yield_now`，每次迭代 `status()` 单次取锁）。
+3. `take_stopped_runtime()`（单次取锁）→ 返回的 `Some(H)` 在锁外 `join_all_vcpu_tasks`。
+
+### 3.4 reset 的前置条件与 `Ready` 瞬态
+
+`reset_with`（machine.rs:392-470）同样**只接受** `Ready`（幂等，:398）与
+`Stopped { resources: Some, runtime: None }`（:403）；`Running`/`Paused`/`Stopping`/
+`Stopped { runtime: Some }` 一律 `InvalidTransition`（:412-458）。`Stopped { resources: None }`
+属类型级预留形态，落 `other` 兜底 → `InvalidTransition`（:460-469）。vm 层 `reset`
+（vm/mod.rs:929-940）对运行态先强制静默到 `Stopped`，再走 `reset_with` → `Ready` 内部瞬态 →
+prepare → `start`，所以外部视角 `reset()` 的终态是 `Running`（`Ready` 只是不可观测的中间态）。
+
+**start 与 reset（从 `Stopped` 出发）的实现层差别：** 两者都经 `prepare()` → `complete_vm_init`
+（prepare.rs:107-148）重建 vCPU/设备/中断结构并 `reset_transient_resources`（prepare.rs:125）。
+差别：`reset()` 额外多走一次 `reset_with`（→`Ready` 瞬态），其闭包显式调
+`reset_transient_resources`（vm/mod.rs:933-937）；`start()` 不经过 `Ready`，靠 `prepare()`
+内部的 `complete_vm_init` 完成同等重建（vm/mod.rs:784）。即 `reset` 路径
+`reset_transient_resources` 会执行两次（幂等）。幂等性由实现保证：每次调用都是**完全重建、非
+增量**——`devices.take()` 后重置（vm/mod.rs:407-411）、`address_space.clear()` 后按 `memory_regions`
+全量重映射（:412-428）、`vcpu_list`/`interrupt_fabric`/`address_layout` 置 `None`（:429-431）；
+重复调用等价于单次调用，不积累状态。外部视角二者都是 warm reboot——lifecycle.md §4
+已写明 start()-from-Stopped 同样"重新初始化 vCPU/设备/中断架构"、"重映射复用同一批 backing page"，
+两份文档一致（不存在"仅重建 runtime"的旧表述）。
+
+## 4. 不可观测状态与锁语义
+
+`Pausing` 与 `Switching` 在锁内、外部观测不到；`Destroying` 正常路径同样不可观测，但**清理闭包
+失败时会泄漏到锁外**（见下表 Destroying 行）。三者"不可观测"的原因各不相同：
+
+| 状态 | 为什么不可观测 | 源码 |
+|------|---------------|------|
+| `Pausing` | **预留态，无任何转换写入**：变体存在（machine.rs:12-15）但没有任何转换函数构造它；设计意图的 `Running → Pausing → Paused` 异步过渡**未实现**，当前 `pause` 是一步到 `Paused`（lifecycle.md §3 的 `Paused*` 注）。`status()` 仍显式映射 `VmStatus::Pausing`（machine.rs:41）。**结论：不可达的预留变体**——保留成本仅一个枚举项与两处匹配（machine.rs:12-15/:41），删除不改变任何可达转换。**调用者无需特殊处理**：外部代码观测不到 `Pausing`，断言状态时可用 `unreachable!()` 或 `_` 兜底 | machine.rs:12-15 |
+| `Switching` | **转换入口占位**：每个转换函数入口第一行都 `core::mem::replace(self, Machine::Switching)`（`start_with` :112、`pause` :171、`resume` :190、`stop_with` :212、`request_stop_with` :279、`finish_stop` :347、`reset_with` :396、`destroy_with` :476），执行期间锁一直被持有，`status()` 拿不到锁 → 不可观测。`Machine::status()` 对 `Switching` 的映射是**显式分支** `Switching => VmStatus::Failed`（machine.rs:48），不是 `_ =>` 兜底——这是有意的：万一 `Switching` 泄漏（持锁逻辑出错），外部只会看到 `failed` 而非崩溃。**设计权衡**：把不可观测占位映射为 `Failed`，使泄漏可被调用方当作"转换失败"识别；代价是调用方无法区分泄漏与真实失败 | machine.rs:112/:171/:190/:212/:279/:347/:396/:476；:48 |
+| `Destroying` | **destroy 入口瞬态**：`destroy_with` 第一行 `replace(self, Machine::Destroying)`（machine.rs:476），执行期间持锁、`status()` 不可观测；`destroy_with` 内也不调用 `status()`。**但清理闭包失败时不回滚**：`f(Some(resources))?` 出错即返回，machine 停在 `Destroying`（resources 已被闭包消费）——锁释放后 `status()` 可观测到 `Destroying`。这是三个"不可观测"态中**唯一可达的泄漏路径**：重试 `destroy()` 走 `f(None)` 到 `Destroyed`（machine.rs:552-556；对应 lifecycle.md §4 ②） | machine.rs:476、:483/:548/:553 |
+
+**锁语义：** `status()`（vm/mod.rs:621）与所有转换方法走**同一把 machine lock**——
+`Mutex<Machine<..>>`（vm/mod.rs:580，`ax_kspin::SpinNoIrq`），**不可重入**。因此
+"转换期间锁被持有 → `status()` 阻塞"是保证不可观测性的机制，不是巧合。这也意味着外部代码
+**只能观测到稳定态**（`Ready`/`Running`/`Paused`/`Stopping`/`Stopped`/`Destroyed`）、
+**确实失败后**的 `Failed`（machine.rs:120/:217 的闭包失败路径），以及 **destroy 清理失败后的
+`Destroying`**（machine.rs:483/:548/:553 的 `f()?` 出错路径）。转换方法的闭包内任何对
+`status()`/`resources()` 的再调用都会在同一锁上重入而死锁（§4.1 第 1 条）。
+
+`wait_until_stopped`（vm/mod.rs:873-893）在 machine 锁**外**执行：每次迭代 `status()` 单次取锁、
+其余时间 `yield_now`，锁不跨迭代持有——因此 `destroy()`/`reset()` 的等待期间，同一 VM 上其他
+task 调 `status()` 可正常返回 `Stopping`（与 lifecycle.md §4 一致）。`SpinNoIrq`
+（= `BaseSpinLock<NoPreemptIrqSave>`，ax_kspin/src/lib.rs:69）获取时**关本地中断并保存状态**
+（`local_irq_save_and_disable`，kernel_guard/src/lib.rs:177-192）、释放时恢复——持锁期间本地中断
+被屏蔽；转换函数与 `status()` 持锁均为短暂（`status()` **持锁后**为 O(1) match；获取锁的等待时间
+取决于当前持锁者的剩余执行时间，通常微秒级），对延迟敏感的设备中断影响有限。
+
+### 4.1 观测规则速查
+
+- 转换函数的闭包内部**不要**调 `status()`/`resources()`（死锁风险：同一锁重入）。
+- 外部代码断言状态时，只认 `VmStatus` 稳定态；`failed` 要么是 `Switching` 泄漏（bug），要么是
+  start/stop 初始化闭包失败（lifecycle.md §5）。
+- **`destroy()` 不会把 VM 移出 manager 注册表**（`AxVM::destroy` 只释放资源，vm/mod.rs:1442-1464；
+  注册表是 `src/manager.rs:27` 的 `VM_REGISTRY`）。`Destroyed` 后 VM 仍可被 `get_vm_by_id` 找到
+  （状态为 `Destroyed`）；须显式 `remove_vm(id)` 才移除（manager.rs:42-45 的 `remove_existing_vm`）。
+  因此 `Destroyed` 不是"句柄失效"信号——调用方应**主动 remove**，而不是假设 VM 已不可见。
+
+## 5. 状态转换规则表（逐条对照源码）
+
+API 使用指南（lifecycle.md §4）只给外部操作语义；此处给出每条转换在状态机层的实现与边界条件。
+**本表覆盖所有被调用过的转换组合，包括返回 `InvalidTransition` 的非法组合**（这些在 §2 图中无对应
+边，图中只画合法可达边）；保留非法组合作为完整性校验参考。
+
+| 转换 | 源码 | 语义 |
+|------|------|------|
+| `Ready → Running` | `start_with` machine.rs:108 | 同步、原子；无 "starting" 过渡态 |
+| `Stopped → Running` | 同上 :124 | 重启 runtime——vm 层 `prepare()` → `complete_vm_init`（prepare.rs:107-148）重建 vCPU/设备/中断结构并 `reset_transient_resources`（prepare.rs:125，RAM backing 保留），与 lifecycle.md §4 的 **warm reboot** 一致；vm 层先 `take_stopped_runtime`（vm/mod.rs:781）满足 `Stopped{runtime: None}` 前置 |
+| `Ready → Stopped` | `request_stop_with` :281 | 同步直达；`Stopped` = runtime 未运行，不表示曾运行过（未启动的 VM 可停止） |
+| `Running/Paused → Stopping` | `request_stop_with` :290 | 异步：只置标志即返回 |
+| `Stopping → Stopped` | `finish_stop` :346 | 由 vCPU 退出路径调用（vcpus.rs:359-371）。**判定机制**：`mark_vcpu_exiting()` 用 `running_halting_vcpu_count` 原子计数（vCPU 进入运行循环 `mark_vcpu_running` +1、退出 -1，vm/mod.rs:319-330），命中判定条件（`try_update` 结果为 `1`）的那个 vCPU 调 `finish_stop`；失败仅 `warn!`（vcpus.rs:362-364），vCPU 照常退出。该路径依赖 vCPU 真正执行到 VM-exit：若 vCPU task **非正常退出**（如 runtime 缺失，vcpus.rs:301-304）或永不 VM-exit（掩中断忙循环），`finish_stop` 不被调用 → **长期停留 Stopping**（wedged） |
+| `Stopping → start` | :158 | `InvalidTransition`，状态不变 |
+| `Stopping → resume` | :196 | `InvalidTransition`，状态不变 |
+| `Stopping → pause` | `machine::pause` :170 | `InvalidTransition`（`machine::pause` 只接受 `Running`，其余 `status()` 兜底拒） |
+| `Stopping → reset` | `reset_with` :412 | machine 层 `InvalidTransition`；vm 层 `reset` 会先经 `stop_and_join_runtime` 等 vCPU 退出到 `Stopped` 再继续（vm/mod.rs:931） |
+| `Stopping → destroy` | vm 层 :1445（machine 层 :511 拒） | `vm::destroy` 允许：对 Stopping 直接 notify + 等 vCPU 退出（stop_and_join）再销毁 |
+| `Stopping → request_stop` | :310 | 幂等成功（重复 stop 无害） |
+| `Stopped → request_stop` | :322 | 幂等成功（`Stopped` 上 stop 仍是 Ok） |
+| `Stopped → finish_stop` | :361 | 幂等成功（`finish_stop` 对 `Stopped` 直接 Ok） |
+| `Destroyed → destroy` | `destroy_with` :478 | 幂等成功（`destroy` 对 `Destroyed` 直接 Ok） |
+| `Running → Paused` | `machine::pause` :170 | 同步；**不 notify、也不主动 park** vCPU——vCPU 在下一次 VM-exit 看到 `suspending()` 后自行 `wait_for(!suspending)`（vcpus.rs:342-350）。锁语义：`vm::pause` 在整个 `suspend_lifecycle_devices()` + `machine.pause()` 期间持锁（vm/mod.rs:832-845），外部 `status()` 此时阻塞。这是**设计意图**——设备挂起与状态翻转原子化，避免 `Paused` 已可见但设备仍在 DMA 的窗口。代价：若设备挂起实现引入慢路径（如阻塞 I/O），持锁时间会从微秒级膨胀，阻塞同一 VM 上所有 `status()`/生命周期操作并屏蔽本地中断（§4）；若需把 `suspend_lifecycle_devices()` 移到锁外，须先处理挂起期间 `stop()`/`resume()` 并发的竞态 |
+| `Paused → Running` | `resume` :189 + `notify_all_vcpus`（runtime/mod.rs:106） | 唤醒 park 的 vCPU |
+| `Paused → Stopping` | `request_stop_with` :294 | 异步；`Paused` 只是状态机翻转，vCPU 可能尚未观察到 Paused（仍在 guest 代码中执行）——stop 仍需等 vCPU 在下一次 VM-exit 退出（wedged guest 则无限期） |
+| `* → destroy`（运行态） | `vm::destroy` vm/mod.rs:1442 | 先强制静默：`stop_and_join_runtime(Forced)` 阻塞等 vCPU 退出，再 destroy |
+| `Ready/Stopped(runtime:None)/Failed → Destroyed` | `destroy_with` machine.rs:472 | 直接销毁（`Stopped` 带 runtime 时拒绝，须先 `take_stopped_runtime`） |
+| `Ready/Stopped/运行态 → Running`（reset） | `vm::reset` vm/mod.rs:929；`reset_with` machine.rs:392 | 分步：运行态先强制静默(→Stopped) → `reset_with`(→Ready，仅接受 `Ready`/`Stopped{runtime:None}`，machine.rs:398/:403) → prepare → start(→Running)。`Failed`/`Destroyed` 不可 reset（machine.rs:460 兜底拒） |
+
+**finish_stop 的实现者契约（新增 vCPU 退出路径时核对）：** 任何 vCPU task 退出路径——正常
+VM-exit、异常退出、外部取消——都必须保证 `running_halting_vcpu_count` 正确递减，并且**恰好**让
+计数命中判定条件（`try_update` 结果为 `1`，vm/mod.rs:324-330）的那个 vCPU 调 `finish_stop`；
+计数漏减或无人触发都会让 machine 永久停留 `Stopping`（wedged）。当前已知的唯一未递减路径：runtime
+缺失时的 early return（vcpus.rs:301-304，此时 `mark_vcpu_running` 尚未 +1，对称地不递减是正确的）。
+新增路径若在 `mark_vcpu_running` 之后提前退出，必须补对称的 `mark_vcpu_exiting` + 判定，否则破坏
+上述契约。
+
+**stop_with 与 request_stop_with 的关系：** 两者都是 machine 层 stop 转换入口，但范围不同。
+`request_stop_with`（machine.rs:275）是**运行时实际使用的路径**（vm 层 `stop` 调它，vm/mod.rs:866），
+同时覆盖 `Ready → Stopped`（同步，:281）与 `Running`/`Pausing`/`Paused → Stopping`（异步，:290），
+并对 `Stopping`（:310）/`Stopped`（:322）幂等。`stop_with`（machine.rs:208）是**只支持
+`Ready → Stopped` 的同步变体**，当前**全 crate 无任何调用点**（仅定义，grep 无使用）；其价值仅是
+`Ready` 下与 `request_stop_with` 等价。实现者在 `Ready → Stopped` 与 `Running → Stopping` 两条路径上
+改动时，先确认改的是 `request_stop_with`。
+
+## 6. 外部接口文件对照与分层关系
+
+API 使用指南（lifecycle.md §3）只给方法名与状态图；此处是定位代码与理解分层的对照
+（路径前缀 `src/` = `virtualization/axvm/src/`）。
+
+| 公开方法 | 定义位置 |
+|---------|---------|
+| `AxVM::new` / `start` / `pause` / `resume` / `stop` / `reset` / `destroy` | `src/vm/mod.rs`（new :593, start :779, pause :832, resume :848, stop :864, reset :929, destroy :1442） |
+| `AxVM::status` / `running` / `stopping` / `suspending` / `stopped` | `src/vm/mod.rs`（status :621, running :812, stopping :817, suspending :822, stopped :827） |
+| `AxvmRuntime::start_vm` / `stop_vm` / `resume_vm` / `reset_vm` / `remove_vm` | `virtualization/axvm/src/manager.rs`（:149 / :154 / :159 / :164 / :169） |
+| `axvm::get_vm_list` / `get_vm_by_id` / `register_vm`（自由函数，非 `AxvmRuntime` 方法） | `src/manager.rs`（:53 / :48 / :175） |
+| `AxvmManager::create_vm_from_toml`（**AxVisor 侧**，TOML 编排入口） | `os/axvisor/src/manager.rs:45` |
+
+`create_vm_from_toml` 不属于 axvm，是 AxVisor 编排层的入口（os/axvisor/src/manager.rs:45），经
+`crate::config::init_guest_vm` 解析 TOML → `AxVM::new`（vm/mod.rs:593）+ 注册到 `VM_REGISTRY`。
+
+`running()`/`stopping()`/`suspending()`/`stopped()` 都是 `status()` 的**便捷谓词**，每次调用各取一次
+machine 锁：`running()` = `Running`（vm/mod.rs:812）、`stopping()` = `Stopping`（:817）、
+`suspending()` = `Pausing | Paused`（:822）、`stopped()` = `Stopped`（:827）。
+
+```mermaid
+graph LR
+    subgraph AX["AxVisor（编排层）"]
+        SH["shell 命令守卫<br/>shell/command/vm.rs"]
+        HTTP["HTTP 管理控制面<br/>（规划中）"]
+        AM["AxvmManager<br/>create_vm_from_toml :45 / start_vm… :50-74"]
+    end
+    subgraph EXT["axvm（对外 API 层）"]
+        RT["AxvmRuntime<br/>start_vm/stop_vm/resume_vm/reset_vm/remove_vm<br/>manager.rs:149-169"]
+        AXVM["AxVM<br/>start/pause/resume/stop/reset/destroy/status<br/>vm/mod.rs:779-1442"]
+    end
+    subgraph INT["axvm（内部实现）"]
+        M["Machine(R, H)<br/>start_with/request_stop_with/finish_stop/…<br/>lifecycle/machine.rs"]
+    end
+    SH --> AM
+    HTTP --> AM
+    AM -->|create_vm_from_toml（TOML 解析 → AxVM::new + 注册）| AXVM
+    AM -->|start_vm/stop_vm/… 委托| RT
+    RT -->|registry 持有 AxVMRef，委托调用其生命周期方法| AXVM
+    AXVM -->|状态转换（§2）| M
+```
+
+**分层要点（命名相近、层级不同的两组）：** `AxvmManager`（AxVisor 编排层）负责 TOML 解析、
+VM 注册与 shell/HTTP 等管理入口，并持有 `AxvmRuntime` 作为它调用 axvm 能力的句柄
+（os/axvisor/src/manager.rs:20-22）；`AxvmRuntime`（axvm 对外 API 层）提供基于 `VM_REGISTRY`
+的生命周期便捷封装（manager.rs:149-169），内部委托 `AxVM` 方法；`AxVM` 内部再走 `Machine`
+状态转换。即 **Manager 是"编排入口"，Runtime 是"API 封装"**——两者共享名字前缀但分属不同 crate，
+新增管理命令时先定位该命令落在哪一层（编排逻辑 → Manager，纯生命周期操作 → Runtime）。

--- a/virtualization/axvm/docs/lifecycle.md
+++ b/virtualization/axvm/docs/lifecycle.md
@@ -190,7 +190,11 @@ stateDiagram-v2
 
 ## 5. Error handling
 
-所有生命周期 API 均返回 `AxVmResult = Result<(), AxVmError>`。主要错误：
+会改变状态的**生命周期操作**（`start()` / `pause()` / `resume()` / `stop()` / `reset()` /
+`destroy()`）统一返回 `AxVmResult = Result<(), AxVmError>`：`Ok(())` 表示请求被接受（同步操作
+同时表示完成），`Err` 携带 `AxVmError`。**构造与查询 API 不适用此签名**：构造 `new(config) ->
+AxVmResult<AxVMRef>`（返回新建 VM 句柄）；查询 `status() -> VmStatus`、`running()`/`stopping()`/
+`stopped() -> bool`——查询不会失败，直接返回值。生命周期操作的主要错误：
 
 | 错误 | 含义 | 建议处理 |
 |------|------|---------|

--- a/virtualization/axvm/docs/lifecycle.md
+++ b/virtualization/axvm/docs/lifecycle.md
@@ -1,0 +1,318 @@
+# axvm VM 生命周期模型（API 使用指南）
+
+面向调用 axvm 公共 API 的 VMM 与控制面（shell 命令、HTTP 管理面、CLI、其他 VMM 等）。本文档
+回答一个问题：**调用某个生命周期方法后，状态如何变化、什么时候算完成**。只讲对外可观测的契约，
+不含实现细节。
+
+> **涉及文件**
+>
+> - `src/vm/mod.rs` —— `AxVM` 公共生命周期 API 的实现（`new`/`start`/`pause`/`resume`/`stop`/
+>   `reset`/`destroy`/`status`）。
+> - `src/lifecycle/status.rs` —— 对外枚举 `VmStatus` / `StopReason` 的定义。
+> - [lifecycle-internals.md](lifecycle-internals.md) —— 实现者视角：`Machine<R,H>` 状态机、转换
+>   方法、runtime 资源双维度、锁语义与源码级行号对照。
+
+## 1. Overview
+
+**axvm 的控制状态转换是同步的；部分操作涉及异步的执行面收敛。**
+
+- `start()` / `resume()`：**同步**，返回即完成状态转换。
+- `reset()` / `destroy()`：**同步阻塞**操作。成功返回时保证清理完成、达到目标状态；失败返回时
+  不保证（如停止等待超时返回 `AxVmError::InvalidState`，见 §4）。阻塞是**协作式等待**：调用 task 通过
+  `yield_now`/`join` **让出 CPU** 等 vCPU 退出，不忙等；但完成时机不固定（见 §4）。
+- `stop()` / `pause()`：**状态立即更新**（`Stopping`/`Paused`），但执行面收敛由运行中的 vCPU
+  异步完成，调用方无法预知何时生效。
+
+**状态是"请求已接受"的信号，不是"执行面已静默"的确认**：禁止中断并持续执行 guest loop 的 guest
+永不 VM-exit → 状态声称 `Paused`/`Stopping` 而 vCPU 实际仍在跑（wedged）。需要确认完成的操作
+（`stop()` 须轮询到 `Stopped`；`destroy()` 是阻塞调用，返回即见结果）依赖 vCPU 是否真正收敛。
+
+最典型的误用：把 `stop()` 的返回当成停止完成。`stop()` 返回只表示请求已接受（`Stopping`），
+`Stopped` 要等最后一个 vCPU 退出；wedged guest 可能让 `Stopping` 无限期停留。正确做法见 §7。
+
+## 2. VM states
+
+状态由 `AxVM::status()` 返回（`VmStatus`）。实际运行中只能观测到下列 8 个状态：7 个常规稳定态 + 1 个异常可观测态 `Destroying`（仅 `destroy()` 资源清理失败时出现，见 §4）。创建用
+`AxVM::new(config)`（→ `Ready`，见 §7）；`new()` 本身不注册到全局注册表，注册由 manager
+（`register_vm` / AxVisor 的 `create_vm_from_toml`）完成。
+
+| 状态 | 含义 |
+|------|------|
+| `Ready` | 已创建，尚未启动 |
+| `Running` | `start()` 已完成，VM 进入运行状态，可接受 `pause()`/`stop()`/`reset()`/`destroy()` 请求；**不保证 guest 已执行第一条指令** |
+| `Paused` | 暂停请求已接受（置暂停标志并挂起设备，vCPU 会停止执行 guest 等待 `resume`）；**不保证暂停已完成** |
+| `Stopping` | 停止请求已接受，执行面收敛中 |
+| `Stopped` | 所有 vCPU 已停止执行 guest（vCPU 运行循环已结束），VM 不再执行 guest；**VM 对象与资源（内存/vCPU 后端/设备）仍保留**（runtime 是否已回收是内部细节，API 不承诺），可通过 `start()`/`reset()`/`destroy()` 继续管理 |
+| `Destroying` | **异常可观测态**（仅 `destroy()` 资源清理失败时停留于此，见 §4）；重试 `destroy()` 可到 `Destroyed`，属可恢复 |
+| `Failed` | 生命周期进入失败状态，不能继续启动或恢复；需 `destroy()` 后重新创建 VM |
+| `Destroyed` | VM 已销毁，不能继续使用；重复 `destroy()` 幂等接受（返回成功、无副作用） |
+
+> `pausing` 是内部瞬态，正常完成时观测不到（瞬态发生在持锁期间，`status()` 须等锁释放，因此只
+> 返回释放后的稳定态）；`Destroying` 平时同是瞬态，但 `destroy()` 资源清理失败时会停留并变为可
+> 观测（见上表该行与 §4）。`Failed`/`Destroyed` 是**终态**；`Stopped` 是**静默态**（quiescent），
+> 不是终态——可 `start()`/`reset()` 恢复。
+>
+> `destroy()` 释放 VM 资源（→`Destroyed`），但**不从全局注册表移除**；`remove_vm(id)` 才移除
+> （此后 `get_vm_by_id(id)` 返回 `None`）。`remove_vm` 对不存在或已移除的 id 返回 `None`
+> （幂等，不报错）。`Destroyed` 状态的 VM 仍可通过 `get_vm_by_id` 查到。
+
+### 2.1 Allowed operations
+
+控制面校验请求时以本表为准；状态不满足转换条件时返回 `InvalidTransition`（§5），状态不变。
+
+| 状态 | 允许的操作 |
+|------|-----------|
+| `Ready` | `start()` / `stop()` / `reset()` / `destroy()` |
+| `Running` | `pause()` / `stop()` / `reset()` / `destroy()` |
+| `Paused` | `resume()` / `stop()` / `reset()` / `destroy()` |
+| `Stopping` | `destroy()`（强制删除路径，阻塞等待停止完成） / `reset()`（先等 stop 完成） |
+| `Stopped` | `start()` / `reset()` / `destroy()` |
+| `Destroying` | `destroy()`（重试；内部不再重复清理，§4） |
+| `Failed` | `destroy()` |
+| `Destroyed` | `destroy()`（幂等 no-op：重复调用返回 `Ok`、状态不变） |
+
+> 上表列出**控制面推荐使用路径**。从 `Stopping` 直接 `destroy()` 是支持的**强制删除路径**
+> （内部阻塞等待停止完成）；控制面也可先 `stop()` 轮询到 `Stopped` 再 `destroy()`。两种模式
+> 都合法（见 §4）。
+>
+> **重试安全（当前实现已验证，供重试逻辑参考）**：`stop()` 在 `Stopping`/`Stopped` 上重复调用
+> 返回 `Ok`（状态不变）。`destroy()` 在 `Destroyed` 上的幂等 no-op 已列主表。
+
+## 3. Lifecycle diagram
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> Ready: create()
+    Ready --> Running: start()
+    Ready --> Failed: start() 失败
+    Ready --> Stopped: stop()（同步直达）
+    Running --> Paused: pause()（请求）
+    Paused --> Running: resume()
+    Running --> Stopping: stop()（异步请求）
+    Paused --> Stopping: stop()
+    Stopping --> Stopped: （内部完成，等最后一个 vCPU 退出）
+    Ready --> Running: reset()
+    Running --> Running: reset()
+    Paused --> Running: reset()
+    Stopping --> Running: reset()
+    Stopped --> Running: start()
+    Stopped --> Running: reset()
+    Failed --> Destroyed: destroy()
+    Ready --> Destroyed: destroy()
+    Running --> Destroyed: destroy()
+    Paused --> Destroyed: destroy()
+    Stopping --> Destroyed: destroy()
+    Stopped --> Destroyed: destroy()
+    Destroying --> Destroyed: destroy() 重试
+    Destroyed --> [*]: remove_vm(id) 从注册表移除
+```
+
+文本版（不支持 mermaid 的阅读器）——状态转换一览（每个操作列出"从哪些状态出发 → 到哪个状态"）：
+
+```
+  create()          → Ready
+  start()           → Running    从 Ready / Stopped（同步）
+  pause()(请求)      → Paused     从 Running；状态立即更新，不保证 vCPU 已暂停
+  resume()          → Running    从 Paused（同步）
+  stop()(异步请求)   → Stopping   从 Running / Paused；须轮询 status() 到 Stopped
+  stop()(同步直达)   → Stopped    从 Ready
+  （内部完成）        → Stopped    Stopping 等最后一个 vCPU 退出后进入
+  start()（重启）    → Running    从 Stopped
+  reset()           → Running    从 Ready / Running / Paused / Stopping / Stopped（见 §4）
+  destroy()         → Destroyed  可从任何状态发起（含 Failed；成功时，失败返回错误，见 §4）
+  destroy()（重试）  → Destroyed  从 Destroying（资源清理失败后的异常可观测态，见 §4）
+```
+
+> `Paused*`：**仅状态机翻转，不保证 vCPU 已暂停**（*state transition only, vCPU quiescence not
+> guaranteed*）。图中 `destroy()` 边是**一步简写**：运行态实际先停止等待/清理再释放资源（见 §4），
+> 只表示**成功时**的最终结果；失败路径见 §4。`reset()` 边同理：从非 `Stopped` 状态发起时，内部
+> 先停止/清理旧状态再启动（见 §4）。
+
+## 4. Operation semantics
+
+| 操作 | 状态转换 | 完成语义 |
+|------|---------|---------|
+| `start()` | `Ready` / `Stopped` → `Running` | **同步**，返回即完成；失败：`Ready`→`Failed`，`Stopped`→保持 `Stopped` |
+| `stop()` | `Running` / `Paused` → `Stopping`（`Ready` → `Stopped` 直达） | 状态立即更新；执行面收敛**异步**，须轮询到 `Stopped`（从 `Ready` 直达：vCPU 从未运行，无需收敛） |
+| `pause()` | `Running` → `Paused` | 置暂停标志并挂起设备；vCPU 观察到后停止执行并等待 `resume`；**无确认 API** 保证暂停已完成（生效时机为 vCPU 下次 VM-exit，通常微秒级，取决于 guest 退出频率；掩中断忙循环的 guest 可能长时间不生效） |
+| `resume()` | `Paused` → `Running` | **同步**，返回即完成 |
+| `reset()` | `Ready` / `Running` / `Paused` / `Stopping` / `Stopped` → `Running`（内部经 `Ready` 瞬态） | **阻塞同步**：成功返回即完成清理与重启。失败分两类：停止等待超时 → 返回错误，VM **始终停留在 `Stopping`**（不回滚到原状态），可稍后重试；重建失败（`reset_transient_resources` 出错）→ 进入 `Failed`（`AxVMResources` 已在失败路径释放，VM 对象不可复用，`destroy()` 后重建）。从 `Stopping` 发起时，内部**先等本次 stop 完成**（`wait_until_stopped`）再重建，**不是取消 stop**，此时超时即本次 stop 等待超时（状态停留 `Stopping`）。`Failed`/`Destroyed` 不可 reset |
+| `destroy()` | 任何可销毁状态 → `Destroyed`（**成功时**） | **阻塞同步**：成功返回即资源释放完成；失败时返回错误，VM 停在 `Stopping`（等待超时）或 `Destroying`（清理失败），不进入 `Destroyed`（详见下方 bullet） |
+
+关键语义：
+
+- **`stop()` 是请求不是完成**：返回只表示"已接受"（`Stopping`），真正完成是最后一个 vCPU 退出时
+  （内部路径）。控制面轮询到 `Stopped` 可确认停止完成再 `destroy()`/重建；直接从 `Stopping`
+  调 `destroy()` 也允许（内部阻塞等待停止完成），但无法先确认停止是否成功。**重试安全**：在
+  `Stopping`/`Stopped` 上重复 `stop()` 返回 `Ok`（状态不变），轮询/重试逻辑无需特判。
+- **`pause()` 与 `stop()` 语义不同**：`stop()` 请求 vCPU 退出、最终有 `Stopped` 终态；`pause()`
+  置暂停标志并挂起设备，vCPU 观察到后停止执行并等待 `resume`，但**没有确认 API** 能证明暂停已
+  完成。若需确认（快照/迁移场景），当前无 API 手段，属已知限制——需 guest 侧协作或后续扩展。
+  **变通方案（部署层，非 axvm 契约）**：在 guest 内部署 agent，通过虚拟串口/PV 通道向控制面
+  带外上报"已暂停"事件，控制面结合该信号与本地 `status()` 综合判断。该方案仅适用于 vCPU 正常
+  退出但暂停确认延迟的场景；wedged guest（永不 VM-exit）连 agent 都无法执行，无法上报。
+  **两者观察机制相同**：暂停/停止标志都只在 vCPU 下次 VM-exit 时被观察到；通知仅唤醒正等待在
+  等待队列上的 vCPU（不注入 guest 中断）。因此掩中断的忙循环 guest（永不 VM-exit）对两者都
+  不可见——`Paused`/`Stopping` 只是状态机翻转，vCPU 实际仍在跑；`Paused` 下 `stop()` 同样
+  不能兜底这种 wedged vCPU（它依赖的也是 VM-exit）。
+- **`Stopped` 下 `start()` vs `reset()`**：两者都 `Stopped → Running`，且都会**重新初始化 vCPU/
+  设备/中断架构**——`start()` 从 `Stopped` 会调 `prepare()`（内部 `reset_transient_resources`
+  + 按配置重建 vCPU/设备/中断架构）；`reset()` 同样经 `prepare()` 重建，只是额外显式多一次
+  `reset_transient_resources` 并经 `Ready` 瞬态。**两者都不从上次执行点恢复 guest**。从
+  `Running`/`Paused`/`Stopping` 重启只能 `reset()`（`start()` 返回 `InvalidTransition`）。
+  **guest 视角**：无论 `start()`（从 `Stopped`）还是 `reset()`，guest 都从配置的启动入口重新
+  开始（warm reboot，非 resume）；物理内存内容保留（重映射复用同一批 backing page），vCPU
+  寄存器/设备/中断架构被重建/清除。**安全提示**：重启**不清零物理内存**——若 VM 将分配给不同
+  安全域/租户，调用者须在重启前自行清零或重新分配 backing page。
+- **`reset()` ≠ 直接 `Stopped → Running`**：它先清理旧状态，再重新启动（内部经 `Ready` 瞬态），
+  外部看起来是"一次调用 → `Running`"（`start()` 从 `Stopped` 同样先 `prepare()` 重建，但不经
+  `Ready` 瞬态，见上）。
+- **`StopReason`**：`Clean`（正常）/ `SystemDown`（系统关机）/ `Forced`（强制）/ `Fault(String)`
+  （故障）。reason 仅记录停止原因（存入 `Stopped`），**不改变停止机制**；控制面按语义选值。
+  `Fault` 的 `String` 为自由文本（错误描述），仅作记录。
+- **`destroy()` 从运行态不是一步 `Running → Destroyed`**：内部先停止再释放资源，**成功**返回即
+  资源释放完成。失败分两类，`status()` 返回值确定：**① 停止等待超时**（从 `Running`/`Paused`/
+  `Stopping` 发起）→ VM **始终停留在 `Stopping`**（不回滚到 `Running`/`Paused`），`status()`
+  返回 `Stopping`；`Stopping` 允许 `destroy()`，直接重试 `destroy()` 会再次发起强制停止。**② 资源
+  清理失败**（`cleanup_resource_set` 出错，从 `Ready`/`Stopped` 或等待完成后发起）→ 机器停留在
+  `Destroying` 且可观测，`status()` 返回 `Destroying`；重试 `destroy()` 仍可到 `Destroyed`（已
+  部分释放的资源不再重复清理）。阻塞是
+  **协作式等待**（`wait_until_stopped` 循环
+  `yield_now` + vCPU `task.join`），调用
+  task 让出 CPU 而非忙等，但**占用时间不固定**——依赖 vCPU 何时退出，无法预知何时返回。等待
+  期间**不持有生命周期锁**：同一 VM 上其他 task 调 `status()` 可正常返回当前状态（如
+  `Stopping`），不会被 `destroy()`/`reset()` 的等待阻塞（`status()` 只读、单次锁获取，§6）。等待有
+  上界：内部 `wait_until_stopped` 最多让出 10,000 次，超时返回错误（`AxVmError::InvalidState`，见 §5），因此 wedged
+  guest 会让 `destroy()` 长时间占用调用 task 甚至最终报错，而非无限卡死。**控制面实现
+  `destroy()` 时应避免同步等待**（如 HTTP `DELETE /vm/{id}`），包装为异步删除任务并配
+  timeout（§6）。
+
+## 5. Error handling
+
+所有生命周期 API 均返回 `AxVmResult = Result<(), AxVmError>`。主要错误：
+
+| 错误 | 含义 | 建议处理 |
+|------|------|---------|
+| `InvalidTransition` | 当前状态下不允许该操作（如在 `Running` 上 `start()`、非 `Paused` 上 `resume()`） | 状态不变；先查 `status()` 再重试 |
+| `ResourceUnavailable` / `OutOfMemory` | 资源不足 | 稍后重试 |
+| 转换初始化失败 | `start()`（从 `Ready`）或 `stop()`（从 `Ready`）的准备步骤失败；`reset()` 重建步骤失败 | 进入 `Failed`（不可恢复），`destroy()` 后重建 |
+| 停止等待超时 | `reset()`/`destroy()` 内部 `wait_until_stopped` 超时 | 返回 **`AxVmError::InvalidState`**（错误枚举无 `Timeout` 变体），**不进入目标状态**；VM 处于 `Stopping`（§4），可直接重试 |
+
+`Failed` 是终态，只能 `destroy()` 离开；当前无独立 API 查询失败原因（原因随错误返回值提供）。
+`start()` 从 `Stopped` 失败则保持 `Stopped`（可重试），不进入 `Failed`。
+
+并发请求到达时，状态不满足转换条件的一方会收到 `InvalidTransition`（状态不变）；生命周期 API
+**不保证并发调用顺序**，控制面应避免对同一 VM 同时发起多个生命周期操作（见 §6）。
+
+## 6. Controller guidelines
+
+控制面本质是**状态机客户端**：发起请求 → 轮询状态 → 等待终态 → 继续下一操作。
+
+```
+request operation（如 stop()）
+        │
+        ▼
+   poll status()（带 timeout）
+        │
+        ▼
+  等待终态（Stopped / Destroyed）
+        │
+        ▼
+   继续下一个操作
+```
+
+**轮询必须带 timeout**，否则 wedged guest 会让调用方死循环：
+
+```rust
+let deadline = Instant::now() + timeout;
+loop {
+    if vm.status() == VmStatus::Stopped { break; }
+    if Instant::now() >= deadline { return Err(Timeout); }
+    sleep(Duration::from_millis(10));
+}
+```
+
+**`status()` 是只读查询，线程安全**（内部一次锁获取 + O(1) 状态匹配，不遍历 vCPU，开销低），
+控制面可从多线程轮询，每 VM 每秒百次量级轮询可忽略，全局巡检频率不受它约束；但**生命周期操作**
+仍应串行化（见下）。状态查询只有 **VM 粒度**（无按 vCPU 查询的 API）；示例中的 10ms 轮询间隔
+是保守建议值，非硬性下限。`destroy()`/`reset()` 内部 `wait_until_stopped` 的 10,000 次让出
+是**硬编码活跃性上界**，不是时间保证——在核隔离的空闲核上单次 `yield_now` 为微秒级，10,000
+次通常远小于 1 秒；但若 vCPU 与等待 task 同核（未隔离），等待 task 无法调度（这正是核隔离的
+原因）。控制面**不要依赖该计数**，应设秒级 timeout（如 30–60s），超时后重试。
+
+**并发语义：** 生命周期 API 不保证并发调用顺序。控制面应避免对同一 VM 同时执行多个生命周期
+操作（如同时 `pause()` 与 `stop()`）；收到 `InvalidTransition` 表示状态不满足，应重新查询
+`status()` 后再决定。
+
+> **安全底线：** 并发调用是**内存安全**的——所有生命周期操作与 `status()` 共用 `AxVM.machine`
+> 内部 `Mutex` 串行化（`Mutex<Machine<..>>`），最坏结果是一方收到 `InvalidTransition`（状态
+> 不变），不会 panic、无未定义行为、不会损坏 VM 状态。因此控制面**不需要**额外锁来防 crash，
+> 只需在逻辑上处理 `InvalidTransition` 与超时。
+
+**竞态例子**：两个请求并发到达同一 VM——
+
+```
+T1: stop()   → Running → Stopping（请求接受）
+T2: start()  → InvalidTransition（Running 上 start 非法，状态不变）
+```
+
+生产控制面应串行化对同一 VM 的生命周期请求（如 per-VM 操作队列），避免依赖时序。
+
+**wedged guest 的恢复**：没有跳过 vCPU 等待的强制 API（资源释放依赖 vCPU 退出）。缓解（部署
+层面建议）：核隔离让僵死 vCPU 只烧自己的核、不阻塞管理面；`destroy()`/`stop()` 超时后可稍后
+重试。若 guest 永不恢复，vCPU 执行资源会滞留，需从 guest 侧治理（如加看门狗）。
+
+## 7. Examples
+
+轮询 stop（带 timeout）后再销毁：
+
+```rust
+let vm = get_vm_by_id(id).ok_or(VmGone)?;   // 从全局注册表取句柄（不存在 → 404）
+vm.stop()?;                                  // 请求停止 → Stopping
+
+let deadline = Instant::now() + timeout;
+loop {
+    match vm.status() {
+        VmStatus::Stopped => break,
+        VmStatus::Destroyed => return Err(VmGone),      // 其他路径已 destroy
+        VmStatus::Failed => return Err(VmFailed),       // 并发 reset 重建失败等
+        VmStatus::Destroying => return Err(VmDestroying), // 并发 destroy 清理失败；或改重试 destroy()
+        _ if Instant::now() >= deadline => return Err(Timeout),
+        _ => sleep(Duration::from_millis(10)),
+    }
+}
+
+vm.destroy()?;                // 阻塞；成功 → Destroyed，资源释放完成
+remove_vm(id);                // 从注册表移除（此后 get_vm_by_id(id) → None）
+```
+
+完整生命周期：
+
+```rust
+let vm = AxVM::new(config)?;      // Ready
+vm.start()?;                      // Running（同步）
+vm.pause()?;                      // Paused（状态立即更新；不保证 vCPU 已停）
+vm.resume()?;                     // Running（同步）
+vm.stop(StopReason::Clean)?;      // Stopping（请求；轮询到 Stopped，见上）
+vm.destroy()?;                    // Destroyed（阻塞，资源释放完成）
+```
+
+## 8. Contract summary
+
+对任何生命周期操作：
+
+1. **API 调用结果表示请求是否被接受**（同步操作同时表示完成；`stop()`/`pause()` 仅表示已接受）。
+2. **`status()` 表示生命周期状态**，调用后据此判断下一步。
+3. **状态语义 ≠ 操作完成语义**：
+   - `start()` / `resume()`：返回即完成 → `Running`
+   - `stop()`：完成是 `Stopped`（须轮询）；`Stopped` 是**静默态**，不是终态，可 `start()`/`reset()` 恢复
+   - `pause()`：无完成确认，vCPU 静默不可保证（同 `stop()`）
+   - `destroy()`：完成是成功返回 → `Destroyed`（终态）；失败返回不保证达到目标状态
+   - `Failed`：不可恢复错误态（终态）
+   `Stopping`/`Paused` 不代表执行面已静默；`Destroying` 是**异常可观测态**（destroy 清理失败），
+   重试 `destroy()` 可达 `Destroyed`。
+4. **控制面必须处理 timeout 与 `InvalidTransition`**（见 §5、§6）。
+
+> **行为基准：** 本文描述的契约以提交 `31f341abc`（dev 分支，2026-07-31）为准；源码级行号对照
+> 见 [lifecycle-internals.md](lifecycle-internals.md)。

--- a/virtualization/axvm/docs/lifecycle.md
+++ b/virtualization/axvm/docs/lifecycle.md
@@ -272,8 +272,10 @@ T2: start()  → InvalidTransition（Running 上 start 非法，状态不变）
 轮询 stop（带 timeout）后再销毁：
 
 ```rust
+use axvm::{AxvmRuntime, StopReason, VmStatus, get_vm_by_id};
+
 let vm = get_vm_by_id(id).ok_or(VmGone)?;   // 从全局注册表取句柄（不存在 → 404）
-vm.stop()?;                                  // 请求停止 → Stopping
+vm.stop(StopReason::Clean)?;                 // 请求停止 → Stopping
 
 let deadline = Instant::now() + timeout;
 loop {
@@ -288,12 +290,14 @@ loop {
 }
 
 vm.destroy()?;                // 阻塞；成功 → Destroyed，资源释放完成
-remove_vm(id);                // 从注册表移除（此后 get_vm_by_id(id) → None）
+AxvmRuntime::remove_vm(id);   // 从注册表移除（此后 get_vm_by_id(id) → None）
 ```
 
 完整生命周期：
 
 ```rust
+use axvm::{AxVM, StopReason};
+
 let vm = AxVM::new(config)?;      // Ready
 vm.start()?;                      // Running（同步）
 vm.pause()?;                      // Paused（状态立即更新；不保证 vCPU 已停）


### PR DESCRIPTION
## 问题

axvm 的 VM 生命周期状态机（Machine<R,H>、VmStatus 九态、stop/pause 请求语义）此前只有源码可读，
缺少面向调用方（VMM/控制面）与实现者的权威参考。同时 docs/docs/components/crates/axvm.md 概览
仍描述已废弃的 init()/boot()/run_vcpu() 旧模型，与当前 src/lifecycle/ 实现不符，可能误导实现者。
此外，lifecycle.md §5 原称"所有生命周期 API 均返回 AxVmResult = Result<()>"，与 AxVM::new 返回
AxVmResult<AxVMRef>、status() 返回 VmStatus、running()/stopping()/stopped() 返回 bool 的实际
签名不符，作为权威指南会误导控制面按错误签名接入；§7 控制面示例又遗漏 stop 必需的 StopReason
参数，照抄无法编译。

## 修改

- 新增 virtualization/axvm/docs/lifecycle.md：对外状态模型（九态 VmStatus、转换规则表、请求 vs
  完成语义、Stopped 静默态/重启、Failed/Destroyed 终态、暂停确认限制）。
  - §5 修正 API 返回类型契约：收窄到改变状态的操作（start/pause/resume/stop/reset/destroy 返回
    AxVmResult = Result<(), AxVmError>），并单列构造（new -> AxVmResult<AxVMRef>）与查询
    （status -> VmStatus、running/stopping/stopped -> bool）的返回类型，消除与源码签名不一致。
  - §7 控制面示例修正 API 调用：vm.stop(StopReason::Clean) 补齐 stop 必需的 StopReason 参数；
    remove_vm(id) 改为 AxvmRuntime::remove_vm(id)（lib.rs 根导出无该自由函数）；两个示例补齐
    axvm crate 根导出的 use 导入。
- 新增 virtualization/axvm/docs/lifecycle-internals.md：实现者视角——内部状态图、lifecycle ×
  runtime 双维度、runtime 生命周期、不可观测状态（Switching/Pausing/Destroying）与锁语义
  （SpinNoIrq 屏蔽本地中断、wait_until_stopped 锁外等）。
- virtualization/axvm/README.md / README_CN.md：增加两份文档的链接。
- docs/docs/components/crates/axvm.md：概览对齐新生命周期语义（九态、Machine/Runtime 双维度、
  start-from-Stopped 重建范围、stop 同步/异步双路径、prepare 三条子路径、重启覆盖要求等）。

## 每一步的逻辑

- 先写对外文档（lifecycle.md）再写实现者文档（lifecycle-internals.md）：对外文档是 API 契约，
  实现者文档解释契约背后的机制，避免实现细节泄漏到公共 API 描述。
- 概览文档只保留摘要并指向两份权威文档：crate 概览定位是"入口/索引"，完整状态图与行号对照
  集中在 docs/ 下，避免三处维护同义内容。
- 每一条声明均对照源码行号（machine.rs / vm/mod.rs / prepare.rs / vcpus.rs）验证后再写入，
  并在文档头标注基准提交 31f341abc，防止行号漂移误导。
- 修改概览文档时同步修正了与 lifecycle 文档矛盾的表述（Destroying 可观测泄漏、start() 重建
  中断架构等），保证两份文档语义一致。
- 修复 §5 返回类型总述：按 review 意见把范围收窄到会改变状态的操作，并单列构造与查询 API 的
  返回类型，避免权威指南中的签名与实际实现产生契约漂移。
- 修复 §7 示例：按 review 意见为 stop() 补必需参数，并把 manager 移除调用限定到实际路径
  （AxvmRuntime::remove_vm），导入均取自 axvm 根导出，保证照抄可编译。