### PR TITLE
fix(starry-process): canonicalize racing process groups

### DIFF
--- a/components/starry-process/src/process.rs
+++ b/components/starry-process/src/process.rs
@@ -154,7 +154,7 @@ impl Process {
         }
 
         let new_session = Session::new(self.pid);
-        let new_group = ProcessGroup::new(self.pid, &new_session);
+        let new_group = ProcessGroup::get_or_create(self.pid, &new_session);
         self.set_group(&new_group);
 
         Some((new_session, new_group))
@@ -174,7 +174,7 @@ impl Process {
             return None;
         }
 
-        let new_group = ProcessGroup::new(self.pid, &self.group.lock().session);
+        let new_group = ProcessGroup::get_or_create(self.pid, &self.group.lock().session);
         self.set_group(&new_group);
 
         Some(new_group)
@@ -360,7 +360,7 @@ impl Process {
         let group = parent.map_or_else(
             || {
                 let session = Session::new(pid);
-                ProcessGroup::new(pid, &session)
+                ProcessGroup::get_or_create(pid, &session)
             },
             |p| p.group(),
         );

--- a/components/starry-process/src/process_group.rs
+++ b/components/starry-process/src/process_group.rs
@@ -17,15 +17,24 @@ pub struct ProcessGroup {
 }
 
 impl ProcessGroup {
-    /// Create a new [`ProcessGroup`] within a [`Session`].
-    pub(crate) fn new(pgid: Pid, session: &Arc<Session>) -> Arc<Self> {
+    /// Returns the canonical live process group for `pgid` in `session`.
+    ///
+    /// The session registry serializes process-group creation so that racing
+    /// parent and child `setpgid()` calls converge on one group identity.
+    pub(crate) fn get_or_create(pgid: Pid, session: &Arc<Session>) -> Arc<Self> {
         let group = Arc::new(Self {
             pgid,
             session: session.clone(),
             processes: SpinNoIrq::new(WeakMap::new()),
         });
-        session.process_groups.lock().insert(pgid, &group);
-        group
+
+        let mut groups = session.process_groups.lock();
+        if let Some(existing) = groups.get(&pgid) {
+            existing
+        } else {
+            groups.insert(pgid, &group);
+            group
+        }
     }
 }
 
@@ -54,5 +63,38 @@ impl fmt::Debug for ProcessGroup {
             self.pgid,
             self.session.sid()
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use std::{sync::Barrier, thread};
+
+    use super::*;
+
+    #[test]
+    fn duplicate_live_group_identity_reuses_the_session_group() {
+        let session = Session::new(7);
+        let start = Arc::new(Barrier::new(2));
+
+        let first_session = session.clone();
+        let first_start = start.clone();
+        let first = thread::spawn(move || {
+            first_start.wait();
+            ProcessGroup::get_or_create(11, &first_session)
+        });
+        let second = thread::spawn(move || {
+            start.wait();
+            ProcessGroup::get_or_create(11, &session)
+        });
+
+        let first = first.join().unwrap();
+        let second = second.join().unwrap();
+        let session = first.session();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(session.process_groups().len(), 1);
     }
 }


### PR DESCRIPTION
## 问题

PR #1775 中包含一项进程组身份修复，但其原始提交依赖后续的关系事务框架，不能直接 cherry-pick 到当前 `dev`。

当前 `starry-process` 的 `ProcessGroup::new` 每次都会创建新的 `Arc<ProcessGroup>`，再无条件覆盖 `Session::process_groups` 中相同 PGID 的条目。当父进程与子进程同时对同一个子进程执行 `setpgid(child, child)` / `setpgid(0, 0)` 时，两边可能得到 PGID 相同但对象不同的进程组。随后全局注册表、进程自身持有的 group 以及成员表可能分别指向不同对象，导致进程组查询、信号广播和 TTY job control 观察到不一致的成员关系。

Linux v7.1 的 `setpgid` 在 `tasklist_lock` 写锁下完成查找和进程组变更，保证同一 session 中一个 PGID 只有一个有效身份。当前 `dev` 缺少对应的创建串行化。

## 修改

- 将 `ProcessGroup::new` 收敛为 `ProcessGroup::get_or_create`。
- 以 `Session::process_groups` 作为进程组身份的唯一注册表，在同一把 `SpinNoIrq` 锁内完成“复用 live group 或插入新 group”的决策。
- 更新 session 创建、进程组创建和 init 进程初始化三个调用点。
- 增加双线程确定性回归测试，两个线程同时请求相同 `(Session, PGID)`，要求返回同一个 `Arc` 且注册表中只有一个 live group。

候选对象仍在锁外分配；锁内只进行 weak-map lookup/insert。已过期的 weak entry 会被新对象替换，已有 live entry 则直接返回其 `Arc`。

本 PR 只修复同一 session/PGID 的 canonical identity，不扩展到 #1775 后续的完整关系事务重构；既存的跨组 membership 事务和并发 `setsid` 状态转换不在本次范围内。

## 回归证明

同一测试 `duplicate_live_group_identity_reuses_the_session_group` 使用真实双线程和 barrier：

- 临时恢复旧的无条件创建/覆盖逻辑后，`cargo test -p starry-process duplicate_live_group_identity_reuses_the_session_group -- --nocapture` 必然在 `Arc::ptr_eq(&first, &second)` 失败。
- 恢复本修复后，同一命令通过。

没有在 `test-suit/starryos` 新增概率型竞态用例：错误状态是内核内部两个 `Arc` 身份分裂，用户态无法在不加入测试 hook 的情况下确定性强制两个创建点交错。回归因此放在拥有该不变量的最低层真实实现中；现有 Starry QEMU session syscall 用例继续验证用户态 ABI。

## 验证

- `cargo fmt --all --check`
- `cargo test -p starry-process`：28 passed
- `cargo xtask clippy --package starry-process`：1 package / 1 check passed
- `cargo xtask starry test qemu --arch riscv64 -c qemu/syscall-test-session-syscalls`：17 passed / 0 failed，grouped case 通过

以上验证在 rebase 到 `origin/dev` `890a82b5b` 后重新执行。

## Syscall / ABI 映射

| Syscall / 接口 | 结论 | 对应标准 | 简要依据 |
| --- | --- | --- | --- |
| `setpgid` | 修复竞态 | [POSIX `setpgid`](https://pubs.opengroup.org/onlinepubs/9799919799/functions/setpgid.html)、[Linux v7.1 `setpgid`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/sys.c#L1114-L1191) | Linux 以 task-list 写锁串行化进程组身份和成员变更；本 PR 在 Starry 的 session identity authority 中串行化同 PGID 创建。 |
| `getpgid` | 无返回值语义变更；竞态后观察一致身份 | [`getpgid(2)`](https://man7.org/linux/man-pages/man2/getpgrp.2.html)、[Linux v7.1 `getpgid`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/sys.c#L1193-L1222) | 数值 PGID 规则未改；避免查询落到被覆盖的重复 group。 |
| `getpgrp` | 无返回值语义变更；竞态后观察一致身份 | [`getpgrp(2)`](https://man7.org/linux/man-pages/man2/getpgrp.2.html)、[Linux v7.1 `getpgrp`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/sys.c#L1224-L1231) | 与 `getpgid(0)` 相同的数值语义，修复仅消除内部重复对象。 |
| `setsid` | 行为不变 | [`setsid(2)`](https://man7.org/linux/man-pages/man2/setsid.2.html)、[Linux v7.1 `setsid`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/sys.c#L1270-L1305) | 调用点改用统一 factory；新 session 的 group registry 初始为空，因此仍创建 PID 对应的新 group。 |
| `getsid` | 行为不变 | [`getsid(2)`](https://man7.org/linux/man-pages/man2/getsid.2.html)、[Linux v7.1 `getsid`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/sys.c#L1233-L1257) | Session ID 计算未改。 |
| `kill`（`pid == 0` / `pid < -1`） | 竞态后进程组广播成员一致 | [`kill(2)`](https://man7.org/linux/man-pages/man2/kill.2.html)、[Linux v7.1 group dispatch](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/signal.c#L1565-L1594) | 避免同 PGID 的成员被分散在两个 group 对象中；信号权限和返回值规则未改。 |
| `pidfd_send_signal`（process-group scope） | 竞态后进程组广播成员一致 | [`pidfd_send_signal(2)`](https://man7.org/linux/man-pages/man2/pidfd_send_signal.2.html) | scope、权限和 siginfo 校验未改，只确保由目标进程解析到 canonical group。 |
| `getpriority` / `setpriority`（`PRIO_PGRP`） | 竞态后组成员枚举一致 | [`getpriority(2)` / `setpriority(2)`](https://man7.org/linux/man-pages/man2/getpriority.2.html) | priority 和 errno 规则未改；全局 PGID lookup 不再可能指向被覆盖的重复 group。 |
| `ioctl`（`TIOCGPGRP` / `TIOCSPGRP` 及前台组信号） | 竞态后前台组身份与成员一致 | [`TIOCGPGRP(2const)`](https://man7.org/linux/man-pages/man2/TIOCGPGRP.2const.html)、[`TIOCSPGRP(2const)`](https://man7.org/linux/man-pages/man2/TIOCSPGRP.2const.html) | TTY session/foreground-group 校验和返回值未改；消除相同 PGID 的重复 `Arc` 身份。 |
| `wait4` / `waitid`（PGID 过滤） | 行为不变 | [`wait(2)`](https://man7.org/linux/man-pages/man2/wait.2.html)、[`waitid(2)`](https://man7.org/linux/man-pages/man2/waitid.2.html) | Starry 按数值 PGID 匹配 child，本修复不改变数值或等待状态。 |

## 功能开发流程

`book/guideline/feature-development.md` 不适用：这是对现有 Linux `setpgid` 并发语义的缺陷修复，没有新增用户可见能力、公共接口或平台支持。

来源：从 #1775 的 `fix(starry-process): canonicalize racing process groups` 中提取，并按当前 `dev` 的旧版 `starry-process` 边界做最小适配。
