### PR TITLE
refactor(axvisor): clean up host dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,15 +1605,10 @@ name = "axvisor"
 version = "0.5.23"
 dependencies = [
  "anyhow",
- "ax-crate-interface",
  "ax-driver",
- "ax-hal",
- "ax-kspin",
  "ax-std",
- "ax-sync",
  "axbacktrace",
  "axbuild",
- "axplat-dyn",
  "axtest",
  "axvm",
  "axvmconfig",
@@ -1622,7 +1617,6 @@ dependencies = [
  "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
- "spin",
  "syn 3.0.3",
  "tokio",
  "toml 1.1.4+spec-1.1.0",

--- a/book/design/axvm-host-application-boundary.md
+++ b/book/design/axvm-host-application-boundary.md
@@ -1,0 +1,95 @@
+# AxVM Host/Application Boundary
+
+## Status
+
+This design records the dependency boundary used by Axvisor and AxVM. The
+change is behavior-preserving: it moves existing host operations behind a
+narrow owner-provided API without changing VM configuration or device handoff
+semantics.
+
+## Problem
+
+Axvisor is the application that selects VM policy and orchestrates VM
+lifecycle. It previously depended directly on `ax-hal` for console and CPU
+operations and on `ax-driver` for the x86 QEMU block-device INTx handoff. Those
+dependencies exposed the implementation types of AxVM's ArceOS host adapter to
+the application and allowed the VM lifecycle to bypass its owner.
+
+Axvisor also exposed aliases for board-driver features. That duplicated
+`ax-driver`'s hardware capability names and made it unclear whether the feature
+belonged to the application or to its build configuration.
+
+## Goals
+
+- Keep Axvisor dependent on `axvm` for VM and VM-related host operations.
+- Keep host HAL and driver types out of the Axvisor API surface.
+- Preserve the single-reader host-console invariant.
+- Preserve the x86 passthrough ordering and error behavior.
+- Select board-driver features directly in build configuration without
+  exposing driver APIs or duplicate feature aliases in Axvisor.
+
+## Non-goals
+
+- Making AxVM independent from its ArceOS host adapter.
+- Defining a general-purpose public HAL or driver abstraction.
+- Changing host-console polling into an interrupt-driven design.
+- Generalizing the QEMU block passthrough profile to arbitrary PCI devices.
+- Changing guest configuration syntax, IRQ routing policy, or VM startup order.
+
+## Considered Boundaries
+
+Keeping direct source-level access to the HAL and driver APIs was rejected
+because it preserves duplicated ownership of host state. Exporting the complete
+internal `HostCpu`, `HostMemory`, `HostTime`, and `HostPlatform` traits was
+rejected because it would turn implementation-oriented runtime capabilities
+into a broad public API. Adding raw HAL and driver wrappers to Axvisor was
+rejected because it only renames the dependency without correcting ownership.
+
+The selected boundary exposes only operations that the Axvisor application
+must orchestrate:
+
+- `axvm::host::console` controls and accesses the physical host console.
+- `axvm::host::cpu` reports host CPU topology needed for console-reader
+  placement.
+- `axvm::host::x86` owns the fixed QEMU block-device IRQ route and handoff.
+
+The public functions use AxVM types or plain data only. `ax-hal` IRQ types,
+`ax-driver` PCI descriptors, and internal host traits remain private.
+
+## Ownership and Lifecycle
+
+Axvisor remains the policy owner: it decides when a filesystem-backed
+passthrough VM requires host resource release and when guest startup may
+continue. AxVM owns the mechanism and preserves this ordering:
+
+1. After the VM is registered, AxVM resolves the host PCI INTx binding and
+   installs the guest IOAPIC forwarding route and activation callback.
+2. Axvisor requests host-filesystem shutdown through AxVM.
+3. AxVM asks the host driver to prepare the QEMU block device for passthrough.
+4. When the forwarding route activates during guest startup, AxVM unmasks the
+   host INTx source.
+
+Route discovery and device preparation remain best-effort and log unsupported
+host configurations, matching the previous behavior. Failure to install an
+AxVM forwarding route remains a VM initialization error.
+
+The console API is task-context-only. Axvisor's multiplexer remains the sole
+physical input reader, disables input interrupts, and polls one byte at a time.
+The boundary does not introduce another buffer, reader, or IRQ callback.
+
+## Feature Ownership
+
+Axvisor board and test configurations select nested `ax-driver/<feature>`
+features directly. The optional Axvisor dependency is a Cargo feature-routing
+anchor: it becomes active only when a configuration selects one of those
+driver features, while Axvisor source code never calls the driver API. AxVM
+separately enables its x86 PCI driver dependency for the `host-fs` capability
+that performs the QEMU block-device handoff.
+
+## Validation
+
+The change is validated by checking that Axvisor's default graph has no direct
+dependency on `ax-hal`, `ax-driver`, `ax-kspin`, `ax-sync`, or `spin`; building
+Axvisor for x86_64, AArch64, and RISC-V; running targeted clippy checks; and
+exercising the Axvisor x86 QEMU/axtest flow where the environment provides the
+required guest image.

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -46,24 +46,10 @@ host-xtask = []
 axtest = []
 fs = ["ax-std/ext4fs", "ax-std/fatfs", "axvm/host-fs"]
 sstc = ["axvm/sstc"]
-rockchip-soc = ["ax-driver/rockchip-soc"]
-rockchip-sdhci = ["ax-driver/rockchip-sdhci", "ax-driver/rockchip-soc"]
-phytium-mci = ["ax-driver/phytium-mci"]
-ahci-fdt = ["ax-driver/ahci-fdt"]
-sdmmc = [
-    "ax-driver/rockchip-sdhci",
-    "ax-driver/rockchip-soc",
-]
-rockchip-pm = ["ax-driver/rockchip-pm"]
 stack-protector = ["ax-std/stack-protector"]
 backtrace = ["ax-std/backtrace", "dep:axbacktrace"]
 test-backtrace-panic = ["backtrace"]
 test-panic-no-backtrace = ["dep:axbacktrace"]
-
-[dependencies]
-spin = { workspace = true }
-ax-kspin = { workspace = true }
-ax-crate-interface = { workspace = true }
 
 [target.'cfg(any(not(any(windows, unix)), target_env = "musl"))'.dependencies]
 anyhow.workspace = true
@@ -83,19 +69,12 @@ ax-std = { workspace = true, default-features = false, features = [
   "tls",
   "std-compat",
 ] }
-ax-hal = { workspace = true, features = ["paging", "irq", "smp", "hv"] }
-ax-sync = { workspace = true, features = ["multitask"] }
 # System dependent modules provided by ArceOS-Hypervisor (bare-metal only)
 # ax-runtime = { version = "=0.3.0-preview.1", features = ["alloc", "irq", "paging", "smp", "multitask"] }
 axvm = { workspace = true, default-features = false, features = ["tls"] }
 axvmconfig = { workspace = true, default-features = false }
-# System independent crates provided by ArceOS
-ax-driver.workspace = true
-axplat-dyn.workspace = true
+ax-driver = { workspace = true, optional = true }
 axbacktrace = { workspace = true, optional = true }
-
-[target.'cfg(target_arch = "riscv64")'.dependencies]
-axplat-dyn = { workspace = true, features = ["hv"] }
 
 [dev-dependencies]
 axtest.workspace = true

--- a/os/axvisor/configs/board/orangepi-5-plus.toml
+++ b/os/axvisor/configs/board/orangepi-5-plus.toml
@@ -1,6 +1,5 @@
 features = [
-  "sdmmc",
-  "rockchip-soc",
+  "ax-driver/rockchip-sdhci",
   "fs",
 ]
 log = "Info"

--- a/os/axvisor/configs/board/phytiumpi.toml
+++ b/os/axvisor/configs/board/phytiumpi.toml
@@ -1,7 +1,7 @@
 features = [
     "fs",
-    "ahci-fdt",
-    "phytium-mci",
+    "ax-driver/ahci-fdt",
+    "ax-driver/phytium-mci",
 ]
 log = "Info"
 target = "aarch64-unknown-none-softfloat"

--- a/os/axvisor/configs/board/roc-rk3568-pc.toml
+++ b/os/axvisor/configs/board/roc-rk3568-pc.toml
@@ -1,6 +1,6 @@
 features = [
     "fs",
-    "rockchip-sdhci",
+    "ax-driver/rockchip-sdhci",
 ]
 log = "Info"
 target = "aarch64-unknown-none-softfloat"

--- a/os/axvisor/src/config.rs
+++ b/os/axvisor/src/config.rs
@@ -23,8 +23,6 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use anyhow::{Context, Result, bail};
-#[cfg(all(feature = "fs", target_arch = "x86_64"))]
-use axvm::InterruptTriggerMode;
 use axvm::{
     AxVM, GuestPhysAddr,
     boot::{
@@ -184,7 +182,8 @@ pub fn init_guest_vm(raw_cfg: &str) -> Result<usize> {
     ))]
     if release_host_filesystem {
         #[cfg(target_arch = "x86_64")]
-        register_x86_host_fs_passthrough_irq_route(&vm)?;
+        axvm::host::x86::register_qemu_block_passthrough_irq(&vm)
+            .context("register x86 QEMU block passthrough IRQ route")?;
         HOST_FILESYSTEM_RELEASE_REQUIRED.store(true, Ordering::Release);
     }
 
@@ -271,129 +270,6 @@ fn vm_config_needs_host_filesystem_release(config: &GuestConfig) -> bool {
 ))]
 pub fn host_filesystem_release_required() -> bool {
     HOST_FILESYSTEM_RELEASE_REQUIRED.load(Ordering::Acquire)
-}
-
-#[cfg(all(feature = "fs", target_arch = "x86_64"))]
-fn register_x86_host_fs_passthrough_irq_route(vm: &axvm::AxVMRef) -> Result<()> {
-    let (_, _, _, guest_gsi) = axvm::boot::x86_qemu_passthrough_block_intx();
-    let info = x86_host_fs_passthrough_pci_info();
-
-    let route = match ax_driver::pci::resolve_intx_binding(info) {
-        Ok(Some(binding)) => {
-            let trigger = x86_intx_forwarding_trigger(&binding);
-            resolve_binding_irq(binding).map(|host_irq| (host_irq, trigger))
-        }
-        Ok(None) => {
-            warn!("x86 host filesystem passthrough PCI INTx route was not found for {info:?}");
-            return Ok(());
-        }
-        Err(err) => {
-            warn!("failed to resolve x86 host filesystem passthrough PCI INTx route: {err:?}");
-            return Ok(());
-        }
-    };
-
-    match route {
-        Ok((host_irq, trigger)) => {
-            axvm::register_x86_ioapic_irq_forwarding_route_with_trigger(
-                vm, guest_gsi, host_irq, trigger,
-            )
-            .context("register x86 host filesystem PCI INTx forwarding route")?;
-            axvm::register_x86_ioapic_irq_forwarding_activator(
-                vm,
-                guest_gsi,
-                unmask_x86_host_fs_passthrough_intx,
-            )
-            .context("register x86 host filesystem PCI INTx forwarding activator")?;
-            info!(
-                "Registered x86 host filesystem PCI INTx forwarding route: guest GSI \
-                 {guest_gsi} <- host IRQ {host_irq:?}, trigger {trigger:?}"
-            );
-        }
-        Err(err) => {
-            warn!(
-                "failed to resolve x86 host filesystem passthrough IRQ source into host IRQ: \
-                 {err:?}"
-            );
-        }
-    }
-    Ok(())
-}
-
-#[cfg(all(feature = "fs", target_arch = "x86_64"))]
-pub(crate) fn prepare_x86_host_fs_passthrough_devices() {
-    let info = x86_host_fs_passthrough_pci_info();
-    match ax_driver::pci::prepare_intx_passthrough(info) {
-        Ok(()) => {
-            info!("Prepared x86 host filesystem PCI INTx passthrough device {info:?}");
-        }
-        Err(err) => {
-            warn!("failed to prepare x86 host filesystem PCI INTx passthrough device: {err:?}");
-        }
-    }
-}
-
-#[cfg(all(feature = "fs", target_arch = "x86_64"))]
-fn unmask_x86_host_fs_passthrough_intx() {
-    let info = x86_host_fs_passthrough_pci_info();
-    match ax_driver::pci::unmask_intx_passthrough(info) {
-        Ok(()) => {
-            info!("Unmasked x86 host filesystem PCI INTx passthrough device {info:?}");
-        }
-        Err(err) => {
-            warn!("failed to unmask x86 host filesystem PCI INTx passthrough device: {err:?}");
-        }
-    }
-}
-
-#[cfg(all(feature = "fs", target_arch = "x86_64"))]
-fn x86_host_fs_passthrough_pci_info() -> ax_driver::probe::pci::PciInfo {
-    use ax_driver::probe::pci::{PciAddress, PciInfo, PciIntxRoute};
-
-    let (device, function, pin, _) = axvm::boot::x86_qemu_passthrough_block_intx();
-    PciInfo {
-        address: PciAddress::new(0, 0, device, function),
-        interrupt_pin: pin,
-        interrupt_line: 0,
-        intx_route: Some(PciIntxRoute {
-            root_device: device,
-            root_function: function,
-            root_pin: pin,
-        }),
-    }
-}
-
-#[cfg(all(feature = "fs", target_arch = "x86_64"))]
-fn resolve_binding_irq(
-    binding: ax_driver::BindingIrq,
-) -> Result<ax_hal::irq::IrqId, ax_hal::irq::IrqError> {
-    use ax_hal::irq;
-
-    match binding {
-        ax_driver::BindingIrq::Id(irq) => Ok(irq),
-        ax_driver::BindingIrq::Source(source) => match source {
-            ax_driver::BindingIrqSource::AcpiGsi(gsi) => {
-                irq::resolve_irq_source(irq::IrqSource::AcpiGsi(gsi))
-            }
-            ax_driver::BindingIrqSource::AcpiGsiRoute(route) => {
-                irq::resolve_irq_source(irq::IrqSource::AcpiGsiRoute(route))
-            }
-            ax_driver::BindingIrqSource::FdtInterrupt(_) => Err(irq::IrqError::Unsupported),
-        },
-    }
-}
-
-#[cfg(all(feature = "fs", target_arch = "x86_64"))]
-fn x86_intx_forwarding_trigger(binding: &ax_driver::BindingIrq) -> InterruptTriggerMode {
-    match binding {
-        ax_driver::BindingIrq::Source(ax_driver::BindingIrqSource::AcpiGsiRoute(route)) => {
-            match route.trigger {
-                ax_hal::irq::AcpiIrqTrigger::Edge => InterruptTriggerMode::EdgeTriggered,
-                ax_hal::irq::AcpiIrqTrigger::Level => InterruptTriggerMode::LevelTriggered,
-            }
-        }
-        _ => InterruptTriggerMode::LevelTriggered,
-    }
 }
 
 struct AxvisorBootImageProvider;

--- a/os/axvisor/src/guest_console/host.rs
+++ b/os/axvisor/src/guest_console/host.rs
@@ -38,10 +38,10 @@ fn console_reader_isolation_cpu(
 /// stay disabled until the host UART IRQ contract can transfer received bytes
 /// to that owner without introducing a second reader.
 pub(crate) fn configure_host_console_reader(vms: &[AxVMRef]) -> Result<()> {
-    ax_hal::console::set_input_irq_enabled(false);
+    axvm::host::console::set_input_irq_enabled(false);
 
     let isolation_cpu = console_reader_isolation_cpu(
-        ax_hal::cpu_num(),
+        axvm::host::cpu::count(),
         vms.iter()
             .flat_map(|vm| vm.vcpu_snapshots())
             .map(|vcpu| vcpu.phys_cpu_set),
@@ -67,7 +67,7 @@ pub(crate) fn configure_host_console_reader(vms: &[AxVMRef]) -> Result<()> {
     if !ax_task::set_current_affinity(owner_affinity) {
         bail!("failed to pin the host console reader to CPU {owner_cpu}");
     }
-    let actual_owner_cpu = ax_hal::percpu::this_cpu_id();
+    let actual_owner_cpu = axvm::host::cpu::current_id();
     if actual_owner_cpu != owner_cpu {
         bail!(
             "host console reader affinity selected CPU {owner_cpu}, but migration ended on CPU \
@@ -83,7 +83,7 @@ pub(crate) fn configure_host_console_reader(vms: &[AxVMRef]) -> Result<()> {
 /// No other Axvisor component may call the platform console input API.
 pub(crate) fn read_host_byte() -> Option<u8> {
     let mut byte = [0u8; 1];
-    (ax_hal::console::read_bytes(&mut byte) == 1).then_some(byte[0])
+    (axvm::host::console::read_bytes(&mut byte) == 1).then_some(byte[0])
 }
 
 /// Yields between polling attempts so other runnable host tasks can progress.
@@ -92,7 +92,7 @@ pub(crate) fn wait_for_host_input() {
 }
 
 pub(super) fn write_host_bytes(bytes: &[u8]) {
-    ax_hal::console::write_bytes(bytes);
+    axvm::host::console::write_bytes(bytes);
 }
 
 #[cfg(test)]

--- a/os/axvisor/src/guest_console/mux/mod.rs
+++ b/os/axvisor/src/guest_console/mux/mod.rs
@@ -7,11 +7,9 @@ use alloc::{
 };
 
 use anyhow::{Result, bail};
-use ax_kspin::SpinRaw as StateLock;
-use ax_sync::Mutex as TaskMutex;
 use axvm::{SerialBackend, SerialBackendFactory, VMId, VmStatus};
 use core::ops::Bound::{Excluded, Unbounded};
-use spin::LazyLock;
+use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use super::host::write_host_bytes;
 
@@ -63,11 +61,11 @@ pub struct GuestConsoleMux {
 
 #[derive(Debug)]
 struct ConsoleCore {
-    state: StateLock<ConsoleState>,
+    state: Mutex<ConsoleState>,
     /// Serializes host writes with backend replacement and invalidation.
     ///
     /// Code that needs both locks must acquire `output_lock` before `state`.
-    output_lock: TaskMutex<()>,
+    output_lock: Mutex<()>,
 }
 
 #[derive(Debug, Default)]
@@ -84,19 +82,10 @@ struct ConsoleState {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct BackendGeneration(u64);
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct GuestState {
     backend_generation: Option<BackendGeneration>,
     input: VecDeque<u8>,
-}
-
-impl Default for GuestState {
-    fn default() -> Self {
-        Self {
-            backend_generation: None,
-            input: VecDeque::new(),
-        }
-    }
 }
 
 #[derive(Debug)]
@@ -116,14 +105,14 @@ impl GuestConsoleMux {
     fn new() -> Self {
         Self {
             core: Arc::new(ConsoleCore {
-                state: StateLock::new(ConsoleState::default()),
-                output_lock: TaskMutex::new(()),
+                state: Mutex::new(ConsoleState::default()),
+                output_lock: Mutex::new(()),
             }),
         }
     }
 
     fn set_running(&self, running: impl IntoIterator<Item = VMId>) -> Option<VMId> {
-        let mut state = self.core.state.lock();
+        let mut state = self.core.lock_state();
         state.running.clear();
         for vm_id in running {
             state.running.insert(vm_id);
@@ -145,14 +134,14 @@ impl GuestConsoleMux {
     }
 
     fn mark_running(&self, vm_id: VMId) {
-        let mut state = self.core.state.lock();
+        let mut state = self.core.lock_state();
         state.running.insert(vm_id);
         state.guests.entry(vm_id).or_default();
     }
 
     fn mark_stopped(&self, vm_id: VMId) -> bool {
-        let _output_guard = self.core.output_lock.lock();
-        let mut state = self.core.state.lock();
+        let _output_guard = self.core.lock_output();
+        let mut state = self.core.lock_state();
         state.running.remove(&vm_id);
         if let Some(guest) = state.guests.get_mut(&vm_id) {
             guest.backend_generation = None;
@@ -168,8 +157,8 @@ impl GuestConsoleMux {
     }
 
     fn remove(&self, vm_id: VMId) -> bool {
-        let _output_guard = self.core.output_lock.lock();
-        let mut state = self.core.state.lock();
+        let _output_guard = self.core.lock_output();
+        let mut state = self.core.lock_state();
         state.running.remove(&vm_id);
         state.guests.remove(&vm_id);
         state.output.reset_guest(vm_id);
@@ -186,7 +175,7 @@ impl GuestConsoleMux {
 
     fn attach_default(&self, running: impl IntoIterator<Item = VMId>) -> Option<VMId> {
         self.set_running(running);
-        let mut state = self.core.state.lock();
+        let mut state = self.core.lock_state();
         let vm_id = state.running.first().copied()?;
         state.attached = Some(vm_id);
         state.last_attached = Some(vm_id);
@@ -194,7 +183,7 @@ impl GuestConsoleMux {
     }
 
     fn attach(&self, vm_id: VMId) -> bool {
-        let mut state = self.core.state.lock();
+        let mut state = self.core.lock_state();
         if !state.running.contains(&vm_id) {
             return false;
         }
@@ -205,11 +194,11 @@ impl GuestConsoleMux {
     }
 
     fn attached_vm(&self) -> Option<VMId> {
-        self.core.state.lock().attached
+        self.core.lock_state().attached
     }
 
     fn route_host_byte(&self, byte: u8) -> RoutedInput {
-        let mut state = self.core.state.lock();
+        let mut state = self.core.lock_state();
 
         if state.shortcut_prefix_pending {
             state.shortcut_prefix_pending = false;
@@ -306,10 +295,22 @@ fn switch_guest(state: &mut ConsoleState, direction: GuestSwitchDirection) -> Ro
 }
 
 impl ConsoleCore {
+    fn lock_state(&self) -> MutexGuard<'_, ConsoleState> {
+        self.state
+            .lock()
+            .expect("guest console state mutex poisoned")
+    }
+
+    fn lock_output(&self) -> MutexGuard<'_, ()> {
+        self.output_lock
+            .lock()
+            .expect("guest console output mutex poisoned")
+    }
+
     fn create_serial_backend(self: &Arc<Self>, vm_id: VMId) -> Arc<GuestSerialBackend> {
-        let _output_guard = self.output_lock.lock();
+        let _output_guard = self.lock_output();
         let generation = {
-            let mut state = self.state.lock();
+            let mut state = self.lock_state();
             state.next_backend_generation = state
                 .next_backend_generation
                 .checked_add(1)
@@ -338,7 +339,7 @@ impl ConsoleCore {
         generation: BackendGeneration,
         buffer: &mut [u8],
     ) -> usize {
-        let mut state = self.state.lock();
+        let mut state = self.lock_state();
         let Some(guest) = state
             .guests
             .get_mut(&vm_id)
@@ -362,7 +363,7 @@ impl ConsoleCore {
         generation: BackendGeneration,
         bytes: &[u8],
     ) -> Option<Vec<u8>> {
-        let mut state = self.state.lock();
+        let mut state = self.lock_state();
         let multiple_running = state.running.len() > 1;
         state
             .guests
@@ -376,7 +377,7 @@ impl ConsoleCore {
             return;
         }
 
-        let _output_guard = self.output_lock.lock();
+        let _output_guard = self.lock_output();
         if let Some(output) = self.format_guest_output(vm_id, generation, bytes) {
             write_host_bytes(&output);
         }

--- a/os/axvisor/src/guest_console/mux/tests.rs
+++ b/os/axvisor/src/guest_console/mux/tests.rs
@@ -93,7 +93,7 @@ fn stopped_or_removed_guest_invalidates_its_serial_backend_generation() {
     let removed_backend = mux.core.create_serial_backend(3);
     mux.remove(3);
     removed_backend.write(b"late output");
-    assert!(!mux.core.state.lock().guests.contains_key(&3));
+    assert!(!mux.core.lock_state().guests.contains_key(&3));
 }
 
 #[test]

--- a/os/axvisor/src/manager.rs
+++ b/os/axvisor/src/manager.rs
@@ -115,7 +115,7 @@ impl AxvmManager {
             "Failed to release host filesystem before guest passthrough devices take ownership",
         );
         #[cfg(target_arch = "x86_64")]
-        crate::config::prepare_x86_host_fs_passthrough_devices();
+        axvm::host::x86::prepare_qemu_block_passthrough_device();
         info!("Host filesystem cleanly unmounted before guest passthrough devices start");
     }
 

--- a/os/axvisor/src/shell/command/mod.rs
+++ b/os/axvisor/src/shell/command/mod.rs
@@ -27,9 +27,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     string::ToString,
 };
-use std::{print, println};
-
-use spin::LazyLock;
+use std::{print, println, sync::LazyLock};
 
 pub static COMMAND_TREE: LazyLock<BTreeMap<String, CommandNode>> =
     LazyLock::new(build_command_tree);

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -1,6 +1,5 @@
 features = [
-  "sdmmc",
-  "rockchip-soc",
+  "ax-driver/rockchip-sdhci",
   "fs",
 ]
 log = "Info"

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/starry/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/starry/build-aarch64-unknown-none-softfloat.toml
@@ -1,6 +1,5 @@
 features = [
-  "sdmmc",
-  "rockchip-soc",
+  "ax-driver/rockchip-sdhci",
   "fs",
 ]
 log = "Info"

--- a/test-suit/axvisor/normal/board-phytiumpi/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-phytiumpi/build-aarch64-unknown-none-softfloat.toml
@@ -1,6 +1,6 @@
 features = [
     "fs",
-    "phytium-mci",
+    "ax-driver/phytium-mci",
 ]
 log = "Info"
 target = "aarch64-unknown-none-softfloat"

--- a/test-suit/axvisor/normal/board-roc-rk3568-pc/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-roc-rk3568-pc/build-aarch64-unknown-none-softfloat.toml
@@ -1,6 +1,5 @@
 features = [
-  "rockchip-sdhci",
-  "rockchip-soc",
+  "ax-driver/rockchip-sdhci",
   "fs",
 ]
 log = "Info"

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [features]
 fs = ["ax-std/fs"]
-host-fs = ["ax-std/fs"]
+host-fs = ["ax-std/fs", "dep:ax-driver"]
 host-test = [
     "ax-hal/host-test",
     "ax-kspin/host-test",
@@ -68,6 +68,7 @@ fdt-edit = { workspace = true }
 fdt-raw = { workspace = true }
 hashbrown = "0.14"
 [target.'cfg(target_arch = "x86_64")'.dependencies]
+ax-driver = { workspace = true, optional = true, features = ["pci"] }
 x86 = "0.52"
 x86_vcpu = { workspace = true }
 x86_vlapic = { workspace = true }

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -100,6 +100,18 @@ pub(crate) fn dispatch_host_irq(vector: usize) {
     modules::ax_hal::irq::handle_irq(vector);
 }
 
+pub(crate) fn set_console_input_irq_enabled(enabled: bool) {
+    modules::ax_hal::console::set_input_irq_enabled(enabled);
+}
+
+pub(crate) fn read_console_bytes(bytes: &mut [u8]) -> usize {
+    modules::ax_hal::console::read_bytes(bytes)
+}
+
+pub(crate) fn write_console_bytes(bytes: &[u8]) {
+    modules::ax_hal::console::write_bytes(bytes);
+}
+
 impl HostCpu for ArceOsHost {
     type CpuMask = api::task::AxCpuMask;
 
@@ -189,6 +201,121 @@ pub fn shutdown_host_filesystems() -> AxVmResult {
         info!("Released {released} host filesystem block IRQ registration(s) before passthrough");
     }
     Ok(())
+}
+
+#[cfg(all(feature = "host-fs", target_arch = "x86_64"))]
+pub(crate) fn register_qemu_block_passthrough_irq(vm: &crate::AxVMRef) -> AxVmResult {
+    let (_, _, _, guest_gsi) = crate::boot::x86_qemu_passthrough_block_intx();
+    let info = qemu_block_passthrough_pci_info();
+
+    let route = match ax_driver::pci::resolve_intx_binding(info) {
+        Ok(Some(binding)) => {
+            let trigger = intx_forwarding_trigger(&binding);
+            resolve_binding_irq(binding).map(|host_irq| (host_irq, trigger))
+        }
+        Ok(None) => {
+            warn!("x86 QEMU block passthrough PCI INTx route was not found for {info:?}");
+            return Ok(());
+        }
+        Err(error) => {
+            warn!("failed to resolve x86 QEMU block passthrough PCI INTx route: {error:?}");
+            return Ok(());
+        }
+    };
+
+    match route {
+        Ok((host_irq, trigger)) => {
+            crate::register_x86_ioapic_irq_forwarding_route_with_trigger(
+                vm, guest_gsi, host_irq, trigger,
+            )?;
+            crate::register_x86_ioapic_irq_forwarding_activator(
+                vm,
+                guest_gsi,
+                unmask_qemu_block_passthrough_intx,
+            )?;
+            info!(
+                "Registered x86 QEMU block passthrough PCI INTx forwarding route: guest GSI \
+                 {guest_gsi} <- host IRQ {host_irq:?}, trigger {trigger:?}"
+            );
+        }
+        Err(error) => {
+            warn!(
+                "failed to resolve x86 QEMU block passthrough IRQ source into host IRQ: {error:?}"
+            );
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(feature = "host-fs", target_arch = "x86_64"))]
+pub(crate) fn prepare_qemu_block_passthrough_device() {
+    let info = qemu_block_passthrough_pci_info();
+    match ax_driver::pci::prepare_intx_passthrough(info) {
+        Ok(()) => info!("Prepared x86 QEMU block PCI INTx passthrough device {info:?}"),
+        Err(error) => {
+            warn!("failed to prepare x86 QEMU block PCI INTx passthrough device: {error:?}");
+        }
+    }
+}
+
+#[cfg(all(feature = "host-fs", target_arch = "x86_64"))]
+fn unmask_qemu_block_passthrough_intx() {
+    let info = qemu_block_passthrough_pci_info();
+    match ax_driver::pci::unmask_intx_passthrough(info) {
+        Ok(()) => info!("Unmasked x86 QEMU block PCI INTx passthrough device {info:?}"),
+        Err(error) => {
+            warn!("failed to unmask x86 QEMU block PCI INTx passthrough device: {error:?}");
+        }
+    }
+}
+
+#[cfg(all(feature = "host-fs", target_arch = "x86_64"))]
+fn qemu_block_passthrough_pci_info() -> ax_driver::probe::pci::PciInfo {
+    use ax_driver::probe::pci::{PciAddress, PciInfo, PciIntxRoute};
+
+    let (device, function, pin, _) = crate::boot::x86_qemu_passthrough_block_intx();
+    PciInfo {
+        address: PciAddress::new(0, 0, device, function),
+        interrupt_pin: pin,
+        interrupt_line: 0,
+        intx_route: Some(PciIntxRoute {
+            root_device: device,
+            root_function: function,
+            root_pin: pin,
+        }),
+    }
+}
+
+#[cfg(all(feature = "host-fs", target_arch = "x86_64"))]
+fn resolve_binding_irq(
+    binding: ax_driver::BindingIrq,
+) -> Result<modules::ax_hal::irq::IrqId, modules::ax_hal::irq::IrqError> {
+    use modules::ax_hal::irq;
+
+    if let Some(irq) = binding.irq_id() {
+        return Ok(irq);
+    }
+    let Some(source) = binding.as_irq_source() else {
+        return Err(irq::IrqError::Unsupported);
+    };
+    irq::resolve_irq_source(source)
+}
+
+#[cfg(all(feature = "host-fs", target_arch = "x86_64"))]
+fn intx_forwarding_trigger(binding: &ax_driver::BindingIrq) -> crate::InterruptTriggerMode {
+    match binding {
+        ax_driver::BindingIrq::Source(ax_driver::BindingIrqSource::AcpiGsiRoute(route)) => {
+            match route.trigger {
+                modules::ax_hal::irq::AcpiIrqTrigger::Edge => {
+                    crate::InterruptTriggerMode::EdgeTriggered
+                }
+                modules::ax_hal::irq::AcpiIrqTrigger::Level => {
+                    crate::InterruptTriggerMode::LevelTriggered
+                }
+            }
+        }
+        _ => crate::InterruptTriggerMode::LevelTriggered,
+    }
 }
 
 impl HostPlatform for ArceOsHost {

--- a/virtualization/axvm/src/host/mod.rs
+++ b/virtualization/axvm/src/host/mod.rs
@@ -1,4 +1,4 @@
-//! Internal host boundary used by the AxVM runtime.
+//! Narrow host services owned by the AxVM runtime.
 
 pub(crate) mod arceos;
 pub(crate) mod paging;
@@ -11,3 +11,55 @@ pub(crate) fn default_host() -> &'static arceos::ArceOsHost {
 
 pub(crate) use paging::PagingHandler;
 pub(crate) use traits::{HostCpu, HostMemory, HostPlatform, HostTime};
+
+/// Physical host-console operations required by an AxVM application.
+///
+/// Callers must keep a single owner for console input. These operations are
+/// intended for task context; they do not provide an IRQ-safe buffering layer.
+pub mod console {
+    /// Enables or disables physical host-console input interrupts.
+    pub fn set_input_irq_enabled(enabled: bool) {
+        super::arceos::set_console_input_irq_enabled(enabled);
+    }
+
+    /// Reads available bytes from the physical host console.
+    pub fn read_bytes(bytes: &mut [u8]) -> usize {
+        super::arceos::read_console_bytes(bytes)
+    }
+
+    /// Writes bytes to the physical host console.
+    pub fn write_bytes(bytes: &[u8]) {
+        super::arceos::write_console_bytes(bytes);
+    }
+}
+
+/// Physical host-CPU information required by an AxVM application.
+pub mod cpu {
+    use super::HostCpu;
+
+    /// Returns the number of physical host CPUs.
+    pub fn count() -> usize {
+        super::default_host().cpu_count()
+    }
+
+    /// Returns the current physical host CPU ID.
+    pub fn current_id() -> usize {
+        super::default_host().this_cpu_id()
+    }
+}
+
+/// x86 host-device handoff required by AxVM's QEMU block passthrough profile.
+#[cfg(all(feature = "host-fs", target_arch = "x86_64"))]
+pub mod x86 {
+    use crate::{AxVMRef, AxVmResult};
+
+    /// Resolves and registers the host INTx route for the QEMU block device.
+    pub fn register_qemu_block_passthrough_irq(vm: &AxVMRef) -> AxVmResult {
+        super::arceos::register_qemu_block_passthrough_irq(vm)
+    }
+
+    /// Detaches the QEMU block device from its host driver before guest start.
+    pub fn prepare_qemu_block_passthrough_device() {
+        super::arceos::prepare_qemu_block_passthrough_device();
+    }
+}

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -30,7 +30,7 @@ mod arch;
 mod architecture;
 pub mod boot;
 mod error;
-mod host;
+pub mod host;
 pub mod irq;
 pub mod layout;
 pub mod lifecycle;


### PR DESCRIPTION
## 问题

Axvisor 作为虚拟机策略和生命周期编排层，原先直接依赖并调用 `ax-hal`、`ax-driver`，同时直接依赖 `ax-kspin`、`ax-sync`、`spin`、`ax-crate-interface` 和 `axplat-dyn`。这让宿主硬件实现细节越过 `axvm` 边界，也使板级驱动 feature 同时存在于 Axvisor 清单和构建配置中。

console mux 的锁只在任务上下文使用，静态初始化也已经运行在 std/musl Axvisor 环境，因此不需要继续直接依赖内核自旋锁和 `spin::LazyLock`。

## 修改

1. 在 `axvm::host` 增加窄化的 console、CPU 和 x86 QEMU block passthrough 接口，并把 PCI INTx 路由解析、设备 prepare/unmask 等宿主实现迁入 AxVM 的 ArceOS host adapter。
2. Axvisor 通过 `axvm` 调用上述宿主能力，不再直接使用 `ax-hal` 或 `ax-driver` API；保持原有 VM 注册、宿主文件系统释放、设备 prepare 和 guest 启动时 unmask 的顺序。
3. console mux 改用 `std::sync::Mutex`，console mux 和 shell command tree 改用 `std::sync::LazyLock`。
4. 删除 Axvisor 的 `rockchip-*`、`phytium-mci`、`ahci-fdt`、`sdmmc` 等硬件 feature 别名；板级配置和测试配置直接选择 `ax-driver/<feature>`。Axvisor 仅保留 optional `ax-driver` 作为 Cargo nested-feature 路由锚点，默认依赖图不会激活它。
5. 删除 Axvisor 对 `ax-kspin`、`ax-sync`、`ax-hal`、`ax-crate-interface`、`axplat-dyn` 和 `spin` 的直接依赖，并补充 AxVM/Axvisor 宿主边界设计说明。

## 设计逻辑

- Axvisor 保留 VM 策略和生命周期编排职责，宿主 HAL/driver 类型与设备交接机制由 AxVM 所有。
- console mux 的两个锁均只在管理任务、vCPU 设备访问和设备轮询任务中获取，不位于硬中断路径，可以使用 std mutex。
- 板级驱动选择属于构建配置。直接写 `ax-driver/<feature>` 可以避免在 Axvisor 重复维护硬件 feature 别名，同时仍允许 Cargo 激活 optional 依赖。
- 公共边界只暴露 AxVM 类型或普通数据，不向 Axvisor 泄漏 HAL IRQ 类型和 PCI descriptor。

## 验证

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- Axvisor x86_64、AArch64、RISC-V 构建
- OrangePi 5 Plus、PhytiumPi 配置构建
- Axvisor x86_64 与 Rockchip 配置 clippy（`-D warnings`）
- `cargo xtask clippy --package axvm`：6/6 checks passed
- `cargo test -p axvm --no-default-features --features host-test,host-fs`：236 passed
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case smoke-vmx`：1/1 passed

补充：`cargo xtask ktest qemu -p axvisor --test axtest --arch x86_64` 当前在 `ax-task` 编译阶段因缺少 `axtest` crate/宏依赖失败；失败发生在本次改动未涉及的 `os/arceos/modules/axtask/src/axtest.rs`。
