### PR TITLE
fix(starry): honor offset in /dev/fb0 read_at/write_at

### DIFF
--- a/os/StarryOS/kernel/src/pseudofs/dev/fb.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/fb.rs
@@ -111,20 +111,23 @@ impl FrameBuffer {
 impl DeviceOps for FrameBuffer {
     fn read_at(&self, buf: &mut [u8], offset: u64) -> VfsResult<usize> {
         let slice = self.as_mut_slice();
-        let len = buf
-            .len()
-            .min((slice.len() as u64).saturating_sub(offset) as usize);
-        buf[..len].copy_from_slice(&slice[..len]);
+        let off = offset as usize;
+        if off >= slice.len() {
+            return Ok(0);
+        }
+        let len = buf.len().min(slice.len() - off);
+        buf[..len].copy_from_slice(&slice[off..off + len]);
         Ok(len)
     }
 
     fn write_at(&self, buf: &[u8], offset: u64) -> VfsResult<usize> {
         let slice = self.as_mut_slice();
-        if offset >= slice.len() as u64 {
+        let off = offset as usize;
+        if off >= slice.len() {
             return Err(VfsError::StorageFull);
         }
-        let len = buf.len().min(slice.len() - offset as usize);
-        slice[..len].copy_from_slice(&buf[..len]);
+        let len = buf.len().min(slice.len() - off);
+        slice[off..off + len].copy_from_slice(&buf[..len]);
         Ok(len)
     }
 

--- a/test-suit/starryos/qemu/system/bugfix-bug-fb0-offset/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-bug-fb0-offset/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-fb0-offset C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-fb0-offset src/main.c)
+target_compile_options(bug-fb0-offset PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-fb0-offset RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-bug-fb0-offset/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-fb0-offset/src/main.c
@@ -1,0 +1,97 @@
+/*
+ * bug-fb0-offset: /dev/fb0 read_at/write_at must honor the byte offset. The
+ * buggy version indexed the scanout slice from 0 regardless of offset, so a
+ * write at offset O aliased the top-left and a read at offset O returned the
+ * top-left bytes. This checks that a write at a non-zero offset is isolated
+ * from offset 0 in both directions.
+ *
+ * Skips (pass) when the QEMU profile exposes no framebuffer device — the fix is
+ * otherwise validated on-board where /dev/fb0 is backed by the real scanout.
+ */
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+enum {
+    CHUNK = 256,
+    OFFSET = 8192,          /* a couple of pages in — well clear of the top-left */
+    PATTERN_AT_OFFSET = 0xA5,
+    PATTERN_AT_ZERO = 0x5A,
+};
+
+int main(void)
+{
+    printf("=== bug-fb0-offset ===\n");
+    printf("Expected: /dev/fb0 read_at/write_at index at the given byte "
+           "offset, not from 0.\n\n");
+
+    int fd = open("/dev/fb0", O_RDWR);
+    if (fd < 0) {
+        /* No framebuffer in this QEMU profile — nothing to exercise here. */
+        printf("SKIP: /dev/fb0 unavailable (%s); covered by the board oracle\n",
+               strerror(errno));
+        printf("TEST PASSED\n");
+        return 0;
+    }
+
+    unsigned char at_off[CHUNK];
+    unsigned char at_zero[CHUNK];
+    memset(at_off, PATTERN_AT_OFFSET, sizeof(at_off));
+    memset(at_zero, PATTERN_AT_ZERO, sizeof(at_zero));
+
+    /* Write a distinct pattern at the non-zero offset. */
+    if (pwrite(fd, at_off, sizeof(at_off), OFFSET) != (ssize_t)sizeof(at_off)) {
+        printf("FAIL: pwrite at offset %d: %s\n", OFFSET, strerror(errno));
+        printf("TEST FAILED\n");
+        close(fd);
+        return 1;
+    }
+
+    /* Read it back at the same offset — must match (offset honored both ways). */
+    unsigned char back[CHUNK];
+    memset(back, 0, sizeof(back));
+    if (pread(fd, back, sizeof(back), OFFSET) != (ssize_t)sizeof(back)) {
+        printf("FAIL: pread at offset %d: %s\n", OFFSET, strerror(errno));
+        printf("TEST FAILED\n");
+        close(fd);
+        return 1;
+    }
+    if (memcmp(back, at_off, sizeof(back)) != 0) {
+        printf("FAIL: read-back at offset %d did not match the write\n", OFFSET);
+        printf("TEST FAILED\n");
+        close(fd);
+        return 1;
+    }
+
+    /* Now write a different pattern at offset 0 and confirm it does NOT alias
+     * the bytes we placed at OFFSET (the core of the aliasing bug). */
+    if (pwrite(fd, at_zero, sizeof(at_zero), 0) != (ssize_t)sizeof(at_zero)) {
+        printf("FAIL: pwrite at offset 0: %s\n", strerror(errno));
+        printf("TEST FAILED\n");
+        close(fd);
+        return 1;
+    }
+    memset(back, 0, sizeof(back));
+    if (pread(fd, back, sizeof(back), OFFSET) != (ssize_t)sizeof(back)) {
+        printf("FAIL: pread(2) at offset %d: %s\n", OFFSET, strerror(errno));
+        printf("TEST FAILED\n");
+        close(fd);
+        return 1;
+    }
+    if (memcmp(back, at_off, sizeof(back)) != 0) {
+        printf("FAIL: write at offset 0 aliased the bytes at offset %d\n",
+               OFFSET);
+        printf("TEST FAILED\n");
+        close(fd);
+        return 1;
+    }
+
+    close(fd);
+    printf("PASS: /dev/fb0 offset honored for read_at and write_at\n");
+    printf("TEST PASSED\n");
+    return 0;
+}


### PR DESCRIPTION
## 问题
`/dev/fb0` 的 `read_at`/`write_at` 无论 offset 都从 scanout 切片 0 处索引，把非零偏移别名到左上角。

## 改动
按 `offset..offset+len` 索引；写超界返回错误、读超界返回 0(EOF)。

## 测试
新增 qemu-system 回归 `bugfix-bug-fb0-offset`：非零偏移写读回一致，且偏移 0 处不被别名；无 framebuffer 的 profile 下优雅跳过（板级 oracle 覆盖真实 scanout）。