### PR TITLE
fix(starry): match sched affinity length ABI

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/schedule.rs
+++ b/os/StarryOS/kernel/src/syscall/task/schedule.rs
@@ -119,11 +119,11 @@ pub fn sys_sched_getaffinity(
     cpusetsize: usize,
     user_mask: *mut u8,
 ) -> StarryResult<isize> {
-    let cpusetsize = sched_affinity_len(cpusetsize);
-    if cpusetsize.wrapping_mul(8) < hal::cpu_num() as u32 {
+    let cpusetsize = sched_affinity_len(cpusetsize) as usize;
+    if cpusetsize < hal::cpu_num().div_ceil(8) {
         return Err(StarryError::InvalidInput);
     }
-    if cpusetsize & (size_of::<usize>() as u32 - 1) != 0 {
+    if cpusetsize & (size_of::<usize>() - 1) != 0 {
         return Err(StarryError::InvalidInput);
     }
 

--- a/os/StarryOS/kernel/src/syscall/task/schedule.rs
+++ b/os/StarryOS/kernel/src/syscall/task/schedule.rs
@@ -1,4 +1,5 @@
 use alloc::{sync::Arc, vec::Vec};
+use core::mem::size_of;
 
 use ax_runtime::hal::{self, time::TimeValue};
 use ax_task::{
@@ -31,6 +32,12 @@ struct SchedParam {
 pub fn sys_sched_yield() -> StarryResult<isize> {
     ax_task::yield_now();
     Ok(0)
+}
+
+/// The raw Linux affinity syscalls take their mask length as `unsigned int`.
+#[inline]
+fn sched_affinity_len(cpusetsize: usize) -> u32 {
+    cpusetsize as u32
 }
 
 fn sleep_impl(clock: impl Fn() -> TimeValue, dur: TimeValue) -> (StarryResult<()>, TimeValue) {
@@ -112,7 +119,11 @@ pub fn sys_sched_getaffinity(
     cpusetsize: usize,
     user_mask: *mut u8,
 ) -> StarryResult<isize> {
-    if cpusetsize * 8 < hal::cpu_num() {
+    let cpusetsize = sched_affinity_len(cpusetsize);
+    if cpusetsize.wrapping_mul(8) < hal::cpu_num() as u32 {
+        return Err(StarryError::InvalidInput);
+    }
+    if cpusetsize & (size_of::<usize>() as u32 - 1) != 0 {
         return Err(StarryError::InvalidInput);
     }
 
@@ -147,6 +158,7 @@ pub fn sys_sched_setaffinity(
     cpusetsize: usize,
     user_mask: *const u8,
 ) -> StarryResult<isize> {
+    let cpusetsize = sched_affinity_len(cpusetsize) as usize;
     let task = SchedulerTarget::try_from(pid)?.resolve()?;
     check_sched_permission(&task)?;
     let size = cpusetsize.min(hal::cpu_num().div_ceil(8));

--- a/test-suit/starryos/qemu/system/test-sched-family/src/main.c
+++ b/test-suit/starryos/qemu/system/test-sched-family/src/main.c
@@ -107,6 +107,13 @@ int main(void)
                       "raw sched_getaffinity truncates oversized cpusetsize to EINVAL");
             CHECK_ERR(syscall(SYS_SCHED_SETAFFINITY, 0, oversized_cpusetsize, &mask), EINVAL,
                       "raw sched_setaffinity truncates oversized cpusetsize to EINVAL");
+
+            // This is a valid unsigned-int length. The implementation must
+            // compare it in bytes, rather than overflow it while converting
+            // to a number of CPU bits.
+            size_t large_cpusetsize = (size_t)1 << 29;
+            CHECK(syscall(SYS_SCHED_GETAFFINITY, 0, large_cpusetsize, &mask) > 0,
+                  "raw sched_getaffinity accepts a large valid cpusetsize");
         }
 #endif
 

--- a/test-suit/starryos/qemu/system/test-sched-family/src/main.c
+++ b/test-suit/starryos/qemu/system/test-sched-family/src/main.c
@@ -1,6 +1,7 @@
 #define _GNU_SOURCE
 #include "test_framework.h"
 #include <sched.h>
+#include <stdint.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -93,6 +94,21 @@ int main(void)
             CHECK_RET(sched_getaffinity(0, sizeof(readback), &readback), 0, "getaffinity current pid");
             CHECK(contains_online_cpus(&readback, nprocs), "getaffinity result contains online CPUs");
         }
+
+#if SIZE_MAX > UINT32_MAX
+        // Linux raw syscalls accept cpusetsize as unsigned int.  A 64-bit
+        // value of 2^32 therefore reaches the kernel as zero bytes.
+        {
+            cpu_set_t mask;
+            size_t oversized_cpusetsize = (size_t)UINT32_MAX + 1U;
+
+            fill_online_cpu_mask(&mask);
+            CHECK_ERR(syscall(SYS_SCHED_GETAFFINITY, 0, oversized_cpusetsize, &mask), EINVAL,
+                      "raw sched_getaffinity truncates oversized cpusetsize to EINVAL");
+            CHECK_ERR(syscall(SYS_SCHED_SETAFFINITY, 0, oversized_cpusetsize, &mask), EINVAL,
+                      "raw sched_setaffinity truncates oversized cpusetsize to EINVAL");
+        }
+#endif
 
         // EFAULT: supplied memory address was invalid
         {

--- a/test-suit/starryos/qemu/system/test-sched-family/src/test_framework.h
+++ b/test-suit/starryos/qemu/system/test-sched-family/src/test_framework.h
@@ -8,21 +8,29 @@
     #define SYS_SCHED_GETPARAM      143
     #define SYS_SCHED_GETSCHEDULER  145
     #define SYS_SCHED_SETSCHEDULER  144
+    #define SYS_SCHED_SETAFFINITY   203
+    #define SYS_SCHED_GETAFFINITY   204
 
 #elif defined(__riscv)
     #define SYS_SCHED_GETPARAM      121
     #define SYS_SCHED_GETSCHEDULER  120
     #define SYS_SCHED_SETSCHEDULER  119
+    #define SYS_SCHED_SETAFFINITY   122
+    #define SYS_SCHED_GETAFFINITY   123
 
 #elif defined(__aarch64__)
     #define SYS_SCHED_GETPARAM      121
     #define SYS_SCHED_GETSCHEDULER  120
     #define SYS_SCHED_SETSCHEDULER  119
+    #define SYS_SCHED_SETAFFINITY   122
+    #define SYS_SCHED_GETAFFINITY   123
 
 #elif defined(__loongarch64)
     #define SYS_SCHED_GETPARAM      121
     #define SYS_SCHED_GETSCHEDULER  120
     #define SYS_SCHED_SETSCHEDULER  119
+    #define SYS_SCHED_SETAFFINITY   122
+    #define SYS_SCHED_GETAFFINITY   123
 
 #else
     #error "unsupported architecture for sched syscalls"
@@ -87,4 +95,3 @@ static int __fail = 0;
     printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
     printf("================================================\n\n");    \
     return __fail > 0 ? 1 : 0
-    


### PR DESCRIPTION
## 问题

StarryOS 将 `sched_getaffinity` / `sched_setaffinity` 的 `cpusetsize` 直接作为 `usize` 使用，但 Linux 的原始 syscall ABI 在两处均定义为 `unsigned int`。64 位调用者传入 `2^32` 时，Linux 接收的长度为零；当前 StarryOS 却继续按原始 64 位长度导入或写回 CPU mask，可能错误返回成功并修改 affinity。

此外，Linux 对 `sched_getaffinity` 要求长度是 `unsigned long` 的整数倍，当前实现缺少该检查。

## 修复

- 在两个 affinity syscall 入口将长度按 Linux ABI 截断为 `u32`。
- 在 `sched_getaffinity` 按 Linux 的检查顺序加入 `unsigned long` 宽度对齐验证。
- 通过原始 syscall 以 `2^32` 长度覆盖两个入口，断言均返回 `EINVAL`。
- rebase 到最新 `dev@0340ed6bfa`，保留 `dev` 的 `SchedulerTarget` PID namespace 解析与权限检查路径。

## ABI 对照

| syscall | 输入 | Linux v6.12 | 修复后 StarryOS |
| --- | --- | --- | --- |
| `sched_getaffinity` | `cpusetsize = 2^32` | `unsigned int` 截断为 0，返回 `EINVAL` | 截断为 0，返回 `EINVAL` |
| `sched_setaffinity` | `cpusetsize = 2^32`，非空 mask | `unsigned int` 截断为 0，空 mask 返回 `EINVAL` | 截断为 0，空 mask 返回 `EINVAL` |
| `sched_getaffinity` | 非字宽整数倍的长度 | `EINVAL` | `EINVAL` |

Linux 依据（固定 commit）：[sched affinity syscall 参数与长度验证](https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/sched/syscalls.c#L1301-L1389)。

## 验证

- `git diff --check`
- `cargo fmt --all --check`
- 按维护要求未继续执行本地 clippy/QEMU，完整行为由本次更新触发的 CI 覆盖。
