### PR TITLE
fix(starry-kernel): update existing signalfd masks

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/signalfd.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/signalfd.rs
@@ -36,7 +36,8 @@ bitflags! {
 ///   `fd` must specify a valid existing signalfd file descriptor.
 /// * `mask` - Pointer to a signal set (sigset_t).
 /// * `sigsetsize` - The size (in bytes) of the mask pointed to by `mask`.
-/// * `flags` - Flags to control the operation.
+/// * `flags` - Flags used when creating a new descriptor. Linux validates but
+///   otherwise ignores these flags when updating an existing signalfd.
 pub fn sys_signalfd4(
     fd: i32,
     mask: *const SignalSet,
@@ -47,18 +48,14 @@ pub fn sys_signalfd4(
 
     let flags = SignalfdFlags::from_bits(flags).ok_or(AxError::InvalidInput)?;
 
-    if fd != -1 && flags.contains(SignalfdFlags::CLOEXEC) {
-        return Err(AxError::InvalidInput);
-    }
-
     // Read the signal mask from user space before handling the request mode.
     let mask = unsafe { mask.vm_read_uninit()?.assume_init() };
 
-    // If fd is not -1, we should modify the existing signalfd
+    // Linux only updates the mask for an existing signalfd. Valid creation
+    // flags do not alter its descriptor or file status flags.
     if fd != -1 {
         let signalfd = Signalfd::from_fd(fd)?;
         signalfd.update_mask(mask);
-        signalfd.set_nonblocking(flags.contains(SignalfdFlags::NONBLOCK))?;
         return Ok(fd as _);
     }
 

--- a/test-suit/starryos/qemu/system/bugfix-signalfd-mask-update-flags/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-signalfd-mask-update-flags/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bugfix-signalfd-mask-update-flags C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-signalfd-mask-update-flags src/main.c)
+target_compile_options(bugfix-signalfd-mask-update-flags PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-signalfd-mask-update-flags RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-signalfd-mask-update-flags/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-signalfd-mask-update-flags/src/main.c
@@ -1,0 +1,94 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/signalfd.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void expect_true(int condition, const char *name)
+{
+    if (condition) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+    printf("FAIL: %s: errno=%d (%s)\n", name, errno, strerror(errno));
+    failed++;
+}
+
+static void add_signal(sigset_t *mask, int signal_number)
+{
+    expect_true(sigaddset(mask, signal_number) == 0, "add signal to mask");
+}
+
+int main(void)
+{
+    printf("=== bugfix-signalfd-mask-update-flags ===\n");
+
+    sigset_t initial_mask;
+    sigemptyset(&initial_mask);
+    add_signal(&initial_mask, SIGUSR1);
+
+    int signal_fd = signalfd(-1, &initial_mask, 0);
+    expect_true(signal_fd >= 0, "create blocking signalfd without CLOEXEC");
+
+    if (signal_fd >= 0) {
+        sigset_t expanded_mask = initial_mask;
+        add_signal(&expanded_mask, SIGUSR2);
+
+        errno = 0;
+        int result = signalfd(signal_fd, &expanded_mask,
+                              SFD_CLOEXEC | SFD_NONBLOCK);
+        expect_true(result == signal_fd,
+                    "update existing signalfd with valid flags returns same fd");
+
+        int descriptor_flags = fcntl(signal_fd, F_GETFD);
+        expect_true(descriptor_flags >= 0 &&
+                        (descriptor_flags & FD_CLOEXEC) == 0,
+                    "update does not add FD_CLOEXEC");
+
+        int status_flags = fcntl(signal_fd, F_GETFL);
+        expect_true(status_flags >= 0 &&
+                        (status_flags & O_NONBLOCK) == 0,
+                    "update does not add O_NONBLOCK");
+
+        close(signal_fd);
+    }
+
+    sigemptyset(&initial_mask);
+    add_signal(&initial_mask, SIGUSR1);
+    signal_fd =
+        signalfd(-1, &initial_mask, SFD_CLOEXEC | SFD_NONBLOCK);
+    expect_true(signal_fd >= 0,
+                "create nonblocking CLOEXEC signalfd");
+
+    if (signal_fd >= 0) {
+        sigset_t expanded_mask = initial_mask;
+        add_signal(&expanded_mask, SIGUSR2);
+
+        errno = 0;
+        int result = signalfd(signal_fd, &expanded_mask,
+                              SFD_CLOEXEC | SFD_NONBLOCK);
+        expect_true(result == signal_fd,
+                    "systemd-style repeated flags update returns same fd");
+
+        close(signal_fd);
+    }
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_SIGNALFD_MASK_UPDATE_FLAGS_PASSED\n");
+        printf("STARRY_GROUPED_TEST_PASSED: bugfix-signalfd-mask-update-flags\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bugfix-signalfd-mask-update-flags\n");
+    return EXIT_FAILURE;
+}

--- a/test-suit/starryos/qemu/system/syscall-test-signalfd4/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-signalfd4/src/main.c
@@ -5,7 +5,7 @@
  *   1. 基本创建：各种 flag 组合，非法 flags → EINVAL
  *   2. sigsetsize 校验：非空 mask 时 size 必须为 8
  *   3. 修改已有 signalfd 的 mask（fd != -1）
- *   4. 修改已有 fd 时传 SFD_CLOEXEC → EINVAL
+ *   4. 修改已有 fd 时合法 flags 只更新 mask
  *   5. 非阻塞空读 → EAGAIN
  *   6. 读缓冲区 < 128 字节 → EINVAL
  *   7. write → EBADF
@@ -153,14 +153,14 @@ static void test_modify_mask(void) {
     close(fd);
 }
 
-/* ─── 4. fd != -1 且 SFD_CLOEXEC → EINVAL ────────────────────── */
+/* ─── 4. fd != -1 时合法 flags 不影响更新 ───────────────────── */
 
-static void test_cloexec_conflict(void) {
+static void test_existing_fd_flags(void) {
     int fd = signalfd4_new(0, 0);
     CHECK(fd >= 0, "create signalfd");
 
-    CHECK_ERR(signalfd4_modify(fd, 0, SFD_CLOEXEC), EINVAL,
-              "modify with SFD_CLOEXEC → EINVAL");
+    int ret = signalfd4_modify(fd, 0, SFD_CLOEXEC);
+    CHECK(ret == fd, "modify with SFD_CLOEXEC returns same fd");
 
     close(fd);
 }
@@ -184,8 +184,8 @@ static void test_buffer_size(void) {
     int fd = signalfd4_new(0, 0);
     CHECK(fd >= 0, "create signalfd for buffer test");
 
-    char small[64];
-    CHECK_ERR(read(fd, small, sizeof(small)), EINVAL,
+    char small[127];
+    CHECK_ERR(read(fd, small, 64), EINVAL,
               "read with 64-byte buffer → EINVAL");
     CHECK_ERR(read(fd, small, 127), EINVAL,
               "read with 127-byte buffer → EINVAL");
@@ -325,8 +325,8 @@ int main(void) {
     printf("\n--- 3. modify mask ---\n");
     test_modify_mask();
 
-    printf("\n--- 4. SFD_CLOEXEC conflict ---\n");
-    test_cloexec_conflict();
+    printf("\n--- 4. existing fd flags ---\n");
+    test_existing_fd_flags();
 
     printf("\n--- 5. nonblocking empty read ---\n");
     test_nonblocking_empty();


### PR DESCRIPTION
## 问题

更新既有 signalfd 的 signal mask 时，需要遵循 signalfd4 的 flags 与 mask 更新语义。

## 修改与逻辑

仅修正 signalfd4 更新既有描述符的处理，并补充专用 QEMU 回归。

## 验证

- 保留对应的 StarryOS QEMU 回归测试。
- 拆分分支相对 `upstream/dev` 仅领先一个提交，且 `git diff --check` 通过。

## 来源

本 PR 从 `silicalet/tgoskits` 的 `004-add-starry-nixos` 分支拆出。