### PR TITLE
fix(axvm): preserve console device poll wakeups

### DIFF
--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -245,11 +245,11 @@ impl ArchOps for Aarch64Arch {
         vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
         runtime: &crate::vm::VmRuntimeHandle,
     ) {
-        let observed_generation = runtime.notification_generation();
+        let wait_snapshot = runtime.vcpu_event_wait_snapshot();
         if !vm.running() {
             return;
         }
-        if runtime.device_poll_requested() {
+        if wait_snapshot.has_pending_event(runtime) {
             return;
         }
         match vcpu.get_arch_vcpu().has_pending_interrupt() {
@@ -285,9 +285,12 @@ impl ArchOps for Aarch64Arch {
             }
         }
 
-        runtime.wait_until(|| {
-            !vm.running() || runtime.notification_generation() != observed_generation
-        });
+        crate::vm::wait_for_vcpu_event_if_idle(
+            runtime,
+            &wait_snapshot,
+            || vm.running(),
+            |condition| runtime.wait_until(condition),
+        );
     }
 }
 

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -249,6 +249,9 @@ impl ArchOps for Aarch64Arch {
         if !vm.running() {
             return;
         }
+        if runtime.device_poll_requested() {
+            return;
+        }
         match vcpu.get_arch_vcpu().has_pending_interrupt() {
             Ok(true) => return,
             Ok(false) => {}

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -109,12 +109,30 @@ pub fn start_vm(vm_id: usize) -> AxVmResult {
 }
 
 /// Wake the primary vCPU of a VM.
+///
+/// Single-vCPU guests retain pending device work across the WFI boundary.
+/// SMP guests keep the legacy wake-only behavior until AxVM provides a
+/// per-vCPU wait queue that can target vCPU0.
 pub fn notify_vm(vm_id: usize) -> AxVmResult {
     let vm = vm_by_id(vm_id)?;
+    let vcpu_num = vm.vcpu_num();
     vm.with_runtime(|runtime| {
-        runtime.notify_device_poll();
+        notify_runtime_for_device_poll(runtime, vcpu_num);
         Ok(())
     })
+}
+
+fn notify_runtime_for_device_poll(runtime: &crate::vm::VmRuntimeHandle, vcpu_num: usize) {
+    if vcpu_num == 1 {
+        runtime.notify_device_poll();
+    } else {
+        // The runtime wait queue is shared by all vCPUs, so notify_one cannot
+        // target vCPU0. Keep the legacy wake semantics for SMP guests until a
+        // dedicated per-vCPU wake path is available; publishing the shared
+        // device-poll flag here could keep a secondary vCPU spinning while
+        // the primary vCPU remains asleep.
+        runtime.notify_one();
+    }
 }
 
 pub fn stop_vm(vm_id: usize) -> AxVmResult {
@@ -183,5 +201,25 @@ mod tests {
     fn missing_vm_is_reported_with_its_id() {
         let vm_id = usize::MAX;
         assert_eq!(missing_vm_error(vm_id), AxVmError::VmNotFound { vm_id });
+    }
+
+    #[test]
+    fn smp_notification_does_not_publish_a_shared_device_poll_request() {
+        let runtime = crate::vm::VmRuntimeHandle::new();
+        let observed_generation = runtime.notification_generation();
+
+        notify_runtime_for_device_poll(&runtime, 2);
+
+        assert!(!runtime.device_poll_requested());
+        assert_ne!(runtime.notification_generation(), observed_generation);
+    }
+
+    #[test]
+    fn single_vcpu_notification_publishes_a_device_poll_request() {
+        let runtime = crate::vm::VmRuntimeHandle::new();
+
+        notify_runtime_for_device_poll(&runtime, 1);
+
+        assert!(runtime.device_poll_requested());
     }
 }

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -110,13 +110,11 @@ pub fn start_vm(vm_id: usize) -> AxVmResult {
 
 /// Wake the primary vCPU of a VM.
 pub fn notify_vm(vm_id: usize) -> AxVmResult {
-    vm_by_id(vm_id)?;
-    notify_vm_with_wake(|| vcpus::notify_primary_vcpu(vm_id));
-    Ok(())
-}
-
-fn notify_vm_with_wake(wake_vcpu: impl FnOnce()) {
-    wake_vcpu();
+    let vm = vm_by_id(vm_id)?;
+    vm.with_runtime(|runtime| {
+        runtime.notify_device_poll();
+        Ok(())
+    })
 }
 
 pub fn stop_vm(vm_id: usize) -> AxVmResult {
@@ -163,8 +161,6 @@ const fn missing_vm_error(vm_id: usize) -> AxVmError {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::RefCell, vec::Vec};
-
     use super::*;
 
     #[test]
@@ -187,15 +183,5 @@ mod tests {
     fn missing_vm_is_reported_with_its_id() {
         let vm_id = usize::MAX;
         assert_eq!(missing_vm_error(vm_id), AxVmError::VmNotFound { vm_id });
-    }
-
-    #[test]
-    fn console_notification_does_not_poll_devices_from_the_host_input_task() {
-        let steps = RefCell::new(Vec::new());
-        notify_vm_with_wake(|| {
-            assert!(steps.borrow().is_empty());
-            steps.borrow_mut().push("wake");
-        });
-        assert_eq!(steps.into_inner(), ["wake"]);
     }
 }

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -482,8 +482,7 @@ fn vcpu_run() {
             // Host services only publish a request and wake this task. Polling
             // here avoids running virtual-device and VGIC callbacks in host
             // console context, where an idle guest may otherwise stall input.
-            let _ = runtime.take_device_poll_request();
-            poll_vm_devices(&vm);
+            let _ = poll_primary_vcpu_devices_with(&runtime, || poll_vm_devices(&vm));
         }
 
         match CurrentArch::run_vcpu(&vm, &vcpu) {
@@ -598,6 +597,12 @@ fn vcpu_run() {
     info!("VM[{}] VCpu[{}] exiting...", vm_id, vcpu_id);
 }
 
+fn poll_primary_vcpu_devices_with(runtime: &VmRuntimeHandle, poll_devices: impl FnOnce()) -> bool {
+    let consumed_request = runtime.take_device_poll_request();
+    poll_devices();
+    consumed_request
+}
+
 pub(super) fn poll_vm_devices(vm: &VMRef) {
     poll_vm_input_devices(vm);
     poll_vm_dma_devices(vm);
@@ -637,6 +642,86 @@ mod tests {
         assert!(!vcpu_start_is_ready(true, false));
         assert!(vcpu_start_is_ready(true, true));
         assert!(!vcpu_start_is_ready(false, true));
+    }
+
+    #[test]
+    fn request_published_before_wfi_snapshot_prevents_sleep_and_is_consumed_once() {
+        let runtime = Arc::new(VmRuntimeHandle::new());
+        let request_published = Arc::new(std::sync::Barrier::new(2));
+        let notifier_runtime = runtime.clone();
+        let notifier_published = request_published.clone();
+        let notifier = std::thread::spawn(move || {
+            notifier_runtime.notify_device_poll();
+            notifier_published.wait();
+        });
+
+        request_published.wait();
+        let wait_snapshot = runtime.vcpu_event_wait_snapshot();
+        let wait_count = std::cell::Cell::new(0);
+        crate::vm::wait_for_vcpu_event_if_idle(
+            &runtime,
+            &wait_snapshot,
+            || true,
+            |_| wait_count.set(wait_count.get() + 1),
+        );
+
+        assert_eq!(wait_count.get(), 0);
+        let poll_count = std::cell::Cell::new(0);
+        let consumed = poll_primary_vcpu_devices_with(&runtime, || {
+            poll_count.set(poll_count.get() + 1);
+        });
+
+        assert!(consumed);
+        assert_eq!(poll_count.get(), 1);
+        assert!(!poll_primary_vcpu_devices_with(&runtime, || {
+            poll_count.set(poll_count.get() + 1);
+        }));
+        assert_eq!(poll_count.get(), 2);
+        notifier.join().unwrap();
+    }
+
+    #[test]
+    fn request_published_at_wait_boundary_prevents_sleep_and_is_consumed_once() {
+        let runtime = Arc::new(VmRuntimeHandle::new());
+        let wait_snapshot = runtime.vcpu_event_wait_snapshot();
+        let wait_boundary_reached = Arc::new(std::sync::Barrier::new(2));
+        let request_published = Arc::new(std::sync::Barrier::new(2));
+        let notifier_runtime = runtime.clone();
+        let notifier_wait_boundary = wait_boundary_reached.clone();
+        let notifier_published = request_published.clone();
+        let notifier = std::thread::spawn(move || {
+            notifier_wait_boundary.wait();
+            notifier_runtime.notify_device_poll();
+            notifier_published.wait();
+        });
+
+        let sleep_count = std::cell::Cell::new(0);
+        crate::vm::wait_for_vcpu_event_if_idle(
+            &runtime,
+            &wait_snapshot,
+            || true,
+            |wake_condition| {
+                wait_boundary_reached.wait();
+                request_published.wait();
+                if !wake_condition() {
+                    sleep_count.set(sleep_count.get() + 1);
+                }
+            },
+        );
+
+        assert_eq!(sleep_count.get(), 0);
+        let poll_count = std::cell::Cell::new(0);
+        let consumed = poll_primary_vcpu_devices_with(&runtime, || {
+            poll_count.set(poll_count.get() + 1);
+        });
+
+        assert!(consumed);
+        assert_eq!(poll_count.get(), 1);
+        assert!(!poll_primary_vcpu_devices_with(&runtime, || {
+            poll_count.set(poll_count.get() + 1);
+        }));
+        assert_eq!(poll_count.get(), 2);
+        notifier.join().unwrap();
     }
 
     #[test]

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -479,6 +479,10 @@ fn vcpu_run() {
 
     loop {
         if vcpu_id == 0 {
+            // Host services only publish a request and wake this task. Polling
+            // here avoids running virtual-device and VGIC callbacks in host
+            // console context, where an idle guest may otherwise stall input.
+            let _ = runtime.take_device_poll_request();
             poll_vm_devices(&vm);
         }
 

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -191,6 +191,25 @@ pub(crate) struct VmRuntimeHandle {
     deferred_reset_requested: AtomicBool,
 }
 
+#[cfg(any(target_arch = "aarch64", test))]
+pub(crate) struct VcpuEventWaitSnapshot {
+    notification_generation: usize,
+}
+
+#[cfg(any(target_arch = "aarch64", test))]
+pub(crate) fn wait_for_vcpu_event_if_idle(
+    runtime: &VmRuntimeHandle,
+    wait_snapshot: &VcpuEventWaitSnapshot,
+    vm_running: impl Fn() -> bool,
+    wait_until: impl FnOnce(&dyn Fn() -> bool),
+) {
+    let wake_condition = || !vm_running() || wait_snapshot.has_pending_event(runtime);
+    if wake_condition() {
+        return;
+    }
+    wait_until(&wake_condition);
+}
+
 pub(crate) fn dispatch_vcpu_interrupt_with(
     enqueue: impl FnOnce() -> AxVmResult<usize>,
     notify: impl FnOnce(),
@@ -378,6 +397,13 @@ impl VmRuntimeHandle {
         self.notification_generation.load(Ordering::Acquire)
     }
 
+    #[cfg(any(target_arch = "aarch64", test))]
+    pub(crate) fn vcpu_event_wait_snapshot(&self) -> VcpuEventWaitSnapshot {
+        VcpuEventWaitSnapshot {
+            notification_generation: self.notification_generation(),
+        }
+    }
+
     pub(crate) fn notify_one(&self) {
         self.notification_generation.fetch_add(1, Ordering::Release);
         self.wait_queue.notify_one(false);
@@ -488,6 +514,14 @@ impl VmRuntimeHandle {
         }
         info!("VM[{vm_id}] VCpu resources cleaned up, {task_count} VCpu tasks joined");
         self.take_lifecycle_error().map_or(Ok(()), Err)
+    }
+}
+
+#[cfg(any(target_arch = "aarch64", test))]
+impl VcpuEventWaitSnapshot {
+    pub(crate) fn has_pending_event(&self, runtime: &VmRuntimeHandle) -> bool {
+        runtime.device_poll_requested()
+            || runtime.notification_generation() != self.notification_generation
     }
 }
 
@@ -1964,19 +1998,6 @@ mod tests {
         runtime.notify_one();
 
         assert_ne!(runtime.notification_generation(), observed);
-    }
-
-    #[test]
-    fn device_poll_notification_survives_wake_generation_snapshot() {
-        let runtime = VmRuntimeHandle::new();
-        let observed = runtime.notification_generation();
-
-        runtime.notify_device_poll();
-
-        assert!(runtime.device_poll_requested());
-        assert_ne!(runtime.notification_generation(), observed);
-        assert!(runtime.take_device_poll_request());
-        assert!(!runtime.take_device_poll_request());
     }
 
     #[test]

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -185,6 +185,7 @@ pub(crate) struct VmRuntimeHandle {
     cpu_off_exit_reservations: StdMutex<BTreeSet<usize>>,
     pending_interrupts: Mutex<BTreeMap<usize, Vec<PendingInterrupt>>>,
     irq_dispatcher: crate::runtime::VcpuIrqDispatcher,
+    device_poll_requested: AtomicBool,
     running_halting_vcpu_count: AtomicUsize,
     lifecycle_error: StdMutex<Option<AxVmError>>,
     deferred_reset_requested: AtomicBool,
@@ -227,6 +228,7 @@ impl VmRuntimeHandle {
             cpu_off_exit_reservations: StdMutex::new(BTreeSet::new()),
             pending_interrupts: Mutex::new(BTreeMap::new()),
             irq_dispatcher: crate::runtime::VcpuIrqDispatcher::new(),
+            device_poll_requested: AtomicBool::new(false),
             running_halting_vcpu_count: AtomicUsize::new(0),
             lifecycle_error: StdMutex::new(None),
             deferred_reset_requested: AtomicBool::new(false),
@@ -384,6 +386,21 @@ impl VmRuntimeHandle {
     pub(crate) fn notify_all(&self) {
         self.notification_generation.fetch_add(1, Ordering::Release);
         self.wait_queue.notify_all(false);
+    }
+
+    /// Publishes pending device work before waking the primary vCPU.
+    pub(crate) fn notify_device_poll(&self) {
+        self.device_poll_requested.store(true, Ordering::Release);
+        self.notify_one();
+    }
+
+    #[cfg(any(target_arch = "aarch64", test))]
+    pub(crate) fn device_poll_requested(&self) -> bool {
+        self.device_poll_requested.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn take_device_poll_request(&self) -> bool {
+        self.device_poll_requested.swap(false, Ordering::AcqRel)
     }
 
     pub(crate) fn mark_vcpu_running(&self) {
@@ -1947,6 +1964,19 @@ mod tests {
         runtime.notify_one();
 
         assert_ne!(runtime.notification_generation(), observed);
+    }
+
+    #[test]
+    fn device_poll_notification_survives_wake_generation_snapshot() {
+        let runtime = VmRuntimeHandle::new();
+        let observed = runtime.notification_generation();
+
+        runtime.notify_device_poll();
+
+        assert!(runtime.device_poll_requested());
+        assert_ne!(runtime.notification_generation(), observed);
+        assert!(runtime.take_device_poll_request());
+        assert!(!runtime.take_device_poll_request());
     }
 
     #[test]


### PR DESCRIPTION
## 问题

宿主控制台将输入加入客户机虚拟串口队列后，会通知客户机主 vCPU。

此前的修复避免了在宿主控制台线程中同步执行虚拟设备和 VGIC 回调，但通知本身只唤醒 vCPU，没有持久记录“需要重新轮询设备”。

当控制台输入发生在以下窗口时：

1. 主 vCPU 已完成本轮设备轮询；
2. 客户机执行 WFI；
3. 设备轮询请求及通知已经发布；
4. vCPU 随后读取了更新后的通知代次并准备进入等待。

此时串口输入尚未经过设备轮询转换为虚拟中断，而普通通知代次已经被 WFI 快照吸收。vCPU 随后仍可能进入等待，导致：

- 客户机串口输入没有响应；
- 客户机不能及时从 WFI 中恢复；
- 后续控制台切换快捷键表现为无响应。

该问题具有时序相关性，不是每次启动都能复现。

## 修改

### 1. 持久记录设备轮询请求

在 `VmRuntimeHandle` 中增加 `device_poll_requested` 原子状态。

宿主输入通知按以下顺序执行：

1. 使用 Release 语义发布设备轮询请求；
2. 推进通知代次；
3. 唤醒主 vCPU。

这样即使普通唤醒发生在 WFI 等待窗口附近，设备工作请求也不会随着一次通知代次检查而丢失。

### 2. 在主 vCPU 上下文中消费请求

主 vCPU 在下一次进入客户机前消费设备轮询请求，并执行虚拟设备轮询。

虚拟 UART、VGIC 等回调继续由 vCPU 线程执行，不会退回到宿主控制台输入线程中同步执行。

### 3. 阻止 AArch64 vCPU 带着待处理设备请求进入 WFI

AArch64 WFI 等待路径通过统一的等待快照同时观察设备轮询请求和通知代次变化。

如果请求仍然存在，vCPU 不进入 WaitQueue，而是返回运行循环处理设备输入；在建立等待的最后边界也会重新检查同一唤醒条件。这覆盖了设备轮询结束到 WFI 建立等待之间的竞态窗口。

### 4. 增加确定性回归测试

测试使用线程与 Barrier 控制并验证两个交错：

- 设备请求先发布，WFI 随后取得通知快照；
- WFI 已取得通知快照，在真正进入等待的边界发布设备请求。

两个测试均断言 WFI 不会实际睡眠，并通过主 vCPU 生产 helper 验证设备请求第一次被消费、第二次不再消费。临时恢复只比较通知代次的旧等待判定时，第一个测试会稳定断言失败；恢复设备请求检查后通过。

## 验证

- `cargo fmt --all --check`
- `cargo test --manifest-path virtualization/axvm/Cargo.toml --all-features`
  - 255 个单元测试和 1 个集成测试通过
- `cargo xtask clippy --package axvm`
  - 6 组 feature 检查全部通过
- `cargo xtask sync-lint`
- AArch64 Axvisor release 构建通过
- AArch64 AxVisor QEMU smoke 通过
- Orange Pi 5 Plus / RK3588 单 Linux 客户机实机验证：
  - Linux 正常启动并挂载现有根文件系统；
  - 连续三轮重新连接客户机控制台；
  - 每轮空闲 60 秒后输入命令均立即响应；
  - 每轮 `Ctrl+X`、松开后按 `h` 均可返回 Axvisor Shell。

## 影响范围

修改仅涉及 AxVM 的控制台输入通知、vCPU 设备轮询和 AArch64 WFI 等待条件。

不修改：

- 客户机配置；
- 板级配置；
- Linux 或 ArceOS 镜像；
- 存储和设备直通策略；
- 控制台快捷键协议。
