### PR TITLE
fix(starry-kernel): bound getrandom temporary storage

### DIFF
--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -1,6 +1,7 @@
 use alloc::{sync::Arc, vec, vec::Vec};
 use core::{ffi::c_char, mem::MaybeUninit};
 
+use ax_hal::mem::PAGE_SIZE_4K;
 use ax_task::current;
 use linux_raw_sys::{
     general::{GRND_INSECURE, GRND_NONBLOCK, GRND_RANDOM},
@@ -40,6 +41,13 @@ const SYSLOG_ACTION_SIZE_UNREAD: i32 = 9;
 const SYSLOG_ACTION_SIZE_BUFFER: i32 = 10;
 const SYSLOG_BUFFER_CAPACITY: usize = 4096;
 const SYSLOG_SEED_MESSAGE: &[u8] = b"StarryOS kernel log buffer initialized\n";
+/// Linux caps `getrandom` through `import_ubuf()` at `MAX_RW_COUNT`.
+/// `MAX_RW_COUNT` is `INT_MAX` rounded down to the page size on the 64-bit
+/// targets supported by StarryOS.
+const GETRANDOM_MAX_LEN: usize = (i32::MAX as usize) & !(PAGE_SIZE_4K - 1);
+/// Keep the syscall's temporary random-data buffer bounded by a small stack
+/// allocation, irrespective of the user-requested length.
+const GETRANDOM_CHUNK_SIZE: usize = 256;
 const SECCOMP_SET_MODE_STRICT: u32 = 0;
 const SECCOMP_SET_MODE_FILTER: u32 = 1;
 const SECCOMP_GET_ACTION_AVAIL: u32 = 2;
@@ -876,13 +884,34 @@ pub fn sys_getrandom(buf: *mut u8, len: usize, flags: u32) -> StarryResult<isize
         "/dev/urandom"
     };
 
+    // Linux `import_ubuf()` limits the iterator before feeding it to the
+    // random source. Bound the request equivalently, and reject an address
+    // range that wraps before touching the random device.
+    let len = len.min(GETRANDOM_MAX_LEN);
+    (buf as usize).checked_add(len).ok_or(Errno::EFAULT)?;
+
     let f = ax_fs_ng::vfs::current_fs_context().lock().resolve(path)?;
-    let mut kbuf = vec![0; len];
-    let len = f.entry().as_file()?.read_at(&mut kbuf, 0)?;
+    let file = f.entry().as_file()?;
+    let mut kbuf = [0u8; GETRANDOM_CHUNK_SIZE];
+    let mut written = 0;
+    while written < len {
+        let chunk_len = (len - written).min(kbuf.len());
+        let read = file.read_at(&mut kbuf[..chunk_len], 0)?;
+        if read == 0 {
+            break;
+        }
+        let dst = (buf as usize).checked_add(written).ok_or(Errno::EFAULT)? as *mut u8;
+        vm_write_slice(dst, &kbuf[..read])?;
+        written += read;
+        // Preserve a short device read as the syscall result. Retrying after
+        // having copied a partial result could turn Linux's partial success
+        // into a later EAGAIN for a nonblocking random source.
+        if read < chunk_len {
+            break;
+        }
+    }
 
-    vm_write_slice(buf, &kbuf)?;
-
-    Ok(len as _)
+    Ok(written as _)
 }
 
 fn check_seccomp_install_permission() -> StarryResult<()> {

--- a/test-suit/starryos/qemu/system/syscall-test-getrandom/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-getrandom/src/main.c
@@ -27,6 +27,7 @@
 #endif
 
 #define UNKNOWN_GETRANDOM_FLAG 0x80000000U
+#define MULTI_CHUNK_GETRANDOM_LEN 1025
 
 /* 通过 syscall() 直接调用 getrandom，避免 glibc 封装差异 */
 static ssize_t my_getrandom(void *buf, size_t len, unsigned int flags) {
@@ -121,14 +122,14 @@ int main(void) {
                   "mutually-exclusive flags take precedence over NULL address");
     }
 
-    /* 8. 较大但仍合理的请求长度，避免只实现了小 buffer 的假阳性 */
+    /* 8. 跨多个内核临时缓冲区的请求必须完整返回，不可只处理首块。 */
     {
-        unsigned char buf[4096];
+        unsigned char buf[MULTI_CHUNK_GETRANDOM_LEN];
         memset(buf, 0, sizeof(buf));
         CHECK_RET(my_getrandom(buf, sizeof(buf), 0), (ssize_t)sizeof(buf),
-                  "large 4096-byte request returns full length");
+                  "multi-chunk request returns full length");
         CHECK(!all_bytes_equal(buf, sizeof(buf), 0),
-              "large request fills buffer");
+              "multi-chunk request fills buffer");
     }
 
     TEST_DONE();

--- a/test-suit/starryos/qemu/system/syscall-test-getrandom/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-getrandom/src/main.c
@@ -11,6 +11,7 @@
  *      必须返回 EINVAL，且不能改写用户缓冲区。
  *   5. 非零长度的 NULL/坏地址必须返回 EFAULT。
  *   6. 错误优先级：无效 flags 应先于用户地址写入检查返回 EINVAL。
+ *   7. 极大长度与溢出地址必须在分配内核临时缓冲区前返回 EFAULT。
  */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -18,6 +19,7 @@
 
 #include "test_framework.h"
 #include <errno.h>
+#include <stdint.h>
 #include <sys/random.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -130,6 +132,12 @@ int main(void) {
                   "multi-chunk request returns full length");
         CHECK(!all_bytes_equal(buf, sizeof(buf), 0),
               "multi-chunk request fills buffer");
+    }
+
+    /* 9. 范围溢出必须先于任何按请求长度的内核分配。旧实现会在 vec![0; SIZE_MAX] 失败。 */
+    {
+        CHECK_ERR(my_getrandom((void *)(uintptr_t)UINTPTR_MAX, SIZE_MAX, 0), EFAULT,
+                  "oversized request with wrapping address returns EFAULT before allocation");
     }
 
     TEST_DONE();


### PR DESCRIPTION
Fixes #1743.

StarryOS allocated `Vec(len)` before reading random bytes, allowing an unprivileged caller to request an arbitrarily large kernel allocation. Linux v6.16 instead imports a bounded user iterator (`MAX_RW_COUNT`) and generates directly into it.

This changes StarryOS to cap the request at Linux's `MAX_RW_COUNT` equivalent and stream random data through a fixed 256-byte stack buffer. It checks address-range overflow before touching the random device and preserves a short device read as a partial syscall success rather than retrying into `EAGAIN`.

The existing getrandom system test now requests 1025 bytes, exercising multiple internal chunks while confirming the full result and nonzero output.

Validation completed so far:
- `git diff --check`
- Existing getrandom C regression compiled with `-Wall -Wextra -Werror` and passed in an isolated Linux container
- Linux v6.16 source review: `drivers/char/random.c:getrandom` and `lib/iov_iter.c:import_ubuf`

Rust formatting, clippy, and Starry QEMU are running in CI.