### PR TITLE
fix(ax-cpu): correct aarch64 TLB maintenance ordering and broadcast scope

### DIFF
--- a/components/axcpu/src/aarch64/asm.rs
+++ b/components/axcpu/src/aarch64/asm.rs
@@ -129,20 +129,29 @@ pub fn flush_tlb(vaddr: Option<VirtAddr>) {
 
         #[cfg(not(feature = "arm-el2"))]
         unsafe {
-            // TLB Invalidate by VA, All ASID, EL1, Inner Shareable
-            asm!("tlbi vaae1is, {}; dsb sy; isb", in(reg) operand)
+            // `dsb ishst` first so the invalidating PTE store (the caller's
+            // break-before-make write) is observable to all cores before the
+            // by-VA TLBI. Without it, a walker on another core can re-cache the
+            // stale entry after the TLBI but before the store lands (ARM ARM
+            // DDI0487, break-before-make). Then TLBI by VA, All ASID, EL1, Inner
+            // Shareable.
+            asm!("dsb ishst; tlbi vaae1is, {}; dsb sy; isb", in(reg) operand)
         }
         #[cfg(feature = "arm-el2")]
         unsafe {
-            // TLB Invalidate by VA, EL2, Inner Shareable
-            asm!("tlbi vae2is, {}; dsb sy; isb", in(reg) operand)
+            // See the EL1 branch: `dsb ishst` orders the PTE store before the
+            // by-VA TLBI. TLBI by VA, EL2, Inner Shareable.
+            asm!("dsb ishst; tlbi vae2is, {}; dsb sy; isb", in(reg) operand)
         }
     } else {
         // flush the entire TLB
         #[cfg(not(feature = "arm-el2"))]
         unsafe {
-            // TLB Invalidate by VMID, All at stage 1, EL1
-            asm!("dsb sy; isb; tlbi vmalle1; dsb sy; isb")
+            // Inner-shareable broadcast (`vmalle1is`, not the CPU-local
+            // `vmalle1`) so sibling cores also drop stale entries; a local-only
+            // full flush leaves other cores translating through freed/replaced
+            // mappings. TLB Invalidate All at stage 1, EL1, Inner Shareable.
+            asm!("dsb sy; isb; tlbi vmalle1is; dsb sy; isb")
         }
         #[cfg(feature = "arm-el2")]
         unsafe {

--- a/components/axcpu/tests/tlb_maintenance_contract.rs
+++ b/components/axcpu/tests/tlb_maintenance_contract.rs
@@ -1,0 +1,47 @@
+//! Guards the aarch64 `flush_tlb` instruction sequences against silent
+//! regression.
+//!
+//! These two sequences are SMP correctness requirements (ARM ARM DDI0487
+//! break-before-make + broadcast invalidation) that a normal single-core build
+//! or run cannot exercise — the hazard only appears when another core caches a
+//! stale translation. So pin the exact instruction strings at the source level,
+//! the same way the sibling `*_contract.rs` tests pin ABI/layout invariants.
+
+/// The aarch64 asm module source. `include_str!` reads it on any host target
+/// (the module itself is `#[cfg(target_arch = "aarch64")]`, but its text is
+/// always present), so this guard runs under `cargo test` on the CI host.
+const AARCH64_ASM_SRC: &str = include_str!("../src/aarch64/asm.rs");
+
+#[test]
+fn by_va_tlbi_orders_the_pte_store_before_the_invalidate() {
+    // `dsb ishst` must precede the by-VA TLBI so the caller's invalidating PTE
+    // store is observable to all cores before the TLBI completes; otherwise a
+    // walker on another core re-caches the stale entry (break-before-make).
+    assert!(
+        AARCH64_ASM_SRC.contains("dsb ishst; tlbi vaae1is"),
+        "the EL1 by-VA TLBI must be preceded by `dsb ishst`"
+    );
+    assert!(
+        AARCH64_ASM_SRC.contains("dsb ishst; tlbi vae2is"),
+        "the EL2 by-VA TLBI must be preceded by `dsb ishst`"
+    );
+}
+
+#[test]
+fn full_el1_flush_is_inner_shareable_broadcast_not_cpu_local() {
+    // The full-flush fallback must broadcast to the inner-shareable domain
+    // (`vmalle1is`); the CPU-local `vmalle1` leaves sibling cores translating
+    // through freed/replaced mappings.
+    assert!(
+        AARCH64_ASM_SRC.contains("tlbi vmalle1is"),
+        "the full EL1 flush must use the inner-shareable broadcast `vmalle1is`"
+    );
+    // Reject any regression back to the CPU-local form, in any spacing. Note
+    // `vmalle1is` never matches these (the char after `vmalle1` is `i`).
+    for local in ["vmalle1;", "vmalle1 ", "vmalle1,"] {
+        assert!(
+            !AARCH64_ASM_SRC.contains(local),
+            "the full EL1 flush must not regress to the CPU-local `vmalle1`"
+        );
+    }
+}

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -33,6 +33,7 @@ ax-display
 ax-driver
 rdrive
 ax-hal
+ax-cpu
 ax-sync
 ax-task
 ax-input


### PR DESCRIPTION
## 问题
`components/axcpu` aarch64 `flush_tlb` 有两处 SMP 正确性缺陷：
1. 按-VA 失效路径 `tlbi vaae1is; dsb sy; isb` 前没有 `dsb`。调用方的 break-before-make PTE 写入可能在另一核观察到之前，TLBI 就已执行完毕——该核随后在 TLBI 之后、写入落地之前重新缓存了旧翻译（ARM ARM DDI0487 break-before-make）。
2. 全量失效兜底用 CPU-本地的 `tlbi vmalle1` 而非广播的 `vmalle1is`，其它核仍通过已释放/替换的映射翻译。该兜底在大范围 unmap/mprotect（超过逐-VA 阈值）与上下文切换处触发。

## 改动
1. 按-VA 失效前置 `dsb ishst`（EL1 与 arm-el2/EL2 两支），保证失效写入先于 TLBI 对所有核可见。
2. 全量兜底 `vmalle1` → `vmalle1is`（Inner Shareable 广播）。

## 逻辑
均为 aarch64 SMP TLB 维护正确性修复，符合 ARM ARM 的 break-before-make 与广播失效要求；单核行为不变。为 break-before-make 类操作（unmap / mprotect 写保护 / COW 断开 / 后续 THP 拆分）提供正确的底层保证。ax-cpu 全特性 clippy 通过。属时序类 SMP 正确性，QEMU-TCG 无法确定性复现，验证以构造正确性 + 板级多核压力为准。