### PR TITLE
fix(cpu-local): keep AArch64 current independent of TLS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -777,7 +777,7 @@ jobs:
           - name: Test OrangePi 5 Plus robot native StarryOS
             use_container: false
             runs_on: '["self-hosted","linux","board"]'
-            timeout_minutes: 15
+            timeout_minutes: 90
             command: cargo xtask starry test board --board orangepi-5-plus-robot
             cache_key: ""
             container_image: ""
@@ -786,7 +786,7 @@ jobs:
           - name: Test OrangePi 5 Plus robot AxVisor StarryOS guest
             use_container: false
             runs_on: '["self-hosted","linux","board"]'
-            timeout_minutes: 15
+            timeout_minutes: 90
             command: cargo xtask axvisor test board --board orangepi-5-plus-robot-starry
             cache_key: ""
             container_image: ""
@@ -795,7 +795,7 @@ jobs:
           - name: Test OrangePi 5 Plus robot AxVisor Linux guest
             use_container: false
             runs_on: '["self-hosted","linux","board"]'
-            timeout_minutes: 15
+            timeout_minutes: 90
             command: cargo xtask axvisor test board --board orangepi-5-plus-robot-linux
             cache_key: ""
             container_image: ""

--- a/components/axcpu/src/aarch64/context.rs
+++ b/components/axcpu/src/aarch64/context.rs
@@ -334,6 +334,8 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         ldp     x25, x26, [x1, {r25_offset}]
         ldp     x27, x28, [x1, {r27_offset}]
         ldp     x29, x30, [x1, {r29_offset}]
+        ldr     x9, [x1, {current_header_offset}]
+        msr     sp_el0, x9
 
         ret",
         sp_offset = const offset_of!(TaskContext, sp),
@@ -343,6 +345,8 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         r25_offset = const offset_of!(TaskContext, r25),
         r27_offset = const offset_of!(TaskContext, r27),
         r29_offset = const offset_of!(TaskContext, r29),
+        current_header_offset = const offset_of!(TaskContext, task_local)
+            + offset_of!(TaskLocalState, current_header),
         kernel_tls_offset = const offset_of!(TaskContext, task_local)
             + offset_of!(TaskLocalState, kernel_tls),
     )

--- a/components/axcpu/src/task_local.rs
+++ b/components/axcpu/src/task_local.rs
@@ -6,9 +6,10 @@ use crate::KernelTlsBase;
 
 /// Architecture-neutral task state participating in the final switch tail.
 ///
-/// The current-header pointer is consumed only by LinuxCurrent assembly. The
-/// kernel TLS base is consumed only by TLS-enabled unikernel assembly. Keeping
-/// both in one C-layout component centralizes their adjacency and ownership.
+/// Architecture switch tails consume the current-header pointer whenever the
+/// hardware provides a task register independent of kernel TLS. Backends whose
+/// task register is also the TLS base use the CPU runtime anchor for current.
+/// Keeping both values adjacent centralizes their switch-time ownership.
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct TaskLocalState {

--- a/components/axcpu/tests/x86_aarch_context_boundary.rs
+++ b/components/axcpu/tests/x86_aarch_context_boundary.rs
@@ -19,7 +19,7 @@ fn x86_task_context_switches_tls_only_in_the_naked_window() {
 }
 
 #[test]
-fn aarch64_task_context_switches_tls_only_in_the_naked_window() {
+fn aarch64_task_context_restores_current_and_tls_in_the_naked_window() {
     let source = read_arch_source("aarch64/context.rs");
     let rust_switch = function_body(&source, "pub fn prepare_switch_to");
     let naked_switch = function_body(&source, r#"unsafe extern "C" fn context_switch_raw"#);
@@ -28,6 +28,8 @@ fn aarch64_task_context_switches_tls_only_in_the_naked_window() {
     assert!(rust_switch.contains("write_user_page_table"));
     assert!(!naked_switch.contains("write_user_page_table"));
     assert!(naked_switch.contains("tpidr_el0"));
+    assert!(naked_switch.contains("sp_el0"));
+    assert!(naked_switch.contains("current_header_offset"));
     assert!(!source.contains("pub fn switch_to("));
     assert!(!task_context_definition(&source).contains("ttbr0_el1"));
 }

--- a/components/cpu-local/Cargo.toml
+++ b/components/cpu-local/Cargo.toml
@@ -10,8 +10,9 @@ categories = ["os", "no-std"]
 license.workspace = true
 
 [features]
-# Select the no-userspace UnikernelTls register ownership model. Images that
-# leave this disabled use LinuxCurrent semantics.
+# Enable task-owned kernel TLS. Backends with an independent current register
+# retain Linux current semantics; TP-aliased backends publish current through
+# the CPU runtime anchor while TP carries the TLS base.
 tls = []
 
 # Use a thread-local register model for host-side tests.

--- a/components/cpu-local/README.md
+++ b/components/cpu-local/README.md
@@ -12,24 +12,28 @@ the scheduler.
 | --- | --- | --- | --- |
 | x86_64 | GS base | GS runtime anchor | FS base |
 | AArch64 | TPIDR_EL1/EL2 | SP_EL0 | TPIDR_EL0 |
-| RISC-V | prefix recovery or `sscratch` | `tp=current`, `sscratch=0` | `tp=TLS`, `sscratch=CPU base` |
-| LoongArch64 | r21, mirrored in KS3 | `tp=current` | `tp=TLS` |
+| RISC-V | prefix recovery or `sscratch` | `tp` without TLS; CPU runtime anchor with TLS | `tp=TLS`, `sscratch=CPU base` |
+| LoongArch64 | r21, mirrored in KS3 | `tp` without TLS; CPU runtime anchor with TLS | `tp=TLS` |
 
 LoongArch KS4 and KS5 are deliberately outside this contract and remain
 available to vCPU scratch state.
 
-The `tls` feature selects the TLS-owning image mode; without it the current
-thread occupies the architecture task-pointer register. `host-test` provides a
-thread-local register model for host-side tests. These are the crate's only
-features; no runtime mode enum or ABI version is retained inside one final
-image.
+The `tls` feature enables task-owned kernel TLS. It does not choose current
+ownership globally. x86_64 keeps current in GS while FS owns TLS, and AArch64
+keeps current in SP_EL0 while TPIDR_EL0 owns TLS. RISC-V and LoongArch64 use the
+CPU runtime anchor for current only when their task register is occupied by
+kernel TLS. `host-test` provides a thread-local register model for host-side
+tests. These are the crate's only features; no runtime ABI mode is retained
+inside one final image.
 
 Scheduler publication follows a strict sequence: validate the pinned binding,
 bind the next task header, prepare all fallible architecture work, consume a
-`PreparedThreadSwitch` to publish the next header immediately before the raw
-switch, then consume `PreviousThreadBinding` in the incoming tail. Dropping an
-uncommitted prepared token rolls the next binding back. The binding epoch is a
-runtime stale-tail guard, not an ABI version.
+`PreparedThreadSwitch` to publish the CPU runtime anchor immediately before the
+raw switch, update a dedicated task register in that raw tail when the backend
+has one, then consume `PreviousThreadBinding` in the incoming tail. On AArch64
+the anchor is also the exception-entry backup while SP_EL0 is temporarily lent
+to userspace. Dropping an uncommitted prepared token rolls the next binding
+back. The binding epoch is a runtime stale-tail guard, not an ABI version.
 
 `CpuPin` can only be created by the higher-ranked `with_cpu_pin` boundary and
 cannot escape its migration guard. `ExclusiveCpu` additionally represents

--- a/components/cpu-local/src/register/aarch64.rs
+++ b/components/cpu-local/src/register/aarch64.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
+    current_source_aliases_kernel_tls: false,
+};
+
 fn current_el() -> Result<usize, CpuLocalError> {
     let current_el: usize;
     unsafe { core::arch::asm!("mrs {value}, CurrentEL", value = out(reg) current_el) };
@@ -21,9 +25,7 @@ pub(super) unsafe fn install_cpu_base(area_base: usize, boot_thread: usize) {
         2 => unsafe { core::arch::asm!("msr TPIDR_EL2, {base}", base = in(reg) area_base) },
         _ => unreachable!(),
     }
-    if !cfg!(feature = "tls") {
-        unsafe { core::arch::asm!("msr SP_EL0, {current}", current = in(reg) boot_thread) };
-    }
+    unsafe { core::arch::asm!("msr SP_EL0, {current}", current = in(reg) boot_thread) };
 }
 
 pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
@@ -36,20 +38,14 @@ pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
     Ok(area_base)
 }
 
-pub(super) unsafe fn read_current_thread(area_base: usize) -> usize {
-    if cfg!(feature = "tls") {
-        unsafe { area_runtime_anchor(area_base) }.current_thread_raw()
-    } else {
-        let current: usize;
-        unsafe { core::arch::asm!("mrs {current}, SP_EL0", current = out(reg) current) };
-        current
-    }
+pub(super) unsafe fn read_current_thread(_area_base: usize) -> usize {
+    let current: usize;
+    unsafe { core::arch::asm!("mrs {current}, SP_EL0", current = out(reg) current) };
+    current
 }
 
 pub(super) unsafe fn write_current_thread(value: usize) {
-    if !cfg!(feature = "tls") {
-        unsafe { core::arch::asm!("msr SP_EL0, {value}", value = in(reg) value) };
-    }
+    unsafe { core::arch::asm!("msr SP_EL0, {value}", value = in(reg) value) };
 }
 
 #[cfg(feature = "tls")]
@@ -62,10 +58,4 @@ pub(super) unsafe fn read_kernel_tls() -> usize {
 #[cfg(feature = "tls")]
 pub(super) unsafe fn write_kernel_tls(value: usize) {
     unsafe { core::arch::asm!("msr TPIDR_EL0, {value}", value = in(reg) value) };
-}
-
-unsafe fn area_runtime_anchor(area_base: usize) -> &'static crate::CpuRuntimeAnchor {
-    unsafe {
-        &*((area_base + crate::CPU_AREA_RUNTIME_ANCHOR_OFFSET) as *const crate::CpuRuntimeAnchor)
-    }
 }

--- a/components/cpu-local/src/register/host.rs
+++ b/components/cpu-local/src/register/host.rs
@@ -2,6 +2,10 @@ use core::cell::Cell;
 
 use super::*;
 
+pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
+    current_source_aliases_kernel_tls: false,
+};
+
 std::thread_local! {
     static CPU_BASE: Cell<usize> = const { Cell::new(0) };
     static KERNEL_TLS: Cell<usize> = const { Cell::new(0) };

--- a/components/cpu-local/src/register/loongarch64.rs
+++ b/components/cpu-local/src/register/loongarch64.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
+    current_source_aliases_kernel_tls: true,
+};
+
 pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
     Ok(())
 }

--- a/components/cpu-local/src/register/mod.rs
+++ b/components/cpu-local/src/register/mod.rs
@@ -44,6 +44,27 @@ use x86_64 as imp;
 ))]
 compile_error!("cpu-local supports x86_64, AArch64, RISC-V, and LoongArch64 only");
 
+#[derive(Clone, Copy, Debug)]
+pub(super) struct ArchitectureCurrentModel {
+    pub(super) current_source_aliases_kernel_tls: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CurrentThreadSource {
+    Architecture,
+    CpuRuntimeAnchor,
+}
+
+impl ArchitectureCurrentModel {
+    const fn current_thread_source(self, tls_enabled: bool) -> CurrentThreadSource {
+        if tls_enabled && self.current_source_aliases_kernel_tls {
+            CurrentThreadSource::CpuRuntimeAnchor
+        } else {
+            CurrentThreadSource::Architecture
+        }
+    }
+}
+
 /// Installs the final area of an offline CPU.
 ///
 /// # Safety
@@ -117,28 +138,27 @@ pub fn current_thread(pin: &CpuPin<'_>) -> Result<NonNull<CurrentThreadHeader>, 
 /// dereference the result after a context switch.
 #[doc(hidden)]
 pub unsafe fn scheduler_current_thread() -> Result<NonNull<CurrentThreadHeader>, CpuLocalError> {
-    #[cfg(not(feature = "tls"))]
-    {
-        // LinuxCurrent images keep the task pointer in one architecture-owned
-        // source. Reading a CPU area first would race migration because this
-        // function is itself used to construct the preemption guard.
-        let register = unsafe { imp::read_current_thread(0) };
-        NonNull::new(register as *mut CurrentThreadHeader)
-            .ok_or(CpuLocalError::CurrentThreadMismatch)
-    }
-
-    #[cfg(feature = "tls")]
-    loop {
-        // UnikernelTls images keep current in the CPU area's runtime anchor.
-        // Retry if migration changes the base between sampling the area and
-        // loading its slot; the caller cannot be pinned before this lookup.
-        let area = current_area()?;
-        let register = unsafe { imp::read_current_thread(area.base()) };
-        if unsafe { imp::read_cpu_base()? } != area.base() {
-            continue;
+    match imp::CURRENT_MODEL.current_thread_source(cfg!(feature = "tls")) {
+        CurrentThreadSource::Architecture => {
+            // The architecture current source does not require a sampled CPU
+            // area. Reading one first would race migration because this
+            // function is itself used to construct the preemption guard.
+            let register = unsafe { imp::read_current_thread(0) };
+            NonNull::new(register as *mut CurrentThreadHeader)
+                .ok_or(CpuLocalError::CurrentThreadMismatch)
         }
-        return NonNull::new(register as *mut CurrentThreadHeader)
-            .ok_or(CpuLocalError::CurrentThreadMismatch);
+        CurrentThreadSource::CpuRuntimeAnchor => loop {
+            // Architectures whose current source is also the kernel TLS base
+            // keep current in the CPU runtime anchor. Retry if migration
+            // changes the area before the guard can be constructed.
+            let area = current_area()?;
+            let register = unsafe { imp::read_current_thread(area.base()) };
+            if unsafe { imp::read_cpu_base()? } != area.base() {
+                continue;
+            }
+            return NonNull::new(register as *mut CurrentThreadHeader)
+                .ok_or(CpuLocalError::CurrentThreadMismatch);
+        },
     }
 }
 
@@ -157,6 +177,36 @@ mod tests {
         );
         // SAFETY: the initialized fixture is leaked for the process lifetime.
         unsafe { CpuAreaRef::from_initialized_base(base) }.unwrap()
+    }
+
+    #[test]
+    fn independent_current_register_ignores_kernel_tls_feature() {
+        let independent = ArchitectureCurrentModel {
+            current_source_aliases_kernel_tls: false,
+        };
+        assert_eq!(
+            independent.current_thread_source(false),
+            CurrentThreadSource::Architecture,
+        );
+        assert_eq!(
+            independent.current_thread_source(true),
+            CurrentThreadSource::Architecture,
+        );
+    }
+
+    #[test]
+    fn aliased_current_register_follows_kernel_tls_feature() {
+        let aliased = ArchitectureCurrentModel {
+            current_source_aliases_kernel_tls: true,
+        };
+        assert_eq!(
+            aliased.current_thread_source(false),
+            CurrentThreadSource::Architecture,
+        );
+        assert_eq!(
+            aliased.current_thread_source(true),
+            CurrentThreadSource::CpuRuntimeAnchor,
+        );
     }
 
     #[test]
@@ -179,17 +229,12 @@ mod tests {
 
     #[test]
     fn scheduler_current_thread_rejects_an_uninstalled_host_area() {
-        #[cfg(feature = "tls")]
-        let expected_error = CpuLocalError::AreaNotInstalled;
-        #[cfg(not(feature = "tls"))]
-        let expected_error = CpuLocalError::CurrentThreadMismatch;
-
         let rejected = std::thread::spawn(move || {
             // SAFETY: the fresh host thread has no installed CPU area, so no
             // scheduler-owned pointer can be returned.
             matches!(
                 unsafe { scheduler_current_thread() },
-                Err(error) if error == expected_error
+                Err(CpuLocalError::CurrentThreadMismatch)
             )
         })
         .join()

--- a/components/cpu-local/src/register/riscv.rs
+++ b/components/cpu-local/src/register/riscv.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
+    current_source_aliases_kernel_tls: true,
+};
+
 pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
     Ok(())
 }

--- a/components/cpu-local/src/register/x86_64.rs
+++ b/components/cpu-local/src/register/x86_64.rs
@@ -5,6 +5,10 @@ const IA32_GS_BASE: u32 = 0xc000_0101;
 #[cfg(feature = "tls")]
 const IA32_FS_BASE: u32 = 0xc000_0100;
 
+pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
+    current_source_aliases_kernel_tls: false,
+};
+
 pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
     Ok(())
 }

--- a/components/cpu-local/tests/register_ownership_contract.rs
+++ b/components/cpu-local/tests/register_ownership_contract.rs
@@ -161,6 +161,39 @@ fn x86_and_aarch64_keep_task_tls_separate_from_the_cpu_anchor() {
 }
 
 #[test]
+fn aarch64_current_stays_in_sp_el0_when_tls_is_enabled() {
+    let install = AARCH64
+        .split_once("unsafe fn install_cpu_base")
+        .unwrap()
+        .1
+        .split_once("unsafe fn read_cpu_base")
+        .unwrap()
+        .0;
+    assert!(install.contains("SP_EL0"));
+    assert!(!install.contains("cfg!(feature = \"tls\")"));
+
+    let read_current = AARCH64
+        .split_once("unsafe fn read_current_thread")
+        .unwrap()
+        .1
+        .split_once("unsafe fn write_current_thread")
+        .unwrap()
+        .0;
+    assert!(read_current.contains("SP_EL0"));
+    assert!(!read_current.contains("area_runtime_anchor"));
+
+    let write_current = AARCH64
+        .split_once("unsafe fn write_current_thread")
+        .unwrap()
+        .1
+        .split_once("unsafe fn read_kernel_tls")
+        .unwrap()
+        .0;
+    assert!(write_current.contains("SP_EL0"));
+    assert!(!write_current.contains("cfg!(feature = \"tls\")"));
+}
+
+#[test]
 fn loongarch_mirrors_the_direct_area_base_in_ks3() {
     let backend = LOONGARCH64;
     assert!(backend.contains("csrwr {shadow}, 0x33"));

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/robot-linux/smoke/board-orangepi-5-plus-robot-linux.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/robot-linux/smoke/board-orangepi-5-plus-robot-linux.toml
@@ -22,4 +22,4 @@ fail_regex = [
   '(?m)^\[ROBOT_CI\] RESULT=FAIL .*$',
   '(?m)^\[ROBOT_CI\] HARNESS=FAIL .*$',
 ]
-timeout = 600
+timeout = 900

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/robot-starry/smoke/board-orangepi-5-plus-robot-starry.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/robot-starry/smoke/board-orangepi-5-plus-robot-starry.toml
@@ -23,4 +23,4 @@ fail_regex = [
   '(?m)^\[ROBOT_CI\] RESULT=FAIL .*$',
   '(?m)^\[ROBOT_CI\] HARNESS=FAIL .*$',
 ]
-timeout = 600
+timeout = 900

--- a/test-suit/starryos/board-orangepi-5-plus/robot-flow/board-orangepi-5-plus-robot.toml
+++ b/test-suit/starryos/board-orangepi-5-plus/robot-flow/board-orangepi-5-plus-robot.toml
@@ -19,4 +19,4 @@ fail_regex = [
   '(?m)^\[ROBOT_CI\] RESULT=FAIL .*$',
   '(?m)^\[ROBOT_CI\] HARNESS=FAIL .*$',
 ]
-timeout = 600
+timeout = 900


### PR DESCRIPTION
## 问题

`cpu-local` 之前把 `tls` feature 同时当成“启用任务 TLS”和“current 必须改走 CPU runtime anchor”的全局模式开关。这两个条件并不等价：

- AArch64 的 current 使用 `SP_EL0`，TLS 使用 `TPIDR_EL0`；两个寄存器相互独立。
- x86_64 同样分别使用 GS 与 FS。
- 只有 RISC-V、LoongArch64 在启用 TLS 后，原本承载 current 的 `tp` 被 TLS 占用，current 才需要回退到 CPU runtime anchor。

因此，按 `tls` feature 全局切换 current 来源会让 AArch64 在启用 TLS 后不再初始化、读取和更新 `SP_EL0`，并且裸上下文切换只恢复 `TPIDR_EL0`。这会破坏 AArch64 current 的寄存器所有权和切换时发布契约。

Linux arm64 也使用 `SP_EL0` 保存 current，可参考 [arch/arm64/include/asm/current.h](https://github.com/torvalds/linux/blob/d58772d8520c7ef247c4b95c9bd76d3a25da9ff5/arch/arm64/include/asm/current.h)。

本 PR 从 #1775 的 `86a9d4bbf` 中提取这一组独立修复，并基于最新 `dev` 做语义移植；由于 #1775 后续还交织了抢占、scheduler fast path、运行时重构和 someboot 多核启动等改动，没有直接 cherry-pick 整个提交链。

## 改动

- 在 `cpu-local` 内部增加架构 current 模型，由后端声明 current 来源是否与 kernel TLS 寄存器重叠。
- AArch64、x86_64、host 始终使用独立的架构 current 来源；RISC-V、LoongArch64 仅在启用 TLS 时使用 CPU runtime anchor。
- AArch64 无论是否启用 TLS，均通过 `SP_EL0` 初始化、读取和写入 current。
- AArch64 TLS 裸切换尾在返回 Rust 前同时恢复下一任务的 `TPIDR_EL0` 和 `SP_EL0`。
- 更新 `TaskLocalState`、feature 注释和 README 中的寄存器所有权说明。
- 增加寄存器/汇编契约回归测试，覆盖 AArch64 TLS 模式下的 `SP_EL0` current 路径。\n- 将三个 OrangePi 5 Plus robot CI job 的外层超时从 15 分钟调整为 90 分钟；对应 board case 的用例级超时从 600 秒调整为 900 秒，确保单个卡住的板测仍会在 15 分钟内终止。

## 设计逻辑与替代方案

保留原来的全局 `tls` 分支虽然改动更少，但它把 feature 能力误当成架构寄存器拓扑：对 RISC-V、LoongArch64 正确，对 AArch64、x86_64 则错误。另一种做法是在调用处继续堆叠 `cfg(target_arch = ...)`，但会让同一架构事实散落在调度路径中。本 PR 将该事实收敛为后端私有能力，公共 API、结构布局、依赖和 `Cargo.lock` 均不变化。

## 非目标

本 PR 不包含 #1775 中的抢占状态、runtime cookie、scheduler CPU-area fast path、`ax-task`/`ax-runtime` 重构或 someboot 改动，也不改变 StarryOS syscall/Linux ABI、启动流程、UEFI、SMP 或动态平台契约。

## 验证

回归测试在修改实现前已确认会稳定失败：旧 AArch64 TLS current 路径会改用 runtime anchor，TLS 裸切换尾也没有 `sp_el0`/`current_header_offset`；实现后同一组测试转为通过。

以下检查均通过：

- `cargo test -p cpu-local --features host-test --lib`
- `cargo test -p cpu-local --features host-test,tls --lib`
- `cargo test -p cpu-local --features host-test,tls --test register_ownership_contract`
- `cargo test -p ax-cpu --test x86_aarch_context_boundary`
- `cargo xtask clippy --package cpu-local`
- `cargo xtask clippy --package ax-cpu`
- `cargo fmt --all --check`
- `git diff --check`\n- `cargo xtask starry test board --board orangepi-5-plus-robot --list`\n- `cargo xtask axvisor test board --board orangepi-5-plus-robot-starry --list`\n- `cargo xtask axvisor test board --board orangepi-5-plus-robot-linux --list`\n- GitHub Actions [OrangePi 5 Plus robot board checks](https://github.com/rcore-os/tgoskits/actions/runs/31496958679)（native StarryOS、AxVisor StarryOS guest、AxVisor Linux guest 均通过）
- `cargo xtask arceos test qemu --arch aarch64 --test-group rust --test-case task-tls`（4 CPU，1/1 通过）
- `cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case smoke`（4 CPU，1/1 通过，包含 shell 与 NVMe 读写检查）

`cpu-local` 全量 host integration 的 `final_image_tls_feature_tree_contract` 仍会触发 Axvisor x86 `arm-el2` feature graph 失败；该失败在 clean `dev` 与本分支上表现一致，本 PR 未放宽相关测试。
