### PR TITLE
fix(crab-usb): migrate UVC tests to ax-sync

### DIFF
--- a/drivers/usb/usb-host/Cargo.toml
+++ b/drivers/usb/usb-host/Cargo.toml
@@ -37,3 +37,6 @@ trait-ffi = "0.2.4"
 usb-if = {workspace = true}
 xhci = "0.9"
 libusb1-sys = {version = "0.7", optional = true}
+
+[dev-dependencies]
+ax-sync = { workspace = true, features = ["host-test"] }

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -1001,7 +1001,7 @@ mod tests {
         sync::atomic::{AtomicU64, AtomicUsize, Ordering as AtomicOrdering},
     };
 
-    use ax_kspin::{SpinRaw as Mutex, SpinRwLock as RwLock};
+    use ax_sync::{SpinLock as Mutex, SpinRwLock as RwLock};
     use dma_api::{DmaAllocHandle, DmaConstraints, DmaError, DmaMapHandle, DmaOp};
     use usb_if::{endpoint::TransferRequest, err::TransferError};
 


### PR DESCRIPTION
#1956 将 `ax_kspin` 统一到 `ax_sync`，但随后合入的 #1924 在新增测试中又引入了 `ax_kspin`，导致 `cargo test -p crab-usb` 无法编译

故改用 `ax_sync`，并通过开发依赖启用 `ax-sync/host-test`