### PR TITLE
fix(some-serial): bound PL011 early-console startup

### DIFF
--- a/book/design/some-serial-pl011-bounded-open.md
+++ b/book/design/some-serial-pl011-bounded-open.md
@@ -1,0 +1,27 @@
+# PL011 early console 有界启动
+
+## 问题
+
+`Pl011::open()` 会先关闭 UART，再等待 `UARTFR.BUSY` 清零。早期启动阶段尚不能假设系统定时器可用；如果硬件、固件或映射异常使 `BUSY` 永久置位，无界轮询会让系统在输出诊断信息之前永久卡住，而且 `UARTCR` 已经被修改。
+
+## 接口与失败语义
+
+`Pl011::open()` 返回值由 `()` 改为 `Result<(), ConfigError>`。这是有意的 breaking API：调用者必须决定初始化失败后是否退出、选择其他控制台或继续无控制台启动。当前可报告的失败是已有的 `ConfigError::Timeout`，不新增重复的错误类型。
+
+`open()` 使用固定次数的寄存器轮询预算，不读取系统时钟，也不依赖中断。这样同一代码可以在 MMU、时钟源和运行时尚未完成初始化时使用。预算只限制启动阶段的 `BUSY` 等待，不改变运行期 `set_config()` 的现有语义。
+
+## 回滚与发布
+
+轮询前完整保存 `UARTCR`，然后关闭 UART。若预算耗尽，驱动把 `UARTCR` 原值完整写回，再返回 `ConfigError::Timeout`；在此之前不修改 FIFO、interrupt mask 或其他配置寄存器。因此失败不会留下半初始化的控制寄存器状态。
+
+someboot 只有在 `open()` 成功后才发布 PL011 early-console 实例：
+
+- cmdline `earlycon=pl011,...` 把 timeout 映射为明确错误，并保持原有 early-console/debug 状态不变；
+- FDT `stdout-path` 路径把失败转换为 `None`，允许现有启动流程继续，但不安装失败实例，也不更新 debug MMIO 状态；
+- `UartPort::startup()` 原样传播 `ConfigError`，由运行时调用者决定策略。
+
+NS16550、PL011 文件结构以及运行期 `set_config()` 不属于本次修改范围。
+
+## 验证
+
+最低层回归使用模拟寄存器永久保持 `UARTFR.BUSY`，验证调用在固定预算后返回 `ConfigError::Timeout`，并验证 `UARTCR` 与调用前逐位一致。集成验证覆盖 some-serial 单元测试、someboot 编译检查，以及 AArch64 上 ArceOS、StarryOS 和 Axvisor 的启动路径。

--- a/drivers/serial/some-serial/src/pl011.rs
+++ b/drivers/serial/some-serial/src/pl011.rs
@@ -10,6 +10,8 @@ use tock_registers::{
 
 use crate::{PollingUart, SerialDirection, SerialEvent, TransBytesError, TransferError};
 
+const OPEN_BUSY_POLL_BUDGET: usize = 1 << 20;
+
 register_bitfields! [
     u32,
 
@@ -172,6 +174,16 @@ impl Pl011 {
         unsafe { &*self.base.0.as_ptr() }
     }
 
+    fn wait_until_idle(&self) -> bool {
+        for _ in 0..OPEN_BUSY_POLL_BUDGET {
+            if !self.registers().uartfr.is_set(UARTFR::BUSY) {
+                return true;
+            }
+            core::hint::spin_loop();
+        }
+        false
+    }
+
     fn current_baudrate(&self) -> u32 {
         let ibrd = self.registers().uartibrd.read(UARTIBRD::BAUD_DIVINT);
         let fbrd = self.registers().uartfbrd.read(UARTFBRD::BAUD_DIVFRAC);
@@ -288,14 +300,20 @@ impl Pl011 {
         Ok(())
     }
 
-    /// 初始化 PL011 UART
-    pub fn open(&mut self) {
+    /// Initializes the PL011 UART.
+    ///
+    /// Returns [`ConfigError::Timeout`] if an in-flight transfer does not
+    /// finish within the fixed early-boot polling budget.
+    pub fn open(&mut self) -> Result<(), ConfigError> {
+        let original_uartcr = self.registers().uartcr.get();
+
         // 禁用 UART
         self.registers().uartcr.modify(UARTCR::UARTEN::CLEAR);
 
         // 等待当前传输完成
-        while self.registers().uartfr.is_set(UARTFR::BUSY) {
-            core::hint::spin_loop();
+        if !self.wait_until_idle() {
+            self.registers().uartcr.set(original_uartcr);
+            return Err(ConfigError::Timeout);
         }
 
         // 清除发送 FIFO
@@ -319,6 +337,7 @@ impl Pl011 {
         self.registers()
             .uartcr
             .modify(UARTCR::UARTEN::SET + UARTCR::TXE::SET + UARTCR::RXE::SET);
+        Ok(())
     }
 
     pub fn set_irq_mask(&mut self, events: SerialEventSet) {
@@ -662,7 +681,7 @@ impl UartIrq for Pl011Irq {
 
 impl UartPort for Pl011 {
     fn startup(&mut self, config: &Config) -> Result<(), ConfigError> {
-        self.open();
+        self.open()?;
         self.set_config(config)?;
         self.mask_all();
         Ok(())
@@ -923,6 +942,24 @@ mod tests {
 
     use super::*;
 
+    // This adapter keeps the regression runnable against both the old `()`
+    // API and the new `Result` API, so the same test exposes the old hang.
+    trait AssertOpenTimeout {
+        fn assert_timeout(self);
+    }
+
+    impl AssertOpenTimeout for () {
+        fn assert_timeout(self) {
+            panic!("unbounded PL011 open returned without reporting a timeout");
+        }
+    }
+
+    impl AssertOpenTimeout for Result<(), ConfigError> {
+        fn assert_timeout(self) {
+            assert_eq!(self, Err(ConfigError::Timeout));
+        }
+    }
+
     #[derive(Default)]
     struct CollectRx(Vec<RxSample>);
 
@@ -974,6 +1011,25 @@ mod tests {
         let mut parts = uart.split();
         parts.port.startup(&Config::new()).unwrap();
         parts
+    }
+
+    #[test]
+    fn early_console_open_has_a_bounded_busy_failure() {
+        let (mut regs, mut uart) = pl011_with_registers();
+        let original_uartcr = (UARTCR::UARTEN::SET
+            + UARTCR::SIREN::SET
+            + UARTCR::LBE::SET
+            + UARTCR::TXE::SET
+            + UARTCR::DTR::SET
+            + UARTCR::OUT2::SET
+            + UARTCR::CTSEN::SET)
+            .value;
+        write_test_reg(&mut regs, 0x018, UARTFR::BUSY::SET.value);
+        write_test_reg(&mut regs, 0x030, original_uartcr);
+
+        uart.open().assert_timeout();
+
+        assert_eq!(read_test_reg(&regs, 0x030), original_uartcr);
     }
 
     #[test]

--- a/platforms/someboot/src/console/mod.rs
+++ b/platforms/someboot/src/console/mod.rs
@@ -10,7 +10,7 @@ use kernutil::memory::{MemoryDescriptor, MemoryType};
 #[cfg(target_arch = "x86_64")]
 use some_serial::ns16550::Port;
 use some_serial::{
-    PollingUart, SerialEvent, TransferError,
+    ConfigError, PollingUart, SerialEvent, TransferError,
     ns16550::{self, Mmio, Ns16550},
     pl011,
 };
@@ -517,7 +517,10 @@ fn set_pl011(config: &EarlyconConfig) -> Result<(), &'static str> {
         NonNull::new(_fixmap_io(base_addr)).ok_or("Invalid base address for pl011 earlycon")?;
 
     let mut serial = pl011::Pl011::new(base_addr, 0);
-    serial.open();
+    serial.open().map_err(|error| match error {
+        ConfigError::Timeout => "PL011 earlycon remained busy until the polling timeout",
+        _ => "Failed to initialize PL011 earlycon",
+    })?;
     set_earlycon_serial(EarlySerial::new(EarlySerialRaw::Pl011(serial)));
 
     Ok(())

--- a/platforms/someboot/src/fdt/earlycon.rs
+++ b/platforms/someboot/src/fdt/earlycon.rs
@@ -52,7 +52,7 @@ fn set_by_stdout() -> Option<()> {
         match com {
             "arm,pl011" | "arm,primecell" => {
                 let mut serial = pl011::Pl011::new(addr, clock);
-                serial.open();
+                serial.open().ok()?;
                 crate::console::set_earlycon_serial(EarlySerial::new(EarlySerialRaw::Pl011(
                     serial,
                 )));


### PR DESCRIPTION
## 问题

`Pl011::open()` 在关闭 UART 后无界等待 `UARTFR.BUSY` 清零。若早期 MMIO、固件或硬件状态异常，系统会在 timer 和完整诊断能力可用前永久卡住，并留下已修改的 `UARTCR`。同时，现有无返回值接口无法让 someboot 或运行时决定失败策略。

## 修改

- 将公共 `Pl011::open()` 改为 `Result<(), ConfigError>`，复用 `ConfigError::Timeout`。
- 使用固定 `1 << 20` 次 polling budget，不依赖早期 timer 或 IRQ。
- polling 前保存完整 `UARTCR`；timeout 时逐位恢复原值，并且不继续修改 FIFO、中断 mask 或其他配置。
- `UartPort::startup()` 使用 `self.open()?` 原样传播失败。
- cmdline PL011 earlycon 将 timeout 映射为明确错误，成功前不安装实例、不更新 debug 状态。
- FDT `stdout-path` PL011 路径将失败转为 `None`，成功前同样不安装实例、不更新 debug MMIO 状态。
- 增加设计材料，记录 breaking API、polling budget、回滚与兼容取舍。

本 PR 不改变 NS16550，不拆分 PL011 文件，也不改变运行期 `set_config()` 的等待语义。

## 设计逻辑

早期控制台不能假定计时器已经可用，因此用固定寄存器读取预算保证调用终止。失败前唯一副作用是关闭 `UARTEN`，保存并恢复完整 `UARTCR` 即可形成明确的事务边界。返回 typed error 后，公共驱动、cmdline 和 FDT 三个调用边界分别采用传播、明确报错和可选降级策略。

## 红绿证据

回归 `early_console_open_has_a_bounded_busy_failure` 使用模拟寄存器永久保持 `UARTFR.BUSY`：

- 旧实现运行 `timeout 5s cargo test -p some-serial --lib early_console_open_has_a_bounded_busy_failure`，测试进入无界轮询并以 124 退出。
- 修复后运行同一测试，正常返回 `ConfigError::Timeout`，并断言 `UARTCR` 与调用前逐位一致。

## 验证

- `cargo test -p some-serial --lib`：48/48 通过。
- `cargo xtask clippy --package some-serial --package someboot`：10/10 检查通过。
- `cargo xtask arceos test qemu --arch aarch64 -g rust -c display-basic`：1/1 通过。
- `cargo xtask starry test qemu --arch aarch64 -c qemu/system/bugfix-bug-futex-wait-wake`：1/1 通过。
- `cargo xtask axvisor test qemu --arch aarch64 -g normal -c smoke`：1/1 通过。
- `cargo fmt --all -- --check`：通过。
- `git diff --check`：通过。