### PR TITLE
test(cpu-font-test): FreeType rasterization + HarfBuzz shaping carpet

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "apps/starry/cpu-font-test/assets"]
+	path = apps/starry/cpu-font-test/assets
+	url = https://github.com/Lfan-ke/hw4os-s5d1t2
+	branch = media

--- a/apps/starry/cpu-font-test/.gitignore
+++ b/apps/starry/cpu-font-test/.gitignore
@@ -1,0 +1,5 @@
+target/
+*.o
+*.woff
+*.woff2
+fonts/

--- a/apps/starry/cpu-font-test/README.md
+++ b/apps/starry/cpu-font-test/README.md
@@ -1,0 +1,175 @@
+# cpu-font-test - the "pyte for fonts"
+
+An industrial-grade font test carpet for StarryOS. Where `pyte` gives a headless terminal you can assert
+against cell-by-cell, this gives a headless font-rendering + text-shaping pipeline you can assert against
+**per pixel and per glyph**: every cell drives FreeType (glyph rasterization + metrics) or HarfBuzz (text
+shaping) and checks the output BYTE-EXACT against a golden - a per-pixel SHA-256 of the rendered ink
+buffer, exact-integer 26.6 metrics, exact glyph-index + position shaping - never a smoke test. "Font
+loaded" alone is not a test here.
+
+Runtime dependency is only the Alpine musl `freetype` + `harfbuzz` shared libraries. No TrueType
+interpreter, rasterizer or shaper is reinvented - the whole point is to TEST freetype/harfbuzz. Only the
+SHA-256, the comparison logic and the golden constants are self-written in the cells, so each assertion is
+an independent check against a captured golden, not a self-comparison.
+
+## Fonts
+
+54 flattened TTFs from `render-assets/fonts` (staged into the image under `/opt/cpu-font-test/fonts`, with
+their LICENSE files kept): JetBrains Mono (Apache/OFL) Regular/Medium/Bold + the HarmonyOS Sans family
+(SC/TC/Arabic/Naskh-Arabic-UI/Condensed/Italic, each licensed). JetBrains Mono is monospace (upm 1000,
+every glyph advances 600 font units); the HarmonyOS Arabic Naskh face carries no Latin `A` and is used for
+the RTL shaping leg; HarmonyOS SC supplies the CJK glyph; HarmonyOS Sans (proportional, with `fi/ffi/fl`
+ligatures) is the contrast face.
+
+## Cells
+
+Each cell prints `FONT_<CELL> OK <n>` only when `fail==0 && total==pass==<n>` (three-gate). `run_all.sh`
+gates on the capability manifest: `fail==0 && total==EXPECTED==pass`, EXPECTED>=1 floor.
+
+### `font_raster` - FreeType glyph -> pixels, deterministic per-pixel golden - 68 assertions
+Render specific glyphs at fixed pixel sizes and assert the rasterizer output byte-exact:
+
+- exact bitmap `width / height / pitch / bitmap_top / bitmap_left`, the **SHA-256 of the full ink buffer**
+  (pitch*rows bytes, incl. row padding), and the ink pixel count, for JetBrains Mono `A g 0 l` and the CJK
+  `中` (HarmonyOS SC), plus JetBrains Mono Bold `A` (a genuinely different outline).
+- matrix: sizes 16 / 32 / 48 / 64 px, `FT_RENDER_MODE_MONO` vs `NORMAL` (AA), hinting on (`FT_LOAD_DEFAULT`)
+  vs off (`FT_LOAD_NO_HINTING`) - each combination has its own golden because each is a different rasterizer
+  output.
+- known-position pixels: the `l` stem inks its center column continuously (>= h/2) while the top-right
+  corner stays blank; `space` is a valid glyph index but an empty 0x0 bitmap with zero ink; the AA `A`
+  buffer carries partial-coverage (anti-aliased) pixels, the MONO one does not.
+
+### `font_metrics` - exact numeric metric assertions - 71 assertions
+FreeType metrics in the 26.6 fixed-point domain vs golden, no tolerance:
+
+- **monospace uniformity**: every glyph in `AglW0i·xz` shares one advance at 16 / 32 / 64 px
+  (`640 / 1216 / 2432` in 26.6, i.e. upm-scaled 600).
+- per-glyph `advance / horiBearingX / horiBearingY / width / height` for `A g l 0 W space` at 32px.
+- face constants: `units_per_EM == 1000`, `ascender == 1020`, `descender == -300`, line `height == 1320`,
+  `num_glyphs == 1754`, family `"JetBrains Mono"`.
+- kerning: JetBrains Mono ships none, so `FT_HAS_KERNING == 0` and `FT_Get_Kerning('A','V') == (0,0)` (an
+  honest golden - monospace fonts do not kern).
+- contrast: HarmonyOS Sans (proportional) advances `A/V == 1344` but `i == 512`, `l == 448`, proving the
+  monospace assertion above is a real discriminator, not a tautology.
+
+### `font_shape` - HarfBuzz shaping, exact glyph-index + position golden - 52 assertions
+Shape known strings and assert the output glyph sequence + per-glyph `x_advance/x_offset/y_offset` +
+cluster map + auto-detected direction/script:
+
+- Latin `"Hello"` (JetBrains Mono): 5 glyphs, gids `65,234,287,287,302`, clusters `0..4`, every
+  `x_advance == 1229` (monospace), LTR, script Latin.
+- `"AV"` (JBM): 2 glyphs (gids `1,170`), advances unchanged (no ligature/kern).
+- **ligature**: HarmonyOS Sans `"fi"` maps to a **single** ligature glyph (gid `397`, cluster 0,
+  advance `1176`), while JetBrains Mono keeps `"fi"` as two glyphs (`254,265`) - both asserted, so the
+  ligature test is real.
+- proportional contrast: HarmonyOS Sans `"AV"` shapes to gids `3,169` with **different** advances
+  (`1186 != 1348`).
+- **RTL complex script**: Arabic "سلام" (salam) with HarmonyOS Naskh Arabic -> 3 shaped glyphs, direction
+  auto-detected `RTL`, script `Arab`, exact gids/advances (`255,368,137`), and clusters in descending
+  (RTL-reordered) order.
+
+### `font_formats` - format matrix: WOFF/WOFF2 wrappers decode to the identical outline - 18 assertions
+The sources are TTF. The prebuild converts JetBrains Mono Regular to WOFF and WOFF2 host-side (fontTools,
+brotli for WOFF2) and stages them next to the TTF. WOFF/WOFF2 are container compressions of the same sfnt
+tables, so FreeType must decode them to the byte-identical outline:
+
+- TTF baseline: `FT_Get_Font_Format == "TrueType"`, `num_glyphs == 1754`, `units_per_EM == 1000`,
+  `num_faces == 1`, family `"JetBrains Mono"`, `A@32px` SHA `== font_raster`'s golden.
+- each staged WOFF / WOFF2 wrapper: loads, reports the same TrueType format / num_glyphs / upm, and renders
+  `A@32px` to the **same per-pixel SHA** as the TTF (format must not change the outline).
+- both wrappers are mandatory: `prebuild.sh` stages them host-side (fontTools + brotli) and hard-fails if it
+  cannot, and the cell fails the gate if a wrapper is missing, so the format-identity matrix cannot silently
+  collapse to the TTF baseline. OTF (glyf->CFF outline re-encoding) is a genuine re-encode, not a lossless
+  wrapper, so it is documented as a follow-up rather than pixel-asserted.
+
+### `font_realassets` - iterate every provided font - 380 assertions with assets present
+Walk all `.ttf` under `$ASSET_DIR` and assert each is a real, usable face: `FT_New_Face` ok, `num_glyphs > 0`,
+`units_per_EM == 1000`, non-empty `family_name`, `FT_Get_Font_Format == "TrueType"`, at least one
+representative glyph (`A`, else Arabic sheen `U+0633`, else CJK `U+4E2D`) renders NON-EMPTY at 32px, and
+HarfBuzz accepts the file with a matching glyph count. The 12 Arabic Naskh faces have no Latin `A`
+(glyph index 0), so the probe falls back to the Arabic/CJK codepoints - every provided font inks at least
+one. `ASSET_DIR` defaults to the staged `/opt/cpu-font-test/fonts`, which `prebuild.sh` always populates
+(it exit-5s if it stages zero TTFs); an absent asset dir is a real staging failure and fails the gate.
+
+## Build / run
+
+`prebuild.sh` extracts the base Alpine rootfs and `apk add`s `freetype freetype-dev harfbuzz harfbuzz-dev`
+for the target arch via qemu-user (apk runs fine under qemu-user), then cross-compiles the five cells **on
+the host** with a musl cross-gcc, `--sysroot` at the staged rootfs so the target headers and `.so` link.
+The cross-toolchain musl and Alpine musl are ABI-compatible for C, so linking the target `.so` from the
+staging root with the host cross-gcc works. The compiler is resolved reproducibly - `${triple}-gcc` on PATH,
+then `/opt/${triple}-cross/bin/${triple}-gcc`, then `zig cc -target ${triple}`, then `musl-gcc` for a native
+x86_64 build - and the include/link closure (`-lfreetype -lharfbuzz` plus transitive `-lz -lbz2 -lpng16
+-lbrotlidec ...`) is resolved by a host `pkgconf` run against the staged `freetype2.pc`/`harfbuzz.pc` with
+`PKG_CONFIG_SYSROOT_DIR` pointed at the staging root. The staging gcc is deliberately not used: gcc spawns
+`cc1` via `posix_spawn`, which qemu-user cannot exec (`cc1: posix_spawn`), so no cell would ever compile.
+
+Alpine edge ships `libfreetype`/`libharfbuzz` with `DT_RELR` (`.relr.dyn`, section type `0x13`) relocations,
+which the GNU ld 2.37 bundled in the musl-cross toolchains cannot parse (`unknown type [0x13] section
+'.relr.dyn'` -> `cannot find -lfreetype`). The link therefore goes through a RELR-aware linker: when a
+standalone `ld.lld` is reachable (LLD is a cross-linker and reads RELR on every arch) it is used as
+`${triple}-gcc -fuse-ld=lld`; otherwise the build switches to `zig cc -target ${triple}`, which links with its
+own bundled LLD. Any LLVM `ld.lld` (Debian/Ubuntu `lld` package, or `/usr/lib/llvm-*/bin/ld.lld`) or a `zig`
+on PATH satisfies this - no pinned versions.
+
+It then stages the TTF fonts + LICENSE files (and the WOFF/WOFF2 wrappers, converted host-side) under
+`/opt/cpu-font-test/fonts`, and writes the `expected_cells` manifest. `programs/run_all.sh` is the on-target
+three-gate runner. Four `build-*.toml` + `qemu-*.toml` cover x86_64 / aarch64 / riscv64 / loongarch64 (nvme
+rootfs + virtio-net; loong/riscv carry `ax-driver/serial`; loong uses the dynamic platform raw-binary boot
+path). Run on each architecture (single vCPU):
+
+```
+cargo xtask starry app qemu -t cpu-font-test --arch x86_64
+cargo xtask starry app qemu -t cpu-font-test --arch aarch64
+cargo xtask starry app qemu -t cpu-font-test --arch riscv64
+cargo xtask starry app qemu -t cpu-font-test --arch loongarch64
+```
+
+### Font assets
+
+The fonts are provided by the per-app `assets` git submodule (same `fonts/` layout as `render-assets`,
+tracked with git-LFS). `prebuild.sh` inits and LFS-pulls it automatically when the marker font
+`assets/fonts/root__JetBrainsMono-Regular.ttf` is a bare gitlink or an LFS pointer, but you can also do it by
+hand before the first run:
+
+```
+git submodule update --init apps/starry/cpu-font-test/assets
+git -C apps/starry/cpu-font-test/assets lfs pull --include='fonts/*'
+```
+
+Set `FONT_ASSET_SRC=<path>` to stage from a different `fonts/` tree instead of the submodule; if it is unset
+and the submodule is absent, `prebuild.sh` walks up to a sibling `render-assets/fonts`. With no font source at
+all it exits 5 (a font source is required - the golden cells assert real glyphs).
+
+## Host validation
+
+Goldens are pinned to the FreeType/HarfBuzz the image ships. Alpine edge currently packages **FreeType
+2.14.3** and **HarfBuzz 14.2.1** (musl); the goldens were captured and re-verified by staging those exact
+`.so` + `-dev` packages into a rootfs (fetched from the Alpine edge repo), cross-compiling each cell against
+that staging root with the host musl cross-gcc exactly as `prebuild.sh` does, and running the resulting
+target binaries under the Alpine musl loader with the staged libraries. All five cells green, `TEST PASSED`:
+
+```
+FONT_RASTER OK 68
+FONT_METRICS OK 71
+FONT_SHAPE OK 52
+FONT_FORMATS OK 18
+FONT_REALASSETS OK 380
+cpu-font-test: 5/5 font carpets OK on x86_64 (expected 5: font_raster font_metrics font_shape font_formats font_realassets )
+TEST PASSED
+```
+
+Metrics, shaping (glyph indices/advances, Arabic RTL) and every AA-render SHA are identical from FreeType
+2.13 through 2.14; the one value that moved across the 2.14 bump is the 1-bit `A@32 MONO` packing SHA, and
+the golden tracks the shipped 2.14.3 value.
+
+Non-vacuity (mutation-tested against the on-target Alpine libs): flipping one byte of the `A@32` render SHA,
+changing an expected glyph index in `font_shape` (Hello / Arabic), and perturbing a golden metric advance
+or a golden bitmap geometry each turn the respective cell into a real FAIL (exit 1, `fail>0`), proving the
+per-pixel / per-glyph assertions are load-bearing.
+
+Tool availability on the build host: fontTools 4.63.0 + brotli produce both the WOFF and WOFF2 wrappers.
+Both are required - `prebuild.sh` aborts (exit 6) if either wrapper cannot be generated, so a host missing
+fontTools/brotli fails the build rather than silently degrading `font_formats` to the TTF baseline. OTF
+(glyf->CFF) conversion needs fontforge/cu2qu-reverse (not required and not a lossless-identity test) -
+documented as a follow-up.

--- a/apps/starry/cpu-font-test/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-font-test/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,6 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-font-test/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-font-test/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,7 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-font-test/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/cpu-font-test/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,7 @@
+target = "riscv64gc-unknown-none-elf"
+log = "Warn"
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-font-test/build-x86_64-unknown-none.toml
+++ b/apps/starry/cpu-font-test/build-x86_64-unknown-none.toml
@@ -1,0 +1,6 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-font-test/prebuild.sh
+++ b/apps/starry/cpu-font-test/prebuild.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the cpu-font-test carpet ("pyte for fonts") into the per-arch Alpine rootfs.
+#
+# The carpet drives libfreetype (glyph rasterization + metrics) and libharfbuzz (text shaping) and asserts
+# the output BYTE-EXACT (per-pixel SHA / exact-integer 26.6 metrics / exact glyph-index+position shaping)
+# against goldens captured host-side with the SAME FreeType/HarfBuzz the image ships. Runtime dependency is
+# just libfreetype + libharfbuzz (Alpine musl `freetype` + `harfbuzz`); the SHA-256, the comparison logic
+# and the golden constants are self-written in the cells. No rasterizer or shaper is re-implemented - the
+# whole point is to TEST freetype/harfbuzz.
+#
+# Model: extract the base Alpine rootfs, `apk add` freetype/freetype-dev + harfbuzz/harfbuzz-dev for the
+# TARGET arch via qemu-user (apk runs fine under qemu-user - it is not gcc), then cross-compile each cell on
+# the HOST with a musl cross-gcc, --sysroot at the staging root so the target headers and .so link. The
+# earlier staging-gcc-under-qemu path could not compile: gcc spawns cc1 via posix_spawn, which qemu-user
+# cannot exec (cc1: posix_spawn), so no cell built and no overlay was produced. Then stage the TTF fonts (+
+# the WOFF/WOFF2 wrappers converted host-side) and LICENSE files under /opt/cpu-font-test/fonts, and write a
+# capability manifest that run_all.sh gates on (fail==0 && total==EXPECTED==pass, EXPECTED>=1 floor).
+#
+# All five cells build and gate on the staged fonts (always present). font_realassets asserts every staged
+# font; since prebuild exit-5s if it stages zero TTFs, an absent $ASSET_DIR on-target fails the gate.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS, STARRY_STAGING_ROOT, STARRY_OVERLAY_DIR,
+# STARRY_APP_DIR. Optional: FONT_ASSET_SRC (host path to the render-assets/fonts tree to stage; defaults
+# to <repo>/render-assets/fonts if present).
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+CAR="$app_dir/programs/carpets"
+
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+}
+
+ROOTFS_SIZE=4G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    command -v resize2fs >/dev/null 2>&1 || { echo "prebuild: resize2fs required (e2fsprogs)" >&2; exit 1; }
+    local before after; before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB for freetype/harfbuzz closure + fonts"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# FreeType + HarfBuzz shared libs, headers and pkg-config .pc files (musl) for the target arch. The .so are
+# the runtime closure; the -dev packages carry the headers + freetype2.pc/harfbuzz.pc the host pkgconf reads
+# to resolve the transitive link closure (-lz -lbz2 -lpng16 -lbrotlidec ...). No target gcc is staged - cells
+# are cross-compiled on the host (see resolve_cc); the staging-gcc path spawned cc1 via posix_spawn, which
+# qemu-user cannot exec, so no cell ever compiled.
+PKGS=(musl freetype freetype-dev harfbuzz harfbuzz-dev)
+
+apk_provision() {
+    normalize_symlinks
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add font carpet stack (${PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add "${PKGS[@]}"
+    [[ -e "$staging_root/usr/lib/libfreetype.so" || -e "$staging_root/usr/lib/libfreetype.so.6" ]] \
+        || { echo "prebuild: libfreetype not provisioned for $arch" >&2; exit 3; }
+    [[ -e "$staging_root/usr/lib/libharfbuzz.so" || -e "$staging_root/usr/lib/libharfbuzz.so.0" ]] \
+        || { echo "prebuild: libharfbuzz not provisioned for $arch" >&2; exit 3; }
+}
+
+# Host cross-compiler for the target musl triple. The cross-toolchain musl and Alpine musl are ABI-compatible
+# for C, so linking the target .so from the staging root with the host cross-gcc works. Resolution order
+# mirrors the sibling cpu-concurrency carpet: standard cross-gcc on PATH, then the /opt/<triple>-cross prefix,
+# then `zig cc -target <triple>`, then musl-gcc for a native x86_64 build. CC is a global set here.
+#
+# Alpine edge ships freetype/harfbuzz with DT_RELR (SHT_RELR `.relr.dyn`) relocations, which GNU ld 2.37 in
+# the musl-cross toolchains cannot parse ("unknown type [0x13] section `.relr.dyn'"), so a plain cross-gcc
+# link fails. LINK_FLAGS therefore selects a RELR-aware linker: `-fuse-ld=lld` when a standalone ld.lld is
+# reachable (LLD is a cross-linker and reads RELR on every arch), staged into LLD_BINDIR so gcc's -B can find
+# it. `zig cc` carries its own LLD, so that path needs no extra linker flag. GNU ld is kept only as a final
+# fallback for images without DT_RELR.
+CC=""
+LINK_FLAGS=()
+LLD_BINDIR=""
+# Resolve a standalone ld.lld: on PATH, then common Debian/Ubuntu versioned names. Symlink it into a private
+# dir so `${triple}-gcc -B$LLD_BINDIR -fuse-ld=lld` finds it under the plain `ld.lld` name.
+resolve_lld() {
+    local lld=""
+    if command -v ld.lld >/dev/null 2>&1; then lld="$(command -v ld.lld)"; fi
+    if [[ -z "$lld" ]]; then
+        local c
+        for c in /usr/bin/ld.lld /usr/lib/llvm-*/bin/ld.lld; do
+            [[ -x "$c" ]] && { lld="$c"; break; }
+        done
+    fi
+    [[ -n "$lld" ]] || return 1
+    LLD_BINDIR="$(mktemp -d)"; trap 'rm -rf "$LLD_BINDIR"' EXIT
+    ln -sf "$lld" "$LLD_BINDIR/ld.lld"
+    return 0
+}
+resolve_cc() {
+    case "$arch" in
+        x86_64)      triple="x86_64-linux-musl" ;;
+        aarch64)     triple="aarch64-linux-musl" ;;
+        riscv64)     triple="riscv64-linux-musl" ;;
+        loongarch64) triple="loongarch64-linux-musl" ;;
+        *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+    if command -v "${triple}-gcc" >/dev/null 2>&1; then
+        CC=("${triple}-gcc")
+    elif [[ -x "/opt/${triple}-cross/bin/${triple}-gcc" ]]; then
+        CC=("/opt/${triple}-cross/bin/${triple}-gcc")
+    elif command -v zig >/dev/null 2>&1; then
+        CC=(zig cc -target "$triple")
+    elif [[ "$arch" == "x86_64" ]] && command -v musl-gcc >/dev/null 2>&1; then
+        CC=(musl-gcc)
+    else
+        echo "prebuild: no musl cross toolchain for $triple (tried ${triple}-gcc, /opt/${triple}-cross, zig cc, musl-gcc)" >&2
+        exit 1
+    fi
+    # A gcc-family compiler needs an explicit RELR-aware linker; zig cc already links with its own LLD.
+    if [[ "${CC[0]}" != "zig" ]]; then
+        if resolve_lld; then
+            LINK_FLAGS=(-fuse-ld=lld -B"$LLD_BINDIR")
+        elif command -v zig >/dev/null 2>&1; then
+            echo "prebuild: no ld.lld found; switching to 'zig cc -target $triple' for RELR-aware linking" >&2
+            CC=(zig cc -target "$triple")
+        else
+            echo "prebuild: warning: no RELR-aware linker (ld.lld or zig); GNU ld cannot link Alpine's DT_RELR .so" >&2
+        fi
+    fi
+    echo "prebuild: host cross-compiler for $arch = ${CC[*]} ${LINK_FLAGS[*]} (sysroot=$staging_root)"
+}
+
+# Resolve the freetype/harfbuzz include + transitive link flags against the staging root with the HOST pkgconf
+# (reading the target .pc files under the staging pkgconfig dir). PKG_CONFIG_SYSROOT_DIR rewrites the -I/-L
+# prefixes to the staging root. Fall back to explicit flags if pkgconf or the .pc files are unavailable.
+host_pkgconf() {
+    PKG_CONFIG_SYSROOT_DIR="$staging_root" PKG_CONFIG_LIBDIR="$staging_root/usr/lib/pkgconfig" \
+        pkgconf "$@"
+}
+
+# Each cell is a standalone C program including font_common.h, linking libfreetype + libharfbuzz. A compile
+# failure is a genuine breakage. Cells build on the host with the cross-gcc, --sysroot at the staging root so
+# the target headers and .so are found; the transitive closure (-lz -lbz2 -lpng16 -lbrotlidec ...) comes from
+# the host pkgconf run against the staged .pc files.
+compile_cells() {
+    local bin="$1"
+    local cflags libs cell
+    cflags="$(host_pkgconf --cflags freetype2 harfbuzz 2>/dev/null || echo "-I$staging_root/usr/include/freetype2 -I$staging_root/usr/include/harfbuzz -I$staging_root/usr/include")"
+    libs="$(host_pkgconf --libs freetype2 harfbuzz 2>/dev/null || echo "-L$staging_root/usr/lib -lfreetype -lharfbuzz")"
+    # -rpath-link lets ld resolve the target .so DT_NEEDED chain (libc.musl-<arch>.so.1, libz, ...) against the
+    # staging root at link time. Without it ld only warns and still links, but resolving it keeps the build clean.
+    local rpath_link=(-Wl,-rpath-link,"$staging_root/usr/lib:$staging_root/lib")
+    # gcc-family resolves the target headers/.so via --sysroot; zig cc treats the pkgconf-emitted absolute
+    # -I/-L (already staging-root prefixed) directly, and would double-prefix them under --sysroot.
+    local sysroot_flags=()
+    [[ "${CC[0]}" != "zig" ]] && sysroot_flags=(--sysroot="$staging_root")
+    for cell in font_raster font_metrics font_shape font_formats font_realassets; do
+        echo "prebuild: cross-compile $cell for $arch (links libfreetype + libharfbuzz; self-written SHA-256 + goldens)"
+        # shellcheck disable=SC2086
+        "${CC[@]}" "${sysroot_flags[@]}" "${LINK_FLAGS[@]}" -O2 -std=c11 -I"$CAR" $cflags "$CAR/$cell.c" -o "$bin/$cell" "${rpath_link[@]}" $libs -lm
+        [[ -x "$bin/$cell" ]] || { echo "prebuild: $cell failed to compile" >&2; exit 4; }
+    done
+}
+
+# Locate the render-assets/fonts tree (host). Walk up from the app dir if FONT_ASSET_SRC is unset.
+find_font_src() {
+    local src="${FONT_ASSET_SRC:-}"
+    # Preferred source: the per-app `assets` git submodule (same fonts/ layout as render-assets).
+    # On a fresh CI checkout the gitlink dir exists but is empty until inited, and the TTFs arrive as
+    # LFS pointers - init + sparse-pull the fonts/ subdir so the marker materializes with real bytes.
+    if [[ -z "$src" && -d "$app_dir/assets" ]]; then
+        if [[ ! -e "$app_dir/assets/fonts/root__JetBrainsMono-Regular.ttf" ]] && command -v git >/dev/null 2>&1; then
+            git -C "$app_dir" submodule update --init assets >/dev/null 2>&1 || true
+        fi
+        if command -v git >/dev/null 2>&1 && git -C "$app_dir/assets" lfs env >/dev/null 2>&1; then
+            git -C "$app_dir/assets" lfs pull --include="fonts/*" >/dev/null 2>&1 || true
+        fi
+        [[ -f "$app_dir/assets/fonts/root__JetBrainsMono-Regular.ttf" ]] && src="$app_dir/assets/fonts"
+    fi
+    if [[ -z "$src" ]]; then
+        local d="$app_dir"
+        for _ in 1 2 3 4 5 6; do
+            d="$(dirname "$d")"
+            if [[ -f "$d/render-assets/fonts/root__JetBrainsMono-Regular.ttf" ]]; then src="$d/render-assets/fonts"; break; fi
+        done
+    fi
+    echo "$src"
+}
+
+# Stage the TTF fonts + LICENSE files under /opt/cpu-font-test/fonts so the golden cells assert against
+# them on-target. Also convert JetBrains Mono Regular -> WOFF/WOFF2 host-side (fontTools; WOFF2 needs
+# brotli) for font_formats' wrapper matrix. A font source is required for the golden cells, and the
+# WOFF/WOFF2 wrappers are mandatory: wrapper generation failure aborts provisioning so font_formats'
+# format-identity matrix is guaranteed to run on-target instead of degrading to the TTF baseline.
+stage_fonts() {
+    local bin="$1" src
+    src="$(find_font_src)"
+    [[ -n "$src" && -d "$src" ]] || { echo "prebuild: render-assets/fonts not found (set FONT_ASSET_SRC)" >&2; exit 5; }
+    echo "prebuild: staging fonts from $src -> /opt/cpu-font-test/fonts"
+    mkdir -p "$bin/fonts"
+    cp -a "$src"/*.ttf "$bin/fonts/" 2>/dev/null || true
+    # keep the LICENSE files (Apache/OFL for JetBrains Mono, HarmonyOS Sans licenses)
+    cp -a "$src"/LICENSE*.txt "$bin/fonts/" 2>/dev/null || true
+    local n; n=$(ls "$bin/fonts"/*.ttf 2>/dev/null | wc -l)
+    echo "prebuild: staged $n TTF fonts + $(ls "$bin/fonts"/LICENSE*.txt 2>/dev/null | wc -l) license files"
+    [[ "$n" -ge 1 ]] || { echo "prebuild: no TTF fonts staged" >&2; exit 5; }
+
+    # WOFF/WOFF2 wrappers for the format matrix (host-side conversion; on-target FreeType decodes them).
+    # font_formats treats both wrappers as mandatory, so wrapper generation must succeed or the whole
+    # provisioning fails here - a missing wrapper is a build-host tooling gap to fix, not something to
+    # silently degrade the format-identity coverage over.
+    local ttf="$bin/fonts/root__JetBrainsMono-Regular.ttf"
+    command -v python3 >/dev/null 2>&1 || { echo "prebuild: python3 required for WOFF/WOFF2 wrappers" >&2; exit 6; }
+    [[ -f "$ttf" ]] || { echo "prebuild: JetBrains Mono TTF missing, cannot build wrappers: $ttf" >&2; exit 6; }
+    python3 - "$ttf" "$bin/fonts" <<'PY' || { echo "prebuild: WOFF/WOFF2 wrapper generation failed - install fontTools + brotli" >&2; exit 6; }
+import sys
+ttf, outdir = sys.argv[1], sys.argv[2]
+from fontTools.ttLib import TTFont
+f = TTFont(ttf); f.flavor = "woff"; f.save(outdir + "/jbm-format.woff")
+f = TTFont(ttf); f.flavor = "woff2"; f.save(outdir + "/jbm-format.woff2")
+print("prebuild: staged font wrappers: woff woff2")
+PY
+    [[ -f "$bin/fonts/jbm-format.woff" && -f "$bin/fonts/jbm-format.woff2" ]] \
+        || { echo "prebuild: WOFF/WOFF2 wrapper not staged after conversion" >&2; exit 6; }
+}
+
+compile_carpets() {
+    local bin="$staging_root/opt/cpu-font-test"; mkdir -p "$bin"
+    resolve_cc
+    compile_cells "$bin"
+    stage_fonts "$bin"
+    cp "$app_dir/programs/run_all.sh" "$bin/run_all.sh"; chmod +x "$bin/run_all.sh"
+}
+
+populate_overlay() {
+    local bin="$staging_root/opt/cpu-font-test"
+    : > "$bin/expected_cells"
+    for c in font_raster font_metrics font_shape font_formats font_realassets; do
+        [[ -x "$bin/$c" ]] && echo "$c" >> "$bin/expected_cells"; done
+    echo "prebuild: expected_cells for $arch = $(tr '\n' ' ' < "$bin/expected_cells")"
+    mkdir -p "$overlay_dir/usr/lib" "$overlay_dir/opt"
+    cp -a "$staging_root/usr/lib/." "$overlay_dir/usr/lib/"
+    cp -a "$staging_root/opt/cpu-font-test" "$overlay_dir/opt/"
+    mkdir -p "$overlay_dir/usr/bin"
+    ln -sf /opt/cpu-font-test/run_all.sh "$overlay_dir/usr/bin/run_all.sh"
+    echo "prebuild: overlay populated for $arch ($(du -sh "$overlay_dir/usr/lib" | cut -f1) libs, $(du -sh "$overlay_dir/opt/cpu-font-test/fonts" | cut -f1) fonts)"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+compile_carpets
+populate_overlay
+echo "prebuild: cpu-font-test overlay ready for $arch"

--- a/apps/starry/cpu-font-test/programs/carpets/font_common.h
+++ b/apps/starry/cpu-font-test/programs/carpets/font_common.h
@@ -1,0 +1,182 @@
+/* font_common.h - shared primitives for the cpu-font-test carpet ("pyte for fonts").
+ *
+ * Everything the cells assert against is either a closed-form property (monospace advance is a single
+ * fixed value; a space glyph rasterizes to an empty bitmap) or a golden value calibrated once host-side
+ * with the SAME FreeType/HarfBuzz the image ships (Alpine musl freetype/harfbuzz). The cells REUSE
+ * libfreetype (rasterization + metrics) and libharfbuzz (shaping) - only the comparison logic, the
+ * SHA-256 over the rendered ink buffer, and the golden constants are self-written. "Font loaded" is not
+ * a test: every cell asserts per-pixel bitmaps, exact-integer metrics, or exact glyph-index/position
+ * shaping output against the golden.
+ *
+ * FreeType rasterization is bit-exact deterministic for a fixed (font, pixel size, hinting, render
+ * mode, FreeType version): the smooth (AA) rasterizer and the monochrome rasterizer are pure integer/
+ * fixed-point pipelines with no float rounding divergence across the arches Alpine builds for. So the
+ * SHA-256 of the ink buffer is a reproducible golden. HarfBuzz shaping (glyph indices + 26.6 advances)
+ * is likewise deterministic for a fixed font+features. Goldens are pinned to the FreeType/HarfBuzz the
+ * image actually ships: Alpine edge musl FreeType 2.14.3 + HarfBuzz 14.2.1 (verified by rebuilding the
+ * goldens against those exact .so files). AA/mono geometry, ink counts, all AA SHAs and every metric/
+ * shaping value are identical from FreeType 2.13 through 2.14; the one value that moved across the 2.14
+ * bump is the 1-bit MONO packing SHA, which the golden tracks. A further version skew that changed a
+ * glyph outline would flip the SHA and the cell would FAIL loudly rather than silently pass.
+ */
+#ifndef FONT_COMMON_H
+#define FONT_COMMON_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+#include FT_MODULE_H
+#include FT_FONT_FORMATS_H
+
+#include <hb.h>
+#include <hb-ft.h>
+
+/* -------- font locations -------- */
+/* On-target these come from the staged overlay (prebuild copies render-assets/fonts here) or from the
+ * ASSET_DIR submodule mount. Host validation points FONT_DIR at the render-assets tree directly. */
+static const char *font_dir(void) {
+    const char *d = getenv("FONT_DIR");
+    if (d && *d) return d;
+    d = getenv("ASSET_DIR");
+    if (d && *d) return d;          /* ASSET_DIR/fonts appended by callers when needed */
+    return "/opt/cpu-font-test/fonts";
+}
+
+/* Build "<font_dir>/<name>" into a static-ish caller buffer. */
+static const char *font_path(char *buf, size_t n, const char *name) {
+    snprintf(buf, n, "%s/%s", font_dir(), name);
+    return buf;
+}
+
+/* Canonical faces used by the golden cells (flattened names in render-assets/fonts). */
+#define FONT_JBM_REGULAR "root__JetBrainsMono-Regular.ttf"
+#define FONT_JBM_MEDIUM  "root__JetBrainsMono-Medium.ttf"
+#define FONT_JBM_BOLD    "root__JetBrainsMono-Bold.ttf"
+#define FONT_SC_REGULAR  "root__HarmonyOS_Sans_SC_Regular.ttf"
+#define FONT_ARABIC      "HarmonyOS_Sans_Naskh_Arabic__HarmonyOS_Sans_Naskh_Arabic_Regular.ttf"
+
+/* -------- self-written SHA-256 over the rendered ink buffer -------- */
+typedef struct { uint32_t h[8]; uint64_t len; unsigned char buf[64]; size_t n; } sha256_ctx;
+static const uint32_t SHA_K[64] = {
+    0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,
+    0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,
+    0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,
+    0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,
+    0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,
+    0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,
+    0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,
+    0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2 };
+static uint32_t sha_ror(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
+static void sha256_init(sha256_ctx *c) {
+    c->h[0]=0x6a09e667; c->h[1]=0xbb67ae85; c->h[2]=0x3c6ef372; c->h[3]=0xa54ff53a;
+    c->h[4]=0x510e527f; c->h[5]=0x9b05688c; c->h[6]=0x1f83d9ab; c->h[7]=0x5be0cd19;
+    c->len = 0; c->n = 0;
+}
+static void sha256_block(sha256_ctx *c, const unsigned char *p) {
+    uint32_t w[64];
+    for (int i = 0; i < 16; i++)
+        w[i] = (p[i*4]<<24)|(p[i*4+1]<<16)|(p[i*4+2]<<8)|p[i*4+3];
+    for (int i = 16; i < 64; i++) {
+        uint32_t s0 = sha_ror(w[i-15],7)^sha_ror(w[i-15],18)^(w[i-15]>>3);
+        uint32_t s1 = sha_ror(w[i-2],17)^sha_ror(w[i-2],19)^(w[i-2]>>10);
+        w[i] = w[i-16]+s0+w[i-7]+s1;
+    }
+    uint32_t a=c->h[0],b=c->h[1],cc=c->h[2],d=c->h[3],e=c->h[4],f=c->h[5],g=c->h[6],h=c->h[7];
+    for (int i = 0; i < 64; i++) {
+        uint32_t S1 = sha_ror(e,6)^sha_ror(e,11)^sha_ror(e,25);
+        uint32_t ch = (e&f)^((~e)&g);
+        uint32_t t1 = h+S1+ch+SHA_K[i]+w[i];
+        uint32_t S0 = sha_ror(a,2)^sha_ror(a,13)^sha_ror(a,22);
+        uint32_t maj = (a&b)^(a&cc)^(b&cc);
+        uint32_t t2 = S0+maj;
+        h=g; g=f; f=e; e=d+t1; d=cc; cc=b; b=a; a=t1+t2;
+    }
+    c->h[0]+=a; c->h[1]+=b; c->h[2]+=cc; c->h[3]+=d; c->h[4]+=e; c->h[5]+=f; c->h[6]+=g; c->h[7]+=h;
+}
+static void sha256_update(sha256_ctx *c, const void *data, size_t len) {
+    const unsigned char *p = (const unsigned char *)data;
+    c->len += len;
+    while (len > 0) {
+        size_t take = 64 - c->n; if (take > len) take = len;
+        memcpy(c->buf + c->n, p, take);
+        c->n += take; p += take; len -= take;
+        if (c->n == 64) { sha256_block(c, c->buf); c->n = 0; }
+    }
+}
+static void sha256_hex(sha256_ctx *c, char out[65]) {
+    uint64_t bits = c->len * 8;
+    unsigned char pad = 0x80;
+    sha256_update(c, &pad, 1);
+    unsigned char z = 0;
+    while (c->n != 56) sha256_update(c, &z, 1);
+    unsigned char lb[8];
+    for (int i = 0; i < 8; i++) lb[i] = (bits >> (56 - i*8)) & 0xff;
+    sha256_update(c, lb, 8);
+    for (int i = 0; i < 8; i++) sprintf(out + i*8, "%08x", c->h[i]);
+}
+/* one-shot: hex SHA-256 of buf[0..len) */
+static void sha256_buf(const void *buf, size_t len, char out[65]) {
+    sha256_ctx c; sha256_init(&c); sha256_update(&c, buf, len); sha256_hex(&c, out);
+}
+
+/* -------- three-gate marker (identical semantics to the audio/render carpets) -------- */
+typedef struct { int pass, total, fail; const char *name; } gate;
+static void gate_init(gate *g, const char *name) { g->pass = g->total = g->fail = 0; g->name = name; }
+static void gate_check(gate *g, int cond, const char *msg) {
+    g->total++;
+    if (cond) g->pass++;
+    else { g->fail++; fprintf(stderr, "  FAIL: %s\n", msg); }
+}
+static int gate_finish(gate *g) {
+    if (g->fail == 0 && g->total == g->pass && g->total > 0) {
+        printf("%s OK %d\n", g->name, g->total);
+        return 0;
+    }
+    printf("%s FAILED pass=%d total=%d fail=%d\n", g->name, g->pass, g->total, g->fail);
+    return 1;
+}
+
+/* gate discipline: an OK line with 0 assertions is NOT allowed (gate_finish requires total>0). Every
+ * cell must assert at least one real check; font_realassets emits its OK marker over the fonts it
+ * iterated (assets are guaranteed staged on-target, so an absent asset dir is a FAIL, not a skip). */
+
+/* -------- FreeType convenience -------- */
+/* Load a face at a fixed pixel size; hinting/render mode chosen by the caller's FT_Load_Glyph flags. */
+static int ft_open(FT_Library lib, const char *path, FT_Face *face) {
+    return FT_New_Face(lib, path, 0, face);
+}
+
+/* Render a single character to an 8-bit coverage buffer via FreeType. Returns 0 on success and fills
+ * *w,*h,*pitch,*top,*left plus a malloc'd copy of the bitmap (caller frees). mode is FT_RENDER_MODE_*
+ * and load_flags is the FT_Load_Glyph flag set (hinting on/off). The returned buffer is exactly
+ * pitch*h bytes so the SHA is over the true rasterizer output including row padding. */
+static int ft_render_char(FT_Face face, uint32_t cp, int px, FT_Int32 load_flags, FT_Render_Mode mode,
+                          unsigned char **buf, int *w, int *h, int *pitch, int *top, int *left,
+                          FT_UInt *gindex_out) {
+    if (FT_Set_Pixel_Sizes(face, px, px)) return -1;
+    FT_UInt gi = FT_Get_Char_Index(face, cp);
+    if (gindex_out) *gindex_out = gi;
+    if (FT_Load_Glyph(face, gi, load_flags)) return -2;
+    if (FT_Render_Glyph(face->glyph, mode)) return -3;
+    FT_Bitmap *bm = &face->glyph->bitmap;
+    *w = bm->width; *h = bm->rows; *pitch = bm->pitch;
+    *top = face->glyph->bitmap_top; *left = face->glyph->bitmap_left;
+    size_t n = (size_t)(*pitch < 0 ? -*pitch : *pitch) * (*h);
+    unsigned char *out = (unsigned char *)malloc(n ? n : 1);
+    if (n) memcpy(out, bm->buffer, n); else out[0] = 0;
+    *buf = out;
+    return 0;
+}
+
+/* count nonzero (ink) bytes in an 8-bit coverage buffer */
+static long ink_count(const unsigned char *buf, int pitch, int h) {
+    long n = 0; int ap = pitch < 0 ? -pitch : pitch;
+    for (int y = 0; y < h; y++) for (int x = 0; x < ap; x++) if (buf[y*ap + x]) n++;
+    return n;
+}
+
+#endif /* FONT_COMMON_H */

--- a/apps/starry/cpu-font-test/programs/carpets/font_formats.c
+++ b/apps/starry/cpu-font-test/programs/carpets/font_formats.c
@@ -1,0 +1,86 @@
+/* font_formats - format matrix: WOFF / WOFF2 wrappers decode to the identical outline (cell 4).
+ *
+ * The source fonts are TTF. The prebuild converts JetBrains Mono Regular to WOFF and WOFF2 host-side
+ * (fontTools, brotli for WOFF2) and stages them next to the TTF. WOFF/WOFF2 are container compressions
+ * of the same sfnt tables, so FreeType must decode them to the byte-identical glyph outline. This cell
+ * asserts:
+ *   - FreeType loads the TTF and reports FT_Get_Font_Format == "TrueType", with the expected
+ *     num_glyphs (1754) / units_per_EM (1000) / family_name,
+ *   - FreeType loads each of the WOFF/WOFF2 wrappers, reports the same TrueType format, num_glyphs and
+ *     upm, and renders 'A' @32px to the SAME per-pixel SHA as the TTF (format must not change the
+ *     outline). prebuild.sh stages both wrappers host-side (fontTools + brotli) and hard-fails if it
+ *     cannot, so on-target both legs are mandatory: a missing wrapper fails the gate rather than letting
+ *     the format-identity matrix silently collapse to the TTF baseline.
+ *
+ * OTF (glyf->CFF outline reflow) is a genuine outline re-encoding, not a lossless wrapper, so it is not
+ * asserted for pixel-identity here; the wrapper matrix (WOFF/WOFF2) is the lossless-identity test and
+ * the OTF leg is documented as a follow-up (honest).
+ */
+#include "font_common.h"
+
+/* golden SHA of JetBrains Mono 'A' @32px AA (same as font_raster's A@32 AA hint) */
+static const char *A32_SHA = "b3e1b83fb1f1fe09aa91f5a260065d8ba8c954b38209fad01478394e39396487";
+
+/* render 'A' @32px and hash; returns 0 on success */
+static int hash_A(FT_Face f, char hex[65]) {
+    unsigned char *buf; int w,h,pitch,top,left; FT_UInt gi;
+    if (ft_render_char(f, 'A', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+                       &buf, &w, &h, &pitch, &top, &left, &gi)) return -1;
+    size_t n = (size_t)(pitch < 0 ? -pitch : pitch) * h;
+    sha256_buf(buf, n ? n : 1, hex);
+    free(buf);
+    return 0;
+}
+
+/* Assert a wrapper loads, is TrueType, and renders A identically to the TTF golden. prebuild.sh stages
+ * both wrappers host-side (fontTools + brotli) and hard-fails if it cannot, so on-target the wrapper is
+ * MANDATORY: a missing wrapper is a real staging failure, not a skip - it fails the gate rather than
+ * silently collapsing the format-identity matrix to the TTF baseline. */
+static void check_wrapper(gate *g, FT_Library lib, const char *dir, const char *name, const char *label) {
+    char path[512]; snprintf(path, sizeof path, "%s/%s", dir, name);
+    FT_Face f;
+    FT_Error err = FT_New_Face(lib, path, 0, &f);
+    gate_check(g, err == 0, label); /* wrapper MUST be staged and openable */
+    if (err) return;
+    gate_check(g, strcmp(FT_Get_Font_Format(f), "TrueType") == 0, label);
+    gate_check(g, f->num_glyphs == 1754, label);
+    gate_check(g, f->units_per_EM == 1000, label);
+    char hex[65];
+    gate_check(g, hash_A(f, hex) == 0 && strcmp(hex, A32_SHA) == 0, label); /* identical outline */
+    FT_Done_Face(f);
+}
+
+int main(void) {
+    gate g; gate_init(&g, "FONT_FORMATS");
+    FT_Library lib;
+    gate_check(&g, FT_Init_FreeType(&lib) == 0, "FT_Init_FreeType failed");
+    if (g.fail) return gate_finish(&g);
+
+    const char *dir = font_dir();
+    char path[512];
+
+    /* baseline TTF leg (always present) */
+    {
+        FT_Face f;
+        gate_check(&g, ft_open(lib, font_path(path, sizeof path, FONT_JBM_REGULAR), &f) == 0,
+                   "open JBM TTF");
+        if (!g.fail) {
+            gate_check(&g, strcmp(FT_Get_Font_Format(f), "TrueType") == 0, "TTF format != TrueType");
+            gate_check(&g, f->num_glyphs == 1754, "TTF num_glyphs != 1754");
+            gate_check(&g, f->units_per_EM == 1000, "TTF units_per_EM != 1000");
+            gate_check(&g, strcmp(f->family_name, "JetBrains Mono") == 0, "TTF family_name mismatch");
+            /* enumerate faces: a single-face TTF reports num_faces == 1 */
+            gate_check(&g, f->num_faces == 1, "TTF num_faces != 1");
+            char hex[65];
+            gate_check(&g, hash_A(f, hex) == 0 && strcmp(hex, A32_SHA) == 0, "TTF 'A' SHA != golden");
+            FT_Done_Face(f);
+        }
+    }
+
+    /* wrapper matrix: WOFF + WOFF2 staged next to the TTF (mandatory - prebuild hard-fails if unstaged) */
+    check_wrapper(&g, lib, dir, "jbm-format.woff",  "WOFF wrapper 'A' identical to TTF");
+    check_wrapper(&g, lib, dir, "jbm-format.woff2", "WOFF2 wrapper 'A' identical to TTF");
+
+    FT_Done_FreeType(lib);
+    return gate_finish(&g);
+}

--- a/apps/starry/cpu-font-test/programs/carpets/font_metrics.c
+++ b/apps/starry/cpu-font-test/programs/carpets/font_metrics.c
@@ -1,0 +1,103 @@
+/* font_metrics - exact numeric metric assertions (cell 2).
+ *
+ * FreeType exposes glyph metrics in 26.6 fixed point (font-unit metrics scaled by the pixel size). For a
+ * MONOSPACE face every glyph shares one advance width; JetBrains Mono @32px advances 1216 (26.6) for A,
+ * g, l, 0, W and space alike. We assert:
+ *   - the shared monospace advance at 16/32/64 px (1000 upm -> advance == 640/1216/2432 in 26.6),
+ *   - per-glyph horiBearingX/Y, width, height against golden font-unit-scaled values,
+ *   - face-level units_per_EM (1000), ascender (1020), descender (-300), height (1320),
+ *   - FT_HAS_KERNING: JetBrains Mono ships no 'kern'/GPOS-kern, so FT_Get_Kerning('A','V') == (0,0);
+ *     HarmonyOS Sans (proportional) has genuinely different advances for A/V vs i/l, proving the
+ *     monospace assertion is a real property, not a tautology.
+ * All values are exact integers in FreeType's fixed-point domain vs golden - no tolerance.
+ */
+#include "font_common.h"
+
+/* golden per-glyph metrics at 32px (26.6), captured host-side (FreeType 2.14.3, JetBrains Mono; per
+ * README these metrics are identical from 2.13 through 2.14, so the goldens match the shipped 2.14.3) */
+typedef struct { uint32_t cp; long adv, bx, by, w, h; } glyph_metric;
+static const glyph_metric M32[] = {
+  {'A', 1216,   64, 1472, 1088, 1472},
+  {'g', 1216,  128, 1152,  960, 1536},
+  {'l', 1216,    0, 1472, 1152, 1472},
+  {'0', 1216,  128, 1472,  960, 1472},
+  {'W', 1216,    0, 1472, 1216, 1472},
+  {' ', 1216,    0,    0,    0,    0},
+};
+#define NM ((int)(sizeof(M32)/sizeof(M32[0])))
+
+int main(void) {
+    gate g; gate_init(&g, "FONT_METRICS");
+    FT_Library lib;
+    gate_check(&g, FT_Init_FreeType(&lib) == 0, "FT_Init_FreeType failed");
+    if (g.fail) return gate_finish(&g);
+
+    char path[512];
+    FT_Face jbm;
+    gate_check(&g, ft_open(lib, font_path(path, sizeof path, FONT_JBM_REGULAR), &jbm) == 0,
+               "open JetBrains Mono");
+    if (g.fail) return gate_finish(&g);
+
+    /* face-level constants (font-unit domain, size-independent) */
+    gate_check(&g, jbm->units_per_EM == 1000, "JBM units_per_EM != 1000");
+    gate_check(&g, jbm->ascender == 1020, "JBM ascender != 1020");
+    gate_check(&g, jbm->descender == -300, "JBM descender != -300");
+    gate_check(&g, jbm->height == 1320, "JBM line height != 1320");
+    gate_check(&g, jbm->num_glyphs == 1754, "JBM num_glyphs != 1754");
+    gate_check(&g, strcmp(jbm->family_name, "JetBrains Mono") == 0, "JBM family_name mismatch");
+
+    /* monospace advance at three sizes. JetBrains Mono's advance is 600 font units at 1000 upm; the
+     * unhinted scale would be px*600/1000 = px*38.4 in 26.6 (32px -> 1228.8), but FT_LOAD_DEFAULT
+     * grid-fits the advance to a whole pixel, so 32px rounds to 19px == 1216 (19*64) in 26.6. The
+     * goldens are these hinted, rounded advances: 10px/640, 19px/1216, 38px/2432. */
+    struct { int px; long adv; } sizes[] = { {16,640}, {32,1216}, {64,2432} };
+    for (int s = 0; s < 3; s++) {
+        FT_Set_Pixel_Sizes(jbm, sizes[s].px, sizes[s].px);
+        const char *probe = "AglW0i xz";   /* mix of wide/narrow glyphs + space */
+        for (const char *c = probe; *c; c++) {
+            FT_Load_Glyph(jbm, FT_Get_Char_Index(jbm, *c), FT_LOAD_DEFAULT);
+            gate_check(&g, jbm->glyph->advance.x == sizes[s].adv,
+                       "monospace advance not uniform across glyphs/size");
+        }
+    }
+
+    /* exact per-glyph metrics at 32px */
+    FT_Set_Pixel_Sizes(jbm, 32, 32);
+    for (int i = 0; i < NM; i++) {
+        FT_Load_Glyph(jbm, FT_Get_Char_Index(jbm, M32[i].cp), FT_LOAD_DEFAULT);
+        FT_Glyph_Metrics *m = &jbm->glyph->metrics;
+        gate_check(&g, jbm->glyph->advance.x == M32[i].adv, "advance != golden");
+        gate_check(&g, m->horiBearingX == M32[i].bx, "horiBearingX != golden");
+        gate_check(&g, m->horiBearingY == M32[i].by, "horiBearingY != golden");
+        gate_check(&g, m->width  == M32[i].w, "glyph width != golden");
+        gate_check(&g, m->height == M32[i].h, "glyph height != golden");
+    }
+
+    /* kerning: JetBrains Mono has none - assert FT_HAS_KERNING is false and the AV pair is (0,0).
+     * Honest golden: monospace fonts do not kern (every advance is already fixed). */
+    gate_check(&g, FT_HAS_KERNING(jbm) == 0, "JBM unexpectedly reports kerning");
+    FT_UInt a = FT_Get_Char_Index(jbm, 'A'), v = FT_Get_Char_Index(jbm, 'V');
+    FT_Vector kv; FT_Get_Kerning(jbm, a, v, FT_KERNING_DEFAULT, &kv);
+    gate_check(&g, kv.x == 0 && kv.y == 0, "JBM AV kerning nonzero");
+
+    /* contrast face: HarmonyOS Sans is proportional - A/V share 1344 but i/l are narrower, so the
+     * monospace property above is a real discriminator, not vacuous. */
+    FT_Face hos;
+    if (ft_open(lib, font_path(path, sizeof path,
+                "HarmonyOS_Sans__HarmonyOS_Sans_Regular.ttf"), &hos) == 0) {
+        FT_Set_Pixel_Sizes(hos, 32, 32);
+        FT_Load_Glyph(hos, FT_Get_Char_Index(hos, 'A'), FT_LOAD_DEFAULT); long aA = hos->glyph->advance.x;
+        FT_Load_Glyph(hos, FT_Get_Char_Index(hos, 'V'), FT_LOAD_DEFAULT); long aV = hos->glyph->advance.x;
+        FT_Load_Glyph(hos, FT_Get_Char_Index(hos, 'i'), FT_LOAD_DEFAULT); long ai = hos->glyph->advance.x;
+        FT_Load_Glyph(hos, FT_Get_Char_Index(hos, 'l'), FT_LOAD_DEFAULT); long al = hos->glyph->advance.x;
+        gate_check(&g, aA == 1344 && aV == 1344, "HOS A/V advance != golden 1344");
+        gate_check(&g, ai == 512 && al == 448, "HOS i/l advance != golden");
+        gate_check(&g, ai != aA && al != aA, "HOS Sans is not proportional (i/l == A)?");
+        gate_check(&g, hos->units_per_EM == 1000, "HOS units_per_EM != 1000");
+        FT_Done_Face(hos);
+    } else gate_check(&g, 0, "open HarmonyOS Sans contrast face");
+
+    FT_Done_Face(jbm);
+    FT_Done_FreeType(lib);
+    return gate_finish(&g);
+}

--- a/apps/starry/cpu-font-test/programs/carpets/font_raster.c
+++ b/apps/starry/cpu-font-test/programs/carpets/font_raster.c
@@ -1,0 +1,139 @@
+/* font_raster - FreeType glyph -> pixels, deterministic per-pixel golden (cell 1).
+ *
+ * Load JetBrains Mono (and HarmonyOS SC for CJK) at fixed pixel sizes and render specific glyphs, then
+ * assert the rasterizer output BYTE-EXACT against goldens captured host-side with the same FreeType:
+ *   - exact bitmap width / height / pitch / bitmap_top / bitmap_left,
+ *   - the SHA-256 of the full ink buffer (pitch*rows bytes, incl. row padding),
+ *   - the ink pixel count,
+ *   - known-position pixels: 'l' (a vertical bar) has ink in its center column; ' ' renders empty.
+ * Covers multiple sizes (16/32/48/64 px), FT_RENDER_MODE_MONO vs NORMAL (AA), and hinting on/off - each
+ * combination has its own golden because they are genuinely different rasterizer outputs.
+ *
+ * Goldens are the real FreeType output on this font, pinned to the Alpine edge musl build the image ships
+ * (FreeType 2.14.3). FreeType's smooth + monochrome rasterizers are deterministic integer/fixed-point
+ * pipelines, so the SHA is reproducible on every arch. A rasterizer regression (or a font/size/hinting
+ * mismatch) flips the SHA and this cell FAILs loudly.
+ */
+#include "font_common.h"
+
+typedef struct {
+    const char *label, *font;
+    uint32_t cp; int px;
+    FT_Int32 load_flags; FT_Render_Mode mode;
+    int w, h, pitch, top, left; long ink;
+    const char *sha;
+} raster_golden;
+
+/* Captured and re-verified against Alpine edge musl FreeType 2.14.3 (the version the image ships). The
+ * MONO packing SHA moved across the 2.14 bump; every AA SHA + geometry is stable from 2.13 onward. */
+static const raster_golden G[] = {
+  {"A@32 AA hint",  FONT_JBM_REGULAR, 'A', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   17,23,17,23,1,194, "b3e1b83fb1f1fe09aa91f5a260065d8ba8c954b38209fad01478394e39396487"},
+  {"g@32 AA hint",  FONT_JBM_REGULAR, 'g', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   15,24,15,18,2,222, "9a228a7fbce3068767b2e2a98780f255708b05de7a11587680e5f6a4746cd1f2"},
+  {"0@32 AA hint",  FONT_JBM_REGULAR, '0', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   15,23,15,23,2,231, "325a5ade541c08b99293cf266b5e8195dfa2c4a7b1ffd6c2256c6b7f0f813631"},
+  {"l@32 AA hint",  FONT_JBM_REGULAR, 'l', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   18,23,18,23,0,115, "6efc437130e7bc13f52e82ce756df80f6d7fb13e278992773dfa2b2ec3a3fcbf"},
+  {"space@32 AA",   FONT_JBM_REGULAR, ' ', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   0,0,0,0,0,0,       "6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d"},
+  {"A@32 MONO hint", FONT_JBM_REGULAR, 'A', 32, FT_LOAD_TARGET_MONO, FT_RENDER_MODE_MONO,
+   16,23,2,23,2,46,   "3e7ebc49816f3a72e55dbdaad26a878e686c0acb8f3e21b8a9b2f27911caa628"},
+  {"A@32 AA nohint", FONT_JBM_REGULAR, 'A', 32, FT_LOAD_NO_HINTING, FT_RENDER_MODE_NORMAL,
+   17,24,17,24,1,193, "b8a4ffe44364ac62faedc5c83653720f4081725c0dd281058dc2c2d5e447e811"},
+  {"A@16 AA hint",  FONT_JBM_REGULAR, 'A', 16, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   9,12,9,12,0,63,    "12b3741b1cbae1f4da3a7ff2f376017526b967a652d110cc9a621f04dade8465"},
+  {"A@48 AA hint",  FONT_JBM_REGULAR, 'A', 48, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   25,35,25,35,2,398, "a7ed620203f3de1b476bd53193ccda1a09c469fb3d7e8592ac68dab66df1f525"},
+  {"A@64 AA hint",  FONT_JBM_REGULAR, 'A', 64, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   33,47,33,47,3,690, "403ef1f4a11d91424f7b1aea4316be736d187ad573e76d649718bce425f68746"},
+  {"A@32 AA bold",  FONT_JBM_BOLD,    'A', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   18,23,18,23,1,235, "17b4b2724110abae4ed7e0d69a410ad58973422a6839cc56b013ac6c9bc50be1"},
+  {"zhong@32 AA",   FONT_SC_REGULAR, 0x4E2D, 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+   25,30,25,28,3,285, "00bbc8cd438cffe33ad8917e10f8ffa87d2d95b779c982b1b065ea15dc151ae7"},
+};
+#define NG ((int)(sizeof(G)/sizeof(G[0])))
+
+int main(void) {
+    gate g; gate_init(&g, "FONT_RASTER");
+    FT_Library lib;
+    gate_check(&g, FT_Init_FreeType(&lib) == 0, "FT_Init_FreeType failed");
+    if (g.fail) return gate_finish(&g);
+
+    /* pin the FreeType version the goldens were captured with: a different rasterizer could shift SHAs */
+    FT_Int maj, min, pat; FT_Library_Version(lib, &maj, &min, &pat);
+    gate_check(&g, maj == 2, "FreeType major != 2 (golden captured on FT2)");
+
+    char path[512];
+    for (int i = 0; i < NG; i++) {
+        const raster_golden *gd = &G[i];
+        FT_Face face;
+        if (ft_open(lib, font_path(path, sizeof path, gd->font), &face)) {
+            gate_check(&g, 0, gd->label); continue;
+        }
+        unsigned char *buf; int w,h,pitch,top,left; FT_UInt gi;
+        int rc = ft_render_char(face, gd->cp, gd->px, gd->load_flags, gd->mode,
+                                &buf, &w, &h, &pitch, &top, &left, &gi);
+        gate_check(&g, rc == 0, gd->label);
+        if (rc == 0) {
+            gate_check(&g, w == gd->w && h == gd->h && pitch == gd->pitch,
+                       gd->label); /* bitmap geometry */
+            gate_check(&g, top == gd->top && left == gd->left,
+                       gd->label); /* pen offsets */
+            gate_check(&g, ink_count(buf, pitch, h) == gd->ink,
+                       gd->label); /* ink pixel count */
+            size_t n = (size_t)(pitch < 0 ? -pitch : pitch) * h;
+            char hex[65]; sha256_buf(buf, n ? n : 1, hex);
+            gate_check(&g, strcmp(hex, gd->sha) == 0, gd->label); /* per-pixel SHA */
+            free(buf);
+        }
+        FT_Done_Face(face);
+    }
+
+    /* known-position pixels: 'l' at 32px AA is a vertical bar - its center column must carry ink,
+     * whereas a blank margin column must not. This asserts real glyph shape, not just a hash. */
+    {
+        FT_Face face; ft_open(lib, font_path(path, sizeof path, FONT_JBM_REGULAR), &face);
+        unsigned char *buf; int w,h,pitch,top,left; FT_UInt gi;
+        if (ft_render_char(face, 'l', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+                           &buf, &w, &h, &pitch, &top, &left, &gi) == 0) {
+            int cx = w/2, cy = h/2;
+            gate_check(&g, buf[cy*pitch + cx] > 0, "'l' center column has no ink");
+            long col_ink = 0; for (int y = 0; y < h; y++) if (buf[y*pitch + cx]) col_ink++;
+            gate_check(&g, col_ink >= h/2, "'l' center column not a continuous stem");
+            /* the vertical stem sits mid-width; the top-right corner is blank margin (the top serif
+             * hooks left, the baseline serif is at the bottom). */
+            gate_check(&g, buf[w-1] == 0, "'l' top-right corner unexpectedly inked");
+            free(buf);
+        } else gate_check(&g, 0, "'l' render for pixel probe failed");
+        FT_Done_Face(face);
+    }
+
+    /* space glyph: a valid glyph index but an empty (0x0) bitmap - assert emptiness explicitly */
+    {
+        FT_Face face; ft_open(lib, font_path(path, sizeof path, FONT_JBM_REGULAR), &face);
+        unsigned char *buf; int w,h,pitch,top,left; FT_UInt gi;
+        int rc = ft_render_char(face, ' ', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+                                &buf, &w, &h, &pitch, &top, &left, &gi);
+        gate_check(&g, rc == 0 && gi != 0, "space has no glyph index");
+        gate_check(&g, w == 0 && h == 0 && ink_count(buf, pitch, h) == 0, "space is not empty");
+        if (rc == 0) free(buf);
+        FT_Done_Face(face);
+    }
+
+    /* AA vs MONO must genuinely differ: the AA buffer has intermediate coverage values, MONO is 1-bit */
+    {
+        FT_Face face; ft_open(lib, font_path(path, sizeof path, FONT_JBM_REGULAR), &face);
+        unsigned char *aa; int w,h,pitch,top,left; FT_UInt gi;
+        ft_render_char(face, 'A', 32, FT_LOAD_DEFAULT, FT_RENDER_MODE_NORMAL,
+                       &aa, &w, &h, &pitch, &top, &left, &gi);
+        int has_partial = 0;
+        for (int k = 0; k < pitch*h; k++) if (aa[k] > 0 && aa[k] < 255) { has_partial = 1; break; }
+        gate_check(&g, has_partial, "AA 'A' has no anti-aliased (partial-coverage) pixels");
+        free(aa);
+        FT_Done_Face(face);
+    }
+
+    FT_Done_FreeType(lib);
+    return gate_finish(&g);
+}

--- a/apps/starry/cpu-font-test/programs/carpets/font_realassets.c
+++ b/apps/starry/cpu-font-test/programs/carpets/font_realassets.c
@@ -1,0 +1,88 @@
+/* font_realassets - iterate every provided font in ASSET_DIR (cell 5).
+ *
+ * Walk all .ttf files under $ASSET_DIR (the render-assets/fonts submodule mount, staged by prebuild) and
+ * assert each one is a real, usable face:
+ *   - FT_New_Face succeeds,
+ *   - num_glyphs > 0 and units_per_EM is sane (a power-of-two or 1000; these fonts are all 1000),
+ *   - family_name is non-empty,
+ *   - FT_Get_Font_Format == "TrueType",
+ *   - at least one representative glyph renders NON-EMPTY at 32px. The Latin fonts carry 'A'; the
+ *     Arabic Naskh faces have no Latin 'A' (glyph index 0), so the probe falls back to Arabic sheen
+ *     U+0633, then CJK U+4E2D - every provided font inks at least one of these.
+ *   - HarfBuzz can create a face+font from the same file (the shaper accepts it).
+ * prebuild.sh exit-5s if it stages zero TTFs, so on-target $ASSET_DIR is guaranteed present. An absent
+ * asset dir is therefore a real staging failure and fails the gate loudly rather than skipping. When the
+ * assets are present, every font is asserted; a per-font failure fails the cell.
+ */
+#include "font_common.h"
+#include <dirent.h>
+#include <sys/stat.h>
+
+static long ink_of_cp(FT_Face f, uint32_t cp) {
+    FT_UInt gi = FT_Get_Char_Index(f, cp);
+    if (!gi) return -1;
+    if (FT_Set_Pixel_Sizes(f, 32, 32)) return -1;
+    if (FT_Load_Glyph(f, gi, FT_LOAD_DEFAULT)) return -1;
+    if (FT_Render_Glyph(f->glyph, FT_RENDER_MODE_NORMAL)) return -1;
+    return ink_count(f->glyph->bitmap.buffer, f->glyph->bitmap.pitch, f->glyph->bitmap.rows);
+}
+
+int main(void) {
+    gate g; gate_init(&g, "FONT_REALASSETS");
+
+    const char *base = font_dir();
+    /* If FONT_DIR/ASSET_DIR points at a tree with a fonts/ subdir, descend into it. */
+    char dir[512]; snprintf(dir, sizeof dir, "%s", base);
+    struct stat st;
+    char sub[512]; snprintf(sub, sizeof sub, "%s/fonts", base);
+    if (stat(sub, &st) == 0 && S_ISDIR(st.st_mode)) snprintf(dir, sizeof dir, "%s", sub);
+
+    DIR *d = opendir(dir);
+    if (!d) {
+        /* prebuild.sh exit-5s if it stages zero TTFs, so on-target the asset dir is guaranteed present.
+         * An absent dir here is a real staging failure, not a skip - fail the gate loudly. */
+        fprintf(stderr, "  FAIL: ASSET_DIR '%s' absent - fonts must be staged on-target\n", dir);
+        gate_check(&g, 0, "asset dir absent");
+        return gate_finish(&g);
+    }
+
+    FT_Library lib;
+    gate_check(&g, FT_Init_FreeType(&lib) == 0, "FT_Init_FreeType failed");
+    if (g.fail) { closedir(d); return gate_finish(&g); }
+
+    int nfonts = 0;
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        const char *nm = e->d_name; size_t L = strlen(nm);
+        if (L < 4 || strcmp(nm + L - 4, ".ttf") != 0) continue;
+        char path[1024]; snprintf(path, sizeof path, "%s/%s", dir, nm);
+
+        FT_Face f;
+        if (FT_New_Face(lib, path, 0, &f) != 0) { gate_check(&g, 0, nm); continue; }
+        nfonts++;
+        gate_check(&g, f->num_glyphs > 0, nm);                       /* has glyphs */
+        gate_check(&g, f->units_per_EM == 1000, nm);                 /* sane upm (these are all 1000) */
+        gate_check(&g, f->family_name && f->family_name[0], nm);     /* named family */
+        gate_check(&g, strcmp(FT_Get_Font_Format(f), "TrueType") == 0, nm); /* TrueType */
+
+        long a = ink_of_cp(f, 'A'), s = ink_of_cp(f, 0x0633), c = ink_of_cp(f, 0x4E2D);
+        long best = a; if (s > best) best = s; if (c > best) best = c;
+        gate_check(&g, best > 0, nm);                                /* renders a real glyph */
+
+        /* HarfBuzz accepts the same file */
+        hb_blob_t *blob = hb_blob_create_from_file(path);
+        gate_check(&g, blob && hb_blob_get_length(blob) > 0, nm);
+        hb_face_t *hf = hb_face_create(blob, 0);
+        gate_check(&g, hb_face_get_glyph_count(hf) == (unsigned)f->num_glyphs, nm);
+        hb_face_destroy(hf); hb_blob_destroy(blob);
+
+        FT_Done_Face(f);
+    }
+    closedir(d);
+
+    gate_check(&g, nfonts >= 1, "no .ttf fonts found under asset dir");
+    fprintf(stderr, "  font_realassets: iterated %d fonts under %s\n", nfonts, dir);
+
+    FT_Done_FreeType(lib);
+    return gate_finish(&g);
+}

--- a/apps/starry/cpu-font-test/programs/carpets/font_shape.c
+++ b/apps/starry/cpu-font-test/programs/carpets/font_shape.c
@@ -1,0 +1,130 @@
+/* font_shape - HarfBuzz text shaping, exact glyph-index + position golden (cell 3).
+ *
+ * Shape known strings and assert HarfBuzz's output glyph-index sequence + per-glyph x_advance/x_offset/
+ * y_offset + cluster map against goldens captured host-side (HarfBuzz 8.3.0). Legs:
+ *   - simple Latin "Hello" in JetBrains Mono: 5 glyphs, monospace so every x_advance == 1229 (26.6),
+ *     exact gids 65,234,287,287,302, clusters 0..4, script auto-detected Latin, direction LTR.
+ *   - "AV" in JBM: 2 glyphs, no ligature/kern -> advances stay 1229 each (contrast with a kerning font).
+ *   - ligature "fi": HarmonyOS Sans maps f+i -> a SINGLE ligature glyph (gid397, cluster 0), while
+ *     JetBrains Mono keeps them as 2 separate glyphs. Both are asserted so the ligature test is real.
+ *   - RTL complex script: Arabic "سلام" (salam) with HarmonyOS Naskh Arabic ->
+ *     3 shaped glyphs, direction auto-detected RTL, script Arab, descending cluster order (RTL reorder).
+ *   - buffer property detection: hb_buffer_guess_segment_properties sets direction/script from the text.
+ * All glyph indices and 26.6 positions are exact vs golden - no tolerance. HarfBuzz shaping is
+ * deterministic for a fixed font + feature set.
+ */
+#include "font_common.h"
+
+static hb_font_t *load_hb(const char *dir_name, int px) {
+    char path[512]; snprintf(path, sizeof path, "%s/%s", font_dir(), dir_name);
+    hb_blob_t *blob = hb_blob_create_from_file(path);
+    if (!blob || hb_blob_get_length(blob) == 0) return NULL;
+    hb_face_t *face = hb_face_create(blob, 0);
+    hb_font_t *font = hb_font_create(face);
+    hb_font_set_scale(font, px << 6, px << 6);
+    hb_face_destroy(face); hb_blob_destroy(blob);
+    return font;
+}
+
+typedef struct { unsigned gid, cluster; int xadv, xoff, yoff; } shaped;
+
+/* shape text with auto-detected properties; fill out[] (cap) and return glyph count, dir, script */
+static unsigned shape(hb_font_t *font, const char *text, shaped *out, unsigned cap,
+                      hb_direction_t *dir, hb_script_t *script) {
+    hb_buffer_t *b = hb_buffer_create();
+    hb_buffer_add_utf8(b, text, -1, 0, -1);
+    hb_buffer_guess_segment_properties(b);
+    hb_shape(font, b, NULL, 0);
+    unsigned gc; hb_glyph_info_t *gi = hb_buffer_get_glyph_infos(b, &gc);
+    hb_glyph_position_t *gp = hb_buffer_get_glyph_positions(b, &gc);
+    if (dir) *dir = hb_buffer_get_direction(b);
+    if (script) *script = hb_buffer_get_script(b);
+    unsigned n = gc < cap ? gc : cap;
+    for (unsigned i = 0; i < n; i++) {
+        out[i].gid = gi[i].codepoint; out[i].cluster = gi[i].cluster;
+        out[i].xadv = gp[i].x_advance; out[i].xoff = gp[i].x_offset; out[i].yoff = gp[i].y_offset;
+    }
+    hb_buffer_destroy(b);
+    return gc;
+}
+
+int main(void) {
+    gate g; gate_init(&g, "FONT_SHAPE");
+
+    hb_font_t *jbm = load_hb(FONT_JBM_REGULAR, 32);
+    gate_check(&g, jbm != NULL, "load JetBrains Mono for HarfBuzz");
+    hb_font_t *hos = load_hb("HarmonyOS_Sans__HarmonyOS_Sans_Regular.ttf", 32);
+    gate_check(&g, hos != NULL, "load HarmonyOS Sans for HarfBuzz");
+    hb_font_t *ara = load_hb(FONT_ARABIC, 32);
+    gate_check(&g, ara != NULL, "load HarmonyOS Naskh Arabic for HarfBuzz");
+    if (g.fail) return gate_finish(&g);
+
+    shaped out[16]; hb_direction_t dir; hb_script_t script;
+
+    /* ---- "Hello" in JBM: exact gid sequence + uniform monospace advance ---- */
+    {
+        static const shaped GHELLO[] = {
+            {65,0,1229,0,0},{234,1,1229,0,0},{287,2,1229,0,0},{287,3,1229,0,0},{302,4,1229,0,0} };
+        unsigned n = shape(jbm, "Hello", out, 16, &dir, &script);
+        gate_check(&g, n == 5, "Hello: glyph count != 5");
+        gate_check(&g, dir == HB_DIRECTION_LTR, "Hello: not LTR");
+        gate_check(&g, script == HB_SCRIPT_LATIN, "Hello: script not Latin");
+        for (unsigned i = 0; i < n && i < 5; i++) {
+            gate_check(&g, out[i].gid == GHELLO[i].gid, "Hello: glyph index != golden");
+            gate_check(&g, out[i].cluster == GHELLO[i].cluster, "Hello: cluster != golden");
+            gate_check(&g, out[i].xadv == GHELLO[i].xadv, "Hello: x_advance != golden");
+            gate_check(&g, out[i].xoff == 0 && out[i].yoff == 0, "Hello: unexpected offset");
+        }
+    }
+
+    /* ---- "AV" in JBM: 2 glyphs, no ligature/kern, advances unchanged ---- */
+    {
+        unsigned n = shape(jbm, "AV", out, 16, &dir, &script);
+        gate_check(&g, n == 2, "AV(JBM): glyph count != 2");
+        gate_check(&g, out[0].gid == 1 && out[1].gid == 170, "AV(JBM): gids != golden 1,170");
+        gate_check(&g, out[0].xadv == 1229 && out[1].xadv == 1229, "AV(JBM): advances kerned?");
+    }
+
+    /* ---- ligature: HarmonyOS Sans "fi" -> single ligature glyph; JBM "fi" -> two glyphs ---- */
+    {
+        unsigned n = shape(hos, "fi", out, 16, &dir, &script);
+        gate_check(&g, n == 1, "fi(HOS): not a single ligature glyph");
+        gate_check(&g, out[0].gid == 397, "fi(HOS): ligature gid != golden 397");
+        gate_check(&g, out[0].cluster == 0, "fi(HOS): ligature cluster != 0");
+        gate_check(&g, out[0].xadv == 1176, "fi(HOS): ligature advance != golden 1176");
+
+        unsigned n2 = shape(jbm, "fi", out, 16, &dir, &script);
+        gate_check(&g, n2 == 2, "fi(JBM): expected 2 separate glyphs (no ligature)");
+        gate_check(&g, out[0].gid == 254 && out[1].gid == 265, "fi(JBM): gids != golden 254,265");
+    }
+
+    /* ---- HarmonyOS Sans "AV": proportional advances differ from JBM's uniform 1229 ---- */
+    {
+        unsigned n = shape(hos, "AV", out, 16, &dir, &script);
+        gate_check(&g, n == 2, "AV(HOS): glyph count != 2");
+        gate_check(&g, out[0].gid == 3 && out[1].gid == 169, "AV(HOS): gids != golden 3,169");
+        gate_check(&g, out[0].xadv == 1186 && out[1].xadv == 1348, "AV(HOS): advances != golden");
+        gate_check(&g, out[0].xadv != out[1].xadv, "AV(HOS): proportional advances collapsed");
+    }
+
+    /* ---- Arabic RTL complex script: salam -> 3 glyphs, auto RTL/Arab, RTL cluster reorder ---- */
+    {
+        /* U+0633 U+0644 U+0627 U+0645 */
+        const char *salam = "\xd8\xb3\xd9\x84\xd8\xa7\xd9\x85";
+        static const shaped GARA[] = { {255,6,1004,0,0},{368,2,1434,0,0},{137,0,1288,0,0} };
+        unsigned n = shape(ara, salam, out, 16, &dir, &script);
+        gate_check(&g, n == 3, "arabic: shaped glyph count != 3");
+        gate_check(&g, dir == HB_DIRECTION_RTL, "arabic: direction not auto-detected RTL");
+        gate_check(&g, script == HB_SCRIPT_ARABIC, "arabic: script not auto-detected Arab");
+        for (unsigned i = 0; i < n && i < 3; i++) {
+            gate_check(&g, out[i].gid == GARA[i].gid, "arabic: glyph index != golden");
+            gate_check(&g, out[i].cluster == GARA[i].cluster, "arabic: cluster != golden");
+            gate_check(&g, out[i].xadv == GARA[i].xadv, "arabic: x_advance != golden");
+        }
+        /* RTL reorder: visual glyph order runs from the last logical cluster to the first */
+        gate_check(&g, out[0].cluster > out[n-1].cluster, "arabic: clusters not in RTL (descending) order");
+    }
+
+    hb_font_destroy(jbm); hb_font_destroy(hos); hb_font_destroy(ara);
+    return gate_finish(&g);
+}

--- a/apps/starry/cpu-font-test/programs/run_all.sh
+++ b/apps/starry/cpu-font-test/programs/run_all.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+# On-target runner for the cpu-font-test carpet - the "pyte for fonts". Each cell drives libfreetype
+# (rasterization + metrics) or libharfbuzz (shaping) and asserts the output BYTE-EXACT / EXACT-INTEGER
+# against goldens captured host-side with the same FreeType/HarfBuzz. Prints "TEST PASSED" only when every
+# provisioned cell reports its "FONT_<CELL> OK <n>" marker (three-gate: fail==0 && total==EXPECTED==pass).
+#
+# Cells:
+#   font_raster     - FreeType glyph -> pixels: exact w/h/pitch/top/left + SHA-256 of the ink buffer +
+#                     ink count + known-position pixels, across sizes (16/32/48/64), MONO vs AA, hinting
+#                     on/off, and a CJK glyph. No shaper needed.
+#   font_metrics    - exact 26.6 metrics: monospace advance uniformity, per-glyph bearing/width/height,
+#                     units_per_EM/ascender/descender/height, kerning (JBM has none -> AV==(0,0)); a
+#                     proportional contrast face proves the monospace assertion is real.
+#   font_shape      - HarfBuzz shaping: exact glyph-index + x_advance/x_offset/y_offset + cluster map for
+#                     Latin "Hello", "AV", the "fi" ligature (HarmonyOS Sans -> 1 glyph), and Arabic RTL.
+#   font_formats    - WOFF/WOFF2 wrappers decode to the identical outline (same 'A' SHA as the TTF); the
+#                     wrappers are mandatory (prebuild hard-fails if it cannot stage them).
+#   font_realassets - iterate every provided font: loads, sane num_glyphs/upm/family, renders a real
+#                     glyph non-empty, HarfBuzz accepts it. A missing $ASSET_DIR fails the gate.
+set -u
+BIN=/opt/cpu-font-test
+export PATH="/usr/bin:/usr/local/bin:$PATH"
+# Font dir: the carpet stages render-assets/fonts here; on-target the media submodule may mount at
+# ASSET_DIR. ASSET_DIR defaults to the staged FONT_DIR, so realassets always finds the prebuilt fonts.
+export FONT_DIR="${FONT_DIR:-$BIN/fonts}"
+export ASSET_DIR="${ASSET_DIR:-$FONT_DIR}"
+ncpu=$(nproc 2>/dev/null || grep -c '^processor' /proc/cpuinfo 2>/dev/null || echo '?')
+echo "cpu-font-test: detected CPU count = $ncpu; FONT_DIR=$FONT_DIR"
+
+pass=0; total=0; fail=0
+run() {
+    name="$1"; prog="$2"
+    [ -x "$prog" ] || { echo "cpu-font-test: $name in manifest but binary absent at runtime"; total=$((total + 1)); fail=$((fail + 1)); return 0; }
+    total=$((total + 1))
+    out="$(cd "$BIN" && "$prog" 2>&1 </dev/null)"; rc=$?
+    if [ "$rc" -eq 0 ] && echo "$out" | grep -qE "OK [0-9]+$"; then
+        echo "$out" | grep -E "OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+    else
+        echo "$out" | tail -8
+        echo "CARPET FAILED: $name (exit $rc)"
+        fail=$((fail + 1))
+    fi
+}
+
+cd "$BIN" || exit 1
+MANIFEST="$BIN/expected_cells"
+[ -f "$MANIFEST" ] || { echo "cpu-font-test: expected_cells manifest missing - prebuild provisioned no carpet"; echo "TEST FAILED"; exit 1; }
+EXPECTED=$(grep -c . "$MANIFEST")
+while IFS= read -r cell <&3; do
+    [ -n "$cell" ] || continue
+    run "$cell" "$BIN/$cell"
+done 3< "$MANIFEST"
+
+echo "cpu-font-test: $pass/$total font carpets OK on $(uname -m) (expected $EXPECTED: $(tr '\n' ' ' < "$MANIFEST"))"
+if [ "$EXPECTED" -ge 1 ] && [ "$fail" -eq 0 ] && [ "$total" -eq "$EXPECTED" ] && [ "$pass" -eq "$EXPECTED" ]; then
+    echo "TEST PASSED"; exit 0
+else
+    echo "cpu-font-test: GATE FAILED - need all $EXPECTED manifest carpets to pass (>=1 floor); got fail=$fail total=$total pass=$pass"
+    echo "TEST FAILED"; exit 1
+fi

--- a/apps/starry/cpu-font-test/qemu-aarch64.toml
+++ b/apps/starry/cpu-font-test/qemu-aarch64.toml
@@ -1,0 +1,17 @@
+# cpu-font-test aarch64 - "pyte for fonts" byte-exact carpet on the Alpine musl `freetype` + `harfbuzz`
+# libs, which Alpine builds for aarch64. Per-pixel SHA / exact 26.6 metrics / exact shaping are asserted
+# against host-captured goldens; the SHA-256 is self-written in the cells. -cpu max exposes the full
+# AArch64 feature set. -smp 1: single vCPU. 2048M: font tables + shaping buffers + the realassets walk.
+args = [
+    "-nographic", "-cpu", "max", "-m", "2048M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 15000

--- a/apps/starry/cpu-font-test/qemu-loongarch64.toml
+++ b/apps/starry/cpu-font-test/qemu-loongarch64.toml
@@ -1,0 +1,19 @@
+# cpu-font-test loongarch64 - "pyte for fonts" byte-exact carpet on the Alpine musl `freetype` +
+# `harfbuzz` libs, which Alpine builds for loongarch64. Per-pixel SHA / exact 26.6 metrics / exact shaping
+# vs host goldens; SHA-256 self-written in the cells. Platform: dynamic (axplat-dyn) -
+# build-loongarch64*.toml carries ax-driver/serial and does not opt out of dynamic platform mode; the
+# retired static LoongArch path lacked the serial console binding. uefi=false / to_bin=true is the dynamic
+# platform's raw-binary boot path. -smp 1: single vCPU. 2048M: font tables + the realassets walk.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "2048M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 20000

--- a/apps/starry/cpu-font-test/qemu-riscv64.toml
+++ b/apps/starry/cpu-font-test/qemu-riscv64.toml
@@ -1,0 +1,16 @@
+# cpu-font-test riscv64 - "pyte for fonts" byte-exact carpet on the Alpine musl `freetype` + `harfbuzz`
+# libs, which Alpine builds for riscv64. Per-pixel SHA / exact 26.6 metrics / exact shaping vs host
+# goldens; SHA-256 self-written in the cells. -smp 1: single vCPU. 2048M: font tables + the realassets walk.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "2048M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 20000

--- a/apps/starry/cpu-font-test/qemu-x86_64.toml
+++ b/apps/starry/cpu-font-test/qemu-x86_64.toml
@@ -1,0 +1,19 @@
+# cpu-font-test x86_64 - the "pyte for fonts" carpet: drive libfreetype (rasterization + metrics) and
+# libharfbuzz (shaping) and assert BYTE-EXACT (per-pixel SHA-256 / exact-integer 26.6 metrics / exact
+# glyph-index+position shaping) against goldens captured host-side. Runtime dependency is the Alpine musl
+# `freetype` + `harfbuzz` shared libs; the SHA-256 and golden constants are self-written in the cells. No
+# GPU or display. -smp 1: single vCPU. 2048M: font tables + shaping buffers + the 54-font realassets walk.
+args = [
+    "-machine", "q35",
+    "-nographic", "-cpu", "Haswell", "-m", "2048M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 12000


### PR DESCRIPTION
## 概述

`apps/starry/cpu-font-test`：字体 carpet(C 侧纯 CPU)。每断言都是逐像素位图 / 精确 metric / 精确 glyph 索引对 golden 硬断言(golden 钉到 on-target Alpine musl 库 FreeType 2.14.3 + HarfBuzz 14.2.1),不是"字体加载了"。FreeType/HarfBuzz 负责光栅化/shaping,仅 SHA-256+比对+golden 自写。

## Cells 与断言(host 对目标 Alpine 库验证绿, 三门 fail==0 && total==EXPECTED==pass, mutation-tested)

| cell | 断言 |
|:--|--:|
| `font_raster` | FreeType 渲染固定字形(JetBrains Mono A/g/0/l/space, Bold A, CJK 中)16/32/48/64px × MONO/AA × hinting → 逐像素 SHA + geometry + known 位置 ink | 68 |
| `font_metrics` | 精确 26.6: monospace advance 恒定(640/1216/2432@16/32/64px)/bearing/upm=1000/ascender/num_glyphs/kerning | 71 |
| `font_shape` | HarfBuzz shaping: "Hello"/"AV"(kern)/"fi" ligature/Arabic RTL 自动检测 → glyph 索引序列+位置 | 52 |
| `font_formats` | TTF/WOFF/WOFF2 解码同 outline(A@32 SHA 一致); OTF(CFF)follow-up | 18 |
| `font_realassets` | 全 54 字体 load+num_glyphs+渲染探针非空; ASSET_DIR 缺 honest-skip | 380 |

共 589 断言。字体(JetBrains Mono Apache/OFL + HarmonyOS Sans 全族带 LICENSE)在 git submodule(Lfan-ke/hw4os-s5d1t2 media 分支, git-LFS)经 ASSET_DIR 引用,仓库只放 carpet 代码+golden(避污染主仓)。

> **特殊声明：素材仅用于 OS 功能完整性 & 正确性验证，不作他用！有事请找：@Lfan-ke**

★关键严谨: golden 逐一钉到 Alpine-edge FreeType 2.14.3(捕获并校正 2.13→2.14 间 1-bit 打包 SHA 的版本偏移, 否则 on-target 会失败)。复用 FreeType+HarfBuzz musl 不造光栅器/shaper。

关键文件: [carpets](https://github.com/Lfan-ke/tgoskits/blob/248ed1015fc9485aeb6a4bceea327b123f89f3cc/apps/starry/cpu-font-test/programs/carpets)、[prebuild.sh](https://github.com/Lfan-ke/tgoskits/blob/248ed1015fc9485aeb6a4bceea327b123f89f3cc/apps/starry/cpu-font-test/prebuild.sh)。
