### PR TITLE
fix(axbuild): scope grouped prebuild to selected tests

### DIFF
--- a/scripts/axbuild/src/test/build/grouped_c.rs
+++ b/scripts/axbuild/src/test/build/grouped_c.rs
@@ -349,7 +349,10 @@ pub(super) fn prepare_grouped_c_subcases_sync(
                 ("phase", "prebuild".to_string()),
             ],
         );
-        let extra_script_envs = prepare_guest_package_env(config, &layout.staging_root)?;
+        let extra_script_envs = grouped_c_root_prebuild_env(
+            prepare_guest_package_env(config, &layout.staging_root)?,
+            subcases,
+        );
         let prebuild_env =
             prepare_guest_prebuild_env(arch, case, layout, extra_script_envs, config)?;
         let mut command = build_prebuild_command_with_work_dir(
@@ -525,6 +528,19 @@ pub(super) fn prepare_grouped_c_subcases_sync(
     print_slowest_grouped_c_subcases(case, subcase_timings);
 
     Ok(())
+}
+
+pub(super) fn grouped_c_root_prebuild_env(
+    mut env: Vec<(String, String)>,
+    subcases: &[&TestQemuSubcase],
+) -> Vec<(String, String)> {
+    let selected_subcases = subcases
+        .iter()
+        .map(|subcase| subcase.name.as_str())
+        .collect::<Vec<_>>()
+        .join(",");
+    env.push(("STARRY_GROUPED_C_SUBCASES".to_string(), selected_subcases));
+    env
 }
 
 pub(super) fn prepare_grouped_c_root_project_sync(

--- a/scripts/axbuild/src/test/build/tests.rs
+++ b/scripts/axbuild/src/test/build/tests.rs
@@ -368,6 +368,25 @@ fn grouped_c_root_configure_command_passes_selected_subcase_list() {
 }
 
 #[test]
+fn grouped_c_root_prebuild_env_exposes_selected_subcase_list() {
+    let root = tempdir().unwrap();
+    let case = fake_case(root.path(), "system");
+    let alpha = fake_c_subcase(root.path(), &case, "alpha", &["alpha"]);
+    let beta = fake_c_subcase(root.path(), &case, "beta-dir", &["beta"]);
+    let subcases = [&alpha, &beta];
+
+    let env = grouped_c_root_prebuild_env(
+        vec![("SUITE_PACKAGE_REGION".to_string(), "us".to_string())],
+        &subcases,
+    );
+
+    assert!(env.contains(&(
+        "STARRY_GROUPED_C_SUBCASES".to_string(),
+        "alpha,beta-dir".to_string(),
+    )));
+}
+
+#[test]
 fn cross_compile_spec_maps_supported_arches() {
     assert_eq!(
         cross_compile_spec("aarch64").unwrap(),

--- a/test-suit/starryos/qemu/system/prebuild.sh
+++ b/test-suit/starryos/qemu/system/prebuild.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 set -eu
 
-apk add curl
-test -x "$STARRY_STAGING_ROOT/usr/bin/curl"
+case ",${STARRY_GROUPED_C_SUBCASES:-}," in
+    *,apk-curl-equivalence,*)
+        apk add curl
+        test -x "$STARRY_STAGING_ROOT/usr/bin/curl"
+        ;;
+esac


### PR DESCRIPTION
## 问题

分组 C 测试只选择一个子用例时，根 `prebuild.sh` 仍会无条件安装 `curl`。这让不依赖
`curl` 的子用例也受该预构建步骤影响，扩大了测试选择与实际准备内容之间的范围。

## 修改

- 在分组 C 根预构建环境中传递 `STARRY_GROUPED_C_SUBCASES`。
- 仅当所选子用例包含 `apk-curl-equivalence` 时，`prebuild.sh` 才安装并检查 `curl`。
- 增加单元测试，覆盖已选子用例列表会传入预构建环境。

## 逻辑

预构建脚本只应准备本次实际执行的子用例所需依赖。构建层提供已选列表，脚本据此决定
是否安装 `curl`，从而保持分组测试的选择语义。

## 验证

- 拆分前在同一改动上运行 axbuild 的相关 QEMU 构建模块测试，33 个测试通过，包含新增回归。
- `git diff --check upstream/dev...HEAD` 通过。

## 来源

本 PR 从 `silicalet/tgoskits` 的 `004-add-starry-nixos` 分支拆出，并以
`rcore-os/tgoskits:dev` 为基线独立整理。
