### PR TITLE
fix(rknpu): set RK3588 NPU clock to 800 MHz

### DIFF
--- a/drivers/ax-driver/src/rknpu.rs
+++ b/drivers/ax-driver/src/rknpu.rs
@@ -1,8 +1,11 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{format, sync::Arc, vec::Vec};
 use core::any::Any;
 
 use log::info;
-use rdrive::{probe::OnProbeError, register::ProbeFdt};
+use rdrive::{
+    probe::{OnProbeError, fdt::FdtInfo},
+    register::ProbeFdt,
+};
 pub use rockchip_npu::{
     GemBufferInfo, GemCachePolicy, RknpuAction,
     ioctrl::{RknpuMemCreate, RknpuMemDestroy, RknpuMemMap, RknpuMemSync, RknpuSubmit},
@@ -10,6 +13,10 @@ pub use rockchip_npu::{
 use rockchip_npu::{Rknpu, RknpuConfig, RknpuType};
 
 use crate::mmio::iomap;
+
+const RK3588_NPU_CLOCK_NAME: &str = "clk_npu";
+// Highest RK3588 NPU OPP that needs no more than the firmware-provided 750 mV.
+const RK3588_NPU_FIXED_RATE_HZ: u64 = 800_000_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Error {
@@ -32,6 +39,7 @@ crate::model_register!(
 
 fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let (info, plat_dev) = probe.into_parts();
+    configure_fixed_clock(&info)?;
     let regs = info.node.regs();
 
     let config = RknpuConfig {
@@ -56,6 +64,22 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let npu = Rknpu::new(&base_regs, config, dma);
     plat_dev.register(npu);
     info!("NPU registered successfully");
+    Ok(())
+}
+
+fn configure_fixed_clock(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
+    let clock = info
+        .find_clock_line_by_name(RK3588_NPU_CLOCK_NAME)?
+        .ok_or_else(|| OnProbeError::other("RK3588 NPU clk_npu is unavailable"))?;
+    clock.set_rate(RK3588_NPU_FIXED_RATE_HZ)?;
+    let actual_rate = clock.rate()?;
+    if actual_rate != RK3588_NPU_FIXED_RATE_HZ {
+        return Err(OnProbeError::other(format!(
+            "RK3588 NPU clock rate mismatch: requested {} Hz, got {actual_rate} Hz",
+            RK3588_NPU_FIXED_RATE_HZ
+        )));
+    }
+    info!("RK3588 NPU fixed clock rate: {actual_rate} Hz");
     Ok(())
 }
 


### PR DESCRIPTION
## 背景

RK3588 的 assigned-clock 配置生效后，StarryOS 中 NPU 默认运行在200 MHz，导致 RKNN 推理性能明显下降。

Linux 会配合 regulator 和 devfreq 动态调整 NPU 电压与频率，但 StarryOS目前尚未实现完整的 NPU 调压和动态调频机制，因此不能直接固定为 Linux使用的 1 GHz。

## 修改内容

在 RK3588 NPU 驱动探测阶段：

- 获取 `clk_npu` 时钟；
- 将 NPU 固定设置为 800 MHz；
- 设置完成后读取实际频率；
- 实际频率不符合预期时返回错误，避免以未知频率继续运行；
- 输出最终生效的 NPU 频率。

800 MHz 是当前无需额外提高 NPU 电压即可使用的最高通用 OPP，因此能够在不引入 regulator/devfreq 完整实现的情况下安全恢复 NPU 性能。

## 性能对比

使用同一块 Orange Pi 5 Plus、同一 StarryOS 配置、同一模型和完整`run_robot_ci_once.sh native` 流程测试：

| 指标 | 200 MHz | 800 MHz |
| --- | ---: | ---: |
| 综合处理帧率 | 9.27 FPS | 18.15 FPS |
| RKNN 推理耗时 | 96.43 ms | 12.65 ms |
| 帧率提升 | - | 95.8% |
| 推理加速 | - | 7.63 倍 |

800 MHz 下两个连续 10 秒性能窗口分别达到：

- 18.49 FPS
- 17.81 FPS