### PR TITLE
fix(starry-kernel): bound shebang interpreter recursion

### DIFF
--- a/os/StarryOS/kernel/src/mm/loader.rs
+++ b/os/StarryOS/kernel/src/mm/loader.rs
@@ -706,6 +706,11 @@ impl ElfLoader {
 
 static ELF_LOADER: Mutex<ElfLoader> = Mutex::new(ElfLoader::new());
 
+// Linux's exec path bounds chained binary-format rewrites and returns ELOOP
+// for a too-deep interpreter chain. Give StarryOS's recursive script loader
+// the same bounded failure behavior.
+const MAX_INTERPRETER_RECURSION: usize = 5;
+
 /// Clear the ELF cache.
 ///
 /// Useful for removing noises during memory leak detect.
@@ -743,23 +748,47 @@ pub fn load_user_app(
 ) -> StarryResult<(VirtAddr, VirtAddr, Vec<AuxEntry>)> {
     validate_exec_arg_size(args, envs)?;
 
+    load_user_app_with_depth(uspace, loc, path, args, envs, 0)
+}
+
+fn load_user_app_with_depth(
+    uspace: &mut AddrSpace,
+    loc: Location,
+    path: &str,
+    args: &[String],
+    envs: &[String],
+    interpreter_depth: usize,
+) -> StarryResult<(VirtAddr, VirtAddr, Vec<AuxEntry>)> {
     // `/proc/self/exe` is available in procfs; busybox can `readlink` it
     // to re-exec itself as a shell on ENOEXEC, provided the busybox build
     // includes that fallback (Alpine's prebuilt binary may not).
     if path.ends_with(".sh") {
+        if interpreter_depth >= MAX_INTERPRETER_RECURSION {
+            return Err(StarryError::FilesystemLoop);
+        }
         let new_args: Vec<String> = iter::once("/bin/sh".to_owned())
             .chain(args.iter().cloned())
             .collect();
         let sh = ax_fs_ng::vfs::current_fs_context()
             .lock()
             .resolve("/bin/sh")?;
-        return load_user_app(uspace, sh, "/bin/sh", &new_args, envs);
+        return load_user_app_with_depth(
+            uspace,
+            sh,
+            "/bin/sh",
+            &new_args,
+            envs,
+            interpreter_depth + 1,
+        );
     }
 
     let (entry, auxv) = match { ELF_LOADER.lock().load(uspace, loc)? } {
         Ok((entry, auxv)) => (entry, auxv),
         Err(data) => {
             if data.starts_with(b"#!") {
+                if interpreter_depth >= MAX_INTERPRETER_RECURSION {
+                    return Err(StarryError::FilesystemLoop);
+                }
                 let head = &data[2..data.len().min(256)];
                 let pos = head.iter().position(|c| *c == b'\n').unwrap_or(head.len());
                 let line =
@@ -777,7 +806,14 @@ pub fn load_user_app(
                 let interp = ax_fs_ng::vfs::current_fs_context()
                     .lock()
                     .resolve(&new_args[0])?;
-                return load_user_app(uspace, interp, &new_args[0], &new_args, envs);
+                return load_user_app_with_depth(
+                    uspace,
+                    interp,
+                    &new_args[0],
+                    &new_args,
+                    envs,
+                    interpreter_depth + 1,
+                );
             }
             return Err(StarryError::InvalidExecutable);
         }

--- a/test-suit/starryos/qemu/system/test-elf-loader-shebang/src/main.c
+++ b/test-suit/starryos/qemu/system/test-elf-loader-shebang/src/main.c
@@ -17,6 +17,7 @@
 // which prints a `FAIL:` line (caught by fail_regex) instead of the marker.
 
 #define _GNU_SOURCE
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
@@ -76,11 +77,57 @@ static int run_exec(const char *path) {
     return 0;
 }
 
+// fork() + execve(path) directly; returns 0 iff execve rejects the script
+// with the expected errno instead of entering an unbounded interpreter loop.
+static int run_expect_errno(const char *path, int expected_errno) {
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return -1;
+    }
+    if (pid == 0) {
+        char *argv[] = {(char *)path, NULL};
+        char *envp[] = {NULL};
+        execve(path, argv, envp);
+        if (errno != expected_errno) {
+            fprintf(stderr, "execve(%s) returned errno=%d, expected %d\n", path, errno,
+                    expected_errno);
+            _exit(1);
+        }
+        _exit(0);
+    }
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) {
+        perror("waitpid");
+        return -1;
+    }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "child for %s did not report expected errno (status=0x%x)\n", path,
+                status);
+        return -1;
+    }
+    return 0;
+}
+
 int main(void) {
     // No .sh suffix -> exercises the kernel `#!` shebang branch.
     const char *shebang = "/tmp/loader-shebang";
     // .sh suffix -> exercises the kernel `.sh` redirect branch.
     const char *dotsh = "/tmp/loader-dotsh.sh";
+    const char *chain0 = "/tmp/loader-shebang-chain-0";
+    const char *chain1 = "/tmp/loader-shebang-chain-1";
+    const char *chain2 = "/tmp/loader-shebang-chain-2";
+    const char *chain3 = "/tmp/loader-shebang-chain-3";
+    const char *chain4 = "/tmp/loader-shebang-chain-4";
+    const char *too_deep0 = "/tmp/loader-shebang-too-deep-0";
+    const char *too_deep1 = "/tmp/loader-shebang-too-deep-1";
+    const char *too_deep2 = "/tmp/loader-shebang-too-deep-2";
+    const char *too_deep3 = "/tmp/loader-shebang-too-deep-3";
+    const char *too_deep4 = "/tmp/loader-shebang-too-deep-4";
+    const char *too_deep5 = "/tmp/loader-shebang-too-deep-5";
+    const char *self_loop = "/tmp/loader-shebang-self-loop";
+    const char *loop_a = "/tmp/loader-shebang-loop-a";
+    const char *loop_b = "/tmp/loader-shebang-loop-b";
 
     if (write_script(shebang, "#!/bin/sh\necho SHEBANG_RAN\n") != 0) {
         printf("FAIL: write shebang script\n");
@@ -90,6 +137,32 @@ int main(void) {
         printf("FAIL: write .sh script\n");
         return 1;
     }
+    // Five script-to-interpreter rewrites are valid; the last script reaches
+    // /bin/sh at recursion depth five.
+    if (write_script(chain0, "#!/tmp/loader-shebang-chain-1\n") != 0 ||
+        write_script(chain1, "#!/tmp/loader-shebang-chain-2\n") != 0 ||
+        write_script(chain2, "#!/tmp/loader-shebang-chain-3\n") != 0 ||
+        write_script(chain3, "#!/tmp/loader-shebang-chain-4\n") != 0 ||
+        write_script(chain4, "#!/bin/sh\nexit 0\n") != 0) {
+        printf("FAIL: write bounded shebang chain\n");
+        return 1;
+    }
+    // A sixth script rewrite must fail before the final /bin/sh load.
+    if (write_script(too_deep0, "#!/tmp/loader-shebang-too-deep-1\n") != 0 ||
+        write_script(too_deep1, "#!/tmp/loader-shebang-too-deep-2\n") != 0 ||
+        write_script(too_deep2, "#!/tmp/loader-shebang-too-deep-3\n") != 0 ||
+        write_script(too_deep3, "#!/tmp/loader-shebang-too-deep-4\n") != 0 ||
+        write_script(too_deep4, "#!/tmp/loader-shebang-too-deep-5\n") != 0 ||
+        write_script(too_deep5, "#!/bin/sh\nexit 0\n") != 0) {
+        printf("FAIL: write too-deep shebang chain\n");
+        return 1;
+    }
+    if (write_script(self_loop, "#!/tmp/loader-shebang-self-loop\n") != 0 ||
+        write_script(loop_a, "#!/tmp/loader-shebang-loop-b\n") != 0 ||
+        write_script(loop_b, "#!/tmp/loader-shebang-loop-a\n") != 0) {
+        printf("FAIL: write cyclic shebang scripts\n");
+        return 1;
+    }
 
     if (run_exec(shebang) != 0) {
         printf("FAIL: exec shebang script\n");
@@ -97,6 +170,22 @@ int main(void) {
     }
     if (run_exec(dotsh) != 0) {
         printf("FAIL: exec .sh script\n");
+        return 1;
+    }
+    if (run_exec(chain0) != 0) {
+        printf("FAIL: exec bounded shebang chain\n");
+        return 1;
+    }
+    if (run_expect_errno(too_deep0, ELOOP) != 0) {
+        printf("FAIL: too-deep shebang chain did not return ELOOP\n");
+        return 1;
+    }
+    if (run_expect_errno(self_loop, ELOOP) != 0) {
+        printf("FAIL: self-referential shebang did not return ELOOP\n");
+        return 1;
+    }
+    if (run_expect_errno(loop_a, ELOOP) != 0) {
+        printf("FAIL: cyclic shebang did not return ELOOP\n");
         return 1;
     }
 


### PR DESCRIPTION
## Summary

Fixes #1744.

A `#!` interpreter is loaded by recursively calling `load_user_app`, but the recursion previously had no bound. A self-referential script or a cycle of scripts could keep growing the kernel stack and rewritten argument vectors.

- Route script redirects through a depth-aware loader helper.
- Permit five script-to-interpreter rewrites, then return `ELOOP` via `StarryError::FilesystemLoop`. The limit covers both the existing `.sh` redirect and normal shebang processing.
- The bound matches the Linux v6.16 `exec_binprm` model: a five-script chain can reach `/bin/sh`, while a further rewrite fails with `ELOOP`.
- Rebase onto the latest `dev@0340ed6bfa` while retaining the current `dev` loader changes.

## Regression coverage

Extends the existing Starry QEMU shebang loader case to verify:

1. direct `#!` and `.sh` redirects still run;
2. a five-script chain ending in `/bin/sh` still succeeds;
3. a sixth rewrite returns `ELOOP`; and
4. self-referential and two-script cycles return `ELOOP` from `execve`.

The previous implementation enters unbounded recursive kernel loading for these cases.

## Validation

- `git diff --check`
- Rebase completed with the original 127-line net change preserved in `loader.rs` and the shebang regression fixture.
- Per request, no local clippy/QEMU validation was run; the newly triggered upstream CI is authoritative.
- No changelog changes.
