### PR TITLE
fix(arm-vcpu): preserve HVC exception PC

### DIFF
--- a/virtualization/arm_vcpu/src/architecture/exception.rs
+++ b/virtualization/arm_vcpu/src/architecture/exception.rs
@@ -44,12 +44,6 @@ const EXCEPTION_SYNC: usize = TrapKind::Synchronous as usize;
 /// Equals to [`TrapKind::Irq`], used in exception.S.
 const EXCEPTION_IRQ: usize = TrapKind::Irq as usize;
 
-const AARCH64_EXCEPTION_INSN_SIZE: usize = 4;
-
-fn advance_aarch64_exception_pc(ctx: &mut TrapFrame) {
-    ctx.set_exception_pc(ctx.exception_pc() + AARCH64_EXCEPTION_INSN_SIZE);
-}
-
 #[repr(u8)]
 #[derive(Debug)]
 #[allow(unused)]
@@ -122,6 +116,8 @@ pub fn handle_exception_sync(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
             handle_data_abort(ctx)
         }
         Some(ESR_EL2::EC::Value::HVC64) => {
+            // HVC records the preferred return address (the instruction after
+            // `hvc`) in ELR_EL2, so the handlers must preserve this PC.
             // The `#imm` argument when triggering a hvc call, currently not used.
             let _hvc_arg_imm16 = ESR_EL2.read(ESR_EL2::ISS);
 
@@ -133,6 +129,9 @@ pub fn handle_exception_sync(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
         }
         Some(ESR_EL2::EC::Value::TrappedMsrMrs) => handle_system_register(ctx),
         Some(ESR_EL2::EC::Value::SMC64) => {
+            // An SMC trapped by HCR_EL2.TSC is a Trap exception, whose
+            // preferred return address is the `smc` itself. Advance past it
+            // before resuming the guest.
             let elr = ctx.exception_pc();
             let val = elr + exception_next_instruction_step();
             ctx.set_exception_pc(val);
@@ -164,14 +163,11 @@ fn handle_hvc_psci_version(ctx: &mut TrapFrame) -> Option<ArmVcpuResult<ArmVmExi
         return None;
     }
 
-    advance_aarch64_exception_pc(ctx);
     ctx.set_gpr(0, PSCI_VERSION_0_2);
     Some(Ok(ArmVmExit::Nothing))
 }
 
 fn handle_hvc64_exception(ctx: &mut TrapFrame) -> ArmVcpuResult<ArmVmExit> {
-    advance_aarch64_exception_pc(ctx);
-
     // Is this a psci call?
     //
     // By convention, a psci call can use either the `hvc` or the `smc` instruction.
@@ -410,25 +406,22 @@ mod tests {
     const TEST_PC: usize = 0x8020_0000;
 
     #[test]
-    fn hvc_psci_exit_advances_exception_pc() {
+    fn hvc_psci_version_preserves_exception_pc() {
         let mut ctx = TrapFrame::default();
         ctx.set_exception_pc(TEST_PC);
         ctx.set_gpr(0, PSCI_VERSION_32 as usize);
 
-        let exit = handle_hvc64_exception(&mut ctx).expect("PSCI HVC should produce VM exit");
+        let exit = handle_hvc_psci_version(&mut ctx)
+            .expect("PSCI version HVC should produce a result")
+            .expect("PSCI version HVC should be handled");
 
-        assert_eq!(ctx.exception_pc(), TEST_PC + AARCH64_EXCEPTION_INSN_SIZE);
-        assert!(matches!(
-            exit,
-            ArmVmExit::Hypercall {
-                nr: PSCI_VERSION_32,
-                ..
-            }
-        ));
+        assert_eq!(ctx.exception_pc(), TEST_PC);
+        assert_eq!(ctx.gpr[0], 0x2);
+        assert!(matches!(exit, ArmVmExit::Nothing));
     }
 
     #[test]
-    fn generic_hvc_exit_advances_exception_pc() {
+    fn generic_hvc_exit_preserves_exception_pc() {
         let mut ctx = TrapFrame::default();
         ctx.set_exception_pc(TEST_PC);
         ctx.set_gpr(0, GENERIC_HVC_NR as usize);
@@ -437,7 +430,7 @@ mod tests {
 
         let exit = handle_hvc64_exception(&mut ctx).expect("generic HVC should produce VM exit");
 
-        assert_eq!(ctx.exception_pc(), TEST_PC + AARCH64_EXCEPTION_INSN_SIZE);
+        assert_eq!(ctx.exception_pc(), TEST_PC);
         assert!(matches!(
             exit,
             ArmVmExit::Hypercall {


### PR DESCRIPTION
## Summary

AArch64 HVC traps already provide the guest return address in `ELR_EL2`.
The HVC handlers incorrectly advanced the PC by another 4 bytes, causing the
guest to skip the instruction immediately following `hvc`.

This corrupted guest control flow after PSCI and generic HVC calls and could
prevent secondary vCPUs from booting.

## Changes

- Remove the extra PC increment from the PSCI HVC version handler.
- Remove the extra PC increment from the generic HVC handler.
- Keep the `+4` increment for SMC traps captured by `HCR_EL2.TSC`.
- Update regression tests to cover the actual PSCI HVC and generic HVC paths.
- Verify that both HVC paths preserve `ELR_EL2`.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p arm_vcpu --target aarch64-unknown-linux-musl --lib --all-targets -- -D warnings`
- AArch64 QEMU user-mode regression tests:
  - `generic_hvc_exit_preserves_exception_pc`
  - `hvc_psci_version_preserves_exception_pc`
  - Result: `2 passed; 0 failed`
- Axvisor + QEMU + Zephyr dual-vCPU test reached:
  - `PSCI_CPU_ON`
  - `VCpu[1] running`
  - `Secondary CPU core 1 ... is up`
  - `SGI SMOKE COMPLETE sent=300 received=300`

The previous implementation was reproduced in an A/B run: restoring the extra
HVC `+4` caused the guest to resume at `0x400044fc` instead of the next
instruction at `0x400044f8`, resulting in a guest Data Abort.

## Scope

This change only adjusts AArch64 HVC exception return handling. It adds no
public API and does not change SMC return-address semantics.