### PR TITLE
fix(ci): unify ax-errno resolution before release

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -11,6 +11,7 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTUP_TOOLCHAIN: stable
 
 concurrency:
   group: release-plz-${{ github.ref }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
 name = "ax-alloc"
 version = "0.8.15"
 dependencies = [
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-kernel-guard",
  "ax-kspin",
  "ax-memory-addr",
@@ -689,7 +689,7 @@ version = "0.7.7"
 dependencies = [
  "ax-alloc",
  "ax-display",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-fs-ng",
  "ax-hal",
  "ax-io",
@@ -797,7 +797,7 @@ dependencies = [
  "ax-alloc",
  "ax-arm-pl031",
  "ax-crate-interface",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-kernel-guard",
  "ax-kspin",
  "axklib",
@@ -856,17 +856,6 @@ dependencies = [
 
 [[package]]
 name = "ax-errno"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b1d0b41dcb73f9abeca41dbd9b05357510caef74babf6cc23ce7b53ea06b56"
-dependencies = [
- "log",
- "quote",
- "strum 0.27.2",
-]
-
-[[package]]
-name = "ax-errno"
 version = "0.6.3"
 dependencies = [
  "axtest",
@@ -879,7 +868,7 @@ dependencies = [
 name = "ax-fs-ng"
 version = "0.8.7"
 dependencies = [
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-io",
  "ax-kspin",
  "ax-sync",
@@ -938,7 +927,7 @@ dependencies = [
 name = "ax-io"
 version = "0.6.4"
 dependencies = [
- "ax-errno 0.6.3",
+ "ax-errno",
  "axtest",
  "heapless",
  "memchr",
@@ -986,7 +975,7 @@ name = "ax-libc"
 version = "0.5.31"
 dependencies = [
  "ax-driver",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-hal",
  "ax-io",
  "ax-kspin",
@@ -1032,7 +1021,7 @@ dependencies = [
 name = "ax-memory-set"
 version = "0.6.14"
 dependencies = [
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-memory-addr",
  "axtest",
 ]
@@ -1042,7 +1031,7 @@ name = "ax-mm"
 version = "0.5.31"
 dependencies = [
  "ax-alloc",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-hal",
  "ax-kspin",
  "ax-lazyinit",
@@ -1058,7 +1047,7 @@ version = "0.12.7"
 dependencies = [
  "async-channel",
  "async-trait",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-hal",
  "ax-io",
  "ax-kspin",
@@ -1096,7 +1085,7 @@ name = "ax-page-table-multiarch"
 version = "0.8.15"
 dependencies = [
  "arrayvec",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-memory-addr",
  "ax-page-table-entry",
  "bitmaps",
@@ -1159,7 +1148,7 @@ name = "ax-posix-api"
 version = "0.5.32"
 dependencies = [
  "ax-alloc",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-fs-ng",
  "ax-hal",
  "ax-io",
@@ -1193,7 +1182,7 @@ dependencies = [
  "ax-ctor-bare",
  "ax-display",
  "ax-driver",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-fs-ng",
  "ax-hal",
  "ax-input",
@@ -1241,7 +1230,7 @@ dependencies = [
  "ax-alloc",
  "ax-api",
  "ax-driver",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-hal",
  "ax-io",
  "ax-kernel-guard",
@@ -1275,7 +1264,7 @@ dependencies = [
  "ax-alloc",
  "ax-cpumask",
  "ax-crate-interface",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-hal",
  "ax-ipi",
  "ax-kernel-guard",
@@ -1418,7 +1407,7 @@ name = "axfs-ng-vfs"
 version = "0.5.8"
 dependencies = [
  "ax-crate-interface",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-kernel-guard",
  "ax-kspin",
  "axtest",
@@ -1442,7 +1431,7 @@ name = "axklib"
 version = "0.7.8"
 dependencies = [
  "ax-alloc",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-memory-addr",
  "dma-api",
  "irq-framework",
@@ -1467,7 +1456,7 @@ name = "axnsproxy"
 version = "0.3.4"
 dependencies = [
  "ax-cgroup",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-kspin",
  "linux-raw-sys 0.12.1",
  "log",
@@ -1486,7 +1475,7 @@ dependencies = [
  "anyhow",
  "ax-cpu",
  "ax-driver",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-memory-addr",
  "ax-percpu",
  "ax-plat",
@@ -4655,7 +4644,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "939c71c68bfebd52de856c50f7650713e449fe8a83255e8cee53d8519500b5e0"
 dependencies = [
- "ax-errno 0.6.2",
+ "ax-errno",
  "bitflags 2.13.1",
  "int-enum",
  "lock_api",
@@ -4732,7 +4721,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a71b521b03673eb47aa8b7d70ff6709fabdc9243ee9e713cacc08f5b0ffae2c2"
 dependencies = [
- "ax-errno 0.6.2",
+ "ax-errno",
  "bitfield-struct 0.13.0",
  "bitflags 2.13.1",
  "cfg-if",
@@ -7554,7 +7543,7 @@ dependencies = [
 name = "sg2002-tpu"
 version = "0.3.10"
 dependencies = [
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-kspin",
  "ax-memory-addr",
  "axklib",
@@ -7917,7 +7906,7 @@ dependencies = [
  "ax-crate-interface",
  "ax-display",
  "ax-driver",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-fs-ng",
  "ax-hal",
  "ax-input",
@@ -8038,7 +8027,7 @@ name = "starry-signal"
 version = "0.8.13"
 dependencies = [
  "ax-cpu",
- "ax-errno 0.6.3",
+ "ax-errno",
  "ax-kspin",
  "bitflags 2.13.1",
  "cfg-if",
@@ -8055,7 +8044,7 @@ dependencies = [
 name = "starry-vm"
 version = "0.5.13"
 dependencies = [
- "ax-errno 0.6.3",
+ "ax-errno",
  "bytemuck",
  "extern-trait",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -337,3 +337,6 @@ bcm2835-sdhci = "0.1.1-preview.1"
 x86 = "0.52"
 kmod-tools = "0.3"
 kprobe = "0.6"
+
+[patch.crates-io]
+ax-errno = { path = "components/axerrno" }


### PR DESCRIPTION
## 问题

release-plz 的工作区发布预检在打包 `starry-kernel` 时失败。`kbpf-basic 0.6.0` 通过传递依赖声明 `ax-errno ^0.6.0`，但现有 `Cargo.lock` 仍将这条依赖解析到 crates.io 的 `ax-errno 0.6.2`；与此同时，工作区直接依赖使用 path 来源的 `ax-errno 0.6.3`。

Cargo 在发布打包时会把 path 依赖改写为 registry 依赖，因此 registry/path 双来源会在同一发布依赖图中发生冲突。这个冲突出现在全工作区上传前预检阶段；若缺少该预检，则可能在部分 crate 已上传后才暴露问题，形成半发布状态。

## 修改

- 在根 `Cargo.toml` 使用 Cargo 官方的 `[patch.crates-io]`，将 crates.io 上的 `ax-errno` 统一替换为 `components/axerrno`。
- 重新生成 `Cargo.lock`，移除 registry 来源的 `ax-errno 0.6.2`，使包括 `kbpf-basic` 在内的依赖边全部解析到 path 来源的 `ax-errno 0.6.3`。
- 在 release-plz workflow 的全局环境固定 `RUSTUP_TOOLCHAIN=stable`，使 release PR 与 release 发布任务使用相同的 stable Cargo 行为。
- 保留 `dependencies_update = true`、release-plz 的拓扑顺序发布行为，以及上传前的 `cargo publish --workspace --dry-run --no-verify` 全工作区预检。

## 方案逻辑

`kbpf-basic` 并未锁死 `ax-errno 0.6.2`，其 `^0.6.0` 版本要求能够接受 `0.6.3`；真正锁定旧版本的是工作区锁文件。根级 `[patch.crates-io]` 会作用于整个依赖图，因此既覆盖工作区直接依赖，也覆盖 registry crate 的传递依赖，从源头消除双来源解析，而不需要修改上游 crate 或放宽发布检查。

全工作区预检继续承担发布事务边界：只有所有待发布 crate 都能按拓扑完成打包后，release-plz 才进入实际上传流程。

## 本地验证

- `cargo +stable metadata --locked --format-version=1`：通过；依赖图仅包含 path 来源的 `ax-errno 0.6.3`。
- `cargo +stable publish --manifest-path os/StarryOS/kernel/Cargo.toml --dry-run --no-verify`：成功进入 `starry-kernel` 打包；随后按预期因同批待发布的 `ax-alloc 0.8.15` 尚未存在于 crates.io 而停止，说明单包模式无法表达本次多 crate 拓扑发布。
- `cargo +stable publish --workspace --dry-run --no-verify`：通过；`ax-errno 0.6.3`、`ax-alloc 0.8.15`、`starry-kernel 0.7.7` 和 `starryos 0.5.28` 均完成打包，命令退出码为 0。
- `cargo xtask clippy --package starry-kernel`：通过，25/25 checks passed。
- `cargo fmt --all -- --check`：通过。
- `git diff --check`：通过。

本地全工作区预检在与 GitHub Actions 相同的 clean worktree 中执行，避免本机 ignored 生成文件影响 Cargo 的 dirty-tree 检查。
