### PR TITLE
test(arceos): guard task IPI progress under constrained TCG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -574,7 +574,10 @@ jobs:
             use_container: false
             runs_on: '["self-hosted","linux","qcs"]'
             self_hosted_owner: rcore-os
-            command: cargo xtask arceos test qemu --arch riscv64
+            command: |
+              cargo xtask arceos test qemu --arch riscv64
+              taskset -c 0 cargo xtask arceos test qemu --arch riscv64 \
+                --test-group rust --test-case task-ipi
             cache_key: ""
             container_image: base
             limit_to_owner: ""

--- a/os/arceos/modules/axipi/src/lib.rs
+++ b/os/arceos/modules/axipi/src/lib.rs
@@ -2,8 +2,11 @@
 //!
 //! Logical pending state belongs to each subsystem. A publisher must make its
 //! state visible with Release ordering before calling [`notify_cpu`]. The IPI
-//! handler calls [`claim_current_delivery`] before checking those owners, so a
-//! publication racing with draining obtains a fresh physical edge.
+//! handler must call [`claim_current_delivery`] before it observes and drains
+//! scheduler work, hard calls, or legacy callbacks, so a publication racing
+//! with draining obtains a fresh physical edge. [`IpiNotification::Coalesced`]
+//! acknowledges only that physical edge; it does not acknowledge completion of
+//! any logical work.
 
 #![cfg_attr(not(test), no_std)]
 
@@ -141,7 +144,8 @@ pub fn wait_until_cpu_ready(cpu_id: usize) -> bool {
 ///
 /// The caller must publish its logical pending state or payload with Release
 /// ordering before calling this function. A delivery error does not consume or
-/// clear that owner state.
+/// clear that owner state. [`IpiNotification::Coalesced`] means that a physical
+/// edge is already armed, not that the caller's logical work has been drained.
 pub fn notify_cpu(cpu: CpuId) -> Result<IpiNotification, IrqError> {
     validate_target_cpu(cpu)?;
     endpoint(cpu)?.edge.notify(|| {
@@ -163,6 +167,11 @@ pub fn claim_current_delivery() {
 }
 
 /// Executes a raw operation synchronously on one CPU without allocation.
+///
+/// A remote caller spin-waits until the target completes the operation. This is
+/// intended for bounded, one-off hard-IRQ work, not bulk delivery or sustained
+/// pressure. A subsystem with queued work should publish its own logical state
+/// and use [`notify_cpu`] to coalesce physical delivery.
 ///
 /// # Safety
 ///
@@ -200,7 +209,8 @@ pub unsafe fn call_on_cpu(
 /// Drains at most 64 caller-owned hard calls on the current CPU.
 ///
 /// Any bounded remainder obtains a self-notification unless another publisher
-/// has already armed a fresh edge.
+/// has already armed a fresh edge. This budget provides interrupt-transport
+/// fairness; it does not make [`call_on_cpu`] a batching interface.
 pub fn drain_hard_calls() -> Result<(), IrqError> {
     let outcome = endpoint(CpuId(this_cpu_id()))?
         .hard_calls

--- a/os/arceos/modules/axipi/src/notification.rs
+++ b/os/arceos/modules/axipi/src/notification.rs
@@ -16,6 +16,8 @@ pub enum IpiNotification {
     /// This publication sent a physical IPI.
     Sent,
     /// An already armed physical IPI covers this publication.
+    ///
+    /// This does not mean that the publisher's logical work has completed.
     Coalesced,
 }
 

--- a/os/arceos/modules/axipi/src/notification_contract.rs
+++ b/os/arceos/modules/axipi/src/notification_contract.rs
@@ -27,6 +27,31 @@ fn first_publication_sends_and_repeated_publication_coalesces() {
 }
 
 #[test]
+fn handler_drains_latest_owner_generation_after_coalescing() {
+    let edges = DeliveryEdges::<2>::new();
+    let owner_generation = AtomicUsize::new(0);
+    let drained_generation = AtomicUsize::new(0);
+
+    owner_generation.store(1, Ordering::Release);
+    assert_eq!(edges.notify(CpuId(1), || Ok(())), Ok(IpiNotification::Sent),);
+
+    owner_generation.store(2, Ordering::Release);
+    assert_eq!(
+        edges.notify(CpuId(1), || panic!("physical edge is already armed")),
+        Ok(IpiNotification::Coalesced),
+    );
+    assert_eq!(drained_generation.load(Ordering::Acquire), 0);
+
+    edges.claim(CpuId(1));
+    drained_generation.store(owner_generation.load(Ordering::Acquire), Ordering::Release);
+    assert_eq!(
+        drained_generation.load(Ordering::Acquire),
+        2,
+        "the handler must drain owner state published behind a coalesced edge"
+    );
+}
+
+#[test]
 fn publication_after_claim_obtains_a_fresh_edge() {
     let edges = DeliveryEdges::<2>::new();
     let sends = AtomicUsize::new(0);

--- a/scripts/axbuild/src/arceos/test/discovery.rs
+++ b/scripts/axbuild/src/arceos/test/discovery.rs
@@ -86,7 +86,7 @@ pub(super) fn load_arceos_test_suit_qemu_case(
     feature: &str,
 ) -> anyhow::Result<ArceosRustQemuCase> {
     let build_config_path = arceos_test_suit_build_config_path(root, target)?;
-    let qemu_config_path = arceos_test_suit_qemu_config_path(root, arch)?;
+    let qemu_config_path = arceos_test_suit_case_qemu_config_path(root, arch, feature)?;
     let host_http_server = qemu_test::load_qemu_case_host_http_server(&qemu_config_path)?;
     Ok(ArceosRustQemuCase {
         case: TestQemuCase {
@@ -119,6 +119,22 @@ pub(super) fn arceos_test_suit_qemu_config_path(
     arch: &str,
 ) -> anyhow::Result<PathBuf> {
     qemu_config_path(root, arch, "ArceOS rust test suite")
+}
+
+pub(super) fn arceos_test_suit_case_qemu_config_path(
+    root: &Path,
+    arch: &str,
+    case: &str,
+) -> anyhow::Result<PathBuf> {
+    let case_path = root
+        .join("cases")
+        .join(case)
+        .join(qemu_test::qemu_config_name(arch));
+    if case_path.is_file() {
+        Ok(case_path)
+    } else {
+        arceos_test_suit_qemu_config_path(root, arch)
+    }
 }
 
 pub(super) fn selected_qemu_test_groups(
@@ -167,6 +183,8 @@ pub(super) fn selected_qemu_test_groups(
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use tempfile::tempdir;
 
     use super::*;
@@ -223,5 +241,33 @@ mod tests {
         .unwrap();
 
         assert_eq!(flows, &[QemuTestFlow::Rust, QemuTestFlow::C]);
+    }
+
+    #[test]
+    fn arceos_rust_case_prefers_its_qemu_config() {
+        let root = tempdir().unwrap();
+        let suite_config = root.path().join("qemu-riscv64.toml");
+        fs::write(&suite_config, "timeout = 120\n").unwrap();
+        let case_dir = root.path().join("cases/task-ipi");
+        fs::create_dir_all(&case_dir).unwrap();
+        let case_config = case_dir.join("qemu-riscv64.toml");
+        fs::write(&case_config, "timeout = 5\n").unwrap();
+
+        let selected =
+            arceos_test_suit_case_qemu_config_path(root.path(), "riscv64", "task-ipi").unwrap();
+
+        assert_eq!(selected, case_config);
+    }
+
+    #[test]
+    fn arceos_rust_case_falls_back_to_suite_qemu_config() {
+        let root = tempdir().unwrap();
+        let suite_config = root.path().join("qemu-riscv64.toml");
+        fs::write(&suite_config, "timeout = 120\n").unwrap();
+
+        let selected =
+            arceos_test_suit_case_qemu_config_path(root.path(), "riscv64", "task-yield").unwrap();
+
+        assert_eq!(selected, suite_config);
     }
 }

--- a/scripts/axbuild/src/arceos/test/rust_qemu.rs
+++ b/scripts/axbuild/src/arceos/test/rust_qemu.rs
@@ -324,10 +324,15 @@ pub(super) fn rust_qemu_features_for_list(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use super::*;
-    use crate::arceos::test::discovery::arceos_test_suit_case_qemu_config_path;
+    use crate::{
+        arceos::test::{
+            ARCEOS_RUST_TEST_PACKAGE, discovery::arceos_test_suit_case_qemu_config_path,
+        },
+        test::case::TestQemuCase,
+    };
 
     fn rust_test_suite_root() -> std::path::PathBuf {
         Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-suit/arceos/rust")
@@ -550,6 +555,45 @@ BT 0 ip=0x1 fp=0x2
         assert_eq!(path, rust_test_suite_root().join("qemu-x86_64.toml"));
     }
 
+    #[tokio::test]
+    async fn arceos_rust_case_preparation_rejects_persistent_rootfs_policy() {
+        let root = tempfile::tempdir().unwrap();
+        let qemu_config_path = write_test_qemu_config(root.path(), Some("persist"));
+        let mut arceos = ArceOS::new().unwrap();
+
+        let error = prepare_rust_qemu_cases(
+            &mut arceos,
+            "riscv64gc-unknown-none-elf",
+            vec![rust_qemu_case(qemu_config_path)],
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("cannot use `rootfs_write_policy = \"persist\"`"));
+    }
+
+    #[tokio::test]
+    async fn arceos_rust_case_preparation_isolates_its_rootfs_writes() {
+        let root = tempfile::tempdir().unwrap();
+        let qemu_config_path = write_test_qemu_config(root.path(), None);
+        let mut arceos = ArceOS::new().unwrap();
+
+        let prepared = prepare_rust_qemu_cases(
+            &mut arceos,
+            "riscv64gc-unknown-none-elf",
+            vec![rust_qemu_case(qemu_config_path)],
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            prepared[0].qemu.args.iter().any(|argument| {
+                argument.contains("id=disk0") && argument.contains("snapshot=on")
+            })
+        );
+    }
+
     #[test]
     fn arceos_rust_normal_qemu_keeps_suite_result_regex() {
         let mut qemu = QemuConfig {
@@ -576,5 +620,57 @@ BT 0 ip=0x1 fp=0x2
     fn arceos_rust_selected_case_can_miss_in_default_group_search() {
         let features = rust_qemu_features_for_list(Some("c/helloworld"), true).unwrap();
         assert!(features.is_empty());
+    }
+
+    fn rust_qemu_case(qemu_config_path: PathBuf) -> ArceosRustQemuCase {
+        ArceosRustQemuCase {
+            case: TestQemuCase {
+                name: "task-ipi".to_string(),
+                display_name: "task-ipi".to_string(),
+                case_dir: qemu_config_path.parent().unwrap().to_path_buf(),
+                qemu_config_path,
+                test_commands: Vec::new(),
+                host_symbolize_success_regex: Vec::new(),
+                host_http_server: None,
+                subcases: Vec::new(),
+                grouped_subcase_filter: None,
+            },
+            build_group: "arceos-rust".to_string(),
+            build_config_path: rust_test_suite_root().join("build-riscv64gc-unknown-none-elf.toml"),
+            package: ARCEOS_RUST_TEST_PACKAGE.to_string(),
+            feature: Some("task-ipi".to_string()),
+        }
+    }
+
+    fn write_test_qemu_config(root: &Path, rootfs_write_policy: Option<&str>) -> PathBuf {
+        let disk_path = root.join("disk.img");
+        std::fs::write(&disk_path, []).unwrap();
+        let policy = rootfs_write_policy
+            .map(|policy| format!("rootfs_write_policy = \"{policy}\"\n"))
+            .unwrap_or_default();
+        let qemu_config_path = root.join("qemu-riscv64.toml");
+        std::fs::write(
+            &qemu_config_path,
+            format!(
+                r#"args = [
+    "-m",
+    "64M",
+    "-smp",
+    "4",
+    "-drive",
+    "id=disk0,if=none,format=raw,file={}",
+]
+
+timeout = 5
+uefi = false
+to_bin = false
+success_regex = ["OK"]
+fail_regex = ["FAIL"]
+{policy}"#,
+                disk_path.display()
+            ),
+        )
+        .unwrap();
+        qemu_config_path
     }
 }

--- a/scripts/axbuild/src/arceos/test/rust_qemu.rs
+++ b/scripts/axbuild/src/arceos/test/rust_qemu.rs
@@ -95,7 +95,7 @@ pub(super) async fn prepare_rust_qemu_cases(
             &mut qemu,
             request.smp.or(build_info.max_cpu_num).or(Some(1)),
         );
-        apply_rust_qemu_feature_overrides(&mut cargo, &mut qemu, case.feature.as_deref());
+        apply_rust_qemu_feature_overrides(&mut qemu, case.feature.as_deref());
         qemu_test::apply_timeout_scale(&mut qemu);
         rootfs::prepare_default_qemu_fat32_rootfs(arceos.app.workspace_root(), &qemu)?;
         rootfs::isolate_qemu_test_rootfs(&mut qemu)?;
@@ -124,11 +124,7 @@ fn rust_qemu_host_symbolize_success_regex(feature: Option<&str>) -> Vec<String> 
     }
 }
 
-fn apply_rust_qemu_feature_overrides(
-    cargo: &mut Cargo,
-    qemu: &mut QemuConfig,
-    feature: Option<&str>,
-) {
+fn apply_rust_qemu_feature_overrides(qemu: &mut QemuConfig, feature: Option<&str>) {
     match feature {
         Some(ARCEOS_RUST_DEBUG_PANIC_PATH_FEATURE) => {
             qemu.success_regex = vec![r"BACKTRACE_BEGIN\b.*\bkind=panic\b".to_string()];
@@ -154,13 +150,6 @@ fn apply_rust_qemu_feature_overrides(
                 vec!["task stack guard page hit for .*stack-guard-page-overflow".to_string()];
             qemu.fail_regex = vec!["stack guard page was not hit".to_string()];
             qemu.timeout = Some(qemu.timeout.unwrap_or(30).min(30));
-        }
-        Some("task-wait-queue-remote-wake")
-            if cargo.target == "riscv64gc-unknown-none-elf"
-                && !qemu.args.iter().any(|arg| arg == "-accel") =>
-        {
-            qemu.args.push("-accel".to_string());
-            qemu.args.push("tcg,thread=single".to_string());
         }
         _ => {}
     }
@@ -338,7 +327,15 @@ mod tests {
     use std::path::Path;
 
     use super::*;
-    use crate::arceos::test::ARCEOS_RUST_TEST_PACKAGE;
+    use crate::arceos::test::discovery::arceos_test_suit_case_qemu_config_path;
+
+    fn rust_test_suite_root() -> std::path::PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-suit/arceos/rust")
+    }
+
+    fn load_qemu_config(path: &Path) -> QemuConfig {
+        toml::from_str(&std::fs::read_to_string(path).unwrap()).unwrap()
+    }
 
     #[test]
     fn arceos_rust_default_run_selects_all_feature_only() {
@@ -392,7 +389,6 @@ BT 0 ip=0x1 fp=0x2
 
     #[test]
     fn arceos_rust_page_fault_qemu_uses_page_fault_result_regex() {
-        let mut cargo = rust_test_cargo_for_target("x86_64-unknown-none");
         let mut qemu = QemuConfig {
             success_regex: vec!["ArceOS test suite run OK!".to_string()],
             fail_regex: vec![r"(?i)\bpanic(?:ked)?\b".to_string()],
@@ -401,7 +397,6 @@ BT 0 ip=0x1 fp=0x2
         };
 
         apply_rust_qemu_feature_overrides(
-            &mut cargo,
             &mut qemu,
             Some(ARCEOS_RUST_EXCEPTION_PAGE_FAULT_FEATURE),
         );
@@ -419,7 +414,6 @@ BT 0 ip=0x1 fp=0x2
 
     #[test]
     fn arceos_rust_stack_guard_page_qemu_uses_guard_page_result_regex() {
-        let mut cargo = rust_test_cargo_for_target("x86_64-unknown-none");
         let mut qemu = QemuConfig {
             success_regex: vec!["ArceOS test suite run OK!".to_string()],
             fail_regex: vec![
@@ -430,11 +424,7 @@ BT 0 ip=0x1 fp=0x2
             ..QemuConfig::default()
         };
 
-        apply_rust_qemu_feature_overrides(
-            &mut cargo,
-            &mut qemu,
-            Some(ARCEOS_RUST_STACK_GUARD_PAGE_FEATURE),
-        );
+        apply_rust_qemu_feature_overrides(&mut qemu, Some(ARCEOS_RUST_STACK_GUARD_PAGE_FEATURE));
 
         assert_eq!(
             qemu.success_regex,
@@ -446,10 +436,8 @@ BT 0 ip=0x1 fp=0x2
 
     #[test]
     fn arceos_rust_aarch64_qemu_config_uses_gicv2_smp4_for_ipi_paths() {
-        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-suit/arceos/rust");
-        let qemu_path = root.join("qemu-aarch64.toml");
-        let config: QemuConfig =
-            toml::from_str(&std::fs::read_to_string(qemu_path).unwrap()).unwrap();
+        let qemu_path = rust_test_suite_root().join("qemu-aarch64.toml");
+        let config = load_qemu_config(&qemu_path);
         let smp = qemu_test::smp_from_qemu_arg(&config).unwrap();
         assert_eq!(smp, 4, "aarch64 GICv2 IPI coverage requires SMP4");
         assert!(
@@ -463,10 +451,8 @@ BT 0 ip=0x1 fp=0x2
 
     #[test]
     fn arceos_rust_aarch64_qemu_config_converts_high_half_kernel_to_bin() {
-        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../test-suit/arceos/rust");
-        let qemu_path = root.join("qemu-aarch64.toml");
-        let config: QemuConfig =
-            toml::from_str(&std::fs::read_to_string(qemu_path).unwrap()).unwrap();
+        let qemu_path = rust_test_suite_root().join("qemu-aarch64.toml");
+        let config = load_qemu_config(&qemu_path);
 
         assert!(
             config.to_bin,
@@ -476,7 +462,6 @@ BT 0 ip=0x1 fp=0x2
 
     #[test]
     fn arceos_rust_panic_path_qemu_uses_panic_backtrace_result_regex() {
-        let mut cargo = rust_test_cargo_for_target("x86_64-unknown-none");
         let mut qemu = QemuConfig {
             success_regex: vec!["ArceOS test suite run OK!".to_string()],
             fail_regex: vec![r"(?i)\bpanic(?:ked)?\b".to_string()],
@@ -484,11 +469,7 @@ BT 0 ip=0x1 fp=0x2
             ..QemuConfig::default()
         };
 
-        apply_rust_qemu_feature_overrides(
-            &mut cargo,
-            &mut qemu,
-            Some(ARCEOS_RUST_DEBUG_PANIC_PATH_FEATURE),
-        );
+        apply_rust_qemu_feature_overrides(&mut qemu, Some(ARCEOS_RUST_DEBUG_PANIC_PATH_FEATURE));
 
         assert_eq!(
             qemu.success_regex,
@@ -500,7 +481,6 @@ BT 0 ip=0x1 fp=0x2
 
     #[test]
     fn arceos_rust_lockdep_detect_qemu_uses_lockdep_result_regex() {
-        let mut cargo = rust_test_cargo_for_target("x86_64-unknown-none");
         let mut qemu = QemuConfig {
             success_regex: vec!["ArceOS test suite run OK!".to_string()],
             fail_regex: vec![r"(?i)\bpanic(?:ked)?\b".to_string()],
@@ -508,11 +488,7 @@ BT 0 ip=0x1 fp=0x2
             ..QemuConfig::default()
         };
 
-        apply_rust_qemu_feature_overrides(
-            &mut cargo,
-            &mut qemu,
-            Some(ARCEOS_RUST_LOCKDEP_DETECT_FEATURE),
-        );
+        apply_rust_qemu_feature_overrides(&mut qemu, Some(ARCEOS_RUST_LOCKDEP_DETECT_FEATURE));
 
         assert_eq!(
             qemu.success_regex,
@@ -526,15 +502,14 @@ BT 0 ip=0x1 fp=0x2
     }
 
     #[test]
-    fn arceos_rust_remote_wake_riscv_uses_single_threaded_tcg() {
-        let mut cargo = rust_test_cargo_for_target("riscv64gc-unknown-none-elf");
-        let mut qemu = QemuConfig::default();
-
-        apply_rust_qemu_feature_overrides(
-            &mut cargo,
-            &mut qemu,
-            Some("task-wait-queue-remote-wake"),
-        );
+    fn arceos_rust_remote_wake_riscv_config_uses_single_threaded_tcg() {
+        let path = arceos_test_suit_case_qemu_config_path(
+            &rust_test_suite_root(),
+            "riscv64",
+            "task-wait-queue-remote-wake",
+        )
+        .unwrap();
+        let qemu = load_qemu_config(&path);
 
         assert!(
             qemu.args
@@ -544,8 +519,39 @@ BT 0 ip=0x1 fp=0x2
     }
 
     #[test]
+    fn arceos_rust_task_ipi_riscv_config_uses_single_threaded_tcg_and_short_timeout() {
+        let path =
+            arceos_test_suit_case_qemu_config_path(&rust_test_suite_root(), "riscv64", "task-ipi")
+                .unwrap();
+        let qemu = load_qemu_config(&path);
+
+        assert!(
+            qemu.args
+                .windows(2)
+                .any(|args| args == ["-accel", "tcg,thread=single"])
+        );
+        assert_eq!(qemu.timeout, Some(5));
+    }
+
+    #[test]
+    fn arceos_rust_task_ipi_non_riscv_falls_back_to_suite_config() {
+        let path =
+            arceos_test_suit_case_qemu_config_path(&rust_test_suite_root(), "x86_64", "task-ipi")
+                .unwrap();
+        let qemu = load_qemu_config(&path);
+
+        assert!(
+            !qemu
+                .args
+                .windows(2)
+                .any(|args| args == ["-accel", "tcg,thread=single"])
+        );
+        assert_eq!(qemu.timeout, Some(120));
+        assert_eq!(path, rust_test_suite_root().join("qemu-x86_64.toml"));
+    }
+
+    #[test]
     fn arceos_rust_normal_qemu_keeps_suite_result_regex() {
-        let mut cargo = rust_test_cargo_for_target("x86_64-unknown-none");
         let mut qemu = QemuConfig {
             success_regex: vec!["ArceOS test suite run OK!".to_string()],
             fail_regex: vec![
@@ -556,7 +562,7 @@ BT 0 ip=0x1 fp=0x2
             ..QemuConfig::default()
         };
 
-        apply_rust_qemu_feature_overrides(&mut cargo, &mut qemu, Some("debug-backtrace"));
+        apply_rust_qemu_feature_overrides(&mut qemu, Some("debug-backtrace"));
 
         assert_eq!(qemu.success_regex, vec!["ArceOS test suite run OK!"]);
         assert_eq!(
@@ -570,24 +576,5 @@ BT 0 ip=0x1 fp=0x2
     fn arceos_rust_selected_case_can_miss_in_default_group_search() {
         let features = rust_qemu_features_for_list(Some("c/helloworld"), true).unwrap();
         assert!(features.is_empty());
-    }
-
-    fn rust_test_cargo_for_target(target: &str) -> Cargo {
-        Cargo {
-            env: Default::default(),
-            target: target.to_string(),
-            package: ARCEOS_RUST_TEST_PACKAGE.to_string(),
-            features: Vec::new(),
-            log: None,
-            extra_config: None,
-            profile: None,
-            disable_someboot_build_config: true,
-            args: Vec::new(),
-            pre_build_cmds: Vec::new(),
-            post_build_cmds: Vec::new(),
-            to_bin: false,
-            bin: None,
-            test: None,
-        }
     }
 }

--- a/test-suit/arceos/rust/cases/task-ipi/qemu-riscv64.toml
+++ b/test-suit/arceos/rust/cases/task-ipi/qemu-riscv64.toml
@@ -1,0 +1,33 @@
+args = [
+    "-m",
+    "256M",
+    "-smp",
+    "4",
+    "-accel",
+    "tcg,thread=single",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/arceos/rust/disk.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-device",
+    "virtio-gpu-pci",
+    "-display",
+    "none",
+    "-serial",
+    "mon:stdio",
+]
+
+timeout = 5
+uefi = false
+to_bin = false
+success_regex = ["ArceOS test suite run OK!"]
+fail_regex = ["(?i)\\bpanic(?:ked)?\\b", "ARCEOS_TEST_FAIL"]
+
+[host_http_server]
+bind = "127.0.0.1"
+port = 18182
+body = "ArceOS rust test suite host fixture\n"

--- a/test-suit/arceos/rust/cases/task-ipi/qemu-riscv64.toml
+++ b/test-suit/arceos/rust/cases/task-ipi/qemu-riscv64.toml
@@ -21,7 +21,7 @@ args = [
     "mon:stdio",
 ]
 
-timeout = 5
+timeout = 15
 uefi = false
 to_bin = false
 success_regex = ["ArceOS test suite run OK!"]

--- a/test-suit/arceos/rust/cases/task-wait-queue-remote-wake/qemu-riscv64.toml
+++ b/test-suit/arceos/rust/cases/task-wait-queue-remote-wake/qemu-riscv64.toml
@@ -1,0 +1,33 @@
+args = [
+    "-m",
+    "256M",
+    "-smp",
+    "4",
+    "-accel",
+    "tcg,thread=single",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/runtime-assets/arceos/rust/disk.img",
+    "-device",
+    "virtio-net-pci,netdev=net0",
+    "-netdev",
+    "user,id=net0",
+    "-device",
+    "virtio-gpu-pci",
+    "-display",
+    "none",
+    "-serial",
+    "mon:stdio",
+]
+
+timeout = 120
+uefi = false
+to_bin = false
+success_regex = ["ArceOS test suite run OK!"]
+fail_regex = ["(?i)\\bpanic(?:ked)?\\b", "ARCEOS_TEST_FAIL"]
+
+[host_http_server]
+bind = "127.0.0.1"
+port = 18182
+body = "ArceOS rust test suite host fixture\n"

--- a/test-suit/arceos/rust/src/task/ipi.rs
+++ b/test-suit/arceos/rust/src/task/ipi.rs
@@ -53,7 +53,7 @@ fn counting_callback() {
         target_cpu,
         "IPI callback ran on the wrong CPU"
     );
-    EXECUTED_CALLBACKS.fetch_add(1, Ordering::Relaxed);
+    EXECUTED_CALLBACKS.fetch_add(1, Ordering::Release);
 }
 
 unsafe fn counting_hard_call(argument: *mut ()) {
@@ -63,15 +63,15 @@ unsafe fn counting_hard_call(argument: *mut ()) {
         expected_cpu,
         "IPI hard call ran on the wrong CPU"
     );
-    EXECUTED_HARD_CALLS.fetch_add(1, Ordering::Relaxed);
+    EXECUTED_HARD_CALLS.fetch_add(1, Ordering::Release);
 }
 
-fn wait_for_callbacks_or_stall(expected: usize) -> bool {
-    let mut last_executed = EXECUTED_CALLBACKS.load(Ordering::Relaxed);
+fn wait_for_counter_or_stall(counter: &AtomicUsize, expected: usize) -> bool {
+    let mut last_executed = counter.load(Ordering::Acquire);
     let mut stalled_polls = 0;
 
     loop {
-        let executed = EXECUTED_CALLBACKS.load(Ordering::Relaxed);
+        let executed = counter.load(Ordering::Acquire);
         if executed == expected {
             return true;
         }
@@ -116,6 +116,100 @@ fn verify_self_ipi_delivery(cpu_id: usize) {
     );
 }
 
+fn run_async_callback_batch(target_cpu: usize, sender_cpus: &[usize], round: usize) {
+    SENT_CALLBACKS.store(0, Ordering::Relaxed);
+    EXECUTED_CALLBACKS.store(0, Ordering::Relaxed);
+
+    let ready = Arc::new(AtomicUsize::new(0));
+    let start = Arc::new(AtomicBool::new(false));
+    let mut senders = Vec::with_capacity(sender_cpus.len());
+
+    for &sender_cpu in sender_cpus {
+        let ready = ready.clone();
+        let start = start.clone();
+        senders.push(thread::spawn(move || {
+            pin_current_to_cpu(sender_cpu);
+            ready.fetch_add(1, Ordering::Release);
+
+            while !start.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+
+            for _ in 0..CALLBACKS_PER_SENDER {
+                SENT_CALLBACKS.fetch_add(1, Ordering::Relaxed);
+                ax_ipi::legacy::run_on_cpu(target_cpu, counting_callback)
+                    .expect("failed to send callback IPI");
+            }
+        }));
+    }
+
+    while ready.load(Ordering::Acquire) != sender_cpus.len() {
+        thread::yield_now();
+    }
+    start.store(true, Ordering::Release);
+
+    for sender in senders {
+        sender.join().unwrap();
+    }
+
+    let expected = sender_cpus.len() * CALLBACKS_PER_SENDER;
+    assert_eq!(SENT_CALLBACKS.load(Ordering::Relaxed), expected);
+    assert!(
+        wait_for_counter_or_stall(&EXECUTED_CALLBACKS, expected),
+        "IPI callbacks stalled at {}/{} in round {round}",
+        EXECUTED_CALLBACKS.load(Ordering::Acquire),
+        expected
+    );
+}
+
+fn run_concurrent_hard_calls(target_cpu: usize, sender_cpus: &[usize]) {
+    EXECUTED_HARD_CALLS.store(0, Ordering::Relaxed);
+
+    let ready = Arc::new(AtomicUsize::new(0));
+    let start = Arc::new(AtomicBool::new(false));
+    let mut senders = Vec::with_capacity(sender_cpus.len());
+
+    for &sender_cpu in sender_cpus {
+        let ready = ready.clone();
+        let start = start.clone();
+        senders.push(thread::spawn(move || {
+            pin_current_to_cpu(sender_cpu);
+            ready.fetch_add(1, Ordering::Release);
+
+            while !start.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+
+            // SAFETY: call_on_cpu is synchronous, so this stack-local target
+            // remains borrowed until the bounded hard-IRQ-safe thunk returns.
+            unsafe {
+                ax_ipi::call_on_cpu(
+                    CpuId(target_cpu),
+                    counting_hard_call,
+                    core::ptr::from_ref(&target_cpu).cast_mut().cast(),
+                )
+            }
+            .expect("failed to execute IPI hard call");
+        }));
+    }
+
+    while ready.load(Ordering::Acquire) != sender_cpus.len() {
+        thread::yield_now();
+    }
+    start.store(true, Ordering::Release);
+
+    assert!(
+        wait_for_counter_or_stall(&EXECUTED_HARD_CALLS, sender_cpus.len()),
+        "IPI hard calls stalled at {}/{}",
+        EXECUTED_HARD_CALLS.load(Ordering::Acquire),
+        sender_cpus.len()
+    );
+
+    for sender in senders {
+        sender.join().unwrap();
+    }
+}
+
 pub fn run() -> crate::TestResult {
     let cpu_num = thread::available_parallelism().unwrap().get();
     if cpu_num < 2 {
@@ -129,73 +223,21 @@ pub fn run() -> crate::TestResult {
         .collect::<Vec<_>>();
     assert!(!sender_cpus.is_empty(), "need at least one sender CPU");
 
+    TARGET_CPU.store(target_cpu, Ordering::Relaxed);
     verify_self_ipi_delivery(sender_cpus[0]);
 
     for round in 0..TEST_ROUNDS {
-        TARGET_CPU.store(target_cpu, Ordering::Relaxed);
-        SENT_CALLBACKS.store(0, Ordering::Relaxed);
-        EXECUTED_CALLBACKS.store(0, Ordering::Relaxed);
-
-        let ready = Arc::new(AtomicUsize::new(0));
-        let start = Arc::new(AtomicBool::new(false));
-        let mut senders = Vec::with_capacity(sender_cpus.len());
-
-        for &sender_cpu in &sender_cpus {
-            let ready = ready.clone();
-            let start = start.clone();
-            senders.push(thread::spawn(move || {
-                pin_current_to_cpu(sender_cpu);
-                ready.fetch_add(1, Ordering::Release);
-
-                while !start.load(Ordering::Acquire) {
-                    thread::yield_now();
-                }
-
-                for _ in 0..CALLBACKS_PER_SENDER {
-                    SENT_CALLBACKS.fetch_add(1, Ordering::Relaxed);
-                    ax_ipi::legacy::run_on_cpu(target_cpu, counting_callback)
-                        .expect("failed to send callback IPI");
-                }
-            }));
-        }
-
-        while ready.load(Ordering::Acquire) != sender_cpus.len() {
-            thread::yield_now();
-        }
-        start.store(true, Ordering::Release);
-
-        for sender in senders {
-            sender.join().unwrap();
-        }
-
-        let expected = sender_cpus.len() * CALLBACKS_PER_SENDER;
-        assert_eq!(SENT_CALLBACKS.load(Ordering::Relaxed), expected);
-
-        assert!(
-            wait_for_callbacks_or_stall(expected),
-            "IPI callbacks stalled at {}/{} in round {round}",
-            EXECUTED_CALLBACKS.load(Ordering::Relaxed),
-            expected
-        );
+        run_async_callback_batch(target_cpu, &sender_cpus, round);
     }
 
-    pin_current_to_cpu(sender_cpus[0]);
-    EXECUTED_HARD_CALLS.store(0, Ordering::Relaxed);
-    // SAFETY: call_on_cpu is synchronous, so target_cpu remains borrowed until
-    // the hard-IRQ-safe counting thunk completes on the target.
-    unsafe {
-        ax_ipi::call_on_cpu(
-            CpuId(target_cpu),
-            counting_hard_call,
-            core::ptr::from_ref(&target_cpu).cast_mut().cast(),
-        )
-    }
-    .expect("failed to execute IPI hard call");
-    assert_eq!(EXECUTED_HARD_CALLS.load(Ordering::Relaxed), 1);
+    run_concurrent_hard_calls(target_cpu, &sender_cpus);
 
     println!(
-        "task_ipi: verified self delivery on CPU {} and remote delivery on CPU {target_cpu}",
-        sender_cpus[0]
+        "task_ipi: passed self-claim on CPU {}, {} async callbacks, and {} concurrent hard calls \
+         on CPU {target_cpu}",
+        sender_cpus[0],
+        TEST_ROUNDS * sender_cpus.len() * CALLBACKS_PER_SENDER,
+        sender_cpus.len()
     );
 
     Ok(())


### PR DESCRIPTION
## 问题

#2006 的直接原因并非物理 IPI 丢失，而是 #1775 中 `d5aabb132` 将两轮约 96 次异步 callback 压力改成逐项同步 `call_on_cpu()`。在新 `TaskSystem` 与 single-thread TCG 的组合下，发送 vCPU 忙等目标 vCPU，串行放大后超过 120 秒。

当前 `dev` 没有该回归，仍保持异步 callback 压力与少量同步 hard-call。本 PR 不迁回 #1775 的 scheduler generation，而是在 `dev` 固化真实 QEMU 防回归门禁和现有 ownership 边界。

## 修改

- 将真实 ArceOS `task-ipi` 用例拆成三个明确场景：self-IPI claim、96 次异步 callback 批量投递、每 producer 一次并发同步 hard-call。
- callback 与 hard-call 完成计数使用 Release/Acquire 发布和观察，并通过有界停滞检测快速失败。
- 为共享 ArceOS Rust suite 增加通用的 case 配置选择约定：优先读取 `cases/<case>/qemu-<arch>.toml`，不存在时回退 suite 根配置。
- RISC-V `task-ipi` 用完整的专属 `QemuConfig` 声明 `-accel tcg,thread=single` 和 15 秒 timeout；axbuild 不识别该 case 的 timeout 或 QEMU 参数。
- 将已有 `task-wait-queue-remote-wake` 的 single-thread TCG runner 特例同步迁入专属配置，删除两处 feature/target 名字分支。
- 在 RISC-V self-hosted CI 中保留全量 ArceOS 测试，并追加 `taskset -c 0` 的精确 `task-ipi` 门禁；`cache_key: ""` 保持不变。
- 扩充 `ax-ipi` 契约测试与文档，明确逻辑 owner 先发布状态再通知、handler 先 claim 物理 edge 再 drain、`Coalesced` 不表示逻辑工作完成，以及 `call_on_cpu()` 只适合少量同步工作。
- rebase 到最新 `dev@f9e8b9dd79`，保留 #2018 的统一 managed-rootfs 写策略校验和 discard 隔离；新增 runner 级回归，确保每个 ArceOS Rust case 都拒绝 `persist`，且实际 drive 带 `snapshot=on`。

## 架构边界

- ax-task 继续拥有逻辑 pending/generation。
- `ax-ipi::DeliveryEdge` 继续唯一拥有物理 IPI edge 与合并状态。
- ax-runtime 只编排 handler 的 claim 和各 owner drain。
- QEMU 的 args、timeout 和 regex 由各 case 的标准 `QemuConfig` 拥有；axbuild 只解析配置路径与 suite fallback。
- rootfs 写策略和隔离继续由 #2018 的通用 QEMU rootfs 框架拥有，per-case 配置不建立第二套隔离逻辑。
- 不修改公开函数签名，不新增兼容 shim、第二套 doorbell、runtime epoch 或 fake `TaskSystem`。

## 红绿证据

- task-IPI Red：在 #1775 修复前的真实新 `TaskSystem` 基线 `1a3f856d1` 临时施加相同 single-thread TCG 与 15 秒限制后，精确 RISC-V 用例到达 `ARCEOS_TEST_BEGIN feature=task-ipi`，随后稳定以 `QEMU timed out after 15s` 失败。临时代码未提交。
- 交叉核验：仅在当前旧 axtask 上临时将 callback 压力改成逐项同步调用仍可在约 350 ms 内通过，说明回归需要 #1775 新 `TaskSystem`、hard-call/handler 组合与同步压力改写共同触发；本 PR 是 `dev` 防回归门禁，不宣称修复当前 `dev` 的已有故障。
- task-IPI Green：最终精确 RISC-V 命令明确加载 `cases/task-ipi/qemu-riscv64.toml`，在门禁内通过，并输出 `96 async callbacks`、`3 concurrent hard calls` 的非 skip 成功标志。
- timeout 校准：5 秒配置在全矩阵并发的 self-hosted runner 上尚未输出串口内容便超时，而完整 RISC-V 聚合已通过；这证明失败来自整机启动抖动而非 task-IPI marker 后停滞。15 秒仍能稳定拦截上述真实 buggy 基线，同时为 CI 启动留出余量。
- rootfs Red：临时移除 `prepare_rust_qemu_cases` 的 policy validation 与 discard isolation 后，同一 runner 回归稳定 2/2 失败：`persist` 被错误接受，且 prepared drive 缺少 `snapshot=on`。临时代码未提交。
- rootfs Green：恢复最新 `dev` 的统一调用后，同一命令 2/2 通过；测试只使用 `tempfile` 中预创建的镜像，不修改 workspace rootfs，也不依赖 `mkfs.fat`。

## 验证

- `cargo test -p axbuild`：890/890 通过。
- `cargo test -p ax-ipi --features host-test`：13/13 通过。
- `cargo xtask clippy --package ax-ipi`、`--package axbuild`、`--package arceos-test-suit`：3 个 package、32 个 check 全部通过。
- x86_64、riscv64、aarch64、loongarch64 的精确 `task-ipi` 均通过；每个架构都输出 self-claim、96 次异步 callback 和 3 次并发 hard-call 成功标志。
- `taskset -c 0 cargo xtask arceos test qemu --arch riscv64 --test-group rust --test-case task-ipi`：实际使用 `tcg,thread=single` 与 `snapshot=on`，2.45 秒通过 15 秒门禁。
- 完整 RISC-V ArceOS 聚合明确加载 suite 根 `qemu-riscv64.toml`，Rust `all` 与 C `all` 均通过，确认专属配置和 rootfs 不会污染整体测试。
- `cargo fmt --all --check` 与 `git diff --check` 通过。

关联 #2006。#1775 应在本 PR 合并后 rebase 到最新 `dev`，保留这里的测试与 `DeliveryEdge`，并避免重新引入逐项同步压力实现。
