### PR TITLE
fix(ax-fs-ng): arm shared IRQ before device sources

### DIFF
--- a/fs/ax-fs-ng/src/block/runtime/lifecycle/mod.rs
+++ b/fs/ax-fs-ng/src/block/runtime/lifecycle/mod.rs
@@ -284,6 +284,9 @@ impl BlockGroupHandle {
                 endpoint_sources.push(source_id);
             }
 
+            for registration in &registrations {
+                registration.enable().map_err(|_| BlkError::Io)?;
+            }
             for source_id in &endpoint_sources {
                 for (_, member) in &bootstrapped {
                     member.inner.controller.call(ControllerEvent::Rearm {
@@ -297,9 +300,6 @@ impl BlockGroupHandle {
                     },
                     CONTROLLER_TRANSITION_TIMEOUT,
                 )?;
-            }
-            for registration in &registrations {
-                registration.enable().map_err(|_| BlkError::Io)?;
             }
             Ok(())
         })();

--- a/fs/ax-fs-ng/src/block/runtime/lifecycle/tests.rs
+++ b/fs/ax-fs-ng/src/block/runtime/lifecycle/tests.rs
@@ -368,6 +368,10 @@ impl BlockController for GroupMemberController {
                 vec![Box::new(self.queue.take().ok_or(BlkError::Io)?)],
                 Vec::new(),
             )),
+            ControllerEvent::Rearm { .. } => {
+                self.log.lock().unwrap().push("member_rearm");
+                Ok(ControllerUpdate::state(ControllerState::Ready))
+            }
             ControllerEvent::QuiesceIrqs => {
                 self.log.lock().unwrap().push("member_quiesce");
                 Ok(ControllerUpdate::state(ControllerState::Ready))
@@ -808,7 +812,7 @@ fn teardown_disables_controller_before_queue_memory_is_released() {
 }
 
 #[test]
-fn controller_group_registers_one_shared_irq_for_two_members_and_tears_down_once() {
+fn controller_group_enables_shared_irq_before_unmasking_sources_and_tears_down_once() {
     let _registrar_guard = lock_test_irq_registrar();
     crate::os::task::install_test_runtime_ops();
     let log = Arc::new(StdMutex::new(Vec::new()));
@@ -854,6 +858,12 @@ fn controller_group_registers_one_shared_irq_for_two_members_and_tears_down_once
             .count(),
         1
     );
+    {
+        let log = log.lock().unwrap();
+        let irq_enable = log_position(&log, "irq_enable");
+        assert!(irq_enable < log_position(&log, "member_rearm"));
+        assert!(irq_enable < log_position(&log, "group_rearm"));
+    }
     assert_eq!(runtime.release_irqs_for_passthrough(), 1);
     let log = log.lock().unwrap();
     assert_eq!(


### PR DESCRIPTION
## 问题

JL-LSGD2K10 的 Starry 板级 CI 在 AHCI hctx 绑定后停住，始终没有出现 IDENTIFY 完成日志，最终在 600 秒后超时。失败记录：

- https://github.com/rcore-os/tgoskits/actions/runs/30924751454/job/92045908549?pr=1851

该现象与 PR #1851 的 pidfd fdinfo 逻辑无关：失败发生在根文件系统挂载与用户态启动之前。共享 IRQ 组启动时，runtime 先通过 `Rearm` 打开成员设备和组控制器的中断源，最后才启用已注册的 OS IRQ action。在 LS2K 的边沿触发链路上，IDENTIFY 完成中断可能落入这个窗口并丢失，之后没有轮询回退可以推进完成队列。

## 修改

- 共享 IRQ endpoint 注册完成后，先启用所有 OS IRQ action，再依次 rearm 成员设备和组控制器中断源。
- 保留原有失败回滚和关闭顺序；rearm 失败时仍会 quiesce 控制器、同步禁用 IRQ 并释放成员。
- 扩展生命周期测试，记录成员 rearm，并断言 `irq_enable` 必须早于成员和组中断源解屏蔽。该断言在修复前必然失败，修复后通过。

## 验证

- `cargo test -p ax-fs-ng controller_group_enables_shared_irq_before_unmasking_sources_and_tears_down_once -- --nocapture`
  - 修复前：断言失败，实际顺序为 source rearm 早于 irq enable
  - 修复后：通过
- `cargo test -p ax-fs-ng`：65 个单元测试和 3 个集成测试通过
- `cargo xtask clippy --package ax-fs-ng`：6/6 配置通过
- `cargo xtask starry build -c test-suit/starryos/board-jl-lsgd2k10/build-loongarch64-unknown-none-softfloat.toml`：通过