### PR TITLE
fix(starry-kernel): correct ptrace syscall and exec stops

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -436,7 +436,12 @@ impl CloneArgs {
         if trace_clone && let Some(tracer_pid) = curr.as_thread().proc_data.ptrace_tracer_pid() {
             if !flags.contains(CloneFlags::THREAD) {
                 new_proc_data.set_ptrace_tracer_pid(tracer_pid);
-                new_proc_data.set_ptrace_attached();
+                let attach_mode = if curr.as_thread().proc_data.is_ptrace_seized() {
+                    crate::task::PtraceAttachMode::Seize
+                } else {
+                    crate::task::PtraceAttachMode::Attach
+                };
+                new_proc_data.set_ptrace_attach_mode(attach_mode);
             }
             new_proc_data.set_ptrace_stop(tid, starry_signal::Signo::SIGSTOP, &new_uctx);
         }

--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -83,6 +83,15 @@ pub const PTRACE_EVENT_CLONE: u32 = 3;
 const PTRACE_EVENT_EXEC: u32 = 4;
 pub const PTRACE_EVENT_VFORK_DONE: u32 = 5;
 const PTRACE_EVENT_EXIT: u32 = 6;
+const PTRACE_EVENT_STOP: u32 = 128;
+
+const PTRACE_OPTION_MASK: usize = PTRACE_O_TRACESYSGOOD
+    | PTRACE_O_TRACEFORK
+    | PTRACE_O_TRACEVFORK
+    | PTRACE_O_TRACECLONE
+    | PTRACE_O_TRACEEXEC
+    | PTRACE_O_TRACEVFORKDONE
+    | PTRACE_O_TRACEEXIT;
 
 #[cfg(target_arch = "riscv64")]
 const EBREAK_INSN: u16 = 0x9002;
@@ -260,7 +269,7 @@ pub fn sys_ptrace(request: u32, pid: usize, addr: usize, data: usize) -> AxResul
         PTRACE_SETSIGINFO => ptrace_setsiginfo(pid, data),
         PTRACE_GETREGSET => ptrace_getregset(pid, addr, data),
         PTRACE_SETREGSET => ptrace_setregset(pid, addr, data),
-        PTRACE_SEIZE => ptrace_seize(pid, addr),
+        PTRACE_SEIZE => ptrace_seize(pid, data),
         PTRACE_INTERRUPT => ptrace_interrupt(pid),
         _ => Err(AxError::Unsupported),
     }
@@ -370,16 +379,7 @@ fn ptrace_syscall(pid: usize, data: usize) -> AxResult<isize> {
 
 fn ptrace_setoptions(pid: usize, options: usize) -> AxResult<isize> {
     let tracee = ptrace_stopped_tracee(pid)?;
-    let valid_mask = PTRACE_O_TRACESYSGOOD
-        | PTRACE_O_TRACEFORK
-        | PTRACE_O_TRACEVFORK
-        | PTRACE_O_TRACECLONE
-        | PTRACE_O_TRACEEXEC
-        | PTRACE_O_TRACEVFORKDONE
-        | PTRACE_O_TRACEEXIT;
-    if options & !valid_mask != 0 {
-        return Err(AxError::InvalidInput);
-    }
+    ptrace_validate_options(options)?;
     tracee.set_ptrace_options(options);
     Ok(0)
 }
@@ -598,13 +598,16 @@ fn ptrace_setfpregs(pid: usize, data: usize) -> AxResult<isize> {
     Err(AxError::Unsupported)
 }
 
-fn ptrace_seize(pid: usize, _addr: usize) -> AxResult<isize> {
+fn ptrace_seize(pid: usize, options: usize) -> AxResult<isize> {
+    ptrace_validate_options(options)?;
+
     let tracer_pid = current().as_thread().proc_data.proc.pid();
-    let tracee_pid = Pid::try_from(pid).map_err(|_| AxError::from(LinuxError::ESRCH))?;
+    let tracee_tid = Pid::try_from(pid).map_err(|_| AxError::from(LinuxError::ESRCH))?;
+    let tracee = ptrace_tracee_by_pid_or_tid(tracee_tid)?;
+    let tracee_pid = tracee.proc.pid();
     if tracee_pid == tracer_pid {
         return Err(AxError::from(LinuxError::EPERM));
     }
-    let tracee = get_process_data(tracee_pid).map_err(|_| AxError::from(LinuxError::ESRCH))?;
     if tracee.is_ptrace_traceme() || tracee.is_ptrace_attached() {
         return Err(AxError::from(LinuxError::EPERM));
     }
@@ -612,8 +615,16 @@ fn ptrace_seize(pid: usize, _addr: usize) -> AxResult<isize> {
         return Err(AxError::from(LinuxError::EPERM));
     }
     tracee.set_ptrace_tracer_pid(tracer_pid);
+    tracee.set_ptrace_options(options);
     tracee.set_ptrace_attached();
     Ok(0)
+}
+
+fn ptrace_validate_options(options: usize) -> AxResult {
+    if options & !PTRACE_OPTION_MASK != 0 {
+        return Err(AxError::InvalidInput);
+    }
+    Ok(())
 }
 
 fn ptrace_may_attach(tracer_pid: Pid, tracee_pid: Pid, tracee: &ProcessData) -> AxResult<bool> {
@@ -645,19 +656,21 @@ fn ptrace_creds_match_for_attach(tracer: &Cred, tracee: &Cred) -> bool {
 }
 
 fn ptrace_interrupt(pid: usize) -> AxResult<isize> {
-    let tracee_pid = Pid::try_from(pid).map_err(|_| AxError::from(LinuxError::ESRCH))?;
-    let tracee = get_process_data(tracee_pid).map_err(|_| AxError::from(LinuxError::ESRCH))?;
-    if !tracee.is_ptrace_attached() && !tracee.is_ptrace_traceme() {
+    let tracee_tid = Pid::try_from(pid).map_err(|_| AxError::from(LinuxError::ESRCH))?;
+    let tracee = ptrace_tracee_by_pid_or_tid(tracee_tid)?;
+    let tracer_pid = current().as_thread().proc_data.proc.pid();
+    if !tracee.is_ptrace_attached() || tracee.ptrace_tracer_pid() != Some(tracer_pid) {
         return Err(AxError::from(LinuxError::ESRCH));
     }
-    if tracee.ptrace_stop_signo().is_some() {
+    if tracee.ptrace_stop_signo_for(tracee_tid).is_some() {
         return Ok(0);
     }
-    use starry_signal::SignalInfo;
-    let _ = crate::task::send_signal_to_process(
-        tracee_pid,
-        Some(SignalInfo::new_kernel(Signo::SIGSTOP)),
-    );
+
+    tracee.set_ptrace_pending_event(tracee_tid, PTRACE_EVENT_STOP, 0);
+    // PTRACE_INTERRUPT creates a ptrace event stop, not a user-visible
+    // SIGTRAP. Interrupt the target so its user-return path consumes the
+    // pending event without leaving a second signal-delivery stop queued.
+    get_task(tracee_tid)?.interrupt();
     Ok(0)
 }
 

--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -680,9 +680,11 @@ fn ptrace_interrupt(pid: usize) -> AxResult<isize> {
     // PTRACE_INTERRUPT creates a ptrace event stop, not a user-visible
     // SIGTRAP. Interrupt the target so its user-return path consumes the
     // pending event without leaving a second signal-delivery stop queued. A
-    // tracee already parked in a job-control stop cannot return to userspace,
-    // so wake that wait loop to publish its event stop instead.
-    if tracee.is_job_stopped() {
+    // A tracee parked as the job-stop waiter cannot return to userspace, so
+    // wake that wait loop to publish its event stop. Process-level stopped
+    // state is insufficient here: a sibling may instead be blocked elsewhere
+    // and must be interrupted directly.
+    if tracee.is_job_stop_waiter(tracee_tid) {
         tracee.wake_job_stop_waiter();
     } else {
         get_task(tracee_tid)?.interrupt();

--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -269,7 +269,7 @@ pub fn sys_ptrace(request: u32, pid: usize, addr: usize, data: usize) -> AxResul
         PTRACE_SETSIGINFO => ptrace_setsiginfo(pid, data),
         PTRACE_GETREGSET => ptrace_getregset(pid, addr, data),
         PTRACE_SETREGSET => ptrace_setregset(pid, addr, data),
-        PTRACE_SEIZE => ptrace_seize(pid, data),
+        PTRACE_SEIZE => ptrace_seize(pid, addr, data),
         PTRACE_INTERRUPT => ptrace_interrupt(pid),
         _ => Err(AxError::Unsupported),
     }
@@ -346,7 +346,7 @@ fn ptrace_attach(pid: usize) -> AxResult<isize> {
         return Err(AxError::from(LinuxError::EPERM));
     }
     tracee.set_ptrace_tracer_pid(tracer_pid);
-    tracee.set_ptrace_attached();
+    tracee.set_ptrace_attach_mode(crate::task::PtraceAttachMode::Attach);
     use starry_signal::SignalInfo;
     let _ = crate::task::send_signal_to_process(
         tracee_pid,
@@ -602,7 +602,10 @@ fn ptrace_setfpregs(pid: usize, data: usize) -> AxResult<isize> {
     Err(AxError::Unsupported)
 }
 
-fn ptrace_seize(pid: usize, options: usize) -> AxResult<isize> {
+fn ptrace_seize(pid: usize, addr: usize, options: usize) -> AxResult<isize> {
+    if addr != 0 {
+        return Err(AxError::from(LinuxError::EIO));
+    }
     ptrace_validate_options(options)?;
 
     let tracer_pid = current().as_thread().proc_data.proc.pid();
@@ -620,7 +623,7 @@ fn ptrace_seize(pid: usize, options: usize) -> AxResult<isize> {
     }
     tracee.set_ptrace_tracer_pid(tracer_pid);
     tracee.set_ptrace_options(options);
-    tracee.set_ptrace_attached();
+    tracee.set_ptrace_attach_mode(crate::task::PtraceAttachMode::Seize);
     Ok(0)
 }
 
@@ -663,8 +666,11 @@ fn ptrace_interrupt(pid: usize) -> AxResult<isize> {
     let tracee_tid = Pid::try_from(pid).map_err(|_| AxError::from(LinuxError::ESRCH))?;
     let tracee = ptrace_tracee_by_pid_or_tid(tracee_tid)?;
     let tracer_pid = current().as_thread().proc_data.proc.pid();
-    if !tracee.is_ptrace_attached() || tracee.ptrace_tracer_pid() != Some(tracer_pid) {
+    if tracee.ptrace_tracer_pid() != Some(tracer_pid) {
         return Err(AxError::from(LinuxError::ESRCH));
+    }
+    if !tracee.is_ptrace_seized() {
+        return Err(AxError::from(LinuxError::EIO));
     }
     if tracee.ptrace_stop_signo_for(tracee_tid).is_some() {
         return Ok(0);

--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -83,7 +83,7 @@ pub const PTRACE_EVENT_CLONE: u32 = 3;
 const PTRACE_EVENT_EXEC: u32 = 4;
 pub const PTRACE_EVENT_VFORK_DONE: u32 = 5;
 const PTRACE_EVENT_EXIT: u32 = 6;
-const PTRACE_EVENT_STOP: u32 = 128;
+pub(crate) const PTRACE_EVENT_STOP: u32 = 128;
 
 const PTRACE_OPTION_MASK: usize = PTRACE_O_TRACESYSGOOD
     | PTRACE_O_TRACEFORK
@@ -372,7 +372,11 @@ fn ptrace_syscall(pid: usize, data: usize) -> AxResult<isize> {
     let signo = ptrace_resume_signo(data)?;
     let (tracee, tid) = ptrace_stopped_tracee_with_tid(pid)?;
     tracee.set_ptrace_singlestep_for(tid, false);
-    tracee.set_ptrace_syscall_trace_for(tid, true);
+    if tracee.ptrace_stop_is_syscall_for(tid) {
+        tracee.advance_ptrace_syscall_trace_for(tid);
+    } else {
+        tracee.set_ptrace_syscall_trace_for(tid, true);
+    }
     tracee.resume_ptrace_stop_with_signal_for(tid, signo);
     Ok(0)
 }
@@ -669,8 +673,14 @@ fn ptrace_interrupt(pid: usize) -> AxResult<isize> {
     tracee.set_ptrace_pending_event(tracee_tid, PTRACE_EVENT_STOP, 0);
     // PTRACE_INTERRUPT creates a ptrace event stop, not a user-visible
     // SIGTRAP. Interrupt the target so its user-return path consumes the
-    // pending event without leaving a second signal-delivery stop queued.
-    get_task(tracee_tid)?.interrupt();
+    // pending event without leaving a second signal-delivery stop queued. A
+    // tracee already parked in a job-control stop cannot return to userspace,
+    // so wake that wait loop to publish its event stop instead.
+    if tracee.is_job_stopped() {
+        tracee.wake_job_stop_waiter();
+    } else {
+        get_task(tracee_tid)?.interrupt();
+    }
     Ok(0)
 }
 
@@ -759,7 +769,23 @@ fn ptrace_read_stopped_user_regs(pid: usize) -> AxResult<ArchUserRegs> {
     let uctx = tracee
         .ptrace_stop_user_context_for(tid)
         .ok_or_else(|| AxError::from(LinuxError::ESRCH))?;
-    Ok(ArchUserRegs::from(&uctx))
+    let regs = ArchUserRegs::from(&uctx);
+    #[cfg(target_arch = "x86_64")]
+    let regs = {
+        let mut regs = regs;
+        if tracee.ptrace_stop_is_syscall_for(tid)
+            && matches!(
+                tracee.ptrace_syscall_trace_state_for(tid),
+                crate::task::SyscallTraceState::Entry
+            )
+        {
+            // Linux exposes the incoming syscall number through `orig_rax` while
+            // presenting `-ENOSYS` in `rax` at a syscall-entry stop.
+            regs.rax = -(LinuxError::ENOSYS.code() as i64) as u64;
+        }
+        regs
+    };
+    Ok(regs)
 }
 
 #[cfg(any(
@@ -792,6 +818,17 @@ fn ptrace_write_stopped_user_regs(pid: usize, regs: ArchUserRegs) -> AxResult<is
         .ptrace_stop_user_context_for(tid)
         .ok_or_else(|| AxError::from(LinuxError::ESRCH))?;
     regs.write_to(&mut uctx)?;
+    #[cfg(target_arch = "x86_64")]
+    if tracee.ptrace_stop_is_syscall_for(tid)
+        && matches!(
+            tracee.ptrace_syscall_trace_state_for(tid),
+            crate::task::SyscallTraceState::Entry
+        )
+    {
+        // `rax` is the synthetic syscall-entry return value. The tracer
+        // changes the syscall to execute through Linux's `orig_rax` field.
+        uctx.set_sysno(regs.orig_rax as usize);
+    }
     if !tracee.set_ptrace_stop_user_context_for(tid, uctx) {
         return Err(AxError::from(LinuxError::ESRCH));
     }

--- a/os/StarryOS/kernel/src/syscall/task/ptrace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ptrace.rs
@@ -773,15 +773,19 @@ fn ptrace_read_stopped_user_regs(pid: usize) -> AxResult<ArchUserRegs> {
     #[cfg(target_arch = "x86_64")]
     let regs = {
         let mut regs = regs;
-        if tracee.ptrace_stop_is_syscall_for(tid)
-            && matches!(
+        if tracee.ptrace_stop_is_syscall_for(tid) {
+            regs.orig_rax = tracee
+                .ptrace_stop_syscall_number_for(tid)
+                .ok_or_else(|| AxError::from(LinuxError::ESRCH))?
+                as u64;
+            if matches!(
                 tracee.ptrace_syscall_trace_state_for(tid),
                 crate::task::SyscallTraceState::Entry
-            )
-        {
-            // Linux exposes the incoming syscall number through `orig_rax` while
-            // presenting `-ENOSYS` in `rax` at a syscall-entry stop.
-            regs.rax = -(LinuxError::ENOSYS.code() as i64) as u64;
+            ) {
+                // Linux exposes the incoming syscall number through `orig_rax` while
+                // presenting `-ENOSYS` in `rax` at a syscall-entry stop.
+                regs.rax = -(LinuxError::ENOSYS.code() as i64) as u64;
+            }
         }
         regs
     };
@@ -819,15 +823,18 @@ fn ptrace_write_stopped_user_regs(pid: usize, regs: ArchUserRegs) -> AxResult<is
         .ok_or_else(|| AxError::from(LinuxError::ESRCH))?;
     regs.write_to(&mut uctx)?;
     #[cfg(target_arch = "x86_64")]
-    if tracee.ptrace_stop_is_syscall_for(tid)
-        && matches!(
+    if tracee.ptrace_stop_is_syscall_for(tid) {
+        if !tracee.set_ptrace_stop_syscall_number_for(tid, regs.orig_rax as usize) {
+            return Err(AxError::from(LinuxError::ESRCH));
+        }
+        if matches!(
             tracee.ptrace_syscall_trace_state_for(tid),
             crate::task::SyscallTraceState::Entry
-        )
-    {
-        // `rax` is the synthetic syscall-entry return value. The tracer
-        // changes the syscall to execute through Linux's `orig_rax` field.
-        uctx.set_sysno(regs.orig_rax as usize);
+        ) {
+            // `rax` is the synthetic syscall-entry return value. The tracer
+            // changes the syscall to execute through Linux's `orig_rax` field.
+            uctx.set_sysno(regs.orig_rax as usize);
+        }
     }
     if !tracee.set_ptrace_stop_user_context_for(tid, uctx) {
         return Err(AxError::from(LinuxError::ESRCH));

--- a/os/StarryOS/kernel/src/syscall/task/wait.rs
+++ b/os/StarryOS/kernel/src/syscall/task/wait.rs
@@ -14,6 +14,7 @@ use starry_process::{Pid, Process};
 use starry_signal::{SignalInfo, Signo};
 use starry_vm::{VmMutPtr, VmPtr};
 
+use super::ptrace::PTRACE_EVENT_STOP;
 use crate::{
     file::{PidFd, get_file_like},
     task::{
@@ -114,7 +115,7 @@ fn waitid_pidfd_target(fd: i32) -> AxResult<WaitTarget> {
 }
 fn stopped_wait_signo(data: &ProcessData, signo: Signo) -> i32 {
     let event = data.ptrace_event().unwrap_or(0);
-    let mut wait_signo = if event != 0 {
+    let mut wait_signo = if event != 0 && event != PTRACE_EVENT_STOP {
         Signo::SIGTRAP as i32
     } else {
         signo as i32

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -1179,6 +1179,14 @@ impl ProcessData {
         }
     }
 
+    /// Wake a job-stopped thread so it can publish a pending ptrace event.
+    ///
+    /// This does not alter the job-control state.  Only `SIGCONT` or `SIGKILL`
+    /// may release a job stop.
+    pub fn wake_job_stop_waiter(&self) {
+        unsafe { self.cont_event.wake(IoEvents::IN) };
+    }
+
     /// The wait queue woken when the process is continued or killed.
     pub fn cont_event(&self) -> Arc<PollSet> {
         self.cont_event.clone()
@@ -1326,6 +1334,14 @@ impl ProcessData {
             .lock()
             .get(&tid)
             .and_then(|stop| stop.signo)
+    }
+
+    /// Return whether the selected stop was produced at a syscall boundary.
+    pub fn ptrace_stop_is_syscall_for(&self, tid: u32) -> bool {
+        self.ptrace_stop
+            .lock()
+            .get(&tid)
+            .is_some_and(|stop| stop.is_syscall)
     }
 
     pub fn ptrace_unreported_stop(&self, preferred_tid: Option<u32>) -> Option<(u32, Signo)> {
@@ -1625,6 +1641,30 @@ impl ProcessData {
         } else {
             traces.insert(tid, state);
         }
+    }
+
+    /// Return the next syscall boundary that a `PTRACE_SYSCALL` tracee stops at.
+    pub fn ptrace_syscall_trace_state_for(&self, tid: u32) -> SyscallTraceState {
+        self.ptrace_syscall_trace
+            .lock()
+            .get(&tid)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// Continue syscall tracing from the opposite boundary.
+    ///
+    /// This is used only when `PTRACE_SYSCALL` resumes a syscall stop. Resuming
+    /// an event, group, or signal-delivery stop begins with the next entry.
+    pub fn advance_ptrace_syscall_trace_for(&self, tid: u32) {
+        let mut traces = self.ptrace_syscall_trace.lock();
+        let next = match traces.get(&tid).copied() {
+            Some(SyscallTraceState::Entry) => SyscallTraceState::Exit,
+            Some(SyscallTraceState::Exit) | Some(SyscallTraceState::None) | None => {
+                SyscallTraceState::Entry
+            }
+        };
+        traces.insert(tid, next);
     }
 
     pub fn take_ptrace_syscall_trace_for(&self, tid: u32) -> SyscallTraceState {

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -67,6 +67,7 @@ struct PtraceStopRecord {
     uctx: UserContext,
     siginfo: Option<SignalInfo>,
     is_syscall: bool,
+    syscall_no: Option<usize>,
     reported: bool,
     event: u32,
     event_msg: usize,
@@ -1276,6 +1277,7 @@ impl ProcessData {
                 uctx: *uctx,
                 siginfo: Some(SignalInfo::new_kernel(signo)),
                 is_syscall: false,
+                syscall_no: None,
                 reported: false,
                 event: pending_event.as_ref().map_or(0, |event| event.event),
                 event_msg: pending_event.as_ref().map_or(0, |event| event.msg),
@@ -1285,10 +1287,17 @@ impl ProcessData {
     }
 
     /// Record that this tracee is stopped at a syscall entry or exit boundary.
-    pub fn set_ptrace_syscall_stop(&self, tid: u32, signo: Signo, uctx: &UserContext) {
+    pub fn set_ptrace_syscall_stop(
+        &self,
+        tid: u32,
+        signo: Signo,
+        uctx: &UserContext,
+        syscall_no: usize,
+    ) {
         self.set_ptrace_stop(tid, signo, uctx);
         if let Some(stop) = self.ptrace_stop.lock().get_mut(&tid) {
             stop.is_syscall = true;
+            stop.syscall_no = Some(syscall_no);
         }
     }
 
@@ -1342,6 +1351,11 @@ impl ProcessData {
             .lock()
             .get(&tid)
             .is_some_and(|stop| stop.is_syscall)
+    }
+
+    /// Return the original syscall number associated with a syscall stop.
+    pub fn ptrace_stop_syscall_number_for(&self, tid: u32) -> Option<usize> {
+        self.ptrace_stop.lock().get(&tid)?.syscall_no
     }
 
     pub fn ptrace_unreported_stop(&self, preferred_tid: Option<u32>) -> Option<(u32, Signo)> {
@@ -1488,6 +1502,19 @@ impl ProcessData {
             return false;
         };
         stop.uctx = uctx;
+        true
+    }
+
+    /// Replace the original syscall number held for a stopped tracee.
+    pub fn set_ptrace_stop_syscall_number_for(&self, tid: u32, syscall_no: usize) -> bool {
+        let mut stops = self.ptrace_stop.lock();
+        let Some(stop) = stops.get_mut(&tid) else {
+            return false;
+        };
+        if !stop.is_syscall {
+            return false;
+        }
+        stop.syscall_no = Some(syscall_no);
         true
     }
 

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -62,6 +62,15 @@ pub enum SyscallTraceState {
     Exit,
 }
 
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum PtraceAttachMode {
+    #[default]
+    None,
+    Attach,
+    Seize,
+}
+
 struct PtraceStopRecord {
     signo: Option<Signo>,
     uctx: UserContext,
@@ -830,8 +839,8 @@ pub struct ProcessData {
     /// Cleared after the exec-stop is delivered in the user-return loop.
     ptrace_exec_stop_pending: AtomicBool,
 
-    /// Set by `PTRACE_ATTACH` / `PTRACE_SEIZE`.
-    ptrace_attached: AtomicBool,
+    /// Attachment mode established by `PTRACE_ATTACH` or `PTRACE_SEIZE`.
+    ptrace_attach_mode: AtomicU8,
 
     /// TID selected by `PTRACE_SINGLESTEP`; causes a temporary EBREAK insertion.
     ptrace_singlestep_tid: AtomicU32,
@@ -983,7 +992,7 @@ impl ProcessData {
                 ptrace_resume_signo: SpinNoIrq::new(BTreeMap::new()),
                 ptrace_resume_signal_bypass: SpinNoIrq::new(BTreeMap::new()),
                 ptrace_exec_stop_pending: AtomicBool::new(false),
-                ptrace_attached: AtomicBool::new(false),
+                ptrace_attach_mode: AtomicU8::new(PtraceAttachMode::None as u8),
                 ptrace_singlestep_tid: AtomicU32::new(0),
                 ptrace_syscall_trace: SpinNoIrq::new(BTreeMap::new()),
                 ptrace_options: AtomicUsize::new(0),
@@ -1611,16 +1620,28 @@ impl ProcessData {
         unsafe { self.ptrace_stop_event.register(waker, IoEvents::IN) };
     }
 
-    pub fn set_ptrace_attached(&self) {
-        self.ptrace_attached.store(true, Ordering::Release);
+    pub(crate) fn set_ptrace_attach_mode(&self, mode: PtraceAttachMode) {
+        self.ptrace_attach_mode.store(mode as u8, Ordering::Release);
     }
 
     pub fn clear_ptrace_attached(&self) {
-        self.ptrace_attached.store(false, Ordering::Release);
+        self.set_ptrace_attach_mode(PtraceAttachMode::None);
+    }
+
+    pub(crate) fn ptrace_attach_mode(&self) -> PtraceAttachMode {
+        match self.ptrace_attach_mode.load(Ordering::Acquire) {
+            value if value == PtraceAttachMode::Attach as u8 => PtraceAttachMode::Attach,
+            value if value == PtraceAttachMode::Seize as u8 => PtraceAttachMode::Seize,
+            _ => PtraceAttachMode::None,
+        }
     }
 
     pub fn is_ptrace_attached(&self) -> bool {
-        self.ptrace_attached.load(Ordering::Acquire)
+        self.ptrace_attach_mode() != PtraceAttachMode::None
+    }
+
+    pub fn is_ptrace_seized(&self) -> bool {
+        self.ptrace_attach_mode() == PtraceAttachMode::Seize
     }
 
     pub fn set_ptrace_singlestep(&self, val: bool) {

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -686,6 +686,10 @@ struct JobControl {
     /// (e.g. busybox `killall5 -STOP` then `-CONT`) without having to scrub the
     /// pending-signal queue.
     continue_generation: u64,
+    /// TID of the thread currently parked in `do_job_stop`. The implementation
+    /// currently parks only the thread that dequeues the stop signal, so ptrace
+    /// must distinguish that waiter from running or syscall-blocked siblings.
+    waiter_tid: Option<Pid>,
 }
 
 /// [`Process`]-shared data.
@@ -1139,7 +1143,12 @@ impl ProcessData {
     /// [`Self::set_job_continued`] / `continue_generation`. Closing this race at
     /// the stop site lets us avoid scrubbing the pending-signal queue (which
     /// would require modifying `starry-signal`).
-    pub fn set_job_stopped(&self, signo: Signo, continue_gen_snapshot: u64) -> bool {
+    pub fn set_job_stopped(
+        &self,
+        signo: Signo,
+        continue_gen_snapshot: u64,
+        waiter_tid: Pid,
+    ) -> bool {
         let mut jc = self.job_control.lock();
         if jc.continue_generation != continue_gen_snapshot {
             // A continue raced in after we observed `continue_gen_snapshot`;
@@ -1148,7 +1157,14 @@ impl ProcessData {
         }
         jc.stopped = Some(signo);
         jc.status = Some(JobStatus::Stopped(signo));
+        jc.waiter_tid = Some(waiter_tid);
         true
+    }
+
+    /// Returns true when `tid` is the thread parked for the active job stop.
+    pub fn is_job_stop_waiter(&self, tid: Pid) -> bool {
+        let jc = self.job_control.lock();
+        jc.stopped.is_some() && jc.waiter_tid == Some(tid)
     }
 
     /// Snapshot the continue generation. Taken right after a stop signal is
@@ -1168,6 +1184,7 @@ impl ProcessData {
         let mut jc = self.job_control.lock();
         jc.continue_generation = jc.continue_generation.wrapping_add(1);
         let was_stopped = jc.stopped.take().is_some();
+        jc.waiter_tid = None;
         if was_stopped {
             jc.status = Some(JobStatus::Continued);
             drop(jc);
@@ -1182,7 +1199,10 @@ impl ProcessData {
     /// Force-clear the stop (for `SIGKILL`) so a parked thread re-checks and
     /// proceeds to terminate. Does not queue a `Continued` report.
     pub fn clear_job_stop_for_kill(&self) {
-        let was_stopped = self.job_control.lock().stopped.take().is_some();
+        let mut jc = self.job_control.lock();
+        let was_stopped = jc.stopped.take().is_some();
+        jc.waiter_tid = None;
+        drop(jc);
         if was_stopped {
             // Stop state is cleared before waking stopped threads.
             unsafe { self.cont_event.wake(IoEvents::IN) };

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -396,7 +396,7 @@ pub fn check_signals(
             }
             do_exit(128 + signo as i32, true);
         }
-        SignalOSAction::Stop => do_job_stop(thr, signo),
+        SignalOSAction::Stop => do_job_stop(thr, signo, uctx),
         SignalOSAction::Continue => {}
         SignalOSAction::NoFurtherAction => {}
     }
@@ -427,7 +427,8 @@ fn notify_parent_job_change(proc_data: &ProcessData, code: i32, status: i32) {
 
 /// Enter a job-control stop: record the stop, notify the parent, then park the
 /// current thread until `SIGCONT` clears the stop (or `SIGKILL` force-resumes it
-/// so the kill can proceed).
+/// so the kill can proceed). A seized tracer may wake this loop solely to
+/// publish `PTRACE_EVENT_STOP`; that wake does not release the job stop.
 ///
 /// Uses a plain block — not [`interruptible`](ax_task::future::interruptible) —
 /// because an ordinary signal must **not** wake a stopped process; only
@@ -445,7 +446,7 @@ fn notify_parent_job_change(proc_data: &ProcessData, code: i32, status: i32) {
 /// - Only the thread that dequeues the stop signal parks; sibling threads of a
 ///   multi-threaded process keep running until they next hit a stop signal.
 ///   Linux stops every thread in the group.
-fn do_job_stop(thr: &Thread, signo: Signo) {
+fn do_job_stop(thr: &Thread, signo: Signo, uctx: &mut UserContext) {
     let proc_data = &thr.proc_data;
     // Snapshot before recording the stop so a racing SIGCONT (which advances the
     // generation) cancels this stop.
@@ -455,21 +456,52 @@ fn do_job_stop(thr: &Thread, signo: Signo) {
     }
     notify_parent_job_change(proc_data, CLD_STOPPED as i32, signo as i32);
 
+    let tid = thr.tid();
     let cont_event = proc_data.cont_event();
-    block_on(poll_fn(|cx| {
-        if !proc_data.is_job_stopped() {
-            return Poll::Ready(());
+    while proc_data.is_job_stopped() {
+        if proc_data.has_ptrace_pending_event_for(tid) {
+            let resume_signo = ptrace_stop_current(thr, signo, uctx).flatten();
+            match resume_signo {
+                // Linux re-reports a seized group stop after a tracer supplies
+                // SIGCONT to resume its PTRACE_EVENT_STOP. The signal is not a
+                // signal-delivery stop, so it must not release the job stop yet.
+                Some(Signo::SIGCONT) => {
+                    proc_data.set_ptrace_pending_event(
+                        tid,
+                        crate::syscall::ptrace::PTRACE_EVENT_STOP,
+                        0,
+                    );
+                }
+                // A subsequent zero-signal ptrace resume leaves the group stop
+                // and resumes user execution. There is no user-visible SIGCONT
+                // delivery to enqueue on this path.
+                None if proc_data.set_job_continued() => {
+                    notify_parent_job_change(
+                        proc_data,
+                        CLD_CONTINUED as i32,
+                        Signo::SIGCONT as i32,
+                    );
+                }
+                _ => {}
+            }
+            continue;
         }
-        // Registration happens from the stopped task context.
-        unsafe { cont_event.register(cx.waker(), axpoll::IoEvents::IN) };
-        // Re-check after registering to avoid a lost wakeup if the continue
-        // landed between the check above and registration.
-        if proc_data.is_job_stopped() {
-            Poll::Pending
-        } else {
-            Poll::Ready(())
-        }
-    }));
+
+        block_on(poll_fn(|cx| {
+            if !proc_data.is_job_stopped() || proc_data.has_ptrace_pending_event_for(tid) {
+                return Poll::Ready(());
+            }
+            // Registration happens from the stopped task context.
+            unsafe { cont_event.register(cx.waker(), axpoll::IoEvents::IN) };
+            // Re-check after registering to avoid a lost wakeup if the continue
+            // or ptrace interrupt landed between the checks and registration.
+            if proc_data.is_job_stopped() && !proc_data.has_ptrace_pending_event_for(tid) {
+                Poll::Pending
+            } else {
+                Poll::Ready(())
+            }
+        }));
+    }
 }
 
 pub fn block_next_signal() {

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -453,12 +453,12 @@ fn do_job_stop(thr: &Thread, signo: Signo, uctx: &mut UserContext) {
     // Snapshot before recording the stop so a racing SIGCONT (which advances the
     // generation) cancels this stop.
     let continue_gen = proc_data.continue_generation();
-    if !proc_data.set_job_stopped(signo, continue_gen) {
+    let tid = thr.tid();
+    if !proc_data.set_job_stopped(signo, continue_gen, tid) {
         return;
     }
     notify_parent_job_change(proc_data, CLD_STOPPED as i32, signo as i32);
 
-    let tid = thr.tid();
     let cont_event = proc_data.cont_event();
     while proc_data.is_job_stopped() {
         if proc_data.has_ptrace_pending_event_for(tid) {

--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -186,15 +186,16 @@ pub fn ptrace_stop_current(
     signo: Signo,
     uctx: &mut UserContext,
 ) -> Option<Option<Signo>> {
-    ptrace_stop_current_impl(thr, signo, uctx, false)
+    ptrace_stop_current_impl(thr, signo, uctx, None)
 }
 
 pub fn ptrace_syscall_stop_current(
     thr: &Thread,
     signo: Signo,
     uctx: &mut UserContext,
+    syscall_no: usize,
 ) -> Option<Option<Signo>> {
-    ptrace_stop_current_impl(thr, signo, uctx, true)
+    ptrace_stop_current_impl(thr, signo, uctx, Some(syscall_no))
 }
 
 pub fn wait_existing_ptrace_stop_current(thr: &Thread, uctx: &mut UserContext) {
@@ -233,7 +234,7 @@ fn ptrace_stop_current_impl(
     thr: &Thread,
     signo: Signo,
     uctx: &mut UserContext,
-    is_syscall_stop: bool,
+    syscall_no: Option<usize>,
 ) -> Option<Option<Signo>> {
     if !thr.proc_data.is_ptrace_traceme() && !thr.proc_data.is_ptrace_attached() {
         return None;
@@ -264,8 +265,9 @@ fn ptrace_stop_current_impl(
     {
         thr.proc_data.save_current_fp_for_ptrace(tid);
     }
-    if is_syscall_stop {
-        thr.proc_data.set_ptrace_syscall_stop(tid, signo, uctx);
+    if let Some(syscall_no) = syscall_no {
+        thr.proc_data
+            .set_ptrace_syscall_stop(tid, signo, uctx, syscall_no);
     } else {
         thr.proc_data.set_ptrace_stop(tid, signo, uctx);
     }

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -131,21 +131,12 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
 
                 match reason {
                     ReturnReason::Syscall => {
-                        let trace_state = thr.proc_data.take_ptrace_syscall_trace_for(tid);
+                        let trace_state = thr.proc_data.ptrace_syscall_trace_state_for(tid);
                         if matches!(trace_state, SyscallTraceState::Entry)
                             && let Some(resume_signo) =
                                 ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx)
                         {
                             enqueue_ptrace_syscall_resume_signal(thr, resume_signo);
-                            match thr.proc_data.take_ptrace_syscall_trace_for(tid) {
-                                SyscallTraceState::Entry | SyscallTraceState::Exit => {
-                                    thr.proc_data.set_ptrace_syscall_trace_state_for(
-                                        tid,
-                                        SyscallTraceState::Exit,
-                                    )
-                                }
-                                SyscallTraceState::None => {}
-                            }
                         }
 
                         if let Some(exit_code) = ptrace_exit_event_code(saved_sysno, saved_a0)
@@ -161,14 +152,6 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                         if stop_for_pending_ptrace_event(thr, &mut uctx) {
                             continue;
                         }
-                        if matches!(
-                            thr.proc_data.take_ptrace_syscall_trace_for(tid),
-                            SyscallTraceState::Exit
-                        ) {
-                            let resume_signo =
-                                ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx);
-                            enqueue_ptrace_syscall_resume_signal(thr, resume_signo.flatten());
-                        }
                         if thr.proc_data.take_ptrace_exec_stop_pending() {
                             let _is_event =
                                 crate::syscall::ptrace_notify_exec(thr.proc_data.proc.pid());
@@ -177,6 +160,14 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                             {
                                 continue;
                             }
+                        }
+                        if matches!(
+                            thr.proc_data.ptrace_syscall_trace_state_for(tid),
+                            SyscallTraceState::Exit
+                        ) {
+                            let resume_signo =
+                                ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx);
+                            enqueue_ptrace_syscall_resume_signal(thr, resume_signo.flatten());
                         }
                     }
                     ReturnReason::PageFault(addr, flags) => {

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -133,13 +133,19 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                     ReturnReason::Syscall => {
                         let trace_state = thr.proc_data.ptrace_syscall_trace_state_for(tid);
                         if matches!(trace_state, SyscallTraceState::Entry)
-                            && let Some(resume_signo) =
-                                ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx)
+                            && let Some(resume_signo) = ptrace_syscall_stop_current(
+                                thr,
+                                Signo::SIGTRAP,
+                                &mut uctx,
+                                saved_sysno,
+                            )
                         {
                             enqueue_ptrace_syscall_resume_signal(thr, resume_signo);
                         }
 
-                        if let Some(exit_code) = ptrace_exit_event_code(saved_sysno, saved_a0)
+                        let syscall_no = uctx.sysno();
+                        let syscall_arg0 = uctx.arg0();
+                        if let Some(exit_code) = ptrace_exit_event_code(syscall_no, syscall_arg0)
                             && crate::syscall::ptrace_notify_exit(
                                 thr.proc_data.proc.pid(),
                                 exit_code,
@@ -165,8 +171,12 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                             thr.proc_data.ptrace_syscall_trace_state_for(tid),
                             SyscallTraceState::Exit
                         ) {
-                            let resume_signo =
-                                ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx);
+                            let resume_signo = ptrace_syscall_stop_current(
+                                thr,
+                                Signo::SIGTRAP,
+                                &mut uctx,
+                                syscall_no,
+                            );
                             enqueue_ptrace_syscall_resume_signal(thr, resume_signo.flatten());
                         }
                     }

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -125,13 +125,18 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                 let saved_sysno = uctx.sysno();
                 let is_syscall = matches!(reason, ReturnReason::Syscall);
 
+                if stop_for_pending_ptrace_event(thr, &mut uctx) {
+                    continue;
+                }
+
                 match reason {
                     ReturnReason::Syscall => {
-                        let tid = thr.tid();
                         let trace_state = thr.proc_data.take_ptrace_syscall_trace_for(tid);
                         if matches!(trace_state, SyscallTraceState::Entry)
-                            && ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx).is_some()
+                            && let Some(resume_signo) =
+                                ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx)
                         {
+                            enqueue_ptrace_syscall_resume_signal(thr, resume_signo);
                             match thr.proc_data.take_ptrace_syscall_trace_for(tid) {
                                 SyscallTraceState::Entry | SyscallTraceState::Exit => {
                                     thr.proc_data.set_ptrace_syscall_trace_state_for(
@@ -153,17 +158,16 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                         }
 
                         handle_syscall(&mut uctx);
-                        if thr.proc_data.has_ptrace_pending_event_for(tid)
-                            && let Some(_resume_sig) =
-                                ptrace_stop_current(thr, Signo::SIGTRAP, &mut uctx)
-                        {
+                        if stop_for_pending_ptrace_event(thr, &mut uctx) {
                             continue;
                         }
                         if matches!(
                             thr.proc_data.take_ptrace_syscall_trace_for(tid),
                             SyscallTraceState::Exit
                         ) {
-                            let _ = ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx);
+                            let resume_signo =
+                                ptrace_syscall_stop_current(thr, Signo::SIGTRAP, &mut uctx);
+                            enqueue_ptrace_syscall_resume_signal(thr, resume_signo.flatten());
                         }
                         if thr.proc_data.take_ptrace_exec_stop_pending() {
                             let _is_event =
@@ -383,4 +387,20 @@ fn ptrace_exit_event_code(sysno: usize, arg0: usize) -> Option<i32> {
         Some(Sysno::exit | Sysno::exit_group) => Some((arg0 as i32) << 8),
         _ => None,
     }
+}
+
+fn stop_for_pending_ptrace_event(thr: &super::Thread, uctx: &mut UserContext) -> bool {
+    thr.proc_data.has_ptrace_pending_event_for(thr.tid())
+        && ptrace_stop_current(thr, Signo::SIGTRAP, uctx).is_some()
+}
+
+fn enqueue_ptrace_syscall_resume_signal(thr: &super::Thread, resume_signo: Option<Signo>) {
+    let Some(signo) = resume_signo else {
+        return;
+    };
+
+    // A PTRACE_SYSCALL resume signal is delivered after the matching syscall
+    // exit stop. Do not arm the ptrace bypass: the tracer must observe its
+    // subsequent signal-delivery stop.
+    let _ = thr.signal.send_signal(SignalInfo::new_kernel(signo));
 }

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-ptrace-seize-syscall-stop C)
+include(${CMAKE_CURRENT_LIST_DIR}/../common/starry_arch_filter.cmake)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+starry_arch_filtered_executable(
+    test-ptrace-seize-syscall-stop
+    "x86_64"
+    "test-ptrace-seize-syscall-stop skipped on unsupported architecture"
+    src/main.c
+)
+target_compile_options(test-ptrace-seize-syscall-stop PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-ptrace-seize-syscall-stop RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/CMakeLists.txt
@@ -13,4 +13,5 @@ starry_arch_filtered_executable(
     src/main.c
 )
 target_compile_options(test-ptrace-seize-syscall-stop PRIVATE -Wall -Wextra -Werror)
+target_link_libraries(test-ptrace-seize-syscall-stop PRIVATE pthread)
 install(TARGETS test-ptrace-seize-syscall-stop RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/src/main.c
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/src/main.c
@@ -1,0 +1,174 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ptrace.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef PTRACE_SEIZE
+#define PTRACE_SEIZE 0x4206
+#endif
+#ifndef PTRACE_INTERRUPT
+#define PTRACE_INTERRUPT 0x4207
+#endif
+#ifndef PTRACE_EVENT_STOP
+#define PTRACE_EVENT_STOP 128
+#endif
+#ifndef PTRACE_O_TRACESYSGOOD
+#define PTRACE_O_TRACESYSGOOD 0x00000001
+#endif
+#ifndef __WALL
+#define __WALL 0x40000000
+#endif
+
+enum {
+    WAIT_TIMEOUT_MS = 3000,
+    WAIT_POLL_INTERVAL_MS = 10,
+};
+
+static int fail(const char *message)
+{
+    printf("FAIL: %s: errno=%d (%s)\n", message, errno, strerror(errno));
+    return 1;
+}
+
+static pid_t wait_for_tracee_event(pid_t pid, int *status)
+{
+    struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = WAIT_POLL_INTERVAL_MS * 1000 * 1000,
+    };
+
+    for (int waited_ms = 0; waited_ms < WAIT_TIMEOUT_MS; waited_ms += WAIT_POLL_INTERVAL_MS) {
+        pid_t waited = waitpid(pid, status, __WALL | WNOHANG);
+        if (waited != 0) {
+            return waited;
+        }
+        (void)nanosleep(&delay, NULL);
+    }
+
+    errno = ETIMEDOUT;
+    return 0;
+}
+
+static int expect_ptrace_stop(pid_t pid, int expected_signal, int expected_event,
+                              const char *description)
+{
+    int status = 0;
+    pid_t waited = wait_for_tracee_event(pid, &status);
+    if (waited != pid) {
+        return fail(description);
+    }
+    if (!WIFSTOPPED(status) || WSTOPSIG(status) != expected_signal
+        || ((unsigned int)status >> 16) != (unsigned int)expected_event) {
+        printf("FAIL: %s: status=%#x signal=%d event=%u\n", description, status,
+               WIFSTOPPED(status) ? WSTOPSIG(status) : -1, (unsigned int)status >> 16);
+        return 1;
+    }
+    return 0;
+}
+
+static int expect_getsiginfo_signal(pid_t pid, int expected_signal, const char *description)
+{
+    siginfo_t siginfo;
+    memset(&siginfo, 0, sizeof(siginfo));
+    errno = 0;
+    long result = ptrace(PTRACE_GETSIGINFO, pid, NULL, &siginfo);
+    if (result != 0 || siginfo.si_signo != expected_signal) {
+        printf("FAIL: %s: result=%ld signo=%d errno=%d (%s)\n", description,
+               result, siginfo.si_signo, errno, strerror(errno));
+        return 1;
+    }
+    return 0;
+}
+
+static void kill_tracee(pid_t pid)
+{
+    int status = 0;
+    (void)kill(pid, SIGKILL);
+    (void)wait_for_tracee_event(pid, &status);
+}
+
+int main(void)
+{
+    printf("PTRACE_SEIZE syscall-stop regression\n");
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        return fail("fork tracee");
+    }
+    if (pid == 0) {
+        for (;;) {
+            (void)syscall(SYS_getpid);
+        }
+    }
+
+    if (ptrace(PTRACE_SEIZE, pid, NULL, (void *)(uintptr_t)PTRACE_O_TRACESYSGOOD) != 0) {
+        kill_tracee(pid);
+        return fail("PTRACE_SEIZE with PTRACE_O_TRACESYSGOOD");
+    }
+    if (ptrace(PTRACE_INTERRUPT, pid, NULL, NULL) != 0) {
+        kill_tracee(pid);
+        return fail("PTRACE_INTERRUPT");
+    }
+    if (expect_ptrace_stop(pid, SIGTRAP, PTRACE_EVENT_STOP,
+                            "PTRACE_INTERRUPT reports PTRACE_EVENT_STOP")
+        != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    if (expect_getsiginfo_signal(pid, SIGTRAP,
+                                 "PTRACE_EVENT_STOP PTRACE_GETSIGINFO returns SIGTRAP")
+        != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+
+    if (ptrace(PTRACE_SYSCALL, pid, NULL, (void *)(uintptr_t)SIGCONT) != 0) {
+        kill_tracee(pid);
+        return fail("PTRACE_SYSCALL resumes PTRACE_EVENT_STOP with SIGCONT");
+    }
+    if (expect_ptrace_stop(pid, SIGTRAP | 0x80, 0,
+                            "PTRACE_SYSCALL reports a TRACESYSGOOD syscall stop")
+        != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    if (expect_getsiginfo_signal(pid, SIGTRAP,
+                                 "syscall stop PTRACE_GETSIGINFO returns SIGTRAP")
+        != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+
+    if (ptrace(PTRACE_SYSCALL, pid, NULL, (void *)(uintptr_t)SIGSTOP) != 0) {
+        kill_tracee(pid);
+        return fail("PTRACE_SYSCALL resumes syscall stop with SIGSTOP");
+    }
+    if (expect_ptrace_stop(pid, SIGTRAP | 0x80, 0,
+                            "PTRACE_SYSCALL preserves the syscall-exit stop before SIGSTOP")
+        != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    if (ptrace(PTRACE_SYSCALL, pid, NULL, NULL) != 0) {
+        kill_tracee(pid);
+        return fail("PTRACE_SYSCALL resumes syscall-exit stop");
+    }
+    if (expect_ptrace_stop(pid, SIGSTOP, 0,
+                            "PTRACE_SYSCALL signal injection reports SIGSTOP delivery stop")
+        != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+
+    printf("PASS: PTRACE_SEIZE interrupt and syscall signal-stop sequence\n");
+    kill_tracee(pid);
+    return 0;
+}

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/src/main.c
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/src/main.c
@@ -1,7 +1,10 @@
 #define _GNU_SOURCE
 
 #include <errno.h>
+#include <poll.h>
+#include <pthread.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
@@ -106,6 +109,22 @@ static int expect_ptrace_stop(pid_t pid, int expected_signal, int expected_event
         return fail(description);
     }
     if (!WIFSTOPPED(status) || WSTOPSIG(status) != expected_signal
+        || ((unsigned int)status >> 16) != (unsigned int)expected_event) {
+        printf("FAIL: %s: status=%#x signal=%d event=%u\n", description, status,
+               WIFSTOPPED(status) ? WSTOPSIG(status) : -1, (unsigned int)status >> 16);
+        return 1;
+    }
+    return 0;
+}
+
+static int expect_ptrace_event(pid_t pid, int expected_event, const char *description)
+{
+    int status = 0;
+    pid_t waited = wait_for_tracee_event(pid, &status);
+    if (waited != pid) {
+        return fail(description);
+    }
+    if (!WIFSTOPPED(status)
         || ((unsigned int)status >> 16) != (unsigned int)expected_event) {
         printf("FAIL: %s: status=%#x signal=%d event=%u\n", description, status,
                WIFSTOPPED(status) ? WSTOPSIG(status) : -1, (unsigned int)status >> 16);
@@ -227,6 +246,155 @@ static pid_t fork_spinning_tracee(void)
     return pid;
 }
 
+static int wait_for_job_stop(pid_t pid)
+{
+    struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = WAIT_POLL_INTERVAL_MS * 1000 * 1000,
+    };
+
+    for (int waited_ms = 0; waited_ms < WAIT_TIMEOUT_MS; waited_ms += WAIT_POLL_INTERVAL_MS) {
+        int status = 0;
+        pid_t waited = waitpid(pid, &status, WUNTRACED | WNOHANG);
+        if (waited == pid) {
+            if (WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP) {
+                return 0;
+            }
+            printf("FAIL: tracee job stop: status=%#x\n", status);
+            return 1;
+        }
+        if (waited < 0) {
+            return fail("waitpid for tracee job stop");
+        }
+        (void)nanosleep(&delay, NULL);
+    }
+
+    errno = ETIMEDOUT;
+    return fail("tracee enters a job stop");
+}
+
+static int wait_for_task_sleeping(_Atomic pid_t *tid_slot)
+{
+    struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = WAIT_POLL_INTERVAL_MS * 1000 * 1000,
+    };
+
+    for (int waited_ms = 0; waited_ms < WAIT_TIMEOUT_MS; waited_ms += WAIT_POLL_INTERVAL_MS) {
+        pid_t tid = atomic_load_explicit(tid_slot, memory_order_acquire);
+        if (tid > 0) {
+            char path[128];
+            snprintf(path, sizeof(path), "/proc/self/task/%ld/status", (long)tid);
+            FILE *file = fopen(path, "r");
+            if (file != NULL) {
+                char line[128];
+                while (fgets(line, sizeof(line), file) != NULL) {
+                    if (strncmp(line, "State:\tS ", strlen("State:\tS ")) == 0) {
+                        fclose(file);
+                        return 0;
+                    }
+                }
+                fclose(file);
+            }
+        }
+        (void)nanosleep(&delay, NULL);
+    }
+
+    return -1;
+}
+
+struct sibling_thread_args {
+    int tid_fd;
+    int block_fd;
+    _Atomic pid_t *tid_slot;
+};
+
+static void *block_sibling_thread(void *opaque)
+{
+    struct sibling_thread_args *args = opaque;
+    pid_t tid = (pid_t)syscall(SYS_gettid);
+    if (write(args->tid_fd, &tid, sizeof(tid)) != (ssize_t)sizeof(tid)) {
+        _exit(2);
+    }
+    atomic_store_explicit(args->tid_slot, tid, memory_order_release);
+
+    char byte;
+    if (read(args->block_fd, &byte, sizeof(byte)) >= 0) {
+        _exit(2);
+    }
+    _exit(2);
+}
+
+static pid_t fork_job_stopped_multithreaded_tracee(pid_t *sibling_tid, int *block_write_fd)
+{
+    int tid_pipe[2];
+    int block_pipe[2];
+    if (pipe(tid_pipe) != 0) {
+        return -1;
+    }
+    if (pipe(block_pipe) != 0) {
+        close(tid_pipe[0]);
+        close(tid_pipe[1]);
+        return -1;
+    }
+
+    pid_t pid = fork();
+    if (pid == 0) {
+        close(tid_pipe[0]);
+        close(block_pipe[1]);
+        _Atomic pid_t sibling_tid_slot = 0;
+        struct sibling_thread_args args = {
+            .tid_fd = tid_pipe[1],
+            .block_fd = block_pipe[0],
+            .tid_slot = &sibling_tid_slot,
+        };
+        pthread_t sibling;
+        if (pthread_create(&sibling, NULL, block_sibling_thread, &args) != 0) {
+            _exit(2);
+        }
+        if (wait_for_task_sleeping(&sibling_tid_slot) != 0) {
+            _exit(2);
+        }
+        if (raise(SIGSTOP) != 0) {
+            _exit(2);
+        }
+        for (;;) {
+            (void)syscall(SYS_getpid);
+        }
+    }
+
+    close(tid_pipe[1]);
+    close(block_pipe[0]);
+    if (pid < 0) {
+        close(tid_pipe[0]);
+        close(block_pipe[1]);
+        return -1;
+    }
+    struct pollfd tid_poll = {
+        .fd = tid_pipe[0],
+        .events = POLLIN,
+    };
+    int poll_result = poll(&tid_poll, 1, WAIT_TIMEOUT_MS);
+    if (poll_result <= 0) {
+        int saved_errno = poll_result == 0 ? ETIMEDOUT : errno;
+        close(tid_pipe[0]);
+        close(block_pipe[1]);
+        kill_tracee(pid);
+        errno = saved_errno;
+        return -1;
+    }
+    ssize_t bytes = read(tid_pipe[0], sibling_tid, sizeof(*sibling_tid));
+    close(tid_pipe[0]);
+    if (bytes != (ssize_t)sizeof(*sibling_tid)) {
+        close(block_pipe[1]);
+        kill_tracee(pid);
+        errno = EIO;
+        return -1;
+    }
+    *block_write_fd = block_pipe[1];
+    return pid;
+}
+
 static int test_seize_rejects_nonzero_addr(void)
 {
     pid_t pid = fork_spinning_tracee();
@@ -264,12 +432,45 @@ static int test_interrupt_rejects_attach_tracee(void)
     return result;
 }
 
+static int test_interrupt_job_stopped_sibling(void)
+{
+    pid_t sibling_tid = -1;
+    int block_write_fd = -1;
+    pid_t pid = fork_job_stopped_multithreaded_tracee(&sibling_tid, &block_write_fd);
+    if (pid < 0) {
+        return fail("fork multithreaded tracee for sibling PTRACE_INTERRUPT");
+    }
+    if (wait_for_job_stop(pid) != 0) {
+        close(block_write_fd);
+        kill_tracee(pid);
+        return 1;
+    }
+
+    if (ptrace(PTRACE_SEIZE, sibling_tid, NULL, NULL) != 0) {
+        close(block_write_fd);
+        kill_tracee(pid);
+        return fail("PTRACE_SEIZE job-stopped sibling");
+    }
+    if (ptrace(PTRACE_INTERRUPT, sibling_tid, NULL, NULL) != 0) {
+        close(block_write_fd);
+        kill_tracee(pid);
+        return fail("PTRACE_INTERRUPT job-stopped sibling");
+    }
+    int result = expect_ptrace_event(
+        sibling_tid, PTRACE_EVENT_STOP,
+        "PTRACE_INTERRUPT reports EVENT_STOP for a running sibling of a job-stop waiter");
+    close(block_write_fd);
+    kill_tracee(pid);
+    return result;
+}
+
 int main(void)
 {
     printf("PTRACE_SEIZE syscall-stop regression\n");
 
     if (test_seize_rejects_nonzero_addr() != 0
-        || test_interrupt_rejects_attach_tracee() != 0) {
+        || test_interrupt_rejects_attach_tracee() != 0
+        || test_interrupt_job_stopped_sibling() != 0) {
         return 1;
     }
 

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/src/main.c
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/src/main.c
@@ -7,10 +7,17 @@
 #include <string.h>
 #include <sys/ptrace.h>
 #include <sys/syscall.h>
+#include <sys/uio.h>
 #include <sys/wait.h>
 #include <time.h>
 #include <unistd.h>
 
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+#ifndef PTRACE_SETREGSET
+#define PTRACE_SETREGSET 0x4205
+#endif
 #ifndef PTRACE_SEIZE
 #define PTRACE_SEIZE 0x4206
 #endif
@@ -26,10 +33,43 @@
 #ifndef __WALL
 #define __WALL 0x40000000
 #endif
+#ifndef NT_PRSTATUS
+#define NT_PRSTATUS 1
+#endif
 
 enum {
     WAIT_TIMEOUT_MS = 3000,
     WAIT_POLL_INTERVAL_MS = 10,
+};
+
+struct x86_64_user_regs {
+    uint64_t r15;
+    uint64_t r14;
+    uint64_t r13;
+    uint64_t r12;
+    uint64_t rbp;
+    uint64_t rbx;
+    uint64_t r11;
+    uint64_t r10;
+    uint64_t r9;
+    uint64_t r8;
+    uint64_t rax;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t orig_rax;
+    uint64_t rip;
+    uint64_t cs;
+    uint64_t eflags;
+    uint64_t rsp;
+    uint64_t ss;
+    uint64_t fs_base;
+    uint64_t gs_base;
+    uint64_t ds;
+    uint64_t es;
+    uint64_t fs;
+    uint64_t gs;
 };
 
 static int fail(const char *message)
@@ -86,6 +126,73 @@ static int expect_getsiginfo_signal(pid_t pid, int expected_signal, const char *
         return 1;
     }
     return 0;
+}
+
+static int read_tracee_regs(pid_t pid, struct x86_64_user_regs *regs)
+{
+    struct iovec iov = {
+        .iov_base = regs,
+        .iov_len = sizeof(*regs),
+    };
+
+    if (ptrace(PTRACE_GETREGSET, pid, (void *)NT_PRSTATUS, &iov) != 0) {
+        return fail("PTRACE_GETREGSET for syscall stop");
+    }
+    if (iov.iov_len != sizeof(*regs)) {
+        printf("FAIL: PTRACE_GETREGSET returned register length %zu, expected %zu\n",
+               iov.iov_len, sizeof(*regs));
+        return 1;
+    }
+    return 0;
+}
+
+static int write_tracee_regs(pid_t pid, struct x86_64_user_regs *regs)
+{
+    struct iovec iov = {
+        .iov_base = regs,
+        .iov_len = sizeof(*regs),
+    };
+
+    if (ptrace(PTRACE_SETREGSET, pid, (void *)NT_PRSTATUS, &iov) != 0) {
+        return fail("PTRACE_SETREGSET replaces the syscall number");
+    }
+    return 0;
+}
+
+static int resume_to_getpid_entry(pid_t pid, struct x86_64_user_regs *regs)
+{
+    int signal_to_deliver = SIGCONT;
+
+    for (int stop_count = 0; stop_count < 32; stop_count++) {
+        if (ptrace(PTRACE_SYSCALL, pid, NULL,
+                   (void *)(uintptr_t)signal_to_deliver)
+            != 0) {
+            return fail("PTRACE_SYSCALL resumes toward a getpid entry stop");
+        }
+        if (expect_ptrace_stop(pid, SIGTRAP | 0x80, 0,
+                               "PTRACE_SYSCALL reports a TRACESYSGOOD syscall stop")
+            != 0) {
+            return 1;
+        }
+        if (expect_getsiginfo_signal(pid, SIGTRAP,
+                                     "syscall stop PTRACE_GETSIGINFO returns SIGTRAP")
+            != 0) {
+            return 1;
+        }
+        if (read_tracee_regs(pid, regs) != 0) {
+            return 1;
+        }
+
+        printf("PTRACE_SYSCALL_REGS: orig_rax=%lld rax=%lld\n",
+               (long long)(int64_t)regs->orig_rax, (long long)(int64_t)regs->rax);
+        if (regs->orig_rax == SYS_getpid && (int64_t)regs->rax == -ENOSYS) {
+            return 0;
+        }
+        signal_to_deliver = 0;
+    }
+
+    errno = ETIMEDOUT;
+    return fail("PTRACE_SYSCALL reaches a getpid entry stop");
 }
 
 static void kill_tracee(pid_t pid)
@@ -192,19 +299,30 @@ int main(void)
         return 1;
     }
 
-    if (ptrace(PTRACE_SYSCALL, pid, NULL, (void *)(uintptr_t)SIGCONT) != 0) {
-        kill_tracee(pid);
-        return fail("PTRACE_SYSCALL resumes PTRACE_EVENT_STOP with SIGCONT");
-    }
-    if (expect_ptrace_stop(pid, SIGTRAP | 0x80, 0,
-                            "PTRACE_SYSCALL reports a TRACESYSGOOD syscall stop")
-        != 0) {
+    struct x86_64_user_regs entry_regs = {0};
+    if (resume_to_getpid_entry(pid, &entry_regs) != 0) {
         kill_tracee(pid);
         return 1;
     }
-    if (expect_getsiginfo_signal(pid, SIGTRAP,
-                                 "syscall stop PTRACE_GETSIGINFO returns SIGTRAP")
-        != 0) {
+    entry_regs.orig_rax = SYS_getppid;
+    if (write_tracee_regs(pid, &entry_regs) != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    struct x86_64_user_regs replaced_entry_regs = {0};
+    if (read_tracee_regs(pid, &replaced_entry_regs) != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    printf("PTRACE_REPLACED_ENTRY_REGS: orig_rax=%lld rax=%lld\n",
+           (long long)(int64_t)replaced_entry_regs.orig_rax,
+           (long long)(int64_t)replaced_entry_regs.rax);
+    if (replaced_entry_regs.orig_rax != SYS_getppid
+        || (int64_t)replaced_entry_regs.rax != -ENOSYS) {
+        printf("FAIL: replacement syscall entry view: orig_rax=%lld rax=%lld expected "
+               "orig_rax=%ld rax=%d\n",
+               (long long)(int64_t)replaced_entry_regs.orig_rax,
+               (long long)(int64_t)replaced_entry_regs.rax, (long)SYS_getppid, -ENOSYS);
         kill_tracee(pid);
         return 1;
     }
@@ -216,6 +334,21 @@ int main(void)
     if (expect_ptrace_stop(pid, SIGTRAP | 0x80, 0,
                             "PTRACE_SYSCALL preserves the syscall-exit stop before SIGSTOP")
         != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    struct x86_64_user_regs exit_regs = {0};
+    if (read_tracee_regs(pid, &exit_regs) != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    printf("PTRACE_REPLACED_SYSCALL_REGS: orig_rax=%lld rax=%lld\n",
+           (long long)(int64_t)exit_regs.orig_rax, (long long)(int64_t)exit_regs.rax);
+    if (exit_regs.orig_rax != SYS_getppid || (pid_t)exit_regs.rax != getpid()) {
+        printf("FAIL: replacement syscall result: orig_rax=%lld rax=%lld expected "
+               "orig_rax=%ld rax=%d\n",
+               (long long)(int64_t)exit_regs.orig_rax,
+               (long long)(int64_t)exit_regs.rax, (long)SYS_getppid, getpid());
         kill_tracee(pid);
         return 1;
     }

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/src/main.c
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-syscall-stop/src/main.c
@@ -95,18 +95,80 @@ static void kill_tracee(pid_t pid)
     (void)wait_for_tracee_event(pid, &status);
 }
 
-int main(void)
+static int expect_ptrace_errno(long request, pid_t pid, void *addr, void *data,
+                               int expected_errno, const char *description)
 {
-    printf("PTRACE_SEIZE syscall-stop regression\n");
-
-    pid_t pid = fork();
-    if (pid < 0) {
-        return fail("fork tracee");
+    errno = 0;
+    long result = syscall(SYS_ptrace, request, pid, addr, data);
+    if (result != -1 || errno != expected_errno) {
+        printf("FAIL: %s: result=%ld errno=%d (%s), expected errno=%d (%s)\n",
+               description, result, errno, strerror(errno), expected_errno,
+               strerror(expected_errno));
+        return 1;
     }
+    return 0;
+}
+
+static pid_t fork_spinning_tracee(void)
+{
+    pid_t pid = fork();
     if (pid == 0) {
         for (;;) {
             (void)syscall(SYS_getpid);
         }
+    }
+    return pid;
+}
+
+static int test_seize_rejects_nonzero_addr(void)
+{
+    pid_t pid = fork_spinning_tracee();
+    if (pid < 0) {
+        return fail("fork tracee for nonzero PTRACE_SEIZE addr");
+    }
+
+    int result = expect_ptrace_errno(
+        PTRACE_SEIZE, pid, (void *)(uintptr_t)1, NULL, EIO,
+        "PTRACE_SEIZE rejects a nonzero addr");
+    kill_tracee(pid);
+    return result;
+}
+
+static int test_interrupt_rejects_attach_tracee(void)
+{
+    pid_t pid = fork_spinning_tracee();
+    if (pid < 0) {
+        return fail("fork tracee for PTRACE_ATTACH interrupt");
+    }
+
+    if (ptrace(PTRACE_ATTACH, pid, NULL, NULL) != 0) {
+        kill_tracee(pid);
+        return fail("PTRACE_ATTACH before PTRACE_INTERRUPT");
+    }
+    if (expect_ptrace_stop(pid, SIGSTOP, 0, "PTRACE_ATTACH reports SIGSTOP") != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+
+    int result = expect_ptrace_errno(
+        PTRACE_INTERRUPT, pid, NULL, NULL, EIO,
+        "PTRACE_INTERRUPT rejects a PTRACE_ATTACH tracee");
+    kill_tracee(pid);
+    return result;
+}
+
+int main(void)
+{
+    printf("PTRACE_SEIZE syscall-stop regression\n");
+
+    if (test_seize_rejects_nonzero_addr() != 0
+        || test_interrupt_rejects_attach_tracee() != 0) {
+        return 1;
+    }
+
+    pid_t pid = fork_spinning_tracee();
+    if (pid < 0) {
+        return fail("fork tracee");
     }
 
     if (ptrace(PTRACE_SEIZE, pid, NULL, (void *)(uintptr_t)PTRACE_O_TRACESYSGOOD) != 0) {
@@ -168,7 +230,7 @@ int main(void)
         return 1;
     }
 
-    printf("PASS: PTRACE_SEIZE interrupt and syscall signal-stop sequence\n");
+    printf("PASS: PTRACE_SEIZE arguments, interrupt mode, and syscall-stop sequence\n");
     kill_tracee(pid);
     return 0;
 }

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-ptrace-seize-traceexec C)
+include(${CMAKE_CURRENT_LIST_DIR}/../common/starry_arch_filter.cmake)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+starry_arch_filtered_executable(
+    test-ptrace-seize-traceexec
+    "x86_64"
+    "test-ptrace-seize-traceexec skipped on unsupported architecture"
+    src/main.c
+)
+target_compile_options(test-ptrace-seize-traceexec PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-ptrace-seize-traceexec RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/README.md
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/README.md
@@ -1,7 +1,8 @@
 # PTRACE_SEIZE TRACEEXEC Regression
 
-This x86_64 QEMU regression covers the ptrace sequence used by a traced
-`execve` after an initial job-control stop:
+This x86_64 QEMU regression covers equivalent `PTRACE_SEIZE` and
+`PTRACE_TRACEME` sequences for a traced `execve` after an initial job-control
+stop:
 
 1. A `PTRACE_SEIZE` tracer interrupts a tracee stopped by `SIGSTOP`.
    `waitpid()` must report `SIGSTOP | (PTRACE_EVENT_STOP << 8)`.
@@ -9,6 +10,12 @@ This x86_64 QEMU regression covers the ptrace sequence used by a traced
    must expose `orig_rax = SYS_execve` and `rax = -ENOSYS`.
 3. With `PTRACE_O_TRACEEXEC`, resuming that entry stop must report
    `SIGTRAP | (PTRACE_EVENT_EXEC << 8)`, not an `execve` syscall-exit stop.
+4. After that event, `PTRACE_SYSCALL` and `PTRACE_GETREGSET` must keep
+   `orig_rax` at `SYS_getppid` from its entry stop through its exit stop, while
+   `rax` changes from `-ENOSYS` to the tracer PID.
+5. A `PTRACE_TRACEME` tracee configured with the same options must observe the
+   same post-exec `SYS_getppid` register pair, then preserve `orig_rax` and the
+   return value through a direct `SYS_getpid` entry and exit stop.
 
 The public ptrace event and option contract is documented by
 [ptrace(2)](https://man7.org/linux/man-pages/man2/ptrace.2.html).
@@ -19,6 +26,12 @@ by running this source directly against Linux `7.1.5-zen1` on 2026-08-05:
 PTRACE_STOP: PTRACE_INTERRUPT reports PTRACE_EVENT_STOP status=0x80137f
 PTRACE_SYSCALL_REGS: orig_rax=59 rax=-38
 PTRACE_STOP: PTRACE_O_TRACEEXEC replaces execve syscall-exit stop status=0x4057f
+PTRACE_POST_EXEC_REGS: orig_rax=110 rax=-38
+PTRACE_POST_EXEC_REGS: orig_rax=110 rax=<tracer-pid>
+PTRACE_TRACEME_POST_EXEC_REGS: orig_rax=110 rax=-38
+PTRACE_TRACEME_POST_EXEC_REGS: orig_rax=110 rax=<tracer-pid>
+PTRACE_TRACEME_POST_EXEC_REGS: orig_rax=39 rax=-38
+PTRACE_TRACEME_POST_EXEC_REGS: orig_rax=39 rax=<tracee-pid>
 ```
 
 In StarryOS, the behavior spans the ptrace request handlers, wait-status

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/README.md
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/README.md
@@ -1,0 +1,26 @@
+# PTRACE_SEIZE TRACEEXEC Regression
+
+This x86_64 QEMU regression covers the ptrace sequence used by a traced
+`execve` after an initial job-control stop:
+
+1. A `PTRACE_SEIZE` tracer interrupts a tracee stopped by `SIGSTOP`.
+   `waitpid()` must report `SIGSTOP | (PTRACE_EVENT_STOP << 8)`.
+2. With `PTRACE_O_TRACESYSGOOD` and `PTRACE_SYSCALL`, the `execve` entry stop
+   must expose `orig_rax = SYS_execve` and `rax = -ENOSYS`.
+3. With `PTRACE_O_TRACEEXEC`, resuming that entry stop must report
+   `SIGTRAP | (PTRACE_EVENT_EXEC << 8)`, not an `execve` syscall-exit stop.
+
+The public ptrace event and option contract is documented by
+[ptrace(2)](https://man7.org/linux/man-pages/man2/ptrace.2.html).
+The precise stop sequence and x86_64 register observation above were checked
+by running this source directly against Linux `7.1.5-zen1` on 2026-08-05:
+
+```text
+PTRACE_STOP: PTRACE_INTERRUPT reports PTRACE_EVENT_STOP status=0x80137f
+PTRACE_SYSCALL_REGS: orig_rax=59 rax=-38
+PTRACE_STOP: PTRACE_O_TRACEEXEC replaces execve syscall-exit stop status=0x4057f
+```
+
+In StarryOS, the behavior spans the ptrace request handlers, wait-status
+translation, job-stop wakeup path, and per-thread syscall trace state. Keep the
+test focused on that observable ABI rather than on an internal stop ordering.

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/src/main.c
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/src/main.c
@@ -1,0 +1,269 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ptrace.h>
+#include <sys/syscall.h>
+#include <sys/uio.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef PTRACE_GETREGSET
+#define PTRACE_GETREGSET 0x4204
+#endif
+#ifndef PTRACE_SEIZE
+#define PTRACE_SEIZE 0x4206
+#endif
+#ifndef PTRACE_INTERRUPT
+#define PTRACE_INTERRUPT 0x4207
+#endif
+#ifndef PTRACE_EVENT_EXEC
+#define PTRACE_EVENT_EXEC 4
+#endif
+#ifndef PTRACE_EVENT_STOP
+#define PTRACE_EVENT_STOP 128
+#endif
+#ifndef PTRACE_O_TRACESYSGOOD
+#define PTRACE_O_TRACESYSGOOD 0x00000001
+#endif
+#ifndef PTRACE_O_TRACEEXEC
+#define PTRACE_O_TRACEEXEC 0x00000010
+#endif
+#ifndef NT_PRSTATUS
+#define NT_PRSTATUS 1
+#endif
+
+enum {
+    WAIT_TIMEOUT_MS = 3000,
+    WAIT_POLL_INTERVAL_MS = 10,
+};
+
+struct x86_64_user_regs {
+    uint64_t r15;
+    uint64_t r14;
+    uint64_t r13;
+    uint64_t r12;
+    uint64_t rbp;
+    uint64_t rbx;
+    uint64_t r11;
+    uint64_t r10;
+    uint64_t r9;
+    uint64_t r8;
+    uint64_t rax;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t orig_rax;
+    uint64_t rip;
+    uint64_t cs;
+    uint64_t eflags;
+    uint64_t rsp;
+    uint64_t ss;
+    uint64_t fs_base;
+    uint64_t gs_base;
+    uint64_t ds;
+    uint64_t es;
+    uint64_t fs;
+    uint64_t gs;
+};
+
+static int fail(const char *message)
+{
+    printf("FAIL: %s: errno=%d (%s)\n", message, errno, strerror(errno));
+    return 1;
+}
+
+static pid_t wait_for_tracee_event(pid_t pid, int *status)
+{
+    struct timespec delay = {
+        .tv_sec = 0,
+        .tv_nsec = WAIT_POLL_INTERVAL_MS * 1000 * 1000,
+    };
+
+    for (int waited_ms = 0; waited_ms < WAIT_TIMEOUT_MS; waited_ms += WAIT_POLL_INTERVAL_MS) {
+        pid_t waited = waitpid(pid, status, WUNTRACED | WNOHANG);
+        if (waited != 0) {
+            return waited;
+        }
+        (void)nanosleep(&delay, NULL);
+    }
+
+    errno = ETIMEDOUT;
+    return 0;
+}
+
+static void print_stop(const char *phase, int status)
+{
+    printf("PTRACE_STOP: %s status=%#x signal=%d event=%u\n", phase, status,
+           WIFSTOPPED(status) ? WSTOPSIG(status) : -1, (unsigned int)status >> 16);
+}
+
+static int expect_stop(pid_t pid, int expected_signal, unsigned int expected_event,
+                       const char *description)
+{
+    int status = 0;
+    pid_t waited = wait_for_tracee_event(pid, &status);
+    if (waited != pid) {
+        return fail(description);
+    }
+    print_stop(description, status);
+    if (!WIFSTOPPED(status) || WSTOPSIG(status) != expected_signal
+        || ((unsigned int)status >> 16) != expected_event) {
+        printf("FAIL: %s: status=%#x signal=%d event=%u\n", description, status,
+               WIFSTOPPED(status) ? WSTOPSIG(status) : -1, (unsigned int)status >> 16);
+        return 1;
+    }
+    return 0;
+}
+
+static void kill_tracee(pid_t pid)
+{
+    int status = 0;
+    (void)kill(pid, SIGKILL);
+    (void)wait_for_tracee_event(pid, &status);
+}
+
+static int read_tracee_regs(pid_t pid, struct x86_64_user_regs *regs)
+{
+    struct iovec iov = {
+        .iov_base = regs,
+        .iov_len = sizeof(*regs),
+    };
+
+    if (ptrace(PTRACE_GETREGSET, pid, (void *)NT_PRSTATUS, &iov) != 0) {
+        return fail("PTRACE_GETREGSET for syscall stop");
+    }
+    if (iov.iov_len != sizeof(*regs)) {
+        errno = EINVAL;
+        return fail("PTRACE_GETREGSET returned a complete x86_64 register set");
+    }
+    return 0;
+}
+
+static int resume_until_execve_entry(pid_t pid)
+{
+    int signal_to_deliver = SIGCONT;
+
+    for (int stop_count = 0; stop_count < 8; stop_count++) {
+        int status = 0;
+        if (ptrace(PTRACE_SYSCALL, pid, NULL, (void *)(uintptr_t)signal_to_deliver) != 0) {
+            return fail("PTRACE_SYSCALL resumes the seized tracee");
+        }
+
+        pid_t waited = wait_for_tracee_event(pid, &status);
+        if (waited != pid || !WIFSTOPPED(status)) {
+            return fail("wait for a ptrace stop while resuming toward execve");
+        }
+
+        print_stop("resume toward execve", status);
+        unsigned int event = (unsigned int)status >> 16;
+        if (WSTOPSIG(status) == SIGSTOP && event == PTRACE_EVENT_STOP) {
+            signal_to_deliver = 0;
+            continue;
+        }
+        if (WSTOPSIG(status) != (SIGTRAP | 0x80) || event != 0) {
+            printf("FAIL: expected a syscall or group-stop before execve entry: status=%#x "
+                   "signal=%d event=%u\n",
+                   status, WSTOPSIG(status), event);
+            return 1;
+        }
+
+        struct x86_64_user_regs regs = {0};
+        if (read_tracee_regs(pid, &regs) != 0) {
+            return 1;
+        }
+        printf("PTRACE_SYSCALL_REGS: orig_rax=%lld rax=%lld\n",
+               (long long)(int64_t)regs.orig_rax, (long long)(int64_t)regs.rax);
+        if (regs.orig_rax == SYS_execve && (int64_t)regs.rax == -ENOSYS) {
+            return 0;
+        }
+
+        signal_to_deliver = 0;
+    }
+
+    errno = ETIMEDOUT;
+    return fail("PTRACE_SYSCALL reaches the execve entry stop");
+}
+
+static int run_traceexec_sequence(pid_t pid)
+{
+    unsigned long old_tid = 0;
+    int status = 0;
+
+    if (ptrace(PTRACE_SEIZE, pid, NULL,
+               (void *)(uintptr_t)(PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEEXEC))
+        != 0) {
+        return fail("PTRACE_SEIZE with PTRACE_O_TRACEEXEC");
+    }
+    if (ptrace(PTRACE_INTERRUPT, pid, NULL, NULL) != 0) {
+        return fail("PTRACE_INTERRUPT");
+    }
+    if (expect_stop(pid, SIGSTOP, PTRACE_EVENT_STOP,
+                    "PTRACE_INTERRUPT reports PTRACE_EVENT_STOP")
+        != 0) {
+        return 1;
+    }
+    if (resume_until_execve_entry(pid) != 0) {
+        return 1;
+    }
+    if (ptrace(PTRACE_SYSCALL, pid, NULL, NULL) != 0) {
+        return fail("PTRACE_SYSCALL resumes execve entry");
+    }
+    if (expect_stop(pid, SIGTRAP, PTRACE_EVENT_EXEC,
+                    "PTRACE_O_TRACEEXEC replaces execve syscall-exit stop")
+        != 0) {
+        return 1;
+    }
+    if (ptrace(PTRACE_GETEVENTMSG, pid, NULL, &old_tid) != 0) {
+        return fail("PTRACE_GETEVENTMSG for PTRACE_EVENT_EXEC");
+    }
+    if ((pid_t)old_tid != pid) {
+        printf("FAIL: PTRACE_EVENT_EXEC former tid=%lu expected %d\n", old_tid, pid);
+        return 1;
+    }
+    if (ptrace(PTRACE_CONT, pid, NULL, NULL) != 0) {
+        return fail("PTRACE_CONT resumes PTRACE_EVENT_EXEC");
+    }
+    if (wait_for_tracee_event(pid, &status) != pid || !WIFEXITED(status)
+        || WEXITSTATUS(status) != 0) {
+        printf("FAIL: tracee did not exit after PTRACE_EVENT_EXEC: status=%#x\n", status);
+        return 1;
+    }
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    if (argc == 2 && strcmp(argv[1], "--after-exec") == 0) {
+        return 0;
+    }
+
+    printf("PTRACE_SEIZE TRACEEXEC syscall-stop regression\n");
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        return fail("fork tracee");
+    }
+    if (pid == 0) {
+        (void)raise(SIGSTOP);
+        execl("/proc/self/exe", "test-ptrace-seize-traceexec", "--after-exec", NULL);
+        _exit(127);
+    }
+
+    if (expect_stop(pid, SIGSTOP, 0, "tracee enters its initial group stop") != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    if (run_traceexec_sequence(pid) != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+
+    printf("PASS: PTRACE_EVENT_EXEC replaces the execve syscall-exit stop\n");
+    return 0;
+}

--- a/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/src/main.c
+++ b/test-suit/starryos/qemu/system/test-ptrace-seize-traceexec/src/main.c
@@ -15,6 +15,9 @@
 #ifndef PTRACE_GETREGSET
 #define PTRACE_GETREGSET 0x4204
 #endif
+#ifndef PTRACE_SETOPTIONS
+#define PTRACE_SETOPTIONS 0x4200
+#endif
 #ifndef PTRACE_SEIZE
 #define PTRACE_SEIZE 0x4206
 #endif
@@ -190,10 +193,164 @@ static int resume_until_execve_entry(pid_t pid)
     return fail("PTRACE_SYSCALL reaches the execve entry stop");
 }
 
+static int trace_syscalls_after_exec(pid_t pid, pid_t expected_parent_pid)
+{
+    int saw_getppid_entry = 0;
+
+    for (int stop_count = 0; stop_count < 128; stop_count++) {
+        int status = 0;
+        if (ptrace(PTRACE_SYSCALL, pid, NULL, NULL) != 0) {
+            return fail("PTRACE_SYSCALL resumes the tracee after PTRACE_EVENT_EXEC");
+        }
+
+        pid_t waited = wait_for_tracee_event(pid, &status);
+        if (waited != pid) {
+            return fail("wait for a tracee event after PTRACE_EVENT_EXEC");
+        }
+        if (WIFEXITED(status)) {
+            printf("FAIL: tracee exited before direct SYS_getppid: status=%#x entry=%d\n", status,
+                   saw_getppid_entry);
+            return 1;
+        }
+        if (!WIFSTOPPED(status) || WSTOPSIG(status) != (SIGTRAP | 0x80)
+            || ((unsigned int)status >> 16) != 0) {
+            print_stop("PTRACE_SYSCALL after PTRACE_EVENT_EXEC", status);
+            return fail("PTRACE_SYSCALL reports a syscall stop after PTRACE_EVENT_EXEC");
+        }
+
+        struct x86_64_user_regs regs = {0};
+        if (read_tracee_regs(pid, &regs) != 0) {
+            return 1;
+        }
+        printf("PTRACE_POST_EXEC_REGS: orig_rax=%lld rax=%lld\n",
+               (long long)(int64_t)regs.orig_rax, (long long)(int64_t)regs.rax);
+
+        if (saw_getppid_entry) {
+            if (regs.orig_rax != SYS_getppid) {
+                errno = EPROTO;
+                return fail("SYS_getppid exit preserves orig_rax after PTRACE_EVENT_EXEC");
+            }
+            if ((pid_t)regs.rax != expected_parent_pid) {
+                errno = EPROTO;
+                return fail("SYS_getppid exit returns the tracer pid after PTRACE_EVENT_EXEC");
+            }
+            if (ptrace(PTRACE_CONT, pid, NULL, NULL) != 0) {
+                return fail("PTRACE_CONT resumes the tracee after direct SYS_getppid");
+            }
+            if (wait_for_tracee_event(pid, &status) != pid || !WIFEXITED(status)
+                || WEXITSTATUS(status) != 0) {
+                printf("FAIL: tracee did not exit after direct SYS_getppid: status=%#x\n", status);
+                return 1;
+            }
+            return 0;
+        }
+        if (regs.orig_rax == SYS_getppid) {
+            if ((int64_t)regs.rax != -ENOSYS) {
+                errno = EPROTO;
+                return fail("SYS_getppid entry has the x86_64 syscall-entry return value");
+            }
+            saw_getppid_entry = 1;
+        }
+    }
+
+    errno = ETIMEDOUT;
+    return fail("PTRACE_SYSCALL observes direct SYS_getppid after PTRACE_EVENT_EXEC");
+}
+
+static int trace_two_syscalls_after_exec(pid_t pid, pid_t expected_parent_pid)
+{
+    int saw_getppid_entry = 0;
+    int saw_getpid_entry = 0;
+
+    for (int stop_count = 0; stop_count < 128; stop_count++) {
+        int status = 0;
+        if (ptrace(PTRACE_SYSCALL, pid, NULL, NULL) != 0) {
+            return fail("PTRACE_SYSCALL resumes the traceme tracee after PTRACE_EVENT_EXEC");
+        }
+
+        pid_t waited = wait_for_tracee_event(pid, &status);
+        if (waited != pid) {
+            return fail("wait for a traceme event after PTRACE_EVENT_EXEC");
+        }
+        if (WIFEXITED(status)) {
+            printf("FAIL: traceme tracee exited before direct SYS_getpid: status=%#x "
+                   "getppid_entry=%d getpid_entry=%d\n",
+                   status, saw_getppid_entry, saw_getpid_entry);
+            return 1;
+        }
+        if (!WIFSTOPPED(status) || WSTOPSIG(status) != (SIGTRAP | 0x80)
+            || ((unsigned int)status >> 16) != 0) {
+            print_stop("PTRACE_SYSCALL traceme after PTRACE_EVENT_EXEC", status);
+            return fail("PTRACE_SYSCALL reports a traceme syscall stop after PTRACE_EVENT_EXEC");
+        }
+
+        struct x86_64_user_regs regs = {0};
+        if (read_tracee_regs(pid, &regs) != 0) {
+            return 1;
+        }
+        printf("PTRACE_TRACEME_POST_EXEC_REGS: orig_rax=%lld rax=%lld\n",
+               (long long)(int64_t)regs.orig_rax, (long long)(int64_t)regs.rax);
+
+        if (!saw_getppid_entry && regs.orig_rax == SYS_getppid) {
+            if ((int64_t)regs.rax != -ENOSYS) {
+                errno = EPROTO;
+                return fail("traceme SYS_getppid entry has the x86_64 syscall-entry return value");
+            }
+            saw_getppid_entry = 1;
+            continue;
+        }
+        if (saw_getppid_entry && !saw_getpid_entry && regs.orig_rax == SYS_getppid) {
+            if ((pid_t)regs.rax != expected_parent_pid) {
+                errno = EPROTO;
+                return fail("traceme SYS_getppid exit returns the tracer pid after PTRACE_EVENT_EXEC");
+            }
+            saw_getpid_entry = 1;
+            continue;
+        }
+        if (saw_getpid_entry && regs.orig_rax == SYS_getpid) {
+            if ((int64_t)regs.rax != -ENOSYS) {
+                errno = EPROTO;
+                return fail("traceme SYS_getpid entry has the x86_64 syscall-entry return value");
+            }
+            if (ptrace(PTRACE_SYSCALL, pid, NULL, NULL) != 0) {
+                return fail("PTRACE_SYSCALL resumes traceme SYS_getpid entry");
+            }
+            if (wait_for_tracee_event(pid, &status) != pid || !WIFSTOPPED(status)
+                || WSTOPSIG(status) != (SIGTRAP | 0x80)
+                || ((unsigned int)status >> 16) != 0) {
+                print_stop("PTRACE_SYSCALL traceme SYS_getpid exit", status);
+                return fail("PTRACE_SYSCALL reports traceme SYS_getpid exit");
+            }
+            memset(&regs, 0, sizeof(regs));
+            if (read_tracee_regs(pid, &regs) != 0) {
+                return 1;
+            }
+            printf("PTRACE_TRACEME_POST_EXEC_REGS: orig_rax=%lld rax=%lld\n",
+                   (long long)(int64_t)regs.orig_rax, (long long)(int64_t)regs.rax);
+            if (regs.orig_rax != SYS_getpid || (pid_t)regs.rax != pid) {
+                errno = EPROTO;
+                return fail("traceme SYS_getpid exit preserves its return value");
+            }
+            if (ptrace(PTRACE_CONT, pid, NULL, NULL) != 0) {
+                return fail("PTRACE_CONT resumes traceme after direct syscalls");
+            }
+            if (wait_for_tracee_event(pid, &status) != pid || !WIFEXITED(status)
+                || WEXITSTATUS(status) != 0) {
+                printf("FAIL: traceme tracee did not exit after direct syscalls: status=%#x\n",
+                       status);
+                return 1;
+            }
+            return 0;
+        }
+    }
+
+    errno = ETIMEDOUT;
+    return fail("PTRACE_SYSCALL observes direct traceme syscalls after PTRACE_EVENT_EXEC");
+}
+
 static int run_traceexec_sequence(pid_t pid)
 {
     unsigned long old_tid = 0;
-    int status = 0;
 
     if (ptrace(PTRACE_SEIZE, pid, NULL,
                (void *)(uintptr_t)(PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEEXEC))
@@ -226,21 +383,84 @@ static int run_traceexec_sequence(pid_t pid)
         printf("FAIL: PTRACE_EVENT_EXEC former tid=%lu expected %d\n", old_tid, pid);
         return 1;
     }
-    if (ptrace(PTRACE_CONT, pid, NULL, NULL) != 0) {
-        return fail("PTRACE_CONT resumes PTRACE_EVENT_EXEC");
+    return trace_syscalls_after_exec(pid, getpid());
+}
+
+static int run_traceme_traceexec_sequence(void)
+{
+    pid_t pid = fork();
+    if (pid < 0) {
+        return fail("fork traceme traceexec child");
     }
-    if (wait_for_tracee_event(pid, &status) != pid || !WIFEXITED(status)
-        || WEXITSTATUS(status) != 0) {
-        printf("FAIL: tracee did not exit after PTRACE_EVENT_EXEC: status=%#x\n", status);
+    if (pid == 0) {
+        if (ptrace(PTRACE_TRACEME, 0, NULL, NULL) != 0) {
+            _exit(100);
+        }
+        if (raise(SIGSTOP) != 0) {
+            _exit(101);
+        }
+        execl("/proc/self/exe", "test-ptrace-seize-traceexec", "--after-traceme-exec", NULL);
+        _exit(127);
+    }
+
+    int status = 0;
+    if (wait_for_tracee_event(pid, &status) != pid || !WIFSTOPPED(status)
+        || WSTOPSIG(status) != SIGSTOP) {
+        printf("FAIL: traceme tracee initial stop: status=%#x\n", status);
+        kill_tracee(pid);
         return 1;
     }
+    if (ptrace(PTRACE_SETOPTIONS, pid, NULL,
+               (void *)(uintptr_t)(PTRACE_O_TRACESYSGOOD | PTRACE_O_TRACEEXEC))
+        != 0) {
+        kill_tracee(pid);
+        return fail("PTRACE_SETOPTIONS for traceme traceexec");
+    }
+    if (resume_until_execve_entry(pid) != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    if (ptrace(PTRACE_SYSCALL, pid, NULL, NULL) != 0) {
+        kill_tracee(pid);
+        return fail("PTRACE_SYSCALL resumes traceme execve entry");
+    }
+    if (expect_stop(pid, SIGTRAP, PTRACE_EVENT_EXEC,
+                    "traceme PTRACE_O_TRACEEXEC replaces execve syscall-exit stop")
+        != 0) {
+        kill_tracee(pid);
+        return 1;
+    }
+    return trace_two_syscalls_after_exec(pid, getpid());
+}
+
+static int verify_direct_syscall_after_exec(void)
+{
+    long parent_pid = syscall(SYS_getppid);
+    if (parent_pid <= 0) {
+        return fail("direct SYS_getppid after PTRACE_EVENT_EXEC");
+    }
+    printf("TRACE_EXEC_CHILD: direct SYS_getppid=%ld\n", parent_pid);
+    return 0;
+}
+
+static int verify_traceme_syscalls_after_exec(void)
+{
+    long parent_pid = syscall(SYS_getppid);
+    long self_pid = syscall(SYS_getpid);
+    if (parent_pid <= 0 || self_pid <= 0) {
+        return fail("direct traceme syscalls after PTRACE_EVENT_EXEC");
+    }
+    printf("TRACE_EXEC_CHILD: direct traceme getppid=%ld getpid=%ld\n", parent_pid, self_pid);
     return 0;
 }
 
 int main(int argc, char **argv)
 {
     if (argc == 2 && strcmp(argv[1], "--after-exec") == 0) {
-        return 0;
+        return verify_direct_syscall_after_exec();
+    }
+    if (argc == 2 && strcmp(argv[1], "--after-traceme-exec") == 0) {
+        return verify_traceme_syscalls_after_exec();
     }
 
     printf("PTRACE_SEIZE TRACEEXEC syscall-stop regression\n");
@@ -263,7 +483,10 @@ int main(int argc, char **argv)
         kill_tracee(pid);
         return 1;
     }
+    if (run_traceme_traceexec_sequence() != 0) {
+        return 1;
+    }
 
-    printf("PASS: PTRACE_EVENT_EXEC replaces the execve syscall-exit stop\n");
+    printf("PASS: PTRACE_EVENT_EXEC preserves seized and traceme syscall ABI\n");
     return 0;
 }


### PR DESCRIPTION
## 问题

StarryOS 当前的 ptrace 停止状态在 `PTRACE_SEIZE`、`PTRACE_SYSCALL` 和
`PTRACE_O_TRACEEXEC` 组合使用时存在一组相互关联的问题：

- attach 到已经 job-stop 的 tracee 后，interrupt stop 没有按
  `PTRACE_EVENT_STOP` 对外报告；
- syscall entry/exit stop 的推进状态不完整，exec 成功后还可能产生本应被
  TRACEEXEC event 替代的 execve syscall-exit stop；
- x86_64 的 `PTRACE_GETREGSET` 在 syscall-exit stop 上不能稳定返回原始
  `orig_rax`，`PTRACE_SETREGSET` 也没有同步更新 ptrace 保存的 syscall 编号；
- 多线程 tracee 处于进程级 job-stop 时，按 sibling TID 发出的
  `PTRACE_INTERRUPT` 会错误唤醒另一个 job-stop waiter，导致目标 sibling
  无法发布自己的 `PTRACE_EVENT_STOP`。

这些问题共享同一套 ptrace stop 状态机和 syscall 上下文，后续修复依赖前序状态
建模，因此合并为一个 PR，并保留分步提交以便审阅。

## 修改

1. 完善 SEIZE syscall-stop 流程：
   - 为 SEIZE interrupt stop 建立 `PTRACE_EVENT_STOP` 语义；
   - 在 `waitpid()` 状态中保留 job-stop signal；
   - 正确推进 `PTRACE_SYSCALL` 的 entry/exit 交替状态。
2. 修正 exec stop 顺序：
   - 成功 exec 时由 TRACEEXEC event 替代 execve syscall-exit stop；
   - 保持 event stop 之后继续跟踪后续 syscall；
   - 添加 SEIZE + TRACEEXEC 的确定性回归测试和 Linux 对照说明。
3. 保留 syscall 寄存器 ABI：
   - 在 `PtraceStopRecord` 中保存原始 syscall 编号；
   - x86_64 syscall-exit stop 上令 `orig_rax` 保持 syscall 编号，同时 `rax`
     返回 syscall 结果；
   - `PTRACE_SETREGSET` 同步更新保存值及仍处于 entry 阶段的活动上下文；
   - 回归测试在 `getpid` entry stop 将 `orig_rax` 改为 `getppid`，立即读回
     entry 视图，继续执行后再验证真实返回值及 exit-stop 寄存器视图；
   - 覆盖 SEIZE、TRACEME、TRACEEXEC 后继续执行等场景。
4. 补齐 SEIZE 请求 ABI：
   - 将 attachment mode 持久化为 `None`、`Attach`、`Seize`，并让 ptrace
     fork 子进程继承对应模式；
   - 非 SEIZE tracee 的 `PTRACE_INTERRUPT` 返回 `EIO`；
   - `PTRACE_SEIZE` 的 `addr` 非零时在修改 tracer/options 前返回 `EIO`；
   - 添加直接调用 `syscall(SYS_ptrace, ...)` 的确定性回归测试。
5. 按目标 TID 区分 job-stop waiter：
   - 在 `JobControl` 同一把锁下记录当前 parked waiter 的 TID；
   - `SIGCONT` 和 `SIGKILL` 清除 stopped 状态时同步清除 waiter TID；
   - `PTRACE_INTERRUPT` 仅在目标 TID 就是 waiter 时唤醒 `cont_event`，否则
     直接 interrupt 目标 task；
   - 新增 pthread 回归：leader 进入 job-stop，sibling 确认阻塞在 pipe read，
     tracer 对 sibling TID 执行 `PTRACE_INTERRUPT` 并要求收到 EVENT_STOP。

## 实现逻辑

ptrace 的 syscall entry/exit、event stop 和寄存器视图不是互相独立的功能：
停止类型决定 `waitpid()` 的编码和下一次 resume 的状态，而寄存器接口必须读取
该停止点对应的稳定 syscall 快照。因此先建立 SEIZE/syscall-stop 状态，再修正
exec event 的替代顺序，最后在同一停止记录上补齐 `orig_rax` 的读写语义。
SEIZE 专属请求还必须能够区分传统 ATTACH 与 SEIZE，因此 attachment mode 使用
单一类型化状态保存，避免由多个布尔状态组合出非法或不一致的模式。

job-stop 的 stopped 标志是进程级状态，但当前实现只有实际 dequeue stop signal 的
线程会 parked，ptrace pending event 又按 TID 存储。因此 waiter 身份必须与 stopped
状态一起受锁保护，不能仅根据进程级 stopped 标志选择唤醒路径。

## 与 #1323 的关系

#1323 面向较早代码基线，主要补充 `PTRACE_SEIZE`/`PTRACE_LISTEN` 基础流程，
当前处于冲突状态。本 PR 基于当前 `dev` 上已经存在的 ptrace 状态机，修复精确的
stop 顺序和寄存器 ABI，并提供对应回归测试；两者关注点互补，不直接复用 #1323
的旧基线改动。

## 验证

- `cargo xtask clippy --package starry-kernel`：官方 CI 容器中 25/25 通过
- `cargo xtask starry test qemu --arch x86_64 -c qemu/system/test-ptrace-seize-syscall-stop`：通过
- `cargo xtask starry test qemu --arch x86_64 -c qemu/system/test-ptrace-seize-traceexec`：通过
- `cargo fmt --all --check`：通过
- 最终 C 回归使用 `-Wall -Wextra -Werror -pthread` 宿主编译通过；当前受限执行环境运行 ptrace 时返回 `EPERM`
- sibling interrupt red/green：
  - 最终版用例先通过 `/proc/self/task/<tid>/status` 确认 sibling 已阻塞在 pipe read；
  - 临时恢复旧的进程级 `is_job_stopped()` 判断后，等待 sibling EVENT_STOP 在 3 秒后稳定超时，并由 grouped runner 传播失败；
  - 恢复目标 waiter-TID 判断后，同一用例通过。
- `PTRACE_SETREGSET` red/green：
  - 旧实现中，entry stop 将 `orig_rax` 从 `getpid` 改为 `getppid` 后立即
    `PTRACE_GETREGSET` 仍返回 `orig_rax=39, rax=-ENOSYS`，测试确定性失败；
  - 修复后立即读回 `orig_rax=110, rax=-ENOSYS`，继续后 exit stop 返回
    `orig_rax=110` 且 `rax` 为 tracer PID，证明实际执行了 `getppid`。
- SEIZE 请求 red/green：
  - 修复前非零 SEIZE `addr` 返回 `0`，修复后返回 `EIO`；
  - 仅修复 `addr` 后，ATTACH tracee 的 INTERRUPT 仍返回 `0`，持久化
    attachment mode 后返回 `EIO`。