### PR TITLE
test(axvisor): validate x86 OVMF ACPI on VMX and SVM

### DIFF
--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -47,7 +47,34 @@ For x86 OVMF/BIOS boot, verify graph-fixed PIO windows `0x510..0x512` and
 `0x514..0x51c` are trapped and that fw_cfg publishes `etc/acpi/tables`,
 `etc/acpi/rsdp`, and `etc/table-loader`. A working selector read alone does not
 prove ACPI installation; check table-loader DMA operations and confirm Linux
-sees `DSDT`, `APIC`, `FACP`, and `XSDT` under `/sys/firmware/acpi/tables`.
+uses the XSDT to discover `DSDT`, `APIC`, `FACP`, and `SPCR` under
+`/sys/firmware/acpi/tables` (Linux does not export the root XSDT there).
+
+For the Axvisor x86 nested OVMF validation cases, troubleshoot in this order:
+
+1. List the `normal` group and confirm both `ovmf-acpi-vmx` and
+   `ovmf-acpi-svm` are discovered. Run VMX only on an Intel/VMX KVM host and
+   SVM only on an AMD/SVM KVM host; neither build config may select a backend
+   Cargo feature.
+2. Read the asset-preparation evidence before interpreting firmware output.
+   It records the actual Ostool CODE and VARS paths, byte sizes, SHA-256
+   digests, the split or monolithic layout, and the final 4 MiB guest image.
+   A monolithic CODE image must report the recorded VARS as unused.
+3. Confirm the final guest-image path is the same path selected by
+   `uefi_firmware_path` in the shared guest TOML. Do not confuse this nested
+   firmware with the outer QEMU pflash used to boot the Axvisor host.
+4. Verify fw_cfg publishes the three ACPI files above, then inspect the
+   table-loader allocation, pointer, checksum, and DMA error tests. A selector
+   read or firmware banner is only an intermediate checkpoint.
+5. Require the guest initramfs marker `AXVISOR_X86_OVMF_ACPI_PASSED`. It means
+   OVMF handed off to Linux and Linux accepted DSDT, APIC, FACP, SPCR, ttyS0,
+   and IOAPIC. Preserve the full command, firmware evidence, last reliable
+   state, and first definite error if the marker is absent.
+
+The current nested OVMF cases still receive their Linux kernel, initramfs, and
+command line through fw_cfg. They do not prove a guest PCI boot disk, ESP, or
+Linux EFI-stub boot path, and a failure in those later capabilities must not be
+fixed by changing these validation-only cases.
 
 For AArch64 host replacement, compare every GICR region and stride in the
 immutable firmware plan with the `ArmVgicConfig` passed to the runtime. Do not

--- a/docs/docs/build/axvisor/test.md
+++ b/docs/docs/build/axvisor/test.md
@@ -146,3 +146,28 @@ Axvisor 测试的六种 pipeline 类型与 StarryOS 完全一致，因为两者�
 | Plain | 以上均不满足 | 最常见，纯 QEMU 启动验证 |
 
 pipeline 类型、检测优先级、资产准备、rootfs 缓存和 grouped runner 协议的完整说明见 [测试基础设施](../test_infra)。Axvisor 的 `prepare_staging_root` 钩子为空操作（`|_| Ok(())`），不做 StarryOS 那样的 DNS 注入和 APK 区域配置。
+
+### 4.1 x86 嵌套 OVMF/ACPI 验证
+
+`normal` 组提供两条对称的 x86 嵌套 OVMF 用例：
+
+```bash
+cargo xtask axvisor test qemu --arch x86_64 --test-group normal \
+  --test-case ovmf-acpi-vmx
+cargo xtask axvisor test qemu --arch x86_64 --test-group normal \
+  --test-case ovmf-acpi-svm
+```
+
+两者共用 `test-suit/axvisor/normal/qemu-acpi-ovmf/x86-linux-acpi-ovmf.toml`、同一 BusyBox initramfs 和同一 4 MiB guest firmware 输出。build config 不选择 `vmx` 或 `svm` Cargo feature；唯一的 backend 差异是外层 QEMU 的 `-cpu` 能力：VMX 暴露 EPT、unrestricted guest 和 flexpriority，SVM 暴露 SVM、NPT 和 NRIP save。因此应分别在 Intel/VMX 与 AMD/SVM KVM 宿主上运行对应 case。本组用例在稳定性阶段完成前保持 non-gating。
+
+资产准备复用 Ostool 的 x86_64 OVMF 缓存，可先用以下命令确认来源路径：
+
+```bash
+cargo xtask ovmf --arch x86_64
+```
+
+Axvisor 测试构建日志会输出本次实际使用的 Ostool CODE、VARS 和最终 guest image 的路径、字节数及 SHA-256，同时说明布局是 `split CODE/VARS` 还是 `monolithic CODE`。对于 monolithic CODE，VARS 仍会记录来源证据，但明确标记为 `unused`；这些运行时摘要不固化到仓库。
+
+成功条件 `AXVISOR_X86_OVMF_ACPI_PASSED` 来自嵌套 Linux initramfs，而不是 QEMU 外层 OVMF。该 marker 只有在 OVMF 完成 kernel handoff、Linux 进入早期用户态，并且 Linux 能读取 DSDT、APIC、FACP、SPCR、发现 `ttyS0`、初始化 IOAPIC 且 online CPU 集合为 `0` 时才会输出。因此它同时证明当前 firmware handoff 和 guest-side ACPI 接受路径。
+
+当前用例仍由 fw_cfg 提供 Linux kernel、initramfs 和命令行。它不证明 OVMF 已枚举 Axvisor guest PCI 启动盘，也不证明 Linux 经 guest ESP 或 EFI stub 启动；这些属于后续独立功能阶段，不能从本 marker 推导。

--- a/scripts/axbuild/src/axvisor/test/initramfs.rs
+++ b/scripts/axbuild/src/axvisor/test/initramfs.rs
@@ -132,8 +132,8 @@ pub(super) async fn prepare_configured_busybox_initramfs(
             "{OVMF_OUTPUT_ENV} is only valid for x86_64 Axvisor tests"
         );
         let output_path = resolve_output_path(workspace_root, configured_output, OVMF_OUTPUT_ENV)?;
-        super::ovmf::prepare_x86_ovmf(&output_path).await?;
-        println!("prepared Axvisor x86 OVMF image: {}", output_path.display());
+        let evidence = super::ovmf::prepare_x86_ovmf(&output_path).await?;
+        println!("{evidence}");
     }
     Ok(())
 }

--- a/scripts/axbuild/src/axvisor/test/ovmf.rs
+++ b/scripts/axbuild/src/axvisor/test/ovmf.rs
@@ -1,20 +1,102 @@
 //! OVMF image preparation for nested x86 Axvisor tests.
 
-use std::{fs, io::Write, path::Path};
+use std::{
+    fmt, fs,
+    io::Write,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, ensure};
 use ostool::ovmf::Arch;
 use tempfile::NamedTempFile;
 
+use crate::support::{download::file_sha256, ovmf::OvmfFirmware};
+
 const OVMF_SIZE: usize = 4 * 1024 * 1024;
 
-pub(super) async fn prepare_x86_ovmf(output_path: &Path) -> anyhow::Result<()> {
-    let firmware = crate::support::ovmf::OvmfFirmware::fetch(Arch::X64).await?;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OvmfLayout {
+    SplitCodeVars,
+    MonolithicCode,
+}
+
+impl fmt::Display for OvmfLayout {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SplitCodeVars => formatter.write_str("split CODE/VARS"),
+            Self::MonolithicCode => formatter.write_str("monolithic CODE"),
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct FirmwareFileEvidence {
+    path: PathBuf,
+    size: u64,
+    sha256: String,
+}
+
+impl FirmwareFileEvidence {
+    fn collect(path: &Path) -> anyhow::Result<Self> {
+        let size = fs::metadata(path)
+            .with_context(|| format!("failed to inspect firmware {}", path.display()))?
+            .len();
+        Ok(Self {
+            path: path.to_path_buf(),
+            size,
+            sha256: file_sha256(path)?,
+        })
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct OvmfEvidence {
+    layout: OvmfLayout,
+    code: FirmwareFileEvidence,
+    vars: FirmwareFileEvidence,
+    guest: FirmwareFileEvidence,
+}
+
+impl fmt::Display for OvmfEvidence {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let vars_usage = match self.layout {
+            OvmfLayout::SplitCodeVars => "prefix",
+            OvmfLayout::MonolithicCode => "unused",
+        };
+        write!(
+            formatter,
+            "Axvisor x86 OVMF firmware evidence:\nlayout: {}\nOstool CODE: path={} size={} \
+             sha256={}\nOstool VARS: path={} size={} sha256={} usage={}\nguest image: path={} \
+             size={} sha256={}",
+            self.layout,
+            self.code.path.display(),
+            self.code.size,
+            self.code.sha256,
+            self.vars.path.display(),
+            self.vars.size,
+            self.vars.sha256,
+            vars_usage,
+            self.guest.path.display(),
+            self.guest.size,
+            self.guest.sha256,
+        )
+    }
+}
+
+pub(super) async fn prepare_x86_ovmf(output_path: &Path) -> anyhow::Result<OvmfEvidence> {
+    let firmware = OvmfFirmware::fetch(Arch::X64).await?;
+    prepare_x86_ovmf_from_firmware(output_path, &firmware)
+}
+
+fn prepare_x86_ovmf_from_firmware(
+    output_path: &Path,
+    firmware: &OvmfFirmware,
+) -> anyhow::Result<OvmfEvidence> {
     let code_path = firmware.code();
     let code = fs::read(code_path)
         .with_context(|| format!("failed to read OVMF code image {}", code_path.display()))?;
-    let vars = if code.len() == OVMF_SIZE {
-        None
+    let (layout, vars) = if code.len() == OVMF_SIZE {
+        (OvmfLayout::MonolithicCode, None)
     } else {
         OVMF_SIZE.checked_sub(code.len()).with_context(|| {
             format!(
@@ -22,12 +104,15 @@ pub(super) async fn prepare_x86_ovmf(output_path: &Path) -> anyhow::Result<()> {
                 code_path.display()
             )
         })?;
-        Some(fs::read(firmware.vars()).with_context(|| {
-            format!(
-                "failed to read OVMF variable store {}",
-                firmware.vars().display()
-            )
-        })?)
+        (
+            OvmfLayout::SplitCodeVars,
+            Some(fs::read(firmware.vars()).with_context(|| {
+                format!(
+                    "failed to read OVMF variable store {}",
+                    firmware.vars().display()
+                )
+            })?),
+        )
     };
     let image = assemble_ovmf_image(&code, vars.as_deref())?;
 
@@ -53,7 +138,13 @@ pub(super) async fn prepare_x86_ovmf(output_path: &Path) -> anyhow::Result<()> {
         .persist(output_path)
         .map_err(|error| error.error)
         .with_context(|| format!("failed to install {}", output_path.display()))?;
-    Ok(())
+
+    Ok(OvmfEvidence {
+        layout,
+        code: FirmwareFileEvidence::collect(code_path)?,
+        vars: FirmwareFileEvidence::collect(firmware.vars())?,
+        guest: FirmwareFileEvidence::collect(output_path)?,
+    })
 }
 
 fn assemble_ovmf_image(code: &[u8], vars: Option<&[u8]>) -> anyhow::Result<Vec<u8>> {
@@ -77,6 +168,8 @@ fn assemble_ovmf_image(code: &[u8], vars: Option<&[u8]>) -> anyhow::Result<Vec<u
 
 #[cfg(test)]
 mod tests {
+    use tempfile::tempdir;
+
     use super::*;
 
     #[test]
@@ -89,5 +182,59 @@ mod tests {
         assert_eq!(&image[..vars.len()], vars);
         assert_eq!(&image[vars.len()..], code);
         assert!(assemble_ovmf_image(&code, None).is_err());
+    }
+
+    #[test]
+    fn split_firmware_evidence_matches_the_installed_guest_image() {
+        let root = tempdir().unwrap();
+        let code_path = root.path().join("OVMF_CODE.fd");
+        let vars_path = root.path().join("OVMF_VARS.fd");
+        let output_path = root.path().join("guest/OVMF_CODE_4M.fd");
+        let vars = vec![0xa5; 0x84_000];
+        let code = vec![0x5a; OVMF_SIZE - vars.len()];
+        fs::write(&code_path, &code).unwrap();
+        fs::write(&vars_path, &vars).unwrap();
+        let firmware = OvmfFirmware::from_paths(code_path.clone(), vars_path.clone());
+
+        let evidence = prepare_x86_ovmf_from_firmware(&output_path, &firmware).unwrap();
+        let image = fs::read(&output_path).unwrap();
+
+        assert_eq!(evidence.layout, OvmfLayout::SplitCodeVars);
+        assert_eq!(image.len(), OVMF_SIZE);
+        assert_eq!(&image[..vars.len()], vars);
+        assert_eq!(&image[vars.len()..], code);
+        assert_eq!(evidence.code.path, code_path);
+        assert_eq!(evidence.code.size, code.len() as u64);
+        assert_eq!(evidence.code.sha256, file_sha256(&code_path).unwrap());
+        assert_eq!(evidence.vars.path, vars_path);
+        assert_eq!(evidence.vars.size, vars.len() as u64);
+        assert_eq!(evidence.vars.sha256, file_sha256(&vars_path).unwrap());
+        assert_eq!(evidence.guest.path, output_path);
+        assert_eq!(evidence.guest.size, OVMF_SIZE as u64);
+        assert_eq!(evidence.guest.sha256, file_sha256(&output_path).unwrap());
+
+        let text = evidence.to_string();
+        assert!(text.contains("layout: split CODE/VARS"));
+        assert!(text.contains(&format!("Ostool CODE: path={}", code_path.display())));
+        assert!(text.contains(&format!("Ostool VARS: path={}", vars_path.display())));
+        assert!(text.contains("usage=prefix"));
+        assert!(text.contains(&format!("guest image: path={}", output_path.display())));
+    }
+
+    #[test]
+    fn monolithic_firmware_reports_the_variable_store_as_unused() {
+        let root = tempdir().unwrap();
+        let code_path = root.path().join("OVMF_CODE.fd");
+        let vars_path = root.path().join("OVMF_VARS.fd");
+        let output_path = root.path().join("OVMF_CODE_4M.fd");
+        fs::write(&code_path, vec![0x5a; OVMF_SIZE]).unwrap();
+        fs::write(&vars_path, b"unused vars").unwrap();
+        let firmware = OvmfFirmware::from_paths(code_path, vars_path);
+
+        let evidence = prepare_x86_ovmf_from_firmware(&output_path, &firmware).unwrap();
+
+        assert_eq!(evidence.layout, OvmfLayout::MonolithicCode);
+        assert!(evidence.to_string().contains("usage=unused"));
+        assert_eq!(fs::metadata(output_path).unwrap().len(), OVMF_SIZE as u64);
     }
 }

--- a/scripts/axbuild/src/axvisor/test/tests.rs
+++ b/scripts/axbuild/src/axvisor/test/tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -26,6 +27,25 @@ struct TestVmKernelConfig {
 struct TestVmKernel {
     #[serde(default)]
     cmdline: String,
+}
+
+#[derive(Debug, Eq, PartialEq, serde::Deserialize)]
+struct TestOvmfBuildConfig {
+    #[serde(default)]
+    features: Vec<String>,
+    vm_configs: Vec<PathBuf>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+}
+
+#[derive(serde::Deserialize)]
+struct TestOvmfGuestConfig {
+    kernel: TestOvmfGuestKernel,
+}
+
+#[derive(serde::Deserialize)]
+struct TestOvmfGuestKernel {
+    uefi_firmware_path: PathBuf,
 }
 
 fn write_qemu_config(root: &Path, case: &str, arch: &str, body: &str) -> PathBuf {
@@ -287,6 +307,89 @@ fn x86_hypervisor_backend_cases_request_raw_bin_artifacts() {
             );
         }
     }
+}
+
+#[test]
+fn x86_ovmf_acpi_cases_share_one_backend_neutral_guest_contract() {
+    const BUILD_OUTPUT_ENV: &str = "AXVISOR_TEST_X86_OVMF_OUTPUT";
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let cases = discover_qemu_cases(
+        &workspace_root,
+        "normal",
+        "x86_64",
+        "x86_64-unknown-none",
+        None,
+    )
+    .unwrap();
+    let vmx_case = cases
+        .iter()
+        .find(|case| case.case.name == "ovmf-acpi-vmx")
+        .expect("runner should discover the VMX OVMF ACPI case");
+    let svm_case = cases
+        .iter()
+        .find(|case| case.case.name == "ovmf-acpi-svm")
+        .expect("runner should discover the SVM OVMF ACPI case");
+
+    let vmx_build = load_ovmf_build_config(&vmx_case.build_config_path);
+    let svm_build = load_ovmf_build_config(&svm_case.build_config_path);
+    assert_eq!(vmx_build, svm_build);
+    assert_eq!(vmx_build.vm_configs.len(), 1);
+    assert!(
+        vmx_build
+            .features
+            .iter()
+            .all(|feature| feature != "vmx" && feature != "svm"),
+        "OVMF ACPI build configs must leave backend selection to runtime CPUID"
+    );
+
+    let guest_path = workspace_root.join(&vmx_build.vm_configs[0]);
+    let guest: TestOvmfGuestConfig =
+        toml::from_str(&fs::read_to_string(&guest_path).unwrap()).unwrap();
+    let build_output = vmx_build
+        .env
+        .get(BUILD_OUTPUT_ENV)
+        .expect("OVMF build config should prepare the guest firmware image");
+    assert_eq!(
+        guest.kernel.uefi_firmware_path,
+        PathBuf::from(format!("${{workspace}}/{build_output}")),
+        "the prepared image must be the image loaded by the guest configuration"
+    );
+
+    let mut vmx_qemu = load_qemu_config(&vmx_case.case.qemu_config_path);
+    let mut svm_qemu = load_qemu_config(&svm_case.case.qemu_config_path);
+    assert_eq!(
+        replace_qemu_argument(&mut vmx_qemu.args, "-cpu", "<backend>"),
+        "host,-la57,+vmx-ept,+vmx-unrestricted-guest,+vmx-flexpriority"
+    );
+    assert_eq!(
+        replace_qemu_argument(&mut svm_qemu.args, "-cpu", "<backend>"),
+        "host,-la57,+svm,+npt,+nrip-save"
+    );
+    assert_eq!(
+        vmx_qemu, svm_qemu,
+        "VMX and SVM OVMF ACPI cases may differ only in outer QEMU CPU capabilities"
+    );
+}
+
+fn load_ovmf_build_config(path: &Path) -> TestOvmfBuildConfig {
+    toml::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
+fn load_qemu_config(path: &Path) -> QemuConfig {
+    toml::from_str(&fs::read_to_string(path).unwrap()).unwrap()
+}
+
+fn replace_qemu_argument(args: &mut [String], option: &str, replacement: &str) -> String {
+    let index = args
+        .iter()
+        .position(|argument| argument == option)
+        .unwrap_or_else(|| panic!("missing QEMU option {option}"));
+    std::mem::replace(
+        args.get_mut(index + 1)
+            .unwrap_or_else(|| panic!("missing value for QEMU option {option}")),
+        replacement.to_string(),
+    )
 }
 
 fn qemu_argument_value<'a>(args: &'a [String], option: &str) -> &'a str {

--- a/test-suit/axvisor/normal/qemu-acpi-ovmf/build-x86_64-unknown-none-svm.toml
+++ b/test-suit/axvisor/normal/qemu-acpi-ovmf/build-x86_64-unknown-none-svm.toml
@@ -1,0 +1,8 @@
+features = []
+log = "Info"
+target = "x86_64-unknown-none"
+vm_configs = ["test-suit/axvisor/normal/qemu-acpi-ovmf/x86-linux-acpi-ovmf.toml"]
+
+[env]
+AXVISOR_TEST_BUSYBOX_INITRAMFS = "tmp/axbuild/axvisor/qemu-acpi-ovmf/initramfs-x86_64.cpio.gz"
+AXVISOR_TEST_X86_OVMF_OUTPUT = "tmp/axbuild/axvisor/qemu-acpi-ovmf/OVMF_CODE_4M.fd"

--- a/test-suit/axvisor/normal/qemu-acpi-ovmf/ovmf-acpi/qemu-x86_64-svm.toml
+++ b/test-suit/axvisor/normal/qemu-acpi-ovmf/ovmf-acpi/qemu-x86_64-svm.toml
@@ -1,0 +1,30 @@
+args = [
+  "-no-user-config",
+  "-display",
+  "none",
+  "-serial",
+  "stdio",
+  "-monitor",
+  "none",
+  "-cpu",
+  "host,-la57,+svm,+npt,+nrip-save",
+  "-machine",
+  "q35,smbus=off,usb=off,graphics=off",
+  "-smp",
+  "2",
+  "-accel",
+  "kvm",
+  "-m",
+  "1G",
+  "-net",
+  "none",
+]
+timeout = 600
+fail_regex = [
+  "(?i)kernel panic",
+  "(?m)^AXVISOR_X86_ACPI_FAILED\\s*$",
+  "(?m)^AXVISOR_GUEST_ASSERTION_CASE_UNKNOWN\\s*$",
+]
+success_regex = ["(?m)^AXVISOR_X86_OVMF_ACPI_PASSED\\s*$"]
+to_bin = true
+uefi = true

--- a/virtualization/axvm/src/arch/x86_64/boot/acpi/fw_cfg.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/acpi/fw_cfg.rs
@@ -164,25 +164,218 @@ fn clear_checksum(
 
 #[cfg(test)]
 mod tests {
+    use std::ops::Range;
+
     use super::*;
 
-    #[test]
-    fn loader_checksum_targets_start_zeroed() {
-        let blobs = build_fw_cfg_blobs(&super::super::config::test_plan(2)).unwrap();
+    const LOADER_ENTRY_SIZE: usize = 128;
 
-        for entry in blobs.loader.chunks_exact(128) {
-            if u32::from_le_bytes(entry[..4].try_into().unwrap()) != 3 {
-                continue;
+    #[derive(Debug, Eq, PartialEq)]
+    enum DecodedLoaderCommand {
+        Allocate {
+            file: String,
+            alignment: u32,
+            zone: u8,
+        },
+        Pointer {
+            pointer_file: String,
+            pointee_file: String,
+            pointer_offset: u32,
+            pointer_size: u8,
+        },
+        Checksum {
+            file: String,
+            checksum_offset: u32,
+            start: u32,
+            length: u32,
+        },
+    }
+
+    #[test]
+    fn fw_cfg_blobs_describe_the_complete_x86_acpi_loader_plan() {
+        let blobs = build_fw_cfg_blobs(&super::super::config::test_plan(2)).unwrap();
+        let commands = decode_loader(&blobs.loader);
+
+        assert_eq!(blobs.loader.len(), 15 * LOADER_ENTRY_SIZE);
+        assert_eq!(commands.len(), 15);
+        assert_eq!(
+            commands[0],
+            DecodedLoaderCommand::Allocate {
+                file: TABLE_FILE.into(),
+                alignment: 64,
+                zone: LoaderZone::High as u8,
             }
-            let file_end = entry[4..60].iter().position(|byte| *byte == 0).unwrap();
-            let file = &entry[4..4 + file_end];
-            let checksum_offset = u32::from_le_bytes(entry[60..64].try_into().unwrap()) as usize;
-            let data = match file {
-                b"etc/acpi/tables" => &blobs.tables,
-                b"etc/acpi/rsdp" => &blobs.rsdp,
-                _ => panic!("unexpected checksum file"),
-            };
-            assert_eq!(data[checksum_offset], 0, "checksum target in {file:?}");
+        );
+        assert_eq!(
+            commands[1],
+            DecodedLoaderCommand::Allocate {
+                file: RSDP_FILE.into(),
+                alignment: 16,
+                zone: LoaderZone::Fseg as u8,
+            }
+        );
+
+        let xsdt = acpi_table_range(&blobs.tables, b"XSDT");
+        let fadt = acpi_table_range(&blobs.tables, b"FACP");
+        let facs = acpi_table_range(&blobs.tables, b"FACS");
+        let dsdt = acpi_table_range(&blobs.tables, b"DSDT");
+        let madt = acpi_table_range(&blobs.tables, b"APIC");
+        let spcr = acpi_table_range(&blobs.tables, b"SPCR");
+
+        for (command, pointer_file, offset, target) in [
+            (&commands[2], TABLE_FILE, fadt.start + 132, &facs),
+            (&commands[3], TABLE_FILE, fadt.start + 140, &dsdt),
+            (&commands[4], TABLE_FILE, xsdt.start + 36, &fadt),
+            (&commands[5], TABLE_FILE, xsdt.start + 44, &madt),
+            (&commands[6], TABLE_FILE, xsdt.start + 52, &spcr),
+            (&commands[7], RSDP_FILE, 24, &xsdt),
+        ] {
+            assert_pointer_command(
+                command,
+                pointer_file,
+                offset,
+                target,
+                &blobs.tables,
+                &blobs.rsdp,
+            );
         }
+
+        for (command, table) in commands[8..13]
+            .iter()
+            .zip([&xsdt, &fadt, &dsdt, &madt, &spcr])
+        {
+            assert_checksum_command(command, TABLE_FILE, table, &blobs.tables);
+        }
+        assert_eq!(
+            commands[13],
+            DecodedLoaderCommand::Checksum {
+                file: RSDP_FILE.into(),
+                checksum_offset: 8,
+                start: 0,
+                length: 20,
+            }
+        );
+        assert_eq!(blobs.rsdp[8], 0);
+        assert_eq!(
+            commands[14],
+            DecodedLoaderCommand::Checksum {
+                file: RSDP_FILE.into(),
+                checksum_offset: 32,
+                start: 0,
+                length: blobs.rsdp.len() as u32,
+            }
+        );
+        assert_eq!(blobs.rsdp[32], 0);
+    }
+
+    fn decode_loader(bytes: &[u8]) -> Vec<DecodedLoaderCommand> {
+        assert_eq!(bytes.len() % LOADER_ENTRY_SIZE, 0);
+        bytes
+            .chunks_exact(LOADER_ENTRY_SIZE)
+            .map(|entry| match read_u32(entry, 0) {
+                1 => DecodedLoaderCommand::Allocate {
+                    file: read_file(&entry[4..60]),
+                    alignment: read_u32(entry, 60),
+                    zone: entry[64],
+                },
+                2 => DecodedLoaderCommand::Pointer {
+                    pointer_file: read_file(&entry[4..60]),
+                    pointee_file: read_file(&entry[60..116]),
+                    pointer_offset: read_u32(entry, 116),
+                    pointer_size: entry[120],
+                },
+                3 => DecodedLoaderCommand::Checksum {
+                    file: read_file(&entry[4..60]),
+                    checksum_offset: read_u32(entry, 60),
+                    start: read_u32(entry, 64),
+                    length: read_u32(entry, 68),
+                },
+                command => panic!("unexpected table-loader command {command}"),
+            })
+            .collect()
+    }
+
+    fn read_file(field: &[u8]) -> String {
+        let length = field
+            .iter()
+            .position(|byte| *byte == 0)
+            .unwrap_or(field.len());
+        String::from_utf8(field[..length].to_vec()).unwrap()
+    }
+
+    fn read_u32(bytes: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
+    }
+
+    fn read_u64(bytes: &[u8], offset: usize) -> u64 {
+        u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap())
+    }
+
+    fn acpi_table_range(tables: &[u8], signature: &[u8; 4]) -> Range<usize> {
+        let start = tables
+            .windows(signature.len())
+            .position(|window| window == signature)
+            .unwrap_or_else(|| panic!("missing ACPI table signature {signature:?}"));
+        let length = read_u32(tables, start + 4) as usize;
+        let end = start.checked_add(length).unwrap();
+        assert!(end <= tables.len(), "ACPI table extends past blob end");
+        start..end
+    }
+
+    fn assert_pointer_command(
+        command: &DecodedLoaderCommand,
+        pointer_file: &str,
+        expected_offset: usize,
+        target: &Range<usize>,
+        tables: &[u8],
+        rsdp: &[u8],
+    ) {
+        let DecodedLoaderCommand::Pointer {
+            pointer_file: actual_pointer_file,
+            pointee_file,
+            pointer_offset,
+            pointer_size,
+        } = command
+        else {
+            panic!("expected pointer command, got {command:?}");
+        };
+        assert_eq!(actual_pointer_file, pointer_file);
+        assert_eq!(pointee_file, TABLE_FILE);
+        assert_eq!(*pointer_offset as usize, expected_offset);
+        assert_eq!(*pointer_size, 8);
+
+        let source = if pointer_file == TABLE_FILE {
+            tables
+        } else {
+            assert_eq!(pointer_file, RSDP_FILE);
+            rsdp
+        };
+        let pointer_end = expected_offset.checked_add(8).unwrap();
+        assert!(pointer_end <= source.len());
+        assert_eq!(read_u64(source, expected_offset) as usize, target.start);
+        assert!(target.end <= tables.len());
+    }
+
+    fn assert_checksum_command(
+        command: &DecodedLoaderCommand,
+        expected_file: &str,
+        table: &Range<usize>,
+        data: &[u8],
+    ) {
+        let DecodedLoaderCommand::Checksum {
+            file,
+            checksum_offset,
+            start,
+            length,
+        } = command
+        else {
+            panic!("expected checksum command, got {command:?}");
+        };
+        assert_eq!(file, expected_file);
+        assert_eq!(*checksum_offset as usize, table.start + 9);
+        assert_eq!(*start as usize, table.start);
+        assert_eq!(*length as usize, table.len());
+        assert!(table.end <= data.len());
+        assert_eq!(data[*checksum_offset as usize], 0);
     }
 }

--- a/virtualization/axvm/src/boot/acpi/loader.rs
+++ b/virtualization/axvm/src/boot/acpi/loader.rs
@@ -167,3 +167,49 @@ fn validate_file(file: &str) -> Result<(), AcpiBuildError> {
 fn write_file(destination: &mut [u8], file: &str) {
     destination[..file.len()].copy_from_slice(file.as_bytes());
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serializes_allocate_pointer_and_checksum_command_layouts() {
+        let mut plan = AcpiLoaderPlan::new();
+        plan.allocate("etc/acpi/tables", 64, LoaderZone::High)
+            .unwrap();
+        plan.add_pointer("etc/acpi/rsdp", "etc/acpi/tables", 24, 8)
+            .unwrap();
+        plan.add_checksum("etc/acpi/rsdp", 8, 0, 20).unwrap();
+
+        let bytes = plan.serialize();
+        assert_eq!(bytes.len(), 3 * ENTRY_SIZE);
+
+        let allocate = &bytes[..ENTRY_SIZE];
+        assert_eq!(&allocate[0..4], &COMMAND_ALLOCATE.to_le_bytes());
+        assert_file_field(&allocate[4..60], "etc/acpi/tables");
+        assert_eq!(&allocate[60..64], &64u32.to_le_bytes());
+        assert_eq!(allocate[64], LoaderZone::High as u8);
+        assert!(allocate[65..].iter().all(|byte| *byte == 0));
+
+        let pointer = &bytes[ENTRY_SIZE..2 * ENTRY_SIZE];
+        assert_eq!(&pointer[0..4], &COMMAND_ADD_POINTER.to_le_bytes());
+        assert_file_field(&pointer[4..60], "etc/acpi/rsdp");
+        assert_file_field(&pointer[60..116], "etc/acpi/tables");
+        assert_eq!(&pointer[116..120], &24u32.to_le_bytes());
+        assert_eq!(pointer[120], 8);
+        assert!(pointer[121..].iter().all(|byte| *byte == 0));
+
+        let checksum = &bytes[2 * ENTRY_SIZE..];
+        assert_eq!(&checksum[0..4], &COMMAND_ADD_CHECKSUM.to_le_bytes());
+        assert_file_field(&checksum[4..60], "etc/acpi/rsdp");
+        assert_eq!(&checksum[60..64], &8u32.to_le_bytes());
+        assert_eq!(&checksum[64..68], &0u32.to_le_bytes());
+        assert_eq!(&checksum[68..72], &20u32.to_le_bytes());
+        assert!(checksum[72..].iter().all(|byte| *byte == 0));
+    }
+
+    fn assert_file_field(field: &[u8], expected: &str) {
+        assert_eq!(&field[..expected.len()], expected.as_bytes());
+        assert!(field[expected.len()..].iter().all(|byte| *byte == 0));
+    }
+}


### PR DESCRIPTION
## 解决的问题

最新 `dev` 已经具备 x86_64 Axvisor guest 的 OVMF、fw_cfg 和 ACPI 启动路径，并已有 VMX `ovmf-acpi` 用例能够启动 Linux initramfs。但是现有证据还不足以稳定回答以下问题：

- 本次运行实际使用了哪一份 Ostool OVMF，最终装入 guest 的 4 MiB 镜像是否可复核；
- SVM 是否能使用与 VMX 完全相同的 guest 配置到达同一个 guest-side 成功条件；
- fw_cfg ACPI table-loader 是否生成了完整且顺序正确的 allocate、pointer 和 checksum 命令；
- `AXVISOR_X86_OVMF_ACPI_PASSED` 究竟证明了哪段启动链路，又有哪些能力仍未覆盖。

本 PR 只补齐当前实现的验证与说明，不新增 guest UEFI 产品 feature，也不延续 #1888 中固定 firmware profile、首次 fw_cfg 访问 marker 或全局设备 trace 的早期诊断方案。

## 改了什么

- 在准备 x86 guest OVMF 镜像时记录实际 Ostool CODE、VARS 和最终 guest image 的路径、字节数及 SHA-256；同时区分 `split CODE/VARS` 与 `monolithic CODE` 布局，并验证最终镜像固定为 4 MiB。
- 增加 `ovmf-acpi-svm` 用例，与 VMX 用例共用同一个 build config、guest TOML、BusyBox initramfs、OVMF 镜像和成功断言；两者只在外层 QEMU 暴露的 VMX/SVM CPU 能力上不同。
- 扩充 ACPI table-loader 最低层测试，逐项解码并验证 table/rsdp 分配、FADT/XSDT/RSDP 指针修正以及各 ACPI 表 checksum 命令的文件、偏移、范围、宽度和顺序。
- 更新 Axvisor 测试文档和 x86 UEFI 调试说明，明确运行命令、证据来源、成功条件以及当前不能据此声明的能力。

## 不包含

- guest PCI 启动设备或 ESP；
- EFI 应用加载或 Linux EFI stub 磁盘启动；
- OVMF VARS 持久化；
- PCI INTx/MSI/MSI-X 完整链路；
- INIT/SIPI、NMI 或多 vCPU UEFI guest；
- 将当前 non-gating 用例升级为 CI 门禁。

## 实现逻辑

### 复用现有强证据

`dev` 已有的 `AXVISOR_X86_OVMF_ACPI_PASSED` 来自嵌套 Linux initramfs。只有在 OVMF 完成 kernel handoff、Linux 进入早期用户态，并且 guest 能读取 DSDT、APIC、FACP、SPCR、发现 `ttyS0`、初始化 IOAPIC 且 online CPU 集合为 `0` 时才会输出。

这个判据比“OVMF 首次访问 fw_cfg”更强，因此本 PR 不在产品代码中增加新的诊断 marker，也不改变 loader、fw_cfg、ACPI、PIO/MMIO 或中断运行语义。

### 固件来源保持单一

OVMF 的版本选择、下载、缓存和完整性校验继续由 Ostool 负责。Axvisor 测试层只组装当前 guest 所需的 4 MiB 镜像，并打印本次实际输入和输出的摘要，不增加第二套 firmware profile、下载器或 manifest。

### VMX/SVM 只验证 backend 差异

两个用例不通过 Cargo feature 选择 VMX 或 SVM。Axvisor 仍根据运行时 CPUID 选择 backend；测试配置只改变外层 QEMU 的 CPU capability，从而保证结果差异可以归因于 VMX/SVM，而不是不同 guest 配置或固件资产。

### 协议错误尽量在最低层暴露

端到端 OVMF 用例证明完整启动结果；table-loader 单元测试则直接检查固件将要消费的二进制命令布局。这样在后续回归时，可以区分 ACPI loader 生成错误与固件、虚拟化 backend 或 guest OS 运行错误。

## 验证

先确认测试用例能够被 runner 发现：

```bash
cargo xtask axvisor test qemu --arch x86_64 --test-group normal --list
```

当前分支已完成以下端到端验证：

```bash
cargo xtask axvisor test qemu --arch x86_64 --test-group normal \
  --test-case smoke-vmx
cargo xtask axvisor test qemu --arch x86_64 --test-group normal \
  --test-case smoke-svm
cargo xtask axvisor test qemu --arch x86_64 --test-group normal \
  --test-case ovmf-acpi-vmx
cargo xtask axvisor test qemu --arch x86_64 --test-group normal \
  --test-case ovmf-acpi-svm
```

四个用例均通过；两个 OVMF 用例均命中：

```text
AXVISOR_X86_OVMF_ACPI_PASSED
```

VMX 用例需要 Intel/VMX KVM 宿主，SVM 用例需要 AMD/SVM KVM 宿主。构建前还可以单独检查 Ostool 当前选择的固件路径：

```bash
cargo xtask ovmf --arch x86_64
```

## 已知限制

两个 OVMF 用例通过时仍观察到以下日志：

```text
vpic wire mode change to LAPIC, unimplemented
vpic wire mode change to NULL, unimplemented
VM wire mode should be changed to INTR here, unimplemented
```

这些日志表明 VM 级 legacy PIC 输出在 `INTR`、`LAPIC` 和 `NULL` 之间的路由切换尚未实现。当前单 vCPU 用例仍能通过，是因为现有中断注入路径足以支撑该工作负载；本 PR 因此只能证明当前 OVMF/Linux/ACPI 路径成立，不能证明完整 PIC/IOAPIC/LAPIC 切换、PCI 中断或 SMP 中断语义。

该缺口不在本验证 PR 中修复，也不会通过屏蔽 warning、放宽成功条件或扩大 timeout 处理；它进入后续中断完整性与 SMP feature 阶段。
