### PR TITLE
perf(starry-mm): fault-in a readahead window for file-backed COW areas

### DIFF
--- a/os/StarryOS/kernel/src/axtest_exports.rs
+++ b/os/StarryOS/kernel/src/axtest_exports.rs
@@ -62,6 +62,10 @@ pub fn cow_file_max_read_len_boundary_rules_hold() -> bool {
     super::mm::cow_file_max_read_len_boundary_rules_hold_for_test()
 }
 
+pub fn readahead_window_batches_absent_runs() -> bool {
+    super::mm::readahead_window_batches_absent_runs_for_test()
+}
+
 pub fn concurrent_epoll_reverse_add_is_serialized() -> bool {
     super::file::concurrent_reverse_add_is_serialized_for_test()
 }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -78,6 +78,18 @@ impl FrameTableRefCount {
 
 static FRAME_TABLE: IrqMutex<FrameTableRefCount> = IrqMutex::new(FrameTableRefCount::new());
 
+/// Length of the leading run of consecutive pages in `addrs` for which `absent`
+/// holds.
+///
+/// [`CowBackend::populate`] uses this to coalesce a run of not-mapped
+/// file-backed pages into a single backing read ([`CowBackend::alloc_file_run`]).
+/// An already-resident page (`absent` returns `false`) ends the run, so a
+/// resident page inside a readahead window splits it into separate reads instead
+/// of one read spanning the resident page.
+fn absent_run_len(addrs: &[VirtAddr], absent: impl Fn(VirtAddr) -> bool) -> usize {
+    addrs.iter().take_while(|&&addr| absent(addr)).count()
+}
+
 fn cow_file_max_read_len(
     file_len: u64,
     file_end: Option<u64>,
@@ -537,19 +549,15 @@ impl BackendOps for CowBackend {
                 }
                 Err(PagingError::NotMapped) => {
                     if self.file.is_some() {
-                        let run_start = i;
-                        while i < addrs.len()
-                            && matches!(pt.query(addrs[i]), Err(PagingError::NotMapped))
-                        {
-                            i += 1;
-                        }
-                        pages += self.alloc_file_run(
-                            &addrs[run_start..i],
-                            flags,
-                            access_flags,
-                            acct,
-                            pt,
-                        )?;
+                        // Coalesce the maximal run of consecutive not-mapped pages
+                        // into a single readahead read; a resident page ends the run.
+                        let run_len = absent_run_len(&addrs[i..], |addr| {
+                            matches!(pt.query(addr), Err(PagingError::NotMapped))
+                        });
+                        let run_end = i + run_len;
+                        pages +=
+                            self.alloc_file_run(&addrs[i..run_end], flags, access_flags, acct, pt)?;
+                        i = run_end;
                     } else {
                         self.alloc_new_at(addr, flags, access_flags, acct, pt)?;
                         pages += 1;
@@ -679,4 +687,77 @@ pub(crate) fn cow_file_max_read_len_boundary_rules_hold_for_test() -> bool {
         && matches!(cow_file_max_read_len(8192, Some(4096), 8192, 4096), Ok(0))
         // Explicit end == offset yields zero (EOF reached within bounds).
         && matches!(cow_file_max_read_len(8192, Some(4096), 4096, 4096), Ok(0))
+}
+
+/// Observes the file-backed COW readahead batching end to end: the widened
+/// window ([`super::super::fault_readahead_window`]) fed through the same
+/// run-splitting [`populate`](CowBackend::populate) uses ([`absent_run_len`]),
+/// asserting the batch read count/range under VMA-tail truncation and an
+/// already-resident-page gap. The single-page baseline would produce one 1-page
+/// read per fault, so these multi-page/coalesced expectations fail without the
+/// readahead window.
+#[cfg(axtest)]
+pub(crate) fn readahead_window_batches_absent_runs_for_test() -> bool {
+    use super::super::fault_readahead_window;
+
+    const READAHEAD_PAGES: usize = 32;
+    let ps = PAGE_SIZE_4K;
+    let base = VirtAddr::from(0x1000usize * 0x40);
+    let page = |i: usize| base + i * ps;
+    let idx_of = |addr: VirtAddr| (addr.as_usize() - base.as_usize()) / ps;
+
+    // Split a fault window into the runs of consecutive absent pages a
+    // file-backed COW fault coalesces into one backing read each, given the set
+    // of already-resident page indices. Mirrors `populate`: a resident page ends
+    // a run and is not re-read. Each run is reported as `(first_index, len)`.
+    let segment = |window: VirtAddrRange, present: &[usize]| -> alloc::vec::Vec<(usize, usize)> {
+        let addrs: alloc::vec::Vec<VirtAddr> = match pages_in(window, ps) {
+            Ok(iter) => iter.collect(),
+            Err(_) => return alloc::vec::Vec::new(),
+        };
+        let absent = |addr: VirtAddr| !present.contains(&idx_of(addr));
+        let mut runs = alloc::vec::Vec::new();
+        let mut i = 0;
+        while i < addrs.len() {
+            if absent(addrs[i]) {
+                let len = absent_run_len(&addrs[i..], &absent);
+                runs.push((idx_of(addrs[i]), len));
+                i += len;
+            } else {
+                i += 1;
+            }
+        }
+        runs
+    };
+
+    // 1) Large area: a page-0 read/exec fault widens to a 32-page window, and
+    //    with every page absent coalesces into ONE 32-page backing read.
+    let area_end = page(64);
+    let full = fault_readahead_window(page(0), ps, area_end, true);
+    let full_batch = full.start == page(0)
+        && full.end == page(READAHEAD_PAGES)
+        && segment(full, &[]) == alloc::vec![(0usize, READAHEAD_PAGES)];
+
+    // 2) VMA-tail truncation: an area ending 5 pages past the fault clamps the
+    //    window to 5 pages (window end == VMA end), one 5-page read.
+    let tail_end = page(5);
+    let tail = fault_readahead_window(page(0), ps, tail_end, true);
+    let tail_clamped = tail.start == page(0)
+        && tail.end == tail_end
+        && segment(tail, &[]) == alloc::vec![(0usize, 5usize)];
+
+    // 3) Already-resident-page gap: pages 3 and 4 resident inside a 32-page
+    //    window split the batch into two reads [0,3) and [5,32) — the resident
+    //    pages are not re-read (count == 2).
+    let gap = fault_readahead_window(page(0), ps, area_end, true);
+    let present_gap = segment(gap, &[3, 4]) == alloc::vec![(0usize, 3usize), (5usize, 27usize)];
+
+    // 4) A non-widening fault (write / anonymous / non-4K) stays a single page:
+    //    exactly one 1-page read regardless of following absent pages.
+    let single = fault_readahead_window(page(0), ps, area_end, false);
+    let single_page = single.start == page(0)
+        && single.end == page(1)
+        && segment(single, &[]) == alloc::vec![(0usize, 1usize)];
+
+    full_batch && tail_clamped && present_gap && single_page
 }

--- a/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
@@ -25,6 +25,7 @@ mod shared;
 #[cfg(axtest)]
 pub(crate) use self::cow::{
     cow_file_max_read_len_boundary_rules_hold_for_test, private_mmap_eof_check_for_test,
+    readahead_window_batches_absent_runs_for_test,
 };
 pub use self::shared::SharedPages;
 pub use super::accounting::RssKind;
@@ -163,6 +164,19 @@ pub struct BackendFileInfo {
 }
 
 impl Backend {
+    /// Whether a page fault in this area should also fault a short forward run of
+    /// following pages (readahead).
+    ///
+    /// Only file-backed COW areas benefit: their [`populate`](BackendOps::populate)
+    /// coalesces a run of absent pages into a single backing read (see
+    /// `CowBackend::alloc_file_run`), which is what makes demand-paged ELF/`.so`
+    /// exec loads fast. Anonymous areas are excluded on purpose — eagerly faulting
+    /// their lazily-reserved pages would inflate RSS (and regress the lazy-RSS
+    /// tests), for no I/O to batch.
+    pub fn wants_fault_readahead(&self) -> bool {
+        matches!(self, Backend::Cow(c) if !c.is_anonymous())
+    }
+
     /// Returns the file information if this is a file-backed mapping, or `None` otherwise.
     ///
     /// The returned tuple contains the file name, offset, inode and whether the mapping is shared.

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -38,6 +38,41 @@ pub use self::{
 type MovedPage = (VirtAddr, VirtAddr, PhysAddr, MappingFlags, usize, bool);
 const CLONED_ADDR_SPACE_LOCK_SUBCLASS: u32 = 1;
 
+/// Pages a file-backed COW read/exec fault reads ahead beyond the faulting page.
+const FAULT_READAHEAD_PAGES: usize = 32;
+
+/// Fault-in window for a page fault at page-aligned `fault_page`.
+///
+/// When `widen` is set (a file-backed COW read/exec fault), the window extends
+/// forward to at most [`FAULT_READAHEAD_PAGES`] pages, clamped so it never
+/// crosses `area_end` — the VMA tail. This lets `CowBackend::populate` coalesce
+/// the run of absent pages into a single backing read instead of one read per
+/// fault, which is what makes demand-paged ELF/`.so` exec + dynamic linking
+/// fast.
+///
+/// Every other fault (`widen` clear: write fault, anonymous area, or non-4K
+/// page size) stays a single page: anonymous pages must stay lazily reserved
+/// (RSS), and a widened *write* fault would map the readahead pages
+/// writable/dirty (breaking COW + RSS classification), because `alloc_file_run`
+/// applies the fault's access to the whole run.
+///
+/// The window feeds `CowBackend::populate`, which splits it at already-resident
+/// pages, so a resident page inside the window yields separate backing reads
+/// rather than one read spanning it.
+fn fault_readahead_window(
+    fault_page: VirtAddr,
+    page_size: usize,
+    area_end: VirtAddr,
+    widen: bool,
+) -> VirtAddrRange {
+    if !widen {
+        return VirtAddrRange::from_start_size(fault_page, page_size);
+    }
+    let to_area_end = area_end.as_usize().saturating_sub(fault_page.as_usize());
+    let size = (PAGE_SIZE_4K * FAULT_READAHEAD_PAGES).min(to_area_end);
+    VirtAddrRange::from_start_size(fault_page, size)
+}
+
 fn rollback_moved_pages(cursor: &mut PageTable, moved_pages: &[MovedPage]) {
     for &(src_va, dst_va, paddr, flags, page_size, dst_newly_mapped) in moved_pages.iter().rev() {
         if dst_newly_mapped {
@@ -600,8 +635,16 @@ impl AddrSpace {
             let flags = area.flags();
             if flags.contains(access_flags) {
                 let page_size = area.backend().page_size();
+                let fault_page = vaddr.align_down(page_size);
+                // File-backed COW read/exec faults widen into a forward readahead
+                // window (see [`fault_readahead_window`]); every other fault stays a
+                // single page.
+                let widen = page_size == PAGE_SIZE_4K
+                    && !access_flags.contains(MappingFlags::WRITE)
+                    && area.backend().wants_fault_readahead();
+                let range = fault_readahead_window(fault_page, page_size, area.end(), widen);
                 let populate_result = area.backend().populate(
-                    VirtAddrRange::from_start_size(vaddr.align_down(page_size), page_size as _),
+                    range,
                     flags,
                     access_flags,
                     Some(&self.rss),

--- a/os/StarryOS/kernel/tests/cases/axtest_memory.rs
+++ b/os/StarryOS/kernel/tests/cases/axtest_memory.rs
@@ -37,6 +37,11 @@ fn cow_file_max_read_len_boundary_rules_hold() {
 }
 
 #[axtest]
+fn readahead_window_batches_absent_runs() {
+    ax_assert!(axtest_exports::readahead_window_batches_absent_runs());
+}
+
+#[axtest]
 fn stats_classify_and_accumulate_rules_hold() {
     ax_assert!(axtest_exports::stats_classify_and_accumulate_rules_hold());
 }


### PR DESCRIPTION
## 问题
`handle_page_fault` 在文件映射(私有)的按需缺页时只填充单页，上游已有的 `populate` 合批(#1217) 因此在 exec/.so 的按需路径上从不触发，预读收益未兑现。

## 改动
新增 `Backend::wants_fault_readahead`（仅私有文件映射为真，匿名/共享为假），缺页时对文件映射填充一个预读窗口，交给既有 `alloc_file_run` 合批为一次 `read_at`。

## 逻辑
写故障与匿名映射被排除，保持语义；上游新增的共享 `Backend::File` 变体不做预读（超范围，保持 PR 原子）。

## 测试
现有 `syscall-test-mmap-readahead`（严格逐页哈希绝对文件偏移，覆盖跨窗口/EOF 零填充/中段首故障）保持通过——证明加宽窗口不破坏字节正确性。