### PR TITLE
fix(starry-kernel): preserve netlink sockopt writeback order

### DIFF
--- a/os/StarryOS/kernel/src/syscall/net/opt.rs
+++ b/os/StarryOS/kernel/src/syscall/net/opt.rs
@@ -10,7 +10,7 @@ use linux_raw_sys::net::{
     TCPI_OPT_ECN, TCPI_OPT_ECN_SEEN, TCPI_OPT_SACK, TCPI_OPT_SYN_DATA, TCPI_OPT_TIMESTAMPS,
     TCPI_OPT_WSCALE, socklen_t, tcp_info,
 };
-use starry_vm::vm_write_slice;
+use starry_vm::{VmMutPtr, VmPtr, vm_write_slice};
 
 use crate::{
     file::{FileLike, Socket, netlink::NetlinkSocket},
@@ -319,15 +319,46 @@ pub fn sys_getsockopt(
     optval: UserPtr<u8>,
     optlen: UserPtr<socklen_t>,
 ) -> AxResult<isize> {
-    let optlen = optlen.get_as_mut()?;
+    let optlen_ptr = optlen.as_ptr();
+    let initial_optlen = optlen_ptr.vm_read()?;
     debug!(
         "sys_getsockopt <= fd: {}, level: {}, optname: {}, optval: {:?}, optlen: {}",
         fd,
         level,
         optname,
         optval.address(),
-        optlen,
+        initial_optlen,
     );
+
+    fn write_fixed<T: bytemuck::NoUninit>(
+        val: UserPtr<u8>,
+        len_ptr: *mut socklen_t,
+        len: socklen_t,
+        value: T,
+    ) -> AxResult<()> {
+        if (len as usize) < size_of::<T>() {
+            return Err(AxError::InvalidInput);
+        }
+        val.as_ptr().cast::<T>().vm_write(value)?;
+        len_ptr.vm_write(size_of::<T>() as socklen_t)?;
+        Ok(())
+    }
+
+    if let Ok(socket) = NetlinkSocket::from_fd(fd) {
+        use linux_raw_sys::net::{SO_REUSEADDR, SOL_SOCKET};
+
+        if (level, optname) == (SOL_SOCKET, SO_REUSEADDR) {
+            write_fixed(
+                optval,
+                optlen_ptr,
+                initial_optlen,
+                i32::from(socket.reuse_address()),
+            )?;
+            return Ok(0);
+        }
+    }
+
+    let optlen = optlen.get_as_mut()?;
 
     fn get<'a, T: 'static>(val: UserPtr<u8>, len: &mut socklen_t) -> AxResult<&'a mut T> {
         if (*len as usize) < size_of::<T>() {
@@ -335,15 +366,6 @@ pub fn sys_getsockopt(
         }
         *len = size_of::<T>() as socklen_t;
         val.cast().get_as_mut()
-    }
-
-    if let Ok(socket) = NetlinkSocket::from_fd(fd) {
-        use linux_raw_sys::net::{SO_REUSEADDR, SOL_SOCKET};
-
-        if (level, optname) == (SOL_SOCKET, SO_REUSEADDR) {
-            *get::<i32>(optval, optlen)? = i32::from(socket.reuse_address());
-            return Ok(0);
-        }
     }
 
     let socket = Socket::from_fd(fd)?;

--- a/test-suit/starryos/qemu/system/bugfix-netlink-uevent-reuseaddr/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-netlink-uevent-reuseaddr/src/main.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 #ifndef AF_NETLINK
@@ -62,6 +63,33 @@ static void expect_reuseaddr_enabled(int fd, const char *name)
     failed++;
 }
 
+static void expect_reuseaddr_alias_writeback(int fd, const char *name)
+{
+    socklen_t shared = sizeof(int);
+
+    errno = 0;
+    long result = syscall(SYS_getsockopt,
+                          fd,
+                          SOL_SOCKET,
+                          SO_REUSEADDR,
+                          &shared,
+                          &shared);
+    if (result == 0 && shared == sizeof(int) && errno == 0) {
+        printf("PASS: %s\n", name);
+        passed++;
+        return;
+    }
+
+    printf("FAIL: %s: result=%ld final=%u expected=%zu errno=%d (%s)\n",
+           name,
+           result,
+           (unsigned int)shared,
+           sizeof(int),
+           errno,
+           strerror(errno));
+    failed++;
+}
+
 static void check_netlink_listener(int protocol,
                                    unsigned int groups,
                                    const char *socket_name,
@@ -84,6 +112,7 @@ static void check_netlink_listener(int protocol,
     expect_zero(setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enabled, sizeof(enabled)),
                 reuseaddr_name);
     expect_reuseaddr_enabled(fd, reuseaddr_get_name);
+    expect_reuseaddr_alias_writeback(fd, "get SO_REUSEADDR with aliased value and length");
 
     struct sockaddr_nl address = {
         .nl_family = AF_NETLINK,


### PR DESCRIPTION
## 问题

PR #1775 中的 `f5d39f971c50b68237a03951182a422ec3d59d46` 修复了 netlink `SO_REUSEADDR` 的安全写回，但它依赖该 PR 内尚未进入 `dev` 的大范围用户指针重构，无法直接 cherry-pick。

当前 `dev` 会先把 `optlen` 转成长期 `&mut`，再通过 `get` 先写长度、后写选项值。当 `optval` 与 `optlen` 指向同一地址时，这既会形成重叠的 Rust 可变引用，也会让最终值停留在选项值 `1`。Linux v7.1 的 [`sk_getsockopt`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/net/core/sock.c#L2169-L2177) 按相反顺序先写 `optval`、再写 `optlen`，因此同一输入的最终值为长度 `4`。

## 修改

- 仅在 netlink `SOL_SOCKET/SO_REUSEADDR` 路径使用现有 `VmPtr`/`VmMutPtr` 拷贝接口：先把用户长度读到内核局部值，不创建可能与 `optval` 重叠的 `&mut`。
- 新增 `write_fixed`，校验调用方容量后先写选项值，再写实际长度；用 `NoUninit` 限制可复制类型，避免复制未初始化 padding。
- 非 netlink `getsockopt` 路径继续使用原有 helper，保持本次提取范围最小。
- 在现有 route/uevent netlink 系统用例中增加直接 `syscall(SYS_getsockopt, ..., &shared, &shared)` 回归，覆盖两个 netlink 协议。

## 逻辑

用户指针允许重叠，内核不能据此构造同时存活的独占 Rust 引用。将输入长度复制到局部值后，两个用户写操作成为按顺序执行的短生命周期拷贝；即使地址相同，第二次长度写回也会像 Linux 一样覆盖第一次选项值写回。

## 验证

- 未修复 `dev`：`cargo xtask starry test qemu --arch riscv64 -c qemu/system/bugfix-netlink-uevent-reuseaddr` 确定性失败，两次同址调用均得到 `final=1 expected=4`，外层 runner 返回失败。
- 修复后及 rebase 到最新 `origin/dev` 后：同一命令均通过，`10 passed, 0 failed`。
- `cargo xtask clippy --package starry-kernel`：25/25 配置通过。
- `cargo fmt --check`：通过。
- Linux 6.8 host 上用相同直接 syscall 输入验证：返回 0，最终共享值为 4。

## Syscall 标准映射

| Syscall | 结论 | 对应标准 | 依据 |
| --- | --- | --- | --- |
| `getsockopt` | 修复 netlink `SO_REUSEADDR` 的同址写回顺序 | [`getsockopt(2)`](https://man7.org/linux/man-pages/man2/getsockopt.2.html)、[Linux v7.1 `sk_getsockopt`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/net/core/sock.c#L1752-L1770)、[Linux 写回顺序](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/net/core/sock.c#L2169-L2177) | 先读取输入长度，成功时先写选项值、再写实际长度；直接 syscall 差分测试覆盖重叠指针。 |

## 关联

- 提取来源：#1775 的 `f5d39f9` 修复意图。
- #1923 也修改同一 netlink 分支以增加 socket introspection，但当前 head 仍保留旧的 `*get(...)` 写法，未包含本修复；后合并的一方需要 rebase 或保留这里的有序写回。