### PR TITLE
fix(ax-task): preserve concurrent signal wakeups

### DIFF
--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -206,7 +206,8 @@ pub fn wait_existing_ptrace_stop_current(thr: &Thread, uctx: &mut UserContext) {
 }
 
 fn wait_ptrace_resume(thr: &Thread, tid: u32, uctx: &mut UserContext) {
-    current().clear_interrupt();
+    let stale_interrupts = current().interrupt_snapshot();
+    current().acknowledge_interrupt(stale_interrupts);
     let wait_result = block_on(interruptible(poll_fn(|cx| {
         if thr.proc_data.ptrace_stop_signo_for(tid).is_none() {
             Poll::Ready(())

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -313,11 +313,6 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                 }
 
                 if !unblock_next_signal() {
-                    // POSIX timers are also driven by the alarm task, but polling
-                    // here closes the window where an expired timer is only noticed
-                    // after the current syscall returns to userspace.
-                    poll_process_timer(thr.proc_data.proc.pid());
-
                     let eintr_code = -(ax_errno::LinuxError::EINTR.code() as isize);
                     let restart = if is_syscall
                         && (uctx.retval() as isize) == eintr_code
@@ -334,13 +329,31 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                     // whether to restart. Subsequent signals in the same
                     // loop must not re-apply the decision.
                     let mut pending_restart = restart.as_ref();
-                    while check_signals(thr, &mut uctx, None, pending_restart) {
-                        pending_restart = None;
+                    let mut poll_timer = true;
+                    loop {
+                        // Only acknowledge publications visible before this
+                        // return-to-userspace safe-point scan. A signal that
+                        // races after the snapshot remains pending and forces
+                        // another pass before an interruptible syscall parks.
+                        let interrupt_snapshot = curr.interrupt_snapshot();
+                        if poll_timer {
+                            // POSIX timers are also driven by the alarm task, but polling
+                            // here closes the window where an expired timer is only noticed
+                            // after the current syscall returns to userspace.
+                            poll_process_timer(thr.proc_data.proc.pid());
+                            poll_timer = false;
+                        }
+                        while check_signals(thr, &mut uctx, None, pending_restart) {
+                            pending_restart = None;
+                        }
+                        curr.acknowledge_interrupt(interrupt_snapshot);
+                        if !curr.interrupted() {
+                            break;
+                        }
                     }
                 }
 
                 set_timer_state(&curr, TimerState::User);
-                curr.clear_interrupt();
             }
         },
         name.into(),

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -23,6 +23,7 @@ pub use crate::task::{AxTaskExt, TaskExt};
 pub use crate::timers::register_timer_callback;
 #[cfg_attr(doc, doc(cfg(feature = "multitask")))]
 pub use crate::{
+    interrupt::InterruptSnapshot,
     task::{CurrentTask, TaskId, TaskInner, TaskState},
     wait_queue::WaitQueue,
 };

--- a/os/arceos/modules/axtask/src/interrupt.rs
+++ b/os/arceos/modules/axtask/src/interrupt.rs
@@ -1,0 +1,103 @@
+//! Task interruption publication state.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// A task interruption observation captured before an owner-side safe-point scan.
+///
+/// Obtain a snapshot through [`crate::TaskInner::interrupt_snapshot`] and pass it
+/// to [`crate::TaskInner::acknowledge_interrupt`] after that scan completes.
+#[derive(Debug, Clone, Copy)]
+pub struct InterruptSnapshot(u64);
+
+/// Sticky interruption publication shared by remote producers and one task.
+pub(crate) struct InterruptState {
+    published: AtomicU64,
+    acknowledged: AtomicU64,
+}
+
+impl InterruptState {
+    pub(crate) const fn new() -> Self {
+        Self {
+            published: AtomicU64::new(0),
+            acknowledged: AtomicU64::new(0),
+        }
+    }
+
+    pub(crate) fn publish(&self) {
+        self.published
+            .try_update(Ordering::Release, Ordering::Relaxed, |generation| {
+                generation.checked_add(1)
+            })
+            .expect("task interruption generation exhausted");
+    }
+
+    pub(crate) fn consume(&self) -> bool {
+        self.acknowledge(self.snapshot())
+    }
+
+    pub(crate) fn is_pending(&self) -> bool {
+        self.published.load(Ordering::Acquire) > self.acknowledged.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn snapshot(&self) -> InterruptSnapshot {
+        InterruptSnapshot(self.published.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn acknowledge(&self, snapshot: InterruptSnapshot) -> bool {
+        let mut acknowledged = self.acknowledged.load(Ordering::Acquire);
+        while acknowledged < snapshot.0 {
+            match self.acknowledged.compare_exchange_weak(
+                acknowledged,
+                snapshot.0,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(current) => acknowledged = current,
+            }
+        }
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InterruptState;
+
+    #[test]
+    fn publication_after_snapshot_survives_acknowledgement() {
+        let state = InterruptState::new();
+        state.publish();
+        let scanned = state.snapshot();
+
+        state.publish();
+        let _advanced = state.acknowledge(scanned);
+
+        assert!(
+            state.is_pending(),
+            "acknowledging an older scan must not erase a later publication"
+        );
+    }
+
+    #[test]
+    fn snapshot_acknowledges_only_visible_publications() {
+        let state = InterruptState::new();
+        state.publish();
+
+        let scanned = state.snapshot();
+
+        assert!(state.acknowledge(scanned));
+        assert!(!state.is_pending());
+    }
+
+    #[test]
+    fn older_acknowledgement_cannot_regress_a_consumer() {
+        let state = InterruptState::new();
+        let old = state.snapshot();
+        state.publish();
+
+        assert!(state.consume());
+        assert!(!state.acknowledge(old));
+        assert!(!state.is_pending());
+    }
+}

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -69,6 +69,7 @@ cfg_if::cfg_if! {
 
         #[macro_use]
         mod run_queue;
+        mod interrupt;
         mod task;
         mod api;
         #[cfg(feature = "lockdep")]

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -33,7 +33,10 @@ use futures_util::task::AtomicWaker;
 
 #[cfg(feature = "lockdep")]
 use crate::lockdep::HeldLockStack;
-use crate::{AxCpuMask, AxTask, AxTaskRef, WaitQueue};
+use crate::{
+    AxCpuMask, AxTask, AxTaskRef, WaitQueue,
+    interrupt::{InterruptSnapshot, InterruptState},
+};
 
 #[cfg(target_pointer_width = "64")]
 const STACK_END_MAGIC: usize = 0x57AC_CE11_57AC_CE11usize;
@@ -129,7 +132,7 @@ pub struct TaskInner {
     #[cfg(feature = "preempt")]
     preempt_disable_count: AtomicUsize,
 
-    interrupted: AtomicBool,
+    interrupted: InterruptState,
     interrupt_waker: AtomicWaker,
 
     exit_code: AtomicI32,
@@ -322,25 +325,28 @@ impl TaskInner {
         // allow `interrupt()` to run and call `wake()` on an empty waker
         // slot — the wake is lost. Registering first closes the window.
         self.interrupt_waker.register(cx.waker());
-        if self.interrupted.swap(false, Ordering::AcqRel) {
+        if self.interrupted.consume() {
             Poll::Ready(())
         } else {
             Poll::Pending
         }
     }
 
-    /// Clears the interrupt state of the task.
+    /// Acknowledges all interruption publications visible at this call.
+    ///
+    /// Publications that race after the internal snapshot remain pending.
     #[inline]
     pub fn clear_interrupt(&self) {
-        self.interrupted.store(false, Ordering::Release);
+        let snapshot = self.interrupt_snapshot();
+        self.acknowledge_interrupt(snapshot);
     }
 
-    /// Atomically checks and clears the interrupt flag.
+    /// Consumes the interruption publications currently visible to this task.
     ///
     /// Returns `true` if the task was interrupted.
     #[inline]
     pub fn take_interrupt(&self) -> bool {
-        self.interrupted.swap(false, Ordering::AcqRel)
+        self.interrupted.consume()
     }
 
     /// Checks whether the task has been interrupted without clearing
@@ -351,14 +357,26 @@ impl TaskInner {
     /// consumers (e.g., an [`interruptible`] future wrapper).
     #[inline]
     pub fn interrupted(&self) -> bool {
-        self.interrupted.load(Ordering::Acquire)
+        self.interrupted.is_pending()
     }
 
     /// Interrupts the task.
     #[inline]
     pub fn interrupt(&self) {
-        self.interrupted.store(true, Ordering::Release);
+        self.interrupted.publish();
         self.interrupt_waker.wake();
+    }
+
+    /// Captures the interruption publications visible before a safe-point scan.
+    #[inline]
+    pub fn interrupt_snapshot(&self) -> InterruptSnapshot {
+        self.interrupted.snapshot()
+    }
+
+    /// Acknowledges the interruption publications covered by `snapshot`.
+    #[inline]
+    pub fn acknowledge_interrupt(&self, snapshot: InterruptSnapshot) {
+        self.interrupted.acknowledge(snapshot);
     }
 }
 
@@ -390,7 +408,7 @@ impl TaskInner {
             force_resched: AtomicBool::new(false),
             #[cfg(feature = "preempt")]
             preempt_disable_count: AtomicUsize::new(0),
-            interrupted: AtomicBool::new(false),
+            interrupted: InterruptState::new(),
             interrupt_waker: AtomicWaker::new(),
             exit_code: AtomicI32::new(0),
             wait_for_exit: WaitQueue::new(),


### PR DESCRIPTION
## 问题

[`Test starry riscv64 qemu / run_container`](https://github.com/rcore-os/tgoskits/actions/runs/30871809984/job/91880381581) 在 `test-proc-status-tracerpid` 开始后不再前进，最终触发 1800 秒 QEMU 超时。

被跟踪线程发布 ptrace stop 并唤醒父线程后，父线程可能在另一个 CPU 上向该线程发送 `SIGKILL`。此时信号入队并调用 `TaskInner::interrupt()`；但被跟踪线程随后会在进入 ptrace 等待前无条件清除布尔中断位，从而抹掉刚发布的唤醒并永久睡眠。返回用户态的信号扫描也存在相同的“扫描后无条件清除”窗口。

## 修改

- 将 `TaskInner` 的布尔中断位改为单调递增的发布/确认代际，并提供不透明的 `InterruptSnapshot`。
- 让消费者在安全点扫描前取得快照，扫描后只确认该快照覆盖的旧发布；扫描期间或之后发生的新发布继续保持 pending。
- ptrace stop 等待只确认进入等待前的陈旧中断，保证并发到达的 `SIGKILL` 仍能中断等待。
- 返回用户态的信号路径在检测到快照后的新发布时重扫，避免并发信号在可中断系统调用再次休眠前丢失。
- 为代际确认状态增加三个宿主单元测试，覆盖“快照后发布不能被旧确认吞掉”、正常消费和旧确认不能回退消费者状态。

## 设计逻辑与边界

中断发布事实仍由 `TaskInner` 统一持有，Starry 仅在现有安全点消费它，没有引入第二份信号状态。仅移动一次布尔清除无法区分“本轮已扫描的旧发布”和“快照后到达的新发布”，因此采用发布/确认代际；确认值只允许单调前进。

本修改不改变用户可见 ABI：

| 接口 | 语义影响 |
| --- | --- |
| `ptrace(PTRACE_TRACEME)` | 参数、返回值和停止状态不变；修复致命信号与 ptrace stop 并发时的活性 |
| `kill(SIGKILL)` | 信号路由和错误码不变；保证已经发布的致命信号不会丢失唤醒 |
| `wait4`/`waitpid` | 返回格式和错误码不变；被跟踪子进程可以按既有语义退出并被回收 |
| 可中断系统调用 | `EINTR`/restart 决策不变；只消除扫描与休眠之间的丢唤醒窗口 |

此前关闭且未合并的 #1836 与大型草稿 #1775 包含相关方向；本 PR 基于最新 `dev` 重新建立最小、可独立合并的修复，并补齐确定性红绿回归与当前基线验证。

## 回归与验证

确定性红绿回归：

- 先以旧的布尔清除语义运行 `publication_after_snapshot_survives_acknowledgement`，稳定失败于 `acknowledging an older scan must not erase a later publication`。
- 改为代际确认后运行同一测试，稳定通过。

最新 `origin/dev`（`ad946c5d7`）上的验证：

- `cargo fmt --all --check`
- `cargo test -p ax-task --features 'multitask host-test'`：14 个单元测试和 1 个 doctest 通过
- `cargo xtask clippy --package ax-task`：17/17 通过
- `cargo xtask clippy --package starry-kernel`：25/25 通过
- `cargo xtask starry test qemu --arch riscv64 -c qemu/system/test-proc-status-tracerpid`：通过（用例在 SMP 下跨 CPU 重复 64 轮）
- `cargo xtask starry test qemu --arch riscv64 -c qemu/system/test-signal-interrupt-eintr`：通过
