### PR TITLE
feat(axvisor): adopt shlex command tokenization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -1617,6 +1617,7 @@ dependencies = [
  "prettyplease 0.3.0",
  "proc-macro2",
  "quote",
+ "shlex 2.0.1",
  "syn 3.0.3",
  "tokio",
  "toml 1.1.4+spec-1.1.0",
@@ -2828,6 +2829,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+dependencies = [
+ "darling_core 0.24.0",
+ "darling_macro 0.24.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,6 +2879,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2901,10 +2925,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.11.0"
+name = "darling_macro"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+dependencies = [
+ "darling_core 0.24.0",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "ddebug"
@@ -4417,15 +4452,15 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+checksum = "2bf84e73fa6f27f299dec58e13223cf70db80da872eb921d4f6138342a0eabc8"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.0",
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4750,7 +4785,7 @@ dependencies = [
  "int-enum",
  "lock_api",
  "log",
- "lru 0.18.1",
+ "lru 0.18.2",
  "printf-compat",
 ]
 
@@ -4893,7 +4928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30aa94490986294aa3a19dc3fbc6b7eefe3fbbac18c323c4153a0cfd1a7a0b74"
 dependencies = [
  "log",
- "lru 0.18.1",
+ "lru 0.18.2",
  "paste",
  "static-keys",
  "tp-lexer",
@@ -5013,9 +5048,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+checksum = "e752191d037c44ad111a8caa762921926658402f01cc1253f7bef2020ece4f5e"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -5091,9 +5126,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -6459,7 +6494,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools 0.14.0",
  "kasuari",
- "lru 0.18.1",
+ "lru 0.18.2",
  "palette",
  "serde",
  "strum 0.28.0",
@@ -6852,9 +6887,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -9048,9 +9083,9 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uboot-shell"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e767c4b671e83b816efd7eb6bdfc3f8e46e94ee520ef4adc375b30940fbe5e"
+checksum = "2025d266d62972e86177045150d4020d57523567a81c4ac0b8afb1194773b870"
 dependencies = [
  "colored",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,6 +310,7 @@ extern-trait = "0.5.0"
 futures = { version = "0.3", default-features = false }
 heapless = "0.9"
 schemars = "1.2.1"
+shlex = { version = "2.0.1", default-features = false }
 prettyplease = "0.3.0"
 proc-macro2 = "1.0.107"
 quote = "1.0.47"

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -48,6 +48,9 @@ backtrace = ["ax-std/backtrace", "dep:axbacktrace"]
 test-backtrace-panic = ["backtrace"]
 test-panic-no-backtrace = ["dep:axbacktrace"]
 
+[dependencies]
+shlex.workspace = true
+
 [target.'cfg(any(not(any(windows, unix)), target_env = "musl"))'.dependencies]
 anyhow.workspace = true
 log = "0.4"

--- a/os/axvisor/README.md
+++ b/os/axvisor/README.md
@@ -80,6 +80,12 @@ Guest configs are organized by platform first. QEMU configs live under `configs/
 
 On x86_64, `boot_protocol` selects the guest firmware flow. `multiboot` keeps the legacy `axvm-bios` path and patches the generated multiboot info into the BIOS image, while `uefi` loads the external firmware from `uefi_firmware_path` without multiboot patching. Legacy UEFI configs that still use `bios_path` are accepted as a compatibility fallback.
 
+## Management Shell Syntax
+
+The AxVisor management shell tokenizes command lines with `shlex` POSIX-style rules. Single and double quotes group words, backslashes follow `shlex` escaping rules, and `""` or `''` produces an empty argument. Unclosed quotes and a trailing standalone backslash are syntax errors. Only ASCII shell whitespace separates arguments.
+
+Tokenization does not provide variable expansion, globbing, pipelines, general redirection, or job control. Command lookup, option validation, and handler behavior remain AxVisor-specific.
+
 ## Compilation
 
 AxVisor uses the xtask tool for build management, supporting multiple hardware platforms and configuration options. For a quick build and run of AxVisor, please refer to the [Quick Start](https://arceos-hypervisor.github.io/axvisorbook/docs/quickstart) chapter in the configuration documentation.

--- a/os/axvisor/README_CN.md
+++ b/os/axvisor/README_CN.md
@@ -78,6 +78,12 @@ Board 运行配置位于 `configs/board/` 目录下，每个配置文件都对�
 
 客户机配置按平台优先组织。QEMU 配置位于 `configs/vms/qemu/<arch>/`，实体板卡配置位于 `configs/vms/<board>/`。文件名只保留客户机系统和变体，例如 `configs/vms/qemu/aarch64/arceos-smp1.toml` 或 `configs/vms/roc-rk3568-pc/linux-smp1.toml`。
 
+## 管理 Shell 语法
+
+AxVisor 管理 Shell 使用 `shlex` 的 POSIX 风格规则拆分命令行。单双引号可以组合参数，反斜杠按 `shlex` 规则转义，`""` 或 `''` 会产生空参数。未闭合引号和末尾孤立反斜杠属于语法错误。只有 ASCII shell 空白字符用于分隔参数。
+
+分词不提供变量展开、glob、管道、通用重定向或 job control。命令查找、选项校验和 handler 行为仍由 AxVisor 自身实现。
+
 ## 编译
 
 AxVisor 使用 xtask 工具进行构建管理，支持多种硬件平台和配置选项。快速构建及运行 AxVisor，请参见配置套文档中的[快速上手](https://arceos-hypervisor.github.io/axvisorbook/docs/quickstart)章节。

--- a/os/axvisor/src/shell/command/mod.rs
+++ b/os/axvisor/src/shell/command/mod.rs
@@ -69,6 +69,7 @@ pub struct ParsedCommand {
 
 #[derive(Debug)]
 pub enum ParseError {
+    InvalidSyntax,
     UnknownCommand(String),
     UnknownOption(String),
     MissingValue(String),
@@ -169,7 +170,7 @@ pub struct CommandParser;
 
 impl CommandParser {
     pub fn parse(input: &str) -> Result<ParsedCommand, ParseError> {
-        let tokens = Self::tokenize(input);
+        let tokens = Self::tokenize(input)?;
         if tokens.is_empty() {
             return Err(ParseError::UnknownCommand("empty command".to_string()));
         }
@@ -191,35 +192,8 @@ impl CommandParser {
         })
     }
 
-    fn tokenize(input: &str) -> Vec<String> {
-        let mut tokens = Vec::new();
-        let mut current_token = String::new();
-        let mut in_quotes = false;
-        let mut escape_next = false;
-
-        for ch in input.chars() {
-            if escape_next {
-                current_token.push(ch);
-                escape_next = false;
-            } else if ch == '\\' {
-                escape_next = true;
-            } else if ch == '"' {
-                in_quotes = !in_quotes;
-            } else if ch.is_whitespace() && !in_quotes {
-                if !current_token.is_empty() {
-                    tokens.push(current_token.clone());
-                    current_token.clear();
-                }
-            } else {
-                current_token.push(ch);
-            }
-        }
-
-        if !current_token.is_empty() {
-            tokens.push(current_token);
-        }
-
-        tokens
+    fn tokenize(input: &str) -> Result<Vec<String>, ParseError> {
+        shlex::split(input).ok_or(ParseError::InvalidSyntax)
     }
 
     fn find_command(
@@ -490,31 +464,12 @@ pub fn prompt_string() -> String {
 pub fn run_cmd_bytes(cmd_bytes: &[u8]) {
     match str::from_utf8(cmd_bytes) {
         Ok(cmd_str) => {
-            let trimmed = cmd_str.trim();
-            if trimmed.is_empty() {
+            if matches!(CommandParser::tokenize(cmd_str), Ok(tokens) if tokens.is_empty()) {
                 return;
             }
 
-            match execute_command(trimmed) {
-                Ok(_) => {
-                    // Command executed successfully
-                }
-                Err(ParseError::UnknownCommand(cmd)) => {
-                    println!("Error: Unknown command '{}'", cmd);
-                    println!("Type 'help' to see available commands");
-                }
-                Err(ParseError::UnknownOption(opt)) => {
-                    println!("Error: Unknown option '{}'", opt);
-                }
-                Err(ParseError::MissingValue(opt)) => {
-                    println!("Error: Option '{}' is missing a value", opt);
-                }
-                Err(ParseError::MissingRequiredOption(opt)) => {
-                    println!("Error: Missing required option '{}'", opt);
-                }
-                Err(ParseError::NoHandler(cmd)) => {
-                    println!("Error: Command '{}' has no handler function", cmd);
-                }
+            if let Err(error) = execute_command(cmd_str) {
+                print_parse_error(error);
             }
         }
         Err(_) => {
@@ -523,29 +478,53 @@ pub fn run_cmd_bytes(cmd_bytes: &[u8]) {
     }
 }
 
+fn print_parse_error(error: ParseError) {
+    match error {
+        ParseError::InvalidSyntax => {
+            println!("Error: Invalid command syntax");
+        }
+        ParseError::UnknownCommand(cmd) => {
+            println!("Error: Unknown command '{}'", cmd);
+            println!("Type 'help' to see available commands");
+        }
+        ParseError::UnknownOption(opt) => {
+            println!("Error: Unknown option '{}'", opt);
+        }
+        ParseError::MissingValue(opt) => {
+            println!("Error: Option '{}' is missing a value", opt);
+        }
+        ParseError::MissingRequiredOption(opt) => {
+            println!("Error: Missing required option '{}'", opt);
+        }
+        ParseError::NoHandler(cmd) => {
+            println!("Error: Command '{}' has no handler function", cmd);
+        }
+    }
+}
+
 // Built-in command handler
 pub fn handle_builtin_commands(input: &str) -> bool {
-    match input.trim() {
-        "help" => {
+    let Ok(tokens) = CommandParser::tokenize(input) else {
+        return false;
+    };
+
+    match tokens.as_slice() {
+        [command] if command == "help" => {
             show_available_commands();
             true
         }
-        "exit" | "quit" => {
+        [command] if command == "exit" || command == "quit" => {
             println!("Goodbye!");
             std::process::exit(0);
         }
-        "clear" => {
+        [command] if command == "clear" => {
             print!("\x1b[2J\x1b[H"); // ANSI clear screen sequence
             std::io::stdout().flush().ok();
             true
         }
-        _ if input.starts_with("help ") => {
-            let cmd_parts: Vec<String> = input[5..]
-                .split_whitespace()
-                .map(|s| s.to_string())
-                .collect();
-            if let Err(e) = show_help(&cmd_parts) {
-                println!("Error: {:?}", e);
+        [command, command_path @ ..] if command == "help" => {
+            if let Err(error) = show_help(command_path) {
+                print_parse_error(error);
             }
             true
         }
@@ -577,4 +556,83 @@ pub fn show_available_commands() {
     println!("  exit/quit       Exit the shell");
     println!();
     println!("Tip: Use 'help <command>' to see detailed usage of a command");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CommandParser, ParseError};
+
+    #[test]
+    fn shlex_tokenizes_shell_words() {
+        let tokens =
+            CommandParser::tokenize(r#"echo plain 'single quoted' "double quoted" escaped\ space"#)
+                .unwrap();
+
+        assert_eq!(
+            tokens,
+            [
+                "echo",
+                "plain",
+                "single quoted",
+                "double quoted",
+                "escaped space"
+            ]
+        );
+    }
+
+    #[test]
+    fn shlex_preserves_empty_and_adjacent_quoted_words() {
+        let tokens = CommandParser::tokenize(r#"echo "" '' pre"middle"'post'"#).unwrap();
+
+        assert_eq!(tokens, ["echo", "", "", "premiddlepost"]);
+    }
+
+    #[test]
+    fn shlex_uses_posix_backslash_rules_inside_double_quotes() {
+        let tokens = CommandParser::tokenize(r#"echo "a\qb" "a\\b""#).unwrap();
+
+        assert_eq!(tokens, ["echo", r"a\qb", r"a\b"]);
+    }
+
+    #[test]
+    fn shlex_uses_ascii_whitespace_separators() {
+        let tokens = CommandParser::tokenize("echo\u{2003}value").unwrap();
+
+        assert_eq!(tokens, ["echo\u{2003}value"]);
+    }
+
+    #[test]
+    fn shlex_preserves_an_escaped_trailing_space() {
+        let tokens = CommandParser::tokenize("echo value\\ ").unwrap();
+
+        assert_eq!(tokens, ["echo", "value "]);
+    }
+
+    #[test]
+    fn shlex_treats_hash_at_word_start_as_a_comment() {
+        let tokens = CommandParser::tokenize("echo value#kept # ignored").unwrap();
+
+        assert_eq!(tokens, ["echo", "value#kept"]);
+    }
+
+    #[test]
+    fn shlex_rejects_unclosed_quotes_and_trailing_backslash() {
+        for input in [
+            r#"echo 'unterminated"#,
+            r#"echo "unterminated"#,
+            "echo trailing\\",
+        ] {
+            assert!(matches!(
+                CommandParser::tokenize(input),
+                Err(ParseError::InvalidSyntax)
+            ));
+        }
+    }
+
+    #[test]
+    fn help_command_uses_shlex_tokenization() {
+        let tokens = CommandParser::tokenize("help\t'vm' start").unwrap();
+
+        assert_eq!(tokens, ["help", "vm", "start"]);
+    }
 }

--- a/scripts/axbuild/src/axvisor/test/tests.rs
+++ b/scripts/axbuild/src/axvisor/test/tests.rs
@@ -876,13 +876,23 @@ fn nvme_smoke_keeps_storage_in_host_and_verifies_file_io() {
             Some("axvisor:/$"),
             "{qemu_path} should wait for the Axvisor host shell"
         );
-        assert_eq!(
-            qemu.success_regex,
+        let expected_success_regex = if name == "aarch64" {
+            vec![
+                r"(?m)^AXVISOR SHLEX  EMPTY\s*$",
+                r"(?m)^Command: vm start\s*$",
+                r"(?m)^Error: Invalid command syntax\s*$",
+                r"(?m)^AXVISOR_NVME_RW_PAYLOAD\s*$",
+                r"(?m)^AXVISOR_NVME_ROOTFS_RW_PASSED\s*$",
+            ]
+        } else {
             vec![
                 r"(?m)^AXVISOR_NVME_RW_PAYLOAD\s*$",
                 r"(?m)^AXVISOR_NVME_ROOTFS_RW_PASSED\s*$",
-            ],
-            "{qemu_path} should require the read-back payload and final file-I/O marker"
+            ]
+        };
+        assert_eq!(
+            qemu.success_regex, expected_success_regex,
+            "{qemu_path} should require all architecture-specific shell markers"
         );
     }
 }

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-aarch64.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-aarch64.toml
@@ -23,11 +23,17 @@ fail_regex = [
   "(?m)^(?:echo|cat|rm):",
 ]
 success_regex = [
+  "(?m)^AXVISOR SHLEX  EMPTY\\s*$",
+  "(?m)^Command: vm start\\s*$",
+  "(?m)^Error: Invalid command syntax\\s*$",
   "(?m)^AXVISOR_NVME_RW_PAYLOAD\\s*$",
   "(?m)^AXVISOR_NVME_ROOTFS_RW_PASSED\\s*$",
 ]
 shell_prefix = "axvisor:/$"
 shell_init_cmd = """
+echo 'AXVISOR SHLEX' "" EMPTY
+'help' vm start
+echo "unterminated
 echo AXVISOR_NVME_RW_PAYLOAD > /tmp/axvisor-nvme-rw
 cat /tmp/axvisor-nvme-rw
 rm -f /tmp/axvisor-nvme-rw


### PR DESCRIPTION
## 问题

Axvisor 管理 shell 使用手写 tokenizer，只支持有限的双引号处理，并会继续执行未闭合引号、末尾反斜杠等畸形输入。`help` 命令还存在独立的空白分词路径，导致同一条命令在不同入口下语义不一致。

## 变更

- 在 workspace 引入无默认 feature 的 `shlex 2.0.1`，Axvisor 统一通过 `shlex::split` 解析命令行。
- 新增 `ParseError::InvalidSyntax`，未闭合单双引号和末尾孤立反斜杠统一输出 `Error: Invalid command syntax`。
- 让内建命令（包括 `help <command path>`）与普通命令共享同一 tokenizer。
- 补充单元测试，覆盖单双引号、POSIX 反斜杠规则、空参数、相邻引用片段、ASCII 空白、注释与错误输入。
- 在双语 README 中记录管理 shell 词法边界，并在 AArch64 QEMU smoke 中加入单引号、空参数、带引号 help 和错误语法 marker。

## 实现逻辑与兼容性

`shlex` 只负责生成参数序列，现有命令树查找、option/flag 校验、handler 调用、行编辑和 guest console 路由保持不变。本变更有意以 `shlex` 的 POSIX 风格词法规则替代旧约定：Unicode 空白不再作为分隔符，畸形输入不再继续执行，反斜杠与注释按 `shlex` 语义处理。

tokenizer 不提供变量展开、glob、管道、通用重定向执行或 job control。

分支已重放到最新 `dev`，保留上游 Axvisor host/runtime 依赖隔离；已删除的 legacy `doc/` 不再恢复，shell 语义迁移到维护中的 README。

## 验证

- `cargo fmt --all --check`
- 使用 Axvisor xtask 生成的 AArch64 musl 配置执行 `cargo clippy --no-deps`（Axvisor 无新增告警）
- `cargo xtask axvisor test qemu --arch aarch64 --test-case smoke`（1/1 通过，包含新增 shlex markers）

说明：最新 `dev` 已将 Axvisor runtime 依赖限定到裸机/musl target，因此 host `cargo test --bin axvisor` 缺少 `ax-std`、`axvm` 等依赖，不能作为当前基线的有效验证入口；词法语义由源码单元用例和裸机 smoke markers 共同锁定。

### Review 修复验证

- `cargo test -p axbuild --lib nvme_smoke_keeps_storage_in_host_and_verifies_file_io -- --nocapture`（先在旧契约上稳定失败，更新 AArch64 marker 期望后通过）
- `cargo xtask clippy --package axbuild`
- `cargo fmt --all --check`
- `git diff --check`
