### PR TITLE
fix(ax-net): complete Unix socket introspection and credentials

### DIFF
--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -113,7 +113,7 @@ pub use self::{
     router::NetDevStats,
     socket::{
         CMsgData, IpCmsg, RecvFlags, RecvOptions, SendFlags, SendOptions, Shutdown, Socket,
-        SocketAddrEx, SocketOps,
+        SocketAddrEx, SocketCmsg, SocketOps,
     },
 };
 

--- a/net/ax-net/src/options.rs
+++ b/net/ax-net/src/options.rs
@@ -139,7 +139,7 @@ macro_rules! define_options {
 
 /// Corresponds to `struct ucred` in Linux.
 #[repr(C)]
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnixCredentials {
     /// Process ID.
     pub pid: u32,

--- a/net/ax-net/src/options.rs
+++ b/net/ax-net/src/options.rs
@@ -172,6 +172,7 @@ define_options! {
     ReceiveTimeout(Duration),
     SendBufferForce(usize),
     PassCredentials(bool),
+    ReceiveTimestamp(bool),
     PeerCredentials(UnixCredentials),
     SocketType(i32),
     SocketProtocol(i32),

--- a/net/ax-net/src/socket.rs
+++ b/net/ax-net/src/socket.rs
@@ -254,6 +254,10 @@ pub trait SocketOps: Configurable {
     fn listen(&self, _backlog: usize) -> AxResult {
         Err(AxError::OperationNotSupported)
     }
+    /// Returns whether this socket currently accepts incoming connections.
+    fn is_listening(&self) -> bool {
+        false
+    }
     /// Accepts a connection on a listening socket, returning a new socket.
     fn accept(&self) -> AxResult<Socket> {
         Err(AxError::OperationNotSupported)
@@ -288,6 +292,10 @@ impl<T: SocketOps + ?Sized> SocketOps for Box<T> {
 
     fn listen(&self, backlog: usize) -> AxResult {
         (**self).listen(backlog)
+    }
+
+    fn is_listening(&self) -> bool {
+        (**self).is_listening()
     }
 
     fn accept(&self) -> AxResult<Socket> {

--- a/net/ax-net/src/socket.rs
+++ b/net/ax-net/src/socket.rs
@@ -36,7 +36,7 @@ use enum_dispatch::enum_dispatch;
 #[cfg(feature = "vsock")]
 use crate::vsock::{VsockAddr, VsockSocket};
 use crate::{
-    options::{Configurable, GetSocketOption, SetSocketOption},
+    options::{Configurable, GetSocketOption, SetSocketOption, UnixCredentials},
     raw::RawSocket,
     tcp::TcpSocket,
     udp::UdpSocket,
@@ -180,6 +180,8 @@ pub enum IpCmsg {
 /// `recvmsg`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SocketCmsg {
+    /// Sender credentials requested with `SO_PASSCRED`.
+    Credentials(UnixCredentials),
     /// Wall-clock receive timestamp requested with `SO_TIMESTAMP`.
     Timestamp(Duration),
 }
@@ -195,6 +197,8 @@ pub struct SendOptions {
     pub flags: SendFlags,
     /// Ancillary control messages.
     pub cmsg: Vec<CMsgData>,
+    /// Real credentials of the task performing this send operation.
+    pub sender_credentials: Option<UnixCredentials>,
 }
 
 /// Options for receiving data from a socket.

--- a/net/ax-net/src/socket.rs
+++ b/net/ax-net/src/socket.rs
@@ -24,6 +24,7 @@ use core::{
     fmt::{self, Debug},
     net::SocketAddr,
     task::Context,
+    time::Duration,
 };
 
 use ax_errno::{AxError, AxResult, LinuxError};
@@ -173,6 +174,14 @@ pub enum IpCmsg {
     Ipv4Tos(u8),
     /// IPv6 traffic-class byte for `IPV6_RECVTCLASS`.
     Ipv6TrafficClass(u8),
+}
+
+/// Transport-independent socket-level ancillary data reported through
+/// `recvmsg`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SocketCmsg {
+    /// Wall-clock receive timestamp requested with `SO_TIMESTAMP`.
+    Timestamp(Duration),
 }
 
 /// Options for sending data to a socket.

--- a/net/ax-net/src/tcp.rs
+++ b/net/ax-net/src/tcp.rs
@@ -543,6 +543,10 @@ impl SocketOps for TcpSocket {
         Ok(())
     }
 
+    fn is_listening(&self) -> bool {
+        self.state.get() == State::Listening
+    }
+
     fn accept(&self) -> AxResult<Socket> {
         if self.state.get() != State::Listening {
             ax_bail!(InvalidInput, "not listening");

--- a/net/ax-net/src/unix/dgram.rs
+++ b/net/ax-net/src/unix/dgram.rs
@@ -19,18 +19,23 @@
 //! global smoltcp socket set.
 
 use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use core::task::Context;
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    task::Context,
+    time::Duration,
+};
 
 use async_channel::TryRecvError;
 use async_trait::async_trait;
 use ax_errno::{AxError, AxResult};
+use ax_hal::time::wall_time;
 use ax_io::{Read, Write};
 use ax_kspin::SpinRwLock as RwLock;
 use ax_sync::Mutex;
 use axpoll::{IoEvents, PollSet, Pollable};
 
 use crate::{
-    CMsgData, RecvFlags, RecvOptions, SendOptions, SocketAddrEx,
+    CMsgData, RecvFlags, RecvOptions, SendOptions, SocketAddrEx, SocketCmsg,
     general::GeneralOptions,
     options::{Configurable, GetSocketOption, SetSocketOption, UnixCredentials},
     unix::{Transport, TransportOps, UnixSocketAddr, with_slot},
@@ -43,6 +48,9 @@ struct Packet {
     cmsg: Vec<CMsgData>,
     /// Sender address reported by recvmsg.
     sender: UnixSocketAddr,
+    /// Wall-clock time captured immediately before this packet entered the
+    /// receiver queue while `SO_TIMESTAMP` was enabled.
+    received_at: Option<Duration>,
 }
 
 /// Receiver plus its poll set: the half a socket reads incoming packets from.
@@ -53,6 +61,8 @@ struct Channel {
     data_tx: async_channel::Sender<Packet>,
     /// Poll set woken when data is queued.
     poll_update: Arc<PollSet>,
+    /// Target receiver's `SO_TIMESTAMP` state.
+    receive_timestamp: Arc<AtomicBool>,
 }
 
 pub struct Bind {
@@ -60,6 +70,8 @@ pub struct Bind {
     data_tx: async_channel::Sender<Packet>,
     /// Poll set associated with the receiver bound at this address.
     poll_update: Arc<PollSet>,
+    /// Bound receiver's `SO_TIMESTAMP` state.
+    receive_timestamp: Arc<AtomicBool>,
 }
 impl Bind {
     fn connect(&self) -> Channel {
@@ -67,6 +79,7 @@ impl Bind {
         Channel {
             data_tx: tx,
             poll_update: self.poll_update.clone(),
+            receive_timestamp: self.receive_timestamp.clone(),
         }
     }
 }
@@ -81,6 +94,8 @@ struct SeqConnRequest {
     addr: UnixSocketAddr,
     /// Client pid used for peer credentials.
     pid: u32,
+    /// Timestamp state owned by the accepted server socket.
+    receive_timestamp: Arc<AtomicBool>,
 }
 
 /// Seqpacket listener published in the Unix namespace.
@@ -96,20 +111,28 @@ pub struct SeqBind {
 impl SeqBind {
     /// Establish a connection: build a packet channel pair, hand the
     /// server side to the listener, and return the client side.
-    fn connect(&self, addr: UnixSocketAddr, pid: u32) -> AxResult<(PacketRx, Channel)> {
+    fn connect(
+        &self,
+        addr: UnixSocketAddr,
+        pid: u32,
+        client_receive_timestamp: Arc<AtomicBool>,
+    ) -> AxResult<(PacketRx, Channel)> {
         let (tx1, rx1) = async_channel::unbounded();
         let (tx2, rx2) = async_channel::unbounded();
         let poll1 = Arc::new(PollSet::new());
         let poll2 = Arc::new(PollSet::new());
+        let server_receive_timestamp = Arc::new(AtomicBool::new(false));
         self.conn_tx
             .try_send(SeqConnRequest {
                 data_rx: (rx2, poll2.clone()),
                 connected: Channel {
                     data_tx: tx1,
                     poll_update: poll1.clone(),
+                    receive_timestamp: client_receive_timestamp,
                 },
                 addr,
                 pid,
+                receive_timestamp: server_receive_timestamp.clone(),
             })
             .map_err(|_| AxError::ConnectionRefused)?;
         // The connection request is queued before waking accept waiters.
@@ -119,6 +142,7 @@ impl SeqBind {
             Channel {
                 data_tx: tx2,
                 poll_update: poll2,
+                receive_timestamp: server_receive_timestamp,
             },
         ))
     }
@@ -147,6 +171,9 @@ pub struct DgramTransport {
     poll_state: Arc<PollSet>,
     /// Shared socket options.
     general: GeneralOptions,
+    /// Per-receiver `SO_TIMESTAMP` state shared with channels targeting this
+    /// socket.
+    receive_timestamp: Arc<AtomicBool>,
     /// Creator pid used for SO_PEERCRED-style reporting.
     pid: u32,
 }
@@ -175,6 +202,7 @@ impl DgramTransport {
             conn_rx: Mutex::new(None),
             poll_state: Arc::default(),
             general: GeneralOptions::new(socket_type, 1, 0),
+            receive_timestamp: Arc::new(AtomicBool::new(false)),
             pid,
         }
     }
@@ -184,6 +212,7 @@ impl DgramTransport {
         connected: Channel,
         pid: u32,
         socket_type: i32,
+        receive_timestamp: Arc<AtomicBool>,
     ) -> Self {
         DgramTransport {
             data_rx: Mutex::new(Some(data_rx)),
@@ -194,6 +223,7 @@ impl DgramTransport {
             conn_rx: Mutex::new(None),
             poll_state: Arc::default(),
             general: GeneralOptions::new(socket_type, 1, 0),
+            receive_timestamp,
             pid,
         }
     }
@@ -213,23 +243,29 @@ impl DgramTransport {
         let (tx2, rx2) = async_channel::unbounded();
         let poll1 = Arc::new(PollSet::new());
         let poll2 = Arc::new(PollSet::new());
+        let timestamp1 = Arc::new(AtomicBool::new(false));
+        let timestamp2 = Arc::new(AtomicBool::new(false));
         let transport1 = DgramTransport::new_connected(
             (rx1, poll1.clone()),
             Channel {
                 data_tx: tx2,
                 poll_update: poll2.clone(),
+                receive_timestamp: timestamp2.clone(),
             },
             pid,
             socket_type,
+            timestamp1.clone(),
         );
         let transport2 = DgramTransport::new_connected(
             (rx2, poll2.clone()),
             Channel {
                 data_tx: tx1,
                 poll_update: poll1.clone(),
+                receive_timestamp: timestamp1,
             },
             pid,
             socket_type,
+            timestamp2,
         );
         (transport1, transport2)
     }
@@ -245,6 +281,9 @@ impl Configurable for DgramTransport {
 
         match opt {
             O::PassCredentials(_) => {}
+            O::ReceiveTimestamp(enabled) => {
+                **enabled = self.receive_timestamp.load(Ordering::Acquire);
+            }
             O::PeerCredentials(cred) => {
                 // Datagram sockets are stateless and do not have a peer, so we
                 // return the credentials of the process that created the
@@ -265,6 +304,9 @@ impl Configurable for DgramTransport {
 
         match opt {
             O::PassCredentials(_) => {}
+            O::ReceiveTimestamp(enabled) => {
+                self.receive_timestamp.store(*enabled, Ordering::Release);
+            }
             _ => return Ok(false),
         }
         Ok(true)
@@ -309,6 +351,7 @@ impl TransportOps for DgramTransport {
         *slot = Some(Bind {
             data_tx: tx,
             poll_update: poll_update.clone(),
+            receive_timestamp: self.receive_timestamp.clone(),
         });
         *guard = Some((rx, poll_update));
         self.local_addr.write().clone_from(local_addr);
@@ -332,7 +375,7 @@ impl TransportOps for DgramTransport {
                 .lock()
                 .as_ref()
                 .ok_or(AxError::ConnectionRefused)?
-                .connect(client_addr, self.pid)?;
+                .connect(client_addr, self.pid, self.receive_timestamp.clone())?;
             *self.data_rx.lock() = Some(client_rx);
             *self.connected.write() = Some(client_chan);
             unsafe { self.poll_state.wake(IoEvents::IN | IoEvents::OUT) };
@@ -367,7 +410,13 @@ impl TransportOps for DgramTransport {
             return Err(AxError::InvalidInput);
         };
         let req = rx.recv().await.map_err(|_| AxError::ConnectionReset)?;
-        let transport = DgramTransport::new_connected(req.data_rx, req.connected, req.pid, 5);
+        let transport = DgramTransport::new_connected(
+            req.data_rx,
+            req.connected,
+            req.pid,
+            5,
+            req.receive_timestamp,
+        );
         Ok((Transport::Dgram(transport), req.addr))
     }
 
@@ -385,8 +434,13 @@ impl TransportOps for DgramTransport {
         };
         match rx.try_recv() {
             Ok(req) => {
-                let transport =
-                    DgramTransport::new_connected(req.data_rx, req.connected, req.pid, 5);
+                let transport = DgramTransport::new_connected(
+                    req.data_rx,
+                    req.connected,
+                    req.pid,
+                    5,
+                    req.receive_timestamp,
+                );
                 Ok((Transport::Dgram(transport), req.addr))
             }
             Err(TryRecvError::Empty) => Err(AxError::WouldBlock),
@@ -410,16 +464,22 @@ impl TransportOps for DgramTransport {
             }
         }
         let len = message.len();
-        let packet = Packet {
-            data: message,
-            cmsg: options.cmsg,
-            sender: self.local_addr.read().clone(),
-        };
+        let sender = self.local_addr.read().clone();
+        let cmsg = options.cmsg;
 
         let wake_poll = if let Some(addr) = options.to {
             let addr = addr.into_unix()?;
             with_slot(&addr, |slot| {
                 if let Some(bind) = slot.dgram.lock().as_ref() {
+                    let packet = Packet {
+                        data: message,
+                        cmsg,
+                        sender,
+                        received_at: bind
+                            .receive_timestamp
+                            .load(Ordering::Acquire)
+                            .then(wall_time),
+                    };
                     bind.data_tx
                         .try_send(packet)
                         .map_err(|_| AxError::BrokenPipe)?;
@@ -429,6 +489,15 @@ impl TransportOps for DgramTransport {
                 }
             })?
         } else if let Some(chan) = self.connected.read().as_ref() {
+            let packet = Packet {
+                data: message,
+                cmsg,
+                sender,
+                received_at: chan
+                    .receive_timestamp
+                    .load(Ordering::Acquire)
+                    .then(wall_time),
+            };
             chan.data_tx
                 .try_send(packet)
                 .map_err(|_| AxError::BrokenPipe)?;
@@ -453,7 +522,7 @@ impl TransportOps for DgramTransport {
             // Drain a packet parked by a previous MSG_PEEK before the channel,
             // preserving record order.
             let mut peeked = self.peeked.lock();
-            let packet = if let Some(p) = peeked.take() {
+            let mut packet = if let Some(p) = peeked.take() {
                 p
             } else {
                 let mut guard = self.data_rx.lock();
@@ -478,6 +547,14 @@ impl TransportOps for DgramTransport {
             if let Some(from) = options.from.as_mut() {
                 **from = SocketAddrEx::Unix(packet.sender.clone());
             }
+            let receive_timestamp = self.receive_timestamp.load(Ordering::Acquire);
+            if receive_timestamp && packet.received_at.is_none() {
+                // Linux fills the current time when SO_TIMESTAMP was enabled
+                // after this datagram entered the receive queue. Persist the
+                // fallback on the packet so MSG_PEEK and the consuming recv
+                // observe the same timestamp.
+                packet.received_at = Some(wall_time());
+            }
             if peek {
                 // MSG_PEEK does not consume the record: deliver a duplicate of
                 // the ancillary data (SCM_RIGHTS fds are cloned via Arc, sharing
@@ -486,10 +563,16 @@ impl TransportOps for DgramTransport {
                 // the rights again.
                 if let Some(dst) = options.cmsg.as_mut() {
                     dst.extend(packet.cmsg.iter().map(|c| c.clone_box()));
+                    if receive_timestamp && let Some(timestamp) = packet.received_at {
+                        dst.push(Box::new(SocketCmsg::Timestamp(timestamp)));
+                    }
                 }
                 *peeked = Some(packet);
             } else if let Some(dst) = options.cmsg.as_mut() {
                 dst.extend(packet.cmsg);
+                if receive_timestamp && let Some(timestamp) = packet.received_at {
+                    dst.push(Box::new(SocketCmsg::Timestamp(timestamp)));
+                }
             }
 
             Ok(if options.flags.contains(RecvFlags::TRUNCATE) {

--- a/net/ax-net/src/unix/dgram.rs
+++ b/net/ax-net/src/unix/dgram.rs
@@ -63,6 +63,8 @@ struct Channel {
     poll_update: Arc<PollSet>,
     /// Target receiver's `SO_TIMESTAMP` state.
     receive_timestamp: Arc<AtomicBool>,
+    /// Target receiver's `SO_PASSCRED` state.
+    receive_credentials: Arc<AtomicBool>,
 }
 
 pub struct Bind {
@@ -72,6 +74,8 @@ pub struct Bind {
     poll_update: Arc<PollSet>,
     /// Bound receiver's `SO_TIMESTAMP` state.
     receive_timestamp: Arc<AtomicBool>,
+    /// Bound receiver's `SO_PASSCRED` state.
+    receive_credentials: Arc<AtomicBool>,
 }
 impl Bind {
     fn connect(&self) -> Channel {
@@ -80,6 +84,7 @@ impl Bind {
             data_tx: tx,
             poll_update: self.poll_update.clone(),
             receive_timestamp: self.receive_timestamp.clone(),
+            receive_credentials: self.receive_credentials.clone(),
         }
     }
 }
@@ -96,6 +101,8 @@ struct SeqConnRequest {
     pid: u32,
     /// Timestamp state owned by the accepted server socket.
     receive_timestamp: Arc<AtomicBool>,
+    /// Passcred state owned by the accepted server socket.
+    receive_credentials: Arc<AtomicBool>,
 }
 
 /// Seqpacket listener published in the Unix namespace.
@@ -108,6 +115,8 @@ pub struct SeqBind {
     conn_tx: async_channel::Sender<SeqConnRequest>,
     poll_new_conn: Arc<PollSet>,
     listening: Arc<AtomicBool>,
+    /// Passcred state inherited by accepted transports.
+    receive_credentials: Arc<AtomicBool>,
 }
 impl SeqBind {
     /// Establish a connection: build a packet channel pair, hand the
@@ -117,6 +126,7 @@ impl SeqBind {
         addr: UnixSocketAddr,
         pid: u32,
         client_receive_timestamp: Arc<AtomicBool>,
+        client_receive_credentials: Arc<AtomicBool>,
     ) -> AxResult<(PacketRx, Channel)> {
         if !self.listening.load(Ordering::Acquire) {
             return Err(AxError::ConnectionRefused);
@@ -126,6 +136,9 @@ impl SeqBind {
         let poll1 = Arc::new(PollSet::new());
         let poll2 = Arc::new(PollSet::new());
         let server_receive_timestamp = Arc::new(AtomicBool::new(false));
+        let server_receive_credentials = Arc::new(AtomicBool::new(
+            self.receive_credentials.load(Ordering::Acquire),
+        ));
         self.conn_tx
             .try_send(SeqConnRequest {
                 data_rx: (rx2, poll2.clone()),
@@ -133,10 +146,12 @@ impl SeqBind {
                     data_tx: tx1,
                     poll_update: poll1.clone(),
                     receive_timestamp: client_receive_timestamp,
+                    receive_credentials: client_receive_credentials,
                 },
                 addr,
                 pid,
                 receive_timestamp: server_receive_timestamp.clone(),
+                receive_credentials: server_receive_credentials.clone(),
             })
             .map_err(|_| AxError::ConnectionRefused)?;
         // The connection request is queued before waking accept waiters.
@@ -147,6 +162,7 @@ impl SeqBind {
                 data_tx: tx2,
                 poll_update: poll2,
                 receive_timestamp: server_receive_timestamp,
+                receive_credentials: server_receive_credentials,
             },
         ))
     }
@@ -180,6 +196,9 @@ pub struct DgramTransport {
     /// Per-receiver `SO_TIMESTAMP` state shared with channels targeting this
     /// socket.
     receive_timestamp: Arc<AtomicBool>,
+    /// Per-receiver `SO_PASSCRED` state shared with channels targeting this
+    /// socket.
+    receive_credentials: Arc<AtomicBool>,
     /// Creator pid used for SO_PEERCRED-style reporting.
     pid: u32,
 }
@@ -210,6 +229,7 @@ impl DgramTransport {
             poll_state: Arc::default(),
             general: GeneralOptions::new(socket_type, 1, 0),
             receive_timestamp: Arc::new(AtomicBool::new(false)),
+            receive_credentials: Arc::new(AtomicBool::new(false)),
             pid,
         }
     }
@@ -220,6 +240,7 @@ impl DgramTransport {
         pid: u32,
         socket_type: i32,
         receive_timestamp: Arc<AtomicBool>,
+        receive_credentials: Arc<AtomicBool>,
     ) -> Self {
         DgramTransport {
             data_rx: Mutex::new(Some(data_rx)),
@@ -232,6 +253,7 @@ impl DgramTransport {
             poll_state: Arc::default(),
             general: GeneralOptions::new(socket_type, 1, 0),
             receive_timestamp,
+            receive_credentials,
             pid,
         }
     }
@@ -253,16 +275,20 @@ impl DgramTransport {
         let poll2 = Arc::new(PollSet::new());
         let timestamp1 = Arc::new(AtomicBool::new(false));
         let timestamp2 = Arc::new(AtomicBool::new(false));
+        let credentials1 = Arc::new(AtomicBool::new(false));
+        let credentials2 = Arc::new(AtomicBool::new(false));
         let transport1 = DgramTransport::new_connected(
             (rx1, poll1.clone()),
             Channel {
                 data_tx: tx2,
                 poll_update: poll2.clone(),
                 receive_timestamp: timestamp2.clone(),
+                receive_credentials: credentials2.clone(),
             },
             pid,
             socket_type,
             timestamp1.clone(),
+            credentials1.clone(),
         );
         let transport2 = DgramTransport::new_connected(
             (rx2, poll2.clone()),
@@ -270,10 +296,12 @@ impl DgramTransport {
                 data_tx: tx1,
                 poll_update: poll1.clone(),
                 receive_timestamp: timestamp1,
+                receive_credentials: credentials1,
             },
             pid,
             socket_type,
             timestamp2,
+            credentials2,
         );
         (transport1, transport2)
     }
@@ -288,7 +316,9 @@ impl Configurable for DgramTransport {
         }
 
         match opt {
-            O::PassCredentials(_) => {}
+            O::PassCredentials(enabled) => {
+                **enabled = self.receive_credentials.load(Ordering::Acquire);
+            }
             O::ReceiveTimestamp(enabled) => {
                 **enabled = self.receive_timestamp.load(Ordering::Acquire);
             }
@@ -311,7 +341,9 @@ impl Configurable for DgramTransport {
         }
 
         match opt {
-            O::PassCredentials(_) => {}
+            O::PassCredentials(enabled) => {
+                self.receive_credentials.store(*enabled, Ordering::Release);
+            }
             O::ReceiveTimestamp(enabled) => {
                 self.receive_timestamp.store(*enabled, Ordering::Release);
             }
@@ -339,6 +371,7 @@ impl TransportOps for DgramTransport {
                 conn_tx: tx,
                 poll_new_conn: poll.clone(),
                 listening: self.listening.clone(),
+                receive_credentials: self.receive_credentials.clone(),
             });
             *guard = Some((rx, poll));
             self.local_addr.write().clone_from(local_addr);
@@ -361,6 +394,7 @@ impl TransportOps for DgramTransport {
             data_tx: tx,
             poll_update: poll_update.clone(),
             receive_timestamp: self.receive_timestamp.clone(),
+            receive_credentials: self.receive_credentials.clone(),
         });
         *guard = Some((rx, poll_update));
         self.local_addr.write().clone_from(local_addr);
@@ -399,7 +433,12 @@ impl TransportOps for DgramTransport {
                 .lock()
                 .as_ref()
                 .ok_or(AxError::ConnectionRefused)?
-                .connect(client_addr, self.pid, self.receive_timestamp.clone())?;
+                .connect(
+                    client_addr,
+                    self.pid,
+                    self.receive_timestamp.clone(),
+                    self.receive_credentials.clone(),
+                )?;
             *self.data_rx.lock() = Some(client_rx);
             *self.connected.write() = Some(client_chan);
             unsafe { self.poll_state.wake(IoEvents::IN | IoEvents::OUT) };
@@ -443,6 +482,7 @@ impl TransportOps for DgramTransport {
             req.pid,
             5,
             req.receive_timestamp,
+            req.receive_credentials,
         );
         Ok((Transport::Dgram(transport), req.addr))
     }
@@ -470,6 +510,7 @@ impl TransportOps for DgramTransport {
                     req.pid,
                     5,
                     req.receive_timestamp,
+                    req.receive_credentials,
                 );
                 Ok((Transport::Dgram(transport), req.addr))
             }
@@ -495,12 +536,18 @@ impl TransportOps for DgramTransport {
         }
         let len = message.len();
         let sender = self.local_addr.read().clone();
-        let cmsg = options.cmsg;
+        let mut cmsg = options.cmsg;
+        let sender_credentials = options.sender_credentials;
 
         let wake_poll = if let Some(addr) = options.to {
             let addr = addr.into_unix()?;
             with_slot(&addr, |slot| {
                 if let Some(bind) = slot.dgram.lock().as_ref() {
+                    if bind.receive_credentials.load(Ordering::Acquire)
+                        && let Some(credentials) = sender_credentials
+                    {
+                        cmsg.push(Box::new(SocketCmsg::Credentials(credentials)));
+                    }
                     let packet = Packet {
                         data: message,
                         cmsg,
@@ -519,6 +566,11 @@ impl TransportOps for DgramTransport {
                 }
             })?
         } else if let Some(chan) = self.connected.read().as_ref() {
+            if chan.receive_credentials.load(Ordering::Acquire)
+                && let Some(credentials) = sender_credentials
+            {
+                cmsg.push(Box::new(SocketCmsg::Credentials(credentials)));
+            }
             let packet = Packet {
                 data: message,
                 cmsg,

--- a/net/ax-net/src/unix/dgram.rs
+++ b/net/ax-net/src/unix/dgram.rs
@@ -107,6 +107,7 @@ struct SeqConnRequest {
 pub struct SeqBind {
     conn_tx: async_channel::Sender<SeqConnRequest>,
     poll_new_conn: Arc<PollSet>,
+    listening: Arc<AtomicBool>,
 }
 impl SeqBind {
     /// Establish a connection: build a packet channel pair, hand the
@@ -117,6 +118,9 @@ impl SeqBind {
         pid: u32,
         client_receive_timestamp: Arc<AtomicBool>,
     ) -> AxResult<(PacketRx, Channel)> {
+        if !self.listening.load(Ordering::Acquire) {
+            return Err(AxError::ConnectionRefused);
+        }
         let (tx1, rx1) = async_channel::unbounded();
         let (tx2, rx2) = async_channel::unbounded();
         let poll1 = Arc::new(PollSet::new());
@@ -167,6 +171,8 @@ pub struct DgramTransport {
     is_seqpacket: bool,
     /// Connection-request queue installed by a seqpacket listener's bind.
     conn_rx: Mutex<Option<(async_channel::Receiver<SeqConnRequest>, Arc<PollSet>)>>,
+    /// True after a bound seqpacket socket enters listening state.
+    listening: Arc<AtomicBool>,
     /// Poll set for local state changes.
     poll_state: Arc<PollSet>,
     /// Shared socket options.
@@ -200,6 +206,7 @@ impl DgramTransport {
             peeked: Mutex::new(None),
             is_seqpacket: socket_type == 5,
             conn_rx: Mutex::new(None),
+            listening: Arc::new(AtomicBool::new(false)),
             poll_state: Arc::default(),
             general: GeneralOptions::new(socket_type, 1, 0),
             receive_timestamp: Arc::new(AtomicBool::new(false)),
@@ -221,6 +228,7 @@ impl DgramTransport {
             peeked: Mutex::new(None),
             is_seqpacket: socket_type == 5,
             conn_rx: Mutex::new(None),
+            listening: Arc::new(AtomicBool::new(false)),
             poll_state: Arc::default(),
             general: GeneralOptions::new(socket_type, 1, 0),
             receive_timestamp,
@@ -330,6 +338,7 @@ impl TransportOps for DgramTransport {
             *slot = Some(SeqBind {
                 conn_tx: tx,
                 poll_new_conn: poll.clone(),
+                listening: self.listening.clone(),
             });
             *guard = Some((rx, poll));
             self.local_addr.write().clone_from(local_addr);
@@ -360,6 +369,21 @@ impl TransportOps for DgramTransport {
         // Datagram bind state is published before waking pollers.
         unsafe { self.poll_state.wake(IoEvents::IN | IoEvents::OUT) };
         Ok(())
+    }
+
+    fn listen(&self) -> AxResult {
+        if !self.is_seqpacket {
+            return Err(AxError::OperationNotSupported);
+        }
+        if self.conn_rx.lock().is_none() {
+            return Err(AxError::InvalidInput);
+        }
+        self.listening.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn is_listening(&self) -> bool {
+        self.is_seqpacket && self.listening.load(Ordering::Acquire)
     }
 
     fn connect(&self, slot: &super::BindSlot, _local_addr: &UnixSocketAddr) -> AxResult {
@@ -404,6 +428,9 @@ impl TransportOps for DgramTransport {
             // `unix_dgram_ops.accept = sock_no_accept` returns -EOPNOTSUPP.
             return Err(AxError::OperationNotSupported);
         }
+        if !self.is_listening() {
+            return Err(AxError::InvalidInput);
+        }
         let Some((rx, _)) = self.conn_rx.lock().clone() else {
             // Not a listening seqpacket socket: accept requires listen(). Linux
             // returns EINVAL for accept on a non-listening socket.
@@ -426,6 +453,9 @@ impl TransportOps for DgramTransport {
             // `unix_dgram_ops.accept = sock_no_accept` returns -EOPNOTSUPP.
             // Must not return WouldBlock, or the accept poll loop hangs forever.
             return Err(AxError::OperationNotSupported);
+        }
+        if !self.is_listening() {
+            return Err(AxError::InvalidInput);
         }
         let Some((rx, _)) = self.conn_rx.lock().clone() else {
             // Not a listening seqpacket socket: accept requires listen(). Linux

--- a/net/ax-net/src/unix/mod.rs
+++ b/net/ax-net/src/unix/mod.rs
@@ -65,6 +65,16 @@ pub trait TransportOps: Configurable + Pollable + Send + Sync {
     /// Connect the transport to a remote address.
     fn connect(&self, slot: &BindSlot, local_addr: &UnixSocketAddr) -> AxResult;
 
+    /// Marks a bound connection-oriented transport as accepting connections.
+    fn listen(&self) -> AxResult {
+        Err(AxError::OperationNotSupported)
+    }
+
+    /// Returns whether this transport currently accepts connections.
+    fn is_listening(&self) -> bool {
+        false
+    }
+
     /// Accept an incoming connection, returning the new transport and peer address.
     async fn accept(&self) -> AxResult<(Transport, UnixSocketAddr)>;
 
@@ -220,7 +230,11 @@ impl SocketOps for UnixSocket {
     }
 
     fn listen(&self, _backlog: usize) -> AxResult {
-        Ok(())
+        self.transport.listen()
+    }
+
+    fn is_listening(&self) -> bool {
+        self.transport.is_listening()
     }
 
     fn accept(&self) -> AxResult<Socket> {

--- a/net/ax-net/src/unix/stream.rs
+++ b/net/ax-net/src/unix/stream.rs
@@ -130,11 +130,16 @@ pub struct Bind {
     /// New connections are sent to this channel.
     conn_tx: async_channel::Sender<ConnRequest>,
     poll_new_conn: Arc<PollSet>,
+    /// Shared listener state published by `listen`.
+    listening: Arc<AtomicBool>,
     /// PID of the process that created the listening transport.
     pid: u32,
 }
 impl Bind {
     fn connect(&self, local_addr: UnixSocketAddr, pid: u32) -> AxResult<Channel> {
+        if !self.listening.load(Ordering::Acquire) {
+            return Err(AxError::ConnectionRefused);
+        }
         let (mut client_chan, mut server_chan) = new_channels(0);
         client_chan.peer_pid = self.pid;
         server_chan.peer_pid = pid;
@@ -166,6 +171,8 @@ pub struct StreamTransport {
     channel: Mutex<Option<Channel>>,
     /// Listener receive queue installed by bind/listen.
     conn_rx: Mutex<Option<(async_channel::Receiver<ConnRequest>, Arc<PollSet>)>>,
+    /// True after `listen` publishes the bound endpoint for connection attempts.
+    listening: Arc<AtomicBool>,
     /// Poll set for local stream state.
     poll_state: PollSet,
     /// Shared socket options.
@@ -187,6 +194,7 @@ impl StreamTransport {
         StreamTransport {
             channel: Mutex::new(channel),
             conn_rx: Mutex::new(None),
+            listening: Arc::new(AtomicBool::new(false)),
             poll_state: PollSet::new(),
             general: GeneralOptions::new(1, 1, 0), // SOCK_STREAM
             pid,
@@ -260,6 +268,7 @@ impl TransportOps for StreamTransport {
         *slot = Some(Bind {
             conn_tx: tx,
             poll_new_conn: poll.clone(),
+            listening: self.listening.clone(),
             pid: self.pid,
         });
         *guard = Some((rx, poll));
@@ -268,6 +277,18 @@ impl TransportOps for StreamTransport {
         // Bind state is published before waking poll waiters.
         unsafe { self.poll_state.wake(IoEvents::IN | IoEvents::OUT) };
         Ok(())
+    }
+
+    fn listen(&self) -> AxResult<()> {
+        if self.conn_rx.lock().is_none() {
+            return Err(AxError::InvalidInput);
+        }
+        self.listening.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    fn is_listening(&self) -> bool {
+        self.listening.load(Ordering::Acquire)
     }
 
     fn connect(&self, slot: &super::BindSlot, local_addr: &UnixSocketAddr) -> AxResult<()> {
@@ -289,6 +310,9 @@ impl TransportOps for StreamTransport {
     }
 
     async fn accept(&self) -> AxResult<(Transport, UnixSocketAddr)> {
+        if !self.is_listening() {
+            return Err(AxError::InvalidInput);
+        }
         let Some((rx, _)) = self.conn_rx.lock().clone() else {
             // Not a listening socket: accept requires a prior listen(). Linux
             // returns EINVAL for accept on a non-listening socket.
@@ -306,6 +330,9 @@ impl TransportOps for StreamTransport {
     }
 
     fn try_accept(&self) -> AxResult<(Transport, UnixSocketAddr)> {
+        if !self.is_listening() {
+            return Err(AxError::InvalidInput);
+        }
         let Some((rx, _)) = self.conn_rx.lock().clone() else {
             // Not a listening socket: accept requires a prior listen(). Linux
             // returns EINVAL for accept on a non-listening socket.

--- a/net/ax-net/src/unix/stream.rs
+++ b/net/ax-net/src/unix/stream.rs
@@ -67,7 +67,11 @@ fn new_uni_channel() -> (HeapProd<u8>, HeapCons<u8>) {
     let rb = HeapRb::new(BUF_SIZE);
     rb.split()
 }
-fn new_channels(pid: u32) -> (Channel, Channel) {
+fn new_channels(
+    pid: u32,
+    first_receive_credentials: Arc<AtomicBool>,
+    second_receive_credentials: Arc<AtomicBool>,
+) -> (Channel, Channel) {
     let (client_tx, server_rx) = new_uni_channel();
     let (server_tx, client_rx) = new_uni_channel();
     let poll_update = Arc::new(PollSet::new());
@@ -88,6 +92,7 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
             peer_tx_closed: server_tx_closed.clone(),
             poll_update: poll_update.clone(),
             peer_pid: pid,
+            peer_receive_credentials: second_receive_credentials,
         },
         Channel {
             tx: server_tx,
@@ -100,6 +105,7 @@ fn new_channels(pid: u32) -> (Channel, Channel) {
             peer_tx_closed: client_tx_closed,
             poll_update,
             peer_pid: pid,
+            peer_receive_credentials: first_receive_credentials,
         },
     )
 }
@@ -124,6 +130,8 @@ struct Channel {
     peer_tx_closed: Arc<AtomicBool>,
     poll_update: Arc<PollSet>,
     peer_pid: u32,
+    /// Peer receiver's `SO_PASSCRED` state.
+    peer_receive_credentials: Arc<AtomicBool>,
 }
 
 pub struct Bind {
@@ -134,13 +142,27 @@ pub struct Bind {
     listening: Arc<AtomicBool>,
     /// PID of the process that created the listening transport.
     pid: u32,
+    /// Receiver passcred state inherited by accepted transports.
+    receive_credentials: Arc<AtomicBool>,
 }
 impl Bind {
-    fn connect(&self, local_addr: UnixSocketAddr, pid: u32) -> AxResult<Channel> {
+    fn connect(
+        &self,
+        local_addr: UnixSocketAddr,
+        pid: u32,
+        client_receive_credentials: Arc<AtomicBool>,
+    ) -> AxResult<Channel> {
         if !self.listening.load(Ordering::Acquire) {
             return Err(AxError::ConnectionRefused);
         }
-        let (mut client_chan, mut server_chan) = new_channels(0);
+        let server_receive_credentials = Arc::new(AtomicBool::new(
+            self.receive_credentials.load(Ordering::Acquire),
+        ));
+        let (mut client_chan, mut server_chan) = new_channels(
+            0,
+            client_receive_credentials,
+            server_receive_credentials.clone(),
+        );
         client_chan.peer_pid = self.pid;
         server_chan.peer_pid = pid;
         self.conn_tx
@@ -148,6 +170,7 @@ impl Bind {
                 channel: server_chan,
                 addr: local_addr,
                 pid,
+                receive_credentials: server_receive_credentials,
             })
             .map_err(|_| AxError::ConnectionRefused)?;
         // The connection request is queued before waking accept waiters.
@@ -163,6 +186,8 @@ struct ConnRequest {
     addr: UnixSocketAddr,
     /// Client pid used for peer credentials.
     pid: u32,
+    /// Passcred state owned by the accepted server socket.
+    receive_credentials: Arc<AtomicBool>,
 }
 
 /// Stream transport for Unix domain sockets.
@@ -177,6 +202,8 @@ pub struct StreamTransport {
     poll_state: PollSet,
     /// Shared socket options.
     general: GeneralOptions,
+    /// Per-receiver `SO_PASSCRED` state.
+    receive_credentials: Arc<AtomicBool>,
     /// Creator pid used for credentials.
     pid: u32,
     /// Public receive-half shutdown flag.
@@ -187,16 +214,21 @@ pub struct StreamTransport {
 impl StreamTransport {
     /// Create a new unconnected stream transport.
     pub fn new(pid: u32) -> Self {
-        StreamTransport::new_channel(None, pid)
+        StreamTransport::new_channel(None, pid, Arc::new(AtomicBool::new(false)))
     }
 
-    fn new_channel(channel: Option<Channel>, pid: u32) -> Self {
+    fn new_channel(
+        channel: Option<Channel>,
+        pid: u32,
+        receive_credentials: Arc<AtomicBool>,
+    ) -> Self {
         StreamTransport {
             channel: Mutex::new(channel),
             conn_rx: Mutex::new(None),
             listening: Arc::new(AtomicBool::new(false)),
             poll_state: PollSet::new(),
             general: GeneralOptions::new(1, 1, 0), // SOCK_STREAM
+            receive_credentials,
             pid,
             rx_closed: AtomicBool::new(false),
             tx_closed: AtomicBool::new(false),
@@ -205,9 +237,11 @@ impl StreamTransport {
 
     /// Create a connected pair of stream transports.
     pub fn new_pair(pid: u32) -> (Self, Self) {
-        let (chan1, chan2) = new_channels(pid);
-        let transport1 = StreamTransport::new_channel(Some(chan1), pid);
-        let transport2 = StreamTransport::new_channel(Some(chan2), pid);
+        let credentials1 = Arc::new(AtomicBool::new(false));
+        let credentials2 = Arc::new(AtomicBool::new(false));
+        let (chan1, chan2) = new_channels(pid, credentials1.clone(), credentials2.clone());
+        let transport1 = StreamTransport::new_channel(Some(chan1), pid, credentials1);
+        let transport2 = StreamTransport::new_channel(Some(chan2), pid, credentials2);
         (transport1, transport2)
     }
 }
@@ -224,7 +258,9 @@ impl Configurable for StreamTransport {
             O::SendBuffer(size) => {
                 **size = BUF_SIZE;
             }
-            O::PassCredentials(_) => {}
+            O::PassCredentials(enabled) => {
+                **enabled = self.receive_credentials.load(Ordering::Acquire);
+            }
             O::PeerCredentials(cred) => {
                 let peer_pid = self
                     .channel
@@ -246,7 +282,9 @@ impl Configurable for StreamTransport {
         }
 
         match opt {
-            O::PassCredentials(_) => {}
+            O::PassCredentials(enabled) => {
+                self.receive_credentials.store(*enabled, Ordering::Release);
+            }
             _ => return Ok(false),
         }
         Ok(true)
@@ -270,6 +308,7 @@ impl TransportOps for StreamTransport {
             poll_new_conn: poll.clone(),
             listening: self.listening.clone(),
             pid: self.pid,
+            receive_credentials: self.receive_credentials.clone(),
         });
         *guard = Some((rx, poll));
         drop(guard);
@@ -301,7 +340,11 @@ impl TransportOps for StreamTransport {
                 .lock()
                 .as_ref()
                 .ok_or(AxError::NotConnected)?
-                .connect(local_addr.clone(), self.pid)?,
+                .connect(
+                    local_addr.clone(),
+                    self.pid,
+                    self.receive_credentials.clone(),
+                )?,
         );
         drop(guard);
         // Connection state is installed before waking poll waiters.
@@ -322,9 +365,14 @@ impl TransportOps for StreamTransport {
             channel,
             addr: peer_addr,
             pid,
+            receive_credentials,
         } = rx.recv().await.map_err(|_| AxError::ConnectionReset)?;
         Ok((
-            Transport::Stream(StreamTransport::new_channel(Some(channel), pid)),
+            Transport::Stream(StreamTransport::new_channel(
+                Some(channel),
+                pid,
+                receive_credentials,
+            )),
             peer_addr,
         ))
     }
@@ -343,8 +391,13 @@ impl TransportOps for StreamTransport {
                 channel,
                 addr: peer_addr,
                 pid,
+                receive_credentials,
             }) => Ok((
-                Transport::Stream(StreamTransport::new_channel(Some(channel), pid)),
+                Transport::Stream(StreamTransport::new_channel(
+                    Some(channel),
+                    pid,
+                    receive_credentials,
+                )),
                 peer_addr,
             )),
             Err(async_channel::TryRecvError::Empty) => Err(AxError::WouldBlock),
@@ -364,6 +417,17 @@ impl TransportOps for StreamTransport {
         // call (Linux semantics: cmsg is delivered with the first byte of
         // the message). We stash the vec here and push into the peer's
         // cmsg queue once some bytes actually got written.
+        if self
+            .channel
+            .lock()
+            .as_ref()
+            .is_some_and(|channel| channel.peer_receive_credentials.load(Ordering::Acquire))
+            && let Some(credentials) = options.sender_credentials
+        {
+            options
+                .cmsg
+                .push(Box::new(crate::SocketCmsg::Credentials(credentials)));
+        }
         let pending_cmsg = core::mem::take(&mut options.cmsg);
         let had_cmsg = !pending_cmsg.is_empty();
         let mut cmsg_slot: Option<Vec<CMsgData>> = had_cmsg.then_some(pending_cmsg);

--- a/os/StarryOS/kernel/src/file/net.rs
+++ b/os/StarryOS/kernel/src/file/net.rs
@@ -15,7 +15,7 @@ use ax_errno::{AxError, AxResult};
 use ax_net::{
     InterfaceFlags, InterfaceId, InterfaceInfo, InterfaceKind, RecvOptions, SendOptions,
     Socket as SocketInner, SocketOps,
-    options::{Configurable, GetSocketOption, SetSocketOption},
+    options::{Configurable, GetSocketOption, SetSocketOption, UnixCredentials},
 };
 use ax_task::current;
 use axpoll::{IoEvents, Pollable};
@@ -74,6 +74,17 @@ impl Socket {
 
     pub fn ip_domain(&self) -> u32 {
         self.ip_domain
+    }
+
+    pub(crate) fn with_current_sender_credentials(mut options: SendOptions) -> SendOptions {
+        let current = current();
+        let credentials = current.as_thread().cred();
+        options.sender_credentials = Some(UnixCredentials {
+            pid: current.as_thread().proc_data.proc.pid(),
+            uid: credentials.uid,
+            gid: credentials.gid,
+        });
+        options
     }
 }
 
@@ -369,7 +380,10 @@ impl FileLike for Socket {
     }
 
     fn write(&self, src: &mut IoSrc) -> AxResult<usize> {
-        self.send(src, SendOptions::default())
+        self.send(
+            src,
+            Self::with_current_sender_credentials(SendOptions::default()),
+        )
     }
 
     fn stat(&self) -> AxResult<Kstat> {

--- a/os/StarryOS/kernel/src/syscall/net/io.rs
+++ b/os/StarryOS/kernel/src/syscall/net/io.rs
@@ -4,14 +4,16 @@ use core::{net::Ipv4Addr, time::Duration};
 use ax_errno::{AxError, AxResult};
 use ax_io::prelude::*;
 use ax_net::{
-    CMsgData, IpCmsg, RecvFlags, RecvOptions, SendFlags, SendOptions, SocketAddrEx, SocketOps,
+    CMsgData, IpCmsg, RecvFlags, RecvOptions, SendFlags, SendOptions, SocketAddrEx, SocketCmsg,
+    SocketOps,
 };
 use ax_runtime::hal::time::wall_time;
 use linux_raw_sys::{
-    general::timespec,
+    general::{timespec, timeval},
     net::{
         IP_TOS, IPPROTO_IPV6, IPV6_TCLASS, MSG_CMSG_CLOEXEC, MSG_CTRUNC, MSG_DONTWAIT, MSG_OOB,
-        MSG_PEEK, MSG_TRUNC, SCM_RIGHTS, SOL_SOCKET, cmsghdr, mmsghdr, msghdr, sockaddr, socklen_t,
+        MSG_PEEK, MSG_TRUNC, SCM_RIGHTS, SCM_TIMESTAMP, SOL_SOCKET, cmsghdr, mmsghdr, msghdr,
+        sockaddr, socklen_t,
     },
 };
 
@@ -298,10 +300,33 @@ fn recv_impl(
                             },
                         )?,
                     },
-                    Err(_) => {
-                        warn!("received unexpected cmsg");
-                        continue;
-                    }
+                    Err(cmsg) => match cmsg.downcast::<SocketCmsg>() {
+                        Ok(cmsg) => match *cmsg {
+                            SocketCmsg::Timestamp(timestamp) => builder.push_sized(
+                                SOL_SOCKET,
+                                SCM_TIMESTAMP,
+                                size_of::<timeval>(),
+                                |data| {
+                                    let timestamp = timeval::from_time_value(timestamp);
+                                    // SAFETY: `timestamp` lives through the
+                                    // copy, and `timeval` is a plain C ABI
+                                    // record with no padding requirements for
+                                    // reading its initialized byte layout.
+                                    data.copy_from_slice(unsafe {
+                                        core::slice::from_raw_parts(
+                                            (&timestamp as *const timeval).cast::<u8>(),
+                                            size_of::<timeval>(),
+                                        )
+                                    });
+                                    Ok(size_of::<timeval>())
+                                },
+                            )?,
+                        },
+                        Err(_) => {
+                            warn!("received unexpected cmsg");
+                            continue;
+                        }
+                    },
                 },
             };
             if !pushed {

--- a/os/StarryOS/kernel/src/syscall/net/io.rs
+++ b/os/StarryOS/kernel/src/syscall/net/io.rs
@@ -12,8 +12,8 @@ use linux_raw_sys::{
     general::{timespec, timeval},
     net::{
         IP_TOS, IPPROTO_IPV6, IPV6_TCLASS, MSG_CMSG_CLOEXEC, MSG_CTRUNC, MSG_DONTWAIT, MSG_OOB,
-        MSG_PEEK, MSG_TRUNC, SCM_RIGHTS, SCM_TIMESTAMP, SOL_SOCKET, cmsghdr, mmsghdr, msghdr,
-        sockaddr, socklen_t,
+        MSG_PEEK, MSG_TRUNC, SCM_CREDENTIALS, SCM_RIGHTS, SCM_TIMESTAMP, SOL_SOCKET, cmsghdr,
+        mmsghdr, msghdr, sockaddr, socklen_t, ucred,
     },
 };
 
@@ -109,11 +109,12 @@ fn send_impl(
 
         let sent = socket.send(
             &mut src,
-            SendOptions {
+            Socket::with_current_sender_credentials(SendOptions {
                 to: addr,
                 flags: send_flags,
                 cmsg,
-            },
+                ..Default::default()
+            }),
         )?;
 
         return Ok(sent as isize);
@@ -250,6 +251,9 @@ fn recv_impl(
             .write_to_user(addr, addrlen.get_as_mut()?)?;
     }
 
+    if cmsg_builder.is_none() && !cmsg.is_empty() {
+        *control_truncated_out = true;
+    }
     if let Some(mut builder) = cmsg_builder {
         for cmsg in cmsg {
             let pushed = match cmsg.into_any().downcast::<CMsg>() {
@@ -302,6 +306,27 @@ fn recv_impl(
                     },
                     Err(cmsg) => match cmsg.downcast::<SocketCmsg>() {
                         Ok(cmsg) => match *cmsg {
+                            SocketCmsg::Credentials(credentials) => builder.push_sized(
+                                SOL_SOCKET,
+                                SCM_CREDENTIALS,
+                                size_of::<ucred>(),
+                                |data| {
+                                    let credentials = ucred {
+                                        pid: credentials.pid as _,
+                                        uid: credentials.uid,
+                                        gid: credentials.gid,
+                                    };
+                                    // SAFETY: `credentials` lives through the
+                                    // copy, and `ucred` is a plain C ABI record.
+                                    data.copy_from_slice(unsafe {
+                                        core::slice::from_raw_parts(
+                                            (&credentials as *const ucred).cast::<u8>(),
+                                            size_of::<ucred>(),
+                                        )
+                                    });
+                                    Ok(size_of::<ucred>())
+                                },
+                            )?,
                             SocketCmsg::Timestamp(timestamp) => builder.push_sized(
                                 SOL_SOCKET,
                                 SCM_TIMESTAMP,
@@ -330,6 +355,7 @@ fn recv_impl(
                 },
             };
             if !pushed {
+                *control_truncated_out = true;
                 break;
             }
         }

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -262,6 +262,7 @@ macro_rules! call_dispatch {
             (SOL_SOCKET, SO_RCVTIMEO) => ReceiveTimeout as Duration,
             (SOL_SOCKET, SO_SNDTIMEO) => SendTimeout as Duration,
             (SOL_SOCKET, SO_PASSCRED) => PassCredentials as IntBool, // TODO: set accepted but no-op for non-unix
+            (SOL_SOCKET, SO_TIMESTAMP) => ReceiveTimestamp as IntBool,
             (SOL_SOCKET, SO_PEERCRED) => PeerCredentials as Ucred,
             (SOL_SOCKET, SO_TYPE) => SocketType as Int<i32>,       // read-only
             (SOL_SOCKET, SO_PROTOCOL) => SocketProtocol as Int<i32>,// read-only

--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -2,7 +2,7 @@ use alloc::vec;
 
 use ax_errno::{AxError, AxResult, LinuxError};
 use ax_net::{
-    InterfaceId,
+    InterfaceId, SocketOps,
     options::{Configurable, GetSocketOption, SetSocketOption, TcpInfo, TcpInfoOptions, TcpState},
 };
 use linux_raw_sys::net::{
@@ -352,9 +352,13 @@ pub fn sys_getsockopt(
     {
         use ax_net::Socket as SocketInner;
         use linux_raw_sys::net::{
-            SO_BINDTODEVICE, SO_TYPE, SOCK_DGRAM, SOCK_RAW, SOCK_STREAM, SOL_SOCKET,
+            SO_ACCEPTCONN, SO_BINDTODEVICE, SO_TYPE, SOCK_DGRAM, SOCK_RAW, SOCK_STREAM, SOL_SOCKET,
         };
 
+        if level == SOL_SOCKET && optname == SO_ACCEPTCONN {
+            *get::<i32>(optval, optlen)? = socket.is_listening() as i32;
+            return Ok(0);
+        }
         if level == SOL_SOCKET && optname == SO_TYPE {
             if *optlen == 0 {
                 return Ok(0);

--- a/test-suit/starryos/qemu/system/bugfix-socket-timestamp/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-socket-timestamp/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bugfix-socket-timestamp C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-socket-timestamp src/main.c)
+target_compile_options(bugfix-socket-timestamp PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-socket-timestamp RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-socket-timestamp/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-socket-timestamp/src/main.c
@@ -1,0 +1,264 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+struct timestamp_result {
+    int found;
+    struct timeval value;
+};
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+static int expect_true(int condition, const char *name)
+{
+    if (condition) {
+        note_pass(name);
+        return 1;
+    }
+    note_fail(name, "condition is false");
+    return 0;
+}
+
+static int64_t timespec_to_micros(struct timespec value)
+{
+    return (int64_t)value.tv_sec * 1000000 + value.tv_nsec / 1000;
+}
+
+static int64_t timeval_to_micros(struct timeval value)
+{
+    return (int64_t)value.tv_sec * 1000000 + value.tv_usec;
+}
+
+static void expect_timestamp_option(int fd, int enabled, const char *name)
+{
+    int value = -1;
+    socklen_t value_len = sizeof(value);
+    errno = 0;
+    if (getsockopt(fd, SOL_SOCKET, SO_TIMESTAMP, &value, &value_len) == 0 &&
+        value_len == sizeof(value) && value == enabled) {
+        note_pass(name);
+        return;
+    }
+
+    char detail[160];
+    snprintf(detail, sizeof(detail), "value=%d len=%u errno=%d (%s)", value,
+             (unsigned)value_len, errno, strerror(errno));
+    note_fail(name, detail);
+}
+
+static void set_timestamp_option(int fd, int enabled, const char *name)
+{
+    errno = 0;
+    if (setsockopt(fd, SOL_SOCKET, SO_TIMESTAMP, &enabled,
+                   sizeof(enabled)) == 0) {
+        note_pass(name);
+        return;
+    }
+
+    char detail[160];
+    snprintf(detail, sizeof(detail), "errno=%d (%s)", errno, strerror(errno));
+    note_fail(name, detail);
+}
+
+static int send_byte(int fd, char value, const char *name)
+{
+    errno = 0;
+    ssize_t sent = send(fd, &value, sizeof(value), 0);
+    if (sent == (ssize_t)sizeof(value)) {
+        note_pass(name);
+        return 0;
+    }
+
+    char detail[160];
+    snprintf(detail, sizeof(detail), "sent=%zd errno=%d (%s)", sent, errno,
+             strerror(errno));
+    note_fail(name, detail);
+    return -1;
+}
+
+static int recv_byte_with_timestamp(int fd, int flags, char expected,
+                                    struct timestamp_result *result,
+                                    const char *name)
+{
+    char value = '\0';
+    char control[CMSG_SPACE(sizeof(struct timeval))] = {0};
+    struct iovec iov = {
+        .iov_base = &value,
+        .iov_len = sizeof(value),
+    };
+    struct msghdr msg = {
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+        .msg_control = control,
+        .msg_controllen = sizeof(control),
+    };
+
+    memset(result, 0, sizeof(*result));
+    errno = 0;
+    ssize_t received = recvmsg(fd, &msg, flags);
+    if (received != (ssize_t)sizeof(value) || value != expected) {
+        char detail[160];
+        snprintf(detail, sizeof(detail),
+                 "received=%zd value=%d errno=%d (%s)", received, value, errno,
+                 strerror(errno));
+        note_fail(name, detail);
+        return -1;
+    }
+    note_pass(name);
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+    if (cmsg != NULL && cmsg->cmsg_level == SOL_SOCKET &&
+        cmsg->cmsg_type == SCM_TIMESTAMP &&
+        cmsg->cmsg_len == CMSG_LEN(sizeof(struct timeval))) {
+        memcpy(&result->value, CMSG_DATA(cmsg), sizeof(result->value));
+        result->found = 1;
+    }
+    return 0;
+}
+
+static void expect_no_timestamp(const struct timestamp_result *result,
+                                const char *name)
+{
+    expect_true(!result->found, name);
+}
+
+static void test_timestamp_delivery(void)
+{
+    int sockets[2] = {-1, -1};
+    if (!expect_true(socketpair(AF_UNIX, SOCK_DGRAM, 0, sockets) == 0,
+                     "create Unix datagram socketpair")) {
+        return;
+    }
+
+    expect_timestamp_option(sockets[1], 0, "SO_TIMESTAMP defaults to disabled");
+    set_timestamp_option(sockets[1], 1, "enable SO_TIMESTAMP");
+    expect_timestamp_option(sockets[1], 1, "SO_TIMESTAMP reports enabled");
+
+    struct timespec before_send;
+    struct timespec after_send;
+    struct timespec before_recv;
+    clock_gettime(CLOCK_REALTIME, &before_send);
+    send_byte(sockets[0], 'A', "send timestamped datagram");
+    clock_gettime(CLOCK_REALTIME, &after_send);
+    usleep(100000);
+    clock_gettime(CLOCK_REALTIME, &before_recv);
+
+    struct timestamp_result result;
+    if (recv_byte_with_timestamp(sockets[1], 0, 'A', &result,
+                                 "receive timestamped datagram") == 0) {
+        expect_true(result.found, "recvmsg returns SCM_TIMESTAMP");
+        if (result.found) {
+            int64_t timestamp = timeval_to_micros(result.value);
+            int64_t send_start = timespec_to_micros(before_send);
+            int64_t send_end = timespec_to_micros(after_send);
+            int64_t recv_start = timespec_to_micros(before_recv);
+            expect_true(result.value.tv_usec >= 0 &&
+                            result.value.tv_usec < 1000000,
+                        "SCM_TIMESTAMP contains a valid timeval");
+            expect_true(timestamp >= send_start - 1000 &&
+                            timestamp <= send_end + 10000,
+                        "SCM_TIMESTAMP records the enqueue window");
+            expect_true(recv_start - timestamp >= 50000,
+                        "SCM_TIMESTAMP is not generated at recvmsg time");
+        }
+    }
+
+    set_timestamp_option(sockets[1], 0, "disable SO_TIMESTAMP");
+    expect_timestamp_option(sockets[1], 0, "SO_TIMESTAMP reports disabled");
+    send_byte(sockets[0], 'B', "send datagram while timestamping disabled");
+    if (recv_byte_with_timestamp(sockets[1], 0, 'B', &result,
+                                 "receive datagram while disabled") == 0) {
+        expect_no_timestamp(&result,
+                            "disabled SO_TIMESTAMP returns no timestamp cmsg");
+    }
+
+    send_byte(sockets[0], 'C', "queue datagram before enabling timestamping");
+    set_timestamp_option(sockets[1], 1,
+                         "enable SO_TIMESTAMP after datagram was queued");
+    struct timespec before_fallback_recv;
+    struct timespec after_fallback_recv;
+    clock_gettime(CLOCK_REALTIME, &before_fallback_recv);
+    if (recv_byte_with_timestamp(sockets[1], 0, 'C', &result,
+                                 "receive datagram queued while disabled") == 0) {
+        clock_gettime(CLOCK_REALTIME, &after_fallback_recv);
+        expect_true(result.found,
+                    "enable-after-enqueue returns Linux fallback timestamp");
+        if (result.found) {
+            int64_t timestamp = timeval_to_micros(result.value);
+            int64_t recv_start = timespec_to_micros(before_fallback_recv);
+            int64_t recv_end = timespec_to_micros(after_fallback_recv);
+            expect_true(timestamp >= recv_start - 1000 &&
+                            timestamp <= recv_end + 10000,
+                        "enable-after-enqueue fallback uses recvmsg time");
+        }
+    }
+
+    send_byte(sockets[0], 'D', "queue datagram while timestamping enabled");
+    set_timestamp_option(sockets[1], 0,
+                         "disable SO_TIMESTAMP before reading queued datagram");
+    if (recv_byte_with_timestamp(sockets[1], 0, 'D', &result,
+                                 "receive timestamped datagram after disable") ==
+        0) {
+        expect_no_timestamp(
+            &result,
+            "disabling before recvmsg suppresses queued timestamp delivery");
+    }
+
+    set_timestamp_option(sockets[1], 1,
+                         "re-enable SO_TIMESTAMP for MSG_PEEK");
+    send_byte(sockets[0], 'E', "send datagram for MSG_PEEK");
+    struct timestamp_result peeked;
+    struct timestamp_result consumed;
+    if (recv_byte_with_timestamp(sockets[1], MSG_PEEK, 'E', &peeked,
+                                 "peek timestamped datagram") == 0 &&
+        recv_byte_with_timestamp(sockets[1], 0, 'E', &consumed,
+                                 "consume timestamped datagram") == 0) {
+        expect_true(peeked.found && consumed.found,
+                    "peek and consume both return SCM_TIMESTAMP");
+        if (peeked.found && consumed.found) {
+            expect_true(peeked.value.tv_sec == consumed.value.tv_sec &&
+                            peeked.value.tv_usec == consumed.value.tv_usec,
+                        "MSG_PEEK preserves the datagram timestamp");
+        }
+    }
+
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+int main(void)
+{
+    printf("=== bugfix-socket-timestamp ===\n");
+
+    test_timestamp_delivery();
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_SOCKET_TIMESTAMP_PASSED\n");
+        printf("STARRY_GROUPED_TEST_PASSED: bugfix-socket-timestamp\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bugfix-socket-timestamp\n");
+    return EXIT_FAILURE;
+}

--- a/test-suit/starryos/qemu/system/bugfix-unix-listener-introspection/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-unix-listener-introspection/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bugfix-unix-listener-introspection C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-unix-listener-introspection src/main.c)
+target_compile_options(bugfix-unix-listener-introspection PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-unix-listener-introspection RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-unix-listener-introspection/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-unix-listener-introspection/src/main.c
@@ -1,0 +1,129 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void expect_true(int condition, const char *name)
+{
+    if (condition) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+    printf("FAIL: %s: errno=%d (%s)\n", name, errno, strerror(errno));
+    failed++;
+}
+
+static int read_int_option(int fd, int option, int *value, socklen_t *length)
+{
+    *value = -1;
+    *length = sizeof(*value);
+    errno = 0;
+    return getsockopt(fd, SOL_SOCKET, option, value, length);
+}
+
+int main(void)
+{
+    char socket_path[sizeof(((struct sockaddr_un *)0)->sun_path)];
+    snprintf(socket_path, sizeof(socket_path),
+             "/tmp/starry-unix-listener-%ld.sock", (long)getpid());
+    unlink(socket_path);
+
+    printf("=== bugfix-unix-listener-introspection ===\n");
+
+    int listener = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+    expect_true(listener >= 0, "create Unix stream socket");
+    if (listener >= 0) {
+        struct stat st;
+        expect_true(fstat(listener, &st) == 0 && S_ISSOCK(st.st_mode),
+                    "fstat reports a socket inode");
+
+        int value;
+        socklen_t option_length;
+        expect_true(read_int_option(listener, SO_TYPE, &value, &option_length) == 0 &&
+                        value == SOCK_STREAM &&
+                        option_length == sizeof(value),
+                    "SO_TYPE reports SOCK_STREAM");
+        expect_true(read_int_option(listener, SO_ACCEPTCONN, &value,
+                                    &option_length) == 0 &&
+                        value == 0 && option_length == sizeof(value),
+                    "SO_ACCEPTCONN is zero before listen");
+
+        struct sockaddr_un address = { .sun_family = AF_UNIX };
+        size_t socket_path_length = strlen(socket_path);
+        expect_true(socket_path_length < sizeof(address.sun_path),
+                    "socket pathname fits sockaddr_un");
+        memcpy(address.sun_path, socket_path, socket_path_length + 1);
+        socklen_t address_length =
+            offsetof(struct sockaddr_un, sun_path) + socket_path_length + 1;
+        expect_true(bind(listener, (struct sockaddr *)&address, address_length) == 0,
+                    "bind pathname Unix socket");
+
+        expect_true(read_int_option(listener, SO_ACCEPTCONN, &value,
+                                    &option_length) == 0 &&
+                        value == 0 && option_length == sizeof(value),
+                    "SO_ACCEPTCONN stays zero after bind");
+
+        int early_client = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+        expect_true(early_client >= 0, "create pre-listen client");
+        if (early_client >= 0) {
+            errno = 0;
+            int connect_result =
+                connect(early_client, (struct sockaddr *)&address, address_length);
+            expect_true(connect_result == -1 && errno == ECONNREFUSED,
+                        "connect is refused before listen");
+            close(early_client);
+        }
+
+        expect_true(listen(listener, 8) == 0, "listen on Unix stream socket");
+
+        expect_true(read_int_option(listener, SO_ACCEPTCONN, &value,
+                                    &option_length) == 0 &&
+                        value == 1 && option_length == sizeof(value),
+                    "SO_ACCEPTCONN is one after listen");
+
+        struct sockaddr_un local = {0};
+        socklen_t local_length = sizeof(local);
+        expect_true(getsockname(listener, (struct sockaddr *)&local,
+                                &local_length) == 0,
+                    "getsockname on Unix listener");
+        expect_true(local.sun_family == AF_UNIX,
+                    "getsockname reports AF_UNIX");
+        expect_true(local_length == address_length,
+                    "getsockname reports exact pathname length");
+        expect_true(strcmp(local.sun_path, socket_path) == 0,
+                    "getsockname reports bound pathname");
+
+        int duplicate = dup(listener);
+        expect_true(duplicate >= 0, "duplicate listener fd");
+        if (duplicate >= 0) {
+            expect_true(read_int_option(duplicate, SO_ACCEPTCONN, &value,
+                                        &option_length) == 0 &&
+                            value == 1 && option_length == sizeof(value),
+                        "duplicated fd remains a listening socket");
+            close(duplicate);
+        }
+        close(listener);
+    }
+    unlink(socket_path);
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_UNIX_LISTENER_INTROSPECTION_PASSED\n");
+        printf("STARRY_GROUPED_TEST_PASSED: bugfix-unix-listener-introspection\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bugfix-unix-listener-introspection\n");
+    return EXIT_FAILURE;
+}

--- a/test-suit/starryos/qemu/system/bugfix-unix-passcred/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-unix-passcred/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(bugfix-unix-passcred C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(bugfix-unix-passcred src/main.c)
+target_compile_options(bugfix-unix-passcred PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-unix-passcred RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-unix-passcred/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-unix-passcred/src/main.c
@@ -1,0 +1,213 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void expect_true(int condition, const char *name)
+{
+    if (condition) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+    printf("FAIL: %s: errno=%d (%s)\n", name, errno, strerror(errno));
+    failed++;
+}
+
+static int read_passcred(int fd, int *value)
+{
+    socklen_t length = sizeof(*value);
+    *value = -1;
+    errno = 0;
+    int result = getsockopt(fd, SOL_SOCKET, SO_PASSCRED, value, &length);
+    if (result == 0 && length != sizeof(*value)) {
+        errno = EPROTO;
+        return -1;
+    }
+    return result;
+}
+
+struct received_message {
+    ssize_t length;
+    int flags;
+    size_t control_length;
+    int has_credentials;
+    struct ucred credentials;
+};
+
+static struct received_message receive_message(int fd, int flags,
+                                               int provide_control)
+{
+    char payload[32] = {0};
+    struct iovec iov = {
+        .iov_base = payload,
+        .iov_len = sizeof(payload),
+    };
+    union {
+        struct cmsghdr align;
+        unsigned char bytes[CMSG_SPACE(sizeof(struct ucred))];
+    } control = {0};
+    struct msghdr message = {
+        .msg_iov = &iov,
+        .msg_iovlen = 1,
+        .msg_control = provide_control ? control.bytes : NULL,
+        .msg_controllen = provide_control ? sizeof(control.bytes) : 0,
+    };
+    struct received_message received = {
+        .length = recvmsg(fd, &message, flags),
+        .flags = message.msg_flags,
+        .control_length = message.msg_controllen,
+    };
+    if (received.length < 0) {
+        return received;
+    }
+
+    struct cmsghdr *cmsg = CMSG_FIRSTHDR(&message);
+    if (cmsg != NULL && cmsg->cmsg_level == SOL_SOCKET &&
+        cmsg->cmsg_type == SCM_CREDENTIALS &&
+        cmsg->cmsg_len == CMSG_LEN(sizeof(struct ucred))) {
+        memcpy(&received.credentials, CMSG_DATA(cmsg),
+               sizeof(received.credentials));
+        received.has_credentials = 1;
+    }
+    return received;
+}
+
+static int send_datagram(int fd, const char *payload)
+{
+    size_t length = strlen(payload);
+    return send(fd, payload, length, 0) == (ssize_t)length ? 0 : -1;
+}
+
+static int write_datagram(int fd, const char *payload)
+{
+    size_t length = strlen(payload);
+    return write(fd, payload, length) == (ssize_t)length ? 0 : -1;
+}
+
+int main(void)
+{
+    printf("=== bugfix-unix-passcred ===\n");
+
+    int sockets[2];
+    expect_true(socketpair(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0, sockets) == 0,
+                "create Unix datagram socketpair");
+    if (failed != 0) {
+        goto finish;
+    }
+
+    int enabled;
+    expect_true(read_passcred(sockets[0], &enabled) == 0 && enabled == 0,
+                "SO_PASSCRED is disabled initially");
+
+    enabled = 1;
+    expect_true(setsockopt(sockets[0], SOL_SOCKET, SO_PASSCRED, &enabled,
+                           sizeof(enabled)) == 0,
+                "enable SO_PASSCRED on receiver");
+    expect_true(read_passcred(sockets[0], &enabled) == 0 && enabled == 1,
+                "SO_PASSCRED enable state reads back");
+
+    pid_t child = fork();
+    expect_true(child >= 0, "fork credential sender");
+    if (child == 0) {
+        close(sockets[0]);
+        int result = send_datagram(sockets[1], "first") |
+                     send_datagram(sockets[1], "peek") |
+                     send_datagram(sockets[1], "truncate") |
+                     write_datagram(sockets[1], "write");
+        close(sockets[1]);
+        _exit(result == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
+    }
+    if (child < 0) {
+        close(sockets[0]);
+        close(sockets[1]);
+        goto finish;
+    }
+
+    close(sockets[1]);
+
+    struct received_message first = receive_message(sockets[0], 0, 1);
+    expect_true(first.length == 5, "receive first child datagram");
+    expect_true(first.has_credentials, "receive SCM_CREDENTIALS automatically");
+    expect_true(first.has_credentials && first.credentials.pid == child,
+                "SCM_CREDENTIALS reports sending child PID");
+    expect_true(first.has_credentials && first.credentials.uid == getuid(),
+                "SCM_CREDENTIALS reports sender real UID");
+    expect_true(first.has_credentials && first.credentials.gid == getgid(),
+                "SCM_CREDENTIALS reports sender real GID");
+
+    struct received_message peeked =
+        receive_message(sockets[0], MSG_PEEK, 1);
+    expect_true(peeked.length == 4 && peeked.has_credentials,
+                "MSG_PEEK reports credentials");
+    expect_true(peeked.has_credentials && peeked.credentials.pid == child,
+                "MSG_PEEK preserves sender PID");
+
+    struct received_message consumed = receive_message(sockets[0], 0, 1);
+    expect_true(consumed.length == 4 && consumed.has_credentials,
+                "consume after MSG_PEEK reports credentials");
+    expect_true(consumed.has_credentials &&
+                    consumed.credentials.pid == peeked.credentials.pid &&
+                    consumed.credentials.uid == peeked.credentials.uid &&
+                    consumed.credentials.gid == peeked.credentials.gid,
+                "peek and consume report identical credentials");
+
+    struct received_message truncated = receive_message(sockets[0], 0, 0);
+    expect_true(truncated.length == 8, "receive datagram without control buffer");
+    expect_true((truncated.flags & MSG_CTRUNC) != 0,
+                "missing credential control space sets MSG_CTRUNC");
+
+    struct received_message written = receive_message(sockets[0], 0, 1);
+    expect_true(written.length == 5, "receive write(2) datagram");
+    expect_true(written.has_credentials,
+                "write(2) automatically reports SCM_CREDENTIALS");
+    expect_true(written.has_credentials && written.credentials.pid == child,
+                "write(2) credentials report sending child PID");
+
+    int status = 0;
+    expect_true(waitpid(child, &status, 0) == child &&
+                    WIFEXITED(status) && WEXITSTATUS(status) == EXIT_SUCCESS,
+                "credential sender exits successfully");
+
+    enabled = 0;
+    expect_true(setsockopt(sockets[0], SOL_SOCKET, SO_PASSCRED, &enabled,
+                           sizeof(enabled)) == 0,
+                "disable SO_PASSCRED on receiver");
+    expect_true(read_passcred(sockets[0], &enabled) == 0 && enabled == 0,
+                "SO_PASSCRED disable state reads back");
+    close(sockets[0]);
+
+    expect_true(socketpair(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0, sockets) == 0,
+                "create disabled-state socketpair");
+    if (sockets[0] >= 0 && sockets[1] >= 0) {
+        expect_true(send_datagram(sockets[1], "disabled") == 0,
+                    "send with SO_PASSCRED disabled");
+        struct received_message disabled = receive_message(sockets[0], 0, 1);
+        expect_true(disabled.length == 8, "receive disabled-state datagram");
+        expect_true(!disabled.has_credentials &&
+                        (disabled.flags & MSG_CTRUNC) == 0 &&
+                        disabled.control_length == 0,
+                    "disabled SO_PASSCRED emits no credentials");
+        close(sockets[0]);
+        close(sockets[1]);
+    }
+
+finish:
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("STARRY_UNIX_PASSCRED_PASSED\n");
+        printf("STARRY_GROUPED_TEST_PASSED: bugfix-unix-passcred\n");
+        return EXIT_SUCCESS;
+    }
+    printf("STARRY_GROUPED_TEST_FAILED: bugfix-unix-passcred\n");
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
## 问题

StarryOS 的 Unix socket 缺少一组相互依赖的 Linux 兼容语义：

- datagram/seqpacket socket 不支持 `SO_TIMESTAMP` 与 `SCM_TIMESTAMP`；
- stream socket 无法通过 `SO_ACCEPTCONN` 等接口观察 listener 状态；
- socket 不支持 `SO_PASSCRED` 与自动生成的 `SCM_CREDENTIALS`。

其中 passcred 需要复用 Unix socket 的状态与消息 ancillary data 路径，因此与 listener、timestamp 放在同一分支中按依赖顺序提交，避免形成无法独立构建或验证的 PR。

本 PR 分支名为 `fix/ax-net-unix-timestamp-from-004`，内容从 `004-add-starry-nixos` 分支拆出，均通过 `git cherry-pick` 保留原实现和回归测试：

- receive timestamp：原提交 `f8d7f278c`，PR 分支提交 `c09c0549e`；
- listener state：原提交 `bcd4044ec86ff9ddf8f5c915970c19672fbfccac`，PR 分支提交 `f539c9a60`；
- pass credentials：原提交 `75a591f589d83579b2f93e1b0838ce9d0345313f`，PR 分支提交 `a4bd114a1`。

原提交中的 004/NixOS 专属进度文档在当前上游已删除，冲突解决时保留上游删除；网络实现和回归测试未重新实现。

## 修改

- 增加 socket receive timestamp 选项，在 Unix datagram/seqpacket 入队和接收路径传递 `SCM_TIMESTAMP`。
- 保持 enable-after-enqueue fallback、接收前 disable 和 `MSG_PEEK` 后再次消费时的时间戳语义。
- 为 TCP/Unix stream socket 暴露 listener 状态，支持 `SO_ACCEPTCONN`、listener `getsockname` 及复制 fd 后的状态观察。
- 增加 `SO_PASSCRED` 状态，在发送路径采集真实 PID/UID/GID，并通过 `SCM_CREDENTIALS` 返回。
- 保持 `MSG_PEEK` 凭据稳定性，并在控制缓冲区缺失或不足时设置 `MSG_CTRUNC`。
- 新增三个 QEMU 系统回归用例，分别覆盖 timestamp、listener introspection 和 passcred。

## 验证

使用项目 Podman 镜像和主工作区 `.ci-cache` 执行 focused 测试：

```text
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-socket-timestamp
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-unix-listener-introspection
cargo xtask starry test qemu --arch x86_64 -c qemu/system/bugfix-unix-passcred
```

- timestamp：30/30 通过，QEMU 汇总 `1/1` 通过。
- listener 红测：保留测试并恢复实现到 `HEAD^` 后，12 项通过、5 项失败；`SO_ACCEPTCONN` 返回 `ENOPROTOOPT`，pre-listen/listen 状态检查失败。
- listener 绿测：17/17 通过，QEMU 汇总 `1/1` 通过。
- passcred 红测：保留测试并恢复实现到 `HEAD^` 后，14 项通过、12 项失败；失败覆盖 `SO_PASSCRED` 状态回读、自动 `SCM_CREDENTIALS`、`MSG_PEEK` 和 `MSG_CTRUNC`。
- passcred 绿测：26/26 通过，QEMU 汇总 `1/1` 通过。
- 合并三段提交后重新回归 timestamp、listener、passcred，均通过。
- `cargo fmt --all -- --check` 通过。
- `git diff --check` 通过。

clippy 由 PR CI 执行。
