### PR TITLE
fix(starry): surface ENOMEM instead of EFAULT when user fault-in is out of memory

### DIFF
--- a/os/StarryOS/kernel/src/error.rs
+++ b/os/StarryOS/kernel/src/error.rs
@@ -259,6 +259,7 @@ impl PollIoError for StarryError {
 fn vm_errno(error: VmError) -> Errno {
     match error {
         VmError::BadAddress | VmError::AccessDenied => Errno::EFAULT,
+        VmError::NoMemory => Errno::ENOMEM,
         VmError::TooLong => Errno::ENAMETOOLONG,
     }
 }
@@ -514,6 +515,7 @@ fn memory_errno_mappings_hold() -> bool {
     errno_cases_hold([
         (VmError::BadAddress.into(), Errno::EFAULT),
         (VmError::AccessDenied.into(), Errno::EFAULT),
+        (VmError::NoMemory.into(), Errno::ENOMEM),
         (VmError::TooLong.into(), Errno::ENAMETOOLONG),
         (
             SignalError::UserMemory(VmError::BadAddress).into(),

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -365,7 +365,14 @@ fn prepare_user_memory(op: &str, start: usize, len: usize, access_flags: Mapping
 
     aspace
         .populate_area(page_start, page_end - page_start, access_flags)
-        .map_err(|_| VmError::AccessDenied)
+        // Preserve a genuine out-of-frames as ENOMEM instead of collapsing every
+        // fault-in error to AccessDenied/EFAULT: a memory-pressure failure on a
+        // valid user pointer must surface as ENOMEM, not a misleading "Bad address"
+        // (diverges from Linux and masks real exhaustion under high task count).
+        .map_err(|e| match e {
+            StarryError::NoMemory => VmError::NoMemory,
+            _ => VmError::AccessDenied,
+        })
 }
 
 /// Faults in and validates a userspace output range without modifying it.

--- a/os/StarryOS/kernel/src/mm/io.rs
+++ b/os/StarryOS/kernel/src/mm/io.rs
@@ -147,6 +147,7 @@ impl Write for IoVectorBufIo {
 fn vm_error_to_io_error(error: VmError) -> IoError {
     match error {
         VmError::BadAddress | VmError::AccessDenied => IoError::BadAddress,
+        VmError::NoMemory => IoError::NoMemory,
         VmError::TooLong => IoError::NameTooLong,
     }
 }

--- a/os/StarryOS/vm/src/lib.rs
+++ b/os/StarryOS/vm/src/lib.rs
@@ -17,6 +17,14 @@ pub enum VmError {
     /// The operation is not allowed, e.g., trying to write to read-only memory.
     #[error("virtual memory access is denied")]
     AccessDenied,
+    /// A genuine out-of-memory (frame or page-table exhaustion) while faulting
+    /// in a valid user address. Kept distinct from
+    /// [`BadAddress`](Self::BadAddress) and
+    /// [`AccessDenied`](Self::AccessDenied) (which map to EFAULT) so it
+    /// surfaces as ENOMEM, matching Linux `copy_{from,to}_user` under
+    /// memory pressure.
+    #[error("virtual memory is out of memory")]
+    NoMemory,
     /// The C-style string or array is too long.
     ///
     /// This error is returned by [`vm_load_until_nul`] when the null terminator


### PR DESCRIPTION
## 问题
`prepare_user_memory`（vm_read/vm_write 的缺页填充路径，`mm/access.rs`）把 `populate_area` 的所有错误统一 `.map_err(|_| VmError::AccessDenied)`，而 `vm_errno` 又把 `AccessDenied` 映射为 EFAULT。因此有效用户指针上的真实物理帧/页表耗尽被误报为 “Bad address”(EFAULT) 而非 ENOMEM，与 Linux `copy_{from,to}_user` 在内存压力下的语义不一致，并掩盖高任务数下的真实内存压力故障（hackbench g=10 / schbench 的 `fork()`/`futex` “Bad address”）。

## 改动
- `starry-vm`：`VmError` 新增 `NoMemory` 变体（`thiserror` `#[error(...)]`）。
- `mm/access.rs`：`prepare_user_memory` 的 `map_err` 改为 `match { StarryError::NoMemory => VmError::NoMemory, _ => VmError::AccessDenied }`，透传真实 OOM。
- `error.rs`：`vm_errno` 新增 `VmError::NoMemory => Errno::ENOMEM`；类型转换由既有 `StarryError::Vm(#[from] VmError)` 在 `?` 边界完成。
- `mm/io.rs`：`vm_error_to_io_error` 补 `VmError::NoMemory => IoError::NoMemory`（穷尽匹配）。
- `execve` 的 `exec_arg_vm_error` 已有 `_ => into()` 兜底（→ ENOMEM），无需改动。

## 逻辑
`check_region`(UserPtr) 路径本就用 `?` 透传 `populate_area` 的 `StarryError::NoMemory`(→ENOMEM)；而 vm_read/vm_write 路径返回 `VmResult`，必须显式经 `VmError::NoMemory` 承载、再由 `vm_errno` 映射为 ENOMEM，两条路径由此保持一致。

## 测试
`error.rs` 的 `memory_errno_mappings_hold`（host + axtest）新增 `(VmError::NoMemory.into(), Errno::ENOMEM)` 回归断言；本地 `axtest_kernel` 组编译 + 启动 + `AXTEST_SUITE_OK` 全绿。access.rs 缺页 OOM 的端到端由 CI 的 aarch64 qemu system 组覆盖。

（本 PR 已针对 dev 的 `VmError`→`thiserror` 重构重写，不再依赖被删除的 `impl From<VmError> for AxError`。）
