### PR TITLE
fix(page-table-generic): invalidate a reclaimed intermediate table before freeing its frame

### DIFF
--- a/memory/page-table-generic/src/lib.rs
+++ b/memory/page-table-generic/src/lib.rs
@@ -66,7 +66,27 @@ pub trait TableMeta: Sync + Send + Clone + Copy + 'static {
         vaddr
     }
 
-    /// 刷新TLB
+    /// Invalidate the TLB entry for `vaddr` (or the whole TLB when `None`).
+    ///
+    /// # SMP shootdown contract (intermediate-table break-before-free)
+    ///
+    /// [`PageTable::unmap`](crate::PageTable::unmap) reclaims an emptied
+    /// intermediate page-table frame by clearing its parent descriptor, calling
+    /// `flush(Some(vaddr))`, and then returning that frame to the allocator. For
+    /// this to be sound on a multiprocessor, the `flush` at that point MUST be a
+    /// *synchronous, system-wide* invalidation: once it returns, no other CPU
+    /// running this address space may still walk the cleared descriptor or reuse
+    /// a cached translation that reaches the freed frame. Otherwise a remote core
+    /// can table-walk the frame after it has been reallocated and overwritten,
+    /// translating to arbitrary physical memory.
+    ///
+    /// AArch64 `TLBI …; DSB` broadcasts to all PEs and satisfies this natively.
+    /// Architectures whose native invalidation is local to the issuing hart
+    /// (RISC-V `sfence.vma`, x86 `invlpg`) MUST turn this into a remote shootdown
+    /// here — an IPI to every CPU sharing the address space plus a wait for its
+    /// completion — or drive reclaim with `flush: false` and free the reclaimed
+    /// frames externally only after performing that shootdown themselves. A
+    /// hart-local flush alone is NOT a valid break-before-free completion barrier.
     fn flush(vaddr: Option<VirtAddr>);
 }
 

--- a/memory/page-table-generic/src/map.rs
+++ b/memory/page-table-generic/src/map.rs
@@ -257,6 +257,17 @@ where
                     // 子页表完全为空，可以回收
                     // 清除指向子页表的PTE
                     pte_ref.clear();
+                    // Invalidate the TLB for the range this table covered BEFORE
+                    // returning its frame to the allocator. The leaf entries were
+                    // already flushed by the recursive unmap above, but the
+                    // now-cleared parent descriptor / table-walk cache is not — so
+                    // without this a concurrent core can reallocate and write the
+                    // freed frame while a stale walk still reads it as page-table
+                    // entries, translating to arbitrary physical memory. This
+                    // completes break-before-free for the intermediate table.
+                    if config.flush {
+                        T::flush(Some(vaddr));
+                    }
                     allocator.dealloc_frame(child_paddr);
                 } else {
                     // 子页表仍有有效映射，不能回收

--- a/memory/page-table-generic/src/map.rs
+++ b/memory/page-table-generic/src/map.rs
@@ -265,6 +265,13 @@ where
                     // freed frame while a stale walk still reads it as page-table
                     // entries, translating to arbitrary physical memory. This
                     // completes break-before-free for the intermediate table.
+                    //
+                    // On SMP this `T::flush` must be a synchronous, system-wide
+                    // shootdown (see the [`TableMeta::flush`] contract): a
+                    // hart-local flush leaves remote cores able to walk the freed
+                    // frame. Callers whose arch flush cannot broadcast+wait must
+                    // pass `flush: false` and reclaim frames externally after their
+                    // own shootdown.
                     if config.flush {
                         T::flush(Some(vaddr));
                     }

--- a/memory/page-table-generic/tests/reclaim_flush_order.rs
+++ b/memory/page-table-generic/tests/reclaim_flush_order.rs
@@ -1,0 +1,158 @@
+//! Break-before-free ordering for intermediate page-table reclaim.
+//!
+//! When `unmap` empties an intermediate table it returns that frame to the
+//! allocator. The frame's translation must be invalidated from the TLB *before*
+//! it is freed: otherwise a concurrent core can reallocate and overwrite the
+//! frame while a stale table-walk still reads it as page-table entries, mapping
+//! to arbitrary physical memory. These tests record `flush` and `dealloc_frame`
+//! into one ordered log and assert every reclaimed frame is flushed before it is
+//! freed (and that `flush: false` suppresses the flush while still reclaiming).
+
+#![cfg(not(target_os = "none"))]
+
+use std::{
+    alloc::{Layout, alloc, dealloc},
+    sync::Mutex,
+};
+
+use page_table_generic::*;
+
+mod mocks;
+
+use mocks::PteImpl;
+
+/// One entry in the ordered operation log shared by the recording `TableMeta`
+/// and `FrameAllocator` below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Flush,
+    Dealloc(usize),
+}
+
+/// `TableMeta::flush` is a static method with no instance state, so the log has
+/// to be a static. `SERIALIZE` keeps the two tests from interleaving on it.
+static OPS: Mutex<Vec<Op>> = Mutex::new(Vec::new());
+static SERIALIZE: Mutex<()> = Mutex::new(());
+
+/// 4-level table so a single 4 KiB unmap reclaims a *chain* of intermediate
+/// tables (L1, L2, L3) — the chained reclaim is what exposes the missing flush
+/// as back-to-back `Dealloc`s with no `Flush` between them.
+#[derive(Clone, Copy)]
+struct RecordingMeta;
+
+impl TableMeta for RecordingMeta {
+    type P = PteImpl;
+
+    const PAGE_SIZE: usize = 0x1000;
+    const LEVEL_BITS: &[usize] = &[9, 9, 9, 9];
+    const MAX_BLOCK_LEVEL: usize = 3;
+
+    fn flush(vaddr: Option<VirtAddr>) {
+        if vaddr.is_some() {
+            OPS.lock().unwrap().push(Op::Flush);
+        }
+    }
+}
+
+/// Real-backing allocator (so page walks are valid and nothing leaks) that also
+/// records every `dealloc_frame` into the shared ordered log.
+#[derive(Clone, Copy)]
+struct RecordingFram4k;
+
+impl FrameAllocator for RecordingFram4k {
+    fn alloc_frame(&self) -> Option<PhysAddr> {
+        let layout = Layout::from_size_align(4096, 4096).unwrap();
+        let ptr = unsafe { alloc(layout) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(PhysAddr::from_usize(ptr as usize))
+        }
+    }
+
+    fn dealloc_frame(&self, frame: PhysAddr) {
+        OPS.lock().unwrap().push(Op::Dealloc(frame.as_usize()));
+        let layout = Layout::from_size_align(4096, 4096).unwrap();
+        unsafe { dealloc(frame.as_usize() as *mut u8, layout) };
+    }
+
+    fn phys_to_virt(&self, paddr: PhysAddr) -> *mut u8 {
+        paddr.as_usize() as *mut u8
+    }
+}
+
+/// Map a single 4 KiB page, then reset the log and record only the unmap.
+fn map_one_page_then_reset() -> PageTable<RecordingMeta, RecordingFram4k> {
+    let mut page_table = PageTable::<RecordingMeta, RecordingFram4k>::new(RecordingFram4k).unwrap();
+    page_table
+        .map(&MapConfig {
+            vaddr: VirtAddr::from_usize(0x20_0000),
+            paddr: PhysAddr::from_usize(0x20_0000),
+            size: RecordingMeta::PAGE_SIZE,
+            pte: PteImpl::kernel_mode_config(),
+            allow_huge: false,
+            flush: false,
+        })
+        .unwrap();
+    OPS.lock().unwrap().clear();
+    page_table
+}
+
+#[test]
+fn reclaimed_table_is_flushed_before_it_is_freed() {
+    let _guard = SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+    OPS.lock().unwrap().clear();
+
+    let mut page_table = map_one_page_then_reset();
+    page_table
+        .unmap(VirtAddr::from_usize(0x20_0000), RecordingMeta::PAGE_SIZE)
+        .unwrap();
+
+    let ops = OPS.lock().unwrap().clone();
+    let deallocs = ops.iter().filter(|o| matches!(o, Op::Dealloc(_))).count();
+    assert!(
+        deallocs >= 2,
+        "expected the single-page unmap to reclaim a chain of >=2 intermediate tables (otherwise \
+         this test cannot detect the ordering bug), got {deallocs}: {ops:?}"
+    );
+
+    // Break-before-free: every reclaimed frame must be flushed immediately
+    // before it is freed. Without the fix the chained reclaims emit back-to-back
+    // `Dealloc`s, so a `Dealloc` is preceded by another `Dealloc`, not a `Flush`.
+    for (i, op) in ops.iter().enumerate() {
+        if matches!(op, Op::Dealloc(_)) {
+            assert!(
+                i > 0 && ops[i - 1] == Op::Flush,
+                "intermediate table freed without a preceding TLB flush (break-before-free \
+                 violated) at op {i}: {ops:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn reclaim_with_flush_disabled_emits_no_flush() {
+    let _guard = SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+    OPS.lock().unwrap().clear();
+
+    let mut page_table = map_one_page_then_reset();
+    page_table
+        .unmap_with_config(&UnmapConfig {
+            start_vaddr: VirtAddr::from_usize(0x20_0000),
+            size: RecordingMeta::PAGE_SIZE,
+            flush: false,
+        })
+        .unwrap();
+
+    let ops = OPS.lock().unwrap().clone();
+    let deallocs = ops.iter().filter(|o| matches!(o, Op::Dealloc(_))).count();
+    let flushes = ops.iter().filter(|o| matches!(o, Op::Flush)).count();
+    assert!(
+        deallocs >= 2,
+        "reclaim must still free the chained tables when flush is disabled: {ops:?}"
+    );
+    assert_eq!(
+        flushes, 0,
+        "no TLB flush must be emitted when flush is disabled: {ops:?}"
+    );
+}


### PR DESCRIPTION
## 问题
`unmap_range_recursive` 回收一个已空的中间页表时，清除父 PTE 后直接 `dealloc_frame`，中间没有任何 TLB 失效。叶子项在递归 unmap 中已逐一失效，但被清除的父级表描述符 / 表遍历缓存没有失效——在 SMP 上，另一核可能在旧遍历仍把该帧当作页表读取时，重新分配并写入该帧，从而翻译到任意物理内存。

## 改动
在 `dealloc_frame` 之前、`config.flush` 为真时，对该表覆盖范围做一次 `T::flush(Some(vaddr))`（广播失效并完成），与叶子路径一致，为中间表补齐 break-before-free。

## 逻辑
纯 SMP 正确性修复；单核不受影响。将该屏障批量化是可分离的后续性能优化。page-table-generic 全量 clippy + 宿主测试通过；时序类 SMP 正确性以构造正确性 + 板级压力验证。