### PR TITLE
fix(starry): keep parent traversal inside chroot

### DIFF
--- a/fs/ax-fs-ng/src/fs_core/context.rs
+++ b/fs/ax-fs-ng/src/fs_core/context.rs
@@ -295,7 +295,9 @@ impl FsContext {
             match comp {
                 Component::CurDir => {}
                 Component::ParentDir => {
-                    dir = dir.parent().unwrap_or_else(|| self.root_dir.clone());
+                    if !dir.ptr_eq(&self.root_dir) {
+                        dir = dir.parent().unwrap_or_else(|| self.root_dir.clone());
+                    }
                 }
                 Component::RootDir => {
                     dir = self.root_dir.clone();
@@ -404,10 +406,14 @@ impl FsContext {
         let (dir, name) = self.resolve_inner(path, &mut 0)?;
         if let Some(name) = name {
             Ok((dir, Cow::Borrowed(name)))
-        } else if let Some(parent) = dir.parent() {
-            Ok((parent, dir.name().into_owned().into()))
         } else {
-            Err(VfsError::InvalidInput)
+            if dir.ptr_eq(&self.root_dir) {
+                Err(VfsError::InvalidInput)
+            } else if let Some(parent) = dir.parent() {
+                Ok((parent, dir.name().into_owned().into()))
+            } else {
+                Err(VfsError::InvalidInput)
+            }
         }
     }
 
@@ -473,6 +479,9 @@ impl FsContext {
     /// Removes a file from the filesystem.
     pub fn remove_file(&self, path: impl AsRef<Path>) -> VfsResult<()> {
         let entry = self.resolve_no_follow(path.as_ref())?;
+        if entry.ptr_eq(&self.root_dir) {
+            return Err(VfsError::IsADirectory);
+        }
         entry
             .parent()
             .ok_or(VfsError::IsADirectory)?
@@ -482,6 +491,9 @@ impl FsContext {
     /// Removes a directory from the filesystem.
     pub fn remove_dir(&self, path: impl AsRef<Path>) -> VfsResult<()> {
         let entry = self.resolve_no_follow(path.as_ref())?;
+        if entry.ptr_eq(&self.root_dir) {
+            return Err(VfsError::ResourceBusy);
+        }
         let dir = entry.entry().as_dir()?;
         if dir.has_children()? {
             return Err(VfsError::DirectoryNotEmpty);

--- a/test-suit/starryos/qemu/system/bugfix-bug-chroot-parent-escape/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-bug-chroot-parent-escape/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-chroot-parent-escape C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bug-chroot-parent-escape src/main.c)
+target_compile_options(bug-chroot-parent-escape PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-chroot-parent-escape RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-bug-chroot-parent-escape/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-chroot-parent-escape/src/main.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -11,9 +12,12 @@ struct paths {
     char base[128];
     char container[160];
     char jail[192];
+    char mountpoint[224];
     char parent_secret[192];
     char grandparent_secret[192];
+    char jail_secret[224];
     char escape_link[224];
+    int mounted;
 };
 
 static int make_directory(const char *path)
@@ -50,11 +54,17 @@ static int create_secret(const char *path)
     return 0;
 }
 
-static void cleanup(const struct paths *paths)
+static void cleanup(struct paths *paths)
 {
+    if (paths->mounted) {
+        umount2(paths->mountpoint, 0);
+        paths->mounted = 0;
+    }
     unlink(paths->escape_link);
+    unlink(paths->jail_secret);
     unlink(paths->parent_secret);
     unlink(paths->grandparent_secret);
+    rmdir(paths->mountpoint);
     rmdir(paths->jail);
     rmdir(paths->container);
     rmdir(paths->base);
@@ -75,17 +85,53 @@ static int expect_hidden(const char *path)
     return 0;
 }
 
-static int child_body(const struct paths *paths)
+static int chroot_to(const char *path)
 {
-    if (chdir(paths->jail) < 0) {
-        perror("chdir jail");
+    if (chdir(path) < 0) {
+        perror("chdir chroot");
         return 1;
     }
     if (chroot(".") < 0) {
-        perror("chroot jail");
+        perror("chroot");
         return 1;
     }
+    return 0;
+}
 
+static int child_from_jail_mount(const struct paths *paths)
+{
+    if (chroot_to(paths->jail) != 0) {
+        return 1;
+    }
+    if (chdir("mountpoint") < 0) {
+        perror("chdir mountpoint");
+        return 1;
+    }
+    if (expect_hidden("../../parent-secret") < 0 ||
+        expect_hidden("../../grandparent-secret") < 0 ||
+        expect_hidden("../../../grandparent-secret") < 0) {
+        return 1;
+    }
+    return 0;
+}
+
+static int child_from_mount_root(const struct paths *paths)
+{
+    if (chroot_to(paths->mountpoint) != 0) {
+        return 1;
+    }
+    if (expect_hidden("../jail-secret") < 0 ||
+        expect_hidden("../../parent-secret") < 0) {
+        return 1;
+    }
+    return 0;
+}
+
+static int child_from_jail_root(const struct paths *paths)
+{
+    if (chroot_to(paths->jail) != 0) {
+        return 1;
+    }
     if (expect_hidden("../parent-secret") < 0 ||
         expect_hidden("../../grandparent-secret") < 0 ||
         expect_hidden("escape-link") < 0) {
@@ -103,6 +149,25 @@ static int child_body(const struct paths *paths)
     return 0;
 }
 
+static int run_child(const struct paths *paths, int (*body)(const struct paths *), const char *name)
+{
+    pid_t child = fork();
+    if (child < 0) {
+        perror("fork");
+        return -1;
+    }
+    if (child == 0) {
+        _exit(body(paths));
+    }
+
+    int status = 0;
+    if (waitpid(child, &status, 0) != child || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "FAIL: %s chroot child status=%d errno=%d\n", name, status, errno);
+        return -1;
+    }
+    return 0;
+}
+
 int main(void)
 {
     struct paths paths = {0};
@@ -113,8 +178,10 @@ int main(void)
     }
     if (join_path(paths.container, sizeof(paths.container), paths.base, "container") < 0 ||
         join_path(paths.jail, sizeof(paths.jail), paths.container, "jail") < 0 ||
+        join_path(paths.mountpoint, sizeof(paths.mountpoint), paths.jail, "mountpoint") < 0 ||
         join_path(paths.parent_secret, sizeof(paths.parent_secret), paths.container, "parent-secret") < 0 ||
         join_path(paths.grandparent_secret, sizeof(paths.grandparent_secret), paths.base, "grandparent-secret") < 0 ||
+        join_path(paths.jail_secret, sizeof(paths.jail_secret), paths.jail, "jail-secret") < 0 ||
         join_path(paths.escape_link, sizeof(paths.escape_link), paths.jail, "escape-link") < 0) {
         return 1;
     }
@@ -122,26 +189,25 @@ int main(void)
     cleanup(&paths);
     if (make_directory("/tmp") < 0 || make_directory(paths.base) < 0 ||
         make_directory(paths.container) < 0 || make_directory(paths.jail) < 0 ||
+        make_directory(paths.mountpoint) < 0 ||
         create_secret(paths.parent_secret) < 0 || create_secret(paths.grandparent_secret) < 0 ||
+        create_secret(paths.jail_secret) < 0 ||
         symlink("../../grandparent-secret", paths.escape_link) < 0) {
         cleanup(&paths);
         return 1;
     }
 
-    pid_t child = fork();
-    if (child < 0) {
-        perror("fork");
+    if (mount("tmpfs", paths.mountpoint, "tmpfs", 0, NULL) < 0) {
+        perror("mount tmpfs");
         cleanup(&paths);
         return 1;
     }
-    if (child == 0) {
-        _exit(child_body(&paths));
-    }
+    paths.mounted = 1;
 
-    int status = 0;
     int result = 0;
-    if (waitpid(child, &status, 0) != child || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-        fprintf(stderr, "FAIL: chroot child status=%d errno=%d\n", status, errno);
+    if (run_child(&paths, child_from_jail_root, "jail root") < 0 ||
+        run_child(&paths, child_from_jail_mount, "jail mount") < 0 ||
+        run_child(&paths, child_from_mount_root, "mount root") < 0) {
         result = 1;
     }
     cleanup(&paths);

--- a/test-suit/starryos/qemu/system/bugfix-bug-chroot-parent-escape/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-chroot-parent-escape/src/main.c
@@ -1,3 +1,5 @@
+#define _GNU_SOURCE
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>

--- a/test-suit/starryos/qemu/system/bugfix-bug-chroot-parent-escape/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-chroot-parent-escape/src/main.c
@@ -1,0 +1,150 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+struct paths {
+    char base[128];
+    char container[160];
+    char jail[192];
+    char parent_secret[192];
+    char grandparent_secret[192];
+    char escape_link[224];
+};
+
+static int make_directory(const char *path)
+{
+    if (mkdir(path, 0700) == 0 || errno == EEXIST) {
+        return 0;
+    }
+    perror(path);
+    return -1;
+}
+
+static int join_path(char *path, size_t size, const char *dir, const char *name)
+{
+    int len = snprintf(path, size, "%s/%s", dir, name);
+    return len < 0 || (size_t)len >= size ? -1 : 0;
+}
+
+static int create_secret(const char *path)
+{
+    int fd = open(path, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+    if (fd < 0) {
+        perror(path);
+        return -1;
+    }
+    if (write(fd, "secret", 6) != 6) {
+        perror("write secret");
+        close(fd);
+        return -1;
+    }
+    if (close(fd) < 0) {
+        perror("close secret");
+        return -1;
+    }
+    return 0;
+}
+
+static void cleanup(const struct paths *paths)
+{
+    unlink(paths->escape_link);
+    unlink(paths->parent_secret);
+    unlink(paths->grandparent_secret);
+    rmdir(paths->jail);
+    rmdir(paths->container);
+    rmdir(paths->base);
+}
+
+static int expect_hidden(const char *path)
+{
+    int fd = open(path, O_RDONLY);
+    if (fd >= 0) {
+        close(fd);
+        fprintf(stderr, "FAIL: chroot escaped through %s\n", path);
+        return -1;
+    }
+    if (errno != ENOENT) {
+        fprintf(stderr, "FAIL: open(%s) errno=%d, expected ENOENT\n", path, errno);
+        return -1;
+    }
+    return 0;
+}
+
+static int child_body(const struct paths *paths)
+{
+    if (chdir(paths->jail) < 0) {
+        perror("chdir jail");
+        return 1;
+    }
+    if (chroot(".") < 0) {
+        perror("chroot jail");
+        return 1;
+    }
+
+    if (expect_hidden("../parent-secret") < 0 ||
+        expect_hidden("../../grandparent-secret") < 0 ||
+        expect_hidden("escape-link") < 0) {
+        return 1;
+    }
+    if (unlink("escape-link") < 0) {
+        perror("unlink escape-link");
+        return 1;
+    }
+    errno = 0;
+    if (rmdir("..") == 0 || errno != EBUSY) {
+        fprintf(stderr, "FAIL: rmdir(..) escaped the jail errno=%d\n", errno);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void)
+{
+    struct paths paths = {0};
+    int len = snprintf(paths.base, sizeof(paths.base),
+                       "/tmp/bug-chroot-parent-escape-%ld", (long)getpid());
+    if (len < 0 || (size_t)len >= sizeof(paths.base)) {
+        return 1;
+    }
+    if (join_path(paths.container, sizeof(paths.container), paths.base, "container") < 0 ||
+        join_path(paths.jail, sizeof(paths.jail), paths.container, "jail") < 0 ||
+        join_path(paths.parent_secret, sizeof(paths.parent_secret), paths.container, "parent-secret") < 0 ||
+        join_path(paths.grandparent_secret, sizeof(paths.grandparent_secret), paths.base, "grandparent-secret") < 0 ||
+        join_path(paths.escape_link, sizeof(paths.escape_link), paths.jail, "escape-link") < 0) {
+        return 1;
+    }
+
+    cleanup(&paths);
+    if (make_directory("/tmp") < 0 || make_directory(paths.base) < 0 ||
+        make_directory(paths.container) < 0 || make_directory(paths.jail) < 0 ||
+        create_secret(paths.parent_secret) < 0 || create_secret(paths.grandparent_secret) < 0 ||
+        symlink("../../grandparent-secret", paths.escape_link) < 0) {
+        cleanup(&paths);
+        return 1;
+    }
+
+    pid_t child = fork();
+    if (child < 0) {
+        perror("fork");
+        cleanup(&paths);
+        return 1;
+    }
+    if (child == 0) {
+        _exit(child_body(&paths));
+    }
+
+    int status = 0;
+    int result = 0;
+    if (waitpid(child, &status, 0) != child || !WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        fprintf(stderr, "FAIL: chroot child status=%d errno=%d\n", status, errno);
+        result = 1;
+    }
+    cleanup(&paths);
+    if (result == 0) {
+        puts("PASS: chroot parent traversal remains inside the jail");
+    }
+    return result;
+}


### PR DESCRIPTION
Closes #1740。

## 问题

`FsContext` 在 chroot 环境处理 `..` 时可能继续沿物理父目录向上遍历，使路径解析越过 chroot 根目录。该问题也可能通过最终的 `.`/`..` 解析或删除辅助路径重新出现。

## 修改

- 通过 `Location` 身份判断 chroot 根目录，并在根目录处截断 `..` 遍历。
- 保留 chroot 内部以及跨挂载点的正常父目录遍历。
- 阻止最终 `.`/`..` 解析和删除辅助逻辑重新引入物理父目录逃逸。
- 增加全架构 StarryOS system 回归，覆盖直接逃逸、多级逃逸、相对符号链接逃逸，以及 `rmdir("..")` 返回 `EBUSY`。

## 实现逻辑

路径解析遇到父目录分量时，先比较当前位置与 chroot 根目录的 `Location`；两者相同时保持在根目录，否则才解析父目录。测试在子进程中建立 chroot，确认所有越界访问均返回 `ENOENT`，同时验证 chroot 内合法遍历不受影响。

## 验证

- `cargo fmt --all --check`
- `cargo xtask clippy --package ax-fs-ng`（6 组 feature 检查全部通过）
- `cargo xtask starry test qemu --arch riscv64 -c qemu/system/bugfix-bug-chroot-parent-escape`（1/1 通过，输出 `PASS: chroot parent traversal remains inside the jail`）

## 分支同步

- 已于 2026-08-21 通过 GitHub rebase 更新到 `dev@8e39cbd586a4a34ab9f522931ca4b1e7523709c7`。
- 当前 head 为 `45f633a5442bb2b53b46a3a7302388fe699313b4`，`dev` 已是其祖先。
- rebase 移除了历史中的 3 个 `dev` merge commit，保留 3 个功能与测试提交；相对 `dev` 的差异仍仅包含原来的 3 个文件。