### PR TITLE
fix(starry): read the futex word atomically for the value compare

### DIFF
--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -141,6 +141,33 @@ impl<T> UserPtr<T> {
     }
 }
 
+/// Atomically read a naturally-aligned `u32` from user memory as a single load,
+/// so a concurrent userspace atomic store cannot be observed torn.
+///
+/// `vm_read::<u32>()` goes through the byte-wise `user_copy` memcpy (four `ldrb` on
+/// aarch64), which is NOT single-copy-atomic — under SMP a racing userspace store to
+/// the word can interleave the byte reads and yield a value that never existed. The
+/// futex value-compare (FUTEX_WAIT and the race-closing re-check) must read the word
+/// atomically, exactly like Linux's `get_user`, or it can spuriously match/mismatch
+/// and — at the re-check — block through a concurrent wake (lost wakeup). This mirrors
+/// [`atomic_update_user_u32`]: `check_region` validates a present, EL0-readable,
+/// aligned word, then the access happens through an `AtomicU32` inside the
+/// user-memory-access window, lowering to one atomic load on every architecture.
+pub fn atomic_read_user_u32(ptr: *const u32) -> StarryResult<u32> {
+    check_region(
+        VirtAddr::from_ptr_of(ptr),
+        Layout::new::<u32>(),
+        MappingFlags::READ,
+    )?;
+
+    let ptr = ptr.cast::<AtomicU32>();
+    Ok(access_user_memory(|| {
+        // SAFETY: check_region() validated that the user address is a readable,
+        // properly aligned u32 in the current address space.
+        unsafe { &*ptr }.load(Ordering::Acquire)
+    }))
+}
+
 pub fn atomic_update_user_u32(
     ptr: *mut u32,
     mut update: impl FnMut(u32) -> StarryResult<u32>,

--- a/os/StarryOS/kernel/src/syscall/sync/futex.rs
+++ b/os/StarryOS/kernel/src/syscall/sync/futex.rs
@@ -12,7 +12,7 @@ use starry_vm::{VmMutPtr, VmPtr};
 
 use crate::{
     StarryError, StarryResult,
-    mm::atomic_update_user_u32,
+    mm::{atomic_read_user_u32, atomic_update_user_u32},
     task::{AsThread, FutexKey, FutexKeyMode, TidNumber, futex_table_for, get_user_task_by_number},
     time::TimeValueLike,
 };
@@ -202,8 +202,9 @@ pub fn sys_futex(
 
     match op.command {
         FutexCommand::Wait | FutexCommand::WaitBitset => {
-            // Fast path
-            if uaddr.vm_read()? != value {
+            // Fast path. Atomic single-load read (not the byte-wise `vm_read`) so a
+            // concurrent userspace store to the futex word is never observed torn.
+            if atomic_read_user_u32(uaddr)? != value {
                 return Err(StarryError::WouldBlock);
             }
 
@@ -221,7 +222,9 @@ pub fn sys_futex(
             if !futex
                 .wq
                 .wait_if_with_cleanup(bitset, timeout, Some(cleanup), || {
-                    uaddr.vm_read() == Ok(value)
+                    // Race-closing re-check under the futex lock: an atomic (untorn)
+                    // read here is what prevents blocking through a concurrent wake.
+                    atomic_read_user_u32(uaddr).is_ok_and(|v| v == value)
                 })?
             {
                 return Err(StarryError::WouldBlock);
@@ -260,7 +263,8 @@ pub fn sys_futex(
             let target_cleanup = table2.cleanup_for(&key2);
 
             let Some(source) = futex_table.get(&key) else {
-                if op.command == FutexCommand::CmpRequeue && uaddr.vm_read()? != value3 {
+                if op.command == FutexCommand::CmpRequeue && atomic_read_user_u32(uaddr)? != value3
+                {
                     return Err(StarryError::WouldBlock);
                 }
                 return Ok(0);
@@ -274,7 +278,7 @@ pub fn sys_futex(
                 &target.wq,
                 || {
                     if op.command == FutexCommand::CmpRequeue {
-                        Ok(uaddr.vm_read()? == value3)
+                        Ok(atomic_read_user_u32(uaddr)? == value3)
                     } else {
                         Ok(true)
                     }


### PR DESCRIPTION
## 问题
futex 的四个值比较点用逐字节 `vm_read` 读取用户 futex 字，在 aarch64 弱内存 SMP 上可能读到撕裂值，导致丢失唤醒。

## 改动
新增 `atomic_read_user_u32`（`AtomicU32` 单拷贝原子读，与既有 `atomic_update_user_u32` 同构），替换 futex WAIT/重检/CmpRequeue 的四处比较读。

## 逻辑
匹配 Linux `get_user` 语义（普通 load，futex 正确性依赖 futex 锁 + 重检）。

## 测试
现有 `test-futex-race` / `bugfix-bug-futex-wait-wake` / `syscall-test-futex-wake-op` 保持通过；撕裂读为真机弱内存效应，由板级 oracle 验证（QEMU-TCG 无法确定性复现）。