### PR TITLE
fix(rsext4): fix misspelled public API names in rsext4

### DIFF
--- a/fs/rsext4/src/api/io.rs
+++ b/fs/rsext4/src/api/io.rs
@@ -26,7 +26,7 @@ pub fn open<B: BlockDevice>(
     path: &str,
     create: bool,
 ) -> Ext4Result<OpenFile> {
-    let norm_path = split_paren_child_and_translatevalid(path);
+    let norm_path = normalize_path(path);
 
     if let Ok(Some(inode)) = get_file_inode(fs, dev, &norm_path) {
         let real_inode = inode.1;

--- a/fs/rsext4/src/axtest.rs
+++ b/fs/rsext4/src/axtest.rs
@@ -1281,20 +1281,20 @@ fn rsext4_tool_layout_and_blockgroup_disk_rules_hold() {
         s_feature_ro_compat: Ext4Superblock::EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER,
         ..Default::default()
     };
-    let layout0 = tool::cloc_group_layout(0, &superblock, 8192, 64, 3, 4, 5, RESERVED_GDT_BLOCKS);
+    let layout0 = tool::calc_group_layout(0, &superblock, 8192, 64, 3, 4, 5, RESERVED_GDT_BLOCKS);
     ax_assert_eq!(layout0.group_start_block, 0);
     ax_assert_eq!(layout0.group_blcok_bitmap_startblocks, 3);
     ax_assert_eq!(layout0.group_inode_bitmap_startblocks, 4);
     ax_assert_eq!(layout0.group_inode_table_startblocks, 5);
 
-    let sparse = tool::cloc_group_layout(3, &superblock, 8192, 64, 3, 4, 5, 2);
+    let sparse = tool::calc_group_layout(3, &superblock, 8192, 64, 3, 4, 5, 2);
     ax_assert_eq!(sparse.group_start_block, 3 * 8192);
     ax_assert_eq!(sparse.group_blcok_bitmap_startblocks, 3 * 8192 + 1 + 2);
     ax_assert_eq!(sparse.group_inode_bitmap_startblocks, 3 * 8192 + 1 + 2 + 1);
     ax_assert_eq!(sparse.metadata_blocks_in_group, 1 + 2 + 1 + 1 + 64);
 
     superblock.s_feature_ro_compat = 0;
-    let dense = tool::cloc_group_layout(3, &superblock, 8192, 64, 3, 4, 5, 2);
+    let dense = tool::calc_group_layout(3, &superblock, 8192, 64, 3, 4, 5, 2);
     ax_assert_eq!(dense.group_blcok_bitmap_startblocks, 3 * 8192);
     ax_assert_eq!(dense.group_inode_bitmap_startblocks, 3 * 8192 + 1);
     ax_assert_eq!(dense.group_inode_table_startblocks, 3 * 8192 + 2);

--- a/fs/rsext4/src/axtest.rs
+++ b/fs/rsext4/src/axtest.rs
@@ -1048,7 +1048,7 @@ fn rsext4_journal_device_overlay_rules_hold() {
         dev.write_blocks(&direct[..8], AbsoluteBN::new(4), 1, false)
             .is_err()
     );
-    dev.cantflush().unwrap();
+    dev.flush().unwrap();
     let inner = dev.into_inner();
     ax_assert_eq!(inner.total_blocks(), 32);
 
@@ -1332,20 +1332,14 @@ fn rsext4_tool_layout_and_blockgroup_disk_rules_hold() {
 fn rsext4_path_and_bitmap_rules_hold() {
     use rsext4::{
         bitmap::{BitmapError, BlockBitmap, InodeBitmap},
-        dir::split_paren_child_and_translatevalid,
+        dir::normalize_path,
     };
 
-    ax_assert_eq!(split_paren_child_and_translatevalid(""), "");
-    ax_assert_eq!(split_paren_child_and_translatevalid("/"), "/");
-    ax_assert_eq!(split_paren_child_and_translatevalid("///"), "/");
-    ax_assert_eq!(
-        split_paren_child_and_translatevalid("//alpha///beta//"),
-        "/alpha/beta"
-    );
-    ax_assert_eq!(
-        split_paren_child_and_translatevalid("alpha//beta///gamma"),
-        "alpha/beta/gamma"
-    );
+    ax_assert_eq!(normalize_path(""), "");
+    ax_assert_eq!(normalize_path("/"), "/");
+    ax_assert_eq!(normalize_path("///"), "/");
+    ax_assert_eq!(normalize_path("//alpha///beta//"), "/alpha/beta");
+    ax_assert_eq!(normalize_path("alpha//beta///gamma"), "alpha/beta/gamma");
 
     let bitmap_errors = [
         (BitmapError::IndexOutOfRange, "bitmap index out of range"),
@@ -2093,7 +2087,7 @@ fn rsext4_mounted_filesystem_file_dir_and_metadata_rules_hold() {
         extents_tree::{ExtentNode, ExtentTree},
         file::build_file_block_mapping_with_inode_num,
         find_file, link,
-        loopfile::{resolve_inode_block, resolve_inode_block_allextend},
+        loopfile::{resolve_inode_block, resolve_inode_blocks},
         metadata::{chmod, chown},
         mkdir, mkdir_with_owner, mkfile, mkfile_with_owner, mkfs, read_file, read_inode_data_into,
         rename, set_flags, set_project,
@@ -2552,8 +2546,7 @@ fn rsext4_mounted_filesystem_file_dir_and_metadata_rules_hold() {
         &mut device,
     );
     ax_assert!(mapped_inode.have_extend_header_and_use_extend());
-    let mapped_blocks =
-        resolve_inode_block_allextend(&mut fs, &mut device, &mut mapped_inode).unwrap();
+    let mapped_blocks = resolve_inode_blocks(&mut fs, &mut device, &mut mapped_inode).unwrap();
     ax_assert_eq!(mapped_blocks.len(), 2);
 
     let mut non_extent_inode = Ext4Inode::default();
@@ -2564,7 +2557,7 @@ fn rsext4_mounted_filesystem_file_dir_and_metadata_rules_hold() {
         Errno::EOPNOTSUPP
     );
     ax_assert!(
-        resolve_inode_block_allextend(&mut fs, &mut device, &mut non_extent_inode)
+        resolve_inode_blocks(&mut fs, &mut device, &mut non_extent_inode)
             .unwrap()
             .is_empty()
     );
@@ -2603,7 +2596,7 @@ fn rsext4_mounted_filesystem_file_dir_and_metadata_rules_hold() {
     };
     ExtentTree::new(&mut skipped_extent_inode).store_root_to_inode(&skipped_node);
     ax_assert!(
-        resolve_inode_block_allextend(&mut fs, &mut device, &mut skipped_extent_inode)
+        resolve_inode_blocks(&mut fs, &mut device, &mut skipped_extent_inode)
             .unwrap()
             .is_empty()
     );
@@ -2655,7 +2648,7 @@ fn rsext4_mounted_filesystem_file_dir_and_metadata_rules_hold() {
     };
     ExtentTree::new(&mut indexed_resolve_inode).store_root_to_inode(&indexed_root);
     let indexed_blocks =
-        resolve_inode_block_allextend(&mut fs, &mut device, &mut indexed_resolve_inode).unwrap();
+        resolve_inode_blocks(&mut fs, &mut device, &mut indexed_resolve_inode).unwrap();
     ax_assert_eq!(indexed_blocks.get(&0).copied(), Some(AbsoluteBN::new(800)));
     ax_assert_eq!(indexed_blocks.get(&9).copied(), Some(AbsoluteBN::new(901)));
 

--- a/fs/rsext4/src/blockdev/journal.rs
+++ b/fs/rsext4/src/blockdev/journal.rs
@@ -22,101 +22,6 @@ pub enum Jbd2RunState {
     Replay,
 }
 
-#[cfg(test)]
-mod tests {
-    use alloc::vec;
-
-    use super::*;
-
-    struct MemBlockDev {
-        data: Vec<u8>,
-    }
-
-    impl MemBlockDev {
-        fn new(blocks: usize) -> Self {
-            Self {
-                data: vec![0; blocks * BLOCK_SIZE],
-            }
-        }
-    }
-
-    impl BlockDevice for MemBlockDev {
-        fn read(&mut self, buffer: &mut [u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
-            let start = block_id.as_usize()? * BLOCK_SIZE;
-            let end = start + buffer.len();
-            buffer.copy_from_slice(&self.data[start..end]);
-            Ok(())
-        }
-
-        fn write(&mut self, buffer: &[u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
-            let start = block_id.as_usize()? * BLOCK_SIZE;
-            let end = start + buffer.len();
-            self.data[start..end].copy_from_slice(buffer);
-            Ok(())
-        }
-
-        fn open(&mut self) -> Ext4Result<()> {
-            Ok(())
-        }
-
-        fn close(&mut self) -> Ext4Result<()> {
-            Ok(())
-        }
-
-        fn total_blocks(&self) -> u64 {
-            (self.data.len() / BLOCK_SIZE) as u64
-        }
-
-        fn block_size(&self) -> u32 {
-            BLOCK_SIZE as u32
-        }
-
-        fn current_time(&self) -> Ext4Result<Ext4Timestamp> {
-            Ok(Ext4Timestamp::new(0, 0))
-        }
-    }
-
-    #[test]
-    fn auto_commit_invalidates_stale_block_cache() {
-        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
-        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
-
-        let target = AbsoluteBN::new(10);
-        dev.read_block(target).expect("prime target cache");
-        assert_eq!(dev.buffer()[0], 0);
-
-        let count = (JBD2_BUFFER_MAX + 1) as u32;
-        let mut updates = vec![0u8; count as usize * BLOCK_SIZE];
-        for idx in 0..count as usize {
-            updates[idx * BLOCK_SIZE] = (idx + 1) as u8;
-        }
-
-        dev.write_blocks(&updates, target, count, true)
-            .expect("queue metadata updates");
-
-        dev.read_block(target)
-            .expect("read target after auto commit");
-        assert_eq!(dev.buffer()[0], 1);
-    }
-
-    #[test]
-    fn bulk_read_overlays_pending_journal_update() {
-        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
-        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
-
-        let target = AbsoluteBN::new(10);
-        let pending = vec![0x5a; BLOCK_SIZE];
-        dev.write_blocks(&pending, target, 1, true)
-            .expect("queue metadata update");
-
-        let mut observed = vec![0; BLOCK_SIZE];
-        dev.read_blocks(&mut observed, target, 1)
-            .expect("bulk read pending metadata");
-
-        assert_eq!(observed, pending);
-    }
-}
-
 /// Block device proxy that optionally routes metadata writes through JBD2.
 pub struct Jbd2Dev<B: BlockDevice> {
     _mode: u8,
@@ -421,5 +326,100 @@ impl<B: BlockDevice> Jbd2Dev<B> {
     /// Returns the current timestamp from the underlying device.
     pub fn current_time(&self) -> Ext4Result<Ext4Timestamp> {
         self.inner._device().current_time()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    struct MemBlockDev {
+        data: Vec<u8>,
+    }
+
+    impl MemBlockDev {
+        fn new(blocks: usize) -> Self {
+            Self {
+                data: vec![0; blocks * BLOCK_SIZE],
+            }
+        }
+    }
+
+    impl BlockDevice for MemBlockDev {
+        fn read(&mut self, buffer: &mut [u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+            let start = block_id.as_usize()? * BLOCK_SIZE;
+            let end = start + buffer.len();
+            buffer.copy_from_slice(&self.data[start..end]);
+            Ok(())
+        }
+
+        fn write(&mut self, buffer: &[u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+            let start = block_id.as_usize()? * BLOCK_SIZE;
+            let end = start + buffer.len();
+            self.data[start..end].copy_from_slice(buffer);
+            Ok(())
+        }
+
+        fn open(&mut self) -> Ext4Result<()> {
+            Ok(())
+        }
+
+        fn close(&mut self) -> Ext4Result<()> {
+            Ok(())
+        }
+
+        fn total_blocks(&self) -> u64 {
+            (self.data.len() / BLOCK_SIZE) as u64
+        }
+
+        fn block_size(&self) -> u32 {
+            BLOCK_SIZE as u32
+        }
+
+        fn current_time(&self) -> Ext4Result<Ext4Timestamp> {
+            Ok(Ext4Timestamp::new(0, 0))
+        }
+    }
+
+    #[test]
+    fn auto_commit_invalidates_stale_block_cache() {
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
+        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
+
+        let target = AbsoluteBN::new(10);
+        dev.read_block(target).expect("prime target cache");
+        assert_eq!(dev.buffer()[0], 0);
+
+        let count = (JBD2_BUFFER_MAX + 1) as u32;
+        let mut updates = vec![0u8; count as usize * BLOCK_SIZE];
+        for idx in 0..count as usize {
+            updates[idx * BLOCK_SIZE] = (idx + 1) as u8;
+        }
+
+        dev.write_blocks(&updates, target, count, true)
+            .expect("queue metadata updates");
+
+        dev.read_block(target)
+            .expect("read target after auto commit");
+        assert_eq!(dev.buffer()[0], 1);
+    }
+
+    #[test]
+    fn bulk_read_overlays_pending_journal_update() {
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
+        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
+
+        let target = AbsoluteBN::new(10);
+        let pending = vec![0x5a; BLOCK_SIZE];
+        dev.write_blocks(&pending, target, 1, true)
+            .expect("queue metadata update");
+
+        let mut observed = vec![0; BLOCK_SIZE];
+        dev.read_blocks(&mut observed, target, 1)
+            .expect("bulk read pending metadata");
+
+        assert_eq!(observed, pending);
     }
 }

--- a/fs/rsext4/src/blockdev/journal.rs
+++ b/fs/rsext4/src/blockdev/journal.rs
@@ -399,8 +399,13 @@ impl<B: BlockDevice> Jbd2Dev<B> {
     }
 
     /// Flushes the inner cached device.
-    pub fn cantflush(&mut self) -> Ext4Result<()> {
+    pub fn flush(&mut self) -> Ext4Result<()> {
         self.inner.flush()
+    }
+
+    /// Flushes the inner cached device using the original misspelled API name.
+    pub fn cantflush(&mut self) -> Ext4Result<()> {
+        self.flush()
     }
 
     /// Returns the total number of device blocks.

--- a/fs/rsext4/src/dir/bootstrap.rs
+++ b/fs/rsext4/src/dir/bootstrap.rs
@@ -118,7 +118,7 @@ pub fn create_lost_found_directory<B: BlockDevice>(
     block_dev: &mut Jbd2Dev<B>,
 ) -> Ext4Result<()> {
     // Allow callers to reuse the helper during setup without duplicating the directory.
-    if file_entry_exisr(fs, block_dev, "/lost+found")? {
+    if file_entry_exist(fs, block_dev, "/lost+found")? {
         return Ok(());
     }
 

--- a/fs/rsext4/src/dir/insert.rs
+++ b/fs/rsext4/src/dir/insert.rs
@@ -54,7 +54,7 @@ pub fn insert_dir_entry<B: BlockDevice>(
     let mut modified_phys: Option<AbsoluteBN> = None;
 
     // Try to satisfy the insertion inside already mapped directory blocks first.
-    let blocks = resolve_inode_block_allextend(fs, device, parent_inode)?;
+    let blocks = resolve_inode_blocks(fs, device, parent_inode)?;
 
     for lbn in 0..total_blocks {
         if modified_phys.is_some() {

--- a/fs/rsext4/src/dir/mkdir.rs
+++ b/fs/rsext4/src/dir/mkdir.rs
@@ -8,10 +8,7 @@ use crate::{
     checksum::update_ext4_dirblock_csum32,
     config::*,
     crc32c::ext4_superblock_has_metadata_csum,
-    dir::{
-        create_lost_found_directory, get_inode_with_num, insert_dir_entry,
-        split_paren_child_and_translatevalid,
-    },
+    dir::{create_lost_found_directory, get_inode_with_num, insert_dir_entry, normalize_path},
     disknode::*,
     endian::DiskFormat,
     entries::*,
@@ -37,7 +34,7 @@ fn mkdir_internal<B: BlockDevice>(
     gid: u32,
 ) -> Ext4Result<Ext4Inode> {
     let has_checksum = ext4_superblock_has_metadata_csum(&fs.superblock);
-    let norm_path = split_paren_child_and_translatevalid(path);
+    let norm_path = normalize_path(path);
     // Resolve trivial and already-existing paths before allocating anything.
     if norm_path.is_empty() {
         return Err(Ext4Error::invalid_input());

--- a/fs/rsext4/src/dir/mod.rs
+++ b/fs/rsext4/src/dir/mod.rs
@@ -11,4 +11,4 @@ pub use insert::insert_dir_entry;
 pub use lookup::get_inode_with_num;
 pub(crate) use mkdir::ensure_directory;
 pub use mkdir::{mkdir, mkdir_with_owner};
-pub use path::split_paren_child_and_translatevalid;
+pub use path::{normalize_path, split_paren_child_and_translatevalid};

--- a/fs/rsext4/src/dir/path.rs
+++ b/fs/rsext4/src/dir/path.rs
@@ -3,7 +3,7 @@
 use alloc::string::String;
 
 /// Normalizes a path by collapsing repeated separators and trimming a trailing slash.
-pub fn split_paren_child_and_translatevalid(pat: &str) -> String {
+pub fn normalize_path(pat: &str) -> String {
     let mut last_c = '\0';
     let mut result_s = String::new();
     for ch in pat.chars() {
@@ -19,4 +19,9 @@ pub fn split_paren_child_and_translatevalid(pat: &str) -> String {
     }
 
     result_s
+}
+
+/// Normalizes a path using the original misspelled API name.
+pub fn split_paren_child_and_translatevalid(pat: &str) -> String {
+    normalize_path(pat)
 }

--- a/fs/rsext4/src/ext4/lookup.rs
+++ b/fs/rsext4/src/ext4/lookup.rs
@@ -48,12 +48,23 @@ impl Ext4FileSystem {
 }
 
 /// Return whether a path resolves to an inode.
-pub fn file_entry_exisr<B: BlockDevice>(
+pub fn file_entry_exist<B: BlockDevice>(
     fs: &mut Ext4FileSystem,
     device: &mut Jbd2Dev<B>,
     path: &str,
 ) -> Ext4Result<bool> {
     fs.file_entries_exist(device, path)
+}
+
+/// Return whether a path resolves to an inode.
+///
+/// Kept for compatibility with the original misspelled API.
+pub fn file_entry_exisr<B: BlockDevice>(
+    fs: &mut Ext4FileSystem,
+    device: &mut Jbd2Dev<B>,
+    path: &str,
+) -> Ext4Result<bool> {
+    file_entry_exist(fs, device, path)
 }
 
 /// Look up an inode by path.

--- a/fs/rsext4/src/ext4/mkfs.rs
+++ b/fs/rsext4/src/ext4/mkfs.rs
@@ -388,9 +388,9 @@ fn write_superblock_redundant_backup<B: BlockDevice>(
     fs_layout: &FsLayoutInfo,
 ) -> Ext4Result<()> {
     // Group 0 already holds the primary copy, so backup writing starts from 1.
-    let sprse_feature =
+    let sparse_feature =
         sb.has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER);
-    if sprse_feature {
+    if sparse_feature {
         for gid in 1..groups_count {
             let group_layout = calc_group_layout(
                 gid,
@@ -482,9 +482,9 @@ fn write_gdt_redundant_backup<B: BlockDevice>(
         ));
     }
 
-    let sprse_feature =
+    let sparse_feature =
         sb.has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER);
-    if sprse_feature {
+    if sparse_feature {
         for gid in 1..groups_count {
             if need_redundant_backup(gid) {
                 let group_layout = calc_group_layout(

--- a/fs/rsext4/src/ext4/mkfs.rs
+++ b/fs/rsext4/src/ext4/mkfs.rs
@@ -52,6 +52,9 @@ pub struct BlcokGroupLayout {
     pub metadata_blocks_in_group: u32,
 }
 
+/// Correctly spelled alias for [`BlcokGroupLayout`].
+pub type BlockGroupLayout = BlcokGroupLayout;
+
 pub fn compute_fs_layout(inode_size: u16, total_blocks: u64) -> FsLayoutInfo {
     let block_size: u32 = 1024u32 << LOG_BLOCK_SIZE;
 
@@ -333,7 +336,7 @@ fn build_uninit_group_desc(
 
     // Derive the physical layout from the shared group-layout helper so mkfs
     // and backup-writing logic stay consistent.
-    let gl = cloc_group_layout(
+    let gl = calc_group_layout(
         group_id,
         sb,
         layout.blocks_per_group,
@@ -389,7 +392,7 @@ fn write_superblock_redundant_backup<B: BlockDevice>(
         sb.has_feature_ro_compat(Ext4Superblock::EXT4_FEATURE_RO_COMPAT_SPARSE_SUPER);
     if sprse_feature {
         for gid in 1..groups_count {
-            let group_layout = cloc_group_layout(
+            let group_layout = calc_group_layout(
                 gid,
                 sb,
                 fs_layout.blocks_per_group,
@@ -484,7 +487,7 @@ fn write_gdt_redundant_backup<B: BlockDevice>(
     if sprse_feature {
         for gid in 1..groups_count {
             if need_redundant_backup(gid) {
-                let group_layout = cloc_group_layout(
+                let group_layout = calc_group_layout(
                     gid,
                     sb,
                     fs_layout.blocks_per_group,
@@ -641,7 +644,7 @@ fn initialize_other_groups_bitmaps<B: BlockDevice>(
     // Group 0 has already been handled separately.
     for group_id in 1..layout.groups {
         // Reuse the same layout calculation as descriptor construction.
-        let gl = cloc_group_layout(
+        let gl = calc_group_layout(
             group_id,
             sb,
             layout.blocks_per_group,

--- a/fs/rsext4/src/ext4/mod.rs
+++ b/fs/rsext4/src/ext4/mod.rs
@@ -30,7 +30,7 @@ mod mount;
 mod sync;
 
 pub use fs::{Ext4FileSystem, FileSystemStats};
-pub use lookup::{file_entry_exisr, find_file};
-pub use mkfs::{BlcokGroupLayout, FsLayoutInfo, compute_fs_layout, mkfs};
+pub use lookup::{file_entry_exisr, file_entry_exist, find_file};
+pub use mkfs::{BlcokGroupLayout, BlockGroupLayout, FsLayoutInfo, compute_fs_layout, mkfs};
 pub use mount::{MountOptions, mount, mount_with_options};
 pub use sync::umount;

--- a/fs/rsext4/src/ext4/mount.rs
+++ b/fs/rsext4/src/ext4/mount.rs
@@ -104,7 +104,7 @@ impl Ext4FileSystem {
         journal_inode: &mut Ext4Inode,
     ) -> Ext4Result<Vec<AbsoluteBN>> {
         let journal_block_count = journal_inode.size().div_ceil(BLOCK_SIZE as u64);
-        let journal_block_map = resolve_inode_block_allextend(self, block_dev, journal_inode)?;
+        let journal_block_map = resolve_inode_blocks(self, block_dev, journal_inode)?;
         let mut journal_blocks = Vec::new();
         for logical in 0..journal_block_count {
             let logical = u32::try_from(logical).map_err(|_| Ext4Error::corrupted())?;

--- a/fs/rsext4/src/ext4/sync.rs
+++ b/fs/rsext4/src/ext4/sync.rs
@@ -16,7 +16,7 @@ impl Ext4FileSystem {
         self.bitmap_cache.flush_all(block_dev)?;
         self.sync_group_descriptors(block_dev)?;
         self.sync_superblock(block_dev)?;
-        block_dev.cantflush()?;
+        block_dev.flush()?;
         Ok(())
     }
 

--- a/fs/rsext4/src/extents_tree/remove.rs
+++ b/fs/rsext4/src/extents_tree/remove.rs
@@ -7,7 +7,7 @@ impl<'a> ExtentTree<'a> {
     /// extents, then walks the tree again to free blocks and rewrite touched
     /// leaf/index nodes, and finally collapses degenerate root states back into
     /// the inode-inline form when possible.
-    pub fn remove_extend<B: BlockDevice>(
+    pub fn remove_extent<B: BlockDevice>(
         &mut self,
         fs: &mut Ext4FileSystem,
         deleted_ext: Ext4Extent,
@@ -592,9 +592,18 @@ impl<'a> ExtentTree<'a> {
             }
         }
     }
+
+    /// Removes an allocated logical extent range using the original misspelled API name.
+    pub fn remove_extend<B: BlockDevice>(
+        &mut self,
+        fs: &mut Ext4FileSystem,
+        deleted_ext: Ext4Extent,
+        block_dev: &mut Jbd2Dev<B>,
+    ) -> Ext4Result<()> {
+        self.remove_extent(fs, deleted_ext, block_dev)
+    }
 }
 
-#[cfg(test)]
 #[cfg(test)]
 mod tests {
     extern crate std;
@@ -799,14 +808,14 @@ mod tests {
     }
 
     #[test]
-    fn remove_extend_root_leaf_no_degeneration() {
+    fn remove_extent_root_leaf_no_degeneration() {
         let (mut dev, mut fs) = setup_fs(16 * 1024);
         let mut inode = new_extent_inode();
 
         let exts = insert_n_extents_with_phys_gaps(&mut fs, &mut dev, &mut inode, 2);
         {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, exts[0], &mut dev).unwrap();
+            tree.remove_extent(&mut fs, exts[0], &mut dev).unwrap();
         }
 
         let tree = ExtentTree::new(&mut inode);
@@ -822,14 +831,14 @@ mod tests {
     }
 
     #[test]
-    fn remove_extend_root_leaf_degeneration_to_empty() {
+    fn remove_extent_root_leaf_degeneration_to_empty() {
         let (mut dev, mut fs) = setup_fs(16 * 1024);
         let mut inode = new_extent_inode();
 
         let exts = insert_n_extents_with_phys_gaps(&mut fs, &mut dev, &mut inode, 1);
         {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, exts[0], &mut dev).unwrap();
+            tree.remove_extent(&mut fs, exts[0], &mut dev).unwrap();
         }
 
         let tree = ExtentTree::new(&mut inode);
@@ -844,7 +853,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_extend_multilevel_to_root_promotion() {
+    fn remove_extent_multilevel_to_root_promotion() {
         let (mut dev, mut fs) = setup_fs(32 * 1024);
         let mut inode = new_extent_inode();
 
@@ -861,9 +870,9 @@ mod tests {
 
         {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, exts[2], &mut dev).unwrap();
-            tree.remove_extend(&mut fs, exts[3], &mut dev).unwrap();
-            tree.remove_extend(&mut fs, exts[4], &mut dev).unwrap();
+            tree.remove_extent(&mut fs, exts[2], &mut dev).unwrap();
+            tree.remove_extent(&mut fs, exts[3], &mut dev).unwrap();
+            tree.remove_extent(&mut fs, exts[4], &mut dev).unwrap();
         }
 
         let tree = ExtentTree::new(&mut inode);
@@ -880,14 +889,14 @@ mod tests {
     }
 
     #[test]
-    fn remove_extend_repeated_deletions_consistency() {
+    fn remove_extent_repeated_deletions_consistency() {
         let (mut dev, mut fs) = setup_fs(32 * 1024);
         let mut inode = new_extent_inode();
         let exts = insert_n_extents_with_phys_gaps(&mut fs, &mut dev, &mut inode, 5);
 
         for ext in exts {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, ext, &mut dev).unwrap();
+            tree.remove_extent(&mut fs, ext, &mut dev).unwrap();
 
             let tree2 = ExtentTree::new(&mut inode);
             assert!(tree2.load_root_from_inode().is_some());
@@ -905,7 +914,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_extend_frees_block_bitmap_bit() {
+    fn remove_extent_frees_block_bitmap_bit() {
         let (mut dev, mut fs) = setup_fs(16 * 1024);
         let mut inode = new_extent_inode();
 
@@ -920,14 +929,14 @@ mod tests {
 
         {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, ext, &mut dev).unwrap();
+            tree.remove_extent(&mut fs, ext, &mut dev).unwrap();
         }
 
         assert!(!bitmap_block_is_allocated(&mut fs, &mut dev, phys));
     }
 
     #[test]
-    fn remove_extend_partial_delete_splits_extent_and_updates_bitmap() {
+    fn remove_extent_partial_delete_splits_extent_and_updates_bitmap() {
         let (mut dev, mut fs) = setup_fs(32 * 1024);
         let mut inode = new_extent_inode();
 
@@ -941,7 +950,7 @@ mod tests {
         let del = Ext4Extent::new(1, 0, 2);
         {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, del, &mut dev).unwrap();
+            tree.remove_extent(&mut fs, del, &mut dev).unwrap();
         }
 
         assert!(bitmap_block_is_allocated(&mut fs, &mut dev, base));
@@ -978,7 +987,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_extend_full_delete_single_extent_bitmap_and_metadata() {
+    fn remove_extent_full_delete_single_extent_bitmap_and_metadata() {
         let (mut dev, mut fs) = setup_fs(32 * 1024);
         let mut inode = new_extent_inode();
 
@@ -992,7 +1001,7 @@ mod tests {
         let del = Ext4Extent::new(0, 0, 2);
         {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, del, &mut dev).unwrap();
+            tree.remove_extent(&mut fs, del, &mut dev).unwrap();
         }
 
         assert!(!bitmap_block_is_allocated(&mut fs, &mut dev, base));
@@ -1006,7 +1015,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_extend_multi_extent_skip_hole_and_verify() {
+    fn remove_extent_multi_extent_skip_hole_and_verify() {
         let (mut dev, mut fs) = setup_fs(64 * 1024);
         let mut inode = new_extent_inode();
 
@@ -1026,7 +1035,7 @@ mod tests {
         // delete 3 allocated blocks starting at lbn=1: deletes lbn=1, then skips hole [2..4), then deletes lbn=4 and lbn=5
         {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, Ext4Extent::new(1, 0, 3), &mut dev)
+            tree.remove_extent(&mut fs, Ext4Extent::new(1, 0, 3), &mut dev)
                 .unwrap();
         }
 
@@ -1054,7 +1063,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_extend_over_length_errors_and_does_not_delete_unrelated() {
+    fn remove_extent_over_length_errors_and_does_not_delete_unrelated() {
         let (mut dev, mut fs) = setup_fs(64 * 1024);
         let mut inode = new_extent_inode();
 
@@ -1079,7 +1088,7 @@ mod tests {
 
         let res = {
             let mut tree = ExtentTree::new(&mut inode);
-            tree.remove_extend(&mut fs, Ext4Extent::new(0, 0, 10), &mut dev)
+            tree.remove_extent(&mut fs, Ext4Extent::new(0, 0, 10), &mut dev)
         };
         assert!(res.is_err());
 

--- a/fs/rsext4/src/file/create.rs
+++ b/fs/rsext4/src/file/create.rs
@@ -45,8 +45,8 @@ pub fn create_symbol_link_with_owner<B: BlockDevice>(
     gid: u32,
 ) -> Ext4Result<()> {
     // Validate the source and destination before allocating the new symlink.
-    let src_norm = split_paren_child_and_translatevalid(src_path);
-    let dst_norm = split_paren_child_and_translatevalid(dst_path);
+    let src_norm = normalize_path(src_path);
+    let dst_norm = normalize_path(dst_path);
 
     if get_file_inode(fs, device, &src_norm)?.is_none() {
         return Err(Ext4Error::invalid_input());
@@ -204,7 +204,7 @@ pub fn mkfile_with_owner<B: BlockDevice>(
     gid: u32,
 ) -> Ext4Result<Ext4Inode> {
     // Normalize first so all later path splitting uses one canonical form.
-    let norm_path = split_paren_child_and_translatevalid(path);
+    let norm_path = normalize_path(path);
     if norm_path.is_empty() || norm_path == "/" {
         return Err(Ext4Error::invalid_input());
     }

--- a/fs/rsext4/src/file/delete.rs
+++ b/fs/rsext4/src/file/delete.rs
@@ -13,7 +13,7 @@ pub fn free_inode<B: BlockDevice>(
     inode_num: InodeNumber,
     inode: &mut Ext4Inode,
 ) -> Ext4Result<()> {
-    let mut used_blocks: Vec<AbsoluteBN> = resolve_inode_block_allextend(fs, block_dev, inode)?
+    let mut used_blocks: Vec<AbsoluteBN> = resolve_inode_blocks(fs, block_dev, inode)?
         .into_values()
         .collect();
     if inode.have_extend_header_and_use_extend() {
@@ -55,7 +55,7 @@ pub fn unlink<B: BlockDevice>(
 ) -> Ext4Result<()> {
     // Resolve the parent directory and target entry before mutating link
     // counts or directory contents.
-    let norm_path = split_paren_child_and_translatevalid(link_path);
+    let norm_path = normalize_path(link_path);
     let (parent_path, child_name) = if let Some(pos) = norm_path.rfind('/') {
         let parent = if pos == 0 {
             "/".to_string()
@@ -225,7 +225,7 @@ fn parent_dir_data_blocks<B: BlockDevice>(
 ) -> Ext4Result<alloc::vec::Vec<AbsoluteBN>> {
     let mut blocks: alloc::vec::Vec<AbsoluteBN> =
         if parent_inode.have_extend_header_and_use_extend() {
-            resolve_inode_block_allextend(fs, block_dev, parent_inode)?
+            resolve_inode_blocks(fs, block_dev, parent_inode)?
                 .into_values()
                 .collect()
         } else {
@@ -360,7 +360,7 @@ pub fn delete_dir<B: BlockDevice>(
         stage: u8, // 0=scan, 1=cleanup
     }
 
-    let norm_path = split_paren_child_and_translatevalid(path);
+    let norm_path = normalize_path(path);
     if norm_path == "/" {
         return Err(Ext4Error::busy());
     }
@@ -405,7 +405,7 @@ pub fn delete_dir<B: BlockDevice>(
         if frame.stage == 0 {
             let block_bytes = BLOCK_SIZE;
 
-            let dir_blocks = resolve_inode_block_allextend(fs, block_dev, &mut frame.inode)?;
+            let dir_blocks = resolve_inode_blocks(fs, block_dev, &mut frame.inode)?;
 
             let mut to_descend: Vec<(
                 alloc::string::String,
@@ -545,7 +545,7 @@ pub fn is_dir_empty<B: BlockDevice>(
     block_dev: &mut Jbd2Dev<B>,
     inode: &mut Ext4Inode,
 ) -> Ext4Result<bool> {
-    let dir_blocks = resolve_inode_block_allextend(fs, block_dev, inode)?;
+    let dir_blocks = resolve_inode_blocks(fs, block_dev, inode)?;
     for &phys in dir_blocks.values() {
         let cached = fs.datablock_cache.get_or_load(block_dev, phys)?;
         let data = &cached.data[..BLOCK_SIZE];
@@ -565,7 +565,7 @@ pub fn delete_file<B: BlockDevice>(
     block_dev: &mut Jbd2Dev<B>,
     path: &str,
 ) -> Ext4Result<()> {
-    let norm_path = split_paren_child_and_translatevalid(path);
+    let norm_path = normalize_path(path);
     let (parent_path, child_name) = if let Some(pos) = norm_path.rfind('/') {
         let parent = if pos == 0 {
             "/".to_string()

--- a/fs/rsext4/src/file/io.rs
+++ b/fs/rsext4/src/file/io.rs
@@ -8,7 +8,7 @@ pub fn truncate<B: BlockDevice>(
     path: &str,
     truncate_size: u64,
 ) -> Ext4Result<()> {
-    let norm_path = split_paren_child_and_translatevalid(path);
+    let norm_path = normalize_path(path);
 
     // Resolve the target inode once, then delegate to the inode-based helper.
     let (inode_num, _inode) = match get_inode_with_num(fs, device, &norm_path).ok().flatten() {
@@ -64,7 +64,7 @@ pub fn truncate_inode<B: BlockDevice>(
             let del_start_lbn = new_blocks as u32;
 
             loop {
-                let blocks_map = resolve_inode_block_allextend(fs, device, &mut inode)?;
+                let blocks_map = resolve_inode_blocks(fs, device, &mut inode)?;
                 let del_len = if truncate_size == 0 {
                     blocks_map.len() as u32
                 } else {
@@ -89,7 +89,7 @@ pub fn truncate_inode<B: BlockDevice>(
                 let chunk = core::cmp::min(del_len, Ext4Extent::EXT_INIT_MAX_LEN as u32);
                 {
                     let mut tree = ExtentTree::with_checksum(&mut inode, &fs.superblock, inode_num);
-                    tree.remove_extend(fs, Ext4Extent::new(start_lbn, 0, chunk as u16), device)?;
+                    tree.remove_extent(fs, Ext4Extent::new(start_lbn, 0, chunk as u16), device)?;
                 }
             }
         }
@@ -137,7 +137,7 @@ pub fn truncate_inode<B: BlockDevice>(
         inode.i_size_lo = (truncate_size & 0xffff_ffff) as u32;
         inode.i_size_high = (truncate_size >> 32) as u32;
         // i_blocks reflects number of allocated blocks, not logical length. Recompute after edits.
-        let alloc_blocks = resolve_inode_block_allextend(fs, device, &mut inode)?.len() as u64;
+        let alloc_blocks = resolve_inode_blocks(fs, device, &mut inode)?.len() as u64;
         let extent_tree_blocks = ExtentTree::with_checksum(&mut inode, &fs.superblock, inode_num)
             .external_node_blocks(device)?
             .len() as u64;
@@ -226,7 +226,7 @@ fn read_symlink_target<B: BlockDevice>(
     let mut buf = Vec::with_capacity(size);
 
     if inode.have_extend_header_and_use_extend() {
-        let blocks = resolve_inode_block_allextend(fs, device, inode)?;
+        let blocks = resolve_inode_blocks(fs, device, inode)?;
         for &phys in blocks.values() {
             let cached = fs.datablock_cache.get_or_load(device, phys)?;
             let data = &cached.data[..block_bytes];
@@ -254,7 +254,7 @@ fn read_symlink_target<B: BlockDevice>(
 
 fn resolve_symlink_path(current_path: &str, target: &str) -> String {
     if target.starts_with('/') {
-        return split_paren_child_and_translatevalid(target);
+        return normalize_path(target);
     }
     let parent = match current_path.rfind('/') {
         Some(0) | None => "/",
@@ -269,7 +269,7 @@ fn resolve_symlink_path(current_path: &str, target: &str) -> String {
         combined.push('/');
         combined.push_str(target);
     }
-    split_paren_child_and_translatevalid(&combined)
+    normalize_path(&combined)
 }
 
 fn read_file_follow<B: BlockDevice>(
@@ -319,7 +319,7 @@ fn read_file_follow<B: BlockDevice>(
     let mut buf = Vec::with_capacity(size);
 
     if inode.have_extend_header_and_use_extend() {
-        let blocks = resolve_inode_block_allextend(fs, device, &mut inode)?;
+        let blocks = resolve_inode_blocks(fs, device, &mut inode)?;
         for &phys in blocks.values() {
             let cached = fs.datablock_cache.get_or_load(device, phys)?;
             let data = &cached.data[..block_bytes];

--- a/fs/rsext4/src/file/link.rs
+++ b/fs/rsext4/src/file/link.rs
@@ -7,8 +7,8 @@ pub fn link<B: BlockDevice>(
     link_path: &str,
     linked_path: &str,
 ) -> Ext4Result<()> {
-    let link_norm = split_paren_child_and_translatevalid(link_path);
-    let linked_norm = split_paren_child_and_translatevalid(linked_path);
+    let link_norm = normalize_path(link_path);
+    let linked_norm = normalize_path(linked_path);
 
     // Resolve the target inode first.
     let (target_ino, target_inode) = match get_file_inode(fs, block_dev, &linked_norm) {
@@ -72,7 +72,7 @@ pub fn link<B: BlockDevice>(
     if let Some((_lpino, mut lp_inode)) = get_inode_with_num(fs, block_dev, &linked_parent_path)
         .ok()
         .flatten()
-        && let Ok(blocks) = resolve_inode_block_allextend(fs, block_dev, &mut lp_inode)
+        && let Ok(blocks) = resolve_inode_blocks(fs, block_dev, &mut lp_inode)
     {
         for &phys in blocks.values() {
             let cached = match fs.datablock_cache.get_or_load(block_dev, phys) {

--- a/fs/rsext4/src/file/rename.rs
+++ b/fs/rsext4/src/file/rename.rs
@@ -22,8 +22,8 @@ pub fn rename<B: BlockDevice>(
     old_path: &str,
     new_path: &str,
 ) -> Ext4Result<()> {
-    let old_norm = split_paren_child_and_translatevalid(old_path);
-    let new_norm = split_paren_child_and_translatevalid(new_path);
+    let old_norm = normalize_path(old_path);
+    let new_norm = normalize_path(new_path);
 
     // Resolve source type for cross-type checks.
     let src_is_dir = get_inode_with_num(fs, device, &old_norm)?.is_some_and(|(_, i)| i.is_dir());
@@ -93,8 +93,8 @@ pub fn mv<B: BlockDevice>(
     // 4. remove the old entry,
     // 5. fix directory-specific link counts and `..` when moving directories.
 
-    let old_norm = split_paren_child_and_translatevalid(old_path);
-    let new_norm = split_paren_child_and_translatevalid(new_path);
+    let old_norm = normalize_path(old_path);
+    let new_norm = normalize_path(new_path);
 
     let (old_parent, old_name) = match old_norm.rfind('/') {
         Some(pos) => {

--- a/fs/rsext4/src/hashtree/lookup.rs
+++ b/fs/rsext4/src/hashtree/lookup.rs
@@ -14,7 +14,7 @@ use crate::{
     disknode::Ext4Inode,
     entries::{DirEntryIterator, Ext4DirEntryInfo, Ext4DxEntry, classic_dir, htree_dir},
     ext4::Ext4FileSystem,
-    loopfile::{resolve_inode_block, resolve_inode_block_allextend},
+    loopfile::{resolve_inode_block, resolve_inode_blocks},
 };
 
 pub(super) fn lookup<B: BlockDevice>(
@@ -205,7 +205,7 @@ impl HashTreeManager {
 
         if dir_inode.have_extend_header_and_use_extend() {
             let mut inode_copy = *dir_inode;
-            let blocks_map = match resolve_inode_block_allextend(fs, block_dev, &mut inode_copy) {
+            let blocks_map = match resolve_inode_blocks(fs, block_dev, &mut inode_copy) {
                 Ok(map) => map,
                 Err(_) => return Err(HashTreeError::BlockOutOfRange),
             };

--- a/fs/rsext4/src/loopfile.rs
+++ b/fs/rsext4/src/loopfile.rs
@@ -55,7 +55,7 @@ pub fn resolve_inode_block<B: BlockDevice>(
 ///
 /// The helper walks the entire extent tree, materializes every mapped block,
 /// and returns the final map sorted by logical block number.
-pub fn resolve_inode_block_allextend<B: BlockDevice>(
+pub fn resolve_inode_blocks<B: BlockDevice>(
     _fs: &mut Ext4FileSystem,
     block_dev: &mut Jbd2Dev<B>,
     inode: &mut Ext4Inode,
@@ -123,6 +123,15 @@ pub fn resolve_inode_block_allextend<B: BlockDevice>(
     Ok(out)
 }
 
+/// Builds a logical-block map using the original misspelled API name.
+pub fn resolve_inode_block_allextend<B: BlockDevice>(
+    fs: &mut Ext4FileSystem,
+    block_dev: &mut Jbd2Dev<B>,
+    inode: &mut Ext4Inode,
+) -> Ext4Result<BTreeMap<u32, AbsoluteBN>> {
+    resolve_inode_blocks(fs, block_dev, inode)
+}
+
 /// Resolves a path to its inode number and inode contents.
 ///
 /// The path walk tries hash-tree lookup first for each component and falls back
@@ -177,7 +186,7 @@ pub fn get_file_inode<B: BlockDevice>(
 
                 let total_size = current_inode.size() as usize;
                 let block_bytes = BLOCK_SIZE;
-                let blocks = resolve_inode_block_allextend(fs, block_dev, &mut current_inode)?;
+                let blocks = resolve_inode_blocks(fs, block_dev, &mut current_inode)?;
                 debug!(
                     "Directory inode size: {} bytes, blocks used: {}",
                     total_size,

--- a/fs/rsext4/src/metadata/api.rs
+++ b/fs/rsext4/src/metadata/api.rs
@@ -3,7 +3,7 @@
 use super::Ext4InodeMetadataUpdate;
 use crate::{
     blockdev::{BlockDevice, Jbd2Dev},
-    dir::{get_inode_with_num, split_paren_child_and_translatevalid},
+    dir::{get_inode_with_num, normalize_path},
     disknode::Ext4TimeSpec,
     error::{Ext4Error, Ext4Result},
     ext4::Ext4FileSystem,
@@ -16,7 +16,7 @@ pub fn chmod<B: BlockDevice>(
     path: &str,
     mode: u16,
 ) -> Ext4Result<()> {
-    let path = split_paren_child_and_translatevalid(path);
+    let path = normalize_path(path);
     let (inode_num, _) = get_inode_with_num(fs, device, &path)?.ok_or(Ext4Error::invalid_input())?;
     let _ = fs.apply_inode_metadata(device, inode_num, Ext4InodeMetadataUpdate::chmod(mode))?;
     Ok(())
@@ -30,7 +30,7 @@ pub fn chown<B: BlockDevice>(
     uid: Option<u32>,
     gid: Option<u32>,
 ) -> Ext4Result<()> {
-    let path = split_paren_child_and_translatevalid(path);
+    let path = normalize_path(path);
     let (inode_num, _) = get_inode_with_num(fs, device, &path)?.ok_or(Ext4Error::invalid_input())?;
     let _ = fs.apply_inode_metadata(device, inode_num, Ext4InodeMetadataUpdate::chown(uid, gid))?;
     Ok(())
@@ -44,7 +44,7 @@ pub fn utimens<B: BlockDevice>(
     atime: Ext4TimeSpec,
     mtime: Ext4TimeSpec,
 ) -> Ext4Result<()> {
-    let path = split_paren_child_and_translatevalid(path);
+    let path = normalize_path(path);
     let (inode_num, _) = get_inode_with_num(fs, device, &path)?.ok_or(Ext4Error::invalid_input())?;
     let _ = fs.apply_inode_metadata(
         device,
@@ -61,7 +61,7 @@ pub fn set_project<B: BlockDevice>(
     path: &str,
     projid: u32,
 ) -> Ext4Result<()> {
-    let path = split_paren_child_and_translatevalid(path);
+    let path = normalize_path(path);
     let (inode_num, _) = get_inode_with_num(fs, device, &path)?.ok_or(Ext4Error::invalid_input())?;
     let _ = fs.apply_inode_project(device, inode_num, projid)?;
     Ok(())
@@ -74,7 +74,7 @@ pub fn set_flags<B: BlockDevice>(
     path: &str,
     flags: u32,
 ) -> Ext4Result<()> {
-    let path = split_paren_child_and_translatevalid(path);
+    let path = normalize_path(path);
     let (inode_num, _) = get_inode_with_num(fs, device, &path)?.ok_or(Ext4Error::invalid_input())?;
     let _ = fs.apply_inode_flags(device, inode_num, flags)?;
     Ok(())

--- a/fs/rsext4/src/tool.rs
+++ b/fs/rsext4/src/tool.rs
@@ -81,7 +81,7 @@ pub fn is_numbers_power(number: usize, base: usize) -> bool {
 /// the sparse-super rules and either reserve space for backup superblock/GDT
 /// copies or start directly with their bitmaps.
 #[allow(clippy::too_many_arguments)]
-pub fn cloc_group_layout(
+pub fn calc_group_layout(
     gid: u32,
     sb: &Ext4Superblock,
     blocks_per_group: u32,
@@ -90,9 +90,9 @@ pub fn cloc_group_layout(
     group0_inode_bitmap: u32,
     group0_inode_table: u32,
     gdt_blocks: u32,
-) -> BlcokGroupLayout {
+) -> BlockGroupLayout {
     if gid == 0 {
-        return BlcokGroupLayout {
+        return BlockGroupLayout {
             group_start_block: 0,
             group_blcok_bitmap_startblocks: group0_block_bitmap as u64,
             group_inode_bitmap_startblocks: group0_inode_bitmap as u64,
@@ -124,11 +124,35 @@ pub fn cloc_group_layout(
         (bb, ib, it, meta)
     };
 
-    BlcokGroupLayout {
+    BlockGroupLayout {
         group_start_block: group_start as u64,
         group_blcok_bitmap_startblocks: block_bitmap as u64,
         group_inode_bitmap_startblocks: inode_bitmap as u64,
         group_inode_table_startblocks: inode_table as u64,
         metadata_blocks_in_group: meta_blocks,
     }
+}
+
+/// Group-layout calculation with the original misspelled API name.
+#[allow(clippy::too_many_arguments)]
+pub fn cloc_group_layout(
+    gid: u32,
+    sb: &Ext4Superblock,
+    blocks_per_group: u32,
+    inode_table_blocks: u32,
+    group0_block_bitmap: u32,
+    group0_inode_bitmap: u32,
+    group0_inode_table: u32,
+    gdt_blocks: u32,
+) -> BlockGroupLayout {
+    calc_group_layout(
+        gid,
+        sb,
+        blocks_per_group,
+        inode_table_blocks,
+        group0_block_bitmap,
+        group0_inode_bitmap,
+        group0_inode_table,
+        gdt_blocks,
+    )
 }

--- a/fs/rsext4/tests/crc_integrity.rs
+++ b/fs/rsext4/tests/crc_integrity.rs
@@ -151,7 +151,7 @@ fn sync_with_axfs_ng_order(
     if dev.is_use_journal() {
         dev.umount_commit();
     }
-    dev.cantflush()
+    dev.flush()
 }
 
 fn read_superblock(device: &SharedCrcDevice) -> Ext4Superblock {

--- a/fs/rsext4/tests/public_api_compat.rs
+++ b/fs/rsext4/tests/public_api_compat.rs
@@ -10,7 +10,7 @@ use rsext4::{
     bmalloc::AbsoluteBN,
     cache::bitmap::CacheKey,
     dir::{normalize_path, split_paren_child_and_translatevalid},
-    disknode::Ext4Extent,
+    disknode::{Ext4Extent, Ext4Inode},
     error::{Ext4Error, Ext4Result},
     ext4::{BlcokGroupLayout, BlockGroupLayout, file_entry_exisr, file_entry_exist},
     extents_tree::{ExtentNode, ExtentTree},

--- a/fs/rsext4/tests/public_api_compat.rs
+++ b/fs/rsext4/tests/public_api_compat.rs
@@ -1,0 +1,370 @@
+//! Public API compatibility tests for corrected misspellings.
+//!
+//! These tests intentionally call the old misspelled public entry points from
+//! outside the crate. They keep the compatibility wrappers compiled and verify
+//! that each old name behaves like its corrected counterpart.
+
+use std::{cell::Cell, collections::BTreeMap};
+
+use rsext4::{
+    bmalloc::AbsoluteBN,
+    cache::bitmap::CacheKey,
+    dir::{normalize_path, split_paren_child_and_translatevalid},
+    disknode::Ext4Extent,
+    error::{Ext4Error, Ext4Result},
+    ext4::{BlcokGroupLayout, BlockGroupLayout, file_entry_exisr, file_entry_exist},
+    extents_tree::{ExtentNode, ExtentTree},
+    loopfile::{resolve_inode_block_allextend, resolve_inode_blocks},
+    tool::{calc_group_layout, cloc_group_layout},
+    *,
+};
+
+#[derive(Clone)]
+struct CompatBlockDevice {
+    data: Vec<u8>,
+    block_size: u32,
+    flush_count: u32,
+    now: Cell<i64>,
+}
+
+impl CompatBlockDevice {
+    fn new(total_blocks: u64) -> Self {
+        Self {
+            data: vec![0; total_blocks as usize * BLOCK_SIZE],
+            block_size: BLOCK_SIZE as u32,
+            flush_count: 0,
+            now: Cell::new(1_700_000_000),
+        }
+    }
+}
+
+impl BlockDevice for CompatBlockDevice {
+    fn read(&mut self, buffer: &mut [u8], block_id: AbsoluteBN, count: u32) -> Ext4Result<()> {
+        let required = self.block_size as usize * count as usize;
+        if buffer.len() < required {
+            return Err(Ext4Error::buffer_too_small(buffer.len(), required));
+        }
+        let start = block_id.as_usize()? * self.block_size as usize;
+        let end = start + required;
+        if end > self.data.len() {
+            return Err(Ext4Error::block_out_of_range(
+                block_id.to_u32()?,
+                self.total_blocks(),
+            ));
+        }
+        buffer[..required].copy_from_slice(&self.data[start..end]);
+        Ok(())
+    }
+
+    fn write(&mut self, buffer: &[u8], block_id: AbsoluteBN, count: u32) -> Ext4Result<()> {
+        let required = self.block_size as usize * count as usize;
+        if buffer.len() < required {
+            return Err(Ext4Error::buffer_too_small(buffer.len(), required));
+        }
+        let start = block_id.as_usize()? * self.block_size as usize;
+        let end = start + required;
+        if end > self.data.len() {
+            return Err(Ext4Error::block_out_of_range(
+                block_id.to_u32()?,
+                self.total_blocks(),
+            ));
+        }
+        self.data[start..end].copy_from_slice(&buffer[..required]);
+        Ok(())
+    }
+
+    fn open(&mut self) -> Ext4Result<()> {
+        Ok(())
+    }
+
+    fn close(&mut self) -> Ext4Result<()> {
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Ext4Result<()> {
+        self.flush_count += 1;
+        Ok(())
+    }
+
+    fn total_blocks(&self) -> u64 {
+        (self.data.len() / self.block_size as usize) as u64
+    }
+
+    fn block_size(&self) -> u32 {
+        self.block_size
+    }
+
+    fn current_time(&self) -> Ext4Result<Ext4Timestamp> {
+        let sec = self.now.get();
+        self.now.set(sec + 1);
+        Ok(Ext4Timestamp::new(sec, 0))
+    }
+}
+
+fn setup_fs(total_blocks: u64) -> (Jbd2Dev<CompatBlockDevice>, Ext4FileSystem) {
+    let device = CompatBlockDevice::new(total_blocks);
+    let mut jbd2_dev = Jbd2Dev::initial_jbd2dev(0, device, false);
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+    let fs = mount(&mut jbd2_dev).expect("mount failed");
+    (jbd2_dev, fs)
+}
+
+fn new_extent_inode() -> Ext4Inode {
+    let mut inode = Ext4Inode::default();
+    inode.i_flags |= Ext4Inode::EXT4_EXTENTS_FL;
+    inode.write_extend_header();
+    inode
+}
+
+fn alloc_contiguous(
+    fs: &mut Ext4FileSystem,
+    dev: &mut Jbd2Dev<CompatBlockDevice>,
+    count: u32,
+) -> AbsoluteBN {
+    assert!(count > 0);
+    let first = fs.alloc_block(dev).expect("allocate first block");
+    let mut previous = first;
+    for _ in 1..count {
+        let block = fs.alloc_block(dev).expect("allocate next block");
+        assert_eq!(block, previous.checked_add(1).expect("next block number"));
+        previous = block;
+    }
+    first
+}
+
+fn bitmap_block_is_allocated(
+    fs: &mut Ext4FileSystem,
+    dev: &mut Jbd2Dev<CompatBlockDevice>,
+    global_block: AbsoluteBN,
+) -> bool {
+    let (group_idx, block_in_group) = fs
+        .block_allocator
+        .global_to_group(global_block)
+        .expect("block should map to a group");
+    let desc = fs
+        .group_descs
+        .get(group_idx.as_usize().expect("group index"))
+        .expect("group descriptor");
+    let bitmap_block = AbsoluteBN::new(desc.block_bitmap());
+    let bitmap = fs
+        .bitmap_cache
+        .get_or_load(dev, CacheKey::new_block(group_idx), bitmap_block)
+        .expect("load block bitmap");
+    let idx = block_in_group.as_usize().expect("block index in group");
+    ((bitmap.data[idx / 8] >> (idx % 8)) & 1) == 1
+}
+
+fn collect_extents(
+    inode: &mut Ext4Inode,
+    dev: &mut Jbd2Dev<CompatBlockDevice>,
+) -> Vec<(u32, u32, u64)> {
+    fn walk(
+        dev: &mut Jbd2Dev<CompatBlockDevice>,
+        node: &ExtentNode,
+        out: &mut Vec<(u32, u32, u64)>,
+    ) {
+        match node {
+            ExtentNode::Leaf { entries, .. } => {
+                out.extend(
+                    entries
+                        .iter()
+                        .map(|extent| (extent.ee_block, extent.len(), extent.start_block())),
+                );
+            }
+            ExtentNode::Index { entries, .. } => {
+                for idx in entries {
+                    let child_block = ((idx.ei_leaf_hi as u64) << 32) | idx.ei_leaf_lo as u64;
+                    dev.read_block(AbsoluteBN::new(child_block))
+                        .expect("read child extent node");
+                    let child = ExtentTree::parse_node(dev.buffer()).expect("parse child node");
+                    walk(dev, &child, out);
+                }
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    let tree = ExtentTree::new(inode);
+    if let Some(root) = tree.load_root_from_inode() {
+        walk(dev, &root, &mut out);
+    }
+    out.sort_unstable();
+    out
+}
+
+fn build_mapped_inode(fs: &mut Ext4FileSystem, dev: &mut Jbd2Dev<CompatBlockDevice>) -> Ext4Inode {
+    let mut inode = new_extent_inode();
+    let first = alloc_contiguous(fs, dev, 2);
+    let second = alloc_contiguous(fs, dev, 1);
+    let mut tree = ExtentTree::new(&mut inode);
+    tree.insert_extent(fs, Ext4Extent::new(0, first.raw(), 2), dev)
+        .expect("insert first extent");
+    tree.insert_extent(fs, Ext4Extent::new(4, second.raw(), 1), dev)
+        .expect("insert second extent");
+    inode
+}
+
+fn assert_layout_eq(left: BlockGroupLayout, right: BlcokGroupLayout) {
+    assert_eq!(left.group_start_block, right.group_start_block);
+    assert_eq!(
+        left.group_blcok_bitmap_startblocks,
+        right.group_blcok_bitmap_startblocks
+    );
+    assert_eq!(
+        left.group_inode_bitmap_startblocks,
+        right.group_inode_bitmap_startblocks
+    );
+    assert_eq!(
+        left.group_inode_table_startblocks,
+        right.group_inode_table_startblocks
+    );
+    assert_eq!(
+        left.metadata_blocks_in_group,
+        right.metadata_blocks_in_group
+    );
+}
+
+#[test]
+fn cantflush_matches_flush_on_cached_block_device() {
+    let payload = vec![0x5a; BLOCK_SIZE];
+    let mut new_dev = Jbd2Dev::initial_jbd2dev(0, CompatBlockDevice::new(16), false);
+    let mut old_dev = Jbd2Dev::initial_jbd2dev(0, CompatBlockDevice::new(16), false);
+
+    new_dev
+        .write_blocks(&payload, AbsoluteBN::new(3), 1, false)
+        .expect("write through new device");
+    old_dev
+        .write_blocks(&payload, AbsoluteBN::new(3), 1, false)
+        .expect("write through old device");
+
+    new_dev.flush().expect("flush through corrected API");
+    old_dev
+        .cantflush()
+        .expect("flush through compatibility API");
+
+    let new_inner = new_dev.into_inner();
+    let old_inner = old_dev.into_inner();
+    assert_eq!(new_inner.flush_count, old_inner.flush_count);
+    assert_eq!(new_inner.data, old_inner.data);
+}
+
+#[test]
+fn file_entry_exisr_matches_file_entry_exist() {
+    let (mut dev, mut fs) = setup_fs(16 * 1024);
+    mkfile(&mut dev, &mut fs, "/compat/file", Some(b"hello"), None).expect("create file");
+
+    for path in ["/", "/compat/file", "/compat/missing"] {
+        let corrected = file_entry_exist(&mut fs, &mut dev, path);
+        let compatible = file_entry_exisr(&mut fs, &mut dev, path);
+        assert_eq!(
+            corrected.map_err(|err| err.code),
+            compatible.map_err(|err| err.code),
+            "path {path}"
+        );
+    }
+}
+
+#[test]
+fn split_paren_child_and_translatevalid_matches_normalize_path() {
+    for path in ["/", "//a///b/", "a//b//", "///"] {
+        assert_eq!(
+            normalize_path(path),
+            split_paren_child_and_translatevalid(path),
+            "path {path}"
+        );
+    }
+}
+
+#[test]
+fn cloc_group_layout_matches_calc_group_layout() {
+    let (_, fs) = setup_fs(16 * 1024);
+    let sb = &fs.superblock;
+    let inode_table_blocks =
+        (sb.s_inodes_per_group * sb.s_inode_size as u32).div_ceil(BLOCK_SIZE as u32);
+
+    for gid in [0, 1, 2, 3, 5, 7, 11] {
+        let corrected = calc_group_layout(
+            gid,
+            sb,
+            sb.s_blocks_per_group,
+            inode_table_blocks,
+            fs.group_descs[0].block_bitmap() as u32,
+            fs.group_descs[0].inode_bitmap() as u32,
+            fs.group_descs[0].inode_table() as u32,
+            1,
+        );
+        let compatible = cloc_group_layout(
+            gid,
+            sb,
+            sb.s_blocks_per_group,
+            inode_table_blocks,
+            fs.group_descs[0].block_bitmap() as u32,
+            fs.group_descs[0].inode_bitmap() as u32,
+            fs.group_descs[0].inode_table() as u32,
+            1,
+        );
+        assert_layout_eq(corrected, compatible);
+    }
+}
+
+#[test]
+fn resolve_inode_block_allextend_matches_resolve_inode_blocks() {
+    let (mut dev, mut fs) = setup_fs(16 * 1024);
+    let inode = build_mapped_inode(&mut fs, &mut dev);
+    let mut corrected_inode = inode;
+    let mut compatible_inode = inode;
+
+    let corrected = resolve_inode_blocks(&mut fs, &mut dev, &mut corrected_inode)
+        .expect("resolve through corrected API");
+    let compatible = resolve_inode_block_allextend(&mut fs, &mut dev, &mut compatible_inode)
+        .expect("resolve through compatibility API");
+
+    assert_eq!(corrected, compatible);
+    assert_eq!(corrected.len(), 3);
+}
+
+#[test]
+fn remove_extend_matches_remove_extent() {
+    fn run_with(
+        remove: impl FnOnce(
+            &mut ExtentTree<'_>,
+            &mut Ext4FileSystem,
+            Ext4Extent,
+            &mut Jbd2Dev<CompatBlockDevice>,
+        ) -> Ext4Result<()>,
+    ) -> (Vec<(u32, u32, u64)>, BTreeMap<u64, bool>) {
+        let (mut dev, mut fs) = setup_fs(32 * 1024);
+        let mut inode = new_extent_inode();
+        let base = alloc_contiguous(&mut fs, &mut dev, 4);
+        let inserted = Ext4Extent::new(0, base.raw(), 4);
+        ExtentTree::new(&mut inode)
+            .insert_extent(&mut fs, inserted, &mut dev)
+            .expect("insert extent");
+
+        let deleted = Ext4Extent::new(1, 0, 2);
+        remove(&mut ExtentTree::new(&mut inode), &mut fs, deleted, &mut dev)
+            .expect("remove extent");
+
+        let allocated = [
+            base,
+            base.checked_add(1).expect("base + 1"),
+            base.checked_add(2).expect("base + 2"),
+            base.checked_add(3).expect("base + 3"),
+        ]
+        .into_iter()
+        .map(|block| {
+            (
+                block.raw(),
+                bitmap_block_is_allocated(&mut fs, &mut dev, block),
+            )
+        })
+        .collect();
+
+        (collect_extents(&mut inode, &mut dev), allocated)
+    }
+
+    let corrected = run_with(|tree, fs, extent, dev| tree.remove_extent(fs, extent, dev));
+    let compatible = run_with(|tree, fs, extent, dev| tree.remove_extend(fs, extent, dev));
+
+    assert_eq!(corrected, compatible);
+}

--- a/fs/rsext4/tests/public_api_compat.rs
+++ b/fs/rsext4/tests/public_api_compat.rs
@@ -224,6 +224,12 @@ fn assert_layout_eq(left: BlockGroupLayout, right: BlcokGroupLayout) {
     );
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct RemovedExtentObservation {
+    extents: Vec<(u32, u32, u64)>,
+    allocated_blocks: BTreeMap<u64, bool>,
+}
+
 #[test]
 fn cantflush_matches_flush_on_cached_block_device() {
     let payload = vec![0x5a; BLOCK_SIZE];
@@ -332,7 +338,7 @@ fn remove_extend_matches_remove_extent() {
             Ext4Extent,
             &mut Jbd2Dev<CompatBlockDevice>,
         ) -> Ext4Result<()>,
-    ) -> (Vec<(u32, u32, u64)>, BTreeMap<u64, bool>) {
+    ) -> RemovedExtentObservation {
         let (mut dev, mut fs) = setup_fs(32 * 1024);
         let mut inode = new_extent_inode();
         let base = alloc_contiguous(&mut fs, &mut dev, 4);
@@ -360,7 +366,10 @@ fn remove_extend_matches_remove_extent() {
         })
         .collect();
 
-        (collect_extents(&mut inode, &mut dev), allocated)
+        RemovedExtentObservation {
+            extents: collect_extents(&mut inode, &mut dev),
+            allocated_blocks: allocated,
+        }
     }
 
     let corrected = run_with(|tree, fs, extent, dev| tree.remove_extent(fs, extent, dev));


### PR DESCRIPTION
## 问题

`rsext4` 中存在若干已经暴露为公共 API 或在 crate 内广泛使用的拼写错误命名，例如 `file_entry_exisr`、`BlcokGroupLayout`、`cloc_group_layout`、`remove_extend`、`resolve_inode_block_allextend`、`split_paren_child_and_translatevalid` 和 `cantflush`。这些名字不影响当前行为，但会降低 API 可读性，也容易让后续维护者误解语义。

## 修改内容

- 新增拼写正确的公共入口：
  - `file_entry_exist`
  - `BlockGroupLayout`
  - `calc_group_layout`
  - `normalize_path`
  - `resolve_inode_blocks`
  - `remove_extent`
  - `Jbd2Dev::flush`
- 将 crate 内部调用迁移到新的正确命名。
- 保留原有拼写错误的公共 API，并通过 wrapper/type alias 转发到新实现，避免破坏已有调用方。
- 修正局部变量拼写 `sprse_feature` 为 `sparse_feature`。
- 移除 `extents_tree/remove.rs` 中重复的 `#[cfg(test)]`。


这次修改只做命名和兼容入口整理，不改变 ext4 文件系统行为。对于函数和类型别名，新增正确名字后让旧名字继续转发，保证旧代码仍可编译；对于 crate 内部调用，统一改用正确名字，后续阅读和维护时优先看到清晰 API。公开字段等无法无破坏兼容迁移的历史拼写问题暂未改动，避免扩大变更范围。