### PR TITLE
fix(ax-task): preserve concurrent signal wakeups

### DIFF
--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -206,7 +206,8 @@ pub fn wait_existing_ptrace_stop_current(thr: &Thread, uctx: &mut UserContext) {
 }
 
 fn wait_ptrace_resume(thr: &Thread, tid: u32, uctx: &mut UserContext) {
-    current().clear_interrupt();
+    let stale_interrupts = current().interrupt_snapshot();
+    current().acknowledge_interrupt(stale_interrupts);
     let wait_result = block_on(interruptible(poll_fn(|cx| {
         if thr.proc_data.ptrace_stop_signo_for(tid).is_none() {
             Poll::Ready(())

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -316,8 +316,6 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                     // POSIX timers are also driven by the alarm task, but polling
                     // here closes the window where an expired timer is only noticed
                     // after the current syscall returns to userspace.
-                    poll_process_timer(thr.proc_data.proc.pid());
-
                     let eintr_code = -(ax_errno::LinuxError::EINTR.code() as isize);
                     let restart = if is_syscall
                         && (uctx.retval() as isize) == eintr_code
@@ -334,13 +332,28 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                     // whether to restart. Subsequent signals in the same
                     // loop must not re-apply the decision.
                     let mut pending_restart = restart.as_ref();
-                    while check_signals(thr, &mut uctx, None, pending_restart) {
-                        pending_restart = None;
+                    let mut poll_timer = true;
+                    loop {
+                        // Only acknowledge publications visible before this
+                        // return-to-userspace safe-point scan. A signal that
+                        // races after the snapshot remains pending and forces
+                        // another pass before an interruptible syscall parks.
+                        let interrupt_snapshot = curr.interrupt_snapshot();
+                        if poll_timer {
+                            poll_process_timer(thr.proc_data.proc.pid());
+                            poll_timer = false;
+                        }
+                        while check_signals(thr, &mut uctx, None, pending_restart) {
+                            pending_restart = None;
+                        }
+                        curr.acknowledge_interrupt(interrupt_snapshot);
+                        if !curr.interrupted() {
+                            break;
+                        }
                     }
                 }
 
                 set_timer_state(&curr, TimerState::User);
-                curr.clear_interrupt();
             }
         },
         name.into(),

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -23,6 +23,7 @@ pub use crate::task::{AxTaskExt, TaskExt};
 pub use crate::timers::register_timer_callback;
 #[cfg_attr(doc, doc(cfg(feature = "multitask")))]
 pub use crate::{
+    interrupt::InterruptSnapshot,
     task::{CurrentTask, TaskId, TaskInner, TaskState},
     wait_queue::WaitQueue,
 };

--- a/os/arceos/modules/axtask/src/interrupt.rs
+++ b/os/arceos/modules/axtask/src/interrupt.rs
@@ -1,0 +1,109 @@
+//! Task interruption publication state.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// A task interruption observation captured before an owner-side safe-point scan.
+///
+/// Obtain a snapshot through [`crate::TaskInner::interrupt_snapshot`] and pass it
+/// to [`crate::TaskInner::acknowledge_interrupt`] after that scan completes.
+#[derive(Debug, Clone, Copy)]
+pub struct InterruptSnapshot(u64);
+
+/// Sticky interruption publication shared by remote producers and one task.
+pub(crate) struct InterruptState {
+    published: AtomicU64,
+    acknowledged: AtomicU64,
+}
+
+impl InterruptState {
+    pub(crate) const fn new() -> Self {
+        Self {
+            published: AtomicU64::new(0),
+            acknowledged: AtomicU64::new(0),
+        }
+    }
+
+    /// Publishes the reason before the caller wakes the task.
+    pub(crate) fn publish(&self) {
+        self.published
+            .try_update(Ordering::Release, Ordering::Relaxed, |generation| {
+                generation.checked_add(1)
+            })
+            .expect("task interruption generation exhausted");
+    }
+
+    /// Consumes the interruption currently visible to an interruptible wait.
+    pub(crate) fn consume(&self) -> bool {
+        self.acknowledge(self.snapshot())
+    }
+
+    pub(crate) fn is_pending(&self) -> bool {
+        self.published.load(Ordering::Acquire) > self.acknowledged.load(Ordering::Acquire)
+    }
+
+    /// Captures the publications covered by the following owner-side scan.
+    pub(crate) fn snapshot(&self) -> InterruptSnapshot {
+        InterruptSnapshot(self.published.load(Ordering::Acquire))
+    }
+
+    /// Acknowledges the publications covered by `snapshot`.
+    ///
+    /// A later publication has a larger generation and remains pending, even
+    /// if it races with this acknowledgement.
+    pub(crate) fn acknowledge(&self, snapshot: InterruptSnapshot) -> bool {
+        let mut acknowledged = self.acknowledged.load(Ordering::Acquire);
+        while acknowledged < snapshot.0 {
+            match self.acknowledged.compare_exchange_weak(
+                acknowledged,
+                snapshot.0,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(current) => acknowledged = current,
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InterruptState;
+
+    #[test]
+    fn publication_after_snapshot_survives_acknowledgement() {
+        let state = InterruptState::new();
+        let scanned = state.snapshot();
+
+        state.publish();
+        let _advanced = state.acknowledge(scanned);
+
+        assert!(
+            state.is_pending(),
+            "acknowledging an older scan must not erase a later publication"
+        );
+    }
+
+    #[test]
+    fn snapshot_acknowledges_only_visible_publications() {
+        let state = InterruptState::new();
+        state.publish();
+
+        let scanned = state.snapshot();
+
+        assert!(state.acknowledge(scanned));
+        assert!(!state.is_pending());
+    }
+
+    #[test]
+    fn older_acknowledgement_cannot_regress_a_consumer() {
+        let state = InterruptState::new();
+        let old = state.snapshot();
+        state.publish();
+
+        assert!(state.consume());
+        assert!(!state.acknowledge(old));
+        assert!(!state.is_pending());
+    }
+}

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -69,6 +69,7 @@ cfg_if::cfg_if! {
 
         #[macro_use]
         mod run_queue;
+        mod interrupt;
         mod task;
         mod api;
         #[cfg(feature = "lockdep")]

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -33,7 +33,10 @@ use futures_util::task::AtomicWaker;
 
 #[cfg(feature = "lockdep")]
 use crate::lockdep::HeldLockStack;
-use crate::{AxCpuMask, AxTask, AxTaskRef, WaitQueue};
+use crate::{
+    AxCpuMask, AxTask, AxTaskRef, WaitQueue,
+    interrupt::{InterruptSnapshot, InterruptState},
+};
 
 #[cfg(target_pointer_width = "64")]
 const STACK_END_MAGIC: usize = 0x57AC_CE11_57AC_CE11usize;
@@ -129,7 +132,7 @@ pub struct TaskInner {
     #[cfg(feature = "preempt")]
     preempt_disable_count: AtomicUsize,
 
-    interrupted: AtomicBool,
+    interrupted: InterruptState,
     interrupt_waker: AtomicWaker,
 
     exit_code: AtomicI32,
@@ -322,25 +325,28 @@ impl TaskInner {
         // allow `interrupt()` to run and call `wake()` on an empty waker
         // slot — the wake is lost. Registering first closes the window.
         self.interrupt_waker.register(cx.waker());
-        if self.interrupted.swap(false, Ordering::AcqRel) {
+        if self.interrupted.consume() {
             Poll::Ready(())
         } else {
             Poll::Pending
         }
     }
 
-    /// Clears the interrupt state of the task.
+    /// Acknowledges all interruption publications visible at this call.
+    ///
+    /// Publications that race after the internal snapshot remain pending.
     #[inline]
     pub fn clear_interrupt(&self) {
-        self.interrupted.store(false, Ordering::Release);
+        let snapshot = self.interrupt_snapshot();
+        self.acknowledge_interrupt(snapshot);
     }
 
-    /// Atomically checks and clears the interrupt flag.
+    /// Consumes the interruption publications currently visible to this task.
     ///
     /// Returns `true` if the task was interrupted.
     #[inline]
     pub fn take_interrupt(&self) -> bool {
-        self.interrupted.swap(false, Ordering::AcqRel)
+        self.interrupted.consume()
     }
 
     /// Checks whether the task has been interrupted without clearing
@@ -351,14 +357,26 @@ impl TaskInner {
     /// consumers (e.g., an [`interruptible`] future wrapper).
     #[inline]
     pub fn interrupted(&self) -> bool {
-        self.interrupted.load(Ordering::Acquire)
+        self.interrupted.is_pending()
     }
 
     /// Interrupts the task.
     #[inline]
     pub fn interrupt(&self) {
-        self.interrupted.store(true, Ordering::Release);
+        self.interrupted.publish();
         self.interrupt_waker.wake();
+    }
+
+    /// Captures the interruption publications visible before a safe-point scan.
+    #[inline]
+    pub fn interrupt_snapshot(&self) -> InterruptSnapshot {
+        self.interrupted.snapshot()
+    }
+
+    /// Acknowledges the interruption publications covered by `snapshot`.
+    #[inline]
+    pub fn acknowledge_interrupt(&self, snapshot: InterruptSnapshot) {
+        self.interrupted.acknowledge(snapshot);
     }
 }
 
@@ -390,7 +408,7 @@ impl TaskInner {
             force_resched: AtomicBool::new(false),
             #[cfg(feature = "preempt")]
             preempt_disable_count: AtomicUsize::new(0),
-            interrupted: AtomicBool::new(false),
+            interrupted: InterruptState::new(),
             interrupt_waker: AtomicWaker::new(),
             exit_code: AtomicI32::new(0),
             wait_for_exit: WaitQueue::new(),


### PR DESCRIPTION
## 问题

[#1775](https://github.com/rcore-os/tgoskits/pull/1775) 中的 `1382af13fd4b6fe82540b35189e039cfcbf617ee` 修复了信号安全点与远端信号发布并发时的丢失唤醒。不过，当前 `dev` 已将中断状态迁入 `ax-task::TaskInner`，不能直接 cherry-pick 原先位于 Starry `Thread` 的实现。

现有布尔标志在本地扫描信号后执行无条件清零。若远端在扫描和清零之间发布新信号，清零会抹去唯一的唤醒理由；信号仍在 pending 队列中，但任务可能在下一次可中断等待永久休眠。

## 改动

- 在 `ax-task` 引入单调的发布/确认代次状态，并用不透明 `InterruptSnapshot` 传递安全点观察结果。
- `interrupt()` 先发布新代次再唤醒；消费或确认只能推进已确认代次，无法回退或确认快照之后的新发布。
- Starry 返回用户态前，先截取快照、检查定时器和信号、只确认该快照；若有更新的发布则再次扫描。
- Ptrace 等待开始前也改为确认一个快照，保留其后的并发信号。

## 设计与替代方案

状态归属选择 `ax-task`，因为 futures 的可中断等待和 Starry 信号生产者都通过同一个 `TaskInner` 标志协作；把代次状态重新放回 Starry `Thread` 会形成两个可能不同步的中断事实来源。

保留布尔标志或仅调整 `clear_interrupt()` 的位置都无法表达“本次扫描已经覆盖到哪个发布”，因而无法排除扫描后发布被清除的交错。代次协议只增加一个实际 Starry 调用方使用的快照令牌，字段保持私有。Linux 6.16 的 [`recalc_sigpending_tsk()` 和 `signal_wake_up_state()`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/signal.c?h=v6.16) 同样将 pending 状态重算与唤醒发布结合；本实现适配该不变量，不复制 Linux 的锁和线程标志布局。

非目标：不修改信号路由、EINTR/restart errno 或 ptrace 的用户态接口，只保证已有 pending 信号的唤醒不会在安全点丢失。

## 验证

| 风险/声明 | 验证 | 结果 |
| --- | --- | --- |
| 扫描后发布不能被确认抹去 | `cargo test -p ax-task --features "multitask host-test" publication_after_snapshot_survives_acknowledgement` | 旧布尔确认实现稳定失败；代次实现通过 |
| 代次确认与消费者单调性 | `cargo test -p ax-task --features "multitask host-test"` | 14 个单元测试和 1 个 doctest 通过 |
| `ax-task` feature 组合 | `cargo xtask clippy --package ax-task` | 17/17 通过 |
| Starry 调用方 feature 组合 | `cargo xtask clippy --package starry-kernel` | 25/25 通过 |
| Starry 信号 EINTR 冒烟 | `cargo xtask starry test qemu --arch riscv64 -c qemu/system/test-signal-interrupt-eintr` | 通过 |
