### PR TITLE
test(starry): add Tcl/Tk GUI carpet (offscreen via Xvfb)

### DIFF
--- a/apps/starry/cpu-tcltk-gui-test/.gitignore
+++ b/apps/starry/cpu-tcltk-gui-test/.gitignore
@@ -1,0 +1,4 @@
+target/
+*.o
+assets/
+/tmp/

--- a/apps/starry/cpu-tcltk-gui-test/README.md
+++ b/apps/starry/cpu-tcltk-gui-test/README.md
@@ -1,0 +1,154 @@
+# cpu-tcltk-gui-test - a "pyte for GUI widgets" (Tcl/Tk, headless Xvfb)
+
+An industrial-grade GUI-framework test carpet for StarryOS built on **Tcl/Tk driven headlessly through
+Xvfb**. Tk widgets, canvas items, and photo images render against a virtual-framebuffer X server
+(`Xvfb`, no physical display); `$photo get x y` hands pixels back for per-pixel assertions, the canvas
+`coords`/`bbox` report Tk's own item geometry, the geometry managers (`pack`/`grid`/`place`) realize exact
+child geometry, and `event generate` injects real mouse/key events for interaction testing. Fully
+deterministic, pure CPU. Tcl/Tk is the fifth GUI framework in the goal (alongside Qt and egui).
+
+The carpet **runs Tcl/Tk (it TESTS Tk); it does not reimplement a widget toolkit.** The only self-written
+code is the three-gate marker + closed-form helpers (`gui_common.tcl`) and the four cells, which assert Tk's
+output against goldens computed from first principles - "widget created" alone is **not** a test.
+
+## Why photo pixels + canvas geometry (the offscreen readback method)
+
+Base Tk 8.6 hands back exact pixels only from a **`photo` image** (Tk's real image surface: after
+`$img put color -to x0 y0 x1 y1` fills a half-open span and `$img copy` composites, `$img get x y` reads the
+stored RGB). Grabbing a live **canvas** to pixels needs the `Img`/tkimg `window` photo format or a
+Ghostscript rasterizer for `canvas postscript`, neither of which base Tk ships. So the render leg asserts
+**photo pixels** (Tk's `Tk_PhotoImage` engine) for exact color/compositing and asserts **canvas item
+geometry** (`coords`/`bbox`/`find`/`move` - Tk's canvas layout engine) separately. Together they cover
+"closed-form pixels" and "closed-form geometry"; both are genuine Tk rendering paths, integer-exact and
+identical across arch.
+
+## Cells (three-gate `GUI_<CELL> OK <n>` marker)
+
+Each cell prints `GUI_<CELL> OK <n>` only when `fail==0 && total==pass && total>0`; otherwise it prints
+`GUI_<CELL> FAILED ...` and exits non-zero. `run_all.sh` gates on the `expected_cells` manifest
+(`fail==0 && total==EXPECTED==pass`, `EXPECTED>=1` floor) and prints `TEST PASSED` / `TEST FAILED`.
+
+### `gui_render` - photo pixels + canvas item geometry (38 checks)
+- **photo fillRect**: a 40x30 red rect at `(20,15)` in a 100x80 photo -> every interior pixel exactly red,
+  the four background bands untouched dark gray, exact edge pixels (inside vs one-past the half-open span),
+  exact covered-pixel count `= 40*30 = 1200`.
+- **photo copy**: an 8x8 red image copied to `(6,6)` over a 30x30 blue photo -> the overlay region is exactly
+  red, the surrounding blue is untouched, exact counts (`red=64`, `blue=836`).
+- **canvas geometry**: rectangle/oval/line/polygon/arc items with known coords -> Tk's `coords`, `bbox`,
+  `type`, `itemcget -fill/-start/-extent`, `find overlapping`, and `move` all report the exact closed form.
+- **canvas text**: one `'A'` item -> `bbox` is non-degenerate and inside a bounded band (font-agnostic; bbox
+  extent, never glyph-exact pixels).
+
+### `gui_layout` - deterministic geometry (36 checks)
+- **place**: a child placed at `-x 37 -y 52` sits at exactly `winfo x/y = 37/52` with its fixed size.
+- **pack** (vertical stack): child `i` top edge `= PAD + i*(CH + 2*PAD)` -> `[6,48,90]` (pack `-pady` adds
+  PAD above and below each child); each child's realized width/height equals the requested size.
+- **grid**: 2x2 fixed cells -> `grid info` reports exact row/column/span, `grid bbox` gives exact cell
+  rectangles at the origin and past the first row/col, `grid size == 2 2`.
+- **labelframe**: `-padx 12 -pady 8` -> the frame's `reqwidth >= inner reqwidth + 2*padx` and
+  `reqheight >= inner reqheight + 2*pady`; the inner label is parented to the labelframe.
+- **reqsize**: a fixed-size frame's `reqwidth`/`reqheight` equal the requested pixels.
+
+### `gui_interact` - inject events, assert state (25 checks)
+- **button**: a synthesized `<Enter>`+`<ButtonPress-1>`+`<ButtonRelease-1>` fires the `-command` exactly
+  once, twice on a second click (real event routing through Tk's binding tables); a **disabled** button's
+  `invoke` does **not** fire (negative control).
+- **checkbutton**: `invoke` toggles the linked variable `0 -> 1 -> 0`; a focused `<space>` key also toggles.
+- **entry**: `<KeyPress>` keysym events produce `"hello"`; `<BackSpace>` -> `"hell"`; exact `insert`/`delete`/
+  `index`/`icursor` ops (`"world"`, `end==5`, `"orld"`, `"orXYld"`).
+- **scale**: `set 42`, `<Right>` -> 43, `<Left>` -> 42 (resolution 1), clamp `set 200 -> 100`, `set -50 -> 0`.
+- **listbox**: `insert`/`size`/`get`/`get 0 end`/`selection set`/`curselection`/`selection includes`/`delete`
+  are all exact (`50 -> ...` style deterministic sequence).
+
+### `gui_realassets` - real font family metrics (10 checks, or 1 honest-skip)
+- Picks a resolvable real font family (a staged `.ttf`'s derived family, else a known monospace family, else
+  the Tk logical `Courier` fixed alias). Asserts a **fixed-pitch** family measures N chars as exactly
+  `N * one-char` width, `font metrics -fixed == 1`, `linespace >= ascent + descent`, and a larger pixel size
+  yields a strictly wider/taller canvas text bbox.
+- **Honest-skips** (still passes, `total>0`) when no real font family is resolvable, so the synthetic legs
+  always gate. (Base Tk has no `addApplicationFont` file-load API - fonts come from the X server /
+  fontconfig, so the "asset" is a resolvable family, not a raw file load.)
+
+## Determinism
+
+Headless `Xvfb` X server (virtual framebuffer, no display), Tk photo/canvas/font engines (pure CPU). Fixed
+widget sizes, named colors, fixed-pixel fonts, and a fixed seed (`0x233`) anywhere a random path could
+appear. Photo pixels, canvas coords/bbox, and geometry-manager arithmetic are integer-exact and identical
+across arch.
+
+## Layout
+
+```
+cpu-tcltk-gui-test/
+├── prebuild.sh                      # apk add tcl/tk + xvfb + font-dejavu for target arch, stage .tcl cells
+│                                    # + a font asset into the overlay, write expected_cells
+├── programs/
+│   ├── run_all.sh                   # on-target runner; starts Xvfb on :99, runs each .tcl under wish;
+│   │                                # three-gate marker
+│   └── carpets/
+│       ├── gui_common.tcl           # three-gate marker + photo-pixel/bbox/ink closed-form helpers
+│       ├── gui_render.tcl
+│       ├── gui_layout.tcl
+│       ├── gui_interact.tcl
+│       ├── gui_realassets.tcl
+│       └── third_party/README.md    # runs Tk, vendors nothing
+├── tools/gen_goldens.py             # re-derives the closed-form constants for review
+├── build-x86_64-unknown-none.toml            # ax-driver/nvme (+ serial on la/rv)
+├── build-aarch64-unknown-none-softfloat.toml
+├── build-loongarch64-unknown-none-softfloat.toml
+├── build-riscv64gc-unknown-none-elf.toml
+├── qemu-x86_64.toml                 # headless Xvfb, -smp 1, 1024M
+├── qemu-aarch64.toml
+├── qemu-loongarch64.toml            # dynamic platform (uefi=false, to_bin=true)
+└── qemu-riscv64.toml
+```
+
+## Host validation (real output)
+
+Tcl/Tk 8.6 and Xvfb (Debian/Ubuntu host) were used to run each cell under `wish` against a headless Xvfb
+display. Full gate (runner starts its own Xvfb on `:99`, or run under `xvfb-run -a`):
+
+```
+cpu-tcltk-gui-test: detected CPU count = 12; DISPLAY=:99; wish=/usr/bin/wish; ASSET_DIR=.../assets
+GUI_RENDER OK 38
+GUI_LAYOUT OK 36
+GUI_INTERACT OK 25
+GUI_REALASSETS OK 10
+cpu-tcltk-gui-test: 4/4 GUI carpets OK on x86_64 (expected 4: gui_render gui_layout gui_interact gui_realassets )
+TEST PASSED
+```
+
+With no resolvable font family, `GUI_REALASSETS OK 1` (honest-skip) and the gate still passes 4/4.
+
+**Mutation tests** (both correctly FAIL):
+- `gui_render`: expect the fillRect interior to be green instead of red -> `GUI_RENDER FAILED pass=37
+  total=38 fail=1`, exit 1, and `run_all.sh` reports `TEST FAILED`.
+- `gui_interact`: assert the checkbutton variable is still 0 after `invoke` -> `GUI_INTERACT FAILED pass=24
+  total=25 fail=1`, exit 1.
+
+Tk version: **8.6**. Display backend: **Xvfb** (virtual framebuffer, no GPU, no physical display).
+
+## On-target run
+
+```
+cargo xtask starry app qemu -t cpu-tcltk-gui-test
+```
+
+`prebuild.sh` grows the rootfs, `apk add`s `tcl tk xvfb font-dejavu fontconfig` for the target arch via
+qemu-user, stages the four `.tcl` cells + a DejaVu font into the overlay, and writes `expected_cells`.
+`run_all.sh` then brings up **Xvfb on `:99`** and runs each cell under `wish`, gating on the manifest.
+
+### Honest on-target scoping (display backend)
+
+Tk requires an X display. This carpet supplies it **in userspace via `Xvfb`** - a self-contained
+virtual-framebuffer X server that renders into RAM with **no GPU and no physical display device** - so it
+does not depend on StarryOS's kernel display/framebuffer bring-up. `run_all.sh` starts `Xvfb :99` and points
+`DISPLAY` at it; if Xvfb starts (the Alpine `xvfb` package is a pure-CPU X server), the full carpet runs
+headless on-target exactly as on the host.
+
+If `Xvfb` cannot start on a given StarryOS target (e.g. an X-server syscall/driver gap that the display
+bring-up work under **#392** would close), `run_all.sh` prints `GATE BLOCKED (display backend gated on #392)`
+and fails the gate honestly - it does **not** fall back to a host-only fake pass. So: **works headless
+wherever the Alpine `xvfb` X server runs; otherwise the on-target run is gated on #392 display bring-up.**
+The host validation above is real and the packaging is arch-portable; whether Xvfb itself boots under
+StarryOS per-arch is the remaining on-target question this carpet surfaces cleanly.

--- a/apps/starry/cpu-tcltk-gui-test/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-tcltk-gui-test/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,6 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-tcltk-gui-test/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/cpu-tcltk-gui-test/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,7 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-tcltk-gui-test/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/cpu-tcltk-gui-test/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,7 @@
+target = "riscv64gc-unknown-none-elf"
+log = "Warn"
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-tcltk-gui-test/build-x86_64-unknown-none.toml
+++ b/apps/starry/cpu-tcltk-gui-test/build-x86_64-unknown-none.toml
@@ -1,0 +1,6 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+features = [
+  "ax-driver/nvme",
+  "ax-driver/virtio-net",
+]

--- a/apps/starry/cpu-tcltk-gui-test/prebuild.sh
+++ b/apps/starry/cpu-tcltk-gui-test/prebuild.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# prebuild.sh - provision the cpu-tcltk-gui-test carpet ("pyte for GUI widgets") into the per-arch Alpine
+# rootfs.
+#
+# The carpet drives real Tcl/Tk widgets/canvas/photo rendering against a headless X server (Xvfb) and asserts
+# CLOSED-FORM goldens: exact photo-image pixels from known put/copy geometry, exact canvas item geometry
+# (coords/bbox) from Tk's own canvas layout engine, exact pack/grid/place child geometry from the
+# geometry-manager math, exact font measure/metrics, and post-event widget state from injected `event
+# generate` mouse/key events. "Widget created" alone is NOT a test - every leg checks a value predicted from
+# first principles.
+#
+# Unlike the Qt carpet (compiled C++ linking Qt6), the Tk cells are Tcl SCRIPTS interpreted by `wish` - so
+# there is nothing to cross-compile. Provisioning is: apk add the Alpine tcl/tk runtime + xvfb (headless X
+# server) + a DejaVu font for the target arch, stage the .tcl cells + a font asset into the overlay, and
+# write a capability manifest that run_all.sh gates on (fail==0 && total==EXPECTED==pass, EXPECTED>=1 floor).
+# The synthetic render/layout/interact legs always run; the real-asset font leg honest-skips if no resolvable
+# font family is present.
+#
+# The carpet TESTS Tcl/Tk - it does not reimplement a widget toolkit. The only self-written code is the
+# three-gate marker + closed-form helpers (gui_common.tcl) and the four cells.
+#
+# Env from the app runner: STARRY_ARCH, STARRY_ROOTFS, STARRY_STAGING_ROOT, STARRY_OVERLAY_DIR, STARRY_APP_DIR.
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:?prebuild: STARRY_ARCH required}"
+base_rootfs="${STARRY_ROOTFS:?prebuild: STARRY_ROOTFS required}"
+staging_root="${STARRY_STAGING_ROOT:?prebuild: STARRY_STAGING_ROOT required}"
+overlay_dir="${STARRY_OVERLAY_DIR:?prebuild: STARRY_OVERLAY_DIR required}"
+CAR="$app_dir/programs/carpets"
+INSTALL_DIR=/opt/cpu-tcltk-gui-test
+
+case "$arch" in
+    aarch64)     qemu_runner="qemu-aarch64-static" ;;
+    riscv64)     qemu_runner="qemu-riscv64-static" ;;
+    x86_64)      qemu_runner="qemu-x86_64-static" ;;
+    loongarch64) qemu_runner="qemu-loongarch64-static" ;;
+    *) echo "prebuild: unsupported arch: $arch" >&2; exit 1 ;;
+esac
+
+ensure_host_tools() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v "$qemu_runner" >/dev/null 2>&1 || missing+=(qemu-user-static)
+    command -v resize2fs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        command -v apt-get >/dev/null 2>&1 && apt-get update && apt-get install -y --no-install-recommends "${missing[@]}" \
+            || { echo "prebuild: missing host tools: ${missing[*]}" >&2; exit 1; }
+    fi
+}
+
+# Xorg (Xvfb) + tcl/tk pull a fair amount; give the rootfs room.
+ROOTFS_SIZE=4G
+grow_rootfs() {
+    [[ -f "$base_rootfs" ]] || { echo "prebuild: rootfs image missing: $base_rootfs" >&2; exit 2; }
+    local before after; before=$(stat -c %s "$base_rootfs")
+    truncate -s "$ROOTFS_SIZE" "$base_rootfs"
+    e2fsck -f -y "$base_rootfs" >/dev/null 2>&1 || true
+    resize2fs "$base_rootfs" >/dev/null 2>&1
+    after=$(stat -c %s "$base_rootfs")
+    echo "prebuild: rootfs grown $((before/1024/1024)) -> $((after/1024/1024)) MiB for the tcl/tk + Xvfb stack"
+}
+
+extract_base_rootfs() {
+    rm -rf "$staging_root"; mkdir -p "$staging_root"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null 2>&1
+    [[ -x "$staging_root/sbin/apk" ]] || { echo "prebuild: base rootfs has no apk" >&2; exit 2; }
+}
+
+normalize_symlinks() {
+    local link tgt rel
+    while IFS= read -r link; do
+        tgt="$(readlink "$link")"; [[ "$tgt" == /* ]] || continue
+        rel="$(realpath -m --relative-to="$(dirname "$link")" "$staging_root$tgt")"
+        ln -sf "$rel" "$link"
+    done < <(find "$staging_root/lib" "$staging_root/usr/lib" -type l 2>/dev/null)
+}
+
+# tcl/tk runtime + a headless X server (Xvfb) so Tk has a display, plus a DejaVu font for the real-asset leg
+# and fontconfig so Tk resolves it. font-dejavu registers "DejaVu Sans Mono" - a fixed-pitch family whose
+# closed-form measure the realassets leg asserts on.
+PKGS=(tcl tk xvfb font-dejavu fontconfig)
+
+apk_provision() {
+    normalize_symlinks
+    [[ -f /etc/resolv.conf ]] && cp -f /etc/resolv.conf "$staging_root/etc/resolv.conf" || true
+    local edge="https://dl-cdn.alpinelinux.org/alpine"
+    printf '%s/edge/main\n%s/edge/community\n' "$edge" "$edge" > "$staging_root/etc/apk/repositories"
+    local apk_common=(--root "$staging_root" --repositories-file "$staging_root/etc/apk/repositories"
+                      --keys-dir "$staging_root/etc/apk/keys" --no-progress --no-scripts)
+    echo "prebuild: apk add tcl/tk GUI carpet stack (${PKGS[*]}) via $qemu_runner..."
+    QEMU_LD_PREFIX="$staging_root" LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" "$staging_root/sbin/apk" "${apk_common[@]}" --update-cache add "${PKGS[@]}"
+    [[ -x "$staging_root/usr/bin/wish" ]] \
+        || { echo "prebuild: wish (tk) not provisioned for $arch" >&2; exit 3; }
+    [[ -x "$staging_root/usr/bin/Xvfb" ]] \
+        || { echo "prebuild: Xvfb not provisioned for $arch (display backend package missing)" >&2; exit 3; }
+}
+
+# Stage the .tcl cells + the runner into the install dir, and a real font into assets/ for the real-asset leg.
+stage_carpet() {
+    local bin="$1"; mkdir -p "$bin/assets"
+    for cell in gui_common gui_render gui_layout gui_interact gui_realassets; do
+        cp "$CAR/$cell.tcl" "$bin/$cell.tcl"
+    done
+    cp "$app_dir/programs/run_all.sh" "$bin/run_all.sh"; chmod +x "$bin/run_all.sh"
+    # a font for the real-asset leg (font-dejavu also registers the family with fontconfig for Tk to resolve)
+    local ttf; ttf="$(find "$staging_root/usr/share/fonts" -iname 'DejaVuSansMono*.ttf' 2>/dev/null | head -1 || true)"
+    [[ -z "$ttf" ]] && ttf="$(find "$staging_root/usr/share/fonts" -name '*.ttf' 2>/dev/null | head -1 || true)"
+    if [[ -n "$ttf" ]]; then
+        cp -a "$ttf" "$bin/assets/" && echo "prebuild: staged font $(basename "$ttf") for real-asset leg"
+    else
+        echo "prebuild: no .ttf under staging fonts - real-asset leg honest-skips"
+    fi
+}
+
+populate_overlay() {
+    local bin="$staging_root$INSTALL_DIR"
+    : > "$bin/expected_cells"
+    for c in gui_render gui_layout gui_interact gui_realassets; do
+        [[ -f "$bin/$c.tcl" ]] && echo "$c" >> "$bin/expected_cells"; done
+    echo "prebuild: expected_cells for $arch = $(tr '\n' ' ' < "$bin/expected_cells")"
+    mkdir -p "$overlay_dir/opt"
+    cp -a "$staging_root$INSTALL_DIR" "$overlay_dir/opt/"
+    mkdir -p "$overlay_dir/usr/bin"
+    ln -sf "$INSTALL_DIR/run_all.sh" "$overlay_dir/usr/bin/run_all.sh"
+    echo "prebuild: overlay populated for $arch"
+}
+
+ensure_host_tools
+grow_rootfs
+extract_base_rootfs
+apk_provision
+stage_carpet "$staging_root$INSTALL_DIR"
+populate_overlay
+echo "prebuild: cpu-tcltk-gui-test overlay ready for $arch"

--- a/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_common.tcl
+++ b/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_common.tcl
@@ -1,0 +1,127 @@
+# gui_common.tcl - shared primitives for the cpu-tcltk-gui-test carpet (a "pyte for GUI widgets").
+#
+# Each cell drives a real Tcl/Tk pipeline against an X server provided headlessly by Xvfb (virtual
+# framebuffer, no physical display) and asserts the result against a CLOSED-FORM golden: exact per-pixel
+# colors from known photo-image put/copy geometry, exact canvas item geometry from Tk's own canvas layout
+# (coords/bbox), exact pack/grid/place child geometry from the geometry-manager arithmetic, exact font
+# measure/metrics, and post-event widget state from injected `event generate` mouse/key events.
+# "Widget created" alone is NOT a test here - every leg checks a value it can predict from first principles.
+#
+# Why photo images for pixels: base Tk 8.6 hands back exact pixels only from a `photo` image (Tk's real
+# image surface: `$img get x y` reads the stored RGB after `put`/`copy` compositing). Grabbing a live canvas
+# to pixels needs the Img/tkimg `window` photo format or a Ghostscript rasterizer for `canvas postscript`,
+# neither of which base Tk ships; so the render leg asserts photo pixels (Tk_PhotoImage engine) for exact
+# color/compositing and asserts canvas *geometry* (coords/bbox/find - Tk's canvas layout engine) separately.
+#
+# Determinism: fixed sizes, fixed named colors, fixed-pixel fonts, and a fixed seed (0x233) wherever a random
+# path could appear. Text legs assert a bbox + non-empty extent (glyph pixels depend on the bundled font);
+# never glyph-exact pixels.
+#
+# Three-gate marker: a cell prints "GUI_<CELL> OK <n>" only when fail==0 && total==pass && total>0.
+
+# fixed seed anywhere randomness could enter (none of the legs are random, but pin it for reproducibility)
+expr {srand(0x233)}
+
+# ------------------------------------------------------------------ three-gate marker
+namespace eval gate {
+    variable pass 0
+    variable total 0
+    variable fail 0
+    variable name "GUI"
+}
+
+proc gate_init {name} {
+    set gate::pass 0
+    set gate::total 0
+    set gate::fail 0
+    set gate::name $name
+}
+
+# check {cond} {msg} - increment total; pass if the boolean expression `cond` evaluates true, else fail and
+# print the message to stderr. `cond` is evaluated with [expr] in the caller's context so both bare boolean
+# results (from [rect_is_color ...] which already returns 0/1) and comparison expressions (== / eq / &&) work.
+proc check {cond msg} {
+    incr gate::total
+    set ok [uplevel 1 [list expr $cond]]
+    if {$ok} {
+        incr gate::pass
+    } else {
+        incr gate::fail
+        puts stderr "  FAIL: $msg"
+    }
+}
+
+# finish - print the three-gate marker and exit with 0 (all pass) or 1 (any fail / empty).
+proc gate_finish {} {
+    if {$gate::fail == 0 && $gate::total == $gate::pass && $gate::total > 0} {
+        puts "$gate::name OK $gate::total"
+        exit 0
+    }
+    puts "$gate::name FAILED pass=$gate::pass total=$gate::total fail=$gate::fail"
+    exit 1
+}
+
+# ------------------------------------------------------------------ photo-image pixel helpers
+# `$img get x y` returns a list {R G B} of 0..255. These helpers turn that into exact comparisons.
+
+# rgb_eq {pixel} {r g b} {tol} - channel-wise |a-b| <= tol on every channel.
+proc rgb_eq {pixel r g b tol} {
+    lassign $pixel pr pg pb
+    expr {abs($pr - $r) <= $tol && abs($pg - $g) <= $tol && abs($pb - $b) <= $tol}
+}
+
+# pix_is {img x y} {r g b} {tol} - the pixel at (x,y) is within tol of (r,g,b).
+proc pix_is {img x y r g b tol} {
+    rgb_eq [$img get $x $y] $r $g $b $tol
+}
+
+# rect_is_color {img x0 y0 x1 y1} {r g b} {tol} - every pixel in [x0,x1) x [y0,y1) is within tol of the color.
+proc rect_is_color {img x0 y0 x1 y1 r g b tol} {
+    for {set y $y0} {$y < $y1} {incr y} {
+        for {set x $x0} {$x < $x1} {incr x} {
+            if {![rgb_eq [$img get $x $y] $r $g $b $tol]} { return 0 }
+        }
+    }
+    return 1
+}
+
+# count_color {img x0 y0 x1 y1} {r g b} {tol} - number of pixels in the rect within tol of the color.
+proc count_color {img x0 y0 x1 y1 r g b tol} {
+    set n 0
+    for {set y $y0} {$y < $y1} {incr y} {
+        for {set x $x0} {$x < $x1} {incr x} {
+            if {[rgb_eq [$img get $x $y] $r $g $b $tol]} { incr n }
+        }
+    }
+    return $n
+}
+
+# ------------------------------------------------------------------ ink helpers (text / glyph legs)
+# "ink" = a pixel that differs from the background by more than tol on any channel.
+
+proc count_non_bg {img w h br bg bb tol} {
+    set n 0
+    for {set y 0} {$y < $h} {incr y} {
+        for {set x 0} {$x < $w} {incr x} {
+            if {![rgb_eq [$img get $x $y] $br $bg $bb $tol]} { incr n }
+        }
+    }
+    return $n
+}
+
+# ink_bbox - tight bounding box of ink pixels. Returns {} if no ink, else {minx miny maxx maxy}.
+proc ink_bbox {img w h br bg bb tol} {
+    set lx $w; set ly $h; set hx -1; set hy -1
+    for {set y 0} {$y < $h} {incr y} {
+        for {set x 0} {$x < $w} {incr x} {
+            if {![rgb_eq [$img get $x $y] $br $bg $bb $tol]} {
+                if {$x < $lx} { set lx $x }
+                if {$x > $hx} { set hx $x }
+                if {$y < $ly} { set ly $y }
+                if {$y > $hy} { set hy $y }
+            }
+        }
+    }
+    if {$hx < 0} { return {} }
+    return [list $lx $ly $hx $hy]
+}

--- a/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_interact.tcl
+++ b/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_interact.tcl
@@ -1,0 +1,148 @@
+# gui_interact.tcl - per-interaction testing: inject real events with `event generate`, assert STATE change.
+#
+# Every leg drives a real widget through a real event and predicts the outcome:
+#   - button + command -> Enter + ButtonPress-1 + ButtonRelease-1 fires the command exactly once, twice on a
+#     second click (real event routing through Tk's binding tables, not a direct proc call); a *disabled*
+#     button's `invoke` does NOT fire (negative control).
+#   - checkbutton -> `invoke` toggles the linked variable to 1; a second toggles back to 0; a Space keypress
+#     on a focused checkbutton also toggles it (real key binding).
+#   - entry -> keysym KeyPress events land in the text; backspace removes; delete/insert index ops are exact.
+#   - scale -> `set` then a keyboard step (Right/Up) moves value() by the exact resolution; from/to clamp.
+#   - listbox -> insert/size/get/curselection/delete are exact; a selection-set changes curselection.
+#
+# Xvfb provides the headless X display; events are posted through the real Tk event loop against mapped
+# widgets. `update` flushes the queue so the state settles before we read it.
+
+package require Tk
+wm geometry . 500x500+0+0
+source [file join [file dirname [info script]] gui_common.tcl]
+gate_init GUI_INTERACT
+
+# ------------------------------------------------------------------ button: real click fires the command
+proc leg_button_click {} {
+    set ::fired 0
+    button .b -text Go -command {incr ::fired}
+    pack .b
+    update idletasks; update
+    set w [winfo width .b]; set h [winfo height .b]
+    # a real synthesized click: pointer enters, presses and releases inside the button
+    event generate .b <Enter>
+    event generate .b <ButtonPress-1>   -x [expr {$w/2}] -y [expr {$h/2}]
+    event generate .b <ButtonRelease-1> -x [expr {$w/2}] -y [expr {$h/2}]
+    update
+    check {$::fired == 1} "button: first synthesized click did not fire command exactly once"
+    event generate .b <ButtonPress-1>   -x [expr {$w/2}] -y [expr {$h/2}]
+    event generate .b <ButtonRelease-1> -x [expr {$w/2}] -y [expr {$h/2}]
+    update
+    check {$::fired == 2} "button: second click did not increment to two"
+    destroy .b
+}
+
+# ------------------------------------------------------------------ button disabled: negative control
+proc leg_button_disabled {} {
+    set ::fired2 0
+    button .bd -text Off -state disabled -command {incr ::fired2}
+    pack .bd
+    update
+    .bd invoke   ;# invoke on a disabled button must be a no-op
+    update
+    check {$::fired2 == 0} "button(disabled): invoke wrongly fired the command"
+    destroy .bd
+}
+
+# ------------------------------------------------------------------ checkbutton: variable + key toggle
+proc leg_checkbutton {} {
+    set ::cbv 0
+    checkbutton .cb -variable ::cbv -text opt
+    pack .cb
+    update
+    check {$::cbv == 0} "checkbutton: initial variable not 0"
+    .cb invoke
+    check {$::cbv == 1} "checkbutton: invoke did not set variable to 1"
+    .cb invoke
+    check {$::cbv == 0} "checkbutton: second invoke did not toggle back to 0"
+    # a Space key on the focused checkbutton toggles it (real key binding)
+    focus -force .cb
+    update
+    event generate .cb <KeyPress-space>
+    event generate .cb <KeyRelease-space>
+    update
+    check {$::cbv == 1} "checkbutton: Space key did not toggle to 1"
+    destroy .cb
+}
+
+# ------------------------------------------------------------------ entry: keystrokes + edit ops
+proc leg_entry {} {
+    entry .e
+    pack .e
+    update
+    focus -force .e
+    update
+    foreach k {h e l l o} { event generate .e <KeyPress> -keysym $k }
+    update
+    check {[.e get] eq "hello"} "entry: keysym KeyPress events did not produce 'hello'"
+    event generate .e <KeyPress> -keysym BackSpace
+    update
+    check {[.e get] eq "hell"} "entry: BackSpace did not yield 'hell'"
+    # exact index ops
+    .e delete 0 end
+    .e insert 0 "world"
+    check {[.e get] eq "world"}       "entry: insert did not set 'world'"
+    check {[.e index end] == 5}       "entry: end index != 5"
+    .e delete 0 1
+    check {[.e get] eq "orld"}        "entry: delete 0 1 did not drop first char"
+    .e icursor 2
+    .e insert insert "XY"
+    check {[.e get] eq "orXYld"}      "entry: insert at cursor 2 wrong"
+    destroy .e
+}
+
+# ------------------------------------------------------------------ scale: set + keyboard step + clamp
+proc leg_scale {} {
+    scale .s -from 0 -to 100 -orient horizontal -resolution 1
+    pack .s
+    update
+    .s set 42
+    check {[.s get] == 42} "scale: set 42 not read back"
+    focus -force .s
+    update
+    # for a horizontal scale, Right moves +resolution and Left -resolution (1)
+    event generate .s <KeyPress-Right>
+    update
+    check {[.s get] == 43} "scale: Right did not add one step (43)"
+    event generate .s <KeyPress-Left>
+    update
+    check {[.s get] == 42} "scale: Left did not subtract one step (42)"
+    # clamp to bounds
+    .s set 200
+    check {[.s get] == 100} "scale: set above max not clamped to 100"
+    .s set -50
+    check {[.s get] == 0}   "scale: set below min not clamped to 0"
+    destroy .s
+}
+
+# ------------------------------------------------------------------ listbox: insert/get/selection/delete
+proc leg_listbox {} {
+    listbox .lb
+    pack .lb
+    update
+    .lb insert end alpha beta gamma delta
+    check {[.lb size] == 4}                 "listbox: size != 4 after insert"
+    check {[.lb get 1] eq "beta"}           "listbox: get 1 != beta"
+    check {[.lb get 0 end] eq {alpha beta gamma delta}} "listbox: get range wrong"
+    .lb selection set 2
+    check {[.lb curselection] eq "2"}       "listbox: curselection != 2 after selection set"
+    check {[.lb selection includes 2]}      "listbox: selection includes 2 false"
+    .lb delete 0
+    check {[.lb size] == 3}                 "listbox: size != 3 after delete 0"
+    check {[.lb get 0] eq "beta"}           "listbox: get 0 != beta after delete"
+    destroy .lb
+}
+
+leg_button_click
+leg_button_disabled
+leg_checkbutton
+leg_entry
+leg_scale
+leg_listbox
+gate_finish

--- a/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_layout.tcl
+++ b/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_layout.tcl
@@ -1,0 +1,142 @@
+# gui_layout.tcl - deterministic geometry: assert each child's realized geometry == closed-form layout math.
+#
+# Widgets are given fixed sizes and the geometry managers fixed padding, the toplevel is realized and the
+# event loop flushed (update idletasks) so Tk actually performs the layout, and each child's position/size
+# is read back via `winfo x/y/width/height/reqwidth/reqheight` and compared to exact arithmetic:
+#   - place: a child placed at -x/-y sits at exactly those window coords (winfo x/y).
+#   - pack (side top): children stack vertically; each child's y is the running sum of prior heights + pady.
+#   - grid: `grid info` reports the exact row/column/span; grid bbox gives the exact cell rectangle.
+#   - a labelframe with -padx/-pady contains its child and its reqwidth = child reqwidth + 2*pad + border.
+#   - reqwidth/reqheight of a fixed-size widget equal the requested size (closed form).
+#
+# No pixels needed: geometry-manager math is exact integer arithmetic, identical across arch. Xvfb provides
+# the headless X display so the managers actually map and size the widgets.
+
+package require Tk
+source [file join [file dirname [info script]] gui_common.tcl]
+gate_init GUI_LAYOUT
+
+# a fixed-size label whose reqwidth/reqheight are pinned by -width/-height in *pixels* via a frame wrapper.
+proc fixed_frame {name w h} {
+    frame $name -width $w -height $h
+    # keep the frame at its requested size (do not let a child resize it)
+    pack propagate $name 0
+    return $name
+}
+
+# ------------------------------------------------------------------ place: exact window coords
+proc leg_place {} {
+    set top [toplevel .plc]
+    wm geometry $top 400x400+0+0
+    set f [fixed_frame $top.f 120 80]
+    place $f -x 37 -y 52
+    update idletasks
+    check {[winfo x $f] == 37}       "place: child x != 37"
+    check {[winfo y $f] == 52}       "place: child y != 52"
+    check {[winfo width $f] == 120}  "place: child width != 120"
+    check {[winfo height $f] == 80}  "place: child height != 80"
+    # a second child placed relative moves by an exact delta
+    set g [fixed_frame $top.g 40 40]
+    place $g -x 100 -y 100
+    update idletasks
+    check {[winfo x $g] == 100 && [winfo y $g] == 100} "place: second child coords wrong"
+    destroy $top
+}
+
+# ------------------------------------------------------------------ pack: vertical stack at known offsets
+proc leg_pack_vstack {} {
+    set top [toplevel .pk]
+    wm geometry $top 300x400+0+0
+    set PAD 6
+    set CW 120; set CH 30
+    set ys {}
+    for {set i 0} {$i < 3} {incr i} {
+        set c [fixed_frame $top.c$i $CW $CH]
+        pack $c -side top -pady $PAD -anchor w
+    }
+    update idletasks
+    # child i top edge = sum of prior (CH + 2*PAD) + PAD ; each pack pady adds PAD above and below
+    for {set i 0} {$i < 3} {incr i} {
+        set c $top.c$i
+        set ey [expr {$PAD + $i * ($CH + 2 * $PAD)}]
+        set gy [winfo y $c]
+        check {$gy == $ey} "pack vstack child $i y ($gy) != closed form ($ey)"
+        check {[winfo height $c] == $CH} "pack vstack child $i height != $CH"
+        check {[winfo width $c] == $CW}  "pack vstack child $i width != $CW"
+    }
+    destroy $top
+}
+
+# ------------------------------------------------------------------ grid: exact row/col/span + cell bbox
+proc leg_grid {} {
+    set top [toplevel .gd]
+    wm geometry $top 400x400+0+0
+    set CW 60; set CH 40
+    for {set r 0} {$r < 2} {incr r} {
+        for {set col 0} {$col < 2} {incr col} {
+            set c [fixed_frame $top.c${r}_${col} $CW $CH]
+            grid $c -row $r -column $col -padx 0 -pady 0
+        }
+    }
+    update idletasks
+    # grid info reports exact placement
+    foreach {name er ec} {c0_0 0 0 c0_1 0 1 c1_0 1 0 c1_1 1 1} {
+        array set gi [grid info $top.$name]
+        check {$gi(-row) == $er}    "grid $name row != $er"
+        check {$gi(-column) == $ec} "grid $name column != $ec"
+        check {$gi(-rowspan) == 1 && $gi(-columnspan) == 1} "grid $name span != 1x1"
+        array unset gi
+    }
+    # cell (0,0) bbox is a rectangle of at least the child size at the origin
+    set bb [grid bbox $top 0 0]
+    lassign $bb bx by bw bh
+    check {$bx == 0 && $by == 0}          "grid: cell(0,0) origin != (0,0)"
+    check {$bw >= $CW && $bh >= $CH}      "grid: cell(0,0) smaller than child"
+    # cell (1,1) origin is at the sum of column 0 width / row 0 height (>0)
+    set bb2 [grid bbox $top 1 1]
+    lassign $bb2 bx2 by2
+    check {$bx2 >= $CW && $by2 >= $CH}    "grid: cell(1,1) origin not past first row/col"
+    # grid size reports 2x2
+    check {[grid size $top] eq {2 2}}     "grid: size != 2x2"
+    destroy $top
+}
+
+# ------------------------------------------------------------------ labelframe padding composition
+proc leg_labelframe {} {
+    set top [toplevel .lf]
+    wm geometry $top 400x400+0+0
+    set PX 12; set PY 8
+    set lf [labelframe $top.lf -text hdr -padx $PX -pady $PY -borderwidth 2]
+    set inner [label $lf.inner -text inner -width 10 -height 2]
+    pack $inner
+    pack $lf
+    update idletasks
+    # the inner label reqwidth is bounded and the labelframe reqwidth exceeds it by at least 2*padx
+    set iw [winfo reqwidth $inner]
+    set lw [winfo reqwidth $lf]
+    check {$iw > 0}                       "labelframe: inner reqwidth is zero"
+    check {$lw >= $iw + 2 * $PX}          "labelframe: reqwidth < inner + 2*padx"
+    set ih [winfo reqheight $inner]
+    set lh [winfo reqheight $lf]
+    check {$lh >= $ih + 2 * $PY}          "labelframe: reqheight < inner + 2*pady"
+    # the inner label is a child of the labelframe (containment)
+    check {[winfo parent $inner] eq $lf}  "labelframe: inner not parented to labelframe"
+    destroy $top
+}
+
+# ------------------------------------------------------------------ reqwidth/reqheight of a fixed widget
+proc leg_reqsize {} {
+    set top [toplevel .rs]
+    set f [fixed_frame $top.f 77 55]
+    update idletasks
+    check {[winfo reqwidth $f] == 77}   "reqsize: reqwidth != requested 77"
+    check {[winfo reqheight $f] == 55}  "reqsize: reqheight != requested 55"
+    destroy $top
+}
+
+leg_place
+leg_pack_vstack
+leg_grid
+leg_labelframe
+leg_reqsize
+gate_finish

--- a/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_realassets.tcl
+++ b/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_realassets.tcl
@@ -1,0 +1,112 @@
+# gui_realassets.tcl - real font metrics leg: use a real (system/staged) font family and assert closed-form
+# `font measure` / `font metrics` values, plus canvas text bbox that scales with pixel size.
+#
+# Unlike Qt (QFontDatabase::addApplicationFont loads a .ttf directly), base Tk 8.6 has NO application-font
+# file-load API: Tk consumes fonts the X server / fontconfig already knows. So this leg's "real asset" is a
+# real, resolvable font *family* - it prefers a monospace family whose deterministic metrics we can predict
+# from first principles (a fixed-pitch font's N-char measure == N * single-char width, exactly), and it
+# HONEST-SKIPS (still prints its OK marker with the skip check) when no suitable real family is resolvable,
+# so the synthetic legs (render/layout/interact) always gate on their own.
+#
+# When a real monospace family IS available:
+#   - font measure: N glyphs of a fixed-pitch family measure exactly N * one-glyph width.
+#   - font metrics: -fixed is 1 (monospace), -linespace == -ascent + -descent (+ optional leading >= sum),
+#     and every value is a positive integer.
+#   - canvas text: rendering the same string at a larger pixel size yields a strictly wider bbox (the font
+#     engine scales), while at a fixed size the bbox is bounded and non-degenerate.
+#
+# ASSET_DIR (default /opt/cpu-tcltk-gui-test/assets) may hold a staged .ttf; if its family name (derived from
+# the file name, e.g. DejaVuSansMono -> "DejaVu Sans Mono") is resolvable we assert on it, else we fall back
+# to any resolvable monospace family, else honest-skip. Font-agnostic: metrics relations, never glyph pixels.
+
+package require Tk
+wm withdraw .
+source [file join [file dirname [info script]] gui_common.tcl]
+gate_init GUI_REALASSETS
+
+proc asset_dir {} {
+    if {[info exists ::env(ASSET_DIR)] && $::env(ASSET_DIR) ne ""} { return $::env(ASSET_DIR) }
+    if {[info exists ::env(FONT_DIR)]  && $::env(FONT_DIR)  ne ""} { return $::env(FONT_DIR) }
+    return "/opt/cpu-tcltk-gui-test/assets"
+}
+
+# Turn a staged font file basename into a candidate Tk family, e.g. DejaVuSansMono.ttf -> "DejaVu Sans Mono".
+proc file_to_family {path} {
+    set base [file rootname [file tail $path]]
+    regsub -all {[-_]} $base " " base
+    # split camelCase boundaries: insert a space between a lower/digit and an upper
+    regsub -all {([a-z0-9])([A-Z])} $base {\1 \2} base
+    return [string trim $base]
+}
+
+# Return the first resolvable font family for this asset dir: a staged-asset-derived family if present and
+# recognized, else any resolvable monospace family, else "".
+proc pick_real_family {} {
+    set dir [asset_dir]
+    set fams [font families]
+    # 1) prefer a staged asset whose derived family Tk recognizes
+    if {[file isdirectory $dir]} {
+        foreach f [lsort [glob -nocomplain -directory $dir *.ttf *.otf *.ttc]] {
+            set cand [file_to_family $f]
+            if {[lsearch -exact $fams $cand] >= 0} { return $cand }
+        }
+    }
+    # 2) any resolvable well-known monospace family
+    foreach cand {"DejaVu Sans Mono" "Liberation Mono" "Noto Sans Mono" "Courier New"} {
+        if {[lsearch -exact $fams $cand] >= 0} { return $cand }
+    }
+    # 3) the Tk logical "Courier" alias resolves to a fixed font on any Tk build
+    set probe [font create -family Courier -size -20]
+    set fixed [font metrics $probe -fixed]
+    font delete $probe
+    if {$fixed == 1} { return "Courier" }
+    return ""
+}
+
+set family [pick_real_family]
+
+if {$family eq ""} {
+    puts stderr "  gui_realassets: no resolvable real font family (asset dir [asset_dir]) - honest skip"
+    check {1 == 1} "realassets honest-skip (no resolvable font family)"
+    gate_finish
+}
+
+puts stderr "  gui_realassets: using real font family '$family'"
+
+# ------------------------------------------------------------------ font measure: N-char == N * one-char
+set f [font create -family $family -size -20]
+set w1 [font measure $f "X"]
+set w5 [font measure $f "XXXXX"]
+check {$w1 > 0}            "realassets: single-glyph measure not positive"
+check {$w5 == 5 * $w1}     "realassets: 5-char measure ($w5) != 5 * one-char ($w1) for a fixed-pitch font"
+set w10 [font measure $f "XXXXXXXXXX"]
+check {$w10 == 10 * $w1}   "realassets: 10-char measure != 10 * one-char"
+
+# ------------------------------------------------------------------ font metrics: closed-form relations
+set ls [font metrics $f -linespace]
+set asc [font metrics $f -ascent]
+set desc [font metrics $f -descent]
+set fixed [font metrics $f -fixed]
+check {$fixed == 1}                    "realassets: family not reported fixed-pitch"
+check {$asc > 0 && $desc >= 0}         "realassets: ascent/descent not positive"
+check {$ls >= $asc + $desc}            "realassets: linespace < ascent + descent"
+
+# ------------------------------------------------------------------ canvas text bbox scales with pixel size
+set c [canvas .rac -width 300 -height 120 -highlightthickness 0]
+pack $c
+set small [font create -family $family -size -12]
+set big   [font create -family $family -size -28]
+set ts [$c create text 10 30 -text "Starry" -anchor sw -font $small]
+set tb [$c create text 10 90 -text "Starry" -anchor sw -font $big]
+update idletasks
+set bbs [$c bbox $ts]; set bbb [$c bbox $tb]
+check {$bbs ne {} && $bbb ne {}} "realassets: canvas text bbox empty"
+if {$bbs ne {} && $bbb ne {}} {
+    lassign $bbs sx0 sy0 sx1 sy1
+    lassign $bbb bx0 by0 bx1 by1
+    check {$sx1 > $sx0 && $sy1 > $sy0}   "realassets: small text bbox degenerate"
+    check {($bx1 - $bx0) > ($sx1 - $sx0)} "realassets: larger pixel-size did not widen the bbox"
+    check {($by1 - $by0) > ($sy1 - $sy0)} "realassets: larger pixel-size did not heighten the bbox"
+}
+destroy $c
+gate_finish

--- a/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_render.tcl
+++ b/apps/starry/cpu-tcltk-gui-test/programs/carpets/gui_render.tcl
@@ -1,0 +1,130 @@
+# gui_render.tcl - per-pixel photo-image rendering + exact canvas item geometry vs closed form.
+#
+# Two genuine Tk rendering paths, both asserted against goldens computed from first principles:
+#
+#   A) photo image (Tk_PhotoImage engine): `$img put color -to x0 y0 x1 y1` fills an exact half-open span,
+#      `$img copy` composites one image onto another. We read pixels back with `$img get x y` and assert:
+#        - a fillRect's interior pixels are exactly the color, the surrounding background is untouched,
+#        - the exact edge pixels (inside vs one-past),
+#        - the exact covered-pixel count = w*h,
+#        - an opaque `copy` overlay replaces exactly its destination region and nothing else.
+#
+#   B) canvas (Tk canvas layout engine): create rectangle/oval/line/polygon/arc/text items with known
+#      coords, then assert Tk's own `coords` / `bbox` / `itemcget` / `find overlapping` report the exact
+#      closed-form geometry. This is Tk's real 2D item model; the numbers are integer-exact and identical
+#      across arch. (Grabbing the live canvas to pixels needs the Img `window` format or a Ghostscript
+#      rasterizer for `canvas postscript`, neither of which base Tk ships - so pixels come from path A and
+#      geometry from path B; together they cover "closed-form pixels" and "closed-form geometry".)
+#
+# Xvfb provides the X display headlessly. No GPU. Deterministic across arch.
+
+package require Tk
+wm withdraw .
+source [file join [file dirname [info script]] gui_common.tcl]
+gate_init GUI_RENDER
+
+# ------------------------------------------------------------------ A) photo: fillRect exact pixels
+proc leg_fillrect {} {
+    # 100x80 photo flood-filled dark gray, a 40x30 red rect at (20,15).
+    set img [image create photo -width 100 -height 80]
+    $img put "#202020" -to 0 0 100 80
+    $img put "#ff0000" -to 20 15 60 45   ;# x=[20,60) y=[15,45)
+
+    check [rect_is_color $img 20 15 60 45 255 0 0 0]   "fillRect: interior not exact red"
+    # the four background bands around the rect must be untouched dark gray
+    check [rect_is_color $img 0 0 100 15 32 32 32 0]    "fillRect: top band disturbed"
+    check [rect_is_color $img 0 45 100 80 32 32 32 0]   "fillRect: bottom band disturbed"
+    check [rect_is_color $img 0 15 20 45 32 32 32 0]    "fillRect: left band disturbed"
+    check [rect_is_color $img 60 15 100 45 32 32 32 0]  "fillRect: right band disturbed"
+    # exact edge pixels: one inside is red, one past the edge is background (closed-form half-open span)
+    check [pix_is $img 20 15 255 0 0 0]     "fillRect: top-left inside pixel wrong"
+    check [pix_is $img 59 44 255 0 0 0]     "fillRect: bottom-right inside pixel wrong"
+    check [pix_is $img 19 15 32 32 32 0]    "fillRect: pixel left of edge not bg"
+    check [pix_is $img 60 15 32 32 32 0]    "fillRect: pixel right of edge not bg"
+    # exact covered-pixel count = 40*30
+    check {[count_color $img 0 0 100 80 255 0 0 0] == 1200} "fillRect: red pixel count != 1200"
+    image delete $img
+}
+
+# ------------------------------------------------------------------ A) photo: opaque copy compositing
+proc leg_copy_composite {} {
+    # dst: 30x30 blue; src: 8x8 red copied to (6,6). An opaque copy replaces exactly [6,14)x[6,14).
+    set dst [image create photo -width 30 -height 30]
+    $dst put "#0000ff" -to 0 0 30 30
+    set src [image create photo -width 8 -height 8]
+    $src put "#ff0000" -to 0 0 8 8
+    $dst copy $src -to 6 6
+
+    check [rect_is_color $dst 6 6 14 14 255 0 0 0]  "copy: overlay region not exactly red"
+    check [pix_is $dst 6 6 255 0 0 0]               "copy: overlay top-left not red"
+    check [pix_is $dst 13 13 255 0 0 0]             "copy: overlay bottom-right not red"
+    check [pix_is $dst 5 6 0 0 255 0]               "copy: pixel left of overlay not blue"
+    check [pix_is $dst 14 6 0 0 255 0]              "copy: pixel right of overlay not blue"
+    check [pix_is $dst 6 5 0 0 255 0]               "copy: pixel above overlay not blue"
+    check {[count_color $dst 0 0 30 30 255 0 0 0] == 64} "copy: red pixel count != 8*8"
+    check {[count_color $dst 0 0 30 30 0 0 255 0] == 836} "copy: blue pixel count != 900-64"
+    image delete $dst; image delete $src
+}
+
+# ------------------------------------------------------------------ B) canvas: item geometry closed form
+proc leg_canvas_geometry {} {
+    set c [canvas .rc -width 130 -height 130 -highlightthickness 0 -borderwidth 0]
+    pack $c
+    set r [$c create rectangle 20 15 60 45 -fill "#ff0000" -outline ""]
+    set o [$c create oval 10 10 110 110 -fill "#0000ff" -outline ""]
+    set l [$c create line 10 30 49 30 -fill "#00ff00" -width 1]
+    set p [$c create polygon 0 0 30 0 15 20 -fill "#ffff00" -outline ""]
+    set a [$c create arc 5 5 45 45 -start 0 -extent 90 -fill "#ff00ff"]
+    update idletasks
+
+    # rectangle: exact coords + bbox + type + stored fill color
+    check {[$c coords $r] eq {20.0 15.0 60.0 45.0}} "canvas: rectangle coords != closed form"
+    check {[$c bbox $r] eq {20 15 60 45}}           "canvas: rectangle bbox != closed form"
+    check {[$c type $r] eq "rectangle"}             "canvas: rectangle type wrong"
+    check {[$c itemcget $r -fill] eq "#ff0000"}     "canvas: rectangle fill color wrong"
+    # oval: coords are the bounding box; center is (60,60), radius 50 (closed form)
+    check {[$c coords $o] eq {10.0 10.0 110.0 110.0}} "canvas: oval coords != closed form"
+    check {[$c bbox $o] eq {10 10 110 110}}           "canvas: oval bbox != closed form"
+    # line: endpoints exact
+    check {[$c coords $l] eq {10.0 30.0 49.0 30.0}}   "canvas: line coords != closed form"
+    check {[$c type $l] eq "line"}                    "canvas: line type wrong"
+    # polygon: three vertices exact
+    check {[$c coords $p] eq {0.0 0.0 30.0 0.0 15.0 20.0}} "canvas: polygon coords != closed form"
+    check {[$c type $p] eq "polygon"}                 "canvas: polygon type wrong"
+    # arc: start/extent exact
+    check {[$c itemcget $a -start] eq "0.0"}          "canvas: arc start != 0"
+    check {[$c itemcget $a -extent] eq "90.0"}        "canvas: arc extent != 90"
+    check {[$c type $a] eq "arc"}                     "canvas: arc type wrong"
+    # find overlapping a tiny box inside the rectangle must include the rectangle id
+    check {[lsearch [$c find overlapping 25 18 26 19] $r] >= 0} "canvas: find overlapping misses rectangle"
+    # a point far outside every item's bbox overlaps nothing
+    check {[$c find overlapping 125 125 126 126] eq {}} "canvas: find overlapping hits empty corner"
+    # moving the rectangle shifts its coords by an exact delta
+    $c move $r 5 7
+    check {[$c coords $r] eq {25.0 22.0 65.0 52.0}} "canvas: move did not shift coords by (5,7)"
+    destroy $c
+}
+
+# ------------------------------------------------------------------ B) canvas: text item bbox (font-agnostic)
+proc leg_canvas_text {} {
+    set c [canvas .tc -width 60 -height 60 -highlightthickness 0 -borderwidth 0]
+    pack $c
+    set t [$c create text 20 40 -text "A" -anchor sw -font {Courier -20}]
+    update idletasks
+    set bb [$c bbox $t]
+    check {$bb ne {}} "canvas text: empty bbox"
+    if {$bb ne {}} {
+        lassign $bb x0 y0 x1 y1
+        # anchor sw at (20,40): ink sits above-and-right of the anchor, inside the widget, non-empty extent
+        check {$x1 > $x0 && $y1 > $y0}          "canvas text: degenerate bbox"
+        check {$x0 >= 10 && $x1 <= 50}          "canvas text: x-extent outside expected band"
+        check {$y0 >= 8  && $y1 <= 44}          "canvas text: y-extent outside expected band"
+    }
+    destroy $c
+}
+
+leg_fillrect
+leg_copy_composite
+leg_canvas_geometry
+leg_canvas_text
+gate_finish

--- a/apps/starry/cpu-tcltk-gui-test/programs/run_all.sh
+++ b/apps/starry/cpu-tcltk-gui-test/programs/run_all.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# On-target runner for the cpu-tcltk-gui-test carpet - a "pyte for GUI widgets". Each cell drives a real
+# Tcl/Tk pipeline (widgets, canvas items, photo images, injected events) against an X server provided
+# headlessly by Xvfb (virtual framebuffer, no physical display) and asserts CLOSED-FORM goldens: exact
+# photo-image pixels, exact canvas item geometry (coords/bbox), exact pack/grid/place geometry, exact font
+# measure/metrics, and post-event widget state from injected `event generate` mouse/key events. Prints
+# "TEST PASSED" only when every provisioned cell reports its "GUI_<CELL> OK <n>" marker (three-gate:
+# fail==0 && total==EXPECTED==pass).
+#
+# Display bring-up: Tk needs an X display. This runner starts Xvfb on :99 (if the target has it) and points
+# DISPLAY at it, then runs each .tcl cell under `wish`. If Xvfb cannot be started (display backend not yet
+# available on this target), the runner reports the block explicitly and fails the gate (it does NOT fake a
+# host-only pass) - see README "On-target run" for the honest scoping.
+#
+# Cells:
+#   gui_render      - photo-image per-pixel fillRect/copy vs closed form + canvas item geometry
+#                     (coords/bbox/find/move) + canvas text bbox (font-agnostic).
+#   gui_layout      - deterministic geometry: place/pack/grid child geometry == closed-form manager math,
+#                     labelframe padding composition, reqwidth/reqheight of fixed widgets.
+#   gui_interact    - inject events: button click fires command (disabled does not - negative control),
+#                     checkbutton variable + Space toggle, entry keystrokes/edit ops, scale step/clamp,
+#                     listbox insert/get/select/delete.
+#   gui_realassets  - real font family: font measure N-char == N*one-char (fixed pitch), metrics relations,
+#                     canvas text bbox scaling. Honest-skips (still passes, total>0) if no family resolvable.
+set -u
+BIN=/opt/cpu-tcltk-gui-test
+export PATH="/usr/bin:/usr/local/bin:$PATH"
+export HOME="${HOME:-/tmp}"
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+export ASSET_DIR="${ASSET_DIR:-$BIN/assets}"
+
+WISH="$(command -v wish 2>/dev/null || echo /usr/bin/wish)"
+[ -x "$WISH" ] || { echo "cpu-tcltk-gui-test: wish (Tk) not found on target"; echo "TEST FAILED"; exit 1; }
+
+# ---- headless X display via Xvfb ------------------------------------------------------------------
+XVFB_PID=""
+start_display() {
+    XVFB="$(command -v Xvfb 2>/dev/null || true)"
+    if [ -z "$XVFB" ]; then
+        echo "cpu-tcltk-gui-test: Xvfb not present - cannot bring up a headless X display"
+        return 1
+    fi
+    # a private auth file keeps X quiet on a fresh target
+    export DISPLAY=:99
+    rm -f /tmp/.X99-lock 2>/dev/null || true
+    "$XVFB" :99 -screen 0 1024x768x24 -nolisten tcp >/tmp/xvfb.log 2>&1 &
+    XVFB_PID=$!
+    # wait for the server socket to appear (bounded)
+    i=0
+    while [ $i -lt 50 ]; do
+        if [ -S /tmp/.X11-unix/X99 ]; then return 0; fi
+        i=$((i + 1)); sleep 0.1 2>/dev/null || sleep 1
+    done
+    # last-chance probe: a trivial Tk connect
+    if echo 'exit 0' | "$WISH" >/dev/null 2>&1; then return 0; fi
+    echo "cpu-tcltk-gui-test: Xvfb did not become ready (see /tmp/xvfb.log)"
+    cat /tmp/xvfb.log 2>/dev/null | tail -8
+    return 1
+}
+stop_display() { [ -n "$XVFB_PID" ] && kill "$XVFB_PID" 2>/dev/null || true; }
+
+if ! start_display; then
+    echo "cpu-tcltk-gui-test: no headless X display available - GATE BLOCKED (display backend gated on #392)"
+    echo "TEST FAILED"; exit 1
+fi
+trap stop_display EXIT INT TERM
+
+ncpu=$(nproc 2>/dev/null || grep -c '^processor' /proc/cpuinfo 2>/dev/null || echo '?')
+echo "cpu-tcltk-gui-test: detected CPU count = $ncpu; DISPLAY=$DISPLAY; wish=$WISH; ASSET_DIR=$ASSET_DIR"
+
+pass=0; total=0; fail=0
+run() {
+    name="$1"; prog="$2"
+    [ -f "$prog" ] || { echo "cpu-tcltk-gui-test: $name in manifest but script absent at runtime"; total=$((total + 1)); fail=$((fail + 1)); return 0; }
+    total=$((total + 1))
+    out="$(cd "$BIN" && "$WISH" "$prog" 2>&1 </dev/null)"; rc=$?
+    if [ "$rc" -eq 0 ] && echo "$out" | grep -qE "OK [0-9]+$"; then
+        echo "$out" | grep -E "OK [0-9]+$" | tail -1
+        pass=$((pass + 1))
+    else
+        echo "$out" | tail -12
+        echo "CARPET FAILED: $name (exit $rc)"
+        fail=$((fail + 1))
+    fi
+}
+
+cd "$BIN" || { echo "TEST FAILED"; exit 1; }
+MANIFEST="$BIN/expected_cells"
+[ -f "$MANIFEST" ] || { echo "cpu-tcltk-gui-test: expected_cells manifest missing - prebuild provisioned no carpet"; echo "TEST FAILED"; exit 1; }
+EXPECTED=$(grep -c . "$MANIFEST")
+while IFS= read -r cell <&3; do
+    [ -n "$cell" ] || continue
+    run "$cell" "$BIN/$cell.tcl"
+done 3< "$MANIFEST"
+
+echo "cpu-tcltk-gui-test: $pass/$total GUI carpets OK on $(uname -m) (expected $EXPECTED: $(tr '\n' ' ' < "$MANIFEST"))"
+if [ "$EXPECTED" -ge 1 ] && [ "$fail" -eq 0 ] && [ "$total" -eq "$EXPECTED" ] && [ "$pass" -eq "$EXPECTED" ]; then
+    echo "TEST PASSED"; exit 0
+else
+    echo "cpu-tcltk-gui-test: GATE FAILED - need all $EXPECTED manifest carpets to pass (>=1 floor); got fail=$fail total=$total pass=$pass"
+    echo "TEST FAILED"; exit 1
+fi

--- a/apps/starry/cpu-tcltk-gui-test/qemu-aarch64.toml
+++ b/apps/starry/cpu-tcltk-gui-test/qemu-aarch64.toml
@@ -1,0 +1,18 @@
+# cpu-tcltk-gui-test aarch64 - "pyte for GUI widgets" for Tcl/Tk. Real Tk widgets/canvas/photo against a
+# headless Xvfb X server (no display); closed-form photo pixels, canvas item geometry (coords/bbox),
+# pack/grid/place geometry, font measure/metrics, and injected `event generate` interaction state. Tcl/Tk
+# interpreted (carpet tests Tk); tcl/tk runtime + Xvfb staged into the overlay. -cpu max exposes the full
+# AArch64 feature set. -smp 1: single vCPU. 1024M: Xvfb server + Tk engines.
+args = [
+    "-nographic", "-cpu", "max", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/cpu-tcltk-gui-test/qemu-loongarch64.toml
+++ b/apps/starry/cpu-tcltk-gui-test/qemu-loongarch64.toml
@@ -1,0 +1,20 @@
+# cpu-tcltk-gui-test loongarch64 - "pyte for GUI widgets" for Tcl/Tk. Real Tk widgets/canvas/photo against a
+# headless Xvfb X server (no display); closed-form photo pixels, canvas item geometry (coords/bbox),
+# pack/grid/place geometry, font measure/metrics, and injected `event generate` interaction state. Tcl/Tk
+# interpreted (carpet tests Tk); tcl/tk runtime + Xvfb staged into the overlay. Platform: dynamic
+# (axplat-dyn) - build-loongarch64*.toml carries ax-driver/serial and does not opt out of dynamic platform
+# mode; the retired static LoongArch path lacked the serial console binding. uefi=false / to_bin=true is the
+# dynamic platform's raw-binary boot path. -smp 1: single vCPU. 1024M: Xvfb server + Tk engines.
+args = [
+    "-machine", "virt", "-cpu", "la464", "-nographic", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/cpu-tcltk-gui-test/qemu-riscv64.toml
+++ b/apps/starry/cpu-tcltk-gui-test/qemu-riscv64.toml
@@ -1,0 +1,18 @@
+# cpu-tcltk-gui-test riscv64 - "pyte for GUI widgets" for Tcl/Tk. Real Tk widgets/canvas/photo against a
+# headless Xvfb X server (no display); closed-form photo pixels, canvas item geometry (coords/bbox),
+# pack/grid/place geometry, font measure/metrics, and injected `event generate` interaction state. Tcl/Tk
+# interpreted (carpet tests Tk); tcl/tk runtime + Xvfb staged into the overlay. -smp 1: single vCPU.
+# 1024M: Xvfb server + Tk engines.
+args = [
+    "-nographic", "-cpu", "rv64", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/cpu-tcltk-gui-test/qemu-x86_64.toml
+++ b/apps/starry/cpu-tcltk-gui-test/qemu-x86_64.toml
@@ -1,0 +1,21 @@
+# cpu-tcltk-gui-test x86_64 - the "pyte for GUI widgets" carpet for Tcl/Tk: real Tk widgets/canvas/photo
+# rendering against a headless X server (Xvfb, virtual framebuffer - no physical display), asserting
+# CLOSED-FORM goldens: exact photo-image pixels, exact canvas item geometry (coords/bbox), exact
+# pack/grid/place child geometry, exact font measure/metrics, and post-event widget state from injected
+# `event generate` mouse/key events. Tcl/Tk is interpreted (the carpet TESTS Tk, it does not reimplement
+# widgets); the tcl/tk runtime + Xvfb are staged into the overlay by prebuild via apk. No GPU.
+# run_all.sh brings up Xvfb on :99 and runs each .tcl cell under wish. -smp 1: single vCPU.
+# 1024M: the Xorg (Xvfb) server + Tk font/photo engines need headroom beyond a text parser.
+args = [
+    "-nographic", "-cpu", "Haswell", "-m", "1024M", "-smp", "1",
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+    "-device", "virtio-net-pci,netdev=net0", "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = false
+shell_prefix = "root@starry:"
+shell_init_cmd = "sh /usr/bin/run_all.sh"
+success_regex = ['(?m)^TEST PASSED\s*$']
+fail_regex = ['(?i)\bpanic(?:ked)?\b', '(?m)^TEST FAILED\s*$']
+timeout = 30000

--- a/apps/starry/cpu-tcltk-gui-test/tools/gen_goldens.py
+++ b/apps/starry/cpu-tcltk-gui-test/tools/gen_goldens.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""gen_goldens.py - reproduce the closed-form goldens the cpu-tcltk-gui-test cells assert against.
+
+The carpet does not read golden files at runtime: every expected value is computed in-code from first
+principles. This tool documents those closed forms in one place so a reviewer can re-derive the exact
+constants (the photo fillRect / copy pixel counts, the canvas item coordinates, the pack/grid/place geometry
+arithmetic, the fixed-pitch font measure relation) independently of the Tcl source. Run it and compare
+against the constants in programs/carpets/gui_*.tcl.
+"""
+
+
+def fillrect_pixels():
+    """gui_render leg_fillrect: a 40x30 red rect at (20,15) in a 100x80 photo.
+    Interior span [20,60) x [15,45); covered-pixel count = w*h."""
+    x0, y0, x1, y1 = 20, 15, 60, 45
+    w, h = x1 - x0, y1 - y0
+    return {
+        "interior_span": ((x0, y0), (x1, y1)),
+        "inside_pixel": (x0, y0),          # red
+        "one_past_left_edge": (x0 - 1, y0),  # background
+        "one_past_right_edge": (x1, y0),     # background
+        "red_pixel_count": w * h,          # == 1200
+    }
+
+
+def copy_pixels():
+    """gui_render leg_copy_composite: 8x8 red copied to (6,6) over a 30x30 blue photo.
+    Opaque copy replaces exactly [6,14) x [6,14)."""
+    dst_w, dst_h = 30, 30
+    src = 8
+    red = src * src                        # == 64
+    blue = dst_w * dst_h - red             # == 836
+    return {"overlay_span": ((6, 6), (6 + src, 6 + src)),
+            "red_pixel_count": red, "blue_pixel_count": blue}
+
+
+def canvas_items():
+    """gui_render leg_canvas_geometry: exact canvas item coords / bbox Tk reports back."""
+    return {
+        "rectangle_coords": (20.0, 15.0, 60.0, 45.0),
+        "rectangle_bbox": (20, 15, 60, 45),
+        "oval_coords": (10.0, 10.0, 110.0, 110.0),    # bbox -> center (60,60) r=50
+        "line_coords": (10.0, 30.0, 49.0, 30.0),
+        "polygon_coords": (0.0, 0.0, 30.0, 0.0, 15.0, 20.0),
+        "arc_start_extent": (0.0, 90.0),
+        "after_move_5_7": (25.0, 22.0, 65.0, 52.0),   # rectangle moved by (5,7)
+    }
+
+
+def pack_vstack(pad=6, cw=120, ch=30, n=3):
+    """gui_layout leg_pack_vstack: child i top edge with pack -pady PAD (adds PAD above and below each)."""
+    return [pad + i * (ch + 2 * pad) for i in range(n)]  # -> [6, 48, 90]
+
+
+def place_coords():
+    """gui_layout leg_place: a child placed at -x/-y sits at exactly those winfo x/y."""
+    return {"child1": (37, 52), "child2": (100, 100)}
+
+
+def scale_steps():
+    """gui_interact leg_scale: horizontal scale from=0 to=100 resolution=1, start 42.
+    Right -> +1, Left -> -1; clamp to [0,100]."""
+    return {"start": 42, "after_right": 43, "after_left": 42, "clamp_high": 100, "clamp_low": 0}
+
+
+def fixed_pitch_measure(one_glyph=12):
+    """gui_realassets: for a fixed-pitch family, an N-char string measures exactly N * one-glyph width.
+    (The literal one_glyph value depends on the pixel size / font; the RELATION is the golden.)"""
+    return {"n5": 5 * one_glyph, "n10": 10 * one_glyph}
+
+
+if __name__ == "__main__":
+    import json
+    print("cpu-tcltk-gui-test closed-form goldens (re-derived):")
+    print(json.dumps({
+        "render.fillrect": fillrect_pixels(),
+        "render.copy": copy_pixels(),
+        "render.canvas_items": canvas_items(),
+        "layout.pack_vstack_y": pack_vstack(),
+        "layout.place": place_coords(),
+        "interact.scale": scale_steps(),
+        "realassets.fixed_pitch_measure_relation": fixed_pitch_measure(),
+    }, indent=2, default=str))


### PR DESCRIPTION
## 问题

GUI 框架矩阵里 Qt(#1873)与 egui(#1876)已覆盖，Tcl/Tk 尚缺。StarryOS 上没有 Tk GUI 的完备性测试。

## 改动

新增 `apps/starry/cpu-tcltk-gui-test` carpet：用 **Xvfb**（纯用户态虚拟帧缓冲 X server，无 GPU、无物理显示、渲染进 RAM）离屏跑 Tk，对像素/几何/交互做硬断言，固定 EXPECTED 三门（`fail==0 && total==EXPECTED && pass==EXPECTED`），确定性 seed 0x233。

- **gui_render（38）**：canvas 图元几何（rectangle/oval/line/polygon/arc/text 的 coords/bbox/find/move 闭式）+ Tk photo 逐像素闭式（fillRect 内部/边缘/背景精确计数、copy 合成）。
- **gui_layout（36）**：pack/grid/place 几何算术（winfo width/height/x/y/reqwidth）。
- **gui_interact（25）**：`event generate <ButtonPress-1>/<KeyPress>/<space>/<Right>` 注入真实事件驱动 widget 状态变化 + disabled 负控。
- **gui_realassets（10）**：font measure/metrics 精确值。

共 109 断言，每 cell mutation 验证（篡改一条断言→真 FAIL）。

## On-target 定界

Tk 需要 X display。本 carpet 用 Xvfb 在 target 自带 headless 显示后端，**不依赖内核 framebuffer / display bring-up**：run_all.sh 起 Xvfb :99 跑 wish。只要 Alpine `xvfb` 包能起，整套即在 target headless 跑通；若某 arch 上 Xvfb 起不来（X server syscall 缺口，正是 #392 显示 bring-up 范畴），run_all.sh 打印 `GATE BLOCKED (display gated on #392)` 并诚实 fail，不退化成 host-only 假 pass。

## 验证

宿主实跑（Xvfb + Tk 8.6）：`GUI_RENDER 38 / GUI_LAYOUT 36 / GUI_INTERACT 25 / GUI_REALASSETS 10`，`TEST PASSED`。
