### PR TITLE
fix(starry-kernel): support fstatfs on directories

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/stat.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/stat.rs
@@ -13,7 +13,7 @@ use linux_raw_sys::general::{
 use starry_vm::{VmMutPtr, VmPtr};
 
 use crate::{
-    file::{File, FileLike, resolve_at},
+    file::{Directory, File, get_file_like, memfd::Memfd, resolve_at},
     mm::{UserPtr, vm_load_path_string},
     task::AsThread,
 };
@@ -244,7 +244,17 @@ pub fn sys_statfs(path: *const c_char, buf: *mut statfs) -> AxResult<isize> {
 pub fn sys_fstatfs(fd: i32, buf: *mut statfs) -> AxResult<isize> {
     debug!("sys_fstatfs <= fd: {fd}");
 
-    buf.vm_write(statfs(File::from_fd(fd)?.inner().location())?)?;
+    let file_like = get_file_like(fd)?;
+    let location = if let Some(directory) = file_like.downcast_ref::<Directory>() {
+        directory.inner()
+    } else if let Some(file) = file_like.downcast_ref::<File>() {
+        file.inner().location()
+    } else if let Some(memfd) = file_like.downcast_ref::<Memfd>() {
+        memfd.inner().inner().location()
+    } else {
+        return Err(AxError::InvalidInput);
+    };
+    buf.vm_write(statfs(location)?)?;
     Ok(0)
 }
 

--- a/test-suit/starryos/qemu/system/bugfix-fstatvfs-directory/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-fstatvfs-directory/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-fstatvfs-directory C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-fstatvfs-directory src/main.c)
+target_compile_options(bugfix-fstatvfs-directory PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bugfix-fstatvfs-directory RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-fstatvfs-directory/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-fstatvfs-directory/src/main.c
@@ -1,0 +1,72 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/statvfs.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void expect_true(int condition, const char *name)
+{
+    if (condition) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+    printf("FAIL: %s: errno=%d (%s)\n", name, errno, strerror(errno));
+    failed++;
+}
+
+int main(void)
+{
+    const char *directory_path = "/tmp/bugfix-fstatvfs-directory";
+    const char *file_path = "/tmp/bugfix-fstatvfs-directory/file";
+    struct statvfs filesystem;
+
+    printf("=== bugfix-fstatvfs-directory ===\n");
+    mkdir(directory_path, 0700);
+
+    int directory_fd = open(directory_path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    expect_true(directory_fd >= 0, "open directory fd");
+    if (directory_fd >= 0) {
+        errno = 0;
+        int result = fstatvfs(directory_fd, &filesystem);
+        expect_true(result == 0, "fstatvfs accepts directory fd");
+        if (result == 0) {
+            expect_true(filesystem.f_bsize > 0,
+                        "directory fstatvfs reports block size");
+        }
+        close(directory_fd);
+    }
+
+    int file_fd = open(file_path, O_CREAT | O_RDWR | O_TRUNC | O_CLOEXEC, 0600);
+    expect_true(file_fd >= 0, "open regular file fd");
+    if (file_fd >= 0) {
+        errno = 0;
+        expect_true(fstatvfs(file_fd, &filesystem) == 0,
+                    "fstatvfs accepts regular file fd");
+        close(file_fd);
+    }
+
+    errno = 0;
+    expect_true(fstatvfs(-1, &filesystem) == -1 && errno == EBADF,
+                "fstatvfs rejects invalid fd with EBADF");
+
+    unlink(file_path);
+    rmdir(directory_path);
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        puts("STARRY_FSTATVFS_DIRECTORY_PASSED");
+        puts("STARRY_GROUPED_TEST_PASSED: bugfix-fstatvfs-directory");
+        return EXIT_SUCCESS;
+    }
+    puts("STARRY_GROUPED_TEST_FAILED: bugfix-fstatvfs-directory");
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## 来源

本修复从 `004-add-starry-nixos` 分支中的 StarryNixOS 兼容性排查结果独立拆出，不包含该分支的 NixOS 功能、进度文档或其他兼容性修改。

## 问题

`sys_fstatfs()` 目前无条件调用 `File::from_fd()`。该转换面向常规文件 I/O，会把目录描述符映射为 `EISDIR`，导致 `fstatfs(2)`/`fstatvfs(3)` 无法查询目录所在文件系统。Linux 的 `fstatfs(2)` 语义是查询 fd 所引用文件所在的已挂载文件系统，目录 fd 也应成功。

参考：
- Linux man-pages `statfs(2)`：https://man7.org/linux/man-pages/man2/statfs.2.html
- Linux VFS 实现 `user_statfs()` / `fd_statfs()`：https://github.com/torvalds/linux/blob/master/fs/statfs.c

## 修改

- 在 `sys_fstatfs()` 中只读取一次 fd 表，并基于同一个 `Arc<dyn FileLike>` 分派。
- 目录 fd 直接使用 `Directory` 保存的 `Location`。
- 常规文件和 memfd 保持既有位置解析语义。
- socket、pipe 等没有文件系统位置的对象继续返回既有的不支持错误，不扩大未验证语义。
- 增加 `bugfix-fstatvfs-directory` QEMU 回归，覆盖目录 fd、常规文件 fd 和无效 fd。

## 语义映射

| Linux 行为 | StarryOS 修改后行为 |
| --- | --- |
| `fstatfs()` 接受目录 fd | 从 `Directory::inner()` 取得挂载位置并返回文件系统信息 |
| `fstatfs()` 接受常规文件 fd | 从已取得的 `File` 返回文件系统信息 |
| `fstatfs()` 接受 memfd 的既有路径 | 从 `Memfd` 的 backing file 返回文件系统信息 |
| 无效 fd 返回 `EBADF` | `get_file_like()` 保持返回 `EBADF` |

一次 fd-table 查询后完成类型分派，也避免查询后再次调用 `File::from_fd(fd)` 产生的关闭/复用竞态。

## 验证

红测（`upstream/dev`）：
```text
FAIL: fstatvfs accepts directory fd: errno=21 (Is a directory)
=== Results: 4 passed, 1 failed ===
```

绿测：
```text
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-fstatvfs-directory
=== Results: 6 passed, 0 failed ===
STARRY_FSTATVFS_DIRECTORY_PASSED
STARRY_GROUPED_TESTS_PASSED
```

静态检查：
```text
cargo fmt --all -- --check
git diff --check
cargo xtask clippy --package starry-kernel
clippy summary: 1 package(s), 25 check(s), 1 package(s) passed, 0 package(s) failed
```