### PR TITLE
feat(rdrive): generation-tagged device locks with dead-holder reclaim

### DIFF
--- a/drivers/rdrive/src/lib.rs
+++ b/drivers/rdrive/src/lib.rs
@@ -265,6 +265,24 @@ pub fn get_one<T: DriverGeneric>() -> Option<Device<T>> {
     read(|manager| manager.dev_container.get_one())
 }
 
+/// Frees every device lock still held by `pid` (a dead process). Returns the
+/// number of locks reclaimed. PID-reuse-safe: reclaim CASes the exact
+/// observed (generation, owner) token, so a recycled pid that re-acquired
+/// the lock is never stomped.
+pub fn reclaim_all_held_by(pid: u32) -> usize {
+    // Keep the registry spinlock's critical section tiny: only the CAS work
+    // happens inside `edit`; logging happens after it's released.
+    let reclaimed = edit(|manager| manager.dev_container.reclaim_all_held_by(pid));
+    let count = reclaimed.len();
+    for id in reclaimed {
+        warn!(
+            "reclaimed device lock (id={:?}) held by dead pid {}",
+            id, pid
+        );
+    }
+    count
+}
+
 pub fn fdt_phandle_to_device_id(phandle: Phandle) -> Option<DeviceId> {
     probe::fdt::try_system().and_then(|system| system.phandle_to_device_id(phandle))
 }

--- a/drivers/rdrive/src/lock.rs
+++ b/drivers/rdrive/src/lock.rs
@@ -5,12 +5,12 @@ use alloc::{
 use core::{
     any::Any,
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicI64, Ordering},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use rdif_base::DriverGeneric;
 
-use crate::{Descriptor, Pid, get_pid};
+use crate::{Descriptor, Pid, get_pid, relax};
 
 pub struct DeviceOwner {
     lock: Arc<LockInner>,
@@ -41,8 +41,51 @@ impl Drop for LockInner {
     }
 }
 
+/// Marks a token's owner field as "no one holds this lock".
+const OWNER_FREE: u32 = 0xFFFF_FFFF;
+/// Marks a token's owner field as "held, but by an unknown/untracked pid"
+/// (e.g. no `Osal` wired up yet, or acquired outside of a process context).
+const OWNER_INVALID: u32 = 0xFFFF_FFFE;
+
+/// Pack a generation counter and an owner into a single atomic word.
+///
+/// Low 32 bits: owner (`OWNER_FREE`, `OWNER_INVALID`, or a pid as `u32`).
+/// High 32 bits: generation, bumped on every successful acquire/release so a
+/// stale token (captured before a reclaim + re-acquire cycle) can never
+/// CAS-succeed against a newer owner.
+fn pack(generation: u32, owner: u32) -> u64 {
+    ((generation as u64) << 32) | (owner as u64)
+}
+
+/// Inverse of [`pack`]: returns `(generation, owner)`.
+fn unpack(token: u64) -> (u32, u32) {
+    ((token >> 32) as u32, token as u32)
+}
+
+/// Encode a [`Pid`] as the owner half of a token.
+fn owner_from_pid(pid: Pid) -> u32 {
+    if pid.is_not_set() {
+        OWNER_FREE
+    } else if pid.is_invalid() {
+        OWNER_INVALID
+    } else {
+        pid.raw() as u32
+    }
+}
+
+/// Decode the owner half of a token back into a [`Pid`].
+///
+/// Only meaningful for a non-`OWNER_FREE` owner (callers check that first).
+fn pid_from_owner(owner: u32) -> Pid {
+    if owner == OWNER_INVALID {
+        Pid::INVALID.into()
+    } else {
+        (owner as usize).into()
+    }
+}
+
 struct LockInner {
-    borrowed: AtomicI64,
+    borrowed: AtomicU64,
     ptr: *mut dyn Any,
     descriptor: Descriptor,
 }
@@ -53,64 +96,117 @@ unsafe impl Sync for LockInner {}
 impl LockInner {
     fn new(descriptor: Descriptor, ptr: *mut dyn Any) -> Self {
         Self {
-            borrowed: AtomicI64::new(-1),
+            borrowed: AtomicU64::new(pack(0, OWNER_FREE)),
             ptr,
             descriptor,
         }
     }
 
-    pub fn try_lock(self: &Arc<Self>, pid: Pid) -> Result<(), GetDeviceError> {
+    /// Try to acquire the lock for `pid`, returning the exact token acquired
+    /// on success so the caller (a [`DeviceGuard`]) can release precisely
+    /// that acquisition later.
+    pub fn try_lock(self: &Arc<Self>, pid: Pid) -> Result<u64, GetDeviceError> {
         let mut pid = pid;
         if pid.is_not_set() {
             pid = Pid::INVALID.into();
         }
+        let owner = owner_from_pid(pid);
 
-        let id: usize = pid.into();
-
-        match self.borrowed.compare_exchange(
-            Pid::NOT_SET as _,
-            id as _,
-            Ordering::Acquire,
-            Ordering::Relaxed,
-        ) {
-            Ok(_) => Ok(()),
-            Err(old) => {
-                if old as usize == Pid::INVALID {
-                    Err(GetDeviceError::UsedByUnknown)
+        loop {
+            let current = self.borrowed.load(Ordering::Relaxed);
+            let (generation, cur_owner) = unpack(current);
+            if cur_owner != OWNER_FREE {
+                return Err(if cur_owner == OWNER_INVALID {
+                    GetDeviceError::UsedByUnknown
                 } else {
-                    let pid: Pid = (old as usize).into();
-                    Err(GetDeviceError::UsedByOthers(pid))
-                }
+                    GetDeviceError::UsedByOthers(pid_from_owner(cur_owner))
+                });
+            }
+
+            let new = pack(generation.wrapping_add(1), owner);
+            match self
+                .borrowed
+                .compare_exchange(current, new, Ordering::Acquire, Ordering::Relaxed)
+            {
+                Ok(_) => return Ok(new),
+                // Someone else raced us for the free slot; reload and re-check.
+                Err(_) => continue,
             }
         }
     }
 
-    pub fn lock(self: &Arc<Self>) -> Result<(), GetDeviceError> {
+    pub fn lock(self: &Arc<Self>) -> Result<u64, GetDeviceError> {
         let pid = get_pid();
         loop {
             match self.try_lock(pid) {
-                Ok(guard) => return Ok(guard),
+                Ok(token) => return Ok(token),
                 Err(GetDeviceError::UsedByOthers(_)) | Err(GetDeviceError::UsedByUnknown) => {
+                    relax();
                     continue;
                 }
                 Err(e) => return Err(e),
             }
         }
     }
+
+    /// Free this lock if it is currently held by `pid`.
+    ///
+    /// Used by the death-reclaim path (`reclaim_all_held_by`) so a process
+    /// that dies while holding a device lock doesn't wedge it forever. The
+    /// CAS uses the exact token observed by this call, so a pid reused by a
+    /// brand-new process can never be reclaimed out from under it: any
+    /// intervening acquire/release bumps the generation and the CAS here
+    /// simply fails, harmlessly.
+    // Not yet called from production code: its only caller,
+    // `reclaim_all_held_by`, is wired up in the registry-level follow-up
+    // (manager.rs/lib.rs). `expect` (not `allow`) so this fails to compile
+    // on its own once that caller lands, forcing removal instead of leaving
+    // stale suppression behind. Exercised directly by the unit tests below.
+    #[expect(
+        dead_code,
+        reason = "consumed by the registry-level reclaim_all_held_by follow-up"
+    )]
+    pub fn reclaim_if_held_by(&self, pid: u32) -> bool {
+        let current = self.borrowed.load(Ordering::Relaxed);
+        let (generation, owner) = unpack(current);
+        if owner != pid {
+            return false;
+        }
+
+        let freed = pack(generation.wrapping_add(1), OWNER_FREE);
+        self.borrowed
+            .compare_exchange(current, freed, Ordering::AcqRel, Ordering::Relaxed)
+            .is_ok()
+    }
 }
 
 pub struct DeviceGuard<T> {
     lock: Arc<LockInner>,
     ptr: *mut T,
+    /// The exact token observed at acquire time; released with a CAS against
+    /// this precise value so a reclaim that already freed (and possibly
+    /// re-acquired) this lock is never stomped.
+    token: u64,
 }
 
 unsafe impl<T> Send for DeviceGuard<T> {}
 
 impl<T> Drop for DeviceGuard<T> {
     fn drop(&mut self) {
-        self.lock
+        let (generation, _owner) = unpack(self.token);
+        let released = pack(generation.wrapping_add(1), OWNER_FREE);
+        if self
+            .lock
             .borrowed
-            .store(Pid::NOT_SET as _, Ordering::Release);
+            .compare_exchange(self.token, released, Ordering::Release, Ordering::Relaxed)
+            .is_err()
+        {
+            warn!(
+                "device lock (id={:?}) token stale on drop, likely reclaimed from a dead holder; \
+                 not releasing to avoid stomping a newer owner",
+                self.lock.descriptor.device_id()
+            );
+        }
     }
 }
 
@@ -175,20 +271,22 @@ impl<T: Any> Device<T> {
     /// rdrive device.
     pub fn lock(&self) -> Result<DeviceGuard<T>, GetDeviceError> {
         let lock = self.lock.upgrade().ok_or(GetDeviceError::DeviceReleased)?;
-        lock.lock()?;
+        let token = lock.lock()?;
 
         Ok(DeviceGuard {
             lock,
             ptr: self.ptr,
+            token,
         })
     }
     pub fn try_lock(&self) -> Result<DeviceGuard<T>, GetDeviceError> {
         let lock = self.lock.upgrade().ok_or(GetDeviceError::DeviceReleased)?;
-        lock.try_lock(get_pid())?;
+        let token = lock.try_lock(get_pid())?;
 
         Ok(DeviceGuard {
             lock,
             ptr: self.ptr,
+            token,
         })
     }
 
@@ -246,4 +344,150 @@ pub enum GetDeviceError {
     DeviceReleased,
     #[error("Device not found")]
     NotFound,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::driver::Empty;
+
+    fn new_owner() -> DeviceOwner {
+        DeviceOwner::new(Descriptor::new(), Empty)
+    }
+
+    #[test]
+    fn reacquire_after_normal_drop_bumps_generation() {
+        let owner = new_owner();
+        let lock = owner.lock.clone();
+        let device: Device<Empty> = owner.weak::<Empty>().unwrap();
+
+        let pid_a: Pid = 100usize.into();
+        let token_a = lock.try_lock(pid_a).expect("first acquire succeeds");
+        let (gen_a, owner_a) = unpack(token_a);
+        assert_eq!(owner_a, 100);
+
+        let guard = DeviceGuard {
+            lock: lock.clone(),
+            ptr: device.ptr,
+            token: token_a,
+        };
+        drop(guard);
+
+        let pid_b: Pid = 200usize.into();
+        let token_b = lock.try_lock(pid_b).expect("reacquire after drop succeeds");
+        let (gen_b, owner_b) = unpack(token_b);
+        assert_eq!(owner_b, 200);
+        assert!(
+            gen_b > gen_a,
+            "generation must strictly increase across acquire cycles"
+        );
+    }
+
+    #[test]
+    fn reclaim_frees_only_matching_pid() {
+        let owner = new_owner();
+        let lock = owner.lock.clone();
+
+        let pid: Pid = 42usize.into();
+        let token = lock.try_lock(pid).unwrap();
+
+        assert!(
+            !lock.reclaim_if_held_by(43),
+            "reclaim for a non-matching pid must be a no-op"
+        );
+        let (_, owner_after) = unpack(lock.borrowed.load(Ordering::Relaxed));
+        assert_eq!(
+            owner_after, 42,
+            "non-matching reclaim must not touch the lock"
+        );
+
+        assert!(
+            lock.reclaim_if_held_by(42),
+            "reclaim for the matching pid must free the lock"
+        );
+        let (_, owner_after2) = unpack(lock.borrowed.load(Ordering::Relaxed));
+        assert_eq!(owner_after2, OWNER_FREE);
+
+        let _ = token;
+    }
+
+    #[test]
+    fn stale_token_cas_is_noop_after_recycled_pid_reacquire() {
+        let owner = new_owner();
+        let lock = owner.lock.clone();
+
+        let dead_pid: Pid = 7usize.into();
+        let stale_token = lock.try_lock(dead_pid).expect("dead process acquires");
+
+        // The reaper frees the lock at do_exit.
+        assert!(lock.reclaim_if_held_by(7));
+
+        // pid 7 gets recycled by the OS and a brand-new, unrelated process
+        // legitimately re-acquires the very same device.
+        let recycled_pid: Pid = 7usize.into();
+        let new_token = lock
+            .try_lock(recycled_pid)
+            .expect("recycled pid re-acquires");
+        assert_ne!(
+            stale_token, new_token,
+            "generation must differ across acquisitions even with an identical numeric pid"
+        );
+
+        // A late/duplicate reclaim-style CAS using the stale (pre-recycle)
+        // token must not be able to free the new legitimate holder's lock.
+        let (stale_gen, _) = unpack(stale_token);
+        let stale_release = pack(stale_gen.wrapping_add(1), OWNER_FREE);
+        assert!(
+            lock.borrowed
+                .compare_exchange(
+                    stale_token,
+                    stale_release,
+                    Ordering::AcqRel,
+                    Ordering::Relaxed
+                )
+                .is_err(),
+            "stale token must not CAS-succeed against the recycled holder's live token"
+        );
+
+        let (_, owner_now) = unpack(lock.borrowed.load(Ordering::Relaxed));
+        assert_eq!(owner_now, 7);
+        assert_eq!(lock.borrowed.load(Ordering::Relaxed), new_token);
+    }
+
+    #[test]
+    fn guard_drop_after_reclaim_does_not_stomp() {
+        let owner = new_owner();
+        let lock = owner.lock.clone();
+        let device: Device<Empty> = owner.weak::<Empty>().unwrap();
+
+        let dead_pid: Pid = 9usize.into();
+        let token = lock.try_lock(dead_pid).expect("dead process acquires");
+        let guard = DeviceGuard {
+            lock: lock.clone(),
+            ptr: device.ptr,
+            token,
+        };
+
+        // The process holding `guard` dies; the reaper reclaims its lock
+        // before the guard itself is ever dropped.
+        assert!(lock.reclaim_if_held_by(9));
+
+        // pid 9 is recycled and a brand-new process legitimately acquires
+        // the same device.
+        let recycled_pid: Pid = 9usize.into();
+        let new_token = lock
+            .try_lock(recycled_pid)
+            .expect("recycled pid re-acquires");
+
+        // The dead process's guard is finally dropped (e.g. late task
+        // teardown): it must not stomp the new legitimate holder.
+        drop(guard);
+
+        let (_, owner_now) = unpack(lock.borrowed.load(Ordering::Relaxed));
+        assert_eq!(
+            owner_now, 9,
+            "guard drop must not free the new holder's lock"
+        );
+        assert_eq!(lock.borrowed.load(Ordering::Relaxed), new_token);
+    }
 }

--- a/drivers/rdrive/src/lock.rs
+++ b/drivers/rdrive/src/lock.rs
@@ -78,7 +78,18 @@ fn owner_from_pid(pid: Pid) -> u32 {
     } else if pid.is_invalid() {
         OWNER_INVALID
     } else {
-        pid.raw() as u32
+        // A tracked pid must round-trip through the 32-bit owner field. A pid that
+        // does not fit in `u32`, or that collides with the reserved `OWNER_FREE` /
+        // `OWNER_INVALID` sentinels, cannot be encoded faithfully: `as u32`
+        // truncation would alias a different pid (`0x1_0000_0001` -> pid 1), and
+        // `OWNER_FREE` would make a held lock read back as free — letting a
+        // concurrent caller acquire it. Degrade such a pid to `OWNER_INVALID`
+        // (held, but untracked) so the lock stays held and never aliases. Real
+        // pids sit far below this boundary; this only guards the soundness edge.
+        match u32::try_from(pid.raw()) {
+            Ok(owner) if owner != OWNER_FREE && owner != OWNER_INVALID => owner,
+            _ => OWNER_INVALID,
+        }
     }
 }
 
@@ -358,6 +369,33 @@ mod tests {
 
     fn new_owner() -> DeviceOwner {
         DeviceOwner::new(Descriptor::new(), Empty)
+    }
+
+    #[test]
+    fn pid_outside_u32_or_reserved_range_degrades_to_untracked() {
+        // A normal pid round-trips through the 32-bit owner field.
+        let normal: Pid = 4242usize.into();
+        assert_eq!(owner_from_pid(normal), 4242);
+
+        // A pid whose low 32 bits equal a reserved sentinel must NOT be encoded as
+        // that sentinel: `OWNER_FREE` would make a held lock read back as free and
+        // let a concurrent caller acquire it. Both reserved encodings degrade to
+        // `OWNER_INVALID` (held, but untracked).
+        let as_free: Pid = (OWNER_FREE as usize).into();
+        assert_ne!(owner_from_pid(as_free), OWNER_FREE);
+        assert_eq!(owner_from_pid(as_free), OWNER_INVALID);
+        let as_invalid: Pid = (OWNER_INVALID as usize).into();
+        assert_eq!(owner_from_pid(as_invalid), OWNER_INVALID);
+
+        // A pid above `u32::MAX` must not truncate and alias a small pid
+        // (`0x1_0000_0001` would otherwise collide with pid 1).
+        #[cfg(target_pointer_width = "64")]
+        {
+            let huge: Pid = 0x1_0000_0001usize.into();
+            let small: Pid = 1usize.into();
+            assert_ne!(owner_from_pid(huge), owner_from_pid(small));
+            assert_eq!(owner_from_pid(huge), OWNER_INVALID);
+        }
     }
 
     #[test]

--- a/drivers/rdrive/src/lock.rs
+++ b/drivers/rdrive/src/lock.rs
@@ -30,6 +30,15 @@ impl DeviceOwner {
     pub fn is<T: DriverGeneric>(&self) -> bool {
         unsafe { &*self.lock.ptr }.is::<T>()
     }
+
+    /// Frees this device's lock if it is currently held by `pid`.
+    ///
+    /// Thin visibility shim over [`LockInner::reclaim_if_held_by`] so the
+    /// registry (`manager.rs`) can reclaim locks without reaching into the
+    /// otherwise-private `lock` field.
+    pub(crate) fn reclaim_if_held_by(&self, pid: u32) -> bool {
+        self.lock.reclaim_if_held_by(pid)
+    }
 }
 
 impl Drop for LockInner {
@@ -151,21 +160,13 @@ impl LockInner {
 
     /// Free this lock if it is currently held by `pid`.
     ///
-    /// Used by the death-reclaim path (`reclaim_all_held_by`) so a process
-    /// that dies while holding a device lock doesn't wedge it forever. The
-    /// CAS uses the exact token observed by this call, so a pid reused by a
-    /// brand-new process can never be reclaimed out from under it: any
-    /// intervening acquire/release bumps the generation and the CAS here
-    /// simply fails, harmlessly.
-    // Not yet called from production code: its only caller,
-    // `reclaim_all_held_by`, is wired up in the registry-level follow-up
-    // (manager.rs/lib.rs). `expect` (not `allow`) so this fails to compile
-    // on its own once that caller lands, forcing removal instead of leaving
-    // stale suppression behind. Exercised directly by the unit tests below.
-    #[expect(
-        dead_code,
-        reason = "consumed by the registry-level reclaim_all_held_by follow-up"
-    )]
+    /// Used by the death-reclaim path (`reclaim_all_held_by`, via
+    /// [`DeviceOwner::reclaim_if_held_by`]) so a process that dies while
+    /// holding a device lock doesn't wedge it forever. The CAS uses the
+    /// exact token observed by this call, so a pid reused by a brand-new
+    /// process can never be reclaimed out from under it: any intervening
+    /// acquire/release bumps the generation and the CAS here simply fails,
+    /// harmlessly.
     pub fn reclaim_if_held_by(&self, pid: u32) -> bool {
         let current = self.borrowed.load(Ordering::Relaxed);
         let (generation, owner) = unpack(current);

--- a/drivers/rdrive/src/lock.rs
+++ b/drivers/rdrive/src/lock.rs
@@ -175,6 +175,10 @@ impl LockInner {
         }
 
         let freed = pack(generation.wrapping_add(1), OWNER_FREE);
+        // The Release half is load-bearing: the dead holder's device writes
+        // reach the reaper via the exit path's scheduler barriers, and this
+        // Release is what carries them onward to the next acquirer's
+        // Acquire-CAS. Do not weaken below AcqRel's Release half.
         self.borrowed
             .compare_exchange(current, freed, Ordering::AcqRel, Ordering::Relaxed)
             .is_ok()

--- a/drivers/rdrive/src/manager.rs
+++ b/drivers/rdrive/src/manager.rs
@@ -84,6 +84,22 @@ impl DeviceContainer {
         }
         result
     }
+
+    /// Frees every device lock in this container currently held by `pid`.
+    ///
+    /// Returns the ids of the devices that were reclaimed. Does no logging
+    /// itself: callers running under a spinlock (see `lib.rs::edit`) should
+    /// keep this call inside the critical section and log the result after
+    /// releasing it.
+    pub fn reclaim_all_held_by(&self, pid: u32) -> Vec<DeviceId> {
+        let mut reclaimed = Vec::new();
+        for (id, dev) in self.devices.iter() {
+            if dev.reclaim_if_held_by(pid) {
+                reclaimed.push(*id);
+            }
+        }
+        reclaimed
+    }
 }
 
 #[cfg(test)]
@@ -257,5 +273,60 @@ mod tests {
             "Expected error when trying to lock an already locked device"
         );
         let _ = device;
+    }
+
+    /// Fixed-pid `Osal` used to acquire a lock as a specific "process" in
+    /// tests, without needing access to `LockInner` (private to lock.rs).
+    struct FixedPidOsal(usize);
+
+    impl crate::Osal for FixedPidOsal {
+        fn get_pid(&self) -> crate::Pid {
+            self.0.into()
+        }
+    }
+
+    #[test]
+    fn test_reclaim_all_held_by() {
+        static OSAL_DEAD: FixedPidOsal = FixedPidOsal(100);
+        static OSAL_LIVE: FixedPidOsal = FixedPidOsal(200);
+
+        let mut container = DeviceContainer::default();
+        let desc_a = Descriptor::new();
+        let id_a = desc_a.device_id;
+        container.insert(desc_a, Empty);
+
+        let desc_b = Descriptor::new();
+        let id_b = desc_b.device_id;
+        container.insert(desc_b, Empty);
+
+        let weak_a = container.get_typed::<Empty>(id_a).unwrap();
+        let weak_b = container.get_typed::<Empty>(id_b).unwrap();
+
+        // pid 100 acquires device A, then dies without ever releasing it.
+        crate::set_osal(&OSAL_DEAD);
+        let guard_a = weak_a.lock().expect("pid 100 acquires device A");
+        core::mem::forget(guard_a);
+
+        // pid 200 legitimately holds device B throughout.
+        crate::set_osal(&OSAL_LIVE);
+        let guard_b = weak_b.lock().expect("pid 200 acquires device B");
+
+        let reclaimed = container.reclaim_all_held_by(100);
+        assert_eq!(
+            reclaimed,
+            vec![id_a],
+            "only the dead pid's device should be reclaimed"
+        );
+
+        assert!(
+            weak_b.try_lock().is_err(),
+            "a live holder's device must not be reclaimed"
+        );
+
+        let guard_a2 = weak_a
+            .try_lock()
+            .expect("device A was freed by the reclaim and can be re-acquired");
+        drop(guard_a2);
+        drop(guard_b);
     }
 }

--- a/drivers/rdrive/src/manager.rs
+++ b/drivers/rdrive/src/manager.rs
@@ -93,9 +93,11 @@ impl DeviceContainer {
     /// releasing it.
     pub fn reclaim_all_held_by(&self, pid: u32) -> Vec<DeviceId> {
         let mut reclaimed = Vec::new();
-        for (id, dev) in self.devices.iter() {
-            if dev.reclaim_if_held_by(pid) {
-                reclaimed.push(*id);
+        for (id, devs) in self.devices.iter() {
+            for dev in devs {
+                if dev.reclaim_if_held_by(pid) {
+                    reclaimed.push(*id);
+                }
             }
         }
         reclaimed

--- a/drivers/rdrive/src/osal.rs
+++ b/drivers/rdrive/src/osal.rs
@@ -19,6 +19,15 @@ impl Pid {
 pub trait Osal: Sync + Send + 'static {
     /// Get the current process ID.
     fn get_pid(&self) -> Pid;
+
+    /// Called on every iteration of a contended blocking `lock()`.
+    ///
+    /// The default just hints the CPU that this is a spin-wait. An OS
+    /// integration should override this to yield the current task to the
+    /// scheduler instead of hard-spinning.
+    fn relax(&self) {
+        core::hint::spin_loop();
+    }
 }
 
 struct OsalImplEmplty;
@@ -38,4 +47,8 @@ pub fn set_osal(osal: &'static dyn Osal) {
 
 pub(crate) fn get_pid() -> Pid {
     OSAL.read().get_pid()
+}
+
+pub(crate) fn relax() {
+    OSAL.read().relax();
 }


### PR DESCRIPTION
## 问题
设备锁在持有者进程死亡后无法安全回收，且回收与再获取之间存在“踩踏”竞争（旧持有者的 guard drop 释放了已被回收/再获取的锁）。

## 改动
- 设备锁令牌带 generation 标签，drop/回收时 bump generation；陈旧令牌的 CAS 变为 no-op（PID 回收再获取后不误伤）。
- 新增 `reclaim_all_held_by(pid)`：回收某死亡进程持有的全部设备锁。
- 明确 reclaim 中承载语义的 Release 定序注释。

## 测试
`drivers/rdrive/src/{lock,manager}.rs` 内 `#[cfg(test)]` 覆盖：正常 drop bump generation、仅回收匹配 PID、回收后陈旧令牌 CAS 为 no-op、回收后 guard drop 不踩踏；并把 `rdrive` 接入 `std_crates.csv` + host-test profile（宿主 33 项通过）。