### PR TITLE
feat(buddy): add split_pages primitive to explode a block into 4K frames

### DIFF
--- a/memory/ax-alloc/src/buddy_slab.rs
+++ b/memory/ax-alloc/src/buddy_slab.rs
@@ -288,6 +288,16 @@ impl GlobalAllocator {
             .dealloc(kind, num_pages * PAGE_SIZE);
     }
 
+    /// Explodes a contiguous page allocation at `pos` into independently
+    /// freeable order-0 (`PAGE_SIZE`) pages (the physical-frame side of a
+    /// transparent-huge-page → per-page split). The block's pages stay allocated
+    /// and their total byte count is unchanged, so the usage counters are
+    /// untouched here; each order-0 page is later released via
+    /// [`dealloc_pages`](Self::dealloc_pages) with a count of 1.
+    pub fn split_pages(&self, pos: usize) {
+        self.inner.lock_irqsave().split_pages(pos);
+    }
+
     /// Returns the number of allocated bytes in the allocator backend.
     pub fn used_bytes(&self) -> usize {
         self.inner.lock_irqsave().allocated_bytes()

--- a/memory/buddy-slab-allocator/src/buddy/mod.rs
+++ b/memory/buddy-slab-allocator/src/buddy/mod.rs
@@ -748,6 +748,59 @@ impl<const PAGE_SIZE: usize> BuddyAllocator<PAGE_SIZE> {
         Self::dealloc_in_section(section, pfn, order);
     }
 
+    /// Explode an allocated block into independently-freeable order-0 pages.
+    ///
+    /// `addr` must be the head address of a block previously obtained from
+    /// [`alloc_pages`](Self::alloc_pages) that is still allocated. After this
+    /// call every order-0 (`PAGE_SIZE`) page in the original block is an
+    /// independent `Allocated` block. Unlike a normal allocation — where only the
+    /// original `alloc_pages` head is a valid free address — each of these
+    /// per-page addresses then becomes a valid `dealloc_pages(page_addr, 1)`
+    /// input and coalesces normally with its buddies on free. This performs a
+    /// metadata rewrite only — no page contents move and the total allocated byte
+    /// count is unchanged.
+    ///
+    /// This is the physical-frame half of a transparent-huge-page → 4 KiB
+    /// split: the 2 MiB VMSAv8 block PTE is re-mapped as 512 leaf PTEs while
+    /// the underlying order-9 buddy block is exploded here so the 512 pages can
+    /// later be unmapped/freed individually.
+    pub fn split_pages(&mut self, addr: usize) {
+        let Some(section) = self.find_section_by_addr_mut(addr) else {
+            debug_assert!(
+                false,
+                "split_pages called with address outside all sections"
+            );
+            return;
+        };
+
+        debug_assert!(is_aligned(addr, PAGE_SIZE));
+        let head_pfn = (addr - section.heap_start) / PAGE_SIZE;
+        debug_assert!(head_pfn < section.max_pages);
+        let stored = unsafe { &*section.meta.add(head_pfn) };
+        debug_assert!(
+            stored.flags == PageFlags::Allocated,
+            "split_pages called on non-allocated block"
+        );
+        let order = stored.order as usize;
+        let count = 1usize << order;
+        debug_assert!(head_pfn + count <= section.max_pages);
+
+        // Re-tag every page (head included) as an independent order-0 allocated
+        // block. Free-list links are irrelevant for allocated pages, but reset
+        // them so a later `dealloc_in_section` sees clean metadata before it
+        // pushes the freed page onto a free list.
+        for i in 0..count {
+            let pfn = head_pfn + i;
+            unsafe {
+                let m = &mut *section.meta.add(pfn);
+                m.flags = PageFlags::Allocated;
+                m.order = 0;
+                m.prev = PFN_NONE;
+                m.next = PFN_NONE;
+            }
+        }
+    }
+
     /// Mark the page at `addr` with the given flags (used by slab to tag pages).
     ///
     /// # Safety

--- a/memory/buddy-slab-allocator/src/global.rs
+++ b/memory/buddy-slab-allocator/src/global.rs
@@ -205,6 +205,12 @@ impl<const PAGE_SIZE: usize> GlobalAllocator<PAGE_SIZE> {
         self.buddy().dealloc_pages(addr, count);
     }
 
+    /// Explode an allocated block at `addr` into independently-freeable order-0
+    /// pages. See [`BuddyAllocator::split_pages`](crate::buddy::BuddyAllocator::split_pages).
+    pub fn split_pages(&self, addr: usize) {
+        self.buddy().split_pages(addr);
+    }
+
     /// Allocate pages with physical address below 4 GiB.
     pub fn alloc_pages_lowmem(&self, count: usize, align: usize) -> AllocResult<usize> {
         self.buddy().alloc_pages_lowmem(count, align)

--- a/memory/buddy-slab-allocator/tests/integration_test.rs
+++ b/memory/buddy-slab-allocator/tests/integration_test.rs
@@ -79,6 +79,72 @@ fn buddy_basic_alloc_dealloc() {
 }
 
 #[test]
+fn buddy_split_pages_explodes_block_into_freeable_4k_pages() {
+    // A 2 MiB (order-9) block must be splittable into 512 independently
+    // freeable 4 KiB pages, and freeing all of them must coalesce back to the
+    // original block (re-allocatable as one 2 MiB block again).
+    const ALIGN_2M: usize = 2 * 1024 * 1024;
+    const PAGES_2M: usize = ALIGN_2M / PAGE_SIZE; // 512
+    let mut region = HostRegion::new(buddy_region_size(TEST_HEAP_SIZE) + ALIGN_2M, ALIGN_2M);
+    let mut buddy = BuddyAllocator::<PAGE_SIZE>::new();
+    let _section = init_buddy_with_heap_alignment(&mut buddy, &mut region, ALIGN_2M);
+
+    let free_start = buddy.free_pages();
+
+    // One contiguous, 2 MiB-aligned order-9 block.
+    let block = buddy.alloc_pages(PAGES_2M, ALIGN_2M).unwrap();
+    assert_eq!(block % ALIGN_2M, 0);
+    assert_eq!(buddy.free_pages(), free_start - PAGES_2M);
+
+    // Explode it: every 4 KiB page becomes an independent order-0 allocation.
+    buddy.split_pages(block);
+    // Splitting is metadata-only; occupancy is unchanged.
+    assert_eq!(buddy.free_pages(), free_start - PAGES_2M);
+
+    // Free all 512 sub-pages individually, in a shuffled order to exercise
+    // buddy coalescing from both directions.
+    let mut order: Vec<usize> = (0..PAGES_2M).collect();
+    order.rotate_left(37);
+    for i in order {
+        buddy.dealloc_pages(block + i * PAGE_SIZE, 1);
+    }
+    assert_eq!(buddy.free_pages(), free_start);
+
+    // Full coalescing back to order-9: the 2 MiB block is allocatable again.
+    let block2 = buddy.alloc_pages(PAGES_2M, ALIGN_2M).unwrap();
+    assert_eq!(block2, block);
+    buddy.dealloc_pages(block2, PAGES_2M);
+    assert_eq!(buddy.free_pages(), free_start);
+}
+
+#[test]
+fn buddy_split_pages_allows_partial_free_of_exploded_block() {
+    // After split, freeing only a sub-range leaves the rest allocated; the
+    // remaining pages stay usable and freeable independently.
+    const ALIGN_2M: usize = 2 * 1024 * 1024;
+    const PAGES_2M: usize = ALIGN_2M / PAGE_SIZE;
+    let mut region = HostRegion::new(buddy_region_size(TEST_HEAP_SIZE) + ALIGN_2M, ALIGN_2M);
+    let mut buddy = BuddyAllocator::<PAGE_SIZE>::new();
+    let _section = init_buddy_with_heap_alignment(&mut buddy, &mut region, ALIGN_2M);
+
+    let free_start = buddy.free_pages();
+    let block = buddy.alloc_pages(PAGES_2M, ALIGN_2M).unwrap();
+    buddy.split_pages(block);
+
+    // Free the first half only.
+    for i in 0..PAGES_2M / 2 {
+        buddy.dealloc_pages(block + i * PAGE_SIZE, 1);
+    }
+    assert_eq!(buddy.free_pages(), free_start - PAGES_2M / 2);
+
+    // Free the second half; everything coalesces back.
+    for i in PAGES_2M / 2..PAGES_2M {
+        buddy.dealloc_pages(block + i * PAGE_SIZE, 1);
+    }
+    assert_eq!(buddy.free_pages(), free_start);
+}
+
+#[test]
 fn buddy_alignment() {
     // Heap must be aligned to the highest alignment we test (PAGE_SIZE * 4)
     let mut region = HostRegion::new(

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -27,6 +27,7 @@ starry-signal
 starry-vm
 ax-timer-list
 ax-alloc
+buddy-slab-allocator
 ax-display
 ax-driver
 rdrive


### PR DESCRIPTION
## 问题
buddy 分配器无法把一个已分配的高阶块原地拆成可独立释放的 order-0（`PAGE_SIZE`）帧——这是透明大页 2M→4K 拆分所需的“物理帧”一半。

## 改动
- `BuddyAllocator::split_pages`：仅改写页元数据，把 order-k 块重标为 2^k 个 order-0 `Allocated` 帧；附 `GlobalAllocator` / `ax-alloc` 包装。
- 新增 `host-test` feature（引入 ax-sync 的 std `SpinOps`），把 `buddy-slab-allocator` 加入 `std_crates.csv` 与 xtask host-test profile，使其宿主测试进入 CI。

## 逻辑
只改元数据、不动数据；此后每个 order-0 页可用 `dealloc_pages(addr, 1)` 单独释放并正常与其 buddy 合并。与普通分配不同（只有 `alloc_pages` 返回的头地址可释放），拆分后每个子页地址都成为合法的释放输入。

## 设计与高风险审查（feature-development）
本 PR 新增公共内存管理 API（`BuddyAllocator::split_pages` / `GlobalAllocator::split_pages` / `ax-alloc` 包装），按 `book/guideline/feature-development.md` 属高风险扩展，补充如下可独立审查的设计契约：

- **消费者 / 调用方**：**#2067**（`feat/thp`，THP-lite）经 `backend::split_frame → global_allocator().split_pages(phys_to_virt(frame))` 消费，作为 2 MiB→4 KiB 拆分的**物理帧侧**，与 **#2065** 的 page-table 侧拆分配对；栈内已有端到端 QEMU 回归（`bugfix-thp-split-subpage`，thp-on aarch64 suite 绿）。这是唯一调用方；不做投机性通用化。
- **成功标准 / Non-goals**：order-k 块 → 2^k 个可独立 `dealloc_pages(., 1)` 的 order-0 帧，元数据一致、正常合并、无泄漏/无 double-free、总分配字节数不变。**Non-goals**：不移动数据、不改分配统计、不触碰 PTE/TLB（那是消费者的 page-table 侧职责）。
- **替代方案**：(a) 另分配 512 个 4 KiB 帧再拷贝——破坏物理连续性且昂贵；(b) 保留 order-9 块、仅按需子映射——无法独立释放子帧，THP 拆分/回收需要；(c) 原地元数据重标（本 PR）——零拷贝、保持物理布局、O(2^k) 元数据。选 (c)。
- **与页表拆分 / TLB 同步的顺序**：`split_pages` **只操作 buddy 元数据，不触及 PTE/TLB**，且帧全程保持 `Allocated`、内容不动。消费者的顺序契约（见 #2065/#2009）是 page-table 侧的 break-before-make（清块 → flush TLB → 装 512 叶）；物理帧拆分与之独立、不依赖 TLB 状态，故二者先后皆安全。
- **并发所有权**：`split_pages` 取 IRQ-safe 锁（`lock_irqsave`）与 `alloc`/`dealloc` 串行化；契约要求调用方对该块持独占所有权（不得与并发释放竞争），与普通分配块的所有权模型一致。
- **失败 / 回滚**：纯元数据重写，**不分配、不可失败**——要么整块重标成功，要么（地址不属于任何 section）`debug_assert` + no-op 返回，绝不留下半拆状态。

## 测试
`memory/buddy-slab-allocator/tests` 的 explode+乱序释放合并、部分释放两例；`cargo xtask test` 本地 54 项通过；消费者端到端见 #2067 的 thp-on aarch64 QEMU suite。
