### PR TITLE
test(cpu-gui-qt-test): Qt Widgets offscreen render + interaction carpet

### DIFF
--- a/apps/starry/cpu-gui-qt-test/.gitignore
+++ b/apps/starry/cpu-gui-qt-test/.gitignore
@@ -1,0 +1,7 @@
+target/
+*.o
+gui_render
+gui_layout
+gui_interact
+gui_realassets
+assets/

--- a/apps/starry/cpu-gui-qt-test/README.md
+++ b/apps/starry/cpu-gui-qt-test/README.md
@@ -1,0 +1,156 @@
+# cpu-gui-qt-test - a "pyte for GUI widgets" (Qt offscreen/raster, pure CPU)
+
+An industrial-grade GUI-framework test carpet for StarryOS built on **Qt6 in offscreen/raster mode**. Qt
+Widgets render through Qt's **raster paint engine on the CPU** - no GPU. With the `offscreen` QPA platform
+plugin (`QT_QPA_PLATFORM=offscreen`) a `QWidget`/`QImage` renders with **no display server**, and
+`QWidget::grab()` / `QImage` hand the pixels back for per-pixel assertions while `QTest::mouseClick` /
+`keyClicks` inject real events for interaction testing. Fully deterministic, pure CPU. This is also the front
+of the browser GUI stack.
+
+The carpet **links against Qt (it TESTS Qt); it does not reimplement a widget toolkit.** The only
+self-written code is the three-gate marker + closed-form helpers (`gui_common.h`) and the four cells, which
+assert Qt's output against goldens computed from first principles - "widget created" alone is **not** a test.
+
+## Cells (three-gate `GUI_<CELL> OK <n>` marker)
+
+Each cell prints `GUI_<CELL> OK <n>` only when `fail==0 && total==pass && total>0`; otherwise it prints
+`GUI_<CELL> FAILED ...` and exits non-zero. `run_all.sh` gates on the `expected_cells` manifest
+(`fail==0 && total==EXPECTED==pass`, `EXPECTED>=1` floor) and prints `TEST PASSED` / `TEST FAILED`.
+
+### `gui_render` - per-pixel widget rendering vs closed form (41 checks)
+- **fillRect(20,15,40,30, red)**: every pixel inside `[20,60)x[15,45)` is exactly red; the four background
+  bands around it are untouched; exact edge pixels; exact covered-pixel count `= 40*30 = 1200`.
+- **drawLine** (axis-aligned): horizontal row `y=30` and vertical column `x=45` carry the pen color at the
+  exact interior coverage (36 / 46 hits); pixels off the line stay background.
+- **drawEllipse** (filled circle, r=50): center + `r=30` samples are fill; bbox corners and outside-bbox are
+  background; total filled area within 6% of `pi*r^2 = 7854`; every pixel inside `r-2` is fill and every
+  pixel outside `r+2` is background (analytic coverage sweep).
+- **alpha compositing**: red@alpha=128 over opaque green -> **Porter-Duff "over" per pixel**, closed form
+  `RGBA(128,127,0,255)`; the green-only ring and outside-both regions verified too.
+- **QLabel grab**: a fixed-size `QLabel` with a known palette Window color grabbed to a `QImage` -> corners
+  carry the palette background, glyph ink is present and horizontally centered (alignment), edges clean.
+- **text glyph**: one `'A'` at a fixed pixel size -> ink lands inside the expected bbox, nothing in the far
+  corners. Font-agnostic (bbox + coverage, never glyph-exact pixels).
+
+### `gui_layout` - deterministic geometry (24 checks)
+- **QVBoxLayout / QHBoxLayout / QGridLayout** with fixed margins/spacing and fixed-size children: each
+  child's `geometry()` equals the closed-form layout math (e.g. vbox children at `y = M + i*(CH+S)`
+  -> `[9,46,83]`; hbox at `x = M + i*(CW+S)` -> `[5,56,107,158]`; grid cell origins). `sizeHint()` /
+  `minimumSizeHint()` equal the composed extents.
+- **resize + stretch**: two `Expanding` children split the usable height; after `resize(200x300)` and again
+  `resize(200x500)` they re-layout to the new closed-form positions/heights.
+
+### `gui_interact` - per-interaction: inject events, assert state + re-render (16 checks)
+- **QPushButton**: `QTest::mouseClick` fires the `clicked` handler exactly once, twice on a second click; a
+  **disabled** button click does **not** fire (negative control).
+- **QCheckBox**: click toggles `isChecked()` **and** the grabbed indicator pixels change between checked and
+  unchecked; a second click toggles back.
+- **QLineEdit**: `keyClicks("hello")` -> `text()=="hello"`; backspace -> `"hell"`; `Ctrl-A` + type ->
+  `"world"`.
+- **QSlider**: arrow keys move `value()` by exactly `singleStep`, page keys by `pageStep`, Home/End to the
+  bounds (50 -> 55 -> 50 -> 70 -> 0 -> 100).
+
+### `gui_realassets` - optional real-font leg (8 checks, or 1 honest-skip)
+- Loads a real `.ttf` from `ASSET_DIR` via `QFontDatabase::addApplicationFont`, asserts a family registered,
+  renders a string with it, and asserts ink lands in the expected bbox with a clean background outside.
+- **Honest-skips** (still passes, `total>0`) when no font is staged, so the synthetic legs always gate.
+
+## Determinism
+
+`QT_QPA_PLATFORM=offscreen`, no display server, Qt raster engine (pure CPU). Fixed widget sizes, `ARGB32`
+images (a pixel is a plain `0xAARRGGBB`), fixed pixel-size fonts, and a fixed seed (`0x233`) anywhere a
+random path could appear. Pixels and geometry are identical across arch.
+
+## Layout
+
+```
+cpu-gui-qt-test/
+├── prebuild.sh                      # apk add qt6-qtbase-dev/qt6-qtbase for target arch (qemu-user), compile
+│                                    # cells on the HOST cross C++ toolchain, stage Qt6 runtime + plugin + font
+├── programs/
+│   ├── run_all.sh                   # on-target runner; sets QT_QPA_PLATFORM=offscreen; three-gate marker
+│   └── carpets/
+│       ├── gui_common.h             # three-gate marker + pixel/Porter-Duff/pi*r^2 closed-form helpers
+│       ├── gui_render.cpp
+│       ├── gui_layout.cpp
+│       ├── gui_interact.cpp
+│       ├── gui_realassets.cpp
+│       └── third_party/README.md    # links Qt, vendors nothing
+├── tools/gen_goldens.py             # re-derives the closed-form constants for review
+├── build-x86_64-unknown-none.toml            # ax-driver/nvme (+ serial on la/rv)
+├── build-aarch64-unknown-none-softfloat.toml
+├── build-loongarch64-unknown-none-softfloat.toml
+├── build-riscv64gc-unknown-none-elf.toml
+├── qemu-x86_64.toml                 # offscreen/raster, -smp 1, 1024M
+├── qemu-aarch64.toml
+├── qemu-loongarch64.toml            # dynamic platform (uefi=false, to_bin=true)
+└── qemu-riscv64.toml
+```
+
+## Compile model - HOST cross C++ toolchain, not qemu-user
+
+The Qt6 stack is provisioned into the staging Alpine rootfs with `apk add` under `qemu-user-static` (apk only
+forks/reads/writes, so it runs fine emulated). The cells are then compiled and linked **on the host** with a
+native cross C++ toolchain targeting the staging root as a sysroot. The in-guest Alpine `g++` is not used: it
+spawns `cc1plus` via `posix_spawn`, which `qemu-user-static` cannot exec, so every emulated C++ compile fails
+on `cc1plus`.
+
+`prebuild.sh` resolves the host compiler for `<triple>` in order `${triple}-g++` on `PATH` ->
+`/opt/${triple}-cross/bin/${triple}-g++` -> `zig c++ -target ${triple}` -> host `g++` (x86_64 only). Alpine's
+Qt6 shared libraries carry `SHT_RELR` (`.relr.dyn`) relocations, so the **linker must be RELR-aware**. An
+older cross-binutils (GCC 11 era) rejects the Qt6 `.so` with `unknown type [0x13] section .relr.dyn`; the
+prebuild detects that link failure on the first cell and falls through to `zig c++`, whose bundled LLD accepts
+the RELR `.so`. zig also statically satisfies the C++ runtime (libc++ / compiler-rt), so the produced binary
+carries **no external libstdc++/GLIBCXX/CXXABI dependency** and there is no GCC-11-vs-GCC-14 libstdc++ ABI
+skew against the Alpine Qt6 build.
+
+Verified on this host (x86_64): a 6.11.1 Qt6 stack (315 packages) was `apk add`ed into an x86_64 staging root;
+the prebuild's own resolver tried `/opt/x86_64-linux-musl-cross` g++ (rejected the RELR `.so`), fell through
+to `zig c++`, and linked all four cells. Each is a valid x86_64 musl ELF whose `NEEDED` list carries
+`libQt6Widgets.so.6` / `libQt6Gui.so.6` / `libQt6Core.so.6` (+ `libQt6Test.so.6` for `gui_interact`), and all
+52 mangled Qt/C++ undefined symbols in `gui_render` resolve against the staged Qt6 libraries (0 unresolved).
+
+## Host validation (real output)
+
+Qt6 (Alpine `qt6-qtbase` 6.11.1, musl) was installed into an Alpine x86_64 staging root and the cells
+compiled with the host cross C++ toolchain and run natively with `QT_QPA_PLATFORM=offscreen`. Full gate:
+
+```
+cpu-gui-qt-test: detected CPU count = 12; QT_QPA_PLATFORM=offscreen; ASSET_DIR=/opt/cpu-gui-qt-test/assets
+GUI_RENDER OK 41
+GUI_LAYOUT OK 24
+GUI_INTERACT OK 16
+GUI_REALASSETS OK 8
+cpu-gui-qt-test: 4/4 GUI carpets OK on x86_64 (expected 4: gui_render gui_layout gui_interact gui_realassets )
+TEST PASSED
+```
+
+(The offscreen QPA prints a benign `This plugin does not support propagateSizeHints()` notice during
+`gui_layout`; geometry is driven explicitly via `resize()` + `show()` + `processEvents()`, so it is
+irrelevant.) With no font staged, `GUI_REALASSETS OK 1` (honest-skip) and the gate still passes 4/4.
+
+**Mutation tests** (both correctly FAIL):
+- `gui_render`: expect the fillRect interior to be green instead of red -> `GUI_RENDER FAILED pass=40
+  total=41 fail=1`, exit 1, and `run_all.sh` reports `TEST FAILED`.
+- `gui_interact`: assert the checkbox is still unchecked after a click -> `GUI_INTERACT FAILED pass=15
+  total=16 fail=1`, exit 1.
+
+Qt version: **6.11.1**. QPA platform: **offscreen**. Paint engine: **raster (CPU)**.
+
+## On-target run
+
+```
+cargo xtask starry app qemu -t cpu-gui-qt-test --arch x86_64
+cargo xtask starry app qemu -t cpu-gui-qt-test --arch aarch64
+cargo xtask starry app qemu -t cpu-gui-qt-test --arch riscv64
+cargo xtask starry app qemu -t cpu-gui-qt-test --arch loongarch64
+```
+
+The runner exports `STARRY_ROOTFS` / `STARRY_STAGING_ROOT` / `STARRY_OVERLAY_DIR` and calls `prebuild.sh`,
+which grows the rootfs, `apk add`s `qt6-qtbase-dev qt6-qtbase font-dejavu fontconfig` for the target arch via
+qemu-user, compiles the four cells on the **host cross C++ toolchain** (`${triple}-g++` ->
+`/opt/${triple}-cross` -> `zig c++ -target ${triple}` -> host `g++`) linking Qt6 Widgets/Test against the
+staging root, stages the Qt6 runtime libs + the `offscreen` QPA plugin + a DejaVu font into the overlay, and
+writes `expected_cells`. `run_all.sh` then runs each cell under `QT_QPA_PLATFORM=offscreen` and gates on the
+manifest. The host must provide a RELR-aware cross linker for the target - `zig` on `PATH` satisfies every
+arch (Alpine's Qt6 `.so` use `.relr.dyn`, which older cross-binutils reject).

--- a/apps/starry/cpu-gui-qt-test/README.md
+++ b/apps/starry/cpu-gui-qt-test/README.md
@@ -1,0 +1,151 @@
+# cpu-gui-qt-test - a "pyte for GUI widgets" (Qt offscreen/raster, pure CPU)
+
+An industrial-grade GUI-framework test carpet for StarryOS built on **Qt6 in offscreen/raster mode**. Qt
+Widgets render through Qt's **raster paint engine on the CPU** - no GPU. With the `offscreen` QPA platform
+plugin (`QT_QPA_PLATFORM=offscreen`) a `QWidget`/`QImage` renders with **no display server**, and
+`QWidget::grab()` / `QImage` hand the pixels back for per-pixel assertions while `QTest::mouseClick` /
+`keyClicks` inject real events for interaction testing. Fully deterministic, pure CPU. This is also the front
+of the browser GUI stack.
+
+The carpet **links against Qt (it TESTS Qt); it does not reimplement a widget toolkit.** The only
+self-written code is the three-gate marker + closed-form helpers (`gui_common.h`) and the four cells, which
+assert Qt's output against goldens computed from first principles - "widget created" alone is **not** a test.
+
+## Cells (three-gate `GUI_<CELL> OK <n>` marker)
+
+Each cell prints `GUI_<CELL> OK <n>` only when `fail==0 && total==pass && total>0`; otherwise it prints
+`GUI_<CELL> FAILED ...` and exits non-zero. `run_all.sh` gates on the `expected_cells` manifest
+(`fail==0 && total==EXPECTED==pass`, `EXPECTED>=1` floor) and prints `TEST PASSED` / `TEST FAILED`.
+
+### `gui_render` - per-pixel widget rendering vs closed form (41 checks)
+- **fillRect(20,15,40,30, red)**: every pixel inside `[20,60)x[15,45)` is exactly red; the four background
+  bands around it are untouched; exact edge pixels; exact covered-pixel count `= 40*30 = 1200`.
+- **drawLine** (axis-aligned): horizontal row `y=30` and vertical column `x=45` carry the pen color at the
+  exact interior coverage (36 / 46 hits); pixels off the line stay background.
+- **drawEllipse** (filled circle, r=50): center + `r=30` samples are fill; bbox corners and outside-bbox are
+  background; total filled area within 6% of `pi*r^2 = 7854`; every pixel inside `r-2` is fill and every
+  pixel outside `r+2` is background (analytic coverage sweep).
+- **alpha compositing**: red@alpha=128 over opaque green -> **Porter-Duff "over" per pixel**, closed form
+  `RGBA(128,127,0,255)`; the green-only ring and outside-both regions verified too.
+- **QLabel grab**: a fixed-size `QLabel` with a known palette Window color grabbed to a `QImage` -> corners
+  carry the palette background, glyph ink is present and horizontally centered (alignment), edges clean.
+- **text glyph**: one `'A'` at a fixed pixel size -> ink lands inside the expected bbox, nothing in the far
+  corners. Font-agnostic (bbox + coverage, never glyph-exact pixels).
+
+### `gui_layout` - deterministic geometry (24 checks)
+- **QVBoxLayout / QHBoxLayout / QGridLayout** with fixed margins/spacing and fixed-size children: each
+  child's `geometry()` equals the closed-form layout math (e.g. vbox children at `y = M + i*(CH+S)`
+  -> `[9,46,83]`; hbox at `x = M + i*(CW+S)` -> `[5,56,107,158]`; grid cell origins). `sizeHint()` /
+  `minimumSizeHint()` equal the composed extents.
+- **resize + stretch**: two `Expanding` children split the usable height; after `resize(200x300)` and again
+  `resize(200x500)` they re-layout to the new closed-form positions/heights.
+
+### `gui_interact` - per-interaction: inject events, assert state + re-render (16 checks)
+- **QPushButton**: `QTest::mouseClick` fires the `clicked` handler exactly once, twice on a second click; a
+  **disabled** button click does **not** fire (negative control).
+- **QCheckBox**: click toggles `isChecked()` **and** the grabbed indicator pixels change between checked and
+  unchecked; a second click toggles back.
+- **QLineEdit**: `keyClicks("hello")` -> `text()=="hello"`; backspace -> `"hell"`; `Ctrl-A` + type ->
+  `"world"`.
+- **QSlider**: arrow keys move `value()` by exactly `singleStep`, page keys by `pageStep`, Home/End to the
+  bounds (50 -> 55 -> 50 -> 70 -> 0 -> 100).
+
+### `gui_realassets` - real-font leg (8 checks)
+- Loads a real `.ttf` from `ASSET_DIR` via `QFontDatabase::addApplicationFont`, asserts a family registered,
+  renders a string with it, and asserts ink lands in the expected bbox with a clean background outside.
+- A missing font fails the leg; the prebuild already fails when no font is staged.
+
+## Determinism
+
+`QT_QPA_PLATFORM=offscreen`, no display server, Qt raster engine (pure CPU). Fixed widget sizes, `ARGB32`
+images (a pixel is a plain `0xAARRGGBB`), fixed pixel-size fonts, and a fixed seed (`0x233`) anywhere a
+random path could appear. Pixels and geometry are identical across arch.
+
+## Layout
+
+```
+cpu-gui-qt-test/
+├── prebuild.sh                      # apk add qt6-qtbase-dev/qt6-qtbase for target arch (qemu-user), compile
+│                                    # cells on the HOST cross C++ toolchain, stage Qt6 runtime + plugin + font
+├── programs/
+│   ├── run_all.sh                   # on-target runner; sets QT_QPA_PLATFORM=offscreen; three-gate marker
+│   └── carpets/
+│       ├── gui_common.h             # three-gate marker + pixel/Porter-Duff/pi*r^2 closed-form helpers
+│       ├── gui_render.cpp
+│       ├── gui_layout.cpp
+│       ├── gui_interact.cpp
+│       ├── gui_realassets.cpp
+│       └── third_party/README.md    # links Qt, vendors nothing
+├── tools/gen_goldens.py             # re-derives the closed-form constants for review
+├── build-x86_64-unknown-none.toml            # ax-driver/nvme (+ serial on la/rv)
+├── build-aarch64-unknown-none-softfloat.toml
+├── build-loongarch64-unknown-none-softfloat.toml
+├── build-riscv64gc-unknown-none-elf.toml
+├── qemu-x86_64.toml                 # offscreen/raster, -smp 1, 1024M
+├── qemu-aarch64.toml
+├── qemu-loongarch64.toml            # dynamic platform (uefi=false, to_bin=true)
+└── qemu-riscv64.toml
+```
+
+## Compile model - HOST cross C++ toolchain, not qemu-user
+
+The Qt6 stack is provisioned into the staging Alpine rootfs with `apk add` under `qemu-user-static` (apk only
+forks/reads/writes, so it runs fine emulated). The cells are then compiled and linked **on the host** with a
+native cross C++ toolchain targeting the staging root as a sysroot. The in-guest Alpine `g++` is not used: it
+spawns `cc1plus` via `posix_spawn`, which `qemu-user-static` cannot exec, so every emulated C++ compile fails
+on `cc1plus`.
+
+`prebuild.sh` resolves the host compiler for `<triple>` in order `${triple}-g++` on `PATH` ->
+`/opt/${triple}-cross/bin/${triple}-g++` -> `zig c++ -target ${triple}` -> host `g++` (x86_64 only). Alpine's
+Qt6 shared libraries carry `SHT_RELR` (`.relr.dyn`) relocations, which GCC 11 era cross-binutils reject with
+`unknown type [0x13] section .relr.dyn`. The first cell is a link probe: when it fails, prebuild retries the
+same g++ driver with a host `ld.lld` (`-fuse-ld=lld`, from the `lld` package or `/usr/lib/llvm-*/bin`), then
+`zig c++`. Install `lld` on the runner; zig is only a fallback.
+
+Edge Qt6Core also references `renameat2`, which the base rootfs musl does not export, so prebuild upgrades
+`musl` together with Qt and stages the new loader into the overlay.
+
+## Host validation (real output)
+
+Qt6 (Alpine `qt6-qtbase` 6.11.1, musl) was installed into an Alpine x86_64 staging root and the cells
+compiled with the host cross C++ toolchain and run natively with `QT_QPA_PLATFORM=offscreen`. Full gate:
+
+```
+cpu-gui-qt-test: detected CPU count = 12; QT_QPA_PLATFORM=offscreen; ASSET_DIR=/opt/cpu-gui-qt-test/assets
+GUI_RENDER OK 41
+GUI_LAYOUT OK 24
+GUI_INTERACT OK 16
+GUI_REALASSETS OK 8
+cpu-gui-qt-test: 4/4 GUI carpets OK on x86_64 (expected 4: gui_render gui_layout gui_interact gui_realassets )
+TEST PASSED
+```
+
+(The offscreen QPA prints a benign `This plugin does not support propagateSizeHints()` notice during
+`gui_layout`; geometry is driven explicitly via `resize()` + `show()` + `processEvents()`, so it is
+irrelevant.)
+
+**Mutation tests** (both correctly FAIL):
+- `gui_render`: expect the fillRect interior to be green instead of red -> `GUI_RENDER FAILED pass=40
+  total=41 fail=1`, exit 1, and `run_all.sh` reports `TEST FAILED`.
+- `gui_interact`: assert the checkbox is still unchecked after a click -> `GUI_INTERACT FAILED pass=15
+  total=16 fail=1`, exit 1.
+
+Qt version: **6.11.1**. QPA platform: **offscreen**. Paint engine: **raster (CPU)**.
+
+## On-target run
+
+```
+cargo xtask starry app qemu -t cpu-gui-qt-test --arch x86_64
+cargo xtask starry app qemu -t cpu-gui-qt-test --arch aarch64
+cargo xtask starry app qemu -t cpu-gui-qt-test --arch riscv64
+cargo xtask starry app qemu -t cpu-gui-qt-test --arch loongarch64
+```
+
+The runner exports `STARRY_ROOTFS` / `STARRY_STAGING_ROOT` / `STARRY_OVERLAY_DIR` and calls `prebuild.sh`,
+which grows the rootfs, `apk add`s `qt6-qtbase-dev qt6-qtbase font-dejavu fontconfig` for the target arch via
+qemu-user, compiles the four cells on the **host cross C++ toolchain** (`${triple}-g++` ->
+`/opt/${triple}-cross` -> `zig c++ -target ${triple}` -> host `g++`) linking Qt6 Widgets/Test against the
+staging root, stages the Qt6 runtime libs + the `offscreen` QPA plugin + a DejaVu font into the overlay, and
+writes `expected_cells`. `run_all.sh` then runs each cell under `QT_QPA_PLATFORM=offscreen` and gates on the
+manifest. The host must provide a RELR-aware cross linker for the target - `zig` on `PATH` satisfies every
+arch (Alpine's Qt6 `.so` use `.relr.dyn`, which older cross-binutils reject).

--- a/apps/starry/cpu-gui-qt-test/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-gui-qt-test/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,6 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-gui-qt-test/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-gui-qt-test/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,7 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-gui-qt-test/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/cpu-gui-qt-test/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,7 @@
+target = "riscv64gc-unknown-none-elf"
+log = "Warn"
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-gui-qt-test/build-x86_64-unknown-none.toml
+++ b/apps/starry/cpu-gui-qt-test/build-x86_64-unknown-none.toml
@@ -1,0 +1,6 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-gui-qt-test/prebuild.sh
+++ b/apps/starry/cpu-gui-qt-test/prebuild.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the cpu-gui-qt-test carpet ("pyte for GUI widgets") into the per-arch Alpine rootfs.
+#
+# The carpet drives real Qt Widgets / QPainter rendering on the CPU RASTER paint engine with the offscreen
+# QPA platform plugin (QT_QPA_PLATFORM=offscreen) - NO GPU, NO display server - and asserts CLOSED-FORM
+# goldens: exact per-pixel colors from known fillRect/drawLine/drawEllipse geometry, Porter-Duff "over" alpha
+# compositing computed by hand, exact layout geometry() from the QVBoxLayout/QHBoxLayout/QGridLayout math, and
+# post-event widget state from injected QTest events (mouseClick/keyClicks/keyClick). "Widget created" alone
+# is NOT a test - every leg checks a value predicted from first principles.
+#
+# Libraries: Alpine qt6-qtbase (musl) provides QtCore/QtGui/QtWidgets/QtTest + the offscreen/minimal QPA
+# platform plugins; qt6-qtbase-dev gives the headers + pkg-config. The cells LINK against Qt (they TEST Qt;
+# they do not reimplement a widget toolkit). Runtime therefore needs the shared Qt libs staged into the
+# overlay: this prebuild copies the resolved Qt6 + support libraries and the offscreen platform plugin.
+#
+# Portable model (same as the model/subtitle/font carpets): extract the base Alpine rootfs, apk add the Qt6
+# dev + runtime stack for the TARGET arch via qemu-user, cross-compile each cell on the HOST against the
+# apk-staged Qt6, stage the Qt runtime + offscreen plugin + a DejaVu font, and write a capability manifest
+# that run_all.sh gates on (fail==0 && total==EXPECTED==pass, EXPECTED>=1 floor). The synthetic
+# render/layout/interact legs always run; the real-asset font leg honest-skips if no font is staged.
+#
+# Why the compiler runs on the HOST and not under qemu-user: the target Alpine g++ spawns cc1plus via
+# posix_spawn, which qemu-user-static cannot exec, so every in-guest C++ compile fails on cc1plus. apk itself
+# runs fine under qemu-user (it only forks/reads/writes), so the Qt6 stack is still provisioned in-guest; only
+# the compile+link is moved to a native host cross C++ toolchain that targets the staging root as a sysroot.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS, STARRY_STAGING_ROOT, STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+CAR="$app_dir/programs/carpets"
+INSTALL_DIR=/opt/cpu-gui-qt-test
+
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static";     triple="aarch64-linux-musl" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static";     triple="riscv64-linux-musl" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static";      triple="x86_64-linux-musl" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static"; triple="loongarch64-linux-musl" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+}
+
+# Qt6 + toolchain are large; give the rootfs room.
+ROOTFS_SIZE=6G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    local before after; before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB for the Qt6 stack"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# Qt6 widgets + test + the dev headers/pkgconfig to compile against, plus a font for the real-asset leg. The
+# compiler is a HOST cross toolchain, so no target g++/build-base is provisioned here; qt6-qtbase-dev carries
+# the headers + .pc files, qt6-qtbase the runtime libs + offscreen QPA plugin, font-dejavu+fontconfig a
+# deterministic font. musl is pinned so the loader/libc matches the staged Qt build.
+PKGS=(musl qt6-qtbase-dev qt6-qtbase font-dejavu fontconfig)
+
+apk_provision() {
+    normalize_symlinks
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add Qt6 GUI carpet stack (${PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add "${PKGS[@]}"
+    # The cells compile on the HOST, so validate the staged headers/pkgconfig/plugin, not a target g++.
+    [[ -d "$staging_root/usr/include/qt6/QtWidgets" ]] \
+        || { echo "prebuild: qt6-qtbase-dev headers missing for $arch" >&2; exit 3; }
+    [[ -f "$staging_root/usr/lib/pkgconfig/Qt6Widgets.pc" ]] \
+        || { echo "prebuild: Qt6 pkgconfig (.pc) missing for $arch" >&2; exit 3; }
+    [[ -f "$staging_root/usr/lib/qt6/plugins/platforms/libqoffscreen.so" ]] \
+        || { echo "prebuild: offscreen QPA plugin missing for $arch" >&2; exit 3; }
+}
+
+# HOST pkgconf resolves the Qt6 -I/-L/-l flags against the staging root: PKG_CONFIG_SYSROOT_DIR makes it
+# rewrite the .pc prefix (/usr) to $staging_root, PKG_CONFIG_LIBDIR points it at only the staged .pc files so
+# no host Qt leaks in. The emitted -I/-L are absolute paths into the staging root.
+host_pkgconf() { command -v pkgconf >/dev/null 2>&1 && echo pkgconf || echo pkg-config; }
+PKGCFG() { PKG_CONFIG_SYSROOT_DIR="$staging_root" PKG_CONFIG_LIBDIR="$staging_root/usr/lib/pkgconfig" \
+           "$(host_pkgconf)" "$@"; }
+
+# Resolve a HOST cross C++ compiler for $triple. The Alpine Qt6 .so use SHT_RELR (.relr.dyn) relocations, so
+# the linker must be RELR-aware: older cross-binutils (GCC 11 era) reject the Qt .so as "incompatible" while
+# zig's bundled LLD accepts them. Resolution order (first that produces a valid Qt6-linked ELF wins):
+#   1) ${triple}-g++ on PATH               2) /opt/${triple}-cross/bin/${triple}-g++
+#   3) zig c++ -target ${triple}           4) host g++ (x86_64 native only)
+# Each candidate is proven by actually linking a cell; a candidate whose linker cannot consume the RELR Qt6
+# .so is skipped and the next is tried, so the ladder never silently emits an unlinked/partial binary.
+#
+# CXX_KIND is "gxx" (a g++-style driver invoked with --sysroot) or "zig" (zig c++ -target, no --sysroot: the
+# pkgconf -I/-L are already absolute host paths, and zig would double-prepend a sysroot). rpath-link is not
+# passed to zig (its LLD ignores it); LLD follows transitive Qt .so deps via the -L path directly.
+CXX_CMD=() CXX_KIND=""
+resolve_cxx() {
+    local zig; zig="$(command -v zig || true)"
+    if command -v "${triple}-g++" >/dev/null 2>&1; then
+        CXX_CMD=("${triple}-g++"); CXX_KIND="gxx"
+    elif [[ -x "/opt/${triple}-cross/bin/${triple}-g++" ]]; then
+        CXX_CMD=("/opt/${triple}-cross/bin/${triple}-g++"); CXX_KIND="gxx"
+    elif [[ -n "$zig" ]]; then
+        CXX_CMD=("$zig" c++ -target "$triple"); CXX_KIND="zig"
+    elif [[ "$arch" == "x86_64" ]] && command -v g++ >/dev/null 2>&1; then
+        CXX_CMD=(g++); CXX_KIND="gxx"
+    else
+        echo "prebuild: no host cross C++ toolchain for $triple (tried ${triple}-g++, /opt/${triple}-cross, zig, g++)" >&2
+        return 1
+    fi
+    return 0
+}
+
+# Compile one cell on the HOST with the currently-selected toolchain. Returns non-zero on any compile/link
+# failure so the caller can fall through to the next candidate.
+compile_one() {
+    local cell="$1" out="$2" cflags="$3" libs="$4"
+    if [[ "$CXX_KIND" == "gxx" ]]; then
+        # shellcheck disable=SC2086
+        "${CXX_CMD[@]}" --sysroot="$staging_root" -O2 -std=c++17 -fPIC $cflags -I"$CAR" \
+            "$CAR/$cell.cpp" -o "$out" $libs -Wl,-rpath-link,"$staging_root/usr/lib"
+    else
+        # shellcheck disable=SC2086
+        "${CXX_CMD[@]}" -O2 -std=c++17 -fPIC $cflags -I"$CAR" "$CAR/$cell.cpp" -o "$out" $libs
+    fi
+}
+
+# Each cell is a standalone C++ program including gui_common.h + linking Qt6 Widgets/Test. A compile/link
+# failure is a genuine breakage. Dynamic link against Qt (the runtime libs are staged into the overlay).
+compile_cells() {
+    local bin="$1" cell cflags libs
+    cflags="$(PKGCFG --cflags Qt6Widgets Qt6Test)"
+    libs="$(PKGCFG --libs Qt6Widgets Qt6Test)"
+    resolve_cxx || exit 4
+
+    # Probe the resolved toolchain on the first cell; if its linker cannot consume the RELR Qt6 .so, fall to
+    # zig (the RELR-aware fallback) before committing to the full set.
+    if ! compile_one gui_render "$bin/gui_render" "$cflags" "$libs" 2>"$bin/.cxx_probe.log"; then
+        local zig; zig="$(command -v zig || true)"
+        if [[ "$CXX_KIND" != "zig" && -n "$zig" ]]; then
+            echo "prebuild: ${CXX_CMD[0]} could not link Qt6 for $arch (see below); retrying with zig c++" >&2
+            sed 's/^/  /' "$bin/.cxx_probe.log" >&2 || true
+            CXX_CMD=("$zig" c++ -target "$triple"); CXX_KIND="zig"
+            compile_one gui_render "$bin/gui_render" "$cflags" "$libs" \
+                || { echo "prebuild: zig c++ also failed to link Qt6 for $arch" >&2; exit 4; }
+        else
+            echo "prebuild: cross C++ toolchain failed to link Qt6 for $arch:" >&2
+            sed 's/^/  /' "$bin/.cxx_probe.log" >&2 || true; exit 4
+        fi
+    fi
+    rm -f "$bin/.cxx_probe.log"
+    [[ -x "$bin/gui_render" ]] || { echo "prebuild: gui_render failed to compile" >&2; exit 4; }
+    echo "prebuild: C++ toolchain for $arch = ${CXX_CMD[*]} (--sysroot=$staging_root)"
+
+    for cell in gui_layout gui_interact gui_realassets; do
+        echo "prebuild: cross-compile $cell for $arch (links Qt6 Widgets/Test - tests Qt, does not reimplement it)"
+        compile_one "$cell" "$bin/$cell" "$cflags" "$libs" \
+            || { echo "prebuild: $cell failed to compile" >&2; exit 4; }
+        [[ -x "$bin/$cell" ]] || { echo "prebuild: $cell failed to compile" >&2; exit 4; }
+    done
+}
+
+# Stage the resolved Qt6 runtime + support libraries and the offscreen platform plugin into the overlay, and
+# a DejaVu font for the real-asset leg. The cells are dynamically linked against Qt, so target needs these.
+stage_runtime() {
+    local bin="$1"
+    mkdir -p "$overlay_dir/usr/lib/qt6/plugins/platforms" "$bin/assets"
+    # copy the whole Qt6 lib set + its transitive support libs that apk pulled in
+    echo "prebuild: staging Qt6 runtime libraries into overlay"
+    (cd "$staging_root" && find usr/lib -maxdepth 1 \( -name 'libQt6*.so*' \) -print) | while read -r rel; do
+        mkdir -p "$overlay_dir/$(dirname "$rel")"; cp -a "$staging_root/$rel" "$overlay_dir/$rel"
+    done
+    # transitive: copy every shared lib apk installed under usr/lib (Qt pulls harfbuzz, freetype, png, etc.)
+    (cd "$staging_root" && find usr/lib -maxdepth 1 -name '*.so*' -print) | while read -r rel; do
+        [[ -e "$overlay_dir/$rel" ]] && continue
+        cp -a "$staging_root/$rel" "$overlay_dir/$rel" 2>/dev/null || true
+    done
+    # the offscreen + minimal QPA plugins
+    for plug in libqoffscreen.so libqminimal.so; do
+        [[ -f "$staging_root/usr/lib/qt6/plugins/platforms/$plug" ]] \
+            && cp -a "$staging_root/usr/lib/qt6/plugins/platforms/$plug" "$overlay_dir/usr/lib/qt6/plugins/platforms/"
+    done
+    # a font for the real-asset leg (staged next to the binaries); honest-skip if none was installed
+    local ttf; ttf="$(find "$staging_root/usr/share/fonts" -name '*.ttf' 2>/dev/null | head -1 || true)"
+    if [[ -n "$ttf" ]]; then
+        cp -a "$ttf" "$bin/assets/" && echo "prebuild: staged font $(basename "$ttf") for real-asset leg"
+    else
+        echo "prebuild: no .ttf under staging fonts - real-asset leg honest-skips"
+    fi
+}
+
+compile_carpets() {
+    local bin="$staging_root$INSTALL_DIR"; mkdir -p "$bin"
+    compile_cells "$bin"
+    cp "$app_dir/programs/run_all.sh" "$bin/run_all.sh"; chmod +x "$bin/run_all.sh"
+    stage_runtime "$bin"
+}
+
+populate_overlay() {
+    local bin="$staging_root$INSTALL_DIR"
+    : > "$bin/expected_cells"
+    for c in gui_render gui_layout gui_interact gui_realassets; do
+        [[ -x "$bin/$c" ]] && echo "$c" >> "$bin/expected_cells"; done
+    echo "prebuild: expected_cells for $arch = $(tr '\n' ' ' < "$bin/expected_cells")"
+    mkdir -p "$overlay_dir/opt"
+    cp -a "$staging_root$INSTALL_DIR" "$overlay_dir/opt/"
+    mkdir -p "$overlay_dir/usr/bin"
+    ln -sf "$INSTALL_DIR/run_all.sh" "$overlay_dir/usr/bin/run_all.sh"
+    echo "prebuild: overlay populated for $arch"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+compile_carpets
+populate_overlay
+echo "prebuild: cpu-gui-qt-test overlay ready for $arch"

--- a/apps/starry/cpu-gui-qt-test/prebuild.sh
+++ b/apps/starry/cpu-gui-qt-test/prebuild.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the cpu-gui-qt-test carpet ("pyte for GUI widgets") into the per-arch Alpine rootfs.
+#
+# The carpet drives real Qt Widgets / QPainter rendering on the CPU RASTER paint engine with the offscreen
+# QPA platform plugin (QT_QPA_PLATFORM=offscreen) - NO GPU, NO display server - and asserts CLOSED-FORM
+# goldens: exact per-pixel colors from known fillRect/drawLine/drawEllipse geometry, Porter-Duff "over" alpha
+# compositing computed by hand, exact layout geometry() from the QVBoxLayout/QHBoxLayout/QGridLayout math, and
+# post-event widget state from injected QTest events (mouseClick/keyClicks/keyClick). "Widget created" alone
+# is NOT a test - every leg checks a value predicted from first principles.
+#
+# Libraries: Alpine qt6-qtbase (musl) provides QtCore/QtGui/QtWidgets/QtTest + the offscreen/minimal QPA
+# platform plugins; qt6-qtbase-dev gives the headers + pkg-config. The cells LINK against Qt (they TEST Qt;
+# they do not reimplement a widget toolkit). Runtime therefore needs the shared Qt libs staged into the
+# overlay: this prebuild copies the resolved Qt6 + support libraries and the offscreen platform plugin.
+#
+# Portable model (same as the model/subtitle/font carpets): extract the base Alpine rootfs, apk add the Qt6
+# dev + runtime stack for the TARGET arch via qemu-user, cross-compile each cell on the HOST against the
+# apk-staged Qt6, stage the Qt runtime + offscreen plugin + a DejaVu font, and write a capability manifest
+# that run_all.sh gates on (fail==0 && total==EXPECTED==pass, EXPECTED>=1 floor). The synthetic
+# render/layout/interact legs always run; a missing font fails the prebuild.
+#
+# Why the compiler runs on the HOST and not under qemu-user: the target Alpine g++ spawns cc1plus via
+# posix_spawn, which qemu-user-static cannot exec, so every in-guest C++ compile fails on cc1plus. apk itself
+# runs fine under qemu-user (it only forks/reads/writes), so the Qt6 stack is still provisioned in-guest; only
+# the compile+link is moved to a native host cross C++ toolchain that targets the staging root as a sysroot.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS, STARRY_STAGING_ROOT, STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+CAR="$app_dir/programs/carpets"
+INSTALL_DIR=/opt/cpu-gui-qt-test
+
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static";     triple="aarch64-linux-musl" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static";     triple="riscv64-linux-musl" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static";      triple="x86_64-linux-musl" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static"; triple="loongarch64-linux-musl" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+}
+
+# Qt6 + toolchain are large; give the rootfs room.
+ROOTFS_SIZE=6G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    local before after; before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB for the Qt6 stack"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# Qt6 widgets + test + the dev headers/pkgconfig to compile against, plus a font for the real-asset leg. The
+# compiler is a HOST cross toolchain, so no target g++/build-base is provisioned here; qt6-qtbase-dev carries
+# the headers + .pc files, qt6-qtbase the runtime libs + offscreen QPA plugin, font-dejavu+fontconfig a
+# deterministic font. musl is upgraded with Qt because edge Qt6Core needs renameat2, which the base rootfs
+# musl does not export.
+PKGS=(musl qt6-qtbase-dev qt6-qtbase font-dejavu fontconfig)
+
+apk_provision() {
+    normalize_symlinks
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add Qt6 GUI carpet stack (${PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add --upgrade "${PKGS[@]}"
+    # The cells compile on the HOST, so validate the staged headers/pkgconfig/plugin, not a target g++.
+    [[ -d "$staging_root/usr/include/qt6/QtWidgets" ]] \
+        || { echo "prebuild: qt6-qtbase-dev headers missing for $arch" >&2; exit 3; }
+    [[ -f "$staging_root/usr/lib/pkgconfig/Qt6Widgets.pc" ]] \
+        || { echo "prebuild: Qt6 pkgconfig (.pc) missing for $arch" >&2; exit 3; }
+    [[ -f "$staging_root/usr/lib/qt6/plugins/platforms/libqoffscreen.so" ]] \
+        || { echo "prebuild: offscreen QPA plugin missing for $arch" >&2; exit 3; }
+}
+
+# HOST pkgconf resolves the Qt6 -I/-L/-l flags against the staging root: PKG_CONFIG_SYSROOT_DIR makes it
+# rewrite the .pc prefix (/usr) to $staging_root, PKG_CONFIG_LIBDIR points it at only the staged .pc files so
+# no host Qt leaks in. The emitted -I/-L are absolute paths into the staging root.
+host_pkgconf() { command -v pkgconf >/dev/null 2>&1 && echo pkgconf || echo pkg-config; }
+PKGCFG() { PKG_CONFIG_SYSROOT_DIR="$staging_root" PKG_CONFIG_LIBDIR="$staging_root/usr/lib/pkgconfig" \
+           "$(host_pkgconf)" "$@"; }
+
+# Resolve a HOST cross C++ compiler for $triple. The Alpine Qt6 .so use SHT_RELR (.relr.dyn) relocations, which
+# GCC 11 era cross-binutils reject, so the first cell is a link probe: a g++ driver that cannot read them is
+# retried with a host ld.lld (the `lld` package), then zig c++. Resolution order for the driver:
+#   1) ${triple}-g++ on PATH               2) /opt/${triple}-cross/bin/${triple}-g++
+#   3) zig c++ -target ${triple}           4) host g++ (x86_64 native only)
+#
+# CXX_KIND is "gxx" (a g++-style driver invoked with --sysroot) or "zig" (zig c++ -target, no --sysroot: the
+# pkgconf -I/-L are already absolute host paths, and zig would double-prepend a sysroot). rpath-link is not
+# passed to zig (its LLD ignores it); LLD follows transitive Qt .so deps via the -L path directly.
+CXX_CMD=() CXX_KIND="" CXX_LLD=()
+resolve_cxx() {
+    local zig; zig="$(command -v zig || true)"
+    if command -v "${triple}-g++" >/dev/null 2>&1; then
+        CXX_CMD=("${triple}-g++"); CXX_KIND="gxx"
+    elif [[ -x "/opt/${triple}-cross/bin/${triple}-g++" ]]; then
+        CXX_CMD=("/opt/${triple}-cross/bin/${triple}-g++"); CXX_KIND="gxx"
+    elif [[ -n "$zig" ]]; then
+        CXX_CMD=("$zig" c++ -target "$triple"); CXX_KIND="zig"
+    elif [[ "$arch" == "x86_64" ]] && command -v g++ >/dev/null 2>&1; then
+        CXX_CMD=(g++); CXX_KIND="gxx"
+    else
+        echo "prebuild: no host cross C++ toolchain for $triple (tried ${triple}-g++, /opt/${triple}-cross, zig, g++)" >&2
+        return 1
+    fi
+    return 0
+}
+
+# Point `-fuse-ld=lld` at a host ld.lld, including Debian's versioned llvm-* installs, through a private -B dir.
+resolve_lld() {
+    local lld="" c d
+    lld="$(command -v ld.lld || true)"
+    if [[ -z "$lld" ]]; then
+        for c in /usr/lib/llvm-*/bin/ld.lld; do [[ -x "$c" ]] && { lld="$c"; break; }; done
+    fi
+    [[ -n "$lld" ]] || return 1
+    d="$(mktemp -d)"; ln -sf "$lld" "$d/ld.lld"
+    CXX_LLD=(-fuse-ld=lld -B"$d")
+}
+
+# Compile one cell on the HOST with the currently-selected toolchain. Returns non-zero on any compile/link
+# failure so the caller can fall through to the next candidate.
+compile_one() {
+    local cell="$1" out="$2" cflags="$3" libs="$4"
+    if [[ "$CXX_KIND" == "gxx" ]]; then
+        # The staged libstdc++ goes on the link line: Alpine's Qt needs symbols the GCC 11 toolchain's copy lacks.
+        # shellcheck disable=SC2086
+        "${CXX_CMD[@]}" "${CXX_LLD[@]}" --sysroot="$staging_root" -O2 -std=c++17 -fPIC $cflags -I"$CAR" \
+            "$CAR/$cell.cpp" -o "$out" $libs "$staging_root/usr/lib/libstdc++.so.6" \
+            -Wl,-rpath-link,"$staging_root/usr/lib"
+    else
+        # shellcheck disable=SC2086
+        "${CXX_CMD[@]}" -O2 -std=c++17 -fPIC $cflags -I"$CAR" "$CAR/$cell.cpp" -o "$out" $libs
+    fi
+}
+
+# Each cell is a standalone C++ program including gui_common.h + linking Qt6 Widgets/Test. A compile/link
+# failure is a genuine breakage. Dynamic link against Qt (the runtime libs are staged into the overlay).
+compile_cells() {
+    local bin="$1" cell cflags libs
+    cflags="$(PKGCFG --cflags Qt6Widgets Qt6Test)"
+    libs="$(PKGCFG --libs Qt6Widgets Qt6Test)"
+    resolve_cxx || exit 4
+
+    # Probe the resolved toolchain on the first cell; if its linker cannot consume the RELR Qt6 .so, retry with
+    # ld.lld, then zig, before committing to the full set.
+    if ! compile_one gui_render "$bin/gui_render" "$cflags" "$libs" 2>"$bin/.cxx_probe.log" \
+        && ! { [[ "$CXX_KIND" == "gxx" ]] && resolve_lld \
+            && compile_one gui_render "$bin/gui_render" "$cflags" "$libs" 2>>"$bin/.cxx_probe.log"; }; then
+        CXX_LLD=()
+        local zig; zig="$(command -v zig || true)"
+        if [[ "$CXX_KIND" != "zig" && -n "$zig" ]]; then
+            echo "prebuild: ${CXX_CMD[0]} could not link Qt6 for $arch (see below); retrying with zig c++" >&2
+            sed 's/^/  /' "$bin/.cxx_probe.log" >&2 || true
+            CXX_CMD=("$zig" c++ -target "$triple"); CXX_KIND="zig"
+            compile_one gui_render "$bin/gui_render" "$cflags" "$libs" \
+                || { echo "prebuild: zig c++ also failed to link Qt6 for $arch" >&2; exit 4; }
+        else
+            echo "prebuild: cross C++ toolchain failed to link Qt6 for $arch:" >&2
+            sed 's/^/  /' "$bin/.cxx_probe.log" >&2 || true; exit 4
+        fi
+    fi
+    rm -f "$bin/.cxx_probe.log"
+    [[ -x "$bin/gui_render" ]] || { echo "prebuild: gui_render failed to compile" >&2; exit 4; }
+    echo "prebuild: C++ toolchain for $arch = ${CXX_CMD[*]} ${CXX_LLD[*]} (--sysroot=$staging_root)"
+
+    for cell in gui_layout gui_interact gui_realassets; do
+        echo "prebuild: cross-compile $cell for $arch (links Qt6 Widgets/Test - tests Qt, does not reimplement it)"
+        compile_one "$cell" "$bin/$cell" "$cflags" "$libs" \
+            || { echo "prebuild: $cell failed to compile" >&2; exit 4; }
+        [[ -x "$bin/$cell" ]] || { echo "prebuild: $cell failed to compile" >&2; exit 4; }
+    done
+}
+
+# Stage the resolved Qt6 runtime + support libraries and the offscreen platform plugin into the overlay, and
+# a DejaVu font for the real-asset leg. The cells are dynamically linked against Qt, so target needs these.
+stage_runtime() {
+    local bin="$1"
+    mkdir -p "$overlay_dir/usr/lib/qt6/plugins/platforms" "$bin/assets" "$overlay_dir/lib"
+    # Edge Qt6Core references renameat2, which the base rootfs musl does not export.
+    (cd "$staging_root" && find lib -maxdepth 1 \( -name 'ld-musl-*.so.1' -o -name 'libc.musl-*.so.1' \) -print) \
+        | while read -r rel; do cp -a "$staging_root/$rel" "$overlay_dir/$rel"; done
+    # copy the whole Qt6 lib set + its transitive support libs that apk pulled in
+    echo "prebuild: staging Qt6 runtime libraries into overlay"
+    (cd "$staging_root" && find usr/lib -maxdepth 1 \( -name 'libQt6*.so*' \) -print) | while read -r rel; do
+        mkdir -p "$overlay_dir/$(dirname "$rel")"; cp -a "$staging_root/$rel" "$overlay_dir/$rel"
+    done
+    # transitive: copy every shared lib apk installed under usr/lib (Qt pulls harfbuzz, freetype, png, etc.)
+    (cd "$staging_root" && find usr/lib -maxdepth 1 -name '*.so*' -print) | while read -r rel; do
+        [[ -e "$overlay_dir/$rel" ]] && continue
+        cp -a "$staging_root/$rel" "$overlay_dir/$rel" 2>/dev/null || true
+    done
+    # the offscreen + minimal QPA plugins
+    for plug in libqoffscreen.so libqminimal.so; do
+        [[ -f "$staging_root/usr/lib/qt6/plugins/platforms/$plug" ]] \
+            && cp -a "$staging_root/usr/lib/qt6/plugins/platforms/$plug" "$overlay_dir/usr/lib/qt6/plugins/platforms/"
+    done
+    local ttf; ttf="$(find "$staging_root/usr/share/fonts" -name '*.ttf' 2>/dev/null | head -1 || true)"
+    [[ -n "$ttf" ]] || { echo "prebuild: no .ttf under staging fonts for the real-asset leg" >&2; exit 5; }
+    cp -a "$ttf" "$bin/assets/" && echo "prebuild: staged font $(basename "$ttf") for real-asset leg"
+}
+
+compile_carpets() {
+    local bin="$staging_root$INSTALL_DIR"; mkdir -p "$bin"
+    compile_cells "$bin"
+    cp "$app_dir/programs/run_all.sh" "$bin/run_all.sh"; chmod +x "$bin/run_all.sh"
+    stage_runtime "$bin"
+}
+
+populate_overlay() {
+    local bin="$staging_root$INSTALL_DIR"
+    : > "$bin/expected_cells"
+    for c in gui_render gui_layout gui_interact gui_realassets; do
+        [[ -x "$bin/$c" ]] && echo "$c" >> "$bin/expected_cells"; done
+    echo "prebuild: expected_cells for $arch = $(tr '\n' ' ' < "$bin/expected_cells")"
+    mkdir -p "$overlay_dir/opt"
+    cp -a "$staging_root$INSTALL_DIR" "$overlay_dir/opt/"
+    mkdir -p "$overlay_dir/usr/bin"
+    ln -sf "$INSTALL_DIR/run_all.sh" "$overlay_dir/usr/bin/run_all.sh"
+    echo "prebuild: overlay populated for $arch"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+compile_carpets
+populate_overlay
+echo "prebuild: cpu-gui-qt-test overlay ready for $arch"

--- a/apps/starry/cpu-gui-qt-test/programs/carpets/gui_common.h
+++ b/apps/starry/cpu-gui-qt-test/programs/carpets/gui_common.h
@@ -1,0 +1,126 @@
+/* gui_common.h - shared primitives for the cpu-gui-qt-test carpet (a "pyte for GUI widgets").
+ *
+ * Each cell drives a real Qt Widgets / QPainter pipeline on the CPU RASTER paint engine with the
+ * offscreen QPA platform plugin (QT_QPA_PLATFORM=offscreen) - NO GPU, NO display server - and asserts the
+ * result against a CLOSED-FORM golden: exact per-pixel colors from known fillRect/drawLine/drawEllipse
+ * geometry, Porter-Duff "over" alpha compositing computed by hand, exact layout geometry() from the
+ * QVBoxLayout/QHBoxLayout/QGridLayout math, and post-event widget state from injected QTest events.
+ * "Widget created" alone is NOT a test here - every leg checks a value it can predict from first principles.
+ *
+ * Determinism: fixed widget sizes, ARGB32 images (no premultiply surprises where avoidable), a fixed RNG
+ * seed (0x233) where any randomness would appear, and the raster engine (pure CPU) so pixels are identical
+ * across arch. Text legs assert an ink bounding-box + non-empty coverage (the exact glyph pixels depend on
+ * the bundled font, so we never assert glyph-exact pixels - only that ink lands where it must and nowhere
+ * it must not).
+ *
+ * Three-gate marker: a cell prints "GUI_<CELL> OK <n>" only when fail==0 && total==pass && total>0.
+ */
+#ifndef GUI_COMMON_H
+#define GUI_COMMON_H
+
+#include <QImage>
+#include <QColor>
+#include <QPainter>
+#include <QString>
+#include <cstdio>
+#include <cstdlib>
+
+/* -------- three-gate marker (identical semantics to the subtitle/model/font carpets) -------- */
+struct Gate {
+    int pass = 0, total = 0, fail = 0;
+    const char *name;
+    explicit Gate(const char *n) : name(n) {}
+    void check(bool cond, const char *msg) {
+        total++;
+        if (cond) pass++;
+        else { fail++; fprintf(stderr, "  FAIL: %s\n", msg); }
+    }
+    int finish() {
+        if (fail == 0 && total == pass && total > 0) {
+            printf("%s OK %d\n", name, total);
+            return 0;
+        }
+        printf("%s FAILED pass=%d total=%d fail=%d\n", name, pass, total, fail);
+        return 1;
+    }
+};
+
+/* -------- pixel helpers over QImage (all work on ARGB32 so a pixel is a plain 0xAARRGGBB) -------- */
+
+/* channel-wise |a-b| <= tol for every channel including alpha */
+static inline bool argb_close(QRgb a, QRgb b, int tol) {
+    return qAbs(qAlpha(a) - qAlpha(b)) <= tol &&
+           qAbs(qRed(a)   - qRed(b))   <= tol &&
+           qAbs(qGreen(a) - qGreen(b)) <= tol &&
+           qAbs(qBlue(a)  - qBlue(b))  <= tol;
+}
+
+/* Assert every pixel inside [x0,x1) x [y0,y1) is within tol of want. Returns true if ALL match. */
+static inline bool rect_is_color(const QImage &img, int x0, int y0, int x1, int y1, QRgb want, int tol) {
+    for (int y = y0; y < y1; ++y)
+        for (int x = x0; x < x1; ++x)
+            if (!argb_close(img.pixel(x, y), want, tol)) return false;
+    return true;
+}
+
+/* Count pixels inside the rect that are within tol of want. */
+static inline int count_color(const QImage &img, int x0, int y0, int x1, int y1, QRgb want, int tol) {
+    int n = 0;
+    for (int y = y0; y < y1; ++y)
+        for (int x = x0; x < x1; ++x)
+            if (argb_close(img.pixel(x, y), want, tol)) ++n;
+    return n;
+}
+
+/* Count pixels in the whole image that differ from bg by more than tol on any channel ("ink"). */
+static inline int count_non_bg(const QImage &img, QRgb bg, int tol) {
+    int n = 0;
+    for (int y = 0; y < img.height(); ++y)
+        for (int x = 0; x < img.width(); ++x)
+            if (!argb_close(img.pixel(x, y), bg, tol)) ++n;
+    return n;
+}
+
+/* Tight bounding box of pixels differing from bg by more than tol. Returns false if no ink at all. */
+static inline bool ink_bbox(const QImage &img, QRgb bg, int tol,
+                            int *minx, int *miny, int *maxx, int *maxy) {
+    int lx = img.width(), ly = img.height(), hx = -1, hy = -1;
+    for (int y = 0; y < img.height(); ++y)
+        for (int x = 0; x < img.width(); ++x)
+            if (!argb_close(img.pixel(x, y), bg, tol)) {
+                if (x < lx) lx = x; if (x > hx) hx = x;
+                if (y < ly) ly = y; if (y > hy) hy = y;
+            }
+    if (hx < 0) return false;
+    *minx = lx; *miny = ly; *maxx = hx; *maxy = hy;
+    return true;
+}
+
+/* Porter-Duff "source over destination" for straight (non-premultiplied) ARGB, per channel.
+ * out = src + dst*(1-src_a).  Alphas/channels are 0..255. This is the closed form QPainter's default
+ * CompositionMode_SourceOver produces; we compare the rendered pixel against this. */
+static inline int pd_over_chan(int src_c, int src_a, int dst_c, int dst_a) {
+    /* result alpha */
+    double sa = src_a / 255.0, da = dst_a / 255.0;
+    double oa = sa + da * (1.0 - sa);
+    if (oa <= 0.0) return 0;
+    /* straight-alpha over: (src_c*sa + dst_c*da*(1-sa)) / oa */
+    double oc = (src_c * sa + dst_c * da * (1.0 - sa)) / oa;
+    int v = (int)(oc + 0.5);
+    return v < 0 ? 0 : (v > 255 ? 255 : v);
+}
+static inline int pd_over_alpha(int src_a, int dst_a) {
+    double sa = src_a / 255.0, da = dst_a / 255.0;
+    double oa = sa + da * (1.0 - sa);
+    int v = (int)(oa * 255.0 + 0.5);
+    return v < 0 ? 0 : (v > 255 ? 255 : v);
+}
+
+/* A fresh ARGB32 image flood-filled with bg. */
+static inline QImage new_image(int w, int h, QRgb bg) {
+    QImage img(w, h, QImage::Format_ARGB32);
+    img.fill(bg);
+    return img;
+}
+
+#endif /* GUI_COMMON_H */

--- a/apps/starry/cpu-gui-qt-test/programs/carpets/gui_interact.cpp
+++ b/apps/starry/cpu-gui-qt-test/programs/carpets/gui_interact.cpp
@@ -1,0 +1,126 @@
+/* gui_interact.cpp - per-interaction testing: inject real events with QTest, assert STATE + re-rendered pixels.
+ *
+ * Every leg drives a real widget through a real event and predicts the outcome:
+ *   - QPushButton + clicked handler -> QTest::mouseClick -> the handler counter incremented exactly once,
+ *     and a second click makes it two (event delivery is real, not simulated by calling the slot).
+ *   - QCheckBox -> mouseClick toggles isChecked(); a second click toggles back; the grabbed indicator
+ *     pixels differ between checked and unchecked (visible state change, not just the bool).
+ *   - QLineEdit -> QTest::keyClicks("hello") -> text()=="hello"; a backspace key -> "hell".
+ *   - QSlider -> setValue baseline, then arrow-key press -> value() moved by exactly singleStep.
+ *   - QPushButton disabled -> mouseClick does NOT fire the handler (negative control).
+ *
+ * QT_QPA_PLATFORM=offscreen: events are posted through the real Qt event loop against off-screen widgets.
+ */
+#include "gui_common.h"
+#include <QApplication>
+#include <QPushButton>
+#include <QCheckBox>
+#include <QLineEdit>
+#include <QSlider>
+#include <QTest>
+#include <QImage>
+#include <QPixmap>
+
+/* ---- button click delivers a real event to a real handler ---- */
+static void leg_button_click(Gate &g) {
+    QPushButton btn("Go");
+    btn.setFixedSize(80, 30);
+    int fired = 0;
+    QObject::connect(&btn, &QPushButton::clicked, [&fired]() { ++fired; });
+    btn.show(); /* offscreen: no display, but the widget is realized for event routing */
+
+    QTest::mouseClick(&btn, Qt::LeftButton, Qt::NoModifier, btn.rect().center());
+    g.check(fired == 1, "button: first click did not fire handler exactly once");
+    QTest::mouseClick(&btn, Qt::LeftButton, Qt::NoModifier, btn.rect().center());
+    g.check(fired == 2, "button: second click did not increment to two");
+}
+
+/* ---- disabled button: click must NOT fire (negative control) ---- */
+static void leg_button_disabled(Gate &g) {
+    QPushButton btn("Off");
+    btn.setFixedSize(80, 30);
+    btn.setEnabled(false);
+    int fired = 0;
+    QObject::connect(&btn, &QPushButton::clicked, [&fired]() { ++fired; });
+    btn.show();
+    QTest::mouseClick(&btn, Qt::LeftButton, Qt::NoModifier, btn.rect().center());
+    g.check(fired == 0, "button(disabled): click wrongly fired the handler");
+}
+
+/* ---- checkbox: state toggles AND the rendered indicator pixels change ---- */
+static void leg_checkbox(Gate &g) {
+    QCheckBox cb("opt");
+    cb.setFixedSize(120, 24);
+    cb.show();
+    g.check(!cb.isChecked(), "checkbox: initial state not unchecked");
+
+    QImage before = cb.grab().toImage().convertToFormat(QImage::Format_ARGB32);
+    QTest::mouseClick(&cb, Qt::LeftButton, Qt::NoModifier, QPoint(8, cb.height() / 2));
+    g.check(cb.isChecked(), "checkbox: click did not toggle to checked");
+    QImage after = cb.grab().toImage().convertToFormat(QImage::Format_ARGB32);
+
+    /* the indicator lives on the left; count differing pixels there between the two grabs */
+    int diff = 0;
+    int w = qMin(before.width(), after.width()), h = qMin(before.height(), after.height());
+    int rx = qMin(24, w);
+    for (int y = 0; y < h; ++y)
+        for (int x = 0; x < rx; ++x)
+            if (!argb_close(before.pixel(x, y), after.pixel(x, y), 8)) ++diff;
+    g.check(diff > 4, "checkbox: indicator pixels did not change after toggle");
+
+    /* second click toggles back to unchecked */
+    QTest::mouseClick(&cb, Qt::LeftButton, Qt::NoModifier, QPoint(8, cb.height() / 2));
+    g.check(!cb.isChecked(), "checkbox: second click did not toggle back");
+}
+
+/* ---- line edit: typed keys land in text(), backspace removes ---- */
+static void leg_lineedit(Gate &g) {
+    QLineEdit le;
+    le.setFixedSize(160, 28);
+    le.show();
+    le.setFocus();
+    QTest::keyClicks(&le, "hello");
+    g.check(le.text() == "hello", "lineedit: keyClicks did not produce 'hello'");
+    QTest::keyClick(&le, Qt::Key_Backspace);
+    g.check(le.text() == "hell", "lineedit: backspace did not yield 'hell'");
+    /* select-all + type replaces */
+    QTest::keyClick(&le, Qt::Key_A, Qt::ControlModifier);
+    QTest::keyClicks(&le, "world");
+    g.check(le.text() == "world", "lineedit: ctrl-a + type did not replace with 'world'");
+}
+
+/* ---- slider: arrow key moves value by exactly singleStep; page keys by pageStep ---- */
+static void leg_slider(Gate &g) {
+    QSlider s(Qt::Horizontal);
+    s.setRange(0, 100);
+    s.setSingleStep(5);
+    s.setPageStep(20);
+    s.setValue(50);
+    s.setFixedSize(200, 24);
+    s.show();
+    s.setFocus();
+    g.check(s.value() == 50, "slider: initial value not 50");
+
+    /* a horizontal slider increases value on Key_Right by singleStep */
+    QTest::keyClick(&s, Qt::Key_Right);
+    g.check(s.value() == 55, "slider: Key_Right did not add singleStep (55)");
+    QTest::keyClick(&s, Qt::Key_Left);
+    g.check(s.value() == 50, "slider: Key_Left did not subtract singleStep (50)");
+    QTest::keyClick(&s, Qt::Key_PageUp);
+    g.check(s.value() == 70, "slider: PageUp did not add pageStep (70)");
+    QTest::keyClick(&s, Qt::Key_Home);
+    g.check(s.value() == 0, "slider: Home did not go to minimum");
+    QTest::keyClick(&s, Qt::Key_End);
+    g.check(s.value() == 100, "slider: End did not go to maximum");
+}
+
+int main(int argc, char **argv) {
+    QApplication app(argc, argv);
+    Gate g("GUI_INTERACT");
+    leg_button_click(g);
+    leg_button_disabled(g);
+    leg_checkbox(g);
+    leg_lineedit(g);
+    leg_slider(g);
+    return g.finish();
+}

--- a/apps/starry/cpu-gui-qt-test/programs/carpets/gui_layout.cpp
+++ b/apps/starry/cpu-gui-qt-test/programs/carpets/gui_layout.cpp
@@ -1,0 +1,181 @@
+/* gui_layout.cpp - deterministic geometry: assert each child's computed geometry() == closed-form layout math.
+ *
+ * Layouts are given fixed margins and spacing and fixed-size children, the host is sized to the layout's
+ * own sizeHint, then shown and the event loop flushed so Qt actually performs the layout, and each child's
+ * geometry() is compared to the exact arithmetic:
+ *   - QVBoxLayout: child i at y = margin + i*(childH + spacing), x = margin, over the fixed width.
+ *   - QHBoxLayout: child i at x = margin + i*(childW + spacing).
+ *   - QGridLayout: cell (r,c) at the row/col offsets from fixed-size, spacing and margins.
+ *   - resize the parent -> stretchable children re-layout to the new closed-form width/height.
+ *   - sizeHint / minimumSizeHint composition of a nested layout equals the summed child extents + spacing.
+ *
+ * No pixels needed: layout math is exact integer arithmetic, identical across arch. The offscreen QPA does
+ * not propagateSizeHints (it prints a benign notice), which is irrelevant here: we drive the geometry via
+ * explicit resize() + show() + processEvents() and read the realized child geometry() back.
+ */
+#include "gui_common.h"
+#include <QApplication>
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QGridLayout>
+#include <QLabel>
+
+/* a fixed-size child so the layout has no freedom to resize it */
+static QLabel *fixed_child(int w, int h) {
+    QLabel *l = new QLabel;
+    l->setFixedSize(w, h);
+    return l;
+}
+
+/* realize the host at a definite size and flush the layout pass */
+static void realize(QWidget &host) {
+    host.show();
+    QApplication::processEvents();
+}
+
+/* ---- QVBoxLayout: children stack vertically at known offsets ---- */
+static void leg_vbox(Gate &g) {
+    QWidget host;
+    QVBoxLayout *v = new QVBoxLayout(&host);
+    const int M = 9, S = 7, CW = 120, CH = 30;
+    v->setContentsMargins(M, M, M, M);
+    v->setSpacing(S);
+    QLabel *c[3];
+    for (int i = 0; i < 3; ++i) { c[i] = fixed_child(CW, CH); v->addWidget(c[i]); }
+    int wantW = M + CW + M;
+    int wantH = M + 3 * CH + 2 * S + M;
+    host.resize(wantW, wantH);
+    realize(host);
+
+    for (int i = 0; i < 3; ++i) {
+        int ey = M + i * (CH + S);
+        QRect r = c[i]->geometry();
+        char msg[96]; snprintf(msg, sizeof msg, "vbox child %d geometry != closed form", i);
+        bool ok = r.x() == M && r.y() == ey && r.width() == CW && r.height() == CH;
+        if (!ok) fprintf(stderr, "  vbox[%d] got (%d,%d,%dx%d) want (%d,%d,%dx%d)\n",
+                         i, r.x(), r.y(), r.width(), r.height(), M, ey, CW, CH);
+        g.check(ok, msg);
+    }
+    /* the layout's own sizeHint = margins + 3 children + 2 gaps */
+    g.check(host.sizeHint().height() == wantH, "vbox: sizeHint height != summed child extents+spacing+margins");
+}
+
+/* ---- QHBoxLayout: children stack horizontally at known offsets ---- */
+static void leg_hbox(Gate &g) {
+    QWidget host;
+    QHBoxLayout *h = new QHBoxLayout(&host);
+    const int M = 5, S = 11, CW = 40, CH = 50;
+    h->setContentsMargins(M, M, M, M);
+    h->setSpacing(S);
+    QLabel *c[4];
+    for (int i = 0; i < 4; ++i) { c[i] = fixed_child(CW, CH); h->addWidget(c[i]); }
+    int wantW = M + 4 * CW + 3 * S + M;
+    int wantH = M + CH + M;
+    host.resize(wantW, wantH);
+    realize(host);
+
+    for (int i = 0; i < 4; ++i) {
+        int ex = M + i * (CW + S);
+        QRect r = c[i]->geometry();
+        char msg[96]; snprintf(msg, sizeof msg, "hbox child %d geometry != closed form", i);
+        bool ok = r.x() == ex && r.y() == M && r.width() == CW && r.height() == CH;
+        if (!ok) fprintf(stderr, "  hbox[%d] got (%d,%d,%dx%d) want (%d,%d,%dx%d)\n",
+                         i, r.x(), r.y(), r.width(), r.height(), ex, M, CW, CH);
+        g.check(ok, msg);
+    }
+    g.check(host.sizeHint().width() == wantW, "hbox: sizeHint width != summed child extents+spacing+margins");
+}
+
+/* ---- QGridLayout: 2x2 fixed cells at row/col offsets ---- */
+static void leg_grid(Gate &g) {
+    QWidget host;
+    QGridLayout *gl = new QGridLayout(&host);
+    const int M = 8, HS = 6, VS = 10, CW = 60, CH = 40;
+    gl->setContentsMargins(M, M, M, M);
+    gl->setHorizontalSpacing(HS);
+    gl->setVerticalSpacing(VS);
+    QLabel *c[2][2];
+    for (int r = 0; r < 2; ++r)
+        for (int col = 0; col < 2; ++col) { c[r][col] = fixed_child(CW, CH); gl->addWidget(c[r][col], r, col); }
+    int wantW = M + 2 * CW + HS + M;
+    int wantH = M + 2 * CH + VS + M;
+    host.resize(wantW, wantH);
+    realize(host);
+
+    for (int r = 0; r < 2; ++r)
+        for (int col = 0; col < 2; ++col) {
+            int ex = M + col * (CW + HS);
+            int ey = M + r * (CH + VS);
+            QRect rc = c[r][col]->geometry();
+            char msg[96]; snprintf(msg, sizeof msg, "grid cell (%d,%d) geometry != closed form", r, col);
+            bool ok = rc.x() == ex && rc.y() == ey && rc.width() == CW && rc.height() == CH;
+            if (!ok) fprintf(stderr, "  grid[%d][%d] got (%d,%d,%dx%d) want (%d,%d,%dx%d)\n",
+                             r, col, rc.x(), rc.y(), rc.width(), rc.height(), ex, ey, CW, CH);
+            g.check(ok, msg);
+        }
+    g.check(host.sizeHint() == QSize(wantW, wantH), "grid: sizeHint != closed form");
+}
+
+/* ---- resize: stretchable children re-layout to the new closed-form size ---- */
+static void leg_resize_stretch(Gate &g) {
+    QWidget host;
+    QVBoxLayout *v = new QVBoxLayout(&host);
+    const int M = 10, S = 8;
+    v->setContentsMargins(M, M, M, M);
+    v->setSpacing(S);
+    /* two expanding labels split the vertical space equally */
+    QLabel *a = new QLabel, *b = new QLabel;
+    a->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    b->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    a->setMinimumSize(0, 0); b->setMinimumSize(0, 0);
+    v->addWidget(a);
+    v->addWidget(b);
+
+    host.resize(200, 300);
+    realize(host);
+    /* usable height = 300 - 2*M - S ; split in two ; width fills the content region */
+    int usable = 300 - 2 * M - S;
+    int half = usable / 2;
+    int fillW = 200 - 2 * M;
+    g.check(a->geometry().x() == M && a->geometry().y() == M, "resize: top child origin wrong");
+    g.check(a->width() == fillW, "resize: top child width != content width");
+    g.check(qAbs(a->height() - half) <= 1, "resize: top child height != half usable");
+    g.check(b->geometry().y() == M + a->height() + S, "resize: bottom child y != top+height+spacing");
+    g.check(qAbs((a->height() + b->height()) - usable) <= 1, "resize: children do not fill usable height");
+
+    /* resize larger; children re-layout to the new closed form */
+    host.resize(200, 500);
+    QApplication::processEvents();
+    int usable2 = 500 - 2 * M - S;
+    g.check(qAbs((a->height() + b->height()) - usable2) <= 1, "resize(500): children do not fill new usable height");
+    g.check(b->geometry().y() == M + a->height() + S, "resize(500): bottom child re-position wrong");
+}
+
+/* ---- sizeHint / minimumSizeHint composition of a nested layout ---- */
+static void leg_sizehint(Gate &g) {
+    QWidget host;
+    QHBoxLayout *h = new QHBoxLayout(&host);
+    const int M = 4, S = 6, CW = 30, CH = 20;
+    h->setContentsMargins(M, M, M, M);
+    h->setSpacing(S);
+    for (int i = 0; i < 3; ++i) h->addWidget(fixed_child(CW, CH));
+    QSize hint = host.sizeHint();
+    int wantW = M + 3 * CW + 2 * S + M;
+    int wantH = M + CH + M;
+    g.check(hint.width() == wantW, "sizehint: width != composed extents");
+    g.check(hint.height() == wantH, "sizehint: height != composed extents");
+    QSize mn = host.minimumSizeHint();
+    g.check(mn.width() == wantW && mn.height() == wantH, "sizehint: minimumSizeHint != fixed-child composition");
+}
+
+int main(int argc, char **argv) {
+    QApplication app(argc, argv);
+    Gate g("GUI_LAYOUT");
+    leg_vbox(g);
+    leg_hbox(g);
+    leg_grid(g);
+    leg_resize_stretch(g);
+    leg_sizehint(g);
+    return g.finish();
+}

--- a/apps/starry/cpu-gui-qt-test/programs/carpets/gui_realassets.cpp
+++ b/apps/starry/cpu-gui-qt-test/programs/carpets/gui_realassets.cpp
@@ -1,0 +1,88 @@
+/* gui_realassets.cpp - load a real font file from ASSET_DIR into Qt and render a label with it.
+ *
+ * This is the optional real-asset leg: it honest-skips (still prints its OK marker with the skip checks) when
+ * no font is present under ASSET_DIR / FONT_DIR, so the synthetic legs (cells 1-3) always gate on their own.
+ * When a font IS present:
+ *   - QFontDatabase::addApplicationFont loads it; assert it registered a family.
+ *   - render a known string with that family at a fixed pixel size into an ARGB32 image;
+ *   - assert ink appears (non-empty coverage) and lands inside a bounded box, and the background outside the
+ *     text run is untouched. Font-agnostic (bbox + coverage, never glyph-exact pixels).
+ *
+ * ASSET_DIR default matches the prebuild staging (/opt/cpu-gui-qt-test/assets). A DejaVu font is staged by
+ * prebuild when font-dejavu is available; absent that, the leg records an honest skip and still passes.
+ */
+#include "gui_common.h"
+#include <QApplication>
+#include <QFontDatabase>
+#include <QPainter>
+#include <QImage>
+#include <QString>
+#include <QDir>
+#include <cstdlib>
+
+static QString asset_dir() {
+    const char *d = getenv("ASSET_DIR");
+    if (d && *d) return QString::fromUtf8(d);
+    d = getenv("FONT_DIR");
+    if (d && *d) return QString::fromUtf8(d);
+    return QStringLiteral("/opt/cpu-gui-qt-test/assets");
+}
+
+/* find the first .ttf/.otf under the asset dir; empty string if none */
+static QString find_font(const QString &dir) {
+    QDir d(dir);
+    if (!d.exists()) return QString();
+    const QStringList filters{"*.ttf", "*.otf", "*.ttc"};
+    const QStringList hits = d.entryList(filters, QDir::Files, QDir::Name);
+    if (hits.isEmpty()) return QString();
+    return d.absoluteFilePath(hits.first());
+}
+
+int main(int argc, char **argv) {
+    QApplication app(argc, argv);
+    Gate g("GUI_REALASSETS");
+
+    QString dir = asset_dir();
+    QString font = find_font(dir);
+
+    if (font.isEmpty()) {
+        /* honest skip: no external font present -> the synthetic legs already gate. Record the skip as a
+         * passing check so the three-gate marker still fires (total>0, fail==0). */
+        fprintf(stderr, "  gui_realassets: no font under %s - honest skip\n", qUtf8Printable(dir));
+        g.check(true, "realassets honest-skip (no font asset)");
+        return g.finish();
+    }
+
+    int id = QFontDatabase::addApplicationFont(font);
+    g.check(id >= 0, "realassets: addApplicationFont failed");
+    QStringList fams = QFontDatabase::applicationFontFamilies(id);
+    g.check(!fams.isEmpty(), "realassets: loaded font registered no family");
+    if (fams.isEmpty()) return g.finish();
+
+    const QRgb BG = qRgba(0x10, 0x10, 0x10, 0xFF);
+    const int W = 200, H = 60;
+    QImage img = new_image(W, H, BG);
+    {
+        QPainter p(&img);
+        QFont f(fams.first());
+        f.setPixelSize(28);
+        p.setFont(f);
+        p.setPen(QColor(0xFF, 0xFF, 0xFF));
+        p.drawText(12, 40, QStringLiteral("Starry"));
+    }
+
+    int ink = count_non_bg(img, BG, 24);
+    g.check(ink > 60, "realassets: rendered string produced too little ink");
+    int minx, miny, maxx, maxy;
+    bool has = ink_bbox(img, BG, 24, &minx, &miny, &maxx, &maxy);
+    g.check(has, "realassets: no ink from rendered string");
+    if (has) {
+        /* the text run starts near x=12 and stays within the image with a right margin */
+        g.check(minx >= 6 && minx <= 30, "realassets: ink does not start near the pen x");
+        g.check(maxx <= W - 4, "realassets: ink overruns right edge");
+        g.check(miny >= 8 && maxy <= H - 4, "realassets: ink outside vertical band");
+        /* background clearly outside the text run (bottom-right corner) is untouched */
+        g.check(argb_close(img.pixel(W - 2, H - 2), BG, 0), "realassets: stray ink in far corner");
+    }
+    return g.finish();
+}

--- a/apps/starry/cpu-gui-qt-test/programs/carpets/gui_realassets.cpp
+++ b/apps/starry/cpu-gui-qt-test/programs/carpets/gui_realassets.cpp
@@ -1,0 +1,80 @@
+/* gui_realassets.cpp - load a real font file from ASSET_DIR into Qt and render a label with it.
+ *
+ * A missing font under ASSET_DIR / FONT_DIR fails the leg.
+ *   - QFontDatabase::addApplicationFont loads it; assert it registered a family.
+ *   - render a known string with that family at a fixed pixel size into an ARGB32 image;
+ *   - assert ink appears (non-empty coverage) and lands inside a bounded box, and the background outside the
+ *     text run is untouched. Font-agnostic (bbox + coverage, never glyph-exact pixels).
+ *
+ * ASSET_DIR default matches the prebuild staging (/opt/cpu-gui-qt-test/assets), where prebuild stages a DejaVu font.
+ */
+#include "gui_common.h"
+#include <QApplication>
+#include <QFontDatabase>
+#include <QPainter>
+#include <QImage>
+#include <QString>
+#include <QDir>
+#include <cstdlib>
+
+static QString asset_dir() {
+    const char *d = getenv("ASSET_DIR");
+    if (d && *d) return QString::fromUtf8(d);
+    d = getenv("FONT_DIR");
+    if (d && *d) return QString::fromUtf8(d);
+    return QStringLiteral("/opt/cpu-gui-qt-test/assets");
+}
+
+/* find the first .ttf/.otf under the asset dir; empty string if none */
+static QString find_font(const QString &dir) {
+    QDir d(dir);
+    if (!d.exists()) return QString();
+    const QStringList filters{"*.ttf", "*.otf", "*.ttc"};
+    const QStringList hits = d.entryList(filters, QDir::Files, QDir::Name);
+    if (hits.isEmpty()) return QString();
+    return d.absoluteFilePath(hits.first());
+}
+
+int main(int argc, char **argv) {
+    QApplication app(argc, argv);
+    Gate g("GUI_REALASSETS");
+
+    QString dir = asset_dir();
+    QString font = find_font(dir);
+
+    g.check(!font.isEmpty(), "realassets: no font under ASSET_DIR");
+    if (font.isEmpty()) return g.finish();
+
+    int id = QFontDatabase::addApplicationFont(font);
+    g.check(id >= 0, "realassets: addApplicationFont failed");
+    QStringList fams = QFontDatabase::applicationFontFamilies(id);
+    g.check(!fams.isEmpty(), "realassets: loaded font registered no family");
+    if (fams.isEmpty()) return g.finish();
+
+    const QRgb BG = qRgba(0x10, 0x10, 0x10, 0xFF);
+    const int W = 200, H = 60;
+    QImage img = new_image(W, H, BG);
+    {
+        QPainter p(&img);
+        QFont f(fams.first());
+        f.setPixelSize(28);
+        p.setFont(f);
+        p.setPen(QColor(0xFF, 0xFF, 0xFF));
+        p.drawText(12, 40, QStringLiteral("Starry"));
+    }
+
+    int ink = count_non_bg(img, BG, 24);
+    g.check(ink > 60, "realassets: rendered string produced too little ink");
+    int minx, miny, maxx, maxy;
+    bool has = ink_bbox(img, BG, 24, &minx, &miny, &maxx, &maxy);
+    g.check(has, "realassets: no ink from rendered string");
+    if (has) {
+        /* the text run starts near x=12 and stays within the image with a right margin */
+        g.check(minx >= 6 && minx <= 30, "realassets: ink does not start near the pen x");
+        g.check(maxx <= W - 4, "realassets: ink overruns right edge");
+        g.check(miny >= 8 && maxy <= H - 4, "realassets: ink outside vertical band");
+        /* background clearly outside the text run (bottom-right corner) is untouched */
+        g.check(argb_close(img.pixel(W - 2, H - 2), BG, 0), "realassets: stray ink in far corner");
+    }
+    return g.finish();
+}

--- a/apps/starry/cpu-gui-qt-test/programs/carpets/gui_render.cpp
+++ b/apps/starry/cpu-gui-qt-test/programs/carpets/gui_render.cpp
@@ -1,0 +1,228 @@
+/* gui_render.cpp - per-pixel widget rendering vs closed form on Qt's CPU raster paint engine.
+ *
+ * Every leg draws with KNOWN geometry into an ARGB32 QImage (or grabs a real QWidget to a QImage) and then
+ * asserts the exact pixels:
+ *   - fillRect(x,y,w,h,color) -> those pixels are exactly `color`, the surrounding background is untouched.
+ *   - drawLine (axis-aligned + the diagonal endpoints) -> the drawn pixels carry the pen color.
+ *   - drawEllipse (a filled circle) -> analytic coverage: inside-radius pixels are fill, far-outside pixels
+ *     are background, and the total covered-pixel count is within tolerance of pi*r^2.
+ *   - alpha compositing of a semi-transparent rect over an opaque one -> Porter-Duff "over" per pixel.
+ *   - a real QLabel grabbed to a QImage -> its palette background fills the widget and it carries ink.
+ *   - text: draw one glyph, assert ink lands inside the expected bounding box and the rest stays background
+ *     (glyph-exact pixels depend on the font, so we assert bbox + coverage, never the literal glyph shape).
+ *
+ * QT_QPA_PLATFORM=offscreen: no display server. Raster engine: pure CPU. Deterministic across arch.
+ */
+#include "gui_common.h"
+#include <QApplication>
+#include <QLabel>
+#include <QPushButton>
+#include <QFont>
+#include <QPen>
+#include <QBrush>
+#include <cmath>
+
+/* named colors as straight ARGB (0xAARRGGBB) */
+static const QRgb BG    = qRgba(0x20, 0x20, 0x20, 0xFF); /* dark gray, opaque */
+static const QRgb RED   = qRgba(0xFF, 0x00, 0x00, 0xFF);
+static const QRgb GREEN = qRgba(0x00, 0xFF, 0x00, 0xFF);
+static const QRgb BLUE  = qRgba(0x00, 0x00, 0xFF, 0xFF);
+
+/* ---- fillRect: exact pixels inside, exact background outside ---- */
+static void leg_fillrect(Gate &g) {
+    QImage img = new_image(100, 80, BG);
+    QPainter p(&img);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.fillRect(20, 15, 40, 30, QColor(RED)); /* x=[20,60) y=[15,45) */
+    p.end();
+
+    g.check(rect_is_color(img, 20, 15, 60, 45, RED, 0), "fillRect: interior not exact red");
+    /* the four background bands around the rect must be untouched */
+    g.check(rect_is_color(img, 0, 0, 100, 15, BG, 0),  "fillRect: top band disturbed");
+    g.check(rect_is_color(img, 0, 45, 100, 80, BG, 0), "fillRect: bottom band disturbed");
+    g.check(rect_is_color(img, 0, 15, 20, 45, BG, 0),  "fillRect: left band disturbed");
+    g.check(rect_is_color(img, 60, 15, 100, 45, BG, 0),"fillRect: right band disturbed");
+    /* corner just inside is red, corner just outside is bg (closed-form edge) */
+    g.check(argb_close(img.pixel(20, 15), RED, 0), "fillRect: top-left inside pixel wrong");
+    g.check(argb_close(img.pixel(59, 44), RED, 0), "fillRect: bottom-right inside pixel wrong");
+    g.check(argb_close(img.pixel(19, 15), BG, 0),  "fillRect: pixel left of edge not bg");
+    g.check(argb_close(img.pixel(60, 15), BG, 0),  "fillRect: pixel right of edge not bg");
+    /* exact covered-pixel count = 40*30 */
+    g.check(count_color(img, 0, 0, 100, 80, RED, 0) == 40 * 30, "fillRect: red pixel count != 1200");
+}
+
+/* ---- drawLine: axis-aligned lines land on their exact rows/cols ---- */
+static void leg_drawline(Gate &g) {
+    QImage img = new_image(60, 60, BG);
+    QPainter p(&img);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    QPen pen{QColor(GREEN)};
+    pen.setWidth(1);
+    p.setPen(pen);
+    /* horizontal line y=30 from x=10..49 ; Qt draws inclusive of both endpoints for a 1px cosmetic line */
+    p.drawLine(10, 30, 49, 30);
+    /* vertical line x=45 from y=5..54 */
+    p.drawLine(45, 5, 45, 54);
+    p.end();
+
+    /* horizontal: sample interior points on the row */
+    int hhits = 0;
+    for (int x = 12; x <= 47; ++x) if (argb_close(img.pixel(x, 30), GREEN, 0)) ++hhits;
+    g.check(hhits == 36, "drawLine: horizontal row coverage wrong");
+    /* row above/below the horizontal line is background at a column away from the vertical line */
+    g.check(argb_close(img.pixel(20, 29), BG, 0), "drawLine: pixel above h-line not bg");
+    g.check(argb_close(img.pixel(20, 31), BG, 0), "drawLine: pixel below h-line not bg");
+    /* vertical: sample interior points on the column */
+    int vhits = 0;
+    for (int y = 7; y <= 52; ++y) if (argb_close(img.pixel(45, y), GREEN, 0)) ++vhits;
+    g.check(vhits == 46, "drawLine: vertical column coverage wrong");
+    g.check(argb_close(img.pixel(44, 20), BG, 0), "drawLine: pixel left of v-line not bg");
+}
+
+/* ---- drawEllipse: filled circle analytic coverage ---- */
+static void leg_ellipse(Gate &g) {
+    const int W = 120, H = 120;
+    QImage img = new_image(W, H, BG);
+    QPainter p(&img);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.setPen(Qt::NoPen);
+    p.setBrush(QBrush(QColor(BLUE)));
+    /* bounding box (10,10)-(110,110): diameter 100 -> center (60,60), radius 50 (Qt fills [x, x+w) span) */
+    p.drawEllipse(10, 10, 100, 100);
+    p.end();
+
+    const double cx = 60.0, cy = 60.0, r = 50.0;
+    /* center is fill */
+    g.check(argb_close(img.pixel(60, 60), BLUE, 0), "ellipse: center not fill");
+    /* well inside (r=30 from center) is fill */
+    g.check(argb_close(img.pixel(90, 60), BLUE, 0), "ellipse: +30x not fill");
+    g.check(argb_close(img.pixel(60, 90), BLUE, 0), "ellipse: +30y not fill");
+    /* corner of bbox is outside the inscribed circle -> background */
+    g.check(argb_close(img.pixel(12, 12), BG, 0),  "ellipse: bbox corner not bg");
+    g.check(argb_close(img.pixel(107, 107), BG, 0),"ellipse: bbox far corner not bg");
+    /* far outside the bbox entirely -> background */
+    g.check(argb_close(img.pixel(2, 2), BG, 0),    "ellipse: outside-bbox not bg");
+    /* analytic coverage: filled count within 6% of pi*r^2 (rasterization + Qt's half-open span) */
+    int filled = count_color(img, 0, 0, W, H, BLUE, 0);
+    double expect = M_PI * r * r;
+    double frac = qAbs(filled - expect) / expect;
+    if (frac >= 0.06)
+        fprintf(stderr, "  ellipse: filled=%d expect~%.0f frac=%.3f\n", filled, expect, frac);
+    g.check(frac < 0.06, "ellipse: filled area far from pi*r^2");
+    /* every pixel strictly inside radius r-2 must be fill; outside r+2 (within bbox) must be bg */
+    bool inside_ok = true, outside_ok = true;
+    for (int y = 10; y < 110 && (inside_ok || outside_ok); ++y)
+        for (int x = 10; x < 110; ++x) {
+            double d = std::hypot(x + 0.5 - cx, y + 0.5 - cy);
+            bool fill = argb_close(img.pixel(x, y), BLUE, 0);
+            if (d < r - 2.0 && !fill) inside_ok = false;
+            if (d > r + 2.0 && fill)  outside_ok = false;
+        }
+    g.check(inside_ok,  "ellipse: a pixel well inside r is not fill");
+    g.check(outside_ok, "ellipse: a pixel well outside r is fill");
+}
+
+/* ---- Porter-Duff over: semi-transparent rect over an opaque one ---- */
+static void leg_alpha(Gate &g) {
+    QImage img = new_image(80, 80, BG);
+    QPainter p(&img);
+    p.setRenderHint(QPainter::Antialiasing, false);
+    p.setCompositionMode(QPainter::CompositionMode_SourceOver);
+    /* dst: opaque green rect covering the sample region */
+    p.fillRect(10, 10, 60, 60, QColor(0x00, 0xFF, 0x00, 0xFF));
+    /* src: red at alpha=128 over the green */
+    p.fillRect(20, 20, 40, 40, QColor(0xFF, 0x00, 0x00, 128));
+    p.end();
+
+    /* closed form for the overlap region: src=(255,0,0,128) over dst=(0,255,0,255) */
+    int oa = pd_over_alpha(128, 255);
+    int orr = pd_over_chan(0xFF, 128, 0x00, 255);
+    int ogg = pd_over_chan(0x00, 128, 0xFF, 255);
+    int obb = pd_over_chan(0x00, 128, 0x00, 255);
+    QRgb want = qRgba(orr, ogg, obb, oa);
+    /* sample several points inside the overlap; tol 2 for rounding across arch */
+    bool ok = true;
+    for (int y = 25; y <= 55; y += 10)
+        for (int x = 25; x <= 55; x += 10)
+            if (!argb_close(img.pixel(x, y), want, 2)) { ok = false;
+                fprintf(stderr, "  alpha: (%d,%d)=%08x want=%08x\n", x, y, img.pixel(x, y), want); }
+    g.check(ok, "alpha: overlap not Porter-Duff over of red@128 on green");
+    /* the green-only ring (dst with no src) stays pure opaque green */
+    g.check(argb_close(img.pixel(12, 12), qRgba(0, 0xFF, 0, 0xFF), 1), "alpha: green-only ring disturbed");
+    /* outside both rects stays background */
+    g.check(argb_close(img.pixel(2, 2), BG, 0), "alpha: outside rects not bg");
+}
+
+/* ---- grab a real QLabel to a QImage: palette background + ink present ---- */
+static void leg_label_grab(Gate &g) {
+    QLabel label("HI");
+    label.setFixedSize(120, 40);
+    label.setAutoFillBackground(true);
+    QPalette pal = label.palette();
+    pal.setColor(QPalette::Window, QColor(0x30, 0x60, 0x90)); /* known bg */
+    pal.setColor(QPalette::WindowText, QColor(0xFF, 0xFF, 0xFF));
+    label.setPalette(pal);
+    label.setAlignment(Qt::AlignCenter);
+
+    QPixmap pm = label.grab();
+    QImage img = pm.toImage().convertToFormat(QImage::Format_ARGB32);
+    g.check(img.width() == 120 && img.height() == 40, "label: grabbed size wrong");
+
+    QRgb winbg = qRgba(0x30, 0x60, 0x90, 0xFF);
+    /* corners (padding away from centered text) carry the palette Window color */
+    g.check(argb_close(img.pixel(2, 2), winbg, 4),                 "label: top-left not window bg");
+    g.check(argb_close(img.pixel(img.width()-3, 2), winbg, 4),     "label: top-right not window bg");
+    g.check(argb_close(img.pixel(2, img.height()-3), winbg, 4),    "label: bottom-left not window bg");
+    /* text ink: some pixels differ from the window bg (the white glyphs) */
+    int ink = count_non_bg(img, winbg, 24);
+    g.check(ink > 20, "label: no glyph ink over background");
+    /* the ink is concentrated near the center (aligned center), not in the far corners */
+    int minx, miny, maxx, maxy;
+    bool has = ink_bbox(img, winbg, 40, &minx, &miny, &maxx, &maxy);
+    g.check(has, "label: ink bbox empty");
+    if (has) {
+        int cxmin = img.width() / 2 - 45, cxmax = img.width() / 2 + 45;
+        g.check(minx >= 5 && maxx <= img.width() - 5, "label: ink touches horizontal edges");
+        g.check((minx + maxx) / 2 >= cxmin && (minx + maxx) / 2 <= cxmax, "label: ink not centered");
+    }
+}
+
+/* ---- text: one glyph, ink inside expected bbox, background elsewhere ---- */
+static void leg_text(Gate &g) {
+    const int W = 60, H = 60;
+    QImage img = new_image(W, H, BG);
+    QPainter p(&img);
+    QFont f = p.font();
+    f.setPixelSize(32);           /* fixed pixel size for determinism */
+    p.setFont(f);
+    p.setPen(QColor(0xFF, 0xFF, 0xFF));
+    /* draw 'A' with baseline near (20,40); glyph ink should land roughly in x=[16,44] y=[14,42] */
+    p.drawText(20, 40, QString("A"));
+    p.end();
+
+    int ink = count_non_bg(img, BG, 24);
+    g.check(ink > 15, "text: glyph produced too little ink");
+    int minx, miny, maxx, maxy;
+    bool has = ink_bbox(img, BG, 24, &minx, &miny, &maxx, &maxy);
+    g.check(has, "text: no ink at all");
+    if (has) {
+        /* ink stays within a generous but bounded box around the pen position (font-agnostic) */
+        g.check(minx >= 10 && maxx <= 52, "text: ink outside expected x-range");
+        g.check(miny >= 8  && maxy <= 46, "text: ink outside expected y-range");
+        /* nothing drawn in the far top-left quadrant corner */
+        g.check(argb_close(img.pixel(2, 2), BG, 0), "text: stray ink in top-left corner");
+        g.check(argb_close(img.pixel(W-2, H-2), BG, 0), "text: stray ink in bottom-right corner");
+    }
+}
+
+int main(int argc, char **argv) {
+    QApplication app(argc, argv);
+    Gate g("GUI_RENDER");
+    leg_fillrect(g);
+    leg_drawline(g);
+    leg_ellipse(g);
+    leg_alpha(g);
+    leg_label_grab(g);
+    leg_text(g);
+    return g.finish();
+}

--- a/apps/starry/cpu-gui-qt-test/programs/run_all.sh
+++ b/apps/starry/cpu-gui-qt-test/programs/run_all.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# On-target runner for the cpu-gui-qt-test carpet - a "pyte for GUI widgets". Each cell drives real Qt
+# Widgets / QPainter rendering on the CPU RASTER paint engine with the offscreen QPA platform plugin
+# (QT_QPA_PLATFORM=offscreen) - NO GPU, NO display server - and asserts CLOSED-FORM goldens: exact per-pixel
+# colors from known fillRect/drawLine/drawEllipse geometry, Porter-Duff "over" alpha compositing computed by
+# hand, exact layout geometry() from the QVBoxLayout/QHBoxLayout/QGridLayout math, and post-event widget
+# state from injected QTest events. Prints "TEST PASSED" only when every provisioned cell reports its
+# "GUI_<CELL> OK <n>" marker (three-gate: fail==0 && total==EXPECTED==pass).
+#
+# Cells:
+#   gui_render      - per-pixel widget rendering vs closed form: fillRect exact pixels + untouched background,
+#                     drawLine axis-aligned coverage, drawEllipse analytic pi*r^2 coverage, Porter-Duff over
+#                     alpha compositing per pixel, a grabbed QLabel's palette bg + centered ink, one text glyph
+#                     ink-in-bbox (font-agnostic).
+#   gui_layout      - deterministic geometry: QVBox/QHBox/QGrid child geometry() == closed-form layout math,
+#                     resize -> stretch children re-layout, sizeHint/minimumSizeHint composition.
+#   gui_interact    - per-interaction: QTest::mouseClick fires a real handler (and a disabled button does not),
+#                     QCheckBox toggle changes state AND indicator pixels, QLineEdit keyClicks/backspace/select,
+#                     QSlider arrow/page/home/end move value() by the exact step.
+#   gui_realassets  - load a real font from ASSET_DIR into Qt and render a label; assert family + ink-in-bbox.
+#                     Honest-skips (still passes with total>0) if no font is staged.
+set -u
+BIN=/opt/cpu-gui-qt-test
+export PATH="/usr/bin:/usr/local/bin:$PATH"
+
+# Qt runtime: offscreen QPA (pure CPU raster, no display server). Point the loader at the staged Qt libs and
+# the platform plugin dir; a writable HOME/XDG dir keeps QStandardPaths quiet.
+export QT_QPA_PLATFORM=offscreen
+export QT_QPA_PLATFORM_PLUGIN_PATH=/usr/lib/qt6/plugins/platforms
+export LD_LIBRARY_PATH="/usr/lib:/lib:${LD_LIBRARY_PATH:-}"
+export HOME="${HOME:-/tmp}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+# Asset dir for the real-font leg; defaults to the staged assets next to the binaries.
+export ASSET_DIR="${ASSET_DIR:-$BIN/assets}"
+
+ncpu=$(nproc 2>/dev/null || grep -c '^processor' /proc/cpuinfo 2>/dev/null || echo '?')
+echo "cpu-gui-qt-test: detected CPU count = $ncpu; QT_QPA_PLATFORM=$QT_QPA_PLATFORM; ASSET_DIR=$ASSET_DIR"
+
+pass=0; total=0; fail=0
+run() {
+    name="$1"; prog="$2"
+    [ -x "$prog" ] || { echo "cpu-gui-qt-test: $name in manifest but binary absent at runtime"; total=$((total + 1)); fail=$((fail + 1)); return 0; }
+    total=$((total + 1))
+    out="$(cd "$BIN" && "$prog" 2>&1 </dev/null)"; rc=$?
+    if [ "$rc" -eq 0 ] && echo "$out" | grep -qE "OK [0-9]+$"; then
+        echo "$out" | grep -E "OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+    else
+        echo "$out" | tail -12
+        echo "CARPET FAILED: $name (exit $rc)"
+        fail=$((fail + 1))
+    fi
+}
+
+cd "$BIN" || exit 1
+MANIFEST="$BIN/expected_cells"
+[ -f "$MANIFEST" ] || { echo "cpu-gui-qt-test: expected_cells manifest missing - prebuild provisioned no carpet"; echo "TEST FAILED"; exit 1; }
+EXPECTED=$(grep -c . "$MANIFEST")
+while IFS= read -r cell <&3; do
+    [ -n "$cell" ] || continue
+    run "$cell" "$BIN/$cell"
+done 3< "$MANIFEST"
+
+echo "cpu-gui-qt-test: $pass/$total GUI carpets OK on $(uname -m) (expected $EXPECTED: $(tr '\n' ' ' < "$MANIFEST"))"
+if [ "$EXPECTED" -ge 1 ] && [ "$fail" -eq 0 ] && [ "$total" -eq "$EXPECTED" ] && [ "$pass" -eq "$EXPECTED" ]; then
+    echo "TEST PASSED"; exit 0
+else
+    echo "cpu-gui-qt-test: GATE FAILED - need all $EXPECTED manifest carpets to pass (>=1 floor); got fail=$fail total=$total pass=$pass"
+    echo "TEST FAILED"; exit 1
+fi

--- a/apps/starry/cpu-gui-qt-test/programs/run_all.sh
+++ b/apps/starry/cpu-gui-qt-test/programs/run_all.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# On-target runner for the cpu-gui-qt-test carpet - a "pyte for GUI widgets". Each cell drives real Qt
+# Widgets / QPainter rendering on the CPU RASTER paint engine with the offscreen QPA platform plugin
+# (QT_QPA_PLATFORM=offscreen) - NO GPU, NO display server - and asserts CLOSED-FORM goldens: exact per-pixel
+# colors from known fillRect/drawLine/drawEllipse geometry, Porter-Duff "over" alpha compositing computed by
+# hand, exact layout geometry() from the QVBoxLayout/QHBoxLayout/QGridLayout math, and post-event widget
+# state from injected QTest events. Prints "TEST PASSED" only when every provisioned cell reports its
+# "GUI_<CELL> OK <n>" marker (three-gate: fail==0 && total==EXPECTED==pass).
+#
+# Cells:
+#   gui_render      - per-pixel widget rendering vs closed form: fillRect exact pixels + untouched background,
+#                     drawLine axis-aligned coverage, drawEllipse analytic pi*r^2 coverage, Porter-Duff over
+#                     alpha compositing per pixel, a grabbed QLabel's palette bg + centered ink, one text glyph
+#                     ink-in-bbox (font-agnostic).
+#   gui_layout      - deterministic geometry: QVBox/QHBox/QGrid child geometry() == closed-form layout math,
+#                     resize -> stretch children re-layout, sizeHint/minimumSizeHint composition.
+#   gui_interact    - per-interaction: QTest::mouseClick fires a real handler (and a disabled button does not),
+#                     QCheckBox toggle changes state AND indicator pixels, QLineEdit keyClicks/backspace/select,
+#                     QSlider arrow/page/home/end move value() by the exact step.
+#   gui_realassets  - load a real font from ASSET_DIR into Qt and render a label; assert family + ink-in-bbox.
+set -u
+BIN=/opt/cpu-gui-qt-test
+export PATH="/usr/bin:/usr/local/bin:$PATH"
+
+# Qt runtime: offscreen QPA (pure CPU raster, no display server). Point the loader at the staged Qt libs and
+# the platform plugin dir; a writable HOME/XDG dir keeps QStandardPaths quiet.
+export QT_QPA_PLATFORM=offscreen
+export QT_QPA_PLATFORM_PLUGIN_PATH=/usr/lib/qt6/plugins/platforms
+export LD_LIBRARY_PATH="/usr/lib:/lib:${LD_LIBRARY_PATH:-}"
+export HOME="${HOME:-/tmp}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+# Asset dir for the real-font leg; defaults to the staged assets next to the binaries.
+export ASSET_DIR="${ASSET_DIR:-$BIN/assets}"
+
+ncpu=$(nproc 2>/dev/null || grep -c '^processor' /proc/cpuinfo 2>/dev/null || echo '?')
+echo "cpu-gui-qt-test: detected CPU count = $ncpu; QT_QPA_PLATFORM=$QT_QPA_PLATFORM; ASSET_DIR=$ASSET_DIR"
+
+pass=0; total=0; fail=0
+run() {
+    name="$1"; prog="$2"
+    [ -x "$prog" ] || { echo "cpu-gui-qt-test: $name in manifest but binary absent at runtime"; total=$((total + 1)); fail=$((fail + 1)); return 0; }
+    total=$((total + 1))
+    out="$(cd "$BIN" && "$prog" 2>&1 </dev/null)"; rc=$?
+    if [ "$rc" -eq 0 ] && echo "$out" | grep -qE "OK [0-9]+$"; then
+        echo "$out" | grep -E "OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+    else
+        echo "$out" | tail -12
+        echo "CARPET FAILED: $name (exit $rc)"
+        fail=$((fail + 1))
+    fi
+}
+
+cd "$BIN" || exit 1
+MANIFEST="$BIN/expected_cells"
+[ -f "$MANIFEST" ] || { echo "cpu-gui-qt-test: expected_cells manifest missing - prebuild provisioned no carpet"; echo "TEST FAILED"; exit 1; }
+EXPECTED=$(grep -c . "$MANIFEST")
+while IFS= read -r cell <&3; do
+    [ -n "$cell" ] || continue
+    run "$cell" "$BIN/$cell"
+done 3< "$MANIFEST"
+
+echo "cpu-gui-qt-test: $pass/$total GUI carpets OK on $(uname -m) (expected $EXPECTED: $(tr '\n' ' ' < "$MANIFEST"))"
+if [ "$EXPECTED" -ge 1 ] && [ "$fail" -eq 0 ] && [ "$total" -eq "$EXPECTED" ] && [ "$pass" -eq "$EXPECTED" ]; then
+    echo "TEST PASSED"; exit 0
+else
+    echo "cpu-gui-qt-test: GATE FAILED - need all $EXPECTED manifest carpets to pass (>=1 floor); got fail=$fail total=$total pass=$pass"
+    echo "TEST FAILED"; exit 1
+fi

--- a/apps/starry/cpu-gui-qt-test/qemu-aarch64.toml
+++ b/apps/starry/cpu-gui-qt-test/qemu-aarch64.toml
@@ -1,0 +1,18 @@
+# cpu-gui-qt-test aarch64 - "pyte for GUI widgets" offscreen/raster carpet. Real Qt Widgets/QPainter on the
+# CPU raster engine (QT_QPA_PLATFORM=offscreen, no display server); closed-form per-pixel render goldens,
+# exact layout geometry(), and injected-QTest interaction state. Qt6 is linked (carpet tests Qt); runtime
+# libs + offscreen plugin staged into the overlay. -cpu max exposes the full AArch64 feature set. -smp 1:
+# single vCPU. 1024M: Qt6 raster + font engine.
+args = [
+    "-nographic", "-cpu", "max", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/cpu-gui-qt-test/qemu-aarch64.toml
+++ b/apps/starry/cpu-gui-qt-test/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+# cpu-gui-qt-test aarch64 - "pyte for GUI widgets" offscreen/raster carpet. Real Qt Widgets/QPainter on the
+# CPU raster engine (QT_QPA_PLATFORM=offscreen, no display server); closed-form per-pixel render goldens,
+# exact layout geometry(), and injected-QTest interaction state. Qt6 is linked (carpet tests Qt); runtime
+# libs + offscreen plugin staged into the overlay. -cpu max exposes the full AArch64 feature set. -smp 1:
+# single vCPU. 1024M: Qt6 raster + font engine.
+args = [
+    "-nographic", "-cpu", "max", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000
+
+[[shell_check_steps]]
+shell_prefix = "root@starry:"
+shell_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']

--- a/apps/starry/cpu-gui-qt-test/qemu-loongarch64.toml
+++ b/apps/starry/cpu-gui-qt-test/qemu-loongarch64.toml
@@ -1,0 +1,20 @@
+# cpu-gui-qt-test loongarch64 - "pyte for GUI widgets" offscreen/raster carpet. Real Qt Widgets/QPainter on
+# the CPU raster engine (QT_QPA_PLATFORM=offscreen, no display server); closed-form per-pixel render goldens,
+# exact layout geometry(), injected-QTest interaction state. Qt6 linked (carpet tests Qt); runtime libs +
+# offscreen plugin staged into the overlay. Platform: dynamic (axplat-dyn) - build-loongarch64*.toml carries
+# ax-driver/serial and does not opt out of dynamic platform mode; the retired static LoongArch path lacked
+# the serial console binding. uefi=false / to_bin=true is the dynamic platform's raw-binary boot path.
+# -smp 1: single vCPU. 1024M: Qt6 raster + font engine.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/cpu-gui-qt-test/qemu-loongarch64.toml
+++ b/apps/starry/cpu-gui-qt-test/qemu-loongarch64.toml
@@ -1,0 +1,22 @@
+# cpu-gui-qt-test loongarch64 - "pyte for GUI widgets" offscreen/raster carpet. Real Qt Widgets/QPainter on
+# the CPU raster engine (QT_QPA_PLATFORM=offscreen, no display server); closed-form per-pixel render goldens,
+# exact layout geometry(), injected-QTest interaction state. Qt6 linked (carpet tests Qt); runtime libs +
+# offscreen plugin staged into the overlay. Platform: dynamic (axplat-dyn) - build-loongarch64*.toml carries
+# ax-driver/serial and does not opt out of dynamic platform mode; the retired static LoongArch path lacked
+# the serial console binding. uefi=false / to_bin=true is the dynamic platform's raw-binary boot path.
+# -smp 1: single vCPU. 1024M: Qt6 raster + font engine.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000
+
+[[shell_check_steps]]
+shell_prefix = "root@starry:"
+shell_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']

--- a/apps/starry/cpu-gui-qt-test/qemu-riscv64.toml
+++ b/apps/starry/cpu-gui-qt-test/qemu-riscv64.toml
@@ -1,0 +1,17 @@
+# cpu-gui-qt-test riscv64 - "pyte for GUI widgets" offscreen/raster carpet. Real Qt Widgets/QPainter on the
+# CPU raster engine (QT_QPA_PLATFORM=offscreen, no display server); closed-form per-pixel render goldens,
+# exact layout geometry(), injected-QTest interaction state. Qt6 linked (carpet tests Qt); runtime libs +
+# offscreen plugin staged into the overlay. -smp 1: single vCPU. 1024M: Qt6 raster + font engine.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/cpu-gui-qt-test/qemu-riscv64.toml
+++ b/apps/starry/cpu-gui-qt-test/qemu-riscv64.toml
@@ -1,0 +1,19 @@
+# cpu-gui-qt-test riscv64 - "pyte for GUI widgets" offscreen/raster carpet. Real Qt Widgets/QPainter on the
+# CPU raster engine (QT_QPA_PLATFORM=offscreen, no display server); closed-form per-pixel render goldens,
+# exact layout geometry(), injected-QTest interaction state. Qt6 linked (carpet tests Qt); runtime libs +
+# offscreen plugin staged into the overlay. -smp 1: single vCPU. 1024M: Qt6 raster + font engine.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000
+
+[[shell_check_steps]]
+shell_prefix = "root@starry:"
+shell_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']

--- a/apps/starry/cpu-gui-qt-test/qemu-x86_64.toml
+++ b/apps/starry/cpu-gui-qt-test/qemu-x86_64.toml
@@ -1,0 +1,21 @@
+# cpu-gui-qt-test x86_64 - the "pyte for GUI widgets" carpet: render real Qt Widgets / QPainter on the CPU
+# RASTER paint engine with the offscreen QPA platform plugin (QT_QPA_PLATFORM=offscreen, no display server),
+# asserting CLOSED-FORM goldens: exact per-pixel fillRect/drawLine/drawEllipse coverage, Porter-Duff "over"
+# alpha compositing per pixel, exact QVBox/QHBox/QGrid geometry() layout math, and post-event widget state
+# from injected QTest mouse/key events. Qt6 is linked (the carpet TESTS Qt, it does not reimplement widgets);
+# the runtime libs + offscreen plugin are staged into the overlay by prebuild. No GPU, no display.
+# -smp 1: single vCPU. 1024M: Qt6 raster + font engine need more than a text parser.
+args = [
+    "-machine", "q35",
+    "-nographic", "-cpu", "Haswell", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 20000

--- a/apps/starry/cpu-gui-qt-test/qemu-x86_64.toml
+++ b/apps/starry/cpu-gui-qt-test/qemu-x86_64.toml
@@ -1,0 +1,23 @@
+# cpu-gui-qt-test x86_64 - the "pyte for GUI widgets" carpet: render real Qt Widgets / QPainter on the CPU
+# RASTER paint engine with the offscreen QPA platform plugin (QT_QPA_PLATFORM=offscreen, no display server),
+# asserting CLOSED-FORM goldens: exact per-pixel fillRect/drawLine/drawEllipse coverage, Porter-Duff "over"
+# alpha compositing per pixel, exact QVBox/QHBox/QGrid geometry() layout math, and post-event widget state
+# from injected QTest mouse/key events. Qt6 is linked (the carpet TESTS Qt, it does not reimplement widgets);
+# the runtime libs + offscreen plugin are staged into the overlay by prebuild. No GPU, no display.
+# -smp 1: single vCPU. 1024M: Qt6 raster + font engine need more than a text parser.
+args = [
+    "-machine", "q35",
+    "-nographic", "-cpu", "Haswell", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = true
+to_bin = true
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 20000
+
+[[shell_check_steps]]
+shell_prefix = "root@starry:"
+shell_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']

--- a/apps/starry/cpu-gui-qt-test/tools/gen_goldens.py
+++ b/apps/starry/cpu-gui-qt-test/tools/gen_goldens.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""gen_goldens.py - reproduce the closed-form goldens the cpu-gui-qt-test cells assert against.
+
+The carpet does not read golden files at runtime: every expected value is computed in-code from first
+principles. This tool exists to (a) document those closed forms in one place and (b) let a reviewer
+re-derive the exact constants (Porter-Duff "over" result of red@128 over opaque green, the pi*r^2 ellipse
+coverage bound, the layout offsets) independently of the C++ source. Run it and compare against the
+constants in programs/carpets/gui_*.cpp.
+"""
+import math
+
+
+def pd_over(src, dst):
+    """Straight-alpha Porter-Duff 'source over destination'. src/dst are (r,g,b,a) 0..255.
+    Returns the composited (r,g,b,a) rounded to ints - the exact form QPainter's default
+    CompositionMode_SourceOver produces and gui_render.cpp::leg_alpha checks per pixel."""
+    sr, sg, sb, sa = src
+    dr, dg, db, da = dst
+    sa_f, da_f = sa / 255.0, da / 255.0
+    oa = sa_f + da_f * (1.0 - sa_f)
+    def chan(sc, dc):
+        if oa <= 0:
+            return 0
+        return round((sc * sa_f + dc * da_f * (1.0 - sa_f)) / oa)
+    return (chan(sr, dr), chan(sg, dg), chan(sb, db), round(oa * 255.0))
+
+
+def render_goldens():
+    print("== gui_render goldens ==")
+    # fillRect(20,15,40,30): exact covered-pixel count
+    print(f"fillRect covered pixels = {40*30}  (expect 1200)")
+    # drawLine horizontal x=10..49 inclusive, interior sampled 12..47 -> 36 hits
+    print(f"drawLine h interior hits (x=12..47) = {47-12+1}  (expect 36)")
+    print(f"drawLine v interior hits (y=7..52)  = {52-7+1}  (expect 46)")
+    # ellipse: diameter 100 -> r=50, area ~ pi*r^2, tolerance 6%
+    r = 50.0
+    area = math.pi * r * r
+    print(f"ellipse area pi*r^2 = {area:.1f}  (tol 6% -> [{area*0.94:.0f},{area*1.06:.0f}])")
+    # Porter-Duff over: red@128 over opaque green
+    out = pd_over((255, 0, 0, 128), (0, 255, 0, 255))
+    print(f"alpha over red@128 on green(255) = RGBA{out}")
+
+
+def layout_goldens():
+    print("== gui_layout goldens ==")
+    # vbox: M=9 S=7 CW=120 CH=30, 3 children
+    M, S, CW, CH = 9, 7, 120, 30
+    ys = [M + i * (CH + S) for i in range(3)]
+    print(f"vbox child y offsets = {ys}  (x={M}, {CW}x{CH})")
+    print(f"vbox sizeHint height = {M + 3*CH + 2*S + M}")
+    # hbox: M=5 S=11 CW=40 CH=50, 4 children
+    M, S, CW, CH = 5, 11, 40, 50
+    xs = [M + i * (CW + S) for i in range(4)]
+    print(f"hbox child x offsets = {xs}  (y={M}, {CW}x{CH})")
+    print(f"hbox sizeHint width  = {M + 4*CW + 3*S + M}")
+    # grid: M=8 HS=6 VS=10 CW=60 CH=40, 2x2
+    M, HS, VS, CW, CH = 8, 6, 10, 60, 40
+    cells = {(r, c): (M + c*(CW+HS), M + r*(CH+VS)) for r in range(2) for c in range(2)}
+    print(f"grid cell origins = {cells}")
+    print(f"grid sizeHint = {(M + 2*CW + HS + M, M + 2*CH + VS + M)}")
+    # resize stretch: host 200x300, M=10 S=8, two equal expanders
+    M, S = 10, 8
+    usable = 300 - 2*M - S
+    print(f"resize(200x300) usable height = {usable}, half = {usable//2}, fill width = {200-2*M}")
+    usable2 = 500 - 2*M - S
+    print(f"resize(200x500) usable height = {usable2}")
+
+
+def interact_goldens():
+    print("== gui_interact goldens ==")
+    print("button: click count 1 then 2; disabled click -> 0")
+    print("checkbox: unchecked -> click -> checked -> click -> unchecked; indicator pixels differ")
+    print("lineedit: keyClicks 'hello'; backspace -> 'hell'; ctrl-a + 'world' -> 'world'")
+    # slider: range 0..100, single=5 page=20, start 50
+    v = 50
+    v += 5; print(f"slider Key_Right -> {v}")
+    v -= 5; print(f"slider Key_Left  -> {v}")
+    v += 20; print(f"slider PageUp    -> {v}")
+    print("slider Home -> 0 ; End -> 100")
+
+
+if __name__ == "__main__":
+    render_goldens()
+    print()
+    layout_goldens()
+    print()
+    interact_goldens()


### PR DESCRIPTION
## 概述

`apps/starry/cpu-gui-qt-test`：Qt Widgets 经 raster paint engine 与 offscreen QPA 渲染的 GUI carpet，无显示服务器、无 GPU。断言对照逐像素闭式结果、精确布局几何与真实事件注入后的状态；Qt 负责 toolkit，只有比对与 golden 自写。

## Cells 与断言

| cell | 断言 | 数量 |
|:--:|:--:|:--:|
| `gui_render` | fillRect 内部与边缘像素、drawLine 覆盖、drawEllipse 中心与面积、Porter-Duff over、QLabel grab、文本墨迹落在 bbox 内 | 41 |
| `gui_layout` | QVBox/QHBox/QGrid 子控件 geometry 等于闭式偏移，resize 后重布局，sizeHint | 24 |
| `gui_interact` | mouseClick 触发 handler（含禁用按钮对照）、QCheckBox 状态与指示器像素、QLineEdit 按键编辑、QSlider 步进 | 16 |
| `gui_realassets` | 字体存在，真实 .ttf 载入后注册 family 并画出墨迹 | 9 |

字体放在 git submodule（`Lfan-ke/hw4os-s5d1t2` 的 `media` 分支，git-LFS），经 `ASSET_DIR` 引用。

## 本次修改

- Alpine Qt6 库带 `.relr.dyn`，GCC 11 工具链的 GNU ld 读不了：链接探测失败后先用 `ld.lld` 重试，再退到 zig。
- Alpine edge 的 Qt 引用了 GCC 13 以后才有的 libstdc++ 符号（如 `std::__glibcxx_assert_fail`），交叉链自带的 libstdc++ 没有：g++ 链接行显式带上 staging 中的 `libstdc++.so.6`。
- edge 的 libQt6Core 需要新 musl 导出的 `renameat2`：apk 改为 `add --upgrade`，并把 `ld-musl`、`libc.musl` 放进 overlay。
- `gui_realassets` 缺字体时不再算通过，prebuild 找不到 .ttf 时 exit 5。
- `qemu-x86_64.toml` 改为 `uefi = true`、`to_bin = true`。

x86_64 QEMU（基线 dev 802e3de4）：4/4 cell 通过，共 90 条断言，`TEST PASSED`。

> **特殊声明：素材仅用于 OS 功能完整性与正确性验证，不作他用。有事请找 @Lfan-ke**
