### PR TITLE
ci(axvisor): run ovmf-acpi-svm on self-hosted AMD CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -677,6 +677,8 @@ jobs:
               cargo xtask image pull qemu-x86_64 --output-dir tmp/axbuild/images
               echo "==> axvisor x86_64 svm direct ACPI boot"
               cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-svm
+              echo "==> axvisor x86_64 svm nested OVMF ACPI boot"
+              cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-svm
             cache_key: ""
             container_image: ""
             limit_to_owner: rcore-os

--- a/docs/docs/build/axvisor/test.md
+++ b/docs/docs/build/axvisor/test.md
@@ -147,7 +147,7 @@ Axvisor 测试的六种 pipeline 类型与 StarryOS 完全一致，因为两者�
 
 pipeline 类型、检测优先级、资产准备、rootfs 缓存和 grouped runner 协议的完整说明见 [测试基础设施](../test_infra)。Axvisor 的 `prepare_staging_root` 钩子为空操作（`|_| Ok(())`），不做 StarryOS 那样的 DNS 注入和 APK 区域配置。
 
-### 4.1 x86 嵌套 OVMF/ACPI 验证
+## 5. x86 嵌套 OVMF/ACPI 验证
 
 `normal` 组提供两条对称的 x86 嵌套 OVMF 用例：
 
@@ -158,7 +158,9 @@ cargo xtask axvisor test qemu --arch x86_64 --test-group normal \
   --test-case ovmf-acpi-svm
 ```
 
-两者共用 `test-suit/axvisor/normal/qemu-acpi-ovmf/x86-linux-acpi-ovmf.toml`、同一 BusyBox initramfs 和同一 4 MiB guest firmware 输出。build config 不选择 `vmx` 或 `svm` Cargo feature；唯一的 backend 差异是外层 QEMU 的 `-cpu` 能力：VMX 暴露 EPT、unrestricted guest 和 flexpriority，SVM 暴露 SVM、NPT 和 NRIP save。因此应分别在 Intel/VMX 与 AMD/SVM KVM 宿主上运行对应 case。本组用例在稳定性阶段完成前保持 non-gating。
+两者共用 `test-suit/axvisor/normal/qemu-acpi-ovmf/x86-linux-acpi-ovmf.toml`、同一 BusyBox initramfs 和同一 4 MiB guest firmware 输出。build config 不选择 `vmx` 或 `svm` Cargo feature；唯一的 backend 差异是外层 QEMU 的 `-cpu` 能力：VMX 暴露 EPT、unrestricted guest 和 flexpriority，SVM 暴露 SVM、NPT 和 NRIP save。因此应分别在 Intel/VMX 与 AMD/SVM KVM 宿主上运行对应 case。
+
+两个 case 均已加入 CI 运行：`ovmf-acpi-vmx` 在 self-hosted Intel/KVM 宿主上运行（见 `.github/workflows/ci.yml` 中 "Test axvisor x86_64 ACPI direct and OVMF boot (vmx)" 任务），`ovmf-acpi-svm` 在 self-hosted AMD/KVM 宿主上运行（见 "Test axvisor self-hosted x86_64 (svm smoke + ACPI)" 任务）。
 
 资产准备复用 Ostool 的 x86_64 OVMF 缓存，可先用以下命令确认来源路径：
 
@@ -170,4 +172,4 @@ Axvisor 测试构建日志会输出本次实际使用的 Ostool CODE、VARS 和�
 
 成功条件 `AXVISOR_X86_OVMF_ACPI_PASSED` 来自嵌套 Linux initramfs，而不是 QEMU 外层 OVMF。该 marker 只有在 OVMF 完成 kernel handoff、Linux 进入早期用户态，并且 Linux 能读取 DSDT、APIC、FACP、SPCR、发现 `ttyS0`、初始化 IOAPIC 且 online CPU 集合为 `0` 时才会输出。因此它同时证明当前 firmware handoff 和 guest-side ACPI 接受路径。
 
-当前用例仍由 fw_cfg 提供 Linux kernel、initramfs 和命令行。它不证明 OVMF 已枚举 Axvisor guest PCI 启动盘，也不证明 Linux 经 guest ESP 或 EFI stub 启动；这些属于后续独立功能阶段，不能从本 marker 推导。
+当前用例仍由 fw_cfg 提供 Linux kernel、initramfs 和命令行。它不证明 OVMF 已枚举 Axvisor guest PCI 启动盘，也不证明 Linux 经 guest ESP 或 EFI stub 启动。


### PR DESCRIPTION
## 问题

Axvisor 的 x86_64 嵌套 OVMF ACPI 验证用例 `ovmf-acpi-vmx` 已在 CI 中运行（self-hosted Intel/KVM），但对称的 `ovmf-acpi-svm` 用例虽已合入 dev （#1931），却始终没有进入 CI，导致 SVM 后端缺少嵌套 OVMF 路径的持续回归覆盖。

## 改动逻辑

直接仿照现有的 `ovmf-acpi-vmx`（共用同一 backend-neutral guest 合约）。