### PR TITLE
chore(ci): balance Axvisor test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -442,75 +442,56 @@ jobs:
             container_image: base
             limit_to_owner: ""
             main_pr_only: false
-          - name: Test axvisor aarch64 qemu (smoke + axtest)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: |
-              cargo xtask axvisor test qemu --arch aarch64 --test-case smoke
-              cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor aarch64 qemu (backtrace-panic)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask axvisor test qemu --arch aarch64 --test-case backtrace-panic
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor aarch64 qemu (no-backtrace)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask axvisor test qemu --arch aarch64 --test-case no-backtrace
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor aarch64 qemu (timer stress)
+          - name: Test axvisor aarch64 qemu (smoke + axtest + timer stress)
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
             timeout_minutes: 30
             command: |
+              echo "==> axvisor aarch64 smoke"
+              cargo xtask axvisor test qemu --arch aarch64 --test-case smoke
+              echo "==> axvisor aarch64 axtest"
+              cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
+              echo "==> pull qemu-aarch64 image"
               cargo xtask image pull qemu-aarch64 --output-dir tmp/axbuild/images
+              echo "==> axvisor aarch64 gicv2 timer stress"
               cargo xtask axvisor test qemu --arch aarch64 --test-case gicv2-timer-stress
+              echo "==> axvisor aarch64 gicv3 timer stress"
               cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress
             cache_key: ""
             container_image: base
             limit_to_owner: ""
             main_pr_only: false
-          - name: Test axvisor riscv64 qemu (smoke)
+          - name: Test axvisor aarch64 qemu (panic modes)
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
+            timeout_minutes: 30
             command: |
+              echo "==> axvisor aarch64 backtrace panic"
+              cargo xtask axvisor test qemu --arch aarch64 --test-case backtrace-panic
+              echo "==> axvisor aarch64 no-backtrace panic"
+              cargo xtask axvisor test qemu --arch aarch64 --test-case no-backtrace
+            cache_key: ""
+            container_image: base
+            limit_to_owner: ""
+            main_pr_only: false
+          - name: Test axvisor riscv64 qemu (smoke + panic modes)
+            use_container: false
+            runs_on: '["self-hosted","linux","qcs"]'
+            self_hosted_owner: rcore-os
+            timeout_minutes: 30
+            command: |
+              echo "==> axvisor riscv64 smoke"
+              cargo xtask axvisor test qemu --arch riscv64 --test-case smoke
+              echo "==> axvisor riscv64 IPI cross-test"
               cargo xtask cross-test --arch riscv64 \
                 --package riscv_vcpu --package axvm \
                 --features axvm/host-test --no-default-features --lib ipi
-              cargo xtask axvisor test qemu --arch riscv64 --test-case smoke
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor riscv64 qemu (backtrace-panic)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask axvisor test qemu --arch riscv64 --test-case backtrace-panic
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor riscv64 qemu (no-backtrace)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask axvisor test qemu --arch riscv64 --test-case no-backtrace
+              echo "==> axvisor riscv64 backtrace panic"
+              cargo xtask axvisor test qemu --arch riscv64 --test-case backtrace-panic
+              echo "==> axvisor riscv64 no-backtrace panic"
+              cargo xtask axvisor test qemu --arch riscv64 --test-case no-backtrace
             cache_key: ""
             container_image: base
             limit_to_owner: ""
@@ -684,11 +665,18 @@ jobs:
           #   apk_region: us
           #   limit_to_owner: ""
           #   main_pr_only: true
-          - name: Test axvisor self-hosted x86_64(svm)
+          - name: Test axvisor self-hosted x86_64 (svm smoke + ACPI)
             use_container: false
             runs_on: '["self-hosted","linux","amd","kvm"]'
             require_kvm: true
-            command: cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm
+            timeout_minutes: 30
+            command: |
+              echo "==> axvisor x86_64 svm smoke"
+              cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm
+              echo "==> pull qemu-x86_64 image"
+              cargo xtask image pull qemu-x86_64 --output-dir tmp/axbuild/images
+              echo "==> axvisor x86_64 svm direct ACPI boot"
+              cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-svm
             cache_key: ""
             container_image: ""
             limit_to_owner: rcore-os
@@ -710,18 +698,6 @@ jobs:
             command: |
               rustup target add x86_64-unknown-uefi
               cargo xtask axloader test qemu --target x86_64-unknown-uefi
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axvisor x86_64 ACPI direct boot (svm)
-            use_container: false
-            runs_on: '["self-hosted","linux","amd","kvm"]'
-            require_kvm: true
-            timeout_minutes: 30
-            command: |
-              cargo xtask image pull qemu-x86_64 --output-dir tmp/axbuild/images
-              cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-svm
             cache_key: ""
             container_image: ""
             limit_to_owner: rcore-os


### PR DESCRIPTION
## 问题

当前 Axvisor 的 aarch64、riscv64 和 AMD SVM 测试被拆成多个运行环境完全相同的短任务，单项通常只运行约 4–6 分钟；与此同时，Starry QEMU 和 Intel ACPI/OVMF 等任务通常需要约 14–17 分钟。过细的拆分会增加 self-hosted runner 调度和重复准备成本，也使各 runner 任务时长差异较大。

## 改动

- 将 Axvisor aarch64 的 4 个 matrix 项按负载重组为 2 个：`smoke + axtest + timer stress` 和 `panic modes`。
- 将 Axvisor riscv64 的 `smoke`、`backtrace-panic`、`no-backtrace` 合并为一个 matrix 项，并保留最新 `dev` 新增的 RISC-V IPI `cross-test`。
- 将 AMD KVM 上的 `smoke-svm` 与 `direct-acpi-svm` 合并为一个 matrix 项。
- 为每个组合任务设置 30 分钟上限，并在每条子测试前输出明确日志标记。
- 保留原有 runner 标签、owner 限制、KVM 要求以及 self-hosted `cache_key: ""` 约束。
- `test_checks` 的有效 matrix 项从 32 个减少到 27 个，所有原测试命令仍各执行一次。

## 设计逻辑

仅合并 OS、arch、runner 能力和运行环境完全一致的测试。Starry、ArceOS、Axvisor loongarch64、Intel VMX/ACPI、Axloader 和物理板卡任务继续保持独立，避免扩大故障域或形成新的长尾。组合命令仍由 reusable workflow 的 `bash -e -o pipefail` 执行，任一子测试失败都会立即终止当前任务。

## 验证

- `python3 scripts/test/check_ci_paths.py`
- `python3 scripts/test/check_ci_routing.py`
- `cargo fmt --all --check`
- `git diff --check`
- 与最新 `origin/dev` 对比，相关 Axvisor/axtest/RISC-V cross-test 命令多重集合一致
- `test_checks` matrix 项计数为 27

rebase 前的完整 CI 已验证四个组合任务及全部板卡任务成功；最新 head 的远端 CI 将再次确认冲突解决后的完整结果。
