### PR TITLE
fix(axvisor): improve multi-VM guest console multiplexing

### DIFF
--- a/os/axvisor/src/guest_console/mod.rs
+++ b/os/axvisor/src/guest_console/mod.rs
@@ -5,6 +5,6 @@ mod mux;
 
 pub(crate) use host::{configure_host_console_reader, read_host_byte, wait_for_host_input};
 pub(crate) use mux::{
-    ConsoleInputEvent, attach, attach_default, attached_vm, mark_running, mark_stopped,
+    ConsoleInputEvent, activate, attach, attach_default, attached_vm, mark_running, mark_stopped,
     reconcile_vm_states, remove, route_host_byte, serial_backend_factory,
 };

--- a/os/axvisor/src/guest_console/mux/mod.rs
+++ b/os/axvisor/src/guest_console/mux/mod.rs
@@ -9,6 +9,7 @@ use alloc::{
 use anyhow::{Result, bail};
 use axvm::{SerialBackend, SerialBackendFactory, VMId, VmStatus};
 use core::ops::Bound::{Excluded, Unbounded};
+use log::warn;
 use std::sync::{LazyLock, Mutex, MutexGuard};
 
 use super::host::write_host_bytes;
@@ -17,11 +18,7 @@ mod output;
 
 use output::GuestOutputMux;
 
-// Terminals encode Alt as a leading ESC, so Ctrl-Alt-[ is ESC ESC and
-// Ctrl-Alt-] is ESC followed by the Ctrl-] byte (group separator).
-const ESC: u8 = 0x1b;
-const CTRL_H: u8 = 0x08;
-const CTRL_RIGHT_BRACKET: u8 = 0x1d;
+const CTRL_X: u8 = 0x18;
 const INPUT_QUEUE_CAPACITY: usize = 4096;
 
 static GUEST_CONSOLE_MUX: LazyLock<GuestConsoleMux> = LazyLock::new(GuestConsoleMux::new);
@@ -47,6 +44,7 @@ pub enum ConsoleInputEvent {
 struct RoutedInput {
     event: ConsoleInputEvent,
     wake_vm: Option<VMId>,
+    host_output: Vec<u8>,
 }
 
 /// Application-owned host console multiplexer.
@@ -112,6 +110,7 @@ impl GuestConsoleMux {
     }
 
     fn set_running(&self, running: impl IntoIterator<Item = VMId>) -> Option<VMId> {
+        let _output_guard = self.core.lock_output();
         let mut state = self.core.lock_state();
         state.running.clear();
         for vm_id in running {
@@ -122,14 +121,19 @@ impl GuestConsoleMux {
         let detached = state
             .attached
             .filter(|vm_id| !state.running.contains(vm_id));
-        if detached.is_some() {
+        let host_output = if detached.is_some() {
             state.attached = None;
             state.shortcut_prefix_pending = false;
-        }
+            state.output.buffer_all()
+        } else {
+            Vec::new()
+        };
         let ConsoleState {
             running, output, ..
         } = &mut *state;
         output.reconcile_running(running);
+        drop(state);
+        write_host_bytes(&host_output);
         detached
     }
 
@@ -148,12 +152,17 @@ impl GuestConsoleMux {
             guest.input.clear();
         }
         state.output.reset_guest(vm_id);
-        if state.attached == Some(vm_id) {
+        let detached = state.attached == Some(vm_id);
+        let host_output = if detached {
             state.attached = None;
             state.shortcut_prefix_pending = false;
-            return true;
-        }
-        false
+            state.output.buffer_all()
+        } else {
+            Vec::new()
+        };
+        drop(state);
+        write_host_bytes(&host_output);
+        detached
     }
 
     fn remove(&self, vm_id: VMId) -> bool {
@@ -165,24 +174,34 @@ impl GuestConsoleMux {
         if state.last_attached == Some(vm_id) {
             state.last_attached = None;
         }
-        if state.attached == Some(vm_id) {
+        let detached = state.attached == Some(vm_id);
+        let host_output = if detached {
             state.attached = None;
             state.shortcut_prefix_pending = false;
-            return true;
-        }
-        false
+            state.output.buffer_all()
+        } else {
+            Vec::new()
+        };
+        drop(state);
+        write_host_bytes(&host_output);
+        detached
     }
 
     fn attach_default(&self, running: impl IntoIterator<Item = VMId>) -> Option<VMId> {
         self.set_running(running);
+        let _output_guard = self.core.lock_output();
         let mut state = self.core.lock_state();
         let vm_id = state.running.first().copied()?;
         state.attached = Some(vm_id);
         state.last_attached = Some(vm_id);
+        state.shortcut_prefix_pending = false;
+        state.output.start_boot_multiplex();
+        state.output.request_preemption(vm_id);
         Some(vm_id)
     }
 
     fn attach(&self, vm_id: VMId) -> bool {
+        let _output_guard = self.core.lock_output();
         let mut state = self.core.lock_state();
         if !state.running.contains(&vm_id) {
             return false;
@@ -190,6 +209,9 @@ impl GuestConsoleMux {
         state.attached = Some(vm_id);
         state.last_attached = Some(vm_id);
         state.shortcut_prefix_pending = false;
+        let host_output = state.output.buffer_all();
+        drop(state);
+        write_host_bytes(&host_output);
         true
     }
 
@@ -197,61 +219,81 @@ impl GuestConsoleMux {
         self.core.lock_state().attached
     }
 
-    fn route_host_byte(&self, byte: u8) -> RoutedInput {
+    fn activate(&self, vm_id: VMId) -> Option<Vec<u8>> {
+        let _output_guard = self.core.lock_output();
         let mut state = self.core.lock_state();
+        (state.attached == Some(vm_id)).then_some(())?;
+        let replay = state.output.select_foreground(vm_id);
+        drop(state);
+        write_host_bytes(&replay);
+        Some(replay)
+    }
 
-        if state.shortcut_prefix_pending {
+    fn route_host_byte(&self, byte: u8) -> RoutedInput {
+        let _output_guard = self.core.lock_output();
+        let mut state = self.core.lock_state();
+        let routed = if state.shortcut_prefix_pending {
             state.shortcut_prefix_pending = false;
-            return match byte {
-                CTRL_H => match state.attached.take() {
+            match byte {
+                b'h' => match state.attached.take() {
                     Some(vm_id) => RoutedInput {
                         event: ConsoleInputEvent::Detached(vm_id),
                         wake_vm: None,
+                        host_output: state.output.buffer_all(),
                     },
                     None => RoutedInput {
                         event: ConsoleInputEvent::Consumed,
                         wake_vm: None,
+                        host_output: Vec::new(),
                     },
                 },
-                ESC => switch_guest(&mut state, GuestSwitchDirection::Previous),
-                CTRL_RIGHT_BRACKET => switch_guest(&mut state, GuestSwitchDirection::Next),
-                byte => match state.attached {
-                    Some(vm_id) => {
-                        enqueue_guest_input(&mut state, vm_id, &[ESC, byte]);
-                        RoutedInput {
-                            event: ConsoleInputEvent::Consumed,
-                            wake_vm: Some(vm_id),
-                        }
-                    }
-                    None => RoutedInput {
-                        event: ConsoleInputEvent::ShellSequence(ESC, byte),
-                        wake_vm: None,
-                    },
-                },
-            };
-        }
-
-        if byte == ESC {
+                b'[' => switch_guest(&mut state, GuestSwitchDirection::Previous),
+                b']' => switch_guest(&mut state, GuestSwitchDirection::Next),
+                CTRL_X => {
+                    route_literal_input(&mut state, &[CTRL_X], ConsoleInputEvent::ShellByte(CTRL_X))
+                }
+                byte => route_literal_input(
+                    &mut state,
+                    &[CTRL_X, byte],
+                    ConsoleInputEvent::ShellSequence(CTRL_X, byte),
+                ),
+            }
+        } else if byte == CTRL_X {
             state.shortcut_prefix_pending = true;
-            return RoutedInput {
+            RoutedInput {
                 event: ConsoleInputEvent::Consumed,
                 wake_vm: None,
-            };
-        }
-
-        match state.attached {
-            Some(vm_id) => {
-                enqueue_guest_input(&mut state, vm_id, &[byte]);
-                RoutedInput {
-                    event: ConsoleInputEvent::Consumed,
-                    wake_vm: Some(vm_id),
-                }
+                host_output: Vec::new(),
             }
-            None => RoutedInput {
-                event: ConsoleInputEvent::ShellByte(byte),
-                wake_vm: None,
-            },
+        } else {
+            route_literal_input(&mut state, &[byte], ConsoleInputEvent::ShellByte(byte))
+        };
+        drop(state);
+        write_host_bytes(&routed.host_output);
+        routed
+    }
+}
+
+fn route_literal_input(
+    state: &mut ConsoleState,
+    guest_bytes: &[u8],
+    shell_event: ConsoleInputEvent,
+) -> RoutedInput {
+    match state.attached {
+        Some(vm_id) => {
+            let host_output = state.output.select_foreground_on_input(vm_id);
+            enqueue_guest_input(state, vm_id, guest_bytes);
+            RoutedInput {
+                event: ConsoleInputEvent::Consumed,
+                wake_vm: Some(vm_id),
+                host_output,
+            }
         }
+        None => RoutedInput {
+            event: shell_event,
+            wake_vm: None,
+            host_output: Vec::new(),
+        },
     }
 }
 
@@ -283,6 +325,7 @@ fn switch_guest(state: &mut ConsoleState, direction: GuestSwitchDirection) -> Ro
         return RoutedInput {
             event: ConsoleInputEvent::NoRunningGuest,
             wake_vm: None,
+            host_output: Vec::new(),
         };
     };
 
@@ -291,6 +334,7 @@ fn switch_guest(state: &mut ConsoleState, direction: GuestSwitchDirection) -> Ro
     RoutedInput {
         event: ConsoleInputEvent::Attached(vm_id),
         wake_vm: None,
+        host_output: state.output.buffer_all(),
     }
 }
 
@@ -445,6 +489,11 @@ pub fn attach(vm_id: VMId) -> Result<()> {
         bail!("VM[{vm_id}] is not available for console attachment");
     }
     Ok(())
+}
+
+/// Activates direct output after the shell has announced an attachment.
+pub fn activate(vm_id: VMId) {
+    GUEST_CONSOLE_MUX.activate(vm_id);
 }
 
 /// Record a VM transition to Running.

--- a/os/axvisor/src/guest_console/mux/output.rs
+++ b/os/axvisor/src/guest_console/mux/output.rs
@@ -2,79 +2,326 @@
 
 extern crate alloc;
 
-use alloc::{collections::BTreeSet, format, vec::Vec};
+use alloc::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    format,
+    vec::Vec,
+};
 
-/// Tracks the guest that owns the currently unterminated host-console line.
-///
-/// Ownership is preemptible at every backend-write boundary. If another guest
-/// writes while the current line is unterminated, the formatter closes that
-/// fragment and starts a newly prefixed line. A shell prompt therefore cannot
-/// indefinitely block output from the foreground guest.
+pub(super) const PER_GUEST_LOG_CAPACITY: usize = 16 * 1024;
+
+/// Arbitrates complete host-console lines across guest serial backends.
 #[derive(Debug, Default)]
 pub(crate) struct GuestOutputMux {
-    host_line_owner: Option<usize>,
-    host_line_prefixed: bool,
+    guests: BTreeMap<usize, GuestOutputState>,
+    mode: OutputMode,
+    owner: Option<usize>,
+    physical_line_open: bool,
+    preemption: Option<usize>,
+    total_pending: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum OutputMode {
+    #[default]
+    BootMultiplex,
+    Interactive {
+        foreground: Option<usize>,
+    },
+}
+
+#[derive(Debug)]
+struct GuestOutputState {
+    pending: VecDeque<u8>,
+    at_line_start: bool,
+}
+
+#[cfg(test)]
+#[derive(Debug, Eq, PartialEq)]
+pub(crate) struct ArbitrationSnapshot {
+    mode: OutputMode,
+    owner: Option<usize>,
+    physical_line_open: bool,
+    preemption: Option<usize>,
+    total_pending: usize,
+    guests: Vec<(usize, usize, bool)>,
+}
+
+impl Default for GuestOutputState {
+    fn default() -> Self {
+        Self {
+            pending: VecDeque::new(),
+            at_line_start: true,
+        }
+    }
 }
 
 impl GuestOutputMux {
-    /// Invalidates a continuation whose guest is no longer running.
+    /// Starts the boot-time mode that displays complete lines from every VM.
+    pub(crate) fn start_boot_multiplex(&mut self) {
+        self.mode = OutputMode::BootMultiplex;
+    }
+
+    /// Gives one interactive guest direct access to the host console.
+    pub(crate) fn enter_interactive(&mut self, vm_id: usize) {
+        self.mode = OutputMode::Interactive {
+            foreground: Some(vm_id),
+        };
+    }
+
+    /// Keeps every guest's output in its ring and terminates its open physical line.
+    pub(crate) fn buffer_all(&mut self) -> Vec<u8> {
+        let separator = if self.physical_line_open {
+            Vec::from(*b"\n")
+        } else {
+            Vec::new()
+        };
+        self.mode = OutputMode::Interactive { foreground: None };
+        self.preemption = None;
+        if let Some(owner) = self.owner
+            && let Some(guest) = self.guests.get_mut(&owner)
+        {
+            guest.at_line_start = true;
+        }
+        self.owner = None;
+        self.physical_line_open = false;
+        separator
+    }
+
+    /// Selects an interactive guest and returns its buffered console log.
+    pub(crate) fn select_foreground(&mut self, vm_id: usize) -> Vec<u8> {
+        self.enter_interactive(vm_id);
+        self.drain_guest_log(vm_id)
+    }
+
+    /// Enters interactive mode on the first input and returns the buffered prompt.
+    pub(crate) fn select_foreground_on_input(&mut self, vm_id: usize) -> Vec<u8> {
+        match self.mode {
+            OutputMode::Interactive {
+                foreground: Some(foreground),
+            } if foreground == vm_id => Vec::new(),
+            _ => self.select_foreground(vm_id),
+        }
+    }
+
+    /// Discards output state for guests that are no longer running.
     pub(crate) fn reconcile_running(&mut self, running: &BTreeSet<usize>) {
+        let discarded = self
+            .guests
+            .iter()
+            .filter(|(vm_id, _)| !running.contains(vm_id))
+            .map(|(_, guest)| guest.pending.len())
+            .sum::<usize>();
+        self.guests.retain(|vm_id, _| running.contains(vm_id));
+        self.total_pending -= discarded;
+        if self.owner.is_some_and(|vm_id| !running.contains(&vm_id)) {
+            self.owner = None;
+        }
         if self
-            .host_line_owner
+            .preemption
             .is_some_and(|vm_id| !running.contains(&vm_id))
         {
-            self.host_line_prefixed = false;
+            self.preemption = None;
         }
     }
 
-    /// Invalidates continuation state for a replaced or stopped backend.
+    /// Discards pending output for a replaced or stopped backend.
     pub(crate) fn reset_guest(&mut self, vm_id: usize) {
-        if self.host_line_owner == Some(vm_id) {
-            self.host_line_prefixed = false;
+        if let Some(guest) = self.guests.remove(&vm_id) {
+            self.total_pending -= guest.pending.len();
+        }
+        if self.owner == Some(vm_id) {
+            self.owner = None;
+        }
+        if self.preemption == Some(vm_id) {
+            self.preemption = None;
         }
     }
 
-    /// Formats one serialized backend write for the physical host console.
-    pub(crate) fn format(&mut self, vm_id: usize, multiple_running: bool, bytes: &[u8]) -> Vec<u8> {
-        let mut output = Vec::with_capacity(bytes.len() + 16);
+    /// Requests that the next write from `vm_id` take physical-line ownership.
+    pub(crate) fn request_preemption(&mut self, vm_id: usize) {
+        self.preemption = Some(vm_id);
+    }
 
-        for &byte in bytes {
-            if multiple_running {
-                self.begin_prefixed_fragment(vm_id, &mut output);
-            } else {
-                self.begin_unprefixed_fragment(vm_id, &mut output);
+    /// Enqueues one backend write and returns bytes ready for the host console.
+    pub(crate) fn format(&mut self, vm_id: usize, multiple_running: bool, bytes: &[u8]) -> Vec<u8> {
+        if let OutputMode::Interactive { foreground } = self.mode {
+            return self.format_interactive(vm_id, foreground, bytes);
+        }
+
+        self.append_log(vm_id, bytes);
+
+        if !multiple_running {
+            let pending = self
+                .guests
+                .get(&vm_id)
+                .expect("guest output queue was just created")
+                .pending
+                .len();
+            let mut output = Vec::with_capacity(pending.saturating_add(1));
+            if self.physical_line_open && self.owner != Some(vm_id) {
+                output.push(b'\n');
+                self.physical_line_open = false;
+            }
+            self.owner = Some(vm_id);
+            let guest = self
+                .guests
+                .get_mut(&vm_id)
+                .expect("guest output queue was just created");
+            self.total_pending -= guest.pending.len();
+            output.extend(guest.pending.drain(..));
+            for &byte in &output {
+                guest.at_line_start = byte == b'\n';
+                self.physical_line_open = byte != b'\n';
+            }
+            if !self.physical_line_open {
+                self.owner = None;
+            }
+            return output;
+        }
+
+        let mut output = Vec::with_capacity(self.total_pending.saturating_add(16));
+        loop {
+            let preferred = self.preemption.filter(|vm_id| {
+                self.guests
+                    .get(vm_id)
+                    .is_some_and(|guest| guest.pending.contains(&b'\n'))
+            });
+            let Some(next) = preferred.or_else(|| {
+                self.guests
+                    .iter()
+                    .find_map(|(&vm_id, guest)| guest.pending.contains(&b'\n').then_some(vm_id))
+            }) else {
+                break;
+            };
+            if preferred == Some(next) {
+                self.preemption = None;
             }
 
-            output.push(byte);
-            if byte == b'\n' {
-                self.host_line_owner = None;
-                self.host_line_prefixed = false;
+            if self.physical_line_open {
+                output.push(b'\n');
+                self.physical_line_open = false;
+            }
+            if let Some(previous_owner) = self.owner
+                && let Some(previous_guest) = self.guests.get_mut(&previous_owner)
+            {
+                previous_guest.at_line_start = true;
+            }
+            self.owner = Some(next);
+            output.extend_from_slice(format!("[VM {next}] ").as_bytes());
+
+            let guest = self
+                .guests
+                .get_mut(&next)
+                .expect("completed line must have guest state");
+            guest.at_line_start = false;
+            while let Some(byte) = guest.pending.pop_front() {
+                self.total_pending -= 1;
+                output.push(byte);
+                self.physical_line_open = byte != b'\n';
+                if byte == b'\n' {
+                    guest.at_line_start = true;
+                    self.owner = None;
+                    break;
+                }
             }
         }
 
         output
     }
 
-    fn begin_prefixed_fragment(&mut self, vm_id: usize, output: &mut Vec<u8>) {
-        if self.host_line_owner == Some(vm_id) && self.host_line_prefixed {
-            return;
+    fn format_interactive(
+        &mut self,
+        vm_id: usize,
+        foreground: Option<usize>,
+        bytes: &[u8],
+    ) -> Vec<u8> {
+        if foreground != Some(vm_id) {
+            self.append_log(vm_id, bytes);
+            return Vec::new();
         }
-        if self.host_line_owner.is_some() {
-            output.push(b'\n');
-        }
-        output.extend_from_slice(format!("[VM {vm_id}] ").as_bytes());
-        self.host_line_owner = Some(vm_id);
-        self.host_line_prefixed = true;
+
+        let mut output = self.drain_guest_log(vm_id);
+        output.reserve(bytes.len());
+        output.extend_from_slice(bytes);
+        self.update_physical_line(vm_id, bytes);
+        output
     }
 
-    fn begin_unprefixed_fragment(&mut self, vm_id: usize, output: &mut Vec<u8>) {
-        if self.host_line_owner.is_some_and(|owner| owner != vm_id) {
+    fn drain_guest_log(&mut self, vm_id: usize) -> Vec<u8> {
+        let pending = self
+            .guests
+            .get(&vm_id)
+            .map_or(0, |guest| guest.pending.len());
+        let mut output = Vec::with_capacity(pending.saturating_add(1));
+        if self.physical_line_open && self.owner != Some(vm_id) {
             output.push(b'\n');
-            self.host_line_owner = None;
         }
-        if self.host_line_owner.is_none() {
-            self.host_line_owner = Some(vm_id);
-            self.host_line_prefixed = false;
+        self.physical_line_open = false;
+        self.owner = Some(vm_id);
+
+        let guest = self.guests.entry(vm_id).or_default();
+        self.total_pending -= guest.pending.len();
+        output.extend(guest.pending.drain(..));
+        self.update_physical_line(vm_id, &output);
+        output
+    }
+
+    fn update_physical_line(&mut self, vm_id: usize, output: &[u8]) {
+        let guest = self.guests.entry(vm_id).or_default();
+        for &byte in output {
+            guest.at_line_start = byte == b'\n';
+            self.physical_line_open = byte != b'\n';
+        }
+        if self.physical_line_open {
+            self.owner = Some(vm_id);
+        } else {
+            self.owner = None;
+        }
+    }
+
+    fn append_log(&mut self, vm_id: usize, bytes: &[u8]) {
+        let guest = self.guests.entry(vm_id).or_default();
+        for &byte in bytes {
+            if guest.pending.len() == PER_GUEST_LOG_CAPACITY {
+                guest.pending.pop_front();
+                self.total_pending -= 1;
+            }
+            guest.pending.push_back(byte);
+            self.total_pending += 1;
+        }
+    }
+
+    #[cfg(test)]
+    fn pending_len(&self, vm_id: usize) -> usize {
+        self.guests
+            .get(&vm_id)
+            .map_or(0, |guest| guest.pending.len())
+    }
+
+    #[cfg(test)]
+    fn total_pending(&self) -> usize {
+        self.total_pending
+    }
+
+    #[cfg(test)]
+    fn preemption(&self) -> Option<usize> {
+        self.preemption
+    }
+
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> ArbitrationSnapshot {
+        ArbitrationSnapshot {
+            mode: self.mode,
+            owner: self.owner,
+            physical_line_open: self.physical_line_open,
+            preemption: self.preemption,
+            total_pending: self.total_pending,
+            guests: self
+                .guests
+                .iter()
+                .map(|(&vm_id, guest)| (vm_id, guest.pending.len(), guest.at_line_start))
+                .collect(),
         }
     }
 }
@@ -83,22 +330,191 @@ impl GuestOutputMux {
 mod tests {
     use super::*;
 
-    #[test]
-    fn unterminated_prompt_cannot_block_another_guest() {
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn complete_line_is_emitted_while_other_fragment_remains_buffered() {
+        let mut mux = GuestOutputMux::default();
+        let mut host = Vec::new();
+
+        host.extend(mux.format(2, true, b"booting"));
+        host.extend(mux.format(1, true, b"ready"));
+        host.extend(mux.format(2, true, b" linux\n"));
+
+        assert_eq!(host, b"[VM 2] booting linux\n");
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn complete_line_preempts_an_abandoned_partial_fragment() {
         let mut mux = GuestOutputMux::default();
 
-        assert_eq!(mux.format(2, true, b"~ # "), b"[VM 2] ~ # ");
+        assert!(mux.format(2, true, b"~ # ").is_empty());
+        assert_eq!(mux.format(1, true, b"ready\n"), b"[VM 1] ready\n");
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn competing_guest_does_not_split_an_incomplete_logical_line() {
+        let mut mux = GuestOutputMux::default();
+
+        assert!(mux.format(1, true, b"long ").is_empty());
+        assert_eq!(mux.format(2, true, b"ready\n"), b"[VM 2] ready\n");
         assert_eq!(
-            mux.format(1, true, b"echo ok\nok\n"),
-            b"\n[VM 1] echo ok\n[VM 1] ok\n"
+            mux.format(1, true, b"logical line\n"),
+            b"[VM 1] long logical line\n"
         );
     }
 
-    #[test]
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
     fn fragmented_output_from_one_guest_keeps_one_prefix() {
         let mut mux = GuestOutputMux::default();
 
-        assert_eq!(mux.format(1, true, b"prom"), b"[VM 1] prom");
-        assert_eq!(mux.format(1, true, b"pt\nnext\n"), b"pt\n[VM 1] next\n");
+        assert!(mux.format(1, true, b"prom").is_empty());
+        assert_eq!(
+            mux.format(1, true, b"pt\nnext\n"),
+            b"[VM 1] prompt\n[VM 1] next\n"
+        );
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn pending_output_is_bounded_per_guest() {
+        let mut mux = GuestOutputMux::default();
+        assert!(mux.format(0, true, b"open").is_empty());
+        assert!(
+            mux.format(1, true, &vec![b'x'; PER_GUEST_LOG_CAPACITY + 1])
+                .is_empty()
+        );
+
+        assert_eq!(mux.pending_len(1), PER_GUEST_LOG_CAPACITY);
+        assert_eq!(mux.format(0, true, b"\n"), b"[VM 0] open\n");
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn full_boot_ring_retains_the_newline_that_completes_a_line() {
+        let mut mux = GuestOutputMux::default();
+        assert!(
+            mux.format(1, true, &vec![b'x'; PER_GUEST_LOG_CAPACITY])
+                .is_empty()
+        );
+
+        let output = mux.format(1, true, b"\n");
+
+        assert!(output.starts_with(b"[VM 1] "));
+        assert!(output.ends_with(b"\n"));
+        assert_eq!(
+            output.iter().filter(|&&byte| byte == b'x').count(),
+            PER_GUEST_LOG_CAPACITY - 1
+        );
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn oversized_backend_write_does_not_drive_output_allocation() {
+        let mut mux = GuestOutputMux::default();
+        let output = mux.format(1, true, &vec![b'x'; PER_GUEST_LOG_CAPACITY * 4]);
+
+        assert!(output.capacity() <= PER_GUEST_LOG_CAPACITY + 16);
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn total_pending_output_is_bounded_and_cleanup_releases_capacity() {
+        let mut mux = GuestOutputMux::default();
+        assert!(mux.format(0, true, b"open").is_empty());
+
+        for vm_id in 1..=5 {
+            assert!(
+                mux.format(vm_id, true, &vec![b'x'; PER_GUEST_LOG_CAPACITY])
+                    .is_empty()
+            );
+        }
+        assert_eq!(mux.total_pending(), PER_GUEST_LOG_CAPACITY * 5 + 4);
+
+        mux.reset_guest(1);
+        assert_eq!(mux.total_pending(), PER_GUEST_LOG_CAPACITY * 4 + 4);
+
+        mux.reconcile_running(&BTreeSet::from([0, 5]));
+        assert_eq!(mux.total_pending(), PER_GUEST_LOG_CAPACITY + 4);
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn complete_line_preempts_a_background_fragment_once() {
+        let mut mux = GuestOutputMux::default();
+        assert!(mux.format(2, true, b"~ # ").is_empty());
+
+        mux.request_preemption(1);
+        assert_eq!(mux.format(1, true, b"echo ok\n"), b"[VM 1] echo ok\n");
+
+        assert!(mux.format(2, true, b"next").is_empty());
+        assert_eq!(mux.format(1, true, b"queued\n"), b"[VM 1] queued\n");
+        assert_eq!(mux.format(2, true, b" line\n"), b"[VM 2] ~ # next line\n");
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn interactive_background_ring_overwrites_oldest_bytes_before_replay() {
+        let mut mux = GuestOutputMux::default();
+        mux.enter_interactive(1);
+        assert!(
+            mux.format(2, true, &vec![b'a'; PER_GUEST_LOG_CAPACITY])
+                .is_empty()
+        );
+        assert!(mux.format(2, true, b"TAIL").is_empty());
+
+        let mut expected = vec![b'a'; PER_GUEST_LOG_CAPACITY - 4];
+        expected.extend_from_slice(b"TAIL");
+        assert_eq!(mux.select_foreground(2), expected);
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn interactive_foreground_fragments_stay_on_the_same_physical_line() {
+        let mut mux = GuestOutputMux::default();
+        mux.enter_interactive(1);
+
+        assert_eq!(mux.format(1, true, b"e"), b"e");
+        assert_eq!(mux.format(1, true, b"c"), b"c");
+        assert_eq!(mux.format(1, true, b"ho\n"), b"ho\n");
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn buffering_for_the_shell_closes_guest_line_ownership() {
+        let mut mux = GuestOutputMux::default();
+        mux.enter_interactive(1);
+        assert_eq!(mux.format(1, true, b"~ # "), b"~ # ");
+
+        assert_eq!(mux.buffer_all(), b"\n");
+        assert!(mux.format(2, true, b"cached\n").is_empty());
+
+        assert_eq!(mux.select_foreground(2), b"cached\n");
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn resetting_an_open_line_owner_preserves_a_physical_separator() {
+        let mut mux = GuestOutputMux::default();
+        assert!(mux.format(2, true, b"partial").is_empty());
+
+        mux.reset_guest(2);
+
+        assert_eq!(mux.format(1, true, b"ready\n"), b"[VM 1] ready\n");
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn reconciliation_clears_invalid_preemption_and_preserves_separator() {
+        let mut mux = GuestOutputMux::default();
+        assert!(mux.format(2, true, b"partial").is_empty());
+        mux.request_preemption(2);
+
+        mux.reconcile_running(&BTreeSet::from([1]));
+
+        assert_eq!(mux.preemption(), None);
+        assert_eq!(mux.format(1, true, b"ready\n"), b"[VM 1] ready\n");
     }
 }

--- a/os/axvisor/src/guest_console/mux/tests.rs
+++ b/os/axvisor/src/guest_console/mux/tests.rs
@@ -1,11 +1,29 @@
 use super::*;
 
 fn route_shortcut(mux: &GuestConsoleMux, suffix: u8) -> ConsoleInputEvent {
-    assert_eq!(mux.route_host_byte(ESC).event, ConsoleInputEvent::Consumed);
+    assert_eq!(
+        mux.route_host_byte(CTRL_X).event,
+        ConsoleInputEvent::Consumed
+    );
     mux.route_host_byte(suffix).event
 }
 
-#[test]
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn ctrl_x_h_detaches_the_foreground_guest() {
+    let mux = GuestConsoleMux::new();
+    mux.core.create_serial_backend(7);
+    assert_eq!(mux.attach_default([7]), Some(7));
+
+    assert_eq!(mux.route_host_byte(0x18).event, ConsoleInputEvent::Consumed);
+    assert_eq!(
+        mux.route_host_byte(b'h').event,
+        ConsoleInputEvent::Detached(7)
+    );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
 fn lowest_running_vm_is_default_and_input_only_reaches_foreground() {
     let mux = GuestConsoleMux::new();
     let backend_1 = mux.core.create_serial_backend(1);
@@ -20,7 +38,8 @@ fn lowest_running_vm_is_default_and_input_only_reaches_foreground() {
     assert_eq!(backend_2.read(&mut input), 0);
 }
 
-#[test]
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
 fn console_shortcuts_detach_and_cycle_running_guests() {
     let mux = GuestConsoleMux::new();
     for vm_id in [2, 7, 10] {
@@ -28,42 +47,48 @@ fn console_shortcuts_detach_and_cycle_running_guests() {
     }
     assert_eq!(mux.attach_default([10, 2, 7]), Some(2));
 
-    assert_eq!(
-        route_shortcut(&mux, CTRL_RIGHT_BRACKET),
-        ConsoleInputEvent::Attached(7)
-    );
-    assert_eq!(
-        route_shortcut(&mux, CTRL_RIGHT_BRACKET),
-        ConsoleInputEvent::Attached(10)
-    );
-    assert_eq!(route_shortcut(&mux, ESC), ConsoleInputEvent::Attached(7));
-    assert_eq!(route_shortcut(&mux, CTRL_H), ConsoleInputEvent::Detached(7));
+    assert_eq!(route_shortcut(&mux, b']'), ConsoleInputEvent::Attached(7));
+    assert_eq!(route_shortcut(&mux, b']'), ConsoleInputEvent::Attached(10));
+    assert_eq!(route_shortcut(&mux, b'['), ConsoleInputEvent::Attached(7));
+    assert_eq!(route_shortcut(&mux, b'h'), ConsoleInputEvent::Detached(7));
     assert_eq!(mux.attached_vm(), None);
-    assert_eq!(
-        route_shortcut(&mux, CTRL_RIGHT_BRACKET),
-        ConsoleInputEvent::Attached(10)
-    );
+    assert_eq!(route_shortcut(&mux, b']'), ConsoleInputEvent::Attached(10));
 }
 
-#[test]
-fn non_shortcut_escape_sequences_reach_the_current_console() {
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn non_shortcut_ctrl_x_sequences_reach_the_current_console() {
     let mux = GuestConsoleMux::new();
     let backend = mux.core.create_serial_backend(7);
     assert_eq!(mux.attach_default([7]), Some(7));
 
-    assert_eq!(route_shortcut(&mux, b'['), ConsoleInputEvent::Consumed);
+    assert_eq!(route_shortcut(&mux, b'z'), ConsoleInputEvent::Consumed);
     let mut input = [0u8; 2];
     assert_eq!(backend.read(&mut input), 2);
-    assert_eq!(input, [ESC, b'[']);
+    assert_eq!(input, [CTRL_X, b'z']);
 
-    assert_eq!(route_shortcut(&mux, CTRL_H), ConsoleInputEvent::Detached(7));
+    assert_eq!(route_shortcut(&mux, b'h'), ConsoleInputEvent::Detached(7));
     assert_eq!(
-        route_shortcut(&mux, b'['),
-        ConsoleInputEvent::ShellSequence(ESC, b'[')
+        route_shortcut(&mux, b'z'),
+        ConsoleInputEvent::ShellSequence(CTRL_X, b'z')
     );
 }
 
-#[test]
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn doubled_ctrl_x_reaches_the_current_console_as_one_byte() {
+    let mux = GuestConsoleMux::new();
+    let backend = mux.core.create_serial_backend(7);
+    assert_eq!(mux.attach_default([7]), Some(7));
+
+    assert_eq!(route_shortcut(&mux, CTRL_X), ConsoleInputEvent::Consumed);
+    let mut input = [0u8; 2];
+    assert_eq!(backend.read(&mut input), 1);
+    assert_eq!(input[0], CTRL_X);
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
 fn stopping_foreground_guest_returns_to_shell() {
     let mux = GuestConsoleMux::new();
     mux.core.create_serial_backend(3);
@@ -73,7 +98,8 @@ fn stopping_foreground_guest_returns_to_shell() {
     assert_eq!(mux.attached_vm(), None);
 }
 
-#[test]
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
 fn stopped_or_removed_guest_invalidates_its_serial_backend_generation() {
     let mux = GuestConsoleMux::new();
     let backend = mux.core.create_serial_backend(4);
@@ -96,7 +122,8 @@ fn stopped_or_removed_guest_invalidates_its_serial_backend_generation() {
     assert!(!mux.core.lock_state().guests.contains_key(&3));
 }
 
-#[test]
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
 fn multiple_running_guests_receive_line_prefixes() {
     let mux = GuestConsoleMux::new();
     let backend_1 = mux.core.create_serial_backend(1);
@@ -112,21 +139,263 @@ fn multiple_running_guests_receive_line_prefixes() {
     assert_eq!(
         mux.core
             .format_guest_output(1, backend_1.generation, b"ready\nprompt"),
-        Some(b"[VM 1] ready\n[VM 1] prompt".to_vec())
+        Some(b"[VM 1] ready\n".to_vec())
     );
     assert_eq!(
         mux.core
             .format_guest_output(2, backend_2.generation, b"other\n"),
-        Some(b"\n[VM 2] other\n".to_vec())
+        Some(b"[VM 2] other\n".to_vec())
     );
     assert_eq!(
         mux.core
             .format_guest_output(1, backend_1.generation, b"> \n"),
-        Some(b"[VM 1] > \n".to_vec())
+        Some(b"[VM 1] prompt> \n".to_vec())
     );
 }
 
-#[test]
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn default_attachment_preempts_an_unterminated_background_fragment() {
+    let mux = GuestConsoleMux::new();
+    let backend_1 = mux.core.create_serial_backend(1);
+    let backend_2 = mux.core.create_serial_backend(2);
+    mux.set_running([1, 2]);
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"background"),
+        Some(Vec::new())
+    );
+
+    assert_eq!(mux.attach_default([1, 2]), Some(1));
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"ready\n"),
+        Some(b"[VM 1] ready\n".to_vec())
+    );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn foreground_input_preempts_an_unterminated_background_fragment() {
+    let mux = GuestConsoleMux::new();
+    let backend_1 = mux.core.create_serial_backend(1);
+    let backend_2 = mux.core.create_serial_backend(2);
+    assert_eq!(mux.attach_default([1, 2]), Some(1));
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"ready\n"),
+        Some(b"[VM 1] ready\n".to_vec())
+    );
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"~ # "),
+        Some(Vec::new())
+    );
+
+    assert_eq!(mux.route_host_byte(b'x').event, ConsoleInputEvent::Consumed);
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"echo\n"),
+        Some(b"echo\n".to_vec())
+    );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn foreground_command_result_preempts_after_its_echo_completed() {
+    let mux = GuestConsoleMux::new();
+    let backend_1 = mux.core.create_serial_backend(1);
+    let backend_2 = mux.core.create_serial_backend(2);
+    assert_eq!(mux.attach_default([1, 2]), Some(1));
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"~ # "),
+        Some(Vec::new())
+    );
+
+    assert_eq!(mux.route_host_byte(b'x').event, ConsoleInputEvent::Consumed);
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"x\n"),
+        Some(b"x\n".to_vec())
+    );
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"waiting"),
+        Some(Vec::new())
+    );
+
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"RESULT\n"),
+        Some(b"RESULT\n".to_vec())
+    );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn first_foreground_input_enters_interactive_exclusive_mode() {
+    let mux = GuestConsoleMux::new();
+    let backend_1 = mux.core.create_serial_backend(1);
+    let backend_2 = mux.core.create_serial_backend(2);
+    assert_eq!(mux.attach_default([1, 2]), Some(1));
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"vm1 booted\n"),
+        Some(b"[VM 1] vm1 booted\n".to_vec())
+    );
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"vm2 booted\n"),
+        Some(b"[VM 2] vm2 booted\n".to_vec())
+    );
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"~ # "),
+        Some(Vec::new())
+    );
+
+    let routed = mux.route_host_byte(b'x');
+    assert_eq!(routed.event, ConsoleInputEvent::Consumed);
+    assert_eq!(routed.host_output, b"~ # ");
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"background\n"),
+        Some(Vec::new())
+    );
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"result\n"),
+        Some(b"result\n".to_vec())
+    );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn switching_guests_replays_background_log_before_direct_output() {
+    let mux = GuestConsoleMux::new();
+    let backend_1 = mux.core.create_serial_backend(1);
+    let backend_2 = mux.core.create_serial_backend(2);
+    assert_eq!(mux.attach_default([1, 2]), Some(1));
+
+    assert_eq!(mux.route_host_byte(b'x').event, ConsoleInputEvent::Consumed);
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"foreground\n"),
+        Some(b"foreground\n".to_vec())
+    );
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"background\n"),
+        Some(Vec::new())
+    );
+
+    assert_eq!(
+        mux.route_host_byte(CTRL_X).event,
+        ConsoleInputEvent::Consumed
+    );
+    let switched = mux.route_host_byte(b']');
+    assert_eq!(switched.event, ConsoleInputEvent::Attached(2));
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"before activation\n"),
+        Some(Vec::new())
+    );
+    assert_eq!(
+        mux.activate(2),
+        Some(b"background\nbefore activation\n".to_vec())
+    );
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"direct\n"),
+        Some(b"direct\n".to_vec())
+    );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn detaching_buffers_all_guest_output() {
+    let mux = GuestConsoleMux::new();
+    let backend = mux.core.create_serial_backend(1);
+    assert_eq!(mux.attach_default([1]), Some(1));
+    assert_eq!(mux.route_host_byte(b'x').event, ConsoleInputEvent::Consumed);
+    assert_eq!(
+        mux.core.format_guest_output(1, backend.generation, b"~ # "),
+        Some(b"~ # ".to_vec())
+    );
+
+    assert_eq!(
+        mux.route_host_byte(CTRL_X).event,
+        ConsoleInputEvent::Consumed
+    );
+    let detached = mux.route_host_byte(b'h');
+    assert_eq!(detached.event, ConsoleInputEvent::Detached(1));
+    assert_eq!(detached.host_output, b"\n");
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend.generation, b"while detached\n"),
+        Some(Vec::new())
+    );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn switching_guests_terminates_unfinished_foreground_output() {
+    let mux = GuestConsoleMux::new();
+    let backend_1 = mux.core.create_serial_backend(1);
+    mux.core.create_serial_backend(2);
+    assert_eq!(mux.attach_default([1, 2]), Some(1));
+    assert_eq!(mux.route_host_byte(b'x').event, ConsoleInputEvent::Consumed);
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"~ # "),
+        Some(b"~ # ".to_vec())
+    );
+
+    assert_eq!(
+        mux.route_host_byte(CTRL_X).event,
+        ConsoleInputEvent::Consumed
+    );
+    let switched = mux.route_host_byte(b']');
+
+    assert_eq!(switched.event, ConsoleInputEvent::Attached(2));
+    assert_eq!(switched.host_output, b"\n");
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn guest_switch_preempts_an_unterminated_background_fragment() {
+    let mux = GuestConsoleMux::new();
+    let backend_1 = mux.core.create_serial_backend(1);
+    let backend_2 = mux.core.create_serial_backend(2);
+    assert_eq!(mux.attach_default([1, 2]), Some(1));
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"ready\n"),
+        Some(b"[VM 1] ready\n".to_vec())
+    );
+    assert_eq!(
+        mux.core
+            .format_guest_output(1, backend_1.generation, b"~ # "),
+        Some(Vec::new())
+    );
+
+    assert_eq!(
+        mux.route_host_byte(CTRL_X).event,
+        ConsoleInputEvent::Consumed
+    );
+    let switched = mux.route_host_byte(b']');
+    assert_eq!(switched.event, ConsoleInputEvent::Attached(2));
+    assert_eq!(mux.activate(2), Some(Vec::new()));
+    assert_eq!(
+        mux.core
+            .format_guest_output(2, backend_2.generation, b"ready\n"),
+        Some(b"ready\n".to_vec())
+    );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
 fn replacement_backend_invalidates_the_previous_vm_generation() {
     let mux = GuestConsoleMux::new();
     let stale_backend = mux.core.create_serial_backend(8);
@@ -143,4 +412,31 @@ fn replacement_backend_invalidates_the_previous_vm_generation() {
             .format_guest_output(8, stale_backend.generation, b"stale"),
         None
     );
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn stale_backends_leave_output_arbitration_unchanged() {
+    let mux = GuestConsoleMux::new();
+
+    let stopped = mux.core.create_serial_backend(1);
+    mux.set_running([1]);
+    mux.mark_stopped(1);
+    let stopped_snapshot = mux.core.lock_state().output.snapshot();
+    stopped.write(b"late stopped output");
+    assert_eq!(mux.core.lock_state().output.snapshot(), stopped_snapshot);
+
+    let removed = mux.core.create_serial_backend(2);
+    mux.set_running([2]);
+    mux.remove(2);
+    let removed_snapshot = mux.core.lock_state().output.snapshot();
+    removed.write(b"late removed output");
+    assert_eq!(mux.core.lock_state().output.snapshot(), removed_snapshot);
+
+    let replaced = mux.core.create_serial_backend(3);
+    mux.set_running([3]);
+    let _current = mux.core.create_serial_backend(3);
+    let replaced_snapshot = mux.core.lock_state().output.snapshot();
+    replaced.write(b"late replaced output");
+    assert_eq!(mux.core.lock_state().output.snapshot(), replaced_snapshot);
 }

--- a/os/axvisor/src/shell/command/vm.rs
+++ b/os/axvisor/src/shell/command/vm.rs
@@ -257,9 +257,13 @@ fn start_vm_by_id(vm_id: usize, attach_console: bool) {
             println!("✓ VM[{}] started successfully", vm_id);
             if attach_console {
                 match crate::guest_console::attach(vm_id) {
-                    Ok(()) => println!(
-                        "✓ Attached VM[{vm_id}] console; use Ctrl+Alt+H to return to the shell"
-                    ),
+                    Ok(()) => {
+                        println!(
+                            "✓ Attached VM[{vm_id}] console; use Ctrl+X, then h to return to the \
+                             shell"
+                        );
+                        crate::guest_console::activate(vm_id);
+                    }
                     Err(error) => println!("✗ Failed to attach VM[{vm_id}] console: {error:#}"),
                 }
             }
@@ -649,7 +653,8 @@ fn vm_console(cmd: &ParsedCommand) {
 
     match crate::guest_console::attach(vm_id) {
         Ok(()) => {
-            println!("✓ Attached VM[{vm_id}] console; use Ctrl+Alt+H to return to the shell");
+            println!("✓ Attached VM[{vm_id}] console; use Ctrl+X, then h to return to the shell");
+            crate::guest_console::activate(vm_id);
         }
         Err(error) => println!("✗ Failed to attach VM[{vm_id}] console: {error:#}"),
     }

--- a/os/axvisor/src/shell/mod.rs
+++ b/os/axvisor/src/shell/mod.rs
@@ -50,9 +50,9 @@ fn print_shell_intro() {
 
 fn print_console_shortcuts() {
     println!("Console shortcuts:");
-    println!("  Ctrl+Alt+H  return to the Axvisor shell");
-    println!("  Ctrl+Alt+[  attach the previous running guest");
-    println!("  Ctrl+Alt+]  attach the next running guest");
+    println!("  Ctrl+X, then h  return to the Axvisor shell");
+    println!("  Ctrl+X, then [  attach the previous running guest");
+    println!("  Ctrl+X, then ]  attach the next running guest");
 }
 
 // Initialize the console shell.
@@ -104,9 +104,10 @@ pub fn console_init() {
                     ConsoleInputEvent::Attached(vm_id) => {
                         println!();
                         println!(
-                            "[Axvisor] attached VM[{vm_id}] console; use Ctrl+Alt+H to return to \
-                             the shell"
+                            "[Axvisor] attached VM[{vm_id}] console; use Ctrl+X, then h to return \
+                             to the shell"
                         );
+                        crate::guest_console::activate(vm_id);
                         continue;
                     }
                     ConsoleInputEvent::Detached(vm_id) => {

--- a/os/axvisor/tests/axtest.rs
+++ b/os/axvisor/tests/axtest.rs
@@ -1,8 +1,35 @@
 #![cfg_attr(target_os = "none", no_std)]
 #![cfg_attr(target_os = "none", no_main)]
 
+extern crate alloc;
+
 use ax_std as _;
 use axvm as _;
+
+mod host {
+    pub(super) fn write_host_bytes(_bytes: &[u8]) {}
+}
+
+mod manager {
+    pub struct AxvmManager;
+
+    impl AxvmManager {
+        pub fn notify_vm(_vm_id: axvm::VMId) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        pub fn vm_by_id(_vm_id: axvm::VMId) -> Option<axvm::AxVMRef> {
+            None
+        }
+
+        pub fn vm_list() -> Vec<axvm::AxVMRef> {
+            Vec::new()
+        }
+    }
+}
+
+#[path = "../src/guest_console/mux/mod.rs"]
+mod guest_console_mux;
 
 #[cfg(feature = "fs")]
 #[path = "../src/shell/command/fs.rs"]


### PR DESCRIPTION
## 问题

AxVisor 同时运行多个 VM 时，各 VM 的串口输出会按字节交错，导致日志内容难以阅读。同时，向某个 VM 输入命令后，其输出可能无法及时显示。

原有的 `Ctrl+Alt+h` 依赖终端传递修饰键信息，在 Zellij、部分终端及 QEMU 环境中无法可靠识别。

## 修改内容

- 启动阶段按完整行显示所有运行中 VM 的串口输出，并添加 `[VM n]` 前缀。
- 第一次向 VM 输入后切换到交互模式：
  - 前台 VM 输出直接显示。
  - 后台 VM 输出保存到独立环形日志。
- 每个 VM 的后台日志上限为 16 KiB，超出后覆盖最旧内容。
- 切换到后台 VM 时回放其缓存日志，随后恢复实时输出。
- 使用顺序式 `Ctrl+X` 快捷键，避免依赖终端增强键盘协议：
  - `Ctrl+X h`：返回 AxVisor 控制台。
  - `Ctrl+X [`：切换到上一个 VM。
  - `Ctrl+X ]`：切换到下一个 VM。
  - `Ctrl+X Ctrl+X`：向当前 VM 输入原始 `Ctrl+X`。
  - 未知组合会原样传递，不丢失输入。
- VM 停止、删除或串口后端被替换时，清理对应的输入、输出和前台状态。

## 实现逻辑

启动阶段仅输出已经完成的逻辑行，避免多个 VM 的分片内容相互穿插。未换行片段暂存在对应 VM 的队列中。

进入交互模式后，当前 VM 获得前台直出权限，其他 VM 的输出写入各自的有界环形日志。切换 VM 时先回放目标 VM 的缓存，再将其设为前台。

主机控制台仍是唯一输入读取方，由多路复用层将普通输入和快捷键事件路由到 AxVisor shell 或对应 VM。

## 验证

执行：

```bash
cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
```

结果：

```text
AXTEST_SUMMARY pass=68 fail=0 skip=0 total=68
```

其中 guest-console 回归测试包括：

- 14 个输出仲裁和环形日志测试。
- 18 个多路复用状态机测试。
- 覆盖 `Ctrl+X` 快捷键、attach/detach、VM 切换、输入路由、后台日志回放、未换行输出收尾，以及 VM 停止、删除和串口后端替换后的状态清理。

其他验证：

- `cargo fmt --all --check` 通过。
- `cargo xtask axvisor build --arch aarch64` 通过。
- AxVisor aarch64 目标配置 Clippy 通过。
- 双 VM QEMU 场景验证了启动期多 VM 输出、命令输入、前后台切换、缓存日志回放和返回 AxVisor 控制台。