### PR TITLE
fix(aarch64): restore RK3588 guest cpufreq and SCMI support

### DIFF
--- a/virtualization/arm_vcpu/src/architecture/exception.rs
+++ b/virtualization/arm_vcpu/src/architecture/exception.rs
@@ -299,16 +299,23 @@ fn handle_psci_call(ctx: &TrapFrame) -> Option<ArmVcpuResult<ArmVmExit>> {
 /// This function will judge if the SMC call is a PSCI call, if so, it will handle it as a PSCI call.
 /// Otherwise, it will forward the SMC call to the ATF directly.
 fn handle_smc64_exception(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
+    const PSCI_VERSION_32: u64 = 0x8400_0000;
+
     // Is this a psci call?
-    if let Some(result) = handle_psci_call(ctx) {
-        result
-    } else {
-        // We just forward the SMC call to the ATF directly.
-        // The args are from lower EL, so it is safe to call the ATF.
-        (ctx.gpr[0], ctx.gpr[1], ctx.gpr[2], ctx.gpr[3]) =
-            unsafe { super::smc::smc_call(ctx.gpr[0], ctx.gpr[1], ctx.gpr[2], ctx.gpr[3]) };
-        Ok(ArmVmExit::Nothing)
+    // Keep virtual CPU lifecycle calls inside AxVisor, but expose the physical
+    // firmware's PSCI version to SMC guests. Linux uses that version to decide
+    // whether it may query the SMCCC version needed by SCMI.
+    if ctx.gpr[0] != PSCI_VERSION_32
+        && let Some(result) = handle_psci_call(ctx)
+    {
+        return result;
     }
+
+    // We just forward the SMC call to the ATF directly.
+    // The args are from lower EL, so it is safe to call the ATF.
+    (ctx.gpr[0], ctx.gpr[1], ctx.gpr[2], ctx.gpr[3]) =
+        unsafe { super::smc::smc_call(ctx.gpr[0], ctx.gpr[1], ctx.gpr[2], ctx.gpr[3]) };
+    Ok(ArmVmExit::Nothing)
 }
 
 /// Handles IRQ exceptions that occur from the current exception level.

--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -410,9 +410,15 @@ mod tests {
     use fdt_raw::RegInfo;
 
     use super::{
-        super::tree::sanitize_bootargs, cpu_node_id, initrd_range_from_image_config, need_cpu_node,
+        super::{device::find_all_passthrough_devices, tree::sanitize_bootargs},
+        cpu_node_id, find_node_by_phandle, initrd_range_from_image_config, need_cpu_node,
     };
-    use crate::{GuestPhysAddr, config::RamdiskInfo};
+    use crate::{
+        GuestPhysAddr,
+        config::{
+            AxVMConfig, AxVMConfigParams, HostDeviceAssignment, PhysCpuList, RamdiskInfo,
+        },
+    };
 
     fn prop_u32(name: &str, value: u32) -> Property {
         let mut prop = Property::new(name, std::vec![]);
@@ -647,5 +653,47 @@ mod tests {
                 .collect::<std::vec::Vec<_>>(),
             [8, 11, 8, 9]
         );
+    }
+
+    #[test]
+    fn orangepi_5_plus_guest_fdt_keeps_cpu_power_dependencies_resolvable() {
+        let host = Fdt::from_bytes(include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../os/axvisor/configs/board/orangepi-5-plus.dtb"
+        )))
+        .unwrap();
+        let vm_cfg = AxVMConfig::new(AxVMConfigParams {
+            phys_cpu_ls: PhysCpuList::new(1, Some(std::vec![0]), None),
+            pass_through_devices: std::vec![HostDeviceAssignment {
+                name: "/".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        let passthrough_devices = find_all_passthrough_devices(&vm_cfg, &host);
+        let cfg = GuestConfig {
+            base: axvmconfig::VMBaseConfig {
+                phys_cpu_ids: Some(std::vec![0]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let dtb = super::create_guest_fdt(&host, &passthrough_devices, &cfg).unwrap();
+        let guest = Fdt::from_bytes(&dtb).unwrap();
+        let cpu = guest.get_by_path("/cpus/cpu@0").unwrap().as_node();
+
+        assert!(cpu.get_property("#cooling-cells").is_some());
+        assert!(cpu.get_property("dynamic-power-coefficient").is_some());
+        for property_name in ["operating-points-v2", "cpu-supply"] {
+            let phandle = cpu
+                .get_property(property_name)
+                .and_then(Property::get_u32)
+                .unwrap();
+            assert!(
+                find_node_by_phandle(&guest, phandle).is_some(),
+                "{property_name} references missing guest phandle {phandle:#x}"
+            );
+        }
     }
 }

--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -415,9 +415,7 @@ mod tests {
     };
     use crate::{
         GuestPhysAddr,
-        config::{
-            AxVMConfig, AxVMConfigParams, HostDeviceAssignment, PhysCpuList, RamdiskInfo,
-        },
+        config::{AxVMConfig, AxVMConfigParams, HostDeviceAssignment, PhysCpuList, RamdiskInfo},
     };
 
     fn prop_u32(name: &str, value: u32) -> Property {

--- a/virtualization/axvm/src/boot/fdt/core/tree.rs
+++ b/virtualization/axvm/src/boot/fdt/core/tree.rs
@@ -161,20 +161,21 @@ impl FdtTree {
         source: &Fdt,
         source_id: NodeId,
         dest_parent: NodeId,
-        skip_cpu_cache_props: bool,
+        filter_guest_cpu_props: bool,
     ) -> AxVmResult<NodeId> {
         let source_node = source
             .node(source_id)
             .ok_or_else(|| ax_err_type!(InvalidData, "source FDT node id is invalid"))?;
         let dest_id = self.add_node(dest_parent, Node::new(source_node.name()));
         copy_properties(
+            source,
             source_node,
             self.fdt.node_mut(dest_id).unwrap(),
-            skip_cpu_cache_props,
+            filter_guest_cpu_props,
         );
 
         for child_id in source_node.children() {
-            self.copy_subtree_from(source, *child_id, dest_id, skip_cpu_cache_props)?;
+            self.copy_subtree_from(source, *child_id, dest_id, filter_guest_cpu_props)?;
         }
 
         Ok(dest_id)
@@ -192,7 +193,12 @@ impl FdtTree {
         let root = source
             .node(root_id)
             .ok_or_else(|| ax_err_type!(InvalidData, "source FDT root is missing"))?;
-        copy_properties(root, dest.fdt.node_mut(dest.fdt.root_id()).unwrap(), false);
+        copy_properties(
+            source,
+            root,
+            dest.fdt.node_mut(dest.fdt.root_id()).unwrap(),
+            false,
+        );
 
         let mut stack = Vec::new();
         for child in root.children().iter().rev() {
@@ -208,6 +214,7 @@ impl FdtTree {
             let next_parent = if node_kept {
                 let new_id = dest.add_node(dest_parent, Node::new(source_node.name()));
                 copy_properties(
+                    source,
                     source_node,
                     dest.fdt.node_mut(new_id).unwrap(),
                     path.starts_with("/cpus/"),
@@ -302,22 +309,34 @@ pub(crate) fn sanitize_bootargs(bootargs: &str) -> String {
     sanitized.join(" ")
 }
 
-pub(crate) fn should_skip_guest_cpu_prop(prop_name: &str) -> bool {
+fn should_skip_guest_cpu_prop(source: &Fdt, prop_name: &str) -> bool {
     matches!(
         prop_name,
-        "riscv,cbop-block-size"
-            | "riscv,cboz-block-size"
-            | "riscv,cbom-block-size"
-            | "operating-points-v2"
-            | "#cooling-cells"
-            | "dynamic-power-coefficient"
-            | "cpu-supply"
-    )
+        "riscv,cbop-block-size" | "riscv,cboz-block-size" | "riscv,cbom-block-size"
+    ) || (is_roc_rk3568(source)
+        && matches!(
+            prop_name,
+            "operating-points-v2" | "#cooling-cells" | "dynamic-power-coefficient" | "cpu-supply"
+        ))
 }
 
-fn copy_properties(source: &Node, dest: &mut Node, skip_cpu_cache_props: bool) {
+fn is_roc_rk3568(source: &Fdt) -> bool {
+    source
+        .node(source.root_id())
+        .and_then(|root| root.get_property("compatible"))
+        .is_some_and(|compatible| {
+            compatible.as_str_iter().any(|value| {
+                matches!(
+                    value,
+                    "rockchip,rk3568-firefly-roc-pc" | "rockchip,rk3568-firefly-roc-pc-se"
+                )
+            })
+        })
+}
+
+fn copy_properties(source_fdt: &Fdt, source: &Node, dest: &mut Node, filter_cpu_props: bool) {
     for prop in source.properties() {
-        if skip_cpu_cache_props && should_skip_guest_cpu_prop(prop.name()) {
+        if filter_cpu_props && should_skip_guest_cpu_prop(source_fdt, prop.name()) {
             continue;
         }
         dest.set_property(prop.clone());

--- a/virtualization/axvm/src/boot/fdt/core/tree_tests.rs
+++ b/virtualization/axvm/src/boot/fdt/core/tree_tests.rs
@@ -233,6 +233,10 @@ fn clone_filtered_preserves_root_sibling_order() {
 fn clone_filtered_drops_guest_cpu_power_management_props() {
     let mut source = Fdt::new();
     let root = source.root_id();
+    source
+        .node_mut(root)
+        .unwrap()
+        .set_property(prop_str("compatible", "rockchip,rk3568-firefly-roc-pc-se"));
 
     let cpus = source.add_node(root, Node::new("cpus"));
     source
@@ -266,4 +270,50 @@ fn clone_filtered_drops_guest_cpu_power_management_props() {
     assert!(cpu_node.get_property("#cooling-cells").is_none());
     assert!(cpu_node.get_property("dynamic-power-coefficient").is_none());
     assert!(cpu_node.get_property("cpu-supply").is_none());
+}
+
+#[test]
+fn clone_filtered_preserves_guest_cpu_power_management_props_on_rk3588() {
+    let mut source = Fdt::new();
+    let root = source.root_id();
+    source
+        .node_mut(root)
+        .unwrap()
+        .set_property(prop_str("compatible", "rockchip,rk3588-orangepi-5-plus"));
+
+    let cpus = source.add_node(root, Node::new("cpus"));
+    let cpu = source.add_node(cpus, Node::new("cpu@0"));
+    let cpu_node = source.node_mut(cpu).unwrap();
+    cpu_node.set_property(prop_u32("operating-points-v2", 3));
+    cpu_node.set_property(prop_u32("#cooling-cells", 2));
+    cpu_node.set_property(prop_u32("dynamic-power-coefficient", 0xbb));
+    cpu_node.set_property(prop_u32("cpu-supply", 5));
+
+    let tree = FdtTree::clone_filtered(&source, |_, _, _| true).unwrap();
+    let bytes = tree.finish();
+    let reparsed = Fdt::from_bytes(&bytes).unwrap();
+    let cpu_node = reparsed.get_by_path("/cpus/cpu@0").unwrap().as_node();
+
+    assert_eq!(
+        cpu_node
+            .get_property("operating-points-v2")
+            .unwrap()
+            .get_u32(),
+        Some(3)
+    );
+    assert_eq!(
+        cpu_node.get_property("#cooling-cells").unwrap().get_u32(),
+        Some(2)
+    );
+    assert_eq!(
+        cpu_node
+            .get_property("dynamic-power-coefficient")
+            .unwrap()
+            .get_u32(),
+        Some(0xbb)
+    );
+    assert_eq!(
+        cpu_node.get_property("cpu-supply").unwrap().get_u32(),
+        Some(5)
+    );
 }

--- a/virtualization/axvm/src/runtime/hvc.rs
+++ b/virtualization/axvm/src/runtime/hvc.rs
@@ -50,6 +50,7 @@ fn is_psci_code(code: HyperCallCode) -> bool {
 }
 const PSCI_RET_SUCCESS: usize = 0;
 const PSCI_VERSION_0_2: usize = 0x0000_0002;
+const ARM_SMCCC_VERSION_FUNC_ID: u64 = 0x8000_0000;
 const PSCI_RET_NOT_SUPPORTED: usize = usize::MAX;
 const PSCI_RET_INVALID_PARAMETERS: usize = (-2isize) as usize;
 const PSCI_RET_DENIED: usize = (-3isize) as usize;
@@ -185,6 +186,10 @@ fn decode_hypercall_code(raw_code: u64, abi: HyperCallAbi) -> HyperCallResult<Hy
 }
 
 fn psci_feature_result(function_id: u64) -> usize {
+    if function_id == ARM_SMCCC_VERSION_FUNC_ID {
+        return PSCI_RET_SUCCESS;
+    }
+
     match decode_hypercall_code(function_id, HyperCallAbi::AArch64) {
         Ok(
             HyperCallCode::PSCIVersion
@@ -999,6 +1004,14 @@ mod tests {
                 Some(Ok(PSCI_RET_NOT_SUPPORTED))
             );
         }
+    }
+
+    #[test]
+    fn hvc_psci_features_advertises_smccc_version_query() {
+        assert_eq!(
+            psci_feature_result(ARM_SMCCC_VERSION_FUNC_ID),
+            PSCI_RET_SUCCESS
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 背景

RK3588 Linux 客户机更新到最新代码后出现以下问题：

- CPU 调频信息不完整，客户机运行频率偏低，用户态性能下降；
- 恢复部分 CPU 设备树属性后，Linux 无法正确识别 PSCI/SMCCC 能力；
- SCMI 通信和 RKNPU 初始化可能失败，导致 `/dev/dri` 中没有可用的 NPU 设备。

问题由两部分共同造成：

1. AxVM 在生成客户机设备树时，无条件删除了 CPU 节点中的
   `operating-points-v2`、`cpu-supply`、`#cooling-cells` 和
   `dynamic-power-coefficient`。

   这些过滤原本用于规避 ROC-RK3568 平台问题，但同时影响了 RK3588，
   使 Linux 客户机无法获得完整的 CPU OPP 和供电信息。

2. SMC 客户机调用 `PSCI_VERSION` 时得到的是 AxVisor 的虚拟 PSCI 版本，
   Linux 因此无法继续确认物理固件支持的 SMCCC 版本，进而影响 SCMI
   固件通信路径。

## 修改内容

- 仅对以下 ROC-RK3568 平台过滤 CPU 电源管理属性：
  - `rockchip,rk3568-firefly-roc-pc`
  - `rockchip,rk3568-firefly-roc-pc-se`
- RK3588 客户机保留 CPU OPP、供电、散热和功耗属性。
- 保留原有 RISC-V cache block 属性过滤逻辑。
- SMC 客户机的 `PSCI_VERSION` 调用转发给物理 ATF。
- CPU_ON、CPU_OFF、SYSTEM_OFF 等虚拟机生命周期调用仍由 AxVisor
  虚拟化处理，不改变现有 vCPU 管理逻辑。
- `PSCI_FEATURES` 正确报告对 `ARM_SMCCC_VERSION` 查询的支持。
- 增加单元测试，分别验证：
  - ROC-RK3568 继续删除相关 CPU 属性；
  - RK3588 保留相关 CPU 属性；
  - SMCCC version feature 查询返回成功。

## 测试结果

本地测试：

- `cargo fmt --all`
- `cargo test -p axvm --features host-test`
  - 252 passed，0 failed
- `cargo xtask clippy --package axvm --package arm_vcpu`
  - 7 项检查全部通过
- `git diff --check`

OrangePi 5 Plus RK3588 实机测试：

- AxVisor 可以正常启动 Linux SMP1 客户机；
- Linux 正常进入用户态；
- PSCI：`PSCIv1.1`
- SMC Calling Convention：`v1.5`
- SCMI：`Protocol v2.0`
- CPU0 调频驱动：`cpufreq-dt`
- CPU0 当前/最高频率：`1.8 GHz`
- NPU 当前/最高频率：`1.0 GHz`
- NPU governor：`rknpu_ondemand`
- RKNPU 驱动初始化成功；
- `/dev/dri/card*` 和 `/dev/dri/renderD*` 正常生成；
- 针对性板端检查通过。