### PR TITLE
fix(starry-procfs): parse oom score adjustments

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -1294,7 +1294,8 @@ impl SimpleDirOps for ThreadDir {
                         if !data.is_empty() {
                             let value = str::from_utf8(data)
                                 .ok()
-                                .and_then(|it| it.parse::<i32>().ok())
+                                .and_then(|it| it.trim_ascii_end().parse::<i32>().ok())
+                                .filter(|value| (-1000..=1000).contains(value))
                                 .ok_or(VfsError::InvalidInput)?;
                             task.as_thread().set_oom_score_adj(value);
                         }

--- a/test-suit/starryos/qemu/system/bugfix-oom-score-adj/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-oom-score-adj/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-oom-score-adj C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-oom-score-adj src/main.c)
+target_compile_options(bugfix-oom-score-adj PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bugfix-oom-score-adj RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-oom-score-adj/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-oom-score-adj/src/main.c
@@ -1,0 +1,93 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define OOM_SCORE_ADJ_PATH "/proc/self/oom_score_adj"
+
+static int failures;
+
+static void check(int condition, const char *message)
+{
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n", message, errno,
+            strerror(errno));
+    failures++;
+}
+
+static ssize_t write_oom_score_adj(const char *value)
+{
+    int fd = open(OOM_SCORE_ADJ_PATH, O_WRONLY);
+    if (fd < 0) {
+        return -1;
+    }
+
+    ssize_t result = write(fd, value, strlen(value));
+    int write_errno = errno;
+    close(fd);
+    errno = write_errno;
+    return result;
+}
+
+static int read_oom_score_adj(void)
+{
+    char buffer[32];
+    int fd = open(OOM_SCORE_ADJ_PATH, O_RDONLY);
+    if (fd < 0) {
+        return 2000;
+    }
+
+    ssize_t length = read(fd, buffer, sizeof(buffer) - 1);
+    int read_errno = errno;
+    close(fd);
+    errno = read_errno;
+    if (length <= 0) {
+        return 2000;
+    }
+
+    buffer[length] = '\0';
+    char *end = NULL;
+    long value = strtol(buffer, &end, 10);
+    if (end == buffer) {
+        errno = EINVAL;
+        return 2000;
+    }
+    return (int)value;
+}
+
+int main(void)
+{
+    const char adjusted[] = "-250\n";
+
+    errno = 0;
+    check(write_oom_score_adj(adjusted) == (ssize_t)(sizeof(adjusted) - 1),
+          "oom_score_adj accepts a newline-terminated signed value");
+
+    errno = 0;
+    check(read_oom_score_adj() == -250,
+          "oom_score_adj reports the adjusted value");
+
+    errno = 0;
+    check(write_oom_score_adj("1001") == -1 && errno == EINVAL,
+          "oom_score_adj rejects values above 1000");
+
+    errno = 0;
+    check(write_oom_score_adj("-1001") == -1 && errno == EINVAL,
+          "oom_score_adj rejects values below -1000");
+
+    if (failures != 0) {
+        fprintf(stderr, "STARRY_OOM_SCORE_ADJ_FAILED: %d checks\n", failures);
+        return 1;
+    }
+
+    puts("STARRY_OOM_SCORE_ADJ_PASSED");
+    return 0;
+}


### PR DESCRIPTION
## 问题

/proc 的 oom score adjustment 写入需要按 Linux 文本接口解析输入。

## 修改与逻辑

仅修正 procfs 对 oom score adjustment 的解析，并加入专用 QEMU 回归用例。

## 验证

- 保留对应的 StarryOS QEMU 回归测试。
- 拆分分支相对 `upstream/dev` 仅领先一个提交，且 `git diff --check` 通过。

## 来源

本 PR 从 `silicalet/tgoskits` 的 `004-add-starry-nixos` 分支拆出。