### PR TITLE
fix(visionfive2): restore booti and SD rootfs boot

### DIFF
--- a/drivers/ax-driver/src/soc/starfive/syscrg.rs
+++ b/drivers/ax-driver/src/soc/starfive/syscrg.rs
@@ -66,6 +66,18 @@ crate::model_register!(
 );
 
 crate::model_register!(
+    name: "StarFive JH7110 System Clock and Reset Controller",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[
+        ProbeKind::Fdt {
+            compatibles: &["starfive,jh7110-syscrg"],
+            on_probe: probe_syscrg
+        }
+    ],
+);
+
+crate::model_register!(
     name: "StarFive JH7110 Reset Controller",
     level: ProbeLevel::PostKernel,
     priority: ProbePriority::CLK,
@@ -233,6 +245,15 @@ fn probe_reset(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let base = map_first_reg(&info)?;
     plat_dev.register(rdif_reset::Reset::new(Jh7110SysReset::new(base)));
     info!("StarFive JH7110 SYS reset provider registered");
+    Ok(())
+}
+
+fn probe_syscrg(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let (info, plat_dev) = probe.into_parts();
+    let base = map_first_reg(&info)?;
+    plat_dev.register(rdif_clk::Clk::new(Jh7110SysClock::new(base)));
+    plat_dev.register(rdif_reset::Reset::new(Jh7110SysReset::new(base)));
+    info!("StarFive JH7110 SYS clock/reset providers registered");
     Ok(())
 }
 

--- a/drivers/ax-driver/tests/starfive_syscrg_fdt.rs
+++ b/drivers/ax-driver/tests/starfive_syscrg_fdt.rs
@@ -1,0 +1,253 @@
+#![cfg(feature = "starfive-soc")]
+
+use core::{
+    ptr::NonNull,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
+
+use ax_driver::register::DriverRegister;
+use axklib::{
+    AxError, AxResult, BoxedIrqHandler, ConcurrentBoxedIrqHandler, IrqCpuMask, IrqHandle, IrqId,
+    Klib, PhysAddr, VirtAddr, impl_trait,
+};
+use fdt_edit::{Fdt, Node, Phandle, Property};
+use rdrive::{
+    DriverGeneric, Platform,
+    probe::{OnProbeError, fdt::ResourcePrepareConfig},
+    register::{ProbeFdt, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+const SYSCRG_PADDR: usize = 0x1302_0000;
+const SYSCRG_MMIO_SIZE: usize = 0x1_0000;
+const SYSCRG_PHANDLE: u32 = 3;
+const SDIO0_AHB_CLOCK: u32 = 91;
+const SDIO0_CARD_CLOCK: u32 = 93;
+const SDIO0_AHB_RESET: u32 = 64;
+const RESET_STATUS_OFFSET: usize = 0x308;
+
+static SYSCRG_MMIO: AtomicUsize = AtomicUsize::new(0);
+
+unsafe extern "Rust" {
+    #[link_name = "__DRIVER_STARFIVE_JH7110_SYSTEM_CLOCK_AND_RESET_CONTROLLER"]
+    static SYSCRG_DRIVER: DriverRegister;
+}
+
+struct KlibImpl;
+
+impl_trait! {
+    impl Klib for KlibImpl {
+        fn mem_iomap(addr: PhysAddr, size: usize) -> AxResult<VirtAddr> {
+            assert_eq!(addr.as_usize(), SYSCRG_PADDR);
+            assert_eq!(size, SYSCRG_MMIO_SIZE);
+            let ptr = SYSCRG_MMIO.load(Ordering::SeqCst);
+            assert_ne!(ptr, 0, "test SYSCRG MMIO must be initialized before probing");
+            Ok(VirtAddr::from_usize(ptr))
+        }
+
+        fn mem_virt_to_phys(addr: VirtAddr) -> PhysAddr {
+            PhysAddr::from_usize(addr.as_usize())
+        }
+
+        fn mem_make_dma_coherent_uncached(
+            _addr: VirtAddr,
+            _size: usize,
+        ) -> axklib::DmaCoherentMappingOutcome {
+            axklib::DmaCoherentMappingOutcome::NotStarted(AxError::Unsupported)
+        }
+
+        fn mem_restore_dma_cached(_addr: VirtAddr, _size: usize) -> AxResult {
+            Err(AxError::Unsupported)
+        }
+
+        fn dma_cache_clean(_addr: VirtAddr, _size: usize) {}
+
+        fn dma_cache_invalidate(_addr: VirtAddr, _size: usize) {}
+
+        fn dma_cache_clean_invalidate(_addr: VirtAddr, _size: usize) {}
+
+        fn dma_alloc_pages(_dma_mask: u64, _num_pages: usize, _align: usize) -> AxResult<VirtAddr> {
+            Err(AxError::Unsupported)
+        }
+
+        fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+
+        fn time_busy_wait(_dur: Duration) {}
+
+        fn time_monotonic_nanos() -> u64 {
+            0
+        }
+
+        fn time_try_init_epoch_offset(_epoch_time_nanos: u64) -> bool {
+            false
+        }
+
+        fn irq_set_enable(_irq: IrqId, _enabled: bool) -> AxResult {
+            Ok(())
+        }
+
+        fn irq_request_shared(_irq: IrqId, _handler: BoxedIrqHandler) -> AxResult<IrqHandle> {
+            Err(AxError::Unsupported)
+        }
+
+        fn irq_request_shared_disabled(
+            _irq: IrqId,
+            _handler: BoxedIrqHandler,
+        ) -> AxResult<IrqHandle> {
+            Err(AxError::Unsupported)
+        }
+
+        fn irq_request_percpu(
+            _irq: IrqId,
+            _cpus: IrqCpuMask,
+            _handler: ConcurrentBoxedIrqHandler,
+        ) -> AxResult<IrqHandle> {
+            Err(AxError::Unsupported)
+        }
+
+        fn irq_free(_handle: IrqHandle) -> AxResult {
+            Err(AxError::Unsupported)
+        }
+
+        fn irq_enable(_handle: IrqHandle) -> AxResult {
+            Err(AxError::Unsupported)
+        }
+
+        fn irq_disable(_handle: IrqHandle) -> AxResult {
+            Err(AxError::Unsupported)
+        }
+    }
+}
+
+struct SyscrgConsumer;
+
+impl DriverGeneric for SyscrgConsumer {
+    fn name(&self) -> &str {
+        "jh7110-syscrg-consumer"
+    }
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    let info = probe.info();
+    let clocks = info.clock_lines()?;
+    assert_eq!(clocks.len(), 2);
+    assert_eq!(clocks[0].name(), Some("ahb"));
+    assert_eq!(clocks[0].id().raw(), SDIO0_AHB_CLOCK as usize);
+    assert_eq!(clocks[1].name(), Some("ciu"));
+    assert_eq!(clocks[1].id().raw(), SDIO0_CARD_CLOCK as usize);
+
+    let resets = info.reset_lines()?;
+    assert_eq!(resets.len(), 1);
+    assert_eq!(resets[0].name(), Some("ahb"));
+    assert_eq!(resets[0].id().raw(), u64::from(SDIO0_AHB_RESET));
+
+    let provider = info
+        .phandle_to_device_id(Phandle::from(SYSCRG_PHANDLE))
+        .ok_or_else(|| OnProbeError::other("SYSCRG provider has no device id"))?;
+    rdrive::get::<rdif_clk::Clk>(provider).map_err(|error| {
+        OnProbeError::other(format!("SYSCRG clock capability missing: {error}"))
+    })?;
+    rdrive::get::<rdif_reset::Reset>(provider).map_err(|error| {
+        OnProbeError::other(format!("SYSCRG reset capability missing: {error}"))
+    })?;
+
+    let resources =
+        info.prepare_resources(ResourcePrepareConfig::default().with_named_clock_rate("ciu"))?;
+    assert_eq!(resources.clock_rate("ciu"), Some(0));
+
+    probe.into_platform_device().register(SyscrgConsumer);
+    Ok(())
+}
+
+static CONSUMER_DRIVER: DriverRegister = DriverRegister {
+    name: "JH7110 SYSCRG consumer test",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,jh7110-syscrg-consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+#[test]
+fn combined_syscrg_node_publishes_clock_and_reset_capabilities() {
+    let regs = Box::leak(vec![0_u32; SYSCRG_MMIO_SIZE / size_of::<u32>()].into_boxed_slice());
+    let reset_status_word = SDIO0_AHB_RESET as usize / u32::BITS as usize;
+    regs[RESET_STATUS_OFFSET / size_of::<u32>() + reset_status_word] =
+        1 << (SDIO0_AHB_RESET % u32::BITS);
+    SYSCRG_MMIO.store(regs.as_mut_ptr() as usize, Ordering::SeqCst);
+
+    let encoded = Box::leak(Box::new(syscrg_consumer_fdt().encode()));
+    let addr = NonNull::new(encoded.as_ref().as_ptr() as *mut u8).unwrap();
+    rdrive::init(Platform::Fdt { addr }).unwrap();
+    rdrive::register_add(unsafe { SYSCRG_DRIVER.clone() });
+    rdrive::register_add(CONSUMER_DRIVER.clone());
+
+    rdrive::probe_all(true).expect("combined SYSCRG provider and consumer must probe");
+
+    let provider = rdrive::fdt_phandle_to_device_id(Phandle::from(SYSCRG_PHANDLE)).unwrap();
+    assert!(rdrive::get::<rdif_clk::Clk>(provider).is_ok());
+    assert!(rdrive::get::<rdif_reset::Reset>(provider).is_ok());
+    assert!(rdrive::get_one::<SyscrgConsumer>().is_some());
+}
+
+fn syscrg_consumer_fdt() -> Fdt {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.node_mut(root)
+        .unwrap()
+        .set_property(prop_u32s("#address-cells", &[2]));
+    fdt.node_mut(root)
+        .unwrap()
+        .set_property(prop_u32s("#size-cells", &[2]));
+
+    // Put the consumer first so the clock probe priority, not FDT order, resolves its provider.
+    let consumer = fdt.add_node(root, Node::new("mmc@16010000"));
+    for property in [
+        prop_strs("compatible", &["test,jh7110-syscrg-consumer"]),
+        prop_u32s(
+            "clocks",
+            &[
+                SYSCRG_PHANDLE,
+                SDIO0_AHB_CLOCK,
+                SYSCRG_PHANDLE,
+                SDIO0_CARD_CLOCK,
+            ],
+        ),
+        prop_strs("clock-names", &["ahb", "ciu"]),
+        prop_u32s("resets", &[SYSCRG_PHANDLE, SDIO0_AHB_RESET]),
+        prop_strs("reset-names", &["ahb"]),
+    ] {
+        fdt.node_mut(consumer).unwrap().set_property(property);
+    }
+
+    let provider = fdt.add_node(root, Node::new("clock-controller@13020000"));
+    for property in [
+        prop_strs("compatible", &["starfive,jh7110-syscrg"]),
+        prop_u32s("phandle", &[SYSCRG_PHANDLE]),
+        prop_u32s("#clock-cells", &[1]),
+        prop_u32s("#reset-cells", &[1]),
+        prop_u32s("reg", &[0, SYSCRG_PADDR as u32, 0, SYSCRG_MMIO_SIZE as u32]),
+    ] {
+        fdt.node_mut(provider).unwrap().set_property(property);
+    }
+
+    fdt
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::with_capacity(core::mem::size_of_val(values));
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/platforms/someboot/src/arch/riscv64/entry.rs
+++ b/platforms/someboot/src/arch/riscv64/entry.rs
@@ -15,11 +15,10 @@ pub unsafe extern "C" fn _head() -> ! {
     naked_asm!(
         ".option push",
         ".option norvc",
-        // code0/code1: use lla+jr instead of j to avoid R_RISCV_JAL
-        // range limit (±1MB); lla expands to auipc+addi with ±2GB reach
-        "lla t0, {kernel_entry}",
-        "jr t0",
-        "nop",
+        ".option norelax",
+        // The RISC-V Image header reserves exactly 8 bytes for code0/code1.
+        "2: auipc t0, %pcrel_hi({kernel_entry})",
+        "jalr zero, %pcrel_lo(2b)(t0)",
         ".option pop",
         // text_offset
         ".quad {text_offset}",

--- a/scripts/axbuild/src/starry/build.rs
+++ b/scripts/axbuild/src/starry/build.rs
@@ -185,6 +185,8 @@ pub(crate) fn postprocess_starry_artifact(
         generate_uimage_from_its(workspace_root, &plan, &request.arch, &request.target, elf)?;
     }
 
+    validate_riscv_image_artifact(&request.arch, elf)?;
+
     Ok(())
 }
 
@@ -312,6 +314,67 @@ fn refresh_bin_if_present(kernel_elf: &Path) -> anyhow::Result<()> {
         .exec()
         .with_context(|| format!("failed to refresh {}", bin.display()))?;
     stage.done();
+    Ok(())
+}
+
+fn validate_riscv_image_artifact(arch: &str, kernel_elf: &Path) -> anyhow::Result<()> {
+    if arch != "riscv64" {
+        return Ok(());
+    }
+    let bin = kernel_elf.with_extension("bin");
+    if !bin.exists() {
+        bail!("RISC-V Image artifact is missing: {}", bin.display());
+    }
+    let image = fs::read(&bin).with_context(|| format!("failed to read {}", bin.display()))?;
+    validate_riscv_image_header(&image)
+        .with_context(|| format!("invalid RISC-V Image header in {}", bin.display()))?;
+    println!("[axbuild] validated RISC-V Image header: {}", bin.display());
+    Ok(())
+}
+
+fn validate_riscv_image_header(image: &[u8]) -> anyhow::Result<()> {
+    const HEADER_SIZE: usize = 0x40;
+    const TEXT_OFFSET: u64 = 0x20_0000;
+    const AUIPC_T0_FIXED_BITS: u32 = 0x297;
+    const JALR_ZERO_T0_FIXED_BITS: u32 = 0x0002_8067;
+
+    if image.len() < HEADER_SIZE {
+        bail!(
+            "image is only {} bytes, need at least {HEADER_SIZE}",
+            image.len()
+        );
+    }
+
+    let code0 = u32::from_le_bytes(image[0..4].try_into().unwrap());
+    let code1 = u32::from_le_bytes(image[4..8].try_into().unwrap());
+    if code0 & 0x0fff != AUIPC_T0_FIXED_BITS {
+        bail!("code0 is not `auipc t0, ...`: {code0:#010x}");
+    }
+    if code1 & 0x000f_ffff != JALR_ZERO_T0_FIXED_BITS {
+        bail!("code1 is not `jalr zero, ...(t0)`: {code1:#010x}");
+    }
+
+    let read_u64 =
+        |offset: usize| u64::from_le_bytes(image[offset..offset + 8].try_into().unwrap());
+    if read_u64(0x08) != TEXT_OFFSET {
+        bail!(
+            "text_offset at 0x08 is {:#x}, expected {TEXT_OFFSET:#x}",
+            read_u64(0x08)
+        );
+    }
+    let image_size = read_u64(0x10);
+    if image_size != image.len() as u64 {
+        bail!(
+            "image_size at 0x10 is {image_size:#x}, but the artifact is {} bytes",
+            image.len()
+        );
+    }
+    if &image[0x30..0x35] != b"RISCV" {
+        bail!("RISC-V magic at 0x30 is missing");
+    }
+    if &image[0x38..0x3c] != b"RSC\x05" {
+        bail!("RISC-V magic2 at 0x38 is missing");
+    }
     Ok(())
 }
 

--- a/scripts/axbuild/src/starry/build/tests.rs
+++ b/scripts/axbuild/src/starry/build/tests.rs
@@ -740,3 +740,48 @@ fn ensure_starry_bin_arg_keeps_existing_bin_arg() {
 
     assert_eq!(args, vec!["--bin".to_string(), "starryos".to_string()]);
 }
+
+#[test]
+fn riscv_image_header_accepts_compact_entry_and_fixed_offsets() {
+    let image = riscv_image_fixture(0x0032_2297, 0x4982_8067);
+
+    validate_riscv_image_header(&image).unwrap();
+}
+
+#[test]
+fn riscv_image_header_rejects_legacy_sixteen_byte_entry() {
+    let mut image = vec![0_u8; 0x80];
+    let image_size = image.len() as u64;
+    put_u32(&mut image, 0x00, 0x0032_2297);
+    put_u32(&mut image, 0x04, 0x0002_8293); // addi t0, t0, 0 from the old lla expansion
+    put_u32(&mut image, 0x08, 0x4982_8067);
+    put_u32(&mut image, 0x0c, 0x0000_0013); // nop
+    put_u64(&mut image, 0x10, 0x20_0000);
+    put_u64(&mut image, 0x18, image_size);
+    image[0x38..0x3d].copy_from_slice(b"RISCV");
+    image[0x40..0x44].copy_from_slice(b"RSC\x05");
+
+    let error = validate_riscv_image_header(&image).unwrap_err();
+
+    assert!(error.to_string().contains("code1"), "{error:#}");
+}
+
+fn riscv_image_fixture(code0: u32, code1: u32) -> Vec<u8> {
+    let mut image = vec![0_u8; 0x80];
+    let image_size = image.len() as u64;
+    put_u32(&mut image, 0x00, code0);
+    put_u32(&mut image, 0x04, code1);
+    put_u64(&mut image, 0x08, 0x20_0000);
+    put_u64(&mut image, 0x10, image_size);
+    image[0x30..0x35].copy_from_slice(b"RISCV");
+    image[0x38..0x3c].copy_from_slice(b"RSC\x05");
+    image
+}
+
+fn put_u32(image: &mut [u8], offset: usize, value: u32) {
+    image[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+fn put_u64(image: &mut [u8], offset: usize, value: u64) {
+    image[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+}

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -47,6 +47,13 @@ const AX_TASK_FEATURE_PROFILES: &[PackageFeatureProfile] = &[
     },
 ];
 
+const AX_DRIVER_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
+    name: "starfive-jh7110-dwmmc",
+    features: &["starfive-jh7110-dwmmc"],
+    name_filter: None,
+    expected_tests: &[],
+}];
+
 const HOST_TEST_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
     name: "host-test",
     features: &["host-test"],
@@ -251,6 +258,7 @@ fn package_feature_profiles(package: &str) -> Option<&'static [PackageFeaturePro
             Some(HOST_TEST_FEATURE_PROFILES)
         }
         "ax-task" => Some(AX_TASK_FEATURE_PROFILES),
+        "ax-driver" => Some(AX_DRIVER_FEATURE_PROFILES),
         _ => None,
     }
 }
@@ -588,6 +596,27 @@ mod tests {
         assert_eq!(
             runner.invocations[0].1.args(),
             vec!["test", "-p", "starry-process"]
+        );
+    }
+
+    #[test]
+    fn ax_driver_uses_visionfive2_mmc_feature_profile() {
+        let root = PathBuf::from("/tmp/workspace");
+        let packages = vec!["ax-driver".to_string()];
+        let mut runner = FakeCargoRunner::succeeding();
+
+        let failed = run_std_tests(&mut runner, &root, &packages).unwrap();
+
+        assert!(failed.is_empty());
+        assert_eq!(
+            runner.invocations[0].1.args(),
+            vec![
+                "test",
+                "-p",
+                "ax-driver",
+                "--features",
+                "starfive-jh7110-dwmmc"
+            ]
         );
     }
 


### PR DESCRIPTION
## 问题

在 StarFive VisionFive 2 v1.3B 开发板上使用 U-Boot `booti`
启动 StarryOS，并从 SD 卡挂载根文件系统时，启动过程先后遇到两个问题。

### 1. U-Boot 无法识别 RISC-V Image

使用 `booti` 启动 `starryos.bin` 时，U-Boot 报错：

```text
StarFive # booti ${kernel_addr} - ${fdtcontroladdr}
Bad Linux RISCV Image magic!
StarFive #
```

问题位于
`platforms/someboot/src/arch/riscv64/entry.rs::_head`。

原入口使用了 `lla`、`jr` 和 `nop`。在禁用压缩指令的情况下，
`lla` 会展开成两条指令，因此入口序列共占用 16 字节。

RISC-V Image 格式只为 `code0` 和 `code1` 预留了 8 字节。入口序列
超过该长度后，后续的 `text_offset`、`image_size` 和镜像 magic
字段全部偏离规定位置，导致 U-Boot `booti` 无法识别镜像。

### 2. JH7110 SYSCRG 设备树节点无法提供 MMC 时钟

修复镜像头并进入内核后，两个 MMC 控制器的资源准备仍然失败：

```text
[123.163451 ax_driver::block::starfive_mmc:45]
starfive-jh7110-dwmmc probe: node=mmc@16010000,
addr=0x16010000, size=0x10000

[123.175911 ax_driver::block::starfive_mmc:45]
starfive-jh7110-dwmmc probe: node=mmc@16020000,
addr=0x16020000, size=0x10000

[123.188231 rdrive:216] Probe failed for [fdt]: other error:
[mmc@16010000] clock provider Phandle(3) has no rdif-clk interface:
Device not found

[123.202385 rdrive:216] Probe failed for [fdt]: other error:
[mmc@16020000] clock provider Phandle(3) has no rdif-clk interface:
Device not found
```

由于 MMC 块设备没有成功注册，根文件系统初始化随后发生 panic：

```text
panicked at fs/ax-fs-ng/src/root.rs:196:28:
failed to determine root device from available block devices

BACKTRACE_BEGIN kind=panic arch=riscv64 alloc=false dwarf=false
BT_ERROR requires_alloc
BACKTRACE_END
```

VisionFive 2 的 U-Boot FDT 中，MMC 引用的 phandle 3 对应以下节点：

```text
StarFive # fdt print /soc/clock-controller@13020000 compatible
compatible = "starfive,jh7110-syscrg"

StarFive # fdt print /soc/clock-controller@13020000 phandle
phandle = <0x00000003>

StarFive # fdt print /soc/mmc@16010000 clocks
clocks = <0x00000003 0x0000005b 0x00000003 0x0000005d>
```

原驱动只支持以下拆分的 compatible：

```text
starfive,jh7110-clkgen
starfive,jh7110-reset
```

因此驱动无法匹配实际的 `starfive,jh7110-syscrg` 节点，也没有为
MMC 所引用的设备注册 `rdif-clk` 接口。

## 修复方式

- 将 RISC-V Image 入口修改为禁止压缩和 relaxation 的
  `auipc + jalr` 两条指令，使 `code0` 和 `code1` 严格保持为 8 字节。
- 增加对 `starfive,jh7110-syscrg` compatible 的匹配。
- 在同一个 SYSCRG 设备节点上同时注册 `rdif-clk` 和
  `rdif-reset` provider。
- 保留对原有拆分式 clock/reset compatible 的兼容支持。

## 修复结果

重新构建后的 `starryos.bin` 可以通过 U-Boot `booti` 的镜像格式
检查并正常进入内核。

JH7110 clock/reset 资源能够被正确解析，SD/MMC 块设备成功注册，
StarryOS 可以挂载 SD 卡上的根文件系统并进入交互式 shell：

```text
root@starry:/root #
```

## 验证方式

```text
cargo fmt --all --check

cargo clippy --no-deps -p ax-driver \
  --no-default-features \
  --features starfive-jh7110-dwmmc -- -D warnings

cargo xtask starry build \
  -c os/StarryOS/configs/board/visionfive2.toml
```

实机验证环境：

```text
开发板：StarFive VisionFive 2 v1.3B
Bootloader：U-Boot 2026.01-rc4
启动方式：booti
根文件系统：SD 卡上的 ext4 文件系统
```

## 补充回归测试

### SYSCRG FDT/rdrive 集成测试

新增宿主侧 FDT/rdrive 测试，构造包含
`starfive,jh7110-syscrg` provider 和 MMC consumer 的设备树，验证：

- `starfive,jh7110-syscrg` compatible 能够正确匹配；
- provider 以 `ProbePriority::CLK` 优先于 consumer 探测；
- 同一个 provider 同时发布 `rdif-clk` 和 `rdif-reset` capability；
- MMC consumer 能够解析 clock、reset 和 clock rate 资源。

```bash
cargo test -p ax-driver \
  --no-default-features \
  --features starfive-jh7110-dwmmc
```

结果：

```text
10 passed; 0 failed
```

### RISC-V Image 产物检查

在 StarryOS 的 riscv64 构建后处理阶段增加最终 `.bin` 产物检查，验证：

- Image 前 8 字节仅包含 `auipc` 和 `jalr`；
- `text_offset` 位于 `0x08`；
- `image_size` 位于 `0x10`，并与最终文件大小一致；
- `RISCV` magic 位于 `0x30`；
- `RSC\x05` magic 位于 `0x38`。

同时增加正反例测试，确认正确的 8 字节入口可以通过检查，旧的
16 字节 `lla + jr + nop` 入口布局会被拒绝。

```bash
cargo test -p axbuild riscv_image_header -- --nocapture
```

结果：

```text
2 passed; 0 failed
```

标准测试入口也会为 `ax-driver` 启用 VisionFive 2 MMC feature：

```bash
cargo test -p axbuild \
  ax_driver_uses_visionfive2_mmc_feature_profile \
  -- --nocapture
```

结果：

```text
1 passed; 0 failed
```

### 静态检查与构建

```bash
cargo fmt --all -- --check

cargo clippy --no-deps -p ax-driver \
  --no-default-features \
  --features starfive-jh7110-dwmmc -- -D warnings

cargo xtask starry build \
  --config os/StarryOS/configs/board/visionfive2.toml \
  --arch riscv64
```

以上检查均通过，构建日志包含：

```text
[axbuild] validated RISC-V Image header: .../starryos.bin
```

GitHub Actions 共 65 项检查：33 项成功，32 项按测试矩阵预期跳过，
0 项失败。

## 补充实板验证结果

```text
开发板：StarFive VisionFive 2 v1.3B
Bootloader：U-Boot 2026.01-rc4
启动方式：booti
根文件系统：SD 卡上的 ext4 文件系统
```

关键启动日志：

```text
RISC-V64 SBI kernel entry.
StarFive JH7110 SYS clock/reset providers registered
sdio: detected Sd ocr=0xc1ff8000
sdmmc block init complete: kind=Sd
selected root device: disk0 raw device
Ext4 filesystem mounted
Welcome to Starry OS!
root@starry:/root #
```

实板验证确认：

- U-Boot `booti` 能够识别并启动修复后的 RISC-V Image；
- JH7110 SYSCRG 能够同时提供 clock/reset 资源；
- SD/MMC 初始化完成；
- StarryOS 能够挂载 SD 卡上的 ext4 根文件系统并进入交互式 shell。