### PR TITLE
fix(rockchip): support OrangePi 5 Plus SD boot with SCMI DWMMC clocks

### DIFF
--- a/drivers/ax-driver/Cargo.toml
+++ b/drivers/ax-driver/Cargo.toml
@@ -96,6 +96,7 @@ rockchip-dwmmc = [
     "block",
     "rockchip-pm",
     "rockchip-soc",
+    "dep:arm-scmi-rs",
     "dep:dwmmc-host",
     "dep:rdif-clk",
     "dep:sdmmc-protocol",

--- a/drivers/ax-driver/src/block/rockchip/clock.rs
+++ b/drivers/ax-driver/src/block/rockchip/clock.rs
@@ -1,16 +1,17 @@
 #[cfg(feature = "rockchip-dwmmc")]
 use alloc::format;
 
+#[cfg(any(feature = "rockchip-dwmmc", test))]
 use fdt_edit::Node;
 use log::info;
-use rdrive::{
-    probe::{OnProbeError, fdt::ClockRef},
-    register::FdtInfo,
-};
+#[cfg(feature = "rockchip-dwmmc")]
+use rdrive::probe::fdt::ClockRef;
+use rdrive::{probe::OnProbeError, register::FdtInfo};
 
 #[cfg(feature = "rockchip-dwmmc")]
 use crate::soc::scmi;
 
+#[cfg(any(feature = "rockchip-dwmmc", test))]
 fn is_scmi_clock_protocol(node: &Node) -> bool {
     node.name().starts_with("protocol@14")
         && node.get_property("reg").and_then(|prop| prop.get_u32()) == Some(0x14)

--- a/drivers/ax-driver/src/block/rockchip/clock.rs
+++ b/drivers/ax-driver/src/block/rockchip/clock.rs
@@ -1,5 +1,20 @@
+#[cfg(feature = "rockchip-dwmmc")]
+use alloc::format;
+
+use fdt_edit::Node;
 use log::info;
-use rdrive::{probe::OnProbeError, register::FdtInfo};
+use rdrive::{
+    probe::{OnProbeError, fdt::ClockRef},
+    register::FdtInfo,
+};
+
+#[cfg(feature = "rockchip-dwmmc")]
+use crate::soc::scmi;
+
+fn is_scmi_clock_protocol(node: &Node) -> bool {
+    node.name().starts_with("protocol@14")
+        && node.get_property("reg").and_then(|prop| prop.get_u32()) == Some(0x14)
+}
 
 /// Enables every non-placeholder clock referenced by the RK3588 DWCMSHC node.
 pub(crate) fn enable_node_clocks(info: &FdtInfo<'_>, label: &str) -> Result<(), OnProbeError> {
@@ -7,6 +22,26 @@ pub(crate) fn enable_node_clocks(info: &FdtInfo<'_>, label: &str) -> Result<(), 
         if clock.select() == Some(0) {
             continue;
         }
+
+        #[cfg(feature = "rockchip-dwmmc")]
+        if let Some(scmi_clock) = ScmiClockOps::from_ref(info, &clock) {
+            scmi_clock.enable().ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] failed to enable SCMI {label} clock {:?} ({:#x})",
+                    info.node.name(),
+                    clock.name,
+                    scmi_clock.clock_id
+                ))
+            })?;
+            info!(
+                "[{}] enabled {label} SCMI clock {:?} ({:#x})",
+                info.node.name(),
+                clock.name,
+                scmi_clock.clock_id
+            );
+            continue;
+        }
+
         let line = info.clock_line(&clock)?;
         line.enable()?;
         info!(
@@ -17,4 +52,59 @@ pub(crate) fn enable_node_clocks(info: &FdtInfo<'_>, label: &str) -> Result<(), 
         );
     }
     Ok(())
+}
+
+#[cfg(feature = "rockchip-dwmmc")]
+pub(crate) struct ScmiClockOps {
+    phandle: fdt_edit::Phandle,
+    clock_id: u32,
+}
+
+#[cfg(feature = "rockchip-dwmmc")]
+impl ScmiClockOps {
+    pub(crate) fn from_ref(info: &FdtInfo<'_>, clock: &ClockRef) -> Option<Self> {
+        let provider = info.get_by_phandle(clock.phandle)?;
+        if !is_scmi_clock_protocol(provider.as_node()) {
+            return None;
+        }
+        Some(Self {
+            phandle: clock.phandle,
+            clock_id: *clock.specifier.first()?,
+        })
+    }
+
+    fn enable(&self) -> Option<()> {
+        scmi::enable_clock(self.phandle, self.clock_id)
+    }
+
+    pub(crate) fn set_rate(&self, rate: u64) -> Option<()> {
+        scmi::set_clock_rate(self.phandle, self.clock_id, rate)
+    }
+
+    pub(crate) fn rate(&self) -> Option<u64> {
+        scmi::clock_rate(self.phandle, self.clock_id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fdt_edit::{Node, Property};
+
+    use super::*;
+
+    #[test]
+    fn identifies_scmi_clock_protocol_provider() {
+        let mut scmi_clock = Node::new("protocol@14");
+        scmi_clock.add_property(Property::new("reg", 0x14_u32.to_be_bytes().to_vec()));
+
+        assert!(is_scmi_clock_protocol(&scmi_clock));
+    }
+
+    #[test]
+    fn does_not_treat_cru_as_scmi_clock_protocol() {
+        let mut cru = Node::new("clock-controller@fd7c0000");
+        cru.add_property(Property::new("reg", 0xfd7c0000_u32.to_be_bytes().to_vec()));
+
+        assert!(!is_scmi_clock_protocol(&cru));
+    }
 }

--- a/drivers/ax-driver/src/block/rockchip/sd/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sd/mod.rs
@@ -29,12 +29,12 @@ use sdmmc_protocol::{
     sdio::{card::SdioSdmmc, init::CardInitPreference},
 };
 
-use super::clock::enable_node_clocks;
+use super::clock::{ScmiClockOps, enable_node_clocks};
 use crate::{block::ProbeFdtBlock, mmio::iomap, soc::RockchipFdtPinctrlParser};
 
 const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
 const ROCKCHIP_DWMMC_CLKGEN_DIV: u32 = 2;
-const ENABLE_SD_SPEED_SELECTION: bool = true;
+const ENABLE_SD_SPEED_SELECTION: bool = false;
 const RK3588_CRU_BASE: usize = 0xfd7c_0000;
 const RK3588_CRU_SIZE: usize = 0x5c000;
 const RK3588_SDMMC_CON0: usize = 0x0c30;
@@ -43,8 +43,9 @@ const RK3588_SDMMC_PHASE_SHIFT: u32 = 1;
 const RK3588_SDMMC_DRV_PHASE_DEG: u32 = 90;
 const RK3588_SDMMC_SAMPLE_PHASE_DEG: u32 = 0;
 
-struct RockchipDwMmcClock {
-    clock: ClockLine,
+enum RockchipDwMmcClock {
+    Rdrive(ClockLine),
+    Scmi(ScmiClockOps),
 }
 
 struct DwMmcClockSetup {
@@ -58,13 +59,24 @@ impl HostClock for RockchipDwMmcClock {
             return Err(Error::InvalidArgument);
         }
         let cclkin = u64::from(target_hz) * u64::from(ROCKCHIP_DWMMC_CLKGEN_DIV);
-        self.clock
-            .set_rate(cclkin)
-            .map_err(|_| Error::BadResponse(ErrorContext::new(Phase::Init)))?;
-        let rate = self
-            .clock
-            .rate()
-            .map_err(|_| Error::BadResponse(ErrorContext::new(Phase::Init)))?;
+        let rate = match self {
+            Self::Rdrive(clock) => {
+                clock
+                    .set_rate(cclkin)
+                    .map_err(|_| Error::BadResponse(ErrorContext::new(Phase::Init)))?;
+                clock
+                    .rate()
+                    .map_err(|_| Error::BadResponse(ErrorContext::new(Phase::Init)))?
+            }
+            Self::Scmi(clock) => {
+                clock
+                    .set_rate(cclkin)
+                    .ok_or_else(|| Error::BadResponse(ErrorContext::new(Phase::Init)))?;
+                clock
+                    .rate()
+                    .ok_or_else(|| Error::BadResponse(ErrorContext::new(Phase::Init)))?
+            }
+        };
         let bus_hz = rate / u64::from(ROCKCHIP_DWMMC_CLKGEN_DIV);
         let bus_hz = validate_bus_clock(bus_hz)?;
         info!(
@@ -269,12 +281,40 @@ fn card_init_preference(info: &FdtInfo<'_>) -> CardInitPreference {
 }
 
 fn dwmmc_clock_setup(info: &FdtInfo<'_>) -> Result<Option<DwMmcClockSetup>, OnProbeError> {
-    let Some(clock) = info.find_clock_line_by_name("ciu")? else {
-        warn!("[{}] ciu clock provider is not available", info.node.name());
+    let Some(clock_ref) = info.find_clk_by_name("ciu") else {
+        warn!(
+            "[{}] ciu clock provider is not available through CRU or SCMI",
+            info.node.name()
+        );
         return Ok(None);
     };
-    clock.set_rate(DWMMC_STABLE_REFERENCE_CLOCK as u64)?;
-    let rate = clock.rate()?;
+    let clock = match ScmiClockOps::from_ref(info, &clock_ref) {
+        Some(clock) => RockchipDwMmcClock::Scmi(clock),
+        None => RockchipDwMmcClock::Rdrive(info.clock_line(&clock_ref)?),
+    };
+    let rate = match &clock {
+        RockchipDwMmcClock::Rdrive(clock) => {
+            clock.set_rate(DWMMC_STABLE_REFERENCE_CLOCK as u64)?;
+            clock.rate()?
+        }
+        RockchipDwMmcClock::Scmi(clock) => {
+            clock
+                .set_rate(DWMMC_STABLE_REFERENCE_CLOCK as u64)
+                .ok_or_else(|| {
+                    OnProbeError::other(format!(
+                        "[{}] failed to set SCMI ciu clock to {} Hz",
+                        info.node.name(),
+                        DWMMC_STABLE_REFERENCE_CLOCK
+                    ))
+                })?;
+            clock.rate().ok_or_else(|| {
+                OnProbeError::other(format!(
+                    "[{}] failed to read SCMI ciu clock rate",
+                    info.node.name()
+                ))
+            })?
+        }
+    };
     let reference_clock = validate_reference_clock(info, rate).ok_or_else(|| {
         OnProbeError::other(format!(
             "[{}] invalid ciu clock rate {rate} Hz",
@@ -283,7 +323,7 @@ fn dwmmc_clock_setup(info: &FdtInfo<'_>) -> Result<Option<DwMmcClockSetup>, OnPr
     })?;
     Ok(Some(DwMmcClockSetup {
         reference_clock,
-        clock: RockchipDwMmcClock { clock },
+        clock,
     }))
 }
 

--- a/drivers/ax-driver/src/soc/mod.rs
+++ b/drivers/ax-driver/src/soc/mod.rs
@@ -16,7 +16,7 @@
 mod fixed_regulator;
 #[cfg(feature = "rockchip-soc")]
 pub(crate) mod rockchip;
-#[cfg(feature = "rk3588-cpufreq")]
+#[cfg(any(feature = "rockchip-dwmmc", feature = "rk3588-cpufreq"))]
 pub mod scmi;
 #[cfg(feature = "starfive-soc")]
 mod starfive;

--- a/os/axvisor/configs/board/orangepi-5-plus.toml
+++ b/os/axvisor/configs/board/orangepi-5-plus.toml
@@ -1,4 +1,5 @@
 features = [
+  "ax-driver/rockchip-dwmmc",
   "ax-driver/rockchip-sdhci",
   "fs",
 ]

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml
@@ -1,4 +1,5 @@
 features = [
+  "ax-driver/rockchip-dwmmc",
   "ax-driver/rockchip-sdhci",
   "fs",
 ]


### PR DESCRIPTION
## 背景

OrangePi 5 Plus 从 SD 卡启动 StarryOS 或 AxVisor 时，SD 控制器`mmc@fe2c0000` 无法完成初始化，最终因找不到根文件系统而启动失败。

设备树中的 DWMMC `ciu` 时钟由 SCMI clock protocol 0x14 提供，而现有驱动只通过 `rdif-clk` 处理普通 CRU 时钟，因此会出现：

```text
clock provider ... has no rdif-clk interface
configured root device was not found in discovered block devices
```

在补充 SCMI 时钟支持后，SD 卡可以识别，但当前高速模式切换流程还会返回`UnsupportedCommand`，导致初始化再次失败。

## 修改内容

- 为 RK3588 DWMMC 增加 SCMI 时钟支持：
  - 识别 SCMI clock protocol 0x14；
  - 支持启用时钟、设置频率和读取实际频率；
  - 普通 CRU 时钟继续使用原有 `ClockLine` 路径。
- `rockchip-dwmmc` feature 增加 `arm-scmi-rs` 依赖。
- SCMI 模块在启用 `rockchip-dwmmc` 时参与编译。
- 暂时关闭当前不受支持的 SD 高速模式切换，使用已经实机验证的稳定初始化路径。
- 在 OrangePi 5 Plus 的 AxVisor构建配置中启用 `rockchip-dwmmc`。
- 增加 SCMI 与普通 CRU 时钟提供者的识别测试。

## 验证结果

在 OrangePi 5 Plus SD 卡环境完成以下验证：

- 原生 StarryOS 能从 SD 根文件系统启动；
- SD 分区能够正常识别并挂载；
- AxVisor 能从 SD 文件系统读取客户机镜像；
- AxVisor 能正常启动 StarryOS 客户机；
- 客户机可以访问 SD 根文件系统中的用户态程序；
- `ax-driver` 单元测试 19 项全部通过；
- Clippy `-D warnings` 检查通过；
- `cargo fmt` 和 `git diff --check` 通过。

## 影响

普通 CRU 时钟路径保持不变。本次修改只在 DWMMC 时钟来自 SCMI 时使用新增路径。

由于暂时不执行 SD 高速模式切换，SD 吞吐能力可能低于高速模式，但能够保证当前
OrangePi 5 Plus 的 StarryOS 和 AxVisor SD 启动稳定完成。
