### PR TITLE
fix(ax-net): validate packets before TCP snooping

### DIFF
--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -1481,7 +1481,8 @@ mod tests {
 
         let mut ipv4_tcp = [0u8; 40];
         ipv4_tcp[0] = 0x45;
-        ipv4_tcp[2..4].copy_from_slice(&(ipv4_tcp.len() as u16).to_be_bytes());
+        let ipv4_tcp_len = ipv4_tcp.len() as u16;
+        ipv4_tcp[2..4].copy_from_slice(&ipv4_tcp_len.to_be_bytes());
         ipv4_tcp[9] = IpProtocol::Tcp.into();
         for len in 0..ipv4_tcp.len() {
             snoop_tcp_packet(&ipv4_tcp[..len], &mut sockets);

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -1197,6 +1197,9 @@ impl smoltcp::phy::TxToken for TxToken<'_> {
 
 /// Detects passive TCP opens before smoltcp consumes the incoming packet.
 fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
+    if buf.is_empty() {
+        return;
+    }
     let (src_addr, dst_addr, payload) = match IpVersion::of_packet(buf) {
         Ok(IpVersion::Ipv4) => {
             let Ok(packet) = Ipv4Packet::new_checked(buf) else {

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -1197,9 +1197,11 @@ impl smoltcp::phy::TxToken for TxToken<'_> {
 
 /// Detects passive TCP opens before smoltcp consumes the incoming packet.
 fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
-    let (src_addr, dst_addr, payload) = match IpVersion::of_packet(buf).unwrap() {
-        IpVersion::Ipv4 => {
-            let packet = Ipv4Packet::new_unchecked(buf);
+    let (src_addr, dst_addr, payload) = match IpVersion::of_packet(buf) {
+        Ok(IpVersion::Ipv4) => {
+            let Ok(packet) = Ipv4Packet::new_checked(buf) else {
+                return;
+            };
             if packet.next_header() != IpProtocol::Tcp {
                 return;
             }
@@ -1209,8 +1211,10 @@ fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
                 packet.payload(),
             )
         }
-        IpVersion::Ipv6 => {
-            let packet = Ipv6Packet::new_unchecked(buf);
+        Ok(IpVersion::Ipv6) => {
+            let Ok(packet) = Ipv6Packet::new_checked(buf) else {
+                return;
+            };
             if packet.next_header() != IpProtocol::Tcp {
                 return;
             }
@@ -1220,8 +1224,11 @@ fn snoop_tcp_packet(buf: &[u8], sockets: &mut SocketSet<'_>) {
                 packet.payload(),
             )
         }
+        Err(_) => return,
     };
-    let tcp_packet = TcpPacket::new_unchecked(payload);
+    let Ok(tcp_packet) = TcpPacket::new_checked(payload) else {
+        return;
+    };
     let src_addr = (src_addr, tcp_packet.src_port()).into();
     let dst_addr = (dst_addr, tcp_packet.dst_port()).into();
     let is_first = tcp_packet.syn() && !tcp_packet.ack();
@@ -1466,6 +1473,27 @@ mod tests {
             .select_route_if(&dst, |interface_id| interface_id != IF0)
             .unwrap();
         assert_eq!(route.interface_id, IF1);
+    }
+
+    #[test]
+    fn snoop_tcp_packet_drops_every_truncated_ipv4_and_ipv6_header() {
+        let mut sockets = SocketSet::new(vec![]);
+
+        let mut ipv4_tcp = [0u8; 40];
+        ipv4_tcp[0] = 0x45;
+        ipv4_tcp[2..4].copy_from_slice(&(ipv4_tcp.len() as u16).to_be_bytes());
+        ipv4_tcp[9] = IpProtocol::Tcp.into();
+        for len in 0..ipv4_tcp.len() {
+            snoop_tcp_packet(&ipv4_tcp[..len], &mut sockets);
+        }
+
+        let mut ipv6_tcp = [0u8; 60];
+        ipv6_tcp[0] = 0x60;
+        ipv6_tcp[4..6].copy_from_slice(&20u16.to_be_bytes());
+        ipv6_tcp[6] = IpProtocol::Tcp.into();
+        for len in 0..ipv6_tcp.len() {
+            snoop_tcp_packet(&ipv6_tcp[..len], &mut sockets);
+        }
     }
 
     #[test]

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -1479,10 +1479,14 @@ mod tests {
     }
 
     #[test]
-    fn snoop_tcp_packet_drops_every_truncated_ipv4_and_ipv6_header() {
+    fn snoop_tcp_packet_drops_truncated_ip_and_tcp_headers() {
+        const IPV4_HEADER_LEN: usize = 20;
+        const IPV6_HEADER_LEN: usize = 40;
+        const TCP_HEADER_LEN: usize = 20;
+
         let mut sockets = SocketSet::new(vec![]);
 
-        let mut ipv4_tcp = [0u8; 40];
+        let mut ipv4_tcp = [0u8; IPV4_HEADER_LEN + TCP_HEADER_LEN];
         ipv4_tcp[0] = 0x45;
         let ipv4_tcp_len = ipv4_tcp.len() as u16;
         ipv4_tcp[2..4].copy_from_slice(&ipv4_tcp_len.to_be_bytes());
@@ -1491,12 +1495,30 @@ mod tests {
             snoop_tcp_packet(&ipv4_tcp[..len], &mut sockets);
         }
 
-        let mut ipv6_tcp = [0u8; 60];
+        let mut ipv6_tcp = [0u8; IPV6_HEADER_LEN + TCP_HEADER_LEN];
         ipv6_tcp[0] = 0x60;
         ipv6_tcp[4..6].copy_from_slice(&20u16.to_be_bytes());
         ipv6_tcp[6] = IpProtocol::Tcp.into();
         for len in 0..ipv6_tcp.len() {
             snoop_tcp_packet(&ipv6_tcp[..len], &mut sockets);
+        }
+
+        // Keep the IP header complete and its length fields consistent so the
+        // packet reaches the TCP parser. The old unchecked TCP parser then
+        // read ports from these 0-19 byte payloads and panicked.
+        for tcp_len in 0..TCP_HEADER_LEN {
+            let mut ipv4_tcp = vec![0u8; IPV4_HEADER_LEN + tcp_len];
+            ipv4_tcp[0] = 0x45;
+            let ipv4_len = ipv4_tcp.len() as u16;
+            ipv4_tcp[2..4].copy_from_slice(&ipv4_len.to_be_bytes());
+            ipv4_tcp[9] = IpProtocol::Tcp.into();
+            snoop_tcp_packet(&ipv4_tcp, &mut sockets);
+
+            let mut ipv6_tcp = vec![0u8; IPV6_HEADER_LEN + tcp_len];
+            ipv6_tcp[0] = 0x60;
+            ipv6_tcp[4..6].copy_from_slice(&(tcp_len as u16).to_be_bytes());
+            ipv6_tcp[6] = IpProtocol::Tcp.into();
+            snoop_tcp_packet(&ipv6_tcp, &mut sockets);
         }
     }
 


### PR DESCRIPTION
## 问题

被动 TCP 建连嗅探在设备 RX 和 loopback 注入路径中读取 IPv4/IPv6 与 TCP 字段。截断或畸形报文若未经检查就进入这些读取，会触发 smoltcp 解析路径 panic。

Closes #1738.

## 修改

- 在读取 IP 字段前拒绝空帧，并使用 checked IPv4/IPv6 packet 解析；
- 在读取 TCP 端口和 flags 前使用 checked TCP packet 解析；
- 对畸形帧直接返回，不写入监听表；
- 回归测试覆盖所有截断 IP 前缀，并新增完整 IP 头、声明长度一致、TCP payload 为 0–19 字节的 IPv4/IPv6 输入，确保 TCP guard 本身被实际执行；
- rebase 到最新 `dev@0340ed6bfa`，保留 `dev` 现有代码路径。

## 验证

- 已整理为最新 `dev@0340ed6bfa` 之上的 4 个功能提交，当前 head 为 `ac35e4d4cebd0ed03569be17d6899d619685697c`；
- 按要求未运行本地 clippy/test，正式 CI 负责执行 `ax-net` 测试和完整矩阵；
- 未修改 changelog。
