### PR TITLE
feat(ax-task): capacity-aware big.LITTLE task placement consuming cpu_capacities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ dependencies = [
  "axtest",
  "cfg-if",
  "cpu-local",
+ "fdt-edit",
  "fdt-parser",
  "heapless",
  "log",

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -103,6 +103,10 @@ sg2002-cvi-usb-camera = [
     "dep:sg200x-jpu",
 ]
 smp = ["ax-std/smp"]
+# Capacity-aware big.LITTLE initial task placement (spawn/clone steered to the
+# least-loaded eligible core, preferring a big core when idle). Placement-only, no
+# continuous migration. See ax-task's `sched-loadbalance`.
+sched-loadbalance = ["ax-task/sched-loadbalance"]
 stack-guard-page = ["ax-runtime/stack-guard-page"]
 stack-protector = ["ax-runtime/stack-protector"]
 axtest = []

--- a/os/arceos/modules/axhal/Cargo.toml
+++ b/os/arceos/modules/axhal/Cargo.toml
@@ -64,6 +64,9 @@ page-table-generic = { workspace = true, optional = true }
 rdrive.workspace = true
 thiserror.workspace = true
 
+[dev-dependencies]
+fdt-edit = { workspace = true }
+
 [build-dependencies]
 quote = { workspace = true }
 

--- a/os/arceos/modules/axhal/src/dtb.rs
+++ b/os/arceos/modules/axhal/src/dtb.rs
@@ -50,3 +50,71 @@ pub fn get_chosen_bootargs() -> Option<&'static str> {
 
     *CACHED_BOOTARGS
 }
+
+/// Upper bound on the number of logical CPUs, sizing the [`cpu_capacities`]
+/// table. Mirrors the build-time bound [`crate::cpu_num`] uses (the `SMP`
+/// build-env-configured max under the `smp` feature); with `smp` disabled
+/// there is always exactly one CPU.
+#[cfg(feature = "smp")]
+const MAX_CPU_NUM: usize = crate::build_info::CPU_CAPACITY;
+#[cfg(not(feature = "smp"))]
+const MAX_CPU_NUM: usize = 1;
+
+/// Fallback capacity when the DT gives no hint (all-equal => homogeneous/QEMU
+/// degrades to plain load-spreading).
+const DEFAULT_CPU_CAPACITY: u16 = 1024;
+
+/// Per-logical-CPU normalized compute capacity (A76 ~ 1024 / A55 ~ 530), indexed
+/// by logical `cpu_id`. Built once from the cached FDT.
+pub fn cpu_capacities() -> &'static [u16; MAX_CPU_NUM] {
+    static CACHED_CAPS: LazyLock<[u16; MAX_CPU_NUM]> = LazyLock::new(build_cpu_capacities);
+    &CACHED_CAPS
+}
+
+fn build_cpu_capacities() -> [u16; MAX_CPU_NUM] {
+    let mut caps = [DEFAULT_CPU_CAPACITY; MAX_CPU_NUM];
+    let Some(fdt) = get_fdt() else {
+        return caps;
+    };
+    // `all_nodes()` yields device-tree order; the N-th `cpu@*` node is logical
+    // CPU N (matches boot's `.enumerate()` cpu_id mapping). Do NOT key by `reg`.
+    let mut idx = 0usize;
+    for node in fdt.all_nodes() {
+        if idx >= caps.len() {
+            break;
+        }
+        if !node.name().starts_with("cpu@") {
+            continue;
+        }
+        // Skip firmware-disabled CPUs (status != okay/ok) so `idx` stays aligned
+        // with boot's `.enumerate()` cpu_id mapping, which also skips them.
+        // Mirrors someboot's is_cpu_node_available (platforms/someboot/src/fdt).
+        let available = node
+            .find_property("status")
+            .map(|p| matches!(p.str(), "okay" | "ok"))
+            .unwrap_or(true);
+        if !available {
+            continue;
+        }
+        let cap = node
+            .find_property("capacity-dmips-mhz")
+            .map(|p| p.u32() as u16)
+            .filter(|&c| c != 0)
+            .or_else(|| {
+                node.compatibles().find_map(|compat| {
+                    if compat.contains("cortex-a55") {
+                        Some(530)
+                    } else if compat.contains("cortex-a76") {
+                        Some(1024)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .unwrap_or(DEFAULT_CPU_CAPACITY);
+        caps[idx] = cap;
+        idx += 1;
+    }
+    log::info!("cpu_capacities: {:?}", &caps[..idx.max(1)]);
+    caps
+}

--- a/os/arceos/modules/axhal/src/dtb.rs
+++ b/os/arceos/modules/axhal/src/dtb.rs
@@ -6,14 +6,14 @@ use fdt_parser::{Fdt, Node};
 
 static BOOTARG: OnceLock<usize> = OnceLock::new();
 
-/// Returns the physical address to probe for DTB.
+/// Returns the physical address to probe for DTB, or `None` if no boot argument was
+/// installed (e.g. host unit tests, or any path that never called [`init`]). The FDT
+/// probe (and thus [`cpu_capacities`]) must degrade to "no device tree" rather than
+/// panic in that case, so this reads the boot arg as an `Option` instead of via the
+/// strict [`get_bootarg`].
 fn dtb_paddr_from_boot_context() -> Option<usize> {
-    let arg = get_bootarg();
-    if arg != 0 {
-        return Some(arg);
-    }
-
-    None
+    let arg = BOOTARG.get().copied()?;
+    if arg != 0 { Some(arg) } else { None }
 }
 
 /// Initializes the boot argument.

--- a/os/arceos/modules/axhal/src/dtb.rs
+++ b/os/arceos/modules/axhal/src/dtb.rs
@@ -72,12 +72,24 @@ pub fn cpu_capacities() -> &'static [u16; MAX_CPU_NUM] {
 }
 
 fn build_cpu_capacities() -> [u16; MAX_CPU_NUM] {
-    let mut caps = [DEFAULT_CPU_CAPACITY; MAX_CPU_NUM];
     let Some(fdt) = get_fdt() else {
-        return caps;
+        return [DEFAULT_CPU_CAPACITY; MAX_CPU_NUM];
     };
-    // `all_nodes()` yields device-tree order; the N-th `cpu@*` node is logical
-    // CPU N (matches boot's `.enumerate()` cpu_id mapping). Do NOT key by `reg`.
+    caps_from_fdt(fdt)
+}
+
+/// Parse per-logical-CPU normalized compute capacities from `fdt`, indexed by
+/// logical `cpu_id`.
+///
+/// `all_nodes()` yields device-tree order; the N-th *enabled* `cpu@*` node is
+/// logical CPU N (matching boot's `.enumerate()` cpu_id mapping — do NOT key by
+/// `reg`). Firmware-disabled CPUs are skipped so the index stays aligned. Each
+/// node's capacity comes from `capacity-dmips-mhz`, else a `cortex-a55`/`a76`
+/// compatible fallback, else [`DEFAULT_CPU_CAPACITY`]. Generic over the table
+/// size `N` so it can be unit-tested with fixture device trees independent of
+/// the build-time [`MAX_CPU_NUM`].
+fn caps_from_fdt<const N: usize>(fdt: &Fdt) -> [u16; N] {
+    let mut caps = [DEFAULT_CPU_CAPACITY; N];
     let mut idx = 0usize;
     for node in fdt.all_nodes() {
         if idx >= caps.len() {
@@ -117,4 +129,125 @@ fn build_cpu_capacities() -> [u16; MAX_CPU_NUM] {
     }
     log::info!("cpu_capacities: {:?}", &caps[..idx.max(1)]);
     caps
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+
+    use fdt_edit::{Fdt as EditFdt, Node, Property};
+    use fdt_parser::Fdt as ParsedFdt;
+
+    use super::{DEFAULT_CPU_CAPACITY, caps_from_fdt};
+
+    /// Fixture description of one `cpu@*` device-tree node.
+    struct CpuSpec {
+        status: Option<&'static str>,
+        compatible: Option<&'static str>,
+        dmips: Option<u32>,
+    }
+
+    fn cpu(
+        status: Option<&'static str>,
+        compatible: Option<&'static str>,
+        dmips: Option<u32>,
+    ) -> CpuSpec {
+        CpuSpec {
+            status,
+            compatible,
+            dmips,
+        }
+    }
+
+    fn str_prop(name: &str, value: &str) -> Property {
+        let mut data = value.as_bytes().to_vec();
+        data.push(0); // device-tree strings are NUL-terminated
+        Property::new(name, data)
+    }
+
+    fn u32_prop(name: &str, value: u32) -> Property {
+        Property::new(name, value.to_be_bytes().to_vec())
+    }
+
+    /// Build a `/cpus` device tree with the given CPUs, encode it to a DTB blob,
+    /// parse it back through the same `fdt_parser` path `build_cpu_capacities`
+    /// uses, and compute the capacity table (fixed `N = 8` regardless of the
+    /// build-time `MAX_CPU_NUM`).
+    fn caps_of(cpus: &[CpuSpec]) -> [u16; 8] {
+        let mut fdt = EditFdt::new();
+        let root = fdt.root_id();
+        let cpus_node = fdt.add_node(root, Node::new("cpus"));
+        fdt.node_mut(cpus_node)
+            .unwrap()
+            .set_property(u32_prop("#address-cells", 1));
+        fdt.node_mut(cpus_node)
+            .unwrap()
+            .set_property(u32_prop("#size-cells", 0));
+
+        for (i, spec) in cpus.iter().enumerate() {
+            let id = fdt.add_node(cpus_node, Node::new(&format!("cpu@{i}")));
+            let node = fdt.node_mut(id).unwrap();
+            node.set_property(str_prop("device_type", "cpu"));
+            node.set_property(u32_prop("reg", i as u32));
+            if let Some(status) = spec.status {
+                node.set_property(str_prop("status", status));
+            }
+            if let Some(compatible) = spec.compatible {
+                node.set_property(str_prop("compatible", compatible));
+            }
+            if let Some(dmips) = spec.dmips {
+                node.set_property(u32_prop("capacity-dmips-mhz", dmips));
+            }
+        }
+
+        let bytes = fdt.encode().as_ref().to_vec();
+        let parsed = ParsedFdt::from_bytes(&bytes).expect("fixture DTB should parse");
+        caps_from_fdt::<8>(&parsed)
+    }
+
+    #[test]
+    fn compatible_fallback_maps_a76_and_a55() {
+        let caps = caps_of(&[
+            cpu(None, Some("arm,cortex-a76"), None),
+            cpu(None, Some("arm,cortex-a55"), None),
+        ]);
+        assert_eq!(caps[0], 1024, "cortex-a76 -> 1024");
+        assert_eq!(caps[1], 530, "cortex-a55 -> 530");
+        // A CPU with no matching node keeps the default.
+        assert_eq!(caps[2], DEFAULT_CPU_CAPACITY);
+    }
+
+    #[test]
+    fn unknown_compatible_uses_default_capacity() {
+        let caps = caps_of(&[cpu(None, Some("arm,cortex-unknown"), None)]);
+        assert_eq!(caps[0], DEFAULT_CPU_CAPACITY);
+    }
+
+    #[test]
+    fn explicit_dmips_property_wins_over_compatible() {
+        let caps = caps_of(&[cpu(None, Some("arm,cortex-a55"), Some(900))]);
+        assert_eq!(
+            caps[0], 900,
+            "explicit capacity-dmips-mhz overrides the compatible fallback"
+        );
+    }
+
+    /// Regression for the disabled-CPU skip: a firmware-disabled `cpu@` node
+    /// interleaved before enabled ones must not consume a logical index, or every
+    /// subsequent capacity is shifted off its `cpu_id`. The pre-fix
+    /// implementation counted disabled nodes and fails this.
+    #[test]
+    fn disabled_cpu_node_does_not_shift_logical_indices() {
+        let caps = caps_of(&[
+            cpu(Some("disabled"), Some("arm,cortex-a55"), None),
+            cpu(Some("okay"), Some("arm,cortex-a76"), None),
+            cpu(None, Some("arm,cortex-a55"), None),
+        ]);
+        // Disabled cpu@0 is skipped: logical CPU 0 is the a76, CPU 1 the a55.
+        assert_eq!(
+            caps[0], 1024,
+            "disabled cpu@0 must not occupy logical index 0"
+        );
+        assert_eq!(caps[1], 530);
+    }
 }

--- a/os/arceos/modules/axhal/src/dtb.rs
+++ b/os/arceos/modules/axhal/src/dtb.rs
@@ -2,7 +2,7 @@
 use core::ptr::NonNull;
 
 use ax_lazyinit::{LazyLock, OnceLock};
-use fdt_parser::Fdt;
+use fdt_parser::{Fdt, Node};
 
 static BOOTARG: OnceLock<usize> = OnceLock::new();
 
@@ -78,62 +78,111 @@ fn build_cpu_capacities() -> [u16; MAX_CPU_NUM] {
     caps_from_fdt(fdt)
 }
 
+/// A `cpu@*` device-tree node the boot path treats as a real, enabled CPU.
+///
+/// Mirrors someboot's `is_cpu_node_available` (platforms/someboot/src/fdt) so
+/// this table's logical indices line up with boot's `.enumerate()` cpu_id
+/// mapping: the node is named `cpu@*`, is not firmware-disabled, and either has
+/// no `device_type` or declares `device_type = "cpu"` (nodes that reuse a
+/// `cpu@` name for something else are excluded).
+fn is_cpu_node_available(node: &Node) -> bool {
+    node.name().starts_with("cpu@")
+        && matches!(
+            node.find_property("device_type").map(|p| p.str()),
+            None | Some("cpu")
+        )
+        && matches!(
+            node.find_property("status").map(|p| p.str()),
+            None | Some("okay") | Some("ok")
+        )
+}
+
 /// Parse per-logical-CPU normalized compute capacities from `fdt`, indexed by
 /// logical `cpu_id`.
 ///
-/// `all_nodes()` yields device-tree order; the N-th *enabled* `cpu@*` node is
-/// logical CPU N (matching boot's `.enumerate()` cpu_id mapping — do NOT key by
-/// `reg`). Firmware-disabled CPUs are skipped so the index stays aligned. Each
-/// node's capacity comes from `capacity-dmips-mhz`, else a `cortex-a55`/`a76`
-/// compatible fallback, else [`DEFAULT_CPU_CAPACITY`]. Generic over the table
-/// size `N` so it can be unit-tested with fixture device trees independent of
-/// the build-time [`MAX_CPU_NUM`].
+/// Only the direct `cpu@*` children of `/cpus` are considered, filtered by
+/// [`is_cpu_node_available`] and taken in device-tree order (the N-th enabled
+/// node is logical CPU N — do NOT key by `reg`); this matches boot's CPU
+/// enumeration so a stray `cpu@*` node elsewhere in the tree cannot shift the
+/// indices. Each CPU's capacity comes from `capacity-dmips-mhz` (a raw relative
+/// value), else a `cortex-a55`/`a76` compatible fallback, else
+/// [`DEFAULT_CPU_CAPACITY`].
+///
+/// `capacity-dmips-mhz` values are normalized so the largest maps to
+/// `SCHED_CAPACITY_SCALE` (1024), the same convention Linux uses; the compat and
+/// default fallbacks are already on the 1024 scale and are left untouched, so
+/// raw DMIPS/MHz numbers can never leak into the table at a different scale.
+///
+/// Generic over the table size `N` so it can be unit-tested with fixture device
+/// trees independent of the build-time [`MAX_CPU_NUM`].
 fn caps_from_fdt<const N: usize>(fdt: &Fdt) -> [u16; N] {
-    let mut caps = [DEFAULT_CPU_CAPACITY; N];
-    let mut idx = 0usize;
+    // Pass 1: select the enabled `/cpus` children, recording each CPU's raw
+    // `capacity-dmips-mhz` (if any) and its already-1024-scaled compat/default
+    // fallback, in logical-cpu_id order.
+    let mut raw_dmips = [None::<u32>; N];
+    let mut fallback = [DEFAULT_CPU_CAPACITY; N];
+    let mut count = 0usize;
+
+    let mut cpus_level: Option<usize> = None;
     for node in fdt.all_nodes() {
-        if idx >= caps.len() {
-            break;
-        }
-        if !node.name().starts_with("cpu@") {
-            continue;
-        }
-        // Skip firmware-disabled CPUs (status != okay/ok) so `idx` stays aligned
-        // with boot's `.enumerate()` cpu_id mapping, which also skips them.
-        // Mirrors someboot's is_cpu_node_available (platforms/someboot/src/fdt).
-        let available = node
-            .find_property("status")
-            .map(|p| matches!(p.str(), "okay" | "ok"))
-            .unwrap_or(true);
-        if !available {
-            continue;
-        }
-        let cap = node
-            .find_property("capacity-dmips-mhz")
-            .map(|p| p.u32() as u16)
-            .filter(|&c| c != 0)
-            .or_else(|| {
-                node.compatibles().find_map(|compat| {
-                    if compat.contains("cortex-a55") {
-                        Some(530)
-                    } else if compat.contains("cortex-a76") {
-                        Some(1024)
-                    } else {
-                        None
+        match cpus_level {
+            None => {
+                if node.name() == "cpus" {
+                    cpus_level = Some(node.level);
+                }
+            }
+            Some(cpus_level) => {
+                // Left the `/cpus` subtree: no more CPU nodes follow.
+                if node.level <= cpus_level {
+                    break;
+                }
+                // Only direct children of `/cpus` are CPUs; skip deeper descendants.
+                if node.level == cpus_level + 1 && is_cpu_node_available(&node) {
+                    if count >= N {
+                        break;
                     }
-                })
-            })
-            .unwrap_or(DEFAULT_CPU_CAPACITY);
-        caps[idx] = cap;
-        idx += 1;
+                    raw_dmips[count] = node
+                        .find_property("capacity-dmips-mhz")
+                        .map(|p| p.u32())
+                        .filter(|&c| c != 0);
+                    fallback[count] = node
+                        .compatibles()
+                        .find_map(|compat| {
+                            if compat.contains("cortex-a55") {
+                                Some(530)
+                            } else if compat.contains("cortex-a76") {
+                                Some(1024)
+                            } else {
+                                None
+                            }
+                        })
+                        .unwrap_or(DEFAULT_CPU_CAPACITY);
+                    count += 1;
+                }
+            }
+        }
     }
-    log::info!("cpu_capacities: {:?}", &caps[..idx.max(1)]);
+
+    // Pass 2: normalize the raw DMIPS/MHz values against the largest so it maps
+    // to 1024; leave compat/default fallbacks (already 1024-scaled) as-is.
+    let max_dmips = raw_dmips[..count].iter().flatten().copied().max();
+
+    let mut caps = [DEFAULT_CPU_CAPACITY; N];
+    for i in 0..count {
+        caps[i] = match (raw_dmips[i], max_dmips) {
+            // u64 math so a large/garbage `capacity-dmips-mhz` can't overflow the
+            // `* 1024` scale; the result is clamped into `[1, 1024]` regardless.
+            (Some(dmips), Some(max)) => (dmips as u64 * 1024 / max as u64).clamp(1, 1024) as u16,
+            _ => fallback[i],
+        };
+    }
+    log::info!("cpu_capacities: {:?}", &caps[..count.max(1)]);
     caps
 }
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
+    use alloc::{format, vec::Vec};
 
     use fdt_edit::{Fdt as EditFdt, Node, Property};
     use fdt_parser::Fdt as ParsedFdt;
@@ -142,17 +191,20 @@ mod tests {
 
     /// Fixture description of one `cpu@*` device-tree node.
     struct CpuSpec {
+        device_type: Option<&'static str>,
         status: Option<&'static str>,
         compatible: Option<&'static str>,
         dmips: Option<u32>,
     }
 
+    /// A normal enabled CPU node (`device_type = "cpu"`).
     fn cpu(
         status: Option<&'static str>,
         compatible: Option<&'static str>,
         dmips: Option<u32>,
     ) -> CpuSpec {
         CpuSpec {
+            device_type: Some("cpu"),
             status,
             compatible,
             dmips,
@@ -169,11 +221,9 @@ mod tests {
         Property::new(name, value.to_be_bytes().to_vec())
     }
 
-    /// Build a `/cpus` device tree with the given CPUs, encode it to a DTB blob,
-    /// parse it back through the same `fdt_parser` path `build_cpu_capacities`
-    /// uses, and compute the capacity table (fixed `N = 8` regardless of the
-    /// build-time `MAX_CPU_NUM`).
-    fn caps_of(cpus: &[CpuSpec]) -> [u16; 8] {
+    /// Build a device tree with `/cpus` holding `cpus`, optionally adding a stray
+    /// `cpu@*` node at the root (outside `/cpus`). Returns the encoded DTB blob.
+    fn build_dtb(cpus: &[CpuSpec], stray_root_cpu: Option<&str>) -> Vec<u8> {
         let mut fdt = EditFdt::new();
         let root = fdt.root_id();
         let cpus_node = fdt.add_node(root, Node::new("cpus"));
@@ -187,7 +237,9 @@ mod tests {
         for (i, spec) in cpus.iter().enumerate() {
             let id = fdt.add_node(cpus_node, Node::new(&format!("cpu@{i}")));
             let node = fdt.node_mut(id).unwrap();
-            node.set_property(str_prop("device_type", "cpu"));
+            if let Some(device_type) = spec.device_type {
+                node.set_property(str_prop("device_type", device_type));
+            }
             node.set_property(u32_prop("reg", i as u32));
             if let Some(status) = spec.status {
                 node.set_property(str_prop("status", status));
@@ -200,7 +252,23 @@ mod tests {
             }
         }
 
-        let bytes = fdt.encode().as_ref().to_vec();
+        if let Some(name) = stray_root_cpu {
+            // A `cpu@*` node directly under the root, not under `/cpus`. A scan
+            // that matched `cpu@*` anywhere in the tree would wrongly count it.
+            let id = fdt.add_node(root, Node::new(name));
+            let node = fdt.node_mut(id).unwrap();
+            node.set_property(str_prop("device_type", "cpu"));
+            node.set_property(str_prop("compatible", "arm,cortex-a55"));
+        }
+
+        fdt.encode().as_ref().to_vec()
+    }
+
+    /// Encode `cpus` under `/cpus`, parse through the same `fdt_parser` path
+    /// `build_cpu_capacities` uses, and compute the capacity table (fixed
+    /// `N = 8`, independent of the build-time `MAX_CPU_NUM`).
+    fn caps_of(cpus: &[CpuSpec]) -> [u16; 8] {
+        let bytes = build_dtb(cpus, None);
         let parsed = ParsedFdt::from_bytes(&bytes).expect("fixture DTB should parse");
         caps_from_fdt::<8>(&parsed)
     }
@@ -224,12 +292,19 @@ mod tests {
     }
 
     #[test]
-    fn explicit_dmips_property_wins_over_compatible() {
-        let caps = caps_of(&[cpu(None, Some("arm,cortex-a55"), Some(900))]);
+    fn dmips_values_are_normalized_to_1024_scale() {
+        // Phytium-like raw DMIPS/MHz values: the largest maps to 1024 and the
+        // rest scale proportionally, so a raw value never leaks into the table.
+        // The normalized DMIPS also takes precedence over the compatible fallback.
+        let caps = caps_of(&[
+            cpu(None, Some("arm,cortex-a55"), Some(2850)),
+            cpu(None, Some("arm,cortex-a76"), Some(5660)),
+        ]);
         assert_eq!(
-            caps[0], 900,
-            "explicit capacity-dmips-mhz overrides the compatible fallback"
+            caps[1], 1024,
+            "largest capacity-dmips-mhz normalizes to 1024"
         );
+        assert_eq!(caps[0], 515, "2850 * 1024 / 5660 = 515");
     }
 
     /// Regression for the disabled-CPU skip: a firmware-disabled `cpu@` node
@@ -247,6 +322,48 @@ mod tests {
         assert_eq!(
             caps[0], 1024,
             "disabled cpu@0 must not occupy logical index 0"
+        );
+        assert_eq!(caps[1], 530);
+    }
+
+    #[test]
+    fn cpu_node_outside_cpus_is_ignored() {
+        // Only `/cpus` children are CPUs; a stray `cpu@9` at the root must not
+        // become a third logical CPU.
+        let bytes = build_dtb(
+            &[
+                cpu(None, Some("arm,cortex-a76"), None),
+                cpu(None, Some("arm,cortex-a55"), None),
+            ],
+            Some("cpu@9"),
+        );
+        let parsed = ParsedFdt::from_bytes(&bytes).expect("fixture DTB should parse");
+        let caps = caps_from_fdt::<8>(&parsed);
+        assert_eq!(caps[0], 1024);
+        assert_eq!(caps[1], 530);
+        assert_eq!(
+            caps[2], DEFAULT_CPU_CAPACITY,
+            "a stray cpu@ outside /cpus must not be counted"
+        );
+    }
+
+    #[test]
+    fn non_cpu_device_type_is_ignored() {
+        // A `/cpus` child named `cpu@*` but declaring a non-"cpu" device_type is
+        // not a CPU (someboot excludes it) and must not consume a logical index.
+        let caps = caps_of(&[
+            CpuSpec {
+                device_type: Some("memory"),
+                status: None,
+                compatible: Some("arm,cortex-a55"),
+                dmips: None,
+            },
+            cpu(None, Some("arm,cortex-a76"), None),
+            cpu(None, Some("arm,cortex-a55"), None),
+        ]);
+        assert_eq!(
+            caps[0], 1024,
+            "a cpu@ node with device_type != cpu must not occupy index 0"
         );
         assert_eq!(caps[1], 530);
     }

--- a/os/arceos/modules/axhal/src/lib.rs
+++ b/os/arceos/modules/axhal/src/lib.rs
@@ -27,6 +27,11 @@
 
 #![no_std]
 
+// `alloc` is only needed by the host unit tests (e.g. `dtb` builds fixture
+// device trees), so pull it in under `cfg(test)` rather than the crate proper.
+#[cfg(test)]
+extern crate alloc;
+
 #[cfg(all(axtest, feature = "axtest"))]
 mod axtest;
 

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -43,6 +43,12 @@ uspace = ["ax-hal/uspace"]
 sched-cfs = ["multitask", "preempt"]
 sched-rr = ["multitask", "preempt"]
 
+# Capacity-aware big.LITTLE INITIAL task placement. A new (spawn/clone) task is
+# steered to the least-loaded eligible core, preferring a big (A76) core when idle
+# so a lone compute thread does not land on a little (A55) core. Does NOT migrate
+# already-running tasks and does NOT change wakeup placement. Requires smp.
+sched-loadbalance = ["smp"]
+
 host-test = [
   "ax-hal/host-test",
   "ax-percpu?/host-test",

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -75,14 +75,64 @@ const ARRAY_REPEAT_VALUE: MaybeUninit<NonNull<AxRunQueue>> = MaybeUninit::uninit
 pub(crate) static BUSY_TICKS: [core::sync::atomic::AtomicU64; crate::build_info::CPU_CAPACITY] =
     [const { core::sync::atomic::AtomicU64::new(0) }; crate::build_info::CPU_CAPACITY];
 
-/// Bitmask (bit `cpu_id`) of CPUs whose per-CPU run queue in [`RUN_QUEUES`] has been
+/// A word-width-safe atomic bitmap of run queues that have finished coming online.
+/// [`AxCpuMask`] (and thus [`build_info::CPU_CAPACITY`], up to 1024) may exceed a
+/// machine word, so a single `usize` cannot address every CPU's bit; this spans as
+/// many `usize` words as the configured capacity needs. Publication is `Release` on
+/// [`set`](Self::set) / `Acquire` on [`contains`](Self::contains), so a CPU's online
+/// bit is observed strictly after the `RUN_QUEUES` slot write that precedes it.
+///
+/// [`build_info::CPU_CAPACITY`]: crate::build_info::CPU_CAPACITY
+#[cfg(any(all(feature = "smp", feature = "sched-loadbalance"), test))]
+struct OnlineCpus<const WORDS: usize> {
+    words: [core::sync::atomic::AtomicUsize; WORDS],
+}
+
+#[cfg(any(all(feature = "smp", feature = "sched-loadbalance"), test))]
+impl<const WORDS: usize> OnlineCpus<WORDS> {
+    const BITS: usize = usize::BITS as usize;
+
+    const fn new() -> Self {
+        Self {
+            words: [const { core::sync::atomic::AtomicUsize::new(0) }; WORDS],
+        }
+    }
+
+    /// Publishes `cpu` as online. `cpu` must be `< WORDS * usize::BITS`, which every
+    /// real CPU id satisfies (a CPU id is `< CPU_CAPACITY`, and `WORDS` is sized to
+    /// cover it).
+    #[inline]
+    fn set(&self, cpu: usize) {
+        self.words[cpu / Self::BITS].fetch_or(
+            1 << (cpu % Self::BITS),
+            core::sync::atomic::Ordering::Release,
+        );
+    }
+
+    /// Whether `cpu`'s run queue is online. An out-of-range `cpu` reads as offline
+    /// rather than indexing past the bitmap.
+    #[inline]
+    fn contains(&self, cpu: usize) -> bool {
+        let word = cpu / Self::BITS;
+        word < WORDS
+            && (self.words[word].load(core::sync::atomic::Ordering::Acquire)
+                & (1 << (cpu % Self::BITS)))
+                != 0
+    }
+}
+
+/// `usize` words needed to hold one online bit per configurable CPU.
+#[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+const ONLINE_WORDS: usize = crate::build_info::CPU_CAPACITY.div_ceil(usize::BITS as usize);
+
+/// Bitmap (bit `cpu_id`) of CPUs whose per-CPU run queue in [`RUN_QUEUES`] has been
 /// initialized. Capacity-aware placement ([`select_least_loaded`]) must only target
 /// online queues: during early boot the secondaries have not yet written their
 /// `RUN_QUEUES` slot, and `get_run_queue` on an uninitialized slot is a use of
 /// uninitialized memory. Set by each CPU as it initializes (see `init` /
 /// `init_secondary`).
 #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
-static RUN_QUEUE_ONLINE: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+static RUN_QUEUE_ONLINE: OnlineCpus<ONLINE_WORDS> = OnlineCpus::new();
 
 /// Bumps a target CPU's occupancy without holding a run-queue reference — lets the
 /// deferred cross-core wake path (`clear_prev_task_on_cpu`) count a task it enqueues
@@ -206,12 +256,10 @@ fn pick_least_loaded(
 /// no current-CPU cache-warmth bias, since a brand-new task has never run anywhere.
 #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
 fn select_least_loaded(cpumask: AxCpuMask) -> usize {
-    use core::sync::atomic::Ordering;
     assert!(!cpumask.is_empty(), "No available CPU for task execution");
-    let online = RUN_QUEUE_ONLINE.load(Ordering::Acquire);
     pick_least_loaded(
         ax_hal::cpu_num(),
-        |c| cpumask.get(c) && (online & (1usize << c)) != 0,
+        |c| cpumask.get(c) && RUN_QUEUE_ONLINE.contains(c),
         // Occupancy = ready tasks PLUS the currently-running non-idle task, read as a
         // single atom, so a core that just started running a task is immediately seen
         // as load 1 — a burst of siblings spreads across big cores, then spills onto
@@ -285,6 +333,39 @@ mod placement_tests {
         // Uniform capacity (e.g. QEMU, where `cpu_capacities()` is all-1024) + all
         // idle: every candidate ties, so placement falls back to the lowest index.
         assert_eq!(pick_least_loaded(4, |_| true, |_| 0, |_| 1024), Some(0));
+    }
+
+    /// The online set must address CPUs beyond a single machine word. `CPU_CAPACITY`
+    /// (and `AxCpuMask`) can be built past 64, so a `usize` bitmap would alias high
+    /// CPUs onto low bits (`1 << 70` wraps to `1 << 6`). Uses 3 words (192 CPUs).
+    #[test]
+    fn online_mask_tracks_cpus_beyond_one_word() {
+        use super::OnlineCpus;
+
+        let online = OnlineCpus::<3>::new();
+        // Empty on construction, including high indices.
+        assert!(!online.contains(0));
+        assert!(!online.contains(70));
+        assert!(!online.contains(191));
+
+        // A CPU in the second word is tracked without aliasing a low bit: the
+        // single-`usize` bug set bit `70 % 64 == 6`, so `contains(6)` would wrongly
+        // read online here.
+        online.set(70);
+        assert!(online.contains(70));
+        assert!(!online.contains(6));
+        assert!(!online.contains(134)); // same intra-word offset, third word
+
+        // Independent low, high, and mid CPUs coexist.
+        online.set(1);
+        online.set(191);
+        assert!(online.contains(1));
+        assert!(online.contains(70));
+        assert!(online.contains(191));
+
+        // Out-of-range CPUs read offline instead of indexing past the bitmap.
+        assert!(!online.contains(192));
+        assert!(!online.contains(10_000));
     }
 }
 
@@ -1731,9 +1812,9 @@ pub(crate) fn init() {
     #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
     get_run_queue(cpu_id).occ_inc();
     // Publish this CPU's run queue as online so capacity-aware placement may target
-    // it; `Release` orders the online bit strictly after the slot write above.
+    // it; the `set` orders the online bit strictly after the slot write above.
     #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
-    RUN_QUEUE_ONLINE.fetch_or(1 << cpu_id, core::sync::atomic::Ordering::Release);
+    RUN_QUEUE_ONLINE.set(cpu_id);
 }
 
 pub(crate) fn init_secondary(stack_ptr: VirtAddr, stack_size: usize) {
@@ -1782,7 +1863,7 @@ pub(crate) fn init_secondary(stack_ptr: VirtAddr, stack_size: usize) {
     // it. A secondary runs `idle` as its current task (not counted), and its gc task
     // is the queue's seed=1, so no `occ_inc` for `main` here (unlike the boot CPU).
     #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
-    RUN_QUEUE_ONLINE.fetch_or(1 << cpu_id, core::sync::atomic::Ordering::Release);
+    RUN_QUEUE_ONLINE.set(cpu_id);
 }
 
 #[cfg(axtest)]

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -75,6 +75,24 @@ const ARRAY_REPEAT_VALUE: MaybeUninit<NonNull<AxRunQueue>> = MaybeUninit::uninit
 pub(crate) static BUSY_TICKS: [core::sync::atomic::AtomicU64; crate::build_info::CPU_CAPACITY] =
     [const { core::sync::atomic::AtomicU64::new(0) }; crate::build_info::CPU_CAPACITY];
 
+/// Bitmask (bit `cpu_id`) of CPUs whose per-CPU run queue in [`RUN_QUEUES`] has been
+/// initialized. Capacity-aware placement ([`select_least_loaded`]) must only target
+/// online queues: during early boot the secondaries have not yet written their
+/// `RUN_QUEUES` slot, and `get_run_queue` on an uninitialized slot is a use of
+/// uninitialized memory. Set by each CPU as it initializes (see `init` /
+/// `init_secondary`).
+#[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+static RUN_QUEUE_ONLINE: core::sync::atomic::AtomicUsize = core::sync::atomic::AtomicUsize::new(0);
+
+/// Bumps a target CPU's occupancy without holding a run-queue reference — lets the
+/// deferred cross-core wake path (`clear_prev_task_on_cpu`) count a task it enqueues
+/// onto another CPU. See [`AxRunQueue::occ`].
+#[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+#[inline]
+fn occ_inc_cpu(cpu: usize) {
+    get_run_queue(cpu).occ_inc();
+}
+
 #[cfg(not(feature = "host-test"))]
 fn main_task_stack() -> TaskStack {
     let (stack_ptr, stack_size) = ax_hal::mem::boot_stack_bounds(this_cpu_id());
@@ -133,6 +151,140 @@ fn select_run_queue_index(cpumask: AxCpuMask) -> usize {
         if cpumask.get(index) {
             return index;
         }
+    }
+}
+
+/// Normalized compute capacity of `cpu` (big.LITTLE weighting), floored at 1 so the
+/// capacity-weighted division is always well-defined. Sourced from the device tree's
+/// `capacity-dmips-mhz` (A76 ~ 1024, A55 ~ 530); homogeneous machines (e.g. QEMU)
+/// report all-equal and this degrades to plain load-spreading.
+#[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+#[inline]
+fn cpu_capacity(cpu: usize) -> usize {
+    (ax_hal::dtb::cpu_capacities()[cpu] as usize).max(1)
+}
+
+/// Pure, host-testable core of capacity-aware placement (mirrors the wake-side idle
+/// picker): the eligible CPU with the lowest capacity-weighted load `load*1024/cap`.
+/// Tie-break, in order: (1) min effective load, (2) max raw capacity (an empty A76
+/// beats an empty A55 — this is what makes a lone compute task land on a big core),
+/// (3) lowest index. Returns `None` if `in_mask` names no CPU. Takes `load`/`cap` as
+/// closures and never dereferences a run queue, so unit tests drive it directly.
+///
+/// Compiled whenever `sched-loadbalance` is on (its only production caller,
+/// `select_least_loaded`) or under `cfg(test)` (so the host unit tests below run
+/// without pulling in the whole SMP scheduler).
+#[cfg(any(feature = "sched-loadbalance", test))]
+fn pick_least_loaded(
+    cpu_num: usize,
+    in_mask: impl Fn(usize) -> bool,
+    load: impl Fn(usize) -> usize,
+    cap: impl Fn(usize) -> usize,
+) -> Option<usize> {
+    let mut best: Option<(usize, usize, usize)> = None; // (cpu, eff_load, capacity)
+    for cpu in 0..cpu_num {
+        if !in_mask(cpu) {
+            continue;
+        }
+        let c = cap(cpu).max(1); // floor so the division is well-defined
+        let eff = load(cpu).saturating_mul(1024) / c;
+        let better = match best {
+            None => true,
+            Some((_, beff, bcap)) => eff < beff || (eff == beff && c > bcap),
+        };
+        if better {
+            best = Some((cpu, eff, c));
+        }
+    }
+    best.map(|(cpu, ..)| cpu)
+}
+
+/// Eligible CPU in `cpumask` with the lowest capacity-weighted load, using each CPU's
+/// occupancy ([`AxRunQueue::occ`]) as the load. Online CPUs only; falls back to the
+/// round-robin selector if the mask names no online CPU. Initial (fork/exec)
+/// placement only — never migrates an already-running task, and (unlike wakeups) adds
+/// no current-CPU cache-warmth bias, since a brand-new task has never run anywhere.
+#[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+fn select_least_loaded(cpumask: AxCpuMask) -> usize {
+    use core::sync::atomic::Ordering;
+    assert!(!cpumask.is_empty(), "No available CPU for task execution");
+    let online = RUN_QUEUE_ONLINE.load(Ordering::Acquire);
+    pick_least_loaded(
+        ax_hal::cpu_num(),
+        |c| cpumask.get(c) && (online & (1usize << c)) != 0,
+        // Occupancy = ready tasks PLUS the currently-running non-idle task, read as a
+        // single atom, so a core that just started running a task is immediately seen
+        // as load 1 — a burst of siblings spreads across big cores, then spills onto
+        // little cores, instead of piling onto one momentarily-"idle" core.
+        |c| get_run_queue(c).occ(),
+        cpu_capacity,
+    )
+    .unwrap_or_else(|| select_run_queue_index(cpumask))
+}
+
+#[cfg(test)]
+mod placement_tests {
+    use super::pick_least_loaded;
+
+    /// RK3588 topology: logical CPUs 0-3 are A55 (capacity 530), 4-7 are A76 (1024).
+    fn rk3588_cap(cpu: usize) -> usize {
+        if cpu < 4 { 530 } else { 1024 }
+    }
+
+    #[test]
+    fn empty_mask_returns_none() {
+        assert_eq!(pick_least_loaded(8, |_| false, |_| 0, rk3588_cap), None);
+    }
+
+    #[test]
+    fn a_lone_task_on_an_all_idle_machine_lands_on_a_big_core() {
+        // All idle (load 0): every effective load is 0, so the tie-break picks the
+        // highest raw capacity — the first A76 (cpu 4), never an A55.
+        assert_eq!(pick_least_loaded(8, |_| true, |_| 0, rk3588_cap), Some(4));
+    }
+
+    #[test]
+    fn equal_raw_load_favors_the_big_core() {
+        // cpu0 (A55) and cpu4 (A76) both carry raw load 2. eff(A55)=2*1024/530=3,
+        // eff(A76)=2*1024/1024=2 — the big core is less loaded per unit capacity.
+        assert_eq!(
+            pick_least_loaded(8, |c| c == 0 || c == 4, |_| 2, rk3588_cap),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn a_busy_big_core_spills_to_an_idle_little_core() {
+        // cpu4 (A76) already runs 1 task (eff 1024/1024 = 1); cpu0 (A55) is idle
+        // (eff 0). Load-spreading sends the new task to the idle little core.
+        let load = |cpu: usize| if cpu == 4 { 1 } else { 0 };
+        assert_eq!(
+            pick_least_loaded(8, |c| c == 0 || c == 4, load, rk3588_cap),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn idle_big_cores_are_preferred_over_idle_little_cores() {
+        // cpu4 (A76) is busy; cpus 5-7 (A76) and 0-3 (A55) are idle. Among the idle
+        // cores (all eff 0) the max-capacity tie-break picks an idle A76 (cpu 5), not
+        // a little core.
+        let load = |cpu: usize| if cpu == 4 { 3 } else { 0 };
+        assert_eq!(pick_least_loaded(8, |_| true, load, rk3588_cap), Some(5));
+    }
+
+    #[test]
+    fn affinity_mask_is_respected() {
+        // Only the little cores are eligible; all idle + equal capacity, so the
+        // lowest index wins the tie.
+        assert_eq!(pick_least_loaded(8, |c| c < 4, |_| 0, rk3588_cap), Some(0));
+    }
+
+    #[test]
+    fn homogeneous_machine_degrades_to_lowest_index() {
+        // Uniform capacity (e.g. QEMU, where `cpu_capacities()` is all-1024) + all
+        // idle: every candidate ties, so placement falls back to the lowest index.
+        assert_eq!(pick_least_loaded(4, |_| true, |_| 0, |_| 1024), Some(0));
     }
 }
 
@@ -490,6 +642,8 @@ mod rr_tests {
         let mut run_queue = AxRunQueue {
             cpu_id: 1,
             scheduler: SpinLock::new(Scheduler::new()),
+            #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+            occ: core::sync::atomic::AtomicUsize::new(0),
         };
         let queued = new_test_task("queued", TaskState::Ready);
         let blocked = new_test_task("blocked", TaskState::Blocked);
@@ -552,13 +706,23 @@ pub(crate) fn select_run_queue<G: GuardState>(task: &AxTaskRef) -> AxRunQueueRef
     }
     #[cfg(feature = "smp")]
     {
-        // When SMP is enabled, prefer the current CPU to keep the task's
-        // cache warm. Fall back to round-robin only when affinity forbids it.
-        let current_cpu = this_cpu_id();
-        let index = if task.cpumask().get(current_cpu) {
-            current_cpu
-        } else {
-            select_run_queue_index(task.cpumask())
+        // With `sched-loadbalance`, new-task (spawn / clone) placement is
+        // capacity-aware: steer to the least-loaded eligible core, preferring a big
+        // (A76) core when idle so a lone compute thread does not land on a little
+        // (A55) core. A fresh task has no warm cache to preserve, so there is no
+        // current-CPU bias here (unlike wakeups; see `select_wake_run_queue`).
+        #[cfg(feature = "sched-loadbalance")]
+        let index = select_least_loaded(task.cpumask());
+        // Default: prefer the current CPU to keep the task's cache warm; fall back to
+        // round-robin only when affinity forbids it.
+        #[cfg(not(feature = "sched-loadbalance"))]
+        let index = {
+            let current_cpu = this_cpu_id();
+            if task.cpumask().get(current_cpu) {
+                current_cpu
+            } else {
+                select_run_queue_index(task.cpumask())
+            }
         };
         AxRunQueueRef {
             inner: get_run_queue(index),
@@ -615,6 +779,22 @@ pub(crate) struct AxRunQueue {
     /// Since irq and preempt are preserved by the kernel guard hold by `AxRunQueueRef`,
     /// we just use a simple raw spin lock here.
     scheduler: SpinLock<Scheduler>,
+    /// Capacity-aware placement occupancy: the number of non-idle tasks this CPU
+    /// currently *owns* — those in its ready queue PLUS the one it is running. It
+    /// counts the running task, so it is the complete load signal a remote placer
+    /// needs, read as ONE atom.
+    ///
+    /// Maintained by incrementing when a task *enters* this CPU's active set (spawn,
+    /// wakeup, or migrate-in) and decrementing when it *leaves* (block, exit, or
+    /// migrate-out). The ready↔running transition (pick / preempt / yield) does NOT
+    /// change it, so — crucially — there is no window in which a core that just
+    /// started running a task is momentarily observed as load 0. A single per-CPU
+    /// counter closes a hazard a two-atom scheme (a length plus a separate is-running
+    /// flag, published at different points) could not: an unlocked reader could see
+    /// the pair inconsistently, which on-board either clustered every sibling thread
+    /// onto a few big cores or left idle big cores looking permanently busy.
+    #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+    occ: core::sync::atomic::AtomicUsize,
 }
 
 /// Permanent run-queue pointer whose references remain scoped to this handle.
@@ -693,6 +873,10 @@ impl<G: GuardState> AxRunQueueRef<G> {
         // SAFETY: `AxRunQueueRef<G>` has already entered the run-queue
         // critical section represented by `G`.
         unsafe { self.inner.scheduler.lock_raw() }.add_task(task);
+        // A brand-new task enters this CPU's active set. This is the single funnel for
+        // new-task enqueues, so every spawn path is counted exactly once.
+        #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+        self.inner.occ_inc();
         #[cfg(all(feature = "smp", feature = "ipi"))]
         kick_remote_cpu(cpu_id);
     }
@@ -817,6 +1001,10 @@ impl<G: GuardState> CurrentRunQueueRef<G> {
         // Mark current task's state as `Ready`,
         // but, do not put current task to the scheduler of this run queue.
         curr.set_state(TaskState::Ready);
+        // The task leaves this CPU's active set; `migrate_entry` will `occ_inc` the
+        // destination CPU when it re-enqueues the task there.
+        #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+        self.inner.occ_dec();
 
         // Call `switch_to` to reschedule to the migration task that performs the migration directly.
         self.inner.switch_to(crate::current(), migration_task);
@@ -927,6 +1115,9 @@ impl<G: GuardState> CurrentRunQueueRef<G> {
             ax_hal::power::system_off();
         } else {
             curr.set_state(TaskState::Exited);
+            // The task leaves this CPU's active set permanently.
+            #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+            self.inner.occ_dec();
 
             // Notify the joiner task.
             curr.notify_exit(exit_code);
@@ -971,6 +1162,11 @@ impl<G: GuardState> CurrentRunQueueRef<G> {
         // Mark the task as blocked, this has to be done before adding it to the wait queue
         // while holding the lock of the wait queue.
         curr.set_state(TaskState::Blocked);
+        // The running task leaves this CPU's active set (pairs with the `occ_inc` in
+        // the eventual wakeup). A racing `unblock_task` can only flip Blocked->Ready
+        // after this store, so its `occ_inc` and this `occ_dec` balance out.
+        #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+        self.inner.occ_dec();
 
         // A preemptive future wake can re-enter a wait path before a previous
         // wait-queue entry has been consumed. Avoid leaving a stale duplicate
@@ -1004,6 +1200,9 @@ impl<G: GuardState> CurrentRunQueueRef<G> {
         // Mark the task as blocked, this has to be done before adding it to the wait queue
         // while holding the lock of the wait queue.
         curr.set_state(TaskState::Blocked);
+        // The running task leaves this CPU's active set (see `blocked_resched`).
+        #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+        self.inner.occ_dec();
         *woke = false;
         drop(woke);
 
@@ -1025,6 +1224,10 @@ impl<G: GuardState> CurrentRunQueueRef<G> {
         while ax_hal::time::monotonic_time() < deadline {
             crate::timers::set_alarm_wakeup(deadline, curr.clone());
             curr.set_state(TaskState::Blocked);
+            // Leaves the active set until the alarm wakes it (which `occ_inc`s via the
+            // wakeup); each loop iteration's block/wake pair balances.
+            #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+            self.inner.occ_dec();
             self.inner.resched();
         }
     }
@@ -1062,6 +1265,57 @@ impl AxRunQueue {
         Self {
             cpu_id,
             scheduler: SpinLock::new(scheduler),
+            // Seed occupancy at 1 for the pre-loaded gc task: it is a non-idle ready
+            // task this CPU owns, enqueued above without going through the spawn
+            // `occ_inc` hook.
+            #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+            occ: core::sync::atomic::AtomicUsize::new(1),
+        }
+    }
+
+    /// This CPU's occupancy (ready + running non-idle tasks). One atomic load — the
+    /// whole placement load signal, with no second atom to race against. See
+    /// [`AxRunQueue::occ`].
+    #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+    #[inline]
+    fn occ(&self) -> usize {
+        self.occ.load(core::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// A task entered this CPU's active set (spawn / wake / migrate-in). Relaxed is
+    /// sufficient: this single atom only needs to be eventually-consistent and
+    /// correctly-signed for a best-effort placement heuristic.
+    #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+    #[inline]
+    fn occ_inc(&self) {
+        self.occ.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// A task left this CPU's active set (block / exit / migrate-out). Saturating: a
+    /// decrement below zero would wrap the unsigned counter and make the CPU look
+    /// infinitely busy. Since the maintenance hooks are exactly balanced there is no
+    /// self-heal, so the clamp is the sole guard; `debug_assert` still flags a real
+    /// missed `occ_inc` (an unbalanced hook) in test builds.
+    #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+    #[inline]
+    fn occ_dec(&self) {
+        use core::sync::atomic::Ordering::Relaxed;
+        // Saturating decrement via CAS: clamp at 0 rather than let a hook imbalance
+        // wrap the unsigned counter into "infinitely busy". `debug_assert` still flags
+        // a real missed `occ_inc` (an unbalanced hook) in test builds.
+        let mut cur = self.occ.load(Relaxed);
+        loop {
+            debug_assert!(cur > 0, "AxRunQueue::occ underflow on CPU {}", self.cpu_id);
+            if cur == 0 {
+                return;
+            }
+            match self
+                .occ
+                .compare_exchange_weak(cur, cur - 1, Relaxed, Relaxed)
+            {
+                Ok(_) => return,
+                Err(actual) => cur = actual,
+            }
         }
     }
 
@@ -1125,6 +1379,15 @@ impl AxRunQueue {
             task.set_cpu_id(self.cpu_id as _);
             // SAFETY: the caller holds the run-queue context guard.
             unsafe { self.scheduler.lock_raw() }.put_prev_task(task, preempt);
+            // A wakeup (Blocked -> Ready) brings a task back into this CPU's active
+            // set. A preemption/yield (Running -> Ready) does not: the task already
+            // belonged to this CPU and stays counted, so the `Blocked` gate excludes
+            // it. The deferred cross-core wake path returned `false` above (task still
+            // `on_cpu`) and is counted in `clear_prev_task_on_cpu` instead.
+            #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+            if current_state == TaskState::Blocked {
+                self.occ_inc();
+            }
             true
         } else {
             false
@@ -1339,6 +1602,10 @@ pub(crate) fn migrate_entry(migrated_task: AxTaskRef) {
     migrated_task.set_cpu_id(cpu_id as _);
     // SAFETY: `rq` owns the target run-queue critical section.
     unsafe { rq.inner.scheduler.lock_raw() }.put_prev_task(migrated_task, false);
+    // The task enters the target CPU's active set (pairs with the `occ_dec` in
+    // `migrate_current` that removed it from the source CPU).
+    #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+    rq.inner.occ_inc();
     #[cfg(all(feature = "smp", feature = "ipi"))]
     // Current-task migration cannot make progress until the target CPU runs
     // the migrated task, so do not let a stale coalescing bit suppress this IPI.
@@ -1380,6 +1647,12 @@ pub(crate) unsafe fn clear_prev_task_on_cpu() {
         // SAFETY: this switch tail runs with preemption and local IRQs disabled;
         // the scheduler lock supplies cross-CPU exclusion.
         unsafe { target_run_queue.scheduler.lock_raw() }.put_prev_task(task, false);
+        // Deferred half of a wakeup (Blocked -> Ready): the task enters the target
+        // CPU's active set here, where `put_task_with_state` could not enqueue it
+        // (still `on_cpu`). Counted exactly once (the wake arbiter guarantees only one
+        // side reaches this).
+        #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+        occ_inc_cpu(target);
         if target != this_cpu_id() {
             // Remote target: ask that CPU to reschedule so it picks the task up
             // (and wakes if it is idle in `wait_for_irqs`).
@@ -1451,6 +1724,16 @@ pub(crate) fn init() {
     unsafe {
         RUN_QUEUES[cpu_id].write(run_queue);
     }
+    // The `main` task runs on this CPU but never went through the spawn `occ_inc`
+    // hook, so count it now (on top of the gc seed). It exits via `system_off` (the
+    // is-init branch of `exit_current`), never `occ_dec`, so this inc is deliberately
+    // unpaired — `main` occupies the CPU for the system's lifetime.
+    #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+    get_run_queue(cpu_id).occ_inc();
+    // Publish this CPU's run queue as online so capacity-aware placement may target
+    // it; `Release` orders the online bit strictly after the slot write above.
+    #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+    RUN_QUEUE_ONLINE.fetch_or(1 << cpu_id, core::sync::atomic::Ordering::Release);
 }
 
 pub(crate) fn init_secondary(stack_ptr: VirtAddr, stack_size: usize) {
@@ -1495,6 +1778,11 @@ pub(crate) fn init_secondary(stack_ptr: VirtAddr, stack_size: usize) {
     unsafe {
         RUN_QUEUES[cpu_id].write(run_queue);
     }
+    // Publish this CPU's run queue as online so capacity-aware placement may target
+    // it. A secondary runs `idle` as its current task (not counted), and its gc task
+    // is the queue's seed=1, so no `occ_inc` for `main` here (unlike the boot CPU).
+    #[cfg(all(feature = "smp", feature = "sched-loadbalance"))]
+    RUN_QUEUE_ONLINE.fetch_or(1 << cpu_id, core::sync::atomic::Ordering::Release);
 }
 
 #[cfg(axtest)]

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -14,6 +14,7 @@ use crate::support::process::run_cargo_status;
 const STD_CRATES_CSV: &str = "scripts/test/std_crates.csv";
 const MIGHT_SLEEP_FILTER: &str = "might_sleep";
 const TASK_INITIALIZATION_FILTER: &str = "task_initialization_precedes_scheduling";
+const PLACEMENT_FILTER: &str = "placement_tests";
 
 #[derive(Clone, Copy, Debug)]
 struct PackageFeatureProfile {
@@ -43,6 +44,23 @@ const AX_TASK_FEATURE_PROFILES: &[PackageFeatureProfile] = &[
         expected_tests: &[
             "tests::might_sleep_reports_held_lock_stack",
             "tests::might_sleep_reports_preempt_disabled_reason",
+        ],
+    },
+    // The capacity-aware placement math (`pick_least_loaded`) is pure and compiles
+    // under `cfg(test)` without the SMP scheduler, so it runs here with the plain
+    // host-test feature set — no `smp`/`sched-loadbalance` needed.
+    PackageFeatureProfile {
+        name: "host-test+placement",
+        features: &["host-test", "multitask"],
+        name_filter: Some(PLACEMENT_FILTER),
+        expected_tests: &[
+            "run_queue::placement_tests::a_busy_big_core_spills_to_an_idle_little_core",
+            "run_queue::placement_tests::a_lone_task_on_an_all_idle_machine_lands_on_a_big_core",
+            "run_queue::placement_tests::affinity_mask_is_respected",
+            "run_queue::placement_tests::empty_mask_returns_none",
+            "run_queue::placement_tests::equal_raw_load_favors_the_big_core",
+            "run_queue::placement_tests::homogeneous_machine_degrades_to_lowest_index",
+            "run_queue::placement_tests::idle_big_cores_are_preferred_over_idle_little_cores",
         ],
     },
 ];
@@ -676,6 +694,24 @@ mod tests {
                     "host-test,multitask,preempt,lockdep",
                     "might_sleep",
                 ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test,multitask",
+                    "placement_tests",
+                    "--",
+                    "--list",
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test,multitask",
+                    "placement_tests",
+                ],
             ]
         );
         assert!(!args.contains(&vec!["test".into(), "-p".into(), "ax-task".into()]));
@@ -817,6 +853,6 @@ mod tests {
         let failed = run_std_tests(&mut runner, &root, &packages).unwrap();
 
         assert_eq!(failed, vec!["ax-task", "ax-api"]);
-        assert_eq!(runner.invocations.len(), 7);
+        assert_eq!(runner.invocations.len(), 9);
     }
 }

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -61,6 +61,7 @@ const AX_TASK_FEATURE_PROFILES: &[PackageFeatureProfile] = &[
             "run_queue::placement_tests::equal_raw_load_favors_the_big_core",
             "run_queue::placement_tests::homogeneous_machine_degrades_to_lowest_index",
             "run_queue::placement_tests::idle_big_cores_are_preferred_over_idle_little_cores",
+            "run_queue::placement_tests::online_mask_tracks_cpus_beyond_one_word",
         ],
     },
 ];


### PR DESCRIPTION
## 问题
#2001 新增了 `axhal::dtb::cpu_capacities()`（per-CPU 大小核算力表），但**无消费者**：`ax-task` 的新任务放置（`select_run_queue`）仍是“优先本核、否则轮询”，不感知大小核差异——一个计算线程可能落到 A55 小核。

## 改动
新增 feature `sched-loadbalance`（默认关闭），实现容量感知的**初始放置**（不迁移运行中任务）：
- 每 run queue 新增原子占用计数 `occ`（就绪 + 正在运行的非 idle 任务数），作为可跨核**无锁读取**的负载信号；任务进入活动集（spawn / wake / migrate-in）时 +1、离开（block / exit / migrate-out）时 −1，就绪↔运行切换不变（避免刚开始运行的核短暂被看作空闲）。饱和递减（CAS）防止下溢。
- `select_least_loaded` 以 `occ` 为负载、`cpu_capacities()` 为算力，挑容量加权负载 `load*1024/cap` 最小的在线核（并列时取算力更大的核，使孤立计算任务落到大核）；抽出纯函数 `pick_least_loaded` 便于单测。`select_run_queue` 的新任务放置在该 feature 下改用它；**唤醒放置不变**。
- 修复 `axhal::dtb`：无 boot arg 时 FDT 探测（及 `cpu_capacities`）**降级为默认值而非 panic**，使其可在宿主单测 / 任意上下文安全调用。

## 逻辑
容量感知放置需要可跨核无锁读的**瞬时**负载；用单个原子 `occ`（就绪+运行）避免“队列长度 + 是否运行”双原子的不一致窗口（该窗口在板上曾导致线程全挤到少数大核，或空闲大核被误判为忙）。放置只在 spawn 时选核、不迁移已运行任务，属最小、低风险子集（**不含** wake_affine / 运行时迁移 / idle-poll）。默认关闭时相关代码不编译，对现有构建零影响。

## 测试
- **纯放置逻辑**：`ax-task` 宿主单测 `pick_least_loaded`（7 例：空掩码 / 全空闲落大核 / 等负载偏好大核 / 大核有活溢出到小核 / 优先空闲大核 / 亲和掩码 / 同构降级到最小下标）。纯函数在 `cfg(test)` 下编译，经 `scripts/axbuild/src/test/std.rs` 新增 profile 在 CI 运行（**无需 smp**）。
- **在线位图（>字宽）**：`online_mask_tracks_cpus_beyond_one_word`（`OnlineCpus<3>` = 192 CPU）断言第二个字里的 CPU 被正确记录且不混叠低位（`set(70)` 不得使 `contains(6)` 为真）。已确认该用例在单-`usize`（单字）实现下必然失败、修复后通过。修复了在线 CPU 位图原用单个 `usize`（无法表示 `cpu_id >= 字宽` 的 CPU，而 `AxCpuMask`/`CPU_CAPACITY` 最高支持 1024）的缺陷。
- **occ 钩子**：开启 `sched-loadbalance` 的完整 `ax-task` 宿主测试全通过（62 例，涵盖 block/wake/exit 等占用钩子）；aarch64 内核带该 feature 构建通过；`cargo fmt` / `cargo xtask clippy`（ax-task、ax-hal）通过。
- **容量比例行为**（A76 比 A55 分到更多线程）在 QEMU 同构核下不可测（`cpu_capacities()` 全为 1024），由 combined-perf 在 RK3588 板上验证。

---
本 PR 基于 #2001（`feat/axhal-cpu-capacity`），作为其 `cpu_capacities()` 的实际消费者；建议与 #2001 一同合入（#2001 合入 dev 后本 PR diff 将自动收敛为仅消费者改动）。

