### PR TITLE
fix(starry-task): release ptrace stop on SIGKILL

### DIFF
--- a/os/StarryOS/kernel/src/task/signal.rs
+++ b/os/StarryOS/kernel/src/task/signal.rs
@@ -17,7 +17,7 @@ use starry_vm::vm_read_slice;
 
 use super::{
     AsThread, ProcessData, Thread, do_exit, get_process_data, get_process_group, get_task,
-    is_zombie_pid, signal_publication::publish_before_release,
+    is_zombie_pid, signal_publication::publish_before_fatal_stop_release,
 };
 
 /// Information needed to restart a syscall if SA_RESTART applies.
@@ -606,14 +606,15 @@ pub fn send_signal_to_process(pid: Pid, sig: Option<SignalInfo>) -> AxResult<()>
         let ptrace_stop_tid = (signo == Signo::SIGKILL)
             .then(|| proc_data.selected_ptrace_stop_tid())
             .flatten();
-        let _wake_tid = publish_before_release(
-            || publish_process_signal(&proc_data, sig, ptrace_stop_tid),
-            || {
-                if signo == Signo::SIGKILL {
-                    proc_data.clear_job_stop_for_kill();
-                }
-            },
-        );
+        if signo == Signo::SIGKILL {
+            let _wake_tid = publish_before_fatal_stop_release(
+                || publish_process_signal(&proc_data, sig, ptrace_stop_tid),
+                ptrace_stop_tid.map(|_| || proc_data.clear_ptrace_stop()),
+                || proc_data.clear_job_stop_for_kill(),
+            );
+        } else {
+            let _wake_tid = publish_process_signal(&proc_data, sig, ptrace_stop_tid);
+        }
         // Wake signalfd waiters on every thread: even blocked process-level
         // signals must be visible from signalfd in an epoll event loop.
         for tid in proc_data.proc.threads() {

--- a/os/StarryOS/kernel/src/task/signal_publication.rs
+++ b/os/StarryOS/kernel/src/task/signal_publication.rs
@@ -1,16 +1,20 @@
 //! Ordering boundary between fatal-signal publication and stop-state wakeup.
 
-/// Runs signal publication and the wakeup that exposes it to the target.
+/// Publishes a fatal signal before releasing stop states that hide it.
 ///
 /// Both operations run synchronously in task context. Keeping the ordering in
 /// one helper mirrors Linux's `siglock` invariant while Starry stores pending
 /// signals and ptrace stop records in separate owners.
-pub(crate) fn publish_before_release<T>(
+pub(crate) fn publish_before_fatal_stop_release<T>(
     publish: impl FnOnce() -> T,
-    release_stop: impl FnOnce(),
+    release_ptrace_stop: Option<impl FnOnce()>,
+    release_job_stop: impl FnOnce(),
 ) -> T {
     let publication = publish();
-    release_stop();
+    if let Some(release_ptrace_stop) = release_ptrace_stop {
+        release_ptrace_stop();
+    }
+    release_job_stop();
     publication
 }
 
@@ -18,12 +22,12 @@ pub(crate) fn publish_before_release<T>(
 mod tests {
     use core::cell::Cell;
 
-    use super::publish_before_release;
+    use super::publish_before_fatal_stop_release;
 
     #[test]
-    fn fatal_signal_publication_precedes_stop_release() {
+    fn fatal_signal_publication_precedes_all_stop_releases() {
         let phase = Cell::new(0_u8);
-        let publication = publish_before_release(
+        let publication = publish_before_fatal_stop_release(
             || {
                 assert_eq!(
                     phase.get(),
@@ -33,17 +37,25 @@ mod tests {
                 phase.set(1);
                 7_u8
             },
-            || {
+            Some(|| {
                 assert_eq!(
                     phase.get(),
                     1,
                     "ptrace stop release must observe the fatal signal publication"
                 );
                 phase.set(2);
+            }),
+            || {
+                assert_eq!(
+                    phase.get(),
+                    2,
+                    "job stop release must follow ptrace stop release"
+                );
+                phase.set(3);
             },
         );
 
         assert_eq!(publication, 7);
-        assert_eq!(phase.get(), 2);
+        assert_eq!(phase.get(), 3);
     }
 }


### PR DESCRIPTION
## 问题

GitHub Actions 的 riscv64 Starry QEMU system job 在进入 `test-proc-status-tracerpid` 后不再输出，最终在 1800 秒后超时：

- https://github.com/rcore-os/tgoskits/actions/runs/31080604210/job/92549586184

tracee 公开 ptrace-stop 后，父进程可能从另一 CPU 发送 SIGKILL。原路径会先发布 SIGKILL 并触发 task interrupt，但只显式释放 job-stop，没有释放 ptrace-stop。如果 interrupt 在 tracee 建立 ptrace 等待前到达，它可能被当作旧中断确认掉；此后 ptrace-stop 没有新的释放事件，tracee 与父进程的 `waitpid` 会永久阻塞。

## 修改

- 将 fatal signal 的顺序边界明确为：发布 SIGKILL、释放 ptrace-stop、释放 job-stop。
- 仅在 SIGKILL 且存在 ptrace-stop 时清理 ptrace 状态；其他信号继续沿用原有发布路径。
- 增加确定性顺序回归测试，验证 signal publication 必须先于 ptrace-stop 与 job-stop 的释放。

该顺序对应 Linux 在 fatal signal 已经 pending 后以 killable wake 释放 traced/stopped task 的要求，同时避免恢复到旧实现中“先释放 stop、后发布 SIGKILL”所导致的错误退出状态竞态。

## 验证

- 确定性回归测试：修复前稳定失败，修复后通过。
- `cargo fmt --all --check`
- `cargo xtask clippy --package starry-kernel`：25/25 checks passed。
- `cargo xtask starry test qemu --arch riscv64 -c qemu/system/test-proc-status-tracerpid`
  - `DONE: 1 pass, 0 fail`
  - `STARRY_SYSTEM_TEST_PASSED`
  - `STARRY_GROUPED_TESTS_PASSED`
