### PR TITLE
fix(axbuild): preserve Axvisor QEMU group artifacts

### DIFF
--- a/scripts/axbuild/CHANGELOG.md
+++ b/scripts/axbuild/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(axvisor)* preserve one QEMU executable per VM configuration build group
+
 ## [0.4.23](https://github.com/rcore-os/tgoskits/compare/axbuild-v0.4.22...axbuild-v0.4.23) - 2026-08-09
 
 ### Added

--- a/scripts/axbuild/src/axvisor/test/qemu.rs
+++ b/scripts/axbuild/src/axvisor/test/qemu.rs
@@ -119,10 +119,25 @@ impl Axvisor {
         let mut build_groups = test_qemu::prepare_case_build_groups(&cases, |build_config_path| {
             Self::qemu_group_build_context(&request, build_config_path)
         })?;
+        let artifact_parent = self.app.workspace_root().join("target");
+        std::fs::create_dir_all(&artifact_parent).with_context(|| {
+            format!(
+                "failed to create Axvisor qemu artifact parent {}",
+                artifact_parent.display()
+            )
+        })?;
+        let artifact_directory = tempfile::Builder::new()
+            .prefix("axvisor-qemu-artifacts-")
+            .tempdir_in(&artifact_parent)
+            .context("failed to create temporary Axvisor qemu artifact directory")?;
+        let mut build_artifacts = Vec::with_capacity(build_groups.len());
 
         // Phase 1: Build all build groups first so compilation errors surface
-        // before any QEMU time is spent.
-        for build_group in &mut build_groups {
+        // before any QEMU time is spent. Preserve each executable immediately:
+        // Cargo uses one output path for build groups that differ only in
+        // embedded VM configuration, so a later build would otherwise replace
+        // the executable belonging to an earlier group.
+        for (index, build_group) in build_groups.iter_mut().enumerate() {
             rootfs::ensure_qemu_rootfs_ready(&build_group.request, self.app.workspace_root(), None)
                 .await?;
             build_group.cargo = build::load_cargo_config(&build_group.request)?;
@@ -132,7 +147,8 @@ impl Axvisor {
                 self.app.workspace_root(),
             )
             .await?;
-            self.app
+            let output = self
+                .app
                 .build(
                     build_group.cargo.clone(),
                     build_group.request.build_info_path.clone(),
@@ -145,36 +161,58 @@ impl Axvisor {
                         build_group.group.build_config_path.display()
                     )
                 })?;
+            build_artifacts.push(preserve_qemu_build_artifact(
+                output.elf_path(),
+                artifact_directory.path(),
+                index,
+            )?);
         }
 
         // Phase 2: Run all QEMU tests now that every artifact is available.
+        let case_groups = build_groups
+            .iter()
+            .map(|build_group| build_group.group.cases.as_slice())
+            .collect::<Vec<_>>();
+        let case_artifacts =
+            plan_qemu_case_artifacts(&case_groups, &build_artifacts, |case| case.qemu.to_bin)?;
         let mut completed = 0;
-        for build_group in &build_groups {
-            for case in &build_group.group.cases {
-                completed += 1;
-                let case_name = &case.case.case.name;
-                println!("[{completed}/{total}] axvisor qemu {case_name}");
+        for case_artifact in case_artifacts {
+            completed += 1;
+            let build_group = &build_groups[case_artifact.build_group_index];
+            let case = case_artifact.case;
+            let case_name = &case.case.case.name;
+            println!("[{completed}/{total}] axvisor qemu {case_name}");
 
-                let case_started = Instant::now();
-                let result = self
-                    .run_qemu_case(
-                        &build_group.request,
-                        &build_group.cargo,
-                        case,
-                        &asset_config,
+            let case_started = Instant::now();
+            let result = async {
+                self.app
+                    .prepare_elf_artifact(
+                        case_artifact.build_artifact.to_path_buf(),
+                        case_artifact.to_bin,
                     )
                     .await
-                    .with_context(|| format!("axvisor qemu test failed for case `{case_name}`"));
-                let duration = case_started.elapsed();
-                match result {
-                    Ok(()) => {
-                        println!("ok: {case_name} ({duration:.2?})");
-                        summary.pass_with_detail(case_name, format!("{duration:.2?}"));
-                    }
-                    Err(err) => {
-                        eprintln!("failed: {}: {err:#}", case_name);
-                        summary.fail_with_detail(case_name, format!("{duration:.2?}"));
-                    }
+                    .with_context(|| {
+                        format!("failed to activate Axvisor qemu artifact for case `{case_name}`")
+                    })?;
+                self.run_qemu_case(
+                    &build_group.request,
+                    &build_group.cargo,
+                    case,
+                    &asset_config,
+                )
+                .await
+            }
+            .await
+            .with_context(|| format!("axvisor qemu test failed for case `{case_name}`"));
+            let duration = case_started.elapsed();
+            match result {
+                Ok(()) => {
+                    println!("ok: {case_name} ({duration:.2?})");
+                    summary.pass_with_detail(case_name, format!("{duration:.2?}"));
+                }
+                Err(err) => {
+                    eprintln!("failed: {}: {err:#}", case_name);
+                    summary.fail_with_detail(case_name, format!("{duration:.2?}"));
                 }
             }
         }
@@ -325,4 +363,70 @@ fn axvisor_qemu_test_build_args(arch: &str, config: Option<PathBuf>) -> AxvisorC
         debug: false,
         vmconfigs: Vec::new(),
     }
+}
+
+pub(super) fn preserve_qemu_build_artifact(
+    source: &Path,
+    artifact_directory: &Path,
+    build_group_index: usize,
+) -> anyhow::Result<PathBuf> {
+    let file_name = source.file_name().with_context(|| {
+        format!(
+            "Axvisor qemu build artifact {} has no file name",
+            source.display()
+        )
+    })?;
+    let group_directory = artifact_directory.join(format!("group-{build_group_index}"));
+    std::fs::create_dir_all(&group_directory).with_context(|| {
+        format!(
+            "failed to create Axvisor qemu build-group artifact directory {}",
+            group_directory.display()
+        )
+    })?;
+    let destination = group_directory.join(file_name);
+    std::fs::copy(source, &destination).with_context(|| {
+        format!(
+            "failed to preserve Axvisor qemu build artifact {} at {}",
+            source.display(),
+            destination.display()
+        )
+    })?;
+    Ok(destination)
+}
+
+#[derive(Debug)]
+pub(super) struct QemuCaseArtifact<'case, 'artifact, T> {
+    pub(super) build_group_index: usize,
+    pub(super) case: &'case T,
+    pub(super) build_artifact: &'artifact Path,
+    pub(super) to_bin: bool,
+}
+
+pub(super) fn plan_qemu_case_artifacts<'case, 'artifact, T>(
+    case_groups: &[&[&'case T]],
+    build_artifacts: &'artifact [PathBuf],
+    to_bin: impl Fn(&T) -> bool,
+) -> anyhow::Result<Vec<QemuCaseArtifact<'case, 'artifact, T>>> {
+    anyhow::ensure!(
+        case_groups.len() == build_artifacts.len(),
+        "Axvisor qemu build-group count ({}) does not match preserved artifact count ({})",
+        case_groups.len(),
+        build_artifacts.len()
+    );
+    Ok(case_groups
+        .iter()
+        .zip(build_artifacts)
+        .enumerate()
+        .flat_map(|(build_group_index, (cases, build_artifact))| {
+            cases.iter().map({
+                let to_bin = &to_bin;
+                move |case| QemuCaseArtifact {
+                    build_group_index,
+                    case: *case,
+                    build_artifact,
+                    to_bin: to_bin(*case),
+                }
+            })
+        })
+        .collect())
 }

--- a/scripts/axbuild/src/axvisor/test/tests.rs
+++ b/scripts/axbuild/src/axvisor/test/tests.rs
@@ -1133,3 +1133,57 @@ fn board_case_config_is_also_valid_board_run_config() {
     assert_eq!(config.board_type, "PhytiumPi");
     assert_eq!(config.shell_prefix.as_deref(), Some("login:"));
 }
+
+#[test]
+fn qemu_build_groups_preserve_distinct_executable_artifacts() {
+    let root = tempdir().unwrap();
+    let build_output = root.path().join("target/release/axvisor");
+    let artifact_directory = root.path().join("preserved");
+    fs::create_dir_all(build_output.parent().unwrap()).unwrap();
+
+    fs::write(&build_output, b"first VM config").unwrap();
+    let first =
+        super::qemu::preserve_qemu_build_artifact(&build_output, &artifact_directory, 0).unwrap();
+    fs::write(&build_output, b"second VM config").unwrap();
+    let second =
+        super::qemu::preserve_qemu_build_artifact(&build_output, &artifact_directory, 1).unwrap();
+
+    assert_ne!(first, second);
+    assert_eq!(fs::read(first).unwrap(), b"first VM config");
+    assert_eq!(fs::read(second).unwrap(), b"second VM config");
+}
+
+#[test]
+fn qemu_cases_activate_their_build_group_artifact_and_conversion_mode() {
+    let first = false;
+    let second = true;
+    let third = false;
+    let first_group = [&first, &second];
+    let second_group = [&third];
+    let groups = [first_group.as_slice(), second_group.as_slice()];
+    let artifacts = [
+        PathBuf::from("group-0/axvisor"),
+        PathBuf::from("group-1/axvisor"),
+    ];
+
+    let plan =
+        super::qemu::plan_qemu_case_artifacts(&groups, &artifacts, |to_bin| *to_bin).unwrap();
+
+    assert_eq!(plan.len(), 3);
+    assert_eq!(plan[0].build_group_index, 0);
+    assert_eq!(plan[0].build_artifact, artifacts[0]);
+    assert!(!plan[0].to_bin);
+    assert_eq!(plan[1].build_group_index, 0);
+    assert_eq!(plan[1].build_artifact, artifacts[0]);
+    assert!(plan[1].to_bin);
+    assert_eq!(plan[2].build_group_index, 1);
+    assert_eq!(plan[2].build_artifact, artifacts[1]);
+    assert!(!plan[2].to_bin);
+
+    let err = super::qemu::plan_qemu_case_artifacts(&groups, &artifacts[..1], |to_bin| *to_bin)
+        .unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("does not match preserved artifact count")
+    );
+}


### PR DESCRIPTION
## 问题

Axvisor QEMU test suite 会先完成所有 build group 的构建，再逐个运行 case。不同 build group 可能只在嵌入的 VM 配置上不同，因此 Cargo 会复用同一个 ELF 输出路径；后一次构建会覆盖前一组产物。旧流程又没有保存每次 `CargoBuildOutput`，Phase 2 因而可能拿最后一次构建的 ELF 运行前面的 case，造成配置错配和间歇失败。

这是从 #1775 中提取出的独立修复，补丁基于最新 `dev`，不依赖其中的 ax-task 或 axbuild 重构。

## 修改

1. 在 workspace `target` 下创建由 `TempDir` 管理的 Axvisor QEMU artifact 目录。
2. 每个 build group 构建完成后，立即把 ELF 复制到独立的 `group-{index}` 目录，避免后续 Cargo 构建覆盖。
3. 建立显式的 case execution plan，校验 build group 数量与保存的 artifact 数量一致，并把每个 case 绑定到对应组的 ELF 与自身的 `to_bin` 模式。
4. 每个 case 启动前调用 `prepare_elf_artifact` 激活对应组产物，再进入原有 QEMU case 流程。
5. 增加确定性回归测试和 `axbuild` changelog 记录。

## 逻辑

构建阶段必须在共享 Cargo 输出被下一次构建覆盖前完成快照；运行阶段则必须重新激活该组快照，因为 ostool 的 runtime artifact 状态决定 QEMU 实际使用哪个 ELF/BIN。显式 execution plan 同时消除了 `zip` 长度不一致时静默少跑 case 的风险，并保留每个 case 独立的 `to_bin` 转换语义。临时目录覆盖整个 `test_qemu` 生命周期，成功和错误返回都会由 RAII 清理。

## 验证

- 确定性 red：保留旧共享路径语义时，第二次写入后两组 artifact 路径相同，`assert_ne!` 必然失败。
- 同一回归 green：两组 artifact 路径和内容均保持独立。
- execution plan 测试覆盖 2 个 group、3 个 case、逐 case `to_bin` 以及 artifact 数量不一致的错误路径。
- `cargo test -p axbuild qemu_ -- --nocapture`：188 passed。
- `cargo xtask clippy --package axbuild`：通过。
- `cargo fmt --all --check`：通过。
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal`：7/7 passed，覆盖 MP fallback、OVMF ACPI、direct ACPI、SVM/VMX smoke 等多个 build group。

补充：全量 `cargo test -p axbuild` 默认并发曾触发现有 `agent_review_bench::tests::mock_agents_write_artifacts_and_reject_invalid_json` 测试失败；该测试不涉及本次路径，单独复跑通过。
