### PR TITLE
refactor(axvm): migrate task ownership to ax-runtime interfaces

### DIFF
--- a/os/arceos/api/arceos_api/src/imp/task.rs
+++ b/os/arceos/api/arceos_api/src/imp/task.rs
@@ -258,6 +258,7 @@ cfg_task! {
             | TaskError::NoRunnableThread
             | TaskError::InvalidPiState
             | TaskError::PiCycle
+            | TaskError::PiChainLimit { .. }
             | TaskError::RuntimeFailure(_) => crate::AxError::BadState,
         }
     }
@@ -300,6 +301,14 @@ cfg_task! {
             assert_eq!(
                 cpu_set_from_mask(AxCpuMask::one_shot(0), 0),
                 Err(crate::AxError::InvalidInput)
+            );
+        }
+
+        #[test]
+        fn pi_chain_limit_maps_to_bad_state() {
+            assert_eq!(
+                map_task_error(ax_runtime::task::TaskError::PiChainLimit { limit: 8 }),
+                crate::AxError::BadState
             );
         }
     }

--- a/os/arceos/modules/axruntime/src/fs/block.rs
+++ b/os/arceos/modules/axruntime/src/fs/block.rs
@@ -234,6 +234,7 @@ fn map_task_error(error: TaskError) -> ax_errno::AxError {
         | TaskError::NoRunnableThread
         | TaskError::InvalidPiState
         | TaskError::PiCycle
+        | TaskError::PiChainLimit { .. }
         | TaskError::RuntimeFailure(_) => ax_errno::AxError::BadState,
     }
 }

--- a/os/axvisor/src/guest_console/host.rs
+++ b/os/axvisor/src/guest_console/host.rs
@@ -1,7 +1,7 @@
 //! Physical host-console ownership.
 
 use anyhow::{Result, bail};
-use ax_std::os::arceos::modules::ax_task;
+use ax_std::os::arceos::task::{CpuId, CpuSet, set_current_thread_affinity};
 use axvm::AxVMRef;
 
 fn console_reader_isolation_cpu(
@@ -63,10 +63,15 @@ pub(crate) fn configure_host_console_reader(vms: &[AxVMRef]) -> Result<()> {
     let Some(owner_cpu) = isolation_cpu else {
         return Ok(());
     };
-    let owner_affinity = ax_task::AxCpuMask::one_shot(owner_cpu);
-    if !ax_task::set_current_affinity(owner_affinity) {
-        bail!("failed to pin the host console reader to CPU {owner_cpu}");
+    let owner_cpu_id = u32::try_from(owner_cpu)
+        .map(CpuId::new)
+        .map_err(|_| anyhow::anyhow!("host console CPU {owner_cpu} exceeds scheduler CPU IDs"))?;
+    let mut owner_affinity = CpuSet::empty(ax_hal::cpu_num());
+    if !owner_affinity.insert(owner_cpu_id) {
+        bail!("host console CPU {owner_cpu} is outside the scheduler topology");
     }
+    set_current_thread_affinity(owner_affinity)
+        .map_err(|error| anyhow::anyhow!("failed to pin host console reader: {error}"))?;
     let actual_owner_cpu = ax_hal::percpu::this_cpu_id();
     if actual_owner_cpu != owner_cpu {
         bail!(

--- a/virtualization/axvm/src/arch/aarch64/capabilities.rs
+++ b/virtualization/axvm/src/arch/aarch64/capabilities.rs
@@ -5,11 +5,9 @@ use alloc::format;
 use super::Aarch64Arch;
 use crate::{
     AxVmResult,
-    architecture::{BootImagePlatform, GuestBootPlatform, HostTimePlatform, MachinePlatform},
+    architecture::{BootImagePlatform, GuestBootPlatform, MachinePlatform},
     ax_err_type,
 };
-
-impl HostTimePlatform for Aarch64Arch {}
 
 impl MachinePlatform for Aarch64Arch {
     const MACHINE_ARCHITECTURE: crate::machine::MachineArchitecture =

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -232,7 +232,6 @@ impl ArchOps for Aarch64Arch {
                         })?;
                     }
                 }
-                crate::check_timer_events();
             }
         }
         Ok(VcpuRunAction {
@@ -314,7 +313,6 @@ impl ArmHostOps for AxvmArmHostOps {
         {
             warn!("{error}");
         }
-        crate::check_timer_events();
     }
 }
 

--- a/virtualization/axvm/src/arch/aarch64/vgic.rs
+++ b/virtualization/axvm/src/arch/aarch64/vgic.rs
@@ -130,9 +130,12 @@ impl Aarch64VgicRuntime {
             return Err(error);
         }
 
-        self.kick.start();
+        if let Err(error) = self.kick.start() {
+            *self.phase.lock() = RuntimePhase::Inactive;
+            return Err(error);
+        }
         if let Err(error) = self.core.bind_assigned_spis() {
-            self.kick.stop();
+            let _ = self.kick.stop();
             *self.phase.lock() = RuntimePhase::Inactive;
             return Err(AxVmError::interrupt("bind assigned physical SPIs", error));
         }
@@ -146,7 +149,7 @@ impl Aarch64VgicRuntime {
                          {rollback_error}"
                     );
                 }
-                self.kick.stop();
+                let _ = self.kick.stop();
                 *self.phase.lock() = RuntimePhase::Inactive;
                 return Err(AxVmError::interrupt(
                     "register assigned physical SPI routes",
@@ -191,9 +194,9 @@ impl Aarch64VgicRuntime {
         // Dropping the route handles removes the static hard-IRQ lookup before
         // the task-context kick worker is stopped.
         drop(routes);
-        self.kick.stop();
+        let stop_result = self.kick.stop();
         *self.phase.lock() = RuntimePhase::Inactive;
-        Ok(())
+        stop_result
     }
 }
 

--- a/virtualization/axvm/src/arch/loongarch64/capabilities.rs
+++ b/virtualization/axvm/src/arch/loongarch64/capabilities.rs
@@ -1,11 +1,7 @@
 //! LoongArch64 implementations of AxVM platform capability hooks.
 
-use alloc::sync::Arc;
-
-use ax_std::os::arceos::modules::ax_task::IrqNotify;
-
 use super::LoongArch64Arch;
-use crate::architecture::{GuestBootPlatform, HostTimePlatform, MachinePlatform};
+use crate::architecture::{GuestBootPlatform, MachinePlatform};
 
 impl MachinePlatform for LoongArch64Arch {
     const MACHINE_ARCHITECTURE: crate::machine::MachineArchitecture =
@@ -30,19 +26,6 @@ impl GuestBootPlatform for LoongArch64Arch {
         }
         super::boot::prepare_uefi_fdt_config(vm_config, vm_create_config)?;
         Ok(None)
-    }
-}
-
-impl HostTimePlatform for LoongArch64Arch {
-    fn request_timer_deadline(_deadline_ns: u64) {}
-
-    fn register_timer_source(
-        _deadline_source: Arc<crate::timer::PublishedTimerDeadline>,
-        notify: Arc<IrqNotify>,
-    ) {
-        ax_std::os::arceos::modules::ax_task::register_timer_callback(move |_| {
-            notify.notify_irq();
-        });
     }
 }
 

--- a/virtualization/axvm/src/arch/loongarch64/idle.rs
+++ b/virtualization/axvm/src/arch/loongarch64/idle.rs
@@ -3,7 +3,6 @@
 use super::AxvmLoongArchVcpu;
 
 pub(crate) fn wait(vcpu: &crate::vm::AxVCpuRef<AxvmLoongArchVcpu>) {
-    crate::check_timer_events();
     if vcpu.get_arch_vcpu().has_enabled_pending_interrupt() {
         trace!(
             "VM[{}] VCpu[{}] skips idle wait because guest has enabled pending interrupt",

--- a/virtualization/axvm/src/arch/loongarch64/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/mod.rs
@@ -303,7 +303,7 @@ fn drain_loongarch_pch_pic_events(vm: &crate::AxVMRef) {
 fn inject_vm_vcpu_interrupt(vm_id: usize, vcpu_id: usize, vector: usize) -> AxVmResult {
     use crate::AsVCpuTask;
 
-    let current = crate::host::task::current_task();
+    let current = crate::host::task::current_thread();
     if let Some(task) = current.try_as_vcpu_task()
         && task.vm().id() == vm_id
         && task.vcpu.id() == vcpu_id

--- a/virtualization/axvm/src/arch/mod.rs
+++ b/virtualization/axvm/src/arch/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) use crate::architecture::*;
 use crate::{
     AxVmResult,
-    architecture::{BootImagePlatform, GuestBootPlatform, HostTimePlatform},
+    architecture::{BootImagePlatform, GuestBootPlatform},
 };
 
 #[cfg(target_arch = "aarch64")]
@@ -80,17 +80,6 @@ pub mod platform {
 pub(crate) type ArchVCpu = <CurrentArch as ArchOps>::VCpu;
 pub(crate) type ArchPerCpu = <CurrentArch as ArchOps>::PerCpu;
 pub(crate) type ArchNestedPageTable = <CurrentArch as ArchOps>::NestedPageTable;
-
-pub(crate) fn register_timer_source(
-    deadline_source: alloc::sync::Arc<crate::timer::PublishedTimerDeadline>,
-    notify: alloc::sync::Arc<ax_std::os::arceos::modules::ax_task::IrqNotify>,
-) {
-    CurrentArch::register_timer_source(deadline_source, notify);
-}
-
-pub(crate) fn request_timer_deadline(deadline_ns: u64) {
-    CurrentArch::request_timer_deadline(deadline_ns);
-}
 
 pub(crate) fn init_guest_boot_resources() {
     CurrentArch::init_guest_boot_resources();

--- a/virtualization/axvm/src/arch/riscv64/capabilities.rs
+++ b/virtualization/axvm/src/arch/riscv64/capabilities.rs
@@ -5,11 +5,9 @@ use alloc::{format, vec::Vec};
 use super::Riscv64Arch;
 use crate::{
     AxVmResult,
-    architecture::{BootImagePlatform, GuestBootPlatform, HostTimePlatform, MachinePlatform},
+    architecture::{BootImagePlatform, GuestBootPlatform, MachinePlatform},
     ax_err_type,
 };
-
-impl HostTimePlatform for Riscv64Arch {}
 
 impl MachinePlatform for Riscv64Arch {
     const MACHINE_ARCHITECTURE: crate::machine::MachineArchitecture =

--- a/virtualization/axvm/src/arch/riscv64/irq/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/irq/mod.rs
@@ -106,18 +106,32 @@ impl RiscvPlicRuntime {
     }
 
     pub(crate) fn activate(self: &Arc<Self>) -> AxVmResult {
-        self.kick.start();
+        self.kick.start()?;
         if let Err(error) = self.physical.start() {
-            self.kick.stop();
-            return Err(error);
+            return match self.kick.stop() {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(AxVmError::lifecycle_rollback(
+                    "activate RISC-V PLIC runtime",
+                    error,
+                    rollback,
+                )),
+            };
         }
         Ok(())
     }
 
     pub(crate) fn deactivate(&self) -> AxVmResult {
-        let result = self.physical.stop();
-        self.kick.stop();
-        result
+        let physical = self.physical.stop();
+        let kick = self.kick.stop();
+        match (physical, kick) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+            (Err(error), Err(rollback)) => Err(AxVmError::lifecycle_rollback(
+                "deactivate RISC-V PLIC runtime",
+                error,
+                rollback,
+            )),
+        }
     }
 
     /// Returns the controller-derived VSEIP state for one vCPU.
@@ -149,7 +163,7 @@ impl RiscvPlicRuntime {
 impl Drop for RiscvPlicRuntime {
     fn drop(&mut self) {
         let _ = self.physical.stop();
-        self.kick.stop();
+        let _ = self.kick.stop();
     }
 }
 

--- a/virtualization/axvm/src/arch/riscv64/irq/physical.rs
+++ b/virtualization/axvm/src/arch/riscv64/irq/physical.rs
@@ -8,12 +8,11 @@ use core::{
 };
 
 use ax_kspin::SpinNoIrq;
-use ax_std::os::arceos::modules::ax_task::IrqNotify;
 use axvm_types::InterruptTriggerMode;
 use riscv_vplic::{PLIC_NUM_SOURCES, VPlicGlobal};
 
 use super::DeferredVcpuKick;
-use crate::{AxTaskRef, AxVmError, AxVmResult, TaskInner, ax_err};
+use crate::{AxVmError, AxVmResult, ThreadHandle, ax_err, host::task::IrqNotification};
 
 const PHYSICAL_IRQ_WORKER_STACK_SIZE: usize = 0x20_000;
 const CLAIM_IDLE: u8 = 0;
@@ -35,7 +34,7 @@ pub(super) struct PhysicalIrqBridge {
     shared: Arc<PhysicalBridgeShared>,
     bindings: Box<[Arc<PhysicalSourceBinding>]>,
     registrations: SpinNoIrq<Vec<PhysicalRouteRegistration>>,
-    worker: SpinNoIrq<Option<AxTaskRef>>,
+    worker: SpinNoIrq<Option<ThreadHandle>>,
     running: AtomicBool,
 }
 
@@ -53,7 +52,7 @@ impl PhysicalIrqBridge {
             vplic,
             kick,
             vcpu_count,
-            notify: IrqNotify::new(),
+            notify: IrqNotification::new(),
             stopping: AtomicBool::new(false),
         });
         let mut bindings = Vec::with_capacity(routes.len());
@@ -99,10 +98,19 @@ impl PhysicalIrqBridge {
         if self.running.swap(true, Ordering::AcqRel) {
             return Ok(());
         }
-        self.start_worker();
-        if let Err(error) = self.install_and_activate_routes() {
-            self.rollback_start();
+        if let Err(error) = self.start_worker() {
+            self.running.store(false, Ordering::Release);
             return Err(error);
+        }
+        if let Err(error) = self.install_and_activate_routes() {
+            return match self.rollback_start() {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(AxVmError::lifecycle_rollback(
+                    "start RISC-V physical IRQ bridge",
+                    error,
+                    rollback,
+                )),
+            };
         }
         Ok(())
     }
@@ -128,7 +136,11 @@ impl PhysicalIrqBridge {
             }
         }
         self.registrations.lock().clear();
-        self.stop_worker();
+        if let Err(error) = self.stop_worker()
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
         self.release_outstanding_claims();
 
         first_error.map_or(Ok(()), Err)
@@ -163,15 +175,23 @@ impl PhysicalIrqBridge {
         }
     }
 
-    fn start_worker(self: &Arc<Self>) {
+    fn start_worker(self: &Arc<Self>) -> AxVmResult {
         self.shared.stopping.store(false, Ordering::Release);
         let bridge = self.clone();
-        let task = TaskInner::new(
-            move || bridge.run_worker(),
-            alloc::format!("VM[{}]-plic-physical", self.shared.vm_id),
-            PHYSICAL_IRQ_WORKER_STACK_SIZE,
-        );
-        *self.worker.lock() = Some(crate::host::task::spawn_task(task));
+        let worker = unsafe {
+            // SAFETY: no OS extension or affinity capability is transferred;
+            // the worker closure and bridge reference move exactly once.
+            crate::host::task::spawn_thread_with_extension_and_affinity(
+                move || bridge.run_worker(),
+                alloc::format!("VM[{}]-plic-physical", self.shared.vm_id),
+                PHYSICAL_IRQ_WORKER_STACK_SIZE,
+                None,
+                None,
+            )
+        }
+        .map_err(|error| AxVmError::host("start RISC-V physical IRQ worker", error))?;
+        *self.worker.lock() = Some(worker);
+        Ok(())
     }
 
     fn install_and_activate_routes(&self) -> AxVmResult {
@@ -198,23 +218,26 @@ impl PhysicalIrqBridge {
         Ok(())
     }
 
-    fn rollback_start(&self) {
+    fn rollback_start(&self) -> AxVmResult {
         for binding in &self.bindings {
             binding.accepting.store(false, Ordering::Release);
             let _ = ax_plat::irq::riscv64_hv::deactivate_guest_plic_source(binding.source as u32);
         }
         self.registrations.lock().clear();
-        self.stop_worker();
+        let stop_result = self.stop_worker();
         self.release_outstanding_claims();
         self.running.store(false, Ordering::Release);
+        stop_result
     }
 
-    fn stop_worker(&self) {
+    fn stop_worker(&self) -> AxVmResult {
         self.shared.stopping.store(true, Ordering::Release);
-        self.shared.notify.notify();
-        if let Some(worker) = self.worker.lock().take() {
-            worker.join();
-        }
+        self.shared.notify.notify_from_task();
+        let worker = self.worker.lock().take();
+        worker
+            .map_or(Ok(0), crate::host::task::join_thread)
+            .map(|_exit_code| ())
+            .map_err(|error| AxVmError::host("join RISC-V physical IRQ worker", error))
     }
 
     fn run_worker(&self) {
@@ -269,7 +292,7 @@ struct PhysicalBridgeShared {
     vplic: Arc<VPlicGlobal>,
     kick: Arc<DeferredVcpuKick>,
     vcpu_count: usize,
-    notify: IrqNotify,
+    notify: IrqNotification,
     stopping: AtomicBool,
 }
 
@@ -297,7 +320,7 @@ impl PhysicalSourceBinding {
         {
             return false;
         }
-        self.shared.notify.notify_irq();
+        self.shared.notify.notify_from_irq();
         true
     }
 

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -95,7 +95,6 @@ impl ArchOps for Riscv64Arch {
             crate::host::arceos::dispatch_host_irq(vector);
             vcpu.get_arch_vcpu().latch_hvip_from_hw();
         });
-        crate::check_timer_events();
     }
 
     fn handle_vcpu_exit_bound(

--- a/virtualization/axvm/src/arch/x86_64/capabilities.rs
+++ b/virtualization/axvm/src/arch/x86_64/capabilities.rs
@@ -1,9 +1,7 @@
 //! x86_64 implementations of AxVM platform capability hooks.
 
 use super::X86_64Arch;
-use crate::architecture::{GuestBootPlatform, HostTimePlatform, MachinePlatform};
-
-impl HostTimePlatform for X86_64Arch {}
+use crate::architecture::{GuestBootPlatform, MachinePlatform};
 
 impl GuestBootPlatform for X86_64Arch {}
 

--- a/virtualization/axvm/src/arch/x86_64/exit.rs
+++ b/virtualization/axvm/src/arch/x86_64/exit.rs
@@ -67,7 +67,6 @@ pub(crate) fn finish(
             X86_64Arch::after_external_interrupt(vm, vcpu, vector);
         }
         DeferredRunWork::PreemptionTimer => {
-            crate::timer::check_events();
             super::irq::inject_due_pit_irq0(vm, vcpu);
         }
         DeferredRunWork::InterruptEnd { vector } => {

--- a/virtualization/axvm/src/arch/x86_64/irq.rs
+++ b/virtualization/axvm/src/arch/x86_64/irq.rs
@@ -5,7 +5,7 @@ use axdevice::{X86InterruptDomainKey, X86InterruptDomainOps, X86PitServiceKey};
 use axvm_types::VmArchVcpuOps;
 
 use crate::{
-    InterruptTriggerMode,
+    AxVmResult, InterruptTriggerMode,
     arch::x86_64::{
         X86InterruptDomain, X86InterruptDomainRuntimeKey,
         host_irq::{self as irq, IrqSource},
@@ -102,7 +102,7 @@ fn ioapic_irq_hook_gsis() -> impl Iterator<Item = usize> {
     (0..IOAPIC_GSI_COUNT).filter(|gsi| should_register_ioapic_gsi_hook(*gsi))
 }
 
-fn interrupt_domain_for_vm(vm: &crate::AxVMRef) -> Option<alloc::sync::Arc<X86InterruptDomain>> {
+fn interrupt_domain_for_vm(vm: &crate::AxVM) -> Option<alloc::sync::Arc<X86InterruptDomain>> {
     vm.get_devices()
         .ok()?
         .services()
@@ -442,16 +442,18 @@ impl X86InterruptDomain {
     }
 }
 
-pub fn start_deferred_irq_delivery(vm: &VMRef) {
+pub fn start_deferred_irq_delivery(vm: &crate::AxVM) -> AxVmResult {
     if let Some(domain) = interrupt_domain_for_vm(vm) {
-        domain.start_kick_worker();
+        domain.start_kick_worker()?;
     }
+    Ok(())
 }
 
-pub fn stop_deferred_irq_delivery(vm: &VMRef) {
+pub fn stop_deferred_irq_delivery(vm: &crate::AxVM) -> AxVmResult {
     if let Some(domain) = interrupt_domain_for_vm(vm) {
-        domain.stop_kick_worker();
+        domain.stop_kick_worker()?;
     }
+    Ok(())
 }
 
 pub fn drain_pending_wired_irqs(vm: &VMRef, vcpu: &VCpuRef) {

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -76,8 +76,15 @@ impl ArchOps for X86_64Arch {
         x86_vcpu::initialize_hardware_support().is_ok()
     }
 
+    fn activate_devices(vm: &crate::AxVM) -> AxVmResult {
+        irq::start_deferred_irq_delivery(vm)
+    }
+
+    fn deactivate_devices(vm: &crate::AxVM) -> AxVmResult {
+        irq::stop_deferred_irq_delivery(vm)
+    }
+
     fn before_first_run(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef<Self::VCpu>) {
-        irq::start_deferred_irq_delivery(vm);
         irq::enable_ioapic_irq_forwarding(vm, vcpu);
     }
 
@@ -94,13 +101,11 @@ impl ArchOps for X86_64Arch {
         vector: usize,
     ) {
         crate::host::arceos::dispatch_host_irq(vector);
-        crate::check_timer_events();
     }
 
     fn on_last_vcpu_exit(vm: &crate::AxVMRef) -> AxVmResult {
         irq::disable_ioapic_irq_forwarding_for_vm(vm);
-        irq::stop_deferred_irq_delivery(vm);
-        Ok(())
+        Self::deactivate_devices(vm)
     }
 
     fn handle_vcpu_exit_bound(
@@ -593,12 +598,12 @@ impl X86InterruptDomain {
         }
     }
 
-    fn start_kick_worker(&self) {
-        self.wired.kick.start();
+    fn start_kick_worker(&self) -> AxVmResult {
+        self.wired.kick.start()
     }
 
-    fn stop_kick_worker(&self) {
-        self.wired.kick.stop();
+    fn stop_kick_worker(&self) -> AxVmResult {
+        self.wired.kick.stop()
     }
 
     fn take_pending_wired_gsis(&self) -> (usize, usize) {

--- a/virtualization/axvm/src/architecture/capabilities.rs
+++ b/virtualization/axvm/src/architecture/capabilities.rs
@@ -1,8 +1,6 @@
 //! Small capability boundaries implemented by the selected guest architecture.
 
-use alloc::{sync::Arc, vec::Vec};
-
-use ax_std::os::arceos::modules::ax_task::IrqNotify;
+use alloc::vec::Vec;
 
 use crate::AxVmResult;
 
@@ -114,27 +112,6 @@ pub(crate) trait BootImagePlatform {
         _provider: &dyn crate::boot::BootImageProvider,
     ) -> bool {
         false
-    }
-}
-
-/// Architecture-specific host timer policy used by the ArceOS adapter.
-pub(crate) trait HostTimePlatform {
-    fn request_timer_deadline(deadline_ns: u64) {
-        ax_std::os::arceos::modules::ax_task::request_timer_deadline_nanos(deadline_ns);
-    }
-
-    fn register_timer_source(
-        deadline_source: Arc<crate::timer::PublishedTimerDeadline>,
-        notify: Arc<IrqNotify>,
-    ) {
-        let published_deadline = deadline_source.clone();
-        ax_std::os::arceos::modules::ax_task::register_timer_deadline_source(move || {
-            published_deadline.deadline_nanos()
-        });
-        ax_std::os::arceos::modules::ax_task::register_timer_irq_callback(move |now| {
-            deadline_source.clear_if_elapsed(now.as_nanos().min(u64::MAX as u128) as u64);
-            notify.notify_irq();
-        });
     }
 }
 

--- a/virtualization/axvm/src/architecture/mod.rs
+++ b/virtualization/axvm/src/architecture/mod.rs
@@ -6,8 +6,8 @@ pub(crate) mod ops;
 mod types;
 
 pub(crate) use capabilities::{
-    BootImagePlatform, GuestBootPlatform, HostTimePlatform, MachinePlatform,
-    minimum_recorded_target_cpu_capability, unsupported_target_cpu_capability,
+    BootImagePlatform, GuestBootPlatform, MachinePlatform, minimum_recorded_target_cpu_capability,
+    unsupported_target_cpu_capability,
 };
 pub(crate) use exit::{handle_hypercall, handle_mmio_read, handle_mmio_write};
 pub(crate) use ops::ArchOps;

--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -116,7 +116,6 @@ pub(crate) trait ArchOps {
         vector: usize,
     ) {
         crate::host::arceos::dispatch_host_irq(vector);
-        crate::check_timer_events();
     }
 
     /// Releases architecture runtime state after the VM's last vCPU exits.
@@ -433,8 +432,7 @@ mod tests {
             trigger: InterruptTriggerMode::LevelTriggered,
         };
         let dispatcher = crate::runtime::VcpuIrqDispatcher::new();
-        dispatcher.register_test_vcpu(0, 2);
-        dispatcher.enqueue(0, interrupt).unwrap();
+        dispatcher.enqueue(0, interrupt);
 
         inject_drained_interrupts::<RecordingArch>(&dispatcher, 1, 0, &vcpu);
 
@@ -452,7 +450,6 @@ mod tests {
         }));
         let vcpu = Arc::new(AxVCpu::<RecordingVcpu>::new(1, 0, None, injections.clone()).unwrap());
         let dispatcher = crate::runtime::VcpuIrqDispatcher::new();
-        dispatcher.register_test_vcpu(0, 2);
         for interrupt in [
             PendingVcpuInterrupt {
                 id: VirtualInterruptId(0x41),
@@ -467,7 +464,7 @@ mod tests {
                 trigger: InterruptTriggerMode::EdgeTriggered,
             },
         ] {
-            dispatcher.enqueue(0, interrupt).unwrap();
+            dispatcher.enqueue(0, interrupt);
         }
 
         inject_drained_interrupts::<RecordingArch>(&dispatcher, 1, 0, &vcpu);

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -13,6 +13,7 @@ use ax_std::{
     thread,
 };
 use axvm_types::{HostPhysAddr, HostVirtAddr};
+use spin::Once;
 
 #[cfg(any(feature = "fs", feature = "host-fs"))]
 use crate::AxVmError;
@@ -86,10 +87,6 @@ impl HostTime for ArceOsHost {
     fn monotonic_time(&self) -> Duration {
         modules::ax_hal::time::monotonic_time()
     }
-
-    fn request_timer_deadline(&self, deadline_ns: u64) {
-        crate::arch::request_timer_deadline(deadline_ns);
-    }
 }
 
 /// Returns the platform IRQ owned by the runtime-selected physical console.
@@ -113,29 +110,103 @@ impl HostCpu for ArceOsHost {
     }
 }
 
-pub(crate) type ArceOsTaskHandle = runtime_task::ThreadHandle;
+pub(crate) type ArceOsThreadHandle = runtime_task::ThreadHandle;
 pub(crate) type ArceOsWaitQueue = runtime_task::WaitQueue;
+#[cfg(target_arch = "aarch64")]
 pub(crate) type ArceOsIrqError = modules::ax_hal::irq::IrqError;
 pub(crate) type ArceOsWaitQueueHandle = api::task::AxWaitQueueHandle;
 pub(crate) use runtime_task::{
-    CpuId as ArceOsTaskCpuId, CpuSet as ArceOsTaskCpuSet, SchedulePolicy as ArceOsSchedulePolicy,
+    CpuId as ArceOsCpuId, CpuSet as ArceOsCpuSet, SchedulePolicy as ArceOsSchedulePolicy,
     SwitchReason as ArceOsSwitchReason, TaskError as ArceOsTaskError,
     ThreadExtension as ArceOsThreadExtension, ThreadExtensionOps as ArceOsThreadExtensionOps,
     ThreadId as ArceOsThreadId,
 };
 
-pub(crate) fn current_task() -> ArceOsTaskHandle {
+/// Hard-IRQ-safe event consumed by one fixed ArceOS service thread.
+pub(crate) struct ArceOsIrqNotification {
+    event: runtime_task::IrqWaitCell,
+    waiter: Once<ArceOsIrqWaiter>,
+}
+
+struct ArceOsIrqWaiter {
+    owner: ArceOsThreadId,
+    registration: runtime_task::IrqWaitRegistration,
+    park: runtime_task::WaitQueue,
+}
+
+impl ArceOsIrqNotification {
+    pub(crate) const fn new() -> Self {
+        Self {
+            event: runtime_task::IrqWaitCell::new(),
+            waiter: Once::new(),
+        }
+    }
+
+    pub(crate) fn notify_from_irq(&self) {
+        let _result = self.event.notify();
+    }
+
+    pub(crate) fn notify_from_task(&self) {
+        let _result = self.event.notify_from_task();
+    }
+
+    pub(crate) fn wait(&self) {
+        let _timed_out = self.wait_until(None);
+    }
+
+    /// Waits for one event or an optional absolute monotonic deadline.
+    ///
+    /// Returns `true` only when the task deadline won the wake race.
+    pub(crate) fn wait_until(&self, deadline: Option<Duration>) -> bool {
+        let current = current_thread();
+        let waiter = self.waiter.call_once(|| ArceOsIrqWaiter {
+            owner: current.id(),
+            registration: runtime_task::IrqWaitRegistration::new(current.wake_handle()),
+            park: runtime_task::WaitQueue::new(),
+        });
+        assert_eq!(
+            waiter.owner,
+            current.id(),
+            "one AxVM IRQ notification must be consumed by one fixed service thread"
+        );
+
+        match self.event.register(&waiter.registration) {
+            runtime_task::IrqRegisterResult::ConsumedPending => false,
+            runtime_task::IrqRegisterResult::Registered(token)
+            | runtime_task::IrqRegisterResult::NotificationInFlight(token) => {
+                let timed_out = match deadline {
+                    Some(deadline) => waiter
+                        .park
+                        .wait_until_deadline(deadline, || !token.is_attached()),
+                    None => {
+                        waiter.park.wait_until(|| !token.is_attached());
+                        false
+                    }
+                };
+                runtime_task::quiesce_irq_wait(token).unwrap_or_else(|error| {
+                    panic!("AxVM IRQ notification could not quiesce: {error}")
+                });
+                timed_out
+            }
+            runtime_task::IrqRegisterResult::Occupied => {
+                panic!("AxVM IRQ notification waiter was registered concurrently")
+            }
+        }
+    }
+}
+
+pub(crate) fn current_thread() -> ArceOsThreadHandle {
     runtime_task::current_thread_handle()
         .unwrap_or_else(|error| panic!("AxVM requires a current scheduler thread: {error}"))
 }
 
-pub(crate) unsafe fn spawn_task_with_extension_and_affinity<F>(
+pub(crate) unsafe fn spawn_thread_with_extension_and_affinity<F>(
     entry: F,
     name: alloc::string::String,
     stack_size: usize,
     extension: Option<ArceOsThreadExtension>,
-    affinity: Option<ArceOsTaskCpuSet>,
-) -> Result<ArceOsTaskHandle, ArceOsTaskError>
+    affinity: Option<ArceOsCpuSet>,
+) -> Result<ArceOsThreadHandle, ArceOsTaskError>
 where
     F: FnOnce() + Send + 'static,
 {
@@ -148,38 +219,38 @@ where
     }
 }
 
-pub(crate) fn join_task(task: ArceOsTaskHandle) -> Result<i32, ArceOsTaskError> {
-    runtime_task::join_thread(task)
+pub(crate) fn join_thread(thread: ArceOsThreadHandle) -> Result<i32, ArceOsTaskError> {
+    runtime_task::join_thread(thread)
 }
 
-pub(crate) fn task_extension(
-    task: &ArceOsTaskHandle,
+pub(crate) fn thread_extension(
+    thread: &ArceOsThreadHandle,
 ) -> Result<Option<runtime_task::ThreadOsExtensionBorrow<'_>>, ArceOsTaskError> {
-    runtime_task::thread_os_extension(task)
+    runtime_task::thread_os_extension(thread)
 }
 
-pub(crate) fn task_cpu_set_from_raw_bits(bits: usize) -> ArceOsTaskCpuSet {
+pub(crate) fn cpu_set_from_raw_bits(bits: usize) -> ArceOsCpuSet {
     let cpu_count = modules::ax_hal::cpu_num();
-    let mut affinity = ArceOsTaskCpuSet::empty(cpu_count);
+    let mut affinity = ArceOsCpuSet::empty(cpu_count);
     for cpu_id in 0..cpu_count.min(usize::BITS as usize) {
         if bits & (1usize << cpu_id) != 0 {
-            assert!(affinity.insert(ArceOsTaskCpuId::new(cpu_id as u32)));
+            assert!(affinity.insert(ArceOsCpuId::new(cpu_id as u32)));
         }
     }
     affinity
 }
 
-pub(crate) fn task_cpu_set_one(cpu_id: usize) -> ArceOsTaskCpuSet {
-    let mut affinity = ArceOsTaskCpuSet::empty(modules::ax_hal::cpu_num());
+pub(crate) fn cpu_set_one(cpu_id: usize) -> ArceOsCpuSet {
+    let mut affinity = ArceOsCpuSet::empty(modules::ax_hal::cpu_num());
     assert!(
-        affinity.insert(ArceOsTaskCpuId::new(cpu_id as u32)),
+        affinity.insert(ArceOsCpuId::new(cpu_id as u32)),
         "AxVM task CPU {cpu_id} is outside the runtime topology"
     );
     affinity
 }
 
-pub(crate) fn task_cpu_id(task: &ArceOsTaskHandle) -> usize {
-    task.assigned_cpu().map_or(0, |cpu| cpu.as_usize())
+pub(crate) fn thread_cpu_id(thread: &ArceOsThreadHandle) -> Option<usize> {
+    thread.assigned_cpu().map(|cpu| cpu.as_usize())
 }
 
 pub(crate) fn yield_now() {
@@ -207,6 +278,7 @@ pub(crate) fn send_ipi(cpu_id: usize) {
     );
 }
 
+#[cfg(target_arch = "aarch64")]
 pub(crate) fn run_on_cpu_sync(
     cpu_id: usize,
     f: unsafe fn(*mut ()),
@@ -245,7 +317,7 @@ impl HostPlatform for ArceOsHost {
     }
 
     fn enable_virtualization_on_current_cpu(&self) -> AxVmResult {
-        crate::timer::init_percpu();
+        crate::timer::init_percpu()?;
         crate::percpu::init_current_cpu()?;
         crate::percpu::enable_current_cpu()?;
         crate::percpu::mark_cpu_enabled(self.this_cpu_id());
@@ -270,11 +342,11 @@ impl HostPlatform for ArceOsHost {
             if cpu_id == current_cpu {
                 continue;
             }
-            let affinity = task_cpu_set_one(cpu_id);
+            let affinity = cpu_set_one(cpu_id);
             // SAFETY: no OS extension is transferred and the affinity is
             // validated against the current runtime topology above.
             let _task = unsafe {
-                spawn_task_with_extension_and_affinity(
+                spawn_thread_with_extension_and_affinity(
                     move || {
                         let host = arceos_host();
                         info!("Core {cpu_id} is initializing hardware virtualization support...");

--- a/virtualization/axvm/src/host/task.rs
+++ b/virtualization/axvm/src/host/task.rs
@@ -2,59 +2,75 @@
 
 use super::arceos;
 
-pub(crate) type TaskHandle = arceos::ArceOsTaskHandle;
-pub(crate) type TaskExtensionBorrow<'task> =
-    ax_std::os::arceos::task::ThreadOsExtensionBorrow<'task>;
+pub(crate) type ThreadHandle = arceos::ArceOsThreadHandle;
+pub(crate) type IrqNotification = arceos::ArceOsIrqNotification;
+pub(crate) type ThreadExtensionBorrow<'thread> =
+    ax_std::os::arceos::task::ThreadOsExtensionBorrow<'thread>;
 pub(crate) type WaitQueue = arceos::ArceOsWaitQueue;
 pub(crate) type WaitQueueHandle = arceos::ArceOsWaitQueueHandle;
 pub(crate) use arceos::{
-    ArceOsSchedulePolicy as SchedulePolicy, ArceOsSwitchReason as SwitchReason,
-    ArceOsTaskCpuSet as TaskCpuSet, ArceOsTaskError as TaskError,
+    ArceOsCpuSet as CpuSet, ArceOsSchedulePolicy as SchedulePolicy,
+    ArceOsSwitchReason as SwitchReason, ArceOsTaskError as TaskError,
     ArceOsThreadExtension as ThreadExtension, ArceOsThreadExtensionOps as ThreadExtensionOps,
     ArceOsThreadId as ThreadId,
 };
 
-pub(crate) fn current_task() -> TaskHandle {
-    arceos::current_task()
+pub(crate) fn current_thread() -> ThreadHandle {
+    arceos::current_thread()
 }
 
-pub(crate) unsafe fn spawn_task_with_extension_and_affinity<F>(
+pub(crate) unsafe fn spawn_thread_with_extension_and_affinity<F>(
     entry: F,
     name: alloc::string::String,
     stack_size: usize,
     extension: Option<ThreadExtension>,
-    affinity: Option<TaskCpuSet>,
-) -> Result<TaskHandle, TaskError>
+    affinity: Option<CpuSet>,
+) -> Result<ThreadHandle, TaskError>
 where
     F: FnOnce() + Send + 'static,
 {
     // SAFETY: the caller transfers the unique extension ownership through this
     // one-to-one host adapter.
     unsafe {
-        arceos::spawn_task_with_extension_and_affinity(entry, name, stack_size, extension, affinity)
+        arceos::spawn_thread_with_extension_and_affinity(
+            entry, name, stack_size, extension, affinity,
+        )
     }
 }
 
-pub(crate) fn join_task(task: TaskHandle) -> Result<i32, TaskError> {
-    arceos::join_task(task)
+pub(crate) fn join_thread(thread: ThreadHandle) -> Result<i32, TaskError> {
+    arceos::join_thread(thread)
 }
 
-pub(crate) fn task_extension(
-    task: &TaskHandle,
-) -> Result<Option<TaskExtensionBorrow<'_>>, TaskError> {
-    arceos::task_extension(task)
+pub(crate) fn thread_extension(
+    thread: &ThreadHandle,
+) -> Result<Option<ThreadExtensionBorrow<'_>>, TaskError> {
+    arceos::thread_extension(thread)
 }
 
 pub(crate) fn yield_now() {
     arceos::yield_now();
 }
 
-pub(crate) fn task_cpu_set_from_raw_bits(bits: usize) -> TaskCpuSet {
-    arceos::task_cpu_set_from_raw_bits(bits)
+pub(crate) fn cpu_set_from_raw_bits(bits: usize) -> CpuSet {
+    arceos::cpu_set_from_raw_bits(bits)
 }
 
-pub(crate) fn task_cpu_id(task: &TaskHandle) -> usize {
-    arceos::task_cpu_id(task)
+pub(crate) fn cpu_set_one(cpu_id: usize) -> CpuSet {
+    arceos::cpu_set_one(cpu_id)
+}
+
+pub(crate) fn thread_cpu_id(thread: &ThreadHandle) -> Option<usize> {
+    arceos::thread_cpu_id(thread)
+}
+
+#[cfg(target_arch = "aarch64")]
+pub(crate) fn run_on_cpu_sync(
+    cpu_id: usize,
+    operation: unsafe fn(*mut ()),
+    argument: *mut (),
+) -> Result<(), arceos::ArceOsIrqError> {
+    arceos::run_on_cpu_sync(cpu_id, operation, argument)
 }
 
 pub(crate) fn wait_queue_wait_until(queue: &WaitQueueHandle, condition: impl Fn() -> bool) {

--- a/virtualization/axvm/src/host/traits.rs
+++ b/virtualization/axvm/src/host/traits.rs
@@ -31,13 +31,10 @@ pub trait HostMemory {
     fn virt_to_phys(&self, vaddr: HostVirtAddr) -> HostPhysAddr;
 }
 
-/// Host time and timer operations.
+/// Host monotonic time source.
 pub trait HostTime {
     /// Read monotonic host time.
     fn monotonic_time(&self) -> Duration;
-
-    /// Publish an earlier deadline to the host's shared timer arbiter.
-    fn request_timer_deadline(&self, deadline_ns: u64);
 }
 
 /// Host CPU topology and affinity operations.

--- a/virtualization/axvm/src/irq/deferred.rs
+++ b/virtualization/axvm/src/irq/deferred.rs
@@ -8,9 +8,8 @@ use alloc::sync::Arc;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use ax_kspin::SpinNoIrq;
-use ax_std::os::arceos::modules::ax_task::IrqNotify;
 
-use crate::{AxVmResult, ax_err};
+use crate::{AxVmError, AxVmResult, ax_err, host::task::IrqNotification};
 
 const KICK_WORKER_STACK_SIZE: usize = 0x20_000;
 
@@ -20,8 +19,8 @@ pub(crate) struct DeferredVcpuKick {
     pending_vcpus: AtomicUsize,
     worker_started: AtomicBool,
     stopping: AtomicBool,
-    notify: IrqNotify,
-    worker: SpinNoIrq<Option<crate::AxTaskRef>>,
+    notify: IrqNotification,
+    worker: SpinNoIrq<Option<crate::ThreadHandle>>,
 }
 
 impl DeferredVcpuKick {
@@ -32,29 +31,38 @@ impl DeferredVcpuKick {
             pending_vcpus: AtomicUsize::new(0),
             worker_started: AtomicBool::new(false),
             stopping: AtomicBool::new(false),
-            notify: IrqNotify::new(),
+            notify: IrqNotification::new(),
             worker: SpinNoIrq::new(None),
         })
     }
 
     /// Starts the task-context worker before an architecture enables IRQ input.
-    pub(crate) fn start(self: &Arc<Self>) {
+    pub(crate) fn start(self: &Arc<Self>) -> AxVmResult {
         let mut worker = self.worker.lock();
         if worker.is_some() {
-            return;
+            return Ok(());
         }
         self.stopping.store(false, Ordering::Release);
         let state = self.clone();
-        let task = crate::TaskInner::new(
-            move || state.run_worker(),
-            alloc::format!("VM[{}]-irq-kick", self.vm_id),
-            KICK_WORKER_STACK_SIZE,
-        );
-        *worker = Some(crate::host::task::spawn_task(task));
+        let thread = unsafe {
+            // SAFETY: no OS extension or affinity capability is transferred;
+            // the worker closure and VM-owned state move exactly once.
+            crate::host::task::spawn_thread_with_extension_and_affinity(
+                move || state.run_worker(),
+                alloc::format!("VM[{}]-irq-kick", self.vm_id),
+                KICK_WORKER_STACK_SIZE,
+                None,
+                None,
+            )
+        }
+        .map_err(|error| AxVmError::host("start deferred vCPU kick worker", error))?;
+        *worker = Some(thread);
+        drop(worker);
         self.worker_started.store(true, Ordering::Release);
         if self.pending_vcpus.load(Ordering::Acquire) != 0 {
-            self.notify.notify();
+            self.notify.notify_from_task();
         }
+        Ok(())
     }
 
     /// Publishes that `vcpu_id` needs to observe controller-owned IRQ state.
@@ -73,21 +81,22 @@ impl DeferredVcpuKick {
         };
         self.pending_vcpus.fetch_or(bit, Ordering::Release);
         if self.worker_started.load(Ordering::Acquire) {
-            self.notify.notify_irq();
+            self.notify.notify_from_irq();
         }
         Ok(())
     }
 
     /// Stops and joins the worker after architecture IRQ input is quiesced.
-    pub(crate) fn stop(&self) {
+    pub(crate) fn stop(&self) -> AxVmResult {
         self.worker_started.store(false, Ordering::Release);
         self.stopping.store(true, Ordering::Release);
-        self.notify.notify();
+        self.notify.notify_from_task();
         let worker = self.worker.lock().take();
-        if let Some(worker) = worker {
-            worker.join();
-        }
+        let join_result = worker.map_or(Ok(0), crate::host::task::join_thread);
         self.pending_vcpus.store(0, Ordering::Release);
+        join_result
+            .map(|_exit_code| ())
+            .map_err(|error| AxVmError::host("join deferred vCPU kick worker", error))
     }
 
     fn run_worker(&self) {

--- a/virtualization/axvm/src/irq/sender.rs
+++ b/virtualization/axvm/src/irq/sender.rs
@@ -121,31 +121,36 @@ mod tests {
         AxVmError, InterruptTriggerMode,
         irq::model::VirtualInterruptId,
         lifecycle::{Machine, StopReason},
-        vm::{VmRuntimeHandle, dispatch_vcpu_interrupt_with},
+        runtime::VcpuIrqDispatcher,
+        vm::dispatch_vcpu_interrupt_with,
     };
 
     struct TestVm {
-        machine: SpinNoIrq<Machine<(), Arc<VmRuntimeHandle>>>,
+        machine: SpinNoIrq<Machine<(), Arc<TestRuntime>>>,
+    }
+
+    struct TestRuntime {
+        dispatcher: VcpuIrqDispatcher,
+        cpu_id: Option<usize>,
     }
 
     impl TestVm {
-        fn new(machine: Machine<(), Arc<VmRuntimeHandle>>) -> Arc<Self> {
+        fn new(machine: Machine<(), Arc<TestRuntime>>) -> Arc<Self> {
             Arc::new(Self {
                 machine: SpinNoIrq::new(machine),
             })
         }
 
-        fn current_interrupt_runtime(&self) -> AxVmResult<Arc<VmRuntimeHandle>> {
+        fn current_interrupt_runtime(&self) -> AxVmResult<Arc<TestRuntime>> {
             Ok(self.machine.lock().interrupt_runtime()?.clone())
         }
     }
 
-    fn runtime(cpu_id: Option<usize>) -> Arc<VmRuntimeHandle> {
-        let runtime = Arc::new(VmRuntimeHandle::new());
-        if let Some(cpu_id) = cpu_id {
-            runtime.irq_dispatcher().register_test_vcpu(0, cpu_id);
-        }
-        runtime
+    fn runtime(cpu_id: Option<usize>) -> Arc<TestRuntime> {
+        Arc::new(TestRuntime {
+            dispatcher: VcpuIrqDispatcher::new(),
+            cpu_id,
+        })
     }
 
     fn interrupt(id: u32) -> PendingVcpuInterrupt {
@@ -168,7 +173,10 @@ mod tests {
             |runtime, vcpu_id, interrupt| {
                 dispatch_vcpu_interrupt_with(
                     || {
-                        let cpu_id = runtime.irq_dispatcher().enqueue(vcpu_id, interrupt)?;
+                        let cpu_id = runtime.cpu_id.ok_or_else(|| {
+                            ax_err_type!(NotFound, format_args!("vCPU {vcpu_id} task not found"))
+                        })?;
+                        runtime.dispatcher.enqueue(vcpu_id, interrupt);
                         events.borrow_mut().push("enqueue");
                         Ok(cpu_id)
                     },
@@ -196,7 +204,7 @@ mod tests {
             send(&sender, 0, interrupt(1), &events).unwrap();
 
             assert_eq!(*events.borrow(), ["enqueue", "notify", "ipi"]);
-            assert_eq!(runtime.irq_dispatcher().drain(0), alloc::vec![interrupt(1)]);
+            assert_eq!(runtime.dispatcher.drain(0), alloc::vec![interrupt(1)]);
         }
     }
 
@@ -279,14 +287,8 @@ mod tests {
         }
         send(&sender, 0, interrupt(2), &events).unwrap();
 
-        assert_eq!(
-            old_runtime.irq_dispatcher().drain(0),
-            alloc::vec![interrupt(1)]
-        );
-        assert_eq!(
-            new_runtime.irq_dispatcher().drain(0),
-            alloc::vec![interrupt(2)]
-        );
+        assert_eq!(old_runtime.dispatcher.drain(0), alloc::vec![interrupt(1)]);
+        assert_eq!(new_runtime.dispatcher.drain(0), alloc::vec![interrupt(2)]);
         assert_eq!(
             *events.borrow(),
             ["enqueue", "notify", "ipi", "enqueue", "notify", "ipi"]

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -66,7 +66,7 @@ pub use error::{AxVmError, AxVmResult};
 pub(crate) use error::{ax_err, ax_err_type};
 pub(crate) use host::{
     paging::HostPagingHandler,
-    task::{TaskHandle, WaitQueue, WaitQueueHandle as HostWaitQueueHandle},
+    task::{ThreadHandle, WaitQueue, WaitQueueHandle as HostWaitQueueHandle},
 };
 pub use lifecycle::{StopReason, VmStatus};
 pub use manager::{
@@ -80,11 +80,6 @@ pub use vm::{
 
 /// The architecture-independent per-CPU type.
 pub(crate) type AxVMPerCpu = vcpu::AxPerCpu<arch::ArchPerCpu>;
-
-/// Check and dispatch pending AxVM timer events on the current CPU.
-pub fn check_timer_events() {
-    timer::check_events();
-}
 
 /// Clean data cache lines covering a host virtual address range.
 pub fn clean_dcache_range(addr: ax_memory_addr::VirtAddr, size: usize) {

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -19,19 +19,10 @@
 //! critical sections short: no wake, IPI, or external callbacks are invoked
 //! while a lock is held.
 
-use alloc::{collections::BTreeMap, vec::Vec};
-
-#[cfg(not(feature = "host-test"))]
-use ax_kspin::SpinNoIrq as Mutex;
-// Host tests have no scheduler CPU-local state, so they retain the atomic
-// exclusion but must not enter the runtime preemption guard.
-#[cfg(feature = "host-test")]
-use ax_kspin::SpinRaw as Mutex;
+use alloc::vec::Vec;
 
 use super::queue::VcpuInterruptQueue;
-use crate::{
-    AxVmResult, TaskHandle, ax_err_type, host::task::task_cpu_id, irq::model::PendingVcpuInterrupt,
-};
+use crate::irq::model::PendingVcpuInterrupt;
 
 /// Runtime-owned vCPU interrupt queue.
 ///
@@ -46,11 +37,6 @@ use crate::{
 /// architecture-specific injection path.
 pub struct VcpuIrqDispatcher {
     queue: VcpuInterruptQueue,
-    vcpu_tasks: Mutex<BTreeMap<usize, TaskHandle>>,
-    /// Test-only cpu_id registry so that round-trip tests can exercise
-    /// enqueue / drain without a full ArceOS task infrastructure.
-    #[cfg(all(test, feature = "host-test"))]
-    test_vcpu_cpu_ids: Mutex<BTreeMap<usize, usize>>,
 }
 
 impl VcpuIrqDispatcher {
@@ -61,77 +47,21 @@ impl VcpuIrqDispatcher {
     pub fn new() -> Self {
         Self {
             queue: VcpuInterruptQueue::new(),
-            vcpu_tasks: Mutex::new(BTreeMap::new()),
-            #[cfg(all(test, feature = "host-test"))]
-            test_vcpu_cpu_ids: Mutex::new(BTreeMap::new()),
         }
     }
 
-    /// Registers a vCPU task so that [`enqueue`](Self::enqueue) can discover
-    /// the target physical CPU.
-    ///
-    /// Called from `VmRuntimeHandle::add_vcpu_task` when a vCPU task is
-    /// spawned and bound to the VM runtime.
-    pub fn register_vcpu_task(&self, vcpu_id: usize, task: TaskHandle) {
-        self.vcpu_tasks.lock().insert(vcpu_id, task);
-    }
-
-    #[cfg(all(test, feature = "host-test"))]
-    pub(crate) fn register_test_vcpu(&self, vcpu_id: usize, cpu_id: usize) {
-        self.test_vcpu_cpu_ids.lock().insert(vcpu_id, cpu_id);
-    }
-
-    #[cfg(all(test, feature = "host-test"))]
-    pub(crate) fn test_lookup_cpu_id(&self, vcpu_id: usize) -> AxVmResult<usize> {
-        self.lookup_cpu_id(vcpu_id)
-    }
-
-    /// Unregisters a vCPU task after the vCPU powers off.
-    pub fn unregister_vcpu_task(&self, vcpu_id: usize) {
-        self.vcpu_tasks.lock().remove(&vcpu_id);
+    /// Drops all queued interrupts for a vCPU that is leaving the runtime.
+    pub fn clear(&self, vcpu_id: usize) {
         self.queue.drain(vcpu_id);
-        #[cfg(all(test, feature = "host-test"))]
-        self.test_vcpu_cpu_ids.lock().remove(&vcpu_id);
     }
 
     /// Enqueues a pending interrupt for the given vCPU.
     ///
-    /// Returns the physical CPU id the target vCPU task is currently running
-    /// on. The two internal locks are held **sequentially** (never together):
-    ///
-    /// 1. Lock `vcpu_tasks`, query the task's CPU through the host facade,
-    ///    release.
-    /// 2. Lock `queue`, push the interrupt, release.
-    ///
-    /// A task migration window exists between steps 1 and 2 (the pCPU may
-    /// change), but `notify_all()` + `send_ipi` in the caller guarantee
-    /// eventual delivery regardless of the race.
-    ///
-    /// # Errors
-    ///
-    /// Returns `NotFound` when the vCPU task has not been registered via
-    /// [`register_vcpu_task`](Self::register_vcpu_task).
-    ///
-    /// Called by `VmRuntimeHandle::dispatch_vcpu_interrupt` when an
-    /// architecture interrupt router requests delivery to a vCPU.
-    pub fn enqueue(&self, vcpu_id: usize, interrupt: PendingVcpuInterrupt) -> AxVmResult<usize> {
-        let cpu_id = self.lookup_cpu_id(vcpu_id)?;
+    /// The runtime validates task ownership and resolves the target pCPU
+    /// before calling this method. Keeping that knowledge in one registry
+    /// avoids duplicated task lifecycle state in the dispatcher.
+    pub fn enqueue(&self, vcpu_id: usize, interrupt: PendingVcpuInterrupt) {
         self.queue.push(vcpu_id, interrupt);
-        Ok(cpu_id)
-    }
-
-    fn lookup_cpu_id(&self, vcpu_id: usize) -> AxVmResult<usize> {
-        #[cfg(all(test, feature = "host-test"))]
-        {
-            if let Some(&cpu_id) = self.test_vcpu_cpu_ids.lock().get(&vcpu_id) {
-                return Ok(cpu_id);
-            }
-        }
-        let tasks = self.vcpu_tasks.lock();
-        tasks
-            .get(&vcpu_id)
-            .map(task_cpu_id)
-            .ok_or_else(|| ax_err_type!(NotFound, format_args!("vCPU {vcpu_id} task not found")))
     }
 
     /// Drains all pending interrupts for the given vCPU, leaving its queue
@@ -167,30 +97,12 @@ mod tests {
     }
 
     #[test]
-    fn enqueue_unregistered_vcpu_returns_error() {
-        let d = VcpuIrqDispatcher::new();
-        assert!(matches!(
-            d.enqueue(0, edge(1)),
-            Err(crate::AxVmError::ResourceUnavailable { .. })
-        ));
-    }
-
-    #[test]
-    fn enqueue_multiple_unregistered_vcpus_all_return_error() {
-        let d = VcpuIrqDispatcher::new();
-        for vcpu_id in [0, 1, 3, 7] {
-            assert!(d.enqueue(vcpu_id, edge(1)).is_err());
-        }
-    }
-
-    #[test]
     fn round_trip_enqueue_drain_preserves_fifo_order() {
         let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 2);
 
-        d.enqueue(0, edge(10)).unwrap();
-        d.enqueue(0, level(20)).unwrap();
-        d.enqueue(0, edge(30)).unwrap();
+        d.enqueue(0, edge(10));
+        d.enqueue(0, level(20));
+        d.enqueue(0, edge(30));
 
         let drained = d.drain(0);
         assert_eq!(drained.len(), 3);
@@ -202,11 +114,9 @@ mod tests {
     #[test]
     fn round_trip_enqueue_drain_isolates_vcpus() {
         let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 1);
-        d.register_test_vcpu(1, 2);
 
-        d.enqueue(0, edge(100)).unwrap();
-        d.enqueue(1, level(200)).unwrap();
+        d.enqueue(0, edge(100));
+        d.enqueue(1, level(200));
 
         assert_eq!(d.drain(0), vec![edge(100)]);
         assert_eq!(d.drain(1), vec![level(200)]);
@@ -215,9 +125,8 @@ mod tests {
     #[test]
     fn round_trip_drain_empties_queue() {
         let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 0);
 
-        d.enqueue(0, edge(7)).unwrap();
+        d.enqueue(0, edge(7));
         assert_eq!(d.drain(0).len(), 1);
         assert!(d.drain(0).is_empty());
     }
@@ -225,9 +134,8 @@ mod tests {
     #[test]
     fn round_trip_double_drain_returns_empty() {
         let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 0);
 
-        d.enqueue(0, edge(7)).unwrap();
+        d.enqueue(0, edge(7));
         d.drain(0);
         assert!(d.drain(0).is_empty());
     }
@@ -235,10 +143,9 @@ mod tests {
     #[test]
     fn round_trip_trigger_mode_preserved() {
         let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 3);
 
-        d.enqueue(0, edge(42)).unwrap();
-        d.enqueue(0, level(43)).unwrap();
+        d.enqueue(0, edge(42));
+        d.enqueue(0, level(43));
 
         let drained = d.drain(0);
         assert_eq!(
@@ -252,20 +159,14 @@ mod tests {
     }
 
     #[test]
-    fn enqueue_returns_registered_cpu_id() {
+    fn clear_drops_only_target_vcpu_interrupts() {
         let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 5);
+        d.enqueue(0, edge(1));
+        d.enqueue(1, edge(2));
 
-        let cpu_id = d.enqueue(0, edge(1)).unwrap();
-        assert_eq!(cpu_id, 5);
-    }
+        d.clear(0);
 
-    #[test]
-    fn unregistered_vcpu_still_fails_when_others_registered() {
-        let d = VcpuIrqDispatcher::new();
-        d.register_test_vcpu(0, 0);
-
-        assert!(d.enqueue(0, edge(1)).is_ok());
-        assert!(d.enqueue(1, edge(2)).is_err());
+        assert!(d.drain(0).is_empty());
+        assert_eq!(d.drain(1), vec![edge(2)]);
     }
 }

--- a/virtualization/axvm/src/runtime/hvc.rs
+++ b/virtualization/axvm/src/runtime/hvc.rs
@@ -312,7 +312,7 @@ impl HyperCall {
             }
             HyperCallCode::PSCICpuOff => {
                 info!("VM[{}] PSCI_CPU_OFF", self.vm.id());
-                let current = crate::host::task::current_task();
+                let current = crate::host::task::current_thread();
                 let cpu_off_reserved = current
                     .try_as_vcpu_task()
                     .map(|task| task.vcpu.id())

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use alloc::{format, sync::Arc};
+use core::sync::atomic::{AtomicU8, Ordering};
 
 use crate::{
     AsVCpuTask, AxVmResult, GuestPhysAddr, StopReason, VCpuTask, VmStatus, VmVcpuState,
@@ -23,6 +24,103 @@ use crate::{
 };
 
 const KERNEL_STACK_SIZE: usize = 0x40000; // 256 KiB
+const VCPU_THREAD_PENDING: u8 = 0;
+const VCPU_THREAD_ACTIVE: u8 = 1;
+const VCPU_THREAD_ABORTED: u8 = 2;
+
+struct VcpuThreadStartGate {
+    state: AtomicU8,
+    wait_queue: crate::WaitQueue,
+}
+
+impl VcpuThreadStartGate {
+    const fn new() -> Self {
+        Self {
+            state: AtomicU8::new(VCPU_THREAD_PENDING),
+            wait_queue: crate::WaitQueue::new(),
+        }
+    }
+
+    fn activate(&self) {
+        self.state
+            .compare_exchange(
+                VCPU_THREAD_PENDING,
+                VCPU_THREAD_ACTIVE,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .unwrap_or_else(|state| panic!("invalid vCPU thread activation state: {state}"));
+        self.wait_queue.notify_all();
+    }
+
+    fn abort(&self) {
+        if self
+            .state
+            .compare_exchange(
+                VCPU_THREAD_PENDING,
+                VCPU_THREAD_ABORTED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+        {
+            self.wait_queue.notify_all();
+        }
+    }
+
+    fn wait_for_activation(&self) -> bool {
+        self.wait_queue
+            .wait_until(|| self.state.load(Ordering::Acquire) != VCPU_THREAD_PENDING);
+        match self.state.load(Ordering::Acquire) {
+            VCPU_THREAD_ACTIVE => true,
+            VCPU_THREAD_ABORTED => false,
+            state => panic!("invalid completed vCPU thread activation state: {state}"),
+        }
+    }
+}
+
+/// Spawned vCPU thread held behind a start gate until VM publication commits.
+#[must_use = "prepared vCPU threads must be activated or explicitly aborted"]
+pub(crate) struct PreparedVcpuThread {
+    thread: Option<crate::ThreadHandle>,
+    start_gate: Arc<VcpuThreadStartGate>,
+}
+
+impl PreparedVcpuThread {
+    pub(crate) fn thread_handle(&self) -> crate::ThreadHandle {
+        self.thread
+            .as_ref()
+            .expect("prepared vCPU thread was already consumed")
+            .clone()
+    }
+
+    pub(crate) fn activate(mut self) {
+        self.start_gate.activate();
+        let _thread = self
+            .thread
+            .take()
+            .expect("prepared vCPU thread was already consumed");
+    }
+
+    pub(crate) fn abort_and_join(mut self) -> AxVmResult {
+        self.start_gate.abort();
+        let thread = self
+            .thread
+            .take()
+            .expect("prepared vCPU thread was already consumed");
+        crate::host::task::join_thread(thread)
+            .map(|_exit_code| ())
+            .map_err(|error| crate::AxVmError::host("abort prepared vCPU thread", error))
+    }
+}
+
+impl Drop for PreparedVcpuThread {
+    fn drop(&mut self) {
+        if self.thread.is_some() {
+            self.start_gate.abort();
+        }
+    }
+}
 
 /// Blocks the current thread until the provided condition is met, using the wait queue
 /// associated with the VCpus of the specified VM.
@@ -285,6 +383,9 @@ pub(crate) fn vcpu_on(
         let runtime = vm
             .with_runtime(|runtime| Ok(runtime.clone()))
             .map_err(|_| VcpuOnError::StartFailed)?;
+        runtime
+            .reap_retired_vcpu_task(vcpu_id)
+            .map_err(|_| VcpuOnError::StartFailed)?;
         if runtime.has_vcpu_task(vcpu_id) {
             return Err(VcpuOnError::StartFailed);
         }
@@ -298,11 +399,22 @@ pub(crate) fn vcpu_on(
             .insert_cpu_on_start_ack(vcpu_id, ack.clone())
             .map_err(|_| VcpuOnError::StartFailed)?;
 
-        let vcpu_task = alloc_vcpu_task(&vm, vcpu.clone());
-        if runtime.add_vcpu_task(vcpu_id, vcpu_task).is_err() {
+        let prepared = match prepare_vcpu_thread(&vm, vcpu.clone()) {
+            Ok(prepared) => prepared,
+            Err(_) => {
+                runtime.remove_cpu_on_start_ack(vcpu_id);
+                return Err(VcpuOnError::StartFailed);
+            }
+        };
+        if runtime
+            .add_vcpu_task(vcpu_id, prepared.thread_handle())
+            .is_err()
+        {
             runtime.remove_cpu_on_start_ack(vcpu_id);
+            let _ = prepared.abort_and_join();
             return Err(VcpuOnError::StartFailed);
         }
+        prepared.activate();
         runtime.notify_all();
 
         runtime.wait_until(|| ack.is_complete() || !vm.running());
@@ -311,8 +423,8 @@ pub(crate) fn vcpu_on(
             if ack.cancel_before_startup() {
                 runtime.notify_all();
 
-                if let Some(task) = runtime.remove_vcpu_task(vcpu_id) {
-                    let _ = crate::host::task::join_task(task);
+                if let Some(thread) = runtime.remove_vcpu_task(vcpu_id) {
+                    let _ = crate::host::task::join_thread(thread);
                 }
 
                 runtime.remove_cpu_on_start_ack(vcpu_id);
@@ -331,7 +443,9 @@ pub(crate) fn vcpu_on(
         runtime.remove_cpu_on_start_ack(vcpu_id);
 
         if result.is_err() {
-            runtime.remove_vcpu_task(vcpu_id);
+            if let Some(thread) = runtime.remove_vcpu_task(vcpu_id) {
+                let _ = crate::host::task::join_thread(thread);
+            }
             return Err(VcpuOnError::StartFailed);
         }
 
@@ -354,7 +468,7 @@ fn spawn_deferred_reset_task(vm_id: usize) {
     // SAFETY: no OS extension is supplied, and the closure plus its captured
     // VM identity are transferred exactly once to the runtime task.
     let spawned = unsafe {
-        crate::host::task::spawn_task_with_extension_and_affinity(
+        crate::host::task::spawn_thread_with_extension_and_affinity(
             reset_entry,
             format!("VM[{vm_id}]-reset"),
             KERNEL_STACK_SIZE,
@@ -368,11 +482,11 @@ fn spawn_deferred_reset_task(vm_id: usize) {
     }
 }
 
-pub(crate) fn alloc_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::TaskHandle {
-    info!("Spawning task for VM[{}] VCpu[{}]", vm.id(), vcpu.id());
+pub(crate) fn prepare_vcpu_thread(vm: &VMRef, vcpu: VCpuRef) -> AxVmResult<PreparedVcpuThread> {
+    info!("Preparing thread for VM[{}] VCpu[{}]", vm.id(), vcpu.id());
     let name = format!("VM[{}]-VCpu[{}]", vm.id(), vcpu.id());
     let affinity = vcpu.phys_cpu_set().map(|phys_cpu_set| {
-        crate::host::task::task_cpu_set_from_raw_bits(vcpu_task_cpu_mask(
+        crate::host::task::cpu_set_from_raw_bits(vcpu_task_cpu_mask(
             vm.id(),
             vcpu.id(),
             phys_cpu_set,
@@ -382,22 +496,32 @@ pub(crate) fn alloc_vcpu_task(vm: &VMRef, vcpu: VCpuRef) -> crate::TaskHandle {
     // Keep only a weak VM reference in the scheduler extension so a retained
     // task handle cannot keep the VM resource graph alive.
     let extension = VCpuTask::new(vm, vcpu).into_thread_extension();
+    let start_gate = Arc::new(VcpuThreadStartGate::new());
+    let thread_start_gate = Arc::clone(&start_gate);
+    let entry = move || {
+        if thread_start_gate.wait_for_activation() {
+            vcpu_run();
+        }
+    };
     // SAFETY: `extension` is a unique owner created immediately above and is
     // transferred exactly once. The optional affinity was validated against
     // the runtime topology by the host adapter.
-    let task = unsafe {
-        crate::host::task::spawn_task_with_extension_and_affinity(
-            vcpu_run,
+    let thread = unsafe {
+        crate::host::task::spawn_thread_with_extension_and_affinity(
+            entry,
             name,
             KERNEL_STACK_SIZE,
             Some(extension),
             affinity,
         )
     }
-    .unwrap_or_else(|error| panic!("failed to spawn AxVM vCPU task: {error}"));
+    .map_err(|error| crate::AxVmError::host("prepare vCPU thread", error))?;
 
-    info!("VCpu task {:?} created", task.id());
-    task
+    info!("vCPU thread {:?} prepared", thread.id());
+    Ok(PreparedVcpuThread {
+        thread: Some(thread),
+        start_gate,
+    })
 }
 
 fn vcpu_task_cpu_mask(vm_id: usize, vcpu_id: usize, requested_mask: usize) -> usize {
@@ -435,7 +559,7 @@ fn vcpu_task_cpu_mask(vm_id: usize, vcpu_id: usize, requested_mask: usize) -> us
 /// When the VCpu first starts running, it waits for the VM to be in the running state.
 /// It then enters a loop where it runs the VCpu and handles the various exit reasons.
 fn vcpu_run() {
-    let curr = crate::host::task::current_task();
+    let curr = crate::host::task::current_thread();
 
     let vm = curr.as_vcpu_task().vm();
     let vcpu = curr.as_vcpu_task().vcpu.clone();
@@ -474,8 +598,6 @@ fn vcpu_run() {
             Err(err) => {
                 ack.complete(Err(err));
                 runtime.notify_all();
-                runtime.remove_cpu_on_start_ack(vcpu_id);
-                runtime.remove_vcpu_task(vcpu_id);
                 return;
             }
         }
@@ -498,7 +620,7 @@ fn vcpu_run() {
                 if let Err(err) = vcpu.power_off_after_cpu_off() {
                     warn!("VM[{vm_id}] VCpu[{vcpu_id}] CPU_OFF cleanup failed: {err:?}");
                 }
-                runtime.remove_vcpu_task(vcpu_id);
+                runtime.retire_vcpu_task(vcpu_id);
                 if !runtime.consume_cpu_off_reservation(vcpu_id) {
                     let _ = runtime.mark_vcpu_exiting();
                 }

--- a/virtualization/axvm/src/task.rs
+++ b/virtualization/axvm/src/task.rs
@@ -10,8 +10,8 @@ use core::ptr;
 
 use crate::{
     host::task::{
-        SchedulePolicy, SwitchReason, TaskHandle, ThreadExtension, ThreadExtensionOps, ThreadId,
-        task_extension,
+        SchedulePolicy, SwitchReason, ThreadExtension, ThreadExtensionOps, ThreadHandle, ThreadId,
+        thread_extension,
     },
     vm::{AxVCpuRef, AxVMRef},
 };
@@ -93,9 +93,9 @@ pub trait AsVCpuTask {
     fn as_vcpu_task(&self) -> &VCpuTask;
 }
 
-impl AsVCpuTask for TaskHandle {
+impl AsVCpuTask for ThreadHandle {
     fn try_as_vcpu_task(&self) -> Option<&VCpuTask> {
-        let extension = task_extension(self)
+        let extension = thread_extension(self)
             .unwrap_or_else(|error| panic!("failed to inspect AxVM task extension: {error}"))?;
         if !ptr::eq(extension.ops(), &VCPU_TASK_EXTENSION_OPS) {
             return None;

--- a/virtualization/axvm/src/timer.rs
+++ b/virtualization/axvm/src/timer.rs
@@ -2,11 +2,15 @@
 
 extern crate alloc;
 
+use alloc::{
+    boxed::Box,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 #[cfg(test)]
-use alloc::vec::Vec;
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc};
+use core::sync::atomic::AtomicU64;
 use core::{
-    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
+    sync::atomic::{AtomicUsize, Ordering},
     time::Duration,
 };
 #[cfg(test)]
@@ -15,64 +19,14 @@ use std::sync::{Mutex, MutexGuard};
 use ax_kernel_guard::NoPreempt;
 use ax_kspin::SpinNoIrq;
 use ax_lazyinit::LazyInit;
-use ax_std::os::arceos::modules::ax_task::IrqNotify;
 use ax_timer_list::{TimeValue, TimerEvent, TimerList};
 
+use crate::host::task::IrqNotification;
 #[cfg(not(test))]
-use crate::host::{HostTime, default_host, task};
+use crate::host::{HostTime, default_host};
 
 static TOKEN: AtomicUsize = AtomicUsize::new(0);
 const TIMER_WORKER_STACK_SIZE: usize = 0x20_000;
-const NO_PUBLISHED_DEADLINE: u64 = 0;
-
-/// Lock-free publication of one CPU's earliest AxVM timer deadline.
-///
-/// The host timer IRQ reads this value while selecting the next shared
-/// hardware comparator deadline. AxVM wheel mutations publish before asking
-/// the host timer arbiter to move the comparator earlier.
-pub(crate) struct PublishedTimerDeadline {
-    deadline_nanos: AtomicU64,
-}
-
-impl PublishedTimerDeadline {
-    const fn new() -> Self {
-        Self {
-            deadline_nanos: AtomicU64::new(NO_PUBLISHED_DEADLINE),
-        }
-    }
-
-    pub(crate) fn deadline_nanos(&self) -> Option<u64> {
-        match self.deadline_nanos.load(Ordering::Acquire) {
-            NO_PUBLISHED_DEADLINE => None,
-            deadline => Some(deadline),
-        }
-    }
-
-    fn publish(&self, deadline: Option<TimeValue>) {
-        let deadline = deadline.map_or(NO_PUBLISHED_DEADLINE, |deadline| {
-            (deadline.as_nanos().min(u64::MAX as u128) as u64).max(1)
-        });
-        self.deadline_nanos.store(deadline, Ordering::Release);
-    }
-
-    /// Removes an elapsed publication before the common IRQ path rearms the
-    /// shared host comparator. The AxVM worker republishes the next wheel
-    /// deadline after consuming all expired events.
-    pub(crate) fn clear_if_elapsed(&self, now_nanos: u64) {
-        let mut observed = self.deadline_nanos.load(Ordering::Acquire);
-        while observed != NO_PUBLISHED_DEADLINE && observed <= now_nanos {
-            match self.deadline_nanos.compare_exchange_weak(
-                observed,
-                NO_PUBLISHED_DEADLINE,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => break,
-                Err(current) => observed = current,
-            }
-        }
-    }
-}
 
 /// Owner-aware handle for one AxVM timer-wheel entry.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -108,7 +62,8 @@ impl TimerEvent for VmTimerEvent {
 struct TimerWheels {
     wheels: BTreeMap<usize, TimerList<VmTimerEvent>>,
     owners: BTreeMap<usize, usize>,
-    published_deadlines: BTreeMap<usize, Arc<PublishedTimerDeadline>>,
+    notifications: BTreeMap<usize, Arc<IrqNotification>>,
+    workers_started: BTreeSet<usize>,
 }
 
 impl TimerWheels {
@@ -116,30 +71,32 @@ impl TimerWheels {
         Self {
             wheels: BTreeMap::new(),
             owners: BTreeMap::new(),
-            published_deadlines: BTreeMap::new(),
+            notifications: BTreeMap::new(),
+            workers_started: BTreeSet::new(),
         }
     }
 
     fn ensure_cpu(&mut self, cpu_id: usize) -> &mut TimerList<VmTimerEvent> {
-        self.published_deadlines
+        self.notifications
             .entry(cpu_id)
-            .or_insert_with(|| Arc::new(PublishedTimerDeadline::new()));
+            .or_insert_with(|| Arc::new(IrqNotification::new()));
         self.wheels.entry(cpu_id).or_default()
     }
 
-    fn published_deadline(&mut self, cpu_id: usize) -> Arc<PublishedTimerDeadline> {
+    fn notification(&mut self, cpu_id: usize) -> Arc<IrqNotification> {
         self.ensure_cpu(cpu_id);
-        self.published_deadlines
+        self.notifications
             .get(&cpu_id)
-            .expect("ensured AxVM timer CPU must have a published deadline")
+            .expect("ensured AxVM timer CPU must have a notification")
             .clone()
     }
 
-    fn publish_next_deadline(&self, cpu_id: usize, deadline: Option<TimeValue>) {
-        self.published_deadlines
-            .get(&cpu_id)
-            .expect("AxVM timer wheel must publish only initialized CPUs")
-            .publish(deadline);
+    fn worker_started(&self, cpu_id: usize) -> bool {
+        self.workers_started.contains(&cpu_id)
+    }
+
+    fn mark_worker_started(&mut self, cpu_id: usize) {
+        self.workers_started.insert(cpu_id);
     }
 
     fn register(
@@ -151,9 +108,7 @@ impl TimerWheels {
     ) -> Option<TimeValue> {
         self.owners.insert(token, owner_cpu);
         self.ensure_cpu(owner_cpu).set(deadline, event);
-        let next_deadline = self.next_deadline(owner_cpu);
-        self.publish_next_deadline(owner_cpu, next_deadline);
-        next_deadline
+        self.next_deadline(owner_cpu)
     }
 
     fn handle(&self, token: usize) -> Option<VmTimerHandle> {
@@ -170,9 +125,7 @@ impl TimerWheels {
         self.owners.remove(&handle.token);
         let wheel = self.wheels.get_mut(&handle.owner_cpu)?;
         wheel.cancel(|event| event.token == handle.token);
-        let next_deadline = wheel.next_deadline();
-        self.publish_next_deadline(handle.owner_cpu, next_deadline);
-        Some(next_deadline)
+        Some(wheel.next_deadline())
     }
 
     fn expire_one(
@@ -187,7 +140,6 @@ impl TimerWheels {
         if let Some((_, event)) = &expired {
             self.owners.remove(&event.token);
         }
-        self.publish_next_deadline(owner_cpu, self.next_deadline(owner_cpu));
         expired
     }
 
@@ -212,25 +164,28 @@ pub(crate) fn register_timer_handle(
     callback: Box<dyn FnOnce(Duration) + Send + 'static>,
 ) -> VmTimerHandle {
     let token = TOKEN.fetch_add(1, Ordering::Relaxed);
-    let (owner_cpu, next_deadline) = with_current_timer_wheels(|cpu_id, timer_wheels| {
-        let next_deadline = timer_wheels.register(
+    let (owner_cpu, notification) = with_current_timer_wheels(|cpu_id, timer_wheels| {
+        timer_wheels.register(
             cpu_id,
             token,
             TimeValue::from_nanos(deadline_ns),
             VmTimerEvent::new(token, callback),
         );
-        (cpu_id, next_deadline)
+        (cpu_id, timer_wheels.notification(cpu_id))
     });
-    rearm_host_timer(next_deadline);
+    notify_timer_worker(&notification);
     VmTimerHandle { token, owner_cpu }
 }
 
 pub(crate) fn cancel_timer_handle(handle: VmTimerHandle) {
     let _guard = NoPreempt::new();
-    let current_cpu = current_cpu_id();
-    let next_deadline = with_timer_wheels(|timer_wheels| timer_wheels.cancel_handle(handle));
-    if let Some(next_deadline) = next_deadline {
-        rearm_owner_host_timer(handle.owner_cpu, current_cpu, next_deadline);
+    let notification = with_timer_wheels(|timer_wheels| {
+        timer_wheels
+            .cancel_handle(handle)
+            .map(|_| timer_wheels.notification(handle.owner_cpu))
+    });
+    if let Some(notification) = notification {
+        notify_timer_worker(&notification);
     }
 }
 
@@ -244,7 +199,7 @@ pub(crate) fn cancel_timer(token: usize) {
     }
 }
 
-pub(crate) fn check_events() {
+fn check_events() -> Option<TimeValue> {
     loop {
         let now = current_host_time();
         let (expired, next_deadline) = with_current_timer_wheels(|cpu_id, timer_wheels| {
@@ -260,8 +215,7 @@ pub(crate) fn check_events() {
             trace!("handle VM timer event scheduled at {deadline:#?}");
             event.callback(now);
         } else {
-            rearm_host_timer(next_deadline);
-            break;
+            return next_deadline;
         }
     }
 }
@@ -276,67 +230,56 @@ fn current_host_time() -> TimeValue {
     TimeValue::from_nanos(TEST_NOW_NS.load(Ordering::Acquire))
 }
 
-fn rearm_owner_host_timer(owner_cpu: usize, current_cpu: usize, next_deadline: Option<TimeValue>) {
-    if owner_cpu == current_cpu {
-        rearm_host_timer(next_deadline);
-    } else {
-        rearm_remote_owner_host_timer(owner_cpu);
-    }
-}
-
-fn rearm_current_host_timer_from_wheel() {
-    let next_deadline =
-        with_current_timer_wheels(|cpu_id, timer_wheels| timer_wheels.next_deadline(cpu_id));
-    rearm_host_timer(next_deadline);
-}
-
-#[cfg(not(test))]
-unsafe fn rearm_current_host_timer_from_wheel_thunk(_arg: *mut ()) {
-    rearm_current_host_timer_from_wheel();
-}
-
-#[cfg(not(test))]
-fn rearm_remote_owner_host_timer(owner_cpu: usize) {
-    let result = task::run_on_cpu_sync(
-        owner_cpu,
-        rearm_current_host_timer_from_wheel_thunk,
-        core::ptr::null_mut(),
-    );
-    if let Err(error) = result {
-        warn!("failed to rearm AxVM timer on owner CPU {owner_cpu}: {error:?}; sending IPI");
-        task::send_ipi(owner_cpu);
+fn timer_worker(notification: Arc<IrqNotification>) -> ! {
+    loop {
+        let next_deadline = check_events();
+        notification.wait_until(next_deadline);
     }
 }
 
 #[cfg(not(test))]
-fn rearm_host_timer(next_deadline: Option<TimeValue>) {
-    if let Some(deadline) = next_deadline {
-        default_host().request_timer_deadline(deadline.as_nanos() as u64);
-    }
+fn notify_timer_worker(notification: &IrqNotification) {
+    notification.notify_from_task();
 }
 
-pub(crate) fn init_percpu() {
+#[cfg(test)]
+fn notify_timer_worker(_notification: &IrqNotification) {}
+
+pub(crate) fn init_percpu() -> crate::AxVmResult {
     info!("Initializing AxVM timer wheel...");
-    let deadline_source =
-        with_current_timer_wheels(|cpu_id, timer_wheels| timer_wheels.published_deadline(cpu_id));
-
     let cpu_id = current_cpu_id();
-    let notify = Arc::new(IrqNotify::new());
-    let worker_notify = notify.clone();
-    let worker = crate::host::task::TaskInner::new(
-        move || loop {
-            worker_notify.wait();
-            check_events();
-        },
-        alloc::format!("axvm-timer-{cpu_id}"),
-        TIMER_WORKER_STACK_SIZE,
+    let (notification, already_started) = with_current_timer_wheels(|cpu_id, timer_wheels| {
+        (
+            timer_wheels.notification(cpu_id),
+            timer_wheels.worker_started(cpu_id),
+        )
+    });
+    if already_started {
+        return Ok(());
+    }
+
+    let worker_notification = Arc::clone(&notification);
+    let affinity = crate::host::task::cpu_set_one(cpu_id);
+    let worker = unsafe {
+        // SAFETY: the per-CPU worker carries no OS extension. Its single-CPU
+        // affinity is installed before scheduler publication, and its owned
+        // notification is moved exactly once into a permanent entry point.
+        crate::host::task::spawn_thread_with_extension_and_affinity(
+            move || timer_worker(worker_notification),
+            alloc::format!("axvm-timer-{cpu_id}"),
+            TIMER_WORKER_STACK_SIZE,
+            None,
+            Some(affinity),
+        )
+    }
+    .map_err(|error| crate::AxVmError::host("start per-CPU AxVM timer worker", error))?;
+    debug!(
+        "AxVM timer worker {} started on CPU {cpu_id}",
+        worker.id().as_u64()
     );
-    let cpu_bit = 1usize
-        .checked_shl(cpu_id as u32)
-        .expect("AxVM timer worker CPU ID must fit the host CPU mask");
-    worker.set_cpumask(crate::host::task::cpu_mask_from_raw_bits(cpu_bit));
-    crate::host::task::spawn_task(worker);
-    crate::arch::register_timer_source(deadline_source, notify);
+    with_current_timer_wheels(|cpu_id, timer_wheels| timer_wheels.mark_worker_started(cpu_id));
+    drop(worker);
+    Ok(())
 }
 
 fn with_timer_wheels<R>(operation: impl FnOnce(&mut TimerWheels) -> R) -> R {
@@ -360,10 +303,6 @@ fn current_cpu_id() -> usize {
 #[cfg(test)]
 static TEST_CURRENT_CPU: AtomicUsize = AtomicUsize::new(0);
 #[cfg(test)]
-static TEST_REARMS: Mutex<Vec<(usize, Option<TimeValue>)>> = Mutex::new(Vec::new());
-#[cfg(test)]
-static TEST_REMOTE_REARMS: Mutex<Vec<usize>> = Mutex::new(Vec::new());
-#[cfg(test)]
 static TEST_NOW_NS: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(test)]
@@ -377,19 +316,6 @@ fn lock_test_mutex<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 }
 
 #[cfg(test)]
-fn rearm_host_timer(next_deadline: Option<TimeValue>) {
-    lock_test_mutex(&TEST_REARMS).push((current_cpu_id(), next_deadline));
-}
-
-#[cfg(test)]
-fn rearm_remote_owner_host_timer(owner_cpu: usize) {
-    lock_test_mutex(&TEST_REMOTE_REARMS).push(owner_cpu);
-    let previous_cpu = TEST_CURRENT_CPU.swap(owner_cpu, Ordering::AcqRel);
-    rearm_current_host_timer_from_wheel();
-    TEST_CURRENT_CPU.store(previous_cpu, Ordering::Release);
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -397,8 +323,6 @@ mod tests {
 
     fn reset_global_timer_state() {
         with_timer_wheels(|timer_wheels| *timer_wheels = TimerWheels::new());
-        lock_test_mutex(&TEST_REARMS).clear();
-        lock_test_mutex(&TEST_REMOTE_REARMS).clear();
         TEST_CURRENT_CPU.store(0, Ordering::Release);
         TEST_NOW_NS.store(0, Ordering::Release);
     }
@@ -414,7 +338,7 @@ mod tests {
     }
 
     #[test]
-    fn host_timer_callback_path_dispatches_registered_event_once() {
+    fn worker_dispatches_registered_event_once_at_its_deadline() {
         let _guard = lock_test_mutex(&TEST_LOCK);
         reset_global_timer_state();
         TEST_CALLBACK_NOW_NS.store(0, Ordering::Release);
@@ -428,15 +352,11 @@ mod tests {
             }),
         );
 
-        check_events();
+        assert_eq!(check_events(), Some(Duration::from_nanos(10_000_000)));
         assert_eq!(TEST_CALLBACK_NOW_NS.load(Ordering::Acquire), 0);
-        assert_eq!(
-            lock_test_mutex(&TEST_REARMS).last().copied(),
-            Some((0, Some(Duration::from_nanos(10_000_000))))
-        );
 
         TEST_NOW_NS.store(10_000_000, Ordering::Release);
-        check_events();
+        assert_eq!(check_events(), None);
         assert_eq!(TEST_CALLBACK_NOW_NS.load(Ordering::Acquire), 10_000_000);
         assert_eq!(
             with_timer_wheels(|timer_wheels| timer_wheels.handle(token)),
@@ -468,7 +388,7 @@ mod tests {
     }
 
     #[test]
-    fn cancel_rearms_to_remaining_owner_deadline() {
+    fn cancel_exposes_remaining_owner_deadline() {
         let mut timer_wheels = TimerWheels::new();
         let early = Duration::from_secs(10);
         let late = Duration::from_secs(20);
@@ -487,7 +407,7 @@ mod tests {
     }
 
     #[test]
-    fn migration_reprogramming_deletes_stale_original_cpu_deadline() {
+    fn migration_deletes_stale_original_cpu_deadline() {
         let mut timer_wheels = TimerWheels::new();
         let stale_deadline = Duration::from_secs(60);
         let migrated_deadline = Duration::from_millis(10);
@@ -530,63 +450,47 @@ mod tests {
     }
 
     #[test]
-    fn published_deadline_tracks_registration_cancellation_and_expiry() {
+    fn worker_deadline_snapshot_tracks_registration_cancellation_and_expiry() {
         let mut timer_wheels = TimerWheels::new();
         let early = Duration::from_millis(5);
         let late = Duration::from_millis(10);
-        let source = timer_wheels.published_deadline(0);
 
         timer_wheels.register(0, 51, early, event(51));
         timer_wheels.register(0, 52, late, event(52));
-        assert_eq!(source.deadline_nanos(), Some(5_000_000));
+        assert_eq!(timer_wheels.next_deadline(0), Some(early));
 
         timer_wheels.cancel_handle(VmTimerHandle {
             token: 51,
             owner_cpu: 0,
         });
-        assert_eq!(source.deadline_nanos(), Some(10_000_000));
+        assert_eq!(timer_wheels.next_deadline(0), Some(late));
 
         timer_wheels.expire_one(0, late);
-        assert_eq!(source.deadline_nanos(), None);
+        assert_eq!(timer_wheels.next_deadline(0), None);
     }
 
     #[test]
-    fn timer_irq_clears_only_an_elapsed_publication() {
-        let source = PublishedTimerDeadline::new();
-        source.publish(Some(Duration::from_nanos(20)));
-
-        source.clear_if_elapsed(19);
-        assert_eq!(source.deadline_nanos(), Some(20));
-
-        source.clear_if_elapsed(20);
-        assert_eq!(source.deadline_nanos(), None);
-    }
-
-    #[test]
-    fn remote_cancel_reprograms_owner_cpu_timer() {
+    fn remote_cancel_updates_the_owner_cpu_wheel() {
         let _guard = lock_test_mutex(&TEST_LOCK);
         reset_global_timer_state();
 
         set_current_cpu_for_test(0);
         let early_token = register_timer(10_000_000, Box::new(|_| {}));
         let late_token = register_timer(20_000_000, Box::new(|_| {}));
-        assert_eq!(lock_test_mutex(&TEST_REARMS).len(), 2);
 
-        lock_test_mutex(&TEST_REARMS).clear();
         set_current_cpu_for_test(1);
         cancel_timer(early_token);
 
-        assert_eq!(lock_test_mutex(&TEST_REMOTE_REARMS).as_slice(), &[0]);
         assert_eq!(
-            lock_test_mutex(&TEST_REARMS).as_slice(),
-            &[(0, Some(Duration::from_nanos(20_000_000)))]
+            with_timer_wheels(|timer_wheels| timer_wheels.next_deadline(0)),
+            Some(Duration::from_nanos(20_000_000))
         );
 
-        lock_test_mutex(&TEST_REARMS).clear();
         cancel_timer(late_token);
-
-        assert_eq!(lock_test_mutex(&TEST_REMOTE_REARMS).as_slice(), &[0, 0]);
-        assert_eq!(lock_test_mutex(&TEST_REARMS).as_slice(), &[(0, None)]);
+        assert_eq!(
+            with_timer_wheels(|timer_wheels| timer_wheels.next_deadline(0)),
+            None
+        );
     }
 
     #[test]
@@ -613,18 +517,19 @@ mod tests {
     }
 
     #[test]
-    fn remote_handle_cancel_reprograms_the_recorded_owner_cpu() {
+    fn remote_handle_cancel_uses_the_recorded_owner_cpu() {
         let _guard = lock_test_mutex(&TEST_LOCK);
         reset_global_timer_state();
 
         set_current_cpu_for_test(2);
         let handle = register_timer_handle(20_000_000, Box::new(|_| {}));
-        lock_test_mutex(&TEST_REARMS).clear();
 
         set_current_cpu_for_test(0);
         cancel_timer_handle(handle);
 
-        assert_eq!(lock_test_mutex(&TEST_REMOTE_REARMS).as_slice(), &[2]);
-        assert_eq!(lock_test_mutex(&TEST_REARMS).as_slice(), &[(2, None)]);
+        assert_eq!(
+            with_timer_wheels(|timer_wheels| timer_wheels.next_deadline(2)),
+            None
+        );
     }
 }

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -187,7 +187,7 @@ pub(crate) enum PendingInterrupt {
 /// Runtime-only resources owned by Running/Paused/Stopping lifecycle states.
 pub(crate) struct VmRuntimeHandle {
     wait_queue: crate::WaitQueue,
-    vcpu_task_list: Mutex<BTreeMap<usize, crate::AxTaskRef>>,
+    vcpu_threads: Mutex<VcpuThreadRegistry>,
     cpu_on_start_acks: Mutex<BTreeMap<usize, Arc<crate::runtime::vcpus::CpuOnStartAck>>>,
     cpu_off_exit_reservations: Mutex<BTreeSet<usize>>,
     pending_interrupts: Mutex<BTreeMap<usize, Vec<PendingInterrupt>>>,
@@ -195,6 +195,12 @@ pub(crate) struct VmRuntimeHandle {
     running_halting_vcpu_count: AtomicUsize,
     lifecycle_error: SpinRaw<Option<AxVmError>>,
     deferred_reset_requested: AtomicBool,
+}
+
+#[derive(Default)]
+struct VcpuThreadRegistry {
+    active: BTreeMap<usize, crate::ThreadHandle>,
+    retired: BTreeMap<usize, crate::ThreadHandle>,
 }
 
 pub(crate) fn dispatch_vcpu_interrupt_with(
@@ -228,7 +234,7 @@ impl VmRuntimeHandle {
     pub(crate) fn new() -> Self {
         Self {
             wait_queue: crate::WaitQueue::new(),
-            vcpu_task_list: Mutex::new(BTreeMap::new()),
+            vcpu_threads: Mutex::new(VcpuThreadRegistry::default()),
             cpu_on_start_acks: Mutex::new(BTreeMap::new()),
             cpu_off_exit_reservations: Mutex::new(BTreeSet::new()),
             pending_interrupts: Mutex::new(BTreeMap::new()),
@@ -241,19 +247,20 @@ impl VmRuntimeHandle {
 
     #[allow(dead_code)]
     pub(crate) fn has_vcpu_task(&self, vcpu_id: usize) -> bool {
-        self.vcpu_task_list.lock().contains_key(&vcpu_id)
+        self.vcpu_threads.lock().active.contains_key(&vcpu_id)
     }
 
-    pub(crate) fn add_vcpu_task(&self, vcpu_id: usize, vcpu_task: crate::AxTaskRef) -> AxVmResult {
-        let mut vcpu_task_list = self.vcpu_task_list.lock();
-        if vcpu_task_list.contains_key(&vcpu_id) {
+    pub(crate) fn add_vcpu_task(
+        &self,
+        vcpu_id: usize,
+        vcpu_thread: crate::ThreadHandle,
+    ) -> AxVmResult {
+        let mut threads = self.vcpu_threads.lock();
+        if threads.active.contains_key(&vcpu_id) {
             return ax_err!(BadState, format!("vCPU {vcpu_id} task already exists"));
         }
-
-        self.irq_dispatcher
-            .register_vcpu_task(vcpu_id, vcpu_task.clone());
-        vcpu_task_list.insert(vcpu_id, vcpu_task);
-        drop(vcpu_task_list);
+        threads.active.insert(vcpu_id, vcpu_thread);
+        drop(threads);
 
         self.pending_interrupts.lock().entry(vcpu_id).or_default();
         Ok(())
@@ -266,10 +273,34 @@ impl VmRuntimeHandle {
         self.cpu_on_start_acks.lock().remove(&vcpu_id)
     }
 
-    pub(crate) fn remove_vcpu_task(&self, vcpu_id: usize) -> Option<crate::AxTaskRef> {
+    pub(crate) fn remove_vcpu_task(&self, vcpu_id: usize) -> Option<crate::ThreadHandle> {
         self.pending_interrupts.lock().remove(&vcpu_id);
-        self.irq_dispatcher.unregister_vcpu_task(vcpu_id);
-        self.vcpu_task_list.lock().remove(&vcpu_id)
+        self.irq_dispatcher.clear(vcpu_id);
+        self.vcpu_threads.lock().active.remove(&vcpu_id)
+    }
+
+    /// Transfers a self-exiting vCPU thread out of the active registry.
+    ///
+    /// A thread cannot join itself. The next CPU_ON or VM-wide cleanup takes
+    /// ownership of the retired handle and joins it from another thread.
+    pub(crate) fn retire_vcpu_task(&self, vcpu_id: usize) {
+        self.pending_interrupts.lock().remove(&vcpu_id);
+        self.irq_dispatcher.clear(vcpu_id);
+        let mut threads = self.vcpu_threads.lock();
+        if let Some(thread) = threads.active.remove(&vcpu_id) {
+            let replaced = threads.retired.insert(vcpu_id, thread);
+            debug_assert!(replaced.is_none(), "retired vCPU thread was not reaped");
+        }
+    }
+
+    pub(crate) fn reap_retired_vcpu_task(&self, vcpu_id: usize) -> AxVmResult {
+        let retired = self.vcpu_threads.lock().retired.remove(&vcpu_id);
+        if let Some(thread) = retired {
+            crate::host::task::join_thread(thread)
+                .map(|_exit_code| ())
+                .map_err(|error| AxVmError::host("join retired vCPU thread", error))?;
+        }
+        Ok(())
     }
 
     #[allow(dead_code)]
@@ -301,26 +332,41 @@ impl VmRuntimeHandle {
         vcpu_id: usize,
         interrupt: PendingInterrupt,
     ) -> AxVmResult<usize> {
-        let task = self
-            .vcpu_task_list
+        let thread = self
+            .vcpu_threads
             .lock()
+            .active
             .get(&vcpu_id)
             .cloned()
             .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
+        let cpu_id = crate::host::task::thread_cpu_id(&thread).ok_or_else(|| {
+            AxVmError::invalid_state(
+                "queue vCPU interrupt",
+                format_args!("vCPU {vcpu_id} thread has no assigned CPU"),
+            )
+        })?;
         self.pending_interrupts
             .lock()
             .entry(vcpu_id)
             .or_default()
             .push(interrupt);
-        Ok(task.cpu_id() as usize)
+        Ok(cpu_id)
     }
 
     pub(crate) fn vcpu_cpu_id(&self, vcpu_id: usize) -> AxVmResult<usize> {
-        self.vcpu_task_list
+        let thread = self
+            .vcpu_threads
             .lock()
+            .active
             .get(&vcpu_id)
-            .map(|task| task.cpu_id() as usize)
-            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))
+            .cloned()
+            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
+        crate::host::task::thread_cpu_id(&thread).ok_or_else(|| {
+            AxVmError::invalid_state(
+                "resolve vCPU CPU",
+                format_args!("vCPU {vcpu_id} thread has no assigned CPU"),
+            )
+        })
     }
 
     /// New delivery path: enqueue → notify → host IPI.
@@ -340,7 +386,11 @@ impl VmRuntimeHandle {
         interrupt: PendingVcpuInterrupt,
     ) -> AxVmResult {
         dispatch_vcpu_interrupt_with(
-            || self.irq_dispatcher.enqueue(vcpu_id, interrupt),
+            || {
+                let pcpu_id = self.vcpu_cpu_id(vcpu_id)?;
+                self.irq_dispatcher.enqueue(vcpu_id, interrupt);
+                Ok(pcpu_id)
+            },
             || self.notify_all(),
             crate::host::task::send_ipi,
         )
@@ -369,11 +419,11 @@ impl VmRuntimeHandle {
     }
 
     pub(crate) fn notify_one(&self) {
-        self.wait_queue.notify_one(false);
+        self.wait_queue.notify_one();
     }
 
     pub(crate) fn notify_all(&self) {
-        self.wait_queue.notify_all(false);
+        self.wait_queue.notify_all();
     }
 
     pub(crate) fn mark_vcpu_running(&self) {
@@ -432,31 +482,56 @@ impl VmRuntimeHandle {
     }
 
     pub(crate) fn join_all_vcpu_tasks(&self, vm_id: usize) -> AxVmResult {
-        if self.vcpu_task_list.lock().is_empty() {
-            return self.take_lifecycle_error().map_or(Ok(()), Err);
+        let current_id = crate::host::task::current_thread().id();
+        let threads = {
+            let mut registry = self.vcpu_threads.lock();
+            let mut joinable = Vec::new();
+            registry.active.retain(|vcpu_id, thread| {
+                if thread.id() == current_id {
+                    true
+                } else {
+                    joinable.push((*vcpu_id, thread.clone()));
+                    false
+                }
+            });
+            registry.retired.retain(|vcpu_id, thread| {
+                if thread.id() == current_id {
+                    true
+                } else {
+                    joinable.push((*vcpu_id, thread.clone()));
+                    false
+                }
+            });
+            joinable
+        };
+
+        for (vcpu_id, _) in &threads {
+            self.pending_interrupts.lock().remove(vcpu_id);
+            self.irq_dispatcher.clear(*vcpu_id);
         }
-        let current = crate::host::task::current_task();
-        let tasks: Vec<_> = self
-            .vcpu_task_list
-            .lock()
-            .values()
-            .filter(|task| !current.ptr_eq(task))
-            .cloned()
-            .collect();
-        let task_count = tasks.len();
-        info!("VM[{vm_id}] Joining {task_count} VCpu tasks...");
-        for (idx, task) in tasks.iter().enumerate() {
-            debug!(
-                "VM[{}] Joining VCpu task[{}]: {}",
-                vm_id,
-                idx,
-                task.id_name()
-            );
-            let exit_code = task.join();
-            debug!("VM[{vm_id}] VCpu task[{idx}] exited with code: {exit_code}");
+
+        let task_count = threads.len();
+        info!("VM[{vm_id}] joining {task_count} vCPU threads...");
+        let mut join_error = None;
+        for (vcpu_id, thread) in threads {
+            let thread_id = thread.id().as_u64();
+            debug!("VM[{vm_id}] joining vCPU[{vcpu_id}] thread {thread_id}");
+            match crate::host::task::join_thread(thread) {
+                Ok(exit_code) => debug!(
+                    "VM[{vm_id}] vCPU[{vcpu_id}] thread {thread_id} exited with code {exit_code}"
+                ),
+                Err(error) => {
+                    warn!("VM[{vm_id}] failed to join vCPU[{vcpu_id}] thread {thread_id}: {error}");
+                    if join_error.is_none() {
+                        join_error = Some(AxVmError::host("join vCPU thread", error));
+                    }
+                }
+            }
         }
-        info!("VM[{vm_id}] VCpu resources cleaned up, {task_count} VCpu tasks joined");
-        self.take_lifecycle_error().map_or(Ok(()), Err)
+        info!("VM[{vm_id}] vCPU resources cleaned up, {task_count} vCPU threads joined");
+        self.take_lifecycle_error()
+            .or(join_error)
+            .map_or(Ok(()), Err)
     }
 }
 
@@ -524,23 +599,36 @@ mod runtime_handle_tests {
     use super::*;
 
     #[test]
-    fn remove_vcpu_task_clears_pending_interrupts_and_dispatcher_registration() {
+    fn remove_vcpu_task_clears_pending_interrupts_and_dispatcher_queue() {
         let runtime = VmRuntimeHandle::new();
 
         runtime.pending_interrupts.lock().entry(3).or_default();
-        runtime.irq_dispatcher.register_test_vcpu(3, 11);
+        runtime.irq_dispatcher.enqueue(
+            3,
+            PendingVcpuInterrupt {
+                id: crate::irq::model::VirtualInterruptId(11),
+                trigger: crate::InterruptTriggerMode::EdgeTriggered,
+            },
+        );
 
         assert!(runtime.pending_interrupts.lock().contains_key(&3));
-        assert_eq!(runtime.irq_dispatcher.test_lookup_cpu_id(3).unwrap(), 11);
+        assert_eq!(runtime.irq_dispatcher.drain(3).len(), 1);
+        runtime.irq_dispatcher.enqueue(
+            3,
+            PendingVcpuInterrupt {
+                id: crate::irq::model::VirtualInterruptId(11),
+                trigger: crate::InterruptTriggerMode::EdgeTriggered,
+            },
+        );
 
         runtime.remove_vcpu_task(3);
 
         assert!(!runtime.pending_interrupts.lock().contains_key(&3));
-        assert!(runtime.irq_dispatcher.test_lookup_cpu_id(3).is_err());
+        assert!(runtime.irq_dispatcher.drain(3).is_empty());
 
         runtime.remove_vcpu_task(3);
         assert!(!runtime.pending_interrupts.lock().contains_key(&3));
-        assert!(runtime.irq_dispatcher.test_lookup_cpu_id(3).is_err());
+        assert!(runtime.irq_dispatcher.drain(3).is_empty());
     }
 }
 
@@ -982,7 +1070,6 @@ impl AxVM {
         let primary_vcpu = self
             .vcpu(0)
             .ok_or_else(|| ax_err_type!(BadState, "VM primary vCPU is not prepared"))?;
-        let primary_task = crate::runtime::vcpus::build_vcpu_task(self, primary_vcpu);
         let runtime = Arc::new(VmRuntimeHandle::new());
 
         self.with_resources(|resources| {
@@ -998,20 +1085,54 @@ impl AxVM {
             Ok(())
         })?;
 
-        crate::arch::CurrentArch::activate_devices(self)?;
+        let prepared = crate::runtime::vcpus::prepare_vcpu_thread(self, primary_vcpu)?;
+        if let Err(error) = runtime.add_vcpu_task(0, prepared.thread_handle()) {
+            return match prepared.abort_and_join() {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(AxVmError::lifecycle_rollback(
+                    "publish primary vCPU thread",
+                    error,
+                    rollback,
+                )),
+            };
+        }
+
+        if let Err(error) = crate::arch::CurrentArch::activate_devices(self) {
+            runtime.remove_vcpu_task(0);
+            return match prepared.abort_and_join() {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(AxVmError::lifecycle_rollback(
+                    "activate VM devices",
+                    error,
+                    rollback,
+                )),
+            };
+        }
         let start_result = self
             .machine
             .lock()
             .start_with(|_resources| Ok(runtime.clone()));
         if let Err(error) = start_result {
-            return match crate::arch::CurrentArch::deactivate_devices(self) {
-                Ok(()) => Err(error),
-                Err(rollback) => Err(AxVmError::lifecycle_rollback("start VM", error, rollback)),
+            runtime.remove_vcpu_task(0);
+            let thread_rollback = prepared.abort_and_join();
+            let device_rollback = crate::arch::CurrentArch::deactivate_devices(self);
+            return match (thread_rollback, device_rollback) {
+                (Ok(()), Ok(())) => Err(error),
+                (Err(thread), Ok(())) => {
+                    Err(AxVmError::lifecycle_rollback("start VM", error, thread))
+                }
+                (Ok(()), Err(devices)) => {
+                    Err(AxVmError::lifecycle_rollback("start VM", error, devices))
+                }
+                (Err(thread), Err(devices)) => Err(AxVmError::lifecycle_rollback(
+                    "start VM",
+                    error,
+                    format_args!("{thread}; {devices}"),
+                )),
             };
         }
 
-        let task = crate::host::task::spawn_task(primary_task);
-        runtime.add_vcpu_task(0, task)?;
+        prepared.activate();
         Ok(())
     }
 
@@ -1819,7 +1940,6 @@ mod tests {
     #[test]
     fn runtime_dispatch_releases_queue_lock_before_callbacks() {
         let dispatcher = VcpuIrqDispatcher::new();
-        dispatcher.register_test_vcpu(0, 3);
         let interrupt = PendingVcpuInterrupt {
             id: crate::irq::model::VirtualInterruptId(7),
             trigger: crate::InterruptTriggerMode::LevelTriggered,
@@ -1827,7 +1947,10 @@ mod tests {
         let events = RefCell::new(Vec::new());
 
         dispatch_vcpu_interrupt_with(
-            || dispatcher.enqueue(0, interrupt),
+            || {
+                dispatcher.enqueue(0, interrupt);
+                Ok(3)
+            },
             || {
                 assert_eq!(dispatcher.drain(0), alloc::vec![interrupt]);
                 events.borrow_mut().push("notify");


### PR DESCRIPTION
## 问题

#1775 重构 `ax-task` 后移除了旧兼容接口，AxVM/Axvisor 仍持有 `AxTaskRef`、`TaskInner`、`IrqNotify`、旧 affinity API 与物理 clockevent 回调等旧边界。基于 #1775 的基线执行 `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm` 会产生 22 个编译错误，Axvisor 无法构建。

此外，#1775 最新提交新增 `TaskError::PiChainLimit` 后，ArceOS API 与 axruntime 块设备路径的错误映射没有同步覆盖该变体。本 PR 将这两处映射为 `BadState`，保证 stacked 分支可独立构建。

本 PR 以 #1775 的 `codex/refactor-ax-task-from-1596` 分支为 base。

## 修改

1. 将 AxVM 的 ArceOS task 适配层迁移到 `ax-runtime` 原生接口：使用带 generation 的 `ThreadId`、`ThreadHandle`、`CpuSet`、extension 与显式 spawn/join API，不再访问调度器内部任务对象。
2. 让 vCPU runtime registry 成为线程所有权的唯一事实源：线程在 VM 发布提交前由 start gate 阻塞；启动失败会回滚并 join；CPU_OFF 先退休当前 handle，后续 CPU_ON 或 VM 清理再从其他线程回收；所有 join 均在锁外执行。
3. 用基于 `IrqWaitCell`/`WaitQueue` 的私有 IRQ notification 替换旧 `IrqNotify`，迁移 deferred vCPU kick、RISC-V PLIC 与 x86 IRQ forwarding worker，并把 stop/join 纳入设备生命周期。
4. 将 AxVM timer 改为每 CPU 常驻、预先绑定 affinity 的任务线程。timer wheel 更新直接通知所属 worker，worker 使用绝对 deadline 等待并在任务上下文执行回调；物理 clockevent 继续只服务调度器。
5. 迁移 Axvisor console affinity API，并补齐 `PiChainLimit` 在 ArceOS task API 与 axruntime block runtime 中的错误映射。

## 设计逻辑

- 线程句柄只由 runtime registry 或具体 worker owner 持有，IRQ 队列不再复制 task 表，避免生命周期和唤醒事实源分裂。
- generation-bearing `ThreadId` 用于识别线程实例，防止 vCPU 复用后旧句柄与新线程混淆。
- IRQ 路径只发布通知/位图，可能阻塞的 park、回调与 join 留在任务上下文并在锁外执行。
- timer deadline 属于 AxVM 的每 CPU worker，不再把 VMM 定时器复用为调度器物理时钟事件。

## 验证

- 回归红灯：基于 #1775 的原始 `smoke-svm` 命令稳定产生 22 个旧 task API 编译错误。
- 回归绿灯：同一命令通过，`1/1` case passed，并命中 `AXVISOR_NVME_ROOTFS_RW_PASSED`。
- `cargo xtask clippy --package axvm`：6/6 配置通过。
- `cargo test -p axvm --features host-test`：241 passed，0 failed。
- `cargo check --tests -p ax-api`：通过。
- `cargo fmt --all`、`git diff --check`：通过。

Fixes #1863
