### PR TITLE
fix(ci): prevent stale dependency locks during release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -36,6 +36,9 @@ jobs:
         name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Preflight workspace packages
+        run: cargo publish --workspace --dry-run --no-verify
+
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -859,10 +859,9 @@ dependencies = [
 
 [[package]]
 name = "ax-errno"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c022cf0479c114aaf55acd23dedad5f0c7e4011142231e60e7a91f47cc070e6"
+version = "0.6.2"
 dependencies = [
+ "axtest",
  "log",
  "quote",
  "strum 0.27.2",
@@ -871,8 +870,9 @@ dependencies = [
 [[package]]
 name = "ax-errno"
 version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4b1d0b41dcb73f9abeca41dbd9b05357510caef74babf6cc23ce7b53ea06b56"
 dependencies = [
- "axtest",
  "log",
  "quote",
  "strum 0.27.2",
@@ -1375,7 +1375,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
@@ -1692,7 +1692,7 @@ dependencies = [
  "serde",
  "serde_repr",
  "thiserror 2.0.19",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -2036,9 +2036,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "camino"
-version = "1.2.4"
+version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f2d30e4173c4026932d51d31d6b0613b1fd3014bf3f9f8943d4ba139c437ba0"
+checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
 ]
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "clang-sys"
-version = "1.8.1"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
 dependencies = [
  "glob",
  "libc",
@@ -2199,9 +2199,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2209,9 +2209,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3036,13 +3036,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3455,12 +3455,6 @@ dependencies = [
  "bit-set",
  "regex",
 ]
-
-[[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
 name = "fastrand"
@@ -4033,9 +4027,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -4094,9 +4088,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -4460,9 +4454,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "irq-framework"
@@ -4613,7 +4607,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "unicode-width 0.2.2",
 ]
 
@@ -4744,7 +4738,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "939c71c68bfebd52de856c50f7650713e449fe8a83255e8cee53d8519500b5e0"
 dependencies = [
- "ax-errno 0.6.1",
+ "ax-errno 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 2.13.1",
  "int-enum",
  "lock_api",
@@ -4785,9 +4779,9 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.1.5"
+version = "4.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298a59b384c540e408a600c8b375a09b49c3f97debc080e2c30675d79a6368a"
+checksum = "72585bb6cc9bc370d1d545b7e23fcce71dfd4461c5e15275e3cf51bdfd9a980a"
 dependencies = [
  "apple-native-keyring-store",
  "keyring-core",
@@ -4821,7 +4815,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71b521b03673eb47aa8b7d70ff6709fabdc9243ee9e713cacc08f5b0ffae2c2"
 dependencies = [
- "ax-errno 0.6.1",
+ "ax-errno 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitfield-struct 0.13.0",
  "bitflags 2.13.1",
  "cfg-if",
@@ -5668,7 +5662,7 @@ dependencies = [
  "tokio-serial",
  "tokio-tungstenite",
  "tokio-util",
- "toml 1.1.3+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
  "uboot-shell",
  "ureq",
  "url",
@@ -5713,26 +5707,35 @@ dependencies = [
 
 [[package]]
 name = "palette"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
 dependencies = [
  "approx",
- "fast-srgb8",
  "libm",
  "palette_derive",
+ "palette_math",
 ]
 
 [[package]]
 name = "palette_derive"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
 dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -7213,9 +7216,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -8612,9 +8615,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.54"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1d5e639ff6bab73cb6885cc7e7b1de96c3f32c68ec55f3952614bec1092244"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
  "libc",
@@ -8714,13 +8717,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8792,9 +8795,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.3+spec-1.1.0"
+version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,3 +1,4 @@
 [workspace]
+dependencies_update = true
 publish_no_verify = true
 release_always = true


### PR DESCRIPTION
## 问题

Release-plz 在 [run 30783684744](https://github.com/rcore-os/tgoskits/actions/runs/30783684744/job/91603769561) 和最新的 [run 30788364101](https://github.com/rcore-os/tgoskits/actions/runs/30788364101/job/91606493652) 中持续失败。

发布 PR 将 workspace 内的 `ax-errno` 从 0.6.1 更新到 0.6.2，但默认的 release-plz 更新只运行 `cargo update --workspace`，因此 `Cargo.lock` 仍保留 crates.io 上的 `ax-errno 0.6.1`。打包 `starry-kernel` 时，`kbpf-basic 0.6.0` 锁定旧 registry 版本，而 `starry-kernel` 直接依赖 0.6.2，Cargo 无法统一解析。此前 release job 已经发布了部分 crate，之后才在 `starry-kernel` 处中止。

## 修改

- 在 release-plz workspace 配置中启用 `dependencies_update = true`，使后续 release PR 通过完整 `cargo update` 刷新 normal、build、dev 和传递依赖锁项。
- 使用 stable Cargo 完整更新 `Cargo.lock`；当前 registry `ax-errno` 已从 0.6.1 更新到 0.6.2，同时保留本地与 registry 来源的区分。
- 在 `release-plz release` action 前增加 `cargo publish --workspace --dry-run --no-verify`。任何 workspace crate 无法完成最终打包或 registry 依赖解析时，job 会在上传第一个 crate 前失败。

采用 release-plz 官方的完整依赖更新能力，避免为 `ax-errno` 或 `kbpf-basic` 维护一次性特判。发布 job 内的 preflight 与普通 CI 中已有的 workspace dry-run 保持相同语义，但通过严格的 step 顺序保证先验证、后上传。

## 验证

- Red：`cargo +stable publish --dry-run --no-verify --manifest-path os/StarryOS/kernel/Cargo.toml`
  - 修改前稳定失败，报 `kbpf-basic` 锁定 `ax-errno 0.6.1` 与直接依赖 0.6.2 冲突。
- Green：同一单包命令在锁文件更新后通过，`starry-kernel` 成功完成打包。
- `cargo +stable publish --workspace --dry-run --no-verify`
  - 全部可发布 workspace crate 完成打包，包括 `starry-kernel` 和 `starryos`；所有上传均由 dry-run 中止。
- `release-plz release --dry-run --no-verify --config release-plz.toml --forge github`
  - 配置解析、已发布包检查和 `starry-kernel` 模拟发布通过；随后 `starryos` 因 dry-run 不会真实上传刚模拟的 `starry-kernel 0.7.6` 而无法从 crates.io 找到该版本。这是多包顺序发布的 dry-run 限制，不是锁冲突回归。
- `cargo fmt --all -- --check`
- `cargo +stable metadata --locked --format-version=1 --no-deps`
- YAML 解析检查
- `git diff --check`

本次未修改 Rust crate，clippy 不适用。
