### PR TITLE
feat(ax-hal): expose per-CPU capacity table from the device tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,6 +904,7 @@ dependencies = [
  "axtest",
  "cfg-if",
  "cpu-local",
+ "fdt-edit",
  "fdt-parser",
  "heapless",
  "log",

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -63,6 +63,9 @@ axplat-dyn = { workspace = true, default-features = false }
 page-table-generic = { workspace = true, optional = true }
 rdrive.workspace = true
 
+[dev-dependencies]
+fdt-edit = { workspace = true }
+
 [build-dependencies]
 quote = { workspace = true }
 

--- a/os/arceos/modules/axhal/src/dtb.rs
+++ b/os/arceos/modules/axhal/src/dtb.rs
@@ -50,3 +50,71 @@ pub fn get_chosen_bootargs() -> Option<&'static str> {
 
     *CACHED_BOOTARGS
 }
+
+/// Upper bound on the number of logical CPUs, sizing the [`cpu_capacities`]
+/// table. Mirrors the build-time bound [`crate::cpu_num`] uses (the `SMP`
+/// build-env-configured max under the `smp` feature); with `smp` disabled
+/// there is always exactly one CPU.
+#[cfg(feature = "smp")]
+const MAX_CPU_NUM: usize = crate::build_info::CPU_CAPACITY;
+#[cfg(not(feature = "smp"))]
+const MAX_CPU_NUM: usize = 1;
+
+/// Fallback capacity when the DT gives no hint (all-equal => homogeneous/QEMU
+/// degrades to plain load-spreading).
+const DEFAULT_CPU_CAPACITY: u16 = 1024;
+
+/// Per-logical-CPU normalized compute capacity (A76 ~ 1024 / A55 ~ 530), indexed
+/// by logical `cpu_id`. Built once from the cached FDT.
+pub fn cpu_capacities() -> &'static [u16; MAX_CPU_NUM] {
+    static CACHED_CAPS: LazyLock<[u16; MAX_CPU_NUM]> = LazyLock::new(build_cpu_capacities);
+    &CACHED_CAPS
+}
+
+fn build_cpu_capacities() -> [u16; MAX_CPU_NUM] {
+    let mut caps = [DEFAULT_CPU_CAPACITY; MAX_CPU_NUM];
+    let Some(fdt) = get_fdt() else {
+        return caps;
+    };
+    // `all_nodes()` yields device-tree order; the N-th `cpu@*` node is logical
+    // CPU N (matches boot's `.enumerate()` cpu_id mapping). Do NOT key by `reg`.
+    let mut idx = 0usize;
+    for node in fdt.all_nodes() {
+        if idx >= caps.len() {
+            break;
+        }
+        if !node.name().starts_with("cpu@") {
+            continue;
+        }
+        // Skip firmware-disabled CPUs (status != okay/ok) so `idx` stays aligned
+        // with boot's `.enumerate()` cpu_id mapping, which also skips them.
+        // Mirrors someboot's is_cpu_node_available (platforms/someboot/src/fdt).
+        let available = node
+            .find_property("status")
+            .map(|p| matches!(p.str(), "okay" | "ok"))
+            .unwrap_or(true);
+        if !available {
+            continue;
+        }
+        let cap = node
+            .find_property("capacity-dmips-mhz")
+            .map(|p| p.u32() as u16)
+            .filter(|&c| c != 0)
+            .or_else(|| {
+                node.compatibles().find_map(|compat| {
+                    if compat.contains("cortex-a55") {
+                        Some(530)
+                    } else if compat.contains("cortex-a76") {
+                        Some(1024)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or(DEFAULT_CPU_CAPACITY);
+        caps[idx] = cap;
+        idx += 1;
+    }
+    log::info!("cpu_capacities: {:?}", &caps[..idx.max(1)]);
+    caps
+}

--- a/os/arceos/modules/axhal/src/dtb.rs
+++ b/os/arceos/modules/axhal/src/dtb.rs
@@ -72,12 +72,24 @@ pub fn cpu_capacities() -> &'static [u16; MAX_CPU_NUM] {
 }
 
 fn build_cpu_capacities() -> [u16; MAX_CPU_NUM] {
-    let mut caps = [DEFAULT_CPU_CAPACITY; MAX_CPU_NUM];
     let Some(fdt) = get_fdt() else {
-        return caps;
+        return [DEFAULT_CPU_CAPACITY; MAX_CPU_NUM];
     };
-    // `all_nodes()` yields device-tree order; the N-th `cpu@*` node is logical
-    // CPU N (matches boot's `.enumerate()` cpu_id mapping). Do NOT key by `reg`.
+    caps_from_fdt(fdt)
+}
+
+/// Parse per-logical-CPU normalized compute capacities from `fdt`, indexed by
+/// logical `cpu_id`.
+///
+/// `all_nodes()` yields device-tree order; the N-th *enabled* `cpu@*` node is
+/// logical CPU N (matching boot's `.enumerate()` cpu_id mapping — do NOT key by
+/// `reg`). Firmware-disabled CPUs are skipped so the index stays aligned. Each
+/// node's capacity comes from `capacity-dmips-mhz`, else a `cortex-a55`/`a76`
+/// compatible fallback, else [`DEFAULT_CPU_CAPACITY`]. Generic over the table
+/// size `N` so it can be unit-tested with fixture device trees independent of
+/// the build-time [`MAX_CPU_NUM`].
+fn caps_from_fdt<const N: usize>(fdt: &Fdt) -> [u16; N] {
+    let mut caps = [DEFAULT_CPU_CAPACITY; N];
     let mut idx = 0usize;
     for node in fdt.all_nodes() {
         if idx >= caps.len() {
@@ -117,4 +129,125 @@ fn build_cpu_capacities() -> [u16; MAX_CPU_NUM] {
     }
     log::info!("cpu_capacities: {:?}", &caps[..idx.max(1)]);
     caps
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+
+    use fdt_edit::{Fdt as EditFdt, Node, Property};
+    use fdt_parser::Fdt as ParsedFdt;
+
+    use super::{DEFAULT_CPU_CAPACITY, caps_from_fdt};
+
+    /// Fixture description of one `cpu@*` device-tree node.
+    struct CpuSpec {
+        status: Option<&'static str>,
+        compatible: Option<&'static str>,
+        dmips: Option<u32>,
+    }
+
+    fn cpu(
+        status: Option<&'static str>,
+        compatible: Option<&'static str>,
+        dmips: Option<u32>,
+    ) -> CpuSpec {
+        CpuSpec {
+            status,
+            compatible,
+            dmips,
+        }
+    }
+
+    fn str_prop(name: &str, value: &str) -> Property {
+        let mut data = value.as_bytes().to_vec();
+        data.push(0); // device-tree strings are NUL-terminated
+        Property::new(name, data)
+    }
+
+    fn u32_prop(name: &str, value: u32) -> Property {
+        Property::new(name, value.to_be_bytes().to_vec())
+    }
+
+    /// Build a `/cpus` device tree with the given CPUs, encode it to a DTB blob,
+    /// parse it back through the same `fdt_parser` path `build_cpu_capacities`
+    /// uses, and compute the capacity table (fixed `N = 8` regardless of the
+    /// build-time `MAX_CPU_NUM`).
+    fn caps_of(cpus: &[CpuSpec]) -> [u16; 8] {
+        let mut fdt = EditFdt::new();
+        let root = fdt.root_id();
+        let cpus_node = fdt.add_node(root, Node::new("cpus"));
+        fdt.node_mut(cpus_node)
+            .unwrap()
+            .set_property(u32_prop("#address-cells", 1));
+        fdt.node_mut(cpus_node)
+            .unwrap()
+            .set_property(u32_prop("#size-cells", 0));
+
+        for (i, spec) in cpus.iter().enumerate() {
+            let id = fdt.add_node(cpus_node, Node::new(&format!("cpu@{i}")));
+            let node = fdt.node_mut(id).unwrap();
+            node.set_property(str_prop("device_type", "cpu"));
+            node.set_property(u32_prop("reg", i as u32));
+            if let Some(status) = spec.status {
+                node.set_property(str_prop("status", status));
+            }
+            if let Some(compatible) = spec.compatible {
+                node.set_property(str_prop("compatible", compatible));
+            }
+            if let Some(dmips) = spec.dmips {
+                node.set_property(u32_prop("capacity-dmips-mhz", dmips));
+            }
+        }
+
+        let bytes = fdt.encode().as_ref().to_vec();
+        let parsed = ParsedFdt::from_bytes(&bytes).expect("fixture DTB should parse");
+        caps_from_fdt::<8>(&parsed)
+    }
+
+    #[test]
+    fn compatible_fallback_maps_a76_and_a55() {
+        let caps = caps_of(&[
+            cpu(None, Some("arm,cortex-a76"), None),
+            cpu(None, Some("arm,cortex-a55"), None),
+        ]);
+        assert_eq!(caps[0], 1024, "cortex-a76 -> 1024");
+        assert_eq!(caps[1], 530, "cortex-a55 -> 530");
+        // A CPU with no matching node keeps the default.
+        assert_eq!(caps[2], DEFAULT_CPU_CAPACITY);
+    }
+
+    #[test]
+    fn unknown_compatible_uses_default_capacity() {
+        let caps = caps_of(&[cpu(None, Some("arm,cortex-unknown"), None)]);
+        assert_eq!(caps[0], DEFAULT_CPU_CAPACITY);
+    }
+
+    #[test]
+    fn explicit_dmips_property_wins_over_compatible() {
+        let caps = caps_of(&[cpu(None, Some("arm,cortex-a55"), Some(900))]);
+        assert_eq!(
+            caps[0], 900,
+            "explicit capacity-dmips-mhz overrides the compatible fallback"
+        );
+    }
+
+    /// Regression for the disabled-CPU skip: a firmware-disabled `cpu@` node
+    /// interleaved before enabled ones must not consume a logical index, or every
+    /// subsequent capacity is shifted off its `cpu_id`. The pre-fix
+    /// implementation counted disabled nodes and fails this.
+    #[test]
+    fn disabled_cpu_node_does_not_shift_logical_indices() {
+        let caps = caps_of(&[
+            cpu(Some("disabled"), Some("arm,cortex-a55"), None),
+            cpu(Some("okay"), Some("arm,cortex-a76"), None),
+            cpu(None, Some("arm,cortex-a55"), None),
+        ]);
+        // Disabled cpu@0 is skipped: logical CPU 0 is the a76, CPU 1 the a55.
+        assert_eq!(
+            caps[0], 1024,
+            "disabled cpu@0 must not occupy logical index 0"
+        );
+        assert_eq!(caps[1], 530);
+    }
 }

--- a/os/arceos/modules/axhal/src/dtb.rs
+++ b/os/arceos/modules/axhal/src/dtb.rs
@@ -2,7 +2,7 @@
 use core::ptr::NonNull;
 
 use ax_lazyinit::{LazyLock, OnceLock};
-use fdt_parser::Fdt;
+use fdt_parser::{Fdt, Node};
 
 static BOOTARG: OnceLock<usize> = OnceLock::new();
 
@@ -78,62 +78,111 @@ fn build_cpu_capacities() -> [u16; MAX_CPU_NUM] {
     caps_from_fdt(fdt)
 }
 
+/// A `cpu@*` device-tree node the boot path treats as a real, enabled CPU.
+///
+/// Mirrors someboot's `is_cpu_node_available` (platforms/someboot/src/fdt) so
+/// this table's logical indices line up with boot's `.enumerate()` cpu_id
+/// mapping: the node is named `cpu@*`, is not firmware-disabled, and either has
+/// no `device_type` or declares `device_type = "cpu"` (nodes that reuse a
+/// `cpu@` name for something else are excluded).
+fn is_cpu_node_available(node: &Node) -> bool {
+    node.name().starts_with("cpu@")
+        && matches!(
+            node.find_property("device_type").map(|p| p.str()),
+            None | Some("cpu")
+        )
+        && matches!(
+            node.find_property("status").map(|p| p.str()),
+            None | Some("okay") | Some("ok")
+        )
+}
+
 /// Parse per-logical-CPU normalized compute capacities from `fdt`, indexed by
 /// logical `cpu_id`.
 ///
-/// `all_nodes()` yields device-tree order; the N-th *enabled* `cpu@*` node is
-/// logical CPU N (matching boot's `.enumerate()` cpu_id mapping — do NOT key by
-/// `reg`). Firmware-disabled CPUs are skipped so the index stays aligned. Each
-/// node's capacity comes from `capacity-dmips-mhz`, else a `cortex-a55`/`a76`
-/// compatible fallback, else [`DEFAULT_CPU_CAPACITY`]. Generic over the table
-/// size `N` so it can be unit-tested with fixture device trees independent of
-/// the build-time [`MAX_CPU_NUM`].
+/// Only the direct `cpu@*` children of `/cpus` are considered, filtered by
+/// [`is_cpu_node_available`] and taken in device-tree order (the N-th enabled
+/// node is logical CPU N — do NOT key by `reg`); this matches boot's CPU
+/// enumeration so a stray `cpu@*` node elsewhere in the tree cannot shift the
+/// indices. Each CPU's capacity comes from `capacity-dmips-mhz` (a raw relative
+/// value), else a `cortex-a55`/`a76` compatible fallback, else
+/// [`DEFAULT_CPU_CAPACITY`].
+///
+/// `capacity-dmips-mhz` values are normalized so the largest maps to
+/// `SCHED_CAPACITY_SCALE` (1024), the same convention Linux uses; the compat and
+/// default fallbacks are already on the 1024 scale and are left untouched, so
+/// raw DMIPS/MHz numbers can never leak into the table at a different scale.
+///
+/// Generic over the table size `N` so it can be unit-tested with fixture device
+/// trees independent of the build-time [`MAX_CPU_NUM`].
 fn caps_from_fdt<const N: usize>(fdt: &Fdt) -> [u16; N] {
-    let mut caps = [DEFAULT_CPU_CAPACITY; N];
-    let mut idx = 0usize;
+    // Pass 1: select the enabled `/cpus` children, recording each CPU's raw
+    // `capacity-dmips-mhz` (if any) and its already-1024-scaled compat/default
+    // fallback, in logical-cpu_id order.
+    let mut raw_dmips = [None::<u32>; N];
+    let mut fallback = [DEFAULT_CPU_CAPACITY; N];
+    let mut count = 0usize;
+
+    let mut cpus_level: Option<usize> = None;
     for node in fdt.all_nodes() {
-        if idx >= caps.len() {
-            break;
-        }
-        if !node.name().starts_with("cpu@") {
-            continue;
-        }
-        // Skip firmware-disabled CPUs (status != okay/ok) so `idx` stays aligned
-        // with boot's `.enumerate()` cpu_id mapping, which also skips them.
-        // Mirrors someboot's is_cpu_node_available (platforms/someboot/src/fdt).
-        let available = node
-            .find_property("status")
-            .map(|p| matches!(p.str(), "okay" | "ok"))
-            .unwrap_or(true);
-        if !available {
-            continue;
-        }
-        let cap = node
-            .find_property("capacity-dmips-mhz")
-            .map(|p| p.u32() as u16)
-            .filter(|&c| c != 0)
-            .or_else(|| {
-                node.compatibles().find_map(|compat| {
-                    if compat.contains("cortex-a55") {
-                        Some(530)
-                    } else if compat.contains("cortex-a76") {
-                        Some(1024)
-                    } else {
-                        None
+        match cpus_level {
+            None => {
+                if node.name() == "cpus" {
+                    cpus_level = Some(node.level);
+                }
+            }
+            Some(cpus_level) => {
+                // Left the `/cpus` subtree: no more CPU nodes follow.
+                if node.level <= cpus_level {
+                    break;
+                }
+                // Only direct children of `/cpus` are CPUs; skip deeper descendants.
+                if node.level == cpus_level + 1 && is_cpu_node_available(&node) {
+                    if count >= N {
+                        break;
                     }
-                })
-            })
-            .unwrap_or(DEFAULT_CPU_CAPACITY);
-        caps[idx] = cap;
-        idx += 1;
+                    raw_dmips[count] = node
+                        .find_property("capacity-dmips-mhz")
+                        .map(|p| p.u32())
+                        .filter(|&c| c != 0);
+                    fallback[count] = node
+                        .compatibles()
+                        .find_map(|compat| {
+                            if compat.contains("cortex-a55") {
+                                Some(530)
+                            } else if compat.contains("cortex-a76") {
+                                Some(1024)
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or(DEFAULT_CPU_CAPACITY);
+                    count += 1;
+                }
+            }
+        }
     }
-    log::info!("cpu_capacities: {:?}", &caps[..idx.max(1)]);
+
+    // Pass 2: normalize the raw DMIPS/MHz values against the largest so it maps
+    // to 1024; leave compat/default fallbacks (already 1024-scaled) as-is.
+    let max_dmips = raw_dmips[..count].iter().flatten().copied().max();
+
+    let mut caps = [DEFAULT_CPU_CAPACITY; N];
+    for i in 0..count {
+        caps[i] = match (raw_dmips[i], max_dmips) {
+            // u64 math so a large/garbage `capacity-dmips-mhz` can't overflow the
+            // `* 1024` scale; the result is clamped into `[1, 1024]` regardless.
+            (Some(dmips), Some(max)) => (dmips as u64 * 1024 / max as u64).clamp(1, 1024) as u16,
+            _ => fallback[i],
+        };
+    }
+    log::info!("cpu_capacities: {:?}", &caps[..count.max(1)]);
     caps
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
+    use alloc::{format, vec::Vec};
 
     use fdt_edit::{Fdt as EditFdt, Node, Property};
     use fdt_parser::Fdt as ParsedFdt;
@@ -142,17 +191,20 @@ mod tests {
 
     /// Fixture description of one `cpu@*` device-tree node.
     struct CpuSpec {
+        device_type: Option<&'static str>,
         status: Option<&'static str>,
         compatible: Option<&'static str>,
         dmips: Option<u32>,
     }
 
+    /// A normal enabled CPU node (`device_type = "cpu"`).
     fn cpu(
         status: Option<&'static str>,
         compatible: Option<&'static str>,
         dmips: Option<u32>,
     ) -> CpuSpec {
         CpuSpec {
+            device_type: Some("cpu"),
             status,
             compatible,
             dmips,
@@ -169,11 +221,9 @@ mod tests {
         Property::new(name, value.to_be_bytes().to_vec())
     }
 
-    /// Build a `/cpus` device tree with the given CPUs, encode it to a DTB blob,
-    /// parse it back through the same `fdt_parser` path `build_cpu_capacities`
-    /// uses, and compute the capacity table (fixed `N = 8` regardless of the
-    /// build-time `MAX_CPU_NUM`).
-    fn caps_of(cpus: &[CpuSpec]) -> [u16; 8] {
+    /// Build a device tree with `/cpus` holding `cpus`, optionally adding a stray
+    /// `cpu@*` node at the root (outside `/cpus`). Returns the encoded DTB blob.
+    fn build_dtb(cpus: &[CpuSpec], stray_root_cpu: Option<&str>) -> Vec<u8> {
         let mut fdt = EditFdt::new();
         let root = fdt.root_id();
         let cpus_node = fdt.add_node(root, Node::new("cpus"));
@@ -187,7 +237,9 @@ mod tests {
         for (i, spec) in cpus.iter().enumerate() {
             let id = fdt.add_node(cpus_node, Node::new(&format!("cpu@{i}")));
             let node = fdt.node_mut(id).unwrap();
-            node.set_property(str_prop("device_type", "cpu"));
+            if let Some(device_type) = spec.device_type {
+                node.set_property(str_prop("device_type", device_type));
+            }
             node.set_property(u32_prop("reg", i as u32));
             if let Some(status) = spec.status {
                 node.set_property(str_prop("status", status));
@@ -200,7 +252,23 @@ mod tests {
             }
         }
 
-        let bytes = fdt.encode().as_ref().to_vec();
+        if let Some(name) = stray_root_cpu {
+            // A `cpu@*` node directly under the root, not under `/cpus`. A scan
+            // that matched `cpu@*` anywhere in the tree would wrongly count it.
+            let id = fdt.add_node(root, Node::new(name));
+            let node = fdt.node_mut(id).unwrap();
+            node.set_property(str_prop("device_type", "cpu"));
+            node.set_property(str_prop("compatible", "arm,cortex-a55"));
+        }
+
+        fdt.encode().as_ref().to_vec()
+    }
+
+    /// Encode `cpus` under `/cpus`, parse through the same `fdt_parser` path
+    /// `build_cpu_capacities` uses, and compute the capacity table (fixed
+    /// `N = 8`, independent of the build-time `MAX_CPU_NUM`).
+    fn caps_of(cpus: &[CpuSpec]) -> [u16; 8] {
+        let bytes = build_dtb(cpus, None);
         let parsed = ParsedFdt::from_bytes(&bytes).expect("fixture DTB should parse");
         caps_from_fdt::<8>(&parsed)
     }
@@ -224,12 +292,19 @@ mod tests {
     }
 
     #[test]
-    fn explicit_dmips_property_wins_over_compatible() {
-        let caps = caps_of(&[cpu(None, Some("arm,cortex-a55"), Some(900))]);
+    fn dmips_values_are_normalized_to_1024_scale() {
+        // Phytium-like raw DMIPS/MHz values: the largest maps to 1024 and the
+        // rest scale proportionally, so a raw value never leaks into the table.
+        // The normalized DMIPS also takes precedence over the compatible fallback.
+        let caps = caps_of(&[
+            cpu(None, Some("arm,cortex-a55"), Some(2850)),
+            cpu(None, Some("arm,cortex-a76"), Some(5660)),
+        ]);
         assert_eq!(
-            caps[0], 900,
-            "explicit capacity-dmips-mhz overrides the compatible fallback"
+            caps[1], 1024,
+            "largest capacity-dmips-mhz normalizes to 1024"
         );
+        assert_eq!(caps[0], 515, "2850 * 1024 / 5660 = 515");
     }
 
     /// Regression for the disabled-CPU skip: a firmware-disabled `cpu@` node
@@ -247,6 +322,48 @@ mod tests {
         assert_eq!(
             caps[0], 1024,
             "disabled cpu@0 must not occupy logical index 0"
+        );
+        assert_eq!(caps[1], 530);
+    }
+
+    #[test]
+    fn cpu_node_outside_cpus_is_ignored() {
+        // Only `/cpus` children are CPUs; a stray `cpu@9` at the root must not
+        // become a third logical CPU.
+        let bytes = build_dtb(
+            &[
+                cpu(None, Some("arm,cortex-a76"), None),
+                cpu(None, Some("arm,cortex-a55"), None),
+            ],
+            Some("cpu@9"),
+        );
+        let parsed = ParsedFdt::from_bytes(&bytes).expect("fixture DTB should parse");
+        let caps = caps_from_fdt::<8>(&parsed);
+        assert_eq!(caps[0], 1024);
+        assert_eq!(caps[1], 530);
+        assert_eq!(
+            caps[2], DEFAULT_CPU_CAPACITY,
+            "a stray cpu@ outside /cpus must not be counted"
+        );
+    }
+
+    #[test]
+    fn non_cpu_device_type_is_ignored() {
+        // A `/cpus` child named `cpu@*` but declaring a non-"cpu" device_type is
+        // not a CPU (someboot excludes it) and must not consume a logical index.
+        let caps = caps_of(&[
+            CpuSpec {
+                device_type: Some("memory"),
+                status: None,
+                compatible: Some("arm,cortex-a55"),
+                dmips: None,
+            },
+            cpu(None, Some("arm,cortex-a76"), None),
+            cpu(None, Some("arm,cortex-a55"), None),
+        ]);
+        assert_eq!(
+            caps[0], 1024,
+            "a cpu@ node with device_type != cpu must not occupy index 0"
         );
         assert_eq!(caps[1], 530);
     }

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -27,6 +27,11 @@
 
 #![no_std]
 
+// `alloc` is only needed by the host unit tests (e.g. `dtb` builds fixture
+// device trees), so pull it in under `cfg(test)` rather than the crate proper.
+#[cfg(test)]
+extern crate alloc;
+
 #[cfg(all(axtest, feature = "axtest"))]
 mod axtest;
 


### PR DESCRIPTION
## 问题
大小核放置需要 per-CPU 算力权重，但 HAL 未从设备树解析 `capacity-dmips-mhz`。评审另指出两点：CPU 节点选择须与启动枚举一致，且原始 `capacity-dmips-mhz` 不能与已归一化的回退值混用。

## 改动
`ax-hal` 新增 `cpu_capacities()`，返回按逻辑 `cpu_id` 索引的 per-CPU 算力表（单文件 `dtb.rs`）；解析抽为泛型纯函数 `caps_from_fdt::<N>` 以便 fixture 测试：

- **节点选择**：只遍历 `/cpus` 的直接子节点，用 `is_cpu_node_available` 逐字段对齐 someboot 的 `is_cpu_node_available`（名字 `cpu@*`、`device_type ∈ {缺省,"cpu"}`、`status ∈ {缺省,"okay","ok"}`），按设备树顺序作为逻辑 `cpu_id`——`/cpus` 外或 `device_type` 非 cpu 的 `cpu@*` 节点不再误计入、不移位下标；firmware-disabled 节点跳过。
- **容量来源与归一化**：优先 `capacity-dmips-mhz`（原始相对值），否则 `cortex-a55`/`a76` 的 compatible 回退（530/1024），否则默认 1024。原始 `capacity-dmips-mhz` 两趟归一——以最大值映射到 `SCHED_CAPACITY_SCALE`(1024)（u64 运算防溢出 + clamp）；compatible/default 回退本就在 1024 标度，保持不变，原始 DMIPS 不再泄漏进公开表。

## 逻辑
纯读只、单文件基础原语，供后续容量感知放置消费；数值与下标是调度策略输入，故与启动 CPU 拓扑契约保持一致。同构（QEMU virt）时全部为 1024。

## 测试
`ax-hal` host 单测（`fdt_edit` 构造 `/cpus` fixture → `encode` → 经 `build_cpu_capacities` 同一 `fdt_parser` 路径解析 → `caps_from_fdt::<8>`）：compatible 回退、未知 compatible 取默认、`capacity-dmips-mhz` 归一化（Phytium-like 2850/5660 → 515/1024）、disabled 节点不移位、`/cpus` 外游离 `cpu@` 忽略、`device_type` 非 cpu 忽略。三个新增用例为红/绿回归（旧实现下必然失败）。容器内验证：`cargo test -p ax-hal`（6 通过）、`cargo fmt --check`、`cargo xtask clippy --package ax-hal`（13 检查全过）。