### PR TITLE
refactor(starry): make per-thread CPU-time state SMP-safe (RefCell -> IrqMutex)

### DIFF
--- a/os/StarryOS/kernel/src/syscall/resources.rs
+++ b/os/StarryOS/kernel/src/syscall/resources.rs
@@ -72,7 +72,7 @@ struct Rusage {
 
 impl Rusage {
     fn from_thread(thread: &Thread) -> Self {
-        let (utime, stime) = thread.time.borrow().output();
+        let (utime, stime) = thread.time.lock().output();
         let max_rss_kb = thread.proc_data.aspace().lock().rss().hiwater_rss_pages()
             * (PAGE_SIZE_4K as u64 / 1024);
         Self {

--- a/os/StarryOS/kernel/src/syscall/time.rs
+++ b/os/StarryOS/kernel/src/syscall/time.rs
@@ -22,7 +22,7 @@ pub fn sys_clock_gettime(clock_id: __kernel_clockid_t, ts: *mut timespec) -> Sta
             monotonic_time()
         }
         CLOCK_PROCESS_CPUTIME_ID | CLOCK_THREAD_CPUTIME_ID => {
-            let (utime, stime) = current().as_thread().time.borrow().output();
+            let (utime, stime) = current().as_thread().time.lock().output();
             utime + stime
         }
         _ => {
@@ -89,7 +89,7 @@ pub struct Tms {
 }
 
 pub fn sys_times(tms: *mut Tms) -> StarryResult<isize> {
-    let (utime, stime) = current().as_thread().time.borrow().output();
+    let (utime, stime) = current().as_thread().time.lock().output();
     let (cutime, cstime) = current().as_thread().proc_data.children_cpu_time();
     tms.vm_write(Tms {
         tms_utime: utime.as_micros() as usize,
@@ -102,7 +102,7 @@ pub fn sys_times(tms: *mut Tms) -> StarryResult<isize> {
 
 pub fn sys_getitimer(which: i32, value: *mut itimerval) -> StarryResult<isize> {
     let ty = ITimerType::from_repr(which).ok_or(StarryError::InvalidInput)?;
-    let (it_interval, it_value) = current().as_thread().time.borrow().get_itimer(ty);
+    let (it_interval, it_value) = current().as_thread().time.lock().get_itimer(ty);
 
     value.vm_write(itimerval {
         it_interval: timeval::from_time_value(it_interval),
@@ -136,7 +136,7 @@ pub fn sys_setitimer(
     let old = curr
         .as_thread()
         .time
-        .borrow_mut()
+        .lock()
         .set_itimer(ty, interval, remained);
 
     if let Some(old_value) = old_value.nullable() {

--- a/os/StarryOS/kernel/src/task/mod.rs
+++ b/os/StarryOS/kernel/src/task/mod.rs
@@ -19,9 +19,7 @@ mod user;
 
 use alloc::{boxed::Box, collections::BTreeMap, string::String, sync::Arc, vec::Vec};
 use core::{
-    cell::RefCell,
     future::poll_fn,
-    ops::Deref,
     sync::atomic::{AtomicBool, AtomicI32, AtomicU8, AtomicU32, AtomicUsize, Ordering},
     task::Poll,
 };
@@ -107,20 +105,6 @@ impl PtraceEventMessage {
 }
 use crate::mm::AddrSpace;
 
-///  A wrapper type that assumes the inner type is `Sync`.
-#[repr(transparent)]
-pub struct AssumeSync<T>(pub T);
-
-unsafe impl<T> Sync for AssumeSync<T> {}
-
-impl<T> Deref for AssumeSync<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
 /// A one-shot flag that suppresses exactly one signal check.
 struct NextSignalCheckBlock(AtomicBool);
 
@@ -172,11 +156,16 @@ pub struct Thread {
     /// The thread-level signal manager
     pub signal: Arc<ThreadSignalManager>,
 
-    /// Time manager
+    /// Time manager.
     ///
-    /// This is assumed to be `Sync` because it's only borrowed mutably during
-    /// context switches, which is exclusive to the current thread.
-    pub time: AssumeSync<RefCell<TimeManager>>,
+    /// An IRQ-disabling spinlock (not a `RefCell`): CPU-time accounting
+    /// borrows this from the timer IRQ / context switch on the thread's own
+    /// CPU, while cross-CPU readers (`getrusage`, `/proc`) and the alarm task
+    /// borrow it from other CPUs. The lock is only ever held for a handful of
+    /// short field updates with no nested lock (itimer signals are returned
+    /// from `poll()` and emitted after unlocking), so it cannot deadlock. IRQ
+    /// / context-switch paths use `try_lock` and skip on contention.
+    pub time: IrqMutex<TimeManager>,
 
     /// The OOM score adjustment value.
     oom_score_adj: AtomicI32,
@@ -294,7 +283,7 @@ impl Thread {
             scope: ContextSwitchRwLock::new(scope),
             clear_child_tid: AtomicUsize::new(0),
             robust_list_head: AtomicUsize::new(0),
-            time: AssumeSync(RefCell::new(TimeManager::new())),
+            time: IrqMutex::new(TimeManager::new()),
             exit: Arc::new(AtomicBool::new(false)),
             exit_started: AtomicBool::new(false),
             oom_score_adj: AtomicI32::new(200),

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -122,8 +122,9 @@ pub fn tick_cpu_time(task: &TaskInner) {
     let Some(thr) = task.try_as_thread() else {
         return;
     };
-    let Ok(mut time) = thr.time.try_borrow_mut() else {
-        // Reentrant borrow means the task is mid-state-transition; skip.
+    let Some(mut time) = thr.time.try_lock() else {
+        // Lock contended (mid state-transition, or a cross-CPU reader/alarm);
+        // skip. Runs from IRQ context, so it must never block.
         return;
     };
     time.tick();
@@ -134,7 +135,9 @@ pub fn task_cpu_time(task: &TaskInner) -> (TimeValue, TimeValue) {
     let Some(thr) = task.try_as_thread() else {
         return (TimeValue::ZERO, TimeValue::ZERO);
     };
-    let Ok(time) = thr.time.try_borrow() else {
+    let Some(time) = thr.time.try_lock() else {
+        // Contended snapshot (the task is mid-accounting on its own CPU); report
+        // zero rather than block a `/proc` reader, matching the prior behavior.
         return (TimeValue::ZERO, TimeValue::ZERO);
     };
     time.output()
@@ -145,14 +148,14 @@ pub fn poll_timer(task: &TaskInner) {
     let Some(thr) = task.try_as_thread() else {
         return;
     };
-    let Ok(mut time) = thr.time.try_borrow_mut() else {
-        // reentrant borrow, likely IRQ
-        return;
-    };
-    let emitter = |signo| {
+    // Called from the alarm task (a normal task context, possibly a different
+    // CPU than the target). Hold the lock only for the poll; emit the returned
+    // itimer signals after releasing it — signal delivery must not run under the
+    // IRQ-disabling time lock.
+    let fired = thr.time.lock().poll();
+    for signo in fired.into_iter().flatten() {
         send_signal_thread_inner(task, thr, SignalInfo::new_kernel(signo));
-    };
-    time.poll(emitter);
+    }
 }
 
 /// Poll the process-level POSIX timers.
@@ -169,15 +172,20 @@ pub fn set_timer_state(task: &TaskInner, state: TimerState) {
     let Some(thr) = task.try_as_thread() else {
         return;
     };
-    let Ok(mut time) = thr.time.try_borrow_mut() else {
-        // reentrant borrow, likely IRQ
-        return;
+    // Hold the (IRQ-disabling) lock only for the accounting update + state flip;
+    // collect any itimer signals and emit them after unlocking — signal delivery
+    // must not run under the time lock. Called at syscall boundaries (task
+    // context, the thread's own CPU), so it can block briefly on the rare
+    // cross-CPU contention without reentrancy.
+    let fired = {
+        let mut time = thr.time.lock();
+        let fired = time.poll();
+        time.set_state(state);
+        fired
     };
-    let emitter = |signo| {
+    for signo in fired.into_iter().flatten() {
         send_signal_thread_inner(task, thr, SignalInfo::new_kernel(signo));
-    };
-    time.poll(emitter);
-    time.set_state(state);
+    }
 }
 
 #[repr(C)]

--- a/os/StarryOS/kernel/src/task/timer.rs
+++ b/os/StarryOS/kernel/src/task/timer.rs
@@ -212,9 +212,17 @@ impl TimeManager {
         // continues to see the full wall-clock delta for itimer accounting.
     }
 
-    /// Polls the time manager to update the timers and emit signals if
-    /// necessary.
-    pub fn poll(&mut self, emitter: impl Fn(Signo)) {
+    /// Polls the time manager to update CPU time and interval timers,
+    /// returning the interval-timer signals that fired (at most 3, in slot
+    /// order Virtual/Prof/Real).
+    ///
+    /// The caller MUST emit the returned signals AFTER releasing the `time`
+    /// lock: signal delivery takes other locks, and the `time` lock is
+    /// IRQ-disabling — running the emitter under it would extend the IRQs-off
+    /// window and risk a lock-ordering deadlock. Returning the signals keeps
+    /// the locked region free of any nested lock.
+    #[must_use = "the returned itimer signals must be emitted after unlocking"]
+    pub fn poll(&mut self) -> [Option<Signo>; 3] {
         let now_ns = monotonic_time_nanos() as usize;
         // itimer_delta: full wall-clock time since the last poll() call.
         // Used for interval-timer accounting so they fire at the right time
@@ -224,23 +232,34 @@ impl TimeManager {
         // in utime_ns / stime_ns.  If tick() was never called, last_tick_ns ==
         // last_wall_ns and remaining == itimer_delta (identical to original).
         let remaining = now_ns.saturating_sub(self.last_tick_ns);
+        // Fixed slots so no `n` counter is needed: 0=Virtual, 1=Prof, 2=Real.
+        let mut fired = [None; 3];
         match self.state {
             TimerState::User => {
                 self.utime_ns += remaining;
-                self.update_itimer(ITimerType::Virtual, itimer_delta, &emitter);
-                self.update_itimer(ITimerType::Prof, itimer_delta, &emitter);
+                if self.itimers[ITimerType::Virtual as usize].update(itimer_delta) {
+                    fired[0] = Some(ITimerType::Virtual.signo());
+                }
+                if self.itimers[ITimerType::Prof as usize].update(itimer_delta) {
+                    fired[1] = Some(ITimerType::Prof.signo());
+                }
             }
             TimerState::Kernel => {
                 self.stime_ns += remaining;
-                self.update_itimer(ITimerType::Prof, itimer_delta, &emitter);
+                if self.itimers[ITimerType::Prof as usize].update(itimer_delta) {
+                    fired[1] = Some(ITimerType::Prof.signo());
+                }
             }
             TimerState::None => {}
         }
-        self.update_itimer(ITimerType::Real, itimer_delta, &emitter);
+        if self.itimers[ITimerType::Real as usize].update(itimer_delta) {
+            fired[2] = Some(ITimerType::Real.signo());
+        }
         self.last_wall_ns = now_ns;
         // Sync tick baseline with poll baseline so the next tick() starts
         // from a clean slate.
         self.last_tick_ns = now_ns;
+        fired
     }
 
     /// Updates the timer state.
@@ -273,12 +292,6 @@ impl TimeManager {
             time_value_from_nanos(itimer.interval_ns),
             time_value_from_nanos(itimer.remained_ns),
         )
-    }
-
-    fn update_itimer(&mut self, ty: ITimerType, delta: usize, emitter: impl Fn(Signo)) {
-        if self.itimers[ty as usize].update(delta) {
-            emitter(ty.signo());
-        }
     }
 }
 


### PR DESCRIPTION
## 问题
`Thread.time` 为 `AssumeSync<RefCell<TimeManager>>`——`AssumeSync` 无条件宣称 `Sync`，但 `RefCell` 并非 `Sync`。`getrusage`/`/proc` 等跨核读取会与目标线程所在核上的计时更新并发访问同一 `RefCell`，属未定义行为（并可能因 borrow 标志竞争而 panic）。

## 改动
- 字段改为 `IrqMutex<TimeManager>`（本代码库既有的关中断自旋锁门面，`seccomp`/`cred` 等跨核字段同款语义），删除 `AssumeSync` 与相关 `RefCell`/`Deref` 引用。
- 所有 `borrow()/borrow_mut()` → `lock()`；IRQ / 上下文切换路径用 `try_lock()`，竞争时跳过（绝不阻塞切换）。
- `TimeManager::poll()` 改为**返回**触发的 interval-timer 信号数组，信号在**释放锁之后**再发送——信号投递不得在关中断计时锁下运行。

## 逻辑
锁只在少量字段更新期间短暂持有、无嵌套锁，故不会死锁；单核语义不变。此为独立的 SMP 健全性修复，不含任何 `tickacct` 性能机制。内核 aarch64 构建通过。