### PR TITLE
fix(starry-kernel): validate mqueue send length before copy

### DIFF
--- a/os/StarryOS/kernel/src/ipc/mqueue.rs
+++ b/os/StarryOS/kernel/src/ipc/mqueue.rs
@@ -496,6 +496,17 @@ impl MessageQueue {
         }
     }
 
+    /// Reject a send larger than this queue's fixed `mq_msgsize` before its
+    /// caller copies the user payload. Linux performs this check before
+    /// `load_msg()` in `do_mq_timedsend` so an oversize send is `EMSGSIZE`, even
+    /// when its user pointer is otherwise invalid.
+    pub fn check_send_len(&self, msg_len: usize) -> StarryResult<()> {
+        if msg_len > self.inner.lock().msg_size {
+            return Err(Errno::EMSGSIZE.into());
+        }
+        Ok(())
+    }
+
     /// Send a message. Blocks while full unless `O_NONBLOCK`, honoring the
     /// optional absolute `CLOCK_REALTIME` deadline.
     ///
@@ -511,12 +522,7 @@ impl MessageQueue {
         if priority >= MQ_PRIO_MAX {
             return Err(Errno::EINVAL.into());
         }
-        {
-            let inner = self.inner.lock();
-            if data.len() > inner.msg_size {
-                return Err(Errno::EMSGSIZE.into());
-            }
-        }
+        self.check_send_len(data.len())?;
 
         let op = || {
             let mut inner = self.inner.lock();

--- a/os/StarryOS/kernel/src/syscall/ipc/mqueue.rs
+++ b/os/StarryOS/kernel/src/syscall/ipc/mqueue.rs
@@ -264,6 +264,10 @@ pub fn sys_mq_timedsend(
     }
     let queue = desc.queue();
     let deadline = load_deadline(abs_timeout)?;
+    // Check the queue's fixed limit before copying user-controlled `msg_len`
+    // bytes. Linux's `do_mq_timedsend` likewise returns EMSGSIZE before
+    // `load_msg`, so an oversize message must win over a bad message pointer.
+    queue.check_send_len(msg_len)?;
     let data = vm_load(msg_ptr, msg_len)?;
     queue.send(&data, msg_prio, deadline, desc.is_nonblocking())?;
     Ok(0)

--- a/test-suit/starryos/qemu/system/mqueue-send-validation/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/mqueue-send-validation/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-mqueue-send-validation C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-mqueue-send-validation src/main.c)
+target_compile_options(test-mqueue-send-validation PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-mqueue-send-validation RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/mqueue-send-validation/src/main.c
+++ b/test-suit/starryos/qemu/system/mqueue-send-validation/src/main.c
@@ -1,0 +1,58 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <mqueue.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define QUEUE_NAME "/mqueue_send_validation"
+
+int main(void)
+{
+    const char message[] = "12345678";
+    struct mq_attr attr = {
+        .mq_maxmsg = 1,
+        .mq_msgsize = sizeof(message) - 1,
+    };
+    mqd_t queue = (mqd_t)-1;
+    int result = 1;
+
+    queue = mq_open(QUEUE_NAME, O_CREAT | O_EXCL | O_RDWR, 0600, &attr);
+    if (queue == (mqd_t)-1) {
+        perror("mq_open");
+        goto cleanup;
+    }
+
+    /*
+     * Linux validates msg_len against mq_msgsize before dereferencing the
+     * message pointer. This invalid pointer must therefore yield EMSGSIZE,
+     * rather than EFAULT from a premature user-memory copy.
+     */
+    errno = 0;
+    if (mq_send(queue, (const char *)(uintptr_t)1, sizeof(message), 0) != -1
+        || errno != EMSGSIZE) {
+        fprintf(stderr, "oversize mq_send returned errno=%d, expected EMSGSIZE\n", errno);
+        goto cleanup;
+    }
+
+    if (mq_send(queue, message, sizeof(message) - 1, 0) != 0) {
+        perror("mq_send at mq_msgsize");
+        goto cleanup;
+    }
+
+    char received[sizeof(message)] = { 0 };
+    if (mq_receive(queue, received, sizeof(received) - 1, NULL) != sizeof(message) - 1
+        || memcmp(received, message, sizeof(message) - 1) != 0) {
+        perror("mq_receive");
+        goto cleanup;
+    }
+
+    result = 0;
+
+cleanup:
+    if (queue != (mqd_t)-1) {
+        mq_close(queue);
+    }
+    mq_unlink(QUEUE_NAME);
+    return result;
+}


### PR DESCRIPTION
Fixes #1751.

Linux validates `msg_len` against a queue's fixed `mq_msgsize` before copying the user payload. StarryOS instead reached `vm_load` first, so an oversized send could allocate/copy attacker-controlled bytes and report `EFAULT` from an invalid pointer instead of `EMSGSIZE`.

This moves the immutable queue-size check ahead of `vm_load` while retaining it inside `MessageQueue::send` as a defense for non-syscall callers.

The new QEMU system regression sends an oversize payload from an invalid pointer and asserts `EMSGSIZE`; it also confirms a payload exactly at `mq_msgsize` still round-trips.

Validation completed so far:
- `git diff --check`
- C syntax check with the test's mqueue ABI declarations (`clang -std=c11 -Wall -Wextra -Werror -fsyntax-only`)
- The same C regression compiled and passed in an isolated Linux container

Starry riscv64 QEMU, formatting, and clippy are running in CI.