### PR TITLE
fix(axdevice): correct fw_cfg DMA fault handling

### DIFF
--- a/scripts/axbuild/src/axvisor/test/qemu.rs
+++ b/scripts/axbuild/src/axvisor/test/qemu.rs
@@ -24,6 +24,8 @@ use crate::{
     test::{case as test_case, qemu as test_qemu},
 };
 
+const VCPU_RUNTIME_ERROR: &str = r"VM\[\d+\] run VCpu\[\d+\] get error";
+
 impl Axvisor {
     pub(super) async fn test_qemu(&mut self, args: ArgsTestQemu) -> anyhow::Result<()> {
         if args.list && args.arch.is_none() && args.target.is_none() && args.test_group.is_none() {
@@ -258,6 +260,13 @@ impl Axvisor {
             &asset_config.grouped_runner,
         );
         test_qemu::apply_timeout_scale(&mut qemu);
+        if !qemu
+            .fail_regex
+            .iter()
+            .any(|pattern| pattern == VCPU_RUNTIME_ERROR)
+        {
+            qemu.fail_regex.push(VCPU_RUNTIME_ERROR.to_string());
+        }
 
         let rootfs_path = rootfs::qemu_rootfs_path(request, self.app.workspace_root(), None)?;
         let prepared_assets = test_case::prepare_case_assets(

--- a/virtualization/axdevice/src/fw_cfg/mod.rs
+++ b/virtualization/axdevice/src/fw_cfg/mod.rs
@@ -404,34 +404,7 @@ impl FwCfg {
             return Ok(None);
         }
         let offset = addr.as_usize() - self.base.as_usize();
-
-        let mut state = self.state.lock();
-        match (offset - FW_CFG_DMA_OFFSET, width) {
-            (0, AccessWidth::Dword) => {
-                let high = (value as u32).swap_bytes() as u64;
-                state.dma_address = (high << 32) | (state.dma_address & u32::MAX as u64);
-                Ok(None)
-            }
-            (4, AccessWidth::Dword) => {
-                let low = (value as u32).swap_bytes() as u64;
-                state.dma_address = (state.dma_address & !u32::MAX as u64) | low;
-                Ok(Some(GuestPhysAddr::from_usize(state.dma_address as usize)))
-            }
-            (0, AccessWidth::Qword) => {
-                state.dma_address = (value as u64).swap_bytes();
-                Ok(Some(GuestPhysAddr::from_usize(state.dma_address as usize)))
-            }
-            _ => {
-                warn!(
-                    "unsupported fw_cfg DMA address write: offset={:#x}, width={:?}",
-                    offset, width
-                );
-                Err(DeviceManagerError::InvalidInput {
-                    operation: "write fw_cfg DMA address",
-                    detail: format!("offset {offset:#x} does not accept width {width:?}"),
-                })
-            }
-        }
+        self.write_dma_value(offset - FW_CFG_DMA_OFFSET, width, value)
     }
 
     /// Records a PIO DMA address-register write relative to the DMA window.
@@ -450,21 +423,25 @@ impl FwCfg {
         width: AccessWidth,
         value: usize,
     ) -> DeviceManagerResult<Option<GuestPhysAddr>> {
+        const LOW_DWORD_MASK: u64 = u32::MAX as u64;
+
         let mut state = self.state.lock();
         match (offset, width) {
             (0, AccessWidth::Dword) => {
                 let high = (value as u32).swap_bytes() as u64;
-                state.dma_address = (high << 32) | (state.dma_address & u32::MAX as u64);
+                state.dma_address = (high << 32) | (state.dma_address & LOW_DWORD_MASK);
                 Ok(None)
             }
             (4, AccessWidth::Dword) => {
                 let low = (value as u32).swap_bytes() as u64;
-                state.dma_address = (state.dma_address & !u32::MAX as u64) | low;
-                Ok(Some(GuestPhysAddr::from_usize(state.dma_address as usize)))
+                state.dma_address = (state.dma_address & !LOW_DWORD_MASK) | low;
+                let descriptor = core::mem::take(&mut state.dma_address);
+                Ok(Some(GuestPhysAddr::from_usize(descriptor as usize)))
             }
             (0, AccessWidth::Qword) => {
-                state.dma_address = (value as u64).swap_bytes();
-                Ok(Some(GuestPhysAddr::from_usize(state.dma_address as usize)))
+                let descriptor = (value as u64).swap_bytes();
+                state.dma_address = 0;
+                Ok(Some(GuestPhysAddr::from_usize(descriptor as usize)))
             }
             _ => Err(DeviceManagerError::InvalidInput {
                 operation: "write fw_cfg DMA address",
@@ -485,7 +462,14 @@ impl FwCfg {
         W: FnMut(GuestPhysAddr, &[u8]) -> DeviceManagerResult,
     {
         let mut desc = [0u8; FW_CFG_DMA_DESC_SIZE];
-        read_guest(desc_addr, &mut desc)?;
+        if let Err(error) = read_guest(desc_addr, &mut desc) {
+            warn!(
+                "failed to read fw_cfg DMA descriptor at {:#x}: {error}",
+                desc_addr.as_usize()
+            );
+            let _ = write_guest(desc_addr, &FW_CFG_DMA_CTL_ERROR.to_be_bytes());
+            return Ok(());
+        }
 
         let mut control = u32::from_be_bytes(desc[0..4].try_into().unwrap());
         let length = u32::from_be_bytes(desc[4..8].try_into().unwrap()) as usize;
@@ -498,13 +482,24 @@ impl FwCfg {
             &mut read_guest,
             &mut write_guest,
         );
-        control = if result.is_ok() {
-            0
-        } else {
+        control = if let Err(error) = result {
+            warn!(
+                "fw_cfg DMA command failed: descriptor={:#x}, buffer={:#x}, length={length:#x}: \
+                 {error}",
+                desc_addr.as_usize(),
+                buffer_addr.as_usize()
+            );
             FW_CFG_DMA_CTL_ERROR
+        } else {
+            0
         };
-        write_guest(desc_addr, &control.to_be_bytes())?;
-        result
+        if let Err(error) = write_guest(desc_addr, &control.to_be_bytes()) {
+            warn!(
+                "failed to write fw_cfg DMA status at {:#x}: {error}",
+                desc_addr.as_usize()
+            );
+        }
+        Ok(())
     }
 
     fn process_dma_command<R, W>(

--- a/virtualization/axdevice/src/fw_cfg/tests.rs
+++ b/virtualization/axdevice/src/fw_cfg/tests.rs
@@ -44,6 +44,39 @@ fn dma_rejects_buffer_address_overflow() {
     assert!(validate_dma_buffer(GuestPhysAddr::from_usize(usize::MAX), 2).is_err());
 }
 
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn dma_address_register_preserves_high_half_and_resets_after_commit() {
+    let fw_cfg = FwCfg::new(
+        GuestPhysAddr::from_usize(0),
+        0x20,
+        FwCfgKernelPayload::unsplit(Arc::from(&b"kernel"[..])),
+        None,
+        None,
+        1,
+        FwCfgPlatformConfig::default(),
+    );
+
+    assert_eq!(
+        fw_cfg
+            .write_dma_port(0, AccessWidth::Dword, 0xdead_beefu32.swap_bytes() as usize)
+            .unwrap(),
+        None
+    );
+    assert_eq!(
+        fw_cfg
+            .write_dma_port(4, AccessWidth::Dword, 0x8000u32.swap_bytes() as usize)
+            .unwrap(),
+        Some(GuestPhysAddr::from_usize(0xdead_beef_0000_8000))
+    );
+    assert_eq!(
+        fw_cfg
+            .write_dma_port(4, AccessWidth::Dword, 0x80u32.swap_bytes() as usize)
+            .unwrap(),
+        Some(GuestPhysAddr::from_usize(0x80))
+    );
+}
+
 #[cfg(feature = "host-test")]
 struct TestGuestMemory {
     bytes: Vec<u8>,
@@ -232,5 +265,66 @@ fn pio_selector_data_and_dma_share_one_fw_cfg_state() {
             &mut memory,
         )
         .unwrap();
+    assert_eq!(&memory.bytes[BUFFER..BUFFER + 4], b"QEMU");
+}
+
+#[cfg(feature = "host-test")]
+#[test]
+fn pio_dma_fault_does_not_poison_the_next_32_bit_transfer() {
+    const DESCRIPTOR: usize = 0x80;
+    const BUFFER: usize = 0x100;
+    let bundle = FwCfgDeviceFactory::new()
+        .build_pio(
+            0x510,
+            2,
+            0x514,
+            8,
+            FwCfgBuildConfig {
+                base: GuestPhysAddr::from_usize(0x510),
+                size: 0x0c,
+                kernel: FwCfgKernelPayload::unsplit(Arc::from(&b"kernel"[..])),
+                initrd: None,
+                cmdline: None,
+                cpu_num: 1,
+                platform: FwCfgPlatformConfig::default(),
+            },
+        )
+        .unwrap();
+    let mut runtime = crate::DeviceRuntime::empty();
+    runtime.register_bundle(bundle).unwrap();
+    let mut memory = TestGuestMemory {
+        bytes: alloc::vec![0; 0x200],
+    };
+
+    runtime
+        .handle_port_write_with_memory(
+            axdevice_base::Port::new(0x514),
+            AccessWidth::Dword,
+            0xdead_beefu32.swap_bytes() as usize,
+            &mut memory,
+        )
+        .unwrap();
+    runtime
+        .handle_port_write_with_memory(
+            axdevice_base::Port::new(0x518),
+            AccessWidth::Dword,
+            0x8000u32.swap_bytes() as usize,
+            &mut memory,
+        )
+        .unwrap();
+
+    let control = FW_CFG_DMA_CTL_SELECT | FW_CFG_DMA_CTL_READ;
+    memory.bytes[DESCRIPTOR..DESCRIPTOR + 4].copy_from_slice(&control.to_be_bytes());
+    memory.bytes[DESCRIPTOR + 4..DESCRIPTOR + 8].copy_from_slice(&4u32.to_be_bytes());
+    memory.bytes[DESCRIPTOR + 8..DESCRIPTOR + 16].copy_from_slice(&(BUFFER as u64).to_be_bytes());
+    runtime
+        .handle_port_write_with_memory(
+            axdevice_base::Port::new(0x518),
+            AccessWidth::Dword,
+            (DESCRIPTOR as u32).swap_bytes() as usize,
+            &mut memory,
+        )
+        .unwrap();
+
     assert_eq!(&memory.bytes[BUFFER..BUFFER + 4], b"QEMU");
 }


### PR DESCRIPTION
## 问题

PR #1917 合入后的 x86 ACPI/OVMF CI 在 OVMF 写 fw_cfg DMA 地址低 32 位时停止了来宾，随后测试仍等待成功标记直到任务超时。失败日志显示 `0x518` Dword 写最终尝试访问未映射 GPA。

根因有三点：

1. DMA 地址低半部的掩码表达式先在 `u32` 上取反，结果为 0，导致已锁存的高 32 位被清空；
2. DMA 事务提交后没有像 QEMU 一样清零地址寄存器，后续低 32 位事务可能继承旧状态；
3. guest-controlled descriptor/buffer 访问失败被当成 vCPU 致命设备错误，且 Axvisor QEMU 测试没有把 vCPU runtime error 作为统一失败条件。

## 修改

- MMIO 和 PIO fw_cfg 共用同一套 DMA 地址寄存器组装逻辑；使用显式 `LOW_DWORD_MASK` 保留高半部，并在低半部或 64 位提交后原子清零寄存器。
- DMA descriptor 或 buffer 访问失败时，按 QEMU 设备语义尽力写回 `FW_CFG_DMA_CTL_ERROR` 并结束当前事务，不再让恶意或无效 guest 地址停止整个 VM；公共 `process_dma` API 保持不变。
- 所有 Axvisor QEMU 用例统一追加 vCPU runtime error fail regex，来宾已经失败时立即结束测试，不再等待完整 timeout。
- 增加两个关键回归：64 位地址高半部/提交后清零，以及坏 descriptor 后下一次 32 位 PIO DMA 可继续工作。

## 验证

- 回归测试在旧实现上稳定失败：高半部被截断为 `0x8000`；坏 descriptor 直接返回 `DeviceError`。
- `cargo fmt --all -- --check`
- `cargo test -p axdevice --features host-test`（38 unit + 7 integration）
- `cargo test -p axbuild --lib -- --test-threads=1`（844 passed）
- `cargo xtask clippy --package axdevice`
- `cargo xtask clippy --package axbuild`
- `cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx`，到达 `AXVISOR_X86_OVMF_ACPI_PASSED`
- 同一主线树上 direct ACPI 与 MP fallback 用例此前均到达各自精确成功标记；最后一次串行复跑时本地 MP fallback 的外层 QEMU 出现一次与改动无关的非终态运行，已中止，未用延长 timeout 规避。
