### PR TITLE
fix(starry-fs): complete mount contexts and notifications

### DIFF
--- a/fs/ax-fs-ng/src/file/cache/mod.rs
+++ b/fs/ax-fs-ng/src/file/cache/mod.rs
@@ -157,10 +157,14 @@ impl FileUserData {
     }
 }
 
+fn filesystem_uses_unbounded_page_cache(name: &str) -> bool {
+    matches!(name, "tmpfs" | "ramfs")
+}
+
 impl CachedFile {
     /// Returns an existing cached file for `location`, or creates a new one.
     pub fn get_or_create(location: Location) -> VfsResult<Self> {
-        let in_memory = location.filesystem().name() == "tmpfs";
+        let in_memory = filesystem_uses_unbounded_page_cache(location.filesystem().name());
 
         let existing = {
             let guard = location.user_data();
@@ -211,8 +215,8 @@ impl CachedFile {
             }
         };
 
-        // In-memory files (tmpfs) have no backing store, so evicting clean
-        // pages would lose data. Only register disk-backed files for reclaim.
+        // tmpfs and ramfs have no backing store, so evicting clean pages would
+        // lose data. Only register disk-backed files for reclaim.
         #[cfg(feature = "vfs")]
         if is_new && !in_memory {
             reclaim::register_cached_file(&shared);

--- a/fs/ax-fs-ng/src/file/cache/tests.rs
+++ b/fs/ax-fs-ng/src/file/cache/tests.rs
@@ -188,6 +188,13 @@ fn reopen_cached_file(backing: Arc<CacheTestFile>) -> CachedFile {
 }
 
 #[test]
+fn tmpfs_and_ramfs_use_unbounded_page_cache() {
+    assert!(filesystem_uses_unbounded_page_cache("tmpfs"));
+    assert!(filesystem_uses_unbounded_page_cache("ramfs"));
+    assert!(!filesystem_uses_unbounded_page_cache("ext4"));
+}
+
+#[test]
 fn page_cache_paddr_reports_bad_state_when_translation_is_missing() {
     with_test_page_provider(false, |_| {
         let page = PageCache::new().unwrap();

--- a/fs/ax-fs-ng/src/file/open.rs
+++ b/fs/ax-fs-ng/src/file/open.rs
@@ -356,8 +356,11 @@ impl OpenOptions {
                 loc
             }
             Err(VfsError::InvalidInput) => {
-                // root directory
-                context.root_dir().clone()
+                // `resolve_parent()` has no parent to return for either `/` or
+                // a relative `.` whose current directory is a detached mount
+                // root. Resolve the path itself so openat(dirfd, ".") keeps
+                // the supplied directory instead of falling back to `/`.
+                context.resolve(path.as_ref())?
             }
             Err(err) => return Err(err),
         };

--- a/fs/axfs-ng-vfs/src/mount/mod.rs
+++ b/fs/axfs-ng-vfs/src/mount/mod.rs
@@ -604,6 +604,44 @@ impl Mountpoint {
         MOUNT_TOPOLOGY_VERSION.fetch_add(1, Ordering::AcqRel);
         Ok(())
     }
+
+    /// Attaches a detached mount tree at `new_location`.
+    ///
+    /// Unlike [`Self::move_to`], the source has no old parent entry to remove.
+    /// Callers must only expose this operation for mount handles created as
+    /// detached trees; the namespace root also has no parent but is not a
+    /// movable mount handle.
+    pub fn attach_detached(self: &Arc<Self>, new_location: &Location) -> VfsResult<()> {
+        let _topology = MOUNT_TOPOLOGY_MUTATION.lock();
+        if self.location.lock().is_some() {
+            return Err(VfsError::InvalidInput);
+        }
+        if new_location.is_mountpoint() {
+            return Err(VfsError::ResourceBusy);
+        }
+        new_location.check_is_dir()?;
+
+        let root_location = self.root_location();
+        let mut current = Some(new_location.clone());
+        while let Some(location) = current {
+            if location.ptr_eq(&root_location) {
+                return Err(VfsError::FilesystemLoop);
+            }
+            current = location.parent();
+        }
+
+        *self.location.lock() = Some(new_location.clone());
+        new_location
+            .mountpoint
+            .children
+            .lock()
+            .insert(new_location.entry.key(), self.clone());
+        if new_location.mountpoint.is_shared() {
+            Self::propagate_new_child(new_location.mountpoint(), new_location, self)?;
+        }
+        MOUNT_TOPOLOGY_VERSION.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -301,6 +301,9 @@ pub struct Directory {
     /// O_PATH on directory descriptors — open(dir, O_PATH|O_DIRECTORY)
     /// must reject fchmod just like O_PATH on a regular file).
     open_flags: u32,
+    /// Whether this is the original handle returned by fsmount(2).
+    /// Reopening it as a normal directory deliberately drops this authority.
+    detached_mount_handle: bool,
 }
 
 impl Directory {
@@ -309,12 +312,26 @@ impl Directory {
             inner,
             offset: Mutex::new(0),
             open_flags,
+            detached_mount_handle: false,
+        }
+    }
+
+    pub(crate) fn new_detached_mount(inner: Location, open_flags: u32) -> Self {
+        Self {
+            inner,
+            offset: Mutex::new(0),
+            open_flags,
+            detached_mount_handle: true,
         }
     }
 
     /// Get the inner node of the directory.
     pub fn inner(&self) -> &Location {
         &self.inner
+    }
+
+    pub(crate) fn is_detached_mount_handle(&self) -> bool {
+        self.detached_mount_handle
     }
 }
 

--- a/os/StarryOS/kernel/src/file/fs.rs
+++ b/os/StarryOS/kernel/src/file/fs.rs
@@ -274,6 +274,9 @@ impl FileLike for File {
         if let Ok(memfd) = any.clone().downcast_arc::<crate::file::memfd::Memfd>() {
             return Ok(memfd.inner().clone());
         }
+        if let Ok(mount_table) = any.clone().downcast_arc::<crate::file::MountTableFile>() {
+            return Ok(mount_table.inner().clone());
+        }
         Err(if any.is::<Directory>() {
             AxError::IsADirectory
         } else {

--- a/os/StarryOS/kernel/src/file/mod.rs
+++ b/os/StarryOS/kernel/src/file/mod.rs
@@ -14,6 +14,7 @@ pub mod io_uring;
 #[cfg(feature = "sg2002")]
 pub mod ion;
 pub mod memfd;
+mod mount_table;
 mod net;
 pub mod netlink;
 mod nsfd;
@@ -66,6 +67,7 @@ pub(crate) use self::epoll_topology::epoll_topology_vec_and_reserve_hold_for_tes
 pub(crate) use self::epoll_topology::push_topology_item_preserves_order_and_grows_capacity;
 #[cfg(axtest)]
 pub(crate) use self::fs::metadata_to_kstat_conversion_rules_hold_for_test;
+pub(crate) use self::mount_table::{MountTableFile, notify_mount_namespace_changed};
 #[cfg(axtest)]
 pub(crate) use self::pipe::{
     peer_close_with_multiple_readers_is_visible_for_test,

--- a/os/StarryOS/kernel/src/file/mount_table.rs
+++ b/os/StarryOS/kernel/src/file/mount_table.rs
@@ -1,0 +1,179 @@
+use alloc::{
+    borrow::Cow,
+    collections::btree_map::BTreeMap,
+    sync::{Arc, Weak},
+};
+use core::{
+    sync::atomic::{AtomicU64, Ordering},
+    task::Context,
+};
+
+use ax_errno::AxResult;
+use ax_fs_ng::vfs::{FileBackend, FileFlags, MountNamespace};
+use ax_kspin::SpinNoIrq;
+use axpoll::{IoEvents, PollSet, Pollable};
+use spin::Once;
+
+use super::{File, FileLike, IoDst, IoSrc, Kstat};
+
+const MOUNT_CHANGE_EVENTS: IoEvents = IoEvents::PRI.union(IoEvents::ERR);
+
+static MOUNT_NAMESPACE_EVENTS: Once<SpinNoIrq<BTreeMap<u64, Weak<MountNamespaceEvent>>>> =
+    Once::new();
+
+fn event_registry() -> &'static SpinNoIrq<BTreeMap<u64, Weak<MountNamespaceEvent>>> {
+    MOUNT_NAMESPACE_EVENTS.call_once(|| SpinNoIrq::new(BTreeMap::new()))
+}
+
+fn event_for_open(namespace: &MountNamespace) -> Arc<MountNamespaceEvent> {
+    let mut registry = event_registry().lock();
+    registry.retain(|_, event| event.strong_count() != 0);
+    if let Some(event) = registry.get(&namespace.id()).and_then(Weak::upgrade) {
+        return event;
+    }
+
+    let event = Arc::new(MountNamespaceEvent::new());
+    registry.insert(namespace.id(), Arc::downgrade(&event));
+    event
+}
+
+/// Reports a mount table change to files opened in `namespace`.
+pub(crate) fn notify_mount_namespace_changed(namespace: &MountNamespace) {
+    let event = event_registry()
+        .lock()
+        .get(&namespace.id())
+        .and_then(Weak::upgrade);
+    if let Some(event) = event {
+        event.notify();
+    }
+}
+
+struct MountNamespaceEvent {
+    generation: AtomicU64,
+    waiters: PollSet,
+}
+
+impl MountNamespaceEvent {
+    const fn new() -> Self {
+        Self {
+            generation: AtomicU64::new(0),
+            waiters: PollSet::new(),
+        }
+    }
+
+    fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    fn notify(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+        // SAFETY: mount syscalls run in task context after releasing filesystem
+        // and namespace locks. The generation is published before waking.
+        unsafe {
+            self.waiters.wake(MOUNT_CHANGE_EVENTS);
+        }
+    }
+
+    fn register(&self, context: &mut Context<'_>, events: IoEvents) {
+        let interests = events & MOUNT_CHANGE_EVENTS;
+        if interests.is_empty() {
+            return;
+        }
+        // SAFETY: poll registration runs in task context without mount or
+        // registry locks held.
+        unsafe {
+            self.waiters.register(context.waker(), interests);
+        }
+    }
+}
+
+/// One open file description for `/proc/.../{mountinfo,mounts}`.
+pub(crate) struct MountTableFile {
+    file: Arc<File>,
+    event: Arc<MountNamespaceEvent>,
+    observed_generation: AtomicU64,
+}
+
+impl MountTableFile {
+    pub(crate) fn new(file: Arc<File>, namespace: &MountNamespace) -> Arc<Self> {
+        let event = event_for_open(namespace);
+        let observed_generation = AtomicU64::new(event.generation());
+        Arc::new(Self {
+            file,
+            event,
+            observed_generation,
+        })
+    }
+
+    pub(crate) fn inner(&self) -> &Arc<File> {
+        &self.file
+    }
+}
+
+impl FileLike for MountTableFile {
+    fn read(&self, dst: &mut IoDst) -> AxResult<usize> {
+        self.file.read(dst)
+    }
+
+    fn write(&self, src: &mut IoSrc) -> AxResult<usize> {
+        self.file.write(src)
+    }
+
+    fn stat(&self) -> AxResult<Kstat> {
+        self.file.stat()
+    }
+
+    fn inode_key(&self) -> Option<(u64, u64)> {
+        self.file.inode_key()
+    }
+
+    fn file_mmap(&self) -> AxResult<(FileBackend, FileFlags)> {
+        self.file.file_mmap()
+    }
+
+    fn ioctl(&self, cmd: u32, arg: usize) -> AxResult<usize> {
+        self.file.ioctl(cmd, arg)
+    }
+
+    fn open_flags(&self) -> u32 {
+        self.file.open_flags()
+    }
+
+    fn nonblocking(&self) -> bool {
+        self.file.nonblocking()
+    }
+
+    fn set_nonblocking(&self, nonblocking: bool) -> AxResult {
+        self.file.set_nonblocking(nonblocking)
+    }
+
+    fn append(&self) -> bool {
+        self.file.append()
+    }
+
+    fn set_append(&self, append: bool) -> AxResult {
+        self.file.set_append(append)
+    }
+
+    fn path(&self) -> Cow<'_, str> {
+        self.file.path()
+    }
+}
+
+impl Pollable for MountTableFile {
+    fn poll(&self) -> IoEvents {
+        let generation = self.event.generation();
+        let observed = self.observed_generation.swap(generation, Ordering::AcqRel);
+        let changed = if generation != observed {
+            MOUNT_CHANGE_EVENTS
+        } else {
+            IoEvents::empty()
+        };
+        self.file.poll() | changed
+    }
+
+    fn register(&self, context: &mut Context<'_>, events: IoEvents) {
+        self.event.register(context, events);
+        self.file.register(context, events);
+    }
+}

--- a/os/StarryOS/kernel/src/pseudofs/tmp.rs
+++ b/os/StarryOS/kernel/src/pseudofs/tmp.rs
@@ -19,6 +19,9 @@ use axpoll::{IoEvents, Pollable};
 use hashbrown::HashMap;
 use slab::Slab;
 
+const TMPFS_MAGIC: u32 = 0x0102_1994;
+const RAMFS_MAGIC: u32 = 0x8584_58f6;
+
 const TMPFS_NESTED_DIR_ENTRIES_SUBCLASS: u32 = 1;
 
 fn fs_events_to_io(events: FsIoEvents) -> IoEvents {
@@ -68,6 +71,8 @@ impl Borrow<str> for FileName {
 
 /// A simple in-memory filesystem that supports basic file operations.
 pub struct MemoryFs {
+    name: &'static str,
+    fs_type: u32,
     // Inodes may be released from atomic cleanup paths, so the slab and
     // metadata locks must not sleep.
     inodes: SpinNoIrq<Slab<Arc<Inode>>>,
@@ -85,10 +90,23 @@ impl MemoryFs {
         fs
     }
 
+    /// Creates an empty ramfs instance with the Linux-visible ramfs identity.
+    pub fn new_ramfs() -> Filesystem {
+        let (fs, handle) = Self::new_named_with_handle("ramfs", RAMFS_MAGIC);
+        drop(handle);
+        fs
+    }
+
     /// Creates a new empty memory filesystem and returns a handle to the
     /// underlying `MemoryFs` so callers can create anonymous (unlinked) nodes.
     pub fn new_with_handle() -> (Filesystem, Arc<Self>) {
+        Self::new_named_with_handle("tmpfs", TMPFS_MAGIC)
+    }
+
+    fn new_named_with_handle(name: &'static str, fs_type: u32) -> (Filesystem, Arc<Self>) {
         let handle = Arc::new(Self {
+            name,
+            fs_type,
             inodes: SpinNoIrq::new(Slab::new()),
             root: SpinNoIrq::new(None),
         });
@@ -134,7 +152,7 @@ impl MemoryFs {
 
 impl FilesystemOps for MemoryFs {
     fn name(&self) -> &str {
-        "tmpfs"
+        self.name
     }
 
     fn root_dir(&self) -> DirEntry {
@@ -152,7 +170,7 @@ impl FilesystemOps for MemoryFs {
         // size, which is enough to unblock every Java server we've hit and remains
         // accurate when the guest VM has >= 2 GiB.
         Ok(StatFs {
-            fs_type: 0x01021994,
+            fs_type: self.fs_type,
             block_size: 4096,
             blocks: 1 << 20,
             blocks_free: 1 << 20,

--- a/os/StarryOS/kernel/src/pseudofs/tmp.rs
+++ b/os/StarryOS/kernel/src/pseudofs/tmp.rs
@@ -1,4 +1,9 @@
-use alloc::{borrow::ToOwned, string::String, sync::Arc, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    string::String,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
 use core::{
     any::Any,
     borrow::Borrow,
@@ -21,6 +26,8 @@ use slab::Slab;
 
 const TMPFS_MAGIC: u32 = 0x0102_1994;
 const RAMFS_MAGIC: u32 = 0x8584_58f6;
+const STATFS_BLOCK_SIZE: u64 = 4096;
+const DEFAULT_TMPFS_SIZE: u64 = 4 * 1024 * 1024 * 1024;
 
 const TMPFS_NESTED_DIR_ENTRIES_SUBCLASS: u32 = 1;
 
@@ -73,6 +80,8 @@ impl Borrow<str> for FileName {
 pub struct MemoryFs {
     name: &'static str,
     fs_type: u32,
+    size_limit: Option<u64>,
+    used_bytes: AtomicU64,
     // Inodes may be released from atomic cleanup paths, so the slab and
     // metadata locks must not sleep.
     inodes: SpinNoIrq<Slab<Arc<Inode>>>,
@@ -85,14 +94,21 @@ impl MemoryFs {
     /// Creates a new empty memory filesystem.
     #[allow(clippy::new_ret_no_self)]
     pub fn new() -> Filesystem {
-        let (fs, handle) = Self::new_with_handle();
+        let (fs, handle) = Self::new_with_handle_and_limit(None);
+        drop(handle);
+        fs
+    }
+
+    /// Creates an empty tmpfs instance with a logical size limit.
+    pub fn new_with_size_limit(size_limit: u64) -> Filesystem {
+        let (fs, handle) = Self::new_with_handle_and_limit(Some(size_limit));
         drop(handle);
         fs
     }
 
     /// Creates an empty ramfs instance with the Linux-visible ramfs identity.
     pub fn new_ramfs() -> Filesystem {
-        let (fs, handle) = Self::new_named_with_handle("ramfs", RAMFS_MAGIC);
+        let (fs, handle) = Self::new_named_with_handle("ramfs", RAMFS_MAGIC, None);
         drop(handle);
         fs
     }
@@ -100,13 +116,23 @@ impl MemoryFs {
     /// Creates a new empty memory filesystem and returns a handle to the
     /// underlying `MemoryFs` so callers can create anonymous (unlinked) nodes.
     pub fn new_with_handle() -> (Filesystem, Arc<Self>) {
-        Self::new_named_with_handle("tmpfs", TMPFS_MAGIC)
+        Self::new_with_handle_and_limit(None)
     }
 
-    fn new_named_with_handle(name: &'static str, fs_type: u32) -> (Filesystem, Arc<Self>) {
+    fn new_with_handle_and_limit(size_limit: Option<u64>) -> (Filesystem, Arc<Self>) {
+        Self::new_named_with_handle("tmpfs", TMPFS_MAGIC, size_limit)
+    }
+
+    fn new_named_with_handle(
+        name: &'static str,
+        fs_type: u32,
+        size_limit: Option<u64>,
+    ) -> (Filesystem, Arc<Self>) {
         let handle = Arc::new(Self {
             name,
             fs_type,
+            size_limit,
+            used_bytes: AtomicU64::new(0),
             inodes: SpinNoIrq::new(Slab::new()),
             root: SpinNoIrq::new(None),
         });
@@ -128,6 +154,32 @@ impl MemoryFs {
 
     fn get(&self, ino: u64) -> Arc<Inode> {
         self.inodes.lock()[ino as usize - 1].clone()
+    }
+
+    fn resize_usage(&self, old_len: u64, new_len: u64) -> VfsResult<()> {
+        if new_len <= old_len {
+            self.used_bytes
+                .fetch_sub(old_len - new_len, AtomicOrdering::AcqRel);
+            return Ok(());
+        }
+
+        let growth = new_len - old_len;
+        let mut used = self.used_bytes.load(AtomicOrdering::Acquire);
+        loop {
+            let new_used = used.checked_add(growth).ok_or(VfsError::StorageFull)?;
+            if self.size_limit.is_some_and(|limit| new_used > limit) {
+                return Err(VfsError::StorageFull);
+            }
+            match self.used_bytes.compare_exchange_weak(
+                used,
+                new_used,
+                AtomicOrdering::AcqRel,
+                AtomicOrdering::Acquire,
+            ) {
+                Ok(_) => return Ok(()),
+                Err(observed) => used = observed,
+            }
+        }
     }
 
     /// Creates an anonymous (unlinked) regular file inode within this tmpfs.
@@ -169,12 +221,18 @@ impl FilesystemOps for MemoryFs {
         // accounting layer, so advertise 4 GiB / 4 GiB free with realistic block
         // size, which is enough to unblock every Java server we've hit and remains
         // accurate when the guest VM has >= 2 GiB.
+        let size_limit = self.size_limit.unwrap_or(DEFAULT_TMPFS_SIZE);
+        let blocks = size_limit.div_ceil(STATFS_BLOCK_SIZE);
+        let used_blocks = self
+            .used_bytes
+            .load(AtomicOrdering::Acquire)
+            .div_ceil(STATFS_BLOCK_SIZE);
         Ok(StatFs {
             fs_type: self.fs_type,
-            block_size: 4096,
-            blocks: 1 << 20,
-            blocks_free: 1 << 20,
-            blocks_available: 1 << 20,
+            block_size: STATFS_BLOCK_SIZE as u32,
+            blocks,
+            blocks_free: blocks.saturating_sub(used_blocks),
+            blocks_available: blocks.saturating_sub(used_blocks),
             file_count: 0,
             free_file_count: 1 << 16,
             name_length: axfs_ng_vfs::path::MAX_NAME_LEN as _,
@@ -199,7 +257,7 @@ struct FileContent {
     ///
     /// We only need to store the length here because we delegate the actual
     /// content management to page cache.
-    length: Mutex<u64>,
+    length: AtomicU64,
     symlink: Mutex<Option<String>>,
 }
 
@@ -226,6 +284,7 @@ enum NodeContent {
 }
 
 struct Inode {
+    fs: Weak<MemoryFs>,
     ino: u64,
     metadata: SpinNoIrq<Metadata>,
     content: NodeContent,
@@ -267,6 +326,7 @@ impl Inode {
             _ => NodeContent::File(FileContent::default()),
         };
         let result = Arc::new(Self {
+            fs: Arc::downgrade(fs),
             ino,
             metadata: SpinNoIrq::new(metadata),
             content,
@@ -299,6 +359,19 @@ impl Inode {
             NodeContent::Dir(ref content) => Ok(content),
             _ => Err(VfsError::NotADirectory),
         }
+    }
+}
+
+impl Drop for Inode {
+    fn drop(&mut self) {
+        let NodeContent::File(content) = &self.content else {
+            return;
+        };
+        let Some(fs) = self.fs.upgrade() else {
+            return;
+        };
+        let length = content.length.load(AtomicOrdering::Acquire);
+        fs.used_bytes.fetch_sub(length, AtomicOrdering::AcqRel);
     }
 }
 
@@ -385,7 +458,7 @@ impl NodeOps for MemoryNode {
         let mut metadata = self.inode.metadata.lock().clone();
         match &self.inode.content {
             NodeContent::File(content) => {
-                metadata.size = *content.length.lock();
+                metadata.size = content.length.load(AtomicOrdering::Acquire);
             }
             NodeContent::Dir(dir) => {
                 metadata.size = dir.entries.lock().len() as u64;
@@ -453,13 +526,19 @@ impl FileNodeOps for MemoryNode {
     }
 
     fn set_len(&self, len: u64) -> VfsResult<()> {
-        *self.inode.as_file()?.length.lock() = len;
+        let file = self.inode.as_file()?;
+        let old_len = file.length.load(AtomicOrdering::Acquire);
+        self.fs.resize_usage(old_len, len)?;
+        file.length.store(len, AtomicOrdering::Release);
         Ok(())
     }
 
     fn set_symlink(&self, target: &str) -> VfsResult<()> {
         let file = self.inode.as_file()?;
-        *file.length.lock() = target.len() as u64;
+        let old_len = file.length.load(AtomicOrdering::Acquire);
+        let new_len = target.len() as u64;
+        self.fs.resize_usage(old_len, new_len)?;
+        file.length.store(new_len, AtomicOrdering::Release);
         *file.symlink.lock() = Some(target.to_owned());
         Ok(())
     }

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -1,4 +1,4 @@
-use alloc::{format, string::ToString, sync::Arc};
+use alloc::{format, string::ToString, sync::Arc, vec::Vec};
 use core::{
     ffi::{c_char, c_int},
     mem::size_of,
@@ -6,7 +6,7 @@ use core::{
 };
 
 use ax_errno::{AxError, AxResult};
-use ax_fs_ng::vfs::{FS_CONTEXT, FileBackend, OpenOptions, OpenResult};
+use ax_fs_ng::vfs::{FS_CONTEXT, FileBackend, MountNamespace, OpenOptions, OpenResult};
 use ax_task::current;
 use axfs_ng_vfs::{DirEntry, FileNode, Location, NodeOps, NodeType, Reference};
 use bitflags::bitflags;
@@ -15,8 +15,8 @@ use starry_vm::{VmMutPtr, VmPtr, vm_load};
 
 use crate::{
     file::{
-        Directory, FD_TABLE, File, FileDescriptor, FileLike, NsFd, Pipe, add_file_like,
-        close_file_like, get_file_like, memfd::Memfd, with_fs,
+        Directory, FD_TABLE, File, FileDescriptor, FileLike, MountTableFile, NsFd, Pipe,
+        add_file_like, close_file_like, get_file_like, memfd::Memfd, with_fs,
     },
     mm::vm_load_path_string,
     pseudofs::{Device, dev::tty},
@@ -75,7 +75,11 @@ fn flags_to_options(flags: c_int, mode: __kernel_mode_t, (uid, gid): (u32, u32))
     options
 }
 
-fn add_to_fd(result: OpenResult, flags: u32) -> AxResult<i32> {
+fn add_to_fd(
+    result: OpenResult,
+    flags: u32,
+    mount_table_namespace: Option<Arc<MountNamespace>>,
+) -> AxResult<i32> {
     // FIFO + O_NONBLOCK + O_WRONLY (no reader) → ENXIO.
     //
     // man 2 open §"ENXIO" 第 1 variant：
@@ -190,7 +194,12 @@ fn add_to_fd(result: OpenResult, flags: u32) -> AxResult<i32> {
                     device.inner().open(flags & O_EXCL != 0)?;
                 }
             }
-            Arc::new(File::new(file, flags))
+            let file = Arc::new(File::new(file, flags));
+            if let Some(namespace) = mount_table_namespace {
+                MountTableFile::new(file, &namespace)
+            } else {
+                file
+            }
         }
         OpenResult::Dir(dir) => Arc::new(Directory::new(dir, flags)),
     };
@@ -198,6 +207,28 @@ fn add_to_fd(result: OpenResult, flags: u32) -> AxResult<i32> {
         f.set_nonblocking(true)?;
     }
     add_file_like(f, flags & O_CLOEXEC != 0)
+}
+
+fn mount_table_namespace(result: &OpenResult) -> Option<Arc<MountNamespace>> {
+    let OpenResult::File(file) = result else {
+        return None;
+    };
+    let path = file.location().absolute_path().ok()?.to_string();
+    let components: Vec<_> = path.trim_start_matches('/').split('/').collect();
+    let pid = match components.as_slice() {
+        ["proc", "mountinfo" | "mounts"] | ["proc", "self", "mountinfo" | "mounts"] => {
+            current().as_thread().proc_data.proc.pid()
+        }
+        ["proc", pid, "mountinfo" | "mounts"] => pid.parse().ok()?,
+        ["proc", _, "task", tid, "mountinfo" | "mounts"] => tid.parse().ok()?,
+        _ => return None,
+    };
+
+    let task = get_task(pid).ok()?;
+    let scope = task.as_thread().scope.read();
+    let fs_context = FS_CONTEXT.scope(&scope).clone();
+    drop(scope);
+    Some(fs_context.lock().mount_namespace().clone())
 }
 
 #[repr(C)]
@@ -422,8 +453,9 @@ pub fn sys_openat(
         })?;
 
     // Open first, then install the file so filesystem errors propagate unchanged.
-    let fd =
-        with_fs(dirfd, |fs| options.open(fs, path)).and_then(|it| add_to_fd(it, flags as _))?;
+    let result = with_fs(dirfd, |fs| options.open(fs, path))?;
+    let mount_table_namespace = mount_table_namespace(&result);
+    let fd = add_to_fd(result, flags as _, mount_table_namespace)?;
     if should_notify_create {
         let file = get_file_like(fd)?;
         crate::file::inotify::notify_create_path(file.path().as_ref(), false);
@@ -508,7 +540,8 @@ pub fn sys_openat2(
         options.no_follow(true);
         options.open(&fs.with_current_dir(parent)?, name.as_ref())
     })?;
-    add_to_fd(result, flags as u32).map(|fd| fd as isize)
+    let mount_table_namespace = mount_table_namespace(&result);
+    add_to_fd(result, flags as u32, mount_table_namespace).map(|fd| fd as isize)
 }
 
 /// Open a file by `filename` and insert it into the file descriptor table.

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -197,15 +197,17 @@ fn is_mount_busy(mp: &Arc<axfs_ng_vfs::Mountpoint>) -> bool {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
-enum MemoryMountKind {
+enum MountContextKind {
     Tmpfs,
     Ramfs,
+    DevPts,
 }
 
 struct MountContextState {
     filesystem: Option<Filesystem>,
     source: Option<String>,
     root_mode: NodePermission,
+    devpts_options: DevPtsOptions,
     tmpfs_size_limit: Option<u64>,
     unsupported_tmpfs_limits: bool,
     readonly_reconfigure: bool,
@@ -213,18 +215,19 @@ struct MountContextState {
 }
 
 struct MountContext {
-    kind: MemoryMountKind,
+    kind: MountContextKind,
     state: Mutex<MountContextState>,
 }
 
 impl MountContext {
-    fn new(kind: MemoryMountKind) -> Self {
+    fn new(kind: MountContextKind) -> Self {
         Self {
             kind,
             state: Mutex::new(MountContextState {
                 filesystem: None,
                 source: None,
                 root_mode: NodePermission::from_bits_truncate(0o755),
+                devpts_options: DevPtsOptions::mounted(),
                 tmpfs_size_limit: None,
                 unsupported_tmpfs_limits: false,
                 readonly_reconfigure: false,
@@ -298,8 +301,9 @@ pub fn sys_fsopen(fs_name: *const c_char, flags: u32) -> AxResult<isize> {
     }
 
     let kind = match vm_load_string(fs_name)?.as_str() {
-        "tmpfs" => MemoryMountKind::Tmpfs,
-        "ramfs" => MemoryMountKind::Ramfs,
+        "tmpfs" => MountContextKind::Tmpfs,
+        "ramfs" => MountContextKind::Ramfs,
+        "devpts" => MountContextKind::DevPts,
         _ => return Err(AxError::NoSuchDevice),
     };
     MountContext::new(kind)
@@ -331,14 +335,24 @@ pub fn sys_fsconfig(
                 (_, "source") if state.filesystem.is_none() && !value.is_empty() => {
                     state.source = Some(value);
                 }
-                (MemoryMountKind::Tmpfs, "size") if !value.is_empty() => {
+                (MountContextKind::Tmpfs, "size") if !value.is_empty() => {
                     state.tmpfs_size_limit = Some(parse_tmpfs_size(&value)?);
                 }
-                (MemoryMountKind::Tmpfs, "nr_inodes") if !value.is_empty() => {
+                (MountContextKind::Tmpfs, "nr_inodes") if !value.is_empty() => {
                     state.unsupported_tmpfs_limits = true;
                 }
-                (_, "mode") => {
+                (MountContextKind::Tmpfs | MountContextKind::Ramfs, "mode") => {
                     state.root_mode = parse_devpts_mode(&value)?;
+                }
+                (MountContextKind::DevPts, "mode") => {
+                    state.devpts_options.slave_mode = parse_devpts_mode(&value)?;
+                }
+                (MountContextKind::DevPts, "gid") => {
+                    state.devpts_options.slave_gid =
+                        value.parse().map_err(|_| AxError::InvalidInput)?;
+                }
+                (MountContextKind::DevPts, "ptmxmode") => {
+                    state.devpts_options.ptmx_mode = parse_devpts_mode(&value)?;
                 }
                 _ => return Err(AxError::InvalidInput),
             }
@@ -350,7 +364,16 @@ pub fn sys_fsconfig(
             match vm_load_string(key)?.as_str() {
                 // Linux systemd deliberately falls back from tmpfs to ramfs
                 // when the kernel cannot configure tmpfs with `noswap`.
-                "noswap" if state.filesystem.is_none() => return Err(AxError::InvalidInput),
+                "noswap"
+                    if context.kind == MountContextKind::Tmpfs && state.filesystem.is_none() =>
+                {
+                    return Err(AxError::InvalidInput);
+                }
+                // A devpts filesystem context already denotes a fresh instance;
+                // retain Linux's accepted option spelling without adding a
+                // second instance-selection state.
+                "newinstance"
+                    if context.kind == MountContextKind::DevPts && state.filesystem.is_none() => {}
                 "ro" if state.filesystem.is_some() => state.readonly_reconfigure = true,
                 _ => return Err(AxError::InvalidInput),
             }
@@ -359,14 +382,17 @@ pub fn sys_fsconfig(
             if !key.is_null() || !value.is_null() || aux != 0 || state.filesystem.is_some() {
                 return Err(AxError::InvalidInput);
             }
-            if context.kind == MemoryMountKind::Tmpfs && state.unsupported_tmpfs_limits {
+            if context.kind == MountContextKind::Tmpfs && state.unsupported_tmpfs_limits {
                 return Err(AxError::OperationNotSupported);
             }
             state.filesystem = Some(match context.kind {
-                MemoryMountKind::Tmpfs => state
+                MountContextKind::Tmpfs => state
                     .tmpfs_size_limit
                     .map_or_else(MemoryFs::new, MemoryFs::new_with_size_limit),
-                MemoryMountKind::Ramfs => MemoryFs::new_ramfs(),
+                MountContextKind::Ramfs => MemoryFs::new_ramfs(),
+                MountContextKind::DevPts => {
+                    new_devptsfs(DevPtsMount::NewInstance(state.devpts_options))
+                }
             });
         }
         command if command == fsconfig_command::FSCONFIG_CMD_RECONFIGURE as u32 => {
@@ -407,10 +433,12 @@ pub fn sys_fsmount(fs_fd: i32, flags: u32, mount_attributes: u32) -> AxResult<is
     let mountpoint =
         Mountpoint::new_root_with_source(&filesystem, state.source.as_deref().unwrap_or("none"));
     let root = mountpoint.root_location();
-    root.update_metadata(MetadataUpdate {
-        mode: Some(state.root_mode),
-        ..Default::default()
-    })?;
+    if context.kind != MountContextKind::DevPts {
+        root.update_metadata(MetadataUpdate {
+            mode: Some(state.root_mode),
+            ..Default::default()
+        })?;
+    }
     mountpoint.set_readonly(mount_attributes & MOUNT_ATTR_RDONLY != 0);
     mountpoint.set_mount_flags(
         mount_attributes & (MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC),

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -267,6 +267,18 @@ pub fn sys_mount(
             }
             mp.set_mount_flags((flags & MOUNT_OPTION_FLAGS) as u32);
         }
+        "ramfs" => {
+            // Linux registers ramfs as a separate nodev filesystem and exposes
+            // RAMFS_MAGIC through statfs. It shares the in-memory inode/data
+            // machinery here, but must not inherit tmpfs's visible identity.
+            let fs = MemoryFs::new_ramfs();
+            let target = ax_fs_ng::vfs::current_fs_context().lock().resolve(target)?;
+            let mp = target.mount_with_source(&fs, mount_source(&source))?;
+            if (flags & MS_RDONLY) != 0 {
+                mp.set_readonly(true);
+            }
+            mp.set_mount_flags((flags & MOUNT_OPTION_FLAGS) as u32);
+        }
         "devpts" => {
             let fs = new_devptsfs(parse_devpts_options(data)?);
             let target = ax_fs_ng::vfs::current_fs_context().lock().resolve(target)?;

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -11,9 +11,11 @@ use ax_task::current;
 use axfs_ng_vfs::{Filesystem, MetadataUpdate, Mountpoint, NodePermission};
 use axpoll::{IoEvents, Pollable};
 use linux_raw_sys::general::{
-    FSMOUNT_CLOEXEC, FSOPEN_CLOEXEC, MOUNT_ATTR_NODEV, MOUNT_ATTR_NOEXEC, MOUNT_ATTR_NOSUID,
-    MOUNT_ATTR_RDONLY, MOVE_MOUNT_F_EMPTY_PATH, O_PATH, fsconfig_command,
+    AT_EMPTY_PATH, FSMOUNT_CLOEXEC, FSOPEN_CLOEXEC, MOUNT_ATTR__ATIME, MOUNT_ATTR_NOATIME,
+    MOUNT_ATTR_NODEV, MOUNT_ATTR_NOEXEC, MOUNT_ATTR_NOSUID, MOUNT_ATTR_RDONLY,
+    MOUNT_ATTR_STRICTATIME, MOVE_MOUNT_F_EMPTY_PATH, O_PATH, fsconfig_command,
 };
+use starry_vm::VmPtr;
 
 use crate::{
     file::{Directory, FD_TABLE, File, FileLike},
@@ -59,6 +61,21 @@ const VALID_UMOUNT_FLAGS: i32 = MNT_FORCE | MNT_DETACH | MNT_EXPIRE | UMOUNT_NOF
 
 const SUPPORTED_FSMOUNT_ATTRIBUTES: u32 =
     MOUNT_ATTR_RDONLY | MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC;
+const MOUNT_ATTR_SIZE_VER0: usize = core::mem::size_of::<MountAttr>();
+const SUPPORTED_MOUNT_SETATTR_ATTRIBUTES: u64 = (MOUNT_ATTR_RDONLY
+    | MOUNT_ATTR_NOSUID
+    | MOUNT_ATTR_NODEV
+    | MOUNT_ATTR_NOEXEC
+    | MOUNT_ATTR__ATIME) as u64;
+
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::AnyBitPattern)]
+pub struct MountAttr {
+    attr_set: u64,
+    attr_clr: u64,
+    propagation: u64,
+    userns_fd: u64,
+}
 
 fn parse_devpts_mode(value: &str) -> AxResult<NodePermission> {
     let mode = u16::from_str_radix(value, 8).map_err(|_| AxError::InvalidInput)?;
@@ -187,8 +204,10 @@ enum MemoryMountKind {
 
 struct MountContextState {
     filesystem: Option<Filesystem>,
+    source: Option<String>,
     root_mode: NodePermission,
-    tmpfs_limits_configured: bool,
+    tmpfs_size_limit: Option<u64>,
+    unsupported_tmpfs_limits: bool,
     readonly_reconfigure: bool,
     mounts: Vec<Arc<Mountpoint>>,
 }
@@ -204,8 +223,10 @@ impl MountContext {
             kind,
             state: Mutex::new(MountContextState {
                 filesystem: None,
+                source: None,
                 root_mode: NodePermission::from_bits_truncate(0o755),
-                tmpfs_limits_configured: false,
+                tmpfs_size_limit: None,
+                unsupported_tmpfs_limits: false,
                 readonly_reconfigure: false,
                 mounts: Vec::new(),
             }),
@@ -225,6 +246,47 @@ impl Pollable for MountContext {
     }
 
     fn register(&self, _context: &mut Context<'_>, _events: IoEvents) {}
+}
+
+fn parse_tmpfs_size(value: &str) -> AxResult<u64> {
+    const PAGE_SIZE: u64 = 4096;
+
+    let bytes = if let Some(percent) = value.strip_suffix('%') {
+        let percent = percent.parse::<u64>().map_err(|_| AxError::InvalidInput)?;
+        if percent == 0 || percent > 100 {
+            return Err(AxError::InvalidInput);
+        }
+        let total_pages = (ax_runtime::hal::mem::total_ram_size() as u64).div_ceil(PAGE_SIZE);
+        total_pages
+            .checked_mul(percent)
+            .ok_or(AxError::InvalidInput)?
+            .div_ceil(100)
+            .checked_mul(PAGE_SIZE)
+            .ok_or(AxError::InvalidInput)?
+    } else {
+        let (number, multiplier) = match value.as_bytes().last().copied() {
+            Some(b'k' | b'K') => (&value[..value.len() - 1], 1_u64 << 10),
+            Some(b'm' | b'M') => (&value[..value.len() - 1], 1_u64 << 20),
+            Some(b'g' | b'G') => (&value[..value.len() - 1], 1_u64 << 30),
+            Some(b't' | b'T') => (&value[..value.len() - 1], 1_u64 << 40),
+            Some(b'p' | b'P') => (&value[..value.len() - 1], 1_u64 << 50),
+            Some(b'e' | b'E') => (&value[..value.len() - 1], 1_u64 << 60),
+            _ => (value, 1),
+        };
+        number
+            .parse::<u64>()
+            .map_err(|_| AxError::InvalidInput)?
+            .checked_mul(multiplier)
+            .ok_or(AxError::InvalidInput)?
+    };
+
+    if bytes == 0 {
+        return Err(AxError::InvalidInput);
+    }
+    bytes
+        .checked_add(PAGE_SIZE - 1)
+        .map(|size| size / PAGE_SIZE * PAGE_SIZE)
+        .ok_or(AxError::InvalidInput)
 }
 
 pub fn sys_fsopen(fs_name: *const c_char, flags: u32) -> AxResult<isize> {
@@ -266,11 +328,14 @@ pub fn sys_fsconfig(
             let key = vm_load_string(key)?;
             let value = vm_load_string(value.cast())?;
             match (context.kind, key.as_str()) {
-                (MemoryMountKind::Tmpfs, "nr_inodes" | "size") if !value.is_empty() => {
-                    // Starry's current memory filesystem has no quota accounting.
-                    // Preserve these settings only long enough for systemd to
-                    // probe `noswap`; creating a constrained tmpfs is rejected.
-                    state.tmpfs_limits_configured = true;
+                (_, "source") if state.filesystem.is_none() && !value.is_empty() => {
+                    state.source = Some(value);
+                }
+                (MemoryMountKind::Tmpfs, "size") if !value.is_empty() => {
+                    state.tmpfs_size_limit = Some(parse_tmpfs_size(&value)?);
+                }
+                (MemoryMountKind::Tmpfs, "nr_inodes") if !value.is_empty() => {
+                    state.unsupported_tmpfs_limits = true;
                 }
                 (_, "mode") => {
                     state.root_mode = parse_devpts_mode(&value)?;
@@ -294,11 +359,13 @@ pub fn sys_fsconfig(
             if !key.is_null() || !value.is_null() || aux != 0 || state.filesystem.is_some() {
                 return Err(AxError::InvalidInput);
             }
-            if context.kind == MemoryMountKind::Tmpfs && state.tmpfs_limits_configured {
+            if context.kind == MemoryMountKind::Tmpfs && state.unsupported_tmpfs_limits {
                 return Err(AxError::OperationNotSupported);
             }
             state.filesystem = Some(match context.kind {
-                MemoryMountKind::Tmpfs => MemoryFs::new(),
+                MemoryMountKind::Tmpfs => state
+                    .tmpfs_size_limit
+                    .map_or_else(MemoryFs::new, MemoryFs::new_with_size_limit),
                 MemoryMountKind::Ramfs => MemoryFs::new_ramfs(),
             });
         }
@@ -337,7 +404,8 @@ pub fn sys_fsmount(fs_fd: i32, flags: u32, mount_attributes: u32) -> AxResult<is
         .as_ref()
         .ok_or(AxError::InvalidInput)?
         .clone();
-    let mountpoint = Mountpoint::new_root_with_source(&filesystem, "none");
+    let mountpoint =
+        Mountpoint::new_root_with_source(&filesystem, state.source.as_deref().unwrap_or("none"));
     let root = mountpoint.root_location();
     root.update_metadata(MetadataUpdate {
         mode: Some(state.root_mode),
@@ -374,12 +442,99 @@ pub fn sys_move_mount(
     }
     let path = vm_load_string(to_path)?;
     let target = if path.starts_with('/') {
-        ax_fs_ng::vfs::current_fs_context().lock().resolve(path)?
+        ax_fs_ng::vfs::current_fs_context().lock().resolve(&path)?
     } else {
-        crate::file::with_fs(to_dirfd, |fs| fs.resolve(path))?
+        crate::file::with_fs(to_dirfd, |fs| fs.resolve(&path))?
     };
     source.inner().mountpoint().attach_detached(&target)?;
     Ok(0)
+}
+
+/// Apply the Linux VFS attributes currently required by util-linux mounts.
+///
+/// The supported boundary is an existing mount root referenced by a directory
+/// fd and an empty path. Mount propagation, idmapped mounts, recursive changes,
+/// and `MOUNT_ATTR_NOSYMFOLLOW` remain explicit `EINVAL` paths.
+pub fn sys_mount_setattr(
+    dirfd: i32,
+    path: *const c_char,
+    flags: u32,
+    attributes: *const MountAttr,
+    size: usize,
+) -> AxResult<isize> {
+    // Linux reserves the all-zero request as a side-effect-free syscall
+    // availability probe. util-linux uses it before choosing the new mount API.
+    if flags == 0 && size == 0 {
+        return Ok(0);
+    }
+    if size != MOUNT_ATTR_SIZE_VER0 || flags != AT_EMPTY_PATH {
+        return Err(AxError::InvalidInput);
+    }
+    if !current().as_thread().cred().has_cap_sys_admin() {
+        return Err(AxError::OperationNotPermitted);
+    }
+    if !vm_load_string(path)?.is_empty() {
+        return Err(AxError::InvalidInput);
+    }
+
+    let attributes = attributes.vm_read()?;
+    validate_mount_attributes(&attributes)?;
+
+    let directory = Directory::from_fd(dirfd)?;
+    if !directory.inner().is_root_of_mount() {
+        return Err(AxError::InvalidInput);
+    }
+    apply_mount_attributes(directory.inner().mountpoint(), &attributes);
+    Ok(0)
+}
+
+fn validate_mount_attributes(attributes: &MountAttr) -> AxResult<()> {
+    if attributes.propagation != 0
+        || attributes.userns_fd != 0
+        || attributes.attr_set & !SUPPORTED_MOUNT_SETATTR_ATTRIBUTES != 0
+        || attributes.attr_clr & !SUPPORTED_MOUNT_SETATTR_ATTRIBUTES != 0
+    {
+        return Err(AxError::InvalidInput);
+    }
+
+    let non_atime_attributes = !(MOUNT_ATTR__ATIME as u64);
+    if attributes.attr_set & attributes.attr_clr & non_atime_attributes != 0 {
+        return Err(AxError::InvalidInput);
+    }
+
+    let requested_atime = attributes.attr_set & MOUNT_ATTR__ATIME as u64;
+    if requested_atime != 0
+        && requested_atime != MOUNT_ATTR_NOATIME as u64
+        && requested_atime != MOUNT_ATTR_STRICTATIME as u64
+    {
+        return Err(AxError::InvalidInput);
+    }
+    Ok(())
+}
+
+fn apply_mount_attributes(mountpoint: &Arc<Mountpoint>, attributes: &MountAttr) {
+    if attributes.attr_set & MOUNT_ATTR_RDONLY as u64 != 0 {
+        mountpoint.set_readonly(true);
+    } else if attributes.attr_clr & MOUNT_ATTR_RDONLY as u64 != 0 {
+        mountpoint.set_readonly(false);
+    }
+
+    let basic_attributes = (MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC) as u64;
+    let mut mount_flags = mountpoint.mount_flags();
+    mount_flags |= (attributes.attr_set & basic_attributes) as u32;
+    mount_flags &= !(attributes.attr_clr & basic_attributes) as u32;
+
+    if (attributes.attr_set | attributes.attr_clr) & MOUNT_ATTR__ATIME as u64 != 0 {
+        mount_flags &= !(MS_NOATIME | MS_RELATIME | MS_STRICTATIME) as u32;
+        match attributes.attr_set & MOUNT_ATTR__ATIME as u64 {
+            value if value == MOUNT_ATTR_NOATIME as u64 => mount_flags |= MS_NOATIME as u32,
+            value if value == MOUNT_ATTR_STRICTATIME as u64 => {
+                mount_flags |= MS_STRICTATIME as u32;
+            }
+            _ => mount_flags |= MS_RELATIME as u32,
+        }
+    }
+    mountpoint.set_mount_flags(mount_flags);
 }
 
 pub fn sys_mount(

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -1,10 +1,19 @@
-use alloc::{string::String, sync::Arc, vec::Vec};
-use core::ffi::{c_char, c_void};
+use alloc::{borrow::Cow, string::String, sync::Arc, vec::Vec};
+use core::{
+    ffi::{c_char, c_void},
+    task::Context,
+};
 
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_fs_ng::vfs::is_mount_busy as fs_is_mount_busy;
+use ax_sync::Mutex;
 use ax_task::current;
-use axfs_ng_vfs::NodePermission;
+use axfs_ng_vfs::{Filesystem, MetadataUpdate, Mountpoint, NodePermission};
+use axpoll::{IoEvents, Pollable};
+use linux_raw_sys::general::{
+    FSMOUNT_CLOEXEC, FSOPEN_CLOEXEC, MOUNT_ATTR_NODEV, MOUNT_ATTR_NOEXEC, MOUNT_ATTR_NOSUID,
+    MOUNT_ATTR_RDONLY, MOVE_MOUNT_F_EMPTY_PATH, O_PATH, fsconfig_command,
+};
 
 use crate::{
     file::{Directory, FD_TABLE, File, FileLike},
@@ -47,6 +56,9 @@ const MOUNT_OPTION_FLAGS: i32 =
 
 const PROPAGATION_FLAGS: i32 = MS_SHARED | MS_PRIVATE | MS_SLAVE | MS_UNBINDABLE;
 const VALID_UMOUNT_FLAGS: i32 = MNT_FORCE | MNT_DETACH | MNT_EXPIRE | UMOUNT_NOFOLLOW;
+
+const SUPPORTED_FSMOUNT_ATTRIBUTES: u32 =
+    MOUNT_ATTR_RDONLY | MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC;
 
 fn parse_devpts_mode(value: &str) -> AxResult<NodePermission> {
     let mode = u16::from_str_radix(value, 8).map_err(|_| AxError::InvalidInput)?;
@@ -165,6 +177,209 @@ fn is_mount_busy(mp: &Arc<axfs_ng_vfs::Mountpoint>) -> bool {
         }
     }
     false
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MemoryMountKind {
+    Tmpfs,
+    Ramfs,
+}
+
+struct MountContextState {
+    filesystem: Option<Filesystem>,
+    root_mode: NodePermission,
+    tmpfs_limits_configured: bool,
+    readonly_reconfigure: bool,
+    mounts: Vec<Arc<Mountpoint>>,
+}
+
+struct MountContext {
+    kind: MemoryMountKind,
+    state: Mutex<MountContextState>,
+}
+
+impl MountContext {
+    fn new(kind: MemoryMountKind) -> Self {
+        Self {
+            kind,
+            state: Mutex::new(MountContextState {
+                filesystem: None,
+                root_mode: NodePermission::from_bits_truncate(0o755),
+                tmpfs_limits_configured: false,
+                readonly_reconfigure: false,
+                mounts: Vec::new(),
+            }),
+        }
+    }
+}
+
+impl FileLike for MountContext {
+    fn path(&self) -> Cow<'_, str> {
+        "anon_inode:[fscontext]".into()
+    }
+}
+
+impl Pollable for MountContext {
+    fn poll(&self) -> IoEvents {
+        IoEvents::empty()
+    }
+
+    fn register(&self, _context: &mut Context<'_>, _events: IoEvents) {}
+}
+
+pub fn sys_fsopen(fs_name: *const c_char, flags: u32) -> AxResult<isize> {
+    if flags & !FSOPEN_CLOEXEC != 0 {
+        return Err(AxError::InvalidInput);
+    }
+    if !current().as_thread().cred().has_cap_sys_admin() {
+        return Err(AxError::OperationNotPermitted);
+    }
+
+    let kind = match vm_load_string(fs_name)?.as_str() {
+        "tmpfs" => MemoryMountKind::Tmpfs,
+        "ramfs" => MemoryMountKind::Ramfs,
+        _ => return Err(AxError::NoSuchDevice),
+    };
+    MountContext::new(kind)
+        .add_to_fd_table(flags & FSOPEN_CLOEXEC != 0)
+        .map(|fd| fd as isize)
+}
+
+pub fn sys_fsconfig(
+    fs_fd: i32,
+    command: u32,
+    key: *const c_char,
+    value: *const c_void,
+    aux: i32,
+) -> AxResult<isize> {
+    if !current().as_thread().cred().has_cap_sys_admin() {
+        return Err(AxError::OperationNotPermitted);
+    }
+    let context = MountContext::from_fd(fs_fd)?;
+    let mut state = context.state.lock();
+
+    match command {
+        command if command == fsconfig_command::FSCONFIG_SET_STRING as u32 => {
+            if key.is_null() || value.is_null() || aux != 0 || state.filesystem.is_some() {
+                return Err(AxError::InvalidInput);
+            }
+            let key = vm_load_string(key)?;
+            let value = vm_load_string(value.cast())?;
+            match (context.kind, key.as_str()) {
+                (MemoryMountKind::Tmpfs, "nr_inodes" | "size") if !value.is_empty() => {
+                    // Starry's current memory filesystem has no quota accounting.
+                    // Preserve these settings only long enough for systemd to
+                    // probe `noswap`; creating a constrained tmpfs is rejected.
+                    state.tmpfs_limits_configured = true;
+                }
+                (_, "mode") => {
+                    state.root_mode = parse_devpts_mode(&value)?;
+                }
+                _ => return Err(AxError::InvalidInput),
+            }
+        }
+        command if command == fsconfig_command::FSCONFIG_SET_FLAG as u32 => {
+            if key.is_null() || !value.is_null() || aux != 0 {
+                return Err(AxError::InvalidInput);
+            }
+            match vm_load_string(key)?.as_str() {
+                // Linux systemd deliberately falls back from tmpfs to ramfs
+                // when the kernel cannot configure tmpfs with `noswap`.
+                "noswap" if state.filesystem.is_none() => return Err(AxError::InvalidInput),
+                "ro" if state.filesystem.is_some() => state.readonly_reconfigure = true,
+                _ => return Err(AxError::InvalidInput),
+            }
+        }
+        command if command == fsconfig_command::FSCONFIG_CMD_CREATE as u32 => {
+            if !key.is_null() || !value.is_null() || aux != 0 || state.filesystem.is_some() {
+                return Err(AxError::InvalidInput);
+            }
+            if context.kind == MemoryMountKind::Tmpfs && state.tmpfs_limits_configured {
+                return Err(AxError::OperationNotSupported);
+            }
+            state.filesystem = Some(match context.kind {
+                MemoryMountKind::Tmpfs => MemoryFs::new(),
+                MemoryMountKind::Ramfs => MemoryFs::new_ramfs(),
+            });
+        }
+        command if command == fsconfig_command::FSCONFIG_CMD_RECONFIGURE as u32 => {
+            if !key.is_null()
+                || !value.is_null()
+                || aux != 0
+                || state.filesystem.is_none()
+                || !state.readonly_reconfigure
+            {
+                return Err(AxError::InvalidInput);
+            }
+            for mountpoint in &state.mounts {
+                mountpoint.set_readonly(true);
+            }
+            state.readonly_reconfigure = false;
+        }
+        _ => return Err(AxError::OperationNotSupported),
+    }
+    Ok(0)
+}
+
+pub fn sys_fsmount(fs_fd: i32, flags: u32, mount_attributes: u32) -> AxResult<isize> {
+    if flags & !FSMOUNT_CLOEXEC != 0 || mount_attributes & !SUPPORTED_FSMOUNT_ATTRIBUTES != 0 {
+        // systemd retries without MOUNT_ATTR_NOSYMFOLLOW on EINVAL.
+        return Err(AxError::InvalidInput);
+    }
+    if !current().as_thread().cred().has_cap_sys_admin() {
+        return Err(AxError::OperationNotPermitted);
+    }
+
+    let context = MountContext::from_fd(fs_fd)?;
+    let mut state = context.state.lock();
+    let filesystem = state
+        .filesystem
+        .as_ref()
+        .ok_or(AxError::InvalidInput)?
+        .clone();
+    let mountpoint = Mountpoint::new_root_with_source(&filesystem, "none");
+    let root = mountpoint.root_location();
+    root.update_metadata(MetadataUpdate {
+        mode: Some(state.root_mode),
+        ..Default::default()
+    })?;
+    mountpoint.set_readonly(mount_attributes & MOUNT_ATTR_RDONLY != 0);
+    mountpoint.set_mount_flags(
+        mount_attributes & (MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_NOEXEC),
+    );
+    state.mounts.push(mountpoint);
+
+    Directory::new_detached_mount(root, O_PATH)
+        .add_to_fd_table(flags & FSMOUNT_CLOEXEC != 0)
+        .map(|fd| fd as isize)
+}
+
+pub fn sys_move_mount(
+    from_dirfd: i32,
+    from_path: *const c_char,
+    to_dirfd: i32,
+    to_path: *const c_char,
+    flags: u32,
+) -> AxResult<isize> {
+    if flags != MOVE_MOUNT_F_EMPTY_PATH || !vm_load_string(from_path)?.is_empty() {
+        return Err(AxError::InvalidInput);
+    }
+    if !current().as_thread().cred().has_cap_sys_admin() {
+        return Err(AxError::OperationNotPermitted);
+    }
+
+    let source = Directory::from_fd(from_dirfd)?;
+    if !source.is_detached_mount_handle() {
+        return Err(AxError::InvalidInput);
+    }
+    let path = vm_load_string(to_path)?;
+    let target = if path.starts_with('/') {
+        ax_fs_ng::vfs::current_fs_context().lock().resolve(path)?
+    } else {
+        crate::file::with_fs(to_dirfd, |fs| fs.resolve(path))?
+    };
+    source.inner().mountpoint().attach_detached(&target)?;
+    Ok(0)
 }
 
 pub fn sys_mount(

--- a/os/StarryOS/kernel/src/syscall/fs/mount.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/mount.rs
@@ -469,12 +469,15 @@ pub fn sys_move_mount(
         return Err(AxError::InvalidInput);
     }
     let path = vm_load_string(to_path)?;
+    let fs_context = ax_fs_ng::vfs::current_fs_context();
+    let mount_namespace = fs_context.lock().mount_namespace().clone();
     let target = if path.starts_with('/') {
-        ax_fs_ng::vfs::current_fs_context().lock().resolve(&path)?
+        fs_context.lock().resolve(&path)?
     } else {
         crate::file::with_fs(to_dirfd, |fs| fs.resolve(&path))?
     };
     source.inner().mountpoint().attach_detached(&target)?;
+    crate::file::notify_mount_namespace_changed(&mount_namespace);
     Ok(0)
 }
 
@@ -512,7 +515,16 @@ pub fn sys_mount_setattr(
     if !directory.inner().is_root_of_mount() {
         return Err(AxError::InvalidInput);
     }
+    let fs_context = ax_fs_ng::vfs::current_fs_context();
+    let mount_namespace = fs_context.lock().mount_namespace().clone();
+    let is_visible = mount_namespace
+        .walk_tree()
+        .into_iter()
+        .any(|(_, _, mountpoint)| Arc::ptr_eq(&mountpoint, directory.inner().mountpoint()));
     apply_mount_attributes(directory.inner().mountpoint(), &attributes);
+    if is_visible {
+        crate::file::notify_mount_namespace_changed(&mount_namespace);
+    }
     Ok(0)
 }
 
@@ -589,6 +601,8 @@ pub fn sys_mount(
         return Err(AxError::OperationNotPermitted);
     }
 
+    let fs_context = ax_fs_ng::vfs::current_fs_context();
+    let mount_namespace = fs_context.lock().mount_namespace().clone();
     let propagation = flags & PROPAGATION_FLAGS;
 
     if propagation.count_ones() > 1 {
@@ -623,6 +637,7 @@ pub fn sys_mount(
                 _ => {}
             }
         }
+        crate::file::notify_mount_namespace_changed(&mount_namespace);
         return Ok(0);
     }
 
@@ -634,24 +649,27 @@ pub fn sys_mount(
         let mp = target.mountpoint();
         mp.set_readonly((flags & MS_RDONLY) != 0);
         mp.set_mount_flags((flags & MOUNT_OPTION_FLAGS) as u32);
+        crate::file::notify_mount_namespace_changed(&mount_namespace);
         return Ok(0);
     }
 
     if (flags & MS_MOVE) != 0 {
-        let fs_context = ax_fs_ng::vfs::current_fs_context();
         let ctx = fs_context.lock();
         let source = ctx.resolve(source)?;
         let target = ctx.resolve(target)?;
         source.move_mount(&target)?;
+        drop(ctx);
+        crate::file::notify_mount_namespace_changed(&mount_namespace);
         return Ok(0);
     }
 
     if (flags & MS_BIND) != 0 {
-        let fs_context = ax_fs_ng::vfs::current_fs_context();
         let ctx = fs_context.lock();
         let source = ctx.resolve(source)?;
         let target = ctx.resolve(target)?;
         target.bind_mount(&source, (flags & MS_REC) != 0)?;
+        drop(ctx);
+        crate::file::notify_mount_namespace_changed(&mount_namespace);
         return Ok(0);
     }
 
@@ -732,6 +750,7 @@ pub fn sys_mount(
         _ => return Err(AxError::NoSuchDevice),
     }
 
+    crate::file::notify_mount_namespace_changed(&mount_namespace);
     Ok(0)
 }
 
@@ -771,12 +790,12 @@ pub fn sys_umount2(target: *const c_char, flags: i32) -> AxResult<isize> {
         return Err(AxError::NotFound);
     }
 
+    let fs_context = ax_fs_ng::vfs::current_fs_context();
+    let mount_namespace = fs_context.lock().mount_namespace().clone();
     let target = if (flags & UMOUNT_NOFOLLOW) != 0 {
-        ax_fs_ng::vfs::current_fs_context()
-            .lock()
-            .resolve_no_follow(target)?
+        fs_context.lock().resolve_no_follow(target)?
     } else {
-        ax_fs_ng::vfs::current_fs_context().lock().resolve(target)?
+        fs_context.lock().resolve(target)?
     };
 
     if !current().as_thread().cred().has_cap_sys_admin() {
@@ -794,6 +813,7 @@ pub fn sys_umount2(target: *const c_char, flags: i32) -> AxResult<isize> {
 
     if (flags & MNT_DETACH) != 0 {
         target.detach_mount()?;
+        crate::file::notify_mount_namespace_changed(&mount_namespace);
         return Ok(0);
     }
 
@@ -823,6 +843,7 @@ pub fn sys_umount2(target: *const c_char, flags: i32) -> AxResult<isize> {
         return Err(AxError::from(LinuxError::EBUSY));
     }
     target.commit_unmount(plan)?;
+    crate::file::notify_mount_namespace_changed(&mount_namespace);
 
     // After unmount, filesystem block I/O has stopped; it is safe to do VFS
     // writeback here. Propagate writeback errors so userspace sees EIO when
@@ -896,6 +917,7 @@ pub fn sys_pivot_root(new_root: *const c_char, put_old: *const c_char) -> AxResu
     // exactly matches the old root Location — mirroring Linux
     // chroot_fs_refs() in fs/namespace.c.
     ax_fs_ng::vfs::FsContext::propagate_pivot_root(&mount_namespace, &old_root, &new_root_loc);
+    crate::file::notify_mount_namespace_changed(&mount_namespace);
 
     Ok(0)
 }

--- a/os/StarryOS/kernel/src/syscall/fs/stat.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/stat.rs
@@ -20,7 +20,13 @@ use crate::{
 
 const FILE_HANDLE_BYTES: usize = size_of::<u64>() * 2;
 const FILE_HANDLE_TYPE_DEV_INO: i32 = 1;
-
+const MS_NOSUID: u32 = 1 << 1;
+const MS_NODEV: u32 = 1 << 2;
+const MS_NOEXEC: u32 = 1 << 3;
+const MS_NOATIME: u32 = 1 << 10;
+const MS_RELATIME: u32 = 1 << 21;
+const ST_RDONLY: u32 = 1;
+const ST_RELATIME: u32 = 1 << 12;
 #[repr(C)]
 pub struct FileHandleHeader {
     handle_bytes: u32,
@@ -223,10 +229,22 @@ fn statfs(loc: &Location) -> AxResult<statfs> {
     };
     result.f_namelen = stat.name_length as _;
     result.f_frsize = stat.fragment_size as _;
-    result.f_flags = stat.mount_flags as _;
+    result.f_flags = (stat.mount_flags | statfs_mount_flags(loc)) as _;
     Ok(result)
 }
 
+fn statfs_mount_flags(loc: &Location) -> u32 {
+    let mountpoint = loc.mountpoint();
+    let mount_flags = mountpoint.mount_flags();
+    let mut statfs_flags = mount_flags & (MS_NOSUID | MS_NODEV | MS_NOEXEC | MS_NOATIME);
+    if mountpoint.is_readonly() {
+        statfs_flags |= ST_RDONLY;
+    }
+    if mount_flags & MS_RELATIME != 0 {
+        statfs_flags |= ST_RELATIME;
+    }
+    statfs_flags
+}
 pub fn sys_statfs(path: *const c_char, buf: *mut statfs) -> AxResult<isize> {
     let path = vm_load_path_string(path)?;
     debug!("sys_statfs <= path: {path:?}");

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -486,6 +486,13 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg3() as _,
             uctx.arg4() as _,
         ),
+        Sysno::mount_setattr => sys_mount_setattr(
+            uctx.arg0() as _,
+            uctx.arg1() as _,
+            uctx.arg2() as _,
+            uctx.arg3() as _,
+            uctx.arg4() as _,
+        ),
 
         // pipe
         Sysno::pipe2 => sys_pipe2(uctx.arg0() as _, uctx.arg1() as _),

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -470,6 +470,22 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         ) as _,
         Sysno::umount2 => sys_umount2(uctx.arg0() as _, uctx.arg1() as _) as _,
         Sysno::pivot_root => sys_pivot_root(uctx.arg0() as _, uctx.arg1() as _) as _,
+        Sysno::fsopen => sys_fsopen(uctx.arg0() as _, uctx.arg1() as _),
+        Sysno::fsconfig => sys_fsconfig(
+            uctx.arg0() as _,
+            uctx.arg1() as _,
+            uctx.arg2() as _,
+            uctx.arg3() as _,
+            uctx.arg4() as _,
+        ),
+        Sysno::fsmount => sys_fsmount(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
+        Sysno::move_mount => sys_move_mount(
+            uctx.arg0() as _,
+            uctx.arg1() as _,
+            uctx.arg2() as _,
+            uctx.arg3() as _,
+            uctx.arg4() as _,
+        ),
 
         // pipe
         Sysno::pipe2 => sys_pipe2(uctx.arg0() as _, uctx.arg1() as _),
@@ -953,13 +969,9 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg3() as _,
         ),
 
-        // The new mount API (fsopen/fsconfig/fsmount/move_mount, plus
-        // fspick/open_tree) is not implemented. Report ENOSYS instead of
-        // handing back a dummy fd: systemd probes this API and only falls back
-        // to the classic mount(2) — which we do support — when the entry point
-        // reports "not supported". A fake fd traps it into the new path, where
-        // the follow-up fsconfig then hard-fails and aborts the mount.
-        Sysno::fsopen | Sysno::fspick | Sysno::open_tree => Err(AxError::Unsupported),
+        // fspick/open_tree remain unsupported. Report ENOSYS instead of a
+        // dummy fd so callers can select their classic-mount fallback.
+        Sysno::fspick | Sysno::open_tree => Err(AxError::Unsupported),
 
         // dummy fds
         Sysno::userfaultfd | Sysno::memfd_secret => sys_dummy_fd(sysno),

--- a/test-suit/starryos/qemu/system/bugfix-bug-mount-api-enosys/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-mount-api-enosys/src/main.c
@@ -45,13 +45,23 @@ static void expect_enosys(const char *name, long ret, int saved_errno)
     }
 }
 
+static void expect_supported_fsopen(long ret, int saved_errno)
+{
+    check(ret >= 0, "fsopen supports the bounded tmpfs filesystem context");
+    if (ret >= 0) {
+        close((int)ret);
+    } else {
+        printf("INFO: fsopen errno: %s\n", strerror(saved_errno));
+    }
+}
+
 int main(void)
 {
     long ret;
 
     errno = 0;
     ret = syscall(SYS_fsopen, "tmpfs", 0);
-    expect_enosys("fsopen", ret, errno);
+    expect_supported_fsopen(ret, errno);
 
     errno = 0;
     ret = syscall(SYS_fspick, AT_FDCWD, "/", 0);

--- a/test-suit/starryos/qemu/system/bugfix-devpts-new-mount-api/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-devpts-new-mount-api/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-devpts-new-mount-api C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-devpts-new-mount-api src/main.c)
+target_compile_options(bugfix-devpts-new-mount-api PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bugfix-devpts-new-mount-api RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-devpts-new-mount-api/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-devpts-new-mount-api/src/main.c
@@ -1,0 +1,170 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/vfs.h>
+#include <unistd.h>
+
+#ifndef SYS_move_mount
+#define SYS_move_mount 429
+#endif
+#ifndef SYS_fsopen
+#define SYS_fsopen 430
+#endif
+#ifndef SYS_fsconfig
+#define SYS_fsconfig 431
+#endif
+#ifndef SYS_fsmount
+#define SYS_fsmount 432
+#endif
+
+#define FSOPEN_CLOEXEC 0x00000001
+#define FSMOUNT_CLOEXEC 0x00000001
+#define FSCONFIG_SET_FLAG 0
+#define FSCONFIG_SET_STRING 1
+#define FSCONFIG_CMD_CREATE 6
+#define MOVE_MOUNT_F_EMPTY_PATH 0x00000004
+
+#define DEVPTS_SUPER_MAGIC 0x1cd1
+#define MOUNT_PATH "/tmp/bugfix-devpts-new-mount-api"
+
+static int failures;
+
+static void check(int condition, const char *message)
+{
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n", message, errno,
+            strerror(errno));
+    failures++;
+}
+
+static void set_string_option(int fsfd, const char *key, const char *value,
+                              const char *message)
+{
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, key, value, 0) == 0,
+          message);
+}
+
+static void verify_devpts_mount(void)
+{
+    struct statfs filesystem;
+    struct stat metadata;
+
+    errno = 0;
+    int result = statfs(MOUNT_PATH, &filesystem);
+    check(result == 0, "statfs reports the attached devpts mount");
+    if (result == 0) {
+        check((unsigned long)filesystem.f_type == DEVPTS_SUPER_MAGIC,
+              "statfs exposes the devpts filesystem identity");
+    }
+
+    errno = 0;
+    result = stat(MOUNT_PATH "/ptmx", &metadata);
+    check(result == 0, "devpts exposes its ptmx node");
+    if (result == 0) {
+        check((metadata.st_mode & 07777) == 0666,
+              "ptmxmode applies through the new mount API");
+    }
+
+    int master = open(MOUNT_PATH "/ptmx", O_RDWR | O_NOCTTY);
+    check(master >= 0, "open allocates a PTY through the new devpts instance");
+    if (master < 0) {
+        return;
+    }
+
+    unsigned int number = ~0U;
+    errno = 0;
+    check(ioctl(master, TIOCGPTN, &number) == 0,
+          "TIOCGPTN reports the allocated PTY number");
+
+    char slave_path[128];
+    int length =
+        snprintf(slave_path, sizeof(slave_path), "%s/%u", MOUNT_PATH, number);
+    check(length > 0 && (size_t)length < sizeof(slave_path),
+          "format the allocated slave path");
+    if (length > 0 && (size_t)length < sizeof(slave_path)) {
+        errno = 0;
+        result = stat(slave_path, &metadata);
+        check(result == 0, "the allocated slave appears in the new instance");
+        if (result == 0) {
+            check((metadata.st_mode & 07777) == 0620,
+                  "mode applies through the new mount API");
+            check(metadata.st_gid == 5,
+                  "gid applies through the new mount API");
+        }
+    }
+    close(master);
+}
+
+int main(void)
+{
+    if (mkdir(MOUNT_PATH, 0755) != 0 && errno != EEXIST) {
+        check(0, "create the devpts mountpoint");
+    }
+
+    errno = 0;
+    int fsfd = syscall(SYS_fsopen, "devpts", FSOPEN_CLOEXEC);
+    check(fsfd >= 0, "fsopen creates a devpts filesystem context");
+    if (fsfd >= 0) {
+        set_string_option(fsfd, "source", "devpts",
+                          "fsconfig records the devpts mount source");
+        set_string_option(fsfd, "mode", "0620",
+                          "fsconfig accepts the devpts slave mode");
+        set_string_option(fsfd, "gid", "5",
+                          "fsconfig accepts the devpts slave gid");
+        set_string_option(fsfd, "ptmxmode", "0666",
+                          "fsconfig accepts the devpts ptmx mode");
+
+        errno = 0;
+        check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_FLAG, "newinstance",
+                      NULL, 0) == 0,
+              "fsconfig accepts the devpts newinstance flag");
+
+        errno = 0;
+        check(syscall(SYS_fsconfig, fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0) ==
+                  0,
+              "fsconfig creates the configured devpts instance");
+
+        int mountfd = -1;
+        if (failures == 0) {
+            errno = 0;
+            mountfd = syscall(SYS_fsmount, fsfd, FSMOUNT_CLOEXEC, 0);
+            check(mountfd >= 0, "fsmount creates a detached devpts mount");
+        }
+        if (mountfd >= 0) {
+            errno = 0;
+            check(syscall(SYS_move_mount, mountfd, "", AT_FDCWD, MOUNT_PATH,
+                          MOVE_MOUNT_F_EMPTY_PATH) == 0,
+                  "move_mount attaches the devpts mount");
+            if (failures == 0) {
+                verify_devpts_mount();
+            }
+            close(mountfd);
+        }
+        close(fsfd);
+    }
+
+    if (syscall(SYS_umount2, MOUNT_PATH, 0) == 0) {
+        rmdir(MOUNT_PATH);
+    }
+
+    if (failures != 0) {
+        fprintf(stderr, "STARRY_DEVPTS_NEW_MOUNT_API_FAILED: %d checks\n",
+                failures);
+        return 1;
+    }
+
+    puts("STARRY_DEVPTS_NEW_MOUNT_API_PASSED");
+    return 0;
+}

--- a/test-suit/starryos/qemu/system/bugfix-mount-setattr/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-mount-setattr/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-mount-setattr C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-mount-setattr src/main.c)
+target_compile_options(bugfix-mount-setattr PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bugfix-mount-setattr RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-mount-setattr/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-mount-setattr/src/main.c
@@ -1,0 +1,247 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/sysinfo.h>
+#include <sys/vfs.h>
+#include <unistd.h>
+
+#ifndef SYS_move_mount
+#define SYS_move_mount 429
+#endif
+#ifndef SYS_fsopen
+#define SYS_fsopen 430
+#endif
+#ifndef SYS_fsconfig
+#define SYS_fsconfig 431
+#endif
+#ifndef SYS_fsmount
+#define SYS_fsmount 432
+#endif
+#ifndef SYS_mount_setattr
+#define SYS_mount_setattr 442
+#endif
+
+#define FSOPEN_CLOEXEC 0x00000001
+#define FSMOUNT_CLOEXEC 0x00000001
+#define FSCONFIG_SET_STRING 1
+#define FSCONFIG_CMD_CREATE 6
+#define MOVE_MOUNT_F_EMPTY_PATH 0x00000004
+#define AT_EMPTY_PATH 0x1000
+
+#define MOUNT_ATTR_NOSUID 0x00000002
+#define MOUNT_ATTR_NODEV 0x00000004
+#define MOUNT_ATTR__ATIME 0x00000070
+#define MOUNT_ATTR_STRICTATIME 0x00000020
+
+#ifndef ST_NOSUID
+#define ST_NOSUID 0x00000002
+#endif
+#ifndef ST_NODEV
+#define ST_NODEV 0x00000004
+#endif
+#define MOUNT_PATH "/tmp/bugfix-mount-setattr"
+#define TMPFS_MOUNT_PATH "/tmp/bugfix-mount-setattr-tmpfs"
+
+struct mount_attr {
+    uint64_t attr_set;
+    uint64_t attr_clr;
+    uint64_t propagation;
+    uint64_t userns_fd;
+};
+
+static int failures;
+
+static void check(int condition, const char *message)
+{
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n", message, errno,
+            strerror(errno));
+    failures++;
+}
+
+static void check_syscall_availability_probe(void)
+{
+    errno = 0;
+    check(syscall(SYS_mount_setattr, -1, NULL, 0, NULL, 0) == 0,
+          "mount_setattr accepts the util-linux availability probe");
+}
+
+static int create_detached_ramfs(void)
+{
+    int fsfd = syscall(SYS_fsopen, "ramfs", FSOPEN_CLOEXEC);
+    check(fsfd >= 0, "fsopen creates a ramfs filesystem context");
+    if (fsfd < 0) {
+        return -1;
+    }
+
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, "source", "ramfs",
+                  0) == 0,
+          "fsconfig records the ramfs mount source");
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, "mode", "0750", 0) ==
+              0,
+          "fsconfig sets the ramfs root mode");
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0) == 0,
+          "fsconfig creates the ramfs");
+
+    int mountfd = -1;
+    if (failures == 0) {
+        mountfd = syscall(SYS_fsmount, fsfd, FSMOUNT_CLOEXEC, 0);
+        check(mountfd >= 0, "fsmount creates a detached ramfs mount");
+    }
+    close(fsfd);
+    return mountfd;
+}
+
+static int create_detached_sized_tmpfs(void)
+{
+    int fsfd = syscall(SYS_fsopen, "tmpfs", FSOPEN_CLOEXEC);
+    check(fsfd >= 0, "fsopen creates a tmpfs filesystem context");
+    if (fsfd < 0) {
+        return -1;
+    }
+
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, "source", "tmpfs",
+                  0) == 0,
+          "fsconfig records the tmpfs mount source");
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, "mode", "0755", 0) ==
+              0,
+          "fsconfig sets the tmpfs root mode");
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, "size", "25%", 0) ==
+              0,
+          "fsconfig accepts the NixOS /run tmpfs size");
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0) == 0,
+          "fsconfig creates the sized NixOS /run tmpfs");
+
+    int mountfd = -1;
+    if (failures == 0) {
+        mountfd = syscall(SYS_fsmount, fsfd, FSMOUNT_CLOEXEC, 0);
+        check(mountfd >= 0, "fsmount creates the sized detached tmpfs");
+    }
+    close(fsfd);
+    return mountfd;
+}
+
+static void apply_mount_attributes(int mountfd)
+{
+    struct mount_attr attributes = {
+        .attr_set =
+            MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV | MOUNT_ATTR_STRICTATIME,
+        .attr_clr = MOUNT_ATTR__ATIME,
+    };
+
+    errno = 0;
+    check(syscall(SYS_mount_setattr, mountfd, "", AT_EMPTY_PATH, &attributes,
+                  sizeof(attributes) - 1) == -1 &&
+              errno == EINVAL,
+          "mount_setattr rejects a short mount_attr structure");
+
+    errno = 0;
+    check(syscall(SYS_mount_setattr, mountfd, "", AT_EMPTY_PATH << 1,
+                  &attributes, sizeof(attributes)) == -1 &&
+              errno == EINVAL,
+          "mount_setattr rejects unknown lookup flags");
+
+    errno = 0;
+    check(syscall(SYS_mount_setattr, mountfd, "", AT_EMPTY_PATH, &attributes,
+                  sizeof(attributes)) == 0,
+          "mount_setattr applies VFS attributes to a detached mount");
+}
+
+static void attach_and_verify(int mountfd)
+{
+    struct statfs filesystem;
+
+    errno = 0;
+    check(syscall(SYS_move_mount, mountfd, "", AT_FDCWD, MOUNT_PATH,
+                  MOVE_MOUNT_F_EMPTY_PATH) == 0,
+          "move_mount attaches the attributed mount");
+
+    errno = 0;
+    int result = statfs(MOUNT_PATH, &filesystem);
+    check(result == 0, "statfs reports the attached mount");
+    if (result == 0) {
+        unsigned long required = ST_NOSUID | ST_NODEV;
+        check(((unsigned long)filesystem.f_flags & required) == required,
+              "statfs exposes nosuid and nodev");
+    }
+}
+
+int main(void)
+{
+    check_syscall_availability_probe();
+
+    if (mkdir(TMPFS_MOUNT_PATH, 0755) != 0 && errno != EEXIST) {
+        check(0, "create the sized tmpfs mountpoint");
+    } else {
+        int tmpfs_mountfd = create_detached_sized_tmpfs();
+        if (tmpfs_mountfd >= 0) {
+            errno = 0;
+            check(syscall(SYS_move_mount, tmpfs_mountfd, "", AT_FDCWD,
+                          TMPFS_MOUNT_PATH, MOVE_MOUNT_F_EMPTY_PATH) == 0,
+                  "move_mount attaches the sized tmpfs");
+            struct statfs filesystem;
+            struct sysinfo memory;
+            errno = 0;
+            int stat_result = statfs(TMPFS_MOUNT_PATH, &filesystem);
+            check(stat_result == 0, "statfs reports the sized tmpfs");
+            errno = 0;
+            int sysinfo_result = sysinfo(&memory);
+            check(sysinfo_result == 0, "sysinfo reports total memory");
+            if (stat_result == 0 && sysinfo_result == 0) {
+                uint64_t total_bytes =
+                    (uint64_t)memory.totalram * memory.mem_unit;
+                uint64_t expected_blocks =
+                    ((total_bytes / 4) + filesystem.f_bsize - 1) /
+                    filesystem.f_bsize;
+                check((uint64_t)filesystem.f_blocks == expected_blocks,
+                      "statfs preserves the 25% tmpfs size limit");
+            }
+            close(tmpfs_mountfd);
+        }
+        if (syscall(SYS_umount2, TMPFS_MOUNT_PATH, 0) == 0) {
+            rmdir(TMPFS_MOUNT_PATH);
+        }
+    }
+
+    if (mkdir(MOUNT_PATH, 0755) != 0 && errno != EEXIST) {
+        check(0, "create the mountpoint");
+    } else {
+        int mountfd = create_detached_ramfs();
+        if (mountfd >= 0) {
+            apply_mount_attributes(mountfd);
+            if (failures == 0) {
+                attach_and_verify(mountfd);
+            }
+            close(mountfd);
+        }
+
+        if (syscall(SYS_umount2, MOUNT_PATH, 0) == 0) {
+            rmdir(MOUNT_PATH);
+        }
+    }
+
+    if (failures != 0) {
+        fprintf(stderr, "STARRY_MOUNT_SETATTR_FAILED: %d checks\n", failures);
+        return 1;
+    }
+
+    puts("STARRY_MOUNT_SETATTR_PASSED");
+    return 0;
+}

--- a/test-suit/starryos/qemu/system/bugfix-mountinfo-poll-notify/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-mountinfo-poll-notify/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-mountinfo-poll-notify C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-mountinfo-poll-notify src/main.c)
+target_compile_options(bugfix-mountinfo-poll-notify PRIVATE -Wall -Wextra -Werror)
+install(
+    TARGETS bugfix-mountinfo-poll-notify
+    RUNTIME DESTINATION usr/bin/starry-test-suit
+)

--- a/test-suit/starryos/qemu/system/bugfix-mountinfo-poll-notify/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-mountinfo-poll-notify/src/main.c
@@ -1,0 +1,142 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define MOUNTINFO_PATH "/proc/self/mountinfo"
+#define MOUNT_PATH "/tmp/bugfix-mountinfo-poll-notify"
+#define MOUNTINFO_SIZE (128 * 1024)
+
+static char mountinfo[MOUNTINFO_SIZE];
+
+static void fail(const char *operation)
+{
+    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n", operation, errno,
+            strerror(errno));
+    exit(EXIT_FAILURE);
+}
+
+static ssize_t read_mountinfo_from_start(int fd)
+{
+    size_t total = 0;
+
+    if (lseek(fd, 0, SEEK_SET) != 0) {
+        return -1;
+    }
+    while (total + 1 < sizeof(mountinfo)) {
+        ssize_t count =
+            read(fd, mountinfo + total, sizeof(mountinfo) - total - 1);
+        if (count < 0) {
+            return -1;
+        }
+        if (count == 0) {
+            mountinfo[total] = '\0';
+            return (ssize_t)total;
+        }
+        total += (size_t)count;
+    }
+
+    errno = ENOSPC;
+    return -1;
+}
+
+static int create_and_attach_tmpfs(void)
+{
+    int result = mount("tmpfs", MOUNT_PATH, "tmpfs", 0, "");
+    if (result < 0) {
+        perror("mount tmpfs");
+    }
+    return result;
+}
+
+int main(void)
+{
+    puts("mountinfo poll notification regression");
+
+    if (mkdir(MOUNT_PATH, 0755) < 0 && errno != EEXIST) {
+        fail("mkdir mountpoint");
+    }
+
+    int mountinfo_fd = open(MOUNTINFO_PATH, O_RDONLY | O_CLOEXEC);
+    if (mountinfo_fd < 0) {
+        fail("open mountinfo");
+    }
+    if (read_mountinfo_from_start(mountinfo_fd) < 0) {
+        fail("read initial mountinfo");
+    }
+
+    struct pollfd monitor = {
+        .fd = mountinfo_fd,
+        .events = POLLPRI,
+    };
+    if (poll(&monitor, 1, 0) != 0) {
+        errno = EPROTO;
+        fail("mountinfo has a spurious initial change event");
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        fail("fork mount helper");
+    }
+    if (child == 0) {
+        if (create_and_attach_tmpfs() < 0) {
+            fail("child mount");
+        }
+        _exit(EXIT_SUCCESS);
+    }
+
+    int status;
+    if (waitpid(child, &status, 0) != child || !WIFEXITED(status) ||
+        WEXITSTATUS(status) != 0) {
+        errno = ECHILD;
+        fail("wait for mount helper");
+    }
+
+    monitor.revents = 0;
+    int ready = poll(&monitor, 1, 1000);
+    if (ready < 0) {
+        fail("poll mountinfo change");
+    }
+    if (ready != 1 ||
+        (monitor.revents & (POLLPRI | POLLERR)) != (POLLPRI | POLLERR)) {
+        fprintf(stderr,
+                "FAIL: mountinfo change event: ready=%d revents=%#x expected "
+                "POLLPRI|POLLERR\n",
+                ready, monitor.revents);
+        return EXIT_FAILURE;
+    }
+
+    monitor.revents = 0;
+    if (poll(&monitor, 1, 0) != 0) {
+        errno = EPROTO;
+        fail("mountinfo repeated an already consumed change event");
+    }
+
+    if (read_mountinfo_from_start(mountinfo_fd) < 0) {
+        fail("reread mountinfo after child mount");
+    }
+    if (strstr(mountinfo, " " MOUNT_PATH " ") == NULL) {
+        errno = ENOENT;
+        fail("parent mountinfo contains child mount");
+    }
+
+    close(mountinfo_fd);
+    if (umount2(MOUNT_PATH, 0) < 0) {
+        fail("unmount test tmpfs");
+    }
+    if (rmdir(MOUNT_PATH) < 0) {
+        fail("remove mountpoint");
+    }
+
+    puts("PASS: parent observed child mount through mountinfo notification");
+    puts("STARRY_MOUNTINFO_POLL_NOTIFY_PASSED");
+    return EXIT_SUCCESS;
+}

--- a/test-suit/starryos/qemu/system/bugfix-new-mount-api-credentials/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-new-mount-api-credentials/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-new-mount-api-credentials C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-new-mount-api-credentials src/main.c)
+target_compile_options(bugfix-new-mount-api-credentials PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bugfix-new-mount-api-credentials RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-new-mount-api-credentials/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-new-mount-api-credentials/src/main.c
@@ -1,0 +1,191 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef SYS_move_mount
+#define SYS_move_mount 429
+#endif
+#ifndef SYS_fsopen
+#define SYS_fsopen 430
+#endif
+#ifndef SYS_fsconfig
+#define SYS_fsconfig 431
+#endif
+#ifndef SYS_fsmount
+#define SYS_fsmount 432
+#endif
+
+#define FSOPEN_CLOEXEC 0x00000001
+#define FSMOUNT_CLOEXEC 0x00000001
+#define FSCONFIG_SET_FLAG 0
+#define FSCONFIG_SET_STRING 1
+#define FSCONFIG_CMD_CREATE 6
+#define FSCONFIG_CMD_RECONFIGURE 7
+#define MOVE_MOUNT_F_EMPTY_PATH 0x00000004
+#define MOUNT_ATTR_NOSUID 0x00000002
+#define MOUNT_ATTR_NODEV 0x00000004
+#define MOUNT_ATTR_NOEXEC 0x00000008
+#define MOUNT_ATTR_NOSYMFOLLOW 0x00200000
+
+#define CREDENTIAL_MOUNT_PATH "/tmp/bugfix-new-mount-api-credentials"
+#define CREDENTIAL_NAME "stage2-proof"
+
+static int failures;
+
+static void check(int condition, const char *message)
+{
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n", message, errno,
+            strerror(errno));
+    failures++;
+}
+
+static int configure_credentials_fs(void)
+{
+    int fsfd = syscall(SYS_fsopen, "tmpfs", FSOPEN_CLOEXEC);
+    check(fsfd >= 0, "fsopen creates a tmpfs filesystem context");
+    if (fsfd < 0) {
+        return -1;
+    }
+
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, "nr_inodes",
+                  "1024", 0) == 0,
+          "fsconfig accepts the credential inode limit");
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, "size", "1M", 0) ==
+              0,
+          "fsconfig accepts the credential size limit");
+    errno = 0;
+    long noswap =
+        syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_FLAG, "noswap", NULL, 0);
+    check(noswap == 0 || (noswap < 0 && errno == EINVAL),
+          "fsconfig either accepts noswap or requests the ramfs fallback");
+    if (noswap < 0 && errno == EINVAL) {
+        close(fsfd);
+        fsfd = syscall(SYS_fsopen, "ramfs", FSOPEN_CLOEXEC);
+        check(fsfd >= 0, "fsopen creates the systemd ramfs fallback context");
+        if (fsfd < 0) {
+            return -1;
+        }
+    }
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_STRING, "mode", "0700", 0) ==
+              0,
+          "fsconfig accepts the credential root mode");
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_CMD_CREATE, NULL, NULL, 0) == 0,
+          "fsconfig creates the configured filesystem");
+    if (failures != 0) {
+        close(fsfd);
+        return -1;
+    }
+    return fsfd;
+}
+
+static int mount_credentials_fs(int fsfd)
+{
+    unsigned int attributes = MOUNT_ATTR_NOSUID | MOUNT_ATTR_NODEV |
+                              MOUNT_ATTR_NOEXEC | MOUNT_ATTR_NOSYMFOLLOW;
+    int mfd = syscall(SYS_fsmount, fsfd, FSMOUNT_CLOEXEC, attributes);
+    if (mfd < 0 && errno == EINVAL) {
+        attributes &= ~MOUNT_ATTR_NOSYMFOLLOW;
+        mfd = syscall(SYS_fsmount, fsfd, FSMOUNT_CLOEXEC, attributes);
+    }
+    check(mfd >= 0, "fsmount creates a detached credentials mount");
+    return mfd;
+}
+
+static void populate_and_attach(int fsfd, int mfd)
+{
+    static const char expected[] = "starrynixos-stage2";
+    char observed[sizeof(expected)] = {0};
+
+    int dfd = openat(mfd, ".", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    check(dfd >= 0, "detached mount fd can be reopened as a directory");
+    if (dfd >= 0) {
+        int fd = openat(dfd, CREDENTIAL_NAME,
+                        O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0400);
+        check(fd >= 0, "credential file can be created before attachment");
+        if (fd >= 0) {
+            check(write(fd, expected, sizeof(expected)) ==
+                      (ssize_t)sizeof(expected),
+                  "credential content can be written before attachment");
+            close(fd);
+        }
+        close(dfd);
+    }
+
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_SET_FLAG, "ro", NULL, 0) == 0,
+          "fsconfig accepts the read-only reconfiguration flag");
+    errno = 0;
+    check(syscall(SYS_fsconfig, fsfd, FSCONFIG_CMD_RECONFIGURE, NULL, NULL, 0) ==
+              0,
+          "fsconfig commits read-only reconfiguration");
+
+    errno = 0;
+    check(syscall(SYS_move_mount, mfd, "", AT_FDCWD, CREDENTIAL_MOUNT_PATH,
+                  MOVE_MOUNT_F_EMPTY_PATH) == 0,
+          "move_mount attaches the detached credentials mount");
+
+    int fd = open(CREDENTIAL_MOUNT_PATH "/" CREDENTIAL_NAME,
+                  O_RDONLY | O_CLOEXEC);
+    check(fd >= 0, "attached credential file is visible by path");
+    if (fd >= 0) {
+        check(read(fd, observed, sizeof(observed)) == (ssize_t)sizeof(expected) &&
+                  memcmp(observed, expected, sizeof(expected)) == 0,
+              "attached credential content survives the move");
+        close(fd);
+    }
+
+    errno = 0;
+    fd = open(CREDENTIAL_MOUNT_PATH "/must-stay-read-only",
+              O_CREAT | O_WRONLY | O_CLOEXEC, 0600);
+    check(fd < 0 && errno == EROFS,
+          "reconfigured credential mount rejects new writes");
+    if (fd >= 0) {
+        close(fd);
+    }
+}
+
+int main(void)
+{
+    if (mkdir(CREDENTIAL_MOUNT_PATH, 0755) != 0 && errno != EEXIST) {
+        check(0, "create the credentials mountpoint");
+    } else {
+        int fsfd = configure_credentials_fs();
+        if (fsfd >= 0) {
+            int mfd = mount_credentials_fs(fsfd);
+            if (mfd >= 0) {
+                populate_and_attach(fsfd, mfd);
+                close(mfd);
+            }
+            close(fsfd);
+        }
+
+        if (syscall(SYS_umount2, CREDENTIAL_MOUNT_PATH, 0) == 0) {
+            rmdir(CREDENTIAL_MOUNT_PATH);
+        }
+    }
+
+    if (failures != 0) {
+        fprintf(stderr, "STARRY_NEW_MOUNT_API_CREDENTIALS_FAILED: %d checks\n",
+                failures);
+        return 1;
+    }
+
+    puts("STARRY_NEW_MOUNT_API_CREDENTIALS_PASSED");
+    return 0;
+}

--- a/test-suit/starryos/qemu/system/bugfix-ramfs-mount/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-ramfs-mount/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-ramfs-mount C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-ramfs-mount src/main.c)
+target_compile_options(bugfix-ramfs-mount PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bugfix-ramfs-mount RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-ramfs-mount/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-ramfs-mount/src/main.c
@@ -1,0 +1,109 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/vfs.h>
+#include <unistd.h>
+
+#define RAMFS_MAGIC 0x858458f6
+#define RAMFS_MOUNT_PATH "/tmp/bugfix-ramfs-mount"
+#define RAMFS_TEST_FILE RAMFS_MOUNT_PATH "/round-trip"
+
+static int failures;
+
+static void check(int condition, const char *message)
+{
+    if (condition) {
+        printf("PASS: %s\n", message);
+        return;
+    }
+
+    fprintf(stderr, "FAIL: %s: errno=%d (%s)\n", message, errno,
+            strerror(errno));
+    failures++;
+}
+
+static int check_ramfs_mount(void)
+{
+    struct statfs filesystem;
+
+    errno = 0;
+    long result = syscall(SYS_mount, "none", RAMFS_MOUNT_PATH, "ramfs", 0,
+                          NULL);
+    check(result == 0, "mount(2) accepts the ramfs filesystem type");
+    if (result != 0) {
+        return 0;
+    }
+
+    errno = 0;
+    result = statfs(RAMFS_MOUNT_PATH, &filesystem);
+    check(result == 0, "statfs reports the mounted ramfs");
+    if (result == 0) {
+        check((unsigned long)filesystem.f_type == RAMFS_MAGIC,
+              "ramfs exposes RAMFS_MAGIC instead of TMPFS_MAGIC");
+    }
+    return 1;
+}
+
+static void check_file_round_trip(void)
+{
+    static const char expected[] = "starrynixos-ramfs";
+    char observed[sizeof(expected)] = {0};
+
+    errno = 0;
+    int fd = open(RAMFS_TEST_FILE, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC,
+                  0600);
+    check(fd >= 0, "create a regular file on ramfs");
+    if (fd < 0) {
+        return;
+    }
+
+    errno = 0;
+    ssize_t length = write(fd, expected, sizeof(expected));
+    check(length == (ssize_t)sizeof(expected), "write file content on ramfs");
+
+    errno = 0;
+    check(lseek(fd, 0, SEEK_SET) == 0, "seek to the start of a ramfs file");
+
+    errno = 0;
+    length = read(fd, observed, sizeof(observed));
+    check(length == (ssize_t)sizeof(expected) &&
+              memcmp(observed, expected, sizeof(expected)) == 0,
+          "read back file content from ramfs");
+    close(fd);
+    unlink(RAMFS_TEST_FILE);
+}
+
+static void check_ramfs_unmount(void)
+{
+    errno = 0;
+    check(syscall(SYS_umount2, RAMFS_MOUNT_PATH, 0) == 0,
+          "umount2 removes the ramfs mount");
+}
+
+int main(void)
+{
+    if (mkdir(RAMFS_MOUNT_PATH, 0755) != 0 && errno != EEXIST) {
+        check(0, "create the ramfs mountpoint");
+    } else {
+        int mounted = check_ramfs_mount();
+        if (mounted) {
+            check_file_round_trip();
+            check_ramfs_unmount();
+        }
+        rmdir(RAMFS_MOUNT_PATH);
+    }
+
+    if (failures != 0) {
+        fprintf(stderr, "STARRY_RAMFS_MOUNT_FAILED: %d checks\n", failures);
+        return 1;
+    }
+
+    puts("STARRY_RAMFS_MOUNT_PASSED");
+    return 0;
+}


### PR DESCRIPTION
## 问题

StarryOS 的挂载兼容性缺少一组相互关联的 Linux 语义：

- legacy `mount(2)` 不识别 `ramfs`；
- new mount API 缺少 credential tmpfs/ramfs context、sized tmpfs、`mount_setattr` 和 devpts context；
- `/proc/*/mountinfo` 文件不能通过 `poll()` 感知 mount table 变化。

mountinfo 通知依赖正确维护并发布挂载表变化；credential、sized memory mount 和 devpts 又共享 `fsopen`/`fsconfig`/`fsmount`/`move_mount` 状态机，因此放在同一分支按依赖顺序提交，避免拆出只能部分构建或无法完整验证的 PR。

本 PR 分支名为 `fix/starry-ramfs-mount-from-004`，内容从 `004-add-starry-nixos` 分支拆出，均通过 `git cherry-pick` 保留原实现和回归测试：

- ramfs mounts：原提交 `977b4a19f`，PR 分支提交 `de06d43bd`；
- credential mount contexts：原提交 `3bf901b56`，PR 分支提交 `eaa9c13ee`；
- sized memory mounts：原提交 `84f048b8c`，PR 分支提交 `9ad55435c`；
- devpts mount contexts：原提交 `745601961`，PR 分支提交 `641d05a82`；
- mount table poll notification：原提交 `e40e93553`，PR 分支提交 `e6e1a36da`。

上游目录调整由 Git 在 cherry-pick 时自动映射。004/NixOS 专属进度与 compatibility 文档未带入；Rust 实现和回归测试未重新实现。

## 修改

- 为 legacy mount 路径注册 `ramfs`，提供独立的 `RAMFS_MAGIC`，并支持文件扩展、读写和卸载。
- 实现 credential tmpfs/ramfs filesystem context，支持 inode/size 限制、root mode、只读 reconfigure 和 detached mount attachment。
- 支持 tmpfs size 配置、mount source、`mount_setattr` VFS 属性及对应 `statfs` 结果。
- 为 devpts 接入 new mount API，支持 `mode`、`gid`、`ptmxmode`、`newinstance` 和 PTY 分配。
- 将 mountinfo 暴露为可轮询的 mount table 文件对象，在 mount、move_mount 和 umount 变化时通知 poller。
- 新增并接入 ramfs、credentials、mount_setattr、devpts、mountinfo poll 五个 QEMU 系统回归用例。

## 设计与替代方案

实现继续沿用现有 VFS mount namespace、伪文件系统和 syscall mount 状态机，不新增平行挂载框架。各 filesystem context 只在已有 `fsopen`/`fsconfig` 分派处增加对应类型和参数，mountinfo 通知则由统一 mount table 变更入口发布。

将 mountinfo 单独实现为 procfs 特例会让挂载状态出现第二个通知源，也无法覆盖 `move_mount`、legacy mount 和 umount 的统一语义；在 mount table 边界维护变更序列和 poll wakeup 能让所有观察者得到同一状态来源。

## 验证

使用项目 Podman 镜像和主工作区 `.ci-cache` 执行：

```text
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-ramfs-mount
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-new-mount-api-credentials
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-mount-setattr
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-devpts-new-mount-api
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-mountinfo-poll-notify
```

- ramfs 红测：`mount(2)` 返回 `ENODEV`；绿测 8/8 通过。
- credentials 红测：`fsopen(tmpfs)` 返回 `ENOSYS`；绿测 17/17 通过。
- sized mounts 红测：`mount_setattr` 返回 `ENOSYS`，tmpfs/ramfs source 与 sized tmpfs create 共 4 项失败；绿测 22/22 通过。
- devpts 红测：`fsopen("devpts")` 返回 `ENODEV`；绿测 19/19 通过。
- mountinfo 红测：mount table 变化后 `poll()` 未返回 `POLLPRI|POLLERR`；绿测观察到 child mount 通知并通过。
- 最终 HEAD 重新运行上述 5 个 focused 用例，全部 QEMU 汇总 `1/1` 通过。
- `cargo fmt --all -- --check` 通过。
- `git diff --check` 通过。

clippy 由 PR CI 执行。
