### PR TITLE
test(starry): cover single-core timer preemption

### DIFF
--- a/test-suit/starryos/timer-preemption-x86/build-x86_64-unknown-none.toml
+++ b/test-suit/starryos/timer-preemption-x86/build-x86_64-unknown-none.toml
@@ -1,0 +1,12 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+  "ax-driver/virtio-gpu",
+  "ax-driver/virtio-input",
+  "ax-driver/virtio-socket",
+  "ax-driver/xhci-pci",
+  "starry-kernel/input",
+]
+max_cpu_num = 1

--- a/test-suit/starryos/timer-preemption-x86/c/CMakeLists.txt
+++ b/test-suit/starryos/timer-preemption-x86/c/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(timer-preemption-x86 C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(timer-preemption-x86 src/main.c)
+target_compile_options(timer-preemption-x86 PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS timer-preemption-x86 RUNTIME DESTINATION usr/bin)

--- a/test-suit/starryos/timer-preemption-x86/c/src/main.c
+++ b/test-suit/starryos/timer-preemption-x86/c/src/main.c
@@ -1,0 +1,210 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+enum {
+    CALIBRATION_SLEEP_NS = 25 * 1000 * 1000,
+    PARENT_SLEEP_NS = 100 * 1000 * 1000,
+    PARENT_WAKE_LIMIT_NS = 2 * 1000 * 1000 * 1000,
+    CHILD_SPIN_MULTIPLIER = 120,
+};
+
+static const uint64_t MIN_CHILD_SPIN_CYCLES = UINT64_C(8) * 1000 * 1000 * 1000;
+
+static uint64_t read_tsc(void)
+{
+    uint32_t low;
+    uint32_t high;
+
+    __asm__ volatile("lfence\n\trdtsc" : "=a"(low), "=d"(high) :: "memory");
+    return ((uint64_t)high << 32) | low;
+}
+
+static uint64_t monotonic_time_ns(void)
+{
+    struct timespec now;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return 0;
+    }
+    return (uint64_t)now.tv_sec * UINT64_C(1000000000) + (uint64_t)now.tv_nsec;
+}
+
+static int sleep_ns(long nanoseconds)
+{
+    const struct timespec requested = {
+        .tv_sec = nanoseconds / 1000000000L,
+        .tv_nsec = nanoseconds % 1000000000L,
+    };
+    struct timespec remaining = requested;
+
+    while (nanosleep(&remaining, &remaining) != 0) {
+        if (errno != EINTR) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static uint64_t calibrate_child_spin_cycles(void)
+{
+    const uint64_t started = read_tsc();
+
+    if (sleep_ns(CALIBRATION_SLEEP_NS) != 0) {
+        return 0;
+    }
+
+    const uint64_t elapsed_cycles = read_tsc() - started;
+    if (elapsed_cycles == 0) {
+        return 0;
+    }
+    if (elapsed_cycles > UINT64_MAX / CHILD_SPIN_MULTIPLIER) {
+        return UINT64_MAX;
+    }
+
+    const uint64_t calibrated_cycles = elapsed_cycles * CHILD_SPIN_MULTIPLIER;
+    return calibrated_cycles > MIN_CHILD_SPIN_CYCLES ? calibrated_cycles :
+                                                        MIN_CHILD_SPIN_CYCLES;
+}
+
+static int read_child_ready(int ready_fd)
+{
+    char ready = '\0';
+
+    for (;;) {
+        const ssize_t read_len = read(ready_fd, &ready, sizeof(ready));
+        if (read_len == 1) {
+            return ready == 'R' ? 0 : -1;
+        }
+        if (read_len == -1 && errno == EINTR) {
+            continue;
+        }
+        return -1;
+    }
+}
+
+static void spin_in_user_mode(uint64_t spin_cycles)
+{
+    const uint64_t deadline = read_tsc() + spin_cycles;
+
+    while ((int64_t)(read_tsc() - deadline) < 0) {
+        __asm__ volatile("pause" ::: "memory");
+    }
+}
+
+static int terminate_child(pid_t child)
+{
+    int status = 0;
+
+    if (kill(child, SIGKILL) != 0 && errno != ESRCH) {
+        return -1;
+    }
+
+    while (waitpid(child, &status, 0) != child) {
+        if (errno != EINTR) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int verify_nanosleep_wakes_while_child_spins(uint64_t spin_cycles)
+{
+    int ready_pipe[2] = {-1, -1};
+    pid_t child = -1;
+    int result = -1;
+
+    if (pipe(ready_pipe) != 0) {
+        perror("pipe");
+        return -1;
+    }
+
+    child = fork();
+    if (child < 0) {
+        perror("fork");
+        goto out;
+    }
+    if (child == 0) {
+        close(ready_pipe[0]);
+        if (write(ready_pipe[1], "R", 1) != 1) {
+            _exit(1);
+        }
+        close(ready_pipe[1]);
+        spin_in_user_mode(spin_cycles);
+        _exit(0);
+    }
+
+    close(ready_pipe[1]);
+    ready_pipe[1] = -1;
+    if (read_child_ready(ready_pipe[0]) != 0) {
+        fprintf(stderr, "FAIL: child did not enter its CPU-bound user loop\n");
+        goto out;
+    }
+    close(ready_pipe[0]);
+    ready_pipe[0] = -1;
+
+    const uint64_t started = monotonic_time_ns();
+    if (started == 0 || sleep_ns(PARENT_SLEEP_NS) != 0) {
+        perror("nanosleep");
+        goto out;
+    }
+    const uint64_t finished = monotonic_time_ns();
+    if (finished == 0 || finished < started) {
+        fprintf(stderr, "FAIL: CLOCK_MONOTONIC did not provide a valid sleep duration\n");
+        goto out;
+    }
+
+    const uint64_t elapsed_ns = finished - started;
+    if (elapsed_ns > PARENT_WAKE_LIMIT_NS) {
+        fprintf(stderr,
+                "FAIL: nanosleep parent woke after %" PRIu64
+                " ns while the same-CPU child was CPU-bound (limit=%d ns)\n",
+                elapsed_ns, PARENT_WAKE_LIMIT_NS);
+        goto out;
+    }
+
+    printf("PASS: nanosleep parent woke after %" PRIu64
+           " ns while the same-CPU child was CPU-bound\n",
+           elapsed_ns);
+    result = 0;
+
+out:
+    if (ready_pipe[0] >= 0) {
+        close(ready_pipe[0]);
+    }
+    if (ready_pipe[1] >= 0) {
+        close(ready_pipe[1]);
+    }
+    if (child > 0 && terminate_child(child) != 0) {
+        perror("terminate child");
+        result = -1;
+    }
+    return result;
+}
+
+int main(void)
+{
+    const uint64_t spin_cycles = calibrate_child_spin_cycles();
+    if (spin_cycles == 0) {
+        fprintf(stderr, "FAIL: unable to calibrate a finite x86 TSC spin budget\n");
+        printf("STARRY_TIMER_PREEMPTION_X86_FAILED\n");
+        return 1;
+    }
+
+    if (verify_nanosleep_wakes_while_child_spins(spin_cycles) != 0) {
+        printf("STARRY_TIMER_PREEMPTION_X86_FAILED\n");
+        return 1;
+    }
+
+    printf("STARRY_TIMER_PREEMPTION_X86_PASSED\n");
+    return 0;
+}

--- a/test-suit/starryos/timer-preemption-x86/c/src/main.c
+++ b/test-suit/starryos/timer-preemption-x86/c/src/main.c
@@ -120,12 +120,17 @@ static int terminate_child(pid_t child)
 static int verify_nanosleep_wakes_while_child_spins(uint64_t spin_cycles)
 {
     int ready_pipe[2] = {-1, -1};
+    int start_pipe[2] = {-1, -1};
     pid_t child = -1;
     int result = -1;
 
     if (pipe(ready_pipe) != 0) {
         perror("pipe");
         return -1;
+    }
+    if (pipe(start_pipe) != 0) {
+        perror("pipe");
+        goto out;
     }
 
     child = fork();
@@ -135,16 +140,23 @@ static int verify_nanosleep_wakes_while_child_spins(uint64_t spin_cycles)
     }
     if (child == 0) {
         close(ready_pipe[0]);
+        close(start_pipe[1]);
         if (write(ready_pipe[1], "R", 1) != 1) {
             _exit(1);
         }
         close(ready_pipe[1]);
+        if (read_child_ready(start_pipe[0]) != 0) {
+            _exit(1);
+        }
+        close(start_pipe[0]);
         spin_in_user_mode(spin_cycles);
         _exit(0);
     }
 
     close(ready_pipe[1]);
     ready_pipe[1] = -1;
+    close(start_pipe[0]);
+    start_pipe[0] = -1;
     if (read_child_ready(ready_pipe[0]) != 0) {
         fprintf(stderr, "FAIL: child did not enter its CPU-bound user loop\n");
         goto out;
@@ -153,10 +165,13 @@ static int verify_nanosleep_wakes_while_child_spins(uint64_t spin_cycles)
     ready_pipe[0] = -1;
 
     const uint64_t started = monotonic_time_ns();
-    if (started == 0 || sleep_ns(PARENT_SLEEP_NS) != 0) {
+    if (started == 0 || write(start_pipe[1], "R", 1) != 1 ||
+        sleep_ns(PARENT_SLEEP_NS) != 0) {
         perror("nanosleep");
         goto out;
     }
+    close(start_pipe[1]);
+    start_pipe[1] = -1;
     const uint64_t finished = monotonic_time_ns();
     if (finished == 0 || finished < started) {
         fprintf(stderr, "FAIL: CLOCK_MONOTONIC did not provide a valid sleep duration\n");
@@ -171,6 +186,12 @@ static int verify_nanosleep_wakes_while_child_spins(uint64_t spin_cycles)
                 elapsed_ns, PARENT_WAKE_LIMIT_NS);
         goto out;
     }
+    if (waitpid(child, NULL, WNOHANG) != 0) {
+        fprintf(stderr,
+                "FAIL: child stopped spinning before the parent woke; "
+                "timer preemption was not exercised\n");
+        goto out;
+    }
 
     printf("PASS: nanosleep parent woke after %" PRIu64
            " ns while the same-CPU child was CPU-bound\n",
@@ -183,6 +204,12 @@ out:
     }
     if (ready_pipe[1] >= 0) {
         close(ready_pipe[1]);
+    }
+    if (start_pipe[0] >= 0) {
+        close(start_pipe[0]);
+    }
+    if (start_pipe[1] >= 0) {
+        close(start_pipe[1]);
     }
     if (child > 0 && terminate_child(child) != 0) {
         perror("terminate child");

--- a/test-suit/starryos/timer-preemption-x86/qemu-x86_64.toml
+++ b/test-suit/starryos/timer-preemption-x86/qemu-x86_64.toml
@@ -1,0 +1,31 @@
+args = [
+  "-nographic",
+  "-cpu",
+  "Haswell,+avx",
+  "-m",
+  "512M",
+  "-device",
+  "nvme,serial=deadbeef,drive=nvm,max_ioqpairs=64,msix_qsize=65",
+  "-drive",
+  "id=nvm,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = '''
+/usr/bin/timer-preemption-x86
+status=$?
+if [ "$status" -eq 0 ]; then
+    echo STARRY_TIMER_PREEMPTION_X86_PASSED
+else
+    echo "STARRY_TIMER_PREEMPTION_X86_FAILED: status=$status"
+    exit "$status"
+fi
+'''
+success_regex = ["(?m)^STARRY_TIMER_PREEMPTION_X86_PASSED\\s*$"]
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?m)^lockdep fatal violation\\s*$",
+  "(?m)^STARRY_TIMER_PREEMPTION_X86_FAILED:",
+]
+timeout = 180


### PR DESCRIPTION
## 问题

单核 QEMU 场景中，需要持续验证：一个用户态 CPU 密集线程运行时，另一个因
`nanosleep` 阻塞的线程仍能由定时器抢占并及时唤醒。该行为直接覆盖定时器中断、
调度和用户态执行的协作。

## 修改与逻辑

- 新增 x86_64 单核 StarryOS QEMU 用例。
- 子进程先通过 ready pipe 声明已就绪，再阻塞在 start pipe；父进程只在记录
  `CLOCK_MONOTONIC` 起点后才释放子进程进入用户态忙等。
- 父进程完成 100 ms `nanosleep` 后以 `waitpid(..., WNOHANG)` 断言子进程仍在运行。
  这排除了子进程在计时前或睡眠期间提前退出而测试仍然成功的假阳性。
- 用例输出确定性成功/失败标记，供 QEMU 测试框架匹配。

## 验证

- `cargo fmt --all --check`
- `cc -std=c11 -Wall -Wextra -Werror -fsyntax-only test-suit/starryos/timer-preemption-x86/c/src/main.c`
- Podman + `.ci-cache`：`cargo xtask starry test qemu --arch x86_64 -c timer-preemption-x86`
  在单核 guest 中通过，并输出 `STARRY_TIMER_PREEMPTION_X86_PASSED`。

## 来源

本 PR 从 `silicalet/tgoskits` 的 `004-add-starry-nixos` 分支拆出，并以
`rcore-os/tgoskits:dev` 为基线独立整理。