### PR TITLE
chore(repo): unify workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ version = "0.5.7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ version = "0.4.8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1135,7 +1135,7 @@ version = "0.4.11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1162,7 +1162,7 @@ version = "0.3.9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1379,7 +1379,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tar",
  "tempfile",
  "tokio",
@@ -1545,7 +1545,7 @@ version = "0.5.13"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1619,13 +1619,13 @@ dependencies = [
  "axvmconfig",
  "clap",
  "log",
- "prettyplease",
+ "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
  "spin",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]
@@ -1775,7 +1775,7 @@ dependencies = [
  "clang-sys",
  "itertools 0.13.0",
  "log",
- "prettyplease",
+ "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
  "regex",
@@ -3434,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "extern-trait"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a141ec56226dca390c7900f04f914a9783177e18ed8ac92e8a94014a84b8078b"
+checksum = "3f0ab10cbaef27c3483262069b23386596bb8e7dffaa1dfa8a30bb280ec8c4fb"
 dependencies = [
  "extern-trait-impl",
  "typeid",
@@ -3444,9 +3444,9 @@ dependencies = [
 
 [[package]]
 name = "extern-trait-impl"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e685faea53fd0bce4d327a36d0e7a2489edc9205576185116ab159c5028c666e"
+checksum = "5f092b2f4f5a147bffe065e36530e12deb1ac666d215be0e68a970a95396ada1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4725,7 +4725,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6076,6 +6076,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bfe0f4c752e450fc2faf62654f1c134747922825d5b04ca717b8874f41a40c0"
+dependencies = [
+ "proc-macro2",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "printf-compat"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6783,7 +6793,7 @@ version = "0.4.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7914,7 +7924,7 @@ dependencies = [
  "num-align",
  "numeric-enum-macro",
  "page-table-generic",
- "prettyplease",
+ "prettyplease 0.3.0",
  "quote",
  "ranges-ext",
  "rgb",
@@ -7923,7 +7933,7 @@ dependencies = [
  "some-serial",
  "somehal-macros",
  "spin",
- "syn 2.0.119",
+ "syn 3.0.3",
  "thiserror 2.0.19",
  "tock-registers 0.10.1",
  "uefi",
@@ -7969,7 +7979,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9344,7 +9354,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.4+spec-1.1.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -295,7 +295,7 @@ kasm-aarch64 = { path = "components/kasm-aarch64", version = "0.2.1" }
 somehal = { version = "0.8.2", path = "platforms/somehal" }
 
 # External crates
-anyhow = { version = "1.0", default-features = false }
+anyhow = { version = "1.0.104", default-features = false }
 bincode = "2.0.1"
 bitflags = "2.11"
 byte-unit = { version = "5", default-features = false, features = ["byte"] }
@@ -307,10 +307,15 @@ chrono = { version = "0.4", default-features = false }
 enum_dispatch = "0.3"
 env_logger = "0.11"
 event-listener = { version = "5.4.0", default-features = false }
+extern-trait = "0.5.0"
 futures = { version = "0.3", default-features = false }
 heapless = "0.9"
 schemars = "1.2.1"
-toml = { version = "1.1.2", default-features = false }
+prettyplease = "0.3.0"
+proc-macro2 = "1.0.107"
+quote = "1.0.47"
+syn = "3.0.3"
+toml = { version = "1", default-features = false }
 dma-api = { version = "0.9.4", path = "memory/dma-api" }
 mmio-api = { version = "0.2.3", path = "memory/mmio-api" }
 cvi-vdec-uapi = { version = "0.1.0", path = "drivers/interface/cvi-vdec-uapi" }

--- a/components/axerrno/Cargo.toml
+++ b/components/axerrno/Cargo.toml
@@ -18,7 +18,7 @@ strum = { version = "0.27.2", default-features = false, features = ["derive"] }
 axtest = ["dep:axtest"]
 
 [build-dependencies]
-quote = "1.0"
+quote = { workspace = true }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(axtest)'] }

--- a/components/axtest/axtest_macros/Cargo.toml
+++ b/components/axtest/axtest_macros/Cargo.toml
@@ -11,9 +11,9 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }
 
 [lib]
 proc-macro = true

--- a/components/crate_interface/Cargo.toml
+++ b/components/crate_interface/Cargo.toml
@@ -10,9 +10,9 @@ categories = ["development-tools::procedural-macro-helpers", "no-std"]
 license = "Apache-2.0"
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = ["full", "visit-mut"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full", "visit-mut"] }
 
 [features]
 default = []

--- a/components/crate_interface/src/impl_interface.rs
+++ b/components/crate_interface/src/impl_interface.rs
@@ -15,7 +15,7 @@ pub fn impl_interface(
     mut ast: ItemImpl,
     macro_arg: ImplInterfaceArgs,
 ) -> Result<TokenStream, Error> {
-    let trait_name = if let Some((_, path, _)) = &ast.trait_ {
+    let trait_name = if let Some((path, _)) = &ast.trait_ {
         &path.segments.last().unwrap().ident
     } else {
         return Err(Error::new_spanned(ast, "expect a trait implementation"));

--- a/components/crate_interface/src/lib.rs
+++ b/components/crate_interface/src/lib.rs
@@ -190,14 +190,11 @@ pub fn call_interface(item: TokenStream) -> TokenStream {
     }
     let fn_name = path.pop().unwrap();
     let trait_name = path.pop().unwrap();
-    let extern_fn_name = extern_fn_name(
-        call.namespace.as_deref(),
-        &trait_name.value().ident,
-        &fn_name.value().ident,
-    );
+    let extern_fn_name =
+        extern_fn_name(call.namespace.as_deref(), &trait_name.ident, &fn_name.ident);
 
     path.push_value(PathSegment {
-        ident: extern_fn_mod_name(&trait_name.value().ident),
+        ident: extern_fn_mod_name(&trait_name.ident),
         arguments: PathArguments::None,
     });
     quote! { unsafe { #path :: #extern_fn_name( #args ) } }.into()

--- a/components/ctor_bare/ctor_bare_macros/Cargo.toml
+++ b/components/ctor_bare/ctor_bare_macros/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 license = "Apache-2.0"
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }
 
 [lib]
 proc-macro = true

--- a/components/kasm-aarch64/Cargo.toml
+++ b/components/kasm-aarch64/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.2.1"
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
-proc-macro2 = "1.0"
-syn = { version = "2.0", features = ["extra-traits", "full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+syn = { workspace = true, features = ["extra-traits", "full"] }
 darling = "0.23"

--- a/components/percpu/percpu_macros/Cargo.toml
+++ b/components/percpu/percpu_macros/Cargo.toml
@@ -10,9 +10,9 @@ categories = ["development-tools::procedural-macro-helpers", "no-std"]
 license = "Apache-2.0"
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }
 
 [lib]
 proc-macro = true

--- a/components/starry-signal/Cargo.toml
+++ b/components/starry-signal/Cargo.toml
@@ -26,4 +26,4 @@ strum = { version = "0.27", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 ax-kspin = { workspace = true, features = ["host-test"] }
-extern-trait = "0.4"
+extern-trait = { workspace = true }

--- a/components/starry-vm/Cargo.toml
+++ b/components/starry-vm/Cargo.toml
@@ -22,7 +22,7 @@ bytemuck = { version = "1.24", features = [
     "const_zeroed",
     "zeroable_maybe_uninit",
 ] }
-extern-trait = "0.4"
+extern-trait = { workspace = true }
 
 [dev-dependencies]
 bytemuck = { version = "1.24", features = ["derive"] }

--- a/drivers/rdrive-macros/Cargo.toml
+++ b/drivers/rdrive-macros/Cargo.toml
@@ -12,6 +12,6 @@ categories = ["embedded", "no-std"]
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
-proc-macro2 = "1.0"
-syn = { version = "2.0", features = ["extra-traits", "full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+syn = { workspace = true, features = ["extra-traits", "full"] }

--- a/drivers/usb/usb-device/hid/keyboard/Cargo.toml
+++ b/drivers/usb/usb-device/hid/keyboard/Cargo.toml
@@ -12,7 +12,7 @@ crab-usb = {workspace = true}
 keyboard-types = { version = "0.8.3", default-features = false }
 log = "0.4"
 usb-if = {workspace = true}
-anyhow = {version = "1", default-features = false}
+anyhow = { workspace = true }
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/drivers/usb/usb-device/uvc/Cargo.toml
+++ b/drivers/usb/usb-device/uvc/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.1"
 crab-usb = {workspace = true}
 log = "0.4"
 usb-if = {workspace = true}
-anyhow = { version = "1", default-features = false}
+anyhow = { workspace = true }
 
 [target.'cfg(not(target_os = "none"))'.dev-dependencies]
 env_logger = "0.11"

--- a/drivers/usb/usb-host/Cargo.toml
+++ b/drivers/usb/usb-host/Cargo.toml
@@ -23,7 +23,7 @@ crossbeam-skiplist = {version = "0.1", features = [
 ], default-features = false}
 dma-api = {workspace = true}
 
-anyhow = {version = "1", default-features = false}
+anyhow = { workspace = true }
 enum_dispatch = "0.3"
 futures = {workspace = true, features = ["alloc"]}
 id-arena = {version = "2", default-features = false}

--- a/drivers/usb/usb-if/Cargo.toml
+++ b/drivers/usb/usb-if/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 version = "0.7.4"
 
 [dependencies]
-anyhow = { version = "1", default-features = false}
+anyhow = { workspace = true }
 futures = {workspace = true, features = ["alloc"]}
 log = {workspace = true}
 num_enum = {version = "0.7", default-features = false}

--- a/drivers/usb/utils/uvc-frame-parser/Cargo.toml
+++ b/drivers/usb/utils/uvc-frame-parser/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4"
 regex = "1.0"
 serde = {version = "1.0", features = ["derive"]}
 tokio = {version = "1", features = ["full"]}
-toml = "0.9"
+toml = { workspace = true, features = ["std", "serde", "parse", "display"] }
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/os/StarryOS/axnsproxy/Cargo.toml
+++ b/os/StarryOS/axnsproxy/Cargo.toml
@@ -21,4 +21,4 @@ log = "0.4"
 spin = { workspace = true }
 
 [build-dependencies]
-quote = "1.0"
+quote = { workspace = true }

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -167,7 +167,7 @@ chrono = { version = "0.4", default-features = false }
 downcast-rs = { version = "2.0", default-features = false, features = ["sync"] }
 enum_dispatch = "0.3"
 event-listener = { version = "5.4", default-features = false }
-extern-trait = "0.4"
+extern-trait = { workspace = true }
 flatten_objects = "0.2.4"
 hashbrown = "0.16"
 indoc = "2"

--- a/os/StarryOS/starryos/Cargo.toml
+++ b/os/StarryOS/starryos/Cargo.toml
@@ -66,7 +66,7 @@ axplat-dyn.workspace = true
 starry-kernel = { workspace = true, features = ["dev-log", "ext4"] }
 
 [target.'cfg(any(windows, all(unix, not(target_env = "musl"))))'.dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true, features = ["std"] }
 axbuild = { workspace = true }
 clap = { version = "4.6", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -59,4 +59,4 @@ rdrive.workspace = true
 spin.workspace = true
 
 [build-dependencies]
-quote = "1.0"
+quote = { workspace = true }

--- a/os/arceos/modules/axipi/Cargo.toml
+++ b/os/arceos/modules/axipi/Cargo.toml
@@ -19,4 +19,4 @@ log.workspace = true
 ax-percpu.workspace = true
 
 [build-dependencies]
-quote = "1.0"
+quote = { workspace = true }

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -126,4 +126,4 @@ rdrive.workspace = true
 spin = {workspace = true, optional = true}
 
 [build-dependencies]
-quote = "1.0"
+quote = { workspace = true }

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -78,7 +78,7 @@ ax-timer-list = {workspace = true, optional = true}
 axtest = {workspace = true, optional = true}
 axpoll = {workspace = true, optional = true}
 cfg-if.workspace = true
-extern-trait = {version = "0.4", optional = true}
+extern-trait = { workspace = true, optional = true }
 futures-util = {version = "0.3", default-features = false, optional = true, features = [
   "alloc",
   "async-await-macro",
@@ -90,4 +90,4 @@ spin = {workspace = true, optional = true}
 ax-hal = { workspace = true, features = ["fp-simd"] }
 
 [build-dependencies]
-quote = "1.0"
+quote = { workspace = true }

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -108,9 +108,9 @@ clap = { version = "4.6", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 
 [build-dependencies]
-anyhow = "1.0"
-prettyplease = "0.2"
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = "2.0"
-toml = "0.9"
+anyhow = { workspace = true, features = ["std"] }
+prettyplease = { workspace = true }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
+toml = { workspace = true, features = ["std", "serde", "parse", "display"] }

--- a/platforms/ax-plat-macros/Cargo.toml
+++ b/platforms/ax-plat-macros/Cargo.toml
@@ -10,9 +10,9 @@ authors = ["Yuekai Jia <equation618@gmail.com>", "Youjie Zheng <Azure_stars@126.
 license = "Apache-2.0"
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = { version = "2.0", features = ["full"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full"] }
 
 [lib]
 proc-macro = true

--- a/platforms/axplat-dyn/Cargo.toml
+++ b/platforms/axplat-dyn/Cargo.toml
@@ -22,7 +22,7 @@ hv = ["somehal/hv"]
 thead-mae = ["somehal/thead-mae", "ax-cpu/xuantie-c9xx"]
 
 [dependencies]
-anyhow = { version = "1", default-features = false }
+anyhow = { workspace = true }
 ax-cpu.workspace = true
 cpu-local.workspace = true
 ax-driver.workspace = true

--- a/platforms/someboot/Cargo.toml
+++ b/platforms/someboot/Cargo.toml
@@ -68,9 +68,9 @@ x86 = "0.52"
 sbi-rt = { workspace = true, features = ["legacy"] }
 
 [build-dependencies]
-prettyplease = "0.2"
-quote = "1.0"
-syn = "2.0"
+prettyplease = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true }
 
 [dev-dependencies]
 libc.workspace = true

--- a/platforms/somehal-macros/Cargo.toml
+++ b/platforms/somehal-macros/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 proc-macro = true
 
 [dependencies]
-quote = "1.0"
-proc-macro2 = "1.0"
-syn = { version = "2.0", features = ["extra-traits", "full"] }
+quote = { workspace = true }
+proc-macro2 = { workspace = true }
+syn = { workspace = true, features = ["extra-traits", "full"] }
 darling = "0.23"

--- a/platforms/somehal-macros/src/_entry.rs
+++ b/platforms/somehal-macros/src/_entry.rs
@@ -68,7 +68,7 @@ pub fn entry(args: TokenStream, input: TokenStream, name: &str) -> TokenStream {
 
     // XXX should we blacklist other attributes?
     let attrs = f.attrs;
-    let unsafety = f.sig.unsafety;
+    let safety = f.sig.safety;
     let args = f.sig.inputs;
     let stmts = f.block.stmts;
     let name = format_ident!("{}", name);
@@ -79,7 +79,7 @@ pub fn entry(args: TokenStream, input: TokenStream, name: &str) -> TokenStream {
         #[allow(non_snake_case)]
         #[unsafe(no_mangle)]
         #(#attrs)*
-        pub #unsafety extern "C" fn #name(#args) {
+        pub #safety extern "C" fn #name(#args) {
             somehal::init(&#kernel_type);
             #(#stmts)*
         }
@@ -121,7 +121,7 @@ pub fn entry_secondary(_args: TokenStream, input: TokenStream, is_someboot: bool
 
     // XXX should we blacklist other attributes?
     let attrs = f.attrs;
-    let unsafety = f.sig.unsafety;
+    let safety = f.sig.safety;
     // let args = f.sig.inputs;
     let stmts = f.block.stmts;
     let name = format_ident!("{}", name);
@@ -131,7 +131,7 @@ pub fn entry_secondary(_args: TokenStream, input: TokenStream, is_someboot: bool
         #[allow(unused_variables)]
         #[unsafe(no_mangle)]
         #(#attrs)*
-        pub #unsafety extern "C" fn #name(meta: &#crate_name::smp::PerCpuMeta) {
+        pub #safety extern "C" fn #name(meta: &#crate_name::smp::PerCpuMeta) {
             #(#stmts)*
         }
     )

--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -45,9 +45,9 @@ tracing-log = "0.2"
 tracing-subscriber = { version = "0.3", features = ["fmt", "std", "time"] }
 xz2 = "0.1"
 raw-cpuid = "11.0"
-proc-macro2 = { version = "1", features = ["span-locations"] }
-quote = "1"
-syn = { version = "2", features = ["full", "visit"] }
+proc-macro2 = { workspace = true, features = ["span-locations"] }
+quote = { workspace = true }
+syn = { workspace = true, features = ["full", "visit"] }
 walkdir = "2"
 
 [target.'cfg(windows)'.dependencies]

--- a/tools/qperf/Cargo.toml
+++ b/tools/qperf/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 test = false
 
 [dependencies]
-anyhow = "1.0.100"
+anyhow = { workspace = true, features = ["std"] }
 bincode.workspace = true
 crossbeam-channel = "0.5.15"
 qemu-plugin = { version = "10.1.0-v2", default-features = false, features = [

--- a/tools/qperf/analyzer/Cargo.toml
+++ b/tools/qperf/analyzer/Cargo.toml
@@ -10,7 +10,7 @@ flamegraph = ["inferno"]
 
 [dependencies]
 addr2line = "0.25.0"
-anyhow = "1.0.100"
+anyhow = { workspace = true, features = ["std"] }
 bincode.workspace = true
 clap = { version = "4.5.45", features = ["derive"] }
 inferno = { version = "0.12", optional = true, default-features = false }

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -24,7 +24,7 @@ tls = ["ax-hal/tls", "ax-std/tls", "cpu-local/tls"]
 [dependencies]
 log = "0.4"
 cfg-if = "1.0"
-extern-trait = "0.4"
+extern-trait = { workspace = true }
 bit_field = "0.10"
 bitflags = "2.9"
 byte-unit = { version = "5", default-features = false, features = ["byte"] }


### PR DESCRIPTION
## 问题

`anyhow`、`extern-trait`、`prettyplease`、`proc-macro2`、`quote`、`syn` 和 `toml` 在多个成员 crate 中分别声明版本，容易产生版本漂移，也增加了统一升级和特性审计的成本。

## 修改

- 在根 `Cargo.toml` 的 `[workspace.dependencies]` 中统一上述依赖，并升级到当前最新版本。
- 成员 crate 统一通过 `workspace = true` 继承版本，同时保留各自需要的 `optional` 和 feature 配置。
- `toml` 使用大版本约束 `1`；`apps/` 下的 `anyhow` 声明保持原样，仍使用大版本约束。
- 适配 `syn 3` 的 AST API 变化，包括 trait impl 路径、路径段访问和函数签名安全性字段。
- 对需要宿主机 `std` 的工具与 OS 入口显式启用 `anyhow/std` 或 `toml/std`，避免根工作区依赖关闭默认特性后改变原有行为。
- 更新 `Cargo.lock`；第三方依赖仍可按其自身约束保留旧版传递依赖。

## 实现逻辑

根工作区作为直接依赖版本的唯一来源，成员只声明用途相关的特性。这样既能确保项目内直接依赖使用同一版本，又不会误改第三方传递依赖或 `apps/` 的既有版本策略。升级 `syn` 后只调整受影响的 AST 访问点，不改变宏展开语义。

## 验证

- `cargo fmt --all -- --check`
- `cargo metadata --format-version 1 --locked --no-deps`
- 受影响 crate 的 127 项 `cargo xtask clippy` 检查全部通过
- 宏相关 crate 的定向 `cargo xtask clippy` 全部通过
- `cargo test -p ax-crate-interface`
- `cargo test -p starry-vm -p starry-signal`
- `cargo xtask axvisor build --arch x86_64`
- `cargo xtask sync-lint`
- `cargo xtask spin-lint`

## 已知基线问题

完整 `cargo test -p axbuild` 在当前 `dev` 基线上有两个可独立复现、且本补丁未修改相关代码的失败：测试仓库 fixture 无可提交内容，以及测试期待已不存在的 `alias.xtask` 配置。实际 Axvisor 官方构建流程已通过。PR CI 若覆盖这些路径，将根据 Actions 的实际失败继续处理。
