### PR TITLE
feat(sched): add len/is_empty/pick_stealable_task introspection for load balancing

### DIFF
--- a/components/axsched/src/cfs.rs
+++ b/components/axsched/src/cfs.rs
@@ -121,6 +121,37 @@ impl<T> CFScheduler<T> {
     pub fn scheduler_name() -> &'static str {
         "Completely Fair"
     }
+
+    /// Returns the number of ready tasks currently in the ready queue.
+    pub fn len(&self) -> usize {
+        self.ready_queue.len()
+    }
+
+    /// Returns whether the ready queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.ready_queue.is_empty()
+    }
+
+    /// Removes and returns the first ready task for which `pred` (over the inner
+    /// task struct) holds. `None` if no task matches. Recomputes the cached
+    /// min-vruntime the same way [`BaseScheduler::remove_task`] does.
+    pub fn pick_stealable_task(
+        &mut self,
+        mut pred: impl FnMut(&T) -> bool,
+    ) -> Option<Arc<CFSTask<T>>> {
+        let key = self
+            .ready_queue
+            .iter()
+            .find(|(_, v)| pred(v.inner()))
+            .map(|(k, _)| *k)?;
+        let task = self.ready_queue.remove(&key);
+        if let Some(((min_vruntime, _), _)) = self.ready_queue.first_key_value() {
+            self.min_vruntime = Some(AtomicIsize::new(*min_vruntime));
+        } else {
+            self.min_vruntime = None;
+        }
+        task
+    }
 }
 
 impl<T> BaseScheduler for CFScheduler<T> {

--- a/components/axsched/src/fifo.rs
+++ b/components/axsched/src/fifo.rs
@@ -35,6 +35,33 @@ impl<T> FifoScheduler<T> {
     pub fn scheduler_name() -> &'static str {
         "FIFO"
     }
+
+    /// Returns the number of ready tasks currently in the ready queue.
+    pub fn len(&self) -> usize {
+        self.ready_queue.len()
+    }
+
+    /// Returns whether the ready queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.ready_queue.is_empty()
+    }
+
+    /// Removes and returns the first ready task for which `pred` (over the inner
+    /// task struct) holds, preserving the order of non-matching tasks. `None` if
+    /// no task matches.
+    pub fn pick_stealable_task(
+        &mut self,
+        mut pred: impl FnMut(&T) -> bool,
+    ) -> Option<Arc<FifoTask<T>>> {
+        let mut cursor = self.ready_queue.cursor_front_mut();
+        loop {
+            let hit = pred(cursor.current()?.inner());
+            if hit {
+                return cursor.remove_current();
+            }
+            cursor.move_next();
+        }
+    }
 }
 
 impl<T> BaseScheduler for FifoScheduler<T> {

--- a/components/axsched/src/round_robin.rs
+++ b/components/axsched/src/round_robin.rs
@@ -83,6 +83,33 @@ impl<T, const S: usize> RRScheduler<T, S> {
     pub fn scheduler_name() -> &'static str {
         "Round-robin"
     }
+
+    /// Returns the number of ready tasks currently in the ready queue.
+    pub fn len(&self) -> usize {
+        self.ready_queue.len()
+    }
+
+    /// Returns whether the ready queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.ready_queue.is_empty()
+    }
+
+    /// Removes and returns the first ready task for which `pred` (over the inner
+    /// task struct) holds, preserving the order of non-matching tasks. `None` if
+    /// no task matches.
+    pub fn pick_stealable_task(
+        &mut self,
+        mut pred: impl FnMut(&T) -> bool,
+    ) -> Option<Arc<RRTask<T, S>>> {
+        let mut cursor = self.ready_queue.cursor_front_mut();
+        loop {
+            let hit = pred(cursor.current()?.inner());
+            if hit {
+                return cursor.remove_current();
+            }
+            cursor.move_next();
+        }
+    }
 }
 
 impl<T, const S: usize> BaseScheduler for RRScheduler<T, S> {

--- a/components/axsched/src/tests.rs
+++ b/components/axsched/src/tests.rs
@@ -30,6 +30,51 @@ macro_rules! def_test_sched {
             }
 
             #[test]
+            fn test_len() {
+                const NUM_TASKS: usize = 7;
+                let mut scheduler = <$scheduler>::new();
+                assert_eq!(scheduler.len(), 0);
+                assert!(scheduler.is_empty());
+                let mut tasks = Vec::new();
+                for i in 0..NUM_TASKS {
+                    let t = Arc::new(<$task>::new(i));
+                    tasks.push(t.clone());
+                    scheduler.add_task(t);
+                    assert_eq!(scheduler.len(), i + 1);
+                }
+                assert!(!scheduler.is_empty());
+                for k in 0..NUM_TASKS {
+                    assert_eq!(scheduler.len(), NUM_TASKS - k);
+                    let _ = scheduler.pick_next_task().unwrap();
+                }
+                assert_eq!(scheduler.len(), 0);
+                assert!(scheduler.pick_next_task().is_none());
+                assert_eq!(scheduler.len(), 0);
+                let mut scheduler = <$scheduler>::new();
+                for t in &tasks {
+                    scheduler.add_task(t.clone());
+                }
+                assert_eq!(scheduler.len(), NUM_TASKS);
+                assert!(scheduler.remove_task(&tasks[3]).is_some());
+                assert_eq!(scheduler.len(), NUM_TASKS - 1);
+            }
+
+            #[test]
+            fn test_steal() {
+                let mut scheduler = <$scheduler>::new();
+                assert!(scheduler.pick_stealable_task(|_| true).is_none());
+                for i in 0..5 {
+                    scheduler.add_task(Arc::new(<$task>::new(i)));
+                }
+                assert!(scheduler.pick_stealable_task(|_| false).is_none());
+                assert_eq!(scheduler.len(), 5);
+                let stolen = scheduler.pick_stealable_task(|v| *v == 3).unwrap();
+                assert_eq!(*stolen.inner(), 3);
+                assert_eq!(scheduler.len(), 4);
+                assert!(scheduler.pick_stealable_task(|v| *v == 3).is_none());
+            }
+
+            #[test]
             fn bench_yield() {
                 const NUM_TASKS: usize = 1_000_000;
                 const COUNT: usize = NUM_TASKS * 3;

--- a/components/linked_list_r4l/src/linked_list.rs
+++ b/components/linked_list_r4l/src/linked_list.rs
@@ -146,6 +146,11 @@ impl<G: GetLinksWrapped> List<G> {
         self.list.is_empty()
     }
 
+    /// Returns the number of elements currently in the list.
+    pub const fn len(&self) -> usize {
+        self.list.len()
+    }
+
     /// Adds the given object to the end (back) of the list.
     ///
     /// It is dropped if it's already on this (or another) list; this can happen for

--- a/components/linked_list_r4l/src/raw_list.rs
+++ b/components/linked_list_r4l/src/raw_list.rs
@@ -92,6 +92,7 @@ impl<T: ?Sized> ListEntry<T> {
 /// The links of objects added to a list are owned by the list.
 pub struct RawList<G: GetLinks> {
     head: Option<NonNull<G::EntryType>>,
+    len: usize,
 }
 
 impl<G: GetLinks> Default for RawList<G> {
@@ -103,7 +104,7 @@ impl<G: GetLinks> Default for RawList<G> {
 impl<G: GetLinks> RawList<G> {
     /// Constructs a new empty RawList.
     pub const fn new() -> Self {
-        Self { head: None }
+        Self { head: None, len: 0 }
     }
 
     /// Returns an iterator for the list starting at the first entry.
@@ -114,6 +115,11 @@ impl<G: GetLinks> RawList<G> {
     /// Returns whether the RawList is empty.
     pub const fn is_empty(&self) -> bool {
         self.head.is_none()
+    }
+
+    /// Returns the number of elements currently in the list.
+    pub const fn len(&self) -> usize {
+        self.len
     }
 
     fn insert_after_priv(
@@ -158,6 +164,7 @@ impl<G: GetLinks> RawList<G> {
         // SAFETY: The links are now owned by the list, so it is safe to get a mutable reference.
         let new_entry = unsafe { &mut *links.entry.get() };
         self.insert_after_priv(existing, new_entry, Some(new));
+        self.len += 1;
         true
     }
 
@@ -187,6 +194,7 @@ impl<G: GetLinks> RawList<G> {
                 new_entry.prev = new_ptr;
             }
         }
+        self.len += 1;
         true
     }
 
@@ -253,6 +261,7 @@ impl<G: GetLinks> RawList<G> {
         entry.next = None;
         entry.prev = None;
         links.release_after_removal();
+        self.len -= 1;
         true
     }
 
@@ -666,5 +675,65 @@ mod tests {
             unsafe { list.insert_after(v[i].as_ref().into(), extra.as_ref().into()) };
             v.insert(i + 1, extra);
         });
+    }
+
+    #[test]
+    fn test_len() {
+        const MAX: usize = 10;
+        let v = build_vector(MAX);
+        let mut list = super::RawList::<Example>::new();
+
+        // An empty list must report a length of zero.
+        assert_eq!(list.len(), 0);
+        assert!(list.is_empty());
+
+        // `len()` must track every successful `push_back` one-for-one.
+        for n in 1..=MAX {
+            // SAFETY: The entry was allocated above, it's not in any lists yet, is never moved,
+            // and outlives the list.
+            unsafe { list.push_back(NonNull::from(&*v[n - 1])) };
+            assert_eq!(list.len(), n);
+        }
+
+        // Inserting after an existing element must also grow the length by exactly one.
+        let extra = Box::new(Example {
+            links: super::Links::new(),
+        });
+        // SAFETY: `v[0]` is on the list; `extra` isn't in any list yet, isn't moved, and
+        // outlives the list.
+        assert!(unsafe { list.insert_after(v[0].as_ref().into(), extra.as_ref().into()) });
+        assert_eq!(list.len(), MAX + 1);
+
+        // Removing an entry that is not on the list must be a no-op: it must not change the
+        // length and, critically, must not underflow it.
+        let not_inserted = Box::new(Example {
+            links: super::Links::new(),
+        });
+        // SAFETY: `not_inserted` was never inserted into `list`.
+        assert!(!unsafe { list.remove(&not_inserted) });
+        assert_eq!(list.len(), MAX + 1);
+
+        // Remove the extra element inserted above, then remove every original element one by
+        // one, checking that `len()` equals the number of live nodes after every removal.
+        // SAFETY: `extra` is on the list and hasn't been removed yet.
+        assert!(unsafe { list.remove(&extra) });
+        assert_eq!(list.len(), MAX);
+
+        for n in (0..MAX).rev() {
+            // SAFETY: `v[n]` was added to the list above, and wasn't removed yet.
+            assert!(unsafe { list.remove(&v[n]) });
+            assert_eq!(list.len(), n);
+
+            // Removing the same (now unlinked) entry again must be a no-op and must not
+            // underflow the counter.
+            // SAFETY: `v[n]` is no longer on any list, so calling `remove` again is a query,
+            // not a real removal.
+            assert!(!unsafe { list.remove(&v[n]) });
+            assert_eq!(list.len(), n);
+        }
+
+        // A fully drained list must report a length of zero again.
+        assert_eq!(list.len(), 0);
+        assert!(list.is_empty());
     }
 }


### PR DESCRIPTION
## 问题
`axsched` 的三种调度器（CFS/FIFO/RR）与底层 `linked_list_r4l` 只暴露了 `is_empty`，缺少 `len` 和“可窃取任务”查询，无法作为负载均衡（run-queue 长度比较、任务窃取）的基础原语。

## 改动
- `linked_list_r4l`：为 `RawList` 增加 `len` 字段，在 insert/push/remove 处维护，并暴露 `RawList::len()` / `List::len()`。
- `axsched`：为 `CFScheduler`/`FifoScheduler`/`RRScheduler` 增加 `len()` / `is_empty()` / `pick_stealable_task(pred)`。

## 逻辑
`len` 随链表增删以 O(1) 维护；`pick_stealable_task` 在 run-queue 上按谓词选出一个可迁移任务并移除。二者均为只读 / 基础原语，不改变现有调度行为，供后续容量感知放置与任务窃取消费。

## 测试
`ax-linked-list-r4l` 与 `ax-sched` 均已在 `scripts/test/std_crates.csv` 中；新增 `test_len` / `test_steal`（fifo/rr/cfs）随 `cargo xtask test` 运行，本地 16 项全部通过，fmt/clippy clean。