### PR TITLE
fix(rdrive): make FDT assigned-clocks best-effort, not probe-fatal

### DIFF
--- a/drivers/rdrive/Cargo.toml
+++ b/drivers/rdrive/Cargo.toml
@@ -36,6 +36,9 @@ x86.workspace = true
 
 [features]
 axtest = ["dep:axtest"]
+# Pull ax-sync's std Spin/RwLock impls so the crate's host tests link off-target
+# under `cargo xtask test`.
+host-test = ["ax-sync/host-test"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(axtest)'] }

--- a/drivers/rdrive/src/probe/fdt/mod.rs
+++ b/drivers/rdrive/src/probe/fdt/mod.rs
@@ -1404,8 +1404,19 @@ impl System {
             let phandle_map = self.phandle_2_device_id.clone();
 
             debug!("Probe [{}]->[{}]", node.name(), node_info.name);
-            let res = apply_assigned_clocks(node)
-                .and_then(|()| apply_power_domains(node))
+            // `assigned-clocks`/`assigned-clock-rates` defaults are best-effort,
+            // matching Linux `of_clk_set_defaults`: a rate the clock provider
+            // can't set (e.g. a VOP root clock the CRU doesn't implement) must
+            // not abort the device's probe. A driver that truly requires a rate
+            // opts into strict application via `prepare_resources`. Power domains
+            // and pinctrl remain required for probe.
+            if let Err(err) = apply_assigned_clocks(node) {
+                warn!(
+                    "[{}] assigned-clocks apply failed (best-effort, continuing to probe): {err}",
+                    node.name()
+                );
+            }
+            let res = apply_power_domains(node)
                 .and_then(|()| apply_default_pinctrl(node))
                 .and_then(|()| {
                     let descriptor = Descriptor {

--- a/drivers/rdrive/tests/fdt_assigned_clocks_best_effort.rs
+++ b/drivers/rdrive/tests/fdt_assigned_clocks_best_effort.rs
@@ -1,0 +1,144 @@
+use core::ptr::NonNull;
+use std::vec::Vec;
+
+use fdt_edit::{Fdt, Node, Property};
+use rdrive::{
+    DriverGeneric, Platform, get_one,
+    probe::{OnProbeError, fdt::ProbeFdt},
+    probe_all,
+    register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority},
+};
+
+/// A clock provider that rejects every `set_rate`, modelling a rate the CRU
+/// doesn't implement (e.g. a VOP root clock).
+struct RejectingClockProvider;
+
+impl DriverGeneric for RejectingClockProvider {
+    fn name(&self) -> &str {
+        "rejecting-clock"
+    }
+}
+
+impl rdif_clk::Interface for RejectingClockProvider {
+    fn perper_enable(&mut self) {}
+
+    fn get_rate(&self, _id: rdif_clk::ClockId) -> Result<u64, rdrive::KError> {
+        Ok(0)
+    }
+
+    fn set_rate(&mut self, _id: rdif_clk::ClockId, _rate: u64) -> Result<(), rdrive::KError> {
+        Err(rdrive::KError::Unknown("clock rate not supported"))
+    }
+}
+
+fn probe_clock(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe
+        .into_platform_device()
+        .register(rdif_clk::Clk::new(RejectingClockProvider));
+    Ok(())
+}
+
+static CLOCK_REGISTER: DriverRegister = DriverRegister {
+    name: "rejecting clock provider",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::CLK,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,rejecting-clock"],
+        on_probe: probe_clock,
+    }],
+};
+
+/// The consumer whose node carries `assigned-clock-rates` the provider rejects.
+struct ConsumerDevice;
+
+impl DriverGeneric for ConsumerDevice {
+    fn name(&self) -> &str {
+        "assigned-clock-consumer"
+    }
+}
+
+fn probe_consumer(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
+    probe.into_platform_device().register(ConsumerDevice);
+    Ok(())
+}
+
+static CONSUMER_REGISTER: DriverRegister = DriverRegister {
+    name: "assigned-clock consumer",
+    level: ProbeLevel::PostKernel,
+    priority: ProbePriority::DEFAULT,
+    probe_kinds: &[ProbeKind::Fdt {
+        compatibles: &["test,best-effort-consumer"],
+        on_probe: probe_consumer,
+    }],
+};
+
+/// `assigned-clocks`/`assigned-clock-rates` are best-effort: a rate the clock
+/// provider can't set must log and continue, not abort the consumer's probe.
+#[test]
+fn assigned_clocks_are_best_effort_and_do_not_abort_probe() {
+    let mut fdt = Fdt::new();
+    let root = fdt.root_id();
+    fdt.add_node(
+        root,
+        node_with_props(
+            "clock-controller@1000",
+            &[
+                prop_strs("compatible", &["test,rejecting-clock"]),
+                prop_u32s("phandle", &[1]),
+                prop_u32s("#clock-cells", &[1]),
+            ],
+        ),
+    );
+    fdt.add_node(
+        root,
+        node_with_props(
+            "vop@2000",
+            &[
+                prop_strs("compatible", &["test,best-effort-consumer"]),
+                prop_u32s("assigned-clocks", &[1, 0]),
+                prop_u32s("assigned-clock-rates", &[100_000_000]),
+            ],
+        ),
+    );
+
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+    rdrive::register_add(CLOCK_REGISTER.clone());
+    rdrive::register_add(CONSUMER_REGISTER.clone());
+
+    // The unsupported assigned-clock rate must not abort probing.
+    probe_all(true).expect("FDT probe should succeed despite a rejected assigned-clock rate");
+    assert!(
+        get_one::<ConsumerDevice>().is_some(),
+        "consumer must still register when its assigned-clock rate is unsupported"
+    );
+}
+
+fn node_with_props(name: &str, props: &[Property]) -> Node {
+    let mut node = Node::new(name);
+    for prop in props {
+        node.set_property(prop.clone());
+    }
+    node
+}
+
+fn prop_u32s(name: &str, values: &[u32]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(&value.to_be_bytes());
+    }
+    Property::new(name, data)
+}
+
+fn prop_strs(name: &str, values: &[&str]) -> Property {
+    let mut data = Vec::new();
+    for value in values {
+        data.extend_from_slice(value.as_bytes());
+        data.push(0);
+    }
+    Property::new(name, data)
+}

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -255,7 +255,7 @@ fn run_std_tests<R: CargoRunner>(
 fn package_feature_profiles(package: &str) -> Option<&'static [PackageFeatureProfile]> {
     match package {
         "arm_vgic" | "axdevice" | "axfs-ng-vfs" | "rsext4" | "scope-local" | "ax-sync" | "axvm"
-        | "ax-display" | "ax-input" | "ax-ipi" | "ax-log" | "ax-runtime" | "ax-api" => {
+        | "ax-display" | "ax-input" | "ax-ipi" | "ax-log" | "ax-runtime" | "ax-api" | "rdrive" => {
             Some(HOST_TEST_FEATURE_PROFILES)
         }
         "ax-task" => Some(AX_TASK_FEATURE_PROFILES),

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -31,6 +31,7 @@ ax-timer-list
 ax-alloc
 ax-display
 ax-driver
+rdrive
 ax-hal
 ax-sync
 ax-task


### PR DESCRIPTION
## 问题
`assigned-clocks`/`assigned-clock-rates` 的默认设置一旦时钟提供者无法设置某速率（如 CRU 未实现的 VOP 根时钟）就中止整个设备 probe，与 Linux `of_clk_set_defaults` 的“尽力而为”不符。

## 改动
`apply_assigned_clocks` 失败改为记录并继续 probe；电源域/pinctrl 仍为 probe 必需。真正需要某速率的驱动经 `prepare_resources` 显式严格应用。

## 测试
`drivers/rdrive/tests` 新增宿主测试：一个拒绝 `set_rate` 的时钟提供者 + 携带不受支持 `assigned-clock-rates` 的消费者节点，消费者仍成功 probe/注册；并把 `rdrive` 接入 `std_crates.csv` + host-test profile，使其(及既有 rdrive 测试)进入 CI。