### PR TITLE
fix(starry-kernel): validate malformed ELF metadata

### DIFF
--- a/os/StarryOS/kernel/src/error.rs
+++ b/os/StarryOS/kernel/src/error.rs
@@ -106,6 +106,8 @@ pub enum StarryError {
     InvalidData,
     #[error("invalid executable image")]
     InvalidExecutable,
+    #[error("malformed executable image")]
+    MalformedExecutable,
     #[error("invalid kernel input")]
     InvalidInput,
     #[error("kernel I/O failed")]
@@ -217,7 +219,7 @@ impl StarryError {
             Self::InProgress => Errno::EINPROGRESS,
             Self::Interrupted => Errno::EINTR,
             Self::InvalidData | Self::InvalidInput => Errno::EINVAL,
-            Self::InvalidExecutable => Errno::ENOEXEC,
+            Self::InvalidExecutable | Self::MalformedExecutable => Errno::ENOEXEC,
             Self::Io | Self::UnexpectedEof | Self::WriteZero => Errno::EIO,
             Self::IsADirectory => Errno::EISDIR,
             Self::NameTooLong => Errno::ENAMETOOLONG,
@@ -694,6 +696,7 @@ fn leaf_errno_mappings_hold() -> bool {
         (StarryError::Interrupted, Errno::EINTR),
         (StarryError::InvalidData, Errno::EINVAL),
         (StarryError::InvalidExecutable, Errno::ENOEXEC),
+        (StarryError::MalformedExecutable, Errno::ENOEXEC),
         (StarryError::InvalidInput, Errno::EINVAL),
         (StarryError::Io, Errno::EIO),
         (StarryError::IsADirectory, Errno::EISDIR),

--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -29,6 +29,9 @@ const R_RISCV_64: u32 = 2;
 #[cfg(target_arch = "riscv64")]
 const R_RISCV_COPY: u32 = 4;
 
+// Linux rejects PT_INTERP paths outside PATH_MAX before allocation.
+const MAX_INTERPRETER_PATH_LEN: u64 = 4096;
+
 /// Creates a new empty user address space.
 pub fn new_user_aspace_empty() -> StarryResult<AddrSpace> {
     AddrSpace::new_empty(VirtAddr::from_usize(USER_SPACE_BASE), USER_SPACE_SIZE)
@@ -576,14 +579,27 @@ impl ElfLoader {
             .find(|ph| ph.get_type() == Ok(xmas_elf::program::Type::Interp))
         {
             let cache = entry.borrow_cache();
-            let mut data = vec![0; header.file_size as usize];
+            let interp_len = header.file_size;
+            let interp_end = header
+                .offset
+                .checked_add(interp_len)
+                .ok_or(StarryError::MalformedExecutable)?;
+            if !(2..=MAX_INTERPRETER_PATH_LEN).contains(&interp_len)
+                || interp_end > cache.len()
+            {
+                return Err(StarryError::MalformedExecutable);
+            }
+
+            let mut data = vec![0; interp_len as usize];
             let read = cache.read_at(&mut data[..], header.offset)?;
-            assert_eq!(data.len(), read);
+            if read != data.len() {
+                return Err(StarryError::MalformedExecutable);
+            }
 
             let ldso = CStr::from_bytes_with_nul(&data)
                 .ok()
                 .and_then(|cstr| cstr.to_str().ok())
-                .ok_or(StarryError::InvalidInput)?;
+                .ok_or(StarryError::MalformedExecutable)?;
             debug!("Loading dynamic linker: {ldso}");
             Some(ldso.to_owned())
         } else {

--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -202,7 +202,14 @@ fn map_elf<'a>(
             ph.flags
         );
         let seg_pad = vaddr.align_offset_4k();
-        assert_eq!(seg_pad, ph.offset as usize % PAGE_SIZE_4K);
+        // ELF requires each loadable segment's virtual address and file
+        // offset to have the same page offset. This is untrusted executable
+        // metadata, so reject a mismatch instead of panicking in the kernel.
+        // Use a distinct error from InvalidExecutable: execve uses that error
+        // to opt into its legacy shell fallback for a non-ELF file.
+        if seg_pad != ph.offset as usize % PAGE_SIZE_4K {
+            return Err(StarryError::MalformedExecutable);
+        }
 
         let seg_align_size =
             (ph.mem_size as usize + seg_pad + PAGE_SIZE_4K - 1) & !(PAGE_SIZE_4K - 1);

--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -584,9 +584,7 @@ impl ElfLoader {
                 .offset
                 .checked_add(interp_len)
                 .ok_or(StarryError::MalformedExecutable)?;
-            if !(2..=MAX_INTERPRETER_PATH_LEN).contains(&interp_len)
-                || interp_end > cache.len()
-            {
+            if !(2..=MAX_INTERPRETER_PATH_LEN).contains(&interp_len) || interp_end > cache.len() {
                 return Err(StarryError::MalformedExecutable);
             }
 

--- a/test-suit/starryos/qemu/system/test-elf-load-alignment/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/test-elf-load-alignment/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(test-elf-load-alignment C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(test-elf-load-alignment src/main.c)
+target_compile_options(test-elf-load-alignment PRIVATE -Wall -Wextra -Werror)
+install(TARGETS test-elf-load-alignment RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/test-elf-load-alignment/src/main.c
+++ b/test-suit/starryos/qemu/system/test-elf-load-alignment/src/main.c
@@ -1,0 +1,204 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <elf.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#define CORRUPTED_ELF_PATH "/tmp/elf-load-misaligned"
+
+static int write_all(int fd, const unsigned char *buffer, size_t count)
+{
+    while (count > 0) {
+        ssize_t written = write(fd, buffer, count);
+        if (written <= 0) {
+            return -1;
+        }
+        buffer += (size_t)written;
+        count -= (size_t)written;
+    }
+    return 0;
+}
+
+static int copy_file(const char *source, const char *destination)
+{
+    unsigned char buffer[4096];
+    int input = open(source, O_RDONLY);
+    int output = -1;
+    int result = -1;
+
+    if (input < 0) {
+        perror("open /proc/self/exe");
+        goto out;
+    }
+    output = open(destination, O_WRONLY | O_CREAT | O_TRUNC, 0755);
+    if (output < 0) {
+        perror("open destination");
+        goto out;
+    }
+
+    for (;;) {
+        ssize_t bytes = read(input, buffer, sizeof(buffer));
+        if (bytes == 0) {
+            result = 0;
+            break;
+        }
+        if (bytes < 0 || write_all(output, buffer, (size_t)bytes) != 0) {
+            perror("copy executable");
+            break;
+        }
+    }
+
+out:
+    if (output >= 0 && close(output) < 0) {
+        perror("close destination");
+        result = -1;
+    }
+    if (input >= 0) {
+        close(input);
+    }
+    return result;
+}
+
+static int read_exact_at(int fd, void *buffer, size_t count, off_t offset)
+{
+    unsigned char *cursor = buffer;
+
+    while (count > 0) {
+        ssize_t bytes = pread(fd, cursor, count, offset);
+        if (bytes <= 0) {
+            return -1;
+        }
+        cursor += (size_t)bytes;
+        count -= (size_t)bytes;
+        offset += bytes;
+    }
+    return 0;
+}
+
+static int corrupt_load_alignment(const char *path)
+{
+    Elf64_Ehdr header;
+    struct stat stat_buffer;
+    int fd = open(path, O_RDWR);
+    int result = -1;
+
+    if (fd < 0) {
+        perror("open ELF for modification");
+        return -1;
+    }
+    if (fstat(fd, &stat_buffer) != 0 ||
+        read_exact_at(fd, &header, sizeof(header), 0) != 0 ||
+        memcmp(header.e_ident, ELFMAG, SELFMAG) != 0 ||
+        header.e_ident[EI_CLASS] != ELFCLASS64 ||
+        header.e_phentsize != sizeof(Elf64_Phdr) ||
+        header.e_phnum == 0 ||
+        header.e_phoff > (uint64_t)stat_buffer.st_size ||
+        (uint64_t)stat_buffer.st_size - header.e_phoff <
+            (uint64_t)header.e_phnum * sizeof(Elf64_Phdr)) {
+        fputs("unexpected ELF layout\n", stderr);
+        goto out;
+    }
+
+    for (size_t index = 0; index < header.e_phnum; index++) {
+        const off_t offset = (off_t)(header.e_phoff + index * sizeof(Elf64_Phdr));
+        Elf64_Phdr program_header;
+        if (read_exact_at(fd, &program_header, sizeof(program_header), offset) != 0) {
+            perror("read program header");
+            goto out;
+        }
+        if (program_header.p_type != PT_LOAD || program_header.p_vaddr == UINT64_MAX) {
+            continue;
+        }
+
+        // Preserve a structurally valid header while making p_vaddr and
+        // p_offset disagree within their page. The loader must reject the
+        // malformed image before attempting to map it.
+        program_header.p_vaddr++;
+        if (pwrite(fd, &program_header, sizeof(program_header), offset) !=
+            (ssize_t)sizeof(program_header)) {
+            perror("write program header");
+            goto out;
+        }
+        result = 0;
+        break;
+    }
+
+    if (result != 0) {
+        fputs("ELF has no mutable PT_LOAD header\n", stderr);
+    }
+
+out:
+    close(fd);
+    return result;
+}
+
+static int expect_enoexec(const char *path)
+{
+    pid_t child = fork();
+    if (child < 0) {
+        perror("fork");
+        return -1;
+    }
+    if (child == 0) {
+        char *const argv[] = {(char *)path, NULL};
+        char *const envp[] = {"LOADER_ALIGNMENT_TARGET=1", NULL};
+        execve(path, argv, envp);
+        if (errno != ENOEXEC) {
+            fprintf(stderr, "execve returned errno=%d, expected ENOEXEC\n", errno);
+            _exit(1);
+        }
+        _exit(0);
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) < 0) {
+        perror("waitpid");
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "malformed ELF child status=0x%x\n", status);
+        return -1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    char executable[PATH_MAX];
+
+    // If the corrupted copy unexpectedly reaches user space, make the parent
+    // fail rather than recursively creating another malformed copy.
+    if (getenv("LOADER_ALIGNMENT_TARGET") != NULL) {
+        return 99;
+    }
+
+    ssize_t length = readlink("/proc/self/exe", executable, sizeof(executable) - 1);
+    if (length < 0 || (size_t)length >= sizeof(executable) - 1) {
+        perror("readlink /proc/self/exe");
+        return 1;
+    }
+    executable[length] = '\0';
+
+    unlink(CORRUPTED_ELF_PATH);
+    if (copy_file(executable, CORRUPTED_ELF_PATH) != 0 ||
+        corrupt_load_alignment(CORRUPTED_ELF_PATH) != 0 ||
+        expect_enoexec(CORRUPTED_ELF_PATH) != 0) {
+        unlink(CORRUPTED_ELF_PATH);
+        return 1;
+    }
+    unlink(CORRUPTED_ELF_PATH);
+
+    puts("ELF_LOAD_ALIGNMENT_OK");
+    return 0;
+}

--- a/test-suit/starryos/qemu/system/test-elf-load-alignment/src/main.c
+++ b/test-suit/starryos/qemu/system/test-elf-load-alignment/src/main.c
@@ -15,7 +15,10 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
-#define CORRUPTED_ELF_PATH "/tmp/elf-load-misaligned"
+#define MISALIGNED_ELF_PATH "/tmp/elf-load-misaligned"
+#define OVERSIZED_INTERP_ELF_PATH "/tmp/elf-interp-oversized"
+#define TRUNCATED_INTERP_ELF_PATH "/tmp/elf-interp-truncated"
+#define MAX_INTERPRETER_PATH_LEN 4096
 
 static int write_all(int fd, const unsigned char *buffer, size_t count)
 {
@@ -143,6 +146,69 @@ out:
     return result;
 }
 
+static int corrupt_interpreter(const char *path, int oversized)
+{
+    Elf64_Ehdr header;
+    struct stat stat_buffer;
+    int fd = open(path, O_RDWR);
+    int result = -1;
+
+    if (fd < 0) {
+        perror("open ELF for modification");
+        return -1;
+    }
+    if (fstat(fd, &stat_buffer) != 0 ||
+        read_exact_at(fd, &header, sizeof(header), 0) != 0 ||
+        memcmp(header.e_ident, ELFMAG, SELFMAG) != 0 ||
+        header.e_ident[EI_CLASS] != ELFCLASS64 ||
+        header.e_phentsize != sizeof(Elf64_Phdr) ||
+        header.e_phnum == 0 || stat_buffer.st_size < 2 ||
+        header.e_phoff > (uint64_t)stat_buffer.st_size ||
+        (uint64_t)stat_buffer.st_size - header.e_phoff <
+            (uint64_t)header.e_phnum * sizeof(Elf64_Phdr)) {
+        fputs("unexpected ELF layout\n", stderr);
+        goto out;
+    }
+
+    for (size_t index = 0; index < header.e_phnum; index++) {
+        const off_t offset = (off_t)(header.e_phoff + index * sizeof(Elf64_Phdr));
+        Elf64_Phdr program_header;
+        if (read_exact_at(fd, &program_header, sizeof(program_header), offset) != 0) {
+            perror("read program header");
+            goto out;
+        }
+        if (program_header.p_type != PT_LOAD) {
+            continue;
+        }
+
+        // Reuse a loadable header so the test works for either static or
+        // dynamic test-suite binaries. The loader reaches PT_INTERP before
+        // mapping this segment.
+        program_header.p_type = PT_INTERP;
+        if (oversized) {
+            program_header.p_filesz = MAX_INTERPRETER_PATH_LEN + 1;
+        } else {
+            program_header.p_offset = (Elf64_Off)stat_buffer.st_size - 1;
+            program_header.p_filesz = 2;
+        }
+        if (pwrite(fd, &program_header, sizeof(program_header), offset) !=
+            (ssize_t)sizeof(program_header)) {
+            perror("write program header");
+            goto out;
+        }
+        result = 0;
+        break;
+    }
+
+    if (result != 0) {
+        fputs("ELF has no mutable PT_LOAD header\n", stderr);
+    }
+
+out:
+    close(fd);
+    return result;
+}
+
 static int expect_enoexec(const char *path)
 {
     pid_t child = fork();
@@ -190,15 +256,27 @@ int main(void)
     }
     executable[length] = '\0';
 
-    unlink(CORRUPTED_ELF_PATH);
-    if (copy_file(executable, CORRUPTED_ELF_PATH) != 0 ||
-        corrupt_load_alignment(CORRUPTED_ELF_PATH) != 0 ||
-        expect_enoexec(CORRUPTED_ELF_PATH) != 0) {
-        unlink(CORRUPTED_ELF_PATH);
+    unlink(MISALIGNED_ELF_PATH);
+    unlink(OVERSIZED_INTERP_ELF_PATH);
+    unlink(TRUNCATED_INTERP_ELF_PATH);
+    if (copy_file(executable, MISALIGNED_ELF_PATH) != 0 ||
+        corrupt_load_alignment(MISALIGNED_ELF_PATH) != 0 ||
+        expect_enoexec(MISALIGNED_ELF_PATH) != 0 ||
+        copy_file(executable, OVERSIZED_INTERP_ELF_PATH) != 0 ||
+        corrupt_interpreter(OVERSIZED_INTERP_ELF_PATH, 1) != 0 ||
+        expect_enoexec(OVERSIZED_INTERP_ELF_PATH) != 0 ||
+        copy_file(executable, TRUNCATED_INTERP_ELF_PATH) != 0 ||
+        corrupt_interpreter(TRUNCATED_INTERP_ELF_PATH, 0) != 0 ||
+        expect_enoexec(TRUNCATED_INTERP_ELF_PATH) != 0) {
+        unlink(MISALIGNED_ELF_PATH);
+        unlink(OVERSIZED_INTERP_ELF_PATH);
+        unlink(TRUNCATED_INTERP_ELF_PATH);
         return 1;
     }
-    unlink(CORRUPTED_ELF_PATH);
+    unlink(MISALIGNED_ELF_PATH);
+    unlink(OVERSIZED_INTERP_ELF_PATH);
+    unlink(TRUNCATED_INTERP_ELF_PATH);
 
-    puts("ELF_LOAD_ALIGNMENT_OK");
+    puts("ELF_LOADER_VALIDATION_OK");
     return 0;
 }

--- a/test-suit/starryos/qemu/system/test-elf-load-alignment/src/main.c
+++ b/test-suit/starryos/qemu/system/test-elf-load-alignment/src/main.c
@@ -150,6 +150,7 @@ static int corrupt_interpreter(const char *path, int oversized)
 {
     Elf64_Ehdr header;
     struct stat stat_buffer;
+    const uint32_t target_types[] = {PT_INTERP, PT_LOAD};
     int fd = open(path, O_RDWR);
     int result = -1;
 
@@ -170,34 +171,40 @@ static int corrupt_interpreter(const char *path, int oversized)
         goto out;
     }
 
-    for (size_t index = 0; index < header.e_phnum; index++) {
-        const off_t offset = (off_t)(header.e_phoff + index * sizeof(Elf64_Phdr));
-        Elf64_Phdr program_header;
-        if (read_exact_at(fd, &program_header, sizeof(program_header), offset) != 0) {
-            perror("read program header");
-            goto out;
-        }
-        if (program_header.p_type != PT_LOAD) {
-            continue;
-        }
+    for (size_t target = 0;
+         target < sizeof(target_types) / sizeof(target_types[0]) && result != 0;
+         target++) {
+        for (size_t index = 0; index < header.e_phnum; index++) {
+            const off_t offset = (off_t)(header.e_phoff + index * sizeof(Elf64_Phdr));
+            Elf64_Phdr program_header;
+            if (read_exact_at(fd, &program_header, sizeof(program_header), offset) != 0) {
+                perror("read program header");
+                goto out;
+            }
+            if (program_header.p_type != target_types[target]) {
+                continue;
+            }
 
-        // Reuse a loadable header so the test works for either static or
-        // dynamic test-suite binaries. The loader reaches PT_INTERP before
-        // mapping this segment.
-        program_header.p_type = PT_INTERP;
-        if (oversized) {
-            program_header.p_filesz = MAX_INTERPRETER_PATH_LEN + 1;
-        } else {
-            program_header.p_offset = (Elf64_Off)stat_buffer.st_size - 1;
-            program_header.p_filesz = 2;
+            // Exercise the interpreter the loader actually consumes. Static
+            // test binaries have no PT_INTERP, so repurpose a PT_LOAD only as
+            // a fallback for that case.
+            if (target_types[target] == PT_LOAD) {
+                program_header.p_type = PT_INTERP;
+            }
+            if (oversized) {
+                program_header.p_filesz = MAX_INTERPRETER_PATH_LEN + 1;
+            } else {
+                program_header.p_offset = (Elf64_Off)stat_buffer.st_size - 1;
+                program_header.p_filesz = 2;
+            }
+            if (pwrite(fd, &program_header, sizeof(program_header), offset) !=
+                (ssize_t)sizeof(program_header)) {
+                perror("write program header");
+                goto out;
+            }
+            result = 0;
+            break;
         }
-        if (pwrite(fd, &program_header, sizeof(program_header), offset) !=
-            (ssize_t)sizeof(program_header)) {
-            perror("write program header");
-            goto out;
-        }
-        result = 0;
-        break;
     }
 
     if (result != 0) {


### PR DESCRIPTION
## Summary

Fixes #1737 and #1736.

ELF program headers are executable-controlled metadata. Two loader paths previously trusted them enough to panic the kernel or allocate without an executable-format bound.

- Validate the required page-offset congruence of every `PT_LOAD` segment before mapping it, replacing a kernel assertion.
- Validate `PT_INTERP` before allocation: it must be 2..=4096 bytes (Linux `PATH_MAX`), its `offset + size` must not overflow or exceed the executable length, the read must be complete, and the value must be a NUL-terminated UTF-8 path.
- Keep a recognized-but-malformed ELF distinct from the existing non-ELF shell fallback. Both map to `ENOEXEC`; malformed ELF is returned to the caller rather than handed to `/bin/sh`.

The ELF gABI requires loadable segments to have congruent `p_vaddr` and `p_offset` values modulo the page size. Linux v6.16 likewise bounds `PT_INTERP.p_filesz` by `PATH_MAX` before allocation.

## Regression coverage

The new Starry QEMU system case copies its own ELF and verifies `execve` returns `ENOEXEC` for each malformed variant:

1. a `PT_LOAD` with mismatched `p_vaddr`/`p_offset` page offsets;
2. a loadable header converted to `PT_INTERP` with `p_filesz = 4097`; and
3. a converted `PT_INTERP` whose two-byte range runs past EOF.

Reusing a `PT_LOAD` header means the test is valid for either static or dynamic test-suite binaries. The previous implementation either asserts or returns the wrong error/fallback behavior.

## Validation

- `git diff --check`
- C fixture is built with `-Wall -Wextra -Werror` by the Starry QEMU system-test build
- Upstream CI pending for `d3811e6`