### PR TITLE
fix(starry): widen COW frame refcount u8->u32 (fixes fork() EFAULT at ~250 procs)

### DIFF
--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -23,7 +23,12 @@ use crate::{
 };
 
 struct FrameRefCnt {
-    count: u8,
+    /// Number of address spaces sharing this frame COW. A `u8` overflowed at 255
+    /// sharers — a read-only libc/text frame shared by ~250 forked processes
+    /// (e.g. `hackbench -P g10`) tripped it and `fork()` failed with EFAULT. Linux
+    /// uses a 32-bit refcount; `u32` (4 billion sharers) is effectively unbounded
+    /// here, and the overflow path now returns `NoMemory` (ENOMEM), not EFAULT.
+    count: u32,
 }
 
 impl FrameRefCnt {
@@ -42,7 +47,7 @@ struct FrameTableRefCount {
 }
 
 impl FrameTableRefCount {
-    const INITIAL_CNT: u8 = 1;
+    const INITIAL_CNT: u32 = 1;
 
     const fn new() -> Self {
         Self {
@@ -361,7 +366,10 @@ impl CowBackend {
         drop(frame_table);
         let mut frame = frame.lock();
         assert!(frame.count > 0, "invalid frame reference count");
-        debug_assert!(frame.count < u8::MAX, "frame reference count near overflow");
+        debug_assert!(
+            frame.count < u32::MAX,
+            "frame reference count near overflow"
+        );
         match frame.count {
             1 => {
                 pt.protect_page(vaddr, vma_flags)
@@ -583,11 +591,17 @@ impl BackendOps for CowBackend {
                         .ok_or(AxError::BadAddress)?;
                     let mut frame = frame.lock();
                     assert!(frame.count > 0, "referencing unreferenced frame");
-                    frame.count += 1;
-                    if frame.count == u8::MAX {
-                        warn!("frame reference count overflow");
-                        return Err(AxError::BadAddress);
-                    }
+                    // Overflow is effectively unreachable with a u32 refcount, but
+                    // if it ever happens report it as ENOMEM (out of a shareable
+                    // resource) rather than EFAULT — a fork hitting a real limit
+                    // must not look like a bad pointer to userspace.
+                    frame.count = match frame.count.checked_add(1) {
+                        Some(c) => c,
+                        None => {
+                            warn!("frame reference count overflow");
+                            return Err(AxError::NoMemory);
+                        }
+                    };
                     old_pt
                         .protect_page(vaddr, cow_flags)
                         .map_err(paging_error_to_ax_error)?;

--- a/test-suit/starryos/qemu/system/bugfix-bug-cow-refcount-overflow/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-bug-cow-refcount-overflow/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-cow-refcount-overflow C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-cow-refcount-overflow src/main.c)
+target_compile_options(bug-cow-refcount-overflow PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-cow-refcount-overflow RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-bug-cow-refcount-overflow/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-cow-refcount-overflow/src/main.c
@@ -1,0 +1,112 @@
+/*
+ * bug-cow-refcount-overflow: a read-only frame shared COW by the parent plus
+ * many forked children must not overflow the per-frame reference count. With a
+ * u8 count the ~255th concurrent sharer overflowed and fork() failed with
+ * EFAULT (seen on `hackbench -P g10`, ~400 tasks). A u32 count fixes it.
+ *
+ * Strategy: fork CHILDREN children that each only READ a shared .rodata frame
+ * (so COW is never broken and the single frame's refcount climbs to
+ * CHILDREN+1), keeping them all alive on a pipe until every fork has happened.
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* > 255 concurrent sharers so a u8 refcount would overflow; the parent is one
+ * more sharer on top, giving CHILDREN + 1. */
+enum { CHILDREN = 300 };
+
+/* A page-sized read-only blob in .rodata, shared COW across every fork. */
+static const volatile unsigned char shared_ro_blob[4096] = {0xC0, 0x1D};
+
+int main(void)
+{
+    printf("=== bug-cow-refcount-overflow ===\n");
+    printf("Expected: %d concurrent COW sharers of one read-only frame do not\n",
+           CHILDREN);
+    printf("          overflow the reference count (fork never returns EFAULT).\n\n");
+
+    int block_pipe[2];
+    if (pipe(block_pipe) != 0) {
+        printf("FAIL: pipe: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    /*
+     * Fault the shared read-only blob into THIS process before forking, so the
+     * frame is resident with refcount 1 in the parent. Each of the CHILDREN
+     * forks then COW-shares exactly this frame (clone_map does
+     * frame.count.checked_add(1)), driving it to CHILDREN+1 and reliably
+     * overflowing a u8 count past 255 — without the pre-fault the blob's first
+     * access is inside a child and demand paging would not exercise the intended
+     * single-frame overflow.
+     */
+    volatile unsigned char probe = shared_ro_blob[0];
+    if (probe != 0xC0) {
+        printf("FAIL: unexpected shared blob byte 0x%02x\n", probe);
+        printf("TEST FAILED\n");
+        return 1;
+    }
+
+    pid_t children[CHILDREN];
+    int forked = 0;
+    for (int i = 0; i < CHILDREN; i++) {
+        pid_t pid = fork();
+        if (pid < 0) {
+            printf("FAIL: fork #%d failed: %s (errno %d)\n", i, strerror(errno),
+                   errno);
+            printf("      a u8 COW refcount overflows here around the 255th "
+                   "sharer\n");
+            /* Release whatever children we managed to create, then fail. */
+            close(block_pipe[1]);
+            for (int j = 0; j < forked; j++) {
+                waitpid(children[j], NULL, 0);
+            }
+            close(block_pipe[0]);
+            printf("TEST FAILED\n");
+            return 1;
+        }
+        if (pid == 0) {
+            /* Child: only READ the shared frame (never break COW), then block
+             * on the pipe until the parent closes it. */
+            close(block_pipe[1]);
+            volatile unsigned char sink = shared_ro_blob[0];
+            (void)sink;
+            char b;
+            while (read(block_pipe[0], &b, 1) > 0) {
+                /* wait for EOF */
+            }
+            _exit(0);
+        }
+        children[forked++] = pid;
+    }
+
+    printf("PASS: all %d forks succeeded (no EFAULT from refcount overflow)\n",
+           forked);
+
+    /* Release the children (EOF on the pipe) and reap them. */
+    close(block_pipe[1]);
+    close(block_pipe[0]);
+    int failures = 0;
+    for (int i = 0; i < forked; i++) {
+        int status = 0;
+        if (waitpid(children[i], &status, 0) != children[i] ||
+            !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            failures++;
+        }
+    }
+    if (failures != 0) {
+        printf("FAIL: %d children exited abnormally\n", failures);
+        printf("TEST FAILED\n");
+        return 1;
+    }
+    printf("PASS: all %d children reaped cleanly\n", forked);
+
+    printf("TEST PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
## 问题
每帧 COW 引用计数为 `u8`，父进程 + ~254 个 fork 子进程共享一个只读 text/rodata 帧时在 255 处溢出，`fork()` 返回 EFAULT（`hackbench -P g10`，约 400 任务复现）。

## 改动
计数 `u8`→`u32`（Linux 用 32 位），溢出路径改用 `checked_add` 并返回 `NoMemory`(ENOMEM) 而非 EFAULT。

## 逻辑
u32（40 亿共享者）实际不可达；溢出即真实资源耗尽，应报 ENOMEM 而非“坏指针”。

## 测试
新增 qemu-system 回归 `bugfix-bug-cow-refcount-overflow`：fork 300 个共享同一只读帧的子进程，全部成功；随 `cargo xtask starry qemu` 运行。