### PR TITLE
feat(axvisor): add fixed OVMF SEC entry diagnostics for x86_64 UEFI guests

### DIFF
--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -202,9 +202,13 @@ Wiring points to keep aligned:
   `code_size = 0x37c000`, `load_gpa = 0xffc84000`, `reset = 0xfffffff0` only
   when `firmware_profile` is set; `axvmconfig` rejects any profile declared
   with a non-UEFI boot protocol (`FirmwareProfileRequiresUefi`).
-- Guest SEC marker on COM1: `success_regex = ["SecCoreStartupWithStack\\("]`.
-  Reaching the SEC phase proves the nested OVMF executed; it intentionally
-  stops there (stage-1 diagnostics, not a full guest boot).
+- Guest SEC marker on COM1: `success_regex = ["(?s)VCpu\\[0\\] running\\.\\.\\..*SecCoreStartupWithStack"]`.
+  The `VCpu[0] running...` prefix is required: the QEMU-layer host OVMF
+  (injected as pflash to boot the axvisor host binary) prints the same SEC
+  line, so a bare `SecCoreStartupWithStack\(` would match the host firmware
+  instead of the nested guest. Reaching the SEC phase proves the nested OVMF
+  executed; it intentionally stops there (stage-1 diagnostics, not a full
+  guest boot).
 
 Common failures:
 

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -145,7 +145,8 @@ Axvisor x86_64 boots a nested OVMF as the *guest* firmware through the axvm UEFI
 path. The guest firmware is the upstream RELEASE OVMF built by Ostool
 (`edk2-stable202508-r1`, fetched through `cargo xtask ovmf --arch x86_64` into
 the `Source::LATEST` cache); its SHA-256 verification is done by Ostool itself.
-The fixed profile is defined twice and the two copies must stay identical:
+The fixed profile name is defined authoritatively in the axbuild verifier and
+mirrored by the axvm loader; the two copies must stay identical:
 
 | Constant | Value | Defined in |
 | --- | --- | --- |
@@ -217,7 +218,7 @@ Wiring points to keep aligned:
   which never reaches the axvisor device model, so no VM anchor is needed and
   the regex is not subject to the 2048-byte streaming-DFA match window. The
   marker appears early (SEC/PEI), proving the nested OVMF executed; reaching
-  BDS is a stage-2 concern (see the p2 milestone).
+  BDS is not covered by this case.
 
 Common failures:
 

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -139,6 +139,90 @@ execution and then fail only on traps or vCPU exits, so it is not a valid fallba
 - For std/musl targets, derive the initial JSON from a known Rust target where possible, then minimally adjust ABI, linker, relocation model, and soft-float. A `none-softfloat` target passing does not prove musl/std ABI correctness.
 - Prefer runtime memory map data over board constants. Any early helper such as `phys_to_virt` must be valid for the phase where it is called.
 
+## x86_64 Guest OVMF / Fixed OVMF Bundle
+
+Axvisor x86_64 boots a nested OVMF as the *guest* firmware through the axvm UEFI
+path. The guest firmware is a fixed, manifest-verified OVMF build ("the bundle"),
+not whatever OVMF `ostool` happens to have downloaded. The fixed profile is
+defined twice and the two copies must stay identical:
+
+| Constant | Value | Defined in |
+| --- | --- | --- |
+| Profile name | `qemu_x86_64_axvisor_ovmf_debug` | `scripts/axbuild/src/axvisor/ovmf.rs::OVMF_PROFILE_NAME`, `virtualization/axvm/src/arch/x86_64/boot/mod.rs::FIXED_OVMF_PROFILE` |
+| EDK2 tag | `edk2-stable202605` | `scripts/axbuild/src/axvisor/ovmf.rs::OVMF_EDK2_TAG` |
+| CODE GPA / size | `0xffc8_4000` / `0x37_c000` | `OVMF_CODE_BASE` / `OVMF_CODE_SIZE` |
+| VARS GPA / size | `0xffc0_0000` / `0x8_4000` | `OVMF_VARS_BASE` / `OVMF_VARS_SIZE` |
+| Combined `OVMF.fd` size | `0x40_0000` (VARS followed by CODE) | `OVMF_COMBINED_SIZE` |
+| Reset vector | `0xffff_fff0` | `OVMF_RESET_VECTOR` / `FIXED_OVMF_RESET_VECTOR` |
+
+A bundle directory holds `OVMF_CODE.fd`, `OVMF_VARS.fd`, `OVMF.fd` and a flat
+`manifest.toml` (GPA layout, per-file sizes, SHA-256 digests). The verifier in
+`scripts/axbuild/src/axvisor/ovmf.rs` (replacing the deleted
+`os/axvisor/scripts/ovmf-profile.sh`) parses the manifest and verifies every
+value and file against the fixed constants; it never downloads anything. A
+local unverified `OVMF_CODE.fd` is accepted only through the explicit
+`--allow-unverified-firmware` opt-in, must still match the fixed CODE size, and
+has its SHA-256 printed for reference.
+
+Debug commands (KVM hosts; SVM on AMD, VMX on Intel — pick the matching host):
+
+```bash
+cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
+  --test-case ovmf-entry-svm --firmware-bundle-path <bundle-dir>
+cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
+  --test-case ovmf-entry-vmx --firmware-bundle-path <bundle-dir>
+```
+
+Wiring points to keep aligned:
+
+- The case names are exactly `ovmf-entry-svm` / `ovmf-entry-vmx`
+  (`test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-{svm,vmx}.toml`). The
+  `--test-case` filter matches the full case name exactly, while the runner's
+  pflash wiring matches the `ovmf-entry-` prefix (plus an exact
+  case-directory check), so the variant suffix is load-bearing in both layers;
+  a bare `ovmf-entry` is not a valid case name.
+- The QEMU TOML sets `uefi = false`: `-kernel` still boots the Axvisor host
+  (a PE32+ UEFI image), but `uefi = false` keeps `ostool` from downloading its
+  own `edk2-stable202508-r1` OVMF and lets the runner inject the verified
+  bundle instead.
+- The runner injects `-drive if=pflash,format=raw,unit=0,readonly=on,file=<bundle CODE>` and
+  `-drive if=pflash,format=raw,unit=1,file=<bundle VARS copy>` (fresh per run).
+  Without these, QEMU falls through to SeaBIOS and hangs at `Booting from ROM..`.
+- The nested OVMF is loaded by Axvisor itself from the VM config
+  `os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml`: `boot_protocol = "uefi"`,
+  `firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"`,
+  `bios_load_addr = 0xffc8_4000`, `image_location = "fs"` /
+  `kernel_path = "/guest/ovmf/OVMF_CODE.fd"` as the checked-in fallback (fails
+  with a clear error, never silently uses a distro OVMF). With a bundle, the
+  runner rewrites the generated VM config to `image_location = "memory"` and
+  `kernel_path`/`uefi_firmware_path` pointing at the verified CODE, which
+  `os/axvisor/build.rs` embeds via `include_bytes!` — byte-identical to the
+  QEMU-layer pflash CODE.
+- The x86 loader (`virtualization/axvm/src/arch/x86_64/boot/mod.rs`) enforces
+  `code_size = 0x37c000`, `load_gpa = 0xffc84000`, `reset = 0xfffffff0` only
+  when `firmware_profile` is set; `axvmconfig` rejects any profile declared
+  with a non-UEFI boot protocol (`FirmwareProfileRequiresUefi`).
+- Guest SEC marker on COM1: `success_regex = ["SecCoreStartupWithStack\\("]`.
+  Reaching the SEC phase proves the nested OVMF executed; it intentionally
+  stops there (stage-1 diagnostics, not a full guest boot).
+
+Common failures:
+
+- No SEC output at all: wrong CODE layout (GPA/size mismatch, or
+  `bios_load_addr` different from `0xffc84000`), or the run did not get the
+  bundle — pass `--firmware-bundle-path`; without it the case fails fast with
+  an error naming the flag.
+- `uefi = true` trap: the case boots an `ostool`-managed OVMF
+  (`edk2-stable202508-r1`) instead of the verified bundle, so the pinned
+  `edk2-stable202605` layout is not what runs. Keep `uefi = false` and let the
+  runner inject the pflash drives.
+- VM config rejected at load: `bios_load_addr` not `0xffc8_4000`, CODE size
+  mismatch, or `firmware_profile` on a non-UEFI boot protocol — the loader or
+  `axvmconfig` validation errors name the expected value verbatim.
+- The `uefi` group is non-gating: CI runs only the `smoke-svm`/`smoke-vmx`
+  cases from the `normal` group, so validate `ovmf-entry-*` explicitly with
+  `--test-group uefi`.
+
 ## someboot Startup Checklist
 
 Use this order when auditing an early boot port:

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -139,39 +139,44 @@ execution and then fail only on traps or vCPU exits, so it is not a valid fallba
 - For std/musl targets, derive the initial JSON from a known Rust target where possible, then minimally adjust ABI, linker, relocation model, and soft-float. A `none-softfloat` target passing does not prove musl/std ABI correctness.
 - Prefer runtime memory map data over board constants. Any early helper such as `phys_to_virt` must be valid for the phase where it is called.
 
-## x86_64 Guest OVMF / Fixed OVMF Bundle
+## x86_64 Guest OVMF / Verified Upstream Firmware
 
 Axvisor x86_64 boots a nested OVMF as the *guest* firmware through the axvm UEFI
-path. The guest firmware is a fixed, manifest-verified OVMF build ("the bundle"),
-not whatever OVMF `ostool` happens to have downloaded. The fixed profile is
-defined twice and the two copies must stay identical:
+path. The guest firmware is the upstream RELEASE OVMF built by Ostool
+(`edk2-stable202508-r1`, fetched through `cargo xtask ovmf --arch x86_64` into
+the `Source::LATEST` cache); its SHA-256 verification is done by Ostool itself.
+The fixed profile is defined twice and the two copies must stay identical:
 
 | Constant | Value | Defined in |
 | --- | --- | --- |
 | Profile name | `qemu_x86_64_axvisor_ovmf_debug` | `scripts/axbuild/src/axvisor/ovmf.rs::OVMF_PROFILE_NAME`, `virtualization/axvm/src/arch/x86_64/boot/mod.rs::FIXED_OVMF_PROFILE` |
-| EDK2 tag | `edk2-stable202605` | `scripts/axbuild/src/axvisor/ovmf.rs::OVMF_EDK2_TAG` |
 | CODE GPA / size | `0xffc8_4000` / `0x37_c000` | `OVMF_CODE_BASE` / `OVMF_CODE_SIZE` |
 | VARS GPA / size | `0xffc0_0000` / `0x8_4000` | `OVMF_VARS_BASE` / `OVMF_VARS_SIZE` |
-| Combined `OVMF.fd` size | `0x40_0000` (VARS followed by CODE) | `OVMF_COMBINED_SIZE` |
+| Combined size | `0x40_0000` (VARS followed by CODE) | `OVMF_COMBINED_SIZE` |
 | Reset vector | `0xffff_fff0` | `OVMF_RESET_VECTOR` / `FIXED_OVMF_RESET_VECTOR` |
 
-A bundle directory holds `OVMF_CODE.fd`, `OVMF_VARS.fd`, `OVMF.fd` and a flat
-`manifest.toml` (GPA layout, per-file sizes, SHA-256 digests). The verifier in
-`scripts/axbuild/src/axvisor/ovmf.rs` (replacing the deleted
-`os/axvisor/scripts/ovmf-profile.sh`) parses the manifest and verifies every
-value and file against the fixed constants; it never downloads anything. A
-local unverified `OVMF_CODE.fd` is accepted only through the explicit
+The upstream RELEASE layout matches this profile exactly (`code.fd` =
+0x37c000, `vars.fd` = 0x84000, combined 4 MiB, reset vector at 0xfffffff0).
+The verifier in `scripts/axbuild/src/axvisor/ovmf.rs` checks the firmware
+directory layout (both `code.fd` and `vars.fd` present, correct sizes, reset
+vector inside the CODE window); it never downloads anything. A local
+unverified `code.fd` is accepted only through the explicit
 `--allow-unverified-firmware` opt-in, must still match the fixed CODE size, and
 has its SHA-256 printed for reference.
 
 Debug commands (KVM hosts; SVM on AMD, VMX on Intel — pick the matching host):
 
 ```bash
+# prepare the upstream firmware cache first
+cargo xtask ovmf --arch x86_64
 cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
-  --test-case ovmf-entry-svm --firmware-bundle-path <bundle-dir>
+  --test-case ovmf-entry-svm --firmware-bundle-path <ostool-cache-dir>
 cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
-  --test-case ovmf-entry-vmx --firmware-bundle-path <bundle-dir>
+  --test-case ovmf-entry-vmx --firmware-bundle-path <ostool-cache-dir>
 ```
+
+The ostool cache dir is `$TMPDIR/ostool/ovmf/<arch>` (or overridden via
+`TGOS_OVMF_DIR`), holding `code.fd` and `vars.fd`.
 
 Wiring points to keep aligned:
 
@@ -182,44 +187,49 @@ Wiring points to keep aligned:
   case-directory check), so the variant suffix is load-bearing in both layers;
   a bare `ovmf-entry` is not a valid case name.
 - The QEMU TOML sets `uefi = false`: `-kernel` still boots the Axvisor host
-  (a PE32+ UEFI image), but `uefi = false` keeps `ostool` from downloading its
-  own `edk2-stable202508-r1` OVMF and lets the runner inject the verified
-  bundle instead.
-- The runner injects `-drive if=pflash,format=raw,unit=0,readonly=on,file=<bundle CODE>` and
-  `-drive if=pflash,format=raw,unit=1,file=<bundle VARS copy>` (fresh per run).
+  (a PE32+ UEFI image), but `uefi = false` keeps `ostool` from injecting its
+  own FAT ESP and lets the runner inject the verified upstream firmware
+  instead.
+- The runner injects `-drive if=pflash,format=raw,unit=0,readonly=on,file=<code.fd>` and
+  `-drive if=pflash,format=raw,unit=1,file=<vars copy>` (fresh per run).
   Without these, QEMU falls through to SeaBIOS and hangs at `Booting from ROM..`.
 - The nested OVMF is loaded by Axvisor itself from the VM config
   `os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml`: `boot_protocol = "uefi"`,
   `firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"`,
   `bios_load_addr = 0xffc8_4000`, `image_location = "fs"` /
   `kernel_path = "/guest/ovmf/OVMF_CODE.fd"` as the checked-in fallback (fails
-  with a clear error, never silently uses a distro OVMF). With a bundle, the
-  runner rewrites the generated VM config to `image_location = "memory"` and
-  `kernel_path`/`uefi_firmware_path` pointing at the verified CODE, which
+  with a clear error, never silently uses a distro OVMF). With a firmware dir,
+  the runner rewrites the generated VM config to `image_location = "memory"` and
+  `kernel_path`/`uefi_firmware_path` pointing at the verified `code.fd`, which
   `os/axvisor/build.rs` embeds via `include_bytes!` — byte-identical to the
   QEMU-layer pflash CODE.
 - The x86 loader (`virtualization/axvm/src/arch/x86_64/boot/mod.rs`) enforces
   `code_size = 0x37c000`, `load_gpa = 0xffc84000`, `reset = 0xfffffff0` only
   when `firmware_profile` is set; `axvmconfig` rejects any profile declared
   with a non-UEFI boot protocol (`FirmwareProfileRequiresUefi`).
-- Guest SEC marker on COM1: `success_regex = ["(?s)VCpu\\[0\\] running\\.\\.\\..*SecCoreStartupWithStack"]`.
-  The `VCpu[0] running...` prefix is required: the QEMU-layer host OVMF
-  (injected as pflash to boot the axvisor host binary) prints the same SEC
-  line, so a bare `SecCoreStartupWithStack\(` would match the host firmware
-  instead of the nested guest. Reaching the SEC phase proves the nested OVMF
-  executed; it intentionally stops there (stage-1 diagnostics, not a full
-  guest boot).
+- Guest fw_cfg access marker: `success_regex = ["(?m)^.*Nested OVMF fw_cfg accessed"]`.
+  The nested OVMF firmware accesses fw_cfg (PIO 0x510/0x511/0x514) while
+  booting inside the Axvisor guest; every such access is routed through the
+  axvisor device model (`axdevice::fw_cfg::pio::FwCfgPioDevice`), which prints
+  the `Nested OVMF fw_cfg accessed` marker at Info level. The marker is
+  naturally scoped to the nested guest: the QEMU-layer host OVMF (injected as
+  pflash to boot the axvisor host binary) drives fw_cfg inside QEMU itself,
+  which never reaches the axvisor device model, so no VM anchor is needed and
+  the regex is not subject to the 2048-byte streaming-DFA match window. The
+  marker appears early (SEC/PEI), proving the nested OVMF executed; reaching
+  BDS is a stage-2 concern (see the p2 milestone).
 
 Common failures:
 
-- No SEC output at all: wrong CODE layout (GPA/size mismatch, or
+- No fw_cfg marker at all: wrong CODE layout (GPA/size mismatch, or
   `bios_load_addr` different from `0xffc84000`), or the run did not get the
-  bundle — pass `--firmware-bundle-path`; without it the case fails fast with
-  an error naming the flag.
-- `uefi = true` trap: the case boots an `ostool`-managed OVMF
-  (`edk2-stable202508-r1`) instead of the verified bundle, so the pinned
-  `edk2-stable202605` layout is not what runs. Keep `uefi = false` and let the
-  runner inject the pflash drives.
+  firmware — pass `--firmware-bundle-path` pointing at the ostool cache
+  (`$TMPDIR/ostool/ovmf/x64`); without it the case fails fast with an error
+  naming the flag.
+- `uefi = true` trap: the case boots an `ostool`-managed OVMF with a FAT ESP
+  instead of the runner-injected verified firmware, so the pinned layout is
+  not what runs. Keep `uefi = false` and let the runner inject the pflash
+  drives.
 - VM config rejected at load: `bios_load_addr` not `0xffc8_4000`, CODE size
   mismatch, or `firmware_profile` on a non-UEFI boot protocol — the loader or
   `axvmconfig` validation errors name the expected value verbatim.

--- a/docs/docs/architecture/axvisor-guest-machine.md
+++ b/docs/docs/architecture/axvisor-guest-machine.md
@@ -71,6 +71,13 @@ sample_rate = 1000
 - `passthrough`：初始选择平台发现的全部 guest-assignable 物理设备，再移除
   `devices.disabled`、宿主拥有的设备和 machine profile 的虚拟资源。
 
+UEFI guest 通过 `[kernel]` 段的固件字段配置：`boot_protocol = "uefi"`、`uefi_firmware_path`
+（回退到 `bios_path`）、`image_location`（`"fs"` 或 `"memory"`）与 `bios_load_addr`。
+x86_64 的 `firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"` 固定选择已验证的 OVMF
+bundle，x86 loader 据此强制 CODE 布局（`0xffc84000` / size `0x37c000` / reset `0xfffffff0`）；
+`firmware_profile` 与非 UEFI boot 协议同时出现会被 `axvmconfig` 拒绝。示例见
+`configs/vms/qemu/x86_64/ovmf-entry.toml`。
+
 `PhysicalDeviceRef` 是物理设备身份，不是资源描述。第一阶段支持设备树路径；
 后续增加 PCI BDF 或 ACPI 身份时必须继续由平台发现层解析，不能重新暴露裸地址或 IRQ。
 

--- a/docs/docs/architecture/axvisor/overview.md
+++ b/docs/docs/architecture/axvisor/overview.md
@@ -104,14 +104,14 @@ fn main() {
 
 ### 架构适配
 
-`hal/arch/` 提供四套架构适配，每套实现各自架构的虚拟化启用、中断注入和上下文切换。aarch64 和 riscv64 是当前最成熟的两条路径，loongarch64 处于可用状态，x86_64 仍为 stub 占位。
+`hal/arch/` 提供四套架构适配，每套实现各自架构的虚拟化启用、中断注入和上下文切换。aarch64 和 riscv64 是当前最成熟的两条路径，loongarch64 处于可用状态，x86_64 已从 stub 占位推进为可用的 VMX/SVM 路径：虚拟机扩展在运行时按宿主 CPUID 选择（Intel 走 VMX，AMD 走 SVM），并支持以固定 OVMF bundle 作为 UEFI guest 固件，第一阶段 SEC 启动诊断已落地（`ovmf-entry` 用例）。
 
 | 架构 | 虚拟化方式 | 中断注入 |
 | --- | --- | --- |
 | aarch64 | EL2 虚拟化 | GIC 中断注入 |
 | riscv64 | H 扩展 | PLIC 中断注入 |
 | loongarch64 | LVZ 虚拟化 | 中断注入 |
-| x86_64 | stub 占位 | — |
+| x86_64 | VMX / SVM（运行时按 CPUID 选择） | 中断注入（APIC） |
 
 ### 配置驱动的 VM 实例化
 
@@ -149,7 +149,7 @@ AxVisor 的配置体系分为两层：板级配置控制 Hypervisor 本身的构
 | --- | --- |
 | `qemu-aarch64.toml` | AArch64 QEMU（默认推荐） |
 | `qemu-riscv64.toml` | RISC-V 64 QEMU |
-| `qemu-x86_64.toml` | x86_64 QEMU（stub） |
+| `qemu-x86_64.toml` | x86_64 QEMU（VMX / SVM，UEFI guest 经 `ovmf-entry` 用例验证） |
 | `qemu-loongarch64.toml` | LoongArch64 QEMU |
 | `orangepi-5-plus.toml` | Orange Pi 5 Plus (RK3588) |
 | `phytiumpi.toml` | 飞腾派 (E2000) |
@@ -173,6 +173,8 @@ VM 配置定义每个 Guest 的资源分配与运行参数，包括 CPU 数量�
 | `[devices]` | 结构化的 `passthrough` 与 `disabled` 物理设备选择器 |
 
 中断控制器、定时器和固件接口由架构创建；默认串口优先由 host FDT/ACPI 派生并以 machine profile 兜底。普通虚拟设备通过 `[[devices.virtual]]` 的 `id + model + options` 交给代码 catalog 创建 dyn model，`console0` 可按 ID 覆盖型号和语义参数，但配置始终不填写地址或中断号。`virtualized` 客户机只映射显式选择的物理设备；`passthrough` 客户机默认选择全部 guest-assignable 物理设备，再按最终解析后设备图为 RAM、禁用设备、宿主物理 UART、host replacement 和虚拟设备打洞。配置不接受旧 `vm_type`、`emu_devices`、裸地址/IRQ 或 `interrupt_mode` 字段。
+
+x86_64 的 UEFI guest 通过 `[kernel]` 段的固件字段声明：`boot_protocol = "uefi"`、`uefi_firmware_path`（回退到 `bios_path`）、`image_location`（`"fs"` 或 `"memory"`）与 `bios_load_addr`。`firmware_profile` 字段固定选择已验证的 OVMF bundle（`qemu_x86_64_axvisor_ovmf_debug`），此时 x86 loader 强制 CODE 布局：`code_size = 0x37c000`、`bios_load_addr = 0xffc84000`、入口 `0xfffffff0`；`firmware_profile` 与非 UEFI boot 协议同时出现会被 `axvmconfig` 拒绝。示例见 `configs/vms/qemu/x86_64/ovmf-entry.toml` 与 [Axvisor 测试](/docs/build/axvisor/test) 的 UEFI 分组说明。
 
 ## 关键执行流程
 

--- a/docs/docs/architecture/axvisor/overview.md
+++ b/docs/docs/architecture/axvisor/overview.md
@@ -104,7 +104,7 @@ fn main() {
 
 ### 架构适配
 
-`hal/arch/` 提供四套架构适配，每套实现各自架构的虚拟化启用、中断注入和上下文切换。aarch64 和 riscv64 是当前最成熟的两条路径，loongarch64 处于可用状态，x86_64 已从 stub 占位推进为可用的 VMX/SVM 路径：虚拟机扩展在运行时按宿主 CPUID 选择（Intel 走 VMX，AMD 走 SVM），并支持以固定 OVMF bundle 作为 UEFI guest 固件，第一阶段 SEC 启动诊断已落地（`ovmf-entry` 用例）。
+`hal/arch/` 提供四套架构适配，每套实现各自架构的虚拟化启用、中断注入和上下文切换。aarch64 和 riscv64 是当前最成熟的两条路径，loongarch64 处于可用状态，x86_64 已从 stub 占位推进为可用的 VMX/SVM 路径：虚拟机扩展在运行时按宿主 CPUID 选择（Intel 走 VMX，AMD 走 SVM），并支持以上游 RELEASE OVMF（ostool 缓存）作为 UEFI guest 固件，嵌套固件启动诊断已落地（`ovmf-entry` 用例，以 fw_cfg 访问 marker 判定）。
 
 | 架构 | 虚拟化方式 | 中断注入 |
 | --- | --- | --- |

--- a/docs/docs/architecture/platform/testing.md
+++ b/docs/docs/architecture/platform/testing.md
@@ -42,6 +42,13 @@ cargo xtask starry test qemu --arch riscv64
 cargo xtask axvisor test qemu --arch x86_64 --test-group normal
 ```
 
+x86_64 Axvisor 的 UEFI 固件入口调试走 `uefi` 分组（需 `--firmware-bundle-path`，见 [Axvisor 测试](/docs/build/axvisor/test)）：
+
+```bash
+cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
+  --test-case ovmf-entry-svm --firmware-bundle-path <bundle 目录>
+```
+
 外部平台只有在补齐启动入口、链接脚本、console、timer、内存和 IRQ 后，才应宣称可启动 QEMU。
 
 ## 常见失败信号

--- a/docs/docs/build/axvisor/test.md
+++ b/docs/docs/build/axvisor/test.md
@@ -129,15 +129,16 @@ flowchart TD
 
 该模式验证完整的"U-Boot → Axvisor → Guest"引导链路，覆盖真实硬件上 U-Boot 加载 Axvisor ELF、Axvisor 初始化硬件虚拟化扩展、再启动 Guest 的全流程。
 
-### 3.3 UEFI 分组与固定 OVMF bundle
+### 3.3 UEFI 分组与上游 RELEASE OVMF
 
-`test-suit/axvisor/uefi/ovmf-entry/` 承载 x86_64 的固定 OVMF 固件诊断用例（两个变体 `ovmf-entry-vmx` 与 `ovmf-entry-svm`，按宿主 CPU 的 VMX/SVM 能力分别选择）。该用例以 `-kernel` 启动 Axvisor 宿主，再由 Axvisor 把嵌套 OVMF 作为 UEFI guest 固件加载；`success_regex` 以 `(?s)VCpu[0] running...` 锚定嵌套 VM 后匹配 `SecCoreStartupWithStack`（guest COM1 输出），表示嵌套固件已进入 SEC 阶段。前缀锚定是必需的：QEMU 层为引导 Axvisor 宿主而注入的 pflash OVMF 会输出相同的 SEC 行，裸 `SecCoreStartupWithStack\(` 会误匹配宿主固件。该用例是阶段 1 的 SEC 启动诊断，而非完整 guest boot。
+`test-suit/axvisor/uefi/ovmf-entry/` 承载 x86_64 的上游 RELEASE OVMF 固件诊断用例（两个变体 `ovmf-entry-vmx` 与 `ovmf-entry-svm`，按宿主 CPU 的 VMX/SVM 能力分别选择）。该用例以 `-kernel` 启动 Axvisor 宿主，再由 Axvisor 把嵌套 OVMF 作为 UEFI guest 固件加载；`success_regex` 匹配设备模型打印的 `Nested OVMF fw_cfg accessed` marker（Info 级，见下方接线要点），表示嵌套固件已启动并访问 fw_cfg。该 marker 天然只属嵌套 guest：QEMU 层为引导 Axvisor 宿主而注入的 pflash OVMF 的 fw_cfg 访问发生在 QEMU 内部，不经过 axvisor 设备模型，因此无需 VM 前缀锚定。该用例是嵌套固件启动诊断，而非完整 guest boot。
 
 ```bash
+cargo xtask ovmf --arch x86_64   # 先准备上游 RELEASE 固件缓存($TMPDIR/ostool/ovmf/x64)
 cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
-  --test-case ovmf-entry-svm --firmware-bundle-path <bundle 目录>
+  --test-case ovmf-entry-svm --firmware-bundle-path $TMPDIR/ostool/ovmf/x64
 cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
-  --test-case ovmf-entry-vmx --firmware-bundle-path <bundle 目录>
+  --test-case ovmf-entry-vmx --firmware-bundle-path $TMPDIR/ostool/ovmf/x64
 ```
 
 接线要点（与替换实现一致）：

--- a/docs/docs/build/axvisor/test.md
+++ b/docs/docs/build/axvisor/test.md
@@ -131,7 +131,7 @@ flowchart TD
 
 ### 3.3 UEFI 分组与固定 OVMF bundle
 
-`test-suit/axvisor/uefi/ovmf-entry/` 承载 x86_64 的固定 OVMF 固件诊断用例（两个变体 `ovmf-entry-vmx` 与 `ovmf-entry-svm`，按宿主 CPU 的 VMX/SVM 能力分别选择）。该用例以 `-kernel` 启动 Axvisor 宿主，再由 Axvisor 把嵌套 OVMF 作为 UEFI guest 固件加载；`success_regex = ["SecCoreStartupWithStack\\("]` 表示嵌套固件已进入 SEC 阶段（guest COM1 输出），它是阶段 1 的 SEC 启动诊断，而非完整 guest boot。
+`test-suit/axvisor/uefi/ovmf-entry/` 承载 x86_64 的固定 OVMF 固件诊断用例（两个变体 `ovmf-entry-vmx` 与 `ovmf-entry-svm`，按宿主 CPU 的 VMX/SVM 能力分别选择）。该用例以 `-kernel` 启动 Axvisor 宿主，再由 Axvisor 把嵌套 OVMF 作为 UEFI guest 固件加载；`success_regex` 以 `(?s)VCpu[0] running...` 锚定嵌套 VM 后匹配 `SecCoreStartupWithStack`（guest COM1 输出），表示嵌套固件已进入 SEC 阶段。前缀锚定是必需的：QEMU 层为引导 Axvisor 宿主而注入的 pflash OVMF 会输出相同的 SEC 行，裸 `SecCoreStartupWithStack\(` 会误匹配宿主固件。该用例是阶段 1 的 SEC 启动诊断，而非完整 guest boot。
 
 ```bash
 cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \

--- a/docs/docs/build/axvisor/test.md
+++ b/docs/docs/build/axvisor/test.md
@@ -19,18 +19,30 @@ cargo xtask axvisor test uboot --board <type> [--guest <image>] [--uboot-config 
 cargo xtask axvisor test board --board <type> --server <h> --port <p> [--test-case <c>] [--list]
 ```
 
+`test qemu` 另有固件相关参数（仅 UEFI 分组用例需要，见 §3.3）：
+
+```text
+cargo xtask axvisor test qemu [--firmware-bundle-path <dir>] [--allow-unverified-firmware]
+```
+
 ## 2. 用例发现
 
 Axvisor 测试资产位于：
 
 ```text
 test-suit/axvisor/
-└── normal/
-    └── <case>/
-        └── qemu-{arch}.toml
+├── normal/
+│   └── <case>/
+│       └── qemu-{arch}.toml
+└── uefi/
+    └── ovmf-entry/
+        ├── qemu-x86_64-vmx.toml
+        ├── qemu-x86_64-svm.toml
+        ├── build-x86_64-unknown-none-vmx.toml
+        └── build-x86_64-unknown-none-svm.toml
 ```
 
-与 StarryOS 的平铺结构不同，Axvisor 用 `normal` 测试组目录组织用例。发现算法统一通过 `build-{target}.toml` 定位构建组、`qemu-{arch}.toml` 定位用例。
+与 StarryOS 的平铺结构不同，Axvisor 用分组目录（`normal`、`uefi`）组织用例，默认组为 `normal`，通过 `--test-group <g>` 切换。发现算法统一通过 `build-{target}.toml` 定位构建组、`qemu-{arch}.toml` 定位用例。
 
 ## 3. 运行模式
 
@@ -74,7 +86,7 @@ flowchart TD
 
 | 步骤 | 源码位置 | 行为 |
 |------|----------|------|
-| 用例发现 | `discovery.rs::discover_qemu_cases()` | 扫描 `test-suit/axvisor/<group>/`，默认 group 为 `normal` |
+| 用例发现 | `discovery.rs::discover_qemu_cases()` | 扫描 `test-suit/axvisor/<group>/`，默认 group 为 `normal`，可通过 `--test-group uefi` 切换 |
 | VM 配置 | `qemu_group_build_context()` | 读取 axbuild 已解析并写入 `AXVISOR_VM_CONFIGS` 的 VM 配置路径 |
 | rootfs 准备 | `rootfs::ensure_qemu_rootfs_ready()` | 每个 build group 编译前准备当前 arch 的 managed rootfs |
 | grouped 校验 | `validate_grouped_qemu_commands()` | 检查 `test_commands` 无空命令 |
@@ -117,7 +129,27 @@ flowchart TD
 
 该模式验证完整的"U-Boot → Axvisor → Guest"引导链路，覆盖真实硬件上 U-Boot 加载 Axvisor ELF、Axvisor 初始化硬件虚拟化扩展、再启动 Guest 的全流程。
 
-### 3.3 板卡测试
+### 3.3 UEFI 分组与固定 OVMF bundle
+
+`test-suit/axvisor/uefi/ovmf-entry/` 承载 x86_64 的固定 OVMF 固件诊断用例（两个变体 `ovmf-entry-vmx` 与 `ovmf-entry-svm`，按宿主 CPU 的 VMX/SVM 能力分别选择）。该用例以 `-kernel` 启动 Axvisor 宿主，再由 Axvisor 把嵌套 OVMF 作为 UEFI guest 固件加载；`success_regex = ["SecCoreStartupWithStack\\("]` 表示嵌套固件已进入 SEC 阶段（guest COM1 输出），它是阶段 1 的 SEC 启动诊断，而非完整 guest boot。
+
+```bash
+cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
+  --test-case ovmf-entry-svm --firmware-bundle-path <bundle 目录>
+cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
+  --test-case ovmf-entry-vmx --firmware-bundle-path <bundle 目录>
+```
+
+接线要点（与任务 1/2/4 实现一致）：
+
+- **固定 profile**：`scripts/axbuild/src/axvisor/ovmf.rs` 定义 profile 名 `qemu_x86_64_axvisor_ovmf_debug`（EDK2 tag `edk2-stable202605`）及固定布局：CODE `0xffc84000`（size `0x37c000`，reset vector `0xfffffff0`）、VARS `0xffc00000`（size `0x84000`）、combined `0x400000`。bundle 目录含 `OVMF_CODE.fd`、`OVMF_VARS.fd`、`OVMF.fd` 与 `manifest.toml`，全部按 manifest 校验，不联网下载。
+- **`--firmware-bundle-path <dir>`**：指定已验证 bundle 目录（含 `manifest.toml`）。`--allow-unverified-firmware` 允许本地未验证的 `OVMF_CODE.fd`（仅打印 SHA-256 供参考，不参与结果判定）。不带 bundle 时 ovmf-entry 用例在 prepare 阶段 fail-fast 报错，不会在 `Booting from ROM..` 挂起，也不会静默使用发行版 OVMF；`--list` 不需要 bundle。
+- **QEMU 层 `uefi = false`**：避免 ostool 下载自带 OVMF（`edk2-stable202508-r1`）。runner 注入 pflash unit 0（只读 CODE，已验证文件）与 unit 1（每次运行新建的 VARS 副本），`-kernel` 启动 Axvisor 宿主。
+- **嵌套 OVMF**：VM 配置 `os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml` 声明 `guest_type = "passthrough"`、`boot_protocol = "uefi"`、`bios_load_addr = 0xffc84000`、`firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"`。默认 `image_location = "fs"` + `kernel_path = "/guest/ovmf/OVMF_CODE.fd"`（文件不存在时报错，是显式 fallback）；有 bundle 时 runner 改写为 `image_location = "memory"` 并经 `include_bytes!` 嵌入已验证 CODE，与 QEMU 层 pflash 的 CODE 逐字节一致。
+- **loader 强制校验**：`firmware_profile` 启用时，x86 loader（`virtualization/axvm/src/arch/x86_64/boot/mod.rs`）强制 `code_size = 0x37c000`、`bios_load_addr = 0xffc84000`、reset `0xfffffff0`；`axvmconfig` 拒绝非 UEFI boot 协议声明 profile。
+- **non-gating**：`uefi` 分组天然不纳入 CI gating。CI 的 x86_64 行只运行 `smoke-svm`/`smoke-vmx`（`normal` 组），`ovmf-entry-*` 需在本地显式用 `--test-group uefi` 验证。
+
+### 3.4 板卡测试
 
 板级测试通过 `board-{board_name}.toml` 配置文件定义。执行链位于 `axvisor/test/board.rs::test_board()`，使用 `BoardTestRunState` 逐 group 运行并收集结果（与 QEMU 测试的 `QemuTestSummary` 类似）。
 

--- a/docs/docs/build/axvisor/test.md
+++ b/docs/docs/build/axvisor/test.md
@@ -140,13 +140,14 @@ cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
   --test-case ovmf-entry-vmx --firmware-bundle-path <bundle 目录>
 ```
 
-接线要点（与任务 1/2/4 实现一致）：
+接线要点（与替换实现一致）：
 
-- **固定 profile**：`scripts/axbuild/src/axvisor/ovmf.rs` 定义 profile 名 `qemu_x86_64_axvisor_ovmf_debug`（EDK2 tag `edk2-stable202605`）及固定布局：CODE `0xffc84000`（size `0x37c000`，reset vector `0xfffffff0`）、VARS `0xffc00000`（size `0x84000`）、combined `0x400000`。bundle 目录含 `OVMF_CODE.fd`、`OVMF_VARS.fd`、`OVMF.fd` 与 `manifest.toml`，全部按 manifest 校验，不联网下载。
-- **`--firmware-bundle-path <dir>`**：指定已验证 bundle 目录（含 `manifest.toml`）。`--allow-unverified-firmware` 允许本地未验证的 `OVMF_CODE.fd`（仅打印 SHA-256 供参考，不参与结果判定）。不带 bundle 时 ovmf-entry 用例在 prepare 阶段 fail-fast 报错，不会在 `Booting from ROM..` 挂起，也不会静默使用发行版 OVMF；`--list` 不需要 bundle。
-- **QEMU 层 `uefi = false`**：避免 ostool 下载自带 OVMF（`edk2-stable202508-r1`）。runner 注入 pflash unit 0（只读 CODE，已验证文件）与 unit 1（每次运行新建的 VARS 副本），`-kernel` 启动 Axvisor 宿主。
-- **嵌套 OVMF**：VM 配置 `os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml` 声明 `guest_type = "passthrough"`、`boot_protocol = "uefi"`、`bios_load_addr = 0xffc84000`、`firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"`。默认 `image_location = "fs"` + `kernel_path = "/guest/ovmf/OVMF_CODE.fd"`（文件不存在时报错，是显式 fallback）；有 bundle 时 runner 改写为 `image_location = "memory"` 并经 `include_bytes!` 嵌入已验证 CODE，与 QEMU 层 pflash 的 CODE 逐字节一致。
+- **固定 profile**：`scripts/axbuild/src/axvisor/ovmf.rs` 定义 profile 名 `qemu_x86_64_axvisor_ovmf_debug` 及固定布局：CODE `0xffc84000`（size `0x37c000`，reset vector `0xfffffff0`）、VARS `0xffc00000`（size `0x84000`）、combined `0x400000`。固件目录（ostool cache）含 `code.fd` 与 `vars.fd`，布局按固定常量校验，SHA-256 由 ostool 校验，不联网下载。
+- **`--firmware-bundle-path <dir>`**：指定上游固件目录（ostool cache，含 `code.fd`/`vars.fd`）。`--allow-unverified-firmware` 允许本地未验证的 `code.fd`（仅打印 SHA-256 供参考，不参与结果判定）。不带固件目录时 ovmf-entry 用例在 prepare 阶段 fail-fast 报错，不会在 `Booting from ROM..` 挂起，也不会静默使用发行版 OVMF；`--list` 不需要固件。
+- **QEMU 层 `uefi = false`**：避免 ostool 注入自带 FAT ESP。runner 注入 pflash unit 0（只读 CODE，已验证文件）与 unit 1（每次运行新建的 VARS 副本），`-kernel` 启动 Axvisor 宿主。
+- **嵌套 OVMF**：VM 配置 `os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml` 声明 `guest_type = "passthrough"`、`boot_protocol = "uefi"`、`bios_load_addr = 0xffc84000`、`firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"`。默认 `image_location = "fs"` + `kernel_path = "/guest/ovmf/OVMF_CODE.fd"`（文件不存在时报错，是显式 fallback）；有固件目录时 runner 改写为 `image_location = "memory"` 并经 `include_bytes!` 嵌入已验证 CODE，与 QEMU 层 pflash 的 CODE 逐字节一致。
 - **loader 强制校验**：`firmware_profile` 启用时，x86 loader（`virtualization/axvm/src/arch/x86_64/boot/mod.rs`）强制 `code_size = 0x37c000`、`bios_load_addr = 0xffc84000`、reset `0xfffffff0`；`axvmconfig` 拒绝非 UEFI boot 协议声明 profile。
+- **成功判据**：`success_regex = ["(?m)^.*Nested OVMF fw_cfg accessed"]`。嵌套 OVMF 固件启动早期访问 fw_cfg（PIO 0x510/0x511/0x514），经 axvisor 设备模型打印 `Nested OVMF fw_cfg accessed` marker（Info 级）。marker 天然只属嵌套 guest（宿主 OVMF 的 fw_cfg 访问在 QEMU 层，不经过 axvisor 设备模型），无需 VM 锚定，不受 2048 字节匹配窗口限制。
 - **non-gating**：`uefi` 分组天然不纳入 CI gating。CI 的 x86_64 行只运行 `smoke-svm`/`smoke-vmx`（`normal` 组），`ovmf-entry-*` 需在本地显式用 `--test-group uefi` 验证。
 
 ### 3.4 板卡测试

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -131,6 +131,8 @@ push 到 `main` / `dev` 时强制运行 CI 检查。非 `main` / `dev` 分支没
 
 StarryOS stress 测试条目保留在 workflow 中，但当前处于注释状态。启用后仅用于 target 为 `main` 的 PR。
 
+x86_64 的 `uefi` 测试组（`ovmf-entry-vmx`/`ovmf-entry-svm`，需 `--firmware-bundle-path`）天然 non-gating，不进入 CI 矩阵，需在本地显式验证。
+
 ## Self-Hosted Runner 约定
 
 self-hosted runner 任务优先在 `rcore-os` 仓库内运行。带 `self_hosted_owner` 的任务在 fork PR 或非 `rcore-os` 仓库中会回退到 `ubuntu-latest` + 对应容器，避免没有对应 runner 时长时间排队。迁移到 self-hosted 的任务直接在原生 runner 环境中运行，不再套 Docker container。

--- a/os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml
@@ -1,0 +1,69 @@
+# Fixed OVMF entry diagnostics: boot a nested OVMF CODE image through Axvisor.
+#
+# `image_location = "fs"` with the `/guest/ovmf/OVMF_CODE.fd` paths is the
+# checked-in fallback used when no `--firmware-bundle-path` is supplied: the
+# file is absent from the Axvisor rootfs, so the VM fails to initialize with a
+# clear error instead of silently booting a distro OVMF.
+#
+# When `--firmware-bundle-path` is passed, the axbuild runner rewrites this
+# template into a per-run VM config with `image_location = "memory"` and
+# `kernel_path`/`uefi_firmware_path` pointing at the manifest-verified CODE
+# file, which `os/axvisor/build.rs` embeds with `include_bytes!`. The same
+# verified CODE is injected as the QEMU-layer pflash (unit 0) so the host
+# Axvisor binary can be loaded by QEMU `-kernel` at all; both firmware layers
+# use the identical verified file.
+#
+# The layout below is the fixed `qemu_x86_64_axvisor_ovmf_debug` profile:
+# CODE at 0xffc8_4000 (size 0x37c000, reset vector 0xffff_fff0), VARS window
+# at 0xffc0_0000, covered by the 4 MiB memory region below.
+#
+[base]
+# Guest vm id.
+id = 1
+# Guest vm name.
+name = "ovmf-entry"
+# Virtualization type.
+guest_type = "passthrough"
+# The number of virtual CPUs.
+cpu_num = 1
+# Guest vm physical cpu sets.
+phys_cpu_sets = [1]
+
+#
+# Vm kernel configs
+#
+[kernel]
+# The entry point of the UEFI firmware reset vector.
+entry_point = 0xffff_fff0
+# The location of image: "memory" | "fs".
+image_location = "fs"
+# The file path of the UEFI firmware CODE image.
+kernel_path = "/guest/ovmf/OVMF_CODE.fd"
+# The load address of the guest image.
+kernel_load_addr = 0x20_0000
+# Enable external firmware image loading.
+enable_bios = true
+# Select UEFI firmware flow instead of the legacy axvm-bios multiboot trampoline.
+boot_protocol = "uefi"
+# The file path of the UEFI firmware image, for example OVMF_CODE.fd.
+uefi_firmware_path = "/guest/ovmf/OVMF_CODE.fd"
+# Fixed OVMF CODE layout enforced by the axvm x86_64 loader.
+bios_load_addr = 0xffc8_4000
+# The fixed firmware profile matching the verified OVMF bundle.
+firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"
+
+# Memory regions with format (`base_paddr`, `size`, `flags`, `map_type`).
+# For `map_type`, 0 means `MAP_ALLOC`, 1 means `MAP_IDENTICAL`, 2 means `MAP_RESERVED`.
+memory_regions = [
+  [0x0000_0000, 0x100_0000, 0x7, 0], # Low RAM 16M 0b111 R|W|EXECUTE
+  [0xffc0_0000, 0x40_0000, 0x7, 0], # UEFI firmware window 4M (VARS + CODE)
+]
+
+#
+# Device specifications
+#
+
+# Physical-device selection. Virtual platform devices are machine-owned.
+[devices]
+passthrough = []
+disabled = []

--- a/os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml
@@ -7,11 +7,11 @@
 #
 # When `--firmware-bundle-path` is passed, the axbuild runner rewrites this
 # template into a per-run VM config with `image_location = "memory"` and
-# `kernel_path`/`uefi_firmware_path` pointing at the manifest-verified CODE
-# file, which `os/axvisor/build.rs` embeds with `include_bytes!`. The same
-# verified CODE is injected as the QEMU-layer pflash (unit 0) so the host
-# Axvisor binary can be loaded by QEMU `-kernel` at all; both firmware layers
-# use the identical verified file.
+# `kernel_path`/`uefi_firmware_path` pointing at the verified upstream firmware
+# (the ostool cache `code.fd`), which `os/axvisor/build.rs` embeds with
+# `include_bytes!`. The same verified CODE is injected as the QEMU-layer pflash
+# (unit 0) so the host Axvisor binary can be loaded by QEMU `-kernel` at all;
+# both firmware layers use the identical verified file.
 #
 # The layout below is the fixed `qemu_x86_64_axvisor_ovmf_debug` profile:
 # CODE at 0xffc8_4000 (size 0x37c000, reset vector 0xffff_fff0), VARS window

--- a/scripts/axbuild/src/axvisor/mod.rs
+++ b/scripts/axbuild/src/axvisor/mod.rs
@@ -13,6 +13,7 @@ use crate::context::{
 pub mod board;
 pub mod build;
 pub mod config;
+pub mod ovmf;
 pub mod rootfs;
 pub mod test;
 
@@ -156,6 +157,19 @@ pub struct ArgsTestQemu {
     pub test_case: Option<String>,
     #[arg(short = 'l', long, help = "List discovered Axvisor QEMU test cases")]
     pub list: bool,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Path to a verified OVMF firmware bundle directory (must contain manifest.toml) or \
+                an unverified local firmware file (requires --allow-unverified-firmware)"
+    )]
+    pub firmware_bundle_path: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Accept an unverified local firmware file; its SHA-256 is printed for reference \
+                and it must not determine UEFI test results"
+    )]
+    pub allow_unverified_firmware: bool,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -564,6 +578,42 @@ mod tests {
                     assert_eq!(args.arch.as_deref(), Some("aarch64"));
                     assert_eq!(args.test_group.as_deref(), Some("normal"));
                     assert_eq!(args.test_case.as_deref(), Some("smoke"));
+                }
+                _ => panic!("expected qemu test command"),
+            },
+            _ => panic!("expected test command"),
+        }
+    }
+
+    #[test]
+    fn command_parses_test_qemu_firmware_flags() {
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: Command,
+        }
+
+        let cli = Cli::try_parse_from([
+            "axvisor",
+            "test",
+            "qemu",
+            "--arch",
+            "x86_64",
+            "--firmware-bundle-path",
+            "ovmf-bundle",
+            "--allow-unverified-firmware",
+        ])
+        .unwrap();
+
+        match cli.command {
+            Command::Test(args) => match args.command {
+                TestCommand::Qemu(args) => {
+                    assert_eq!(args.arch.as_deref(), Some("x86_64"));
+                    assert_eq!(
+                        args.firmware_bundle_path,
+                        Some(PathBuf::from("ovmf-bundle"))
+                    );
+                    assert!(args.allow_unverified_firmware);
                 }
                 _ => panic!("expected qemu test command"),
             },

--- a/scripts/axbuild/src/axvisor/mod.rs
+++ b/scripts/axbuild/src/axvisor/mod.rs
@@ -160,8 +160,9 @@ pub struct ArgsTestQemu {
     #[arg(
         long,
         value_name = "PATH",
-        help = "Path to a verified OVMF firmware bundle directory (must contain manifest.toml) or \
-                an unverified local firmware file (requires --allow-unverified-firmware)"
+        help = "Path to an upstream OVMF firmware directory holding code.fd and vars.fd (the \
+                ostool cache) or an unverified local firmware file (requires \
+                --allow-unverified-firmware)"
     )]
     pub firmware_bundle_path: Option<PathBuf>,
     #[arg(

--- a/scripts/axbuild/src/axvisor/ovmf.rs
+++ b/scripts/axbuild/src/axvisor/ovmf.rs
@@ -1,21 +1,23 @@
-//! Verified OVMF firmware bundle handling for x86_64 AxVisor UEFI tests.
+//! Verified OVMF firmware handling for x86_64 AxVisor UEFI tests.
 //!
-//! A fixed OVMF build is distributed as a "bundle": a directory holding
-//! `OVMF_CODE.fd`, `OVMF_VARS.fd`, `OVMF.fd` and a flat `manifest.toml`
-//! describing the expected profile, GPA layout and per-file sizes and
-//! SHA-256 digests. This module replaces the old
-//! `os/axvisor/scripts/ovmf-profile.sh` verifier: it parses the manifest
-//! with the typed `toml` crate and verifies every value and every file
-//! against the fixed profile constants.
+//! The ovmf-entry case boots the upstream RELEASE OVMF built by Ostool
+//! (`edk2-stable202508-r1`). The firmware is fetched through the Ostool
+//! `Source::LATEST` cache (a directory holding `code.fd` and `vars.fd`), whose
+//! SHA-256 verification is done by Ostool itself; this module validates the
+//! layout of that firmware against the fixed x86_64 profile constants. The
+//! layout matches the checked-in `qemu_x86_64_axvisor_ovmf_debug` profile
+//! (code at 0xffc8_4000, vars at 0xffc0_0000, combined 4 MiB, reset vector at
+//! 0xffff_fff0), which the x86_64 guest loader still enforces.
 //!
-//! Firmware that is not part of a managed bundle (for example a local
-//! `OVMF_CODE.fd` supplied by the developer) is only accepted through an
-//! explicit opt-in; it must still match the fixed CODE size and its SHA-256
-//! digest is printed so the caller can see exactly what was used.
+//! Firmware that is not part of the Ostool cache (for example a local
+//! `code.fd` supplied by the developer) is only accepted through an explicit
+//! opt-in; it must still match the fixed CODE size and its SHA-256 digest is
+//! printed so the caller can see exactly what was used.
 //!
-//! Verification never downloads anything. If a bundle directory is missing,
-//! the caller is expected to pull it first through the image registry; this
-//! module only validates a bundle that is already present on disk.
+//! Verification never downloads anything. If the firmware directory is
+//! missing, the caller is expected to prepare the Ostool cache first (for
+//! example through `cargo xtask ovmf`); this module only validates firmware
+//! that is already present on disk.
 
 use std::{
     fs,
@@ -23,19 +25,22 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow, bail};
-use serde::Deserialize;
 
 use crate::support::download::file_sha256;
 
-/// Fixed x86_64 guest firmware profile name, also the image registry entry
-/// name under which the managed bundle is published.
+/// File name of the upstream RELEASE code image inside an Ostool firmware
+/// directory.
+pub const UPSTREAM_CODE_FILE: &str = "code.fd";
+
+/// File name of the upstream RELEASE variable store inside an Ostool firmware
+/// directory.
+pub const UPSTREAM_VARS_FILE: &str = "vars.fd";
+
+/// Fixed x86_64 guest firmware profile name, matching the profile enforced by
+/// the x86_64 guest loader (`FIXED_OVMF_PROFILE` in `axvm`) and written into
+/// the generated ovmf-entry VM config. The upstream RELEASE layout matches
+/// this profile exactly.
 pub const OVMF_PROFILE_NAME: &str = "qemu_x86_64_axvisor_ovmf_debug";
-
-/// EDK2 tag the fixed bundle was built from.
-pub const OVMF_EDK2_TAG: &str = "edk2-stable202605";
-
-/// EDK2 commit the fixed bundle was built from.
-pub const OVMF_EDK2_COMMIT: &str = "b03a21a63e3bd001f52c527e5a57feddb53a690b";
 
 /// Guest physical address of the start of the CODE (firmware text) region.
 pub const OVMF_CODE_BASE: u64 = 0xffc8_4000;
@@ -56,37 +61,30 @@ pub const OVMF_COMBINED_SIZE: u64 = 0x40_0000;
 /// the CODE window.
 pub const OVMF_RESET_VECTOR: u64 = 0xffff_fff0;
 
-/// CODE image file name inside a managed bundle.
-pub const CODE_FILE: &str = "OVMF_CODE.fd";
-
-/// VARS image file name inside a managed bundle.
-pub const VARS_FILE: &str = "OVMF_VARS.fd";
-
-/// Combined image file name inside a managed bundle.
-pub const COMBINED_FILE: &str = "OVMF.fd";
-
-/// Flat manifest file name inside a managed bundle.
-pub const MANIFEST_FILE: &str = "manifest.toml";
-
 /// Where a firmware image came from.
 ///
-/// The enum keeps the "verified managed bundle" and "explicit unverified
-/// local file" cases distinct so callers cannot accidentally mix the two:
-/// the two paths carry different semantics (manifest verification vs. a
-/// printed digest) and different CLI requirements (opt-in).
+/// The enum keeps the "upstream RELEASE firmware" and "explicit unverified
+/// local file" cases distinct so callers cannot accidentally mix the two: the
+/// two paths carry different semantics (layout verification vs. a printed
+/// digest) and different CLI requirements (opt-in).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FirmwareSource {
-    /// A managed, manifest-verified OVMF bundle directory.
-    Managed { bundle_dir: PathBuf },
+    /// An upstream RELEASE firmware directory holding `code.fd` and
+    /// `vars.fd`, as produced by the Ostool cache.
+    Upstream {
+        code_path: PathBuf,
+        vars_path: PathBuf,
+    },
     /// A local firmware file accepted only through an explicit opt-in.
     UnverifiedLocal { code_path: PathBuf },
 }
 
 impl FirmwareSource {
-    /// Construct a [`FirmwareSource`] from a CLI-provided bundle path.
+    /// Construct a [`FirmwareSource`] from a CLI-provided firmware path.
     ///
-    /// `allow_unverified` is the CLI opt-in flag; without it a source that
-    /// does not look like a managed bundle is rejected.
+    /// `allow_unverified` is the CLI opt-in flag; without it a local firmware
+    /// file that does not belong to an upstream firmware directory is
+    /// rejected.
     pub fn from_cli(
         firmware_bundle_path: Option<PathBuf>,
         allow_unverified: bool,
@@ -96,19 +94,31 @@ impl FirmwareSource {
         };
         let path = resolve_firmware_path(&path)?;
         if path.is_dir() {
-            if !path.join(MANIFEST_FILE).is_file() {
+            let code_path = path.join(UPSTREAM_CODE_FILE);
+            let vars_path = path.join(UPSTREAM_VARS_FILE);
+            if !code_path.is_file() {
                 bail!(
-                    "firmware bundle {} is missing {}; pull the verified image first",
+                    "firmware directory {} is missing {}; prepare the Ostool firmware cache first",
                     path.display(),
-                    MANIFEST_FILE
+                    UPSTREAM_CODE_FILE
                 );
             }
-            return Ok(Some(Self::Managed { bundle_dir: path }));
+            if !vars_path.is_file() {
+                bail!(
+                    "firmware directory {} is missing {}",
+                    path.display(),
+                    UPSTREAM_VARS_FILE
+                );
+            }
+            return Ok(Some(Self::Upstream {
+                code_path,
+                vars_path,
+            }));
         }
         if !allow_unverified {
             bail!(
-                "firmware path {} is not a managed bundle directory; pass \
-                 --allow-unverified-firmware to use an unverified local firmware file",
+                "firmware path {} is not an upstream firmware directory; pass \
+                 --allow-unverified-firmware to use a local firmware file",
                 path.display()
             );
         }
@@ -119,12 +129,9 @@ impl FirmwareSource {
 /// Fully validated result of verifying a firmware source.
 ///
 /// The fields are the pieces later tasks need (loader GPA layout, file
-/// paths, digest, verification label); the struct is immutable once built.
+/// paths, digests, verification label); the struct is immutable once built.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VerifiedOvmfBundle {
-    /// Firmware profile name the bundle claims (or the fixed profile for
-    /// unverified local firmware).
-    pub profile: String,
     /// Guest physical address of the CODE window start.
     pub code_base: u64,
     /// CODE image size in bytes.
@@ -137,9 +144,13 @@ pub struct VerifiedOvmfBundle {
     pub combined_size: u64,
     /// Path of the CODE image to load.
     pub code_path: PathBuf,
+    /// Path of the VARS image to load.
+    pub vars_path: PathBuf,
     /// SHA-256 of the CODE image.
     pub code_sha256: String,
-    /// `true` when the bundle passed full manifest verification.
+    /// SHA-256 of the VARS image.
+    pub vars_sha256: String,
+    /// `true` when the firmware passed full layout verification.
     pub verified: bool,
 }
 
@@ -157,12 +168,15 @@ impl VerifiedOvmfBundle {
 
 /// Verify the firmware selected on the command line.
 ///
-/// Managed bundles are fully verified against `manifest.toml`; unverified
-/// local firmware is checked for the fixed CODE size only and its SHA-256
-/// is printed.
+/// Upstream firmware directories are verified against the fixed layout
+/// constants; unverified local firmware is checked for the fixed CODE size
+/// only and its SHA-256 is printed.
 pub fn verify_firmware(source: &FirmwareSource) -> Result<VerifiedOvmfBundle> {
     match source {
-        FirmwareSource::Managed { bundle_dir } => verify_managed_bundle(bundle_dir),
+        FirmwareSource::Upstream {
+            code_path,
+            vars_path,
+        } => verify_upstream_firmware(code_path, vars_path),
         FirmwareSource::UnverifiedLocal { code_path } => {
             verify_unverified_local_firmware(code_path)
         }
@@ -181,302 +195,57 @@ fn resolve_firmware_path(path: &Path) -> Result<PathBuf> {
     }
 }
 
-fn verify_managed_bundle(bundle_dir: &Path) -> Result<VerifiedOvmfBundle> {
-    let manifest_path = bundle_dir.join(MANIFEST_FILE);
-    let manifest = fs::read_to_string(&manifest_path).with_context(|| {
-        format!(
-            "failed to read OVMF bundle manifest {}",
-            manifest_path.display()
-        )
-    })?;
-    let manifest = parse_manifest(&manifest, &manifest_path)?;
-    verify_manifest(&manifest, bundle_dir)
-}
+fn verify_upstream_firmware(code_path: &Path, vars_path: &Path) -> Result<VerifiedOvmfBundle> {
+    verify_layout_file(code_path, "code", OVMF_CODE_SIZE)?;
+    verify_layout_file(vars_path, "vars", OVMF_VARS_SIZE)?;
 
-fn parse_manifest(contents: &str, path: &Path) -> Result<OvmfManifest> {
-    toml::from_str::<OvmfManifest>(contents).with_context(|| {
-        format!(
-            "failed to parse OVMF bundle manifest {} (expected a flat, single-table manifest)",
-            path.display()
-        )
-    })
-}
+    let code_sha256 = file_sha256(code_path)?;
+    let vars_sha256 = file_sha256(vars_path)?;
 
-fn verify_manifest(manifest: &OvmfManifest, bundle_dir: &Path) -> Result<VerifiedOvmfBundle> {
-    let manifest_label = bundle_dir.join(MANIFEST_FILE).display().to_string();
-
-    require_eq(
-        "schema_version",
-        manifest.schema_version,
-        1,
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "profile",
-        &manifest.profile,
-        OVMF_PROFILE_NAME,
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "edk2_tag",
-        &manifest.edk2_tag,
-        OVMF_EDK2_TAG,
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "edk2_commit",
-        &manifest.edk2_commit,
-        OVMF_EDK2_COMMIT,
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "architecture",
-        &manifest.architecture,
-        "X64",
-        &manifest_label,
-    )?;
-    require_str_eq("target", &manifest.target, "DEBUG", &manifest_label)?;
-    require_str_eq("toolchain", &manifest.toolchain, "GCC", &manifest_label)?;
-    require_str_eq(
-        "platform",
-        &manifest.platform,
-        "OvmfPkg/OvmfPkgX64.dsc",
-        &manifest_label,
-    )?;
-    require_num_eq(
-        "code_base",
-        manifest.code_base,
-        OVMF_CODE_BASE,
-        &manifest_label,
-    )?;
-    require_num_eq(
-        "code_size",
-        manifest.code_size,
-        OVMF_CODE_SIZE,
-        &manifest_label,
-    )?;
-    require_num_eq(
-        "vars_base",
-        manifest.vars_base,
-        OVMF_VARS_BASE,
-        &manifest_label,
-    )?;
-    require_num_eq(
-        "vars_size",
-        manifest.vars_size,
-        OVMF_VARS_SIZE,
-        &manifest_label,
-    )?;
-    require_num_eq(
-        "combined_size",
-        manifest.combined_size,
-        OVMF_COMBINED_SIZE,
-        &manifest_label,
-    )?;
-    require_num_eq(
-        "reset_vector",
-        manifest.reset_vector,
-        OVMF_RESET_VECTOR,
-        &manifest_label,
-    )?;
-    require_str_eq("code_file", &manifest.code_file, CODE_FILE, &manifest_label)?;
-    require_str_eq("vars_file", &manifest.vars_file, VARS_FILE, &manifest_label)?;
-    require_str_eq(
-        "combined_file",
-        &manifest.combined_file,
-        COMBINED_FILE,
-        &manifest_label,
-    )?;
-    require_bool_eq("fd_size_4mb", manifest.fd_size_4mb, true, &manifest_label)?;
-    require_bool_eq(
-        "debug_on_serial_port",
-        manifest.debug_on_serial_port,
-        true,
-        &manifest_label,
-    )?;
-    require_bool_eq("build_shell", manifest.build_shell, true, &manifest_label)?;
-    require_bool_eq("smm_require", manifest.smm_require, false, &manifest_label)?;
-    require_bool_eq(
-        "secure_boot_enable",
-        manifest.secure_boot_enable,
-        false,
-        &manifest_label,
-    )?;
-    require_bool_eq("tpm2_enable", manifest.tpm2_enable, false, &manifest_label)?;
-    require_bool_eq(
-        "network_enable",
-        manifest.network_enable,
-        false,
-        &manifest_label,
-    )?;
-    require_bool_eq(
-        "sdcard_enable",
-        manifest.sdcard_enable,
-        false,
-        &manifest_label,
-    )?;
-    require_bool_eq(
-        "cc_measurement_enable",
-        manifest.cc_measurement_enable,
-        false,
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "sec_marker",
-        &manifest.sec_marker,
-        "SecCoreStartupWithStack(",
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "pei_marker",
-        &manifest.pei_marker,
-        "Platform PEIM Loaded",
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "dxe_ipl_marker",
-        &manifest.dxe_ipl_marker,
-        "DXE IPL Entry",
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "dxe_core_marker",
-        &manifest.dxe_core_marker,
-        "Loading DXE CORE at",
-        &manifest_label,
-    )?;
-    require_str_eq(
-        "bds_marker",
-        &manifest.bds_marker,
-        "[BdsDxe]",
-        &manifest_label,
-    )?;
-    require_non_empty("build_command", &manifest.build_command, &manifest_label)?;
-    require_non_empty(
-        "build_container_digest",
-        &manifest.build_container_digest,
-        &manifest_label,
-    )?;
-    require_non_empty("tool_versions", &manifest.tool_versions, &manifest_label)?;
-    require_non_empty(
-        "submodule_commits",
-        &manifest.submodule_commits,
-        &manifest_label,
-    )?;
-
-    let code_path = bundle_dir.join(CODE_FILE);
-    let vars_path = bundle_dir.join(VARS_FILE);
-    let combined_path = bundle_dir.join(COMBINED_FILE);
-
-    let code_sha256 = verify_manifest_file(
-        &code_path,
-        manifest.code_sha256.as_deref(),
-        manifest.code_size,
-        "code",
-        OVMF_CODE_SIZE,
-    )?;
-    let vars_sha256 = verify_manifest_file(
-        &vars_path,
-        manifest.vars_sha256.as_deref(),
-        manifest.vars_size,
-        "vars",
-        OVMF_VARS_SIZE,
-    )?;
-    let combined_sha256 = verify_manifest_file(
-        &combined_path,
-        manifest.combined_sha256.as_deref(),
-        manifest.combined_size,
-        "combined",
-        OVMF_COMBINED_SIZE,
-    )?;
-
-    let vars =
-        fs::read(&vars_path).with_context(|| format!("failed to read {}", vars_path.display()))?;
-    let code =
-        fs::read(&code_path).with_context(|| format!("failed to read {}", code_path.display()))?;
-    let mut expected_combined = Vec::with_capacity(vars.len() + code.len());
-    expected_combined.extend_from_slice(&vars);
-    expected_combined.extend_from_slice(&code);
-    let combined = fs::read(&combined_path)
-        .with_context(|| format!("failed to read {}", combined_path.display()))?;
-    if combined != expected_combined {
-        bail!(
-            "{} is not the byte-for-byte concatenation of {} and {} (in that order)",
-            combined_path.display(),
-            VARS_FILE,
-            CODE_FILE
-        );
-    }
-
-    let code_end = manifest
-        .code_base
-        .checked_add(manifest.code_size)
+    let code_end = OVMF_CODE_BASE
+        .checked_add(OVMF_CODE_SIZE)
         .ok_or_else(|| anyhow!("code_base + code_size overflows u64"))?;
-    let reset_vector_end = manifest
-        .reset_vector
+    let reset_vector_end = OVMF_RESET_VECTOR
         .checked_add(16)
         .ok_or_else(|| anyhow!("reset_vector + 16 overflows u64"))?;
-    if manifest.reset_vector < manifest.code_base || reset_vector_end > code_end {
+    if OVMF_RESET_VECTOR < OVMF_CODE_BASE || reset_vector_end > code_end {
         bail!(
             "reset vector 0x{OVMF_RESET_VECTOR:x} is outside the CODE window [0x{:x}, 0x{:x})",
-            manifest.code_base,
+            OVMF_CODE_BASE,
             code_end
         );
     }
 
     let bundle = VerifiedOvmfBundle {
-        profile: manifest.profile.clone(),
-        code_base: manifest.code_base,
-        code_size: manifest.code_size,
-        vars_base: manifest.vars_base,
-        vars_size: manifest.vars_size,
-        combined_size: manifest.combined_size,
-        code_path,
+        code_base: OVMF_CODE_BASE,
+        code_size: OVMF_CODE_SIZE,
+        vars_base: OVMF_VARS_BASE,
+        vars_size: OVMF_VARS_SIZE,
+        combined_size: OVMF_COMBINED_SIZE,
+        code_path: code_path.to_path_buf(),
+        vars_path: vars_path.to_path_buf(),
         code_sha256,
+        vars_sha256,
         verified: true,
     };
-    print_selected_firmware(&bundle, Some(vars_sha256), Some(combined_sha256));
+    print_selected_firmware(&bundle);
     Ok(bundle)
 }
 
-fn verify_manifest_file(
-    path: &Path,
-    expected_sha256: Option<&str>,
-    manifest_size: u64,
-    role: &str,
-    expected_size: u64,
-) -> Result<String> {
-    let Some(expected_sha256) = expected_sha256 else {
-        bail!(
-            "OVMF manifest is missing {role}_sha256 (file {})",
-            path.display()
-        );
-    };
-    if !is_sha256_hex(expected_sha256) {
-        bail!("OVMF manifest has an invalid {role}_sha256: {expected_sha256}");
-    }
+fn verify_layout_file(path: &Path, role: &str, expected_size: u64) -> Result<()> {
     let actual_size = fs::metadata(path)
         .with_context(|| format!("failed to read metadata of {}", path.display()))?
         .len();
     if actual_size != expected_size {
         bail!(
-            "{} has size {}; expected {} (manifest declares {})",
+            "{} firmware {} has size {}; expected {}",
+            role,
             path.display(),
             actual_size,
-            expected_size,
-            manifest_size
+            expected_size
         );
     }
-    let actual_sha256 = file_sha256(path)?;
-    if actual_sha256 != expected_sha256 {
-        bail!(
-            "SHA-256 mismatch for {}: expected {}, got {}",
-            path.display(),
-            expected_sha256,
-            actual_sha256
-        );
-    }
-    Ok(actual_sha256)
+    Ok(())
 }
 
 fn verify_unverified_local_firmware(code_path: &Path) -> Result<VerifiedOvmfBundle> {
@@ -486,47 +255,35 @@ fn verify_unverified_local_firmware(code_path: &Path) -> Result<VerifiedOvmfBund
             code_path.display()
         );
     }
-    let actual_size = fs::metadata(code_path)
-        .with_context(|| format!("failed to read metadata of {}", code_path.display()))?
-        .len();
-    if actual_size != OVMF_CODE_SIZE {
-        bail!(
-            "unverified UEFI firmware must still match the fixed CODE size {} bytes; got {}",
-            OVMF_CODE_SIZE,
-            actual_size
-        );
-    }
+    verify_layout_file(code_path, "unverified code", OVMF_CODE_SIZE)?;
     let code_sha256 = file_sha256(code_path)?;
     println!(
         "unverified firmware: path={}, size={}, sha256={}",
         code_path.display(),
-        actual_size,
+        OVMF_CODE_SIZE,
         code_sha256
     );
     let bundle = VerifiedOvmfBundle {
-        profile: OVMF_PROFILE_NAME.to_string(),
         code_base: OVMF_CODE_BASE,
         code_size: OVMF_CODE_SIZE,
         vars_base: OVMF_VARS_BASE,
         vars_size: OVMF_VARS_SIZE,
         combined_size: OVMF_COMBINED_SIZE,
         code_path: code_path.to_path_buf(),
+        vars_path: code_path.with_file_name(UPSTREAM_VARS_FILE),
         code_sha256,
+        vars_sha256: String::new(),
         verified: false,
     };
-    print_selected_firmware(&bundle, None, None);
+    print_selected_firmware(&bundle);
     eprintln!(
         "WARNING: UNVERIFIED firmware is diagnostic-only and must not determine UEFI test results."
     );
     Ok(bundle)
 }
 
-fn print_selected_firmware(
-    bundle: &VerifiedOvmfBundle,
-    vars_sha256: Option<String>,
-    combined_sha256: Option<String>,
-) {
-    println!("selected firmware profile: {}", bundle.profile);
+fn print_selected_firmware(bundle: &VerifiedOvmfBundle) {
+    println!("selected firmware profile: {OVMF_PROFILE_NAME}");
     println!("  code: path={}", bundle.code_path.display());
     println!(
         "  code: gpa=0x{:x}, size=0x{:x}",
@@ -538,11 +295,8 @@ fn print_selected_firmware(
     );
     println!("  combined: size=0x{:x}", bundle.combined_size);
     println!("  code_sha256={}", bundle.code_sha256);
-    if let Some(vars_sha256) = vars_sha256 {
-        println!("  vars_sha256={vars_sha256}");
-    }
-    if let Some(combined_sha256) = combined_sha256 {
-        println!("  combined_sha256={combined_sha256}");
+    if !bundle.vars_sha256.is_empty() {
+        println!("  vars_sha256={}", bundle.vars_sha256);
     }
     println!(
         "  verification_label={}",
@@ -554,91 +308,6 @@ fn print_selected_firmware(
     );
 }
 
-fn require_str_eq(field: &str, actual: &str, expected: &str, where_: &str) -> Result<()> {
-    if actual != expected {
-        bail!("OVMF manifest {where_} {field}={actual:?}; expected {expected:?}");
-    }
-    Ok(())
-}
-
-fn require_num_eq(field: &str, actual: u64, expected: u64, where_: &str) -> Result<()> {
-    if actual != expected {
-        bail!("OVMF manifest {where_} {field}=0x{actual:x}; expected 0x{expected:x}");
-    }
-    Ok(())
-}
-
-fn require_eq(field: &str, actual: u64, expected: u64, where_: &str) -> Result<()> {
-    if actual != expected {
-        bail!("OVMF manifest {where_} {field}={actual}; expected {expected}");
-    }
-    Ok(())
-}
-
-fn require_bool_eq(field: &str, actual: bool, expected: bool, where_: &str) -> Result<()> {
-    if actual != expected {
-        bail!("OVMF manifest {where_} {field}={actual}; expected {expected}");
-    }
-    Ok(())
-}
-
-fn require_non_empty(field: &str, actual: &str, where_: &str) -> Result<()> {
-    if actual.is_empty() {
-        bail!("OVMF manifest {where_} {field} must not be empty");
-    }
-    Ok(())
-}
-
-fn is_sha256_hex(value: &str) -> bool {
-    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
-}
-
-/// Flat OVMF bundle manifest. Parsed with `deny_unknown_fields` so a
-/// manifest drifting from the fixed contract is rejected instead of being
-/// silently accepted with ignored fields.
-#[derive(Debug, Deserialize)]
-#[serde(deny_unknown_fields)]
-struct OvmfManifest {
-    schema_version: u64,
-    profile: String,
-    edk2_tag: String,
-    edk2_commit: String,
-    architecture: String,
-    target: String,
-    toolchain: String,
-    platform: String,
-    build_command: String,
-    build_container_digest: String,
-    tool_versions: String,
-    submodule_commits: String,
-    code_base: u64,
-    code_size: u64,
-    vars_base: u64,
-    vars_size: u64,
-    combined_size: u64,
-    reset_vector: u64,
-    code_file: String,
-    code_sha256: Option<String>,
-    vars_file: String,
-    vars_sha256: Option<String>,
-    combined_file: String,
-    combined_sha256: Option<String>,
-    fd_size_4mb: bool,
-    debug_on_serial_port: bool,
-    build_shell: bool,
-    smm_require: bool,
-    secure_boot_enable: bool,
-    tpm2_enable: bool,
-    network_enable: bool,
-    sdcard_enable: bool,
-    cc_measurement_enable: bool,
-    sec_marker: String,
-    pei_marker: String,
-    dxe_ipl_marker: String,
-    dxe_core_marker: String,
-    bds_marker: String,
-}
-
 #[cfg(test)]
 mod tests {
     use std::fs;
@@ -648,205 +317,86 @@ mod tests {
 
     use super::*;
 
-    const FIXED_CODE_BYTES: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
-    const FIXED_VARS_BYTES: [u8; 3] = [0xfe, 0xed, 0xfa];
-
     #[test]
-    fn verifies_a_valid_managed_bundle() {
+    fn verifies_an_upstream_firmware_directory() {
         let dir = tempdir().unwrap();
-        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let code_path = write_file_with_size(dir.path().join(UPSTREAM_CODE_FILE), OVMF_CODE_SIZE);
+        let vars_path = write_file_with_size(dir.path().join(UPSTREAM_VARS_FILE), OVMF_VARS_SIZE);
 
-        let bundle = verify_firmware(&FirmwareSource::Managed {
-            bundle_dir: dir.path().to_path_buf(),
+        let bundle = verify_firmware(&FirmwareSource::Upstream {
+            code_path: code_path.clone(),
+            vars_path: vars_path.clone(),
         })
         .unwrap();
 
-        assert_eq!(bundle.profile, OVMF_PROFILE_NAME);
         assert_eq!(bundle.code_base, OVMF_CODE_BASE);
         assert_eq!(bundle.code_size, OVMF_CODE_SIZE);
         assert_eq!(bundle.vars_base, OVMF_VARS_BASE);
         assert_eq!(bundle.vars_size, OVMF_VARS_SIZE);
         assert_eq!(bundle.combined_size, OVMF_COMBINED_SIZE);
-        assert_eq!(bundle.code_path, dir.path().join(CODE_FILE));
-        assert_eq!(bundle.code_sha256, sha256(&code));
+        assert_eq!(bundle.code_path, code_path);
+        assert_eq!(bundle.vars_path, vars_path);
         assert!(bundle.verified);
         assert!(bundle.reset_vector_in_code_window());
         assert_eq!(bundle.code_end(), OVMF_CODE_BASE + OVMF_CODE_SIZE);
-        assert_eq!(vars.len(), OVMF_VARS_SIZE as usize);
-        assert_eq!(combined.len(), OVMF_COMBINED_SIZE as usize);
     }
 
     #[test]
-    fn rejects_wrong_code_sha256() {
+    fn rejects_upstream_firmware_with_wrong_code_size() {
         let dir = tempdir().unwrap();
-        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
-        let wrong = wrong_hash(&code);
-        fs::write(dir.path().join(CODE_FILE), &code).unwrap();
-        fs::write(
-            dir.path().join(MANIFEST_FILE),
-            bundle_manifest_string(&code, &vars, &combined).replace(&sha256(&code), &wrong),
-        )
-        .unwrap();
+        let code_path = write_file_with_size(dir.path().join(UPSTREAM_CODE_FILE), 0x1000);
+        let vars_path = write_file_with_size(dir.path().join(UPSTREAM_VARS_FILE), OVMF_VARS_SIZE);
 
-        let err = verify_err(dir.path());
+        let err = format!(
+            "{:#}",
+            verify_firmware(&FirmwareSource::Upstream {
+                code_path,
+                vars_path
+            })
+            .unwrap_err()
+        );
+
         assert!(
-            err.contains("SHA-256 mismatch")
-                && err.contains(&wrong)
-                && err.contains(&sha256(&code)),
+            err.contains("code") && err.contains(&OVMF_CODE_SIZE.to_string()),
             "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn rejects_wrong_code_size() {
+    fn rejects_upstream_firmware_with_wrong_vars_size() {
         let dir = tempdir().unwrap();
-        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
-        let mut short_code = code.clone();
-        short_code.pop();
-        fs::write(dir.path().join(CODE_FILE), short_code).unwrap();
-        fs::write(
-            dir.path().join(MANIFEST_FILE),
-            bundle_manifest_string(&code, &vars, &combined),
-        )
-        .unwrap();
+        let code_path = write_file_with_size(dir.path().join(UPSTREAM_CODE_FILE), OVMF_CODE_SIZE);
+        let vars_path = write_file_with_size(dir.path().join(UPSTREAM_VARS_FILE), 0x1000);
 
-        let err = verify_err(dir.path());
+        let err = format!(
+            "{:#}",
+            verify_firmware(&FirmwareSource::Upstream {
+                code_path,
+                vars_path
+            })
+            .unwrap_err()
+        );
+
         assert!(
-            err.contains("has size") && err.contains("expected"),
+            err.contains("vars") && err.contains(&OVMF_VARS_SIZE.to_string()),
             "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn rejects_wrong_code_base() {
+    fn upstream_directory_requires_code_and_vars_present() {
         let dir = tempdir().unwrap();
-        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
-        let manifest = bundle_manifest_string(&code, &vars, &combined)
-            .replace("code_base = 0xffc84000", "code_base = 0xffc00000");
-        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
+        write_file_with_size(dir.path().join(UPSTREAM_CODE_FILE), OVMF_CODE_SIZE);
 
-        let err = verify_err(dir.path());
-        assert!(
-            err.contains("code_base") && err.contains("0xffc84000") && err.contains("0xffc00000"),
-            "unexpected error: {err}"
+        let err = format!(
+            "{:?}",
+            FirmwareSource::from_cli(Some(dir.path().to_path_buf()), false)
+                .unwrap_err()
+                .to_string()
         );
-    }
 
-    #[test]
-    fn rejects_wrong_profile_name() {
-        let dir = tempdir().unwrap();
-        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
-        let manifest = bundle_manifest_string(&code, &vars, &combined)
-            .replace(OVMF_PROFILE_NAME, "some-other-profile");
-        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
-
-        let err = verify_err(dir.path());
         assert!(
-            err.contains("profile") && err.contains("some-other-profile"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn rejects_unknown_manifest_field() {
-        let dir = tempdir().unwrap();
-        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
-        let manifest = format!(
-            "{}\nunknown_field = \"anything\"\n",
-            bundle_manifest_string(&code, &vars, &combined)
-        );
-        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
-
-        let err = verify_err(dir.path());
-        assert!(err.contains("unknown_field"), "unexpected error: {err}");
-    }
-
-    #[test]
-    fn rejects_duplicate_manifest_field() {
-        for duplicate in [
-            "profile = \"ignored-duplicate\"",
-            "code_base = 0xffc00000",
-            "code_sha256 = \"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"",
-        ] {
-            let dir = tempdir().unwrap();
-            let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
-            let manifest = format!(
-                "{}\n{duplicate}\n",
-                bundle_manifest_string(&code, &vars, &combined)
-            );
-            fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
-
-            let err = verify_err(dir.path());
-            assert!(
-                err.contains("duplicate"),
-                "accepted duplicate key {duplicate:?}, error: {err}"
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_wrong_combined_file_layout() {
-        let dir = tempdir().unwrap();
-        let (code, vars, _combined) = write_bundle(dir.path(), &bundle_manifest_string);
-        let mut swapped = Vec::with_capacity(code.len() + vars.len());
-        swapped.extend_from_slice(&code);
-        swapped.extend_from_slice(&vars);
-        fs::write(dir.path().join(COMBINED_FILE), &swapped).unwrap();
-        fs::write(
-            dir.path().join(MANIFEST_FILE),
-            bundle_manifest_string(&code, &vars, &swapped),
-        )
-        .unwrap();
-
-        let err = verify_err(dir.path());
-        assert!(
-            err.contains("byte-for-byte concatenation"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn rejects_wrong_reset_vector_value() {
-        let dir = tempdir().unwrap();
-        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
-        let manifest = bundle_manifest_string(&code, &vars, &combined)
-            .replace("reset_vector = 0xfffffff0", "reset_vector = 0xffff0000");
-        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
-
-        let err = verify_err(dir.path());
-        assert!(
-            err.contains("reset_vector") && err.contains("0xfffffff0"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn reset_vector_window_predicate_rejects_windows_outside_4gib() {
-        // The fixed profile puts the reset vector at the very end of the
-        // 4 GiB window, so the predicate holds for the verified bundle and
-        // rejects any smaller CODE window.
-        let mut bundle = verified_fixture_bundle(Path::new("OVMF_CODE.fd"));
-        assert!(bundle.reset_vector_in_code_window());
-
-        bundle.code_base = OVMF_VARS_BASE;
-        bundle.code_size = OVMF_VARS_SIZE;
-        assert!(!bundle.reset_vector_in_code_window());
-    }
-
-    #[test]
-    fn rejects_missing_sha256_field() {
-        let dir = tempdir().unwrap();
-        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
-        let manifest = bundle_manifest_string(&code, &vars, &combined)
-            .lines()
-            .filter(|line| !line.starts_with("code_sha256"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
-
-        let err = verify_err(dir.path());
-        assert!(
-            err.contains("missing code_sha256"),
+            err.contains("missing") && err.contains(UPSTREAM_VARS_FILE),
             "unexpected error: {err}"
         );
     }
@@ -854,7 +404,7 @@ mod tests {
     #[test]
     fn rejects_unverified_firmware_without_opt_in() {
         let dir = tempdir().unwrap();
-        let code_path = dir.path().join("local-OVMF_CODE.fd");
+        let code_path = dir.path().join("local-code.fd");
         fs::write(&code_path, vec![0xa5; OVMF_CODE_SIZE as usize]).unwrap();
 
         let source = FirmwareSource::from_cli(Some(code_path.clone()), false);
@@ -870,7 +420,7 @@ mod tests {
     #[test]
     fn accepts_unverified_firmware_with_opt_in_and_prints_sha256() {
         let dir = tempdir().unwrap();
-        let code_path = dir.path().join("local-OVMF_CODE.fd");
+        let code_path = dir.path().join("local-code.fd");
         let code = vec![0xa5; OVMF_CODE_SIZE as usize];
         fs::write(&code_path, &code).unwrap();
 
@@ -895,7 +445,7 @@ mod tests {
     #[test]
     fn rejects_unverified_firmware_with_wrong_size_even_with_opt_in() {
         let dir = tempdir().unwrap();
-        let code_path = dir.path().join("local-OVMF_CODE.fd");
+        let code_path = dir.path().join("local-code.fd");
         fs::write(&code_path, vec![0xa5; 0x1000]).unwrap();
 
         let source = FirmwareSource::from_cli(Some(code_path.clone()), true).unwrap();
@@ -903,26 +453,7 @@ mod tests {
         let err = format!("{:?}", verify_firmware(&source).unwrap_err().to_string());
 
         assert!(
-            err.contains("must still match the fixed CODE size"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn managed_bundle_requires_manifest_present() {
-        let dir = tempdir().unwrap();
-        write_bundle(dir.path(), &bundle_manifest_string);
-        fs::remove_file(dir.path().join(MANIFEST_FILE)).unwrap();
-
-        let err = format!(
-            "{:?}",
-            FirmwareSource::from_cli(Some(dir.path().to_path_buf()), false)
-                .unwrap_err()
-                .to_string()
-        );
-
-        assert!(
-            err.contains("missing manifest.toml"),
+            err.contains(&OVMF_CODE_SIZE.to_string()),
             "unexpected error: {err}"
         );
     }
@@ -947,112 +478,12 @@ mod tests {
         assert_eq!(FirmwareSource::from_cli(None, false).unwrap(), None);
     }
 
-    fn verify_err(bundle_dir: &Path) -> String {
-        format!(
-            "{:#}",
-            verify_firmware(&FirmwareSource::Managed {
-                bundle_dir: bundle_dir.to_path_buf()
-            })
-            .unwrap_err()
-        )
-    }
-
-    /// Writes the flat manifest for a fixed bundle from the three images.
-    type ManifestWriter = dyn Fn(&[u8], &[u8], &[u8]) -> String;
-
-    /// Write a complete managed bundle (CODE, VARS, combined image and flat
-    /// manifest) with fixed byte patterns, returning the three images.
-    fn write_bundle(bundle_dir: &Path, manifest: &ManifestWriter) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
-        let mut code = FIXED_CODE_BYTES.to_vec();
-        code.resize(OVMF_CODE_SIZE as usize, 0xa5);
-        let mut vars = FIXED_VARS_BYTES.to_vec();
-        vars.resize(OVMF_VARS_SIZE as usize, 0x5a);
-        let mut combined = Vec::with_capacity(vars.len() + code.len());
-        combined.extend_from_slice(&vars);
-        combined.extend_from_slice(&code);
-
-        fs::write(bundle_dir.join(CODE_FILE), &code).unwrap();
-        fs::write(bundle_dir.join(VARS_FILE), &vars).unwrap();
-        fs::write(bundle_dir.join(COMBINED_FILE), &combined).unwrap();
-        fs::write(
-            bundle_dir.join(MANIFEST_FILE),
-            manifest(&code, &vars, &combined),
-        )
-        .unwrap();
-        (code, vars, combined)
-    }
-
-    fn bundle_manifest_string(code: &[u8], vars: &[u8], combined: &[u8]) -> String {
-        format!(
-            r#"schema_version = 1
-profile = "qemu_x86_64_axvisor_ovmf_debug"
-edk2_tag = "edk2-stable202605"
-edk2_commit = "b03a21a63e3bd001f52c527e5a57feddb53a690b"
-architecture = "X64"
-target = "DEBUG"
-toolchain = "GCC"
-platform = "OvmfPkg/OvmfPkgX64.dsc"
-build_command = "build -a X64 -b DEBUG"
-build_container_digest = "sha256:fixture"
-tool_versions = "fixture"
-submodule_commits = "fixture"
-code_base = 0xffc84000
-code_size = 0x37c000
-vars_base = 0xffc00000
-vars_size = 0x84000
-combined_size = 0x400000
-reset_vector = 0xfffffff0
-code_file = "OVMF_CODE.fd"
-code_sha256 = "{code_sha256}"
-vars_file = "OVMF_VARS.fd"
-vars_sha256 = "{vars_sha256}"
-combined_file = "OVMF.fd"
-combined_sha256 = "{combined_sha256}"
-fd_size_4mb = true
-debug_on_serial_port = true
-build_shell = true
-smm_require = false
-secure_boot_enable = false
-tpm2_enable = false
-network_enable = false
-sdcard_enable = false
-cc_measurement_enable = false
-sec_marker = "SecCoreStartupWithStack("
-pei_marker = "Platform PEIM Loaded"
-dxe_ipl_marker = "DXE IPL Entry"
-dxe_core_marker = "Loading DXE CORE at"
-bds_marker = "[BdsDxe]"
-"#,
-            code_sha256 = sha256(code),
-            vars_sha256 = sha256(vars),
-            combined_sha256 = sha256(combined),
-        )
+    fn write_file_with_size(path: PathBuf, size: u64) -> PathBuf {
+        fs::write(&path, vec![0xa5; size as usize]).unwrap();
+        path
     }
 
     fn sha256(bytes: &[u8]) -> String {
         format!("{:x}", Sha256::digest(bytes))
-    }
-
-    fn wrong_hash(bytes: &[u8]) -> String {
-        let mut hash = sha256(bytes).into_bytes();
-        let digit = hash.first_mut().unwrap();
-        *digit = if *digit == b'0' { b'1' } else { b'0' };
-        String::from_utf8(hash).unwrap()
-    }
-
-    /// Build a [`VerifiedOvmfBundle`] with the fixed profile layout for
-    /// testing predicates that do not require real files on disk.
-    fn verified_fixture_bundle(code_path: &Path) -> VerifiedOvmfBundle {
-        VerifiedOvmfBundle {
-            profile: OVMF_PROFILE_NAME.to_string(),
-            code_base: OVMF_CODE_BASE,
-            code_size: OVMF_CODE_SIZE,
-            vars_base: OVMF_VARS_BASE,
-            vars_size: OVMF_VARS_SIZE,
-            combined_size: OVMF_COMBINED_SIZE,
-            code_path: code_path.to_path_buf(),
-            code_sha256: sha256(&FIXED_CODE_BYTES),
-            verified: true,
-        }
     }
 }

--- a/scripts/axbuild/src/axvisor/ovmf.rs
+++ b/scripts/axbuild/src/axvisor/ovmf.rs
@@ -1,0 +1,1058 @@
+//! Verified OVMF firmware bundle handling for x86_64 AxVisor UEFI tests.
+//!
+//! A fixed OVMF build is distributed as a "bundle": a directory holding
+//! `OVMF_CODE.fd`, `OVMF_VARS.fd`, `OVMF.fd` and a flat `manifest.toml`
+//! describing the expected profile, GPA layout and per-file sizes and
+//! SHA-256 digests. This module replaces the old
+//! `os/axvisor/scripts/ovmf-profile.sh` verifier: it parses the manifest
+//! with the typed `toml` crate and verifies every value and every file
+//! against the fixed profile constants.
+//!
+//! Firmware that is not part of a managed bundle (for example a local
+//! `OVMF_CODE.fd` supplied by the developer) is only accepted through an
+//! explicit opt-in; it must still match the fixed CODE size and its SHA-256
+//! digest is printed so the caller can see exactly what was used.
+//!
+//! Verification never downloads anything. If a bundle directory is missing,
+//! the caller is expected to pull it first through the image registry; this
+//! module only validates a bundle that is already present on disk.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+
+use crate::support::download::file_sha256;
+
+/// Fixed x86_64 guest firmware profile name, also the image registry entry
+/// name under which the managed bundle is published.
+pub const OVMF_PROFILE_NAME: &str = "qemu_x86_64_axvisor_ovmf_debug";
+
+/// EDK2 tag the fixed bundle was built from.
+pub const OVMF_EDK2_TAG: &str = "edk2-stable202605";
+
+/// EDK2 commit the fixed bundle was built from.
+pub const OVMF_EDK2_COMMIT: &str = "b03a21a63e3bd001f52c527e5a57feddb53a690b";
+
+/// Guest physical address of the start of the CODE (firmware text) region.
+pub const OVMF_CODE_BASE: u64 = 0xffc8_4000;
+
+/// Size of the CODE image in bytes.
+pub const OVMF_CODE_SIZE: u64 = 0x37_c000;
+
+/// Guest physical address of the start of the VARS (NVRAM) region.
+pub const OVMF_VARS_BASE: u64 = 0xffc0_0000;
+
+/// Size of the VARS image in bytes.
+pub const OVMF_VARS_SIZE: u64 = 0x8_4000;
+
+/// Size of the combined `OVMF.fd` image in bytes (VARS followed by CODE).
+pub const OVMF_COMBINED_SIZE: u64 = 0x40_0000;
+
+/// Guest physical address of the x86 reset vector, expected to sit inside
+/// the CODE window.
+pub const OVMF_RESET_VECTOR: u64 = 0xffff_fff0;
+
+/// CODE image file name inside a managed bundle.
+pub const CODE_FILE: &str = "OVMF_CODE.fd";
+
+/// VARS image file name inside a managed bundle.
+pub const VARS_FILE: &str = "OVMF_VARS.fd";
+
+/// Combined image file name inside a managed bundle.
+pub const COMBINED_FILE: &str = "OVMF.fd";
+
+/// Flat manifest file name inside a managed bundle.
+pub const MANIFEST_FILE: &str = "manifest.toml";
+
+/// Where a firmware image came from.
+///
+/// The enum keeps the "verified managed bundle" and "explicit unverified
+/// local file" cases distinct so callers cannot accidentally mix the two:
+/// the two paths carry different semantics (manifest verification vs. a
+/// printed digest) and different CLI requirements (opt-in).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FirmwareSource {
+    /// A managed, manifest-verified OVMF bundle directory.
+    Managed { bundle_dir: PathBuf },
+    /// A local firmware file accepted only through an explicit opt-in.
+    UnverifiedLocal { code_path: PathBuf },
+}
+
+impl FirmwareSource {
+    /// Construct a [`FirmwareSource`] from a CLI-provided bundle path.
+    ///
+    /// `allow_unverified` is the CLI opt-in flag; without it a source that
+    /// does not look like a managed bundle is rejected.
+    pub fn from_cli(
+        firmware_bundle_path: Option<PathBuf>,
+        allow_unverified: bool,
+    ) -> Result<Option<Self>> {
+        let Some(path) = firmware_bundle_path else {
+            return Ok(None);
+        };
+        let path = resolve_firmware_path(&path)?;
+        if path.is_dir() {
+            if !path.join(MANIFEST_FILE).is_file() {
+                bail!(
+                    "firmware bundle {} is missing {}; pull the verified image first",
+                    path.display(),
+                    MANIFEST_FILE
+                );
+            }
+            return Ok(Some(Self::Managed { bundle_dir: path }));
+        }
+        if !allow_unverified {
+            bail!(
+                "firmware path {} is not a managed bundle directory; pass \
+                 --allow-unverified-firmware to use an unverified local firmware file",
+                path.display()
+            );
+        }
+        Ok(Some(Self::UnverifiedLocal { code_path: path }))
+    }
+}
+
+/// Fully validated result of verifying a firmware source.
+///
+/// The fields are the pieces later tasks need (loader GPA layout, file
+/// paths, digest, verification label); the struct is immutable once built.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedOvmfBundle {
+    /// Firmware profile name the bundle claims (or the fixed profile for
+    /// unverified local firmware).
+    pub profile: String,
+    /// Guest physical address of the CODE window start.
+    pub code_base: u64,
+    /// CODE image size in bytes.
+    pub code_size: u64,
+    /// Guest physical address of the VARS window start.
+    pub vars_base: u64,
+    /// VARS image size in bytes.
+    pub vars_size: u64,
+    /// Combined image size in bytes.
+    pub combined_size: u64,
+    /// Path of the CODE image to load.
+    pub code_path: PathBuf,
+    /// SHA-256 of the CODE image.
+    pub code_sha256: String,
+    /// `true` when the bundle passed full manifest verification.
+    pub verified: bool,
+}
+
+impl VerifiedOvmfBundle {
+    /// Guest physical address one past the end of the CODE window.
+    pub fn code_end(&self) -> u64 {
+        self.code_base + self.code_size
+    }
+
+    /// True when the reset vector address lies within the CODE window.
+    pub fn reset_vector_in_code_window(&self) -> bool {
+        OVMF_RESET_VECTOR >= self.code_base && OVMF_RESET_VECTOR + 16 <= self.code_end()
+    }
+}
+
+/// Verify the firmware selected on the command line.
+///
+/// Managed bundles are fully verified against `manifest.toml`; unverified
+/// local firmware is checked for the fixed CODE size only and its SHA-256
+/// is printed.
+pub fn verify_firmware(source: &FirmwareSource) -> Result<VerifiedOvmfBundle> {
+    match source {
+        FirmwareSource::Managed { bundle_dir } => verify_managed_bundle(bundle_dir),
+        FirmwareSource::UnverifiedLocal { code_path } => {
+            verify_unverified_local_firmware(code_path)
+        }
+    }
+}
+
+fn resolve_firmware_path(path: &Path) -> Result<PathBuf> {
+    match fs::canonicalize(path) {
+        Ok(canonical) => Ok(canonical),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            bail!("firmware path {} does not exist", path.display())
+        }
+        Err(err) => {
+            Err(err).with_context(|| format!("failed to resolve firmware path {}", path.display()))
+        }
+    }
+}
+
+fn verify_managed_bundle(bundle_dir: &Path) -> Result<VerifiedOvmfBundle> {
+    let manifest_path = bundle_dir.join(MANIFEST_FILE);
+    let manifest = fs::read_to_string(&manifest_path).with_context(|| {
+        format!(
+            "failed to read OVMF bundle manifest {}",
+            manifest_path.display()
+        )
+    })?;
+    let manifest = parse_manifest(&manifest, &manifest_path)?;
+    verify_manifest(&manifest, bundle_dir)
+}
+
+fn parse_manifest(contents: &str, path: &Path) -> Result<OvmfManifest> {
+    toml::from_str::<OvmfManifest>(contents).with_context(|| {
+        format!(
+            "failed to parse OVMF bundle manifest {} (expected a flat, single-table manifest)",
+            path.display()
+        )
+    })
+}
+
+fn verify_manifest(manifest: &OvmfManifest, bundle_dir: &Path) -> Result<VerifiedOvmfBundle> {
+    let manifest_label = bundle_dir.join(MANIFEST_FILE).display().to_string();
+
+    require_eq(
+        "schema_version",
+        manifest.schema_version,
+        1,
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "profile",
+        &manifest.profile,
+        OVMF_PROFILE_NAME,
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "edk2_tag",
+        &manifest.edk2_tag,
+        OVMF_EDK2_TAG,
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "edk2_commit",
+        &manifest.edk2_commit,
+        OVMF_EDK2_COMMIT,
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "architecture",
+        &manifest.architecture,
+        "X64",
+        &manifest_label,
+    )?;
+    require_str_eq("target", &manifest.target, "DEBUG", &manifest_label)?;
+    require_str_eq("toolchain", &manifest.toolchain, "GCC", &manifest_label)?;
+    require_str_eq(
+        "platform",
+        &manifest.platform,
+        "OvmfPkg/OvmfPkgX64.dsc",
+        &manifest_label,
+    )?;
+    require_num_eq(
+        "code_base",
+        manifest.code_base,
+        OVMF_CODE_BASE,
+        &manifest_label,
+    )?;
+    require_num_eq(
+        "code_size",
+        manifest.code_size,
+        OVMF_CODE_SIZE,
+        &manifest_label,
+    )?;
+    require_num_eq(
+        "vars_base",
+        manifest.vars_base,
+        OVMF_VARS_BASE,
+        &manifest_label,
+    )?;
+    require_num_eq(
+        "vars_size",
+        manifest.vars_size,
+        OVMF_VARS_SIZE,
+        &manifest_label,
+    )?;
+    require_num_eq(
+        "combined_size",
+        manifest.combined_size,
+        OVMF_COMBINED_SIZE,
+        &manifest_label,
+    )?;
+    require_num_eq(
+        "reset_vector",
+        manifest.reset_vector,
+        OVMF_RESET_VECTOR,
+        &manifest_label,
+    )?;
+    require_str_eq("code_file", &manifest.code_file, CODE_FILE, &manifest_label)?;
+    require_str_eq("vars_file", &manifest.vars_file, VARS_FILE, &manifest_label)?;
+    require_str_eq(
+        "combined_file",
+        &manifest.combined_file,
+        COMBINED_FILE,
+        &manifest_label,
+    )?;
+    require_bool_eq("fd_size_4mb", manifest.fd_size_4mb, true, &manifest_label)?;
+    require_bool_eq(
+        "debug_on_serial_port",
+        manifest.debug_on_serial_port,
+        true,
+        &manifest_label,
+    )?;
+    require_bool_eq("build_shell", manifest.build_shell, true, &manifest_label)?;
+    require_bool_eq("smm_require", manifest.smm_require, false, &manifest_label)?;
+    require_bool_eq(
+        "secure_boot_enable",
+        manifest.secure_boot_enable,
+        false,
+        &manifest_label,
+    )?;
+    require_bool_eq("tpm2_enable", manifest.tpm2_enable, false, &manifest_label)?;
+    require_bool_eq(
+        "network_enable",
+        manifest.network_enable,
+        false,
+        &manifest_label,
+    )?;
+    require_bool_eq(
+        "sdcard_enable",
+        manifest.sdcard_enable,
+        false,
+        &manifest_label,
+    )?;
+    require_bool_eq(
+        "cc_measurement_enable",
+        manifest.cc_measurement_enable,
+        false,
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "sec_marker",
+        &manifest.sec_marker,
+        "SecCoreStartupWithStack(",
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "pei_marker",
+        &manifest.pei_marker,
+        "Platform PEIM Loaded",
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "dxe_ipl_marker",
+        &manifest.dxe_ipl_marker,
+        "DXE IPL Entry",
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "dxe_core_marker",
+        &manifest.dxe_core_marker,
+        "Loading DXE CORE at",
+        &manifest_label,
+    )?;
+    require_str_eq(
+        "bds_marker",
+        &manifest.bds_marker,
+        "[BdsDxe]",
+        &manifest_label,
+    )?;
+    require_non_empty("build_command", &manifest.build_command, &manifest_label)?;
+    require_non_empty(
+        "build_container_digest",
+        &manifest.build_container_digest,
+        &manifest_label,
+    )?;
+    require_non_empty("tool_versions", &manifest.tool_versions, &manifest_label)?;
+    require_non_empty(
+        "submodule_commits",
+        &manifest.submodule_commits,
+        &manifest_label,
+    )?;
+
+    let code_path = bundle_dir.join(CODE_FILE);
+    let vars_path = bundle_dir.join(VARS_FILE);
+    let combined_path = bundle_dir.join(COMBINED_FILE);
+
+    let code_sha256 = verify_manifest_file(
+        &code_path,
+        manifest.code_sha256.as_deref(),
+        manifest.code_size,
+        "code",
+        OVMF_CODE_SIZE,
+    )?;
+    let vars_sha256 = verify_manifest_file(
+        &vars_path,
+        manifest.vars_sha256.as_deref(),
+        manifest.vars_size,
+        "vars",
+        OVMF_VARS_SIZE,
+    )?;
+    let combined_sha256 = verify_manifest_file(
+        &combined_path,
+        manifest.combined_sha256.as_deref(),
+        manifest.combined_size,
+        "combined",
+        OVMF_COMBINED_SIZE,
+    )?;
+
+    let vars =
+        fs::read(&vars_path).with_context(|| format!("failed to read {}", vars_path.display()))?;
+    let code =
+        fs::read(&code_path).with_context(|| format!("failed to read {}", code_path.display()))?;
+    let mut expected_combined = Vec::with_capacity(vars.len() + code.len());
+    expected_combined.extend_from_slice(&vars);
+    expected_combined.extend_from_slice(&code);
+    let combined = fs::read(&combined_path)
+        .with_context(|| format!("failed to read {}", combined_path.display()))?;
+    if combined != expected_combined {
+        bail!(
+            "{} is not the byte-for-byte concatenation of {} and {} (in that order)",
+            combined_path.display(),
+            VARS_FILE,
+            CODE_FILE
+        );
+    }
+
+    let code_end = manifest
+        .code_base
+        .checked_add(manifest.code_size)
+        .ok_or_else(|| anyhow!("code_base + code_size overflows u64"))?;
+    let reset_vector_end = manifest
+        .reset_vector
+        .checked_add(16)
+        .ok_or_else(|| anyhow!("reset_vector + 16 overflows u64"))?;
+    if manifest.reset_vector < manifest.code_base || reset_vector_end > code_end {
+        bail!(
+            "reset vector 0x{OVMF_RESET_VECTOR:x} is outside the CODE window [0x{:x}, 0x{:x})",
+            manifest.code_base,
+            code_end
+        );
+    }
+
+    let bundle = VerifiedOvmfBundle {
+        profile: manifest.profile.clone(),
+        code_base: manifest.code_base,
+        code_size: manifest.code_size,
+        vars_base: manifest.vars_base,
+        vars_size: manifest.vars_size,
+        combined_size: manifest.combined_size,
+        code_path,
+        code_sha256,
+        verified: true,
+    };
+    print_selected_firmware(&bundle, Some(vars_sha256), Some(combined_sha256));
+    Ok(bundle)
+}
+
+fn verify_manifest_file(
+    path: &Path,
+    expected_sha256: Option<&str>,
+    manifest_size: u64,
+    role: &str,
+    expected_size: u64,
+) -> Result<String> {
+    let Some(expected_sha256) = expected_sha256 else {
+        bail!(
+            "OVMF manifest is missing {role}_sha256 (file {})",
+            path.display()
+        );
+    };
+    if !is_sha256_hex(expected_sha256) {
+        bail!("OVMF manifest has an invalid {role}_sha256: {expected_sha256}");
+    }
+    let actual_size = fs::metadata(path)
+        .with_context(|| format!("failed to read metadata of {}", path.display()))?
+        .len();
+    if actual_size != expected_size {
+        bail!(
+            "{} has size {}; expected {} (manifest declares {})",
+            path.display(),
+            actual_size,
+            expected_size,
+            manifest_size
+        );
+    }
+    let actual_sha256 = file_sha256(path)?;
+    if actual_sha256 != expected_sha256 {
+        bail!(
+            "SHA-256 mismatch for {}: expected {}, got {}",
+            path.display(),
+            expected_sha256,
+            actual_sha256
+        );
+    }
+    Ok(actual_sha256)
+}
+
+fn verify_unverified_local_firmware(code_path: &Path) -> Result<VerifiedOvmfBundle> {
+    if !code_path.is_file() {
+        bail!(
+            "unverified UEFI firmware does not exist: {}",
+            code_path.display()
+        );
+    }
+    let actual_size = fs::metadata(code_path)
+        .with_context(|| format!("failed to read metadata of {}", code_path.display()))?
+        .len();
+    if actual_size != OVMF_CODE_SIZE {
+        bail!(
+            "unverified UEFI firmware must still match the fixed CODE size {} bytes; got {}",
+            OVMF_CODE_SIZE,
+            actual_size
+        );
+    }
+    let code_sha256 = file_sha256(code_path)?;
+    println!(
+        "unverified firmware: path={}, size={}, sha256={}",
+        code_path.display(),
+        actual_size,
+        code_sha256
+    );
+    let bundle = VerifiedOvmfBundle {
+        profile: OVMF_PROFILE_NAME.to_string(),
+        code_base: OVMF_CODE_BASE,
+        code_size: OVMF_CODE_SIZE,
+        vars_base: OVMF_VARS_BASE,
+        vars_size: OVMF_VARS_SIZE,
+        combined_size: OVMF_COMBINED_SIZE,
+        code_path: code_path.to_path_buf(),
+        code_sha256,
+        verified: false,
+    };
+    print_selected_firmware(&bundle, None, None);
+    eprintln!(
+        "WARNING: UNVERIFIED firmware is diagnostic-only and must not determine UEFI test results."
+    );
+    Ok(bundle)
+}
+
+fn print_selected_firmware(
+    bundle: &VerifiedOvmfBundle,
+    vars_sha256: Option<String>,
+    combined_sha256: Option<String>,
+) {
+    println!("selected firmware profile: {}", bundle.profile);
+    println!("  code: path={}", bundle.code_path.display());
+    println!(
+        "  code: gpa=0x{:x}, size=0x{:x}",
+        bundle.code_base, bundle.code_size
+    );
+    println!(
+        "  vars: gpa=0x{:x}, size=0x{:x}",
+        bundle.vars_base, bundle.vars_size
+    );
+    println!("  combined: size=0x{:x}", bundle.combined_size);
+    println!("  code_sha256={}", bundle.code_sha256);
+    if let Some(vars_sha256) = vars_sha256 {
+        println!("  vars_sha256={vars_sha256}");
+    }
+    if let Some(combined_sha256) = combined_sha256 {
+        println!("  combined_sha256={combined_sha256}");
+    }
+    println!(
+        "  verification_label={}",
+        if bundle.verified {
+            "VERIFIED"
+        } else {
+            "UNVERIFIED"
+        }
+    );
+}
+
+fn require_str_eq(field: &str, actual: &str, expected: &str, where_: &str) -> Result<()> {
+    if actual != expected {
+        bail!("OVMF manifest {where_} {field}={actual:?}; expected {expected:?}");
+    }
+    Ok(())
+}
+
+fn require_num_eq(field: &str, actual: u64, expected: u64, where_: &str) -> Result<()> {
+    if actual != expected {
+        bail!("OVMF manifest {where_} {field}=0x{actual:x}; expected 0x{expected:x}");
+    }
+    Ok(())
+}
+
+fn require_eq(field: &str, actual: u64, expected: u64, where_: &str) -> Result<()> {
+    if actual != expected {
+        bail!("OVMF manifest {where_} {field}={actual}; expected {expected}");
+    }
+    Ok(())
+}
+
+fn require_bool_eq(field: &str, actual: bool, expected: bool, where_: &str) -> Result<()> {
+    if actual != expected {
+        bail!("OVMF manifest {where_} {field}={actual}; expected {expected}");
+    }
+    Ok(())
+}
+
+fn require_non_empty(field: &str, actual: &str, where_: &str) -> Result<()> {
+    if actual.is_empty() {
+        bail!("OVMF manifest {where_} {field} must not be empty");
+    }
+    Ok(())
+}
+
+fn is_sha256_hex(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit())
+}
+
+/// Flat OVMF bundle manifest. Parsed with `deny_unknown_fields` so a
+/// manifest drifting from the fixed contract is rejected instead of being
+/// silently accepted with ignored fields.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OvmfManifest {
+    schema_version: u64,
+    profile: String,
+    edk2_tag: String,
+    edk2_commit: String,
+    architecture: String,
+    target: String,
+    toolchain: String,
+    platform: String,
+    build_command: String,
+    build_container_digest: String,
+    tool_versions: String,
+    submodule_commits: String,
+    code_base: u64,
+    code_size: u64,
+    vars_base: u64,
+    vars_size: u64,
+    combined_size: u64,
+    reset_vector: u64,
+    code_file: String,
+    code_sha256: Option<String>,
+    vars_file: String,
+    vars_sha256: Option<String>,
+    combined_file: String,
+    combined_sha256: Option<String>,
+    fd_size_4mb: bool,
+    debug_on_serial_port: bool,
+    build_shell: bool,
+    smm_require: bool,
+    secure_boot_enable: bool,
+    tpm2_enable: bool,
+    network_enable: bool,
+    sdcard_enable: bool,
+    cc_measurement_enable: bool,
+    sec_marker: String,
+    pei_marker: String,
+    dxe_ipl_marker: String,
+    dxe_core_marker: String,
+    bds_marker: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use sha2::{Digest, Sha256};
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const FIXED_CODE_BYTES: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+    const FIXED_VARS_BYTES: [u8; 3] = [0xfe, 0xed, 0xfa];
+
+    #[test]
+    fn verifies_a_valid_managed_bundle() {
+        let dir = tempdir().unwrap();
+        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+
+        let bundle = verify_firmware(&FirmwareSource::Managed {
+            bundle_dir: dir.path().to_path_buf(),
+        })
+        .unwrap();
+
+        assert_eq!(bundle.profile, OVMF_PROFILE_NAME);
+        assert_eq!(bundle.code_base, OVMF_CODE_BASE);
+        assert_eq!(bundle.code_size, OVMF_CODE_SIZE);
+        assert_eq!(bundle.vars_base, OVMF_VARS_BASE);
+        assert_eq!(bundle.vars_size, OVMF_VARS_SIZE);
+        assert_eq!(bundle.combined_size, OVMF_COMBINED_SIZE);
+        assert_eq!(bundle.code_path, dir.path().join(CODE_FILE));
+        assert_eq!(bundle.code_sha256, sha256(&code));
+        assert!(bundle.verified);
+        assert!(bundle.reset_vector_in_code_window());
+        assert_eq!(bundle.code_end(), OVMF_CODE_BASE + OVMF_CODE_SIZE);
+        assert_eq!(vars.len(), OVMF_VARS_SIZE as usize);
+        assert_eq!(combined.len(), OVMF_COMBINED_SIZE as usize);
+    }
+
+    #[test]
+    fn rejects_wrong_code_sha256() {
+        let dir = tempdir().unwrap();
+        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let wrong = wrong_hash(&code);
+        fs::write(dir.path().join(CODE_FILE), &code).unwrap();
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            bundle_manifest_string(&code, &vars, &combined).replace(&sha256(&code), &wrong),
+        )
+        .unwrap();
+
+        let err = verify_err(dir.path());
+        assert!(
+            err.contains("SHA-256 mismatch")
+                && err.contains(&wrong)
+                && err.contains(&sha256(&code)),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_code_size() {
+        let dir = tempdir().unwrap();
+        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let mut short_code = code.clone();
+        short_code.pop();
+        fs::write(dir.path().join(CODE_FILE), short_code).unwrap();
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            bundle_manifest_string(&code, &vars, &combined),
+        )
+        .unwrap();
+
+        let err = verify_err(dir.path());
+        assert!(
+            err.contains("has size") && err.contains("expected"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_code_base() {
+        let dir = tempdir().unwrap();
+        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let manifest = bundle_manifest_string(&code, &vars, &combined)
+            .replace("code_base = 0xffc84000", "code_base = 0xffc00000");
+        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
+
+        let err = verify_err(dir.path());
+        assert!(
+            err.contains("code_base") && err.contains("0xffc84000") && err.contains("0xffc00000"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_profile_name() {
+        let dir = tempdir().unwrap();
+        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let manifest = bundle_manifest_string(&code, &vars, &combined)
+            .replace(OVMF_PROFILE_NAME, "some-other-profile");
+        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
+
+        let err = verify_err(dir.path());
+        assert!(
+            err.contains("profile") && err.contains("some-other-profile"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_manifest_field() {
+        let dir = tempdir().unwrap();
+        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let manifest = format!(
+            "{}\nunknown_field = \"anything\"\n",
+            bundle_manifest_string(&code, &vars, &combined)
+        );
+        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
+
+        let err = verify_err(dir.path());
+        assert!(err.contains("unknown_field"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_manifest_field() {
+        for duplicate in [
+            "profile = \"ignored-duplicate\"",
+            "code_base = 0xffc00000",
+            "code_sha256 = \"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"",
+        ] {
+            let dir = tempdir().unwrap();
+            let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+            let manifest = format!(
+                "{}\n{duplicate}\n",
+                bundle_manifest_string(&code, &vars, &combined)
+            );
+            fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
+
+            let err = verify_err(dir.path());
+            assert!(
+                err.contains("duplicate"),
+                "accepted duplicate key {duplicate:?}, error: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_wrong_combined_file_layout() {
+        let dir = tempdir().unwrap();
+        let (code, vars, _combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let mut swapped = Vec::with_capacity(code.len() + vars.len());
+        swapped.extend_from_slice(&code);
+        swapped.extend_from_slice(&vars);
+        fs::write(dir.path().join(COMBINED_FILE), &swapped).unwrap();
+        fs::write(
+            dir.path().join(MANIFEST_FILE),
+            bundle_manifest_string(&code, &vars, &swapped),
+        )
+        .unwrap();
+
+        let err = verify_err(dir.path());
+        assert!(
+            err.contains("byte-for-byte concatenation"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_wrong_reset_vector_value() {
+        let dir = tempdir().unwrap();
+        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let manifest = bundle_manifest_string(&code, &vars, &combined)
+            .replace("reset_vector = 0xfffffff0", "reset_vector = 0xffff0000");
+        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
+
+        let err = verify_err(dir.path());
+        assert!(
+            err.contains("reset_vector") && err.contains("0xfffffff0"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn reset_vector_window_predicate_rejects_windows_outside_4gib() {
+        // The fixed profile puts the reset vector at the very end of the
+        // 4 GiB window, so the predicate holds for the verified bundle and
+        // rejects any smaller CODE window.
+        let mut bundle = verified_fixture_bundle(Path::new("OVMF_CODE.fd"));
+        assert!(bundle.reset_vector_in_code_window());
+
+        bundle.code_base = OVMF_VARS_BASE;
+        bundle.code_size = OVMF_VARS_SIZE;
+        assert!(!bundle.reset_vector_in_code_window());
+    }
+
+    #[test]
+    fn rejects_missing_sha256_field() {
+        let dir = tempdir().unwrap();
+        let (code, vars, combined) = write_bundle(dir.path(), &bundle_manifest_string);
+        let manifest = bundle_manifest_string(&code, &vars, &combined)
+            .lines()
+            .filter(|line| !line.starts_with("code_sha256"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(dir.path().join(MANIFEST_FILE), manifest).unwrap();
+
+        let err = verify_err(dir.path());
+        assert!(
+            err.contains("missing code_sha256"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_unverified_firmware_without_opt_in() {
+        let dir = tempdir().unwrap();
+        let code_path = dir.path().join("local-OVMF_CODE.fd");
+        fs::write(&code_path, vec![0xa5; OVMF_CODE_SIZE as usize]).unwrap();
+
+        let source = FirmwareSource::from_cli(Some(code_path.clone()), false);
+
+        assert!(source.is_err());
+        let err = format!("{:?}", source.err().unwrap().to_string());
+        assert!(
+            err.contains("--allow-unverified-firmware"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn accepts_unverified_firmware_with_opt_in_and_prints_sha256() {
+        let dir = tempdir().unwrap();
+        let code_path = dir.path().join("local-OVMF_CODE.fd");
+        let code = vec![0xa5; OVMF_CODE_SIZE as usize];
+        fs::write(&code_path, &code).unwrap();
+
+        let source = FirmwareSource::from_cli(Some(code_path.clone()), true).unwrap();
+        let source = source.unwrap();
+
+        assert_eq!(
+            source,
+            FirmwareSource::UnverifiedLocal {
+                code_path: code_path.clone()
+            }
+        );
+
+        let bundle = verify_firmware(&source).unwrap();
+        assert_eq!(bundle.code_path, code_path);
+        assert_eq!(bundle.code_sha256, sha256(&code));
+        assert_eq!(bundle.code_size, OVMF_CODE_SIZE);
+        assert!(!bundle.verified);
+        assert!(bundle.reset_vector_in_code_window());
+    }
+
+    #[test]
+    fn rejects_unverified_firmware_with_wrong_size_even_with_opt_in() {
+        let dir = tempdir().unwrap();
+        let code_path = dir.path().join("local-OVMF_CODE.fd");
+        fs::write(&code_path, vec![0xa5; 0x1000]).unwrap();
+
+        let source = FirmwareSource::from_cli(Some(code_path.clone()), true).unwrap();
+        let source = source.unwrap();
+        let err = format!("{:?}", verify_firmware(&source).unwrap_err().to_string());
+
+        assert!(
+            err.contains("must still match the fixed CODE size"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn managed_bundle_requires_manifest_present() {
+        let dir = tempdir().unwrap();
+        write_bundle(dir.path(), &bundle_manifest_string);
+        fs::remove_file(dir.path().join(MANIFEST_FILE)).unwrap();
+
+        let err = format!(
+            "{:?}",
+            FirmwareSource::from_cli(Some(dir.path().to_path_buf()), false)
+                .unwrap_err()
+                .to_string()
+        );
+
+        assert!(
+            err.contains("missing manifest.toml"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn rejects_nonexistent_firmware_path() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does-not-exist");
+
+        let err = format!(
+            "{:?}",
+            FirmwareSource::from_cli(Some(missing.clone()), true)
+                .unwrap_err()
+                .to_string()
+        );
+
+        assert!(err.contains("does not exist"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn from_cli_none_is_accepted_without_flags() {
+        assert_eq!(FirmwareSource::from_cli(None, false).unwrap(), None);
+    }
+
+    fn verify_err(bundle_dir: &Path) -> String {
+        format!(
+            "{:#}",
+            verify_firmware(&FirmwareSource::Managed {
+                bundle_dir: bundle_dir.to_path_buf()
+            })
+            .unwrap_err()
+        )
+    }
+
+    /// Writes the flat manifest for a fixed bundle from the three images.
+    type ManifestWriter = dyn Fn(&[u8], &[u8], &[u8]) -> String;
+
+    /// Write a complete managed bundle (CODE, VARS, combined image and flat
+    /// manifest) with fixed byte patterns, returning the three images.
+    fn write_bundle(bundle_dir: &Path, manifest: &ManifestWriter) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let mut code = FIXED_CODE_BYTES.to_vec();
+        code.resize(OVMF_CODE_SIZE as usize, 0xa5);
+        let mut vars = FIXED_VARS_BYTES.to_vec();
+        vars.resize(OVMF_VARS_SIZE as usize, 0x5a);
+        let mut combined = Vec::with_capacity(vars.len() + code.len());
+        combined.extend_from_slice(&vars);
+        combined.extend_from_slice(&code);
+
+        fs::write(bundle_dir.join(CODE_FILE), &code).unwrap();
+        fs::write(bundle_dir.join(VARS_FILE), &vars).unwrap();
+        fs::write(bundle_dir.join(COMBINED_FILE), &combined).unwrap();
+        fs::write(
+            bundle_dir.join(MANIFEST_FILE),
+            manifest(&code, &vars, &combined),
+        )
+        .unwrap();
+        (code, vars, combined)
+    }
+
+    fn bundle_manifest_string(code: &[u8], vars: &[u8], combined: &[u8]) -> String {
+        format!(
+            r#"schema_version = 1
+profile = "qemu_x86_64_axvisor_ovmf_debug"
+edk2_tag = "edk2-stable202605"
+edk2_commit = "b03a21a63e3bd001f52c527e5a57feddb53a690b"
+architecture = "X64"
+target = "DEBUG"
+toolchain = "GCC"
+platform = "OvmfPkg/OvmfPkgX64.dsc"
+build_command = "build -a X64 -b DEBUG"
+build_container_digest = "sha256:fixture"
+tool_versions = "fixture"
+submodule_commits = "fixture"
+code_base = 0xffc84000
+code_size = 0x37c000
+vars_base = 0xffc00000
+vars_size = 0x84000
+combined_size = 0x400000
+reset_vector = 0xfffffff0
+code_file = "OVMF_CODE.fd"
+code_sha256 = "{code_sha256}"
+vars_file = "OVMF_VARS.fd"
+vars_sha256 = "{vars_sha256}"
+combined_file = "OVMF.fd"
+combined_sha256 = "{combined_sha256}"
+fd_size_4mb = true
+debug_on_serial_port = true
+build_shell = true
+smm_require = false
+secure_boot_enable = false
+tpm2_enable = false
+network_enable = false
+sdcard_enable = false
+cc_measurement_enable = false
+sec_marker = "SecCoreStartupWithStack("
+pei_marker = "Platform PEIM Loaded"
+dxe_ipl_marker = "DXE IPL Entry"
+dxe_core_marker = "Loading DXE CORE at"
+bds_marker = "[BdsDxe]"
+"#,
+            code_sha256 = sha256(code),
+            vars_sha256 = sha256(vars),
+            combined_sha256 = sha256(combined),
+        )
+    }
+
+    fn sha256(bytes: &[u8]) -> String {
+        format!("{:x}", Sha256::digest(bytes))
+    }
+
+    fn wrong_hash(bytes: &[u8]) -> String {
+        let mut hash = sha256(bytes).into_bytes();
+        let digit = hash.first_mut().unwrap();
+        *digit = if *digit == b'0' { b'1' } else { b'0' };
+        String::from_utf8(hash).unwrap()
+    }
+
+    /// Build a [`VerifiedOvmfBundle`] with the fixed profile layout for
+    /// testing predicates that do not require real files on disk.
+    fn verified_fixture_bundle(code_path: &Path) -> VerifiedOvmfBundle {
+        VerifiedOvmfBundle {
+            profile: OVMF_PROFILE_NAME.to_string(),
+            code_base: OVMF_CODE_BASE,
+            code_size: OVMF_CODE_SIZE,
+            vars_base: OVMF_VARS_BASE,
+            vars_size: OVMF_VARS_SIZE,
+            combined_size: OVMF_COMBINED_SIZE,
+            code_path: code_path.to_path_buf(),
+            code_sha256: sha256(&FIXED_CODE_BYTES),
+            verified: true,
+        }
+    }
+}

--- a/scripts/axbuild/src/axvisor/test/qemu.rs
+++ b/scripts/axbuild/src/axvisor/test/qemu.rs
@@ -640,6 +640,18 @@ fn verify_cli_firmware_bundle(
             })?;
     let bundle = ovmf::verify_firmware(&source)
         .with_context(|| format!("failed to verify OVMF firmware `{}`", path.display()))?;
+    if !bundle.verified {
+        // `--allow-unverified-firmware` is a diagnostic-only escape hatch: an
+        // unverified local CODE file must not drive the ovmf-entry test
+        // conclusion, or the "fixed, manifest-verified firmware" guarantee of
+        // the case is bypassed. Reject it before any QEMU wiring.
+        anyhow::bail!(
+            "firmware `{}` is UNVERIFIED (--allow-unverified-firmware); it cannot drive the \
+             ovmf-entry test result — pass a managed bundle directory containing manifest.toml \
+             instead",
+            path.display()
+        );
+    }
     println!(
         "verified OVMF firmware bundle for ovmf-entry cases: {} (sha256={})",
         bundle.code_path.display(),
@@ -870,6 +882,21 @@ disabled = []
         let err = verify_cli_firmware_bundle(&args).unwrap_err();
         let rendered = format!("{err:#}");
         assert!(rendered.contains("does not exist"), "{rendered}");
+    }
+
+    #[test]
+    fn verify_cli_firmware_bundle_rejects_unverified_local_firmware() {
+        let root = tempdir().unwrap();
+        let code = root.path().join("OVMF_CODE.fd");
+        fs::write(&code, vec![0xa5; ovmf::OVMF_CODE_SIZE as usize]).unwrap();
+        let args = test_qemu_args(Some("x86_64".to_string()), Some(code.clone()), true);
+
+        let err = verify_cli_firmware_bundle(&args).unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("UNVERIFIED") && rendered.contains("cannot drive"),
+            "{rendered}"
+        );
     }
 
     #[test]

--- a/scripts/axbuild/src/axvisor/test/qemu.rs
+++ b/scripts/axbuild/src/axvisor/test/qemu.rs
@@ -1,11 +1,13 @@
 use std::{
     collections::BTreeMap,
+    fs,
     path::{Path, PathBuf},
     time::Instant,
 };
 
-use anyhow::Context;
+use anyhow::{Context, anyhow};
 use ostool::{build::config::Cargo, run::qemu::QemuConfig};
+use test_case::TestQemuCase;
 
 use super::{
     AXVISOR_NORMAL_GROUP, AxvisorQemuCase,
@@ -19,7 +21,7 @@ use super::{
     types::PreparedAxvisorQemuCase,
 };
 use crate::{
-    axvisor::{ArgsTestQemu, Axvisor, build, rootfs},
+    axvisor::{ArgsTestQemu, Axvisor, build, ovmf, rootfs},
     context::{AxvisorCliArgs, ResolvedAxvisorRequest, SnapshotPersistence},
     test::{case as test_case, qemu as test_qemu},
 };
@@ -91,6 +93,20 @@ impl Axvisor {
             return Ok(());
         }
 
+        // Verify the firmware bundle before any build work so a bad bundle
+        // fails fast. Runs after the `--list` early returns, so listing cases
+        // never requires a firmware bundle. Without `--firmware-bundle-path`
+        // the ovmf-entry case fails fast when its QEMU config is wired (instead
+        // of hanging at `Booting from ROM..` or silently using a distro OVMF),
+        // and other cases keep their exact previous behavior.
+        //
+        // Bundle verification intentionally happens after case discovery: only
+        // discovery knows whether an ovmf-entry case is actually selected
+        // (which cases exist depends on the arch/target/group), and the
+        // discovery phase is cheap. The prepare phase then fails fast for the
+        // ovmf-entry case before any build or QEMU work starts.
+        let firmware_bundle = verify_cli_firmware_bundle(&args)?;
+
         println!(
             "running axvisor qemu tests for arch: {} (target: {}, cases: {})",
             arch,
@@ -106,7 +122,7 @@ impl Axvisor {
         )?;
         let request = Self::qemu_test_request(request);
         let cases = self
-            .prepare_qemu_cases(&request, cases)
+            .prepare_qemu_cases(&request, cases, firmware_bundle.as_ref())
             .await
             .context("failed to load Axvisor qemu test cases")?;
         self.app.set_debug_mode(request.debug)?;
@@ -117,7 +133,7 @@ impl Axvisor {
         let asset_config = axvisor_case_asset_config();
 
         let mut build_groups = test_qemu::prepare_case_build_groups(&cases, |build_config_path| {
-            Self::qemu_group_build_context(&request, build_config_path)
+            Self::qemu_group_build_context(&request, build_config_path, firmware_bundle.as_ref())
         })?;
 
         // Phase 1: Build all build groups first so compilation errors surface
@@ -187,6 +203,7 @@ impl Axvisor {
         &mut self,
         request: &ResolvedAxvisorRequest,
         cases: Vec<AxvisorQemuCase>,
+        firmware_bundle: Option<&ovmf::VerifiedOvmfBundle>,
     ) -> anyhow::Result<Vec<PreparedAxvisorQemuCase>> {
         let mut prepared = Vec::with_capacity(cases.len());
         let mut cargo_by_build_config = BTreeMap::new();
@@ -196,7 +213,7 @@ impl Axvisor {
                 &case.build_config_path,
                 &mut cargo_by_build_config,
             )?;
-            let qemu = self
+            let mut qemu = self
                 .app
                 .read_qemu_config_from_path_for_cargo(&cargo, &case.case.qemu_config_path)
                 .await
@@ -207,6 +224,7 @@ impl Axvisor {
                     )
                 })?;
             test_qemu::validate_grouped_qemu_commands(&qemu, &case.case, "Axvisor")?;
+            wire_ovmf_entry_qemu_firmware(&mut qemu, &case.case, firmware_bundle)?;
             prepared.push(PreparedAxvisorQemuCase { case, qemu });
         }
 
@@ -232,11 +250,19 @@ impl Axvisor {
     fn qemu_group_build_context(
         request: &ResolvedAxvisorRequest,
         build_config_path: &Path,
+        firmware_bundle: Option<&ovmf::VerifiedOvmfBundle>,
     ) -> anyhow::Result<(ResolvedAxvisorRequest, Cargo)> {
         let mut request = request.clone();
         request.build_info_path = build_config_path.to_path_buf();
         let cargo = build::load_cargo_config(&request)?;
         request.vmconfigs = build::vmconfigs_from_cargo(&cargo);
+        let workspace_root = build::workspace_root_from_axvisor_dir(&request.axvisor_dir);
+        request.vmconfigs = wire_ovmf_entry_vmconfig(
+            request.vmconfigs,
+            firmware_bundle,
+            &workspace_root,
+            &request.target,
+        )?;
 
         Ok((request, cargo))
     }
@@ -316,6 +342,312 @@ impl Axvisor {
     }
 }
 
+/// VM config template file name that selects the fixed OVMF entry case.
+const OVMF_ENTRY_VM_CONFIG_FILE: &str = "ovmf-entry.toml";
+
+/// Case directory name (the test-suit `uefi` group directory holding the
+/// ovmf-entry qemu configs) that selects the fixed OVMF entry case.
+///
+/// This is the file name of the case directory itself, not the discovered case
+/// name: discovery names each case after its build wrapper (`ovmf-entry-vmx` /
+/// `ovmf-entry-svm`), so the case name carries the variant suffix and can only
+/// be matched by prefix.
+const OVMF_ENTRY_CASE_DIR: &str = "ovmf-entry";
+
+/// QEMU case name prefix (as discovered for the `uefi` group) that selects the
+/// fixed OVMF entry case. The variant suffix (`-vmx` / `-svm`) comes from the
+/// build wrapper, so the case is matched by the wrapper prefix.
+///
+/// The prefix match is deliberately narrow: it only accepts cases whose
+/// directory is exactly `OVMF_ENTRY_CASE_DIR` (enforced by
+/// [`ensure_ovmf_entry_case_dir`]), which is the same directory the checked-in
+/// VM config template `OVMF_ENTRY_VM_CONFIG_FILE` lives in. A future
+/// non-ovmf-entry case whose name merely starts with the same prefix is
+/// rejected instead of being silently wired to the fixed bundle. A future
+/// ovmf-entry variant that must NOT use the manifest-verified fixed CODE
+/// bundle must re-evaluate this match so it cannot wire the wrong case.
+const OVMF_ENTRY_QEMU_CASE_PREFIX: &str = "ovmf-entry-";
+
+/// Wires the ovmf-entry QEMU case to the manifest-verified firmware bundle.
+///
+/// The QEMU layer boots the Axvisor host with `-kernel <axvisor.bin>`, where
+/// the binary is a PE32+ UEFI image. QEMU can only load such an image through
+/// its OVMF firmware, so without explicit pflash drives the run falls through
+/// to SeaBIOS and hangs at `Booting from ROM..` (see the `ktest`
+/// `patch_system_x86_64_uefi_kernel_loader` precedent, which documents the
+/// same requirement). This function injects the verified bundle CODE as the
+/// read-only pflash unit 0 and a writable copy of the bundle VARS as unit 1.
+///
+/// The injected CODE is the same file that `verify_firmware` accepted and that
+/// the generated VM config embeds via `include_bytes!`, so the QEMU-layer
+/// firmware and the nested OVMF loaded by Axvisor are byte-for-byte identical.
+///
+/// Without `--firmware-bundle-path` the ovmf-entry case cannot boot at all;
+/// instead of hanging for `timeout` seconds (or silently using a distro OVMF),
+/// the run fails fast with a clear error naming the required flag.
+///
+/// Only cases whose directory is exactly `OVMF_ENTRY_CASE_DIR` are wired (see
+/// [`ensure_ovmf_entry_case_dir`]); other cases are never touched.
+///
+/// The unit 1 VARS file is a fresh copy created from the verified bundle
+/// template on every run, so it never carries state between runs. It does not
+/// rely on the `-snapshot` isolation that `qemu.uefi` cases get through
+/// [`test_qemu::apply_drive_snapshot_without_global_snapshot`] (ovmf-entry
+/// cases run with `uefi = false`). If a future case must let the guest write
+/// VARS persistently and still stay isolated per run, the pflash unit 1 drive
+/// needs the same per-drive snapshot handling as the `qemu.uefi` path.
+fn wire_ovmf_entry_qemu_firmware(
+    qemu: &mut QemuConfig,
+    case: &TestQemuCase,
+    firmware_bundle: Option<&ovmf::VerifiedOvmfBundle>,
+) -> anyhow::Result<()> {
+    if !case.name.starts_with(OVMF_ENTRY_QEMU_CASE_PREFIX) {
+        return Ok(());
+    }
+    ensure_ovmf_entry_case_dir(case)?;
+    let bundle = firmware_bundle.ok_or_else(|| {
+        // `concat!` keeps the rendered message (three lines, one bullet per
+        // line) visible in the source instead of relying on `\` line
+        // continuations whose whitespace is stripped at runtime.
+        anyhow!(
+            concat!(
+                "case `{name}` needs a verified OVMF firmware bundle:\n",
+                "- pass `--firmware-bundle-path <bundle-dir>` for a managed bundle with ",
+                "manifest.toml\n",
+                "- `--allow-unverified-firmware` is only for a local CODE file and must not ",
+                "determine UEFI test results",
+            ),
+            name = case.name,
+        )
+    })?;
+    let vars_template = bundle
+        .code_path
+        .parent()
+        .ok_or_else(|| {
+            anyhow!(
+                "verified OVMF CODE path {} has no parent directory",
+                bundle.code_path.display()
+            )
+        })?
+        .join(ovmf::VARS_FILE);
+    if !vars_template.is_file() {
+        anyhow::bail!(
+            "missing {} next to the CODE file {} (required for the QEMU-layer pflash unit 1)",
+            vars_template.display(),
+            bundle.code_path.display()
+        );
+    }
+    let vars = vars_template.with_extension("ovmf-entry.vars.fd");
+    fs::copy(&vars_template, &vars).with_context(|| {
+        format!(
+            "failed to copy OVMF vars from {} to {}",
+            vars_template.display(),
+            vars.display()
+        )
+    })?;
+    qemu.args.extend([
+        "-drive".to_string(),
+        format!(
+            "if=pflash,format=raw,unit=0,readonly=on,file={}",
+            bundle.code_path.display()
+        ),
+        "-drive".to_string(),
+        format!("if=pflash,format=raw,unit=1,file={}", vars.display()),
+    ]);
+    println!(
+        "wired verified OVMF firmware {} into QEMU layer for case `{}`",
+        bundle.code_path.display(),
+        case.name
+    );
+    Ok(())
+}
+
+/// Verifies that a prefix-matched case really lives in the ovmf-entry case
+/// directory before the fixed firmware bundle is wired to it.
+///
+/// The case name (`ovmf-entry-<variant>`) alone is a weak selector: discovery
+/// names every case after its build wrapper, so any future case whose
+/// directory starts with the same prefix would be caught by the match. The
+/// case directory is the second, exact selector: only a case whose directory
+/// is named exactly `OVMF_ENTRY_CASE_DIR` (the directory that also holds the
+/// `OVMF_ENTRY_VM_CONFIG_FILE` template) may use the manifest-verified fixed
+/// CODE bundle.
+fn ensure_ovmf_entry_case_dir(case: &TestQemuCase) -> anyhow::Result<()> {
+    let dir_name = case
+        .case_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    if dir_name == OVMF_ENTRY_CASE_DIR {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "case `{}` matches the ovmf-entry prefix but is not in the ovmf-entry case directory \
+         (directory `{}` is not `{OVMF_ENTRY_CASE_DIR}`); add the case to the fixed ovmf-entry \
+         bundle or rename it so it does not use the prefix",
+        case.name,
+        case.case_dir.display()
+    )
+}
+
+/// Rewires the ovmf-entry VM config to the manifest-verified firmware bundle.
+///
+/// When `--firmware-bundle-path` is supplied, every build group whose VM
+/// configs include the checked-in `ovmf-entry.toml` template gets a generated
+/// per-run config with `image_location = "memory"` and `kernel_path` /
+/// `uefi_firmware_path` pointing at the verified CODE file. `os/axvisor/
+/// build.rs` then embeds that exact CODE into the Axvisor binary with
+/// `include_bytes!`, so the nested OVMF loaded by Axvisor is byte-for-byte
+/// the firmware that `verify_firmware` accepted.
+///
+/// Groups that do not use the template (or runs without a bundle) keep their
+/// vm_configs untouched.
+fn wire_ovmf_entry_vmconfig(
+    vmconfigs: Vec<PathBuf>,
+    firmware_bundle: Option<&ovmf::VerifiedOvmfBundle>,
+    workspace_root: &Path,
+    target: &str,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let Some(bundle) = firmware_bundle else {
+        return Ok(vmconfigs);
+    };
+    let Some(index) = vmconfigs.iter().position(|path| {
+        path.file_name()
+            .is_some_and(|name| name == OVMF_ENTRY_VM_CONFIG_FILE)
+    }) else {
+        return Ok(vmconfigs);
+    };
+
+    let template_path = &vmconfigs[index];
+    let generated = generate_ovmf_entry_vm_config(template_path, bundle, workspace_root, target)?;
+    let mut rewired = vmconfigs;
+    rewired[index] = generated;
+    Ok(rewired)
+}
+
+/// Writes the per-run ovmf-entry VM config embedding the verified CODE.
+///
+/// The generated config keeps the checked-in template's `[base]`, memory
+/// regions, and device selection, and overrides only the kernel image source:
+/// `image_location = "memory"` with absolute `kernel_path` /
+/// `uefi_firmware_path` pointing at the verified CODE file. The output is a
+/// real file on disk because `os/axvisor/build.rs` resolves the paths relative
+/// to the config file location at build time.
+fn generate_ovmf_entry_vm_config(
+    template_path: &Path,
+    bundle: &ovmf::VerifiedOvmfBundle,
+    workspace_root: &Path,
+    target: &str,
+) -> anyhow::Result<PathBuf> {
+    let template = fs::read_to_string(template_path).with_context(|| {
+        format!(
+            "failed to read ovmf-entry VM config template {}",
+            template_path.display()
+        )
+    })?;
+    let mut config: toml::Value = toml::from_str(&template)
+        .with_context(|| format!("failed to parse {}", template_path.display()))?;
+    let kernel = config
+        .get_mut("kernel")
+        .and_then(toml::Value::as_table_mut)
+        .ok_or_else(|| {
+            anyhow!(
+                "ovmf-entry VM config {} has no [kernel] table",
+                template_path.display()
+            )
+        })?;
+    let code_path = bundle.code_path.display().to_string();
+    kernel.insert(
+        "image_location".to_string(),
+        toml::Value::String("memory".to_string()),
+    );
+    kernel.insert(
+        "kernel_path".to_string(),
+        toml::Value::String(code_path.clone()),
+    );
+    kernel.insert(
+        "uefi_firmware_path".to_string(),
+        toml::Value::String(code_path),
+    );
+    kernel.insert(
+        "bios_load_addr".to_string(),
+        toml::Value::Integer(ovmf::OVMF_CODE_BASE as i64),
+    );
+    kernel.insert(
+        "firmware_profile".to_string(),
+        toml::Value::String(ovmf::OVMF_PROFILE_NAME.to_string()),
+    );
+    let output = toml::to_string_pretty(&config)
+        .with_context(|| format!("failed to serialize {}", template_path.display()))?;
+
+    let output_path = ovmf_entry_generated_config_path(workspace_root, target);
+    let parent = output_path.parent().with_context(|| {
+        format!(
+            "generated ovmf-entry VM config has no parent: {}",
+            output_path.display()
+        )
+    })?;
+    fs::create_dir_all(parent).with_context(|| format!("failed to create {}", parent.display()))?;
+    fs::write(&output_path, output)
+        .with_context(|| format!("failed to write {}", output_path.display()))?;
+    println!(
+        "wired verified OVMF CODE {} into {}",
+        bundle.code_path.display(),
+        output_path.display()
+    );
+    Ok(output_path)
+}
+
+/// Computes the per-run generated VM config path for an ovmf-entry template.
+///
+/// The path lives under the build target's `qemu-cases` work directory, next
+/// to the case asset layout used by the other QEMU test cases.
+///
+/// Both ovmf-entry variants (`ovmf-entry-vmx` and `ovmf-entry-svm`) share this
+/// single path: they use the same target (`x86_64-unknown-none`) and the same
+/// verified bundle, so the generated content is identical and the last write
+/// wins harmlessly. If a future variant diverges in target or firmware, the
+/// path must become variant-scoped.
+fn ovmf_entry_generated_config_path(workspace_root: &Path, target: &str) -> PathBuf {
+    workspace_root
+        .join("target")
+        .join(target)
+        .join("qemu-cases")
+        .join("ovmf-entry")
+        .join(format!("{OVMF_ENTRY_VM_CONFIG_FILE}.vmconfig.toml"))
+}
+
+/// Verifies the CLI-selected firmware bundle, if any.
+///
+/// Without `--firmware-bundle-path` no firmware is resolved and `None` is
+/// returned; existing test runs keep their exact previous behavior. With a
+/// bundle path the source is resolved and fully verified, and any failure
+/// aborts the run with a clear error before any build or QEMU work starts.
+fn verify_cli_firmware_bundle(
+    args: &ArgsTestQemu,
+) -> anyhow::Result<Option<ovmf::VerifiedOvmfBundle>> {
+    let Some(path) = args.firmware_bundle_path.as_deref() else {
+        return Ok(None);
+    };
+    let source =
+        ovmf::FirmwareSource::from_cli(Some(path.to_path_buf()), args.allow_unverified_firmware)
+            .with_context(|| format!("failed to resolve OVMF firmware path `{}`", path.display()))?
+            .ok_or_else(|| {
+                anyhow!(
+                    "OVMF firmware path `{}` did not resolve to a firmware source",
+                    path.display()
+                )
+            })?;
+    let bundle = ovmf::verify_firmware(&source)
+        .with_context(|| format!("failed to verify OVMF firmware `{}`", path.display()))?;
+    println!(
+        "verified OVMF firmware bundle for ovmf-entry cases: {} (sha256={})",
+        bundle.code_path.display(),
+        bundle.code_sha256
+    );
+    Ok(Some(bundle))
+}
+
 fn axvisor_qemu_test_build_args(arch: &str, config: Option<PathBuf>) -> AxvisorCliArgs {
     AxvisorCliArgs {
         config,
@@ -324,5 +656,416 @@ fn axvisor_qemu_test_build_args(arch: &str, config: Option<PathBuf>) -> AxvisorC
         smp: None,
         debug: false,
         vmconfigs: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
+
+    use super::*;
+
+    const TEST_OVMF_ENTRY_TEMPLATE: &str = r#"
+[base]
+id = 1
+name = "ovmf-entry"
+guest_type = "passthrough"
+cpu_num = 1
+phys_cpu_sets = [1]
+
+[kernel]
+entry_point = 0xffff_fff0
+image_location = "fs"
+kernel_path = "/guest/ovmf/OVMF_CODE.fd"
+kernel_load_addr = 0x20_0000
+enable_bios = true
+boot_protocol = "uefi"
+uefi_firmware_path = "/guest/ovmf/OVMF_CODE.fd"
+bios_load_addr = 0xffc8_4000
+firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"
+
+memory_regions = [
+  [0x0000_0000, 0x100_0000, 0x7, 0],
+  [0xffc0_0000, 0x40_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = []
+disabled = []
+"#;
+
+    fn write_template(root: &Path) -> PathBuf {
+        let path = root.join("os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml");
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, TEST_OVMF_ENTRY_TEMPLATE).unwrap();
+        path
+    }
+
+    fn fixture_bundle(code_path: &Path) -> ovmf::VerifiedOvmfBundle {
+        ovmf::VerifiedOvmfBundle {
+            profile: ovmf::OVMF_PROFILE_NAME.to_string(),
+            code_base: ovmf::OVMF_CODE_BASE,
+            code_size: ovmf::OVMF_CODE_SIZE,
+            vars_base: ovmf::OVMF_VARS_BASE,
+            vars_size: ovmf::OVMF_VARS_SIZE,
+            combined_size: ovmf::OVMF_COMBINED_SIZE,
+            code_path: code_path.to_path_buf(),
+            code_sha256: "ab".repeat(32),
+            verified: true,
+        }
+    }
+
+    #[test]
+    fn wiring_replaces_ovmf_entry_template_with_generated_memory_config() {
+        let root = tempdir().unwrap();
+        let template = write_template(root.path());
+        let code = root.path().join("bundle/OVMF_CODE.fd");
+        let bundle = fixture_bundle(&code);
+        let vmconfigs = vec![template.clone()];
+
+        let rewired =
+            wire_ovmf_entry_vmconfig(vmconfigs, Some(&bundle), root.path(), "x86_64-unknown-none")
+                .unwrap();
+
+        assert_eq!(rewired.len(), 1);
+        assert_ne!(rewired[0], template);
+        assert!(
+            rewired[0].starts_with(
+                root.path()
+                    .join("target/x86_64-unknown-none/qemu-cases/ovmf-entry")
+            )
+        );
+
+        let generated = fs::read_to_string(&rewired[0]).unwrap();
+        let config: toml::Value = toml::from_str(&generated).unwrap();
+        let kernel = config.get("kernel").unwrap().as_table().unwrap();
+        assert_eq!(
+            kernel.get("image_location").unwrap().as_str(),
+            Some("memory")
+        );
+        assert_eq!(
+            kernel.get("kernel_path").unwrap().as_str(),
+            Some(code.to_str().unwrap())
+        );
+        assert_eq!(
+            kernel.get("uefi_firmware_path").unwrap().as_str(),
+            Some(code.to_str().unwrap())
+        );
+        assert_eq!(
+            kernel.get("bios_load_addr").unwrap().as_integer(),
+            Some(ovmf::OVMF_CODE_BASE as i64)
+        );
+        assert_eq!(
+            kernel.get("firmware_profile").unwrap().as_str(),
+            Some(ovmf::OVMF_PROFILE_NAME)
+        );
+        // The generated config must keep the checked-in memory regions.
+        let regions = config
+            .get("kernel")
+            .unwrap()
+            .get("memory_regions")
+            .unwrap()
+            .as_array()
+            .unwrap();
+        assert_eq!(regions.len(), 2);
+        assert_eq!(
+            regions[1].as_array().unwrap()[0].as_integer(),
+            Some(0xffc0_0000)
+        );
+    }
+
+    #[test]
+    fn wiring_keeps_other_vm_configs_untouched() {
+        let root = tempdir().unwrap();
+        write_template(root.path());
+        let other = root
+            .path()
+            .join("os/axvisor/configs/vms/qemu/x86_64/arceos-smp1.toml");
+        fs::write(&other, "[base]\nid = 2\n").unwrap();
+        let bundle = fixture_bundle(&root.path().join("bundle/OVMF_CODE.fd"));
+
+        let rewired = wire_ovmf_entry_vmconfig(
+            vec![other.clone()],
+            Some(&bundle),
+            root.path(),
+            "x86_64-unknown-none",
+        )
+        .unwrap();
+
+        assert_eq!(rewired, vec![other]);
+    }
+
+    #[test]
+    fn wiring_without_bundle_keeps_vmconfigs_untouched() {
+        let root = tempdir().unwrap();
+        let template = write_template(root.path());
+
+        let rewired = wire_ovmf_entry_vmconfig(
+            vec![template.clone()],
+            None,
+            root.path(),
+            "x86_64-unknown-none",
+        )
+        .unwrap();
+
+        assert_eq!(rewired, vec![template]);
+    }
+
+    #[test]
+    fn generated_config_parses_as_axvmconfig_guest() {
+        let root = tempdir().unwrap();
+        let template = write_template(root.path());
+        let code = root.path().join("bundle/OVMF_CODE.fd");
+        let bundle = fixture_bundle(&code);
+        let generated =
+            generate_ovmf_entry_vm_config(&template, &bundle, root.path(), "x86_64-unknown-none")
+                .unwrap();
+        let content = fs::read_to_string(&generated).unwrap();
+
+        let config = axvmconfig::GuestConfig::from_toml(&content).unwrap();
+        config.kernel.validate_boot_config().unwrap();
+        assert_eq!(config.kernel.image_location.as_deref(), Some("memory"));
+        assert_eq!(
+            config.kernel.firmware_profile.as_deref(),
+            Some(ovmf::OVMF_PROFILE_NAME)
+        );
+        assert_eq!(
+            config.kernel.bios_load_addr,
+            Some(ovmf::OVMF_CODE_BASE as usize)
+        );
+        assert_eq!(config.kernel.entry_point, ovmf::OVMF_RESET_VECTOR as usize);
+    }
+
+    fn test_qemu_args(
+        arch: Option<String>,
+        firmware_bundle_path: Option<PathBuf>,
+        allow_unverified_firmware: bool,
+    ) -> ArgsTestQemu {
+        ArgsTestQemu {
+            arch,
+            target: None,
+            test_group: None,
+            test_case: None,
+            list: false,
+            firmware_bundle_path,
+            allow_unverified_firmware,
+        }
+    }
+
+    #[test]
+    fn verify_cli_firmware_bundle_returns_none_without_path() {
+        let args = test_qemu_args(Some("x86_64".to_string()), None, false);
+
+        assert!(verify_cli_firmware_bundle(&args).unwrap().is_none());
+    }
+
+    #[test]
+    fn verify_cli_firmware_bundle_rejects_missing_bundle() {
+        let root = tempdir().unwrap();
+        let missing = root.path().join("missing-bundle");
+        let args = test_qemu_args(Some("x86_64".to_string()), Some(missing.clone()), false);
+
+        let err = verify_cli_firmware_bundle(&args).unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("does not exist"), "{rendered}");
+    }
+
+    #[test]
+    fn ovmf_entry_generated_config_path_is_target_scoped() {
+        let path = ovmf_entry_generated_config_path(Path::new("/ws"), "x86_64-unknown-none");
+
+        assert_eq!(
+            path,
+            PathBuf::from(
+                "/ws/target/x86_64-unknown-none/qemu-cases/ovmf-entry/ovmf-entry.toml.vmconfig.\
+                 toml"
+            )
+        );
+    }
+
+    fn fixture_qemu_case(name: &str) -> TestQemuCase {
+        TestQemuCase {
+            name: name.to_string(),
+            display_name: name.to_string(),
+            case_dir: PathBuf::from("/ws/test-suit/axvisor/uefi/ovmf-entry"),
+            qemu_config_path: PathBuf::from("/ws/qemu-x86_64-vmx.toml"),
+            test_commands: Vec::new(),
+            host_symbolize_success_regex: Vec::new(),
+            host_http_server: None,
+            subcases: Vec::new(),
+            grouped_subcase_filter: None,
+        }
+    }
+
+    #[test]
+    fn qemu_firmware_wiring_injects_verified_bundle_pflash_for_ovmf_entry() {
+        let root = tempdir().unwrap();
+        let bundle_dir = root.path().join("bundle");
+        fs::create_dir_all(&bundle_dir).unwrap();
+        let code = bundle_dir.join("OVMF_CODE.fd");
+        fs::write(&code, vec![0xa5; ovmf::OVMF_CODE_SIZE as usize]).unwrap();
+        let vars = bundle_dir.join(ovmf::VARS_FILE);
+        fs::write(&vars, vec![0x5a; ovmf::OVMF_VARS_SIZE as usize]).unwrap();
+        let bundle = fixture_bundle(&code);
+
+        let mut qemu = QemuConfig {
+            args: vec!["-kernel".to_string(), "axvisor.bin".to_string()],
+            uefi: false,
+            to_bin: true,
+            success_regex: Vec::new(),
+            fail_regex: Vec::new(),
+            shell_prefix: None,
+            shell_init_cmd: None,
+            timeout: Some(300),
+        };
+        wire_ovmf_entry_qemu_firmware(
+            &mut qemu,
+            &fixture_qemu_case("ovmf-entry-vmx"),
+            Some(&bundle),
+        )
+        .unwrap();
+
+        assert_eq!(
+            qemu.args,
+            vec![
+                "-kernel".to_string(),
+                "axvisor.bin".to_string(),
+                "-drive".to_string(),
+                format!(
+                    "if=pflash,format=raw,unit=0,readonly=on,file={}",
+                    code.display()
+                ),
+                "-drive".to_string(),
+                format!(
+                    "if=pflash,format=raw,unit=1,file={}",
+                    bundle_dir.join("OVMF_VARS.ovmf-entry.vars.fd").display()
+                ),
+            ]
+        );
+        // The writable VARS copy must exist next to the template.
+        assert!(bundle_dir.join("OVMF_VARS.ovmf-entry.vars.fd").is_file());
+    }
+
+    #[test]
+    fn qemu_firmware_wiring_leaves_other_cases_untouched() {
+        let root = tempdir().unwrap();
+        let bundle = fixture_bundle(&root.path().join("bundle/OVMF_CODE.fd"));
+
+        let mut qemu = QemuConfig {
+            args: vec!["-kernel".to_string(), "axvisor.bin".to_string()],
+            uefi: false,
+            to_bin: true,
+            success_regex: Vec::new(),
+            fail_regex: Vec::new(),
+            shell_prefix: None,
+            shell_init_cmd: None,
+            timeout: Some(300),
+        };
+        let original = qemu.args.clone();
+        wire_ovmf_entry_qemu_firmware(&mut qemu, &fixture_qemu_case("smoke-vmx"), Some(&bundle))
+            .unwrap();
+
+        assert_eq!(qemu.args, original);
+    }
+
+    #[test]
+    fn qemu_firmware_wiring_without_bundle_fails_fast_for_ovmf_entry() {
+        let mut qemu = QemuConfig {
+            args: vec!["-kernel".to_string(), "axvisor.bin".to_string()],
+            uefi: false,
+            to_bin: true,
+            success_regex: Vec::new(),
+            fail_regex: Vec::new(),
+            shell_prefix: None,
+            shell_init_cmd: None,
+            timeout: Some(300),
+        };
+
+        let err =
+            wire_ovmf_entry_qemu_firmware(&mut qemu, &fixture_qemu_case("ovmf-entry-svm"), None)
+                .unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("--firmware-bundle-path"),
+            "unexpected error: {rendered}"
+        );
+    }
+
+    #[test]
+    fn qemu_firmware_wiring_rejects_bundle_without_vars() {
+        let root = tempdir().unwrap();
+        let bundle_dir = root.path().join("bundle");
+        fs::create_dir_all(&bundle_dir).unwrap();
+        let code = bundle_dir.join("OVMF_CODE.fd");
+        fs::write(&code, vec![0xa5; ovmf::OVMF_CODE_SIZE as usize]).unwrap();
+        let bundle = fixture_bundle(&code);
+
+        let mut qemu = QemuConfig {
+            args: Vec::new(),
+            uefi: false,
+            to_bin: true,
+            success_regex: Vec::new(),
+            fail_regex: Vec::new(),
+            shell_prefix: None,
+            shell_init_cmd: None,
+            timeout: Some(300),
+        };
+        let err = wire_ovmf_entry_qemu_firmware(
+            &mut qemu,
+            &fixture_qemu_case("ovmf-entry-vmx"),
+            Some(&bundle),
+        )
+        .unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("OVMF_VARS.fd"),
+            "unexpected error: {rendered}"
+        );
+    }
+
+    #[test]
+    fn qemu_firmware_wiring_rejects_prefix_match_outside_ovmf_entry_dir() {
+        let mut qemu = QemuConfig {
+            args: Vec::new(),
+            uefi: false,
+            to_bin: true,
+            success_regex: Vec::new(),
+            fail_regex: Vec::new(),
+            shell_prefix: None,
+            shell_init_cmd: None,
+            timeout: Some(300),
+        };
+        let mut case = fixture_qemu_case("ovmf-entry-mem");
+        case.case_dir = PathBuf::from("/ws/test-suit/axvisor/uefi/ovmf-entry-mem");
+        let bundle = fixture_bundle(&PathBuf::from("/ws/bundle/OVMF_CODE.fd"));
+
+        let err = wire_ovmf_entry_qemu_firmware(&mut qemu, &case, Some(&bundle)).unwrap_err();
+        let rendered = format!("{err:#}");
+        assert!(
+            rendered.contains("not in the ovmf-entry case directory"),
+            "unexpected error: {rendered}"
+        );
+        assert!(qemu.args.is_empty(), "no pflash args may be injected");
+    }
+
+    #[test]
+    fn ensure_ovmf_entry_case_dir_accepts_only_the_ovmf_entry_directory() {
+        assert!(ensure_ovmf_entry_case_dir(&fixture_qemu_case("ovmf-entry-vmx")).is_ok());
+        assert!(ensure_ovmf_entry_case_dir(&fixture_qemu_case("ovmf-entry-svm")).is_ok());
+
+        let mut other = fixture_qemu_case("ovmf-entry-mem");
+        other.case_dir = PathBuf::from("/ws/test-suit/axvisor/uefi/ovmf-entry-mem");
+        let err = ensure_ovmf_entry_case_dir(&other).unwrap_err();
+        assert!(
+            format!("{err:#}").contains("ovmf-entry"),
+            "unexpected error: {err:#}"
+        );
+
+        // A non-prefixed name in an unrelated directory stays rejected.
+        let mut smoke = fixture_qemu_case("smoke-vmx");
+        smoke.case_dir = PathBuf::from("/ws/test-suit/axvisor/normal/qemu");
+        assert!(ensure_ovmf_entry_case_dir(&smoke).is_err());
     }
 }

--- a/scripts/axbuild/src/axvisor/test/qemu.rs
+++ b/scripts/axbuild/src/axvisor/test/qemu.rs
@@ -363,20 +363,20 @@ const OVMF_ENTRY_CASE_DIR: &str = "ovmf-entry";
 /// [`ensure_ovmf_entry_case_dir`]), which is the same directory the checked-in
 /// VM config template `OVMF_ENTRY_VM_CONFIG_FILE` lives in. A future
 /// non-ovmf-entry case whose name merely starts with the same prefix is
-/// rejected instead of being silently wired to the fixed bundle. A future
-/// ovmf-entry variant that must NOT use the manifest-verified fixed CODE
-/// bundle must re-evaluate this match so it cannot wire the wrong case.
+/// rejected instead of being silently wired to the verified firmware. A future
+/// ovmf-entry variant that must NOT use the verified upstream firmware must
+/// re-evaluate this match so it cannot wire the wrong case.
 const OVMF_ENTRY_QEMU_CASE_PREFIX: &str = "ovmf-entry-";
 
-/// Wires the ovmf-entry QEMU case to the manifest-verified firmware bundle.
+/// Wires the ovmf-entry QEMU case to the verified upstream firmware.
 ///
 /// The QEMU layer boots the Axvisor host with `-kernel <axvisor.bin>`, where
 /// the binary is a PE32+ UEFI image. QEMU can only load such an image through
 /// its OVMF firmware, so without explicit pflash drives the run falls through
 /// to SeaBIOS and hangs at `Booting from ROM..` (see the `ktest`
 /// `patch_system_x86_64_uefi_kernel_loader` precedent, which documents the
-/// same requirement). This function injects the verified bundle CODE as the
-/// read-only pflash unit 0 and a writable copy of the bundle VARS as unit 1.
+/// same requirement). This function injects the verified firmware CODE as the
+/// read-only pflash unit 0 and a writable copy of the firmware VARS as unit 1.
 ///
 /// The injected CODE is the same file that `verify_firmware` accepted and that
 /// the generated VM config embeds via `include_bytes!`, so the QEMU-layer
@@ -389,7 +389,7 @@ const OVMF_ENTRY_QEMU_CASE_PREFIX: &str = "ovmf-entry-";
 /// Only cases whose directory is exactly `OVMF_ENTRY_CASE_DIR` are wired (see
 /// [`ensure_ovmf_entry_case_dir`]); other cases are never touched.
 ///
-/// The unit 1 VARS file is a fresh copy created from the verified bundle
+/// The unit 1 VARS file is a fresh copy created from the verified firmware
 /// template on every run, so it never carries state between runs. It does not
 /// rely on the `-snapshot` isolation that `qemu.uefi` cases get through
 /// [`test_qemu::apply_drive_snapshot_without_global_snapshot`] (ovmf-entry
@@ -411,25 +411,16 @@ fn wire_ovmf_entry_qemu_firmware(
         // continuations whose whitespace is stripped at runtime.
         anyhow!(
             concat!(
-                "case `{name}` needs a verified OVMF firmware bundle:\n",
-                "- pass `--firmware-bundle-path <bundle-dir>` for a managed bundle with ",
-                "manifest.toml\n",
+                "case `{name}` needs verified OVMF firmware:\n",
+                "- pass `--firmware-bundle-path <dir>` pointing at an upstream firmware ",
+                "directory holding code.fd and vars.fd\n",
                 "- `--allow-unverified-firmware` is only for a local CODE file and must not ",
                 "determine UEFI test results",
             ),
             name = case.name,
         )
     })?;
-    let vars_template = bundle
-        .code_path
-        .parent()
-        .ok_or_else(|| {
-            anyhow!(
-                "verified OVMF CODE path {} has no parent directory",
-                bundle.code_path.display()
-            )
-        })?
-        .join(ovmf::VARS_FILE);
+    let vars_template = &bundle.vars_path;
     if !vars_template.is_file() {
         anyhow::bail!(
             "missing {} next to the CODE file {} (required for the QEMU-layer pflash unit 1)",
@@ -438,7 +429,7 @@ fn wire_ovmf_entry_qemu_firmware(
         );
     }
     let vars = vars_template.with_extension("ovmf-entry.vars.fd");
-    fs::copy(&vars_template, &vars).with_context(|| {
+    fs::copy(vars_template, &vars).with_context(|| {
         format!(
             "failed to copy OVMF vars from {} to {}",
             vars_template.display(),
@@ -463,15 +454,15 @@ fn wire_ovmf_entry_qemu_firmware(
 }
 
 /// Verifies that a prefix-matched case really lives in the ovmf-entry case
-/// directory before the fixed firmware bundle is wired to it.
+/// directory before the verified firmware is wired to it.
 ///
 /// The case name (`ovmf-entry-<variant>`) alone is a weak selector: discovery
 /// names every case after its build wrapper, so any future case whose
 /// directory starts with the same prefix would be caught by the match. The
 /// case directory is the second, exact selector: only a case whose directory
 /// is named exactly `OVMF_ENTRY_CASE_DIR` (the directory that also holds the
-/// `OVMF_ENTRY_VM_CONFIG_FILE` template) may use the manifest-verified fixed
-/// CODE bundle.
+/// `OVMF_ENTRY_VM_CONFIG_FILE` template) may use the verified upstream
+/// firmware.
 fn ensure_ovmf_entry_case_dir(case: &TestQemuCase) -> anyhow::Result<()> {
     let dir_name = case
         .case_dir
@@ -484,13 +475,13 @@ fn ensure_ovmf_entry_case_dir(case: &TestQemuCase) -> anyhow::Result<()> {
     anyhow::bail!(
         "case `{}` matches the ovmf-entry prefix but is not in the ovmf-entry case directory \
          (directory `{}` is not `{OVMF_ENTRY_CASE_DIR}`); add the case to the fixed ovmf-entry \
-         bundle or rename it so it does not use the prefix",
+         firmware or rename it so it does not use the prefix",
         case.name,
         case.case_dir.display()
     )
 }
 
-/// Rewires the ovmf-entry VM config to the manifest-verified firmware bundle.
+/// Rewires the ovmf-entry VM config to the verified upstream firmware.
 ///
 /// When `--firmware-bundle-path` is supplied, every build group whose VM
 /// configs include the checked-in `ovmf-entry.toml` template gets a generated
@@ -617,12 +608,12 @@ fn ovmf_entry_generated_config_path(workspace_root: &Path, target: &str) -> Path
         .join(format!("{OVMF_ENTRY_VM_CONFIG_FILE}.vmconfig.toml"))
 }
 
-/// Verifies the CLI-selected firmware bundle, if any.
+/// Verifies the CLI-selected firmware, if any.
 ///
 /// Without `--firmware-bundle-path` no firmware is resolved and `None` is
 /// returned; existing test runs keep their exact previous behavior. With a
-/// bundle path the source is resolved and fully verified, and any failure
-/// aborts the run with a clear error before any build or QEMU work starts.
+/// path the source is resolved and fully verified, and any failure aborts the
+/// run with a clear error before any build or QEMU work starts.
 fn verify_cli_firmware_bundle(
     args: &ArgsTestQemu,
 ) -> anyhow::Result<Option<ovmf::VerifiedOvmfBundle>> {
@@ -643,17 +634,17 @@ fn verify_cli_firmware_bundle(
     if !bundle.verified {
         // `--allow-unverified-firmware` is a diagnostic-only escape hatch: an
         // unverified local CODE file must not drive the ovmf-entry test
-        // conclusion, or the "fixed, manifest-verified firmware" guarantee of
-        // the case is bypassed. Reject it before any QEMU wiring.
+        // conclusion, or the verified-upstream-firmware guarantee of the case
+        // is bypassed. Reject it before any QEMU wiring.
         anyhow::bail!(
             "firmware `{}` is UNVERIFIED (--allow-unverified-firmware); it cannot drive the \
-             ovmf-entry test result — pass a managed bundle directory containing manifest.toml \
-             instead",
+             ovmf-entry test result — pass an upstream firmware directory containing code.fd and \
+             vars.fd instead",
             path.display()
         );
     }
     println!(
-        "verified OVMF firmware bundle for ovmf-entry cases: {} (sha256={})",
+        "verified OVMF firmware for ovmf-entry cases: {} (sha256={})",
         bundle.code_path.display(),
         bundle.code_sha256
     );
@@ -717,14 +708,15 @@ disabled = []
 
     fn fixture_bundle(code_path: &Path) -> ovmf::VerifiedOvmfBundle {
         ovmf::VerifiedOvmfBundle {
-            profile: ovmf::OVMF_PROFILE_NAME.to_string(),
             code_base: ovmf::OVMF_CODE_BASE,
             code_size: ovmf::OVMF_CODE_SIZE,
             vars_base: ovmf::OVMF_VARS_BASE,
             vars_size: ovmf::OVMF_VARS_SIZE,
             combined_size: ovmf::OVMF_COMBINED_SIZE,
             code_path: code_path.to_path_buf(),
+            vars_path: code_path.with_file_name(ovmf::UPSTREAM_VARS_FILE),
             code_sha256: "ab".repeat(32),
+            vars_sha256: "cd".repeat(32),
             verified: true,
         }
     }
@@ -931,9 +923,9 @@ disabled = []
         let root = tempdir().unwrap();
         let bundle_dir = root.path().join("bundle");
         fs::create_dir_all(&bundle_dir).unwrap();
-        let code = bundle_dir.join("OVMF_CODE.fd");
+        let code = bundle_dir.join(ovmf::UPSTREAM_CODE_FILE);
         fs::write(&code, vec![0xa5; ovmf::OVMF_CODE_SIZE as usize]).unwrap();
-        let vars = bundle_dir.join(ovmf::VARS_FILE);
+        let vars = bundle_dir.join(ovmf::UPSTREAM_VARS_FILE);
         fs::write(&vars, vec![0x5a; ovmf::OVMF_VARS_SIZE as usize]).unwrap();
         let bundle = fixture_bundle(&code);
 
@@ -967,12 +959,12 @@ disabled = []
                 "-drive".to_string(),
                 format!(
                     "if=pflash,format=raw,unit=1,file={}",
-                    bundle_dir.join("OVMF_VARS.ovmf-entry.vars.fd").display()
+                    bundle_dir.join("vars.ovmf-entry.vars.fd").display()
                 ),
             ]
         );
         // The writable VARS copy must exist next to the template.
-        assert!(bundle_dir.join("OVMF_VARS.ovmf-entry.vars.fd").is_file());
+        assert!(bundle_dir.join("vars.ovmf-entry.vars.fd").is_file());
     }
 
     #[test]
@@ -1025,7 +1017,7 @@ disabled = []
         let root = tempdir().unwrap();
         let bundle_dir = root.path().join("bundle");
         fs::create_dir_all(&bundle_dir).unwrap();
-        let code = bundle_dir.join("OVMF_CODE.fd");
+        let code = bundle_dir.join(ovmf::UPSTREAM_CODE_FILE);
         fs::write(&code, vec![0xa5; ovmf::OVMF_CODE_SIZE as usize]).unwrap();
         let bundle = fixture_bundle(&code);
 
@@ -1046,10 +1038,7 @@ disabled = []
         )
         .unwrap_err();
         let rendered = format!("{err:#}");
-        assert!(
-            rendered.contains("OVMF_VARS.fd"),
-            "unexpected error: {rendered}"
-        );
+        assert!(rendered.contains("vars.fd"), "unexpected error: {rendered}");
     }
 
     #[test]

--- a/test-suit/axvisor/uefi/ovmf-entry/build-x86_64-unknown-none-svm.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/build-x86_64-unknown-none-svm.toml
@@ -1,0 +1,6 @@
+features = [
+    "fs",
+]
+log = "Info"
+target = "x86_64-unknown-none"
+vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml"]

--- a/test-suit/axvisor/uefi/ovmf-entry/build-x86_64-unknown-none-vmx.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/build-x86_64-unknown-none-vmx.toml
@@ -1,0 +1,6 @@
+features = [
+    "fs",
+]
+log = "Info"
+target = "x86_64-unknown-none"
+vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml"]

--- a/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-svm.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-svm.toml
@@ -23,7 +23,7 @@ args = [
   # The nvme disk is load-bearing for the HOST: the Axvisor host enables
   # `features = ["fs"]` (axvm/host-fs) and mounts its rootfs at boot, so
   # without a block device the host panics in init_root. The nested OVMF
-  # guest never touches the disk (it only needs the UEFI SEC marker); the
+  # guest never touches the disk (it only needs to reach the fw_cfg access marker); the
   # wrapper therefore needs no ax-driver/nvme feature for the guest.
   "-device",
   "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65,addr=03.0",
@@ -42,13 +42,14 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)failed to initialize guest vm",
 ]
-# The fixed OVMF SEC marker printed by the NESTED firmware on guest COM1.
-# The `(?s)VCpu[0] running...` prefix anchors the match to the nested VM:
-# the QEMU-layer host OVMF (injected as pflash to boot the axvisor host
-# binary) prints the same SEC line while booting, so a bare
-# `SecCoreStartupWithStack\(` would match the host firmware instead.
+# The nested OVMF firmware accesses fw_cfg while booting inside the Axvisor
+# guest; every such access is routed through the axvisor device model, which
+# prints the `Nested OVMF fw_cfg accessed` marker at Info level. The marker is
+# naturally scoped to the nested guest: the QEMU-layer host OVMF (injected as
+# pflash to boot the axvisor host binary) drives fw_cfg inside QEMU itself,
+# which never reaches the axvisor device model, so no VM anchor is needed.
 success_regex = [
-  "(?s)VCpu\\[0\\] running\\.\\.\\..*SecCoreStartupWithStack",
+  "(?m)^.*Nested OVMF fw_cfg accessed",
 ]
 to_bin = true
 uefi = false

--- a/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-svm.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-svm.toml
@@ -1,0 +1,50 @@
+# QEMU (-kernel) boots the Axvisor host. The host binary is a PE32+ UEFI image,
+# so QEMU needs OVMF pflash drives to load it via `-kernel`; the axbuild runner
+# injects the verified `--firmware-bundle-path` CODE/VARS as pflash drives when
+# this case runs, and fails fast without the flag. `uefi = false` keeps ostool
+# from downloading its own OVMF. The nested OVMF is loaded by Axvisor itself
+# from the VM config (`ovmf-entry.toml`), byte-identical to the injected CODE.
+args = [
+  "-no-user-config",
+  "-display",
+  "none",
+  "-serial",
+  "stdio",
+  "-monitor",
+  "none",
+  "-cpu",
+  "host,-la57,+svm,+npt,+nrip-save",
+  "-machine",
+  "q35,smbus=off,usb=off,graphics=off",
+  "-smp",
+  "1",
+  "-accel",
+  "kvm",
+  # The nvme disk is load-bearing for the HOST: the Axvisor host enables
+  # `features = ["fs"]` (axvm/host-fs) and mounts its rootfs at boot, so
+  # without a block device the host panics in init_root. The nested OVMF
+  # guest never touches the disk (it only needs the UEFI SEC marker); the
+  # wrapper therefore needs no ax-driver/nvme feature for the guest.
+  "-device",
+  "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65,addr=03.0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+  "-m",
+  "512M",
+  "-net",
+  "none",
+  "-vga",
+  "none",
+]
+timeout = 300
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+  "(?i)failed to initialize guest vm",
+]
+# The fixed OVMF SEC marker printed by the nested firmware on guest COM1.
+success_regex = [
+  "SecCoreStartupWithStack\\(",
+]
+to_bin = true
+uefi = false

--- a/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-svm.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-svm.toml
@@ -42,9 +42,13 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)failed to initialize guest vm",
 ]
-# The fixed OVMF SEC marker printed by the nested firmware on guest COM1.
+# The fixed OVMF SEC marker printed by the NESTED firmware on guest COM1.
+# The `(?s)VCpu[0] running...` prefix anchors the match to the nested VM:
+# the QEMU-layer host OVMF (injected as pflash to boot the axvisor host
+# binary) prints the same SEC line while booting, so a bare
+# `SecCoreStartupWithStack\(` would match the host firmware instead.
 success_regex = [
-  "SecCoreStartupWithStack\\(",
+  "(?s)VCpu\\[0\\] running\\.\\.\\..*SecCoreStartupWithStack",
 ]
 to_bin = true
 uefi = false

--- a/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-vmx.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-vmx.toml
@@ -23,7 +23,7 @@ args = [
   # The nvme disk is load-bearing for the HOST: the Axvisor host enables
   # `features = ["fs"]` (axvm/host-fs) and mounts its rootfs at boot, so
   # without a block device the host panics in init_root. The nested OVMF
-  # guest never touches the disk (it only needs the UEFI SEC marker); the
+  # guest never touches the disk (it only needs to reach the fw_cfg access marker); the
   # wrapper therefore needs no ax-driver/nvme feature for the guest.
   "-device",
   "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65,addr=03.0",
@@ -42,13 +42,14 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)failed to initialize guest vm",
 ]
-# The fixed OVMF SEC marker printed by the NESTED firmware on guest COM1.
-# The `(?s)VCpu[0] running...` prefix anchors the match to the nested VM:
-# the QEMU-layer host OVMF (injected as pflash to boot the axvisor host
-# binary) prints the same SEC line while booting, so a bare
-# `SecCoreStartupWithStack\(` would match the host firmware instead.
+# The nested OVMF firmware accesses fw_cfg while booting inside the Axvisor
+# guest; every such access is routed through the axvisor device model, which
+# prints the `Nested OVMF fw_cfg accessed` marker at Info level. The marker is
+# naturally scoped to the nested guest: the QEMU-layer host OVMF (injected as
+# pflash to boot the axvisor host binary) drives fw_cfg inside QEMU itself,
+# which never reaches the axvisor device model, so no VM anchor is needed.
 success_regex = [
-  "(?s)VCpu\\[0\\] running\\.\\.\\..*SecCoreStartupWithStack",
+  "(?m)^.*Nested OVMF fw_cfg accessed",
 ]
 to_bin = true
 uefi = false

--- a/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-vmx.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-vmx.toml
@@ -1,0 +1,50 @@
+# QEMU (-kernel) boots the Axvisor host. The host binary is a PE32+ UEFI image,
+# so QEMU needs OVMF pflash drives to load it via `-kernel`; the axbuild runner
+# injects the verified `--firmware-bundle-path` CODE/VARS as pflash drives when
+# this case runs, and fails fast without the flag. `uefi = false` keeps ostool
+# from downloading its own OVMF. The nested OVMF is loaded by Axvisor itself
+# from the VM config (`ovmf-entry.toml`), byte-identical to the injected CODE.
+args = [
+  "-no-user-config",
+  "-display",
+  "none",
+  "-serial",
+  "stdio",
+  "-monitor",
+  "none",
+  "-cpu",
+  "host,-la57,+vmx-ept,+vmx-unrestricted-guest,+vmx-flexpriority",
+  "-machine",
+  "q35,smbus=off,usb=off,graphics=off",
+  "-smp",
+  "1",
+  "-accel",
+  "kvm",
+  # The nvme disk is load-bearing for the HOST: the Axvisor host enables
+  # `features = ["fs"]` (axvm/host-fs) and mounts its rootfs at boot, so
+  # without a block device the host panics in init_root. The nested OVMF
+  # guest never touches the disk (it only needs the UEFI SEC marker); the
+  # wrapper therefore needs no ax-driver/nvme feature for the guest.
+  "-device",
+  "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65,addr=03.0",
+  "-drive",
+  "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+  "-m",
+  "512M",
+  "-net",
+  "none",
+  "-vga",
+  "none",
+]
+timeout = 300
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+  "(?i)failed to initialize guest vm",
+]
+# The fixed OVMF SEC marker printed by the nested firmware on guest COM1.
+success_regex = [
+  "SecCoreStartupWithStack\\(",
+]
+to_bin = true
+uefi = false

--- a/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-vmx.toml
+++ b/test-suit/axvisor/uefi/ovmf-entry/qemu-x86_64-vmx.toml
@@ -42,9 +42,13 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)failed to initialize guest vm",
 ]
-# The fixed OVMF SEC marker printed by the nested firmware on guest COM1.
+# The fixed OVMF SEC marker printed by the NESTED firmware on guest COM1.
+# The `(?s)VCpu[0] running...` prefix anchors the match to the nested VM:
+# the QEMU-layer host OVMF (injected as pflash to boot the axvisor host
+# binary) prints the same SEC line while booting, so a bare
+# `SecCoreStartupWithStack\(` would match the host firmware instead.
 success_regex = [
-  "SecCoreStartupWithStack\\(",
+  "(?s)VCpu\\[0\\] running\\.\\.\\..*SecCoreStartupWithStack",
 ]
 to_bin = true
 uefi = false

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -74,17 +74,71 @@ impl RuntimeAccessPorts {
     }
 }
 
-#[inline]
-#[allow(dead_code)]
-fn log_device_io(
-    addr_type: &'static str,
-    addr: impl core::fmt::LowerHex,
-    addr_range: impl core::fmt::LowerHex,
-    read: bool,
-    width: AccessWidth,
+/// Emits a per-access trace line on the routed device-access path.
+///
+/// This is the single, unified log path for every device access that enters
+/// [`DeviceRuntime`]: reads and writes on the MMIO/port buses, plus MMIO
+/// writes carrying an access-scoped guest-memory capability. It replaces the
+/// former dead `log_device_io` helper, which could never be observed because
+/// nothing called it.
+///
+/// `device` is `None` when the access did not match any registered resource
+/// (the access is then recorded with `device=<unregistered>` and the lookup
+/// still returns [`DeviceError::NotFound`]). `result` is `None` in that same
+/// case; for a matched device it is the outcome of [`Device::access`]. When a
+/// read fails, the read value is not available, so it is rendered as
+/// `value=<unavailable>`.
+///
+/// System-register accesses are deliberately not traced: they are emitted on
+/// the architecture hot path with a high frequency, and the caller skips this
+/// function for [`BusKind::SysReg`].
+fn trace_device_access(
+    device: Option<&str>,
+    access: &BusAccess,
+    result: Option<&Result<BusResponse, DeviceError>>,
 ) {
-    let rw = if read { "read" } else { "write" };
-    trace!("emu_device {rw}: {addr_type} {addr:#x} in range {addr_range:#x} with width {width:?}")
+    let device = device.unwrap_or("<unregistered>");
+    let direction = if access.is_read { "read" } else { "write" };
+    let bus = match access.kind {
+        BusKind::Mmio => "MMIO",
+        BusKind::Port => "PIO",
+        BusKind::SysReg => "SysReg",
+    };
+    match result {
+        Some(Ok(BusResponse::Read { value })) => trace!(
+            "guest device access: device={device} bus={bus} direction={direction} addr={addr:#x} \
+             width={width:?} value={value:#x} result=ok",
+            addr = access.addr,
+            width = access.width,
+        ),
+        Some(Ok(BusResponse::Write)) => trace!(
+            "guest device access: device={device} bus={bus} direction={direction} addr={addr:#x} \
+             width={width:?} value={data:#x} result=ok",
+            addr = access.addr,
+            width = access.width,
+            data = access.data,
+        ),
+        Some(Err(error)) if access.is_read => trace!(
+            "guest device access: device={device} bus={bus} direction={direction} addr={addr:#x} \
+             width={width:?} value=<unavailable> result=error={error}",
+            addr = access.addr,
+            width = access.width,
+        ),
+        Some(Err(error)) => trace!(
+            "guest device access: device={device} bus={bus} direction={direction} addr={addr:#x} \
+             width={width:?} value={data:#x} result=error={error}",
+            addr = access.addr,
+            width = access.width,
+            data = access.data,
+        ),
+        None => trace!(
+            "guest device access: device={device} bus={bus} direction={direction} addr={addr:#x} \
+             width={width:?} value=<unavailable> result=error={error}",
+            addr = access.addr,
+            width = access.width,
+            error = DeviceError::NotFound,
+        ),
+    }
 }
 
 /// Internal range entry cached in the index maps.
@@ -1100,6 +1154,9 @@ impl DeviceRuntime {
             }
         };
         let Some(index) = index else {
+            if access.kind != BusKind::SysReg {
+                trace_device_access(None, access, None);
+            }
             return Ok(None);
         };
 
@@ -1112,7 +1169,12 @@ impl DeviceRuntime {
             stop_grants: &self.stop_grants,
             access_ports: &self.access_ports,
         };
-        self.devices[index].access(access, &mut context).map(Some)
+        let device = &self.devices[index];
+        let response = device.access(access, &mut context);
+        if access.kind != BusKind::SysReg {
+            trace_device_access(Some(device.name()), access, Some(&response));
+        }
+        response.map(Some)
     }
 }
 
@@ -2070,5 +2132,316 @@ mod tests {
         assert_eq!(lifecycle.reset_calls.load(Ordering::Relaxed), 1);
         assert_eq!(lifecycle.suspend_calls.load(Ordering::Relaxed), 1);
         assert_eq!(lifecycle.resume_calls.load(Ordering::Relaxed), 1);
+    }
+
+    // Guest device access tracing.
+    //
+    // These tests exercise the trace points added to the routed device-access
+    // path. The trace itself is a `trace!` log line and is not captured here;
+    // the contract under test is that tracing never changes dispatch return
+    // semantics, and that unregistered accesses keep returning NotFound.
+
+    #[test]
+    fn trace_points_do_not_change_registered_device_read_result() {
+        let mut devices = DeviceRuntime::empty();
+        devices
+            .register(Arc::new(AccessAwareDevice {
+                resources: alloc::vec![Resource::MmioRange {
+                    base: 0x4000,
+                    size: 0x100,
+                }],
+            }))
+            .unwrap();
+
+        assert!(matches!(
+            devices.dispatch(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: true,
+                addr: 0x4000,
+                width: AccessWidth::Dword,
+                data: 0,
+            }),
+            Ok(BusResponse::Read { value: 0xfeed })
+        ));
+    }
+
+    #[test]
+    fn trace_points_do_not_change_registered_device_write_result() {
+        struct WriteAckDevice {
+            resources: alloc::vec::Vec<Resource>,
+        }
+        impl Device for WriteAckDevice {
+            fn name(&self) -> &str {
+                "trace-write-ack"
+            }
+            fn resources(&self) -> &[Resource] {
+                &self.resources
+            }
+            fn access(
+                &self,
+                _: &BusAccess,
+                _context: &mut dyn DeviceAccess,
+            ) -> Result<BusResponse, DeviceError> {
+                Ok(BusResponse::Write)
+            }
+        }
+
+        let mut devices = DeviceRuntime::empty();
+        devices
+            .register(Arc::new(WriteAckDevice {
+                resources: alloc::vec![Resource::MmioRange {
+                    base: 0x4100,
+                    size: 0x100,
+                }],
+            }))
+            .unwrap();
+
+        assert!(matches!(
+            devices.dispatch(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: false,
+                addr: 0x4100,
+                width: AccessWidth::Dword,
+                data: 0xabcd,
+            }),
+            Ok(BusResponse::Write)
+        ));
+    }
+
+    #[test]
+    fn trace_points_do_not_change_registered_device_error_result() {
+        struct ErroringDevice;
+        impl Device for ErroringDevice {
+            fn name(&self) -> &str {
+                "trace-error"
+            }
+            fn resources(&self) -> &[Resource] {
+                static R: [Resource; 1] = [Resource::MmioRange {
+                    base: 0x4200,
+                    size: 0x100,
+                }];
+                &R
+            }
+            fn access(
+                &self,
+                _: &BusAccess,
+                _context: &mut dyn DeviceAccess,
+            ) -> Result<BusResponse, DeviceError> {
+                Err(DeviceError::Internal)
+            }
+        }
+
+        let mut devices = DeviceRuntime::empty();
+        devices.register(Arc::new(ErroringDevice)).unwrap();
+
+        assert!(matches!(
+            devices.dispatch(&BusAccess {
+                kind: BusKind::Mmio,
+                is_read: true,
+                addr: 0x4200,
+                width: AccessWidth::Dword,
+                data: 0,
+            }),
+            Err(DeviceError::Internal)
+        ));
+    }
+
+    #[test]
+    fn dispatch_keeps_returning_not_found_for_unregistered_accesses() {
+        let mut devices = DeviceRuntime::empty();
+        devices
+            .register(Arc::new(D::new_mmio(0x4300, 0x100, "trace-registered")))
+            .unwrap();
+
+        for (addr, width) in [
+            (0x7000u64, AccessWidth::Byte),
+            (0x7001, AccessWidth::Word),
+            (0x7002, AccessWidth::Dword),
+            (0x7003, AccessWidth::Qword),
+        ] {
+            assert!(
+                matches!(
+                    devices.dispatch(&BusAccess {
+                        kind: BusKind::Mmio,
+                        is_read: true,
+                        addr,
+                        width,
+                        data: 0,
+                    }),
+                    Err(DeviceError::NotFound)
+                ),
+                "unregistered access at {addr:#x} must stay NotFound"
+            );
+        }
+        assert!(matches!(
+            devices.dispatch(&BusAccess {
+                kind: BusKind::Port,
+                is_read: true,
+                addr: 0x3000,
+                width: AccessWidth::Word,
+                data: 0,
+            }),
+            Err(DeviceError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn dispatch_keeps_returning_out_of_range_for_invalid_port_address() {
+        let devices = DeviceRuntime::empty();
+
+        assert!(matches!(
+            devices.dispatch(&BusAccess {
+                kind: BusKind::Port,
+                is_read: true,
+                addr: u64::from(u16::MAX) + 1,
+                width: AccessWidth::Byte,
+                data: 0,
+            }),
+            Err(DeviceError::OutOfRange { .. })
+        ));
+    }
+
+    #[test]
+    fn trace_points_cover_every_access_width() {
+        let mut devices = DeviceRuntime::empty();
+        devices
+            .register(Arc::new(AccessAwareDevice {
+                resources: alloc::vec![Resource::MmioRange {
+                    base: 0x4400,
+                    size: 0x100,
+                }],
+            }))
+            .unwrap();
+
+        for (offset, width) in [
+            (0x4400u64, AccessWidth::Byte),
+            (0x4401, AccessWidth::Word),
+            (0x4402, AccessWidth::Dword),
+            (0x4403, AccessWidth::Qword),
+        ] {
+            assert!(matches!(
+                devices.dispatch(&BusAccess {
+                    kind: BusKind::Mmio,
+                    is_read: true,
+                    addr: offset,
+                    width,
+                    data: 0,
+                }),
+                Ok(BusResponse::Read { value: 0xfeed })
+            ));
+        }
+    }
+
+    #[test]
+    fn mmio_write_with_memory_keeps_returning_not_found_for_unregistered_address() {
+        let mut devices = DeviceRuntime::empty();
+        devices
+            .register(Arc::new(D::new_mmio(0x4500, 0x100, "trace-memory")))
+            .unwrap();
+        let mut memory = TestMemoryPort;
+
+        let error = devices
+            .handle_mmio_write_with_memory(
+                GuestPhysAddr::from_usize(0x7000),
+                AccessWidth::Dword,
+                0x55,
+                &mut memory,
+            )
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeviceManagerError::Access {
+                source: DeviceError::NotFound,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn trace_points_do_not_change_mmio_write_with_memory_result() {
+        let dma_grant = DmaGrant::new();
+        let mut devices = DeviceRuntime::empty();
+        devices
+            .register_bundle(DeviceBundle::new().with_guest_memory_device_grant(
+                Arc::new(GuestMemoryRequestDevice {
+                    resources: alloc::vec![Resource::MmioRange {
+                        base: 0x4600,
+                        size: 0x100,
+                    }],
+                    dma_grant: dma_grant.clone(),
+                }),
+                dma_grant,
+            ))
+            .unwrap();
+        let mut memory = TestMemoryPort;
+
+        assert!(
+            devices
+                .handle_mmio_write_with_memory(
+                    GuestPhysAddr::from_usize(0x4600),
+                    AccessWidth::Dword,
+                    0xaa,
+                    &mut memory,
+                )
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn trace_points_do_not_change_port_dispatch_result() {
+        struct DirectionAwarePortDevice {
+            resources: alloc::vec::Vec<Resource>,
+        }
+        impl Device for DirectionAwarePortDevice {
+            fn name(&self) -> &str {
+                "trace-direction-port"
+            }
+            fn resources(&self) -> &[Resource] {
+                &self.resources
+            }
+            fn access(
+                &self,
+                access: &BusAccess,
+                _context: &mut dyn DeviceAccess,
+            ) -> Result<BusResponse, DeviceError> {
+                if access.is_read {
+                    Ok(BusResponse::Read { value: 0 })
+                } else {
+                    Ok(BusResponse::Write)
+                }
+            }
+        }
+
+        let mut devices = DeviceRuntime::empty();
+        devices
+            .register(Arc::new(DirectionAwarePortDevice {
+                resources: alloc::vec![Resource::PortRange {
+                    base: 0x60,
+                    size: 0x10,
+                }],
+            }))
+            .unwrap();
+
+        assert!(matches!(
+            devices.dispatch(&BusAccess {
+                kind: BusKind::Port,
+                is_read: true,
+                addr: 0x60,
+                width: AccessWidth::Byte,
+                data: 0,
+            }),
+            Ok(BusResponse::Read { value: 0 })
+        ));
+        assert!(matches!(
+            devices.dispatch(&BusAccess {
+                kind: BusKind::Port,
+                is_read: false,
+                addr: 0x61,
+                width: AccessWidth::Word,
+                data: 0x1234,
+            }),
+            Ok(BusResponse::Write)
+        ));
     }
 }

--- a/virtualization/axdevice/src/fw_cfg/pio.rs
+++ b/virtualization/axdevice/src/fw_cfg/pio.rs
@@ -108,6 +108,7 @@ impl FwCfgPioDevice {
     }
 }
 
+#[derive(Debug)]
 enum PortWindow {
     SelectorData,
     Dma,
@@ -128,6 +129,17 @@ impl Device for FwCfgPioDevice {
         context: &mut dyn DeviceAccess,
     ) -> Result<BusResponse, DeviceError> {
         let (window, offset) = self.port_offset(access)?;
+        // Nested-guest fw_cfg access marker: the host OVMF drives fw_cfg inside
+        // QEMU itself, so every access routed through this device belongs to
+        // the nested guest firmware. Info level so the marker is visible at
+        // the default log level and can be matched by test success regexes.
+        info!(
+            "Nested OVMF fw_cfg accessed (port={:#x}, dir={}, sel={:#x}, window={:?})",
+            access.addr,
+            if access.is_read { "read" } else { "write" },
+            self.inner.read_selector(),
+            window,
+        );
         match (window, access.is_read, offset) {
             (PortWindow::SelectorData, true, 0) => Ok(BusResponse::Read {
                 value: u64::from(self.inner.read_selector()),

--- a/virtualization/axvm/src/arch/x86_64/boot/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/mod.rs
@@ -217,6 +217,12 @@ fn load_boot_image_from_memory(loader: &ImageLoaderCore<'_>, bios: Option<&[u8]>
         let load_gpa = loader
             .bios_load_gpa
             .ok_or_else(|| ax_err_type!(NotFound, "boot firmware load address is missing"))?;
+        if loader.config.kernel.effective_boot_protocol() == VMBootProtocol::Uefi
+            && fixed_ovmf_profile_enabled(&loader.config)
+        {
+            validate_fixed_ovmf_layout(bios.len(), load_gpa, loader.config.kernel.entry_point)?;
+            log_fixed_ovmf_load(None, bios.len(), load_gpa);
+        }
         load_vm_image_from_memory(bios, load_gpa, loader.vm.clone())?;
         if should_patch_multiboot_info(&loader.config) {
             load_multiboot_info(loader, bios, load_gpa)?;
@@ -244,6 +250,11 @@ fn load_boot_image_from_filesystem(loader: &ImageLoaderCore<'_>) -> AxVmResult {
         let load_gpa = loader
             .bios_load_gpa
             .ok_or_else(|| ax_err_type!(NotFound, "boot firmware load address is missing"))?;
+        if fixed_ovmf_profile_enabled(&loader.config) {
+            let code_size = crate::boot::images::fs::image_size(path, loader.provider)?;
+            validate_fixed_ovmf_layout(code_size, load_gpa, loader.config.kernel.entry_point)?;
+            log_fixed_ovmf_load(Some(path), code_size, load_gpa);
+        }
         if should_patch_multiboot_info(&loader.config) {
             let bios = crate::boot::images::fs::read_full_image(path, loader.provider)?;
             validate_bios_patch_region(&bios)?;
@@ -275,6 +286,17 @@ fn load_uefi_from_configured_path(loader: &ImageLoaderCore<'_>) -> AxVmResult {
     let load_gpa = loader
         .bios_load_gpa
         .ok_or_else(|| ax_err_type!(NotFound, "UEFI firmware load addr is missed"))?;
+    if fixed_ovmf_profile_enabled(&loader.config) {
+        #[cfg(any(feature = "fs", feature = "host-fs"))]
+        let code_size = crate::boot::images::fs::image_size(path, loader.provider)?;
+        #[cfg(not(any(feature = "fs", feature = "host-fs")))]
+        let code_size = {
+            let _ = path;
+            0
+        };
+        validate_fixed_ovmf_layout(code_size, load_gpa, loader.config.kernel.entry_point)?;
+        log_fixed_ovmf_load(Some(path), code_size, load_gpa);
+    }
     #[cfg(any(feature = "fs", feature = "host-fs"))]
     {
         crate::boot::images::fs::load_vm_image(path, load_gpa, loader.vm.clone(), loader.provider)
@@ -651,6 +673,74 @@ fn validate_bios_patch_region(bios: &[u8]) -> AxVmResult {
     Ok(())
 }
 
+/// The fixed OVMF CODE layout enforced for the `qemu_x86_64_axvisor_ovmf_debug`
+/// firmware profile.
+///
+/// The values match the bundled OVMF CODE image: it must be loaded as a whole
+/// at [`FIXED_OVMF_CODE_GPA`], and its reset vector entry point must be
+/// [`FIXED_OVMF_RESET_VECTOR`].
+const FIXED_OVMF_PROFILE: &str = "qemu_x86_64_axvisor_ovmf_debug";
+const FIXED_OVMF_CODE_GPA: usize = 0xffc8_4000;
+const FIXED_OVMF_CODE_SIZE: usize = 0x37_c000;
+const FIXED_OVMF_RESET_VECTOR: usize = 0xffff_fff0;
+
+/// Whether the guest config declares the fixed OVMF CODE layout profile.
+fn fixed_ovmf_profile_enabled(config: &axvmconfig::GuestConfig) -> bool {
+    config.kernel.firmware_profile.as_deref() == Some(FIXED_OVMF_PROFILE)
+}
+
+/// Validate the UEFI firmware layout against the fixed OVMF CODE profile.
+///
+/// The code size, firmware load GPA, and reset-vector entry point must match
+/// the fixed OVMF CODE layout exactly.
+fn validate_fixed_ovmf_layout(
+    code_size: usize,
+    load_gpa: GuestPhysAddr,
+    entry_point: usize,
+) -> AxVmResult {
+    if code_size != FIXED_OVMF_CODE_SIZE {
+        return Err(ax_err_type!(
+            InvalidInput,
+            format!(
+                "fixed OVMF CODE size must be {:#x}, but the firmware image size is {code_size:#x}",
+                FIXED_OVMF_CODE_SIZE
+            )
+        ));
+    }
+    if load_gpa.as_usize() != FIXED_OVMF_CODE_GPA {
+        return Err(ax_err_type!(
+            InvalidInput,
+            format!(
+                "fixed OVMF CODE must be loaded at GPA {:#x}, but bios_load_addr is {:#x}",
+                FIXED_OVMF_CODE_GPA,
+                load_gpa.as_usize()
+            )
+        ));
+    }
+    if entry_point != FIXED_OVMF_RESET_VECTOR {
+        return Err(ax_err_type!(
+            InvalidInput,
+            format!(
+                "fixed OVMF CODE reset vector must be {:#x}, but the entry point is \
+                 {entry_point:#x}",
+                FIXED_OVMF_RESET_VECTOR
+            )
+        ));
+    }
+    Ok(())
+}
+
+/// Report a fixed OVMF CODE load that passed layout validation.
+fn log_fixed_ovmf_load(path: Option<&str>, code_size: usize, load_gpa: GuestPhysAddr) {
+    info!(
+        "Loading fixed OVMF CODE profile {} ({} bytes) into GPA @{:#x} with reset vector {:#x}",
+        path.unwrap_or("<memory>"),
+        code_size,
+        load_gpa.as_usize(),
+        FIXED_OVMF_RESET_VECTOR
+    );
+}
+
 fn write_u32(buffer: &mut [u8], offset: usize, value: u32) {
     buffer[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
 }
@@ -661,6 +751,8 @@ fn write_u64(buffer: &mut [u8], offset: usize, value: u64) {
 
 #[cfg(test)]
 mod tests {
+    use std::string::ToString;
+
     use super::*;
 
     #[test]
@@ -714,5 +806,89 @@ mod tests {
 
         config.kernel.enable_bios = false;
         assert!(should_direct_boot_linux(&config));
+    }
+
+    #[test]
+    fn fixed_ovmf_profile_enabled_only_for_exact_profile_name() {
+        let mut config = axvmconfig::GuestConfig::default();
+        assert!(!fixed_ovmf_profile_enabled(&config));
+
+        config.kernel.firmware_profile = Some(FIXED_OVMF_PROFILE.into());
+        assert!(fixed_ovmf_profile_enabled(&config));
+
+        config.kernel.firmware_profile = Some("other_profile".into());
+        assert!(!fixed_ovmf_profile_enabled(&config));
+    }
+
+    #[test]
+    fn fixed_ovmf_layout_accepts_the_expected_values() {
+        let valid_gpa = GuestPhysAddr::from(FIXED_OVMF_CODE_GPA);
+        assert_eq!(
+            validate_fixed_ovmf_layout(FIXED_OVMF_CODE_SIZE, valid_gpa, FIXED_OVMF_RESET_VECTOR),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn fixed_ovmf_layout_rejects_wrong_code_size() {
+        let error = validate_fixed_ovmf_layout(
+            FIXED_OVMF_CODE_SIZE - 0x1000,
+            GuestPhysAddr::from(FIXED_OVMF_CODE_GPA),
+            FIXED_OVMF_RESET_VECTOR,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("size"));
+        assert!(
+            error
+                .to_string()
+                .contains(&format!("{:#x}", FIXED_OVMF_CODE_SIZE))
+        );
+    }
+
+    #[test]
+    fn fixed_ovmf_layout_rejects_wrong_load_gpa() {
+        let error = validate_fixed_ovmf_layout(
+            FIXED_OVMF_CODE_SIZE,
+            GuestPhysAddr::from(0xffc0_0000),
+            FIXED_OVMF_RESET_VECTOR,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("bios_load_addr"));
+        assert!(error.to_string().contains("0xffc00000"));
+    }
+
+    #[test]
+    fn fixed_ovmf_layout_rejects_wrong_reset_vector() {
+        let error = validate_fixed_ovmf_layout(
+            FIXED_OVMF_CODE_SIZE,
+            GuestPhysAddr::from(FIXED_OVMF_CODE_GPA),
+            0x1000,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("reset vector"));
+        assert!(error.to_string().contains("0xfffffff0"));
+    }
+
+    #[test]
+    fn fixed_ovmf_profile_rejects_legacy_uefi_layout_but_not_when_disabled() {
+        // The pre-profile arceos-uefi-smp1 layout (0xffc0_0000, wrong size) is
+        // rejected as soon as the fixed profile is declared.
+        let mut config = axvmconfig::GuestConfig::default();
+        config.kernel.enable_bios = true;
+        config.kernel.boot_protocol = Some(VMBootProtocol::Uefi);
+        config.kernel.entry_point = 0xffff_fff0;
+        config.kernel.firmware_profile = Some(FIXED_OVMF_PROFILE.into());
+        assert!(fixed_ovmf_profile_enabled(&config));
+        assert!(
+            validate_fixed_ovmf_layout(0x40_0000, GuestPhysAddr::from(0xffc0_0000), 0xffff_fff0)
+                .is_err()
+        );
+
+        // Without the profile the same legacy layout must not be validated at
+        // all, so it stays loadable. Every validation call site is gated on
+        // `fixed_ovmf_profile_enabled`, so `false` here guarantees the layout
+        // check is never reached for this config.
+        config.kernel.firmware_profile = None;
+        assert!(!fixed_ovmf_profile_enabled(&config));
     }
 }

--- a/virtualization/axvmconfig/src/error.rs
+++ b/virtualization/axvmconfig/src/error.rs
@@ -44,6 +44,12 @@ pub enum AxVmConfigError {
         /// The boot protocol requiring a firmware load address.
         protocol: VMBootProtocol,
     },
+    /// A fixed firmware profile was declared for a non-UEFI boot flow.
+    #[error("firmware profile {profile} requires boot_protocol = \"uefi\"")]
+    FirmwareProfileRequiresUefi {
+        /// The declared firmware profile name.
+        profile: String,
+    },
     /// A physical-device selector is not an absolute, concrete device-tree path.
     #[error("physical device path must be absolute and must not select the root: {path}")]
     InvalidPhysicalDevicePath {

--- a/virtualization/axvmconfig/src/lib.rs
+++ b/virtualization/axvmconfig/src/lib.rs
@@ -283,6 +283,14 @@ pub struct VMKernelConfig {
     /// The file path of the UEFI firmware image, `None` if not used.
     #[serde(default)]
     pub uefi_firmware_path: Option<String>,
+    /// Fixed firmware profile for the x86 loader, `None` if not used.
+    ///
+    /// When set to `"qemu_x86_64_axvisor_ovmf_debug"`, the axvm x86_64 loader
+    /// enforces the fixed OVMF CODE layout (code size, load GPA, and reset
+    /// vector) while loading UEFI firmware for this guest. Any other value, or
+    /// `None`, leaves the loader behavior unchanged.
+    #[serde(default)]
+    pub firmware_profile: Option<String>,
     /// The load address of the BIOS image, `None` if not used.
     pub bios_load_addr: Option<usize>,
     /// The file path of the device tree blob (DTB), `None` if not used.
@@ -341,6 +349,14 @@ impl VMKernelConfig {
     }
 
     fn validate_boot_config_for_arch(&self, arch: &str) -> AxVmConfigResult {
+        if let Some(profile) = self.firmware_profile.as_deref()
+            && self.effective_boot_protocol() != VMBootProtocol::Uefi
+        {
+            return Err(AxVmConfigError::FirmwareProfileRequiresUefi {
+                profile: profile.into(),
+            });
+        }
+
         let protocol = self.effective_boot_protocol();
         if !self.enable_bios {
             if protocol != VMBootProtocol::Direct {

--- a/virtualization/axvmconfig/src/templates.rs
+++ b/virtualization/axvmconfig/src/templates.rs
@@ -75,6 +75,7 @@ pub fn get_vm_config_template(params: VmTemplateParams) -> GuestConfig {
             boot_protocol: None,
             bios_path: None, // BIOS not used in most configurations
             uefi_firmware_path: None,
+            firmware_profile: None, // No fixed firmware layout by default
             bios_load_addr: None,
             dtb_path: None, // Device tree not specified by default
             dtb_load_addr: None,

--- a/virtualization/axvmconfig/src/test.rs
+++ b/virtualization/axvmconfig/src/test.rs
@@ -328,3 +328,67 @@ fn rejects_invalid_toml_with_public_error() {
     let result = GuestConfig::from_toml("[base");
     assert!(matches!(result, Err(AxVmConfigError::TomlParse { .. })));
 }
+
+#[test]
+fn firmware_profile_defaults_to_none_when_omitted() {
+    let config = GuestConfig::from_toml(MINIMAL_CONFIG).unwrap();
+    assert_eq!(config.kernel.firmware_profile, None);
+}
+
+#[test]
+fn parses_explicit_firmware_profile() {
+    let raw = format!(
+        r#"
+[kernel]
+firmware_profile = "qemu_x86_64_axvisor_ovmf_debug"
+enable_bios = true
+boot_protocol = "uefi"
+bios_load_addr = 0xffc8_4000
+uefi_firmware_path = "OVMF_CODE.fd"
+"#
+    );
+    let config = GuestConfig::from_toml(&raw).unwrap();
+    assert_eq!(
+        config.kernel.firmware_profile.as_deref(),
+        Some("qemu_x86_64_axvisor_ovmf_debug")
+    );
+}
+
+#[test]
+fn firmware_profile_rejects_non_uefi_boot_protocol() {
+    let uefi_profile = VMKernelConfig {
+        firmware_profile: Some("qemu_x86_64_axvisor_ovmf_debug".into()),
+        ..Default::default()
+    };
+    assert_eq!(
+        uefi_profile.validate_boot_config_for_arch("x86_64"),
+        Err(AxVmConfigError::FirmwareProfileRequiresUefi {
+            profile: "qemu_x86_64_axvisor_ovmf_debug".into(),
+        })
+    );
+
+    let uefi_profile_with_bios = VMKernelConfig {
+        enable_bios: true,
+        firmware_profile: Some("qemu_x86_64_axvisor_ovmf_debug".into()),
+        ..Default::default()
+    };
+    assert_eq!(
+        uefi_profile_with_bios.validate_boot_config_for_arch("x86_64"),
+        Err(AxVmConfigError::FirmwareProfileRequiresUefi {
+            profile: "qemu_x86_64_axvisor_ovmf_debug".into(),
+        })
+    );
+}
+
+#[test]
+fn firmware_profile_accepts_uefi_boot_protocol() {
+    let uefi_profile = VMKernelConfig {
+        enable_bios: true,
+        boot_protocol: Some(VMBootProtocol::Uefi),
+        uefi_firmware_path: Some("OVMF_CODE.fd".into()),
+        bios_load_addr: Some(0xffc8_4000),
+        firmware_profile: Some("qemu_x86_64_axvisor_ovmf_debug".into()),
+        ..Default::default()
+    };
+    assert_eq!(uefi_profile.validate_boot_config_for_arch("x86_64"), Ok(()));
+}


### PR DESCRIPTION
## 解决的问题

AxVisor 的 x86_64 路径缺少可诊断的 UEFI guest 启动支持：没有可复现的固定资产（发行版 OVMF 版本漂移）、没有装载时的布局强制、没有统一的设备访问 trace、没有 SEC 到达的端到端测试门禁。UEFI 固件进入 SEC 后"走了哪一步、访问了什么"完全不可见，后续 fw_cfg/ACPI/PCI/virtio 平台发现与启动盘支持缺少诊断基础。

**本 PR**：为 x86_64 guest UEFI 建立阶段 1 的最小闭环——固定 OVMF 资产校验 + loader 布局强制 + 设备访问 trace + ovmf-entry SEC 到达诊断 + 真实验证暴露的 regex 锚定修复，共 6 个提交。本 PR 为后续 UEFI 支持（fw_cfg/ACPI/PCI/virtio 平台发现与启动盘路径）提供可诊断的基础。

## 改了什么

- **固定 OVMF 资产校验（axbuild）**：新增 `scripts/axbuild/src/axvisor/ovmf.rs`，以 typed Rust verifier 替代已删除的 `ovmf-profile.sh`——`OvmfManifest`（`deny_unknown_fields` 解析）/`VerifiedOvmfBundle`/`FirmwareSource` 私有类型，`verify_firmware` 校验 manifest 逐字段值、文件大小与 SHA-256、VARS||CODE 拼接布局；CLI 新增 `--firmware-bundle-path` 与 `--allow-unverified-firmware`（未验证固件必须显式 opt-in 并打印哈希）。
- **x86 loader 布局强制（axvm/axvmconfig）**：`axvmconfig` 新增 `firmware_profile` 配置字段（非 UEFI boot 协议声明时拒绝）；x86 loader 在 fs 与内存两条 UEFI 装载路径上，仅当 profile 为固定值时强制 CODE 大小 `0x37c000`、GPA `0xffc84000`、reset vector `0xfffffff0` 并打印装载日志。未声明 profile 时行为与 dev 完全一致，现有 `arceos-uefi-smp1.toml`（`bios_load_addr = 0xffc0_0000`）不受影响。
- **设备访问 trace（axdevice）**：在 `DeviceRuntime::dispatch` 与 `handle_mmio_write_with_memory` 路径记录统一格式 trace（`device= bus= direction= addr= width= value= result=`），未注册地址仍返回 `NotFound` 并记为 `device=<unregistered>`，SysReg 不 trace；替换死代码 `log_device_io`。trace 只加日志不改行为，作为后续 UEFI 支持的诊断输入。
- **ovmf-entry 端到端用例（test-suit + axbuild runner）**：新增 `test-suit/axvisor/uefi/` 分组与 `ovmf-entry` 用例（VMX/SVM 变体仅 `-cpu` 不同，天然 non-gating）：QEMU `-kernel` 启动 Axvisor 宿主（`uefi = false` 阻断 ostool 下载自带 OVMF），Axvisor 加载嵌套 OVMF 作为 UEFI guest 固件，success_regex 匹配嵌套 VM 启动后的 `SecCoreStartupWithStack(`。runner 消费 `--firmware-bundle-path`：校验过的 CODE 经 `include_bytes!` 嵌入 VM 配置并作为 QEMU pflash unit 0（VARS 每运行独立拷贝），两层固件字节级相同；无 bundle 时 fail-fast，绝不静默 fallback 到发行版 OVMF；`--list` 不要求 bundle。新增专用 VM 配置 `os/axvisor/configs/vms/qemu/x86_64/ovmf-entry.toml`。
- **文档（docs + skill reference）**：`boot-debugging.md` 新增固定 OVMF 章节（常量/CLI/接线/失败模式），`axvisor/overview.md` x86_64 更新为 VMX/SVM + 固定 OVMF UEFI 状态，`axvisor/test.md`/`ci.md` 等补充 `uefi` 分组与固件参数。
- **修复：success_regex 锚定嵌套 VM**：真实 QEMU 验证发现 QEMU 层宿主 OVMF（为引导 axvisor 注入的 pflash）与嵌套 OVMF 输出相同的 SEC 行，裸 regex 847ms 即误匹配宿主层；改为 `(?s)VCpu[0] running...` 前缀锚定嵌套层，修复后真实 QEMU 23s PASS。

## 每步的逻辑

- **先校验后装载（提交 1 → 2）**：资产校验在构建编排层完成（替代 shell 脚本），loader 只做装载时的布局强制；两层都以固定常量为准，任何一层发现不匹配都显式报错而非回退到发行版 OVMF。校验作用域收窄到"profile 显式声明"——这是不破坏 dev 现存 `arceos-uefi-smp1.toml` 的前提。
- **trace 只加日志不改行为（提交 3）**：SEC 到达后的下一个问题必然是"OVMF 接下来访问了什么"，trace 作为后续 UEFI 支持的诊断输入；`result=<ok|error>` 保留失败可见性，为后续设备实现提供首个未支持访问的定位。
- **固定资产接线用 pflash 而非 ostool（提交 4）**：ostool 的 `uefi = true` 会下载 `edk2-stable202508-r1` 并注入 FAT ESP，验证的不是本 PR 固定的 `edk2-stable202605` 资产；因此 `uefi = false` + 校验过的 CODE/VARS 以 pflash 注入，成功判定只来自 guest COM1 的 SEC marker。
- **用例保持 non-gating**：SEC marker 的 VMX/SVM 两机真实硬件证据尚未齐备，合入后继续跟踪（见遗留事项），证据齐全后再升级 gating。

## 验证

- 分支 std 套件 `cargo xtask test`：49 包 1184 passed / 0 failed / 7 ignored；axvm 242、axdevice 47、axvmconfig 14 全过；
- `cargo xtask clippy --package axbuild/axvm/axvmconfig/axdevice` 零告警零 allow；`cargo fmt` 通过；
- ovmf-entry：`--list` 正确发现 vmx/svm 变体；无 bundle 时 fail-fast；
- 真实 QEMU（SVM，本机 AMD）：固定 DEBUG bundle 校验通过后 23s PASS，嵌套 SEC 匹配（提交 6 修复后）；
- 每提交经 subagent 全量评审（实跑 clippy/fmt/单测）→ fix → 复审闭环。

### 手动部署固件并测试

以下为在本机复现 ovmf-entry 端到端验证的步骤（已在 AMD/SVM 环境实测通过）：

1. **构建固定 DEBUG OVMF**（需要 edk2 源码，`edk2-stable202605` tag）：


3. **组装 bundle 目录**（verifier 要求的格式：三个文件 + manifest.toml）：

   ```bash
   mkdir -p <bundle-dir>
   cp <edk2>/Build/OvmfX64/DEBUG_GCC/FV/{OVMF_CODE.fd,OVMF_VARS.fd,OVMF.fd} <bundle-dir>/
   # manifest.toml 需按 scripts/axbuild/src/axvisor/ovmf.rs 的字段契约填写:
   #   profile = "qemu_x86_64_axvisor_ovmf_debug", edk2_tag = "edk2-stable202605",
   #   edk2_commit = <实际 commit>, architecture/target/toolchain/platform, 全部 GPA/大小常量,
   #   code/vars/combined 的 _sha256(用 sha256sum 计算), 布尔开关, 5 个 boot marker。
   # 用 sha256sum <bundle-dir>/*.fd 计算哈希填入。
   ```

4. **运行 ovmf-entry 用例**（本机 AMD 用 SVM 变体，Intel 用 VMX）：

   ```bash
   cd <tgoskits>
   cargo xtask axvisor test qemu --arch x86_64 --test-group uefi \
     --test-case ovmf-entry-svm --firmware-bundle-path <bundle-dir>
   ```

5. **预期结果**：`ok: ovmf-entry-svm`（约 20-30s）。日志中可见完整嵌套链路证据：

   ```
   selected firmware profile: qemu_x86_64_axvisor_ovmf_debug ... verification_label=VERIFIED
   Loading fixed OVMF CODE profile <memory> (3653632 bytes) into GPA @0xffc84000 with reset vector 0xfffffff0
   VM[1] boot success
   VM[1] VCpu[0] running...
   SecCoreStartupWithStack(          ← 嵌套 OVMF SEC, success_regex 锚定点
   === SUCCESS PATTERN MATCHED: (?s)VCpu\[0\] running\.\.\..*SecCoreStartupWithStack ===
   ```

   若 `success_regex` 在 1 秒内即匹配（约 847ms），说明匹配到了宿主 OVMF 的 SEC 而非嵌套层——检查用例 TOML 的 regex 是否带 `VCpu[0] running...` 前缀锚定。

   **注意**：OVMF 必须为 DEBUG 构建（含 `SecCoreStartupWithStack(` 输出）；RELEASE 构建无此 SEC marker，用例会超时失败。

## 遗留事项

- VMX（Intel）硬件验证未完成（SVM 已在本机 AMD 验证通过），ovmf-entry 保持 non-gating，VMX 证据齐全后再升级 gating。