### PR TITLE
fix(arm-gic-driver): handle implicit GICv2 uniprocessor targets

### DIFF
--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -221,6 +221,13 @@ work even when the kernel image and CPU topology are correct.
   For that implicit route, leave SPI targets untouched and use the SGI
   self-filter instead of inventing a CPU bit. SMP must fail discovery when no
   unique target bit exists.
+- Keep the AArch64 QEMU multiprocessor regression on
+  `virt,gic-version=2` with SMP4 and run
+  `cargo xtask arceos test qemu --arch aarch64 --test-group rust --test-case task-ipi`.
+  The case must verify a
+  self-SGI is claimed and that callbacks sent from other CPUs execute only on
+  the selected remote CPU. This explicit-target test complements, but does not
+  replace, the driver unit regression for the GICv2 uniprocessor RAZ/WI route.
 - The RK3576 CRU node must be `rockchip,rk3576-cru` at `0x2720_0000`, size
   `0x50000`. Early driver evidence should include
   `RK3576 CRU reg: addr=0x27200000, size=0x50000` followed by

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -213,9 +213,14 @@ work even when the kernel image and CPU topology are correct.
   from dense logical CPU indices. Both the maintained single-core board test
   and an eight-core boot have been validated.
 - GICv2 CPU target bits are firmware/controller interface IDs, not dense
-  logical CPU indices. Record each CPU's banked `GICD_ITARGETSR0` mask during
-  per-CPU initialization and reuse that mask for SPI affinity, AxVM-assigned
-  physical SPIs, and SGIs.
+  logical CPU indices. Scan all 32 banked private `GICD_ITARGETSR` bytes during
+  per-CPU initialization and record the unique one-hot mask in the shared route table
+  used by SPI affinity, AxVM-assigned physical SPIs, and SGIs. A zero mask is
+  valid only when `GICD_TYPER.CPUNumber` reports a uniprocessor controller whose
+  target registers are RAZ/WI; the OS runtime CPU limit alone is not sufficient.
+  For that implicit route, leave SPI targets untouched and use the SGI
+  self-filter instead of inventing a CPU bit. SMP must fail discovery when no
+  unique target bit exists.
 - The RK3576 CRU node must be `rockchip,rk3576-cru` at `0x2720_0000`, size
   `0x50000`. Early driver evidence should include
   `RK3576 CRU reg: addr=0x27200000, size=0x50000` followed by

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,7 +520,12 @@ jobs:
           - name: Test starry aarch64 qemu
             use_container: true
             runs_on: '["ubuntu-latest"]'
-            command: target/debug/tg-xtask starry test qemu --arch aarch64
+            command: |
+              echo "==> starry aarch64 GICv2 boot"
+              target/debug/tg-xtask starry qemu --arch aarch64 \
+                --qemu-config os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml
+              echo "==> starry aarch64 test suites"
+              target/debug/tg-xtask starry test qemu --arch aarch64
             cache_key: test-starry-aarch64
             container_image: base
             apk_region: us
@@ -565,11 +570,16 @@ jobs:
             container_image: base
             limit_to_owner: ""
             main_pr_only: false
-          - name: Test arceos aarch64 qemu
+          - name: Test arceos aarch64 qemu (app + suites)
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
-            command: cargo xtask arceos test qemu --arch aarch64
+            command: |
+              echo "==> arceos aarch64 default app boot"
+              cargo xtask arceos qemu --arch aarch64 \
+                --qemu-config os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
+              echo "==> arceos aarch64 test suites"
+              cargo xtask arceos test qemu --arch aarch64
             cache_key: ""
             container_image: base
             limit_to_owner: ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -521,8 +521,8 @@ jobs:
             use_container: true
             runs_on: '["ubuntu-latest"]'
             command: |
-              echo "==> starry aarch64 GICv2 boot"
-              target/debug/tg-xtask starry qemu --arch aarch64 \
+              echo "==> starry aarch64 GICv2 SMP4 boot"
+              target/debug/tg-xtask starry qemu --arch aarch64 --smp 4 \
                 --qemu-config os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml
               echo "==> starry aarch64 test suites"
               target/debug/tg-xtask starry test qemu --arch aarch64
@@ -575,10 +575,10 @@ jobs:
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
             command: |
-              echo "==> arceos aarch64 default app boot"
-              cargo xtask arceos qemu --arch aarch64 \
+              echo "==> arceos aarch64 GICv2 SMP4 default app boot"
+              cargo xtask arceos qemu --arch aarch64 --smp 4 \
                 --qemu-config os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
-              echo "==> arceos aarch64 test suites"
+              echo "==> arceos aarch64 test suites (Rust GICv2 SMP4 IPI + C GICv3 SMP4)"
               cargo xtask arceos test qemu --arch aarch64
             cache_key: ""
             container_image: base

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "log",
  "paste",
  "rdif-intc",
+ "thiserror 2.0.20",
  "tock-registers 0.10.1",
 ]
 

--- a/drivers/intc/arm-gic-driver/Cargo.toml
+++ b/drivers/intc/arm-gic-driver/Cargo.toml
@@ -27,6 +27,7 @@ log = "0.4"
 bitflags = "2.9"
 paste = "1"
 rdif-intc = {workspace = true, optional = true}
+thiserror.workspace = true
 
 [target.'cfg(target_arch = "aarch64")'.dependencies]
 aarch64-cpu = "11"

--- a/drivers/intc/arm-gic-driver/src/version/v2/gicd.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v2/gicd.rs
@@ -186,6 +186,10 @@ impl DistributorReg {
         (it_lines_number + 1) * 32
     }
 
+    pub(crate) fn cpu_interface_count(&self) -> usize {
+        self.TYPER.read(TYPER::CPUNumber) as usize + 1
+    }
+
     pub fn set_cfg(&self, id: IntId, cfg: Trigger) {
         let int_num = id.to_u32();
         let reg_index = (int_num / 16) as usize;

--- a/drivers/intc/arm-gic-driver/src/version/v2/mod.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v2/mod.rs
@@ -1,7 +1,7 @@
 use core::{
     hint::spin_loop,
     ptr::NonNull,
-    sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
+    sync::atomic::{AtomicBool, AtomicU16, AtomicUsize, Ordering},
 };
 
 use log::trace;
@@ -96,6 +96,15 @@ impl Gic {
         self.cpu_targets?.for_hardware_cpu(hardware_cpu_id)
     }
 
+    /// Returns the target capability associated with a host hardware CPU identifier.
+    pub fn cpu_interface_target_for_hardware_cpu(
+        &self,
+        hardware_cpu_id: usize,
+    ) -> Option<CpuInterfaceTarget> {
+        self.cpu_targets?
+            .cpu_interface_target_for_hardware_cpu(hardware_cpu_id)
+    }
+
     fn gicd(&self) -> &DistributorReg {
         unsafe { &*(self.gicd.as_ptr()) }
     }
@@ -136,14 +145,31 @@ impl Gic {
         })
     }
 
-    /// Initialize the GIC according to GICv2 specification
-    /// This includes both Distributor and CPU Interface initialization
+    /// Initializes the GIC according to the GICv2 specification.
+    ///
+    /// This includes both Distributor and CPU Interface initialization. Use
+    /// [`Self::try_init`] when target-discovery failures must be reported to a
+    /// platform probe instead of treated as a one-time initialization failure.
     pub fn init(&mut self) {
+        self.try_init()
+            .unwrap_or_else(|error| panic!("failed to discover boot GICv2 CPU target: {error}"));
+    }
+
+    /// Discovers the boot CPU-interface target and initializes the GIC.
+    ///
+    /// Target discovery runs before the Distributor is disabled, so an error
+    /// leaves the controller untouched.
+    pub fn try_init(&mut self) -> Result<CpuInterfaceTarget, CpuTargetDiscoveryError> {
+        let boot_target = self.cpu_interface().discover_target()?;
+        self.init_with_target(boot_target);
+        Ok(boot_target)
+    }
+
+    fn init_with_target(&mut self, boot_target: CpuInterfaceTarget) {
         trace!(
             "Initializing GICv2 Distributor@{:#p}...",
             self.gicd.as_ptr::<u8>()
         );
-        let bsp_target = self.cpu_interface().current_cpu_target();
         // 1. Disable the Distributor first
         self.gicd().disable();
 
@@ -167,11 +193,13 @@ impl Gic {
         self.gicd().set_default_spi_priorities(max_spi);
 
         // 8. Configure interrupt targets (for SPIs)
-        self.gicd().configure_interrupt_targets(max_spi, bsp_target);
-        trace!(
-            "[GICv2] Configure all SPIs to target BSP mask {:#04x}",
-            bsp_target.as_u8()
-        );
+        if let CpuInterfaceTarget::Explicit(target) = boot_target {
+            self.gicd().configure_interrupt_targets(max_spi, target);
+            trace!(
+                "[GICv2] Configure all SPIs to target BSP mask {:#04x}",
+                target.as_u8()
+            );
+        }
         // 9. Configure interrupt configuration (edge/level trigger)
         self.gicd().configure_interrupt_config(max_spi);
 
@@ -224,6 +252,16 @@ impl Gic {
             "Invalid interrupt ID for target: {id:?}"
         );
         self.gicd().ITARGETSR[index].set(target_list.as_u8());
+    }
+
+    /// Routes an SPI through the target capability discovered for one CPU interface.
+    ///
+    /// Uniprocessor GICs route SPIs to their sole CPU interface implicitly and
+    /// expose `GICD_ITARGETSR` as RAZ/WI, so no register write is required.
+    pub fn route_interrupt_to_cpu(&self, id: IntId, target: CpuInterfaceTarget) {
+        if let CpuInterfaceTarget::Explicit(target) = target {
+            self.set_target_cpu(id, target);
+        }
     }
 
     pub fn get_target_cpu(&self, id: IntId) -> TargetList {
@@ -326,13 +364,22 @@ pub enum SGITarget {
 }
 
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub struct TargetList(u8);
 
 impl TargetList {
     /// Creates a target list from the CPU target mask reported by GICv2.
     pub const fn from_raw(raw: u8) -> Self {
         Self(raw)
+    }
+
+    /// Creates a target list only when the controller reported one interface bit.
+    pub const fn from_one_hot(raw: u8) -> Option<Self> {
+        if raw.count_ones() == 1 {
+            Some(Self(raw))
+        } else {
+            None
+        }
     }
 
     /// Create a new TargetList with a specific CPU target list. list is Cpu interface IDs.
@@ -350,7 +397,7 @@ impl TargetList {
         self.0 |= 1 << cpu; // Set bit for the target CPU
     }
 
-    pub fn as_u8(&self) -> u8 {
+    pub const fn as_u8(&self) -> u8 {
         self.0
     }
 
@@ -359,35 +406,57 @@ impl TargetList {
     }
 }
 
+/// The target-list capability exposed by one GICv2 CPU interface.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CpuInterfaceTarget {
+    /// A uniprocessor controller makes ITARGETSR read-as-zero/write-ignored.
+    ImplicitUniprocessor,
+    /// The controller reports one implementation-defined target-list bit.
+    Explicit(TargetList),
+}
+
+/// Failure to discover one usable GICv2 CPU-interface target.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum CpuTargetDiscoveryError {
+    /// The banked target registers exposed no unique interface bit.
+    #[error("banked GICv2 target registers did not expose one unique CPU-interface bit")]
+    MissingOrAmbiguous,
+}
+
 const MAX_CPU_INTERFACES: usize = 8;
-const TARGET_INITIALIZING: u8 = u8::MAX;
+const TARGET_UNPUBLISHED: u16 = 0;
+const TARGET_IMPLICIT_UNIPROCESSOR: u16 = 1 << u8::BITS;
+const TARGET_INITIALIZING: u16 = u16::MAX;
 
 struct CpuTargetRoute {
     hardware_cpu_id: AtomicUsize,
-    target: AtomicU8,
+    target: AtomicU16,
 }
 
 impl CpuTargetRoute {
     const fn empty() -> Self {
         Self {
             hardware_cpu_id: AtomicUsize::new(0),
-            target: AtomicU8::new(0),
+            target: AtomicU16::new(TARGET_UNPUBLISHED),
         }
     }
 }
 
 /// Error returned when registering a GICv2 CPU-interface route.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum CpuTargetMapError {
     /// The logical CPU does not fit the eight GICv2 target bits.
+    #[error("logical CPU does not fit the eight GICv2 CPU interfaces")]
     InvalidLogicalCpu,
     /// A banked target must contain exactly one CPU-interface bit.
+    #[error("GICv2 route must contain exactly one CPU-interface target")]
     InvalidTarget,
     /// The logical CPU, hardware CPU, or target bit is already mapped differently.
+    #[error("GICv2 logical CPU, hardware CPU, or target is already mapped differently")]
     ConflictingRoute,
 }
 
-/// GICv2 CPU-interface routes discovered from banked `GICD_ITARGETSR0` values.
+/// GICv2 CPU-interface routes discovered from banked private `GICD_ITARGETSR` values.
 pub struct CpuTargetMap {
     registration_lock: AtomicBool,
     routes: [CpuTargetRoute; MAX_CPU_INTERFACES],
@@ -415,13 +484,31 @@ impl CpuTargetMap {
         hardware_cpu_id: usize,
         target: TargetList,
     ) -> Result<(), CpuTargetMapError> {
-        let target = target.as_u8();
+        self.record_cpu_interface_target(
+            logical_cpu,
+            hardware_cpu_id,
+            CpuInterfaceTarget::Explicit(target),
+        )
+    }
+
+    /// Records one logical/hardware CPU association with its target capability.
+    pub fn record_cpu_interface_target(
+        &self,
+        logical_cpu: usize,
+        hardware_cpu_id: usize,
+        target: CpuInterfaceTarget,
+    ) -> Result<(), CpuTargetMapError> {
         if logical_cpu >= MAX_CPU_INTERFACES {
             return Err(CpuTargetMapError::InvalidLogicalCpu);
         }
-        if !target.is_power_of_two() {
+        let target_is_valid = match target {
+            CpuInterfaceTarget::ImplicitUniprocessor => logical_cpu == 0,
+            CpuInterfaceTarget::Explicit(target) => target.as_u8().is_power_of_two(),
+        };
+        if !target_is_valid {
             return Err(CpuTargetMapError::InvalidTarget);
         }
+        let target = encode_cpu_target(target);
 
         while self
             .registration_lock
@@ -439,11 +526,11 @@ impl CpuTargetMap {
         &self,
         logical_cpu: usize,
         hardware_cpu_id: usize,
-        target: u8,
+        target: u16,
     ) -> Result<(), CpuTargetMapError> {
         for (index, route) in self.routes.iter().enumerate() {
             let existing_target = route.target.load(Ordering::Acquire);
-            if existing_target == 0 || existing_target == TARGET_INITIALIZING {
+            if existing_target == TARGET_UNPUBLISHED || existing_target == TARGET_INITIALIZING {
                 continue;
             }
             let existing_hardware_cpu = route.hardware_cpu_id.load(Ordering::Relaxed);
@@ -453,6 +540,11 @@ impl CpuTargetMap {
                 } else {
                     Err(CpuTargetMapError::ConflictingRoute)
                 };
+            }
+            if existing_target == TARGET_IMPLICIT_UNIPROCESSOR
+                || target == TARGET_IMPLICIT_UNIPROCESSOR
+            {
+                return Err(CpuTargetMapError::ConflictingRoute);
             }
             if existing_hardware_cpu == hardware_cpu_id || existing_target == target {
                 return Err(CpuTargetMapError::ConflictingRoute);
@@ -470,19 +562,62 @@ impl CpuTargetMap {
 
     /// Looks up the target bit for a host logical CPU index.
     pub fn for_logical_cpu(&self, logical_cpu: usize) -> Option<TargetList> {
+        match self.cpu_interface_target_for_logical_cpu(logical_cpu)? {
+            CpuInterfaceTarget::Explicit(target) => Some(target),
+            CpuInterfaceTarget::ImplicitUniprocessor => None,
+        }
+    }
+
+    /// Looks up the target capability for a host logical CPU index.
+    pub fn cpu_interface_target_for_logical_cpu(
+        &self,
+        logical_cpu: usize,
+    ) -> Option<CpuInterfaceTarget> {
         let target = self.routes.get(logical_cpu)?.target.load(Ordering::Acquire);
-        (target != 0 && target != TARGET_INITIALIZING).then(|| TargetList::from_raw(target))
+        decode_cpu_target(target)
     }
 
     /// Looks up the target bit for a host hardware CPU identifier.
     pub fn for_hardware_cpu(&self, hardware_cpu_id: usize) -> Option<TargetList> {
+        match self.cpu_interface_target_for_hardware_cpu(hardware_cpu_id)? {
+            CpuInterfaceTarget::Explicit(target) => Some(target),
+            CpuInterfaceTarget::ImplicitUniprocessor => None,
+        }
+    }
+
+    /// Looks up the target capability for a host hardware CPU identifier.
+    pub fn cpu_interface_target_for_hardware_cpu(
+        &self,
+        hardware_cpu_id: usize,
+    ) -> Option<CpuInterfaceTarget> {
         self.routes.iter().find_map(|route| {
             let target = route.target.load(Ordering::Acquire);
-            (target != 0
-                && target != TARGET_INITIALIZING
-                && route.hardware_cpu_id.load(Ordering::Relaxed) == hardware_cpu_id)
-                .then(|| TargetList::from_raw(target))
+            if route.hardware_cpu_id.load(Ordering::Relaxed) != hardware_cpu_id {
+                return None;
+            }
+            decode_cpu_target(target)
         })
+    }
+}
+
+const fn encode_cpu_target(target: CpuInterfaceTarget) -> u16 {
+    match target {
+        CpuInterfaceTarget::ImplicitUniprocessor => TARGET_IMPLICIT_UNIPROCESSOR,
+        CpuInterfaceTarget::Explicit(target) => target.as_u8() as u16,
+    }
+}
+
+const fn decode_cpu_target(raw: u16) -> Option<CpuInterfaceTarget> {
+    if raw == TARGET_IMPLICIT_UNIPROCESSOR {
+        return Some(CpuInterfaceTarget::ImplicitUniprocessor);
+    }
+    if raw > u8::MAX as u16 {
+        return None;
+    }
+    let raw = raw as u8;
+    match TargetList::from_one_hot(raw) {
+        Some(target) => Some(CpuInterfaceTarget::Explicit(target)),
+        None => None,
     }
 }
 
@@ -495,7 +630,7 @@ impl SGITarget {
 
 #[cfg(test)]
 mod cpu_target_map_tests {
-    use super::{CpuTargetMap, CpuTargetMapError, TargetList};
+    use super::{CpuInterfaceTarget, CpuTargetMap, CpuTargetMapError, TargetList};
 
     #[test]
     fn records_and_looks_up_logical_and_hardware_cpu_routes() {
@@ -504,8 +639,12 @@ mod cpu_target_map_tests {
 
         routes.record(5, 0x102, target).unwrap();
 
-        assert_eq!(routes.for_logical_cpu(5).unwrap().as_u8(), 0x40);
-        assert_eq!(routes.for_hardware_cpu(0x102).unwrap().as_u8(), 0x40);
+        assert_eq!(routes.for_logical_cpu(5), Some(target));
+        assert_eq!(routes.for_hardware_cpu(0x102), Some(target));
+        assert_eq!(
+            routes.cpu_interface_target_for_logical_cpu(5),
+            Some(CpuInterfaceTarget::Explicit(target))
+        );
         assert!(routes.for_logical_cpu(4).is_none());
         assert!(routes.for_hardware_cpu(0x103).is_none());
     }
@@ -527,10 +666,11 @@ mod cpu_target_map_tests {
             Err(CpuTargetMapError::InvalidLogicalCpu)
         );
 
-        routes.record(2, 0x102, TargetList::from_raw(0x80)).unwrap();
-        routes.record(2, 0x102, TargetList::from_raw(0x80)).unwrap();
+        let target_80 = TargetList::from_raw(0x80);
+        routes.record(2, 0x102, target_80).unwrap();
+        routes.record(2, 0x102, target_80).unwrap();
         assert_eq!(
-            routes.record(2, 0x103, TargetList::from_raw(0x80)),
+            routes.record(2, 0x103, target_80),
             Err(CpuTargetMapError::ConflictingRoute)
         );
         assert_eq!(
@@ -538,7 +678,47 @@ mod cpu_target_map_tests {
             Err(CpuTargetMapError::ConflictingRoute)
         );
         assert_eq!(
-            routes.record(3, 0x103, TargetList::from_raw(0x80)),
+            routes.record(3, 0x103, target_80),
+            Err(CpuTargetMapError::ConflictingRoute)
+        );
+    }
+
+    #[test]
+    fn records_only_one_implicit_uniprocessor_route() {
+        let routes = CpuTargetMap::new();
+
+        routes
+            .record_cpu_interface_target(0, 0, CpuInterfaceTarget::ImplicitUniprocessor)
+            .unwrap();
+        assert_eq!(
+            routes.cpu_interface_target_for_logical_cpu(0),
+            Some(CpuInterfaceTarget::ImplicitUniprocessor)
+        );
+        assert_eq!(
+            routes.cpu_interface_target_for_hardware_cpu(0),
+            Some(CpuInterfaceTarget::ImplicitUniprocessor)
+        );
+        assert!(routes.for_logical_cpu(0).is_none());
+        assert!(routes.for_hardware_cpu(0).is_none());
+        assert_eq!(
+            routes.record_cpu_interface_target(1, 1, CpuInterfaceTarget::ImplicitUniprocessor),
+            Err(CpuTargetMapError::InvalidTarget)
+        );
+        assert_eq!(
+            routes.record(1, 1, TargetList::from_raw(0x02)),
+            Err(CpuTargetMapError::ConflictingRoute)
+        );
+
+        let explicit_routes = CpuTargetMap::new();
+        explicit_routes
+            .record(1, 1, TargetList::from_raw(0x02))
+            .unwrap();
+        assert_eq!(
+            explicit_routes.record_cpu_interface_target(
+                0,
+                0,
+                CpuInterfaceTarget::ImplicitUniprocessor
+            ),
             Err(CpuTargetMapError::ConflictingRoute)
         );
     }
@@ -603,7 +783,25 @@ impl CpuInterface {
 
     /// Returns the banked CPU target mask for the current CPU interface.
     pub fn current_cpu_target(&self) -> TargetList {
-        TargetList::from_raw(self.gicd().ITARGETSR[0].get())
+        // The register view is byte-addressed: indices 0..32 cover Linux's
+        // eight banked 32-bit ITARGETSR registers; SPI targets begin at 32.
+        TargetList::from_raw(
+            self.gicd().ITARGETSR[..32]
+                .iter()
+                .fold(0, |mask, target| mask | target.get()),
+        )
+    }
+
+    /// Discovers the current CPU target without inventing a bit for RAZ/WI UP GICs.
+    pub fn discover_target(&self) -> Result<CpuInterfaceTarget, CpuTargetDiscoveryError> {
+        let observed = self.current_cpu_target().as_u8();
+        if let Some(target) = TargetList::from_one_hot(observed) {
+            Ok(CpuInterfaceTarget::Explicit(target))
+        } else if observed == 0 && self.gicd().cpu_interface_count() == 1 {
+            Ok(CpuInterfaceTarget::ImplicitUniprocessor)
+        } else {
+            Err(CpuTargetDiscoveryError::MissingOrAmbiguous)
+        }
     }
 
     /// Initialize the CPU interface for the current CPU
@@ -1288,16 +1486,49 @@ mod tests {
     }
 
     #[test]
-    fn cpu_interface_reads_current_banked_target_mask() {
+    fn cpu_interface_scans_every_banked_target_byte() {
         let mut distributor = std::boxed::Box::new([0u8; 0x1000]);
         let mut cpu_registers = std::boxed::Box::new([0u8; 0x1000]);
         let cpu = CpuInterface {
             gicd: distributor.as_mut_ptr().cast(),
             gicc: cpu_registers.as_mut_ptr().cast(),
         };
-        cpu.gicd().ITARGETSR[0].set(0x40);
+        cpu.gicd().ITARGETSR[0].set(0);
+        cpu.gicd().ITARGETSR[31].set(0x40);
+        cpu.gicd().ITARGETSR[32].set(0x02);
 
         assert_eq!(cpu.current_cpu_target().as_u8(), 0x40);
+    }
+
+    #[test]
+    fn cpu_target_discovery_distinguishes_implicit_up_from_explicit_smp() {
+        let mut distributor = std::boxed::Box::new([0u8; 0x1000]);
+        let mut cpu_registers = std::boxed::Box::new([0u8; 0x1000]);
+        let cpu = CpuInterface {
+            gicd: distributor.as_mut_ptr().cast(),
+            gicc: cpu_registers.as_mut_ptr().cast(),
+        };
+
+        assert_eq!(
+            cpu.discover_target(),
+            Ok(CpuInterfaceTarget::ImplicitUniprocessor)
+        );
+        distributor[4..8].copy_from_slice(&(1u32 << 5).to_ne_bytes());
+        assert_eq!(
+            cpu.discover_target(),
+            Err(CpuTargetDiscoveryError::MissingOrAmbiguous)
+        );
+
+        cpu.gicd().ITARGETSR[29].set(0x04);
+        assert_eq!(
+            cpu.discover_target(),
+            Ok(CpuInterfaceTarget::Explicit(TargetList::from_raw(0x04)))
+        );
+        cpu.gicd().ITARGETSR[31].set(0x02);
+        assert_eq!(
+            cpu.discover_target(),
+            Err(CpuTargetDiscoveryError::MissingOrAmbiguous)
+        );
     }
 
     #[test]
@@ -1314,7 +1545,7 @@ mod tests {
         };
 
         let bsp_target = TargetList::from_raw(0x40);
-        gic.init();
+        assert_eq!(gic.try_init(), Ok(CpuInterfaceTarget::Explicit(bsp_target)));
 
         let regs = gic.gicd();
         assert_eq!(regs.IPRIORITYR[31].get(), 0);
@@ -1326,5 +1557,46 @@ mod tests {
         assert_eq!(regs.ITARGETSR[32].get(), bsp_target.as_u8());
         assert_eq!(regs.ITARGETSR[63].get(), bsp_target.as_u8());
         assert_eq!(regs.ITARGETSR[64].get(), 0);
+    }
+
+    #[test]
+    fn distributor_leaves_implicit_uniprocessor_targets_untouched() {
+        let mut regs = std::boxed::Box::new([0u8; 0x1000]);
+        regs[4..8].copy_from_slice(&1u32.to_ne_bytes());
+        regs[0x820] = 0x55;
+        let mut gic = unsafe {
+            Gic::new(
+                VirtAddr::from(regs.as_mut_ptr()),
+                VirtAddr::from(regs.as_mut_ptr()),
+                None,
+            )
+        };
+
+        gic.init();
+
+        assert_eq!(gic.gicd().ITARGETSR[32].get(), 0x55);
+    }
+
+    #[test]
+    fn interrupt_routing_reuses_explicit_and_implicit_target_semantics() {
+        let mut regs = std::boxed::Box::new([0u8; 0x1000]);
+        let gic = unsafe {
+            Gic::new(
+                VirtAddr::from(regs.as_mut_ptr()),
+                VirtAddr::from(regs.as_mut_ptr()),
+                None,
+            )
+        };
+        let intid = IntId::spi(0);
+        gic.gicd().ITARGETSR[32].set(0x55);
+
+        gic.route_interrupt_to_cpu(intid, CpuInterfaceTarget::ImplicitUniprocessor);
+        assert_eq!(gic.gicd().ITARGETSR[32].get(), 0x55);
+
+        gic.route_interrupt_to_cpu(
+            intid,
+            CpuInterfaceTarget::Explicit(TargetList::from_raw(0x40)),
+        );
+        assert_eq!(gic.gicd().ITARGETSR[32].get(), 0x40);
     }
 }

--- a/os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml
+++ b/os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml
@@ -1,0 +1,21 @@
+args = [
+  "-machine", "virt,gic-version=2",
+  "-m", "512M",
+  "-smp", "1",
+  "-nographic",
+  "-cpu", "cortex-a53",
+  "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+  "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img",
+  "-device", "virtio-net-pci,netdev=net0",
+  "-netdev", "user,id=net0",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "echo STARRY_AARCH64_GICV2_BOOT_PASSED"
+success_regex = ["(?m)^STARRY_AARCH64_GICV2_BOOT_PASSED\\s*$"]
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?m)^lockdep fatal violation\\s*$",
+]
+timeout = 120

--- a/os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml
+++ b/os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml
@@ -1,7 +1,7 @@
 args = [
   "-machine", "virt,gic-version=2",
   "-m", "512M",
-  "-smp", "1",
+  "-smp", "4",
   "-nographic",
   "-cpu", "cortex-a53",
   "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",

--- a/os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
+++ b/os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
@@ -1,0 +1,17 @@
+args = [
+  "-machine", "virt,gic-version=2",
+  "-cpu", "cortex-a72",
+  "-m", "512M",
+  "-smp", "1",
+  "-nographic",
+  "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+  "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/arceos-aarch64-fat32.img",
+  "-device", "virtio-net-pci,netdev=net0",
+  "-netdev", "user,id=net0",
+  "-serial", "mon:stdio",
+]
+uefi = false
+to_bin = true
+success_regex = ["(?m)^Hello, world!\\s*$"]
+fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]
+timeout = 60

--- a/os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
+++ b/os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
@@ -2,7 +2,7 @@ args = [
   "-machine", "virt,gic-version=2",
   "-cpu", "cortex-a72",
   "-m", "512M",
-  "-smp", "1",
+  "-smp", "4",
   "-nographic",
   "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
   "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/arceos-aarch64-fat32.img",

--- a/platforms/somehal/src/arch/aarch64/gic/v2.rs
+++ b/platforms/somehal/src/arch/aarch64/gic/v2.rs
@@ -68,7 +68,11 @@ fn probe_gic(probe: ProbeFdt<'_>) -> Result<(), OnProbeError> {
 
     let mut gic = unsafe { Gic::new(gicd.as_ptr().into(), gicr.as_ptr().into(), hyper) };
     gic.set_cpu_target_map(&CPU_TARGETS);
-    gic.init();
+    gic.try_init().map_err(|error| {
+        OnProbeError::other(format!(
+            "failed to discover boot GICv2 CPU target: {error:?}"
+        ))
+    })?;
     let cpu = gic.cpu_interface();
     let trap = cpu.trap_operations();
     CPU_IF.init(cpu);
@@ -133,26 +137,24 @@ pub fn init_cpu(cpu_idx: usize) {
             cpu.init_current_cpu();
             #[cfg(feature = "hv")]
             cpu.set_eoi_mode_ns(true);
-            cpu.current_cpu_target()
+            discover_cpu_target(cpu).unwrap_or_else(|error| {
+                panic!("failed to discover GICv2 target for logical CPU {cpu_idx}: {error:?}")
+            })
         })
     };
     let hardware_cpu_id = super::hardware_cpu_id(cpu_idx).unwrap_or_else(|error| {
         panic!("failed to resolve hardware ID for logical CPU {cpu_idx}: {error:?}")
     });
     CPU_TARGETS
-        .record(cpu_idx, hardware_cpu_id, target)
+        .record_cpu_interface_target(cpu_idx, hardware_cpu_id, target)
         .unwrap_or_else(|error| {
             panic!(
                 "failed to record GICv2 route for logical CPU {cpu_idx}, hardware CPU \
-                 {hardware_cpu_id:#x}, target {:#04x}: {error:?}",
-                target.as_u8()
+                 {hardware_cpu_id:#x}, target {target:?}: {error:?}"
             )
         });
 
-    debug!(
-        "GICCv2 initialized for logical CPU {cpu_idx}, target mask {:#04x}",
-        target.as_u8()
-    );
+    debug!("GICCv2 initialized for logical CPU {cpu_idx}, target {target:?}");
 }
 
 pub fn irq_set_enable(irq: IrqId, enable: bool) -> Result<(), crate::irq::IrqError> {
@@ -202,7 +204,7 @@ pub fn irq_set_affinity(
     let target_cpu = cpu_target(cpu_id).ok_or(crate::irq::IrqError::InvalidIrq)?;
     super::with_gic_domain::<Gic, _>(irq.domain, |gic| {
         let intid = checked_runtime_intid(irq.hwirq.0, gic.max_intid())?;
-        gic.set_target_cpu(intid, target_cpu);
+        gic.route_interrupt_to_cpu(intid, target_cpu);
         Ok::<(), crate::irq::IrqError>(())
     })??;
     Ok(())
@@ -224,9 +226,11 @@ pub fn send_ipi(raw: usize, target: crate::irq::IpiTarget) -> Result<(), crate::
     let sgi = IntId::sgi(raw);
     let target = match target {
         crate::irq::IpiTarget::Current => SGITarget::Current,
-        crate::irq::IpiTarget::Cpu(cpu) => {
-            SGITarget::TargetList(cpu_target(cpu.0).ok_or(crate::irq::IrqError::InvalidCpu)?)
-        }
+        crate::irq::IpiTarget::Cpu(cpu) => match cpu_target(cpu.0) {
+            Some(CpuInterfaceTarget::Explicit(target)) => SGITarget::TargetList(target),
+            Some(CpuInterfaceTarget::ImplicitUniprocessor) => SGITarget::Current,
+            _ => return Err(crate::irq::IrqError::InvalidCpu),
+        },
     };
     // The relaxed GICD_SGIR write is the IPI doorbell. Publish prior Normal-
     // memory stores before ringing it so the target cannot observe the SGI
@@ -236,6 +240,10 @@ pub fn send_ipi(raw: usize, target: crate::irq::IpiTarget) -> Result<(), crate::
     Ok(())
 }
 
-pub(super) fn cpu_target(cpu_idx: usize) -> Option<TargetList> {
-    CPU_TARGETS.for_logical_cpu(cpu_idx)
+fn discover_cpu_target(cpu: &CpuInterface) -> Result<CpuInterfaceTarget, CpuTargetDiscoveryError> {
+    cpu.discover_target()
+}
+
+pub(super) fn cpu_target(cpu_idx: usize) -> Option<CpuInterfaceTarget> {
+    CPU_TARGETS.cpu_interface_target_for_logical_cpu(cpu_idx)
 }

--- a/scripts/axbuild/src/arceos/test/rust_qemu.rs
+++ b/scripts/axbuild/src/arceos/test/rust_qemu.rs
@@ -443,16 +443,19 @@ BT 0 ip=0x1 fp=0x2
     }
 
     #[test]
-    fn arceos_rust_aarch64_qemu_config_enables_smp_for_ipi_paths() {
+    fn arceos_rust_aarch64_qemu_config_uses_gicv2_smp4_for_ipi_paths() {
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-suit/arceos/rust");
         let qemu_path = root.join("qemu-aarch64.toml");
         let config: QemuConfig =
             toml::from_str(&std::fs::read_to_string(qemu_path).unwrap()).unwrap();
         let smp = qemu_test::smp_from_qemu_arg(&config).unwrap();
+        assert_eq!(smp, 4, "aarch64 GICv2 IPI coverage requires SMP4");
         assert!(
-            smp >= 2,
-            "aarch64 task-ipi, task-smp-online, and task-stack-guard-page require SMP >= 2, got \
-             {smp}"
+            config
+                .args
+                .windows(2)
+                .any(|args| args == ["-machine", "virt,gic-version=2"]),
+            "aarch64 IPI coverage must exercise the GICv2 target-list path"
         );
     }
 

--- a/test-suit/arceos/rust/qemu-aarch64.toml
+++ b/test-suit/arceos/rust/qemu-aarch64.toml
@@ -1,6 +1,6 @@
 args = [
     "-machine",
-    "virt,gic-version=3",
+    "virt,gic-version=2",
     "-m",
     "256M",
     "-cpu",

--- a/test-suit/arceos/rust/src/task/ipi.rs
+++ b/test-suit/arceos/rust/src/task/ipi.rs
@@ -56,15 +56,6 @@ fn counting_callback() {
     EXECUTED_CALLBACKS.fetch_add(1, Ordering::Relaxed);
 }
 
-fn noop_callback() {
-    let target_cpu = TARGET_CPU.load(Ordering::Relaxed);
-    assert_eq!(
-        this_cpu_id(),
-        target_cpu,
-        "IPI callback ran on the wrong CPU"
-    );
-}
-
 unsafe fn counting_hard_call(argument: *mut ()) {
     let expected_cpu = unsafe { *(argument as *const usize) };
     assert_eq!(
@@ -125,15 +116,6 @@ fn verify_self_ipi_delivery(cpu_id: usize) {
     );
 }
 
-fn send_recovery_ipi(target_cpu: usize, sender_cpu: usize) {
-    thread::spawn(move || {
-        pin_current_to_cpu(sender_cpu);
-        ax_ipi::legacy::run_on_cpu(target_cpu, noop_callback).expect("failed to send recovery IPI");
-    })
-    .join()
-    .unwrap();
-}
-
 pub fn run() -> crate::TestResult {
     let cpu_num = thread::available_parallelism().unwrap().get();
     if cpu_num < 2 {
@@ -189,19 +171,12 @@ pub fn run() -> crate::TestResult {
         let expected = sender_cpus.len() * CALLBACKS_PER_SENDER;
         assert_eq!(SENT_CALLBACKS.load(Ordering::Relaxed), expected);
 
-        if !wait_for_callbacks_or_stall(expected) {
-            send_recovery_ipi(target_cpu, sender_cpus[0]);
-            let _ = wait_for_callbacks_or_stall(expected);
-            let executed_after_recovery = EXECUTED_CALLBACKS.load(Ordering::Relaxed);
-            if executed_after_recovery == expected {
-                panic!("IPI callbacks only drained after an extra recovery IPI in round {round}");
-            } else {
-                panic!(
-                    "IPI callbacks stalled at {executed_after_recovery}/{expected} in round \
-                     {round}"
-                );
-            }
-        }
+        assert!(
+            wait_for_callbacks_or_stall(expected),
+            "IPI callbacks stalled at {}/{} in round {round}",
+            EXECUTED_CALLBACKS.load(Ordering::Relaxed),
+            expected
+        );
     }
 
     pin_current_to_cpu(sender_cpus[0]);

--- a/test-suit/arceos/rust/src/task/ipi.rs
+++ b/test-suit/arceos/rust/src/task/ipi.rs
@@ -7,7 +7,7 @@ use std::{
         api::task::{AxCpuMask, ax_set_current_affinity},
         modules::{
             ax_hal::{irq::CpuId, percpu::this_cpu_id},
-            ax_ipi,
+            ax_ipi::{self, IpiNotification},
         },
     },
     println,
@@ -99,6 +99,32 @@ fn wait_for_callbacks_or_stall(expected: usize) -> bool {
     }
 }
 
+fn wait_for_fresh_self_ipi(cpu_id: usize) -> bool {
+    for _ in 0..STALL_POLLS {
+        match ax_ipi::notify_cpu(CpuId(cpu_id)).expect("failed to send self IPI") {
+            IpiNotification::Sent => return true,
+            IpiNotification::Coalesced => {
+                thread::sleep(Duration::from_millis(POLL_INTERVAL_MS));
+            }
+        }
+    }
+    false
+}
+
+fn verify_self_ipi_delivery(cpu_id: usize) {
+    pin_current_to_cpu(cpu_id);
+    // A second fresh send is possible only after the handler claims the first
+    // physical self-SGI; an undelivered edge remains coalesced indefinitely.
+    assert!(
+        wait_for_fresh_self_ipi(cpu_id),
+        "could not send a fresh self IPI to CPU {cpu_id}"
+    );
+    assert!(
+        wait_for_fresh_self_ipi(cpu_id),
+        "self IPI was not claimed on CPU {cpu_id}"
+    );
+}
+
 fn send_recovery_ipi(target_cpu: usize, sender_cpu: usize) {
     thread::spawn(move || {
         pin_current_to_cpu(sender_cpu);
@@ -120,6 +146,8 @@ pub fn run() -> crate::TestResult {
         .take(min(MAX_SENDER_CPUS, cpu_num - 1))
         .collect::<Vec<_>>();
     assert!(!sender_cpus.is_empty(), "need at least one sender CPU");
+
+    verify_self_ipi_delivery(sender_cpus[0]);
 
     for round in 0..TEST_ROUNDS {
         TARGET_CPU.store(target_cpu, Ordering::Relaxed);
@@ -189,6 +217,11 @@ pub fn run() -> crate::TestResult {
     }
     .expect("failed to execute IPI hard call");
     assert_eq!(EXECUTED_HARD_CALLS.load(Ordering::Relaxed), 1);
+
+    println!(
+        "task_ipi: verified self delivery on CPU {} and remote delivery on CPU {target_cpu}",
+        sender_cpus[0]
+    );
 
     Ok(())
 }

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -80,6 +80,14 @@ test-suit/starryos/
 `qemu/system` 是统一的 SMP4 聚合 QEMU case。`qemu/` 根目录只放四架构 build
 config，不放 `qemu-*.toml`。
 
+### AArch64 CI 启动 smoke
+
+AArch64 CI 在运行 `cargo xtask starry test qemu --arch aarch64` 前，会先执行一次
+普通 `starry qemu` 启动，并通过
+`os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml` 显式选择 GICv2 和 SMP1。
+这个 smoke 等待 shell 后输出唯一成功标记，用来覆盖 test-suit 的 GICv3/SMP4
+配置没有覆盖到的普通单核启动路径；它不是 `test-suit/starryos/` 下的可发现 case。
+
 ## qemu/system 聚合
 
 `qemu/system/qemu-*.toml` 共用一次 StarryOS 启动，在 SMP4 配置下运行所有系统类

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -83,10 +83,11 @@ config，不放 `qemu-*.toml`。
 ### AArch64 CI 启动 smoke
 
 AArch64 CI 在运行 `cargo xtask starry test qemu --arch aarch64` 前，会先执行一次
-普通 `starry qemu` 启动，并通过
-`os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml` 显式选择 GICv2 和 SMP1。
-这个 smoke 等待 shell 后输出唯一成功标记，用来覆盖 test-suit 的 GICv3/SMP4
-配置没有覆盖到的普通单核启动路径；它不是 `test-suit/starryos/` 下的可发现 case。
+带 `--smp 4` 的普通 `starry qemu` 启动，并通过
+`os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml` 显式选择 GICv2 和 SMP4。
+这个 smoke 等待四个 CPU 完成启动并进入 shell 后输出唯一成功标记，用来
+覆盖 test-suit 的 GICv3/SMP4 配置没有覆盖到的普通 GICv2 启动路径；它不是
+`test-suit/starryos/` 下的可发现 case。
 
 ## qemu/system 聚合
 

--- a/virtualization/axvm/src/arch/aarch64/gic.rs
+++ b/virtualization/axvm/src/arch/aarch64/gic.rs
@@ -46,12 +46,18 @@ pub(super) fn try_with_gic<T>(
 struct PhysicalSpiSnapshot {
     enabled: bool,
     trigger: Trigger,
-    target: PhysicalSpiTarget,
+    target: PhysicalSpiRegisterTarget,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum PhysicalSpiRegisterTarget {
+    V2(arm_gic_driver::v2::TargetList),
+    V3(Option<arm_gic_driver::v3::Affinity>),
 }
 
 #[derive(Clone, Copy, Debug)]
 enum PhysicalSpiTarget {
-    V2(arm_gic_driver::v2::TargetList),
+    V2(arm_gic_driver::v2::CpuInterfaceTarget),
     V3(Option<arm_gic_driver::v3::Affinity>),
 }
 
@@ -176,14 +182,14 @@ impl GicV3Backend for AxvmVgicBackend {
                 return Some(PhysicalSpiSnapshot {
                     enabled: gic.is_irq_enable(intid),
                     trigger: gic.get_cfg(intid),
-                    target: PhysicalSpiTarget::V2(gic.get_target_cpu(intid)),
+                    target: PhysicalSpiRegisterTarget::V2(gic.get_target_cpu(intid)),
                 });
             }
             if let Some(gic) = gic.typed_mut::<arm_gic_driver::v3::Gic>() {
                 return Some(PhysicalSpiSnapshot {
                     enabled: gic.is_irq_enable(intid),
                     trigger: gic.get_cfg(intid),
-                    target: PhysicalSpiTarget::V3(gic.get_target_cpu(intid)),
+                    target: PhysicalSpiRegisterTarget::V3(gic.get_target_cpu(intid)),
                 });
             }
             None
@@ -337,7 +343,7 @@ fn configure_physical_interrupt(
                 gic.typed_mut::<arm_gic_driver::v2::Gic>().map(|gic| {
                     gic.set_irq_enable(intid, false);
                     gic.set_cfg(intid, expected_trigger);
-                    gic.set_target_cpu(intid, target);
+                    gic.route_interrupt_to_cpu(intid, target);
                 })
             }
             (HostGicVersion::V3, PhysicalSpiTarget::V3(target)) => {
@@ -373,7 +379,7 @@ fn physical_spi_target(
             })?;
             let target = try_with_gic("target assigned physical interrupt", |intc| {
                 intc.typed_mut::<arm_gic_driver::v2::Gic>()
-                    .and_then(|gic| gic.target_for_hardware_cpu(hardware_cpu_id))
+                    .and_then(|gic| gic.cpu_interface_target_for_hardware_cpu(hardware_cpu_id))
             })?
             .ok_or_else(|| {
                 GicV3BackendError::new(
@@ -400,14 +406,14 @@ fn restore_physical_interrupt(
 ) -> Result<(), GicV3BackendError> {
     try_with_gic("restore assigned physical interrupt", |gic| {
         match (version, snapshot.target) {
-            (HostGicVersion::V2, PhysicalSpiTarget::V2(target)) => {
+            (HostGicVersion::V2, PhysicalSpiRegisterTarget::V2(target)) => {
                 gic.typed_mut::<arm_gic_driver::v2::Gic>().map(|gic| {
                     gic.set_cfg(intid, snapshot.trigger);
                     gic.set_target_cpu(intid, target);
                     gic.set_irq_enable(intid, snapshot.enabled);
                 })
             }
-            (HostGicVersion::V3, PhysicalSpiTarget::V3(target)) => {
+            (HostGicVersion::V3, PhysicalSpiRegisterTarget::V3(target)) => {
                 gic.typed_mut::<arm_gic_driver::v3::Gic>().map(|gic| {
                     gic.set_cfg(intid, snapshot.trigger);
                     gic.set_target_cpu(intid, target);


### PR DESCRIPTION
## 问题

#1803 在初始化 GICv2 时把 banked `GICD_ITARGETSR` 读值作为显式 CPU target，并要求它是 one-hot。GICv2 单处理器实现中，这组 target 寄存器是 RAZ/WI，QEMU 的单核 GICv2 因此读回 `0`；原逻辑随后把 `0` 注册到 CPU route map 并在 `unwrap` 处失败，导致 ArceOS 普通应用启动挂起、StarryOS 普通启动 panic。

这里不能简单回退到固定 `0x01`：单处理器下写 target 无效，多处理器下则可能猜错实现定义的 CPU interface ID。

## 修改

- 用 `CpuInterfaceTarget::{ImplicitUniprocessor, Explicit}` 表达 GICv2 的两种路由能力。
- 扫描全部 32 个 banked private `GICD_ITARGETSR` byte；只有唯一 one-hot mask 才作为显式 target。
- 仅当 mask 为 `0` 且 `GICD_TYPER.CPUNumber` 表明控制器只有一个 CPU interface 时，识别为隐式单处理器路由；不能只根据 OS 当前启动一个 CPU 推断。
- 隐式路由下保持 SPI target 寄存器不变，SPI affinity 作为 no-op，定向到唯一 CPU 的 SGI 使用 self-filter；SMP 控制器缺少唯一 target 时继续明确报错。
- 保留现有 `TargetList` 公共 API，新增 capability API 给 somehal 和 AxVM 使用；route map 禁止隐式单核与显式 SMP route 混用。
- AxVM 分离运行时路由能力和原始 target 寄存器快照，确保分配物理 SPI 时使用正确语义，恢复时仍还原原寄存器值。
- 增加确定性单元回归，覆盖 UP 不写 SPI target、UP/MP 发现、显式/隐式 affinity，以及 route mode 双向互斥。
- 将 ArceOS 和 StarryOS 的普通 AArch64 启动 smoke 调整为显式 `virt,gic-version=2`、SMP4，并在 CI 命令中同时传入 `--smp 4`，确保构建容量和 QEMU vCPU 数一致。
- 将 ArceOS Rust AArch64 QEMU 套件切到 GICv2/SMP4；`task-ipi` 先验证当前 CPU 的 self-SGI 被 claim，再由 CPU0/1/2 向 CPU3 发送回调，并用执行 CPU 断言、同步 hard call 以及无恢复 IPI 的超时断言检测错投、广播或丢失。ArceOS C 套件继续保留 GICv3/SMP4 覆盖。

## 方案依据

GICv2 的单处理器控制器通过唯一 CPU interface 隐式路由中断，`GICD_ITARGETSR` 为 RAZ/WI。因此，target 为零在 UP 控制器上是有效能力描述，不是需要猜测 fallback 的坏值；在 MP 控制器上仍视为发现失败。控制器拓扑以 `GICD_TYPER.CPUNumber` 为准，避免把“MP GIC 但 OS 只启动一个 CPU”错误降级为 UP。

运行时 SMP4 用例验证显式 target-list 路由和本地/远端 IPI；原始 SMP1 隐式路由由最低层确定性单元回归继续覆盖。两者语义互补，不能相互替代。

## 验证

修复前先用等价的 MMIO 回归测试验证旧实现会改写隐式 UP 的 SPI target，测试失败（期望保留 `0x01`，实际变为 `0x00`）；应用修复后同一语义测试通过。

- `cargo fmt --all --check`
- `cargo test -p arm-gic-driver --lib`：13/13 通过
- `cargo xtask clippy --package arm-gic-driver`：3/3 通过
- `cargo xtask clippy --package somehal`：8/8 通过
- `cargo xtask clippy --package axvm`：6/6 通过
- `cargo xtask clippy --package arceos-test-suit`：29/29 通过
- `cargo xtask clippy --package axbuild`：1/1 通过
- `cargo test -p axbuild arceos_rust_aarch64_qemu_config_uses_gicv2_smp4_for_ipi_paths`：通过
- `cargo xtask arceos test qemu --arch aarch64 --test-group rust --test-case task-ipi`：GICv2/SMP4 下四个 CPU 上线，self CPU0 与 remote CPU3 投递均通过
- `cargo xtask arceos qemu --arch aarch64 --smp 4 --qemu-config os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml`：GICv2/SMP4 启动并匹配 `Hello, world!`
- `cargo xtask starry qemu --arch aarch64 --smp 4 --qemu-config os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml`：GICv2/SMP4 进入 shell 并匹配成功标记
- `cargo xtask arceos test qemu --arch aarch64`：Rust GICv2/SMP4 与 C GICv3/SMP4 套件均通过
- `cargo xtask starry test qemu --arch aarch64`：3/3 场景通过，system 423/423 用例通过
- `cargo xtask axvisor build --arch aarch64`：通过

物理板和 self-hosted 流程未在本地执行。

## 相关 PR

开放的 #1596 和 draft #1775 都包含更大范围的 SMP/调度重构，并与 GICv2 target 建模存在部分重叠；当前没有专门关联 #1840 的 PR。本 PR 保持在 GICv2 路由建模和对应 CI 回归范围内，便于独立审查与合入。

Fixes #1840