### PR TITLE
fix(starry-kernel): reject threads in new PID namespaces

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -147,6 +147,13 @@ impl CloneArgs {
         if flags.contains(CloneFlags::NEWNS | CloneFlags::FS) {
             return Err(AxError::InvalidInput);
         }
+        // A thread must remain in the PID namespace of its thread group.
+        // CLONE_PARENT only changes parentage, so Linux permits it with
+        // CLONE_NEWPID. clone3 separately requires a zero exit signal when
+        // CLONE_PARENT is present.
+        if flags.contains(CloneFlags::NEWPID | CloneFlags::THREAD) {
+            return Err(AxError::InvalidInput);
+        }
 
         Ok(())
     }
@@ -594,6 +601,19 @@ pub(crate) fn clone_validation_rules_hold_for_test() -> bool {
     }
     .validate()
     .is_err();
+    let thread_with_newpid_rejected = CloneArgs {
+        flags: CloneFlags::THREAD | CloneFlags::VM | CloneFlags::SIGHAND | CloneFlags::NEWPID,
+        ..Default::default()
+    }
+    .validate()
+    .is_err();
+    let legacy_parent_newpid_allowed = CloneArgs {
+        flags: CloneFlags::PARENT | CloneFlags::NEWPID,
+        exit_signal: SIGCHLD as u64,
+        ..Default::default()
+    }
+    .validate()
+    .is_ok();
     // Cover the remaining validation arms to keep the full state machine under
     // axtest coverage (the host `#[cfg(test)]` mod below mirrors these but does
     // not execute during the kernel coverage run).
@@ -643,6 +663,8 @@ pub(crate) fn clone_validation_rules_hold_for_test() -> bool {
         && thread_signal_rejected
         && sighand_without_vm_rejected
         && newns_with_fs_rejected
+        && thread_with_newpid_rejected
+        && legacy_parent_newpid_allowed
         && thread_without_vm_sighand_rejected
         && vfork_with_thread_rejected
         && pidfd_with_detached_rejected
@@ -677,5 +699,26 @@ mod tests {
         };
 
         assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn clone_thread_rejects_new_pid_namespace() {
+        let args = CloneArgs {
+            flags: CloneFlags::THREAD | CloneFlags::VM | CloneFlags::SIGHAND | CloneFlags::NEWPID,
+            ..Default::default()
+        };
+
+        assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn legacy_clone_parent_allows_new_pid_namespace() {
+        let args = CloneArgs {
+            flags: CloneFlags::PARENT | CloneFlags::NEWPID,
+            exit_signal: SIGCHLD as u64,
+            ..Default::default()
+        };
+
+        assert!(args.validate().is_ok());
     }
 }

--- a/os/StarryOS/kernel/src/syscall/task/clone3.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone3.rs
@@ -96,7 +96,9 @@ pub fn sys_clone3(uctx: &UserContext, args: *const u8, size: usize) -> AxResult<
 
 #[cfg(axtest)]
 pub(crate) fn clone3_validation_rules_hold_for_test() -> bool {
-    use linux_raw_sys::general::{CLONE_DETACHED, CLONE_PARENT, CLONE_THREAD, SIGCHLD};
+    use linux_raw_sys::general::{
+        CLONE_DETACHED, CLONE_NEWPID, CLONE_PARENT, CLONE_THREAD, SIGCHLD,
+    };
 
     let parent_signal_rejected = CloneArgs::try_from(Clone3Args {
         flags: CLONE_PARENT as u64,
@@ -139,6 +141,12 @@ pub(crate) fn clone3_validation_rules_hold_for_test() -> bool {
         ..Default::default()
     })
     .is_ok();
+    let parent_newpid_zero_signal_accepted = CloneArgs::try_from(Clone3Args {
+        flags: (CLONE_PARENT | CLONE_NEWPID) as u64,
+        exit_signal: 0,
+        ..Default::default()
+    })
+    .is_ok_and(|args| args.flags.contains(CloneFlags::PARENT | CloneFlags::NEWPID));
     let zero_stack_ignored_size = CloneArgs::try_from(Clone3Args {
         stack: 0,
         stack_size: 0x2000,
@@ -181,6 +189,7 @@ pub(crate) fn clone3_validation_rules_hold_for_test() -> bool {
         && stack_top_is_derived_from_base_and_size
         && thread_zero_signal_accepted
         && parent_zero_signal_accepted
+        && parent_newpid_zero_signal_accepted
         && zero_stack_ignored_size
         && stack_only_no_size
         && plain_clone_accepted

--- a/test-suit/starryos/qemu/system/syscall-test-namespace/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-namespace/src/main.c
@@ -5,6 +5,7 @@
  *   1. unshare(CLONE_NEWUTS) + sethostname does not affect the parent.
  *   2. clone(CLONE_NEWPID)  -> child getpid() returns the local PID.
  *   3. unshare(CLONE_NEWUSER) -> getuid() returns 65534 (nobody).
+ *   4. clone3(CLONE_THREAD | CLONE_NEWPID) is rejected with EINVAL.
  */
 
 #include "test_framework.h"
@@ -55,6 +56,33 @@ static pid_t clone3_child(unsigned long long flags)
     args.flags = flags;
     args.exit_signal = SIGCHLD;
     return (pid_t)syscall(__NR_clone3, &args, sizeof(args));
+}
+
+static void run_pid_namespace_flag_validation_test(void)
+{
+    pid_t verifier = fork();
+    CHECK(verifier >= 0, "fork for PID namespace flag validation");
+
+    if (verifier == 0)
+    {
+        struct clone3_args args;
+        memset(&args, 0, sizeof(args));
+        args.flags = CLONE_THREAD | CLONE_VM | CLONE_SIGHAND | CLONE_NEWPID;
+
+        errno = 0;
+        long result = syscall(__NR_clone3, &args, sizeof(args));
+        if (result == -1)
+            _exit(errno == EINVAL ? 0 : 2);
+
+        syscall(SYS_exit_group, 1);
+        __builtin_unreachable();
+    }
+
+    int status;
+    CHECK(waitpid(verifier, &status, 0) == verifier,
+          "wait for PID namespace flag verifier");
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0,
+          "clone3(CLONE_THREAD | CLONE_NEWPID) rejected with EINVAL");
 }
 
 // ---------------------------------------------------------------------------
@@ -189,6 +217,7 @@ int main(void)
     TEST_START("namespace (UTS / PID / USER isolation)");
 
     run_uts_namespace_test();
+    run_pid_namespace_flag_validation_test();
     run_pid_namespace_test();
     run_user_namespace_test();
 


### PR DESCRIPTION
## 问题

当前 `CloneArgs::validate` 在后续重构后丢失了 PID namespace 的线程组约束，使 `clone` 和 `clone3` 都可能接受 `CLONE_THREAD | CLONE_NEWPID`。这会让线程进入与所属线程组不同的 PID namespace，偏离 Linux ABI；Linux 对该组合返回 `EINVAL`。

原始修复意图来自 #1775 中的提交 [cef15f5](https://github.com/rcore-os/tgoskits/commit/cef15f5fa7dbdd78c990edebc8e51a2d8f34e3f9)。该提交对象虽已出现在 `dev` 历史中，但当前代码已不再包含对应校验，因此这里按当前 `dev` 的结构恢复这一约束。

`CLONE_PARENT | CLONE_NEWPID` 不共享上述线程组约束，必须继续允许：Linux 曾因误拒绝该组合破坏 `lxc-attach`，随后通过 [1f7f4dde](https://github.com/torvalds/linux/commit/1f7f4dde5c945f41a7abc2285be43d918029ecc5) 明确恢复支持。当前 `clone(2)` man page 对此仍有滞后描述，内核实现和该回归修复提交是本 PR 采用的语义依据。

## 修改

- 在 `CloneArgs::validate` 的共享校验中拒绝 `CLONE_THREAD | CLONE_NEWPID`，同时覆盖 `clone` 与 `clone3`。
- 增加内核 axtest，锁定：
  - `CLONE_THREAD | CLONE_NEWPID` 返回 `EINVAL`；
  - legacy `CLONE_PARENT | CLONE_NEWPID | SIGCHLD` 继续通过；
  - clone3 的 `CLONE_PARENT | CLONE_NEWPID` 在 `exit_signal = 0` 时继续通过参数转换。
- 扩展 Starry namespace QEMU 测试，直接调用 `clone3` 验证 `CLONE_THREAD | CLONE_NEWPID` 的真实 syscall 行为。验证进程由 `fork` 隔离；若错误实现创建线程，则使用 `exit_group` 确定性结束该进程组并报告失败。
- 补充注释，明确 legacy clone 与 clone3 的退出信号差异，避免后续再次把 `CLONE_PARENT` 误纳入 PID namespace 限制。

## 依据与调用路径

| syscall | 参数转换 | 共用约束 | 额外约束 |
| --- | --- | --- | --- |
| `clone` | 旧式参数组装为 `CloneArgs` | `CloneArgs::validate` | 无 clone3 的 zero-exit-signal 限制 |
| `clone3` | `clone3_args` 转换为 `CloneArgs` | `CloneArgs::validate` | `CLONE_PARENT`/`CLONE_THREAD` 搭配非零 `exit_signal` 返回 `EINVAL` |

当前 Linux 在 [kernel/fork.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/fork.c#L2007-L2024) 中只对线程组共享语义拒绝 `CLONE_THREAD | CLONE_NEWPID`；`CLONE_PARENT` 仅在调用者为不可杀死的 init 进程时另行受限。clone3 对非零退出信号的额外限制见 [kernel/fork.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/kernel/fork.c#L2982-L2984)。

## 确定性回归

修复前，同一组新增测试得到：

- `cargo xtask ktest qemu --package starry-kernel --test axtest_kernel --arch riscv64`：390 pass / 1 fail，新增 clone 校验项失败。
- `cargo xtask starry test qemu --arch riscv64 -c qemu/system/syscall-test-namespace`：15 pass / 1 fail，内核错误接受 `clone3(CLONE_THREAD | CLONE_NEWPID)`。

恢复校验后，这两个新增断言均通过。

## 当前 head 验证

基于最新 `dev`（`ee8b92072895f48dc1a8191780318ad70f6ee3f9`）完成：

- `cargo xtask clippy --package starry-kernel`：25/25 配置通过。
- `cargo xtask ktest qemu --package starry-kernel --test axtest_kernel --arch riscv64`：398 pass / 0 fail。
- `cargo xtask starry test qemu --arch riscv64 -c qemu/system/syscall-test-namespace`：16 pass / 0 fail。
- `cargo xtask starry test qemu --arch x86_64 -c qemu/test-nix-clone-parent`：通过，输出 `TEST_NIX_CLONE_PARENT_PASSED`，覆盖 legacy clone 与 clone3 的 `CLONE_PARENT | CLONE_NEWPID` 真实运行时行为。
- `cargo fmt --all --check` 与 `git diff --check`：通过。

上一版 head 的 Axvisor aarch64 CI 唯一失败项为 `axtest::tests::touch_preserves_content_and_updates_times`，与本 PR 的 Starry clone/namespace 变更无关；对应间歇问题由 #1950 单独处理。本次强推已触发当前 head 的全新 CI。
