### PR TITLE
fix(starry-kernel): accept netlink reuse address

### DIFF
--- a/os/StarryOS/kernel/src/file/netlink.rs
+++ b/os/StarryOS/kernel/src/file/netlink.rs
@@ -238,6 +238,7 @@ struct NetlinkState {
     addr: Option<sockaddr_nl>,
     receive_buffer_size: usize,
     passcred: bool,
+    reuse_address: bool,
 }
 
 pub struct NetlinkSocket {
@@ -306,6 +307,14 @@ impl NetlinkSocket {
 
     pub fn set_passcred(&self, enabled: bool) {
         self.state.lock().passcred = enabled;
+    }
+
+    pub fn reuse_address(&self) -> bool {
+        self.state.lock().reuse_address
+    }
+
+    pub fn set_reuse_address(&self, enabled: bool) {
+        self.state.lock().reuse_address = enabled;
     }
 
     #[allow(dead_code)]

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -456,8 +456,8 @@ pub fn sys_setsockopt(
 
     if let Ok(socket) = NetlinkSocket::from_fd(fd) {
         use linux_raw_sys::net::{
-            SO_ATTACH_FILTER, SO_LOCK_FILTER, SO_PASSCRED, SO_RCVBUF, SO_RCVBUFFORCE, SO_SNDBUF,
-            SO_SNDBUFFORCE, SOL_SOCKET,
+            SO_ATTACH_FILTER, SO_LOCK_FILTER, SO_PASSCRED, SO_RCVBUF, SO_RCVBUFFORCE, SO_REUSEADDR,
+            SO_SNDBUF, SO_SNDBUFFORCE, SOL_SOCKET,
         };
 
         match (level, optname) {
@@ -480,6 +480,13 @@ pub fn sys_setsockopt(
             (SOL_SOCKET, SO_PASSCRED) => {
                 let value = read_int_sockopt(optval, optlen)?;
                 socket.set_passcred(value != 0);
+                return Ok(0);
+            }
+            (SOL_SOCKET, SO_REUSEADDR) => {
+                // Linux accepts this generic socket option before netlink
+                // bind. Netlink port and multicast-group binding in Starry
+                // does not use local-address reuse to resolve conflicts.
+                let _ = read_int_sockopt(optval, optlen)?;
                 return Ok(0);
             }
             _ => return Err(AxError::from(LinuxError::ENOPROTOOPT)),

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -335,6 +335,15 @@ pub fn sys_getsockopt(
         val.cast().get_as_mut()
     }
 
+    if let Ok(socket) = NetlinkSocket::from_fd(fd) {
+        use linux_raw_sys::net::{SO_REUSEADDR, SOL_SOCKET};
+
+        if (level, optname) == (SOL_SOCKET, SO_REUSEADDR) {
+            *get::<i32>(optval, optlen)? = i32::from(socket.reuse_address());
+            return Ok(0);
+        }
+    }
+
     let socket = Socket::from_fd(fd)?;
 
     // SO_TYPE is handled at the kernel level because the socket type is
@@ -486,7 +495,7 @@ pub fn sys_setsockopt(
                 // Linux accepts this generic socket option before netlink
                 // bind. Netlink port and multicast-group binding in Starry
                 // does not use local-address reuse to resolve conflicts.
-                let _ = read_int_sockopt(optval, optlen)?;
+                socket.set_reuse_address(read_int_sockopt(optval, optlen)? != 0);
                 return Ok(0);
             }
             _ => return Err(AxError::from(LinuxError::ENOPROTOOPT)),

--- a/test-suit/starryos/qemu/system/bugfix-netlink-uevent-reuseaddr/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-netlink-uevent-reuseaddr/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bugfix-netlink-uevent-reuseaddr C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-netlink-uevent-reuseaddr src/main.c)
+target_compile_options(bugfix-netlink-uevent-reuseaddr PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-netlink-uevent-reuseaddr RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-netlink-uevent-reuseaddr/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-netlink-uevent-reuseaddr/src/main.c
@@ -39,10 +39,34 @@ static void expect_zero(int result, const char *name)
     failed++;
 }
 
+static void expect_reuseaddr_enabled(int fd, const char *name)
+{
+    int enabled = 0;
+    socklen_t enabled_len = sizeof(enabled);
+
+    errno = 0;
+    int result = getsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enabled, &enabled_len);
+    if (result == 0 && enabled_len == sizeof(enabled) && enabled == 1) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+
+    printf("FAIL: %s: result=%d value=%d len=%u errno=%d (%s)\n",
+           name,
+           result,
+           enabled,
+           (unsigned int)enabled_len,
+           errno,
+           strerror(errno));
+    failed++;
+}
+
 static void check_netlink_listener(int protocol,
                                    unsigned int groups,
                                    const char *socket_name,
                                    const char *reuseaddr_name,
+                                   const char *reuseaddr_get_name,
                                    const char *bind_name)
 {
     errno = 0;
@@ -59,6 +83,7 @@ static void check_netlink_listener(int protocol,
     errno = 0;
     expect_zero(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enabled, sizeof(enabled)),
                 reuseaddr_name);
+    expect_reuseaddr_enabled(fd, reuseaddr_get_name);
 
     struct sockaddr_nl address = {
         .nl_family = AF_NETLINK,
@@ -77,11 +102,13 @@ int main(void)
                            0,
                            "create route netlink control socket",
                            "set SO_REUSEADDR on route netlink socket",
+                           "get SO_REUSEADDR from route netlink socket",
                            "bind route netlink socket");
     check_netlink_listener(NETLINK_KOBJECT_UEVENT,
                            1,
                            "create systemd-style uevent socket",
                            "set SO_REUSEADDR on uevent socket",
+                           "get SO_REUSEADDR from uevent socket",
                            "bind uevent multicast group 1");
 
     printf("=== Results: %d passed, %d failed ===\n", passed, failed);

--- a/test-suit/starryos/qemu/system/bugfix-netlink-uevent-reuseaddr/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-netlink-uevent-reuseaddr/src/main.c
@@ -1,0 +1,95 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#ifndef AF_NETLINK
+#define AF_NETLINK 16
+#endif
+#ifndef NETLINK_KOBJECT_UEVENT
+#define NETLINK_KOBJECT_UEVENT 15
+#endif
+#ifndef NETLINK_ROUTE
+#define NETLINK_ROUTE 0
+#endif
+
+struct sockaddr_nl {
+    unsigned short nl_family;
+    unsigned short nl_pad;
+    unsigned int nl_pid;
+    unsigned int nl_groups;
+};
+
+static int passed;
+static int failed;
+
+static void expect_zero(int result, const char *name)
+{
+    if (result == 0) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+    printf("FAIL: %s: result=%d errno=%d (%s)\n", name, result, errno, strerror(errno));
+    failed++;
+}
+
+static void check_netlink_listener(int protocol,
+                                   unsigned int groups,
+                                   const char *socket_name,
+                                   const char *reuseaddr_name,
+                                   const char *bind_name)
+{
+    errno = 0;
+    int fd = socket(AF_NETLINK, SOCK_RAW | SOCK_CLOEXEC | SOCK_NONBLOCK, protocol);
+    if (fd < 0) {
+        printf("FAIL: %s: errno=%d (%s)\n", socket_name, errno, strerror(errno));
+        failed++;
+        return;
+    }
+    printf("PASS: %s\n", socket_name);
+    passed++;
+
+    int enabled = 1;
+    errno = 0;
+    expect_zero(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enabled, sizeof(enabled)),
+                reuseaddr_name);
+
+    struct sockaddr_nl address = {
+        .nl_family = AF_NETLINK,
+        .nl_groups = groups,
+    };
+    errno = 0;
+    expect_zero(bind(fd, (struct sockaddr *)&address, sizeof(address)), bind_name);
+    close(fd);
+}
+
+int main(void)
+{
+    printf("=== bugfix-netlink-uevent-reuseaddr ===\n");
+
+    check_netlink_listener(NETLINK_ROUTE,
+                           0,
+                           "create route netlink control socket",
+                           "set SO_REUSEADDR on route netlink socket",
+                           "bind route netlink socket");
+    check_netlink_listener(NETLINK_KOBJECT_UEVENT,
+                           1,
+                           "create systemd-style uevent socket",
+                           "set SO_REUSEADDR on uevent socket",
+                           "bind uevent multicast group 1");
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_NETLINK_UEVENT_REUSEADDR_PASSED\n");
+        printf("STARRY_GROUPED_TEST_PASSED: bugfix-netlink-uevent-reuseaddr\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bugfix-netlink-uevent-reuseaddr\n");
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## 问题

`NETLINK_ROUTE` 与 `NETLINK_KOBJECT_UEVENT` socket 已接受 `SOL_SOCKET/SO_REUSEADDR`，但原实现丢弃了设置值，且 `getsockopt` 会落入普通 socket 路径并返回错误。Linux 会为 netlink socket 保留该通用选项状态。

## 修改与逻辑

- 在 `NetlinkSocket` 状态中保存 `SO_REUSEADDR` 的布尔值。
- 对 netlink 增加 `getsockopt(SOL_SOCKET, SO_REUSEADDR)`，返回保存的值。
- `setsockopt` 将非零值保存为启用状态。
- 回归用例分别覆盖 route 与 uevent netlink 的 set 后 get，再继续验证 bind 流程。

## 验证

- Podman + `.ci-cache`：`cargo xtask starry test qemu --arch x86_64 -c qemu/bugfix-netlink-uevent-reuseaddr`，8 passed，0 failed。
- Podman + `.ci-cache`：`cargo xtask clippy --package starry-kernel`，25/25 组合通过。
- 旧 CI 的 RISC-V QEMU 失败发生在既有 `test-proc-status-tracerpid`，1800 秒超时，与本 PR 的 netlink 路径无关。

## 来源

本 PR 从 `silicalet/tgoskits` 的 `004-add-starry-nixos` 分支拆出。