### PR TITLE
fix(starry): handle oversized module images

### DIFF
--- a/os/StarryOS/kernel/src/syscall/kmod.rs
+++ b/os/StarryOS/kernel/src/syscall/kmod.rs
@@ -6,7 +6,7 @@
 //! small subsystems as `<name>.rs` rather than `<name>/mod.rs` (cf.
 //! `syscall/signal.rs`, `syscall/time.rs`).
 
-use alloc::vec;
+use alloc::vec::Vec;
 
 use ax_io::Read;
 use ax_task::current;
@@ -26,6 +26,17 @@ fn require_module_privilege() -> StarryResult<()> {
     }
 }
 
+/// Allocate module-image storage without letting an oversized syscall input
+/// reach the allocator's infallible OOM path.
+fn allocate_module_image(len: usize) -> StarryResult<Vec<u8>> {
+    let mut module_image = Vec::new();
+    module_image
+        .try_reserve_exact(len)
+        .map_err(|_| StarryError::NoMemory)?;
+    module_image.resize(len, 0);
+    Ok(module_image)
+}
+
 /// See <https://man7.org/linux/man-pages/man2/init_module.2.html>
 pub fn sys_init_module(
     module_ptr: *const u8,
@@ -34,7 +45,7 @@ pub fn sys_init_module(
 ) -> StarryResult<isize> {
     require_module_privilege()?;
     let mut module_buf = VmBytes::new(module_ptr as *mut u8, len);
-    let mut module_data = vec![0u8; len];
+    let mut module_data = allocate_module_image(len)?;
     module_buf.read(&mut module_data)?;
 
     let param_buf = if !param_ptr.is_null() {
@@ -62,7 +73,7 @@ pub fn sys_finit_module(module_fd: i32, param_ptr: *const u8, flags: u32) -> Sta
     let file = get_file_like(module_fd)?;
     let fsize = file.stat()?.size as usize;
 
-    let mut module_data = vec![0u8; fsize];
+    let mut module_data = allocate_module_image(fsize)?;
     let mut offset = 0;
     while offset < fsize {
         let mut buf: &mut [u8] = &mut module_data[offset..];

--- a/test-suit/starryos/qemu/system/syscall-test-kmod-loader/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-kmod-loader/src/main.c
@@ -155,5 +155,11 @@ int main(void) {
     CHECK(raw_init_module(big, sizeof(big), "") < 0,
           "init_module(256-byte junk) returns error, no crash");
 
+    MODULE_START("init_module_oversized_len");
+    CHECK(geteuid() == 0, "oversized module test starts with root credentials");
+    errno = 0;
+    CHECK(raw_init_module(&dummy, SIZE_MAX, "") == -1 && errno == ENOMEM,
+          "init_module(SIZE_MAX) returns ENOMEM for an oversized image");
+
     SUMMARY();
 }


### PR DESCRIPTION
## 问题

`init_module(2)` 直接把用户提供的 `len` 用于 `vec![0; len]`，`finit_module(2)` 也会按文件报告的大小进行同样的不可失败分配。超大但有权限的请求会进入分配器的 OOM/panic 路径，而不是向用户态返回可恢复的错误。

## 修改

- 提取私有的 `allocate_module_image`：先用 `Vec::try_reserve_exact` 预留容量；容量溢出或内存不足统一映射到既有的 `StarryError::NoMemory`（即 `ENOMEM`），成功后再初始化零填充缓冲区。
- `sys_init_module` 与 `sys_finit_module` 共享该 helper；模块读取、参数解析与实际加载逻辑均保持不变。
- 扩展既有 `qemu/system/syscall-test-kmod-loader`：在 init 进程的 root/CAP_SYS_MODULE 前置条件下，直接以 `SIZE_MAX` 调用 `SYS_init_module`，断言返回 `-1` 且 `errno == ENOMEM`。旧实现会先尝试 `vec![0; SIZE_MAX]`，不能满足该断言。

## Linux ABI 核对

比对目标为 Linux v6.12（commit `adc218676eef25575469234709c2d87185ca223a`）。

| Syscall | 结论 | 对应标准 | 依据 |
| --- | --- | --- | --- |
| `init_module` | 符合本次错误路径修复 | [init_module(2)](https://man7.org/linux/man-pages/man2/init_module.2.html)、[Linux v6.12 入口](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/module/main.c#L3066-L3086) | 保留原有 `CAP_SYS_MODULE` 前置检查；Linux 的 `copy_module_from_user` 分配失败返回 `ENOMEM` 后才读取用户缓冲区。本实现将不可失败分配替换为同一错误语义。 |
| `finit_module` | 符合本次错误路径修复 | [init_module(2)](https://man7.org/linux/man-pages/man2/init_module.2.html)、[Linux v6.12 入口](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/module/main.c#L3220-L3239) | 保留 capability、flags、fd、参数和顺序读取语义；仅将按 `stat().size` 创建的同一模块镜像缓冲区改为可失败分配，失败映射为 `ENOMEM`。 |

## 验证

- `git diff --check`
- 新增 C 回归的 `-Wall -Wextra -Werror` 语法检查
- `cmake -S test-suit/starryos/qemu/system/syscall-test-kmod-loader -B /private/tmp/tgoskits-kmod-fallible-allocation-build`
- `cmake --build /private/tmp/tgoskits-kmod-fallible-allocation-build --parallel 2`

该环境没有 Rust/Cargo 工具链，因此无法本地执行 `cargo fmt`、clippy 或 `cargo xtask starry test qemu --arch x86_64 -c qemu/system/syscall-test-kmod-loader`；CI 是 Rust 编译、格式化和真实 Starry QEMU syscall 行为的剩余验证门。