### PR TITLE
Fix UVC asynchronous transfer lifecycle

### DIFF
--- a/components/axklib/src/dma.rs
+++ b/components/axklib/src/dma.rs
@@ -206,9 +206,7 @@ impl DmaOp for KlibDma {
         let layout = Layout::from_size_align(size.get(), align)?;
         let dma_addr = dma_addr_from_ptr(addr);
 
-        if dma_range_fits_mask(dma_addr, size.get(), constraints.addr_mask)
-            && dma_addr_is_aligned(dma_addr, align)
-        {
+        if dma_mapping_can_be_direct(dma_addr, size.get(), constraints) {
             return Ok(unsafe { DmaMapHandle::new(addr, dma_addr.into(), layout, None) });
         }
 
@@ -268,6 +266,15 @@ fn dma_range_fits_mask(dma_addr: u64, size: usize, dma_mask: u64) -> bool {
 
 fn dma_addr_is_aligned(dma_addr: u64, align: usize) -> bool {
     dma_addr.is_multiple_of(align.max(1) as u64)
+}
+
+fn dma_mapping_can_be_direct(dma_addr: u64, size: usize, constraints: DmaConstraints) -> bool {
+    let align = constraints.align.max(1);
+    // A direct streaming mapping transfers cache-line ownership to the device.
+    // Keep both ends aligned so unrelated heap objects cannot share that range.
+    dma_range_fits_mask(dma_addr, size, constraints.addr_mask)
+        && dma_addr_is_aligned(dma_addr, align)
+        && size.is_multiple_of(align)
 }
 
 #[cfg(test)]
@@ -340,5 +347,15 @@ mod tests {
 
         assert_eq!(result, None);
         assert!(events.borrow().is_empty());
+    }
+
+    #[test]
+    fn direct_streaming_mapping_requires_an_isolated_aligned_range() {
+        let constraints = DmaConstraints::new(u32::MAX as u64).with_align(64);
+
+        assert!(dma_mapping_can_be_direct(0x1000, 64, constraints));
+        assert!(dma_mapping_can_be_direct(0x1000, 128, constraints));
+        assert!(!dma_mapping_can_be_direct(0x1000, 9, constraints));
+        assert!(!dma_mapping_can_be_direct(0x1001, 64, constraints));
     }
 }

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/device.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/device.rs
@@ -351,11 +351,19 @@ impl Device {
         let mut data = vec![0u8; 8];
 
         // DMA 传输
-        self.control_endpoint_mut()
+        let actual = self
+            .control_endpoint_mut()
             .get_descriptor(DescriptorType::DEVICE, 0, 0, data.as_mut_slice())
             .await?;
+        if actual != data.len() {
+            return Err(anyhow!(
+                "short device descriptor header: expected {} bytes, got {actual}",
+                data.len()
+            )
+            .into());
+        }
 
-        let desc = unsafe { *(data.as_mut_slice().as_ptr() as *const DeviceDescriptorBase) };
+        let desc = unsafe { (data.as_ptr() as *const DeviceDescriptorBase).read_unaligned() };
 
         Ok(desc)
     }
@@ -603,9 +611,8 @@ impl Device {
             EndpointType::Isochronous => {
                 match self.port_speed {
                     Speed::High | Speed::SuperSpeed | Speed::SuperSpeedPlus => {
-                        // HighSpeed, SuperSpeed, SuperSpeedPlus ISO 端点
-                        // Interval = max(1, min(16, bInterval))
-                        let interval = binterval.clamp(1, 16);
+                        // HS/SS bInterval is one-based; xHCI Interval is zero-based.
+                        let interval = binterval.clamp(1, 16) - 1;
                         debug!(
                             "ISO endpoint HS/SS: bInterval={} -> XHCI interval={}",
                             binterval, interval
@@ -613,53 +620,33 @@ impl Device {
                         interval
                     }
                     _ => {
-                        // FullSpeed/LowSpeed ISO 端点
-                        // Interval = max(1, min(16, floor(log2(bInterval)) + 3))
-                        if binterval == 0 {
-                            1
-                        } else {
-                            // 计算 floor(log2(bInterval))
-                            let log2_binterval = 31 - (binterval as u32).leading_zeros() as u8 - 1;
-                            let interval = (log2_binterval + 3).clamp(1, 16);
-                            debug!(
-                                "ISO endpoint FS/LS: bInterval={} -> log2={} -> XHCI interval={}",
-                                binterval, log2_binterval, interval
-                            );
-                            interval
-                        }
-                    }
-                }
-            }
-            EndpointType::Interrupt => {
-                match self.port_speed {
-                    Speed::High | Speed::SuperSpeed | Speed::SuperSpeedPlus => {
-                        // HighSpeed, SuperSpeed, SuperSpeedPlus 中断端点
-                        // Interval = max(1, min(16, bInterval))
-                        let interval = binterval.clamp(1, 16);
+                        let interval = binterval.max(1).ilog2() as u8 + 3;
                         debug!(
-                            "INT endpoint HS/SS: bInterval={} -> XHCI interval={}",
+                            "ISO endpoint FS/LS: bInterval={} -> XHCI interval={}",
                             binterval, interval
                         );
                         interval
                     }
-                    _ => {
-                        // FullSpeed/LowSpeed 中断端点
-                        // Interval = max(1, min(16, floor(log2(bInterval)) + 3))
-                        if binterval == 0 {
-                            1
-                        } else {
-                            // 计算 floor(log2(bInterval))
-                            let log2_binterval = 31 - (binterval as u32).leading_zeros() as u8 - 1;
-                            let interval = (log2_binterval + 3).clamp(1, 16);
-                            debug!(
-                                "INT endpoint FS/LS: bInterval={} -> log2={} -> XHCI interval={}",
-                                binterval, log2_binterval, interval
-                            );
-                            interval
-                        }
-                    }
                 }
             }
+            EndpointType::Interrupt => match self.port_speed {
+                Speed::High | Speed::SuperSpeed | Speed::SuperSpeedPlus => {
+                    let interval = binterval.clamp(1, 16) - 1;
+                    debug!(
+                        "INT endpoint HS/SS: bInterval={} -> XHCI interval={}",
+                        binterval, interval
+                    );
+                    interval
+                }
+                _ => {
+                    let interval = binterval.max(1).ilog2() as u8 + 3;
+                    debug!(
+                        "INT endpoint FS/LS: bInterval={} -> XHCI interval={}",
+                        binterval, interval
+                    );
+                    interval
+                }
+            },
             _ => {
                 // 控制和批量端点不使用 interval
                 default

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -850,6 +850,10 @@ impl EndpointOp for Endpoint {
             .ok_or(TransferError::InvalidEndpoint)
     }
 
+    fn supports_retire_after_quiesce(&self) -> bool {
+        true
+    }
+
     fn reset(&mut self) -> EndpointResetFuture {
         if !self.inflight.is_empty() || self.outstanding_trbs != 0 {
             return Box::pin(async { Err(TransferError::QueueFull) });

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -79,11 +79,17 @@ struct SubmittedTd {
     cancelled: bool,
 }
 
-#[derive(Clone)]
 enum SubmittedTdKind {
     Normal { completion_trb: TransferId },
     Control(ControlTd),
     Iso { packets: Vec<IsoPacketTd> },
+}
+
+#[derive(Clone, Copy)]
+enum ReclaimTarget {
+    Normal(TransferId),
+    Control(ControlTd),
+    Iso,
 }
 
 #[derive(Clone, Copy)]
@@ -239,7 +245,7 @@ impl Endpoint {
         event_trb: TransferId,
         event: TransferEvent,
     ) -> Result<Transfer, TransferError> {
-        let submitted = self.inflight.remove(&request_id).ok_or_else(|| {
+        let submitted = self.remove_request(request_id).ok_or_else(|| {
             warn!(
                 "xhci: completion for missing request dci={} request_id={} event_trb={:#x}",
                 self.dci.raw(),
@@ -248,6 +254,22 @@ impl Endpoint {
             );
             TransferError::InvalidEndpoint
         })?;
+
+        if submitted.cancelled {
+            return Err(TransferError::Cancelled);
+        }
+
+        if matches!(event.completion_code(), Ok(CompletionCode::StallError)) {
+            self.halted.store(true, Ordering::Release);
+        }
+        if !matches!(submitted.kind, SubmittedTdKind::Iso { .. }) {
+            self.validate_completion_code(event, &submitted.transfer)?;
+        }
+        self.transfer_from_completion(submitted, event_trb, event)
+    }
+
+    fn remove_request(&mut self, request_id: EndpointRequestId) -> Option<SubmittedTd> {
+        let submitted = self.inflight.remove(&request_id)?;
         self.outstanding_trbs = self.outstanding_trbs.saturating_sub(submitted.trb_count);
         match &submitted.kind {
             SubmittedTdKind::Normal { completion_trb } => {
@@ -264,18 +286,7 @@ impl Endpoint {
                 }
             }
         }
-
-        if submitted.cancelled {
-            return Err(TransferError::Cancelled);
-        }
-
-        if matches!(event.completion_code(), Ok(CompletionCode::StallError)) {
-            self.halted.store(true, Ordering::Release);
-        }
-        if !matches!(submitted.kind, SubmittedTdKind::Iso { .. }) {
-            self.validate_completion_code(event, &submitted.transfer)?;
-        }
-        self.transfer_from_completion(submitted, event_trb, event)
+        Some(submitted)
     }
 
     fn transfer_from_completion(
@@ -628,9 +639,7 @@ impl EndpointOp for Endpoint {
 
         let mut data_bus_addr = 0;
         if transfer.buffer_len() > 0 {
-            if matches!(transfer.direction, Direction::Out) {
-                transfer.prepare_for_device_all();
-            }
+            transfer.prepare_for_device_all();
             data_bus_addr = transfer.dma_addr();
             let buffer_end = data_bus_addr + transfer.buffer_len() as u64;
             if data_bus_addr > self.kernel.dma_mask() || buffer_end > self.kernel.dma_mask() {
@@ -784,19 +793,23 @@ impl EndpointOp for Endpoint {
         id: RequestId,
     ) -> Option<Result<TransferCompletion, TransferError>> {
         let request_id = Self::private_request_id(id);
-        let kind = self.inflight.get(&request_id)?.kind.clone();
-        match kind {
-            SubmittedTdKind::Normal { completion_trb } => {
+        let target = match &self.inflight.get(&request_id)?.kind {
+            SubmittedTdKind::Normal { completion_trb } => ReclaimTarget::Normal(*completion_trb),
+            SubmittedTdKind::Control(control_td) => ReclaimTarget::Control(*control_td),
+            SubmittedTdKind::Iso { .. } => ReclaimTarget::Iso,
+        };
+        match target {
+            ReclaimTarget::Normal(completion_trb) => {
                 let event = self.ring.get_finished(completion_trb.0)?;
                 Some(
                     self.complete_request(request_id, completion_trb, event)
                         .map(|transfer| transfer_to_completion(id, transfer)),
                 )
             }
-            SubmittedTdKind::Control(control_td) => {
+            ReclaimTarget::Control(control_td) => {
                 self.reclaim_control_request(id, request_id, control_td)
             }
-            SubmittedTdKind::Iso { .. } => self.reclaim_iso_request(id, request_id),
+            ReclaimTarget::Iso => self.reclaim_iso_request(id, request_id),
         }
     }
 
@@ -828,6 +841,13 @@ impl EndpointOp for Endpoint {
             .ok_or(TransferError::InvalidEndpoint)?;
         submitted.cancelled = true;
         Ok(())
+    }
+
+    fn retire_request_after_quiesce(&mut self, id: RequestId) -> Result<(), TransferError> {
+        let request_id = Self::private_request_id(id);
+        self.remove_request(request_id)
+            .map(drop)
+            .ok_or(TransferError::InvalidEndpoint)
     }
 
     fn reset(&mut self) -> EndpointResetFuture {

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -984,3 +984,147 @@ impl EndpointDescriptorExt for EndpointDescriptor {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::{
+        alloc::{alloc_zeroed, dealloc},
+        sync::Arc,
+        vec,
+        vec::Vec,
+    };
+    use core::{
+        alloc::Layout,
+        num::NonZeroUsize,
+        ptr::NonNull,
+        sync::atomic::{AtomicU64, AtomicUsize, Ordering as AtomicOrdering},
+    };
+
+    use ax_kspin::{SpinRaw as Mutex, SpinRwLock as RwLock};
+    use dma_api::{DmaAllocHandle, DmaConstraints, DmaError, DmaMapHandle, DmaOp};
+    use usb_if::{endpoint::TransferRequest, err::TransferError};
+
+    use super::*;
+    use crate::{backend::kmod::xhci::reg::XhciRegisters, osal::KernelOp};
+
+    struct TestKernel;
+
+    static TEST_DMA_ADDR: AtomicU64 = AtomicU64::new(0x1000);
+    static ACTIVE_STREAMING_MAPPINGS: AtomicUsize = AtomicUsize::new(0);
+
+    impl DmaOp for TestKernel {
+        fn page_size(&self) -> usize {
+            4096
+        }
+
+        unsafe fn alloc_contiguous(
+            &self,
+            constraints: DmaConstraints,
+            layout: Layout,
+        ) -> Option<DmaAllocHandle> {
+            // SAFETY: The test kernel models contiguous DMA with the same heap-backed
+            // allocation used for coherent DMA below.
+            unsafe { self.alloc_coherent(constraints, layout) }
+        }
+
+        unsafe fn dealloc_contiguous(&self, handle: DmaAllocHandle) {
+            // SAFETY: Contiguous handles are allocated by `alloc_coherent` above.
+            unsafe { self.dealloc_coherent(handle) }
+                .expect("test coherent DMA release must succeed")
+        }
+
+        unsafe fn alloc_coherent(
+            &self,
+            constraints: DmaConstraints,
+            layout: Layout,
+        ) -> Option<DmaAllocHandle> {
+            // SAFETY: Unit tests pass valid layouts, and the allocation remains owned by
+            // the returned DMA handle until `dealloc_coherent` consumes it.
+            let ptr = NonNull::new(unsafe { alloc_zeroed(layout) })?;
+            let align = constraints.align.max(layout.align()).max(1) as u64;
+            let size = layout.size().max(1) as u64;
+            let current = TEST_DMA_ADDR.fetch_add(size + align, AtomicOrdering::Relaxed);
+            let dma_addr = (current + align - 1) & !(align - 1);
+            // SAFETY: `ptr` and `layout` describe the allocation above. The fake bus
+            // address is deterministic and never reaches hardware.
+            Some(unsafe { DmaAllocHandle::new(ptr, dma_addr.into(), layout) })
+        }
+
+        unsafe fn dealloc_coherent(&self, handle: DmaAllocHandle) -> Result<(), DmaError> {
+            // SAFETY: The handle was allocated by `alloc_zeroed` with this exact layout.
+            unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) };
+            Ok(())
+        }
+
+        unsafe fn map_streaming(
+            &self,
+            constraints: DmaConstraints,
+            addr: NonNull<u8>,
+            size: NonZeroUsize,
+            _direction: DmaDirection,
+        ) -> Result<DmaMapHandle, DmaError> {
+            let layout = Layout::from_size_align(size.get(), 1)?;
+            let align = constraints.align.max(1) as u64;
+            let current =
+                TEST_DMA_ADDR.fetch_add(size.get() as u64 + align, AtomicOrdering::Relaxed);
+            let dma_addr = (current + align - 1) & !(align - 1);
+            // SAFETY: The mapped buffer remains owned by the test until the request is
+            // retired, and the mapping is never submitted to real hardware.
+            let handle = unsafe { DmaMapHandle::new(addr, dma_addr.into(), layout, None) };
+            ACTIVE_STREAMING_MAPPINGS.fetch_add(1, AtomicOrdering::Relaxed);
+            Ok(handle)
+        }
+
+        unsafe fn unmap_streaming(&self, _handle: DmaMapHandle) {
+            ACTIVE_STREAMING_MAPPINGS.fetch_sub(1, AtomicOrdering::Relaxed);
+        }
+    }
+
+    impl KernelOp for TestKernel {
+        fn delay(&self, _duration: core::time::Duration) {}
+    }
+
+    static TEST_KERNEL: TestKernel = TestKernel;
+
+    fn test_endpoint() -> (Vec<u32>, Endpoint) {
+        let mut mmio = vec![0u32; 4096];
+        // The xHCI accessor requires a doorbell entry for slot one and a port array.
+        mmio[1] = 2 | (1 << 24);
+        let mmio_base = NonNull::new(mmio.as_mut_ptr().cast::<u8>()).unwrap();
+        let registers = Arc::new(RwLock::new(XhciRegisters::new(mmio_base)));
+        let slot_id = SlotId::from(1);
+        let bell = Arc::new(Mutex::new(SlotBell::new(slot_id, registers.read().clone())));
+        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
+        let command_ring =
+            CommandRing::new(DmaDirection::Bidirectional, &kernel, registers).unwrap();
+        let endpoint = Endpoint::new(slot_id, Dci::from(2), &kernel, bell, command_ring).unwrap();
+        (mmio, endpoint)
+    }
+
+    #[test]
+    fn cancelled_iso_request_is_retired_exactly_once_after_endpoint_quiesce() {
+        let (_mmio, mut endpoint) = test_endpoint();
+        let payload = [0u8; 128];
+        let request_id = endpoint
+            .submit_request(TransferRequest::iso_out(&payload, &[64, 64]))
+            .unwrap();
+
+        assert_eq!(endpoint.inflight.len(), 1);
+        assert_eq!(endpoint.trb_to_request.len(), 2);
+        assert_eq!(endpoint.outstanding_trbs, 2);
+        assert_eq!(ACTIVE_STREAMING_MAPPINGS.load(AtomicOrdering::Relaxed), 1);
+
+        endpoint.cancel_request(request_id).unwrap();
+        endpoint.retire_request_after_quiesce(request_id).unwrap();
+
+        assert!(endpoint.inflight.is_empty());
+        assert!(endpoint.trb_to_request.is_empty());
+        assert_eq!(endpoint.outstanding_trbs, 0);
+        assert_eq!(ACTIVE_STREAMING_MAPPINGS.load(AtomicOrdering::Relaxed), 0);
+        assert!(endpoint.reclaim_request(request_id).is_none());
+        assert!(matches!(
+            endpoint.retire_request_after_quiesce(request_id),
+            Err(TransferError::InvalidEndpoint)
+        ));
+    }
+}

--- a/drivers/usb/usb-host/src/backend/ty/ep/ctrl.rs
+++ b/drivers/usb/usb-host/src/backend/ty/ep/ctrl.rs
@@ -67,8 +67,16 @@ impl Endpoint {
 
     pub async fn get_device_descriptor(&mut self) -> Result<DeviceDescriptor, USBError> {
         let mut buff = alloc::vec![0u8; DeviceDescriptor::LEN];
-        self.get_descriptor(DescriptorType::DEVICE, 0, 0, &mut buff)
+        let actual = self
+            .get_descriptor(DescriptorType::DEVICE, 0, 0, &mut buff)
             .await?;
+        if actual != buff.len() {
+            return Err(anyhow!(
+                "short device descriptor: expected {} bytes, got {actual}",
+                buff.len()
+            )
+            .into());
+        }
         trace!("data: {buff:?}");
         let desc = DeviceDescriptor::parse(&buff).ok_or(anyhow!("device descriptor parse err"))?;
 

--- a/drivers/usb/usb-host/src/backend/ty/ep/mod.rs
+++ b/drivers/usb/usb-host/src/backend/ty/ep/mod.rs
@@ -43,6 +43,10 @@ pub(crate) trait EndpointOp: Send + Any + 'static {
         Err(TransferError::NotSupported)
     }
 
+    fn supports_retire_after_quiesce(&self) -> bool {
+        false
+    }
+
     fn reset(&mut self) -> EndpointResetFuture {
         Box::pin(async { Err(TransferError::NotSupported) })
     }
@@ -104,6 +108,10 @@ impl Endpoint {
 
     pub fn retire_after_quiesce(&mut self, id: RequestId) -> Result<(), TransferError> {
         self.raw.retire_request_after_quiesce(id)
+    }
+
+    pub fn supports_retire_after_quiesce(&self) -> bool {
+        self.raw.supports_retire_after_quiesce()
     }
 
     /// Resets host-controller state for this endpoint after a successful

--- a/drivers/usb/usb-host/src/backend/ty/ep/mod.rs
+++ b/drivers/usb/usb-host/src/backend/ty/ep/mod.rs
@@ -35,6 +35,14 @@ pub(crate) trait EndpointOp: Send + Any + 'static {
         Err(TransferError::NotSupported)
     }
 
+    /// Retires a request after the controller has stopped using this endpoint.
+    ///
+    /// The caller must first quiesce the endpoint in hardware, for example by
+    /// switching its interface to another alternate setting.
+    fn retire_request_after_quiesce(&mut self, _id: RequestId) -> Result<(), TransferError> {
+        Err(TransferError::NotSupported)
+    }
+
     fn reset(&mut self) -> EndpointResetFuture {
         Box::pin(async { Err(TransferError::NotSupported) })
     }
@@ -92,6 +100,10 @@ impl Endpoint {
 
     pub fn cancel(&mut self, id: RequestId) -> Result<(), TransferError> {
         self.raw.cancel_request(id)
+    }
+
+    pub fn retire_after_quiesce(&mut self, id: RequestId) -> Result<(), TransferError> {
+        self.raw.retire_request_after_quiesce(id)
     }
 
     /// Resets host-controller state for this endpoint after a successful

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
@@ -92,6 +92,12 @@ pub(super) struct SubmittedTransfer {
     inner: SubmittedTransferInner,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum SubmittedTransferQueue {
+    Endpoint(usize),
+    Control(usize),
+}
+
 enum SubmittedTransferInner {
     Endpoint {
         endpoint: EndpointHandle,
@@ -126,6 +132,17 @@ impl Clone for SubmittedTransfer {
 }
 
 impl SubmittedTransfer {
+    pub(super) fn queue_key(&self) -> SubmittedTransferQueue {
+        match &self.inner {
+            SubmittedTransferInner::Endpoint { endpoint, .. } => {
+                SubmittedTransferQueue::Endpoint(Arc::as_ptr(endpoint) as usize)
+            }
+            SubmittedTransferInner::Control { live_device, .. } => {
+                SubmittedTransferQueue::Control(Arc::as_ptr(live_device) as usize)
+            }
+        }
+    }
+
     pub(super) fn try_reclaim(&self) -> AxResult<Option<TransferCompletion>> {
         match &self.inner {
             SubmittedTransferInner::Endpoint {
@@ -186,6 +203,19 @@ impl SubmittedTransfer {
                 .ctrl_ep_mut()
                 .cancel(*request_id)
                 .map_err(map_transfer_error),
+        }
+    }
+
+    pub(super) fn retire_after_quiesce(&self) -> AxResult<()> {
+        match &self.inner {
+            SubmittedTransferInner::Endpoint {
+                endpoint,
+                request_id,
+            } => endpoint
+                .lock()
+                .retire_after_quiesce(*request_id)
+                .map_err(map_transfer_error),
+            SubmittedTransferInner::Control { .. } => Err(AxError::Unsupported),
         }
     }
 }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
@@ -218,6 +218,15 @@ impl SubmittedTransfer {
             SubmittedTransferInner::Control { .. } => Err(AxError::Unsupported),
         }
     }
+
+    pub(super) fn supports_retire_after_quiesce(&self) -> bool {
+        match &self.inner {
+            SubmittedTransferInner::Endpoint { endpoint, .. } => {
+                endpoint.lock().supports_retire_after_quiesce()
+            }
+            SubmittedTransferInner::Control { .. } => false,
+        }
+    }
 }
 
 fn wait_endpoint(

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -307,6 +307,13 @@ impl SubmittedUrb {
         }
     }
 
+    fn supports_retire_after_quiesce(&self) -> bool {
+        match &self.transfer {
+            SubmittedUrbTransfer::Live(transfer) => transfer.supports_retire_after_quiesce(),
+            SubmittedUrbTransfer::Deferred(_) => true,
+        }
+    }
+
     fn deferred_quirk(&self) -> Option<UsbfsQuirk> {
         match &self.transfer {
             SubmittedUrbTransfer::Live(_) => None,
@@ -408,17 +415,34 @@ impl UsbDeviceFile {
             self.claimed_interfaces.lock().insert(interface, alternate);
             return Ok(0);
         }
+        let retire_after_quiesce = submitted
+            .iter()
+            .all(SubmittedUrb::supports_retire_after_quiesce);
+        let submitted = if retire_after_quiesce {
+            submitted
+        } else {
+            let remaining = cleanup_submitted_urbs(submitted, Some(USBFS_URB_CANCEL_TIMEOUT));
+            if !remaining.is_empty() {
+                self.submitted_urbs.lock().extend(remaining);
+                return Err(AxError::ResourceBusy);
+            }
+            Vec::new()
+        };
         if let Err(err) = self.with_live_lease(|lease| lease.claim_interface(interface, alternate))
         {
             self.submitted_urbs.lock().extend(submitted);
             return Err(err);
         }
-        let remaining = retire_quiesced_urbs(submitted);
+        self.claimed_interfaces.lock().insert(interface, alternate);
+        let remaining = if retire_after_quiesce {
+            retire_quiesced_urbs(submitted)
+        } else {
+            Vec::new()
+        };
         if !remaining.is_empty() {
             self.submitted_urbs.lock().extend(remaining);
             return Err(AxError::ResourceBusy);
         }
-        self.claimed_interfaces.lock().insert(interface, alternate);
         Ok(0)
     }
 
@@ -435,11 +459,30 @@ impl UsbDeviceFile {
             let remaining = if alternate != 0
                 && usbfs_quirk_for_interface(&self.snapshot, interface, alternate).is_none()
             {
+                let retire_after_quiesce = submitted
+                    .iter()
+                    .all(SubmittedUrb::supports_retire_after_quiesce);
+                let submitted = if retire_after_quiesce {
+                    submitted
+                } else {
+                    let remaining =
+                        cleanup_submitted_urbs(submitted, Some(USBFS_URB_CANCEL_TIMEOUT));
+                    if !remaining.is_empty() {
+                        self.submitted_urbs.lock().extend(remaining);
+                        return Err(AxError::ResourceBusy);
+                    }
+                    Vec::new()
+                };
                 if let Err(err) = lease.claim_interface(interface, 0) {
                     self.submitted_urbs.lock().extend(submitted);
                     return Err(err);
                 }
-                retire_quiesced_urbs(submitted)
+                self.claimed_interfaces.lock().insert(interface, 0);
+                if retire_after_quiesce {
+                    retire_quiesced_urbs(submitted)
+                } else {
+                    Vec::new()
+                }
             } else {
                 cleanup_submitted_urbs(submitted, Some(USBFS_URB_CANCEL_TIMEOUT))
             };
@@ -1501,7 +1544,10 @@ impl Drop for UsbDeviceFile {
                             index += 1;
                         }
                     }
-                    if lease.claim_interface(interface, 0).is_ok() {
+                    let retire_after_quiesce = interface_urbs
+                        .iter()
+                        .all(SubmittedUrb::supports_retire_after_quiesce);
+                    if retire_after_quiesce && lease.claim_interface(interface, 0).is_ok() {
                         submitted.extend(retire_quiesced_urbs(interface_urbs));
                     } else {
                         submitted.extend(interface_urbs);

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -4,7 +4,12 @@ mod manager;
 mod sysfs;
 mod tree;
 
-use alloc::{borrow::ToOwned, collections::VecDeque, sync::Arc, vec::Vec};
+use alloc::{
+    borrow::ToOwned,
+    collections::{BTreeSet, VecDeque},
+    sync::Arc,
+    vec::Vec,
+};
 use core::{
     any::Any,
     future::{Future, poll_fn},
@@ -267,6 +272,13 @@ enum UsbfsQuirk {
 }
 
 impl SubmittedUrb {
+    fn queue_key(&self) -> Option<manager::SubmittedTransferQueue> {
+        match &self.transfer {
+            SubmittedUrbTransfer::Live(transfer) => Some(transfer.queue_key()),
+            SubmittedUrbTransfer::Deferred(_) => None,
+        }
+    }
+
     fn try_reclaim(&self) -> AxResult<Option<TransferCompletion>> {
         match &self.transfer {
             SubmittedUrbTransfer::Live(transfer) => transfer.try_reclaim(),
@@ -284,6 +296,13 @@ impl SubmittedUrb {
     fn cancel(&self) -> AxResult<()> {
         match &self.transfer {
             SubmittedUrbTransfer::Live(transfer) => transfer.cancel(),
+            SubmittedUrbTransfer::Deferred(_) => Ok(()),
+        }
+    }
+
+    fn retire_after_quiesce(&self) -> AxResult<()> {
+        match &self.transfer {
+            SubmittedUrbTransfer::Live(transfer) => transfer.retire_after_quiesce(),
             SubmittedUrbTransfer::Deferred(_) => Ok(()),
         }
     }
@@ -369,7 +388,7 @@ impl UsbDeviceFile {
         }
 
         let interface_quirk = usbfs_quirk_for_interface(&self.snapshot, interface, alternate);
-        self.cancel_submitted_urbs_for_interface(interface)?;
+        let submitted = self.drain_submitted_urbs_for_interface(interface);
         if interface_quirk != Some(UsbfsQuirk::UserspaceClaimedUvcControlInterface)
             && self
                 .submitted_urbs
@@ -377,24 +396,64 @@ impl UsbDeviceFile {
                 .iter()
                 .any(|submitted| !submitted.is_deferred())
         {
+            self.submitted_urbs.lock().extend(submitted);
             return Err(AxError::ResourceBusy);
         }
-        self.release_endpoint_handles_for_interface(interface)?;
         if interface_quirk == Some(UsbfsQuirk::UserspaceClaimedUvcControlInterface) {
+            let remaining = cleanup_submitted_urbs(submitted, Some(USBFS_URB_CANCEL_TIMEOUT));
+            if !remaining.is_empty() {
+                self.submitted_urbs.lock().extend(remaining);
+                return Err(AxError::ResourceBusy);
+            }
             self.claimed_interfaces.lock().insert(interface, alternate);
             return Ok(0);
         }
-        self.with_live_lease(|lease| lease.claim_interface(interface, alternate))?;
+        if let Err(err) = self.with_live_lease(|lease| lease.claim_interface(interface, alternate))
+        {
+            self.submitted_urbs.lock().extend(submitted);
+            return Err(err);
+        }
+        let remaining = retire_quiesced_urbs(submitted);
+        if !remaining.is_empty() {
+            self.submitted_urbs.lock().extend(remaining);
+            return Err(AxError::ResourceBusy);
+        }
         self.claimed_interfaces.lock().insert(interface, alternate);
         Ok(0)
     }
 
     fn release_interface(&self, interface: u8) -> AxResult<usize> {
         let _lifecycle_guard = self.lifecycle_lock.lock();
-        self.cancel_submitted_urbs_for_interface(interface)?;
+        let alternate = self
+            .claimed_interfaces
+            .lock()
+            .get(&interface)
+            .copied()
+            .ok_or(AxError::InvalidInput)?;
+        let submitted = self.drain_submitted_urbs_for_interface(interface);
         if let Some(lease) = self.lease.lock().as_ref().cloned() {
+            let remaining = if alternate != 0
+                && usbfs_quirk_for_interface(&self.snapshot, interface, alternate).is_none()
+            {
+                if let Err(err) = lease.claim_interface(interface, 0) {
+                    self.submitted_urbs.lock().extend(submitted);
+                    return Err(err);
+                }
+                retire_quiesced_urbs(submitted)
+            } else {
+                cleanup_submitted_urbs(submitted, Some(USBFS_URB_CANCEL_TIMEOUT))
+            };
+            if !remaining.is_empty() {
+                self.submitted_urbs.lock().extend(remaining);
+                return Err(AxError::ResourceBusy);
+            }
             lease.release_interface(interface)?;
         } else {
+            let remaining = cleanup_submitted_urbs(submitted, Some(USBFS_URB_CANCEL_TIMEOUT));
+            if !remaining.is_empty() {
+                self.submitted_urbs.lock().extend(remaining);
+                return Err(AxError::ResourceBusy);
+            }
             self.release_endpoint_handles_for_interface(interface)?;
         }
         self.claimed_interfaces.lock().remove(&interface);
@@ -416,18 +475,6 @@ impl UsbDeviceFile {
         }
         self.with_live_lease(|lease| lease.set_configuration(configuration as u8))?;
         Ok(0)
-    }
-
-    fn cancel_submitted_urbs_for_interface(&self, interface: u8) -> AxResult<()> {
-        let remaining = cleanup_submitted_urbs(
-            self.drain_submitted_urbs_for_interface(interface),
-            Some(USBFS_URB_CANCEL_TIMEOUT),
-        );
-        if !remaining.is_empty() {
-            self.submitted_urbs.lock().extend(remaining);
-            return Err(AxError::ResourceBusy);
-        }
-        Ok(())
     }
 
     fn drain_submitted_urbs_for_interface(&self, interface: u8) -> Vec<SubmittedUrb> {
@@ -742,8 +789,14 @@ impl UsbDeviceFile {
         let mut ready = Vec::new();
         {
             let mut submitted_urbs = self.submitted_urbs.lock();
+            let mut blocked_queues = BTreeSet::new();
             let mut index = 0;
             while index < submitted_urbs.len() {
+                let queue_key = submitted_urbs[index].queue_key();
+                if queue_key.is_some_and(|key| blocked_queues.contains(&key)) {
+                    index += 1;
+                    continue;
+                }
                 let result = match cx.as_mut() {
                     Some(cx) => match submitted_urbs[index].poll_reclaim(cx) {
                         Poll::Ready(result) => Some(result),
@@ -762,6 +815,9 @@ impl UsbDeviceFile {
                         .expect("pending submitted URB disappeared");
                     ready.push((submitted, result));
                 } else {
+                    if let Some(queue_key) = queue_key {
+                        blocked_queues.insert(queue_key);
+                    }
                     index += 1;
                 }
             }
@@ -791,8 +847,14 @@ impl UsbDeviceFile {
                         let mut ready = Vec::new();
                         {
                             let mut submitted = submitted_urbs.lock();
+                            let mut blocked_queues = BTreeSet::new();
                             let mut index = 0;
                             while index < submitted.len() {
+                                let queue_key = submitted[index].queue_key();
+                                if queue_key.is_some_and(|key| blocked_queues.contains(&key)) {
+                                    index += 1;
+                                    continue;
+                                }
                                 let result = match submitted[index].try_reclaim() {
                                     Ok(Some(completion)) => Some(Ok(completion)),
                                     Ok(None) => None,
@@ -804,6 +866,9 @@ impl UsbDeviceFile {
                                         result,
                                     ));
                                 } else {
+                                    if let Some(queue_key) = queue_key {
+                                        blocked_queues.insert(queue_key);
+                                    }
                                     index += 1;
                                 }
                             }
@@ -859,9 +924,17 @@ impl UsbDeviceFile {
                             let usb_activity_ready = manager.usb_activity_seq() != activity_seq
                                 || activity_listener.as_mut().poll(cx).is_ready();
                             let mut submitted = submitted_urbs.lock();
+                            let mut blocked_queues = BTreeSet::new();
                             let mut index = 0;
                             while index < submitted.len() {
                                 if submitted[index].is_deferred() {
+                                    index += 1;
+                                    continue;
+                                }
+                                let queue_key = submitted[index]
+                                    .queue_key()
+                                    .expect("live submitted URB has no transfer queue");
+                                if blocked_queues.contains(&queue_key) {
                                     index += 1;
                                     continue;
                                 }
@@ -872,7 +945,10 @@ impl UsbDeviceFile {
                                             .expect("submitted URB disappeared");
                                         return Poll::Ready(Some((submitted, result)));
                                     }
-                                    Poll::Pending => index += 1,
+                                    Poll::Pending => {
+                                        blocked_queues.insert(queue_key);
+                                        index += 1;
+                                    }
                                 }
                             }
                             if usb_activity_ready {
@@ -1406,18 +1482,34 @@ impl Drop for UsbDeviceFile {
     fn drop(&mut self) {
         self.urb_worker.close();
         let lease = self.lease.lock().take();
+        let mut submitted = self.drain_all_submitted_urbs();
         if let Some(lease) = lease.as_ref() {
             let interfaces = self
                 .claimed_interfaces
                 .lock()
-                .keys()
-                .copied()
+                .iter()
+                .map(|(&interface, &alternate)| (interface, alternate))
                 .collect::<Vec<_>>();
-            for interface in interfaces {
+            for (interface, alternate) in interfaces {
+                if alternate != 0 {
+                    let mut interface_urbs = Vec::new();
+                    let mut index = 0;
+                    while index < submitted.len() {
+                        if submitted[index].interface == Some(interface) {
+                            interface_urbs.push(submitted.swap_remove(index));
+                        } else {
+                            index += 1;
+                        }
+                    }
+                    if lease.claim_interface(interface, 0).is_ok() {
+                        submitted.extend(retire_quiesced_urbs(interface_urbs));
+                    } else {
+                        submitted.extend(interface_urbs);
+                    }
+                }
                 let _ = lease.release_interface(interface);
             }
         }
-        let submitted = self.drain_all_submitted_urbs();
         self.pending_urbs.lock().clear();
         if submitted.is_empty() {
             drop(lease);
@@ -1500,6 +1592,27 @@ fn cleanup_submitted_urbs(
     }
 
     submitted_urbs
+}
+
+fn retire_quiesced_urbs(submitted_urbs: Vec<SubmittedUrb>) -> Vec<SubmittedUrb> {
+    let mut remaining = Vec::new();
+    for submitted in submitted_urbs {
+        if submitted.is_deferred() {
+            continue;
+        }
+        match submitted.try_reclaim() {
+            Ok(None) => {}
+            Ok(Some(_)) | Err(_) => continue,
+        }
+        if let Err(err) = submitted.retire_after_quiesce() {
+            debug!(
+                "usbfs: failed to retire quiesced URB ptr={:#x}: {err:?}",
+                submitted.user_urb_ptr
+            );
+            remaining.push(submitted);
+        }
+    }
+    remaining
 }
 
 fn usbfs_should_log_urb() -> bool {

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -253,6 +253,7 @@ struct SubmittedUrb {
     user_urb_ptr: usize,
     transfer: SubmittedUrbTransfer,
     interface: Option<u8>,
+    discarded: bool,
     buffer: Vec<u8>,
     is_in: bool,
     data_offset: usize,
@@ -546,7 +547,7 @@ impl UsbDeviceFile {
         let mut submitted_urbs = self.submitted_urbs.lock();
         let index = submitted_urbs
             .iter()
-            .position(|submitted| submitted.user_urb_ptr == user_urb_ptr)
+            .position(|submitted| !submitted.discarded && submitted.user_urb_ptr == user_urb_ptr)
             .ok_or(AxError::InvalidInput)?;
         submitted_urbs.remove(index).ok_or(AxError::InvalidInput)
     }
@@ -805,6 +806,9 @@ impl UsbDeviceFile {
         submitted: SubmittedUrb,
         result: AxResult<TransferCompletion>,
     ) {
+        if submitted.discarded {
+            return;
+        }
         if submitted.log {
             match &result {
                 Ok(completion) => debug!(
@@ -918,6 +922,9 @@ impl UsbDeviceFile {
                         }
 
                         for (submitted, result) in ready {
+                            if submitted.discarded {
+                                continue;
+                            }
                             complete_urb(
                                 &pending_urbs,
                                 &poll_urbs,
@@ -1002,6 +1009,9 @@ impl UsbDeviceFile {
                         })
                         .await;
                         if let Some((submitted, result)) = completed {
+                            if submitted.discarded {
+                                continue;
+                            }
                             complete_urb(
                                 &pending_urbs,
                                 &poll_urbs,
@@ -1120,6 +1130,7 @@ impl UsbDeviceFile {
             user_urb_ptr: arg,
             transfer: SubmittedUrbTransfer::Live(transfer),
             interface: Some(claimed_endpoint.interface),
+            discarded: false,
             buffer,
             is_in,
             data_offset: 0,
@@ -1197,6 +1208,7 @@ impl UsbDeviceFile {
             user_urb_ptr: arg,
             transfer: SubmittedUrbTransfer::Live(transfer),
             interface: None,
+            discarded: false,
             buffer,
             is_in,
             data_offset: 8,
@@ -1248,6 +1260,7 @@ impl UsbDeviceFile {
                 user_urb_ptr: arg,
                 transfer: SubmittedUrbTransfer::Deferred(UsbfsQuirk::DeferredStatusInterrupt),
                 interface: Some(claimed_endpoint.interface),
+                discarded: false,
                 buffer: Vec::new(),
                 is_in: true,
                 data_offset: 0,
@@ -1301,14 +1314,12 @@ impl UsbDeviceFile {
     }
 
     fn submit_urb(&self, arg: usize) -> AxResult<usize> {
+        let _lifecycle_guard = self.lifecycle_lock.lock();
         self.collect_submitted_urbs(None);
         let urb = (arg as *const descriptor::UsbdevfsUrb).vm_read()?;
         let type_ = urb.type_;
         match type_ {
-            descriptor::USBDEVFS_URB_TYPE_CONTROL => {
-                let _lifecycle_guard = self.lifecycle_lock.lock();
-                self.submit_control_urb(arg)
-            }
+            descriptor::USBDEVFS_URB_TYPE_CONTROL => self.submit_control_urb(arg),
             descriptor::USBDEVFS_URB_TYPE_BULK => self.submit_bulk_urb(arg),
             descriptor::USBDEVFS_URB_TYPE_INTERRUPT => self.submit_interrupt_urb(arg),
             descriptor::USBDEVFS_URB_TYPE_ISO => self.submit_iso_urb(arg),
@@ -1350,8 +1361,10 @@ impl UsbDeviceFile {
     }
 
     fn discard_urb(&self, arg: usize) -> AxResult<usize> {
-        let submitted = self.drain_submitted_urb_by_ptr(arg)?;
+        let _lifecycle_guard = self.lifecycle_lock.lock();
+        let mut submitted = self.drain_submitted_urb_by_ptr(arg)?;
         submitted.cancel()?;
+        submitted.discarded = true;
 
         complete_urb(
             &self.pending_urbs,
@@ -1364,14 +1377,8 @@ impl UsbDeviceFile {
         );
 
         if !submitted.is_deferred() {
-            let lease = self.lease.lock().clone();
-            ax_task::spawn_with_name(
-                move || {
-                    let _lease = lease;
-                    cleanup_submitted_urbs(alloc::vec![submitted], None);
-                },
-                "usbfs-urb-discard".to_owned(),
-            );
+            self.submitted_urbs.lock().push_back(submitted);
+            self.ensure_urb_worker();
         }
         Ok(0)
     }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -6,7 +6,7 @@ mod tree;
 
 use alloc::{
     borrow::ToOwned,
-    collections::{BTreeSet, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     sync::Arc,
     vec::Vec,
 };
@@ -413,8 +413,12 @@ impl UsbDeviceFile {
                 self.submitted_urbs.lock().extend(remaining);
                 return Err(AxError::ResourceBusy);
             }
-            self.claimed_interfaces.lock().insert(interface, alternate);
-            return Ok(0);
+            return commit_userspace_uvc_claim(
+                &self.claimed_interfaces,
+                interface,
+                alternate,
+                |interface| self.release_endpoint_handles_for_interface(interface),
+            );
         }
         let retire_after_quiesce = submitted
             .iter()
@@ -1384,6 +1388,17 @@ impl UsbDeviceFile {
     }
 }
 
+fn commit_userspace_uvc_claim(
+    claimed_interfaces: &Mutex<BTreeMap<u8, u8>>,
+    interface: u8,
+    alternate: u8,
+    release_endpoint_handles: impl FnOnce(u8) -> AxResult<()>,
+) -> AxResult<usize> {
+    release_endpoint_handles(interface)?;
+    claimed_interfaces.lock().insert(interface, alternate);
+    Ok(0)
+}
+
 impl FileLike for UsbDeviceFile {
     fn read(&self, dst: &mut IoDst) -> AxResult<usize> {
         self.base.read(dst)
@@ -1914,4 +1929,29 @@ fn write_iso_packet_descs(
         vm_write_slice(ptr, descs)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uvc_claim_releases_live_endpoints_before_updating_alternate() {
+        let interface = 1;
+        let claimed_interfaces = Mutex::new(BTreeMap::from([(interface, 2)]));
+        let live_endpoint_handles = Mutex::new(BTreeMap::from([(0x81, interface), (0x82, 3)]));
+
+        let result =
+            commit_userspace_uvc_claim(&claimed_interfaces, interface, 0, |claimed_interface| {
+                assert_eq!(claimed_interfaces.lock().get(&interface), Some(&2));
+                live_endpoint_handles
+                    .lock()
+                    .retain(|_, owner| *owner != claimed_interface);
+                Ok(())
+            });
+
+        assert_eq!(result, Ok(0));
+        assert_eq!(*live_endpoint_handles.lock(), BTreeMap::from([(0x82, 3)]));
+        assert_eq!(claimed_interfaces.lock().get(&interface), Some(&0));
+    }
 }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -1954,4 +1954,17 @@ mod tests {
         assert_eq!(*live_endpoint_handles.lock(), BTreeMap::from([(0x82, 3)]));
         assert_eq!(claimed_interfaces.lock().get(&interface), Some(&0));
     }
+
+    #[test]
+    fn uvc_claim_keeps_alternate_when_endpoint_cleanup_is_busy() {
+        let interface = 1;
+        let claimed_interfaces = Mutex::new(BTreeMap::from([(interface, 2)]));
+
+        let result = commit_userspace_uvc_claim(&claimed_interfaces, interface, 0, |_| {
+            Err(AxError::ResourceBusy)
+        });
+
+        assert_eq!(result, Err(AxError::ResourceBusy));
+        assert_eq!(claimed_interfaces.lock().get(&interface), Some(&2));
+    }
 }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -438,16 +438,27 @@ impl UsbDeviceFile {
             self.submitted_urbs.lock().extend(submitted);
             return Err(err);
         }
-        self.claimed_interfaces.lock().insert(interface, alternate);
         let remaining = if retire_after_quiesce {
             retire_quiesced_urbs(submitted)
         } else {
             Vec::new()
         };
         if !remaining.is_empty() {
+            if let Some(previous_alternate) =
+                self.claimed_interfaces.lock().get(&interface).copied()
+                && let Err(err) = self
+                    .with_live_lease(|lease| lease.claim_interface(interface, previous_alternate))
+            {
+                warn!(
+                    "usbfs: failed to restore interface {} alt {} after URB retirement failure: \
+                     {err:?}",
+                    interface, previous_alternate
+                );
+            }
             self.submitted_urbs.lock().extend(remaining);
             return Err(AxError::ResourceBusy);
         }
+        self.claimed_interfaces.lock().insert(interface, alternate);
         Ok(0)
     }
 
@@ -1929,42 +1940,4 @@ fn write_iso_packet_descs(
         vm_write_slice(ptr, descs)?;
     }
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn uvc_claim_releases_live_endpoints_before_updating_alternate() {
-        let interface = 1;
-        let claimed_interfaces = Mutex::new(BTreeMap::from([(interface, 2)]));
-        let live_endpoint_handles = Mutex::new(BTreeMap::from([(0x81, interface), (0x82, 3)]));
-
-        let result =
-            commit_userspace_uvc_claim(&claimed_interfaces, interface, 0, |claimed_interface| {
-                assert_eq!(claimed_interfaces.lock().get(&interface), Some(&2));
-                live_endpoint_handles
-                    .lock()
-                    .retain(|_, owner| *owner != claimed_interface);
-                Ok(())
-            });
-
-        assert_eq!(result, Ok(0));
-        assert_eq!(*live_endpoint_handles.lock(), BTreeMap::from([(0x82, 3)]));
-        assert_eq!(claimed_interfaces.lock().get(&interface), Some(&0));
-    }
-
-    #[test]
-    fn uvc_claim_keeps_alternate_when_endpoint_cleanup_is_busy() {
-        let interface = 1;
-        let claimed_interfaces = Mutex::new(BTreeMap::from([(interface, 2)]));
-
-        let result = commit_userspace_uvc_claim(&claimed_interfaces, interface, 0, |_| {
-            Err(AxError::ResourceBusy)
-        });
-
-        assert_eq!(result, Err(AxError::ResourceBusy));
-        assert_eq!(claimed_interfaces.lock().get(&interface), Some(&2));
-    }
 }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -264,6 +264,8 @@ struct SubmittedUrb {
 enum SubmittedUrbTransfer {
     Live(manager::SubmittedTransfer),
     Deferred(UsbfsQuirk),
+    #[cfg(test)]
+    Test(tests::TestSubmittedTransfer),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -277,6 +279,8 @@ impl SubmittedUrb {
         match &self.transfer {
             SubmittedUrbTransfer::Live(transfer) => Some(transfer.queue_key()),
             SubmittedUrbTransfer::Deferred(_) => None,
+            #[cfg(test)]
+            SubmittedUrbTransfer::Test(_) => None,
         }
     }
 
@@ -284,6 +288,8 @@ impl SubmittedUrb {
         match &self.transfer {
             SubmittedUrbTransfer::Live(transfer) => transfer.try_reclaim(),
             SubmittedUrbTransfer::Deferred(_) => Ok(None),
+            #[cfg(test)]
+            SubmittedUrbTransfer::Test(transfer) => transfer.try_reclaim(),
         }
     }
 
@@ -291,6 +297,8 @@ impl SubmittedUrb {
         match &self.transfer {
             SubmittedUrbTransfer::Live(transfer) => transfer.poll_reclaim(cx),
             SubmittedUrbTransfer::Deferred(_) => Poll::Pending,
+            #[cfg(test)]
+            SubmittedUrbTransfer::Test(_) => Poll::Pending,
         }
     }
 
@@ -298,6 +306,8 @@ impl SubmittedUrb {
         match &self.transfer {
             SubmittedUrbTransfer::Live(transfer) => transfer.cancel(),
             SubmittedUrbTransfer::Deferred(_) => Ok(()),
+            #[cfg(test)]
+            SubmittedUrbTransfer::Test(_) => Ok(()),
         }
     }
 
@@ -305,6 +315,8 @@ impl SubmittedUrb {
         match &self.transfer {
             SubmittedUrbTransfer::Live(transfer) => transfer.retire_after_quiesce(),
             SubmittedUrbTransfer::Deferred(_) => Ok(()),
+            #[cfg(test)]
+            SubmittedUrbTransfer::Test(transfer) => transfer.retire_after_quiesce(),
         }
     }
 
@@ -312,6 +324,8 @@ impl SubmittedUrb {
         match &self.transfer {
             SubmittedUrbTransfer::Live(transfer) => transfer.supports_retire_after_quiesce(),
             SubmittedUrbTransfer::Deferred(_) => true,
+            #[cfg(test)]
+            SubmittedUrbTransfer::Test(_) => true,
         }
     }
 
@@ -319,6 +333,8 @@ impl SubmittedUrb {
         match &self.transfer {
             SubmittedUrbTransfer::Live(_) => None,
             SubmittedUrbTransfer::Deferred(quirk) => Some(*quirk),
+            #[cfg(test)]
+            SubmittedUrbTransfer::Test(_) => None,
         }
     }
 
@@ -433,31 +449,23 @@ impl UsbDeviceFile {
             }
             Vec::new()
         };
-        if let Err(err) = self.with_live_lease(|lease| lease.claim_interface(interface, alternate))
-        {
-            self.submitted_urbs.lock().extend(submitted);
-            return Err(err);
+        if retire_after_quiesce {
+            let previous_alternate = self.claimed_interfaces.lock().get(&interface).copied();
+            return switch_alternate_and_retire_quiesced_urbs(
+                submitted,
+                interface,
+                alternate,
+                previous_alternate,
+                |interface, alternate| {
+                    self.with_live_lease(|lease| lease.claim_interface(interface, alternate))
+                },
+                |remaining| self.submitted_urbs.lock().extend(remaining),
+                |interface, alternate| {
+                    self.claimed_interfaces.lock().insert(interface, alternate);
+                },
+            );
         }
-        let remaining = if retire_after_quiesce {
-            retire_quiesced_urbs(submitted)
-        } else {
-            Vec::new()
-        };
-        if !remaining.is_empty() {
-            if let Some(previous_alternate) =
-                self.claimed_interfaces.lock().get(&interface).copied()
-                && let Err(err) = self
-                    .with_live_lease(|lease| lease.claim_interface(interface, previous_alternate))
-            {
-                warn!(
-                    "usbfs: failed to restore interface {} alt {} after URB retirement failure: \
-                     {err:?}",
-                    interface, previous_alternate
-                );
-            }
-            self.submitted_urbs.lock().extend(remaining);
-            return Err(AxError::ResourceBusy);
-        }
+        self.with_live_lease(|lease| lease.claim_interface(interface, alternate))?;
         self.claimed_interfaces.lock().insert(interface, alternate);
         Ok(0)
     }
@@ -1631,6 +1639,37 @@ fn completed_urb_from_result(
     }
 }
 
+fn switch_alternate_and_retire_quiesced_urbs(
+    submitted: Vec<SubmittedUrb>,
+    interface: u8,
+    alternate: u8,
+    previous_alternate: Option<u8>,
+    mut switch_alternate: impl FnMut(u8, u8) -> AxResult<()>,
+    mut requeue: impl FnMut(Vec<SubmittedUrb>),
+    mut commit_alternate: impl FnMut(u8, u8),
+) -> AxResult<usize> {
+    if let Err(err) = switch_alternate(interface, alternate) {
+        requeue(submitted);
+        return Err(err);
+    }
+    let remaining = retire_quiesced_urbs(submitted);
+    if !remaining.is_empty() {
+        if let Some(previous_alternate) = previous_alternate
+            && let Err(err) = switch_alternate(interface, previous_alternate)
+        {
+            warn!(
+                "usbfs: failed to restore interface {} alt {} after URB retirement failure: \
+                 {err:?}",
+                interface, previous_alternate
+            );
+        }
+        requeue(remaining);
+        return Err(AxError::ResourceBusy);
+    }
+    commit_alternate(interface, alternate);
+    Ok(0)
+}
+
 fn cleanup_submitted_urbs(
     mut submitted_urbs: Vec<SubmittedUrb>,
     timeout: Option<Duration>,
@@ -1940,4 +1979,150 @@ fn write_iso_packet_descs(
         vm_write_slice(ptr, descs)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::{sync::Arc, vec};
+    use core::cell::RefCell;
+
+    use crab_usb::usb_if::endpoint::{RequestId, TransferStatus};
+
+    use self::std::sync::Mutex as TestMutex;
+    use super::*;
+
+    struct TestXhciState {
+        alternate: u8,
+        alternate_history: Vec<u8>,
+        inflight_requests: usize,
+        completion_pending: bool,
+        completion_reclaims: usize,
+        fail_next_retire: bool,
+    }
+
+    struct TestUsbfsXhciAdapter(Arc<TestMutex<TestXhciState>>);
+
+    impl TestUsbfsXhciAdapter {
+        fn new(alternate: u8) -> Self {
+            Self(Arc::new(TestMutex::new(TestXhciState {
+                alternate,
+                alternate_history: Vec::new(),
+                inflight_requests: 0,
+                completion_pending: false,
+                completion_reclaims: 0,
+                fail_next_retire: true,
+            })))
+        }
+
+        fn submit_async_urb(&self, interface: u8) -> SubmittedUrb {
+            self.0.lock().unwrap().inflight_requests += 1;
+            SubmittedUrb {
+                user_urb_ptr: 1,
+                transfer: SubmittedUrbTransfer::Test(TestSubmittedTransfer(self.0.clone())),
+                interface: Some(interface),
+                discarded: false,
+                buffer: Vec::new(),
+                is_in: false,
+                data_offset: 0,
+                packet_lengths: Vec::new(),
+                log: false,
+            }
+        }
+
+        fn switch_alternate(&self, alternate: u8) -> AxResult<()> {
+            let mut state = self.0.lock().unwrap();
+            state.alternate = alternate;
+            state.alternate_history.push(alternate);
+            Ok(())
+        }
+
+        fn complete_request(&self) {
+            let mut state = self.0.lock().unwrap();
+            assert_eq!(state.inflight_requests, 1);
+            assert!(!state.completion_pending);
+            state.completion_pending = true;
+        }
+    }
+
+    pub(super) struct TestSubmittedTransfer(Arc<TestMutex<TestXhciState>>);
+
+    impl TestSubmittedTransfer {
+        pub(super) fn try_reclaim(&self) -> AxResult<Option<TransferCompletion>> {
+            let mut state = self.0.lock().unwrap();
+            if !state.completion_pending {
+                return Ok(None);
+            }
+            state.completion_pending = false;
+            state.inflight_requests -= 1;
+            state.completion_reclaims += 1;
+            Ok(Some(TransferCompletion {
+                request_id: RequestId::new(1),
+                status: TransferStatus::Completed,
+                actual_length: 0,
+                iso_packets: Vec::new(),
+            }))
+        }
+
+        pub(super) fn retire_after_quiesce(&self) -> AxResult<()> {
+            let mut state = self.0.lock().unwrap();
+            if core::mem::take(&mut state.fail_next_retire) {
+                return Err(AxError::ResourceBusy);
+            }
+            state.inflight_requests -= 1;
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn retire_failure_restores_alternate_and_completes_requeued_urb_once() {
+        const INTERFACE: u8 = 1;
+        const PREVIOUS_ALTERNATE: u8 = 2;
+        const REQUESTED_ALTERNATE: u8 = 0;
+
+        let adapter = TestUsbfsXhciAdapter::new(PREVIOUS_ALTERNATE);
+        let submitted = vec![adapter.submit_async_urb(INTERFACE)];
+        let requeued = RefCell::new(Vec::new());
+        let claimed = RefCell::new(BTreeMap::from([(INTERFACE, PREVIOUS_ALTERNATE)]));
+        let previous_alternate = claimed.borrow().get(&INTERFACE).copied();
+
+        let result = switch_alternate_and_retire_quiesced_urbs(
+            submitted,
+            INTERFACE,
+            REQUESTED_ALTERNATE,
+            previous_alternate,
+            |_, alternate| adapter.switch_alternate(alternate),
+            |remaining| requeued.borrow_mut().extend(remaining),
+            |interface, alternate| {
+                claimed.borrow_mut().insert(interface, alternate);
+            },
+        );
+
+        assert_eq!(result, Err(AxError::ResourceBusy));
+        assert_eq!(
+            claimed.borrow().get(&INTERFACE).copied(),
+            Some(PREVIOUS_ALTERNATE)
+        );
+        {
+            let state = adapter.0.lock().unwrap();
+            assert_eq!(state.alternate, PREVIOUS_ALTERNATE);
+            assert_eq!(
+                state.alternate_history,
+                vec![REQUESTED_ALTERNATE, PREVIOUS_ALTERNATE]
+            );
+            assert_eq!(state.inflight_requests, 1);
+        }
+        assert_eq!(requeued.borrow().len(), 1);
+
+        adapter.complete_request();
+        let submitted = requeued.borrow_mut().pop().unwrap();
+        assert!(submitted.try_reclaim().unwrap().is_some());
+        assert!(submitted.try_reclaim().unwrap().is_none());
+        let state = adapter.0.lock().unwrap();
+        assert_eq!(state.inflight_requests, 0);
+        assert!(!state.completion_pending);
+        assert_eq!(state.completion_reclaims, 1);
+        assert!(requeued.borrow().is_empty());
+    }
 }

--- a/test-suit/starryos/qemu/system/bugfix-usbfs-alternate-urb-lifecycle/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-usbfs-alternate-urb-lifecycle/CMakeLists.txt
@@ -1,0 +1,30 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(usbfs-alternate-urb-lifecycle C)
+include(${CMAKE_CURRENT_LIST_DIR}/../common/starry_arch_filter.cmake)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH OFF)
+
+if(CMAKE_C_COMPILER_TARGET MATCHES "(x86_64|aarch64|riscv64)")
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(LIBUSB REQUIRED IMPORTED_TARGET libusb-1.0)
+
+    add_executable(usbfs-alternate-urb-lifecycle src/main.c)
+    target_link_libraries(usbfs-alternate-urb-lifecycle PRIVATE PkgConfig::LIBUSB)
+else()
+    starry_arch_filtered_executable(
+        usbfs-alternate-urb-lifecycle
+        "(x86_64|aarch64|riscv64)"
+        "usbfs alternate URB lifecycle test skipped without QEMU xHCI"
+        src/main.c
+    )
+endif()
+
+target_compile_options(usbfs-alternate-urb-lifecycle PRIVATE -Wall -Wextra -Werror)
+if(CMAKE_C_COMPILER_TARGET MATCHES "riscv64")
+    target_compile_options(usbfs-alternate-urb-lifecycle PRIVATE -march=rv64gc -mabi=lp64d)
+endif()
+install(TARGETS usbfs-alternate-urb-lifecycle RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-usbfs-alternate-urb-lifecycle/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-usbfs-alternate-urb-lifecycle/src/main.c
@@ -1,0 +1,373 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <libusb.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#define USB_AUDIO_CLASS 0x01
+#define USB_AUDIO_SUBCLASS_STREAMING 0x02
+/* QEMU usb-audio is full-speed, so 2048 ISO packets span more than usbfs's
+ * one-second cancellation deadline and remain in flight at SETINTERFACE. */
+#define QUIESCED_URB_PACKETS 2048
+#define BARRIER_URB_PACKETS 8
+
+#define USBFS_URB_TYPE_ISO 0
+#define USBFS_URB_ISO_ASAP 0x02
+
+struct usbfs_setinterface {
+    unsigned int interface;
+    unsigned int altsetting;
+};
+
+struct usbfs_iso_packet_desc {
+    unsigned int length;
+    unsigned int actual_length;
+    unsigned int status;
+};
+
+struct usbfs_urb {
+    unsigned char type;
+    unsigned char endpoint;
+    int status;
+    unsigned int flags;
+    void *buffer;
+    int buffer_length;
+    int actual_length;
+    int start_frame;
+    int number_of_packets;
+    int error_count;
+    unsigned int signr;
+    void *usercontext;
+    struct usbfs_iso_packet_desc iso_frame_desc[];
+};
+
+#define USBFS_SETINTERFACE _IOR('U', 4, struct usbfs_setinterface)
+#define USBFS_SUBMITURB _IOR('U', 10, struct usbfs_urb)
+#define USBFS_REAPURB _IOW('U', 12, void *)
+#define USBFS_REAPURBNDELAY _IOW('U', 13, void *)
+#define USBFS_CLAIMINTERFACE _IOR('U', 15, unsigned int)
+#define USBFS_RELEASEINTERFACE _IOR('U', 16, unsigned int)
+
+typedef struct audio_endpoint {
+    uint8_t bus_number;
+    uint8_t device_address;
+    uint8_t configuration;
+    uint8_t interface_number;
+    uint8_t alternate;
+    uint8_t endpoint;
+    int packet_size;
+} audio_endpoint_t;
+
+typedef struct iso_urb {
+    struct usbfs_urb *urb;
+    unsigned char *buffer;
+} iso_urb_t;
+
+static int failf(const char *format, ...) {
+    va_list args;
+    va_start(args, format);
+    fputs("usbfs alternate URB lifecycle failed: ", stdout);
+    vprintf(format, args);
+    fputc('\n', stdout);
+    va_end(args);
+    return 1;
+}
+
+static bool is_audio_iso_out(
+    libusb_device *device,
+    const struct libusb_interface_descriptor *interface,
+    uint8_t *endpoint,
+    int *packet_size
+) {
+    if (interface->bInterfaceClass != USB_AUDIO_CLASS ||
+        interface->bInterfaceSubClass != USB_AUDIO_SUBCLASS_STREAMING ||
+        interface->bAlternateSetting == 0) {
+        return false;
+    }
+
+    for (int index = 0; index < interface->bNumEndpoints; index++) {
+        const struct libusb_endpoint_descriptor *descriptor = &interface->endpoint[index];
+        if ((descriptor->bmAttributes & LIBUSB_TRANSFER_TYPE_MASK) !=
+                LIBUSB_TRANSFER_TYPE_ISOCHRONOUS ||
+            (descriptor->bEndpointAddress & LIBUSB_ENDPOINT_DIR_MASK) != LIBUSB_ENDPOINT_OUT) {
+            continue;
+        }
+        int size = libusb_get_max_iso_packet_size(device, descriptor->bEndpointAddress);
+        if (size > 0) {
+            *endpoint = descriptor->bEndpointAddress;
+            *packet_size = size;
+            return true;
+        }
+    }
+    return false;
+}
+
+static int find_audio_endpoint(libusb_context *context, audio_endpoint_t *candidate) {
+    libusb_device **devices = NULL;
+    ssize_t count = libusb_get_device_list(context, &devices);
+    if (count < 0) {
+        return failf("libusb_get_device_list: %s", libusb_error_name((int)count));
+    }
+
+    memset(candidate, 0, sizeof(*candidate));
+    for (ssize_t device_index = 0; device_index < count && candidate->packet_size == 0;
+         device_index++) {
+        libusb_device *device = devices[device_index];
+        struct libusb_device_descriptor device_descriptor;
+        if (libusb_get_device_descriptor(device, &device_descriptor) != 0) {
+            continue;
+        }
+        for (uint8_t config_index = 0;
+             config_index < device_descriptor.bNumConfigurations && candidate->packet_size == 0;
+             config_index++) {
+            struct libusb_config_descriptor *configuration = NULL;
+            if (libusb_get_config_descriptor(device, config_index, &configuration) != 0 ||
+                configuration == NULL) {
+                continue;
+            }
+            for (int interface_index = 0;
+                 interface_index < configuration->bNumInterfaces && candidate->packet_size == 0;
+                 interface_index++) {
+                const struct libusb_interface *interface =
+                    &configuration->interface[interface_index];
+                for (int alternate_index = 0; alternate_index < interface->num_altsetting;
+                     alternate_index++) {
+                    const struct libusb_interface_descriptor *alternate =
+                        &interface->altsetting[alternate_index];
+                    uint8_t endpoint = 0;
+                    int packet_size = 0;
+                    if (!is_audio_iso_out(device, alternate, &endpoint, &packet_size)) {
+                        continue;
+                    }
+                    candidate->bus_number = libusb_get_bus_number(device);
+                    candidate->device_address = libusb_get_device_address(device);
+                    candidate->configuration = configuration->bConfigurationValue;
+                    candidate->interface_number = alternate->bInterfaceNumber;
+                    candidate->alternate = alternate->bAlternateSetting;
+                    candidate->endpoint = endpoint;
+                    candidate->packet_size = packet_size;
+                    break;
+                }
+            }
+            libusb_free_config_descriptor(configuration);
+        }
+    }
+    libusb_free_device_list(devices, 1);
+
+    if (candidate->packet_size == 0) {
+        return failf("QEMU USB audio ISO OUT endpoint not found");
+    }
+    return 0;
+}
+
+static int ensure_configuration(libusb_context *context, const audio_endpoint_t *endpoint) {
+    libusb_device_handle *handle = NULL;
+    libusb_device **devices = NULL;
+    ssize_t count = libusb_get_device_list(context, &devices);
+    for (ssize_t index = 0; index < count; index++) {
+        if (libusb_get_bus_number(devices[index]) == endpoint->bus_number &&
+            libusb_get_device_address(devices[index]) == endpoint->device_address &&
+            libusb_open(devices[index], &handle) == 0) {
+            break;
+        }
+    }
+    if (devices != NULL) {
+        libusb_free_device_list(devices, 1);
+    }
+    if (handle == NULL) {
+        return failf("failed to open QEMU USB audio device");
+    }
+
+    int active_configuration = 0;
+    int result = libusb_get_configuration(handle, &active_configuration);
+    if (result == 0 && active_configuration != endpoint->configuration) {
+        result = libusb_set_configuration(handle, endpoint->configuration);
+    }
+    libusb_close(handle);
+    if (result != 0) {
+        return failf("set configuration %u: %s", endpoint->configuration, libusb_error_name(result));
+    }
+    return 0;
+}
+
+static iso_urb_t allocate_iso_urb(const audio_endpoint_t *endpoint, int packet_count) {
+    iso_urb_t allocation = {0};
+    size_t urb_size =
+        sizeof(struct usbfs_urb) + (size_t)packet_count * sizeof(struct usbfs_iso_packet_desc);
+    allocation.urb = calloc(1, urb_size);
+    allocation.buffer = calloc((size_t)packet_count, (size_t)endpoint->packet_size);
+    if (allocation.urb == NULL || allocation.buffer == NULL) {
+        free(allocation.urb);
+        free(allocation.buffer);
+        return (iso_urb_t){0};
+    }
+
+    allocation.urb->type = USBFS_URB_TYPE_ISO;
+    allocation.urb->endpoint = endpoint->endpoint;
+    allocation.urb->flags = USBFS_URB_ISO_ASAP;
+    allocation.urb->buffer = allocation.buffer;
+    allocation.urb->buffer_length = packet_count * endpoint->packet_size;
+    allocation.urb->number_of_packets = packet_count;
+    for (int index = 0; index < packet_count; index++) {
+        allocation.urb->iso_frame_desc[index].length = (unsigned int)endpoint->packet_size;
+    }
+    return allocation;
+}
+
+static void free_iso_urb(iso_urb_t *allocation) {
+    free(allocation->urb);
+    free(allocation->buffer);
+    *allocation = (iso_urb_t){0};
+}
+
+static int set_alternate(int fd, const audio_endpoint_t *endpoint, uint8_t alternate) {
+    struct usbfs_setinterface setting = {
+        .interface = endpoint->interface_number,
+        .altsetting = alternate,
+    };
+    if (ioctl(fd, USBFS_SETINTERFACE, &setting) < 0) {
+        return failf(
+            "SETINTERFACE if=%u alt=%u: errno=%d (%s)",
+            endpoint->interface_number,
+            alternate,
+            errno,
+            strerror(errno)
+        );
+    }
+    return 0;
+}
+
+static int expect_no_completion(int fd, const char *stage) {
+    void *completed = NULL;
+    if (ioctl(fd, USBFS_REAPURBNDELAY, &completed) == 0) {
+        return failf("%s unexpectedly completed URB %p", stage, completed);
+    }
+    if (errno != EAGAIN) {
+        return failf("%s REAPURBNDELAY: errno=%d (%s)", stage, errno, strerror(errno));
+    }
+    return 0;
+}
+
+static int run_lifecycle_test(const audio_endpoint_t *endpoint) {
+    char path[32];
+    snprintf(path, sizeof(path), "/dev/bus/usb/%03u/%03u", endpoint->bus_number,
+             endpoint->device_address);
+    int fd = open(path, O_RDWR | O_CLOEXEC);
+    if (fd < 0) {
+        return failf("open %s: errno=%d (%s)", path, errno, strerror(errno));
+    }
+
+    int interface = endpoint->interface_number;
+    int result = 1;
+    iso_urb_t quiesced = {0};
+    iso_urb_t barrier = {0};
+    bool claimed = false;
+
+    if (ioctl(fd, USBFS_CLAIMINTERFACE, &interface) < 0) {
+        failf("CLAIMINTERFACE %d: errno=%d (%s)", interface, errno, strerror(errno));
+        goto cleanup;
+    }
+    claimed = true;
+    if (set_alternate(fd, endpoint, endpoint->alternate) != 0) {
+        goto cleanup;
+    }
+
+    quiesced = allocate_iso_urb(endpoint, QUIESCED_URB_PACKETS);
+    if (quiesced.urb == NULL) {
+        failf("allocate quiesced URB");
+        goto cleanup;
+    }
+    if (ioctl(fd, USBFS_SUBMITURB, quiesced.urb) < 0) {
+        failf("SUBMITURB quiesced: errno=%d (%s)", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    if (set_alternate(fd, endpoint, 0) != 0) {
+        goto cleanup;
+    }
+    if (expect_no_completion(fd, "after endpoint quiesce") != 0) {
+        goto cleanup;
+    }
+
+    if (set_alternate(fd, endpoint, endpoint->alternate) != 0) {
+        goto cleanup;
+    }
+    /* Completion of this request proves that xHCI has accepted work on the
+     * replacement endpoint. It is an ordering barrier, not a grace period. */
+    barrier = allocate_iso_urb(endpoint, BARRIER_URB_PACKETS);
+    if (barrier.urb == NULL) {
+        failf("allocate barrier URB");
+        goto cleanup;
+    }
+    if (ioctl(fd, USBFS_SUBMITURB, barrier.urb) < 0) {
+        failf("SUBMITURB barrier: errno=%d (%s)", errno, strerror(errno));
+        goto cleanup;
+    }
+
+    void *completed = NULL;
+    if (ioctl(fd, USBFS_REAPURB, &completed) < 0) {
+        failf("REAPURB barrier: errno=%d (%s)", errno, strerror(errno));
+        goto cleanup;
+    }
+    if (completed != barrier.urb) {
+        failf("expected barrier URB %p, got stale completion %p", (void *)barrier.urb, completed);
+        goto cleanup;
+    }
+    if (expect_no_completion(fd, "after barrier completion") != 0) {
+        goto cleanup;
+    }
+
+    puts("usbfs alternate URB lifecycle passed: quiesced request retired once, no stale completion");
+    result = 0;
+
+cleanup:
+    if (claimed) {
+        (void)set_alternate(fd, endpoint, 0);
+        (void)ioctl(fd, USBFS_RELEASEINTERFACE, &interface);
+    }
+    close(fd);
+    free_iso_urb(&barrier);
+    free_iso_urb(&quiesced);
+    return result;
+}
+
+int main(void) {
+#if defined(__loongarch__) || defined(__loongarch64)
+    puts("usbfs alternate URB lifecycle test skipped without QEMU xHCI");
+    return 0;
+#endif
+
+    libusb_context *context = NULL;
+    int result = libusb_init(&context);
+    if (result != 0) {
+        return failf("libusb_init: %s", libusb_error_name(result));
+    }
+
+    audio_endpoint_t endpoint;
+    result = find_audio_endpoint(context, &endpoint);
+    if (result == 0) {
+        result = ensure_configuration(context, &endpoint);
+    }
+    if (result == 0) {
+        printf(
+            "usbfs lifecycle device: bus=%u device=%u if=%u alt=%u ep=%02x packet=%d\n",
+            endpoint.bus_number,
+            endpoint.device_address,
+            endpoint.interface_number,
+            endpoint.alternate,
+            endpoint.endpoint,
+            endpoint.packet_size
+        );
+        result = run_lifecycle_test(&endpoint);
+    }
+    libusb_exit(context);
+    return result;
+}


### PR DESCRIPTION
## 问题
- usbfs worker 在每次 USB 活动后遍历所有已提交 URB，包括同一硬件队列中排在未完成请求之后的 URB。xHCI readiness probe 还会复制 isochronous packet metadata。深队列下，这会产生大量无效 reclaim 和 waker 注册，使已完成画面持续积压。导致摄像头画面延迟
- 异步 URB 在 `DISCARDURB`、接口 alternate setting 切换、接口释放和文件关闭时缺少完整的清理流程，可能导致 endpoint 仍被控制器引用、旧 endpoint handle 残留或 URB 被重复完成

## 改动
- 每次只探测每个 endpoint 或 control queue 最早的 pending transfer，并允许不同硬件队列独立推进
- 不再复制完整 isochronous packet metadata，只记录请求类型
- 串行化 URB 提交、丢弃和接口生命周期操作，被丢弃的 URB 由统一 worker 完成底层清理
- 接口切换时先确保旧 endpoint 停止，再清除不会继续产生 completion 的 xHCI 请求，其他控制器则在切换前完成取消和回收
- 同步清理旧 endpoint handles，避免残留引用和重复完成
- 修正 xHCI endpoint interval 编码、设备描述符短读及非对齐读取
- streaming DMA 仅在地址和长度均满足 cache-line 对齐时直映射，否则使用 bounce buffer

## 效果
实测摄像头画面更新延迟从原来的 300-450 ms 转变为 24-37 ms