### PR TITLE
fix(starry-cred): ignore unused capbset drop arguments

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/task/ctl.rs
@@ -414,8 +414,9 @@ pub fn sys_prctl(
         }
         PR_CAPBSET_DROP => {
             // Permanently drop a capability from this thread's bounding set.
-            // Linux requires CAP_SETPCAP for this operation.
-            if arg2 > CAP_LAST_CAP as usize || arg3 != 0 || arg4 != 0 || arg5 != 0 {
+            // Linux consumes only arg2 for this variadic prctl option and
+            // requires CAP_SETPCAP for the operation.
+            if arg2 > CAP_LAST_CAP as usize {
                 return Err(AxError::InvalidInput);
             }
             let thread_ref = current();

--- a/test-suit/starryos/qemu/system/syscall-test-capset/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-capset/src/main.c
@@ -149,9 +149,12 @@ static void capbset_drop_child(void)
                  "PR_CAPBSET_READ sees dropped capability");
 
     errno = 0;
-    long ret = prctl_raw(PR_CAPBSET_DROP, CAP_SETUID, 1, 0, 0);
-    child_expect(ret == -1 && errno == EINVAL,
-                 "PR_CAPBSET_DROP rejects nonzero reserved args");
+    child_expect(prctl_raw(PR_CAPBSET_DROP, CAP_SETUID, 1, 2, 3) == 0,
+                 "PR_CAPBSET_DROP ignores unused trailing args");
+
+    errno = 0;
+    child_expect(prctl_raw(PR_CAPBSET_READ, CAP_SETUID, 0, 0, 0) == 0,
+                 "PR_CAPBSET_READ sees capability dropped with trailing args");
 }
 
 static void ambient_cap_child(void)


### PR DESCRIPTION
## 问题

StarryOS 当前把 `prctl(PR_CAPBSET_DROP, cap, arg3, arg4, arg5)` 的未使用 trailing arguments 当作必须为零，并在非零时返回 `EINVAL`。Linux 对这个 variadic prctl 操作只消费 capability 参数，用户态传入未使用寄存器值时仍应执行 bounding set drop。

本 PR 从 `004-add-starry-nixos` 分支的原提交 `3fec67ee5` 拆出，通过 `git cherry-pick` 保留原实现和测试修改。原提交附带的 004 进度文档未带入；`ctl.rs` 和 capset 测试的实际 diff 与原提交逐行一致。

## 修改

- `PR_CAPBSET_DROP` 仅校验 capability 编号是否超过 `CAP_LAST_CAP`。
- 不再校验未使用的 arg3/arg4/arg5。
- 更新现有 capset QEMU 回归，验证带非零 trailing args 的 drop 成功，并能通过 `PR_CAPBSET_READ` 观察结果。

该修改不改变 `CAP_SETPCAP` 权限检查，也不放宽 capability 编号的有效范围，只对齐未使用参数的 Linux 调用约定。

## 验证

使用项目容器及 `.ci-cache` 执行：

```text
cargo xtask starry test qemu --arch x86_64 -c qemu/system/syscall-test-capset
```

- 红测：临时恢复 `ctl.rs` 到 `HEAD^`、保留更新后的测试时，19 pass/1 fail；唯一失败为 nonzero trailing args 返回 `EINVAL`。
- 绿测：恢复 cherry-pick 后，20 pass/0 fail，`CAPSET_ALL_PASSED`，QEMU 汇总 `1/1` 通过。
- `cargo fmt --all -- --check` 通过。
- `git diff --check` 通过。

clippy 由 PR CI 执行。