### PR TITLE
feat(starry): add LTP hackbench SMP QEMU benchmark

### DIFF
--- a/apps/.ignore
+++ b/apps/.ignore
@@ -47,3 +47,4 @@ apps/starry/py-tui
 apps/starry/python-net
 apps/starry/qt-calc
 apps/starry/openssh
+apps/starry/qemu/ltp-hackbench

--- a/apps/starry/qemu/ltp-hackbench/README.md
+++ b/apps/starry/qemu/ltp-hackbench/README.md
@@ -1,0 +1,66 @@
+# LTP hackbench SMP QEMU app
+
+This manually selected Starry app validates scheduler and SMP behavior on
+x86_64, AArch64, RISC-V, and LoongArch with the unmodified LTP `hackbench`
+installed by the managed Alpine rootfs. It requires `tgosimages` v0.0.12 or
+newer, including these files:
+
+- `/opt/ltp/testcases/bin/hackbench`
+- `/opt/ltp/Version`
+
+The prebuild step only compiles the Starry-owned affinity helper and installs
+the guest runner. It does not clone, download, build, or patch LTP.
+
+All smoke profiles use four virtual CPUs and an NVMe rootfs. The helper verifies
+that four CPUs are online and allowed, then uses raw affinity syscalls and
+checks the selected mask before it executes `hackbench`. The x86_64 benchmark
+profile additionally fixes multi-threaded TCG and 512 MiB of memory for
+repeatable measurements.
+
+## Smoke validation
+
+The default profile is intentionally short. It runs process and thread mode on
+one and four CPUs once each with `groups=1` and `loops=10`. It validates the
+rootfs contract, topology, affinity, workload execution, and output parsing; it
+does not report representative performance.
+
+```bash
+for arch in x86_64 aarch64 riscv64 loongarch64; do
+  cargo xtask starry app qemu \
+    -t qemu/ltp-hackbench \
+    --arch "$arch"
+done
+```
+
+A successful smoke run emits four `LTP_HACKBENCH_SMOKE` records and ends with
+exactly one `LTP_HACKBENCH_SMOKE_PASSED`.
+
+## Performance benchmark
+
+Select the x86_64-only benchmark profile explicitly when performance data is
+required:
+
+```bash
+set -o pipefail
+cargo xtask starry app qemu \
+  -t qemu/ltp-hackbench \
+  --arch x86_64 \
+  --qemu-config qemu-x86_64-benchmark.toml \
+  2>&1 | tee target/ltp-hackbench/current-performance.log
+```
+
+For both process and thread mode, the benchmark performs one warmup and five
+measured runs on one and four CPUs. It alternates the measured CPU order and
+reports the median plus the informational `one_cpu_median / four_cpu_median`
+speedup without enforcing a minimum speedup.
+
+The benchmark defaults are `groups=1`, `loops=1000`, and `rounds=5`. When the
+runner is invoked directly in the guest, these can be overridden with
+`LTP_HACKBENCH_GROUPS`, `LTP_HACKBENCH_LOOPS`, and `LTP_HACKBENCH_ROUNDS`.
+`rounds` must be odd and at least three.
+
+Structured benchmark output includes `LTP_HACKBENCH_SOURCE`,
+`LTP_HACKBENCH_TOPOLOGY`, `LTP_HACKBENCH_SAMPLE`, `LTP_HACKBENCH_RESULT`, and
+`LTP_HACKBENCH_SPEEDUP`. A complete benchmark ends with exactly one
+`LTP_HACKBENCH_APP_PASSED`. Any smoke or benchmark failure emits
+`LTP_HACKBENCH_APP_FAILED` and exits nonzero.

--- a/apps/starry/qemu/ltp-hackbench/affinity_exec.c
+++ b/apps/starry/qemu/ltp-hackbench/affinity_exec.c
@@ -1,0 +1,164 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <limits.h>
+#include <sched.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static void usage(const char *program)
+{
+    fprintf(stderr,
+            "Usage: %s check <expected-cpus>\n"
+            "       %s run <cpu-count> <program> [args...]\n",
+            program, program);
+}
+
+static int parse_cpu_count(const char *text, int *cpu_count)
+{
+    char *end = NULL;
+    long value;
+
+    errno = 0;
+    value = strtol(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0' || value <= 0 ||
+        value > CPU_SETSIZE || value > INT_MAX) {
+        return -1;
+    }
+
+    *cpu_count = (int)value;
+    return 0;
+}
+
+static int raw_get_affinity(cpu_set_t *mask)
+{
+    CPU_ZERO(mask);
+    if (syscall(SYS_sched_getaffinity, 0, sizeof(*mask), mask) < 0) {
+        fprintf(stderr, "sched_getaffinity failed: %s\n", strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+static int raw_set_affinity(const cpu_set_t *mask)
+{
+    if (syscall(SYS_sched_setaffinity, 0, sizeof(*mask), mask) < 0) {
+        fprintf(stderr, "sched_setaffinity failed: %s\n", strerror(errno));
+        return -1;
+    }
+    return 0;
+}
+
+static unsigned long long low_mask(const cpu_set_t *mask)
+{
+    unsigned long long value = 0;
+    int limit = CPU_SETSIZE < 64 ? CPU_SETSIZE : 64;
+
+    for (int cpu = 0; cpu < limit; cpu++) {
+        if (CPU_ISSET(cpu, mask)) {
+            value |= 1ULL << cpu;
+        }
+    }
+    return value;
+}
+
+static int check_topology(int expected_cpus)
+{
+    cpu_set_t allowed;
+    long online = sysconf(_SC_NPROCESSORS_ONLN);
+
+    if (online < 0) {
+        fprintf(stderr, "sysconf(_SC_NPROCESSORS_ONLN) failed: %s\n",
+                strerror(errno));
+        return 1;
+    }
+    if (raw_get_affinity(&allowed) != 0) {
+        return 1;
+    }
+
+    int allowed_count = CPU_COUNT(&allowed);
+    printf("LTP_HACKBENCH_TOPOLOGY online=%ld allowed=%d mask=0x%llx\n",
+           online, allowed_count, low_mask(&allowed));
+    if (online != expected_cpus || allowed_count != expected_cpus) {
+        fprintf(stderr,
+                "expected %d online and allowed CPUs, got online=%ld "
+                "allowed=%d\n",
+                expected_cpus, online, allowed_count);
+        return 1;
+    }
+    return 0;
+}
+
+static int run_with_affinity(int cpu_count, char **command)
+{
+    cpu_set_t allowed;
+    cpu_set_t selected;
+    cpu_set_t observed;
+
+    if (raw_get_affinity(&allowed) != 0) {
+        return 1;
+    }
+    if (CPU_COUNT(&allowed) < cpu_count) {
+        fprintf(stderr, "requested %d CPUs but only %d are allowed\n", cpu_count,
+                CPU_COUNT(&allowed));
+        return 1;
+    }
+
+    CPU_ZERO(&selected);
+    int remaining = cpu_count;
+    for (int cpu = 0; cpu < CPU_SETSIZE && remaining > 0; cpu++) {
+        if (CPU_ISSET(cpu, &allowed)) {
+            CPU_SET(cpu, &selected);
+            remaining--;
+        }
+    }
+
+    if (raw_set_affinity(&selected) != 0 || raw_get_affinity(&observed) != 0) {
+        return 1;
+    }
+    if (!CPU_EQUAL(&selected, &observed)) {
+        fprintf(stderr,
+                "affinity round-trip mismatch: requested=0x%llx observed=0x%llx\n",
+                low_mask(&selected), low_mask(&observed));
+        return 1;
+    }
+
+    printf("LTP_HACKBENCH_AFFINITY cpus=%d mask=0x%llx\n", cpu_count,
+           low_mask(&observed));
+    fflush(stdout);
+    execv(command[0], command);
+    fprintf(stderr, "execv(%s) failed: %s\n", command[0], strerror(errno));
+    return 1;
+}
+
+int main(int argc, char **argv)
+{
+    int cpu_count;
+
+    if (argc == 3 && strcmp(argv[1], "check") == 0) {
+        if (parse_cpu_count(argv[2], &cpu_count) != 0) {
+            fprintf(stderr, "invalid expected CPU count: %s\n", argv[2]);
+            return 2;
+        }
+        return check_topology(cpu_count);
+    }
+
+    if (argc >= 4 && strcmp(argv[1], "run") == 0) {
+        if (parse_cpu_count(argv[2], &cpu_count) != 0) {
+            fprintf(stderr, "invalid CPU count: %s\n", argv[2]);
+            return 2;
+        }
+        if (argv[3][0] != '/') {
+            fprintf(stderr, "program path must be absolute: %s\n", argv[3]);
+            return 2;
+        }
+        return run_with_affinity(cpu_count, &argv[3]);
+    }
+
+    usage(argv[0]);
+    return 2;
+}

--- a/apps/starry/qemu/ltp-hackbench/build-aarch64-unknown-none-softfloat.toml
+++ b/apps/starry/qemu/ltp-hackbench/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,6 @@
+target = "aarch64-unknown-none-softfloat"
+log = "Warn"
+max_cpu_num = 4
+features = [
+  "ax-driver/nvme",
+]

--- a/apps/starry/qemu/ltp-hackbench/build-loongarch64-unknown-none-softfloat.toml
+++ b/apps/starry/qemu/ltp-hackbench/build-loongarch64-unknown-none-softfloat.toml
@@ -1,0 +1,7 @@
+target = "loongarch64-unknown-none-softfloat"
+log = "Warn"
+max_cpu_num = 4
+features = [
+  "axplat-dyn/efi",
+  "ax-driver/nvme",
+]

--- a/apps/starry/qemu/ltp-hackbench/build-riscv64gc-unknown-none-elf.toml
+++ b/apps/starry/qemu/ltp-hackbench/build-riscv64gc-unknown-none-elf.toml
@@ -1,0 +1,7 @@
+target = "riscv64gc-unknown-none-elf"
+log = "Warn"
+max_cpu_num = 4
+features = [
+  "ax-driver/serial",
+  "ax-driver/nvme",
+]

--- a/apps/starry/qemu/ltp-hackbench/build-x86_64-unknown-none.toml
+++ b/apps/starry/qemu/ltp-hackbench/build-x86_64-unknown-none.toml
@@ -1,0 +1,4 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+max_cpu_num = 4
+features = ["ax-driver/nvme"]

--- a/apps/starry/qemu/ltp-hackbench/ltp-hackbench.sh
+++ b/apps/starry/qemu/ltp-hackbench/ltp-hackbench.sh
@@ -1,0 +1,238 @@
+#!/bin/sh
+
+set -eu
+
+hackbench=/opt/ltp/testcases/bin/hackbench
+version_file=/opt/ltp/Version
+affinity=/usr/bin/ltp-hackbench-affinity
+execution=${1:-smoke}
+groups=${LTP_HACKBENCH_GROUPS:-1}
+work_dir=
+completed=0
+failure_reason=unexpected_exit
+
+cleanup_and_report()
+{
+    status=$?
+    trap - EXIT INT TERM
+    if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+        rm -rf -- "$work_dir"
+    fi
+    if [ "$completed" -ne 1 ]; then
+        if [ "$status" -eq 0 ]; then
+            status=1
+        fi
+        printf 'LTP_HACKBENCH_APP_FAILED: %s\n' "$failure_reason" >&2
+    fi
+    exit "$status"
+}
+
+fail()
+{
+    failure_reason=$1
+    exit 1
+}
+
+on_signal()
+{
+    failure_reason=interrupted
+    exit 1
+}
+
+is_positive_integer()
+{
+    case "$1" in
+        ''|*[!0-9]*|0) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+run_case()
+{
+    task_mode=$1
+    case_cpus=$2
+    case_phase=$3
+    case_round=$4
+
+    if case_output=$("$affinity" run "$case_cpus" "$hackbench" \
+        -pipe "$groups" "$task_mode" "$loops" 2>&1); then
+        case_status=0
+    else
+        case_status=$?
+    fi
+    printf '%s\n' "$case_output"
+    if [ "$case_status" -ne 0 ]; then
+        fail "hackbench_exit mode=$task_mode cpus=$case_cpus phase=$case_phase round=$case_round status=$case_status"
+    fi
+
+    running_count=$(printf '%s\n' "$case_output" \
+        | awk '/^Running with .*tasks\.$/ { count++ } END { print count + 0 }')
+    if [ "$running_count" -ne 1 ]; then
+        fail "unexpected_task_summary mode=$task_mode cpus=$case_cpus phase=$case_phase round=$case_round"
+    fi
+
+    if case_elapsed_us=$(printf '%s\n' "$case_output" | awk '
+        /^Time: [0-9][0-9]*\.[0-9][0-9]*$/ {
+            count++
+            split($2, part, ".")
+            fraction = part[2] "000000"
+            value = part[1] * 1000000 + substr(fraction, 1, 6)
+        }
+        END {
+            if (count != 1 || value <= 0) {
+                exit 1
+            }
+            printf "%.0f\n", value
+        }
+    '); then
+        :
+    else
+        fail "time_parse_failed mode=$task_mode cpus=$case_cpus phase=$case_phase round=$case_round"
+    fi
+
+    last_elapsed_us=$case_elapsed_us
+    case "$case_phase" in
+        smoke)
+            printf 'LTP_HACKBENCH_SMOKE mode=%s cpus=%s elapsed_us=%s\n' \
+                "$task_mode" "$case_cpus" "$case_elapsed_us"
+            ;;
+        warmup)
+            printf 'LTP_HACKBENCH_WARMUP mode=%s cpus=%s elapsed_us=%s\n' \
+                "$task_mode" "$case_cpus" "$case_elapsed_us"
+            ;;
+        sample)
+            printf 'LTP_HACKBENCH_SAMPLE mode=%s cpus=%s round=%s elapsed_us=%s\n' \
+                "$task_mode" "$case_cpus" "$case_round" "$case_elapsed_us"
+            ;;
+        *) fail "invalid_phase=$case_phase" ;;
+    esac
+}
+
+run_smoke()
+{
+    run_case process 1 smoke 0
+    run_case process 4 smoke 0
+    run_case thread 1 smoke 0
+    run_case thread 4 smoke 0
+}
+
+summarize()
+{
+    summary_mode=$1
+    summary_cpus=$2
+    samples_file=$3
+    sample_count=$(wc -l < "$samples_file" | tr -d ' ')
+    [ "$sample_count" -eq "$rounds" ] || \
+        fail "sample_count mode=$summary_mode cpus=$summary_cpus expected=$rounds actual=$sample_count"
+
+    median_index=$(((rounds + 1) / 2))
+    median=$(sort -n "$samples_file" | sed -n "${median_index}p")
+    is_positive_integer "$median" || \
+        fail "invalid_median mode=$summary_mode cpus=$summary_cpus"
+    samples=$(awk '{ printf "%s%s", NR == 1 ? "" : ",", $1 } END { print "" }' \
+        "$samples_file")
+
+    printf 'LTP_HACKBENCH_RESULT mode=%s cpus=%s groups=%s loops=%s rounds=%s samples_us=%s median_us=%s\n' \
+        "$summary_mode" "$summary_cpus" "$groups" "$loops" "$rounds" \
+        "$samples" "$median"
+    summary_median=$median
+}
+
+run_benchmark_mode()
+{
+    benchmark_mode=$1
+    one_cpu_samples=$work_dir/$benchmark_mode-1.samples
+    four_cpu_samples=$work_dir/$benchmark_mode-4.samples
+    : > "$one_cpu_samples"
+    : > "$four_cpu_samples"
+
+    run_case "$benchmark_mode" 1 warmup 0
+    run_case "$benchmark_mode" 4 warmup 0
+
+    round=1
+    while [ "$round" -le "$rounds" ]; do
+        if [ $((round % 2)) -eq 1 ]; then
+            run_case "$benchmark_mode" 1 sample "$round"
+            printf '%s\n' "$last_elapsed_us" >> "$one_cpu_samples"
+            run_case "$benchmark_mode" 4 sample "$round"
+            printf '%s\n' "$last_elapsed_us" >> "$four_cpu_samples"
+        else
+            run_case "$benchmark_mode" 4 sample "$round"
+            printf '%s\n' "$last_elapsed_us" >> "$four_cpu_samples"
+            run_case "$benchmark_mode" 1 sample "$round"
+            printf '%s\n' "$last_elapsed_us" >> "$one_cpu_samples"
+        fi
+        round=$((round + 1))
+    done
+
+    summarize "$benchmark_mode" 1 "$one_cpu_samples"
+    one_cpu_median=$summary_median
+    summarize "$benchmark_mode" 4 "$four_cpu_samples"
+    four_cpu_median=$summary_median
+
+    speedup_milli=$((one_cpu_median * 1000 / four_cpu_median))
+    speedup_whole=$((speedup_milli / 1000))
+    speedup_fraction=$((speedup_milli % 1000))
+    printf 'LTP_HACKBENCH_SPEEDUP mode=%s one_cpu_median_us=%s four_cpu_median_us=%s speedup_milli=%s speedup=%s.%03dx\n' \
+        "$benchmark_mode" "$one_cpu_median" "$four_cpu_median" "$speedup_milli" \
+        "$speedup_whole" "$speedup_fraction"
+}
+
+trap cleanup_and_report EXIT
+trap on_signal INT TERM
+
+if [ "$#" -gt 1 ]; then
+    fail "usage=ltp-hackbench-run_[smoke|benchmark]"
+fi
+case "$execution" in
+    smoke)
+        loops=${LTP_HACKBENCH_LOOPS:-10}
+        ;;
+    benchmark)
+        loops=${LTP_HACKBENCH_LOOPS:-1000}
+        rounds=${LTP_HACKBENCH_ROUNDS:-5}
+        ;;
+    *) fail "invalid_execution=$execution" ;;
+esac
+
+is_positive_integer "$groups" || fail "invalid_groups=$groups"
+is_positive_integer "$loops" || fail "invalid_loops=$loops"
+if [ "$execution" = benchmark ]; then
+    is_positive_integer "$rounds" || fail "invalid_rounds=$rounds"
+    if [ "$rounds" -lt 3 ] || [ $((rounds % 2)) -ne 1 ]; then
+        fail "rounds_must_be_an_odd_integer_at_least_3"
+    fi
+fi
+
+[ -x "$hackbench" ] || fail "missing_executable=$hackbench"
+[ -r "$version_file" ] || fail "missing_version_file=$version_file"
+[ -x "$affinity" ] || fail "missing_executable=$affinity"
+
+raw_version=$(sed -n '1p' "$version_file")
+version=$(printf '%s' "$raw_version" | tr -c '[:alnum:]._-' '_')
+[ -n "$version" ] || fail "empty_version_file=$version_file"
+printf 'LTP_HACKBENCH_SOURCE path=%s version_file=%s version=%s\n' \
+    "$hackbench" "$version_file" "$version"
+if [ "$execution" = benchmark ]; then
+    printf 'LTP_HACKBENCH_CONFIG execution=%s groups=%s loops=%s rounds=%s expected_cpus=4\n' \
+        "$execution" "$groups" "$loops" "$rounds"
+else
+    printf 'LTP_HACKBENCH_CONFIG execution=%s groups=%s loops=%s expected_cpus=4\n' \
+        "$execution" "$groups" "$loops"
+fi
+
+if ! "$affinity" check 4; then
+    fail "topology_or_allowed_cpu_check_failed"
+fi
+
+if [ "$execution" = smoke ]; then
+    run_smoke
+    printf 'LTP_HACKBENCH_SMOKE_PASSED\n'
+else
+    work_dir=$(mktemp -d /tmp/ltp-hackbench.XXXXXX) || fail "mktemp_failed"
+    last_elapsed_us=
+    run_benchmark_mode process
+    run_benchmark_mode thread
+    printf 'LTP_HACKBENCH_APP_PASSED\n'
+fi
+completed=1

--- a/apps/starry/qemu/ltp-hackbench/prebuild.sh
+++ b/apps/starry/qemu/ltp-hackbench/prebuild.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${STARRY_APP_DIR:?STARRY_APP_DIR is required}"
+: "${STARRY_OVERLAY_DIR:?STARRY_OVERLAY_DIR is required}"
+: "${STARRY_ARCH:?STARRY_ARCH is required}"
+
+case "$STARRY_ARCH" in
+    x86_64) compiler_triple=x86_64-linux-musl ;;
+    aarch64) compiler_triple=aarch64-linux-musl ;;
+    riscv64) compiler_triple=riscv64-linux-musl ;;
+    loongarch64) compiler_triple=loongarch64-linux-musl ;;
+    *)
+        echo "ltp-hackbench does not support architecture: $STARRY_ARCH" >&2
+        exit 1
+        ;;
+esac
+
+if [[ -n "${LTP_HACKBENCH_CC:-}" ]]; then
+    compiler="$LTP_HACKBENCH_CC"
+elif command -v "${compiler_triple}-gcc" >/dev/null 2>&1; then
+    compiler=$(command -v "${compiler_triple}-gcc")
+elif [[ -x "/opt/${compiler_triple}-cross/bin/${compiler_triple}-gcc" ]]; then
+    compiler="/opt/${compiler_triple}-cross/bin/${compiler_triple}-gcc"
+else
+    echo "no $compiler_triple compiler found; set LTP_HACKBENCH_CC" >&2
+    exit 1
+fi
+
+install_dir="$STARRY_OVERLAY_DIR/usr/bin"
+mkdir -p "$install_dir"
+
+"$compiler" \
+    -std=c11 -O2 -Wall -Wextra -Werror -static -no-pie \
+    "$STARRY_APP_DIR/affinity_exec.c" \
+    -o "$install_dir/ltp-hackbench-affinity"
+install -m 0755 "$STARRY_APP_DIR/ltp-hackbench.sh" \
+    "$install_dir/ltp-hackbench-run"
+
+echo "Installed the Starry affinity helper and hackbench runner."

--- a/apps/starry/qemu/ltp-hackbench/qemu-aarch64.toml
+++ b/apps/starry/qemu/ltp-hackbench/qemu-aarch64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-nographic",
+    "-machine",
+    "virt,gic-version=3,its=on",
+    "-m",
+    "512M",
+    "-cpu",
+    "cortex-a53",
+    "-smp",
+    "4",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-aarch64-alpine.img,snapshot=on",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/ltp-hackbench-run smoke"
+success_regex = ["(?m)^LTP_HACKBENCH_SMOKE_PASSED\\s*$"]
+fail_regex = [
+    "(?i)kernel panic",
+    "(?i)lockdep.*(panic|fatal)",
+    "(?i)segmentation fault",
+    "(?m)^LTP_HACKBENCH_APP_FAILED:",
+]
+timeout = 300

--- a/apps/starry/qemu/ltp-hackbench/qemu-loongarch64.toml
+++ b/apps/starry/qemu/ltp-hackbench/qemu-loongarch64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-machine",
+    "virt",
+    "-cpu",
+    "la464",
+    "-nographic",
+    "-m",
+    "2G",
+    "-smp",
+    "4",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-loongarch64-alpine.img,snapshot=on",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/ltp-hackbench-run smoke"
+success_regex = ["(?m)^LTP_HACKBENCH_SMOKE_PASSED\\s*$"]
+fail_regex = [
+    "(?i)kernel panic",
+    "(?i)lockdep.*(panic|fatal)",
+    "(?i)segmentation fault",
+    "(?m)^LTP_HACKBENCH_APP_FAILED:",
+]
+timeout = 600

--- a/apps/starry/qemu/ltp-hackbench/qemu-riscv64.toml
+++ b/apps/starry/qemu/ltp-hackbench/qemu-riscv64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-nographic",
+    "-machine",
+    "virt",
+    "-m",
+    "512M",
+    "-cpu",
+    "rv64",
+    "-smp",
+    "4",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-riscv64-alpine.img,snapshot=on",
+]
+uefi = false
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/ltp-hackbench-run smoke"
+success_regex = ["(?m)^LTP_HACKBENCH_SMOKE_PASSED\\s*$"]
+fail_regex = [
+    "(?i)kernel panic",
+    "(?i)lockdep.*(panic|fatal)",
+    "(?i)segmentation fault",
+    "(?m)^LTP_HACKBENCH_APP_FAILED:",
+]
+timeout = 300

--- a/apps/starry/qemu/ltp-hackbench/qemu-x86_64-benchmark.toml
+++ b/apps/starry/qemu/ltp-hackbench/qemu-x86_64-benchmark.toml
@@ -1,0 +1,27 @@
+args = [
+    "-machine",
+    "q35",
+    "-accel",
+    "tcg,thread=multi",
+    "-nographic",
+    "-m",
+    "512M",
+    "-smp",
+    "4",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img,snapshot=on",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/ltp-hackbench-run benchmark"
+success_regex = ["(?m)^LTP_HACKBENCH_APP_PASSED\\s*$"]
+fail_regex = [
+    "(?i)kernel panic",
+    "(?i)lockdep.*(panic|fatal)",
+    "(?i)segmentation fault",
+    "(?m)^LTP_HACKBENCH_APP_FAILED:",
+]
+timeout = 1800

--- a/apps/starry/qemu/ltp-hackbench/qemu-x86_64.toml
+++ b/apps/starry/qemu/ltp-hackbench/qemu-x86_64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-machine",
+    "q35",
+    "-accel",
+    "tcg,thread=multi",
+    "-nographic",
+    "-m",
+    "512M",
+    "-smp",
+    "4",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img,snapshot=on",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/ltp-hackbench-run smoke"
+success_regex = ["(?m)^LTP_HACKBENCH_SMOKE_PASSED\\s*$"]
+fail_regex = [
+    "(?i)kernel panic",
+    "(?i)lockdep.*(panic|fatal)",
+    "(?i)segmentation fault",
+    "(?m)^LTP_HACKBENCH_APP_FAILED:",
+]
+timeout = 300


### PR DESCRIPTION
## 问题

Starry 缺少一个可手工复现的多核任务调度/SMP 测例，用于确认同一 LTP workload 在单核绑核与 4 核运行时的调度、affinity 和性能行为。完整 hackbench 测量耗时较长，不适合默认 app/test-suit 自动执行，也不应为了日常可运行性而降低正式采样要求。

`tgosimages` v0.0.12 已在 x86_64、AArch64、RISC-V 和 LoongArch Alpine rootfs 中提供原版 `/opt/ltp/testcases/bin/hackbench` 与 `/opt/ltp/Version`。本 PR 直接使用 rootfs 中的程序，不手工注入 LTP。

## 变更与逻辑

- 新增仅支持显式手工运行的 `apps/starry/qemu/ltp-hackbench`，并加入 `apps/.ignore`，避免进入默认 app 扫描。
- `prebuild.sh` 只按目标架构编译 Starry 自有的静态 affinity helper，并注入 helper 与 guest runner；不下载、clone、编译或修改 LTP，也不包含开发者私有工具链路径。
- 为 x86_64、AArch64、RISC-V 和 LoongArch 提供 SMP4 短烟测配置，构建特性收敛到各架构启动和 NVMe rootfs 所需的最小集合。
- helper 通过原始 affinity syscall 验证 online/allowed CPU 均为 4，并把 workload 限制到前 1 个或全部 4 个 CPU；设置后必须回读相同 mask。
- 默认 smoke 执行 `process/thread × 1/4 CPU` 各一次，默认 `groups=1`、`loops=10`，验证 rootfs、SMP、affinity、执行和解析后输出 `LTP_HACKBENCH_SMOKE_PASSED`。
- 完整性能流程保留为 x86_64 显式配置 `qemu-x86_64-benchmark.toml`：默认 `groups=1`、`loops=1000`、`rounds=5`，每组预热一次、正式采样 5 次，交替 1/4 CPU 顺序，输出 median 与 `1 CPU median / 4 CPU median` speedup；不设置固定加速比门槛。
- smoke/benchmark 的检查、执行或解析失败都输出 `LTP_HACKBENCH_APP_FAILED` 并非零退出。

四架构短烟测：

```bash
for arch in x86_64 aarch64 riscv64 loongarch64; do
  cargo xtask starry app qemu \
    -t qemu/ltp-hackbench \
    --arch "$arch"
done
```

x86_64 完整性能测量：

```bash
set -o pipefail
cargo xtask starry app qemu \
  -t qemu/ltp-hackbench \
  --arch x86_64 \
  --qemu-config qemu-x86_64-benchmark.toml \
  2>&1 | tee target/ltp-hackbench/current-performance.log
```

## latest dev + v0.0.12 当前烟测

- 基线：`origin/dev@fdc43da155335da4cbf9badb11ba7cc1692e433e`
- 测试提交：`ca398cea282288d924b56d12e7f3600490d8307f`
- 时间：2026-08-19 10:08–10:11 +08:00
- QEMU：10.1.0，TCG，4 vCPU；x86_64 显式使用 `tcg,thread=multi`
- 内存：x86_64/AArch64/RISC-V 为 512 MiB，LoongArch 为 2 GiB；均使用 NVMe rootfs
- 宿主：Intel Core i7-10700，8C/16T
- LTP：四个 rootfs 的 `/opt/ltp/Version` 均为 `20260529`，实际执行路径均为 `/opt/ltp/testcases/bin/hackbench`
- 参数：`groups=1`、`loops=10`，process/thread，1 CPU 与 4 CPU 各一次

| 架构 | process 1 CPU | process 4 CPU | thread 1 CPU | thread 4 CPU | 结果 |
| --- | ---: | ---: | ---: | ---: | --- |
| x86_64 | 0.754 s | 0.783 s | 0.717 s | 0.665 s | PASS |
| AArch64 | 0.884 s | 1.063 s | 0.797 s | 0.830 s | PASS |
| RISC-V | 1.313 s | 1.343 s | 0.910 s | 0.880 s | PASS |
| LoongArch | 0.696 s | 0.715 s | 0.662 s | 0.607 s | PASS |

每个架构均满足 `source=1 topology=1 smoke=4 smoke_pass=1 fail=0 sample=0`。online/allowed CPU 均为 4，1/4 CPU mask 均回读为 `0x1`/`0xf`，没有发现调度或 affinity 异常。以上单次短 workload 只用于“bench 能否运行”的验证，不作为性能结论，也不计算 speedup。

v0.0.12 archive 校验：

| 架构 | SHA-256 |
| --- | --- |
| x86_64 | `3de902d27492ff9b540ff3c156eabb90854183356e41f837303dd4ca73e4791f` |
| AArch64 | `31703a908957cf90abb2b50c626b8bdf25d42641d84322845869faba359d5ed9` |
| RISC-V | `ba9dc34a7a85bd0f67a3c45cfbd9ab5ce468c9c3c2e8aeb8d651a48fc8399380` |
| LoongArch | `9bf5878109eed203b2b7e88317cf4879c1ab544e28aabf930bebdbd72d225941` |

## 历史完整性能基线与问题

本轮按要求没有重跑完整 benchmark。以下数据保留自 2026-08-14 的完整 5 轮测量：提交 `49f4a3e92b7c62116f7970582780adff3bd2444e`，QEMU 10.1.0 TCG multi-thread，4 vCPU，宿主 Intel Core i7-10700，Alpine 3.23.5，手工注入未修改的 LTP 20240524 `hackbench`，参数为 `groups=1`、`loops=1000`、`rounds=5`。

| 模式 | 1 CPU 样本（秒） | 1 CPU median | 4 CPU 样本（秒） | 4 CPU median | speedup |
| --- | --- | ---: | --- | ---: | ---: |
| process | 34.054, 32.171, 32.360, 33.666, 33.469 | 33.469 s | 32.217, 31.744, 32.619, 37.844, 34.431 | 32.619 s | 1.026x |
| thread | 33.541, 57.882, 60.645, 64.835, 53.122 | 57.882 s | 41.321, 48.858, 56.675, 60.691, 61.736 | 56.675 s | 1.021x |

这里的 speedup 为 `1 CPU median / 4 CPU median`。两种模式的 4 CPU median 只改善约 2%，thread 样本抖动明显；基于该组数据，TCG 下跨核并行收益大部分被调度、IPC/唤醒和仿真开销抵消。该结果不代表 v0.0.12/LTP 20260529 在当前 head 上的完整性能，后续需要时应使用显式 benchmark 配置重新测量。

## 验证

- `bash -n apps/starry/qemu/ltp-hackbench/prebuild.sh`
- `sh -n apps/starry/qemu/ltp-hackbench/ltp-hackbench.sh`
- 全部 build/QEMU TOML 配置解析检查
- runner 非法模式、非法 loops/rounds 与 FAIL marker 检查
- 四架构 affinity helper 静态交叉编译、ELF 架构、非法参数、绝对路径和 mask 回读检查
- `cargo fmt --all -- --check`
- `cargo xtask clippy --package axbuild`
- `git diff --check`
- 四次 `cargo xtask starry app qemu -t qemu/ltp-hackbench --arch <arch>`

四架构 smoke 均正常退出且没有残留 QEMU/测试进程。完整 benchmark 配置只做了配置与脚本路径检查，本轮未启动完整采样。
