### PR TITLE
fix(axvm): preserve PSCI in generated guest FDT

### DIFF
--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -85,6 +85,13 @@ fn should_keep_generated_node(
         return true;
     }
 
+    if node
+        .compatibles()
+        .any(|compatible| matches!(compatible, "arm,psci" | "arm,psci-0.2" | "arm,psci-1.0"))
+    {
+        return true;
+    }
+
     passthrough_device_names
         .iter()
         .any(|device_path| device_path == node_path)
@@ -356,7 +363,11 @@ pub(crate) fn patch_guest_fdt_for_runtime(
     for serial in additional_serials {
         super::serial::install_additional_serial(&mut tree, *serial)?;
     }
-    Ok(tree.finish())
+    let bytes = tree.finish();
+    Fdt::from_bytes(&bytes).map_err(|error| {
+        ax_err_type!(InvalidData, std::format!("invalid patched FDT: {error:?}"))
+    })?;
+    Ok(bytes)
 }
 
 pub(crate) fn calculate_dtb_load_addr(vm: AxVMRef, fdt_size: usize) -> AxVmResult<GuestPhysAddr> {
@@ -550,6 +561,27 @@ mod tests {
         assert!(reparsed.get_by_path_id("/cpus/cpu@100").is_some());
         assert!(reparsed.get_by_path_id("/cpus/cpu@0").is_none());
         assert!(reparsed.get_by_path_id("/cpus/cpu@101").is_none());
+    }
+
+    #[test]
+    fn generated_fdt_keeps_psci_firmware_node() {
+        let mut fdt = test_fdt("cpu@0=0");
+        let psci = fdt.add_node(fdt.root_id(), Node::new("psci"));
+        let mut compatible = Property::new("compatible", std::vec![]);
+        compatible.set_string("arm,psci-0.2");
+        fdt.node_mut(psci).unwrap().set_property(compatible);
+
+        let cfg = GuestConfig {
+            base: axvmconfig::VMBaseConfig {
+                phys_cpu_ids: Some(std::vec![0]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let dtb = super::create_guest_fdt(&fdt, &[], &cfg).unwrap();
+        let reparsed = Fdt::from_bytes(&dtb).unwrap();
+
+        assert!(reparsed.get_by_path_id("/psci").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## 问题

AxVM 根据宿主设备树动态生成 guest FDT 时，现有过滤规则会删除 PSCI 固件节点。依赖 PSCI 的 ArceOS guest 因而可能在平台初始化阶段无法取得 CPU 电源管理方法。

## 修改

- 生成 guest FDT 时保留兼容 `arm,psci`、`arm,psci-0.2` 或 `arm,psci-1.0` 的节点。
- runtime patch 完成序列化后重新解析输出，避免将无效 FDT 交给 guest。
- 增加回归测试，验证未作为直通设备配置的 PSCI 节点仍会出现在生成的 guest FDT 中。

## 实现逻辑

PSCI 描述的是 guest 启动所必需的固件接口，不属于普通设备直通范围，因此应作为生成 FDT 的基础节点显式保留。序列化后的重新解析位于最终输出边界，可在加载到 guest 内存前发现结构错误。

Reviewer 指出的 DMA polling capability 没有生产消费者的问题已通过拆分处理：本 PR 已移除该 API；DMA polling capability 与真实的 AxVisor virtio-net consumer、设备注册及端到端测试一并放入 #1927。

## 验证

已通过：

```bash
cargo fmt --all --check
cargo xtask clippy --package axvm
```

尝试执行 `cargo test -p axvm --lib boot::fdt`，但 host 测试链接阶段缺少 AxVM 运行环境提供的 `STACK_SIZE`、`PAGE_SIZE` 和 per-CPU linker symbols，因此未将该命令列为通过项。