### PR TITLE
fix(tty): handle input flush and wakeups

### DIFF
--- a/drivers/interface/rdif-serial/src/axtest.rs
+++ b/drivers/interface/rdif-serial/src/axtest.rs
@@ -99,6 +99,10 @@ impl UartPort for MockPort {
         self.rx.take()
     }
 
+    fn discard_rx(&mut self) {
+        self.rx = None;
+    }
+
     fn write_tx(&mut self, bytes: &[u8]) -> usize {
         let count = bytes.len().min(self.tx.len());
         self.tx[..count].copy_from_slice(&bytes[..count]);

--- a/drivers/interface/rdif-serial/src/axtest.rs
+++ b/drivers/interface/rdif-serial/src/axtest.rs
@@ -106,6 +106,10 @@ impl UartPort for MockPort {
         count
     }
 
+    fn discard_tx(&mut self) {
+        self.tx_len = 0;
+    }
+
     fn tx_idle(&mut self) -> bool {
         self.tx_len == 0
     }

--- a/drivers/interface/rdif-serial/src/axtest.rs
+++ b/drivers/interface/rdif-serial/src/axtest.rs
@@ -110,8 +110,9 @@ impl UartPort for MockPort {
         count
     }
 
-    fn discard_tx(&mut self) {
+    fn discard_tx(&mut self) -> bool {
         self.tx_len = 0;
+        true
     }
 
     fn tx_idle(&mut self) -> bool {

--- a/drivers/interface/rdif-serial/src/raw.rs
+++ b/drivers/interface/rdif-serial/src/raw.rs
@@ -46,6 +46,9 @@ pub trait UartPort: Send + 'static {
     /// Reads one normalized hardware sample without consulting IRQ state.
     fn read_rx(&mut self) -> Option<RxSample>;
 
+    /// Discards bytes and error state pending in the hardware receiver.
+    fn discard_rx(&mut self);
+
     /// Writes as much of `bytes` as the hardware can currently accept.
     fn write_tx(&mut self, bytes: &[u8]) -> usize;
 

--- a/drivers/interface/rdif-serial/src/raw.rs
+++ b/drivers/interface/rdif-serial/src/raw.rs
@@ -49,6 +49,10 @@ pub trait UartPort: Send + 'static {
     /// Writes as much of `bytes` as the hardware can currently accept.
     fn write_tx(&mut self, bytes: &[u8]) -> usize;
 
+    /// Discards bytes queued in the hardware transmitter. A byte already in
+    /// the shift register may still complete.
+    fn discard_tx(&mut self);
+
     /// Returns whether both the FIFO and transmitter shift register are empty.
     fn tx_idle(&mut self) -> bool;
 

--- a/drivers/interface/rdif-serial/src/raw.rs
+++ b/drivers/interface/rdif-serial/src/raw.rs
@@ -54,7 +54,8 @@ pub trait UartPort: Send + 'static {
 
     /// Discards bytes queued in the hardware transmitter. A byte already in
     /// the shift register may still complete.
-    fn discard_tx(&mut self);
+    /// Returns whether the hardware supports an independent TX-only discard.
+    fn discard_tx(&mut self) -> bool;
 
     /// Returns whether both the FIFO and transmitter shift register are empty.
     fn tx_idle(&mut self) -> bool;

--- a/drivers/serial/some-serial/src/ns16550/mod.rs
+++ b/drivers/serial/some-serial/src/ns16550/mod.rs
@@ -255,6 +255,16 @@ impl<T: Kind> UartPort for Ns16550<T> {
         Ns16550::read_rx(self)
     }
 
+    fn discard_rx(&mut self) {
+        self.saved_lsr = LineStatusFlags::empty();
+        self.write_flags(
+            UART_FCR,
+            FifoControlFlags::ENABLE_FIFO
+                | FifoControlFlags::CLEAR_RECEIVER_FIFO
+                | FifoControlFlags::TRIGGER_8_BYTES,
+        );
+    }
+
     fn write_tx(&mut self, bytes: &[u8]) -> usize {
         self.try_write(bytes)
     }
@@ -791,6 +801,15 @@ mod tests {
             REGS[reg as usize].store(val, Ordering::SeqCst);
             if reg == UART_FCR {
                 LAST_FCR_WRITE.store(val, Ordering::SeqCst);
+                if val & FifoControlFlags::CLEAR_RECEIVER_FIFO.bits() != 0 {
+                    REGS[UART_LSR as usize].fetch_and(
+                        !(LineStatusFlags::DATA_READY
+                            | LineStatusFlags::ERROR_MASK
+                            | LineStatusFlags::FIFO_ERROR)
+                            .bits(),
+                        Ordering::SeqCst,
+                    );
+                }
                 if val & FifoControlFlags::ENABLE_FIFO.bits() != 0 {
                     REGS[UART_IIR as usize].fetch_or(
                         InterruptIdentificationFlags::FIFO_ENABLE_MASK.bits(),
@@ -1009,6 +1028,28 @@ mod tests {
             fcr & FifoControlFlags::TRIGGER_LEVEL_MASK,
             FifoControlFlags::TRIGGER_8_BYTES,
         );
+    }
+
+    #[test]
+    fn discard_rx_clears_only_the_receiver_fifo_and_saved_status() {
+        let (_guard, mut uart) = serial();
+        uart.saved_lsr = LineStatusFlags::PARITY_ERROR;
+        REGS[UART_RBR as usize].store(b'x', Ordering::SeqCst);
+        REGS[UART_LSR as usize].store(LineStatusFlags::DATA_READY.bits(), Ordering::SeqCst);
+
+        UartPort::discard_rx(&mut uart);
+
+        let fcr = FifoControlFlags::from_bits_retain(LAST_FCR_WRITE.load(Ordering::SeqCst));
+        assert!(fcr.contains(FifoControlFlags::ENABLE_FIFO));
+        assert!(fcr.contains(FifoControlFlags::CLEAR_RECEIVER_FIFO));
+        assert!(!fcr.contains(FifoControlFlags::CLEAR_TRANSMITTER_FIFO));
+        assert_eq!(
+            fcr & FifoControlFlags::TRIGGER_LEVEL_MASK,
+            FifoControlFlags::TRIGGER_8_BYTES,
+        );
+        assert!(uart.saved_lsr.is_empty());
+        assert!(uart.read_rx().is_none());
+        assert_eq!(RBR_READS.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/drivers/serial/some-serial/src/ns16550/mod.rs
+++ b/drivers/serial/some-serial/src/ns16550/mod.rs
@@ -269,13 +269,14 @@ impl<T: Kind> UartPort for Ns16550<T> {
         self.try_write(bytes)
     }
 
-    fn discard_tx(&mut self) {
+    fn discard_tx(&mut self) -> bool {
         self.write_flags(
             UART_FCR,
             FifoControlFlags::ENABLE_FIFO
                 | FifoControlFlags::CLEAR_TRANSMITTER_FIFO
                 | FifoControlFlags::TRIGGER_8_BYTES,
         );
+        true
     }
 
     fn tx_idle(&mut self) -> bool {
@@ -1018,7 +1019,7 @@ mod tests {
     fn discard_tx_clears_only_the_transmitter_fifo() {
         let (_guard, mut uart) = serial();
 
-        UartPort::discard_tx(&mut uart);
+        assert!(UartPort::discard_tx(&mut uart));
 
         let fcr = FifoControlFlags::from_bits_retain(LAST_FCR_WRITE.load(Ordering::SeqCst));
         assert!(fcr.contains(FifoControlFlags::ENABLE_FIFO));

--- a/drivers/serial/some-serial/src/ns16550/mod.rs
+++ b/drivers/serial/some-serial/src/ns16550/mod.rs
@@ -259,6 +259,15 @@ impl<T: Kind> UartPort for Ns16550<T> {
         self.try_write(bytes)
     }
 
+    fn discard_tx(&mut self) {
+        self.write_flags(
+            UART_FCR,
+            FifoControlFlags::ENABLE_FIFO
+                | FifoControlFlags::CLEAR_TRANSMITTER_FIFO
+                | FifoControlFlags::TRIGGER_8_BYTES,
+        );
+    }
+
     fn tx_idle(&mut self) -> bool {
         let lsr: LineStatusFlags = self.read_flags(UART_LSR);
         lsr.contains(
@@ -983,6 +992,22 @@ mod tests {
             fcr & FifoControlFlags::TRIGGER_LEVEL_MASK,
             FifoControlFlags::TRIGGER_8_BYTES,
             "deferred RX service must amortize IRQ wakeups at the Linux 16550A default trigger",
+        );
+    }
+
+    #[test]
+    fn discard_tx_clears_only_the_transmitter_fifo() {
+        let (_guard, mut uart) = serial();
+
+        UartPort::discard_tx(&mut uart);
+
+        let fcr = FifoControlFlags::from_bits_retain(LAST_FCR_WRITE.load(Ordering::SeqCst));
+        assert!(fcr.contains(FifoControlFlags::ENABLE_FIFO));
+        assert!(fcr.contains(FifoControlFlags::CLEAR_TRANSMITTER_FIFO));
+        assert!(!fcr.contains(FifoControlFlags::CLEAR_RECEIVER_FIFO));
+        assert_eq!(
+            fcr & FifoControlFlags::TRIGGER_LEVEL_MASK,
+            FifoControlFlags::TRIGGER_8_BYTES,
         );
     }
 

--- a/drivers/serial/some-serial/src/ns16550/rockchip_fiq.rs
+++ b/drivers/serial/some-serial/src/ns16550/rockchip_fiq.rs
@@ -576,6 +576,10 @@ impl UartPort for RockchipFiqSerial {
         UartPort::read_rx(&mut self.serial)
     }
 
+    fn discard_rx(&mut self) {
+        UartPort::discard_rx(&mut self.serial)
+    }
+
     fn write_tx(&mut self, bytes: &[u8]) -> usize {
         UartPort::write_tx(&mut self.serial, bytes)
     }

--- a/drivers/serial/some-serial/src/ns16550/rockchip_fiq.rs
+++ b/drivers/serial/some-serial/src/ns16550/rockchip_fiq.rs
@@ -584,7 +584,7 @@ impl UartPort for RockchipFiqSerial {
         UartPort::write_tx(&mut self.serial, bytes)
     }
 
-    fn discard_tx(&mut self) {
+    fn discard_tx(&mut self) -> bool {
         UartPort::discard_tx(&mut self.serial)
     }
 

--- a/drivers/serial/some-serial/src/ns16550/rockchip_fiq.rs
+++ b/drivers/serial/some-serial/src/ns16550/rockchip_fiq.rs
@@ -580,6 +580,10 @@ impl UartPort for RockchipFiqSerial {
         UartPort::write_tx(&mut self.serial, bytes)
     }
 
+    fn discard_tx(&mut self) {
+        UartPort::discard_tx(&mut self.serial)
+    }
+
     fn tx_idle(&mut self) -> bool {
         self.serial.tx_idle()
     }

--- a/drivers/serial/some-serial/src/pl011.rs
+++ b/drivers/serial/some-serial/src/pl011.rs
@@ -734,6 +734,14 @@ impl UartPort for Pl011 {
         written
     }
 
+    fn discard_tx(&mut self) {
+        let fifo_enabled = self.registers().uartlcr_h.is_set(UARTLCR_H::FEN);
+        self.registers().uartlcr_h.modify(UARTLCR_H::FEN::CLEAR);
+        if fifo_enabled {
+            self.registers().uartlcr_h.modify(UARTLCR_H::FEN::SET);
+        }
+    }
+
     fn tx_idle(&mut self) -> bool {
         let fr = self.registers().uartfr.extract();
         !fr.is_set(UARTFR::BUSY) && !fr.is_set(UARTFR::TXFF)

--- a/drivers/serial/some-serial/src/pl011.rs
+++ b/drivers/serial/some-serial/src/pl011.rs
@@ -722,6 +722,17 @@ impl UartPort for Pl011 {
         Pl011::read_rx(self)
     }
 
+    fn discard_rx(&mut self) {
+        while !self.registers().uartfr.is_set(UARTFR::RXFE) {
+            let _ = self.registers().uartdr.get();
+        }
+        self.saved_rx_status = Pl011RxStatus::empty();
+        self.registers().uartrsr_ecr.set(0);
+        self.registers()
+            .uarticr
+            .set(imsc_for_events(SerialEventSet::RX));
+    }
+
     fn write_tx(&mut self, bytes: &[u8]) -> usize {
         let mut written = 0;
         for &byte in bytes {
@@ -1053,6 +1064,23 @@ mod tests {
         assert!(event.events.contains(SerialEventSet::TX_SPACE));
         assert_eq!(parts.port.write_tx(b"x"), 1);
         assert_eq!(regs.uartdr.get() as u8, b'x');
+    }
+
+    #[test]
+    fn discard_rx_clears_saved_status_without_touching_tx_data() {
+        let (mut regs, mut uart) = pl011_with_registers();
+        uart.saved_rx_status = Pl011RxStatus::PARITY;
+        regs.uartdr.set(UARTDR::DATA.val(b'x' as u32).into());
+        write_test_reg(&mut regs, 0x018, UARTFR::RXFE::SET.value);
+
+        UartPort::discard_rx(&mut uart);
+
+        assert!(uart.saved_rx_status.is_empty());
+        assert_eq!(regs.uartdr.get() as u8, b'x');
+        assert_eq!(
+            read_test_reg(&regs, 0x044) & imsc_for_events(SerialEventSet::RX),
+            imsc_for_events(SerialEventSet::RX),
+        );
     }
 
     #[test]

--- a/drivers/serial/some-serial/src/pl011.rs
+++ b/drivers/serial/some-serial/src/pl011.rs
@@ -745,12 +745,8 @@ impl UartPort for Pl011 {
         written
     }
 
-    fn discard_tx(&mut self) {
-        let fifo_enabled = self.registers().uartlcr_h.is_set(UARTLCR_H::FEN);
-        self.registers().uartlcr_h.modify(UARTLCR_H::FEN::CLEAR);
-        if fifo_enabled {
-            self.registers().uartlcr_h.modify(UARTLCR_H::FEN::SET);
-        }
+    fn discard_tx(&mut self) -> bool {
+        false
     }
 
     fn tx_idle(&mut self) -> bool {
@@ -1081,6 +1077,19 @@ mod tests {
             read_test_reg(&regs, 0x044) & imsc_for_events(SerialEventSet::RX),
             imsc_for_events(SerialEventSet::RX),
         );
+    }
+
+    #[test]
+    fn discard_tx_reports_unsupported_without_touching_rx_data() {
+        let (mut regs, mut uart) = pl011_with_registers();
+        regs.uartlcr_h.modify(UARTLCR_H::FEN::SET);
+        regs.uartdr.set(UARTDR::DATA.val(b'r' as u32).into());
+        write_test_reg(&mut regs, 0x018, 0);
+        let lcr_h = regs.uartlcr_h.get();
+
+        assert!(!UartPort::discard_tx(&mut uart));
+        assert_eq!(regs.uartlcr_h.get(), lcr_h);
+        assert_eq!(uart.read_rx().unwrap().byte, Some(b'r'));
     }
 
     #[test]

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -297,8 +297,12 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 return Err(AxError::Unsupported);
             }
             TCFLSH => match arg {
-                TCIFLUSH | TCIOFLUSH => self.ldisc.lock().drain_input(),
-                TCOFLUSH => {}
+                TCIFLUSH => self.ldisc.lock().drain_input(),
+                TCOFLUSH => self.writer.discard_output()?,
+                TCIOFLUSH => {
+                    self.writer.discard_output()?;
+                    self.ldisc.lock().drain_input();
+                }
                 _ => return Err(AxError::InvalidInput),
             },
             TIOCSPTLCK => {}

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -298,10 +298,11 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
             }
             TCFLSH => match arg {
                 TCIFLUSH => self.ldisc.lock().drain_input(),
-                TCOFLUSH => self.writer.discard_output()?,
+                TCOFLUSH => self.ldisc.lock().discard_output(&self.writer)?,
                 TCIOFLUSH => {
-                    self.writer.discard_output()?;
-                    self.ldisc.lock().drain_input();
+                    let mut ldisc = self.ldisc.lock();
+                    ldisc.discard_output(&self.writer)?;
+                    ldisc.drain_input();
                 }
                 _ => return Err(AxError::InvalidInput),
             },

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -231,7 +231,7 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 };
                 self.writer.termios_changed(old.as_ref(), termios.as_ref());
                 if cmd == TCSETSF {
-                    self.ldisc.lock().drain_input();
+                    self.ldisc.lock().drain_input()?;
                 }
             }
             TCSETS2 | TCSETSF2 | TCSETSW2 => {
@@ -247,7 +247,7 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 };
                 self.writer.termios_changed(old.as_ref(), termios.as_ref());
                 if cmd == TCSETSF2 {
-                    self.ldisc.lock().drain_input();
+                    self.ldisc.lock().drain_input()?;
                 }
             }
             TIOCGPGRP => {
@@ -297,12 +297,12 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 return Err(AxError::Unsupported);
             }
             TCFLSH => match arg {
-                TCIFLUSH => self.ldisc.lock().drain_input(),
+                TCIFLUSH => self.ldisc.lock().drain_input()?,
                 TCOFLUSH => self.ldisc.lock().discard_output(&self.writer)?,
                 TCIOFLUSH => {
                     let mut ldisc = self.ldisc.lock();
                     ldisc.discard_output(&self.writer)?;
-                    ldisc.drain_input();
+                    ldisc.drain_input()?;
                 }
                 _ => return Err(AxError::InvalidInput),
             },

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/mod.rs
@@ -48,6 +48,9 @@ use crate::{
 
 const ANSI_CURSOR_POSITION_REQUEST: &[u8] = b"\x1b[6n";
 const ANSI_CURSOR_POSITION_RESPONSE: &[u8] = b"\x1b[1;1R";
+const TCIFLUSH: usize = 0;
+const TCOFLUSH: usize = 1;
+const TCIOFLUSH: usize = 2;
 
 pub(crate) enum TerminalDevice {
     Location(Location),
@@ -293,6 +296,11 @@ impl<R: TtyRead, W: TtyWrite> DeviceOps for Tty<R, W> {
                 self.writer.drain()?;
                 return Err(AxError::Unsupported);
             }
+            TCFLSH => match arg {
+                TCIFLUSH | TCIOFLUSH => self.ldisc.lock().drain_input(),
+                TCOFLUSH => {}
+                _ => return Err(AxError::InvalidInput),
+            },
             TIOCSPTLCK => {}
             TIOCGPTN => {
                 (arg as *mut u32).vm_write(self.pty_number())?;

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/pty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/pty.rs
@@ -22,17 +22,19 @@ pub type PtyDriver = Tty<PtyReader, PtyWriter>;
 
 type Buffer = Arc<HeapRb<u8>>;
 
-pub struct PtyReader(Cons<Buffer>, Arc<AtomicBool>);
+type SharedConsumer = Arc<SpinNoIrq<Cons<Buffer>>>;
+
+pub struct PtyReader(SharedConsumer, Arc<AtomicBool>);
 
 impl PtyReader {
-    pub fn new(buffer: Buffer, writer_closed: Arc<AtomicBool>) -> Self {
-        Self(Cons::new(buffer), writer_closed)
+    pub fn new(consumer: SharedConsumer, writer_closed: Arc<AtomicBool>) -> Self {
+        Self(consumer, writer_closed)
     }
 }
 
 impl TtyRead for PtyReader {
     fn read(&mut self, buf: &mut [u8]) -> usize {
-        self.0.pop_slice(buf)
+        self.0.lock().pop_slice(buf)
     }
 
     fn closed(&self) -> bool {
@@ -41,12 +43,23 @@ impl TtyRead for PtyReader {
 }
 
 #[derive(Clone)]
-pub struct PtyWriter(Arc<SpinNoIrq<Prod<Buffer>>>, Arc<PollSet>, Arc<AtomicBool>);
+pub struct PtyWriter(
+    Arc<SpinNoIrq<Prod<Buffer>>>,
+    SharedConsumer,
+    Arc<PollSet>,
+    Arc<AtomicBool>,
+);
 
 impl PtyWriter {
-    pub fn new(buffer: Buffer, poll_rx: Arc<PollSet>, writer_closed: Arc<AtomicBool>) -> Self {
+    pub fn new(
+        buffer: Buffer,
+        consumer: SharedConsumer,
+        poll_rx: Arc<PollSet>,
+        writer_closed: Arc<AtomicBool>,
+    ) -> Self {
         Self(
             Arc::new(SpinNoIrq::new(Prod::new(buffer))),
+            consumer,
             poll_rx,
             writer_closed,
         )
@@ -64,8 +77,14 @@ impl TtyWrite for PtyWriter {
     fn try_write(&self, buf: &[u8]) -> usize {
         let read = self.0.lock().push_slice(buf);
         // PTY bytes are committed before waking the peer reader.
-        unsafe { self.1.wake(IoEvents::IN) };
+        unsafe { self.2.wake(IoEvents::IN) };
         read
+    }
+
+    fn discard_output(&self) -> ax_errno::AxResult<()> {
+        let _producer = self.0.lock();
+        self.1.lock().clear();
+        Ok(())
     }
 
     fn close(&self) {
@@ -74,8 +93,8 @@ impl TtyWrite for PtyWriter {
         // blocked poll()/read() observe the hangup. The peer drains any
         // already-buffered bytes first, then sees hangup on the next poll/read
         // once the buffer is empty.
-        self.2.store(true, Ordering::Release);
-        unsafe { self.1.wake(IoEvents::IN) };
+        self.3.store(true, Ordering::Release);
+        unsafe { self.2.wake(IoEvents::IN) };
     }
 }
 
@@ -88,15 +107,18 @@ pub(crate) fn create_pty_pair() -> (Arc<PtyDriver>, Arc<PtyDriver>) {
     // peer reader can observe hangup (POLLHUP / EOF).
     let master_closed = Arc::new(AtomicBool::new(false));
     let slave_closed = Arc::new(AtomicBool::new(false));
+    let master_to_slave_consumer = Arc::new(SpinNoIrq::new(Cons::new(master_to_slave.clone())));
+    let slave_to_master_consumer = Arc::new(SpinNoIrq::new(Cons::new(slave_to_master.clone())));
 
     let terminal = Arc::new(Terminal::default());
 
     let master = Tty::new(
         terminal.clone(),
         TtyConfig {
-            reader: PtyReader::new(slave_to_master.clone(), slave_closed.clone()),
+            reader: PtyReader::new(slave_to_master_consumer.clone(), slave_closed.clone()),
             writer: PtyWriter::new(
                 master_to_slave.clone(),
+                master_to_slave_consumer.clone(),
                 poll_rx_slave.clone(),
                 master_closed.clone(),
             ),
@@ -107,8 +129,13 @@ pub(crate) fn create_pty_pair() -> (Arc<PtyDriver>, Arc<PtyDriver>) {
     let slave = Tty::new(
         terminal,
         TtyConfig {
-            reader: PtyReader::new(master_to_slave, master_closed),
-            writer: PtyWriter::new(slave_to_master, poll_rx_master, slave_closed),
+            reader: PtyReader::new(master_to_slave_consumer, master_closed),
+            writer: PtyWriter::new(
+                slave_to_master,
+                slave_to_master_consumer,
+                poll_rx_master,
+                slave_closed,
+            ),
             process_mode: ProcessMode::InterruptDriven {
                 input: poll_rx_slave,
                 output: None,

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/pty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/pty.rs
@@ -37,8 +37,9 @@ impl TtyRead for PtyReader {
         self.0.lock().pop_slice(buf)
     }
 
-    fn discard_input(&mut self) {
+    fn discard_input(&mut self) -> ax_errno::AxResult<()> {
         self.0.lock().clear();
+        Ok(())
     }
 
     fn closed(&self) -> bool {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/pty.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/pty.rs
@@ -37,6 +37,10 @@ impl TtyRead for PtyReader {
         self.0.lock().pop_slice(buf)
     }
 
+    fn discard_input(&mut self) {
+        self.0.lock().clear();
+    }
+
     fn closed(&self) -> bool {
         self.1.load(Ordering::Acquire)
     }

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
@@ -361,6 +361,11 @@ impl TtyRead for SerialReader {
 
         total
     }
+
+    fn discard_input(&mut self) {
+        let mut temp = [RxItem::default(); SERIAL_RX_DRAIN_CHUNK];
+        while self.backend.drain_rx(&mut temp) != 0 {}
+    }
 }
 
 impl TtyWrite for SerialWriter {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
@@ -362,9 +362,8 @@ impl TtyRead for SerialReader {
         total
     }
 
-    fn discard_input(&mut self) {
-        let mut temp = [RxItem::default(); SERIAL_RX_DRAIN_CHUNK];
-        while self.backend.drain_rx(&mut temp) != 0 {}
+    fn discard_input(&mut self) -> AxResult<()> {
+        self.backend.rx.discard_pending()
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/serial.rs
@@ -420,6 +420,12 @@ impl TtyWrite for SerialWriter {
         self.backend.drain_tx()
     }
 
+    fn discard_output(&self) -> AxResult<()> {
+        self.backend.ensure_started()?;
+        let _guard = self.backend.output_lock.lock();
+        self.backend.tx.discard_pending()
+    }
+
     fn termios_changed(&self, old: &Termios2, new: &Termios2) {
         if old.baudrate() == new.baudrate()
             && old.data_bits() == new.data_bits()

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -92,6 +92,10 @@ pub trait TtyWrite: Send + Sync + 'static {
         Ok(())
     }
 
+    fn discard_output(&self) -> AxResult<()> {
+        Err(AxError::Unsupported)
+    }
+
     fn termios_changed(&self, _old: &Termios2, _new: &Termios2) {}
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, collections::VecDeque, sync::Arc, task::Wake, vec::Vec};
+use alloc::{boxed::Box, collections::VecDeque, sync::Arc, vec::Vec};
 use core::{
     future::poll_fn,
     marker::PhantomData,
@@ -409,22 +409,6 @@ pub struct LineDiscipline<R, W> {
     _writer: PhantomData<W>,
 }
 
-struct WakeSignal {
-    fired: Arc<AtomicBool>,
-    task: Waker,
-}
-
-impl Wake for WakeSignal {
-    fn wake(self: Arc<Self>) {
-        self.wake_by_ref();
-    }
-
-    fn wake_by_ref(self: &Arc<Self>) {
-        self.fired.store(true, Ordering::Release);
-        self.task.wake_by_ref();
-    }
-}
-
 impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
     fn drive_input(reader: &mut InputReader<R, W>, input_ready: &PollSet) -> bool {
         let mut progressed = false;
@@ -447,36 +431,21 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         worker_source: Arc<PollSet>,
     ) {
         ax_task::spawn_with_name(
-            move || loop {
-                Self::drive_input(&mut reader, input_ready.as_ref());
-
-                let fired = Arc::new(AtomicBool::new(false));
+            move || {
                 block_on(poll_fn(|cx| {
-                    if Self::drive_input(&mut reader, input_ready.as_ref())
-                        || fired.swap(false, Ordering::AcqRel)
-                    {
-                        return Poll::Ready(());
-                    }
-
-                    let waker = Waker::from(Arc::new(WakeSignal {
-                        fired: fired.clone(),
-                        task: cx.waker().clone(),
-                    }));
+                    Self::drive_input(&mut reader, input_ready.as_ref());
                     // The reader task registers from ordinary task context.
-                    unsafe { input_source.register(&waker, IoEvents::IN) };
+                    unsafe { input_source.register(cx.waker(), IoEvents::IN) };
                     if let Some(output_source) = output_source.as_ref() {
-                        unsafe { output_source.register(&waker, IoEvents::OUT) };
+                        unsafe { output_source.register(cx.waker(), IoEvents::OUT) };
                     }
-                    unsafe { worker_source.register(&waker, IoEvents::OUT) };
+                    unsafe { worker_source.register(cx.waker(), IoEvents::OUT) };
 
-                    if Self::drive_input(&mut reader, input_ready.as_ref())
-                        || fired.swap(false, Ordering::AcqRel)
-                    {
-                        Poll::Ready(())
-                    } else {
-                        Poll::Pending
-                    }
-                }));
+                    // Close the check/register race. block_on's stable AxWaker
+                    // remembers a concurrent source wake before it parks.
+                    Self::drive_input(&mut reader, input_ready.as_ref());
+                    Poll::<()>::Pending
+                }))
             },
             "tty-reader".into(),
         );

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -8,6 +8,7 @@ use core::{
 
 use ax_errno::{AxError, AxResult};
 use ax_kspin::SpinNoIrq;
+use ax_sync::Mutex;
 use ax_task::future::block_on;
 use axpoll::{IoEvents, PollSet};
 use linux_raw_sys::general::{
@@ -56,7 +57,7 @@ pub trait TtyRead: Send + Sync + 'static {
     ///
     /// Once this returns, a later [`Self::read`] must not expose bytes that
     /// were observable by this reader before the discard began.
-    fn discard_input(&mut self);
+    fn discard_input(&mut self) -> AxResult<()>;
 
     /// Whether the writer peer has been fully closed (last fd dropped).
     /// Default: never closed. Lets a Passive reader report hangup
@@ -146,11 +147,12 @@ struct InputReader<R, W> {
     eof_ready: Arc<AtomicBool>,
 }
 impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
-    fn discard_input(&mut self) {
-        self.reader.discard_input();
+    fn discard_input(&mut self) -> AxResult<()> {
+        self.reader.discard_input()?;
         self.read_range = 0..0;
         self.line_buf.clear();
         self.line_read = None;
+        Ok(())
     }
 
     pub fn drain_source_into_line_buffer(&mut self) -> bool {
@@ -393,8 +395,8 @@ struct SimpleReader<R> {
     buf_tx: CachingProd<ReadBuf>,
 }
 impl<R: TtyRead> SimpleReader<R> {
-    fn discard_input(&mut self) {
-        self.reader.discard_input();
+    fn discard_input(&mut self) -> AxResult<()> {
+        self.reader.discard_input()
     }
 
     pub fn closed(&self) -> bool {
@@ -414,7 +416,7 @@ impl<R: TtyRead> SimpleReader<R> {
 }
 
 enum Processor<R, W> {
-    InterruptDriven(Arc<SpinNoIrq<InputReader<R, W>>>),
+    InterruptDriven(Arc<Mutex<InputReader<R, W>>>),
     Passive(Box<SimpleReader<R>>, Arc<PollSet>),
 }
 
@@ -429,7 +431,7 @@ pub struct LineDiscipline<R, W> {
 }
 
 impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
-    fn drive_input(reader: &SpinNoIrq<InputReader<R, W>>, input_ready: &PollSet) -> bool {
+    fn drive_input(reader: &Mutex<InputReader<R, W>>, input_ready: &PollSet) -> bool {
         let mut reader = reader.lock();
         let mut progressed = false;
         progressed |= reader.echo.drain_available();
@@ -444,7 +446,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
     }
 
     fn spawn_interrupt_driven_reader(
-        reader: Arc<SpinNoIrq<InputReader<R, W>>>,
+        reader: Arc<Mutex<InputReader<R, W>>>,
         input_source: Arc<PollSet>,
         output_source: Option<Arc<PollSet>>,
         input_ready: Arc<PollSet>,
@@ -495,7 +497,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
         let processor = match config.process_mode {
             ProcessMode::InterruptDriven { input, output } => {
-                let reader = Arc::new(SpinNoIrq::new(reader));
+                let reader = Arc::new(Mutex::new(reader));
                 Self::spawn_interrupt_driven_reader(
                     reader.clone(),
                     input,
@@ -528,20 +530,21 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         }
     }
 
-    pub fn drain_input(&mut self) {
+    pub fn drain_input(&mut self) -> AxResult<()> {
         match &mut self.processor {
             Processor::InterruptDriven(reader) => {
                 let mut reader = reader.lock();
-                reader.discard_input();
+                reader.discard_input()?;
                 self.buf_rx.clear();
             }
             Processor::Passive(reader, _) => {
-                reader.discard_input();
+                reader.discard_input()?;
                 self.buf_rx.clear();
             }
         }
         self.injected_input.clear();
         self.eof_ready.store(false, Ordering::Release);
+        Ok(())
     }
 
     pub fn discard_output(&self, writer: &W) -> AxResult<()> {
@@ -711,8 +714,9 @@ mod tests {
             n
         }
 
-        fn discard_input(&mut self) {
+        fn discard_input(&mut self) -> AxResult<()> {
             self.pos = self.data.len();
+            Ok(())
         }
 
         fn closed(&self) -> bool {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -1,7 +1,6 @@
 use alloc::{boxed::Box, collections::VecDeque, sync::Arc, vec::Vec};
 use core::{
     future::poll_fn,
-    marker::PhantomData,
     ops::Range,
     sync::atomic::{AtomicBool, AtomicUsize, Ordering},
     task::{Poll, Waker},
@@ -52,6 +51,12 @@ pub struct TtyConfig<R, W> {
 
 pub trait TtyRead: Send + Sync + 'static {
     fn read(&mut self, buf: &mut [u8]) -> usize;
+
+    /// Discards bytes already queued by the underlying input source.
+    ///
+    /// Once this returns, a later [`Self::read`] must not expose bytes that
+    /// were observable by this reader before the discard began.
+    fn discard_input(&mut self);
 
     /// Whether the writer peer has been fully closed (last fd dropped).
     /// Default: never closed. Lets a Passive reader report hangup
@@ -139,13 +144,16 @@ struct InputReader<R, W> {
     line_buf: Vec<u8>,
     line_read: Option<usize>,
     eof_ready: Arc<AtomicBool>,
-    clear_line_buf: Arc<AtomicBool>,
 }
 impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
+    fn discard_input(&mut self) {
+        self.reader.discard_input();
+        self.read_range = 0..0;
+        self.line_buf.clear();
+        self.line_read = None;
+    }
+
     pub fn drain_source_into_line_buffer(&mut self) -> bool {
-        if self.clear_line_buf.swap(false, Ordering::Relaxed) {
-            self.line_buf.clear();
-        }
         let mut progressed = false;
         if self.read_range.is_empty() {
             let read = self.reader.read(&mut self.read_buf);
@@ -380,6 +388,10 @@ struct SimpleReader<R> {
     buf_tx: CachingProd<ReadBuf>,
 }
 impl<R: TtyRead> SimpleReader<R> {
+    fn discard_input(&mut self) {
+        self.reader.discard_input();
+    }
+
     pub fn closed(&self) -> bool {
         self.reader.closed()
     }
@@ -396,8 +408,8 @@ impl<R: TtyRead> SimpleReader<R> {
     }
 }
 
-enum Processor<R> {
-    InterruptDriven,
+enum Processor<R, W> {
+    InterruptDriven(Arc<SpinNoIrq<InputReader<R, W>>>),
     Passive(Box<SimpleReader<R>>, Arc<PollSet>),
 }
 
@@ -408,13 +420,12 @@ pub struct LineDiscipline<R, W> {
     input_ready: Arc<PollSet>,
     worker_source: Arc<PollSet>,
     eof_ready: Arc<AtomicBool>,
-    clear_line_buf: Arc<AtomicBool>,
-    processor: Processor<R>,
-    _writer: PhantomData<W>,
+    processor: Processor<R, W>,
 }
 
 impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
-    fn drive_input(reader: &mut InputReader<R, W>, input_ready: &PollSet) -> bool {
+    fn drive_input(reader: &SpinNoIrq<InputReader<R, W>>, input_ready: &PollSet) -> bool {
+        let mut reader = reader.lock();
         let mut progressed = false;
         progressed |= reader.echo.drain_available();
         while reader.drain_source_into_line_buffer() {
@@ -428,7 +439,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
     }
 
     fn spawn_interrupt_driven_reader(
-        mut reader: InputReader<R, W>,
+        reader: Arc<SpinNoIrq<InputReader<R, W>>>,
         input_source: Arc<PollSet>,
         output_source: Option<Arc<PollSet>>,
         input_ready: Arc<PollSet>,
@@ -437,7 +448,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         ax_task::spawn_with_name(
             move || {
                 block_on(poll_fn(|cx| {
-                    Self::drive_input(&mut reader, input_ready.as_ref());
+                    Self::drive_input(&reader, input_ready.as_ref());
                     // The reader task registers from ordinary task context.
                     unsafe { input_source.register(cx.waker(), IoEvents::IN) };
                     if let Some(output_source) = output_source.as_ref() {
@@ -447,7 +458,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
                     // Close the check/register race. block_on's stable AxWaker
                     // remembers a concurrent source wake before it parks.
-                    Self::drive_input(&mut reader, input_ready.as_ref());
+                    Self::drive_input(&reader, input_ready.as_ref());
                     Poll::<()>::Pending
                 }))
             },
@@ -459,7 +470,6 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         let (buf_tx, buf_rx) = ReadBuf::default().split();
 
         let eof_ready = Arc::new(AtomicBool::new(false));
-        let clear_line_buf = Arc::new(AtomicBool::new(false));
         let input_ready = Arc::new(PollSet::new());
         let worker_source = Arc::new(PollSet::new());
         let echo = EchoQueue::new(config.writer, worker_source.clone());
@@ -476,19 +486,19 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             line_buf: Vec::new(),
             line_read: None,
             eof_ready: eof_ready.clone(),
-            clear_line_buf: clear_line_buf.clone(),
         };
 
         let processor = match config.process_mode {
             ProcessMode::InterruptDriven { input, output } => {
+                let reader = Arc::new(SpinNoIrq::new(reader));
                 Self::spawn_interrupt_driven_reader(
-                    reader,
+                    reader.clone(),
                     input,
                     output,
                     input_ready.clone(),
                     worker_source.clone(),
                 );
-                Processor::InterruptDriven
+                Processor::InterruptDriven(reader)
             }
             ProcessMode::Passive(poll_rx) => {
                 let InputReader { reader, buf_tx, .. } = reader;
@@ -509,17 +519,24 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
             input_ready,
             worker_source,
             eof_ready,
-            clear_line_buf,
             processor,
-            _writer: PhantomData,
         }
     }
 
     pub fn drain_input(&mut self) {
-        self.buf_rx.clear();
+        match &mut self.processor {
+            Processor::InterruptDriven(reader) => {
+                let mut reader = reader.lock();
+                reader.discard_input();
+                self.buf_rx.clear();
+            }
+            Processor::Passive(reader, _) => {
+                reader.discard_input();
+                self.buf_rx.clear();
+            }
+        }
         self.injected_input.clear();
         self.eof_ready.store(false, Ordering::Release);
-        self.clear_line_buf.store(true, Ordering::Relaxed);
     }
 
     pub fn inject_input(&mut self, input: &[u8]) {
@@ -556,7 +573,7 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
 
     pub fn register_rx_waker(&self, waker: &Waker) {
         match &self.processor {
-            Processor::InterruptDriven => {
+            Processor::InterruptDriven(_) => {
                 // Registration happens from tty read poll context.
                 unsafe { self.input_ready.register(waker, IoEvents::IN) };
             }
@@ -680,6 +697,10 @@ mod tests {
             n
         }
 
+        fn discard_input(&mut self) {
+            self.pos = self.data.len();
+        }
+
         fn closed(&self) -> bool {
             self.closed
         }
@@ -799,7 +820,6 @@ mod tests {
             line_buf: Vec::new(),
             line_read: None,
             eof_ready: Arc::new(AtomicBool::new(false)),
-            clear_line_buf: Arc::new(AtomicBool::new(false)),
         };
         (reader, buf_rx)
     }
@@ -861,7 +881,6 @@ mod tests {
             line_buf: Vec::new(),
             line_read: None,
             eof_ready: Arc::new(AtomicBool::new(false)),
-            clear_line_buf: Arc::new(AtomicBool::new(false)),
         };
 
         assert!(reader.drain_source_into_line_buffer());
@@ -895,7 +914,6 @@ mod tests {
             line_buf: Vec::new(),
             line_read: None,
             eof_ready: Arc::new(AtomicBool::new(false)),
-            clear_line_buf: Arc::new(AtomicBool::new(false)),
         };
 
         assert!(reader.drain_source_into_line_buffer());
@@ -926,7 +944,6 @@ mod tests {
             line_buf: Vec::new(),
             line_read: None,
             eof_ready: Arc::new(AtomicBool::new(false)),
-            clear_line_buf: Arc::new(AtomicBool::new(false)),
         };
 
         assert!(reader.drain_source_into_line_buffer());
@@ -959,7 +976,6 @@ mod tests {
             line_buf: Vec::new(),
             line_read: None,
             eof_ready: Arc::new(AtomicBool::new(false)),
-            clear_line_buf: Arc::new(AtomicBool::new(false)),
         };
 
         assert!(reader.drain_source_into_line_buffer());
@@ -985,7 +1001,6 @@ mod tests {
             line_buf: Vec::new(),
             line_read: None,
             eof_ready: Arc::new(AtomicBool::new(false)),
-            clear_line_buf: Arc::new(AtomicBool::new(false)),
         };
 
         assert!(reader.drain_source_into_line_buffer());

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/terminal/ldisc.rs
@@ -343,6 +343,11 @@ impl<W: TtyWrite> EchoQueue<W> {
         }
     }
 
+    fn discard_pending(&self) {
+        self.queue.lock().clear();
+        self.dropped.store(0, Ordering::Release);
+    }
+
     fn drain_available(&self) -> bool {
         let mut progressed = false;
         loop {
@@ -537,6 +542,15 @@ impl<R: TtyRead, W: TtyWrite> LineDiscipline<R, W> {
         }
         self.injected_input.clear();
         self.eof_ready.store(false, Ordering::Release);
+    }
+
+    pub fn discard_output(&self, writer: &W) -> AxResult<()> {
+        if let Processor::InterruptDriven(reader) = &self.processor {
+            // Synchronize with the input worker so echo generated before this
+            // flush is either pending here or already queued in the backend.
+            reader.lock().echo.discard_pending();
+        }
+        writer.discard_output()
     }
 
     pub fn inject_input(&mut self, input: &[u8]) {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/usb_serial/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/usb_serial/mod.rs
@@ -485,8 +485,9 @@ impl TtyRead for UsbSerialReader {
         self.backend.drain_rx(buf)
     }
 
-    fn discard_input(&mut self) {
+    fn discard_input(&mut self) -> AxResult<()> {
         self.backend.rx_queue.lock().clear();
+        Ok(())
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/usb_serial/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/usb_serial/mod.rs
@@ -484,6 +484,10 @@ impl TtyRead for UsbSerialReader {
         }
         self.backend.drain_rx(buf)
     }
+
+    fn discard_input(&mut self) {
+        self.backend.rx_queue.lock().clear();
+    }
 }
 
 impl TtyWrite for UsbSerialWriter {

--- a/os/StarryOS/kernel/src/pseudofs/dev/tty/usb_serial/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/tty/usb_serial/mod.rs
@@ -504,6 +504,12 @@ impl TtyWrite for UsbSerialWriter {
         self.backend.try_queue_bytes(buf)
     }
 
+    fn discard_output(&self) -> AxResult<()> {
+        let _guard = self.backend.output_lock.lock();
+        self.backend.clear_tx_queue();
+        Ok(())
+    }
+
     fn termios_changed(&self, old: &Termios2, new: &Termios2) {
         let Some(new_baud) = new.baudrate() else {
             return;

--- a/os/arceos/modules/axruntime/src/serial/control.rs
+++ b/os/arceos/modules/axruntime/src/serial/control.rs
@@ -11,6 +11,7 @@ pub(super) enum ControlOp {
     Start(Config),
     Shutdown,
     SetConfig(Config),
+    DiscardTx,
 }
 
 pub(super) struct ControlCommand {

--- a/os/arceos/modules/axruntime/src/serial/control.rs
+++ b/os/arceos/modules/axruntime/src/serial/control.rs
@@ -11,6 +11,7 @@ pub(super) enum ControlOp {
     Start(Config),
     Shutdown,
     SetConfig(Config),
+    DiscardRx,
     DiscardTx,
 }
 

--- a/os/arceos/modules/axruntime/src/serial/ingress.rs
+++ b/os/arceos/modules/axruntime/src/serial/ingress.rs
@@ -103,6 +103,10 @@ impl TxIngress {
         state.idle = true;
     }
 
+    pub(super) fn discard_pending(&self) {
+        self.state.lock().frames.clear();
+    }
+
     pub(super) fn write_room(&self) -> usize {
         let state = self.state.lock();
         if !state.accepting {
@@ -259,6 +263,20 @@ mod tests {
             TX_FRAME_BYTES * TX_FRAME_CAPACITY
         );
         assert_eq!(submit_locked(&mut state, b"x"), 0);
+    }
+
+    #[test]
+    fn discard_pending_drops_queued_frames_without_stopping_ingress() {
+        let ingress = TxIngress::new();
+        ingress.start_accepting();
+        assert_eq!(submit_locked(&mut ingress.state.lock(), b"stale"), 5);
+
+        ingress.discard_pending();
+
+        assert!(!ingress.has_pending());
+        assert_eq!(ingress.write_room(), TX_FRAME_BYTES * TX_FRAME_CAPACITY);
+        assert_eq!(submit_locked(&mut ingress.state.lock(), b"fresh"), 5);
+        assert_eq!(ingress.pop().unwrap().bytes(), b"fresh");
     }
 
     #[test]

--- a/os/arceos/modules/axruntime/src/serial/mod.rs
+++ b/os/arceos/modules/axruntime/src/serial/mod.rs
@@ -343,8 +343,26 @@ impl SerialRxSubscription {
             .ok_or(AxError::BadState)
     }
 
+    pub fn discard_pending(&self) -> AxResult {
+        self.shared.ensure_started()?;
+        self.clear_pending();
+        let result = self
+            .shared
+            .control
+            .submit(ControlOp::DiscardRx, &self.shared.bridge.notify);
+        self.clear_pending();
+        result
+    }
+
     pub fn poll_source(&self) -> Arc<PollSet> {
         self.shared.rx_source.clone()
+    }
+
+    fn clear_pending(&self) {
+        if let Some(consumer) = self.consumer.lock().as_mut() {
+            consumer.clear();
+        }
+        self.shared.bridge.notify.notify();
     }
 }
 

--- a/os/arceos/modules/axruntime/src/serial/mod.rs
+++ b/os/arceos/modules/axruntime/src/serial/mod.rs
@@ -291,6 +291,13 @@ impl SerialTxSender {
         }
     }
 
+    pub fn discard_pending(&self) -> AxResult {
+        self.shared.ensure_started()?;
+        self.shared
+            .control
+            .submit(ControlOp::DiscardTx, &self.shared.bridge.notify)
+    }
+
     pub fn poll_source(&self) -> Arc<PollSet> {
         self.shared.tx_source.clone()
     }

--- a/os/arceos/modules/axruntime/src/serial/state.rs
+++ b/os/arceos/modules/axruntime/src/serial/state.rs
@@ -28,6 +28,13 @@ impl SerialIrqLatch {
     pub(super) fn has_pending(&self) -> bool {
         self.packed.load(Ordering::Acquire) != 0
     }
+
+    pub(super) fn discard_rx(&self) {
+        let rx = SerialEventSet::RX.bits()
+            | (RxErrorFlags::all().bits() << ERROR_SHIFT)
+            | (SerialEventSet::RX.bits() << REARM_SHIFT);
+        self.packed.fetch_and(!rx, Ordering::AcqRel);
+    }
 }
 
 const fn pack(event: SerialIrqEvent) -> u32 {
@@ -207,5 +214,22 @@ mod tests {
         assert_eq!(events, SerialEventSet::RX_DATA | SerialEventSet::TX_SPACE);
         assert_eq!(errors, RxErrorFlags::PARITY);
         assert_eq!(rearm, SerialEventSet::TX_SPACE);
+    }
+
+    #[test]
+    fn discard_rx_preserves_unrelated_irq_state() {
+        let latch = SerialIrqLatch::new();
+        latch.publish(SerialIrqEvent {
+            events: SerialEventSet::RX_DATA | SerialEventSet::TX_SPACE,
+            rx_errors: RxErrorFlags::PARITY,
+            rearm: SerialEventSet::RX | SerialEventSet::TX_SPACE,
+        });
+
+        latch.discard_rx();
+
+        let event = latch.take().unwrap();
+        assert_eq!(event.events, SerialEventSet::TX_SPACE);
+        assert!(event.rx_errors.is_empty());
+        assert_eq!(event.rearm, SerialEventSet::TX_SPACE);
     }
 }

--- a/os/arceos/modules/axruntime/src/serial/worker.rs
+++ b/os/arceos/modules/axruntime/src/serial/worker.rs
@@ -166,10 +166,7 @@ impl SerialWorker {
                     self.discard_rx();
                     Ok(())
                 }
-                ControlOp::DiscardTx => {
-                    self.discard_tx();
-                    Ok(())
-                }
+                ControlOp::DiscardTx => self.discard_tx(),
             };
             command.complete(result);
         }
@@ -242,16 +239,18 @@ impl SerialWorker {
         self.shared.tx_progress.notify_all(true);
     }
 
-    fn discard_tx(&mut self) {
+    fn discard_tx(&mut self) -> AxResult {
+        let hardware_idle = {
+            let mut port = self.shared.port.lock();
+            if !port.discard_tx() {
+                return Err(AxError::Unsupported);
+            }
+            port.tx_idle()
+        };
         self.shared.ingress.discard_pending();
         self.pending_frame = None;
         self.pending_rearm.remove(SerialEventSet::TX_SPACE);
         self.immediate_events.remove(SerialEventSet::TX_SPACE);
-        let hardware_idle = {
-            let mut port = self.shared.port.lock();
-            port.discard_tx();
-            port.tx_idle()
-        };
         if !hardware_idle && !self.shared.polling {
             self.pending_rearm.insert(SerialEventSet::TX_SPACE);
         }
@@ -260,6 +259,7 @@ impl SerialWorker {
         if self.shared.ingress.mark_idle_if_empty(true, hardware_idle) {
             self.shared.publish_tx_idle();
         }
+        Ok(())
     }
 
     fn discard_rx(&mut self) {
@@ -605,7 +605,9 @@ mod tests {
             0
         }
 
-        fn discard_tx(&mut self) {}
+        fn discard_tx(&mut self) -> bool {
+            true
+        }
 
         fn tx_idle(&mut self) -> bool {
             true

--- a/os/arceos/modules/axruntime/src/serial/worker.rs
+++ b/os/arceos/modules/axruntime/src/serial/worker.rs
@@ -243,7 +243,7 @@ impl SerialWorker {
         let hardware_idle = {
             let mut port = self.shared.port.lock();
             if !port.discard_tx() {
-                return Err(AxError::Unsupported);
+                return Err(AxError::OperationNotSupported);
             }
             port.tx_idle()
         };

--- a/os/arceos/modules/axruntime/src/serial/worker.rs
+++ b/os/arceos/modules/axruntime/src/serial/worker.rs
@@ -162,6 +162,10 @@ impl SerialWorker {
                     force_service |= result.is_ok();
                     result
                 }
+                ControlOp::DiscardTx => {
+                    self.discard_tx();
+                    Ok(())
+                }
             };
             command.complete(result);
         }
@@ -232,6 +236,26 @@ impl SerialWorker {
             self.shared.tx_source.wake(IoEvents::ERR | IoEvents::HUP);
         }
         self.shared.tx_progress.notify_all(true);
+    }
+
+    fn discard_tx(&mut self) {
+        self.shared.ingress.discard_pending();
+        self.pending_frame = None;
+        self.pending_rearm.remove(SerialEventSet::TX_SPACE);
+        self.immediate_events.remove(SerialEventSet::TX_SPACE);
+        let hardware_idle = {
+            let mut port = self.shared.port.lock();
+            port.discard_tx();
+            port.tx_idle()
+        };
+        if !hardware_idle && !self.shared.polling {
+            self.pending_rearm.insert(SerialEventSet::TX_SPACE);
+        }
+
+        self.shared.publish_tx_space();
+        if self.shared.ingress.mark_idle_if_empty(true, hardware_idle) {
+            self.shared.publish_tx_idle();
+        }
     }
 
     fn service_rx(&mut self, path: RxPath) -> RxServiceOutcome {

--- a/os/arceos/modules/axruntime/src/serial/worker.rs
+++ b/os/arceos/modules/axruntime/src/serial/worker.rs
@@ -6,7 +6,7 @@ use axpoll::IoEvents;
 use rdif_serial::{Config, ConfigError, RxErrorFlags, RxFlag, RxSample, SerialEventSet};
 
 use super::{
-    RuntimeShared, RxItem,
+    RuntimeIrqBridge, RuntimeShared, RxItem,
     control::{CONTROL_QUEUE_CAPACITY, ControlOp},
     ingress::TxFrameCursor,
     spsc::{Consumer as SpscConsumer, Producer as SpscProducer},
@@ -162,6 +162,10 @@ impl SerialWorker {
                     force_service |= result.is_ok();
                     result
                 }
+                ControlOp::DiscardRx => {
+                    self.discard_rx();
+                    Ok(())
+                }
                 ControlOp::DiscardTx => {
                     self.discard_tx();
                     Ok(())
@@ -255,6 +259,23 @@ impl SerialWorker {
         self.shared.publish_tx_space();
         if self.shared.ingress.mark_idle_if_empty(true, hardware_idle) {
             self.shared.publish_tx_idle();
+        }
+    }
+
+    fn discard_rx(&mut self) {
+        self.pending_rx = None;
+        self.port_rx_ready = false;
+        self.latched_rx_errors = RxErrorFlags::empty();
+        self.pending_rearm.remove(SerialEventSet::RX);
+        self.immediate_events.remove(SerialEventSet::RX);
+
+        {
+            let mut port = self.shared.port.lock();
+            discard_rx_sources(&mut **port, &mut self.irq_rx, &self.shared.bridge);
+        }
+
+        if !self.shared.polling {
+            self.pending_rearm.insert(SerialEventSet::RX);
         }
     }
 
@@ -436,6 +457,19 @@ impl SerialWorker {
     }
 }
 
+fn discard_rx_sources(
+    port: &mut dyn rdif_serial::UartPort,
+    irq_rx: &mut SpscConsumer<RxSample>,
+    bridge: &RuntimeIrqBridge,
+) {
+    port.discard_rx();
+    irq_rx.clear();
+    bridge.latch.discard_rx();
+    bridge
+        .rx_overflow
+        .store(false, core::sync::atomic::Ordering::Release);
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RxPath {
     Irq,
@@ -534,7 +568,88 @@ fn rearm_drained_rx(
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
+    use core::sync::atomic::{AtomicBool, Ordering};
+
     use super::*;
+
+    struct SourcePort {
+        source_pending: Arc<AtomicBool>,
+    }
+
+    impl rdif_serial::UartPort for SourcePort {
+        fn startup(&mut self, _config: &Config) -> Result<(), ConfigError> {
+            Ok(())
+        }
+
+        fn shutdown(&mut self) {}
+
+        fn set_config(&mut self, _config: &Config) -> Result<(), ConfigError> {
+            Ok(())
+        }
+
+        fn read_rx(&mut self) -> Option<RxSample> {
+            self.source_pending
+                .swap(false, Ordering::AcqRel)
+                .then_some(RxSample {
+                    byte: Some(b'h'),
+                    ..RxSample::default()
+                })
+        }
+
+        fn discard_rx(&mut self) {
+            self.source_pending.store(false, Ordering::Release);
+        }
+
+        fn write_tx(&mut self, _bytes: &[u8]) -> usize {
+            0
+        }
+
+        fn discard_tx(&mut self) {}
+
+        fn tx_idle(&mut self) -> bool {
+            true
+        }
+
+        fn mask_all(&mut self) {}
+
+        fn rearm(&mut self, _sources: SerialEventSet) -> SerialEventSet {
+            SerialEventSet::empty()
+        }
+    }
+
+    #[test]
+    fn discard_rx_clears_hardware_and_irq_sources_before_returning() {
+        let source_pending = Arc::new(AtomicBool::new(true));
+        let mut port: Box<dyn rdif_serial::UartPort> = Box::new(SourcePort {
+            source_pending: source_pending.clone(),
+        });
+        let (mut irq_tx, mut irq_rx) = super::super::spsc::channel(2);
+        irq_tx
+            .push(RxSample {
+                byte: Some(b'i'),
+                ..RxSample::default()
+            })
+            .unwrap();
+        let bridge = RuntimeIrqBridge::new();
+        bridge.rx_overflow.store(true, Ordering::Release);
+        bridge.latch.publish(rdif_serial::SerialIrqEvent {
+            events: SerialEventSet::RX_DATA | SerialEventSet::TX_SPACE,
+            rx_errors: RxErrorFlags::OVERRUN,
+            rearm: SerialEventSet::RX | SerialEventSet::TX_SPACE,
+        });
+
+        discard_rx_sources(&mut *port, &mut irq_rx, &bridge);
+
+        assert!(!source_pending.load(Ordering::Acquire));
+        assert!(port.read_rx().is_none());
+        assert!(irq_rx.pop().is_none());
+        assert!(!bridge.rx_overflow.load(Ordering::Acquire));
+        let event = bridge.latch.take().unwrap();
+        assert_eq!(event.events, SerialEventSet::TX_SPACE);
+        assert!(event.rx_errors.is_empty());
+        assert_eq!(event.rearm, SerialEventSet::TX_SPACE);
+    }
 
     #[test]
     fn normalized_sample_reserves_byte_and_overrun_slots_together() {

--- a/test-suit/starryos/qemu/system/test-tty-flush/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-tty-flush/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-tty-flush C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-tty-flush src/main.c)
+target_compile_options(test-tty-flush PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-tty-flush RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
+++ b/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
@@ -201,6 +201,38 @@ static void check_input_source_flush(struct pty_pair *pty)
         fail("TCIFLUSH discards source and staged input");
 }
 
+static void check_deferred_echo_flush(void)
+{
+    struct pty_pair pty = {.master = -1, .slave = -1};
+    unsigned char fill[4096];
+    static const unsigned char stale = 'S';
+    static const unsigned char fresh = 'F';
+    struct termios term;
+
+    memset(fill, 'x', sizeof(fill));
+    if (open_raw_pty(&pty) != 0 || tcgetattr(pty.slave, &term) != 0) {
+        fail("open PTY for deferred echo flush");
+        goto out;
+    }
+    term.c_lflag |= ECHO;
+    if (tcsetattr(pty.slave, TCSANOW, &term) != 0
+        || write_all(pty.slave, fill, sizeof(fill)) != 0
+        || write_all(pty.master, &stale, sizeof(stale)) != 0
+        || !wait_readable(pty.slave, 2000)) {
+        fail("queue echo behind full PTY output");
+        goto out;
+    }
+
+    if (ioctl(pty.slave, TCFLSH, TCOFLUSH) != 0
+        || write_all(pty.master, &fresh, sizeof(fresh)) != 0
+        || read_exact(pty.master, &fresh, sizeof(fresh)) != 0
+        || expect_empty(pty.master) != 0)
+        fail("TCOFLUSH discards deferred echo");
+
+out:
+    close_pty(&pty);
+}
+
 static void check_reader_wakeup_after_flush(struct pty_pair *pty)
 {
     enum { ROUNDS = 64 };
@@ -285,6 +317,7 @@ int main(void)
         check_input_source_flush(&pty);
     }
     close_pty(&pty);
+    check_deferred_echo_flush();
 
     if (failures != 0) {
         fprintf(stderr, "test-tty-flush: %d failure(s)\n", failures);

--- a/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
+++ b/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
@@ -149,81 +149,97 @@ static int queue_output(struct pty_pair *pty, const char *payload)
     return write_all(pty->slave, payload, strlen(payload));
 }
 
-static void check_selector(int selector, int drop_input, int drop_output)
+static void check_selector(struct pty_pair *pty, int selector, int drop_input,
+                           int drop_output)
 {
     static const char input[] = "queued-input";
     static const char output[] = "queued-output";
-    struct pty_pair pty = {.master = -1, .slave = -1};
 
-    if (open_raw_pty(&pty) != 0) {
-        fail("open raw PTY");
-        close_pty(&pty);
-        return;
-    }
-    if (queue_input(&pty, input) != 0 || queue_output(&pty, output) != 0) {
+    if (queue_input(pty, input) != 0 || queue_output(pty, output) != 0) {
         fail("queue PTY input and output");
-        close_pty(&pty);
         return;
     }
-    if (ioctl(pty.slave, TCFLSH, selector) != 0) {
+    if (ioctl(pty->slave, TCFLSH, selector) != 0) {
         fail("TCFLSH selector succeeds");
-        close_pty(&pty);
         return;
     }
 
-    if ((drop_input ? expect_empty(pty.slave)
-                    : read_exact(pty.slave, input, sizeof(input) - 1)) != 0)
+    if ((drop_input ? expect_empty(pty->slave)
+                    : read_exact(pty->slave, input, sizeof(input) - 1)) != 0)
         fail("TCFLSH input effect");
-    if ((drop_output ? expect_empty(pty.master)
-                     : read_exact(pty.master, output, sizeof(output) - 1)) != 0)
+    if ((drop_output ? expect_empty(pty->master)
+                     : read_exact(pty->master, output, sizeof(output) - 1)) != 0)
         fail("TCFLSH output effect");
-    close_pty(&pty);
 }
 
-static void check_invalid_selector(void)
+static void check_invalid_selector(struct pty_pair *pty)
 {
-    struct pty_pair pty = {.master = -1, .slave = -1};
-    if (open_raw_pty(&pty) != 0) {
-        fail("open PTY for invalid selector");
-        close_pty(&pty);
+    errno = 0;
+    if (ioctl(pty->slave, TCFLSH, 3) != -1 || errno != EINVAL)
+        fail("TCFLSH rejects invalid selector with EINVAL");
+}
+
+static void check_input_source_flush(struct pty_pair *pty)
+{
+    static const unsigned char stale = 0x5a;
+    static const unsigned char fresh = 0xa5;
+    unsigned char delivered[4096];
+
+    memset(delivered, 0x33, sizeof(delivered));
+    if (write_all(pty->master, delivered, sizeof(delivered)) != 0
+        || !wait_readable(pty->slave, 2000)) {
+        fail("fill line discipline input buffer");
         return;
     }
-    errno = 0;
-    if (ioctl(pty.slave, TCFLSH, 3) != -1 || errno != EINVAL)
-        fail("TCFLSH rejects invalid selector with EINVAL");
-    close_pty(&pty);
+    if (write_all(pty->master, &stale, sizeof(stale)) != 0
+        || ioctl(pty->slave, TCFLSH, TCIFLUSH) != 0) {
+        fail("flush input before line discipline delivery");
+        return;
+    }
+    if (write_all(pty->master, &fresh, sizeof(fresh)) != 0
+        || read_exact(pty->slave, &fresh, sizeof(fresh)) != 0)
+        fail("TCIFLUSH discards source and staged input");
 }
 
-static void check_reader_wakeup_after_flush(void)
+static void check_reader_wakeup_after_flush(struct pty_pair *pty)
 {
     enum { ROUNDS = 64 };
-    struct pty_pair pty = {.master = -1, .slave = -1};
     int ready[2] = {-1, -1};
     int done[2] = {-1, -1};
 
-    if (open_raw_pty(&pty) != 0 || pipe(ready) != 0 || pipe(done) != 0) {
+    if (pipe(ready) != 0 || pipe(done) != 0) {
         fail("prepare reader wakeup test");
-        close_pty(&pty);
+        if (ready[0] >= 0)
+            close(ready[0]);
+        if (ready[1] >= 0)
+            close(ready[1]);
+        if (done[0] >= 0)
+            close(done[0]);
+        if (done[1] >= 0)
+            close(done[1]);
         return;
     }
 
     pid_t child = fork();
     if (child < 0) {
         fail("fork reader wakeup test");
-        close_pty(&pty);
+        close(ready[0]);
+        close(ready[1]);
+        close(done[0]);
+        close(done[1]);
         return;
     }
     if (child == 0) {
         close(ready[0]);
         close(done[0]);
-        close(pty.master);
-        if (set_nonblocking(pty.slave, 0) != 0)
+        close(pty->master);
+        if (set_nonblocking(pty->slave, 0) != 0)
             _exit(10);
         for (unsigned int round = 0; round < ROUNDS; round++) {
             unsigned char byte;
             if (write_all(ready[1], "R", 1) != 0)
                 _exit(11);
-            if (read(pty.slave, &byte, 1) != 1
+            if (read(pty->slave, &byte, 1) != 1
                 || byte != (unsigned char)(round + 1))
                 _exit(12);
             if (write_all(done[1], "D", 1) != 0)
@@ -238,8 +254,8 @@ static void check_reader_wakeup_after_flush(void)
         unsigned char signal;
         unsigned char byte = (unsigned char)(round + 1);
         if (read(ready[0], &signal, 1) != 1
-            || ioctl(pty.slave, TCFLSH, TCIFLUSH) != 0
-            || write_all(pty.master, &byte, 1) != 0
+            || ioctl(pty->slave, TCFLSH, TCIFLUSH) != 0
+            || write_all(pty->master, &byte, 1) != 0
             || read(done[0], &signal, 1) != 1) {
             fail("flush followed by blocked reader wakeup");
             break;
@@ -252,16 +268,23 @@ static void check_reader_wakeup_after_flush(void)
         fail("reader wakeup child completed");
     close(ready[0]);
     close(done[0]);
-    close_pty(&pty);
 }
 
 int main(void)
 {
-    check_selector(TCIFLUSH, 1, 0);
-    check_selector(TCOFLUSH, 0, 1);
-    check_selector(TCIOFLUSH, 1, 1);
-    check_invalid_selector();
-    check_reader_wakeup_after_flush();
+    struct pty_pair pty = {.master = -1, .slave = -1};
+
+    if (open_raw_pty(&pty) != 0) {
+        fail("open raw PTY");
+    } else {
+        check_selector(&pty, TCIFLUSH, 1, 0);
+        check_selector(&pty, TCOFLUSH, 0, 1);
+        check_selector(&pty, TCIOFLUSH, 1, 1);
+        check_invalid_selector(&pty);
+        check_reader_wakeup_after_flush(&pty);
+        check_input_source_flush(&pty);
+    }
+    close_pty(&pty);
 
     if (failures != 0) {
         fprintf(stderr, "test-tty-flush: %d failure(s)\n", failures);

--- a/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
+++ b/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
@@ -236,13 +236,19 @@ out:
 static void check_serial_output_flush(void)
 {
     int fd = open("/dev/ttyS0", O_RDWR | O_NOCTTY | O_NONBLOCK);
+    int rc;
 
     if (fd < 0) {
         fail("open serial TTY for output flush");
         return;
     }
-    if (ioctl(fd, TCFLSH, TCOFLUSH) != 0)
-        fail("TCOFLUSH discards serial output");
+    rc = ioctl(fd, TCFLSH, TCOFLUSH);
+    if (rc != 0) {
+        if (errno == EOPNOTSUPP)
+            puts("SKIP: serial hardware has no TX-only discard");
+        else
+            fail("TCOFLUSH discards serial output");
+    }
     close(fd);
 }
 

--- a/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
+++ b/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
@@ -233,6 +233,19 @@ out:
     close_pty(&pty);
 }
 
+static void check_serial_output_flush(void)
+{
+    int fd = open("/dev/ttyS0", O_RDWR | O_NOCTTY | O_NONBLOCK);
+
+    if (fd < 0) {
+        fail("open serial TTY for output flush");
+        return;
+    }
+    if (ioctl(fd, TCFLSH, TCOFLUSH) != 0)
+        fail("TCOFLUSH discards serial output");
+    close(fd);
+}
+
 static void check_reader_wakeup_after_flush(struct pty_pair *pty)
 {
     enum { ROUNDS = 64 };
@@ -318,6 +331,7 @@ int main(void)
     }
     close_pty(&pty);
     check_deferred_echo_flush();
+    check_serial_output_flush();
 
     if (failures != 0) {
         fprintf(stderr, "test-tty-flush: %d failure(s)\n", failures);

--- a/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
+++ b/test-suit/starryos/qemu/system/test-tty-flush/src/main.c
@@ -1,0 +1,272 @@
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/wait.h>
+#include <termios.h>
+#include <unistd.h>
+
+struct pty_pair {
+    int master;
+    int slave;
+};
+
+static int failures;
+
+static void fail(const char *message)
+{
+    fprintf(stderr, "FAIL: %s (errno=%d: %s)\n", message, errno,
+            strerror(errno));
+    failures++;
+}
+
+static int set_nonblocking(int fd, int enabled)
+{
+    int flags = fcntl(fd, F_GETFL);
+    if (flags < 0)
+        return -1;
+    if (enabled)
+        flags |= O_NONBLOCK;
+    else
+        flags &= ~O_NONBLOCK;
+    return fcntl(fd, F_SETFL, flags);
+}
+
+static int open_raw_pty(struct pty_pair *pty)
+{
+    pty->master = posix_openpt(O_RDWR | O_NOCTTY);
+    if (pty->master < 0 || grantpt(pty->master) != 0
+        || unlockpt(pty->master) != 0)
+        return -1;
+
+    char *name = ptsname(pty->master);
+    if (name == NULL)
+        return -1;
+    pty->slave = open(name, O_RDWR | O_NOCTTY);
+    if (pty->slave < 0)
+        return -1;
+
+    struct termios term;
+    if (tcgetattr(pty->slave, &term) != 0)
+        return -1;
+    cfmakeraw(&term);
+    term.c_cc[VMIN] = 1;
+    term.c_cc[VTIME] = 0;
+    if (tcsetattr(pty->slave, TCSANOW, &term) != 0
+        || set_nonblocking(pty->master, 1) != 0
+        || set_nonblocking(pty->slave, 1) != 0)
+        return -1;
+    return 0;
+}
+
+static void close_pty(struct pty_pair *pty)
+{
+    if (pty->master >= 0)
+        close(pty->master);
+    if (pty->slave >= 0)
+        close(pty->slave);
+}
+
+static int wait_readable(int fd, int timeout_ms)
+{
+    struct pollfd pfd = {.fd = fd, .events = POLLIN, .revents = 0};
+    int rc;
+    do {
+        rc = poll(&pfd, 1, timeout_ms);
+    } while (rc < 0 && errno == EINTR);
+    return rc > 0 && (pfd.revents & POLLIN) != 0;
+}
+
+static int write_all(int fd, const void *data, size_t len)
+{
+    const unsigned char *bytes = data;
+    size_t offset = 0;
+    while (offset < len) {
+        ssize_t count = write(fd, bytes + offset, len - offset);
+        if (count > 0) {
+            offset += (size_t)count;
+            continue;
+        }
+        if (count < 0 && errno == EINTR)
+            continue;
+        if (count < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+            struct pollfd pfd = {.fd = fd, .events = POLLOUT, .revents = 0};
+            if (poll(&pfd, 1, 2000) > 0)
+                continue;
+        }
+        return -1;
+    }
+    return 0;
+}
+
+static int read_exact(int fd, const void *expected, size_t len)
+{
+    unsigned char actual[64];
+    size_t offset = 0;
+    if (len > sizeof(actual))
+        return -1;
+    while (offset < len) {
+        if (!wait_readable(fd, 2000))
+            return -1;
+        ssize_t count = read(fd, actual + offset, len - offset);
+        if (count > 0) {
+            offset += (size_t)count;
+            continue;
+        }
+        if (count < 0 && errno == EINTR)
+            continue;
+        return -1;
+    }
+    return memcmp(actual, expected, len) == 0 ? 0 : -1;
+}
+
+static int expect_empty(int fd)
+{
+    unsigned char byte;
+    if (wait_readable(fd, 50))
+        return -1;
+    errno = 0;
+    return read(fd, &byte, 1) == -1
+        && (errno == EAGAIN || errno == EWOULDBLOCK)
+        ? 0
+        : -1;
+}
+
+static int queue_input(struct pty_pair *pty, const char *payload)
+{
+    return write_all(pty->master, payload, strlen(payload)) == 0
+        && wait_readable(pty->slave, 2000)
+        ? 0
+        : -1;
+}
+
+static int queue_output(struct pty_pair *pty, const char *payload)
+{
+    return write_all(pty->slave, payload, strlen(payload));
+}
+
+static void check_selector(int selector, int drop_input, int drop_output)
+{
+    static const char input[] = "queued-input";
+    static const char output[] = "queued-output";
+    struct pty_pair pty = {.master = -1, .slave = -1};
+
+    if (open_raw_pty(&pty) != 0) {
+        fail("open raw PTY");
+        close_pty(&pty);
+        return;
+    }
+    if (queue_input(&pty, input) != 0 || queue_output(&pty, output) != 0) {
+        fail("queue PTY input and output");
+        close_pty(&pty);
+        return;
+    }
+    if (ioctl(pty.slave, TCFLSH, selector) != 0) {
+        fail("TCFLSH selector succeeds");
+        close_pty(&pty);
+        return;
+    }
+
+    if ((drop_input ? expect_empty(pty.slave)
+                    : read_exact(pty.slave, input, sizeof(input) - 1)) != 0)
+        fail("TCFLSH input effect");
+    if ((drop_output ? expect_empty(pty.master)
+                     : read_exact(pty.master, output, sizeof(output) - 1)) != 0)
+        fail("TCFLSH output effect");
+    close_pty(&pty);
+}
+
+static void check_invalid_selector(void)
+{
+    struct pty_pair pty = {.master = -1, .slave = -1};
+    if (open_raw_pty(&pty) != 0) {
+        fail("open PTY for invalid selector");
+        close_pty(&pty);
+        return;
+    }
+    errno = 0;
+    if (ioctl(pty.slave, TCFLSH, 3) != -1 || errno != EINVAL)
+        fail("TCFLSH rejects invalid selector with EINVAL");
+    close_pty(&pty);
+}
+
+static void check_reader_wakeup_after_flush(void)
+{
+    enum { ROUNDS = 64 };
+    struct pty_pair pty = {.master = -1, .slave = -1};
+    int ready[2] = {-1, -1};
+    int done[2] = {-1, -1};
+
+    if (open_raw_pty(&pty) != 0 || pipe(ready) != 0 || pipe(done) != 0) {
+        fail("prepare reader wakeup test");
+        close_pty(&pty);
+        return;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        fail("fork reader wakeup test");
+        close_pty(&pty);
+        return;
+    }
+    if (child == 0) {
+        close(ready[0]);
+        close(done[0]);
+        close(pty.master);
+        if (set_nonblocking(pty.slave, 0) != 0)
+            _exit(10);
+        for (unsigned int round = 0; round < ROUNDS; round++) {
+            unsigned char byte;
+            if (write_all(ready[1], "R", 1) != 0)
+                _exit(11);
+            if (read(pty.slave, &byte, 1) != 1
+                || byte != (unsigned char)(round + 1))
+                _exit(12);
+            if (write_all(done[1], "D", 1) != 0)
+                _exit(13);
+        }
+        _exit(0);
+    }
+
+    close(ready[1]);
+    close(done[1]);
+    for (unsigned int round = 0; round < ROUNDS; round++) {
+        unsigned char signal;
+        unsigned char byte = (unsigned char)(round + 1);
+        if (read(ready[0], &signal, 1) != 1
+            || ioctl(pty.slave, TCFLSH, TCIFLUSH) != 0
+            || write_all(pty.master, &byte, 1) != 0
+            || read(done[0], &signal, 1) != 1) {
+            fail("flush followed by blocked reader wakeup");
+            break;
+        }
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child || !WIFEXITED(status)
+        || WEXITSTATUS(status) != 0)
+        fail("reader wakeup child completed");
+    close(ready[0]);
+    close(done[0]);
+    close_pty(&pty);
+}
+
+int main(void)
+{
+    check_selector(TCIFLUSH, 1, 0);
+    check_selector(TCOFLUSH, 0, 1);
+    check_selector(TCIOFLUSH, 1, 1);
+    check_invalid_selector();
+    check_reader_wakeup_after_flush();
+
+    if (failures != 0) {
+        fprintf(stderr, "test-tty-flush: %d failure(s)\n", failures);
+        return 1;
+    }
+    puts("test-tty-flush: PASS");
+    return 0;
+}


### PR DESCRIPTION
修复 TTY 输入清理和唤醒问题：
- 支持通过 TCFLSH 清理输入缓冲区
- 简化 TTY reader 的事件唤醒机制，避免检查与休眠之间丢失唤醒