### PR TITLE
fix(axvirtio-common): harden shared virtqueue against untrusted guests

### DIFF
--- a/virtualization/axvirtio-blk/src/mmio/device.rs
+++ b/virtualization/axvirtio-blk/src/mmio/device.rs
@@ -128,6 +128,11 @@ impl<B: BlockBackend, T: GuestMemoryAccessor + Clone> VirtioMmioBlockDevice<B, T
 
     /// Handles an MMIO write using a guest-memory capability scoped to this
     /// device access.
+    ///
+    /// The capability backs the `QUEUE_READY` ring-layout validation as well
+    /// as queue processing, so runtimes whose queues were constructed with a
+    /// non-translating placeholder accessor (e.g. axvisor) can still make
+    /// queues ready.
     pub fn mmio_write_with_memory(
         &self,
         addr: GuestPhysAddr,
@@ -135,7 +140,10 @@ impl<B: BlockBackend, T: GuestMemoryAccessor + Clone> VirtioMmioBlockDevice<B, T
         val: usize,
         memory: &mut dyn axvirtio_common::GuestMemory,
     ) -> VirtioResult<BlockDeviceEvent> {
-        match self.state.mmio_write(addr, width, val)? {
+        match self
+            .state
+            .mmio_write_with_memory(addr, width, val, memory)?
+        {
             MmioWriteAction::None => Ok(BlockDeviceEvent::None),
             MmioWriteAction::Reset => {
                 // A transport reset invalidates every in-flight descriptor,

--- a/virtualization/axvirtio-blk/tests/block_tests.rs
+++ b/virtualization/axvirtio-blk/tests/block_tests.rs
@@ -17,6 +17,7 @@ use axdevice_base::{
 use axvirtio_blk::{
     BlockBackend, ManagedVirtioBlockDevice, VirtioBlockConfig, VirtioMmioBlockDevice, VirtioResult,
 };
+use axvirtio_common::{AddressSpaceMemory, NoGuestMemoryAccessor};
 use axvm_types::{AccessWidth, GuestPhysAddr};
 
 // ============================================================================
@@ -515,6 +516,12 @@ mod mmio_device_tests {
     const VIRTIO_MMIO_DEVICE_FEATURES_SEL: u32 = 0x014;
     const VIRTIO_MMIO_QUEUE_NUM_MAX: u32 = 0x034;
     const VIRTIO_MMIO_STATUS: u32 = 0x070;
+    const VIRTIO_MMIO_QUEUE_SEL: u32 = 0x030;
+    const VIRTIO_MMIO_QUEUE_NUM: u32 = 0x038;
+    const VIRTIO_MMIO_QUEUE_READY: u32 = 0x044;
+    const VIRTIO_MMIO_QUEUE_DESC_LOW: u32 = 0x080;
+    const VIRTIO_MMIO_QUEUE_AVAIL_LOW: u32 = 0x090;
+    const VIRTIO_MMIO_QUEUE_USED_LOW: u32 = 0x0a0;
     const VIRTIO_MMIO_CONFIG: u32 = 0x100;
 
     const MMIO_MAGIC: u32 = 0x74726976; // "virt" in little endian
@@ -701,6 +708,84 @@ mod mmio_device_tests {
         // Queue 100 should not exist
         let queue = device.get_queue(100);
         assert!(queue.is_none());
+    }
+
+    #[test]
+    fn test_queue_ready_requires_scoped_memory_with_placeholder_accessor() {
+        // axvisor constructs the block device with `NoGuestMemoryAccessor` and
+        // holds real guest memory only as a scoped capability at MMIO access
+        // time (`os/axvisor/src/virtio_blk.rs`). The `QUEUE_READY` layout
+        // validation must be screened against that scoped memory: the
+        // accessor-based fallback cannot translate any guest address, while
+        // the scoped path validates the same layout against the real backing
+        // and must make the queue ready.
+        let backend = MockBlockBackend::new(2048, 512);
+        let config = VirtioBlockConfig::default();
+        let base_ipa = GuestPhysAddr::from(0x0a000000);
+        let device =
+            VirtioMmioBlockDevice::new(base_ipa, 0x200, backend, config, NoGuestMemoryAccessor)
+                .unwrap();
+
+        // Program a valid in-bounds layout (desc 0x1000, avail 0x2000,
+        // used 0x3000; all inside the 1 MiB backing below).
+        for (reg, val) in [
+            (VIRTIO_MMIO_QUEUE_SEL, 0),
+            (VIRTIO_MMIO_QUEUE_NUM, 4),
+            (VIRTIO_MMIO_QUEUE_DESC_LOW, 0x1000),
+            (VIRTIO_MMIO_QUEUE_AVAIL_LOW, 0x2000),
+            (VIRTIO_MMIO_QUEUE_USED_LOW, 0x3000),
+        ] {
+            device
+                .mmio_write(
+                    GuestPhysAddr::from(base_ipa.as_usize() + reg as usize),
+                    AccessWidth::Dword,
+                    val,
+                )
+                .unwrap();
+        }
+
+        // The accessor-based path must reject the layout: the queue's own
+        // accessor cannot translate any guest address.
+        device
+            .mmio_write(
+                GuestPhysAddr::from(base_ipa.as_usize() + VIRTIO_MMIO_QUEUE_READY as usize),
+                AccessWidth::Dword,
+                1,
+            )
+            .unwrap();
+        assert_eq!(
+            device
+                .mmio_read(
+                    GuestPhysAddr::from(base_ipa.as_usize() + VIRTIO_MMIO_QUEUE_READY as usize),
+                    AccessWidth::Dword,
+                )
+                .unwrap(),
+            0,
+            "the queue's own accessor cannot satisfy the layout probe"
+        );
+
+        // The scoped-memory path validates the same addresses against the real
+        // backing and must make the queue ready.
+        let backing = MockGuestMemoryAccessor::new(1024 * 1024);
+        let mut memory = AddressSpaceMemory::new(&backing);
+        device
+            .mmio_write_with_memory(
+                GuestPhysAddr::from(base_ipa.as_usize() + VIRTIO_MMIO_QUEUE_READY as usize),
+                AccessWidth::Dword,
+                1,
+                &mut memory,
+            )
+            .unwrap();
+        assert_eq!(
+            device
+                .mmio_read(
+                    GuestPhysAddr::from(base_ipa.as_usize() + VIRTIO_MMIO_QUEUE_READY as usize),
+                    AccessWidth::Dword,
+                )
+                .unwrap(),
+            1,
+            "the scoped-memory path must make the queue ready"
+        );
     }
 }
 

--- a/virtualization/axvirtio-common/src/error.rs
+++ b/virtualization/axvirtio-common/src/error.rs
@@ -7,7 +7,7 @@
 pub enum VirtioError {
     /// Invalid queue configuration
     InvalidQueue,
-    /// Queue not ready for operation
+    /// Queue not ready for operation (not configured yet)
     QueueNotReady,
     /// Invalid descriptor
     InvalidDescriptor,
@@ -37,6 +37,19 @@ pub enum VirtioError {
     InvalidRegister,
     /// Invalid address or address translation failed
     InvalidAddress,
+    /// One or more virtqueue rings are misaligned (desc 16B, avail 2B, used 4B)
+    RingMisaligned,
+    /// The virtqueue ring regions overlap each other
+    RingOverlap,
+    /// The virtqueue ring layout is invalid (zero address, region overflow, or
+    /// a ring region lies outside the guest address space)
+    InvalidRingLayout,
+    /// The queue is faulted after a runtime ring/descriptor failure and must be
+    /// reset before further use. Unlike [`QueueNotReady`](Self::QueueNotReady),
+    /// which is a normal pre-configuration state, a faulted queue has served
+    /// requests and hit a runtime failure; it rejects all queue operations and
+    /// writes no guest memory until `reset`.
+    QueueFaulted,
     /// Resource not found
     NotFound,
     /// The operation is valid but cannot complete until asynchronous backend

--- a/virtualization/axvirtio-common/src/error.rs
+++ b/virtualization/axvirtio-common/src/error.rs
@@ -47,8 +47,10 @@ pub enum VirtioError {
     /// The queue is faulted after a runtime ring/descriptor failure and must be
     /// reset before further use. Unlike [`QueueNotReady`](Self::QueueNotReady),
     /// which is a normal pre-configuration state, a faulted queue has served
-    /// requests and hit a runtime failure; it rejects all queue operations and
-    /// writes no guest memory until `reset`.
+    /// requests and hit a runtime failure; its guest-serving data paths
+    /// (`pop`/`complete`, chain walks and data access) reject with this error
+    /// and write no guest memory until `reset`, while the configuration
+    /// setters remain usable.
     QueueFaulted,
     /// Resource not found
     NotFound,

--- a/virtualization/axvirtio-common/src/mmio/state.rs
+++ b/virtualization/axvirtio-common/src/mmio/state.rs
@@ -253,11 +253,47 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
     }
 
     /// Handle a standard MMIO write and report any action the device must take.
+    ///
+    /// The `QUEUE_READY` layout validation is screened against the selected
+    /// queue's own guest-memory accessor. Runtimes whose real guest memory
+    /// only exists as a scoped capability at MMIO access time must use
+    /// [`mmio_write_with_memory`](Self::mmio_write_with_memory) instead.
     pub fn mmio_write(
         &self,
         addr: GuestPhysAddr,
         width: AccessWidth,
         val: usize,
+    ) -> VirtioResult<MmioWriteAction> {
+        self.mmio_write_inner(addr, width, val, None)
+    }
+
+    /// Handles a standard MMIO write using a scoped guest-memory capability.
+    ///
+    /// The capability is used for the `QUEUE_READY` layout validation and
+    /// must be backed by the same guest memory the queues' runtime accesses
+    /// use; passing a capability over different memory makes the layout
+    /// check vacuous.
+    pub fn mmio_write_with_memory(
+        &self,
+        addr: GuestPhysAddr,
+        width: AccessWidth,
+        val: usize,
+        memory: &mut dyn crate::GuestMemory,
+    ) -> VirtioResult<MmioWriteAction> {
+        self.mmio_write_inner(addr, width, val, Some(memory))
+    }
+
+    /// Shared MMIO write implementation.
+    ///
+    /// `ready_memory` is the scoped capability used to screen the selected
+    /// queue's ring layout on a `QUEUE_READY` write; `None` falls back to a
+    /// capability built from the queue's own accessor.
+    fn mmio_write_inner(
+        &self,
+        addr: GuestPhysAddr,
+        width: AccessWidth,
+        val: usize,
+        ready_memory: Option<&mut dyn crate::GuestMemory>,
     ) -> VirtioResult<MmioWriteAction> {
         if !transport::is_address_in_range(addr, self.base_ipa, self.length) {
             return Ok(MmioWriteAction::None);
@@ -294,11 +330,22 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
             }
             vc::VIRTIO_MMIO_QUEUE_READY => {
                 let sel = *self.queue_sel.lock_irqsave();
+                // Hold the queues lock across the layout check and the ready
+                // transition so validation and `set_ready` form one atomic
+                // enforcement point. The probe is bounded (first/last byte of
+                // the three ring regions) and performs no callbacks, so the
+                // hold is short.
                 if let Some(q) = self.queues.lock_irqsave().get_mut(sel as usize) {
                     let layout_ok = if q.is_configured() {
-                        let accessor = q.accessor().clone();
-                        let mut memory = crate::AddressSpaceMemory::new(&*accessor);
-                        q.validate_layout_with_memory(&mut memory).is_ok()
+                        match ready_memory {
+                            Some(memory) => q.validate_layout_with_memory(memory),
+                            None => {
+                                let accessor = q.accessor().clone();
+                                let mut memory = crate::AddressSpaceMemory::new(&*accessor);
+                                q.validate_layout_with_memory(&mut memory)
+                            }
+                        }
+                        .is_ok()
                     } else {
                         false
                     };

--- a/virtualization/axvirtio-common/src/mmio/state.rs
+++ b/virtualization/axvirtio-common/src/mmio/state.rs
@@ -295,7 +295,14 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
             vc::VIRTIO_MMIO_QUEUE_READY => {
                 let sel = *self.queue_sel.lock_irqsave();
                 if let Some(q) = self.queues.lock_irqsave().get_mut(sel as usize) {
-                    q.set_ready(val != 0);
+                    let layout_ok = if q.is_configured() {
+                        let accessor = q.accessor().clone();
+                        let mut memory = crate::AddressSpaceMemory::new(&*accessor);
+                        q.validate_layout_with_memory(&mut memory).is_ok()
+                    } else {
+                        false
+                    };
+                    q.set_ready(val != 0 && layout_ok);
                 }
             }
             vc::VIRTIO_MMIO_QUEUE_NOTIFY => return Ok(MmioWriteAction::QueueNotified(val as u16)),

--- a/virtualization/axvirtio-common/src/queue/available.rs
+++ b/virtualization/axvirtio-common/src/queue/available.rs
@@ -124,13 +124,27 @@ impl<T: GuestMemoryAccessor + Clone> AvailableRing<T> {
 
     /// Get the address of the used event field (if event_idx is enabled)
     pub fn used_event_addr(&self) -> GuestPhysAddr {
-        let offset = core::mem::size_of::<VirtQueueAvail>() + (self.size as usize * 2);
-        self.base_addr + offset
+        // Header + ring array fill the region up to 2 bytes before its end;
+        // the `used_event` footer is always part of the region (see
+        // `layout_size`).
+        self.base_addr + Self::layout_size(self.size) - 2
     }
 
-    /// Calculate the total size of the available ring
+    /// Size in bytes of the complete available ring for a queue of `size`
+    /// entries, including the trailing 2-byte `used_event` field.
+    ///
+    /// The footer is always counted: a driver that negotiated
+    /// `VIRTIO_F_RING_EVENT_IDX` writes `used_event` there, and layout
+    /// validation must not depend on negotiation state.
+    pub(crate) const fn layout_size(size: u16) -> usize {
+        core::mem::size_of::<VirtQueueAvail>() + (size as usize) * 2 + 2
+    }
+
+    /// The size in bytes this ring occupies in guest memory, always including
+    /// the trailing 2-byte event-index footer (see
+    /// [`layout_size`](Self::layout_size)).
     pub fn total_size(&self) -> usize {
-        core::mem::size_of::<VirtQueueAvail>() + (self.size as usize * 2) + 2
+        Self::layout_size(self.size)
     }
 
     /// Check if the available ring is valid
@@ -291,5 +305,22 @@ impl<T: GuestMemoryAccessor + Clone> AvailableRing<T> {
         self.accessor
             .write_obj(event_addr, event)
             .map_err(|_| VirtioError::InvalidAddress)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoGuestMemoryAccessor;
+
+    #[test]
+    fn layout_size_counts_header_entries_and_footer() {
+        // header (4) + 4 entries * 2 bytes + used_event footer (2) = 14.
+        assert_eq!(AvailableRing::<NoGuestMemoryAccessor>::layout_size(4), 14);
+        // Boundary: the largest queue size still counts the footer.
+        assert_eq!(
+            AvailableRing::<NoGuestMemoryAccessor>::layout_size(256),
+            4 + 256 * 2 + 2
+        );
     }
 }

--- a/virtualization/axvirtio-common/src/queue/descriptor.rs
+++ b/virtualization/axvirtio-common/src/queue/descriptor.rs
@@ -228,9 +228,18 @@ impl DescriptorTable {
         Some(self.base_addr + offset)
     }
 
+    /// Size in bytes of the descriptor table for a queue of `size` descriptors.
+    ///
+    /// Owns the `size * sizeof(VirtQueueDesc)` math so ring-region derivation
+    /// (`VirtioQueue::ring_regions`) cannot drift from the per-descriptor
+    /// address computation.
+    pub(crate) const fn layout_size(size: u16) -> usize {
+        size as usize * core::mem::size_of::<VirtQueueDesc>()
+    }
+
     /// Calculate the total size of the descriptor table
     pub fn total_size(&self) -> usize {
-        self.size as usize * core::mem::size_of::<VirtQueueDesc>()
+        Self::layout_size(self.size)
     }
 
     /// Check if the descriptor table is valid
@@ -515,5 +524,13 @@ mod tests {
         table.write_desc(1, &d1_ok, &mut memory).unwrap();
         let ok_addr = table.get_status_addr(0, &mut memory).unwrap();
         assert_eq!(ok_addr.as_usize(), 0x200);
+    }
+
+    #[test]
+    fn layout_size_counts_descriptors() {
+        // 4 descriptors * 16 bytes (VirtQueueDesc) = 64.
+        assert_eq!(DescriptorTable::layout_size(4), 64);
+        // Boundary: the largest queue size still counts every descriptor.
+        assert_eq!(DescriptorTable::layout_size(256), 4096);
     }
 }

--- a/virtualization/axvirtio-common/src/queue/descriptor.rs
+++ b/virtualization/axvirtio-common/src/queue/descriptor.rs
@@ -368,7 +368,7 @@ impl DescriptorTable {
             current = desc.next;
             // A chain referencing more than `size` descriptors is a cycle or
             // corruption. Bounding the walk also guarantees termination.
-            if descriptors.len() >= self.size as usize {
+            if descriptors.len() > self.size as usize {
                 return Err(VirtioError::InvalidDescriptor);
             }
         }

--- a/virtualization/axvirtio-common/src/queue/mod.rs
+++ b/virtualization/axvirtio-common/src/queue/mod.rs
@@ -3,13 +3,13 @@ mod descriptor;
 mod used;
 
 use alloc::{sync::Arc, vec::Vec};
-use core::cell::Cell;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 pub use available::{AvailableRing, VirtQueueAvail};
 use axaddrspace::GuestMemoryAccessor;
 use axvm_types::GuestPhysAddr;
 pub use descriptor::{DescriptorChain, DescriptorTable, VirtQueueDesc};
-use log::trace;
+use log::{trace, warn};
 pub use used::{UsedRing, VirtQueueUsed, VirtqUsedElem};
 
 use crate::{
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// VirtIO queue implementation
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct VirtioQueue<T: GuestMemoryAccessor + Clone> {
     /// Queue index
     pub index: u16,
@@ -47,22 +47,56 @@ pub struct VirtioQueue<T: GuestMemoryAccessor + Clone> {
     next_avail: u16,
     /// Next used index
     next_used: u16,
-    /// Event index enabled
+    /// Event index enabled.
+    ///
+    /// Currently always `false` and intentionally unused: event-index feature
+    /// negotiation is not implemented yet, and a follow-up will wire this
+    /// flag. Layout validation deliberately does not depend on it: the ring
+    /// regions always include the 2-byte event-index footer through the
+    /// `layout_size` math, so the check stays negotiation-independent.
     pub event_idx_enabled: bool,
     /// Set when a runtime ring/descriptor validation failure occurs; the queue
     /// rejects `pop`/`complete` and the guest-data paths until
     /// [`reset`](Self::reset) clears it.
     ///
-    /// Uses interior mutability so that `&self` validation queries
-    /// ([`descriptor_chain_with_memory`](Self::descriptor_chain_with_memory),
-    /// [`get_status_addr`](Self::get_status_addr),
-    /// [`should_notify`](Self::should_notify)) can latch the failure; the
-    /// `&mut` paths (`pop`, `complete`, `reset`) only read the flag. The queue
-    /// is always guarded by the owning device's lock (the MMIO transport holds
-    /// its queue mutex for every access), so callers must never alias the
-    /// queue across threads without that mutual exclusion; `Cell` is only
-    /// sound under that single-owner rule.
-    faulted: Cell<bool>,
+    /// A single bool that latches only `false -> true` (no lost-update
+    /// concern): the `Release` store in `latch_fault` publishes the fault to
+    /// any thread that later queries `is_faulted` with an `Acquire` load.
+    /// The queue is expected to be guarded by the owning device's lock, but
+    /// unlike a `Cell` the atomic stays sound even if the queue is aliased
+    /// across threads.
+    faulted: AtomicBool,
+    /// Set once per configuration cycle after the layout-rejection warning has
+    /// been emitted. A guest can re-trigger the `QUEUE_READY` memory probe
+    /// unboundedly, so repeats are logged at `trace!` instead of `warn!`;
+    /// [`reset`](Self::reset) clears the latch for the next configuration.
+    layout_warn_emitted: AtomicBool,
+}
+
+impl<T: GuestMemoryAccessor + Clone> Clone for VirtioQueue<T> {
+    /// Clones the queue configuration, snapshotting the current faulted and
+    /// layout-warning latch states into fresh atomics (the clone does not
+    /// share the original's latches).
+    fn clone(&self) -> Self {
+        Self {
+            index: self.index,
+            size: self.size,
+            desc_table: self.desc_table.clone(),
+            avail_ring: self.avail_ring.clone(),
+            used_ring: self.used_ring.clone(),
+            accessor: self.accessor.clone(),
+            max_size: self.max_size,
+            ready: self.ready,
+            desc_table_addr: self.desc_table_addr,
+            avail_ring_addr: self.avail_ring_addr,
+            used_ring_addr: self.used_ring_addr,
+            next_avail: self.next_avail,
+            next_used: self.next_used,
+            event_idx_enabled: self.event_idx_enabled,
+            faulted: AtomicBool::new(self.faulted.load(Ordering::Acquire)),
+            layout_warn_emitted: AtomicBool::new(self.layout_warn_emitted.load(Ordering::Acquire)),
+        }
+    }
 }
 
 impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
@@ -83,7 +117,8 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
             next_avail: 0,
             next_used: 0,
             event_idx_enabled: false,
-            faulted: Cell::new(false),
+            faulted: AtomicBool::new(false),
+            layout_warn_emitted: AtomicBool::new(false),
         }
     }
 
@@ -164,6 +199,13 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     /// - the three regions do not overlap (overlap would let a used-element
     ///   write corrupt descriptors the device is about to read).
     ///
+    /// The available and used regions always include their 2-byte event-index
+    /// footer (`used_event` / `avail_event`), even when
+    /// `VIRTIO_F_RING_EVENT_IDX` is not negotiated: a driver that negotiated
+    /// it writes into those bytes, and the ring types' own `total_size`
+    /// counts them. Always covering the footer is the conservative,
+    /// negotiation-independent envelope.
+    ///
     /// The transport is expected to call this from its single "queue becomes
     /// usable" enforcement point (MMIO: the `QUEUE_READY` write; PCI: layout
     /// programmed in the queue config registers) and to refuse to mark the
@@ -204,15 +246,29 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         Ok(())
     }
 
-    /// Validate the ring layout like [`validate_layout`](Self::validate_layout)
-    /// and additionally require every ring region to lie entirely inside the
-    /// guest address space, translated through `memory`.
+    /// Validates the ring layout like [`validate_layout`](Self::validate_layout)
+    /// and additionally screens the ring regions against `memory`: the first
+    /// byte and the last byte (`end - 1`) of every region must be readable
+    /// through `memory`.
     ///
-    /// `memory` must be the same capability used for the queue's runtime
-    /// accesses, so a layout accepted here cannot fail later because a ring
-    /// address is unmapped or reaches past the end of a mapped region. Any
-    /// failure is reported as [`VirtioError::InvalidRingLayout`] so the caller
-    /// only needs to distinguish "layout rejected" from "queue ready".
+    /// `memory` must be backed by the same accessor the queue uses for its
+    /// runtime accesses; passing a capability over different memory makes the
+    /// check vacuous. Only the two boundary bytes per region are probed on
+    /// purpose: this is a best-effort enable-time screen, and the per-byte
+    /// runtime accesses are what ultimately verify mid-region mapping.
+    ///
+    /// An accessor that cannot translate any guest address (such as
+    /// [`NoGuestMemoryAccessor`](crate::memory::NoGuestMemoryAccessor), whose
+    /// `translate_and_get_limit` always returns `None`) fails every probe and
+    /// therefore cannot satisfy this check; such layouts are rejected (the
+    /// first rejection per configuration cycle is warned, later ones only
+    /// traced), so the MMIO transport requires an accessor backed by real
+    /// guest memory. Memory-screening failures are reported as
+    /// [`VirtioError::InvalidRingLayout`], while pure layout errors keep their
+    /// specific variants ([`RingMisaligned`](VirtioError::RingMisaligned),
+    /// [`RingOverlap`](VirtioError::RingOverlap)); any `Err` means the layout
+    /// was rejected, so the caller only needs to distinguish "layout rejected"
+    /// from "queue ready".
     pub fn validate_layout_with_memory(
         &self,
         memory: &mut dyn crate::GuestMemory,
@@ -220,16 +276,30 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         self.validate_layout()?;
         for region in self.ring_regions() {
             let end = region.end().ok_or(VirtioError::InvalidRingLayout)?;
-            // `usize::MAX` denotes "no bound" for `GuestMemory` implementations
-            // derived from an accessor without a real address space.
-            if end == usize::MAX {
-                continue;
-            }
             if memory.read(region.base, &mut [0u8; 1]).is_err()
                 || memory
                     .read(GuestPhysAddr::from(end - 1), &mut [0u8; 1])
                     .is_err()
             {
+                // A guest can write QUEUE_READY unboundedly, so warn only once
+                // per configuration cycle; later rejections are traced.
+                if self.layout_warn_emitted.swap(true, Ordering::AcqRel) {
+                    trace!(
+                        "virtqueue {}: ring region 0x{:x}..0x{:x} is still not fully mapped; \
+                         rejecting layout again",
+                        self.index,
+                        region.base.as_usize(),
+                        end,
+                    );
+                } else {
+                    warn!(
+                        "virtqueue {}: ring region 0x{:x}..0x{:x} is not fully mapped in guest \
+                         memory; rejecting layout",
+                        self.index,
+                        region.base.as_usize(),
+                        end,
+                    );
+                }
                 return Err(VirtioError::InvalidRingLayout);
             }
         }
@@ -237,23 +307,36 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     }
 
     /// The three ring regions derived from the current layout.
+    ///
+    /// The available and used regions always include their 2-byte event-index
+    /// footer, regardless of whether `VIRTIO_F_RING_EVENT_IDX` is negotiated;
+    /// the size math is owned by `DescriptorTable::layout_size`,
+    /// `AvailableRing::layout_size` and `UsedRing::layout_size` so the footer
+    /// cannot be forgotten here.
     fn ring_regions(&self) -> [RingRegion; 3] {
-        let size = self.size as usize;
-        let desc_size = size * core::mem::size_of::<VirtQueueDesc>();
-        let avail_size = core::mem::size_of::<VirtQueueAvail>() + size * 2;
-        let used_size =
-            core::mem::size_of::<VirtQueueUsed>() + size * core::mem::size_of::<VirtqUsedElem>();
         [
-            RingRegion::new(self.desc_table_addr, desc_size),
-            RingRegion::new(self.avail_ring_addr, avail_size),
-            RingRegion::new(self.used_ring_addr, used_size),
+            RingRegion::new(
+                self.desc_table_addr,
+                DescriptorTable::layout_size(self.size),
+            ),
+            RingRegion::new(
+                self.avail_ring_addr,
+                AvailableRing::<T>::layout_size(self.size),
+            ),
+            RingRegion::new(self.used_ring_addr, UsedRing::<T>::layout_size(self.size)),
         ]
     }
 
     /// Whether the queue is in the faulted state and must be reset before
     /// further `pop`/`complete` calls.
+    ///
+    /// While faulted, the guest-serving data paths (`pop`/`complete`, chain
+    /// walks and data access) reject with [`VirtioError::QueueFaulted`]. The
+    /// configuration setters remain usable so a driver can re-program the
+    /// queue, and [`reset`](Self::reset) is the only operation that clears
+    /// the fault.
     pub fn is_faulted(&self) -> bool {
-        self.faulted.get()
+        self.faulted.load(Ordering::Acquire)
     }
 
     /// Check if queue is valid and ready
@@ -268,10 +351,18 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     /// Latch the queue into the faulted state after a runtime validation
     /// failure; `pop`/`complete` are rejected until [`reset`](Self::reset).
     fn latch_fault(&self) {
-        self.faulted.set(true);
+        self.faulted.store(true, Ordering::Release);
+        trace!("virtqueue {}: latched faulted state", self.index);
     }
 
-    /// Reset the queue
+    /// Reset the queue: clears the ready flag, the faulted state and the
+    /// layout-warning latch, and discards the programmed ring addresses,
+    /// indices and ring objects, so the driver must re-program the queue
+    /// before it can be used again.
+    ///
+    /// While faulted, the guest-serving data paths reject with
+    /// [`VirtioError::QueueFaulted`] but the configuration setters remain
+    /// usable; `reset` is the only operation that clears the fault.
     pub fn reset(&mut self) {
         self.ready = false;
         self.desc_table_addr = GuestPhysAddr::from(0);
@@ -282,16 +373,21 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         self.desc_table = None;
         self.avail_ring = None;
         self.used_ring = None;
-        self.faulted.set(false);
+        self.faulted.store(false, Ordering::Release);
+        self.layout_warn_emitted.store(false, Ordering::Release);
     }
 
-    /// Read available ring index
+    /// Read available ring index through the queue's own accessor.
+    ///
+    /// Returns [`VirtioError::QueueFaulted`] when the queue is faulted and
+    /// [`VirtioError::QueueNotReady`] when the available ring is not
+    /// configured (not a runtime failure, so the queue is not faulted). A read
+    /// failure of a configured ring is a runtime failure and latches the
+    /// fault, matching the other avail-ring pre-read paths.
     pub fn read_avail_idx(&self) -> VirtioResult<u16> {
-        if let Some(ref avail_ring) = self.avail_ring {
-            avail_ring.get_avail_idx()
-        } else {
-            Err(VirtioError::QueueNotReady)
-        }
+        let accessor = self.accessor.clone();
+        let mut memory = crate::AddressSpaceMemory::new(&*accessor);
+        self.read_avail_idx_with_memory(&mut memory)
     }
 
     /// Reads the available index with a scoped memory capability.
@@ -305,7 +401,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         &self,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<u16> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         let Some(avail_ring) = self.avail_ring.as_ref() else {
@@ -318,27 +414,32 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         result
     }
 
-    /// Add a used buffer to the used ring
+    /// Add a used buffer to the used ring.
+    ///
+    /// Returns [`VirtioError::QueueNotReady`] when the queue is not ready or
+    /// the used ring is not configured: a missing used ring is never silently
+    /// accepted as a success (the historical fallback did exactly that).
+    /// Being unconfigured is not a runtime failure, so the queue is not
+    /// faulted; a guest-memory write failure on a configured ring does latch
+    /// the fault.
     pub fn add_used(&mut self, desc_index: u16, len: u32) -> VirtioResult<()> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         if !self.is_valid() {
             return Err(VirtioError::QueueNotReady);
         }
 
-        let result = if let Some(ref mut used_ring) = self.used_ring {
-            let result = used_ring.add_used(desc_index as u32, len);
-            if result.is_ok() {
-                self.next_used = used_ring.get_used_idx();
-            }
-            result
-        } else {
-            // Fallback: just update the index
-            self.next_used = (self.next_used + 1) % self.size;
-            Ok(())
+        let Some(used_ring) = self.used_ring.as_mut() else {
+            // No used ring is configured: completing into nothing would be
+            // an "error success" against this crate's fault contract, so
+            // report QueueNotReady without latching the fault.
+            return Err(VirtioError::QueueNotReady);
         };
-        if result.is_err() {
+        let result = used_ring.add_used(desc_index as u32, len);
+        if result.is_ok() {
+            self.next_used = used_ring.get_used_idx();
+        } else {
             // A guest-memory write failure on a configured queue is a runtime
             // failure: latch the fault so no "error success" completion can
             // follow, mirroring `complete_with_memory`.
@@ -363,7 +464,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         &mut self,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<Option<u16>> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         if !self.is_valid() {
@@ -432,7 +533,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         head: u16,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<DescriptorChain> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         let Some(ref desc_table) = self.desc_table else {
@@ -470,7 +571,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         written_len: u32,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<bool> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         let result = (|| {
@@ -506,13 +607,17 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         self.desc_table.as_ref()
     }
 
-    /// Read available ring entry
+    /// Read available ring entry through the queue's own accessor.
+    ///
+    /// Returns [`VirtioError::QueueFaulted`] when the queue is faulted and
+    /// [`VirtioError::QueueNotReady`] when the available ring is not
+    /// configured (not a runtime failure, so the queue is not faulted). A read
+    /// failure of a configured ring is a runtime failure and latches the
+    /// fault, matching the other avail-ring pre-read paths.
     pub fn read_avail_entry(&self, ring_index: u16) -> VirtioResult<u16> {
-        if let Some(ref avail_ring) = self.avail_ring {
-            avail_ring.read_avail_ring_entry(ring_index)
-        } else {
-            Err(VirtioError::QueueNotReady)
-        }
+        let accessor = self.accessor.clone();
+        let mut memory = crate::AddressSpaceMemory::new(&*accessor);
+        self.read_avail_entry_with_memory(ring_index, &mut memory)
     }
 
     /// Reads an available-ring entry with a scoped memory capability.
@@ -527,7 +632,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         ring_index: u16,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<u16> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         let Some(avail_ring) = self.avail_ring.as_ref() else {
@@ -569,7 +674,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         head_index: u16,
         min_length: usize,
     ) -> VirtioResult<bool> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         let Some(ref desc_table) = self.desc_table else {
@@ -595,7 +700,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         head_index: u16,
         device_type: VirtioDeviceID,
     ) -> VirtioResult<Vec<(GuestPhysAddr, usize, bool)>> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         let Some(ref desc_table) = self.desc_table else {
@@ -615,7 +720,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     /// configured and [`VirtioError::QueueFaulted`] when the queue is faulted.
     /// Any guest-memory failure on a configured queue latches the fault.
     pub fn get_status_addr(&self, head_index: u16) -> VirtioResult<GuestPhysAddr> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         let Some(ref desc_table) = self.desc_table else {
@@ -641,7 +746,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     /// configured (not a runtime failure, so the queue is not faulted), and
     /// latches the fault on a read failure of a configured ring.
     pub fn should_notify(&self) -> VirtioResult<bool> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         let Some(ref avail_ring) = self.avail_ring else {
@@ -665,7 +770,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     /// configured and [`VirtioError::QueueFaulted`] when the queue is faulted;
     /// a faulted queue never writes guest memory.
     pub fn write_status_byte(&self, head_index: u16, status: u8) -> VirtioResult<()> {
-        if self.faulted.get() {
+        if self.faulted.load(Ordering::Acquire) {
             return Err(VirtioError::QueueFaulted);
         }
         // Get the status descriptor address (last descriptor in chain)

--- a/virtualization/axvirtio-common/src/queue/mod.rs
+++ b/virtualization/axvirtio-common/src/queue/mod.rs
@@ -123,8 +123,17 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     }
 
     /// Set queue size
+    ///
+    /// Rejected once any ring address is programmed or the queue is ready: the
+    /// ring objects snapshot the size when their address is set, so a later
+    /// resize would leave layout validation and runtime ring accesses derived
+    /// from different sizes, letting the queue serve requests outside the
+    /// validated regions.
     pub fn set_size(&mut self, size: u16) -> VirtioResult<()> {
         if size == 0 || size > self.max_size || (size & (size - 1)) != 0 {
+            return Err(VirtioError::InvalidQueue);
+        }
+        if self.ready || self.is_configured() {
             return Err(VirtioError::InvalidQueue);
         }
         self.size = size;

--- a/virtualization/axvirtio-common/src/queue/mod.rs
+++ b/virtualization/axvirtio-common/src/queue/mod.rs
@@ -3,6 +3,7 @@ mod descriptor;
 mod used;
 
 use alloc::{sync::Arc, vec::Vec};
+use core::cell::Cell;
 
 pub use available::{AvailableRing, VirtQueueAvail};
 use axaddrspace::GuestMemoryAccessor;
@@ -13,6 +14,7 @@ pub use used::{UsedRing, VirtQueueUsed, VirtqUsedElem};
 
 use crate::{
     VirtioDeviceID,
+    constants::{VIRTQ_AVAIL_ALIGN, VIRTQ_DESC_ALIGN, VIRTQ_USED_ALIGN},
     error::{VirtioError, VirtioResult},
 };
 
@@ -47,6 +49,20 @@ pub struct VirtioQueue<T: GuestMemoryAccessor + Clone> {
     next_used: u16,
     /// Event index enabled
     pub event_idx_enabled: bool,
+    /// Set when a runtime ring/descriptor validation failure occurs; the queue
+    /// rejects `pop`/`complete` and the guest-data paths until
+    /// [`reset`](Self::reset) clears it.
+    ///
+    /// Uses interior mutability so that `&self` validation queries
+    /// ([`descriptor_chain_with_memory`](Self::descriptor_chain_with_memory),
+    /// [`get_status_addr`](Self::get_status_addr),
+    /// [`should_notify`](Self::should_notify)) can latch the failure; the
+    /// `&mut` paths (`pop`, `complete`, `reset`) only read the flag. The queue
+    /// is always guarded by the owning device's lock (the MMIO transport holds
+    /// its queue mutex for every access), so callers must never alias the
+    /// queue across threads without that mutual exclusion; `Cell` is only
+    /// sound under that single-owner rule.
+    faulted: Cell<bool>,
 }
 
 impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
@@ -67,6 +83,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
             next_avail: 0,
             next_used: 0,
             event_idx_enabled: false,
+            faulted: Cell::new(false),
         }
     }
 
@@ -120,12 +137,138 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         self.ready = ready;
     }
 
+    /// Whether the three ring addresses have all been programmed.
+    ///
+    /// Address `0` is the "unconfigured" sentinel: a driver that has not
+    /// finished programming a ring must never be able to make the queue ready.
+    pub fn is_configured(&self) -> bool {
+        self.desc_table_addr.as_usize() != 0
+            && self.avail_ring_addr.as_usize() != 0
+            && self.used_ring_addr.as_usize() != 0
+    }
+
+    /// The guest-memory accessor used by the non-`_with_memory` operations.
+    pub fn accessor(&self) -> &Arc<T> {
+        &self.accessor
+    }
+
+    /// Validate the three ring layouts against the VirtIO split-ring
+    /// requirements. This is a pure query and does not change queue state.
+    ///
+    /// Checks, per VirtIO 1.x §2.7:
+    /// - all three ring addresses are non-zero;
+    /// - the descriptor table is 16-byte aligned, the available ring 2-byte and
+    ///   the used ring 4-byte aligned;
+    /// - `addr + size * elem_size` does not overflow the guest address space
+    ///   for any ring;
+    /// - the three regions do not overlap (overlap would let a used-element
+    ///   write corrupt descriptors the device is about to read).
+    ///
+    /// The transport is expected to call this from its single "queue becomes
+    /// usable" enforcement point (MMIO: the `QUEUE_READY` write; PCI: layout
+    /// programmed in the queue config registers) and to refuse to mark the
+    /// queue ready when it fails.
+    pub fn validate_layout(&self) -> VirtioResult<()> {
+        let regions = self.ring_regions();
+        regions
+            .iter()
+            .all(|region| region.base.as_usize() != 0)
+            .then_some(())
+            .ok_or(VirtioError::InvalidRingLayout)?;
+        if !self
+            .desc_table_addr
+            .as_usize()
+            .is_multiple_of(VIRTQ_DESC_ALIGN)
+            || !self
+                .avail_ring_addr
+                .as_usize()
+                .is_multiple_of(VIRTQ_AVAIL_ALIGN)
+            || !self
+                .used_ring_addr
+                .as_usize()
+                .is_multiple_of(VIRTQ_USED_ALIGN)
+        {
+            return Err(VirtioError::RingMisaligned);
+        }
+        for (index, region) in regions.iter().enumerate() {
+            if region.end().is_none() {
+                return Err(VirtioError::InvalidRingLayout);
+            }
+            if regions[index + 1..]
+                .iter()
+                .any(|other| region.overlaps(other))
+            {
+                return Err(VirtioError::RingOverlap);
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate the ring layout like [`validate_layout`](Self::validate_layout)
+    /// and additionally require every ring region to lie entirely inside the
+    /// guest address space, translated through `memory`.
+    ///
+    /// `memory` must be the same capability used for the queue's runtime
+    /// accesses, so a layout accepted here cannot fail later because a ring
+    /// address is unmapped or reaches past the end of a mapped region. Any
+    /// failure is reported as [`VirtioError::InvalidRingLayout`] so the caller
+    /// only needs to distinguish "layout rejected" from "queue ready".
+    pub fn validate_layout_with_memory(
+        &self,
+        memory: &mut dyn crate::GuestMemory,
+    ) -> VirtioResult<()> {
+        self.validate_layout()?;
+        for region in self.ring_regions() {
+            let end = region.end().ok_or(VirtioError::InvalidRingLayout)?;
+            // `usize::MAX` denotes "no bound" for `GuestMemory` implementations
+            // derived from an accessor without a real address space.
+            if end == usize::MAX {
+                continue;
+            }
+            if memory.read(region.base, &mut [0u8; 1]).is_err()
+                || memory
+                    .read(GuestPhysAddr::from(end - 1), &mut [0u8; 1])
+                    .is_err()
+            {
+                return Err(VirtioError::InvalidRingLayout);
+            }
+        }
+        Ok(())
+    }
+
+    /// The three ring regions derived from the current layout.
+    fn ring_regions(&self) -> [RingRegion; 3] {
+        let size = self.size as usize;
+        let desc_size = size * core::mem::size_of::<VirtQueueDesc>();
+        let avail_size = core::mem::size_of::<VirtQueueAvail>() + size * 2;
+        let used_size =
+            core::mem::size_of::<VirtQueueUsed>() + size * core::mem::size_of::<VirtqUsedElem>();
+        [
+            RingRegion::new(self.desc_table_addr, desc_size),
+            RingRegion::new(self.avail_ring_addr, avail_size),
+            RingRegion::new(self.used_ring_addr, used_size),
+        ]
+    }
+
+    /// Whether the queue is in the faulted state and must be reset before
+    /// further `pop`/`complete` calls.
+    pub fn is_faulted(&self) -> bool {
+        self.faulted.get()
+    }
+
     /// Check if queue is valid and ready
     pub fn is_valid(&self) -> bool {
         self.ready
             && self.desc_table_addr.as_usize() != 0
             && self.avail_ring_addr.as_usize() != 0
             && self.used_ring_addr.as_usize() != 0
+            && self.validate_layout().is_ok()
+    }
+
+    /// Latch the queue into the faulted state after a runtime validation
+    /// failure; `pop`/`complete` are rejected until [`reset`](Self::reset).
+    fn latch_fault(&self) {
+        self.faulted.set(true);
     }
 
     /// Reset the queue
@@ -139,6 +282,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         self.desc_table = None;
         self.avail_ring = None;
         self.used_ring = None;
+        self.faulted.set(false);
     }
 
     /// Read available ring index
@@ -163,20 +307,31 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
 
     /// Add a used buffer to the used ring
     pub fn add_used(&mut self, desc_index: u16, len: u32) -> VirtioResult<()> {
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
+        }
         if !self.is_valid() {
             return Err(VirtioError::QueueNotReady);
         }
 
-        // Use the UsedRing to properly manage the used ring
-        if let Some(ref mut used_ring) = self.used_ring {
-            used_ring.add_used(desc_index as u32, len)?;
-            self.next_used = used_ring.get_used_idx();
+        let result = if let Some(ref mut used_ring) = self.used_ring {
+            let result = used_ring.add_used(desc_index as u32, len);
+            if result.is_ok() {
+                self.next_used = used_ring.get_used_idx();
+            }
+            result
         } else {
             // Fallback: just update the index
             self.next_used = (self.next_used + 1) % self.size;
+            Ok(())
+        };
+        if result.is_err() {
+            // A guest-memory write failure on a configured queue is a runtime
+            // failure: latch the fault so no "error success" completion can
+            // follow, mirroring `complete_with_memory`.
+            self.latch_fault();
         }
-
-        Ok(())
+        result
     }
 
     /// Consume one available-ring head index, or `None` if the queue is empty.
@@ -195,6 +350,9 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         &mut self,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<Option<u16>> {
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
+        }
         if !self.is_valid() {
             return Err(VirtioError::QueueNotReady);
         }
@@ -206,15 +364,28 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         let last = self.get_last_avail_idx();
         let pending = avail_idx.wrapping_sub(last);
         if pending > self.size {
+            // Corrupted available ring: more entries pending than the queue
+            // can hold. Latch the fault so the queue stops serving until reset.
+            self.latch_fault();
             return Err(VirtioError::InvalidQueue);
         }
         if pending == 0 {
             return Ok(None);
         }
-        let head = if let Some(avail_ring) = &self.avail_ring {
-            avail_ring.read_avail_ring_entry_with_memory(last % self.size, memory)?
-        } else {
-            return Err(VirtioError::QueueNotReady);
+        let head = match self
+            .avail_ring
+            .as_ref()
+            .map(|ring| ring.read_avail_ring_entry_with_memory(last % self.size, memory))
+        {
+            Some(Ok(head)) => head,
+            Some(Err(error)) => {
+                // A guest-memory read failure on a configured queue is a
+                // runtime failure; latch the fault like the other runtime
+                // paths do.
+                self.latch_fault();
+                return Err(error);
+            }
+            None => return Err(VirtioError::QueueNotReady),
         };
         self.update_last_avail_idx(last.wrapping_add(1));
         Ok(Some(head))
@@ -243,16 +414,28 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     }
 
     /// Builds a validated descriptor chain using a scoped memory capability.
+    ///
+    /// Returns [`VirtioError::QueueNotReady`] when the descriptor table is not
+    /// configured (not a runtime failure, so the queue is not faulted) and
+    /// [`VirtioError::QueueFaulted`] when the queue is already faulted.
     pub fn descriptor_chain_with_memory(
         &self,
         head: u16,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<DescriptorChain> {
-        if let Some(ref desc_table) = self.desc_table {
-            desc_table.descriptor_chain(head, memory)
-        } else {
-            Err(VirtioError::QueueNotReady)
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
         }
+        let Some(ref desc_table) = self.desc_table else {
+            return Err(VirtioError::QueueNotReady);
+        };
+        let result = desc_table.descriptor_chain(head, memory);
+        if result.is_err() {
+            // The descriptor table is configured, so a chain failure is a
+            // runtime validation failure: latch the fault.
+            self.latch_fault();
+        }
+        result
     }
 
     /// Complete a descriptor chain: append a used element for `head` with the
@@ -266,23 +449,32 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     }
 
     /// Completes a chain with a scoped memory capability.
+    ///
+    /// Returns [`VirtioError::QueueNotReady`] when a ring is not configured
+    /// (not a runtime failure, so the queue is not faulted) and
+    /// [`VirtioError::QueueFaulted`] when the queue is already faulted. Any
+    /// failure while writing the used ring or reading the available flags is
+    /// treated as a runtime failure and latches the fault.
     pub fn complete_with_memory(
         &mut self,
         head: u16,
         written_len: u32,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<bool> {
-        if let Some(used_ring) = &mut self.used_ring {
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
+        }
+        let result = (|| {
+            let used_ring = self.used_ring.as_mut().ok_or(VirtioError::QueueNotReady)?;
             used_ring.add_used_with_memory(head as u32, written_len, memory)?;
             self.next_used = used_ring.get_used_idx();
-        } else {
-            return Err(VirtioError::QueueNotReady);
-        }
-        if let Some(avail_ring) = &self.avail_ring {
+            let avail_ring = self.avail_ring.as_ref().ok_or(VirtioError::QueueNotReady)?;
             Ok(!avail_ring.interrupts_suppressed_with_memory(memory)?)
-        } else {
-            Err(VirtioError::QueueNotReady)
+        })();
+        if result.is_err() {
+            self.latch_fault();
         }
+        result
     }
 
     /// Get the used ring reference
@@ -345,42 +537,74 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     }
 
     /// Validate VirtIO block chain
+    ///
+    /// Returns [`VirtioError::QueueNotReady`] when the descriptor table is not
+    /// configured and [`VirtioError::QueueFaulted`] when the queue is faulted.
+    /// Any validation or guest-memory failure on a configured queue latches
+    /// the fault, matching the other descriptor-chain walk entry points.
     pub fn validate_virtio_block_chain(
         &self,
         head_index: u16,
         min_length: usize,
     ) -> VirtioResult<bool> {
-        let mut memory = crate::AddressSpaceMemory::new(&*self.accessor);
-        if let Some(ref desc_table) = self.desc_table {
-            let descriptors = desc_table.follow_chain(head_index, &mut memory)?;
-            Ok(descriptors.len() >= min_length)
-        } else {
-            Err(VirtioError::QueueNotReady)
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
         }
+        let Some(ref desc_table) = self.desc_table else {
+            return Err(VirtioError::QueueNotReady);
+        };
+        let mut memory = crate::AddressSpaceMemory::new(&*self.accessor);
+        let result = desc_table
+            .follow_chain(head_index, &mut memory)
+            .map(|descriptors| descriptors.len() >= min_length);
+        if result.is_err() {
+            self.latch_fault();
+        }
+        result
     }
 
     /// Get data buffers from descriptor chain
+    ///
+    /// Returns [`VirtioError::QueueNotReady`] when the descriptor table is not
+    /// configured and [`VirtioError::QueueFaulted`] when the queue is faulted.
+    /// Any guest-memory failure on a configured queue latches the fault.
     pub fn get_data_buffers(
         &self,
         head_index: u16,
         device_type: VirtioDeviceID,
     ) -> VirtioResult<Vec<(GuestPhysAddr, usize, bool)>> {
-        let mut memory = crate::AddressSpaceMemory::new(&*self.accessor);
-        if let Some(ref desc_table) = self.desc_table {
-            desc_table.get_data_buffers(head_index, device_type, &mut memory)
-        } else {
-            Err(VirtioError::QueueNotReady)
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
         }
+        let Some(ref desc_table) = self.desc_table else {
+            return Err(VirtioError::QueueNotReady);
+        };
+        let mut memory = crate::AddressSpaceMemory::new(&*self.accessor);
+        let result = desc_table.get_data_buffers(head_index, device_type, &mut memory);
+        if result.is_err() {
+            self.latch_fault();
+        }
+        result
     }
 
     /// Get status address from descriptor chain
+    ///
+    /// Returns [`VirtioError::QueueNotReady`] when the descriptor table is not
+    /// configured and [`VirtioError::QueueFaulted`] when the queue is faulted.
+    /// Any guest-memory failure on a configured queue latches the fault.
     pub fn get_status_addr(&self, head_index: u16) -> VirtioResult<GuestPhysAddr> {
-        let mut memory = crate::AddressSpaceMemory::new(&*self.accessor);
-        if let Some(ref desc_table) = self.desc_table {
-            desc_table.get_status_addr(head_index, &mut memory)
-        } else {
-            Err(VirtioError::QueueNotReady)
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
         }
+        let Some(ref desc_table) = self.desc_table else {
+            return Err(VirtioError::QueueNotReady);
+        };
+        let mut memory = crate::AddressSpaceMemory::new(&*self.accessor);
+        let result = desc_table.get_status_addr(head_index, &mut memory);
+        if result.is_err() {
+            self.latch_fault();
+        }
+        result
     }
 
     /// Whether the device should interrupt the driver after updating the used ring.
@@ -389,19 +613,39 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     /// `VIRTQ_AVAIL_F_NO_INTERRUPT` flag. The used ring's `VIRTQ_USED_F_NO_NOTIFY`
     /// flag is the opposite direction (the driver reads it to decide whether to
     /// kick the device), so it must not gate device-to-driver interrupts.
+    ///
+    /// Returns [`VirtioError::QueueFaulted`] when the queue is faulted,
+    /// [`VirtioError::QueueNotReady`] when the available ring is not
+    /// configured (not a runtime failure, so the queue is not faulted), and
+    /// latches the fault on a read failure of a configured ring.
     pub fn should_notify(&self) -> VirtioResult<bool> {
-        if let Some(ref avail_ring) = self.avail_ring {
-            Ok(!avail_ring.interrupts_suppressed()?)
-        } else {
-            Err(VirtioError::QueueNotReady)
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
         }
+        let Some(ref avail_ring) = self.avail_ring else {
+            return Err(VirtioError::QueueNotReady);
+        };
+        let result = avail_ring
+            .interrupts_suppressed()
+            .map(|suppressed| !suppressed);
+        if result.is_err() {
+            self.latch_fault();
+        }
+        result
     }
 
     /// Write status byte to the status buffer of a descriptor chain
     ///
     /// This method writes the status byte to the last descriptor in the chain,
     /// which should be a write-only descriptor according to VirtIO specification.
+    ///
+    /// Returns [`VirtioError::QueueNotReady`] when the descriptor table is not
+    /// configured and [`VirtioError::QueueFaulted`] when the queue is faulted;
+    /// a faulted queue never writes guest memory.
     pub fn write_status_byte(&self, head_index: u16, status: u8) -> VirtioResult<()> {
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
+        }
         // Get the status descriptor address (last descriptor in chain)
         let status_addr_guest = self.get_status_addr(head_index)?;
 
@@ -418,5 +662,42 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
             .map_err(|_| VirtioError::InvalidAddress)?;
 
         Ok(())
+    }
+}
+
+/// One half-open guest region `[base, base + size)` used by ring-layout
+/// validation. Deliberately uses `usize` arithmetic like the rest of the queue
+/// layer so the checks match the arithmetic actually performed on ring
+/// accesses.
+#[derive(Clone, Copy)]
+struct RingRegion {
+    base: GuestPhysAddr,
+    size: usize,
+}
+
+impl RingRegion {
+    fn new(base: GuestPhysAddr, size: usize) -> Self {
+        Self { base, size }
+    }
+
+    /// The exclusive end address, or `None` if `base + size` overflows the
+    /// guest address space.
+    fn end(&self) -> Option<usize> {
+        self.base.as_usize().checked_add(self.size)
+    }
+
+    /// Whether the two regions share any byte.
+    ///
+    /// A region whose end overflows the address space is unbounded; treating
+    /// it as non-overlapping would let a wrap-around ring alias the memory of
+    /// a neighbouring ring, so an overflowing region always overlaps.
+    fn overlaps(&self, other: &Self) -> bool {
+        let Some(self_end) = self.end() else {
+            return true;
+        };
+        let Some(other_end) = other.end() else {
+            return true;
+        };
+        self.base.as_usize() < other_end && other.base.as_usize() < self_end
     }
 }

--- a/virtualization/axvirtio-common/src/queue/mod.rs
+++ b/virtualization/axvirtio-common/src/queue/mod.rs
@@ -295,14 +295,27 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     }
 
     /// Reads the available index with a scoped memory capability.
+    ///
+    /// Returns [`VirtioError::QueueFaulted`] when the queue is faulted and
+    /// [`VirtioError::QueueNotReady`] when the available ring is not
+    /// configured (not a runtime failure, so the queue is not faulted). A read
+    /// failure of a configured ring is a runtime failure and latches the
+    /// fault, matching the other avail-ring pre-read paths.
     pub fn read_avail_idx_with_memory(
         &self,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<u16> {
-        self.avail_ring
-            .as_ref()
-            .ok_or(VirtioError::QueueNotReady)?
-            .read_avail_idx_with_memory(memory)
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
+        }
+        let Some(avail_ring) = self.avail_ring.as_ref() else {
+            return Err(VirtioError::QueueNotReady);
+        };
+        let result = avail_ring.read_avail_idx_with_memory(memory);
+        if result.is_err() {
+            self.latch_fault();
+        }
+        result
     }
 
     /// Add a used buffer to the used ring
@@ -356,11 +369,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         if !self.is_valid() {
             return Err(VirtioError::QueueNotReady);
         }
-        let avail_idx = if let Some(avail_ring) = &self.avail_ring {
-            avail_ring.read_avail_idx_with_memory(memory)?
-        } else {
-            return Err(VirtioError::QueueNotReady);
-        };
+        let avail_idx = self.read_avail_idx_with_memory(memory)?;
         let last = self.get_last_avail_idx();
         let pending = avail_idx.wrapping_sub(last);
         if pending > self.size {
@@ -507,15 +516,28 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     }
 
     /// Reads an available-ring entry with a scoped memory capability.
+    ///
+    /// Returns [`VirtioError::QueueFaulted`] when the queue is faulted and
+    /// [`VirtioError::QueueNotReady`] when the available ring is not
+    /// configured (not a runtime failure, so the queue is not faulted). A read
+    /// failure of a configured ring is a runtime failure and latches the
+    /// fault, matching the other avail-ring pre-read paths.
     pub fn read_avail_entry_with_memory(
         &self,
         ring_index: u16,
         memory: &mut dyn crate::GuestMemory,
     ) -> VirtioResult<u16> {
-        self.avail_ring
-            .as_ref()
-            .ok_or(VirtioError::QueueNotReady)?
-            .read_avail_ring_entry_with_memory(ring_index, memory)
+        if self.faulted.get() {
+            return Err(VirtioError::QueueFaulted);
+        }
+        let Some(avail_ring) = self.avail_ring.as_ref() else {
+            return Err(VirtioError::QueueNotReady);
+        };
+        let result = avail_ring.read_avail_ring_entry_with_memory(ring_index, memory);
+        if result.is_err() {
+            self.latch_fault();
+        }
+        result
     }
 
     /// Update last available index

--- a/virtualization/axvirtio-common/src/queue/used.rs
+++ b/virtualization/axvirtio-common/src/queue/used.rs
@@ -151,16 +151,29 @@ impl<T: GuestMemoryAccessor + Clone> UsedRing<T> {
 
     /// Get the address of the available event field (if event_idx is enabled)
     pub fn avail_event_addr(&self) -> GuestPhysAddr {
-        let offset = core::mem::size_of::<VirtQueueUsed>()
-            + (self.size as usize * core::mem::size_of::<VirtqUsedElem>());
-        self.base_addr + offset
+        // Header + ring array fill the region up to 2 bytes before its end;
+        // the `avail_event` footer is always part of the region (see
+        // `layout_size`).
+        self.base_addr + Self::layout_size(self.size) - 2
     }
 
-    /// Calculate the total size of the used ring
-    pub fn total_size(&self) -> usize {
+    /// Size in bytes of the complete used ring for a queue of `size` entries,
+    /// including the trailing 2-byte `avail_event` field.
+    ///
+    /// The footer is always counted: a driver that negotiated
+    /// `VIRTIO_F_RING_EVENT_IDX` reads `avail_event` from there, and layout
+    /// validation must not depend on negotiation state.
+    pub(crate) const fn layout_size(size: u16) -> usize {
         core::mem::size_of::<VirtQueueUsed>()
-            + (self.size as usize * core::mem::size_of::<VirtqUsedElem>())
+            + (size as usize) * core::mem::size_of::<VirtqUsedElem>()
             + 2
+    }
+
+    /// The size in bytes this ring occupies in guest memory, always including
+    /// the trailing 2-byte event-index footer (see
+    /// [`layout_size`](Self::layout_size)).
+    pub fn total_size(&self) -> usize {
+        Self::layout_size(self.size)
     }
 
     /// Check if the used ring is valid
@@ -282,5 +295,22 @@ impl<T: GuestMemoryAccessor + Clone> UsedRing<T> {
         self.write_used_header(&header)?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::NoGuestMemoryAccessor;
+
+    #[test]
+    fn layout_size_counts_header_elements_and_footer() {
+        // header (4) + 4 elements * 8 bytes + avail_event footer (2) = 38.
+        assert_eq!(UsedRing::<NoGuestMemoryAccessor>::layout_size(4), 38);
+        // Boundary: the largest queue size still counts the footer.
+        assert_eq!(
+            UsedRing::<NoGuestMemoryAccessor>::layout_size(256),
+            4 + 256 * 8 + 2
+        );
     }
 }

--- a/virtualization/axvirtio-common/tests/mmio_state_tests.rs
+++ b/virtualization/axvirtio-common/tests/mmio_state_tests.rs
@@ -59,7 +59,7 @@ fn bounded_state(device_features: u64) -> VirtioMmioState<Mem> {
     state(device_features)
 }
 
-fn bounded_rd(s: &VirtioMmioState<Mem>, reg: usize) -> u32 {
+fn bounded_rd<T: GuestMemoryAccessor + Clone>(s: &VirtioMmioState<T>, reg: usize) -> u32 {
     match s
         .mmio_read(GuestPhysAddr::from(BASE + reg), AccessWidth::Dword)
         .unwrap()
@@ -77,7 +77,7 @@ fn bounded_wr(s: &VirtioMmioState<Mem>, reg: usize, val: u32) -> MmioWriteAction
     .unwrap()
 }
 
-fn rd(s: &VirtioMmioState<Mem>, reg: usize) -> u32 {
+fn rd<T: GuestMemoryAccessor + Clone>(s: &VirtioMmioState<T>, reg: usize) -> u32 {
     match s
         .mmio_read(GuestPhysAddr::from(BASE + reg), AccessWidth::Dword)
         .unwrap()
@@ -188,6 +188,33 @@ fn queue_ready_rejected_when_ring_outside_guest_address_space() {
 }
 
 #[test]
+fn queue_ready_rejected_when_ring_footer_crosses_guest_address_space() {
+    let s = bounded_state(0);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_SEL, 0);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_NUM, 4);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_DESC_LOW, 0x1000);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW, 0x2000);
+    // The used ring data ends exactly at the end of the guest address space
+    // (0xffdc + 4 + 4*8 == 0x10000); only the 2-byte `avail_event` footer
+    // crosses it. The footer is part of the ring region, so the layout must
+    // be rejected.
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0xffdc);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+    assert_eq!(
+        bounded_rd(&s, vc::VIRTIO_MMIO_QUEUE_READY),
+        0,
+        "a ring whose event-index footer crosses the guest address-space boundary must not become \
+         ready"
+    );
+
+    // Moving the whole ring, footer included, inside the address space lets
+    // the queue become ready.
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0xffd8);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+    assert_eq!(bounded_rd(&s, vc::VIRTIO_MMIO_QUEUE_READY), 1);
+}
+
+#[test]
 fn queue_ready_rejected_on_malformed_ring_layout() {
     let s = state(0);
     wr(&s, vc::VIRTIO_MMIO_QUEUE_SEL, 0);
@@ -209,6 +236,95 @@ fn queue_ready_rejected_on_malformed_ring_layout() {
 
     // Writing ready=0 clears it again.
     wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 0);
+    assert_eq!(rd(&s, vc::VIRTIO_MMIO_QUEUE_READY), 0);
+}
+
+/// An accessor that never translates any guest address. Mirrors the runtime
+/// arrangement where real guest memory only exists as a scoped capability at
+/// MMIO access time (axvisor's `NoGuestMemoryAccessor`), so the queue's own
+/// accessor cannot satisfy any memory probe.
+#[derive(Clone, Copy, Default)]
+struct NoMem;
+
+impl GuestMemoryAccessor for NoMem {
+    fn translate_and_get_limit(&self, _guest_addr: GuestPhysAddr) -> Option<(PhysAddr, usize)> {
+        None
+    }
+}
+
+#[test]
+fn queue_ready_uses_scoped_memory_for_layout_validation() {
+    // The queue's own accessor translates nothing; only the scoped memory
+    // capability passed at MMIO-write time can. The QUEUE_READY write must
+    // validate the layout against that scoped capability, or real guests
+    // could never make a queue ready.
+    let accessor = Arc::new(NoMem);
+    let queue = VirtioQueue::new(0, vc::DEFAULT_QUEUE_SIZE, accessor);
+    let s = VirtioMmioState::new(
+        GuestPhysAddr::from(BASE),
+        LEN,
+        2,
+        vc::VIRTIO_VENDOR_ID,
+        0,
+        vec![queue],
+    );
+
+    // Program a valid in-bounds layout (desc 0x1000, avail 0x2000,
+    // used 0x3000; all inside the 0x10000-byte backing below).
+    for (reg, val) in [
+        (vc::VIRTIO_MMIO_QUEUE_SEL, 0),
+        (vc::VIRTIO_MMIO_QUEUE_NUM, 4),
+        (vc::VIRTIO_MMIO_QUEUE_DESC_LOW, 0x1000),
+        (vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW, 0x2000),
+        (vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0x3000),
+    ] {
+        s.mmio_write(
+            GuestPhysAddr::from(BASE + reg),
+            AccessWidth::Dword,
+            val as usize,
+        )
+        .unwrap();
+    }
+
+    // The accessor-based path must reject the layout: the queue's own
+    // accessor cannot translate any guest address.
+    s.mmio_write(
+        GuestPhysAddr::from(BASE + vc::VIRTIO_MMIO_QUEUE_READY),
+        AccessWidth::Dword,
+        1,
+    )
+    .unwrap();
+    assert_eq!(
+        rd(&s, vc::VIRTIO_MMIO_QUEUE_READY),
+        0,
+        "the queue's own accessor cannot satisfy the layout probe"
+    );
+
+    // The scoped-memory path validates the same addresses against the real
+    // backing and must make the queue ready.
+    let backing = mem();
+    let mut memory = axvirtio_common::AddressSpaceMemory::new(&backing);
+    s.mmio_write_with_memory(
+        GuestPhysAddr::from(BASE + vc::VIRTIO_MMIO_QUEUE_READY),
+        AccessWidth::Dword,
+        1,
+        &mut memory,
+    )
+    .unwrap();
+    assert_eq!(
+        rd(&s, vc::VIRTIO_MMIO_QUEUE_READY),
+        1,
+        "the scoped-memory path must make the queue ready"
+    );
+
+    // Writing ready=0 through the scoped path clears it again.
+    s.mmio_write_with_memory(
+        GuestPhysAddr::from(BASE + vc::VIRTIO_MMIO_QUEUE_READY),
+        AccessWidth::Dword,
+        0,
+        &mut memory,
+    )
+    .unwrap();
     assert_eq!(rd(&s, vc::VIRTIO_MMIO_QUEUE_READY), 0);
 }
 

--- a/virtualization/axvirtio-common/tests/mmio_state_tests.rs
+++ b/virtualization/axvirtio-common/tests/mmio_state_tests.rs
@@ -12,16 +12,36 @@ use axvm_types::{AccessWidth, GuestPhysAddr};
 const BASE: usize = 0x0a00_0000;
 const LEN: usize = 0x200;
 
+/// Mock guest memory: a flat backing buffer where guest physical address `gpa`
+/// maps to `buf[gpa..]` for `gpa < 0x10000`. The accessor returns real host
+/// pointers, so the memory-based ring layout check and the trait defaults work
+/// against the same buffer.
 #[derive(Clone)]
-struct Mem;
+struct Mem {
+    buf: std::sync::Arc<Vec<u8>>,
+}
 impl GuestMemoryAccessor for Mem {
-    fn translate_and_get_limit(&self, _guest_addr: GuestPhysAddr) -> Option<(PhysAddr, usize)> {
-        None
+    fn translate_and_get_limit(&self, guest_addr: GuestPhysAddr) -> Option<(PhysAddr, usize)> {
+        let off = guest_addr.as_usize();
+        if off < self.buf.len() {
+            Some((
+                PhysAddr::from(self.buf.as_ptr() as usize + off),
+                self.buf.len() - off,
+            ))
+        } else {
+            None
+        }
+    }
+}
+
+fn mem() -> Mem {
+    Mem {
+        buf: std::sync::Arc::new(vec![0u8; 0x1_0000]),
     }
 }
 
 fn state(device_features: u64) -> VirtioMmioState<Mem> {
-    let accessor = Arc::new(Mem);
+    let accessor = Arc::new(mem());
     let queue = VirtioQueue::new(0, vc::DEFAULT_QUEUE_SIZE, accessor);
     VirtioMmioState::new(
         GuestPhysAddr::from(BASE),
@@ -31,6 +51,30 @@ fn state(device_features: u64) -> VirtioMmioState<Mem> {
         device_features,
         vec![queue],
     )
+}
+
+fn bounded_state(device_features: u64) -> VirtioMmioState<Mem> {
+    // Same mock: backing covers `[0, 0x10000)`, so a used ring at 0xfff8
+    // crosses the end of the guest address space.
+    state(device_features)
+}
+
+fn bounded_rd(s: &VirtioMmioState<Mem>, reg: usize) -> u32 {
+    match s
+        .mmio_read(GuestPhysAddr::from(BASE + reg), AccessWidth::Dword)
+        .unwrap()
+    {
+        MmioReadOutcome::Standard(v) => v,
+        MmioReadOutcome::DeviceConfig { .. } => panic!("expected standard register"),
+    }
+}
+fn bounded_wr(s: &VirtioMmioState<Mem>, reg: usize, val: u32) -> MmioWriteAction {
+    s.mmio_write(
+        GuestPhysAddr::from(BASE + reg),
+        AccessWidth::Dword,
+        val as usize,
+    )
+    .unwrap()
 }
 
 fn rd(s: &VirtioMmioState<Mem>, reg: usize) -> u32 {
@@ -120,6 +164,52 @@ fn status_zero_resets() {
         0,
         "reset must clear driver features"
     );
+}
+
+#[test]
+fn queue_ready_rejected_when_ring_outside_guest_address_space() {
+    let s = bounded_state(0);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_SEL, 0);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_NUM, 4);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_DESC_LOW, 0x1000);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW, 0x2000);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0xfff8); // tail beyond 0x10000
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+    assert_eq!(
+        bounded_rd(&s, vc::VIRTIO_MMIO_QUEUE_READY),
+        0,
+        "a ring crossing the guest address-space boundary must not become ready"
+    );
+
+    // Re-programming a fully in-space layout lets the queue become ready.
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0xf000);
+    bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+    assert_eq!(bounded_rd(&s, vc::VIRTIO_MMIO_QUEUE_READY), 1);
+}
+
+#[test]
+fn queue_ready_rejected_on_malformed_ring_layout() {
+    let s = state(0);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_SEL, 0);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_NUM, 4);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_DESC_LOW, 0x1000);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW, 0x2000);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0x3003); // not 4-byte aligned
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+    assert_eq!(
+        rd(&s, vc::VIRTIO_MMIO_QUEUE_READY),
+        0,
+        "ready must not become effective on a malformed layout"
+    );
+
+    // Re-programming a valid layout lets the same queue become ready.
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0x3000);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+    assert_eq!(rd(&s, vc::VIRTIO_MMIO_QUEUE_READY), 1);
+
+    // Writing ready=0 clears it again.
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 0);
+    assert_eq!(rd(&s, vc::VIRTIO_MMIO_QUEUE_READY), 0);
 }
 
 #[test]

--- a/virtualization/axvirtio-common/tests/queue_tests.rs
+++ b/virtualization/axvirtio-common/tests/queue_tests.rs
@@ -389,6 +389,32 @@ fn validate_layout_rejects_overlapping_rings() {
 }
 
 #[test]
+fn validate_layout_rejects_used_ring_aliasing_avail_footer() {
+    let mem = Arc::new(MockMem::new(0x1_0000));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_desc_table_addr(GuestPhysAddr::from(0x1000)).unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    // The used ring starts exactly at the available ring's `used_event`
+    // footer address (avail + 4 + size*2). The 2-byte footer belongs to the
+    // available ring region, so the two rings alias and must be rejected.
+    q.set_used_ring_addr(GuestPhysAddr::from(0x200c)).unwrap();
+    assert_eq!(q.validate_layout().unwrap_err(), VirtioError::RingOverlap);
+}
+
+#[test]
+fn validate_layout_rejects_avail_ring_aliasing_used_footer() {
+    let mem = Arc::new(MockMem::new(0x1_0000));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_desc_table_addr(GuestPhysAddr::from(0x1000)).unwrap();
+    // The available ring starts exactly at the used ring's `avail_event`
+    // footer address (used + 4 + size*8), aliasing the footer bytes the
+    // device writes after `add_used`.
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x3024)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    assert_eq!(q.validate_layout().unwrap_err(), VirtioError::RingOverlap);
+}
+
+#[test]
 fn validate_layout_rejects_overflowing_ring() {
     let mem = Arc::new(MockMem::new(0x1_0000));
     let mut q = VirtioQueue::new(0, 4, mem);
@@ -620,6 +646,52 @@ fn read_avail_entry_pre_read_failure_faults_queue() {
 }
 
 #[test]
+fn read_avail_idx_non_memory_read_failure_faults_queue() {
+    let mem = Arc::new(MockMem::new(0x3002));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_desc_table_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    // The avail ring header is configured but its `idx` field (base + 2)
+    // crosses the mapped boundary; the non-`_with_memory` API reads through
+    // the queue's own accessor and must latch the fault like its
+    // `_with_memory` twin.
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x4000)).unwrap();
+    q.set_ready(true);
+    assert_eq!(q.read_avail_idx().unwrap_err(), VirtioError::InvalidAddress);
+    assert!(
+        q.is_faulted(),
+        "avail-index read failure through the non-memory API must fault the queue"
+    );
+    // The queue stays faulted: repeating the read reports QueueFaulted
+    // instead of retrying the failing access.
+    assert_eq!(q.read_avail_idx().unwrap_err(), VirtioError::QueueFaulted);
+}
+
+#[test]
+fn read_avail_entry_non_memory_read_failure_faults_queue() {
+    let mem = Arc::new(MockMem::new(0x3004));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_desc_table_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x4000)).unwrap();
+    q.set_ready(true);
+    // Entry 0 lives at avail + 4 == 0x3004, beyond the mapped boundary; the
+    // non-`_with_memory` API must latch the fault like its twin.
+    assert_eq!(
+        q.read_avail_entry(0).unwrap_err(),
+        VirtioError::InvalidAddress
+    );
+    assert!(
+        q.is_faulted(),
+        "avail-entry read failure through the non-memory API must fault the queue"
+    );
+    assert_eq!(
+        q.read_avail_entry(0).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+}
+
+#[test]
 fn add_used_write_failure_faults_queue() {
     let mem = Arc::new(MockMem::new(0x100));
     let mut q = VirtioQueue::new(0, 4, mem.clone());
@@ -634,6 +706,26 @@ fn add_used_write_failure_faults_queue() {
     );
     assert_eq!(q.add_used(0, 0).unwrap_err(), VirtioError::QueueFaulted);
     assert_eq!(q.complete(0, 0).unwrap_err(), VirtioError::QueueFaulted);
+}
+
+#[test]
+fn add_used_without_used_ring_reports_not_ready_without_faulting() {
+    let mem = Arc::new(MockMem::new(0x1_0000));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_desc_table_addr(GuestPhysAddr::from(0x1000)).unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    // Program the used address through the public field so the layout
+    // validates while the used-ring object stays unconfigured; this is the
+    // state the historical fallback used to turn into a silent "success".
+    q.used_ring_addr = GuestPhysAddr::from(0x3000);
+    q.set_ready(true);
+    assert!(q.is_valid());
+    assert_eq!(q.add_used(0, 0).unwrap_err(), VirtioError::QueueNotReady);
+    assert!(
+        !q.is_faulted(),
+        "an unconfigured used ring is not a runtime failure"
+    );
+    assert!(q.get_used_ring().is_none());
 }
 
 #[test]

--- a/virtualization/axvirtio-common/tests/queue_tests.rs
+++ b/virtualization/axvirtio-common/tests/queue_tests.rs
@@ -204,6 +204,34 @@ fn setter_combined_layout_fails_alignment_validation() {
 }
 
 #[test]
+fn set_size_after_ring_addresses_is_rejected() {
+    // The ring objects snapshot the queue size when their address is
+    // programmed, so changing `size` after that would validate the layout for
+    // the new size while runtime ring accesses stay bounded by the old one: a
+    // guest could serve requests outside the validated regions. The layout
+    // must therefore stay consistent with the size the rings were built for.
+    let mem = Arc::new(MockMem::new(4096));
+    let mut q = VirtioQueue::new(0, 8, mem.clone());
+    q.set_size(4).unwrap();
+    q.set_desc_table_addr(GuestPhysAddr::from(0x1000)).unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    assert_eq!(
+        q.set_size(8).unwrap_err(),
+        VirtioError::InvalidQueue,
+        "resizing after ring addresses are programmed must be rejected"
+    );
+    assert_eq!(q.size, 4, "the size must not change on a rejected write");
+
+    // The same guard applies while the queue is ready: the programmed rings
+    // are in use.
+    let mut f = Fixture::new(4);
+    f.queue.set_ready(true);
+    assert_eq!(f.queue.set_size(4).unwrap_err(), VirtioError::InvalidQueue);
+    assert!(f.queue.is_valid(), "the ready queue must stay usable");
+}
+
+#[test]
 fn reset_clears_addresses_ready_and_indexes() {
     let mut f = Fixture::new(4);
     f.set_avail_idx(2);

--- a/virtualization/axvirtio-common/tests/queue_tests.rs
+++ b/virtualization/axvirtio-common/tests/queue_tests.rs
@@ -185,6 +185,25 @@ fn address_setters_overwrite_so_low_high_combine() {
 }
 
 #[test]
+fn setter_combined_layout_fails_alignment_validation() {
+    // The overwrite setter semantics intentionally accept non-aligned
+    // addresses; the resulting layout must be rejected by `validate_layout`.
+    // Constructed independently of `address_setters_overwrite_so_low_high_combine`
+    // so this assertion does not depend on that test's intermediate state.
+    let mem = Arc::new(MockMem::new(4096));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_desc_table_addr(GuestPhysAddr::from(0x0000_00ff))
+        .unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    assert_eq!(
+        q.validate_layout().unwrap_err(),
+        VirtioError::RingMisaligned,
+        "the desc table address 0x..ff is not 16-byte aligned"
+    );
+}
+
+#[test]
 fn reset_clears_addresses_ready_and_indexes() {
     let mut f = Fixture::new(4);
     f.set_avail_idx(2);
@@ -297,6 +316,385 @@ fn descriptor_chain_rejects_next_out_of_bounds() {
     assert_eq!(
         f.queue.descriptor_chain(0).unwrap_err(),
         VirtioError::InvalidDescriptor
+    );
+}
+
+#[test]
+fn descriptor_chain_accepts_full_size_chain() {
+    let f = Fixture::new(4);
+    for i in 0..4u16 {
+        let next = if i == 3 { 0 } else { i + 1 };
+        let flags = if i == 3 { 0 } else { VIRTQ_DESC_F_NEXT };
+        f.set_desc(i, 0x1000 + i as usize * 16, 8, flags, next);
+    }
+    let chain = f.queue.descriptor_chain(0).unwrap();
+    assert_eq!(
+        chain.len(),
+        4,
+        "a full-size chain (len == size) must be accepted"
+    );
+
+    // A chain that walks one descriptor beyond `size` is a cycle and must be
+    // rejected on both paths.
+    f.set_desc(3, 0x1000 + 3 * 16, 8, VIRTQ_DESC_F_NEXT, 0); // 0->1->2->3->0 cycle
+    assert!(matches!(
+        f.queue.descriptor_chain(0),
+        Err(VirtioError::InvalidDescriptor)
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// Ring layout validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_layout_rejects_zero_addresses() {
+    let mem = Arc::new(MockMem::new(4096));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    // desc address is still 0 -> layout invalid.
+    assert_eq!(
+        q.validate_layout().unwrap_err(),
+        VirtioError::InvalidRingLayout
+    );
+    // A layout check must not touch `ready`.
+    q.set_ready(true);
+    assert!(!q.is_valid());
+}
+
+#[test]
+fn validate_layout_rejects_misaligned_rings() {
+    let mem = Arc::new(MockMem::new(0x1_0000));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_desc_table_addr(GuestPhysAddr::from(0x1000)).unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    // used ring at a 3-byte offset: not 4-byte aligned.
+    q.set_used_ring_addr(GuestPhysAddr::from(0x3003)).unwrap();
+    assert_eq!(
+        q.validate_layout().unwrap_err(),
+        VirtioError::RingMisaligned
+    );
+}
+
+#[test]
+fn validate_layout_rejects_overlapping_rings() {
+    let mem = Arc::new(MockMem::new(0x1_0000));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    q.set_desc_table_addr(GuestPhysAddr::from(0x1000)).unwrap();
+    // avail ring starts inside the descriptor table region.
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x1008)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    assert_eq!(q.validate_layout().unwrap_err(), VirtioError::RingOverlap);
+}
+
+#[test]
+fn validate_layout_rejects_overflowing_ring() {
+    let mem = Arc::new(MockMem::new(0x1_0000));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    // desc table base + size*16 overflows the address space.
+    q.set_desc_table_addr(GuestPhysAddr::from(usize::MAX - 15))
+        .unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    assert_eq!(
+        q.validate_layout().unwrap_err(),
+        VirtioError::InvalidRingLayout
+    );
+}
+
+#[test]
+fn validate_layout_accepts_proper_layout() {
+    let f = Fixture::new(4);
+    assert!(f.queue.validate_layout().is_ok());
+}
+
+#[test]
+fn validate_layout_rejects_overflowing_region_adjacent_to_valid_ring() {
+    let mem = Arc::new(MockMem::new(0x1_0000));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    // desc table base + size*16 wraps around the address space.
+    q.set_desc_table_addr(GuestPhysAddr::from(usize::MAX - 15))
+        .unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    assert_eq!(
+        q.validate_layout().unwrap_err(),
+        VirtioError::InvalidRingLayout
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Faulted state
+// ---------------------------------------------------------------------------
+
+#[test]
+fn descriptor_chain_failure_faults_queue_and_blocks_pop_complete() {
+    let mut f = Fixture::new(4);
+    // A cyclic chain fails validation in `descriptor_chain`.
+    f.set_desc(0, 0x1000, 8, VIRTQ_DESC_F_NEXT, 1);
+    f.set_desc(1, 0x2000, 8, VIRTQ_DESC_F_NEXT, 0);
+    assert!(matches!(
+        f.queue.descriptor_chain(0),
+        Err(VirtioError::InvalidDescriptor)
+    ));
+    assert!(
+        f.queue.is_faulted(),
+        "validation failure must fault the queue"
+    );
+
+    // pop/complete are rejected while faulted, with no partial completion.
+    assert_eq!(
+        f.queue.pop_available_head().unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue.complete(0, 0).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.used_idx(),
+        0,
+        "no used element may be written while faulted"
+    );
+
+    // reset clears the faulted state (and the programmed layout, per the
+    // existing reset semantics) and restores operation once re-programmed.
+    f.queue.reset();
+    assert!(!f.queue.is_faulted());
+    f.queue
+        .set_desc_table_addr(GuestPhysAddr::from(f.desc_base))
+        .unwrap();
+    f.queue
+        .set_avail_ring_addr(GuestPhysAddr::from(f.avail_base))
+        .unwrap();
+    f.queue
+        .set_used_ring_addr(GuestPhysAddr::from(f.used_base))
+        .unwrap();
+    f.queue.set_ready(true);
+    // The ring memory is still valid for this fixture; a fresh chain works.
+    f.set_desc(0, 0x1000, 8, 0, 0);
+    f.set_avail_idx(1);
+    f.set_avail_entry(0, 0);
+    assert!(f.queue.pop_available().is_ok());
+    assert_eq!(f.used_idx(), 0);
+
+    assert!(f.queue.complete(3, 42).is_ok());
+    assert_eq!(f.used_idx(), 1, "used ring must advance after reset");
+    assert_eq!(f.used_elem(0), (3, 42));
+}
+
+#[test]
+fn unconfigured_queue_failures_do_not_fault() {
+    let mem = Arc::new(MockMem::new(4096));
+    let mut q = VirtioQueue::new(0, 4, mem);
+    assert_eq!(
+        q.descriptor_chain(0).unwrap_err(),
+        VirtioError::QueueNotReady
+    );
+    assert_eq!(
+        q.get_status_addr(0).unwrap_err(),
+        VirtioError::QueueNotReady
+    );
+    assert_eq!(q.should_notify().unwrap_err(), VirtioError::QueueNotReady);
+    assert!(!q.is_faulted(), "unconfigured must not latch a fault");
+
+    // A faulted queue reports QueueFaulted for these entry points before any
+    // QueueNotReady check. Fault the queue via a real runtime failure (the
+    // avail ring is unconfigured at address 0, so reading it fails).
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    assert_eq!(q.should_notify().unwrap_err(), VirtioError::InvalidAddress);
+    assert!(q.is_faulted());
+    assert_eq!(
+        q.descriptor_chain(0).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(q.should_notify().unwrap_err(), VirtioError::QueueFaulted);
+}
+
+#[test]
+fn descriptor_chain_memory_failure_faults_queue() {
+    let mem = Arc::new(MockMem::new(0x100));
+    let mut q = VirtioQueue::new(0, 4, mem.clone());
+    q.set_desc_table_addr(GuestPhysAddr::from(0x2000)).unwrap(); // beyond the mock backing -> unmapped
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x4000)).unwrap();
+    q.set_ready(true);
+    let mut memory = axvirtio_common::AddressSpaceMemory::new(&*mem);
+    assert_eq!(
+        q.descriptor_chain_with_memory(0, &mut memory).unwrap_err(),
+        VirtioError::InvalidAddress
+    );
+    assert!(q.is_faulted(), "memory read failure must fault the queue");
+    assert_eq!(
+        q.complete_with_memory(0, 0, &mut memory).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+}
+
+#[test]
+fn pop_available_head_read_failure_faults_queue() {
+    let mem = Arc::new(MockMem::new(0x3005));
+    let mut q = VirtioQueue::new(0, 4, mem.clone());
+    q.set_desc_table_addr(GuestPhysAddr::from(0x2000)).unwrap(); // beyond the mock backing -> unmapped
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x4000)).unwrap();
+    q.set_ready(true);
+    let mut memory = axvirtio_common::AddressSpaceMemory::new(&*mem);
+    // avail.idx reads 0 -> empty, no memory touch beyond the header, no fault.
+    assert!(
+        q.pop_available_head_with_memory(&mut memory)
+            .unwrap()
+            .is_none()
+    );
+    assert!(!q.is_faulted());
+
+    // A pending entry makes the head read at base + 4 cross the mapped
+    // boundary, which must fault the queue.
+    mem.put(0x3002, &1u16.to_le_bytes());
+    assert_eq!(
+        q.pop_available_head_with_memory(&mut memory).unwrap_err(),
+        VirtioError::InvalidAddress
+    );
+    assert!(q.is_faulted(), "head read failure must fault the queue");
+}
+
+#[test]
+fn add_used_write_failure_faults_queue() {
+    let mem = Arc::new(MockMem::new(0x100));
+    let mut q = VirtioQueue::new(0, 4, mem.clone());
+    q.set_desc_table_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x4000)).unwrap();
+    q.set_ready(true);
+    assert_eq!(q.add_used(0, 0).unwrap_err(), VirtioError::InvalidAddress);
+    assert!(
+        q.is_faulted(),
+        "used-ring write failure must fault the queue"
+    );
+    assert_eq!(q.add_used(0, 0).unwrap_err(), VirtioError::QueueFaulted);
+    assert_eq!(q.complete(0, 0).unwrap_err(), VirtioError::QueueFaulted);
+}
+
+#[test]
+fn faulted_queue_rejects_guest_data_paths() {
+    let mut f = Fixture::new(4);
+    f.set_desc(0, 0x1000, 8, VIRTQ_DESC_F_NEXT, 1);
+    f.set_desc(1, 0x2000, 8, VIRTQ_DESC_F_NEXT, 0);
+    assert!(f.queue.descriptor_chain(0).is_err());
+    assert!(f.queue.is_faulted());
+
+    assert_eq!(
+        f.queue.get_status_addr(0).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue.write_status_byte(0, 0).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue
+            .get_data_buffers(0, axvirtio_common::VirtioDeviceID::Block)
+            .unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue.validate_virtio_block_chain(0, 1).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue.should_notify().unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue.pop_available_head().unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    // The status byte of the chain is guest memory (desc 1 base_addr
+    // 0x2000) and must not be written while faulted. The fixture backing is
+    // small, so assert only through the queue API: the earlier
+    // `write_status_byte` call already returned QueueFaulted, which is the
+    // guarantee that no guest memory is written.
+    assert_eq!(
+        f.queue.write_status_byte(0, 0xab).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+}
+
+#[test]
+fn write_status_byte_writes_guest_status_and_completes() {
+    // Positive control for the faulted-path test: on a healthy queue,
+    // `write_status_byte` really writes the chain's status byte (desc 1
+    // base_addr 0x2000) and `get_status_addr` resolves it. The backing is
+    // large enough to map the status address.
+    let (desc_base, avail_base, used_base, _) = layout(4);
+    let mem = Arc::new(MockMem::new(0x3000));
+    let mut q = VirtioQueue::new(0, 4, mem.clone());
+    q.set_desc_table_addr(GuestPhysAddr::from(desc_base))
+        .unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(avail_base))
+        .unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(used_base))
+        .unwrap();
+    q.set_ready(true);
+    let mut d0 = [0u8; 16];
+    d0[0..8].copy_from_slice(&(0x1000u64).to_le_bytes());
+    d0[8..12].copy_from_slice(&8u32.to_le_bytes());
+    d0[12..14].copy_from_slice(&VIRTQ_DESC_F_NEXT.to_le_bytes());
+    d0[14..16].copy_from_slice(&1u16.to_le_bytes());
+    mem.put(desc_base, &d0);
+    let mut d1 = [0u8; 16];
+    d1[0..8].copy_from_slice(&(0x2000u64).to_le_bytes());
+    d1[8..12].copy_from_slice(&8u32.to_le_bytes());
+    d1[12..14].copy_from_slice(&VIRTQ_DESC_F_WRITE.to_le_bytes());
+    mem.put(desc_base + 16, &d1);
+    assert_eq!(q.get_status_addr(0).unwrap().as_usize(), 0x2000);
+    q.write_status_byte(0, 0xab).unwrap();
+    assert_eq!(
+        mem.buf[0x2000], 0xab,
+        "a healthy queue must write the status byte"
+    );
+}
+
+#[test]
+fn faulted_check_precedes_ready_check_on_complete() {
+    let mut f = Fixture::new(4);
+    f.set_desc(0, 0x1000, 8, VIRTQ_DESC_F_NEXT, 1);
+    f.set_desc(1, 0x2000, 8, VIRTQ_DESC_F_NEXT, 0);
+    assert!(f.queue.descriptor_chain(0).is_err());
+    assert!(f.queue.is_faulted());
+    f.queue.set_ready(false); // now neither ready nor faulted-clear
+    assert_eq!(
+        f.queue.complete(0, 0).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue.add_used(0, 0).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue.pop_available_head().unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+}
+
+#[test]
+fn pop_available_faults_queue_on_ring_corruption() {
+    let mut f = Fixture::new(4);
+    // avail.idx more than `size` ahead of last_avail -> corruption error.
+    f.set_avail_idx(f.size + 5);
+    assert_eq!(
+        f.queue.pop_available_head().unwrap_err(),
+        VirtioError::InvalidQueue
+    );
+    assert!(f.queue.is_faulted());
+    assert_eq!(
+        f.queue.pop_available_head().unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        f.queue.complete(0, 0).unwrap_err(),
+        VirtioError::QueueFaulted
     );
 }
 

--- a/virtualization/axvirtio-common/tests/queue_tests.rs
+++ b/virtualization/axvirtio-common/tests/queue_tests.rs
@@ -560,6 +560,66 @@ fn pop_available_head_read_failure_faults_queue() {
 }
 
 #[test]
+fn read_avail_idx_pre_read_failure_faults_queue() {
+    let mem = Arc::new(MockMem::new(0x3002));
+    let mut q = VirtioQueue::new(0, 4, mem.clone());
+    q.set_desc_table_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    // The avail ring header is configured but its `idx` field (base + 2)
+    // crosses the mapped boundary: the pre-read must fail and latch.
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x4000)).unwrap();
+    q.set_ready(true);
+    let mut memory = axvirtio_common::AddressSpaceMemory::new(&*mem);
+    assert_eq!(
+        q.read_avail_idx_with_memory(&mut memory).unwrap_err(),
+        VirtioError::InvalidAddress
+    );
+    assert!(
+        q.is_faulted(),
+        "avail-index pre-read failure on a configured queue must fault it"
+    );
+    // The queue stays faulted: the same read and the drain entry points reject
+    // until reset, instead of repeating the failure every call.
+    assert_eq!(
+        q.read_avail_idx_with_memory(&mut memory).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        q.pop_available_head_with_memory(&mut memory).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+    assert_eq!(
+        q.read_avail_entry_with_memory(0, &mut memory).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+}
+
+#[test]
+fn read_avail_entry_pre_read_failure_faults_queue() {
+    let mem = Arc::new(MockMem::new(0x3004));
+    let mut q = VirtioQueue::new(0, 4, mem.clone());
+    q.set_desc_table_addr(GuestPhysAddr::from(0x2000)).unwrap();
+    q.set_avail_ring_addr(GuestPhysAddr::from(0x3000)).unwrap();
+    q.set_used_ring_addr(GuestPhysAddr::from(0x4000)).unwrap();
+    q.set_ready(true);
+    let mut memory = axvirtio_common::AddressSpaceMemory::new(&*mem);
+    // entry 0 lives at avail + 4 == 0x3004, which is beyond the mapped
+    // boundary, so the 2-byte entry read fails.
+    assert_eq!(
+        q.read_avail_entry_with_memory(0, &mut memory).unwrap_err(),
+        VirtioError::InvalidAddress
+    );
+    assert!(
+        q.is_faulted(),
+        "avail-entry pre-read failure on a configured queue must fault it"
+    );
+    assert_eq!(
+        q.read_avail_entry_with_memory(0, &mut memory).unwrap_err(),
+        VirtioError::QueueFaulted
+    );
+}
+
+#[test]
 fn add_used_write_failure_faults_queue() {
     let mem = Arc::new(MockMem::new(0x100));
     let mut q = VirtioQueue::new(0, 4, mem.clone());

--- a/virtualization/axvirtio-net/src/device.rs
+++ b/virtualization/axvirtio-net/src/device.rs
@@ -203,6 +203,13 @@ impl<B: NetworkBackend, T: GuestMemoryAccessor + Clone> VirtioMmioNetDevice<B, T
         let last = tx.get_last_avail_idx();
         let pending = avail_idx.wrapping_sub(last).min(tx.size);
         for _ in 0..pending {
+            if tx.is_faulted() {
+                warn!(
+                    "virtio-net TX queue is faulted; stop draining until the guest resets the \
+                     device"
+                );
+                break;
+            }
             let head = match tx.pop_available_head_with_memory(memory) {
                 Ok(Some(h)) => h,
                 Ok(None) => break,
@@ -304,6 +311,14 @@ impl<B: NetworkBackend, T: GuestMemoryAccessor + Clone> VirtioMmioNetDevice<B, T
 
         // Peek before consuming so capacity/chain problems leave the ring intact.
         let last = rx.get_last_avail_idx();
+        if rx.is_faulted() {
+            // A faulted RX queue must not be served; the guest re-programs
+            // the queue after resetting the device.
+            warn!(
+                "virtio-net RX queue is faulted; dropping frames until the guest resets the device"
+            );
+            return Err(NetError::Queue(axvirtio_common::VirtioError::QueueFaulted));
+        }
         let avail_idx = rx
             .read_avail_idx_with_memory(memory)
             .map_err(NetError::from)?;

--- a/virtualization/axvirtio-net/src/device.rs
+++ b/virtualization/axvirtio-net/src/device.rs
@@ -170,6 +170,11 @@ impl<B: NetworkBackend, T: GuestMemoryAccessor + Clone> VirtioMmioNetDevice<B, T
 
     /// Handles an MMIO write using a guest-memory capability scoped to this
     /// device access.
+    ///
+    /// The capability backs the `QUEUE_READY` ring-layout validation as well
+    /// as the TX drain, so runtimes whose queues were constructed with a
+    /// non-translating placeholder accessor (e.g. axvisor) can still make
+    /// queues ready.
     pub fn mmio_write_with_memory(
         &self,
         addr: GuestPhysAddr,
@@ -177,7 +182,10 @@ impl<B: NetworkBackend, T: GuestMemoryAccessor + Clone> VirtioMmioNetDevice<B, T
         val: usize,
         memory: &mut dyn axvirtio_common::GuestMemory,
     ) -> VirtioResult<DeviceEvent> {
-        match self.state.mmio_write(addr, width, val)? {
+        match self
+            .state
+            .mmio_write_with_memory(addr, width, val, memory)?
+        {
             MmioWriteAction::None => Ok(DeviceEvent::None),
             MmioWriteAction::Reset => Ok(DeviceEvent::Reset),
             MmioWriteAction::InterruptPending => Ok(DeviceEvent::InterruptPending),

--- a/virtualization/axvirtio-net/src/device.rs
+++ b/virtualization/axvirtio-net/src/device.rs
@@ -100,6 +100,18 @@ impl<B: NetworkBackend, T: GuestMemoryAccessor + Clone> VirtioMmioNetDevice<B, T
         self.state.is_driver_ok()
     }
 
+    /// Whether the queue with the given index has latched the faulted state.
+    ///
+    /// A faulted queue rejects `pop`/`complete` and all guest-data paths until
+    /// the guest resets the device; the VMM can poll this to surface the
+    /// condition instead of silently dropping service.
+    pub fn is_queue_faulted(&self, index: usize) -> bool {
+        self.state
+            .queues_lock()
+            .get(index)
+            .is_some_and(|q| q.is_faulted())
+    }
+
     /// Current interrupt status bits.
     pub fn interrupt_status(&self) -> u32 {
         self.state.interrupt_status()
@@ -199,7 +211,19 @@ impl<B: NetworkBackend, T: GuestMemoryAccessor + Clone> VirtioMmioNetDevice<B, T
             return DeviceEvent::None;
         }
 
-        let avail_idx = tx.read_avail_idx_with_memory(memory).unwrap_or(0);
+        // The available-index pre-read latches a fault on a configured queue
+        // whose ring became unreadable; stop draining and let the guest reset
+        // the device instead of treating the queue as empty.
+        let avail_idx = match tx.read_avail_idx_with_memory(memory) {
+            Ok(idx) => idx,
+            Err(error) => {
+                warn!(
+                    "virtio-net TX queue is faulted; stop draining until the guest resets the \
+                     device: {error:?}"
+                );
+                return DeviceEvent::None;
+            }
+        };
         let last = tx.get_last_avail_idx();
         let pending = avail_idx.wrapping_sub(last).min(tx.size);
         for _ in 0..pending {

--- a/virtualization/axvirtio-net/tests/net_tests.rs
+++ b/virtualization/axvirtio-net/tests/net_tests.rs
@@ -480,6 +480,66 @@ fn tx_backend_error_still_completes_used() {
     assert_eq!(h.used_idx(h.tx_used), 1);
 }
 
+#[test]
+fn tx_avail_pre_read_failure_faults_queue_and_stops_drain() {
+    let h = Harness::new();
+    h.bring_up();
+    // Post one valid TX frame first so the TX queue has a non-zero last-consumed
+    // index: a silent "empty queue" fallback could otherwise mask the failure
+    // by reporting pending == 0.
+    let payload = [1, 2, 3, 4];
+    let mut frame = vec![0u8; NEGOTIATED_HEADER_SIZE];
+    frame.extend_from_slice(&payload);
+    h.write_desc(h.tx_desc, 0, h.tx_desc + 0x100, frame.len() as u32, 0, 0);
+    h.mem.put(h.tx_desc + 0x100, &frame);
+    h.set_avail(h.tx_avail, 0, 0, 1);
+    assert_eq!(
+        h.w(vc::VIRTIO_MMIO_QUEUE_NOTIFY, 1),
+        DeviceEvent::InterruptPending
+    );
+    assert_eq!(h.backend.calls(), 1, "sanity: one TX frame is transmitted");
+    assert_eq!(
+        h.used_idx(h.tx_used),
+        1,
+        "sanity: the TX frame is completed"
+    );
+    // A second request is now visible (avail.idx ahead of last-consumed index 1).
+    h.set_avail(h.tx_avail, 0, 0, 2);
+    // Rewrite the TX avail-ring address to a region whose `idx` field (base + 2)
+    // is unmapped (well beyond the mock backing). The address write alone keeps
+    // the queue ready; the layout check runs on QUEUE_READY, not on address
+    // writes.
+    h.w(vc::VIRTIO_MMIO_QUEUE_SEL, 1);
+    h.w(vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW, 0xffff_fffe);
+    h.w(vc::VIRTIO_MMIO_QUEUE_AVAIL_HIGH, 0);
+
+    // The pre-read fails: the queue is faulted and the drain must not silently
+    // treat the queue as empty.
+    let ev = h.w(vc::VIRTIO_MMIO_QUEUE_NOTIFY, 1);
+    assert_eq!(ev, DeviceEvent::None);
+    assert_eq!(
+        h.backend.calls(),
+        1,
+        "no TX may be transmitted from a faulted queue"
+    );
+    // No completion is written and the queue is not consumed.
+    assert_eq!(h.used_idx(h.tx_used), 1);
+    // The queue is latched into the faulted state until the guest resets the
+    // device; the TX path observes it.
+    assert!(
+        h.device.is_queue_faulted(1),
+        "the unreadable avail ring must latch the queue faulted"
+    );
+    // Every later kick repeats the same rejection instead of re-failing per
+    // entry: the queue stays faulted until the guest resets the device.
+    assert_eq!(h.w(vc::VIRTIO_MMIO_QUEUE_NOTIFY, 1), DeviceEvent::None);
+    assert_eq!(h.used_idx(h.tx_used), 1);
+    assert_eq!(h.backend.calls(), 1);
+    // A guest reset clears the fault and the queue serves requests again.
+    h.w(vc::VIRTIO_MMIO_STATUS, 0);
+    assert!(!h.device.is_queue_faulted(1));
+}
+
 // ---------------------------------------------------------------------------
 // RX (13.5, subset)
 // ---------------------------------------------------------------------------
@@ -596,6 +656,44 @@ fn rx_readable_descriptor_rejected() {
     let err = h.device.receive_frame(&[0; 4]).unwrap_err();
     assert!(matches!(err, NetError::InvalidDescriptor), "got {err:?}");
     assert_eq!(h.used_idx(h.rx_used), 0);
+}
+
+#[test]
+fn rx_avail_pre_read_failure_faults_queue_and_rejects_frames() {
+    let h = Harness::new();
+    h.bring_up();
+    // Rewrite the RX avail-ring address to a region whose `idx` field (base + 2)
+    // is unmapped. The address write alone keeps the queue ready; the layout
+    // check runs on QUEUE_READY, not on address writes.
+    h.w(vc::VIRTIO_MMIO_QUEUE_SEL, 0);
+    h.w(vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW, 0xffff_fffe);
+    h.w(vc::VIRTIO_MMIO_QUEUE_AVAIL_HIGH, 0);
+    // The queue stays faulted: `receive_frame` must return an error instead of
+    // silently treating the unreadable ring as empty. (The exact variant is the
+    // pre-existing `VirtioError -> NetError` mapping; the guarantee under test
+    // is the error itself plus the latch.)
+    let err = h.device.receive_frame(&[1, 2, 3]).unwrap_err();
+    assert!(
+        matches!(err, NetError::Queue(_) | NetError::GuestMemoryFault),
+        "got {err:?}"
+    );
+    assert_eq!(h.used_idx(h.rx_used), 0, "no RX completion may be written");
+    // The unreadable avail ring latches the queue faulted; the RX path observes
+    // it (the old behavior never latched and only reported flow control).
+    assert!(
+        h.device.is_queue_faulted(0),
+        "the unreadable avail ring must latch the queue faulted"
+    );
+    // Every later delivery repeats the same rejection.
+    let err = h.device.receive_frame(&[4, 5, 6]).unwrap_err();
+    assert!(
+        matches!(err, NetError::Queue(_) | NetError::GuestMemoryFault),
+        "got {err:?}"
+    );
+    assert_eq!(h.used_idx(h.rx_used), 0);
+    // A guest reset clears the fault and the queue accepts deliveries again.
+    h.w(vc::VIRTIO_MMIO_STATUS, 0);
+    assert!(!h.device.is_queue_faulted(0));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
fix issue #1979 

## 1. 要解决的问题

`axvirtio-common::VirtioQueue` 是本仓库所有 virtio 设备模型共用的唯一 virtqueue 实现（当前消费者 `axvirtio-net` 和 `axvirtio-blk`）。面向不可信 guest（或 buggy 驱动）时存在以下缺口（issue 2.1–2.4）：

1. **链长边界 off-by-one**：`descriptor_chain` 用 `>= size` 拒绝合法全索引链（`len == size`），与 `follow_chain` 的 `> size` 不一致，同一条合法链两条路径行为不同；
2. **缺少 enable 期布局校验**：三个环地址接受任意非零值，不对齐、`addr + size*elem` 溢出、三区域互相重叠（used 环别名到 desc 表可破坏设备将读的 descriptor）均不检查；
3. **`ready` 可在未验证布局上生效**：MMIO transport 编程地址后直接置 ready，不执行布局校验；
4. **`VirtioError` 无法表达布局为何无效**：`InvalidQueue`/`InvalidAddress`/`InvalidDescriptor` 不够具体，transport 无法据此决定响应（如 PCI 不置 ready 位需区分"布局错误"与"队列未就绪"）。

## 2. 改动内容

### `virtualization/axvirtio-common/`

- **`queue/descriptor.rs`**：`descriptor_chain` 链长边界 `>= size` → `> size`，与 `follow_chain` 一致（一条链最大 `size` 个节点），合法全索引链不再被拒（issue 3.1）。
- **`queue/mod.rs`**：
  - 新增 `validate_layout()`——检查三环地址非零、对齐（desc 16B / avail 2B / used 4B）、`addr + size*elem` 不溢出、三区域互不重叠（issue 3.2）；
  - 新增 `validate_layout_with_memory()`——利用 guest 地址翻译/limit 检查每环完整落在 guest 地址空间内（design 7.6 要求）；只探测每环首尾字节作为 enable 期筛查，区域内映射由运行期逐字节访问兜底；不可翻译的占位 accessor（如 `NoGuestMemoryAccessor`）无法通过筛查，其布局被拒绝（每个配置周期首次拒绝 warn、后续仅 trace）；
  - 新增 `faulted` 状态（`is_faulted()`/`latch_fault()`，`AtomicBool` Acquire/Release）：运行期 ring/descriptor 校验失败即置位，`pop`/`complete` 及 5 条 guest-data 路径（`descriptor_chain_with_memory`/`validate_virtio_block_chain`/`get_data_buffers`/`get_status_addr`/`write_status_byte`）在 faulted 下拒绝且不写 guest 内存，`reset()` 清除；faulted 检查优先于 `is_valid`（始终返回 `QueueFaulted` 而非 `QueueNotReady`）；未配置（`QueueNotReady`）不触发 fault（issue 3.3）；
  - `ring_regions()` 的环区域大小**无条件包含 2 字节 EVENT_IDX footer**（与协商状态无关），并集中到 `AvailableRing`/`UsedRing`/`DescriptorTable::layout_size`（`pub(crate)`）单一来源，`total_size()`/footer 地址计算均从它推导；footer 别名（`RingOverlap`）或越出 guest 地址空间的布局被拒绝；
  - 非 `_with_memory` 入口（`read_avail_idx`/`read_avail_entry`）改为委托 `_with_memory` 孪生，运行期读失败同样 latch fault（面向未来 `axvirtio-blk` 消费者）；`add_used` 在 used ring 未配置时返回 `QueueNotReady` 而非静默推进 `next_used`（消灭"错误成功"completion）；
  - `is_valid()` 内部增加 `validate_layout()` 调用（签名不变）。
- **`mmio/state.rs`**：MMIO `QUEUE_READY` 写强制点统一为"三地址非零（`is_configured`）+ `validate_layout_with_memory`"，未配置或畸形布局时 `ready` 不生效、地址保留可重编程重试（issue 2.3/3.2 单一强制点）；新增 `mmio_write_with_memory`，把 vCPU 访问时的 scoped `GuestMemory` 传入 `QUEUE_READY` 校验（原 `mmio_write` 签名不变、回退到队列自带 accessor），axvisor 生产路径（`NoGuestMemoryAccessor`）因此可以正常置 ready；持队列锁完成"校验 + 置 ready"保证单一强制点原子性。
- **`error.rs`**：新增 `RingMisaligned`/`RingOverlap`/`InvalidRingLayout`/`QueueFaulted` 四变体，rustdoc 明确 `QueueFaulted`（运行期故障需 reset）与 `QueueNotReady`（正常预配置状态）的区别；`axvirtio-net` 的 `From<VirtioError>` 通配臂保证编译兼容（issue 2.4）。

### `virtualization/axvirtio-net/`

- **`device.rs`**：TX `handle_tx_notify` 每轮 drain 前检查 `tx.is_faulted()`，faulted 时 warn + 停止 drain；RX `receive_frame_with_memory` peek 前检查 `rx.is_faulted()`，faulted 时返回 `NetError::Queue(QueueFaulted)`；`mmio_write_with_memory` 把 scoped guest memory 透传给共享状态的 `QUEUE_READY` 校验。队列不再被静默吞错永久停滞（issue 3.3 / 第 4 节要求的 `is_faulted()` 消费者接线）。公开 API 签名零变化。

### 测试（`tests/queue_tests.rs`、`tests/mmio_state_tests.rs`）

- 链长：合法全索引链两条路径一致、超长链两条路径 Err；
- 布局：零地址/未对齐/溢出/重叠/环越出 guest 地址空间 5 类拒绝 + 合法布局通过；EVENT_IDX footer 别名（used 环指向 avail footer、avail 环指向 used footer）与 footer 越界拒绝；MMIO 畸形布局 ready 不生效、重编程可恢复、写 0 清除；
- faulted：运行期校验失败置位、pop/complete 及 5 条 guest-data 路径拒绝、不写 guest 内存、未配置不 fault、reset 清除且恢复后 complete 正确写 used ring（无"错误成功"completion）；非 `_with_memory` 预读失败同样 latch；`add_used` 未配置环返回 `QueueNotReady`；
- MMIO 强制点：队列用不可翻译 accessor 构建时，`mmio_write`（accessor 路径）拒绝 ready，`mmio_write_with_memory`（scoped 内存路径）可正常置 ready——axvisor 生产路径回归测试。

## 3. 各步解决方案的逻辑

- **布局校验放共享队列层**：virtio 1.x §2.7 的环布局约束与 transport 无关（MMIO 与 PCI 布局一致），放 `axvirtio-common` 让所有消费者（net、未来的 blk/PCI）一次受益，避免各 transport 各做一遍。
- **校验时机选"延迟到使用点"**：MMIO 对 64 位地址分两次写 setter，setter 内即时校验会在第一次写入时误报；`validate_layout` 只在"队列变为可用"的单一强制点（QUEUE_READY 写）执行，保留 setter 覆盖语义。
- **`faulted` 状态纳入本次**：运行期校验失败把队列置为不可用直到 reset，防止恶意/异常 ring 造成"错误成功"completion——与硬件 transport 暴露不可恢复队列错误的方式一致。
- **可达性检查用 `_with_memory` 变体**：遵循既有 `pop_available_head_with_memory` 等先例，`GuestMemoryAccessor` 的地址翻译/limit 为每个环区域做可达性验证，补齐 design 7.6 "完整落在 guest 地址空间内"的要求。
- **`QUEUE_READY` 强制点用 scoped 内存而非队列自带 accessor**：axvisor 等运行时以 `NoGuestMemoryAccessor` 构建设备、真实 guest 内存只存在于 MMIO 访问时刻的 scoped capability，用队列 accessor 校验会让所有队列永远无法 ready；`mmio_write_with_memory` 把 scoped `GuestMemory` 传入强制点，无 scoped 内存的调用方保留原 accessor 回退。
- **环区域大小无条件包含 EVENT_IDX footer**：guest 一旦协商 EVENT_IDX 就会读写 footer 字节，因此别名 footer 的布局无论协商状态都必须拒绝；无条件覆盖是保守包络，且无需把协商状态传入队列层。
- **faulted 检查优先于 `is_valid`**：faulted 是比"未就绪"更重的状态，必须返回 `QueueFaulted` 让消费者决策（reset），不能因 `is_valid` 为假而返回 `QueueNotReady` 掩盖故障。
- **net 只接线不吞错**：队列层新增 `is_faulted()` 后，net 的 TX/RX 路径显式检查并停止服务（warn），避免 `unwrap_or` 吞掉故障导致队列永久停滞（对照 dev_guidelines 3.6 教训"成功但无效果"路径）。

## 4. 验证

| 验证 | 结果 |
|---|---|
| `cargo fmt --all --check` | 通过 |
| `cargo xtask clippy --package axvirtio-common` | 通过（0 warning） |
| `cargo xtask clippy --package axvirtio-net` | 通过（0 warning） |
| `cargo clippy --no-deps -p axvirtio-common --all-targets -- -D warnings` | 通过 |
| `cargo clippy --no-deps -p axvirtio-net --all-targets -- -D warnings` | 通过 |
| `cargo test -p axvirtio-common` | 55 通过（4 单测 + 13 mmio 集成 + 38 queue 集成） |
| `cargo test -p axvirtio-net` | 32 通过（14 单测 + 18 集成） |
| `cargo xtask axvisor build --config os/axvisor/.build.toml` | 通过（x86_64-unknown-linux-musl 目标，验证 scoped-memory 改动在真实运行时路径可编译） |

（`cargo check -p axvisor` host 目标失败为预先存在——裸机 target-gated 依赖，与本改动无关。）

## 5. 验收标准（issue 第 5 节）对照

| 验收项 | 结果 |
|---|---|
| 链遍历两条路径行为一致（`len == size` 放行、超长 Err） | 满足 |
| `validate_layout()` 拒绝未对齐/溢出/重叠环；MMIO 无法在畸形布局上使 `ready` 生效 | 满足 |
| 既有公开函数无签名变化；`axvirtio-net` 原样编译、测试通过 | 满足 |
| 2.1–2.3 与 faulted（3.3）各新增回归测试（is_faulted 为真、pop/complete 拒绝、reset 清除、无错误成功 completion） | 满足 |