### PR TITLE
fix(starry-kernel): wake signalfd epoll waiters

### DIFF
--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -491,6 +491,15 @@ impl Epoll {
         file.register(&mut context, register_events(interest.event.events));
     }
 
+    /// Registers enabled interests with the thread currently waiting in epoll.
+    pub fn register_waiter_wakers(&self) -> AxResult {
+        let interests = self.inner.snapshot_interests()?;
+        for interest in &interests {
+            self.register_waker_only(interest);
+        }
+        Ok(())
+    }
+
     // for add/modify
     fn check_and_register_waker(&self, interest: &Arc<EpollInterest>) {
         let Some(file) = interest.key.get_file() else {

--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -20,6 +20,7 @@ use core::{
 
 use ax_errno::{AxError, AxResult};
 use ax_kspin::SpinNoIrq;
+use ax_task::current;
 use axpoll::{IoEvents, PollSet};
 use bitflags::bitflags;
 use hashbrown::HashMap;
@@ -31,7 +32,10 @@ use super::epoll_topology::{
     EpollTopology, EpollTopologyLink, commit_nested_link, detach_nested_link, lock_epoll_topology,
     prepare_nested_link, reserve_nested_link,
 };
-use crate::file::{FileLike, get_file_like};
+use crate::{
+    file::{FileLike, get_file_like, signalfd::Signalfd},
+    task::{AsThread, ProcessData},
+};
 
 pub struct EpollEvent {
     pub events: IoEvents,
@@ -171,6 +175,11 @@ struct EpollInterest {
     key: EntryKey,
     event: EpollEvent,
     nested_link: Option<EpollTopologyLink>,
+    // Linux keeps inherited signalfd descriptors readable after fork, but an
+    // inherited epoll interest must not observe signals directed to the child.
+    // A weak owner preserves same-process waiter refreshes without extending
+    // the originating process lifetime.
+    signalfd_registration_owner: Option<Weak<ProcessData>>,
     mode: SpinNoIrq<TriggerMode>,
     exclusive: bool,
     in_ready_queue: AtomicBool,
@@ -184,6 +193,10 @@ impl EpollInterest {
         nested_link: Option<EpollTopologyLink>,
     ) -> Self {
         Self {
+            signalfd_registration_owner: key
+                .get_file()
+                .filter(|file| file.is::<Signalfd>())
+                .map(|_| Arc::downgrade(&current().as_thread().proc_data)),
             key,
             event,
             nested_link,
@@ -257,6 +270,16 @@ impl EpollInterest {
 
     fn restore_mode(&self, mode: TriggerMode) {
         *self.mode.lock() = mode;
+    }
+
+    fn can_refresh_waker_from_current_process(&self) -> bool {
+        self.signalfd_registration_owner
+            .as_ref()
+            .is_none_or(|owner| {
+                owner
+                    .upgrade()
+                    .is_some_and(|owner| Arc::ptr_eq(&owner, &current().as_thread().proc_data))
+            })
     }
 }
 
@@ -474,6 +497,10 @@ impl Epoll {
 
     // only register waker, not add to ready queue
     fn register_waker_only(&self, interest: &Arc<EpollInterest>) {
+        if !interest.can_refresh_waker_from_current_process() {
+            return;
+        }
+
         let Some(file) = interest.key.get_file() else {
             return;
         };

--- a/os/StarryOS/kernel/src/file/signalfd.rs
+++ b/os/StarryOS/kernel/src/file/signalfd.rs
@@ -182,8 +182,17 @@ impl Pollable for Signalfd {
 
     fn register(&self, context: &mut Context<'_>, events: IoEvents) {
         if events.contains(IoEvents::IN) {
-            // Registration happens from file poll task context.
-            unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
+            // The private poll set covers mask updates and additional queued
+            // signals. New signal delivery wakes the current thread's shared
+            // signalfd poll set, so an already-blocked epoll waiter must be
+            // registered with both sources.
+            unsafe {
+                self.poll_rx.register(context.waker(), IoEvents::IN);
+                current()
+                    .as_thread()
+                    .signalfd_waker
+                    .register(context.waker(), IoEvents::IN);
+            }
         }
     }
 }

--- a/os/StarryOS/kernel/src/syscall/io_mpx/epoll.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/epoll.rs
@@ -205,6 +205,7 @@ fn do_epoll_wait(
         || match block_on(future::timeout(
             timeout,
             poll_io(epoll.as_ref(), IoEvents::IN, false, || {
+                epoll.register_waiter_wakers()?;
                 epoll.poll_events_with(maxevents, |index, event| {
                     write_epoll_event(events, index, &event)?;
                     Ok(())

--- a/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/CMakeLists.txt
@@ -8,5 +8,6 @@ set(CMAKE_C_EXTENSIONS ON)
 
 add_executable(bugfix-signalfd-epoll-wakeup src/main.c)
 target_compile_options(bugfix-signalfd-epoll-wakeup PRIVATE -Wall -Wextra -Werror)
+target_link_libraries(bugfix-signalfd-epoll-wakeup PRIVATE pthread)
 
 install(TARGETS bugfix-signalfd-epoll-wakeup RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bugfix-signalfd-epoll-wakeup C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-signalfd-epoll-wakeup src/main.c)
+target_compile_options(bugfix-signalfd-epoll-wakeup PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-signalfd-epoll-wakeup RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/src/main.c
@@ -2,18 +2,31 @@
 
 #include <errno.h>
 #include <signal.h>
-#include <stdint.h>
+#include <pthread.h>
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 #include <string.h>
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
-#include <sys/types.h>
-#include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 static int passed;
 static int failed;
+static _Atomic int waiter_entered;
+
+struct waiter_context {
+    int epoll_fd;
+    int signal_fd;
+    int wait_result;
+    int wait_errno;
+    ssize_t read_length;
+    int read_errno;
+    struct epoll_event event;
+    struct signalfd_siginfo signal_info;
+};
 
 static void expect_true(int condition, const char *name)
 {
@@ -26,14 +39,50 @@ static void expect_true(int condition, const char *name)
     failed++;
 }
 
+static void *wait_for_signalfd_event(void *opaque)
+{
+    struct waiter_context *context = opaque;
+
+    atomic_store_explicit(&waiter_entered, 1, memory_order_release);
+    errno = 0;
+    context->wait_result = epoll_wait(context->epoll_fd, &context->event, 1, 2000);
+    context->wait_errno = errno;
+    if (context->wait_result != 1) {
+        return NULL;
+    }
+
+    errno = 0;
+    context->read_length = read(
+        context->signal_fd,
+        &context->signal_info,
+        sizeof(context->signal_info)
+    );
+    context->read_errno = errno;
+    return NULL;
+}
+
+static int wait_for_epoll_waiter(void)
+{
+    const struct timespec settle = {
+        .tv_sec = 0,
+        .tv_nsec = 100 * 1000 * 1000,
+    };
+
+    while (atomic_load_explicit(&waiter_entered, memory_order_acquire) == 0) {
+        sched_yield();
+    }
+
+    return nanosleep(&settle, NULL);
+}
+
 int main(void)
 {
     printf("=== bugfix-signalfd-epoll-wakeup ===\n");
 
     sigset_t mask;
     sigemptyset(&mask);
-    sigaddset(&mask, SIGCHLD);
-    expect_true(sigprocmask(SIG_BLOCK, &mask, NULL) == 0, "block SIGCHLD");
+    sigaddset(&mask, SIGUSR1);
+    expect_true(sigprocmask(SIG_BLOCK, &mask, NULL) == 0, "block SIGUSR1");
 
     int signal_fd = signalfd(-1, &mask, SFD_CLOEXEC | SFD_NONBLOCK);
     expect_true(signal_fd >= 0, "create nonblocking signalfd");
@@ -50,46 +99,32 @@ int main(void)
                               &interest) == 0,
                 "register signalfd with epoll");
 
-    pid_t child = fork();
-    expect_true(child >= 0, "fork delayed child");
-    if (child == 0) {
-        usleep(200000);
-        _exit(7);
-    }
+    struct waiter_context context = {
+        .epoll_fd = epoll_fd,
+        .signal_fd = signal_fd,
+        .wait_result = -1,
+        .wait_errno = 0,
+        .read_length = -1,
+        .read_errno = 0,
+    };
+    pthread_t waiter;
+    int waiter_started = signal_fd >= 0 && epoll_fd >= 0 &&
+                         pthread_create(&waiter, NULL, wait_for_signalfd_event, &context) == 0;
+    expect_true(waiter_started, "start epoll_wait thread");
 
-    if (child > 0 && signal_fd >= 0 && epoll_fd >= 0) {
-        struct epoll_event event = {0};
-        errno = 0;
-        int ready = epoll_wait(epoll_fd, &event, 1, 2000);
-        expect_true(ready == 1 && event.data.fd == signal_fd &&
-                        (event.events & EPOLLIN) != 0,
-                    "epoll wakes when blocked SIGCHLD reaches signalfd");
-
-        struct signalfd_siginfo signal_info = {0};
-        ssize_t length = read(signal_fd, &signal_info, sizeof(signal_info));
-        expect_true(length == (ssize_t)sizeof(signal_info),
-                    "read SIGCHLD from signalfd");
-        expect_true(length == (ssize_t)sizeof(signal_info) &&
-                        signal_info.ssi_signo == SIGCHLD &&
-                        signal_info.ssi_pid == (uint32_t)child,
-                    "signalfd reports exiting child");
-
-        siginfo_t child_info = {0};
-        expect_true(waitid(P_ALL, 0, &child_info,
-                           WEXITED | WNOHANG | WNOWAIT) == 0 &&
-                        child_info.si_pid == child &&
-                        child_info.si_code == CLD_EXITED &&
-                        child_info.si_status == 7,
-                    "waitid WNOWAIT observes child after signalfd wake");
-
-        memset(&child_info, 0, sizeof(child_info));
-        expect_true(waitid(P_PID, (id_t)child, &child_info, WEXITED) == 0 &&
-                        child_info.si_pid == child &&
-                        child_info.si_code == CLD_EXITED &&
-                        child_info.si_status == 7,
-                    "waitid P_PID reaps observed child");
-    } else if (child > 0) {
-        waitpid(child, NULL, 0);
+    if (waiter_started) {
+        expect_true(wait_for_epoll_waiter() == 0, "wait for epoll_wait thread to block");
+        expect_true(pthread_kill(waiter, SIGUSR1) == 0,
+                    "send blocked SIGUSR1 to epoll_wait thread");
+        expect_true(pthread_join(waiter, NULL) == 0, "join epoll_wait thread");
+        expect_true(context.wait_result == 1 && context.event.data.fd == signal_fd &&
+                        (context.event.events & EPOLLIN) != 0,
+                    "epoll wakes when target thread receives blocked SIGUSR1");
+        expect_true(context.read_length == (ssize_t)sizeof(context.signal_info),
+                    "read SIGUSR1 from signalfd in epoll_wait thread");
+        expect_true(context.read_length == (ssize_t)sizeof(context.signal_info) &&
+                        context.signal_info.ssi_signo == SIGUSR1,
+                    "signalfd reports target thread SIGUSR1");
     }
 
     if (epoll_fd >= 0) {

--- a/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/src/main.c
@@ -1,0 +1,110 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/epoll.h>
+#include <sys/signalfd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void expect_true(int condition, const char *name)
+{
+    if (condition) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+    printf("FAIL: %s: errno=%d (%s)\n", name, errno, strerror(errno));
+    failed++;
+}
+
+int main(void)
+{
+    printf("=== bugfix-signalfd-epoll-wakeup ===\n");
+
+    sigset_t mask;
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGCHLD);
+    expect_true(sigprocmask(SIG_BLOCK, &mask, NULL) == 0, "block SIGCHLD");
+
+    int signal_fd = signalfd(-1, &mask, SFD_CLOEXEC | SFD_NONBLOCK);
+    expect_true(signal_fd >= 0, "create nonblocking signalfd");
+
+    int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+    expect_true(epoll_fd >= 0, "create epoll");
+
+    struct epoll_event interest = {
+        .events = EPOLLIN,
+        .data.fd = signal_fd,
+    };
+    expect_true(signal_fd >= 0 && epoll_fd >= 0 &&
+                    epoll_ctl(epoll_fd, EPOLL_CTL_ADD, signal_fd,
+                              &interest) == 0,
+                "register signalfd with epoll");
+
+    pid_t child = fork();
+    expect_true(child >= 0, "fork delayed child");
+    if (child == 0) {
+        usleep(200000);
+        _exit(7);
+    }
+
+    if (child > 0 && signal_fd >= 0 && epoll_fd >= 0) {
+        struct epoll_event event = {0};
+        errno = 0;
+        int ready = epoll_wait(epoll_fd, &event, 1, 2000);
+        expect_true(ready == 1 && event.data.fd == signal_fd &&
+                        (event.events & EPOLLIN) != 0,
+                    "epoll wakes when blocked SIGCHLD reaches signalfd");
+
+        struct signalfd_siginfo signal_info = {0};
+        ssize_t length = read(signal_fd, &signal_info, sizeof(signal_info));
+        expect_true(length == (ssize_t)sizeof(signal_info),
+                    "read SIGCHLD from signalfd");
+        expect_true(length == (ssize_t)sizeof(signal_info) &&
+                        signal_info.ssi_signo == SIGCHLD &&
+                        signal_info.ssi_pid == (uint32_t)child,
+                    "signalfd reports exiting child");
+
+        siginfo_t child_info = {0};
+        expect_true(waitid(P_ALL, 0, &child_info,
+                           WEXITED | WNOHANG | WNOWAIT) == 0 &&
+                        child_info.si_pid == child &&
+                        child_info.si_code == CLD_EXITED &&
+                        child_info.si_status == 7,
+                    "waitid WNOWAIT observes child after signalfd wake");
+
+        memset(&child_info, 0, sizeof(child_info));
+        expect_true(waitid(P_PID, (id_t)child, &child_info, WEXITED) == 0 &&
+                        child_info.si_pid == child &&
+                        child_info.si_code == CLD_EXITED &&
+                        child_info.si_status == 7,
+                    "waitid P_PID reaps observed child");
+    } else if (child > 0) {
+        waitpid(child, NULL, 0);
+    }
+
+    if (epoll_fd >= 0) {
+        close(epoll_fd);
+    }
+    if (signal_fd >= 0) {
+        close(signal_fd);
+    }
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_SIGNALFD_EPOLL_WAKEUP_PASSED\n");
+        printf("STARRY_GROUPED_TEST_PASSED: bugfix-signalfd-epoll-wakeup\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bugfix-signalfd-epoll-wakeup\n");
+    return EXIT_FAILURE;
+}

--- a/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-signalfd-epoll-wakeup/src/main.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <sys/epoll.h>
 #include <sys/signalfd.h>
+#include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -75,6 +76,80 @@ static int wait_for_epoll_waiter(void)
     return nanosleep(&settle, NULL);
 }
 
+static int check_inherited_signalfd_epoll(int epoll_fd, int signal_fd)
+{
+    struct epoll_event event;
+    struct signalfd_siginfo signal_info;
+
+    errno = 0;
+    int wait_result = epoll_wait(epoll_fd, &event, 1, 500);
+    if (wait_result != 0) {
+        printf("FAIL: inherited epoll reported signalfd in child: result=%d errno=%d (%s)\n",
+               wait_result, errno, strerror(errno));
+        return EXIT_FAILURE;
+    }
+
+    errno = 0;
+    ssize_t read_length = read(signal_fd, &signal_info, sizeof(signal_info));
+    if (read_length != (ssize_t)sizeof(signal_info)) {
+        printf("FAIL: inherited signalfd did not read child SIGUSR1: result=%zd errno=%d (%s)\n",
+               read_length, errno, strerror(errno));
+        return EXIT_FAILURE;
+    }
+    if (signal_info.ssi_signo != SIGUSR1) {
+        printf("FAIL: inherited signalfd reported signal %u instead of SIGUSR1\n",
+               signal_info.ssi_signo);
+        return EXIT_FAILURE;
+    }
+
+    printf("PASS: inherited signalfd reads child SIGUSR1 without epoll readiness\n");
+    return EXIT_SUCCESS;
+}
+
+static void test_forked_child_signalfd_epoll_isolation(int epoll_fd, int signal_fd)
+{
+    const struct timespec settle = {
+        .tv_sec = 0,
+        .tv_nsec = 100 * 1000 * 1000,
+    };
+    int ready_pipe[2] = {-1, -1};
+
+    expect_true(pipe(ready_pipe) == 0, "create fork readiness pipe");
+    if (ready_pipe[0] < 0 || ready_pipe[1] < 0) {
+        return;
+    }
+
+    fflush(stdout);
+    pid_t child = fork();
+    expect_true(child >= 0, "fork inherited signalfd and epoll");
+    if (child == 0) {
+        const char ready = 'R';
+
+        close(ready_pipe[0]);
+        if (write(ready_pipe[1], &ready, sizeof(ready)) != (ssize_t)sizeof(ready)) {
+            _exit(EXIT_FAILURE);
+        }
+        close(ready_pipe[1]);
+        _exit(check_inherited_signalfd_epoll(epoll_fd, signal_fd));
+    }
+
+    close(ready_pipe[1]);
+    if (child > 0) {
+        char ready = '\0';
+        expect_true(read(ready_pipe[0], &ready, sizeof(ready)) == (ssize_t)sizeof(ready) &&
+                        ready == 'R',
+                    "wait for child epoll_wait setup");
+        expect_true(nanosleep(&settle, NULL) == 0, "let child enter epoll_wait");
+        expect_true(kill(child, SIGUSR1) == 0, "send SIGUSR1 to child process");
+
+        int status = 0;
+        expect_true(waitpid(child, &status, 0) == child, "wait for child process");
+        expect_true(WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SUCCESS,
+                    "inherited epoll ignores child signalfd readiness");
+    }
+    close(ready_pipe[0]);
+}
+
 int main(void)
 {
     printf("=== bugfix-signalfd-epoll-wakeup ===\n");
@@ -125,6 +200,8 @@ int main(void)
         expect_true(context.read_length == (ssize_t)sizeof(context.signal_info) &&
                         context.signal_info.ssi_signo == SIGUSR1,
                     "signalfd reports target thread SIGUSR1");
+
+        test_forked_child_signalfd_epoll_isolation(epoll_fd, signal_fd);
     }
 
     if (epoll_fd >= 0) {


### PR DESCRIPTION
## 问题

`epoll_ctl(ADD)` 与 `epoll_wait()` 可以在不同线程执行。原实现只在执行 `epoll_ctl` 的线程注册 signalfd waker；向实际等待线程投递受阻塞信号时，epoll 可能无法被唤醒。

此外，fork 后子进程继承 signalfd 与 epoll fd。Linux 允许子进程直接从继承 signalfd 读取发给自己的信号，但继承 epoll 的 `epoll_wait()` 不应因此报告该 fd 就绪。

## 修改与逻辑

- `epoll_wait` 每次轮询前快照已启用 interest，并在释放 interest 锁后重新注册 waker。
- 因此 `Signalfd::register` 绑定到实际执行等待的线程，而不是控制线程。
- signalfd interest 记录创建或修改该 interest 的进程，仅允许同一进程刷新 waker；fork 子进程不会将自己的 `signalfd_waker` 重新绑定到继承 interest。
- 使用 `Weak<ProcessData>` 保存归属，不延长原进程生命周期；普通 fd 和同进程跨线程刷新行为不变。
- 使用可失败的 interest 快照，内存不足时返回 `AxError::NoMemory`，不在锁内调用文件注册。
- 回归用例覆盖主线程 `epoll_ctl`、第二线程 `epoll_wait`、`pthread_kill` 唤醒，以及 fork 子进程直接读取 child-directed `SIGUSR1` 但继承 `epoll_wait` 超时。

## 验证

- 红灯：未加 fork 隔离时，聚焦 QEMU 用例稳定报 `FAIL: inherited epoll reported signalfd in child: result=1`。
- Podman + `.ci-cache`：`cargo xtask starry test qemu --arch x86_64 -c qemu/bugfix-signalfd-epoll-wakeup`，guest 中 18 passed，0 failed，并由 `qemu/system` grouped runner 发现、构建、安装、执行。
- Podman + `.ci-cache`：`cargo xtask clippy --package starry-kernel`，25/25 组合通过。
- 旧 CI 的 `Test starry riscv64 qemu / run_container` 在已有 `test-proc-status-tracerpid` 处耗尽 1800 秒总预算；该 job 未运行到本 PR 的回归用例。该类 `qemu/system` 总超时由 #1767 跟踪，本次观察已补充至该 issue。

## 来源

本 PR 从 `silicalet/tgoskits` 的 `004-add-starry-nixos` 分支拆出。