### PR TITLE
perf(net): optimize RTL8125 data path and polling

### DIFF
--- a/apps/starry/iperf3/README.md
+++ b/apps/starry/iperf3/README.md
@@ -19,6 +19,6 @@ downloads and starts the benchmark script. The xtask command therefore needs
 neither a fixed IP address nor a separate board launcher.
 
 The benchmark profile is intentionally fixed: 10 seconds, a 2-second omit,
-128K application blocks, three rounds, and a 5-second cooldown after each
+128K application blocks, three rounds, and a 15-second cooldown after each
 connection so TCP teardown from one round cannot affect the next.
 `native-network-smoke` remains the short CI-oriented connectivity check.

--- a/apps/starry/iperf3/README.md
+++ b/apps/starry/iperf3/README.md
@@ -19,6 +19,6 @@ downloads and starts the benchmark script. The xtask command therefore needs
 neither a fixed IP address nor a separate board launcher.
 
 The benchmark profile is intentionally fixed: 10 seconds, a 2-second omit,
-128K application blocks, three rounds, and a 15-second cooldown after each
+128K application blocks, three rounds, and a 5-second cooldown after each
 connection so TCP teardown from one round cannot affect the next.
 `native-network-smoke` remains the short CI-oriented connectivity check.

--- a/apps/starry/iperf3/iperf-bench.sh
+++ b/apps/starry/iperf3/iperf-bench.sh
@@ -5,7 +5,7 @@ duration=10
 omit=2
 block_size=128K
 rounds=3
-cooldown=15
+cooldown=5
 result_dir=/tmp/starry-iperf3-bench
 summary_file=$result_dir/summary
 
@@ -43,6 +43,13 @@ read_receiver_mbps() {
 }
 
 print_command() {
+    case "$case_mode" in
+        tx) case_direction=TX ;;
+        rx) case_direction=RX ;;
+        bidir) case_direction=TX/RX ;;
+    esac
+
+    printf '类别：%s %s\n' "$case_category" "$case_direction"
     printf 'Command: iperf3 -c %s -t %s -O %s -P %s -l %s' \
         "$server_ip" "$duration" "$omit" "$case_streams" "$block_size"
     case "$case_mode" in
@@ -121,8 +128,8 @@ summarize_direction() {
     summary_median=$(sort -n "$summary_samples" | sed -n '2p')
 
     printf '\nMedian %-6s %10s Mbps\n' "DUT $summary_direction:" "$summary_median"
-    printf '%s|%s|%s|%s|%s|%s|%s\n' \
-        "$case_id" "$case_label" "$summary_direction" \
+    printf '%s|%s|%s|%s|%s|%s|%s|%s\n' \
+        "$case_id" "$case_category" "$case_label" "$summary_direction" \
         "$summary_run_1" "$summary_run_2" "$summary_run_3" "$summary_median" \
         >>"$summary_file"
     printf 'STARRY_IPERF3_BENCH_RESULT case=%s direction=%s median_mbps=%s\n' \
@@ -131,9 +138,10 @@ summarize_direction() {
 
 run_case() {
     case_id=$1
-    case_label=$2
-    case_mode=$3
-    case_streams=$4
+    case_category=$2
+    case_label=$3
+    case_mode=$4
+    case_streams=$5
 
     : >"$result_dir/$case_id-TX.samples"
     : >"$result_dir/$case_id-RX.samples"
@@ -163,18 +171,22 @@ print_summary() {
     printf '\n============================================================\n'
     printf 'iperf3 benchmark summary (Mbps)\n'
     printf '============================================================\n\n'
-    printf '%-4s %-29s %-4s %10s %10s %10s %10s\n' \
-        Case Scenario Dir Run1 Run2 Run3 Median
-    printf '%-4s %-29s %-4s %10s %10s %10s %10s\n' \
-        ---- ----------------------------- ---- ---------- ---------- ---------- ----------
+    printf '%-4s %-8s %-29s %-4s %10s %10s %10s %10s\n' \
+        Case Category Scenario Dir Run1 Run2 Run3 Median
+    printf '%-4s %-8s %-29s %-4s %10s %10s %10s %10s\n' \
+        ---- -------- ----------------------------- ---- \
+        ---------- ---------- ---------- ----------
 
-    while IFS='|' read -r summary_case summary_label summary_direction \
-        summary_run_1 summary_run_2 summary_run_3 summary_median; do
-        printf '%-4s %-29s %-4s %10s %10s %10s %10s\n' \
-            "$summary_case" "$summary_label" "$summary_direction" \
+    while IFS='|' read -r summary_case summary_category summary_label \
+        summary_direction summary_run_1 summary_run_2 summary_run_3 \
+        summary_median; do
+        printf '%-4s %-8s %-29s %-4s %10s %10s %10s %10s\n' \
+            "$summary_case" "$summary_category" "$summary_label" \
+            "$summary_direction" \
             "$summary_run_1" "$summary_run_2" "$summary_run_3" "$summary_median"
     done <"$summary_file"
 
+    printf '\n注：TX 表示板端发送、宿主机接收；RX 表示宿主机发送、板端接收。\n'
     printf '\nSTARRY_IPERF3_BENCH_PASSED\n'
 }
 
@@ -193,13 +205,13 @@ main() {
     printf 'Profile: 10 seconds, 2-second omit, 128K block, 3 rounds\n'
     printf 'Isolation: %s-second cooldown after every connection\n' "$cooldown"
 
-    run_case T01 "Single-stream DUT TX" tx 1
-    run_case T02 "Single-stream DUT RX" rx 1
-    run_case T03 "Single-stream bidirectional" bidir 1
-    run_case T04 "2-stream DUT TX" tx 2
-    run_case T05 "4-stream DUT TX" tx 4
-    run_case T06 "8-stream DUT TX" tx 8
-    run_case T07 "4-stream DUT RX" rx 4
+    run_case T01 "单流单向" "Single-stream DUT TX" tx 1
+    run_case T02 "单流单向" "Single-stream DUT RX" rx 1
+    run_case T03 "单流双向" "Single-stream bidirectional" bidir 1
+    run_case T04 "双流单向" "2-stream DUT TX" tx 2
+    run_case T05 "四流单向" "4-stream DUT TX" tx 4
+    run_case T06 "八流单向" "8-stream DUT TX" tx 8
+    run_case T07 "四流单向" "4-stream DUT RX" rx 4
 
     print_summary
 }

--- a/apps/starry/iperf3/iperf-bench.sh
+++ b/apps/starry/iperf3/iperf-bench.sh
@@ -5,7 +5,7 @@ duration=10
 omit=2
 block_size=128K
 rounds=3
-cooldown=5
+cooldown=15
 result_dir=/tmp/starry-iperf3-bench
 summary_file=$result_dir/summary
 

--- a/drivers/interface/rdif-eth/src/lib.rs
+++ b/drivers/interface/rdif-eth/src/lib.rs
@@ -103,6 +103,59 @@ pub struct QueueConfig {
     pub ring_size: usize,
 }
 
+/// Transport checksums a transmit queue can calculate for complete packets.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TxChecksumCapabilities(u8);
+
+impl TxChecksumCapabilities {
+    const TCP: u8 = 1 << 0;
+    const UDP: u8 = 1 << 1;
+
+    /// The queue does not calculate transport checksums.
+    pub const NONE: Self = Self(0);
+    /// The queue calculates TCP and UDP checksums for IPv4 and IPv6 packets.
+    pub const TCP_UDP: Self = Self(Self::TCP | Self::UDP);
+
+    /// Retains only checksum operations supported by both queues.
+    pub const fn intersection(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+
+    /// Returns whether TCP checksum calculation is supported.
+    pub const fn supports_tcp(self) -> bool {
+        self.0 & Self::TCP != 0
+    }
+
+    /// Returns whether UDP checksum calculation is supported.
+    pub const fn supports_udp(self) -> bool {
+        self.0 & Self::UDP != 0
+    }
+}
+
+/// Network protocol containing a transport checksum requested from hardware.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TxNetworkProtocol {
+    Ipv4,
+    Ipv6,
+}
+
+/// Transport protocol whose checksum hardware must calculate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TxTransportProtocol {
+    Tcp,
+    Udp,
+}
+
+/// Per-packet transmit checksum request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct TxChecksumOffload {
+    pub network: TxNetworkProtocol,
+    pub transport: TxTransportProtocol,
+    /// Byte offset of the transport header from the start of the L2 frame.
+    pub transport_offset: u16,
+}
+
 /// Move-only DMA ownership token passed between a runtime and one driver queue.
 ///
 /// The token uniquely owns CPU access to the mapped range while it is outside
@@ -684,6 +737,39 @@ pub trait WifiControl: Send + 'static {
 // Transmit queue
 // ---------------------------------------------------------------------------
 
+/// Hardware-notification policy for one transmit submission.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum TxNotify {
+    /// Make the submitted descriptor visible to the device immediately.
+    #[default]
+    Immediate,
+    /// Defer notification until [`ITxQueue::flush`] is called.
+    Deferred,
+}
+
+/// Per-packet options passed across the runtime transmit boundary.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TxSubmitOptions {
+    pub checksum: Option<TxChecksumOffload>,
+    pub notify: TxNotify,
+}
+
+impl TxSubmitOptions {
+    pub const fn immediate(checksum: Option<TxChecksumOffload>) -> Self {
+        Self {
+            checksum,
+            notify: TxNotify::Immediate,
+        }
+    }
+
+    pub const fn deferred(checksum: Option<TxChecksumOffload>) -> Self {
+        Self {
+            checksum,
+            notify: TxNotify::Deferred,
+        }
+    }
+}
+
 /// Transmit queue interface.
 ///
 /// A driver moves one TX queue into each [`NetPollGroupParts`].
@@ -694,6 +780,11 @@ pub trait ITxQueue: Send + 'static {
     /// DMA buffer configuration for this queue.
     fn config(&self) -> QueueConfig;
 
+    /// Returns transport checksums this queue can calculate.
+    fn checksum_capabilities(&self) -> TxChecksumCapabilities {
+        TxChecksumCapabilities::NONE
+    }
+
     /// Submit a DMA buffer for transmission.
     ///
     /// `bus_addr` must point to a DMA-capable buffer whose first `len` bytes
@@ -701,6 +792,26 @@ pub trait ITxQueue: Send + 'static {
     /// [`NetError::LinkDown`] failure must have a future queue or link event
     /// that can wake the fixed-CPU poll owner after it rearms IRQs.
     fn submit(&mut self, buffer: DmaBuffer) -> Result<(), SubmitError>;
+
+    /// Submits a buffer with checksum and device-notification options.
+    ///
+    /// The default rejects checksum requests and otherwise preserves the
+    /// existing immediate-notification behavior. A rejected submission must
+    /// return the original move-only token to the runtime.
+    fn submit_with_options(
+        &mut self,
+        buffer: DmaBuffer,
+        options: TxSubmitOptions,
+    ) -> Result<(), SubmitError> {
+        if options.checksum.is_some() {
+            Err(SubmitError::new(buffer, NetError::NotSupported))
+        } else {
+            self.submit(buffer)
+        }
+    }
+
+    /// Makes all deferred descriptors visible to the device.
+    fn flush(&mut self) {}
 
     /// Reclaim the next completed transmit buffer.
     ///

--- a/drivers/net/rd-net/src/lib.rs
+++ b/drivers/net/rd-net/src/lib.rs
@@ -61,10 +61,30 @@ impl TxQueue {
         self.config.ring_size.saturating_sub(1)
     }
 
+    /// Returns transport checksums this queue can calculate.
+    pub fn checksum_capabilities(&self) -> TxChecksumCapabilities {
+        self.queue.checksum_capabilities()
+    }
+
     /// Transfers one prepared token to the device.
     pub fn submit(&mut self, buffer: DmaBuffer) -> Result<(), SubmitError> {
         buffer.prepare_for_device();
         self.queue.submit(buffer)
+    }
+
+    /// Transfers one prepared token with checksum and notification options.
+    pub fn submit_with_options(
+        &mut self,
+        buffer: DmaBuffer,
+        options: TxSubmitOptions,
+    ) -> Result<(), SubmitError> {
+        buffer.prepare_for_device();
+        self.queue.submit_with_options(buffer, options)
+    }
+
+    /// Makes all deferred submissions visible to the device.
+    pub fn flush(&mut self) {
+        self.queue.flush();
     }
 
     /// Reclaims one completed token from the device.
@@ -100,6 +120,11 @@ impl RxQueue {
     /// Returns the number of buffers the queue can own concurrently.
     pub fn capacity(&self) -> usize {
         self.config.ring_size.saturating_sub(1)
+    }
+
+    /// Allocates one queue-compatible token for replacement-before-delivery.
+    pub fn allocate_replacement(&self) -> Result<DmaBuffer, NetError> {
+        self.pool.allocate(self.config.buf_size)
     }
 
     /// Posts fresh buffers up to `budget` or until the queue reaches capacity.
@@ -365,6 +390,31 @@ mod tests {
 
     struct RetryRxQueue;
 
+    struct PlainTxQueue;
+
+    impl ITxQueue for PlainTxQueue {
+        fn id(&self) -> NetQueueId {
+            NetQueueId::new(0)
+        }
+
+        fn config(&self) -> QueueConfig {
+            QueueConfig {
+                dma_mask: u64::MAX,
+                align: 64,
+                buf_size: 256,
+                ring_size: 2,
+            }
+        }
+
+        fn submit(&mut self, _buffer: DmaBuffer) -> Result<(), SubmitError> {
+            panic!("a checksum request must not fall through to plain submit")
+        }
+
+        fn reclaim(&mut self) -> Option<DmaBuffer> {
+            None
+        }
+    }
+
     impl IRxQueue for RetryRxQueue {
         fn id(&self) -> NetQueueId {
             NetQueueId::new(0)
@@ -430,6 +480,31 @@ mod tests {
             ),
             &DMA,
         )
+    }
+
+    #[test]
+    fn unsupported_checksum_submission_returns_the_move_only_token() {
+        let config = PlainTxQueue.config();
+        let pool = make_pool(&test_device_dma(), config, DmaDirection::ToDevice).unwrap();
+        let buffer = pool.allocate(128).unwrap();
+        let bus_addr = buffer.bus_addr();
+        let mut tx = TxQueue::new(Box::new(PlainTxQueue));
+
+        let error = tx
+            .submit_with_options(
+                buffer,
+                TxSubmitOptions::immediate(Some(TxChecksumOffload {
+                    network: TxNetworkProtocol::Ipv4,
+                    transport: TxTransportProtocol::Tcp,
+                    transport_offset: 34,
+                })),
+            )
+            .unwrap_err();
+        let (buffer, reason) = error.into_parts();
+
+        assert!(matches!(reason, NetError::NotSupported));
+        assert_eq!(buffer.bus_addr(), bus_addr);
+        assert_eq!(buffer.len(), 128);
     }
 
     #[test]

--- a/drivers/net/realtek-rtl8125/src/descriptor.rs
+++ b/drivers/net/realtek-rtl8125/src/descriptor.rs
@@ -1,7 +1,16 @@
+use rdif_eth::{TxChecksumOffload, TxNetworkProtocol, TxTransportProtocol};
+
 pub const DESC_OWN: u32 = 1 << 31;
 pub const RING_END: u32 = 1 << 30;
 pub const FIRST_FRAG: u32 = 1 << 29;
 pub const LAST_FRAG: u32 = 1 << 28;
+
+const TX_TRANSPORT_OFFSET_SHIFT: u32 = 18;
+const TX_TRANSPORT_OFFSET_MAX: u16 = 0x03ff;
+const TX_IPV6_CHECKSUM: u32 = 1 << 28;
+const TX_IPV4_CHECKSUM: u32 = 1 << 29;
+const TX_TCP_CHECKSUM: u32 = 1 << 30;
+const TX_UDP_CHECKSUM: u32 = 1 << 31;
 
 pub const RX_RES: u32 = 1 << 21;
 pub const RX_RUNT: u32 = 1 << 20;
@@ -19,16 +28,34 @@ pub struct TxDesc {
 }
 
 impl TxDesc {
-    pub fn new_cpu_owned(addr: u64, len: usize, ring_end: bool) -> Self {
+    pub fn new_cpu_owned(
+        addr: u64,
+        len: usize,
+        ring_end: bool,
+        checksum: Option<TxChecksumOffload>,
+    ) -> Option<Self> {
         let mut opts1 = FIRST_FRAG | LAST_FRAG | len as u32;
         if ring_end {
             opts1 |= RING_END;
         }
-        Self {
-            opts1,
-            opts2: 0,
-            addr,
-        }
+        let opts2 = match checksum {
+            None => 0,
+            Some(checksum) if checksum.transport_offset <= TX_TRANSPORT_OFFSET_MAX => {
+                let network = match checksum.network {
+                    TxNetworkProtocol::Ipv4 => TX_IPV4_CHECKSUM,
+                    TxNetworkProtocol::Ipv6 => TX_IPV6_CHECKSUM,
+                };
+                let transport = match checksum.transport {
+                    TxTransportProtocol::Tcp => TX_TCP_CHECKSUM,
+                    TxTransportProtocol::Udp => TX_UDP_CHECKSUM,
+                };
+                network
+                    | transport
+                    | (u32::from(checksum.transport_offset) << TX_TRANSPORT_OFFSET_SHIFT)
+            }
+            Some(_) => return None,
+        };
+        Some(Self { opts1, opts2, addr })
     }
 
     pub fn release_to_hw(mut self) -> Self {
@@ -86,5 +113,46 @@ impl RxDesc {
     pub fn packet_len(&self) -> usize {
         let len = (self.opts1 & RX_PACKET_LEN_MASK) as usize;
         len.saturating_sub(ETH_FCS_LEN)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rdif_eth::{TxChecksumOffload, TxNetworkProtocol, TxTransportProtocol};
+
+    use super::*;
+
+    #[test]
+    fn transmit_checksum_request_uses_csum_v2_descriptor_fields() {
+        let desc = TxDesc::new_cpu_owned(
+            0x1000,
+            1500,
+            false,
+            Some(TxChecksumOffload {
+                network: TxNetworkProtocol::Ipv4,
+                transport: TxTransportProtocol::Tcp,
+                transport_offset: 34,
+            }),
+        )
+        .expect("the checksum request must fit the descriptor");
+
+        assert_eq!(desc.opts2, (1 << 29) | (1 << 30) | (34 << 18));
+    }
+
+    #[test]
+    fn transmit_checksum_request_rejects_unrepresentable_offset() {
+        assert!(
+            TxDesc::new_cpu_owned(
+                0x1000,
+                1500,
+                false,
+                Some(TxChecksumOffload {
+                    network: TxNetworkProtocol::Ipv6,
+                    transport: TxTransportProtocol::Udp,
+                    transport_offset: 0x0400,
+                }),
+            )
+            .is_none()
+        );
     }
 }

--- a/drivers/net/realtek-rtl8125/src/lib.rs
+++ b/drivers/net/realtek-rtl8125/src/lib.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 use alloc::{boxed::Box, collections::VecDeque, sync::Arc, vec};
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use ax_sync::SpinLock as Mutex;
 use descriptor::{RING_END, RxDesc, TxDesc};
@@ -42,7 +43,6 @@ const TX_RECLAIM_LOG_INTERVAL: u64 = 64;
 const RX_RECLAIM_LOG_INTERVAL: u64 = 64;
 const RX_IDLE_LOG_INTERVAL: u64 = 262_144;
 const RX_OVERFLOW_REARM_IDLE_POLLS: u64 = 2048;
-const TX_LINK_SAMPLE_INTERVAL: u64 = 64;
 const OCP_STD_PHY_BASE: u32 = 0xa400;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -99,6 +99,7 @@ pub struct Rtl8125 {
     chip: ChipVersion,
     phy_ocp_base: u32,
     queue_start: QueueStart,
+    link_up: Arc<AtomicBool>,
 }
 
 impl Rtl8125 {
@@ -126,8 +127,10 @@ impl Rtl8125 {
             chip,
             phy_ocp_base: OCP_STD_PHY_BASE,
             queue_start: Arc::new(Mutex::new(QueueStartState::default())),
+            link_up: Arc::new(AtomicBool::new(false)),
         };
         dev.init()?;
+        dev.link_up.store(dev.regs.link_up(), Ordering::Release);
         info!(
             "RTL8125 device initialized: chip={:?}, xid={:#x}, \
              mac={:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}, status={:?}",
@@ -227,6 +230,7 @@ impl NetDevice for Rtl8125 {
             chip: _,
             phy_ocp_base: _,
             queue_start,
+            link_up,
         } = *self;
 
         let mut tx_desc = dma
@@ -255,10 +259,11 @@ impl NetDevice for Rtl8125 {
             buffers: core::array::from_fn(|_| None),
             next_submit: 0,
             next_reclaim: 0,
-            link_up: None,
+            link_up: Arc::clone(&link_up),
             link_down_drops: 0,
             submitted: 0,
             reclaimed: 0,
+            notification: queue::TxNotificationState::default(),
         };
 
         let rx_desc = dma
@@ -301,11 +306,12 @@ impl NetDevice for Rtl8125 {
                     regs,
                     _mmio,
                     queue_start,
+                    link_up: Arc::clone(&link_up),
                 }),
                 owner_startup: None,
                 irq_endpoints: vec![NetHardIrqEndpoint::new(
                     IRQ_SOURCE0,
-                    Box::new(Rtl8125IrqHandler { regs }),
+                    Box::new(Rtl8125IrqHandler { regs, link_up }),
                 )],
             }],
         })
@@ -316,6 +322,7 @@ struct Rtl8125IrqControl {
     regs: Regs,
     _mmio: Mmio,
     queue_start: QueueStart,
+    link_up: Arc<AtomicBool>,
 }
 
 impl NetPollIrqControl for Rtl8125IrqControl {
@@ -352,11 +359,15 @@ impl NetPollIrqControl for Rtl8125IrqControl {
             return Err(NetError::InvalidParts);
         }
 
-        let before = rtl8125_irq_snapshot(self.regs.read_interrupt_status());
+        let before_status = self.regs.read_interrupt_status();
+        let before = rtl8125_irq_snapshot(before_status);
         self.regs.write_interrupt_status(u32::MAX);
         self.regs.write_interrupt_mask(DEFAULT_IRQ_MASK);
         self.regs.commit();
         let after_status = self.regs.read_interrupt_status();
+        if irq_has_link_change(before_status | after_status) {
+            self.link_up.store(self.regs.link_up(), Ordering::Release);
+        }
         let pending = before.union(rtl8125_irq_snapshot(after_status));
         if pending == NetIrqSnapshot::empty() {
             Ok(NetRearmResult::Idle)
@@ -371,6 +382,7 @@ impl NetPollIrqControl for Rtl8125IrqControl {
 
 struct Rtl8125IrqHandler {
     regs: Regs,
+    link_up: Arc<AtomicBool>,
 }
 
 impl NetHardIrqHandler for Rtl8125IrqHandler {
@@ -379,6 +391,10 @@ impl NetHardIrqHandler for Rtl8125IrqHandler {
         let snapshot = rtl8125_irq_snapshot(status);
         if snapshot == NetIrqSnapshot::empty() {
             return NetHardIrqResult::Spurious;
+        }
+
+        if irq_has_link_change(status) {
+            self.link_up.store(self.regs.link_up(), Ordering::Release);
         }
 
         self.regs.write_interrupt_mask(0);

--- a/drivers/net/realtek-rtl8125/src/queue.rs
+++ b/drivers/net/realtek-rtl8125/src/queue.rs
@@ -1,18 +1,19 @@
 use alloc::{boxed::Box, collections::VecDeque, sync::Arc};
-use core::sync::atomic::{Ordering as AtomicOrdering, fence};
+use core::sync::atomic::{AtomicBool, Ordering as AtomicOrdering, fence};
 
 use ax_sync::SpinLock as Mutex;
 use dma_api::CoherentArray;
 use log::{debug, info, trace, warn};
 use rdif_eth::{
     DmaBuffer, IRxQueue, ITxQueue, NetError, NetQueueId, QueueConfig, RxCompletion, SubmitError,
+    TxChecksumCapabilities, TxNotify, TxSubmitOptions,
 };
 
 use crate::{
     DMA_ALIGN, EARLY_PACKET_LOG_COUNT, LINK_DOWN_DROP_LOG_INTERVAL, MAX_PACKET, QUEUE_ID0,
     QUEUE_SIZE, RX_BUF_SIZE, RX_DESC_PER_CACHE_LINE, RX_IDLE_LOG_INTERVAL,
     RX_OVERFLOW_REARM_IDLE_POLLS, RX_QUEUE_CONFIG_SIZE, RX_RECLAIM_LOG_INTERVAL,
-    RX_START_THRESHOLD, TX_LINK_SAMPLE_INTERVAL, TX_RECLAIM_LOG_INTERVAL, TX_SUBMIT_LOG_INTERVAL,
+    RX_START_THRESHOLD, TX_RECLAIM_LOG_INTERVAL, TX_SUBMIT_LOG_INTERVAL,
     descriptor::{RxDesc, TxDesc},
     read_status,
     registers::{Regs, irq_has_rx_overflow},
@@ -20,6 +21,30 @@ use crate::{
 };
 
 pub(crate) type QueueStart = Arc<Mutex<QueueStartState>>;
+
+#[derive(Default)]
+pub(crate) struct TxNotificationState {
+    pending: bool,
+}
+
+impl TxNotificationState {
+    fn descriptor_submitted(&mut self, notify: TxNotify) -> bool {
+        match notify {
+            TxNotify::Immediate => {
+                self.pending = false;
+                true
+            }
+            TxNotify::Deferred => {
+                self.pending = true;
+                false
+            }
+        }
+    }
+
+    fn take_pending(&mut self) -> bool {
+        core::mem::take(&mut self.pending)
+    }
+}
 
 #[derive(Default)]
 pub(crate) struct QueueStartState {
@@ -36,10 +61,11 @@ pub(crate) struct Rtl8125TxQueue {
     pub(crate) buffers: [Option<DmaBuffer>; QUEUE_SIZE],
     pub(crate) next_submit: usize,
     pub(crate) next_reclaim: usize,
-    pub(crate) link_up: Option<bool>,
+    pub(crate) link_up: Arc<AtomicBool>,
     pub(crate) link_down_drops: u64,
     pub(crate) submitted: u64,
     pub(crate) reclaimed: u64,
+    pub(crate) notification: TxNotificationState,
 }
 
 impl ITxQueue for Rtl8125TxQueue {
@@ -56,44 +82,26 @@ impl ITxQueue for Rtl8125TxQueue {
         }
     }
 
+    fn checksum_capabilities(&self) -> TxChecksumCapabilities {
+        TxChecksumCapabilities::TCP_UDP
+    }
+
     fn submit(&mut self, buffer: DmaBuffer) -> core::result::Result<(), SubmitError> {
-        if buffer.len() > MAX_PACKET {
-            return Err(SubmitError::new(buffer, NetError::NotSupported));
-        }
+        self.submit_buffer(buffer, TxSubmitOptions::default())
+    }
 
-        if !self.observe_link_before_tx(buffer.len()) {
-            self.link_down_drops = self.link_down_drops.saturating_add(1);
-            return Err(SubmitError::new(buffer, NetError::LinkDown));
-        }
+    fn submit_with_options(
+        &mut self,
+        buffer: DmaBuffer,
+        options: TxSubmitOptions,
+    ) -> core::result::Result<(), SubmitError> {
+        self.submit_buffer(buffer, options)
+    }
 
-        let idx = self.next_submit;
-        let next = (idx + 1) % QUEUE_SIZE;
-        if self.buffers[idx].is_some() {
-            return Err(SubmitError::new(buffer, NetError::Retry));
+    fn flush(&mut self) {
+        if self.notification.take_pending() {
+            self.notify_device();
         }
-
-        let ring_end = idx == QUEUE_SIZE - 1;
-        let len = buffer.len();
-        let desc = TxDesc::new_cpu_owned(buffer.bus_addr(), len, ring_end);
-        self.desc.set_cpu(idx, desc);
-        release_dma_descriptor();
-        self.desc.set_cpu(idx, desc.release_to_hw());
-        self.buffers[idx] = Some(buffer);
-        self.next_submit = next;
-        self.submitted = self.submitted.saturating_add(1);
-        self.regs.poll_tx();
-        if self.submitted <= EARLY_PACKET_LOG_COUNT
-            || self.submitted.is_multiple_of(TX_SUBMIT_LOG_INTERVAL)
-        {
-            trace!(
-                "RTL8125 tx submitted: idx={idx}, len={}, submitted={}, reclaimed={}, status={:?}",
-                len,
-                self.submitted,
-                self.reclaimed,
-                read_status(self.regs),
-            );
-        }
-        Ok(())
     }
 
     fn reclaim(&mut self) -> Option<DmaBuffer> {
@@ -123,16 +131,68 @@ impl ITxQueue for Rtl8125TxQueue {
 }
 
 impl Rtl8125TxQueue {
+    fn submit_buffer(
+        &mut self,
+        buffer: DmaBuffer,
+        options: TxSubmitOptions,
+    ) -> core::result::Result<(), SubmitError> {
+        if buffer.len() > MAX_PACKET {
+            return Err(SubmitError::new(buffer, NetError::NotSupported));
+        }
+
+        if !self.observe_link_before_tx(buffer.len()) {
+            self.link_down_drops = self.link_down_drops.saturating_add(1);
+            return Err(SubmitError::new(buffer, NetError::LinkDown));
+        }
+
+        let idx = self.next_submit;
+        let next = (idx + 1) % QUEUE_SIZE;
+        if self.buffers[idx].is_some() {
+            return Err(SubmitError::new(buffer, NetError::Retry));
+        }
+
+        let ring_end = idx == QUEUE_SIZE - 1;
+        let len = buffer.len();
+        let Some(desc) = TxDesc::new_cpu_owned(buffer.bus_addr(), len, ring_end, options.checksum)
+        else {
+            return Err(SubmitError::new(buffer, NetError::NotSupported));
+        };
+        self.desc.set_cpu(idx, desc);
+        release_dma_descriptor();
+        self.desc.set_cpu(idx, desc.release_to_hw());
+        self.buffers[idx] = Some(buffer);
+        self.next_submit = next;
+        self.submitted = self.submitted.saturating_add(1);
+        if self.notification.descriptor_submitted(options.notify) {
+            self.notify_device();
+        }
+        if self.submitted <= EARLY_PACKET_LOG_COUNT
+            || self.submitted.is_multiple_of(TX_SUBMIT_LOG_INTERVAL)
+        {
+            trace!(
+                "RTL8125 tx submitted: idx={idx}, len={}, submitted={}, reclaimed={}, status={:?}",
+                len,
+                self.submitted,
+                self.reclaimed,
+                read_status(self.regs),
+            );
+        }
+        Ok(())
+    }
+
+    fn notify_device(&self) {
+        // Descriptor ownership must become visible before the MMIO doorbell.
+        fence(AtomicOrdering::Release);
+        self.regs.poll_tx();
+    }
+
     fn observe_link_before_tx(&mut self, len: usize) -> bool {
-        let must_sample = self.link_up != Some(true)
-            || self.submitted == 0
-            || self.submitted.is_multiple_of(TX_LINK_SAMPLE_INTERVAL);
-        if !must_sample {
+        if self.link_up.load(AtomicOrdering::Acquire) {
             return true;
         }
 
         let link_up = self.regs.link_up();
-        let changed = self.link_up.replace(link_up) != Some(link_up);
+        let changed = self.link_up.swap(link_up, AtomicOrdering::AcqRel) != link_up;
 
         if link_up {
             if changed {
@@ -390,4 +450,23 @@ pub(crate) fn boxed_tx(queue: Rtl8125TxQueue) -> Box<dyn ITxQueue> {
 
 pub(crate) fn boxed_rx(queue: Rtl8125RxQueue) -> Box<dyn IRxQueue> {
     Box::new(queue)
+}
+
+#[cfg(test)]
+mod tests {
+    use rdif_eth::TxNotify;
+
+    use super::TxNotificationState;
+
+    #[test]
+    fn deferred_descriptors_share_one_device_notification() {
+        let mut notification = TxNotificationState::default();
+
+        assert!(!notification.descriptor_submitted(TxNotify::Deferred));
+        assert!(!notification.descriptor_submitted(TxNotify::Deferred));
+        assert!(notification.take_pending());
+        assert!(!notification.take_pending());
+        assert!(notification.descriptor_submitted(TxNotify::Immediate));
+        assert!(!notification.take_pending());
+    }
 }

--- a/net/ax-net/src/consts.rs
+++ b/net/ax-net/src/consts.rs
@@ -15,8 +15,8 @@
 
 pub const STANDARD_MTU: usize = 1500;
 
-pub const TCP_RX_BUF_LEN: usize = 64 * 1024;
-pub const TCP_TX_BUF_LEN: usize = 64 * 1024;
+pub const TCP_RX_BUF_LEN: usize = 256 * 1024;
+pub const TCP_TX_BUF_LEN: usize = 256 * 1024;
 pub const UDP_RX_BUF_LEN: usize = 64 * 1024;
 pub const UDP_TX_BUF_LEN: usize = 64 * 1024;
 pub const RAW_RX_BUF_LEN: usize = 64 * 1024;

--- a/net/ax-net/src/device/driver.rs
+++ b/net/ax-net/src/device/driver.rs
@@ -4,7 +4,12 @@
 //! executor only sees move-only DMA tokens exchanged through bounded SPSC
 //! rings; it never calls a NIC queue or an IRQ endpoint directly.
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+
+pub use rd_net::{
+    DmaBuffer, RxCompletion, TxChecksumCapabilities, TxChecksumOffload, TxNetworkProtocol,
+    TxNotify, TxSubmitOptions, TxTransportProtocol,
+};
 
 /// Minimum Ethernet frame length on the wire, excluding the FCS.
 pub(crate) const ETH_ZLEN: usize = 60;
@@ -32,12 +37,12 @@ pub enum NetDeviceError {
 
 pub type NetDeviceResult<T = ()> = Result<T, NetDeviceError>;
 
-/// Inline frame used only by the single protocol executor.
+/// Inline compatibility frame used by non-DMA ports and tests.
 ///
-/// Queue-facing storage remains a move-only DMA token.  The protocol port
-/// copies a bounded frame into this inline object and immediately publishes
-/// the token to the recycle SPSC ring, so no heap allocation or shared frame
-/// ownership is introduced.
+/// Queue-backed ports use the callback methods on [`EthernetFramePort`] so TX
+/// is filled directly in DMA storage and RX is consumed before its token is
+/// returned. This bounded object remains available for adapters that cannot
+/// expose borrowed queue storage.
 pub struct ProtocolEthernetFrame {
     bytes: [u8; ETHERNET_FRAME_CAPACITY],
     len: usize,
@@ -73,6 +78,58 @@ impl ProtocolEthernetFrame {
     }
 }
 
+/// Queue-runtime endpoint that accepts an RX DMA token after protocol use.
+pub(crate) trait RxBufferRecycler: Send + Sync {
+    fn recycle(&self, buffer: DmaBuffer);
+}
+
+/// Complete Ethernet frame backed by an owned receive DMA token.
+///
+/// Dropping this value returns the token to its queue-local recycler. This
+/// lets the token remain owned through smoltcp's `RxToken::consume` without
+/// exposing NIC queue state to the protocol executor.
+pub struct ProtocolRxFrame {
+    completion: Option<RxCompletion>,
+    recycler: Arc<dyn RxBufferRecycler>,
+}
+
+impl ProtocolRxFrame {
+    pub(crate) fn new(completion: RxCompletion, recycler: Arc<dyn RxBufferRecycler>) -> Self {
+        debug_assert!(completion.packet_len <= completion.buffer.capacity());
+        Self {
+            completion: Some(completion),
+            recycler,
+        }
+    }
+
+    /// Returns the received L2 frame length excluding FCS.
+    pub fn packet_len(&self) -> usize {
+        self.completion
+            .as_ref()
+            .expect("owned RX frame lost its DMA token")
+            .packet_len
+    }
+
+    /// Borrows the received frame while this value retains DMA ownership.
+    pub fn read_with<R>(&self, consume: impl FnOnce(&[u8]) -> R) -> R {
+        let completion = self
+            .completion
+            .as_ref()
+            .expect("owned RX frame lost its DMA token");
+        completion
+            .buffer
+            .read_with_cpu(completion.packet_len, consume)
+    }
+}
+
+impl Drop for ProtocolRxFrame {
+    fn drop(&mut self) {
+        if let Some(completion) = self.completion.take() {
+            self.recycler.recycle(completion.buffer);
+        }
+    }
+}
+
 /// Device-level protocol endpoint backed by one or more queue-group SPSC
 /// pipelines.
 pub trait EthernetFramePort: Send + 'static {
@@ -82,12 +139,53 @@ pub trait EthernetFramePort: Send + 'static {
     /// Link-layer address captured during atomic initialization.
     fn mac_address(&self) -> [u8; 6];
 
-    /// Copies and publishes one complete Ethernet frame to exactly one queue
-    /// group's TX-ready ring.
+    /// Returns transport checksums available on every TX queue of this port.
+    fn checksum_capabilities(&self) -> TxChecksumCapabilities {
+        TxChecksumCapabilities::NONE
+    }
+
+    /// Publishes one complete Ethernet frame to exactly one queue group's
+    /// TX-ready ring.
     fn transmit(&mut self, frame: &ProtocolEthernetFrame) -> NetDeviceResult;
+
+    /// Fills a queue-owned DMA token and publishes it for transmission.
+    ///
+    /// Queue-backed ports override this method so `fill` writes directly into
+    /// DMA storage. The compatibility implementation retains the inline frame
+    /// path for non-DMA ports and tests.
+    fn transmit_frame_with_options(
+        &mut self,
+        frame_len: usize,
+        options: TxSubmitOptions,
+        fill: &mut dyn FnMut(&mut [u8]),
+    ) -> NetDeviceResult {
+        if options.checksum.is_some() {
+            return Err(NetDeviceError::InvalidParam);
+        }
+        let mut frame = ProtocolEthernetFrame::new(frame_len)?;
+        fill(frame.packet_mut());
+        self.transmit(&frame)
+    }
 
     /// Takes one completed RX frame, if any.
     fn receive(&mut self) -> NetDeviceResult<ProtocolEthernetFrame>;
+
+    /// Takes one completed frame with its DMA ownership token when supported.
+    ///
+    /// `Ok(None)` selects the compatibility [`receive`](Self::receive) path.
+    /// Queue-backed ports return `Err(Again)` while their owned path is idle.
+    fn receive_owned(&mut self) -> NetDeviceResult<Option<ProtocolRxFrame>> {
+        Ok(None)
+    }
+
+    /// Consumes one completed frame while its DMA token is borrowed locally.
+    ///
+    /// Queue-backed ports override this method to avoid copying into an inline
+    /// frame before the protocol adapter consumes it.
+    fn receive_with(&mut self, consume: &mut dyn FnMut(&[u8]) -> usize) -> NetDeviceResult<usize> {
+        let frame = self.receive()?;
+        Ok(consume(frame.packet()))
+    }
 }
 
 /// Protocol endpoints handed to the unique smoltcp owner during startup.

--- a/net/ax-net/src/device/ethernet.rs
+++ b/net/ax-net/src/device/ethernet.rs
@@ -28,17 +28,35 @@ use smoltcp::{
     time::{Duration, Instant},
     wire::{
         ArpOperation, ArpPacket, ArpRepr, EthernetAddress, EthernetFrame, EthernetProtocol,
-        EthernetRepr, IpAddress, Ipv4Cidr,
+        EthernetRepr, IpAddress, IpVersion, Ipv4Cidr,
     },
 };
 
 use crate::{
     config::InterfaceId,
     consts::{ETHERNET_MAX_PENDING_PACKETS, STANDARD_MTU},
-    device::{ArpEntry, Device, ETH_ZLEN, EthernetFramePort, ProtocolEthernetFrame},
+    device::{
+        ArpEntry, Device, DeviceRxPacket, DeviceRxPoll, ETH_ZLEN, EthernetFramePort,
+        NetDeviceError, NetDeviceResult, ProtocolEthernetFrame, TxChecksumCapabilities,
+        TxChecksumOffload, TxNetworkProtocol, TxNotify, TxSubmitOptions, TxTransportProtocol,
+        fill_transport_checksum,
+    },
 };
 
 const EMPTY_MAC: EthernetAddress = EthernetAddress([0; 6]);
+const IPV4_MIN_HEADER_LEN: usize = 20;
+const IPV6_HEADER_LEN: usize = 40;
+const TCP_CHECKSUM_OFFSET: usize = 16;
+const UDP_CHECKSUM_OFFSET: usize = 6;
+const IP_PROTOCOL_TCP: u8 = 6;
+const IP_PROTOCOL_UDP: u8 = 17;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TxChecksumPlan {
+    None,
+    Software,
+    Hardware(TxChecksumOffload),
+}
 
 struct Neighbor {
     hardware_address: EthernetAddress,
@@ -127,6 +145,75 @@ impl EthernetDevice {
         EthernetAddress(self.inner.mac_address())
     }
 
+    fn checksum_plan(&self, packet: &[u8]) -> TxChecksumPlan {
+        let capabilities = self.inner.checksum_capabilities();
+        let Some(version) = packet.first().map(|byte| byte >> 4) else {
+            return TxChecksumPlan::None;
+        };
+        let (network, protocol, transport_offset) = match version {
+            4 if packet.len() >= IPV4_MIN_HEADER_LEN => {
+                let header_len = usize::from(packet[0] & 0x0f) * 4;
+                if header_len < IPV4_MIN_HEADER_LEN || header_len >= packet.len() {
+                    return TxChecksumPlan::None;
+                }
+                (TxNetworkProtocol::Ipv4, packet[9], header_len)
+            }
+            6 if packet.len() > IPV6_HEADER_LEN => {
+                (TxNetworkProtocol::Ipv6, packet[6], IPV6_HEADER_LEN)
+            }
+            _ => return TxChecksumPlan::None,
+        };
+        let (transport, checksum_offset) = match protocol {
+            IP_PROTOCOL_TCP if capabilities.supports_tcp() => {
+                (TxTransportProtocol::Tcp, TCP_CHECKSUM_OFFSET)
+            }
+            IP_PROTOCOL_UDP if capabilities.supports_udp() => {
+                (TxTransportProtocol::Udp, UDP_CHECKSUM_OFFSET)
+            }
+            _ => return TxChecksumPlan::None,
+        };
+        let checksum = transport_offset + checksum_offset..transport_offset + checksum_offset + 2;
+        if packet.get(checksum) != Some(&[0, 0]) {
+            return TxChecksumPlan::None;
+        }
+        if EthernetFrame::<&[u8]>::header_len() + packet.len() < ETH_ZLEN {
+            return TxChecksumPlan::Software;
+        }
+        let Some(transport_offset) = EthernetFrame::<&[u8]>::header_len()
+            .checked_add(transport_offset)
+            .and_then(|offset| offset.try_into().ok())
+        else {
+            return TxChecksumPlan::None;
+        };
+        TxChecksumPlan::Hardware(TxChecksumOffload {
+            network,
+            transport,
+            transport_offset,
+        })
+    }
+
+    fn transmit_ip_to(
+        &mut self,
+        destination: EthernetAddress,
+        packet: &[u8],
+    ) -> NetDeviceResult<usize> {
+        let protocol = match IpVersion::of_packet(packet) {
+            Ok(IpVersion::Ipv4) => EthernetProtocol::Ipv4,
+            Ok(IpVersion::Ipv6) => EthernetProtocol::Ipv6,
+            Err(_) => return Err(NetDeviceError::InvalidParam),
+        };
+        let checksum = self.checksum_plan(packet);
+        Self::send_to_with_options(
+            &mut *self.inner,
+            destination,
+            packet.len(),
+            |buffer| buffer.copy_from_slice(packet),
+            protocol,
+            checksum,
+            TxNotify::Deferred,
+        )
+    }
+
     /// Builds an Ethernet frame around `size` bytes of payload written by `f`,
     /// emits it via `inner.transmit()`, and returns the total L2 frame length
     /// (including padding to [`ETH_ZLEN`], excluding FCS) on success, or 0 on
@@ -138,6 +225,35 @@ impl EthernetDevice {
         f: F,
         proto: EthernetProtocol,
     ) -> usize
+    where
+        F: FnOnce(&mut [u8]),
+    {
+        match Self::send_to_with_options(
+            inner,
+            dst,
+            size,
+            f,
+            proto,
+            TxChecksumPlan::None,
+            TxNotify::Immediate,
+        ) {
+            Ok(wire_len) => wire_len,
+            Err(err) => {
+                warn!("{}: transmit failed: {:?}", inner.device_name(), err);
+                0
+            }
+        }
+    }
+
+    fn send_to_with_options<F>(
+        inner: &mut dyn EthernetFramePort,
+        dst: EthernetAddress,
+        size: usize,
+        f: F,
+        proto: EthernetProtocol,
+        checksum: TxChecksumPlan,
+        notify: TxNotify,
+    ) -> NetDeviceResult<usize>
     where
         F: FnOnce(&mut [u8]),
     {
@@ -153,27 +269,37 @@ impl EthernetDevice {
         // FCS, aligned with Linux /proc/net/dev semantics.
         let wire_len = total_frame_len.max(ETH_ZLEN);
 
-        let mut tx_buf = match ProtocolEthernetFrame::new(total_frame_len) {
-            Ok(buf) => buf,
-            Err(err) => {
-                warn!("{}: alloc_tx_buffer failed: {:?}", inner.device_name(), err);
-                return 0;
-            }
+        let hardware_checksum = match checksum {
+            TxChecksumPlan::Hardware(checksum) => Some(checksum),
+            TxChecksumPlan::None | TxChecksumPlan::Software => None,
         };
-        let mut frame = EthernetFrame::new_unchecked(tx_buf.packet_mut());
-        repr.emit(&mut frame);
-        f(frame.payload_mut());
-        trace!(
-            "SEND {} bytes: {:02X?}",
-            tx_buf.packet_len(),
-            tx_buf.packet()
-        );
-        if let Err(err) = inner.transmit(&tx_buf) {
-            warn!("{}: transmit failed: {:?}", inner.device_name(), err);
-            0
-        } else {
-            wire_len
-        }
+        let mut fill_once = Some(f);
+        let mut fill = |packet: &mut [u8]| {
+            let mut frame = EthernetFrame::new_unchecked(packet);
+            repr.emit(&mut frame);
+            fill_once
+                .take()
+                .expect("frame port must fill each packet exactly once")(
+                frame.payload_mut()
+            );
+            if checksum == TxChecksumPlan::Software {
+                fill_transport_checksum(frame.payload_mut());
+            }
+            trace!(
+                "SEND {} bytes: {:02X?}",
+                frame.as_ref().len(),
+                frame.as_ref()
+            );
+        };
+        inner.transmit_frame_with_options(
+            total_frame_len,
+            TxSubmitOptions {
+                checksum: hardware_checksum,
+                notify,
+            },
+            &mut fill,
+        )?;
+        Ok(wire_len)
     }
 
     /// Parses and handles a single Ethernet frame.
@@ -205,7 +331,7 @@ impl EthernetDevice {
         }
 
         match repr.ethertype {
-            EthernetProtocol::Ipv4 => {
+            EthernetProtocol::Ipv4 | EthernetProtocol::Ipv6 => {
                 snoop(frame.payload());
                 buffer
                     .enqueue(frame.payload().len(), interface_id)
@@ -234,6 +360,26 @@ impl EthernetDevice {
                 self.deferred_rx_frame_lens.push(frame_len);
                 self.deferred_rx_drops += 1;
                 0
+            }
+        }
+    }
+
+    fn handle_non_ip_frame(&mut self, frame: &[u8], timestamp: Instant) {
+        let frame_len = frame.len();
+        let frame = EthernetFrame::new_unchecked(frame);
+        let Ok(repr) = EthernetRepr::parse(&frame) else {
+            self.deferred_rx_errors += 1;
+            return;
+        };
+        match repr.ethertype {
+            EthernetProtocol::Arp => {
+                self.process_arp(frame.payload(), timestamp);
+                self.deferred_rx_frame_lens.push(frame_len);
+            }
+            EthernetProtocol::Ipv4 | EthernetProtocol::Ipv6 => {}
+            _ => {
+                self.deferred_rx_frame_lens.push(frame_len);
+                self.deferred_rx_drops += 1;
             }
         }
     }
@@ -451,6 +597,10 @@ impl Device for EthernetDevice {
         &self.name
     }
 
+    fn tx_checksum_capabilities(&self) -> TxChecksumCapabilities {
+        self.inner.checksum_capabilities()
+    }
+
     fn recv(
         &mut self,
         interface_id: InterfaceId,
@@ -483,36 +633,164 @@ impl Device for EthernetDevice {
         }
     }
 
+    fn poll_owned_rx(&mut self, timestamp: Instant) -> DeviceRxPoll {
+        loop {
+            let frame = match self.inner.receive_owned() {
+                Ok(Some(frame)) => frame,
+                Ok(None) => return DeviceRxPoll::Unsupported,
+                Err(NetDeviceError::Again) => return DeviceRxPoll::Idle,
+                Err(err) => {
+                    warn!("receive failed: {err:?}");
+                    self.deferred_rx_errors += 1;
+                    return DeviceRxPoll::Idle;
+                }
+            };
+            let hardware_address = self.hardware_address();
+            let mut malformed = false;
+            let mut side_frame = false;
+            let packet_range = frame.read_with(|packet| {
+                trace!("RECV {} bytes: {:02X?}", packet.len(), packet);
+                let Ok(ethernet) = EthernetFrame::new_checked(packet) else {
+                    malformed = true;
+                    return None;
+                };
+                let Ok(repr) = EthernetRepr::parse(&ethernet) else {
+                    malformed = true;
+                    return None;
+                };
+                if !repr.dst_addr.is_broadcast()
+                    && repr.dst_addr != EMPTY_MAC
+                    && repr.dst_addr != hardware_address
+                {
+                    return None;
+                }
+                match repr.ethertype {
+                    EthernetProtocol::Ipv4 | EthernetProtocol::Ipv6 => {
+                        let payload_len = ethernet.payload().len();
+                        let payload_start = packet.len() - payload_len;
+                        Some(payload_start..payload_start + payload_len)
+                    }
+                    _ => {
+                        side_frame = true;
+                        None
+                    }
+                }
+            });
+            if malformed {
+                self.deferred_rx_errors += 1;
+            }
+            if side_frame {
+                frame.read_with(|packet| self.handle_non_ip_frame(packet, timestamp));
+            }
+            if let Some(packet_range) = packet_range {
+                let frame_len = frame.packet_len();
+                return DeviceRxPoll::Packet(DeviceRxPacket::with_packet_range(
+                    frame_len,
+                    frame,
+                    packet_range,
+                ));
+            }
+        }
+    }
+
+    fn recv_direct(
+        &mut self,
+        timestamp: Instant,
+        deliver: &mut dyn FnMut(&[u8]) -> bool,
+        snoop: &mut dyn FnMut(&[u8]),
+    ) -> Option<usize> {
+        loop {
+            let hardware_address = self.hardware_address();
+            let mut side_frame = None;
+            let mut malformed = false;
+            let mut dropped = false;
+            let result = self.inner.receive_with(&mut |packet| {
+                trace!("RECV {} bytes: {:02X?}", packet.len(), packet);
+                let Ok(frame) = EthernetFrame::new_checked(packet) else {
+                    malformed = true;
+                    return 0;
+                };
+                let Ok(repr) = EthernetRepr::parse(&frame) else {
+                    malformed = true;
+                    return 0;
+                };
+                if !repr.dst_addr.is_broadcast()
+                    && repr.dst_addr != EMPTY_MAC
+                    && repr.dst_addr != hardware_address
+                {
+                    return 0;
+                }
+                match repr.ethertype {
+                    EthernetProtocol::Ipv4 | EthernetProtocol::Ipv6 => {
+                        snoop(frame.payload());
+                        if deliver(frame.payload()) {
+                            packet.len()
+                        } else {
+                            dropped = true;
+                            0
+                        }
+                    }
+                    _ => {
+                        match ProtocolEthernetFrame::copy_from_slice(packet) {
+                            Ok(frame) => side_frame = Some(frame),
+                            Err(_) => malformed = true,
+                        }
+                        0
+                    }
+                }
+            });
+            let frame_len = match result {
+                Ok(frame_len) => frame_len,
+                Err(NetDeviceError::Again) => return Some(0),
+                Err(err) => {
+                    warn!("receive failed: {err:?}");
+                    self.deferred_rx_errors += 1;
+                    return Some(0);
+                }
+            };
+            if malformed {
+                self.deferred_rx_errors += 1;
+            }
+            if dropped {
+                self.deferred_rx_drops += 1;
+            }
+            if let Some(frame) = side_frame {
+                self.handle_non_ip_frame(frame.packet(), timestamp);
+            }
+            if frame_len > 0 {
+                return Some(frame_len);
+            }
+        }
+    }
+
     fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> usize {
+        match self.try_send(next_hop, packet, timestamp) {
+            Ok(frame_len) => frame_len,
+            Err(err) => {
+                if !matches!(err, NetDeviceError::Again) {
+                    self.deferred_tx_errors += 1;
+                }
+                0
+            }
+        }
+    }
+
+    fn try_send(
+        &mut self,
+        next_hop: IpAddress,
+        packet: &[u8],
+        timestamp: Instant,
+    ) -> NetDeviceResult<usize> {
         let is_subnet_broadcast =
             self.ip.and_then(|ip| ip.broadcast()).map(IpAddress::Ipv4) == Some(next_hop);
-        if next_hop.is_broadcast() || is_subnet_broadcast {
-            let frame_len = Self::send_to(
-                &mut *self.inner,
-                EthernetAddress::BROADCAST,
-                packet.len(),
-                |buf| buf.copy_from_slice(packet),
-                EthernetProtocol::Ipv4,
-            );
-            if frame_len == 0 {
-                self.deferred_tx_errors += 1;
-            }
-            return frame_len;
+        if next_hop.is_broadcast() || next_hop.is_multicast() || is_subnet_broadcast {
+            return self.transmit_ip_to(EthernetAddress::BROADCAST, packet);
         }
 
         let need_request = match self.neighbors.get(&next_hop) {
             Some(neighbor) if neighbor.expires_at > timestamp => {
-                let frame_len = Self::send_to(
-                    &mut *self.inner,
-                    neighbor.hardware_address,
-                    packet.len(),
-                    |buf| buf.copy_from_slice(packet),
-                    EthernetProtocol::Ipv4,
-                );
-                if frame_len == 0 {
-                    self.deferred_tx_errors += 1;
-                }
-                return frame_len;
+                let hardware_address = neighbor.hardware_address;
+                return self.transmit_ip_to(hardware_address, packet);
             }
             Some(_) => {
                 self.neighbors.remove(&next_hop);
@@ -531,7 +809,7 @@ impl Device for EthernetDevice {
             // request_arp() internally increments deferred_tx_errors for all
             // failure modes (hardware send_to failure, IPv6 not supported,
             // IPv4 not configured), so the caller does not add a second counter.
-            return 0;
+            return Ok(0);
         }
         if self.pending_packets.is_full() {
             warn!(
@@ -539,15 +817,15 @@ impl Device for EthernetDevice {
                 self.name
             );
             self.deferred_tx_drops += 1;
-            return 0;
+            return Ok(0);
         }
         let Ok(dst_buffer) = self.pending_packets.enqueue(packet.len(), next_hop) else {
             warn!("Failed to enqueue packet in pending packets buffer");
             self.deferred_tx_drops += 1;
-            return 0;
+            return Ok(0);
         };
         dst_buffer.copy_from_slice(packet);
-        0
+        Ok(0)
     }
 
     fn drain_deferred_tx(&mut self) -> Vec<usize> {
@@ -626,6 +904,7 @@ mod ethernet_counter_tests {
     /// Minimal protocol frame port for testing EthernetDevice ARP paths.
     struct MockEthernetDriver {
         mac: [u8; 6],
+        checksum_capabilities: TxChecksumCapabilities,
         /// Pre-canned frames returned by `receive()` in FIFO order.
         rx_frames: VecDeque<Vec<u8>>,
         /// Frames transmitted through `transmit()`, captured for inspection.
@@ -638,6 +917,7 @@ mod ethernet_counter_tests {
         fn new(mac: [u8; 6]) -> Self {
             Self {
                 mac,
+                checksum_capabilities: TxChecksumCapabilities::NONE,
                 rx_frames: VecDeque::new(),
                 tx_frames: Vec::new(),
                 tx_alloc_fail: false,
@@ -656,6 +936,10 @@ mod ethernet_counter_tests {
 
         fn mac_address(&self) -> [u8; 6] {
             self.mac
+        }
+
+        fn checksum_capabilities(&self) -> TxChecksumCapabilities {
+            self.checksum_capabilities
         }
 
         fn transmit(&mut self, frame: &ProtocolEthernetFrame) -> NetDeviceResult {
@@ -1010,6 +1294,30 @@ mod ethernet_counter_tests {
             EthernetProtocol::Ipv4,
         );
         assert_eq!(wire_len, 114);
+    }
+
+    #[test]
+    fn long_tcp_packet_uses_hardware_checksum_but_short_frame_stays_software() {
+        let mut mock = MockEthernetDriver::new(DEV_MAC);
+        mock.checksum_capabilities = TxChecksumCapabilities::TCP_UDP;
+        let device = make_test_device(mock);
+
+        let mut long_tcp = [0u8; 60];
+        long_tcp[0] = 0x45;
+        long_tcp[9] = IP_PROTOCOL_TCP;
+        assert_eq!(
+            device.checksum_plan(&long_tcp),
+            TxChecksumPlan::Hardware(TxChecksumOffload {
+                network: TxNetworkProtocol::Ipv4,
+                transport: TxTransportProtocol::Tcp,
+                transport_offset: 34,
+            })
+        );
+
+        let mut short_udp = [0u8; 28];
+        short_udp[0] = 0x45;
+        short_udp[9] = IP_PROTOCOL_UDP;
+        assert_eq!(device.checksum_plan(&short_udp), TxChecksumPlan::Software);
     }
 
     // ── Integration: combined ARP + IP recv/drain cycle ────────────────

--- a/net/ax-net/src/device/mod.rs
+++ b/net/ax-net/src/device/mod.rs
@@ -19,11 +19,14 @@
 //! register/wake operations after releasing the concrete device lock.
 
 use alloc::{string::String, vec::Vec};
+use core::ops::Range;
 
 use smoltcp::{
     storage::PacketBuffer,
     time::Instant,
-    wire::{IpAddress, Ipv4Cidr},
+    wire::{
+        IpAddress, IpProtocol, IpVersion, Ipv4Cidr, Ipv4Packet, Ipv6Packet, TcpPacket, UdpPacket,
+    },
 };
 
 use crate::config::InterfaceId;
@@ -39,6 +42,101 @@ pub use ethernet::*;
 pub use loopback::*;
 #[cfg(feature = "vsock")]
 pub use vsock::*;
+
+/// Completes a TCP or UDP checksum before software delivery.
+pub(crate) fn fill_transport_checksum(packet: &mut [u8]) {
+    let Ok(version) = IpVersion::of_packet(packet) else {
+        return;
+    };
+    let (src_addr, dst_addr, protocol, transport_offset) = match version {
+        IpVersion::Ipv4 => {
+            let Ok(ipv4) = Ipv4Packet::new_checked(&*packet) else {
+                return;
+            };
+            (
+                IpAddress::Ipv4(ipv4.src_addr()),
+                IpAddress::Ipv4(ipv4.dst_addr()),
+                ipv4.next_header(),
+                usize::from(ipv4.header_len()),
+            )
+        }
+        IpVersion::Ipv6 => {
+            let Ok(ipv6) = Ipv6Packet::new_checked(&*packet) else {
+                return;
+            };
+            (
+                IpAddress::Ipv6(ipv6.src_addr()),
+                IpAddress::Ipv6(ipv6.dst_addr()),
+                ipv6.next_header(),
+                ipv6.header_len(),
+            )
+        }
+    };
+    let Some(transport) = packet.get_mut(transport_offset..) else {
+        return;
+    };
+    match protocol {
+        IpProtocol::Tcp => {
+            if let Ok(mut tcp) = TcpPacket::new_checked(transport) {
+                tcp.fill_checksum(&src_addr, &dst_addr);
+            }
+        }
+        IpProtocol::Udp => {
+            if let Ok(mut udp) = UdpPacket::new_checked(transport) {
+                udp.fill_checksum(&src_addr, &dst_addr);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Owned IP packet whose backing RX DMA token is retained through consumption.
+pub struct DeviceRxPacket {
+    frame_len: usize,
+    frame: ProtocolRxFrame,
+    packet: Range<usize>,
+}
+
+impl DeviceRxPacket {
+    pub(crate) fn with_packet_range(
+        frame_len: usize,
+        frame: ProtocolRxFrame,
+        packet: Range<usize>,
+    ) -> Self {
+        assert!(packet.end <= frame.packet_len());
+        Self {
+            frame_len,
+            frame,
+            packet,
+        }
+    }
+
+    /// Borrows the IP packet without releasing the RX DMA token.
+    pub fn read_with<R>(&self, consume: impl FnOnce(&[u8]) -> R) -> R {
+        self.frame
+            .read_with(|frame| consume(&frame[self.packet.clone()]))
+    }
+
+    /// Consumes the IP packet and recycles its DMA token afterwards.
+    pub fn consume<R>(self, consume: impl FnOnce(&[u8]) -> R) -> R {
+        self.read_with(consume)
+    }
+
+    /// Returns the received L2 frame length excluding FCS.
+    pub const fn frame_len(&self) -> usize {
+        self.frame_len
+    }
+}
+
+/// Result of polling a device's optional owned receive path.
+pub enum DeviceRxPoll {
+    /// This device only implements the compatibility receive path.
+    Unsupported,
+    /// The owned receive path is supported but no IP packet is ready.
+    Idle,
+    /// One IP packet and its backing DMA token were received.
+    Packet(DeviceRxPacket),
+}
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ArpEntry {
@@ -58,6 +156,11 @@ pub struct ArpEntry {
 pub trait Device: Send {
     /// Human-readable device name used in logs and userspace queries.
     fn name(&self) -> &str;
+
+    /// Returns transport checksums the device can calculate on transmit.
+    fn tx_checksum_capabilities(&self) -> TxChecksumCapabilities {
+        TxChecksumCapabilities::NONE
+    }
 
     /// Moves packets from the device into the shared IP RX buffer.
     ///
@@ -82,6 +185,25 @@ pub trait Device: Send {
         timestamp: Instant,
         snoop: &mut dyn FnMut(&[u8]),
     ) -> usize;
+
+    /// Polls an optional owned receive path that retains DMA through `RxToken`.
+    fn poll_owned_rx(&mut self, _timestamp: Instant) -> DeviceRxPoll {
+        DeviceRxPoll::Unsupported
+    }
+
+    /// Receives directly from queue-owned backing into the final protocol
+    /// destination when supported.
+    ///
+    /// `None` selects the compatibility [`recv`](Self::recv) path. `Some(0)`
+    /// means the direct path is supported but no IP packet was delivered.
+    fn recv_direct(
+        &mut self,
+        _timestamp: Instant,
+        _deliver: &mut dyn FnMut(&[u8]) -> bool,
+        _snoop: &mut dyn FnMut(&[u8]),
+    ) -> Option<usize> {
+        None
+    }
     /// Sends a packet to the next hop.
     ///
     /// Returns the L2 frame byte count (excluding FCS) actually transmitted,
@@ -89,6 +211,19 @@ pub trait Device: Send {
     /// resolution) or could not be sent. The returned byte count aligns with
     /// Linux `/proc/net/dev` semantics.
     fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> usize;
+
+    /// Attempts a transmission while preserving transient queue backpressure.
+    ///
+    /// [`NetDeviceError::Again`] means the caller still owns the packet and
+    /// must leave it queued until a later protocol poll.
+    fn try_send(
+        &mut self,
+        next_hop: IpAddress,
+        packet: &[u8],
+        timestamp: Instant,
+    ) -> NetDeviceResult<usize> {
+        Ok(self.send(next_hop, packet, timestamp))
+    }
 
     /// Returns the per-packet L2 frame byte counts for packets transmitted
     /// on a side path during `recv()` (e.g. ARP resolution and replies)

--- a/net/ax-net/src/ip_tos.rs
+++ b/net/ax-net/src/ip_tos.rs
@@ -6,6 +6,8 @@
 //! boundary, after the IP header has been generated and before the packet is
 //! handed to loopback or a concrete device.
 
+use core::sync::atomic::{AtomicBool, Ordering};
+
 use ax_lazyinit::LazyLock;
 use ax_sync::Mutex;
 use hashbrown::HashMap;
@@ -55,23 +57,54 @@ impl EgressIpTosKey {
     }
 }
 
-static EGRESS_IP_TOS: LazyLock<Mutex<HashMap<EgressIpTosKey, u8>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+struct EgressIpTosPolicies {
+    table: Mutex<HashMap<EgressIpTosKey, u8>>,
+    active: AtomicBool,
+}
 
-pub(crate) fn set_egress_ip_tos(key: EgressIpTosKey, tos: u8) {
-    let mut table = EGRESS_IP_TOS.lock();
-    if tos == 0 {
+impl EgressIpTosPolicies {
+    fn new() -> Self {
+        Self {
+            table: Mutex::new(HashMap::new()),
+            active: AtomicBool::new(false),
+        }
+    }
+
+    fn set(&self, key: EgressIpTosKey, tos: u8) {
+        let mut table = self.table.lock();
+        if tos == 0 {
+            table.remove(&key);
+        } else {
+            table.insert(key, tos);
+        }
+        self.active.store(!table.is_empty(), Ordering::Release);
+    }
+
+    fn clear(&self, key: EgressIpTosKey) {
+        let mut table = self.table.lock();
         table.remove(&key);
-    } else {
-        table.insert(key, tos);
+        self.active.store(!table.is_empty(), Ordering::Release);
+    }
+
+    fn is_active(&self) -> bool {
+        self.active.load(Ordering::Acquire)
     }
 }
 
+static EGRESS_IP_TOS: LazyLock<EgressIpTosPolicies> = LazyLock::new(EgressIpTosPolicies::new);
+
+pub(crate) fn set_egress_ip_tos(key: EgressIpTosKey, tos: u8) {
+    EGRESS_IP_TOS.set(key, tos);
+}
+
 pub(crate) fn clear_egress_ip_tos(key: EgressIpTosKey) {
-    EGRESS_IP_TOS.lock().remove(&key);
+    EGRESS_IP_TOS.clear(key);
 }
 
 pub(crate) fn apply_egress_ip_tos(packet: &mut [u8]) {
+    if !EGRESS_IP_TOS.is_active() {
+        return;
+    }
     let tos = packet_egress_ip_tos(packet);
     if tos != 0 {
         apply_ip_tos(packet, tos);
@@ -159,7 +192,7 @@ fn egress_ip_tos(protocol: IpProtocol, local: IpEndpoint, remote: IpEndpoint) ->
         return 0;
     }
 
-    let table = EGRESS_IP_TOS.lock();
+    let table = EGRESS_IP_TOS.table.lock();
     let protocol = protocol.into();
     let candidates = [
         EgressIpTosKey {
@@ -203,6 +236,27 @@ mod tests {
     use smoltcp::wire::{Ipv4Address, Ipv6Address};
 
     use super::*;
+
+    #[test]
+    fn policy_activity_tracks_nonzero_entries() {
+        let policies = EgressIpTosPolicies::new();
+        let key = EgressIpTosKey::exact(
+            IpProtocol::Tcp,
+            (Ipv4Address::new(192, 0, 2, 10), 41001).into(),
+            (Ipv4Address::new(198, 51, 100, 20), 5201).into(),
+        )
+        .unwrap();
+
+        assert!(!policies.is_active());
+        policies.set(key, 0x10);
+        assert!(policies.is_active());
+        policies.set(key, 0);
+        assert!(!policies.is_active());
+
+        policies.set(key, 0x10);
+        policies.clear(key);
+        assert!(!policies.is_active());
+    }
 
     #[test]
     fn exact_policy_takes_precedence_over_listener_policy() {

--- a/net/ax-net/src/queue_runtime/executor/mod.rs
+++ b/net/ax-net/src/queue_runtime/executor/mod.rs
@@ -4,7 +4,7 @@ use core::sync::atomic::{AtomicU8, Ordering};
 use ax_sync::SpinLock;
 use rd_net::{
     DmaBuffer, NetError, NetOwnerStartupProgress, NetRearmResult, PreparedNetPollGroup,
-    RxCompletion,
+    RxCompletion, TxChecksumCapabilities, TxSubmitOptions,
 };
 
 use super::{
@@ -12,68 +12,157 @@ use super::{
     STATE_MASK, STATE_MISSED, STATE_POLLING, STATE_SCHEDULED, STATUS_FAILED, STATUS_READY,
     SpscConsumer, SpscProducer,
 };
-use crate::device::{EthernetFramePort, NetDeviceError, NetDeviceResult, ProtocolEthernetFrame};
+use crate::device::{
+    ETH_ZLEN, EthernetFramePort, NetDeviceError, NetDeviceResult, ProtocolEthernetFrame,
+    ProtocolRxFrame, RxBufferRecycler,
+};
 
 mod wifi;
 
 pub(super) use wifi::WifiExecutorSlot;
 use wifi::process_wifi_requests;
 
+pub(super) struct TxRequest {
+    pub(super) buffer: DmaBuffer,
+    pub(super) options: TxSubmitOptions,
+}
+
+struct RxRecycleState {
+    producer: SpscProducer<DmaBuffer>,
+    overflow: Vec<DmaBuffer>,
+}
+
+pub(super) struct RxRecycler {
+    state: SpinLock<RxRecycleState>,
+    shared: Arc<PollGroupState>,
+}
+
+impl RxRecycler {
+    pub(super) fn new(
+        producer: SpscProducer<DmaBuffer>,
+        shared: Arc<PollGroupState>,
+        capacity: usize,
+    ) -> Self {
+        Self {
+            state: SpinLock::new(RxRecycleState {
+                producer,
+                overflow: Vec::with_capacity(capacity.max(QUEUE_BUDGET)),
+            }),
+            shared,
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn flush_overflow(&self) {
+        let mut state = self.state.lock_irqsave();
+        while let Some(buffer) = state.overflow.pop() {
+            if let Err(buffer) = state.producer.push(buffer) {
+                state.overflow.push(buffer);
+                break;
+            }
+        }
+    }
+
+    fn drain_into(
+        &self,
+        consumer: &mut SpscConsumer<DmaBuffer>,
+        spares: &mut Vec<DmaBuffer>,
+        budget: usize,
+    ) -> usize {
+        let mut state = self.state.lock_irqsave();
+        let start = spares.len();
+        while spares.len() - start < budget {
+            if let Some(buffer) = consumer.pop() {
+                spares.push(buffer);
+            } else if let Some(buffer) = state.overflow.pop() {
+                spares.push(buffer);
+            } else {
+                break;
+            }
+        }
+        spares.len() - start
+    }
+
+    #[cfg(test)]
+    pub(super) fn overflow_len(&self) -> usize {
+        self.state.lock_irqsave().overflow.len()
+    }
+}
+
+impl RxBufferRecycler for RxRecycler {
+    fn recycle(&self, buffer: DmaBuffer) {
+        let mut state = self.state.lock_irqsave();
+        if let Err(buffer) = state.producer.push(buffer) {
+            state.overflow.push(buffer);
+        }
+        drop(state);
+        self.shared.schedule_task();
+    }
+}
+
 pub(super) struct ProtocolGroupPort {
     pub(super) rx_ready: SpscConsumer<RxCompletion>,
-    pub(super) rx_recycle: SpscProducer<DmaBuffer>,
-    pub(super) tx_ready: SpscProducer<DmaBuffer>,
+    pub(super) rx_recycler: Arc<RxRecycler>,
+    pub(super) tx_ready: SpscProducer<TxRequest>,
     pub(super) tx_free: SpscConsumer<DmaBuffer>,
-    pub(super) pending_recycle: Vec<DmaBuffer>,
     pub(super) tx_spares: Vec<DmaBuffer>,
     pub(super) shared: Arc<PollGroupState>,
 }
 
 impl ProtocolGroupPort {
-    pub(super) fn flush_recycle(&mut self) {
-        while let Some(buffer) = self.pending_recycle.pop() {
-            if let Err(buffer) = self.rx_recycle.push(buffer) {
-                self.pending_recycle.push(buffer);
-                break;
-            }
-            self.shared.schedule_task();
+    pub(super) fn receive_owned(&mut self) -> NetDeviceResult<ProtocolRxFrame> {
+        let completion = self.rx_ready.pop().ok_or(NetDeviceError::Again)?;
+        if completion.packet_len > completion.buffer.capacity() {
+            self.rx_recycler.recycle(completion.buffer);
+            return Err(NetDeviceError::Io);
         }
-    }
-
-    fn recycle_rx_buffer(&mut self, buffer: DmaBuffer) {
-        if let Err(buffer) = self.rx_recycle.push(buffer) {
-            self.pending_recycle.push(buffer);
-        }
-        self.shared.schedule_task();
+        Ok(ProtocolRxFrame::new(
+            completion,
+            Arc::clone(&self.rx_recycler) as Arc<dyn RxBufferRecycler>,
+        ))
     }
 
     pub(super) fn receive(&mut self) -> NetDeviceResult<ProtocolEthernetFrame> {
-        self.flush_recycle();
-        let completion = self.rx_ready.pop().ok_or(NetDeviceError::Again)?;
-        let frame = if completion.packet_len > completion.buffer.capacity() {
-            Err(NetDeviceError::Io)
-        } else {
-            completion
-                .buffer
-                .read_with_cpu(completion.packet_len, |packet| {
-                    ProtocolEthernetFrame::copy_from_slice(packet)
-                })
-        };
-        self.recycle_rx_buffer(completion.buffer);
-        frame
+        let frame = self.receive_owned()?;
+        frame.read_with(ProtocolEthernetFrame::copy_from_slice)
+    }
+
+    pub(super) fn receive_with(
+        &mut self,
+        consume: &mut dyn FnMut(&[u8]) -> usize,
+    ) -> NetDeviceResult<usize> {
+        let frame = self.receive_owned()?;
+        Ok(frame.read_with(consume))
     }
 
     fn transmit(&mut self, frame: &ProtocolEthernetFrame) -> NetDeviceResult {
+        self.transmit_frame_with_options(
+            frame.packet_len(),
+            TxSubmitOptions::default(),
+            &mut |target| target.copy_from_slice(frame.packet()),
+        )
+    }
+
+    pub(super) fn transmit_frame_with_options(
+        &mut self,
+        frame_len: usize,
+        options: TxSubmitOptions,
+        fill: &mut dyn FnMut(&mut [u8]),
+    ) -> NetDeviceResult {
         let Some(mut buffer) = self.tx_spares.pop().or_else(|| self.tx_free.pop()) else {
             return Err(NetDeviceError::Again);
         };
-        if buffer.set_len(frame.packet_len()).is_err() {
+        let tx_len = frame_len.max(ETH_ZLEN);
+        if buffer.set_len(tx_len).is_err() {
             self.tx_spares.push(buffer);
             return Err(NetDeviceError::InvalidParam);
         }
-        buffer.write_with_cpu(|target| target.copy_from_slice(frame.packet()));
-        if let Err(buffer) = self.tx_ready.push(buffer) {
-            self.tx_spares.push(buffer);
+        buffer.write_with_cpu(|target| {
+            fill(&mut target[..frame_len]);
+            target[frame_len..].fill(0);
+        });
+        if let Err(request) = self.tx_ready.push(TxRequest { buffer, options }) {
+            self.tx_spares.push(request.buffer);
             return Err(NetDeviceError::Again);
         }
         self.shared.schedule_task();
@@ -87,6 +176,7 @@ pub(super) struct QueueFramePort {
     pub(super) groups: Vec<ProtocolGroupPort>,
     pub(super) next_rx: usize,
     pub(super) next_tx: usize,
+    pub(super) checksum_capabilities: TxChecksumCapabilities,
 }
 
 impl EthernetFramePort for QueueFramePort {
@@ -96,6 +186,10 @@ impl EthernetFramePort for QueueFramePort {
 
     fn mac_address(&self) -> [u8; 6] {
         *self.mac.lock_irqsave()
+    }
+
+    fn checksum_capabilities(&self) -> TxChecksumCapabilities {
+        self.checksum_capabilities
     }
 
     fn transmit(&mut self, frame: &ProtocolEthernetFrame) -> NetDeviceResult {
@@ -110,6 +204,36 @@ impl EthernetFramePort for QueueFramePort {
                     return Ok(());
                 }
                 Err(NetDeviceError::Again) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Err(NetDeviceError::Again)
+    }
+
+    fn transmit_frame_with_options(
+        &mut self,
+        frame_len: usize,
+        options: TxSubmitOptions,
+        fill: &mut dyn FnMut(&mut [u8]),
+    ) -> NetDeviceResult {
+        if self.groups.is_empty() {
+            return Err(NetDeviceError::Stopped);
+        }
+        for offset in 0..self.groups.len() {
+            let index = (self.next_tx + offset) % self.groups.len();
+            let mut filled = false;
+            let mut fill_once = |target: &mut [u8]| {
+                filled = true;
+                fill(target);
+            };
+            match self.groups[index].transmit_frame_with_options(frame_len, options, &mut fill_once)
+            {
+                Ok(()) => {
+                    self.next_tx = (index + 1) % self.groups.len();
+                    return Ok(());
+                }
+                Err(NetDeviceError::Again) if !filled => {}
+                Err(NetDeviceError::Again) => return Err(NetDeviceError::Again),
                 Err(error) => return Err(error),
             }
         }
@@ -133,6 +257,42 @@ impl EthernetFramePort for QueueFramePort {
         }
         Err(NetDeviceError::Again)
     }
+
+    fn receive_owned(&mut self) -> NetDeviceResult<Option<ProtocolRxFrame>> {
+        if self.groups.is_empty() {
+            return Err(NetDeviceError::Stopped);
+        }
+        for offset in 0..self.groups.len() {
+            let index = (self.next_rx + offset) % self.groups.len();
+            match self.groups[index].receive_owned() {
+                Ok(frame) => {
+                    self.next_rx = (index + 1) % self.groups.len();
+                    return Ok(Some(frame));
+                }
+                Err(NetDeviceError::Again) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Err(NetDeviceError::Again)
+    }
+
+    fn receive_with(&mut self, consume: &mut dyn FnMut(&[u8]) -> usize) -> NetDeviceResult<usize> {
+        if self.groups.is_empty() {
+            return Err(NetDeviceError::Stopped);
+        }
+        for offset in 0..self.groups.len() {
+            let index = (self.next_rx + offset) % self.groups.len();
+            match self.groups[index].receive_with(consume) {
+                Ok(consumed) => {
+                    self.next_rx = (index + 1) % self.groups.len();
+                    return Ok(consumed);
+                }
+                Err(NetDeviceError::Again) => {}
+                Err(error) => return Err(error),
+            }
+        }
+        Err(NetDeviceError::Again)
+    }
 }
 
 pub(super) enum GroupPollOutcome {
@@ -140,6 +300,11 @@ pub(super) enum GroupPollOutcome {
     More(usize),
     Blocked(usize),
     Failed,
+}
+
+pub(super) struct PendingRxRefill {
+    completion: RxCompletion,
+    replacement: DmaBuffer,
 }
 
 pub(super) const fn hardware_retry_outcome(work: usize) -> GroupPollOutcome {
@@ -184,11 +349,13 @@ pub(super) struct QueueGroupExecutor {
     pub(super) group: PreparedNetPollGroup,
     pub(super) rx_ready: SpscProducer<RxCompletion>,
     pub(super) rx_recycle: SpscConsumer<DmaBuffer>,
-    pub(super) tx_ready: SpscConsumer<DmaBuffer>,
+    pub(super) rx_recycler: Arc<RxRecycler>,
+    pub(super) rx_spares: Vec<DmaBuffer>,
+    pub(super) tx_ready: SpscConsumer<TxRequest>,
     pub(super) tx_free: SpscProducer<DmaBuffer>,
     pub(super) pending_rx: Option<RxCompletion>,
-    pub(super) pending_rx_recycle: Option<DmaBuffer>,
-    pub(super) pending_tx: Option<DmaBuffer>,
+    pub(super) pending_rx_refill: Option<PendingRxRefill>,
+    pub(super) pending_tx: Option<TxRequest>,
     pub(super) pending_tx_free: Option<DmaBuffer>,
     pub(super) retry_at: Option<u64>,
     pub(super) shared: Arc<PollGroupState>,
@@ -273,41 +440,33 @@ impl QueueGroupExecutor {
             }
             crate::request_poll();
         }
-        let mut rx_refill_blocked = false;
-        if let Some(buffer) = self.pending_rx_recycle.take() {
-            match self.group.rx.recycle(buffer) {
-                Ok(()) => work += 1,
-                Err(error) => {
-                    let (buffer, reason) = error.into_parts();
-                    self.pending_rx_recycle = Some(buffer);
-                    if !matches!(reason, NetError::Retry) {
-                        self.shared.disable();
-                        return GroupPollOutcome::Failed;
-                    }
-                    rx_refill_blocked = true;
-                }
-            }
-        }
-
         let per_class = QUEUE_BUDGET.min(cpu_budget.saturating_sub(work));
-        let mut recycled = 0;
-        while !rx_refill_blocked && recycled < per_class {
-            let Some(buffer) = self.rx_recycle.pop() else {
-                break;
-            };
-            match self.group.rx.recycle(buffer) {
+        let recycled =
+            self.rx_recycler
+                .drain_into(&mut self.rx_recycle, &mut self.rx_spares, per_class);
+        work += recycled;
+
+        if let Some(pending) = self.pending_rx_refill.take() {
+            match self.group.rx.recycle(pending.replacement) {
                 Ok(()) => {
-                    recycled += 1;
                     work += 1;
+                    if let Err(completion) = self.rx_ready.push(pending.completion) {
+                        self.pending_rx = Some(completion);
+                        return GroupPollOutcome::Blocked(work);
+                    }
+                    crate::request_poll();
                 }
                 Err(error) => {
-                    let (buffer, reason) = error.into_parts();
-                    self.pending_rx_recycle = Some(buffer);
-                    if !matches!(reason, NetError::Retry) {
-                        self.shared.disable();
-                        return GroupPollOutcome::Failed;
+                    let (replacement, reason) = error.into_parts();
+                    self.pending_rx_refill = Some(PendingRxRefill {
+                        completion: pending.completion,
+                        replacement,
+                    });
+                    if matches!(reason, NetError::Retry) {
+                        return hardware_retry_outcome(work);
                     }
-                    rx_refill_blocked = true;
+                    self.shared.disable();
+                    return GroupPollOutcome::Failed;
                 }
             }
         }
@@ -320,6 +479,30 @@ impl QueueGroupExecutor {
             };
             received += 1;
             work += 1;
+            let replacement = match self.rx_spares.pop() {
+                Some(buffer) => buffer,
+                None => match self.group.rx.allocate_replacement() {
+                    Ok(buffer) => buffer,
+                    Err(_) => {
+                        self.shared.disable();
+                        return GroupPollOutcome::Failed;
+                    }
+                },
+            };
+            // Keep the hardware ring full before the completed token crosses
+            // into protocol ownership and may be retained by smoltcp.
+            if let Err(error) = self.group.rx.recycle(replacement) {
+                let (replacement, reason) = error.into_parts();
+                self.pending_rx_refill = Some(PendingRxRefill {
+                    completion,
+                    replacement,
+                });
+                if matches!(reason, NetError::Retry) {
+                    return rx_refill_retry_outcome(work, received);
+                }
+                self.shared.disable();
+                return GroupPollOutcome::Failed;
+            }
             if let Err(completion) = self.rx_ready.push(completion) {
                 self.pending_rx = Some(completion);
                 return GroupPollOutcome::Blocked(work);
@@ -345,11 +528,15 @@ impl QueueGroupExecutor {
         let tx_submit_budget = QUEUE_BUDGET.min(cpu_budget.saturating_sub(work));
         let mut submitted = 0;
         while submitted < tx_submit_budget {
-            let buffer = match self.pending_tx.take().or_else(|| self.tx_ready.pop()) {
-                Some(buffer) => buffer,
+            let request = match self.pending_tx.take().or_else(|| self.tx_ready.pop()) {
+                Some(request) => request,
                 None => break,
             };
-            match self.group.tx.submit(buffer) {
+            match self
+                .group
+                .tx
+                .submit_with_options(request.buffer, request.options)
+            {
                 Ok(()) => {
                     submitted += 1;
                     work += 1;
@@ -357,19 +544,27 @@ impl QueueGroupExecutor {
                 Err(error) => {
                     let (buffer, reason) = error.into_parts();
                     if waits_for_hardware_event(&reason) {
-                        self.pending_tx = Some(buffer);
+                        self.pending_tx = Some(TxRequest {
+                            buffer,
+                            options: request.options,
+                        });
+                        if submitted > 0 {
+                            self.group.tx.flush();
+                        }
                         return hardware_retry_outcome(work);
                     }
                     if let Err(buffer) = self.tx_free.push(buffer) {
                         self.pending_tx_free = Some(buffer);
+                        if submitted > 0 {
+                            self.group.tx.flush();
+                        }
                         return GroupPollOutcome::Blocked(work);
                     }
                 }
             }
         }
-
-        if rx_refill_blocked {
-            return rx_refill_retry_outcome(work, received);
+        if submitted > 0 {
+            self.group.tx.flush();
         }
 
         let exhausted = budget_was_exhausted(received, rx_budget)

--- a/net/ax-net/src/queue_runtime/mod.rs
+++ b/net/ax-net/src/queue_runtime/mod.rs
@@ -372,18 +372,31 @@ impl<'a> NetworkRuntimeBuilder<'a> {
                 poll_groups,
             } = input.device;
             let mut protocol_groups = Vec::with_capacity(poll_groups.len());
+            let mut checksum_capabilities = None;
             let mut wifi_target = None;
             for mut group in poll_groups {
+                checksum_capabilities = Some(checksum_capabilities.map_or(
+                    group.tx.checksum_capabilities(),
+                    |current: rd_net::TxChecksumCapabilities| {
+                        current.intersection(group.tx.checksum_capabilities())
+                    },
+                ));
                 let owner_cpu = group_owners[flat_group];
                 let owner_group_index = groups_by_cpu[owner_cpu].len();
                 let shared = Arc::new(PollGroupState::new(
                     owner_cpu,
                     Arc::clone(&cpu_notifies[owner_cpu]),
                 ));
-                let (rx_ready_tx, rx_ready_rx) = spsc_ring(group.rx.capacity());
-                let (rx_recycle_tx, rx_recycle_rx) = spsc_ring(group.rx.capacity());
+                let rx_capacity = group.rx.capacity();
+                let (rx_ready_tx, rx_ready_rx) = spsc_ring(rx_capacity);
+                let (rx_recycle_tx, rx_recycle_rx) = spsc_ring(rx_capacity);
                 let (tx_ready_tx, tx_ready_rx) = spsc_ring(group.tx.capacity());
                 let (tx_free_tx, tx_free_rx) = spsc_ring(group.tx.capacity());
+                let rx_recycler = Arc::new(RxRecycler::new(
+                    rx_recycle_tx,
+                    Arc::clone(&shared),
+                    rx_capacity,
+                ));
 
                 for endpoint in group.irq_endpoints.drain(..) {
                     let irq = resolve_endpoint_irq(&input.irq_sources, endpoint.source_id())
@@ -404,10 +417,9 @@ impl<'a> NetworkRuntimeBuilder<'a> {
 
                 protocol_groups.push(ProtocolGroupPort {
                     rx_ready: rx_ready_rx,
-                    rx_recycle: rx_recycle_tx,
+                    rx_recycler: Arc::clone(&rx_recycler),
                     tx_ready: tx_ready_tx,
                     tx_free: tx_free_rx,
-                    pending_recycle: Vec::with_capacity(group.rx.capacity()),
                     tx_spares: Vec::with_capacity(group.tx.capacity()),
                     shared: Arc::clone(&shared),
                 });
@@ -415,10 +427,12 @@ impl<'a> NetworkRuntimeBuilder<'a> {
                     group,
                     rx_ready: rx_ready_tx,
                     rx_recycle: rx_recycle_rx,
+                    rx_recycler,
+                    rx_spares: Vec::with_capacity(rx_capacity.max(QUEUE_BUDGET)),
                     tx_ready: tx_ready_rx,
                     tx_free: tx_free_tx,
                     pending_rx: None,
-                    pending_rx_recycle: None,
+                    pending_rx_refill: None,
                     pending_tx: None,
                     pending_tx_free: None,
                     retry_at: None,
@@ -458,6 +472,8 @@ impl<'a> NetworkRuntimeBuilder<'a> {
                 groups: protocol_groups,
                 next_rx: 0,
                 next_tx: 0,
+                checksum_capabilities: checksum_capabilities
+                    .unwrap_or(rd_net::TxChecksumCapabilities::NONE),
             }) as Box<dyn EthernetFramePort>);
         }
 

--- a/net/ax-net/src/queue_runtime/tests.rs
+++ b/net/ax-net/src/queue_runtime/tests.rs
@@ -7,6 +7,7 @@ use std::{
 use irq_framework::{HwIrq, IrqDomainId};
 use rd_net::{
     DmaBuffer, NetControlEndpoint, NetDeviceInfo, PreparedNetDevice, RxCompletion,
+    TxNetworkProtocol, TxNotify, TxSubmitOptions, TxTransportProtocol,
     dma_api::{
         DeviceDma, DmaAllocHandle, DmaCoherency, DmaConstraints, DmaDeviceInfo, DmaDirection,
         DmaDomainId, DmaError, DmaMapHandle, DmaOp,
@@ -331,29 +332,29 @@ fn oversized_rx_frame_recycles_token_and_next_frame_remains_receivable() {
     rx_recycle_tx.push(occupied).unwrap();
 
     let shared = Arc::new(group_state(STATE_IDLE));
+    let rx_recycler = Arc::new(RxRecycler::new(rx_recycle_tx, Arc::clone(&shared), 2));
     let mut port = ProtocolGroupPort {
         rx_ready: rx_ready_rx,
-        rx_recycle: rx_recycle_tx,
+        rx_recycler,
         tx_ready: tx_ready_tx,
         tx_free: tx_free_rx,
-        pending_recycle: Vec::with_capacity(2),
         tx_spares: Vec::new(),
         shared,
     };
 
     assert!(matches!(port.receive(), Err(NetDeviceError::InvalidParam)));
-    assert_eq!(port.pending_recycle.len(), 1);
+    assert_eq!(port.rx_recycler.overflow_len(), 1);
     assert_eq!(rx_recycle_rx.pop().unwrap().bus_addr(), occupied_bus_addr);
 
     let frame = port
         .receive()
         .expect("a malformed frame must not consume the next completion");
     assert_eq!(frame.packet_len(), 64);
-    assert_eq!(rx_recycle_rx.pop().unwrap().bus_addr(), oversized_bus_addr);
-
-    port.flush_recycle();
     assert_eq!(rx_recycle_rx.pop().unwrap().bus_addr(), valid_bus_addr);
-    assert!(port.pending_recycle.is_empty());
+
+    port.rx_recycler.flush_overflow();
+    assert_eq!(rx_recycle_rx.pop().unwrap().bus_addr(), oversized_bus_addr);
+    assert_eq!(port.rx_recycler.overflow_len(), 0);
 
     let invalid_length = dma_buffer(2048, 2048);
     let invalid_length_bus_addr = invalid_length.bus_addr();
@@ -368,6 +369,119 @@ fn oversized_rx_frame_recycles_token_and_next_frame_remains_receivable() {
         rx_recycle_rx.pop().unwrap().bus_addr(),
         invalid_length_bus_addr
     );
+}
+
+#[test]
+fn direct_rx_consumes_dma_backing_before_recycling_the_token() {
+    let (mut rx_ready_tx, rx_ready_rx) = spsc_ring(1);
+    let (rx_recycle_tx, mut rx_recycle_rx) = spsc_ring(1);
+    let (tx_ready_tx, _tx_ready_rx) = spsc_ring(1);
+    let (_tx_free_tx, tx_free_rx) = spsc_ring(1);
+    let mut buffer = dma_buffer(4096, 4096);
+    buffer.write_with_cpu(|packet| packet[..3000].fill(0x5a));
+    let bus_addr = buffer.bus_addr();
+    rx_ready_tx
+        .push(RxCompletion {
+            buffer,
+            packet_len: 3000,
+        })
+        .unwrap();
+
+    let shared = Arc::new(group_state(STATE_IDLE));
+    let mut port = ProtocolGroupPort {
+        rx_ready: rx_ready_rx,
+        rx_recycler: Arc::new(RxRecycler::new(rx_recycle_tx, Arc::clone(&shared), 1)),
+        tx_ready: tx_ready_tx,
+        tx_free: tx_free_rx,
+        tx_spares: Vec::new(),
+        shared,
+    };
+    let consumed = port
+        .receive_with(&mut |packet| {
+            assert_eq!(packet.len(), 3000);
+            assert!(packet.iter().all(|byte| *byte == 0x5a));
+            packet.len()
+        })
+        .unwrap();
+
+    assert_eq!(consumed, 3000);
+    assert_eq!(rx_recycle_rx.pop().unwrap().bus_addr(), bus_addr);
+}
+
+#[test]
+fn detached_rx_retains_dma_until_the_owned_frame_is_dropped() {
+    let (mut rx_ready_tx, rx_ready_rx) = spsc_ring(1);
+    let (rx_recycle_tx, mut rx_recycle_rx) = spsc_ring(1);
+    let (tx_ready_tx, _tx_ready_rx) = spsc_ring(1);
+    let (_tx_free_tx, tx_free_rx) = spsc_ring(1);
+    let mut buffer = dma_buffer(4096, 4096);
+    buffer.write_with_cpu(|packet| packet[..3000].fill(0x6b));
+    let bus_addr = buffer.bus_addr();
+    rx_ready_tx
+        .push(RxCompletion {
+            buffer,
+            packet_len: 3000,
+        })
+        .unwrap();
+
+    let shared = Arc::new(group_state(STATE_IDLE));
+    let mut port = ProtocolGroupPort {
+        rx_ready: rx_ready_rx,
+        rx_recycler: Arc::new(RxRecycler::new(rx_recycle_tx, Arc::clone(&shared), 1)),
+        tx_ready: tx_ready_tx,
+        tx_free: tx_free_rx,
+        tx_spares: Vec::new(),
+        shared,
+    };
+    let frame = port
+        .receive_owned()
+        .expect("the queued DMA frame must be returned as owned storage");
+
+    assert!(rx_recycle_rx.pop().is_none());
+    frame.read_with(|packet| {
+        assert_eq!(packet.len(), 3000);
+        assert!(packet.iter().all(|byte| *byte == 0x6b));
+    });
+    drop(frame);
+    assert_eq!(rx_recycle_rx.pop().unwrap().bus_addr(), bus_addr);
+}
+
+#[test]
+fn direct_tx_fills_dma_and_preserves_submission_options() {
+    let (_rx_ready_tx, rx_ready_rx) = spsc_ring(1);
+    let (rx_recycle_tx, _rx_recycle_rx) = spsc_ring(1);
+    let (tx_ready_tx, mut tx_ready_rx) = spsc_ring(1);
+    let (mut tx_free_tx, tx_free_rx) = spsc_ring(1);
+    tx_free_tx.push(dma_buffer(2048, 2048)).unwrap();
+    let shared = Arc::new(group_state(STATE_IDLE));
+    let mut port = ProtocolGroupPort {
+        rx_ready: rx_ready_rx,
+        rx_recycler: Arc::new(RxRecycler::new(rx_recycle_tx, Arc::clone(&shared), 1)),
+        tx_ready: tx_ready_tx,
+        tx_free: tx_free_rx,
+        tx_spares: Vec::new(),
+        shared,
+    };
+    let options = TxSubmitOptions::deferred(Some(rd_net::TxChecksumOffload {
+        network: TxNetworkProtocol::Ipv4,
+        transport: TxTransportProtocol::Tcp,
+        transport_offset: 34,
+    }));
+
+    port.transmit_frame_with_options(100, options, &mut |packet| {
+        packet.fill(0xa5);
+    })
+    .unwrap();
+
+    let request = tx_ready_rx
+        .pop()
+        .expect("one DMA request must be published");
+    assert_eq!(request.options, options);
+    assert_eq!(request.buffer.len(), 100);
+    request.buffer.read_with_cpu(100, |packet| {
+        assert!(packet.iter().all(|byte| *byte == 0xa5));
+    });
+    assert_eq!(options.notify, TxNotify::Deferred);
 }
 
 fn group_state(initial: u8) -> PollGroupState {

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -16,12 +16,12 @@
 //!
 //! # Data Paths
 //!
-//! - Queue executors publish RX DMA tokens into bounded SPSC rings. The unique
-//!   protocol executor copies a frame from the selected port and returns the
-//!   token through its recycle ring before `Router::poll()` consumes the packet.
+//! - Queue executors replace a completed RX descriptor before publishing its
+//!   old DMA token. The token remains owned through smoltcp `RxToken::consume`
+//!   and then returns to the queue-local replacement cache.
 //! - smoltcp TX writes into `tx_buffer`. `Router::dispatch()` parses the IP
-//!   destination, selects a route, and publishes the packet to the chosen frame
-//!   port's TX SPSC ring.
+//!   destination, selects a route, and fills a queue-owned DMA token directly.
+//!   A descriptor batch shares one device notification.
 //! - Loopback bypasses hardware queue domains: dispatch copies directly
 //!   from TX buffer to RX buffer and asks the protocol core to poll again.
 //!
@@ -32,6 +32,7 @@
 
 use alloc::{
     boxed::Box,
+    collections::VecDeque,
     string::{String, ToString},
     sync::Arc,
     vec,
@@ -43,7 +44,7 @@ use ax_hal::time::{NANOS_PER_MICROS, monotonic_time_nanos};
 use ax_sync::SpinRwLock as RwLock;
 use smoltcp::{
     iface::SocketSet,
-    phy::{DeviceCapabilities, Medium, PacketMeta},
+    phy::{Checksum, DeviceCapabilities, Medium, PacketMeta},
     storage::PacketMetadata,
     time::Instant,
     wire::{
@@ -56,7 +57,10 @@ use crate::{
     LISTEN_TABLE,
     config::{DeviceBinding, InterfaceId, RouteInfo},
     consts::{SOCKET_BUFFER_SIZE, STANDARD_MTU},
-    device::{ArpEntry, Device},
+    device::{
+        ArpEntry, Device, DeviceRxPacket, DeviceRxPoll, NetDeviceError, TxChecksumCapabilities,
+        fill_transport_checksum,
+    },
     ip_tos::apply_egress_ip_tos,
     rx_meta::packet_meta_for_rx_packet,
 };
@@ -141,6 +145,11 @@ struct RxMetadata {
 
 type RouterPacketBuffer = smoltcp::storage::PacketBuffer<'static, RxMetadata>;
 type DevicePacketBuffer = smoltcp::storage::PacketBuffer<'static, InterfaceId>;
+
+struct OwnedRxPacket {
+    metadata: RxMetadata,
+    packet: DeviceRxPacket,
+}
 
 // TX metadata is created before route lookup; dispatch() selects the real
 // egress interface from the packet destination and route table.
@@ -286,6 +295,24 @@ impl DeviceHandle {
     }
 
     fn send(&mut self, next_hop: IpAddress, packet: &[u8], timestamp: Instant) -> bool {
+        match self.try_send(next_hop, packet, timestamp) {
+            Ok(consumed) => consumed,
+            Err(NetDeviceError::Again) => false,
+            Err(error) => {
+                warn!("{}: transmit failed: {error:?}", self.name);
+                self.count_tx_errors(1);
+                self.drain_device_counters();
+                false
+            }
+        }
+    }
+
+    fn try_send(
+        &mut self,
+        next_hop: IpAddress,
+        packet: &[u8],
+        timestamp: Instant,
+    ) -> Result<bool, NetDeviceError> {
         if packet.len() > STANDARD_MTU {
             warn!(
                 "{}: packet to {} exceeds MTU ({} bytes), dropping",
@@ -294,15 +321,14 @@ impl DeviceHandle {
                 packet.len()
             );
             self.count_tx_dropped(1);
-            self.count_tx_dropped(1);
-            return false;
+            return Ok(false);
         }
-        let frame_len = self.inner.send(next_hop, packet, timestamp);
+        let frame_len = self.inner.try_send(next_hop, packet, timestamp)?;
         if frame_len > 0 {
             self.count_tx(frame_len);
         }
         self.drain_device_counters();
-        true
+        Ok(true)
     }
 }
 
@@ -438,6 +464,10 @@ pub(crate) type SharedRouteTable = Arc<RwLock<RouteTable>>;
 pub struct Router {
     rx_buffer: RouterPacketBuffer,
     tx_buffer: RouterPacketBuffer,
+    /// DMA-backed packets waiting for smoltcp consumption.
+    ready_rx: VecDeque<OwnedRxPacket>,
+    /// Checksum operations common to every registered physical TX path.
+    tx_checksum_capabilities: Option<TxChecksumCapabilities>,
     devices: Vec<DeviceHandle>,
     table: SharedRouteTable,
 }
@@ -455,6 +485,8 @@ impl Router {
         Self {
             rx_buffer,
             tx_buffer,
+            ready_rx: VecDeque::with_capacity(SOCKET_BUFFER_SIZE),
+            tx_checksum_capabilities: None,
             devices: Vec::new(),
             table,
         }
@@ -467,6 +499,13 @@ impl Router {
 
     /// Registers a concrete device and returns its router device index.
     pub fn add_device(&mut self, interface_id: InterfaceId, device: Box<dyn Device>) -> usize {
+        if interface_id != InterfaceId::LOOPBACK {
+            let capabilities = device.tx_checksum_capabilities();
+            self.tx_checksum_capabilities = Some(
+                self.tx_checksum_capabilities
+                    .map_or(capabilities, |current| current.intersection(capabilities)),
+            );
+        }
         self.devices.push(DeviceHandle::new(interface_id, device));
         self.devices.len() - 1
     }
@@ -549,13 +588,64 @@ impl Router {
         mut snoop: impl FnMut(InterfaceId, &[u8]),
     ) -> bool {
         let mut moved_rx = false;
-        for device in &mut self.devices {
+        let Router {
+            rx_buffer,
+            ready_rx,
+            devices,
+            ..
+        } = self;
+        for device in devices {
             if device.interface_id == InterfaceId::LOOPBACK {
                 continue;
             }
             let mut budget = DEVICE_RX_WORKER_BATCH;
-            while budget > 0 && !self.rx_buffer.is_full() && !device.rx_buffer.is_full() {
+            while budget > 0 && ready_rx.len() < SOCKET_BUFFER_SIZE {
+                let interface_id = device.interface_id;
+                match device.inner.poll_owned_rx(now()) {
+                    DeviceRxPoll::Packet(packet) => {
+                        let metadata = packet.read_with(|bytes| {
+                            snoop_tcp_packet(bytes, sockets);
+                            snoop(interface_id, bytes);
+                            rx_metadata(interface_id, bytes)
+                        });
+                        let frame_len = packet.frame_len();
+                        ready_rx.push_back(OwnedRxPacket { metadata, packet });
+                        device.count_rx(frame_len);
+                        moved_rx = true;
+                        budget -= 1;
+                        continue;
+                    }
+                    DeviceRxPoll::Idle => break,
+                    DeviceRxPoll::Unsupported => {}
+                }
+                if rx_buffer.is_full() || device.rx_buffer.is_full() {
+                    break;
+                }
                 let mut frame_snoop = |_packet: &[u8]| {};
+                let direct = device.inner.recv_direct(
+                    now(),
+                    &mut |packet| {
+                        snoop_tcp_packet(packet, sockets);
+                        snoop(interface_id, packet);
+                        let Ok(dst) =
+                            rx_buffer.enqueue(packet.len(), rx_metadata(interface_id, packet))
+                        else {
+                            return false;
+                        };
+                        dst.copy_from_slice(packet);
+                        true
+                    },
+                    &mut frame_snoop,
+                );
+                if let Some(frame_len) = direct {
+                    if frame_len == 0 {
+                        break;
+                    }
+                    device.count_rx(frame_len);
+                    moved_rx = true;
+                    budget -= 1;
+                    continue;
+                }
                 let frame_len = device.inner.recv(
                     device.interface_id,
                     &mut device.rx_buffer,
@@ -571,9 +661,7 @@ impl Router {
                 };
                 snoop_tcp_packet(packet, sockets);
                 snoop(interface_id, packet);
-                let Ok(dst) = self
-                    .rx_buffer
-                    .enqueue(packet.len(), rx_metadata(interface_id, packet))
+                let Ok(dst) = rx_buffer.enqueue(packet.len(), rx_metadata(interface_id, packet))
                 else {
                     device.count_rx_dropped(1);
                     break;
@@ -653,19 +741,21 @@ impl Router {
             table,
             ..
         } = self;
-        while let Ok((_, packet)) = tx_buffer.dequeue() {
-            apply_egress_ip_tos(packet);
-            match IpVersion::of_packet(packet).expect("got invalid IP packet") {
+        while let Ok((_, packet)) = tx_buffer.peek() {
+            let outcome = match IpVersion::of_packet(packet).expect("got invalid IP packet") {
                 IpVersion::Ipv4 => {
                     let packet = smoltcp::wire::Ipv4Packet::new_checked(packet)
                         .expect("got invalid IPv4 packet");
                     let src_addr = IpAddress::Ipv4(packet.src_addr());
                     let dst_addr = IpAddress::Ipv4(packet.dst_addr());
                     if packet.dst_addr().is_broadcast() {
-                        poll_next |=
-                            dispatch_link_local_fanout(devices, dst_addr, packet.into_inner());
+                        DispatchOutcome::Consumed(dispatch_link_local_fanout(
+                            devices,
+                            dst_addr,
+                            packet.into_inner(),
+                        ))
                     } else {
-                        poll_next |= dispatch_unicast_packet(
+                        dispatch_unicast_packet(
                             rx_buffer,
                             devices,
                             table,
@@ -673,7 +763,7 @@ impl Router {
                             dst_addr,
                             packet.into_inner(),
                             sockets,
-                        );
+                        )
                     }
                 }
                 IpVersion::Ipv6 => {
@@ -682,10 +772,13 @@ impl Router {
                     let src_addr = IpAddress::Ipv6(packet.src_addr());
                     let dst_addr = IpAddress::Ipv6(packet.dst_addr());
                     if packet.dst_addr().is_multicast() {
-                        poll_next |=
-                            dispatch_link_local_fanout(devices, dst_addr, packet.into_inner());
+                        DispatchOutcome::Consumed(dispatch_link_local_fanout(
+                            devices,
+                            dst_addr,
+                            packet.into_inner(),
+                        ))
                     } else {
-                        poll_next |= dispatch_unicast_packet(
+                        dispatch_unicast_packet(
                             rx_buffer,
                             devices,
                             table,
@@ -693,9 +786,18 @@ impl Router {
                             dst_addr,
                             packet.into_inner(),
                             sockets,
-                        );
+                        )
                     }
                 }
+            };
+            match outcome {
+                DispatchOutcome::Consumed(next) => {
+                    poll_next |= next;
+                    tx_buffer
+                        .dequeue()
+                        .expect("the packet was only peeked while dispatching");
+                }
+                DispatchOutcome::Retry => break,
             }
         }
         poll_next
@@ -716,6 +818,12 @@ fn dispatch_link_local_fanout(
     poll_next
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DispatchOutcome {
+    Consumed(bool),
+    Retry,
+}
+
 fn dispatch_unicast_packet(
     rx_buffer: &mut RouterPacketBuffer,
     devices: &mut [DeviceHandle],
@@ -724,7 +832,7 @@ fn dispatch_unicast_packet(
     dst_addr: IpAddress,
     packet: &[u8],
     sockets: &mut SocketSet<'_>,
-) -> bool {
+) -> DispatchOutcome {
     let route = {
         let routes = table.read();
         let Some(route) = routes.select_route_for_source(&dst_addr, &src_addr) else {
@@ -737,7 +845,7 @@ fn dispatch_unicast_packet(
             // IPSTATS_MIB_OUTNOROUTES (IpOutNoRoutes in /proc/net/snmp), never via
             // per-device tx_dropped.  Once system-level SNMP counters are available
             // this should update IpOutNoRoutes instead.
-            return false;
+            return DispatchOutcome::Consumed(false);
         };
         route
     };
@@ -760,9 +868,18 @@ fn dispatch_unicast_packet(
             // behaves identically.
             dev.count_rx_dropped(1);
         }
-        ok
+        DispatchOutcome::Consumed(ok)
     } else {
-        dev.send(route.next_hop, packet, now())
+        match dev.try_send(route.next_hop, packet, now()) {
+            Ok(consumed) => DispatchOutcome::Consumed(consumed),
+            Err(NetDeviceError::Again) => DispatchOutcome::Retry,
+            Err(error) => {
+                warn!("{}: transmit failed: {error:?}", dev.name);
+                dev.count_tx_errors(1);
+                dev.drain_device_counters();
+                DispatchOutcome::Consumed(false)
+            }
+        }
     }
 }
 
@@ -780,6 +897,7 @@ fn inject_loopback_rx_direct(
         return false;
     };
     dst.copy_from_slice(packet);
+    fill_transport_checksum(dst);
     true
 }
 
@@ -793,10 +911,13 @@ impl smoltcp::phy::TxToken for TxToken<'_> {
     {
         // TX metadata is ignored: Router::dispatch parses the emitted IP
         // packet and selects the actual egress interface from the route table.
-        f(self
+        let packet = self
             .0
             .enqueue(len, tx_metadata())
-            .expect("This was checked before creating the TxToken"))
+            .expect("This was checked before creating the TxToken");
+        let result = f(packet);
+        apply_egress_ip_tos(packet);
+        result
     }
 }
 
@@ -845,11 +966,16 @@ fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
     }
 }
 
+enum RxTokenPacket<'a> {
+    Borrowed(&'a [u8]),
+    Owned(DeviceRxPacket),
+}
+
 /// smoltcp RX token for one packet queued by the router.
 pub struct RxToken<'a> {
     interface_id: InterfaceId,
     packet_meta: PacketMeta,
-    packet: &'a [u8],
+    packet: RxTokenPacket<'a>,
 }
 
 impl<'a> smoltcp::phy::RxToken for RxToken<'a> {
@@ -858,7 +984,10 @@ impl<'a> smoltcp::phy::RxToken for RxToken<'a> {
         F: FnOnce(&[u8]) -> R,
     {
         let _ingress_if = self.interface_id;
-        f(self.packet)
+        match self.packet {
+            RxTokenPacket::Borrowed(packet) => f(packet),
+            RxTokenPacket::Owned(packet) => packet.consume(f),
+        }
     }
 
     fn meta(&self) -> PacketMeta {
@@ -871,21 +1000,31 @@ impl smoltcp::phy::Device for Router {
     type TxToken<'a> = TxToken<'a>;
 
     fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-        if self.rx_buffer.is_empty() || self.tx_buffer.is_full() {
-            None
-        } else {
-            Some((
-                {
-                    let (metadata, packet) = self.rx_buffer.dequeue().unwrap();
-                    RxToken {
-                        interface_id: metadata.interface_id,
-                        packet_meta: metadata.packet_meta,
-                        packet,
-                    }
-                },
-                TxToken(&mut self.tx_buffer),
-            ))
+        if self.tx_buffer.is_full() {
+            return None;
         }
+        let Self {
+            rx_buffer,
+            ready_rx,
+            tx_buffer,
+            ..
+        } = self;
+        let rx_token = if !rx_buffer.is_empty() {
+            let (metadata, packet) = rx_buffer.dequeue().unwrap();
+            RxToken {
+                interface_id: metadata.interface_id,
+                packet_meta: metadata.packet_meta,
+                packet: RxTokenPacket::Borrowed(packet),
+            }
+        } else {
+            let packet = ready_rx.pop_front()?;
+            RxToken {
+                interface_id: packet.metadata.interface_id,
+                packet_meta: packet.metadata.packet_meta,
+                packet: RxTokenPacket::Owned(packet.packet),
+            }
+        };
+        Some((rx_token, TxToken(tx_buffer)))
     }
 
     fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
@@ -901,6 +1040,14 @@ impl smoltcp::phy::Device for Router {
         caps.medium = Medium::Ip;
         caps.max_transmission_unit = STANDARD_MTU;
         caps.max_burst_size = Some(SOCKET_BUFFER_SIZE);
+        if let Some(checksum) = self.tx_checksum_capabilities {
+            if checksum.supports_tcp() {
+                caps.checksum.tcp = Checksum::Rx;
+            }
+            if checksum.supports_udp() {
+                caps.checksum.udp = Checksum::Rx;
+            }
+        }
         caps
     }
 }
@@ -921,6 +1068,63 @@ mod tests {
     impl Device for EmptyDevice {
         fn name(&self) -> &str {
             "empty"
+        }
+
+        fn recv(
+            &mut self,
+            _interface_id: InterfaceId,
+            _buffer: &mut PacketBuffer<InterfaceId>,
+            _timestamp: Instant,
+            _snoop: &mut dyn FnMut(&[u8]),
+        ) -> usize {
+            0
+        }
+
+        fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> usize {
+            0
+        }
+    }
+
+    struct RetryDevice;
+
+    impl Device for RetryDevice {
+        fn name(&self) -> &str {
+            "retry"
+        }
+
+        fn recv(
+            &mut self,
+            _interface_id: InterfaceId,
+            _buffer: &mut PacketBuffer<InterfaceId>,
+            _timestamp: Instant,
+            _snoop: &mut dyn FnMut(&[u8]),
+        ) -> usize {
+            0
+        }
+
+        fn send(&mut self, _next_hop: IpAddress, _packet: &[u8], _timestamp: Instant) -> usize {
+            0
+        }
+
+        fn try_send(
+            &mut self,
+            _next_hop: IpAddress,
+            _packet: &[u8],
+            _timestamp: Instant,
+        ) -> crate::device::NetDeviceResult<usize> {
+            Err(NetDeviceError::Again)
+        }
+    }
+
+    struct ChecksumDevice;
+
+    impl Device for ChecksumDevice {
+        fn name(&self) -> &str {
+            "checksum"
+        }
+
+        fn tx_checksum_capabilities(&self) -> TxChecksumCapabilities {
+            TxChecksumCapabilities::TCP_UDP
         }
 
         fn recv(
@@ -976,6 +1180,53 @@ mod tests {
             route.next_hop,
             IpAddress::Ipv4(Ipv4Address::new(10, 0, 1, 99))
         );
+    }
+
+    #[test]
+    fn transient_tx_backpressure_keeps_the_router_packet_queued() {
+        let table = Arc::new(RwLock::new(RouteTable::new()));
+        let mut router = Router::new(Arc::clone(&table));
+        router.add_device(IF0, Box::new(RetryDevice));
+        router.add_rule(Rule::new(
+            ipv4_cidr(Ipv4Address::UNSPECIFIED, 0),
+            Some(IpAddress::Ipv4(Ipv4Address::new(10, 0, 0, 1))),
+            0,
+            IF0,
+            SRC0,
+            100,
+        ));
+        let packet = router
+            .tx_buffer
+            .enqueue(20, tx_metadata())
+            .expect("the empty router TX queue has capacity");
+        packet[0] = 0x45;
+        packet[2..4].copy_from_slice(&20u16.to_be_bytes());
+        packet[12..16].copy_from_slice(&[10, 0, 0, 2]);
+        packet[16..20].copy_from_slice(&[198, 51, 100, 1]);
+
+        let mut sockets = SocketSet::new(vec![]);
+        assert!(!router.dispatch(Instant::from_millis(0), &mut sockets));
+        assert_eq!(router.tx_buffer.payload_bytes_count(), 20);
+        assert_eq!(router.devices[0].stats().tx_packets, 0);
+        assert_eq!(router.devices[0].stats().tx_dropped, 0);
+    }
+
+    #[test]
+    fn router_advertises_tx_checksum_offload_only_for_capable_devices() {
+        let table = Arc::new(RwLock::new(RouteTable::new()));
+        let mut router = Router::new(table);
+        router.add_device(IF0, Box::new(ChecksumDevice));
+
+        let caps = smoltcp::phy::Device::capabilities(&router);
+        assert!(caps.checksum.tcp.rx());
+        assert!(!caps.checksum.tcp.tx());
+        assert!(caps.checksum.udp.rx());
+        assert!(!caps.checksum.udp.tx());
+
+        router.add_device(IF1, Box::new(EmptyDevice));
+        let caps = smoltcp::phy::Device::capabilities(&router);
+        assert!(caps.checksum.tcp.tx());
+        assert!(caps.checksum.udp.tx());
     }
 
     #[test]
@@ -1177,7 +1428,7 @@ mod tests {
 
         let before: Vec<_> = devices.iter().map(|d| d.stats()).collect();
 
-        let ok = dispatch_unicast_packet(
+        let outcome = dispatch_unicast_packet(
             &mut rx_buffer,
             &mut devices,
             &shared_table,
@@ -1187,7 +1438,11 @@ mod tests {
             &mut sockets,
         );
 
-        assert!(!ok, "no-route dispatch must return false");
+        assert_eq!(
+            outcome,
+            DispatchOutcome::Consumed(false),
+            "no-route dispatch must consume the packet without scheduling work"
+        );
 
         for (i, dev) in devices.iter().enumerate() {
             let snap = dev.stats();


### PR DESCRIPTION
## 问题

Orange Pi 5 Plus 使用 RTL8125 千兆网卡运行 StarryOS 时，网络热路径仍有多处可以直接消除的开销：

1. TX frame 先在临时对象中构造，再完整复制到驱动 DMA buffer；
2. 每个 TX descriptor 单独写 doorbell，批量发送产生额外 MMIO；
3. TX 热路径周期性读取 PHY/MMIO 状态，增加无关控制面访问；
4. RX buffer 交给协议栈后才补 ring，且 packet 还会经过中间 frame/Router buffer 复制；
5. 无活动 IP_TOS 策略时仍进入策略表查询，小 socket buffer 也限制高带宽时延积场景。

当前 `dev` 已提供 queue-level NAPI、IRQ mask/drain/rearm 状态机和固定 CPU queue executor。本 PR 在这些现有契约上实现 RTL8125 收发性能优化，不重复引入旧版 NAPI 框架，也不通过回退性能路径来换取 CI 正确性。

## 修改

### 1. 扩展通用 TX/RX 队列能力

- `rdif-eth` 增加 `TxChecksumCapabilities`、逐包 `TxChecksumOffload`、`TxNotify` 和 `TxSubmitOptions`，`ITxQueue` 支持带提交选项发送及批次 `flush()`。
- checksum offload 是显式可选能力；不支持请求时返回原 move-only DMA token，调用方可以安全回退而不丢失 buffer 所有权。
- `rd-net` 将提交选项、flush 和 RX replacement 分配适配到上层队列，保持驱动能力边界，不把 RTL8125 细节泄漏到 Router。

### 2. 直接构造 TX DMA frame 并合并 doorbell

- `ax-net` 直接在 queue-owned DMA buffer 中写 Ethernet header、IP packet 和 `ETH_ZLEN` padding，移除队列快路径上的临时完整 frame 及一次整帧复制。
- Router 先 peek packet，仅在提交成功后 dequeue；TX ring 临时返回 `Again` 时保留原 packet，等待 completion 后重试。
- 同一轮 dispatch 使用 deferred notify，批次结束以及提前 retry/blocked 返回前统一 `flush()`。
- RTL8125 使用 checksum-v2 descriptor 为满足约束的 IPv4/IPv6 TCP/UDP packet 执行逐包 checksum offload，并在 MMIO doorbell 前以 Release 顺序发布 descriptor；短 padding frame 使用软件 checksum。

### 3. 先补 RX ring，再把 DMA buffer 交给协议栈

- queue executor reclaim completion 后，优先从 queue-local spare cache 或预建 DMA pool 提交 replacement，再发布旧 DMA token。
- `ProtocolRxFrame` 持有 DMA buffer，经 `EthernetDevice`、Router 一直传递到 smoltcp `RxToken::consume`，消费完成后再回收到原 RX queue。
- DMA 端口不再把 IP payload 复制到中间 frame 或 Router packet buffer；非 DMA 设备继续使用兼容复制路径。
- ARP 和未知二层协议在旧 token 回收前完成处理，避免生命周期提前结束。

### 4. 保留当前 NAPI 正确性并收紧热路径状态

- 直接复用当前基线的 queue-level NAPI、sticky completion readiness 和 IRQ mask/drain/rearm 状态机，性能改动不改变 IRQ ownership。
- RTL8125 TX 使用共享原子 link state，不再每 64 个 packet 读取一次 PHY/MMIO；控制面更新仍发布真实链路状态。
- 网卡 MAC 继续从共享设备状态实时读取，保留最新基线要求的 CI 正确性修复，不恢复静态缓存行为。

### 5. 优化协议栈剩余热路径

- 没有活动 IP_TOS 策略时通过原子状态快速返回，避免逐包进入策略表锁。
- Router 只有在所有物理出口都声明相同能力时才向 smoltcp 公布硬件 TX checksum；loopback 会补齐 smoltcp 在 offload 路径中保留为零的 checksum。
- TCP TX/RX socket buffer 从 64 KiB 调整为固定 256 KiB，以明确的内存预算换取吞吐。
- 正常 packet 进度使用低频 Debug 计数，异常路径保留诊断寄存器；`/proc/net/dev` 按二层 frame 长度统计，不包含 FCS。
- 保留 iperf benchmark 的 TOS 配置检查、receiver 结果判定和统一通过标记。

## 设计与兼容性

- 优化通过通用可选能力下沉到 `rdif-eth`/`rd-net`，Router 不识别 RTL8125；未实现能力的设备保持原有软件 checksum 和复制路径。
- TX DMA token 的返回、提交和 completion 回收均保持 move-only 所有权；RX replacement-before-delivery 保证上层持有 packet 时硬件 ring 仍可继续接收。
- checksum 能力按网络栈初始化时已注册物理出口的共同能力公布；本 PR 不宣称支持运行期新增设备后的 capability refresh。
- 固定 256 KiB TCP buffer 是明确的吞吐/内存取舍，不是 Linux 式自动调节。
- 实现不设置 CPU affinity，不修改 IPI、调度器或板卡启动流程。

## 实现逻辑

1. `rdif-eth` 定义提交选项、checksum 能力和 DMA token 所有权，`rd-net` 将其适配为通用 TX/RX queue API。
2. `ax-net` 在可用时直接取得 TX DMA buffer，完成组帧后批量提交；失败时原 packet 和 DMA token 都有明确归属。
3. RTL8125 发布 descriptor 后延迟写 doorbell，queue executor 在每轮退出前 flush，减少 MMIO 且不延迟已发布工作。
4. RX completion 先获得并提交 replacement，再把旧 buffer 的所有权沿协议栈上移，最终在 `RxToken` 消费结束后回收。
5. 当前基线继续负责 NAPI/IRQ 状态机，本 PR 只在其 queue executor 和驱动数据面上增加性能能力，避免重复框架和回退路径。

> 以下实板性能区段保持原 PR 数据与口径，对应测试 head `25f39db6942c7361f638bcc24a56712d407e7ad0`。当前 head `c3016610e46220356cd28960417f23317b0b6202` 完成最新基线适配后按要求未重新占用板卡，因此不把下列数据表述为当前 head 的重新测量。

## 性能结果

### 测试条件

- 板卡：Orange Pi 5 Plus，RTL8125 千兆链路；
- PR head：`25f39db6942c7361f638bcc24a56712d407e7ad0`；
- rebase 基线 / `dev`：`21353e0dcfd41be4db52a27097bd4233471f3a34`；
- FIT SHA-256：`2e8ce89b534d44278d49c748722c437586c9c500744810b74788c8a89e2537ca`；
- benchmark 脚本 SHA-256：`2414db1cf09172f2c02495f3fe4f8063abd9b9e9e912301001910b9b72b56b57`（仅将轮间冷却改为 15 秒的测试副本）；
- 使用 PR1948 的 T01--T07 测试方式，参数为 `-t 10 -O 2 -l 128K`，每个场景运行 3 轮并取中位数；
- 本次脚本与 PR1948 基线均使用 15 秒轮间冷却，测试负载和结果解析口径相同；
- StarryOS 使用原有 `Info` 配置，未设置网络任务或 iperf3 的 CPU 亲和性；
- 有效矩阵开始前重启宿主机 iperf3 server，所有场景完整返回 receiver 结果。

### 与未优化 dev 基线对比

基线取自 PR1948 最终 head `11bb2254c70a08d702661dfdf2b50e1e7f8473cd` 公布的 Orange Pi 5 Plus 实跑结果。该 head 已包含 benchmark，但未包含本 PR 的网络性能修改。

| 测试项 | 方向 | PR1948 未优化 dev 三次 / 中位数 | 当前 PR 三次 / 中位数 | 中位数比值 |
| --- | --- | ---: | ---: | ---: |
| T01 单流单向 | DUT TX | 100、103、87.8 / **100** | 705、713、726 / **713** | **7.13x** |
| T02 单流单向 | DUT RX | 210、209、211 / **210** | 624、630、628 / **628** | **2.99x** |
| T03 单流双向 | DUT TX | 64.4、63.1、63.3 / **63.3** | 349、347、360 / **349** | **5.51x** |
| T03 单流双向 | DUT RX | 129、126、127 / **127** | 348、347、360 / **348** | **2.74x** |
| T04 双流单向 | DUT TX | 97.7、111、94.4 / **97.7** | 851、811、751 / **811** | **8.30x** |
| T05 四流单向 | DUT TX | 76.3、114、71.1 / **76.3** | 799、845、836 / **836** | **10.96x** |
| T06 八流单向 | DUT TX | 0.738、0.743、0.739 / **0.739** | 700、788、551 / **700** | **947.23x** |
| T07 四流单向 | DUT RX | 216、206、194 / **206** | 701、669、663 / **669** | **3.25x** |

当前 head 完成全部场景后输出 `STARRY_IPERF3_BENCH_PASSED`。

## 验证

### 当前 head 非板端验证

- `cargo fmt --all -- --check`：通过；
- `git diff --check`：通过；
- `sh -n apps/starry/iperf3/iperf-bench.sh`：通过；
- host tests：`rdif-eth` 0 项、`rd-net` 4 项、`realtek-rtl8125` 4 项通过；
- Docker Linux `cargo test -p ax-net --lib`：105 项通过；
- 对 `rdif-eth`、`rd-net`、`realtek-rtl8125` 和 `ax-net` 执行定向 `cargo xtask clippy --package <crate>`：通过；`ax-net` 的 base、vsock、host-test 组合共 3 组通过；
- Docker `cargo xtask starry quick-start orangepi-5-plus build`：aarch64 release、kallsyms 和二进制生成通过，仅构建，未启动板卡。

### 历史实板验证（对应性能数据 head）

- Orange Pi 5 Plus StarryOS release 构建、含 DTB 的 FIT 启动和 T01--T07 实板矩阵：通过；
- 测试结束后恢复 Linux 启动脚本，板卡已正常进入 Linux 6.1.115。

当前 head 未重新运行实板性能矩阵，未连接、重启或修改板卡。
