### PR TITLE
fix(axvm): boot x86 guest from passthrough NVMe

### DIFF
--- a/drivers/ax-driver/src/block/nvme.rs
+++ b/drivers/ax-driver/src/block/nvme.rs
@@ -4,7 +4,7 @@ use alloc::format;
 
 use log::{info, warn};
 use nvme_driver::{Config, Nvme, NvmeBlockDriver, NvmeIntxSource};
-use pcie::{CommandRegister, DeviceType, Endpoint};
+use pcie::{CommandRegister, DeviceType};
 use rdrive::probe::{
     OnProbeError,
     pci::{FnOnProbe, ProbePci},
@@ -98,7 +98,7 @@ fn probe_pci(mut probe: ProbePci<'_>) -> Result<(), OnProbeError> {
     )
     .map_err(|err| OnProbeError::other(format!("failed to initialize NVMe: {err:?}")))?;
     let intx_source = PciNvmeIntxSource {
-        endpoint: probe.take_endpoint(),
+        endpoint: crate::pci::take_intx_endpoint_for_handoff(probe.endpoint_mut()),
     };
     let driver = NvmeBlockDriver::from_nvme(nvme).with_intx_source(intx_source);
     let irq = probe.register_block(driver, PciIrqRequirement::Required)?;
@@ -136,17 +136,18 @@ fn register_msix_block(
     .map_err(|err| OnProbeError::other(format!("failed to initialize NVMe: {err:?}")))?;
     let driver = NvmeBlockDriver::from_nvme(nvme);
 
+    crate::pci::retain_endpoint_for_handoff(probe.endpoint_mut());
     let (_, _, plat_dev) = probe.into_parts();
     let _legacy_irq = plat_dev.register_irq_bound_block(driver, irq_lease);
     Ok(vector_count)
 }
 
 struct PciNvmeIntxSource {
-    endpoint: Endpoint,
+    endpoint: crate::pci::PciIntxEndpoint,
 }
 
 impl NvmeIntxSource for PciNvmeIntxSource {
     fn is_asserted(&self) -> bool {
-        self.endpoint.status().interrupt_status()
+        self.endpoint.interrupt_status()
     }
 }

--- a/drivers/ax-driver/src/pci/mod.rs
+++ b/drivers/ax-driver/src/pci/mod.rs
@@ -1,13 +1,13 @@
 use alloc::format;
-#[cfg(virtio_dev)]
+#[cfg(any(virtio_dev, feature = "nvme"))]
 use alloc::sync::Arc;
 
 use ax_sync::{RawSpinLockGuard, SpinLock as Mutex};
 use heapless::Vec as ArrayVec;
 use mmio_api::MmioOp;
-#[cfg(any(test, virtio_dev))]
+#[cfg(any(test, virtio_dev, feature = "nvme"))]
 use pcie::CommandRegister;
-#[cfg(virtio_dev)]
+#[cfg(any(virtio_dev, feature = "nvme"))]
 use rdrive::probe::pci::{Endpoint, EndpointRc};
 use rdrive::{
     PlatformDevice,
@@ -38,7 +38,7 @@ pub(crate) use fdt::fdt_irq_for_endpoint;
 pub use msi::{PciIrqLease, PciMsiTarget, PciMsixAllocation};
 
 const MAX_PCIE_LEGACY_IRQS: usize = 8;
-#[cfg(virtio_dev)]
+#[cfg(any(virtio_dev, feature = "nvme"))]
 const MAX_TAKEN_ENDPOINT_CONFIGS: usize = 16;
 
 fn raw_lock<T>(lock: &Mutex<T>) -> RawSpinLockGuard<'_, T> {
@@ -171,7 +171,7 @@ impl LegacyIrqRoute {
 
 static LEGACY_IRQ_ROUTES: Mutex<ArrayVec<LegacyIrqRoute, MAX_PCIE_LEGACY_IRQS>> =
     Mutex::new(ArrayVec::new());
-#[cfg(virtio_dev)]
+#[cfg(any(virtio_dev, feature = "nvme"))]
 static TAKEN_ENDPOINT_CONFIGS: Mutex<ArrayVec<TakenEndpointConfig, MAX_TAKEN_ENDPOINT_CONFIGS>> =
     Mutex::new(ArrayVec::new());
 
@@ -293,22 +293,20 @@ pub fn resolve_intx_irq(info: PciInfo) -> Result<Option<usize>, OnProbeError> {
 }
 
 pub fn prepare_intx_passthrough(info: PciInfo) -> Result<(), OnProbeError> {
-    #[cfg(virtio_dev)]
+    #[cfg(any(virtio_dev, feature = "nvme"))]
     {
         if info.interrupt_pin == 0 {
             return Err(OnProbeError::NotMatch);
         }
 
-        let bdf = as_device_function(info.address);
         let configs = raw_lock(&TAKEN_ENDPOINT_CONFIGS);
         let config = configs
             .iter()
-            .find(|config| config.bdf == bdf)
+            .find(|config| config.address == info.address)
             .ok_or(OnProbeError::NotMatch)?;
 
-        config
-            .access
-            .update_command(prepare_intx_passthrough_command);
+        config.disable_msix()?;
+        config.update_command(prepare_intx_passthrough_command);
         log::info!(
             "prepared PCI INTx passthrough endpoint {} with native config handoff",
             info.address
@@ -316,7 +314,7 @@ pub fn prepare_intx_passthrough(info: PciInfo) -> Result<(), OnProbeError> {
         Ok(())
     }
 
-    #[cfg(not(virtio_dev))]
+    #[cfg(not(any(virtio_dev, feature = "nvme")))]
     {
         let _ = info;
         Err(OnProbeError::Unsupported(
@@ -326,22 +324,19 @@ pub fn prepare_intx_passthrough(info: PciInfo) -> Result<(), OnProbeError> {
 }
 
 pub fn unmask_intx_passthrough(info: PciInfo) -> Result<(), OnProbeError> {
-    #[cfg(virtio_dev)]
+    #[cfg(any(virtio_dev, feature = "nvme"))]
     {
         if info.interrupt_pin == 0 {
             return Err(OnProbeError::NotMatch);
         }
 
-        let bdf = as_device_function(info.address);
         let configs = raw_lock(&TAKEN_ENDPOINT_CONFIGS);
         let config = configs
             .iter()
-            .find(|config| config.bdf == bdf)
+            .find(|config| config.address == info.address)
             .ok_or(OnProbeError::NotMatch)?;
 
-        config
-            .access
-            .update_command(unmask_intx_passthrough_command);
+        config.update_command(unmask_intx_passthrough_command);
         log::info!(
             "unmasked PCI INTx passthrough endpoint {} after guest route became ready",
             info.address
@@ -349,7 +344,7 @@ pub fn unmask_intx_passthrough(info: PciInfo) -> Result<(), OnProbeError> {
         Ok(())
     }
 
-    #[cfg(not(virtio_dev))]
+    #[cfg(not(any(virtio_dev, feature = "nvme")))]
     {
         let _ = info;
         Err(OnProbeError::Unsupported(
@@ -358,7 +353,55 @@ pub fn unmask_intx_passthrough(info: PciInfo) -> Result<(), OnProbeError> {
     }
 }
 
-#[cfg(any(test, virtio_dev))]
+/// Reads one aligned dword from a PCI endpoint retained for guest handoff.
+pub fn read_handoff_config_u32(address: PciAddress, offset: u16) -> Option<u32> {
+    #[cfg(any(virtio_dev, feature = "nvme"))]
+    {
+        if offset >= 256 || offset & 3 != 0 {
+            return None;
+        }
+        let configs = raw_lock(&TAKEN_ENDPOINT_CONFIGS);
+        let config = configs.iter().find(|config| config.address == address)?;
+        return Some(raw_lock(&config.endpoint).read(offset));
+    }
+
+    #[cfg(not(any(virtio_dev, feature = "nvme")))]
+    {
+        let _ = (address, offset);
+        None
+    }
+}
+
+/// Updates selected bytes in one aligned dword of a retained PCI endpoint.
+pub fn update_handoff_config_u32(
+    address: PciAddress,
+    offset: u16,
+    byte_mask: u32,
+    value: u32,
+) -> bool {
+    #[cfg(any(virtio_dev, feature = "nvme"))]
+    {
+        if offset >= 256 || offset & 3 != 0 {
+            return false;
+        }
+        let configs = raw_lock(&TAKEN_ENDPOINT_CONFIGS);
+        let Some(config) = configs.iter().find(|config| config.address == address) else {
+            return false;
+        };
+        let endpoint = raw_lock(&config.endpoint);
+        let old = endpoint.read(offset);
+        endpoint.write(offset, (old & !byte_mask) | (value & byte_mask));
+        true
+    }
+
+    #[cfg(not(any(virtio_dev, feature = "nvme")))]
+    {
+        let _ = (address, offset, byte_mask, value);
+        false
+    }
+}
+
+#[cfg(any(test, virtio_dev, feature = "nvme"))]
 fn prepare_intx_passthrough_command(mut command: CommandRegister) -> CommandRegister {
     command.insert(
         CommandRegister::IO_ENABLE
@@ -369,7 +412,7 @@ fn prepare_intx_passthrough_command(mut command: CommandRegister) -> CommandRegi
     command
 }
 
-#[cfg(any(test, virtio_dev))]
+#[cfg(any(test, virtio_dev, feature = "nvme"))]
 fn unmask_intx_passthrough_command(mut command: CommandRegister) -> CommandRegister {
     command.remove(CommandRegister::INTERRUPT_DISABLE);
     command
@@ -1132,7 +1175,6 @@ fn take_virtio_transport_with_intx_policy(
     enable_virtio_pci_command(endpoint);
 
     let config_access = EndpointConfigAccess::new(bdf, endpoint.take());
-    remember_taken_endpoint_config(&config_access);
 
     let mut root = PciRoot::new(config_access);
     PciTransport::new::<VirtIoHalImpl, _>(&mut root, bdf).map_err(|err| {
@@ -1142,26 +1184,53 @@ fn take_virtio_transport_with_intx_policy(
     })
 }
 
-#[cfg(virtio_dev)]
-fn remember_taken_endpoint_config(access: &EndpointConfigAccess) {
+#[cfg(any(virtio_dev, feature = "nvme"))]
+fn share_endpoint_for_handoff(endpoint: Endpoint) -> Arc<Mutex<Endpoint>> {
+    let address = endpoint.address();
+    let endpoint = Arc::new(Mutex::new(endpoint));
     let mut configs = raw_lock(&TAKEN_ENDPOINT_CONFIGS);
-    if let Some(config) = configs.iter_mut().find(|config| config.bdf == access.bdf) {
-        config.access = access.clone_for_handoff();
-        return;
+    if let Some(config) = configs.iter_mut().find(|config| config.address == address) {
+        config.endpoint = Arc::clone(&endpoint);
+        return endpoint;
     }
 
     if configs
         .push(TakenEndpointConfig {
-            bdf: access.bdf,
-            access: access.clone_for_handoff(),
+            address,
+            endpoint: Arc::clone(&endpoint),
         })
         .is_err()
     {
         log::warn!(
             "too many taken PCI endpoint configs; dropping passthrough handoff access for {}",
-            access.bdf
+            address
         );
     }
+    endpoint
+}
+
+#[cfg(feature = "nvme")]
+pub(crate) struct PciIntxEndpoint {
+    endpoint: Arc<Mutex<Endpoint>>,
+}
+
+#[cfg(feature = "nvme")]
+impl PciIntxEndpoint {
+    pub(crate) fn interrupt_status(&self) -> bool {
+        raw_lock(&self.endpoint).status().interrupt_status()
+    }
+}
+
+#[cfg(feature = "nvme")]
+pub(crate) fn take_intx_endpoint_for_handoff(endpoint: &mut EndpointRc) -> PciIntxEndpoint {
+    PciIntxEndpoint {
+        endpoint: share_endpoint_for_handoff(endpoint.take()),
+    }
+}
+
+#[cfg(feature = "nvme")]
+pub(crate) fn retain_endpoint_for_handoff(endpoint: &mut EndpointRc) {
+    let _ = share_endpoint_for_handoff(endpoint.take());
 }
 
 #[cfg(virtio_dev)]
@@ -1208,10 +1277,31 @@ fn as_device_function_info(endpoint: &Endpoint) -> DeviceFunctionInfo {
     }
 }
 
-#[cfg(virtio_dev)]
+#[cfg(any(virtio_dev, feature = "nvme"))]
 struct TakenEndpointConfig {
-    bdf: DeviceFunction,
-    access: EndpointConfigAccess,
+    address: PciAddress,
+    endpoint: Arc<Mutex<Endpoint>>,
+}
+
+#[cfg(any(virtio_dev, feature = "nvme"))]
+impl TakenEndpointConfig {
+    fn disable_msix(&self) -> Result<(), OnProbeError> {
+        let mut endpoint = raw_lock(&self.endpoint);
+        endpoint.set_msix_enabled(false).map_err(|error| {
+            OnProbeError::other(format!(
+                "failed to disable MSI-X for PCI INTx passthrough endpoint {}: {error}",
+                self.address
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn update_command<F>(&self, f: F)
+    where
+        F: FnOnce(CommandRegister) -> CommandRegister,
+    {
+        raw_lock(&self.endpoint).update_command(f);
+    }
 }
 
 #[cfg(virtio_dev)]
@@ -1225,25 +1315,12 @@ impl EndpointConfigAccess {
     fn new(bdf: DeviceFunction, endpoint: Endpoint) -> Self {
         Self {
             bdf,
-            endpoint: Arc::new(Mutex::new(endpoint)),
+            endpoint: share_endpoint_for_handoff(endpoint),
         }
     }
 
     fn assert_same_function(&self, device_function: DeviceFunction) {
         assert_eq!(device_function, self.bdf);
-    }
-
-    fn clone_for_handoff(&self) -> Self {
-        // SAFETY: EndpointConfigAccess serializes all shared config-space
-        // accesses through the same internal mutex.
-        unsafe { self.unsafe_clone() }
-    }
-
-    fn update_command<F>(&self, f: F)
-    where
-        F: FnOnce(CommandRegister) -> CommandRegister,
-    {
-        raw_lock(&self.endpoint).update_command(f);
     }
 }
 

--- a/os/axvisor/configs/vms/qemu/x86_64/linux-smp1.toml
+++ b/os/axvisor/configs/vms/qemu/x86_64/linux-smp1.toml
@@ -31,8 +31,8 @@ enable_bios = false
 # options avoid the previously observed timer calibration and early device
 # probing stalls without selecting VMX or SVM in the guest configuration. The
 # x86 direct-boot protocol limits this command line to 231 bytes, so omit the
-# non-essential rootfs `noload` and terminal `dumb` options instead.
-cmdline = "console=ttyS0 root=/dev/vda ro rootwait devtmpfs.mount=1 init=/sbin/getty pci=conf1 pci=nomsi irqpoll nox2apic tsc=unstable no_timer_check initcall_blacklist=ahci_pci_driver_init,i8042_init -- -n -l /bin/sh -L 115200 ttyS0"
+# non-essential devtmpfs mount, rootfs `noload`, and terminal `dumb` options.
+cmdline = "console=ttyS0 root=/dev/nvme0n1 rw rootwait init=/sbin/getty pci=conf1 pci=nomsi irqpoll nox2apic tsc=unstable no_timer_check initcall_blacklist=ahci_pci_driver_init,i8042_init -- -n -l /bin/sh -L 115200 ttyS0"
 
 ## The path of the disk image.
 

--- a/scripts/axbuild/src/axvisor/test/tests.rs
+++ b/scripts/axbuild/src/axvisor/test/tests.rs
@@ -975,16 +975,6 @@ fn nvme_smoke_keeps_storage_in_host_and_verifies_file_io() {
             "test-suit/axvisor/normal/qemu/build-loongarch64-unknown-none-softfloat.toml",
             "test-suit/axvisor/normal/qemu/smoke/qemu-loongarch64.toml",
         ),
-        (
-            "x86_64-svm",
-            "test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-svm.toml",
-            "test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-svm.toml",
-        ),
-        (
-            "x86_64-vmx",
-            "test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-vmx.toml",
-            "test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-vmx.toml",
-        ),
     ] {
         let build_content = fs::read_to_string(workspace_root.join(&build_path)).unwrap();
         let build: TestBuildConfigVmConfigs = toml::from_str(&build_content).unwrap();

--- a/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-svm.toml
+++ b/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-svm.toml
@@ -4,4 +4,4 @@ features = [
 ]
 log = "Info"
 target = "x86_64-unknown-none"
-vm_configs = []
+vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-vmx.toml
+++ b/test-suit/axvisor/normal/qemu/build-x86_64-unknown-none-vmx.toml
@@ -4,4 +4,4 @@ features = [
 ]
 log = "Info"
 target = "x86_64-unknown-none"
-vm_configs = []
+vm_configs = ["os/axvisor/configs/vms/qemu/x86_64/linux-smp1.toml"]

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-svm.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-svm.toml
@@ -31,18 +31,12 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)login incorrect",
   "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm):",
+  "failed to mask forwarded IOAPIC GSI .*: Busy",
 ]
 success_regex = [
-  "(?m)^AXVISOR_NVME_RW_PAYLOAD\\s*$",
-  "(?m)^AXVISOR_NVME_ROOTFS_RW_PASSED\\s*$",
+  "(?m)^AXVISOR_X86_NVME_GUEST_BOOT_PASSED\\s*$",
 ]
-shell_prefix = "axvisor:/$"
-shell_init_cmd = """
-echo AXVISOR_NVME_RW_PAYLOAD > /tmp/axvisor-nvme-rw
-cat /tmp/axvisor-nvme-rw
-rm -f /tmp/axvisor-nvme-rw
-echo AXVISOR_NVME_ROOTFS_RW_PASSED
-"""
+shell_prefix = "~ #"
+shell_init_cmd = "\u001b[1;1Rpwd && echo AXVISOR_X86_NVME_GUEST_BOOT_PASSED"
 to_bin = true
 uefi = true

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-vmx.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-vmx.toml
@@ -31,18 +31,12 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)login incorrect",
   "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm):",
+  "failed to mask forwarded IOAPIC GSI .*: Busy",
 ]
 success_regex = [
-  "(?m)^AXVISOR_NVME_RW_PAYLOAD\\s*$",
-  "(?m)^AXVISOR_NVME_ROOTFS_RW_PASSED\\s*$",
+  "(?m)^AXVISOR_X86_NVME_GUEST_BOOT_PASSED\\s*$",
 ]
-shell_prefix = "axvisor:/$"
-shell_init_cmd = """
-echo AXVISOR_NVME_RW_PAYLOAD > /tmp/axvisor-nvme-rw
-cat /tmp/axvisor-nvme-rw
-rm -f /tmp/axvisor-nvme-rw
-echo AXVISOR_NVME_ROOTFS_RW_PASSED
-"""
+shell_prefix = "~ #"
+shell_init_cmd = "\u001b[1;1Rpwd && echo AXVISOR_X86_NVME_GUEST_BOOT_PASSED"
 to_bin = true
 uefi = true

--- a/virtualization/axvm/Cargo.toml
+++ b/virtualization/axvm/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 
 [features]
 fs = ["ax-std/fs"]
-host-fs = ["ax-std/fs", "dep:ax-driver"]
+host-fs = ["ax-std/fs"]
 host-test = [
     "ax-std/host-test",
     "axdevice/host-test",
@@ -58,7 +58,7 @@ axvmconfig = { workspace = true, default-features = false }
 fdt-edit = { workspace = true }
 fdt-raw = { workspace = true }
 [target.'cfg(target_arch = "x86_64")'.dependencies]
-ax-driver = { workspace = true, optional = true, features = ["pci"] }
+ax-driver = { workspace = true, features = ["pci"] }
 x86 = "0.52"
 x86_vcpu = { workspace = true }
 x86_vlapic = { workspace = true }

--- a/virtualization/axvm/src/arch/x86_64/irq.rs
+++ b/virtualization/axvm/src/arch/x86_64/irq.rs
@@ -813,10 +813,18 @@ fn forward_passthrough_gsi(
         return false;
     };
     let ioapic = devices.services().require::<X86InterruptDomainKey>().ok();
-    let Some(guest_irq) = ioapic
-        .as_ref()
-        .and_then(|ioapic| ioapic.assert_gsi(guest_gsi))
-    else {
+    let Some(guest_irq) = ioapic.as_ref().and_then(|ioapic| {
+        if host_level_triggered {
+            ioapic.assert_gsi(guest_gsi)
+        } else {
+            ioapic
+                .vector_for_gsi(guest_gsi)
+                .map(|vector| x86_vlapic::IoApicInterrupt {
+                    vector,
+                    level_triggered: false,
+                })
+        }
+    }) else {
         if ioapic
             .as_ref()
             .is_some_and(|ioapic| ioapic.vector_for_gsi(guest_gsi).is_some())
@@ -922,10 +930,10 @@ fn ioapic_irq_forwarding_handler(
         return irq::IrqReturn::Unhandled;
     };
 
-    if !mask_forwarded_host_gsi(domain, gsi) {
+    let level_triggered = domain.is_forwarded_host_gsi_level_triggered(gsi);
+    if level_triggered && !mask_forwarded_host_gsi(domain, gsi) {
         return irq::IrqReturn::Unhandled;
     }
-    let level_triggered = domain.is_forwarded_host_gsi_level_triggered(gsi);
     domain.mark_forwarded_gsi_pending(gsi, level_triggered);
     irq::IrqReturn::Handled
 }

--- a/virtualization/axvm/src/arch/x86_64/pci_config.rs
+++ b/virtualization/axvm/src/arch/x86_64/pci_config.rs
@@ -1,8 +1,275 @@
 //! Device-graph factory for the x86 PCI configuration port window.
 
+use std::sync::Arc;
+
+use ax_driver::probe::pci::PciAddress;
+use ax_std::os::arceos::sync::IrqSafeMutex;
 use axdevice::*;
+use axdevice_base::*;
+
+const CONFIG_ADDRESS_ENABLE: u32 = 1 << 31;
+const CONFIG_ADDRESS_PORT: u16 = 0xcf8;
+const CONFIG_DATA_PORT: u16 = 0xcfc;
+const CONFIG_SPACE_SIZE: usize = 256;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct PciBdf {
+    bus: u8,
+    device: u8,
+    function: u8,
+}
+
+impl PciBdf {
+    const fn new(bus: u8, device: u8, function: u8) -> Self {
+        Self {
+            bus,
+            device,
+            function,
+        }
+    }
+}
+
+trait HostPciConfigAccess: Send + Sync {
+    fn read_aligned_u32(&self, address: PciBdf, offset: u16) -> Option<u32>;
+    fn update_aligned_u32(&self, address: PciBdf, offset: u16, byte_mask: u32, value: u32) -> bool;
+}
+
+struct CapturedEndpointConfig;
+
+impl HostPciConfigAccess for CapturedEndpointConfig {
+    fn read_aligned_u32(&self, address: PciBdf, offset: u16) -> Option<u32> {
+        ax_driver::pci::read_handoff_config_u32(
+            PciAddress::new(0, address.bus, address.device, address.function),
+            offset,
+        )
+    }
+
+    fn update_aligned_u32(&self, address: PciBdf, offset: u16, byte_mask: u32, value: u32) -> bool {
+        ax_driver::pci::update_handoff_config_u32(
+            PciAddress::new(0, address.bus, address.device, address.function),
+            offset,
+            byte_mask,
+            value,
+        )
+    }
+}
+
+struct PassthroughPciConfigState {
+    address: u32,
+}
+
+struct PassthroughPciConfigDevice {
+    endpoint: PciBdf,
+    backend: Arc<dyn HostPciConfigAccess>,
+    q35: X86PciConfigDevice,
+    state: IrqSafeMutex<PassthroughPciConfigState>,
+    resources: Box<[Resource]>,
+}
+
+impl PassthroughPciConfigDevice {
+    fn new(endpoint: PciBdf) -> Self {
+        Self::new_with_backend(endpoint, Arc::new(CapturedEndpointConfig))
+    }
+
+    fn new_with_backend(endpoint: PciBdf, backend: Arc<dyn HostPciConfigAccess>) -> Self {
+        Self {
+            endpoint,
+            backend,
+            q35: X86PciConfigDevice::new(),
+            state: IrqSafeMutex::new(PassthroughPciConfigState { address: 0 }),
+            resources: std::vec![Resource::PortRange {
+                base: CONFIG_ADDRESS_PORT,
+                size: 8,
+            }]
+            .into_boxed_slice(),
+        }
+    }
+
+    fn access_size(width: AccessWidth) -> DeviceResult<usize> {
+        match width {
+            AccessWidth::Byte | AccessWidth::Word | AccessWidth::Dword => Ok(width.size()),
+            AccessWidth::Qword => Err(DeviceError::Unsupported {
+                operation: "access passthrough PCI configuration ports",
+                detail: "PCI configuration mechanism #1 supports accesses up to 32 bits".into(),
+            }),
+        }
+    }
+
+    fn selection(address: u32, data_offset: usize, size: usize) -> Option<(PciBdf, u16)> {
+        if address & CONFIG_ADDRESS_ENABLE == 0 {
+            return None;
+        }
+        let register = (address as usize & 0xfc) + data_offset;
+        if register.checked_add(size)? > CONFIG_SPACE_SIZE {
+            return None;
+        }
+        Some((
+            PciBdf::new(
+                (address >> 16) as u8,
+                ((address >> 11) & 0x1f) as u8,
+                ((address >> 8) & 0x7) as u8,
+            ),
+            register as u16,
+        ))
+    }
+
+    const fn is_guest_owned_chipset(address: PciBdf) -> bool {
+        matches!(
+            (address.bus, address.device, address.function),
+            (0, 0, 0) | (0, 0x1f, 0)
+        )
+    }
+}
+
+impl Device for PassthroughPciConfigDevice {
+    fn name(&self) -> &str {
+        "x86-passthrough-pci-config"
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn access(
+        &self,
+        access: &BusAccess,
+        context: &mut dyn DeviceAccess,
+    ) -> DeviceResult<BusResponse> {
+        if access.kind != BusKind::Port {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        let size = Self::access_size(access.width)?;
+        let port = u16::try_from(access.addr)
+            .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
+        let mut state = self.state.lock();
+
+        if (CONFIG_ADDRESS_PORT..CONFIG_DATA_PORT).contains(&port) {
+            let offset = usize::from(port - CONFIG_ADDRESS_PORT);
+            if offset + size > 4 {
+                return Err(DeviceError::OutOfRange { addr: access.addr });
+            }
+            if access.is_read {
+                return Ok(BusResponse::Read {
+                    value: read_bytes(&state.address.to_le_bytes(), offset, size),
+                });
+            }
+            let mut address = state.address.to_le_bytes();
+            write_bytes(&mut address, offset, size, access.data);
+            state.address = u32::from_le_bytes(address);
+            self.q35.access(access, context)?;
+            return Ok(BusResponse::Write);
+        }
+
+        if !(CONFIG_DATA_PORT..CONFIG_DATA_PORT + 4).contains(&port) {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        let data_offset = usize::from(port - CONFIG_DATA_PORT);
+        if data_offset + size > 4 {
+            return Err(DeviceError::OutOfRange { addr: access.addr });
+        }
+        let Some((selected, register)) = Self::selection(state.address, data_offset, size) else {
+            return Ok(if access.is_read {
+                BusResponse::Read {
+                    value: all_ones(size),
+                }
+            } else {
+                BusResponse::Write
+            });
+        };
+        if Self::is_guest_owned_chipset(selected) {
+            return self.q35.access(access, context);
+        }
+        if selected != self.endpoint {
+            return Ok(if access.is_read {
+                BusResponse::Read {
+                    value: all_ones(size),
+                }
+            } else {
+                BusResponse::Write
+            });
+        }
+        let aligned_register = register & !3;
+        let byte_offset = usize::from(register & 3);
+        if access.is_read {
+            let value = self
+                .backend
+                .read_aligned_u32(selected, aligned_register)
+                .unwrap_or(u32::MAX);
+            Ok(BusResponse::Read {
+                value: read_bytes(&value.to_le_bytes(), byte_offset, size),
+            })
+        } else {
+            let mask = ((1_u64 << (size * 8)) - 1) as u32;
+            let byte_mask = mask << (byte_offset * 8);
+            let value = (access.data as u32 & mask) << (byte_offset * 8);
+            let _ = self
+                .backend
+                .update_aligned_u32(selected, aligned_register, byte_mask, value);
+            Ok(BusResponse::Write)
+        }
+    }
+}
+
+fn read_bytes(bytes: &[u8], offset: usize, size: usize) -> u64 {
+    bytes[offset..offset + size]
+        .iter()
+        .enumerate()
+        .fold(0, |value, (index, byte)| {
+            value | (u64::from(*byte) << (index * 8))
+        })
+}
+
+fn write_bytes(bytes: &mut [u8], offset: usize, size: usize, value: u64) {
+    for index in 0..size {
+        bytes[offset + index] = (value >> (index * 8)) as u8;
+    }
+}
+
+fn all_ones(size: usize) -> u64 {
+    u64::MAX >> ((8 - size) * 8)
+}
 
 pub(super) struct X86PciConfigModel;
+
+pub(super) struct X86PassthroughPciConfigModel {
+    endpoint: PciBdf,
+}
+
+impl X86PassthroughPciConfigModel {
+    pub(super) const fn new(bus: u8, device: u8, function: u8) -> Self {
+        Self {
+            endpoint: PciBdf::new(bus, device, function),
+        }
+    }
+}
+
+impl DeviceModel for X86PassthroughPciConfigModel {
+    fn requirements(&self) -> DeviceManagerResult<DeviceRequirements> {
+        DeviceRequirements::new().with_pio(
+            ResourceSlot::new("registers")?,
+            axdevice::X86PciConfigDevice::PORT_SIZE,
+            1,
+            ResourceRequest::Fixed(axdevice::X86PciConfigDevice::PORT_BASE),
+        )
+    }
+
+    fn build(&self, context: &mut DeviceBuildContext<'_>) -> DeviceManagerResult<DeviceBundle> {
+        let range = context.pio(&ResourceSlot::new("registers")?)?;
+        let expected = (
+            axdevice::X86PciConfigDevice::PORT_BASE,
+            axdevice::X86PciConfigDevice::PORT_SIZE,
+        );
+        if range != expected {
+            return Err(DeviceManagerError::InvalidConfig {
+                operation: "build x86 passthrough PCI configuration",
+                detail: "planned PCI configuration range must be 0xcf8..=0xcff".into(),
+            });
+        }
+        Ok(DeviceBundle::from_registration(DeviceRegistration::Device(
+            Arc::new(PassthroughPciConfigDevice::new(self.endpoint)),
+        )))
+    }
+}
 
 impl DeviceModel for X86PciConfigModel {
     fn requirements(&self) -> DeviceManagerResult<DeviceRequirements> {
@@ -29,5 +296,151 @@ impl DeviceModel for X86PciConfigModel {
         Ok(DeviceBundle::from_registration(DeviceRegistration::Device(
             std::sync::Arc::new(axdevice::X86PciConfigDevice::new()),
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use axdevice_base::{
+        AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceId,
+    };
+
+    use super::{HostPciConfigAccess, PassthroughPciConfigDevice, PciBdf};
+
+    #[derive(Default)]
+    struct FakeHostConfig {
+        reads: Mutex<Vec<(PciBdf, u16)>>,
+        writes: Mutex<Vec<(PciBdf, u16, u32)>>,
+    }
+
+    impl HostPciConfigAccess for FakeHostConfig {
+        fn read_aligned_u32(&self, address: PciBdf, offset: u16) -> Option<u32> {
+            self.reads.lock().unwrap().push((address, offset));
+            Some(0x4433_2211)
+        }
+
+        fn update_aligned_u32(
+            &self,
+            address: PciBdf,
+            offset: u16,
+            byte_mask: u32,
+            value: u32,
+        ) -> bool {
+            let old = 0x4433_2211;
+            let updated = (old & !byte_mask) | (value & byte_mask);
+            self.writes.lock().unwrap().push((address, offset, updated));
+            true
+        }
+    }
+
+    struct NoMemory;
+
+    impl DeviceAccess for NoMemory {
+        fn device_id(&self) -> DeviceId {
+            DeviceId::new(0)
+        }
+    }
+
+    fn write(device: &dyn Device, port: u16, width: AccessWidth, value: u64) {
+        device
+            .access(
+                &BusAccess {
+                    kind: BusKind::Port,
+                    is_read: false,
+                    addr: u64::from(port),
+                    width,
+                    data: value,
+                },
+                &mut NoMemory,
+            )
+            .unwrap();
+    }
+
+    fn read(device: &dyn Device, port: u16, width: AccessWidth) -> u64 {
+        match device
+            .access(
+                &BusAccess {
+                    kind: BusKind::Port,
+                    is_read: true,
+                    addr: u64::from(port),
+                    width,
+                    data: 0,
+                },
+                &mut NoMemory,
+            )
+            .unwrap()
+        {
+            BusResponse::Read { value } => value,
+            BusResponse::Write => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn passthrough_config_rejects_unassigned_non_chipset_bdfs_without_host_io() {
+        let host = Arc::new(FakeHostConfig::default());
+        let device =
+            PassthroughPciConfigDevice::new_with_backend(PciBdf::new(0, 3, 0), host.clone());
+
+        for selection in [0x8001_1800_u64, 0x8000_2000, 0x8000_1900] {
+            write(&device, 0xcf8, AccessWidth::Dword, selection);
+            assert_eq!(
+                read(&device, 0xcfc, AccessWidth::Dword),
+                u64::from(u32::MAX)
+            );
+            write(&device, 0xcfc, AccessWidth::Dword, 0xdead_beef);
+        }
+
+        assert!(host.reads.lock().unwrap().is_empty());
+        assert!(host.writes.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn passthrough_config_forwards_only_the_assigned_endpoint() {
+        let host = Arc::new(FakeHostConfig::default());
+        let endpoint = PciBdf::new(0, 3, 0);
+        let device = PassthroughPciConfigDevice::new_with_backend(endpoint, host.clone());
+
+        write(&device, 0xcf8, AccessWidth::Dword, 0x8000_1810);
+        assert_eq!(read(&device, 0xcfd, AccessWidth::Word), 0x3322);
+        write(&device, 0xcfe, AccessWidth::Byte, 0xaa);
+
+        assert_eq!(*host.reads.lock().unwrap(), [(endpoint, 0x10)]);
+        assert_eq!(
+            *host.writes.lock().unwrap(),
+            [(endpoint, 0x10, 0x44aa_2211)]
+        );
+    }
+
+    #[test]
+    fn passthrough_config_keeps_guest_owned_q35_lpc_pm_base() {
+        let host = Arc::new(FakeHostConfig::default());
+        let device =
+            PassthroughPciConfigDevice::new_with_backend(PciBdf::new(0, 3, 0), host.clone());
+
+        write(&device, 0xcf8, AccessWidth::Dword, 0x8000_f840);
+        write(&device, 0xcfc, AccessWidth::Dword, 0x601);
+        assert_eq!(read(&device, 0xcfc, AccessWidth::Dword), 0x601);
+
+        write(&device, 0xcf8, AccessWidth::Dword, 0x8000_f844);
+        write(&device, 0xcfc, AccessWidth::Byte, 0x80);
+        assert_eq!(read(&device, 0xcfc, AccessWidth::Byte), 0x80);
+
+        assert!(host.reads.lock().unwrap().is_empty());
+        assert!(host.writes.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn config_address_latch_is_guest_owned() {
+        let host = Arc::new(FakeHostConfig::default());
+        let device =
+            PassthroughPciConfigDevice::new_with_backend(PciBdf::new(0, 3, 0), host.clone());
+
+        write(&device, 0xcf8, AccessWidth::Dword, 0x8000_1810);
+
+        assert_eq!(read(&device, 0xcf8, AccessWidth::Dword), 0x8000_1810);
+        assert!(host.reads.lock().unwrap().is_empty());
+        assert!(host.writes.lock().unwrap().is_empty());
     }
 }

--- a/virtualization/axvm/src/arch/x86_64/vm.rs
+++ b/virtualization/axvm/src/arch/x86_64/vm.rs
@@ -116,15 +116,25 @@ fn plan_devices(
             std::sync::Arc::new(super::cmos::X86CmosModel::new(low_memory_size)),
         ),
         DeviceNodeSpec::virtual_device(
-            DeviceNodeId::new("pci-config")?,
-            std::sync::Arc::new(super::pci_config::X86PciConfigModel),
-        ),
-        DeviceNodeSpec::virtual_device(
             DeviceNodeId::new("acpi-pm-timer")?,
             std::sync::Arc::new(super::acpi_pm_timer::X86AcpiPmTimerModel),
         )
         .with_dependency(controller_id.clone()),
     ];
+    if config.address_space_policy() == axvm_types::AddressSpacePolicy::Passthrough {
+        let (device, function, ..) = crate::boot::x86_qemu_passthrough_block_intx();
+        nodes.push(DeviceNodeSpec::virtual_device(
+            DeviceNodeId::new("host-pci-config")?,
+            std::sync::Arc::new(super::pci_config::X86PassthroughPciConfigModel::new(
+                0, device, function,
+            )),
+        ));
+    } else {
+        nodes.push(DeviceNodeSpec::virtual_device(
+            DeviceNodeId::new("pci-config")?,
+            std::sync::Arc::new(super::pci_config::X86PciConfigModel),
+        ));
+    }
     for port in config.pass_through_ports() {
         let id = DeviceNodeId::new(std::format!("host-port-{:x}", port.base))?;
         nodes.push(DeviceNodeSpec::virtual_device(

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -220,11 +220,8 @@ pub(crate) fn register_qemu_block_passthrough_irq(vm: &crate::AxVMRef) -> AxVmRe
     let (_, _, _, guest_gsi) = crate::boot::x86_qemu_passthrough_block_intx();
     let info = qemu_block_passthrough_pci_info();
 
-    let route = match ax_driver::pci::resolve_intx_binding(info) {
-        Ok(Some(binding)) => {
-            let trigger = intx_forwarding_trigger(&binding);
-            resolve_binding_irq(binding).map(|host_irq| (host_irq, trigger))
-        }
+    let host_irq = match ax_driver::pci::resolve_intx_binding(info) {
+        Ok(Some(binding)) => resolve_qemu_nvme_host_irq(binding),
         Ok(None) => {
             warn!("x86 QEMU block passthrough PCI INTx route was not found for {info:?}");
             return Ok(());
@@ -235,10 +232,14 @@ pub(crate) fn register_qemu_block_passthrough_irq(vm: &crate::AxVMRef) -> AxVmRe
         }
     };
 
-    match route {
-        Ok((host_irq, trigger)) => {
+    match host_irq {
+        Ok(host_irq) => {
+            let host_delivery = crate::InterruptTriggerMode::EdgeTriggered;
             crate::register_x86_ioapic_irq_forwarding_route_with_trigger(
-                vm, guest_gsi, host_irq, trigger,
+                vm,
+                guest_gsi,
+                host_irq,
+                host_delivery,
             )?;
             crate::register_x86_ioapic_irq_forwarding_activator(
                 vm,
@@ -247,7 +248,7 @@ pub(crate) fn register_qemu_block_passthrough_irq(vm: &crate::AxVMRef) -> AxVmRe
             )?;
             info!(
                 "Registered x86 QEMU block passthrough PCI INTx forwarding route: guest GSI \
-                 {guest_gsi} <- host IRQ {host_irq:?}, trigger {trigger:?}"
+                 {guest_gsi} <- host IRQ {host_irq:?}, host delivery {host_delivery:?}"
             );
         }
         Err(error) => {
@@ -314,19 +315,22 @@ fn resolve_binding_irq(
 }
 
 #[cfg(all(feature = "host-fs", target_arch = "x86_64"))]
-fn intx_forwarding_trigger(binding: &ax_driver::BindingIrq) -> crate::InterruptTriggerMode {
+fn resolve_qemu_nvme_host_irq(
+    binding: ax_driver::BindingIrq,
+) -> Result<modules::ax_hal::irq::IrqId, modules::ax_hal::irq::IrqError> {
+    use ax_driver::{BindingIrq, BindingIrqSource};
+    use modules::ax_hal::irq::{self, AcpiIrqTrigger, IrqSource};
+
     match binding {
-        ax_driver::BindingIrq::Source(ax_driver::BindingIrqSource::AcpiGsiRoute(route)) => {
-            match route.trigger {
-                modules::ax_hal::irq::AcpiIrqTrigger::Edge => {
-                    crate::InterruptTriggerMode::EdgeTriggered
-                }
-                modules::ax_hal::irq::AcpiIrqTrigger::Level => {
-                    crate::InterruptTriggerMode::LevelTriggered
-                }
-            }
+        BindingIrq::Source(BindingIrqSource::AcpiGsiRoute(mut route)) => {
+            // QEMU's NVMe legacy fallback drives a short assert/deassert pulse.
+            // Program the host IOAPIC as edge-triggered so its Remote-IRR state
+            // cannot turn that pulse into a stuck level interrupt. The guest
+            // keeps the level-triggered PCI INTx route described by its ACPI.
+            route.trigger = AcpiIrqTrigger::Edge;
+            irq::resolve_irq_source(IrqSource::AcpiGsiRoute(route))
         }
-        _ => crate::InterruptTriggerMode::LevelTriggered,
+        binding => resolve_binding_irq(binding),
     }
 }
 


### PR DESCRIPTION
## 问题

x86_64 Axvisor 的 VMX/SVM smoke case 之前只验证 Axvisor Host 可以读写 NVMe rootfs，没有启动 Linux Guest，也没有覆盖 NVMe 设备交给 Guest 后的启动路径。

将外层 QEMU NVMe 交给 Guest 后还存在以下缺口：

- Guest 使用模拟 PCI 配置空间，无法枚举透传的 NVMe endpoint；
- Host NVMe 驱动初始化后没有保留 PCI endpoint，无法在交接阶段关闭 MSI-X并切换到 INTx；
- 没有 IOMMU 二级 DMA 翻译时，Guest DMA 地址与 Host 物理地址不一致；
- QEMU NVMe legacy INTx 的短脉冲按 level IRQ 转发后，IOAPIC Remote-IRR/EOI 状态可能卡住，Linux 会停在 NVMe 初始化阶段。

## 修改内容

- VMX/SVM build 配置加载同一份 x86 Linux Guest 配置；
- Guest rootfs 改为 `/dev/nvme0n1`，并通过 `pci=nomsi` 使用 legacy INTx；
- 为 DMA 可用内存配置 `MAP_IDENTICAL`，保留独立的 x86 低地址启动区域；
- passthrough Guest 直接转发 PCI configuration mechanism 1 端口，普通 Guest 仍使用原有虚拟 PCI config model；
- Host NVMe probe 后保留共享 PCI endpoint，用于查询 INTx 状态及设备交接；
- 设备交给 Guest 前关闭 MSI-X，启用 memory space、bus master 和 legacy INTx；
- Guest IOAPIC 路由建立前保持 INTx masked，路由就绪后再解除屏蔽；
- 将 QEMU NVMe 的 Host INTx 按 edge/pulse 转发，避免错误进入 level IRQ 的 Remote-IRR/EOI 流程；
- x86 smoke 成功条件改为 Guest 出现 `~ #`，证明 Guest 已从 NVMe 挂载根文件系统并启动 init；
- 从原有“NVMe 保留给 Host”测试矩阵中移除 x86 VMX/SVM，其他架构保持原行为。

## 实现逻辑

启动初期，Axvisor Host 仍使用 NVMe 挂载自己的 rootfs。创建 Guest 后，Axvisor先同步并卸载 Host 文件系统，释放 Host block IRQ，再通过保存的 PCI endpoint 关闭 MSI-X并准备 legacy INTx。

Guest 使用 passthrough PCI 配置端口枚举外层 QEMU NVMe。DMA 内存采用 identity mapping，使 Guest 写入 NVMe queue 的地址可以直接作为 Host 物理地址使用。Guest IOAPIC route 就绪后，Axvisor解除 PCI INTx 屏蔽，并将 NVMe completion pulse 注入 Guest 配置的中断 vector。

当前设备生命周期仍是单向交接：

```text
Axvisor Host → 卸载 Host rootfs → NVMe 交给 Guest
```

本次不实现 Guest 停止后的 NVMe 回收、Host 驱动重新初始化及 rootfs 重新挂载。