### PR TITLE
fix(axbuild): suppress debugfs copy noise in Starry image builds

### DIFF
--- a/apps/starry/claw-code/prebuild.sh
+++ b/apps/starry/claw-code/prebuild.sh
@@ -64,7 +64,7 @@ inject_claw() {
     local img="$1"
     echo "  injecting into $img ..."
     debugfs -w "$img" -R "rm /usr/bin/claw" 2>/dev/null || true
-    debugfs -w "$img" -R "write $CLAW_BIN /usr/bin/claw"
+    debugfs -w "$img" -R "write $CLAW_BIN /usr/bin/claw" >/dev/null
     debugfs -w "$img" -R "sif /usr/bin/claw mode 0100755"
 }
 inject_claw "$CLAW_IMG"

--- a/apps/starry/doom/prebuild.sh
+++ b/apps/starry/doom/prebuild.sh
@@ -35,7 +35,7 @@ ensure_host_packages() {
 }
 
 extract_base_rootfs() {
-    debugfs -R "rdump / $staging_root" "$base_rootfs"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null
 }
 
 install_packages() {

--- a/apps/starry/ffmpeg/prebuild.sh
+++ b/apps/starry/ffmpeg/prebuild.sh
@@ -84,7 +84,7 @@ run_guest_apk_with_retry() {
 }
 
 extract_base_rootfs() {
-    debugfs -R "rdump / $staging_root" "$base_rootfs"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null
 }
 
 install_ffmpeg_package() {

--- a/apps/starry/ffplay/prebuild.sh
+++ b/apps/starry/ffplay/prebuild.sh
@@ -49,7 +49,7 @@ ensure_host_packages() {
 }
 
 extract_base_rootfs() {
-    debugfs -R "rdump / $staging_root" "$base_rootfs"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null
 }
 
 install_packages() {

--- a/apps/starry/gdb-smoke/prebuild.sh
+++ b/apps/starry/gdb-smoke/prebuild.sh
@@ -58,7 +58,7 @@ ensure_host_packages() {
 }
 
 extract_base_rootfs() {
-    debugfs -R "rdump / $staging_root" "$base_rootfs"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null
 }
 
 find_qemu_runner() {

--- a/apps/starry/mosquitto/prebuild.sh
+++ b/apps/starry/mosquitto/prebuild.sh
@@ -84,7 +84,7 @@ run_guest_apk_with_retry() {
 }
 
 extract_base_rootfs() {
-    debugfs -R "rdump / $staging_root" "$base_rootfs"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null
 }
 
 install_mosquitto_package() {

--- a/apps/starry/pip-uv/prebuild.sh
+++ b/apps/starry/pip-uv/prebuild.sh
@@ -85,7 +85,7 @@ ensure_host_packages() {
 }
 
 extract_base_rootfs() {
-    debugfs -R "rdump / $staging_root" "$base_rootfs"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null
 }
 
 install_python_packages() {

--- a/apps/starry/pip/prebuild.sh
+++ b/apps/starry/pip/prebuild.sh
@@ -46,7 +46,7 @@ ensure_host_packages() {
 }
 
 extract_base_rootfs() {
-    debugfs -R "rdump / $staging_root" "$base_rootfs"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null
 }
 
 install_pip_packages() {

--- a/apps/starry/qt-calc/prebuild.sh
+++ b/apps/starry/qt-calc/prebuild.sh
@@ -45,7 +45,7 @@ ensure_host_packages() {
 }
 
 extract_base_rootfs() {
-    debugfs -R "rdump / $staging_root" "$base_rootfs"
+    debugfs -R "rdump / $staging_root" "$base_rootfs" >/dev/null
 }
 
 resize_rootfs() {

--- a/apps/starry/redis/prebuild.sh
+++ b/apps/starry/redis/prebuild.sh
@@ -107,7 +107,7 @@ run_guest_apk() {
 }
 
 extract_rootfs() {
-    debugfs -R "rdump / $staging_root" "$rootfs"
+    debugfs -R "rdump / $staging_root" "$rootfs" >/dev/null
 }
 
 install_redis_package() {

--- a/apps/starry/stress/stress-ng-0/stress-ng-0/prebuild.sh
+++ b/apps/starry/stress/stress-ng-0/stress-ng-0/prebuild.sh
@@ -94,7 +94,7 @@ run_guest_apk() {
 }
 
 extract_rootfs() {
-    debugfs -R "rdump / $staging_root" "$rootfs"
+    debugfs -R "rdump / $staging_root" "$rootfs" >/dev/null
 }
 
 install_stress_ng() {

--- a/scripts/axbuild/src/rootfs/inject.rs
+++ b/scripts/axbuild/src/rootfs/inject.rs
@@ -470,12 +470,21 @@ fn run_debugfs_script(
     commands: &[String],
     context_message: &str,
 ) -> anyhow::Result<()> {
+    run_debugfs_script_with_program(Path::new("debugfs"), rootfs_img, commands, context_message)
+}
+
+fn run_debugfs_script_with_program(
+    debugfs_program: &Path,
+    rootfs_img: &Path,
+    commands: &[String],
+    context_message: &str,
+) -> anyhow::Result<()> {
     eprintln!("debugfs -w {}", rootfs_img.display());
-    let mut child = Command::new("debugfs")
+    let mut child = Command::new(debugfs_program)
         .arg("-w")
         .arg(rootfs_img)
         .stdin(Stdio::piped())
-        .stdout(Stdio::inherit())
+        .stdout(Stdio::null())
         .stderr(Stdio::piped())
         .spawn()
         .with_context(|| format!("failed to spawn debugfs for {}", rootfs_img.display()))?;
@@ -689,6 +698,35 @@ mod tests {
         assert!(!status_has_effective_cap_chown(
             "Name:\ttg-xtask\nCapEff:\tinvalid\n"
         ));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn debugfs_script_discards_normal_stdout_and_receives_all_commands() {
+        let root = tempdir().unwrap();
+        let debugfs = root.path().join("debugfs");
+        let received_commands = root.path().join("received-commands");
+        write_executable(
+            &debugfs,
+            &format!(
+                "#!/bin/sh\ntest \"$(readlink /proc/$$/fd/1)\" = /dev/null || exit 91\ncat > '{}'
+",
+                received_commands.display()
+            ),
+        );
+
+        run_debugfs_script_with_program(
+            &debugfs,
+            Path::new("rootfs.img"),
+            &["rm /usr/bin/app".into(), "write app /usr/bin/app".into()],
+            "failed to inject test overlay",
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(received_commands).unwrap(),
+            "rm /usr/bin/app\nwrite app /usr/bin/app\nquit\n"
+        );
     }
 
     #[cfg(unix)]

--- a/scripts/axbuild/src/starry/app/tests/qemu.rs
+++ b/scripts/axbuild/src/starry/app/tests/qemu.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use tempfile::tempdir;
+use walkdir::WalkDir;
 
 use super::{
     app_qemu_test_case, load_qemu_app_case_fields, prepare_qemu_app_case, resolve_qemu_config,
@@ -977,5 +978,46 @@ fn claw_code_qemu_config_exits_after_smoke_check() {
             && !shell_init_cmd.contains("STARRY_CLAW_MISSING"),
         "{} must not echo full claw smoke markers as shell input",
         config_path.display()
+    );
+}
+
+#[test]
+fn debugfs_copy_commands_in_prebuild_scripts_suppress_stdout() {
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("axbuild manifest should live under scripts/axbuild")
+        .to_path_buf();
+    let mut copy_commands = 0;
+
+    for entry in WalkDir::new(repo.join("apps/starry")) {
+        let entry = entry.unwrap();
+        if entry.file_name() != "prebuild.sh" {
+            continue;
+        }
+
+        let content = fs::read_to_string(entry.path()).unwrap();
+        for (line_index, line) in content.lines().enumerate() {
+            let line = line.trim();
+            if line.starts_with('#')
+                || !line.contains("debugfs")
+                || !(line.contains("rdump ") || line.contains("-R \"write "))
+            {
+                continue;
+            }
+
+            copy_commands += 1;
+            assert!(
+                line.contains(">/dev/null") || line.contains("1>/dev/null"),
+                "{}:{} must suppress normal debugfs copy output",
+                entry.path().display(),
+                line_index + 1
+            );
+        }
+    }
+
+    assert!(
+        copy_commands > 0,
+        "expected to inspect debugfs copy commands"
     );
 }


### PR DESCRIPTION
## 问题

Starry 镜像构建过程中，`debugfs` 的 `rdump` 和 `write` 会把正常操作输出直接写入 CI 日志。最新 Starry Apps 运行在首个 Apache 用例中就出现了大量 `debugfs:` prompt 和 `Allocated inode` 回显，掩盖了真正需要关注的构建及运行诊断。

## 修改

1. 将 axbuild 通用 rootfs 注入路径的 `debugfs` stdout 设置为 `/dev/null`，保留现有 stderr 并发读取、过滤和转发逻辑。
2. 为 10 个未静默的 Starry `rdump` 调用和 `claw-code` 的直接 `write` 调用增加 stdout 重定向；stderr 不重定向。
3. 增加 fake debugfs 回归测试，验证 stdout 被丢弃且 `rm`、`write`、`quit` 命令仍完整送达。
4. 增加 Starry prebuild 策略测试，遍历所有 `prebuild.sh` 并约束 `rdump`/直接 `write` 复制命令必须显式静默 stdout。

## 逻辑

`debugfs` 没有 quiet 参数，正常复制进度来自 stdout，因此在执行边界丢弃 stdout 是最小且一致的方案。stderr 继续走原有并发 drain，既保留真实诊断，也避免 stderr 管道填满后与 stdin 写入形成死锁。生产入口和公开 API 均不变化。

## 测试

- `cargo test -p axbuild`：857 passed
- `cargo xtask clippy --package axbuild`：passed
- `cargo fmt --all --check`：passed
- 修改的 11 个 `prebuild.sh` 执行 `bash -n`：passed
- `git diff --check`：passed
- 仓库扫描确认 22 个 `rdump` 和 1 个直接 `write` 复制命令均显式静默 stdout