### PR TITLE
fix(starry): match unlinkat flag ABI width

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -409,7 +409,7 @@ pub fn sys_link(old_path: *const c_char, new_path: *const c_char) -> StarryResul
 /// path: the name of link to be removed
 /// flags: can be 0 or AT_REMOVEDIR
 /// return 0 when success, else return -1
-pub fn sys_unlinkat(dirfd: i32, path: *const c_char, flags: usize) -> StarryResult<isize> {
+pub fn sys_unlinkat(dirfd: i32, path: *const c_char, flags: i32) -> StarryResult<isize> {
     let path = vm_load_path_string(path)?;
 
     debug!("sys_unlinkat <= dirfd: {dirfd}, path: {path:?}, flags: {flags}");
@@ -417,13 +417,13 @@ pub fn sys_unlinkat(dirfd: i32, path: *const c_char, flags: usize) -> StarryResu
     // Linux kernel (fs/namei.c) rejects any flag bit other than AT_REMOVEDIR
     // with EINVAL. Silently ignoring unknown bits would mask caller bugs and
     // diverge from POSIX semantics (see man 2 unlinkat).
-    if flags & !(AT_REMOVEDIR as usize) != 0 {
+    if flags & !(AT_REMOVEDIR as i32) != 0 {
         return Err(StarryError::InvalidInput);
     }
 
     let deleted = path_info_at(dirfd, &path).ok();
     let result = with_fs(dirfd, |fs| {
-        if flags & AT_REMOVEDIR as usize != 0 {
+        if flags & AT_REMOVEDIR as i32 != 0 {
             fs.remove_dir(&path)?;
         } else {
             fs.remove_file(&path)?;

--- a/test-suit/starryos/qemu/system/syscall-test-path-family/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-path-family/src/main.c
@@ -187,6 +187,18 @@ static void test_unlinkat_success_and_failures(void)
     errno = 0;
     CHECK(fstatat(dfd, "workfile", &st, 0) == -1 && errno == ENOENT, "unlinkat: deleted file -> ENOENT");
 
+    fd = openat(dfd, "upper_word_flags", O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    CHECK(fd >= 0, "unlinkat: create raw upper-word flags file");
+    if (fd >= 0) {
+        close(fd);
+        errno = 0;
+        long raw_rc = syscall(SYS_unlinkat, dfd, "upper_word_flags", 1ULL << 32);
+        CHECK(raw_rc == 0, "unlinkat: raw upper-word flags truncate to zero");
+        errno = 0;
+        CHECK(fstatat(dfd, "upper_word_flags", &st, 0) == -1 && errno == ENOENT,
+              "unlinkat: raw upper-word flags delete the file");
+    }
+
     mkdirat(dfd, "emptydir", 0755);
     CHECK_RET(unlinkat(dfd, "emptydir", AT_REMOVEDIR), 0, "unlinkat: delete empty dir (AT_REMOVEDIR)");
     errno = 0;


### PR DESCRIPTION
## Summary
- receive raw `unlinkat` flags as Linux `int` rather than a machine word
- retain validation for all invalid low-word flag bits
- add a path-family regression for `SYS_unlinkat(..., 1ULL << 32)`

## Rationale
Linux declares the `unlinkat` flag argument as `int`. A raw 64-bit syscall value with only bit 32 set is therefore truncated to flags=0 and removes the target file. Starry inspected that upper bit as an invalid flag and returned `EINVAL`, diverging from the syscall ABI.

## Testing
- `git diff --check`
- strict C syntax check for the raw syscall expression
- upstream format, build, and Starry QEMU CI pending