### PR TITLE
fix(someboot): harden timer boundary arithmetic

### DIFF
--- a/platforms/someboot/src/arch/loongarch64/mod.rs
+++ b/platforms/someboot/src/arch/loongarch64/mod.rs
@@ -27,7 +27,6 @@ pub use relocate::relocate;
 
 use crate::{ArchTrait, DCacheOp, efi_stub, irq::IrqId, power::CpuOnError};
 
-const MIN_TICKS: usize = 4;
 #[cfg(feature = "tls")]
 const BOOT_TLS_SIZE: usize = 64 * 1024;
 
@@ -120,9 +119,7 @@ impl ArchTrait for Arch {
         tcfg::read().en()
     }
     fn systimer_set_interval(ticks: usize) {
-        let ticks = ticks.max(MIN_TICKS);
-        // Ensure the value is aligned to a multiple of 4 as required by TCFG
-        let ticks = (ticks + 3) & !3;
+        let ticks = crate::timer::loongarch64_interval::aligned_ticks(ticks);
 
         // 先禁用定时器
         tcfg::set_en(false);

--- a/platforms/someboot/src/arch/riscv64/mod.rs
+++ b/platforms/someboot/src/arch/riscv64/mod.rs
@@ -353,11 +353,7 @@ impl ArchTrait for Arch {
 
     fn systimer_set_interval(ticks: usize) {
         let now = Self::systimer_tick() as u64;
-        let next = if ticks == usize::MAX {
-            u64::MAX
-        } else {
-            now.saturating_add(ticks as u64).max(now + 1)
-        };
+        let next = crate::timer::riscv64_interval::absolute_deadline(now, ticks as u64);
         let _ = sbi::set_timer(next);
     }
 

--- a/platforms/someboot/src/timer.rs
+++ b/platforms/someboot/src/timer.rs
@@ -147,6 +147,32 @@ pub(crate) mod aarch64_deadline {
     }
 }
 
+#[cfg(any(target_arch = "riscv64", test))]
+pub(crate) mod riscv64_interval {
+    /// Converts an SBI relative interval into an absolute timer deadline.
+    pub(crate) fn absolute_deadline(current_ticks: u64, interval_ticks: u64) -> u64 {
+        let interval_ticks = if interval_ticks == 0 {
+            1
+        } else {
+            interval_ticks
+        };
+        current_ticks.saturating_add(interval_ticks)
+    }
+}
+
+#[cfg(any(target_arch = "loongarch64", test))]
+pub(crate) mod loongarch64_interval {
+    const ALIGNMENT: usize = 4;
+    const MIN_TICKS: usize = 4;
+
+    /// Converts a relative interval to the bounded 4-tick value encoded by TCFG.
+    pub(crate) fn aligned_ticks(interval_ticks: usize) -> usize {
+        let max_aligned = usize::MAX - usize::MAX % ALIGNMENT;
+        let clamped = interval_ticks.max(MIN_TICKS).min(max_aligned);
+        (clamped + (ALIGNMENT - 1)) & !(ALIGNMENT - 1)
+    }
+}
+
 /// Acknowledge and clear the timer interrupt.
 /// This must be called in the timer interrupt handler.
 pub fn ack() {
@@ -265,6 +291,26 @@ mod tests {
             current + interval
         );
         assert_eq!(aarch64_deadline::from_interval(u64::MAX - 3, 8), 4);
+    }
+
+    #[test]
+    fn riscv64_deadline_saturates_at_counter_limit() {
+        assert_eq!(
+            riscv64_interval::absolute_deadline(u64::MAX - 3, 8),
+            u64::MAX
+        );
+        assert_eq!(riscv64_interval::absolute_deadline(10, 0), 11);
+        assert_eq!(riscv64_interval::absolute_deadline(u64::MAX, 0), u64::MAX);
+    }
+
+    #[test]
+    fn loongarch64_interval_clamps_before_rounding() {
+        assert_eq!(loongarch64_interval::aligned_ticks(1), 4);
+        assert_eq!(loongarch64_interval::aligned_ticks(5), 8);
+        assert_eq!(
+            loongarch64_interval::aligned_ticks(usize::MAX),
+            usize::MAX & !3
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 问题

`someboot` 的两处定时器 interval 换算在整数边界上不安全：

- RISC-V 需要把相对 interval 转成 SBI 使用的绝对 deadline；旧实现对 `now + 1` 的求值在计数器已为 `u64::MAX` 时会溢出。
- LoongArch TCFG 要求 interval 为 4 tick 对齐；旧实现先执行 `ticks + 3`，在 `usize::MAX` 附近会溢出。

## 修改

- RISC-V 增加私有换算 helper：零 interval 至少推进 1 tick，绝对 deadline 使用饱和加法并封顶于 `u64::MAX`。
- LoongArch 增加独立的私有换算 helper：先将 interval 限制到最大可表示的 4-tick 对齐值，再向上对齐。
- 保持两架构的规则各自封装，不引入共同抽象。
- 保留现有 `systimer_enable`、IRQ 生命周期及 clockevent 结构，不带入其他 timer 重构。

## 设计逻辑

RISC-V 的输出语义是 SBI absolute deadline，核心不变量是非零推进和饱和；LoongArch 的输出语义是 TCFG 编码，核心不变量是最小 4 tick、4 tick 对齐以及加法前限幅。两者硬件约束不同，因此分别保留为架构私有 helper。

## 红绿证据

- RISC-V：旧 helper 下运行 `cargo test -p someboot --lib riscv64_deadline_saturates_at_counter_limit`，`current=u64::MAX, interval=0` 在 `now + 1` 处溢出，退出码 101；修复后同一测试通过并返回 `u64::MAX`。
- LoongArch：旧 helper 下运行 `cargo test -p someboot --lib loongarch64_interval_clamps_before_rounding`，`interval=usize::MAX` 在对齐加法处溢出，退出码 101；修复后同一测试通过并返回 `usize::MAX & !3`。

## 验证

- `cargo test -p someboot`：通过（49 个 lib 单元测试及全部集成测试）。
- `cargo xtask clippy --package someboot`：8/8 检查通过。
- `cargo xtask arceos test qemu --arch riscv64 -g rust -c task-sleep`：1/1 通过。
- `cargo xtask arceos test qemu --arch loongarch64 -g rust -c task-sleep`：1/1 通过。
- `cargo fmt --all -- --check`：通过。
- `git diff --check`：通过。