### PR TITLE
fix(ax-hal): normalize hypervisor IRQ entry state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,7 @@ dependencies = [
  "ax-percpu",
  "ax-plat",
  "axplat-dyn",
+ "axtest",
  "cfg-if",
  "cpu-local",
  "fdt-parser",

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -231,7 +231,7 @@ axtest.workspace = true
 axbacktrace = { workspace = true, features = ["axtest"] }
 ax-cpumask = { workspace = true, features = ["axtest"] }
 ax-driver = { workspace = true, features = ["axtest"] }
-ax-hal.workspace = true
+ax-hal = { workspace = true, features = ["axtest"] }
 ax-std = { workspace = true, default-features = false, features = [
     "alloc",
     "fd",

--- a/os/StarryOS/kernel/tests/axtest_kernel.rs
+++ b/os/StarryOS/kernel/tests/axtest_kernel.rs
@@ -6,6 +6,7 @@ extern crate alloc;
 use ax_cpumask as _;
 use ax_driver as _;
 use ax_errno as _;
+use ax_hal as _;
 use ax_io as _;
 use ax_kernel_guard as _;
 use ax_lazyinit as _;

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -8,6 +8,7 @@ description = "ArceOS hardware abstraction layer, provides unified APIs for plat
 license.workspace = true
 
 [features]
+axtest = ["dep:axtest"]
 smp = [
     "axplat-dyn/smp",
     "ax-plat/smp",
@@ -41,6 +42,7 @@ default = []
 ipi = ["irq"]
 
 [dependencies]
+axtest = { workspace = true, optional = true }
 ax-alloc = { workspace = true, optional = true }
 ax-cpu.workspace = true
 cpu-local.workspace = true
@@ -60,3 +62,6 @@ spin.workspace = true
 
 [build-dependencies]
 quote = { workspace = true }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(axtest)'] }

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -8,7 +8,7 @@ description = "ArceOS hardware abstraction layer, provides unified APIs for plat
 license.workspace = true
 
 [features]
-axtest = ["dep:axtest"]
+axtest = ["dep:axtest", "irq"]
 smp = [
     "axplat-dyn/smp",
     "ax-plat/smp",

--- a/os/arceos/modules/axhal/src/axtest.rs
+++ b/os/arceos/modules/axhal/src/axtest.rs
@@ -1,0 +1,6 @@
+use axtest::prelude::*;
+
+#[axtest]
+fn axhal_irq_entry_disables_and_restores_local_irqs() {
+    ax_assert!(crate::irq::irq_entry_state_rules_hold_for_test());
+}

--- a/os/arceos/modules/axhal/src/axtest.rs
+++ b/os/arceos/modules/axhal/src/axtest.rs
@@ -1,6 +1,26 @@
 use axtest::prelude::*;
 
 #[axtest]
-fn axhal_irq_entry_disables_and_restores_local_irqs() {
-    ax_assert!(crate::irq::irq_entry_state_rules_hold_for_test());
+fn axhal_irq_entry_keeps_irqs_disabled_until_preemption_is_reenabled() {
+    let original_irq_state = ax_kernel_guard::IrqSave::new();
+    crate::asm::enable_irqs();
+    let observation = crate::irq::observe_irq_entry_state_for_test();
+    drop(original_irq_state);
+
+    ax_assert!(irq_entry_stages_hold(&observation));
+    ax_assert!(observation.return_irqs_enabled);
+}
+
+#[axtest]
+fn axhal_irq_entry_preserves_disabled_caller_state() {
+    let caller_irq_guard = ax_kernel_guard::IrqSave::new();
+    let observation = crate::irq::observe_irq_entry_state_for_test();
+    drop(caller_irq_guard);
+
+    ax_assert!(irq_entry_stages_hold(&observation));
+    ax_assert!(!observation.return_irqs_enabled);
+}
+
+fn irq_entry_stages_hold(observation: &crate::irq::IrqEntryStateObservation) -> bool {
+    !observation.dispatch_irqs_enabled && !observation.after_preempt_release_irqs_enabled
 }

--- a/os/arceos/modules/axhal/src/irq.rs
+++ b/os/arceos/modules/axhal/src/irq.rs
@@ -26,16 +26,50 @@ pub fn ipi_irq() -> IrqId {
 
 /// IRQ handler.
 ///
-/// # Warn
+/// Normalizes both hardware-trap and hypervisor VM-exit callers to the same
+/// local-IRQ-disabled entry contract. A hypervisor may restore the host IRQ
+/// state before forwarding a deferred external interrupt.
+///
+/// # Warning
 ///
 /// Make sure called in an interrupt context or hypervisor VM exit handler.
 pub fn handle_irq(vector: usize) -> bool {
-    prepare_irq_context(TrapVector(vector));
-    let guard = ax_kernel_guard::NoPreempt::new();
-    let handled = handle(TrapVector(vector)).is_some();
+    with_irq_entry(
+        || prepare_irq_context(TrapVector(vector)),
+        || handle(TrapVector(vector)).is_some(),
+    )
+}
 
-    drop(guard); // rescheduling may occur when preemption is re-enabled.
-    handled
+fn with_irq_entry<T>(prepare: impl FnOnce(), dispatch: impl FnOnce() -> T) -> T {
+    // Keep IRQs disabled until the preemption guard has handed any pending
+    // reschedule back to the IRQ-return path. Hardware traps already enter in
+    // this state; IrqSave also covers deferred VM-exit dispatchers.
+    let irq_guard = ax_kernel_guard::IrqSave::new();
+    prepare();
+    let preempt_guard = ax_kernel_guard::NoPreempt::new();
+    let result = dispatch();
+
+    drop(preempt_guard); // rescheduling may occur when preemption is re-enabled.
+    drop(irq_guard);
+    result
+}
+
+#[cfg(axtest)]
+pub(crate) fn irq_entry_state_rules_hold_for_test() -> bool {
+    let caller_irqs_enabled = crate::asm::irqs_enabled();
+    let enabled_entry_irqs = with_irq_entry(|| {}, crate::asm::irqs_enabled);
+    let enabled_state_restored = crate::asm::irqs_enabled();
+
+    crate::asm::disable_irqs();
+    let disabled_entry_irqs = with_irq_entry(|| {}, crate::asm::irqs_enabled);
+    let disabled_state_restored = !crate::asm::irqs_enabled();
+    crate::asm::enable_irqs();
+
+    caller_irqs_enabled
+        && !enabled_entry_irqs
+        && enabled_state_restored
+        && !disabled_entry_irqs
+        && disabled_state_restored
 }
 
 /// Installs the default ArceOS IRQ dispatcher into `ax-cpu`'s runtime hook.

--- a/os/arceos/modules/axhal/src/irq.rs
+++ b/os/arceos/modules/axhal/src/irq.rs
@@ -41,6 +41,14 @@ pub fn handle_irq(vector: usize) -> bool {
 }
 
 fn with_irq_entry<T>(prepare: impl FnOnce(), dispatch: impl FnOnce() -> T) -> T {
+    with_observed_irq_entry(prepare, dispatch, || {})
+}
+
+fn with_observed_irq_entry<T>(
+    prepare: impl FnOnce(),
+    dispatch: impl FnOnce() -> T,
+    after_preempt_release: impl FnOnce(),
+) -> T {
     // Keep IRQs disabled until the preemption guard has handed any pending
     // reschedule back to the IRQ-return path. Hardware traps already enter in
     // this state; IrqSave also covers deferred VM-exit dispatchers.
@@ -50,26 +58,9 @@ fn with_irq_entry<T>(prepare: impl FnOnce(), dispatch: impl FnOnce() -> T) -> T 
     let result = dispatch();
 
     drop(preempt_guard); // rescheduling may occur when preemption is re-enabled.
+    after_preempt_release();
     drop(irq_guard);
     result
-}
-
-#[cfg(axtest)]
-pub(crate) fn irq_entry_state_rules_hold_for_test() -> bool {
-    let caller_irqs_enabled = crate::asm::irqs_enabled();
-    let enabled_entry_irqs = with_irq_entry(|| {}, crate::asm::irqs_enabled);
-    let enabled_state_restored = crate::asm::irqs_enabled();
-
-    crate::asm::disable_irqs();
-    let disabled_entry_irqs = with_irq_entry(|| {}, crate::asm::irqs_enabled);
-    let disabled_state_restored = !crate::asm::irqs_enabled();
-    crate::asm::enable_irqs();
-
-    caller_irqs_enabled
-        && !enabled_entry_irqs
-        && enabled_state_restored
-        && !disabled_entry_irqs
-        && disabled_state_restored
 }
 
 /// Installs the default ArceOS IRQ dispatcher into `ax-cpu`'s runtime hook.
@@ -79,4 +70,27 @@ pub(crate) fn irq_entry_state_rules_hold_for_test() -> bool {
 /// link-time override path.
 pub fn init_common_irq_handler() {
     let _ = set_irq_handler(handle_irq);
+}
+
+#[cfg(axtest)]
+pub(crate) struct IrqEntryStateObservation {
+    pub(crate) dispatch_irqs_enabled: bool,
+    pub(crate) after_preempt_release_irqs_enabled: bool,
+    pub(crate) return_irqs_enabled: bool,
+}
+
+#[cfg(axtest)]
+pub(crate) fn observe_irq_entry_state_for_test() -> IrqEntryStateObservation {
+    let mut after_preempt_release_irqs_enabled = false;
+    let dispatch_irqs_enabled = with_observed_irq_entry(
+        || {},
+        crate::asm::irqs_enabled,
+        || after_preempt_release_irqs_enabled = crate::asm::irqs_enabled(),
+    );
+
+    IrqEntryStateObservation {
+        dispatch_irqs_enabled,
+        after_preempt_release_irqs_enabled,
+        return_irqs_enabled: crate::asm::irqs_enabled(),
+    }
 }

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -20,11 +20,15 @@
 //! - `tls`: Enable kernel space thread-local storage support.
 //! - `rtc`: Enable real-time clock support.
 //! - `uspace`: Enable user space support.
+//! - `axtest`: Enable internal AxTest cases.
 //!
 //! [ArceOS]: https://github.com/arceos-org/arceos
 //! [cargo test]: https://doc.rust-lang.org/cargo/guide/tests.html
 
 #![no_std]
+
+#[cfg(all(axtest, feature = "axtest"))]
+mod axtest;
 
 #[cfg(all(feature = "uspace", feature = "tls"))]
 compile_error!("ax-hal features `uspace` and `tls` select incompatible register ownership modes");

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -87,7 +87,7 @@ axbacktrace = { workspace = true, optional = true }
 
 [dev-dependencies]
 axtest.workspace = true
-ax-hal = { workspace = true, features = ["paging", "irq", "smp", "hv"] }
+ax-hal = { workspace = true, features = ["paging", "irq", "smp", "hv", "axtest"] }
 ax-task = { workspace = true, features = ["axtest"] }
 
 # xtask dependencies (only used on host platforms)

--- a/os/axvisor/tests/axtest.rs
+++ b/os/axvisor/tests/axtest.rs
@@ -3,6 +3,7 @@
 
 extern crate alloc;
 
+use ax_hal as _;
 use ax_std as _;
 use axvm as _;
 


### PR DESCRIPTION
## 问题

`ax_hal::irq::handle_irq` 同时服务于硬件 trap 和 AxVM 的 deferred VM-exit 外部中断转发。硬件 trap 天然以本地 IRQ 关闭状态进入，但 VM-exit 转发调用方不应成为该公共入口隐含 IRQ 状态的唯一保证。原实现只建立 `NoPreempt`，没有在入口统一 IRQ 状态；因此 IRQ handler 以及 preemption guard 的释放可能落在与硬件中断入口不同的状态边界。

本 PR 从 #1775 的 [1ec335987](https://github.com/rcore-os/tgoskits/commit/1ec3359877f528c726d7a74df4e4d3c9b97ee105) 独立提取修复，并已 rebase 到 `dev@41e194e9d`。

## 修改与逻辑

1. 在 `handle_irq` 最外层建立 `IrqSave`，使 `prepare_irq_context` 和 IRQ dispatch 都在本地 IRQ 关闭状态运行。
2. 将 `NoPreempt` 保持在 `IrqSave` 内层，并显式先释放 `NoPreempt`、再释放 `IrqSave`。这样潜在 reschedule 交回 IRQ-return 路径时 IRQ 仍关闭，最后再恢复调用方原始 IRQ 状态。
3. 为 `ax-hal` 增加 AxTest，分阶段观测 dispatch、`NoPreempt` 释放后且 `IrqSave` 释放前、函数返回后三个状态，同时覆盖 IRQ enabled/disabled 两种调用现场。enabled 用例显式建立目标状态，并在结束时恢复运行器原始 IRQ 状态，避免依赖测试顺序。
4. 将 `ax-hal/axtest` 作为 StarryOS 与 Axvisor 的 dev-only feature 接入现有 ktest 目标；`axtest` feature 显式包含其测试代码所需的 `irq` feature，不影响生产依赖。

Linux KVM 也会在 guest entry/exit 与 IRQ 处理之间显式建立 local-IRQ/preemption 边界，可作为合同层面的对照；本 PR 不主张 Linux 的具体分发流程与 AxVM 完全相同：

- [`guest_state_enter_irqoff`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/include/linux/kvm_host.h#L453-L479)
- [`guest_state_exit_irqoff`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/include/linux/kvm_host.h#L534-L558)
- [VMX guest enter/exit boundary](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/arch/x86/kvm/vmx/vmx.c#L7476-L7491)
- [generic IRQ entry contract](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/include/linux/irq-entry-common.h#L445-L469)

## 确定性回归

同一条 x86_64 AxTest 命令完成 red/green。旧测试辅助实现会无条件重新开启 IRQ；在外层保持 `IrqSave` 的 disabled-caller 场景下必然失败。修正后同一命令覆盖 enabled/disabled 两种现场并全部通过：

```text
cargo xtask ktest qemu --package starry-kernel --test axtest_kernel --arch x86_64

# 旧测试辅助实现
AXTEST_SUMMARY pass=395 fail=1 skip=0 total=396
AXTEST_SUITE_FAIL failed=1

# 修正后（原 PR base）
AXTEST_SUMMARY pass=396 fail=0 skip=0 total=396
AXTEST_SUITE_OK

# rebase 到当前 dev 后
AXTEST_SUMMARY pass=403 fail=0 skip=0 total=403
AXTEST_SUITE_OK
```

Axvisor CI 对应入口也已验证实际发现并执行两条测试：

```text
cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
AXTEST_SUMMARY pass=70 fail=0 skip=0 total=70
AXTEST_SUITE_OK
```

Review 指出的最小 feature 组合也完成同命令 red/green：修复前因 `axtest` 未包含 `irq` 而稳定产生 3 个 `E0433`；将 `axtest = ["dep:axtest", "irq"]` 后通过：

```text
RUSTFLAGS='--cfg axtest' cargo check -p ax-hal --no-default-features --features axtest
```

## CI 失败处理

上一 head 的 [VMX/OVMF 作业](https://github.com/rcore-os/tgoskits/actions/runs/31376649575/job/93418811887) 中，其余 31 个作业成功、32 个跳过，唯一失败为 `ovmf-acpi-vmx` 等待 600 秒超时。该作业里的 `direct-acpi-vmx` 与 `mp-fallback-vmx` 已通过；OVMF 日志出现一次 fw_cfg DMA descriptor 客体地址转换失败，地址范围仍位于配置的客体 RAM 内。PR 未修改 fw_cfg、客体地址空间或 OVMF 配置，本地也无法复现，因此没有把无因果依据的 fw_cfg 改动混入本修复。

本地验证结果：

- 单独运行 `ovmf-acpi-vmx` 多次通过；最新 rebase 后在 13.87 秒命中 `AXVISOR_X86_OVMF_ACPI_PASSED`；
- 严格按 CI 原顺序运行 `direct-acpi-vmx`、`mp-fallback-vmx`、`ovmf-acpi-vmx`，三项全部通过；
- 未放宽成功正则、未增加重试、未延长超时。

当前 head 由 CI 重新验证该作业；若远端再次出现相同超时，将按独立的 fw_cfg/OVMF 间歇问题处理，不用放松测试掩盖。

## 验证

- `cargo fmt --all --check`
- `git diff --check`
- `RUSTFLAGS='--cfg axtest' cargo check -p ax-hal --no-default-features --features axtest`：通过
- `cargo xtask clippy --package ax-hal`：13/13 配置通过
- `cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64`：70/70 通过
- `cargo xtask ktest qemu --package starry-kernel --test axtest_kernel --arch x86_64`：403/403 通过
- `cargo xtask arceos test qemu --arch x86_64 --test-group rust --test-case task-irq`：1/1 通过
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case smoke-vmx`：1/1 通过（KVM/VMX）
- CI 原序列 `direct-acpi-vmx`、`mp-fallback-vmx`、`ovmf-acpi-vmx`：3/3 通过

`cargo xtask clippy --package axvisor` 会按 xtask 策略跳过需要 Axvisor target/build 配置的包；对应的 Axvisor axtest 与 VMX 构建运行已由上述专用 xtask 流程覆盖。
