### PR TITLE
feat(starry-kernel): consume user_access_ok_page in a lock-free user-copy fast path

### DIFF
--- a/components/axcpu/src/aarch64/asm.rs
+++ b/components/axcpu/src/aarch64/asm.rs
@@ -278,3 +278,72 @@ unsafe extern "C" {
     /// while a value > 0 indicates failure.
     pub fn user_copy(dst: *mut u8, src: *const u8, size: usize) -> usize;
 }
+
+/// Probes whether EL0 is permitted to access the page containing `vaddr` under
+/// the *current* user translation regime (`TTBR0_EL1`), without taking any lock.
+///
+/// Uses the `AT S1E0R` / `AT S1E0W` address-translation instruction, which asks
+/// the MMU to translate `vaddr` for an EL0 read (or write, when `write`) access
+/// and reports the result in `PAR_EL1`. `PAR_EL1.F == 0` means the translation
+/// succeeded and the access is permitted — exactly the permission the CPU itself
+/// enforces for a user-mode access, read lock-free. A not-present page or one
+/// lacking the requested EL0 permission (e.g. a copy-on-write page probed for
+/// write) reports `F == 1`.
+///
+/// Returns `true` iff the MMU would permit the EL0 access.
+///
+/// # Safety
+///
+/// The caller MUST invoke this with interrupts disabled. `PAR_EL1` is a per-CPU
+/// scratch register shared across contexts; an interrupt executing another `AT`
+/// between this `AT` and the `mrs` would clobber the result. On the
+/// pointer-validation path that could turn an inaccessible page into a `true`
+/// result and thus a raw kernel dereference of an unchecked address. IRQs-off
+/// guarantees no other `AT` runs on this CPU in between. Because violating this
+/// precondition is a memory-safety hazard (not merely a wrong answer), the
+/// function is `unsafe` so every call site must establish it.
+#[cfg(all(feature = "uspace", not(feature = "arm-el2")))]
+#[inline]
+pub unsafe fn user_access_ok_page(vaddr: usize, write: bool) -> bool {
+    let par: u64;
+    // SAFETY: `AT` reads the current translation tables and writes `PAR_EL1`;
+    // `mrs` reads it back. No memory is accessed and no flags are clobbered. The
+    // caller holds IRQs off so the `AT`/`mrs` pair is not split by another `AT`.
+    unsafe {
+        if write {
+            asm!(
+                "at s1e0w, {vaddr}",
+                "isb",
+                "mrs {par}, par_el1",
+                vaddr = in(reg) vaddr,
+                par = out(reg) par,
+                options(nostack, preserves_flags),
+            );
+        } else {
+            asm!(
+                "at s1e0r, {vaddr}",
+                "isb",
+                "mrs {par}, par_el1",
+                vaddr = in(reg) vaddr,
+                par = out(reg) par,
+                options(nostack, preserves_flags),
+            );
+        }
+    }
+    // PAR_EL1.F (bit 0): 0 = translation succeeded and the EL0 access is allowed.
+    par & 1 == 0
+}
+
+/// `arm-el2` builds run the hypervisor at EL2, where the EL1&0 `AT` probe does
+/// not describe guest-user access, so always fall back to the locked slow path.
+///
+/// # Safety
+///
+/// No precondition — this stub reads nothing and always returns `false`. It is
+/// `unsafe` only to share the signature of the aarch64 EL1 probe (which requires
+/// IRQs-off), so callers can use one `unsafe` block across all targets.
+#[cfg(all(feature = "uspace", feature = "arm-el2"))]
+#[inline]
+pub unsafe fn user_access_ok_page(_vaddr: usize, _write: bool) -> bool {
+    false
+}

--- a/components/axcpu/src/loongarch64/asm.rs
+++ b/components/axcpu/src/loongarch64/asm.rs
@@ -247,3 +247,18 @@ unsafe extern "C" {
     /// while a value > 0 indicates failure.
     pub fn user_copy(dst: *mut u8, src: *const u8, size: usize) -> usize;
 }
+
+/// Lock-free EL0/user access probe. No hardware address-translation probe is
+/// wired up on this architecture yet, so always report "not fast-path eligible"
+/// and let the caller take the locked slow path (correctness preserved).
+///
+/// # Safety
+///
+/// No precondition — this stub reads nothing and always returns `false`. It is
+/// `unsafe` only to share the signature of the aarch64 EL1 probe (which requires
+/// IRQs-off), so callers can use one `unsafe` block across all targets.
+#[cfg(feature = "uspace")]
+#[inline]
+pub unsafe fn user_access_ok_page(_vaddr: usize, _write: bool) -> bool {
+    false
+}

--- a/components/axcpu/src/riscv/asm.rs
+++ b/components/axcpu/src/riscv/asm.rs
@@ -172,3 +172,18 @@ unsafe extern "C" {
     /// while a value > 0 indicates failure.
     pub fn user_copy(dst: *mut u8, src: *const u8, size: usize) -> usize;
 }
+
+/// Lock-free EL0/user access probe. No hardware address-translation probe is
+/// wired up on this architecture yet, so always report "not fast-path eligible"
+/// and let the caller take the locked slow path (correctness preserved).
+///
+/// # Safety
+///
+/// No precondition — this stub reads nothing and always returns `false`. It is
+/// `unsafe` only to share the signature of the aarch64 EL1 probe (which requires
+/// IRQs-off), so callers can use one `unsafe` block across all targets.
+#[cfg(feature = "uspace")]
+#[inline]
+pub unsafe fn user_access_ok_page(_vaddr: usize, _write: bool) -> bool {
+    false
+}

--- a/components/axcpu/src/x86_64/asm.rs
+++ b/components/axcpu/src/x86_64/asm.rs
@@ -153,3 +153,18 @@ unsafe extern "C" {
     /// while a value > 0 indicates failure.
     pub fn user_copy(dst: *mut u8, src: *const u8, size: usize) -> usize;
 }
+
+/// Lock-free EL0/user access probe. No hardware address-translation probe is
+/// wired up on this architecture yet, so always report "not fast-path eligible"
+/// and let the caller take the locked slow path (correctness preserved).
+///
+/// # Safety
+///
+/// No precondition — this stub reads nothing and always returns `false`. It is
+/// `unsafe` only to share the signature of the aarch64 EL1 probe (which requires
+/// IRQs-off), so callers can use one `unsafe` block across all targets.
+#[cfg(feature = "uspace")]
+#[inline]
+pub unsafe fn user_access_ok_page(_vaddr: usize, _write: bool) -> bool {
+    false
+}

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -65,6 +65,12 @@ SMP = "4"
 [features]
 default = ["dynamic_debug"]
 dev-log = []
+# Lock-free user-copy fast path: probe the HW page table (aarch64 `AT S1E0R/W`)
+# so a syscall copy of already-present, EL0-permitted pages skips the aspace lock
+# and `populate_area`. Off by default; misses fall to the unchanged locked slow
+# path. The probe itself is always compiled (rides ax-cpu `uspace`); this gate
+# only enables its use. Only meaningful on aarch64 (other arches stub to false).
+user-access-fastpath = []
 ext4 = ["ax-fs-ng/ext4"]
 fat = ["ax-fs-ng/fat"]
 input = ["dep:ax-input", "ax-runtime/input"]

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -9,6 +9,8 @@ use core::{
 };
 
 use ax_io::{IoError, prelude::*};
+#[cfg(feature = "user-access-fastpath")]
+use ax_memory_addr::PAGE_SIZE_4K;
 use ax_memory_addr::{MemoryAddr, VirtAddr};
 use ax_runtime::hal::{
     cpu::{
@@ -48,6 +50,73 @@ pub fn access_user_memory<R>(f: impl FnOnce() -> R) -> R {
     result
 }
 
+/// syscall-argument structs are far smaller than this; larger transfers take the
+/// slow path, where the aspace lock is amortized over a large copy anyway.
+#[cfg(feature = "user-access-fastpath")]
+const FASTPATH_MAX_PAGES: usize = 16;
+
+/// Lock-free eligibility probe for a user range: `true` iff every 4 KiB page
+/// covering `[start, start+len)` is already present and EL0-permitted for the
+/// requested access, so the caller can skip the aspace lock and `populate_area`.
+///
+/// A write requires the page present *and* EL0-writable, so a copy-on-write page
+/// (present read-only) correctly misses and routes to the slow path where the COW
+/// copy happens. Any miss / empty / oversized range / address-space overflow
+/// returns `false` and the caller takes the unchanged locked slow path.
+#[cfg(feature = "user-access-fastpath")]
+fn user_range_fast_ok(start: VirtAddr, len: usize, access_flags: MappingFlags) -> bool {
+    if len == 0 {
+        return false;
+    }
+    // Checked arithmetic, mirroring the slow path's `VirtAddrRange::try_from_start_size`
+    // + page rounding: reject to the slow path on any address-space overflow rather
+    // than relying on wrap semantics. `check_region` reaches this with a fully
+    // caller-controlled `start` and no prior range bound, so a hostile top-of-space
+    // pointer must not overflow here (which would panic under an overflow-checks
+    // build); it simply falls through to `can_access_range`, which rejects it.
+    let start = start.as_usize();
+    let Some(end) = start.checked_add(len) else {
+        return false;
+    };
+    let page_start = start & !(PAGE_SIZE_4K - 1);
+    let Some(page_end) = end
+        .checked_add(PAGE_SIZE_4K - 1)
+        .map(|v| v & !(PAGE_SIZE_4K - 1))
+    else {
+        return false;
+    };
+    // `end >= start` and both are rounded the same way, so `page_end >= page_start`.
+    let pages = (page_end - page_start) / PAGE_SIZE_4K;
+    // `pages == 0` is unreachable here: the `len == 0` early return plus
+    // `page_end > page_start` guarantee `pages >= 1`. It is kept as a defensive
+    // guard so the range cap still holds if either invariant is later removed.
+    if pages == 0 || pages > FASTPATH_MAX_PAGES {
+        return false;
+    }
+    // A write access requires the page to be present *and* EL0-writable; a
+    // copy-on-write page is present-read-only, so a write probe correctly misses
+    // and routes to the slow path where `populate_area` performs the COW copy.
+    let write = access_flags.contains(MappingFlags::WRITE);
+
+    // IRQs off across the whole probe: `PAR_EL1` is a per-CPU scratch register
+    // shared with any interrupt handler that also executes an `AT`. Disabling
+    // IRQs guarantees no other `AT` runs on this CPU between our `AT` and the
+    // `mrs` that reads the result. The range is capped, so the window is a
+    // handful of instructions.
+    let _guard = crate::sync::PreemptIrqSaveGuard::new();
+    let mut page = page_start;
+    while page < page_end {
+        // SAFETY: IRQs are disabled for the whole loop by the guard above, which
+        // is `user_access_ok_page`'s precondition (`PAR_EL1` not clobbered by a
+        // concurrent `AT` on this CPU).
+        if !unsafe { ax_runtime::hal::cpu::asm::user_access_ok_page(page, write) } {
+            return false;
+        }
+        page += PAGE_SIZE_4K;
+    }
+    true
+}
+
 fn check_region(start: VirtAddr, layout: Layout, access_flags: MappingFlags) -> StarryResult<()> {
     let align = layout.align();
     if start.as_usize() & (align - 1) != 0 {
@@ -68,6 +137,15 @@ fn check_region(start: VirtAddr, layout: Layout, access_flags: MappingFlags) -> 
     if unsafe { aspace_arc.raw() }.is_owned_by_current() {
         return Err(StarryError::BadAddress);
     }
+
+    // Lock-free fast path: if every page is already present with the requested
+    // permission, the later dereference will not fault, so skip the aspace lock
+    // and `populate_area`. Misses fall through to the locked slow path.
+    #[cfg(feature = "user-access-fastpath")]
+    if user_range_fast_ok(start, layout.size(), access_flags) {
+        return Ok(());
+    }
+
     let mut aspace = aspace_arc.lock();
 
     if !aspace.can_access_range(start, layout.size(), access_flags) {
@@ -356,6 +434,14 @@ fn prepare_user_memory(op: &str, start: usize, len: usize, access_flags: Mapping
     let aspace_arc = thr.proc_data.aspace();
     if unsafe { aspace_arc.raw() }.is_owned_by_current() {
         return Err(VmError::AccessDenied);
+    }
+
+    // Lock-free fast path: if every page is already present with the requested
+    // permission, the copy will not fault, so skip the aspace lock and
+    // `populate_area`. Misses fall through to the locked slow path.
+    #[cfg(feature = "user-access-fastpath")]
+    if user_range_fast_ok(start, len, access_flags) {
+        return Ok(());
     }
 
     let mut aspace = aspace_arc.lock();

--- a/test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -10,6 +10,10 @@ features = [
   "ax-driver/xhci-pci",
   "starry-kernel/input",
   "starry-kernel/vsock",
+  # Exercise the lock-free user-copy fast path across the whole aarch64 suite
+  # (the AT-probe consumer of ax-cpu `user_access_ok_page`); every syscall copy
+  # of present pages now takes it, with the COW/not-present cases covered below.
+  "starry-kernel/user-access-fastpath",
 ]
 max_cpu_num = 4
 log = "Warn"

--- a/test-suit/starryos/qemu/system/bugfix-usercopy-fastpath-cow-write/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-usercopy-fastpath-cow-write/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.20)
+project(usercopy-fastpath-cow-write C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+add_executable(usercopy-fastpath-cow-write src/main.c)
+target_compile_options(usercopy-fastpath-cow-write PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS usercopy-fastpath-cow-write RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-usercopy-fastpath-cow-write/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-usercopy-fastpath-cow-write/src/main.c
@@ -4,9 +4,13 @@
 // covered page is already present with the requested EL0 permission; it must
 // otherwise fall through to the unchanged locked slow path. The subtle case is
 // a write: a copy-on-write page is present but read-only, so the write probe
-// must MISS and let the slow path perform the COW copy. These cases run through
-// the real syscall user-copy path, so with the fast path enabled they exercise
-// it directly.
+// must MISS and let the slow path perform the COW copy. A third case covers a
+// moved-away address after an `mremap` move: `mremap` clears the source PTEs
+// (and flushes the TLB) before it drops the source VMA, so there is never a
+// "stale PTE, no VMA" window; the fast path must fault on the old address just
+// like the slow path and must not treat an absent old PTE as accessible. These
+// cases run through the real syscall user-copy path, so with the fast path
+// enabled they exercise it directly.
 #define _GNU_SOURCE
 #include <errno.h>
 #include <stdio.h>
@@ -131,12 +135,93 @@ static void cow_page_write_via_syscall(void)
     munmap(page, 4096);
 }
 
+// After an `mremap` move, the old address has no live PTE: mremap relocates the
+// source page-table entries (clearing each and flushing the TLB) before it drops
+// the source VMA metadata. A syscall user-copy targeting the moved-away old
+// address must therefore fault on the AT-probe fast path exactly as on the
+// locked slow path -- the fast path must not treat the absent old PTE as
+// accessible. read() copies into the buffer (the same copy_to_user path the COW
+// case uses); it must return EFAULT.
+static void mremap_moved_page_faults_on_old_address(void)
+{
+    long ps = sysconf(_SC_PAGESIZE);
+    if (ps <= 0) {
+        note_fail("sysconf(_SC_PAGESIZE)", strerror(errno));
+        return;
+    }
+    size_t page_size = (size_t)ps;
+
+    // Reserve a distinct destination so MREMAP_FIXED performs a real move
+    // (old != new), guaranteeing the source PTEs are relocated and cleared.
+    char *dst = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    char *src = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (dst == MAP_FAILED || src == MAP_FAILED) {
+        note_fail("mmap mremap pages", strerror(errno));
+        return;
+    }
+    src[0] = 'Z'; // present + writable before the move
+
+    void *moved = mremap(src, page_size, page_size,
+                         MREMAP_MAYMOVE | MREMAP_FIXED, dst);
+    if (moved == MAP_FAILED) {
+        note_fail("mremap move", strerror(errno));
+        munmap(src, page_size);
+        munmap(dst, page_size);
+        return;
+    }
+    if (moved != dst) {
+        note_fail("mremap move target", "moved != dst");
+        munmap(dst, page_size);
+        return;
+    }
+    // The data relocated -> the source PTE was cleared by the move, not left
+    // stale at the old address.
+    if (dst[0] != 'Z') {
+        note_fail("mremap data relocation", "dst[0] != 'Z'");
+        munmap(dst, page_size);
+        return;
+    }
+
+    // `src` is now a moved-away address with no VMA and no PTE. Have the kernel
+    // copy INTO it via read() and require EFAULT: the fast-path write probe
+    // misses on the absent PTE, and the slow path rejects the missing VMA.
+    int pfd[2];
+    if (pipe(pfd) != 0) {
+        note_fail("mremap pipe", strerror(errno));
+        munmap(dst, page_size);
+        return;
+    }
+    if (write(pfd[1], "x", 1) != 1) {
+        note_fail("mremap pipe write", strerror(errno));
+        close(pfd[0]);
+        close(pfd[1]);
+        munmap(dst, page_size);
+        return;
+    }
+    errno = 0;
+    ssize_t n = read(pfd[0], src, 1);
+    if (n == -1 && errno == EFAULT) {
+        note_pass("mremap moved page: user-copy to old address faults");
+    } else {
+        char detail[96];
+        snprintf(detail, sizeof(detail), "n=%zd errno=%d (%s)", n, errno,
+                 strerror(errno));
+        note_fail("mremap moved page fault", detail);
+    }
+    close(pfd[0]);
+    close(pfd[1]);
+    munmap(dst, page_size);
+}
+
 int main(void)
 {
     printf("=== usercopy-fastpath-cow-write ===\n");
 
     present_page_fastpath_hit();
     cow_page_write_via_syscall();
+    mremap_moved_page_faults_on_old_address();
 
     printf("=== Results: %d passed, %d failed ===\n", passed, failed);
     if (failed == 0) {

--- a/test-suit/starryos/qemu/system/bugfix-usercopy-fastpath-cow-write/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-usercopy-fastpath-cow-write/src/main.c
@@ -1,0 +1,148 @@
+// Correctness guard for the lock-free user-copy fast path
+// (`starry-kernel/user-access-fastpath`, the consumer of ax-cpu
+// `user_access_ok_page`). The fast path skips the aspace lock only when every
+// covered page is already present with the requested EL0 permission; it must
+// otherwise fall through to the unchanged locked slow path. The subtle case is
+// a write: a copy-on-write page is present but read-only, so the write probe
+// must MISS and let the slow path perform the COW copy. These cases run through
+// the real syscall user-copy path, so with the fast path enabled they exercise
+// it directly.
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+static int passed;
+static int failed;
+
+static void note_pass(const char *name)
+{
+    printf("PASS: %s\n", name);
+    passed++;
+}
+
+static void note_fail(const char *name, const char *detail)
+{
+    printf("FAIL: %s: %s\n", name, detail);
+    failed++;
+}
+
+// A present, EL0-writable page: the fast path's write probe hits, so the kernel
+// writes through it without the aspace lock. Uses getcwd (a copy_to_user).
+static void present_page_fastpath_hit(void)
+{
+    char *buf = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (buf == MAP_FAILED) {
+        note_fail("mmap present page", strerror(errno));
+        return;
+    }
+    buf[0] = 'x'; // fault in -> present + writable
+
+    if (chdir("/") != 0) {
+        note_fail("chdir /", strerror(errno));
+        munmap(buf, 4096);
+        return;
+    }
+    errno = 0;
+    char *ret = getcwd(buf, 4096);
+    if (ret == buf && strcmp(buf, "/") == 0) {
+        note_pass("present writable page: syscall write hits fast path");
+    } else {
+        char detail[128];
+        snprintf(detail, sizeof(detail), "ret=%p errno=%d (%s) buf='%s'",
+                 (void *)ret, errno, strerror(errno), buf);
+        note_fail("present writable page write", detail);
+    }
+    munmap(buf, 4096);
+}
+
+// A copy-on-write page is present but read-only, so the fast path's write probe
+// must miss and route to the slow path, which performs the COW copy. A child
+// reads a payload from a pipe into its COW page (a kernel write via the
+// user-copy path); the write must succeed and stay private to the child.
+static void cow_page_write_via_syscall(void)
+{
+    int pfd[2];
+    if (pipe(pfd) != 0) {
+        note_fail("pipe", strerror(errno));
+        return;
+    }
+
+    char *page = mmap(NULL, 4096, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (page == MAP_FAILED) {
+        note_fail("mmap cow page", strerror(errno));
+        return;
+    }
+    page[0] = 'A'; // fault in; fork() below marks this page COW read-only
+
+    static const char payload[] = "COW-WRITE-OK";
+    pid_t pid = fork();
+    if (pid < 0) {
+        note_fail("fork", strerror(errno));
+        munmap(page, 4096);
+        return;
+    }
+    if (pid == 0) {
+        // Child: `page` is a present, read-only COW page shared with the parent.
+        // read() has the kernel write the payload into it via the user-copy
+        // path -> fast-path write probe misses (read-only) -> slow path
+        // COW-copies the page so the write lands.
+        close(pfd[1]);
+        size_t got = 0;
+        while (got < sizeof(payload)) {
+            ssize_t n = read(pfd[0], page + got, sizeof(payload) - got);
+            if (n <= 0) {
+                _exit(2);
+            }
+            got += (size_t)n;
+        }
+        _exit(memcmp(page, payload, sizeof(payload)) == 0 ? 0 : 3);
+    }
+
+    // Parent: feed the payload, wait, verify the child's write succeeded and our
+    // copy is untouched (COW isolation).
+    close(pfd[0]);
+    if (write(pfd[1], payload, sizeof(payload)) != (ssize_t)sizeof(payload)) {
+        note_fail("parent write to pipe", strerror(errno));
+    }
+    close(pfd[1]);
+
+    int st = 0;
+    waitpid(pid, &st, 0);
+    if (WIFEXITED(st) && WEXITSTATUS(st) == 0) {
+        note_pass("COW page written via read(): fast path misses -> slow-path COW");
+    } else {
+        char detail[96];
+        snprintf(detail, sizeof(detail), "child status=%d", st);
+        note_fail("COW page write via syscall", detail);
+    }
+    if (page[0] == 'A') {
+        note_pass("parent copy preserved (COW isolation)");
+    } else {
+        char detail[64];
+        snprintf(detail, sizeof(detail), "page[0]=%d expected 'A'", page[0]);
+        note_fail("COW isolation", detail);
+    }
+    munmap(page, 4096);
+}
+
+int main(void)
+{
+    printf("=== usercopy-fastpath-cow-write ===\n");
+
+    present_page_fastpath_hit();
+    cow_page_write_via_syscall();
+
+    printf("=== Results: %d passed, %d failed ===\n", passed, failed);
+    if (failed == 0) {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+    printf("SOME TESTS FAILED\n");
+    return 1;
+}


### PR DESCRIPTION
## 问题
#2011（`feat/ax-cpu-user-access-ok`）新增了 `user_access_ok_page`（aarch64 `AT S1E0R/W` 硬件页表探测）原语，但内核尚无消费者：每次 syscall 的用户内存访问仍走 `check_region` / `prepare_user_memory` 的加锁慢路径（取 aspace 锁 + `populate_area`），即便目标页早已存在且具备所需权限。

## 改动
- 新增 feature `user-access-fastpath`（默认关闭）。开启后，`check_region` 与 `prepare_user_memory` 在取 aspace 锁之前先做一次无锁探测 `user_range_fast_ok`：若覆盖范围内每一页都已存在且具备所需 EL0 权限，则直接返回、跳过锁与 `populate_area`；任何未命中都回退到原有加锁慢路径。
- `user_range_fast_ok` 用溢出安全的分页取整 + 页数上限（16 页）界定探测窗口，在关中断（`PreemptIrqSaveGuard`；`PAR_EL1` 为 per-CPU 且与中断中的 `AT` 共享）下逐页调用 `user_access_ok_page`。写访问要求页存在且 EL0 可写，故 COW（存在但只读）页的写探测必然未命中并回退到慢路径完成 COW 拷贝。
- 在 aarch64 qemu 测试构建启用该 feature，使整套 qemu 用例都经由 fast path；并新增/扩充 `bugfix-usercopy-fastpath-cow-write` 用例覆盖关键回退情形。

## 逻辑
fast path 与慢路径行为等价，仅在“全部页已就绪”时省去锁与建映射。因此在现有整套 qemu 用例（大量 present 页的 syscall 拷贝）之上开启该 feature 即为直接覆盖；新增用例补齐 not-present / COW 的回退语义。

## 测试
- `bugfix-usercopy-fastpath-cow-write`：(1) present+可写页经 `getcwd` 命中 fast path 写入成功；(2) `fork` 后的 COW 只读页经 `read()` 写入时 fast path 未命中、由慢路径 COW 拷贝完成，且对父进程隔离（父副本保持不变）；(3) `mremap` 移动（`MREMAP_FIXED` 强制 old != new）后，对旧地址 `read()` 拷入必须返回 EFAULT——`mremap` 先经 `move_pages` 清除源 PTE 并刷 TLB、再删除源 VMA，不存在“PTE 尚在、VMA 已除”窗口，故 fast path 在缺失 PTE 上未命中、慢路径因 VMA 缺失而 EFAULT，与关闭 fast path 一致。本地已在 Linux 上验证三例全绿、`-Wall -Wextra -Werror` 无告警。
- `cargo fmt` 通过；`starry-kernel`（开启 `user-access-fastpath`）clippy 通过。

---
本 PR 基于 #2011（`feat/ax-cpu-user-access-ok`），作为其 `user_access_ok_page` 原语的实际消费者；建议与 #2011 一同合入（在 #2011 合入 dev 后本 PR diff 将自动收敛为仅消费者改动）。

