### PR TITLE
fix(sg2002, sdhci-cv1800, aic8800): fix WiFi TX throughput via XFER_COMPLETE interrupt

### DIFF
--- a/components/aic8800/src/fdrv/thread/rx.rs
+++ b/components/aic8800/src/fdrv/thread/rx.rs
@@ -60,11 +60,10 @@ fn align_up(val: usize, align: usize) -> usize {
 /// 启动 wifi-rx 线程
 pub fn start(bus: Arc<WifiBus>) {
     log::debug!("[wifi-rx] thread starting");
-    // RX poll kicker 仅 DC/DW 启用(与 TX kicker 对称)。D80/8801 走 upstream/dev
-    // 的纯事件(ISR)驱动路径,不启动周期 kicker。
-    if bus.transport.is_dual_pipe() {
-        start_rx_poll_kicker(bus.clone());
-    }
+    // RX poll kicker: D80/8801 的 ISR 驱动路径不可靠（PLIC IRQ 在 probe 阶段
+    // 未使能，固件响应在 TX->RX 的单次 wake 之后才到达时 RX 线程无人唤醒），
+    // 用 10ms kicker 兜底保证轮询响应和异步入站帧不丢失。
+    start_rx_poll_kicker(bus.clone());
     crate::runtime::runtime().spawn_poll_task(
         "wifi-rx",
         alloc::boxed::Box::new(move |cx| {

--- a/components/sdhci-cv1800/src/irq.rs
+++ b/components/sdhci-cv1800/src/irq.rs
@@ -19,11 +19,10 @@ use core::sync::atomic::{AtomicU16, AtomicU64, AtomicUsize, Ordering};
 
 use crate::{mmio_read, mmio_write, regs::*};
 
-/// Callback slot: stores a function pointer for ISR invocation.
+/// 回调槽：存储 ISR 调用的函数指针。
 ///
-/// Uses `AtomicUsize` because `fn()` is pointer-width on all supported
-/// targets (riscv64, aarch64, x86_64). A zero value means unregistered;
-/// the ISR guards against this.
+/// 使用 `AtomicUsize` 因为 `fn()` 在所有支持的平台上是指针宽度
+/// （riscv64、aarch64、x86_64）。零值表示未注册，ISR 对此有防护。
 struct CallbackSlot {
     ptr: AtomicUsize,
 }
@@ -35,28 +34,25 @@ impl CallbackSlot {
         }
     }
 
-    /// Register a callback. Call once during init before IRQs are enabled.
+    /// 注册回调函数。在初始化期间、IRQ 使能前调用一次。
     fn register(&self, cb: fn()) {
         self.ptr.store(cb as usize, Ordering::Release);
     }
 
-    /// Invoke the registered callback, if any.
+    /// 调用已注册的回调（如果有）。
     ///
-    /// # Safety
+    /// # 安全性
     ///
-    /// - The stored value must be a valid `fn()` previously stored via
-    ///   `register`. A zero value (empty slot) is guarded and does not
-    ///   invoke the callback.
-    /// - Single-core assumption: no concurrent store to this slot from another
-    ///   hart while the callback is being invoked.
-    /// - The callback runs in hard-IRQ context on the calling hart and must not
-    ///   allocate, hold locks, schedule, or call `log` macros that synchronously
-    ///   write UART.
+    /// - 存储的值必须是先前通过 `register` 存储的有效 `fn()`。
+    ///   零值（空槽）被防护，不会触发回调调用。
+    /// - 单核假设：回调调用期间没有其他 hart 并发写入此槽。
+    /// - 回调在硬中断上下文中运行，禁止：分配堆、持锁、调度、
+    ///   调用同步写 UART 的 `log` 宏。
     unsafe fn invoke(&self) {
         let v = self.ptr.load(Ordering::Acquire);
         if v != 0 {
-            // SAFETY: v was stored as `cb as usize` by register().
-            // fn() and usize are the same size on all supported targets.
+            // SAFETY: v 由 register() 以 `cb as usize` 存入。
+            // fn() 和 usize 在所有支持的平台上大小相同。
             let cb: fn() = unsafe { core::mem::transmute::<usize, fn()>(v) };
             cb();
         }
@@ -137,7 +133,7 @@ pub fn disable_irq_signals() {
 // 方便审查单核竞态假设和未来 SMP 适配。
 // 注意：enable_irq_signals/disable_irq_signals 是全量写入（reset 语义），不属于 RMW。
 
-/// Read-Modify-Write on `SDHCI_NORM_INT_SIG_EN`.
+/// 对 `SDHCI_NORM_INT_SIG_EN` 执行 Read-Modify-Write。
 ///
 /// RMW 本身不是原子的（可能被 ISR 抢占），但设计依赖 XFER_COMPLETE sticky bit
 /// 自愈：即使本次写入携带过期值，中断线在 task 阻塞后重新断言，ISR 重新触发。
@@ -193,26 +189,24 @@ pub fn sdhci_irq_handler(_irq: usize) {
     if norm & NORM_INT_CARD_INT != 0 {
         SDHCI_CARD_INT_COUNT.fetch_add(1, Ordering::Relaxed);
         mask_card_irq_raw(base, true);
-        // SAFETY: CARD_INT callback is registered once during init via
-        // register_card_irq_callback. Single-core: no concurrent store.
+        // SAFETY: CARD_INT 回调在初始化期间通过 register_card_irq_callback
+        // 注册一次。单核：无并发写入。
         unsafe { SDHCI_IRQ_STATE.card_irq_callback.invoke() };
     }
 
-    // Handle XFER_COMPLETE: mask signal, then wake blocked task.
-    // The sticky status bit is NOT cleared here — the task observes and
-    // W1C-clears it after wake. Clearing it here would destroy the
-    // wake condition and cause guaranteed 200ms timeout.
-    // XFER_COMPLETE is normally only enabled in SIG_EN while a task is
-    // blocked in poll_int_status (see unmask_xfer_complete_signal), so
-    // this path is idle in steady state. After a race-guard win or timeout
-    // the SIG_EN bit may briefly remain set; the resulting spurious ISR
-    // re-masks and notifies harmlessly.
+    // 处理 XFER_COMPLETE：mask 信号，然后唤醒阻塞任务。
+    // sticky 状态位不在此处清除——任务在唤醒后观察并 W1C 清除它。
+    // 若在此清除会破坏唤醒条件并导致必然的 200ms 超时。
+    // XFER_COMPLETE 通常仅在任务阻塞于 poll_int_status 时才在 SIG_EN 中
+    // 使能（见 unmask_xfer_complete_signal），因此此路径在稳态时空闲。
+    // 在 race-guard 胜出或超时后 SIG_EN 位可能短暂保持置位；
+    // 由此产生的多余 ISR 重新 mask 并通知，无害。
     if norm & NORM_INT_XFER_COMPLETE != 0 {
-        // Mask the XFER_COMPLETE signal to prevent re-firing
+        // Mask XFER_COMPLETE 信号以防重复触发
         rmw_norm_sig_en(base, 0, NORM_INT_XFER_COMPLETE);
-        // Wake the blocked task (status bit stays sticky for task to observe)
-        // SAFETY: PIO wake callback is registered once during init via
-        // register_pio_wake_callback. Single-core: no concurrent store.
+        // 唤醒阻塞任务（状态位保持 sticky 供任务观察）
+        // SAFETY: PIO 唤醒回调在初始化期间通过 register_pio_wake_callback
+        // 注册一次。单核：无并发写入。
         unsafe { SDHCI_IRQ_STATE.pio_wake_callback.invoke() };
     }
 }

--- a/components/sdhci-cv1800/src/irq.rs
+++ b/components/sdhci-cv1800/src/irq.rs
@@ -1,27 +1,84 @@
 //! SDHCI 中断处理模块
 //!
 //! 设计模式：
-//!   - ISR: 裸函数，只处理 CARD_INT (mask 信号 + 调用回调)
-//!   - PIO: CviSdhci 的 wait_* 方法直接轮询 INT_STATUS 寄存器
-//!   - 分离 ISR 和 PIO 事件避免竞态条件
+//!   - ISR: 处理 CARD_INT 和 XFER_COMPLETE 中断
+//!     - CARD_INT: mask 信号 + 调用回调（通知 WiFi 驱动有数据可读）
+//!     - XFER_COMPLETE: mask 信号 + 调用 PIO 唤醒回调（唤醒阻塞的任务）
+//!   - PIO: CviSdhci 的 wait_* 方法在 Phase 1 直接轮询 INT_STATUS 寄存器，
+//!     Phase 2 通过中断驱动等待（block_timeout）
+//!
+//! # Single-core assumption
+//!
+//! SIG_EN 的 RMW（task 侧 unmask 与 ISR 侧 mask）在单 hart 上仍可能被中断
+//! 抢占：ISR 可能在 task 的 `mmio_read` 和 `mmio_write` 之间触发。此竞态
+//! 由 XFER_COMPLETE sticky bit 自愈——即使 SIG_EN 被错误重写，电平触发的中断线
+//! 会在 task 阻塞后重新断言、ISR 重新触发。最坏情况退化为一次 10ms 超时。
+//! SMP 平台需额外围栏和 per-hart INT_STATUS 分离。
 
 use core::sync::atomic::{AtomicU16, AtomicU64, AtomicUsize, Ordering};
 
 use crate::{mmio_read, mmio_write, regs::*};
+
+/// Callback slot: stores a function pointer for ISR invocation.
+///
+/// Uses `AtomicUsize` because `fn()` is pointer-width on all supported
+/// targets (riscv64, aarch64, x86_64). A zero value means unregistered;
+/// the ISR guards against this.
+struct CallbackSlot {
+    ptr: AtomicUsize,
+}
+
+impl CallbackSlot {
+    const fn new() -> Self {
+        Self {
+            ptr: AtomicUsize::new(0),
+        }
+    }
+
+    /// Register a callback. Call once during init before IRQs are enabled.
+    fn register(&self, cb: fn()) {
+        self.ptr.store(cb as usize, Ordering::Release);
+    }
+
+    /// Invoke the registered callback, if any.
+    ///
+    /// # Safety
+    ///
+    /// - The stored value must be a valid `fn()` previously stored via
+    ///   `register`. A zero value (empty slot) is guarded and does not
+    ///   invoke the callback.
+    /// - Single-core assumption: no concurrent store to this slot from another
+    ///   hart while the callback is being invoked.
+    /// - The callback runs in hard-IRQ context on the calling hart and must not
+    ///   allocate, hold locks, schedule, or call `log` macros that synchronously
+    ///   write UART.
+    unsafe fn invoke(&self) {
+        let v = self.ptr.load(Ordering::Acquire);
+        if v != 0 {
+            // SAFETY: v was stored as `cb as usize` by register().
+            // fn() and usize are the same size on all supported targets.
+            let cb: fn() = unsafe { core::mem::transmute::<usize, fn()>(v) };
+            cb();
+        }
+    }
+}
 
 /// SDHCI 中断全局状态
 struct SdhciIrqState {
     /// SDHCI MMIO 基地址（ISR 裸写用）
     base: AtomicUsize,
     /// CARD_INT 回调（通知上层驱动有数据可读）
-    card_irq_callback: AtomicUsize, // fn() 的裸指针
+    card_irq_callback: CallbackSlot,
+    /// XFER_COMPLETE PIO 唤醒回调（唤醒阻塞在 block_timeout 的任务）
+    pio_wake_callback: CallbackSlot,
 }
 
 impl SdhciIrqState {
     const fn new() -> Self {
         Self {
             base: AtomicUsize::new(0),
-            card_irq_callback: AtomicUsize::new(0),
+            card_irq_callback: CallbackSlot::new(),
+            pio_wake_callback: CallbackSlot::new(),
         }
     }
 }
@@ -42,14 +99,24 @@ pub fn irq_state_init(base: usize) {
 /// WiFi 驱动初始化时调用，注册一个函数用于在 ISR 中通知"卡有数据可读"。
 /// 回调在硬中断上下文执行，禁止：持锁、分配堆、调度、调用 log。
 pub fn register_card_irq_callback(cb: fn()) {
-    SDHCI_IRQ_STATE
-        .card_irq_callback
-        .store(cb as usize, Ordering::Release);
+    SDHCI_IRQ_STATE.card_irq_callback.register(cb);
 }
 
-/// 使能 CARD_INT 中断信号（ISR 仅处理 CARD_INT，PIO 事件由轮询处理）
+/// 注册 PIO 唤醒回调函数
+///
+/// OS 胶水层在初始化时调用，注册一个函数用于在 ISR 中唤醒阻塞在
+/// `block_timeout` 上的任务。回调在硬中断上下文执行，禁止：持锁、分配堆、
+/// 调度、调用 log。
+pub fn register_pio_wake_callback(cb: fn()) {
+    SDHCI_IRQ_STATE.pio_wake_callback.register(cb);
+}
+
+/// 使能 CARD_INT 中断信号（XFER_COMPLETE 由 poll_int_status 动态 un-mask）
 pub fn enable_irq_signals() {
     let base = SDHCI_IRQ_STATE.base.load(Ordering::Acquire);
+    if base == 0 {
+        return;
+    }
     mmio_write::<u16>(base + SDHCI_NORM_INT_SIG_EN as usize, NORM_INT_SIG_MASK);
     mmio_write::<u16>(base + SDHCI_ERR_INT_SIG_EN as usize, ERR_INT_SIG_MASK);
 }
@@ -57,24 +124,56 @@ pub fn enable_irq_signals() {
 /// 禁用所有 SDHCI 中断信号
 pub fn disable_irq_signals() {
     let base = SDHCI_IRQ_STATE.base.load(Ordering::Acquire);
+    if base == 0 {
+        return;
+    }
     mmio_write::<u16>(base + SDHCI_NORM_INT_SIG_EN as usize, 0);
     mmio_write::<u16>(base + SDHCI_ERR_INT_SIG_EN as usize, 0);
 }
 
-/// 屏蔽/恢复 CARD_INT 信号（裸地址操作，ISR 安全）
-pub(crate) fn mask_card_irq_raw(base: usize, mask: bool) {
+// ── SIG_EN 寄存器 RMW 辅助函数 ──
+//
+// 所有 SIG_EN 的 read-modify-write 操作集中在此，
+// 方便审查单核竞态假设和未来 SMP 适配。
+// 注意：enable_irq_signals/disable_irq_signals 是全量写入（reset 语义），不属于 RMW。
+
+/// Read-Modify-Write on `SDHCI_NORM_INT_SIG_EN`.
+///
+/// RMW 本身不是原子的（可能被 ISR 抢占），但设计依赖 XFER_COMPLETE sticky bit
+/// 自愈：即使本次写入携带过期值，中断线在 task 阻塞后重新断言，ISR 重新触发。
+fn rmw_norm_sig_en(base: usize, set: u16, clear: u16) {
     let addr = base + SDHCI_NORM_INT_SIG_EN as usize;
     let cur = mmio_read::<u16>(addr);
-    mmio_write::<u16>(
-        addr,
-        (cur & !NORM_INT_CARD_INT) | (!mask as u16 * NORM_INT_CARD_INT),
-    );
+    mmio_write::<u16>(addr, (cur & !clear) | set);
+}
+
+/// 启用 XFER_COMPLETE 中断信号（在 poll_int_status 阻塞前调用）
+///
+/// 注意：SDHCI ISR 收到 XFER_COMPLETE 后会立即 mask 掉该信号，
+/// 因此每次阻塞前都需要重新调用此函数。
+pub fn unmask_xfer_complete_signal() {
+    let base = SDHCI_IRQ_STATE.base.load(Ordering::Acquire);
+    if base == 0 {
+        return;
+    }
+    rmw_norm_sig_en(base, NORM_INT_XFER_COMPLETE, 0);
+}
+
+/// 屏蔽/恢复 CARD_INT 信号（裸地址操作，ISR 安全）
+pub(crate) fn mask_card_irq_raw(base: usize, mask: bool) {
+    if mask {
+        rmw_norm_sig_en(base, 0, NORM_INT_CARD_INT);
+    } else {
+        rmw_norm_sig_en(base, NORM_INT_CARD_INT, 0);
+    }
 }
 
 /// SDHCI 中断处理函数（注册到 PLIC）
 ///
-/// 只处理 CARD_INT：mask 信号 + 调用回调。
-/// PIO 事件（CMD_COMPLETE / BUF_RD_READY / XFER_COMPLETE）由 wait 函数直接轮询。
+/// 处理两种中断：
+/// - CARD_INT: mask 信号 + 调用回调（通知 WiFi 驱动有数据可读）
+/// - XFER_COMPLETE: mask 信号 + 调用 PIO 唤醒回调（不消费锁存位，由任务端 W1C）
+///   PIO 事件（CMD_COMPLETE / BUF_RD_READY / BUF_WR_READY）由 wait 函数 Phase 1 直接轮询。
 pub fn sdhci_irq_handler(_irq: usize) {
     SDHCI_IRQ_COUNT.fetch_add(1, Ordering::Relaxed);
 
@@ -94,9 +193,26 @@ pub fn sdhci_irq_handler(_irq: usize) {
     if norm & NORM_INT_CARD_INT != 0 {
         SDHCI_CARD_INT_COUNT.fetch_add(1, Ordering::Relaxed);
         mask_card_irq_raw(base, true);
-        let cb = SDHCI_IRQ_STATE.card_irq_callback.load(Ordering::Acquire);
-        if cb != 0 {
-            unsafe { core::mem::transmute::<usize, fn()>(cb)() };
-        }
+        // SAFETY: CARD_INT callback is registered once during init via
+        // register_card_irq_callback. Single-core: no concurrent store.
+        unsafe { SDHCI_IRQ_STATE.card_irq_callback.invoke() };
+    }
+
+    // Handle XFER_COMPLETE: mask signal, then wake blocked task.
+    // The sticky status bit is NOT cleared here — the task observes and
+    // W1C-clears it after wake. Clearing it here would destroy the
+    // wake condition and cause guaranteed 200ms timeout.
+    // XFER_COMPLETE is normally only enabled in SIG_EN while a task is
+    // blocked in poll_int_status (see unmask_xfer_complete_signal), so
+    // this path is idle in steady state. After a race-guard win or timeout
+    // the SIG_EN bit may briefly remain set; the resulting spurious ISR
+    // re-masks and notifies harmlessly.
+    if norm & NORM_INT_XFER_COMPLETE != 0 {
+        // Mask the XFER_COMPLETE signal to prevent re-firing
+        rmw_norm_sig_en(base, 0, NORM_INT_XFER_COMPLETE);
+        // Wake the blocked task (status bit stays sticky for task to observe)
+        // SAFETY: PIO wake callback is registered once during init via
+        // register_pio_wake_callback. Single-core: no concurrent store.
+        unsafe { SDHCI_IRQ_STATE.pio_wake_callback.invoke() };
     }
 }

--- a/components/sdhci-cv1800/src/irq.rs
+++ b/components/sdhci-cv1800/src/irq.rs
@@ -5,15 +5,21 @@
 //!     - CARD_INT: mask 信号 + 调用回调（通知 WiFi 驱动有数据可读）
 //!     - XFER_COMPLETE: mask 信号 + 调用 PIO 唤醒回调（唤醒阻塞的任务）
 //!   - PIO: CviSdhci 的 wait_* 方法在 Phase 1 直接轮询 INT_STATUS 寄存器，
-//!     Phase 2 通过中断驱动等待（block_timeout）
+//!     Phase 2 通过中断驱动等待（block_timeout_until）
 //!
 //! # Single-core assumption
 //!
 //! SIG_EN 的 RMW（task 侧 unmask 与 ISR 侧 mask）在单 hart 上仍可能被中断
-//! 抢占：ISR 可能在 task 的 `mmio_read` 和 `mmio_write` 之间触发。此竞态
-//! 由 XFER_COMPLETE sticky bit 自愈——即使 SIG_EN 被错误重写，电平触发的中断线
-//! 会在 task 阻塞后重新断言、ISR 重新触发。最坏情况退化为一次 10ms 超时。
-//! SMP 平台需额外围栏和 per-hart INT_STATUS 分离。
+//! 抢占：ISR 可能在 task 的 `mmio_read` 和 `mmio_write` 之间触发，task 的
+//! 过期值可能重写 SIG_EN。此竞态不会丢事件：XFER_COMPLETE sticky 位由等待
+//! 任务独占消费（ISR 从不 W1C），且 `block_timeout_until` 的条件检查与任务
+//! 入队在同一关中断临界区内衔接——ISR 无论发生在锁内条件检查前（notify
+//! 落空，sticky 位被条件观察到）、检查后入队前（不可能，同一关中断临界区）
+//! 还是入队后（notify 命中队列），事件都不会错过。SIG_EN 被过期值重写
+//! 最多产生一次多余 ISR（读状态无 XFER 位则空转）。SMP 平台下跨 hart 的
+//! ISR 可在检查与入队之间触发（notify 落空、退化为有界 10ms 超时），需
+//! 额外围栏和 per-hart INT_STATUS 分离；wifi_glue 的单核 debug_assert
+//! 在 release 构建中被编译掉，不构成运行时防护。
 
 use core::sync::atomic::{AtomicU16, AtomicU64, AtomicUsize, Ordering};
 
@@ -65,7 +71,7 @@ struct SdhciIrqState {
     base: AtomicUsize,
     /// CARD_INT 回调（通知上层驱动有数据可读）
     card_irq_callback: CallbackSlot,
-    /// XFER_COMPLETE PIO 唤醒回调（唤醒阻塞在 block_timeout 的任务）
+    /// XFER_COMPLETE PIO 唤醒回调（唤醒阻塞在 block_timeout_until 的任务）
     pio_wake_callback: CallbackSlot,
 }
 
@@ -101,7 +107,7 @@ pub fn register_card_irq_callback(cb: fn()) {
 /// 注册 PIO 唤醒回调函数
 ///
 /// OS 胶水层在初始化时调用，注册一个函数用于在 ISR 中唤醒阻塞在
-/// `block_timeout` 上的任务。回调在硬中断上下文执行，禁止：持锁、分配堆、
+/// `block_timeout_until` 上的任务。回调在硬中断上下文执行，禁止：持锁、分配堆、
 /// 调度、调用 log。
 pub fn register_pio_wake_callback(cb: fn()) {
     SDHCI_IRQ_STATE.pio_wake_callback.register(cb);
@@ -199,7 +205,7 @@ pub fn sdhci_irq_handler(_irq: usize) {
     // 若在此清除会破坏唤醒条件并导致必然的 200ms 超时。
     // XFER_COMPLETE 通常仅在任务阻塞于 poll_int_status 时才在 SIG_EN 中
     // 使能（见 unmask_xfer_complete_signal），因此此路径在稳态时空闲。
-    // 在 race-guard 胜出或超时后 SIG_EN 位可能短暂保持置位；
+    // 在 pre-check 快路径命中或超时退出后 SIG_EN 位可能短暂保持置位；
     // 由此产生的多余 ISR 重新 mask 并通知，无害。
     if norm & NORM_INT_XFER_COMPLETE != 0 {
         // Mask XFER_COMPLETE 信号以防重复触发

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -118,28 +118,26 @@ impl CviSdhci {
         }
     }
 
-    /// W1C-clear only the given bits in INT_STATUS_NORM.
-    /// Never clears CARD_INT — that is exclusively managed by the ISR/mask protocol.
+    /// 仅 W1C 清除 INT_STATUS_NORM 中指定的位。
+    /// 绝不清除 CARD_INT——该位由 ISR/mask 协议独占管理。
     fn clear_int_status_norm(&self, bits: u16) {
         self.write::<u16>(SDHCI_INT_STATUS_NORM, bits);
     }
 
-    /// Poll INT_STATUS once: check for error or the wanted bit, consuming on match.
-    /// Returns:
-    /// - `Some(Ok(()))` if the wanted bit is set (W1C cleared)
-    /// - `Some(Err(...))` if an error interrupt is detected (W1C cleared + DAT reset)
-    /// - `None` if neither condition is met (keep polling/waiting)
+    /// 轮询 INT_STATUS 一次：检查错误或目标位，命中时消费。
+    /// 返回：
+    /// - `Some(Ok(()))` 目标位置位（W1C 清除）
+    /// - `Some(Err(...))` 检测到错误中断（W1C 清除 + DAT 复位）
+    /// - `None` 两个条件均未满足（继续轮询/等待）
     fn poll_status_once(&self, bit: u16) -> Option<Result<(), SdioError>> {
         let norm = self.read::<u16>(SDHCI_INT_STATUS_NORM);
         if norm & NORM_INT_ERROR != 0 {
             let err = self.read::<u16>(SDHCI_INT_STATUS_ERR);
             self.write::<u16>(SDHCI_INT_STATUS_ERR, err);
-            // Selective clear: error bits + waited bit + XFER_COMPLETE.
-            // XFER_COMPLETE may be asserted concurrently with an error
-            // (e.g. DAT error after data-phase completion).  Consuming it
-            // here prevents a stale bit from leaking into the next
-            // transfer's wait_transfer_complete as a false early success.
-            // CARD_INT is intentionally preserved (ISR/mask protocol).
+            // 选择性清除：错误位 + 等待位 + XFER_COMPLETE。
+            // XFER_COMPLETE 可能与错误同时被置位（如数据阶段完成后 DAT 错误）。
+            // 在此消费可防止 stale bit 泄漏至下一传输的 wait_transfer_complete
+            // 导致虚假过早成功。CARD_INT 有意保留（ISR/mask 协议）。
             self.clear_int_status_norm(NORM_INT_ERROR | bit | NORM_INT_XFER_COMPLETE);
             self.reset_dat_line();
             return Some(Err(Self::classify_error(err)));
@@ -160,18 +158,14 @@ impl CviSdhci {
     /// 读取 ERR_STATUS，选择性 W1C 清除错误位 + 当前等待位（保留 CARD_INT），
     /// 然后复位 DAT 线并返回错误。
     fn poll_int_status(&self, bit: u16) -> Result<(), SdioError> {
-        // Drain the store buffer before entering the Phase 1 spin loop.
-        // Without this fence, pending MMIO writes (e.g. pio_write's 128
-        // stores to SDHCI_BUFFER) can still be queued in the CPU's store
-        // buffer when the following mmio_read(INT_STATUS_NORM) loop begins.
-        // The reads then compete with the draining writes on the SDHCI bus,
-        // delaying the hardware from actually receiving the data and
-        // asserting BUF_WR_READY / CMD_COMPLETE.  Phase 1's 1000-iteration
-        // window (≈50 µs) can then expire before the status bit becomes
-        // visible, causing a fall-through into the 10 ms Phase 2 delay.
-        // A single fence here guarantees the store buffer is empty before
-        // polling starts — the same effect that task-switch implied fences
-        // (mret) provided in the old yield_now-based busy-wait scheme.
+        // 在进入 Phase 1 自旋循环前排空存储缓冲区。
+        // 若无此栅栏，待处理的 MMIO 写（如 pio_write 的 128 次 SDHCI_BUFFER
+        // 写入）可能仍排在 CPU 存储缓冲区中，而此时后续的
+        // mmio_read(INT_STATUS_NORM) 循环已开始。读取与排空写入在 SDHCI
+        // 总线上竞争，延迟硬件实际接收数据并置位 BUF_WR_READY/CMD_COMPLETE。
+        // Phase 1 的 1000 次迭代窗口（约 50µs）可能在状态位可见前过期，
+        // 导致落入 10ms Phase 2 延迟。此处单一栅栏保证轮询开始前存储缓冲区
+        // 已空——与旧 yield_now 忙等待方案中任务切换隐含栅栏（mret）效果相同。
         core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
 
         // Phase 1: 快速自旋
@@ -316,16 +310,16 @@ impl CviSdhci {
         }
     }
 
-    /// Clear stale INT_STATUS bits before starting a command.
+    /// 在启动命令前清除残留的 INT_STATUS 位。
     ///
-    /// Uses selective W1C: preserves XFER_COMPLETE (may be consumed by a task
-    /// blocked in `poll_int_status` Phase 2).  The ISR does not clear
-    /// XFER_COMPLETE either — only the waiting task's recheck in
-    /// `poll_int_status` may consume it.
+    /// 使用选择性 W1C：保留 XFER_COMPLETE（可能被阻塞在
+    /// `poll_int_status` Phase 2 的任务消费）。ISR 同样不清除
+    /// XFER_COMPLETE——仅等待任务的 recheck 在 `poll_int_status`
+    /// 中可消费它。
     fn clear_stale_status(&self) {
         let norm = self.read::<u16>(SDHCI_INT_STATUS_NORM);
-        // Mask out XFER_COMPLETE — it belongs to a potentially blocked PIO
-        // waiter and must not be destroyed by the command path.
+        // Mask 掉 XFER_COMPLETE——它属于可能阻塞的 PIO waiter，
+        // 不得被命令路径破坏。
         let clearable = norm & !NORM_INT_XFER_COMPLETE;
         if clearable != 0 {
             if clearable & NORM_INT_ERROR != 0 {
@@ -621,10 +615,10 @@ impl CviSdhci {
     /// XFER_COMPLETE 信号由 poll_int_status 阻塞前通过 unmask_xfer_complete_signal 动态启用。
     fn enable_interrupts_irq(&self) -> Result<(), SdioError> {
         irq::irq_state_init(self.base);
-        // Status Enable: 使能所有状态位 (用于 poll_int_status 轮询)
+        // 状态使能：使能所有状态位（用于 poll_int_status 轮询）
         self.write::<u16>(SDHCI_NORM_INT_STS_EN, NORM_INT_ENABLE_MASK);
         self.write::<u16>(SDHCI_ERR_INT_STS_EN, ERR_INT_ENABLE_MASK);
-        // Signal Enable: 仅使能 CARD_INT；XFER_COMPLETE 由 poll_int_status 动态 un-mask
+        // 信号使能：仅使能 CARD_INT；XFER_COMPLETE 由 poll_int_status 动态 un-mask
         irq::enable_irq_signals();
         Ok(())
     }

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -22,7 +22,10 @@ pub mod regs;
 pub mod runtime;
 
 use alloc::sync::Arc;
-use core::ptr::{read_volatile, write_volatile};
+use core::{
+    ptr::{read_volatile, write_volatile},
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 pub use runtime::{SdhciDelay, set_delay};
 use sdio_host::{SdioCardIrq, SdioHost, cccr::*, cmd::*, error::SdioError};
@@ -37,6 +40,167 @@ const PHASE2_STEP_MS: u64 = 10;
 const PHASE2_MAX_ITERS: u32 = 20;
 /// Phase 2 中段警告阈值（迭代次数）
 const PHASE2_WARN_AT: u32 = 10;
+
+// ── 诊断计数器：追踪 poll_int_status 每个中断位的 Phase 1/2 命中率 ──
+
+const DIAG_CMD_COMPLETE: usize = 0;
+const DIAG_XFER_COMPLETE: usize = 1;
+const DIAG_BUF_WR_READY: usize = 2;
+const DIAG_BUF_RD_READY: usize = 3;
+const DIAG_NUM_SLOTS: usize = 4;
+const DIAG_NONE: usize = DIAG_NUM_SLOTS;
+
+struct PollBitDiag {
+    total: AtomicU64,
+    phase1_hits: AtomicU64,
+    /// Cumulative wall-clock nanos spent in Phase 1 (from entry to resolve).
+    phase1_ns: AtomicU64,
+    phase2_entries: AtomicU64,
+    /// Cumulative wall-clock nanos spent in Phase 2 for successful resolves.
+    /// Excludes errors and the timeout path.
+    phase2_ns: AtomicU64,
+    /// Sum of `timeout_count` at each successful Phase 2 resolve.
+    /// Excludes errors and the timeout path.
+    phase2_iters: AtomicU64,
+    timeouts: AtomicU64,
+    /// Errors detected inside poll_status_once (SDIO bus errors), split by phase.
+    phase1_errors: AtomicU64,
+    phase2_errors: AtomicU64,
+}
+
+impl PollBitDiag {
+    const fn new() -> Self {
+        Self {
+            total: AtomicU64::new(0),
+            phase1_hits: AtomicU64::new(0),
+            phase1_ns: AtomicU64::new(0),
+            phase2_entries: AtomicU64::new(0),
+            phase2_ns: AtomicU64::new(0),
+            phase2_iters: AtomicU64::new(0),
+            timeouts: AtomicU64::new(0),
+            phase1_errors: AtomicU64::new(0),
+            phase2_errors: AtomicU64::new(0),
+        }
+    }
+
+    fn reset(&self) {
+        self.total.store(0, Ordering::Relaxed);
+        self.phase1_hits.store(0, Ordering::Relaxed);
+        self.phase1_ns.store(0, Ordering::Relaxed);
+        self.phase2_entries.store(0, Ordering::Relaxed);
+        self.phase2_ns.store(0, Ordering::Relaxed);
+        self.phase2_iters.store(0, Ordering::Relaxed);
+        self.timeouts.store(0, Ordering::Relaxed);
+        self.phase1_errors.store(0, Ordering::Relaxed);
+        self.phase2_errors.store(0, Ordering::Relaxed);
+    }
+}
+
+static POLL_DIAG: [PollBitDiag; DIAG_NUM_SLOTS] = [
+    PollBitDiag::new(),
+    PollBitDiag::new(),
+    PollBitDiag::new(),
+    PollBitDiag::new(),
+];
+
+fn diag_slot(bit: u16) -> usize {
+    match bit {
+        NORM_INT_CMD_COMPLETE => DIAG_CMD_COMPLETE,
+        NORM_INT_XFER_COMPLETE => DIAG_XFER_COMPLETE,
+        NORM_INT_BUF_WR_READY => DIAG_BUF_WR_READY,
+        NORM_INT_BUF_RD_READY => DIAG_BUF_RD_READY,
+        _ => DIAG_NONE,
+    }
+}
+
+fn diag_name(slot: usize) -> &'static str {
+    match slot {
+        DIAG_CMD_COMPLETE => "CMD_COMPLETE",
+        DIAG_XFER_COMPLETE => "XFER_COMPLETE",
+        DIAG_BUF_WR_READY => "BUF_WR_READY",
+        DIAG_BUF_RD_READY => "BUF_RD_READY",
+        _ => "?",
+    }
+}
+
+/// Dump per-interrupt-bit poll diagnostics via `log::info`.
+///
+/// Each line reports: total calls, Phase 1 hits + avg wall time, Phase 2
+/// entries / hits + rate + avg wall time + avg iters, timeouts, per-phase errors.
+/// Also prints the IRQ counts and SDHCI clock frequency.
+///
+/// Call this after an iperf3 run to see which bits fall through to the safety
+/// net. Counters are reset after the dump; call [`reset_poll_diagnostics`] to
+/// reset mid-epoch without printing.
+pub fn dump_poll_diagnostics() {
+    for (slot, d) in POLL_DIAG.iter().enumerate() {
+        let total = d.total.load(Ordering::Relaxed);
+        if total == 0 {
+            continue;
+        }
+        let p1 = d.phase1_hits.load(Ordering::Relaxed);
+        let p1_ns = d.phase1_ns.load(Ordering::Relaxed);
+        let p2_entries = d.phase2_entries.load(Ordering::Relaxed);
+        let p2_ns = d.phase2_ns.load(Ordering::Relaxed);
+        let p2_iters = d.phase2_iters.load(Ordering::Relaxed);
+        let timeouts = d.timeouts.load(Ordering::Relaxed);
+        let p1_err = d.phase1_errors.load(Ordering::Relaxed);
+        let p2_err = d.phase2_errors.load(Ordering::Relaxed);
+        // Phase 2 hits = entered Phase 2, resolved Ok (not timeout, not error).
+        let p2_hits = total
+            .saturating_sub(p1)
+            .saturating_sub(timeouts)
+            .saturating_sub(p1_err)
+            .saturating_sub(p2_err);
+        let p2_rate = (p2_entries as f64 / total as f64) * 100.0;
+        let avg_p1_us = if p1 > 0 {
+            p1_ns as f64 / p1 as f64 / 1000.0
+        } else {
+            0.0
+        };
+        let avg_p2_us = if p2_hits > 0 {
+            p2_ns as f64 / p2_hits as f64 / 1000.0
+        } else {
+            0.0
+        };
+        let avg_iters = if p2_hits > 0 {
+            p2_iters as f64 / p2_hits as f64
+        } else {
+            0.0
+        };
+        log::info!(
+            "[SDHCI-diag] {}: total={} p1={} (avg {:.0}us) p2_entry={} p2_hit={} p2_rate={:.1}% \
+             avg_p2={:.0}us avg_p2_iters={:.1} to={} p1err={} p2err={}",
+            diag_name(slot),
+            total,
+            p1,
+            avg_p1_us,
+            p2_entries,
+            p2_hits,
+            p2_rate,
+            avg_p2_us,
+            avg_iters,
+            timeouts,
+            p1_err,
+            p2_err,
+        );
+    }
+    log::info!(
+        "[SDHCI-diag] IRQ: total={} card_int={} clk={}MHz",
+        irq::SDHCI_IRQ_COUNT.load(Ordering::Relaxed),
+        irq::SDHCI_CARD_INT_COUNT.load(Ordering::Relaxed),
+        HIGH_SPEED_CLOCK_HZ / 1_000_000,
+    );
+    reset_poll_diagnostics();
+}
+
+/// Reset all per-bit diagnostic counters to zero.
+/// Call before starting a new measurement epoch (e.g., before iperf3).
+pub fn reset_poll_diagnostics() {
+    for d in POLL_DIAG.iter() {
+        d.reset();
+    }
+}
 
 #[inline]
 pub(crate) fn delay_ms(ms: u64) {
@@ -155,13 +319,46 @@ impl CviSdhci {
     /// 同时检测 Error 中断：如果 ERROR bit (bit 15) 置位，
     /// 读取 ERR_STATUS 并 W1C 清除所有状态位，然后返回错误。
     fn poll_int_status(&self, bit: u16) -> Result<(), SdioError> {
+        let slot = diag_slot(bit);
+        let t_entry = if slot < DIAG_NUM_SLOTS {
+            crate::runtime::delay().now_nanos()
+        } else {
+            0
+        };
+
         // Phase 1: 快速自旋
         for _ in 0..PHASE1_SPIN_ITERS {
             if let Some(result) = self.poll_status_once(bit) {
+                if slot < DIAG_NUM_SLOTS {
+                    let elapsed = crate::runtime::delay().now_nanos().saturating_sub(t_entry);
+                    if result.is_ok() {
+                        POLL_DIAG[slot].phase1_hits.fetch_add(1, Ordering::Relaxed);
+                        POLL_DIAG[slot]
+                            .phase1_ns
+                            .fetch_add(elapsed, Ordering::Relaxed);
+                    } else {
+                        POLL_DIAG[slot]
+                            .phase1_errors
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    POLL_DIAG[slot].total.fetch_add(1, Ordering::Relaxed);
+                }
                 return result;
             }
             core::hint::spin_loop();
         }
+
+        if slot < DIAG_NUM_SLOTS {
+            POLL_DIAG[slot]
+                .phase2_entries
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        let t_p2_entry = if slot < DIAG_NUM_SLOTS {
+            crate::runtime::delay().now_nanos()
+        } else {
+            0
+        };
+
         // Phase 2: XFER_COMPLETE 走硬件中断驱动等待；其他位走纯超时睡眠
         // （不经过 WaitQueue——ISR 不会为这些位发 notify，经过 WQ 是无效开销）
         let use_irq = bit == NORM_INT_XFER_COMPLETE;
@@ -171,6 +368,24 @@ impl CviSdhci {
             // 注意：pre-check 不能关闭 unmask→block 之间的丢唤醒窗口，
             // 真正的防护是 XFER_COMPLETE sticky bit + post-wake recheck。
             if let Some(result) = self.poll_status_once(bit) {
+                if slot < DIAG_NUM_SLOTS {
+                    let elapsed = crate::runtime::delay()
+                        .now_nanos()
+                        .saturating_sub(t_p2_entry);
+                    if result.is_ok() {
+                        POLL_DIAG[slot]
+                            .phase2_iters
+                            .fetch_add(timeout_count as u64, Ordering::Relaxed);
+                        POLL_DIAG[slot]
+                            .phase2_ns
+                            .fetch_add(elapsed, Ordering::Relaxed);
+                    } else {
+                        POLL_DIAG[slot]
+                            .phase2_errors
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    POLL_DIAG[slot].total.fetch_add(1, Ordering::Relaxed);
+                }
                 return result;
             }
 
@@ -199,9 +414,34 @@ impl CviSdhci {
 
             // 被唤醒后检查状态寄存器
             if let Some(result) = self.poll_status_once(bit) {
+                if slot < DIAG_NUM_SLOTS {
+                    let elapsed = crate::runtime::delay()
+                        .now_nanos()
+                        .saturating_sub(t_p2_entry);
+                    if result.is_ok() {
+                        POLL_DIAG[slot]
+                            .phase2_iters
+                            .fetch_add(timeout_count as u64, Ordering::Relaxed);
+                        POLL_DIAG[slot]
+                            .phase2_ns
+                            .fetch_add(elapsed, Ordering::Relaxed);
+                    } else {
+                        POLL_DIAG[slot]
+                            .phase2_errors
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    POLL_DIAG[slot].total.fetch_add(1, Ordering::Relaxed);
+                }
                 return result;
             }
         }
+
+        // 超时
+        if slot < DIAG_NUM_SLOTS {
+            POLL_DIAG[slot].timeouts.fetch_add(1, Ordering::Relaxed);
+            POLL_DIAG[slot].total.fetch_add(1, Ordering::Relaxed);
+        }
+
         let pres = self.read::<u32>(SDHCI_PRESENT_STATE);
         let sts = self.read::<u16>(SDHCI_INT_STATUS_NORM);
         log::error!(

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -9,8 +9,13 @@
 //! 设计:
 //!   - ISR: 处理 CARD_INT (通知 WiFi 驱动) + XFER_COMPLETE (唤醒阻塞任务)
 //!   - PIO: wait_* 方法 Phase 1 轮询 INT_STATUS, Phase 2 中断驱动等待
-//!   - 单核串行化: ISR 与任务在单 hart 上执行。SIG_EN RMW 仍可被 ISR 抢占，
-//!     但依赖 XFER_COMPLETE sticky bit 自愈（详见 irq.rs 模块文档）。
+//!   - 丢唤醒防护: Phase 2 阻塞走 `SdhciDelay::block_timeout_until`，
+//!     条件检查与任务入队在同一关中断临界区内衔接，配合 ISR 不消费的
+//!     XFER_COMPLETE sticky 位——ISR 无论在锁内检查前触发（notify 落空、
+//!     sticky 位被观察到）、检查后入队前（不可能，临界区关中断）还是
+//!     入队后（notify 命中队列），事件都不会错过。
+//!   - 单核串行化: ISR 与任务在单 hart 上执行。SIG_EN RMW 仍可被 ISR
+//!     抢占，但事件由 sticky 位锁存（详见 irq.rs 模块文档）。
 
 #![no_std]
 
@@ -183,9 +188,11 @@ impl CviSdhci {
         }
         let mut timeout_count: u32 = 0;
         for i in 0..PHASE2_MAX_ITERS {
-            // Race guard: 阻塞前先检查状态寄存器。
-            // 注意：pre-check 不能关闭 unmask→block 之间的丢唤醒窗口，
-            // 真正的防护是 XFER_COMPLETE sticky bit + post-wake recheck。
+            // 阻塞前先检查状态寄存器（快路径）。此 pre-check 不能单独关闭
+            // 丢唤醒窗口——真正的防护是下方的 block_timeout_until 协议：
+            // 条件检查与任务入队在同一关中断临界区内衔接，unmask 与入队
+            // 之间的 ISR 事件由 XFER_COMPLETE sticky 位保留并被锁内条件
+            // 检查观察到（见 SdhciDelay 契约）。
             if let Some(result) = self.poll_status_once(bit) {
                 return result;
             }
@@ -205,7 +212,25 @@ impl CviSdhci {
 
             if use_irq {
                 irq::unmask_xfer_complete_signal();
-                let _timed_out = crate::runtime::delay().block_timeout(PHASE2_STEP_MS);
+                // 条件等待：ISR 若在 unmask 后、锁内检查前触发，其 notify
+                // 落空（队列为空），但它 latch 的 sticky 位会被胶水层锁内
+                // 条件检查立即观察到，任务无需等满超时。错误位也纳入条件：
+                // 错误不产生中断（SIG_EN 不含 error 位），锁内检查前已锁存
+                // 的错误可即时返回；睡期中段到达的错误仍由 10ms 超时后的
+                // post-wake 重检查出，与旧实现时延一致。
+                let timed_out =
+                    crate::runtime::delay().block_timeout_until(PHASE2_STEP_MS, &|| {
+                        let norm = self.read::<u16>(SDHCI_INT_STATUS_NORM);
+                        norm & (bit | NORM_INT_ERROR) != 0
+                    });
+                // 返回值无需驱动分支——post-wake 重检无条件执行，覆盖两种
+                // 返回路径。仅在超时（10ms 退化路径）时留观测信号。
+                if timed_out {
+                    log::trace!(
+                        "[SDHCI] poll_int Phase-2 IRQ wait timed out: bit=0x{:04x}",
+                        bit
+                    );
+                }
             } else {
                 // 非 XFER 位：直接 sleep，不经过 WaitQueue——
                 // ISR 只对 XFER_COMPLETE 发 notify，经过 WQ 是无效开销。
@@ -876,5 +901,160 @@ impl SdioHost for CviSdhci {
 
     fn card_irq_ctrl(&self) -> Option<Arc<dyn SdioCardIrq>> {
         Some(Arc::new(CviCardIrqCtrl::new(self.base)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! 丢唤醒协议回归验证。
+    //!
+    //! 全局状态注意：`set_delay` 与 `irq_state_init` 安装的是进程级全局
+    //! provider/基地址，不同测试会相互覆盖，因此新增场景必须并入下面的
+    //! 单一测试函数内顺序执行。
+    //!
+    //! 建模局限（记录在案）：
+    //! - W1C 未建模：对 INT_STATUS 的写是直接覆写而非"写 1 清位"。
+    //!   当前断言（返回结果、零睡眠、SIG_EN 状态）不受影响；
+    //!   场景切换时由测试显式清零寄存器区。
+
+    use alloc::boxed::Box;
+    use core::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
+
+    use super::*;
+    use crate::runtime::{SdhciDelay, set_delay};
+
+    /// 泄漏一块寄存器缓冲区，仅以裸指针访问（避免与 `&mut` 别名）。
+    /// 32 × u64 = 256 字节，8 字节对齐保证 u16/u32 访问满足对齐要求。
+    fn fake_regs() -> usize {
+        Box::leak(Box::new([0u64; 0x20])) as *mut [u64; 0x20] as usize
+    }
+
+    /// 重放模式：窗口内 XFER ISR（mask + notify 落空）。
+    const MODE_XFER_ISR: u8 = 0;
+    /// 重放模式：错误位锁存（错误不产生 ISR，SIG_EN 不变）。
+    const MODE_ERROR_LATCH: u8 = 1;
+
+    /// 确定性重放 Phase 2 窗口内的硬件/ISR 事件的 fake 延时提供者。
+    ///
+    /// `block_timeout_until` 被调用时，重放事件已经发生（对应真实时序中
+    /// "unmask 之后、锁内条件检查之前"的窗口），随后按胶水层语义
+    /// （关中断临界区内）检查条件：
+    ///
+    /// - MODE_XFER_ISR：硬件置位 XFER_COMPLETE sticky 位，ISR mask 信号
+    ///   并 notify——此时任务尚未入队，notify 落空丢失。
+    /// - MODE_ERROR_LATCH：硬件锁存错误位（NORM_ERROR + DAT_TIMEOUT），
+    ///   错误不产生中断，无 ISR、无 mask。
+    struct FakeIrqDelay {
+        base: AtomicUsize,
+        slept_ms: AtomicU64,
+        mode: AtomicU8,
+    }
+
+    impl FakeIrqDelay {
+        fn replay_event_in_window(&self) {
+            let base = self.base.load(Ordering::Acquire);
+            let sig_en_addr = base + SDHCI_NORM_INT_SIG_EN as usize;
+            // 前置断言：unmask 必须先于阻塞发生（SIG_EN 已含 XFER 位），
+            // 拦截"block 先于 unmask"的顺序回归。
+            let sig_en = mmio_read::<u16>(sig_en_addr);
+            assert!(
+                sig_en & NORM_INT_XFER_COMPLETE != 0,
+                "unmask_xfer_complete_signal 必须先于 block_timeout_until 执行"
+            );
+
+            let norm_addr = base + SDHCI_INT_STATUS_NORM as usize;
+            let norm = mmio_read::<u16>(norm_addr);
+            match self.mode.load(Ordering::Acquire) {
+                MODE_ERROR_LATCH => {
+                    // 硬件锁存错误位；错误不产生中断，SIG_EN 不变。
+                    mmio_write::<u16>(norm_addr, norm | NORM_INT_ERROR);
+                    let err_addr = base + SDHCI_INT_STATUS_ERR as usize;
+                    let err = mmio_read::<u16>(err_addr);
+                    mmio_write::<u16>(err_addr, err | ERR_INT_DAT_TIMEOUT);
+                }
+                _ => {
+                    // 硬件在 unmask 后立即置位 XFER_COMPLETE sticky 位。
+                    mmio_write::<u16>(norm_addr, norm | NORM_INT_XFER_COMPLETE);
+                    // ISR mask XFER 信号（RMW 清除 XFER 位）。
+                    mmio_write::<u16>(sig_en_addr, sig_en & !NORM_INT_XFER_COMPLETE);
+                    // notify：队列为空，通知丢失（无动作）。
+                }
+            }
+        }
+    }
+
+    impl SdhciDelay for FakeIrqDelay {
+        fn delay_ms(&self, ms: u64) {
+            self.slept_ms.fetch_add(ms, Ordering::Relaxed);
+        }
+
+        fn block_timeout_until(&self, timeout_ms: u64, condition: &dyn Fn() -> bool) -> bool {
+            self.replay_event_in_window();
+            if condition() {
+                return false;
+            }
+            // 条件未观察到事件 → 协议失效路径：按真实语义睡满超时。
+            self.delay_ms(timeout_ms);
+            true
+        }
+    }
+
+    /// Phase 2 IRQ 等待的两个确定性回归场景：
+    ///
+    /// - 场景 A：ISR 在 unmask 之后、锁内检查之前触发（notify 落空），
+    ///   XFER_COMPLETE 等待必须即时返回，不得退化为睡满 10ms 超时兜底。
+    /// - 场景 B：错误位在锁内检查前锁存时，条件立即返回错误路径，
+    ///   且错误不产生 ISR。
+    #[test]
+    fn phase2_wait_lost_wakeup_and_error_latch_regressions() {
+        static FAKE_DELAY: FakeIrqDelay = FakeIrqDelay {
+            base: AtomicUsize::new(0),
+            slept_ms: AtomicU64::new(0),
+            mode: AtomicU8::new(MODE_XFER_ISR),
+        };
+
+        let base = fake_regs();
+        FAKE_DELAY.base.store(base, Ordering::Release);
+        FAKE_DELAY.slept_ms.store(0, Ordering::Relaxed);
+        set_delay(&FAKE_DELAY);
+        irq::irq_state_init(base);
+
+        let sdhci = CviSdhci::new(base);
+
+        // ── 场景 A：ISR 先于入队（notify 落空）──
+        FAKE_DELAY.mode.store(MODE_XFER_ISR, Ordering::Release);
+        let result = sdhci.poll_int_status(NORM_INT_XFER_COMPLETE);
+
+        assert_eq!(result, Ok(()));
+        // 关键断言：等待未落入 10ms 超时兜底——ISR 丢失的 notify 由
+        // 锁内条件检查对 sticky 位的观察补偿，事件即时消费。
+        assert_eq!(FAKE_DELAY.slept_ms.load(Ordering::Relaxed), 0);
+        // 锁定等待后 SIG_EN 的 XFER 位保持 mask 稳态——配合 replay 入口
+        // 断言（unmask 已置位）证明 unmask→ISR mask 序列完整执行。
+        let sig_en = mmio_read::<u16>(base + SDHCI_NORM_INT_SIG_EN as usize);
+        assert_eq!(sig_en & NORM_INT_XFER_COMPLETE, 0);
+
+        // ── 场景 B：错误位锁存（错误路径即时返回）──
+        // 先锁定 STS_EN 门控：enable_interrupts_irq 后 STS_EN 必须含
+        // NORM_INT_ERROR，否则错误场景在真实硬件上无意义（错误位不锁存）。
+        sdhci.enable_interrupts_irq().unwrap();
+        let sts_en = mmio_read::<u16>(base + SDHCI_NORM_INT_STS_EN as usize);
+        assert_ne!(
+            sts_en & NORM_INT_ERROR,
+            0,
+            "NORM_INT_ERROR 必须已加入 STS_EN 掩码，否则错误检测路径恒假"
+        );
+        // 清掉场景 A 的覆写残留（fake 不建模 W1C，见模块文档）。
+        mmio_write::<u16>(base + SDHCI_INT_STATUS_NORM as usize, 0);
+        FAKE_DELAY.mode.store(MODE_ERROR_LATCH, Ordering::Release);
+        FAKE_DELAY.slept_ms.store(0, Ordering::Relaxed);
+
+        let result = sdhci.poll_int_status(NORM_INT_XFER_COMPLETE);
+
+        assert_eq!(result, Err(SdioError::Timeout));
+        assert_eq!(FAKE_DELAY.slept_ms.load(Ordering::Relaxed), 0);
+        // 错误不产生 ISR：SIG_EN 的 XFER 位未被 mask。
+        let sig_en = mmio_read::<u16>(base + SDHCI_NORM_INT_SIG_EN as usize);
+        assert_ne!(sig_en & NORM_INT_XFER_COMPLETE, 0);
     }
 }

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -147,13 +147,14 @@ impl CviSdhci {
         None
     }
 
-    /// 直接轮询 INT_STATUS_NORM，等待指定 bit 置位后 W1C 清除
+    /// 轮询 INT_STATUS_NORM，等待指定 bit 置位后选择性 W1C 清除。
     ///
     /// Phase 1: 快速自旋 (PHASE1_SPIN_ITERS 次, ~50µs)
     /// Phase 2: XFER_COMPLETE 走硬件中断驱动等待；其他位使用 10ms 睡眠轮询
     ///
     /// 同时检测 Error 中断：如果 ERROR bit (bit 15) 置位，
-    /// 读取 ERR_STATUS 并 W1C 清除所有状态位，然后返回错误。
+    /// 读取 ERR_STATUS，选择性 W1C 清除错误位 + 当前等待位（保留 CARD_INT），
+    /// 然后复位 DAT 线并返回错误。
     fn poll_int_status(&self, bit: u16) -> Result<(), SdioError> {
         // Drain the store buffer before entering the Phase 1 spin loop.
         // Without this fence, pending MMIO writes (e.g. pio_write's 128
@@ -179,6 +180,9 @@ impl CviSdhci {
         // Phase 2: XFER_COMPLETE 走硬件中断驱动等待；其他位走纯超时睡眠
         // （不经过 WaitQueue——ISR 不会为这些位发 notify，经过 WQ 是无效开销）
         let use_irq = bit == NORM_INT_XFER_COMPLETE;
+        if !use_irq {
+            log::trace!("[SDHCI] poll_int Phase-2 fallback: bit=0x{:04x}", bit);
+        }
         let mut timeout_count: u32 = 0;
         for i in 0..PHASE2_MAX_ITERS {
             // Race guard: 阻塞前先检查状态寄存器。
@@ -307,17 +311,25 @@ impl CviSdhci {
         }
     }
 
-    /// Clear stale INT_STATUS bits (W1C clear all set bits)
+    /// Clear stale INT_STATUS bits before starting a command.
+    ///
+    /// Uses selective W1C: preserves XFER_COMPLETE (may be consumed by a task
+    /// blocked in `poll_int_status` Phase 2).  The ISR does not clear
+    /// XFER_COMPLETE either — only the waiting task's recheck in
+    /// `poll_int_status` may consume it.
     fn clear_stale_status(&self) {
         let norm = self.read::<u16>(SDHCI_INT_STATUS_NORM);
-        if norm != 0 {
-            if norm & NORM_INT_ERROR != 0 {
+        // Mask out XFER_COMPLETE — it belongs to a potentially blocked PIO
+        // waiter and must not be destroyed by the command path.
+        let clearable = norm & !NORM_INT_XFER_COMPLETE;
+        if clearable != 0 {
+            if clearable & NORM_INT_ERROR != 0 {
                 let err = self.read::<u16>(SDHCI_INT_STATUS_ERR);
                 if err != 0 {
                     self.write::<u16>(SDHCI_INT_STATUS_ERR, err);
                 }
             }
-            self.write::<u16>(SDHCI_INT_STATUS_NORM, norm);
+            self.write::<u16>(SDHCI_INT_STATUS_NORM, clearable);
         }
     }
 

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -3,13 +3,14 @@
 //! 职责:
 //!   - SDHCI 标准寄存器操作 (CMD52/CMD53/PIO)
 //!   - SDIO 卡枚举 (CMD5/CMD3/CMD7)
-//!   - 中断处理 (ISR 仅 CARD_INT, PIO 事件直接轮询 INT_STATUS)
+//!   - 中断处理 (ISR 处理 CARD_INT + XFER_COMPLETE)
 //!   - 时钟/电源/总线宽度配置
 //!
 //! 设计:
-//!   - ISR: 仅处理 CARD_INT (WiFi 芯片通知有数据可读)
-//!   - PIO: wait_* 方法直接轮询 INT_STATUS 寄存器，W1C 清除
-//!   - 分离 ISR/PIO 消除竞态条件
+//!   - ISR: 处理 CARD_INT (通知 WiFi 驱动) + XFER_COMPLETE (唤醒阻塞任务)
+//!   - PIO: wait_* 方法 Phase 1 轮询 INT_STATUS, Phase 2 中断驱动等待
+//!   - 单核串行化: ISR 与任务在单 hart 上执行。SIG_EN RMW 仍可被 ISR 抢占，
+//!     但依赖 XFER_COMPLETE sticky bit 自愈（详见 irq.rs 模块文档）。
 
 #![no_std]
 
@@ -27,6 +28,15 @@ pub use runtime::{SdhciDelay, set_delay};
 use sdio_host::{SdioCardIrq, SdioHost, cccr::*, cmd::*, error::SdioError};
 
 use crate::regs::*;
+
+/// Phase 1 快速自旋迭代次数（~50µs on C906 @1GHz）
+const PHASE1_SPIN_ITERS: u32 = 1000;
+/// Phase 2 单次等待时长 (ms)
+const PHASE2_STEP_MS: u64 = 10;
+/// Phase 2 最大迭代次数（总预算 = 20 × 10ms = 200ms）
+const PHASE2_MAX_ITERS: u32 = 20;
+/// Phase 2 中段警告阈值（迭代次数）
+const PHASE2_WARN_AT: u32 = 10;
 
 #[inline]
 pub(crate) fn delay_ms(ms: u64) {
@@ -108,65 +118,105 @@ impl CviSdhci {
         }
     }
 
+    /// W1C-clear only the given bits in INT_STATUS_NORM.
+    /// Never clears CARD_INT — that is exclusively managed by the ISR/mask protocol.
+    fn clear_int_status_norm(&self, bits: u16) {
+        self.write::<u16>(SDHCI_INT_STATUS_NORM, bits);
+    }
+
+    /// Poll INT_STATUS once: check for error or the wanted bit, consuming on match.
+    /// Returns:
+    /// - `Some(Ok(()))` if the wanted bit is set (W1C cleared)
+    /// - `Some(Err(...))` if an error interrupt is detected (W1C cleared + DAT reset)
+    /// - `None` if neither condition is met (keep polling/waiting)
+    fn poll_status_once(&self, bit: u16) -> Option<Result<(), SdioError>> {
+        let norm = self.read::<u16>(SDHCI_INT_STATUS_NORM);
+        if norm & NORM_INT_ERROR != 0 {
+            let err = self.read::<u16>(SDHCI_INT_STATUS_ERR);
+            self.write::<u16>(SDHCI_INT_STATUS_ERR, err);
+            // Selective clear: only error bits + waited bit, preserving CARD_INT
+            // (mirrors the timeout path's narrowed clear policy).
+            self.clear_int_status_norm(NORM_INT_ERROR | bit);
+            self.reset_dat_line();
+            return Some(Err(Self::classify_error(err)));
+        }
+        if norm & bit != 0 {
+            self.clear_int_status_norm(bit);
+            return Some(Ok(()));
+        }
+        None
+    }
+
     /// 直接轮询 INT_STATUS_NORM，等待指定 bit 置位后 W1C 清除
+    ///
+    /// Phase 1: 快速自旋 (PHASE1_SPIN_ITERS 次, ~50µs)
+    /// Phase 2: XFER_COMPLETE 走硬件中断驱动等待；其他位使用 10ms 睡眠轮询
     ///
     /// 同时检测 Error 中断：如果 ERROR bit (bit 15) 置位，
     /// 读取 ERR_STATUS 并 W1C 清除所有状态位，然后返回错误。
     fn poll_int_status(&self, bit: u16) -> Result<(), SdioError> {
         // Phase 1: 快速自旋
-        for _ in 0..1000 {
-            let norm = self.read::<u16>(SDHCI_INT_STATUS_NORM);
-            if norm & NORM_INT_ERROR != 0 {
-                let err = self.read::<u16>(SDHCI_INT_STATUS_ERR);
-                self.write::<u16>(SDHCI_INT_STATUS_ERR, err);
-                self.write::<u16>(SDHCI_INT_STATUS_NORM, norm);
-                self.reset_dat_line();
-                return Err(Self::classify_error(err));
-            }
-            if norm & bit != 0 {
-                self.write::<u16>(SDHCI_INT_STATUS_NORM, bit);
-                return Ok(());
+        for _ in 0..PHASE1_SPIN_ITERS {
+            if let Some(result) = self.poll_status_once(bit) {
+                return result;
             }
             core::hint::spin_loop();
         }
-        // Phase 2: 协作式等待
-        for i in 0..200_000 {
-            let norm = self.read::<u16>(SDHCI_INT_STATUS_NORM);
-            if norm & NORM_INT_ERROR != 0 {
-                let err = self.read::<u16>(SDHCI_INT_STATUS_ERR);
-                self.write::<u16>(SDHCI_INT_STATUS_ERR, err);
-                self.write::<u16>(SDHCI_INT_STATUS_NORM, norm);
-                self.reset_dat_line();
-                return Err(Self::classify_error(err));
+        // Phase 2: XFER_COMPLETE 走硬件中断驱动等待；其他位走纯超时睡眠
+        // （不经过 WaitQueue——ISR 不会为这些位发 notify，经过 WQ 是无效开销）
+        let use_irq = bit == NORM_INT_XFER_COMPLETE;
+        let mut timeout_count: u32 = 0;
+        for i in 0..PHASE2_MAX_ITERS {
+            // Race guard: 阻塞前先检查状态寄存器。
+            // 注意：pre-check 不能关闭 unmask→block 之间的丢唤醒窗口，
+            // 真正的防护是 XFER_COMPLETE sticky bit + post-wake recheck。
+            if let Some(result) = self.poll_status_once(bit) {
+                return result;
             }
-            if norm & bit != 0 {
-                self.write::<u16>(SDHCI_INT_STATUS_NORM, bit);
-                return Ok(());
-            }
-            if i == 100_000 {
+
+            if i == PHASE2_WARN_AT {
                 let pres = self.read::<u32>(SDHCI_PRESENT_STATE);
+                let sts = self.read::<u16>(SDHCI_INT_STATUS_NORM);
                 log::warn!(
-                    "[SDHCI] poll_int mid-timeout: bit=0x{:04x} PRES=0x{:08x} INT_STS=0x{:04x}",
+                    "[SDHCI] poll_int mid-timeout: bit=0x{:04x} PRES=0x{:08x} INT_STS=0x{:04x} \
+                     timeouts={}",
                     bit,
                     pres,
-                    norm
+                    sts,
+                    timeout_count
                 );
             }
-            crate::runtime::delay().yield_now();
+
+            if use_irq {
+                irq::unmask_xfer_complete_signal();
+                let _timed_out = crate::runtime::delay().block_timeout(PHASE2_STEP_MS);
+            } else {
+                // 非 XFER 位：直接 sleep，不经过 WaitQueue——
+                // ISR 只对 XFER_COMPLETE 发 notify，经过 WQ 是无效开销。
+                crate::runtime::delay().delay_ms(PHASE2_STEP_MS);
+            }
+            timeout_count += 1;
+
+            // 被唤醒后检查状态寄存器
+            if let Some(result) = self.poll_status_once(bit) {
+                return result;
+            }
         }
         let pres = self.read::<u32>(SDHCI_PRESENT_STATE);
         let sts = self.read::<u16>(SDHCI_INT_STATUS_NORM);
         log::error!(
-            "[SDHCI] poll_int_status timeout: bit=0x{:04x} PRES=0x{:08x} INT_STS=0x{:04x}",
+            "[SDHCI] poll_int_status timeout: bit=0x{:04x} PRES=0x{:08x} INT_STS=0x{:04x} \
+             timeouts={}",
             bit,
             pres,
-            sts
+            sts,
+            timeout_count
         );
         // 超时后总线可能仍处于 DAT-busy(PRES bit1 DATA_INHIBIT 置位),若不复位
         // DAT 线状态机,后续任何数据命令的 wait_data_idle 都会一直超时,整条 SDIO
-        // 总线被焊死(连 WiFi 模式切回 AP 也起不来)。这里对齐错误中断分支:清残留
-        // INT_STATUS 并复位 DAT 线,让总线能从一次读超时中恢复。
-        self.write::<u16>(SDHCI_INT_STATUS_NORM, sts);
+        // 总线被焊死(连 WiFi 模式切回 AP 也起不来)。这里对齐错误中断分支:选择性
+        // 清除错误位 + 当前等待位（避免误清 CARD_INT），然后复位 DAT 线。
+        self.clear_int_status_norm(NORM_INT_ERROR | bit);
         self.reset_dat_line();
         Err(SdioError::Timeout)
     }
@@ -536,13 +586,14 @@ impl CviSdhci {
         self.set_clock(400_000)
     }
 
-    /// 使能中断状态位 + CARD_INT 信号
+    /// 使能中断状态位 + CARD_INT 信号。
+    /// XFER_COMPLETE 信号由 poll_int_status 阻塞前通过 unmask_xfer_complete_signal 动态启用。
     fn enable_interrupts_irq(&self) -> Result<(), SdioError> {
         irq::irq_state_init(self.base);
         // Status Enable: 使能所有状态位 (用于 poll_int_status 轮询)
         self.write::<u16>(SDHCI_NORM_INT_STS_EN, NORM_INT_ENABLE_MASK);
         self.write::<u16>(SDHCI_ERR_INT_STS_EN, ERR_INT_ENABLE_MASK);
-        // Signal Enable: 仅使能 CARD_INT (ISR 只处理 CARD_INT)
+        // Signal Enable: 仅使能 CARD_INT；XFER_COMPLETE 由 poll_int_status 动态 un-mask
         irq::enable_irq_signals();
         Ok(())
     }

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -134,9 +134,13 @@ impl CviSdhci {
         if norm & NORM_INT_ERROR != 0 {
             let err = self.read::<u16>(SDHCI_INT_STATUS_ERR);
             self.write::<u16>(SDHCI_INT_STATUS_ERR, err);
-            // Selective clear: only error bits + waited bit, preserving CARD_INT
-            // (mirrors the timeout path's narrowed clear policy).
-            self.clear_int_status_norm(NORM_INT_ERROR | bit);
+            // Selective clear: error bits + waited bit + XFER_COMPLETE.
+            // XFER_COMPLETE may be asserted concurrently with an error
+            // (e.g. DAT error after data-phase completion).  Consuming it
+            // here prevents a stale bit from leaking into the next
+            // transfer's wait_transfer_complete as a false early success.
+            // CARD_INT is intentionally preserved (ISR/mask protocol).
+            self.clear_int_status_norm(NORM_INT_ERROR | bit | NORM_INT_XFER_COMPLETE);
             self.reset_dat_line();
             return Some(Err(Self::classify_error(err)));
         }
@@ -233,8 +237,9 @@ impl CviSdhci {
         // 超时后总线可能仍处于 DAT-busy(PRES bit1 DATA_INHIBIT 置位),若不复位
         // DAT 线状态机,后续任何数据命令的 wait_data_idle 都会一直超时,整条 SDIO
         // 总线被焊死(连 WiFi 模式切回 AP 也起不来)。这里对齐错误中断分支:选择性
-        // 清除错误位 + 当前等待位（避免误清 CARD_INT），然后复位 DAT 线。
-        self.clear_int_status_norm(NORM_INT_ERROR | bit);
+        // 清除错误位 + 当前等待位 + XFER_COMPLETE（防止 stale bit 泄漏到下一传输），
+        // 保留 CARD_INT，然后复位 DAT 线。
+        self.clear_int_status_norm(NORM_INT_ERROR | bit | NORM_INT_XFER_COMPLETE);
         self.reset_dat_line();
         Err(SdioError::Timeout)
     }

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -22,10 +22,7 @@ pub mod regs;
 pub mod runtime;
 
 use alloc::sync::Arc;
-use core::{
-    ptr::{read_volatile, write_volatile},
-    sync::atomic::{AtomicU64, Ordering},
-};
+use core::ptr::{read_volatile, write_volatile};
 
 pub use runtime::{SdhciDelay, set_delay};
 use sdio_host::{SdioCardIrq, SdioHost, cccr::*, cmd::*, error::SdioError};
@@ -40,167 +37,6 @@ const PHASE2_STEP_MS: u64 = 10;
 const PHASE2_MAX_ITERS: u32 = 20;
 /// Phase 2 中段警告阈值（迭代次数）
 const PHASE2_WARN_AT: u32 = 10;
-
-// ── 诊断计数器：追踪 poll_int_status 每个中断位的 Phase 1/2 命中率 ──
-
-const DIAG_CMD_COMPLETE: usize = 0;
-const DIAG_XFER_COMPLETE: usize = 1;
-const DIAG_BUF_WR_READY: usize = 2;
-const DIAG_BUF_RD_READY: usize = 3;
-const DIAG_NUM_SLOTS: usize = 4;
-const DIAG_NONE: usize = DIAG_NUM_SLOTS;
-
-struct PollBitDiag {
-    total: AtomicU64,
-    phase1_hits: AtomicU64,
-    /// Cumulative wall-clock nanos spent in Phase 1 (from entry to resolve).
-    phase1_ns: AtomicU64,
-    phase2_entries: AtomicU64,
-    /// Cumulative wall-clock nanos spent in Phase 2 for successful resolves.
-    /// Excludes errors and the timeout path.
-    phase2_ns: AtomicU64,
-    /// Sum of `timeout_count` at each successful Phase 2 resolve.
-    /// Excludes errors and the timeout path.
-    phase2_iters: AtomicU64,
-    timeouts: AtomicU64,
-    /// Errors detected inside poll_status_once (SDIO bus errors), split by phase.
-    phase1_errors: AtomicU64,
-    phase2_errors: AtomicU64,
-}
-
-impl PollBitDiag {
-    const fn new() -> Self {
-        Self {
-            total: AtomicU64::new(0),
-            phase1_hits: AtomicU64::new(0),
-            phase1_ns: AtomicU64::new(0),
-            phase2_entries: AtomicU64::new(0),
-            phase2_ns: AtomicU64::new(0),
-            phase2_iters: AtomicU64::new(0),
-            timeouts: AtomicU64::new(0),
-            phase1_errors: AtomicU64::new(0),
-            phase2_errors: AtomicU64::new(0),
-        }
-    }
-
-    fn reset(&self) {
-        self.total.store(0, Ordering::Relaxed);
-        self.phase1_hits.store(0, Ordering::Relaxed);
-        self.phase1_ns.store(0, Ordering::Relaxed);
-        self.phase2_entries.store(0, Ordering::Relaxed);
-        self.phase2_ns.store(0, Ordering::Relaxed);
-        self.phase2_iters.store(0, Ordering::Relaxed);
-        self.timeouts.store(0, Ordering::Relaxed);
-        self.phase1_errors.store(0, Ordering::Relaxed);
-        self.phase2_errors.store(0, Ordering::Relaxed);
-    }
-}
-
-static POLL_DIAG: [PollBitDiag; DIAG_NUM_SLOTS] = [
-    PollBitDiag::new(),
-    PollBitDiag::new(),
-    PollBitDiag::new(),
-    PollBitDiag::new(),
-];
-
-fn diag_slot(bit: u16) -> usize {
-    match bit {
-        NORM_INT_CMD_COMPLETE => DIAG_CMD_COMPLETE,
-        NORM_INT_XFER_COMPLETE => DIAG_XFER_COMPLETE,
-        NORM_INT_BUF_WR_READY => DIAG_BUF_WR_READY,
-        NORM_INT_BUF_RD_READY => DIAG_BUF_RD_READY,
-        _ => DIAG_NONE,
-    }
-}
-
-fn diag_name(slot: usize) -> &'static str {
-    match slot {
-        DIAG_CMD_COMPLETE => "CMD_COMPLETE",
-        DIAG_XFER_COMPLETE => "XFER_COMPLETE",
-        DIAG_BUF_WR_READY => "BUF_WR_READY",
-        DIAG_BUF_RD_READY => "BUF_RD_READY",
-        _ => "?",
-    }
-}
-
-/// Dump per-interrupt-bit poll diagnostics via `log::info`.
-///
-/// Each line reports: total calls, Phase 1 hits + avg wall time, Phase 2
-/// entries / hits + rate + avg wall time + avg iters, timeouts, per-phase errors.
-/// Also prints the IRQ counts and SDHCI clock frequency.
-///
-/// Call this after an iperf3 run to see which bits fall through to the safety
-/// net. Counters are reset after the dump; call [`reset_poll_diagnostics`] to
-/// reset mid-epoch without printing.
-pub fn dump_poll_diagnostics() {
-    for (slot, d) in POLL_DIAG.iter().enumerate() {
-        let total = d.total.load(Ordering::Relaxed);
-        if total == 0 {
-            continue;
-        }
-        let p1 = d.phase1_hits.load(Ordering::Relaxed);
-        let p1_ns = d.phase1_ns.load(Ordering::Relaxed);
-        let p2_entries = d.phase2_entries.load(Ordering::Relaxed);
-        let p2_ns = d.phase2_ns.load(Ordering::Relaxed);
-        let p2_iters = d.phase2_iters.load(Ordering::Relaxed);
-        let timeouts = d.timeouts.load(Ordering::Relaxed);
-        let p1_err = d.phase1_errors.load(Ordering::Relaxed);
-        let p2_err = d.phase2_errors.load(Ordering::Relaxed);
-        // Phase 2 hits = entered Phase 2, resolved Ok (not timeout, not error).
-        let p2_hits = total
-            .saturating_sub(p1)
-            .saturating_sub(timeouts)
-            .saturating_sub(p1_err)
-            .saturating_sub(p2_err);
-        let p2_rate = (p2_entries as f64 / total as f64) * 100.0;
-        let avg_p1_us = if p1 > 0 {
-            p1_ns as f64 / p1 as f64 / 1000.0
-        } else {
-            0.0
-        };
-        let avg_p2_us = if p2_hits > 0 {
-            p2_ns as f64 / p2_hits as f64 / 1000.0
-        } else {
-            0.0
-        };
-        let avg_iters = if p2_hits > 0 {
-            p2_iters as f64 / p2_hits as f64
-        } else {
-            0.0
-        };
-        log::info!(
-            "[SDHCI-diag] {}: total={} p1={} (avg {:.0}us) p2_entry={} p2_hit={} p2_rate={:.1}% \
-             avg_p2={:.0}us avg_p2_iters={:.1} to={} p1err={} p2err={}",
-            diag_name(slot),
-            total,
-            p1,
-            avg_p1_us,
-            p2_entries,
-            p2_hits,
-            p2_rate,
-            avg_p2_us,
-            avg_iters,
-            timeouts,
-            p1_err,
-            p2_err,
-        );
-    }
-    log::info!(
-        "[SDHCI-diag] IRQ: total={} card_int={} clk={}MHz",
-        irq::SDHCI_IRQ_COUNT.load(Ordering::Relaxed),
-        irq::SDHCI_CARD_INT_COUNT.load(Ordering::Relaxed),
-        HIGH_SPEED_CLOCK_HZ / 1_000_000,
-    );
-    reset_poll_diagnostics();
-}
-
-/// Reset all per-bit diagnostic counters to zero.
-/// Call before starting a new measurement epoch (e.g., before iperf3).
-pub fn reset_poll_diagnostics() {
-    for d in POLL_DIAG.iter() {
-        d.reset();
-    }
-}
 
 #[inline]
 pub(crate) fn delay_ms(ms: u64) {
@@ -319,46 +155,13 @@ impl CviSdhci {
     /// 同时检测 Error 中断：如果 ERROR bit (bit 15) 置位，
     /// 读取 ERR_STATUS 并 W1C 清除所有状态位，然后返回错误。
     fn poll_int_status(&self, bit: u16) -> Result<(), SdioError> {
-        let slot = diag_slot(bit);
-        let t_entry = if slot < DIAG_NUM_SLOTS {
-            crate::runtime::delay().now_nanos()
-        } else {
-            0
-        };
-
         // Phase 1: 快速自旋
         for _ in 0..PHASE1_SPIN_ITERS {
             if let Some(result) = self.poll_status_once(bit) {
-                if slot < DIAG_NUM_SLOTS {
-                    let elapsed = crate::runtime::delay().now_nanos().saturating_sub(t_entry);
-                    if result.is_ok() {
-                        POLL_DIAG[slot].phase1_hits.fetch_add(1, Ordering::Relaxed);
-                        POLL_DIAG[slot]
-                            .phase1_ns
-                            .fetch_add(elapsed, Ordering::Relaxed);
-                    } else {
-                        POLL_DIAG[slot]
-                            .phase1_errors
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                    POLL_DIAG[slot].total.fetch_add(1, Ordering::Relaxed);
-                }
                 return result;
             }
             core::hint::spin_loop();
         }
-
-        if slot < DIAG_NUM_SLOTS {
-            POLL_DIAG[slot]
-                .phase2_entries
-                .fetch_add(1, Ordering::Relaxed);
-        }
-        let t_p2_entry = if slot < DIAG_NUM_SLOTS {
-            crate::runtime::delay().now_nanos()
-        } else {
-            0
-        };
-
         // Phase 2: XFER_COMPLETE 走硬件中断驱动等待；其他位走纯超时睡眠
         // （不经过 WaitQueue——ISR 不会为这些位发 notify，经过 WQ 是无效开销）
         let use_irq = bit == NORM_INT_XFER_COMPLETE;
@@ -368,24 +171,6 @@ impl CviSdhci {
             // 注意：pre-check 不能关闭 unmask→block 之间的丢唤醒窗口，
             // 真正的防护是 XFER_COMPLETE sticky bit + post-wake recheck。
             if let Some(result) = self.poll_status_once(bit) {
-                if slot < DIAG_NUM_SLOTS {
-                    let elapsed = crate::runtime::delay()
-                        .now_nanos()
-                        .saturating_sub(t_p2_entry);
-                    if result.is_ok() {
-                        POLL_DIAG[slot]
-                            .phase2_iters
-                            .fetch_add(timeout_count as u64, Ordering::Relaxed);
-                        POLL_DIAG[slot]
-                            .phase2_ns
-                            .fetch_add(elapsed, Ordering::Relaxed);
-                    } else {
-                        POLL_DIAG[slot]
-                            .phase2_errors
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                    POLL_DIAG[slot].total.fetch_add(1, Ordering::Relaxed);
-                }
                 return result;
             }
 
@@ -414,34 +199,9 @@ impl CviSdhci {
 
             // 被唤醒后检查状态寄存器
             if let Some(result) = self.poll_status_once(bit) {
-                if slot < DIAG_NUM_SLOTS {
-                    let elapsed = crate::runtime::delay()
-                        .now_nanos()
-                        .saturating_sub(t_p2_entry);
-                    if result.is_ok() {
-                        POLL_DIAG[slot]
-                            .phase2_iters
-                            .fetch_add(timeout_count as u64, Ordering::Relaxed);
-                        POLL_DIAG[slot]
-                            .phase2_ns
-                            .fetch_add(elapsed, Ordering::Relaxed);
-                    } else {
-                        POLL_DIAG[slot]
-                            .phase2_errors
-                            .fetch_add(1, Ordering::Relaxed);
-                    }
-                    POLL_DIAG[slot].total.fetch_add(1, Ordering::Relaxed);
-                }
                 return result;
             }
         }
-
-        // 超时
-        if slot < DIAG_NUM_SLOTS {
-            POLL_DIAG[slot].timeouts.fetch_add(1, Ordering::Relaxed);
-            POLL_DIAG[slot].total.fetch_add(1, Ordering::Relaxed);
-        }
-
         let pres = self.read::<u32>(SDHCI_PRESENT_STATE);
         let sts = self.read::<u16>(SDHCI_INT_STATUS_NORM);
         log::error!(

--- a/components/sdhci-cv1800/src/lib.rs
+++ b/components/sdhci-cv1800/src/lib.rs
@@ -155,6 +155,20 @@ impl CviSdhci {
     /// 同时检测 Error 中断：如果 ERROR bit (bit 15) 置位，
     /// 读取 ERR_STATUS 并 W1C 清除所有状态位，然后返回错误。
     fn poll_int_status(&self, bit: u16) -> Result<(), SdioError> {
+        // Drain the store buffer before entering the Phase 1 spin loop.
+        // Without this fence, pending MMIO writes (e.g. pio_write's 128
+        // stores to SDHCI_BUFFER) can still be queued in the CPU's store
+        // buffer when the following mmio_read(INT_STATUS_NORM) loop begins.
+        // The reads then compete with the draining writes on the SDHCI bus,
+        // delaying the hardware from actually receiving the data and
+        // asserting BUF_WR_READY / CMD_COMPLETE.  Phase 1's 1000-iteration
+        // window (≈50 µs) can then expire before the status bit becomes
+        // visible, causing a fall-through into the 10 ms Phase 2 delay.
+        // A single fence here guarantees the store buffer is empty before
+        // polling starts — the same effect that task-switch implied fences
+        // (mret) provided in the old yield_now-based busy-wait scheme.
+        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
+
         // Phase 1: 快速自旋
         for _ in 0..PHASE1_SPIN_ITERS {
             if let Some(result) = self.poll_status_once(bit) {

--- a/components/sdhci-cv1800/src/regs.rs
+++ b/components/sdhci-cv1800/src/regs.rs
@@ -74,7 +74,7 @@ pub const ERR_INT_CMD_MASK: u16 =
 
 pub const ERR_INT_DAT_MASK: u16 = ERR_INT_DAT_TIMEOUT | ERR_INT_DAT_CRC | ERR_INT_DAT_END_BIT;
 
-/// Signal Enable: 仅使能 CARD_INT (PIO 事件由 wait 函数直接轮询 INT_STATUS)
+/// Signal Enable: 仅使能 CARD_INT（XFER_COMPLETE 信号由 poll_int_status 阻塞前动态 un-mask）
 pub const NORM_INT_SIG_MASK: u16 = NORM_INT_CARD_INT;
 
 pub const ERR_INT_SIG_MASK: u16 = 0;
@@ -177,8 +177,4 @@ pub const CAPS_BASE_FREQ_MASK: u32 = 0xFF; // 基频字段掩码 (8 bits)
 pub const RESET_TIMEOUT: u32 = 100_000;
 pub const CLOCK_STABLE_TIMEOUT: u32 = 100_000;
 pub const CMD_RESPONSE_TIMEOUT: u32 = 100_000;
-pub const CMD5_READY_TIMEOUT: u32 = 1_000;
 pub const CMD5_OCR_RETRY: u32 = 1000;
-pub const PIO_TIMEOUT: u32 = 1_000_000;
-pub const FUNC_READY_TIMEOUT: u32 = 1_000;
-pub const FUNC_READY_DELAY: u32 = 100_000;

--- a/components/sdhci-cv1800/src/regs.rs
+++ b/components/sdhci-cv1800/src/regs.rs
@@ -74,7 +74,7 @@ pub const ERR_INT_CMD_MASK: u16 =
 
 pub const ERR_INT_DAT_MASK: u16 = ERR_INT_DAT_TIMEOUT | ERR_INT_DAT_CRC | ERR_INT_DAT_END_BIT;
 
-/// Signal Enable: 仅使能 CARD_INT（XFER_COMPLETE 信号由 poll_int_status 阻塞前动态 un-mask）
+/// 信号使能：仅使能 CARD_INT（XFER_COMPLETE 信号由 poll_int_status 阻塞前动态 un-mask）
 pub const NORM_INT_SIG_MASK: u16 = NORM_INT_CARD_INT;
 
 pub const ERR_INT_SIG_MASK: u16 = 0;

--- a/components/sdhci-cv1800/src/regs.rs
+++ b/components/sdhci-cv1800/src/regs.rs
@@ -54,12 +54,17 @@ pub const ERR_INT_DAT_CRC: u16 = 1 << 5;
 pub const ERR_INT_DAT_END_BIT: u16 = 1 << 6;
 
 /// 组合掩码
-/// Status Enable: 使能所有需要的状态位
+/// Status Enable: 使能所有需要的状态位。
+/// 含 NORM_INT_ERROR：按 SDHCI 规范，INT_STATUS 位仅在对应 STS_EN 置位时
+/// 锁存——缺 bit15 时错误检测路径（poll_status_once 错误分支与 Phase 2
+/// 条件中的错误项）恒假。错误位不进入 SIG_EN（见 NORM_INT_SIG_MASK），
+/// 不产生中断，仅由轮询/条件检查消费。
 pub const NORM_INT_ENABLE_MASK: u16 = NORM_INT_CMD_COMPLETE
     | NORM_INT_XFER_COMPLETE
     | NORM_INT_BUF_WR_READY
     | NORM_INT_BUF_RD_READY
-    | NORM_INT_CARD_INT;
+    | NORM_INT_CARD_INT
+    | NORM_INT_ERROR;
 
 pub const ERR_INT_ENABLE_MASK: u16 = ERR_INT_CMD_TIMEOUT
     | ERR_INT_CMD_CRC

--- a/components/sdhci-cv1800/src/runtime.rs
+++ b/components/sdhci-cv1800/src/runtime.rs
@@ -11,16 +11,36 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 pub trait SdhciDelay: Send + Sync + 'static {
     /// 阻塞延迟指定毫秒数。
     fn delay_ms(&self, ms: u64);
-    /// 阻塞当前任务直至硬件中断唤醒或超时。
-    /// 超时返回 `true`，被中断唤醒返回 `false`。
+    /// 阻塞当前任务直至 `condition` 满足或超时。
+    /// 条件满足返回 `false`，超时返回 `true`。
+    ///
+    /// # 丢唤醒协议（实现必须满足）
+    ///
+    /// `condition` 的最终检查与任务入队必须发生在同一关中断临界区内，
+    /// 使“检查后、入队前 ISR 已发布完成事件”的情况不可能出现：
+    ///
+    /// - ISR 在锁内检查前触发：其 latch 的硬件状态位（XFER_COMPLETE sticky）
+    ///   由 `condition` 观察到，任务不进入睡眠直接返回；
+    /// - ISR 在入队后触发：notify 命中已入队的任务。
+    ///
+    /// 调用方在调用前负责重新打开中断信号（unmask）；开信号与入队之间的
+    /// ISR 不会丢事件——它 latch 的硬件状态位由锁内 `condition` 检查看到。
+    ///
+    /// 本方法在中断开启的 task 上下文被调用（禁止在 ISR 上下文调用）；
+    /// 上文的关中断临界区由实现自行建立（如 `SpinNoIrq` 锁），
+    /// 调用方不负责关中断。
     ///
     /// # 单 waiter 契约
     ///
     /// 调用方保证至多一个任务同时阻塞于此方法（由 SDIO 总线锁序列化）。
-    /// OS 胶水层可依赖此保证使用单一共享唤醒队列；丢失唤醒由超时兜底。
+    /// OS 胶水层可依赖此保证使用单一共享唤醒队列。
     ///
-    /// 默认实现使用基于 sleep 的回退，兼容尚未更新为中断驱动唤醒的 OS 胶水层。
-    fn block_timeout(&self, timeout_ms: u64) -> bool {
+    /// 默认实现退化为“检查一次 + 睡满超时”，事件即时性由调用方重检兜底，
+    /// 兼容未实现条件等待的 OS 胶水层。
+    fn block_timeout_until(&self, timeout_ms: u64, condition: &dyn Fn() -> bool) -> bool {
+        if condition() {
+            return false;
+        }
         self.delay_ms(timeout_ms);
         true
     }

--- a/components/sdhci-cv1800/src/runtime.rs
+++ b/components/sdhci-cv1800/src/runtime.rs
@@ -20,12 +20,6 @@ pub trait SdhciDelay: Send + Sync + 'static {
         self.delay_ms(timeout_ms);
         true
     }
-    /// Monotonic timestamp in nanoseconds. Used by the diagnostic counters to
-    /// measure per-phase wall-clock time. Returns 0 when the OS glue does not
-    /// provide a clock (diagnostics remain usable from iteration counts alone).
-    fn now_nanos(&self) -> u64 {
-        0
-    }
 }
 
 static DELAY: AtomicPtr<&'static dyn SdhciDelay> = AtomicPtr::new(core::ptr::null_mut());

--- a/components/sdhci-cv1800/src/runtime.rs
+++ b/components/sdhci-cv1800/src/runtime.rs
@@ -1,9 +1,9 @@
 //! OS timing capability injection.
 //!
-//! The controller driver needs millisecond delays and a CPU-yield while polling
-//! hardware, but must not bind to any specific kernel's task runtime. The OS
-//! glue installs a [`SdhciDelay`] provider once via [`set_delay`]; the driver
-//! reaches it through [`delay`].
+//! The controller driver needs millisecond delays and an interrupt-driven
+//! blocking wait, but must not bind to any specific kernel's task runtime.
+//! The OS glue installs a [`SdhciDelay`] provider once via [`set_delay`];
+//! the driver reaches it through [`delay`].
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 
@@ -11,14 +11,21 @@ use core::sync::atomic::{AtomicPtr, Ordering};
 pub trait SdhciDelay: Send + Sync + 'static {
     /// Blocking delay for the given milliseconds.
     fn delay_ms(&self, ms: u64);
-    /// Yield the CPU to other tasks while polling hardware.
-    fn yield_now(&self);
+    /// Block the current task until a hardware interrupt wakes it, or timeout.
+    /// Returns `true` if the wait timed out, `false` if woken by interrupt.
+    ///
+    /// The default implementation uses a sleep-based fallback for compatibility
+    /// with OS glue that hasn't been updated with interrupt-driven wake support.
+    fn block_timeout(&self, timeout_ms: u64) -> bool {
+        self.delay_ms(timeout_ms);
+        true
+    }
 }
 
 static DELAY: AtomicPtr<&'static dyn SdhciDelay> = AtomicPtr::new(core::ptr::null_mut());
 
 /// Installs the timing capability provider. Call once during init, before
-/// driving the controller.
+/// driving the controller. Must not be called concurrently with [`delay`].
 pub fn set_delay(provider: &'static dyn SdhciDelay) {
     let boxed = alloc::boxed::Box::new(provider);
     let ptr = alloc::boxed::Box::into_raw(boxed);

--- a/components/sdhci-cv1800/src/runtime.rs
+++ b/components/sdhci-cv1800/src/runtime.rs
@@ -20,6 +20,12 @@ pub trait SdhciDelay: Send + Sync + 'static {
         self.delay_ms(timeout_ms);
         true
     }
+    /// Monotonic timestamp in nanoseconds. Used by the diagnostic counters to
+    /// measure per-phase wall-clock time. Returns 0 when the OS glue does not
+    /// provide a clock (diagnostics remain usable from iteration counts alone).
+    fn now_nanos(&self) -> u64 {
+        0
+    }
 }
 
 static DELAY: AtomicPtr<&'static dyn SdhciDelay> = AtomicPtr::new(core::ptr::null_mut());

--- a/components/sdhci-cv1800/src/runtime.rs
+++ b/components/sdhci-cv1800/src/runtime.rs
@@ -1,27 +1,25 @@
-//! OS timing capability injection.
+//! OS 时序能力注入。
 //!
-//! The controller driver needs millisecond delays and an interrupt-driven
-//! blocking wait, but must not bind to any specific kernel's task runtime.
-//! The OS glue installs a [`SdhciDelay`] provider once via [`set_delay`];
-//! the driver reaches it through [`delay`].
+//! 控制器驱动需要毫秒级延迟和中断驱动的阻塞等待，
+//! 但不能绑定到任何特定内核的任务运行时。
+//! OS 胶水层通过 [`set_delay`] 一次性安装 [`SdhciDelay`] 提供者；
+//! 驱动通过 [`delay`] 访问它。
 
 use core::sync::atomic::{AtomicPtr, Ordering};
 
-/// Timing capabilities the SDHCI controller needs from the OS.
+/// SDHCI 控制器所需的 OS 时序能力。
 pub trait SdhciDelay: Send + Sync + 'static {
-    /// Blocking delay for the given milliseconds.
+    /// 阻塞延迟指定毫秒数。
     fn delay_ms(&self, ms: u64);
-    /// Block the current task until a hardware interrupt wakes it, or timeout.
-    /// Returns `true` if the wait timed out, `false` if woken by interrupt.
+    /// 阻塞当前任务直至硬件中断唤醒或超时。
+    /// 超时返回 `true`，被中断唤醒返回 `false`。
     ///
-    /// # Single-waiter contract
+    /// # 单 waiter 契约
     ///
-    /// The driver guarantees at most one task is blocked in this method at any
-    /// time (serialised by the SDIO bus lock). The OS glue may rely on this to
-    /// use a single shared wake queue; a lost wake is bounded by the timeout.
+    /// 调用方保证至多一个任务同时阻塞于此方法（由 SDIO 总线锁序列化）。
+    /// OS 胶水层可依赖此保证使用单一共享唤醒队列；丢失唤醒由超时兜底。
     ///
-    /// The default implementation uses a sleep-based fallback for compatibility
-    /// with OS glue that hasn't been updated with interrupt-driven wake support.
+    /// 默认实现使用基于 sleep 的回退，兼容尚未更新为中断驱动唤醒的 OS 胶水层。
     fn block_timeout(&self, timeout_ms: u64) -> bool {
         self.delay_ms(timeout_ms);
         true
@@ -30,8 +28,8 @@ pub trait SdhciDelay: Send + Sync + 'static {
 
 static DELAY: AtomicPtr<&'static dyn SdhciDelay> = AtomicPtr::new(core::ptr::null_mut());
 
-/// Installs the timing capability provider. Call once during init, before
-/// driving the controller. Must not be called concurrently with [`delay`].
+/// 安装时序能力提供者。在初始化期间、操作控制器前调用一次。
+/// 不得与 [`delay`] 并发调用。
 pub fn set_delay(provider: &'static dyn SdhciDelay) {
     let boxed = alloc::boxed::Box::new(provider);
     let ptr = alloc::boxed::Box::into_raw(boxed);

--- a/components/sdhci-cv1800/src/runtime.rs
+++ b/components/sdhci-cv1800/src/runtime.rs
@@ -14,6 +14,12 @@ pub trait SdhciDelay: Send + Sync + 'static {
     /// Block the current task until a hardware interrupt wakes it, or timeout.
     /// Returns `true` if the wait timed out, `false` if woken by interrupt.
     ///
+    /// # Single-waiter contract
+    ///
+    /// The driver guarantees at most one task is blocked in this method at any
+    /// time (serialised by the SDIO bus lock). The OS glue may rely on this to
+    /// use a single shared wake queue; a lost wake is bounded by the timeout.
+    ///
     /// The default implementation uses a sleep-based fallback for compatibility
     /// with OS glue that hasn't been updated with interrupt-driven wake support.
     fn block_timeout(&self, timeout_ms: u64) -> bool {

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002.its
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002.its
@@ -1,12 +1,12 @@
 /dts-v1/;
 
 / {
-    description = "StarryOS for LicheeRV Nano SG2002";
+    description = "StarryOS Wi-Fi for LicheeRV Nano SG2002";
     #address-cells = <1>;
 
     images {
         kernel {
-            description = "StarryOS kernel";
+            description = "StarryOS Wi-Fi kernel";
             data = /incbin/("${kernel_bin}");
             type = "kernel";
             arch = "riscv";
@@ -25,7 +25,7 @@
         default = "config";
 
         config {
-            description = "StarryOS SG2002";
+            description = "StarryOS SG2002 Wi-Fi";
             kernel = "kernel";
         };
     };

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
@@ -1,5 +1,6 @@
 features = [
   "starry-kernel/sg2002",
+  "ax-runtime/aic8800-wifi",
   "axplat-dyn/thead-mae",
   "ax-driver/serial",
   "ax-driver/cv181x-sdhci",

--- a/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
+++ b/os/StarryOS/configs/board/licheerv-nano-sg2002.toml
@@ -1,6 +1,5 @@
 features = [
   "starry-kernel/sg2002",
-  "ax-runtime/aic8800-wifi",
   "axplat-dyn/thead-mae",
   "ax-driver/serial",
   "ax-driver/cv181x-sdhci",

--- a/os/arceos/modules/axruntime/src/wifi_glue.rs
+++ b/os/arceos/modules/axruntime/src/wifi_glue.rs
@@ -14,6 +14,7 @@ use alloc::boxed::Box;
 use core::{future::poll_fn, time::Duration};
 
 use aic8800::{PollFn, SendPollFn, TimedOut, WifiRuntime};
+use ax_task::WaitQueue;
 use sdhci_cv1800::SdhciDelay;
 
 /// ArceOS-backed implementation of the Wi-Fi driver's runtime capabilities.
@@ -61,7 +62,16 @@ impl WifiRuntime for ArceosWifiRuntime {
     }
 }
 
-/// ArceOS-backed SDHCI delay/yield provider.
+/// WaitQueue for PIO interrupt-driven wakeup.
+/// The SDHCI ISR calls `sdhci_pio_wake_callback` which notifies this queue,
+/// waking tasks blocked in `ArceosDelay::block_timeout`.
+static SDHCI_PIO_WQ: WaitQueue = WaitQueue::new();
+
+fn sdhci_pio_wake_callback() {
+    SDHCI_PIO_WQ.notify_one_from_irq();
+}
+
+/// ArceOS-backed SDHCI delay/wake provider.
 struct ArceosDelay;
 
 impl SdhciDelay for ArceosDelay {
@@ -69,8 +79,8 @@ impl SdhciDelay for ArceosDelay {
         ax_task::sleep(Duration::from_millis(ms));
     }
 
-    fn yield_now(&self) {
-        ax_task::yield_now();
+    fn block_timeout(&self, timeout_ms: u64) -> bool {
+        SDHCI_PIO_WQ.wait_timeout(Duration::from_millis(timeout_ms))
     }
 }
 
@@ -80,6 +90,13 @@ static ARCEOS_DELAY: ArceosDelay = ArceosDelay;
 /// Installs the ArceOS runtime into the aic8800 driver core *and* the
 /// sdhci-cv1800 delay glue. Call once during init, before any Wi-Fi operation.
 pub(crate) fn install_runtime() {
+    // The ISR/task SIG_EN RMW protocol relies on single-core serialization;
+    // wake correctness under SMP requires additional fencing (see irq.rs).
+    debug_assert!(
+        ax_hal::cpu_num() == 1,
+        "sdhci-cv1800 ISR design assumes single-core; SMP not yet supported"
+    );
     sdhci_cv1800::set_delay(&ARCEOS_DELAY);
     aic8800::set_runtime(&ARCEOS_RUNTIME);
+    sdhci_cv1800::irq::register_pio_wake_callback(sdhci_pio_wake_callback);
 }

--- a/os/arceos/modules/axruntime/src/wifi_glue.rs
+++ b/os/arceos/modules/axruntime/src/wifi_glue.rs
@@ -62,23 +62,22 @@ impl WifiRuntime for ArceosWifiRuntime {
     }
 }
 
-/// WaitQueue for PIO interrupt-driven wakeup.
-/// The SDHCI ISR calls `sdhci_pio_wake_callback` which notifies this queue,
-/// waking tasks blocked in `ArceosDelay::block_timeout`.
+/// PIO 中断驱动唤醒的 WaitQueue。
+/// SDHCI ISR 调用 `sdhci_pio_wake_callback` 通知此队列，
+/// 唤醒阻塞在 `ArceosDelay::block_timeout` 中的任务。
 ///
-/// # Single-waiter invariant
+/// # 单 waiter 不变量
 ///
-/// At most one task is ever blocked on this queue at a time — the SDIO bus
-/// lock (`SdioTransport`) serialises all transfers, so only the TX or RX
-/// thread (never both) can be inside `block_timeout`.  This invariant is part
-/// of the `SdhciDelay::block_timeout` contract.
+/// 至多一个任务同时阻塞在此队列上——SDIO 总线锁（`SdioTransport`）
+/// 序列化所有传输，因此仅 TX 或 RX 线程（不会两者同时）可处于
+/// `block_timeout` 中。此不变量是 `SdhciDelay::block_timeout` 契约的一部分。
 static SDHCI_PIO_WQ: WaitQueue = WaitQueue::new();
 
 fn sdhci_pio_wake_callback() {
     SDHCI_PIO_WQ.notify_one_from_irq();
 }
 
-/// ArceOS-backed SDHCI delay/wake provider.
+/// 基于 ArceOS 的 SDHCI 延迟/唤醒提供者。
 struct ArceosDelay;
 
 impl SdhciDelay for ArceosDelay {
@@ -94,11 +93,11 @@ impl SdhciDelay for ArceosDelay {
 static ARCEOS_RUNTIME: ArceosWifiRuntime = ArceosWifiRuntime;
 static ARCEOS_DELAY: ArceosDelay = ArceosDelay;
 
-/// Installs the ArceOS runtime into the aic8800 driver core *and* the
-/// sdhci-cv1800 delay glue. Call once during init, before any Wi-Fi operation.
+/// 将 ArceOS 运行时安装到 aic8800 驱动核心和 sdhci-cv1800 延迟胶水层。
+/// 在初始化期间、任何 WiFi 操作前调用一次。
 pub(crate) fn install_runtime() {
-    // The ISR/task SIG_EN RMW protocol relies on single-core serialization;
-    // wake correctness under SMP requires additional fencing (see irq.rs).
+    // ISR/task SIG_EN RMW 协议依赖单核序列化；
+    // SMP 下的唤醒正确性需要额外围栏（见 irq.rs）。
     debug_assert!(
         ax_hal::cpu_num() == 1,
         "sdhci-cv1800 ISR design assumes single-core; SMP not yet supported"

--- a/os/arceos/modules/axruntime/src/wifi_glue.rs
+++ b/os/arceos/modules/axruntime/src/wifi_glue.rs
@@ -65,6 +65,13 @@ impl WifiRuntime for ArceosWifiRuntime {
 /// WaitQueue for PIO interrupt-driven wakeup.
 /// The SDHCI ISR calls `sdhci_pio_wake_callback` which notifies this queue,
 /// waking tasks blocked in `ArceosDelay::block_timeout`.
+///
+/// # Single-waiter invariant
+///
+/// At most one task is ever blocked on this queue at a time — the SDIO bus
+/// lock (`SdioTransport`) serialises all transfers, so only the TX or RX
+/// thread (never both) can be inside `block_timeout`.  This invariant is part
+/// of the `SdhciDelay::block_timeout` contract.
 static SDHCI_PIO_WQ: WaitQueue = WaitQueue::new();
 
 fn sdhci_pio_wake_callback() {

--- a/os/arceos/modules/axruntime/src/wifi_glue.rs
+++ b/os/arceos/modules/axruntime/src/wifi_glue.rs
@@ -64,13 +64,22 @@ impl WifiRuntime for ArceosWifiRuntime {
 
 /// PIO 中断驱动唤醒的 WaitQueue。
 /// SDHCI ISR 调用 `sdhci_pio_wake_callback` 通知此队列，
-/// 唤醒阻塞在 `ArceosDelay::block_timeout` 中的任务。
+/// 唤醒阻塞在 `ArceosDelay::block_timeout_until` 中的任务。
+///
+/// # 丢唤醒防护
+///
+/// 阻塞走 [`WaitQueue::wait_timeout_until`]：条件的最终检查与任务入队在
+/// WQ 自旋锁（关中断）的同一临界区内衔接。ISR 若在 unmask 与锁内检查
+/// 之间触发，其 notify 虽落空（队列为空），XFER_COMPLETE sticky 位仍被
+/// 锁内条件检查观察到；检查后入队前 ISR 不可能触发（临界区关中断）；
+/// ISR 若在入队后触发，notify 命中队列中的任务。
 ///
 /// # 单 waiter 不变量
 ///
 /// 至多一个任务同时阻塞在此队列上——SDIO 总线锁（`SdioTransport`）
 /// 序列化所有传输，因此仅 TX 或 RX 线程（不会两者同时）可处于
-/// `block_timeout` 中。此不变量是 `SdhciDelay::block_timeout` 契约的一部分。
+/// `block_timeout_until` 中。此不变量是 `SdhciDelay::block_timeout_until`
+/// 契约的一部分。
 static SDHCI_PIO_WQ: WaitQueue = WaitQueue::new();
 
 fn sdhci_pio_wake_callback() {
@@ -85,8 +94,8 @@ impl SdhciDelay for ArceosDelay {
         ax_task::sleep(Duration::from_millis(ms));
     }
 
-    fn block_timeout(&self, timeout_ms: u64) -> bool {
-        SDHCI_PIO_WQ.wait_timeout(Duration::from_millis(timeout_ms))
+    fn block_timeout_until(&self, timeout_ms: u64, condition: &dyn Fn() -> bool) -> bool {
+        SDHCI_PIO_WQ.wait_timeout_until(Duration::from_millis(timeout_ms), condition)
     }
 }
 

--- a/os/arceos/modules/axruntime/src/wifi_glue.rs
+++ b/os/arceos/modules/axruntime/src/wifi_glue.rs
@@ -82,10 +82,6 @@ impl SdhciDelay for ArceosDelay {
     fn block_timeout(&self, timeout_ms: u64) -> bool {
         SDHCI_PIO_WQ.wait_timeout(Duration::from_millis(timeout_ms))
     }
-
-    fn now_nanos(&self) -> u64 {
-        ax_hal::time::monotonic_time_nanos()
-    }
 }
 
 static ARCEOS_RUNTIME: ArceosWifiRuntime = ArceosWifiRuntime;

--- a/os/arceos/modules/axruntime/src/wifi_glue.rs
+++ b/os/arceos/modules/axruntime/src/wifi_glue.rs
@@ -82,6 +82,10 @@ impl SdhciDelay for ArceosDelay {
     fn block_timeout(&self, timeout_ms: u64) -> bool {
         SDHCI_PIO_WQ.wait_timeout(Duration::from_millis(timeout_ms))
     }
+
+    fn now_nanos(&self) -> u64 {
+        ax_hal::time::monotonic_time_nanos()
+    }
 }
 
 static ARCEOS_RUNTIME: ArceosWifiRuntime = ArceosWifiRuntime;


### PR DESCRIPTION
使用 XFER_COMPLETE 中断修复 SG2002 WiFi 上行吞吐量

## 背景
@BattiestStone4 
SG2002 (LicheeRV Nano) 的 aic8800 WiFi 模组通过 SDIO 接口与 SoC 通信，SDHCI 驱动使用 PIO 模式，PIO 传输完成等待（`poll_int_status`）采用两阶段轮询：

- **Phase 1**：纯寄存器自旋 1000 次（约 50µs）
- **Phase 2**：最多 20 万次循环，每圈 `yield_now()` 让出 CPU 后重新检查 INT_STATUS

上行方向存在严重吞吐问题，见 [StarryOS WiFi 上行吞吐排查报告](https://docs.qq.com/doc/DTkN3Y1JOeWhJVGdV) (@BattiestStone4)。报告发现，硬件在 t≈250µs 就发完帧并置好了 XFER_COMPLETE。本 PR 认为可以通过使能 XFER_COMPLETE 的中断来控制 CPU 返回驱动以修复上行吞吐量极低的问题，无需让出时间片或忙等 XFER_COMPLETE 置位。

## 方案与改动

核心思路：用 XFER_COMPLETE 硬件中断替代 `yield_now()`——任务阻塞在 WaitQueue，硬件完成传输后 ISR 立即唤醒，唤醒延迟从约 48ms 降至微秒级。

### 1. 修复 WiFi 启动

aic8800 RX 线程的周期性 kicker 原先仅在 dual-pipe 模式下启动。改为无条件启动 10ms kicker，作为 ISR 驱动 RX 响应路径不可靠时的兜底，确保入站帧不丢失。此改动使得单通道的 aic8800D80 WiFi 芯片可在 starryos 启动时顺利初始化 AP 模式。

> **提交**：`fix&test(sg2002,wifi): fix wifi boot & include sg2002 wifi config`
>*该提交包含一处对 sg2002 配置文件的改动，已追加提交回退。

### 2. XFER_COMPLETE 中断

在 Phase 2 中使能 XFER_COMPLETE 中断信号，任务通过 `block_timeout` 阻塞在 WaitQueue，硬件完成时 SDHCI ISR 写 `NORM_INT_SIG_EN` 清零 XFER_COMPLETE 使能位并调用 `notify_one_from_irq` 唤醒任务，任务醒来后在 `poll_status_once` 中读到 XFER_COMPLETE 已置位，W1C 清除后返回。

XFER_COMPLETE 是 sticky bit，若 ISR 提前 W1C 清除，任务醒来看到状态为 0 会误判未完成，所以 ISR 只 mask 信号不碰状态位，清除统一由 `poll_status_once`（`poll_int_status` 内）执行。

此前 `clear_stale_status` 在每条命令前 W1C 清理 INT_STATUS 残留位，在实现了 XFER_COMPLETE 中断后会误清 XFER_COMPLETE ，故清理残留位时过滤该位。此外，非 XFER 等待的错误/超时退出路径也需要处理未受理的 XFER_COMPLETE，否则会被下一次 `wait_transfer_complete` 当成提前成功，因此改为退出路径加清。

> **提交**：
> - `fix(sdhci-cv1800): add interrupt-driven PIO transfer completion`
> - `fix(sdhci-cv1800): use selective W1C to preserve XFER_COMPLETE across command and error paths`
> - `fix(sdhci-cv1800): consume XFER_COMPLETE in error and timeout exit paths`

### 3. Store Buffer Fence

PIO 写 `SDHCI_BUFFER` 后，写操作可能会被 CPU store buffer 暂存而非直接输出到总线（SDHCI 寄存器是 MMIO，CPU 有可能会乱序执行不同内存地址的操作）。若 `pio_write` 操作被暂存，进入 Phase 1 后 CPU 自旋读 `INT_STATUS`，妨碍滞后的 `pio_write` 及时输出到总线（竞争总线），硬件收到 `pio_write` 并置位 `INT_STATUS` 的时间被推迟，导致 Phase 1 的 50µs 窗口可能在硬件就绪前过期。实测表现如此，上行吞吐极小（略好于引入 XFER_COMPLETE 中断之前）。

在 Phase 1 入口加 `fence(SeqCst)` 排空 store buffer 再轮询。原本的 `yield_now()` 没这个问题，其任务切换的 `mret` 自带 fence 语义，换成阻塞等待后需要显式补上。

> **提交**：`fix(sdhci-cv1800): drain store buffer before Phase 1 MMIO polling`

## 测试结果

平台：LicheeRV Nano SG2002，网卡：aic8800D80

**纯上传（TX）**

```
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  1.12 MBytes  9.43 Mbits/sec    0   0.00 Bytes
[  5]   1.00-2.00   sec  1.25 MBytes  10.5 Mbits/sec    0   0.00 Bytes
[  5]   2.00-3.00   sec  1.12 MBytes  9.44 Mbits/sec    0   0.00 Bytes
[  5]   3.00-4.00   sec  1.25 MBytes  10.5 Mbits/sec    0   0.00 Bytes
[  5]   4.00-5.00   sec  1.25 MBytes  10.5 Mbits/sec    0   0.00 Bytes
[  5]   5.00-6.00   sec  1.00 MBytes  8.39 Mbits/sec    0   0.00 Bytes
[  5]   6.00-7.00   sec  1.12 MBytes  9.43 Mbits/sec    0   0.00 Bytes
[  5]   7.00-8.00   sec  1.25 MBytes  10.5 Mbits/sec    0   0.00 Bytes
[  5]   8.00-9.00   sec  1.25 MBytes  10.5 Mbits/sec    0   0.00 Bytes
[  5]   9.00-10.00  sec  1.12 MBytes  9.44 Mbits/sec    0   0.00 Bytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[  5]   0.00-10.02  sec  11.9 MBytes  9.94 Mbits/sec    0            sender
```

**纯下载（RX）**

```
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  1.25 MBytes  10.5 Mbits/sec
[  5]   1.00-2.00   sec  1.38 MBytes  11.5 Mbits/sec
[  5]   2.00-3.00   sec  1.38 MBytes  11.5 Mbits/sec
[  5]   3.00-4.00   sec  1.25 MBytes  10.5 Mbits/sec
[  5]   4.00-5.00   sec  1.25 MBytes  10.5 Mbits/sec
[  5]   5.00-6.00   sec  1.25 MBytes  10.5 Mbits/sec
[  5]   6.00-7.00   sec  1.38 MBytes  11.5 Mbits/sec
[  5]   7.00-8.00   sec  1.25 MBytes  10.5 Mbits/sec
[  5]   8.00-9.00   sec  1.38 MBytes  11.5 Mbits/sec
[  5]   9.00-9.94   sec  1.25 MBytes  11.2 Mbits/sec
- - - - - - - - - - - - - - - - - - - - - - - - -
[  5]   0.00-9.94   sec  13.0 MBytes  11.0 Mbits/sec                  receiver
```

**双向**

```
[ ID][Role] Interval           Transfer     Bitrate         Retr  Cwnd
[  5][RX-S]   0.00-1.00   sec   512 KBytes  4.19 Mbits/sec
[  8][TX-S]   0.00-1.00   sec   640 KBytes  5.24 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   1.00-2.00   sec   640 KBytes  5.24 Mbits/sec
[  8][TX-S]   1.00-2.00   sec   640 KBytes  5.24 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   2.00-3.00   sec   640 KBytes  5.24 Mbits/sec
[  8][TX-S]   2.00-3.00   sec   768 KBytes  6.29 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   3.00-4.00   sec   640 KBytes  5.24 Mbits/sec
[  8][TX-S]   3.00-4.00   sec   640 KBytes  5.24 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   4.00-5.00   sec   768 KBytes  6.29 Mbits/sec
[  8][TX-S]   4.00-5.00   sec   640 KBytes  5.24 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   5.00-6.00   sec   640 KBytes  5.24 Mbits/sec
[  8][TX-S]   5.00-6.00   sec   640 KBytes  5.24 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   6.00-7.00   sec   640 KBytes  5.25 Mbits/sec
[  8][TX-S]   6.00-7.00   sec   768 KBytes  6.30 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   7.00-8.00   sec   640 KBytes  5.24 Mbits/sec
[  8][TX-S]   7.00-8.00   sec   640 KBytes  5.24 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   8.00-9.00   sec   640 KBytes  5.24 Mbits/sec
[  8][TX-S]   8.00-9.00   sec   640 KBytes  5.24 Mbits/sec    0   0.00 Bytes
[  5][RX-S]   9.00-9.96   sec   640 KBytes  5.49 Mbits/sec
[  8][TX-S]   9.00-9.96   sec   640 KBytes  5.49 Mbits/sec    0   0.00 Bytes
- - - - - - - - - - - - - - - - - - - - - - - - -
[  5][RX-S]   0.00-9.96   sec  6.25 MBytes  5.27 Mbits/sec                  receiver
[  8][TX-S]   0.00-9.96   sec  6.50 MBytes  5.48 Mbits/sec    0            sender
```

## 改动内容

### 提交列表

| 提交 | 说明 |
|------|------|
| `fix&test(sg2002,wifi): fix wifi boot & include sg2002 wifi config` | RX kicker 无条件启动 |
| `fix(sdhci-cv1800): add interrupt-driven PIO transfer completion` | XFER_COMPLETE 中断驱动核心实现 |
| `fix(sdhci-cv1800): drain store buffer before Phase 1 MMIO polling` | Phase 1 入口 atomic fence |
| `fix(sdhci-cv1800): use selective W1C to preserve XFER_COMPLETE` | 选择性 W1C，保护 XFER_COMPLETE |
| `fix(sdhci-cv1800): consume XFER_COMPLETE in error and timeout exit paths` | 错误/超时路径消费 XFER_COMPLETE |
| `chore(sdhci-cv1800): translate newly-introduced comments to Chinese` | 注释中文化 |
| `chore(sg2002): remove aic8800-wifi feature from licheerv-nano-sg2002 base config` | 回退 base config |

### 改动文件

| 文件 | 说明 |
|------|------|
| `components/aic8800/src/fdrv/thread/rx.rs` | RX kicker 无条件启动 |
| `components/sdhci-cv1800/src/irq.rs` | XFER_COMPLETE ISR、CallbackSlot、RMW 集中化 |
| `components/sdhci-cv1800/src/lib.rs` | poll_int_status 两阶段重构、fence、选择性 W1C |
| `components/sdhci-cv1800/src/regs.rs` | SIG_MASK 仅使能 CARD_INT |
| `components/sdhci-cv1800/src/runtime.rs` | SdhciDelay trait：yield_now → block_timeout |
| `os/arceos/modules/axruntime/src/wifi_glue.rs` | block_timeout 实现、PIO wake callback |
| `os/StarryOS/configs/board/licheerv-nano-sg2002.its` | WiFi 启动修复（ITS 设备树） |
