### PR TITLE
fix(ax-net): avoid sleeping mutex under datagram spin lock

### DIFF
--- a/net/ax-net/src/unix/dgram.rs
+++ b/net/ax-net/src/unix/dgram.rs
@@ -450,17 +450,21 @@ impl TransportOps for DgramTransport {
             *self.connected.write() = Some(client_chan);
             return Ok(Some(accept_poll));
         }
-        let mut guard = self.connected.write();
-        if guard.is_some() {
+        if self.connected.read().is_some() {
             return Err(AxError::AlreadyConnected);
         }
-        *guard = Some(
+        let connected = {
             slot.dgram
                 .lock()
                 .as_ref()
                 .ok_or(AxError::NotConnected)?
-                .connect(),
-        );
+                .connect()
+        };
+        let mut guard = self.connected.write();
+        if guard.is_some() {
+            return Err(AxError::AlreadyConnected);
+        }
+        *guard = Some(connected);
         Ok(None)
     }
 
@@ -709,5 +713,21 @@ impl Drop for DgramTransport {
             // Connection teardown is visible before waking the peer.
             unsafe { chan.poll_update.wake(IoEvents::IN | IoEvents::OUT) };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::unix::BindSlot;
+
+    #[test]
+    fn datagram_connect_does_not_lock_a_mutex_with_preemption_disabled() {
+        let slot = BindSlot::default();
+        let server = DgramTransport::new(1);
+        server.bind(&slot, &UnixSocketAddr::Unnamed).unwrap();
+
+        let client = DgramTransport::new(2);
+        client.connect(&slot, &UnixSocketAddr::Unnamed).unwrap();
     }
 }

--- a/os/arceos/modules/axsync/src/mutex.rs
+++ b/os/arceos/modules/axsync/src/mutex.rs
@@ -410,6 +410,11 @@ mod host {
         fn might_sleep(caller: &'static Location<'static>) {
             MIGHT_SLEEP_CALLS.set(MIGHT_SLEEP_CALLS.get() + 1);
             LAST_MIGHT_SLEEP_CALLER.set(Some(caller));
+            assert_eq!(
+                crate::host_preempt_depth(),
+                0,
+                "sleeping mutex acquired with preemption disabled at {caller}"
+            );
         }
 
         fn current_task_id() -> u64 {
@@ -512,6 +517,18 @@ mod tests {
     use std::{sync::Arc, thread};
 
     use super::{Mutex, host};
+    use crate::SpinLock;
+
+    #[test]
+    fn lock_rejects_preemption_disabled_context() {
+        let spin = SpinLock::new(());
+        let mutex = Mutex::new(());
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _spin_guard = spin.lock();
+            let _mutex_guard = mutex.lock();
+        }));
+        assert!(result.is_err());
+    }
 
     #[test]
     fn contended_mutex_wakes_waiters_without_lost_wakeups() {


### PR DESCRIPTION
AF_UNIX datagram 的 `connect()` 在持有自旋锁时获取了可睡眠 Mutex，导致 atomic-context panic

调整了锁获取顺序，并增加 host-test 检查和回归测试