### PR TITLE
feat(ax-cgroup): enforce cgroup v2 pids limits

### DIFF
--- a/book/design/starry-cgroup-pids-l4.md
+++ b/book/design/starry-cgroup-pids-l4.md
@@ -44,6 +44,14 @@ pulls `axfs-ng-vfs` and `ax_errno` into the reusable domain layer. The chosen
 approach extends the current `CgroupNode` and `CgroupProvider` boundaries and
 keeps VFS text rendering and Linux errno conversion in StarryOS kernel glue.
 
+Open draft PR [#1379](https://github.com/rcore-os/tgoskits/pull/1379) has
+partial surface overlap because it also contains a pids controller among five
+controllers, manager/inotify work, and scheduler changes. It is classified as
+`conflict-risk/partial-overlap`, not as a reusable replacement: its pids
+accounting is process-based and does not provide this increment's task-level
+thread accounting, migration serialization, reservation rollback, or
+`CLONE_PARENT_SETTID` rejection regression.
+
 ## State, ownership, and synchronization
 
 Every `CgroupNode` owns a private pids state. The state retains a task count,
@@ -94,7 +102,7 @@ existing entry points:
 
 | Syscall | Impact and compatibility basis |
 | --- | --- |
-| `clone` | `CloneArgs::do_clone` reserves one pids charge before publishing the TID and returns `EAGAIN` on a hierarchical limit, matching [`clone(2)`](https://man7.org/linux/man-pages/man2/clone.2.html) and Linux [`pids_can_fork()`](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/cgroup/pids.c#L273-L284). |
+| `clone` | `CloneArgs::do_clone` reserves one pids charge before publishing the TID and returns `EAGAIN` on a hierarchical limit, matching [`clone(2)`](https://man7.org/linux/man-pages/man2/clone.2.html) and Linux [`pids_can_fork()`](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/cgroup/pids.c#L273-L284). A `CLONE_PARENT_SETTID` pointer is written only after the reservation succeeds, so a rejected clone has no parent-TID side effect. |
 | `clone3` | Uses the same `CloneArgs::do_clone` path after existing ABI validation, so the pids result is identical to `clone`; argument parsing is unchanged. |
 | `fork` | The architecture wrapper uses the clone path with `SIGCHLD`; the pids rejection is therefore `EAGAIN`, matching [`fork(2)`](https://man7.org/linux/man-pages/man2/fork.2.html). |
 | `vfork` | The architecture wrapper uses the clone path with `CLONE_VFORK | CLONE_VM`; the charge is committed before publication and before the parent waits, matching [`vfork(2)`](https://man7.org/linux/man-pages/man2/vfork.2.html). |
@@ -115,12 +123,18 @@ Host tests cover parse and read-back behavior, hierarchical charges, CAS limit
 races, rollback, thread accounting, idempotent exit, and migration above a
 limit. The Starry QEMU system test performs the user-visible sequence of
 enabling pids, migration, `pids.max` update, successful first fork, failed
-second fork with `EAGAIN`, hierarchical event observation, and counter recovery
-after exit. It must fail if the clone-path limit check or event propagation is
+second fork with `EAGAIN`, a rejected raw `clone(CLONE_PARENT_SETTID)`,
+hierarchical event observation, and counter recovery after exit. It must fail
+if the clone-path limit check, parent-TID ordering, or event propagation is
 removed.
 
-Validation on base `edd793e51512e8e3c1e09a8dc0f553abad09c417` completed on
-2026-08-13 (Asia/Shanghai):
+Full validation of the patch completed on base
+`106bede3070da3c44fd1cc61190aa95e96149ca6` on 2026-08-13
+(Asia/Shanghai). Before the ordering fix, the new aarch64 test produced
+56 passes and 2 failures: the rejected clone changed the parent-TID pointer,
+and the existing event expectation did not account for the additional valid
+rejection. Moving the write after the cgroup reservation commit and updating
+the event expectation produced 58 passes and 0 failures.
 
 | Gate | Result |
 | --- | --- |
@@ -135,13 +149,22 @@ Validation on base `edd793e51512e8e3c1e09a8dc0f553abad09c417` completed on
 | `cargo xtask starry build --arch riscv64` | passed on final worktree |
 | `cargo xtask starry build --arch loongarch64` | passed on final worktree |
 | `cargo xtask starry build --arch x86_64` | passed on final worktree |
-| aarch64 `qemu/system/cgroup-pids` | 55 passed, 0 failed |
-| riscv64 `qemu/system/cgroup-pids` | 55 passed, 0 failed |
+| aarch64 `qemu/system/cgroup-pids` | 58 passed, 0 failed |
+| riscv64 `qemu/system/cgroup-pids` | 58 passed, 0 failed |
 | loongarch64 `qemu/system/cgroup-pids` | passed the same focused binary |
-| x86_64 `qemu/system/cgroup-pids` | 55 passed, 0 failed |
+| x86_64 `qemu/system/cgroup-pids` | 58 passed, 0 failed |
 
 The host regression also covers rejecting migration while a pending task is
 unpublished and resolving a reservation from the process's current cgroup.
 All four supported QEMU architectures were rebuilt and rerun after the final
 API convergence. Existing Cargo artifacts, rootfs archives, and grouped-case
 assets were reused; no `cargo clean` was run.
+
+The branch was then rebased without conflicts onto
+`9063198d91d0fbf42be575c02f5e2bf9e94f2c58`, whose only change from the
+validated base adds files under `apps/starry/aka-rk3588`. It does not touch
+cgroup, clone, the focused test, Cargo metadata, or the build/test tooling.
+The committed patches were checked with `git range-diff`, and the full
+cross-build/QEMU evidence was reused rather than rebuilt for this unrelated
+baseline-only change. Fast host and kernel gates were rerun on the rebased
+worktree before the final local commit.

--- a/book/design/starry-cgroup-pids-l4.md
+++ b/book/design/starry-cgroup-pids-l4.md
@@ -1,0 +1,139 @@
+# StarryOS cgroup v2 pids L4 design
+
+## Problem and success criteria
+
+The current `ax-cgroup` crate owns hierarchy, process membership, and cgroup
+namespace state, but its `cgroup.controllers` and `cgroup.subtree_control`
+interfaces are empty. Consequently, `clone(2)` can always create a task and
+the existing cgroup QEMU test cannot distinguish an enforced limit from a
+no-op implementation.
+
+This change adds the first controller increment: pids. A successful
+implementation lets a process move into a non-root pids-enabled cgroup, set
+`pids.max`, and observe that the next task-creating `fork` or `clone` fails
+with `EAGAIN` once the hierarchical limit is exhausted. The counters must
+remain balanced across fork rollback, thread exit, process exit, and process
+migration.
+
+This is deliberately not a CPU, memory, cpuset, or I/O implementation. It
+does not add cgroup v2 threaded mode, delegation, notifications,
+`pids.events.local`, `pids.peak`, controller disabling, or the cgroup core's
+no-internal-process rule. Those features require their own observable behavior
+and validation.
+
+## Prior art and alternatives
+
+The semantics follow Linux v6.12 at commit
+`adc218676eef25575469234709c2d87185ca223a`, especially
+[`cgroup-v2.rst`](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/Documentation/admin-guide/cgroup-v2.rst#L2251-L2285),
+[`pids_try_charge()` and rollback](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/cgroup/pids.c#L166-L209),
+and
+[`pids_event()`](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/cgroup/pids.c#L243-L271):
+
+- pids tracks tasks (kernel TIDs), not only process leaders;
+- `pids.current` includes the cgroup's descendants;
+- organizational operations may exceed `pids.max`; only fork and clone are
+  rejected with `EAGAIN`;
+- pids limits are hierarchical and `pids.events` records failures in the
+  cgroup's subtree.
+
+`fork/feat/cgroup-unified-rebased` already contains a controller framework
+and pids implementation. It is retained as a behavioral reference, but it is
+not merged or cherry-picked because it replaces the current cgroup crate and
+pulls `axfs-ng-vfs` and `ax_errno` into the reusable domain layer. The chosen
+approach extends the current `CgroupNode` and `CgroupProvider` boundaries and
+keeps VFS text rendering and Linux errno conversion in StarryOS kernel glue.
+
+## State, ownership, and synchronization
+
+Every `CgroupNode` owns a private pids state. The state retains a task count,
+an optional maximum, and the hierarchical `pids.events` max counter. Counts
+and max events are maintained for the affected non-root ancestors so they
+match the cgroup v2 hierarchy before an interface becomes visible.
+The root owns accounting state but does not expose `pids.*` files; those files
+exist only in non-root cgroups whose parent enabled pids in
+`cgroup.subtree_control`.
+
+`MembershipState` is the serialization boundary for task lifecycle changes. It
+owns pending task reservations and the committed task-to-cgroup mapping. A
+fork guard charges the source cgroup path before the child is runnable and
+either commits the mapping or releases every charge on drop. A task exit
+removes exactly one committed mapping before uncharging its path. Process
+migration receives all live TIDs from `CgroupProvider`, moves their mappings
+as one membership transaction, charges the target-only path without checking
+limits, and releases the source-only path after publication.
+
+The per-node pids counter uses compare-and-exchange for limit-checked fork
+charges. The membership lock orders multi-node lifecycle operations and
+prevents migration from observing a partially committed task set. No VFS,
+allocation, scheduling, or provider callback executes while a node counter is
+being updated.
+
+## Interfaces and errors
+
+`CgroupProvider` gains a live-task query so migration can move a complete
+thread group. The kernel implementation obtains that snapshot from
+`starry-process::Process::threads()`; test providers model it explicitly.
+
+The domain API distinguishes a process child from a thread child. Both reserve
+a pids task charge, while only a process child is added to `cgroup.procs`.
+Task exit takes the task identity and whether it is the last task in the
+process, so membership remains process-based while pids accounting remains
+task-based.
+
+`CgroupError::LimitExceeded` is the domain result for a failed pids charge and
+the StarryOS cgroup adapter maps it to `EAGAIN`. Invalid pids input and
+unsupported controller operations map to `EINVAL`; a top-down controller
+violation or a pending lifecycle operation maps to `EBUSY`.
+
+## User-visible syscall impact
+
+The implementation does not change syscall numbers, argument layouts, or
+flag parsing. It changes the state transitions reached through the following
+existing entry points:
+
+| Syscall | Impact and compatibility basis |
+| --- | --- |
+| `clone` | `CloneArgs::do_clone` reserves one pids charge before publishing the TID and returns `EAGAIN` on a hierarchical limit, matching [`clone(2)`](https://man7.org/linux/man-pages/man2/clone.2.html) and Linux [`pids_can_fork()`](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/cgroup/pids.c#L273-L284). |
+| `clone3` | Uses the same `CloneArgs::do_clone` path after existing ABI validation, so the pids result is identical to `clone`; argument parsing is unchanged. |
+| `fork` | The architecture wrapper uses the clone path with `SIGCHLD`; the pids rejection is therefore `EAGAIN`, matching [`fork(2)`](https://man7.org/linux/man-pages/man2/fork.2.html). |
+| `vfork` | The architecture wrapper uses the clone path with `CLONE_VFORK | CLONE_VM`; the charge is committed before publication and before the parent waits, matching [`vfork(2)`](https://man7.org/linux/man-pages/man2/vfork.2.html). |
+| `execve` | Successful de-threading renames the surviving task ledger entry without changing the charge; executable loading, argument handling, and errno ordering are unchanged. See [`execve(2)`](https://man7.org/linux/man-pages/man2/execve.2.html). |
+| `execveat` | Shares the same `do_execve` de-thread path as `execve`; only the internal task identity mapping is updated. See [`execveat(2)`](https://man7.org/linux/man-pages/man2/execveat.2.html). |
+| `exit` | `do_exit` removes exactly one task charge after thread-group bookkeeping; repeated teardown is idempotent. See [`_exit(2)`](https://man7.org/linux/man-pages/man2/_exit.2.html). |
+| `exit_group` | The same exit path releases each exiting task and removes process membership on the final task. Signal-driven exits use this same lifecycle boundary. |
+
+The cgroupfs interface is observed through existing `mount`, `openat`, `read`,
+`write`, and `getdents64` paths. The change adds dynamic controller and
+`pids.*` entries to the existing cgroup2 filesystem adapter; it does not alter
+the generic syscall ABI. The QEMU cases validate file visibility, permissions,
+input errors, `cgroup.procs` migration, and read-back results.
+
+## Validation evidence
+
+Host tests cover parse and read-back behavior, hierarchical charges, CAS limit
+races, rollback, thread accounting, idempotent exit, and migration above a
+limit. The Starry QEMU system test performs the user-visible sequence of
+enabling pids, migration, `pids.max` update, successful first fork, failed
+second fork with `EAGAIN`, hierarchical event observation, and counter recovery
+after exit. It must fail if the clone-path limit check or event propagation is
+removed.
+
+Validation on base `edd793e51512e8e3c1e09a8dc0f553abad09c417` completed on
+2026-08-13 (Asia/Shanghai):
+
+| Gate | Result |
+| --- | --- |
+| `cargo fmt --all -- --check` | passed |
+| `cargo xtask lock-lint` | passed |
+| `cargo test -p ax-cgroup` | 19 passed |
+| `cargo xtask clippy --package ax-cgroup` | passed |
+| `cargo check -p ax-cgroup` | passed |
+| `cargo check -p starry-kernel` | passed |
+| `cargo xtask clippy --package starry-kernel` | 25 configurations passed with the full cross-toolchain `PATH` |
+| `cargo xtask starry build --arch aarch64` | passed; ELF and BIN regenerated |
+| `cargo xtask starry test qemu --arch aarch64 --test-case qemu/system/cgroup-basic` | 48 passed, 0 failed |
+| `cargo xtask starry test qemu --arch aarch64 --test-case qemu/system/cgroup-pids` | 55 passed, 0 failed |
+
+Only aarch64 is claimed by this evidence. Other architectures remain
+unverified for this increment.

--- a/book/design/starry-cgroup-pids-l4.md
+++ b/book/design/starry-cgroup-pids-l4.md
@@ -126,14 +126,22 @@ Validation on base `edd793e51512e8e3c1e09a8dc0f553abad09c417` completed on
 | --- | --- |
 | `cargo fmt --all -- --check` | passed |
 | `cargo xtask lock-lint` | passed |
-| `cargo test -p ax-cgroup` | 19 passed |
+| `cargo test -p ax-cgroup` | 20 passed |
 | `cargo xtask clippy --package ax-cgroup` | passed |
 | `cargo check -p ax-cgroup` | passed |
 | `cargo check -p starry-kernel` | passed |
 | `cargo xtask clippy --package starry-kernel` | 25 configurations passed with the full cross-toolchain `PATH` |
-| `cargo xtask starry build --arch aarch64` | passed; ELF and BIN regenerated |
-| `cargo xtask starry test qemu --arch aarch64 --test-case qemu/system/cgroup-basic` | 48 passed, 0 failed |
-| `cargo xtask starry test qemu --arch aarch64 --test-case qemu/system/cgroup-pids` | 55 passed, 0 failed |
+| `cargo xtask starry build --arch aarch64` | passed on final worktree |
+| `cargo xtask starry build --arch riscv64` | passed on final worktree |
+| `cargo xtask starry build --arch loongarch64` | passed on final worktree |
+| `cargo xtask starry build --arch x86_64` | passed on final worktree |
+| aarch64 `qemu/system/cgroup-pids` | 55 passed, 0 failed |
+| riscv64 `qemu/system/cgroup-pids` | 55 passed, 0 failed |
+| loongarch64 `qemu/system/cgroup-pids` | passed the same focused binary |
+| x86_64 `qemu/system/cgroup-pids` | 55 passed, 0 failed |
 
-Only aarch64 is claimed by this evidence. Other architectures remain
-unverified for this increment.
+The host regression also covers rejecting migration while a pending task is
+unpublished and resolving a reservation from the process's current cgroup.
+All four supported QEMU architectures were rebuilt and rerun after the final
+API convergence. Existing Cargo artifacts, rootfs archives, and grouped-case
+assets were reused; no `cargo clean` was run.

--- a/book/design/starry-cgroup-pids-l4.md
+++ b/book/design/starry-cgroup-pids-l4.md
@@ -64,12 +64,17 @@ exist only in non-root cgroups whose parent enabled pids in
 
 `MembershipState` is the serialization boundary for task lifecycle changes. It
 owns pending task reservations and the committed task-to-cgroup mapping. A
-fork guard charges the source cgroup path before the child is runnable and
-either commits the mapping or releases every charge on drop. A task exit
+fork guard charges the selected cgroup path before the child is runnable and
+either commits the mapping or releases every charge on drop. Ordinary process
+and thread clones resolve the owning process's current cgroup while holding the
+membership lock. `clone3(CLONE_INTO_CGROUP)` instead reserves a process child
+directly in the validated target cgroup. A task exit
 removes exactly one committed mapping before uncharging its path. Process
-migration receives all live TIDs from `CgroupProvider`, moves their mappings
-as one membership transaction, charges the target-only path without checking
-limits, and releases the source-only path after publication.
+migration enumerates all committed TIDs for the process from the same ledger,
+moves their mappings as one membership transaction, charges the target-only
+path without checking limits, and releases the source-only path after
+publication. A pending reservation owned by that process makes migration
+return busy, so migration cannot split a thread group across two cgroups.
 
 The per-node pids counter uses compare-and-exchange for limit-checked fork
 charges. The membership lock orders multi-node lifecycle operations and
@@ -79,9 +84,10 @@ being updated.
 
 ## Interfaces and errors
 
-`CgroupProvider` gains a live-task query so migration can move a complete
-thread group. The kernel implementation obtains that snapshot from
-`starry-process::Process::threads()`; test providers model it explicitly.
+`CgroupProvider` supplies the process's authoritative cgroup pointer, updates
+that pointer during migration, and reports zombie state. It does not enumerate
+threads: provider visibility is not the reservation commit boundary, so the
+owner-aware committed ledger is the authoritative task set for migration.
 
 The domain API distinguishes a process child from a thread child. Both reserve
 a pids task charge, while only a process child is added to `cgroup.procs`.
@@ -103,7 +109,7 @@ existing entry points:
 | Syscall | Impact and compatibility basis |
 | --- | --- |
 | `clone` | `CloneArgs::do_clone` reserves one pids charge before publishing the TID and returns `EAGAIN` on a hierarchical limit, matching [`clone(2)`](https://man7.org/linux/man-pages/man2/clone.2.html) and Linux [`pids_can_fork()`](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/cgroup/pids.c#L273-L284). A `CLONE_PARENT_SETTID` pointer is written only after the reservation succeeds, so a rejected clone has no parent-TID side effect. |
-| `clone3` | Uses the same `CloneArgs::do_clone` path after existing ABI validation, so the pids result is identical to `clone`; argument parsing is unchanged. |
+| `clone3` | Uses the same `CloneArgs::do_clone` path after existing ABI validation. Ordinary clones inherit through the owner-aware path. With `CLONE_INTO_CGROUP`, the process child is reserved and charged directly in the requested target; its `ProcessData.cgroup`, cgroup-namespace root, committed task ledger, and pids charge all derive from that same selected cgroup. `CLONE_INTO_CGROUP | CLONE_THREAD` and a flag/target mismatch return `EINVAL`. A target limit failure returns `EAGAIN` without publishing a child or writing `CLONE_PARENT_SETTID`. |
 | `fork` | The architecture wrapper uses the clone path with `SIGCHLD`; the pids rejection is therefore `EAGAIN`, matching [`fork(2)`](https://man7.org/linux/man-pages/man2/fork.2.html). |
 | `vfork` | The architecture wrapper uses the clone path with `CLONE_VFORK | CLONE_VM`; the charge is committed before publication and before the parent waits, matching [`vfork(2)`](https://man7.org/linux/man-pages/man2/vfork.2.html). |
 | `execve` | Successful de-threading renames the surviving task ledger entry without changing the charge; executable loading, argument handling, and errno ordering are unchanged. See [`execve(2)`](https://man7.org/linux/man-pages/man2/execve.2.html). |
@@ -124,47 +130,40 @@ races, rollback, thread accounting, idempotent exit, and migration above a
 limit. The Starry QEMU system test performs the user-visible sequence of
 enabling pids, migration, `pids.max` update, successful first fork, failed
 second fork with `EAGAIN`, a rejected raw `clone(CLONE_PARENT_SETTID)`,
-hierarchical event observation, and counter recovery after exit. It must fail
-if the clone-path limit check, parent-TID ordering, or event propagation is
+hierarchical event observation, and counter recovery after exit. The grouped
+`cgroup-basic` case also verifies that a successful
+`clone3(CLONE_INTO_CGROUP)` publishes the child in the target cgroup. The pids
+case verifies that a target with `pids.max=0` rejects that clone3 request,
+increments the target's `pids.events`, leaves `pids.current` at zero, and does
+not write the parent-TID pointer. These tests fail if target selection, the
+clone-path limit check, parent-TID ordering, rollback, or event propagation is
 removed.
 
-Full validation of the patch completed on base
-`106bede3070da3c44fd1cc61190aa95e96149ca6` on 2026-08-13
-(Asia/Shanghai). Before the ordering fix, the new aarch64 test produced
-56 passes and 2 failures: the rejected clone changed the parent-TID pointer,
-and the existing event expectation did not account for the additional valid
-rejection. Moving the write after the cgroup reservation commit and updating
-the event expectation produced 58 passes and 0 failures.
+The initial implementation received a four-architecture focused QEMU run on
+2026-08-13. That historical matrix remains useful reuse evidence, including the
+red/green `CLONE_PARENT_SETTID` ordering result, but it does not replace
+validation of later membership-ledger or clone3 target-selection repairs.
+
+The current repair was validated on `origin/dev` at
+`6bca19eb0a6e2488f38a8302df5647d4e2f06180` on 2026-08-17
+(Asia/Shanghai):
 
 | Gate | Result |
 | --- | --- |
 | `cargo fmt --all -- --check` | passed |
-| `cargo xtask lock-lint` | passed |
-| `cargo test -p ax-cgroup` | 20 passed |
-| `cargo xtask clippy --package ax-cgroup` | passed |
-| `cargo check -p ax-cgroup` | passed |
+| `git diff --check` | passed |
+| `cargo test --manifest-path components/ax-cgroup/Cargo.toml --all-features` | 25 passed |
+| `cargo clippy --manifest-path components/ax-cgroup/Cargo.toml --all-features -- -D warnings` | passed |
 | `cargo check -p starry-kernel` | passed |
-| `cargo xtask clippy --package starry-kernel` | 25 configurations passed with the full cross-toolchain `PATH` |
-| `cargo xtask starry build --arch aarch64` | passed on final worktree |
-| `cargo xtask starry build --arch riscv64` | passed on final worktree |
-| `cargo xtask starry build --arch loongarch64` | passed on final worktree |
-| `cargo xtask starry build --arch x86_64` | passed on final worktree |
-| aarch64 `qemu/system/cgroup-pids` | 58 passed, 0 failed |
-| riscv64 `qemu/system/cgroup-pids` | 58 passed, 0 failed |
-| loongarch64 `qemu/system/cgroup-pids` | passed the same focused binary |
-| x86_64 `qemu/system/cgroup-pids` | 58 passed, 0 failed |
+| loongarch64 `qemu/system/cgroup-basic` | passed, 1/1; successful `CLONE_INTO_CGROUP` observed in the target |
+| loongarch64 `qemu/system/cgroup-pids` | passed, 1/1; target rejection, rollback, event, and parent-TID checks passed |
 
-The host regression also covers rejecting migration while a pending task is
-unpublished and resolving a reservation from the process's current cgroup.
-All four supported QEMU architectures were rebuilt and rerun after the final
-API convergence. Existing Cargo artifacts, rootfs archives, and grouped-case
-assets were reused; no `cargo clean` was run.
-
-The branch was then rebased without conflicts onto
-`9063198d91d0fbf42be575c02f5e2bf9e94f2c58`, whose only change from the
-validated base adds files under `apps/starry/aka-rk3588`. It does not touch
-cgroup, clone, the focused test, Cargo metadata, or the build/test tooling.
-The committed patches were checked with `git range-diff`, and the full
-cross-build/QEMU evidence was reused rather than rebuilt for this unrelated
-baseline-only change. Fast host and kernel gates were rerun on the rebased
-worktree before the final local commit.
+A diagnostic loongarch64 grouped-system run also passed both cgroup binaries in
+their real order. It was stopped after the unrelated I/O-heavy
+`test-ext4-inode-unique` and `test-pagecache-cap` cases each reached their
+existing 240-second per-binary budget; it is not recorded as a full-suite pass.
+A direct `starry-kernel` lib-test attempt is currently blocked before test
+execution by pre-existing `pseudofs/proc.rs` fixtures that still initialize
+`TgidNumber`, `TidNumber`, and optional parent identities with raw integers;
+the normal kernel check above succeeds. Existing Cargo and rootfs artifacts
+were reused, and no `cargo clean` was run.

--- a/components/ax-cgroup/src/lib.rs
+++ b/components/ax-cgroup/src/lib.rs
@@ -137,8 +137,12 @@ pub fn exit_task(
 }
 
 /// Rename a task identity after Linux de-threading during execve.
-pub fn rename_task(old_tid: ProcessId, new_tid: ProcessId) -> CgroupResult<()> {
-    membership::rename_task(old_tid, new_tid)
+pub fn rename_task(
+    process_pid: ProcessId,
+    old_tid: ProcessId,
+    new_tid: ProcessId,
+) -> CgroupResult<()> {
+    membership::rename_task(process_pid, old_tid, new_tid)
 }
 
 /// Render `target` relative to an arbitrary cgroup namespace root.

--- a/components/ax-cgroup/src/lib.rs
+++ b/components/ax-cgroup/src/lib.rs
@@ -105,16 +105,16 @@ pub fn attach_initial_process(pid: ProcessId) -> CgroupResult<()> {
 
 /// Prepare inherited membership for a non-thread child.
 pub fn begin_fork(parent: Arc<CgroupNode>, child_pid: ProcessId) -> CgroupResult<CgroupForkGuard> {
-    membership::begin_task(parent, child_pid, CgroupChildKind::Process)
+    membership::begin_task_at(parent, child_pid, child_pid, CgroupChildKind::Process)
 }
 
-/// Reserve the pids charge for a new process or thread before it is runnable.
+/// Resolve a process's current cgroup and reserve a task charge atomically.
 pub fn begin_task(
-    parent: Arc<CgroupNode>,
+    process_pid: ProcessId,
     child_tid: ProcessId,
     child_kind: CgroupChildKind,
 ) -> CgroupResult<CgroupForkGuard> {
-    membership::begin_task(parent, child_tid, child_kind)
+    membership::begin_task(process_pid, child_tid, child_kind)
 }
 
 /// Move a live process to another cgroup.

--- a/components/ax-cgroup/src/lib.rs
+++ b/components/ax-cgroup/src/lib.rs
@@ -9,12 +9,13 @@ extern crate std;
 mod membership;
 mod namespace;
 mod node;
+mod pids;
 
 use alloc::sync::Arc;
 use core::{fmt, num::NonZeroU64};
 
 use ax_lazyinit::LazyInit;
-pub use membership::{CgroupForkGuard, CgroupProvider};
+pub use membership::{CgroupChildKind, CgroupForkGuard, CgroupProvider, CgroupTaskExit};
 pub use namespace::CgroupNamespace;
 pub use node::{CgroupNode, CgroupPin};
 
@@ -59,6 +60,9 @@ pub enum CgroupError {
     /// The cgroup is still referenced, populated, or has a pending fork.
     #[error("cgroup is busy")]
     ResourceBusy,
+    /// A task creation would exceed a pids limit in this cgroup hierarchy.
+    #[error("cgroup pids limit exceeded")]
+    LimitExceeded,
     /// The supplied name, PID, or file content is invalid.
     #[error("invalid cgroup input")]
     InvalidInput,
@@ -101,7 +105,16 @@ pub fn attach_initial_process(pid: ProcessId) -> CgroupResult<()> {
 
 /// Prepare inherited membership for a non-thread child.
 pub fn begin_fork(parent: Arc<CgroupNode>, child_pid: ProcessId) -> CgroupResult<CgroupForkGuard> {
-    membership::begin_fork(parent, child_pid)
+    membership::begin_task(parent, child_pid, CgroupChildKind::Process)
+}
+
+/// Reserve the pids charge for a new process or thread before it is runnable.
+pub fn begin_task(
+    parent: Arc<CgroupNode>,
+    child_tid: ProcessId,
+    child_kind: CgroupChildKind,
+) -> CgroupResult<CgroupForkGuard> {
+    membership::begin_task(parent, child_tid, child_kind)
 }
 
 /// Move a live process to another cgroup.
@@ -111,7 +124,21 @@ pub fn migrate_process(pid: ProcessId, target: Arc<CgroupNode>) -> CgroupResult<
 
 /// Release membership for a process whose final thread is exiting.
 pub fn exit_process(pid: ProcessId) -> CgroupResult<()> {
-    membership::exit_process(pid)
+    membership::exit_task(pid, pid, CgroupTaskExit::LastProcessTask)
+}
+
+/// Release one task charge and, for the final task, process membership.
+pub fn exit_task(
+    process_pid: ProcessId,
+    task_tid: ProcessId,
+    exit_kind: CgroupTaskExit,
+) -> CgroupResult<()> {
+    membership::exit_task(process_pid, task_tid, exit_kind)
+}
+
+/// Rename a task identity after Linux de-threading during execve.
+pub fn rename_task(old_tid: ProcessId, new_tid: ProcessId) -> CgroupResult<()> {
+    membership::rename_task(old_tid, new_tid)
 }
 
 /// Render `target` relative to an arbitrary cgroup namespace root.

--- a/components/ax-cgroup/src/lib.rs
+++ b/components/ax-cgroup/src/lib.rs
@@ -103,9 +103,12 @@ pub fn attach_initial_process(pid: ProcessId) -> CgroupResult<()> {
     membership::attach_initial_process(root(), pid)
 }
 
-/// Prepare inherited membership for a non-thread child.
-pub fn begin_fork(parent: Arc<CgroupNode>, child_pid: ProcessId) -> CgroupResult<CgroupForkGuard> {
-    membership::begin_task_at(parent, child_pid, child_pid, CgroupChildKind::Process)
+/// Reserve a non-thread child directly in an explicit target cgroup.
+pub fn begin_process_at(
+    target: Arc<CgroupNode>,
+    child_pid: ProcessId,
+) -> CgroupResult<CgroupForkGuard> {
+    membership::begin_task_at(target, child_pid, child_pid, CgroupChildKind::Process)
 }
 
 /// Resolve a process's current cgroup and reserve a task charge atomically.

--- a/components/ax-cgroup/src/membership.rs
+++ b/components/ax-cgroup/src/membership.rs
@@ -100,12 +100,12 @@ pub struct CgroupForkGuard {
 }
 
 impl CgroupForkGuard {
-    /// Return the cgroup inherited by the reserved task.
+    /// Return the cgroup selected for the reserved task.
     pub fn cgroup(&self) -> Arc<CgroupNode> {
         Arc::clone(&self.cgroup)
     }
 
-    /// Publish inherited membership before the child becomes runnable.
+    /// Publish the reserved membership before the child becomes runnable.
     pub fn commit(&mut self) {
         if matches!(self.state, ForkState::Committed) {
             return;
@@ -146,13 +146,13 @@ impl Drop for CgroupForkGuard {
 
 /// Reserve a pids charge for a process or thread that is not runnable yet.
 pub(crate) fn begin_task_at(
-    parent: Arc<CgroupNode>,
+    target: Arc<CgroupNode>,
     process_id: ProcessId,
     task_id: ProcessId,
     child_kind: CgroupChildKind,
 ) -> CgroupResult<CgroupForkGuard> {
     let mut state = state()?.lock_irqsave();
-    reserve_task(&mut state, parent, process_id, task_id, child_kind)
+    reserve_task(&mut state, target, process_id, task_id, child_kind)
 }
 
 /// Resolve the process's current cgroup and reserve a task charge atomically
@@ -171,7 +171,7 @@ pub(crate) fn begin_task(
 
 fn reserve_task(
     state: &mut MembershipState,
-    parent: Arc<CgroupNode>,
+    target: Arc<CgroupNode>,
     process_id: ProcessId,
     task_id: ProcessId,
     child_kind: CgroupChildKind,
@@ -180,7 +180,7 @@ fn reserve_task(
         return Err(CgroupError::ResourceBusy);
     }
 
-    let charged_path = ancestry(&parent);
+    let charged_path = ancestry(&target);
     charge_path(&charged_path)?;
     state.pending_tasks.insert(task_id, process_id);
     let task_process_id = match child_kind {
@@ -188,7 +188,7 @@ fn reserve_task(
         CgroupChildKind::Thread => process_id,
     };
     Ok(CgroupForkGuard {
-        cgroup: parent,
+        cgroup: target,
         task_id,
         task_process_id,
         child_kind,
@@ -515,6 +515,50 @@ mod tests {
         assert_eq!(exit_task(pid, pid, CgroupTaskExit::LastProcessTask), Ok(()));
         assert_eq!(exit_task(pid, pid, CgroupTaskExit::LastProcessTask), Ok(()));
         assert!(!root.has_member(pid));
+    }
+
+    #[test]
+    fn explicit_process_reservation_charges_only_the_target_path() {
+        let _guard = setup();
+        let root = crate::root();
+        let source = root.create_child("explicit-process-source").unwrap();
+        let target = root.create_child("explicit-process-target").unwrap();
+        let parent = process_id(1032);
+        let child = process_id(1033);
+        root.write_subtree_control("+pids").unwrap();
+        commit_process(&source, parent);
+        target.write_pids_max("1").unwrap();
+
+        let pending = crate::begin_process_at(Arc::clone(&target), child).unwrap();
+        assert!(Arc::ptr_eq(&pending.cgroup(), &target));
+        assert_eq!(source.pids_current_text().unwrap(), "1\n");
+        assert_eq!(target.pids_current_text().unwrap(), "1\n");
+
+        drop(pending);
+        assert_eq!(source.pids_current_text().unwrap(), "1\n");
+        assert_eq!(target.pids_current_text().unwrap(), "0\n");
+
+        let mut pending = crate::begin_process_at(Arc::clone(&target), child).unwrap();
+        pending.commit();
+        assert!(target.has_member(child));
+        assert_eq!(source.pids_current_text().unwrap(), "1\n");
+        assert_eq!(target.pids_current_text().unwrap(), "1\n");
+
+        exit_task(child, child, CgroupTaskExit::LastProcessTask).unwrap();
+        assert!(!target.has_member(child));
+        assert_eq!(source.pids_current_text().unwrap(), "1\n");
+        assert_eq!(target.pids_current_text().unwrap(), "0\n");
+
+        target.write_pids_max("0").unwrap();
+        assert!(matches!(
+            crate::begin_process_at(Arc::clone(&target), child),
+            Err(CgroupError::LimitExceeded)
+        ));
+        assert_eq!(source.pids_current_text().unwrap(), "1\n");
+        assert_eq!(target.pids_current_text().unwrap(), "0\n");
+        assert_eq!(target.pids_events_text().unwrap(), "max 1\n");
+
+        exit_task(parent, parent, CgroupTaskExit::LastProcessTask).unwrap();
     }
 
     #[test]

--- a/components/ax-cgroup/src/membership.rs
+++ b/components/ax-cgroup/src/membership.rs
@@ -1,4 +1,10 @@
-use alloc::{collections::BTreeSet, sync::Arc};
+//! Process membership and task-lifecycle transactions.
+
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+    vec::Vec,
+};
 
 use ax_lazyinit::LazyInit;
 use ax_sync::SpinLock;
@@ -13,12 +19,30 @@ pub trait CgroupProvider: Send + Sync {
     /// Snapshot the process's authoritative cgroup membership.
     fn membership(&self, pid: ProcessId) -> Option<Arc<CgroupNode>>;
 
+    /// Return all live task IDs in the process.
+    fn task_ids(&self, pid: ProcessId) -> Vec<ProcessId>;
+
     /// Replace the process's authoritative cgroup membership.
     fn set_membership(&self, pid: ProcessId, cgroup: Arc<CgroupNode>);
 }
 
+/// Whether a new task is also a new process in `cgroup.procs`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CgroupChildKind {
+    Process,
+    Thread,
+}
+
+/// Whether an exiting task ends its process membership.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CgroupTaskExit {
+    Thread,
+    LastProcessTask,
+}
+
 struct MembershipState {
-    pending_forks: BTreeSet<ProcessId>,
+    pending_tasks: BTreeSet<ProcessId>,
+    tasks: BTreeMap<ProcessId, Arc<CgroupNode>>,
 }
 
 static STATE: LazyInit<SpinLock<MembershipState>> = LazyInit::new();
@@ -26,7 +50,8 @@ static PROVIDER: LazyInit<&'static dyn CgroupProvider> = LazyInit::new();
 
 pub(crate) fn init() {
     STATE.init_once(SpinLock::new(MembershipState {
-        pending_forks: BTreeSet::new(),
+        pending_tasks: BTreeSet::new(),
+        tasks: BTreeMap::new(),
     }));
 }
 
@@ -42,9 +67,16 @@ fn provider() -> CgroupResult<&'static dyn CgroupProvider> {
     PROVIDER.get().copied().ok_or(CgroupError::NotInitialized)
 }
 
+/// Attach the initial task to the root without applying a configurable limit.
 pub(crate) fn attach_initial_process(root: Arc<CgroupNode>, pid: ProcessId) -> CgroupResult<()> {
-    let _state = state()?.lock_irqsave();
+    let mut state = state()?.lock_irqsave();
+    if state.tasks.contains_key(&pid) {
+        return Err(CgroupError::ResourceBusy);
+    }
+
+    charge_path_unchecked(&ancestry(&root), 1);
     root.add_member(pid);
+    state.tasks.insert(pid, root);
     Ok(())
 }
 
@@ -53,62 +85,80 @@ enum ForkState {
     Committed,
 }
 
-/// Rolls back a pending cgroup fork unless membership is committed.
+/// Rolls back a pending cgroup task reservation unless it is committed.
 pub struct CgroupForkGuard {
     cgroup: Arc<CgroupNode>,
-    pid: ProcessId,
+    task_id: ProcessId,
+    child_kind: CgroupChildKind,
+    charged_path: Vec<Arc<CgroupNode>>,
     state: ForkState,
 }
 
 impl CgroupForkGuard {
     /// Publish inherited membership before the child becomes runnable.
     pub fn commit(&mut self) {
+        if matches!(self.state, ForkState::Committed) {
+            return;
+        }
+
         let mut state = STATE
             .get()
-            // SAFE-EXPECT: a fork guard can only be created after membership initialization.
+            // SAFE-EXPECT: a fork guard can only be created after initialization.
             .expect("cgroup membership must be initialized")
             .lock_irqsave();
-        state.pending_forks.remove(&self.pid);
-        self.cgroup.add_member(self.pid);
+        state.pending_tasks.remove(&self.task_id);
+        if matches!(self.child_kind, CgroupChildKind::Process) {
+            self.cgroup.add_member(self.task_id);
+        }
+        state.tasks.insert(self.task_id, Arc::clone(&self.cgroup));
         self.state = ForkState::Committed;
     }
 }
 
 impl Drop for CgroupForkGuard {
     fn drop(&mut self) {
-        if matches!(self.state, ForkState::Pending)
-            && let Some(state) = STATE.get()
-        {
-            state.lock_irqsave().pending_forks.remove(&self.pid);
+        if !matches!(self.state, ForkState::Pending) {
+            return;
         }
+
+        if let Some(state) = STATE.get() {
+            state.lock_irqsave().pending_tasks.remove(&self.task_id);
+        }
+        uncharge_path(&self.charged_path, 1);
     }
 }
 
-pub(crate) fn begin_fork(
+/// Reserve a pids charge for a process or thread that is not runnable yet.
+pub(crate) fn begin_task(
     parent: Arc<CgroupNode>,
-    child_pid: ProcessId,
+    task_id: ProcessId,
+    child_kind: CgroupChildKind,
 ) -> CgroupResult<CgroupForkGuard> {
     let mut state = state()?.lock_irqsave();
-    if !state.pending_forks.insert(child_pid) {
+    if state.pending_tasks.contains(&task_id) || state.tasks.contains_key(&task_id) {
         return Err(CgroupError::ResourceBusy);
     }
+
+    let charged_path = ancestry(&parent);
+    charge_path(&charged_path)?;
+    state.pending_tasks.insert(task_id);
     Ok(CgroupForkGuard {
         cgroup: parent,
-        pid: child_pid,
+        task_id,
+        child_kind,
+        charged_path,
         state: ForkState::Pending,
     })
 }
 
+/// Move all live tasks of a process to another cgroup.
 pub(crate) fn migrate_process(pid: ProcessId, target: Arc<CgroupNode>) -> CgroupResult<()> {
-    let state = state()?.lock_irqsave();
-    if state.pending_forks.contains(&pid) {
-        return Err(CgroupError::ResourceBusy);
-    }
-
+    let mut state = state()?.lock_irqsave();
     let provider = provider()?;
     if provider.is_zombie(pid) {
         return Err(CgroupError::NoSuchProcess);
     }
+
     let old = provider.membership(pid).ok_or(CgroupError::NoSuchProcess)?;
     if Arc::ptr_eq(&old, &target) {
         return old
@@ -116,31 +166,150 @@ pub(crate) fn migrate_process(pid: ProcessId, target: Arc<CgroupNode>) -> Cgroup
             .then_some(())
             .ok_or(CgroupError::NoSuchProcess);
     }
-    if !old.remove_member(pid) {
+    if state.pending_tasks.contains(&pid) {
+        return Err(CgroupError::ResourceBusy);
+    }
+
+    let task_ids = provider.task_ids(pid);
+    if task_ids.is_empty() {
         return Err(CgroupError::NoSuchProcess);
     }
+    for task_id in &task_ids {
+        if state.pending_tasks.contains(task_id)
+            || !state
+                .tasks
+                .get(task_id)
+                .is_some_and(|cgroup| Arc::ptr_eq(cgroup, &old))
+        {
+            return Err(CgroupError::ResourceBusy);
+        }
+    }
+
+    let old_path = ancestry(&old);
+    let target_path = ancestry(&target);
+    let (old_unique, target_unique) = unique_paths(&old_path, &target_path);
+    let task_count = task_ids.len() as u64;
+    charge_path_unchecked(target_unique, task_count);
+
+    if !old.remove_member(pid) {
+        uncharge_path(target_unique, task_count);
+        return Err(CgroupError::NoSuchProcess);
+    }
+
     target.add_member(pid);
-    provider.set_membership(pid, target);
+    provider.set_membership(pid, Arc::clone(&target));
+    for task_id in task_ids {
+        state.tasks.insert(task_id, Arc::clone(&target));
+    }
+    uncharge_path(old_unique, task_count);
     Ok(())
 }
 
-pub(crate) fn exit_process(pid: ProcessId) -> CgroupResult<()> {
-    let _state = state()?.lock_irqsave();
-    let provider = provider()?;
-    let cgroup = provider.membership(pid).ok_or(CgroupError::NoSuchProcess)?;
-    cgroup.remove_member(pid);
+/// Release one task charge and, for the final task, process membership.
+pub(crate) fn exit_task(
+    process_pid: ProcessId,
+    task_tid: ProcessId,
+    exit_kind: CgroupTaskExit,
+) -> CgroupResult<()> {
+    let mut state = state()?.lock_irqsave();
+    let Some(cgroup) = state.tasks.remove(&task_tid) else {
+        // Teardown is intentionally idempotent: a repeated exit notification
+        // must not decrement the pids ledger twice.
+        return Ok(());
+    };
+
+    if matches!(exit_kind, CgroupTaskExit::LastProcessTask) {
+        cgroup.remove_member(process_pid);
+    }
+    uncharge_path(&ancestry(&cgroup), 1);
     Ok(())
+}
+
+/// Rename a live task identity after `execve` de-threading.
+pub(crate) fn rename_task(old_tid: ProcessId, new_tid: ProcessId) -> CgroupResult<()> {
+    let mut state = state()?.lock_irqsave();
+    let cgroup = state
+        .tasks
+        .remove(&old_tid)
+        .ok_or(CgroupError::NoSuchProcess)?;
+    if state.tasks.contains_key(&new_tid) {
+        state.tasks.insert(old_tid, cgroup);
+        return Err(CgroupError::ResourceBusy);
+    }
+    state.tasks.insert(new_tid, cgroup);
+    Ok(())
+}
+
+fn ancestry(node: &Arc<CgroupNode>) -> Vec<Arc<CgroupNode>> {
+    let mut nodes = Vec::new();
+    let mut current = Some(Arc::clone(node));
+    while let Some(node) = current {
+        current = node.parent();
+        nodes.push(node);
+    }
+    nodes
+}
+
+fn charge_path(path: &[Arc<CgroupNode>]) -> CgroupResult<()> {
+    for (charged, node) in path.iter().enumerate() {
+        if let Err(error) = node.try_charge_pids() {
+            uncharge_path(&path[..charged], 1);
+            record_max_event(&path[charged..]);
+            return Err(error);
+        }
+    }
+    Ok(())
+}
+
+fn record_max_event(failed_node_and_ancestors: &[Arc<CgroupNode>]) {
+    for node in failed_node_and_ancestors {
+        if node.parent().is_some() {
+            node.record_pids_max_event();
+        }
+    }
+}
+
+fn charge_path_unchecked(path: &[Arc<CgroupNode>], count: u64) {
+    for node in path {
+        node.charge_pids_unchecked(count);
+    }
+}
+
+fn uncharge_path(path: &[Arc<CgroupNode>], count: u64) {
+    for node in path {
+        node.uncharge_pids(count);
+    }
+}
+
+fn unique_paths<'a>(
+    old_path: &'a [Arc<CgroupNode>],
+    target_path: &'a [Arc<CgroupNode>],
+) -> (&'a [Arc<CgroupNode>], &'a [Arc<CgroupNode>]) {
+    let mut old_unique = old_path.len();
+    let mut target_unique = target_path.len();
+    while old_unique > 0
+        && target_unique > 0
+        && Arc::ptr_eq(&old_path[old_unique - 1], &target_path[target_unique - 1])
+    {
+        old_unique -= 1;
+        target_unique -= 1;
+    }
+    (&old_path[..old_unique], &target_path[..target_unique])
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::collections::{BTreeMap, BTreeSet};
+    use alloc::{
+        collections::{BTreeMap, BTreeSet},
+        vec,
+    };
     use std::sync::{LazyLock, Mutex, MutexGuard, Once};
 
     use super::*;
 
     struct MockProvider {
         memberships: Mutex<BTreeMap<ProcessId, Arc<CgroupNode>>>,
+        task_groups: Mutex<BTreeMap<ProcessId, Vec<ProcessId>>>,
         zombies: Mutex<BTreeSet<ProcessId>>,
     }
 
@@ -153,6 +322,15 @@ mod tests {
             self.memberships.lock().unwrap().get(&pid).cloned()
         }
 
+        fn task_ids(&self, pid: ProcessId) -> Vec<ProcessId> {
+            self.task_groups
+                .lock()
+                .unwrap()
+                .get(&pid)
+                .cloned()
+                .unwrap_or_default()
+        }
+
         fn set_membership(&self, pid: ProcessId, cgroup: Arc<CgroupNode>) {
             self.memberships.lock().unwrap().insert(pid, cgroup);
         }
@@ -160,6 +338,7 @@ mod tests {
 
     static PROVIDER: MockProvider = MockProvider {
         memberships: Mutex::new(BTreeMap::new()),
+        task_groups: Mutex::new(BTreeMap::new()),
         zombies: Mutex::new(BTreeSet::new()),
     };
     static INIT: Once = Once::new();
@@ -176,29 +355,36 @@ mod tests {
             register_provider(&PROVIDER);
         });
         PROVIDER.memberships.lock().unwrap().clear();
+        PROVIDER.task_groups.lock().unwrap().clear();
         PROVIDER.zombies.lock().unwrap().clear();
         guard
     }
 
-    #[test]
-    fn migration_updates_node_lists_and_authoritative_handle() {
-        let _guard = setup();
-        let root = crate::root();
-        let target = root.create_child("migration-target").unwrap();
-        let pid = process_id(1001);
-        root.add_member(pid);
+    fn commit_process(root: &Arc<CgroupNode>, pid: ProcessId) {
+        let mut guard = begin_task(Arc::clone(root), pid, CgroupChildKind::Process).unwrap();
+        guard.commit();
         PROVIDER
             .memberships
             .lock()
             .unwrap()
-            .insert(pid, root.clone());
+            .insert(pid, Arc::clone(root));
+        PROVIDER.task_groups.lock().unwrap().insert(pid, vec![pid]);
+    }
 
-        migrate_process(pid, target.clone()).unwrap();
+    #[test]
+    fn migration_updates_all_task_mappings_and_node_lists() {
+        let _guard = setup();
+        let root = crate::root();
+        let target = root.create_child("migration-target").unwrap();
+        let pid = process_id(1001);
+        commit_process(&root, pid);
+
+        migrate_process(pid, Arc::clone(&target)).unwrap();
 
         assert!(!root.has_member(pid));
         assert!(target.has_member(pid));
         assert!(Arc::ptr_eq(&PROVIDER.membership(pid).unwrap(), &target));
-        exit_process(pid).unwrap();
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
     }
 
     #[test]
@@ -206,16 +392,27 @@ mod tests {
         let _guard = setup();
         let root = crate::root();
         let pid = process_id(1002);
-        root.add_member(pid);
-        PROVIDER
-            .memberships
-            .lock()
-            .unwrap()
-            .insert(pid, root.clone());
+        commit_process(&root, pid);
 
-        assert_eq!(migrate_process(pid, root.clone()), Ok(()));
+        assert_eq!(migrate_process(pid, Arc::clone(&root)), Ok(()));
         assert!(root.has_member(pid));
-        exit_process(pid).unwrap();
+
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn migration_preserves_a_process_that_has_exceeded_its_target_limit() {
+        let _guard = setup();
+        let root = crate::root();
+        let target = root.create_child("over-limit-target").unwrap();
+        let pid = process_id(1003);
+        commit_process(&root, pid);
+        root.write_subtree_control("+pids").unwrap();
+        target.write_pids_max("0").unwrap();
+
+        migrate_process(pid, Arc::clone(&target)).unwrap();
+        assert_eq!(target.pids_current_text().unwrap(), "1\n");
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
     }
 
     #[test]
@@ -225,40 +422,195 @@ mod tests {
         let target = root.create_child("invalid-target").unwrap();
 
         assert_eq!(
-            migrate_process(process_id(1003), target.clone()),
+            migrate_process(process_id(1004), Arc::clone(&target)),
             Err(CgroupError::NoSuchProcess)
         );
 
-        let zombie = process_id(1004);
-        PROVIDER.memberships.lock().unwrap().insert(zombie, root);
+        let zombie = process_id(1005);
+        commit_process(&root, zombie);
         PROVIDER.zombies.lock().unwrap().insert(zombie);
         assert_eq!(
             migrate_process(zombie, target),
             Err(CgroupError::NoSuchProcess)
         );
+        exit_task(zombie, zombie, CgroupTaskExit::LastProcessTask).unwrap();
     }
 
     #[test]
-    fn fork_guard_rolls_back_or_commits_before_exit() {
+    fn task_guard_rolls_back_or_commits_before_exit() {
         let _guard = setup();
         let root = crate::root();
-        let pid = process_id(1005);
-        PROVIDER
-            .memberships
-            .lock()
-            .unwrap()
-            .insert(pid, root.clone());
+        let pid = process_id(1006);
 
-        drop(begin_fork(root.clone(), pid).unwrap());
+        drop(begin_task(Arc::clone(&root), pid, CgroupChildKind::Process).unwrap());
         assert!(!root.has_member(pid));
 
-        let mut guard = begin_fork(root.clone(), pid).unwrap();
+        let mut guard = begin_task(Arc::clone(&root), pid, CgroupChildKind::Process).unwrap();
         guard.commit();
         drop(guard);
         assert!(root.has_member(pid));
 
-        assert_eq!(exit_process(pid), Ok(()));
-        assert_eq!(exit_process(pid), Ok(()));
+        assert_eq!(exit_task(pid, pid, CgroupTaskExit::LastProcessTask), Ok(()));
+        assert_eq!(exit_task(pid, pid, CgroupTaskExit::LastProcessTask), Ok(()));
         assert!(!root.has_member(pid));
+    }
+
+    #[test]
+    fn thread_charge_does_not_create_a_process_member() {
+        let _guard = setup();
+        let root = crate::root();
+        let cgroup = root.create_child("thread-accounting-target").unwrap();
+        let pid = process_id(1007);
+        let tid = process_id(1008);
+        root.write_subtree_control("+pids").unwrap();
+        commit_process(&cgroup, pid);
+
+        let mut guard = begin_task(Arc::clone(&cgroup), tid, CgroupChildKind::Thread).unwrap();
+        guard.commit();
+
+        assert!(cgroup.has_member(pid));
+        assert!(!cgroup.has_member(tid));
+        assert_eq!(cgroup.pids_current_text().unwrap(), "2\n");
+
+        exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
+        assert_eq!(cgroup.pids_current_text().unwrap(), "1\n");
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn migration_moves_a_complete_thread_group_without_double_charging_ancestors() {
+        let _guard = setup();
+        let root = crate::root();
+        let parent = root.create_child("thread-group-migration-parent").unwrap();
+        root.write_subtree_control("+pids").unwrap();
+        parent.write_subtree_control("+pids").unwrap();
+        let source = parent.create_child("source").unwrap();
+        let target = parent.create_child("target").unwrap();
+        let pid = process_id(1009);
+        let tid = process_id(1010);
+        commit_process(&source, pid);
+
+        let mut thread = begin_task(Arc::clone(&source), tid, CgroupChildKind::Thread).unwrap();
+        thread.commit();
+        PROVIDER
+            .task_groups
+            .lock()
+            .unwrap()
+            .get_mut(&pid)
+            .unwrap()
+            .push(tid);
+        target.write_pids_max("0").unwrap();
+
+        assert_eq!(source.pids_current_text().unwrap(), "2\n");
+        assert_eq!(parent.pids_current_text().unwrap(), "2\n");
+        migrate_process(pid, Arc::clone(&target)).unwrap();
+
+        assert!(!source.has_member(pid));
+        assert!(target.has_member(pid));
+        assert_eq!(source.pids_current_text().unwrap(), "0\n");
+        assert_eq!(target.pids_current_text().unwrap(), "2\n");
+        assert_eq!(parent.pids_current_text().unwrap(), "2\n");
+
+        exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
+        assert_eq!(target.pids_current_text().unwrap(), "1\n");
+        assert_eq!(parent.pids_current_text().unwrap(), "1\n");
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+        assert_eq!(target.pids_current_text().unwrap(), "0\n");
+        assert_eq!(parent.pids_current_text().unwrap(), "0\n");
+    }
+
+    #[test]
+    fn migration_rejects_a_pending_thread_without_moving_the_process() {
+        let _guard = setup();
+        let root = crate::root();
+        let source = root.create_child("pending-migration-source").unwrap();
+        let target = root.create_child("pending-migration-target").unwrap();
+        let pid = process_id(1011);
+        let tid = process_id(1012);
+        root.write_subtree_control("+pids").unwrap();
+        commit_process(&source, pid);
+        let pending = begin_task(Arc::clone(&source), tid, CgroupChildKind::Thread).unwrap();
+        PROVIDER
+            .task_groups
+            .lock()
+            .unwrap()
+            .get_mut(&pid)
+            .unwrap()
+            .push(tid);
+
+        assert_eq!(source.pids_current_text().unwrap(), "2\n");
+        assert_eq!(
+            migrate_process(pid, Arc::clone(&target)),
+            Err(CgroupError::ResourceBusy)
+        );
+        assert!(source.has_member(pid));
+        assert!(!target.has_member(pid));
+        assert_eq!(source.pids_current_text().unwrap(), "2\n");
+        assert_eq!(target.pids_current_text().unwrap(), "0\n");
+
+        drop(pending);
+        assert_eq!(source.pids_current_text().unwrap(), "1\n");
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn leaf_limit_event_is_visible_in_ancestor_events() {
+        let _guard = setup();
+        let root = crate::root();
+        let parent = root.create_child("hierarchical-event-parent").unwrap();
+        root.write_subtree_control("+pids").unwrap();
+        parent.write_subtree_control("+pids").unwrap();
+        let child = parent.create_child("hierarchical-event-child").unwrap();
+        let pid = process_id(1013);
+        let tid = process_id(1014);
+        commit_process(&child, pid);
+        child.write_pids_max("1").unwrap();
+
+        assert!(matches!(
+            begin_task(Arc::clone(&child), tid, CgroupChildKind::Thread),
+            Err(CgroupError::LimitExceeded)
+        ));
+        assert_eq!(child.pids_events_text().unwrap(), "max 1\n");
+        assert_eq!(parent.pids_events_text().unwrap(), "max 1\n");
+
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn de_thread_rename_preserves_the_last_task_charge() {
+        let _guard = setup();
+        let root = crate::root();
+        let cgroup = root.create_child("de-thread-rename-target").unwrap();
+        let pid = process_id(1015);
+        let tid = process_id(1016);
+        root.write_subtree_control("+pids").unwrap();
+        commit_process(&cgroup, pid);
+        let mut thread = begin_task(Arc::clone(&cgroup), tid, CgroupChildKind::Thread).unwrap();
+        thread.commit();
+
+        exit_task(pid, pid, CgroupTaskExit::Thread).unwrap();
+        assert!(cgroup.has_member(pid));
+        assert_eq!(cgroup.pids_current_text().unwrap(), "1\n");
+        rename_task(tid, pid).unwrap();
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+
+        assert!(!cgroup.has_member(pid));
+        assert_eq!(cgroup.pids_current_text().unwrap(), "0\n");
+    }
+
+    #[test]
+    fn rename_rejects_a_live_target_without_losing_the_source_task() {
+        let _guard = setup();
+        let root = crate::root();
+        let cgroup = root.create_child("rename-collision-target").unwrap();
+        let pid = process_id(1017);
+        let tid = process_id(1018);
+        commit_process(&cgroup, pid);
+        let mut thread = begin_task(Arc::clone(&cgroup), tid, CgroupChildKind::Thread).unwrap();
+        thread.commit();
+
+        assert_eq!(rename_task(tid, pid), Err(CgroupError::ResourceBusy));
+        exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
     }
 }

--- a/components/ax-cgroup/src/membership.rs
+++ b/components/ax-cgroup/src/membership.rs
@@ -15,9 +15,6 @@ pub trait CgroupProvider: Send + Sync {
     /// Snapshot the process's authoritative cgroup membership.
     fn membership(&self, pid: ProcessId) -> Option<Arc<CgroupNode>>;
 
-    /// Return all live task IDs in the process.
-    fn task_ids(&self, pid: ProcessId) -> Vec<ProcessId>;
-
     /// Replace the process's authoritative cgroup membership.
     fn set_membership(&self, pid: ProcessId, cgroup: Arc<CgroupNode>);
 }
@@ -38,7 +35,12 @@ pub enum CgroupTaskExit {
 
 struct MembershipState {
     pending_tasks: BTreeMap<ProcessId, ProcessId>,
-    tasks: BTreeMap<ProcessId, Arc<CgroupNode>>,
+    tasks: BTreeMap<ProcessId, TaskMembership>,
+}
+
+struct TaskMembership {
+    process_id: ProcessId,
+    cgroup: Arc<CgroupNode>,
 }
 
 static STATE: LazyInit<SpinLock<MembershipState>> = LazyInit::new();
@@ -72,7 +74,13 @@ pub(crate) fn attach_initial_process(root: Arc<CgroupNode>, pid: ProcessId) -> C
 
     charge_path_unchecked(&ancestry(&root), 1);
     root.add_member(pid);
-    state.tasks.insert(pid, root);
+    state.tasks.insert(
+        pid,
+        TaskMembership {
+            process_id: pid,
+            cgroup: root,
+        },
+    );
     Ok(())
 }
 
@@ -85,6 +93,7 @@ enum ForkState {
 pub struct CgroupForkGuard {
     cgroup: Arc<CgroupNode>,
     task_id: ProcessId,
+    task_process_id: ProcessId,
     child_kind: CgroupChildKind,
     charged_path: Vec<Arc<CgroupNode>>,
     state: ForkState,
@@ -111,7 +120,13 @@ impl CgroupForkGuard {
         if matches!(self.child_kind, CgroupChildKind::Process) {
             self.cgroup.add_member(self.task_id);
         }
-        state.tasks.insert(self.task_id, Arc::clone(&self.cgroup));
+        state.tasks.insert(
+            self.task_id,
+            TaskMembership {
+                process_id: self.task_process_id,
+                cgroup: Arc::clone(&self.cgroup),
+            },
+        );
         self.state = ForkState::Committed;
     }
 }
@@ -168,9 +183,14 @@ fn reserve_task(
     let charged_path = ancestry(&parent);
     charge_path(&charged_path)?;
     state.pending_tasks.insert(task_id, process_id);
+    let task_process_id = match child_kind {
+        CgroupChildKind::Process => task_id,
+        CgroupChildKind::Thread => process_id,
+    };
     Ok(CgroupForkGuard {
         cgroup: parent,
         task_id,
+        task_process_id,
         child_kind,
         charged_path,
         state: ForkState::Pending,
@@ -200,16 +220,19 @@ pub(crate) fn migrate_process(pid: ProcessId, target: Arc<CgroupNode>) -> Cgroup
         return Err(CgroupError::ResourceBusy);
     }
 
-    let task_ids = provider.task_ids(pid);
+    let task_ids: Vec<_> = state
+        .tasks
+        .iter()
+        .filter_map(|(task_id, membership)| (membership.process_id == pid).then_some(*task_id))
+        .collect();
     if task_ids.is_empty() {
         return Err(CgroupError::NoSuchProcess);
     }
     for task_id in &task_ids {
-        if state.pending_tasks.contains_key(task_id)
-            || !state
-                .tasks
-                .get(task_id)
-                .is_some_and(|cgroup| Arc::ptr_eq(cgroup, &old))
+        if !state
+            .tasks
+            .get(task_id)
+            .is_some_and(|membership| Arc::ptr_eq(&membership.cgroup, &old))
         {
             return Err(CgroupError::ResourceBusy);
         }
@@ -229,7 +252,11 @@ pub(crate) fn migrate_process(pid: ProcessId, target: Arc<CgroupNode>) -> Cgroup
     target.add_member(pid);
     provider.set_membership(pid, Arc::clone(&target));
     for task_id in task_ids {
-        state.tasks.insert(task_id, Arc::clone(&target));
+        state
+            .tasks
+            .get_mut(&task_id)
+            .expect("cgroup task ledger changed while locked")
+            .cgroup = Arc::clone(&target);
     }
     uncharge_path(old_unique, task_count);
     Ok(())
@@ -242,31 +269,50 @@ pub(crate) fn exit_task(
     exit_kind: CgroupTaskExit,
 ) -> CgroupResult<()> {
     let mut state = state()?.lock_irqsave();
-    let Some(cgroup) = state.tasks.remove(&task_tid) else {
+    let Some(membership) = state.tasks.get(&task_tid) else {
         // Teardown is intentionally idempotent: a repeated exit notification
         // must not decrement the pids ledger twice.
         return Ok(());
     };
+    if membership.process_id != process_pid {
+        return Err(CgroupError::NoSuchProcess);
+    }
+    let membership = state
+        .tasks
+        .remove(&task_tid)
+        .expect("validated cgroup task disappeared while locked");
 
     if matches!(exit_kind, CgroupTaskExit::LastProcessTask) {
-        cgroup.remove_member(process_pid);
+        membership.cgroup.remove_member(process_pid);
     }
-    uncharge_path(&ancestry(&cgroup), 1);
+    uncharge_path(&ancestry(&membership.cgroup), 1);
     Ok(())
 }
 
 /// Rename a live task identity after `execve` de-threading.
-pub(crate) fn rename_task(old_tid: ProcessId, new_tid: ProcessId) -> CgroupResult<()> {
+pub(crate) fn rename_task(
+    process_id: ProcessId,
+    old_tid: ProcessId,
+    new_tid: ProcessId,
+) -> CgroupResult<()> {
     let mut state = state()?.lock_irqsave();
-    let cgroup = state
+    let membership = state
         .tasks
-        .remove(&old_tid)
+        .get(&old_tid)
         .ok_or(CgroupError::NoSuchProcess)?;
-    if state.tasks.contains_key(&new_tid) {
-        state.tasks.insert(old_tid, cgroup);
+    if membership.process_id != process_id {
+        return Err(CgroupError::NoSuchProcess);
+    }
+    if old_tid != new_tid
+        && (state.pending_tasks.contains_key(&new_tid) || state.tasks.contains_key(&new_tid))
+    {
         return Err(CgroupError::ResourceBusy);
     }
-    state.tasks.insert(new_tid, cgroup);
+    let membership = state
+        .tasks
+        .remove(&old_tid)
+        .expect("validated cgroup task disappeared while locked");
+    state.tasks.insert(new_tid, membership);
     Ok(())
 }
 
@@ -329,17 +375,13 @@ fn unique_paths<'a>(
 
 #[cfg(test)]
 mod tests {
-    use alloc::{
-        collections::{BTreeMap, BTreeSet},
-        vec,
-    };
+    use alloc::collections::{BTreeMap, BTreeSet};
     use std::sync::{LazyLock, Mutex, MutexGuard, Once};
 
     use super::*;
 
     struct MockProvider {
         memberships: Mutex<BTreeMap<ProcessId, Arc<CgroupNode>>>,
-        task_groups: Mutex<BTreeMap<ProcessId, Vec<ProcessId>>>,
         zombies: Mutex<BTreeSet<ProcessId>>,
     }
 
@@ -352,15 +394,6 @@ mod tests {
             self.memberships.lock().unwrap().get(&pid).cloned()
         }
 
-        fn task_ids(&self, pid: ProcessId) -> Vec<ProcessId> {
-            self.task_groups
-                .lock()
-                .unwrap()
-                .get(&pid)
-                .cloned()
-                .unwrap_or_default()
-        }
-
         fn set_membership(&self, pid: ProcessId, cgroup: Arc<CgroupNode>) {
             self.memberships.lock().unwrap().insert(pid, cgroup);
         }
@@ -368,7 +401,6 @@ mod tests {
 
     static PROVIDER: MockProvider = MockProvider {
         memberships: Mutex::new(BTreeMap::new()),
-        task_groups: Mutex::new(BTreeMap::new()),
         zombies: Mutex::new(BTreeSet::new()),
     };
     static INIT: Once = Once::new();
@@ -385,7 +417,6 @@ mod tests {
             register_provider(&PROVIDER);
         });
         PROVIDER.memberships.lock().unwrap().clear();
-        PROVIDER.task_groups.lock().unwrap().clear();
         PROVIDER.zombies.lock().unwrap().clear();
         guard
     }
@@ -399,7 +430,6 @@ mod tests {
             .lock()
             .unwrap()
             .insert(pid, Arc::clone(root));
-        PROVIDER.task_groups.lock().unwrap().insert(pid, vec![pid]);
     }
 
     #[test]
@@ -526,13 +556,6 @@ mod tests {
         let mut thread =
             begin_task_at(Arc::clone(&source), pid, tid, CgroupChildKind::Thread).unwrap();
         thread.commit();
-        PROVIDER
-            .task_groups
-            .lock()
-            .unwrap()
-            .get_mut(&pid)
-            .unwrap()
-            .push(tid);
         target.write_pids_max("0").unwrap();
 
         assert_eq!(source.pids_current_text().unwrap(), "2\n");
@@ -581,6 +604,80 @@ mod tests {
     }
 
     #[test]
+    fn migration_tracks_multiple_pending_tasks_by_process_owner() {
+        let _guard = setup();
+        let root = crate::root();
+        let source = root.create_child("multiple-pending-source").unwrap();
+        let target = root.create_child("multiple-pending-target").unwrap();
+        let pid = process_id(1021);
+        let tid1 = process_id(1022);
+        let tid2 = process_id(1023);
+        root.write_subtree_control("+pids").unwrap();
+        commit_process(&source, pid);
+
+        let pending1 = begin_task(pid, tid1, CgroupChildKind::Thread).unwrap();
+        let pending2 = begin_task(pid, tid2, CgroupChildKind::Thread).unwrap();
+        assert_eq!(
+            migrate_process(pid, Arc::clone(&target)),
+            Err(CgroupError::ResourceBusy)
+        );
+
+        drop(pending1);
+        assert_eq!(
+            migrate_process(pid, Arc::clone(&target)),
+            Err(CgroupError::ResourceBusy)
+        );
+        drop(pending2);
+        migrate_process(pid, Arc::clone(&target)).unwrap();
+        assert_eq!(target.pids_current_text().unwrap(), "1\n");
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn unrelated_pending_task_does_not_block_process_migration() {
+        let _guard = setup();
+        let root = crate::root();
+        let source = root.create_child("unrelated-pending-source").unwrap();
+        let target = root.create_child("unrelated-pending-target").unwrap();
+        let first = process_id(1024);
+        let second = process_id(1025);
+        let pending_tid = process_id(1026);
+        root.write_subtree_control("+pids").unwrap();
+        commit_process(&source, first);
+        commit_process(&source, second);
+
+        let pending = begin_task(second, pending_tid, CgroupChildKind::Thread).unwrap();
+        migrate_process(first, Arc::clone(&target)).unwrap();
+        assert_eq!(target.pids_current_text().unwrap(), "1\n");
+
+        drop(pending);
+        exit_task(second, second, CgroupTaskExit::LastProcessTask).unwrap();
+        exit_task(first, first, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn committed_task_migrates_without_provider_thread_publication() {
+        let _guard = setup();
+        let root = crate::root();
+        let source = root.create_child("ledger-only-source").unwrap();
+        let target = root.create_child("ledger-only-target").unwrap();
+        let pid = process_id(1027);
+        let tid = process_id(1028);
+        root.write_subtree_control("+pids").unwrap();
+        commit_process(&source, pid);
+
+        let mut thread =
+            begin_task_at(Arc::clone(&source), pid, tid, CgroupChildKind::Thread).unwrap();
+        thread.commit();
+        // The mock provider intentionally exposes only the process leader.
+        migrate_process(pid, Arc::clone(&target)).unwrap();
+        assert_eq!(target.pids_current_text().unwrap(), "2\n");
+
+        exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
     fn leaf_limit_event_is_visible_in_ancestor_events() {
         let _guard = setup();
         let root = crate::root();
@@ -619,7 +716,17 @@ mod tests {
         exit_task(pid, pid, CgroupTaskExit::Thread).unwrap();
         assert!(cgroup.has_member(pid));
         assert_eq!(cgroup.pids_current_text().unwrap(), "1\n");
-        rename_task(tid, pid).unwrap();
+        assert_eq!(
+            rename_task(process_id(1099), tid, pid),
+            Err(CgroupError::NoSuchProcess)
+        );
+        assert_eq!(cgroup.pids_current_text().unwrap(), "1\n");
+        rename_task(pid, tid, pid).unwrap();
+        assert_eq!(
+            exit_task(process_id(1099), pid, CgroupTaskExit::LastProcessTask),
+            Err(CgroupError::NoSuchProcess)
+        );
+        assert_eq!(cgroup.pids_current_text().unwrap(), "1\n");
         exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
 
         assert!(!cgroup.has_member(pid));
@@ -638,7 +745,7 @@ mod tests {
             begin_task_at(Arc::clone(&cgroup), pid, tid, CgroupChildKind::Thread).unwrap();
         thread.commit();
 
-        assert_eq!(rename_task(tid, pid), Err(CgroupError::ResourceBusy));
+        assert_eq!(rename_task(pid, tid, pid), Err(CgroupError::ResourceBusy));
         exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
         exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
     }
@@ -663,5 +770,26 @@ mod tests {
         task.commit();
         exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
         exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn process_task_commits_under_the_child_process_owner() {
+        let _guard = setup();
+        let root = crate::root();
+        let cgroup = root.create_child("process-owner-target").unwrap();
+        let parent = process_id(1030);
+        let child = process_id(1031);
+
+        let mut process =
+            begin_task_at(Arc::clone(&cgroup), parent, child, CgroupChildKind::Process).unwrap();
+        process.commit();
+
+        assert_eq!(
+            exit_task(parent, child, CgroupTaskExit::LastProcessTask),
+            Err(CgroupError::NoSuchProcess)
+        );
+        assert!(cgroup.has_member(child));
+        exit_task(child, child, CgroupTaskExit::LastProcessTask).unwrap();
+        assert!(!cgroup.has_member(child));
     }
 }

--- a/components/ax-cgroup/src/membership.rs
+++ b/components/ax-cgroup/src/membership.rs
@@ -1,10 +1,6 @@
 //! Process membership and task-lifecycle transactions.
 
-use alloc::{
-    collections::{BTreeMap, BTreeSet},
-    sync::Arc,
-    vec::Vec,
-};
+use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 
 use ax_lazyinit::LazyInit;
 use ax_sync::SpinLock;
@@ -41,7 +37,7 @@ pub enum CgroupTaskExit {
 }
 
 struct MembershipState {
-    pending_tasks: BTreeSet<ProcessId>,
+    pending_tasks: BTreeMap<ProcessId, ProcessId>,
     tasks: BTreeMap<ProcessId, Arc<CgroupNode>>,
 }
 
@@ -50,7 +46,7 @@ static PROVIDER: LazyInit<&'static dyn CgroupProvider> = LazyInit::new();
 
 pub(crate) fn init() {
     STATE.init_once(SpinLock::new(MembershipState {
-        pending_tasks: BTreeSet::new(),
+        pending_tasks: BTreeMap::new(),
         tasks: BTreeMap::new(),
     }));
 }
@@ -95,6 +91,11 @@ pub struct CgroupForkGuard {
 }
 
 impl CgroupForkGuard {
+    /// Return the cgroup inherited by the reserved task.
+    pub fn cgroup(&self) -> Arc<CgroupNode> {
+        Arc::clone(&self.cgroup)
+    }
+
     /// Publish inherited membership before the child becomes runnable.
     pub fn commit(&mut self) {
         if matches!(self.state, ForkState::Committed) {
@@ -129,19 +130,44 @@ impl Drop for CgroupForkGuard {
 }
 
 /// Reserve a pids charge for a process or thread that is not runnable yet.
-pub(crate) fn begin_task(
+pub(crate) fn begin_task_at(
     parent: Arc<CgroupNode>,
+    process_id: ProcessId,
     task_id: ProcessId,
     child_kind: CgroupChildKind,
 ) -> CgroupResult<CgroupForkGuard> {
     let mut state = state()?.lock_irqsave();
-    if state.pending_tasks.contains(&task_id) || state.tasks.contains_key(&task_id) {
+    reserve_task(&mut state, parent, process_id, task_id, child_kind)
+}
+
+/// Resolve the process's current cgroup and reserve a task charge atomically
+/// with migration and other membership transactions.
+pub(crate) fn begin_task(
+    process_id: ProcessId,
+    task_id: ProcessId,
+    child_kind: CgroupChildKind,
+) -> CgroupResult<CgroupForkGuard> {
+    let mut state = state()?.lock_irqsave();
+    let parent = provider()?
+        .membership(process_id)
+        .ok_or(CgroupError::NoSuchProcess)?;
+    reserve_task(&mut state, parent, process_id, task_id, child_kind)
+}
+
+fn reserve_task(
+    state: &mut MembershipState,
+    parent: Arc<CgroupNode>,
+    process_id: ProcessId,
+    task_id: ProcessId,
+    child_kind: CgroupChildKind,
+) -> CgroupResult<CgroupForkGuard> {
+    if state.pending_tasks.contains_key(&task_id) || state.tasks.contains_key(&task_id) {
         return Err(CgroupError::ResourceBusy);
     }
 
     let charged_path = ancestry(&parent);
     charge_path(&charged_path)?;
-    state.pending_tasks.insert(task_id);
+    state.pending_tasks.insert(task_id, process_id);
     Ok(CgroupForkGuard {
         cgroup: parent,
         task_id,
@@ -166,7 +192,11 @@ pub(crate) fn migrate_process(pid: ProcessId, target: Arc<CgroupNode>) -> Cgroup
             .then_some(())
             .ok_or(CgroupError::NoSuchProcess);
     }
-    if state.pending_tasks.contains(&pid) {
+    if state
+        .pending_tasks
+        .values()
+        .any(|process_id| *process_id == pid)
+    {
         return Err(CgroupError::ResourceBusy);
     }
 
@@ -175,7 +205,7 @@ pub(crate) fn migrate_process(pid: ProcessId, target: Arc<CgroupNode>) -> Cgroup
         return Err(CgroupError::NoSuchProcess);
     }
     for task_id in &task_ids {
-        if state.pending_tasks.contains(task_id)
+        if state.pending_tasks.contains_key(task_id)
             || !state
                 .tasks
                 .get(task_id)
@@ -361,7 +391,8 @@ mod tests {
     }
 
     fn commit_process(root: &Arc<CgroupNode>, pid: ProcessId) {
-        let mut guard = begin_task(Arc::clone(root), pid, CgroupChildKind::Process).unwrap();
+        let mut guard =
+            begin_task_at(Arc::clone(root), pid, pid, CgroupChildKind::Process).unwrap();
         guard.commit();
         PROVIDER
             .memberships
@@ -442,10 +473,11 @@ mod tests {
         let root = crate::root();
         let pid = process_id(1006);
 
-        drop(begin_task(Arc::clone(&root), pid, CgroupChildKind::Process).unwrap());
+        drop(begin_task_at(Arc::clone(&root), pid, pid, CgroupChildKind::Process).unwrap());
         assert!(!root.has_member(pid));
 
-        let mut guard = begin_task(Arc::clone(&root), pid, CgroupChildKind::Process).unwrap();
+        let mut guard =
+            begin_task_at(Arc::clone(&root), pid, pid, CgroupChildKind::Process).unwrap();
         guard.commit();
         drop(guard);
         assert!(root.has_member(pid));
@@ -465,7 +497,8 @@ mod tests {
         root.write_subtree_control("+pids").unwrap();
         commit_process(&cgroup, pid);
 
-        let mut guard = begin_task(Arc::clone(&cgroup), tid, CgroupChildKind::Thread).unwrap();
+        let mut guard =
+            begin_task_at(Arc::clone(&cgroup), pid, tid, CgroupChildKind::Thread).unwrap();
         guard.commit();
 
         assert!(cgroup.has_member(pid));
@@ -490,7 +523,8 @@ mod tests {
         let tid = process_id(1010);
         commit_process(&source, pid);
 
-        let mut thread = begin_task(Arc::clone(&source), tid, CgroupChildKind::Thread).unwrap();
+        let mut thread =
+            begin_task_at(Arc::clone(&source), pid, tid, CgroupChildKind::Thread).unwrap();
         thread.commit();
         PROVIDER
             .task_groups
@@ -529,14 +563,7 @@ mod tests {
         let tid = process_id(1012);
         root.write_subtree_control("+pids").unwrap();
         commit_process(&source, pid);
-        let pending = begin_task(Arc::clone(&source), tid, CgroupChildKind::Thread).unwrap();
-        PROVIDER
-            .task_groups
-            .lock()
-            .unwrap()
-            .get_mut(&pid)
-            .unwrap()
-            .push(tid);
+        let pending = begin_task(pid, tid, CgroupChildKind::Thread).unwrap();
 
         assert_eq!(source.pids_current_text().unwrap(), "2\n");
         assert_eq!(
@@ -567,7 +594,7 @@ mod tests {
         child.write_pids_max("1").unwrap();
 
         assert!(matches!(
-            begin_task(Arc::clone(&child), tid, CgroupChildKind::Thread),
+            begin_task_at(Arc::clone(&child), pid, tid, CgroupChildKind::Thread),
             Err(CgroupError::LimitExceeded)
         ));
         assert_eq!(child.pids_events_text().unwrap(), "max 1\n");
@@ -585,7 +612,8 @@ mod tests {
         let tid = process_id(1016);
         root.write_subtree_control("+pids").unwrap();
         commit_process(&cgroup, pid);
-        let mut thread = begin_task(Arc::clone(&cgroup), tid, CgroupChildKind::Thread).unwrap();
+        let mut thread =
+            begin_task_at(Arc::clone(&cgroup), pid, tid, CgroupChildKind::Thread).unwrap();
         thread.commit();
 
         exit_task(pid, pid, CgroupTaskExit::Thread).unwrap();
@@ -606,10 +634,33 @@ mod tests {
         let pid = process_id(1017);
         let tid = process_id(1018);
         commit_process(&cgroup, pid);
-        let mut thread = begin_task(Arc::clone(&cgroup), tid, CgroupChildKind::Thread).unwrap();
+        let mut thread =
+            begin_task_at(Arc::clone(&cgroup), pid, tid, CgroupChildKind::Thread).unwrap();
         thread.commit();
 
         assert_eq!(rename_task(tid, pid), Err(CgroupError::ResourceBusy));
+        exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn task_reservation_uses_the_process_current_membership() {
+        let _guard = setup();
+        let root = crate::root();
+        let source = root.create_child("reservation-source").unwrap();
+        let target = root.create_child("reservation-target").unwrap();
+        let pid = process_id(1019);
+        let tid = process_id(1020);
+        root.write_subtree_control("+pids").unwrap();
+        commit_process(&source, pid);
+        migrate_process(pid, Arc::clone(&target)).unwrap();
+
+        let mut task = begin_task(pid, tid, CgroupChildKind::Thread).unwrap();
+        assert!(Arc::ptr_eq(&task.cgroup(), &target));
+        assert_eq!(source.pids_current_text().unwrap(), "0\n");
+        assert_eq!(target.pids_current_text().unwrap(), "2\n");
+
+        task.commit();
         exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
         exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
     }

--- a/components/ax-cgroup/src/node.rs
+++ b/components/ax-cgroup/src/node.rs
@@ -4,14 +4,16 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 use ax_sync::SpinLock;
 
-use crate::{CgroupError, CgroupResult, ProcessId};
+use crate::{CgroupError, CgroupResult, ProcessId, pids::PidsState};
 
 static NEXT_CGROUP_ID: AtomicU64 = AtomicU64::new(2);
 const NESTED_CHILDREN_LOCK_SUBCLASS: u32 = 1;
+const PIDS_CONTROLLER: &[&str] = &["pids"];
+const NO_CONTROLLERS: &[&str] = &[];
 
 /// A stable node in the cgroup v2 hierarchy.
 pub struct CgroupNode {
@@ -20,6 +22,8 @@ pub struct CgroupNode {
     parent: Option<Weak<Self>>,
     children: SpinLock<BTreeMap<String, Arc<Self>>>,
     members: SpinLock<BTreeSet<ProcessId>>,
+    pids: PidsState,
+    pids_enabled_for_children: AtomicBool,
     pins: AtomicUsize,
 }
 
@@ -36,6 +40,8 @@ impl CgroupNode {
             parent: None,
             children: SpinLock::new(BTreeMap::new()),
             members: SpinLock::new(BTreeSet::new()),
+            pids: PidsState::new(),
+            pids_enabled_for_children: AtomicBool::new(false),
             pins: AtomicUsize::new(0),
         })
     }
@@ -55,6 +61,71 @@ impl CgroupNode {
         self.parent.as_ref().and_then(Weak::upgrade)
     }
 
+    /// Return controllers this cgroup may enable for its direct children.
+    pub fn available_controllers(&self) -> &'static [&'static str] {
+        if self.parent.is_none()
+            || self
+                .parent()
+                .is_some_and(|parent| parent.pids_enabled_for_children.load(Ordering::Acquire))
+        {
+            PIDS_CONTROLLER
+        } else {
+            NO_CONTROLLERS
+        }
+    }
+
+    /// Return controllers enabled for direct child cgroups.
+    pub fn enabled_subtree_controllers(&self) -> &'static [&'static str] {
+        if self.pids_enabled_for_children.load(Ordering::Acquire) {
+            PIDS_CONTROLLER
+        } else {
+            NO_CONTROLLERS
+        }
+    }
+
+    /// Enable pids for direct children.
+    ///
+    /// The first controller increment intentionally supports only `+pids`.
+    /// Other controller updates remain unsupported until their domain behavior
+    /// is implemented and independently validated.
+    pub fn write_subtree_control(&self, data: &str) -> CgroupResult<()> {
+        if data.trim() != "+pids" || !self.available_controllers().contains(&"pids") {
+            return Err(CgroupError::InvalidInput);
+        }
+        self.pids_enabled_for_children
+            .store(true, Ordering::Release);
+        Ok(())
+    }
+
+    /// Return whether this non-root cgroup exposes pids interface files.
+    pub fn has_pids_interface(&self) -> bool {
+        self.parent.is_some() && self.available_controllers().contains(&"pids")
+    }
+
+    /// Render `pids.max`.
+    pub fn pids_max_text(&self) -> CgroupResult<String> {
+        self.require_pids_interface()?;
+        Ok(self.pids.maximum_text())
+    }
+
+    /// Render `pids.current`.
+    pub fn pids_current_text(&self) -> CgroupResult<String> {
+        self.require_pids_interface()?;
+        Ok(self.pids.current_text())
+    }
+
+    /// Render `pids.events`.
+    pub fn pids_events_text(&self) -> CgroupResult<String> {
+        self.require_pids_interface()?;
+        Ok(self.pids.events_text())
+    }
+
+    /// Update `pids.max`.
+    pub fn write_pids_max(&self, data: &str) -> CgroupResult<()> {
+        self.require_pids_interface()?;
+        self.pids.set_maximum(data)
+    }
+
     /// Create a direct child.
     pub fn create_child(self: &Arc<Self>, name: &str) -> CgroupResult<Arc<Self>> {
         if name.is_empty() || name == "." || name == ".." || name.contains('/') {
@@ -71,6 +142,8 @@ impl CgroupNode {
             parent: Some(Arc::downgrade(self)),
             children: SpinLock::new(BTreeMap::new()),
             members: SpinLock::new(BTreeSet::new()),
+            pids: PidsState::new(),
+            pids_enabled_for_children: AtomicBool::new(false),
             pins: AtomicUsize::new(0),
         });
         children.insert(name.to_string(), Arc::clone(&child));
@@ -128,12 +201,34 @@ impl CgroupNode {
         self.members.lock_irqsave().contains(&pid)
     }
 
+    pub(crate) fn try_charge_pids(&self) -> CgroupResult<()> {
+        self.pids.try_charge()
+    }
+
+    pub(crate) fn charge_pids_unchecked(&self, count: u64) {
+        self.pids.charge_unchecked(count);
+    }
+
+    pub(crate) fn uncharge_pids(&self, count: u64) {
+        self.pids.uncharge(count);
+    }
+
+    pub(crate) fn record_pids_max_event(&self) {
+        self.pids.record_max_event();
+    }
+
     /// Pin this node as a namespace or mounted hierarchy root.
     pub fn pin(self: &Arc<Self>) -> CgroupPin {
         self.pins.fetch_add(1, Ordering::AcqRel);
         CgroupPin {
             node: Arc::clone(self),
         }
+    }
+
+    fn require_pids_interface(&self) -> CgroupResult<()> {
+        self.has_pids_interface()
+            .then_some(())
+            .ok_or(CgroupError::NotFound)
     }
 }
 
@@ -224,6 +319,21 @@ mod tests {
         drop(pin);
         assert_eq!(root.remove_child("child"), Ok(()));
         assert_eq!(incidental_reference.name(), "child");
+    }
+
+    #[test]
+    fn exposes_pids_only_after_the_parent_enables_it() {
+        let root = CgroupNode::new_root();
+        let child = root.create_child("child").unwrap();
+
+        assert_eq!(root.available_controllers(), ["pids"]);
+        assert!(!child.has_pids_interface());
+        assert_eq!(child.pids_max_text(), Err(CgroupError::NotFound));
+
+        root.write_subtree_control("+pids").unwrap();
+
+        assert!(child.has_pids_interface());
+        assert_eq!(child.pids_max_text(), Ok(String::from("max\n")));
     }
 
     #[test]

--- a/components/ax-cgroup/src/pids.rs
+++ b/components/ax-cgroup/src/pids.rs
@@ -1,0 +1,170 @@
+//! Per-cgroup pids accounting.
+//!
+//! The pids controller counts tasks in a cgroup and every ancestor. The
+//! membership layer serializes path updates; this module only owns one node's
+//! atomic counter and limit state.
+
+use alloc::{format, string::String};
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use crate::{CgroupError, CgroupResult};
+
+const UNLIMITED: u64 = u64::MAX;
+
+pub(crate) struct PidsState {
+    current: AtomicU64,
+    maximum: AtomicU64,
+    max_events: AtomicU64,
+}
+
+impl PidsState {
+    pub(crate) const fn new() -> Self {
+        Self {
+            current: AtomicU64::new(0),
+            maximum: AtomicU64::new(UNLIMITED),
+            max_events: AtomicU64::new(0),
+        }
+    }
+
+    /// Charge one task while enforcing this node's configured limit.
+    pub(crate) fn try_charge(&self) -> CgroupResult<()> {
+        loop {
+            let current = self.current.load(Ordering::Acquire);
+            let maximum = self.maximum.load(Ordering::Acquire);
+            if current >= maximum || current == UNLIMITED {
+                return Err(CgroupError::LimitExceeded);
+            }
+
+            if self
+                .current
+                .compare_exchange(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
+                .is_ok()
+            {
+                return Ok(());
+            }
+        }
+    }
+
+    /// Account for organizational movement without applying `pids.max`.
+    pub(crate) fn charge_unchecked(&self, count: u64) {
+        let previous = self.current.fetch_add(count, Ordering::AcqRel);
+        debug_assert!(previous <= UNLIMITED - count, "pids.current overflow");
+    }
+
+    /// Release a task count that was previously charged to this node.
+    pub(crate) fn uncharge(&self, count: u64) {
+        let current = self.current.load(Ordering::Acquire);
+        debug_assert!(current >= count, "pids.current underflow");
+        self.current.fetch_sub(count, Ordering::AcqRel);
+    }
+
+    pub(crate) fn record_max_event(&self) {
+        self.max_events.fetch_add(1, Ordering::AcqRel);
+    }
+
+    pub(crate) fn maximum_text(&self) -> String {
+        let maximum = self.maximum.load(Ordering::Acquire);
+        if maximum == UNLIMITED {
+            String::from("max\n")
+        } else {
+            format!("{maximum}\n")
+        }
+    }
+
+    pub(crate) fn current_text(&self) -> String {
+        format!("{}\n", self.current.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn events_text(&self) -> String {
+        format!("max {}\n", self.max_events.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn set_maximum(&self, value: &str) -> CgroupResult<()> {
+        let maximum = match value.trim() {
+            "max" => UNLIMITED,
+            text => text
+                .parse::<u64>()
+                .ok()
+                .filter(|value| *value != UNLIMITED)
+                .ok_or(CgroupError::InvalidInput)?,
+        };
+        self.maximum.store(maximum, Ordering::Release);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicUsize, Ordering},
+        },
+        thread,
+    };
+
+    use super::*;
+
+    #[test]
+    fn denies_the_next_task_and_records_the_limit_event() {
+        let state = PidsState::new();
+        state.set_maximum("1").unwrap();
+
+        assert_eq!(state.try_charge(), Ok(()));
+        assert_eq!(state.try_charge(), Err(CgroupError::LimitExceeded));
+        state.record_max_event();
+        assert_eq!(state.current_text(), "1\n");
+        assert_eq!(state.events_text(), "max 1\n");
+    }
+
+    #[test]
+    fn organizational_charge_may_exceed_the_configured_limit() {
+        let state = PidsState::new();
+        state.set_maximum("1").unwrap();
+
+        state.charge_unchecked(2);
+
+        assert_eq!(state.current_text(), "2\n");
+        assert_eq!(state.try_charge(), Err(CgroupError::LimitExceeded));
+    }
+
+    #[test]
+    fn rejects_invalid_pids_max_values() {
+        let state = PidsState::new();
+
+        assert_eq!(state.set_maximum("-1"), Err(CgroupError::InvalidInput));
+        assert_eq!(state.set_maximum(""), Err(CgroupError::InvalidInput));
+        assert_eq!(state.maximum_text(), "max\n");
+    }
+
+    #[test]
+    fn concurrent_charges_never_overshoot_the_limit() {
+        const LIMIT: usize = 8;
+        const ATTEMPTS: usize = 32;
+
+        let state = Arc::new(PidsState::new());
+        state.set_maximum("8").unwrap();
+        let start = Arc::new(Barrier::new(ATTEMPTS));
+        let successes = Arc::new(AtomicUsize::new(0));
+
+        thread::scope(|scope| {
+            for _ in 0..ATTEMPTS {
+                let state = Arc::clone(&state);
+                let start = Arc::clone(&start);
+                let successes = Arc::clone(&successes);
+                scope.spawn(move || {
+                    start.wait();
+                    if state.try_charge().is_ok() {
+                        successes.fetch_add(1, Ordering::AcqRel);
+                    }
+                });
+            }
+        });
+
+        assert_eq!(successes.load(Ordering::Acquire), LIMIT);
+        assert_eq!(state.current_text(), "8\n");
+
+        state.uncharge(LIMIT as u64);
+        assert_eq!(state.current_text(), "0\n");
+    }
+}

--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -36,21 +36,6 @@ impl ax_cgroup::CgroupProvider for KernelCgroupProvider {
             .map(|process| process.cgroup.read().clone())
     }
 
-    fn task_ids(&self, process: ProcessId) -> alloc::vec::Vec<ProcessId> {
-        process_identity(process)
-            .and_then(|identity| identity.live_data())
-            .map(|process| {
-                process
-                    .proc
-                    .threads()
-                    .into_iter()
-                    .filter_map(|tid| crate::task::ROOT_PID_NS.lookup(tid.pid_number()))
-                    .map(|identity| process_id(&identity))
-                    .collect()
-            })
-            .unwrap_or_default()
-    }
-
     fn set_membership(&self, process: ProcessId, cgroup: Arc<CgroupNode>) {
         if let Some(process) = process_identity(process).and_then(|identity| identity.live_data()) {
             *process.cgroup.write() = cgroup;
@@ -92,10 +77,15 @@ pub fn exit_task(
 
 /// Rename one exact task generation after execve de-threading.
 pub fn rename_task(
+    process: &Arc<PidIdentity>,
     old_task: &Arc<PidIdentity>,
     new_task: &Arc<PidIdentity>,
 ) -> Result<(), CgroupError> {
-    ax_cgroup::rename_task(process_id(old_task), process_id(new_task))
+    ax_cgroup::rename_task(
+        process_id(process),
+        process_id(old_task),
+        process_id(new_task),
+    )
 }
 
 /// Initialize the cgroup hierarchy and kernel process provider.

--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -3,19 +3,24 @@
 use alloc::{string::String, sync::Arc};
 use core::fmt::Write;
 
-use ax_cgroup::{CgroupError, CgroupForkGuard, CgroupNode, ProcessId};
+use ax_cgroup::{
+    CgroupChildKind, CgroupError, CgroupForkGuard, CgroupNode, CgroupTaskExit, ProcessId,
+};
 pub use ax_cgroup::{relative_path, root};
 use ax_task::current;
 
 use crate::{
-    Errno, StarryError,
+    StarryError,
     task::{AsThread, PidIdentity, PidIdentityId, Tgid, TgidNumber, current_pid_view},
 };
 
-const INTERFACE_FILES: [&str; 3] = [
+const INTERFACE_FILES: [&str; 6] = [
     "cgroup.procs",
     "cgroup.controllers",
     "cgroup.subtree_control",
+    "pids.max",
+    "pids.current",
+    "pids.events",
 ];
 
 struct KernelCgroupProvider;
@@ -29,6 +34,21 @@ impl ax_cgroup::CgroupProvider for KernelCgroupProvider {
         process_identity(process)
             .and_then(|identity| identity.live_data())
             .map(|process| process.cgroup.read().clone())
+    }
+
+    fn task_ids(&self, process: ProcessId) -> alloc::vec::Vec<ProcessId> {
+        process_identity(process)
+            .and_then(|identity| identity.live_data())
+            .map(|process| {
+                process
+                    .proc
+                    .threads()
+                    .into_iter()
+                    .filter_map(|tid| crate::task::ROOT_PID_NS.lookup(tid.pid_number()))
+                    .map(|identity| process_id(&identity))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 
     fn set_membership(&self, process: ProcessId, cgroup: Arc<CgroupNode>) {
@@ -52,17 +72,30 @@ pub fn attach_initial_process(identity: &Arc<PidIdentity>) -> Result<(), CgroupE
     ax_cgroup::attach_initial_process(process_id(identity))
 }
 
-/// Prepare inherited membership for a child process generation.
-pub fn begin_fork(
+/// Reserve one task charge before publishing a child identity.
+pub fn begin_task(
     parent: Arc<CgroupNode>,
     child: &Arc<PidIdentity>,
+    child_kind: CgroupChildKind,
 ) -> Result<CgroupForkGuard, CgroupError> {
-    ax_cgroup::begin_fork(parent, process_id(child))
+    ax_cgroup::begin_task(parent, process_id(child), child_kind)
 }
 
-/// Release membership for one exact process generation.
-pub fn exit_process(identity: &Arc<PidIdentity>) -> Result<(), CgroupError> {
-    ax_cgroup::exit_process(process_id(identity))
+/// Release one exact task generation and optionally its process membership.
+pub fn exit_task(
+    process: &Arc<PidIdentity>,
+    task: &Arc<PidIdentity>,
+    exit_kind: CgroupTaskExit,
+) -> Result<(), CgroupError> {
+    ax_cgroup::exit_task(process_id(process), process_id(task), exit_kind)
+}
+
+/// Rename one exact task generation after execve de-threading.
+pub fn rename_task(
+    old_task: &Arc<PidIdentity>,
+    new_task: &Arc<PidIdentity>,
+) -> Result<(), CgroupError> {
+    ax_cgroup::rename_task(process_id(old_task), process_id(new_task))
 }
 
 /// Initialize the cgroup hierarchy and kernel process provider.
@@ -75,8 +108,12 @@ pub fn is_interface_file_name(name: &str) -> bool {
     INTERFACE_FILES.contains(&name)
 }
 
-pub fn controllers_text(_node: &CgroupNode) -> &'static str {
-    ""
+pub fn controllers_text(node: &CgroupNode) -> String {
+    let mut text = String::new();
+    for controller in node.available_controllers() {
+        let _ = writeln!(text, "{controller}");
+    }
+    text
 }
 
 pub fn procs_text(node: &CgroupNode) -> String {
@@ -97,8 +134,12 @@ pub fn procs_text(node: &CgroupNode) -> String {
     text
 }
 
-pub fn subtree_control_text(_node: &CgroupNode) -> &'static str {
-    ""
+pub fn subtree_control_text(node: &CgroupNode) -> String {
+    let mut text = String::new();
+    for controller in node.enabled_subtree_controllers() {
+        let _ = writeln!(text, "{controller}");
+    }
+    text
 }
 
 pub fn write_procs(node: Arc<CgroupNode>, data: &[u8]) -> Result<(), StarryError> {
@@ -115,6 +156,24 @@ pub fn write_procs(node: Arc<CgroupNode>, data: &[u8]) -> Result<(), StarryError
     ax_cgroup::migrate_process(process_id(&identity), node).map_err(StarryError::from)
 }
 
-pub fn write_subtree_control(_node: &CgroupNode, _data: &[u8]) -> Result<(), StarryError> {
-    Err(Errno::EINVAL.into())
+pub fn write_subtree_control(node: &CgroupNode, data: &[u8]) -> Result<(), StarryError> {
+    let data = core::str::from_utf8(data).map_err(|_| StarryError::InvalidInput)?;
+    node.write_subtree_control(data).map_err(StarryError::from)
+}
+
+pub fn pids_max_text(node: &CgroupNode) -> Result<String, StarryError> {
+    node.pids_max_text().map_err(StarryError::from)
+}
+
+pub fn pids_current_text(node: &CgroupNode) -> Result<String, StarryError> {
+    node.pids_current_text().map_err(StarryError::from)
+}
+
+pub fn pids_events_text(node: &CgroupNode) -> Result<String, StarryError> {
+    node.pids_events_text().map_err(StarryError::from)
+}
+
+pub fn write_pids_max(node: &CgroupNode, data: &[u8]) -> Result<(), StarryError> {
+    let data = core::str::from_utf8(data).map_err(|_| StarryError::InvalidInput)?;
+    node.write_pids_max(data).map_err(StarryError::from)
 }

--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -66,6 +66,14 @@ pub fn begin_task(
     ax_cgroup::begin_task(process_id(process), process_id(child), child_kind)
 }
 
+/// Reserve a process task in an explicit target cgroup.
+pub fn begin_process_at(
+    target: Arc<CgroupNode>,
+    child: &Arc<PidIdentity>,
+) -> Result<CgroupForkGuard, CgroupError> {
+    ax_cgroup::begin_process_at(target, process_id(child))
+}
+
 /// Release one exact task generation and optionally its process membership.
 pub fn exit_task(
     process: &Arc<PidIdentity>,

--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -74,11 +74,11 @@ pub fn attach_initial_process(identity: &Arc<PidIdentity>) -> Result<(), CgroupE
 
 /// Reserve one task charge before publishing a child identity.
 pub fn begin_task(
-    parent: Arc<CgroupNode>,
+    process: &Arc<PidIdentity>,
     child: &Arc<PidIdentity>,
     child_kind: CgroupChildKind,
 ) -> Result<CgroupForkGuard, CgroupError> {
-    ax_cgroup::begin_task(parent, process_id(child), child_kind)
+    ax_cgroup::begin_task(process_id(process), process_id(child), child_kind)
 }
 
 /// Release one exact task generation and optionally its process membership.

--- a/os/StarryOS/kernel/src/error.rs
+++ b/os/StarryOS/kernel/src/error.rs
@@ -305,6 +305,7 @@ fn cgroup_errno(error: CgroupError) -> Errno {
         CgroupError::NotFound => Errno::ENOENT,
         CgroupError::AlreadyExists => Errno::EEXIST,
         CgroupError::ResourceBusy => Errno::EBUSY,
+        CgroupError::LimitExceeded => Errno::EAGAIN,
         CgroupError::NoSuchProcess => Errno::ESRCH,
         CgroupError::DirectoryNotEmpty => Errno::ENOTEMPTY,
     }
@@ -545,6 +546,7 @@ fn memory_errno_mappings_hold() -> bool {
         (CgroupError::NotFound.into(), Errno::ENOENT),
         (CgroupError::AlreadyExists.into(), Errno::EEXIST),
         (CgroupError::ResourceBusy.into(), Errno::EBUSY),
+        (CgroupError::LimitExceeded.into(), Errno::EAGAIN),
         (CgroupError::InvalidInput.into(), Errno::EINVAL),
         (CgroupError::NoSuchProcess.into(), Errno::ESRCH),
         (CgroupError::DirectoryNotEmpty.into(), Errno::ENOTEMPTY),

--- a/os/StarryOS/kernel/src/pseudofs/cgroup.rs
+++ b/os/StarryOS/kernel/src/pseudofs/cgroup.rs
@@ -19,6 +19,9 @@ enum CgroupFileKind {
     Controllers,
     Procs,
     SubtreeControl,
+    PidsMax,
+    PidsCurrent,
+    PidsEvents,
 }
 
 impl CgroupFileKind {
@@ -27,6 +30,9 @@ impl CgroupFileKind {
             "cgroup.controllers" => Some(Self::Controllers),
             "cgroup.procs" => Some(Self::Procs),
             "cgroup.subtree_control" => Some(Self::SubtreeControl),
+            "pids.max" => Some(Self::PidsMax),
+            "pids.current" => Some(Self::PidsCurrent),
+            "pids.events" => Some(Self::PidsEvents),
             _ => None,
         }
     }
@@ -36,22 +42,33 @@ impl CgroupFileKind {
             Self::Controllers => "cgroup.controllers",
             Self::Procs => "cgroup.procs",
             Self::SubtreeControl => "cgroup.subtree_control",
+            Self::PidsMax => "pids.max",
+            Self::PidsCurrent => "pids.current",
+            Self::PidsEvents => "pids.events",
         }
     }
 
     fn permission(self) -> NodePermission {
         let mode = match self {
-            Self::Controllers => 0o444,
-            Self::Procs | Self::SubtreeControl => 0o644,
+            Self::Controllers | Self::PidsCurrent | Self::PidsEvents => 0o444,
+            Self::Procs | Self::SubtreeControl | Self::PidsMax => 0o644,
         };
         NodePermission::from_bits_truncate(mode)
     }
+
+    fn is_available(self, cgroup: &CgroupNode) -> bool {
+        !matches!(self, Self::PidsMax | Self::PidsCurrent | Self::PidsEvents)
+            || cgroup.has_pids_interface()
+    }
 }
 
-const CGROUP_FILES: [CgroupFileKind; 3] = [
+const CGROUP_FILES: [CgroupFileKind; 6] = [
     CgroupFileKind::Controllers,
     CgroupFileKind::Procs,
     CgroupFileKind::SubtreeControl,
+    CgroupFileKind::PidsMax,
+    CgroupFileKind::PidsCurrent,
+    CgroupFileKind::PidsEvents,
 ];
 
 struct CgroupFile {
@@ -69,6 +86,13 @@ impl CgroupFile {
             CgroupFileKind::SubtreeControl => crate::cgroup::subtree_control_text(&self.cgroup)
                 .as_bytes()
                 .to_vec(),
+            CgroupFileKind::PidsMax => crate::cgroup::pids_max_text(&self.cgroup)?.into_bytes(),
+            CgroupFileKind::PidsCurrent => {
+                crate::cgroup::pids_current_text(&self.cgroup)?.into_bytes()
+            }
+            CgroupFileKind::PidsEvents => {
+                crate::cgroup::pids_events_text(&self.cgroup)?.into_bytes()
+            }
         })
     }
 }
@@ -95,6 +119,10 @@ impl DirectRwFsFileOps for CgroupFile {
             CgroupFileKind::Procs => crate::cgroup::write_procs(self.cgroup.clone(), buf)?,
             CgroupFileKind::SubtreeControl => {
                 crate::cgroup::write_subtree_control(&self.cgroup, buf)?
+            }
+            CgroupFileKind::PidsMax => crate::cgroup::write_pids_max(&self.cgroup, buf)?,
+            CgroupFileKind::PidsCurrent | CgroupFileKind::PidsEvents => {
+                return Err(VfsError::OperationNotPermitted);
             }
         }
         Ok(buf.len())
@@ -131,6 +159,9 @@ impl CgroupDir {
     }
 
     fn file_entry(&self, kind: CgroupFileKind) -> VfsResult<DirEntry> {
+        if !kind.is_available(&self.cgroup) {
+            return Err(VfsError::NotFound);
+        }
         let file = SpecialFsFile::new_regular_with_perm(
             self.fs.clone(),
             CgroupFile {
@@ -177,7 +208,9 @@ impl DirNodeOps for CgroupDir {
         names.push(DOT.to_string());
         names.push(DOTDOT.to_string());
         for kind in CGROUP_FILES {
-            names.push(kind.name().to_string());
+            if kind.is_available(&self.cgroup) {
+                names.push(kind.name().to_string());
+            }
         }
         names.extend(self.cgroup.child_names());
 
@@ -266,6 +299,7 @@ fn cgroup_error_to_vfs_error(error: CgroupError) -> VfsError {
         CgroupError::NotFound => VfsError::NotFound,
         CgroupError::AlreadyExists => VfsError::AlreadyExists,
         CgroupError::ResourceBusy => VfsError::ResourceBusy,
+        CgroupError::LimitExceeded => VfsError::WouldBlock,
         CgroupError::NoSuchProcess => VfsError::NotFound,
         CgroupError::DirectoryNotEmpty => VfsError::DirectoryNotEmpty,
     }

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -461,6 +461,14 @@ impl CloneArgs {
             *FS_CONTEXT.scope_mut(&mut scope).lock() = fs_context;
         }
 
+        let child_kind = if flags.contains(CloneFlags::THREAD) {
+            ax_cgroup::CgroupChildKind::Thread
+        } else {
+            ax_cgroup::CgroupChildKind::Process
+        };
+        let mut cgroup_guard =
+            crate::cgroup::begin_task(inherited_cgroup.clone(), &identity, child_kind)?;
+        // Reserve pids before publishing the new TID in its thread group.
         new_proc_data.proc.add_thread(root_tid);
 
         let parent_cred = Some(curr_thread.cred());
@@ -509,15 +517,6 @@ impl CloneArgs {
             new_proc_data.set_vfork_done(poll);
         }
 
-        let mut cgroup_guard = if flags.contains(CloneFlags::THREAD) {
-            None
-        } else {
-            Some(
-                crate::cgroup::begin_fork(new_proc_data.cgroup.read().clone(), &identity)
-                    .map_err(StarryError::from)?,
-            )
-        };
-
         if let Some((pidfd_ptr, fd)) = pidfd_copyout {
             pidfd_ptr.vm_write(fd)?;
         }
@@ -563,9 +562,7 @@ impl CloneArgs {
             new_proc_data.set_ptrace_stop(root_tid, starry_signal::Signo::SIGSTOP, &new_uctx);
         }
 
-        if let Some(guard) = &mut cgroup_guard {
-            guard.commit();
-        }
+        cgroup_guard.commit();
         spawn_task_with(new_task, add_task_to_table);
         clone_transaction.commit();
 

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -288,7 +288,6 @@ impl CloneArgs {
         }
 
         let parent_pid_ns = curr_thread.active_pid_namespace();
-        let inherited_cgroup = old_proc_data.cgroup.read().clone();
         let target_pid_ns = if flags.contains(CloneFlags::THREAD) {
             parent_pid_ns.clone()
         } else if flags.contains(CloneFlags::NEWPID) {
@@ -296,6 +295,37 @@ impl CloneArgs {
         } else {
             old_proc_data.nsproxy.lock().pid_ns_for_children.clone()
         };
+        let reservation_kind = if flags.contains(CloneFlags::THREAD) {
+            PidReservationKind::Thread
+        } else {
+            PidReservationKind::ProcessLeader
+        };
+        let reservation = PidReservation::reserve(&target_pid_ns, reservation_kind)?;
+        let root_tid = TidNumber::from(
+            reservation
+                .number_in(&crate::task::ROOT_PID_NS)
+                .ok_or(StarryError::BadState)?,
+        );
+        let parent_visible_tid = TidNumber::from(
+            reservation
+                .number_in(&parent_pid_ns)
+                .ok_or(StarryError::BadState)?,
+        );
+        let identity = reservation.identity();
+        let tid_lease = identity.acquire_role::<Tid>()?;
+        let mut tgid_lease = (!flags.contains(CloneFlags::THREAD))
+            .then(|| identity.acquire_role::<Tgid>())
+            .transpose()?;
+        let mut clone_transaction = CloneTransaction::new(identity.clone());
+
+        let child_kind = if flags.contains(CloneFlags::THREAD) {
+            ax_cgroup::CgroupChildKind::Thread
+        } else {
+            ax_cgroup::CgroupChildKind::Process
+        };
+        let mut cgroup_guard =
+            crate::cgroup::begin_task(&old_proc_data.identity(), &identity, child_kind)?;
+        let inherited_cgroup = cgroup_guard.cgroup();
         let mut prepared_nsproxy = (!flags.contains(CloneFlags::THREAD)).then(|| {
             let mut nsproxy = old_proc_data.nsproxy.lock().clone_all();
             if flags.contains(CloneFlags::NEWUTS) {
@@ -321,28 +351,6 @@ impl CloneArgs {
             }
             nsproxy
         });
-        let reservation_kind = if flags.contains(CloneFlags::THREAD) {
-            PidReservationKind::Thread
-        } else {
-            PidReservationKind::ProcessLeader
-        };
-        let reservation = PidReservation::reserve(&target_pid_ns, reservation_kind)?;
-        let root_tid = TidNumber::from(
-            reservation
-                .number_in(&crate::task::ROOT_PID_NS)
-                .ok_or(StarryError::BadState)?,
-        );
-        let parent_visible_tid = TidNumber::from(
-            reservation
-                .number_in(&parent_pid_ns)
-                .ok_or(StarryError::BadState)?,
-        );
-        let identity = reservation.identity();
-        let tid_lease = identity.acquire_role::<Tid>()?;
-        let mut tgid_lease = (!flags.contains(CloneFlags::THREAD))
-            .then(|| identity.acquire_role::<Tgid>())
-            .transpose()?;
-        let mut clone_transaction = CloneTransaction::new(identity.clone());
 
         let new_proc_data = if flags.contains(CloneFlags::THREAD) {
             new_task
@@ -461,13 +469,6 @@ impl CloneArgs {
             *FS_CONTEXT.scope_mut(&mut scope).lock() = fs_context;
         }
 
-        let child_kind = if flags.contains(CloneFlags::THREAD) {
-            ax_cgroup::CgroupChildKind::Thread
-        } else {
-            ax_cgroup::CgroupChildKind::Process
-        };
-        let mut cgroup_guard =
-            crate::cgroup::begin_task(inherited_cgroup.clone(), &identity, child_kind)?;
         // Reserve pids before publishing the new TID in its thread group.
         new_proc_data.proc.add_thread(root_tid);
 

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -199,7 +199,18 @@ impl CloneArgs {
         if flags.contains(CloneFlags::NEWPID | CloneFlags::THREAD) {
             return Err(StarryError::InvalidInput);
         }
+        if flags.contains(CloneFlags::INTO_CGROUP | CloneFlags::THREAD) {
+            return Err(StarryError::InvalidInput);
+        }
 
+        Ok(())
+    }
+
+    fn validate_cgroup_target(&self, has_requested_cgroup: bool) -> StarryResult<()> {
+        self.validate()?;
+        if self.flags.contains(CloneFlags::INTO_CGROUP) != has_requested_cgroup {
+            return Err(StarryError::InvalidInput);
+        }
         Ok(())
     }
 
@@ -212,7 +223,7 @@ impl CloneArgs {
         uctx: &UserContext,
         requested_cgroup: Option<Arc<ax_cgroup::CgroupNode>>,
     ) -> StarryResult<isize> {
-        self.validate()?;
+        self.validate_cgroup_target(requested_cgroup.is_some())?;
 
         let Self {
             flags,
@@ -323,9 +334,16 @@ impl CloneArgs {
         } else {
             ax_cgroup::CgroupChildKind::Process
         };
-        let mut cgroup_guard =
-            crate::cgroup::begin_task(&old_proc_data.identity(), &identity, child_kind)?;
-        let inherited_cgroup = cgroup_guard.cgroup();
+        let mut cgroup_guard = match (child_kind, requested_cgroup) {
+            (ax_cgroup::CgroupChildKind::Process, Some(target)) => {
+                crate::cgroup::begin_process_at(target, &identity)?
+            }
+            (kind, None) => crate::cgroup::begin_task(&old_proc_data.identity(), &identity, kind)?,
+            (ax_cgroup::CgroupChildKind::Thread, Some(_)) => {
+                unreachable!("CLONE_INTO_CGROUP with CLONE_THREAD passed validation")
+            }
+        };
+        let child_cgroup = cgroup_guard.cgroup();
         let mut prepared_nsproxy = (!flags.contains(CloneFlags::THREAD)).then(|| {
             let mut nsproxy = old_proc_data.nsproxy.lock().clone_all();
             if flags.contains(CloneFlags::NEWUTS) {
@@ -344,7 +362,7 @@ impl CloneArgs {
                 nsproxy.unshare_user();
             }
             if flags.contains(CloneFlags::NEWCGROUP) {
-                nsproxy.unshare_cgroup(inherited_cgroup.clone());
+                nsproxy.unshare_cgroup(child_cgroup.clone());
             }
             if flags.contains(CloneFlags::NEWPID) {
                 nsproxy.pid_ns_for_children = target_pid_ns.clone();
@@ -420,9 +438,7 @@ impl CloneArgs {
             );
             proc_data.set_umask(old_proc_data.umask());
             proc_data.set_nice(old_proc_data.nice());
-            *proc_data.cgroup.write() = requested_cgroup
-                .clone()
-                .unwrap_or_else(|| inherited_cgroup.clone());
+            *proc_data.cgroup.write() = child_cgroup.clone();
             proc_data.set_heap_top(old_proc_data.get_heap_top());
             proc_data.replace_personality(old_proc_data.personality());
             // Inherit parent dumpable (PR_SET_DUMPABLE state). Linux: child
@@ -707,6 +723,25 @@ pub(crate) fn clone_validation_rules_hold_for_test() -> bool {
     }
     .validate()
     .is_err();
+    let thread_with_into_cgroup_rejected = CloneArgs {
+        flags: CloneFlags::THREAD | CloneFlags::VM | CloneFlags::SIGHAND | CloneFlags::INTO_CGROUP,
+        ..Default::default()
+    }
+    .validate_cgroup_target(true)
+    .is_err();
+    let into_cgroup_without_target_rejected = CloneArgs {
+        flags: CloneFlags::INTO_CGROUP,
+        ..Default::default()
+    }
+    .validate_cgroup_target(false)
+    .is_err();
+    let unexpected_target_rejected = CloneArgs::default().validate_cgroup_target(true).is_err();
+    let into_cgroup_with_target_allowed = CloneArgs {
+        flags: CloneFlags::INTO_CGROUP,
+        ..Default::default()
+    }
+    .validate_cgroup_target(true)
+    .is_ok();
     let legacy_parent_newpid_allowed = CloneArgs {
         flags: CloneFlags::PARENT | CloneFlags::NEWPID,
         exit_signal: SIGCHLD as u64,
@@ -764,6 +799,10 @@ pub(crate) fn clone_validation_rules_hold_for_test() -> bool {
         && sighand_without_vm_rejected
         && newns_with_fs_rejected
         && thread_with_newpid_rejected
+        && thread_with_into_cgroup_rejected
+        && into_cgroup_without_target_rejected
+        && unexpected_target_rejected
+        && into_cgroup_with_target_allowed
         && legacy_parent_newpid_allowed
         && thread_without_vm_sighand_rejected
         && vfork_with_thread_rejected
@@ -820,5 +859,30 @@ mod tests {
         };
 
         assert!(args.validate().is_ok());
+    }
+
+    #[test]
+    fn clone_thread_rejects_into_cgroup() {
+        let args = CloneArgs {
+            flags: CloneFlags::THREAD
+                | CloneFlags::VM
+                | CloneFlags::SIGHAND
+                | CloneFlags::INTO_CGROUP,
+            ..Default::default()
+        };
+
+        assert!(args.validate_cgroup_target(true).is_err());
+    }
+
+    #[test]
+    fn clone_into_cgroup_requires_exactly_one_resolved_target() {
+        let args = CloneArgs {
+            flags: CloneFlags::INTO_CGROUP,
+            ..Default::default()
+        };
+        assert!(args.validate_cgroup_target(false).is_err());
+        assert!(args.validate_cgroup_target(true).is_ok());
+
+        assert!(CloneArgs::default().validate_cgroup_target(true).is_err());
     }
 }

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -264,8 +264,8 @@ impl CloneArgs {
             0
         };
 
-        if flags.contains(CloneFlags::PARENT_SETTID) && parent_tid != 0 {
-            crate::mm::prepare_user_write(parent_tid, size_of::<u32>())?;
+        if flags.contains(CloneFlags::PARENT_SETTID) && parent_tid_ptr != 0 {
+            crate::mm::prepare_user_write(parent_tid_ptr, size_of::<u32>())?;
         }
         if flags.contains(CloneFlags::PIDFD) && pidfd != 0 {
             crate::mm::prepare_user_write(pidfd, size_of::<i32>())?;
@@ -530,10 +530,10 @@ impl CloneArgs {
         if let Some(pidfd) = prepared_pidfd.take() {
             pidfd.install();
         }
-        if flags.contains(CloneFlags::PARENT_SETTID) && parent_tid != 0 {
+        if flags.contains(CloneFlags::PARENT_SETTID) && parent_tid_ptr != 0 {
             // Linux performs this copyout after the child is visible and does
             // not roll the child back if a concurrent unmap makes it fail.
-            let _ = (parent_tid as *mut u32).vm_write(parent_visible_tid.get());
+            let _ = (parent_tid_ptr as *mut u32).vm_write(parent_visible_tid.get());
         }
 
         let parent_pid = curr.as_thread().proc_data.proc.pid_number();

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -219,7 +219,7 @@ impl CloneArgs {
             exit_signal,
             stack,
             tls,
-            parent_tid,
+            parent_tid: parent_tid_ptr,
             child_tid,
             pidfd,
         } = self;

--- a/os/StarryOS/kernel/src/syscall/task/execve.rs
+++ b/os/StarryOS/kernel/src/syscall/task/execve.rs
@@ -451,7 +451,8 @@ fn do_execve(
     if my_tid != leader_tid {
         let old_task_identity = thr.pid_identity();
         let leader_identity = proc_data.identity();
-        crate::cgroup::rename_task(&old_task_identity, &leader_identity)?;
+        crate::cgroup::rename_task(&leader_identity, &old_task_identity, &leader_identity)
+            .expect("de-threaded task must own the process's sole cgroup charge");
         let leader_tid_lease = leader_identity
             .acquire_role::<Tid>()
             .expect("exited exec leader retained its TID role");

--- a/os/StarryOS/kernel/src/syscall/task/execve.rs
+++ b/os/StarryOS/kernel/src/syscall/task/execve.rs
@@ -449,7 +449,9 @@ fn do_execve(
     // viewpoint), did its `do_exit(0, false)`, and is no longer in the
     // task table or thread group, so the destination TID is free.
     if my_tid != leader_tid {
+        let old_task_identity = thr.pid_identity();
         let leader_identity = proc_data.identity();
+        crate::cgroup::rename_task(&old_task_identity, &leader_identity)?;
         let leader_tid_lease = leader_identity
             .acquire_role::<Tid>()
             .expect("exited exec leader retained its TID role");

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -399,15 +399,24 @@ pub fn do_exit(exit_code: i32, group_exit: bool) {
     // a non-leader `execve`'s de_thread the two differ, and the thread
     // group is keyed by the user-visible TID.
     let (utime, stime) = task_cpu_time(&curr);
+    let process_identity = thr.proc_data.identity();
+    let task_identity = thr.pid_identity();
     let thread_exit = process.exit_thread(
         thr.tid_number(),
         exit_code,
         ProcessCpuTime::new(utime, stime),
     );
+    let cgroup_exit = match thread_exit {
+        ThreadExit::AlreadyExited => None,
+        ThreadExit::Remaining => Some(ax_cgroup::CgroupTaskExit::Thread),
+        ThreadExit::Last(_) => Some(ax_cgroup::CgroupTaskExit::LastProcessTask),
+    };
+    if let Some(exit_kind) = cgroup_exit
+        && let Err(error) = crate::cgroup::exit_task(&process_identity, &task_identity, exit_kind)
+    {
+        warn!("failed to release cgroup task charge: {error}");
+    }
     if let ThreadExit::Last(process_cpu_time) = thread_exit {
-        if let Err(error) = crate::cgroup::exit_process(&thr.proc_data.identity()) {
-            warn!("failed to release cgroup membership: {error}");
-        }
         thr.proc_data.nsproxy.lock().release_cgroup_namespace();
 
         // AIO contexts pin the process address space and may have worker tasks

--- a/test-suit/starryos/qemu/system/cgroup-basic/src/main.c
+++ b/test-suit/starryos/qemu/system/cgroup-basic/src/main.c
@@ -209,6 +209,22 @@ static void expect_write_errno(const char *path, const char *data,
     CHECK(written == -1 && saved_errno == expected_errno, msg);
 }
 
+static void expect_write_ok(const char *path, const char *data, const char *msg)
+{
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) {
+        CHECK(0, msg);
+        return;
+    }
+
+    errno = 0;
+    ssize_t written = write(fd, data, strlen(data));
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    CHECK(written == (ssize_t)strlen(data), msg);
+}
+
 static void expect_link_errno(const char *old_path, const char *new_path,
                               int expected_errno, const char *msg)
 {
@@ -312,7 +328,8 @@ int main(void)
     nread = read_text_file(CGROUP2_PATH "/cgroup.controllers", buf, sizeof(buf));
     CHECK(nread >= 0, "read root cgroup.controllers");
     if (nread >= 0) {
-        CHECK(nread == 0, "root cgroup.controllers is empty before controllers exist");
+        CHECK(strstr(buf, "pids") != NULL,
+              "root cgroup.controllers advertises the pids controller");
     }
 
     nread = read_text_file(CGROUP2_PATH "/cgroup.subtree_control", buf, sizeof(buf));
@@ -321,17 +338,29 @@ int main(void)
         CHECK(nread == 0, "root cgroup.subtree_control is initially empty");
     }
 
-    expect_write_errno(CGROUP2_PATH "/cgroup.subtree_control", "+pids",
-                       EINVAL, "writing +pids to subtree_control fails with EINVAL");
+    expect_write_ok(CGROUP2_PATH "/cgroup.subtree_control", "+pids",
+                    "writing +pids to subtree_control succeeds");
+    nread = read_text_file(CGROUP2_PATH "/cgroup.subtree_control", buf, sizeof(buf));
+    CHECK(nread >= 0 && strstr(buf, "pids") != NULL,
+          "root cgroup.subtree_control reports enabled pids");
+    expect_write_errno(CGROUP2_PATH "/cgroup.subtree_control", "+not-a-controller",
+                       EINVAL, "unknown controller is rejected with EINVAL");
 
     expect_mkdir_ok(CGROUP2_PATH "/a", "mkdir child cgroup a succeeds");
     expect_path_exists(CGROUP2_PATH "/a", "child cgroup a exists");
     expect_empty_file(CGROUP2_PATH "/a/cgroup.procs",
                       "child cgroup.procs is empty before migration exists");
-    expect_empty_file(CGROUP2_PATH "/a/cgroup.controllers",
-                      "child cgroup.controllers is empty before controllers exist");
+    nread = read_text_file(CGROUP2_PATH "/a/cgroup.controllers", buf, sizeof(buf));
+    CHECK(nread >= 0 && strstr(buf, "pids") != NULL,
+          "child cgroup.controllers inherits available pids");
     expect_empty_file(CGROUP2_PATH "/a/cgroup.subtree_control",
                       "child cgroup.subtree_control is initially empty");
+    expect_path_exists(CGROUP2_PATH "/a/pids.max",
+                       "child pids.max is exposed after parent enables pids");
+    expect_path_exists(CGROUP2_PATH "/a/pids.current",
+                       "child pids.current is exposed after parent enables pids");
+    expect_path_exists(CGROUP2_PATH "/a/pids.events",
+                       "child pids.events is exposed after parent enables pids");
     expect_mkdir_errno(CGROUP2_PATH "/a", EEXIST,
                        "duplicate mkdir child cgroup fails with EEXIST");
 

--- a/test-suit/starryos/qemu/system/cgroup-basic/src/main.c
+++ b/test-suit/starryos/qemu/system/cgroup-basic/src/main.c
@@ -209,22 +209,6 @@ static void expect_write_errno(const char *path, const char *data,
     CHECK(written == -1 && saved_errno == expected_errno, msg);
 }
 
-static void expect_write_ok(const char *path, const char *data, const char *msg)
-{
-    int fd = open(path, O_WRONLY);
-    if (fd < 0) {
-        CHECK(0, msg);
-        return;
-    }
-
-    errno = 0;
-    ssize_t written = write(fd, data, strlen(data));
-    int saved_errno = errno;
-    close(fd);
-    errno = saved_errno;
-    CHECK(written == (ssize_t)strlen(data), msg);
-}
-
 static void expect_link_errno(const char *old_path, const char *new_path,
                               int expected_errno, const char *msg)
 {
@@ -338,11 +322,6 @@ int main(void)
         CHECK(nread == 0, "root cgroup.subtree_control is initially empty");
     }
 
-    expect_write_ok(CGROUP2_PATH "/cgroup.subtree_control", "+pids",
-                    "writing +pids to subtree_control succeeds");
-    nread = read_text_file(CGROUP2_PATH "/cgroup.subtree_control", buf, sizeof(buf));
-    CHECK(nread >= 0 && strstr(buf, "pids") != NULL,
-          "root cgroup.subtree_control reports enabled pids");
     expect_write_errno(CGROUP2_PATH "/cgroup.subtree_control", "+not-a-controller",
                        EINVAL, "unknown controller is rejected with EINVAL");
 
@@ -350,17 +329,16 @@ int main(void)
     expect_path_exists(CGROUP2_PATH "/a", "child cgroup a exists");
     expect_empty_file(CGROUP2_PATH "/a/cgroup.procs",
                       "child cgroup.procs is empty before migration exists");
-    nread = read_text_file(CGROUP2_PATH "/a/cgroup.controllers", buf, sizeof(buf));
-    CHECK(nread >= 0 && strstr(buf, "pids") != NULL,
-          "child cgroup.controllers inherits available pids");
+    expect_empty_file(CGROUP2_PATH "/a/cgroup.controllers",
+                      "child cgroup.controllers is empty before pids is enabled");
     expect_empty_file(CGROUP2_PATH "/a/cgroup.subtree_control",
                       "child cgroup.subtree_control is initially empty");
-    expect_path_exists(CGROUP2_PATH "/a/pids.max",
-                       "child pids.max is exposed after parent enables pids");
-    expect_path_exists(CGROUP2_PATH "/a/pids.current",
-                       "child pids.current is exposed after parent enables pids");
-    expect_path_exists(CGROUP2_PATH "/a/pids.events",
-                       "child pids.events is exposed after parent enables pids");
+    expect_path_missing(CGROUP2_PATH "/a/pids.max",
+                        "child pids.max is hidden before parent enables pids");
+    expect_path_missing(CGROUP2_PATH "/a/pids.current",
+                        "child pids.current is hidden before parent enables pids");
+    expect_path_missing(CGROUP2_PATH "/a/pids.events",
+                        "child pids.events is hidden before parent enables pids");
     expect_mkdir_errno(CGROUP2_PATH "/a", EEXIST,
                        "duplicate mkdir child cgroup fails with EEXIST");
 

--- a/test-suit/starryos/qemu/system/cgroup-pids/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/cgroup-pids/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.20)
+project(cgroup-pids C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(cgroup-pids src/main.c)
+target_compile_options(cgroup-pids PRIVATE -Wall -Wextra -Werror)
+install(TARGETS cgroup-pids RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/cgroup-pids/src/main.c
+++ b/test-suit/starryos/qemu/system/cgroup-pids/src/main.c
@@ -4,6 +4,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <sched.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -31,6 +32,13 @@ static int fail_count;
 #define CHILD_PATH CGROUP2_PATH "/limited"
 #define NESTED_PARENT_PATH CGROUP2_PATH "/nested-parent"
 #define NESTED_CHILD_PATH NESTED_PARENT_PATH "/nested-child"
+#define CLONE_STACK_SIZE (64 * 1024)
+
+static int clone_child(void *arg)
+{
+    (void)arg;
+    return 0;
+}
 
 static ssize_t read_text(const char *path, char *buf, size_t capacity)
 {
@@ -226,10 +234,30 @@ int main(void)
     CHECK(read_number(CHILD_PATH "/pids.current") == 2,
           "pids.current includes parent and held child");
 
+    void *clone_stack = malloc(CLONE_STACK_SIZE);
+    CHECK(clone_stack != NULL, "allocate clone stack");
+    if (clone_stack != NULL) {
+        pid_t parent_tid = -1;
+        errno = 0;
+        int clone_result = clone(clone_child,
+                                 (char *)clone_stack + CLONE_STACK_SIZE,
+                                 CLONE_PARENT_SETTID | SIGCHLD, NULL,
+                                 &parent_tid);
+        int clone_errno = errno;
+        CHECK(clone_result == -1 && clone_errno == EAGAIN,
+              "clone with parent TID is rejected with EAGAIN");
+        CHECK(parent_tid == -1,
+              "denied clone leaves the parent TID pointer unchanged");
+        if (clone_result > 0) {
+            (void)waitpid(clone_result, NULL, 0);
+        }
+        free(clone_stack);
+    }
+
     char event_text[128];
     nread = read_text(CHILD_PATH "/pids.events", event_text, sizeof(event_text));
-    CHECK(nread >= 0 && strstr(event_text, "max 1") != NULL,
-          "pids.events records the denied fork");
+    CHECK(nread >= 0 && strstr(event_text, "max 2") != NULL,
+          "pids.events records both denied task creations");
 
     char release = 'x';
     CHECK(write(gate[1], &release, sizeof(release)) == (ssize_t)sizeof(release),

--- a/test-suit/starryos/qemu/system/cgroup-pids/src/main.c
+++ b/test-suit/starryos/qemu/system/cgroup-pids/src/main.c
@@ -5,11 +5,13 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <sched.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -30,9 +32,25 @@ static int fail_count;
 #define CGROUP2_PATH "/tmp/cg-pids"
 #define PRE_ENABLE_PATH CGROUP2_PATH "/before-enable"
 #define CHILD_PATH CGROUP2_PATH "/limited"
+#define CLONE_INTO_PATH CGROUP2_PATH "/clone-into"
 #define NESTED_PARENT_PATH CGROUP2_PATH "/nested-parent"
 #define NESTED_CHILD_PATH NESTED_PARENT_PATH "/nested-child"
 #define CLONE_STACK_SIZE (64 * 1024)
+#define CLONE_INTO_CGROUP (1ULL << 33)
+
+struct clone_args {
+    unsigned long long flags;
+    unsigned long long pidfd;
+    unsigned long long child_tid;
+    unsigned long long parent_tid;
+    unsigned long long exit_signal;
+    unsigned long long stack;
+    unsigned long long stack_size;
+    unsigned long long tls;
+    unsigned long long set_tid;
+    unsigned long long set_tid_size;
+    unsigned long long cgroup;
+};
 
 static int clone_child(void *arg)
 {
@@ -270,6 +288,43 @@ int main(void)
           "echo 0 returns current process to root");
     CHECK(read_number(CHILD_PATH "/pids.current") == 0,
           "migration back to root releases child charge");
+
+    CHECK(mkdir(CLONE_INTO_PATH, 0755) == 0 || errno == EEXIST,
+          "create clone3 target cgroup");
+    CHECK(write_text(CLONE_INTO_PATH "/pids.max", "0") == 0,
+          "set clone3 target pids.max to zero");
+    int clone_into_fd = open(CLONE_INTO_PATH, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    CHECK(clone_into_fd >= 0, "open clone3 target cgroup");
+    if (clone_into_fd >= 0) {
+        pid_t clone_into_parent_tid = -1;
+        struct clone_args args = {
+            .flags = CLONE_INTO_CGROUP | CLONE_PARENT_SETTID,
+            .parent_tid = (unsigned long long)&clone_into_parent_tid,
+            .exit_signal = SIGCHLD,
+            .cgroup = (unsigned long long)clone_into_fd,
+        };
+        errno = 0;
+        pid_t clone_into = (pid_t)syscall(SYS_clone3, &args, sizeof(args));
+        int clone_into_errno = errno;
+        if (clone_into == 0) {
+            _exit(0);
+        }
+        if (clone_into > 0) {
+            (void)waitpid(clone_into, NULL, 0);
+        }
+        close(clone_into_fd);
+        errno = clone_into_errno;
+        CHECK(clone_into == -1 && clone_into_errno == EAGAIN,
+              "clone3 target pids.max rejects child with EAGAIN");
+        CHECK(clone_into_parent_tid == -1,
+              "denied clone3 leaves the parent TID pointer unchanged");
+    }
+    CHECK(read_number(CLONE_INTO_PATH "/pids.current") == 0,
+          "denied clone3 leaves target pids.current unchanged");
+    expect_text(CLONE_INTO_PATH "/pids.events", "max 1\n",
+                "clone3 target records its own limit failure");
+    CHECK(rmdir(CLONE_INTO_PATH) == 0,
+          "remove empty clone3 target cgroup");
 
     CHECK(mkdir(NESTED_PARENT_PATH, 0755) == 0 || errno == EEXIST,
           "create nested pids parent");

--- a/test-suit/starryos/qemu/system/cgroup-pids/src/main.c
+++ b/test-suit/starryos/qemu/system/cgroup-pids/src/main.c
@@ -1,0 +1,306 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int pass_count;
+static int fail_count;
+
+#define CHECK(cond, msg) do {                                             \
+    if (cond) {                                                           \
+        printf("  PASS | %s\n", msg);                                   \
+        pass_count++;                                                    \
+    } else {                                                             \
+        printf("  FAIL | %s | errno=%d (%s)\n",                         \
+               msg, errno, strerror(errno));                             \
+        fail_count++;                                                    \
+    }                                                                    \
+} while (0)
+
+#define CGROUP2_PATH "/tmp/cg-pids"
+#define PRE_ENABLE_PATH CGROUP2_PATH "/before-enable"
+#define CHILD_PATH CGROUP2_PATH "/limited"
+#define NESTED_PARENT_PATH CGROUP2_PATH "/nested-parent"
+#define NESTED_CHILD_PATH NESTED_PARENT_PATH "/nested-child"
+
+static ssize_t read_text(const char *path, char *buf, size_t capacity)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        return -1;
+    }
+    ssize_t result = read(fd, buf, capacity - 1);
+    int saved_errno = errno;
+    if (result >= 0) {
+        buf[result] = '\0';
+    }
+    close(fd);
+    errno = saved_errno;
+    return result;
+}
+
+static int write_text(const char *path, const char *value)
+{
+    int fd = open(path, O_WRONLY);
+    if (fd < 0) {
+        return -1;
+    }
+    ssize_t expected = (ssize_t)strlen(value);
+    ssize_t result = write(fd, value, (size_t)expected);
+    int saved_errno = errno;
+    close(fd);
+    errno = saved_errno;
+    return result == expected ? 0 : -1;
+}
+
+static long read_number(const char *path)
+{
+    char buf[128];
+    ssize_t nread = read_text(path, buf, sizeof(buf));
+    if (nread < 0) {
+        return -1;
+    }
+    errno = 0;
+    char *end = NULL;
+    long value = strtol(buf, &end, 10);
+    if (end == buf || errno != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    return value;
+}
+
+static void expect_text(const char *path, const char *expected, const char *msg)
+{
+    char buf[128];
+    ssize_t nread = read_text(path, buf, sizeof(buf));
+    CHECK(nread >= 0 && strcmp(buf, expected) == 0, msg);
+}
+
+static void expect_missing(const char *path, const char *msg)
+{
+    errno = 0;
+    int result = access(path, F_OK);
+    int saved_errno = errno;
+    errno = saved_errno;
+    CHECK(result == -1 && saved_errno == ENOENT, msg);
+}
+
+static void expect_write_permission_denied(const char *path, const char *value,
+                                           const char *msg)
+{
+    errno = 0;
+    int fd = open(path, O_WRONLY);
+    int saved_errno = errno;
+    ssize_t result = -1;
+    if (fd >= 0) {
+        errno = 0;
+        result = write(fd, value, strlen(value));
+        saved_errno = errno;
+        close(fd);
+    }
+    errno = saved_errno;
+    CHECK(result == -1 && (saved_errno == EPERM || saved_errno == EACCES), msg);
+}
+
+static void expect_write_errno(const char *path, const char *value,
+                               int expected_errno, const char *msg)
+{
+    errno = 0;
+    int fd = open(path, O_WRONLY);
+    int saved_errno = errno;
+    ssize_t result = -1;
+    if (fd >= 0) {
+        errno = 0;
+        result = write(fd, value, strlen(value));
+        saved_errno = errno;
+        close(fd);
+    }
+    errno = saved_errno;
+    CHECK(result == -1 && saved_errno == expected_errno, msg);
+}
+
+int main(void)
+{
+    printf("================================================\n");
+    printf("  TEST: cgroup-pids\n");
+    printf("================================================\n");
+
+    CHECK(mkdir(CGROUP2_PATH, 0755) == 0 || errno == EEXIST,
+          "create cgroup2 mountpoint");
+    errno = 0;
+    int mount_result = mount("none", CGROUP2_PATH, "cgroup2", 0, NULL);
+    CHECK(mount_result == 0, "mount cgroup2");
+    if (mount_result != 0) {
+        return 1;
+    }
+
+    char controllers[128];
+    ssize_t nread = read_text(CGROUP2_PATH "/cgroup.controllers",
+                               controllers, sizeof(controllers));
+    CHECK(nread >= 0 && strstr(controllers, "pids") != NULL,
+          "root advertises pids");
+    CHECK(mkdir(PRE_ENABLE_PATH, 0755) == 0 || errno == EEXIST,
+          "create child before enabling pids");
+    expect_missing(PRE_ENABLE_PATH "/pids.max",
+                   "pids.max is absent before parent enables pids");
+    expect_missing(CGROUP2_PATH "/pids.max",
+                   "root does not expose pids interface files");
+    CHECK(write_text(CGROUP2_PATH "/cgroup.subtree_control", "+pids") == 0,
+          "enable pids for child cgroups");
+    CHECK(access(PRE_ENABLE_PATH "/pids.max", F_OK) == 0,
+          "existing child gains pids.max after enable");
+    CHECK(access(PRE_ENABLE_PATH "/pids.current", F_OK) == 0,
+          "existing child gains pids.current after enable");
+    CHECK(access(PRE_ENABLE_PATH "/pids.events", F_OK) == 0,
+          "existing child gains pids.events after enable");
+    CHECK(mkdir(CHILD_PATH, 0755) == 0 || errno == EEXIST,
+          "create limited child cgroup");
+    CHECK(access(CHILD_PATH "/pids.max", F_OK) == 0,
+          "child exposes pids.max");
+    CHECK(access(CHILD_PATH "/pids.current", F_OK) == 0,
+          "child exposes pids.current");
+    CHECK(access(CHILD_PATH "/pids.events", F_OK) == 0,
+          "child exposes pids.events");
+    expect_text(CHILD_PATH "/pids.max", "max\n",
+                "pids.max starts unlimited");
+    expect_write_errno(CHILD_PATH "/pids.max", "-1", EINVAL,
+                       "pids.max rejects negative limits");
+    expect_text(CHILD_PATH "/pids.max", "max\n",
+                "invalid pids.max write leaves limit unchanged");
+    expect_text(CHILD_PATH "/pids.events", "max 0\n",
+                "pids.events starts at zero");
+    expect_write_permission_denied(CHILD_PATH "/pids.current", "0",
+                                   "pids.current is read-only");
+    expect_write_permission_denied(CHILD_PATH "/pids.events", "max 0",
+                                   "pids.events is read-only");
+
+    CHECK(write_text(CHILD_PATH "/cgroup.procs", "0") == 0,
+          "migrate current process into child");
+    CHECK(read_number(CHILD_PATH "/pids.current") == 1,
+          "migration charges the current task");
+    CHECK(write_text(CHILD_PATH "/pids.max", "2") == 0,
+          "set pids.max to two tasks");
+    expect_text(CHILD_PATH "/pids.max", "2\n",
+                "pids.max reads back the configured value");
+
+    int gate[2];
+    CHECK(pipe(gate) == 0, "create child synchronization pipe");
+    if (fail_count != 0) {
+        return 1;
+    }
+
+    pid_t first = fork();
+    if (first == 0) {
+        close(gate[1]);
+        char token;
+        (void)read(gate[0], &token, sizeof(token));
+        close(gate[0]);
+        _exit(0);
+    }
+    CHECK(first > 0, "first fork stays within pids.max");
+    if (first < 0) {
+        close(gate[0]);
+        close(gate[1]);
+        return 1;
+    }
+    close(gate[0]);
+
+    errno = 0;
+    pid_t second = fork();
+    int second_errno = errno;
+    CHECK(second == -1 && second_errno == EAGAIN,
+          "second fork is rejected with EAGAIN");
+    if (second > 0) {
+        (void)waitpid(second, NULL, 0);
+    }
+    CHECK(read_number(CHILD_PATH "/pids.current") == 2,
+          "pids.current includes parent and held child");
+
+    char event_text[128];
+    nread = read_text(CHILD_PATH "/pids.events", event_text, sizeof(event_text));
+    CHECK(nread >= 0 && strstr(event_text, "max 1") != NULL,
+          "pids.events records the denied fork");
+
+    char release = 'x';
+    CHECK(write(gate[1], &release, sizeof(release)) == (ssize_t)sizeof(release),
+          "release held child");
+    close(gate[1]);
+    CHECK(waitpid(first, NULL, 0) == first, "child exit is observed");
+    CHECK(read_number(CHILD_PATH "/pids.current") == 1,
+          "child exit releases one pids charge");
+    CHECK(write_text(CGROUP2_PATH "/cgroup.procs", "0") == 0,
+          "echo 0 returns current process to root");
+    CHECK(read_number(CHILD_PATH "/pids.current") == 0,
+          "migration back to root releases child charge");
+
+    CHECK(mkdir(NESTED_PARENT_PATH, 0755) == 0 || errno == EEXIST,
+          "create nested pids parent");
+    CHECK(write_text(NESTED_PARENT_PATH "/cgroup.subtree_control", "+pids") == 0,
+          "enable pids for nested children");
+    CHECK(mkdir(NESTED_CHILD_PATH, 0755) == 0 || errno == EEXIST,
+          "create nested pids child");
+    CHECK(access(NESTED_CHILD_PATH "/pids.max", F_OK) == 0,
+          "nested child exposes pids interface");
+    CHECK(write_text(NESTED_PARENT_PATH "/pids.max", "1") == 0,
+          "set ancestor pids.max to one task");
+    CHECK(write_text(NESTED_CHILD_PATH "/cgroup.procs", "0") == 0,
+          "migrate current process into nested child");
+    CHECK(read_number(NESTED_PARENT_PATH "/pids.current") == 1,
+          "ancestor pids.current includes leaf task");
+    CHECK(read_number(NESTED_CHILD_PATH "/pids.current") == 1,
+          "leaf pids.current includes current task");
+
+    errno = 0;
+    pid_t nested_fork = fork();
+    int nested_fork_errno = errno;
+    CHECK(nested_fork == -1 && nested_fork_errno == EAGAIN,
+          "ancestor pids.max rejects a nested fork with EAGAIN");
+    if (nested_fork > 0) {
+        (void)waitpid(nested_fork, NULL, 0);
+    }
+    CHECK(read_number(NESTED_PARENT_PATH "/pids.current") == 1,
+          "ancestor charge remains stable after denied nested fork");
+    CHECK(read_number(NESTED_CHILD_PATH "/pids.current") == 1,
+          "leaf charge rolls back after ancestor rejects fork");
+    expect_text(NESTED_PARENT_PATH "/pids.events", "max 1\n",
+                "ancestor records the denied nested fork");
+    expect_text(NESTED_CHILD_PATH "/pids.events", "max 0\n",
+                "leaf does not record a limit event after rollback");
+    CHECK(write_text(NESTED_PARENT_PATH "/pids.max", "max") == 0,
+          "remove the ancestor pids limit");
+    CHECK(write_text(NESTED_CHILD_PATH "/pids.max", "1") == 0,
+          "set the leaf pids limit to its current task count");
+
+    errno = 0;
+    pid_t leaf_fork = fork();
+    int leaf_fork_errno = errno;
+    CHECK(leaf_fork == -1 && leaf_fork_errno == EAGAIN,
+          "leaf pids.max rejects a nested fork with EAGAIN");
+    if (leaf_fork > 0) {
+        (void)waitpid(leaf_fork, NULL, 0);
+    }
+    expect_text(NESTED_PARENT_PATH "/pids.events", "max 2\n",
+                "ancestor events include a descendant limit failure");
+    expect_text(NESTED_CHILD_PATH "/pids.events", "max 1\n",
+                "leaf records its own limit failure");
+    CHECK(write_text(CGROUP2_PATH "/cgroup.procs", "0") == 0,
+          "echo 0 returns nested process to root");
+    CHECK(read_number(NESTED_PARENT_PATH "/pids.current") == 0,
+          "migration back clears ancestor pids charge");
+    CHECK(read_number(NESTED_CHILD_PATH "/pids.current") == 0,
+          "migration back clears leaf pids charge");
+
+    printf("------------------------------------------------\n");
+    printf("  DONE: %d pass, %d fail\n", pass_count, fail_count);
+    return fail_count == 0 ? 0 : 1;
+}


### PR DESCRIPTION
## 背景

当前 StarryOS cgroup v2 已支持层级、进程成员关系和 cgroup namespace，
但 `cgroup.controllers` 与 `cgroup.subtree_control` 仍为空，`fork`/`clone`
不会受到 cgroup 任务数限制。

本 PR 增加一个范围明确、可通过真实系统调用验证的 pids controller。

## 修改内容

- 在 `ax-cgroup` 中增加层级化的 `pids.current`、`pids.max` 和
  `pids.events` 状态。
- pids 按任务计数，包括线程，而不是仅统计进程组 leader。
- 在 child 可运行前预扣 pids charge；创建失败时通过 guard 自动回滚。
- 线程和进程退出时只释放一次 charge。
- 进程迁移时原子迁移完整线程组，并允许组织性迁移暂时超过
  `pids.max`。
- migration 与 pending task reservation 使用同一 membership
  串行化边界，避免漏迁移或重复计数。
- execve de-thread 时重命名任务账本项，避免最后一个线程的 charge
  泄漏。
- pids 超限统一映射为 `EAGAIN`。
- `CLONE_PARENT_SETTID` 只在 pids reservation 成功后写入用户指针；
  被限额拒绝的 clone 不产生 parent-TID 副作用。

实现参考 Linux v6.12 commit
`adc218676eef25575469234709c2d87185ca223a` 的 pids controller、
`pids_try_charge()`、rollback 和 `pids_event()` 语义。

## 验证

- [x] `cargo fmt --all -- --check`
- [x] `cargo xtask lock-lint`
- [x] `cargo test -p ax-cgroup`：20 passed
- [x] `cargo xtask clippy --package ax-cgroup`
- [x] `cargo check -p ax-cgroup`
- [x] `cargo check -p starry-kernel`
- [x] `cargo xtask clippy --package starry-kernel`：25 configurations
- [x] aarch64 `qemu/system/cgroup-pids`：58 passed
- [x] riscv64 `qemu/system/cgroup-pids`：58 passed
- [x] loongarch64：同一 focused binary 通过
- [x] x86_64 `qemu/system/cgroup-pids`：58 passed
- [ ] rebase 到提交 PR 时最新 `origin/dev` 后，重新通过 aarch64 focused QEMU

`CLONE_PARENT_SETTID` 回归进行了确定性的 red/green 验证：

- 修复前：56 passed，2 failed，parent-TID 哨兵值被错误改写。
- 修复后：58 passed，0 failed，超限返回 `EAGAIN` 且用户指针保持不变。

完整四架构结果复用了 Cargo、rootfs 和 grouped-case 缓存，没有执行
`cargo clean`。

## 与 #1379 的关系

Draft PR #1379 与本 PR 存在部分 surface overlap，但它同时包含五个
controller、manager/inotify 和调度修改，并采用按进程计数的 pids 实现。

本 PR 按任务统计线程，覆盖 migration 串行化、reservation rollback、
execve de-thread 和 parent-TID ABI 回归。因此 #1379 不能直接替代本 PR，
关系分类为 `conflict-risk/partial-overlap`。