### PR TITLE
perf(starry): seccomp syscall fast-path via a lock-free active flag

### DIFF
--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -76,27 +76,30 @@ pub fn handle_syscall(uctx: &mut UserContext) {
     };
 
     trace!("Syscall {sysno:?}");
-    match ax_task::current()
-        .as_thread()
-        .seccomp_state()
-        .evaluate(uctx)
-    {
-        SeccompDecision::Allow => {}
-        SeccompDecision::Errno(errno) => {
-            uctx.set_retval(seccomp_errno(errno));
-            return;
-        }
-        SeccompDecision::KillProcess => {
-            do_exit(Signo::SIGSYS as i32, true);
-            return;
-        }
-        SeccompDecision::KillThread => {
-            do_exit(Signo::SIGSYS as i32, false);
-            return;
-        }
-        SeccompDecision::UnsupportedAction => {
-            uctx.set_retval(-LinuxError::ENOSYS.code() as usize);
-            return;
+    // Fast path: skip the seccomp lock + SeccompState clone + evaluate entirely when
+    // no filter is installed (the common case). `seccomp_active` is a lock-free
+    // one-way flag, so this can never bypass an installed filter.
+    let curr = ax_task::current();
+    let thread = curr.as_thread();
+    if thread.seccomp_active() {
+        match thread.seccomp_state().evaluate(uctx) {
+            SeccompDecision::Allow => {}
+            SeccompDecision::Errno(errno) => {
+                uctx.set_retval(seccomp_errno(errno));
+                return;
+            }
+            SeccompDecision::KillProcess => {
+                do_exit(Signo::SIGSYS as i32, true);
+                return;
+            }
+            SeccompDecision::KillThread => {
+                do_exit(Signo::SIGSYS as i32, false);
+                return;
+            }
+            SeccompDecision::UnsupportedAction => {
+                uctx.set_retval(-LinuxError::ENOSYS.code() as usize);
+                return;
+            }
         }
     }
 

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -204,6 +204,13 @@ pub struct Thread {
     /// seccomp syscall filtering state.
     seccomp: IrqMutex<SeccompState>,
 
+    /// Lock-free mirror of `seccomp.is_active()`. Read on every syscall to skip the
+    /// `seccomp` lock + `SeccompState` clone + evaluate when no filter is installed
+    /// (the overwhelmingly common case). seccomp is one-way (disabled -> active, never
+    /// back), so this only ever transitions false -> true and can never bypass an
+    /// installed filter. Mirrors Linux's `TIF_SECCOMP` bit.
+    seccomp_active: AtomicBool,
+
     /// Process credentials (uid, gid, etc.).
     cred: IrqMutex<Arc<Cred>>,
 
@@ -274,6 +281,7 @@ impl Thread {
             rseq_signature: AtomicU32::new(0),
             pdeathsig: AtomicU32::new(0),
             no_new_privs: AtomicBool::new(false),
+            seccomp_active: AtomicBool::new(false),
             seccomp: IrqMutex::new(SeccompState::default()),
             cred: IrqMutex::new(cred),
 
@@ -428,6 +436,12 @@ impl Thread {
         self.no_new_privs.store(true, Ordering::Relaxed);
     }
 
+    /// Lock-free check of whether any seccomp mode is installed. When false, the
+    /// syscall dispatch skips the seccomp lock+clone+evaluate entirely.
+    pub fn seccomp_active(&self) -> bool {
+        self.seccomp_active.load(Ordering::Acquire)
+    }
+
     /// Get a snapshot of the current seccomp state.
     pub fn seccomp_state(&self) -> SeccompState {
         self.seccomp.lock().clone()
@@ -435,17 +449,25 @@ impl Thread {
 
     /// Replace seccomp state. Used by clone inheritance.
     pub fn set_seccomp_state(&self, state: SeccompState) {
+        // Publish activeness before/with the state so a concurrent syscall reader
+        // never sees active=false while the filter is installed.
+        self.seccomp_active
+            .store(state.is_active(), Ordering::Release);
         *self.seccomp.lock() = state;
     }
 
     /// Enable strict seccomp mode.
     pub fn install_seccomp_strict(&self) -> AxResult<()> {
-        self.seccomp.lock().install_strict()
+        self.seccomp.lock().install_strict()?;
+        self.seccomp_active.store(true, Ordering::Release);
+        Ok(())
     }
 
     /// Append a seccomp filter. Filters are inherited and evaluated in order.
     pub fn append_seccomp_filter(&self, insns: Vec<SockFilter>) -> AxResult<()> {
-        self.seccomp.lock().append_filter(insns)
+        self.seccomp.lock().append_filter(insns)?;
+        self.seccomp_active.store(true, Ordering::Release);
+        Ok(())
     }
 
     /// Get a snapshot of the current credentials (clones the `Arc`).

--- a/os/StarryOS/kernel/src/task/seccomp.rs
+++ b/os/StarryOS/kernel/src/task/seccomp.rs
@@ -158,6 +158,12 @@ struct SeccompData {
 }
 
 impl SeccompState {
+    /// Whether any seccomp mode is installed (strict or filter). When false, the
+    /// syscall path can skip locking+cloning+evaluating this state entirely.
+    pub fn is_active(&self) -> bool {
+        self.mode != SeccompMode::Disabled
+    }
+
     /// Enable Linux strict seccomp mode for this thread.
     ///
     /// Strict mode can only be installed from the disabled state.  Once a


### PR DESCRIPTION
## 问题
`handle_syscall` 每次系统调用都在 seccomp 锁下克隆整个 `SeccompState` 并 `evaluate()`，即使绝大多数线程未安装任何过滤器。

## 改动
用每线程 `AtomicBool`(seccomp_active) 镜像“是否激活”：安装 strict/filter 时 Release 发布，系统调用热路径 Acquire 读取，未激活时跳过锁+克隆+evaluate。

## 逻辑
seccomp 为单向（disabled→active，不可逆），故该标志不可能在过滤器已安装时显示 active=false，绝不绕过过滤器。

## 测试
由现有 `syscall-test-seccomp`（安装 strict/BPF 过滤器并验证安装后的系统调用仍被拦截）守护。