### PR TITLE
fix(starry): bound openat2 how size

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -6,6 +6,7 @@ use core::{
 };
 
 use ax_fs_ng::vfs::{FS_CONTEXT, FileBackend, MountNamespace, OpenOptions, OpenResult};
+use ax_memory_addr::PAGE_SIZE_4K;
 use ax_task::current;
 use axfs_ng_vfs::{DirEntry, FileNode, Location, NodeOps, NodeType, Reference, VfsError};
 use bitflags::bitflags;
@@ -472,6 +473,9 @@ pub fn sys_openat2(
     let base_size = size_of::<OpenHow>();
     if size < base_size {
         return Err(StarryError::InvalidInput);
+    }
+    if size > PAGE_SIZE_4K {
+        return Err(StarryError::ArgumentListTooLong);
     }
 
     let how_value = how.vm_read()?;

--- a/test-suit/starryos/qemu/system/syscall-test-ltp-pilot-min/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-ltp-pilot-min/src/main.c
@@ -108,6 +108,23 @@ static void expect_openat2_padded_e2big(void)
     CHECK(ret == -1 && errno == E2BIG, "openat2 nonzero extension bytes -> E2BIG");
 }
 
+static void expect_openat2_oversized_how_e2big(void)
+{
+    struct open_how how = {
+        .flags = O_RDONLY,
+        .mode = 0,
+        .resolve = 0,
+    };
+
+    errno = 0;
+    long ret = do_openat2(AT_FDCWD, "file", &how, SIZE_MAX);
+    if (ret >= 0) {
+        close((int)ret);
+    }
+    CHECK(ret == -1 && errno == E2BIG,
+          "openat2 oversized how size returns E2BIG before user-memory import");
+}
+
 static void expect_openat2_success(const char *name, int dirfd, const char *path,
                                    uint64_t flags, uint64_t resolve)
 {
@@ -166,6 +183,7 @@ static void test_openat2_min(void)
     expect_openat2_errno("openat2 size small -> EINVAL", AT_FDCWD, "file",
                          (struct open_how){ O_RDWR | O_CREAT, 0700, 0 },
                          sizeof(struct open_how) - 1, EINVAL);
+    expect_openat2_oversized_how_e2big();
     expect_openat2_padded_e2big();
 
     expect_openat2_success("openat2 ordinary path succeeds", dirfd, "basic", O_RDWR, 0);


### PR DESCRIPTION
## 问题

`sys_openat2` 仅拒绝小于 `struct open_how` 的 `size`；随后先读取头部，再将 `size - 24` 作为扩展字节数传给 `vm_load`。因此，`size = SIZE_MAX` 会在用户内存导入路径触发超大分配，而非按 Linux ABI 返回 errno。

Linux v6.12 在访问 `how` 指针前规定：`usize > PAGE_SIZE` 返回 `E2BIG`。

## 修复

- 在现有下限检查之后、所有 `how` 用户内存读取之前，以 `PAGE_SIZE_4K` 限制 `size`。
- 使用已有的 `StarryError::ArgumentListTooLong`（映射为 `E2BIG`）。
- 在现有 LTP-derived 小型 syscall 用例中，固定 `openat2(..., &how, SIZE_MAX)` 必须返回 `-1/E2BIG`。

## ABI 对照

| syscall | 输入 | Linux v6.12 | 修复后 StarryOS |
| --- | --- | --- | --- |
| `openat2` | 有效 `how`，`size = SIZE_MAX` | 在导入 `how` 前返回 `E2BIG` | 在导入 `how` 前返回 `E2BIG` |

Linux 依据（固定 commit）：[fs/open.c: openat2 size 检查](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/fs/open.c#L1457-L1461)。

## 验证

- `git diff --check`
- `syscall-test-ltp-pilot-min` 的 C 源在 `-std=c11 -Wall -Wextra -Werror` 下编译为对象文件；本机 macOS 缺少 Linux 专用头文件，兼容声明仅置于 `/private/tmp`，未纳入提交。
- StarryOS 的完整 RISC-V/QEMU 行为由 CI 覆盖。