### PR TITLE
fix(starry-kernel): expose UTS hostname proc sysctl

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -1830,6 +1830,27 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
                 "ostype",
                 SimpleFile::new_regular(fs.clone(), || Ok("Linux\n")),
             );
+            kernel.add(
+                "hostname",
+                SimpleFile::new_regular(fs.clone(), || {
+                    let nodename = {
+                        let task = current();
+                        let nsproxy = task.as_thread().proc_data.nsproxy.lock();
+                        let uts_namespace = nsproxy.uts_ns.lock();
+                        uts_namespace.nodename
+                    };
+                    let name_len = nodename
+                        .iter()
+                        .position(|&byte| byte == 0)
+                        .unwrap_or(nodename.len());
+                    let mut output = Vec::with_capacity(name_len + 1);
+                    for byte in &nodename[..name_len] {
+                        output.push(byte.to_ne_bytes()[0]);
+                    }
+                    output.push(b'\n');
+                    Ok(output)
+                }),
+            );
 
             // perf knobs the upstream Linux `perf` tool probes at startup.
             // `perf_event_paranoid` gates how much unprivileged users may

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -1832,24 +1832,55 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
             );
             kernel.add(
                 "hostname",
-                SimpleFile::new_regular(fs.clone(), || {
-                    let nodename = {
-                        let task = current();
-                        let nsproxy = task.as_thread().proc_data.nsproxy.lock();
-                        let uts_namespace = nsproxy.uts_ns.lock();
-                        uts_namespace.nodename
-                    };
-                    let name_len = nodename
-                        .iter()
-                        .position(|&byte| byte == 0)
-                        .unwrap_or(nodename.len());
-                    let mut output = Vec::with_capacity(name_len + 1);
-                    for byte in &nodename[..name_len] {
-                        output.push(byte.to_ne_bytes()[0]);
-                    }
-                    output.push(b'\n');
-                    Ok(output)
-                }),
+                SimpleFile::new_regular(
+                    fs.clone(),
+                    RwFile::new(move |req| match req {
+                        SimpleFileOperation::Read => {
+                            let nodename = {
+                                let task = current();
+                                let nsproxy = task.as_thread().proc_data.nsproxy.lock();
+                                let uts_namespace = nsproxy.uts_ns.lock();
+                                uts_namespace.nodename
+                            };
+                            let name_len = nodename
+                                .iter()
+                                .position(|&byte| byte == 0)
+                                .unwrap_or(nodename.len());
+                            let mut output = Vec::with_capacity(name_len + 1);
+                            output.extend(
+                                nodename[..name_len]
+                                    .iter()
+                                    .map(|byte| byte.to_ne_bytes()[0]),
+                            );
+                            output.push(b'\n');
+                            Ok(Some(output))
+                        }
+                        SimpleFileOperation::Write(data) => {
+                            if data.is_empty() {
+                                return Ok(None);
+                            }
+                            let hostname = data.strip_suffix(b"\n").unwrap_or(data);
+                            if hostname.len() > 64
+                                || hostname.iter().any(|byte| matches!(byte, 0 | b'\n'))
+                            {
+                                return Err(VfsError::InvalidInput);
+                            }
+
+                            if current().as_thread().cred().euid != 0 {
+                                return Err(VfsError::OperationNotPermitted);
+                            }
+
+                            let mut nodename = [0; 65];
+                            for (slot, byte) in nodename.iter_mut().zip(hostname) {
+                                *slot = *byte as _;
+                            }
+                            let task = current();
+                            let nsproxy = task.as_thread().proc_data.nsproxy.lock();
+                            nsproxy.uts_ns.lock().nodename = nodename;
+                            Ok(None)
+                        }
+                    }),
+                ),
             );
 
             // perf knobs the upstream Linux `perf` tool probes at startup.

--- a/test-suit/starryos/qemu/system/bugfix-proc-sys-kernel-hostname/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-proc-sys-kernel-hostname/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bugfix-proc-sys-kernel-hostname C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-proc-sys-kernel-hostname src/main.c)
+target_compile_options(bugfix-proc-sys-kernel-hostname PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-proc-sys-kernel-hostname RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-proc-sys-kernel-hostname/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-proc-sys-kernel-hostname/src/main.c
@@ -25,7 +25,10 @@ static void expect_true(int condition, const char *name)
 
 int main(void)
 {
+    const char updated_hostname[] = "starry-proc-hostname";
     char hostname[65] = {0};
+    char original_hostname[65] = {0};
+    size_t original_hostname_len = 0;
     struct utsname uts;
     char content[128] = {0};
 
@@ -58,6 +61,11 @@ int main(void)
                         "hostname sysctl equals current hostname plus newline");
             expect_true(memchr(content, '\0', (size_t)count) == NULL,
                         "hostname sysctl has no NUL padding");
+            if ((size_t)count <= sizeof(original_hostname) &&
+                content[count - 1] == '\n') {
+                original_hostname_len = (size_t)count - 1;
+                memcpy(original_hostname, content, original_hostname_len);
+            }
         }
 
         char extra;
@@ -73,6 +81,69 @@ int main(void)
                         content[strlen(hostname)] == '\n',
                     "hostname sysctl repeats the same UTS value");
         close(fd);
+    }
+
+    char update_request[sizeof(updated_hostname) + 1];
+    snprintf(update_request, sizeof(update_request), "%s\n", updated_hostname);
+    errno = 0;
+    fd = open("/proc/sys/kernel/hostname", O_WRONLY | O_CLOEXEC);
+    expect_true(fd >= 0, "open hostname sysctl for writing");
+    if (fd >= 0) {
+        ssize_t written = write(fd, update_request, strlen(update_request));
+        expect_true(written == (ssize_t)strlen(update_request),
+                    "write hostname sysctl with trailing newline");
+        close(fd);
+
+        if (written == (ssize_t)strlen(update_request)) {
+            memset(hostname, 0, sizeof(hostname));
+            expect_true(gethostname(hostname, sizeof(hostname)) == 0,
+                        "gethostname after proc sysctl write");
+            expect_true(strcmp(hostname, updated_hostname) == 0,
+                        "proc sysctl write updates gethostname");
+
+            memset(&uts, 0, sizeof(uts));
+            expect_true(uname(&uts) == 0, "uname after proc sysctl write");
+            expect_true(strcmp(uts.nodename, updated_hostname) == 0,
+                        "proc sysctl write updates uname nodename");
+
+            fd = open("/proc/sys/kernel/hostname", O_RDONLY | O_CLOEXEC);
+            expect_true(fd >= 0, "reopen hostname sysctl after write");
+            if (fd >= 0) {
+                memset(content, 0, sizeof(content));
+                ssize_t count = read(fd, content, sizeof(content));
+                expect_true(count == (ssize_t)strlen(updated_hostname) + 1,
+                            "read updated hostname sysctl");
+                expect_true(memcmp(content, updated_hostname,
+                                   strlen(updated_hostname)) == 0 &&
+                                content[strlen(updated_hostname)] == '\n',
+                            "hostname sysctl readback matches updated UTS value");
+                close(fd);
+            }
+        }
+    }
+
+    char oversized_hostname[67];
+    memset(oversized_hostname, 'a', 65);
+    oversized_hostname[65] = '\n';
+    oversized_hostname[66] = '\0';
+    errno = 0;
+    fd = open("/proc/sys/kernel/hostname", O_WRONLY | O_CLOEXEC);
+    expect_true(fd >= 0, "open hostname sysctl for oversized write");
+    if (fd >= 0) {
+        expect_true(write(fd, oversized_hostname, 66) == -1 && errno == EINVAL,
+                    "hostname sysctl rejects names longer than 64 bytes");
+        close(fd);
+    }
+
+    fd = open("/proc/sys/kernel/hostname", O_WRONLY | O_CLOEXEC);
+    if (fd >= 0) {
+        ssize_t restored =
+            write(fd, original_hostname, original_hostname_len);
+        expect_true(restored == (ssize_t)original_hostname_len,
+                    "restore original hostname");
+        close(fd);
+    } else {
+        expect_true(0, "open hostname sysctl to restore original hostname");
     }
 
     printf("=== Results: %d passed, %d failed ===\n", passed, failed);

--- a/test-suit/starryos/qemu/system/bugfix-proc-sys-kernel-hostname/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-proc-sys-kernel-hostname/src/main.c
@@ -1,0 +1,86 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void expect_true(int condition, const char *name)
+{
+    if (condition) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+    printf("FAIL: %s: errno=%d (%s)\n", name, errno, strerror(errno));
+    failed++;
+}
+
+int main(void)
+{
+    char hostname[65] = {0};
+    struct utsname uts;
+    char content[128] = {0};
+
+    printf("=== bugfix-proc-sys-kernel-hostname ===\n");
+
+    errno = 0;
+    expect_true(gethostname(hostname, sizeof(hostname)) == 0,
+                "gethostname succeeds");
+    expect_true(uname(&uts) == 0, "uname succeeds");
+    expect_true(strcmp(hostname, uts.nodename) == 0,
+                "gethostname matches uname nodename");
+
+    errno = 0;
+    int fd = open("/proc/sys/kernel/hostname", O_RDONLY | O_CLOEXEC);
+    expect_true(fd >= 0, "open /proc/sys/kernel/hostname");
+    if (fd >= 0) {
+        struct stat st;
+        expect_true(fstat(fd, &st) == 0 && S_ISREG(st.st_mode),
+                    "hostname sysctl is a regular file");
+
+        errno = 0;
+        ssize_t count = read(fd, content, sizeof(content));
+        expect_true(count > 0, "read hostname sysctl");
+        if (count > 0) {
+            size_t hostname_len = strlen(hostname);
+            expect_true((size_t)count == hostname_len + 1,
+                        "hostname sysctl has exact length");
+            expect_true(memcmp(content, hostname, hostname_len) == 0 &&
+                            content[hostname_len] == '\n',
+                        "hostname sysctl equals current hostname plus newline");
+            expect_true(memchr(content, '\0', (size_t)count) == NULL,
+                        "hostname sysctl has no NUL padding");
+        }
+
+        char extra;
+        expect_true(read(fd, &extra, 1) == 0,
+                    "hostname sysctl reaches EOF");
+        expect_true(lseek(fd, 0, SEEK_SET) == 0,
+                    "hostname sysctl seeks to start");
+        memset(content, 0, sizeof(content));
+        ssize_t repeated = read(fd, content, sizeof(content));
+        expect_true(repeated > 0 &&
+                        (size_t)repeated == strlen(hostname) + 1 &&
+                        memcmp(content, hostname, strlen(hostname)) == 0 &&
+                        content[strlen(hostname)] == '\n',
+                    "hostname sysctl repeats the same UTS value");
+        close(fd);
+    }
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_PROC_SYS_HOSTNAME_PASSED\n");
+        printf("STARRY_GROUPED_TEST_PASSED: bugfix-proc-sys-kernel-hostname\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bugfix-proc-sys-kernel-hostname\n");
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## 问题

`/proc/sys/kernel/hostname` 需要符合 Linux UTS hostname sysctl 的读写语义：写入应更新调用者当前 UTS namespace，随后 `gethostname`、`uname` 和 procfs 读回都应观察到新值。

## 修改

- 将 hostname 节点改为 `RwFile`：读路径返回当前 UTS nodename 加换行。
- 写路径接受一个可选尾随换行，拒绝内嵌 NUL/换行和超过 64 字节的名称；非 root 返回 `EPERM`，成功时更新当前 `nsproxy.uts_ns`。
- QEMU 回归覆盖写入、`gethostname`、`uname`、procfs 读回、65 字节拒绝，以及用原始 procfs 字节恢复初始 hostname。

## 逻辑

hostname 是 UTS namespace 状态，不应维护 procfs 的独立副本。procfs 的读写均通过当前任务的 `nsproxy.uts_ns` 完成，保证与既有 hostname syscall 路径观察到同一状态。

## 验证

所有命令均在挂载 `.ci-cache` 的 Podman 容器内执行；rootless rootfs 注入需要的 `fakeroot` 仅在临时容器内安装。

- `cargo fmt --all --check`
- `cargo xtask clippy --package starry-kernel`：25/25 配置通过（含 aarch64 system 与 system-rga）。
- `cargo xtask starry test qemu --arch x86_64 -c qemu/bugfix-proc-sys-kernel-hostname`：通过，guest 中 24 项断言全部成功。
- `git diff --check`

## 来源

本 PR 从 `silicalet/tgoskits` 的 `004-add-starry-nixos` 分支拆出。