### PR TITLE
fix(dma-api): enforce typed DMA safety contracts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ dependencies = [
  "rdif-block",
  "thiserror 2.0.20",
  "tock-registers 0.10.1",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2362,6 +2363,7 @@ dependencies = [
  "trait-ffi",
  "usb-if",
  "xhci",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2979,6 +2981,7 @@ dependencies = [
  "log",
  "mbarrier",
  "thiserror 2.0.20",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3063,6 +3066,7 @@ dependencies = [
  "sdio-host2",
  "sdmmc-protocol",
  "volatile 0.6.1",
+ "zerocopy",
 ]
 
 [[package]]
@@ -3270,6 +3274,7 @@ dependencies = [
  "mmio-api",
  "rdif-eth",
  "thiserror 2.0.20",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5410,6 +5415,7 @@ dependencies = [
  "mmio-api",
  "rdif-block",
  "tock-registers 0.10.1",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5788,6 +5794,7 @@ dependencies = [
  "sdio-host2",
  "sdmmc-protocol",
  "volatile 0.6.1",
+ "zerocopy",
 ]
 
 [[package]]
@@ -6626,6 +6633,7 @@ dependencies = [
  "rdif-eth",
  "thiserror 2.0.20",
  "tock-registers 0.10.1",
+ "zerocopy",
 ]
 
 [[package]]
@@ -7298,6 +7306,7 @@ dependencies = [
  "rdif-block",
  "sdio-host2",
  "sdmmc-protocol",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -321,6 +321,7 @@ fdt-raw = "0.3"
 thiserror = { version = "2", default-features = false }
 trait-ffi = "0.2.11"
 tock-registers = "0.10"
+zerocopy = { version = "0.8", default-features = false, features = ["derive"] }
 sg200x-bsp = { version = "0.7.1", default-features = false }
 sg200x-jpu = { version = "0.1.3", path = "drivers/vpu/sg200x-jpu" }
 bcm2835-sdhci = "0.1.1-preview.1"

--- a/drivers/blk/ahci-driver/Cargo.toml
+++ b/drivers/blk/ahci-driver/Cargo.toml
@@ -16,6 +16,7 @@ mmio-api.workspace = true
 rdif-block.workspace = true
 thiserror.workspace = true
 tock-registers.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
 axtest.workspace = true

--- a/drivers/blk/ahci-driver/src/command.rs
+++ b/drivers/blk/ahci-driver/src/command.rs
@@ -39,7 +39,7 @@ const IDENTIFY_FLUSH_EXT_SUPPORTED: u16 = 1 << 13;
 const IDENTIFY_FUA_SUPPORTED: u16 = 1 << 6;
 const IDENTIFY_VALID_COMMAND_SET: u16 = 0x4000;
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 #[repr(C)]
 pub(super) struct CommandHeader {
     options: u32,
@@ -49,14 +49,10 @@ pub(super) struct CommandHeader {
     reserved: [u32; 4],
 }
 
-// SAFETY: The C-layout command header contains only integer fields, accepts
-// every bit pattern, and owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for CommandHeader {}
-
 pub(super) type CommandList = [CommandHeader; 32];
 pub(super) type ReceivedFis = [u8; 256];
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 #[repr(C)]
 struct PhysicalRegionDescriptor {
     address_low: u32,
@@ -65,7 +61,7 @@ struct PhysicalRegionDescriptor {
     byte_count_and_flags: u32,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 #[repr(C)]
 pub(super) struct CommandTable {
     command_fis: [u8; 64],
@@ -73,10 +69,6 @@ pub(super) struct CommandTable {
     reserved: [u8; 48],
     descriptors: [PhysicalRegionDescriptor; MAX_PRDS],
 }
-
-// SAFETY: The C-layout command table contains only byte arrays and C-layout
-// integer descriptors, so every bit pattern is valid.
-unsafe impl dma_api::DmaPod for CommandTable {}
 
 impl Default for CommandTable {
     fn default() -> Self {

--- a/drivers/blk/ahci-driver/src/command.rs
+++ b/drivers/blk/ahci-driver/src/command.rs
@@ -49,6 +49,10 @@ pub(super) struct CommandHeader {
     reserved: [u32; 4],
 }
 
+// SAFETY: The C-layout command header contains only integer fields, accepts
+// every bit pattern, and owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for CommandHeader {}
+
 pub(super) type CommandList = [CommandHeader; 32];
 pub(super) type ReceivedFis = [u8; 256];
 
@@ -69,6 +73,10 @@ pub(super) struct CommandTable {
     reserved: [u8; 48],
     descriptors: [PhysicalRegionDescriptor; MAX_PRDS],
 }
+
+// SAFETY: The C-layout command table contains only byte arrays and C-layout
+// integer descriptors, so every bit pattern is valid.
+unsafe impl dma_api::DmaPod for CommandTable {}
 
 impl Default for CommandTable {
     fn default() -> Self {

--- a/drivers/blk/dwmmc-host/Cargo.toml
+++ b/drivers/blk/dwmmc-host/Cargo.toml
@@ -18,6 +18,7 @@ volatile = { version = "0.6", features = ["derive"] }
 log.workspace = true
 dma-api.workspace = true
 mmio-api.workspace = true
+zerocopy.workspace = true
 
 [features]
 default = []

--- a/drivers/blk/dwmmc-host/src/dma/idmac.rs
+++ b/drivers/blk/dwmmc-host/src/dma/idmac.rs
@@ -58,6 +58,10 @@ pub struct IdmacDesc {
     pub(super) des3: u32,
 }
 
+// SAFETY: The aligned C-layout descriptor contains only `u32` fields, accepts
+// every bit pattern, and owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for IdmacDesc {}
+
 pub(crate) struct IdmacRing {
     descriptors: CoherentArray<IdmacDesc>,
     used: usize,

--- a/drivers/blk/dwmmc-host/src/dma/idmac.rs
+++ b/drivers/blk/dwmmc-host/src/dma/idmac.rs
@@ -50,7 +50,17 @@ pub const IDMAC_MAX_TRANSFER_SIZE: usize = (IDMAC_RING_DESC_COUNT - 1) * IDMAC_D
 pub const IDMAC_MAX_BLOCKS: u32 = (IDMAC_MAX_TRANSFER_SIZE / BLOCK_SIZE) as u32;
 
 #[repr(C, align(16))]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+)]
 pub struct IdmacDesc {
     pub(super) des0: u32,
     pub(super) des1: u32,
@@ -58,9 +68,8 @@ pub struct IdmacDesc {
     pub(super) des3: u32,
 }
 
-// SAFETY: The aligned C-layout descriptor contains only `u32` fields, accepts
-// every bit pattern, and owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for IdmacDesc {}
+const _: () = assert!(core::mem::size_of::<IdmacDesc>() == 16);
+const _: () = assert!(core::mem::align_of::<IdmacDesc>() == 16);
 
 pub(crate) struct IdmacRing {
     descriptors: CoherentArray<IdmacDesc>,

--- a/drivers/blk/nvme-driver/Cargo.toml
+++ b/drivers/blk/nvme-driver/Cargo.toml
@@ -17,6 +17,7 @@ mmio-api.workspace = true
 mbarrier = "0.1"
 rdif-block.workspace = true
 tock-registers = "0.10"
+zerocopy.workspace = true
 
 # bare-test integration test is temporarily disabled.
 # [[test]]

--- a/drivers/blk/nvme-driver/src/queue.rs
+++ b/drivers/blk/nvme-driver/src/queue.rs
@@ -48,12 +48,8 @@ register_bitfields! [
 ];
 
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 pub struct NvmeSubmission([u8; 64]);
-
-// SAFETY: The transparent wrapper contains only bytes, accepts every bit
-// pattern, and owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for NvmeSubmission {}
 
 pub trait Submission {
     fn to_submission(self) -> NvmeSubmission;
@@ -222,7 +218,9 @@ impl Submission for CommandSet {
 }
 
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(
+    Debug, Copy, Clone, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes,
+)]
 pub(crate) struct NvmeCompletion {
     pub result: u64,
     pub sq_head: u16,
@@ -231,13 +229,15 @@ pub(crate) struct NvmeCompletion {
     pub status: CompletionStatus,
 }
 
-// SAFETY: The C-layout completion contains only integer fields and a
-// transparent `u16` wrapper, so every bit pattern is valid.
-unsafe impl dma_api::DmaPod for NvmeCompletion {}
-
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, Default)]
+#[derive(
+    Debug, Copy, Clone, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes,
+)]
 pub(crate) struct CompletionStatus(pub u16);
+
+const _: () = assert!(core::mem::size_of::<NvmeSubmission>() == 64);
+const _: () = assert!(core::mem::size_of::<NvmeCompletion>() == 16);
+const _: () = assert!(core::mem::size_of::<CompletionStatus>() == 2);
 
 impl CompletionStatus {
     pub fn phase(&self) -> bool {

--- a/drivers/blk/nvme-driver/src/queue.rs
+++ b/drivers/blk/nvme-driver/src/queue.rs
@@ -51,6 +51,10 @@ register_bitfields! [
 #[derive(Clone, Copy)]
 pub struct NvmeSubmission([u8; 64]);
 
+// SAFETY: The transparent wrapper contains only bytes, accepts every bit
+// pattern, and owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for NvmeSubmission {}
+
 pub trait Submission {
     fn to_submission(self) -> NvmeSubmission;
 }
@@ -226,6 +230,10 @@ pub(crate) struct NvmeCompletion {
     pub command_id: u16,
     pub status: CompletionStatus,
 }
+
+// SAFETY: The C-layout completion contains only integer fields and a
+// transparent `u16` wrapper, so every bit pattern is valid.
+unsafe impl dma_api::DmaPod for NvmeCompletion {}
 
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Default)]

--- a/drivers/blk/phytium-mci-host/Cargo.toml
+++ b/drivers/blk/phytium-mci-host/Cargo.toml
@@ -18,6 +18,7 @@ log.workspace = true
 dma-api.workspace = true
 mmio-api.workspace = true
 mbarrier = "0.1"
+zerocopy.workspace = true
 
 [features]
 default = []

--- a/drivers/blk/phytium-mci-host/src/dma/idmac.rs
+++ b/drivers/blk/phytium-mci-host/src/dma/idmac.rs
@@ -33,6 +33,10 @@ pub struct IdmacDesc {
     desc_hi: u32,
 }
 
+// SAFETY: The aligned C-layout descriptor contains only `u32` fields, accepts
+// every bit pattern, and owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for IdmacDesc {}
+
 pub(crate) struct IdmacRing {
     descriptors: CoherentArray<IdmacDesc>,
     used: usize,

--- a/drivers/blk/phytium-mci-host/src/dma/idmac.rs
+++ b/drivers/blk/phytium-mci-host/src/dma/idmac.rs
@@ -21,7 +21,17 @@ pub const IDMAC_MAX_BLOCKS: u32 = (IDMAC_MAX_TRANSFER_SIZE / BLOCK_SIZE) as u32;
 pub(crate) const IDMAC_BUFFER_ALIGN: u64 = 4;
 
 #[repr(C, align(32))]
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+)]
 pub struct IdmacDesc {
     attribute: u32,
     reserved0: u32,
@@ -33,9 +43,8 @@ pub struct IdmacDesc {
     desc_hi: u32,
 }
 
-// SAFETY: The aligned C-layout descriptor contains only `u32` fields, accepts
-// every bit pattern, and owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for IdmacDesc {}
+const _: () = assert!(core::mem::size_of::<IdmacDesc>() == 32);
+const _: () = assert!(core::mem::align_of::<IdmacDesc>() == IDMAC_DESC_ALIGN);
 
 pub(crate) struct IdmacRing {
     descriptors: CoherentArray<IdmacDesc>,

--- a/drivers/blk/sdhci-host/Cargo.toml
+++ b/drivers/blk/sdhci-host/Cargo.toml
@@ -17,6 +17,7 @@ log.workspace = true
 dma-api.workspace = true
 mmio-api.workspace = true
 rdif-block.workspace = true
+zerocopy.workspace = true
 
 [features]
 default = []

--- a/drivers/blk/sdhci-host/src/dma/mod.rs
+++ b/drivers/blk/sdhci-host/src/dma/mod.rs
@@ -59,6 +59,10 @@ pub(crate) struct Adma2Desc32 {
     address: u32,
 }
 
+// SAFETY: The aligned C-layout descriptor contains only integer fields, so
+// every bit pattern is valid and it owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for Adma2Desc32 {}
+
 /// 96-bit ADMA2 descriptor used for 64-bit system addresses in pre-v4 mode.
 #[repr(C, align(4))]
 #[derive(Clone, Copy, Default)]
@@ -68,6 +72,10 @@ pub(crate) struct Adma2Desc64 {
     address_low: u32,
     address_high: u32,
 }
+
+// SAFETY: The aligned C-layout descriptor contains only integer fields, so
+// every bit pattern is valid and it owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for Adma2Desc64 {}
 
 pub(crate) enum Adma2DescriptorTable {
     Addr32(CoherentArray<Adma2Desc32>),

--- a/drivers/blk/sdhci-host/src/dma/mod.rs
+++ b/drivers/blk/sdhci-host/src/dma/mod.rs
@@ -52,20 +52,16 @@ mod request;
 ///   4      address[31:0]
 /// ```
 #[repr(C, align(4))]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 pub(crate) struct Adma2Desc32 {
     attr: u16,
     length: u16,
     address: u32,
 }
 
-// SAFETY: The aligned C-layout descriptor contains only integer fields, so
-// every bit pattern is valid and it owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for Adma2Desc32 {}
-
 /// 96-bit ADMA2 descriptor used for 64-bit system addresses in pre-v4 mode.
 #[repr(C, align(4))]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 pub(crate) struct Adma2Desc64 {
     attr: u16,
     length: u16,
@@ -73,9 +69,8 @@ pub(crate) struct Adma2Desc64 {
     address_high: u32,
 }
 
-// SAFETY: The aligned C-layout descriptor contains only integer fields, so
-// every bit pattern is valid and it owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for Adma2Desc64 {}
+const _: () = assert!(core::mem::size_of::<Adma2Desc32>() == 8);
+const _: () = assert!(core::mem::size_of::<Adma2Desc64>() == 12);
 
 pub(crate) enum Adma2DescriptorTable {
     Addr32(CoherentArray<Adma2Desc32>),

--- a/drivers/net/eth-intel/Cargo.toml
+++ b/drivers/net/eth-intel/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 mmio-api.workspace = true
 rdif-eth.workspace = true
 thiserror = { version = "2", default-features = false }
+zerocopy.workspace = true
 
 [lib]
 test = false

--- a/drivers/net/eth-intel/src/e1000/descriptor.rs
+++ b/drivers/net/eth-intel/src/e1000/descriptor.rs
@@ -1,5 +1,5 @@
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 pub struct TxDesc {
     pub addr: u64,
     pub length: u16,
@@ -9,10 +9,6 @@ pub struct TxDesc {
     pub css: u8,
     pub special: u16,
 }
-
-// SAFETY: The C-layout descriptor contains only integer fields, so every bit
-// pattern is valid and it owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for TxDesc {}
 
 impl TxDesc {
     pub const CMD_EOP: u8 = 1 << 0;
@@ -39,7 +35,7 @@ impl TxDesc {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 pub struct RxDesc {
     pub addr: u64,
     pub length: u16,
@@ -49,9 +45,8 @@ pub struct RxDesc {
     pub special: u16,
 }
 
-// SAFETY: The C-layout descriptor contains only integer fields, so every bit
-// pattern is valid and it owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for RxDesc {}
+const _: () = assert!(core::mem::size_of::<TxDesc>() == 16);
+const _: () = assert!(core::mem::size_of::<RxDesc>() == 16);
 
 impl RxDesc {
     pub const STATUS_DD: u8 = 1 << 0;

--- a/drivers/net/eth-intel/src/e1000/descriptor.rs
+++ b/drivers/net/eth-intel/src/e1000/descriptor.rs
@@ -10,6 +10,10 @@ pub struct TxDesc {
     pub special: u16,
 }
 
+// SAFETY: The C-layout descriptor contains only integer fields, so every bit
+// pattern is valid and it owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for TxDesc {}
+
 impl TxDesc {
     pub const CMD_EOP: u8 = 1 << 0;
     pub const CMD_IFCS: u8 = 1 << 1;
@@ -44,6 +48,10 @@ pub struct RxDesc {
     pub errors: u8,
     pub special: u16,
 }
+
+// SAFETY: The C-layout descriptor contains only integer fields, so every bit
+// pattern is valid and it owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for RxDesc {}
 
 impl RxDesc {
     pub const STATUS_DD: u8 = 1 << 0;

--- a/drivers/net/realtek-rtl8125/Cargo.toml
+++ b/drivers/net/realtek-rtl8125/Cargo.toml
@@ -17,3 +17,4 @@ mmio-api.workspace = true
 rdif-eth.workspace = true
 thiserror = { version = "2", default-features = false }
 tock-registers = "0.10"
+zerocopy.workspace = true

--- a/drivers/net/realtek-rtl8125/src/descriptor.rs
+++ b/drivers/net/realtek-rtl8125/src/descriptor.rs
@@ -11,16 +11,12 @@ const RX_PACKET_LEN_MASK: u32 = 0x3fff;
 const ETH_FCS_LEN: usize = 4;
 
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 pub struct TxDesc {
     pub opts1: u32,
     pub opts2: u32,
     pub addr: u64,
 }
-
-// SAFETY: The C-layout descriptor contains only integer fields, so every bit
-// pattern is valid and it owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for TxDesc {}
 
 impl TxDesc {
     pub fn new_cpu_owned(addr: u64, len: usize, ring_end: bool) -> Self {
@@ -50,16 +46,12 @@ impl TxDesc {
 }
 
 #[repr(C)]
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy, Default, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 pub struct RxDesc {
     pub opts1: u32,
     pub opts2: u32,
     pub addr: u64,
 }
-
-// SAFETY: The C-layout descriptor contains only integer fields, so every bit
-// pattern is valid and it owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for RxDesc {}
 
 impl RxDesc {
     pub fn new_cpu_owned(addr: u64, len: usize, ring_end: bool) -> Self {

--- a/drivers/net/realtek-rtl8125/src/descriptor.rs
+++ b/drivers/net/realtek-rtl8125/src/descriptor.rs
@@ -18,6 +18,10 @@ pub struct TxDesc {
     pub addr: u64,
 }
 
+// SAFETY: The C-layout descriptor contains only integer fields, so every bit
+// pattern is valid and it owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for TxDesc {}
+
 impl TxDesc {
     pub fn new_cpu_owned(addr: u64, len: usize, ring_end: bool) -> Self {
         let mut opts1 = FIRST_FRAG | LAST_FRAG | len as u32;
@@ -52,6 +56,10 @@ pub struct RxDesc {
     pub opts2: u32,
     pub addr: u64,
 }
+
+// SAFETY: The C-layout descriptor contains only integer fields, so every bit
+// pattern is valid and it owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for RxDesc {}
 
 impl RxDesc {
     pub fn new_cpu_owned(addr: u64, len: usize, ring_end: bool) -> Self {

--- a/drivers/npu/rockchip-npu/src/task/op/matmul.rs
+++ b/drivers/npu/rockchip-npu/src/task/op/matmul.rs
@@ -1,4 +1,4 @@
-use dma_api::{ContiguousArray, DeviceDma, DmaDirection};
+use dma_api::{ContiguousArray, DeviceDma, DmaDirection, DmaPod};
 
 use super::super::def::*;
 use crate::{
@@ -7,7 +7,7 @@ use crate::{
     op::{Operation, OperationTrait, Precision},
 };
 
-pub struct MatMul<T: Sized + Copy, O: Sized + Copy> {
+pub struct MatMul<T: DmaPod, O: DmaPod> {
     m: u16,
     k: u16,
     n: u16,
@@ -16,7 +16,7 @@ pub struct MatMul<T: Sized + Copy, O: Sized + Copy> {
     output: ContiguousArray<O>,
 }
 
-impl<T: Sized + Copy, O: Sized + Copy> MatMul<T, O> {
+impl<T: DmaPod, O: DmaPod> MatMul<T, O> {
     pub fn new(dma: &DeviceDma, m: usize, k: usize, n: usize) -> Self {
         Self {
             m: m as _,

--- a/drivers/usb/usb-host/Cargo.toml
+++ b/drivers/usb/usb-host/Cargo.toml
@@ -37,6 +37,7 @@ trait-ffi = "0.2.4"
 usb-if = {workspace = true}
 xhci = "0.9"
 libusb1-sys = {version = "0.7", optional = true}
+zerocopy.workspace = true
 
 [dev-dependencies]
 ax-sync = { workspace = true, features = ["host-test"] }

--- a/drivers/usb/usb-host/src/backend/kmod/ehci/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/ehci/mod.rs
@@ -410,8 +410,11 @@ fn ehci_qh_link(addr: u32) -> u32 {
     (addr & !0x1f) | EHCI_QH_LINK_TYPE_QH
 }
 
-#[derive(Clone, Copy)]
-#[repr(C, align(32))]
+// EHCI requires queue-head and qTD allocation bases to be 32-byte aligned.
+// Keep their wire layouts padding-free and enforce that constraint at the
+// coherent allocation sites instead of adding trailing type padding.
+#[derive(Clone, Copy, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
+#[repr(C)]
 struct QueueHead {
     horizontal_link: u32,
     endpoint_chars: u32,
@@ -419,10 +422,6 @@ struct QueueHead {
     current_qtd: u32,
     overlay: QueueTransferDescriptor,
 }
-
-// SAFETY: The aligned C-layout queue head contains only integers and the
-// integer-only transfer descriptor, so every bit pattern is valid.
-unsafe impl dma_api::DmaPod for QueueHead {}
 
 impl QueueHead {
     fn async_head(addr: u32) -> Self {
@@ -462,8 +461,8 @@ impl QueueHead {
     }
 }
 
-#[derive(Clone, Copy)]
-#[repr(C, align(32))]
+#[derive(Clone, Copy, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
+#[repr(C)]
 struct QueueTransferDescriptor {
     next_qtd: u32,
     alt_next_qtd: u32,
@@ -471,10 +470,6 @@ struct QueueTransferDescriptor {
     buffer: [u32; 5],
     ext_buffer: [u32; 5],
 }
-
-// SAFETY: The aligned C-layout descriptor contains only integers and integer
-// arrays, so every bit pattern is valid and it owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for QueueTransferDescriptor {}
 
 impl QueueTransferDescriptor {
     const fn terminated() -> Self {
@@ -521,6 +516,9 @@ impl QueueTransferDescriptor {
         self.next_qtd = next.map(|addr| addr & !0x1f).unwrap_or(EHCI_LINK_TERMINATE);
     }
 }
+
+const _: () = assert!(core::mem::size_of::<QueueHead>() == 68);
+const _: () = assert!(core::mem::size_of::<QueueTransferDescriptor>() == 52);
 
 #[derive(Clone)]
 struct TransferWakeups {

--- a/drivers/usb/usb-host/src/backend/kmod/ehci/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/ehci/mod.rs
@@ -420,6 +420,10 @@ struct QueueHead {
     overlay: QueueTransferDescriptor,
 }
 
+// SAFETY: The aligned C-layout queue head contains only integers and the
+// integer-only transfer descriptor, so every bit pattern is valid.
+unsafe impl dma_api::DmaPod for QueueHead {}
+
 impl QueueHead {
     fn async_head(addr: u32) -> Self {
         Self {
@@ -467,6 +471,10 @@ struct QueueTransferDescriptor {
     buffer: [u32; 5],
     ext_buffer: [u32; 5],
 }
+
+// SAFETY: The aligned C-layout descriptor contains only integers and integer
+// arrays, so every bit pattern is valid and it owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for QueueTransferDescriptor {}
 
 impl QueueTransferDescriptor {
     const fn terminated() -> Self {

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/context.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/context.rs
@@ -10,33 +10,46 @@ use crate::{err::*, osal::Kernel};
 #[derive(Clone, Copy)]
 struct DeviceContext32Dma(Device32Byte);
 
-// SAFETY: xhci 0.9.2 defines `Device<8>` as a C-layout aggregate of
-// transparent `u32` arrays, so every bit pattern is valid.
+// SAFETY: xhci 0.9.2 defines `Device<8>` as a padding-free C-layout aggregate
+// of transparent `u32` arrays. It accepts every bit pattern and contains no
+// pointers, interior mutability, or owned resources.
 unsafe impl dma_api::DmaPod for DeviceContext32Dma {}
 
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 struct DeviceContext64Dma(Device64Byte);
 
-// SAFETY: xhci 0.9.2 defines `Device<16>` as a C-layout aggregate of
-// transparent `u32` arrays, so every bit pattern is valid.
+// SAFETY: xhci 0.9.2 defines `Device<16>` as a padding-free C-layout aggregate
+// of transparent `u32` arrays. It accepts every bit pattern and contains no
+// pointers, interior mutability, or owned resources.
 unsafe impl dma_api::DmaPod for DeviceContext64Dma {}
 
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 struct InputContext32Dma(Input32Byte);
 
-// SAFETY: xhci 0.9.2 defines `Input<8>` as a C-layout aggregate of
-// transparent `u32` arrays, so every bit pattern is valid.
+// SAFETY: xhci 0.9.2 defines `Input<8>` as a padding-free C-layout aggregate of
+// transparent `u32` arrays. It accepts every bit pattern and contains no
+// pointers, interior mutability, or owned resources.
 unsafe impl dma_api::DmaPod for InputContext32Dma {}
 
 #[repr(transparent)]
 #[derive(Clone, Copy)]
 struct InputContext64Dma(Input64Byte);
 
-// SAFETY: xhci 0.9.2 defines `Input<16>` as a C-layout aggregate of
-// transparent `u32` arrays, so every bit pattern is valid.
+// SAFETY: xhci 0.9.2 defines `Input<16>` as a padding-free C-layout aggregate
+// of transparent `u32` arrays. It accepts every bit pattern and contains no
+// pointers, interior mutability, or owned resources.
 unsafe impl dma_api::DmaPod for InputContext64Dma {}
+
+const _: () = assert!(core::mem::size_of::<DeviceContext32Dma>() == 1024);
+const _: () = assert!(core::mem::size_of::<DeviceContext64Dma>() == 2048);
+const _: () = assert!(core::mem::size_of::<InputContext32Dma>() == 1056);
+const _: () = assert!(core::mem::size_of::<InputContext64Dma>() == 2112);
+const _: () = assert!(core::mem::align_of::<DeviceContext32Dma>() == 4);
+const _: () = assert!(core::mem::align_of::<DeviceContext64Dma>() == 4);
+const _: () = assert!(core::mem::align_of::<InputContext32Dma>() == 4);
+const _: () = assert!(core::mem::align_of::<InputContext64Dma>() == 4);
 
 pub struct DeviceContextList {
     pub dcbaa: CoherentArray<u64>,

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/context.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/context.rs
@@ -6,6 +6,38 @@ use xhci::context::{Device32Byte, Device64Byte, Input32Byte, Input64Byte, InputH
 use super::SlotId;
 use crate::{err::*, osal::Kernel};
 
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct DeviceContext32Dma(Device32Byte);
+
+// SAFETY: xhci 0.9.2 defines `Device<8>` as a C-layout aggregate of
+// transparent `u32` arrays, so every bit pattern is valid.
+unsafe impl dma_api::DmaPod for DeviceContext32Dma {}
+
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct DeviceContext64Dma(Device64Byte);
+
+// SAFETY: xhci 0.9.2 defines `Device<16>` as a C-layout aggregate of
+// transparent `u32` arrays, so every bit pattern is valid.
+unsafe impl dma_api::DmaPod for DeviceContext64Dma {}
+
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct InputContext32Dma(Input32Byte);
+
+// SAFETY: xhci 0.9.2 defines `Input<8>` as a C-layout aggregate of
+// transparent `u32` arrays, so every bit pattern is valid.
+unsafe impl dma_api::DmaPod for InputContext32Dma {}
+
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+struct InputContext64Dma(Input64Byte);
+
+// SAFETY: xhci 0.9.2 defines `Input<16>` as a C-layout aggregate of
+// transparent `u32` arrays, so every bit pattern is valid.
+unsafe impl dma_api::DmaPod for InputContext64Dma {}
+
 pub struct DeviceContextList {
     pub dcbaa: CoherentArray<u64>,
     max_slots: usize,
@@ -15,13 +47,13 @@ unsafe impl Send for DeviceContextList {}
 unsafe impl Sync for DeviceContextList {}
 
 pub(crate) struct Context32 {
-    out: CoherentBox<Device32Byte>,
-    input: CoherentBox<Input32Byte>,
+    out: CoherentBox<DeviceContext32Dma>,
+    input: CoherentBox<InputContext32Dma>,
 }
 
 pub(crate) struct Context64 {
-    out: CoherentBox<Device64Byte>,
-    input: CoherentBox<Input64Byte>,
+    out: CoherentBox<DeviceContext64Dma>,
+    input: CoherentBox<InputContext64Dma>,
 }
 pub(crate) enum ContextData {
     Context32(Context32),
@@ -51,12 +83,12 @@ impl ContextData {
             ContextData::Context32(ctx) => {
                 let mut input = Input32Byte::new_32byte();
                 f(&mut input);
-                ctx.input.write_cpu(input);
+                ctx.input.write_cpu(InputContext32Dma(input));
             }
             ContextData::Context64(ctx) => {
                 let mut input = Input64Byte::new_64byte();
                 f(&mut input);
-                ctx.input.write_cpu(input);
+                ctx.input.write_cpu(InputContext64Dma(input));
             }
         }
     }
@@ -67,14 +99,14 @@ impl ContextData {
     {
         match self {
             ContextData::Context32(ctx) => {
-                let mut input = ctx.input.read_cpu();
+                let mut input = ctx.input.read_cpu().0;
                 f(&mut input);
-                ctx.input.write_cpu(input);
+                ctx.input.write_cpu(InputContext32Dma(input));
             }
             ContextData::Context64(ctx) => {
-                let mut input = ctx.input.read_cpu();
+                let mut input = ctx.input.read_cpu().0;
                 f(&mut input);
-                ctx.input.write_cpu(input);
+                ctx.input.write_cpu(InputContext64Dma(input));
             }
         }
     }

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/event.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/event.rs
@@ -8,16 +8,14 @@ use super::ring::{Ring, TRBS_PER_SEGMENT};
 use crate::{err::*, osal::Kernel};
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 pub struct EventRingSte {
     pub addr: u64,
     pub size: u16,
     _reserved: [u8; 6],
 }
 
-// SAFETY: The C-layout event ring entry contains only integers and bytes, so
-// every bit pattern is valid and it owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for EventRingSte {}
+const _: () = assert!(core::mem::size_of::<EventRingSte>() == 16);
 
 pub struct EventRing {
     segments: Vec<Ring>,

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/event.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/event.rs
@@ -15,6 +15,10 @@ pub struct EventRingSte {
     _reserved: [u8; 6],
 }
 
+// SAFETY: The C-layout event ring entry contains only integers and bytes, so
+// every bit pattern is valid and it owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for EventRingSte {}
+
 pub struct EventRing {
     segments: Vec<Ring>,
     segment_index: usize,

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/ring.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/ring.rs
@@ -16,13 +16,11 @@ pub(crate) const TRB_SIZE: usize = size_of::<TrbData>();
 pub(crate) const TRBS_PER_SEGMENT: usize = 256;
 const DEFAULT_RING_PAGES: usize = 2;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 #[repr(transparent)]
 pub struct TrbData([u32; TRB_LEN]);
 
-// SAFETY: The transparent wrapper contains only a `u32` array, accepts every
-// bit pattern, and owns no CPU-side resources.
-unsafe impl dma_api::DmaPod for TrbData {}
+const _: () = assert!(core::mem::size_of::<TrbData>() == 16);
 
 impl TrbData {
     pub fn to_raw(self) -> [u32; TRB_LEN] {

--- a/drivers/usb/usb-host/src/backend/kmod/xhci/ring.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/xhci/ring.rs
@@ -20,6 +20,10 @@ const DEFAULT_RING_PAGES: usize = 2;
 #[repr(transparent)]
 pub struct TrbData([u32; TRB_LEN]);
 
+// SAFETY: The transparent wrapper contains only a `u32` array, accepts every
+// bit pattern, and owns no CPU-side resources.
+unsafe impl dma_api::DmaPod for TrbData {}
+
 impl TrbData {
     pub fn to_raw(self) -> [u32; TRB_LEN] {
         self.0

--- a/memory/dma-api/CHANGELOG.md
+++ b/memory/dma-api/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Made allocation and mapping handles move-only, required explicit `DmaPod`
-  implementations for typed DMA data, and rejected zero-sized requests before
-  invoking DMA backends.
+- Made allocation and mapping handles move-only, required
+  representation-checked `DmaPod` types for typed DMA data, and rejected
+  zero-sized requests before invoking DMA backends.
 
 ## [0.9.5](https://github.com/rcore-os/tgoskits/compare/dma-api-v0.9.4...dma-api-v0.9.5) - 2026-08-09
 

--- a/memory/dma-api/CHANGELOG.md
+++ b/memory/dma-api/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Made allocation and mapping handles move-only, required explicit `DmaPod`
+  implementations for typed DMA data, and rejected zero-sized requests before
+  invoking DMA backends.
+
 ## [0.9.5](https://github.com/rcore-os/tgoskits/compare/dma-api-v0.9.4...dma-api-v0.9.5) - 2026-08-09
 
 ### Other

--- a/memory/dma-api/Cargo.toml
+++ b/memory/dma-api/Cargo.toml
@@ -20,6 +20,7 @@ derive_more.workspace = true
 log.workspace = true
 mbarrier = "0.1"
 thiserror.workspace = true
+zerocopy.workspace = true
 
 [dev-dependencies]
 ax-sync = { workspace = true, features = ["host-test"] }

--- a/memory/dma-api/README.md
+++ b/memory/dma-api/README.md
@@ -31,12 +31,14 @@ handles are split into `DmaAllocHandle` for owned allocations and
 their matching release operation consumes them, so safe code cannot release
 the same allocation or mapping twice.
 
-Typed DMA storage requires an explicit `DmaPod` implementation. Primitive
-integer and floating-point types, plus arrays of `DmaPod` elements, are
-provided by `dma-api`. Driver descriptor and wire-format structs must use a
-stable layout and provide their own safety justification. Types with invalid
-bit patterns, references, pointers, or owned resources must not implement
-`DmaPod`.
+Typed DMA storage requires `DmaPod`. Integer and floating-point scalars, plus
+arrays of valid elements, satisfy the contract automatically. Local driver
+descriptor and wire-format structs must use a stable layout and derive
+`zerocopy::FromBytes`, `zerocopy::IntoBytes`, and `zerocopy::Immutable`; this
+rejects invalid bit patterns, implicit padding, and interior mutability at
+compile time. Manual `DmaPod` implementations are reserved for audited foreign
+types that cannot derive these traits. References, pointers, padding, and owned
+resources are not permitted.
 
 All allocation and mapping entry points reject zero-sized buffers before
 calling the platform backend.

--- a/memory/dma-api/README.md
+++ b/memory/dma-api/README.md
@@ -27,7 +27,19 @@ and when it has completed.
 
 `DmaAddr` is the only portable device-visible address type. Backend-private raw
 handles are split into `DmaAllocHandle` for owned allocations and
-`DmaMapHandle` for streaming mappings.
+`DmaMapHandle` for streaming mappings. Both handles are move-only tokens:
+their matching release operation consumes them, so safe code cannot release
+the same allocation or mapping twice.
+
+Typed DMA storage requires an explicit `DmaPod` implementation. Primitive
+integer and floating-point types, plus arrays of `DmaPod` elements, are
+provided by `dma-api`. Driver descriptor and wire-format structs must use a
+stable layout and provide their own safety justification. Types with invalid
+bit patterns, references, pointers, or owned resources must not implement
+`DmaPod`.
+
+All allocation and mapping entry points reject zero-sized buffers before
+calling the platform backend.
 
 ## Constraints
 

--- a/memory/dma-api/src/axtest.rs
+++ b/memory/dma-api/src/axtest.rs
@@ -214,6 +214,10 @@ struct Descriptor {
     flags: u32,
 }
 
+// SAFETY: `Descriptor` has a stable C layout, every field accepts all bit
+// patterns, and it contains no references or owned resources.
+unsafe impl crate::DmaPod for Descriptor {}
+
 #[axtest]
 fn dma_api_device_metadata_constraints_and_nop_cache_ops_are_callable() {
     let (dev, op) = tracking_device();

--- a/memory/dma-api/src/axtest.rs
+++ b/memory/dma-api/src/axtest.rs
@@ -206,17 +206,23 @@ fn tracking_device() -> (DeviceDma, &'static TrackingDmaOp) {
     (DeviceDma::new_legacy(u64::MAX, op), op)
 }
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    PartialEq,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+)]
 #[repr(C)]
 struct Descriptor {
     addr: u64,
     len: u32,
     flags: u32,
 }
-
-// SAFETY: `Descriptor` has a stable C layout, every field accepts all bit
-// patterns, and it contains no references or owned resources.
-unsafe impl crate::DmaPod for Descriptor {}
 
 #[axtest]
 fn dma_api_device_metadata_constraints_and_nop_cache_ops_are_callable() {

--- a/memory/dma-api/src/common.rs
+++ b/memory/dma-api/src/common.rs
@@ -76,9 +76,6 @@ impl DmaAllocation {
         let Some(handle) = self.handle.take() else {
             return Ok(());
         };
-        if handle.size() == 0 {
-            return Ok(());
-        }
 
         unsafe {
             match self.kind {

--- a/memory/dma-api/src/def.rs
+++ b/memory/dma-api/src/def.rs
@@ -150,16 +150,61 @@ pub enum DmaError {
 
 /// Marker for plain data that can be safely stored in typed DMA buffers.
 ///
+/// Types with restricted bit patterns, such as `bool`, must not implement this
+/// trait because a device can write bytes that do not represent a valid value.
+///
+/// ```compile_fail
+/// use dma_api::DmaPod;
+///
+/// fn require_dma_pod<T: DmaPod>() {}
+/// require_dma_pod::<bool>();
+/// ```
+///
 /// # Safety
 ///
-/// Implementors must be `Copy`, have no invalid all-zero bit pattern, and must
-/// not own resources or references whose validity can be broken by raw device
-/// writes.
+/// Implementors must be `Copy`, permit every possible bit pattern, and contain
+/// no references, pointers, or owned resources whose validity can be broken by
+/// raw device writes. Padding bytes are allowed, but drivers must not rely on
+/// their contents.
 pub unsafe trait DmaPod: Copy {}
 
-unsafe impl<T: Copy> DmaPod for T {}
+macro_rules! impl_dma_pod_for_scalars {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            // SAFETY: Integer and floating-point scalars accept every bit pattern and
+            // contain no references or owned resources.
+            unsafe impl DmaPod for $ty {}
+        )+
+    };
+}
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+impl_dma_pod_for_scalars!(
+    u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64,
+);
+
+// SAFETY: An array has the same validity requirements as its elements and
+// contains no additional references or owned resources.
+unsafe impl<T: DmaPod, const N: usize> DmaPod for [T; N] {}
+
+/// Backend-owned token for one DMA allocation.
+///
+/// The token is consumed by the matching deallocation operation and therefore
+/// cannot be copied.
+///
+/// ```compile_fail
+/// use dma_api::DmaAllocHandle;
+///
+/// fn require_copy<T: Copy>() {}
+/// require_copy::<DmaAllocHandle>();
+/// ```
+///
+/// ```compile_fail
+/// use dma_api::DmaAllocHandle;
+///
+/// fn require_clone<T: Clone>() {}
+/// require_clone::<DmaAllocHandle>();
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct DmaAllocHandle {
     pub(crate) cpu_addr: NonNull<u8>,
     pub(crate) dma_addr: DmaAddr,
@@ -200,7 +245,25 @@ impl DmaAllocHandle {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Backend-owned token for one streaming DMA mapping.
+///
+/// The token is consumed by the matching unmap operation and therefore cannot
+/// be copied.
+///
+/// ```compile_fail
+/// use dma_api::DmaMapHandle;
+///
+/// fn require_copy<T: Copy>() {}
+/// require_copy::<DmaMapHandle>();
+/// ```
+///
+/// ```compile_fail
+/// use dma_api::DmaMapHandle;
+///
+/// fn require_clone<T: Clone>() {}
+/// require_clone::<DmaMapHandle>();
+/// ```
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct DmaMapHandle {
     pub(crate) cpu_addr: NonNull<u8>,
     pub(crate) dma_addr: DmaAddr,

--- a/memory/dma-api/src/def.rs
+++ b/memory/dma-api/src/def.rs
@@ -160,31 +160,49 @@ pub enum DmaError {
 /// require_dma_pod::<bool>();
 /// ```
 ///
+/// Raw pointers are also excluded from typed DMA storage.
+///
+/// ```compile_fail
+/// use dma_api::DmaPod;
+///
+/// fn require_dma_pod<T: DmaPod>() {}
+/// require_dma_pod::<*const u8>();
+/// ```
+///
+/// Representation derives reject implicit padding at compile time.
+///
+/// ```compile_fail
+/// use zerocopy::{FromBytes, Immutable, IntoBytes};
+///
+/// #[repr(C)]
+/// #[derive(Clone, Copy, FromBytes, Immutable, IntoBytes)]
+/// struct Padded {
+///     tag: u8,
+///     value: u32,
+/// }
+/// ```
+///
 /// # Safety
 ///
-/// Implementors must be `Copy`, permit every possible bit pattern, and contain
-/// no references, pointers, or owned resources whose validity can be broken by
-/// raw device writes. Padding bytes are allowed, but drivers must not rely on
-/// their contents.
+/// Implementors must be `Copy`, permit every possible bit pattern, expose no
+/// uninitialized or padding bytes to the device, and contain no references,
+/// pointers, interior mutability, or owned resources whose validity can be
+/// broken by raw device writes.
+///
+/// Local wire-format types should derive [`zerocopy::FromBytes`],
+/// [`zerocopy::IntoBytes`], and [`zerocopy::Immutable`] instead of implementing
+/// this trait manually. Manual implementations are reserved for audited foreign
+/// types that cannot derive those traits.
 pub unsafe trait DmaPod: Copy {}
 
-macro_rules! impl_dma_pod_for_scalars {
-    ($($ty:ty),+ $(,)?) => {
-        $(
-            // SAFETY: Integer and floating-point scalars accept every bit pattern and
-            // contain no references or owned resources.
-            unsafe impl DmaPod for $ty {}
-        )+
-    };
+// SAFETY: `FromBytes` accepts every initialized bit pattern, `IntoBytes`
+// guarantees that the full representation contains initialized bytes without
+// padding, and `Immutable` excludes interior mutability. Together with `Copy`,
+// these bounds satisfy the `DmaPod` contract.
+unsafe impl<T> DmaPod for T where
+    T: Copy + zerocopy::FromBytes + zerocopy::IntoBytes + zerocopy::Immutable
+{
 }
-
-impl_dma_pod_for_scalars!(
-    u8, u16, u32, u64, u128, usize, i8, i16, i32, i64, i128, isize, f32, f64,
-);
-
-// SAFETY: An array has the same validity requirements as its elements and
-// contains no additional references or owned resources.
-unsafe impl<T: DmaPod, const N: usize> DmaPod for [T; N] {}
 
 /// Backend-owned token for one DMA allocation.
 ///

--- a/memory/dma-api/src/lib.rs
+++ b/memory/dma-api/src/lib.rs
@@ -87,6 +87,9 @@ impl DeviceDma {
         &self,
         layout: core::alloc::Layout,
     ) -> Result<DmaAllocHandle, DmaError> {
+        if layout.size() == 0 {
+            return Err(DmaError::ZeroSizedBuffer);
+        }
         let constraints = self.constraints.with_align(layout.align());
         let res =
             unsafe { self.op.alloc_contiguous(constraints, layout) }.ok_or(DmaError::NoMemory)?;
@@ -107,6 +110,9 @@ impl DeviceDma {
         &self,
         layout: core::alloc::Layout,
     ) -> Result<DmaAllocHandle, DmaError> {
+        if layout.size() == 0 {
+            return Err(DmaError::ZeroSizedBuffer);
+        }
         let constraints = self.constraints.with_align(layout.align());
         let res =
             unsafe { self.op.alloc_coherent(constraints, layout) }.ok_or(DmaError::NoMemory)?;

--- a/memory/dma-api/src/op/mod.rs
+++ b/memory/dma-api/src/op/mod.rs
@@ -19,6 +19,8 @@ pub trait DmaOp: Sync + Send + 'static {
 
     /// Allocates a device-visible contiguous DMA address range.
     ///
+    /// `dma-api` rejects zero-sized layouts before calling this method.
+    ///
     /// The returned CPU mapping is normal memory. Non-coherent platforms must
     /// use `sync_alloc_for_device` and `sync_alloc_for_cpu` to transfer
     /// ownership between CPU and device.
@@ -40,6 +42,8 @@ pub trait DmaOp: Sync + Send + 'static {
     unsafe fn dealloc_contiguous(&self, handle: DmaAllocHandle);
 
     /// Allocates coherent DMA memory.
+    ///
+    /// `dma-api` rejects zero-sized layouts before calling this method.
     ///
     /// Coherent memory is CPU/device visible without explicit cache
     /// maintenance. Ordering barriers are still the driver's responsibility.
@@ -78,7 +82,8 @@ pub trait DmaOp: Sync + Send + 'static {
 
     /// # Safety
     ///
-    /// Must be paired with `map_streaming`.
+    /// Must be paired with `map_streaming`. The handle is consumed by this
+    /// operation and must not be reused.
     unsafe fn unmap_streaming(&self, handle: DmaMapHandle);
 
     fn flush(&self, addr: NonNull<u8>, size: usize) {

--- a/memory/dma-api/src/streaming.rs
+++ b/memory/dma-api/src/streaming.rs
@@ -4,7 +4,7 @@ use core::{marker::PhantomData, num::NonZeroUsize, ptr::NonNull};
 use crate::{DeviceDma, DmaDirection, DmaError, DmaMapHandle, DmaPod};
 
 pub struct StreamingMap<T: DmaPod> {
-    handle: DmaMapHandle,
+    handle: Option<DmaMapHandle>,
     device: DeviceDma,
     direction: DmaDirection,
     _marker: PhantomData<*mut T>,
@@ -25,7 +25,7 @@ impl<T: DmaPod> StreamingMap<T> {
         let handle = unsafe { os.map_streaming(addr, size, align, direction)? };
 
         Ok(Self {
-            handle,
+            handle: Some(handle),
             device: os.clone(),
             direction,
             _marker: PhantomData,
@@ -33,14 +33,14 @@ impl<T: DmaPod> StreamingMap<T> {
     }
 
     pub fn dma_addr(&self) -> crate::DmaAddr {
-        self.handle.dma_addr()
+        self.handle().dma_addr()
     }
 
     pub fn len(&self) -> usize {
         if core::mem::size_of::<T>() == 0 {
             0
         } else {
-            self.handle.size() / core::mem::size_of::<T>()
+            self.handle().size() / core::mem::size_of::<T>()
         }
     }
 
@@ -49,14 +49,14 @@ impl<T: DmaPod> StreamingMap<T> {
     }
 
     pub fn bytes_len(&self) -> usize {
-        self.handle.size()
+        self.handle().size()
     }
 
     pub fn read_cpu(&self, index: usize) -> Option<T> {
         if index >= self.len() {
             return None;
         }
-        Some(unsafe { self.handle.as_ptr().cast::<T>().add(index).read() })
+        Some(unsafe { self.handle().as_ptr().cast::<T>().add(index).read() })
     }
 
     pub fn set_cpu(&mut self, index: usize, value: T) {
@@ -67,17 +67,17 @@ impl<T: DmaPod> StreamingMap<T> {
             self.len()
         );
         unsafe {
-            self.handle.as_ptr().cast::<T>().add(index).write(value);
+            self.handle().as_ptr().cast::<T>().add(index).write(value);
         }
     }
 
     pub fn copy_from_slice_cpu(&mut self, src: &[T]) {
         assert!(
-            core::mem::size_of_val(src) <= self.handle.size(),
+            core::mem::size_of_val(src) <= self.handle().size(),
             "source slice is larger than DMA buffer"
         );
         unsafe {
-            self.handle
+            self.handle()
                 .as_ptr()
                 .cast::<T>()
                 .as_ptr()
@@ -88,22 +88,23 @@ impl<T: DmaPod> StreamingMap<T> {
     pub fn write_with_cpu<R>(&mut self, len: usize, f: impl FnOnce(&mut [T]) -> R) -> R {
         assert!(len <= self.len(), "range out of bounds");
         let data = unsafe {
-            core::slice::from_raw_parts_mut(self.handle.as_ptr().cast::<T>().as_ptr(), len)
+            core::slice::from_raw_parts_mut(self.handle().as_ptr().cast::<T>().as_ptr(), len)
         };
         f(data)
     }
 
     pub fn read_with_cpu<R>(&self, len: usize, f: impl FnOnce(&[T]) -> R) -> R {
         assert!(len <= self.len(), "range out of bounds");
-        let data =
-            unsafe { core::slice::from_raw_parts(self.handle.as_ptr().cast::<T>().as_ptr(), len) };
+        let data = unsafe {
+            core::slice::from_raw_parts(self.handle().as_ptr().cast::<T>().as_ptr(), len)
+        };
         f(data)
     }
 
     pub fn to_vec_cpu(&self) -> Vec<T> {
         let mut vec: Vec<T> = Vec::with_capacity(self.len());
         unsafe {
-            let src_ptr = self.handle.as_ptr().as_ptr().cast::<T>();
+            let src_ptr = self.handle().as_ptr().as_ptr().cast::<T>();
             let dst_ptr = vec.as_mut_ptr();
             dst_ptr.copy_from_nonoverlapping(src_ptr, self.len());
             vec.set_len(self.len());
@@ -114,23 +115,23 @@ impl<T: DmaPod> StreamingMap<T> {
     pub fn sync_for_device(&self, offset: usize, size: usize) {
         self.check_range(offset, size);
         self.device
-            .sync_map_for_device(&self.handle, offset, size, self.direction);
+            .sync_map_for_device(self.handle(), offset, size, self.direction);
     }
 
     pub fn sync_for_cpu(&self, offset: usize, size: usize) {
         self.check_range(offset, size);
         self.device
-            .sync_map_for_cpu(&self.handle, offset, size, self.direction);
+            .sync_map_for_cpu(self.handle(), offset, size, self.direction);
     }
 
     pub fn sync_for_device_all(&self) {
         self.device
-            .sync_map_for_device(&self.handle, 0, self.handle.size(), self.direction);
+            .sync_map_for_device(self.handle(), 0, self.handle().size(), self.direction);
     }
 
     pub fn sync_for_cpu_all(&self) {
         self.device
-            .sync_map_for_cpu(&self.handle, 0, self.handle.size(), self.direction);
+            .sync_map_for_cpu(self.handle(), 0, self.handle().size(), self.direction);
     }
 
     pub fn prepare_for_device(&self, offset: usize, size: usize) {
@@ -161,7 +162,13 @@ impl<T: DmaPod> StreamingMap<T> {
     }
 
     pub fn bounce_ptr(&self) -> Option<NonNull<u8>> {
-        self.handle.bounce_ptr()
+        self.handle().bounce_ptr()
+    }
+
+    fn handle(&self) -> &DmaMapHandle {
+        self.handle
+            .as_ref()
+            .expect("live streaming mapping must retain its handle")
     }
 
     fn check_range(&self, offset: usize, size: usize) {
@@ -279,8 +286,10 @@ pub(crate) fn streaming_dma_direction_all_variants_hold_for_test() -> bool {
 
 impl<T: DmaPod> Drop for StreamingMap<T> {
     fn drop(&mut self) {
-        unsafe {
-            self.device.unmap_streaming(self.handle);
+        if let Some(handle) = self.handle.take() {
+            unsafe {
+                self.device.unmap_streaming(handle);
+            }
         }
     }
 }

--- a/memory/dma-api/tests/test.rs
+++ b/memory/dma-api/tests/test.rs
@@ -5,7 +5,17 @@ mod test_helpers;
 use dma_api::*;
 use test_helpers::{DmaOperation, TrackingDmaOp};
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    zerocopy::FromBytes,
+    zerocopy::Immutable,
+    zerocopy::IntoBytes,
+)]
 #[repr(C)]
 struct Descriptor {
     addr: u64,
@@ -13,15 +23,8 @@ struct Descriptor {
     flags: u32,
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, zerocopy::FromBytes, zerocopy::Immutable, zerocopy::IntoBytes)]
 struct ZeroSizedDmaPod;
-
-// SAFETY: The type has no bytes, invalid bit patterns, references, or owned resources.
-unsafe impl DmaPod for ZeroSizedDmaPod {}
-
-// SAFETY: `Descriptor` has a stable C layout, every field accepts all bit
-// patterns, and it contains no references or owned resources.
-unsafe impl DmaPod for Descriptor {}
 
 fn new_tracking_device() -> (DeviceDma, &'static TrackingDmaOp) {
     let tracker = Box::new(TrackingDmaOp::new());

--- a/memory/dma-api/tests/test.rs
+++ b/memory/dma-api/tests/test.rs
@@ -13,6 +13,16 @@ struct Descriptor {
     flags: u32,
 }
 
+#[derive(Clone, Copy)]
+struct ZeroSizedDmaPod;
+
+// SAFETY: The type has no bytes, invalid bit patterns, references, or owned resources.
+unsafe impl DmaPod for ZeroSizedDmaPod {}
+
+// SAFETY: `Descriptor` has a stable C layout, every field accepts all bit
+// patterns, and it contains no references or owned resources.
+unsafe impl DmaPod for Descriptor {}
+
 fn new_tracking_device() -> (DeviceDma, &'static TrackingDmaOp) {
     let tracker = Box::new(TrackingDmaOp::new());
     let tracker = Box::leak(tracker);
@@ -109,6 +119,14 @@ fn streaming_map_has_explicit_device_and_cpu_sync() {
             .operations()
             .iter()
             .any(|op| matches!(op, DmaOperation::UnmapStreaming { size: 128 }))
+    );
+    assert_eq!(
+        tracker
+            .operations()
+            .iter()
+            .filter(|op| matches!(op, DmaOperation::UnmapStreaming { .. }))
+            .count(),
+        1
     );
 }
 
@@ -299,6 +317,57 @@ fn allocation_rejects_backend_address_outside_mask() {
 }
 
 #[test]
+fn coherent_array_rejects_zero_length_before_backend() {
+    let (dev, tracker) = new_tracking_device();
+
+    let result = dev.coherent_array_zero::<u8>(0);
+
+    assert!(matches!(result, Err(DmaError::ZeroSizedBuffer)));
+    assert!(tracker.operations().is_empty());
+}
+
+#[test]
+fn contiguous_array_rejects_zero_length_before_backend() {
+    let (dev, tracker) = new_tracking_device();
+
+    let result = dev.contiguous_array_zero::<u8>(0, DmaDirection::ToDevice);
+
+    assert!(matches!(result, Err(DmaError::ZeroSizedBuffer)));
+    assert!(tracker.operations().is_empty());
+}
+
+#[test]
+fn coherent_box_rejects_zero_sized_type_before_backend() {
+    let (dev, tracker) = new_tracking_device();
+
+    let result = dev.coherent_box_zero::<ZeroSizedDmaPod>();
+
+    assert!(matches!(result, Err(DmaError::ZeroSizedBuffer)));
+    assert!(tracker.operations().is_empty());
+}
+
+#[test]
+fn contiguous_box_rejects_zero_sized_type_before_backend() {
+    let (dev, tracker) = new_tracking_device();
+
+    let result = dev.contiguous_box_zero::<ZeroSizedDmaPod>(DmaDirection::FromDevice);
+
+    assert!(matches!(result, Err(DmaError::ZeroSizedBuffer)));
+    assert!(tracker.operations().is_empty());
+}
+
+#[test]
+fn streaming_map_rejects_zero_length_before_backend() {
+    let (dev, tracker) = new_tracking_device();
+    let mut backing = [0u8; 0];
+
+    let result = dev.map_streaming_slice(&mut backing, 1, DmaDirection::Bidirectional);
+
+    assert!(matches!(result, Err(DmaError::ZeroSizedBuffer)));
+    assert!(tracker.operations().is_empty());
+}
+
+#[test]
 fn coherent_try_release_reports_failure_without_retrying() {
     let (dev, tracker) = new_tracking_device();
     let buffer = dev.coherent_array_zero::<u8>(64).unwrap();
@@ -332,6 +401,26 @@ fn coherent_drop_failure_attempts_release_only_once() {
             .operations()
             .iter()
             .filter(|op| matches!(op, DmaOperation::DeallocCoherent { .. }))
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn contiguous_drop_releases_allocation_only_once() {
+    let (dev, tracker) = new_tracking_device();
+    let buffer = dev
+        .contiguous_array_zero::<u8>(64, DmaDirection::ToDevice)
+        .unwrap();
+    tracker.clear();
+
+    drop(buffer);
+
+    assert_eq!(
+        tracker
+            .operations()
+            .iter()
+            .filter(|op| matches!(op, DmaOperation::DeallocContiguous { .. }))
             .count(),
         1
     );

--- a/memory/dma-api/tests/test_helpers.rs
+++ b/memory/dma-api/tests/test_helpers.rs
@@ -158,6 +158,9 @@ impl TrackingDmaOp {
         constraints: DmaConstraints,
         layout: core::alloc::Layout,
     ) -> Option<DmaAllocHandle> {
+        if layout.size() == 0 {
+            return None;
+        }
         let ptr = unsafe { alloc_zeroed(layout) };
         let cpu_addr = NonNull::new(ptr)?;
         let dma_addr = self.alloc_dma_addr(layout, constraints);


### PR DESCRIPTION
## 基线与结论

以下问题、修改和收益均以当前 PR 的 base 分支 `dev` 为基线，不与 PR 的任何中间提交比较。

这个 PR 不是普通代码清理，也不以性能提升为目标。它修复 `dev` 中 `dma-api` typed buffer 的 safe API soundness 缺口，并把 DMA 分配、映射和释放建立在可由类型系统检查的统一契约上。

其中 `DmaPod` 问题必须修复；否则 safe Rust 调用可以构造无效 Rust 值并触发未定义行为。move-only token 和 coherent/contiguous 零长度拒绝属于同一资源生命周期契约的相邻缺口，一并收敛可以避免只修数据表示、仍保留重复释放凭据和 backend 模糊输入的半完成状态。

## `dev` 中的具体问题

### 1. `T: Copy` 不能证明类型可以安全承受 DMA 原始字节

`dev` 中存在：

```rust
unsafe impl<T: Copy> DmaPod for T {}
```

但 `Copy` 只表示值可以按位复制，不表示所有 bit pattern 都合法，也不表示类型没有 padding、指针或 interior mutability。例如 `dev` 允许：

```rust
let buffer = device.coherent_box_zero::<core::num::NonZeroU32>()?;
let value = buffer.read_cpu();
```

`coherent_box_zero` 会把底层存储清零，而 safe 的 `read_cpu()` 随后会把这些字节读成值为 0 的 `NonZeroU32`。这违反该类型的不变量并产生无效 Rust 值；不需要真实设备参与即可到达该路径。

同样，设备可以向 `CoherentBox<bool>` 写入 `0x02`，之后 safe 的 `read_cpu()` 会构造非法 `bool`。带隐式 padding 的结构体还可能在 CPU 写给设备时暴露未初始化 padding。

因此，不修改意味着继续保留“满足公开 trait bound 的 safe 调用可能产生未定义行为”的接口，这不是可接受的长期状态。

### 2. allocation/map handle 可以复制，释放凭据不唯一

`dev` 中的 `DmaAllocHandle` 和 `DmaMapHandle` 实现了 `Copy + Clone`。同一 backend allocation 或 mapping 可以产生多个完全相同的释放凭据，`dealloc`/`unmap` 虽然按值接收 handle，但类型系统无法证明它只会被消费一次。

`dev` 中现有 allocation 容器大多通过 `Option::take()` 避免重复释放，因此这不是已确认的线上 double-free；问题在于公共 backend 契约允许适配器或后续代码轻易复制 token，并把 double-free、重复 unmap 或 use-after-free 留给人工 unsafe 审核。

### 3. coherent/contiguous 零长度请求会进入 backend

`dev` 已经在 streaming mapping 入口拒绝零长度，但 coherent 和 contiguous 入口仍会把 size 为 0 的 `Layout` 传给平台 backend。不同 allocator 对零长度的处理并不一致，而且 `dev` 中的 `DmaAllocation::try_release()` 会跳过 size 为 0 的 handle，backend 如果为其建立了内部记录就可能无法获得匹配释放。

公共入口应提供一致的非零前置条件，而不是要求每个平台分别猜测零长度语义。

## 相对于 `dev` 的修改

- 将 `DmaPod for T: Copy` 替换为只对 `Copy + FromBytes + IntoBytes + Immutable` 自动实现：
  - `FromBytes`：设备写入的任意 bit pattern 都能形成合法值；
  - `IntoBytes`：CPU 交给设备的完整表示不含隐式 padding；
  - `Immutable`：类型不含 interior mutability。
- 为当前实际使用的 18 个本地 driver descriptor/wire-format 派生上述表示证明，并固定关键协议类型的 size/alignment。
- 对无法在本地派生的 xhci 0.9.2 外部 context 类型增加 4 个透明 wrapper；它们是最终实现中仅有的 descriptor 级手写 `DmaPod` 例外，并带有版本、字段表示和 size/alignment 证据。
- 将 `DmaAllocHandle`、`DmaMapHandle` 从 `Copy + Clone` 改为 move-only；release 操作消费唯一 token，`StreamingMap` 相应通过 `Option::take()` 在 Drop 时移动 handle。
- 为 `dev` 尚未覆盖的 coherent/contiguous 入口增加零长度拒绝，保留 streaming 已有的同类检查，并删除释放阶段对零长度 handle 的跳过逻辑。
- 驱动侧迁移只更新类型证明，不修改队列、IRQ、寄存器访问或设备状态机。

## 带来的具体收益

| `dev` 中的原问题 | PR head 的可观察结果 |
| --- | --- |
| `NonZeroU32`、`bool`、裸指针等因实现了 `Copy` 而自动成为 `DmaPod` | 编译期拒绝，safe `read_cpu()` 不再因类型表示产生无效值 |
| 任意 `Copy` 描述符都能通过，字段变化不会检查 padding | 18 个本地 wire type 在定义处派生证明；新增隐式 padding 会直接编译失败 |
| 同一 backend 资源可以复制出多个释放 token | handle 的 `Copy`/`Clone` 在编译期失败，释放凭据只能移动一次 |
| coherent/contiguous 零长度请求会进入 backend | 公共入口返回 `ZeroSizedBuffer`，mock 证明 backend 调用次数为 0 |
| `DmaPod` 安全性由一个不成立的全局 `T: Copy` 假设承担 | 本地类型由编译器验证；最终只保留 4 个有完整布局证据的外部类型例外 |

这些收益是正确性、soundness 和维护性收益；本 PR 不声明吞吐、延迟或内存占用改善。

## 方案选择

- 保持 `dev` 的 `T: Copy`：实现最少，但继续保留 safe API 未定义行为，不能接受。
- 只允许原始 `[u8]`/整数数组：可以避免表示问题，但会丢失类型化硬件描述符，驱动需要手工编码字段。
- 要求每个描述符手写 `unsafe impl DmaPod`：能够修复 soundness，但重复知识多，后续字段变化仍依赖人工复审。
- 使用 `zerocopy` 表示证明：保留类型化描述符，并在定义处由编译器检查 bit pattern、padding 和 interior mutability，因此采用该方案。

没有采用 `bytemuck::Pod`，因为工作区 Starry 配置启用了其 raw-pointer Pod 特性，Cargo feature 合并会意外扩大 `DmaPod` 边界。

## 范围与非目标

本 PR 只收敛 `dma-api` capability boundary 的数据表示、token 所有权和非零请求契约。不修改 DMA cache ownership 时序、IOMMU/domain 策略、bounce buffer 算法、驱动队列、IRQ 或设备行为。

公共契约变化后，`dev` 中已有 descriptor 必须在同一 PR 中完成机械迁移，否则 PR head 无法构建；这也是本 PR 涉及多个驱动 crate 的原因。

## 验证

- `cargo test -p dma-api`：23 个集成测试和 7 个 compile-fail doctest 通过。
- compile-fail 覆盖非法 bit pattern、裸指针、隐式 padding，以及 allocation/map token 不可 `Copy`/`Clone`。
- 新增的 4 个 coherent/contiguous 零长度用例证明 backend 调用次数为 0；已有 streaming 零长度行为继续通过。
- mock backend 覆盖 allocation/map 恰好释放一次。
- 受影响驱动的定向库测试和 `cargo check --all-targets` 通过。
- `cargo xtask clippy --package` 对 `dma-api`、全部受影响驱动及 `rockchip-npu` 通过；`axklib` 3/3、`ax-driver` 52/52、`starry-kernel` 25/25 配置通过。
- `cargo fmt --all` 与 `git diff --check` 通过。

已知验证限制：`crab-usb` 全量并行测试会偶发触发既有 xHCI 测试夹具 MMIO 基址未保证 32 字节对齐的断言；该失败用例单独执行通过，本 PR 未修改该测试夹具或 xHCI 寄存器逻辑。`cargo check --workspace --all-targets` 还会触发仓库既有的 axcpu 非法 feature 组合，相关修改目标已通过上述定向矩阵验证。此次改动不影响 StarryOS 用户态 ABI 或 syscall 语义。