### PR TITLE
fix(someboot)!: expose queryable secondary CPU startup

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -155,7 +155,7 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
 1. Discover enabled CPUs from firmware data and keep firmware IDs separate from logical CPU IDs.
 2. Bound-check CPU indices and avoid assuming hart/apic/mpidr/cpuid values are dense.
 3. Prepare one boot argument block per secondary CPU with stack, page table, kernel entry, typed per-CPU area, and logical ID.
-4. Flush boot arguments and page tables before `cpu_on`.
+4. Flush boot arguments and page tables before the architecture CPU-on transport.
 5. In the secondary path, initialize arch address windows, stack, page table state, the
    architecture CPU-local register contract, trap vectors, timer, and interrupt state before
    entering generic secondary code. Install the final `CpuAreaRef` while the CPU is offline, then
@@ -170,6 +170,14 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
    release before entering the OS. Keep this mutable state outside the copyable trampoline
    metadata and separate from the later scheduler-online publication. Do not replace it with a
    global last-CPU ID, an architecture-only completion, timeout retry, or scheduler-online flag.
+   Expose this lifecycle through the non-blocking, non-copyable
+   `start_secondary_cpu`/`status`/`release` handle: status observation must not release the CPU,
+   and only a matching alive handle may release it. Claim the single in-flight transport with a
+   non-blocking CAS. A dropped handle, upper-layer timeout, cancellation, or possibly partial
+   transport error must keep the owner claimed because a late x86 AP may still consume the shared
+   trampoline. Do not add cancellation, retry, fallback, or a someboot `Future`; a future upper
+   layer needs a real waker and terminal cancellation semantics. Keep the 10-second synchronous
+   polling policy in `axplat-dyn::PowerIf`, not in the someboot mechanism.
    On x86, encode SIPI as Linux `APIC_DM_STARTUP` (`0x600`); INIT level bits do not belong to SIPI.
    Keep this contract synchronized with `book/design/someboot-secondary-cpu-startup.md`.
 

--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -163,6 +163,15 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
    fallible state afterward.
 6. Before the OS per-CPU register is initialized on a secondary CPU, use cached controller fast paths for interrupt and timer setup through `somehal::irq::init_secondary_boot_irqs(cpu_id)`; do not take `rdrive`, IRQ-domain, or generic route locks from that window.
 7. Debug secondary failure with physical-address markers first; serial logging may not work until the secondary has its own mapping and trap state.
+8. Keep architecture wake transport separate from generic CPU bring-up synchronization. The
+   architecture hook only delivers PSCI/SBI/mailbox or INIT/SIPI; a shutdown-lifetime per-CPU
+   state owned by someboot publishes `DEAD -> KICKED -> ALIVE -> SHOULD_ONLINE`. The secondary
+   reports `ALIVE` after reaching the common someboot entry, then waits for the control CPU
+   release before entering the OS. Keep this mutable state outside the copyable trampoline
+   metadata and separate from the later scheduler-online publication. Do not replace it with a
+   global last-CPU ID, an architecture-only completion, timeout retry, or scheduler-online flag.
+   On x86, encode SIPI as Linux `APIC_DM_STARTUP` (`0x600`); INIT level bits do not belong to SIPI.
+   Keep this contract synchronized with `book/design/someboot-secondary-cpu-startup.md`.
 
 ## Validation Ladder
 

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -290,7 +290,7 @@ device-specific drivers.
 - Relocated symbols must be resolved relative to the running image. In the LoongArch SMP path, the secondary exception vector had to use a runtime symbol helper such as `sym_running_addr!(__exception_vectors)`, while the TLB refill entry needed the corresponding physical address.
 - A secondary CPU can fault before it has a working serial path. Put markers before and after DMW setup, stack switch, page table register setup, trap-vector setup, and jump to the common secondary entry.
 - Initialize trap vectors on every CPU, not only the boot CPU.
-- Flush or barrier boot arguments before `cpu_on`; otherwise secondaries can observe stale stack, page table, or per-CPU data.
+- Flush or barrier boot arguments before the architecture CPU-on transport; otherwise secondaries can observe stale stack, page table, or per-CPU data.
 - Keep logical CPU ID mapping separate from firmware CPU IDs. LoongArch CPU IDs in firmware data are not guaranteed to be dense array indices.
 - Compare ordering with local Linux architecture code when uncertain. For LoongArch, useful topics include DMW setup, CSR write ordering, TLB refill vector, exception entry, SMP boot argument handoff, and cache/TLB barriers.
 
@@ -348,7 +348,7 @@ Important details:
 | Immediate reset after MMU enable | wrong page table root, missing identity/current mapping, bad barrier/TLB flush, invalid jump target |
 | High-half fetch fault | kernel high map, relocation offset, symbol address basis, direct-map window |
 | TLB refill recursion | TLB refill vector address, stack mapping, refill handler mapping, CSR ordering |
-| Secondary CPU silent | per-CPU `KICKED/ALIVE/SHOULD_ONLINE` state, architecture wake delivery, `cpu_on` argument, cache flush, stack, per-CPU base, trap setup, logical CPU ID mapping; on x86 verify SIPI is `APIC_DM_STARTUP` (`0x600`) rather than INIT level encoding |
+| Secondary CPU silent | inspect the per-CPU `KICKED/ALIVE/SHOULD_ONLINE` state and the active startup handle first: `KICKED` means transport/common-entry progress is missing, while `ALIVE` means the control path has not called `release`; then check architecture wake delivery, CPU-on argument, cache flush, stack, per-CPU base, trap setup, and logical CPU ID mapping. A second `start_secondary_cpu` must return `StartupInProgress`, not spin. On x86 verify SIPI is `APIC_DM_STARTUP` (`0x600`) rather than INIT level encoding, and never clear the active owner after a dropped handle or timeout because a late AP may still use the shared trampoline. |
 | ArceOS works but Starry fails | rootfs staging, std/musl ABI, console/input feature, tty assumptions, CPR sizing |
 | Starry shell works but grouped tests fail | generated runner path, copied assets, success regex, `shell_init_cmd` versus `test_commands` |
 | AArch64 Axvisor stops at first dynamic MMIO read | missing `ax-cpu/arm-el2`, inactive EL1 page-table root, stale `TTBR0_EL2` boot table |

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -182,6 +182,11 @@ Use this order when auditing an early boot port:
 10. Runtime CPU areas and secondary boot stacks are dynamically allocated; every typed area is
     initialized once, frozen, and bound through the architecture CPU-local register contract.
 11. Secondary CPU release happens only after boot arguments and page tables are visible to other CPUs.
+12. The architecture hook ends after delivering its wake transport. The common someboot owner
+    publishes one per-CPU `KICKED` state before that hook, waits for the secondary to report
+    `ALIVE` at the common entry, and then releases exactly that CPU as `SHOULD_ONLINE`. Keep this
+    handshake outside immutable trampoline metadata and separate from the later OS scheduler,
+    IRQ, and timer online publication. See `book/design/someboot-secondary-cpu-startup.md`.
 
 ## RISC-V FDT SMP Notes
 
@@ -343,7 +348,7 @@ Important details:
 | Immediate reset after MMU enable | wrong page table root, missing identity/current mapping, bad barrier/TLB flush, invalid jump target |
 | High-half fetch fault | kernel high map, relocation offset, symbol address basis, direct-map window |
 | TLB refill recursion | TLB refill vector address, stack mapping, refill handler mapping, CSR ordering |
-| Secondary CPU silent | `cpu_on` argument, cache flush, stack, per-CPU base, trap setup, logical CPU ID mapping |
+| Secondary CPU silent | per-CPU `KICKED/ALIVE/SHOULD_ONLINE` state, architecture wake delivery, `cpu_on` argument, cache flush, stack, per-CPU base, trap setup, logical CPU ID mapping; on x86 verify SIPI is `APIC_DM_STARTUP` (`0x600`) rather than INIT level encoding |
 | ArceOS works but Starry fails | rootfs staging, std/musl ABI, console/input feature, tty assumptions, CPR sizing |
 | Starry shell works but grouped tests fail | generated runner path, copied assets, success regex, `shell_init_cmd` versus `test_commands` |
 | AArch64 Axvisor stops at first dynamic MMIO read | missing `ax-cpu/arm-el2`, inactive EL1 page-table root, stale `TTBR0_EL2` boot table |

--- a/book/design/someboot-secondary-cpu-startup.md
+++ b/book/design/someboot-secondary-cpu-startup.md
@@ -2,14 +2,11 @@
 
 ## 状态
 
-本文定义 someboot 启动 secondary CPU 时的平台层同步契约。它覆盖四种架构的共同生命周期、架构 transport 边界、per-CPU 存储、超时语义，以及它与 OS scheduler online 状态的关系。修改这些边界时必须同步更新本文和 `arch-platform-porting` skill。
+本文定义 someboot 启动 secondary CPU 时的平台层同步契约。它覆盖四种架构的共同生命周期、架构 transport 边界、per-CPU 存储、非阻塞查询接口，以及它与上层超时策略和 OS scheduler online 状态的关系。修改这些边界时必须同步更新本文和 `arch-platform-porting` skill。
 
 ## 问题与成功标准
 
-旧 x86 路径用一个全局 `AP_BOOTED_ID` 和私有启动锁确认 AP 到达架构入口，并在 500 ms 后超时。其他架构则只以 PSCI、SBI 或 mailbox 调用返回作为启动完成。这样产生了两个问题：
-
-1. “已发送硬件唤醒请求”和“目标 CPU 已进入可继续执行的 someboot 公共入口”没有统一状态语义。
-2. 全局 last-CPU ID 不能独立表达每个 logical CPU 的启动状态，并把 x86 transport 私有事实误当成通用启动完成。
+旧 x86 路径用一个全局 `AP_BOOTED_ID` 和私有启动锁确认 AP 到达架构入口，并在 500 ms 后超时。其他架构则只以 PSCI、SBI 或 mailbox 调用返回作为启动完成。统一 per-CPU 握手后，同步 `cpu_on()` 又把 prepare、transport、查询、10 秒超时和 release 固定在一次阻塞调用中，上层既不能轮询，也不能接入未来的真实异步唤醒源。
 
 本设计的成功标准是：
 
@@ -17,20 +14,24 @@
 - BSP 只能释放实际报告 `ALIVE` 的目标 CPU；
 - 四架构 hook 只发送 PSCI、SBI、mailbox 或 INIT/SIPI 请求；
 - secondary 在进入 OS runtime 前报告 `ALIVE`，并在 BSP 明确释放前等待；
-- 10 秒内未到达同步点时返回可匹配的 `CpuOnError::AliveTimeout`；
+- someboot 的公共接口只执行 `start/status/release`，不在启动请求内等待 AP；
+- 同一时间只有一个不可复制的 typed handle 拥有共享启动 transport；
+- `axplat-dyn` 保持同步 `PowerIf` 契约，在 10 秒内轮询并返回可匹配的 `CpuOnError::AliveTimeout`；
 - `PerCpuMeta` 继续保持不可变 trampoline ABI。
 
-非目标包括 CPU hotplug、启动 retry、fallback transport、scheduler online 发布、timer/clockevent 生命周期重构，以及 secondary 进入 OS 后的失败回滚。
+非目标包括 CPU hotplug、someboot `Future`、启动 cancel/retry、fallback transport、scheduler online 发布、timer/clockevent 生命周期重构，以及 secondary 进入 OS 后的失败回滚。
 
 ## Prior art
 
 设计对照本地 Linux v7.1 源码 commit `8cd9520d35a6c38db6567e97dd93b1f11f185dc6`：
 
 - `arch/x86/include/asm/apicdef.h` 将 `APIC_DM_STARTUP` 定义为 `0x00600`；SIPI 是 edge-triggered delivery，不携带 INIT 的 level-assert 位。
+- `kernel/cpu.c` 的 `cpu_up()` 对调用方仍表现为同步事务，但内部将 architecture kick、AP completion 和 CPU hotplug 状态推进分成不同阶段。
 - `arch/x86/kernel/smpboot.c` 将 INIT/SIPI 发送和 AP 后续启动阶段分开处理。
+- `arch/riscv/kernel/smpboot.c` 同样把 SBI hart start transport 与 generic secondary completion 分开。
 - `include/linux/cpuhotplug.h` 将 CPU bring-up 的 starting 阶段与最终 online 生命周期分开。
 
-TGOSKits 不复制 Linux hotplug 状态机。这里只复用两个成熟边界：架构代码负责 wake transport；平台到达启动同步点与 scheduler online 是不同事实。
+TGOSKits 不复制 Linux hotplug 状态机，也不照搬 Linux 的公开同步接口。这里只复用内部阶段化的成熟边界：架构代码负责 wake transport；平台到达启动同步点与 scheduler online 是不同事实；等待策略属于具有时间源的上层。
 
 ## 所有权与存储
 
@@ -48,21 +49,80 @@ DEAD --BSP prepare--> KICKED --secondary report--> ALIVE --BSP release--> SHOULD
 
 - `prepare_secondary_boot(cpu)` 以 AcqRel CAS 将该 CPU 从 `DEAD` 改为 `KICKED`。
 - secondary 到达公共 someboot entry 后，以 AcqRel CAS 将自身从 `KICKED` 改为 `ALIVE`。
-- BSP 只对目标 CPU 执行 `ALIVE -> SHOULD_ONLINE` CAS；其他 CPU 报告 alive 不会满足该等待。
+- BSP 以 Acquire 查询目标 CPU；查询 `ALIVE` 不执行任何状态转换。
+- BSP 只对目标 CPU 执行 `ALIVE -> SHOULD_ONLINE` CAS；其他 CPU 报告 alive 不会满足该 release。
 - secondary 以 Acquire 读取 `SHOULD_ONLINE`，观察到后才调用 `__someboot_secondary`。
 - 重复 prepare、未 kick 就报告 alive、重复 release 都是状态不变量错误，不隐式 retry 或重置状态。
 
-## 启动顺序
+## 公共接口与启动顺序
 
-BSP 对 secondary CPU 逐个执行：
+someboot 用不可复制、不可构造且带 `#[must_use]` 的 `SecondaryCpuStartup` 表示唯一 in-flight 启动：
 
-1. 解析 logical CPU 对应的 immutable `PerCpuMeta`。
-2. 清理启动映像所需 cache，并将该 CPU 标记为 `KICKED`。
-3. 调用 `ArchTrait::kick_secondary_cpu` 发送架构 transport。
-4. 轮询目标 CPU 的 `ALIVE`，最多等待 10 秒。
-5. CAS 为 `SHOULD_ONLINE`，允许该 CPU 进入 OS runtime。
+```rust
+pub fn start_secondary_cpu(
+    logical_cpu: usize,
+) -> Result<SecondaryCpuStartup, CpuOnError>;
+
+pub enum SecondaryCpuStartupStatus {
+    WaitingForAlive,
+    Alive,
+}
+
+impl SecondaryCpuStartup {
+    pub fn logical_cpu(&self) -> usize;
+    pub fn hardware_id(&self) -> usize;
+    pub fn status(&self) -> SecondaryCpuStartupStatus;
+    pub fn release(self) -> Result<(), CpuOnError>;
+}
+```
+
+`start_secondary_cpu()` 对目标 CPU 依次执行：
+
+1. 以 CAS 获取全局 `ACTIVE_SECONDARY_CPU`；已有启动时立即返回 `StartupInProgress`，不等待锁。
+2. 解析 logical CPU 对应的 immutable `PerCpuMeta`；无效目标在 transport 开始前安全归还 owner。
+3. 清理启动映像所需 cache，并将该 CPU 标记为 `KICKED`。
+4. 调用 `ArchTrait::kick_secondary_cpu` 发送架构 transport。
+5. 返回拥有 logical CPU 和 hardware ID 的 handle，不等待 `ALIVE`。
+
+handle 的操作严格分离观察和修改：
+
+- `status()` 只以 Acquire 读取目标 `CpuBootSync`，将 `KICKED` 映射为 `WaitingForAlive`、`ALIVE` 映射为 `Alive`，没有 CAS 或隐式 release。
+- `release(self)` 只在目标为 `ALIVE` 时执行 `ALIVE -> SHOULD_ONLINE` CAS；CAS 成功后才清除 `ACTIVE_SECONDARY_CPU`。consume handle 防止同一次启动被重复释放。
+- 非 `ALIVE` release 返回 `CpuOnError::NotAlive`，不会清除 owner。
+
+`axplat-dyn::PowerIf::cpu_boot()` 保持已有同步接口，在具有稳定 somehal timer 的层次执行：
+
+1. 调用 `start_secondary_cpu()`；
+2. 轮询 `status()`，看到 `Alive` 后调用 `release()`；
+3. 10 秒内未到达 `Alive` 则返回带 logical CPU 和 hardware ID 的 `AliveTimeout`。
+
+因此“非阻塞”只表示 someboot 不等待 AP `ALIVE`。x86 INIT/SIPI 规范要求的短延迟和 IPI delivery 检查仍是一次 transport 调用的组成部分，不能移到无状态查询中。
 
 secondary 的公共路径先完成架构 `per_cpu_trap_init(false)` 并解析自身 metadata，然后报告 `ALIVE`、等待 release，最后调用 `__someboot_secondary`。因此 `ALIVE` 证明目标 CPU 已到达 final stack/page-table/common-entry 边界；它不证明 scheduler、runtime IRQ、task queue 或其他 OS per-CPU 服务已经 online。
+
+## 串行化与放弃语义
+
+四架构共用一致的单 in-flight 契约。即使 PSCI 或 SBI 平台可能支持并行启动，x86 共享 `0x8000` trampoline 和 boot parameters 在整个 prepare/kick/alive/release 生命周期中都不能被下一个目标覆盖；公共接口不暴露依赖架构的并发差异。
+
+以下情况都不会清除 `ACTIVE_SECONDARY_CPU`：
+
+- 未完成 handle 被丢弃；
+- 包装 handle 的异步任务被取消；
+- 上层等待超时；
+- architecture transport 返回可能发生在部分发送之后的错误；
+- 在目标尚未 `ALIVE` 时错误调用 `release()`。
+
+这些情况都不能证明目标 CPU 没有开始执行。开放下一个 trampoline 会让迟到 AP 读取被覆盖的 metadata，因此本次启动被视为本次 boot 的终止性失败，不提供 cancel、retry 或 fallback。只有在 architecture transport 开始前的 metadata/状态 prepare 失败，才能安全回收 owner。
+
+## 为什么 someboot 不提供 `Future`
+
+someboot 运行在 executor、task runtime 和可靠 timer/waker 建立之前。把轮询简单包装成 `Future` 不会产生真实唤醒源，只会把 busy polling 隐藏成伪异步，并让 cancellation 语义不明确。
+
+未来具有 timer 和硬件事件唤醒能力的上层可以基于 `SecondaryCpuStartup` 自行包装异步等待，但必须同时满足：
+
+- `ALIVE` 状态变化能触发真实 waker；
+- cancellation 被当作终止性启动失败，不能隐式释放或复用 transport；
+- 最终仍由唯一 handle 显式执行 `release()`。
 
 ## 架构边界
 
@@ -73,7 +133,7 @@ secondary 的公共路径先完成架构 `per_cpu_trap_init(false)` 并解析自
 - LoongArch：boot argument mailbox 和 boot IPI；
 - x86_64：共享 trampoline 准备、INIT assert/deassert 和两次 SIPI。
 
-x86 SIPI 使用 `0x600 | vector`。x86 不再维护 `AP_BOOTED_ID`、架构私有启动锁或 500 ms AP 轮询。通用 `CPU_BOOT_LOCK` 串行化完整 prepare/kick/wait/release 流程，也保护 x86 共享 trampoline 在前一个 AP 到达公共入口前不被覆盖。
+x86 SIPI 使用 `0x600 | vector`。x86 不再维护 `AP_BOOTED_ID`、架构私有启动锁或 500 ms AP 轮询。通用 `ACTIVE_SECONDARY_CPU` 以非阻塞 CAS 串行化完整 prepare/kick/alive/release 生命周期，也保护 x86 共享 trampoline 在前一个 AP 被显式 release 前不被覆盖。
 
 ## 平台 alive 与 scheduler online
 
@@ -82,13 +142,13 @@ x86 SIPI 使用 `0x600 | vector`。x86 不再维护 `AP_BOOTED_ID`、架构私�
 - someboot `ALIVE/SHOULD_ONLINE` 只属于启动 handoff，回答“该 CPU 是否到达平台同步点，以及 BSP 是否允许它进入 OS”。
 - OS/runtime scheduler online 回答“该 CPU 的 scheduler、IRQ、timer 和运行时服务是否已经完成发布，可否接收普通工作”。
 
-someboot 不读取 scheduler online 来完成启动握手，OS 也不把 `SHOULD_ONLINE` 当作最终 online publication。这样避免循环依赖：OS online 初始化必须先获得 someboot release 才能执行，而 someboot release 不能反过来等待 OS online。
+someboot 不读取 scheduler online 来完成启动握手，OS 也不把 `SHOULD_ONLINE` 当作最终 online publication。`axruntime` 的 `ENTERED_CPUS` 等待继续保留：它证明 CPU 已进入 OS runtime，而不是重复 someboot 的 platform-alive 状态。这样避免循环依赖：OS online 初始化必须先获得 someboot release 才能执行，而 someboot release 不能反过来等待 OS online。
 
 ## 失败与兼容性
 
-`CpuOnError::AliveTimeout` 携带 logical CPU 和 hardware ID。超时上限固定为 10 秒，不执行 retry、备用 transport 或假成功。transport 自身错误继续由架构 hook 映射为 `NotSupported`、`AlreadyOn`、`InvalidParameters` 或带上下文的 `Other`。
+`CpuOnError::StartupInProgress` 同时携带 requested 和 active logical CPU；`NotAlive` 与 `AliveTimeout` 携带 logical CPU 和 hardware ID。超时上限固定为 10 秒，但策略由 `axplat-dyn` 执行；someboot 只保留可供上层匹配的 typed error。任何失败都不执行 retry、备用 transport 或假成功。transport 自身错误继续由架构 hook 映射为 `NotSupported`、`AlreadyOn`、`InvalidParameters` 或带上下文的 `Other`。
 
-这是 someboot 内部架构 trait 的破坏性重命名，但四个实现和唯一调用方在同一变更中迁移；没有外部稳定 ABI。`PerCpuMeta` 的布局和含义保持不变。
+这是 someboot/somehal 公共 Rust API 的 breaking change：同步 `cpu_on()` 被 `start_secondary_cpu()` 和 typed handle 替代。`ax-plat::PowerIf` 保持同步，唯一动态平台调用方在同一变更中迁移。`PerCpuMeta` 的布局和含义保持不变。
 
 ## 方案比较
 
@@ -97,13 +157,16 @@ someboot 不读取 scheduler online 来完成启动握手，OS 也不把 `SHOULD
 | 保留各架构私有完成信号 | 拒绝；四架构对“启动完成”的语义继续不同，x86 全局状态仍是额外 owner。 |
 | 把状态加入 `PerCpuMeta` | 拒绝；会混合 immutable trampoline ABI 与 mutable synchronization。 |
 | 等待 OS scheduler online | 拒绝；会让平台 release 与 OS 初始化形成循环依赖。 |
+| someboot 直接返回 `Future` | 拒绝；早期启动没有 executor/waker，无法提供真实异步进展和安全 cancellation。 |
+| someboot 同步等待 10 秒 | 拒绝；把查询机制、时间策略和阻塞行为绑定在最低层，无法供轮询或未来异步上层复用。 |
 | 超时后 retry 或 fallback | 拒绝；可能对已运行但尚未报告的 CPU 重复 kick，并掩盖真实 bring-up 失败。 |
-| someboot 独立 `CpuBootSync` | 采用；状态按 CPU 隔离，transport 和 lifecycle 边界清楚，并可在最低层确定性测试。 |
+| 非阻塞 typed handle + 独立 `CpuBootSync` | 采用；状态按 CPU 隔离，查询无副作用，transport 和等待策略边界清楚，并可在最低层确定性测试。 |
 
 ## 验证
 
 - x86 单元测试验证 SIPI base 为 `0x600` 且不含 level-assert 位；旧 `0x4600` 必然失败。
-- 状态机单元测试验证只有报告 `ALIVE` 的同一 `CpuBootSync` 可以 release，并覆盖非法顺序和未发布 CPU。
+- 状态机单元测试验证查询 `ALIVE` 不会 release，只有报告 `ALIVE` 的同一 `CpuBootSync` 可以 release，并覆盖非法顺序和未发布 CPU。
+- owner 单元测试验证第二次 start 立即失败、错误 CPU 不能释放 owner、只有显式匹配 release 后下一个 CPU 才能获取 transport。
 - `cargo test -p someboot` 覆盖状态、layout 和现有启动契约。
-- `cargo xtask clippy --package someboot` 覆盖 crate 的 feature 组合。
-- 四架构 ArceOS `task-smp-online` QEMU 用例验证实际 secondary handoff。
+- `cargo xtask clippy --package someboot --package axplat-dyn` 覆盖修改 crate 的 feature 组合。
+- 四架构 ArceOS `task-smp-online` QEMU 用例验证实际 secondary handoff，以及 someboot alive 与 runtime entered 两个状态源都能推进。

--- a/book/design/someboot-secondary-cpu-startup.md
+++ b/book/design/someboot-secondary-cpu-startup.md
@@ -1,0 +1,109 @@
+# someboot secondary CPU 启动握手
+
+## 状态
+
+本文定义 someboot 启动 secondary CPU 时的平台层同步契约。它覆盖四种架构的共同生命周期、架构 transport 边界、per-CPU 存储、超时语义，以及它与 OS scheduler online 状态的关系。修改这些边界时必须同步更新本文和 `arch-platform-porting` skill。
+
+## 问题与成功标准
+
+旧 x86 路径用一个全局 `AP_BOOTED_ID` 和私有启动锁确认 AP 到达架构入口，并在 500 ms 后超时。其他架构则只以 PSCI、SBI 或 mailbox 调用返回作为启动完成。这样产生了两个问题：
+
+1. “已发送硬件唤醒请求”和“目标 CPU 已进入可继续执行的 someboot 公共入口”没有统一状态语义。
+2. 全局 last-CPU ID 不能独立表达每个 logical CPU 的启动状态，并把 x86 transport 私有事实误当成通用启动完成。
+
+本设计的成功标准是：
+
+- 每个 logical CPU 都有独立的 `DEAD -> KICKED -> ALIVE -> SHOULD_ONLINE` 状态；
+- BSP 只能释放实际报告 `ALIVE` 的目标 CPU；
+- 四架构 hook 只发送 PSCI、SBI、mailbox 或 INIT/SIPI 请求；
+- secondary 在进入 OS runtime 前报告 `ALIVE`，并在 BSP 明确释放前等待；
+- 10 秒内未到达同步点时返回可匹配的 `CpuOnError::AliveTimeout`；
+- `PerCpuMeta` 继续保持不可变 trampoline ABI。
+
+非目标包括 CPU hotplug、启动 retry、fallback transport、scheduler online 发布、timer/clockevent 生命周期重构，以及 secondary 进入 OS 后的失败回滚。
+
+## Prior art
+
+设计对照本地 Linux v7.1 源码 commit `8cd9520d35a6c38db6567e97dd93b1f11f185dc6`：
+
+- `arch/x86/include/asm/apicdef.h` 将 `APIC_DM_STARTUP` 定义为 `0x00600`；SIPI 是 edge-triggered delivery，不携带 INIT 的 level-assert 位。
+- `arch/x86/kernel/smpboot.c` 将 INIT/SIPI 发送和 AP 后续启动阶段分开处理。
+- `include/linux/cpuhotplug.h` 将 CPU bring-up 的 starting 阶段与最终 online 生命周期分开。
+
+TGOSKits 不复制 Linux hotplug 状态机。这里只复用两个成熟边界：架构代码负责 wake transport；平台到达启动同步点与 scheduler online 是不同事实。
+
+## 所有权与存储
+
+someboot 是启动握手的唯一 owner。`CpuBootSync` 由 someboot 在每个 CPU area 中单独分配并原位构造，地址在关机前保持稳定。`CPU_AREA_RUNTIME_COUNT` 的 Release 发布发生在全部 `CpuBootSync` 和 `PerCpuMeta` 构造及 cache maintenance 完成之后；读取方通过 Acquire 观察发布。
+
+`CpuBootSync` 不放进 `PerCpuMeta`。后者由 trampoline 和架构入口按值读取，发布后只包含 stack、hardware ID、logical index、entry 和 page-table 地址。将原子状态塞进该结构会把不可变启动 ABI 与运行时可变同步混在一起。
+
+## 状态机
+
+每个 CPU 的状态只能按以下顺序推进：
+
+```text
+DEAD --BSP prepare--> KICKED --secondary report--> ALIVE --BSP release--> SHOULD_ONLINE
+```
+
+- `prepare_secondary_boot(cpu)` 以 AcqRel CAS 将该 CPU 从 `DEAD` 改为 `KICKED`。
+- secondary 到达公共 someboot entry 后，以 AcqRel CAS 将自身从 `KICKED` 改为 `ALIVE`。
+- BSP 只对目标 CPU 执行 `ALIVE -> SHOULD_ONLINE` CAS；其他 CPU 报告 alive 不会满足该等待。
+- secondary 以 Acquire 读取 `SHOULD_ONLINE`，观察到后才调用 `__someboot_secondary`。
+- 重复 prepare、未 kick 就报告 alive、重复 release 都是状态不变量错误，不隐式 retry 或重置状态。
+
+## 启动顺序
+
+BSP 对 secondary CPU 逐个执行：
+
+1. 解析 logical CPU 对应的 immutable `PerCpuMeta`。
+2. 清理启动映像所需 cache，并将该 CPU 标记为 `KICKED`。
+3. 调用 `ArchTrait::kick_secondary_cpu` 发送架构 transport。
+4. 轮询目标 CPU 的 `ALIVE`，最多等待 10 秒。
+5. CAS 为 `SHOULD_ONLINE`，允许该 CPU 进入 OS runtime。
+
+secondary 的公共路径先完成架构 `per_cpu_trap_init(false)` 并解析自身 metadata，然后报告 `ALIVE`、等待 release，最后调用 `__someboot_secondary`。因此 `ALIVE` 证明目标 CPU 已到达 final stack/page-table/common-entry 边界；它不证明 scheduler、runtime IRQ、task queue 或其他 OS per-CPU 服务已经 online。
+
+## 架构边界
+
+`ArchTrait::kick_secondary_cpu` 只负责 transport：
+
+- AArch64：PSCI `CPU_ON`；
+- RISC-V：SBI HSM `hart_start`；
+- LoongArch：boot argument mailbox 和 boot IPI；
+- x86_64：共享 trampoline 准备、INIT assert/deassert 和两次 SIPI。
+
+x86 SIPI 使用 `0x600 | vector`。x86 不再维护 `AP_BOOTED_ID`、架构私有启动锁或 500 ms AP 轮询。通用 `CPU_BOOT_LOCK` 串行化完整 prepare/kick/wait/release 流程，也保护 x86 共享 trampoline 在前一个 AP 到达公共入口前不被覆盖。
+
+## 平台 alive 与 scheduler online
+
+这两个状态源表达不同事实，不能合并：
+
+- someboot `ALIVE/SHOULD_ONLINE` 只属于启动 handoff，回答“该 CPU 是否到达平台同步点，以及 BSP 是否允许它进入 OS”。
+- OS/runtime scheduler online 回答“该 CPU 的 scheduler、IRQ、timer 和运行时服务是否已经完成发布，可否接收普通工作”。
+
+someboot 不读取 scheduler online 来完成启动握手，OS 也不把 `SHOULD_ONLINE` 当作最终 online publication。这样避免循环依赖：OS online 初始化必须先获得 someboot release 才能执行，而 someboot release 不能反过来等待 OS online。
+
+## 失败与兼容性
+
+`CpuOnError::AliveTimeout` 携带 logical CPU 和 hardware ID。超时上限固定为 10 秒，不执行 retry、备用 transport 或假成功。transport 自身错误继续由架构 hook 映射为 `NotSupported`、`AlreadyOn`、`InvalidParameters` 或带上下文的 `Other`。
+
+这是 someboot 内部架构 trait 的破坏性重命名，但四个实现和唯一调用方在同一变更中迁移；没有外部稳定 ABI。`PerCpuMeta` 的布局和含义保持不变。
+
+## 方案比较
+
+| 方案 | 结论 |
+| --- | --- |
+| 保留各架构私有完成信号 | 拒绝；四架构对“启动完成”的语义继续不同，x86 全局状态仍是额外 owner。 |
+| 把状态加入 `PerCpuMeta` | 拒绝；会混合 immutable trampoline ABI 与 mutable synchronization。 |
+| 等待 OS scheduler online | 拒绝；会让平台 release 与 OS 初始化形成循环依赖。 |
+| 超时后 retry 或 fallback | 拒绝；可能对已运行但尚未报告的 CPU 重复 kick，并掩盖真实 bring-up 失败。 |
+| someboot 独立 `CpuBootSync` | 采用；状态按 CPU 隔离，transport 和 lifecycle 边界清楚，并可在最低层确定性测试。 |
+
+## 验证
+
+- x86 单元测试验证 SIPI base 为 `0x600` 且不含 level-assert 位；旧 `0x4600` 必然失败。
+- 状态机单元测试验证只有报告 `ALIVE` 的同一 `CpuBootSync` 可以 release，并覆盖非法顺序和未发布 CPU。
+- `cargo test -p someboot` 覆盖状态、layout 和现有启动契约。
+- `cargo xtask clippy --package someboot` 覆盖 crate 的 feature 组合。
+- 四架构 ArceOS `task-smp-online` QEMU 用例验证实际 secondary handoff。

--- a/docs/docs/architecture/platform/contract.md
+++ b/docs/docs/architecture/platform/contract.md
@@ -45,7 +45,7 @@ pub use ax_plat_macros::secondary_main;
 | `ConsoleIf` | `console.rs` | `write_bytes`、`read_bytes`、`device_id`、`claim_runtime_output`，以及 `irq` feature 下的 IRQ 系列 |
 | `MemIf` | `mem.rs` | `phys_ram_ranges`、`reserved_phys_ram_ranges`、`mmio_ranges`、`phys_to_virt`、`virt_to_phys`、`kernel_aspace` |
 | `TimeIf` | `time.rs` | `current_ticks`、`ticks_to_nanos`、`nanos_to_ticks`、`epochoffset_nanos`，`irq` 下还有 `irq_num`/`set_oneshot_timer` |
-| `PowerIf` | `power.rs` | `system_off`、`system_reset`、`cpu_num`，`smp` 下 `cpu_boot(cpu_id, stack_top_paddr)` |
+| `PowerIf` | `power.rs` | `system_off`、`system_reset`、`cpu_num`，`smp` 下同步 `cpu_boot(cpu_id, stack_top_paddr)`；动态平台内部可轮询 someboot 的非阻塞启动 handle |
 | `IrqIf` | `irq.rs` | `set_enable`、`set_affinity`、`handle`、`send_ipi`、`ipi_irq`、`resolve_source`、`resolve_percpu` |
 | `LoongArchHvIrqIf` | `irq/loongarch64_hv.rs` | 虚拟中断注入 / guest IRQ 路由（仅 LoongArch hypervisor） |
 

--- a/docs/docs/architecture/platform/dynamic.md
+++ b/docs/docs/architecture/platform/dynamic.md
@@ -176,8 +176,16 @@ x86_64 上特别处理：当 IRQ 向量落在 PCI INTx 区间时，通过 `ax_pl
 fn cpu_num() -> usize { somehal::smp::cpu_meta_list().count() }
 fn system_off() -> !  { somehal::power::shutdown() }
 fn system_reset() -> !{ somehal::power::reset() }
-fn cpu_boot(cpu_id, stack_top_paddr) { somehal::power::cpu_on(cpu_id, stack_top_paddr) }
+fn cpu_boot(cpu_id, _stack_top_paddr) {
+    let startup = somehal::power::start_secondary_cpu(cpu_id).unwrap();
+    while startup.status() != SecondaryCpuStartupStatus::Alive {
+        // axplat-dyn uses the somehal timer to enforce a 10-second deadline.
+    }
+    startup.release().unwrap()
+}
 ```
+
+`PowerIf::cpu_boot()` 的公共契约保持同步；`axplat-dyn` 负责轮询和 10 秒超时策略。someboot 只提供非阻塞 `start/status/release` 机制，因此未来具有真实 timer/waker 的上层可以自行包装异步等待。`stack_top_paddr` 继续由动态平台忽略，因为 secondary stack 已在 someboot 发布的 immutable `PerCpuMeta` 中确定。
 
 ## generic_timer.rs — TimeIf 实现
 

--- a/platforms/axplat-dyn/src/power.rs
+++ b/platforms/axplat-dyn/src/power.rs
@@ -1,4 +1,12 @@
+#[cfg(feature = "smp")]
+use core::hint::spin_loop;
+
 use ax_plat::power::PowerIf;
+#[cfg(feature = "smp")]
+use somehal::power::{CpuOnError, SecondaryCpuStartupStatus};
+
+#[cfg(feature = "smp")]
+const CPU_ALIVE_TIMEOUT_SECONDS: usize = 10;
 
 struct PowerImpl;
 
@@ -11,7 +19,8 @@ impl PowerIf for PowerImpl {
     /// CPU cores on the platform).
     #[cfg(feature = "smp")]
     fn cpu_boot(cpu_id: usize, _stack_top_paddr: usize) {
-        somehal::power::cpu_on(cpu_id).unwrap();
+        start_secondary_cpu(cpu_id)
+            .unwrap_or_else(|error| panic!("failed to start logical CPU {cpu_id}: {error}"));
     }
 
     /// Shutdown the whole system.
@@ -27,5 +36,26 @@ impl PowerIf for PowerImpl {
     /// Get the number of CPU cores available on this platform.
     fn cpu_num() -> usize {
         somehal::smp::cpu_count()
+    }
+}
+
+#[cfg(feature = "smp")]
+fn start_secondary_cpu(cpu_id: usize) -> Result<(), CpuOnError> {
+    let startup = somehal::power::start_secondary_cpu(cpu_id)?;
+    let start = somehal::timer::ticks();
+    let timeout_ticks = somehal::timer::freq().saturating_mul(CPU_ALIVE_TIMEOUT_SECONDS);
+
+    loop {
+        match startup.status() {
+            SecondaryCpuStartupStatus::Alive => return startup.release(),
+            SecondaryCpuStartupStatus::WaitingForAlive => {}
+        }
+        if somehal::timer::ticks().wrapping_sub(start) >= timeout_ticks {
+            return Err(CpuOnError::AliveTimeout {
+                logical_cpu: startup.logical_cpu(),
+                hardware_id: startup.hardware_id(),
+            });
+        }
+        spin_loop();
     }
 }

--- a/platforms/someboot/CHANGELOG.md
+++ b/platforms/someboot/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** replace blocking `cpu_on()` with a non-blocking, typed
+  `start_secondary_cpu()`/`status()`/`release()` lifecycle, keeping transport ownership claimed
+  across dropped handles, timeouts, and possibly partial architecture errors.
+
 ## [0.3.8](https://github.com/rcore-os/tgoskits/compare/someboot-v0.3.7...someboot-v0.3.8) - 2026-08-09
 
 ### Fixed

--- a/platforms/someboot/src/arch/aarch64/mod.rs
+++ b/platforms/someboot/src/arch/aarch64/mod.rs
@@ -213,7 +213,11 @@ impl ArchTrait for Arch {
         elx::is_mmu_enabled()
     }
 
-    fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), crate::power::CpuOnError> {
+    fn kick_secondary_cpu(
+        hartid: usize,
+        entry: usize,
+        arg: usize,
+    ) -> Result<(), crate::power::CpuOnError> {
         power::cpu_on(hartid as _, entry as _, arg as _).map_err(|e| match e {
             smccc::psci::error::Error::NotSupported => crate::power::CpuOnError::NotSupported,
             smccc::psci::error::Error::InvalidParameters => {

--- a/platforms/someboot/src/arch/loongarch64/mod.rs
+++ b/platforms/someboot/src/arch/loongarch64/mod.rs
@@ -325,7 +325,7 @@ impl ArchTrait for Arch {
         crmd::read().pg()
     }
 
-    fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
+    fn kick_secondary_cpu(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
         power::cpu_on(hartid, entry, arg)
     }
 

--- a/platforms/someboot/src/arch/riscv64/mod.rs
+++ b/platforms/someboot/src/arch/riscv64/mod.rs
@@ -301,7 +301,7 @@ impl ArchTrait for Arch {
         _secondary_entry as *const ()
     }
 
-    fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
+    fn kick_secondary_cpu(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
         match sbi::hart_start(hartid, entry, arg) {
             Ok(()) => Ok(()),
             Err(sbi::HartStartError::AlreadyAvailable | sbi::HartStartError::AlreadyStarted) => {

--- a/platforms/someboot/src/arch/x86_64/entry.rs
+++ b/platforms/someboot/src/arch/x86_64/entry.rs
@@ -1,7 +1,7 @@
 use core::ffi::c_void;
 
 use super::head::_head;
-use crate::{entry::PrimaryCpuInitInfo, smp::PerCpuMeta};
+use crate::entry::PrimaryCpuInitInfo;
 
 unsafe extern "C" {
     fn __kernel_code_end();
@@ -44,8 +44,6 @@ pub(crate) fn mmu_entry() -> ! {
 }
 
 pub(crate) unsafe extern "C" fn _secondary_entry(arg: usize) -> ! {
-    let cpu_meta = unsafe { &*(crate::mem::phys_to_virt(arg) as *const PerCpuMeta) };
-    super::power::notify_ap_started(cpu_meta.cpu_id);
     crate::entry::secondary_entry(arg);
     loop {
         core::hint::spin_loop();

--- a/platforms/someboot/src/arch/x86_64/mod.rs
+++ b/platforms/someboot/src/arch/x86_64/mod.rs
@@ -138,8 +138,8 @@ impl ArchTrait for Arch {
         _secondary_entry as *const ()
     }
 
-    fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
-        power::cpu_on(hartid, entry, arg)
+    fn kick_secondary_cpu(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
+        power::kick_secondary_cpu(hartid, entry, arg)
     }
 
     fn systimer_enable() {

--- a/platforms/someboot/src/arch/x86_64/power.rs
+++ b/platforms/someboot/src/arch/x86_64/power.rs
@@ -1,8 +1,4 @@
-use core::{
-    arch::global_asm,
-    hint::spin_loop,
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
-};
+use core::{arch::global_asm, hint::spin_loop, sync::atomic::Ordering};
 
 use x86::msr::{
     IA32_APIC_BASE, IA32_X2APIC_APICID, IA32_X2APIC_ESR, IA32_X2APIC_ICR, rdmsr, wrmsr,
@@ -13,7 +9,6 @@ use crate::{mem::phys_to_virt, power::CpuOnError, smp::PerCpuMeta};
 pub const AP_TRAMPOLINE_PADDR: usize = 0x8000;
 const AP_TRAMPOLINE_VECTOR: u8 = (AP_TRAMPOLINE_PADDR >> 12) as u8;
 const AP_TRAMPOLINE_SIZE: usize = 0x1000;
-const AP_START_TIMEOUT_US: u64 = 500_000;
 
 const LAPIC_REG_ESR: u32 = 0x280;
 const LAPIC_REG_ICR_LOW: u32 = 0x300;
@@ -28,9 +23,6 @@ const ICR_INIT_DEASSERT: u32 = 0x0000_8500;
 // STARTUP IPI, matching Linux APIC_DM_STARTUP. Edge-triggered delivery does
 // not carry the level-assert bit used by INIT.
 const ICR_STARTUP_BASE: u32 = 0x0000_0600;
-
-static START_LOCK: AtomicBool = AtomicBool::new(false);
-static AP_BOOTED_ID: AtomicUsize = AtomicUsize::new(usize::MAX);
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ApicMode {
@@ -143,10 +135,6 @@ unsafe extern "C" {
     static __x86_ap_trampoline_entry: u8;
 }
 
-pub(crate) fn notify_ap_started(apic_id: usize) {
-    AP_BOOTED_ID.store(apic_id, Ordering::Release);
-}
-
 fn current_apic_id() -> usize {
     match current_apic_mode() {
         ApicMode::X2Apic => unsafe { rdmsr(IA32_X2APIC_APICID) as usize },
@@ -157,7 +145,11 @@ fn current_apic_id() -> usize {
     }
 }
 
-pub(crate) fn cpu_on(apic_id: usize, entry: usize, arg: usize) -> Result<(), CpuOnError> {
+pub(crate) fn kick_secondary_cpu(
+    apic_id: usize,
+    entry: usize,
+    arg: usize,
+) -> Result<(), CpuOnError> {
     if apic_id == current_apic_id() {
         return Err(CpuOnError::AlreadyOn);
     }
@@ -170,8 +162,6 @@ pub(crate) fn cpu_on(apic_id: usize, entry: usize, arg: usize) -> Result<(), Cpu
         )));
     }
 
-    let _guard = StartupGuard::lock();
-    AP_BOOTED_ID.store(usize::MAX, Ordering::Release);
     let entry_virt = crate::mem::__kimage_va(entry) as usize;
     prepare_trampoline(
         meta.boot_table_paddr as u64,
@@ -187,20 +177,7 @@ pub(crate) fn cpu_on(apic_id: usize, entry: usize, arg: usize) -> Result<(), Cpu
     send_ipi(apic_id, ICR_STARTUP_BASE | AP_TRAMPOLINE_VECTOR as u32)?;
     delay_us(200);
     send_ipi(apic_id, ICR_STARTUP_BASE | AP_TRAMPOLINE_VECTOR as u32)?;
-
-    let start = super::trap::ticks_now();
-    let timeout_ticks = us_to_tsc_ticks(AP_START_TIMEOUT_US);
-    while super::trap::ticks_now().wrapping_sub(start) < timeout_ticks {
-        if AP_BOOTED_ID.load(Ordering::Acquire) == apic_id as usize {
-            return Ok(());
-        }
-        spin_loop();
-    }
-
-    Err(CpuOnError::Other(anyhow::anyhow!(
-        "timeout waiting APIC ID {:#x} online",
-        apic_id
-    )))
+    Ok(())
 }
 
 fn us_to_tsc_ticks(us: u64) -> u64 {
@@ -367,26 +344,6 @@ fn wait_x2apic_delivery() -> Result<(), CpuOnError> {
     Err(CpuOnError::Other(anyhow::anyhow!(
         "timeout waiting x2APIC IPI delivery"
     )))
-}
-
-struct StartupGuard;
-
-impl StartupGuard {
-    fn lock() -> Self {
-        while START_LOCK
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            spin_loop();
-        }
-        Self
-    }
-}
-
-impl Drop for StartupGuard {
-    fn drop(&mut self) {
-        START_LOCK.store(false, Ordering::Release);
-    }
 }
 
 #[cfg(test)]

--- a/platforms/someboot/src/arch/x86_64/power.rs
+++ b/platforms/someboot/src/arch/x86_64/power.rs
@@ -25,8 +25,9 @@ const IA32_APIC_BASE_X2APIC_ENABLE: u64 = 1 << 10;
 // INIT IPI (level-triggered): assert then deassert.
 const ICR_INIT_ASSERT: u32 = 0x0000_c500;
 const ICR_INIT_DEASSERT: u32 = 0x0000_8500;
-// STARTUP IPI (edge-triggered + assert level)
-const ICR_STARTUP_BASE: u32 = 0x0000_4600;
+// STARTUP IPI, matching Linux APIC_DM_STARTUP. Edge-triggered delivery does
+// not carry the level-assert bit used by INIT.
+const ICR_STARTUP_BASE: u32 = 0x0000_0600;
 
 static START_LOCK: AtomicBool = AtomicBool::new(false);
 static AP_BOOTED_ID: AtomicUsize = AtomicUsize::new(usize::MAX);
@@ -407,5 +408,13 @@ mod tests {
 
         assert_eq!(icr >> 32, 0x1234_5678);
         assert_eq!(icr as u32, ICR_STARTUP_BASE | AP_TRAMPOLINE_VECTOR as u32);
+    }
+
+    #[test]
+    fn startup_ipi_matches_linux_edge_triggered_delivery_mode() {
+        const ICR_LEVEL_ASSERT: u32 = 1 << 14;
+
+        assert_eq!(ICR_STARTUP_BASE, 0x600);
+        assert_eq!(ICR_STARTUP_BASE & ICR_LEVEL_ASSERT, 0);
     }
 }

--- a/platforms/someboot/src/entry/mod.rs
+++ b/platforms/someboot/src/entry/mod.rs
@@ -38,6 +38,7 @@ pub(crate) fn secondary_entry(cpu_meta_paddr: usize) {
         let virt = crate::mem::phys_to_virt(cpu_meta_paddr);
         &*(virt as *const crate::smp::PerCpuMeta)
     };
+    crate::smp::synchronize_secondary_boot(cpu_meta.cpu_idx);
 
     unsafe extern "Rust" {
         fn __someboot_secondary(cpu_meta: &PerCpuMeta);

--- a/platforms/someboot/src/lib.rs
+++ b/platforms/someboot/src/lib.rs
@@ -117,7 +117,12 @@ pub trait ArchTrait {
         Self::shutdown()
     }
     fn secondary_entry_fn_address() -> *const ();
-    fn cpu_on(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError>;
+    /// Delivers the architecture-specific wake request to one secondary CPU.
+    ///
+    /// This method owns only the hardware or firmware transport. The generic
+    /// someboot lifecycle publishes `KICKED`, waits for the target CPU to
+    /// report `ALIVE`, and releases it into the OS entry path.
+    fn kick_secondary_cpu(hartid: usize, entry: usize, arg: usize) -> Result<(), CpuOnError>;
 
     fn systimer_enable();
     fn systimer_irq_enable();

--- a/platforms/someboot/src/power.rs
+++ b/platforms/someboot/src/power.rs
@@ -1,8 +1,17 @@
+use core::{
+    hint::spin_loop,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
 use crate::{
     ArchTrait, DCacheOp,
+    arch::Arch,
     mem::{__kimage_va, cpu_area_phys_to_virt, dcache_range, virt_to_phys},
     smp::PerCpuMeta,
 };
+
+const CPU_ALIVE_TIMEOUT_SECONDS: usize = 10;
+static CPU_BOOT_LOCK: AtomicBool = AtomicBool::new(false);
 
 pub fn shutdown() -> ! {
     crate::arch::Arch::shutdown()
@@ -13,6 +22,7 @@ pub fn reset() -> ! {
 }
 
 pub fn cpu_on(cpu_idx: usize) -> Result<(), CpuOnError> {
+    let _guard = CpuBootGuard::lock();
     let entry = secondary_entry_addr();
     debug!("Secondary entry address: {entry:#x}");
     let arg = crate::smp::cpu_meta_addr(cpu_idx).ok_or(CpuOnError::InvalidParameters)?;
@@ -26,8 +36,52 @@ pub fn cpu_on(cpu_idx: usize) -> Result<(), CpuOnError> {
     let size = kimg.end - kimg.start;
     dcache_range(DCacheOp::Clean, kimg_start, size);
 
-    crate::arch::Arch::cpu_on(meta.cpu_id, entry, arg)?;
-    Ok(())
+    crate::smp::prepare_secondary_boot(cpu_idx).map_err(|error| {
+        CpuOnError::Other(anyhow::anyhow!(
+            "cannot kick logical CPU {cpu_idx} (hardware ID {:#x}): {error}",
+            meta.cpu_id
+        ))
+    })?;
+    Arch::kick_secondary_cpu(meta.cpu_id, entry, arg)?;
+    wait_for_secondary_alive(cpu_idx, meta.cpu_id)
+}
+
+fn wait_for_secondary_alive(cpu_idx: usize, hardware_id: usize) -> Result<(), CpuOnError> {
+    let start = Arch::systimer_tick();
+    let timeout_ticks = Arch::systimer_freq().saturating_mul(CPU_ALIVE_TIMEOUT_SECONDS);
+
+    loop {
+        if crate::smp::try_release_secondary(cpu_idx) {
+            return Ok(());
+        }
+        if Arch::systimer_tick().wrapping_sub(start) >= timeout_ticks {
+            return Err(CpuOnError::AliveTimeout {
+                logical_cpu: cpu_idx,
+                hardware_id,
+            });
+        }
+        spin_loop();
+    }
+}
+
+struct CpuBootGuard;
+
+impl CpuBootGuard {
+    fn lock() -> Self {
+        while CPU_BOOT_LOCK
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            spin_loop();
+        }
+        Self
+    }
+}
+
+impl Drop for CpuBootGuard {
+    fn drop(&mut self) {
+        CPU_BOOT_LOCK.store(false, Ordering::Release);
+    }
 }
 
 /// secondary entry address
@@ -45,6 +99,14 @@ pub enum CpuOnError {
     AlreadyOn,
     #[error("Invalid parameters")]
     InvalidParameters,
+    #[error(
+        "logical CPU {logical_cpu} (hardware ID {hardware_id:#x}) did not reach the alive \
+         synchronization point"
+    )]
+    AliveTimeout {
+        logical_cpu: usize,
+        hardware_id: usize,
+    },
     #[error("Other error: {0}")]
     Other(#[from] anyhow::Error),
 }

--- a/platforms/someboot/src/power.rs
+++ b/platforms/someboot/src/power.rs
@@ -1,17 +1,14 @@
-use core::{
-    hint::spin_loop,
-    sync::atomic::{AtomicBool, Ordering},
-};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use crate::{
     ArchTrait, DCacheOp,
     arch::Arch,
     mem::{__kimage_va, cpu_area_phys_to_virt, dcache_range, virt_to_phys},
-    smp::PerCpuMeta,
+    smp::{CpuBootPrepareError, CpuBootStatus, PerCpuMeta},
 };
 
-const CPU_ALIVE_TIMEOUT_SECONDS: usize = 10;
-static CPU_BOOT_LOCK: AtomicBool = AtomicBool::new(false);
+const NO_ACTIVE_SECONDARY_CPU: usize = usize::MAX;
+static ACTIVE_SECONDARY_CPU: SecondaryCpuOwner = SecondaryCpuOwner::new();
 
 pub fn shutdown() -> ! {
     crate::arch::Arch::shutdown()
@@ -21,67 +18,173 @@ pub fn reset() -> ! {
     crate::arch::Arch::reset()
 }
 
-pub fn cpu_on(cpu_idx: usize) -> Result<(), CpuOnError> {
-    let _guard = CpuBootGuard::lock();
+/// Starts one secondary CPU without waiting for it to reach the common entry.
+///
+/// The returned handle is the unique owner of the in-flight startup. Call
+/// [`SecondaryCpuStartup::status`] until it reports
+/// [`SecondaryCpuStartupStatus::Alive`], then call
+/// [`SecondaryCpuStartup::release`] to let the CPU enter the OS runtime.
+///
+/// Dropping an incomplete handle does not cancel the hardware request or
+/// release the startup owner. A late secondary may still be executing through
+/// a shared architecture trampoline, so another CPU cannot safely reuse that
+/// transport state. There is deliberately no retry or cancellation operation.
+///
+/// # Errors
+///
+/// Returns [`CpuOnError::StartupInProgress`] if another secondary startup owns
+/// the shared transport lifecycle. Architecture firmware and transport errors
+/// are returned after the per-CPU state has been published as kicked; such an
+/// error is terminal for this boot and keeps the startup owner claimed.
+pub fn start_secondary_cpu(cpu_idx: usize) -> Result<SecondaryCpuStartup, CpuOnError> {
+    if cpu_idx == NO_ACTIVE_SECONDARY_CPU {
+        return Err(CpuOnError::InvalidParameters);
+    }
+    ACTIVE_SECONDARY_CPU
+        .try_claim(cpu_idx)
+        .map_err(|active_logical_cpu| CpuOnError::StartupInProgress {
+            requested_logical_cpu: cpu_idx,
+            active_logical_cpu,
+        })?;
+
     let entry = secondary_entry_addr();
     debug!("Secondary entry address: {entry:#x}");
-    let arg = crate::smp::cpu_meta_addr(cpu_idx).ok_or(CpuOnError::InvalidParameters)?;
+    let Some(arg) = crate::smp::cpu_meta_addr(cpu_idx) else {
+        ACTIVE_SECONDARY_CPU
+            .release(cpu_idx)
+            .expect("the validating CPU must own the secondary startup");
+        return Err(CpuOnError::InvalidParameters);
+    };
     debug!("Secondary entry argument (cpu meta address): {arg:#x}");
 
+    // SAFETY: cpu_meta_addr returns a published per-CPU metadata slot. The
+    // object was constructed before runtime CPU-count publication and remains
+    // immutable at a stable address until shutdown.
     let meta = unsafe { &*(cpu_area_phys_to_virt(arg) as *const PerCpuMeta) };
-
     debug!("Power on CPU {meta:#x?}");
     let kimg = crate::mem::kimage_range();
     let kimg_start = __kimage_va(kimg.start);
     let size = kimg.end - kimg.start;
     dcache_range(DCacheOp::Clean, kimg_start, size);
 
-    crate::smp::prepare_secondary_boot(cpu_idx).map_err(|error| {
-        CpuOnError::Other(anyhow::anyhow!(
-            "cannot kick logical CPU {cpu_idx} (hardware ID {:#x}): {error}",
-            meta.cpu_id
-        ))
-    })?;
+    if let Err(error) = crate::smp::prepare_secondary_boot(cpu_idx) {
+        ACTIVE_SECONDARY_CPU
+            .release(cpu_idx)
+            .expect("the preparing CPU must own the secondary startup");
+        return Err(prepare_error(cpu_idx, meta.cpu_id, error));
+    }
+
+    // Once the architecture request begins, failure cannot prove that the
+    // target CPU did not consume shared trampoline state. Keep the owner
+    // claimed on error so a later startup cannot overwrite it.
     Arch::kick_secondary_cpu(meta.cpu_id, entry, arg)?;
-    wait_for_secondary_alive(cpu_idx, meta.cpu_id)
+    Ok(SecondaryCpuStartup {
+        logical_cpu: cpu_idx,
+        hardware_id: meta.cpu_id,
+    })
 }
 
-fn wait_for_secondary_alive(cpu_idx: usize, hardware_id: usize) -> Result<(), CpuOnError> {
-    let start = Arch::systimer_tick();
-    let timeout_ticks = Arch::systimer_freq().saturating_mul(CPU_ALIVE_TIMEOUT_SECONDS);
+/// Unique ownership of one in-flight secondary CPU startup.
+///
+/// This handle is intentionally neither `Clone` nor `Copy`. Dropping it before
+/// [`release`](Self::release) abandons the boot attempt without making shared
+/// architecture startup state reusable.
+#[derive(Debug)]
+#[must_use = "an in-flight secondary CPU must be observed and explicitly released"]
+pub struct SecondaryCpuStartup {
+    logical_cpu: usize,
+    hardware_id: usize,
+}
 
-    loop {
-        if crate::smp::try_release_secondary(cpu_idx) {
-            return Ok(());
+impl SecondaryCpuStartup {
+    /// Returns the dense logical CPU index owned by this startup.
+    pub const fn logical_cpu(&self) -> usize {
+        self.logical_cpu
+    }
+
+    /// Returns the firmware or hardware CPU ID targeted by this startup.
+    pub const fn hardware_id(&self) -> usize {
+        self.hardware_id
+    }
+
+    /// Observes whether the secondary has reached the common someboot entry.
+    ///
+    /// This query is side-effect free. In particular, observing
+    /// [`SecondaryCpuStartupStatus::Alive`] does not release the CPU into the
+    /// OS runtime.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the per-CPU boot state no longer belongs to this live handle.
+    /// That indicates an internal lifecycle invariant violation.
+    pub fn status(&self) -> SecondaryCpuStartupStatus {
+        match crate::smp::secondary_boot_status(self.logical_cpu).unwrap_or_else(|error| {
+            panic!(
+                "cannot observe logical CPU {} (hardware ID {:#x}): {error}",
+                self.logical_cpu, self.hardware_id
+            )
+        }) {
+            CpuBootStatus::WaitingForAlive => SecondaryCpuStartupStatus::WaitingForAlive,
+            CpuBootStatus::Alive => SecondaryCpuStartupStatus::Alive,
         }
-        if Arch::systimer_tick().wrapping_sub(start) >= timeout_ticks {
-            return Err(CpuOnError::AliveTimeout {
-                logical_cpu: cpu_idx,
-                hardware_id,
-            });
-        }
-        spin_loop();
+    }
+
+    /// Releases an alive secondary CPU into the OS runtime.
+    ///
+    /// The handle is consumed so the startup owner can be released exactly
+    /// once. Call [`status`](Self::status) first and release only after it
+    /// reports [`SecondaryCpuStartupStatus::Alive`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CpuOnError::NotAlive`] if the secondary has not reached the
+    /// common entry. The startup remains claimed and cannot be retried.
+    pub fn release(self) -> Result<(), CpuOnError> {
+        ACTIVE_SECONDARY_CPU
+            .ensure_owned(self.logical_cpu)
+            .map_err(|active_logical_cpu| {
+                CpuOnError::Other(anyhow::anyhow!(
+                    "cannot release logical CPU {} (hardware ID {:#x}) while startup owner is \
+                     {:#x}",
+                    self.logical_cpu,
+                    self.hardware_id,
+                    active_logical_cpu
+                ))
+            })?;
+        crate::smp::release_secondary_boot(self.logical_cpu).map_err(|error| match error {
+            CpuBootPrepareError::UnexpectedState { .. } => CpuOnError::NotAlive {
+                logical_cpu: self.logical_cpu,
+                hardware_id: self.hardware_id,
+            },
+            CpuBootPrepareError::Missing { .. } => CpuOnError::InvalidParameters,
+        })?;
+        ACTIVE_SECONDARY_CPU
+            .release(self.logical_cpu)
+            .map_err(|active_logical_cpu| {
+                CpuOnError::Other(anyhow::anyhow!(
+                    "released logical CPU {} (hardware ID {:#x}) while startup owner was {:#x}",
+                    self.logical_cpu,
+                    self.hardware_id,
+                    active_logical_cpu
+                ))
+            })
     }
 }
 
-struct CpuBootGuard;
-
-impl CpuBootGuard {
-    fn lock() -> Self {
-        while CPU_BOOT_LOCK
-            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
-            .is_err()
-        {
-            spin_loop();
-        }
-        Self
-    }
+/// Non-blocking observation of a secondary CPU startup.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SecondaryCpuStartupStatus {
+    /// The architecture request was sent, but the CPU has not reached the
+    /// common someboot entry.
+    WaitingForAlive,
+    /// The CPU reached the common someboot entry and is waiting for release.
+    Alive,
 }
 
-impl Drop for CpuBootGuard {
-    fn drop(&mut self) {
-        CPU_BOOT_LOCK.store(false, Ordering::Release);
-    }
+fn prepare_error(logical_cpu: usize, hardware_id: usize, error: CpuBootPrepareError) -> CpuOnError {
+    CpuOnError::Other(anyhow::anyhow!(
+        "cannot kick logical CPU {logical_cpu} (hardware ID {hardware_id:#x}): {error}"
+    ))
 }
 
 /// secondary entry address
@@ -91,14 +194,88 @@ fn secondary_entry_addr() -> usize {
     virt_to_phys(ptr)
 }
 
+struct SecondaryCpuOwner {
+    active_cpu: AtomicUsize,
+}
+
+impl SecondaryCpuOwner {
+    const fn new() -> Self {
+        Self {
+            active_cpu: AtomicUsize::new(NO_ACTIVE_SECONDARY_CPU),
+        }
+    }
+
+    fn try_claim(&self, logical_cpu: usize) -> Result<(), usize> {
+        self.active_cpu
+            .compare_exchange(
+                NO_ACTIVE_SECONDARY_CPU,
+                logical_cpu,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map(|_| ())
+    }
+
+    #[cfg(test)]
+    fn active_cpu(&self) -> Option<usize> {
+        match self.active_cpu.load(Ordering::Acquire) {
+            NO_ACTIVE_SECONDARY_CPU => None,
+            logical_cpu => Some(logical_cpu),
+        }
+    }
+
+    fn release(&self, logical_cpu: usize) -> Result<(), usize> {
+        self.active_cpu
+            .compare_exchange(
+                logical_cpu,
+                NO_ACTIVE_SECONDARY_CPU,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map(|_| ())
+    }
+
+    fn ensure_owned(&self, logical_cpu: usize) -> Result<(), usize> {
+        let active_logical_cpu = self.active_cpu.load(Ordering::Acquire);
+        if active_logical_cpu == logical_cpu {
+            Ok(())
+        } else {
+            Err(active_logical_cpu)
+        }
+    }
+}
+
+/// Failure to start, observe, or release a secondary CPU.
 #[derive(thiserror::Error, Debug)]
 pub enum CpuOnError {
+    /// The architecture or firmware does not implement secondary CPU startup.
     #[error("CPU on is not supported")]
     NotSupported,
+    /// The target CPU is already running.
     #[error("CPU is already on")]
     AlreadyOn,
+    /// The logical CPU index or architecture parameters are invalid.
     #[error("Invalid parameters")]
     InvalidParameters,
+    /// Another CPU owns the serialized secondary startup lifecycle.
+    #[error(
+        "cannot start logical CPU {requested_logical_cpu}: logical CPU {active_logical_cpu} \
+         already owns the secondary startup transport"
+    )]
+    StartupInProgress {
+        requested_logical_cpu: usize,
+        active_logical_cpu: usize,
+    },
+    /// Release was requested before the secondary reached the common entry.
+    #[error(
+        "logical CPU {logical_cpu} (hardware ID {hardware_id:#x}) has not reached the alive \
+         synchronization point"
+    )]
+    NotAlive {
+        logical_cpu: usize,
+        hardware_id: usize,
+    },
+    /// The upper-layer wait policy expired before the secondary reported alive.
     #[error(
         "logical CPU {logical_cpu} (hardware ID {hardware_id:#x}) did not reach the alive \
          synchronization point"
@@ -107,6 +284,51 @@ pub enum CpuOnError {
         logical_cpu: usize,
         hardware_id: usize,
     },
+    /// An architecture transport or internal lifecycle operation failed.
     #[error("Other error: {0}")]
     Other(#[from] anyhow::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn active_secondary_cpu_rejects_a_second_start_without_spinning() {
+        let owner = SecondaryCpuOwner::new();
+
+        assert_eq!(owner.try_claim(1), Ok(()));
+        assert_eq!(owner.try_claim(2), Err(1));
+    }
+
+    #[test]
+    fn active_secondary_cpu_is_released_only_explicitly() {
+        let owner = SecondaryCpuOwner::new();
+
+        owner.try_claim(1).unwrap();
+        assert_eq!(owner.active_cpu(), Some(1));
+        assert_eq!(owner.ensure_owned(2), Err(1));
+        assert_eq!(owner.release(2), Err(1));
+        assert_eq!(owner.active_cpu(), Some(1));
+
+        owner.release(1).unwrap();
+        assert_eq!(owner.active_cpu(), None);
+        assert_eq!(owner.try_claim(2), Ok(()));
+    }
+
+    #[test]
+    fn dropping_an_incomplete_handle_keeps_the_transport_claimed() {
+        const LOGICAL_CPU: usize = 17;
+        ACTIVE_SECONDARY_CPU.try_claim(LOGICAL_CPU).unwrap();
+
+        let startup = SecondaryCpuStartup {
+            logical_cpu: LOGICAL_CPU,
+            hardware_id: 0x11,
+        };
+        drop(startup);
+
+        assert_eq!(ACTIVE_SECONDARY_CPU.active_cpu(), Some(LOGICAL_CPU));
+        assert_eq!(ACTIVE_SECONDARY_CPU.try_claim(18), Err(LOGICAL_CPU));
+        ACTIVE_SECONDARY_CPU.release(LOGICAL_CPU).unwrap();
+    }
 }

--- a/platforms/someboot/src/smp/layout.rs
+++ b/platforms/someboot/src/smp/layout.rs
@@ -1,9 +1,12 @@
 //! Runtime allocation geometry for CPU areas, metadata, and boot stacks.
 
-use core::{alloc::Layout, mem::size_of};
+use core::{
+    alloc::Layout,
+    mem::{align_of, size_of},
+};
 
 use super::{
-    PerCpuLayoutError, PerCpuMeta, allocate_cpu_area_region, allocated_cpu_count,
+    CpuBootSync, PerCpuLayoutError, PerCpuMeta, allocate_cpu_area_region, allocated_cpu_count,
     checked_align_up_pow2, checked_allocation_layout, cpu_area_region, cpu_area_region_alignment,
     cpu_area_template_size, cpu_count, meta_align, set_cpu_area_region,
 };
@@ -14,6 +17,8 @@ struct LayoutRequirements {
     data_size: usize,
     metadata_size: usize,
     metadata_alignment: usize,
+    boot_sync_size: usize,
+    boot_sync_alignment: usize,
     stack_size: usize,
     page_alignment: usize,
     region_alignment: usize,
@@ -22,6 +27,7 @@ struct LayoutRequirements {
 #[derive(Clone, Copy, Debug)]
 struct LayoutInfo {
     meta_offset: usize,
+    boot_sync_offset: usize,
     stack_offset: usize,
     area_stride: usize,
     allocation_layout: Layout,
@@ -34,6 +40,8 @@ fn layout_info(cpu_count: usize) -> Result<LayoutInfo, PerCpuLayoutError> {
             data_size: cpu_area_template_size()?,
             metadata_size: size_of::<PerCpuMeta>(),
             metadata_alignment: meta_align(),
+            boot_sync_size: size_of::<CpuBootSync>(),
+            boot_sync_alignment: align_of::<CpuBootSync>(),
             stack_size: stack_size(),
             page_alignment: crate::mem::page_size(),
             region_alignment: cpu_area_region_alignment()?,
@@ -53,7 +61,11 @@ fn calculate_layout(
     let metadata_end = meta_offset
         .checked_add(requirements.metadata_size)
         .ok_or(PerCpuLayoutError::AddressOverflow)?;
-    let stack_offset = checked_align_up_pow2(metadata_end, requirements.page_alignment)?;
+    let boot_sync_offset = checked_align_up_pow2(metadata_end, requirements.boot_sync_alignment)?;
+    let boot_sync_end = boot_sync_offset
+        .checked_add(requirements.boot_sync_size)
+        .ok_or(PerCpuLayoutError::AddressOverflow)?;
+    let stack_offset = checked_align_up_pow2(boot_sync_end, requirements.page_alignment)?;
     let stack_end = stack_offset
         .checked_add(requirements.stack_size)
         .ok_or(PerCpuLayoutError::AddressOverflow)?;
@@ -65,6 +77,7 @@ fn calculate_layout(
 
     Ok(LayoutInfo {
         meta_offset,
+        boot_sync_offset,
         stack_offset,
         area_stride,
         allocation_layout,
@@ -115,6 +128,11 @@ pub(crate) fn cpu_meta_addr(cpu_index: usize) -> Option<usize> {
     cpu_area_start(cpu_index)?.checked_add(layout.meta_offset)
 }
 
+pub(crate) fn cpu_boot_sync_addr(cpu_index: usize) -> Option<usize> {
+    let layout = layout_info(allocated_cpu_count()).ok()?;
+    cpu_area_start(cpu_index)?.checked_add(layout.boot_sync_offset)
+}
+
 pub(crate) fn cpu_area_phys(cpu_index: usize) -> Option<usize> {
     cpu_area_start(cpu_index)
 }
@@ -134,6 +152,8 @@ mod tests {
         data_size: 128,
         metadata_size: 64,
         metadata_alignment: 64,
+        boot_sync_size: 4,
+        boot_sync_alignment: 4,
         stack_size: 4096,
         page_alignment: 4096,
         region_alignment: 4096,
@@ -159,6 +179,7 @@ mod tests {
     fn ordinary_layout_keeps_metadata_and_stack_inside_each_area() {
         let layout = calculate_layout(4, TEST_REQUIREMENTS).unwrap();
         assert_eq!(layout.meta_offset, 128);
+        assert_eq!(layout.boot_sync_offset, 192);
         assert_eq!(layout.stack_offset, 4096);
         assert_eq!(layout.area_stride, 8192);
         assert_eq!(layout.allocation_layout.size(), 4 * 8192);

--- a/platforms/someboot/src/smp/mod.rs
+++ b/platforms/someboot/src/smp/mod.rs
@@ -1,7 +1,7 @@
 use core::{
     alloc::Layout,
     mem::size_of,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::{AtomicU32, AtomicUsize, Ordering},
 };
 
 use kernutil::memory::MemoryType;
@@ -22,6 +22,83 @@ static CPU_AREA_LAYOUT_COUNT: AtomicUsize = AtomicUsize::new(0);
 static CPU_AREA_RUNTIME_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 const PERCPU_INIT_OK: u32 = 0;
+
+const CPU_BOOT_DEAD: u32 = 0;
+const CPU_BOOT_KICKED: u32 = 1;
+const CPU_BOOT_ALIVE: u32 = 2;
+const CPU_BOOT_SHOULD_ONLINE: u32 = 3;
+
+/// Per-CPU synchronization owned by the generic secondary-boot core.
+///
+/// This object is deliberately separate from [`PerCpuMeta`]. Metadata is an
+/// immutable trampoline ABI after publication, while this object is the sole
+/// mutable owner of the `DEAD -> KICKED -> ALIVE -> SHOULD_ONLINE` handshake.
+#[repr(C)]
+pub(crate) struct CpuBootSync {
+    state: AtomicU32,
+}
+
+impl CpuBootSync {
+    const fn new() -> Self {
+        Self {
+            state: AtomicU32::new(CPU_BOOT_DEAD),
+        }
+    }
+
+    fn prepare_kick(&self) -> Result<(), CpuBootPrepareError> {
+        self.state
+            .compare_exchange(
+                CPU_BOOT_DEAD,
+                CPU_BOOT_KICKED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map(|_| ())
+            .map_err(|state| CpuBootPrepareError::UnexpectedState { state })
+    }
+
+    fn report_alive(&self) -> Result<(), CpuBootPrepareError> {
+        self.state
+            .compare_exchange(
+                CPU_BOOT_KICKED,
+                CPU_BOOT_ALIVE,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .map(|_| ())
+            .map_err(|state| CpuBootPrepareError::UnexpectedState { state })
+    }
+
+    fn try_release_alive(&self) -> bool {
+        self.state
+            .compare_exchange(
+                CPU_BOOT_ALIVE,
+                CPU_BOOT_SHOULD_ONLINE,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn wait_until_released(&self) {
+        while self.state.load(Ordering::Acquire) != CPU_BOOT_SHOULD_ONLINE {
+            core::hint::spin_loop();
+        }
+    }
+
+    #[cfg(test)]
+    fn state(&self) -> u32 {
+        self.state.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub(crate) enum CpuBootPrepareError {
+    #[error("logical CPU {cpu_index} has no published boot synchronization")]
+    Missing { cpu_index: usize },
+    #[error("CPU boot synchronization is in unexpected state {state}")]
+    UnexpectedState { state: u32 },
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 enum PerCpuLayoutError {
@@ -271,6 +348,42 @@ pub(crate) fn cpu_meta_addr(idx: usize) -> Option<usize> {
     layout::cpu_meta_addr(idx)
 }
 
+fn cpu_boot_sync(idx: usize) -> Option<&'static CpuBootSync> {
+    if idx >= runtime_cpu_count() {
+        return None;
+    }
+    let sync_start = layout::cpu_boot_sync_addr(idx)?;
+    let sync_va = phys_to_virt(sync_start);
+    // SAFETY: initialization constructs one CpuBootSync in every reserved
+    // slot before the Release publication of CPU_AREA_RUNTIME_COUNT. Its
+    // address remains stable until shutdown and all mutation is atomic.
+    Some(unsafe { &*sync_va.cast::<CpuBootSync>() })
+}
+
+pub(crate) fn prepare_secondary_boot(cpu_index: usize) -> Result<(), CpuBootPrepareError> {
+    cpu_boot_sync(cpu_index)
+        .ok_or(CpuBootPrepareError::Missing { cpu_index })?
+        .prepare_kick()
+}
+
+pub(crate) fn try_release_secondary(cpu_index: usize) -> bool {
+    try_release_secondary_from(cpu_boot_sync(cpu_index), cpu_index)
+}
+
+fn try_release_secondary_from(sync: Option<&CpuBootSync>, cpu_index: usize) -> bool {
+    sync.unwrap_or_else(|| panic!("missing boot synchronization for CPU {cpu_index}"))
+        .try_release_alive()
+}
+
+pub(crate) fn synchronize_secondary_boot(cpu_index: usize) {
+    let sync = cpu_boot_sync(cpu_index)
+        .unwrap_or_else(|| panic!("missing boot synchronization for CPU {cpu_index}"));
+    sync.report_alive().unwrap_or_else(|error| {
+        panic!("CPU {cpu_index} reported alive from an invalid boot state: {error}")
+    });
+    sync.wait_until_released();
+}
+
 pub(crate) fn cpu_area_phys(idx: usize) -> Option<usize> {
     layout::cpu_area_phys(idx)
 }
@@ -508,11 +621,17 @@ fn initialize_runtime_metadata() {
             boot_table_paddr: 0,
             primary_table_paddr: 0,
         };
+        let sync_start = layout::cpu_boot_sync_addr(cpu_index)
+            .expect("reserved per-CPU boot synchronization slot must remain addressable");
         let meta_va = phys_to_virt(meta_start);
+        let sync_va = phys_to_virt(sync_start);
         debug_assert_eq!((meta_va as usize) % meta_align(), 0);
         // SAFETY: early allocation reserved this unique raw metadata slot and
         // no consumer can observe it before runtime count publication.
         unsafe { meta_va.cast::<PerCpuMeta>().write(meta) };
+        // SAFETY: every CPU area owns exactly one disjoint synchronization
+        // slot and runtime publication has not occurred yet.
+        unsafe { sync_va.cast::<CpuBootSync>().write(CpuBootSync::new()) };
     }
 }
 
@@ -554,6 +673,54 @@ mod tests {
             boot_table_paddr: 0,
             primary_table_paddr: 0,
         })
+    }
+
+    #[test]
+    fn boot_sync_release_requires_the_matching_cpu_to_report_alive() {
+        let first = CpuBootSync::new();
+        let second = CpuBootSync::new();
+
+        first.prepare_kick().unwrap();
+        second.prepare_kick().unwrap();
+        second.report_alive().unwrap();
+
+        assert!(!first.try_release_alive());
+        assert!(second.try_release_alive());
+        assert_eq!(first.state(), CPU_BOOT_KICKED);
+        assert_eq!(second.state(), CPU_BOOT_SHOULD_ONLINE);
+    }
+
+    #[test]
+    fn boot_sync_rejects_a_cpu_already_released_to_online_startup() {
+        let sync = CpuBootSync::new();
+        sync.prepare_kick().unwrap();
+        sync.report_alive().unwrap();
+        assert!(sync.try_release_alive());
+
+        assert_eq!(
+            sync.prepare_kick(),
+            Err(CpuBootPrepareError::UnexpectedState {
+                state: CPU_BOOT_SHOULD_ONLINE
+            })
+        );
+    }
+
+    #[test]
+    fn boot_sync_rejects_alive_before_the_cpu_is_kicked() {
+        let sync = CpuBootSync::new();
+
+        assert_eq!(
+            sync.report_alive(),
+            Err(CpuBootPrepareError::UnexpectedState {
+                state: CPU_BOOT_DEAD
+            })
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "missing boot synchronization for CPU")]
+    fn releasing_an_unpublished_cpu_is_an_invariant_violation() {
+        let _ = try_release_secondary_from(None, usize::MAX);
     }
 
     #[test]

--- a/platforms/someboot/src/smp/mod.rs
+++ b/platforms/someboot/src/smp/mod.rs
@@ -28,6 +28,12 @@ const CPU_BOOT_KICKED: u32 = 1;
 const CPU_BOOT_ALIVE: u32 = 2;
 const CPU_BOOT_SHOULD_ONLINE: u32 = 3;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum CpuBootStatus {
+    WaitingForAlive,
+    Alive,
+}
+
 /// Per-CPU synchronization owned by the generic secondary-boot core.
 ///
 /// This object is deliberately separate from [`PerCpuMeta`]. Metadata is an
@@ -69,7 +75,15 @@ impl CpuBootSync {
             .map_err(|state| CpuBootPrepareError::UnexpectedState { state })
     }
 
-    fn try_release_alive(&self) -> bool {
+    fn status(&self) -> Result<CpuBootStatus, CpuBootPrepareError> {
+        match self.state.load(Ordering::Acquire) {
+            CPU_BOOT_KICKED => Ok(CpuBootStatus::WaitingForAlive),
+            CPU_BOOT_ALIVE => Ok(CpuBootStatus::Alive),
+            state => Err(CpuBootPrepareError::UnexpectedState { state }),
+        }
+    }
+
+    fn release_alive(&self) -> Result<(), CpuBootPrepareError> {
         self.state
             .compare_exchange(
                 CPU_BOOT_ALIVE,
@@ -77,7 +91,8 @@ impl CpuBootSync {
                 Ordering::AcqRel,
                 Ordering::Acquire,
             )
-            .is_ok()
+            .map(|_| ())
+            .map_err(|state| CpuBootPrepareError::UnexpectedState { state })
     }
 
     fn wait_until_released(&self) {
@@ -366,13 +381,24 @@ pub(crate) fn prepare_secondary_boot(cpu_index: usize) -> Result<(), CpuBootPrep
         .prepare_kick()
 }
 
-pub(crate) fn try_release_secondary(cpu_index: usize) -> bool {
-    try_release_secondary_from(cpu_boot_sync(cpu_index), cpu_index)
+pub(crate) fn secondary_boot_status(
+    cpu_index: usize,
+) -> Result<CpuBootStatus, CpuBootPrepareError> {
+    cpu_boot_sync(cpu_index)
+        .ok_or(CpuBootPrepareError::Missing { cpu_index })?
+        .status()
 }
 
-fn try_release_secondary_from(sync: Option<&CpuBootSync>, cpu_index: usize) -> bool {
-    sync.unwrap_or_else(|| panic!("missing boot synchronization for CPU {cpu_index}"))
-        .try_release_alive()
+pub(crate) fn release_secondary_boot(cpu_index: usize) -> Result<(), CpuBootPrepareError> {
+    release_secondary_boot_from(cpu_boot_sync(cpu_index), cpu_index)
+}
+
+fn release_secondary_boot_from(
+    sync: Option<&CpuBootSync>,
+    cpu_index: usize,
+) -> Result<(), CpuBootPrepareError> {
+    sync.ok_or(CpuBootPrepareError::Missing { cpu_index })?
+        .release_alive()
 }
 
 pub(crate) fn synchronize_secondary_boot(cpu_index: usize) {
@@ -684,10 +710,27 @@ mod tests {
         second.prepare_kick().unwrap();
         second.report_alive().unwrap();
 
-        assert!(!first.try_release_alive());
-        assert!(second.try_release_alive());
+        assert_eq!(
+            first.release_alive(),
+            Err(CpuBootPrepareError::UnexpectedState {
+                state: CPU_BOOT_KICKED
+            })
+        );
+        second.release_alive().unwrap();
         assert_eq!(first.state(), CPU_BOOT_KICKED);
         assert_eq!(second.state(), CPU_BOOT_SHOULD_ONLINE);
+    }
+
+    #[test]
+    fn boot_sync_observation_does_not_release_an_alive_cpu() {
+        let sync = CpuBootSync::new();
+
+        sync.prepare_kick().unwrap();
+        assert_eq!(sync.status(), Ok(CpuBootStatus::WaitingForAlive));
+
+        sync.report_alive().unwrap();
+        assert_eq!(sync.status(), Ok(CpuBootStatus::Alive));
+        assert_eq!(sync.state(), CPU_BOOT_ALIVE);
     }
 
     #[test]
@@ -695,7 +738,7 @@ mod tests {
         let sync = CpuBootSync::new();
         sync.prepare_kick().unwrap();
         sync.report_alive().unwrap();
-        assert!(sync.try_release_alive());
+        sync.release_alive().unwrap();
 
         assert_eq!(
             sync.prepare_kick(),
@@ -718,9 +761,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "missing boot synchronization for CPU")]
-    fn releasing_an_unpublished_cpu_is_an_invariant_violation() {
-        let _ = try_release_secondary_from(None, usize::MAX);
+    fn releasing_an_unpublished_cpu_returns_a_typed_error() {
+        assert_eq!(
+            release_secondary_boot_from(None, usize::MAX),
+            Err(CpuBootPrepareError::Missing {
+                cpu_index: usize::MAX
+            })
+        );
     }
 
     #[test]

--- a/platforms/somehal/CHANGELOG.md
+++ b/platforms/somehal/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking:** re-export the queryable someboot secondary CPU startup handle in place of the
+  blocking `cpu_on()` API; timeout and polling policy now belong to the platform adapter.
+
 ## [0.8.3](https://github.com/rcore-os/tgoskits/compare/somehal-v0.8.2...somehal-v0.8.3) - 2026-08-09
 
 ### Added


### PR DESCRIPTION
## 问题

原实现已经把四架构 secondary CPU 启动统一为 per-CPU `DEAD -> KICKED -> ALIVE -> SHOULD_ONLINE` 握手，但公共 `cpu_on()` 仍在 someboot 内部同步轮询最长 10 秒，并把“查询 AP 是否到达”和“释放 AP 进入 OS runtime”合并在一次操作中。这样会带来两个问题：

1. 上层不能选择轮询或基于真实 waker 的异步等待；直接在 someboot 返回 `Future` 又缺少 executor、timer 和唤醒源，只会形成伪异步。
2. x86 共享 `0x8000` trampoline 要求完整启动生命周期串行。若等待任务被丢弃、取消、超时，或 transport 可能已部分发送，不能把全局 owner 交给下一个 CPU，否则迟到 AP 可能读取被覆盖的 trampoline metadata。

Linux 的 `cpu_up()` 对上层仍是同步事务，但内部将 architecture kick、AP completion 和 CPUHP 状态推进分开。本 PR 借鉴这种内部阶段化，不复制 Linux hotplug 状态机，也不把 someboot 直接改成 `Future`。

## 修改

- 修正 x86 STARTUP IPI 为 edge-triggered `0x600 | vector`，删除架构私有 `AP_BOOTED_ID`、启动锁和 500 ms AP 轮询。
- 在每个 CPU area 中独立构造并发布 `CpuBootSync`，保持 immutable `PerCpuMeta` trampoline ABI 不变。
- 用 breaking API `start_secondary_cpu()` 替换同步 `cpu_on()`，返回不可复制、`#[must_use]` 的 `SecondaryCpuStartup` handle：
  - `status()` 仅以 Acquire 查询 `WaitingForAlive` / `Alive`，没有隐式 release；
  - `release(self)` 仅在匹配目标为 `ALIVE` 时执行 `ALIVE -> SHOULD_ONLINE`，成功后才清除 active owner；
  - 第二次 start 通过非阻塞 CAS 立即返回 `StartupInProgress`。
- 未完成 handle 被丢弃、上层取消/超时、非 ALIVE release 或可能部分失败的 transport 都保留 `ACTIVE_SECONDARY_CPU`，不提供 cancel、retry 或 fallback。只有 transport 开始前的参数/prepare 失败可以安全归还 owner。
- `ax-plat::PowerIf::cpu_boot()` 保持同步；`axplat-dyn` 轮询 handle，并继续执行 10 秒超时策略。`axruntime::ENTERED_CPUS` 等待保留，因为 someboot common-entry alive 与 OS runtime entry 是两个独立状态源。
- 更新 someboot/somehal changelog、中文设计材料、动态平台文档和 `arch-platform-porting` skill/reference，记录 breaking API、polling ownership、放弃语义和未来异步包装约束。

## 设计逻辑

状态推进保持单一 owner：someboot 拥有 per-CPU 启动事实，架构 hook 只负责 PSCI/SBI/mailbox/INIT-SIPI transport，`axplat-dyn` 拥有同步等待与超时策略。`status()` 与 `release()` 分离后，上层可以主动轮询；未来若要包装异步接口，必须提供真实硬件事件 waker，并把 cancellation 视为终止性启动失败。

全局单 in-flight 限制是四架构公共契约，不按架构暴露不同并发能力。它保守满足 x86 共享 trampoline 的生命周期要求，并防止错误恢复覆盖迟到 AP 使用的启动数据。

## 红绿证据

在旧同步实现上先加入目标接口/状态语义回归，运行 `cargo test -p someboot --lib` 确定性失败（exit 101）：旧实现缺少 `SecondaryCpuOwner`、`CpuBootSync::status()` 和 `CpuBootStatus`，且原 `try_release_secondary` 查询路径会直接执行 `ALIVE -> SHOULD_ONLINE`。

修复后同组测试通过，覆盖：

- `KICKED -> WaitingForAlive`；
- secondary 报告后 `ALIVE -> Alive`，且查询不改变状态；
- 非 ALIVE/错误 CPU 不能 release；
- 第二次 start 立即失败，不自旋；
- 只有匹配 handle 显式 release 后才清除 owner；
- 丢弃未完成 handle 后 owner 仍保持占用，不能复用 trampoline；
- 非法顺序和未发布 CPU 返回 typed error。

## 提交

1. `8e92b2334 fix(someboot): encode x86 STARTUP IPI as edge-triggered`
2. `46ec23f73 fix(someboot): synchronize secondary startup per CPU`
3. `3c112c773 docs(someboot): define secondary startup ownership`
4. `87970aaf9 fix(someboot)!: expose queryable secondary CPU startup`
5. `9d1481ac5 docs(someboot): define queryable startup lifecycle`

## 本地验证

- `cargo test -p someboot`：通过（56 个库单测及全部集成契约测试）。
- `cargo xtask clippy --package someboot --package axplat-dyn`：通过（2 个 package、18 个 feature checks）。
- `cargo xtask arceos test qemu --arch x86_64 -g rust -c task-smp-online`：通过，4/4 CPU online。
- `cargo xtask arceos test qemu --arch riscv64 -g rust -c task-smp-online`：通过，4/4 CPU online。
- `cargo xtask arceos test qemu --arch aarch64 -g rust -c task-smp-online`：通过，4/4 CPU online。
- `cargo xtask arceos test qemu --arch loongarch64 -g rust -c task-smp-online`：通过，4/4 CPU online。
- `cargo fmt --all -- --check`：通过。
- `git diff --check`：通过。

未把 `cargo test -p axplat-dyn --lib` 作为验收项：该 crate 的 host lib test 在当前基线上会因 kernel linker symbols 缺失而无法链接；上层轮询路径由完整 clippy feature 矩阵和四架构 QEMU 覆盖。
