### PR TITLE
fix(rsext4): reject empty internal extent nodes

### DIFF
--- a/fs/rsext4/src/extents_tree/insert.rs
+++ b/fs/rsext4/src/extents_tree/insert.rs
@@ -17,7 +17,7 @@ impl<'a> ExtentTree<'a> {
 
         let mut root = match self.load_root_from_inode() {
             Some(node) => node,
-            None => return Err(Ext4Error::unsupported()),
+            None => return Err(Ext4Error::corrupted()),
         };
 
         match &root {
@@ -339,13 +339,14 @@ impl<'a> ExtentTree<'a> {
                     new_ext.start_block(),
                     phy_block
                 );
+                // Internal nodes must always have a child to descend into.
+                if entries.is_empty() {
+                    return Err(Ext4Error::corrupted());
+                }
+
                 // Descend through the last child whose key is <= the new extent.
-                let idx_pos = if entries.is_empty() {
-                    0
-                } else {
-                    let pp = entries.partition_point(|idx| idx.ei_block <= new_ext.ee_block);
-                    if pp == 0 { 0 } else { pp - 1 }
-                };
+                let pp = entries.partition_point(|idx| idx.ei_block <= new_ext.ee_block);
+                let idx_pos = if pp == 0 { 0 } else { pp - 1 };
 
                 let child_phy_block = AbsoluteBN::new(
                     ((entries[idx_pos].ei_leaf_hi as u64) << 32)
@@ -354,7 +355,7 @@ impl<'a> ExtentTree<'a> {
                 block_dev.read_block(child_phy_block)?;
                 let child_bytes = block_dev.buffer();
                 let mut child_node =
-                    Self::parse_node_from_bytes(child_bytes).expect("Can't parse node from bytes!");
+                    Self::parse_node_from_bytes(child_bytes).ok_or(Ext4Error::corrupted())?;
 
                 let child_split_res = self.insert_recursive(
                     fs,

--- a/fs/rsext4/src/extents_tree/parse.rs
+++ b/fs/rsext4/src/extents_tree/parse.rs
@@ -40,6 +40,10 @@ impl<'a> ExtentTree<'a> {
             error!("Extent header entries overflow: entries={entries}, max={max}");
             return None;
         }
+        if header.eh_depth != 0 && entries == 0 {
+            error!("Extent internal node has no child indexes");
+            return None;
+        }
 
         let mut offset = hdr_size;
 
@@ -393,5 +397,82 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn insert_rejects_empty_internal_root_without_mutating_inode() {
+        let (mut dev, mut fs) = setup_fs(16 * 1024);
+        let mut inode = new_extent_inode();
+        let empty_root = ExtentNode::Index {
+            header: Ext4ExtentHeader {
+                eh_magic: Ext4ExtentHeader::EXT4_EXT_MAGIC,
+                eh_entries: 0,
+                eh_max: 4,
+                eh_depth: 1,
+                eh_generation: 0,
+            },
+            entries: Vec::new(),
+        };
+        ExtentTree::new(&mut inode).store_root_to_inode(&empty_root);
+        let inode_before = inode.i_block;
+
+        let result =
+            ExtentTree::new(&mut inode).insert_extent(&mut fs, Ext4Extent::new(0, 1, 1), &mut dev);
+
+        assert_eq!(result, Err(Ext4Error::corrupted()));
+        assert_eq!(inode.i_block, inode_before);
+    }
+
+    #[test]
+    fn insert_rejects_parent_with_empty_internal_child_without_mutating_metadata() {
+        let (mut dev, mut fs) = setup_fs(16 * 1024);
+        let mut inode = new_extent_inode();
+        let child_block = fs.alloc_block(&mut dev).unwrap();
+        let empty_child = ExtentNode::Index {
+            header: Ext4ExtentHeader {
+                eh_magic: Ext4ExtentHeader::EXT4_EXT_MAGIC,
+                eh_entries: 0,
+                eh_max: ExtentTree::calc_block_eh_max(),
+                eh_depth: 1,
+                eh_generation: 0,
+            },
+            entries: Vec::new(),
+        };
+        let root = ExtentNode::Index {
+            header: Ext4ExtentHeader {
+                eh_magic: Ext4ExtentHeader::EXT4_EXT_MAGIC,
+                eh_entries: 1,
+                eh_max: 4,
+                eh_depth: 1,
+                eh_generation: 0,
+            },
+            entries: vec![Ext4ExtentIdx {
+                ei_block: 0,
+                ei_leaf_lo: child_block.raw() as u32,
+                ei_leaf_hi: (child_block.raw() >> 32) as u16,
+                ei_unused: 0,
+            }],
+        };
+        {
+            let mut tree = ExtentTree::new(&mut inode);
+            tree.write_node_to_block(&mut dev, child_block, &empty_child)
+                .unwrap();
+            tree.store_root_to_inode(&root);
+        }
+
+        let inode_before = inode.i_block;
+        dev.read_block(child_block).unwrap();
+        let child_before = dev.buffer().to_vec();
+
+        let result = ExtentTree::new(&mut inode).insert_extent(
+            &mut fs,
+            Ext4Extent::new(0, child_block.raw(), 1),
+            &mut dev,
+        );
+
+        assert_eq!(result, Err(Ext4Error::corrupted()));
+        assert_eq!(inode.i_block, inode_before);
+        dev.read_block(child_block).unwrap();
+        assert_eq!(dev.buffer(), child_before);
     }
 }


### PR DESCRIPTION
处理漏洞
- https://github.com/rcore-os/tgoskits/issues/1735