### PR TITLE
feat(ax-cpu): add lock-free user_access_ok_page AT-probe (aarch64 AT S1E0R/W + PAR_EL1)

### DIFF
--- a/components/axcpu/src/aarch64/asm.rs
+++ b/components/axcpu/src/aarch64/asm.rs
@@ -278,3 +278,72 @@ unsafe extern "C" {
     /// while a value > 0 indicates failure.
     pub fn user_copy(dst: *mut u8, src: *const u8, size: usize) -> usize;
 }
+
+/// Probes whether EL0 is permitted to access the page containing `vaddr` under
+/// the *current* user translation regime (`TTBR0_EL1`), without taking any lock.
+///
+/// Uses the `AT S1E0R` / `AT S1E0W` address-translation instruction, which asks
+/// the MMU to translate `vaddr` for an EL0 read (or write, when `write`) access
+/// and reports the result in `PAR_EL1`. `PAR_EL1.F == 0` means the translation
+/// succeeded and the access is permitted — exactly the permission the CPU itself
+/// enforces for a user-mode access, read lock-free. A not-present page or one
+/// lacking the requested EL0 permission (e.g. a copy-on-write page probed for
+/// write) reports `F == 1`.
+///
+/// Returns `true` iff the MMU would permit the EL0 access.
+///
+/// # Safety
+///
+/// The caller MUST invoke this with interrupts disabled. `PAR_EL1` is a per-CPU
+/// scratch register shared across contexts; an interrupt executing another `AT`
+/// between this `AT` and the `mrs` would clobber the result. On the
+/// pointer-validation path that could turn an inaccessible page into a `true`
+/// result and thus a raw kernel dereference of an unchecked address. IRQs-off
+/// guarantees no other `AT` runs on this CPU in between. Because violating this
+/// precondition is a memory-safety hazard (not merely a wrong answer), the
+/// function is `unsafe` so every call site must establish it.
+#[cfg(all(feature = "uspace", not(feature = "arm-el2")))]
+#[inline]
+pub unsafe fn user_access_ok_page(vaddr: usize, write: bool) -> bool {
+    let par: u64;
+    // SAFETY: `AT` reads the current translation tables and writes `PAR_EL1`;
+    // `mrs` reads it back. No memory is accessed and no flags are clobbered. The
+    // caller holds IRQs off so the `AT`/`mrs` pair is not split by another `AT`.
+    unsafe {
+        if write {
+            asm!(
+                "at s1e0w, {vaddr}",
+                "isb",
+                "mrs {par}, par_el1",
+                vaddr = in(reg) vaddr,
+                par = out(reg) par,
+                options(nostack, preserves_flags),
+            );
+        } else {
+            asm!(
+                "at s1e0r, {vaddr}",
+                "isb",
+                "mrs {par}, par_el1",
+                vaddr = in(reg) vaddr,
+                par = out(reg) par,
+                options(nostack, preserves_flags),
+            );
+        }
+    }
+    // PAR_EL1.F (bit 0): 0 = translation succeeded and the EL0 access is allowed.
+    par & 1 == 0
+}
+
+/// `arm-el2` builds run the hypervisor at EL2, where the EL1&0 `AT` probe does
+/// not describe guest-user access, so always fall back to the locked slow path.
+///
+/// # Safety
+///
+/// No precondition — this stub reads nothing and always returns `false`. It is
+/// `unsafe` only to share the signature of the aarch64 EL1 probe (which requires
+/// IRQs-off), so callers can use one `unsafe` block across all targets.
+#[cfg(all(feature = "uspace", feature = "arm-el2"))]
+#[inline]
+pub unsafe fn user_access_ok_page(_vaddr: usize, _write: bool) -> bool {
+    false
+}

--- a/components/axcpu/src/loongarch64/asm.rs
+++ b/components/axcpu/src/loongarch64/asm.rs
@@ -247,3 +247,18 @@ unsafe extern "C" {
     /// while a value > 0 indicates failure.
     pub fn user_copy(dst: *mut u8, src: *const u8, size: usize) -> usize;
 }
+
+/// Lock-free EL0/user access probe. No hardware address-translation probe is
+/// wired up on this architecture yet, so always report "not fast-path eligible"
+/// and let the caller take the locked slow path (correctness preserved).
+///
+/// # Safety
+///
+/// No precondition — this stub reads nothing and always returns `false`. It is
+/// `unsafe` only to share the signature of the aarch64 EL1 probe (which requires
+/// IRQs-off), so callers can use one `unsafe` block across all targets.
+#[cfg(feature = "uspace")]
+#[inline]
+pub unsafe fn user_access_ok_page(_vaddr: usize, _write: bool) -> bool {
+    false
+}

--- a/components/axcpu/src/riscv/asm.rs
+++ b/components/axcpu/src/riscv/asm.rs
@@ -172,3 +172,18 @@ unsafe extern "C" {
     /// while a value > 0 indicates failure.
     pub fn user_copy(dst: *mut u8, src: *const u8, size: usize) -> usize;
 }
+
+/// Lock-free EL0/user access probe. No hardware address-translation probe is
+/// wired up on this architecture yet, so always report "not fast-path eligible"
+/// and let the caller take the locked slow path (correctness preserved).
+///
+/// # Safety
+///
+/// No precondition — this stub reads nothing and always returns `false`. It is
+/// `unsafe` only to share the signature of the aarch64 EL1 probe (which requires
+/// IRQs-off), so callers can use one `unsafe` block across all targets.
+#[cfg(feature = "uspace")]
+#[inline]
+pub unsafe fn user_access_ok_page(_vaddr: usize, _write: bool) -> bool {
+    false
+}

--- a/components/axcpu/src/x86_64/asm.rs
+++ b/components/axcpu/src/x86_64/asm.rs
@@ -153,3 +153,18 @@ unsafe extern "C" {
     /// while a value > 0 indicates failure.
     pub fn user_copy(dst: *mut u8, src: *const u8, size: usize) -> usize;
 }
+
+/// Lock-free EL0/user access probe. No hardware address-translation probe is
+/// wired up on this architecture yet, so always report "not fast-path eligible"
+/// and let the caller take the locked slow path (correctness preserved).
+///
+/// # Safety
+///
+/// No precondition — this stub reads nothing and always returns `false`. It is
+/// `unsafe` only to share the signature of the aarch64 EL1 probe (which requires
+/// IRQs-off), so callers can use one `unsafe` block across all targets.
+#[cfg(feature = "uspace")]
+#[inline]
+pub unsafe fn user_access_ok_page(_vaddr: usize, _write: bool) -> bool {
+    false
+}


### PR DESCRIPTION
## 问题
用户态指针校验（access_ok 模型）目前走加锁的地址空间查表慢路径，在共享地址空间的 `CLONE_VM` 多线程上串行（`-T` 场景）。缺少一个无锁的硬件页表探测原语。

## 改动
在 `ax-cpu` 新增 `user_access_ok_page(vaddr, write) -> bool`：
- **aarch64**（`uspace` 且非 `arm-el2`）：用 `AT S1E0R/W` 让 MMU 按 EL0 读/写权限翻译该 VA，读回 `PAR_EL1.F`（0 = 翻译成功且允许 EL0 访问），完全无锁。契约：调用方必须关中断（`PAR_EL1` 是每-CPU 临时寄存器，中途另一条 `AT` 会覆盖结果，可能把不可访问页误判为可直接解引用）。
- **arm-el2** 与 **riscv/x86_64/loongarch64**：返回 `false`，回退到既有加锁慢路径（正确性不变）。

## 逻辑
纯原语；本 PR 不接线任何消费者（内核 `access.rs` 快路径是独立的后续 PR）。gate 用既有 `uspace` feature，不引入新的默认开启行为。ax-cpu 全特性 clippy 通过。真实 `AT` 行为需运行中的 MMU，其正确性由消费者 PR 的 QEMU/板级测试覆盖。