### PR TITLE
fix(rsext4): propagate journal I/O failures without panicking

### DIFF
--- a/fs/ax-fs-ng/src/fs/ext4/rsext4/inode.rs
+++ b/fs/ax-fs-ng/src/fs/ext4/rsext4/inode.rs
@@ -322,7 +322,8 @@ impl FileNodeOps for Inode {
                     self.ino,
                     &data_blocks,
                     dev,
-                );
+                )
+                .map_err(into_vfs_err)?;
             }
 
             fs.modify_inode(dev, self.ino, |on_disk| {

--- a/fs/rsext4/src/axtest.rs
+++ b/fs/rsext4/src/axtest.rs
@@ -2533,7 +2533,8 @@ fn rsext4_mounted_filesystem_file_dir_and_metadata_rules_hold() {
     );
 
     let mut mapped_inode = Ext4Inode::empty_for_reuse(32);
-    build_file_block_mapping_with_inode_num(&mut fs, &mut mapped_inode, file_ino, &[], &mut device);
+    build_file_block_mapping_with_inode_num(&mut fs, &mut mapped_inode, file_ino, &[], &mut device)
+        .unwrap();
     ax_assert_eq!(mapped_inode.blocks_count(), 0);
     let map_block_a = fs.alloc_block(&mut device).unwrap();
     let _map_gap = fs.alloc_block(&mut device).unwrap();
@@ -2544,7 +2545,8 @@ fn rsext4_mounted_filesystem_file_dir_and_metadata_rules_hold() {
         file_ino,
         &[map_block_a, map_block_b],
         &mut device,
-    );
+    )
+    .unwrap();
     ax_assert!(mapped_inode.have_extend_header_and_use_extend());
     let mapped_blocks = resolve_inode_blocks(&mut fs, &mut device, &mut mapped_inode).unwrap();
     ax_assert_eq!(mapped_blocks.len(), 2);

--- a/fs/rsext4/src/blockdev/journal.rs
+++ b/fs/rsext4/src/blockdev/journal.rs
@@ -336,6 +336,7 @@ mod tests {
     struct MemBlockDev {
         data: Vec<u8>,
         fail_flush: bool,
+        fail_write_block: Option<AbsoluteBN>,
     }
 
     impl MemBlockDev {
@@ -343,6 +344,7 @@ mod tests {
             Self {
                 data: vec![0; blocks * BLOCK_SIZE],
                 fail_flush: false,
+                fail_write_block: None,
             }
         }
 
@@ -350,6 +352,15 @@ mod tests {
             Self {
                 data: vec![0; blocks * BLOCK_SIZE],
                 fail_flush: true,
+                fail_write_block: None,
+            }
+        }
+
+        fn with_failing_write_block(blocks: usize, block: AbsoluteBN) -> Self {
+            Self {
+                data: vec![0; blocks * BLOCK_SIZE],
+                fail_flush: false,
+                fail_write_block: Some(block),
             }
         }
     }
@@ -363,6 +374,9 @@ mod tests {
         }
 
         fn write(&mut self, buffer: &[u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+            if self.fail_write_block == Some(block_id) {
+                return Err(Ext4Error::io());
+            }
             let start = block_id.as_usize()? * BLOCK_SIZE;
             let end = start + buffer.len();
             self.data[start..end].copy_from_slice(buffer);
@@ -450,5 +464,55 @@ mod tests {
             .expect_err("unmount commit must propagate the device error");
 
         assert_eq!(error, Ext4Error::io());
+    }
+
+    #[test]
+    fn umount_commit_returns_journal_superblock_write_failure_without_panicking() {
+        let journal_superblock = AbsoluteBN::new(128);
+        let mut dev = Jbd2Dev::initial_jbd2dev(
+            0,
+            MemBlockDev::with_failing_write_block(256, journal_superblock),
+            true,
+        );
+        dev.set_journal_superblock(JournalSuperBllockS::default(), journal_superblock);
+        dev.write_block(AbsoluteBN::new(10), true)
+            .expect("queue metadata update");
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| dev.umount_commit()));
+
+        assert!(result.is_ok(), "journal I/O failure must not panic");
+        assert_eq!(result.unwrap(), Err(Ext4Error::io()));
+    }
+
+    #[test]
+    fn umount_commit_returns_cache_invalidation_failure_without_panicking() {
+        let cached_block = AbsoluteBN::new(20);
+        let mut dev = Jbd2Dev::initial_jbd2dev(
+            0,
+            MemBlockDev::with_failing_write_block(256, cached_block),
+            true,
+        );
+        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
+        dev.read_block(cached_block).expect("prime cached block");
+        dev.buffer_mut()[0] = 1;
+        dev.write_block(AbsoluteBN::new(10), true)
+            .expect("queue metadata update");
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| dev.umount_commit()));
+
+        assert!(result.is_ok(), "cache invalidation failure must not panic");
+        assert_eq!(result.unwrap(), Err(Ext4Error::io()));
+    }
+
+    #[test]
+    fn rejects_an_empty_journal_mapping() {
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
+
+        let error = dev
+            .set_journal_superblock_with_mapping(JournalSuperBllockS::default(), Vec::new())
+            .expect_err("empty journal mappings are corrupt");
+
+        assert_eq!(error, Ext4Error::corrupted());
+        assert_eq!(dev.journal_sequence(), None);
     }
 }

--- a/fs/rsext4/src/dir/bootstrap.rs
+++ b/fs/rsext4/src/dir/bootstrap.rs
@@ -87,7 +87,7 @@ pub fn create_root_directory_entry<B: BlockDevice>(
         fs.root_inode,
         &[data_block],
         block_dev,
-    );
+    )?;
     fs.finalize_inode_update(
         block_dev,
         fs.root_inode,
@@ -196,7 +196,7 @@ pub fn create_lost_found_directory<B: BlockDevice>(
         lost_ino,
         &[data_block],
         block_dev,
-    );
+    )?;
     debug!(
         "When create lost+found inode iblock,:{:?} ,data_block:{:?}",
         lost_inode.i_block, data_block

--- a/fs/rsext4/src/dir/mkdir.rs
+++ b/fs/rsext4/src/dir/mkdir.rs
@@ -157,7 +157,13 @@ fn mkdir_internal<B: BlockDevice>(
         dir_mode,
         parent_inode.i_flags & Ext4Inode::EXT4_FL_INHERITED,
     );
-    build_file_block_mapping_with_inode_num(fs, &mut new_inode, new_dir_ino, &[data_block], device);
+    build_file_block_mapping_with_inode_num(
+        fs,
+        &mut new_inode,
+        new_dir_ino,
+        &[data_block],
+        device,
+    )?;
     let mut create_update = Ext4InodeMetadataUpdate::create(dir_mode);
     create_update.uid = Some(uid);
     create_update.gid = Some(gid);

--- a/fs/rsext4/src/ext4/mount.rs
+++ b/fs/rsext4/src/ext4/mount.rs
@@ -220,7 +220,7 @@ impl Ext4FileSystem {
                         error!("Journal inode missing while filesystem needs recovery");
                         return Err(Ext4Error::corrupted());
                     }
-                    create_journal_entry(&mut fs, block_dev).expect("create journal entry failed");
+                    create_journal_entry(&mut fs, block_dev)?;
                 }
             }
             if needs_recovery && options.replay_journal && !fs.superblock.has_journal() {
@@ -235,7 +235,9 @@ impl Ext4FileSystem {
                 // `Jbd2Dev`.
                 let mut j_inode = fs
                     .get_inode_by_num(block_dev, InodeNumber::new(JOURNAL_FILE_INODE as u32)?)
-                    .expect("load journal inode failed");
+                    .inspect_err(|e| {
+                        error!("Failed to load journal inode: {e}");
+                    })?;
 
                 let journal_blocks =
                     fs.journal_blocks(block_dev, &mut j_inode)
@@ -251,7 +253,9 @@ impl Ext4FileSystem {
                 let journal_data = fs
                     .datablock_cache
                     .get_or_load(block_dev, journal_first_block)
-                    .expect("load journal superblock block failed")
+                    .inspect_err(|e| {
+                        error!("Failed to load journal superblock block: {e}");
+                    })?
                     .data
                     .clone();
 
@@ -379,13 +383,13 @@ impl Ext4FileSystem {
                     block_dev,
                     inode_cache_key,
                     AbsoluteBN::new(inode_bitmap_blk),
-                )
-                .expect("block read failed")
+                )?
                 .clone();
-            let blockbitmap_data = fs
-                .bitmap_cache
-                .get_or_load(block_dev, data_cache_key, AbsoluteBN::new(data_bitmap_blk))
-                .expect("block read failed");
+            let blockbitmap_data = fs.bitmap_cache.get_or_load(
+                block_dev,
+                data_cache_key,
+                AbsoluteBN::new(data_bitmap_blk),
+            )?;
 
             if ext4_superblock_has_metadata_csum(&fs.superblock) {
                 if !g0.is_inode_bitmap_uninit() {

--- a/fs/rsext4/src/file/blocks.rs
+++ b/fs/rsext4/src/file/blocks.rs
@@ -7,12 +7,12 @@ pub fn build_file_block_mapping_with_inode_num<B: BlockDevice>(
     inode_num: InodeNumber,
     data_blocks: &[AbsoluteBN],
     block_dev: &mut Jbd2Dev<B>,
-) {
+) -> Ext4Result<()> {
     if data_blocks.is_empty() {
         inode.i_blocks_lo = 0;
         inode.l_i_blocks_high = 0;
         inode.i_block = [0; 15];
-        return;
+        return Ok(());
     }
 
     if fs.superblock.has_extents() {
@@ -60,10 +60,12 @@ pub fn build_file_block_mapping_with_inode_num<B: BlockDevice>(
         // receives the same serialized structure as runtime writes.
         let mut tree = ExtentTree::with_checksum(inode, &fs.superblock, inode_num);
         for extend in exts_vec {
-            tree.insert_extent(fs, extend, block_dev)
-                .expect("Extent insert failed!");
+            tree.insert_extent(fs, extend, block_dev)?;
         }
     } else {
         error!("not support traditional block pointer");
+        return Err(Ext4Error::unsupported());
     }
+
+    Ok(())
 }

--- a/fs/rsext4/src/file/create.rs
+++ b/fs/rsext4/src/file/create.rs
@@ -151,7 +151,7 @@ pub fn create_symbol_link_with_owner<B: BlockDevice>(
         new_inode.i_blocks_lo = iblocks_used;
         new_inode.l_i_blocks_high = 0; // iblocks_used is u32, so high part is 0
 
-        build_file_block_mapping_with_inode_num(fs, &mut new_inode, new_ino, &data_blocks, device);
+        build_file_block_mapping_with_inode_num(fs, &mut new_inode, new_ino, &data_blocks, device)?;
     }
 
     let mut create_update = Ext4InodeMetadataUpdate::create(symlink_mode);
@@ -339,7 +339,7 @@ pub fn mkfile_with_owner<B: BlockDevice>(
             new_file_ino,
             &data_blocks,
             device,
-        );
+        )?;
     } else {
         // Empty file starts with no data blocks.
         new_inode.i_size_lo = 0;

--- a/fs/rsext4/src/jbd2/jbd2.rs
+++ b/fs/rsext4/src/jbd2/jbd2.rs
@@ -283,19 +283,14 @@ impl JBD2DEVSYSTEM {
         &mut self,
         block_dev: &mut B,
         journal_blocks: &[AbsoluteBN],
-    ) {
-        let sb_block = self
-            .journal_phys_block(journal_blocks, 0)
-            .expect("journal superblock block is invalid");
+    ) -> Ext4Result<()> {
+        let sb_block = self.journal_phys_block(journal_blocks, 0)?;
         let mut sb_data = [0u8; BLOCK_SIZE];
-        block_dev
-            .read(&mut sb_data, sb_block, 1)
-            .expect("Read journal superblock failed");
+        block_dev.read(&mut sb_data, sb_block, 1)?;
         jbd2_update_superblock_checksum(&mut self.jbd2_super_block);
         self.jbd2_super_block.to_disk_bytes(&mut sb_data[0..1024]);
-        block_dev
-            .write(&sb_data, sb_block, 1)
-            .expect("Write journal superblock failed");
+        block_dev.write(&sb_data, sb_block, 1)?;
+        Ok(())
     }
 
     /// Returns the next writable journal block, handling wrap-around.
@@ -318,8 +313,14 @@ impl JBD2DEVSYSTEM {
 
         // The first commit initializes `s_start` in the journal superblock.
         if self.jbd2_super_block.s_start == 0 {
+            let previous_superblock = self.jbd2_super_block;
             self.jbd2_super_block.s_start = self.jbd2_super_block.s_first;
-            self.write_journal_superblock_with_mapping(block_dev, journal_blocks);
+            if let Err(error) =
+                self.write_journal_superblock_with_mapping(block_dev, journal_blocks)
+            {
+                self.jbd2_super_block = previous_superblock;
+                return Err(error);
+            }
             self.head += 1;
             let mut rel = self
                 .jbd2_super_block
@@ -501,7 +502,7 @@ impl JBD2DEVSYSTEM {
         self.jbd2_super_block.s_sequence = self.sequence;
         self.jbd2_super_block.s_start = 0;
         self.head = 0;
-        self.write_journal_superblock_with_mapping(block_dev, journal_blocks);
+        self.write_journal_superblock_with_mapping(block_dev, journal_blocks)?;
         block_dev.flush()?;
         debug!(
             "[JBD2 commit] end: tid={} new_sequence={}",
@@ -841,8 +842,13 @@ impl JBD2DEVSYSTEM {
                 "[JBD2 replay] write journal superblock to block={} (sequence={} s_start={})",
                 sb_block, self.jbd2_super_block.s_sequence, self.jbd2_super_block.s_start
             );
-            self.write_journal_superblock_with_mapping(block_dev, journal_blocks);
-            let _ = block_dev.flush();
+            if self
+                .write_journal_superblock_with_mapping(block_dev, journal_blocks)
+                .is_err()
+                || block_dev.flush().is_err()
+            {
+                return ReplayStatus::Incomplete;
+            }
         }
         debug!(
             "[JBD2 replay] end: status={status:?} transactions={} records={} payloads={} \
@@ -890,9 +896,7 @@ pub fn create_journal_entry<B: BlockDevice>(
     // Allocate the journal area. Block 0 stores the journal superblock and the
     // remaining blocks hold descriptor/data/commit traffic.
     let journal_inode_num = JOURNAL_FILE_INODE;
-    let free_block = fs
-        .alloc_blocks(block_dev, 4096)
-        .expect("No enough block can alloc out!");
+    let free_block = fs.alloc_blocks(block_dev, 4096)?;
 
     // Ensure journal area starts clean: otherwise old image contents could look like valid
     // descriptor/commit blocks and replay would corrupt filesystem metadata.
@@ -919,7 +923,7 @@ pub fn create_journal_entry<B: BlockDevice>(
         InodeNumber::new(journal_inode_num as u32)?,
         &free_block,
         block_dev,
-    );
+    )?;
     debug!(
         "When creating journal inode: iblock={:?}",
         jour_inode.i_block
@@ -929,8 +933,7 @@ pub fn create_journal_entry<B: BlockDevice>(
         InodeNumber::new(journal_inode_num as u32)?,
         &mut jour_inode,
         Ext4InodeMetadataUpdate::create(Ext4Inode::S_IFREG | 0o600),
-    )
-    .expect("journal inode creation failed");
+    )?;
 
     let mut jbd2_sb = JournalSuperBllockS::default();
 

--- a/fs/rsext4/tests/crc_integrity.rs
+++ b/fs/rsext4/tests/crc_integrity.rs
@@ -14,7 +14,7 @@ use std::{
 
 use rsext4::{
     blockgroup_description::Ext4GroupDesc,
-    bmalloc::AbsoluteBN,
+    bmalloc::{AbsoluteBN, InodeNumber},
     checksum::{
         ext4_block_bitmap_csum32, ext4_group_desc_csum16, ext4_inode_bitmap_csum32,
         ext4_superblock_csum32,
@@ -23,7 +23,8 @@ use rsext4::{
     error::{Errno, Ext4Error, Ext4Result},
     jbd2::jbdstruct::{
         JBD2_BLOCKTYPE_DESCRIPTOR, JBD2_BLOCKTYPE_REVOKE, JBD2_FLAG_LAST_TAG, JBD2_FLAG_SAME_UUID,
-        JBD2_MAGIC, JBD2_UUID_SIZE, JournalBlockTagS, JournalHeaderS, JournalSuperBllockS,
+        JBD2_MAGIC, JBD2_UUID_SIZE, JOURNAL_FILE_INODE, JournalBlockTagS, JournalHeaderS,
+        JournalSuperBllockS,
     },
     loopfile::resolve_inode_block,
     superblock::Ext4Superblock,
@@ -38,6 +39,10 @@ struct SharedCrcDevice {
     block_size: u32,
     now: Rc<Cell<i64>>,
     blocked_read_block: Rc<Cell<Option<u64>>>,
+    fail_writes: Rc<Cell<bool>>,
+    failing_write_block: Rc<Cell<Option<u64>>>,
+    journal_superblock_write_attempts: Rc<Cell<u8>>,
+    failing_write_attempts: Rc<RefCell<BTreeSet<u8>>>,
 }
 
 impl SharedCrcDevice {
@@ -47,6 +52,10 @@ impl SharedCrcDevice {
             block_size: BLOCK_SIZE as u32,
             now: Rc::new(Cell::new(1_700_000_000)),
             blocked_read_block: Rc::new(Cell::new(None)),
+            fail_writes: Rc::new(Cell::new(false)),
+            failing_write_block: Rc::new(Cell::new(None)),
+            journal_superblock_write_attempts: Rc::new(Cell::new(0)),
+            failing_write_attempts: Rc::new(RefCell::new(BTreeSet::new())),
         }
     }
 
@@ -85,6 +94,16 @@ impl BlockDevice for SharedCrcDevice {
     }
 
     fn write(&mut self, buffer: &[u8], block_id: AbsoluteBN, _count: u32) -> Ext4Result<()> {
+        if self.failing_write_block.get() == Some(block_id.raw()) {
+            let attempt = self.journal_superblock_write_attempts.get() + 1;
+            self.journal_superblock_write_attempts.set(attempt);
+            if self.failing_write_attempts.borrow_mut().remove(&attempt) {
+                return Err(Ext4Error::io());
+            }
+        }
+        if self.fail_writes.get() {
+            return Err(Ext4Error::io());
+        }
         let start = block_id.as_usize()? * self.block_size as usize;
         let end = start + buffer.len();
         if end > self.data.borrow().len() {
@@ -887,4 +906,167 @@ fn corrupted_block_bitmap_payload_is_reported_as_euclean_on_mount() {
         Err(err) => err,
     };
     assert_eq!(err.code, Errno::EUCLEAN);
+}
+
+#[test]
+fn mount_returns_journal_superblock_read_failure_without_panicking() {
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_block = fs
+        .journal_sb_block_start
+        .expect("journal superblock should be mapped")
+        .raw();
+    umount(fs, &mut first_mount_dev).expect("umount failed");
+
+    device.blocked_read_block.set(Some(journal_block));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut remount_dev = new_jbd2_dev(device.clone());
+        mount(&mut remount_dev)
+    }));
+
+    assert!(
+        result.is_ok(),
+        "journal superblock I/O failure must not panic"
+    );
+    let Err(error) = result.unwrap() else {
+        panic!("mount must fail");
+    };
+    assert_eq!(error.code, Errno::EIO);
+}
+
+#[test]
+fn mount_returns_bitmap_read_failures_without_panicking() {
+    let (device, _) = build_filesystem_with_written_file();
+    let superblock = read_superblock(&device);
+    let group_desc = read_group_desc0(&device, &superblock);
+
+    for bitmap_block in [group_desc.inode_bitmap(), group_desc.block_bitmap()] {
+        device.blocked_read_block.set(Some(bitmap_block));
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut remount_dev = new_jbd2_dev(device.clone());
+            mount(&mut remount_dev)
+        }));
+
+        assert!(result.is_ok(), "bitmap I/O failure must not panic");
+        let Err(error) = result.unwrap() else {
+            panic!("mount must fail");
+        };
+        assert_eq!(error.code, Errno::EIO);
+    }
+}
+
+#[test]
+fn mount_rejects_an_empty_journal_mapping_without_panicking() {
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let mut fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_inode = InodeNumber::new(JOURNAL_FILE_INODE as u32).expect("valid journal inode");
+    fs.modify_inode(&mut first_mount_dev, journal_inode, |inode| {
+        inode.i_size_lo = 0;
+        inode.i_size_high = 0;
+    })
+    .expect("corrupt journal inode mapping");
+    sync_with_axfs_ng_order(&mut first_mount_dev, &mut fs).expect("persist corrupted mapping");
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut remount_dev = new_jbd2_dev(device.clone());
+        mount(&mut remount_dev)
+    }));
+
+    assert!(result.is_ok(), "invalid journal mapping must not panic");
+    let Err(error) = result.unwrap() else {
+        panic!("mount must reject an empty journal mapping");
+    };
+    assert_eq!(error.code, Errno::EUCLEAN);
+}
+
+#[test]
+fn mount_returns_journal_bootstrap_write_failure_without_panicking() {
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut jbd2_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut jbd2_dev).expect("mkfs failed");
+
+    let mut first_mount_dev = new_jbd2_dev(device.clone());
+    let mut fs = mount(&mut first_mount_dev).expect("mount failed");
+    let journal_inode = InodeNumber::new(JOURNAL_FILE_INODE as u32).expect("valid journal inode");
+    fs.modify_inode(&mut first_mount_dev, journal_inode, |inode| {
+        inode.i_mode = 0
+    })
+    .expect("remove journal inode");
+    sync_with_axfs_ng_order(&mut first_mount_dev, &mut fs).expect("persist missing journal inode");
+
+    let mut superblock = read_superblock(&device);
+    superblock.s_feature_incompat &= !Ext4Superblock::EXT4_FEATURE_INCOMPAT_RECOVER;
+    superblock.update_checksum();
+    write_superblock(&device, &superblock);
+
+    device.fail_writes.set(true);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut remount_dev = new_jbd2_dev(device.clone());
+        mount(&mut remount_dev)
+    }));
+
+    assert!(
+        result.is_ok(),
+        "journal bootstrap I/O failure must not panic"
+    );
+    let Err(error) = result.unwrap() else {
+        panic!("mount must fail when journal bootstrap writes fail");
+    };
+    assert_eq!(error.code, Errno::EIO);
+}
+
+#[test]
+fn journal_commit_retry_persists_replay_start_after_initial_superblock_write_failure() {
+    let device = SharedCrcDevice::new(100 * 1024 * 1024);
+    let mut format_dev = new_jbd2_dev(device.clone());
+    mkfs(&mut format_dev).expect("mkfs failed");
+
+    let mut dev = new_jbd2_dev(device.clone());
+    let fs = mount(&mut dev).expect("mount failed");
+    let journal_block = fs
+        .journal_sb_block_start
+        .expect("journal superblock should be mapped")
+        .raw();
+
+    let unchanged_home_block = AbsoluteBN::new(42);
+    dev.read_block(unchanged_home_block)
+        .expect("read home block");
+    dev.write_block(unchanged_home_block, true)
+        .expect("queue metadata update");
+
+    device.failing_write_block.set(Some(journal_block));
+    // Fail the initial replay-start write, then fail the final cleanup write
+    // after the retry has written a committed transaction. The second failure
+    // models a crash before journal cleanup can hide the transaction.
+    *device.failing_write_attempts.borrow_mut() = [1, 3].into_iter().collect();
+
+    let first_error = dev
+        .umount_commit()
+        .expect_err("initial journal superblock write must fail");
+    assert_eq!(first_error.code, Errno::EIO);
+
+    let retry_error = dev
+        .umount_commit()
+        .expect_err("final journal cleanup write must fail");
+    assert_eq!(retry_error.code, Errno::EIO);
+
+    let on_disk_journal =
+        JournalSuperBllockS::from_disk_bytes(&device.read_block_bytes(journal_block));
+    assert_ne!(
+        on_disk_journal.s_start, 0,
+        "the retried committed transaction must remain discoverable after a crash"
+    );
+
+    let mut remount_dev = new_jbd2_dev(device.clone());
+    let recovered =
+        mount(&mut remount_dev).expect("mount must replay the discoverable transaction");
+    umount(recovered, &mut remount_dev).expect("clean unmount after replay");
 }


### PR DESCRIPTION
处理漏洞
- https://github.com/rcore-os/tgoskits/issues/1746