### PR TITLE
perf(rdrive): add fdt_ref() to borrow the device tree without cloning

### DIFF
--- a/drivers/ax-driver/src/pci/fdt/rk3588/resources.rs
+++ b/drivers/ax-driver/src/pci/fdt/rk3588/resources.rs
@@ -366,7 +366,7 @@ fn enable_vpcie3v3_supply(supply: Option<Phandle>) -> Result<(), OnProbeError> {
         .map_err(|err| OnProbeError::other(format!("failed to lock PinctrlDevice: {err}")))?;
     FdtPinctrl::apply_fixed_regulator(
         &mut *pinctrl,
-        &fdt,
+        fdt,
         regulator.as_node(),
         &RockchipFdtPinctrlParser,
         "rk3588-pcie-regulator",

--- a/drivers/ax-driver/src/pci/fdt/rk3588/windows.rs
+++ b/drivers/ax-driver/src/pci/fdt/rk3588/windows.rs
@@ -92,8 +92,8 @@ pub(super) fn prop_str_list(node: &Node, prop_name: &str) -> Vec<String> {
         .unwrap_or_default()
 }
 
-pub(super) fn live_fdt() -> Result<Fdt, OnProbeError> {
-    rdrive::with_fdt(Clone::clone).ok_or_else(|| OnProbeError::other("live FDT not found"))
+pub(super) fn live_fdt() -> Result<&'static Fdt, OnProbeError> {
+    rdrive::fdt_ref().ok_or_else(|| OnProbeError::other("live FDT not found"))
 }
 
 pub(super) fn align_up_4k(size: usize) -> usize {

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
@@ -305,8 +305,8 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     Ok(())
 }
 
-fn live_fdt() -> Result<Fdt, OnProbeError> {
-    rdrive::with_fdt(Clone::clone).ok_or_else(|| OnProbeError::other("live FDT not found"))
+fn live_fdt() -> Result<&'static Fdt, OnProbeError> {
+    rdrive::fdt_ref().ok_or_else(|| OnProbeError::other("live FDT not found"))
 }
 
 fn map_phandle_reg(

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl.rs
@@ -95,7 +95,7 @@ impl RockchipPinCtrl {
         let node_name = node.name().to_string();
         FdtPinctrl::apply_fixed_regulator(
             self,
-            &fdt,
+            fdt,
             node.as_node(),
             &RockchipFdtPinctrlParser,
             "rockchip-fixed-regulator",
@@ -251,7 +251,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
         .ok_or_else(|| {
             OnProbeError::other(format!("[{}] has no rockchip,grf", info.node.name()))
         })?;
-    let ioc = map_phandle_reg(&fdt, grf_phandle, "pinctrl rockchip,grf")?;
+    let ioc = map_phandle_reg(fdt, grf_phandle, "pinctrl rockchip,grf")?;
 
     let mut gpio_banks = [None; GPIO_BANK_COUNT];
     for node in fdt.find_compatible(&["rockchip,gpio-bank"]) {
@@ -288,7 +288,7 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
                 .get_property("rockchip,sys-grf")
                 .and_then(|prop| prop.get_u32())
                 .map(Phandle::from)
-                .map(|phandle| map_phandle_reg(&fdt, phandle, "pinctrl rockchip,sys-grf"))
+                .map(|phandle| map_phandle_reg(fdt, phandle, "pinctrl rockchip,sys-grf"))
                 .transpose()?;
             PinCtrl::new_rk3576(ioc, sys_grf, &gpio_banks)
         }
@@ -467,7 +467,7 @@ mod tests {
 
         FdtPinctrl::apply_state_from_consumer(
             &mut controller,
-            &fdt,
+            fdt,
             fdt.node(consumer).unwrap(),
             0,
             &RockchipFdtPinctrlParser,
@@ -541,7 +541,7 @@ mod tests {
 
         FdtPinctrl::apply_fixed_regulator(
             &mut controller,
-            &fdt,
+            fdt,
             fdt.node(regulator).unwrap(),
             &RockchipFdtPinctrlParser,
             "test-sd-regulator",

--- a/drivers/ax-driver/src/usb/dwc.rs
+++ b/drivers/ax-driver/src/usb/dwc.rs
@@ -426,8 +426,8 @@ fn has_prop(node: &Node, names: &[&str]) -> bool {
     names.iter().any(|name| node.get_property(name).is_some())
 }
 
-fn live_fdt() -> Result<Fdt, OnProbeError> {
-    rdrive::with_fdt(Clone::clone).ok_or_else(|| OnProbeError::other("live FDT not found"))
+fn live_fdt() -> Result<&'static Fdt, OnProbeError> {
+    rdrive::fdt_ref().ok_or_else(|| OnProbeError::other("live FDT not found"))
 }
 
 fn map_phandle_reg(

--- a/drivers/ax-driver/src/usb/dwc.rs
+++ b/drivers/ax-driver/src/usb/dwc.rs
@@ -112,18 +112,17 @@ fn probe(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
     }
 
     let fdt = live_fdt()?;
-    let resources = collect_resources(info, &fdt)?;
+    let resources = collect_resources(info, fdt)?;
 
     enable_clocks(&resources.clocks)?;
 
     let ctrl = map_reg(resources.ctrl)?;
     let phy = map_reg(resources.usbdp.reg)?;
-    let u2phy_grf = map_phandle_reg(&fdt, resources.usbdp.u2phy_grf, "rockchip,u2phy-grf")?;
-    let usb_grf = map_phandle_reg(&fdt, resources.usbdp.usb_grf, "rockchip,usb-grf")?;
-    let usbdpphy_grf =
-        map_phandle_reg(&fdt, resources.usbdp.usbdpphy_grf, "rockchip,usbdpphy-grf")?;
-    let vo_grf = map_phandle_reg(&fdt, resources.usbdp.vo_grf, "rockchip,vo-grf")?;
-    let usb2phy_grf = map_phandle_reg(&fdt, resources.usb2.grf, "usb2phy-grf")?;
+    let u2phy_grf = map_phandle_reg(fdt, resources.usbdp.u2phy_grf, "rockchip,u2phy-grf")?;
+    let usb_grf = map_phandle_reg(fdt, resources.usbdp.usb_grf, "rockchip,usb-grf")?;
+    let usbdpphy_grf = map_phandle_reg(fdt, resources.usbdp.usbdpphy_grf, "rockchip,usbdpphy-grf")?;
+    let vo_grf = map_phandle_reg(fdt, resources.usbdp.vo_grf, "rockchip,vo-grf")?;
+    let usb2phy_grf = map_phandle_reg(fdt, resources.usb2.grf, "usb2phy-grf")?;
 
     let usb2_port = Usb2PhyPortId::from_node_name(&resources.usb2.port_name).ok_or_else(|| {
         OnProbeError::other(format!(

--- a/drivers/rdrive/Cargo.toml
+++ b/drivers/rdrive/Cargo.toml
@@ -36,6 +36,9 @@ x86.workspace = true
 
 [features]
 axtest = ["dep:axtest"]
+# Pull ax-sync's std Spin/RwLock impls so the crate's host tests link off-target
+# under `cargo xtask test`.
+host-test = ["ax-sync/host-test"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(axtest)'] }

--- a/drivers/rdrive/src/lib.rs
+++ b/drivers/rdrive/src/lib.rs
@@ -295,6 +295,17 @@ pub fn with_fdt<T>(f: impl FnOnce(&Fdt) -> T) -> Option<T> {
     probe::fdt::try_system().map(|system| f(system.fdt()))
 }
 
+/// Borrow the live device tree for the lifetime of the program.
+///
+/// The FDT is parsed once at init and never mutated, so this hands out a
+/// `'static` reference with no lock and no copy. Prefer this over
+/// `with_fdt(Clone::clone)`, which deep-copies the entire blob on every call —
+/// a real cost when hot paths (e.g. concurrent device probes resolving phandles)
+/// call it repeatedly.
+pub fn fdt_ref() -> Option<&'static Fdt> {
+    probe::fdt::try_system().map(|system| system.fdt())
+}
+
 /// Macro for generating a driver module.
 ///
 /// This macro automatically generates a driver registration module that creates a static

--- a/drivers/rdrive/tests/fdt_ref.rs
+++ b/drivers/rdrive/tests/fdt_ref.rs
@@ -1,0 +1,37 @@
+use core::ptr::NonNull;
+
+use fdt_edit::Fdt;
+use rdrive::{Platform, with_fdt};
+
+/// `fdt_ref()` hands out a stable `'static` borrow of the parsed device tree
+/// with no per-call clone, and is `None` before any FDT source is initialized.
+#[test]
+fn fdt_ref_borrows_without_cloning() {
+    // Nothing to borrow before an FDT source is installed.
+    assert!(rdrive::fdt_ref().is_none());
+
+    // Install a minimal FDT (mirrors tests/fdt_probe.rs).
+    let fdt = Fdt::new();
+    let encoded = fdt.encode();
+    let dtb = Box::leak(encoded.as_ref().to_vec().into_boxed_slice());
+    rdrive::init(Platform::Fdt {
+        addr: NonNull::new(dtb.as_mut_ptr()).unwrap(),
+    })
+    .expect("FDT platform should initialize");
+
+    // After init the borrow is available, and repeated calls return the SAME
+    // tree — proving it borrows the parse-once device tree rather than deep-
+    // copying the ~hundreds-of-KiB blob on every call.
+    let a = rdrive::fdt_ref().expect("fdt_ref after init");
+    let b = rdrive::fdt_ref().expect("fdt_ref after init");
+    assert!(
+        core::ptr::eq(a, b),
+        "fdt_ref must borrow, not clone, the device tree"
+    );
+
+    // It is the same underlying tree that `with_fdt` exposes, so switching a
+    // consumer from `with_fdt(Clone::clone)` to `fdt_ref()` is semantics-
+    // preserving.
+    let same = with_fdt(|f| core::ptr::eq(f, a)).expect("with_fdt after init");
+    assert!(same, "fdt_ref and with_fdt must borrow the same tree");
+}

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -255,7 +255,7 @@ fn run_std_tests<R: CargoRunner>(
 fn package_feature_profiles(package: &str) -> Option<&'static [PackageFeatureProfile]> {
     match package {
         "arm_vgic" | "axdevice" | "axfs-ng-vfs" | "rsext4" | "scope-local" | "ax-sync" | "axvm"
-        | "ax-display" | "ax-input" | "ax-ipi" | "ax-log" | "ax-runtime" | "ax-api" => {
+        | "ax-display" | "ax-input" | "ax-ipi" | "ax-log" | "ax-runtime" | "ax-api" | "rdrive" => {
             Some(HOST_TEST_FEATURE_PROFILES)
         }
         "ax-task" => Some(AX_TASK_FEATURE_PROFILES),

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -31,6 +31,7 @@ ax-timer-list
 ax-alloc
 ax-display
 ax-driver
+rdrive
 ax-hal
 ax-sync
 ax-task


### PR DESCRIPTION
## 问题
`live_fdt()` 通过 `with_fdt(Clone::clone)` 每次深拷贝整棵约数百 KiB 的扁平设备树；FDT 解析一次且不再修改，热路径（并发设备 probe 解析 phandle）反复调用代价可观。

## 改动
新增 `rdrive::fdt_ref() -> &'static Fdt`（无锁、无拷贝借用），并把 RK3588 PCIe / pinctrl / DWC-USB 三处 `live_fdt` 切到它；同步清理由此产生的 `clippy::needless_borrow`（`&fdt`→`fdt`）。

## 逻辑
`System` 由 `OnceLock` 持有、`fdt(&self)->&Fdt`，故可安全给出 `'static` 借用。

## 测试
`drivers/rdrive/tests/fdt_ref.rs`：init 前为 None、init 后两次调用返回同一指针(不拷贝)、与 `with_fdt` 借用同一棵树；并把 `rdrive` 接入 `std_crates.csv` + host-test profile。板级验证 Rockchip 三处 probe 仍成功。