### PR TITLE
fix(axbuild): lint host-test targets with clippy

### DIFF
--- a/docs/docs/build/clippy.md
+++ b/docs/docs/build/clippy.md
@@ -89,7 +89,7 @@ Clippy 的代码按选择、展开、执行和报告划分，避免参数解析�
 1. **target** 来自 `docs_rs_targets(package)`，从 docs.rs metadata 读取包声明支持的 target；为空时取单个 `None`（host target）。
 2. **feature** 取包 `Cargo.toml` 中除 `default` 外的全部 feature；`ax-std` 额外注入一个名为 `default` 的特殊 feature。
 3. 每个 (target, base) 组合产生一个 base check；`NoDeps` 模式下再为每个该 target 支持的 feature 产生一个 feature check。
-4. feature check 使用对应 feature 名执行；普通包不额外注入构建环境变量。
+4. feature check 使用对应 feature 名执行；`host-test` 是 workspace 的宿主测试约定，不参与 docs.rs target 矩阵，而是在 host target 上单独检查一次并加上 `--tests`，让 Clippy 编译单元测试和集成测试目标。普通包不额外注入构建环境变量。
 5. `NoDeps` 模式下，包还可以通过 `[package.metadata.clippy]` 声明命名配置；每条配置按一个明确 target、完整 feature 集和环境变量额外生成 check。`WithDeps` 仍只运行 base check，避免增量反向依赖扫描膨胀成完整配置矩阵。
 
 命名配置用于 docs.rs target × 单 feature 矩阵无法表达的正式构建组合。它保留包的默认 feature，再额外启用配置中的完整 feature 集：
@@ -144,7 +144,7 @@ targets = ["aarch64-unknown-linux-gnu", "riscv64gc-unknown-none-elf"]
 `ClippyCheck::cargo_args()` 构造命令行：
 
 - Base check：`clippy -p <pkg>`
-- Feature check：`clippy -p <pkg> --no-default-features --features <feature>`
+- Feature check：`clippy -p <pkg> --no-default-features --features <feature>`；当 feature 为 `host-test` 时额外传入 `--tests`
 - Named configuration check：`clippy -p <pkg> --features <feature-a>,<feature-b> --target <target>`，并注入配置声明的环境变量
 - `ax-std` default 特判：替换为 `--features std-compat,fs,multitask,irq,net`
 - `NoDeps`：在 `clippy` 后插入 `--no-deps`，避免依赖 crate 的告警污染结果

--- a/drivers/rdrive/src/probe/acpi.rs
+++ b/drivers/rdrive/src/probe/acpi.rs
@@ -295,6 +295,10 @@ mod tests {
     };
     use crate::register::{DriverRegister, ProbeKind, ProbeLevel, ProbePriority};
 
+    #[expect(
+        clippy::arc_with_non_send_sync,
+        reason = "acpi::Interpreter requires Arc even for this single-threaded test handler"
+    )]
     fn test_fixed_registers(handler: &AcpiHandler) -> Arc<FixedRegisters<AcpiHandler>> {
         let event_gas = GenericAddress {
             address_space: AddressSpace::SystemIo,

--- a/os/arceos/modules/axinput/src/rdif.rs
+++ b/os/arceos/modules/axinput/src/rdif.rs
@@ -105,6 +105,54 @@ impl From<rdif_input::InputDeviceId> for InputDeviceId {
     }
 }
 
+impl From<EventType> for rdif_input::EventType {
+    fn from(value: EventType) -> Self {
+        match value {
+            EventType::Synchronization => Self::Synchronization,
+            EventType::Key => Self::Key,
+            EventType::Relative => Self::Relative,
+            EventType::Absolute => Self::Absolute,
+            EventType::Misc => Self::Misc,
+            EventType::Switch => Self::Switch,
+            EventType::Led => Self::Led,
+            EventType::Sound => Self::Sound,
+            EventType::ForceFeedback => Self::ForceFeedback,
+        }
+    }
+}
+
+impl From<rdif_input::InputEvent> for Event {
+    fn from(value: rdif_input::InputEvent) -> Self {
+        Self {
+            event_type: value.event_type,
+            code: value.code,
+            value: value.value,
+        }
+    }
+}
+
+impl From<rdif_input::AbsInfo> for AbsInfo {
+    fn from(value: rdif_input::AbsInfo) -> Self {
+        Self {
+            min: value.min,
+            max: value.max,
+            fuzz: value.fuzz,
+            flat: value.flat,
+            res: value.res,
+        }
+    }
+}
+
+fn map_input_error(error: RdifInputError) -> InputError {
+    match error {
+        RdifInputError::NotSupported => InputError::Unsupported,
+        RdifInputError::Again => InputError::Again,
+        RdifInputError::NotAvailable => InputError::ResourceBusy,
+        RdifInputError::InvalidEvent => InputError::InvalidInput,
+        RdifInputError::Other(_) => InputError::Io,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use irq_framework::{HwIrq, IrqDomainId, IrqId};
@@ -162,53 +210,5 @@ mod tests {
         let erased = crate::ErasedInputDevice::new(device);
 
         assert_eq!(erased.irq_id(), None);
-    }
-}
-
-impl From<EventType> for rdif_input::EventType {
-    fn from(value: EventType) -> Self {
-        match value {
-            EventType::Synchronization => Self::Synchronization,
-            EventType::Key => Self::Key,
-            EventType::Relative => Self::Relative,
-            EventType::Absolute => Self::Absolute,
-            EventType::Misc => Self::Misc,
-            EventType::Switch => Self::Switch,
-            EventType::Led => Self::Led,
-            EventType::Sound => Self::Sound,
-            EventType::ForceFeedback => Self::ForceFeedback,
-        }
-    }
-}
-
-impl From<rdif_input::InputEvent> for Event {
-    fn from(value: rdif_input::InputEvent) -> Self {
-        Self {
-            event_type: value.event_type,
-            code: value.code,
-            value: value.value,
-        }
-    }
-}
-
-impl From<rdif_input::AbsInfo> for AbsInfo {
-    fn from(value: rdif_input::AbsInfo) -> Self {
-        Self {
-            min: value.min,
-            max: value.max,
-            fuzz: value.fuzz,
-            flat: value.flat,
-            res: value.res,
-        }
-    }
-}
-
-fn map_input_error(error: RdifInputError) -> InputError {
-    match error {
-        RdifInputError::NotSupported => InputError::Unsupported,
-        RdifInputError::Again => InputError::Again,
-        RdifInputError::NotAvailable => InputError::ResourceBusy,
-        RdifInputError::InvalidEvent => InputError::InvalidInput,
-        RdifInputError::Other(_) => InputError::Io,
     }
 }

--- a/os/arceos/modules/axlog/src/lib.rs
+++ b/os/arceos/modules/axlog/src/lib.rs
@@ -368,7 +368,7 @@ mod tests {
     #[test]
     fn log_buffer_truncates_at_utf8_boundary() {
         let mut buf = LogBuffer::<22>::new();
-        write!(buf, "ab你好xxxxxxxxxxxxxxxx\n").unwrap();
+        writeln!(buf, "ab你好xxxxxxxxxxxxxxxx").unwrap();
         buf.append_truncation_marker();
 
         assert_eq!(buf.as_str(), "ab\u{1B}[m<log truncated>\n");

--- a/scripts/axbuild/src/clippy/check.rs
+++ b/scripts/axbuild/src/clippy/check.rs
@@ -1,4 +1,6 @@
-use super::{AXSTD_STD_CLIPPY_FEATURES, AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE};
+use super::{
+    AXSTD_STD_CLIPPY_FEATURES, AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE, HOST_TEST_FEATURE,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) enum ClippyCheckKind {
@@ -26,14 +28,18 @@ impl ClippyCheck {
     pub(super) fn cargo_args(&self) -> Vec<String> {
         let mut args = match &self.kind {
             ClippyCheckKind::Base => vec!["clippy".into(), "-p".into(), self.package.clone()],
-            ClippyCheckKind::Feature(feature) => vec![
-                "clippy".into(),
-                "-p".into(),
-                self.package.clone(),
-                "--no-default-features".into(),
-                "--features".into(),
-                feature.clone(),
-            ],
+            ClippyCheckKind::Feature(feature) => {
+                let mut args = vec!["clippy".into(), "-p".into(), self.package.clone()];
+                if feature == HOST_TEST_FEATURE {
+                    args.push("--tests".into());
+                }
+                args.extend([
+                    "--no-default-features".into(),
+                    "--features".into(),
+                    feature.clone(),
+                ]);
+                args
+            }
             ClippyCheckKind::Configuration { features, .. } => {
                 let mut args = vec!["clippy".into(), "-p".into(), self.package.clone()];
                 if !features.is_empty() {

--- a/scripts/axbuild/src/clippy/expand.rs
+++ b/scripts/axbuild/src/clippy/expand.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use cargo_metadata::Metadata;
 
 use super::{
-    AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE, DEFAULT_FEATURE,
+    AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE, DEFAULT_FEATURE, HOST_TEST_FEATURE,
     check::{ClippyCheck, ClippyCheckKind, ClippyDepsMode},
     configurations::package_clippy_configurations,
     env::{clippy_env, feature_clippy_env},
@@ -28,6 +28,7 @@ pub(super) fn expand_clippy_checks(
         if package.name == AXSTD_STD_PACKAGE {
             features.insert(AXSTD_STD_DEFAULT_FEATURE.to_string());
         }
+        let has_host_test = features.remove(HOST_TEST_FEATURE);
         let targets = docs_rs_targets(package);
         let target_iter = if targets.is_empty() {
             vec![None]
@@ -71,6 +72,24 @@ pub(super) fn expand_clippy_checks(
         }
 
         if matches!(selected.deps_mode, ClippyDepsMode::NoDeps) {
+            if has_host_test {
+                let feature_env =
+                    feature_clippy_env(package, HOST_TEST_FEATURE, env.clone(), metadata)
+                        .with_context(|| {
+                            format!(
+                                "failed to prepare clippy env for `{}` feature \
+                                 `{HOST_TEST_FEATURE}`",
+                                package.name
+                            )
+                        })?;
+                checks.push(ClippyCheck {
+                    package: package.name.to_string(),
+                    kind: ClippyCheckKind::Feature(HOST_TEST_FEATURE.to_string()),
+                    deps_mode: selected.deps_mode.clone(),
+                    target: None,
+                    env: feature_env,
+                });
+            }
             for configuration in package_clippy_configurations(package)? {
                 checks.push(ClippyCheck {
                     package: package.name.to_string(),

--- a/scripts/axbuild/src/clippy/mod.rs
+++ b/scripts/axbuild/src/clippy/mod.rs
@@ -26,6 +26,7 @@ use selection::{
 use timing::print_clippy_timing;
 
 pub(super) const DEFAULT_FEATURE: &str = "default";
+pub(super) const HOST_TEST_FEATURE: &str = "host-test";
 pub(super) const AXSTD_STD_PACKAGE: &str = "ax-std";
 pub(super) const AXSTD_STD_DEFAULT_FEATURE: &str = "default";
 pub(super) const AXSTD_STD_CLIPPY_FEATURES: &str = "std-compat,fs,multitask,irq,net";

--- a/scripts/axbuild/src/clippy/tests/expand.rs
+++ b/scripts/axbuild/src/clippy/tests/expand.rs
@@ -81,6 +81,59 @@ fn feature_expansion_is_deterministic() {
 }
 
 #[test]
+fn host_test_feature_lints_test_targets() {
+    let checks = expand(&[pkg(
+        "alpha",
+        "alpha 0.1.0 (path+file:///tmp/alpha)",
+        &[("host-test", &[])],
+        None,
+    )]);
+    let host_test = checks
+        .iter()
+        .find(|check| check.label() == "alpha (feature: host-test)")
+        .expect("host-test feature check should be planned");
+
+    assert_eq!(
+        host_test.cargo_args(),
+        vec![
+            "clippy",
+            "--no-deps",
+            "-p",
+            "alpha",
+            "--tests",
+            "--no-default-features",
+            "--features",
+            "host-test",
+            "--",
+            "-D",
+            "warnings",
+        ]
+    );
+}
+
+#[test]
+fn host_test_feature_uses_host_target_outside_docs_target_matrix() {
+    let checks = expand(&[pkg(
+        "alpha",
+        "alpha 0.1.0 (path+file:///tmp/alpha)",
+        &[("host-test", &[]), ("platform", &[])],
+        Some(&["aarch64-unknown-none-softfloat"]),
+    )]);
+    let host_test_checks = checks
+        .iter()
+        .filter(|check| check.label().contains("feature: host-test"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(host_test_checks.len(), 1);
+    assert_eq!(host_test_checks[0].label(), "alpha (feature: host-test)");
+    assert!(
+        !host_test_checks[0]
+            .cargo_args()
+            .contains(&"--target".into())
+    );
+}
+
+#[test]
 fn incremental_selection_keeps_runnable_top_levels_when_some_are_skipped() {
     let packages = vec![
         pkg("alpha", "alpha 0.1.0 (path+file:///tmp/alpha)", &[], None),

--- a/virtualization/axvm/src/arch/aarch64/capabilities.rs
+++ b/virtualization/axvm/src/arch/aarch64/capabilities.rs
@@ -94,18 +94,20 @@ pub(super) fn patch_runtime_fdt(
         ))
     })?;
     super::fdt::core::create::patch_guest_fdt_for_runtime(
-        fdt_bytes,
-        &vm.memory_regions(),
-        &ivc_channels,
-        crate_config,
-        serial_profile,
-        serial_identity.as_ref(),
-        &additional_serials,
-        Some(&gic_profile),
-        None,
-        Some(&timer_profile),
-        initrd,
-        true,
+        super::fdt::core::create::GuestFdtRuntimePatch {
+            fdt_bytes,
+            memory_regions: &vm.memory_regions(),
+            ivc_channels: &ivc_channels,
+            crate_config,
+            serial_profile,
+            serial_identity: serial_identity.as_ref(),
+            additional_serials: &additional_serials,
+            gic_profile: Some(&gic_profile),
+            plic_profile: None,
+            timer_profile: Some(&timer_profile),
+            initrd_start_size: initrd,
+            create_chosen: true,
+        },
     )
 }
 

--- a/virtualization/axvm/src/arch/mod.rs
+++ b/virtualization/axvm/src/arch/mod.rs
@@ -94,6 +94,7 @@ pub(crate) fn register_timer_source(
     CurrentArch::register_timer_source(deadline_source, notify);
 }
 
+#[cfg(not(test))]
 pub(crate) fn request_timer_deadline(deadline_ns: u64) {
     CurrentArch::request_timer_deadline(deadline_ns);
 }

--- a/virtualization/axvm/src/arch/riscv64/capabilities.rs
+++ b/virtualization/axvm/src/arch/riscv64/capabilities.rs
@@ -106,18 +106,20 @@ pub(super) fn patch_runtime_fdt(
         )
     });
     let guest_fdt = super::fdt::core::create::patch_guest_fdt_for_runtime(
-        fdt_bytes,
-        &vm.memory_regions(),
-        &ivc_channels,
-        crate_config,
-        serial_profile,
-        serial_identity.as_ref(),
-        &additional_serials,
-        None,
-        plic_profile.as_ref(),
-        None,
-        None,
-        false,
+        super::fdt::core::create::GuestFdtRuntimePatch {
+            fdt_bytes,
+            memory_regions: &vm.memory_regions(),
+            ivc_channels: &ivc_channels,
+            crate_config,
+            serial_profile,
+            serial_identity: serial_identity.as_ref(),
+            additional_serials: &additional_serials,
+            gic_profile: None,
+            plic_profile: plic_profile.as_ref(),
+            timer_profile: None,
+            initrd_start_size: None,
+            create_chosen: false,
+        },
     )?;
     super::fdt::ensure_chosen_from_host(guest_fdt, host_fdt.as_ref())
 }

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -93,7 +93,7 @@ impl ArchOps for Riscv64Arch {
     }
 
     fn inject_vcpu_interrupt(
-        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        vcpu: &crate::vcpu::AxVCpu<Self::VCpu>,
         interrupt: crate::irq::model::PendingVcpuInterrupt,
     ) -> AxVmResult {
         const SCAUSE_INTERRUPT_BIT: usize = 1 << (usize::BITS - 1);

--- a/virtualization/axvm/src/arch/x86_64/boot/acpi/fw_cfg.rs
+++ b/virtualization/axvm/src/arch/x86_64/boot/acpi/fw_cfg.rs
@@ -271,7 +271,9 @@ mod tests {
     fn decode_loader(bytes: &[u8]) -> Vec<DecodedLoaderCommand> {
         assert_eq!(bytes.len() % LOADER_ENTRY_SIZE, 0);
         bytes
-            .chunks_exact(LOADER_ENTRY_SIZE)
+            .as_chunks::<LOADER_ENTRY_SIZE>()
+            .0
+            .iter()
             .map(|entry| match read_u32(entry, 0) {
                 1 => DecodedLoaderCommand::Allocate {
                     file: read_file(&entry[4..60]),

--- a/virtualization/axvm/src/architecture/capabilities.rs
+++ b/virtualization/axvm/src/architecture/capabilities.rs
@@ -119,6 +119,7 @@ pub(crate) trait BootImagePlatform {
 
 /// Architecture-specific host timer policy used by the ArceOS adapter.
 pub(crate) trait HostTimePlatform {
+    #[cfg(not(test))]
     fn request_timer_deadline(deadline_ns: u64) {
         ax_std::os::arceos::modules::ax_task::request_timer_deadline_nanos(deadline_ns);
     }

--- a/virtualization/axvm/src/architecture/exit.rs
+++ b/virtualization/axvm/src/architecture/exit.rs
@@ -99,7 +99,7 @@ fn is_aarch64_psci_function_id(raw_code: u64, abi: crate::runtime::hvc::HyperCal
 }
 
 fn complete_hypercall_decode_error<V: VmArchVcpuOps>(
-    vcpu: &crate::vm::AxVCpuRef<V>,
+    vcpu: &crate::vcpu::AxVCpu<V>,
     raw_code: u64,
     abi: crate::runtime::hvc::HyperCallAbi,
 ) {
@@ -263,9 +263,7 @@ mod tests {
 
     #[test]
     fn hvc_unknown_aarch64_psci_id_returns_not_supported() {
-        let vcpu = crate::vm::AxVCpuRef::new(
-            crate::vcpu::AxVCpu::<UnknownPsciVcpu>::new(99, 0, None, ()).unwrap(),
-        );
+        let vcpu = crate::vcpu::AxVCpu::<UnknownPsciVcpu>::new(99, 0, None, ()).unwrap();
 
         complete_hypercall_decode_error(
             &vcpu,
@@ -278,9 +276,7 @@ mod tests {
 
     #[test]
     fn hvc_unknown_non_aarch64_psci_id_does_not_clobber_return_value() {
-        let vcpu = crate::vm::AxVCpuRef::new(
-            crate::vcpu::AxVCpu::<UnknownPsciVcpu>::new(99, 0, None, ()).unwrap(),
-        );
+        let vcpu = crate::vcpu::AxVCpu::<UnknownPsciVcpu>::new(99, 0, None, ()).unwrap();
         vcpu.set_return_value(0x8400_000c);
 
         complete_hypercall_decode_error(

--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -104,7 +104,7 @@ pub(crate) trait ArchOps {
     /// system registers (GIC LR, x86 vLAPIC, etc.) happen on the correct
     /// physical CPU.
     fn inject_vcpu_interrupt(
-        vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
+        vcpu: &crate::vcpu::AxVCpu<Self::VCpu>,
         interrupt: PendingVcpuInterrupt,
     ) -> AxVmResult {
         vcpu.inject_interrupt_with_trigger(interrupt.id.0 as usize, interrupt.trigger)
@@ -228,7 +228,7 @@ fn inject_drained_interrupts<A: ArchOps>(
     dispatcher: &crate::runtime::VcpuIrqDispatcher,
     vm_id: usize,
     vcpu_id: usize,
-    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
+    vcpu: &crate::vcpu::AxVCpu<A::VCpu>,
 ) {
     for interrupt in dispatcher.drain(vcpu_id) {
         if let Err(err) = A::inject_vcpu_interrupt(vcpu, interrupt) {
@@ -427,7 +427,7 @@ mod tests {
     #[test]
     fn inject_vcpu_interrupt_preserves_level_trigger_at_backend_boundary() {
         let injections = Arc::new(IrqSafeMutex::new(InjectionLog::default()));
-        let vcpu = Arc::new(AxVCpu::<RecordingVcpu>::new(1, 0, None, injections.clone()).unwrap());
+        let vcpu = AxVCpu::<RecordingVcpu>::new(1, 0, None, injections.clone()).unwrap();
         let interrupt = PendingVcpuInterrupt {
             id: VirtualInterruptId(0x31),
             trigger: InterruptTriggerMode::LevelTriggered,
@@ -450,7 +450,7 @@ mod tests {
             failing_vector: Some(0x42),
             ..Default::default()
         }));
-        let vcpu = Arc::new(AxVCpu::<RecordingVcpu>::new(1, 0, None, injections.clone()).unwrap());
+        let vcpu = AxVCpu::<RecordingVcpu>::new(1, 0, None, injections.clone()).unwrap();
         let dispatcher = crate::runtime::VcpuIrqDispatcher::new();
         dispatcher.register_test_vcpu(0, 2);
         for interrupt in [

--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -331,20 +331,36 @@ fn load_patched_fdt(vm: AxVMRef, new_fdt_bytes: Vec<u8>) -> AxVmResult {
     vm.set_guest_device_tree(dest_addr, new_fdt_bytes)
 }
 
-pub(crate) fn patch_guest_fdt_for_runtime(
-    fdt_bytes: &[u8],
-    memory_regions: &[VMMemoryRegion],
-    ivc_channels: &[GuestIvcChannel],
-    crate_config: &GuestConfig,
-    serial_profile: crate::machine::GuestSerialProfile,
-    serial_identity: Option<&crate::machine::GuestSerialFdtIdentity>,
-    additional_serials: &[crate::machine::GuestSerialProfile],
-    gic_profile: Option<&crate::machine::GuestGicProfile>,
-    plic_profile: Option<&crate::machine::GuestPlicProfile>,
-    timer_profile: Option<&crate::machine::GuestTimerProfile>,
-    initrd_start_size: Option<(u64, u64)>,
-    create_chosen: bool,
-) -> AxVmResult<Vec<u8>> {
+pub(crate) struct GuestFdtRuntimePatch<'a> {
+    pub(crate) fdt_bytes: &'a [u8],
+    pub(crate) memory_regions: &'a [VMMemoryRegion],
+    pub(crate) ivc_channels: &'a [GuestIvcChannel],
+    pub(crate) crate_config: &'a GuestConfig,
+    pub(crate) serial_profile: crate::machine::GuestSerialProfile,
+    pub(crate) serial_identity: Option<&'a crate::machine::GuestSerialFdtIdentity>,
+    pub(crate) additional_serials: &'a [crate::machine::GuestSerialProfile],
+    pub(crate) gic_profile: Option<&'a crate::machine::GuestGicProfile>,
+    pub(crate) plic_profile: Option<&'a crate::machine::GuestPlicProfile>,
+    pub(crate) timer_profile: Option<&'a crate::machine::GuestTimerProfile>,
+    pub(crate) initrd_start_size: Option<(u64, u64)>,
+    pub(crate) create_chosen: bool,
+}
+
+pub(crate) fn patch_guest_fdt_for_runtime(patch: GuestFdtRuntimePatch<'_>) -> AxVmResult<Vec<u8>> {
+    let GuestFdtRuntimePatch {
+        fdt_bytes,
+        memory_regions,
+        ivc_channels,
+        crate_config,
+        serial_profile,
+        serial_identity,
+        additional_serials,
+        gic_profile,
+        plic_profile,
+        timer_profile,
+        initrd_start_size,
+        create_chosen,
+    } = patch;
     let mut tree = FdtTree::from_bytes(fdt_bytes)?;
     let memory_specs = guest_memory_specs(memory_regions, crate_config);
     tree.rebuild_memory_nodes(&memory_specs)?;
@@ -991,40 +1007,40 @@ mod tests {
         let cfg = GuestConfig::default();
 
         let serial = crate::machine::current_machine_profile(1).serial;
-        let patched = super::patch_guest_fdt_for_runtime(
-            &dtb,
-            &[],
-            &[],
-            &cfg,
-            serial,
-            None,
-            &[],
-            None,
-            None,
-            None,
-            None,
-            false,
-        )
+        let patched = super::patch_guest_fdt_for_runtime(super::GuestFdtRuntimePatch {
+            fdt_bytes: &dtb,
+            memory_regions: &[],
+            ivc_channels: &[],
+            crate_config: &cfg,
+            serial_profile: serial,
+            serial_identity: None,
+            additional_serials: &[],
+            gic_profile: None,
+            plic_profile: None,
+            timer_profile: None,
+            initrd_start_size: None,
+            create_chosen: false,
+        })
         .unwrap();
         let reparsed = Fdt::from_bytes(&patched).unwrap();
 
         assert!(reparsed.get_by_path_id("/chosen").is_none());
 
         let serial = crate::machine::current_machine_profile(1).serial;
-        let patched = super::patch_guest_fdt_for_runtime(
-            &dtb,
-            &[],
-            &[],
-            &cfg,
-            serial,
-            None,
-            &[],
-            None,
-            None,
-            None,
-            None,
-            true,
-        )
+        let patched = super::patch_guest_fdt_for_runtime(super::GuestFdtRuntimePatch {
+            fdt_bytes: &dtb,
+            memory_regions: &[],
+            ivc_channels: &[],
+            crate_config: &cfg,
+            serial_profile: serial,
+            serial_identity: None,
+            additional_serials: &[],
+            gic_profile: None,
+            plic_profile: None,
+            timer_profile: None,
+            initrd_start_size: None,
+            create_chosen: true,
+        })
         .unwrap();
         let reparsed = Fdt::from_bytes(&patched).unwrap();
 
@@ -1051,20 +1067,20 @@ mod tests {
         let serial = crate::machine::current_machine_profile(1).serial;
         let gic = gic_profile(7);
 
-        let patched = super::patch_guest_fdt_for_runtime(
-            &dtb,
-            &[],
-            &ivc_channels,
-            &cfg,
-            serial,
-            None,
-            &[],
-            Some(&gic),
-            None,
-            None,
-            None,
-            false,
-        )
+        let patched = super::patch_guest_fdt_for_runtime(super::GuestFdtRuntimePatch {
+            fdt_bytes: &dtb,
+            memory_regions: &[],
+            ivc_channels: &ivc_channels,
+            crate_config: &cfg,
+            serial_profile: serial,
+            serial_identity: None,
+            additional_serials: &[],
+            gic_profile: Some(&gic),
+            plic_profile: None,
+            timer_profile: None,
+            initrd_start_size: None,
+            create_chosen: false,
+        })
         .unwrap();
         let reparsed = Fdt::from_bytes(&patched).unwrap();
         let node_id = reparsed.get_by_path_id("/ivc-channel@bff00000").unwrap();

--- a/virtualization/axvm/src/boot/fdt/core/interrupt/gic.rs
+++ b/virtualization/axvm/src/boot/fdt/core/interrupt/gic.rs
@@ -16,9 +16,7 @@ const DEFAULT_REDISTRIBUTOR_STRIDE: usize = 0x2_0000;
 pub(crate) fn host_gic_profile(fdt: &Fdt) -> AxVmResult<Option<GuestGicProfile>> {
     let Some((controller, compatible)) = fdt.iter_node_ids().find_map(|node_id| {
         let node = fdt.node(node_id)?;
-        if node.get_property("interrupt-controller").is_none() {
-            return None;
-        }
+        node.get_property("interrupt-controller")?;
         node.compatibles()
             .find(|compatible| is_supported(compatible))
             .map(|compatible| (node_id, std::string::String::from(compatible)))

--- a/virtualization/axvm/src/boot/fdt/core/mod.rs
+++ b/virtualization/axvm/src/boot/fdt/core/mod.rs
@@ -60,19 +60,18 @@ fn resolve_machine_resources_from_host(
     })?;
     let machine = crate::machine::current_machine_profile(vm_config.phys_cpu_ls.cpu_num());
     let current = vm_config.serial_profile();
-    if let Some(interrupt_encoding) = machine.serial_fdt_interrupt {
-        if let Some(resolved) =
+    if let Some(interrupt_encoding) = machine.serial_fdt_interrupt
+        && let Some(resolved) =
             serial::host_selected_serial(&host_fdt, current, interrupt_encoding)?
-        {
-            if resolved.profile != current {
-                info!(
-                    "VM[{}] virtual UART follows the host-selected UART: {:?}",
-                    vm_config.id(),
-                    resolved.profile
-                );
-            }
-            vm_config.replace_machine_serial(resolved.profile, Some(resolved.identity))?;
+    {
+        if resolved.profile != current {
+            info!(
+                "VM[{}] virtual UART follows the host-selected UART: {:?}",
+                vm_config.id(),
+                resolved.profile
+            );
         }
+        vm_config.replace_machine_serial(resolved.profile, Some(resolved.identity))?;
     }
 
     if let Some(gic) = interrupt::host_gic_profile(&host_fdt)? {

--- a/virtualization/axvm/src/boot/fdt/core/timer.rs
+++ b/virtualization/axvm/src/boot/fdt/core/timer.rs
@@ -100,8 +100,10 @@ pub(crate) fn host_timer_profile(fdt: &Fdt) -> AxVmResult<Option<GuestTimerProfi
     }
 
     let interrupt_specifiers = interrupt_cells
-        .chunks_exact(3)
-        .map(<[u32]>::to_vec)
+        .as_chunks::<3>()
+        .0
+        .iter()
+        .map(|specifier| specifier.to_vec())
         .collect::<Vec<_>>();
     let intids = interrupt_specifiers
         .iter()

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -82,6 +82,7 @@ impl HostTime for ArceOsHost {
         modules::ax_hal::time::monotonic_time()
     }
 
+    #[cfg(not(test))]
     fn request_timer_deadline(&self, deadline_ns: u64) {
         crate::arch::request_timer_deadline(deadline_ns);
     }
@@ -130,6 +131,7 @@ pub(crate) type ArceOsAxTaskRef = modules::ax_task::AxTaskRef;
 pub(crate) type ArceOsCurrentTask = modules::ax_task::CurrentTask;
 pub(crate) type ArceOsTaskInner = modules::ax_task::TaskInner;
 pub(crate) type ArceOsWaitQueue = modules::ax_task::WaitQueue;
+#[cfg(any(not(test), target_arch = "aarch64"))]
 pub(crate) type ArceOsIrqError = modules::ax_hal::irq::IrqError;
 pub(crate) type ArceOsWaitQueueHandle = api::task::AxWaitQueueHandle;
 pub(crate) use modules::ax_task::TaskExt as ArceOsTaskExt;
@@ -175,6 +177,7 @@ pub(crate) fn send_ipi(cpu_id: usize) {
     .unwrap_or_else(|err| panic!("failed to deliver AxVM IPI to CPU {cpu_id}: {err:?}"));
 }
 
+#[cfg(any(not(test), target_arch = "aarch64"))]
 pub(crate) fn run_on_cpu_sync(
     cpu_id: usize,
     f: unsafe fn(*mut ()),

--- a/virtualization/axvm/src/host/task.rs
+++ b/virtualization/axvm/src/host/task.rs
@@ -38,6 +38,7 @@ pub(crate) fn wait_queue_wake(queue: &WaitQueueHandle, count: u32) {
     arceos::wait_queue_wake(queue, count);
 }
 
+#[cfg(any(not(test), target_arch = "aarch64"))]
 pub(crate) fn run_on_cpu_sync(
     cpu_id: usize,
     f: unsafe fn(*mut ()),

--- a/virtualization/axvm/src/host/traits.rs
+++ b/virtualization/axvm/src/host/traits.rs
@@ -37,6 +37,7 @@ pub trait HostTime {
     fn monotonic_time(&self) -> Duration;
 
     /// Publish an earlier deadline to the host's shared timer arbiter.
+    #[cfg(not(test))]
     fn request_timer_deadline(&self, deadline_ns: u64);
 }
 

--- a/virtualization/axvm/src/vm/prepare/device_plan/passthrough.rs
+++ b/virtualization/axvm/src/vm/prepare/device_plan/passthrough.rs
@@ -287,7 +287,8 @@ mod tests {
         });
 
         let mut builder = DeviceGraphBuilder::new();
-        add_host_nodes(&config, &[0xfd7c_0000..0xfd81_0000], &mut builder).unwrap();
+        let replacement = 0xfd7c_0000..0xfd81_0000;
+        add_host_nodes(&config, std::slice::from_ref(&replacement), &mut builder).unwrap();
         let declared = builder.declare().unwrap();
         let requests = declared.requests().unwrap();
         let mut pools = ResourcePools::new();


### PR DESCRIPTION
## 问题

CI 同时运行 `cargo xtask clippy --since ...` 和 `cargo xtask test`，但两条路径之间存在覆盖空隙：

- axbuild Clippy 原先把 `host-test` 当作普通 feature，只检查库目标，没有传入 `--tests`，因此不会编译 `#[cfg(test)]` 和集成测试目标。
- std 测试任务会编译并运行这些测试，但不会执行 Clippy lint。
- 对声明 docs.rs 交叉 target 的包，`host-test` 还会进入交叉 target 矩阵，而不是在宿主机上检查。

这使 AxVM 测试代码中的 Clippy 问题能够绕过既有 CI。

## 修改

1. 在现有 axbuild Clippy 展开框架中统一识别 workspace 的 `host-test` 约定：
   - 从 docs.rs target × feature 矩阵中移除 `host-test`；
   - 在 host target 上生成一次独立检查；
   - 自动传入 `--tests --no-default-features --features host-test`；
   - 保持现有 `NoDeps`/`WithDeps` 增量检查策略不变。
2. 增加确定性回归测试，分别验证 test targets 会被检查，以及 `host-test` 不会继承 docs.rs 交叉 target。两个测试在旧实现下分别因缺少 `--tests` 和错误携带 `--target` 而失败。
3. 修复新检查暴露的 AxVM test-target Clippy 问题，包括仅生产路径的接口、过长参数列表、无效 Arc 包装及可直接简化的表达式。
4. 修复通用检查同时暴露的 `rdrive`、`ax-log` 和 `ax-input` 既有 test-target lint，并补充 Clippy 行为文档。

该实现不按 AxVM 包名分支，也不要求包声明额外 metadata；当前及后续任何声明 `host-test` feature 的包都会获得同样的检查。

## 验证

- `cargo xtask clippy` 覆盖全部 20 个现有 `host-test` 包：186/186 checks 通过
- `cargo test -p axbuild`：886 tests 通过
- `cargo test -p axvm --features host-test`：276 unit tests + 1 integration test 通过
- `cargo xtask test`：46/46 packages 通过
- `cargo fmt --all -- --check`
- `git diff --check origin/dev...HEAD`