### PR TITLE
fix(starry): honor syslog signed-length ABI

### DIFF
--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -760,15 +760,15 @@ fn require_syslog_privilege() -> StarryResult<()> {
     }
 }
 
-fn validate_syslog_read_args(buf: *mut c_char, len: usize) -> StarryResult<()> {
-    if buf.is_null() || len > i32::MAX as usize {
+fn validate_syslog_read_args(buf: *mut c_char, len: i32) -> StarryResult<()> {
+    if buf.is_null() || len < 0 {
         Err(StarryError::InvalidInput)
     } else {
         Ok(())
     }
 }
 
-pub fn sys_syslog(ty: i32, buf: *mut c_char, len: usize) -> StarryResult<isize> {
+pub fn sys_syslog(ty: i32, buf: *mut c_char, len: i32) -> StarryResult<isize> {
     match ty {
         SYSLOG_ACTION_CLOSE | SYSLOG_ACTION_OPEN => Ok(0),
         SYSLOG_ACTION_READ => {
@@ -776,7 +776,7 @@ pub fn sys_syslog(ty: i32, buf: *mut c_char, len: usize) -> StarryResult<isize> 
             validate_syslog_read_args(buf, len)?;
             let data = {
                 let mut state = SYSLOG_STATE.lock();
-                state.read(len)
+                state.read(len as usize)
             };
             if !data.is_empty() {
                 vm_write_slice(buf.cast::<u8>(), &data)?;
@@ -788,7 +788,7 @@ pub fn sys_syslog(ty: i32, buf: *mut c_char, len: usize) -> StarryResult<isize> 
             validate_syslog_read_args(buf, len)?;
             let data = {
                 let state = SYSLOG_STATE.lock();
-                state.read_all(len)
+                state.read_all(len as usize)
             };
             if !data.is_empty() {
                 vm_write_slice(buf.cast::<u8>(), &data)?;
@@ -800,7 +800,7 @@ pub fn sys_syslog(ty: i32, buf: *mut c_char, len: usize) -> StarryResult<isize> 
             validate_syslog_read_args(buf, len)?;
             let data = {
                 let mut state = SYSLOG_STATE.lock();
-                let data = state.read_all(len);
+                let data = state.read_all(len as usize);
                 state.clear();
                 data
             };
@@ -834,7 +834,7 @@ pub fn sys_syslog(ty: i32, buf: *mut c_char, len: usize) -> StarryResult<isize> 
             }
             let mut state = SYSLOG_STATE.lock();
             let old_level = state.console_level;
-            state.console_level = len;
+            state.console_level = len as usize;
             Ok(old_level as isize)
         }
         SYSLOG_ACTION_SIZE_UNREAD => {
@@ -1044,15 +1044,15 @@ pub(crate) fn uid_valid_and_syslog_validation_rules_hold_for_test() -> bool {
         && uid_valid(u32::MAX - 1)
         && !uid_valid(u32::MAX)  // NOCHG is invalid
 
-    // validate_syslog_read_args: null buf or len > i32::MAX is invalid.
+    // validate_syslog_read_args: null buf or negative len is invalid.
     && validate_syslog_read_args(core::ptr::null_mut(), 0).is_err()
     && validate_syslog_read_args(core::ptr::null_mut::<c_char>(), 100).is_err()
     && validate_syslog_read_args(0x1 as *mut c_char, 0).is_ok()  // non-null, len=0 is ok
     && {
         let mut dummy: c_char = 0;
         let ptr: *mut c_char = &mut dummy;
-        validate_syslog_read_args(ptr, i32::MAX as usize).is_ok()
-        && validate_syslog_read_args(ptr, (i32::MAX as usize) + 1).is_err()
+        validate_syslog_read_args(ptr, i32::MAX).is_ok()
+        && validate_syslog_read_args(ptr, -1).is_err()
     }
 }
 

--- a/test-suit/starryos/qemu/system/test-syslog/src/main.c
+++ b/test-suit/starryos/qemu/system/test-syslog/src/main.c
@@ -26,6 +26,14 @@
 #define SYSLOG_ACTION_SIZE_UNREAD 9
 #define SYSLOG_ACTION_SIZE_BUFFER 10
 
+_Static_assert(sizeof(unsigned long) >= 8,
+               "StarryOS syscall ABI tests require a 64-bit unsigned long");
+
+static unsigned long with_nonzero_upper_syslog_len(unsigned long low_word)
+{
+    return (1UL << 32) | low_word;
+}
+
 static int run_in_child(void (*func)(void)) {
     pid_t pid = fork();
     if (pid < 0)
@@ -117,6 +125,9 @@ int main(void) {
         CHECK(memcmp(buf, (unsigned char[128]){ [0 ... 127] = 0xA5 }, sizeof(buf)) == 0,
               "READ_ALL leaves buffer unchanged when nothing is copied");
     }
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_READ_ALL, buf,
+                      with_nonzero_upper_syslog_len(0)),
+              0, "READ_ALL narrows an upper-word length to int");
 
     long size_unread_after_read_all = syscall(SYS_syslog, SYSLOG_ACTION_SIZE_UNREAD, NULL, 0);
     CHECK(size_unread_after_read_all == size_unread,
@@ -139,10 +150,12 @@ int main(void) {
               "CONSOLE_OFF returns 0");
     CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_ON, NULL, 0), 0,
               "CONSOLE_ON returns 0");
-    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 1), 7,
-              "CONSOLE_LEVEL returns the previous level");
-    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 7), 1,
-              "CONSOLE_LEVEL updates and reports the old level");
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL,
+                      with_nonzero_upper_syslog_len(1)),
+              7, "CONSOLE_LEVEL narrows an upper-word level to int");
+    CHECK_RET(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL,
+                      with_nonzero_upper_syslog_len(7)),
+              1, "CONSOLE_LEVEL updates and reports the old narrowed level");
     CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 0), EINVAL,
               "CONSOLE_LEVEL rejects level 0 with EINVAL");
     CHECK_ERR(syscall(SYS_syslog, SYSLOG_ACTION_CONSOLE_LEVEL, NULL, 9), EINVAL,


### PR DESCRIPTION
## 问题

Linux v6.12 将 `syslog(2)` 的 `len` 定义为有符号 `int`：https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/printk/printk.c#L1743-L1805 ，syscall 入口同样使用该类型：https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/kernel/printk/printk.c#L1856-L1859 。StarryOS 原先把寄存器原值保留为 `usize`；因此 64 位调用者传入 `len = 2^32 | 1` 时，Linux 按 ABI 截断为合法 level 1，StarryOS 却将其当作超范围长度并返回 `EINVAL`。

## 修改

- 将 `sys_syslog` 及其 read-argument 校验改为接收 `i32`，使 dispatch 在 ABI 边界按 Linux 窄化。
- 只在验证非负后把 read action 的长度转为 `usize`，保留既有的 `EINVAL` 与 permission-first 顺序。
- 扩展既有 `test-syslog`：直接以 `syscall(SYS_syslog, ...)` 传入非零高 32 位的 read-all 和 console-level 长度，覆盖旧实现必然返回 `EINVAL` 的路径。

## 验证

- `git diff --check`
- `cmake -S test-suit/starryos/qemu/system -B /tmp/tgoskits-syslog-len-cmake-check -DSTARRY_GROUPED_C_SUBCASES=test-syslog`
- `cc -std=c11 -Wall -Wextra -Werror -Wno-deprecated-declarations -I../common -Dsetresuid(a,b,c)=0 -fsyntax-only src/main.c`（macOS 宿主仅作语法检查）

宿主未安装 Cargo/Rust 工具链，未能本地运行 `cargo xtask starry test qemu --arch riscv64 -c qemu/system/test-syslog`；请 CI 完成 Rust 格式、clippy 与真实 guest 回归。