### PR TITLE
fix(ax-fs-ng): skip metadata updates on read-only mounts

### DIFF
--- a/os/arceos/modules/axfs-ng/src/file/handle.rs
+++ b/os/arceos/modules/axfs-ng/src/file/handle.rs
@@ -383,10 +383,14 @@ impl FsPollable for File {
     }
 }
 
+fn needs_metadata_update_on_drop(location: &Location, access_flags: u8) -> bool {
+    access_flags != 0 && !location.is_readonly()
+}
+
 impl Drop for File {
     fn drop(&mut self) {
         let flags = self.access_flags.load(Ordering::Acquire);
-        if flags != 0 {
+        if needs_metadata_update_on_drop(self.inner.location(), flags) {
             let mut update = axfs_ng_vfs::MetadataUpdate::default();
             if flags & 1 != 0 {
                 update.atime = Some(crate::os::wall_time());
@@ -398,5 +402,146 @@ impl Drop for File {
                 warn!("Failed to update file times on drop: {err:?}");
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::sync::Arc;
+    use core::{any::Any, task::Context, time::Duration};
+
+    use axfs_ng_vfs::{
+        DeviceId, DirEntry, FileNode, FileNodeOps, Filesystem, FilesystemOps, FsIoEvents,
+        FsPollable, Metadata, MetadataUpdate, Mountpoint, NodeOps, NodePermission, NodeType,
+        Reference, StatFs,
+    };
+
+    use super::*;
+
+    struct ReadonlyTestFilesystem;
+
+    static READONLY_TEST_FILESYSTEM: ReadonlyTestFilesystem = ReadonlyTestFilesystem;
+
+    impl FilesystemOps for ReadonlyTestFilesystem {
+        fn name(&self) -> &str {
+            "readonly-file-drop-test"
+        }
+
+        fn is_readonly(&self) -> bool {
+            true
+        }
+
+        fn root_dir(&self) -> DirEntry {
+            test_entry(Arc::new(ReadonlyTestFile::new()))
+        }
+
+        fn stat(&self) -> VfsResult<StatFs> {
+            Err(VfsError::InvalidInput)
+        }
+    }
+
+    struct ReadonlyTestFile {}
+
+    impl ReadonlyTestFile {
+        const fn new() -> Self {
+            Self {}
+        }
+    }
+
+    impl NodeOps for ReadonlyTestFile {
+        fn inode(&self) -> u64 {
+            1
+        }
+
+        fn metadata(&self) -> VfsResult<Metadata> {
+            Ok(Metadata {
+                device: 1,
+                inode: self.inode(),
+                nlink: 1,
+                mode: NodePermission::default(),
+                node_type: NodeType::RegularFile,
+                uid: 0,
+                gid: 0,
+                size: 1,
+                block_size: 1,
+                blocks: 1,
+                rdev: DeviceId::default(),
+                atime: Duration::ZERO,
+                mtime: Duration::ZERO,
+                ctime: Duration::ZERO,
+            })
+        }
+
+        fn update_metadata(&self, _update: MetadataUpdate) -> VfsResult<()> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+
+        fn filesystem(&self) -> &dyn FilesystemOps {
+            &READONLY_TEST_FILESYSTEM
+        }
+
+        fn sync(&self, _data_only: bool) -> VfsResult<()> {
+            Ok(())
+        }
+
+        fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+            self
+        }
+
+        fn flags(&self) -> NodeFlags {
+            NodeFlags::empty()
+        }
+    }
+
+    impl FsPollable for ReadonlyTestFile {
+        fn poll(&self) -> FsIoEvents {
+            FsIoEvents::IN | FsIoEvents::OUT
+        }
+
+        fn register(&self, _context: &mut Context<'_>, _events: FsIoEvents) {}
+    }
+
+    impl FileNodeOps for ReadonlyTestFile {
+        fn read_at(&self, buf: &mut [u8], _offset: u64) -> VfsResult<usize> {
+            if let Some(byte) = buf.first_mut() {
+                *byte = 0;
+                Ok(1)
+            } else {
+                Ok(0)
+            }
+        }
+
+        fn write_at(&self, _buf: &[u8], _offset: u64) -> VfsResult<usize> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+
+        fn append(&self, _buf: &[u8]) -> VfsResult<(usize, u64)> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+
+        fn set_len(&self, _len: u64) -> VfsResult<()> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+
+        fn set_symlink(&self, _target: &str) -> VfsResult<()> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+    }
+
+    fn test_entry(node: Arc<ReadonlyTestFile>) -> DirEntry {
+        DirEntry::new_file(
+            FileNode::new(node),
+            NodeType::RegularFile,
+            Reference::root(),
+        )
+    }
+
+    #[test]
+    fn readonly_mount_skips_read_access_metadata_update() {
+        let filesystem = Filesystem::new(Arc::new(ReadonlyTestFilesystem));
+        let mountpoint = Mountpoint::new_root(&filesystem);
+        let location = Location::new(mountpoint, test_entry(Arc::new(ReadonlyTestFile::new())));
+
+        assert!(!needs_metadata_update_on_drop(&location, 1));
     }
 }

--- a/os/arceos/modules/axfs-ng/src/file/handle.rs
+++ b/os/arceos/modules/axfs-ng/src/file/handle.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use core::sync::atomic::AtomicUsize;
 use core::{
     sync::atomic::{AtomicU8, Ordering},
     task::Context,
@@ -387,10 +389,15 @@ fn needs_metadata_update_on_drop(location: &Location, access_flags: u8) -> bool 
     access_flags != 0 && !location.is_readonly()
 }
 
+#[cfg(test)]
+static DROP_METADATA_UPDATE_ATTEMPTS: AtomicUsize = AtomicUsize::new(0);
+
 impl Drop for File {
     fn drop(&mut self) {
         let flags = self.access_flags.load(Ordering::Acquire);
         if needs_metadata_update_on_drop(self.inner.location(), flags) {
+            #[cfg(test)]
+            DROP_METADATA_UPDATE_ATTEMPTS.fetch_add(1, Ordering::Relaxed);
             let mut update = axfs_ng_vfs::MetadataUpdate::default();
             if flags & 1 != 0 {
                 update.atime = Some(crate::os::wall_time());
@@ -408,7 +415,12 @@ impl Drop for File {
 #[cfg(test)]
 mod tests {
     use alloc::sync::Arc;
-    use core::{any::Any, task::Context, time::Duration};
+    use core::{
+        any::Any,
+        sync::atomic::{AtomicUsize, Ordering},
+        task::Context,
+        time::Duration,
+    };
 
     use axfs_ng_vfs::{
         DeviceId, DirEntry, FileNode, FileNodeOps, Filesystem, FilesystemOps, FsIoEvents,
@@ -418,21 +430,37 @@ mod tests {
 
     use super::*;
 
-    struct ReadonlyTestFilesystem;
+    struct TestFilesystem {
+        name: &'static str,
+        readonly: bool,
+    }
 
-    static READONLY_TEST_FILESYSTEM: ReadonlyTestFilesystem = ReadonlyTestFilesystem;
+    static READONLY_TEST_FILESYSTEM: TestFilesystem = TestFilesystem {
+        name: "readonly-file-drop-test",
+        readonly: true,
+    };
 
-    impl FilesystemOps for ReadonlyTestFilesystem {
+    static WRITABLE_TEST_FILESYSTEM: TestFilesystem = TestFilesystem {
+        name: "writable-file-drop-test",
+        readonly: false,
+    };
+
+    static DROP_METADATA_UPDATE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    impl FilesystemOps for TestFilesystem {
         fn name(&self) -> &str {
-            "readonly-file-drop-test"
+            self.name
         }
 
         fn is_readonly(&self) -> bool {
-            true
+            self.readonly
         }
 
         fn root_dir(&self) -> DirEntry {
-            test_entry(Arc::new(ReadonlyTestFile::new()))
+            test_entry(Arc::new(MetadataTrackingTestFile::new(
+                &READONLY_TEST_FILESYSTEM,
+                Arc::new(AtomicUsize::new(0)),
+            )))
         }
 
         fn stat(&self) -> VfsResult<StatFs> {
@@ -440,15 +468,21 @@ mod tests {
         }
     }
 
-    struct ReadonlyTestFile {}
+    struct MetadataTrackingTestFile {
+        filesystem: &'static dyn FilesystemOps,
+        metadata_updates: Arc<AtomicUsize>,
+    }
 
-    impl ReadonlyTestFile {
-        const fn new() -> Self {
-            Self {}
+    impl MetadataTrackingTestFile {
+        fn new(filesystem: &'static dyn FilesystemOps, metadata_updates: Arc<AtomicUsize>) -> Self {
+            Self {
+                filesystem,
+                metadata_updates,
+            }
         }
     }
 
-    impl NodeOps for ReadonlyTestFile {
+    impl NodeOps for MetadataTrackingTestFile {
         fn inode(&self) -> u64 {
             1
         }
@@ -473,11 +507,12 @@ mod tests {
         }
 
         fn update_metadata(&self, _update: MetadataUpdate) -> VfsResult<()> {
-            Err(VfsError::ReadOnlyFilesystem)
+            self.metadata_updates.fetch_add(1, Ordering::Relaxed);
+            Ok(())
         }
 
         fn filesystem(&self) -> &dyn FilesystemOps {
-            &READONLY_TEST_FILESYSTEM
+            self.filesystem
         }
 
         fn sync(&self, _data_only: bool) -> VfsResult<()> {
@@ -493,7 +528,7 @@ mod tests {
         }
     }
 
-    impl FsPollable for ReadonlyTestFile {
+    impl FsPollable for MetadataTrackingTestFile {
         fn poll(&self) -> FsIoEvents {
             FsIoEvents::IN | FsIoEvents::OUT
         }
@@ -501,9 +536,11 @@ mod tests {
         fn register(&self, _context: &mut Context<'_>, _events: FsIoEvents) {}
     }
 
-    impl FileNodeOps for ReadonlyTestFile {
-        fn read_at(&self, buf: &mut [u8], _offset: u64) -> VfsResult<usize> {
-            if let Some(byte) = buf.first_mut() {
+    impl FileNodeOps for MetadataTrackingTestFile {
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> VfsResult<usize> {
+            if offset == 0
+                && let Some(byte) = buf.first_mut()
+            {
                 *byte = 0;
                 Ok(1)
             } else {
@@ -528,7 +565,7 @@ mod tests {
         }
     }
 
-    fn test_entry(node: Arc<ReadonlyTestFile>) -> DirEntry {
+    fn test_entry(node: Arc<MetadataTrackingTestFile>) -> DirEntry {
         DirEntry::new_file(
             FileNode::new(node),
             NodeType::RegularFile,
@@ -536,12 +573,65 @@ mod tests {
         )
     }
 
-    #[test]
-    fn readonly_mount_skips_read_access_metadata_update() {
-        let filesystem = Filesystem::new(Arc::new(ReadonlyTestFilesystem));
-        let mountpoint = Mountpoint::new_root(&filesystem);
-        let location = Location::new(mountpoint, test_entry(Arc::new(ReadonlyTestFile::new())));
+    fn reset_drop_metadata_update_attempts() {
+        DROP_METADATA_UPDATE_ATTEMPTS.store(0, Ordering::Relaxed);
+    }
 
-        assert!(!needs_metadata_update_on_drop(&location, 1));
+    #[test]
+    fn readonly_file_drop_skips_metadata_update_after_read() {
+        let _guard = DROP_METADATA_UPDATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_drop_metadata_update_attempts();
+        let metadata_updates = Arc::new(AtomicUsize::new(0));
+        let filesystem = Filesystem::new(Arc::new(TestFilesystem {
+            name: "readonly-file-drop-test",
+            readonly: true,
+        }));
+        let mountpoint = Mountpoint::new_root(&filesystem);
+        let location = Location::new(
+            mountpoint,
+            test_entry(Arc::new(MetadataTrackingTestFile::new(
+                &READONLY_TEST_FILESYSTEM,
+                metadata_updates.clone(),
+            ))),
+        );
+
+        let file = File::new(FileBackend::new_direct(location), FileFlags::READ);
+        let mut byte = [0];
+        assert_eq!(file.read(&mut byte[..]).unwrap(), 1);
+        drop(file);
+
+        assert_eq!(metadata_updates.load(Ordering::Relaxed), 0);
+        assert_eq!(DROP_METADATA_UPDATE_ATTEMPTS.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn writable_file_drop_updates_metadata_after_read() {
+        let _guard = DROP_METADATA_UPDATE_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        reset_drop_metadata_update_attempts();
+        let metadata_updates = Arc::new(AtomicUsize::new(0));
+        let filesystem = Filesystem::new(Arc::new(TestFilesystem {
+            name: "writable-file-drop-test",
+            readonly: false,
+        }));
+        let mountpoint = Mountpoint::new_root(&filesystem);
+        let location = Location::new(
+            mountpoint,
+            test_entry(Arc::new(MetadataTrackingTestFile::new(
+                &WRITABLE_TEST_FILESYSTEM,
+                metadata_updates.clone(),
+            ))),
+        );
+
+        let file = File::new(FileBackend::new_direct(location), FileFlags::READ);
+        let mut byte = [0];
+        assert_eq!(file.read(&mut byte[..]).unwrap(), 1);
+        drop(file);
+
+        assert_eq!(metadata_updates.load(Ordering::Relaxed), 1);
+        assert_eq!(DROP_METADATA_UPDATE_ATTEMPTS.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
## 问题

只读挂载上的文件在读取后关闭时不应尝试更新 atime/mtime。原有回归只直接测试判断 helper，无法证明真实 `File` 的读取和销毁路径不会重新引入该写入尝试。

## 修改

- 保持销毁路径仅在存在访问标志且挂载可写时更新元数据。
- 用真实 `FileBackend::new_direct` 和 `File` 构造只读、可写文件，读取后显式 `drop`。
- 只读用例断言销毁路径没有进入元数据更新分支；可写对照用例断言该更新仍执行一次。

## 逻辑

读取只读挂载不应在句柄销毁阶段产生写入副作用。测试直接覆盖 `File::read` 到 `Drop` 的真实调用路径；测试构建中的计数仅用于观察销毁分支，生产构建不包含该状态。

## 验证

所有命令均在挂载 `.ci-cache` 的 Podman 容器内执行：

- 临时恢复旧条件 `flags != 0` 时，只读回归确定性失败（检测到一次元数据更新尝试）；恢复 `access_flags != 0 && !location.is_readonly()` 后通过。
- `cargo fmt --all --check`
- `cargo test -p ax-fs-ng file_drop_`：2 passed。
- `cargo xtask clippy --package ax-fs-ng`：6/6 passed。
- `git diff --check`

## 来源

本 PR 从 `silicalet/tgoskits` 的 `004-add-starry-nixos` 分支拆出，并以 `rcore-os/tgoskits:dev` 为基线独立整理。