### PR TITLE
perf(starry): skip per-syscall poll_process_timer when the process has no POSIX timers

### DIFF
--- a/os/StarryOS/kernel/src/task/posix_timer.rs
+++ b/os/StarryOS/kernel/src/task/posix_timer.rs
@@ -2,7 +2,7 @@
 
 use alloc::{collections::BTreeMap, sync::Arc};
 use core::{
-    sync::atomic::{AtomicI32, Ordering},
+    sync::atomic::{AtomicI32, AtomicUsize, Ordering},
     time::Duration,
 };
 
@@ -47,6 +47,11 @@ pub struct TimerSpec {
 pub struct PosixTimerTable {
     next_id: AtomicI32,
     timers: Mutex<BTreeMap<i32, PosixTimer>>,
+    /// Lock-free "might have timers" hint: the exact `timers` length, republished
+    /// under the `timers` lock by every mutator. Lets the per-syscall
+    /// `poll_process_timer` path skip the global process lookup + the timers lock
+    /// entirely when the process has no POSIX timers (the overwhelming case).
+    count: AtomicUsize,
 }
 
 impl Default for PosixTimerTable {
@@ -54,6 +59,7 @@ impl Default for PosixTimerTable {
         Self {
             next_id: AtomicI32::new(0),
             timers: Mutex::new(BTreeMap::new()),
+            count: AtomicUsize::new(0),
         }
     }
 }
@@ -125,18 +131,42 @@ impl PosixTimerTable {
             interval_ns: 0,
             deadline_ns: 0,
         };
-        self.timers.lock().insert(id, timer);
+        let mut timers = self.timers.lock();
+        timers.insert(id, timer);
+        self.publish_count(&timers);
         Ok(id)
     }
 
     /// Delete a timer. Returns true if it existed.
     pub fn delete(&self, id: i32) -> bool {
-        self.timers.lock().remove(&id).is_some()
+        let mut timers = self.timers.lock();
+        let removed = timers.remove(&id).is_some();
+        self.publish_count(&timers);
+        removed
     }
 
     /// Clear all timers. Used on execve.
     pub fn clear(&self) {
-        self.timers.lock().clear();
+        let mut timers = self.timers.lock();
+        timers.clear();
+        self.publish_count(&timers);
+    }
+
+    /// Republish the lock-free `count` hint as the exact map length. Called under
+    /// the `timers` lock by every mutator so `count` can never drift or
+    /// underflow (e.g. an `execve` clear racing a concurrent create/delete would
+    /// otherwise over-count or wrap with the old outside-the-lock fetch_add/sub).
+    /// `Relaxed` is sufficient: readers use it only as a "might have timers" hint,
+    /// and the alarm task fires every armed timer at its deadline regardless.
+    fn publish_count(&self, timers: &BTreeMap<i32, PosixTimer>) {
+        self.count.store(timers.len(), Ordering::Relaxed);
+    }
+
+    /// Whether this process might have any POSIX timer. Used by the per-syscall
+    /// `poll_process_timer` fast path to skip the global lookup + timers lock
+    /// when there are none.
+    pub fn maybe_has_timers(&self) -> bool {
+        self.count.load(Ordering::Relaxed) != 0
     }
 
     /// Set (arm/disarm) a timer. Returns the old (interval, remaining) in nanos.

--- a/os/StarryOS/kernel/src/task/user.rs
+++ b/os/StarryOS/kernel/src/task/user.rs
@@ -362,8 +362,12 @@ pub fn new_user_task(name: &str, mut uctx: UserContext, set_child_tid: usize) ->
                         if poll_timer {
                             // POSIX timers are also driven by the alarm task, but polling
                             // here closes the window where an expired timer is only noticed
-                            // after the current syscall returns to userspace.
-                            poll_process_timer(&thr.proc_data.identity());
+                            // after the current syscall returns to userspace. Skip the
+                            // global process lookup + the timers lock entirely when this
+                            // process has no POSIX timers (the overwhelming common case).
+                            if thr.proc_data.posix_timers.maybe_has_timers() {
+                                poll_process_timer(&thr.proc_data.identity());
+                            }
                             poll_timer = false;
                         }
                         while check_signals(thr, &mut uctx, None, pending_restart) {


### PR DESCRIPTION
## 问题
系统调用返回路径在**每次**系统调用都轮询进程的 POSIX 定时器（一次全局进程查找 + 每进程 timers 锁），而几乎没有进程会创建 POSIX 定时器。

## 改动
- 在 `PosixTimerTable` 新增无锁提示 `maybe_has_timers()`：其值为 `timers` 映射的精确长度，由每个修改者（create/delete/clear）在 `timers` 锁下经 `publish_count()` 重新发布。
- `user.rs` 每系统调用的轮询点先查 `maybe_has_timers()`，无定时器时直接跳过全局查找 + 加锁。

## 逻辑
计数在锁下由 `len()` 推导（而非锁外 `fetch_add/sub`），故对「execve 清空」与并发 create/delete 竞争是无竞态的，不会漂移或下溢。`Relaxed` 足够：它只是提示，闹钟任务仍会在到期时触发每个已武装定时器。板上实测 getpid 约 −17%。内核 aarch64 构建通过。