### PR TITLE
refactor(axbuild): reuse ostool OVMF assets and paths

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -50,6 +50,10 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
   access. Scheduler switches keep IRQs off and consume prepared/previous transaction tokens.
 - **Build system**: wire arch/target mapping in `scripts/axbuild`, dynamic platform defaults, feature propagation, kernel format conversion, UEFI/to-bin behavior, rootfs handling, and per-OS test discovery.
 - **QEMU and firmware**: verify QEMU binary, machine type, CPU, SMP count, pflash/OVMF files, serial console, disk/rootfs device, `-snapshot`, debug flags, timeout, and success/fail regexes.
+  Obtain OVMF CODE/VARS through `cargo xtask ovmf --arch <arch>`, which reuses Ostool's pinned
+  version, mirror probing, SHA-256 verification, and `$TMPDIR/ostool/ovmf` cache. Use
+  `TGOS_OVMF_DIR` only to select another Ostool-format cache root; do not add per-consumer
+  firmware variables or scan distribution-specific `/usr/share` candidates.
   QEMU `uefi`, `to_bin`, acceleration, CPU feature, and device choices are part of each
   `qemu-*.toml` contract; axbuild must not infer or overwrite them from the target architecture
   or host `/dev/kvm` availability.
@@ -210,7 +214,9 @@ Adjust the package list to match the crates touched.
 - Secondary CPU never prints: suspect firmware CPU ID mapping, boot args cache visibility, secondary stack, per-CPU base, page table root, or per-secondary trap setup.
 - Starry boots but interactive/system tests fail: suspect rootfs staging, input/console features, CPR/tty sizing assumptions, or success regex mismatches.
 - NVMe block/rootfs missing: suspect PCI command enable, MMIO mapping, DMA address translation, MSI-X/INTx registration, bootstrap hctx startup, or rootfs patch path. Do not mask the failure by re-enabling `virtio-blk`.
-- Axvisor only fails in LVZ container: verify container QEMU path, OVMF path, target toolchain, KVM/LVZ flags, and whether xtask was built inside the mounted workspace.
+- Axvisor only fails in LVZ container: verify container QEMU path, `cargo xtask ovmf --arch
+  loongarch64` output (and `TGOS_OVMF_DIR` when set), target toolchain, KVM/LVZ flags, and whether
+  xtask was built inside the mounted workspace.
 
 ## Completion Criteria
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -705,46 +705,7 @@ jobs:
             timeout_minutes: 25
             command: |
               rustup target add x86_64-unknown-uefi
-              find_uefi_firmware() {
-                # ostool stores verified prebuilts under std::env::temp_dir().
-                for candidate in \
-                  "${TMPDIR:-/tmp}/ostool/ovmf/x64/code.fd" \
-                  /usr/share/OVMF/OVMF_CODE_4M.fd \
-                  /usr/share/OVMF/OVMF_CODE.fd \
-                  /usr/share/ovmf/OVMF.fd \
-                  /usr/share/qemu/OVMF.fd; do
-                  if [ -f "${candidate}" ]; then
-                    printf '%s\n' "${candidate}"
-                    return 0
-                  fi
-                done
-                return 1
-              }
-              UEFI_FIRMWARE="$(find_uefi_firmware || true)"
-              if [ -z "${UEFI_FIRMWARE}" ]; then
-                # apt against the runner mirrors fails transiently with exit 100
-                # (mirror hiccup / lock); a bare invocation lets a flaky mirror
-                # abort the whole smoke, so retry with backoff before giving up.
-                for attempt in 1 2 3; do
-                  if sudo apt-get update -o Acquire::Retries=3 \
-                    && sudo apt-get install -y --no-install-recommends \
-                         -o Acquire::Retries=3 ovmf; then
-                    break
-                  fi
-                  if [ "${attempt}" -eq 3 ]; then
-                    echo "ERROR: apt-get failed to install OVMF after 3 attempts." >&2
-                    exit 1
-                  fi
-                  sleep "$((attempt * 10))"
-                done
-                UEFI_FIRMWARE="$(find_uefi_firmware || true)"
-              fi
-              if [ -z "${UEFI_FIRMWARE}" ]; then
-                echo "ERROR: installed OVMF firmware image was not found under /usr/share." >&2
-                exit 1
-              fi
-              export AXLOADER_X86_64_UEFI_FIRMWARE="${UEFI_FIRMWARE}"
-              cargo axloader test qemu --target x86_64-unknown-uefi
+              cargo xtask axloader test qemu --target x86_64-unknown-uefi
             cache_key: ""
             container_image: ""
             limit_to_owner: rcore-os

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5525,9 +5525,9 @@ dependencies = [
 
 [[package]]
 name = "ostool"
-version = "0.26.0"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e925c3719ebd62bc412332e9b78ad994a1fcb96a02840776e8708b0cab748324"
+checksum = "83b6dcc7618bf13d75e0fa02acb0eebf3c3d00eb624468c1eef4f64d75b56752"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5566,7 +5566,6 @@ dependencies = [
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
  "uboot-shell",
- "ureq",
  "url",
 ]
 
@@ -8629,7 +8628,11 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
 ]
 
@@ -8874,6 +8877,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.5",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.7",
  "thiserror 2.0.19",
  "utf-8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -322,7 +322,7 @@ lock_api = { version = "0.4", default-features = false }
 log = "0.4"
 spin = { version = "=0.12.2", default-features = false, features = ["lock_api", "once", "lazylock"] }
 atomic-waker = { version = "1.1", default-features = false }
-ostool = { version = "0.26.0" }
+ostool = { version = "0.27.1" }
 riscv = { version = "0.16.1", default-features = false }
 sbi-rt = { version = "0.0.4", default-features = false }
 uefi = "0.37.0"

--- a/docs/docs/build/axloader.md
+++ b/docs/docs/build/axloader.md
@@ -30,7 +30,7 @@ cargo xtask axloader <subcommand>
 ```mermaid
 flowchart TB
     BUILD["1. cargo build --release<br/>产出 target/<uefi>/release/axloader.efi"]
-    FW["2. find_uefi_firmware<br/>OVMF (env / ostool 缓存 / 标准路径)"]
+    FW["2. OvmfFirmware::fetch<br/>Ostool 固定版本、校验与缓存"]
     ESP["3. 组装 ESP<br/>esp/EFI/BOOT/BOOTX64.EFI"]
     KERNEL["4. minimal_x86_64_kernel_elf<br/>手工拼装的 2 字节 jmp . 内核"]
     HTTP["5. SmokeHttpServer::start<br/>监听 0.0.0.0:0 提供 /kernel.elf"]
@@ -46,7 +46,7 @@ flowchart TB
 
 关键点：
 
-- **UEFI 固件定位**：`find_uefi_firmware` 依次查询环境变量（`AXLOADER_X86_64_UEFI_FIRMWARE`，兼容旧名 `AXVISOR_X86_64_UEFI_FIRMWARE`）、ostool 的 `${TMPDIR}/ostool/ovmf/x64/code.fd` 缓存，再扫描 `X86_64_UEFI_FIRMWARE_CANDIDATES` 中常见的系统 OVMF 路径（`/usr/share/OVMF/OVMF_CODE_4M.fd` 等）。当前 ostool 依赖没有公开其 OVMF 下载函数，因此 axbuild 复用同一缓存文件而不复制下载逻辑；所有候选都不存在时才提示设置环境变量或安装 `ovmf`。
+- **UEFI 固件定位**：`OvmfFirmware::fetch` 复用 Ostool 的固定版本、镜像探测、SHA-256 校验与离线缓存语义。默认缓存根目录由 Ostool 统一确定为 `${TMPDIR}/ostool/ovmf`；需要隔离缓存时可设置 `TGOS_OVMF_DIR`。Axloader 不扫描系统 OVMF 目录，也不维护专用固件环境变量或下载器。
 - **虚拟化契约**：x86_64 smoke 显式使用 `-accel kvm -cpu host`，必须在有可用 `/dev/kvm` 的主机上运行。固定的 ostool OVMF 在 QEMU 默认 TCG/`qemu64` CPU 下不会发布本测试需要的 IPv4/HTTP 协议；CI 因此将该任务调度到带 KVM 标签的 runner。
 - **QEMU user-net 网关**：QEMU 的 user-mode 网络把 host 映射为 `10.0.2.2`（常量 `QEMU_HOST_GATEWAY`），因此 guest 内的 axloader 通过这个 IP 访问 host 上临时启动的 HTTP 服务，无需配置 bridge/tap。
 - **最小内核**：`minimal_x86_64_kernel_elf` 手工拼装一个极简 ELF64——程序头指向 `0x20_0000`，入口指令为 `eb fe`（`jmp .`）。它不需要做任何实际工作，smoke test 只关心 axloader 是否成功下载、解析 ELF 并报告 `elf_loaded:`。
@@ -98,7 +98,7 @@ const HTTP_SMOKE_MAX_ATTEMPTS: usize = 2;
 const QEMU_HOST_GATEWAY: &str = "10.0.2.2";
 ```
 
-`LoaderSmokeTarget` 是按 target 抽象的测试目标（cargo target、arch、EFI 文件名、固件候选、QEMU 程序、QEMU 参数构造函数、内核 ELF 工厂），目前只实现了 `x86_64-unknown-uefi`。新增架构（如 aarch64 UEFI）时按同样模式扩展 `smoke_target` 即可。
+`LoaderSmokeTarget` 是按 target 抽象的测试目标（协议 arch、OVMF arch、EFI 文件名、QEMU 程序、QEMU 参数构造函数、内核 ELF 工厂），目前只实现了 `x86_64-unknown-uefi`。新增架构（如 aarch64 UEFI）时按同样模式扩展 `smoke_target` 即可。
 
 ## 用法示例
 
@@ -113,4 +113,4 @@ cargo xtask axloader test qemu
 cargo xtask axloader test qemu --target x86_64-unknown-uefi
 ```
 
-CI 中通常直接 `cargo xtask axloader test qemu`。本地运行 x86_64 smoke 需要安装 `qemu-system-x86_64` 并拥有 `/dev/kvm` 访问权限。固件会优先复用 ostool 已下载到 `${TMPDIR}/ostool/ovmf/x64/code.fd` 的文件；若该缓存不存在，可设置 `AXLOADER_X86_64_UEFI_FIRMWARE=/path/to/OVMF_CODE.fd` 指向已有固件，或安装系统 `ovmf` 包。
+CI 中通常直接 `cargo xtask axloader test qemu`。本地运行 x86_64 smoke 需要安装 `qemu-system-x86_64` 并拥有 `/dev/kvm` 访问权限。固件由 Ostool 自动获取并复用 `${TMPDIR}/ostool/ovmf` 缓存；需要使用预先准备的 Ostool 格式缓存时设置 `TGOS_OVMF_DIR=/path/to/cache-root`。

--- a/docs/docs/build/axvisor/build.md
+++ b/docs/docs/build/axvisor/build.md
@@ -18,9 +18,10 @@ flowchart TD
     C --> D["加载或生成 Axvisor Build Config"]
     D --> E["合并 FEATURES 与 CLI --smp"]
     E --> F["验证平台 feature 边界"]
-    F --> G["BuildInfo → std PIE Cargo"]
-    G --> H["AXVISOR_VM_CONFIGS / AX_ARCH / AX_TARGET"]
-    H --> I["ostool cargo_build → ELF"]
+    F --> G["解析 VM 镜像路径变量"]
+    G --> H["BuildInfo → std PIE Cargo"]
+    H --> I["AXVISOR_VM_CONFIGS / AX_ARCH / AX_TARGET"]
+    I --> J["ostool cargo_build → ELF"]
 ```
 
 ### 1.1 配置装载
@@ -57,10 +58,18 @@ tmp/axbuild/config/axvisor/build-<target>.toml
 - 固定 Cargo package 和 binary 为 `axvisor`；
 - 写入 `AX_ARCH` 与原始裸机 `AX_TARGET`；
 - 选择 CLI `--vmconfigs`，或在 CLI 为空时选择 Build Config 的 `vm_configs`；
+- 仅在 `[kernel]` 的 `kernel_path`、`dtb_path`、`bios_path`、`uefi_firmware_path`、
+  `ramdisk_path` 中展开 Ostool 变量；相对路径仍以原 VM config 所在目录为基准；
+- 含变量的配置原子写入 `tmp/axbuild/axvisor/resolved-vm-configs/`，文件名由源路径
+  SHA-256 生成；
 - 非空 VM 列表以平台路径分隔符写入 `AXVISOR_VM_CONFIGS`；
 - 对 feature 排序去重。
 
 基础 Cargo 的 `to_bin` 固定为 `false`。`axvisor build` 因而只保证 ELF；QEMU 路径在读取 TOML 后再明确设置其 `to_bin`。
+
+支持的变量为 `${workspace}`、`${workspaceFolder}`、`${package}`、`${tmpDir}` 和
+`${env:NAME}`。解析后的同一组配置同时供 rootfs 推断、`AXVISOR_VM_CONFIGS` 和
+`os/axvisor/build.rs` 使用，避免三处分别解释镜像路径。
 
 ## 2. 虚拟化后端
 

--- a/docs/docs/build/axvisor/overview.md
+++ b/docs/docs/build/axvisor/overview.md
@@ -50,7 +50,10 @@ vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/linux-vmx-smp1.toml"]
 
 ### 2.2 VM 选择
 
-CLI 传入的 `--vmconfigs` 非空时覆盖该配置中的 `vm_configs`；否则使用 Build Config 中的列表。相对 VM 路径相对于 workspace 根解析后写入 `AXVISOR_VM_CONFIGS`，以平台路径分隔符连接。
+CLI 传入的 `--vmconfigs` 非空时覆盖该配置中的 `vm_configs`；否则使用 Build Config 中的列表。
+相对 VM config 路径相对于 workspace 根解析；其中五个 `[kernel]` 镜像路径字段支持 Ostool
+变量，并按原 VM config 目录解析相对路径。最终解析后的配置写入 `AXVISOR_VM_CONFIGS`，以
+平台路径分隔符连接。
 
 ## 3. 虚拟化后端
 

--- a/docs/docs/build/axvisor/runtime.md
+++ b/docs/docs/build/axvisor/runtime.md
@@ -9,16 +9,19 @@ Axvisor 的 QEMU 流程把 host 启动配置、hypervisor 构建配置、VM 描�
 
 ## 1. QEMU 启动
 
-Axvisor QEMU 运行先选择 rootfs，再读取 host 启动 TOML 并检查产物格式；VM 配置只提供 guest 语义。下图对应 `axvisor/rootfs.rs::qemu()` 的主要步骤。
+Axvisor QEMU 运行先解析 VM 镜像路径，再用同一组配置选择 rootfs，随后读取 host 启动
+TOML 并检查产物格式；VM 配置只提供 guest 语义。下图对应 `axvisor/rootfs.rs::qemu()`
+的主要步骤。
 
 ```mermaid
 flowchart TD
     A["axvisor qemu"] --> B["解析 Build Config / --vmconfigs"]
-    B --> C["选择并确保 rootfs"]
-    C --> D["加载 --qemu-config 或 configs/qemu/qemu-<arch>.toml"]
-    D --> E["替换或插入 rootfs -drive"]
-    E --> F["检查 UEFI + to_bin"]
-    F --> G["ostool cargo_run"]
+    B --> C["展开 VM 镜像路径变量"]
+    C --> D["从解析后配置选择并确保 rootfs"]
+    D --> E["加载 --qemu-config 或 configs/qemu/qemu-<arch>.toml"]
+    E --> F["替换或插入 rootfs -drive"]
+    F --> G["检查 UEFI + to_bin"]
+    G --> H["ostool cargo_run"]
 ```
 
 默认 QEMU 模板位于：
@@ -47,7 +50,9 @@ QEMU rootfs 路径的选择顺序为：
 - `to_bin = false` 时直接保留 ELF；
 - `uefi = true` 且 `to_bin = false` 是明确错误。Axvisor 在启动前报告该错误，要求配置显式设置 `to_bin = true`。
 
-仓库的 Axvisor x86_64 和 loongarch64 默认 QEMU 配置均将 UEFI 和 BIN 选择写在 TOML 中。guest UEFI firmware 的路径属于 VM config（例如 `boot_protocol = "uefi"` 与 `uefi_firmware_path`），不由 axbuild 运行时重写。
+仓库的 Axvisor x86_64 和 loongarch64 默认 QEMU 配置均将 UEFI 和 BIN 选择写在 TOML 中。
+guest UEFI firmware 的路径属于 VM config（例如 `boot_protocol = "uefi"` 与
+`uefi_firmware_path`）；axbuild 只在构建前展开受支持的路径变量，不改变 guest 固件 ABI。
 
 ### 1.3 LVZ QEMU
 

--- a/docs/docs/build/axvisor/test.md
+++ b/docs/docs/build/axvisor/test.md
@@ -75,7 +75,7 @@ flowchart TD
 | 步骤 | 源码位置 | 行为 |
 |------|----------|------|
 | 用例发现 | `discovery.rs::discover_qemu_cases()` | 扫描 `test-suit/axvisor/<group>/`，默认 group 为 `normal` |
-| VM 配置 | `qemu_group_build_context()` | 从 `AXVISOR_VM_CONFIGS` 环境变量解析 VM 配置路径，相对路径相对于 workspace 根 |
+| VM 配置 | `qemu_group_build_context()` | 读取 axbuild 已解析并写入 `AXVISOR_VM_CONFIGS` 的 VM 配置路径 |
 | rootfs 准备 | `rootfs::ensure_qemu_rootfs_ready()` | 每个 build group 编译前准备当前 arch 的 managed rootfs |
 | grouped 校验 | `validate_grouped_qemu_commands()` | 检查 `test_commands` 无空命令 |
 | 结果判定 | `QemuTestSummary` | 收集所有 case 的 pass/fail，最终 `finish_with_total_detail()` 统一判定退出码 |

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -120,7 +120,7 @@ push 到 `main` / `dev` 时强制运行 CI 检查。非 `main` / `dev` 分支没
 | Test arceos loongarch64 qemu | `self-hosted linux qcs` | 否 | 无 | `cargo xtask arceos test qemu --arch loongarch64`；仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted x86_64(svm) | `self-hosted linux amd kvm` | 否 | 无 | `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm`；验证 SVM 宿主启动及宿主 NVMe 根文件系统写入/回读，仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted x86_64(vmx) | `self-hosted linux intel kvm` | 否 | 无 | `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx`；验证 VMX 宿主启动及宿主 NVMe 根文件系统写入/回读，仅 `rcore-os` 仓库触发 |
-| Test axloader HTTP smoke | `self-hosted linux intel kvm` | 否 | 无 | 安装 `x86_64-unknown-uefi` target 与 OVMF，运行 `cargo axloader test qemu --target x86_64-unknown-uefi`；仅 `rcore-os` 仓库触发 |
+| Test axloader HTTP smoke | `self-hosted linux intel kvm` | 否 | 无 | 安装 `x86_64-unknown-uefi` target，通过 Ostool 获取并校验 OVMF，运行 `cargo xtask axloader test qemu --target x86_64-unknown-uefi`；仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted board orangepi-5-plus-linux | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board orangepi-5-plus-linux`；物理板卡；仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted board orangepi-5-plus-starry | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board orangepi-5-plus-starry`；物理板卡；仅 `rcore-os` 仓库触发 |
 | Test axvisor self-hosted board roc-rk3568-pc-linux | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board roc-rk3568-pc-linux`；物理板卡；仅 `rcore-os` 仓库触发 |

--- a/docs/docs/build/commands.md
+++ b/docs/docs/build/commands.md
@@ -47,6 +47,7 @@ cargo arceos qemu --package arceos-httpserver   # 同上
 | `cargo xtask board` | 远程板卡管理（ls/connect/config） | [板卡管理](./board) |
 | `cargo xtask backtrace` | host 端 backtrace 符号化 | [Backtrace 符号化](./backtrace) |
 | `cargo xtask image` | TGOS rootfs/guest 镜像管理 | [镜像管理](./image) |
+| `cargo xtask ovmf` | 获取经校验的 OVMF CODE/VARS 路径 | 本节 |
 | `cargo xtask axloader` | UEFI bootloader 构建与 HTTP smoke 测试 | [Axloader](./axloader) |
 | `cargo xtask agent-review-bench` | 历史 PR 快照的离线 review benchmark | [Review Benchmark](./agent-review-bench) |
 | **OS 子系统** | | |
@@ -177,7 +178,20 @@ TGOS rootfs/guest 镜像管理。**全局选项**（所有子命令可用）：`
 
 详见 [镜像管理](./image)。
 
-### 4.4 UEFI 引导
+### 4.4 OVMF 固件
+
+通过 Ostool 的固定版本、镜像探测和 SHA-256 校验流程准备 OVMF，并在 stdout 输出一个
+仅包含 `code`、`vars` 路径的 JSON 对象：
+
+```bash
+cargo xtask ovmf --arch x86_64
+TGOS_OVMF_DIR=/path/to/cache cargo xtask ovmf --arch aarch64
+```
+
+`--arch` 支持 `x86_64`、`aarch64`、`riscv64`、`loongarch64` 和 `ia32`。默认缓存根目录为
+`$TMPDIR/ostool/ovmf`；`TGOS_OVMF_DIR` 只覆盖缓存根目录，不绕过版本选择和校验。
+
+### 4.5 UEFI 引导
 
 UEFI bootloader（axloader）构建与 HTTP smoke 测试。
 
@@ -188,7 +202,7 @@ UEFI bootloader（axloader）构建与 HTTP smoke 测试。
 
 详见 [Axloader](./axloader)。
 
-### 4.5 Review Benchmark
+### 4.6 Review Benchmark
 
 离线回放 `scripts/agent-review-bench/cases/*.toml` 中登记的历史 PR 快照，并对 review findings 评分。该命令面向维护 benchmark，而非日常构建：
 

--- a/docs/docs/build/configuration.md
+++ b/docs/docs/build/configuration.md
@@ -207,6 +207,7 @@ guest 内核驱动不属于该迁移。
 | `STARRY_APK_REGION` | Starry managed rootfs 的 APK 区域，支持 `china`/`cn`、`us`/`usa` |
 | `TGOS_IMAGE_LOCAL_STORAGE` | 覆盖 image storage 目录 |
 | `TGOS_IMAGE_REGISTRY_FALLBACK_URL` | 覆盖镜像注册表 fallback URL |
+| `TGOS_OVMF_DIR` | 覆盖 Ostool 格式的 OVMF 缓存根目录；不绕过版本选择和 SHA-256 校验 |
 | `AXBUILD_KEEP_QEMU_LOG` | 保留 QEMU 日志，便于事后符号化 |
 
 `AX_LOG`、`SMP`、`AX_TARGET`、`AX_ARCH` 和 `AXVISOR_VM_CONFIGS` 主要由 axbuild 根据上述配置生成，不建议用外部环境绕过请求解析。

--- a/docs/docs/build/starry/perf.md
+++ b/docs/docs/build/starry/perf.md
@@ -8,9 +8,9 @@ sidebar_label: "性能剖析"
 `cargo xtask starry perf` 构建 StarryOS 并通过 qperf 进行性能剖析，输出火焰图（SVG/HTML/Folded）、Pprof 或 callchain 数据。这是 StarryOS 独有的命令，[ArceOS](../arceos/overview) 和 [Axvisor](../axvisor/overview) 没有。
 
 目前支持 `riscv64`、`loongarch64` 和 `x86_64`。x86_64 使用 StarryOS 的 q35/UEFI
-启动配置；命令会优先复用 ostool 下载的 OVMF，也可以通过 `QPERF_OVMF_DIR` 指向包含
-`code.fd` 和 `vars.fd` 的目录。建议在 x86_64 上同时使用 `--kernel-filter`，排除 UEFI
-固件和用户态地址。
+启动配置，并通过 Ostool 的固定版本和 SHA-256 校验流程复用公共 OVMF 缓存。需要隔离缓存时，
+统一设置 `TGOS_OVMF_DIR`；该目录必须使用 Ostool 的 `<arch>/code.fd`、`vars.fd` 布局。
+建议在 x86_64 上同时使用 `--kernel-filter`，排除 UEFI 固件和用户态地址。
 
 ## 剖析流程
 

--- a/docs/docs/build/starry/self-compilation.md
+++ b/docs/docs/build/starry/self-compilation.md
@@ -50,7 +50,8 @@ app runner 检测到成功标记后可安全结束 QEMU。来宾还会把当前�
 
 - Linux x86_64 host，并可读写 `/dev/kvm`；app runner 检测到后会自动加入 `-accel kvm`，
   上述长时间构建实际启用了 KVM；
-- `qemu-system-x86_64`、OVMF、`debugfs` 和 ext4 resize 工具；
+- `qemu-system-x86_64`、`debugfs` 和 ext4 resize 工具；OVMF 由 `cargo xtask ovmf`
+  下载并校验，首次运行需要网络；
 - host 和 QEMU guest 都可访问网络。
 
 正常流程不需要 sudo。第一次运行需要下载 Rust 官方组件、Alpine 包和 Cargo crates，后续运行
@@ -72,7 +73,8 @@ debugfs -R 'stat /opt/starryos-selfbuilt' "$ROOTFS"
 scripts/run-selfbuilt-kernel.sh --arch x86_64
 ```
 
-脚本会重新从 rootfs 提取 ELF，转换为 EFI payload，并通过 OVMF 启动。该脚本当前保留为
+脚本会重新从 rootfs 提取 ELF，转换为 EFI payload，通过 `cargo xtask ovmf --arch x86_64`
+取得与其他 QEMU 流程相同的 CODE/VARS 后启动。该脚本当前保留为
 后续烟测工具；本 PR 尚未完成产物生成和启动验证，不能据此宣称已经到达 Starry shell。
 
 ## riscv64 旧流程

--- a/os/axvisor/build.rs
+++ b/os/axvisor/build.rs
@@ -119,19 +119,16 @@ fn write_tokens(out_file: &mut fs::File, tokens: proc_macro2::TokenStream) -> an
     Ok(())
 }
 
-// Convert relative path to absolute path
-fn convert_to_absolute(configs_path: impl AsRef<Path>, path: &str) -> PathBuf {
+fn resolve_config_path(configs_path: impl AsRef<Path>, path: &str) -> PathBuf {
     let path = Path::new(path);
-    let configs_path = configs_path
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    configs_path
         .as_ref()
         .parent()
         .map(|parent| parent.join(path))
-        .unwrap_or_else(|| path.to_path_buf());
-    if path.is_relative() {
-        fs::canonicalize(configs_path).unwrap_or_else(|_| path.to_path_buf())
-    } else {
-        path.to_path_buf()
-    }
+        .unwrap_or_else(|| path.to_path_buf())
 }
 
 struct MemoryImage {
@@ -181,14 +178,14 @@ fn parse_config_file(config_file: &ConfigFile) -> Option<MemoryImage> {
 
     let kernel_path = config.get("kernel")?.as_table()?.get("kernel_path")?;
 
-    let kernel = convert_to_absolute(&config_file.path, kernel_path.as_str()?);
+    let kernel = resolve_config_path(&config_file.path, kernel_path.as_str()?);
 
     let dtb = config
         .get("kernel")?
         .as_table()?
         .get("dtb_path")
         .and_then(|v| v.as_str())
-        .map(|v| convert_to_absolute(&config_file.path, v));
+        .map(|v| resolve_config_path(&config_file.path, v));
 
     let enable_bios = config
         .get("kernel")?
@@ -200,12 +197,12 @@ fn parse_config_file(config_file: &ConfigFile) -> Option<MemoryImage> {
     let kernel_config = config.get("kernel")?.as_table()?;
 
     let bios = boot_firmware_path(kernel_config, enable_bios)
-        .map(|v| convert_to_absolute(&config_file.path, v));
+        .map(|v| resolve_config_path(&config_file.path, v));
 
     let ramdisk = kernel_config
         .get("ramdisk_path")
         .and_then(|v| v.as_str())
-        .map(|v| convert_to_absolute(&config_file.path, v));
+        .map(|v| resolve_config_path(&config_file.path, v));
 
     Some(MemoryImage {
         id,
@@ -225,7 +222,7 @@ fn parse_firmware_config_file(config_file: &ConfigFile) -> Option<FirmwareImage>
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     let bios = boot_firmware_path(kernel_config, enable_bios)
-        .map(|v| convert_to_absolute(&config_file.path, v))?;
+        .map(|v| resolve_config_path(&config_file.path, v))?;
 
     Some(FirmwareImage { id, bios })
 }

--- a/scripts/axbuild/src/axloader/mod.rs
+++ b/scripts/axbuild/src/axloader/mod.rs
@@ -15,8 +15,9 @@ use std::{
 
 use anyhow::{Context, bail};
 use clap::{Args, Subcommand};
+use ostool::ovmf::Arch;
 
-use crate::support::process::ProcessExt;
+use crate::support::{ovmf::OvmfFirmware, process::ProcessExt};
 
 const AXLOADER_PACKAGE: &str = "axloader";
 const AXLOADER_BIN: &str = "axloader";
@@ -25,15 +26,12 @@ const HTTP_SMOKE_BOOT_TIMEOUT: Duration = Duration::from_secs(240);
 const HTTP_SMOKE_TRANSFER_TIMEOUT: Duration = Duration::from_secs(30);
 const HTTP_SMOKE_MAX_ATTEMPTS: usize = 2;
 const QEMU_HOST_GATEWAY: &str = "10.0.2.2";
-const LEGACY_X86_64_UEFI_FIRMWARE_ENV: &str = "AXVISOR_X86_64_UEFI_FIRMWARE";
 
 #[derive(Clone, Copy)]
 struct LoaderSmokeTarget {
-    cargo_target: &'static str,
     arch: &'static str,
+    ovmf_arch: Arch,
     efi_output_file: &'static str,
-    firmware_env: &'static str,
-    firmware_candidates: &'static [&'static str],
     qemu_program: &'static str,
     qemu_args: fn(&Path, &Path) -> Vec<String>,
     kernel_elf: fn() -> Vec<u8>,
@@ -73,13 +71,6 @@ impl SmokeAttemptProgress {
         now >= self.deadline
     }
 }
-
-const X86_64_UEFI_FIRMWARE_CANDIDATES: &[&str] = &[
-    "/usr/share/OVMF/OVMF_CODE_4M.fd",
-    "/usr/share/OVMF/OVMF_CODE.fd",
-    "/usr/share/ovmf/OVMF.fd",
-    "/usr/share/qemu/OVMF.fd",
-];
 
 #[derive(Args, Debug, Clone, PartialEq, Eq)]
 pub struct ArgsBuild {
@@ -134,7 +125,7 @@ impl Axloader {
     pub async fn execute(&mut self, command: Command) -> anyhow::Result<()> {
         match command {
             Command::Build(args) => build(&self.workspace_root, args),
-            Command::Test(args) => test(&self.workspace_root, args),
+            Command::Test(args) => test(&self.workspace_root, args).await,
         }
     }
 }
@@ -143,13 +134,13 @@ pub fn build(workspace_root: &Path, args: ArgsBuild) -> anyhow::Result<()> {
     run_loader_build(workspace_root, &args.target, args.release || !args.debug)
 }
 
-pub fn test(workspace_root: &Path, args: ArgsTest) -> anyhow::Result<()> {
+pub async fn test(workspace_root: &Path, args: ArgsTest) -> anyhow::Result<()> {
     match args.command {
-        TestCommand::Qemu(args) => test_qemu(workspace_root, args),
+        TestCommand::Qemu(args) => test_qemu(workspace_root, args).await,
     }
 }
 
-fn test_qemu(workspace_root: &Path, args: ArgsTestQemu) -> anyhow::Result<()> {
+async fn test_qemu(workspace_root: &Path, args: ArgsTestQemu) -> anyhow::Result<()> {
     run_cargo(
         workspace_root,
         ["test", "-p", AXLOADER_PACKAGE, "--all-targets"],
@@ -168,7 +159,7 @@ fn test_qemu(workspace_root: &Path, args: ArgsTestQemu) -> anyhow::Result<()> {
     );
     result?;
 
-    run_http_smoke_test(workspace_root, &args.target)
+    run_http_smoke_test(workspace_root, &args.target).await
 }
 
 fn run_loader_build(workspace_root: &Path, target: &str, release: bool) -> anyhow::Result<()> {
@@ -196,23 +187,23 @@ fn run_cargo<'a>(
     command.exec()
 }
 
-fn run_http_smoke_test(workspace_root: &Path, target: &str) -> anyhow::Result<()> {
+async fn run_http_smoke_test(workspace_root: &Path, target: &str) -> anyhow::Result<()> {
     let smoke_target = smoke_target(target)?;
 
     println!("axloader http smoke: building UEFI loader ...");
     run_loader_build(workspace_root, target, true)?;
 
-    let firmware = find_uefi_firmware(smoke_target)?;
+    let firmware = OvmfFirmware::fetch(smoke_target.ovmf_arch).await?;
     println!(
         "axloader http smoke: using UEFI firmware {}",
-        firmware.display()
+        firmware.code().display()
     );
     let kernel = (smoke_target.kernel_elf)();
     let attempt_context = SmokeAttemptContext {
         workspace_root,
         target,
         smoke_target,
-        firmware: &firmware,
+        firmware: firmware.code(),
         kernel: &kernel,
     };
     let mut attempt = 1;
@@ -372,61 +363,15 @@ fn axloader_efi_path(workspace_root: &Path, target: &str) -> PathBuf {
 fn smoke_target(target: &str) -> anyhow::Result<LoaderSmokeTarget> {
     match target {
         "x86_64-unknown-uefi" => Ok(LoaderSmokeTarget {
-            cargo_target: "x86_64-unknown-uefi",
             arch: "x86_64",
+            ovmf_arch: Arch::X64,
             efi_output_file: "BOOTX64.EFI",
-            firmware_env: "AXLOADER_X86_64_UEFI_FIRMWARE",
-            firmware_candidates: X86_64_UEFI_FIRMWARE_CANDIDATES,
             qemu_program: "qemu-system-x86_64",
             qemu_args: x86_64_qemu_args,
             kernel_elf: minimal_x86_64_kernel_elf,
         }),
         _ => bail!("axloader HTTP smoke does not support target `{target}`"),
     }
-}
-
-fn find_uefi_firmware(target: LoaderSmokeTarget) -> anyhow::Result<PathBuf> {
-    if let Some(path) = std::env::var_os(target.firmware_env) {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Ok(path);
-        }
-    }
-    if target.firmware_env == "AXLOADER_X86_64_UEFI_FIRMWARE"
-        && let Some(path) = std::env::var_os(LEGACY_X86_64_UEFI_FIRMWARE_ENV)
-    {
-        let path = PathBuf::from(path);
-        if path.is_file() {
-            return Ok(path);
-        }
-    }
-
-    for path in uefi_firmware_candidates(target, &std::env::temp_dir()) {
-        if path.is_file() {
-            return Ok(path);
-        }
-    }
-
-    bail!(
-        "UEFI firmware not found for {}; set {} or install ovmf",
-        target.cargo_target,
-        target.firmware_env
-    )
-}
-
-fn uefi_firmware_candidates(target: LoaderSmokeTarget, temp_dir: &Path) -> Vec<PathBuf> {
-    let mut candidates = Vec::with_capacity(target.firmware_candidates.len() + 1);
-    if target.arch == "x86_64" {
-        candidates.push(
-            temp_dir
-                .join("ostool")
-                .join("ovmf")
-                .join("x64")
-                .join("code.fd"),
-        );
-    }
-    candidates.extend(target.firmware_candidates.iter().map(PathBuf::from));
-    candidates
 }
 
 fn spawn_axloader_qemu(
@@ -702,20 +647,6 @@ mod tests {
         assert!(boot_line.contains("\"kernel_size\":4096"));
         assert!(boot_line.contains("\"arch\":\"x86_64\""));
         assert!(boot_line.ends_with('\n'));
-    }
-
-    #[test]
-    fn x86_64_firmware_search_prefers_ostool_cache() {
-        let temp = tempfile::tempdir().unwrap();
-        let cached_firmware = temp.path().join("ostool/ovmf/x64/code.fd");
-        fs::create_dir_all(cached_firmware.parent().unwrap()).unwrap();
-        fs::write(&cached_firmware, b"OVMF").unwrap();
-        let target = smoke_target("x86_64-unknown-uefi").unwrap();
-
-        let candidates = uefi_firmware_candidates(target, temp.path());
-        let selected = candidates.into_iter().find(|path| path.is_file());
-
-        assert_eq!(selected, Some(cached_firmware));
     }
 
     #[test]

--- a/scripts/axbuild/src/axvisor/build/load.rs
+++ b/scripts/axbuild/src/axvisor/build/load.rs
@@ -42,7 +42,7 @@ pub(crate) fn workspace_root_from_axvisor_dir(axvisor_dir: &Path) -> PathBuf {
 
 pub(crate) fn default_build_info_path(axvisor_dir: &Path, target: &str) -> PathBuf {
     crate::build::default_build_info_path_in_workspace(
-        &super::workspace_root_from_axvisor_dir(axvisor_dir),
+        &workspace_root_from_axvisor_dir(axvisor_dir),
         super::AXVISOR_PACKAGE,
         target,
     )

--- a/scripts/axbuild/src/axvisor/build/mod.rs
+++ b/scripts/axbuild/src/axvisor/build/mod.rs
@@ -2,6 +2,7 @@ mod config;
 mod features;
 mod load;
 mod metadata;
+mod vm_config;
 
 #[cfg(test)]
 mod tests;
@@ -14,7 +15,7 @@ pub(crate) use config::AxvisorBoardFile;
 pub use config::{AXVISOR_PACKAGE, AxvisorBoardConfig};
 pub(crate) use load::{
     default_build_info_path, load_board_file, load_target_from_build_config,
-    resolve_build_info_path,
+    resolve_build_info_path, workspace_root_from_axvisor_dir,
 };
 use ostool::build::config::Cargo;
 
@@ -24,10 +25,6 @@ use self::{
 };
 pub use crate::build::LogLevel;
 use crate::context::ResolvedAxvisorRequest;
-
-pub(crate) fn workspace_root_from_axvisor_dir(axvisor_dir: &Path) -> PathBuf {
-    load::workspace_root_from_axvisor_dir(axvisor_dir)
-}
 
 pub(crate) fn load_cargo_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<Cargo> {
     let metadata =
@@ -65,7 +62,7 @@ fn patch_axvisor_cargo_config(
     cargo
         .env
         .insert("AX_TARGET".to_string(), request.target.clone());
-    let vmconfigs = if request.vmconfigs.is_empty() {
+    let configured_vmconfigs = if request.vmconfigs.is_empty() {
         config_vmconfigs
             .iter()
             .map(|path| resolve_build_config_vmconfig_path(request, path))
@@ -73,6 +70,7 @@ fn patch_axvisor_cargo_config(
     } else {
         request.vmconfigs.clone()
     };
+    let vmconfigs = vm_config::resolve_vmconfigs(request, &configured_vmconfigs)?;
     if !vmconfigs.is_empty() {
         let joined = std::env::join_paths(&vmconfigs)
             .map_err(|e| anyhow!("failed to join vmconfig paths: {e}"))?;
@@ -85,6 +83,14 @@ fn patch_axvisor_cargo_config(
     cargo.features.sort();
     cargo.features.dedup();
     Ok(())
+}
+
+pub(crate) fn vmconfigs_from_cargo(cargo: &Cargo) -> Vec<PathBuf> {
+    cargo
+        .env
+        .get("AXVISOR_VM_CONFIGS")
+        .map(|paths| std::env::split_paths(paths).collect())
+        .unwrap_or_default()
 }
 
 fn resolve_build_config_vmconfig_path(request: &ResolvedAxvisorRequest, path: &Path) -> PathBuf {

--- a/scripts/axbuild/src/axvisor/build/tests.rs
+++ b/scripts/axbuild/src/axvisor/build/tests.rs
@@ -256,6 +256,9 @@ fn load_cargo_config_injects_vmconfigs() {
     let root = tempdir().unwrap();
     let config_path = root.path().join(".build.toml");
     let vmconfigs = vec![root.path().join("a.toml"), root.path().join("b.toml")];
+    for vmconfig in &vmconfigs {
+        fs::write(vmconfig, "[kernel]\n").unwrap();
+    }
     fs::write(
         &config_path,
         r#"

--- a/scripts/axbuild/src/axvisor/build/vm_config.rs
+++ b/scripts/axbuild/src/axvisor/build/vm_config.rs
@@ -1,0 +1,203 @@
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, anyhow};
+use ostool::variables::{VariableScope, expand_path_variables};
+use sha2::{Digest, Sha256};
+use tempfile::NamedTempFile;
+
+use crate::context::ResolvedAxvisorRequest;
+
+const IMAGE_PATH_FIELDS: [&str; 5] = [
+    "kernel_path",
+    "dtb_path",
+    "bios_path",
+    "uefi_firmware_path",
+    "ramdisk_path",
+];
+
+pub(super) fn resolve_vmconfigs(
+    request: &ResolvedAxvisorRequest,
+    configured_paths: &[PathBuf],
+) -> anyhow::Result<Vec<PathBuf>> {
+    let workspace_root = super::workspace_root_from_axvisor_dir(&request.axvisor_dir);
+    let scope = VariableScope::new(
+        workspace_root.clone(),
+        request.axvisor_dir.clone(),
+        std::env::temp_dir(),
+    );
+    let output_dir = workspace_root.join("tmp/axbuild/axvisor/resolved-vm-configs");
+
+    configured_paths
+        .iter()
+        .map(|path| {
+            let source = if path.is_absolute() {
+                path.clone()
+            } else {
+                workspace_root.join(path)
+            };
+            resolve_vmconfig(&source, &scope, &output_dir)
+        })
+        .collect()
+}
+
+fn resolve_vmconfig(
+    source: &Path,
+    scope: &VariableScope,
+    output_dir: &Path,
+) -> anyhow::Result<PathBuf> {
+    let content = fs::read_to_string(source)
+        .with_context(|| format!("failed to read VM config {}", source.display()))?;
+    let mut document = content
+        .parse::<toml::Table>()
+        .with_context(|| format!("failed to parse VM config {}", source.display()))?;
+    let Some(kernel) = document.get("kernel").and_then(toml::Value::as_table) else {
+        return Ok(source.to_path_buf());
+    };
+
+    let mut paths = Vec::new();
+    let mut expanded_any = false;
+    for field in IMAGE_PATH_FIELDS {
+        let Some(value) = kernel.get(field) else {
+            continue;
+        };
+        let value = value.as_str().ok_or_else(|| {
+            anyhow!(
+                "VM config {} field kernel.{field} must be a string",
+                source.display()
+            )
+        })?;
+        let expanded = expand_path_variables(Path::new(value), scope).with_context(|| {
+            format!(
+                "failed to expand VM config {} field kernel.{field}",
+                source.display()
+            )
+        })?;
+        expanded_any |= expanded != Path::new(value);
+        paths.push((field, expanded));
+    }
+
+    if !expanded_any {
+        return Ok(source.to_path_buf());
+    }
+
+    let source_dir = source
+        .parent()
+        .with_context(|| format!("VM config path has no parent: {}", source.display()))?;
+    let kernel = document
+        .get_mut("kernel")
+        .and_then(toml::Value::as_table_mut)
+        .expect("kernel table was validated above");
+    for (field, path) in paths {
+        let path = if path.is_absolute() {
+            path
+        } else {
+            source_dir.join(path)
+        };
+        kernel.insert(
+            field.to_string(),
+            toml::Value::String(path.to_string_lossy().into_owned()),
+        );
+    }
+
+    let resolved = toml::to_string_pretty(&document)
+        .context("failed to serialize resolved Axvisor VM config")?;
+    install_resolved_config(source, output_dir, &resolved)
+}
+
+fn install_resolved_config(
+    source: &Path,
+    output_dir: &Path,
+    resolved: &str,
+) -> anyhow::Result<PathBuf> {
+    let digest = Sha256::digest(source.as_os_str().as_encoded_bytes());
+    let output = output_dir.join(format!("{digest:x}.toml"));
+    if fs::read_to_string(&output).is_ok_and(|current| current == resolved) {
+        return Ok(output);
+    }
+
+    fs::create_dir_all(output_dir).with_context(|| {
+        format!(
+            "failed to create resolved VM config directory {}",
+            output_dir.display()
+        )
+    })?;
+    let mut temporary = NamedTempFile::new_in(output_dir).with_context(|| {
+        format!(
+            "failed to create temporary VM config in {}",
+            output_dir.display()
+        )
+    })?;
+    temporary
+        .write_all(resolved.as_bytes())
+        .with_context(|| format!("failed to write resolved VM config {}", output.display()))?;
+    temporary
+        .persist(&output)
+        .map_err(|error| error.error)
+        .with_context(|| format!("failed to install resolved VM config {}", output.display()))?;
+    Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn resolves_all_image_paths_from_one_variable_scope() {
+        let root = tempdir().unwrap();
+        let workspace = root.path();
+        let package = workspace.join("os/axvisor");
+        let source_dir = workspace.join("configs/vms");
+        fs::create_dir_all(&package).unwrap();
+        fs::create_dir_all(&source_dir).unwrap();
+        let source = source_dir.join("guest.toml");
+        fs::write(
+            &source,
+            r#"
+[kernel]
+kernel_path = "${workspace}/tmp/kernel"
+dtb_path = "${tmpDir}/guest.dtb"
+bios_path = "firmware/bios.fd"
+uefi_firmware_path = "${package}/firmware/uefi.fd"
+ramdisk_path = "../images/initramfs.cpio"
+"#,
+        )
+        .unwrap();
+        let scope = VariableScope::new(
+            workspace.to_path_buf(),
+            package.clone(),
+            std::env::temp_dir(),
+        );
+
+        let output = resolve_vmconfig(
+            &source,
+            &scope,
+            &workspace.join("tmp/axbuild/axvisor/resolved-vm-configs"),
+        )
+        .unwrap();
+        let resolved = fs::read_to_string(output)
+            .unwrap()
+            .parse::<toml::Table>()
+            .unwrap();
+        let kernel = resolved["kernel"].as_table().unwrap();
+        let expected = [
+            ("kernel_path", workspace.join("tmp/kernel")),
+            ("dtb_path", std::env::temp_dir().join("guest.dtb")),
+            ("bios_path", source_dir.join("firmware/bios.fd")),
+            ("uefi_firmware_path", package.join("firmware/uefi.fd")),
+            ("ramdisk_path", source_dir.join("../images/initramfs.cpio")),
+        ];
+
+        for (field, path) in expected {
+            assert_eq!(
+                kernel[field].as_str(),
+                Some(path.to_string_lossy().as_ref())
+            );
+        }
+    }
+}

--- a/scripts/axbuild/src/axvisor/rootfs.rs
+++ b/scripts/axbuild/src/axvisor/rootfs.rs
@@ -29,7 +29,7 @@ struct VmKernelRootfsProbe {
 }
 
 pub(super) async fn qemu(axvisor: &mut Axvisor, args: super::ArgsQemu) -> anyhow::Result<()> {
-    let request = axvisor.prepare_request(
+    let mut request = axvisor.prepare_request(
         (&args.build).into(),
         args.qemu_config,
         None,
@@ -46,13 +46,14 @@ pub(super) async fn qemu(axvisor: &mut Axvisor, args: super::ArgsQemu) -> anyhow
             )
         })
         .transpose()?;
+    let mut cargo = build::load_cargo_config(&request)?;
+    request.vmconfigs = build::vmconfigs_from_cargo(&cargo);
     ensure_qemu_rootfs_ready(
         &request,
         axvisor.app.workspace_root(),
         explicit_rootfs.as_deref(),
     )
     .await?;
-    let mut cargo = build::load_cargo_config(&request)?;
     let qemu =
         load_patched_qemu_config(axvisor, &request, &cargo, explicit_rootfs.as_deref()).await?;
     cargo.to_bin = qemu_to_bin_requested(&qemu)?;
@@ -178,9 +179,16 @@ pub(crate) fn infer_rootfs_path(vmconfigs: &[PathBuf]) -> anyhow::Result<Option<
         let Some(kernel_path) = probe.kernel.and_then(|kernel| kernel.kernel_path) else {
             continue;
         };
-        let rootfs_path = Path::new(&kernel_path)
-            .parent()
-            .map(|dir| dir.join("rootfs.img"));
+        let kernel_path = Path::new(&kernel_path);
+        let kernel_path = if kernel_path.is_absolute() {
+            kernel_path.to_path_buf()
+        } else {
+            vmconfig
+                .parent()
+                .map(|parent| parent.join(kernel_path))
+                .unwrap_or_else(|| kernel_path.to_path_buf())
+        };
+        let rootfs_path = kernel_path.parent().map(|dir| dir.join("rootfs.img"));
         if let Some(rootfs_path) = rootfs_path
             && rootfs_path.exists()
         {
@@ -234,13 +242,10 @@ mod tests {
         let vmconfig = root.path().join("vm.toml");
         fs::write(
             &vmconfig,
-            format!(
-                r#"
+            r#"
 [kernel]
-kernel_path = "{}"
+kernel_path = "image/qemu-aarch64"
 "#,
-                image_dir.join("qemu-aarch64").display()
-            ),
         )
         .unwrap();
 

--- a/scripts/axbuild/src/axvisor/test/initramfs.rs
+++ b/scripts/axbuild/src/axvisor/test/initramfs.rs
@@ -112,7 +112,7 @@ fi
 exec /bin/busybox sh -i
 "#;
 
-pub(super) fn prepare_configured_busybox_initramfs(
+pub(super) async fn prepare_configured_busybox_initramfs(
     request: &ResolvedAxvisorRequest,
     cargo: &Cargo,
     workspace_root: &Path,
@@ -132,7 +132,7 @@ pub(super) fn prepare_configured_busybox_initramfs(
             "{OVMF_OUTPUT_ENV} is only valid for x86_64 Axvisor tests"
         );
         let output_path = resolve_output_path(workspace_root, configured_output, OVMF_OUTPUT_ENV)?;
-        super::ovmf::prepare_x86_ovmf(&output_path)?;
+        super::ovmf::prepare_x86_ovmf(&output_path).await?;
         println!("prepared Axvisor x86 OVMF image: {}", output_path.display());
     }
     Ok(())

--- a/scripts/axbuild/src/axvisor/test/ovmf.rs
+++ b/scripts/axbuild/src/axvisor/test/ovmf.rs
@@ -1,74 +1,32 @@
 //! OVMF image preparation for nested x86 Axvisor tests.
 
-use std::{
-    fs,
-    io::Write,
-    path::{Path, PathBuf},
-};
+use std::{fs, io::Write, path::Path};
 
 use anyhow::{Context, ensure};
+use ostool::ovmf::Arch;
 use tempfile::NamedTempFile;
 
-const OVMF_SOURCE_ENV: &str = "AXVISOR_X86_64_UEFI_FIRMWARE";
 const OVMF_SIZE: usize = 4 * 1024 * 1024;
-const CODE_CANDIDATES: &[&str] = &[
-    "/usr/share/OVMF/OVMF_CODE_4M.fd",
-    "/usr/share/edk2/x64/OVMF_CODE.4m.fd",
-    "/usr/share/edk2/ovmf/OVMF_CODE_4M.fd",
-];
-const VARS_CANDIDATES: &[&str] = &[
-    "/usr/share/OVMF/OVMF_VARS_4M.fd",
-    "/usr/share/edk2/x64/OVMF_VARS.4m.fd",
-    "/usr/share/edk2/ovmf/OVMF_VARS_4M.fd",
-];
 
-pub(super) fn prepare_x86_ovmf(output_path: &Path) -> anyhow::Result<()> {
-    let configured = std::env::var_os(OVMF_SOURCE_ENV).map(PathBuf::from);
-    let managed_code = std::env::temp_dir().join("ostool/ovmf/x64/code.fd");
-    let code_path = configured
-        .as_deref()
-        .filter(|path| path.is_file())
-        .or_else(|| managed_code.is_file().then_some(managed_code.as_path()))
-        .or_else(|| {
-            CODE_CANDIDATES
-                .iter()
-                .map(Path::new)
-                .find(|path| path.is_file())
-        })
-        .with_context(|| {
-            format!(
-                "x86 Axvisor test requires an OVMF 4 MiB code image; set {OVMF_SOURCE_ENV} or \
-                 install ovmf"
-            )
-        })?;
+pub(super) async fn prepare_x86_ovmf(output_path: &Path) -> anyhow::Result<()> {
+    let firmware = crate::support::ovmf::OvmfFirmware::fetch(Arch::X64).await?;
+    let code_path = firmware.code();
     let code = fs::read(code_path)
         .with_context(|| format!("failed to read OVMF code image {}", code_path.display()))?;
     let vars = if code.len() == OVMF_SIZE {
         None
     } else {
-        let required = OVMF_SIZE.checked_sub(code.len()).with_context(|| {
+        OVMF_SIZE.checked_sub(code.len()).with_context(|| {
             format!(
                 "OVMF code image {} is larger than 4 MiB",
                 code_path.display()
             )
         })?;
-        let vars_path = paired_vars_path(code_path)
-            .filter(|path| file_has_size(path, required))
-            .or_else(|| {
-                VARS_CANDIDATES
-                    .iter()
-                    .map(Path::new)
-                    .find(|path| file_has_size(path, required))
-                    .map(Path::to_path_buf)
-            })
-            .with_context(|| {
-                format!(
-                    "OVMF code image {} needs a {required:#x}-byte variable-store prefix",
-                    code_path.display()
-                )
-            })?;
-        Some(fs::read(&vars_path).with_context(|| {
-            format!("failed to read OVMF variable store {}", vars_path.display())
+        Some(fs::read(firmware.vars()).with_context(|| {
+            format!(
+                "failed to read OVMF variable store {}",
+                firmware.vars().display()
+            )
         })?)
     };
     let image = assemble_ovmf_image(&code, vars.as_deref())?;
@@ -115,20 +73,6 @@ fn assemble_ovmf_image(code: &[u8], vars: Option<&[u8]>) -> anyhow::Result<Vec<u
     image.extend_from_slice(vars);
     image.extend_from_slice(code);
     Ok(image)
-}
-
-fn paired_vars_path(code_path: &Path) -> Option<PathBuf> {
-    let file_name = code_path.file_name()?.to_str()?;
-    let vars_name = if file_name == "code.fd" {
-        "vars.fd".to_string()
-    } else {
-        file_name.replace("CODE", "VARS")
-    };
-    (vars_name != file_name).then(|| code_path.with_file_name(vars_name))
-}
-
-fn file_has_size(path: &Path, size: usize) -> bool {
-    path.is_file() && fs::metadata(path).is_ok_and(|metadata| metadata.len() == size as u64)
 }
 
 #[cfg(test)]

--- a/scripts/axbuild/src/axvisor/test/qemu.rs
+++ b/scripts/axbuild/src/axvisor/test/qemu.rs
@@ -128,7 +128,8 @@ impl Axvisor {
                 &build_group.request,
                 &build_group.cargo,
                 self.app.workspace_root(),
-            )?;
+            )
+            .await?;
             self.app
                 .build(
                     build_group.cargo.clone(),
@@ -233,7 +234,7 @@ impl Axvisor {
         let mut request = request.clone();
         request.build_info_path = build_config_path.to_path_buf();
         let cargo = build::load_cargo_config(&request)?;
-        request.vmconfigs = qemu_group_vmconfigs(&request, &cargo)?;
+        request.vmconfigs = build::vmconfigs_from_cargo(&cargo);
 
         Ok((request, cargo))
     }
@@ -304,29 +305,6 @@ impl Axvisor {
         )
         .await
     }
-}
-
-fn qemu_group_vmconfigs(
-    request: &ResolvedAxvisorRequest,
-    cargo: &Cargo,
-) -> anyhow::Result<Vec<PathBuf>> {
-    let Some(value) = cargo.env.get("AXVISOR_VM_CONFIGS") else {
-        return Ok(Vec::new());
-    };
-    std::env::split_paths(value)
-        .map(|path| {
-            if path.is_absolute() {
-                Ok(path)
-            } else {
-                Ok(request
-                    .axvisor_dir
-                    .parent()
-                    .and_then(Path::parent)
-                    .unwrap_or(&request.axvisor_dir)
-                    .join(path))
-            }
-        })
-        .collect()
 }
 
 fn axvisor_qemu_test_build_args(arch: &str, config: Option<PathBuf>) -> AxvisorCliArgs {

--- a/scripts/axbuild/src/ktest/mod.rs
+++ b/scripts/axbuild/src/ktest/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use anyhow::{Context, anyhow, bail};
 use cargo_metadata::Package;
 use clap::{Args, Subcommand, ValueEnum};
-use ostool::{board::RunBoardOptions, build::config::Cargo, run::qemu::QemuConfig};
+use ostool::{board::RunBoardOptions, build::config::Cargo, ovmf::Arch, run::qemu::QemuConfig};
 
 use crate::{
     axvisor,
@@ -208,7 +208,7 @@ async fn run_qemu(args: ArgsKtestQemu) -> anyhow::Result<()> {
             crate::rootfs::qemu::RootfsPatchMode::EnsureDiskBootNet,
         );
     }
-    patch_system_x86_64_uefi_kernel_loader(&mut qemu, &arch, output.elf_path())?;
+    patch_x86_64_uefi_kernel_loader(&mut qemu, &arch, output.elf_path()).await?;
     apply_axtest_qemu_markers(&mut qemu);
     app.run_qemu_with_axtest_coverage(&cargo, qemu, None)
         .await?;
@@ -218,7 +218,7 @@ async fn run_qemu(args: ArgsKtestQemu) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn patch_system_x86_64_uefi_kernel_loader(
+async fn patch_x86_64_uefi_kernel_loader(
     qemu: &mut QemuConfig,
     arch: &str,
     elf_path: &Path,
@@ -227,26 +227,22 @@ fn patch_system_x86_64_uefi_kernel_loader(
         return Ok(());
     }
 
-    let Some((code, vars_template)) = find_system_x86_64_ovmf_pair() else {
-        return Ok(());
-    };
-
+    let firmware = crate::support::ovmf::OvmfFirmware::fetch(Arch::X64).await?;
     let vars = elf_path.with_extension("vars.fd");
-    fs::copy(vars_template, &vars).with_context(|| {
+    fs::copy(firmware.vars(), &vars).with_context(|| {
         format!(
             "failed to copy OVMF vars from {} to {}",
-            vars_template.display(),
+            firmware.vars().display(),
             vars.display()
         )
     })?;
-    apply_system_x86_64_uefi_kernel_loader(qemu, code, &vars);
+    apply_x86_64_uefi_kernel_loader(qemu, firmware.code(), &vars);
     Ok(())
 }
 
-fn apply_system_x86_64_uefi_kernel_loader(qemu: &mut QemuConfig, code: &Path, vars: &Path) {
-    // Keep ostool's BIN conversion and QEMU `-kernel` loader, but bypass its
-    // prebuilt OVMF path. QEMU can load this x86_64 UEFI image directly via
-    // `-kernel` when system OVMF pflash drives are supplied explicitly.
+fn apply_x86_64_uefi_kernel_loader(qemu: &mut QemuConfig, code: &Path, vars: &Path) {
+    // Keep ostool's BIN conversion and QEMU kernel loader while supplying
+    // the shared OVMF cache as explicit pflash drives.
     qemu.uefi = false;
     qemu.to_bin = true;
     qemu.args.extend([
@@ -258,29 +254,6 @@ fn apply_system_x86_64_uefi_kernel_loader(qemu: &mut QemuConfig, code: &Path, va
         "-drive".to_string(),
         format!("if=pflash,format=raw,unit=1,file={}", vars.display()),
     ]);
-}
-
-fn find_system_x86_64_ovmf_pair() -> Option<(&'static Path, &'static Path)> {
-    x86_64_system_ovmf_candidates()
-        .iter()
-        .copied()
-        .map(|(code, vars)| (Path::new(code), Path::new(vars)))
-        .find(|(code, vars)| code.is_file() && vars.is_file())
-}
-
-fn x86_64_system_ovmf_candidates() -> &'static [(&'static str, &'static str)] {
-    &[
-        (
-            "/usr/share/OVMF/OVMF_CODE.fd",
-            "/usr/share/OVMF/OVMF_VARS.fd",
-        ),
-        (
-            "/usr/share/OVMF/OVMF_CODE_4M.fd",
-            "/usr/share/OVMF/OVMF_VARS_4M.fd",
-        ),
-        ("/usr/share/ovmf/OVMF.fd", "/usr/share/OVMF/OVMF_VARS.fd"),
-        ("/usr/share/qemu/OVMF.fd", "/usr/share/OVMF/OVMF_VARS.fd"),
-    ]
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/scripts/axbuild/src/ktest/tests.rs
+++ b/scripts/axbuild/src/ktest/tests.rs
@@ -205,23 +205,31 @@ fn starry_kernel_ktest_target_log_features_remain_no_std() {
 }
 
 #[test]
-fn system_x86_64_uefi_kernel_loader_avoids_ostool_ovmf_prebuilt() {
+fn x86_64_uefi_kernel_loader_uses_explicit_cached_pflash() {
     let mut qemu = QemuConfig {
         args: vec!["-nographic".into()],
         uefi: true,
         ..QemuConfig::default()
     };
 
-    apply_system_x86_64_uefi_kernel_loader(
+    apply_x86_64_uefi_kernel_loader(
         &mut qemu,
-        Path::new("/usr/share/OVMF/OVMF_CODE.fd"),
+        Path::new("/cache/ovmf/x64/code.fd"),
         Path::new("/tmp/axtest.vars.fd"),
     );
 
     assert!(!qemu.uefi);
     assert!(qemu.to_bin);
-    assert!(qemu.args.iter().any(|arg| arg.contains("OVMF_CODE.fd")));
-    assert!(qemu.args.iter().any(|arg| arg.contains("axtest.vars.fd")));
+    assert!(
+        qemu.args
+            .iter()
+            .any(|arg| arg.contains("/cache/ovmf/x64/code.fd"))
+    );
+    assert!(
+        qemu.args
+            .iter()
+            .any(|arg| arg.contains("/tmp/axtest.vars.fd"))
+    );
 }
 
 #[test]

--- a/scripts/axbuild/src/lib.rs
+++ b/scripts/axbuild/src/lib.rs
@@ -78,6 +78,8 @@ enum Commands {
     },
     /// TGOS image management
     Image(image::ImageArgs),
+    /// Fetch verified OVMF firmware and print its paths as JSON
+    Ovmf(support::ovmf::OvmfArgs),
     /// Axvisor host-side commands
     Axvisor {
         #[command(subcommand)]
@@ -128,6 +130,7 @@ async fn run_root_cli(cli: Cli) -> anyhow::Result<()> {
         Commands::Board { command } => board::execute(command).await,
         Commands::Backtrace { command } => backtrace::execute(command),
         Commands::Image(args) => image::run(args).await,
+        Commands::Ovmf(args) => support::ovmf::execute(args).await,
         Commands::Axvisor { command } => Axvisor::new()?.execute(command).await,
         Commands::Axloader { command } => Axloader::new()?.execute(command).await,
         Commands::Arceos { command } => ArceOS::new()?.execute(command).await,

--- a/scripts/axbuild/src/starry/perf/mod.rs
+++ b/scripts/axbuild/src/starry/perf/mod.rs
@@ -72,7 +72,7 @@ pub(super) async fn run(starry: &mut Starry, args: ArgsPerf) -> anyhow::Result<(
     qemu::write_qemu_config(&outputs, &tools, &args, &arch, &qemu, text_range)?;
 
     let kernel_bin = symbols::kernel_bin_path(starry.app.workspace_root(), &target, args.debug);
-    let qemu_run = qemu::run_qemu_direct(&outputs, &args, &arch, &kernel_bin)?;
+    let qemu_run = qemu::run_qemu_direct(&outputs, &args, &arch, &kernel_bin).await?;
     if !qemu_run.status.success() {
         if !outputs::file_nonempty(&outputs.raw) {
             bail!(

--- a/scripts/axbuild/src/starry/perf/qemu.rs
+++ b/scripts/axbuild/src/starry/perf/qemu.rs
@@ -1,12 +1,13 @@
 use std::{
-    env, fs,
+    fs,
     fs::File,
-    path::{Path, PathBuf},
+    path::Path,
     process::{Command, ExitStatus},
     time::Instant,
 };
 
 use anyhow::{Context, bail};
+use ostool::ovmf::Arch;
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -26,7 +27,6 @@ use super::{
 pub(super) const QPERF_QUEUE_SIZE: usize = 4096;
 pub(super) const DEFAULT_STARRY_SHELL_PREFIX: &str = "root@starry:";
 const SUPPORTED_ARCHES: &str = "riscv64, loongarch64, and x86_64";
-const OVMF_DIR_ENV: &str = "QPERF_OVMF_DIR";
 
 #[derive(Deserialize, Serialize)]
 pub(super) struct PerfQemuConfig {
@@ -163,7 +163,7 @@ fn has_qemu_option(args: &[String], option: &str) -> bool {
     args.iter().any(|arg| arg == option)
 }
 
-pub(super) fn run_qemu_direct(
+pub(super) async fn run_qemu_direct(
     outputs: &PerfOutputs,
     args: &ArgsPerf,
     arch: &str,
@@ -177,7 +177,7 @@ pub(super) fn run_qemu_direct(
 
     let mut command_args = qemu_command_prefix(qemu, args.timeout, monitor_stdout);
     command_args.extend(qemu_args);
-    command_args.extend(prepare_boot_args(outputs, &config, arch, kernel_bin)?);
+    command_args.extend(prepare_boot_args(outputs, &config, arch, kernel_bin).await?);
 
     if args.host_perf {
         if let Some(perf) = find_executable("perf") {
@@ -251,7 +251,7 @@ fn qemu_command_prefix(qemu: &str, timeout: u64, monitor_stdout: bool) -> Vec<St
     }
 }
 
-fn prepare_boot_args(
+async fn prepare_boot_args(
     outputs: &PerfOutputs,
     config: &PerfQemuConfig,
     arch: &str,
@@ -270,57 +270,18 @@ fn prepare_boot_args(
         bail!("StarryOS x86_64 qperf requires a QEMU config with `to_bin = true`");
     }
 
-    let firmware = find_x86_64_uefi_firmware()?;
+    let firmware = crate::support::ovmf::OvmfFirmware::fetch(Arch::X64).await?;
     prepare_x86_64_uefi_boot(&outputs.dir, kernel_bin, &firmware)
-}
-
-struct UefiFirmware {
-    code: PathBuf,
-    vars: PathBuf,
-}
-
-fn find_x86_64_uefi_firmware() -> anyhow::Result<UefiFirmware> {
-    let mut candidates = Vec::new();
-    if let Some(dir) = env::var_os(OVMF_DIR_ENV) {
-        candidates.push(PathBuf::from(dir));
-    }
-    candidates.extend([
-        env::temp_dir().join("ostool/ovmf/x64"),
-        PathBuf::from("/usr/share/OVMF"),
-        PathBuf::from("/usr/share/edk2/x64"),
-        PathBuf::from("/usr/share/qemu"),
-    ]);
-
-    for dir in candidates {
-        for (code_name, vars_name) in [
-            ("code.fd", "vars.fd"),
-            ("OVMF_CODE.fd", "OVMF_VARS.fd"),
-            ("edk2-x86_64-code.fd", "edk2-i386-vars.fd"),
-        ] {
-            let firmware = UefiFirmware {
-                code: dir.join(code_name),
-                vars: dir.join(vars_name),
-            };
-            if firmware.code.is_file() && firmware.vars.is_file() {
-                return Ok(firmware);
-            }
-        }
-    }
-
-    bail!(
-        "qperf could not find x86_64 OVMF firmware; install the host OVMF package or set \
-         {OVMF_DIR_ENV} to a directory containing code.fd and vars.fd"
-    )
 }
 
 fn prepare_x86_64_uefi_boot(
     output_dir: &Path,
     kernel_bin: &Path,
-    firmware: &UefiFirmware,
+    firmware: &crate::support::ovmf::OvmfFirmware,
 ) -> anyhow::Result<Vec<String>> {
     ensure_file(kernel_bin, "StarryOS x86_64 UEFI image")?;
-    ensure_file(&firmware.code, "OVMF code image")?;
-    ensure_file(&firmware.vars, "OVMF vars template")?;
+    ensure_file(firmware.code(), "OVMF code image")?;
+    ensure_file(firmware.vars(), "OVMF vars template")?;
 
     let esp_dir = output_dir.join("starryos.esp");
     let boot_dir = esp_dir.join("EFI/BOOT");
@@ -336,10 +297,10 @@ fn prepare_x86_64_uefi_boot(
     })?;
 
     let vars = output_dir.join("starryos.vars.fd");
-    fs::copy(&firmware.vars, &vars).with_context(|| {
+    fs::copy(firmware.vars(), &vars).with_context(|| {
         format!(
             "failed to copy OVMF vars template from {} to {}",
-            firmware.vars.display(),
+            firmware.vars().display(),
             vars.display()
         )
     })?;
@@ -348,7 +309,7 @@ fn prepare_x86_64_uefi_boot(
         "-drive".to_string(),
         format!(
             "if=pflash,format=raw,unit=0,readonly=on,file={}",
-            firmware.code.display()
+            firmware.code().display()
         ),
         "-drive".to_string(),
         format!("if=pflash,format=raw,unit=1,file={}", vars.display()),
@@ -394,10 +355,13 @@ mod tests {
     use std::fs;
 
     use super::{
-        UefiFirmware, append_text_filter_params, direct_qemu_args, prepare_x86_64_uefi_boot,
-        qemu_command_prefix, validate_arch,
+        append_text_filter_params, direct_qemu_args, prepare_x86_64_uefi_boot, qemu_command_prefix,
+        validate_arch,
     };
-    use crate::starry::perf::symbols::{AddressRange, KernelTextRange};
+    use crate::{
+        starry::perf::symbols::{AddressRange, KernelTextRange},
+        support::ovmf::OvmfFirmware,
+    };
 
     #[test]
     fn direct_qemu_args_accepts_x86_64_q35_config() {
@@ -466,10 +430,7 @@ mod tests {
         let args = prepare_x86_64_uefi_boot(
             temp.path(),
             &kernel_bin,
-            &UefiFirmware {
-                code: code.clone(),
-                vars,
-            },
+            &OvmfFirmware::from_paths(code.clone(), vars),
         )
         .unwrap();
 

--- a/scripts/axbuild/src/support/mod.rs
+++ b/scripts/axbuild/src/support/mod.rs
@@ -3,5 +3,6 @@ pub(crate) mod backtrace_output_capture;
 pub(crate) mod download;
 pub(crate) mod git;
 pub(crate) mod logging;
+pub(crate) mod ovmf;
 pub mod process;
 pub(crate) mod qemu_success;

--- a/scripts/axbuild/src/support/ovmf.rs
+++ b/scripts/axbuild/src/support/ovmf.rs
@@ -1,0 +1,106 @@
+use std::{ffi::OsString, path::PathBuf};
+
+use anyhow::{Context, ensure};
+use clap::Args;
+use ostool::ovmf::*;
+use serde::Serialize;
+
+const CACHE_DIR_ENV: &str = "TGOS_OVMF_DIR";
+
+#[derive(Args, Clone, Debug)]
+pub(crate) struct OvmfArgs {
+    /// OVMF architecture: x86_64, aarch64, riscv64, loongarch64, or ia32
+    #[arg(long, value_parser = parse_arch)]
+    pub(crate) arch: Arch,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct OvmfFirmware {
+    code: PathBuf,
+    vars: PathBuf,
+}
+
+impl OvmfFirmware {
+    pub(crate) async fn fetch(arch: Arch) -> anyhow::Result<Self> {
+        let cache_dir = selected_cache_dir(std::env::var_os(CACHE_DIR_ENV))?;
+        let prebuilt = Prebuilt::fetch(Source::LATEST, &cache_dir)
+            .await
+            .with_context(|| format!("failed to prepare OVMF cache {}", cache_dir.display()))?;
+        let firmware = Self {
+            code: prebuilt.get_file(arch, FileType::Code),
+            vars: prebuilt.get_file(arch, FileType::Vars),
+        };
+        ensure!(
+            firmware.code.is_file() && firmware.vars.is_file(),
+            "OVMF cache {} does not contain code and vars firmware for {}",
+            cache_dir.display(),
+            arch.as_str()
+        );
+        Ok(firmware)
+    }
+
+    pub(crate) fn code(&self) -> &std::path::Path {
+        &self.code
+    }
+
+    pub(crate) fn vars(&self) -> &std::path::Path {
+        &self.vars
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_paths(code: PathBuf, vars: PathBuf) -> Self {
+        Self { code, vars }
+    }
+}
+
+pub(crate) async fn execute(args: OvmfArgs) -> anyhow::Result<()> {
+    let firmware = OvmfFirmware::fetch(args.arch).await?;
+    println!("{}", serde_json::to_string(&firmware)?);
+    Ok(())
+}
+
+fn selected_cache_dir(override_dir: Option<OsString>) -> anyhow::Result<PathBuf> {
+    let Some(override_dir) = override_dir else {
+        return Ok(default_cache_dir());
+    };
+    ensure!(
+        !override_dir.is_empty(),
+        "{CACHE_DIR_ENV} must not be empty"
+    );
+    Ok(PathBuf::from(override_dir))
+}
+
+fn parse_arch(value: &str) -> Result<Arch, String> {
+    match value {
+        "x86_64" | "x64" => Ok(Arch::X64),
+        "aarch64" => Ok(Arch::Aarch64),
+        "riscv64" => Ok(Arch::Riscv64),
+        "loongarch64" => Ok(Arch::LoongArch64),
+        "i386" | "ia32" => Ok(Arch::Ia32),
+        _ => Err(format!("unsupported OVMF architecture '{value}'")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn override_and_json_contract_are_stable() {
+        let override_dir = PathBuf::from("/cache/ovmf");
+        assert_eq!(
+            selected_cache_dir(Some(override_dir.clone().into_os_string())).unwrap(),
+            override_dir
+        );
+        assert_eq!(selected_cache_dir(None).unwrap(), default_cache_dir());
+        assert!(selected_cache_dir(Some(OsString::new())).is_err());
+
+        let json = serde_json::to_value(OvmfFirmware {
+            code: PathBuf::from("/cache/ovmf/x64/code.fd"),
+            vars: PathBuf::from("/cache/ovmf/x64/vars.fd"),
+        })
+        .unwrap();
+        assert_eq!(json["code"], "/cache/ovmf/x64/code.fd");
+        assert_eq!(json["vars"], "/cache/ovmf/x64/vars.fd");
+    }
+}

--- a/scripts/run-selfbuilt-kernel.sh
+++ b/scripts/run-selfbuilt-kernel.sh
@@ -179,40 +179,19 @@ case "$ARCH" in
         cp "$BIN_KERNEL" "$ESP_DIR/EFI/BOOT/BOOTX64.EFI"
         info "ESP ready: $ESP_DIR/EFI/BOOT/BOOTX64.EFI"
 
-        # OVMF firmware — search common distribution paths.
-        # Arch:    /usr/share/edk2/x64/OVMF_CODE.4m.fd  (edk2-ovmf)
-        # Debian:  /usr/share/OVMF/OVMF_CODE_4M.fd, /usr/share/OVMF/OVMF_CODE.fd  (ovmf)
-        # Fedora:  /usr/share/edk2/ovmf/OVMF_CODE.fd    (edk2-ovmf)
-        # Generic: /usr/share/ovmf/OVMF.fd, /usr/share/qemu/OVMF.fd
-        OVMF_CODE=""
-        for candidate in \
-            /usr/share/edk2/x64/OVMF_CODE.4m.fd \
-            /usr/share/OVMF/OVMF_CODE_4M.fd \
-            /usr/share/OVMF/OVMF_CODE.fd \
-            /usr/share/edk2/ovmf/OVMF_CODE.fd \
-            /usr/share/ovmf/OVMF.fd \
-            /usr/share/qemu/OVMF.fd; do
-            if [ -f "$candidate" ]; then
-                OVMF_CODE="$candidate"
-                break
-            fi
-        done
-        [ -n "$OVMF_CODE" ] || error "OVMF firmware not found; install edk2-ovmf or ovmf"
+        # Fetch the same verified OVMF asset used by xtask QEMU flows.
+        OVMF_JSON="$(cargo xtask ovmf --arch x86_64)" ||
+            error "failed to prepare OVMF firmware"
+        OVMF_PATHS="$(python3 -c \
+            'import json, sys; value = json.load(sys.stdin); print(value["code"]); print(value["vars"])' \
+            <<<"$OVMF_JSON")" || error "failed to parse OVMF path JSON"
+        OVMF_CODE="$(printf '%s\n' "$OVMF_PATHS" | sed -n '1p')"
+        OVMF_VARS_TEMPLATE="$(printf '%s\n' "$OVMF_PATHS" | sed -n '2p')"
+        [ -f "$OVMF_CODE" ] || error "OVMF code firmware not found: $OVMF_CODE"
+        [ -f "$OVMF_VARS_TEMPLATE" ] ||
+            error "OVMF vars firmware not found: $OVMF_VARS_TEMPLATE"
         info "OVMF firmware: $OVMF_CODE"
 
-        # Derive VARS template from same directory as CODE.
-        OVMF_DIR="$(dirname "$OVMF_CODE")"
-        OVMF_VARS_TEMPLATE=""
-        for candidate in \
-            "${OVMF_DIR}/OVMF_VARS.4m.fd" \
-            "${OVMF_DIR}/OVMF_VARS_4M.fd" \
-            "${OVMF_DIR}/OVMF_VARS.fd"; do
-            if [ -f "$candidate" ]; then
-                OVMF_VARS_TEMPLATE="$candidate"
-                break
-            fi
-        done
-        [ -n "$OVMF_VARS_TEMPLATE" ] || error "OVMF_VARS not found alongside OVMF_CODE in $OVMF_DIR"
         OVMF_VARS="$REPO_ROOT/tmp/OVMF_VARS.x86_64.fd"
         if [ ! -f "$OVMF_VARS" ]; then
             cp "$OVMF_VARS_TEMPLATE" "$OVMF_VARS"

--- a/test-suit/axvisor/normal/qemu-acpi-off/x86-linux-acpi-off.toml
+++ b/test-suit/axvisor/normal/qemu-acpi-off/x86-linux-acpi-off.toml
@@ -8,9 +8,9 @@ phys_cpu_ids = [1]
 [kernel]
 entry_point = 0x8000
 image_location = "memory"
-kernel_path = "../../../../tmp/axbuild/images/qemu-x86_64/linux/linux-qemu"
+kernel_path = "${workspace}/tmp/axbuild/images/qemu-x86_64/linux/linux-qemu"
 kernel_load_addr = 0x20_0000
-ramdisk_path = "../../../../tmp/axbuild/axvisor/qemu-acpi-off/initramfs-x86_64.cpio.gz"
+ramdisk_path = "${workspace}/tmp/axbuild/axvisor/qemu-acpi-off/initramfs-x86_64.cpio.gz"
 ramdisk_load_addr = 0x0800_0000
 enable_bios = false
 boot_protocol = "direct"

--- a/test-suit/axvisor/normal/qemu-acpi-ovmf/x86-linux-acpi-ovmf.toml
+++ b/test-suit/axvisor/normal/qemu-acpi-ovmf/x86-linux-acpi-ovmf.toml
@@ -8,13 +8,13 @@ phys_cpu_ids = [1]
 [kernel]
 entry_point = 0xffff_fff0
 image_location = "memory"
-kernel_path = "../../../../tmp/axbuild/images/qemu-x86_64/linux/linux-qemu"
+kernel_path = "${workspace}/tmp/axbuild/images/qemu-x86_64/linux/linux-qemu"
 kernel_load_addr = 0x20_0000
-ramdisk_path = "../../../../tmp/axbuild/axvisor/qemu-acpi-ovmf/initramfs-x86_64.cpio.gz"
+ramdisk_path = "${workspace}/tmp/axbuild/axvisor/qemu-acpi-ovmf/initramfs-x86_64.cpio.gz"
 ramdisk_load_addr = 0x1000_0000
 enable_bios = true
 boot_protocol = "uefi"
-uefi_firmware_path = "../../../../tmp/axbuild/axvisor/qemu-acpi-ovmf/OVMF_CODE_4M.fd"
+uefi_firmware_path = "${workspace}/tmp/axbuild/axvisor/qemu-acpi-ovmf/OVMF_CODE_4M.fd"
 bios_load_addr = 0xffc0_0000
 cmdline = "console=ttyS0 rdinit=/init devtmpfs.mount=1 loglevel=7 nox2apic no_timer_check initcall_blacklist=ahci_pci_driver_init axvisor.acpi_case=ovmf"
 memory_regions = [

--- a/test-suit/axvisor/normal/qemu-acpi/x86-linux-acpi-direct.toml
+++ b/test-suit/axvisor/normal/qemu-acpi/x86-linux-acpi-direct.toml
@@ -8,9 +8,9 @@ phys_cpu_ids = [1]
 [kernel]
 entry_point = 0x8000
 image_location = "memory"
-kernel_path = "../../../../tmp/axbuild/images/qemu-x86_64/linux/linux-qemu"
+kernel_path = "${workspace}/tmp/axbuild/images/qemu-x86_64/linux/linux-qemu"
 kernel_load_addr = 0x20_0000
-ramdisk_path = "../../../../tmp/axbuild/axvisor/qemu-acpi/initramfs-x86_64.cpio.gz"
+ramdisk_path = "${workspace}/tmp/axbuild/axvisor/qemu-acpi/initramfs-x86_64.cpio.gz"
 ramdisk_load_addr = 0x0800_0000
 enable_bios = false
 boot_protocol = "direct"

--- a/test-suit/axvisor/normal/qemu-timer-stress/aarch64-linux-timer-stress-v2.toml
+++ b/test-suit/axvisor/normal/qemu-timer-stress/aarch64-linux-timer-stress-v2.toml
@@ -8,10 +8,10 @@ phys_cpu_ids = [0, 1]
 [kernel]
 entry_point = 0x8020_0000
 image_location = "memory"
-kernel_path = "../../../../tmp/axbuild/images/qemu-aarch64/linux/linux-qemu"
+kernel_path = "${workspace}/tmp/axbuild/images/qemu-aarch64/linux/linux-qemu"
 kernel_load_addr = 0x8020_0000
 dtb_load_addr = 0x8000_0000
-ramdisk_path = "../../../../tmp/axbuild/axvisor/qemu-timer-stress/initramfs-aarch64.cpio.gz"
+ramdisk_path = "${workspace}/tmp/axbuild/axvisor/qemu-timer-stress/initramfs-aarch64.cpio.gz"
 ramdisk_load_addr = 0x8400_0000
 memory_regions = [
   [0x8000_0000, 0x4000_0000, 0x7, 0],

--- a/test-suit/axvisor/normal/qemu-timer-stress/aarch64-linux-timer-stress.toml
+++ b/test-suit/axvisor/normal/qemu-timer-stress/aarch64-linux-timer-stress.toml
@@ -8,10 +8,10 @@ phys_cpu_ids = [0, 1, 2, 3]
 [kernel]
 entry_point = 0x8020_0000
 image_location = "memory"
-kernel_path = "../../../../tmp/axbuild/images/qemu-aarch64/linux/linux-qemu"
+kernel_path = "${workspace}/tmp/axbuild/images/qemu-aarch64/linux/linux-qemu"
 kernel_load_addr = 0x8020_0000
 dtb_load_addr = 0x8000_0000
-ramdisk_path = "../../../../tmp/axbuild/axvisor/qemu-timer-stress/initramfs-aarch64.cpio.gz"
+ramdisk_path = "${workspace}/tmp/axbuild/axvisor/qemu-timer-stress/initramfs-aarch64.cpio.gz"
 ramdisk_load_addr = 0x8400_0000
 memory_regions = [
   [0x8000_0000, 0x4000_0000, 0x7, 0],


### PR DESCRIPTION
## 问题

仓内多个 x86 UEFI 流程分别扫描系统 OVMF、定义缓存环境变量或自行处理固件路径，导致下载、版本、校验和缓存语义重复。Axvisor VM 配置还包含多层相对路径，不同消费点分别解释配置路径，容易让构建脚本、rootfs 推断和运行时看到不同文件。

## 实现

- 升级到正式发布的 `ostool 0.27.1`，统一通过其公共 OVMF API 选择固定版本、下载、校验并复用缓存。
- 新增 `cargo xtask ovmf --arch <arch>`，以单个 JSON 对象输出 CODE/VARS 路径；`TGOS_OVMF_DIR` 只覆盖 Ostool 格式缓存根目录。
- 迁移 Axvisor nested OVMF、Starry qperf、x86 ktest、Axloader smoke 和自编译启动脚本，删除各自的系统 OVMF 候选表与下载/探测逻辑。nested Axvisor 仍只在本地组装所需的 4 MiB 派生镜像，不重复下载。
- 基于已合入的 #1907 保留 Axloader 的 KVM/host CPU、virtio 网卡、分阶段超时、全新实例重试与真实 HTTP 请求判据；删除其 CI 中新增的 `/usr/share/OVMF` 扫描和 `apt-get install ovmf`，代码与 CI 均改为公共 Ostool 入口。
- 在 Axvisor build 阶段集中解析 VM 配置的五个镜像路径字段，复用 Ostool 的 `${workspace}`、`${workspaceFolder}`、`${package}`、`${tmpDir}`、`${env:NAME}` 语法；相对路径以原配置目录为基准。含变量的解析结果原子写入按源路径 SHA-256 命名的临时配置，供 `AXVISOR_VM_CONFIGS`、rootfs 推断与 `os/axvisor/build.rs` 共用。
- 将 Axvisor QEMU 用例中的多层 `../../../../tmp/...` 改为 `${workspace}/tmp/...`，并同步构建文档与架构移植说明。

## 实现逻辑

Ostool 继续唯一拥有 OVMF 版本、镜像命名、SHA-256 校验和 `$TMPDIR/ostool/ovmf` 默认缓存；TGOSKits 只提供一个类型化适配层，不复制下载器。VM 配置路径只在进入 Axvisor 构建数据流时解析一次，后续所有消费者读取同一份配置，避免三套相对路径语义。

## 验证

- `cargo fmt --all -- --check`
- `cargo test -p axbuild --lib -- --test-threads=1`：844 passed
- `cargo xtask clippy --package axbuild`
- 空缓存首次获取与第二次直接复用，JSON 输出和 CODE/VARS 文件均验证
- `cargo xtask axloader test qemu --target x86_64-unknown-uefi`：真实下载 4098 字节并输出 `elf_loaded:`
- x86 UEFI ktest：396/396，`AXTEST_SUITE_OK`
- Axvisor `ovmf-acpi-vmx`：Linux ACPI 检查通过，`AXVISOR_X86_OVMF_ACPI_PASSED`

## 上游依赖

Ostool 公共 API 已由 drivercraft/ostool#167 合入并正式发布为 0.27.1。本分支已 rebase 到包含 #1907 的最新 `dev`。