### PR TITLE
fix(ax-std): implement futimens for regular files

### DIFF
--- a/fs/ax-fs-ng/src/fops.rs
+++ b/fs/ax-fs-ng/src/fops.rs
@@ -1,8 +1,9 @@
 use alloc::{string::String, vec::Vec};
+use core::time::Duration;
 
 use ax_errno::{AxError, AxResult};
 use ax_io::{Seek, SeekFrom};
-use axfs_ng_vfs::{Metadata, NodePermission, NodeType};
+use axfs_ng_vfs::{Metadata, MetadataUpdate, NodePermission, NodeType};
 
 use crate::highlevel::{File as CoreFile, OpenOptions as CoreOpenOptions, current_fs_context};
 
@@ -206,6 +207,20 @@ impl File {
 
     pub fn get_attr(&self) -> AxResult<FileAttr> {
         self.inner.location().metadata()
+    }
+
+    /// Updates the access and modification times selected by non-`None` values.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying filesystem error when metadata cannot be updated.
+    pub fn set_times(&self, atime: Option<Duration>, mtime: Option<Duration>) -> AxResult {
+        self.inner.location().update_metadata(MetadataUpdate {
+            atime,
+            mtime,
+            ..MetadataUpdate::default()
+        })?;
+        Ok(())
     }
 }
 

--- a/os/arceos/api/arceos_posix_api/src/imp/fs.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/fs.rs
@@ -13,6 +13,9 @@ use ax_sync::Mutex;
 use super::fd_ops::{FileLike, get_file_like};
 use crate::{ctypes, utils::char_ptr_to_str};
 
+const UTIME_NOW: i64 = (1 << 30) - 1;
+const UTIME_OMIT: i64 = (1 << 30) - 2;
+
 pub struct File {
     inner: Mutex<ax_fs_ng::fops::File>,
 }
@@ -355,6 +358,64 @@ pub unsafe fn sys_fstat(fd: c_int, buf: *mut ctypes::stat) -> c_int {
     })
 }
 
+/// Update the access and modification times of an open file descriptor.
+///
+/// A null `times` pointer sets both timestamps to the current wall-clock time.
+/// Individual timestamps also support the Linux `UTIME_NOW` and `UTIME_OMIT`
+/// values in `tv_nsec`.
+///
+/// # Safety
+///
+/// When non-null, `times` must point to two readable [`ctypes::timespec`]
+/// values for the duration of this call.
+pub unsafe fn sys_futimens(fd: c_int, times: *const ctypes::timespec) -> c_int {
+    debug!("sys_futimens <= {fd} {:#x}", times as usize);
+    syscall_body!(sys_futimens, {
+        let file = File::from_fd(fd)?;
+        let (atime, mtime) = unsafe { futimens_times(times)? };
+        if atime.is_none() && mtime.is_none() {
+            return Ok(0);
+        }
+        file.inner.lock().set_times(atime, mtime)?;
+        Ok(0)
+    })
+}
+
+unsafe fn futimens_times(
+    times: *const ctypes::timespec,
+) -> LinuxResult<(Option<Duration>, Option<Duration>)> {
+    let now = ax_hal::time::wall_time();
+    if times.is_null() {
+        return Ok((Some(now), Some(now)));
+    }
+
+    let times = unsafe { core::slice::from_raw_parts(times, 2) };
+    Ok((
+        file_time_from_timespec(times[0], now)?,
+        file_time_from_timespec(times[1], now)?,
+    ))
+}
+
+fn file_time_from_timespec(
+    timespec: ctypes::timespec,
+    now: Duration,
+) -> LinuxResult<Option<Duration>> {
+    match timespec.tv_nsec {
+        UTIME_NOW => Ok(Some(now)),
+        UTIME_OMIT => Ok(None),
+        nanoseconds
+            if (0..=u32::MAX as i64).contains(&timespec.tv_sec)
+                && (0..1_000_000_000).contains(&nanoseconds) =>
+        {
+            Ok(Some(Duration::new(
+                timespec.tv_sec as u64,
+                nanoseconds as u32,
+            )))
+        }
+        _ => Err(LinuxError::EINVAL),
+    }
+}
+
 /// Get the metadata of the symbolic link and write into `buf`.
 ///
 /// Return 0 if success.
@@ -448,5 +509,67 @@ mod tests {
         assert_eq!(stat.st_mtime.tv_nsec, 13);
         assert_eq!(stat.st_ctime.tv_sec, 14);
         assert_eq!(stat.st_ctime.tv_nsec, 15);
+    }
+
+    #[test]
+    fn file_time_from_timespec_handles_linux_special_values() {
+        let now = Duration::new(30, 40);
+
+        assert_eq!(
+            file_time_from_timespec(
+                ctypes::timespec {
+                    tv_sec: 0,
+                    tv_nsec: UTIME_NOW as _,
+                },
+                now,
+            ),
+            Ok(Some(now))
+        );
+        assert_eq!(
+            file_time_from_timespec(
+                ctypes::timespec {
+                    tv_sec: 0,
+                    tv_nsec: UTIME_OMIT as _,
+                },
+                now,
+            ),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn file_time_from_timespec_rejects_invalid_values() {
+        let now = Duration::ZERO;
+
+        assert_eq!(
+            file_time_from_timespec(
+                ctypes::timespec {
+                    tv_sec: -1,
+                    tv_nsec: 0,
+                },
+                now,
+            ),
+            Err(LinuxError::EINVAL)
+        );
+        assert_eq!(
+            file_time_from_timespec(
+                ctypes::timespec {
+                    tv_sec: 0,
+                    tv_nsec: 1_000_000_000,
+                },
+                now,
+            ),
+            Err(LinuxError::EINVAL)
+        );
+        assert_eq!(
+            file_time_from_timespec(
+                ctypes::timespec {
+                    tv_sec: u32::MAX as i64 + 1,
+                    tv_nsec: 0,
+                },
+                now,
+            ),
+            Err(LinuxError::EINVAL)
+        );
     }
 }

--- a/os/arceos/api/arceos_posix_api/src/lib.rs
+++ b/os/arceos/api/arceos_posix_api/src/lib.rs
@@ -38,7 +38,8 @@ pub use imp::eventfd::sys_eventfd;
 pub use imp::fd_ops::{sys_close, sys_dup, sys_dup2, sys_fcntl};
 #[cfg(feature = "fs")]
 pub use imp::fs::{
-    sys_fstat, sys_getcwd, sys_getdents64, sys_lseek, sys_lstat, sys_open, sys_rename, sys_stat,
+    sys_fstat, sys_futimens, sys_getcwd, sys_getdents64, sys_lseek, sys_lstat, sys_open,
+    sys_rename, sys_stat,
 };
 #[cfg(feature = "poll")]
 pub use imp::io_mpx::sys_poll;

--- a/os/arceos/ulib/axstd/src/os/libc_compat.rs
+++ b/os/arceos/ulib/axstd/src/os/libc_compat.rs
@@ -1413,8 +1413,8 @@ pub unsafe extern "C" fn fdatasync(_fd: c_int) -> c_int {
 /// Callers must uphold the Linux/musl ABI contract for this libc symbol.
 #[cfg(feature = "fs")]
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn futimens(_fd: c_int, _times: *const libc::timespec) -> c_int {
-    0
+pub unsafe extern "C" fn futimens(fd: c_int, times: *const libc::timespec) -> c_int {
+    ok_or_errno(unsafe { ax_posix_api::sys_futimens(fd, times.cast()) })
 }
 
 /// # Safety

--- a/os/axvisor/src/shell/command/fs.rs
+++ b/os/axvisor/src/shell/command/fs.rs
@@ -102,13 +102,16 @@ pub(crate) const fn copy_after_rename_failure(kind: ErrorKind) -> bool {
 }
 
 pub(crate) fn touch_file(path: &str) -> io::Result<()> {
+    touch_file_at(path, SystemTime::now())
+}
+
+pub(crate) fn touch_file_at(path: &str, time: SystemTime) -> io::Result<()> {
     let file = OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(false)
         .open(path)?;
-    let now = SystemTime::now();
-    file.set_times(FileTimes::new().set_accessed(now).set_modified(now))
+    file.set_times(FileTimes::new().set_accessed(time).set_modified(time))
 }
 
 pub(crate) fn copy_path(source: &str, destination: &str, mode: CopyMode) -> io::Result<()> {

--- a/os/axvisor/tests/axtest.rs
+++ b/os/axvisor/tests/axtest.rs
@@ -41,7 +41,7 @@ mod tests {
     #[cfg(feature = "fs")]
     use std::{
         ffi::OsString,
-        fs::{self, FileTimes, OpenOptions},
+        fs,
         io::{self, ErrorKind},
         string::ToString,
         time::{Duration, SystemTime, UNIX_EPOCH},
@@ -51,7 +51,7 @@ mod tests {
     use super::shell_fs::{
         CopyMode, RemoveOptions, collect_directory_entry_names, copy_after_rename_failure,
         copy_operands, copy_path, ensure_recursive_destination_outside_source, ignore_remove_error,
-        metadata_for_remove, move_file_or_dir, remove_path, touch_file,
+        metadata_for_remove, move_file_or_dir, remove_path, touch_file_at,
     };
 
     #[test]
@@ -63,32 +63,23 @@ mod tests {
     #[test]
     fn touch_preserves_content_and_updates_times() {
         let path = "/tmp/axvisor-touch-regression";
-        let old_time = SystemTime::now()
-            .checked_add(Duration::from_secs(60))
-            .expect("fixture time must be representable");
+        let touch_time = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
         let _ = fs::remove_file(path);
         fs::write(path, b"preserve me").expect("create touch fixture");
-        OpenOptions::new()
-            .write(true)
-            .open(path)
-            .expect("open touch fixture")
-            .set_times(
-                FileTimes::new()
-                    .set_accessed(old_time)
-                    .set_modified(old_time),
-            )
-            .expect("set old fixture times");
 
-        let earliest_touch_time = unix_seconds(SystemTime::now());
-        touch_file(path).expect("touch fixture");
-        let latest_touch_time = unix_seconds(SystemTime::now());
+        touch_file_at(path, touch_time).expect("touch fixture");
 
         let metadata = fs::metadata(path).expect("read touched metadata");
         ax_assert_eq!(fs::read(path).expect("read touched file"), b"preserve me");
         let accessed = unix_seconds(metadata.accessed().expect("read atime"));
         let modified = unix_seconds(metadata.modified().expect("read mtime"));
-        ax_assert!((earliest_touch_time..=latest_touch_time).contains(&accessed));
-        ax_assert!((earliest_touch_time..=latest_touch_time).contains(&modified));
+        ax_assert_eq!(accessed, unix_seconds(touch_time));
+        ax_assert_eq!(modified, unix_seconds(touch_time));
+
+        let unsupported_time = UNIX_EPOCH + Duration::from_secs(u32::MAX as u64 + 1);
+        let error = touch_file_at(path, unsupported_time)
+            .expect_err("timestamps that would be truncated must fail");
+        ax_assert_eq!(error.kind(), ErrorKind::InvalidInput);
         fs::remove_file(path).expect("remove touch fixture");
     }
 


### PR DESCRIPTION
## 问题

Axvisor 的 `touch_preserves_content_and_updates_times` 会间歇失败。`std::fs::File::set_times` 最终调用 axstd 的 `futimens`，但原实现无条件返回成功且没有更新时间；旧测试又用当前墙钟时间判断，因此创建文件与断言位于同一秒时会误通过，跨秒时才失败。相同失败也曾出现在 `dev` 的 CI 中，说明并非其他 PR 引入。

## 修改

- 在 `ax-fs-ng::File` 增加时间元数据更新入口，经现有 VFS `MetadataUpdate` 写入后端。
- 在 `ax-posix-api` 实现普通文件描述符的 `futimens`，支持空 `times`、`UTIME_NOW` 和 `UTIME_OMIT`，并将 libc 包装接入该实现。
- 对负秒、非法纳秒以及超过当前 ext4 秒字段范围的时间返回 `EINVAL`，避免静默截断后仍报告成功。
- 将 Axvisor 回归改为注入固定时间戳并精确检查 atime/mtime，同时验证超范围输入失败；测试不再依赖执行是否跨秒。

## 设计与边界

更新沿 `std -> libc -> ax-posix-api -> ax-fs-ng -> VFS` 的现有所有权边界传递，没有用空写等方式间接改变时间。当前仅对普通文件提供语义；目录及其他 fd 返回 `EINVAL`，因为 FAT 目录元数据更新尚未实现，避免继续出现假成功。底层文件系统可以按自身时间分辨率保存合法时间。

## 验证

- 修复前：`cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64`，固定时间戳回归稳定失败，`pass=67 fail=1`。
- 修复后：同一命令通过，`pass=68 fail=0`，`AXTEST_SUITE_OK`。
- `cargo xtask clippy --package ax-posix-api`：16/16 通过。
- `cargo xtask clippy --package ax-fs-ng`：6/6 通过。
- `cargo xtask clippy --package ax-std`：44/44 通过。
- `cargo fmt --all` 与 `git diff --check` 通过。

历史 `dev` 失败记录：https://github.com/rcore-os/tgoskits/actions/runs/31299160731/job/92817953182