### PR TITLE
fix(sdmmc): align Rockchip reset failure lifecycle

### DIFF
--- a/drivers/ax-driver/src/block/rockchip/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/mod.rs
@@ -1,3 +1,6 @@
+use fdt_edit::Node;
+use sdmmc_protocol::sdio::init::CardInitPreference;
+
 mod clock;
 #[cfg(feature = "rockchip-dwmmc")]
 mod sd;
@@ -5,3 +8,28 @@ mod sd;
 mod sdhci_rk3568;
 #[cfg(feature = "rockchip-sdhci")]
 mod sdhci_rk3588;
+
+fn supports_block_card_protocol(node: &Node) -> bool {
+    node.get_property("no-sd").is_none() || node.get_property("no-mmc").is_none()
+}
+
+/// Mirrors Linux MMC core's SD-then-MMC attach order unless firmware limits
+/// which protocol the controller may use during initialization.
+fn card_init_preference(node: &Node) -> CardInitPreference {
+    if node.get_property("no-mmc").is_some() {
+        CardInitPreference::SdOnly
+    } else if node.get_property("no-sd").is_some() {
+        CardInitPreference::MmcFirst
+    } else {
+        CardInitPreference::SdFirst
+    }
+}
+
+fn media_name(preference: CardInitPreference) -> &'static str {
+    match preference {
+        CardInitPreference::SdOnly => "SD",
+        CardInitPreference::MmcFirst => "MMC",
+        CardInitPreference::SdFirst => "SD-or-MMC",
+        _ => "unknown",
+    }
+}

--- a/drivers/ax-driver/src/block/rockchip/sd/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sd/mod.rs
@@ -26,10 +26,12 @@ use sdmmc_protocol::{
     Error,
     error::{ErrorContext, Phase},
     rdif::{config::BlockConfig, device::BlockDevice},
-    sdio::{card::SdioSdmmc, init::CardInitPreference},
+    sdio::card::SdioSdmmc,
 };
 
-use super::clock::enable_node_clocks;
+use super::{
+    card_init_preference, clock::enable_node_clocks, media_name, supports_block_card_protocol,
+};
 use crate::{block::ProbeFdtBlock, mmio::iomap, soc::RockchipFdtPinctrlParser};
 
 const DWMMC_STABLE_REFERENCE_CLOCK: u32 = 50_000_000;
@@ -153,10 +155,18 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         ))
     })?;
 
-    info!("rockchip-dwmmc: defer protocol initialization to IRQ-driven hctx");
+    let preference = card_init_preference(info.node.as_node());
+    let identity = format!("rockchip-dwmmc:{}", info.node.path());
+    info!(
+        "rockchip-dwmmc: defer protocol initialization controller={} media={} preference={:?}",
+        identity,
+        media_name(preference),
+        preference
+    );
     let mut card = SdioSdmmc::new(host);
+    card.set_diagnostic_identity(identity);
     card.set_sd_speed_selection_enabled(ENABLE_SD_SPEED_SELECTION);
-    let dev = BlockDevice::new_initializing(card, block_config, card_init_preference(info));
+    let dev = BlockDevice::new_initializing(card, block_config, preference);
     let irq = probe.register_block(dev)?;
     info!("rockchip-dwmmc block device registered irq={:?}", irq);
     Ok(())
@@ -187,10 +197,6 @@ fn apply_rockchip_sd_resources(info: &FdtInfo<'_>) -> Result<(), OnProbeError> {
         }
     }
     Ok(())
-}
-
-fn supports_block_card_protocol(node: &Node) -> bool {
-    node.get_property("no-sd").is_none() || node.get_property("no-mmc").is_none()
 }
 
 fn enable_fixed_regulator_with_pinctrl(
@@ -257,17 +263,6 @@ fn regulator_has_fixed_gpio_enable(node: &Node) -> bool {
             || node.get_property("pinctrl-0").is_some())
 }
 
-fn card_init_preference(info: &FdtInfo<'_>) -> CardInitPreference {
-    let node = info.node.as_node();
-    if node.get_property("no-mmc").is_some() {
-        CardInitPreference::SdOnly
-    } else if node.get_property("no-sd").is_some() || node.get_property("non-removable").is_some() {
-        CardInitPreference::MmcFirst
-    } else {
-        CardInitPreference::SdFirst
-    }
-}
-
 fn dwmmc_clock_setup(info: &FdtInfo<'_>) -> Result<Option<DwMmcClockSetup>, OnProbeError> {
     let Some(clock) = info.find_clock_line_by_name("ciu")? else {
         warn!("[{}] ciu clock provider is not available", info.node.name());
@@ -312,6 +307,8 @@ fn validate_bus_clock(rate: u64) -> Result<u32, Error> {
 #[cfg(test)]
 mod tests {
     use alloc::{vec, vec::Vec};
+
+    use sdmmc_protocol::sdio::init::CardInitPreference;
 
     use super::*;
 
@@ -383,5 +380,33 @@ mod tests {
         node.add_property(fdt_edit::Property::new("no-mmc", Vec::new()));
 
         assert!(supports_block_card_protocol(&node));
+    }
+
+    #[test]
+    fn removable_sd_slot_never_falls_back_to_mmc_when_fdt_says_no_mmc() {
+        let mut node = Node::new("mmc@fe2c0000");
+        node.add_property(fdt_edit::Property::new("no-mmc", Vec::new()));
+
+        assert_eq!(card_init_preference(&node), CardInitPreference::SdOnly);
+        assert_eq!(media_name(card_init_preference(&node)), "SD");
+    }
+
+    #[test]
+    fn non_removable_emmc_controller_starts_with_mmc() {
+        let mut node = Node::new("mmc@fe2e0000");
+        node.add_property(fdt_edit::Property::new("no-sd", Vec::new()));
+        node.add_property(fdt_edit::Property::new("non-removable", Vec::new()));
+
+        assert_eq!(card_init_preference(&node), CardInitPreference::MmcFirst);
+        assert_eq!(media_name(card_init_preference(&node)), "MMC");
+    }
+
+    #[test]
+    fn non_removable_without_protocol_limit_keeps_linux_probe_order() {
+        let mut node = Node::new("mmc@10000000");
+        node.add_property(fdt_edit::Property::new("non-removable", Vec::new()));
+
+        assert_eq!(card_init_preference(&node), CardInitPreference::SdFirst);
+        assert_eq!(media_name(card_init_preference(&node)), "SD-or-MMC");
     }
 }

--- a/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
@@ -27,10 +27,12 @@ use sdhci_host::{HostClock, HostResetHook, HostTimer, Sdhci, rdif as sdhci_rdif}
 use sdmmc_protocol::{
     Error,
     error::{ErrorContext, Phase},
-    sdio::{card::SdioSdmmc, init::CardInitPreference},
+    sdio::card::SdioSdmmc,
 };
 
-use super::clock::enable_node_clocks;
+use super::{
+    card_init_preference, clock::enable_node_clocks, media_name, supports_block_card_protocol,
+};
 use crate::{block::ProbeFdtBlock, mmio::iomap};
 
 // RK3588 DWCMSHC follows Linux's normal SDHCI completion path: hard IRQ only
@@ -152,6 +154,13 @@ crate::model_register!(
 
 fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     let info = probe.info();
+    if !supports_block_card_protocol(info.node.as_node()) {
+        info!(
+            "rockchip-sdhci: skip SDIO-only controller {}",
+            info.node.path()
+        );
+        return Ok(());
+    }
     let resets = apply_rockchip_sdhci_resources(info)?;
     let base_reg = info
         .node
@@ -194,9 +203,17 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         ))
     })?;
 
-    info!("rockchip-sdhci: defer eMMC protocol initialization to IRQ-driven hctx");
-    let card = SdioSdmmc::new(host);
-    let dev = sdhci_rdif::initializing_device(card, config, CardInitPreference::MmcFirst);
+    let preference = card_init_preference(info.node.as_node());
+    let identity = alloc::format!("rockchip-sdhci:{}", info.node.path());
+    info!(
+        "rockchip-sdhci: defer protocol initialization controller={} media={} preference={:?}",
+        identity,
+        media_name(preference),
+        preference
+    );
+    let mut card = SdioSdmmc::new(host);
+    card.set_diagnostic_identity(identity);
+    let dev = sdhci_rdif::initializing_device(card, config, preference);
     let irq = probe.register_block(dev)?;
     info!("rockchip-sdhci block device registered irq={:?}", irq);
     Ok(())

--- a/drivers/blk/dwmmc-host/src/host2/bus.rs
+++ b/drivers/blk/dwmmc-host/src/host2/bus.rs
@@ -40,6 +40,8 @@ pub(super) enum BusRequestState {
 pub(super) enum DwMmcResetState {
     Start,
     WaitReset { polls: u32 },
+    WaitDmaRequest { polls: u32 },
+    WaitSecondFifoReset { polls: u32 },
 }
 
 pub(super) enum DwMmcClockState {
@@ -180,15 +182,16 @@ impl DwMmc {
                     self.regs.intmask().write(0);
                     self.clear_all_int_status();
                     self.irq.state.clear(u32::MAX);
-                    self.regs.ctype().write(crate::regs::CType::new());
-                    self.regs.uhs().write(crate::regs::UHS::new());
-                    self.program_linux_init_baseline();
-                    if restore_completion_irq {
-                        self.enable_completion_irq();
-                    } else {
-                        self.completion_irq_enabled
-                            .store(false, core::sync::atomic::Ordering::Release);
+                    if self.idmac_ring.is_some() || self.dma_poisoned {
+                        if self.regs.status().read().dma_req() {
+                            *state = DwMmcResetState::WaitDmaRequest { polls: 0 };
+                        } else {
+                            self.start_second_fifo_reset();
+                            *state = DwMmcResetState::WaitSecondFifoReset { polls: 0 };
+                        }
+                        return Ok(sdio_host2::RequestProgress::WaitingForIrq);
                     }
+                    self.finish_host2_reset_all(restore_completion_irq);
                     return Ok(sdio_host2::RequestProgress::Complete(Ok(())));
                 }
                 if *polls >= DWMMC_RESET_POLLS {
@@ -200,6 +203,55 @@ impl DwMmc {
                 *polls += 1;
                 Ok(sdio_host2::RequestProgress::WaitingForIrq)
             }
+            DwMmcResetState::WaitDmaRequest { polls } => {
+                if !self.regs.status().read().dma_req() {
+                    self.start_second_fifo_reset();
+                    *state = DwMmcResetState::WaitSecondFifoReset { polls: 0 };
+                    return Ok(sdio_host2::RequestProgress::WaitingForIrq);
+                }
+                if *polls >= DWMMC_RESET_POLLS {
+                    self.log_host2_timeout("reset-all-dma-request");
+                    return Err(map_protocol_error(Error::Timeout(ErrorContext::new(
+                        Phase::Init,
+                    ))));
+                }
+                *polls += 1;
+                Ok(sdio_host2::RequestProgress::WaitingForIrq)
+            }
+            DwMmcResetState::WaitSecondFifoReset { polls } => {
+                if !self.regs.ctrl().read().fifo_reset() {
+                    self.finish_host2_reset_all(restore_completion_irq);
+                    return Ok(sdio_host2::RequestProgress::Complete(Ok(())));
+                }
+                if *polls >= DWMMC_RESET_POLLS {
+                    self.log_host2_timeout("reset-all-second-fifo");
+                    return Err(map_protocol_error(Error::Timeout(ErrorContext::new(
+                        Phase::Init,
+                    ))));
+                }
+                *polls += 1;
+                Ok(sdio_host2::RequestProgress::WaitingForIrq)
+            }
+        }
+    }
+
+    fn start_second_fifo_reset(&mut self) {
+        self.regs.ctrl().update(|ctrl| ctrl.with_fifo_reset(true));
+    }
+
+    fn finish_host2_reset_all(&mut self, restore_completion_irq: bool) {
+        self.regs.ctype().write(crate::regs::CType::new());
+        self.regs.uhs().write(crate::regs::UHS::new());
+        self.program_linux_init_baseline();
+        if let Some(ring) = self.idmac_ring.as_mut() {
+            ring.clear_after_reset();
+        }
+        self.dma_poisoned = false;
+        if restore_completion_irq {
+            self.enable_completion_irq();
+        } else {
+            self.completion_irq_enabled
+                .store(false, core::sync::atomic::Ordering::Release);
         }
     }
 

--- a/drivers/blk/dwmmc-host/src/lib.rs
+++ b/drivers/blk/dwmmc-host/src/lib.rs
@@ -562,6 +562,7 @@ mod tests {
             <DwMmc as sdio_host2::SdioHost>::submit_bus_op(&mut host, sdio_host2::BusOp::ResetAll)
         }
         .unwrap();
+        host.poison_dma();
         const CTRL_WORD: usize = 0;
         const TMOUT_WORD: usize = 5;
         const CMD_WORD: usize = 11;
@@ -574,6 +575,18 @@ mod tests {
                 &mut host,
                 &mut request,
                 sdio_host2::ProgressCause::Submitted,
+            )
+            .unwrap(),
+            sdio_host2::RequestProgress::RegisterPending { .. }
+        ));
+        unsafe {
+            mmio.as_mut_ptr().add(CTRL_WORD).write_volatile(0);
+        }
+        assert!(matches!(
+            <DwMmc as sdio_host2::SdioHost>::advance_bus_op(
+                &mut host,
+                &mut request,
+                sdio_host2::ProgressCause::RegisterRetry,
             )
             .unwrap(),
             sdio_host2::RequestProgress::RegisterPending { .. }
@@ -604,6 +617,70 @@ mod tests {
             EXPECTED_FIFOTH
         );
         assert_eq!(unsafe { mmio.as_ptr().add(CMD_WORD).read_volatile() }, 0);
+        assert!(
+            host.check_not_poisoned().is_ok(),
+            "Linux-style ResetAll must rebuild a reusable IDMAC baseline"
+        );
+    }
+
+    #[test]
+    fn host2_reset_waits_for_dma_request_before_second_fifo_reset() {
+        let mut mmio = [0u32; 256];
+        let base = NonNull::new(mmio.as_mut_ptr().cast()).unwrap();
+        let mut host = unsafe { DwMmc::new(base) };
+        let mut request = unsafe {
+            <DwMmc as sdio_host2::SdioHost>::submit_bus_op(&mut host, sdio_host2::BusOp::ResetAll)
+        }
+        .unwrap();
+        host.poison_dma();
+        const CTRL_WORD: usize = 0;
+        const STATUS_WORD: usize = 18;
+
+        assert!(matches!(
+            <DwMmc as sdio_host2::SdioHost>::advance_bus_op(
+                &mut host,
+                &mut request,
+                sdio_host2::ProgressCause::Submitted,
+            )
+            .unwrap(),
+            sdio_host2::RequestProgress::RegisterPending { .. }
+        ));
+        unsafe {
+            mmio.as_mut_ptr().add(CTRL_WORD).write_volatile(0);
+            mmio.as_mut_ptr()
+                .add(STATUS_WORD)
+                .write_volatile(crate::regs::Status::new().with_dma_req(true).into_bits());
+        }
+
+        assert!(matches!(
+            <DwMmc as sdio_host2::SdioHost>::advance_bus_op(
+                &mut host,
+                &mut request,
+                sdio_host2::ProgressCause::RegisterRetry,
+            )
+            .unwrap(),
+            sdio_host2::RequestProgress::RegisterPending { .. }
+        ));
+        assert_eq!(
+            mmio[CTRL_WORD], 0,
+            "FIFO reset must wait for DMA_REQ to clear"
+        );
+
+        unsafe {
+            mmio.as_mut_ptr()
+                .add(STATUS_WORD)
+                .write_volatile(crate::regs::Status::new().into_bits());
+        }
+        assert!(matches!(
+            <DwMmc as sdio_host2::SdioHost>::advance_bus_op(
+                &mut host,
+                &mut request,
+                sdio_host2::ProgressCause::RegisterRetry,
+            )
+            .unwrap(),
+            sdio_host2::RequestProgress::RegisterPending { .. }
+        ));
+        assert!(crate::regs::Ctrl::from_bits(mmio[CTRL_WORD]).fifo_reset());
     }
 
     #[test]

--- a/drivers/blk/sdhci-host/src/host2/bus.rs
+++ b/drivers/blk/sdhci-host/src/host2/bus.rs
@@ -183,7 +183,11 @@ impl Sdhci {
         if self.read_u8(REG_SOFTWARE_RESET) & mask == 0 {
             if mask == RESET_ALL {
                 self.call_after_reset_hook().map_err(map_protocol_error)?;
+                self.write_u16(REG_NORMAL_INT_STATUS, NORMAL_INT_CLEAR_ALL);
+                self.write_u16(REG_ERROR_INT_STATUS, ERROR_INT_CLEAR_ALL);
+                self.clear_cached_irq_status();
                 self.restore_completion_irq_after_reset(was_irq_enabled);
+                self.dma_poisoned = false;
             }
             return Ok(sdio_host2::RequestProgress::Complete(Ok(())));
         }

--- a/drivers/blk/sdhci-host/src/tests.rs
+++ b/drivers/blk/sdhci-host/src/tests.rs
@@ -237,6 +237,50 @@ fn host2_advance_after_complete_is_rejected() {
 }
 
 #[test]
+fn host2_reset_all_invalidates_stale_irq_state_before_restore() {
+    #[repr(align(4))]
+    struct FakeRegs([u8; 0x100]);
+
+    let mut regs = FakeRegs([0; 0x100]);
+    let base = NonNull::new(regs.0.as_mut_ptr()).unwrap();
+    let mut host = unsafe { Sdhci::new(base) };
+    host.enable_interrupt_status_capture();
+    host.enable_completion_irq();
+    host.irq.state.begin_request();
+    let generation = host.irq.state.generation();
+    host.irq
+        .state
+        .cache_if_current(generation, NORMAL_INT_CMD_COMPLETE, ERROR_INT_DATA_TIMEOUT);
+    let mut request = unsafe {
+        <Sdhci as sdio_host2::SdioHost>::submit_bus_op(&mut host, sdio_host2::BusOp::ResetAll)
+    }
+    .unwrap();
+
+    assert!(matches!(
+        <Sdhci as sdio_host2::SdioHost>::advance_bus_op(
+            &mut host,
+            &mut request,
+            ProgressCause::Submitted,
+        ),
+        Ok(RequestProgress::RegisterPending { .. })
+    ));
+    host.write_u8(REG_SOFTWARE_RESET, 0);
+    assert!(matches!(
+        <Sdhci as sdio_host2::SdioHost>::advance_bus_op(
+            &mut host,
+            &mut request,
+            ProgressCause::RegisterRetry,
+        ),
+        Ok(RequestProgress::Complete(Ok(())))
+    ));
+
+    assert_eq!(host.irq.state.generation(), 0);
+    assert_eq!(host.irq.state.pending_normal(), 0);
+    assert_eq!(host.irq.state.pending_error(), 0);
+    assert!(host.completion_irq_enabled());
+}
+
+#[test]
 fn host2_bus_request_is_bound_to_originating_host() {
     #[repr(align(4))]
     struct FakeRegs([u8; 0x100]);

--- a/drivers/blk/sdmmc-protocol/src/rdif/device.rs
+++ b/drivers/blk/sdmmc-protocol/src/rdif/device.rs
@@ -1,4 +1,4 @@
-use alloc::{boxed::Box, sync::Arc, vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec};
 use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering};
 
 use rdif_block::{
@@ -84,6 +84,7 @@ where
     irq_handler: Option<Box<dyn HardIrqHandler>>,
     init_preference: Option<CardInitPreference>,
     init_status: Arc<BlockInitStatus>,
+    diagnostic_identity: Option<String>,
     started: bool,
     stopped: bool,
 }
@@ -95,6 +96,7 @@ where
     H::BusRequest: Send,
 {
     pub fn new(mut card: SdioSdmmc<H>, config: BlockConfig) -> Self {
+        let diagnostic_identity = card.diagnostic_identity().map(String::from);
         let init_status = Arc::new(BlockInitStatus::initialized(config.capacity_blocks()));
         let irq_handler = Box::new(BlockIrqHandler::<H> {
             irq: SdioIrqHost::irq_handle(card.host_mut()),
@@ -106,6 +108,7 @@ where
             irq_handler: Some(irq_handler),
             init_preference: None,
             init_status,
+            diagnostic_identity,
             started: false,
             stopped: false,
         }
@@ -118,6 +121,7 @@ where
         config: BlockConfig,
         preference: CardInitPreference,
     ) -> Self {
+        let diagnostic_identity = card.diagnostic_identity().map(String::from);
         let init_status = Arc::new(BlockInitStatus::initializing());
         let irq_handler = Box::new(BlockIrqHandler::<H> {
             irq: SdioIrqHost::irq_handle(card.host_mut()),
@@ -129,6 +133,7 @@ where
             irq_handler: Some(irq_handler),
             init_preference: Some(preference),
             init_status,
+            diagnostic_identity,
             started: false,
             stopped: false,
         }
@@ -185,7 +190,9 @@ where
     H::BusRequest: Send,
 {
     fn name(&self) -> &str {
-        self.config.name()
+        self.diagnostic_identity
+            .as_deref()
+            .unwrap_or_else(|| self.config.name())
     }
 }
 

--- a/drivers/blk/sdmmc-protocol/src/sdio/card.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/card.rs
@@ -1,5 +1,6 @@
 //! Card-facing SD/MMC command and block I/O wrapper.
 
+use alloc::string::String;
 use core::num::NonZeroU16;
 
 use dma_api::{CompletedDma, CpuDmaBuffer};
@@ -28,6 +29,7 @@ pub struct SdioSdmmc<H: SdioIrqHost + 'static> {
     pub(super) kind: CardKind,
     pub(super) sd_speed_selection_enabled: bool,
     pub(super) sd_uhs_selection_enabled: bool,
+    pub(super) diagnostic_identity: Option<String>,
 }
 
 pub struct SdioDataRequest<'a, H: SdioIrqHost + 'static> {
@@ -68,7 +70,22 @@ impl<H: SdioIrqHost + 'static> SdioSdmmc<H> {
             kind: CardKind::Sd,
             sd_speed_selection_enabled: true,
             sd_uhs_selection_enabled: true,
+            diagnostic_identity: None,
         }
+    }
+
+    /// Sets the platform-provided controller identity used in protocol logs.
+    ///
+    /// Portable protocol code treats this as an opaque diagnostic label. OS
+    /// glue may include firmware identity such as an FDT path without making
+    /// the driver core depend on firmware or probe APIs.
+    pub fn set_diagnostic_identity(&mut self, identity: impl Into<String>) {
+        self.diagnostic_identity = Some(identity.into());
+    }
+
+    /// Returns the platform-provided controller identity, when available.
+    pub fn diagnostic_identity(&self) -> Option<&str> {
+        self.diagnostic_identity.as_deref()
     }
 
     /// Returns mutable access to the underlying SDIO host controller.

--- a/drivers/blk/sdmmc-protocol/src/sdio/init/state_machine.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/init/state_machine.rs
@@ -152,8 +152,12 @@ impl<H: SdioIrqHost> SdioSdmmc<H> {
             Ok(progress) => Ok(progress),
             Err(err) => {
                 warn!(
-                    "sdio: init state {:?} aborted ({:?}), resetting host",
-                    request.state, err
+                    "sdio: controller={} preference={:?} init state {:?} aborted ({:?}), \
+                     restoring bus baseline",
+                    self.diagnostic_identity().unwrap_or("unidentified"),
+                    request.preference,
+                    request.state,
+                    err
                 );
                 if let Err(recovery) = self.abort_init_request(request) {
                     warn!("sdio: init request recovery failed: {recovery:?}");

--- a/drivers/blk/sdmmc-protocol/src/sdio/init/state_machine/identify.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/init/state_machine/identify.rs
@@ -269,8 +269,10 @@ impl<H: SdioIrqHost> SdioSdmmc<H> {
                             power_up_deadline_passed(self.host.inner(), request.mmc_started_ms);
                         if request.mmc_polls >= SdioInitTiming::MAX_POLLS || elapsed_exceeded {
                             warn!(
-                                "sdio: CMD1 timed out after {} polls (~{} ms at the recommended \
-                                 cadence)",
+                                "sdio: controller={} media=MMC preference={:?} CMD1 timed out \
+                                 after {} polls (~{} ms at the recommended cadence)",
+                                self.diagnostic_identity().unwrap_or("unidentified"),
+                                request.preference,
                                 request.mmc_polls,
                                 request.mmc_polls * SdioInitTiming::POLL_TICK_MS_HINT,
                             );

--- a/drivers/blk/sdmmc-protocol/src/sdio/tests/rdif_lifecycle.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/tests/rdif_lifecycle.rs
@@ -2,12 +2,24 @@ use core::{num::NonZeroUsize, time::Duration};
 
 use rdif_block::{
     BatchSubmitDisposition, BlockController, CompletedRequest, CompletionSink, ControllerEvent,
-    ControllerState, OwnedRequest, OwnedRequestBatch, RequestFlags, RequestId, RequestOp,
-    SubmissionSink,
+    ControllerState, DriverGeneric, OwnedRequest, OwnedRequestBatch, RequestFlags, RequestId,
+    RequestOp, SubmissionSink,
 };
 
 use super::*;
 use crate::rdif::{BlockConfig, BlockDevice};
+
+#[test]
+fn controller_uses_card_diagnostic_identity() {
+    let host = MockHost::new(Vec::new());
+    let config = BlockConfig::dma("sdmmc-test", 1, test_device_dma());
+    let mut card = SdioSdmmc::new(host);
+    card.set_diagnostic_identity("rockchip-dwmmc:/mmc@fe2c0000");
+
+    let controller = BlockDevice::new(card, config);
+
+    assert_eq!(controller.name(), "rockchip-dwmmc:/mmc@fe2c0000");
+}
 
 #[test]
 fn controller_teardown_is_idempotent_after_watchdog_shutdown() {

--- a/fs/ax-fs-ng/src/block/runtime/hctx/mod.rs
+++ b/fs/ax-fs-ng/src/block/runtime/hctx/mod.rs
@@ -288,6 +288,9 @@ fn run_hctx(
             &mut fatal_error,
             &mut irq_events,
         );
+        if fatal_error.is_some() {
+            break;
+        }
         if irq_progress {
             // An acknowledged device event supersedes a timer selected from
             // the prior queue state. Reconcile with the state produced by the
@@ -314,6 +317,9 @@ fn run_hctx(
                 fatal_error: &mut fatal_error,
             },
         );
+        if fatal_error.is_some() {
+            break;
+        }
         if irq_progress || register_progress {
             submission_blocked = false;
         }
@@ -478,6 +484,9 @@ fn advance_register_retry_if_due(
     now: Duration,
     context: &mut RegisterRetryContext<'_>,
 ) -> bool {
+    if context.fatal_error.is_some() {
+        return false;
+    }
     if context.deadline.is_some_and(|deadline| deadline <= now) {
         set_hctx_fatal(context.state, context.fatal_error, BlkError::TimedOut);
         return true;
@@ -564,6 +573,12 @@ fn drain_latched_irqs(
         // Queue-owned state must observe the acknowledged hardware event
         // before the controller reacts to the same IRQ. Initialization uses
         // this ordering to publish discovered geometry before Ready.
+        // A terminal queue result owns teardown from this point onward. Do not
+        // let the failed IRQ race its Watchdog by advancing or rearming the
+        // controller after queue state has already declared the device dead.
+        if fatal_error.is_some() {
+            continue;
+        }
         if !event.control.is_empty() {
             controller.post(ControllerEvent::Irq(event.control));
             progressed = true;

--- a/fs/ax-fs-ng/src/block/runtime/hctx/tests.rs
+++ b/fs/ax-fs-ng/src/block/runtime/hctx/tests.rs
@@ -80,6 +80,48 @@ struct CapabilityRefreshQueue {
     initialized: Arc<AtomicBool>,
 }
 
+struct FailingDrainQueue {
+    counters: Arc<QueueCounters>,
+}
+
+impl DriverGeneric for FailingDrainQueue {
+    fn name(&self) -> &str {
+        "failing-drain"
+    }
+}
+
+impl HardwareQueue for FailingDrainQueue {
+    fn id(&self) -> usize {
+        0
+    }
+
+    fn info(&self) -> QueueInfo {
+        test_queue_info(1)
+    }
+
+    fn submit_batch_owned(
+        &mut self,
+        _requests: &mut OwnedRequestBatch,
+        _sink: &mut dyn SubmissionSink,
+    ) -> rdif_block::BatchSubmitResult {
+        rdif_block::BatchSubmitResult::new(0, BatchSubmitDisposition::Continue)
+    }
+
+    fn commit_submissions(&mut self) -> Result<(), BlkError> {
+        Ok(())
+    }
+
+    fn drain_completions(&mut self, _sink: &mut dyn CompletionSink) -> Result<(), BlkError> {
+        self.counters.drained.fetch_add(1, Ordering::AcqRel);
+        Err(BlkError::Io)
+    }
+
+    fn shutdown(&mut self, _sink: &mut dyn CompletionSink) -> Result<(), BlkError> {
+        self.counters.shutdown.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+}
+
 impl DriverGeneric for CapabilityRefreshQueue {
     fn name(&self) -> &str {
         "capability-refresh"
@@ -384,6 +426,14 @@ impl HardIrqHandler for QueueZeroIrq {
     }
 }
 
+struct QueueZeroControlIrq;
+
+impl HardIrqHandler for QueueZeroControlIrq {
+    fn ack(&mut self) -> IrqAck {
+        IrqAck::masked_needs_rearm(IrqQueueMask::from_queue(0), ControlEvent::new(0, 1))
+    }
+}
+
 fn test_queue_info(depth: usize) -> QueueInfo {
     let mut limits = QueueLimits::simple(512, u64::MAX);
     limits.max_inflight = depth;
@@ -504,6 +554,55 @@ fn register_retry_advances_only_register_state_and_posts_controller_event() {
 }
 
 #[test]
+fn terminal_state_rejects_an_already_due_register_retry() {
+    crate::os::task::install_test_runtime_ops();
+    let ops = runtime_ops().unwrap();
+    let state = HctxState {
+        info: IrqMutex::new(test_queue_info(1)),
+        submission_channels: IrqMutex::new(Vec::new()),
+        notification: ops.notification(),
+        lifecycle_notification: ops.notification(),
+        irq_latches: IrqMutex::new(Vec::new()),
+        quiescing: AtomicBool::new(false),
+        quiesced: AtomicBool::new(false),
+        stopping: AtomicBool::new(true),
+        terminated: AtomicBool::new(false),
+    };
+    let retries = Arc::new(AtomicUsize::new(0));
+    let drains = Arc::new(AtomicUsize::new(0));
+    let mut queue = RegisterRetryQueue {
+        retry_after: Some(Duration::from_millis(1)),
+        retries: Arc::clone(&retries),
+        drains,
+    };
+    let controller = TestControllerPort::default();
+    let now = Duration::from_secs(10);
+    let mut retry_at = Some(now);
+    let mut deadline = Some(now + QUEUE_REGISTER_TRANSITION_TIMEOUT);
+    let mut fatal_error = Some(BlkError::Io);
+    let mut pending = BTreeMap::new();
+    let observer: Arc<dyn HctxObserver> = Arc::new(TestObserver::default());
+    let observer = Arc::downgrade(&observer);
+
+    assert!(!advance_register_retry_if_due(
+        &mut queue,
+        now,
+        &mut RegisterRetryContext {
+            controller: &controller,
+            pending: &mut pending,
+            observer: &observer,
+            retry_at: &mut retry_at,
+            deadline: &mut deadline,
+            state: &state,
+            fatal_error: &mut fatal_error,
+        },
+    ));
+
+    assert_eq!(retries.load(Ordering::Acquire), 0);
+    assert!(controller.events.lock().unwrap().is_empty());
+}
+
+#[test]
 fn retry_backlog_does_not_starve_fresh_cpu_channel_submissions() {
     crate::os::task::install_test_runtime_ops();
     let ops = runtime_ops().unwrap();
@@ -603,6 +702,48 @@ fn irq_drain_refreshes_hctx_queue_capabilities() {
         initial.limits.max_submit_batch
     );
     hctx.stop();
+}
+
+#[test]
+fn terminal_irq_drain_failure_does_not_advance_controller_or_rearm() {
+    crate::os::task::install_test_runtime_ops();
+    let counters = Arc::new(QueueCounters::default());
+    let observer = Arc::new(TestObserver::default());
+    let observer_dyn: Arc<dyn HctxObserver> = observer.clone();
+    let controller = Arc::new(TestControllerPort::default());
+    let controller_dyn: Arc<dyn ControllerEventPort> = controller.clone();
+    let queue = FailingDrainQueue {
+        counters: Arc::clone(&counters),
+    };
+    let hctx = Hctx::start(
+        Box::new(queue),
+        0,
+        Arc::downgrade(&observer_dyn),
+        controller_dyn,
+    )
+    .unwrap();
+
+    let target = hctx.irq_target(0);
+    let mut action = BlockIrqAction::new(Box::new(QueueZeroControlIrq), vec![target]);
+    assert_eq!(action.run(), crate::os::BlockIrqOutcome::Wake);
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while observer.failed.load(Ordering::Acquire) != 1 {
+        assert!(
+            Instant::now() < deadline,
+            "terminal queue failure did not stop the hctx"
+        );
+        thread::yield_now();
+    }
+    hctx.stop();
+
+    assert_eq!(counters.drained.load(Ordering::Acquire), 1);
+    assert_eq!(counters.shutdown.load(Ordering::Acquire), 1);
+    assert_eq!(
+        controller.events.lock().unwrap().as_slice(),
+        [ControllerEvent::Watchdog { queue_id: 0 }],
+        "the hctx terminal owner must not forward the failed IRQ or rearm it"
+    );
 }
 
 #[test]

--- a/fs/ax-fs-ng/src/block/runtime/lifecycle/controller.rs
+++ b/fs/ax-fs-ng/src/block/runtime/lifecycle/controller.rs
@@ -354,7 +354,10 @@ fn advance_controller_once(
     let mut update = match controller.advance(event) {
         Ok(update) => update,
         Err(error) => {
-            warn!("block controller transition {event:?} failed: {error:?}");
+            warn!(
+                "block controller {} transition {event:?} failed: {error:?}",
+                controller.name()
+            );
             return Err(error);
         }
     };

--- a/fs/ax-fs-ng/src/block/runtime/lifecycle/mod.rs
+++ b/fs/ax-fs-ng/src/block/runtime/lifecycle/mod.rs
@@ -129,10 +129,11 @@ impl BlockRuntime {
     pub fn from_rdif_devices(devices: impl IntoIterator<Item = RdifBlockDevice>) -> Self {
         let mut registered = Vec::new();
         for device in devices {
+            let name = device.name.clone();
             match BlockDeviceHandle::start(device) {
                 Ok(handle) => registered.push(handle),
                 Err(error) => {
-                    warn!("failed to start IRQ-driven block controller: {error:?}");
+                    warn!("failed to start IRQ-driven block controller {name}: {error:?}");
                 }
             }
         }


### PR DESCRIPTION
## 问题

OrangePi 5 Plus 原生 StarryOS 与 AxVisor Starry guest 会在可选 MMC 控制器初始化失败后继续向已经进入终态的 block controller 注入 `Irq`、`Rearm` 或 register-retry，随后产生二次 `Io`，使真正的设备失败被生命周期噪声掩盖。同时，原有日志没有携带唯一 controller/FDT path，无法判断 CMD1 timeout 来自根 SD 卡还是独立 eMMC 控制器。

## 根因与方案

本次修改以 `~/orangepi-build/kernel/orange-pi-6.1-rk35xx` 的 MMC core、`dw_mmc` 与 `sdhci-of-dwcmshc` 实现为参照：

1. Linux 在一次 rescan 中只执行一次 power-up/reset/CMD0，随后按 SDIO、SD、MMC 顺序 attach；SD attach 失败后直接尝试 CMD1，不额外 ResetAll。因此保留现有 SD→MMC 直接 fallback，不增加 timeout 或插入多余 reset。
2. Rockchip 的卡类型策略统一由 FDT `no-sd`/`no-mmc` 参数化：`no-mmc` 使用 `SdOnly`，`no-sd` 使用 `MmcFirst`，其余保持 Linux 的 `SdFirst` 顺序。`non-removable` 不再被误当作 eMMC 类型标记，也没有按板型、寄存器地址或 alias 写死。
3. DWMMC `ResetAll` 补齐 Linux 顺序：controller/FIFO/DMA reset 后清 raw IRQ，等待 `DMA_REQ` 消失，再执行第二次 FIFO reset，最后重建 IDMAC 软件基线。
4. SDHCI `ResetAll` 完成后清 normal/error status、使旧软件 IRQ generation 失效，再恢复 runtime 所有的 completion IRQ，防止 reset 前的状态污染下一次请求。
5. hctx 在 queue drain 或 register-retry 产生 terminal error 后立即进入统一 teardown；失败 IRQ 不再推进 controller 或 rearm。唯一终态 owner 先发送 `Watchdog`，确认 controller shutdown 后再执行 queue shutdown。
6. Rockchip glue 把 `controller type + FDT path` 作为不透明诊断 identity 传入 portable protocol 层；probe、CMD1 timeout、init abort、controller transition 与注册失败日志都可定位具体设备、介质与 preference。单个失败设备仍不会阻止其他 block device 注册。

## 确定性回归

新增回归均先在旧实现上验证失败，再由同一测试验证修复：

- terminal queue drain 旧实现会产生 `Irq + Rearm + Watchdog`，修复后只保留一次 `Watchdog`。
- 已进入 fatal 状态的到期 register-retry 旧实现仍会推进 queue/controller，修复后 retry/event 均为 0。
- 仅声明 `non-removable` 的 FDT 节点旧实现被误判为 `MmcFirst`，修复后保持 `SdFirst`。
- SDHCI ResetAll 旧实现保留 reset 前 IRQ generation，修复后 generation/status 清零并恢复 completion IRQ。
- DWMMC ResetAll 旧实现不等待 `DMA_REQ`、不执行第二次 FIFO reset且保留 poisoned IDMAC 基线，修复后按 Linux 顺序完成。

## 本地验证

- `cargo test -p ax-fs-ng --features ax-sync/host-test`（69 unit + 3 integration）
- `cargo test -p sdmmc-protocol --no-default-features --features sdio,rdif`（103 tests）
- `cargo test -p dwmmc-host --lib`（56 tests）
- `cargo test -p sdhci-host --lib`（45 tests）
- `cargo test -p ax-driver --no-default-features --features rockchip-dwmmc,rockchip-sdhci --lib`（27 tests）
- `cargo xtask clippy --package ax-fs-ng`
- `cargo xtask clippy --package sdmmc-protocol`
- `cargo xtask clippy --package dwmmc-host`
- `cargo xtask clippy --package sdhci-host`
- `cargo xtask clippy --package ax-driver`（52 feature checks）
- `cargo xtask starry build --config test-suit/starryos/board-orangepi-5-plus/robot-flow/build-aarch64-unknown-none-softfloat.toml --target aarch64-unknown-none-softfloat`
- `cargo xtask axvisor build --config test-suit/axvisor/normal/board-orangepi-5-plus/robot-starry/build-aarch64-unknown-none-softfloat.toml`
- `cargo fmt --all --check`
- `git diff --check`

实体板运行留给 PR 的 OrangePi 5 Plus self-hosted CI，需分别确认原生 StarryOS 与 AxVisor Starry guest 的具体 controller identity、成功标记及终态结果。

Fixes #1986
