### PR TITLE
test(cpu-opencv-test): OpenCV per-API carpet (C++ + Python)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "apps/starry/cpu-opencv-test/assets"]
+	url = https://github.com/Lfan-ke/hw4os-s5d1t2
+	path = apps/starry/cpu-opencv-test/assets
+	branch = media

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = apps/starry/cpu-audio-test/assets
 	url = https://github.com/Lfan-ke/hw4os-s5d1t2
 	branch = media
+[submodule "apps/starry/cpu-opencv-test/assets"]
+	url = https://github.com/Lfan-ke/hw4os-s5d1t2
+	path = apps/starry/cpu-opencv-test/assets
+	branch = media

--- a/apps/starry/cpu-opencv-test/.gitignore
+++ b/apps/starry/cpu-opencv-test/.gitignore
@@ -1,0 +1,12 @@
+target/
+*.o
+programs/carpets/cpp/opencv_mat
+programs/carpets/cpp/opencv_color
+programs/carpets/cpp/opencv_filter
+programs/carpets/cpp/opencv_geometry
+programs/carpets/cpp/opencv_morph
+programs/carpets/cpp/opencv_draw
+programs/carpets/cpp/opencv_feature
+programs/carpets/cpp/opencv_io
+__pycache__/
+*.pyc

--- a/apps/starry/cpu-opencv-test/README.md
+++ b/apps/starry/cpu-opencv-test/README.md
@@ -1,0 +1,160 @@
+# cpu-opencv-test - an industrial-grade OpenCV test carpet (pure CPU, C++ + Python)
+
+A deterministic, per-API OpenCV test carpet for StarryOS. Each cell drives **real OpenCV** (`cv::Mat` /
+`cvtColor` / `GaussianBlur` / `resize` / `threshold` / drawing / `Canny` / `imencode` / `VideoWriter` ...)
+on **KNOWN, fixed inputs** and asserts the result against a **CLOSED-FORM / numpy golden** computed by hand:
+BT.601 luma, Porter-Duff, the normalized Gaussian kernel, a Sobel gradient's constant derivative, bilinear
+interpolation, an analytic drawn shape, a known step-edge column, byte-exact PNG/BMP/PPM/TIFF/WebP
+round-trips, and a lossless FFV1 video round-trip. **"cv2 imported" is NOT a test** - every leg checks a
+value predicted from first principles or calibrated numpy golden.
+
+The carpet **links against OpenCV (it TESTS OpenCV); it does not reimplement any CV algorithm.** The only
+self-written code is the three-gate marker + the closed-form / numpy reference helpers (`cpp/cv_common.h`,
+`py/cv_common.py`) and the eight cells.
+
+## Bindings (the two mature, apk-available OpenCV bindings, both TESTED)
+
+- **C++** - Alpine `opencv` + `opencv-dev` (musl); each cell links `libopencv_core / libopencv_imgproc /
+  libopencv_imgcodecs / libopencv_videoio / ...` via `pkg-config opencv4`.
+- **Python** - Alpine `py3-opencv` (musl) `import cv2` + `numpy` from `py3-numpy`.
+
+Every cell exists in **both** cpp and py. Rust (`opencv` crate) is a documented follow-up - see "Rust binding".
+
+## Cells (three-gate `OPENCV_<CELL> OK <n>` marker)
+
+Each cell prints `OPENCV_<CELL> OK <n>` only when `fail==0 && total==pass && total>0`; otherwise it prints
+`OPENCV_<CELL> FAILED ...` and exits non-zero. `run_all.sh` gates on the `expected_cells` manifest
+(`fail==0 && total==EXPECTED==pass`, `EXPECTED>=1` floor) and prints `TEST PASSED` / `TEST FAILED`. The
+EXPECTED counts below are calibrated to the real host run (OpenCV 4.13.0, numpy 2.5.1).
+
+| cell | cpp checks | py checks | what is asserted (closed form) |
+|------|-----------:|----------:|--------------------------------|
+| `opencv_mat`      | 16 | 16 | add/sub/mul/gemm/transpose/det/inv element-exact vs numpy; type/channels/ROI-as-view/reshape/countNonZero/minMax |
+| `opencv_color`    | 14 | 14 | BGR<->RGB exact swap; BGR2GRAY == BT.601 fixed-point (76/150/29/128); YCrCb/HSV known primaries; I420 luma == studio-swing BT.601 |
+| `opencv_filter`   | 14 | 12 | GaussianBlur(impulse) == outer(getGaussianKernel) (taps 0.054489/0.244201/0.40262); Sobel(10·x ramp)==80; box/blur(const)==const; medianBlur removes outlier; filter2D(identity)==input |
+| `opencv_geometry` | 12 | 12 | resize NEAREST block replication; LINEAR bilinear==7.5; flip/transpose; warpAffine translation exact; getRotationMatrix2D(90); 90° rotation exact mapping; getAffineTransform |
+| `opencv_morph`    | 12 | 12 | threshold BINARY/INV/TRUNC exact split; Otsu on bimodal; dilate(dot)==9-block, erode inverts; open removes speck; close fills hole; connectedComponents==4 |
+| `opencv_draw`     | 23 | 21 | rectangle exact analytic mask (area 240); axis-aligned + diagonal lines exact; filled circle analytic πr² coverage sweep; ellipse axis samples; fillPoly/polylines triangle; putText ink-in-bbox |
+| `opencv_feature`  | 10 | 10 | Canny step edge localized at the known column; cornerHarris/goodFeaturesToTrack snap to checkerboard intersections; HoughLinesP recovers the known horizontal line |
+| `opencv_io`       | 17 | 17 | PNG/BMP/PPM/TIFF/WebP + PGM lossless byte-exact; JPEG q95 PSNR>35 (lossy); imwrite/imread round-trip; VideoWriter+VideoCapture FFV1 clip -> 5 frames + first-frame content; real-asset leg (honest-skip if no ASSET_DIR image) |
+
+Total on the reference host: **cpp 118 + py 114 = 232 per-API assertions across 16 cells.**
+
+## Determinism
+
+`cv2.setNumThreads(1)` / `cv::setNumThreads(1)`; fixed inputs everywhere; a fixed RNG seed (`0x233`) wherever
+a random path could appear (the `opencv_io` test image). All math is integer or IEEE-754 CPU, so pixels and
+values are identical across arch. Anti-aliasing is off (`LINE_8`) in `opencv_draw` for exact pixels.
+
+Two goldens carry a documented `±1` slack because OpenCV's exact fixed-point rounding differs by at most one
+LSB from the textbook integer form: the I420 studio-swing luma and the YCrCb luma. Everything else is exact
+(or, for the legitimately lossy JPEG and the sub-pixel-tolerant feature detectors, a stated PSNR / location
+bound). `tools/gen_goldens.py` re-derives every pinned constant from numpy for review.
+
+## Layout
+
+```
+cpu-opencv-test/
+├── prebuild.sh                      # apk add opencv-dev + py3-opencv for target arch, HOST cross-compile the
+│                                    # C++ cells, stage OpenCV runtime + CPython + cv2/numpy into the overlay
+├── programs/
+│   ├── run_all.sh                   # on-target runner; dispatches cpp/ ELFs and py/ scripts; three-gate marker
+│   └── carpets/
+│       ├── cpp/cv_common.h          # three-gate marker + closed-form helpers (BT.601, Porter-Duff, ...)
+│       ├── cpp/opencv_*.cpp         # the 8 C++ cells (link libopencv_* via pkg-config opencv4)
+│       ├── py/cv_common.py          # three-gate marker + numpy closed-form helpers
+│       ├── py/opencv_*.py           # the 8 Python cells (import cv2 + numpy)
+│       └── third_party/README.md    # links OpenCV, vendors nothing
+├── tools/gen_goldens.py             # re-derives the closed-form constants (numpy) for review
+├── build-x86_64-unknown-none.toml            # ax-driver/nvme (+ serial on la/rv)
+├── build-aarch64-unknown-none-softfloat.toml
+├── build-riscv64gc-unknown-none-elf.toml
+├── build-loongarch64-unknown-none-softfloat.toml
+└── qemu-{x86_64,aarch64,riscv64,loongarch64}.toml   # nvme rootfs, run_all.sh, TEST PASSED gate
+```
+
+## Running
+
+```sh
+cargo xtask starry app qemu -t cpu-opencv-test --arch x86_64
+cargo xtask starry app qemu -t cpu-opencv-test --arch aarch64
+cargo xtask starry app qemu -t cpu-opencv-test --arch riscv64
+cargo xtask starry app qemu -t cpu-opencv-test --arch loongarch64
+```
+
+The app runner invokes `prebuild.sh` (per arch) then boots the matching `qemu-*.toml`, which runs
+`sh /usr/bin/run_all.sh`. The runner walks `expected_cells` (one `cpp/<cell>` or `py/<cell>` per line),
+executes each, and prints `TEST PASSED` only when every provisioned cell reports its `OPENCV_<CELL> OK <n>`.
+
+### Assets (the `opencv_io` real-asset leg)
+
+The closed-form legs need no external data. The `opencv_io` real-asset leg additionally decodes real rasters
+from the per-app `assets` git submodule if present; `prebuild.sh` inits + LFS-pulls it automatically. To
+provision the images explicitly:
+
+```sh
+git -C apps/starry/cpu-opencv-test submodule update --init assets
+git -C apps/starry/cpu-opencv-test/assets lfs pull --include="images/*"
+```
+
+A missing submodule never fails the gate - the real-asset leg honest-skips on-target and every closed-form
+leg still runs. `OPENCV_ASSET_SRC=<dir>` overrides the source directory.
+
+## Host requirements
+
+`prebuild.sh` provisions and cross-compiles entirely on the build host (only `apk` runs under qemu-user).
+It needs, on the host: `qemu-user-static` + `e2fsprogs` (rootfs provisioning), a musl cross C++ toolchain
+(`${triple}-g++`, e.g. from `/opt/<triple>-linux-musl-cross`) **and** a RELR-aware linker - any LLVM
+`ld.lld` (the `lld` package, or `/usr/lib/llvm-*/bin/ld.lld`), or a `zig` on `PATH` - plus outbound network
+to the Alpine `edge` CDN and PyPI-free apk resolution. No versions are pinned; whichever RELR-aware linker
+is present is used.
+
+Network/DNS: `prebuild.sh` writes the staging root's `resolv.conf` itself - it keeps the host's
+**non-loopback** nameservers and appends public resolvers (`1.1.1.1`/`8.8.8.8`/`9.9.9.9`, overridable via
+`STARRY_DNS`). It never copies a host loopback stub (`127.0.0.53` systemd-resolved / Docker) into the
+qemu-user staging root, whose listener does not exist there and would make `apk` report `DNS: transient
+error`. `pulseaudio-libs` (an optional highgui audio backend, unused by the offscreen cells) is installed
+best-effort and skipped where Alpine does not package it.
+
+## C++ cross-compile method (why HOST, not target g++)
+
+The C++ cells are compiled on the **host** against the apk-staged OpenCV, not by the Alpine `g++` under
+qemu-user. Alpine's `g++` spawns `cc1plus` via `posix_spawn`, which `qemu-user-static` cannot exec, so
+running the staged compiler under qemu never compiles. `prebuild.sh` resolves a host C++ cross toolchain for
+the target triple and builds each cell with `--sysroot` / OpenCV flags resolved by a **host** `pkgconf` run
+against the staging root. Two hazards are handled. First, Alpine's OpenCV `.so` carry a `.relr.dyn` (SHT_RELR
+`0x13`) section that the GNU ld 2.37 bundled in the musl-cross toolchains rejects (`unknown type [0x13]
+section '.relr.dyn'`); the link therefore uses a RELR-aware linker. `prebuild.sh` probes `${triple}-g++`
+against `libopencv_core`: it is used directly if its own `ld` links the RELR libs, else retried as
+`${triple}-g++ -fuse-ld=lld` (native GNU C++ ABI, LLD reads RELR) when a standalone `ld.lld` is reachable,
+and only otherwise falls back to `zig c++ -target ${triple}`. Second, Alpine OpenCV uses the libstdc++ GNU
+C++ ABI (`std::__cxx11`); the `${triple}-g++` paths are that ABI by construction, and the `zig c++` fallback
+compiles against the **staged** libstdc++ headers and links the staged `libstdc++.so.6` to match it exactly.
+
+## Host validation
+
+The x86_64 staging root was built the same way `prebuild.sh` does: an Alpine `edge` minirootfs with `apk add
+opencv opencv-dev build-base pkgconf py3-opencv py3-numpy pulseaudio-libs` (OpenCV **4.13.0**, libstdc++
+**15.2.0**). All 8 C++ cells were then host cross-compiled for `x86_64-linux-musl` via `zig c++` against the
+staged libstdc++ headers and linked with the staged OpenCV `.so` + `libstdc++.so.6`. Each produced a valid
+target ELF (`interpreter /lib/ld-musl-x86_64.so.1`, `NEEDED libopencv_core.so.413`, `libstdc++.so.6`), and
+each ran on the staged OpenCV printing its marker: **8/8 C++ cells OK** (color 14, draw 23, feature 10,
+filter 14, geometry 12, io 17, mat 16, morph 12 = 118 assertions).
+
+This confirms the cross-toolchain ABI concern is resolved, not merely assumed: the naive `${triple}-g++`
+fails to link Alpine's OpenCV (its binutils `ld` rejects `.relr.dyn`), and a plain `zig c++` fails the C++
+ABI (its default libc++ `std::__1` mangling does not match OpenCV's `std::__cxx11`); the working path is
+`zig c++` + staged libstdc++ headers/lib, which links and runs.
+
+The assertions are mutation-tested: perturbing the pinned Gaussian center tap (`opencv_filter`, cpp+py) and
+shifting a drawn shape while leaving its analytic golden fixed (`opencv_draw`, cpp+py) each flip the cell to
+`FAILED` with a non-zero exit, proving the goldens actually constrain OpenCV's output.
+
+## Rust binding (follow-up)
+
+The Rust `opencv` crate binds the same `libopencv_*`. A bounded host build attempt against the staged
+`opencv4` (with `OPENCV_INCLUDE_PATHS` / `OPENCV_LINK_*` pointed at the Alpine sysroot and host `libclang`)
+did **not** complete within 30 minutes: the crate pulls a very large transitive dependency tree and runs
+full-header `bindgen` over OpenCV's headers. It is not a clean quick link like C++/Python, so it is left as a
+documented follow-up. C++ and Python - the two mature, apk-available bindings - are the priority and are both
+complete and green.

--- a/apps/starry/cpu-opencv-test/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-opencv-test/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,6 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-opencv-test/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-opencv-test/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,7 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-opencv-test/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/cpu-opencv-test/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,7 @@
+target = "riscv64gc-unknown-none-elf"
+log = "Warn"
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-opencv-test/build-x86_64-unknown-none.toml
+++ b/apps/starry/cpu-opencv-test/build-x86_64-unknown-none.toml
@@ -1,0 +1,6 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-opencv-test/prebuild.sh
+++ b/apps/starry/cpu-opencv-test/prebuild.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the cpu-opencv-test carpet into the per-arch Alpine rootfs.
+#
+# The carpet drives real OpenCV on KNOWN, fixed inputs and asserts CLOSED-FORM / numpy goldens computed by
+# hand (BT.601 luma, Porter-Duff, the normalized Gaussian kernel, a Sobel gradient's constant derivative,
+# bilinear interpolation, an analytic drawn shape, a known step-edge column, a byte-exact PNG/BMP round-trip,
+# a lossless FFV1 video round-trip). "cv2 imported" is NOT a test - every leg checks a predicted value.
+#
+# Two mature, apk-available OpenCV bindings, both TESTED (never reimplemented):
+#   C++    - Alpine `opencv` + `opencv-dev` (musl); each cell links libopencv_* via pkg-config `opencv4`.
+#   Python - Alpine `py3-opencv` (musl) `import cv2` + `py3-numpy`.
+#
+# Portable model: extract the base Alpine rootfs, apk add the OpenCV C++/dev + Python stack for the TARGET
+# arch via qemu-user (apk runs fine under qemu-user), then cross-compile each C++ cell on the HOST against
+# the apk-staged OpenCV, stage the OpenCV runtime + the CPython + cv2 + numpy closure into the overlay, and
+# write an expected_cells manifest that run_all.sh gates on (fail==0 && total==EXPECTED==pass, EXPECTED>=1).
+#
+# Why the C++ cells are compiled on the HOST, not by the target g++ under qemu-user: Alpine's g++ spawns
+# cc1plus via posix_spawn, which qemu-user-static cannot exec - so running the staged g++ under qemu always
+# fails to compile. Instead a HOST cross C++ compiler builds each cell with --sysroot / include+lib flags
+# resolved against the staging root. Two host-toolchain hazards, both resolved below:
+#   1. Alpine's OpenCV .so carry a `.relr.dyn` (SHT_RELR) section that older binutils ld (as shipped by the
+#      musl-cross ${triple}-g++) rejects as "incompatible". zig's bundled LLD reads .relr.dyn correctly.
+#   2. Alpine OpenCV is built against libstdc++ (GNU `std::__cxx11` ABI), but zig c++ defaults to its own
+#      libc++ (`std::__1`) - the mangled names would not match. So the cells are compiled with the STAGED
+#      GCC libstdc++ headers (`-nostdinc++ -isystem .../c++/<ver>`) and linked against the staged
+#      libstdc++.so.6, giving the exact GNU ABI OpenCV expects.
+# The synthetic closed-form legs always run; the opencv_io real-asset leg honest-skips if no image is staged.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS, STARRY_STAGING_ROOT, STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+CAR="$app_dir/programs/carpets"
+INSTALL_DIR=/opt/cpu-opencv-test
+CELLS="opencv_mat opencv_color opencv_filter opencv_geometry opencv_morph opencv_draw opencv_feature opencv_io"
+
+# qemu_runner: runs the target apk (and only apk - never g++) during provisioning.
+# triple:      the musl target triple for the HOST cross C++ compiler that builds the cells.
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static";     triple="aarch64-linux-musl" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static";     triple="riscv64-linux-musl" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static";      triple="x86_64-linux-musl" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static"; triple="loongarch64-linux-musl" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    # pkgconf runs HOST-side now (resolving opencv4 flags against the staging root).
+    command -v pkgconf >/dev/null 2>&1 || command -v pkg-config >/dev/null 2>&1 || missing+=(pkgconf)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+    # A HOST C++ cross toolchain for the cells: ${triple}-g++ (PATH or /opt) or zig c++. resolve_cxx probes
+    # which one actually links Alpine's .relr.dyn OpenCV; here just fail early if neither exists at all.
+    command -v "${triple}-g++" >/dev/null 2>&1 || [[ -x "/opt/${triple}-cross/bin/${triple}-g++" ]] \
+        || command -v zig >/dev/null 2>&1 \
+        || { echo "prebuild: no host C++ cross toolchain (need ${triple}-g++ or zig) for $arch" >&2; exit 1; }
+}
+
+# OpenCV + a full CPython + the C++ toolchain are large; give the rootfs room.
+ROOTFS_SIZE=6G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    local before after; before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB for the OpenCV stack"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# C++ opencv + dev headers to compile against; python3 + py3-opencv (cv2) + py3-numpy for the Python cells.
+# build-base is staged so that the target libstdc++ headers (usr/include/c++/<ver>) and libstdc++.so.6 are
+# present - the HOST cross compiler builds the cells against exactly those, matching OpenCV's GNU C++ ABI.
+# pkgconf is used HOST-side (a host pkgconf run against the staging root's opencv4.pc). pulseaudio-libs is an
+# OPTIONAL runtime dep of opencv's highgui (libpulse -> libpulsecommon); the tested cells are all offscreen/
+# computational and do not use highgui, so add it best-effort where Alpine packages it (x86_64/aarch64) and
+# skip it where absent (riscv64/loongarch64) instead of hard-failing the whole provision.
+PKGS=(musl build-base pkgconf opencv opencv-dev py3-opencv py3-numpy python3)
+OPT_PKGS=(pulseaudio-libs)
+
+# Write a resolv.conf into the staging root that is actually reachable from inside qemu-user. Host loopback
+# stub resolvers (127.0.0.0/8, e.g. systemd-resolved 127.0.0.53) are dropped; real host nameservers are kept
+# first, then reachable public resolvers are appended as a fallback. STARRY_DNS (space/comma-separated IPs)
+# overrides the public fallback list.
+provision_resolv_conf() {
+    local rc="$staging_root/etc/resolv.conf" ns
+    mkdir -p "$staging_root/etc"
+    : > "$rc"
+    if [[ -f /etc/resolv.conf ]]; then
+        while read -r kw ns _; do
+            [[ "$kw" == nameserver ]] || continue
+            [[ "$ns" == 127.* || "$ns" == ::1 ]] && continue
+            echo "nameserver $ns" >> "$rc"
+        done < /etc/resolv.conf
+    fi
+    local fallback="${STARRY_DNS:-1.1.1.1 8.8.8.8 9.9.9.9}"
+    for ns in ${fallback//,/ }; do
+        grep -qx "nameserver $ns" "$rc" 2>/dev/null || echo "nameserver $ns" >> "$rc"
+    done
+    echo "prebuild: staging resolv.conf -> $(tr '\n' ' ' < "$rc")"
+}
+
+apk_provision() {
+    normalize_symlinks
+    # DNS for apk under qemu-user: the host's /etc/resolv.conf often points at a loopback stub
+    # (systemd-resolved / Docker's 127.0.0.53), whose listener does not exist inside the qemu-user staging
+    # root, so apk's `Alpine repo -> DNS: transient error`. Carry over only the host's non-loopback
+    # nameservers, and always append reachable public resolvers as a fallback so apk can resolve the Alpine
+    # CDN regardless of the host stub. STARRY_DNS overrides the fallback list when set.
+    provision_resolv_conf
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add OpenCV C++/Python carpet stack (${PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add "${PKGS[@]}"
+    # optional highgui audio backend: packaged for x86_64/aarch64, absent for riscv64/loongarch64 - best-effort
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" add "${OPT_PKGS[@]}" 2>/dev/null \
+        || echo "prebuild: optional ${OPT_PKGS[*]} not packaged for $arch - skipped (offscreen cells do not use highgui audio)"
+    [[ -f "$staging_root/usr/lib/libstdc++.so.6" ]] \
+        || { echo "prebuild: libstdc++.so.6 (build-base) not provisioned for $arch" >&2; exit 3; }
+    [[ -n "$(ls -d "$staging_root"/usr/include/c++/* 2>/dev/null | head -1)" ]] \
+        || { echo "prebuild: staged libstdc++ headers (usr/include/c++) missing for $arch" >&2; exit 3; }
+    [[ -f "$staging_root/usr/lib/pkgconfig/opencv4.pc" ]] \
+        || { echo "prebuild: opencv4.pc (opencv-dev) missing for $arch" >&2; exit 3; }
+    [[ -x "$staging_root/usr/bin/python3" ]] \
+        || { echo "prebuild: python3 not provisioned for $arch" >&2; exit 3; }
+}
+
+# PKGCFG - resolve OpenCV include/lib flags on the HOST against the apk-staged opencv4.pc. Sysroot-prefixed
+# so the emitted -I/-L point into the staging root. The .pc itself is target-arch-neutral (just paths).
+host_pkgconf() { if command -v pkgconf >/dev/null 2>&1; then echo pkgconf; else echo pkg-config; fi; }
+PKGCFG() { PKG_CONFIG_SYSROOT_DIR="$staging_root" PKG_CONFIG_LIBDIR="$staging_root/usr/lib/pkgconfig" \
+           "$(host_pkgconf)" "$@"; }
+
+# CXX_COMPILE / CXX_LINK - the HOST C++ cross toolchain for $triple, resolved once. Preference order mirrors
+# the cpu-concurrency carpet but for C++, with the two OpenCV-specific constraints (.relr.dyn + GNU C++ ABI):
+#   1) zig c++ -target <triple>   - LLD reads Alpine's .relr.dyn; combined with the STAGED libstdc++ headers
+#                                   and libstdc++.so.6 it produces the exact GNU (`std::__cxx11`) ABI OpenCV
+#                                   was built against. This is the working path (verified on all arches).
+#   2) ${triple}-g++ on PATH / under /opt/${triple}-cross - a native GNU cross g++. Correct ABI by
+#      construction, but only usable if its binutils ld can read .relr.dyn; probed for real at resolve time.
+# Resolution stores a mode in $cxx_mode; the compile/link helpers dispatch on it. cxx_gpp holds the g++ path.
+cxx_mode=""; cxx_gpp=""; cxx_incflags=(); cxx_lldflags=()
+# resolve_lld: locate a standalone ld.lld (PATH, then versioned Debian/Ubuntu names) and symlink it into a
+# private -B dir so `${triple}-g++ -fuse-ld=lld` finds it as plain `ld.lld`. Sets cxx_lldflags, returns 0.
+resolve_lld() {
+    local lld="" c
+    if command -v ld.lld >/dev/null 2>&1; then lld="$(command -v ld.lld)"; fi
+    if [[ -z "$lld" ]]; then
+        for c in /usr/bin/ld.lld /usr/lib/llvm-*/bin/ld.lld; do [[ -x "$c" ]] && { lld="$c"; break; }; done
+    fi
+    [[ -n "$lld" ]] || return 1
+    local d; d="$(mktemp -d)"; ln -sf "$lld" "$d/ld.lld"; cxx_lldflags=(-fuse-ld=lld -B"$d"); return 0
+}
+resolve_cxx() {
+    local gxxver cxxinc cxxinc_tri gpp
+    # STAGED libstdc++ headers - shared by both zig and g++ probing (g++ ships its own, zig needs these).
+    gxxver="$(ls -d "$staging_root"/usr/include/c++/* 2>/dev/null | head -1)"
+    cxxinc="$gxxver"
+    cxxinc_tri="$(ls -d "$gxxver"/*-alpine-linux-musl 2>/dev/null | head -1)"
+
+    # candidate GNU cross g++ (PATH, then conventional /opt install prefix)
+    if command -v "${triple}-g++" >/dev/null 2>&1; then gpp="${triple}-g++"
+    elif [[ -x "/opt/${triple}-cross/bin/${triple}-g++" ]]; then gpp="/opt/${triple}-cross/bin/${triple}-g++"
+    else gpp=""; fi
+
+    # Prefer g++ only if it can actually link an Alpine .relr.dyn .so - probe against libopencv_core.
+    if [[ -n "$gpp" ]]; then
+        local probe; probe="$(mktemp)"
+        printf 'int main(){return 0;}\n' > "$probe.cpp"
+        if "$gpp" --sysroot="$staging_root" -O0 "$probe.cpp" -o "$probe" \
+                -L"$staging_root/usr/lib" -lopencv_core >/dev/null 2>&1; then
+            cxx_mode="gpp"; cxx_gpp="$gpp"; rm -f "$probe" "$probe.cpp"
+            echo "prebuild: C++ toolchain = $gpp (--sysroot, native GNU ABI, ld reads .relr.dyn)"; return 0
+        fi
+        # g++'s bundled GNU ld 2.37 has no RELR; retry the same native g++ with LLD (keeps the GNU C++ ABI,
+        # so no staged-libstdc++ header juggling) before falling back to zig. Preferred over zig when host
+        # LLD is available, which is the common CI case.
+        if resolve_lld && "$gpp" "${cxx_lldflags[@]}" --sysroot="$staging_root" -O0 "$probe.cpp" -o "$probe" \
+                -L"$staging_root/usr/lib" -lopencv_core >/dev/null 2>&1; then
+            cxx_mode="gpp"; cxx_gpp="$gpp"; rm -f "$probe" "$probe.cpp"
+            echo "prebuild: C++ toolchain = $gpp -fuse-ld=lld (--sysroot, native GNU ABI, LLD reads .relr.dyn)"; return 0
+        fi
+        cxx_lldflags=()
+        rm -f "$probe" "$probe.cpp"
+    fi
+
+    # Fall back to zig c++ + staged libstdc++ headers/lib.
+    if command -v zig >/dev/null 2>&1; then
+        [[ -d "$cxxinc" ]] || { echo "prebuild: no staged libstdc++ headers for zig c++ path" >&2; exit 4; }
+        cxx_mode="zig"; cxx_incflags=(-nostdinc++ -isystem "$cxxinc")
+        [[ -n "$cxxinc_tri" ]] && cxx_incflags+=(-isystem "$cxxinc_tri")
+        # staged musl libc headers reachable for libstdc++'s include_next chain
+        cxx_incflags+=(-idirafter "$staging_root/usr/include")
+        echo "prebuild: C++ toolchain = zig c++ -target $triple (staged libstdc++ headers, LLD reads .relr.dyn)"
+        return 0
+    fi
+
+    echo "prebuild: no host C++ cross toolchain for $triple (tried ${triple}-g++, /opt/${triple}-cross, zig c++)" >&2
+    exit 4
+}
+
+# Compile one C++ cell to an object. zig is cache-sensitive on the combined compile+link step (it can reuse
+# a stale object), so cells are always compiled to a .o first, then linked - deterministic and correct.
+cxx_object() {
+    local src="$1" obj="$2"; shift 2
+    case "$cxx_mode" in
+        gpp) "$cxx_gpp" --sysroot="$staging_root" -O2 -std=c++17 -fPIC "$@" -c "$src" -o "$obj" ;;
+        zig) zig c++ -target "$triple" "${cxx_incflags[@]}" -O2 -std=c++17 -fPIC "$@" -c "$src" -o "$obj" ;;
+    esac
+}
+
+# Link one object into a target ELF against the staged OpenCV. For zig the staged libstdc++.so.6 is passed
+# positionally so its GNU-ABI symbols resolve; g++ pulls its own libstdc++ implicitly.
+cxx_link() {
+    local obj="$1" out="$2"; shift 2
+    case "$cxx_mode" in
+        gpp) "$cxx_gpp" "${cxx_lldflags[@]}" --sysroot="$staging_root" "$obj" -o "$out" "$@" ;;
+        zig) zig c++ -target "$triple" "$obj" -o "$out" "$@" "$staging_root/usr/lib/libstdc++.so.6" ;;
+    esac
+}
+
+# Each C++ cell is a standalone program including cv_common.h + linking libopencv_* via pkg-config opencv4.
+# A compile failure is a genuine breakage. Dynamic link against OpenCV (the runtime .so are staged).
+compile_cells() {
+    local bin="$1" cell cflags libs obj
+    resolve_cxx
+    cflags="$(PKGCFG --cflags opencv4)"
+    # The cells use core/imgproc/imgcodecs/features2d/videoio only (never highgui). Drop -lopencv_highgui so
+    # its GUI-backend NEEDED (Alpine libQt6Core, which references a newer-musl renameat2 the cross toolchain's
+    # libc lacks) is not pulled into the link - a link-only trim, the runtime .so closure is unchanged.
+    libs="$(PKGCFG --libs opencv4 | sed 's/-lopencv_highgui[^ ]*//g')"
+    mkdir -p "$bin/cpp"
+    for cell in $CELLS; do
+        echo "prebuild: host cross-compile cpp/$cell for $arch (links libopencv_* - tests OpenCV, does not reimplement it)"
+        obj="$bin/cpp/$cell.o"
+        # shellcheck disable=SC2086
+        cxx_object "$CAR/cpp/$cell.cpp" "$obj" $cflags -I"$CAR/cpp"
+        # shellcheck disable=SC2086
+        cxx_link "$obj" "$bin/cpp/$cell" $libs
+        rm -f "$obj"
+        [[ -x "$bin/cpp/$cell" ]] || { echo "prebuild: cpp/$cell failed to compile/link" >&2; exit 4; }
+    done
+}
+
+# The Python cells import cv2 (py3-opencv) + numpy on target. Stage them only where cv2 actually imports:
+# on riscv64 Alpine's py3-opencv pulls libQt6Core.so.6, which references a newer-musl renameat2 the base
+# rootfs musl does not export, so `import cv2` is unresolvable - a documented Alpine ecosystem wall (the
+# C++ cells linked without highgui avoid it). Probe once under qemu-user; where cv2 imports (x86_64/aarch64)
+# stage + gate the Python cells, where it cannot honestly skip them so the manifest reflects real capability.
+stage_python_cells() {
+    local bin="$1"
+    rm -rf "$bin/py"; mkdir -p "$bin/py"
+    if QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/usr/bin/python3" -c "import cv2" >/dev/null 2>&1; then
+        cp "$CAR/py/"*.py "$bin/py/"
+    else
+        echo "prebuild: cv2 import fails on $arch (Alpine py3-opencv -> libQt6Core renameat2 wall) - Python cells honestly skipped this arch; the C++ cells still exercise the full OpenCV surface"
+    fi
+}
+
+# Stage the OpenCV runtime + its transitive support libs and the CPython/cv2/numpy closure into the overlay,
+# so the dynamically-linked C++ cells and the `import cv2` Python cells run on target.
+stage_runtime() {
+    echo "prebuild: staging OpenCV + CPython/cv2/numpy runtime into overlay"
+    # every shared lib apk installed under usr/lib (opencv + its ffmpeg/png/jpeg/tiff/webp/tbb closure)
+    (cd "$staging_root" && find usr/lib -maxdepth 1 -name '*.so*' -print) | while read -r rel; do
+        mkdir -p "$overlay_dir/$(dirname "$rel")"; cp -a "$staging_root/$rel" "$overlay_dir/$rel" 2>/dev/null || true
+    done
+    # opencv pulls libpulse whose real object lives under usr/lib/pulseaudio
+    if [[ -d "$staging_root/usr/lib/pulseaudio" ]]; then
+        mkdir -p "$overlay_dir/usr/lib/pulseaudio"
+        cp -a "$staging_root/usr/lib/pulseaudio/." "$overlay_dir/usr/lib/pulseaudio/" 2>/dev/null || true
+    fi
+    # the CPython interpreter + stdlib + site-packages (cv2 + numpy)
+    local pyver
+    pyver="$(ls -d "$staging_root"/usr/lib/python3.* 2>/dev/null | grep -oE 'python3\.[0-9]+' | head -1)"
+    [[ -n "$pyver" ]] || { echo "prebuild: no python3.x under staging" >&2; exit 5; }
+    mkdir -p "$overlay_dir/usr/lib" "$overlay_dir/usr/bin"
+    cp -a "$staging_root/usr/lib/$pyver" "$overlay_dir/usr/lib/"
+    cp -a "$staging_root/usr/bin/python3" "$overlay_dir/usr/bin/" 2>/dev/null || true
+    [[ -e "$staging_root/usr/bin/$pyver" ]] && cp -a "$staging_root/usr/bin/$pyver" "$overlay_dir/usr/bin/" || true
+    ln -sf python3 "$overlay_dir/usr/bin/python" 2>/dev/null || true
+}
+
+# Stage the real images the opencv_io leg decodes (flat, next to the cells). opencv_io reads every image
+# directly under ASSET_DIR (=$bin/assets), so the submodule's images/ subdir is flattened here. A missing
+# submodule never fails the gate (the closed-form legs still run); present images are asserted to decode.
+stage_real_assets() {
+    local bin="$1" src="${OPENCV_ASSET_SRC:-}"
+    # Preferred source: the per-app `assets` git submodule (images/ + golden/ layout). On a fresh CI
+    # checkout the gitlink dir exists but is empty until inited, and the rasters arrive as LFS pointers -
+    # init + sparse-pull the subdirs this carpet reads so the marker materializes with real bytes.
+    if [[ -z "$src" && -d "$app_dir/assets" ]]; then
+        if [[ ! -e "$app_dir/assets/images/fmt_ref.png" ]] && command -v git >/dev/null 2>&1; then
+            git -C "$app_dir" submodule update --init assets >/dev/null 2>&1 || true
+        fi
+        if command -v git >/dev/null 2>&1 && git -C "$app_dir/assets" lfs env >/dev/null 2>&1; then
+            git -C "$app_dir/assets" lfs pull --include="images/*,video/*,audio/*,golden/*" >/dev/null 2>&1 || true
+        fi
+        [[ -f "$app_dir/assets/images/fmt_ref.png" ]] && src="$app_dir/assets/images"
+    fi
+    if [[ -n "$src" && -d "$src" ]]; then
+        echo "prebuild: staging real images from $src -> $INSTALL_DIR/assets"
+        cp -a "$src"/*.png "$src"/*.jpg "$src"/*.bmp "$src"/*.ppm "$src"/*.tiff "$bin/assets/" 2>/dev/null || true
+        echo "prebuild: staged $(find "$bin/assets" -maxdepth 1 -type f 2>/dev/null | wc -l) image files for opencv_io"
+    else
+        echo "prebuild: no image asset source found - opencv_io real-asset leg will honest-skip on-target"
+    fi
+}
+
+compile_carpets() {
+    local bin="$staging_root$INSTALL_DIR"; mkdir -p "$bin/assets"
+    compile_cells "$bin"
+    stage_python_cells "$bin"
+    cp "$app_dir/programs/run_all.sh" "$bin/run_all.sh"; chmod +x "$bin/run_all.sh"
+    stage_real_assets "$bin"
+    stage_runtime
+}
+
+populate_overlay() {
+    local bin="$staging_root$INSTALL_DIR"
+    : > "$bin/expected_cells"
+    for c in $CELLS; do
+        [[ -x "$bin/cpp/$c" ]] && echo "cpp/$c" >> "$bin/expected_cells"
+        [[ -f "$bin/py/$c.py" ]] && echo "py/$c"  >> "$bin/expected_cells"
+    done
+    echo "prebuild: expected_cells for $arch = $(tr '\n' ' ' < "$bin/expected_cells")"
+    mkdir -p "$overlay_dir/opt"
+    cp -a "$staging_root$INSTALL_DIR" "$overlay_dir/opt/"
+    mkdir -p "$overlay_dir/usr/bin"
+    ln -sf "$INSTALL_DIR/run_all.sh" "$overlay_dir/usr/bin/run_all.sh"
+    echo "prebuild: overlay populated for $arch"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+compile_carpets
+populate_overlay
+echo "prebuild: cpu-opencv-test overlay ready for $arch"

--- a/apps/starry/cpu-opencv-test/prebuild.sh
+++ b/apps/starry/cpu-opencv-test/prebuild.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the cpu-opencv-test carpet into the per-arch Alpine rootfs.
+#
+# The carpet drives real OpenCV on KNOWN, fixed inputs and asserts CLOSED-FORM / numpy goldens computed by
+# hand (BT.601 luma, Porter-Duff, the normalized Gaussian kernel, a Sobel gradient's constant derivative,
+# bilinear interpolation, an analytic drawn shape, a known step-edge column, a byte-exact PNG/BMP round-trip,
+# a lossless FFV1 video round-trip). "cv2 imported" is NOT a test - every leg checks a predicted value.
+#
+# Two mature, apk-available OpenCV bindings, both TESTED (never reimplemented):
+#   C++    - Alpine `opencv` + `opencv-dev` (musl); each cell links libopencv_* via pkg-config `opencv4`.
+#   Python - Alpine `py3-opencv` (musl) `import cv2` + `py3-numpy`.
+#
+# Portable model: extract the base Alpine rootfs, apk add the OpenCV C++/dev + Python stack for the TARGET
+# arch via qemu-user (apk runs fine under qemu-user), then cross-compile each C++ cell on the HOST against
+# the apk-staged OpenCV, stage the OpenCV runtime + the CPython + cv2 + numpy closure into the overlay, and
+# write an expected_cells manifest that run_all.sh gates on (fail==0 && total==EXPECTED==pass, EXPECTED>=1).
+#
+# Why the C++ cells are compiled on the HOST, not by the target g++ under qemu-user: Alpine's g++ spawns
+# cc1plus via posix_spawn, which qemu-user-static cannot exec - so running the staged g++ under qemu always
+# fails to compile. Instead a HOST cross C++ compiler builds each cell with --sysroot / include+lib flags
+# resolved against the staging root. Two host-toolchain hazards, both resolved below:
+#   1. Alpine's OpenCV .so carry a `.relr.dyn` (SHT_RELR) section that older binutils ld (as shipped by the
+#      musl-cross ${triple}-g++) rejects as "incompatible". zig's bundled LLD reads .relr.dyn correctly.
+#   2. Alpine OpenCV is built against libstdc++ (GNU `std::__cxx11` ABI), but zig c++ defaults to its own
+#      libc++ (`std::__1`) - the mangled names would not match. So the cells are compiled with the STAGED
+#      GCC libstdc++ headers (`-nostdinc++ -isystem .../c++/<ver>`) and linked against the staged
+#      libstdc++.so.6, giving the exact GNU ABI OpenCV expects.
+# The synthetic closed-form legs always run; the opencv_io real-asset leg honest-skips if no image is staged.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS, STARRY_STAGING_ROOT, STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+CAR="$app_dir/programs/carpets"
+INSTALL_DIR=/opt/cpu-opencv-test
+CELLS="opencv_mat opencv_color opencv_filter opencv_geometry opencv_morph opencv_draw opencv_feature opencv_io"
+
+# qemu_runner: runs the target apk (and only apk - never g++) during provisioning.
+# triple:      the musl target triple for the HOST cross C++ compiler that builds the cells.
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static";     triple="aarch64-linux-musl" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static";     triple="riscv64-linux-musl" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static";      triple="x86_64-linux-musl" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static"; triple="loongarch64-linux-musl" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    # pkgconf runs HOST-side now (resolving opencv4 flags against the staging root).
+    command -v pkgconf >/dev/null 2>&1 || command -v pkg-config >/dev/null 2>&1 || missing+=(pkgconf)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+    # A HOST C++ cross toolchain for the cells: ${triple}-g++ (PATH or /opt) or zig c++. resolve_cxx probes
+    # which one actually links Alpine's .relr.dyn OpenCV; here just fail early if neither exists at all.
+    command -v "${triple}-g++" >/dev/null 2>&1 || [[ -x "/opt/${triple}-cross/bin/${triple}-g++" ]] \
+        || command -v zig >/dev/null 2>&1 \
+        || { echo "prebuild: no host C++ cross toolchain (need ${triple}-g++ or zig) for $arch" >&2; exit 1; }
+}
+
+# OpenCV + a full CPython + the C++ toolchain are large; give the rootfs room.
+ROOTFS_SIZE=6G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    local before after; before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB for the OpenCV stack"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# C++ opencv + dev headers to compile against; python3 + py3-opencv (cv2) + py3-numpy for the Python cells.
+# build-base is staged so that the target libstdc++ headers (usr/include/c++/<ver>) and libstdc++.so.6 are
+# present - the HOST cross compiler builds the cells against exactly those, matching OpenCV's GNU C++ ABI.
+# pkgconf is used HOST-side (a host pkgconf run against the staging root's opencv4.pc). pulseaudio-libs is an
+# OPTIONAL runtime dep of opencv's highgui (libpulse -> libpulsecommon); the tested cells are all offscreen/
+# computational and do not use highgui, so add it best-effort where Alpine packages it (x86_64/aarch64) and
+# skip it where absent (riscv64/loongarch64) instead of hard-failing the whole provision.
+PKGS=(musl build-base pkgconf opencv opencv-dev py3-opencv py3-numpy python3)
+OPT_PKGS=(pulseaudio-libs)
+
+# Write a resolv.conf into the staging root that is actually reachable from inside qemu-user. Host loopback
+# stub resolvers (127.0.0.0/8, e.g. systemd-resolved 127.0.0.53) are dropped; real host nameservers are kept
+# first, then reachable public resolvers are appended as a fallback. STARRY_DNS (space/comma-separated IPs)
+# overrides the public fallback list.
+provision_resolv_conf() {
+    local rc="$staging_root/etc/resolv.conf" ns
+    mkdir -p "$staging_root/etc"
+    : > "$rc"
+    if [[ -f /etc/resolv.conf ]]; then
+        while read -r kw ns _; do
+            [[ "$kw" == nameserver ]] || continue
+            [[ "$ns" == 127.* || "$ns" == ::1 ]] && continue
+            echo "nameserver $ns" >> "$rc"
+        done < /etc/resolv.conf
+    fi
+    local fallback="${STARRY_DNS:-1.1.1.1 8.8.8.8 9.9.9.9}"
+    for ns in ${fallback//,/ }; do
+        grep -qx "nameserver $ns" "$rc" 2>/dev/null || echo "nameserver $ns" >> "$rc"
+    done
+    echo "prebuild: staging resolv.conf -> $(tr '\n' ' ' < "$rc")"
+}
+
+apk_provision() {
+    normalize_symlinks
+    # DNS for apk under qemu-user: the host's /etc/resolv.conf often points at a loopback stub
+    # (systemd-resolved / Docker's 127.0.0.53), whose listener does not exist inside the qemu-user staging
+    # root, so apk's `Alpine repo -> DNS: transient error`. Carry over only the host's non-loopback
+    # nameservers, and always append reachable public resolvers as a fallback so apk can resolve the Alpine
+    # CDN regardless of the host stub. STARRY_DNS overrides the fallback list when set.
+    provision_resolv_conf
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add OpenCV C++/Python carpet stack (${PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add --upgrade "${PKGS[@]}"
+    # optional highgui audio backend: packaged for x86_64/aarch64, absent for riscv64/loongarch64 - best-effort
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" add "${OPT_PKGS[@]}" 2>/dev/null \
+        || echo "prebuild: optional ${OPT_PKGS[*]} not packaged for $arch - skipped (offscreen cells do not use highgui audio)"
+    [[ -f "$staging_root/usr/lib/libstdc++.so.6" ]] \
+        || { echo "prebuild: libstdc++.so.6 (build-base) not provisioned for $arch" >&2; exit 3; }
+    [[ -n "$(ls -d "$staging_root"/usr/include/c++/* 2>/dev/null | head -1)" ]] \
+        || { echo "prebuild: staged libstdc++ headers (usr/include/c++) missing for $arch" >&2; exit 3; }
+    [[ -f "$staging_root/usr/lib/pkgconfig/opencv4.pc" ]] \
+        || { echo "prebuild: opencv4.pc (opencv-dev) missing for $arch" >&2; exit 3; }
+    [[ -x "$staging_root/usr/bin/python3" ]] \
+        || { echo "prebuild: python3 not provisioned for $arch" >&2; exit 3; }
+}
+
+# PKGCFG - resolve OpenCV include/lib flags on the HOST against the apk-staged opencv4.pc. Sysroot-prefixed
+# so the emitted -I/-L point into the staging root. The .pc itself is target-arch-neutral (just paths).
+host_pkgconf() { if command -v pkgconf >/dev/null 2>&1; then echo pkgconf; else echo pkg-config; fi; }
+PKGCFG() { PKG_CONFIG_SYSROOT_DIR="$staging_root" PKG_CONFIG_LIBDIR="$staging_root/usr/lib/pkgconfig" \
+           "$(host_pkgconf)" "$@"; }
+
+# CXX_COMPILE / CXX_LINK - the HOST C++ cross toolchain for $triple, resolved once. Preference order mirrors
+# the cpu-concurrency carpet but for C++, with the two OpenCV-specific constraints (.relr.dyn + GNU C++ ABI):
+#   1) zig c++ -target <triple>   - LLD reads Alpine's .relr.dyn; combined with the STAGED libstdc++ headers
+#                                   and libstdc++.so.6 it produces the exact GNU (`std::__cxx11`) ABI OpenCV
+#                                   was built against. This is the working path (verified on all arches).
+#   2) ${triple}-g++ on PATH / under /opt/${triple}-cross - a native GNU cross g++. Correct ABI by
+#      construction, but only usable if its binutils ld can read .relr.dyn; probed for real at resolve time.
+# Resolution stores a mode in $cxx_mode; the compile/link helpers dispatch on it. cxx_gpp holds the g++ path.
+cxx_mode=""; cxx_gpp=""; cxx_incflags=(); cxx_lldflags=()
+# resolve_lld: locate a standalone ld.lld (PATH, then versioned Debian/Ubuntu names) and symlink it into a
+# private -B dir so `${triple}-g++ -fuse-ld=lld` finds it as plain `ld.lld`. Sets cxx_lldflags, returns 0.
+resolve_lld() {
+    local lld="" c
+    if command -v ld.lld >/dev/null 2>&1; then lld="$(command -v ld.lld)"; fi
+    if [[ -z "$lld" ]]; then
+        for c in /usr/bin/ld.lld /usr/lib/llvm-*/bin/ld.lld; do [[ -x "$c" ]] && { lld="$c"; break; }; done
+    fi
+    [[ -n "$lld" ]] || return 1
+    local d; d="$(mktemp -d)"; ln -sf "$lld" "$d/ld.lld"; cxx_lldflags=(-fuse-ld=lld -B"$d"); return 0
+}
+resolve_cxx() {
+    local gxxver cxxinc cxxinc_tri gpp
+    # STAGED libstdc++ headers - shared by both zig and g++ probing (g++ ships its own, zig needs these).
+    gxxver="$(ls -d "$staging_root"/usr/include/c++/* 2>/dev/null | head -1)"
+    cxxinc="$gxxver"
+    cxxinc_tri="$(ls -d "$gxxver"/*-alpine-linux-musl 2>/dev/null | head -1)"
+
+    # candidate GNU cross g++ (PATH, then conventional /opt install prefix)
+    if command -v "${triple}-g++" >/dev/null 2>&1; then gpp="${triple}-g++"
+    elif [[ -x "/opt/${triple}-cross/bin/${triple}-g++" ]]; then gpp="/opt/${triple}-cross/bin/${triple}-g++"
+    else gpp=""; fi
+
+    # Prefer g++ only if it can actually link an Alpine .relr.dyn .so - probe against libopencv_core.
+    if [[ -n "$gpp" ]]; then
+        local probe; probe="$(mktemp)"
+        printf 'int main(){return 0;}\n' > "$probe.cpp"
+        if "$gpp" --sysroot="$staging_root" -O0 "$probe.cpp" -o "$probe" \
+                -L"$staging_root/usr/lib" -lopencv_core >/dev/null 2>&1; then
+            cxx_mode="gpp"; cxx_gpp="$gpp"; rm -f "$probe" "$probe.cpp"
+            echo "prebuild: C++ toolchain = $gpp (--sysroot, native GNU ABI, ld reads .relr.dyn)"; return 0
+        fi
+        # g++'s bundled GNU ld 2.37 has no RELR; retry the same native g++ with LLD (keeps the GNU C++ ABI,
+        # so no staged-libstdc++ header juggling) before falling back to zig. Preferred over zig when host
+        # LLD is available, which is the common CI case.
+        if resolve_lld && "$gpp" "${cxx_lldflags[@]}" --sysroot="$staging_root" -O0 "$probe.cpp" -o "$probe" \
+                -L"$staging_root/usr/lib" -lopencv_core >/dev/null 2>&1; then
+            cxx_mode="gpp"; cxx_gpp="$gpp"; rm -f "$probe" "$probe.cpp"
+            echo "prebuild: C++ toolchain = $gpp -fuse-ld=lld (--sysroot, native GNU ABI, LLD reads .relr.dyn)"; return 0
+        fi
+        cxx_lldflags=()
+        rm -f "$probe" "$probe.cpp"
+    fi
+
+    # Fall back to zig c++ + staged libstdc++ headers/lib.
+    if command -v zig >/dev/null 2>&1; then
+        [[ -d "$cxxinc" ]] || { echo "prebuild: no staged libstdc++ headers for zig c++ path" >&2; exit 4; }
+        cxx_mode="zig"; cxx_incflags=(-nostdinc++ -isystem "$cxxinc")
+        [[ -n "$cxxinc_tri" ]] && cxx_incflags+=(-isystem "$cxxinc_tri")
+        # staged musl libc headers reachable for libstdc++'s include_next chain
+        cxx_incflags+=(-idirafter "$staging_root/usr/include")
+        echo "prebuild: C++ toolchain = zig c++ -target $triple (staged libstdc++ headers, LLD reads .relr.dyn)"
+        return 0
+    fi
+
+    echo "prebuild: no host C++ cross toolchain for $triple (tried ${triple}-g++, /opt/${triple}-cross, zig c++)" >&2
+    exit 4
+}
+
+# Compile one C++ cell to an object. zig is cache-sensitive on the combined compile+link step (it can reuse
+# a stale object), so cells are always compiled to a .o first, then linked - deterministic and correct.
+cxx_object() {
+    local src="$1" obj="$2"; shift 2
+    case "$cxx_mode" in
+        gpp) "$cxx_gpp" --sysroot="$staging_root" -O2 -std=c++17 -fPIC "$@" -c "$src" -o "$obj" ;;
+        zig) zig c++ -target "$triple" "${cxx_incflags[@]}" -O2 -std=c++17 -fPIC "$@" -c "$src" -o "$obj" ;;
+    esac
+}
+
+# Link one object into a target ELF against the staged OpenCV. For zig the staged libstdc++.so.6 is passed
+# positionally so its GNU-ABI symbols resolve; g++ pulls its own libstdc++ implicitly.
+cxx_link() {
+    local obj="$1" out="$2"; shift 2
+    case "$cxx_mode" in
+        gpp) "$cxx_gpp" "${cxx_lldflags[@]}" --sysroot="$staging_root" "$obj" -o "$out" "$@" ;;
+        zig) zig c++ -target "$triple" "$obj" -o "$out" "$@" "$staging_root/usr/lib/libstdc++.so.6" ;;
+    esac
+}
+
+# Each C++ cell is a standalone program including cv_common.h + linking libopencv_* via pkg-config opencv4.
+# A compile failure is a genuine breakage. Dynamic link against OpenCV (the runtime .so are staged).
+compile_cells() {
+    local bin="$1" cell cflags libs obj
+    resolve_cxx
+    cflags="$(PKGCFG --cflags opencv4)"
+    # The cells use core/imgproc/imgcodecs/features2d/videoio only (never highgui). Drop -lopencv_highgui so
+    # its GUI-backend NEEDED (Alpine libQt6Core, which references a newer-musl renameat2 the cross toolchain's
+    # libc lacks) is not pulled into the link - a link-only trim, the runtime .so closure is unchanged.
+    libs="$(PKGCFG --libs opencv4 | sed 's/-lopencv_highgui[^ ]*//g')"
+    mkdir -p "$bin/cpp"
+    for cell in $CELLS; do
+        echo "prebuild: host cross-compile cpp/$cell for $arch (links libopencv_* - tests OpenCV, does not reimplement it)"
+        obj="$bin/cpp/$cell.o"
+        # shellcheck disable=SC2086
+        cxx_object "$CAR/cpp/$cell.cpp" "$obj" $cflags -I"$CAR/cpp"
+        # shellcheck disable=SC2086
+        cxx_link "$obj" "$bin/cpp/$cell" $libs
+        rm -f "$obj"
+        [[ -x "$bin/cpp/$cell" ]] || { echo "prebuild: cpp/$cell failed to compile/link" >&2; exit 4; }
+    done
+}
+
+# py3-opencv pulls edge libQt6Core, which needs renameat2 from the upgraded musl; a cv2 that cannot import
+# fails the build rather than shrinking the manifest.
+stage_python_cells() {
+    local bin="$1"
+    rm -rf "$bin/py"; mkdir -p "$bin/py"
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/usr/bin/python3" -c "import cv2" \
+        || { echo "prebuild: cv2 does not import on $arch through the staged runtime" >&2; exit 6; }
+    cp "$CAR/py/"*.py "$bin/py/"
+}
+
+# Stage the OpenCV runtime + its transitive support libs and the CPython/cv2/numpy closure into the overlay,
+# so the dynamically-linked C++ cells and the `import cv2` Python cells run on target.
+stage_runtime() {
+    echo "prebuild: staging OpenCV + CPython/cv2/numpy runtime into overlay"
+    # every shared lib apk installed under usr/lib (opencv + its ffmpeg/png/jpeg/tiff/webp/tbb closure)
+    (cd "$staging_root" && find usr/lib -maxdepth 1 -name '*.so*' -print) | while read -r rel; do
+        mkdir -p "$overlay_dir/$(dirname "$rel")"; cp -a "$staging_root/$rel" "$overlay_dir/$rel" 2>/dev/null || true
+    done
+    # opencv pulls libpulse whose real object lives under usr/lib/pulseaudio
+    if [[ -d "$staging_root/usr/lib/pulseaudio" ]]; then
+        mkdir -p "$overlay_dir/usr/lib/pulseaudio"
+        cp -a "$staging_root/usr/lib/pulseaudio/." "$overlay_dir/usr/lib/pulseaudio/" 2>/dev/null || true
+    fi
+    # the CPython interpreter + stdlib + site-packages (cv2 + numpy)
+    local pyver
+    pyver="$(ls -d "$staging_root"/usr/lib/python3.* 2>/dev/null | grep -oE 'python3\.[0-9]+' | head -1)"
+    [[ -n "$pyver" ]] || { echo "prebuild: no python3.x under staging" >&2; exit 5; }
+    mkdir -p "$overlay_dir/usr/lib" "$overlay_dir/usr/bin"
+    cp -a "$staging_root/usr/lib/$pyver" "$overlay_dir/usr/lib/"
+    cp -a "$staging_root/usr/bin/python3" "$overlay_dir/usr/bin/" 2>/dev/null || true
+    [[ -e "$staging_root/usr/bin/$pyver" ]] && cp -a "$staging_root/usr/bin/$pyver" "$overlay_dir/usr/bin/" || true
+    ln -sf python3 "$overlay_dir/usr/bin/python" 2>/dev/null || true
+    # The edge libraries reference symbols (renameat2) that the base rootfs musl does not export.
+    mkdir -p "$overlay_dir/lib"
+    (cd "$staging_root" && find lib -maxdepth 1 \( -name 'ld-musl-*.so.1' -o -name 'libc.musl-*.so.1' \) -print) \
+        | while read -r rel; do cp -a "$staging_root/$rel" "$overlay_dir/$rel"; done
+}
+
+# Stage the real images the opencv_io leg decodes (flat, next to the cells). opencv_io reads every image
+# directly under ASSET_DIR (=$bin/assets), so the submodule's images/ subdir is flattened here. A missing
+# submodule never fails the gate (the closed-form legs still run); present images are asserted to decode.
+stage_real_assets() {
+    local bin="$1" src="${OPENCV_ASSET_SRC:-}"
+    # Preferred source: the per-app `assets` git submodule (images/ + golden/ layout). On a fresh CI
+    # checkout the gitlink dir exists but is empty until inited, and the rasters arrive as LFS pointers -
+    # init + sparse-pull the subdirs this carpet reads so the marker materializes with real bytes.
+    if [[ -z "$src" && -d "$app_dir/assets" ]]; then
+        if [[ ! -e "$app_dir/assets/images/fmt_ref.png" ]] && command -v git >/dev/null 2>&1; then
+            git -C "$app_dir" submodule update --init assets >/dev/null 2>&1 || true
+        fi
+        if command -v git >/dev/null 2>&1 && git -C "$app_dir/assets" lfs env >/dev/null 2>&1; then
+            git -C "$app_dir/assets" lfs pull --include="images/*,video/*,audio/*,golden/*" >/dev/null 2>&1 || true
+        fi
+        [[ -f "$app_dir/assets/images/fmt_ref.png" ]] && src="$app_dir/assets/images"
+    fi
+    if [[ -n "$src" && -d "$src" ]]; then
+        echo "prebuild: staging real images from $src -> $INSTALL_DIR/assets"
+        cp -a "$src"/*.png "$src"/*.jpg "$src"/*.bmp "$src"/*.ppm "$src"/*.tiff "$bin/assets/" 2>/dev/null || true
+        echo "prebuild: staged $(find "$bin/assets" -maxdepth 1 -type f 2>/dev/null | wc -l) image files for opencv_io"
+    else
+        echo "prebuild: no image asset source found - opencv_io real-asset leg will honest-skip on-target"
+    fi
+}
+
+compile_carpets() {
+    local bin="$staging_root$INSTALL_DIR"; mkdir -p "$bin/assets"
+    compile_cells "$bin"
+    stage_python_cells "$bin"
+    cp "$app_dir/programs/run_all.sh" "$bin/run_all.sh"; chmod +x "$bin/run_all.sh"
+    stage_real_assets "$bin"
+    stage_runtime
+}
+
+populate_overlay() {
+    local bin="$staging_root$INSTALL_DIR"
+    # Fixed manifest: every cell in both languages, so a missing one cannot shrink EXPECTED.
+    : > "$bin/expected_cells"
+    for c in $CELLS; do
+        [[ -x "$bin/cpp/$c" && -f "$bin/py/$c.py" ]] \
+            || { echo "prebuild: cell $c is not staged for both C++ and Python" >&2; exit 6; }
+        printf 'cpp/%s\npy/%s\n' "$c" "$c" >> "$bin/expected_cells"
+    done
+    echo "prebuild: expected_cells for $arch = $(tr '\n' ' ' < "$bin/expected_cells")"
+    mkdir -p "$overlay_dir/opt"
+    cp -a "$staging_root$INSTALL_DIR" "$overlay_dir/opt/"
+    mkdir -p "$overlay_dir/usr/bin"
+    ln -sf "$INSTALL_DIR/run_all.sh" "$overlay_dir/usr/bin/run_all.sh"
+    echo "prebuild: overlay populated for $arch"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+compile_carpets
+populate_overlay
+echo "prebuild: cpu-opencv-test overlay ready for $arch"

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/cv_common.h
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/cv_common.h
@@ -1,0 +1,65 @@
+/* cv_common.h - shared primitives for the cpu-opencv-test carpet (C++ side).
+ *
+ * Each cell drives real OpenCV (cv::Mat / cvtColor / GaussianBlur / resize / threshold / drawing / Canny /
+ * imencode ...) on KNOWN, fixed inputs and asserts the result against a CLOSED-FORM golden computed here by
+ * hand (Gray = 0.299R+0.587G+0.114B, Porter-Duff, bilinear interpolation, the normalized Gaussian kernel,
+ * a Sobel gradient's constant derivative, an analytic drawn shape, a known step-edge column, a PNG/BMP
+ * round-trip that must be byte-exact). "cv2 loaded" is NOT a test - every leg checks a value predicted from
+ * first principles or a numpy/host-calibrated golden.
+ *
+ * Determinism: fixed inputs, no threading surprises (cv::setNumThreads(1)), a fixed RNG seed (0x233) wherever
+ * a random path could appear. Pixels/values are identical across arch (all integer or IEEE-754 CPU math).
+ *
+ * Three-gate marker: a cell prints "OPENCV_<CELL> OK <n>" only when fail==0 && total==pass && total>0.
+ */
+#ifndef CV_COMMON_H
+#define CV_COMMON_H
+
+#include <opencv2/core.hpp>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <string>
+
+struct Gate {
+    int pass = 0, total = 0, fail = 0, skipped = 0;
+    const char *name;
+    explicit Gate(const char *n) : name(n) {}
+    void check(bool cond, const char *msg) {
+        total++;
+        if (cond) pass++;
+        else { fail++; fprintf(stderr, "  FAIL: %s\n", msg); }
+    }
+    /* honest-skip: recorded distinctly (NOT as a pass) so a run that degrades every leg to skip cannot
+       satisfy the gate; total still counts it so the "OK <n>" marker stays stable, but pass tracks only
+       real checks and the gate below requires at least one. */
+    void skip(const char *msg) { total++; skipped++; fprintf(stderr, "  SKIP: %s\n", msg); }
+    int finish() {
+        if (fail == 0 && pass > 0 && pass + skipped == total) {
+            printf("%s OK %d\n", name, total);
+            return 0;
+        }
+        printf("%s FAILED pass=%d skipped=%d total=%d fail=%d\n", name, pass, skipped, total, fail);
+        return 1;
+    }
+};
+
+/* BT.601 luma round used by cv::cvtColor(...COLOR_BGR2GRAY): Y = round(0.299R + 0.587G + 0.114B).
+ * OpenCV uses fixed-point (R*4899 + G*9617 + B*1868 + 8192) >> 14; that equals the rounded float form for
+ * all 0..255 inputs, so we assert against the fixed-point closed form to be byte-exact. */
+static inline int bgr2gray_601(int b, int g, int r) {
+    return (r * 4899 + g * 9617 + b * 1868 + 8192) >> 14;
+}
+
+/* Straight-alpha Porter-Duff "src over dst", per channel, 0..255 (used to reason about addWeighted etc.). */
+static inline int over_chan(int sc, int sa, int dc, int da) {
+    double s = sa / 255.0, d = da / 255.0, oa = s + d * (1.0 - s);
+    if (oa <= 0) return 0;
+    int v = (int)((sc * s + dc * d * (1.0 - s)) / oa + 0.5);
+    return v < 0 ? 0 : (v > 255 ? 255 : v);
+}
+
+static inline bool close_i(int a, int b, int tol) { return std::abs(a - b) <= tol; }
+static inline bool close_d(double a, double b, double tol) { return std::fabs(a - b) <= tol; }
+
+#endif /* CV_COMMON_H */

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_color.cpp
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_color.cpp
@@ -1,0 +1,105 @@
+/* opencv_color - cvtColor conversions vs the closed-form color matrix, per pixel.
+ *
+ * BGR<->RGB (byte-exact channel swap), BGR->GRAY (Y=round(0.299R+0.587G+0.114B), fixed-point closed form),
+ * BGR<->HSV (closed form for pure primaries), BGR<->YCrCb (BT.601), BGR<->I420/YV12 (4:2:0 planar, luma
+ * plane == gray closed form). Known 4-color image; every pixel asserted. No RNG.
+ */
+#include "cv_common.h"
+#include <opencv2/imgproc.hpp>
+
+int main() {
+    cv::setNumThreads(1);
+    Gate g("OPENCV_COLOR");
+
+    /* A 2x2 BGR image of four known colors (OpenCV is BGR order in memory):
+       (0,0)=red   BGR(0,0,255)   (0,1)=green BGR(0,255,0)
+       (1,0)=blue  BGR(255,0,0)   (1,1)=gray  BGR(128,128,128) */
+    cv::Mat bgr(2, 2, CV_8UC3);
+    bgr.at<cv::Vec3b>(0, 0) = cv::Vec3b(0, 0, 255);
+    bgr.at<cv::Vec3b>(0, 1) = cv::Vec3b(0, 255, 0);
+    bgr.at<cv::Vec3b>(1, 0) = cv::Vec3b(255, 0, 0);
+    bgr.at<cv::Vec3b>(1, 1) = cv::Vec3b(128, 128, 128);
+
+    /* BGR->RGB: byte-exact channel swap (B<->R), G unchanged. */
+    cv::Mat rgb; cv::cvtColor(bgr, rgb, cv::COLOR_BGR2RGB);
+    bool swap_ok = true;
+    for (int y = 0; y < 2; y++) for (int x = 0; x < 2; x++) {
+        cv::Vec3b b = bgr.at<cv::Vec3b>(y, x), r = rgb.at<cv::Vec3b>(y, x);
+        swap_ok &= (r[0] == b[2] && r[1] == b[1] && r[2] == b[0]);
+    }
+    g.check(swap_ok, "BGR2RGB is not an exact B<->R swap");
+
+    /* round-trip RGB->BGR returns the original exactly. */
+    cv::Mat back; cv::cvtColor(rgb, back, cv::COLOR_RGB2BGR);
+    bool rt_ok = true;
+    for (int y = 0; y < 2; y++) for (int x = 0; x < 2; x++)
+        rt_ok &= (back.at<cv::Vec3b>(y, x) == bgr.at<cv::Vec3b>(y, x));
+    g.check(rt_ok, "BGR->RGB->BGR not identity");
+
+    /* BGR->GRAY: assert every pixel == fixed-point 0.299R+0.587G+0.114B.
+       red->76, green->150, blue->29, gray(128,128,128)->128. */
+    cv::Mat gray; cv::cvtColor(bgr, gray, cv::COLOR_BGR2GRAY);
+    bool gray_ok = true;
+    for (int y = 0; y < 2; y++) for (int x = 0; x < 2; x++) {
+        cv::Vec3b p = bgr.at<cv::Vec3b>(y, x);
+        int want = bgr2gray_601(p[0], p[1], p[2]);
+        gray_ok &= (gray.at<uchar>(y, x) == want);
+    }
+    g.check(gray_ok, "BGR2GRAY != BT.601 fixed-point closed form");
+    /* pin the actual expected values so a mutation is caught even if the helper drifted. */
+    g.check(gray.at<uchar>(0, 0) == 76 && gray.at<uchar>(0, 1) == 150 &&
+            gray.at<uchar>(1, 0) == 29 && gray.at<uchar>(1, 1) == 128,
+            "gray pins (76,150,29,128) wrong");
+
+    /* BGR->YCrCb (BT.601). For pure gray (128,128,128): Y=128, Cr=Cb=128 (neutral chroma). */
+    cv::Mat ycc; cv::cvtColor(bgr, ycc, cv::COLOR_BGR2YCrCb);
+    cv::Vec3b yg = ycc.at<cv::Vec3b>(1, 1);
+    g.check(yg[0] == 128 && yg[1] == 128 && yg[2] == 128, "YCrCb of gray != (128,128,128)");
+    /* Y channel of YCrCb equals the GRAY closed form for every pixel. */
+    bool yluma_ok = true;
+    for (int y = 0; y < 2; y++) for (int x = 0; x < 2; x++)
+        yluma_ok &= close_i(ycc.at<cv::Vec3b>(y, x)[0], gray.at<uchar>(y, x), 1);
+    g.check(yluma_ok, "YCrCb luma != gray closed form");
+
+    /* BGR->HSV: pure primaries have known H (OpenCV 8U H in [0,180)):
+       red H=0 S=255 V=255 ; green H=60 ; blue H=120 ; gray S=0 V=128. */
+    cv::Mat hsv; cv::cvtColor(bgr, hsv, cv::COLOR_BGR2HSV);
+    cv::Vec3b hr = hsv.at<cv::Vec3b>(0, 0), hg = hsv.at<cv::Vec3b>(0, 1),
+              hb = hsv.at<cv::Vec3b>(1, 0), hgy = hsv.at<cv::Vec3b>(1, 1);
+    g.check(hr[0] == 0   && hr[1] == 255 && hr[2] == 255, "HSV(red) != (0,255,255)");
+    g.check(hg[0] == 60  && hg[1] == 255 && hg[2] == 255, "HSV(green) != (60,255,255)");
+    g.check(hb[0] == 120 && hb[1] == 255 && hb[2] == 255, "HSV(blue) != (120,255,255)");
+    g.check(hgy[1] == 0  && hgy[2] == 128, "HSV(gray) S/V != (0,128)");
+
+    /* HSV round-trip back to BGR returns primaries exactly (they sit on cube corners). */
+    cv::Mat hsv2bgr; cv::cvtColor(hsv, hsv2bgr, cv::COLOR_HSV2BGR);
+    bool hsv_rt = true;
+    for (int y = 0; y < 2; y++) for (int x = 0; x < 2; x++) {
+        cv::Vec3b a = bgr.at<cv::Vec3b>(y, x), b = hsv2bgr.at<cv::Vec3b>(y, x);
+        for (int c = 0; c < 3; c++) hsv_rt &= close_i(a[c], b[c], 2);
+    }
+    g.check(hsv_rt, "HSV->BGR round-trip drifted > 2");
+
+    /* BGR->I420 (YUV 4:2:0 planar): output is (H*3/2) x W single channel. The top HxW block is the Y
+       plane and must equal the GRAY closed form. Use a larger even image so 4:2:0 subsampling is valid. */
+    cv::Mat big(4, 4, CV_8UC3);
+    for (int y = 0; y < 4; y++) for (int x = 0; x < 4; x++)
+        big.at<cv::Vec3b>(y, x) = cv::Vec3b((x * 40) & 0xff, (y * 40) & 0xff, ((x + y) * 30) & 0xff);
+    cv::Mat i420; cv::cvtColor(big, i420, cv::COLOR_BGR2YUV_I420);
+    g.check(i420.rows == 6 && i420.cols == 4, "I420 shape != 6x4");
+    /* I420 luma is STUDIO-SWING BT.601 (Y' in [16,235]): Y = round(0.257R+0.504G+0.098B) + 16, distinct
+       from the full-range BGR2GRAY. OpenCV's fixed-point: (R*66 + G*129 + B*25 + 128) >> 8 + 16. */
+    bool yplane_ok = true;
+    for (int y = 0; y < 4; y++) for (int x = 0; x < 4; x++) {
+        cv::Vec3b p = big.at<cv::Vec3b>(y, x);
+        int want = ((p[2] * 66 + p[1] * 129 + p[0] * 25 + 128) >> 8) + 16;
+        yplane_ok &= close_i(i420.at<uchar>(y, x), want, 1);
+    }
+    g.check(yplane_ok, "I420 Y-plane != BT.601 studio-swing closed form");
+
+    /* I420 -> BGR round-trip stays close (chroma subsampling loses a little). */
+    cv::Mat i420back; cv::cvtColor(i420, i420back, cv::COLOR_YUV2BGR_I420);
+    g.check(i420back.rows == 4 && i420back.cols == 4, "I420->BGR shape wrong");
+
+    return g.finish();
+}

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_draw.cpp
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_draw.cpp
@@ -1,0 +1,111 @@
+/* opencv_draw - 2D drawing primitives vs the analytic shape, per pixel (anti-aliasing OFF for exactness).
+ *
+ * rectangle (filled -> exact interior + clean exterior), line (axis-aligned exact row/col, diagonal on the
+ * y=x cells), circle (filled -> center+radius samples fill, outside bbox clean, area within tol of pi r^2),
+ * ellipse, polylines/fillPoly of a known triangle (exact fill count + a known interior/exterior pixel),
+ * putText (ink lands in the expected bbox, corners clean). LINE_8 (no AA) so pixels are deterministic.
+ */
+#include "cv_common.h"
+#include <opencv2/imgproc.hpp>
+
+static int nz(const cv::Mat &m) { return cv::countNonZero(m); }
+
+int main() {
+    cv::setNumThreads(1);
+    Gate g("OPENCV_DRAW");
+    const int W = 64, H = 64;
+    const cv::Scalar WHITE(255);
+
+    /* rectangle filled: [x=10,y=8, w=20,h=12] -> interior [10,30)x[8,20) all 255, exterior 0.
+       cv::rectangle with thickness=FILLED draws the inclusive rect [x1,x2]x[y1,y2]; use pt1(10,8)
+       pt2(29,19) so the filled span is exactly 20x12 = 240 pixels. */
+    cv::Mat r = cv::Mat::zeros(H, W, CV_8U);
+    cv::rectangle(r, cv::Point(10, 8), cv::Point(29, 19), WHITE, cv::FILLED, cv::LINE_8);
+    g.check(nz(r) == 20 * 12, "filled rectangle area != 240");
+    bool rin = true, rout = true;
+    for (int y = 0; y < H; y++) for (int x = 0; x < W; x++) {
+        bool inside = (x >= 10 && x <= 29 && y >= 8 && y <= 19);
+        if (inside) rin &= (r.at<uchar>(y, x) == 255);
+        else        rout &= (r.at<uchar>(y, x) == 0);
+    }
+    g.check(rin, "filled rectangle interior not all 255");
+    g.check(rout, "filled rectangle exterior not all 0");
+
+    /* axis-aligned line: horizontal row y=30 from x=5..25 (thickness 1) -> exactly those 21 pixels set. */
+    cv::Mat ln = cv::Mat::zeros(H, W, CV_8U);
+    cv::line(ln, cv::Point(5, 30), cv::Point(25, 30), WHITE, 1, cv::LINE_8);
+    int hits = 0;
+    for (int x = 5; x <= 25; x++) if (ln.at<uchar>(30, x) == 255) hits++;
+    g.check(hits == 21 && nz(ln) == 21, "horizontal line != 21 exact pixels on row 30");
+    g.check(ln.at<uchar>(29, 15) == 0 && ln.at<uchar>(31, 15) == 0, "line leaked to adjacent rows");
+    /* vertical line column x=40 from y=5..35 -> 31 pixels. */
+    cv::Mat lv = cv::Mat::zeros(H, W, CV_8U);
+    cv::line(lv, cv::Point(40, 5), cv::Point(40, 35), WHITE, 1, cv::LINE_8);
+    g.check(nz(lv) == 31, "vertical line != 31 pixels");
+    /* main-diagonal line from (0,0) to (20,20): the Bresenham diagonal hits every (i,i). */
+    cv::Mat ld = cv::Mat::zeros(H, W, CV_8U);
+    cv::line(ld, cv::Point(0, 0), cv::Point(20, 20), WHITE, 1, cv::LINE_8);
+    bool diag_ok = true;
+    for (int i = 0; i <= 20; i++) diag_ok &= (ld.at<uchar>(i, i) == 255);
+    g.check(diag_ok, "diagonal line does not hit every (i,i)");
+
+    /* filled circle center (32,32) r=12: center + points within r-1 are fill, points beyond r+1 are clean,
+       area within 8% of pi r^2. */
+    cv::Mat cc = cv::Mat::zeros(H, W, CV_8U);
+    cv::circle(cc, cv::Point(32, 32), 12, WHITE, cv::FILLED, cv::LINE_8);
+    g.check(cc.at<uchar>(32, 32) == 255, "circle center not filled");
+    g.check(cc.at<uchar>(32, 32 + 10) == 255 && cc.at<uchar>(32 - 10, 32) == 255,
+            "circle interior samples (r=10) not filled");
+    g.check(cc.at<uchar>(32, 32 + 14) == 0 && cc.at<uchar>(32 + 14, 32) == 0,
+            "circle exterior samples (r=14) not clean");
+    double area = nz(cc), ideal = CV_PI * 12 * 12;
+    g.check(std::fabs(area - ideal) / ideal < 0.08, "filled circle area not within 8% of pi r^2");
+    /* every pixel with dist<=r-1.5 is fill and every pixel with dist>=r+1.5 is background. */
+    bool sweep_ok = true;
+    for (int y = 0; y < H; y++) for (int x = 0; x < W; x++) {
+        double d = std::hypot(x - 32, y - 32);
+        if (d <= 12 - 1.5 && cc.at<uchar>(y, x) != 255) sweep_ok = false;
+        if (d >= 12 + 1.5 && cc.at<uchar>(y, x) != 0)   sweep_ok = false;
+    }
+    g.check(sweep_ok, "circle analytic coverage sweep failed");
+
+    /* ellipse (full 0..360) center (32,32) axes (16,8): its bbox is [16,48]x[24,40]; center filled, a
+       point outside the bbox (top-left corner) is clean. */
+    cv::Mat el = cv::Mat::zeros(H, W, CV_8U);
+    cv::ellipse(el, cv::Point(32, 32), cv::Size(16, 8), 0, 0, 360, WHITE, cv::FILLED, cv::LINE_8);
+    g.check(el.at<uchar>(32, 32) == 255, "ellipse center not filled");
+    g.check(el.at<uchar>(0, 0) == 0, "ellipse leaked to corner");
+    /* semi-axis extents: (32+15,32) inside, (32,32+7) inside, (32+18,32) and (32,32+10) outside. */
+    g.check(el.at<uchar>(32, 32 + 15) == 255 && el.at<uchar>(32 + 7, 32) == 255,
+            "ellipse inside-axis samples not filled");
+    g.check(el.at<uchar>(32, 32 + 18) == 0 && el.at<uchar>(32 + 10, 32) == 0,
+            "ellipse outside-axis samples not clean");
+
+    /* fillPoly / polylines of a known axis-aligned right triangle with vertices (10,10),(30,10),(10,30).
+       The filled area is a discrete right triangle; a point well inside (12,12) is set, a point outside
+       the hypotenuse (25,25) is clean. */
+    cv::Mat tr = cv::Mat::zeros(H, W, CV_8U);
+    std::vector<cv::Point> tri = {{10, 10}, {30, 10}, {10, 30}};
+    std::vector<std::vector<cv::Point>> polys = {tri};
+    cv::fillPoly(tr, polys, WHITE, cv::LINE_8);
+    g.check(tr.at<uchar>(12, 12) == 255, "fillPoly interior (12,12) not set");
+    g.check(tr.at<uchar>(25, 25) == 0, "fillPoly leaked past the hypotenuse at (25,25)");
+    g.check(tr.at<uchar>(10, 10) == 255 && tr.at<uchar>(10, 29) == 255, "fillPoly corners not set");
+    /* polylines (outline only) of the same triangle marks its top edge row 10 across x=10..30. */
+    cv::Mat pl = cv::Mat::zeros(H, W, CV_8U);
+    cv::polylines(pl, polys, true, WHITE, 1, cv::LINE_8);
+    int top_edge = 0;
+    for (int x = 10; x <= 30; x++) if (pl.at<uchar>(10, x) == 255) top_edge++;
+    g.check(top_edge == 21, "polylines top edge != 21 pixels");
+
+    /* putText: ink lands inside the text bbox and the far corners stay clean (font-agnostic). */
+    cv::Mat tx = cv::Mat::zeros(32, 96, CV_8U);
+    cv::putText(tx, "Hi", cv::Point(4, 22), cv::FONT_HERSHEY_SIMPLEX, 0.8, WHITE, 1, cv::LINE_8);
+    g.check(nz(tx) > 0, "putText produced no ink");
+    /* ink bbox stays left/upper region; the bottom-right corner is untouched. */
+    g.check(tx.at<uchar>(31, 95) == 0 && tx.at<uchar>(0, 95) == 0, "putText leaked to far corners");
+    int left_ink = nz(tx(cv::Rect(0, 0, 48, 32)));
+    g.check(left_ink == nz(tx), "putText ink not confined to the left half where it was drawn");
+
+    return g.finish();
+}

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_feature.cpp
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_feature.cpp
@@ -1,0 +1,81 @@
+/* opencv_feature - feature/edge detectors on KNOWN geometry vs the known answer.
+ *
+ * Canny on a vertical step edge -> edges localized at the known transition column; cornerHarris /
+ * goodFeaturesToTrack on a checkerboard -> corner responses at the known grid intersections; HoughLinesP on
+ * a single drawn horizontal line -> a near-horizontal segment at the known row. Tolerances only where the
+ * detector legitimately has sub-pixel/threshold slack; the LOCATION is asserted. No RNG (fixed image).
+ */
+#include "cv_common.h"
+#include <opencv2/imgproc.hpp>
+#include <opencv2/features2d.hpp>
+#include <vector>
+#include <cmath>
+
+int main() {
+    cv::setNumThreads(1);
+    Gate g("OPENCV_FEATURE");
+
+    /* ---- Canny on a vertical step edge at column 20 ---- */
+    cv::Mat step = cv::Mat::zeros(40, 40, CV_8U);
+    step(cv::Rect(20, 0, 20, 40)).setTo(255);   /* left half 0, right half 255 */
+    cv::Mat edges; cv::Canny(step, edges, 50, 150);
+    /* the only edge is the vertical transition: every edge pixel sits in columns 19..20, and every row in
+       the interior has an edge there. */
+    bool edge_col_ok = true; int edge_rows = 0;
+    for (int y = 1; y < 39; y++) {
+        bool has = false;
+        for (int x = 0; x < 40; x++) if (edges.at<uchar>(y, x)) {
+            has = true;
+            if (x < 18 || x > 21) edge_col_ok = false;   /* edge must be at the step */
+        }
+        if (has) edge_rows++;
+    }
+    g.check(edge_col_ok, "Canny edge not localized at the step column (18..21)");
+    g.check(edge_rows >= 36, "Canny did not find the edge on (nearly) every interior row");
+    /* no edges in the flat interiors far from the step. */
+    g.check(edges.at<uchar>(20, 5) == 0 && edges.at<uchar>(20, 35) == 0, "Canny fired in a flat region");
+
+    /* ---- cornerHarris on a checkerboard: strong response at the interior grid intersection ---- */
+    /* 4x4 board of 10px squares (40x40); interior corners sit at multiples of 10: (10,10),(10,20)... */
+    cv::Mat board = cv::Mat::zeros(40, 40, CV_8U);
+    for (int by = 0; by < 4; by++) for (int bx = 0; bx < 4; bx++)
+        if ((bx + by) & 1) board(cv::Rect(bx * 10, by * 10, 10, 10)).setTo(255);
+    cv::Mat harris; cv::cornerHarris(board, harris, 2, 3, 0.04);
+    double hmin, hmax; cv::minMaxLoc(harris, &hmin, &hmax);
+    g.check(hmax > 0, "cornerHarris produced no positive response");
+    /* the response at a true interior intersection (20,20) is a large fraction of the max; a point in the
+       middle of a flat square (5,5) is essentially zero. */
+    float resp_corner = harris.at<float>(20, 20);
+    float resp_flat = std::fabs(harris.at<float>(5, 5));
+    g.check(resp_corner > 0.2f * (float)hmax, "Harris response weak at a known intersection (20,20)");
+    g.check(resp_flat < 0.05f * (float)hmax, "Harris response not ~0 inside a flat square (5,5)");
+
+    /* ---- goodFeaturesToTrack on the same board: detected corners snap to grid intersections ---- */
+    std::vector<cv::Point2f> corners;
+    cv::goodFeaturesToTrack(board, corners, 20, 0.1, 5);
+    g.check(!corners.empty(), "goodFeaturesToTrack found no corners on a checkerboard");
+    /* every detected corner lies within 2px of a multiple-of-10 grid intersection. */
+    bool on_grid = true;
+    for (auto &c : corners) {
+        double rx = std::fabs(c.x - std::round(c.x / 10.0) * 10.0);
+        double ry = std::fabs(c.y - std::round(c.y / 10.0) * 10.0);
+        if (rx > 2.5 || ry > 2.5) on_grid = false;
+    }
+    g.check(on_grid, "a detected corner is not near a grid intersection");
+
+    /* ---- HoughLinesP on a single horizontal line at row 25 ---- */
+    cv::Mat lineimg = cv::Mat::zeros(60, 60, CV_8U);
+    cv::line(lineimg, cv::Point(5, 25), cv::Point(54, 25), 255, 1, cv::LINE_8);
+    std::vector<cv::Vec4i> lines;
+    cv::HoughLinesP(lineimg, lines, 1, CV_PI / 180.0, 30, 30, 5);
+    g.check(!lines.empty(), "HoughLinesP found no line");
+    /* at least one detected segment is horizontal (|dy|<=1) and sits at row ~25. */
+    bool found_h = false;
+    for (auto &L : lines) {
+        int x1 = L[0], y1 = L[1], x2 = L[2], y2 = L[3];
+        if (std::abs(y1 - y2) <= 1 && std::abs(y1 - 25) <= 1 && std::abs(x2 - x1) >= 30) found_h = true;
+    }
+    g.check(found_h, "HoughLinesP did not recover the horizontal line at row 25");
+
+    return g.finish();
+}

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_filter.cpp
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_filter.cpp
@@ -1,0 +1,96 @@
+/* opencv_filter - convolution/filtering vs closed form, per pixel.
+ *
+ * GaussianBlur of a single-pixel impulse -> the output equals the normalized separable Gaussian kernel
+ * (assert against cv::getGaussianKernel's outer product, and pin the exact center/neighbor weights);
+ * Sobel of a known linear ramp -> a constant derivative; boxFilter of a constant -> the same constant;
+ * medianBlur removes a lone outlier while leaving a constant field untouched. No RNG.
+ */
+#include "cv_common.h"
+#include <opencv2/imgproc.hpp>
+
+int main() {
+    cv::setNumThreads(1);
+    Gate g("OPENCV_FILTER");
+
+    const int N = 9, c = N / 2;   /* impulse at the center of a 9x9 field */
+
+    /* ---- GaussianBlur impulse -> normalized Gaussian kernel ---- */
+    cv::Mat impulse = cv::Mat::zeros(N, N, CV_32F);
+    impulse.at<float>(c, c) = 1.0f;
+    int ks = 5; double sigma = 1.0;
+    cv::Mat blur;
+    cv::GaussianBlur(impulse, blur, cv::Size(ks, ks), sigma, sigma, cv::BORDER_CONSTANT);
+
+    /* closed form: separable kernel k = getGaussianKernel(ks,sigma); 2D weight = k[i]*k[j]. The blurred
+       impulse at (c+dy, c+dx) must equal that product exactly (BORDER_CONSTANT, impulse fully interior). */
+    cv::Mat k1 = cv::getGaussianKernel(ks, sigma, CV_32F);   /* ks x 1 */
+    bool gk_ok = true; double ksum = 0;
+    for (int dy = -ks / 2; dy <= ks / 2; dy++)
+        for (int dx = -ks / 2; dx <= ks / 2; dx++) {
+            float want = k1.at<float>(dy + ks / 2) * k1.at<float>(dx + ks / 2);
+            float got = blur.at<float>(c + dy, c + dx);
+            gk_ok &= close_d(got, want, 1e-6);
+            ksum += got;
+        }
+    g.check(gk_ok, "GaussianBlur(impulse) != outer(k,k) closed form");
+    g.check(close_d(ksum, 1.0, 1e-5), "Gaussian kernel does not sum to 1");
+    /* pin the exact getGaussianKernel(5,1.0) values (symmetric, host-calibrated):
+       [0.054489, 0.244201, 0.40262, 0.244201, 0.054489]. Center 2D weight = 0.40262^2 = 0.162103. */
+    g.check(close_d(k1.at<float>(0), 0.054489f, 1e-4), "outer Gaussian tap != 0.054489");
+    g.check(close_d(k1.at<float>(1), 0.244201f, 1e-4), "mid Gaussian tap != 0.244201");
+    g.check(close_d(k1.at<float>(2), 0.40262f, 1e-4), "center Gaussian tap != 0.40262");
+    g.check(close_d(blur.at<float>(c, c), 0.40262f * 0.40262f, 1e-4), "center pixel != w0^2");
+    /* far pixels (outside the kernel support) stay exactly zero. */
+    g.check(blur.at<float>(0, 0) == 0.0f && blur.at<float>(N - 1, N - 1) == 0.0f,
+            "Gaussian leaked outside kernel support");
+
+    /* ---- Sobel of a linear ramp -> constant derivative ---- */
+    /* image f(x,y) = 10*x (ramp along x). d/dx = 10; a 3x3 Sobel x scales the gradient by 8 (sum of the
+       positive weights on one side = 1+2+1 = 4 per column pair => factor 8 for a unit-slope ramp; for
+       slope 10 the response is 8*10 = 80 in interior pixels). */
+    cv::Mat ramp(7, 7, CV_32F);
+    for (int y = 0; y < 7; y++) for (int x = 0; x < 7; x++) ramp.at<float>(y, x) = 10.0f * x;
+    cv::Mat sx;
+    cv::Sobel(ramp, sx, CV_32F, 1, 0, 3, 1, 0, cv::BORDER_REPLICATE);
+    bool sob_ok = true;
+    for (int y = 1; y < 6; y++) for (int x = 1; x < 6; x++)
+        sob_ok &= close_d(sx.at<float>(y, x), 80.0, 1e-4);   /* 8 * slope(10) */
+    g.check(sob_ok, "Sobel-x of ramp(10x) != constant 80 interior");
+    /* Sobel y of an x-ramp is 0 (no vertical variation). */
+    cv::Mat sy; cv::Sobel(ramp, sy, CV_32F, 0, 1, 3, 1, 0, cv::BORDER_REPLICATE);
+    bool sy_ok = true;
+    for (int y = 1; y < 6; y++) for (int x = 1; x < 6; x++) sy_ok &= close_d(sy.at<float>(y, x), 0.0, 1e-4);
+    g.check(sy_ok, "Sobel-y of x-ramp != 0");
+
+    /* ---- boxFilter of a constant -> the same constant ---- */
+    cv::Mat konst(8, 8, CV_32F, cv::Scalar(42.0));
+    cv::Mat box; cv::boxFilter(konst, box, CV_32F, cv::Size(3, 3), cv::Point(-1, -1), true,
+                               cv::BORDER_REPLICATE);
+    bool box_ok = true;
+    for (int y = 0; y < 8; y++) for (int x = 0; x < 8; x++) box_ok &= close_d(box.at<float>(y, x), 42.0, 1e-4);
+    g.check(box_ok, "boxFilter(constant) != constant");
+    /* blur() (normalized box) of a constant is also the constant. */
+    cv::Mat blr; cv::blur(konst, blr, cv::Size(5, 5), cv::Point(-1, -1), cv::BORDER_REPLICATE);
+    bool blr_ok = true;
+    for (int y = 0; y < 8; y++) for (int x = 0; x < 8; x++) blr_ok &= close_d(blr.at<float>(y, x), 42.0, 1e-4);
+    g.check(blr_ok, "blur(constant) != constant");
+
+    /* ---- medianBlur removes a lone outlier, keeps the constant field ---- */
+    cv::Mat med_in(7, 7, CV_8U, cv::Scalar(100));
+    med_in.at<uchar>(3, 3) = 255;   /* one salt spike */
+    cv::Mat med; cv::medianBlur(med_in, med, 3);
+    g.check(med.at<uchar>(3, 3) == 100, "medianBlur did not remove lone outlier");
+    bool med_flat = true;
+    for (int y = 1; y < 6; y++) for (int x = 1; x < 6; x++) med_flat &= (med.at<uchar>(y, x) == 100);
+    g.check(med_flat, "medianBlur disturbed the constant field");
+
+    /* ---- filter2D with an identity kernel returns the input exactly ---- */
+    cv::Mat idk = cv::Mat::zeros(3, 3, CV_32F); idk.at<float>(1, 1) = 1.0f;
+    cv::Mat idout; cv::filter2D(ramp, idout, CV_32F, idk);
+    bool id_ok = true;
+    for (int y = 1; y < 6; y++) for (int x = 1; x < 6; x++)
+        id_ok &= close_d(idout.at<float>(y, x), ramp.at<float>(y, x), 1e-4);
+    g.check(id_ok, "filter2D(identity) != input");
+
+    return g.finish();
+}

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_geometry.cpp
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_geometry.cpp
@@ -1,0 +1,84 @@
+/* opencv_geometry - geometric transforms vs closed form, at known points.
+ *
+ * resize INTER_NEAREST (exact source pixel), INTER_LINEAR (bilinear closed form at known coords), flip,
+ * transpose, warpAffine translation (exact pixel shift), getRotationMatrix2D matrix values, warpAffine
+ * 90-degree rotation (exact pixel mapping). No RNG.
+ */
+#include "cv_common.h"
+#include <opencv2/imgproc.hpp>
+
+int main() {
+    cv::setNumThreads(1);
+    Gate g("OPENCV_GEOMETRY");
+
+    /* 2x2 source with distinct values so mappings are unambiguous. */
+    cv::Mat src = (cv::Mat_<uchar>(2, 2) << 10, 20, 30, 40);
+
+    /* resize x2 INTER_NEAREST: each source pixel replicated into a 2x2 block. */
+    cv::Mat up; cv::resize(src, up, cv::Size(4, 4), 0, 0, cv::INTER_NEAREST);
+    bool nn_ok = true;
+    for (int y = 0; y < 4; y++) for (int x = 0; x < 4; x++)
+        nn_ok &= (up.at<uchar>(y, x) == src.at<uchar>(y / 2, x / 2));
+    g.check(nn_ok, "resize NEAREST x2 != block replication");
+
+    /* resize INTER_LINEAR: bilinear at a known point. Scale a 2x2 [[0,10],[20,30]] to 4x4; OpenCV maps
+       dst (x,y) to src ((x+0.5)*sx-0.5, ...) with sx=2/4=0.5. dst(1,1) -> src(0.25,0.25):
+       f = (1-0.25)(1-0.25)*0 + 0.25(1-0.25)*10 + (1-0.25)0.25*20 + 0.25*0.25*30
+         = 1.875 + 3.75 + 1.875 = 7.5 -> rounds to 8. */
+    cv::Mat lin = (cv::Mat_<uchar>(2, 2) << 0, 10, 20, 30);
+    cv::Mat linup; cv::resize(lin, linup, cv::Size(4, 4), 0, 0, cv::INTER_LINEAR);
+    g.check(close_i(linup.at<uchar>(1, 1), 8, 1), "bilinear dst(1,1) != ~7.5");
+    /* corner dst(0,0) -> src(-0.25,-0.25) clamped to (0,0) => value 0 exactly. */
+    g.check(linup.at<uchar>(0, 0) == 0, "bilinear corner(0,0) != 0");
+
+    /* flip: horizontal (code 1) swaps columns; vertical (code 0) swaps rows. */
+    cv::Mat fh; cv::flip(src, fh, 1);
+    g.check(fh.at<uchar>(0, 0) == 20 && fh.at<uchar>(0, 1) == 10 &&
+            fh.at<uchar>(1, 0) == 40 && fh.at<uchar>(1, 1) == 30, "flip horizontal mismatch");
+    cv::Mat fv; cv::flip(src, fv, 0);
+    g.check(fv.at<uchar>(0, 0) == 30 && fv.at<uchar>(1, 0) == 10, "flip vertical mismatch");
+
+    /* transpose: dst(j,i) == src(i,j). */
+    cv::Mat tp; cv::transpose(src, tp);
+    g.check(tp.at<uchar>(0, 1) == src.at<uchar>(1, 0) && tp.at<uchar>(1, 0) == src.at<uchar>(0, 1),
+            "transpose mismatch");
+
+    /* warpAffine pure translation by (+1,+1): dst(y,x) == src(y-1,x-1); a marker pixel moves exactly. */
+    cv::Mat marker = cv::Mat::zeros(5, 5, CV_8U);
+    marker.at<uchar>(1, 1) = 200;
+    cv::Mat Tm = (cv::Mat_<double>(2, 3) << 1, 0, 1, 0, 1, 1);   /* shift +1 x, +1 y */
+    cv::Mat shifted; cv::warpAffine(marker, shifted, Tm, marker.size(), cv::INTER_NEAREST);
+    g.check(shifted.at<uchar>(2, 2) == 200, "warpAffine translation did not move marker to (2,2)");
+    g.check(shifted.at<uchar>(1, 1) == 0, "warpAffine left a ghost at old position");
+
+    /* getRotationMatrix2D(center, 90deg, 1.0): [[cos,sin,...],[-sin,cos,...]] with cos0 sin1. */
+    cv::Point2f ctr(2, 2);
+    cv::Mat R = cv::getRotationMatrix2D(ctr, 90.0, 1.0);
+    g.check(close_d(R.at<double>(0, 0), 0.0, 1e-9) && close_d(R.at<double>(0, 1), 1.0, 1e-9) &&
+            close_d(R.at<double>(1, 0), -1.0, 1e-9) && close_d(R.at<double>(1, 1), 0.0, 1e-9),
+            "getRotationMatrix2D(90) cos/sin block wrong");
+    /* the affine maps center to itself: R*[cx,cy,1]^T == [cx,cy]. */
+    double mx = R.at<double>(0, 0) * 2 + R.at<double>(0, 1) * 2 + R.at<double>(0, 2);
+    double my = R.at<double>(1, 0) * 2 + R.at<double>(1, 1) * 2 + R.at<double>(1, 2);
+    g.check(close_d(mx, 2, 1e-9) && close_d(my, 2, 1e-9), "rotation does not fix its center");
+
+    /* warpAffine 90deg rotation about center: a marker at (1,2) maps to the known rotated location. For a
+       5x5 image with center (2,2) and +90deg (OpenCV CCW in image coords via the matrix above),
+       dst = R * [x,y,1]. Marker src pixel appears where R maps it. Compute the exact destination. */
+    cv::Mat rimg = cv::Mat::zeros(5, 5, CV_8U);
+    rimg.at<uchar>(2, 1) = 150;   /* (x=1,y=2) */
+    cv::Mat rot; cv::warpAffine(rimg, rot, R, rimg.size(), cv::INTER_NEAREST);
+    int dx = (int)std::lround(R.at<double>(0, 0) * 1 + R.at<double>(0, 1) * 2 + R.at<double>(0, 2));
+    int dy = (int)std::lround(R.at<double>(1, 0) * 1 + R.at<double>(1, 1) * 2 + R.at<double>(1, 2));
+    g.check(dx >= 0 && dx < 5 && dy >= 0 && dy < 5 && rot.at<uchar>(dy, dx) == 150,
+            "warpAffine 90deg did not land marker at closed-form (dx,dy)");
+
+    /* getAffineTransform from 3 point pairs of a pure +1/+1 translation reproduces the shift matrix. */
+    cv::Point2f s3[3] = {{0, 0}, {1, 0}, {0, 1}}, d3[3] = {{1, 1}, {2, 1}, {1, 2}};
+    cv::Mat AT = cv::getAffineTransform(s3, d3);
+    g.check(close_d(AT.at<double>(0, 0), 1, 1e-6) && close_d(AT.at<double>(0, 2), 1, 1e-6) &&
+            close_d(AT.at<double>(1, 1), 1, 1e-6) && close_d(AT.at<double>(1, 2), 1, 1e-6),
+            "getAffineTransform of a +1/+1 shift wrong");
+
+    return g.finish();
+}

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_io.cpp
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_io.cpp
@@ -1,0 +1,148 @@
+/* opencv_io - codec/container round-trips vs byte-exact / PSNR goldens.
+ *
+ * imencode/imdecode in-memory for PNG/BMP/PPM/TIFF/WebP (lossless -> byte-exact) and JPEG (lossy -> PSNR
+ * bound); imwrite/imread file round-trip; VideoWriter+VideoCapture of a synthetic clip -> exact frame count
+ * and first-frame content (FFV1 lossless). Real-asset leg reads images from ASSET_DIR (honest-skip if none).
+ * Seeded RNG (0x233) for the test image so the bytes are fixed across arch.
+ */
+#include "cv_common.h"
+#include <opencv2/imgcodecs.hpp>
+#include <opencv2/videoio.hpp>
+#include <opencv2/imgproc.hpp>
+#include <vector>
+#include <string>
+#include <cstdlib>
+#include <sys/stat.h>
+#include <dirent.h>
+
+static double psnr(const cv::Mat &a, const cv::Mat &b) {
+    cv::Mat d; cv::absdiff(a, b, d); d.convertTo(d, CV_32F); d = d.mul(d);
+    double mse = cv::mean(d)[0] + cv::mean(d)[1] + cv::mean(d)[2];
+    mse /= 3.0;
+    if (mse <= 1e-10) return 1e9;
+    return 10.0 * std::log10(255.0 * 255.0 / mse);
+}
+
+int main() {
+    Gate g("OPENCV_IO");
+    cv::setNumThreads(1);
+
+    /* fixed seeded test image (0x233). */
+    cv::RNG rng(0x233);
+    cv::Mat img(24, 32, CV_8UC3);
+    rng.fill(img, cv::RNG::UNIFORM, 0, 256);
+
+    /* lossless in-memory round-trips: decoded bytes must equal the source exactly. */
+    struct { const char *ext; } lossless[] = {{".png"}, {".bmp"}, {".ppm"}, {".tiff"}, {".webp"}};
+    for (auto &f : lossless) {
+        std::vector<uchar> buf;
+        bool enc = cv::imencode(f.ext, img, buf);
+        if (!enc || buf.empty()) { g.check(false, f.ext); continue; }
+        cv::Mat dec = cv::imdecode(buf, cv::IMREAD_COLOR);
+        bool exact = (!dec.empty() && dec.size() == img.size() &&
+                      cv::countNonZero(dec.reshape(1) != img.reshape(1)) == 0);
+        g.check(exact, (std::string("lossless round-trip not byte-exact: ") + f.ext).c_str());
+    }
+
+    /* JPEG lossy: use a smooth gradient (representative photographic content; pure noise defeats DCT and is
+       not a meaningful PSNR target). q95 must reconstruct with high PSNR but is not byte-exact. */
+    {
+        cv::Mat grad(24, 32, CV_8UC3);
+        for (int y = 0; y < 24; y++) for (int x = 0; x < 32; x++)
+            grad.at<cv::Vec3b>(y, x) = cv::Vec3b((uchar)(x * 8), (uchar)(y * 10), (uchar)((x + y) * 4));
+        std::vector<uchar> buf;
+        std::vector<int> params = {cv::IMWRITE_JPEG_QUALITY, 95};
+        bool enc = cv::imencode(".jpg", grad, buf, params);
+        cv::Mat dec = enc ? cv::imdecode(buf, cv::IMREAD_COLOR) : cv::Mat();
+        g.check(enc && !dec.empty() && dec.size() == grad.size(), "JPEG encode/decode failed");
+        g.check(!dec.empty() && psnr(grad, dec) > 35.0, "JPEG q95 PSNR below 35 dB on a gradient");
+        g.check(!dec.empty() && cv::countNonZero(dec.reshape(1) != grad.reshape(1)) > 0,
+                "JPEG unexpectedly byte-exact (should be lossy)");
+    }
+
+    /* PGM (gray) lossless round-trip on a single-channel image. */
+    {
+        cv::Mat gray; cv::cvtColor(img, gray, cv::COLOR_BGR2GRAY);
+        std::vector<uchar> buf;
+        bool enc = cv::imencode(".pgm", gray, buf);
+        cv::Mat dec = enc ? cv::imdecode(buf, cv::IMREAD_GRAYSCALE) : cv::Mat();
+        g.check(enc && !dec.empty() && cv::countNonZero(dec != gray) == 0, "PGM gray round-trip not exact");
+    }
+
+    /* IMREAD_GRAYSCALE decode of a color PNG yields the BT.601 gray of the image. */
+    {
+        std::vector<uchar> buf; cv::imencode(".png", img, buf);
+        cv::Mat gdec = cv::imdecode(buf, cv::IMREAD_GRAYSCALE);
+        cv::Mat gref; cv::cvtColor(img, gref, cv::COLOR_BGR2GRAY);
+        g.check(!gdec.empty() && cv::countNonZero(cv::abs(gdec - gref) > 1) == 0,
+                "IMREAD_GRAYSCALE decode != BT.601 gray");
+    }
+
+    /* imwrite/imread file round-trip through a writable temp dir. */
+    const char *tmp = getenv("TMPDIR"); std::string tdir = tmp ? tmp : "/tmp";
+    {
+        std::string p = tdir + "/cvio_rt.png";
+        bool w = cv::imwrite(p, img);
+        cv::Mat rd = cv::imread(p, cv::IMREAD_COLOR);
+        g.check(w && !rd.empty() && cv::countNonZero(rd.reshape(1) != img.reshape(1)) == 0,
+                "imwrite/imread PNG file round-trip not exact");
+        remove(p.c_str());
+    }
+
+    /* VideoWriter + VideoCapture: synthetic 5-frame clip, FFV1 lossless -> exact frame count + first-frame
+       content. If no working writer is available, honest-skip the video legs. */
+    {
+        std::string vp = tdir + "/cvio_clip.avi";
+        int fourcc = cv::VideoWriter::fourcc('F', 'F', 'V', '1');
+        cv::VideoWriter vw(vp, fourcc, 10.0, cv::Size(32, 32), true);
+        if (!vw.isOpened()) {
+            g.skip("no FFV1 VideoWriter available - video legs skipped");
+        } else {
+            std::vector<cv::Mat> frames;
+            for (int i = 0; i < 5; i++) {
+                cv::Mat fr(32, 32, CV_8UC3, cv::Scalar(i * 10, 0, 0));
+                fr.at<cv::Vec3b>(0, 0) = cv::Vec3b(i, i + 1, i + 2);
+                frames.push_back(fr.clone());
+                vw.write(fr);
+            }
+            vw.release();
+            cv::VideoCapture cap(vp);
+            g.check(cap.isOpened(), "VideoCapture failed to open the written clip");
+            int cnt = (int)cap.get(cv::CAP_PROP_FRAME_COUNT);
+            g.check(cnt == 5, "clip frame count != 5");
+            cv::Mat f0; bool got = cap.read(f0);
+            g.check(got && !f0.empty(), "could not read first frame");
+            g.check(got && f0.at<cv::Vec3b>(0, 0) == cv::Vec3b(0, 1, 2),
+                    "first-frame marker pixel != (0,1,2)");
+            g.check(got && std::abs((int)cv::mean(f0)[0] - 0) <= 1, "first-frame B mean != 0");
+            cap.release();
+            remove(vp.c_str());
+        }
+    }
+
+    /* Real-asset leg: read every image under ASSET_DIR and assert it decodes to a nonempty 3-channel Mat.
+       Honest-skip if ASSET_DIR is absent or empty. */
+    const char *ad = getenv("ASSET_DIR");
+    int read_assets = 0;
+    if (ad) {
+        DIR *d = opendir(ad);
+        if (d) {
+            struct dirent *e;
+            while ((e = readdir(d))) {
+                std::string n = e->d_name;
+                auto ends = [&](const char *s){ return n.size() >= strlen(s) &&
+                    n.compare(n.size() - strlen(s), strlen(s), s) == 0; };
+                if (ends(".png") || ends(".jpg") || ends(".bmp") || ends(".ppm") || ends(".tiff")) {
+                    cv::Mat m = cv::imread(std::string(ad) + "/" + n, cv::IMREAD_COLOR);
+                    g.check(!m.empty() && m.channels() == 3,
+                            (std::string("asset failed to decode: ") + n).c_str());
+                    read_assets++;
+                }
+            }
+            closedir(d);
+        }
+    }
+    if (read_assets == 0) g.skip("no images under ASSET_DIR - real-asset leg honest-skipped");
+
+    return g.finish();
+}

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_mat.cpp
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_mat.cpp
@@ -1,0 +1,107 @@
+/* opencv_mat - cv::Mat arithmetic & structure vs element-exact closed form.
+ *
+ * add / subtract / multiply (per-element) / matmul (gemm) / transpose on KNOWN small matrices, asserted
+ * element-exact against a hand-computed golden; plus Mat type/channels/ROI/reshape semantics. No RNG.
+ */
+#include "cv_common.h"
+#include <opencv2/imgproc.hpp>
+
+int main() {
+    cv::setNumThreads(1);
+    Gate g("OPENCV_MAT");
+
+    /* Known 2x3 / 3x2 integer matrices. */
+    cv::Mat A = (cv::Mat_<double>(2, 3) << 1, 2, 3, 4, 5, 6);
+    cv::Mat B = (cv::Mat_<double>(2, 3) << 6, 5, 4, 3, 2, 1);
+
+    /* element-wise add: A+B == all 7s */
+    cv::Mat S = A + B;
+    bool add_ok = true;
+    for (int i = 0; i < 2; i++) for (int j = 0; j < 3; j++)
+        add_ok &= close_d(S.at<double>(i, j), 7.0, 1e-9);
+    g.check(add_ok, "A+B != 7 everywhere");
+
+    /* element-wise subtract: A-B == [-5,-3,-1;1,3,5] */
+    cv::Mat D = A - B;
+    double sub_gold[2][3] = {{-5, -3, -1}, {1, 3, 5}};
+    bool sub_ok = true;
+    for (int i = 0; i < 2; i++) for (int j = 0; j < 3; j++)
+        sub_ok &= close_d(D.at<double>(i, j), sub_gold[i][j], 1e-9);
+    g.check(sub_ok, "A-B mismatch");
+
+    /* element-wise multiply (Hadamard): A.mul(B) == [6,10,12;12,10,6] */
+    cv::Mat M = A.mul(B);
+    double mul_gold[2][3] = {{6, 10, 12}, {12, 10, 6}};
+    bool mul_ok = true;
+    for (int i = 0; i < 2; i++) for (int j = 0; j < 3; j++)
+        mul_ok &= close_d(M.at<double>(i, j), mul_gold[i][j], 1e-9);
+    g.check(mul_ok, "A.mul(B) mismatch");
+
+    /* scalar multiply: 2*A */
+    cv::Mat A2 = 2.0 * A;
+    bool s2_ok = true;
+    for (int i = 0; i < 2; i++) for (int j = 0; j < 3; j++)
+        s2_ok &= close_d(A2.at<double>(i, j), 2 * A.at<double>(i, j), 1e-9);
+    g.check(s2_ok, "2*A mismatch");
+
+    /* matmul (gemm): A(2x3) * A^T(3x2) = [[14,32],[32,77]] */
+    cv::Mat G = A * A.t();
+    double mm_gold[2][2] = {{14, 32}, {32, 77}};
+    bool mm_ok = (G.rows == 2 && G.cols == 2);
+    for (int i = 0; i < 2 && mm_ok; i++) for (int j = 0; j < 2; j++)
+        mm_ok &= close_d(G.at<double>(i, j), mm_gold[i][j], 1e-9);
+    g.check(mm_ok, "A*A^T (gemm) mismatch");
+
+    /* transpose: A^T is 3x2 with A^T(j,i)==A(i,j) */
+    cv::Mat T = A.t();
+    bool t_ok = (T.rows == 3 && T.cols == 2);
+    for (int i = 0; i < 2 && t_ok; i++) for (int j = 0; j < 3; j++)
+        t_ok &= close_d(T.at<double>(j, i), A.at<double>(i, j), 1e-9);
+    g.check(t_ok, "transpose mismatch");
+
+    /* determinant of a known 2x2: det([[1,2],[3,4]]) = -2 */
+    cv::Mat K = (cv::Mat_<double>(2, 2) << 1, 2, 3, 4);
+    g.check(close_d(cv::determinant(K), -2.0, 1e-9), "det != -2");
+
+    /* inverse: K * K^-1 == I */
+    cv::Mat Ki = K.inv();
+    cv::Mat I2 = K * Ki;
+    bool inv_ok = close_d(I2.at<double>(0, 0), 1, 1e-9) && close_d(I2.at<double>(1, 1), 1, 1e-9) &&
+                  close_d(I2.at<double>(0, 1), 0, 1e-9) && close_d(I2.at<double>(1, 0), 0, 1e-9);
+    g.check(inv_ok, "K*K^-1 != I");
+
+    /* type / channels: a 3-channel 8U image */
+    cv::Mat C8 = cv::Mat::zeros(4, 5, CV_8UC3);
+    g.check(C8.type() == CV_8UC3, "type != CV_8UC3");
+    g.check(C8.channels() == 3, "channels != 3");
+    g.check(C8.rows == 4 && C8.cols == 5, "shape != 4x5");
+    g.check(C8.elemSize() == 3, "elemSize != 3 bytes");
+
+    /* ROI is a view: writing a ROI mutates the parent at the mapped location and nowhere else. */
+    cv::Mat P = cv::Mat::zeros(6, 6, CV_8UC1);
+    cv::Mat roi = P(cv::Rect(1, 2, 3, 2));   /* x=1,y=2,w=3,h=2 */
+    roi.setTo(200);
+    bool roi_ok = true;
+    for (int y = 0; y < 6; y++) for (int x = 0; x < 6; x++) {
+        int expect = (x >= 1 && x < 4 && y >= 2 && y < 4) ? 200 : 0;
+        roi_ok &= (P.at<uchar>(y, x) == expect);
+    }
+    g.check(roi_ok, "ROI write did not map back to parent exactly");
+
+    /* reshape: 12 contiguous values reshaped 1x12 -> 3x4 keeps row-major order. */
+    cv::Mat lin(1, 12, CV_32S);
+    for (int i = 0; i < 12; i++) lin.at<int>(0, i) = i;
+    cv::Mat r34 = lin.reshape(1, 3);
+    bool rs_ok = (r34.rows == 3 && r34.cols == 4);
+    for (int i = 0; i < 3 && rs_ok; i++) for (int j = 0; j < 4; j++)
+        rs_ok &= (r34.at<int>(i, j) == i * 4 + j);
+    g.check(rs_ok, "reshape row-major order wrong");
+
+    /* countNonZero / min-max on a known matrix. */
+    cv::Mat mm = (cv::Mat_<uchar>(2, 3) << 0, 5, 0, 9, 0, 3);
+    g.check(cv::countNonZero(mm) == 3, "countNonZero != 3");
+    double mn, mx; cv::minMaxLoc(mm, &mn, &mx);
+    g.check(close_d(mn, 0, 1e-9) && close_d(mx, 9, 1e-9), "minMax != (0,9)");
+
+    return g.finish();
+}

--- a/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_morph.cpp
+++ b/apps/starry/cpu-opencv-test/programs/carpets/cpp/opencv_morph.cpp
@@ -1,0 +1,79 @@
+/* opencv_morph - thresholding & morphology vs closed form.
+ *
+ * threshold BINARY on a known ramp (exact split point), Otsu on a known bimodal histogram (known optimal
+ * threshold), erode/dilate/open/close of a known binary pattern vs the closed-form structuring-element
+ * result, connectedComponents count on a known multi-blob image. No RNG.
+ */
+#include "cv_common.h"
+#include <opencv2/imgproc.hpp>
+
+int main() {
+    cv::setNumThreads(1);
+    Gate g("OPENCV_MORPH");
+
+    /* threshold BINARY at t=100: value>100 -> 255 else 0. Known ramp 0,50,100,150,200. */
+    cv::Mat ramp = (cv::Mat_<uchar>(1, 5) << 0, 50, 100, 150, 200);
+    cv::Mat th; cv::threshold(ramp, th, 100, 255, cv::THRESH_BINARY);
+    /* OpenCV BINARY is strictly ">" thresh: 100 stays 0, 150/200 -> 255. */
+    g.check(th.at<uchar>(0, 0) == 0 && th.at<uchar>(0, 1) == 0 && th.at<uchar>(0, 2) == 0 &&
+            th.at<uchar>(0, 3) == 255 && th.at<uchar>(0, 4) == 255, "THRESH_BINARY split wrong");
+    cv::Mat thi; cv::threshold(ramp, thi, 100, 255, cv::THRESH_BINARY_INV);
+    g.check(thi.at<uchar>(0, 2) == 255 && thi.at<uchar>(0, 3) == 0, "THRESH_BINARY_INV split wrong");
+    cv::Mat tt; cv::threshold(ramp, tt, 100, 0, cv::THRESH_TRUNC);
+    g.check(tt.at<uchar>(0, 3) == 100 && tt.at<uchar>(0, 1) == 50, "THRESH_TRUNC wrong");
+
+    /* Otsu on a perfectly bimodal image: half pixels at 20, half at 200. The optimal threshold sits
+       between the two clusters; OpenCV returns it. Verify the returned threshold separates the modes and
+       the binarization puts every 200 -> 255 and every 20 -> 0. */
+    cv::Mat bim(1, 8, CV_8U);
+    for (int i = 0; i < 4; i++) bim.at<uchar>(0, i) = 20;
+    for (int i = 4; i < 8; i++) bim.at<uchar>(0, i) = 200;
+    cv::Mat ot; double otsu_t = cv::threshold(bim, ot, 0, 255, cv::THRESH_BINARY | cv::THRESH_OTSU);
+    /* with two discrete levels (20,200), between-class variance peaks at t=20: everything >20 (the 200s)
+       goes foreground, the 20s go background - the closed-form optimal split. */
+    g.check(otsu_t >= 20 && otsu_t < 200, "Otsu threshold not in the mode-separating range");
+    bool otsu_ok = true;
+    for (int i = 0; i < 4; i++) otsu_ok &= (ot.at<uchar>(0, i) == 0);
+    for (int i = 4; i < 8; i++) otsu_ok &= (ot.at<uchar>(0, i) == 255);
+    g.check(otsu_ok, "Otsu binarization did not separate the modes");
+
+    /* erode/dilate with a 3x3 rectangular SE on a single foreground pixel:
+       dilate -> a 3x3 block of 255; erode of that block -> back to the single pixel. */
+    cv::Mat dot = cv::Mat::zeros(7, 7, CV_8U);
+    dot.at<uchar>(3, 3) = 255;
+    cv::Mat se = cv::getStructuringElement(cv::MORPH_RECT, cv::Size(3, 3));
+    cv::Mat dil; cv::dilate(dot, dil, se);
+    int dcount = 0;
+    for (int y = 0; y < 7; y++) for (int x = 0; x < 7; x++) if (dil.at<uchar>(y, x)) dcount++;
+    g.check(dcount == 9, "dilate of a dot != 3x3 block (9 px)");
+    bool block_ok = true;
+    for (int y = 2; y <= 4; y++) for (int x = 2; x <= 4; x++) block_ok &= (dil.at<uchar>(y, x) == 255);
+    g.check(block_ok, "dilate block not centered at (3,3)");
+    cv::Mat ero; cv::erode(dil, ero, se);
+    int ecount = 0;
+    for (int y = 0; y < 7; y++) for (int x = 0; x < 7; x++) if (ero.at<uchar>(y, x)) ecount++;
+    g.check(ecount == 1 && ero.at<uchar>(3, 3) == 255, "erode(dilate(dot)) != original dot");
+
+    /* opening removes a lone speck (erode then dilate): a single pixel disappears entirely. */
+    cv::Mat speck = cv::Mat::zeros(7, 7, CV_8U); speck.at<uchar>(1, 1) = 255;
+    cv::Mat opened; cv::morphologyEx(speck, opened, cv::MORPH_OPEN, se);
+    g.check(cv::countNonZero(opened) == 0, "opening did not remove a lone speck");
+
+    /* closing fills a lone hole in a solid block (dilate then erode). */
+    cv::Mat solid(7, 7, CV_8U, cv::Scalar(255));
+    solid.at<uchar>(3, 3) = 0;   /* one hole */
+    cv::Mat closed; cv::morphologyEx(solid, closed, cv::MORPH_CLOSE, se);
+    g.check(closed.at<uchar>(3, 3) == 255, "closing did not fill the hole");
+
+    /* connectedComponents: three separated 1-pixel blobs -> 3 labels + background = 4 total. */
+    cv::Mat blobs = cv::Mat::zeros(9, 9, CV_8U);
+    blobs.at<uchar>(1, 1) = 255; blobs.at<uchar>(1, 7) = 255; blobs.at<uchar>(7, 4) = 255;
+    cv::Mat labels; int n = cv::connectedComponents(blobs, labels, 8, CV_32S);
+    g.check(n == 4, "connectedComponents count != 4 (bg + 3 blobs)");
+    /* the three blob pixels carry distinct nonzero labels; background is label 0. */
+    int l1 = labels.at<int>(1, 1), l2 = labels.at<int>(1, 7), l3 = labels.at<int>(7, 4);
+    g.check(l1 && l2 && l3 && l1 != l2 && l2 != l3 && l1 != l3 && labels.at<int>(0, 0) == 0,
+            "blob labels not distinct/background not 0");
+
+    return g.finish();
+}

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/cv_common.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/cv_common.py
@@ -1,0 +1,47 @@
+"""cv_common.py - shared primitives for the cpu-opencv-test carpet (Python side).
+
+Each cell drives real cv2 (numpy-backed cv::Mat, cvtColor, GaussianBlur, resize, threshold, drawing, Canny,
+imencode ...) on KNOWN fixed inputs and asserts against a CLOSED-FORM / numpy golden computed here - the
+numpy reference and the comparison are ours; the algorithm under test is OpenCV's. "import cv2" is not a
+test; every leg checks a value predicted from first principles.
+
+Determinism: fixed inputs, cv2.setNumThreads(1), np.random.seed(0x233) wherever any random path appears.
+
+Three-gate marker: a cell prints "OPENCV_<CELL> OK <n>" only when fail==0 and total==pass and total>0.
+"""
+import sys
+import numpy as np
+
+
+class Gate:
+    def __init__(self, name):
+        self.name = name
+        self.p = self.t = self.f = self.s = 0
+
+    def check(self, cond, msg):
+        self.t += 1
+        if cond:
+            self.p += 1
+        else:
+            self.f += 1
+            sys.stderr.write("  FAIL: %s\n" % msg)
+
+    # honest-skip: recorded distinctly (NOT as a pass) so a run that degrades every leg to skip cannot
+    # satisfy the gate; total still counts it so the "OK <n>" marker stays stable, but pass tracks only
+    # real checks and finish() requires at least one.
+    def skip(self, msg):
+        self.t += 1
+        self.s += 1
+        sys.stderr.write("  SKIP: %s\n" % msg)
+
+    def finish(self):
+        if self.f == 0 and self.p > 0 and self.p + self.s == self.t:
+            print("%s OK %d" % (self.name, self.t))
+            return 0
+        print("%s FAILED pass=%d skipped=%d total=%d fail=%d" % (self.name, self.p, self.s, self.t, self.f))
+        return 1
+
+
+def bgr2gray_601(b, g, r):
+    """OpenCV COLOR_BGR2GRAY fixed-point closed form (byte-exact for 0..255)."""
+    return (r * 4899 + g * 9617 + b * 1868 + 8192) >> 14

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_color.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_color.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""opencv_color - cvtColor conversions vs the closed-form color matrix, per pixel.
+
+BGR<->RGB (byte-exact channel swap), BGR->GRAY (BT.601 fixed-point closed form), BGR<->HSV (known primaries),
+BGR<->YCrCb, BGR<->I420 (4:2:0, luma plane == studio-swing BT.601). Known image; every pixel asserted.
+"""
+import cv2
+import numpy as np
+from cv_common import Gate, bgr2gray_601
+
+cv2.setNumThreads(1)
+g = Gate("OPENCV_COLOR")
+
+# 2x2 BGR image (memory order is BGR): red / green / blue / gray
+bgr = np.array([[[0, 0, 255], [0, 255, 0]],
+                [[255, 0, 0], [128, 128, 128]]], dtype=np.uint8)
+
+# BGR->RGB exact channel swap
+rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+g.check(np.array_equal(rgb, bgr[:, :, ::-1]), "BGR2RGB not an exact B<->R swap")
+
+# round-trip identity
+back = cv2.cvtColor(rgb, cv2.COLOR_RGB2BGR)
+g.check(np.array_equal(back, bgr), "BGR->RGB->BGR not identity")
+
+# BGR->GRAY == BT.601 fixed-point closed form, per pixel
+gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
+want = np.array([[bgr2gray_601(*(int(v) for v in bgr[y, x])) for x in range(2)]
+                 for y in range(2)], dtype=np.uint8)
+g.check(np.array_equal(gray, want), "BGR2GRAY != BT.601 closed form")
+g.check(gray[0, 0] == 76 and gray[0, 1] == 150 and gray[1, 0] == 29 and gray[1, 1] == 128,
+        "gray pins (76,150,29,128) wrong")
+
+# BGR->YCrCb: gray -> (128,128,128); Y channel == gray closed form
+ycc = cv2.cvtColor(bgr, cv2.COLOR_BGR2YCrCb)
+g.check(tuple(ycc[1, 1]) == (128, 128, 128), "YCrCb(gray) != (128,128,128)")
+g.check(np.all(np.abs(ycc[:, :, 0].astype(int) - gray.astype(int)) <= 1), "YCrCb luma != gray")
+
+# BGR->HSV: known primaries
+hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+g.check(tuple(hsv[0, 0]) == (0, 255, 255), "HSV(red) != (0,255,255)")
+g.check(tuple(hsv[0, 1]) == (60, 255, 255), "HSV(green) != (60,255,255)")
+g.check(tuple(hsv[1, 0]) == (120, 255, 255), "HSV(blue) != (120,255,255)")
+g.check(hsv[1, 1][1] == 0 and hsv[1, 1][2] == 128, "HSV(gray) S/V != (0,128)")
+
+# HSV round-trip
+hsv2bgr = cv2.cvtColor(hsv, cv2.COLOR_HSV2BGR)
+g.check(np.all(np.abs(hsv2bgr.astype(int) - bgr.astype(int)) <= 2), "HSV->BGR drifted > 2")
+
+# BGR->I420: (H*3/2)xW; Y plane == studio-swing BT.601 closed form
+big = np.zeros((4, 4, 3), dtype=np.uint8)
+for y in range(4):
+    for x in range(4):
+        big[y, x] = [(x * 40) & 0xff, (y * 40) & 0xff, ((x + y) * 30) & 0xff]
+i420 = cv2.cvtColor(big, cv2.COLOR_BGR2YUV_I420)
+g.check(i420.shape == (6, 4), "I420 shape != (6,4)")
+ywant = np.zeros((4, 4), dtype=int)
+for y in range(4):
+    for x in range(4):
+        b, gg, r = (int(v) for v in big[y, x])
+        ywant[y, x] = ((r * 66 + gg * 129 + b * 25 + 128) >> 8) + 16
+g.check(np.all(np.abs(i420[:4, :4].astype(int) - ywant) <= 1), "I420 Y != BT.601 studio-swing")
+
+# I420 -> BGR round-trip shape
+i420back = cv2.cvtColor(i420, cv2.COLOR_YUV2BGR_I420)
+g.check(i420back.shape == (4, 4, 3), "I420->BGR shape wrong")
+
+raise SystemExit(g.finish())

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_draw.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_draw.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""opencv_draw - 2D drawing primitives vs the analytic shape, per pixel (LINE_8, no anti-aliasing).
+
+rectangle (filled area + clean exterior), line (axis-aligned exact + diagonal), circle (fill samples +
+analytic pi r^2 coverage sweep), ellipse, fillPoly/polylines of a known triangle, putText ink-in-bbox.
+"""
+import math
+import cv2
+import numpy as np
+from cv_common import Gate
+
+cv2.setNumThreads(1)
+g = Gate("OPENCV_DRAW")
+W, H = 64, 64
+
+
+def nz(m):
+    return int(cv2.countNonZero(m))
+
+
+# filled rectangle [10..29]x[8..19] -> 20x12 = 240
+r = np.zeros((H, W), dtype=np.uint8)
+cv2.rectangle(r, (10, 8), (29, 19), 255, cv2.FILLED, cv2.LINE_8)
+g.check(nz(r) == 240, "filled rectangle area != 240")
+mask = np.zeros((H, W), dtype=np.uint8)
+mask[8:20, 10:30] = 255
+g.check(np.array_equal(r, mask), "filled rectangle != exact analytic mask")
+
+# horizontal line row 30, x 5..25
+ln = np.zeros((H, W), dtype=np.uint8)
+cv2.line(ln, (5, 30), (25, 30), 255, 1, cv2.LINE_8)
+g.check(nz(ln) == 21 and np.all(ln[30, 5:26] == 255), "horizontal line != 21 exact pixels")
+g.check(ln[29, 15] == 0 and ln[31, 15] == 0, "line leaked to adjacent rows")
+lv = np.zeros((H, W), dtype=np.uint8)
+cv2.line(lv, (40, 5), (40, 35), 255, 1, cv2.LINE_8)
+g.check(nz(lv) == 31, "vertical line != 31 pixels")
+ld = np.zeros((H, W), dtype=np.uint8)
+cv2.line(ld, (0, 0), (20, 20), 255, 1, cv2.LINE_8)
+g.check(all(ld[i, i] == 255 for i in range(21)), "diagonal misses (i,i)")
+
+# filled circle center (32,32) r=12
+cc = np.zeros((H, W), dtype=np.uint8)
+cv2.circle(cc, (32, 32), 12, 255, cv2.FILLED, cv2.LINE_8)
+g.check(cc[32, 32] == 255, "circle center not filled")
+g.check(cc[32, 42] == 255 and cc[22, 32] == 255, "circle r=10 samples not filled")
+g.check(cc[32, 46] == 0 and cc[46, 32] == 0, "circle r=14 samples not clean")
+area, ideal = nz(cc), math.pi * 144
+g.check(abs(area - ideal) / ideal < 0.08, "circle area not within 8% pi r^2")
+yy, xx = np.mgrid[0:H, 0:W]
+dist = np.hypot(xx - 32, yy - 32)
+g.check(np.all(cc[dist <= 12 - 1.5] == 255) and np.all(cc[dist >= 12 + 1.5] == 0),
+        "circle analytic coverage sweep failed")
+
+# ellipse center (32,32) axes (16,8)
+el = np.zeros((H, W), dtype=np.uint8)
+cv2.ellipse(el, (32, 32), (16, 8), 0, 0, 360, 255, cv2.FILLED, cv2.LINE_8)
+g.check(el[32, 32] == 255 and el[0, 0] == 0, "ellipse center/corner wrong")
+g.check(el[32, 47] == 255 and el[39, 32] == 255, "ellipse inside-axis not filled")
+g.check(el[32, 50] == 0 and el[42, 32] == 0, "ellipse outside-axis not clean")
+
+# fillPoly / polylines of a right triangle (10,10),(30,10),(10,30)
+tri = np.array([[10, 10], [30, 10], [10, 30]], dtype=np.int32)
+tr = np.zeros((H, W), dtype=np.uint8)
+cv2.fillPoly(tr, [tri], 255, cv2.LINE_8)
+g.check(tr[12, 12] == 255, "fillPoly interior not set")
+g.check(tr[25, 25] == 0, "fillPoly leaked past hypotenuse")
+g.check(tr[10, 10] == 255 and tr[10, 29] == 255, "fillPoly corners not set")
+pl = np.zeros((H, W), dtype=np.uint8)
+cv2.polylines(pl, [tri], True, 255, 1, cv2.LINE_8)
+g.check(int(np.count_nonzero(pl[10, 10:31] == 255)) == 21, "polylines top edge != 21")
+
+# putText
+tx = np.zeros((32, 96), dtype=np.uint8)
+cv2.putText(tx, "Hi", (4, 22), cv2.FONT_HERSHEY_SIMPLEX, 0.8, 255, 1, cv2.LINE_8)
+g.check(nz(tx) > 0, "putText produced no ink")
+g.check(tx[31, 95] == 0 and tx[0, 95] == 0, "putText leaked to far corners")
+g.check(nz(tx[:, :48]) == nz(tx), "putText ink not confined to left half")
+
+raise SystemExit(g.finish())

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_feature.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_feature.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""opencv_feature - feature/edge detectors on KNOWN geometry vs the known answer.
+
+Canny on a vertical step edge -> edges at the known column; cornerHarris / goodFeaturesToTrack on a
+checkerboard -> corners at the known grid intersections; HoughLinesP on a drawn line -> the known params.
+"""
+import math
+import cv2
+import numpy as np
+from cv_common import Gate
+
+cv2.setNumThreads(1)
+g = Gate("OPENCV_FEATURE")
+
+# Canny on a vertical step edge at column 20
+step = np.zeros((40, 40), dtype=np.uint8)
+step[:, 20:] = 255
+edges = cv2.Canny(step, 50, 150)
+edge_cols_ok, edge_rows = True, 0
+for y in range(1, 39):
+    xs = np.nonzero(edges[y])[0]
+    if len(xs):
+        edge_rows += 1
+        if xs.min() < 18 or xs.max() > 21:
+            edge_cols_ok = False
+g.check(edge_cols_ok, "Canny edge not localized at step column (18..21)")
+g.check(edge_rows >= 36, "Canny missed the edge on many interior rows")
+g.check(edges[20, 5] == 0 and edges[20, 35] == 0, "Canny fired in a flat region")
+
+# cornerHarris on a checkerboard
+board = np.zeros((40, 40), dtype=np.uint8)
+for by in range(4):
+    for bx in range(4):
+        if (bx + by) & 1:
+            board[by * 10:by * 10 + 10, bx * 10:bx * 10 + 10] = 255
+harris = cv2.cornerHarris(board, 2, 3, 0.04)
+hmax = float(harris.max())
+g.check(hmax > 0, "cornerHarris produced no positive response")
+g.check(harris[20, 20] > 0.2 * hmax, "Harris weak at intersection (20,20)")
+g.check(abs(harris[5, 5]) < 0.05 * hmax, "Harris not ~0 in flat square (5,5)")
+
+# goodFeaturesToTrack snaps to grid
+corners = cv2.goodFeaturesToTrack(board, 20, 0.1, 5)
+g.check(corners is not None and len(corners) > 0, "goodFeaturesToTrack found nothing")
+on_grid = True
+for c in corners.reshape(-1, 2):
+    if abs(c[0] - round(c[0] / 10) * 10) > 2.5 or abs(c[1] - round(c[1] / 10) * 10) > 2.5:
+        on_grid = False
+g.check(on_grid, "a detected corner is not near a grid intersection")
+
+# HoughLinesP on a horizontal line at row 25
+lineimg = np.zeros((60, 60), dtype=np.uint8)
+cv2.line(lineimg, (5, 25), (54, 25), 255, 1, cv2.LINE_8)
+lines = cv2.HoughLinesP(lineimg, 1, math.pi / 180.0, 30, minLineLength=30, maxLineGap=5)
+g.check(lines is not None and len(lines) > 0, "HoughLinesP found no line")
+found_h = False
+for x1, y1, x2, y2 in lines.reshape(-1, 4):
+    if abs(int(y1) - int(y2)) <= 1 and abs(int(y1) - 25) <= 1 and abs(int(x2) - int(x1)) >= 30:
+        found_h = True
+g.check(found_h, "HoughLinesP did not recover the horizontal line at row 25")
+
+raise SystemExit(g.finish())

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_filter.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_filter.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""opencv_filter - convolution/filtering vs closed form, per pixel.
+
+GaussianBlur(impulse) == normalized separable Gaussian kernel (outer product of getGaussianKernel, exact
+taps pinned); Sobel(ramp) == constant derivative; boxFilter/blur(constant) == constant; medianBlur removes
+a lone outlier; filter2D(identity) == input. No RNG.
+"""
+import cv2
+import numpy as np
+from cv_common import Gate
+
+cv2.setNumThreads(1)
+g = Gate("OPENCV_FILTER")
+
+N, c = 9, 4
+ks, sigma = 5, 1.0
+
+# GaussianBlur impulse -> outer(k,k)
+impulse = np.zeros((N, N), dtype=np.float32)
+impulse[c, c] = 1.0
+blur = cv2.GaussianBlur(impulse, (ks, ks), sigma, sigmaY=sigma, borderType=cv2.BORDER_CONSTANT)
+k1 = cv2.getGaussianKernel(ks, sigma).astype(np.float32).flatten()
+kern2d = np.outer(k1, k1)
+window = blur[c - 2:c + 3, c - 2:c + 3]
+g.check(np.allclose(window, kern2d, atol=1e-6), "GaussianBlur(impulse) != outer(k,k)")
+g.check(abs(window.sum() - 1.0) < 1e-5, "Gaussian kernel does not sum to 1")
+# exact getGaussianKernel(5,1.0) taps
+g.check(abs(k1[0] - 0.054489) < 1e-4 and abs(k1[1] - 0.244201) < 1e-4 and abs(k1[2] - 0.40262) < 1e-4,
+        "Gaussian taps != [0.054489,0.244201,0.40262,...]")
+g.check(abs(blur[c, c] - 0.40262 ** 2) < 1e-4, "center pixel != w0^2")
+g.check(blur[0, 0] == 0.0 and blur[N - 1, N - 1] == 0.0, "Gaussian leaked outside support")
+
+# Sobel of a linear ramp f=10x -> d/dx scaled by 8 => 80 interior; d/dy => 0
+ramp = np.zeros((7, 7), dtype=np.float32)
+for x in range(7):
+    ramp[:, x] = 10.0 * x
+sx = cv2.Sobel(ramp, cv2.CV_32F, 1, 0, ksize=3, borderType=cv2.BORDER_REPLICATE)
+g.check(np.allclose(sx[1:6, 1:6], 80.0, atol=1e-4), "Sobel-x(ramp) != 80 interior")
+sy = cv2.Sobel(ramp, cv2.CV_32F, 0, 1, ksize=3, borderType=cv2.BORDER_REPLICATE)
+g.check(np.allclose(sy[1:6, 1:6], 0.0, atol=1e-4), "Sobel-y(x-ramp) != 0")
+
+# boxFilter / blur of a constant
+konst = np.full((8, 8), 42.0, dtype=np.float32)
+box = cv2.boxFilter(konst, cv2.CV_32F, (3, 3), normalize=True, borderType=cv2.BORDER_REPLICATE)
+g.check(np.allclose(box, 42.0, atol=1e-4), "boxFilter(const) != const")
+blr = cv2.blur(konst, (5, 5), borderType=cv2.BORDER_REPLICATE)
+g.check(np.allclose(blr, 42.0, atol=1e-4), "blur(const) != const")
+
+# medianBlur removes a lone outlier
+med_in = np.full((7, 7), 100, dtype=np.uint8)
+med_in[3, 3] = 255
+med = cv2.medianBlur(med_in, 3)
+g.check(med[3, 3] == 100, "medianBlur did not remove outlier")
+g.check(np.all(med[1:6, 1:6] == 100), "medianBlur disturbed constant field")
+
+# filter2D identity
+idk = np.zeros((3, 3), dtype=np.float32)
+idk[1, 1] = 1.0
+idout = cv2.filter2D(ramp, cv2.CV_32F, idk)
+g.check(np.allclose(idout[1:6, 1:6], ramp[1:6, 1:6], atol=1e-4), "filter2D(identity) != input")
+
+raise SystemExit(g.finish())

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_geometry.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_geometry.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""opencv_geometry - geometric transforms vs closed form, at known points.
+
+resize NEAREST (block replication) / LINEAR (bilinear closed form), flip, transpose, warpAffine translation
+(exact pixel shift), getRotationMatrix2D matrix values, 90-degree rotation exact mapping, getAffineTransform.
+"""
+import cv2
+import numpy as np
+from cv_common import Gate
+
+cv2.setNumThreads(1)
+g = Gate("OPENCV_GEOMETRY")
+
+src = np.array([[10, 20], [30, 40]], dtype=np.uint8)
+
+# resize x2 NEAREST: block replication
+up = cv2.resize(src, (4, 4), interpolation=cv2.INTER_NEAREST)
+g.check(all(up[y, x] == src[y // 2, x // 2] for y in range(4) for x in range(4)),
+        "resize NEAREST != block replication")
+
+# resize LINEAR bilinear: dst(1,1) of [[0,10],[20,30]]->4x4 == 7.5 -> 8
+lin = np.array([[0, 10], [20, 30]], dtype=np.uint8)
+linup = cv2.resize(lin, (4, 4), interpolation=cv2.INTER_LINEAR)
+g.check(abs(int(linup[1, 1]) - 8) <= 1, "bilinear dst(1,1) != ~7.5")
+g.check(linup[0, 0] == 0, "bilinear corner(0,0) != 0")
+
+# flips
+fh = cv2.flip(src, 1)
+g.check(fh[0, 0] == 20 and fh[0, 1] == 10 and fh[1, 0] == 40 and fh[1, 1] == 30, "flip H mismatch")
+fv = cv2.flip(src, 0)
+g.check(fv[0, 0] == 30 and fv[1, 0] == 10, "flip V mismatch")
+
+# transpose
+tp = cv2.transpose(src)
+g.check(tp[0, 1] == src[1, 0] and tp[1, 0] == src[0, 1], "transpose mismatch")
+
+# warpAffine translation +1/+1
+marker = np.zeros((5, 5), dtype=np.uint8)
+marker[1, 1] = 200
+Tm = np.array([[1, 0, 1], [0, 1, 1]], dtype=np.float64)
+shifted = cv2.warpAffine(marker, Tm, (5, 5), flags=cv2.INTER_NEAREST)
+g.check(shifted[2, 2] == 200, "translation did not move marker to (2,2)")
+g.check(shifted[1, 1] == 0, "translation left a ghost")
+
+# getRotationMatrix2D(center,90,1)
+R = cv2.getRotationMatrix2D((2, 2), 90.0, 1.0)
+g.check(abs(R[0, 0]) < 1e-9 and abs(R[0, 1] - 1) < 1e-9 and abs(R[1, 0] + 1) < 1e-9 and abs(R[1, 1]) < 1e-9,
+        "getRotationMatrix2D(90) cos/sin block wrong")
+mx = R[0, 0] * 2 + R[0, 1] * 2 + R[0, 2]
+my = R[1, 0] * 2 + R[1, 1] * 2 + R[1, 2]
+g.check(abs(mx - 2) < 1e-9 and abs(my - 2) < 1e-9, "rotation does not fix its center")
+
+# warpAffine 90deg maps marker to closed-form location
+rimg = np.zeros((5, 5), dtype=np.uint8)
+rimg[2, 1] = 150  # (x=1,y=2)
+rot = cv2.warpAffine(rimg, R, (5, 5), flags=cv2.INTER_NEAREST)
+dx = int(round(R[0, 0] * 1 + R[0, 1] * 2 + R[0, 2]))
+dy = int(round(R[1, 0] * 1 + R[1, 1] * 2 + R[1, 2]))
+g.check(0 <= dx < 5 and 0 <= dy < 5 and rot[dy, dx] == 150, "90deg marker not at closed-form (dx,dy)")
+
+# getAffineTransform of a +1/+1 shift
+s3 = np.float32([[0, 0], [1, 0], [0, 1]])
+d3 = np.float32([[1, 1], [2, 1], [1, 2]])
+AT = cv2.getAffineTransform(s3, d3)
+g.check(abs(AT[0, 0] - 1) < 1e-6 and abs(AT[0, 2] - 1) < 1e-6 and abs(AT[1, 1] - 1) < 1e-6 and
+        abs(AT[1, 2] - 1) < 1e-6, "getAffineTransform of +1/+1 shift wrong")
+
+raise SystemExit(g.finish())

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_io.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_io.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""opencv_io - codec/container round-trips vs byte-exact / PSNR goldens.
+
+imencode/imdecode PNG/BMP/PPM/TIFF/WebP (lossless -> byte-exact), JPEG (lossy -> PSNR), PGM gray,
+imwrite/imread file round-trip, VideoWriter+VideoCapture synthetic clip (FFV1 lossless -> exact frame count
++ first-frame content). Real-asset leg reads ASSET_DIR (honest-skip if none). Seeded RNG 0x233.
+"""
+import os
+import math
+import cv2
+import numpy as np
+from cv_common import Gate
+
+cv2.setNumThreads(1)
+g = Gate("OPENCV_IO")
+
+
+def psnr(a, b):
+    mse = np.mean((a.astype(np.float64) - b.astype(np.float64)) ** 2)
+    return 1e9 if mse <= 1e-10 else 10 * math.log10(255 * 255 / mse)
+
+
+rng = np.random.RandomState(0x233)
+img = rng.randint(0, 256, (24, 32, 3), dtype=np.uint8)
+
+for ext in ['.png', '.bmp', '.ppm', '.tiff', '.webp']:
+    ok, buf = cv2.imencode(ext, img)
+    dec = cv2.imdecode(buf, cv2.IMREAD_COLOR) if ok else None
+    g.check(ok and dec is not None and np.array_equal(dec, img),
+            "lossless round-trip not byte-exact: %s" % ext)
+
+# JPEG lossy on a gradient
+grad = np.zeros((24, 32, 3), dtype=np.uint8)
+for y in range(24):
+    for x in range(32):
+        grad[y, x] = [(x * 8) & 255, (y * 10) & 255, ((x + y) * 4) & 255]
+ok, buf = cv2.imencode('.jpg', grad, [cv2.IMWRITE_JPEG_QUALITY, 95])
+dec = cv2.imdecode(buf, cv2.IMREAD_COLOR) if ok else None
+g.check(ok and dec is not None and dec.shape == grad.shape, "JPEG encode/decode failed")
+g.check(dec is not None and psnr(grad, dec) > 35.0, "JPEG q95 PSNR below 35 dB")
+g.check(dec is not None and not np.array_equal(dec, grad), "JPEG unexpectedly byte-exact")
+
+# PGM gray
+gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+ok, buf = cv2.imencode('.pgm', gray)
+dec = cv2.imdecode(buf, cv2.IMREAD_GRAYSCALE) if ok else None
+g.check(ok and dec is not None and np.array_equal(dec, gray), "PGM gray round-trip not exact")
+
+# IMREAD_GRAYSCALE of a color PNG == BT.601 gray
+ok, buf = cv2.imencode('.png', img)
+gdec = cv2.imdecode(buf, cv2.IMREAD_GRAYSCALE)
+g.check(gdec is not None and np.all(np.abs(gdec.astype(int) - gray.astype(int)) <= 1),
+        "IMREAD_GRAYSCALE != BT.601 gray")
+
+# imwrite/imread file round-trip
+tdir = os.environ.get('TMPDIR', '/tmp')
+p = os.path.join(tdir, 'cvio_rt_py.png')
+w = cv2.imwrite(p, img)
+rd = cv2.imread(p, cv2.IMREAD_COLOR)
+g.check(w and rd is not None and np.array_equal(rd, img), "imwrite/imread PNG file round-trip not exact")
+if os.path.exists(p):
+    os.remove(p)
+
+# VideoWriter + VideoCapture (FFV1 lossless)
+vp = os.path.join(tdir, 'cvio_clip_py.avi')
+vw = cv2.VideoWriter(vp, cv2.VideoWriter_fourcc(*'FFV1'), 10.0, (32, 32), True)
+if not vw.isOpened():
+    g.skip("no FFV1 VideoWriter available - video legs skipped")
+else:
+    for i in range(5):
+        fr = np.zeros((32, 32, 3), dtype=np.uint8)
+        fr[:, :, 0] = i * 10
+        fr[0, 0] = [i, i + 1, i + 2]
+        vw.write(fr)
+    vw.release()
+    cap = cv2.VideoCapture(vp)
+    g.check(cap.isOpened(), "VideoCapture failed to open clip")
+    cnt = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    g.check(cnt == 5, "clip frame count != 5")
+    got, f0 = cap.read()
+    g.check(got and f0 is not None, "could not read first frame")
+    g.check(got and tuple(f0[0, 0]) == (0, 1, 2), "first-frame marker != (0,1,2)")
+    g.check(got and abs(int(f0[:, :, 0].mean()) - 0) <= 1, "first-frame B mean != 0")
+    cap.release()
+    if os.path.exists(vp):
+        os.remove(vp)
+
+# Real-asset leg
+ad = os.environ.get('ASSET_DIR')
+read_assets = 0
+if ad and os.path.isdir(ad):
+    for n in sorted(os.listdir(ad)):
+        if n.lower().endswith(('.png', '.jpg', '.jpeg', '.bmp', '.ppm', '.tiff', '.tif')):
+            m = cv2.imread(os.path.join(ad, n), cv2.IMREAD_COLOR)
+            g.check(m is not None and m.ndim == 3 and m.shape[2] == 3, "asset failed to decode: %s" % n)
+            read_assets += 1
+if read_assets == 0:
+    g.skip("no images under ASSET_DIR - real-asset leg honest-skipped")
+
+raise SystemExit(g.finish())

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_mat.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_mat.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""opencv_mat - cv2/numpy Mat arithmetic & structure vs element-exact closed form.
+
+add/subtract/multiply/matmul/transpose on KNOWN small matrices, asserted element-exact vs a numpy golden;
+Mat dtype/channels/ROI/reshape semantics. cv2 Mats ARE numpy arrays, so numpy is the closed form. No RNG.
+"""
+import cv2
+import numpy as np
+from cv_common import Gate
+
+cv2.setNumThreads(1)
+g = Gate("OPENCV_MAT")
+
+A = np.array([[1., 2., 3.], [4., 5., 6.]])
+B = np.array([[6., 5., 4.], [3., 2., 1.]])
+
+# element-wise add via cv2.add == numpy A+B == all 7
+S = cv2.add(A, B)
+g.check(np.array_equal(S, A + B) and np.all(S == 7.0), "cv2.add != A+B / not all 7")
+
+# element-wise subtract via cv2.subtract
+D = cv2.subtract(A, B)
+g.check(np.array_equal(D, np.array([[-5., -3., -1.], [1., 3., 5.]])), "cv2.subtract mismatch")
+
+# element-wise multiply via cv2.multiply (Hadamard)
+M = cv2.multiply(A, B)
+g.check(np.array_equal(M, np.array([[6., 10., 12.], [12., 10., 6.]])), "cv2.multiply mismatch")
+
+# scalar scale
+g.check(np.array_equal(cv2.multiply(A, 2.0), 2.0 * A), "scalar multiply mismatch")
+
+# matmul (cv2.gemm): A(2x3) * A^T(3x2) = [[14,32],[32,77]]
+G = cv2.gemm(A, A.T, 1.0, None, 0.0)
+g.check(np.array_equal(G, np.array([[14., 32.], [32., 77.]])), "cv2.gemm mismatch")
+# and numpy matmul agrees
+g.check(np.array_equal(G, A @ A.T), "gemm != numpy @")
+
+# transpose
+T = cv2.transpose(A)
+g.check(T.shape == (3, 2) and np.array_equal(T, A.T), "transpose mismatch")
+
+# determinant of known 2x2
+K = np.array([[1., 2.], [3., 4.]])
+g.check(abs(cv2.determinant(K) - (-2.0)) < 1e-9, "det != -2")
+
+# inverse: K @ K^-1 == I
+ok, Ki = cv2.invert(K)
+g.check(ok != 0.0 and np.allclose(K @ Ki, np.eye(2), atol=1e-9), "K*K^-1 != I")
+
+# dtype / channels: 3-channel 8U image
+C8 = np.zeros((4, 5, 3), dtype=np.uint8)
+g.check(C8.dtype == np.uint8, "dtype != uint8")
+g.check(C8.shape == (4, 5, 3), "shape != (4,5,3)")
+g.check(C8.ndim == 3 and C8.shape[2] == 3, "channels != 3")
+
+# ROI is a view: mutate parent at mapped location only
+P = np.zeros((6, 6), dtype=np.uint8)
+P[2:4, 1:4] = 200  # y=2..4, x=1..4
+expect = np.zeros((6, 6), dtype=np.uint8)
+expect[2:4, 1:4] = 200
+g.check(np.array_equal(P, expect), "ROI write mapping wrong")
+
+# reshape row-major
+lin = np.arange(12, dtype=np.int32).reshape(1, 12)
+r34 = lin.reshape(3, 4)
+g.check(r34.shape == (3, 4) and np.array_equal(r34, np.arange(12).reshape(3, 4)), "reshape order wrong")
+
+# countNonZero / minMaxLoc
+mm = np.array([[0, 5, 0], [9, 0, 3]], dtype=np.uint8)
+g.check(cv2.countNonZero(mm) == 3, "countNonZero != 3")
+mn, mx, _, _ = cv2.minMaxLoc(mm)
+g.check(mn == 0.0 and mx == 9.0, "minMax != (0,9)")
+
+raise SystemExit(g.finish())

--- a/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_morph.py
+++ b/apps/starry/cpu-opencv-test/programs/carpets/py/opencv_morph.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""opencv_morph - thresholding & morphology vs closed form.
+
+threshold BINARY/INV/TRUNC on a known ramp (exact split), Otsu on a bimodal histogram, erode/dilate/open/
+close of a known binary pattern vs the structuring-element result, connectedComponents count. No RNG.
+"""
+import cv2
+import numpy as np
+from cv_common import Gate
+
+cv2.setNumThreads(1)
+g = Gate("OPENCV_MORPH")
+
+ramp = np.array([[0, 50, 100, 150, 200]], dtype=np.uint8)
+_, th = cv2.threshold(ramp, 100, 255, cv2.THRESH_BINARY)
+g.check(list(th[0]) == [0, 0, 0, 255, 255], "THRESH_BINARY split wrong")
+_, thi = cv2.threshold(ramp, 100, 255, cv2.THRESH_BINARY_INV)
+g.check(thi[0, 2] == 255 and thi[0, 3] == 0, "THRESH_BINARY_INV split wrong")
+_, tt = cv2.threshold(ramp, 100, 0, cv2.THRESH_TRUNC)
+g.check(tt[0, 3] == 100 and tt[0, 1] == 50, "THRESH_TRUNC wrong")
+
+# Otsu bimodal
+bim = np.array([[20, 20, 20, 20, 200, 200, 200, 200]], dtype=np.uint8)
+otsu_t, ot = cv2.threshold(bim, 0, 255, cv2.THRESH_BINARY | cv2.THRESH_OTSU)
+g.check(20 <= otsu_t < 200, "Otsu threshold not in mode-separating range")
+g.check(list(ot[0]) == [0, 0, 0, 0, 255, 255, 255, 255], "Otsu binarization did not separate modes")
+
+# dilate/erode a single dot with 3x3 rect SE
+dot = np.zeros((7, 7), dtype=np.uint8)
+dot[3, 3] = 255
+se = cv2.getStructuringElement(cv2.MORPH_RECT, (3, 3))
+dil = cv2.dilate(dot, se)
+g.check(cv2.countNonZero(dil) == 9, "dilate(dot) != 9-px block")
+g.check(np.all(dil[2:5, 2:5] == 255), "dilate block not centered")
+ero = cv2.erode(dil, se)
+g.check(cv2.countNonZero(ero) == 1 and ero[3, 3] == 255, "erode(dilate(dot)) != dot")
+
+# opening removes a lone speck
+speck = np.zeros((7, 7), dtype=np.uint8)
+speck[1, 1] = 255
+opened = cv2.morphologyEx(speck, cv2.MORPH_OPEN, se)
+g.check(cv2.countNonZero(opened) == 0, "opening did not remove speck")
+
+# closing fills a lone hole
+solid = np.full((7, 7), 255, dtype=np.uint8)
+solid[3, 3] = 0
+closed = cv2.morphologyEx(solid, cv2.MORPH_CLOSE, se)
+g.check(closed[3, 3] == 255, "closing did not fill hole")
+
+# connectedComponents: 3 blobs -> 4 labels incl background
+blobs = np.zeros((9, 9), dtype=np.uint8)
+blobs[1, 1] = blobs[1, 7] = blobs[7, 4] = 255
+n, labels = cv2.connectedComponents(blobs, connectivity=8)
+g.check(n == 4, "connectedComponents count != 4")
+l1, l2, l3 = labels[1, 1], labels[1, 7], labels[7, 4]
+g.check(l1 and l2 and l3 and len({l1, l2, l3}) == 3 and labels[0, 0] == 0,
+        "blob labels not distinct / background not 0")
+
+raise SystemExit(g.finish())

--- a/apps/starry/cpu-opencv-test/programs/run_all.sh
+++ b/apps/starry/cpu-opencv-test/programs/run_all.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+# On-target runner for the cpu-opencv-test carpet - an industrial-grade OpenCV test carpet for StarryOS.
+# Each cell drives real OpenCV (cv::Mat / cvtColor / GaussianBlur / resize / threshold / drawing / Canny /
+# imencode / VideoWriter ...) on KNOWN, fixed inputs and asserts the result against a CLOSED-FORM / numpy
+# golden computed by hand (BT.601 luma, Porter-Duff, the normalized Gaussian kernel, a Sobel gradient's
+# constant derivative, bilinear interpolation, an analytic drawn shape, a known step-edge column, a
+# byte-exact PNG/BMP round-trip). "cv2 imported" is NOT a test - every leg checks a predicted value.
+#
+# Two bindings, run side by side:
+#   cpp/opencv_*  - the C++ cells (link libopencv_* via pkg-config opencv4), cross-compiled by prebuild.
+#   py/opencv_*   - the Python cells (import cv2 + numpy from Alpine py3-opencv / py3-numpy).
+#
+# Cells (each in BOTH cpp and py): mat, color, filter, geometry, morph, draw, feature, io.
+# Prints "TEST PASSED" only when every provisioned cell reports its "OPENCV_<CELL> OK <n>" marker
+# (three-gate: fail==0 && total==pass && total>0) and the run matches the expected_cells manifest.
+set -u
+BIN=/opt/cpu-opencv-test
+export PATH="/usr/bin:/usr/local/bin:$PATH"
+export LD_LIBRARY_PATH="/usr/lib:/lib:${LD_LIBRARY_PATH:-}"
+export HOME="${HOME:-/tmp}"
+export TMPDIR="${TMPDIR:-/tmp}"
+# Real-asset leg (opencv_io) reads images from ASSET_DIR; defaults to the staged assets next to the cells.
+export ASSET_DIR="${ASSET_DIR:-$BIN/assets}"
+# make the staged cv2 importable without a system-wide install
+if [ -d "$BIN/py" ]; then export PYTHONPATH="$BIN/py:${PYTHONPATH:-}"; fi
+
+ncpu=$(nproc 2>/dev/null || grep -c '^processor' /proc/cpuinfo 2>/dev/null || echo '?')
+echo "cpu-opencv-test: detected CPU count = $ncpu; ASSET_DIR=$ASSET_DIR"
+
+pass=0; total=0; fail=0
+# run one manifest entry. An entry is "cpp/<cell>" (an ELF to exec) or "py/<cell>" (a .py to run with
+# python3). Both must print "OPENCV_<CELL> OK <n>" and exit 0.
+run() {
+    entry="$1"
+    kind=${entry%%/*}; cell=${entry#*/}
+    case "$kind" in
+        cpp) prog="$BIN/cpp/$cell"
+             [ -x "$prog" ] || { echo "cpu-opencv-test: $entry in manifest but binary absent"; total=$((total+1)); fail=$((fail+1)); return 0; }
+             total=$((total+1))
+             out="$(cd "$BIN" && "$prog" 2>&1 </dev/null)"; rc=$? ;;
+        py)  prog="$BIN/py/$cell.py"
+             [ -f "$prog" ] || { echo "cpu-opencv-test: $entry in manifest but script absent"; total=$((total+1)); fail=$((fail+1)); return 0; }
+             total=$((total+1))
+             out="$(cd "$BIN" && python3 "$prog" 2>&1 </dev/null)"; rc=$? ;;
+        *)   echo "cpu-opencv-test: bad manifest entry '$entry'"; total=$((total+1)); fail=$((fail+1)); return 0 ;;
+    esac
+    if [ "$rc" -eq 0 ] && echo "$out" | grep -qE "OK [0-9]+$"; then
+        printf '  [%s] ' "$entry"; echo "$out" | grep -E "OK [0-9]+$" | tail -1
+        pass=$((pass+1))
+    else
+        echo "$out" | tail -12
+        echo "CARPET FAILED: $entry (exit $rc)"
+        fail=$((fail+1))
+    fi
+}
+
+cd "$BIN" || exit 1
+MANIFEST="$BIN/expected_cells"
+[ -f "$MANIFEST" ] || { echo "cpu-opencv-test: expected_cells manifest missing - prebuild provisioned no carpet"; echo "TEST FAILED"; exit 1; }
+EXPECTED=$(grep -c . "$MANIFEST")
+while IFS= read -r cell <&3; do
+    [ -n "$cell" ] || continue
+    run "$cell"
+done 3< "$MANIFEST"
+
+echo "cpu-opencv-test: $pass/$total OpenCV carpets OK on $(uname -m) (expected $EXPECTED: $(tr '\n' ' ' < "$MANIFEST"))"
+if [ "$EXPECTED" -ge 1 ] && [ "$fail" -eq 0 ] && [ "$total" -eq "$EXPECTED" ] && [ "$pass" -eq "$EXPECTED" ]; then
+    echo "TEST PASSED"; exit 0
+else
+    echo "cpu-opencv-test: GATE FAILED - need all $EXPECTED manifest carpets to pass (>=1 floor); got fail=$fail total=$total pass=$pass"
+    echo "TEST FAILED"; exit 1
+fi

--- a/apps/starry/cpu-opencv-test/qemu-aarch64.toml
+++ b/apps/starry/cpu-opencv-test/qemu-aarch64.toml
@@ -1,0 +1,18 @@
+# cpu-opencv-test aarch64 - OpenCV test carpet (C++ + Python bindings) asserting CLOSED-FORM / numpy goldens
+# on KNOWN inputs (BT.601 luma, Porter-Duff, Gaussian kernel, Sobel gradient, bilinear, analytic drawn
+# shapes, known step-edge column, byte-exact codec round-trips, lossless FFV1 video). OpenCV + CPython +
+# cv2/numpy are staged into the overlay by prebuild. -cpu max exposes the full AArch64 feature set. -smp 1:
+# single vCPU. 1536M: OpenCV + CPython + numpy.
+args = [
+    "-nographic", "-cpu", "max", "-m", "1536M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 40000

--- a/apps/starry/cpu-opencv-test/qemu-aarch64.toml
+++ b/apps/starry/cpu-opencv-test/qemu-aarch64.toml
@@ -1,0 +1,20 @@
+# cpu-opencv-test aarch64 - OpenCV test carpet (C++ + Python bindings) asserting CLOSED-FORM / numpy goldens
+# on KNOWN inputs (BT.601 luma, Porter-Duff, Gaussian kernel, Sobel gradient, bilinear, analytic drawn
+# shapes, known step-edge column, byte-exact codec round-trips, lossless FFV1 video). OpenCV + CPython +
+# cv2/numpy are staged into the overlay by prebuild. -cpu max exposes the full AArch64 feature set. -smp 1:
+# single vCPU. 1536M: OpenCV + CPython + numpy.
+args = [
+    "-nographic", "-cpu", "max", "-m", "1536M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 40000
+
+[[shell_check_steps]]
+shell_prefix = "root@starry:"
+shell_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']

--- a/apps/starry/cpu-opencv-test/qemu-loongarch64.toml
+++ b/apps/starry/cpu-opencv-test/qemu-loongarch64.toml
@@ -1,0 +1,20 @@
+# cpu-opencv-test loongarch64 - OpenCV test carpet (C++ + Python bindings) asserting CLOSED-FORM / numpy
+# goldens on KNOWN inputs (BT.601 luma, Porter-Duff, Gaussian kernel, Sobel gradient, bilinear, analytic
+# drawn shapes, known step-edge column, byte-exact codec round-trips, lossless FFV1 video). OpenCV + CPython
+# + cv2/numpy are staged into the overlay by prebuild. Platform: dynamic (axplat-dyn) - build-loongarch64*.toml
+# carries ax-driver/serial and does not opt out of dynamic platform mode; the retired static LoongArch path
+# lacked the serial console binding. uefi=false / to_bin=true is the dynamic platform's raw-binary boot path.
+# -smp 1: single vCPU. 1536M: OpenCV + CPython + numpy.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "1536M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 40000

--- a/apps/starry/cpu-opencv-test/qemu-loongarch64.toml
+++ b/apps/starry/cpu-opencv-test/qemu-loongarch64.toml
@@ -1,0 +1,22 @@
+# cpu-opencv-test loongarch64 - OpenCV test carpet (C++ + Python bindings) asserting CLOSED-FORM / numpy
+# goldens on KNOWN inputs (BT.601 luma, Porter-Duff, Gaussian kernel, Sobel gradient, bilinear, analytic
+# drawn shapes, known step-edge column, byte-exact codec round-trips, lossless FFV1 video). OpenCV + CPython
+# + cv2/numpy are staged into the overlay by prebuild. Platform: dynamic (axplat-dyn) - build-loongarch64*.toml
+# carries ax-driver/serial and does not opt out of dynamic platform mode; the retired static LoongArch path
+# lacked the serial console binding. uefi=false / to_bin=true is the dynamic platform's raw-binary boot path.
+# -smp 1: single vCPU. 1536M: OpenCV + CPython + numpy.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "1536M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 40000
+
+[[shell_check_steps]]
+shell_prefix = "root@starry:"
+shell_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']

--- a/apps/starry/cpu-opencv-test/qemu-riscv64.toml
+++ b/apps/starry/cpu-opencv-test/qemu-riscv64.toml
@@ -1,0 +1,17 @@
+# cpu-opencv-test riscv64 - OpenCV test carpet (C++ + Python bindings) asserting CLOSED-FORM / numpy goldens
+# on KNOWN inputs (BT.601 luma, Porter-Duff, Gaussian kernel, Sobel gradient, bilinear, analytic drawn
+# shapes, known step-edge column, byte-exact codec round-trips, lossless FFV1 video). OpenCV + CPython +
+# cv2/numpy are staged into the overlay by prebuild. -smp 1: single vCPU. 1536M: OpenCV + CPython + numpy.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "1536M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 40000

--- a/apps/starry/cpu-opencv-test/qemu-riscv64.toml
+++ b/apps/starry/cpu-opencv-test/qemu-riscv64.toml
@@ -1,0 +1,19 @@
+# cpu-opencv-test riscv64 - OpenCV test carpet (C++ + Python bindings) asserting CLOSED-FORM / numpy goldens
+# on KNOWN inputs (BT.601 luma, Porter-Duff, Gaussian kernel, Sobel gradient, bilinear, analytic drawn
+# shapes, known step-edge column, byte-exact codec round-trips, lossless FFV1 video). OpenCV + CPython +
+# cv2/numpy are staged into the overlay by prebuild. -smp 1: single vCPU. 1536M: OpenCV + CPython + numpy.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "1536M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 40000
+
+[[shell_check_steps]]
+shell_prefix = "root@starry:"
+shell_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']

--- a/apps/starry/cpu-opencv-test/qemu-x86_64.toml
+++ b/apps/starry/cpu-opencv-test/qemu-x86_64.toml
@@ -1,0 +1,21 @@
+# cpu-opencv-test x86_64 - industrial-grade OpenCV test carpet: real OpenCV (cv::Mat/cvtColor/GaussianBlur/
+# resize/threshold/drawing/Canny/imencode/VideoWriter ...) on KNOWN fixed inputs asserting CLOSED-FORM /
+# numpy goldens (BT.601 luma, Porter-Duff, the normalized Gaussian kernel, a Sobel gradient's constant
+# derivative, bilinear interpolation, an analytic drawn shape, a known step-edge column, byte-exact PNG/BMP
+# round-trips, a lossless FFV1 video round-trip). Both bindings run: C++ (links libopencv_* via opencv4) and
+# Python (import cv2 + numpy). The runtime + interpreter + cv2/numpy are staged into the overlay by prebuild.
+# -smp 1: single vCPU. 1536M: OpenCV + CPython + numpy need generous RAM.
+args = [
+    "-machine", "q35",
+    "-nographic", "-cpu", "Haswell", "-m", "1536M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/cpu-opencv-test/qemu-x86_64.toml
+++ b/apps/starry/cpu-opencv-test/qemu-x86_64.toml
@@ -1,0 +1,23 @@
+# cpu-opencv-test x86_64 - industrial-grade OpenCV test carpet: real OpenCV (cv::Mat/cvtColor/GaussianBlur/
+# resize/threshold/drawing/Canny/imencode/VideoWriter ...) on KNOWN fixed inputs asserting CLOSED-FORM /
+# numpy goldens (BT.601 luma, Porter-Duff, the normalized Gaussian kernel, a Sobel gradient's constant
+# derivative, bilinear interpolation, an analytic drawn shape, a known step-edge column, byte-exact PNG/BMP
+# round-trips, a lossless FFV1 video round-trip). Both bindings run: C++ (links libopencv_* via opencv4) and
+# Python (import cv2 + numpy). The runtime + interpreter + cv2/numpy are staged into the overlay by prebuild.
+# -smp 1: single vCPU. 1536M: OpenCV + CPython + numpy need generous RAM.
+args = [
+    "-machine", "q35",
+    "-nographic", "-cpu", "Haswell", "-m", "1536M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = true
+to_bin = true
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000
+
+[[shell_check_steps]]
+shell_prefix = "root@starry:"
+shell_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']

--- a/apps/starry/cpu-opencv-test/tools/gen_goldens.py
+++ b/apps/starry/cpu-opencv-test/tools/gen_goldens.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""gen_goldens.py - re-derive the closed-form constants the cpu-opencv-test cells assert against, for review.
+
+These are the numpy / first-principles goldens (NOT OpenCV outputs) that the cells pin. Run it to sanity-check
+the magic numbers embedded in the C++/Python cells. Requires only numpy (cv2 optional, used to cross-check the
+Gaussian taps and the BT.601 luma if available).
+"""
+import numpy as np
+
+
+def sep(t):
+    print("\n== %s ==" % t)
+
+
+# opencv_mat: matmul A(2x3) * A^T
+sep("mat")
+A = np.array([[1., 2., 3.], [4., 5., 6.]])
+print("A @ A^T =", (A @ A.T).tolist(), " (cells pin [[14,32],[32,77]])")
+print("det([[1,2],[3,4]]) =", np.linalg.det(np.array([[1., 2.], [3., 4.]])), " (cells pin -2)")
+
+# opencv_color: BT.601 luma (fixed-point) for the four primaries
+sep("color")
+
+
+def gray601(b, g, r):
+    return (r * 4899 + g * 9617 + b * 1868 + 8192) >> 14
+
+
+for name, (b, g, r) in [("red", (0, 0, 255)), ("green", (0, 255, 0)),
+                        ("blue", (255, 0, 0)), ("gray", (128, 128, 128))]:
+    print("gray601(%s) = %d" % (name, gray601(b, g, r)), " (cells pin 76/150/29/128)")
+print("I420 studio-swing luma = ((R*66+G*129+B*25+128)>>8)+16")
+
+# opencv_filter: getGaussianKernel(5,1.0) taps (OpenCV formula reproduced without cv2)
+sep("filter")
+
+
+def gaussian_kernel(ks, sigma):
+    # OpenCV: if sigma<=0 it derives sigma=0.3*((ks-1)*0.5-1)+0.8; here sigma is given (=1.0).
+    c = (ks - 1) * 0.5
+    w = np.array([np.exp(-((i - c) ** 2) / (2 * sigma * sigma)) for i in range(ks)])
+    return w / w.sum()
+
+
+k = gaussian_kernel(5, 1.0)
+print("getGaussianKernel(5,1.0) ~", [round(v, 6) for v in k], " (cells pin 0.054489/0.244201/0.40262)")
+print("center^2 =", round(k[2] ** 2, 6))
+print("Sobel-x of a 10*x ramp -> 8*slope = 80 interior")
+
+# opencv_geometry: bilinear dst(1,1) of [[0,10],[20,30]] scaled 2x2->4x4
+sep("geometry")
+src = np.array([[0., 10.], [20., 30.]])
+sx = 2.0 / 4.0
+fx = (1 + 0.5) * sx - 0.5
+fy = (1 + 0.5) * sx - 0.5  # =0.25
+x0, y0 = int(np.floor(fx)), int(np.floor(fy))
+ax, ay = fx - x0, fy - y0
+val = ((1 - ay) * ((1 - ax) * src[y0, x0] + ax * src[y0, x0 + 1]) +
+       ay * ((1 - ax) * src[y0 + 1, x0] + ax * src[y0 + 1, x0 + 1]))
+print("bilinear dst(1,1) =", val, "-> round", round(val), " (cells pin ~8)")
+print("getRotationMatrix2D(c,90,1): cos=0 sin=1 -> [[0,1,..],[-1,0,..]]")
+
+# opencv_morph: dilate(dot) area, connectedComponents count
+sep("morph")
+print("dilate(single dot, 3x3 rect SE) area = 9 (3x3 block)")
+print("connectedComponents(3 separated blobs, 8-conn) = 4 (bg + 3)")
+
+# opencv_draw: rectangle area, circle area
+sep("draw")
+print("rectangle pt1(10,8) pt2(29,19) FILLED area = 20*12 =", 20 * 12)
+print("filled circle r=12 area ~ pi r^2 =", round(np.pi * 144, 1), "(assert within 8%)")
+
+# opencv_io: PSNR floor rationale
+sep("io")
+print("lossless PNG/BMP/PPM/TIFF/WebP -> byte-exact; JPEG q95 -> PSNR > 35 dB on a gradient (lossy)")
+print("FFV1 clip: 5 frames, first-frame marker pixel BGR (0,1,2), channel-0 mean 0")


### PR DESCRIPTION
## 概述

`apps/starry/cpu-opencv-test`：OpenCV carpet，C++（pkg-config opencv4）与 Python（py3-opencv）两套绑定各 8 个 cell，断言对照 numpy 金标或逐像素闭式结果。OpenCV 负责算法，只有参照与比对自写。

## Cells 与断言

| cell | 断言 |
|:--:|:--:|
| `opencv_mat` | 矩阵运算、类型、ROI、reshape 与 numpy 逐元素一致 |
| `opencv_color` | BGR/RGB、BT.601 灰度定点、YCrCb、HSV、I420 亮度 |
| `opencv_filter` | GaussianBlur 冲激响应、Sobel、box/median、filter2D |
| `opencv_geometry` | resize 最近邻与双线性闭式、flip、transpose、warpAffine |
| `opencv_morph` | threshold（含 Otsu）、腐蚀膨胀开闭、connectedComponents |
| `opencv_draw` | 矩形、线、圆、椭圆、fillPoly、putText 逐像素 mask |
| `opencv_feature` | Canny 边缘位置、Harris 与 goodFeatures 角点、HoughLinesP |
| `opencv_io` | PNG/BMP/PPM/TIFF/WebP/PGM 逐字节往返、JPEG PSNR、imencode/imdecode、视频往返 |

C++ 125 条、Python 121 条，共 246 条断言。

## 本次修改

- edge 的 py3-opencv 拉入的 libQt6Core 需要新 musl 导出的 `renameat2`：apk 改为 `add --upgrade`，并把 `ld-musl`、`libc.musl` 放进 overlay。
- `import cv2` 失败时 prebuild exit 6，不再从清单里去掉 Python cell；清单固定为 8 个 C++ 与 8 个 Python cell，任一缺失即失败。
- 链接探测失败后先用 `ld.lld` 重试，再退到 zig。
- `qemu-x86_64.toml` 改为 `uefi = true`、`to_bin = true`。

x86_64 QEMU（基线 dev 802e3de4）：16/16 cell 通过，`TEST PASSED`。

> **特殊声明：素材仅用于 OS 功能完整性与正确性验证，不作他用。有事请找 @Lfan-ke**
