### PR TITLE
feat(axvm): migrate to real Rust std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1236,8 +1236,10 @@ dependencies = [
  "ax-errno 0.6.2",
  "ax-hal",
  "ax-io",
+ "ax-kernel-guard",
  "ax-kspin",
  "ax-lazyinit",
+ "ax-percpu",
  "ax-posix-api",
  "ax-runtime",
  "ax-task",
@@ -1606,13 +1608,8 @@ dependencies = [
  "ax-cpumask",
  "ax-crate-interface",
  "ax-driver",
- "ax-hal",
- "ax-kernel-guard",
- "ax-kspin",
- "ax-lazyinit",
  "ax-memory-addr",
  "ax-memory-set",
- "ax-percpu",
  "ax-plat",
  "ax-std",
  "ax-timer-list",
@@ -1626,12 +1623,10 @@ dependencies = [
  "bit_field",
  "bitflags 2.13.1",
  "byte-unit",
- "cfg-if",
  "cpu-local",
  "extern-trait",
  "fdt-edit",
  "fdt-raw",
- "hashbrown 0.14.5",
  "irq-framework",
  "log",
  "loongarch_vcpu",
@@ -1643,7 +1638,6 @@ dependencies = [
  "rdrive",
  "riscv_vcpu",
  "riscv_vplic",
- "spin",
  "thiserror 2.0.19",
  "x86",
  "x86_vcpu",
@@ -3858,16 +3852,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.8",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash 0.8.12",
- "allocator-api2",
 ]
 
 [[package]]

--- a/book/design/axvm-host-application-boundary.md
+++ b/book/design/axvm-host-application-boundary.md
@@ -1,95 +1,74 @@
-# AxVM Host/Application Boundary
+# AxVM Host/Application 边界
 
-## Status
+## 状态
 
-This design records the dependency boundary used by Axvisor and AxVM. The
-change is behavior-preserving: it moves existing host operations behind a
-narrow owner-provided API without changing VM configuration or device handoff
-semantics.
+本文档记录 Axvisor 与 AxVM 之间的依赖边界。本次调整保持行为不变：现有宿主操作被收口到由所有者提供的窄接口之后，VM 配置和设备交接语义不变。
 
-## Problem
+## 问题
 
-Axvisor is the application that selects VM policy and orchestrates VM
-lifecycle. It previously depended directly on `ax-hal` for console and CPU
-operations and on `ax-driver` for the x86 QEMU block-device INTx handoff. Those
-dependencies exposed the implementation types of AxVM's ArceOS host adapter to
-the application and allowed the VM lifecycle to bypass its owner.
+Axvisor 是选择 VM 策略并编排 VM 生命周期的应用。此前它直接依赖 `ax-hal` 执行控制台和 CPU 操作，并依赖 `ax-driver` 完成 x86 QEMU 块设备的 INTx 交接。这些依赖把 AxVM ArceOS 宿主适配器的实现类型暴露给应用，也允许 VM 生命周期绕过其所有者。
 
-Axvisor also exposed aliases for board-driver features. That duplicated
-`ax-driver`'s hardware capability names and made it unclear whether the feature
-belonged to the application or to its build configuration.
+Axvisor 此前还导出了板级驱动 feature 的别名。这既重复了 `ax-driver` 的硬件能力名称，也使这些 feature 究竟属于应用还是构建配置变得不明确。
 
-## Goals
+## 目标
 
-- Keep Axvisor dependent on `axvm` for VM and VM-related host operations.
-- Keep host HAL and driver types out of the Axvisor API surface.
-- Preserve the single-reader host-console invariant.
-- Preserve the x86 passthrough ordering and error behavior.
-- Select board-driver features directly in build configuration without
-  exposing driver APIs or duplicate feature aliases in Axvisor.
+- Axvisor 通过 `axvm` 使用 VM 及 VM 相关的宿主操作。
+- 不在 Axvisor API 中暴露宿主 HAL 和驱动类型。
+- 保持宿主控制台只有一个读取者的约束。
+- 保持 x86 直通流程的操作顺序和错误行为。
+- 在构建配置中直接选择板级驱动 feature，不在 Axvisor 中暴露驱动 API 或重复的 feature 别名。
 
-## Non-goals
+## 非目标
 
-- Making AxVM independent from its ArceOS host adapter.
-- Defining a general-purpose public HAL or driver abstraction.
-- Changing host-console polling into an interrupt-driven design.
-- Generalizing the QEMU block passthrough profile to arbitrary PCI devices.
-- Changing guest configuration syntax, IRQ routing policy, or VM startup order.
+- 使 AxVM 脱离 ArceOS 宿主适配器。
+- 定义通用的公共 HAL 或驱动抽象。
+- 把宿主控制台轮询改为中断驱动。
+- 把 QEMU 块设备直通配置泛化到任意 PCI 设备。
+- 修改 guest 配置语法、IRQ 路由策略或 VM 启动顺序。
 
-## Considered Boundaries
+## 边界方案
 
-Keeping direct source-level access to the HAL and driver APIs was rejected
-because it preserves duplicated ownership of host state. Exporting the complete
-internal `HostCpu`, `HostMemory`, `HostTime`, and `HostPlatform` traits was
-rejected because it would turn implementation-oriented runtime capabilities
-into a broad public API. Adding raw HAL and driver wrappers to Axvisor was
-rejected because it only renames the dependency without correcting ownership.
+没有保留对 HAL 和驱动 API 的源码级直接访问，因为这会继续让多方共同持有宿主状态。没有导出完整的内部 `HostCpu`、`HostMemory`、`HostTime` 和 `HostPlatform` trait，因为这会把面向实现的运行时能力扩大为宽泛的公共 API。也没有在 Axvisor 中增加原始 HAL 和驱动包装，因为仅重命名依赖不能修正所有权。
 
-The selected boundary exposes only operations that the Axvisor application
-must orchestrate:
+选定的边界只暴露 Axvisor 应用必须编排的操作：
 
-- `axvm::host::console` controls and accesses the physical host console.
-- `axvm::host::cpu` reports host CPU topology needed for console-reader
-  placement.
-- `axvm::host::x86` owns the fixed QEMU block-device IRQ route and handoff.
+- `axvm::host::console` 控制并访问物理宿主控制台。
+- `axvm::host::cpu` 报告控制台读取任务选核所需的宿主 CPU 拓扑。
+- `axvm::host::x86` 持有固定的 QEMU 块设备 IRQ 路由和交接流程。
 
-The public functions use AxVM types or plain data only. `ax-hal` IRQ types,
-`ax-driver` PCI descriptors, and internal host traits remain private.
+公共函数只使用 AxVM 类型或普通数据。`ax-hal` IRQ 类型、`ax-driver` PCI 描述符和内部宿主 trait 均保持私有。
 
-## Ownership and Lifecycle
+## 所有权与生命周期
 
-Axvisor remains the policy owner: it decides when a filesystem-backed
-passthrough VM requires host resource release and when guest startup may
-continue. AxVM owns the mechanism and preserves this ordering:
+Axvisor 仍是策略所有者：它决定使用文件系统后端的直通 VM 何时需要释放宿主资源，以及 guest 何时可以继续启动。AxVM 持有具体机制并保持以下顺序：
 
-1. After the VM is registered, AxVM resolves the host PCI INTx binding and
-   installs the guest IOAPIC forwarding route and activation callback.
-2. Axvisor requests host-filesystem shutdown through AxVM.
-3. AxVM asks the host driver to prepare the QEMU block device for passthrough.
-4. When the forwarding route activates during guest startup, AxVM unmasks the
-   host INTx source.
+1. VM 注册后，AxVM 解析宿主 PCI INTx 绑定，并安装 guest IOAPIC 转发路由和激活回调。
+2. Axvisor 通过 AxVM 请求关闭宿主文件系统。
+3. AxVM 请求宿主驱动为 QEMU 块设备直通做好准备。
+4. guest 启动过程中转发路由激活时，AxVM 解除宿主 INTx 源的屏蔽。
 
-Route discovery and device preparation remain best-effort and log unsupported
-host configurations, matching the previous behavior. Failure to install an
-AxVM forwarding route remains a VM initialization error.
+路由发现和设备准备仍采用尽力而为的行为；不支持的宿主配置会被记录，这与此前行为一致。安装 AxVM 转发路由失败仍是 VM 初始化错误。
 
-The console API is task-context-only. Axvisor's multiplexer remains the sole
-physical input reader, disables input interrupts, and polls one byte at a time.
-The boundary does not introduce another buffer, reader, or IRQ callback.
+控制台 API 只能在任务上下文使用。Axvisor 的多路复用器仍是唯一的物理输入读取者：它关闭输入中断并逐字节轮询。该边界不引入额外缓冲区、读取者或 IRQ 回调。
 
-## Feature Ownership
+## Feature 所有权
 
-Axvisor board and test configurations select nested `ax-driver/<feature>`
-features directly. The optional Axvisor dependency is a Cargo feature-routing
-anchor: it becomes active only when a configuration selects one of those
-driver features, while Axvisor source code never calls the driver API. AxVM
-separately enables its x86 PCI driver dependency for the `host-fs` capability
-that performs the QEMU block-device handoff.
+Axvisor 的板级和测试配置直接选择嵌套的 `ax-driver/<feature>` feature。Axvisor 的可选依赖只是 Cargo feature 路由锚点：仅在配置选择某个驱动 feature 时启用，而 Axvisor 源码从不调用驱动 API。AxVM 则为执行 QEMU 块设备交接的 `host-fs` 能力单独启用其 x86 PCI 驱动依赖。
 
-## Validation
+## Rust 标准库边界
 
-The change is validated by checking that Axvisor's default graph has no direct
-dependency on `ax-hal`, `ax-driver`, `ax-kspin`, `ax-sync`, or `spin`; building
-Axvisor for x86_64, AArch64, and RISC-V; running targeted clippy checks; and
-exercising the Axvisor x86 QEMU/axtest flow where the environment provides the
-required guest image.
+AxVM 是仅支持 Rust `std` 的 crate。生产环境中的 Axvisor 消费者使用仓库为所请求架构提供的 RustStd/musl target 构建；axbuild 把 bare-metal 请求 target 映射到对应的 `*-unknown-linux-musl` PIE target，并同时构建 `std` 与 `panic_abort`。不再支持把 AxVM 独立构建为仅含 `core`/`alloc` 的 bare-metal 库。
+
+因此，AxVM 的集合、所有权内存、格式化、原子操作、时间、线程、`OnceLock` 和任务上下文 `Mutex` 状态都使用真实 `std` 接口，不使用 `ax-std` 中的同名 mini-std 替代品。宿主测试中的任务上下文 mutex 中毒后会保留并恢复受保护状态；生产构建采用 panic abort，不会在 unwind 后观察到中毒状态。
+
+`ax-std` 只保留为 AxVM 的 ArceOS 扩展边界。HAL、任务、中断、抢占 guard、per-CPU 和非休眠锁能力只能通过 `ax_std::os::arceos` 访问。特殊锁的语义化名称用于说明调用上下文约束：
+
+- `IrqSafeMutex` 在持锁期间关闭抢占和本地中断。
+- `NoPreemptMutex` 关闭抢占，且不得与 IRQ handler 共享。
+- `RawSpinLock` 不改变任何执行状态；调用方必须已经排除 CPU 迁移和中断重入。
+
+任务上下文注册表、CPU_ON acknowledgement、deferred worker 所有权、固件暂存和生命周期错误使用 `std::sync::Mutex`。VM/runtime 快照、待处理中断队列、vCPU 内部状态、timer wheel 和架构中断控制器状态继续使用非休眠锁，因为其调用链可能进入 IRQ、IPI、禁抢占或 guest-entry 路径。这些路径禁止获取可能阻塞的标准 mutex。混合对象把两类所有权域拆为独立字段；回调、通知和 IPI 均在锁临界区之外执行。
+
+## 验证
+
+Cargo metadata 契约测试禁止 AxVM 直接依赖 `ax-hal`、`ax-kernel-guard`、`ax-percpu`、`ax-lazyinit`、`ax-kspin`、`ax-sync` 或 `spin`；源码检查同时禁止这些实现路径和遗留的 `alloc` 访问。axbuild 测试要求 x86_64、AArch64、RISC-V 和 LoongArch64 的 Axvisor 请求全部选择对应 RustStd/musl target，并使用 `std + panic_abort`。针对性的 clippy、AxVM 宿主测试、四架构 Axvisor 构建和可用的 QEMU smoke 测试共同验证运行时边界保持不变。

--- a/os/arceos/ulib/axstd/Cargo.toml
+++ b/os/arceos/ulib/axstd/Cargo.toml
@@ -25,6 +25,16 @@ default = ["alloc", "tls", "fd"]
 # through their own `arceos` feature instead of axbuild completing it at runtime.
 arceos = ["irq", "paging", "std-compat", "smp"]
 
+# Host-side implementations for OS-specific ArceOS capabilities.
+host-test = [
+    "ax-api/host-test",
+    "ax-hal/host-test",
+    "ax-kernel-guard/host-test",
+    "ax-kspin/host-test",
+    "ax-percpu/host-test",
+    "ax-task/host-test",
+]
+
 # libc compatibility surface used when ax-std is linked as fake libc for Rust std.
 std-compat = ["ax-alloc/global-allocator", "ax-runtime/std-compat"]
 
@@ -125,8 +135,10 @@ ax-driver.workspace = true
 ax-errno.workspace = true
 ax-hal.workspace = true
 ax-io.workspace = true
+ax-kernel-guard.workspace = true
 ax-kspin.workspace = true
 ax-lazyinit.workspace = true
+ax-percpu.workspace = true
 ax-posix-api.workspace = true
 ax-runtime.workspace = true
 ax-task.workspace = true

--- a/os/arceos/ulib/axstd/src/os.rs
+++ b/os/arceos/ulib/axstd/src/os.rs
@@ -11,10 +11,65 @@
 pub mod arceos {
     /// ArceOS public API facade.
     pub use ax_api as api;
+
+    /// Guards for ArceOS interrupt and preemption contexts.
+    pub mod guard {
+        pub use ax_kernel_guard::{IrqSave, NoOp, NoPreempt, NoPreemptIrqSave};
+    }
+
     /// Lower-level ArceOS module facade for system components.
     #[doc(no_inline)]
     pub use ax_api::modules;
+    /// ArceOS host driver registry and firmware discovery capabilities.
+    #[doc(no_inline)]
+    pub use ax_driver as driver;
+    /// ArceOS per-CPU storage and CPU-pinning capabilities.
+    #[doc(no_inline)]
+    pub use ax_percpu as percpu;
+
+    /// Non-sleeping synchronization for ArceOS kernel contexts.
+    pub mod sync {
+        /// A mutex that disables preemption and local interrupts while held.
+        pub type IrqSafeMutex<T> = ax_kspin::SpinNoIrq<T>;
+        /// A guard returned by [`IrqSafeMutex::lock`].
+        pub type IrqSafeMutexGuard<'a, T> = ax_kspin::SpinNoIrqGuard<'a, T>;
+
+        /// A mutex that disables preemption while held.
+        ///
+        /// Callers must ensure the lock is not used by an interrupt handler.
+        pub type NoPreemptMutex<T> = ax_kspin::SpinNoPreempt<T>;
+        /// A guard returned by [`NoPreemptMutex::lock`].
+        pub type NoPreemptMutexGuard<'a, T> = ax_kspin::SpinNoPreemptGuard<'a, T>;
+
+        /// A raw spin lock that does not alter interrupt or preemption state.
+        ///
+        /// Callers must disable preemption and local interrupts before taking
+        /// this lock, or prove that interrupt handlers never acquire it.
+        pub type RawSpinLock<T> = ax_kspin::SpinRaw<T>;
+        /// A guard returned by [`RawSpinLock::lock`].
+        pub type RawSpinLockGuard<'a, T> = ax_kspin::SpinRawGuard<'a, T>;
+    }
 }
 
 #[cfg(feature = "std-compat")]
 pub mod libc_compat;
+
+#[cfg(all(test, feature = "host-test"))]
+mod tests {
+    use super::arceos::sync::{IrqSafeMutex, NoPreemptMutex, RawSpinLock};
+
+    static IRQ_SAFE: IrqSafeMutex<usize> = IrqSafeMutex::new(0);
+    static NO_PREEMPT: NoPreemptMutex<usize> = NoPreemptMutex::new(0);
+    static RAW: RawSpinLock<usize> = RawSpinLock::new(0);
+
+    #[test]
+    fn special_locks_support_const_initialization_and_try_lock() {
+        *IRQ_SAFE.lock() += 1;
+        *NO_PREEMPT.lock() += 1;
+        *RAW.lock() += 1;
+
+        assert_eq!(*IRQ_SAFE.try_lock().unwrap(), 1);
+        assert_eq!(*NO_PREEMPT.try_lock().unwrap(), 1);
+        assert_eq!(*RAW.try_lock().unwrap(), 1);
+    }
+}

--- a/scripts/axbuild/src/axvisor/build/tests.rs
+++ b/scripts/axbuild/src/axvisor/build/tests.rs
@@ -112,6 +112,62 @@ fn axvisor_host_xtask_is_opt_in() {
 }
 
 #[test]
+fn axvisor_all_architectures_use_rust_std_musl_with_abort_panics() {
+    let cases = [
+        (
+            "x86_64",
+            "x86_64-unknown-none",
+            "x86_64-unknown-linux-musl.json",
+        ),
+        (
+            "aarch64",
+            "aarch64-unknown-none-softfloat",
+            "aarch64-unknown-linux-musl.json",
+        ),
+        (
+            "riscv64",
+            "riscv64gc-unknown-none-elf",
+            "riscv64gc-unknown-linux-musl.json",
+        ),
+        (
+            "loongarch64",
+            "loongarch64-unknown-none-softfloat",
+            "loongarch64-unknown-linux-musl.json",
+        ),
+    ];
+
+    for (arch, target, std_target) in cases {
+        let root = tempdir().unwrap();
+        let config_path = root.path().join(format!(".{arch}-build.toml"));
+        fs::write(&config_path, "features = []\nlog = \"Info\"\n").unwrap();
+
+        let cargo = load_cargo_config(&request(config_path, arch, target)).unwrap();
+        assert!(
+            cargo
+                .target
+                .ends_with(&format!("scripts/targets/std/pie/{std_target}")),
+            "{arch} Axvisor must use its RustStd/musl PIE target"
+        );
+
+        let config: toml::Table =
+            toml::from_str(&fs::read_to_string(cargo.extra_config.unwrap()).unwrap()).unwrap();
+        assert_eq!(
+            config["unstable"]["build-std"].as_array().unwrap(),
+            &vec![
+                toml::Value::String("std".to_string()),
+                toml::Value::String("panic_abort".to_string()),
+            ],
+            "{arch} Axvisor must build real Rust std and panic_abort"
+        );
+        assert_eq!(
+            config["profile"]["release"]["panic"].as_str(),
+            Some("abort"),
+            "{arch} Axvisor release profile must abort on panic"
+        );
+    }
+}
+
+#[test]
 fn resolve_build_info_path_uses_default_axvisor_location() {
     let root = tempdir().unwrap();
     let path = resolve_build_info_path(

--- a/scripts/axbuild/src/build/tests/metadata.rs
+++ b/scripts/axbuild/src/build/tests/metadata.rs
@@ -71,3 +71,30 @@ fn unknown_ax_hal_features_are_not_platforms() {
         assert_eq!(ax_hal_platform_feature_name(feature, Some(&metadata)), None);
     }
 }
+
+#[test]
+fn axvm_os_implementation_dependencies_are_facaded_by_ax_std() {
+    let metadata = repo_metadata();
+    let axvm = workspace_package(&metadata, "axvm").unwrap();
+    let forbidden = [
+        "ax-hal",
+        "ax-kernel-guard",
+        "ax-kspin",
+        "ax-lazyinit",
+        "ax-percpu",
+        "ax-sync",
+        "spin",
+    ];
+
+    let direct_forbidden = axvm
+        .dependencies
+        .iter()
+        .filter(|dependency| forbidden.contains(&dependency.name.as_str()))
+        .map(|dependency| dependency.name.as_str())
+        .collect::<Vec<_>>();
+
+    assert!(
+        direct_forbidden.is_empty(),
+        "axvm must obtain OS implementation capabilities through ax-std: {direct_forbidden:?}"
+    );
+}

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -3,7 +3,7 @@ name = "axvm"
 authors = ["aarkegz <aarkegz@gmail.com>"]
 version = "0.5.25"
 edition.workspace = true
-categories = ["virtualization", "no-std"]
+categories = ["virtualization"]
 description = "Virtual Machine resource management crate for ArceOS's hypervisor variant."
 repository = "https://github.com/arceos-hypervisor/axvm"
 keywords = ["vm", "hypervisor", "arceos"]
@@ -13,39 +13,29 @@ license = "Apache-2.0"
 fs = ["ax-std/fs"]
 host-fs = ["ax-std/fs", "dep:ax-driver"]
 host-test = [
-    "ax-hal/host-test",
-    "ax-kspin/host-test",
-    "ax-kernel-guard/host-test",
+    "ax-std/host-test",
     "axdevice/host-test",
 ]
 sstc = ["riscv_vcpu/sstc"]
-tls = ["ax-hal/tls", "ax-std/tls", "cpu-local/tls"]
+tls = ["ax-std/tls", "cpu-local/tls"]
 
 [dependencies]
 log = "0.4"
-cfg-if = "1.0"
 extern-trait = { workspace = true }
 bit_field = "0.10"
 bitflags = "2.9"
 byte-unit = { version = "5", default-features = false, features = ["byte"] }
 numeric-enum-macro = "0.2"
-spin = { workspace = true }
 thiserror = { workspace = true }
 
 # System independent crates provided by ArceOS.
 ax-cpumask = { workspace = true }
 ax-crate-interface = { workspace = true }
-ax-kernel-guard = { workspace = true }
-ax-kspin.workspace = true
-ax-lazyinit = { workspace = true }
 ax-memory-addr = { workspace = true }
 ax-memory-set = { workspace = true }
-ax-percpu.workspace = true
 cpu-local.workspace = true
 page-table-generic = { workspace = true }
 ax-std = { workspace = true, default-features = false, features = [
-    "alloc",
-    "fd",
     "paging",
     "irq",
     "multitask",
@@ -54,7 +44,6 @@ ax-std = { workspace = true, default-features = false, features = [
     "hv",
     "ipi",
 ] }
-ax-hal = { workspace = true, features = ["ipi"] }
 ax-timer-list = { workspace = true }
 irq-framework = { workspace = true }
 # System dependent modules provided by ArceOS-Hypervisor.
@@ -66,7 +55,6 @@ axdevice_base = { workspace = true }
 axvmconfig = { workspace = true, default-features = false }
 fdt-edit = { workspace = true }
 fdt-raw = { workspace = true }
-hashbrown = "0.14"
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 ax-driver = { workspace = true, optional = true, features = ["pci"] }
 x86 = "0.52"
@@ -77,7 +65,6 @@ ax-plat = { workspace = true }
 riscv_vcpu = { workspace = true }
 riscv_vplic = { workspace = true }
 [target.'cfg(target_arch = "loongarch64")'.dependencies]
-ax-driver = { workspace = true }
 ax-plat = { workspace = true }
 loongarch_vcpu = { workspace = true }
 [target.'cfg(target_arch = "aarch64")'.dependencies]
@@ -92,7 +79,4 @@ rdrive.workspace = true
 rdif-clk.workspace = true
 
 [dev-dependencies]
-ax-hal = { workspace = true, features = ["host-test"] }
-ax-kernel-guard = { workspace = true, features = ["host-test"] }
-ax-kspin = { workspace = true, features = ["host-test"] }
 rdif-clk.workspace = true

--- a/virtualization/axvm/src/arch/aarch64/capabilities.rs
+++ b/virtualization/axvm/src/arch/aarch64/capabilities.rs
@@ -1,6 +1,6 @@
 //! AArch64 implementations of AxVM platform capability hooks.
 
-use alloc::format;
+use std::format;
 
 use super::Aarch64Arch;
 use crate::{
@@ -22,7 +22,7 @@ impl BootImagePlatform for Aarch64Arch {
         dtb: &crate::boot::fdt::GuestDtbImage,
     ) -> AxVmResult {
         let bytes = dtb.as_bytes();
-        let source = core::ptr::NonNull::new(bytes.as_ptr() as *mut u8)
+        let source = std::ptr::NonNull::new(bytes.as_ptr() as *mut u8)
             .ok_or_else(|| ax_err_type!(InvalidData, "Guest DTB pointer is null"))?;
         super::fdt::core::update_fdt(source, bytes.len(), loader.vm.clone(), &loader.config)
     }
@@ -72,7 +72,7 @@ pub(super) fn patch_runtime_fdt(
     fdt_bytes: &[u8],
     vm: &crate::AxVMRef,
     crate_config: &axvmconfig::GuestConfig,
-) -> AxVmResult<alloc::vec::Vec<u8>> {
+) -> AxVmResult<std::vec::Vec<u8>> {
     let (initrd, serial_profile, serial_identity, gic_profile, timer_profile) =
         vm.with_config(|config| {
             (
@@ -103,7 +103,7 @@ pub(super) fn patch_provided_fdt(
     provided_dtb: &[u8],
     host_dtb: Option<&[u8]>,
     crate_config: &axvmconfig::GuestConfig,
-) -> AxVmResult<alloc::vec::Vec<u8>> {
+) -> AxVmResult<std::vec::Vec<u8>> {
     let provided_fdt = fdt_edit::Fdt::from_bytes(provided_dtb).map_err(|err| {
         ax_err_type!(
             InvalidData,

--- a/virtualization/axvm/src/arch/aarch64/fdt.rs
+++ b/virtualization/axvm/src/arch/aarch64/fdt.rs
@@ -1,6 +1,6 @@
 //! AArch64 compatibility facade and target-specific guest FDT policy.
 
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 use fdt_edit::Fdt;
 

--- a/virtualization/axvm/src/arch/aarch64/gic.rs
+++ b/virtualization/axvm/src/arch/aarch64/gic.rs
@@ -1,6 +1,6 @@
 //! AArch64 GIC host operations for the ArceOS-backed AxVM runtime.
 
-use alloc::{
+use std::{
     collections::BTreeMap,
     sync::{Arc, Weak},
 };
@@ -11,7 +11,7 @@ use arm_vgic::{
     HostGicVersion, IntId, PhysicalInterruptBinding, PhysicalIrqId, PpiId, VgicBackendCapabilities,
     VgicCore, VgicError, VgicResult,
 };
-use ax_kspin::SpinNoIrq;
+use ax_std::os::arceos::sync::IrqSafeMutex;
 use axdevice_base::InterruptTrigger;
 
 use super::vtimer::Aarch64TimerBinding;
@@ -58,8 +58,8 @@ enum PhysicalSpiTarget {
 /// Checked bridge from the VM-local controller to the current host GIC.
 pub(crate) struct AxvmVgicBackend {
     capabilities: VgicBackendCapabilities,
-    physical_spis: SpinNoIrq<BTreeMap<PhysicalIrqId, PhysicalSpiSnapshot>>,
-    timer_ppis: SpinNoIrq<BTreeMap<(GicVcpuId, IntId), Weak<Aarch64TimerBinding>>>,
+    physical_spis: IrqSafeMutex<BTreeMap<PhysicalIrqId, PhysicalSpiSnapshot>>,
+    timer_ppis: IrqSafeMutex<BTreeMap<(GicVcpuId, IntId), Weak<Aarch64TimerBinding>>>,
 }
 
 impl AxvmVgicBackend {
@@ -67,8 +67,8 @@ impl AxvmVgicBackend {
     pub(crate) fn new() -> Result<Self, GicV3BackendError> {
         Ok(Self {
             capabilities: cpu_interface::capabilities()?,
-            physical_spis: SpinNoIrq::new(BTreeMap::new()),
-            timer_ppis: SpinNoIrq::new(BTreeMap::new()),
+            physical_spis: IrqSafeMutex::new(BTreeMap::new()),
+            timer_ppis: IrqSafeMutex::new(BTreeMap::new()),
         })
     }
 
@@ -83,7 +83,7 @@ impl AxvmVgicBackend {
         if timer_ppis.get(&key).and_then(Weak::upgrade).is_some() {
             return Err(VgicError::ResourceConflict {
                 resource: "host virtual-timer PPI binding",
-                detail: alloc::format!(
+                detail: std::format!(
                     "vCPU {} INTID {} already has a live binding",
                     vcpu.raw(),
                     ppi.raw()
@@ -106,13 +106,13 @@ impl AxvmVgicBackend {
         let raw = u32::try_from(binding.host().raw()).map_err(|_| {
             GicV3BackendError::new(
                 operation,
-                alloc::format!("host IRQ {} does not fit a GIC INTID", binding.host().raw()),
+                std::format!("host IRQ {} does not fit a GIC INTID", binding.host().raw()),
             )
         })?;
         if raw != binding.guest().raw() {
             return Err(GicV3BackendError::new(
                 operation,
-                alloc::format!(
+                std::format!(
                     "identity forwarding requires guest INTID {} to equal host INTID {raw}",
                     binding.guest().raw()
                 ),
@@ -121,7 +121,7 @@ impl AxvmVgicBackend {
         arm_gic_driver::checked_intid(raw, 1020).map_err(|_| {
             GicV3BackendError::new(
                 operation,
-                alloc::format!("host INTID {raw} is outside the assignable GIC range"),
+                std::format!("host INTID {raw} is outside the assignable GIC range"),
             )
         })
     }
@@ -162,7 +162,7 @@ impl GicV3Backend for AxvmVgicBackend {
             return Ok(());
         };
         binding.retire_host_activation().map_err(|error| {
-            GicV3BackendError::new("retire host virtual-timer PPI", alloc::format!("{error}"))
+            GicV3BackendError::new("retire host virtual-timer PPI", std::format!("{error}"))
         })
     }
 
@@ -203,7 +203,7 @@ impl GicV3Backend for AxvmVgicBackend {
         if bindings.contains_key(&binding.host()) {
             return Err(GicV3BackendError::new(
                 "bind physical interrupt",
-                alloc::format!("host INTID {} is already bound", binding.host().raw()),
+                std::format!("host INTID {} is already bound", binding.host().raw()),
             ));
         }
         bindings.insert(binding.host(), snapshot);
@@ -229,7 +229,7 @@ impl GicV3Backend for AxvmVgicBackend {
         if !self.physical_spis.lock().contains_key(&binding.host()) {
             return Err(GicV3BackendError::new(
                 "set physical interrupt enable state",
-                alloc::format!("host INTID {} is not bound", binding.host().raw()),
+                std::format!("host INTID {} is not bound", binding.host().raw()),
             ));
         }
         set_physical_enabled(self.capabilities.host_version(), intid, enabled)
@@ -243,7 +243,7 @@ impl GicV3Backend for AxvmVgicBackend {
         if vcpu != binding.target() {
             return Err(GicV3BackendError::new(
                 "complete physical interrupt",
-                alloc::format!(
+                std::format!(
                     "binding targets vCPU {}, but vCPU {} issued DIR",
                     binding.target().raw(),
                     vcpu.raw()
@@ -259,7 +259,7 @@ impl GicV3Backend for AxvmVgicBackend {
         .ok_or_else(|| {
             GicV3BackendError::new(
                 "complete physical interrupt",
-                alloc::format!(
+                std::format!(
                     "host INTID {} has no active assigned-SPI delivery",
                     binding.host().raw()
                 ),
@@ -275,7 +275,7 @@ impl GicV3Backend for AxvmVgicBackend {
         if vcpu != binding.target() {
             return Err(GicV3BackendError::new(
                 "deactivate physical interrupt",
-                alloc::format!(
+                std::format!(
                     "binding targets vCPU {}, but vCPU {} requested forced deactivation",
                     binding.target().raw(),
                     vcpu.raw()
@@ -291,7 +291,7 @@ impl GicV3Backend for AxvmVgicBackend {
         if completed.is_none() {
             return Err(GicV3BackendError::new(
                 "deactivate physical interrupt",
-                alloc::format!(
+                std::format!(
                     "host INTID {} has no active assigned-SPI delivery",
                     binding.host().raw()
                 ),
@@ -312,7 +312,7 @@ impl GicV3Backend for AxvmVgicBackend {
             .ok_or_else(|| {
                 GicV3BackendError::new(
                     "unbind physical interrupt",
-                    alloc::format!("host INTID {} is not bound", binding.host().raw()),
+                    std::format!("host INTID {} is not bound", binding.host().raw()),
                 )
             })?;
         if let Err(error) =
@@ -353,7 +353,7 @@ fn configure_physical_interrupt(
     .ok_or_else(|| {
         GicV3BackendError::new(
             "configure assigned physical interrupt",
-            alloc::format!("the registered interrupt controller does not match {version:?}"),
+            std::format!("the registered interrupt controller does not match {version:?}"),
         )
     })
 }
@@ -368,7 +368,7 @@ fn physical_spi_target(
             let hardware_cpu_id = usize::try_from(affinity.mpidr()).map_err(|_| {
                 GicV3BackendError::new(
                     "target assigned physical interrupt",
-                    alloc::format!("host CPU affinity {affinity:?} does not fit usize"),
+                    std::format!("host CPU affinity {affinity:?} does not fit usize"),
                 )
             })?;
             let target = try_with_gic("target assigned physical interrupt", |intc| {
@@ -378,7 +378,7 @@ fn physical_spi_target(
             .ok_or_else(|| {
                 GicV3BackendError::new(
                     "target assigned physical interrupt",
-                    alloc::format!(
+                    std::format!(
                         "GICv2 cannot route host INTID {} to affinity {affinity:?}: the host CPU \
                          route is not initialized",
                         binding.host().raw()
@@ -420,7 +420,7 @@ fn restore_physical_interrupt(
     .ok_or_else(|| {
         GicV3BackendError::new(
             "restore assigned physical interrupt",
-            alloc::format!("the registered interrupt controller does not match {version:?}"),
+            std::format!("the registered interrupt controller does not match {version:?}"),
         )
     })
 }
@@ -441,7 +441,7 @@ fn set_physical_enabled(
     .ok_or_else(|| {
         GicV3BackendError::new(
             "set physical interrupt enable state",
-            alloc::format!("the registered interrupt controller does not match {version:?}"),
+            std::format!("the registered interrupt controller does not match {version:?}"),
         )
     })
 }
@@ -449,7 +449,7 @@ fn set_physical_enabled(
 fn instruction_sync_barrier() {
     // SAFETY: `isb` only synchronizes preceding GIC register operations on the
     // current CPU and does not access Rust memory.
-    unsafe { core::arch::asm!("isb", options(nostack, preserves_flags)) };
+    unsafe { std::arch::asm!("isb", options(nostack, preserves_flags)) };
 }
 
 pub(crate) fn backend() -> Result<Arc<AxvmVgicBackend>, GicV3BackendError> {
@@ -486,7 +486,7 @@ pub(crate) fn host_spi_count() -> Result<usize, GicV3BackendError> {
     GicV3HardwareCapabilities::from_distributor_typer(typer)
         .map(|capabilities| capabilities.spi_count())
         .map_err(|error| {
-            GicV3BackendError::new("inspect host SPI capacity", alloc::format!("{error}"))
+            GicV3BackendError::new("inspect host SPI capacity", std::format!("{error}"))
         })
 }
 

--- a/virtualization/axvm/src/arch/aarch64/gic/cpu_interface.rs
+++ b/virtualization/axvm/src/arch/aarch64/gic/cpu_interface.rs
@@ -1,5 +1,7 @@
 //! Checked GICH/ICH register save and restore.
 
+use std::sync::OnceLock;
+
 use arm_gic_driver::v3::{
     ICH_AP1R0_EL2, ICH_AP1R1_EL2, ICH_AP1R2_EL2, ICH_AP1R3_EL2, ICH_HCR_EL2, ICH_LR_EL2,
     ICH_VMCR_EL2, ICH_VTR_EL2, LocalRegisterCopy, Readable, Writeable, ich_lr_el2_get,
@@ -10,15 +12,14 @@ use arm_vgic::{
     CpuInterfaceState, GicV3BackendError, GicVcpuId, HostGicVersion, IntId, InterruptState,
     ListRegisterBacking, ListRegisterState, PhysicalIrqId, Priority, VgicBackendCapabilities,
 };
-use ax_kspin::SpinNoIrq;
-use spin::Once;
+use ax_std::os::arceos::sync::IrqSafeMutex;
 
 const V2_SGI_TOKEN: usize = 1usize << (usize::BITS as usize - 1);
 const V2_SGI_SOURCE_SHIFT: usize = 24;
 
 enum HostCpuInterface {
     V2 {
-        hypervisor: SpinNoIrq<arm_gic_driver::v2::HypervisorInterface>,
+        hypervisor: IrqSafeMutex<arm_gic_driver::v2::HypervisorInterface>,
         trap: arm_gic_driver::v2::TrapOp,
         capabilities: VgicBackendCapabilities,
         irq_config: ArmHostIrqConfig,
@@ -43,14 +44,14 @@ impl HostCpuInterface {
     }
 }
 
-static HOST_CPU_INTERFACE: Once<HostCpuInterface> = Once::new();
+static HOST_CPU_INTERFACE: OnceLock<HostCpuInterface> = OnceLock::new();
 
 fn host_cpu_interface() -> Result<&'static HostCpuInterface, GicV3BackendError> {
     // Discovery is the only operation that takes the `rdrive` device lock.
     // The returned register capability is immutable, and every vCPU/IRQ hot
     // path below uses it directly so a hard IRQ cannot re-enter `rdrive` while
     // interrupted code already owns the same non-IRQ-safe device lock.
-    HOST_CPU_INTERFACE.try_call_once(discover_host_cpu_interface)
+    HOST_CPU_INTERFACE.get_or_try_init(discover_host_cpu_interface)
 }
 
 fn discover_host_cpu_interface() -> Result<HostCpuInterface, GicV3BackendError> {
@@ -76,7 +77,7 @@ fn discover_host_cpu_interface() -> Result<HostCpuInterface, GicV3BackendError> 
                 false,
             );
             return Ok(HostCpuInterface::V2 {
-                hypervisor: SpinNoIrq::new(interface),
+                hypervisor: IrqSafeMutex::new(interface),
                 trap: gic.cpu_interface().trap_operations(),
                 capabilities,
                 irq_config,
@@ -143,7 +144,7 @@ fn checked_host_cpu_interface(
     if discovered != capabilities {
         return Err(GicV3BackendError::new(
             operation,
-            alloc::format!(
+            std::format!(
                 "cached host capabilities {discovered:?} do not match backend capabilities \
                  {capabilities:?}"
             ),
@@ -153,7 +154,7 @@ fn checked_host_cpu_interface(
 }
 
 fn load_v2(
-    hypervisor: &SpinNoIrq<arm_gic_driver::v2::HypervisorInterface>,
+    hypervisor: &IrqSafeMutex<arm_gic_driver::v2::HypervisorInterface>,
     state: &CpuInterfaceState,
 ) -> Result<(), GicV3BackendError> {
     let interface = hypervisor.lock();
@@ -181,7 +182,7 @@ fn load_v2(
 }
 
 fn save_v2(
-    hypervisor: &SpinNoIrq<arm_gic_driver::v2::HypervisorInterface>,
+    hypervisor: &IrqSafeMutex<arm_gic_driver::v2::HypervisorInterface>,
     state: &mut CpuInterfaceState,
 ) -> Result<(), GicV3BackendError> {
     let interface = hypervisor.lock();
@@ -198,7 +199,7 @@ fn save_v2(
         let raw = interface.list_register_raw(index).ok_or_else(|| {
             GicV3BackendError::new(
                 "save GICv2 list register",
-                alloc::format!("GICH_LR{index} is not implemented"),
+                std::format!("GICH_LR{index} is not implemented"),
             )
         })?;
         *slot = decode_v2_list_register(index, raw, *slot)?;
@@ -261,7 +262,7 @@ pub(super) fn deactivate_host_irq(token: usize) -> Result<(), GicV3BackendError>
             let intid = arm_gic_driver::checked_intid(raw, 1020).map_err(|_| {
                 GicV3BackendError::new(
                     "deactivate acknowledged host IRQ",
-                    alloc::format!("INTID {raw} is outside the GICv2 interrupt range"),
+                    std::format!("INTID {raw} is outside the GICv2 interrupt range"),
                 )
             })?;
             let ack = if token & V2_SGI_TOKEN != 0 {
@@ -282,7 +283,7 @@ pub(super) fn deactivate_host_irq(token: usize) -> Result<(), GicV3BackendError>
             let intid = arm_gic_driver::checked_intid(raw, 1 << 24).map_err(|_| {
                 GicV3BackendError::new(
                     "deactivate acknowledged host IRQ",
-                    alloc::format!("INTID {raw} is outside the GICv3 interrupt range"),
+                    std::format!("INTID {raw} is outside the GICv3 interrupt range"),
                 )
             })?;
             arm_gic_driver::v3::dir(intid);
@@ -329,13 +330,13 @@ fn encode_v2_list_register(entry: ListRegisterState) -> Result<u32, GicV3Backend
             let physical = u32::try_from(physical.raw()).map_err(|_| {
                 GicV3BackendError::new(
                     "encode GICv2 list register",
-                    alloc::format!("physical IRQ {} does not fit GICH_LR", physical.raw()),
+                    std::format!("physical IRQ {} does not fit GICH_LR", physical.raw()),
                 )
             })?;
             if physical >= 1024 {
                 return Err(GicV3BackendError::new(
                     "encode GICv2 list register",
-                    alloc::format!("physical IRQ {physical} exceeds the 10-bit GICH_LR field"),
+                    std::format!("physical IRQ {physical} exceeds the 10-bit GICH_LR field"),
                 ));
             }
             raw |= (physical << 10) | (1 << 31);
@@ -388,7 +389,7 @@ fn load_v3(state: &CpuInterfaceState) -> Result<(), GicV3BackendError> {
     if state.apr()[apr_count..].iter().any(|value| *value != 0) {
         return Err(GicV3BackendError::new(
             "load GICv3 active priorities",
-            alloc::format!("saved state uses APR{apr_count} or above"),
+            std::format!("saved state uses APR{apr_count} or above"),
         ));
     }
 
@@ -424,7 +425,7 @@ fn save_v3(state: &mut CpuInterfaceState) -> Result<(), GicV3BackendError> {
             if !state.set_apr(index, value) {
                 return Err(GicV3BackendError::new(
                     "save GICv3 active priorities",
-                    alloc::format!("APR index {index} is outside saved state"),
+                    std::format!("APR index {index} is outside saved state"),
                 ));
             }
         }
@@ -452,7 +453,7 @@ fn hardware_v3_apr_count() -> Result<usize, GicV3BackendError> {
         7 => Ok(4),
         count => Err(GicV3BackendError::new(
             "inspect GICv3 active-priority registers",
-            alloc::format!("unsupported preemption-bit count {count}"),
+            std::format!("unsupported preemption-bit count {count}"),
         )),
     }
 }
@@ -514,7 +515,7 @@ fn write_v3_list_register(index: usize, entry: ListRegisterState) -> Result<(), 
         let pintid = u16::try_from(physical.raw()).map_err(|_| {
             GicV3BackendError::new(
                 "encode GICv3 list register",
-                alloc::format!("physical IRQ {} does not fit PINTID", physical.raw()),
+                std::format!("physical IRQ {} does not fit PINTID", physical.raw()),
             )
         })?;
         fields = fields + ICH_LR_EL2::HW::SET + ICH_LR_EL2::PINTID.val(u64::from(pintid));
@@ -536,7 +537,7 @@ fn read_v3_list_register(
         value => {
             return Err(GicV3BackendError::new(
                 "decode GICv3 list register",
-                alloc::format!("LR{index} has invalid state {value}"),
+                std::format!("LR{index} has invalid state {value}"),
             ));
         }
     };
@@ -566,7 +567,7 @@ fn decode_intid(index: usize, raw: u32, version: &'static str) -> Result<IntId, 
     IntId::new(raw).map_err(|error| {
         GicV3BackendError::new(
             "decode virtual list register",
-            alloc::format!("{version} LR{index} contains invalid INTID {raw}: {error}"),
+            std::format!("{version} LR{index} contains invalid INTID {raw}: {error}"),
         )
     })
 }
@@ -579,7 +580,7 @@ fn require_software_backing(
     if previous.is_some_and(|entry| matches!(entry.backing(), ListRegisterBacking::Physical(_))) {
         Err(GicV3BackendError::new(
             "decode virtual list register",
-            alloc::format!("{version} LR{index} lost its physical backing"),
+            std::format!("{version} LR{index} lost its physical backing"),
         ))
     } else {
         Ok(())
@@ -596,13 +597,13 @@ fn validate_physical_backing(
     let previous = previous.ok_or_else(|| {
         GicV3BackendError::new(
             "decode virtual list register",
-            alloc::format!("{version} LR{index} acquired unexpected physical backing"),
+            std::format!("{version} LR{index} acquired unexpected physical backing"),
         )
     })?;
     if previous.intid() != intid || previous.backing() != ListRegisterBacking::Physical(physical) {
         return Err(GicV3BackendError::new(
             "decode virtual list register",
-            alloc::format!(
+            std::format!(
                 "{version} LR{index} changed physical identity from {:?}/{:?} to \
                  {intid:?}/{physical:?}",
                 previous.intid(),
@@ -623,7 +624,7 @@ fn require_lr_count(
     } else {
         Err(GicV3BackendError::new(
             operation,
-            alloc::format!("saved state has {saved} LRs, hardware exposes {available}"),
+            std::format!("saved state has {saved} LRs, hardware exposes {available}"),
         ))
     }
 }
@@ -633,7 +634,7 @@ fn require_current_vcpu(vcpu: GicVcpuId, operation: &'static str) -> Result<(), 
         Some(current) if current == vcpu.raw() => Ok(()),
         Some(current) => Err(GicV3BackendError::new(
             operation,
-            alloc::format!("requested vCPU {}, current vCPU is {current}", vcpu.raw()),
+            std::format!("requested vCPU {}, current vCPU is {current}", vcpu.raw()),
         )),
         None => Err(GicV3BackendError::new(
             operation,
@@ -645,11 +646,11 @@ fn require_current_vcpu(vcpu: GicVcpuId, operation: &'static str) -> Result<(), 
 fn instruction_sync_barrier() {
     // SAFETY: `isb` only synchronizes architectural register effects on the
     // current CPU and does not access Rust memory.
-    unsafe { core::arch::asm!("isb", options(nostack, preserves_flags)) };
+    unsafe { std::arch::asm!("isb", options(nostack, preserves_flags)) };
 }
 
 fn data_sync_barrier() {
     // SAFETY: `dsb sy` only orders architectural register and memory effects
     // on the current CPU.
-    unsafe { core::arch::asm!("dsb sy", options(nostack, preserves_flags)) };
+    unsafe { std::arch::asm!("dsb sy", options(nostack, preserves_flags)) };
 }

--- a/virtualization/axvm/src/arch/aarch64/gic/maintenance.rs
+++ b/virtualization/axvm/src/arch/aarch64/gic/maintenance.rs
@@ -1,10 +1,11 @@
 //! Per-CPU host interrupt used to force VGIC state folding after guest EOI.
 
+use std::sync::OnceLock;
+
 use axvm_types::{VmBackendError as BackendError, VmBackendResult as BackendResult};
 use fdt_edit::Fdt;
-use spin::Once;
 
-static HOST_MAINTENANCE_INTID: Once<u32> = Once::new();
+static HOST_MAINTENANCE_INTID: OnceLock<u32> = OnceLock::new();
 
 pub(super) fn enable_current_cpu() -> BackendResult {
     set_current_cpu_enabled(true)
@@ -24,7 +25,7 @@ pub(super) fn matches_token(token: usize) -> bool {
 }
 
 fn set_current_cpu_enabled(enabled: bool) -> BackendResult {
-    let intid = *HOST_MAINTENANCE_INTID.try_call_once(discover_host_maintenance_intid)?;
+    let intid = *HOST_MAINTENANCE_INTID.get_or_try_init(discover_host_maintenance_intid)?;
     set_enabled(intid, enabled)
 }
 

--- a/virtualization/axvm/src/arch/aarch64/gic/physical.rs
+++ b/virtualization/axvm/src/arch/aarch64/gic/physical.rs
@@ -4,15 +4,19 @@
 //! enters this module. It publishes through a preallocated route slot directly
 //! into IRQ-safe canonical VGIC state; only the resulting vCPU kick is deferred.
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use core::{
+use std::{
+    boxed::Box,
     hint::spin_loop,
     ptr,
-    sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering},
+    },
+    vec::Vec,
 };
 
 use arm_vgic::{GicV3BackendError, PhysicalIrqId, VgicCore};
-use ax_kspin::SpinNoIrq;
+use ax_std::os::arceos::sync::IrqSafeMutex;
 use axdevice_base::HostIrqId;
 
 use super::{deactivate_host_irq, dispatch_acknowledged_host_irq, host_irq_intid};
@@ -25,7 +29,7 @@ static ASSIGNED_SPI_ROUTES: [AssignedSpiRouteSlot; GIC_INTID_COUNT] =
 /// Owns every fixed host-INTID route installed for one VM.
 pub(crate) struct AssignedSpiRoutes {
     bindings: Box<[Arc<AssignedSpiBinding>]>,
-    registrations: SpinNoIrq<Vec<AssignedSpiRouteRegistration>>,
+    registrations: IrqSafeMutex<Vec<AssignedSpiRouteRegistration>>,
 }
 
 impl AssignedSpiRoutes {
@@ -39,14 +43,14 @@ impl AssignedSpiRoutes {
                     irq: assigned.host_irq(),
                     controller: controller.clone(),
                     accepting: AtomicBool::new(false),
-                    delivery: SpinNoIrq::new(AssignedSpiDelivery::Idle),
+                    delivery: IrqSafeMutex::new(AssignedSpiDelivery::Idle),
                 })
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
         let routes = Arc::new(Self {
             bindings,
-            registrations: SpinNoIrq::new(Vec::new()),
+            registrations: IrqSafeMutex::new(Vec::new()),
         });
 
         {
@@ -99,7 +103,7 @@ struct AssignedSpiBinding {
     irq: HostIrqId,
     controller: Arc<VgicCore>,
     accepting: AtomicBool,
-    delivery: SpinNoIrq<AssignedSpiDelivery>,
+    delivery: IrqSafeMutex<AssignedSpiDelivery>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -203,7 +207,7 @@ impl AssignedSpiRouteRegistration {
         let Some(route) = ASSIGNED_SPI_ROUTES.get(intid) else {
             return Err(GicV3BackendError::new(
                 "register assigned physical SPI route",
-                alloc::format!("host INTID {intid} is outside the assignable GIC range"),
+                std::format!("host INTID {intid} is outside the assignable GIC range"),
             ));
         };
         let raw = Arc::into_raw(binding.clone()) as *mut AssignedSpiBinding;
@@ -217,7 +221,7 @@ impl AssignedSpiRouteRegistration {
             drop(unsafe { Arc::from_raw(raw) });
             return Err(GicV3BackendError::new(
                 "register assigned physical SPI route",
-                alloc::format!("host INTID {intid} is already assigned to another VM"),
+                std::format!("host INTID {intid} is already assigned to another VM"),
             ));
         }
         Ok(Self {

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -4,7 +4,7 @@
 //! Guest interrupt state belongs to one VM-local [`arm_vgic::VgicCore`];
 //! host IRQ tokens remain opaque until that controller completes split EOI.
 
-use alloc::sync::Arc;
+use std::sync::Arc;
 
 use arm_vcpu::{
     ArmAccessWidth, ArmGicCpuInterfaceRegister, ArmGuestPhysAddr, ArmHostIrqGuard, ArmHostOps,
@@ -413,7 +413,7 @@ impl AxvmArmVcpu {
         let snapshot = self.inner.timer_snapshot().map_err(|error| {
             crate::AxVmError::vcpu(
                 "snapshot AArch64 architectural timers",
-                alloc::format!("{error:?}"),
+                std::format!("{error:?}"),
             )
         })?;
         self.timer_binding

--- a/virtualization/axvm/src/arch/aarch64/npt.rs
+++ b/virtualization/axvm/src/arch/aarch64/npt.rs
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 
-use core::{arch::asm, fmt};
+use std::{arch::asm, fmt};
 
 use axvm_types::{HostPhysAddr, MappingFlags};
 use page_table_generic as ptg;

--- a/virtualization/axvm/src/arch/aarch64/shared_mmio.rs
+++ b/virtualization/axvm/src/arch/aarch64/shared_mmio.rs
@@ -1,6 +1,6 @@
 //! Portable write filtering for shared physical MMIO providers.
 
-use alloc::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
+use std::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
 
 use axdevice_base::{
     AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, Resource,
@@ -128,7 +128,7 @@ impl SharedMmioDevice {
         if !offset.is_multiple_of(width) {
             return Err(DeviceError::InvalidInput {
                 operation: "access shared MMIO provider",
-                detail: alloc::format!(
+                detail: std::format!(
                     "unaligned {:?} access at provider offset {offset:#x}",
                     access.width
                 ),

--- a/virtualization/axvm/src/arch/aarch64/shared_provider.rs
+++ b/virtualization/axvm/src/arch/aarch64/shared_provider.rs
@@ -1,6 +1,6 @@
 //! Mediation for physical MMIO providers shared with a passthrough guest.
 
-use alloc::{format, string::String, sync::Arc, vec, vec::Vec};
+use std::{format, string::String, sync::Arc, vec, vec::Vec};
 
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceFactoryRegistry, DeviceManagerError,

--- a/virtualization/axvm/src/arch/aarch64/vgic.rs
+++ b/virtualization/axvm/src/arch/aarch64/vgic.rs
@@ -1,13 +1,13 @@
 //! AArch64 VM-local VGIC construction and activation lifecycle.
 
-use alloc::{sync::Arc, vec::Vec};
+use std::{sync::Arc, vec::Vec};
 
 use arm_vgic::{
     ArmVgicConfig, AssignedSpiConfig, GicAffinity, GicV3Backend, GicV3VcpuBinding, GicV3VcpuWake,
     GicVcpuId, HostGicVersion, PpiId, SpiId, TriggerMode, VgicAccessContext, VgicCore,
     VgicDeviceSet, VgicError, VgicMmioRegion, VgicResult, VgicV2Config, VgicV3Config,
 };
-use ax_kspin::SpinNoIrq;
+use ax_std::os::arceos::sync::IrqSafeMutex;
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceFactoryRegistry, DeviceManagerError,
     DeviceManagerResult, DeviceRegistration, ServiceCardinality, ServiceKey,
@@ -56,7 +56,7 @@ pub(crate) struct Aarch64VgicRuntime {
     backend: Arc<gic::AxvmVgicBackend>,
     kick: Arc<DeferredVcpuKick>,
     host_virtual_timer_intid: u32,
-    phase: SpinNoIrq<RuntimePhase>,
+    phase: IrqSafeMutex<RuntimePhase>,
 }
 
 impl Aarch64VgicRuntime {
@@ -71,7 +71,7 @@ impl Aarch64VgicRuntime {
             backend,
             kick: DeferredVcpuKick::new(vm_id),
             host_virtual_timer_intid,
-            phase: SpinNoIrq::new(RuntimePhase::Inactive),
+            phase: IrqSafeMutex::new(RuntimePhase::Inactive),
         })
     }
 
@@ -162,7 +162,7 @@ impl Aarch64VgicRuntime {
     pub(crate) fn deactivate(&self) -> AxVmResult {
         let routes = {
             let mut phase = self.phase.lock();
-            match core::mem::replace(&mut *phase, RuntimePhase::Deactivating) {
+            match std::mem::replace(&mut *phase, RuntimePhase::Deactivating) {
                 RuntimePhase::Inactive => {
                     *phase = RuntimePhase::Inactive;
                     return Ok(());
@@ -221,7 +221,7 @@ impl GicV3VcpuWake for Aarch64VcpuWake {
             .publish_from_irq(self.vcpu_id)
             .map_err(|error| VgicError::Backend {
                 operation: "publish deferred AArch64 vCPU kick",
-                detail: alloc::format!("{error}"),
+                detail: std::format!("{error}"),
             })
     }
 }
@@ -333,7 +333,7 @@ pub(crate) fn register_device_factories(
     if capabilities.host_version() != guest_version {
         return Err(AxVmError::unsupported(
             "create AArch64 virtual GIC",
-            alloc::format!(
+            std::format!(
                 "machine profile requires {guest_version:?}, but the host CPU interface is {:?}",
                 capabilities.host_version()
             ),
@@ -382,7 +382,7 @@ pub(crate) fn register_device_factories(
                 ));
             };
             if *configured_vcpu_count != placements.len() {
-                return Err(AxVmError::invalid_config(alloc::format!(
+                return Err(AxVmError::invalid_config(std::format!(
                     "AArch64 redistributor descriptor names {} vCPUs, but placement has {}",
                     configured_vcpu_count,
                     placements.len()
@@ -392,7 +392,7 @@ pub(crate) fn register_device_factories(
                 VgicV3Config::new(
                     controller_id,
                     distributor_region,
-                    alloc::vec![cpu_region],
+                    std::vec![cpu_region],
                     REDISTRIBUTOR_STRIDE,
                     affinities,
                 )
@@ -463,7 +463,7 @@ fn unique_config<'a>(
     if matches.next().is_some() {
         return Err(AxVmError::resource_conflict(
             "machine device",
-            alloc::format!("more than one {resource} descriptor is configured"),
+            std::format!("more than one {resource} descriptor is configured"),
         ));
     }
     Ok(config)
@@ -472,6 +472,6 @@ fn unique_config<'a>(
 fn vgic_device_error(operation: &'static str, error: VgicError) -> DeviceManagerError {
     DeviceManagerError::InvalidConfig {
         operation,
-        detail: alloc::format!("{error}"),
+        detail: std::format!("{error}"),
     }
 }

--- a/virtualization/axvm/src/arch/aarch64/vm.rs
+++ b/virtualization/axvm/src/arch/aarch64/vm.rs
@@ -1,6 +1,6 @@
 //! AArch64 VM resource creation and initialization.
 
-use alloc::{sync::Arc, vec::Vec};
+use std::{sync::Arc, vec::Vec};
 
 use arm_vcpu::{ArmTimerVmConfig, ArmVcpuCreateConfig, ArmVcpuSetupConfig};
 use axdevice::DeviceFactoryRegistry;
@@ -224,7 +224,7 @@ fn timer_vm_config(
         ArmTimerVmConfig::uniform_frequency(&frequency_values).map_err(|_| {
             AxVmError::unsupported(
                 "configure AArch64 architectural timers",
-                alloc::format!(
+                std::format!(
                     "target CPUs report different counter frequencies: {target_frequencies:?}"
                 ),
             )
@@ -236,7 +236,7 @@ fn timer_vm_config(
     ArmTimerVmConfig::new(guest_frequency, super::vtimer::physical_counter(), 0).map_err(|error| {
         AxVmError::unsupported(
             "configure AArch64 architectural timers",
-            alloc::format!("{error:?}"),
+            std::format!("{error:?}"),
         )
     })
 }

--- a/virtualization/axvm/src/arch/aarch64/vtimer/host_ppi.rs
+++ b/virtualization/axvm/src/arch/aarch64/vtimer/host_ppi.rs
@@ -1,9 +1,8 @@
 //! Process-wide host virtual-timer PPI registration.
 
-use alloc::{format, vec::Vec};
+use std::{format, sync::OnceLock, vec::Vec};
 
 use ax_std::os::arceos::modules::ax_hal::irq;
-use spin::Once;
 
 use super::percpu::{PerCpuIrqControl, claim_enabled_percpu_irq};
 use crate::{
@@ -17,7 +16,7 @@ use crate::{
 /// lifetime of the hypervisor. Whichever vCPU is loaded on a pCPU owns that
 /// CPU's CNTV register state, so multiple VMs may safely time-share the same
 /// physical line.
-static HOST_TIMER_PPI: Once<HostTimerPpiClaim> = Once::new();
+static HOST_TIMER_PPI: OnceLock<HostTimerPpiClaim> = OnceLock::new();
 
 struct HostTimerPpiClaim {
     intid: u32,
@@ -25,7 +24,7 @@ struct HostTimerPpiClaim {
 }
 
 pub(in crate::arch::aarch64) fn ensure_host_timer_ppi(intid: u32) -> AxVmResult {
-    let claim = HOST_TIMER_PPI.try_call_once(|| HostTimerPpiClaim::install(intid))?;
+    let claim = HOST_TIMER_PPI.get_or_try_init(|| HostTimerPpiClaim::install(intid))?;
     if claim.intid != intid {
         return Err(AxVmError::resource_conflict(
             "host virtual-timer PPI",

--- a/virtualization/axvm/src/arch/aarch64/vtimer/percpu.rs
+++ b/virtualization/axvm/src/arch/aarch64/vtimer/percpu.rs
@@ -34,7 +34,7 @@ pub(crate) fn claim_enabled_percpu_irq<C: PerCpuIrqControl>(
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
+    use std::vec::Vec;
 
     use super::{PerCpuIrqControl, claim_enabled_percpu_irq};
 

--- a/virtualization/axvm/src/arch/aarch64/vtimer/state.rs
+++ b/virtualization/axvm/src/arch/aarch64/vtimer/state.rs
@@ -1,12 +1,17 @@
 //! Connects vCPU-owned architectural timer state to VGIC PPIs and host wakeups.
 
-use alloc::{boxed::Box, sync::Arc};
-use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::{
+    boxed::Box,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+};
 
 use aarch64_cpu_ext::registers::{CNTPCT_EL0, Readable};
 use arm_vcpu::{ArmTimerKind, ArmTimerSnapshot};
 use arm_vgic::{GicVcpuId, PpiId, VgicCore, VgicResult};
-use ax_kspin::SpinNoIrq;
+use ax_std::os::arceos::sync::IrqSafeMutex;
 
 use crate::{
     arch::aarch64::gic::AxvmVgicBackend,
@@ -38,8 +43,8 @@ pub(in crate::arch::aarch64) struct Aarch64TimerBinding {
     frequency: u64,
     registered: AtomicBool,
     wait_generation: AtomicU64,
-    scheduled: SpinNoIrq<Option<VmTimerHandle>>,
-    host_activation: SpinNoIrq<Option<HostTimerActivation>>,
+    scheduled: IrqSafeMutex<Option<VmTimerHandle>>,
+    host_activation: IrqSafeMutex<Option<HostTimerActivation>>,
 }
 
 impl Aarch64TimerBinding {
@@ -64,8 +69,8 @@ impl Aarch64TimerBinding {
             frequency,
             registered: AtomicBool::new(false),
             wait_generation: AtomicU64::new(0),
-            scheduled: SpinNoIrq::new(None),
-            host_activation: SpinNoIrq::new(None),
+            scheduled: IrqSafeMutex::new(None),
+            host_activation: IrqSafeMutex::new(None),
         });
         backend.register_timer_ppi(vcpu, virtual_ppi, Arc::downgrade(&binding))?;
         binding.registered.store(true, Ordering::Release);
@@ -246,7 +251,7 @@ impl Aarch64TimerBinding {
         )
         .map_err(|error| arm_vgic::VgicError::Backend {
             operation: "deactivate host virtual-timer PPI",
-            detail: alloc::format!(
+            detail: std::format!(
                 "cannot run completion on owner CPU {}: {error:?}",
                 activation.owner_cpu
             ),

--- a/virtualization/axvm/src/arch/loongarch64/boot/acpi.rs
+++ b/virtualization/axvm/src/arch/loongarch64/boot/acpi.rs
@@ -4,7 +4,7 @@
 //! LoongArch platform description so architecture policy does not leak into the
 //! reusable device crate.
 
-use alloc::{format, vec, vec::Vec};
+use std::{format, vec, vec::Vec};
 
 use axdevice::{FwCfgAcpiBlobs, FwCfgRamRegion};
 
@@ -762,7 +762,7 @@ fn qword_memory_resource(base: u64, size: u64, prefetchable: bool, fixed: bool) 
 }
 
 fn extended_interrupt_resource(irqs: &[u32], consumer: bool) -> Vec<u8> {
-    let payload_len = 2 + core::mem::size_of_val(irqs);
+    let payload_len = 2 + std::mem::size_of_val(irqs);
     let mut out = vec![0x89];
     out.extend_from_slice(&(payload_len as u16).to_le_bytes());
     out.push(if consumer { 0x09 } else { 0x01 });
@@ -864,7 +864,7 @@ fn push_loader_add_checksum(out: &mut Vec<u8>, file: &str, start: usize, length:
 
 fn write_loader_file(dst: &mut [u8], file: &str) {
     let bytes = file.as_bytes();
-    let len = core::cmp::min(bytes.len(), dst.len().saturating_sub(1));
+    let len = std::cmp::min(bytes.len(), dst.len().saturating_sub(1));
     dst[..len].copy_from_slice(&bytes[..len]);
 }
 

--- a/virtualization/axvm/src/arch/loongarch64/boot/fdt/guest_firmware_dtb.rs
+++ b/virtualization/axvm/src/arch/loongarch64/boot/fdt/guest_firmware_dtb.rs
@@ -1,4 +1,4 @@
-use alloc::{format, vec::Vec};
+use std::{format, vec::Vec};
 
 use fdt_edit::{Fdt, Node, NodeId};
 

--- a/virtualization/axvm/src/arch/loongarch64/boot/fdt/property.rs
+++ b/virtualization/axvm/src/arch/loongarch64/boot/fdt/property.rs
@@ -1,4 +1,4 @@
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 use fdt_edit::Property;
 

--- a/virtualization/axvm/src/arch/loongarch64/boot/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/boot/mod.rs
@@ -3,7 +3,7 @@ mod fdt;
 mod probe;
 mod resources;
 
-use alloc::{boxed::Box, format, vec::Vec};
+use std::{boxed::Box, format, vec::Vec};
 
 use axdevice::{FwCfgPlatformConfig, FwCfgRamRegion};
 use axvm_types::{EmulatedDeviceConfig, EmulatedDeviceType};
@@ -314,7 +314,7 @@ fn fill_vm_region(load_addr: GuestPhysAddr, size: usize, byte: u8, vm: AxVMRef) 
     for region in regions {
         // SAFETY: AxVM returned this writable guest-memory region and the fill
         // is bounded by its length.
-        unsafe { core::ptr::write_bytes(region.as_mut_ptr(), byte, region.len()) };
+        unsafe { std::ptr::write_bytes(region.as_mut_ptr(), byte, region.len()) };
         crate::clean_dcache_range((region.as_ptr() as usize).into(), region.len());
         filled_size += region.len();
     }

--- a/virtualization/axvm/src/arch/loongarch64/boot/probe.rs
+++ b/virtualization/axvm/src/arch/loongarch64/boot/probe.rs
@@ -1,4 +1,6 @@
-use alloc::vec::Vec;
+use std::vec::Vec;
+
+use ax_std::os::arceos::driver as ax_driver;
 
 use super::{
     FirmwareDevices, FlashDevice, GedDevice, GuestPlatform, InterruptTopology, IrqMmioDevice,

--- a/virtualization/axvm/src/arch/loongarch64/boot/resources.rs
+++ b/virtualization/axvm/src/arch/loongarch64/boot/resources.rs
@@ -1,7 +1,6 @@
-use alloc::{collections::BTreeMap, format, string::String, vec::Vec};
+use std::{collections::BTreeMap, format, string::String, sync::OnceLock, vec::Vec};
 
-use ax_kspin::SpinNoIrq as Mutex;
-use ax_lazyinit::LazyInit;
+use ax_std::os::arceos::{driver as ax_driver, modules::ax_hal, sync::IrqSafeMutex as Mutex};
 use axvmconfig::GuestConfig;
 
 use super::UEFI_FIRMWARE_FDT_BASE;
@@ -10,8 +9,8 @@ use crate::{
     config::{AxVMConfig, PassThroughDeviceConfig},
 };
 
-static LOONGARCH_GUEST_IRQ_ROUTES: LazyInit<Mutex<BTreeMap<usize, Vec<LoongArchGuestIrqRoute>>>> =
-    LazyInit::new();
+static LOONGARCH_GUEST_IRQ_ROUTES: OnceLock<Mutex<BTreeMap<usize, Vec<LoongArchGuestIrqRoute>>>> =
+    OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct LoongArchGuestIrqRoute {
@@ -20,7 +19,7 @@ pub struct LoongArchGuestIrqRoute {
 }
 
 pub fn init() {
-    LOONGARCH_GUEST_IRQ_ROUTES.init_once(Mutex::new(BTreeMap::new()));
+    let _ = LOONGARCH_GUEST_IRQ_ROUTES.set(Mutex::new(BTreeMap::new()));
 }
 
 pub fn store_guest_irq_routes(vm_id: usize, routes: Vec<LoongArchGuestIrqRoute>) {

--- a/virtualization/axvm/src/arch/loongarch64/capabilities.rs
+++ b/virtualization/axvm/src/arch/loongarch64/capabilities.rs
@@ -1,6 +1,6 @@
 //! LoongArch64 implementations of AxVM platform capability hooks.
 
-use alloc::sync::Arc;
+use std::sync::Arc;
 
 use ax_std::os::arceos::modules::ax_task::IrqNotify;
 

--- a/virtualization/axvm/src/arch/loongarch64/irq.rs
+++ b/virtualization/axvm/src/arch/loongarch64/irq.rs
@@ -1,8 +1,8 @@
 //! LoongArch platform IRQ routing used by AxVM.
 
-use alloc::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
-use ax_kspin::SpinNoIrq;
+use ax_std::os::arceos::sync::IrqSafeMutex;
 use axdevice_base::{
     ControllerInputId, InterruptControllerId, InterruptEndpoint, IrqError, IrqResult,
     VirtualInterruptController, WiredIrqInput, WiredIrqSink,
@@ -39,7 +39,7 @@ impl WiredIrqSink for LoongArchPchPicIrqSink {
             IrqError::Backend {
                 endpoint: Self::endpoint(input),
                 operation: "queue LoongArch PCH-PIC output",
-                detail: alloc::format!("{error}"),
+                detail: std::format!("{error}"),
             }
         })
     }
@@ -54,14 +54,14 @@ impl WiredIrqSink for LoongArchPchPicIrqSink {
 /// guest-visible PCH-PIC instance.
 pub(crate) struct LoongArchInterruptDomain {
     sink: Arc<LoongArchPchPicIrqSink>,
-    inputs: SpinNoIrq<BTreeMap<usize, (InterruptTriggerMode, WiredIrqInput)>>,
+    inputs: IrqSafeMutex<BTreeMap<usize, (InterruptTriggerMode, WiredIrqInput)>>,
 }
 
 impl LoongArchInterruptDomain {
     pub(crate) fn new(vm_id: usize, pic: Arc<axdevice::LoongArchPchPic>) -> Arc<Self> {
         Arc::new(Self {
             sink: Arc::new(LoongArchPchPicIrqSink { vm_id, pic }),
-            inputs: SpinNoIrq::new(BTreeMap::new()),
+            inputs: IrqSafeMutex::new(BTreeMap::new()),
         })
     }
 }
@@ -83,7 +83,7 @@ impl VirtualInterruptController for LoongArchInterruptDomain {
                     input,
                 },
                 operation: "open LoongArch PCH-PIC input",
-                detail: alloc::format!(
+                detail: std::format!(
                     "input {} is outside 0..{PCH_PIC_INPUT_COUNT}",
                     input.value()
                 ),
@@ -98,7 +98,7 @@ impl VirtualInterruptController for LoongArchInterruptDomain {
                         input,
                     },
                     operation: "open LoongArch PCH-PIC input",
-                    detail: alloc::format!(
+                    detail: std::format!(
                         "input {} is already registered as {registered_trigger:?}",
                         input.value()
                     ),

--- a/virtualization/axvm/src/arch/loongarch64/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/mod.rs
@@ -1,5 +1,4 @@
-use alloc::boxed::Box;
-use core::time::Duration;
+use std::{boxed::Box, time::Duration};
 
 use ax_memory_addr::VirtAddr;
 use axvm_types::{
@@ -206,7 +205,7 @@ impl ArchOps for LoongArch64Arch {
     fn clean_dcache_range(addr: VirtAddr, size: usize) {
         unsafe {
             cache_range::<DCACHE_WB>(addr, size);
-            core::arch::asm!("dbar 0");
+            std::arch::asm!("dbar 0");
         }
     }
 }
@@ -541,7 +540,7 @@ unsafe fn cache_range<const OP: u8>(addr: VirtAddr, size: usize) {
 
     while current < end {
         unsafe {
-            core::arch::asm!("cacop {0}, {1}, 0", const OP, in(reg) current);
+            std::arch::asm!("cacop {0}, {1}, 0", const OP, in(reg) current);
         }
         current += CACHE_LINE_SIZE;
     }

--- a/virtualization/axvm/src/arch/loongarch64/npt.rs
+++ b/virtualization/axvm/src/arch/loongarch64/npt.rs
@@ -3,7 +3,7 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 
-use core::{arch::asm, fmt};
+use std::{arch::asm, fmt};
 
 use axvm_types::{HostPhysAddr, MappingFlags};
 use page_table_generic as ptg;

--- a/virtualization/axvm/src/arch/loongarch64/vm.rs
+++ b/virtualization/axvm/src/arch/loongarch64/vm.rs
@@ -1,6 +1,6 @@
 //! LoongArch64 VM resource creation and initialization.
 
-use alloc::sync::Arc;
+use std::sync::Arc;
 
 use axdevice::DeviceFactoryRegistry;
 use axvm_types::{NestedPagingConfig, VmArchVcpuOps};

--- a/virtualization/axvm/src/arch/mod.rs
+++ b/virtualization/axvm/src/arch/mod.rs
@@ -82,8 +82,8 @@ pub(crate) type ArchPerCpu = <CurrentArch as ArchOps>::PerCpu;
 pub(crate) type ArchNestedPageTable = <CurrentArch as ArchOps>::NestedPageTable;
 
 pub(crate) fn register_timer_source(
-    deadline_source: alloc::sync::Arc<crate::timer::PublishedTimerDeadline>,
-    notify: alloc::sync::Arc<ax_std::os::arceos::modules::ax_task::IrqNotify>,
+    deadline_source: std::sync::Arc<crate::timer::PublishedTimerDeadline>,
+    notify: std::sync::Arc<ax_std::os::arceos::modules::ax_task::IrqNotify>,
 ) {
     CurrentArch::register_timer_source(deadline_source, notify);
 }

--- a/virtualization/axvm/src/arch/riscv64/capabilities.rs
+++ b/virtualization/axvm/src/arch/riscv64/capabilities.rs
@@ -1,6 +1,6 @@
 //! RISC-V implementations of AxVM platform capability hooks.
 
-use alloc::{format, vec::Vec};
+use std::{format, vec::Vec};
 
 use super::Riscv64Arch;
 use crate::{
@@ -22,7 +22,7 @@ impl BootImagePlatform for Riscv64Arch {
         dtb: &crate::boot::fdt::GuestDtbImage,
     ) -> AxVmResult {
         let bytes = dtb.as_bytes();
-        let source = core::ptr::NonNull::new(bytes.as_ptr() as *mut u8)
+        let source = std::ptr::NonNull::new(bytes.as_ptr() as *mut u8)
             .ok_or_else(|| ax_err_type!(InvalidData, "Guest DTB pointer is null"))?;
         super::fdt::core::update_fdt(source, bytes.len(), loader.vm.clone(), &loader.config)
     }

--- a/virtualization/axvm/src/arch/riscv64/fdt.rs
+++ b/virtualization/axvm/src/arch/riscv64/fdt.rs
@@ -1,6 +1,6 @@
 //! RISC-V compatibility facade and target-specific guest FDT policy.
 
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 use crate::{
     AxVmResult,

--- a/virtualization/axvm/src/arch/riscv64/irq/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/irq/mod.rs
@@ -14,9 +14,9 @@
 
 //! RISC-V virtual PLIC interrupt backend.
 
-use alloc::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, sync::Arc};
 
-use ax_kspin::SpinNoIrq;
+use ax_std::os::arceos::sync::IrqSafeMutex;
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceFactoryRegistry, DeviceManagerResult,
     DeviceRegistration, ServiceCardinality, ServiceKey, VirtualInterruptControllerKey,
@@ -55,7 +55,7 @@ impl ServiceKey for RiscvPlicRuntimeKey {
 pub(crate) struct RiscvPlicRuntime {
     vplic: Arc<VPlicGlobal>,
     sink: Arc<RiscvPlicWiredSink>,
-    inputs: SpinNoIrq<BTreeMap<usize, (InterruptTriggerMode, WiredIrqInput)>>,
+    inputs: IrqSafeMutex<BTreeMap<usize, (InterruptTriggerMode, WiredIrqInput)>>,
     kick: Arc<DeferredVcpuKick>,
     physical: Arc<physical::PhysicalIrqBridge>,
     vcpu_count: usize,
@@ -75,7 +75,7 @@ impl RiscvPlicRuntime {
         if vcpu_count > usize::BITS as usize {
             return ax_err!(
                 Unsupported,
-                alloc::format!(
+                std::format!(
                     "RISC-V VM has {vcpu_count} vCPUs, but deferred IRQ wake supports at most {}",
                     usize::BITS
                 )
@@ -98,7 +98,7 @@ impl RiscvPlicRuntime {
         Ok(Arc::new(Self {
             vplic,
             sink,
-            inputs: SpinNoIrq::new(BTreeMap::new()),
+            inputs: IrqSafeMutex::new(BTreeMap::new()),
             kick,
             physical,
             vcpu_count,
@@ -125,7 +125,7 @@ impl RiscvPlicRuntime {
         if vcpu_id >= self.vcpu_count {
             return ax_err!(
                 InvalidInput,
-                alloc::format!(
+                std::format!(
                     "RISC-V vCPU {vcpu_id} is outside the configured range 0..{}",
                     self.vcpu_count
                 )
@@ -171,7 +171,7 @@ impl VirtualInterruptController for RiscvPlicRuntime {
                     input,
                 },
                 operation: "open RISC-V vPLIC input",
-                detail: alloc::format!(
+                detail: std::format!(
                     "source {source} is outside the valid range 1..{PLIC_NUM_SOURCES}"
                 ),
             });
@@ -186,7 +186,7 @@ impl VirtualInterruptController for RiscvPlicRuntime {
                         input,
                     },
                     operation: "open RISC-V vPLIC input",
-                    detail: alloc::format!(
+                    detail: std::format!(
                         "source {source} is already registered as {registered_trigger:?}"
                     ),
                 });
@@ -218,12 +218,12 @@ impl RiscvPlicWiredSink {
     fn backend_error(
         input: ControllerInputId,
         operation: &'static str,
-        error: impl core::fmt::Display,
+        error: impl std::fmt::Display,
     ) -> IrqError {
         IrqError::Backend {
             endpoint: Self::endpoint(input),
             operation,
-            detail: alloc::format!("{error}"),
+            detail: std::format!("{error}"),
         }
     }
 
@@ -384,7 +384,7 @@ pub(crate) fn register_device_factory(
         .checked_mul(2)
         .ok_or_else(|| ax_err_type!(InvalidInput, "RISC-V vPLIC context count overflow"))?;
     if contexts_num != expected_contexts {
-        return Err(AxVmError::invalid_config(alloc::format!(
+        return Err(AxVmError::invalid_config(std::format!(
             "virtual PLIC declares {contexts_num} contexts for {vcpu_count} vCPUs; expected \
              {expected_contexts}"
         )));

--- a/virtualization/axvm/src/arch/riscv64/irq/physical.rs
+++ b/virtualization/axvm/src/arch/riscv64/irq/physical.rs
@@ -1,14 +1,17 @@
 //! Deferred physical PLIC claims backing guest-owned vPLIC sources.
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
-use core::{
+use std::{
+    boxed::Box,
     hint::spin_loop,
     ptr,
-    sync::atomic::{AtomicBool, AtomicPtr, AtomicU8, AtomicUsize, Ordering},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicPtr, AtomicU8, AtomicUsize, Ordering},
+    },
+    vec::Vec,
 };
 
-use ax_kspin::SpinNoIrq;
-use ax_std::os::arceos::modules::ax_task::IrqNotify;
+use ax_std::os::arceos::{modules::ax_task::IrqNotify, sync::IrqSafeMutex};
 use axvm_types::InterruptTriggerMode;
 use riscv_vplic::{PLIC_NUM_SOURCES, VPlicGlobal};
 
@@ -34,8 +37,8 @@ pub(super) fn publish_physical_claim_from_irq(source: u32) -> bool {
 pub(super) struct PhysicalIrqBridge {
     shared: Arc<PhysicalBridgeShared>,
     bindings: Box<[Arc<PhysicalSourceBinding>]>,
-    registrations: SpinNoIrq<Vec<PhysicalRouteRegistration>>,
-    worker: SpinNoIrq<Option<AxTaskRef>>,
+    registrations: IrqSafeMutex<Vec<PhysicalRouteRegistration>>,
+    worker: IrqSafeMutex<Option<AxTaskRef>>,
     running: AtomicBool,
 }
 
@@ -62,7 +65,7 @@ impl PhysicalIrqBridge {
             if source == 0 || source >= PLIC_NUM_SOURCES {
                 return ax_err!(
                     InvalidInput,
-                    alloc::format!(
+                    std::format!(
                         "RISC-V physical PLIC source {} is outside 1..{PLIC_NUM_SOURCES}",
                         route.source
                     )
@@ -74,7 +77,7 @@ impl PhysicalIrqBridge {
             {
                 return ax_err!(
                     AlreadyExists,
-                    alloc::format!("RISC-V physical PLIC source {source} is configured twice")
+                    std::format!("RISC-V physical PLIC source {source} is configured twice")
                 );
             }
             bindings.push(Arc::new(PhysicalSourceBinding {
@@ -89,8 +92,8 @@ impl PhysicalIrqBridge {
         Ok(Arc::new(Self {
             shared,
             bindings: bindings.into_boxed_slice(),
-            registrations: SpinNoIrq::new(Vec::new()),
-            worker: SpinNoIrq::new(None),
+            registrations: IrqSafeMutex::new(Vec::new()),
+            worker: IrqSafeMutex::new(None),
             running: AtomicBool::new(false),
         }))
     }
@@ -123,7 +126,7 @@ impl PhysicalIrqBridge {
             {
                 first_error = Some(AxVmError::interrupt(
                     "deactivate RISC-V guest PLIC source",
-                    alloc::format!("{error:?}"),
+                    std::format!("{error:?}"),
                 ));
             }
         }
@@ -168,7 +171,7 @@ impl PhysicalIrqBridge {
         let bridge = self.clone();
         let task = TaskInner::new(
             move || bridge.run_worker(),
-            alloc::format!("VM[{}]-plic-physical", self.shared.vm_id),
+            std::format!("VM[{}]-plic-physical", self.shared.vm_id),
             PHYSICAL_IRQ_WORKER_STACK_SIZE,
         );
         *self.worker.lock() = Some(crate::host::task::spawn_task(task));
@@ -191,7 +194,7 @@ impl PhysicalIrqBridge {
                 binding.accepting.store(false, Ordering::Release);
                 return Err(AxVmError::interrupt(
                     "activate RISC-V guest PLIC source",
-                    alloc::format!("{error:?}"),
+                    std::format!("{error:?}"),
                 ));
             }
         }
@@ -418,7 +421,7 @@ impl PhysicalRouteRegistration {
             drop(unsafe { Arc::from_raw(raw) });
             return Err(AxVmError::resource_conflict(
                 "RISC-V physical PLIC route",
-                alloc::format!("source {source} is already assigned to another VM"),
+                std::format!("source {source} is already assigned to another VM"),
             ));
         }
         Ok(Self {

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{sync::Arc, vec::Vec};
+use std::{sync::Arc, vec::Vec};
 
 use ax_memory_addr::VirtAddr;
 use axvm_types::{

--- a/virtualization/axvm/src/arch/riscv64/npt.rs
+++ b/virtualization/axvm/src/arch/riscv64/npt.rs
@@ -20,7 +20,7 @@ impl ptg::TableMeta for Sv39x4MetaData {
         // SAFETY: `hfence.gvma` only orders guest-stage translations. It does
         // not access memory directly and is required after G-stage PTE updates.
         unsafe {
-            core::arch::asm!("hfence.gvma", options(nostack, preserves_flags));
+            std::arch::asm!("hfence.gvma", options(nostack, preserves_flags));
         }
     }
 }

--- a/virtualization/axvm/src/arch/riscv64/vm.rs
+++ b/virtualization/axvm/src/arch/riscv64/vm.rs
@@ -1,6 +1,6 @@
 //! RISC-V VM resource creation and initialization.
 
-use alloc::sync::Arc;
+use std::sync::Arc;
 
 use axdevice::DeviceFactoryRegistry;
 use axvm_types::{NestedPagingConfig, VmArchVcpuOps};

--- a/virtualization/axvm/src/arch/x86_64/boot/boot_params.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/boot_params.rs
@@ -14,7 +14,7 @@
 
 //! Linux x86 `boot_params` / zero page construction.
 
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 use super::linux::{
     BOOT_PARAMS_SIZE, X86LinuxHeader, X86LinuxLayoutError, X86LinuxLoadLayout, X86LinuxRange,
@@ -72,8 +72,8 @@ impl<'a> BootParamsBuilder<'a> {
             kernel_image,
             header,
             layout,
-            ram_ranges: alloc::vec![main_memory],
-            reserved_ranges: alloc::vec![
+            ram_ranges: std::vec![main_memory],
+            reserved_ranges: std::vec![
                 layout.boot_params,
                 layout.boot_stub,
                 X86LinuxRange::new(LEGACY_RESERVED_START, LEGACY_RESERVED_SIZE),
@@ -396,7 +396,7 @@ mod tests {
     }
 
     fn valid_image() -> Vec<u8> {
-        let mut image = alloc::vec![0u8; SETUP_HEADER_END + 0x1000];
+        let mut image = std::vec![0u8; SETUP_HEADER_END + 0x1000];
         image[SETUP_SECTS_OFFSET] = 5;
         write_header_u16(&mut image, BOOT_FLAG_OFFSET, 0xaa55);
         write_header_u32(&mut image, HEADER_OFFSET, u32::from_le_bytes(*b"HdrS"));
@@ -475,7 +475,7 @@ mod tests {
         let layout = valid_layout(&header);
         let mut builder =
             BootParamsBuilder::new(&image, header, layout, X86LinuxRange::new(0, 0x20_0000));
-        let long_command_line = alloc::string::String::from_utf8(alloc::vec![
+        let long_command_line = std::string::String::from_utf8(std::vec![
             b'a';
             BOOT_PARAMS_SIZE - COMMAND_LINE_OFFSET
         ])

--- a/virtualization/axvm/src/arch/x86_64/boot/linux.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/linux.rs
@@ -43,7 +43,7 @@ const HEADER_MAGIC: u32 = u32::from_le_bytes(*b"HdrS");
 
 /// Number of bytes needed to parse every field used by [`X86LinuxHeader`].
 #[cfg(any(feature = "fs", feature = "host-fs", test))]
-pub const HEADER_READ_SIZE: usize = CMDLINE_SIZE_OFFSET + core::mem::size_of::<u32>();
+pub const HEADER_READ_SIZE: usize = CMDLINE_SIZE_OFFSET + std::mem::size_of::<u32>();
 
 /// Parsed subset of Linux x86 setup header fields.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -249,7 +249,7 @@ fn read_u8(image: &[u8], offset: usize) -> Result<u8, X86LinuxHeaderError> {
     image
         .get(offset)
         .copied()
-        .ok_or_else(|| truncated(offset, core::mem::size_of::<u8>(), image.len()))
+        .ok_or_else(|| truncated(offset, std::mem::size_of::<u8>(), image.len()))
 }
 
 fn read_u16(image: &[u8], offset: usize) -> Result<u16, X86LinuxHeaderError> {

--- a/virtualization/axvm/src/arch/x86_64/boot/linux_boot.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/linux_boot.rs
@@ -133,7 +133,7 @@ mod tests {
     }
 
     fn valid_header() -> X86LinuxHeader {
-        let mut image = alloc::vec![0u8; CMDLINE_SIZE_OFFSET + 4];
+        let mut image = std::vec![0u8; CMDLINE_SIZE_OFFSET + 4];
         image[SETUP_SECTS_OFFSET] = 5;
         write_header_u16(&mut image, BOOT_FLAG_OFFSET, 0xaa55);
         write_header_u32(&mut image, HEADER_OFFSET, u32::from_le_bytes(*b"HdrS"));

--- a/virtualization/axvm/src/arch/x86_64/boot/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/mod.rs
@@ -1,6 +1,6 @@
 //! x86_64 Linux direct boot, BIOS/UEFI firmware, and MP-table image planning.
 
-use alloc::format;
+use std::format;
 
 use axvm_types::GuestPhysAddr;
 use axvmconfig::{EmulatedDeviceType, VMBootProtocol, VmMemMappingType};
@@ -479,7 +479,7 @@ fn builtin_bios_load_gpa(configured: Option<GuestPhysAddr>) -> AxVmResult<GuestP
 }
 
 fn validate_bios_patch_region(bios: &[u8]) -> AxVmResult {
-    let patch_end = multiboot::AXVM_BIOS_EBX_IMM_OFFSET + core::mem::size_of::<u32>();
+    let patch_end = multiboot::AXVM_BIOS_EBX_IMM_OFFSET + std::mem::size_of::<u32>();
     if bios.len() < patch_end
         || bios[multiboot::AXVM_BIOS_EBX_IMM_OFFSET - 1] != multiboot::MOV_EBX_IMM32_OPCODE
     {

--- a/virtualization/axvm/src/arch/x86_64/boot/mptable.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/mptable.rs
@@ -1,6 +1,6 @@
 //! Minimal Intel MultiProcessor table for x86 Linux direct boot.
 
-use alloc::{vec, vec::Vec};
+use std::{vec, vec::Vec};
 
 use super::linux::X86LinuxRange;
 

--- a/virtualization/axvm/src/arch/x86_64/host_irq.rs
+++ b/virtualization/axvm/src/arch/x86_64/host_irq.rs
@@ -1,7 +1,7 @@
 //! Host IRQ facade for AxVM runtime glue.
 
 #[cfg(test)]
-use core::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use ax_std::os::arceos::modules::ax_hal::irq as host_irq;
 

--- a/virtualization/axvm/src/arch/x86_64/irq.rs
+++ b/virtualization/axvm/src/arch/x86_64/irq.rs
@@ -1,6 +1,6 @@
-use alloc::vec::Vec;
+use std::vec::Vec;
 
-use ax_kspin::SpinRaw as Mutex;
+use ax_std::os::arceos::sync::RawSpinLock as Mutex;
 use axdevice::{X86InterruptDomainKey, X86InterruptDomainOps, X86PitServiceKey};
 use axvm_types::VmArchVcpuOps;
 
@@ -102,7 +102,7 @@ fn ioapic_irq_hook_gsis() -> impl Iterator<Item = usize> {
     (0..IOAPIC_GSI_COUNT).filter(|gsi| should_register_ioapic_gsi_hook(*gsi))
 }
 
-fn interrupt_domain_for_vm(vm: &crate::AxVMRef) -> Option<alloc::sync::Arc<X86InterruptDomain>> {
+fn interrupt_domain_for_vm(vm: &crate::AxVMRef) -> Option<std::sync::Arc<X86InterruptDomain>> {
     vm.get_devices()
         .ok()?
         .services()
@@ -113,35 +113,35 @@ fn interrupt_domain_for_vm(vm: &crate::AxVMRef) -> Option<alloc::sync::Arc<X86In
 fn require_interrupt_domain(
     vm: &crate::AxVMRef,
     operation: &'static str,
-) -> crate::AxVmResult<alloc::sync::Arc<X86InterruptDomain>> {
+) -> crate::AxVmResult<std::sync::Arc<X86InterruptDomain>> {
     interrupt_domain_for_vm(vm).ok_or_else(|| crate::AxVmError::ResourceUnavailable {
         resource: "x86 interrupt domain",
-        detail: alloc::format!("VM[{}] must be prepared before {operation}", vm.id()),
+        detail: std::format!("VM[{}] must be prepared before {operation}", vm.id()),
     })
 }
 
 fn forwarding_route_error(
     vm_id: usize,
     guest_gsi: usize,
-    host_irq: impl core::fmt::Debug,
+    host_irq: impl std::fmt::Debug,
     error: ForwardingRouteError,
 ) -> crate::AxVmError {
     let detail = match error {
         ForwardingRouteError::UnsupportedGsi => {
-            alloc::format!("guest GSI {guest_gsi} is not supported")
+            std::format!("guest GSI {guest_gsi} is not supported")
         }
-        ForwardingRouteError::AlreadyActive => alloc::format!(
+        ForwardingRouteError::AlreadyActive => std::format!(
             "VM[{vm_id}] forwarding is already active; routes must be configured before the boot \
              vCPU starts"
         ),
-        ForwardingRouteError::HostIrqConflict => alloc::format!(
+        ForwardingRouteError::HostIrqConflict => std::format!(
             "host IRQ {host_irq:?} is already mapped to a different guest GSI in VM[{vm_id}]"
         ),
         ForwardingRouteError::HostOwnedConsole => {
-            alloc::format!("host IRQ {host_irq:?} belongs to the runtime-selected physical console")
+            std::format!("host IRQ {host_irq:?} belongs to the runtime-selected physical console")
         }
         ForwardingRouteError::ResolveHostIrq(error) => {
-            alloc::format!("failed to resolve host IRQ for guest GSI {guest_gsi}: {error:?}")
+            std::format!("failed to resolve host IRQ for guest GSI {guest_gsi}: {error:?}")
         }
     };
     crate::AxVmError::Interrupt {
@@ -289,7 +289,7 @@ impl X86InterruptDomain {
         if !state.hooks_registered || state.owner_vcpu_id != Some(vcpu_id) {
             return None;
         }
-        let pending = core::mem::take(&mut state.pending);
+        let pending = std::mem::take(&mut state.pending);
         if pending == 0 {
             return None;
         }
@@ -420,7 +420,7 @@ impl X86InterruptDomain {
         state.pending_level = 0;
         state.hooks_registered = false;
         state.enabled = false;
-        let masked = core::mem::take(&mut state.masked);
+        let masked = std::mem::take(&mut state.masked);
         state
             .routes
             .iter()
@@ -496,11 +496,11 @@ pub fn drain_pending_wired_irqs(vm: &VMRef, vcpu: &VCpuRef) {
         domain
             .wired
             .pending
-            .fetch_or(retry, core::sync::atomic::Ordering::Release);
+            .fetch_or(retry, std::sync::atomic::Ordering::Release);
         domain
             .wired
             .pending_level
-            .fetch_or(retry_level, core::sync::atomic::Ordering::Release);
+            .fetch_or(retry_level, std::sync::atomic::Ordering::Release);
     }
 }
 
@@ -526,7 +526,7 @@ pub fn register_ioapic_irq_forwarding_route_with_trigger(
     if !should_register_ioapic_gsi_hook(guest_gsi) {
         return Err(crate::AxVmError::InvalidInput {
             operation: "register x86 IOAPIC forwarding route",
-            detail: alloc::format!("unsupported guest GSI {guest_gsi}"),
+            detail: std::format!("unsupported guest GSI {guest_gsi}"),
         });
     }
 
@@ -550,7 +550,7 @@ pub fn register_ioapic_irq_forwarding_activator(
     if !should_register_ioapic_gsi_hook(guest_gsi) {
         return Err(crate::AxVmError::InvalidInput {
             operation: "register x86 IOAPIC forwarding activator",
-            detail: alloc::format!("unsupported guest GSI {guest_gsi}"),
+            detail: std::format!("unsupported guest GSI {guest_gsi}"),
         });
     }
 
@@ -960,10 +960,12 @@ fn host_irq_forwarding_lease_count() -> usize {
 
 #[cfg(test)]
 mod tests {
-    use alloc::sync::Arc;
-    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
 
-    use ax_kspin::SpinRaw as Mutex;
+    use ax_std::os::arceos::sync::RawSpinLock as Mutex;
     use axdevice::X86IoApicDeviceOps;
 
     use super::{

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -3,14 +3,18 @@
 //! This module owns the AxVM/ArceOS glue for the OS-neutral `x86_vcpu` and
 //! `x86_vlapic` cores.
 
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc};
-use core::{
+use std::{
     arch::asm,
-    sync::atomic::{AtomicUsize, Ordering},
+    boxed::Box,
+    collections::BTreeMap,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::Duration,
 };
 
-use ax_kspin::SpinRaw;
+use ax_std::os::arceos::sync::RawSpinLock;
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceFactoryRegistry, DeviceManagerResult,
     DeviceRegistration, ServiceCardinality, ServiceKey, VirtualInterruptControllerKey,
@@ -534,12 +538,12 @@ fn unique_x86_machine_device<'a>(
         .iter()
         .filter(|config| config.emu_type == device_type);
     let config = matches.next().ok_or_else(|| {
-        AxVmError::resource_unavailable("x86 machine device", alloc::format!("missing {resource}"))
+        AxVmError::resource_unavailable("x86 machine device", std::format!("missing {resource}"))
     })?;
     if matches.next().is_some() {
         return Err(AxVmError::resource_conflict(
             "x86 machine device",
-            alloc::format!("more than one {resource} descriptor is configured"),
+            std::format!("more than one {resource} descriptor is configured"),
         ));
     }
     Ok(config)
@@ -552,9 +556,9 @@ fn unique_x86_machine_device<'a>(
 /// VM-owned domain.
 pub(super) struct X86InterruptDomain {
     wired: Arc<X86WiredState>,
-    inputs: SpinRaw<BTreeMap<usize, (InterruptTriggerMode, WiredIrqInput)>>,
-    forwarding: SpinRaw<irq::X86IoApicForwardingState>,
-    forwarding_hooks: SpinRaw<alloc::vec::Vec<host_irq::IrqHandle>>,
+    inputs: RawSpinLock<BTreeMap<usize, (InterruptTriggerMode, WiredIrqInput)>>,
+    forwarding: RawSpinLock<irq::X86IoApicForwardingState>,
+    forwarding_hooks: RawSpinLock<std::vec::Vec<host_irq::IrqHandle>>,
 }
 
 struct X86WiredState {
@@ -587,9 +591,9 @@ impl X86InterruptDomain {
                 pending_level: AtomicUsize::new(0),
                 kick: DeferredVcpuKick::new(vm_id),
             }),
-            inputs: SpinRaw::new(BTreeMap::new()),
-            forwarding: SpinRaw::new(irq::X86IoApicForwardingState::new()),
-            forwarding_hooks: SpinRaw::new(alloc::vec::Vec::new()),
+            inputs: RawSpinLock::new(BTreeMap::new()),
+            forwarding: RawSpinLock::new(irq::X86IoApicForwardingState::new()),
+            forwarding_hooks: RawSpinLock::new(std::vec::Vec::new()),
         }
     }
 
@@ -614,8 +618,8 @@ impl X86InterruptDomain {
         self.forwarding_hooks.lock().push(hook);
     }
 
-    pub(super) fn take_forwarding_hooks(&self) -> alloc::vec::Vec<host_irq::IrqHandle> {
-        core::mem::take(&mut *self.forwarding_hooks.lock())
+    pub(super) fn take_forwarding_hooks(&self) -> std::vec::Vec<host_irq::IrqHandle> {
+        std::mem::take(&mut *self.forwarding_hooks.lock())
     }
 }
 
@@ -651,7 +655,7 @@ impl VirtualInterruptController for X86InterruptDomain {
                     input,
                 },
                 operation: "open x86 IOAPIC input",
-                detail: alloc::format!("GSI {gsi} is outside 0..{}", irq::IOAPIC_GSI_COUNT),
+                detail: std::format!("GSI {gsi} is outside 0..{}", irq::IOAPIC_GSI_COUNT),
             });
         }
         let mut inputs = self.inputs.lock();
@@ -663,7 +667,7 @@ impl VirtualInterruptController for X86InterruptDomain {
                         input,
                     },
                     operation: "open x86 IOAPIC input",
-                    detail: alloc::format!(
+                    detail: std::format!(
                         "GSI {gsi} is already registered as {registered_trigger:?}"
                     ),
                 });
@@ -696,7 +700,7 @@ impl X86WiredState {
                     input,
                 },
                 operation: "publish x86 IOAPIC vCPU kick",
-                detail: alloc::format!("{error}"),
+                detail: std::format!("{error}"),
             })
     }
 }
@@ -981,7 +985,7 @@ mod tests {
     #[test]
     fn x86_platform_devices_are_built_by_registered_factories() {
         let mut factories = DeviceFactoryRegistry::new();
-        let configs = alloc::vec![
+        let configs = std::vec![
             EmulatedDeviceConfig {
                 name: "ioapic".into(),
                 base_gpa: 0xfec0_0000,

--- a/virtualization/axvm/src/arch/x86_64/nested_paging/ept.rs
+++ b/virtualization/axvm/src/arch/x86_64/nested_paging/ept.rs
@@ -1,6 +1,6 @@
 //! Intel Extended Page Table entry encoding.
 
-use core::{convert::TryFrom, fmt};
+use std::{convert::TryFrom, fmt};
 
 use axvm_types::{HostPhysAddr, MappingFlags};
 use bit_field::BitField;

--- a/virtualization/axvm/src/arch/x86_64/nested_paging/npt.rs
+++ b/virtualization/axvm/src/arch/x86_64/nested_paging/npt.rs
@@ -1,6 +1,6 @@
 //! AMD Nested Page Table entry encoding.
 
-use core::fmt;
+use std::fmt;
 
 use axvm_types::{HostPhysAddr, MappingFlags};
 use page_table_generic as ptg;

--- a/virtualization/axvm/src/arch/x86_64/port.rs
+++ b/virtualization/axvm/src/arch/x86_64/port.rs
@@ -1,6 +1,6 @@
 //! Native x86 host I/O port passthrough devices.
 
-use alloc::{boxed::Box, sync::Arc};
+use std::{boxed::Box, sync::Arc};
 
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceManagerError, DeviceManagerResult,
@@ -33,7 +33,7 @@ impl HostPortPassthrough {
         Ok(Self {
             base: Port::new(base),
             length,
-            resources: alloc::vec![Resource::PortRange { base, size: length }].into_boxed_slice(),
+            resources: std::vec![Resource::PortRange { base, size: length }].into_boxed_slice(),
         })
     }
 
@@ -135,7 +135,7 @@ impl DeviceFactory for HostPortPassthroughDeviceFactory {
             .build()
             .map_err(|error| DeviceManagerError::InvalidConfig {
                 operation: "build host port passthrough",
-                detail: alloc::format!("{error}"),
+                detail: std::format!("{error}"),
             })
     }
 }
@@ -174,7 +174,7 @@ impl Device for HostPortPassthrough {
 unsafe fn inb(port: u16) -> u8 {
     let value: u8;
     unsafe {
-        core::arch::asm!("in al, dx", in("dx") port, out("al") value, options(nomem, nostack));
+        std::arch::asm!("in al, dx", in("dx") port, out("al") value, options(nomem, nostack));
     }
     value
 }
@@ -182,7 +182,7 @@ unsafe fn inb(port: u16) -> u8 {
 unsafe fn inw(port: u16) -> u16 {
     let value: u16;
     unsafe {
-        core::arch::asm!("in ax, dx", in("dx") port, out("ax") value, options(nomem, nostack));
+        std::arch::asm!("in ax, dx", in("dx") port, out("ax") value, options(nomem, nostack));
     }
     value
 }
@@ -190,26 +190,26 @@ unsafe fn inw(port: u16) -> u16 {
 unsafe fn inl(port: u16) -> u32 {
     let value: u32;
     unsafe {
-        core::arch::asm!("in eax, dx", in("dx") port, out("eax") value, options(nomem, nostack));
+        std::arch::asm!("in eax, dx", in("dx") port, out("eax") value, options(nomem, nostack));
     }
     value
 }
 
 unsafe fn outb(port: u16, value: u8) {
     unsafe {
-        core::arch::asm!("out dx, al", in("dx") port, in("al") value, options(nomem, nostack));
+        std::arch::asm!("out dx, al", in("dx") port, in("al") value, options(nomem, nostack));
     }
 }
 
 unsafe fn outw(port: u16, value: u16) {
     unsafe {
-        core::arch::asm!("out dx, ax", in("dx") port, in("ax") value, options(nomem, nostack));
+        std::arch::asm!("out dx, ax", in("dx") port, in("ax") value, options(nomem, nostack));
     }
 }
 
 unsafe fn outl(port: u16, value: u32) {
     unsafe {
-        core::arch::asm!("out dx, eax", in("dx") port, in("eax") value, options(nomem, nostack));
+        std::arch::asm!("out dx, eax", in("dx") port, in("eax") value, options(nomem, nostack));
     }
 }
 

--- a/virtualization/axvm/src/arch/x86_64/vm.rs
+++ b/virtualization/axvm/src/arch/x86_64/vm.rs
@@ -67,7 +67,7 @@ fn prepare_device_bootstrap(
     vm: &AxVM,
 ) -> AxVmResult<(
     axdevice::DeviceFactoryRegistry,
-    alloc::sync::Arc<dyn axdevice_base::VirtualInterruptController>,
+    std::sync::Arc<dyn axdevice_base::VirtualInterruptController>,
 )> {
     let mut factories = default_device_factories(vm)?;
     let configs = vm.with_config(|config| config.emu_devices().clone());
@@ -78,7 +78,7 @@ fn prepare_device_bootstrap(
 fn init_vm_with(
     vm: &AxVM,
     factories: &axdevice::DeviceFactoryRegistry,
-    interrupt_controller: alloc::sync::Arc<dyn axdevice_base::VirtualInterruptController>,
+    interrupt_controller: std::sync::Arc<dyn axdevice_base::VirtualInterruptController>,
 ) -> AxVmResult {
     complete_vm_init(
         vm,
@@ -133,7 +133,7 @@ fn build_vcpu_setup_config(
     Ok(setup_config)
 }
 
-fn arch_extra_device_configs(config: &AxVMConfig) -> alloc::vec::Vec<EmulatedDeviceConfig> {
+fn arch_extra_device_configs(config: &AxVMConfig) -> std::vec::Vec<EmulatedDeviceConfig> {
     config
         .pass_through_ports()
         .iter()
@@ -144,18 +144,18 @@ fn arch_extra_device_configs(config: &AxVMConfig) -> alloc::vec::Vec<EmulatedDev
                 port.base as u32 + port.length as u32 - 1,
             );
             EmulatedDeviceConfig {
-                name: alloc::format!("x86-port-passthrough-{:#x}", port.base),
+                name: std::format!("x86-port-passthrough-{:#x}", port.base),
                 base_gpa: port.base as usize,
                 length: port.length as usize,
                 irq_id: 0,
                 emu_type: EmulatedDeviceType::X86PortPassthrough,
-                cfg_list: alloc::vec![],
+                cfg_list: std::vec![],
             }
         })
         .collect()
 }
 
-fn append_arch_owned_regions(regions: &mut alloc::vec::Vec<GuestOwnedRegion>) {
+fn append_arch_owned_regions(regions: &mut std::vec::Vec<GuestOwnedRegion>) {
     regions.push(GuestOwnedRegion::new(
         X86_LOCAL_APIC_GPA,
         X86_LOCAL_APIC_SIZE,
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn svm_reserves_the_local_apic_trap_region() {
-        let mut regions = alloc::vec::Vec::new();
+        let mut regions = std::vec::Vec::new();
 
         append_arch_owned_regions(&mut regions);
 
@@ -232,7 +232,7 @@ mod tests {
                 .mappings()
                 .iter()
                 .map(|mapping| (mapping.gpa.as_usize(), mapping.size))
-                .collect::<alloc::vec::Vec<_>>(),
+                .collect::<std::vec::Vec<_>>(),
             [
                 (0, X86_LOCAL_APIC_GPA),
                 (

--- a/virtualization/axvm/src/architecture/capabilities.rs
+++ b/virtualization/axvm/src/architecture/capabilities.rs
@@ -1,6 +1,6 @@
 //! Small capability boundaries implemented by the selected guest architecture.
 
-use alloc::{sync::Arc, vec::Vec};
+use std::{sync::Arc, vec::Vec};
 
 use ax_std::os::arceos::modules::ax_task::IrqNotify;
 

--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -1,6 +1,6 @@
 //! Core vCPU and nested-paging contract implemented by every target architecture.
 
-use alloc::{format, vec::Vec};
+use std::{format, vec::Vec};
 
 use ax_memory_addr::VirtAddr;
 use axaddrspace::NestedPageTableOps;
@@ -284,9 +284,9 @@ pub(crate) fn default_vcpu_affinities(
 
 #[cfg(all(test, feature = "host-test"))]
 mod tests {
-    use alloc::{sync::Arc, vec};
+    use std::{sync::Arc, vec};
 
-    use ax_kspin::SpinNoIrq;
+    use ax_std::os::arceos::sync::IrqSafeMutex;
     use axvm_types::{
         GuestPhysAddr, InterruptTriggerMode, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps,
         VmArchVcpuOps, VmBackendError, VmBackendResult,
@@ -302,11 +302,11 @@ mod tests {
     }
 
     struct RecordingVcpu {
-        injections: Arc<SpinNoIrq<InjectionLog>>,
+        injections: Arc<IrqSafeMutex<InjectionLog>>,
     }
 
     impl VmArchVcpuOps for RecordingVcpu {
-        type CreateConfig = Arc<SpinNoIrq<InjectionLog>>;
+        type CreateConfig = Arc<IrqSafeMutex<InjectionLog>>;
         type SetupConfig = ();
         type Exit = ();
 
@@ -426,7 +426,7 @@ mod tests {
 
     #[test]
     fn inject_vcpu_interrupt_preserves_level_trigger_at_backend_boundary() {
-        let injections = Arc::new(SpinNoIrq::new(InjectionLog::default()));
+        let injections = Arc::new(IrqSafeMutex::new(InjectionLog::default()));
         let vcpu = Arc::new(AxVCpu::<RecordingVcpu>::new(1, 0, None, injections.clone()).unwrap());
         let interrupt = PendingVcpuInterrupt {
             id: VirtualInterruptId(0x31),
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn dispatcher_drain_injects_fifo_once_and_consumes_failed_entries() {
-        let injections = Arc::new(SpinNoIrq::new(InjectionLog {
+        let injections = Arc::new(IrqSafeMutex::new(InjectionLog {
             failing_vector: Some(0x42),
             ..Default::default()
         }));

--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{string::String, vec::Vec};
-use core::ptr::NonNull;
+use std::{ptr::NonNull, string::String, vec::Vec};
 
 use ax_memory_addr::MemoryAddr;
 use axvmconfig::GuestConfig;
@@ -134,7 +133,7 @@ fn prune_dangling_interrupts_extended(source: &Fdt, guest: &mut FdtTree) -> AxVm
             .ok_or_else(|| {
                 ax_err_type!(
                     InvalidData,
-                    alloc::format!("source FDT node {path} lost interrupts-extended")
+                    std::format!("source FDT node {path} lost interrupts-extended")
                 )
             })?;
         let cells = property.get_u32_iter().collect::<Vec<_>>();
@@ -147,7 +146,7 @@ fn prune_dangling_interrupts_extended(source: &Fdt, guest: &mut FdtTree) -> AxVm
                 .ok_or_else(|| {
                     ax_err_type!(
                         InvalidData,
-                        alloc::format!(
+                        std::format!(
                             "FDT node {path} references missing interrupt provider {phandle:#x}"
                         )
                     )
@@ -158,7 +157,7 @@ fn prune_dangling_interrupts_extended(source: &Fdt, guest: &mut FdtTree) -> AxVm
                 .ok_or_else(|| {
                     ax_err_type!(
                         InvalidData,
-                        alloc::format!(
+                        std::format!(
                             "interrupt provider {phandle:#x} for {path} has no #interrupt-cells"
                         )
                     )
@@ -169,7 +168,7 @@ fn prune_dangling_interrupts_extended(source: &Fdt, guest: &mut FdtTree) -> AxVm
                 .ok_or_else(|| {
                     ax_err_type!(
                         InvalidData,
-                        alloc::format!("FDT node {path} has truncated interrupts-extended")
+                        std::format!("FDT node {path} has truncated interrupts-extended")
                     )
                 })?;
             if find_node_by_phandle(guest.inner(), phandle).is_some() {
@@ -179,7 +178,7 @@ fn prune_dangling_interrupts_extended(source: &Fdt, guest: &mut FdtTree) -> AxVm
         }
 
         if filtered.len() != cells.len() {
-            let mut property = Property::new("interrupts-extended", alloc::vec![]);
+            let mut property = Property::new("interrupts-extended", std::vec![]);
             property.set_u32_ls(&filtered);
             guest.set_property(node_id, property)?;
         }
@@ -305,7 +304,7 @@ pub fn update_fdt(
     let patch_runtime = super::selected_guest_fdt_policy().patch_runtime;
     // SAFETY: `fdt_src` originates from `GuestDtbImage::as_bytes`, and the
     // caller supplies the exact slice length while the image remains borrowed.
-    let fdt_bytes = unsafe { core::slice::from_raw_parts(fdt_src.as_ptr(), dtb_size) };
+    let fdt_bytes = unsafe { std::slice::from_raw_parts(fdt_src.as_ptr(), dtb_size) };
     let new_fdt_bytes = patch_runtime(fdt_bytes, &vm, crate_config)?;
 
     load_patched_fdt(vm, new_fdt_bytes)
@@ -400,7 +399,7 @@ mod tests {
     use crate::{GuestPhysAddr, config::RamdiskInfo};
 
     fn prop_u32(name: &str, value: u32) -> Property {
-        let mut prop = Property::new(name, alloc::vec![]);
+        let mut prop = Property::new(name, std::vec![]);
         prop.set_u32_ls(&[value]);
         prop
     }
@@ -431,7 +430,7 @@ mod tests {
     #[test]
     fn cpu_node_selection_uses_node_id_when_reg_differs() {
         let fdt = test_fdt("cpu@0=200\ncpu@100=0\ncpu@101=100");
-        let selected: alloc::vec::Vec<_> = fdt
+        let selected: std::vec::Vec<_> = fdt
             .iter_node_ids()
             .map(|id| (id, fdt.path_of(id)))
             .filter(|(_, path)| path.starts_with("/cpus/cpu@"))
@@ -533,7 +532,7 @@ mod tests {
         let fdt = test_fdt("cpu@0=200\ncpu@100=0\ncpu@101=100");
         let cfg = GuestConfig {
             base: axvmconfig::VMBaseConfig {
-                phys_cpu_ids: Some(alloc::vec![0x100]),
+                phys_cpu_ids: Some(std::vec![0x100]),
                 ..Default::default()
             },
             ..Default::default()
@@ -557,7 +556,7 @@ mod tests {
                 .set_property(prop_u32("#interrupt-cells", 1));
             fdt.node_mut(intc)
                 .unwrap()
-                .set_property(Property::new("interrupt-controller", alloc::vec![]));
+                .set_property(Property::new("interrupt-controller", std::vec![]));
             fdt.node_mut(intc)
                 .unwrap()
                 .set_property(prop_u32("phandle", phandle));
@@ -565,22 +564,22 @@ mod tests {
         let root = fdt.root_id();
         let soc = fdt.add_node(root, Node::new("soc"));
         let plic = fdt.add_node(soc, Node::new("plic@c000000"));
-        let mut compatible = Property::new("compatible", alloc::vec![]);
+        let mut compatible = Property::new("compatible", std::vec![]);
         compatible.set_string("riscv,plic0");
         fdt.node_mut(plic).unwrap().set_property(compatible);
         fdt.node_mut(plic)
             .unwrap()
-            .set_property(Property::new("interrupt-controller", alloc::vec![]));
+            .set_property(Property::new("interrupt-controller", std::vec![]));
         fdt.node_mut(plic)
             .unwrap()
             .set_property(prop_u32("phandle", 9));
-        let mut contexts = Property::new("interrupts-extended", alloc::vec![]);
+        let mut contexts = Property::new("interrupts-extended", std::vec![]);
         contexts.set_u32_ls(&[8, 11, 8, 9, 6, 11, 6, 9]);
         fdt.node_mut(plic).unwrap().set_property(contexts);
 
         let cfg = GuestConfig {
             base: axvmconfig::VMBaseConfig {
-                phys_cpu_ids: Some(alloc::vec![0]),
+                phys_cpu_ids: Some(std::vec![0]),
                 ..Default::default()
             },
             ..Default::default()
@@ -598,7 +597,7 @@ mod tests {
                 .get_property("interrupts-extended")
                 .unwrap()
                 .get_u32_iter()
-                .collect::<alloc::vec::Vec<_>>(),
+                .collect::<std::vec::Vec<_>>(),
             [8, 11, 8, 9]
         );
     }

--- a/virtualization/axvm/src/boot/fdt/core/device.rs
+++ b/virtualization/axvm/src/boot/fdt/core/device.rs
@@ -14,7 +14,7 @@
 
 //! Device passthrough and dependency analysis for FDT processing.
 
-use alloc::{
+use std::{
     collections::{BTreeMap, BTreeSet},
     string::{String, ToString},
     vec::Vec,

--- a/virtualization/axvm/src/boot/fdt/core/interrupt.rs
+++ b/virtualization/axvm/src/boot/fdt/core/interrupt.rs
@@ -39,7 +39,7 @@ pub(crate) fn install_machine_interrupt_controller(
             };
             fallback = GuestGicProfile {
                 compatible: "arm,gic-v3".into(),
-                node_path: alloc::string::String::new(),
+                node_path: std::string::String::new(),
                 node_phandle: None,
                 distributor: GuestMmioRegion {
                     base: distributor.base_gpa,
@@ -92,7 +92,7 @@ pub(crate) fn host_gic_profile(fdt: &Fdt) -> AxVmResult<Option<GuestGicProfile>>
         }
         node.compatibles()
             .find(|compatible| is_supported_gic(compatible))
-            .map(|compatible| (node_id, alloc::string::String::from(compatible)))
+            .map(|compatible| (node_id, std::string::String::from(compatible)))
     }) else {
         return Ok(None);
     };
@@ -185,7 +185,7 @@ pub(crate) fn host_gic_maintenance_intid(fdt: &Fdt) -> AxVmResult<Option<u32>> {
     if interrupt_type != 1 || source >= 16 {
         return Err(ax_err_type!(
             Unsupported,
-            alloc::format!(
+            std::format!(
                 "host GIC maintenance interrupt must be a PPI, got type {interrupt_type} source \
                  {source}"
             )
@@ -198,7 +198,7 @@ fn checked_reg(reg: &fdt_edit::RegFixed, name: &str) -> AxVmResult<(usize, usize
     let base = usize::try_from(reg.address).map_err(|_| {
         ax_err_type!(
             InvalidData,
-            alloc::format!("host GIC {name} address does not fit usize")
+            std::format!("host GIC {name} address does not fit usize")
         )
     })?;
     let length = reg
@@ -206,21 +206,21 @@ fn checked_reg(reg: &fdt_edit::RegFixed, name: &str) -> AxVmResult<(usize, usize
         .ok_or_else(|| {
             ax_err_type!(
                 InvalidData,
-                alloc::format!("host GIC {name} range has no size")
+                std::format!("host GIC {name} range has no size")
             )
         })
         .and_then(|length| {
             usize::try_from(length).map_err(|_| {
                 ax_err_type!(
                     InvalidData,
-                    alloc::format!("host GIC {name} range size does not fit usize")
+                    std::format!("host GIC {name} range size does not fit usize")
                 )
             })
         })?;
     if length == 0 {
         return Err(ax_err_type!(
             InvalidData,
-            alloc::format!("host GIC {name} range is empty")
+            std::format!("host GIC {name} range is empty")
         ));
     }
     Ok((base, length))
@@ -322,7 +322,7 @@ fn install_controller_phandle(
     {
         return Err(ax_err_type!(
             InvalidData,
-            alloc::format!(
+            std::format!(
                 "host {controller_name} phandle {phandle:#x} conflicts with another guest node"
             )
         ));
@@ -346,7 +346,7 @@ fn install_controller_phandle(
                     })
                 })
             })
-            .collect::<alloc::vec::Vec<_>>();
+            .collect::<std::vec::Vec<_>>();
         for node_id in references {
             for name in ["interrupt-parent", "msi-parent"] {
                 let matches = tree
@@ -366,13 +366,13 @@ fn install_controller_phandle(
 }
 
 fn prop_u32(name: &str, value: u32) -> Property {
-    let mut property = Property::new(name, alloc::vec![]);
+    let mut property = Property::new(name, std::vec![]);
     property.set_u32_ls(&[value]);
     property
 }
 
 fn prop_string(name: &str, value: &str) -> Property {
-    let mut property = Property::new(name, alloc::vec![]);
+    let mut property = Property::new(name, std::vec![]);
     property.set_string(value);
     property
 }
@@ -419,7 +419,7 @@ fn find_plic_in_fdt(fdt: &Fdt) -> Option<NodeId> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
+    use std::vec;
 
     use fdt_edit::{Fdt, Node, Property};
 

--- a/virtualization/axvm/src/boot/fdt/core/mod.rs
+++ b/virtualization/axvm/src/boot/fdt/core/mod.rs
@@ -1,6 +1,6 @@
 //! Architecture-neutral guest device-tree preparation.
 
-use alloc::{format, vec::Vec};
+use std::{format, vec::Vec};
 
 use axvmconfig::{GuestConfig, VMBootProtocol};
 

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -14,7 +14,7 @@
 
 //! Architecture-neutral FDT parsing and guest configuration enrichment.
 
-use alloc::{
+use std::{
     collections::BTreeSet,
     format,
     string::{String, ToString},
@@ -729,7 +729,7 @@ pub fn update_provided_fdt(
 
 #[cfg(test)]
 mod tests {
-    use alloc::{string::ToString, vec, vec::Vec};
+    use std::{string::ToString, vec, vec::Vec};
 
     use axvm_types::{AddressSpacePolicy, PassThroughDeviceConfig, VmMemConfig, VmMemMappingType};
     use axvmconfig::{GuestConfig, GuestDevices, GuestType, PhysicalDeviceRef};
@@ -743,13 +743,13 @@ mod tests {
     use crate::config::{AxVMConfig, AxVMConfigParams, PhysCpuList};
 
     fn prop_u32(name: &str, value: u32) -> fdt_edit::Property {
-        let mut prop = fdt_edit::Property::new(name, alloc::vec![]);
+        let mut prop = fdt_edit::Property::new(name, std::vec![]);
         prop.set_u32_ls(&[value]);
         prop
     }
 
     fn prop_u32_list(name: &str, values: &[u32]) -> fdt_edit::Property {
-        let mut prop = fdt_edit::Property::new(name, alloc::vec![]);
+        let mut prop = fdt_edit::Property::new(name, std::vec![]);
         prop.set_u32_ls(values);
         prop
     }
@@ -783,10 +783,7 @@ mod tests {
         let intc = fdt.add_node(root, Node::new("interrupt-controller@0"));
         fdt.node_mut(intc)
             .unwrap()
-            .set_property(fdt_edit::Property::new(
-                "interrupt-controller",
-                alloc::vec![],
-            ));
+            .set_property(fdt_edit::Property::new("interrupt-controller", std::vec![]));
         fdt.node_mut(intc)
             .unwrap()
             .set_property(prop_u32("#interrupt-cells", 1));
@@ -826,10 +823,7 @@ mod tests {
         let intc = fdt.add_node(root, Node::new("interrupt-controller@0"));
         fdt.node_mut(intc)
             .unwrap()
-            .set_property(fdt_edit::Property::new(
-                "interrupt-controller",
-                alloc::vec![],
-            ));
+            .set_property(fdt_edit::Property::new("interrupt-controller", std::vec![]));
         fdt.node_mut(intc)
             .unwrap()
             .set_property(prop_u32("#interrupt-cells", 1));
@@ -875,10 +869,7 @@ mod tests {
             .set_property(super::super::tree::prop_string("compatible", "riscv,plic0"));
         fdt.node_mut(intc)
             .unwrap()
-            .set_property(fdt_edit::Property::new(
-                "interrupt-controller",
-                alloc::vec![],
-            ));
+            .set_property(fdt_edit::Property::new("interrupt-controller", std::vec![]));
         fdt.view_typed_mut(intc)
             .unwrap()
             .set_regs(&[RegInfo::new(0x0c00_0000, Some(0x40_0000))]);

--- a/virtualization/axvm/src/boot/fdt/core/policy.rs
+++ b/virtualization/axvm/src/boot/fdt/core/policy.rs
@@ -1,6 +1,6 @@
 //! Static target policies consumed by common guest FDT operations.
 
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 use axdevice_base::InterruptTriggerMode;
 use axvmconfig::GuestConfig;

--- a/virtualization/axvm/src/boot/fdt/core/print.rs
+++ b/virtualization/axvm/src/boot/fdt/core/print.rs
@@ -14,23 +14,21 @@
 
 //! FDT parsing and processing functionality.
 
-use alloc::format;
+use std::format;
 
 use fdt_edit::Fdt;
 use fdt_raw::Header;
 
 #[allow(dead_code)]
 pub fn print_fdt(fdt_addr: usize) {
-    let header = unsafe {
-        core::slice::from_raw_parts(fdt_addr as *const u8, core::mem::size_of::<Header>())
-    };
+    let header =
+        unsafe { std::slice::from_raw_parts(fdt_addr as *const u8, std::mem::size_of::<Header>()) };
     let fdt_header = Header::from_bytes(header)
         .map_err(|e| format!("Failed to parse FDT header: {e:#?}"))
         .unwrap();
 
-    let fdt_bytes = unsafe {
-        core::slice::from_raw_parts(fdt_addr as *const u8, fdt_header.totalsize as usize)
-    };
+    let fdt_bytes =
+        unsafe { std::slice::from_raw_parts(fdt_addr as *const u8, fdt_header.totalsize as usize) };
 
     let fdt = Fdt::from_bytes(fdt_bytes)
         .map_err(|e| format!("Failed to parse FDT: {e:#?}"))
@@ -38,7 +36,7 @@ pub fn print_fdt(fdt_addr: usize) {
 
     // Statistics of node count and level distribution
     let mut node_count = 0;
-    let mut level_counts = alloc::collections::BTreeMap::new();
+    let mut level_counts = std::collections::BTreeMap::new();
     let mut max_level = 0;
 
     info!("=== FDT Node Information Statistics ===");
@@ -94,7 +92,7 @@ pub fn print_guest_fdt(fdt_bytes: &[u8]) {
         .expect("Failed to parse FDT");
     // Statistics of node count and level distribution
     let mut node_count = 0;
-    let mut level_counts = alloc::collections::BTreeMap::new();
+    let mut level_counts = std::collections::BTreeMap::new();
     let mut max_level = 0;
 
     info!("=== FDT Node Information Statistics ===");

--- a/virtualization/axvm/src/boot/fdt/core/serial/mod.rs
+++ b/virtualization/axvm/src/boot/fdt/core/serial/mod.rs
@@ -1,6 +1,6 @@
 //! Machine-owned virtual serial description for guest device trees.
 
-use alloc::{format, string::String, vec, vec::Vec};
+use std::{format, string::String, vec, vec::Vec};
 
 use axdevice_base::AccessWidth;
 use fdt_edit::{Fdt, Node, Property, RegFixed};
@@ -372,7 +372,7 @@ fn install_mmio_serial(
     };
 
     let mut old_paths = physical_serial_paths(tree.inner());
-    old_paths.sort_by_key(|path| core::cmp::Reverse(path.matches('/').count()));
+    old_paths.sort_by_key(|path| std::cmp::Reverse(path.matches('/').count()));
     for path in old_paths {
         tree.inner_mut().remove_by_path(&path);
     }

--- a/virtualization/axvm/src/boot/fdt/core/serial/tests.rs
+++ b/virtualization/axvm/src/boot/fdt/core/serial/tests.rs
@@ -1,4 +1,4 @@
-use alloc::string::ToString;
+use std::string::ToString;
 
 use super::*;
 

--- a/virtualization/axvm/src/boot/fdt/core/timer.rs
+++ b/virtualization/axvm/src/boot/fdt/core/timer.rs
@@ -1,6 +1,6 @@
 //! Machine-owned AArch64 architectural timer description.
 
-use alloc::{string::String, vec::Vec};
+use std::{string::String, vec::Vec};
 
 use fdt_edit::{Fdt, Node, Property};
 
@@ -68,7 +68,7 @@ pub(crate) fn host_timer_profile(fdt: &Fdt) -> AxVmResult<Option<GuestTimerProfi
     if !(4..=5).contains(&interrupt_count) {
         return Err(ax_err_type!(
             InvalidData,
-            alloc::format!(
+            std::format!(
                 "host architectural timer must describe four or five interrupts, got \
                  {interrupt_count}"
             )
@@ -77,7 +77,7 @@ pub(crate) fn host_timer_profile(fdt: &Fdt) -> AxVmResult<Option<GuestTimerProfi
     let controller = fdt.get_by_phandle(interrupt_parent.into()).ok_or_else(|| {
         ax_err_type!(
             InvalidData,
-            alloc::format!(
+            std::format!(
                 "host architectural timer references missing interrupt parent \
                  {interrupt_parent:#x}"
             )
@@ -169,13 +169,13 @@ pub(crate) fn install_machine_timer(
     let (parent_path, node_name) = path.rsplit_once('/').ok_or_else(|| {
         ax_err_type!(
             InvalidData,
-            alloc::format!("architectural timer node path is not absolute: {path}")
+            std::format!("architectural timer node path is not absolute: {path}")
         )
     })?;
     if node_name.is_empty() {
         return Err(ax_err_type!(
             InvalidData,
-            alloc::format!("architectural timer node path has no node name: {path}")
+            std::format!("architectural timer node path has no node name: {path}")
         ));
     }
     let parent = if parent_path.is_empty() {
@@ -206,7 +206,7 @@ pub(crate) fn install_machine_timer(
         {
             return Err(ax_err_type!(
                 InvalidData,
-                alloc::format!("architectural timer phandle {phandle:#x} is already in use")
+                std::format!("architectural timer phandle {phandle:#x} is already in use")
             ));
         }
         tree.set_property(timer, prop_u32("phandle", phandle))?;
@@ -227,7 +227,7 @@ fn prop_u32_list(name: &str, values: &[u32]) -> Property {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
+    use std::vec;
 
     use fdt_edit::{Node, Property};
 

--- a/virtualization/axvm/src/boot/fdt/core/tree.rs
+++ b/virtualization/axvm/src/boot/fdt/core/tree.rs
@@ -1,4 +1,4 @@
-use alloc::{format, string::String, vec::Vec};
+use std::{format, string::String, vec::Vec};
 
 use fdt_edit::{Fdt, Node, NodeId, Property};
 use fdt_raw::{Header, RegInfo};
@@ -226,7 +226,7 @@ impl FdtTree {
     }
 
     fn remove_paths_deepest_first(&mut self, mut paths: Vec<String>) {
-        paths.sort_by_key(|path| core::cmp::Reverse(path.matches('/').count()));
+        paths.sort_by_key(|path| std::cmp::Reverse(path.matches('/').count()));
         for path in paths {
             self.fdt.remove_by_path(&path);
         }
@@ -251,11 +251,11 @@ pub(crate) fn host_fdt_bytes_from_ptr(ptr: *const u8) -> Option<&'static [u8]> {
     }
 
     let header = unsafe {
-        let bytes = core::slice::from_raw_parts(ptr, core::mem::size_of::<Header>());
+        let bytes = std::slice::from_raw_parts(ptr, std::mem::size_of::<Header>());
         Header::from_bytes(bytes).ok()?
     };
 
-    Some(unsafe { core::slice::from_raw_parts(ptr, header.totalsize as usize) })
+    Some(unsafe { std::slice::from_raw_parts(ptr, header.totalsize as usize) })
 }
 
 pub(crate) fn sanitize_bootargs(bootargs: &str) -> String {

--- a/virtualization/axvm/src/boot/fdt/core/tree_tests.rs
+++ b/virtualization/axvm/src/boot/fdt/core/tree_tests.rs
@@ -1,4 +1,4 @@
-use alloc::{vec, vec::Vec};
+use std::{vec, vec::Vec};
 
 use fdt_edit::{Fdt, Node, Property};
 use fdt_raw::{MemoryReservation, RegInfo};
@@ -62,7 +62,7 @@ fn tree_rebuilds_memory_nodes_from_guest_regions() {
         .iter_node_ids()
         .map(|id| reparsed.path_of(id))
         .filter(|path| path.starts_with("/memory"))
-        .collect::<alloc::vec::Vec<_>>();
+        .collect::<std::vec::Vec<_>>();
 
     assert_eq!(memory_paths, ["/memory@80000000", "/memory@90000000"]);
     let first = reparsed.get_by_path("/memory@80000000").unwrap();
@@ -142,7 +142,7 @@ fn explicit_cmdline_replaces_host_bootargs() {
 
 #[test]
 fn host_fdt_pointer_rejects_null() {
-    assert!(host_fdt_bytes_from_ptr(core::ptr::null()).is_none());
+    assert!(host_fdt_bytes_from_ptr(std::ptr::null()).is_none());
 }
 
 #[test]

--- a/virtualization/axvm/src/boot/fdt/mod.rs
+++ b/virtualization/axvm/src/boot/fdt/mod.rs
@@ -1,6 +1,6 @@
 //! Guest device-tree artifact and selected architecture compatibility facade.
 
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 pub use crate::arch::fdt::*;
 

--- a/virtualization/axvm/src/boot/images/linux.rs
+++ b/virtualization/axvm/src/boot/images/linux.rs
@@ -85,10 +85,10 @@ impl ARM64Header {
     const MAGIC: u32 = 0x644d5241; // 'ARMd' in little-endian
 
     fn parse(buffer: &[u8]) -> Option<Self> {
-        if buffer.len() < core::mem::size_of::<Self>() {
+        if buffer.len() < std::mem::size_of::<Self>() {
             return None;
         }
-        let hdr: Self = unsafe { core::ptr::read_unaligned(buffer.as_ptr() as *const _) };
+        let hdr: Self = unsafe { std::ptr::read_unaligned(buffer.as_ptr() as *const _) };
         if hdr.magic != Self::MAGIC {
             return None;
         }
@@ -146,10 +146,10 @@ impl RiscvHeader {
     const MAGIC2: u32 = 0x56534905; // secondary magic
 
     fn parse(buffer: &[u8]) -> Option<Self> {
-        if buffer.len() < core::mem::size_of::<Self>() {
+        if buffer.len() < std::mem::size_of::<Self>() {
             return None;
         }
-        let hdr: Self = unsafe { core::ptr::read_unaligned(buffer.as_ptr() as *const _) };
+        let hdr: Self = unsafe { std::ptr::read_unaligned(buffer.as_ptr() as *const _) };
         if hdr.magic != Self::MAGIC || hdr.magic2 != Self::MAGIC2 {
             return None;
         }

--- a/virtualization/axvm/src/boot/images/mod.rs
+++ b/virtualization/axvm/src/boot/images/mod.rs
@@ -1,6 +1,6 @@
 //! Architecture-neutral guest image loading and source access.
 
-use alloc::format;
+use std::format;
 
 use axvmconfig::GuestConfig;
 use byte_unit::Byte;
@@ -251,7 +251,7 @@ pub fn load_vm_image_from_memory(
         // SAFETY: The destination comes from `get_image_load_region`, the source
         // contains `bytes_to_write` bytes, and guest memory cannot overlap the image.
         unsafe {
-            core::ptr::copy_nonoverlapping(
+            std::ptr::copy_nonoverlapping(
                 image_buffer[buffer_pos..].as_ptr(),
                 region.as_mut_ptr().cast(),
                 bytes_to_write,
@@ -276,7 +276,7 @@ pub fn load_vm_image_from_memory(
 
 #[cfg(any(feature = "fs", feature = "host-fs"))]
 pub mod fs {
-    use alloc::{format, vec::Vec};
+    use std::{format, vec::Vec};
 
     use axvmconfig::GuestConfig;
 

--- a/virtualization/axvm/src/boot/mod.rs
+++ b/virtualization/axvm/src/boot/mod.rs
@@ -43,14 +43,14 @@ pub trait BootImageProvider {
     }
 
     #[cfg(any(feature = "fs", feature = "host-fs"))]
-    fn read_file(&self, file_name: &str) -> crate::AxVmResult<alloc::vec::Vec<u8>>;
+    fn read_file(&self, file_name: &str) -> crate::AxVmResult<std::vec::Vec<u8>>;
 
     #[cfg(any(feature = "fs", feature = "host-fs"))]
     fn read_file_exact(
         &self,
         file_name: &str,
         read_size: usize,
-    ) -> crate::AxVmResult<alloc::vec::Vec<u8>> {
+    ) -> crate::AxVmResult<std::vec::Vec<u8>> {
         let buffer = self.read_file(file_name)?;
         if buffer.len() < read_size {
             return Err(ax_err_type!(

--- a/virtualization/axvm/src/boot/policy.rs
+++ b/virtualization/axvm/src/boot/policy.rs
@@ -14,7 +14,7 @@
 
 //! Guest boot-description ownership for AxVM.
 
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 use axvm_types::GuestPhysAddr;
 

--- a/virtualization/axvm/src/config.rs
+++ b/virtualization/axvm/src/config.rs
@@ -14,7 +14,7 @@
 
 //! Runtime configuration structures for an AxVM instance.
 
-use alloc::{string::String, sync::Arc, vec::Vec};
+use std::{string::String, sync::Arc, vec::Vec};
 
 use axdevice::{NullSerialBackendFactory, SerialBackendFactory};
 pub use axvm_types::{
@@ -241,7 +241,7 @@ impl AxVMConfig {
             .flatten()
             .any(|excluded| excluded == &path)
         {
-            self.excluded_devices.push(alloc::vec![path]);
+            self.excluded_devices.push(std::vec![path]);
         }
     }
 
@@ -384,14 +384,14 @@ impl AxVMConfig {
                 const GICV2_DISTRIBUTOR_SIZE: usize = 0x1_000;
                 const GICV2_CPU_INTERFACE_SIZE: usize = 0x2_000;
                 if profile.distributor.length < GICV2_DISTRIBUTOR_SIZE {
-                    return Err(crate::AxVmError::invalid_config(alloc::format!(
+                    return Err(crate::AxVmError::invalid_config(std::format!(
                         "AArch64 GICv2 distributor window {:#x} is smaller than \
                          {GICV2_DISTRIBUTOR_SIZE:#x}",
                         profile.distributor.length
                     )));
                 }
                 if region.length < GICV2_CPU_INTERFACE_SIZE {
-                    return Err(crate::AxVmError::invalid_config(alloc::format!(
+                    return Err(crate::AxVmError::invalid_config(std::format!(
                         "AArch64 GICv2 CPU-interface window {:#x} is smaller than \
                          {GICV2_CPU_INTERFACE_SIZE:#x}",
                         region.length
@@ -405,7 +405,7 @@ impl AxVMConfig {
             GuestGicCpuRegion::Redistributors(region) => {
                 const GICV3_DISTRIBUTOR_MINIMUM_SIZE: usize = 0x1_0000;
                 if profile.distributor.length < GICV3_DISTRIBUTOR_MINIMUM_SIZE {
-                    return Err(crate::AxVmError::invalid_config(alloc::format!(
+                    return Err(crate::AxVmError::invalid_config(std::format!(
                         "AArch64 GICv3 distributor window {:#x} is smaller than \
                          {GICV3_DISTRIBUTOR_MINIMUM_SIZE:#x}",
                         profile.distributor.length
@@ -419,7 +419,7 @@ impl AxVMConfig {
                         )
                     })?;
                 if region.length < required_size {
-                    return Err(crate::AxVmError::invalid_config(alloc::format!(
+                    return Err(crate::AxVmError::invalid_config(std::format!(
                         "AArch64 GIC redistributor window {:#x} is smaller than required size \
                          {required_size:#x}",
                         region.length
@@ -511,7 +511,7 @@ impl AxVMConfig {
                 crate::AxVmError::invalid_config("RISC-V PLIC context window size overflows usize")
             })?;
         if profile.length < minimum_length {
-            return Err(crate::AxVmError::invalid_config(alloc::format!(
+            return Err(crate::AxVmError::invalid_config(std::format!(
                 "RISC-V PLIC window {:#x} is smaller than required size {minimum_length:#x}",
                 profile.length
             )));
@@ -638,7 +638,7 @@ impl PhysCpuList {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
+    use std::vec;
 
     use super::*;
 

--- a/virtualization/axvm/src/error.rs
+++ b/virtualization/axvm/src/error.rs
@@ -1,7 +1,6 @@
 //! AxVM-owned error contract.
 
-use alloc::{format, string::String};
-use core::fmt::Display;
+use std::{fmt::Display, format, string::String};
 
 use axaddrspace::AddrSpaceError;
 use axdevice::DeviceManagerError;
@@ -420,7 +419,7 @@ pub(crate) use ax_err_type;
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::ToString;
+    use std::string::ToString;
 
     use super::*;
 

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -1,17 +1,13 @@
 //! Default private ArceOS host adapter for AxVM.
 
-extern crate alloc;
-
-use core::{
+use std::{
     sync::atomic::{AtomicUsize, Ordering},
+    thread,
     time::Duration,
 };
 
 use ax_memory_addr::PAGE_SIZE_4K;
-use ax_std::{
-    os::arceos::{api, modules},
-    thread,
-};
+use ax_std::os::arceos::{api, modules};
 use axvm_types::{HostPhysAddr, HostVirtAddr};
 
 #[cfg(any(feature = "fs", feature = "host-fs"))]
@@ -358,7 +354,7 @@ impl HostPlatform for ArceOsHost {
                     info!("Hardware virtualization support enabled on core {cpu_id}");
                     let _ = CORES.fetch_add(1, Ordering::Release);
                 },
-                alloc::format!("axvm-hv-init-{cpu_id}"),
+                std::format!("axvm-hv-init-{cpu_id}"),
                 modules::ax_task::default_task_stack_size(),
             );
             task.set_cpumask(<Self as HostCpu>::CpuMask::one_shot(cpu_id));

--- a/virtualization/axvm/src/host/traits.rs
+++ b/virtualization/axvm/src/host/traits.rs
@@ -1,6 +1,6 @@
 //! Internal host capability traits used by the AxVM runtime.
 
-use core::time::Duration;
+use std::time::Duration;
 
 use axvm_types::{HostPhysAddr, HostVirtAddr};
 

--- a/virtualization/axvm/src/irq/deferred.rs
+++ b/virtualization/axvm/src/irq/deferred.rs
@@ -4,13 +4,14 @@
 //! Architecture interrupt controllers own that state.  A hard-IRQ producer
 //! publishes only the target-vCPU bit and wakes one pre-created worker.
 
-use alloc::sync::Arc;
-use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
 
-use ax_kspin::SpinNoIrq;
 use ax_std::os::arceos::modules::ax_task::IrqNotify;
 
-use crate::{AxVmResult, ax_err};
+use crate::{AxVmResult, ax_err, sync::MutexExt};
 
 const KICK_WORKER_STACK_SIZE: usize = 0x20_000;
 
@@ -21,7 +22,7 @@ pub(crate) struct DeferredVcpuKick {
     worker_started: AtomicBool,
     stopping: AtomicBool,
     notify: IrqNotify,
-    worker: SpinNoIrq<Option<crate::AxTaskRef>>,
+    worker: Mutex<Option<crate::AxTaskRef>>,
 }
 
 impl DeferredVcpuKick {
@@ -33,13 +34,13 @@ impl DeferredVcpuKick {
             worker_started: AtomicBool::new(false),
             stopping: AtomicBool::new(false),
             notify: IrqNotify::new(),
-            worker: SpinNoIrq::new(None),
+            worker: Mutex::new(None),
         })
     }
 
     /// Starts the task-context worker before an architecture enables IRQ input.
     pub(crate) fn start(self: &Arc<Self>) {
-        let mut worker = self.worker.lock();
+        let mut worker = self.worker.lock_unpoisoned();
         if worker.is_some() {
             return;
         }
@@ -47,7 +48,7 @@ impl DeferredVcpuKick {
         let state = self.clone();
         let task = crate::TaskInner::new(
             move || state.run_worker(),
-            alloc::format!("VM[{}]-irq-kick", self.vm_id),
+            std::format!("VM[{}]-irq-kick", self.vm_id),
             KICK_WORKER_STACK_SIZE,
         );
         *worker = Some(crate::host::task::spawn_task(task));
@@ -65,7 +66,7 @@ impl DeferredVcpuKick {
         let Some(bit) = 1usize.checked_shl(vcpu_id as u32) else {
             return ax_err!(
                 InvalidInput,
-                alloc::format!(
+                std::format!(
                     "VM[{}] vCPU {vcpu_id} exceeds the deferred IRQ kick bitmap",
                     self.vm_id
                 )
@@ -83,7 +84,7 @@ impl DeferredVcpuKick {
         self.worker_started.store(false, Ordering::Release);
         self.stopping.store(true, Ordering::Release);
         self.notify.notify();
-        let worker = self.worker.lock().take();
+        let worker = self.worker.lock_unpoisoned().take();
         if let Some(worker) = worker {
             worker.join();
         }

--- a/virtualization/axvm/src/irq/sender.rs
+++ b/virtualization/axvm/src/irq/sender.rs
@@ -17,7 +17,7 @@
 //! The sender holds only a [`Weak`] reference to the VM, so it never creates
 //! a strong reference cycle and automatically fails when the VM is destroyed.
 
-use alloc::sync::{Arc, Weak};
+use std::sync::{Arc, Weak};
 
 use crate::{AxVM, AxVmResult, ax_err_type, irq::model::PendingVcpuInterrupt};
 
@@ -111,10 +111,9 @@ impl<T> StableInterruptTarget<T> {
 
 #[cfg(all(test, feature = "host-test"))]
 mod tests {
-    use alloc::vec::Vec;
-    use core::cell::RefCell;
+    use std::{cell::RefCell, vec::Vec};
 
-    use ax_kspin::SpinNoIrq;
+    use ax_std::os::arceos::sync::IrqSafeMutex;
 
     use super::*;
     use crate::{
@@ -125,13 +124,13 @@ mod tests {
     };
 
     struct TestVm {
-        machine: SpinNoIrq<Machine<(), Arc<VmRuntimeHandle>>>,
+        machine: IrqSafeMutex<Machine<(), Arc<VmRuntimeHandle>>>,
     }
 
     impl TestVm {
         fn new(machine: Machine<(), Arc<VmRuntimeHandle>>) -> Arc<Self> {
             Arc::new(Self {
-                machine: SpinNoIrq::new(machine),
+                machine: IrqSafeMutex::new(machine),
             })
         }
 
@@ -196,7 +195,7 @@ mod tests {
             send(&sender, 0, interrupt(1), &events).unwrap();
 
             assert_eq!(*events.borrow(), ["enqueue", "notify", "ipi"]);
-            assert_eq!(runtime.irq_dispatcher().drain(0), alloc::vec![interrupt(1)]);
+            assert_eq!(runtime.irq_dispatcher().drain(0), std::vec![interrupt(1)]);
         }
     }
 
@@ -281,11 +280,11 @@ mod tests {
 
         assert_eq!(
             old_runtime.irq_dispatcher().drain(0),
-            alloc::vec![interrupt(1)]
+            std::vec![interrupt(1)]
         );
         assert_eq!(
             new_runtime.irq_dispatcher().drain(0),
-            alloc::vec![interrupt(2)]
+            std::vec![interrupt(2)]
         );
         assert_eq!(
             *events.borrow(),

--- a/virtualization/axvm/src/layout.rs
+++ b/virtualization/axvm/src/layout.rs
@@ -14,8 +14,11 @@
 
 //! Guest physical address layout planning.
 
-use alloc::{format, vec::Vec};
-use core::cmp::{max, min};
+use std::{
+    cmp::{max, min},
+    format,
+    vec::Vec,
+};
 
 use ax_memory_addr::{PAGE_SIZE_4K, align_down_4k};
 use axdevice_base::Resource;
@@ -226,7 +229,7 @@ impl GuestRegionPlanner {
         let guest_end = checked_end("guest address space", guest_base, guest_size)?;
         let windows = match policy {
             AddressSpacePolicy::Virtualized => Vec::new(),
-            AddressSpacePolicy::Passthrough => alloc::vec![PassthroughWindow {
+            AddressSpacePolicy::Passthrough => std::vec![PassthroughWindow {
                 base: guest_base,
                 size: guest_size,
             }],
@@ -657,7 +660,7 @@ mod tests {
         assert!(layout.mappings().is_empty());
 
         let device = PassThroughDeviceConfig {
-            name: alloc::string::String::from("uart"),
+            name: std::string::String::from("uart"),
             base_gpa: 0x2000,
             base_hpa: 0x9000,
             length: 0x1000,
@@ -726,7 +729,7 @@ mod tests {
     #[test]
     fn passthrough_identity_device_does_not_refill_emulated_mmio_hole() {
         let provider = PassThroughDeviceConfig {
-            name: alloc::string::String::from("shared-clock-provider"),
+            name: std::string::String::from("shared-clock-provider"),
             base_gpa: 0x8000,
             base_hpa: 0x8000,
             length: 0x1000,
@@ -823,14 +826,14 @@ mod tests {
     fn passthrough_device_uses_base_hpa_and_keeps_non_contiguous_mappings_split() {
         let devices = [
             PassThroughDeviceConfig {
-                name: alloc::string::String::from("dev0"),
+                name: std::string::String::from("dev0"),
                 base_gpa: 0x1000,
                 base_hpa: 0x9000,
                 length: 0x1000,
                 irq_id: 0,
             },
             PassThroughDeviceConfig {
-                name: alloc::string::String::from("dev1"),
+                name: std::string::String::from("dev1"),
                 base_gpa: 0x2000,
                 base_hpa: 0xb000,
                 length: 0x1000,
@@ -858,14 +861,14 @@ mod tests {
     fn duplicate_explicit_passthrough_ranges_are_merged_when_linear_mapping_matches() {
         let devices = [
             PassThroughDeviceConfig {
-                name: alloc::string::String::from("dev0"),
+                name: std::string::String::from("dev0"),
                 base_gpa: 0x1000,
                 base_hpa: 0x9000,
                 length: 0x2000,
                 irq_id: 0,
             },
             PassThroughDeviceConfig {
-                name: alloc::string::String::from("dev1"),
+                name: std::string::String::from("dev1"),
                 base_gpa: 0x2000,
                 base_hpa: 0xa000,
                 length: 0x2000,
@@ -953,14 +956,14 @@ mod tests {
 
         let conflicting_hpa = [
             PassThroughDeviceConfig {
-                name: alloc::string::String::from("dev0"),
+                name: std::string::String::from("dev0"),
                 base_gpa: 0x3000,
                 base_hpa: 0x9000,
                 length: 0x1000,
                 irq_id: 0,
             },
             PassThroughDeviceConfig {
-                name: alloc::string::String::from("dev1"),
+                name: std::string::String::from("dev1"),
                 base_gpa: 0x3000,
                 base_hpa: 0xa000,
                 length: 0x1000,

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -12,17 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_std]
-
 //! This crate provides a minimal VM monitor (VMM) for running guest VMs.
 //!
 //! This crate contains:
 //! - [`AxVM`]: The main structure representing a VM.
 
-#[cfg(any(test, feature = "host-test"))]
-extern crate std;
+#![cfg_attr(any(test, target_arch = "aarch64"), feature(once_cell_try))]
 
-extern crate alloc;
 #[macro_use]
 extern crate log;
 
@@ -39,6 +35,7 @@ mod manager;
 mod npt;
 mod percpu;
 mod runtime;
+mod sync;
 mod task;
 mod timer;
 mod vcpu;

--- a/virtualization/axvm/src/lifecycle/machine.rs
+++ b/virtualization/axvm/src/lifecycle/machine.rs
@@ -1,4 +1,4 @@
-use alloc::string::{String, ToString};
+use std::string::{String, ToString};
 
 use super::{StopReason, VmStatus};
 use crate::{AxVmError, AxVmResult};
@@ -100,7 +100,7 @@ impl<R, H> Machine<R, H> {
             Machine::Running { runtime, .. } | Machine::Paused { runtime, .. } => Ok(runtime),
             state => Err(AxVmError::invalid_state(
                 "send vCPU interrupt",
-                alloc::format!("VM cannot accept interrupts in {:?}", state.status()),
+                std::format!("VM cannot accept interrupts in {:?}", state.status()),
             )),
         }
     }
@@ -109,7 +109,7 @@ impl<R, H> Machine<R, H> {
     where
         F: FnOnce(&mut R) -> AxVmResult<H>,
     {
-        let old = core::mem::replace(self, Machine::Switching);
+        let old = std::mem::replace(self, Machine::Switching);
         match old {
             Machine::Ready(mut resources) => match f(&mut resources) {
                 Ok(runtime) => {
@@ -168,7 +168,7 @@ impl<R, H> Machine<R, H> {
     }
 
     pub fn pause(&mut self) -> AxVmResult {
-        let old = core::mem::replace(self, Machine::Switching);
+        let old = std::mem::replace(self, Machine::Switching);
         match old {
             Machine::Running { resources, runtime } => {
                 *self = Machine::Paused { resources, runtime };
@@ -187,7 +187,7 @@ impl<R, H> Machine<R, H> {
     }
 
     pub fn resume(&mut self) -> AxVmResult {
-        let old = core::mem::replace(self, Machine::Switching);
+        let old = std::mem::replace(self, Machine::Switching);
         match old {
             Machine::Paused { resources, runtime } => {
                 *self = Machine::Running { resources, runtime };
@@ -209,7 +209,7 @@ impl<R, H> Machine<R, H> {
     where
         F: FnOnce(Option<&mut R>, &StopReason) -> AxVmResult,
     {
-        let old = core::mem::replace(self, Machine::Switching);
+        let old = std::mem::replace(self, Machine::Switching);
         match old {
             Machine::Ready(resources) => {
                 let mut resources = Some(resources);
@@ -276,7 +276,7 @@ impl<R, H> Machine<R, H> {
     where
         F: FnOnce(Option<&mut R>, &StopReason) -> AxVmResult,
     {
-        let old = core::mem::replace(self, Machine::Switching);
+        let old = std::mem::replace(self, Machine::Switching);
         match old {
             Machine::Ready(mut resources) => {
                 f(Some(&mut resources), &reason)?;
@@ -344,7 +344,7 @@ impl<R, H> Machine<R, H> {
     }
 
     pub fn finish_stop(&mut self) -> AxVmResult {
-        let old = core::mem::replace(self, Machine::Switching);
+        let old = std::mem::replace(self, Machine::Switching);
         match old {
             Machine::Stopping {
                 resources,
@@ -393,7 +393,7 @@ impl<R, H> Machine<R, H> {
     where
         F: FnOnce(&mut R) -> AxVmResult,
     {
-        let old = core::mem::replace(self, Machine::Switching);
+        let old = std::mem::replace(self, Machine::Switching);
         match old {
             Machine::Ready(mut resources) => {
                 f(&mut resources)?;
@@ -473,7 +473,7 @@ impl<R, H> Machine<R, H> {
     where
         F: FnOnce(Option<R>) -> AxVmResult,
     {
-        let old = core::mem::replace(self, Machine::Destroying);
+        let old = std::mem::replace(self, Machine::Destroying);
         match old {
             Machine::Destroyed => {
                 *self = Machine::Destroyed;

--- a/virtualization/axvm/src/lifecycle/status.rs
+++ b/virtualization/axvm/src/lifecycle/status.rs
@@ -1,5 +1,4 @@
-use alloc::string::String;
-use core::fmt;
+use std::{fmt, string::String};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StopReason {

--- a/virtualization/axvm/src/machine.rs
+++ b/virtualization/axvm/src/machine.rs
@@ -5,7 +5,7 @@
 //! default virtual UART with the host-selected UART's register model, layout,
 //! address, and firmware identity before VM construction.
 
-use alloc::{string::String, sync::Arc, vec, vec::Vec};
+use std::{string::String, sync::Arc, vec, vec::Vec};
 
 use axdevice::{
     DeviceBuildContext, DeviceBundle, DeviceFactory, DeviceFactoryRegistry, DeviceManagerError,

--- a/virtualization/axvm/src/manager.rs
+++ b/virtualization/axvm/src/manager.rs
@@ -1,10 +1,8 @@
 //! AxVM runtime services backed by the default ArceOS host.
 
-extern crate alloc;
+use std::{collections::BTreeMap, vec::Vec};
 
-use alloc::{collections::BTreeMap, vec::Vec};
-
-use ax_kspin::SpinNoIrq as Mutex;
+use ax_std::os::arceos::sync::IrqSafeMutex as Mutex;
 use axvm_types::VMId;
 
 use crate::{

--- a/virtualization/axvm/src/npt.rs
+++ b/virtualization/axvm/src/npt.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::marker::PhantomData;
+use std::marker::PhantomData;
 
 use ax_memory_addr::{PhysAddr, VirtAddr};
 use ax_memory_set::{MappingError, MappingResult};

--- a/virtualization/axvm/src/percpu.rs
+++ b/virtualization/axvm/src/percpu.rs
@@ -1,8 +1,8 @@
 //! AxVM-owned per-CPU virtualization state.
 
-use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
-use ax_kernel_guard::NoPreemptIrqSave;
+use ax_std::os::arceos::{guard::NoPreemptIrqSave, percpu as ax_percpu};
 use axvm_types::VmArchPerCpuOps;
 
 use crate::{
@@ -103,8 +103,8 @@ fn with_current_percpu_mut<R>(operation: impl FnOnce(&mut AxVMPerCpu) -> R) -> R
     // SAFETY: initialization and hardware enable are serialized once per CPU;
     // the guard excludes migration, IRQ/re-entry, and conflicting access.
     unsafe {
-        ax_percpu::with_cpu_pin(|pin| {
-            ax_percpu::with_exclusive_cpu(pin, |exclusive| {
+        ax_std::os::arceos::percpu::with_cpu_pin(|pin| {
+            ax_std::os::arceos::percpu::with_exclusive_cpu(pin, |exclusive| {
                 AXVM_PER_CPU.with_current_mut(exclusive, operation)
             })
         })

--- a/virtualization/axvm/src/runtime/dispatcher.rs
+++ b/virtualization/axvm/src/runtime/dispatcher.rs
@@ -19,9 +19,9 @@
 //! critical sections short: no wake, IPI, or external callbacks are invoked
 //! while a lock is held.
 
-use alloc::{collections::BTreeMap, vec::Vec};
+use std::{collections::BTreeMap, vec::Vec};
 
-use ax_kspin::SpinNoIrq as Mutex;
+use ax_std::os::arceos::sync::IrqSafeMutex as Mutex;
 
 use super::queue::VcpuInterruptQueue;
 use crate::{AxTaskRef, AxVmResult, ax_err_type, irq::model::PendingVcpuInterrupt};

--- a/virtualization/axvm/src/runtime/hvc.rs
+++ b/virtualization/axvm/src/runtime/hvc.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{format, string::ToString};
+use std::{format, string::ToString};
 
 use axhvc::{HyperCallCode, HyperCallError, HyperCallResult};
 

--- a/virtualization/axvm/src/runtime/ivc.rs
+++ b/virtualization/axvm/src/runtime/ivc.rs
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 //! Inter-VM communication (IVC) module.
-use alloc::{
+use std::{
     collections::{BTreeMap, btree_map::Entry},
     format,
+    sync::Mutex,
     vec::Vec,
 };
 
-use ax_kspin::SpinNoIrq as Mutex;
-
-use crate::{AxVmError, AxVmResult, GuestPhysAddr, HostPhysAddr, ax_err_type, host::PagingHandler};
+use crate::{
+    AxVmError, AxVmResult, GuestPhysAddr, HostPhysAddr, ax_err_type, host::PagingHandler,
+    sync::MutexExt,
+};
 
 /// A global btree map to store IVC channels,
 /// indexed by (publisher_vm_id, channel_key).
@@ -32,7 +34,7 @@ static IVC_CHANNELS: Mutex<BTreeMap<(usize, usize), HostIVCChannel>> = Mutex::ne
 pub const MAX_IVC_CHANNEL_SIZE: usize = 4096;
 
 pub fn insert_channel(publisher_vm_id: usize, channel: HostIVCChannel) -> AxVmResult<()> {
-    let mut channels = IVC_CHANNELS.lock();
+    let mut channels = IVC_CHANNELS.lock_unpoisoned();
     let channel_key = (publisher_vm_id, channel.key);
     match channels.entry(channel_key) {
         Entry::Vacant(entry) => {
@@ -44,7 +46,10 @@ pub fn insert_channel(publisher_vm_id: usize, channel: HostIVCChannel) -> AxVmRe
 }
 
 pub fn ensure_channel_absent(publisher_vm_id: usize, key: usize) -> AxVmResult<()> {
-    if IVC_CHANNELS.lock().contains_key(&(publisher_vm_id, key)) {
+    if IVC_CHANNELS
+        .lock_unpoisoned()
+        .contains_key(&(publisher_vm_id, key))
+    {
         Err(ax_err_type!(
             AlreadyExists,
             format!(
@@ -63,7 +68,7 @@ pub fn ensure_channel_absent(publisher_vm_id: usize, key: usize) -> AxVmResult<(
 /// If the channel is successfully unpublished, it will return the base GPA and size of the channel.
 /// If the channel does not exist, it will return an error.
 pub fn unpublish_channel(publisher_vm_id: usize, key: usize) -> AxVmResult<(GuestPhysAddr, usize)> {
-    let mut channels = IVC_CHANNELS.lock();
+    let mut channels = IVC_CHANNELS.lock_unpoisoned();
     let channel_key = (publisher_vm_id, key);
     let channel = channels.get_mut(&channel_key).ok_or_else(|| {
         ax_err_type!(
@@ -100,7 +105,7 @@ pub fn prepare_subscribe_channel(
     key: usize,
     subscriber_vm_id: usize,
 ) -> AxVmResult<usize> {
-    let channels = IVC_CHANNELS.lock();
+    let channels = IVC_CHANNELS.lock_unpoisoned();
     let channel = channels.get(&(publisher_vm_id, key)).ok_or_else(|| {
         ax_err_type!(
             NotFound,
@@ -141,7 +146,7 @@ pub fn subscribe_to_channel_of_publisher(
     subscriber_vm_id: usize,
     subscriber_gpa: GuestPhysAddr,
 ) -> AxVmResult<(HostPhysAddr, usize)> {
-    let mut channels = IVC_CHANNELS.lock();
+    let mut channels = IVC_CHANNELS.lock_unpoisoned();
     let channel = channels.get_mut(&(publisher_vm_id, key)).ok_or_else(|| {
         ax_err_type!(
             NotFound,
@@ -182,7 +187,7 @@ pub fn unsubscribe_from_channel_of_publisher(
     key: usize,
     subscriber_vm_id: usize,
 ) -> AxVmResult<(GuestPhysAddr, usize)> {
-    let mut channels = IVC_CHANNELS.lock();
+    let mut channels = IVC_CHANNELS.lock_unpoisoned();
     let (base_gpa, size) = if let Some(channel) = channels.get_mut(&(publisher_vm_id, key)) {
         // Remove the subscriber VM ID from the channel.
         if let Some(subscriber_gpa) = channel.remove_subscriber(subscriber_vm_id) {
@@ -227,7 +232,7 @@ pub struct IVCChannel<H: PagingHandler> {
     /// The base address of the shared memory region in guest physical address of the publisher VM.
     /// `None` if the channel has been unpublished (but still has subscribers).
     base_gpa: Option<GuestPhysAddr>,
-    _phantom: core::marker::PhantomData<H>,
+    _phantom: std::marker::PhantomData<H>,
 }
 
 #[repr(C)]
@@ -271,13 +276,13 @@ impl<H: PagingHandler> IVCChannel<H> {
             // Return a pointer to the data region, which starts after the header.
             H::phys_to_virt(self.shared_region_base)
                 .as_mut_ptr()
-                .add(core::mem::size_of::<IVCChannelHeader>())
+                .add(std::mem::size_of::<IVCChannelHeader>())
         }
     }
 }
 
-impl<H: PagingHandler> core::fmt::Debug for IVCChannel<H> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl<H: PagingHandler> std::fmt::Debug for IVCChannel<H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "IVCChannel(publisher[{}], subscribers {:?}, base: {:?}, size: {:#x}, gpa: {:?})",
@@ -327,7 +332,7 @@ impl<H: PagingHandler> IVCChannel<H> {
             shared_region_base,
             shared_region_size,
             base_gpa: Some(base_gpa),
-            _phantom: core::marker::PhantomData,
+            _phantom: std::marker::PhantomData,
         };
 
         {

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod vcpus;
 
 mod dispatcher;
 mod queue;
-use core::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 // Re-exported for [`VmRuntimeHandle`](crate::vm::VmRuntimeHandle) which will
 // embed the dispatcher as a field and expose it to the vCPU run loop.
@@ -49,9 +49,9 @@ pub fn start() {
 }
 
 /// Start all registered VMs and return the IDs that entered Running.
-pub fn launch_all() -> alloc::vec::Vec<usize> {
+pub fn launch_all() -> std::vec::Vec<usize> {
     info!("VMM starting, booting VMs...");
-    let mut started = alloc::vec::Vec::new();
+    let mut started = std::vec::Vec::new();
     for vm in crate::get_vm_list() {
         match vm.start() {
             Ok(_) => {
@@ -167,8 +167,7 @@ const fn missing_vm_error(vm_id: usize) -> AxVmError {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec::Vec;
-    use core::cell::RefCell;
+    use std::{cell::RefCell, vec::Vec};
 
     use super::*;
 

--- a/virtualization/axvm/src/runtime/queue.rs
+++ b/virtualization/axvm/src/runtime/queue.rs
@@ -21,9 +21,9 @@
 //! covered by `#[test]` on the host when the `host-test` feature is
 //! enabled.
 
-use alloc::{collections::BTreeMap, vec::Vec};
+use std::{collections::BTreeMap, vec::Vec};
 
-use ax_kspin::SpinNoIrq as Mutex;
+use ax_std::os::arceos::sync::IrqSafeMutex as Mutex;
 
 use crate::irq::model::PendingVcpuInterrupt;
 
@@ -59,14 +59,14 @@ impl VcpuInterruptQueue {
         self.pending
             .lock()
             .get_mut(&vcpu_id)
-            .map(core::mem::take)
+            .map(std::mem::take)
             .unwrap_or_default()
     }
 }
 
 #[cfg(all(test, feature = "host-test"))]
 mod tests {
-    use alloc::vec;
+    use std::vec;
 
     use super::*;
     use crate::irq::model::VirtualInterruptId;

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use alloc::{format, sync::Arc};
+use std::{format, sync::Arc};
 
 use crate::{
     AsVCpuTask, AxVmResult, GuestPhysAddr, StopReason, VCpuTask, VmStatus, VmVcpuState,
@@ -166,10 +166,7 @@ fn mark_vcpu_running(vm: &VMRef) {
     });
 }
 
-#[cfg(test)]
 type CpuOnStartAckLock<T> = std::sync::Mutex<T>;
-#[cfg(not(test))]
-type CpuOnStartAckLock<T> = ax_kspin::SpinNoIrq<T>;
 
 #[allow(dead_code)]
 pub(crate) struct CpuOnStartAck {
@@ -230,14 +227,9 @@ impl CpuOnStartAck {
         self.lock_inner().result.take()
     }
 
-    #[cfg(test)]
-    fn lock_inner(&self) -> impl core::ops::DerefMut<Target = CpuOnStartAckInner> + '_ {
-        self.inner.lock().unwrap()
-    }
-
-    #[cfg(not(test))]
-    fn lock_inner(&self) -> impl core::ops::DerefMut<Target = CpuOnStartAckInner> + '_ {
-        self.inner.lock()
+    fn lock_inner(&self) -> impl std::ops::DerefMut<Target = CpuOnStartAckInner> + '_ {
+        use crate::sync::MutexExt;
+        self.inner.lock_unpoisoned()
     }
 }
 

--- a/virtualization/axvm/src/sync.rs
+++ b/virtualization/axvm/src/sync.rs
@@ -1,0 +1,53 @@
+//! Synchronization helpers for task-context standard-library locks.
+
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+/// Recovers a standard-library mutex guard after host-side unwinding.
+///
+/// Axvisor production builds use `panic_abort`, so mutex poisoning cannot be
+/// observed there. Host tests may unwind, and retaining the protected value is
+/// more useful than turning one failed test into unrelated follow-on failures.
+pub(crate) trait MutexExt<T: ?Sized> {
+    fn lock_unpoisoned(&self) -> MutexGuard<'_, T>;
+}
+
+impl<T: ?Sized> MutexExt<T> for Mutex<T> {
+    fn lock_unpoisoned(&self) -> MutexGuard<'_, T> {
+        self.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex, OnceLock},
+        thread,
+    };
+
+    use super::MutexExt;
+
+    #[test]
+    fn lock_recovers_the_value_after_host_unwinding() {
+        let value = Arc::new(Mutex::new(7));
+        let poisoned = value.clone();
+        let _ = thread::spawn(move || {
+            let _guard = poisoned.lock_unpoisoned();
+            panic!("poison the host mutex");
+        })
+        .join();
+
+        assert_eq!(*value.lock_unpoisoned(), 7);
+    }
+
+    #[test]
+    fn once_lock_retries_after_failed_initialization() {
+        let value = OnceLock::new();
+
+        assert_eq!(
+            value.get_or_try_init(|| Err::<usize, _>("retry")),
+            Err("retry")
+        );
+        assert_eq!(value.get_or_try_init(|| Ok::<usize, &str>(11)), Ok(&11));
+        assert_eq!(value.get(), Some(&11));
+    }
+}

--- a/virtualization/axvm/src/task.rs
+++ b/virtualization/axvm/src/task.rs
@@ -1,8 +1,6 @@
 //! Host task extension data used by AxVM vCPU tasks.
 
-extern crate alloc;
-
-use alloc::sync::{Arc, Weak};
+use std::sync::{Arc, Weak};
 
 use crate::{
     host::task::{TaskExt, TaskInner},

--- a/virtualization/axvm/src/timer.rs
+++ b/virtualization/axvm/src/timer.rs
@@ -1,21 +1,20 @@
 //! AxVM-owned CPU-bucketed VM timer wheels.
 
-extern crate alloc;
-
-#[cfg(test)]
-use alloc::vec::Vec;
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc};
-use core::{
-    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
-    time::Duration,
-};
 #[cfg(test)]
 use std::sync::{Mutex, MutexGuard};
+#[cfg(test)]
+use std::vec::Vec;
+use std::{
+    boxed::Box,
+    collections::BTreeMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
 
-use ax_kernel_guard::NoPreempt;
-use ax_kspin::SpinNoIrq;
-use ax_lazyinit::LazyInit;
-use ax_std::os::arceos::modules::ax_task::IrqNotify;
+use ax_std::os::arceos::{guard::NoPreempt, modules::ax_task::IrqNotify, sync::IrqSafeMutex};
 use ax_timer_list::{TimeValue, TimerEvent, TimerList};
 
 #[cfg(not(test))]
@@ -198,7 +197,7 @@ impl TimerWheels {
     }
 }
 
-static TIMER_WHEELS: LazyInit<SpinNoIrq<TimerWheels>> = LazyInit::new();
+static TIMER_WHEELS: std::sync::OnceLock<IrqSafeMutex<TimerWheels>> = std::sync::OnceLock::new();
 
 pub(crate) fn register_timer(
     deadline_ns: u64,
@@ -300,7 +299,7 @@ fn rearm_remote_owner_host_timer(owner_cpu: usize) {
     let result = task::run_on_cpu_sync(
         owner_cpu,
         rearm_current_host_timer_from_wheel_thunk,
-        core::ptr::null_mut(),
+        std::ptr::null_mut(),
     );
     if let Err(error) = result {
         warn!("failed to rearm AxVM timer on owner CPU {owner_cpu}: {error:?}; sending IPI");
@@ -328,7 +327,7 @@ pub(crate) fn init_percpu() {
             worker_notify.wait();
             check_events();
         },
-        alloc::format!("axvm-timer-{cpu_id}"),
+        std::format!("axvm-timer-{cpu_id}"),
         TIMER_WORKER_STACK_SIZE,
     );
     let cpu_bit = 1usize
@@ -340,7 +339,7 @@ pub(crate) fn init_percpu() {
 }
 
 fn with_timer_wheels<R>(operation: impl FnOnce(&mut TimerWheels) -> R) -> R {
-    let timer_wheels = TIMER_WHEELS.get_or_init(|| SpinNoIrq::new(TimerWheels::new()));
+    let timer_wheels = TIMER_WHEELS.get_or_init(|| IrqSafeMutex::new(TimerWheels::new()));
     operation(&mut timer_wheels.lock())
 }
 

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -14,12 +14,13 @@
 
 //! AxVM-owned architecture-independent vCPU wrapper.
 
-use alloc::format;
-use core::{cell::UnsafeCell, mem::MaybeUninit};
+use std::{cell::UnsafeCell, format, mem::MaybeUninit};
 
-use ax_kernel_guard::NoPreempt;
-use ax_kspin::SpinNoIrq as Mutex;
-use ax_percpu::{CpuAreaRef, CpuPin};
+use ax_std::os::arceos::{
+    guard::NoPreempt,
+    percpu::{self as ax_percpu, CpuAreaRef, CpuPin},
+    sync::IrqSafeMutex as Mutex,
+};
 use axvm_types::{
     GuestPhysAddr, InterruptTriggerMode, NestedPagingConfig, VCpuId, VMId, VmArchPerCpuOps,
     VmArchVcpuOps, VmBackendError, VmVcpuState,
@@ -37,7 +38,7 @@ struct PinnedCpuContext<'pin, 'cpu> {
 
 impl<'pin, 'cpu> PinnedCpuContext<'pin, 'cpu> {
     fn new(cpu_pin: &'pin CpuPin<'cpu>) -> Self {
-        ax_percpu::current_area(cpu_pin)
+        ax_std::os::arceos::percpu::current_area(cpu_pin)
             .expect("vCPU operation requires the installed per-CPU area");
         Self {
             cpu_pin,
@@ -51,7 +52,7 @@ impl<'pin, 'cpu> PinnedCpuContext<'pin, 'cpu> {
         // SAFETY: the outer NoPreempt guard remains active. A new pin forces a
         // fresh read of both host CPU-local and current-thread registers.
         let current = unsafe {
-            ax_percpu::with_cpu_pin(|pin| {
+            ax_std::os::arceos::percpu::with_cpu_pin(|pin| {
                 (
                     pin.area(),
                     #[cfg(feature = "tls")]
@@ -304,11 +305,11 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
         // SAFETY: the guard prevents migration through the backend operation,
         // guest run, restoration check, and publication withdrawal.
         unsafe {
-            ax_percpu::with_cpu_pin(|cpu_pin| {
+            ax_std::os::arceos::percpu::with_cpu_pin(|cpu_pin| {
                 let pinned_cpu = PinnedCpuContext::new(cpu_pin);
 
                 if let Some(current_vcpu) = get_current_vcpu::<A>(cpu_pin) {
-                    if core::ptr::eq(current_vcpu, self) {
+                    if std::ptr::eq(current_vcpu, self) {
                         let result = f();
                         pinned_cpu.assert_host_cpu_binding();
                         result
@@ -447,7 +448,7 @@ pub(crate) fn with_current_vcpu<A: VmArchVcpuOps, R>(
 ) -> R {
     let _guard = NoPreempt::new();
     // SAFETY: the guard prevents migration through the closure.
-    unsafe { ax_percpu::with_cpu_pin(|pin| operation(get_current_vcpu(pin))) }
+    unsafe { ax_std::os::arceos::percpu::with_cpu_pin(|pin| operation(get_current_vcpu(pin))) }
         .expect("current vCPU lookup requires an installed CPU-local area")
 }
 

--- a/virtualization/axvm/src/vm/boot.rs
+++ b/virtualization/axvm/src/vm/boot.rs
@@ -47,7 +47,7 @@ impl BootImagePlan {
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::String;
+    use std::string::String;
 
     use super::*;
     use crate::config::{AxVCpuConfig, AxVMConfig, AxVMConfigParams, PhysCpuList, VMImageConfig};

--- a/virtualization/axvm/src/vm/memory.rs
+++ b/virtualization/axvm/src/vm/memory.rs
@@ -1,7 +1,6 @@
 //! VM memory region planning.
 
-use alloc::vec::Vec;
-use core::alloc::Layout;
+use std::{alloc::Layout, vec::Vec};
 
 use axvm_types::{GuestPhysAddr, VmMemConfig, VmMemMappingType};
 
@@ -104,7 +103,7 @@ impl MemoryRegionPlan {
         let layout = Layout::from_size_align(config.size, VM_MEMORY_ALIGN).map_err(|err| {
             ax_err_type!(
                 InvalidInput,
-                alloc::format!("invalid VM memory region {config:?}: {err:?}")
+                std::format!("invalid VM memory region {config:?}: {err:?}")
             )
         })?;
         let configured_gpa = match config.map_type {
@@ -135,8 +134,10 @@ impl MemoryRegionPlan {
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
-    use core::cell::{Cell, RefCell};
+    use std::{
+        cell::{Cell, RefCell},
+        vec,
+    };
 
     use super::*;
 

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -14,22 +14,22 @@
 
 //! Virtual machine state, resources, and lifecycle entry points.
 
-use alloc::{
+use std::{
+    alloc::Layout,
     boxed::Box,
     collections::{BTreeMap, BTreeSet},
     format,
     string::String,
-    sync::Arc,
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
     vec::Vec,
-};
-use core::{
-    alloc::Layout,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use ax_cpumask::CpuMask;
-use ax_kspin::{SpinNoIrq as Mutex, SpinRaw};
 use ax_memory_addr::align_up_4k;
+use ax_std::os::arceos::sync::IrqSafeMutex as Mutex;
 use axaddrspace::{AddrSpace, NestedPageTableOps};
 use axdevice::{
     DeviceRuntime, FwCfgPayloadConfig, FwCfgPlatformConfig, RuntimeAccessPorts, StopAccessPort,
@@ -52,6 +52,7 @@ use crate::{
     layout::VmAddressLayout,
     lifecycle::{Machine, StopReason, VmStatus},
     runtime::VcpuIrqDispatcher,
+    sync::MutexExt,
     vcpu::AxVCpu,
 };
 
@@ -88,7 +89,7 @@ impl DeviceAccess for VmDmaAccess<'_> {
             .read_from_guest(addr, data)
             .map_err(|error| axdevice_base::DeviceError::Backend {
                 operation: "read guest memory for DMA",
-                detail: alloc::format!("{error}"),
+                detail: std::format!("{error}"),
             })
     }
     fn write_guest_memory(
@@ -101,7 +102,7 @@ impl DeviceAccess for VmDmaAccess<'_> {
             .write_to_guest(addr, data)
             .map_err(|error| axdevice_base::DeviceError::Backend {
                 operation: "write guest memory for DMA",
-                detail: alloc::format!("{error}"),
+                detail: std::format!("{error}"),
             })
     }
 }
@@ -188,12 +189,12 @@ pub(crate) enum PendingInterrupt {
 pub(crate) struct VmRuntimeHandle {
     wait_queue: crate::WaitQueue,
     vcpu_task_list: Mutex<BTreeMap<usize, crate::AxTaskRef>>,
-    cpu_on_start_acks: Mutex<BTreeMap<usize, Arc<crate::runtime::vcpus::CpuOnStartAck>>>,
-    cpu_off_exit_reservations: Mutex<BTreeSet<usize>>,
+    cpu_on_start_acks: StdMutex<BTreeMap<usize, Arc<crate::runtime::vcpus::CpuOnStartAck>>>,
+    cpu_off_exit_reservations: StdMutex<BTreeSet<usize>>,
     pending_interrupts: Mutex<BTreeMap<usize, Vec<PendingInterrupt>>>,
     irq_dispatcher: crate::runtime::VcpuIrqDispatcher,
     running_halting_vcpu_count: AtomicUsize,
-    lifecycle_error: SpinRaw<Option<AxVmError>>,
+    lifecycle_error: StdMutex<Option<AxVmError>>,
     deferred_reset_requested: AtomicBool,
 }
 
@@ -229,12 +230,12 @@ impl VmRuntimeHandle {
         Self {
             wait_queue: crate::WaitQueue::new(),
             vcpu_task_list: Mutex::new(BTreeMap::new()),
-            cpu_on_start_acks: Mutex::new(BTreeMap::new()),
-            cpu_off_exit_reservations: Mutex::new(BTreeSet::new()),
+            cpu_on_start_acks: StdMutex::new(BTreeMap::new()),
+            cpu_off_exit_reservations: StdMutex::new(BTreeSet::new()),
             pending_interrupts: Mutex::new(BTreeMap::new()),
             irq_dispatcher: crate::runtime::VcpuIrqDispatcher::new(),
             running_halting_vcpu_count: AtomicUsize::new(0),
-            lifecycle_error: SpinRaw::new(None),
+            lifecycle_error: StdMutex::new(None),
             deferred_reset_requested: AtomicBool::new(false),
         }
     }
@@ -263,7 +264,7 @@ impl VmRuntimeHandle {
         &self,
         vcpu_id: usize,
     ) -> Option<Arc<crate::runtime::vcpus::CpuOnStartAck>> {
-        self.cpu_on_start_acks.lock().remove(&vcpu_id)
+        self.cpu_on_start_acks.lock_unpoisoned().remove(&vcpu_id)
     }
 
     pub(crate) fn remove_vcpu_task(&self, vcpu_id: usize) -> Option<crate::AxTaskRef> {
@@ -278,7 +279,7 @@ impl VmRuntimeHandle {
         vcpu_id: usize,
         ack: Arc<crate::runtime::vcpus::CpuOnStartAck>,
     ) -> AxVmResult {
-        let mut acks = self.cpu_on_start_acks.lock();
+        let mut acks = self.cpu_on_start_acks.lock_unpoisoned();
         if acks.contains_key(&vcpu_id) {
             return ax_err!(
                 AlreadyExists,
@@ -293,7 +294,10 @@ impl VmRuntimeHandle {
         &self,
         vcpu_id: usize,
     ) -> Option<Arc<crate::runtime::vcpus::CpuOnStartAck>> {
-        self.cpu_on_start_acks.lock().get(&vcpu_id).cloned()
+        self.cpu_on_start_acks
+            .lock_unpoisoned()
+            .get(&vcpu_id)
+            .cloned()
     }
 
     pub(crate) fn queue_pending_interrupt(
@@ -356,7 +360,7 @@ impl VmRuntimeHandle {
         self.pending_interrupts
             .lock()
             .get_mut(&vcpu_id)
-            .map(core::mem::take)
+            .map(std::mem::take)
             .unwrap_or_default()
     }
 
@@ -395,14 +399,14 @@ impl VmRuntimeHandle {
     }
 
     pub(crate) fn record_lifecycle_error(&self, error: AxVmError) {
-        let mut recorded = self.lifecycle_error.lock();
+        let mut recorded = self.lifecycle_error.lock_unpoisoned();
         if recorded.is_none() {
             *recorded = Some(error);
         }
     }
 
     fn take_lifecycle_error(&self) -> Option<AxVmError> {
-        self.lifecycle_error.lock().take()
+        self.lifecycle_error.lock_unpoisoned().take()
     }
 
     pub(crate) fn request_deferred_reset(&self) -> bool {
@@ -422,13 +426,17 @@ impl VmRuntimeHandle {
             .is_ok();
 
         if reserved {
-            self.cpu_off_exit_reservations.lock().insert(vcpu_id);
+            self.cpu_off_exit_reservations
+                .lock_unpoisoned()
+                .insert(vcpu_id);
         }
         reserved
     }
 
     pub(crate) fn consume_cpu_off_reservation(&self, vcpu_id: usize) -> bool {
-        self.cpu_off_exit_reservations.lock().remove(&vcpu_id)
+        self.cpu_off_exit_reservations
+            .lock_unpoisoned()
+            .remove(&vcpu_id)
     }
 
     pub(crate) fn join_all_vcpu_tasks(&self, vm_id: usize) -> AxVmResult {
@@ -770,7 +778,7 @@ pub struct AxVM {
     id: usize,
     name: String,
     machine: Mutex<Machine<AxVMResources, Arc<VmRuntimeHandle>>>,
-    pending_fw_cfg_payload: Mutex<Option<PendingFwCfgPayload>>,
+    pending_fw_cfg_payload: StdMutex<Option<PendingFwCfgPayload>>,
 }
 
 impl AxVM {
@@ -790,7 +798,7 @@ impl AxVM {
             id,
             name,
             machine: Mutex::new(Machine::Ready(resources)),
-            pending_fw_cfg_payload: Mutex::new(None),
+            pending_fw_cfg_payload: StdMutex::new(None),
         });
 
         info!("VM created: id={}", result.id());
@@ -1165,7 +1173,7 @@ impl AxVM {
 
     /// Queue a QEMU fw_cfg device that will be attached during VM initialization.
     pub fn add_fw_cfg_device(&self, config: FwCfgDeviceConfig) -> AxVmResult {
-        let mut pending = self.pending_fw_cfg_payload.lock();
+        let mut pending = self.pending_fw_cfg_payload.lock_unpoisoned();
         if pending.is_some() {
             return ax_err!(
                 AlreadyExists,
@@ -1195,7 +1203,7 @@ impl AxVM {
     #[allow(dead_code)]
     pub(crate) fn fw_cfg_payload(&self) -> Option<FwCfgPayloadConfig> {
         self.pending_fw_cfg_payload
-            .lock()
+            .lock_unpoisoned()
             .as_ref()
             .map(|pending| FwCfgPayloadConfig {
                 base: pending.base,
@@ -1419,13 +1427,10 @@ impl AxVM {
 
     /// Reads an object of type `T` from the guest physical address.
     pub fn read_from_guest_of<T>(&self, gpa_ptr: GuestPhysAddr) -> AxVmResult<T> {
-        let size = core::mem::size_of::<T>();
+        let size = std::mem::size_of::<T>();
 
         // Ensure the address is properly aligned for the type.
-        if !gpa_ptr
-            .as_usize()
-            .is_multiple_of(core::mem::align_of::<T>())
-        {
+        if !gpa_ptr.as_usize().is_multiple_of(std::mem::align_of::<T>()) {
             return ax_err!(InvalidInput, "Unaligned guest physical address");
         }
 
@@ -1457,7 +1462,7 @@ impl AxVM {
             }
             let data: T = unsafe {
                 // Use `ptr::read_unaligned` for safety in case of unaligned memory.
-                core::ptr::read_unaligned(data_bytes.as_ptr() as *const T)
+                std::ptr::read_unaligned(data_bytes.as_ptr() as *const T)
             };
             Ok(data)
         })
@@ -1493,7 +1498,7 @@ impl AxVM {
     /// Writes an object of type `T` to the guest physical address.
     pub fn write_to_guest_of<T>(&self, gpa_ptr: GuestPhysAddr, data: &T) -> AxVmResult {
         let bytes = unsafe {
-            core::slice::from_raw_parts(data as *const T as *const u8, core::mem::size_of::<T>())
+            std::slice::from_raw_parts(data as *const T as *const u8, std::mem::size_of::<T>())
         };
         self.write_to_guest(gpa_ptr, bytes)
     }
@@ -1556,13 +1561,13 @@ impl AxVM {
             "Cannot allocate zero-sized memory region"
         );
 
-        let hva = unsafe { alloc::alloc::alloc_zeroed(layout) };
+        let hva = unsafe { std::alloc::alloc_zeroed(layout) };
         if hva.is_null() {
             return Err(AxVmError::OutOfMemory {
                 operation: "allocate IVC channel",
             });
         }
-        let s = unsafe { core::slice::from_raw_parts_mut(hva, layout.size()) };
+        let s = unsafe { std::slice::from_raw_parts_mut(hva, layout.size()) };
         let hva = HostVirtAddr::from_mut_ptr_of(hva);
 
         let hpa = virt_to_phys(hva);
@@ -1591,7 +1596,7 @@ impl AxVM {
             Ok(())
         }) {
             unsafe {
-                alloc::alloc::dealloc(hva.as_mut_ptr(), layout);
+                std::alloc::dealloc(hva.as_mut_ptr(), layout);
             }
             return Err(err);
         }
@@ -1716,7 +1721,7 @@ impl AxVM {
                     region.size()
                 );
                 unsafe {
-                    alloc::alloc::dealloc(region.hva.as_mut_ptr(), region.layout);
+                    std::alloc::dealloc(region.hva.as_mut_ptr(), region.layout);
                 }
             } else {
                 debug!(
@@ -1753,7 +1758,7 @@ impl Drop for AxVM {
 
 #[cfg(test)]
 mod tests {
-    use core::{cell::RefCell, sync::atomic::AtomicBool};
+    use std::{cell::RefCell, sync::atomic::AtomicBool};
 
     use axdevice_base::{
         ControllerInputId, InterruptControllerId, InterruptEndpoint, InterruptTriggerMode,
@@ -1829,7 +1834,7 @@ mod tests {
         dispatch_vcpu_interrupt_with(
             || dispatcher.enqueue(0, interrupt),
             || {
-                assert_eq!(dispatcher.drain(0), alloc::vec![interrupt]);
+                assert_eq!(dispatcher.drain(0), std::vec![interrupt]);
                 events.borrow_mut().push("notify");
             },
             |_| events.borrow_mut().push("ipi"),

--- a/virtualization/axvm/src/vm/prepare.rs
+++ b/virtualization/axvm/src/vm/prepare.rs
@@ -4,7 +4,7 @@ pub(crate) mod address_space;
 pub(crate) mod devices;
 pub(crate) mod vcpus;
 
-use alloc::{format, sync::Arc};
+use std::{format, sync::Arc};
 
 use axdevice::{DeviceFactoryRegistry, FwCfgPayloadFactory, register_builtin_factories};
 use axdevice_base::VirtualInterruptController;

--- a/virtualization/axvm/src/vm/prepare/address_space.rs
+++ b/virtualization/axvm/src/vm/prepare/address_space.rs
@@ -1,6 +1,6 @@
 //! Guest address-space construction for VM preparation.
 
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 use axdevice::DeviceRuntime;
 use axdevice_base::Resource;

--- a/virtualization/axvm/src/vm/prepare/devices.rs
+++ b/virtualization/axvm/src/vm/prepare/devices.rs
@@ -1,6 +1,6 @@
 //! Device construction for VM preparation.
 
-use alloc::vec::Vec;
+use std::vec::Vec;
 
 use axdevice::{DeviceBuildContext, DeviceFactoryRegistry, DeviceRuntime, RuntimeAccessPorts};
 use axdevice_base::VirtualInterruptController;

--- a/virtualization/axvm/src/vm/prepare/vcpus.rs
+++ b/virtualization/axvm/src/vm/prepare/vcpus.rs
@@ -1,6 +1,6 @@
 //! Architecture-neutral vCPU collection construction and setup.
 
-use alloc::{boxed::Box, sync::Arc, vec::Vec};
+use std::{boxed::Box, sync::Arc, vec::Vec};
 
 use axvm_types::VmArchVcpuOps;
 
@@ -84,7 +84,7 @@ impl PreparedVcpus {
 
 impl<'a> IntoIterator for &'a PreparedVcpus {
     type Item = &'a AxVCpuRef;
-    type IntoIter = core::slice::Iter<'a, AxVCpuRef>;
+    type IntoIter = std::slice::Iter<'a, AxVCpuRef>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.vcpus.iter()


### PR DESCRIPTION
## 问题

AxVM 已通过 Axvisor 的 RustStd/musl 流程构建，但源码仍混用 `core`、`alloc`、mini-std 同名接口以及底层同步和 OS 实现 crate。这使普通任务上下文与 IRQ/禁抢占路径的能力边界不清晰，也让 AxVM 重复选择底层依赖和 feature。

## 修改

- 将 AxVM 明确调整为仅支持真实 Rust `std` 的 crate，删除 `no_std` 和 `extern crate alloc`，集合、内存对象、格式化、原子操作、线程、时间、`Mutex` 与 `OnceLock` 统一使用 `std`。
- 为任务上下文的标准 mutex 增加统一的 poison 恢复扩展；IVC、CPU_ON acknowledgement、deferred worker、固件暂存和生命周期状态迁移到标准 mutex。
- 保留 VM/runtime 快照、中断队列、vCPU、timer wheel 和架构中断控制器等 IRQ/guest-entry 路径的非休眠锁。
- 在 `ax_std::os::arceos` 导出 `IrqSafeMutex`、`NoPreemptMutex`、`RawSpinLock` 及 guard、per-CPU 和 host-test 能力；AxVM 的 OS 专属访问统一经过该边界。
- 删除 AxVM 对 `spin`、`ax-kspin`、`ax-sync`、`ax-hal`、`ax-kernel-guard`、`ax-percpu`、`ax-lazyinit`、`hashbrown` 和 `cfg-if` 等直接依赖。
- 增加 Cargo metadata 依赖契约，以及四架构 Axvisor 必须映射到 RustStd/musl 并构建 `std + panic_abort` 的测试。
- 更新中文 AxVM host/application 边界设计文档，说明 std-only 构建契约、锁上下文与 IRQ 禁止阻塞要求。

## 设计逻辑

普通任务上下文直接使用标准库能力，避免维护与 Rust `std` 同名的替代接口。只有 Rust 标准库无法表达的 ArceOS 特殊能力通过 `ax_std::os::arceos` 暴露，并以锁名明确 IRQ 和抢占语义。领域 crate 继续保持直接依赖，不被错误包装为标准库或 OS facade。

这是明确的构建兼容性变化：仅有 `core`/`alloc` 的外部 AxVM 构建方式不再受支持，正式构建依赖现有 Axvisor RustStd/musl 流程。

## 验证

- `cargo fmt --all`
- `cargo test -p axvm --features host-test`：239 项通过
- `cargo xtask clippy --package ax-std`：44/44 组合通过
- `cargo xtask clippy --package axvm`：6/6 组合通过
- `cargo xtask test`：47 个 std package 全部通过
- `cargo xtask sync-lint`
- `cargo xtask spin-lint`
- x86_64、AArch64、RISC-V、LoongArch64 Axvisor RustStd 构建通过
- x86_64 VMX、AArch64、RISC-V QEMU smoke 通过
- LoongArch64 已启动到 Axvisor；当前 QEMU LA464 报告不支持硬件虚拟化，因此未完成 guest smoke，构建本身通过
