### PR TITLE
feat(dwc2): migrate stream-based DDMA backend onto mainline API

### DIFF
--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/channel/iso.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/channel/iso.rs
@@ -1,0 +1,993 @@
+//! ISO 传输状态机
+
+use alloc::{collections::VecDeque, vec::Vec};
+use core::{sync::atomic::Ordering, task::Context};
+
+use mbarrier::mb;
+use usb_if::{
+    endpoint::{IsoPacketResult, RequestId, TransferCompletion, TransferRequest, TransferStatus},
+    err::TransferError,
+    host::hub::Speed,
+    transfer::Direction,
+};
+
+use crate::backend::kmod::{
+    Kernel,
+    dwc2::{
+        Dwc2EpType, Dwc2Pid, Dwc2TransferFault,
+        channel::{ChannelConfig, ChannelLease, HostChannelPool},
+        dma::{DmaDescriptor, DmaDescriptors, Dwc2DmaBuffer, Dwc2DmaBufferPool},
+        dma_addr32, endpoint_number, fault_to_transfer_error, hcchar, hcint_fault, hctsiz_ddma,
+        reg::{
+            DWC2_COMPLETION_DISCONNECTED, DWC2_DMA_ALIGN, Dwc2Registers, HCINT_AHBERR,
+            HCINT_BBLERR, HCINT_CHHLTD, HCINT_FRMOVRN, HCINT_XACTERR, HCINT_XFERCOMPL,
+        },
+        stats::Dwc2Stats,
+    },
+};
+
+// ═══════════════════════════════════════════
+// ISO 周期性调度计算（Linux hcd_ddma.c/hcd_queue.c 语义）
+// ═══════════════════════════════════════════
+
+/// ISO 描述符环容量（Linux MAX_DMA_DESC_NUM_*）：HS 每帧 8 个微帧槽位，
+/// 256 项 = 32 帧；FS 每帧 1 个槽位，64 项 = 64 帧。
+const DWC2_ISO_RING_HS: usize = 256;
+const DWC2_ISO_RING_FS: usize = 64;
+
+/// 每个 ISO 包的最大传输字节（Linux MAX_ISOC_XFER_SIZE_*）。
+const DWC2_ISO_MAX_XFER_HS: usize = 3072; // mult(3) × 1024
+const DWC2_ISO_MAX_XFER_FS: usize = 1023;
+
+/// ISO 描述符环容量：HS 每帧 8 个微帧槽位（256 = 32 帧），FS 每帧 1 槽位（64 帧）。
+fn iso_ring_size(speed: Speed) -> usize {
+    match speed {
+        Speed::High => DWC2_ISO_RING_HS,
+        _ => DWC2_ISO_RING_FS,
+    }
+}
+
+/// 每个 ISO 包的最大传输字节（Linux MAX_ISOC_XFER_SIZE_*）。
+fn iso_max_xfer_size(speed: Speed) -> usize {
+    match speed {
+        Speed::High => DWC2_ISO_MAX_XFER_HS,
+        _ => DWC2_ISO_MAX_XFER_FS,
+    }
+}
+
+/// HCTSIZ.SCHINFO：HS 为每帧内被服务的微帧位图（bit n = 微帧 n），
+/// 非 HS 为 0xff（每帧）。Linux `dwc2_update_frame_list` 同款计算。
+fn iso_schinfo(speed: Speed, interval: u32) -> u32 {
+    if !matches!(speed, Speed::High) {
+        return 0xff;
+    }
+    let interval = interval.max(1);
+    let inc = 8_u32.div_ceil(interval);
+    let mut schinfo = 0u32;
+    let mut bit = 1u32;
+    for _ in 0..inc {
+        schinfo |= bit;
+        bit = bit.wrapping_shl(interval.min(31));
+    }
+    schinfo & 0xff
+}
+
+/// ISO 的 HCTSIZ.PID/MC 编码（Linux `dwc2_set_pid_isoc`）：
+/// HS IN mult1→DATA0、mult2→DATA1、mult3→DATA2；HS OUT mult1→DATA0 其余 MDATA；
+/// FS/LS 恒 DATA0。
+fn iso_pid(speed: Speed, direction: Direction, mult: u8) -> Dwc2Pid {
+    match speed {
+        Speed::High => match direction {
+            Direction::In => match mult.max(1) {
+                1 => Dwc2Pid::Data0,
+                2 => Dwc2Pid::Data1,
+                _ => Dwc2Pid::Data2,
+            },
+            Direction::Out => {
+                if mult.max(1) <= 1 {
+                    Dwc2Pid::Data0
+                } else {
+                    Dwc2Pid::MData
+                }
+            }
+        },
+        _ => Dwc2Pid::Data0,
+    }
+}
+
+/// 帧号 → 描述符环起始索引（Linux `dwc2_frame_to_desc_idx`）：
+/// HS 每帧 8 个微帧槽位、起始对齐微帧 0；FS 每帧 1 槽位。
+fn frame_to_desc_idx(speed: Speed, full_frame: u32) -> usize {
+    match speed {
+        Speed::High => ((full_frame & 0x1f) as usize) * 8,
+        _ => (full_frame & 0x3f) as usize,
+    }
+}
+
+/// 计算 ISO 起始整帧号：HS 按当前微帧位置跳过 1–2 个整帧，FS 跳过 2 帧。
+fn iso_starting_frame(raw_frame: u32, speed: Speed) -> u32 {
+    match speed {
+        Speed::High => {
+            let microframe = raw_frame & 0x7;
+            let skip = if microframe >= 5 { 2 } else { 1 };
+            raw_frame.wrapping_add(skip * 8) >> 3
+        }
+        _ => raw_frame.wrapping_add(2) & 0xffff,
+    }
+}
+
+/// 最大公约数（调度网格步长与环容量反压共用；b 为 0 时回退 1）。
+fn gcd(mut a: usize, mut b: usize) -> usize {
+    while b != 0 {
+        let t = a % b;
+        a = b;
+        b = t;
+    }
+    a.max(1)
+}
+
+/// 沿调度网格把写游标推进到 `>= target` 的下一个合法索引（模 ring）。
+/// 通道被服务的时刻为 `T0 + m·interval`，对应描述符索引需落在
+/// `T0 mod gcd(interval, ring)` 的同余类；因此以 `gcd(interval, ring)`
+/// 为步长对齐（interval 整除 ring 时等价于保持 mod interval 同余）。
+fn advance_along_grid(td_last: usize, target: usize, interval: usize, ring: usize) -> usize {
+    let step = gcd(interval.max(1), ring.max(1));
+    let delta = (td_last as isize - target as isize).rem_euclid(step as isize) as usize;
+    (target + delta) % ring
+}
+
+/// 单请求允许的最大包数：desc 索引以 interval 步进、模 ring 回绕，碰撞
+/// 当且仅当 `(k2 − k1) · interval ≡ 0 (mod ring)`。最大包数 =
+/// `ring / gcd(interval, ring) − 1`（Linux 会话模型允许填满，但一次性
+/// 请求模型下满环会与首包碰撞）。
+fn iso_max_packets(interval: u32, speed: Speed) -> usize {
+    let ring = iso_ring_size(speed) as u32;
+    let interval = interval.max(1);
+    let gcd = gcd(interval as usize, ring as usize) as u32;
+    (ring / gcd).saturating_sub(1) as usize
+}
+
+/// 通道在 FrameList 中被调度的帧索引（Linux `dwc2_update_frame_list` 的
+/// 帧步进）：HS 每 `ceil(interval/8)` 帧一次（interval 为微帧数），
+/// 非 HS 每 `interval` 帧一次（interval 为帧数）。返回 64 项视野内的
+/// 全部服务帧索引（覆盖整个回绕周期）。
+fn iso_service_frames(start_full_frame: u32, interval_slots: u32, speed: Speed) -> Vec<usize> {
+    let inc = match speed {
+        Speed::High => (interval_slots.max(1).div_ceil(8)) as usize,
+        _ => interval_slots.max(1) as usize,
+    };
+    let start = (start_full_frame & 0xffff) as usize & 63;
+    let mut out = Vec::new();
+    let mut frame = start;
+    loop {
+        out.push(frame);
+        frame = (frame + inc) & 63;
+        if frame == start {
+            break;
+        }
+    }
+    out
+}
+
+/// 常驻通道的 ISO 调度参数（首次 submit 时从 ChannelConfig 计算一次）。
+struct IsoChannelSchedule {
+    direction: Direction,
+    pid: Dwc2Pid,
+    schinfo: u32,
+    hcchar: u32,
+    ring_size: usize,
+}
+
+/// 单个包的计划与实际结算结果。
+struct IsoPacketPlan {
+    planned: usize,
+    desc_index: usize,
+    actual: usize,
+    status: TransferStatus,
+}
+
+/// 已在描述符环中编程、按提交顺序等待结算的 ISO 请求。
+struct IsoActiveRequest {
+    id: RequestId,
+    transfer: Dwc2DmaBuffer,
+    packets: Vec<IsoPacketPlan>,
+}
+
+/// 会话级中止原因：cancel 或通道故障。置位后等待 CHHLTD 再整会话结算。
+#[derive(Clone, Copy)]
+enum IsoHaltReason {
+    Cancelled,
+    Fault(Dwc2TransferFault, u32),
+}
+
+impl IsoHaltReason {
+    fn error(self) -> TransferError {
+        match self {
+            IsoHaltReason::Cancelled => TransferError::Cancelled,
+            IsoHaltReason::Fault(fault, hcint) => fault_to_transfer_error(fault, hcint),
+        }
+    }
+}
+
+/// ISO 传输状态机：持有一条常驻通道、一个描述符环与一个在飞请求队列。
+pub(crate) struct IsoChannelState {
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    stats: Dwc2Stats,
+    dma_pool: Dwc2DmaBufferPool,
+    pool: HostChannelPool,
+    next_request_id: u64,
+    schedule: Option<IsoChannelSchedule>,
+    lease: Option<ChannelLease>,
+    ring: Option<DmaDescriptors>,
+    td_last: usize,
+    start_full_frame: u32,
+    pending: VecDeque<IsoActiveRequest>,
+    completed: VecDeque<(
+        RequestId,
+        core::result::Result<TransferCompletion, TransferError>,
+    )>,
+    fatal: Option<IsoHaltReason>,
+}
+
+impl Drop for IsoChannelState {
+    fn drop(&mut self) {
+        if let Some(lease) = self.lease.as_ref()
+            && lease.hardware_active.load(Ordering::Acquire)
+        {
+            error!(
+                "dwc2: leaking ISO channel {} because hardware still references it",
+                lease.channel
+            );
+            // 硬件仍可能引用该通道寄存器/描述符，直接释放会触发租约 Drop 的
+            // quarantine 或释放仍被 DMA 使用的内存；按 non_iso 同类做法遗忘。
+            if let Some(lease) = self.lease.take() {
+                core::mem::forget(lease);
+            }
+            if let Some(ring) = self.ring.take() {
+                core::mem::forget(ring);
+            }
+            while let Some(active) = self.pending.pop_front() {
+                core::mem::forget(active);
+            }
+        }
+    }
+}
+
+impl IsoChannelState {
+    pub(crate) fn new(
+        regs: Dwc2Registers,
+        kernel: Kernel,
+        stats: Dwc2Stats,
+        pool: HostChannelPool,
+    ) -> Self {
+        Self {
+            regs,
+            kernel,
+            stats,
+            dma_pool: Dwc2DmaBufferPool::default(),
+            pool,
+            next_request_id: 1,
+            schedule: None,
+            lease: None,
+            ring: None,
+            td_last: 0,
+            start_full_frame: 0,
+            pending: VecDeque::new(),
+            completed: VecDeque::new(),
+            fatal: None,
+        }
+    }
+
+    /// 在飞或已完成的请求 id（端点回收/配置切换前停稳用）。
+    pub(crate) fn in_flight_request_id(&self) -> Option<RequestId> {
+        self.pending
+            .front()
+            .map(|request| request.id)
+            .or_else(|| self.completed.front().map(|(id, _)| *id))
+    }
+
+    fn allocate_request_id(&mut self) -> RequestId {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
+        RequestId::new(id)
+    }
+
+    fn channel(&self) -> u8 {
+        self.lease
+            .as_ref()
+            .expect("ISO channel must be leased before register access")
+            .channel
+    }
+
+    /// 在生命周期 IRQ-save 门（防本地 DWC2 事件重入）与通道租约
+    /// （排除任务侧寄存器改写）内执行寄存器操作。
+    fn with_lease_guard<T>(
+        &self,
+        operation: impl FnOnce(u8) -> core::result::Result<T, TransferError>,
+    ) -> core::result::Result<T, TransferError> {
+        let lease = self
+            .lease
+            .as_ref()
+            .expect("ISO channel must be leased for register access");
+        lease.completions.with_connected(|| {
+            // SAFETY: the lifecycle IRQ-save gate prevents local DWC2 event
+            // re-entry, while the channel lease excludes task-side mutation.
+            let _guard = unsafe { lease.gate.lock_raw() };
+            operation(lease.channel)
+        })
+    }
+
+    /// ISO 中断使能：XFERCOMPL（IOC 到达）+ CHHLTD（停稳）+ 致命故障位；
+    /// IN 侧额外使能 XACTERR/BBLERR（Linux `dwc2_hc_enable_slave_ints` ISO 分支）。
+    /// 注意不使能 ACK：Linux 在 IRQ 处理器里单独处理 ACK，本驱动任务侧结算
+    /// 模型下 ACK 中断会造成无 XFERCOMPL 的误发布。
+    fn iso_hcintmsk(direction: Direction) -> u32 {
+        let mut mask = HCINT_XFERCOMPL | HCINT_CHHLTD | HCINT_FRMOVRN | HCINT_AHBERR;
+        if matches!(direction, Direction::In) {
+            mask |= HCINT_XACTERR | HCINT_BBLERR;
+        }
+        mask
+    }
+
+    /// 首次 submit 时初始化常驻通道的“非使能”部分：租借通道、分配描述符环、
+    /// 计算调度参数并编程通道寄存器。返回 `true` 表示本次新建（需要随后
+    /// `start_channel`）。已有通道时直接返回 `false` 复用。
+    fn ensure_channel(
+        &mut self,
+        cfg: &ChannelConfig,
+        direction: Direction,
+        interval_slots: u32,
+        speed: Speed,
+        ring_size: usize,
+    ) -> core::result::Result<bool, TransferError> {
+        if self.lease.is_some() {
+            return Ok(false);
+        }
+        let lease = self.pool.acquire(false)?;
+        let ring = DmaDescriptors::new(&self.kernel, ring_size, DWC2_DMA_ALIGN).map_err(|err| {
+            TransferError::Other(anyhow!("DWC2 ISO descriptor ring alloc failed: {err}"))
+        })?;
+        self.stats.record_dma_alloc();
+        self.lease = Some(lease);
+        self.ring = Some(ring);
+
+        let mult = cfg.info.packets_per_microframe.max(1) as u8;
+        self.schedule = Some(IsoChannelSchedule {
+            direction,
+            pid: iso_pid(speed, direction, mult),
+            schinfo: iso_schinfo(speed, interval_slots),
+            hcchar: hcchar(
+                cfg.device_address,
+                endpoint_number(cfg.info.address.raw()),
+                direction,
+                Dwc2EpType::Isochronous,
+                cfg.info.max_packet_size.max(1),
+                false,
+                mult,
+            ),
+            ring_size,
+        });
+
+        let start_full = iso_starting_frame(self.regs.frame_number(), speed);
+        self.start_full_frame = start_full;
+        self.td_last = frame_to_desc_idx(speed, start_full);
+
+        // 通道仍禁用：硬件不会取描述符，可以安全编程寄存器。IRQ-save 门
+        // 防止事件处理器在寄存器写入中间重入。
+        let schedule = self.schedule.as_ref().expect("schedule set above");
+        let ring_addr = self.ring.as_ref().expect("ring set above").dma_addr();
+        let mask = Self::iso_hcintmsk(direction);
+        let hctsiz = hctsiz_ddma(schedule.pid, schedule.ring_size as u32, schedule.schinfo);
+        self.with_lease_guard(|channel| {
+            let ch = self.regs.channel(channel);
+            ch.set_hcsplt(0);
+            ch.clear_all_irqs();
+            ch.set_hcintmsk(mask);
+            ch.set_hctsiz(hctsiz);
+            mb();
+            ch.set_hcdma(ring_addr);
+            mb();
+            Ok(())
+        })
+        .inspect_err(|_| {
+            // 连接已断开：回滚半初始化状态（通道从未使能，安全释放）。
+            self.release_idle_channel();
+        })?;
+        Ok(true)
+    }
+
+    /// 装载 FrameList 并 CHENA 使能通道（首次使能；描述符已就绪后才调用，
+    /// 避免硬件在首个服务帧取到零描述符）。`mark_iso` 在使能前置位，
+    /// 防止早期 XFERCOMPL 被事件处理器按非 ISO 路径 defer+关闭。
+    fn start_channel(
+        &mut self,
+        interval_slots: u32,
+        speed: Speed,
+    ) -> core::result::Result<(), TransferError> {
+        self.pool.completions.mark_iso(self.channel(), true);
+        self.pool.periodic.ensure_enabled(self.regs);
+        let frames = iso_service_frames(self.start_full_frame, interval_slots, speed);
+        self.pool.periodic.set_channel(self.channel(), &frames);
+        let schedule = self
+            .schedule
+            .as_ref()
+            .expect("schedule must exist when starting channel");
+        self.with_lease_guard(|channel| {
+            self.regs.channel(channel).enable(schedule.hcchar);
+            Ok(())
+        })?;
+        self.lease
+            .as_ref()
+            .expect("lease must exist when starting channel")
+            .hardware_active
+            .store(true, Ordering::Release);
+        log::debug!(
+            "dwc2: iso channel {} enabled start_frame={} interval={} ring={}",
+            self.channel(),
+            self.start_full_frame,
+            interval_slots,
+            schedule.ring_size,
+        );
+        Ok(())
+    }
+
+    /// 释放常驻通道（无在飞请求时调用）：清 FrameList、标记非 ISO、清空并
+    /// 释放描述符环与租约。不访问寄存器，因此断开路径也安全。
+    fn release_idle_channel(&mut self) {
+        let Some(lease) = self.lease.take() else {
+            return;
+        };
+        self.pool.periodic.clear_channel(lease.channel);
+        self.pool.completions.mark_iso(lease.channel, false);
+        // 通道已停（或从未使能/已断开），清空环描述符（A=0）后再释放，
+        // 避免硬件读到陈旧 A 位。
+        if let Some(ring) = self.ring.take() {
+            ring.clear_all();
+        }
+        self.schedule = None;
+        self.td_last = 0;
+        self.start_full_frame = 0;
+        lease.release();
+    }
+
+    fn prepare_request(
+        &mut self,
+        cfg: &ChannelConfig,
+        id: RequestId,
+        request: TransferRequest,
+        interval_slots: u32,
+    ) -> core::result::Result<IsoActiveRequest, TransferError> {
+        // submit 已校验请求形态（Isochronous + 非空包 + 有缓冲）。
+        let direction = request.direction();
+        let buffer = request
+            .buffer()
+            .expect("ISO request buffer must exist after submit validation");
+        let packets = request.iso_packets();
+        let speed = cfg.port_speed;
+        let ring_size = iso_ring_size(speed);
+
+        // 1. 包长校验：每包不得超过速度对应的最大 ISO 传输长度与描述符
+        //    12 位 ISO NBYTES 上限（Linux MAX_ISOC_XFER_SIZE_* 同款语义）。
+        let max_xfer = iso_max_xfer_size(speed);
+        for (i, packet) in packets.iter().enumerate() {
+            if packet.length > max_xfer || packet.length > DmaDescriptor::ISO_NBYTES_LIMIT as usize
+            {
+                return Err(TransferError::Other(anyhow!(
+                    "DWC2 ISO packet {i} length {} exceeds limit {max_xfer}",
+                    packet.length
+                )));
+            }
+        }
+
+        // 2. 分配 DMA 传输缓冲：coherent 分配 + IN 清零/OUT 拷贝调用方数据。
+        //    ISO 按各包精确长度之和分配（desc 按精确长度编程，不取整）。
+        self.stats.record_transfer();
+        let len = packets.iter().map(|packet| packet.length).sum::<usize>();
+        if buffer.len != len {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 ISO request buffer len {} != sum of packet lengths {len}",
+                buffer.len
+            )));
+        }
+        let transfer = Dwc2DmaBuffer::new(
+            &self.kernel,
+            &mut self.dma_pool,
+            &self.stats,
+            Some(buffer),
+            direction,
+            len,
+        )?;
+        // 3. 计算各包 DMA 地址
+        let mut paddrs = Vec::with_capacity(packets.len());
+        let mut offset = 0u64;
+        for packet in packets {
+            paddrs.push(dma_addr32(transfer.dma_addr() + offset)?);
+            offset += packet.length as u64;
+        }
+        // 4. 初始化常驻通道（仅首次 submit）：租借通道、分配描述符环、
+        //    计算调度参数并编程通道寄存器；已有通道时直接复用。
+        let first_time = self.ensure_channel(cfg, direction, interval_slots, speed, ring_size)?;
+
+        // 5. 计算插入索引：队尾请求仍未服务（其末包描述符 A 位仍置位，硬件
+        //    取指至少一个 interval 之后）时紧跟环尾插入，流水线无缝衔接；
+        //    否则按当前帧推进到下一个未来网格槽位，避免把描述符编程到硬件
+        //    已越过的位置。
+        let cur_full = iso_starting_frame(self.regs.frame_number(), speed);
+        let target = frame_to_desc_idx(speed, cur_full);
+        let insert = if self.pending_tail_active() {
+            self.td_last
+        } else {
+            advance_along_grid(self.td_last, target, interval_slots as usize, ring_size)
+        };
+
+        // 6. 写入描述符环：每包一个 desc、按 interval 步进，末包置 IOC；
+        //    同时构建结算用计划表（desc_index 与计划长度）。
+        let ring = self
+            .ring
+            .as_ref()
+            .expect("ring must exist after ensure_channel");
+        let mut plans = Vec::with_capacity(packets.len());
+        for (i, (packet, paddr)) in packets.iter().zip(paddrs).enumerate() {
+            let index = (insert + i * interval_slots as usize) % ring_size;
+            let last = i + 1 == packets.len();
+            ring.write_descs(
+                index,
+                core::slice::from_ref(&DmaDescriptor::new_iso(paddr, packet.length as u32, last)),
+            );
+            plans.push(IsoPacketPlan {
+                planned: packet.length,
+                desc_index: index,
+                actual: 0,
+                status: TransferStatus::Completed,
+            });
+        }
+
+        // 7. 首次使能通道：描述符已写入环后才 CHENA，避免硬件在首个服务
+        //    帧取到零描述符。
+        if first_time && let Err(err) = self.start_channel(interval_slots, speed) {
+            // 使能失败（如连接断开）：尽力停通道后释放，避免留下永不启动的
+            // 半初始化常驻通道。
+            let _ = self.halt_channel();
+            self.release_idle_channel();
+            return Err(err);
+        }
+
+        // 8. 推进环尾游标（下次续插位置），记录统计与调试日志。
+        self.stats.record_stage();
+        self.td_last = (insert + packets.len() * interval_slots as usize) % ring_size;
+        log::debug!(
+            "dwc2: iso submit ch={} id={} packets={} insert={} td_last={} queued={}",
+            self.channel(),
+            id.raw(),
+            packets.len(),
+            insert,
+            self.td_last,
+            self.pending.len() + 1,
+        );
+
+        Ok(IsoActiveRequest {
+            id,
+            transfer,
+            packets: plans,
+        })
+    }
+
+    fn halt_channel(&self) -> core::result::Result<(), TransferError> {
+        if self.lease.is_none() {
+            return Ok(());
+        }
+        self.with_lease_guard(|channel| {
+            self.regs.channel(channel).disable();
+            Ok(())
+        })
+    }
+
+    /// 结算一个完成请求：读回各包描述符、计算实际长度与错误状态，清空本请求
+    /// 描述符（A=0）以防环回绕时被重复服务。通道保持使能，FrameList 不清。
+    fn settle_request(
+        &self,
+        active: &mut IsoActiveRequest,
+    ) -> core::result::Result<TransferCompletion, TransferError> {
+        let ring = self.ring.as_ref().expect("ISO ring must exist");
+        let schedule = self.schedule.as_ref().expect("ISO schedule must exist");
+        let is_in = matches!(schedule.direction, Direction::In);
+        let mut actual_total = 0usize;
+        for plan in active.packets.iter_mut() {
+            let desc = &ring.read_descs(plan.desc_index, 1)[0];
+            let actual = if is_in {
+                plan.planned.saturating_sub(desc.iso_remaining() as usize)
+            } else {
+                plan.planned
+            };
+            plan.actual = actual;
+            plan.status = if desc.iso_status_error() {
+                TransferStatus::Error
+            } else {
+                TransferStatus::Completed
+            };
+            actual_total += actual;
+        }
+        for plan in &active.packets {
+            ring.clear(plan.desc_index);
+        }
+
+        // IN：拷回整段请求区（未收满的槽位保持初始 0，调用方可整槽读取）。
+        active
+            .transfer
+            .copy_in_to_request(active.transfer.buffer_len())?;
+        Ok(TransferCompletion {
+            request_id: active.id,
+            status: TransferStatus::Completed,
+            actual_length: actual_total,
+            iso_packets: active
+                .packets
+                .iter()
+                .map(|plan| IsoPacketResult {
+                    requested_length: plan.planned,
+                    actual_length: plan.actual,
+                    status: plan.status,
+                })
+                .collect(),
+        })
+    }
+
+    /// 队尾请求的最后一个包描述符是否仍为活动（未服务）。活动时环尾
+    /// `td_last` 至少在下一个 interval 之后才被硬件取指，可安全续插，
+    /// 流水线无需等待上一条完成。
+    fn pending_tail_active(&self) -> bool {
+        self.pending
+            .back()
+            .is_some_and(|request| self.last_desc_active(request))
+    }
+
+    /// 队首请求是否已被硬件服务（其最后一个包描述符的 A 位被硬件回写清零）。
+    /// 服务先于中断发生，因此回读必在中断触发后的任务侧可见；该回读用于
+    /// 覆盖 XFERCOMPL 位被同批消费（中断合并）时丢失的后续完成。
+    fn head_serviced(&self) -> bool {
+        !self.last_desc_active(self.pending.front().expect("called with non-empty pending"))
+    }
+
+    /// 请求最后一个包描述符的 A 位回读（硬件服务后随状态字回写清零）。
+    fn last_desc_active(&self, request: &IsoActiveRequest) -> bool {
+        let index = request
+            .packets
+            .last()
+            .expect("ISO request has at least one packet")
+            .desc_index;
+        self.ring
+            .as_ref()
+            .expect("ISO ring must exist while requests are pending")
+            .read_descs(index, 1)[0]
+            .is_active()
+    }
+
+    /// 结算队首已服务请求并移入完成队列。`bit_done` 为本次消费到的
+    /// XFERCOMPL 位（覆盖第一个请求的结算，不依赖 A 位回写），其后逐项
+    /// 以 A 位回读结算同一批中已服务的请求。
+    fn drain_serviced(&mut self, bit_done: bool) {
+        let mut done = bit_done;
+        while !self.pending.is_empty() {
+            if !(done || self.head_serviced()) {
+                break;
+            }
+            let mut head = self.pending.pop_front().expect("non-empty checked above");
+            let result = self.settle_request(&mut head);
+            self.dma_pool.reclaim(head.transfer);
+            self.completed.push_back((head.id, result));
+            done = false;
+        }
+    }
+
+    /// 终止整会话：把全部在飞请求结算为同一错误并释放常驻通道。
+    /// 不访问寄存器，因此断开路径也安全。
+    fn settle_all_with(&mut self, mk_err: impl FnMut() -> TransferError) {
+        self.fatal = None;
+        let mut mk_err = mk_err;
+        while let Some(active) = self.pending.pop_front() {
+            self.dma_pool.reclaim(active.transfer);
+            self.completed.push_back((active.id, Err(mk_err())));
+        }
+        self.release_idle_channel();
+    }
+
+    /// 从完成队列取走指定 id 的结果（允许乱序 reclaim）。
+    fn take_completed(
+        &mut self,
+        id: RequestId,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        let pos = self
+            .completed
+            .iter()
+            .position(|(done_id, _)| *done_id == id)?;
+        self.completed.remove(pos).map(|(_, result)| result)
+    }
+
+    /// 推进状态机：消费通道完成位，结算所有已服务的在飞请求；cancel/故障/
+    /// 断开则整会话结算。所有结果进入 `completed` 队列，由 `reclaim` 取走。
+    fn poll_channel(&mut self) {
+        if self.lease.is_none() {
+            return;
+        }
+        let channel = self.channel();
+        let Some(hcint) = self.pool.completions.take(channel) else {
+            return;
+        };
+
+        if hcint & DWC2_COMPLETION_DISCONNECTED != 0 {
+            self.settle_all_with(|| TransferError::Disconnected);
+            return;
+        }
+
+        if let Some(fault) = hcint_fault(hcint) {
+            self.stats.record_fault(fault);
+            warn!("dwc2: iso channel fault ch={channel} hcint={hcint:#x}");
+            if hcint & HCINT_CHHLTD != 0 {
+                // 硬件已自行停稳（CHHLTD 同批到达），直接整会话结算。
+                self.settle_all_with(|| fault_to_transfer_error(fault, hcint));
+            } else {
+                // 硬件尚未停：置中止原因并下发 halt，等 CHHLTD 确认后结算。
+                self.fatal = Some(IsoHaltReason::Fault(fault, hcint));
+                let _ = self.halt_channel();
+            }
+            return;
+        }
+
+        if let Some(reason) = self.fatal {
+            if hcint & HCINT_CHHLTD == 0 {
+                // 停稳确认未到：halt 已在置中止原因时下发，继续等待。
+                return;
+            }
+            self.settle_all_with(move || reason.error());
+            return;
+        }
+
+        if hcint & HCINT_CHHLTD != 0 {
+            // 无中止原因却停稳：通道意外停摆，防御性整会话结算。
+            warn!("dwc2: iso channel halted without fault ch={channel} hcint={hcint:#x}");
+            self.settle_all_with(|| {
+                TransferError::Other(anyhow!(
+                    "DWC2 ISO channel halted without completion hcint={hcint:#x}"
+                ))
+            });
+            return;
+        }
+
+        // 正常路径：结算本批已服务的请求（本次 XFERCOMPL 位 + A 位回读）。
+        self.drain_serviced(hcint & HCINT_XFERCOMPL != 0);
+    }
+}
+
+// ═══════════════════════════════════════════
+// 状态机对外接口
+// ═══════════════════════════════════════════
+
+impl IsoChannelState {
+    /// 提交一次 ISO 传输并立即编程入环（常驻通道在首次 submit 时自行租借）。
+    /// 环容量不足（在飞包数总和达到 `iso_max_packets`）时返回 `QueueFull`。
+    pub(crate) fn submit(
+        &mut self,
+        cfg: &ChannelConfig,
+        request: TransferRequest,
+    ) -> core::result::Result<RequestId, TransferError> {
+        // 1. 入口校验：中止中的会话（QueueFull）、Low-speed（NotSupported）、
+        //    非 ISO 请求或空包/无缓冲（InvalidEndpoint）一律拒绝。
+        if self.fatal.is_some() {
+            // 会话正在中止（cancel/故障），停稳结算后由下一次 submit 建立新会话。
+            return Err(TransferError::QueueFull);
+        }
+        if matches!(cfg.port_speed, Speed::Low) {
+            return Err(TransferError::NotSupported);
+        }
+        if !matches!(request, TransferRequest::Isochronous { .. }) {
+            return Err(TransferError::InvalidEndpoint);
+        }
+        if request.iso_packets().is_empty() {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 ISO request has no packets"
+            )));
+        }
+        if request.buffer().is_none() {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 ISO request has no buffer"
+            )));
+        }
+
+        // 2. 环容量反压：在飞包数总和不得超过 ring/gcd(interval, ring) − 1，
+        //    否则描述符索引按 interval 步进回绕会与未服务槽位碰撞。
+        let interval_slots = u32::from(cfg.info.interval.max(1));
+        let max_packets = iso_max_packets(interval_slots, cfg.port_speed);
+        let in_ring = self
+            .pending
+            .iter()
+            .map(|request| request.packets.len())
+            .sum::<usize>();
+        let packet_count = request.iso_packets().len();
+        if in_ring + packet_count > max_packets {
+            if self.pending.is_empty() {
+                return Err(TransferError::Other(anyhow!(
+                    "DWC2 ISO request has {packet_count} packets exceeding ring capacity \
+                     {max_packets} (interval={interval_slots}, ring={})",
+                    iso_ring_size(cfg.port_speed),
+                )));
+            }
+            return Err(TransferError::QueueFull);
+        }
+
+        // 3. 分配请求 id，编程入环后入队，之后由硬件按帧调度服务。
+        let id = self.allocate_request_id();
+        let active = self.prepare_request(cfg, id, request, interval_slots)?;
+        self.pending.push_back(active);
+        Ok(id)
+    }
+
+    /// 取走指定 id 的完成结果。结果未就绪时推进状态机后再取；id 仍
+    /// 在飞返回 `None`，未知 id 返回 `InvalidEndpoint`。
+    pub(crate) fn reclaim(
+        &mut self,
+        id: RequestId,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        if let Some(result) = self.take_completed(id) {
+            return Some(result);
+        }
+        self.poll_channel();
+        if let Some(result) = self.take_completed(id) {
+            return Some(result);
+        }
+        if self.pending.iter().any(|request| request.id == id) {
+            None
+        } else {
+            Some(Err(TransferError::InvalidEndpoint))
+        }
+    }
+
+    pub(crate) fn register_waker(&self, id: RequestId, cx: &mut Context<'_>) {
+        if self.pending.iter().any(|request| request.id == id)
+            && let Some(lease) = self.lease.as_ref()
+        {
+            lease.completions.register_waker(lease.channel, cx);
+        }
+    }
+
+    /// 取消请求：结果已入完成队列则改写为 Cancelled；在飞请求则停通道、
+    /// 停稳后整会话结算为 Cancelled（Linux `dwc2_hcd_urb_dequeue` 同款
+    /// 会话终止语义，后续 submit 建立新会话）。
+    pub(crate) fn cancel(&mut self, id: RequestId) -> core::result::Result<(), TransferError> {
+        if let Some(entry) = self
+            .completed
+            .iter_mut()
+            .find(|(done_id, _)| *done_id == id)
+        {
+            entry.1 = Err(TransferError::Cancelled);
+            return Ok(());
+        }
+        if !self.pending.iter().any(|request| request.id == id) {
+            return Err(TransferError::InvalidEndpoint);
+        }
+        if self.fatal.is_some() {
+            // 会话已在终止（cancel/故障）等待停稳，重复取消为无操作。
+            return Ok(());
+        }
+        self.fatal = Some(IsoHaltReason::Cancelled);
+        let result = self.halt_channel();
+        if matches!(result, Err(TransferError::Disconnected)) {
+            return Ok(());
+        }
+        result
+    }
+
+    pub(crate) fn reset(&mut self) -> core::result::Result<(), TransferError> {
+        if self.pending.is_empty() && self.completed.is_empty() && self.fatal.is_none() {
+            self.td_last = 0;
+            Ok(())
+        } else {
+            Err(TransferError::QueueFull)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::vec;
+
+    use super::*;
+
+    #[test]
+    fn iso_ring_size_follows_speed() {
+        assert_eq!(iso_ring_size(Speed::High), 256);
+        assert_eq!(iso_ring_size(Speed::Full), 64);
+        assert_eq!(iso_ring_size(Speed::Low), 64);
+    }
+
+    #[test]
+    fn iso_schinfo_bitmap_matches_linux() {
+        // HS 每帧微帧位图：interval=1 → 全部 8 微帧；2 → 0,2,4,6；8 → 仅微帧 0。
+        assert_eq!(iso_schinfo(Speed::High, 1), 0xff);
+        assert_eq!(iso_schinfo(Speed::High, 2), 0x55);
+        assert_eq!(iso_schinfo(Speed::High, 4), 0x11);
+        assert_eq!(iso_schinfo(Speed::High, 8), 0x01);
+        assert_eq!(iso_schinfo(Speed::High, 16), 0x01);
+        // 非 HS 恒 0xff。
+        assert_eq!(iso_schinfo(Speed::Full, 1), 0xff);
+        assert_eq!(iso_schinfo(Speed::Full, 16), 0xff);
+    }
+
+    #[test]
+    fn iso_pid_matches_linux_pid_table() {
+        assert_eq!(iso_pid(Speed::High, Direction::In, 1), Dwc2Pid::Data0);
+        assert_eq!(iso_pid(Speed::High, Direction::In, 2), Dwc2Pid::Data1);
+        assert_eq!(iso_pid(Speed::High, Direction::In, 3), Dwc2Pid::Data2);
+        assert_eq!(iso_pid(Speed::High, Direction::Out, 1), Dwc2Pid::Data0);
+        assert_eq!(iso_pid(Speed::High, Direction::Out, 2), Dwc2Pid::MData);
+        assert_eq!(iso_pid(Speed::Full, Direction::In, 3), Dwc2Pid::Data0);
+        assert_eq!(iso_pid(Speed::Full, Direction::Out, 3), Dwc2Pid::Data0);
+    }
+
+    #[test]
+    fn frame_to_desc_idx_aligns_hs_to_frame_0_microframe() {
+        // HS：整帧 0 → 索引 0，整帧 1 → 索引 8，整帧 32 → 回绕 0。
+        assert_eq!(frame_to_desc_idx(Speed::High, 0), 0);
+        assert_eq!(frame_to_desc_idx(Speed::High, 1), 8);
+        assert_eq!(frame_to_desc_idx(Speed::High, 31), 248);
+        assert_eq!(frame_to_desc_idx(Speed::High, 32), 0);
+        // FS：帧号 mod 64 直接作索引。
+        assert_eq!(frame_to_desc_idx(Speed::Full, 0), 0);
+        assert_eq!(frame_to_desc_idx(Speed::Full, 63), 63);
+        assert_eq!(frame_to_desc_idx(Speed::Full, 64), 0);
+    }
+
+    #[test]
+    fn iso_starting_frame_skips_race_margin() {
+        // HS 微帧位 <5 跳过 1 帧，>=5 跳过 2 帧，结果对齐整帧。
+        assert_eq!(iso_starting_frame(0x10, Speed::High), (0x10 >> 3) + 1);
+        assert_eq!(iso_starting_frame(0x15, Speed::High), (0x15 >> 3) + 2);
+        // FS 恒跳过 2 帧。
+        assert_eq!(iso_starting_frame(0x10, Speed::Full), 0x12);
+    }
+
+    #[test]
+    fn advance_along_grid_keeps_schedule_residue() {
+        // HS interval=8（整除 256）：保持 mod 8 同余，推进到 >= target。
+        assert_eq!(advance_along_grid(8, 20, 8, 256), 24);
+        // 已越过时对齐到下一网格点。
+        assert_eq!(advance_along_grid(8, 4, 8, 256), 8);
+        // 环回绕：target 低、td_last 高时推进到下一圈。
+        assert_eq!(advance_along_grid(248, 4, 8, 256), 8);
+        // interval=3 与 ring=256 互质：任意索引均在调度网格上，直接取 target。
+        assert_eq!(advance_along_grid(0, 10, 3, 256), 10);
+        // FS interval=4（gcd(4,64)=4）：推进到 mod 4 同余。
+        assert_eq!(advance_along_grid(8, 10, 4, 64), 12);
+    }
+
+    #[test]
+    fn iso_max_packets_prevents_ring_collision() {
+        // HS interval 整除 256：max = 256/interval − 1。
+        assert_eq!(iso_max_packets(1, Speed::High), 255);
+        assert_eq!(iso_max_packets(8, Speed::High), 31);
+        assert_eq!(iso_max_packets(16, Speed::High), 15);
+        // FS interval=1 → 63；interval=48（gcd(48,64)=16）→ 3。
+        assert_eq!(iso_max_packets(1, Speed::Full), 63);
+        assert_eq!(iso_max_packets(48, Speed::Full), 3);
+        assert_eq!(iso_max_packets(7, Speed::Full), 63);
+    }
+
+    #[test]
+    fn iso_service_frames_covers_full_rollover_cycle() {
+        // FS interval=8：从起始帧起每 8 帧一个服务帧，共 8 个。
+        let frames = iso_service_frames(0, 8, Speed::Full);
+        assert_eq!(frames, vec![0, 8, 16, 24, 32, 40, 48, 56]);
+        // HS interval=8（微帧）→ 每 1 帧服务，覆盖全部 64 帧。
+        let frames = iso_service_frames(3, 8, Speed::High);
+        assert_eq!(frames.len(), 64);
+        assert!(frames.contains(&3));
+        // HS interval=16（微帧）→ 每 2 帧服务，从奇数起始帧开始覆盖 32 个奇数帧。
+        let frames = iso_service_frames(1, 16, Speed::High);
+        assert_eq!(frames.len(), 32);
+        assert!(frames.iter().all(|f| f % 2 == 1));
+        // FS interval=3（gcd(3,64)=1）覆盖全部 64 帧。
+        let frames = iso_service_frames(0, 3, Speed::Full);
+        assert_eq!(frames.len(), 64);
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/channel/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/channel/mod.rs
@@ -1,0 +1,354 @@
+pub mod iso;
+pub mod non_iso;
+
+use alloc::{sync::Arc, vec::Vec};
+use core::{
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+    task::Context,
+};
+
+use ax_sync::SpinLock as Mutex;
+use dma_api::{ContiguousArray, DmaDirection};
+use futures::task::AtomicWaker;
+use mbarrier::mb;
+use tock_registers::interfaces::{Readable, Writeable};
+use usb_if::{endpoint::EndpointInfo, err::TransferError, host::hub::Speed};
+
+use super::{
+    Kernel,
+    reg::{DWC2_COMPLETION_DISCONNECTED, DWC2_DMA_ALIGN, DWC2_MAX_CHANNELS, Dwc2Registers},
+};
+use crate::backend::kmod::dwc2::{HCFG_FRLISTEN_64, HCFG_FRLISTEN_MASK, HCFG_PERSCHEDENA};
+
+/// 端点级通道配置
+pub(crate) struct ChannelConfig {
+    pub(crate) device_address: u8,
+    pub(crate) info: EndpointInfo,
+    pub(crate) port_speed: Speed,
+}
+
+// ═══════════════════════════════════════════
+// 控制器级 Host Periodic Frame List
+// ═══════════════════════════════════════════
+
+/// DWC2 Host Periodic Frame List（Linux HFLBADDR + HCFG.PERSCHEDENA）。
+///
+/// 64 项 u32 帧位图，bit n = 通道 n 在对应帧被周期调度。DDMA 模式下
+/// 周期传输必须通过帧列表调度（Linux `dwc2_per_sched_enable` 在首个周期
+/// QH 时使能），ISO 通道激活时置位、释放时清位。
+pub(crate) struct Dwc2PeriodicSchedule {
+    inner: Arc<Dwc2PeriodicScheduleInner>,
+}
+
+struct Dwc2PeriodicScheduleInner {
+    data: ContiguousArray<u8>,
+    dma_addr: u32,
+    enabled: AtomicBool,
+    gate: Mutex<()>,
+}
+
+impl Dwc2PeriodicSchedule {
+    pub(crate) fn new(kernel: &Kernel) -> Result<Self, anyhow::Error> {
+        let data = kernel
+            .contiguous_array_zero_with_align::<u8>(64 * 4, DWC2_DMA_ALIGN, DmaDirection::ToDevice)
+            .map_err(|err| anyhow!("DWC2 frame list alloc failed: {err}"))?;
+        let dma_addr = u32::try_from(data.dma_addr().as_u64())
+            .map_err(|_| anyhow!("DWC2 frame list DMA above 32-bit mask"))?;
+        Ok(Self {
+            inner: Arc::new(Dwc2PeriodicScheduleInner {
+                data,
+                dma_addr,
+                enabled: AtomicBool::new(false),
+                gate: Mutex::new(()),
+            }),
+        })
+    }
+
+    /// 首次 ISO 通道激活时使能周期调度并装载帧列表（幂等）。
+    pub(crate) fn ensure_enabled(&self, regs: Dwc2Registers) {
+        let _guard = self.inner.gate.lock();
+        if self.inner.enabled.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        regs.regs().hflbaddr.set(self.inner.dma_addr);
+        let hcfg = regs.regs().hcfg.get();
+        regs.regs()
+            .hcfg
+            .set((hcfg & !HCFG_FRLISTEN_MASK) | HCFG_FRLISTEN_64 | HCFG_PERSCHEDENA);
+        log::debug!(
+            "dwc2: periodic schedule enabled (frame list @ {:#010x})",
+            self.inner.dma_addr
+        );
+    }
+
+    /// 在帧位图中置位通道的每个服务帧。
+    pub(crate) fn set_channel(&self, channel: u8, frames: &[usize]) {
+        let _guard = self.inner.gate.lock();
+        let ptr = self.inner.data.as_ptr().as_ptr() as *mut u32;
+        for &frame in frames {
+            let index = frame & 63;
+            let value = unsafe { ptr.add(index).read_volatile() };
+            unsafe { ptr.add(index).write_volatile(value | (1u32 << channel)) };
+        }
+        self.inner.data.sync_for_device_all();
+        mb();
+    }
+
+    /// 清掉通道在帧位图中的所有位（释放通道时调用）。
+    pub(crate) fn clear_channel(&self, channel: u8) {
+        let _guard = self.inner.gate.lock();
+        let ptr = self.inner.data.as_ptr().as_ptr() as *mut u32;
+        for index in 0..64 {
+            let value = unsafe { ptr.add(index).read_volatile() };
+            unsafe { ptr.add(index).write_volatile(value & !(1u32 << channel)) };
+        }
+        self.inner.data.sync_for_device_all();
+        mb();
+    }
+}
+
+struct Dwc2ChannelCompletionSlot {
+    hcint: AtomicU32,
+    deferred_hcint: AtomicU32,
+    busy: AtomicBool,
+    iso: AtomicBool,
+    waker: AtomicWaker,
+}
+
+impl Dwc2ChannelCompletionSlot {
+    fn new() -> Self {
+        Self {
+            hcint: AtomicU32::new(0),
+            deferred_hcint: AtomicU32::new(0),
+            busy: AtomicBool::new(false),
+            iso: AtomicBool::new(false),
+            waker: AtomicWaker::new(),
+        }
+    }
+
+    fn try_begin_request(&self) -> bool {
+        self.busy
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    fn end_request(&self) {
+        self.busy.store(false, Ordering::Release);
+        self.iso.store(false, Ordering::Release);
+        self.clear();
+    }
+
+    fn clear(&self) {
+        self.hcint.store(0, Ordering::Release);
+        self.deferred_hcint.store(0, Ordering::Release);
+    }
+
+    fn publish(&self, hcint: u32) {
+        let deferred = self.deferred_hcint.swap(0, Ordering::AcqRel);
+        self.hcint.fetch_or(hcint | deferred, Ordering::AcqRel);
+        self.waker.wake();
+    }
+
+    fn defer(&self, hcint: u32) {
+        self.deferred_hcint.fetch_or(hcint, Ordering::AcqRel);
+    }
+
+    fn take(&self) -> Option<u32> {
+        let hcint = self.hcint.swap(0, Ordering::AcqRel);
+        (hcint != 0).then_some(hcint)
+    }
+
+    fn register_waker(&self, cx: &mut Context<'_>) {
+        self.waker.register(cx.waker());
+    }
+
+    fn mark_iso(&self, iso: bool) {
+        self.iso.store(iso, Ordering::Release);
+    }
+
+    fn is_iso(&self) -> bool {
+        self.iso.load(Ordering::Acquire)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct Dwc2ChannelCompletions {
+    slots: Arc<Vec<Dwc2ChannelCompletionSlot>>,
+    connected: Arc<AtomicBool>,
+    lifecycle_gate: Arc<Mutex<()>>,
+}
+
+impl Dwc2ChannelCompletions {
+    pub(crate) fn new() -> Self {
+        Self {
+            slots: Arc::new(
+                (0..usize::from(DWC2_MAX_CHANNELS))
+                    .map(|_| Dwc2ChannelCompletionSlot::new())
+                    .collect(),
+            ),
+            connected: Arc::new(AtomicBool::new(true)),
+            lifecycle_gate: Arc::new(Mutex::new(())),
+        }
+    }
+
+    fn slot(&self, channel: u8) -> &Dwc2ChannelCompletionSlot {
+        &self.slots[usize::from(channel)]
+    }
+
+    pub(crate) fn try_begin_request(&self, channel: u8) -> bool {
+        self.slot(channel).try_begin_request()
+    }
+
+    pub(crate) fn end_request(&self, channel: u8) {
+        self.slot(channel).end_request();
+    }
+
+    pub(crate) fn clear(&self, channel: u8) {
+        self.slot(channel).clear();
+    }
+
+    pub(crate) fn publish(&self, channel: u8, hcint: u32) {
+        self.slot(channel).publish(hcint);
+    }
+
+    pub(crate) fn defer(&self, channel: u8, hcint: u32) {
+        self.slot(channel).defer(hcint);
+    }
+
+    pub(crate) fn take(&self, channel: u8) -> Option<u32> {
+        self.slot(channel).take()
+    }
+
+    pub(crate) fn register_waker(&self, channel: u8, cx: &mut Context<'_>) {
+        self.slot(channel).register_waker(cx);
+    }
+
+    /// 标记通道当前处于 ISO 常驻模式（IRQ 侧据此直发 XFERCOMPL 而不关通道）。
+    pub(crate) fn mark_iso(&self, channel: u8, iso: bool) {
+        self.slot(channel).mark_iso(iso);
+    }
+
+    pub(crate) fn is_iso(&self, channel: u8) -> bool {
+        self.slot(channel).is_iso()
+    }
+
+    fn is_connected(&self) -> bool {
+        self.connected.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn mark_connected(&self, configure_irqs: impl FnOnce()) {
+        let _guard = self.lifecycle_gate.lock_irqsave();
+        configure_irqs();
+        self.connected.store(true, Ordering::Release);
+    }
+
+    pub(crate) fn disconnect_all_with(&self, mask_channel_irqs: impl FnOnce()) {
+        let _guard = self.lifecycle_gate.lock_irqsave();
+        // DISCONNINT is the controller's hardware confirmation that the host
+        // bus transaction has ended. From this point the host-channel
+        // registers may no longer be accessed, so publish terminal ownership
+        // release directly instead of trying to synthesize CHHLTD or CHDIS.
+        self.connected.store(false, Ordering::Release);
+        mask_channel_irqs();
+        for slot in self
+            .slots
+            .iter()
+            .filter(|slot| slot.busy.load(Ordering::Acquire))
+        {
+            slot.publish(DWC2_COMPLETION_DISCONNECTED);
+        }
+    }
+
+    pub(crate) fn with_connected<T>(
+        &self,
+        operation: impl FnOnce() -> core::result::Result<T, TransferError>,
+    ) -> core::result::Result<T, TransferError> {
+        let _guard = self.lifecycle_gate.lock_irqsave();
+        if !self.is_connected() {
+            return Err(TransferError::Disconnected);
+        }
+        operation()
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct HostChannelPool {
+    pub(crate) channel_count: u8,
+    pub(crate) completions: Dwc2ChannelCompletions,
+    pub(crate) periodic: Arc<Dwc2PeriodicSchedule>,
+    channel_gates: Arc<Vec<Arc<Mutex<()>>>>,
+}
+
+impl HostChannelPool {
+    pub(crate) fn new(
+        channel_count: u8,
+        completions: Dwc2ChannelCompletions,
+        periodic: Arc<Dwc2PeriodicSchedule>,
+    ) -> Self {
+        let channel_gates = (0..usize::from(channel_count.max(1)))
+            .map(|_| Arc::new(Mutex::new(())))
+            .collect();
+
+        Self {
+            channel_count,
+            completions,
+            periodic,
+            channel_gates: Arc::new(channel_gates),
+        }
+    }
+
+    /// 获取一个可用的通道
+    pub(crate) fn acquire(&self, control: bool) -> Result<ChannelLease, TransferError> {
+        if !self.completions.is_connected() {
+            return Err(TransferError::Disconnected);
+        }
+        let channels = if control { 0..1 } else { 1..self.channel_count };
+        for channel in channels {
+            if self.completions.try_begin_request(channel) {
+                self.completions.clear(channel);
+                let gate = self.channel_gates[usize::from(channel)].clone();
+
+                return Ok(ChannelLease {
+                    channel,
+                    gate,
+                    completions: self.completions.clone(),
+                    released: false,
+                    hardware_active: AtomicBool::new(false),
+                });
+            }
+        }
+        Err(TransferError::QueueFull)
+    }
+}
+
+// ═══════════════════════════════════════════
+// 通道租约（non_iso 与 iso 状态机共用）
+// ═══════════════════════════════════════════
+
+pub(crate) struct ChannelLease {
+    pub(crate) channel: u8,
+    pub(crate) gate: Arc<Mutex<()>>,
+    pub(crate) completions: Dwc2ChannelCompletions,
+    pub(crate) hardware_active: AtomicBool,
+    pub(crate) released: bool,
+}
+
+impl ChannelLease {
+    pub(crate) fn release(mut self) {
+        self.completions.end_request(self.channel);
+        self.released = true;
+    }
+}
+
+impl Drop for ChannelLease {
+    fn drop(&mut self) {
+        if !self.released && !self.hardware_active.load(Ordering::Acquire) {
+            self.completions.end_request(self.channel);
+        } else if !self.released {
+            error!(
+                "dwc2: quarantining host channel {} because hardware stop was not confirmed",
+                self.channel
+            );
+        }
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/channel/non_iso.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/channel/non_iso.rs
@@ -1,0 +1,1144 @@
+//! 非 ISO 传输状态机（control/bulk/interrupt 的 DDMA 阶段推进）。
+//!
+//! 一次传输 = 若干 stage（每条 stage 是一条 A 全置、链尾 IOC+EOL 的 desc 链），
+//! 每 stage 一次通道编程、一次 CHHLTD 完成中断；结算与推进全部在任务侧完成
+//! （IRQ 只通过完成槽发布 hcint 位）。
+
+use alloc::{vec, vec::Vec};
+use core::{sync::atomic::Ordering, task::Context};
+
+use dma_api::CoherentArray;
+use mbarrier::mb;
+use usb_if::{
+    descriptor::EndpointType,
+    endpoint::{RequestId, TransferCompletion, TransferRequest, TransferStatus},
+    err::TransferError,
+    host::{ControlSetup, hub::Speed},
+    transfer::{BmRequestType, Direction},
+};
+
+use crate::backend::kmod::{
+    Kernel,
+    dwc2::{
+        Dwc2EpType, Dwc2Pid,
+        channel::{ChannelConfig, ChannelLease, HostChannelPool},
+        dma::{DmaDescriptor, DmaDescriptors, Dwc2DmaBuffer, Dwc2DmaBufferPool, initial_len},
+        dma_addr32, endpoint_number, fault_to_transfer_error, hcchar, hcint_fault, hctsiz_ddma,
+        reg::{
+            DWC2_COMPLETION_DISCONNECTED, DWC2_DMA_ALIGN, DWC2_MAX_DMA_DESCS, DWC2_STATUS_BUF_SIZE,
+            Dwc2Registers, HCCHAR_EPDIR,
+        },
+        stats::Dwc2Stats,
+    },
+};
+
+// ═══════════════════════════════════════════
+// stage 模型
+// ═══════════════════════════════════════════
+
+/// 一次通道编程（一个 stage = 一条 desc 链，链尾 EOL 后通道自停一次）。
+#[derive(Debug, Clone)]
+struct Dwc2TransferStage {
+    hcchar: u32,
+    hctsiz: u32,       // DDMA 编码（PID | NTD = desc 数 − 1 | SCHINFO）
+    dma_addr: u32,     // 本 stage 数据缓冲基址（desc.buf 从这起按 expect 逐块推进）
+    desc_base: usize,  // 本 stage 在请求 desc 数组中的起始索引（prepare 时分配）
+    descs: Vec<usize>, // 每 desc 的期望长度
+}
+
+impl Dwc2TransferStage {
+    fn total_len(&self) -> usize {
+        self.descs.iter().sum()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Dwc2ControlPlan {
+    setup: Dwc2TransferStage,
+    data: Vec<Dwc2TransferStage>,
+    status: Dwc2TransferStage,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Dwc2StageRole {
+    ControlSetup,
+    ControlData,
+    ControlStatus,
+    Data {
+        direction: Direction,
+        max_packet_size: u16,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct Dwc2QueuedStage {
+    stage: Dwc2TransferStage,
+    role: Dwc2StageRole,
+}
+
+struct Dwc2ActiveRequest {
+    id: RequestId,
+    channel: ChannelLease,
+    transfer: Dwc2DmaBuffer,
+    _setup_dma: Option<CoherentArray<u8>>,
+    descs: DmaDescriptors,
+    stages: Vec<Dwc2QueuedStage>,
+    next_stage: usize,
+    in_flight: Option<Dwc2QueuedStage>,
+    actual_length: usize,
+    cancelled: bool,
+}
+
+struct Dwc2PreparedStages {
+    stages: Vec<Dwc2QueuedStage>,
+    setup_dma: Option<CoherentArray<u8>>,
+}
+
+/// 通道数据 toggle（跨请求延续，DDMA 下由 HCTSIZ.PID 编程）。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct DataToggle(bool);
+
+impl DataToggle {
+    const fn data0() -> Self {
+        Self(false)
+    }
+
+    const fn data1() -> Self {
+        Self(true)
+    }
+
+    fn pid(self) -> Dwc2Pid {
+        if self.0 {
+            Dwc2Pid::Data1
+        } else {
+            Dwc2Pid::Data0
+        }
+    }
+
+    fn advance(&mut self, packet_count: u32) {
+        if packet_count % 2 == 1 {
+            self.0 = !self.0;
+        }
+    }
+}
+
+// ═══════════════════════════════════════════
+// 构建与结算
+// ═══════════════════════════════════════════
+
+/// 单 stage 结算：OUT 用计划总长（DDMA 下 OUT 无硬件回写）；
+/// IN 逐 desc 读回写剩余字节：actual = Σ min(initial_i − remaining_i, expect_i)。
+/// 未处理的 desc（短包中断链）保留编程值 → 贡献 0。
+fn stage_actual_length(stage: &Dwc2TransferStage, descs: &[DmaDescriptor]) -> usize {
+    if stage.hcchar & HCCHAR_EPDIR == 0 {
+        return stage.total_len();
+    }
+    let mps = stage.hcchar & 0x7ff;
+    stage
+        .descs
+        .iter()
+        .zip(descs)
+        .map(|(expect, desc)| {
+            initial_len(*expect, mps, true)
+                .saturating_sub(desc.remaining() as usize)
+                .min(*expect)
+        })
+        .sum()
+}
+
+/// 按 stage 角色构建其整条 desc 链：A 全置、链尾 IOC+EOL、setup 附加 SUP；
+/// buf 从 `stage.dma_addr` 起按 expect 长度逐块推进。
+fn build_stage_descs(queued: &Dwc2QueuedStage) -> Vec<DmaDescriptor> {
+    let mps = queued.stage.hcchar & 0x7ff;
+    let is_in = queued.stage.hcchar & HCCHAR_EPDIR != 0;
+    let n = queued.stage.descs.len();
+    let mut buf = queued.stage.dma_addr;
+    let mut out = Vec::with_capacity(n);
+    for (i, expect) in queued.stage.descs.iter().enumerate() {
+        let last = i + 1 == n;
+        out.push(match queued.role {
+            Dwc2StageRole::ControlSetup => DmaDescriptor::new_setup(buf, 8),
+            _ if is_in => DmaDescriptor::new_in(buf, *expect as u32, mps, last),
+            _ => DmaDescriptor::new_out(buf, *expect as u32, mps, last),
+        });
+        buf = buf.wrapping_add(*expect as u32);
+    }
+    out
+}
+
+fn build_control_plan(
+    request: &TransferRequest,
+    device: u8,
+    max_packet_size: u16,
+    setup_dma: u32,
+    data_dma: u32,
+    status_dma: u32,
+) -> core::result::Result<Dwc2ControlPlan, TransferError> {
+    let TransferRequest::Control {
+        direction, buffer, ..
+    } = request
+    else {
+        return Err(TransferError::InvalidEndpoint);
+    };
+
+    let data_len = buffer.map(|buffer| buffer.len).unwrap_or(0);
+    let setup = Dwc2TransferStage {
+        hcchar: hcchar(
+            device,
+            0,
+            Direction::Out,
+            Dwc2EpType::Control,
+            max_packet_size,
+            false,
+            1,
+        ),
+        hctsiz: hctsiz_ddma(Dwc2Pid::Setup, 1, 0),
+        dma_addr: setup_dma,
+        desc_base: 0,
+        descs: vec![8],
+    };
+
+    // 数据段合并为单 stage 多 desc 链（EOL 只在链尾 → 整段一次中断）；
+    // 超过 NTD 上限（256 desc）时按组拆分，组间独立通道编程。
+    let mut data = Vec::new();
+    if data_len > 0 {
+        let chunks = split_dma_lengths(data_len, max_packet_size);
+        let mut offset = 0usize;
+        let mut toggle = DataToggle::data1();
+        for group in chunks.chunks(DWC2_MAX_DMA_DESCS) {
+            let group_len = group.iter().sum::<usize>();
+            let packets = packet_count(group_len, max_packet_size);
+            data.push(Dwc2TransferStage {
+                hcchar: hcchar(
+                    device,
+                    0,
+                    *direction,
+                    Dwc2EpType::Control,
+                    max_packet_size,
+                    false,
+                    1,
+                ),
+                hctsiz: hctsiz_ddma(toggle.pid(), group.len() as u32, 0),
+                dma_addr: data_dma.wrapping_add(offset as u32),
+                desc_base: 0,
+                descs: group.to_vec(),
+            });
+            toggle.advance(packets);
+            offset += group_len;
+        }
+    }
+
+    let status_direction = if data_len > 0 {
+        match direction {
+            Direction::In => Direction::Out,
+            Direction::Out => Direction::In,
+        }
+    } else {
+        Direction::In
+    };
+    let status = Dwc2TransferStage {
+        hcchar: hcchar(
+            device,
+            0,
+            status_direction,
+            Dwc2EpType::Control,
+            max_packet_size,
+            false,
+            1,
+        ),
+        hctsiz: hctsiz_ddma(Dwc2Pid::Data1, 1, 0),
+        dma_addr: match status_direction {
+            Direction::In => status_dma,
+            Direction::Out => setup_dma,
+        },
+        desc_base: 0,
+        descs: vec![0],
+    };
+    Ok(Dwc2ControlPlan {
+        setup,
+        data,
+        status,
+    })
+}
+
+fn packet_count(len: usize, max_packet_size: u16) -> u32 {
+    if len == 0 {
+        return 1;
+    }
+    let max_packet_size = u32::from(max_packet_size.max(1));
+    (len as u32).div_ceil(max_packet_size)
+}
+
+fn split_dma_lengths(len: usize, max_packet_size: u16) -> Vec<usize> {
+    if len == 0 {
+        return vec![0];
+    }
+
+    let mps = usize::from(max_packet_size.max(1));
+    // 单 desc 的 NBYTES 上限（17 位）预留一个包，避免 IN 取整溢出。
+    let max_len = (DmaDescriptor::NBYTES_LIMIT as usize)
+        .saturating_sub(mps - 1)
+        .max(1);
+    // 切块对齐到 mps 整数倍：保证各 desc 取整后的 NBYTES 之和不越过
+    // 按整请求 initial_len 分配的 IN 缓冲（非 2 的幂 mps 下防越界）。
+    let max_chunk = max_len / mps * mps;
+    let mut left = len;
+    let mut out = Vec::new();
+    while left > max_chunk {
+        out.push(max_chunk);
+        left -= max_chunk;
+    }
+    out.push(left);
+    out
+}
+
+fn successful_packet_count(actual: usize, requested: usize, max_packet_size: u16) -> u32 {
+    if requested == 0 || actual == 0 {
+        1
+    } else {
+        packet_count(actual, max_packet_size)
+    }
+}
+
+fn setup_packet_bytes(setup: &ControlSetup, direction: Direction, len: usize) -> [u8; 8] {
+    let request_type = BmRequestType::new(direction, setup.request_type, setup.recipient);
+    let value = setup.value.to_le_bytes();
+    let index = setup.index.to_le_bytes();
+    let len = (len as u16).to_le_bytes();
+    [
+        request_type.into(),
+        setup.request.into(),
+        value[0],
+        value[1],
+        index[0],
+        index[1],
+        len[0],
+        len[1],
+    ]
+}
+
+// ═══════════════════════════════════════════
+// 状态机
+// ═══════════════════════════════════════════
+
+/// 非 ISO 传输状态机：持有一个在飞请求与一个待回收完成
+pub(crate) struct NonIsoChannelState {
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    stats: Dwc2Stats,
+    dma_pool: Dwc2DmaBufferPool,
+    pool: HostChannelPool,
+    status_buf: Option<CoherentArray<u8>>,
+    data_toggle: DataToggle,
+    next_request_id: u64,
+    active: Option<Dwc2ActiveRequest>,
+    completed: Option<(
+        RequestId,
+        core::result::Result<TransferCompletion, TransferError>,
+    )>,
+}
+
+impl Drop for NonIsoChannelState {
+    fn drop(&mut self) {
+        if let Some(active) = self.active.take()
+            && active.channel.hardware_active.load(Ordering::Acquire)
+        {
+            error!(
+                "dwc2: leaking request {:?} DMA because channel {} still references it",
+                active.id, active.channel.channel
+            );
+            core::mem::forget(active);
+        }
+    }
+}
+
+impl NonIsoChannelState {
+    pub(crate) fn new(
+        regs: Dwc2Registers,
+        kernel: Kernel,
+        stats: Dwc2Stats,
+        pool: HostChannelPool,
+    ) -> Self {
+        Self {
+            regs,
+            kernel,
+            stats,
+            dma_pool: Dwc2DmaBufferPool::default(),
+            pool,
+            status_buf: None,
+            data_toggle: DataToggle::data0(),
+            next_request_id: 1,
+            active: None,
+            completed: None,
+        }
+    }
+
+    /// 在飞或已完成的请求 id（端点回收/配置切换前停稳用）。
+    pub(crate) fn in_flight_request_id(&self) -> Option<RequestId> {
+        self.active
+            .as_ref()
+            .map(|active| active.id)
+            .or_else(|| self.completed.as_ref().map(|(id, _)| *id))
+    }
+
+    fn allocate_request_id(&mut self) -> RequestId {
+        let id = self.next_request_id;
+        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
+        RequestId::new(id)
+    }
+
+    fn prepare_request(
+        &mut self,
+        cfg: &ChannelConfig,
+        id: RequestId,
+        channel: ChannelLease,
+        request: TransferRequest,
+    ) -> core::result::Result<Dwc2ActiveRequest, TransferError> {
+        if matches!(request, TransferRequest::Isochronous { .. }) {
+            return Err(TransferError::NotSupported);
+        }
+
+        self.stats.record_transfer();
+        let mps = match &request {
+            TransferRequest::Control { .. } => cfg.info.max_packet_size.max(8),
+            _ => cfg.info.max_packet_size.max(1),
+        };
+        // 分配长度：IN 按 initial_len 取整（设备可合法收满取整量，防 DMA
+        // 越界），OUT/零长至少 1 字节，desc 始终有合法 buf 地址。
+        let direction = request.direction();
+        let buffer = request.buffer();
+        let data_len = buffer.map_or(0, |buffer| buffer.len);
+        let alloc_len = match direction {
+            Direction::In => initial_len(data_len, mps as u32, true).max(1),
+            Direction::Out => data_len.max(1),
+        };
+        let transfer = Dwc2DmaBuffer::new(
+            &self.kernel,
+            &mut self.dma_pool,
+            &self.stats,
+            buffer,
+            direction,
+            alloc_len,
+        )?;
+        let mut prepared = match &request {
+            TransferRequest::Control { .. } => self.control_stages(cfg, &request, &transfer)?,
+            TransferRequest::Bulk { .. } | TransferRequest::Interrupt { .. } => {
+                Dwc2PreparedStages {
+                    stages: self.data_stages(cfg, &request, &transfer)?,
+                    setup_dma: None,
+                }
+            }
+            TransferRequest::Isochronous { .. } => return Err(TransferError::NotSupported),
+        };
+
+        // 为各 stage 分配 desc 数组中的连续区间（desc_base），再一次性写入
+        // 整条链（每 stage 一条 A 全置、链尾 IOC+EOL 的 desc 链）。
+        let mut desc_base = 0usize;
+        for queued in &mut prepared.stages {
+            queued.stage.desc_base = desc_base;
+            desc_base += queued.stage.descs.len();
+        }
+        let descs = DmaDescriptors::new(&self.kernel, desc_base, DWC2_DMA_ALIGN)
+            .map_err(|err| TransferError::Other(anyhow!("DWC2 desc array alloc failed: {err}")))?;
+        let desc_vec: Vec<DmaDescriptor> =
+            prepared.stages.iter().flat_map(build_stage_descs).collect();
+        if log::log_enabled!(log::Level::Debug) {
+            for (i, desc) in desc_vec.iter().enumerate() {
+                log::debug!(
+                    "dwc2: desc[{i}] status={:#010x} buf={:#010x}",
+                    desc.status.get(),
+                    desc.paddr,
+                );
+            }
+        }
+        descs.write_descs(0, &desc_vec);
+
+        Ok(Dwc2ActiveRequest {
+            id,
+            channel,
+            transfer,
+            _setup_dma: prepared.setup_dma,
+            descs,
+            stages: prepared.stages,
+            next_stage: 0,
+            in_flight: None,
+            actual_length: 0,
+            cancelled: false,
+        })
+    }
+
+    fn control_stages(
+        &mut self,
+        cfg: &ChannelConfig,
+        request: &TransferRequest,
+        transfer: &Dwc2DmaBuffer,
+    ) -> core::result::Result<Dwc2PreparedStages, TransferError> {
+        let TransferRequest::Control {
+            setup, direction, ..
+        } = request
+        else {
+            return Err(TransferError::InvalidEndpoint);
+        };
+
+        let mut setup_dma = self
+            .kernel
+            .coherent_array_zero_with_align::<u8>(8, DWC2_DMA_ALIGN)
+            .map_err(|err| {
+                TransferError::Other(anyhow!("DWC2 setup DMA allocation failed: {err}"))
+            })?;
+        self.stats.record_dma_alloc();
+        let setup_bytes = setup_packet_bytes(setup, *direction, transfer.buffer_len());
+        setup_dma.write_with_cpu(8, |dst| dst.copy_from_slice(&setup_bytes));
+        let setup_addr = dma_addr32(setup_dma.dma_addr().as_u64())?;
+        let data_addr = dma_addr32(transfer.dma_addr())?;
+        let status_addr = dma_addr32(self.status_buf_addr()?)?;
+        let plan = build_control_plan(
+            request,
+            cfg.device_address,
+            cfg.info.max_packet_size.max(8),
+            setup_addr,
+            data_addr,
+            status_addr,
+        )?;
+
+        let mut stages = Vec::with_capacity(plan.data.len() + 2);
+        stages.push(Dwc2QueuedStage {
+            stage: plan.setup,
+            role: Dwc2StageRole::ControlSetup,
+        });
+        for stage in plan.data {
+            stages.push(Dwc2QueuedStage {
+                stage,
+                role: Dwc2StageRole::ControlData,
+            });
+        }
+        stages.push(Dwc2QueuedStage {
+            stage: plan.status,
+            role: Dwc2StageRole::ControlStatus,
+        });
+        Ok(Dwc2PreparedStages {
+            stages,
+            setup_dma: Some(setup_dma),
+        })
+    }
+
+    /// 控制传输 status IN 阶段的可写缓冲（64B，惰性分配、跨请求复用）。
+    /// desc 编程 NBYTES = mps ≤ 64，设备合法收满时不会越界。
+    fn status_buf_addr(&mut self) -> core::result::Result<u64, TransferError> {
+        if self.status_buf.is_none() {
+            let status_buf = self
+                .kernel
+                .coherent_array_zero_with_align::<u8>(DWC2_STATUS_BUF_SIZE, DWC2_DMA_ALIGN)
+                .map_err(|err| {
+                    TransferError::Other(anyhow!("DWC2 status DMA allocation failed: {err}"))
+                })?;
+            self.stats.record_dma_alloc();
+            self.status_buf = Some(status_buf);
+        }
+        Ok(self
+            .status_buf
+            .as_ref()
+            .expect("status buffer must exist after allocation")
+            .dma_addr()
+            .as_u64())
+    }
+
+    fn data_stages(
+        &self,
+        cfg: &ChannelConfig,
+        request: &TransferRequest,
+        transfer: &Dwc2DmaBuffer,
+    ) -> core::result::Result<Vec<Dwc2QueuedStage>, TransferError> {
+        let (direction, ep_type) = match request {
+            TransferRequest::Bulk { direction, .. } => (*direction, Dwc2EpType::Bulk),
+            TransferRequest::Interrupt { direction, .. } => (*direction, Dwc2EpType::Interrupt),
+            _ => return Err(TransferError::InvalidEndpoint),
+        };
+
+        let mps = cfg.info.max_packet_size.max(1);
+        let endpoint = endpoint_number(cfg.info.address.raw());
+        // 数据段合并为单 stage 多 desc 链（一次通道编程、一次中断）；
+        // 超过 NTD 上限时按组拆分，组间独立通道编程。
+        let chunks = split_dma_lengths(transfer.buffer_len(), mps);
+        let mut stages = Vec::new();
+        let mut toggle = self.data_toggle;
+        let mut offset = 0u64;
+        for group in chunks.chunks(DWC2_MAX_DMA_DESCS) {
+            let group_len = group.iter().sum::<usize>();
+            let packets = packet_count(group_len, mps);
+            let mut stage = Dwc2TransferStage {
+                hcchar: hcchar(
+                    cfg.device_address,
+                    endpoint,
+                    direction,
+                    ep_type,
+                    mps,
+                    matches!(cfg.port_speed, Speed::Low),
+                    1,
+                ),
+                hctsiz: hctsiz_ddma(toggle.pid(), group.len() as u32, 0),
+                dma_addr: dma_addr32(transfer.dma_addr() + offset)?,
+                desc_base: 0,
+                descs: group.to_vec(),
+            };
+            if matches!(ep_type, Dwc2EpType::Interrupt) {
+                stage.hcchar |= self.regs.periodic_odd_frame_bit();
+            }
+            stages.push(Dwc2QueuedStage {
+                stage,
+                role: Dwc2StageRole::Data {
+                    direction,
+                    max_packet_size: mps,
+                },
+            });
+            toggle.advance(packets);
+            offset += group_len as u64;
+        }
+        Ok(stages)
+    }
+
+    fn start_active_request(
+        &mut self,
+        mut active: Dwc2ActiveRequest,
+    ) -> core::result::Result<Dwc2ActiveRequest, TransferError> {
+        self.start_next_stage(&mut active)?;
+        Ok(active)
+    }
+
+    fn start_next_stage(
+        &self,
+        active: &mut Dwc2ActiveRequest,
+    ) -> core::result::Result<bool, TransferError> {
+        let Some(queued) = active.stages.get(active.next_stage).cloned() else {
+            return Ok(false);
+        };
+        active.next_stage += 1;
+        let desc_addr = active
+            .descs
+            .dma_addr()
+            .wrapping_add((queued.stage.desc_base as u32).wrapping_mul(DmaDescriptor::SIZE as u32));
+        self.start_stage(&active.channel, queued.stage.clone(), desc_addr)?;
+        active.in_flight = Some(queued);
+        Ok(true)
+    }
+
+    fn start_stage(
+        &self,
+        channel: &ChannelLease,
+        stage: Dwc2TransferStage,
+        desc_addr: u32,
+    ) -> core::result::Result<(), TransferError> {
+        channel.completions.with_connected(|| {
+            let regs = self.regs.channel(channel.channel);
+            if regs.is_enabled() {
+                return Err(TransferError::QueueFull);
+            }
+
+            self.stats.record_stage();
+            channel.completions.clear(channel.channel);
+            // SAFETY: the lifecycle IRQ-save gate prevents local DWC2 event
+            // re-entry, while the channel lease excludes task-side mutation.
+            let _guard = unsafe { channel.gate.lock_raw() };
+            regs.set_hcsplt(0);
+            regs.clear_all_irqs();
+            regs.enable_irqs();
+            regs.set_hctsiz(stage.hctsiz);
+            mb();
+            regs.set_hcdma(desc_addr);
+            mb();
+            regs.enable(stage.hcchar);
+            channel.hardware_active.store(true, Ordering::Release);
+            log::debug!(
+                "dwc2: stage start ch={} hcchar={:#010x} hctsiz={:#010x} hcdma={:#010x}",
+                channel.channel,
+                stage.hcchar | 1 << 31,
+                stage.hctsiz,
+                desc_addr,
+            );
+            Ok(())
+        })
+    }
+
+    fn poll_active_request(
+        &mut self,
+        mut active: Dwc2ActiveRequest,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        let Some(hcint) = active.channel.completions.take(active.channel.channel) else {
+            self.active = Some(active);
+            return None;
+        };
+        active
+            .channel
+            .hardware_active
+            .store(false, Ordering::Release);
+        if hcint & DWC2_COMPLETION_DISCONNECTED != 0 {
+            return Some(self.complete_active_request(active, Err(TransferError::Disconnected)));
+        }
+        if active.cancelled {
+            return Some(self.complete_active_request(active, Err(TransferError::Cancelled)));
+        }
+        let Some(queued) = active.in_flight.take() else {
+            return Some(self.complete_active_request(
+                active,
+                Err(TransferError::Other(anyhow!(
+                    "DWC2 completion arrived without an in-flight stage"
+                ))),
+            ));
+        };
+
+        // DDMA 下无软件 NAK/XACT 重试：NAK 由硬件自动重试，其余故障
+        // 均以 CHHLTD + 故障位终止，直接上报。
+        if let Some(fault) = hcint_fault(hcint) {
+            self.stats.record_fault(fault);
+            warn!(
+                "dwc2: transfer fault channel={} role={:?} hcint={:#x}",
+                active.channel.channel, queued.role, hcint,
+            );
+            return Some(
+                self.complete_active_request(active, Err(fault_to_transfer_error(fault, hcint))),
+            );
+        }
+
+        let read = active
+            .descs
+            .read_descs(queued.stage.desc_base, queued.stage.descs.len());
+        let actual = stage_actual_length(&queued.stage, read);
+        log::debug!(
+            "dwc2: stage done ch={} base={} ndesc={} role={:?} hcint={:#x} actual={} total={}",
+            active.channel.channel,
+            queued.stage.desc_base,
+            queued.stage.descs.len(),
+            queued.role,
+            hcint,
+            actual,
+            active.actual_length,
+        );
+        match queued.role {
+            Dwc2StageRole::ControlSetup | Dwc2StageRole::ControlStatus => {}
+            Dwc2StageRole::ControlData => {
+                active.actual_length = active.actual_length.saturating_add(actual);
+            }
+            Dwc2StageRole::Data {
+                direction,
+                max_packet_size,
+            } => {
+                active.actual_length = active.actual_length.saturating_add(actual);
+                self.data_toggle.advance(successful_packet_count(
+                    actual,
+                    queued.stage.total_len(),
+                    max_packet_size,
+                ));
+                if matches!(direction, Direction::In) && actual < queued.stage.total_len() {
+                    return Some(self.complete_active_request(active, Ok(())));
+                }
+            }
+        }
+
+        match self.start_next_stage(&mut active) {
+            Ok(true) => {
+                self.active = Some(active);
+                None
+            }
+            Ok(false) => Some(self.complete_active_request(active, Ok(()))),
+            Err(err) => Some(self.complete_active_request(active, Err(err))),
+        }
+    }
+
+    fn complete_active_request(
+        &mut self,
+        active: Dwc2ActiveRequest,
+        result: core::result::Result<(), TransferError>,
+    ) -> core::result::Result<TransferCompletion, TransferError> {
+        let id = active.id;
+        let completion = result.and_then(|()| {
+            active.transfer.copy_in_to_request(active.actual_length)?;
+            Ok(TransferCompletion {
+                request_id: id,
+                status: TransferStatus::Completed,
+                actual_length: active.actual_length,
+                iso_packets: Vec::new(),
+            })
+        });
+        self.dma_pool.reclaim(active.transfer);
+        active.channel.release();
+        completion
+    }
+}
+
+// ═══════════════════════════════════════════
+// 状态机对外接口
+// ═══════════════════════════════════════════
+
+impl NonIsoChannelState {
+    /// 提交一次传输：从池中租借通道（控制端点独占通道 0，其余在 1..n 中
+    /// 选取）后编程启动；prepare/启动失败时租约随 Drop 归还通道槽。
+    pub(crate) fn submit(
+        &mut self,
+        cfg: &ChannelConfig,
+        request: TransferRequest,
+    ) -> core::result::Result<RequestId, TransferError> {
+        if self.active.is_some() || self.completed.is_some() {
+            return Err(TransferError::QueueFull);
+        }
+        let channel = self
+            .pool
+            .acquire(matches!(cfg.info.transfer_type, EndpointType::Control))?;
+        let id = self.allocate_request_id();
+        let active = self.prepare_request(cfg, id, channel, request)?;
+        let active = self.start_active_request(active)?;
+        self.active = Some(active);
+        Ok(id)
+    }
+
+    pub(crate) fn reclaim(
+        &mut self,
+        id: RequestId,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        if let Some((completed_id, _)) = self.completed.as_ref() {
+            if *completed_id != id {
+                return Some(Err(TransferError::InvalidEndpoint));
+            }
+            return self.completed.take().map(|(_, result)| result);
+        }
+
+        let active = self.active.take()?;
+        if active.id != id {
+            self.active = Some(active);
+            return Some(Err(TransferError::InvalidEndpoint));
+        }
+        self.poll_active_request(active)
+    }
+
+    pub(crate) fn register_waker(&self, id: RequestId, cx: &mut Context<'_>) {
+        if let Some(active) = self.active.as_ref().filter(|active| active.id == id) {
+            active
+                .channel
+                .completions
+                .register_waker(active.channel.channel, cx);
+        }
+    }
+
+    pub(crate) fn cancel(&mut self, id: RequestId) -> core::result::Result<(), TransferError> {
+        if self
+            .completed
+            .as_ref()
+            .is_some_and(|(done_id, _)| *done_id == id)
+        {
+            self.completed = Some((id, Err(TransferError::Cancelled)));
+            return Ok(());
+        }
+        let Some(active) = self.active.as_mut() else {
+            return Err(TransferError::InvalidEndpoint);
+        };
+        if active.id != id {
+            return Err(TransferError::InvalidEndpoint);
+        }
+        active.cancelled = true;
+        let channel = active.channel.channel;
+        let result = active.channel.completions.with_connected(|| {
+            // SAFETY: The lifecycle IRQ-save gate prevents local DWC2
+            // event re-entry, while the channel lease excludes task-side
+            // register mutation.
+            let _guard = unsafe { active.channel.gate.lock_raw() };
+            self.regs.channel(channel).disable();
+            Ok(())
+        });
+        if matches!(result, Err(TransferError::Disconnected)) {
+            return Ok(());
+        }
+        result
+    }
+
+    pub(crate) fn reset(&mut self) -> core::result::Result<(), TransferError> {
+        if self.active.is_some() || self.completed.is_some() {
+            Err(TransferError::QueueFull)
+        } else {
+            self.data_toggle = DataToggle::data0();
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::vec;
+
+    use tock_registers::interfaces::Readable;
+    use usb_if::{
+        descriptor::EndpointType,
+        endpoint::{EndpointAddress, EndpointInfo, TransferRequest},
+        host::{ControlSetup, hub::Speed},
+        transfer::{Direction, Recipient, Request, RequestType},
+    };
+
+    use super::*;
+    use crate::backend::kmod::dwc2::{
+        dma::DMA_DESCRIPTOR,
+        reg::{HCINT_CHHLTD, HCINT_NAK, HCINT_XFERCOMPL},
+        testutil as tu,
+    };
+
+    fn bulk_config(direction: Direction) -> ChannelConfig {
+        ChannelConfig {
+            device_address: 2,
+            info: EndpointInfo {
+                address: EndpointAddress::new(if direction == Direction::In {
+                    0x81
+                } else {
+                    0x01
+                }),
+                transfer_type: EndpointType::Bulk,
+                direction,
+                max_packet_size: 512,
+                packets_per_microframe: 1,
+                interval: 0,
+            },
+            port_speed: Speed::High,
+        }
+    }
+
+    fn test_stage(direction: Direction, descs: Vec<usize>) -> Dwc2TransferStage {
+        Dwc2TransferStage {
+            hcchar: hcchar(
+                2,
+                if direction == Direction::In { 1 } else { 2 },
+                direction,
+                Dwc2EpType::Bulk,
+                512,
+                false,
+                1,
+            ),
+            hctsiz: hctsiz_ddma(Dwc2Pid::Data0, descs.len() as u32, 0),
+            dma_addr: 0x4000,
+            desc_base: 0,
+            descs,
+        }
+    }
+
+    #[test]
+    fn control_plan_uses_dma_for_setup_data_and_status() {
+        let mut data = [0u8; 18];
+        let request = TransferRequest::control_in(
+            ControlSetup {
+                request_type: RequestType::Standard,
+                recipient: Recipient::Device,
+                request: Request::GetDescriptor,
+                value: 0x0100,
+                index: 0,
+            },
+            &mut data,
+        );
+
+        let plan = build_control_plan(&request, 2, 64, 0x1000, 0x2000, 0x3000)
+            .expect("control IN plan builds");
+
+        assert_eq!(plan.setup.dma_addr, 0x1000);
+        assert_eq!(plan.setup.descs, vec![8]);
+        assert_eq!(plan.setup.hctsiz, hctsiz_ddma(Dwc2Pid::Setup, 1, 0));
+        assert_eq!(plan.setup.hcchar & HCCHAR_EPDIR, 0);
+
+        let stage = plan.data.first().expect("control IN has a data stage");
+        assert_eq!(stage.dma_addr, 0x2000);
+        assert_eq!(stage.hctsiz, hctsiz_ddma(Dwc2Pid::Data1, 1, 0));
+        assert_eq!(stage.hcchar & HCCHAR_EPDIR, HCCHAR_EPDIR);
+        assert_eq!(stage.descs, vec![18]);
+
+        // 带数据的 status 阶段方向反向（IN → OUT），复位时复用 setup 缓冲。
+        assert_eq!(plan.status.hcchar & HCCHAR_EPDIR, 0);
+        assert_eq!(plan.status.dma_addr, 0x1000);
+        assert_eq!(plan.status.hctsiz, hctsiz_ddma(Dwc2Pid::Data1, 1, 0));
+        assert_eq!(plan.status.descs, vec![0]);
+
+        // 无数据的 OUT 控制传输：status 为 IN，使用独立 status 缓冲。
+        let out = TransferRequest::control_out(
+            ControlSetup {
+                request_type: RequestType::Standard,
+                recipient: Recipient::Device,
+                request: Request::SetAddress,
+                value: 2,
+                index: 0,
+            },
+            &[],
+        );
+        let out_plan = build_control_plan(&out, 2, 64, 0x1000, 0x2000, 0x3000)
+            .expect("control OUT plan builds");
+        assert!(out_plan.data.is_empty());
+        assert_eq!(out_plan.status.hcchar & HCCHAR_EPDIR, HCCHAR_EPDIR);
+        assert_eq!(out_plan.status.dma_addr, 0x3000);
+    }
+
+    #[test]
+    fn control_data_stage_splits_at_ntd_limit_and_toggles_pid() {
+        // 257 个 desc 块（每块 ≈ 131008 B，17 位 NBYTES 上限内）→ 256 desc
+        // 组 + 1 desc 组两个 stage；2047 包（奇数）令第二组 PID 翻转。
+        let chunk = 0x1FFC0usize; // mps=64 时 max_chunk = 0x1FFFF & ~63 … 131008
+        let mut data = vec![0u8; 256 * chunk + 1];
+        let request = TransferRequest::control_in(
+            ControlSetup {
+                request_type: RequestType::Standard,
+                recipient: Recipient::Device,
+                request: Request::GetDescriptor,
+                value: 0x0200,
+                index: 0,
+            },
+            &mut data,
+        );
+
+        let plan = build_control_plan(&request, 2, 64, 0x1000, 0x2000, 0x3000)
+            .expect("control split plan builds");
+
+        assert_eq!(plan.data.len(), 2);
+        assert_eq!((plan.data[0].hctsiz >> 8) & 0xff, 255);
+        assert_eq!((plan.data[1].hctsiz >> 8) & 0xff, 0);
+        // 数据阶段从 Data1 起步；整组 256 × 2047 包为偶数 → 分组间不翻转
+        //（翻转语义由 data_toggle_advances_by_packet_count 覆盖）。
+        assert_eq!(plan.data[0].hctsiz >> 29, Dwc2Pid::Data1.bits());
+        assert_eq!(plan.data[1].hctsiz >> 29, Dwc2Pid::Data1.bits());
+        assert_eq!(
+            plan.data[1].dma_addr - plan.data[0].dma_addr,
+            256 * chunk as u32
+        );
+
+        // 单块与边界拆分。
+        assert_eq!(split_dma_lengths(8192, 8), vec![8192]);
+        assert_eq!(split_dma_lengths(1, 8), vec![1]);
+        assert_eq!(split_dma_lengths(0, 8), vec![0]);
+        let chunks = split_dma_lengths(0x1FFFF, 64);
+        assert_eq!(chunks.iter().sum::<usize>(), 0x1FFFF);
+        assert_eq!(chunks[..chunks.len() - 1], vec![0x1FFC0]);
+        assert_eq!(chunks.last(), Some(&63));
+    }
+
+    #[test]
+    fn data_toggle_advances_by_packet_count() {
+        let mut toggle = DataToggle::data0();
+
+        assert_eq!(toggle.pid(), Dwc2Pid::Data0);
+        toggle.advance(packet_count(512, 512));
+        assert_eq!(toggle.pid(), Dwc2Pid::Data1);
+        toggle.advance(packet_count(1024, 512));
+        assert_eq!(toggle.pid(), Dwc2Pid::Data1);
+        toggle.advance(packet_count(1, 512));
+        assert_eq!(toggle.pid(), Dwc2Pid::Data0);
+        // 零长请求按 1 个包推进（DDMA 成功结算同款语义）。
+        assert_eq!(packet_count(0, 512), 1);
+        assert_eq!(successful_packet_count(0, 64, 64), 1);
+        assert_eq!(successful_packet_count(64, 64, 64), 1);
+        assert_eq!(successful_packet_count(32, 64, 64), 1);
+    }
+
+    #[test]
+    fn out_stage_completion_reports_requested_length() {
+        // OUT：DDMA 下无硬件回写，结算使用计划总长。
+        let out = test_stage(Direction::Out, vec![31]);
+        let out_desc = DmaDescriptor::new_out(0, 31, 512, true);
+        assert_eq!(
+            stage_actual_length(&out, core::slice::from_ref(&out_desc)),
+            31
+        );
+
+        // IN：逐 desc 读回写剩余字节，实际 = 初始 − 剩余。
+        let in_stage = test_stage(Direction::In, vec![31]);
+        let mut in_desc = DmaDescriptor::new_in(0, 31, 512, true);
+        in_desc.status.modify(DMA_DESCRIPTOR::NBYTES.val(512 - 18));
+        assert_eq!(
+            stage_actual_length(&in_stage, core::slice::from_ref(&in_desc)),
+            18
+        );
+
+        // 短读：第一块收满（remaining 0）、第二块未处理（保留编程值）→ 只计第一块。
+        // 期望长度与 desc 的 mps 必须一致（64）。
+        let split = Dwc2TransferStage {
+            hcchar: hcchar(2, 1, Direction::In, Dwc2EpType::Bulk, 64, false, 1),
+            hctsiz: hctsiz_ddma(Dwc2Pid::Data0, 2, 0),
+            dma_addr: 0,
+            desc_base: 0,
+            descs: vec![64, 64],
+        };
+        let mut first = DmaDescriptor::new_in(0, 64, 64, false);
+        first.status.modify(DMA_DESCRIPTOR::NBYTES.val(0));
+        let second = DmaDescriptor::new_in(64, 64, 64, false);
+        assert_eq!(stage_actual_length(&split, &[first, second]), 64);
+    }
+
+    #[test]
+    fn submit_programs_channel_and_waits_for_irq_before_reclaim() {
+        let (_backing, regs, kernel, baselines, pool) = tu::channel_fixture(2);
+        let stats = Dwc2Stats::new();
+        let mut state = NonIsoChannelState::new(regs, kernel, stats.clone(), pool);
+        let cfg = bulk_config(Direction::In);
+        let mut data = [0u8; 512];
+        let id = state
+            .submit(&cfg, TransferRequest::bulk_in(&mut data))
+            .unwrap();
+
+        // 非控制端点从通道 1 起租借；只开 CHHLTD，NAK/XFERCOMPL 不产生中断
+        // （NAK 由硬件重试，XFERCOMPL 由 DDMA 链尾 IOC 伴随 CHHLTD 呈现）。
+        assert_eq!(regs.regs().hc[1].hcintmsk.get(), HCINT_CHHLTD);
+        assert_eq!(
+            regs.regs().hc[1].hcintmsk.get() & (HCINT_NAK | HCINT_XFERCOMPL),
+            0
+        );
+        assert_eq!(regs.regs().hc[1].hcchar.get() & (1 << 31), 1 << 31);
+        assert_eq!(regs.regs().hc[1].hctsiz.get() & (3 << 29), 0);
+        assert!(state.reclaim(id).is_none());
+        assert_eq!(stats.snapshot().transfer_busy_wait_iters, 0);
+
+        // 模拟硬件完成：回写 desc 状态字（A 清、remaining 0）后发布 IRQ。
+        state
+            .active
+            .as_mut()
+            .unwrap()
+            .descs
+            .data
+            .write_with_cpu(8, |dst| dst.fill(0));
+        baselines.publish(1, HCINT_CHHLTD | HCINT_XFERCOMPL);
+
+        let completion = state.reclaim(id).expect("completion must be published");
+        let completion = completion.expect("512B IN transfer completes");
+        assert_eq!(completion.actual_length, 512);
+    }
+
+    #[test]
+    fn cancelled_request_waits_for_real_channel_halt_before_reclaim() {
+        let (_backing, regs, kernel, baselines, pool) = tu::channel_fixture(2);
+        let mut state = NonIsoChannelState::new(regs, kernel, Dwc2Stats::new(), pool);
+        let cfg = bulk_config(Direction::In);
+        let mut data = [0u8; 512];
+        let id = state
+            .submit(&cfg, TransferRequest::bulk_in(&mut data))
+            .unwrap();
+
+        state.cancel(id).unwrap();
+
+        // 取消只投递 CHDIS；回收必须等真实 CHHLTD。
+        assert_eq!(
+            regs.regs().hc[1].hcchar.get() & ((1 << 30) | (1 << 31)),
+            1 << 30
+        );
+        assert!(state.reclaim(id).is_none());
+        baselines.publish(1, HCINT_CHHLTD);
+        assert!(matches!(
+            state.reclaim(id),
+            Some(Err(TransferError::Cancelled))
+        ));
+    }
+
+    #[test]
+    fn completed_handler_publish_is_taken_exactly_once() {
+        let (_backing, regs, kernel, baselines, pool) = tu::channel_fixture(2);
+        let stats = Dwc2Stats::new();
+        let mut state = NonIsoChannelState::new(regs, kernel, stats, pool);
+        let cfg = bulk_config(Direction::In);
+        let mut data = [0u8; 512];
+        let id = state
+            .submit(&cfg, TransferRequest::bulk_in(&mut data))
+            .unwrap();
+
+        baselines.publish(1, HCINT_CHHLTD | HCINT_XFERCOMPL);
+        assert!(state.reclaim(id).expect("completion is taken once").is_ok());
+        assert!(state.reclaim(id).is_none());
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/dma.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/dma.rs
@@ -1,0 +1,549 @@
+use core::ptr::NonNull;
+
+use dma_api::{ContiguousArray, DmaDirection};
+use mbarrier::mb;
+use tock_registers::{LocalRegisterCopy, register_bitfields};
+use usb_if::{endpoint::TransferBuffer, err::TransferError, transfer::Direction};
+
+use crate::backend::kmod::{
+    Kernel,
+    dwc2::{DWC2_DMA_ALIGN, stats::Dwc2Stats},
+};
+
+// 描述符状态字位字段
+register_bitfields![u32,
+    pub DMA_DESCRIPTOR [
+        /// HOST_DMA_A（BIT31）：活动位。CPU 置位；硬件完成传输后改写整个状态字。
+        A OFFSET(31) NUMBITS(1) [],
+        /// HOST_DMA_STS（bits 28-29）：传输状态。hw.h 仅定义 PKTERR；
+        /// XFERERR/BABBLE 见 Synopsys databook，本驱动不读取。
+        STS OFFSET(28) NUMBITS(2) [
+            /// 包错误（HOST_DMA_STS_PKTERR）。
+            PKTERR = 1,
+        ],
+        /// HOST_DMA_EOL（BIT26）：链尾指示。
+        EOL OFFSET(26) NUMBITS(1) [],
+        /// HOST_DMA_IOC（BIT25）：完成中断，链尾/批尾置位。
+        IOC OFFSET(25) NUMBITS(1) [],
+        /// HOST_DMA_SUP（BIT24）：SETUP 对齐（仅 SETUP 阶段，见 active_setup）。
+        SUP OFFSET(24) NUMBITS(1) [],
+        /// HOST_DMA_ALT_QTD（BIT23）：备用 QTD 指示（非 ISO 队列用，本驱动不读取）。
+        ALT_QTD OFFSET(23) NUMBITS(1) [],
+        /// HOST_DMA_QTD_OFFSET（bits 17-22）：QTD 偏移（非 ISO 队列用，本驱动不读取）。
+        QTD_OFFSET OFFSET(17) NUMBITS(6) [],
+        /// HOST_DMA_ISOC_NBYTES（bits 0-11）：ISO 硬件写回的 12 位剩余字节。
+        /// 与 NBYTES 同基址、宽度更窄。
+        ISOC_NBYTES OFFSET(0) NUMBITS(12) [],
+        /// HOST_DMA_NBYTES（bits 0-16，SHIFT=0）：硬件写回的剩余字节数。
+        /// 非 ISO 用 17 位；读 ISO 值也无害（12 位值落在低 12 位）。
+        NBYTES OFFSET(0) NUMBITS(17) [],
+    ]
+];
+
+/// DWC2 DMA 描述符 — 8 字节，硬件按此格式读写。
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub(crate) struct DmaDescriptor {
+    pub(crate) status: LocalRegisterCopy<u32, DMA_DESCRIPTOR::Register>,
+    pub(crate) paddr: u32, // DMA 传输缓冲区地址（物理地址）
+}
+
+/// desc 编程的 NBYTES 值（与结算镜像共用，Linux `qh->n_bytes[]` 语义）：
+/// IN 向上取整到 mps 整数倍（0 长 → 1 个包）；OUT 原值。两侧必须一致。
+pub(crate) fn initial_len(len: usize, mps: u32, is_in: bool) -> usize {
+    let cap = (DmaDescriptor::NBYTES_LIMIT - mps.saturating_sub(1)) as usize;
+    let len = len.min(cap);
+    if is_in {
+        if len > 0 && mps > 0 {
+            len.div_ceil(mps as usize) * mps as usize
+        } else if mps > 0 {
+            mps as usize
+        } else {
+            0
+        }
+    } else {
+        len
+    }
+}
+
+impl DmaDescriptor {
+    pub(crate) const SIZE: usize = 8;
+    pub(crate) const NBYTES_LIMIT: u32 = 0x1FFFF;
+    /// ISO 描述符的 12 位 NBYTES 上限（HOST_DMA_ISOC_NBYTES）。
+    pub(crate) const ISO_NBYTES_LIMIT: u32 = 0xfff;
+
+    /// ISO 传输：每个 interval 一个描述符，环形列表、不设 EOL。
+    /// NBYTES 截断到 12 位 ISO 上限（HOST_DMA_ISOC_NBYTES），0 长 → 1 字节。
+    pub(crate) fn new_iso(paddr: u32, len: u32, last: bool) -> Self {
+        let nbytes = if len == 0 {
+            1
+        } else {
+            len.min(Self::ISO_NBYTES_LIMIT)
+        };
+        let mut status = LocalRegisterCopy::new(0);
+        status.write(DMA_DESCRIPTOR::NBYTES.val(nbytes) + DMA_DESCRIPTOR::A::SET);
+
+        if last {
+            status.modify(DMA_DESCRIPTOR::IOC::SET);
+        }
+
+        Self { status, paddr }
+    }
+
+    /// IN 传输：NBYTES 向上取整到 mps 整数倍（0 长 → 1 个包），不拆包且不
+    /// 溢出 17 位。链尾（`last`）置 IOC + EOL。
+    pub(crate) fn new_in(paddr: u32, len: u32, mps: u32, last: bool) -> Self {
+        let len = initial_len(len as usize, mps, true) as u32;
+        let mut status = LocalRegisterCopy::new(0);
+        status.write(DMA_DESCRIPTOR::NBYTES.val(len) + DMA_DESCRIPTOR::A::SET);
+        if last {
+            status.modify(DMA_DESCRIPTOR::IOC::SET + DMA_DESCRIPTOR::EOL::SET);
+        }
+
+        Self { status, paddr }
+    }
+
+    /// OUT 传输：不需要整包对齐，只截断到字段上限。链尾（`last`）置 IOC + EOL。
+    pub(crate) fn new_out(paddr: u32, len: u32, mps: u32, last: bool) -> Self {
+        let len = initial_len(len as usize, mps, false) as u32;
+        let mut status = LocalRegisterCopy::new(0);
+        status.write(DMA_DESCRIPTOR::NBYTES.val(len) + DMA_DESCRIPTOR::A::SET);
+        if last {
+            status.modify(DMA_DESCRIPTOR::IOC::SET + DMA_DESCRIPTOR::EOL::SET);
+        }
+
+        Self { status, paddr }
+    }
+
+    /// SETUP 传输：置 SUP，单描述符 A|IOC|EOL
+    pub(crate) fn new_setup(paddr: u32, len: u32) -> Self {
+        let mut status = LocalRegisterCopy::new(0);
+        status.write(
+            DMA_DESCRIPTOR::NBYTES.val(len)
+                + DMA_DESCRIPTOR::A::SET
+                + DMA_DESCRIPTOR::SUP::SET
+                + DMA_DESCRIPTOR::IOC::SET
+                + DMA_DESCRIPTOR::EOL::SET,
+        );
+
+        Self { status, paddr }
+    }
+
+    /// 硬件写回的剩余字节数（非 ISO 用 17 位，ISO 用 12 位）。
+    pub(crate) fn remaining(&self) -> u32 {
+        self.status.read(DMA_DESCRIPTOR::NBYTES)
+    }
+    pub(crate) fn iso_remaining(&self) -> u32 {
+        self.status.read(DMA_DESCRIPTOR::ISOC_NBYTES)
+    }
+
+    /// 描述符是否仍为活动（A 位由 CPU 置位，硬件服务后随状态字回写清零）。
+    pub(crate) fn is_active(&self) -> bool {
+        self.status.read(DMA_DESCRIPTOR::A) != 0
+    }
+
+    /// ISO 描述符是否被硬件标记为包错误（HOST_DMA_STS_PKTERR，即 XactErr /
+    /// 无法在调度窗口内完成全部事务）。
+    pub(crate) fn iso_status_error(&self) -> bool {
+        self.status.read_as_enum(DMA_DESCRIPTOR::STS) == Some(DMA_DESCRIPTOR::STS::Value::PKTERR)
+    }
+}
+
+/// DWC2 DMA 描述符数组，连续分配、对齐、可 flush。
+pub(crate) struct DmaDescriptors {
+    pub(crate) data: ContiguousArray<u8>,
+    pub(crate) dma_addr: u32, // data 字段的物理地址
+}
+
+impl DmaDescriptors {
+    pub(crate) fn new(kernel: &Kernel, n: usize, align: usize) -> Result<Self, anyhow::Error> {
+        let data = kernel
+            .contiguous_array_zero_with_align::<u8>(
+                n * DmaDescriptor::SIZE,
+                align,
+                DmaDirection::Bidirectional,
+            )
+            .map_err(|err| anyhow!("DWC2 desc array alloc: {err}"))?;
+
+        let dma_addr = u32::try_from(data.dma_addr().as_u64())
+            .map_err(|_| anyhow!("DWC2 desc array DMA above 32-bit mask"))?;
+        Ok(Self { data, dma_addr })
+    }
+
+    pub(crate) fn write_descs(&self, start: usize, descs: &[DmaDescriptor]) {
+        let ptr = (self.data.as_ptr().as_ptr() as usize + start * DmaDescriptor::SIZE) as *mut u8;
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                descs.as_ptr() as *const u8,
+                ptr,
+                descs.len() * DmaDescriptor::SIZE,
+            )
+        }
+        self.data.sync_for_device(
+            start * DmaDescriptor::SIZE,
+            descs.len() * DmaDescriptor::SIZE,
+        );
+        mb();
+    }
+
+    /// 读回 `start` 起的 `count` 个 desc（先 invalidate 整段再读，硬件可能
+    /// 已回写状态字）。返回的切片在下次 sync 前有效。
+    pub(crate) fn read_descs(&self, start: usize, count: usize) -> &[DmaDescriptor] {
+        self.data
+            .sync_for_cpu(start * DmaDescriptor::SIZE, count * DmaDescriptor::SIZE);
+        let base = self.data.as_ptr().as_ptr() as *const DmaDescriptor;
+        unsafe { core::slice::from_raw_parts(base.add(start), count) }
+    }
+
+    /// 清空第 `index` 个 desc（status=0、buf=0，A 位清零）并 flush 落盘
+    pub(crate) fn clear(&self, index: usize) {
+        let ptr = (self.data.as_ptr().as_ptr() as usize + index * DmaDescriptor::SIZE) as *mut u64;
+        unsafe { core::ptr::write_volatile(ptr, 0u64) }
+
+        self.data
+            .sync_for_device(index * DmaDescriptor::SIZE, DmaDescriptor::SIZE);
+    }
+
+    /// 清空全部 desc（A=0）并 flush 落盘
+    pub(crate) fn clear_all(&self) {
+        let bytes = self.data.len();
+        unsafe { core::ptr::write_bytes(self.data.as_ptr().as_ptr(), 0, bytes) }
+
+        self.data.sync_for_device(0, bytes);
+    }
+
+    /// DMA 地址（物理地址），用于编程 DMA 控制寄存器。
+    pub(crate) fn dma_addr(&self) -> u32 {
+        self.dma_addr
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct Dwc2DmaBufferPool {
+    cached: Option<ContiguousArray<u8>>,
+}
+
+impl Dwc2DmaBufferPool {
+    pub(crate) fn take(
+        &mut self,
+        kernel: &Kernel,
+        len: usize,
+        stats: &Dwc2Stats,
+    ) -> Result<Option<ContiguousArray<u8>>, TransferError> {
+        let len = len.max(1);
+        if self
+            .cached
+            .as_ref()
+            .is_some_and(|buffer| buffer.len() >= len)
+        {
+            return Ok(self.cached.take());
+        }
+
+        let buffer = kernel
+            .contiguous_array_zero_with_align::<u8>(
+                len,
+                DWC2_DMA_ALIGN,
+                DmaDirection::Bidirectional,
+            )
+            .map_err(|err| {
+                TransferError::Other(anyhow!("DWC2 coherent DMA allocation failed: {err}"))
+            })?;
+        stats.record_dma_alloc();
+        Ok(Some(buffer))
+    }
+
+    pub(crate) fn reclaim(&mut self, buffer: Dwc2DmaBuffer) {
+        if let Some(coherent) = buffer.coherent {
+            self.cached = Some(coherent);
+        }
+    }
+}
+
+pub(crate) struct Dwc2DmaBuffer {
+    direction: Direction,
+    request_buffer: Option<(NonNull<u8>, usize)>,
+    coherent: Option<ContiguousArray<u8>>,
+    len: usize,
+}
+
+impl Dwc2DmaBuffer {
+    /// 构建传输的 DMA 缓冲：分配 `alloc_len` 字节 coherent 内存，OUT 拷贝
+    /// 调用方数据、IN 清零，记录调用方缓冲供完成时拷回。
+    ///
+    /// `alloc_len` 为分配长度，由调用方决定：non-ISO IN 需按 `initial_len`
+    /// 取整（与 desc NBYTES 取整镜像，防 DMA 越界），其余为请求数据长度；
+    /// ISO 为各包长度精确之和（desc 按精确长度编程）。OUT 时须保证
+    /// `alloc_len >= buffer.len`（拷贝数据长度取调用方缓冲长度）。
+    /// `buffer` 为 None（零长请求）时仍分配但无调用方缓冲。
+    pub(crate) fn new(
+        kernel: &Kernel,
+        pool: &mut Dwc2DmaBufferPool,
+        stats: &Dwc2Stats,
+        buffer: Option<TransferBuffer>,
+        direction: Direction,
+        alloc_len: usize,
+    ) -> Result<Self, TransferError> {
+        let request_buffer = buffer
+            .filter(|buffer| buffer.len > 0)
+            .map(|buffer| (buffer.ptr, buffer.len));
+        let len = request_buffer.map_or(0, |(_, len)| len);
+        let alloc_len = alloc_len.max(1);
+        let coherent = {
+            let mut coherent = pool.take(kernel, alloc_len, stats)?.ok_or_else(|| {
+                TransferError::Other(anyhow!("DWC2 DMA buffer pool returned no buffer"))
+            })?;
+            if let Some((ptr, len)) = request_buffer {
+                match direction {
+                    Direction::Out => {
+                        let data =
+                            unsafe { core::slice::from_raw_parts(ptr.as_ptr().cast_const(), len) };
+                        coherent.write_with_cpu(len, |dst| dst.copy_from_slice(data));
+                        stats.record_bounce_to_device(len);
+                    }
+                    Direction::In => {
+                        coherent.write_with_cpu(alloc_len, |dst| dst.fill(0));
+                        stats.record_bounce_from_device(len);
+                    }
+                }
+            } else if matches!(direction, Direction::In) {
+                coherent.write_with_cpu(alloc_len, |dst| dst.fill(0));
+            }
+            // CPU 写（OUT 载荷 / IN 清零）flush 到内存后才能交给 DMA 侧：
+            // IN 短包未覆盖区域在完成时 invalidate 后必须已是内存中的 0。
+            coherent.sync_for_device(0, alloc_len);
+            Some(coherent)
+        };
+
+        Ok(Self {
+            direction,
+            request_buffer,
+            coherent,
+            len,
+        })
+    }
+
+    pub(crate) fn buffer_len(&self) -> usize {
+        self.len
+    }
+
+    pub(crate) fn dma_addr(&self) -> u64 {
+        self.coherent
+            .as_ref()
+            .map_or(0, |buffer| buffer.dma_addr().as_u64())
+    }
+
+    pub(crate) fn copy_in_to_request(&self, actual: usize) -> Result<(), TransferError> {
+        if !matches!(self.direction, Direction::In) || actual == 0 {
+            return Ok(());
+        }
+        let Some((ptr, len)) = self.request_buffer else {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 IN transfer completed without a request buffer"
+            )));
+        };
+        let Some(coherent) = self.coherent.as_ref() else {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 IN transfer completed without a DMA buffer"
+            )));
+        };
+        if actual > len || actual > coherent.len() {
+            return Err(TransferError::Other(anyhow!(
+                "DWC2 IN transfer actual length {actual} exceeds buffer len {len}"
+            )));
+        }
+
+        // Cache 纪律（IN，DMA → CPU）：先 invalidate 丢弃旧值、从内存拿到
+        // DMA 写入的数据，再拷贝回调用方 buffer。漏掉会读到陈旧数据。
+        coherent.sync_for_cpu(0, actual);
+        let dst = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), actual) };
+        coherent.read_with_cpu(actual, |src| dst.copy_from_slice(src));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+
+    const A: u32 = 1 << 31;
+    const SUP: u32 = 1 << 24;
+    const IOC: u32 = 1 << 25;
+    const EOL: u32 = 1 << 26;
+    const NBYTES_MASK: u32 = 0x1FFFF;
+
+    fn status(d: &DmaDescriptor) -> u32 {
+        d.status.get()
+    }
+
+    #[test]
+    fn initial_len_rounds_in_to_packet_boundary() {
+        assert_eq!(initial_len(100, 64, true), 128);
+        assert_eq!(initial_len(0, 64, true), 64);
+        assert_eq!(initial_len(512, 64, true), 512);
+        assert_eq!(initial_len(0, 0, true), 0);
+    }
+
+    #[test]
+    fn initial_len_passes_out_through_and_caps() {
+        assert_eq!(initial_len(100, 64, false), 100);
+        assert_eq!(initial_len(0, 64, false), 0);
+        // 17 位上限：cap = 0x1FFFF - (mps - 1)，IN 取整后不溢出。
+        assert_eq!(initial_len(0x1FFFF, 64, true), 0x1FFC0);
+        assert_eq!(initial_len(0x1FFFF, 64, false), 0x1FFC0);
+    }
+
+    #[test]
+    fn setup_desc_sets_a_sup_ioc_eol() {
+        let d = DmaDescriptor::new_setup(0x1000, 8);
+        assert_eq!(status(&d) & NBYTES_MASK, 8);
+        assert_eq!(status(&d) & (A | SUP | IOC | EOL), A | SUP | IOC | EOL);
+    }
+
+    #[test]
+    fn in_desc_rounds_and_marks_chain_tail() {
+        let tail = DmaDescriptor::new_in(0x1000, 100, 64, true);
+        assert_eq!(status(&tail) & NBYTES_MASK, 128);
+        assert_eq!(status(&tail) & (IOC | EOL), IOC | EOL);
+
+        let head = DmaDescriptor::new_in(0x1000, 100, 64, false);
+        assert_eq!(status(&head) & (IOC | EOL), 0);
+        assert_eq!(status(&head) & A, A);
+    }
+
+    #[test]
+    fn out_desc_caps_nbytes() {
+        let d = DmaDescriptor::new_out(0x1000, 0x1FFFF, 64, true);
+        assert_eq!(status(&d) & NBYTES_MASK, 0x1FFC0);
+        assert_eq!(status(&d) & (IOC | EOL), IOC | EOL);
+    }
+
+    #[test]
+    fn iso_desc_sets_a_ioc_and_caps_nbytes() {
+        let last = DmaDescriptor::new_iso(0x1000, 512, true);
+        assert_eq!(status(&last) & NBYTES_MASK, 512);
+        assert_eq!(status(&last) & (IOC | EOL), IOC);
+        assert_eq!(status(&last) & A, A);
+
+        // 0 长 → 1 字节；超过 12 位 ISO 上限截断。
+        let zero = DmaDescriptor::new_iso(0x1000, 0, false);
+        assert_eq!(status(&zero) & NBYTES_MASK, 1);
+        let big = DmaDescriptor::new_iso(0x1000, DmaDescriptor::ISO_NBYTES_LIMIT + 100, false);
+        assert_eq!(status(&big) & NBYTES_MASK, DmaDescriptor::ISO_NBYTES_LIMIT);
+        // 非链尾不置 IOC。
+        assert_eq!(status(&big) & IOC, 0);
+    }
+
+    #[test]
+    fn iso_remaining_and_pkterr_readback() {
+        let mut d = DmaDescriptor::new_iso(0x1000, 512, true);
+        assert!(!d.iso_status_error());
+        d.status.modify(DMA_DESCRIPTOR::ISOC_NBYTES.val(64));
+        assert_eq!(d.iso_remaining(), 64);
+        d.status.modify(DMA_DESCRIPTOR::STS.val(1));
+        assert!(d.iso_status_error());
+    }
+
+    #[test]
+    fn iso_desc_a_bit_readback() {
+        let mut d = DmaDescriptor::new_iso(0x1000, 512, true);
+        assert!(d.is_active());
+        // 硬件服务后回写状态字会清掉 A 位（Linux DDMA 结算同款语义）。
+        d.status.modify(DMA_DESCRIPTOR::A::CLEAR);
+        assert!(!d.is_active());
+    }
+
+    #[test]
+    fn remaining_reads_written_back_nbytes() {
+        let mut d = DmaDescriptor::new_in(0x1000, 100, 64, true);
+        d.status.modify(DMA_DESCRIPTOR::NBYTES.val(28));
+        assert_eq!(d.remaining(), 28);
+    }
+
+    #[test]
+    fn dma_buffer_bounces_in_data_through_coherent_dma_memory() {
+        let kernel = crate::backend::kmod::dwc2::testutil::test_kernel();
+        let mut pool = Dwc2DmaBufferPool::default();
+        let stats = Dwc2Stats::new();
+        let mut data = [0u8; 4];
+        let buffer = Some(TransferBuffer::from_mut_slice(&mut data).unwrap());
+        let dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, buffer, Direction::In, 4)
+            .expect("IN bounce buffer builds");
+
+        assert_eq!(dma.buffer_len(), 4);
+        assert_ne!(dma.dma_addr(), data.as_ptr() as u64);
+        let mut dma = dma;
+        dma.coherent
+            .as_mut()
+            .unwrap()
+            .write_with_cpu(4, |dst| dst.copy_from_slice(&[1, 2, 3, 4]));
+        dma.copy_in_to_request(3).expect("partial completion copy");
+
+        assert_eq!(data, [1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn dma_buffer_pool_reuses_existing_dma_allocation() {
+        let kernel = crate::backend::kmod::dwc2::testutil::test_kernel();
+        let stats = Dwc2Stats::new();
+        let mut pool = Dwc2DmaBufferPool::default();
+        let mut first = [0u8; 64];
+        let first_buffer = Some(TransferBuffer::from_mut_slice(&mut first).unwrap());
+        let first_dma =
+            Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, first_buffer, Direction::In, 64)
+                .expect("first buffer builds");
+        let first_addr = first_dma.dma_addr();
+        pool.reclaim(first_dma);
+
+        let mut smaller = [0u8; 32];
+        let smaller_buffer = Some(TransferBuffer::from_mut_slice(&mut smaller).unwrap());
+        let smaller_dma = Dwc2DmaBuffer::new(
+            &kernel,
+            &mut pool,
+            &stats,
+            smaller_buffer,
+            Direction::In,
+            32,
+        )
+        .expect("smaller buffer reuses cache");
+        assert_eq!(smaller_dma.dma_addr(), first_addr);
+        pool.reclaim(smaller_dma);
+
+        let mut larger = [0u8; 128];
+        let larger_buffer = Some(TransferBuffer::from_mut_slice(&mut larger).unwrap());
+        let larger_dma = Dwc2DmaBuffer::new(
+            &kernel,
+            &mut pool,
+            &stats,
+            larger_buffer,
+            Direction::In,
+            128,
+        )
+        .expect("larger buffer allocates");
+        assert_eq!(larger_dma.buffer_len(), 128);
+        pool.reclaim(larger_dma);
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.dma_allocs, 2);
+        assert_eq!(snapshot.bounce_from_device_bytes, 64 + 32 + 128);
+    }
+
+    #[test]
+    fn out_dma_buffer_copies_request_data_for_device() {
+        let kernel = crate::backend::kmod::dwc2::testutil::test_kernel();
+        let mut pool = Dwc2DmaBufferPool::default();
+        let stats = Dwc2Stats::new();
+        let data = [1u8, 2, 3, 4];
+        let buffer = Some(TransferBuffer::from_slice(&data).unwrap());
+        let dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, buffer, Direction::Out, 4)
+            .expect("OUT bounce buffer builds");
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.bounce_to_device_bytes, 4);
+        dma.coherent
+            .as_ref()
+            .unwrap()
+            .read_with_cpu(4, |src| assert_eq!(src, &[1, 2, 3, 4]));
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/endpoint.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/endpoint.rs
@@ -1,0 +1,273 @@
+use alloc::boxed::Box;
+use core::task::Context;
+
+use usb_if::{
+    descriptor::EndpointType,
+    endpoint::{EndpointInfo, RequestId, TransferCompletion, TransferRequest},
+    err::TransferError,
+    host::hub::Speed,
+};
+
+use crate::{
+    backend::kmod::{
+        Kernel,
+        dwc2::{
+            channel::{
+                ChannelConfig, HostChannelPool, iso::IsoChannelState, non_iso::NonIsoChannelState,
+            },
+            endpoint_type_to_dwc2,
+            reg::Dwc2Registers,
+            stats::Dwc2Stats,
+        },
+    },
+    err::Result,
+};
+
+pub(crate) struct Dwc2Endpoint {
+    config: ChannelConfig,
+    non_iso: NonIsoChannelState,
+    iso: IsoChannelState,
+}
+
+unsafe impl Send for Dwc2Endpoint {}
+
+pub(crate) struct Dwc2EndpointParams {
+    pub(crate) regs: Dwc2Registers,
+    pub(crate) kernel: Kernel,
+    pub(crate) device_address: u8,
+    pub(crate) port_speed: Speed,
+    pub(crate) info: EndpointInfo,
+    pub(crate) channel_pool: HostChannelPool,
+    pub(crate) stats: Dwc2Stats,
+}
+
+impl Dwc2Endpoint {
+    pub(crate) fn new(params: Dwc2EndpointParams) -> Result<Self> {
+        let Dwc2EndpointParams {
+            regs,
+            kernel,
+            device_address,
+            port_speed,
+            info,
+            channel_pool,
+            stats,
+        } = params;
+        endpoint_type_to_dwc2(info.transfer_type)?;
+        let config = ChannelConfig {
+            device_address,
+            info,
+            port_speed,
+        };
+        Ok(Self {
+            config,
+            non_iso: NonIsoChannelState::new(
+                regs,
+                kernel.clone(),
+                stats.clone(),
+                channel_pool.clone(),
+            ),
+            iso: IsoChannelState::new(regs, kernel, stats, channel_pool),
+        })
+    }
+
+    pub(crate) fn set_device_address(&mut self, address: u8) {
+        self.config.device_address = address;
+    }
+
+    pub(crate) fn set_max_packet_size(&mut self, max_packet_size: u8) {
+        self.config.info.max_packet_size = u16::from(max_packet_size).max(8);
+    }
+
+    /// 在飞或已完成的请求 id（`Dwc2Device::quiesce_endpoints` 停稳前查询）。
+    pub(crate) fn in_flight_request_id(&self) -> Option<RequestId> {
+        match self.config.info.transfer_type {
+            EndpointType::Isochronous => self.iso.in_flight_request_id(),
+            _ => self.non_iso.in_flight_request_id(),
+        }
+    }
+}
+
+impl crate::backend::ty::ep::EndpointOp for Dwc2Endpoint {
+    fn submit_request(
+        &mut self,
+        request: TransferRequest,
+    ) -> core::result::Result<RequestId, TransferError> {
+        // 通道由各状态机内部从池中租借（ISO 常驻会话，non-ISO 按请求）。
+        if matches!(request, TransferRequest::Isochronous { .. }) {
+            return self.iso.submit(&self.config, request);
+        }
+        self.non_iso.submit(&self.config, request)
+    }
+
+    fn reclaim_request(
+        &mut self,
+        id: RequestId,
+    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
+        match self.config.info.transfer_type {
+            EndpointType::Isochronous => self.iso.reclaim(id),
+            _ => self.non_iso.reclaim(id),
+        }
+    }
+
+    fn register_waker(&self, id: RequestId, cx: &mut Context<'_>) {
+        match self.config.info.transfer_type {
+            EndpointType::Isochronous => self.iso.register_waker(id, cx),
+            _ => self.non_iso.register_waker(id, cx),
+        }
+    }
+
+    fn cancel_request(&mut self, id: RequestId) -> core::result::Result<(), TransferError> {
+        match self.config.info.transfer_type {
+            EndpointType::Isochronous => self.iso.cancel(id),
+            _ => self.non_iso.cancel(id),
+        }
+    }
+
+    fn reset(&mut self) -> crate::backend::ty::ep::EndpointResetFuture {
+        let result = match self.config.info.transfer_type {
+            EndpointType::Isochronous => self.iso.reset(),
+            _ => self.non_iso.reset(),
+        };
+        Box::pin(async move { result })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::sync::Arc;
+
+    use tock_registers::interfaces::{Readable, Writeable};
+    use usb_if::{
+        descriptor::EndpointType,
+        endpoint::{EndpointAddress, EndpointInfo, TransferRequest},
+        host::hub::Speed,
+        transfer::Direction,
+    };
+
+    use super::*;
+    use crate::{
+        backend::{
+            kmod::dwc2::{
+                channel::{Dwc2ChannelCompletions, Dwc2PeriodicSchedule, HostChannelPool},
+                event::Dwc2EventHandler,
+                reg::{GINTSTS_DISCONNINT, HCINT_CHHLTD, HCINT_NAK, HCINT_XFERCOMPL},
+                stats::Dwc2Stats,
+                testutil as tu,
+            },
+            ty::{Event, EventHandlerOp, ep::EndpointOp},
+        },
+        osal::Kernel,
+    };
+
+    fn channel_pool(
+        channels: u8,
+        kernel: &Kernel,
+        completions: &Dwc2ChannelCompletions,
+    ) -> HostChannelPool {
+        HostChannelPool::new(
+            channels,
+            completions.clone(),
+            Arc::new(Dwc2PeriodicSchedule::new(kernel).unwrap()),
+        )
+    }
+
+    fn bulk_endpoint(regs: Dwc2Registers, kernel: Kernel, pool: HostChannelPool) -> Dwc2Endpoint {
+        match Dwc2Endpoint::new(Dwc2EndpointParams {
+            regs,
+            kernel,
+            device_address: 2,
+            port_speed: Speed::High,
+            info: EndpointInfo {
+                address: EndpointAddress::new(0x81),
+                transfer_type: EndpointType::Bulk,
+                direction: Direction::In,
+                max_packet_size: 512,
+                packets_per_microframe: 1,
+                interval: 0,
+            },
+            channel_pool: pool,
+            stats: Dwc2Stats::new(),
+        }) {
+            Ok(endpoint) => endpoint,
+            Err(err) => panic!("DWC2 test endpoint creation failed: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn submit_waits_for_irq_completion_before_reclaiming() {
+        let (_backing, regs) = tu::test_regs();
+        let kernel = tu::test_kernel();
+        let completions = Dwc2ChannelCompletions::new();
+        let channel_pool = channel_pool(2, &kernel, &completions);
+        let mut endpoint = bulk_endpoint(regs, kernel, channel_pool);
+        let mut data = [0u8; 512];
+        let id = endpoint
+            .submit_request(TransferRequest::bulk_in(&mut data))
+            .unwrap();
+
+        // 只开 CHHLTD（DDMA 下 XFERCOMPL/NAK 不单独中断）。
+        assert_eq!(regs.regs().hc[1].hcintmsk.get(), HCINT_CHHLTD);
+        assert_eq!(
+            regs.regs().hc[1].hcintmsk.get() & (HCINT_NAK | HCINT_XFERCOMPL),
+            0
+        );
+        assert!(endpoint.reclaim_request(id).is_none());
+
+        completions.publish(1, HCINT_CHHLTD | HCINT_XFERCOMPL);
+        assert!(endpoint.reclaim_request(id).is_some());
+    }
+
+    #[test]
+    fn cancelled_endpoint_waits_for_real_channel_halt_before_reclaiming() {
+        let (_backing, regs) = tu::test_regs();
+        let kernel = tu::test_kernel();
+        let completions = Dwc2ChannelCompletions::new();
+        let channel_pool = channel_pool(2, &kernel, &completions);
+        let mut endpoint = bulk_endpoint(regs, kernel, channel_pool);
+        let mut data = [0u8; 512];
+        let id = endpoint
+            .submit_request(TransferRequest::bulk_in(&mut data))
+            .unwrap();
+
+        endpoint.cancel_request(id).unwrap();
+
+        // 取消投递 CHDIS 而非立即回收；真实 CHHLTD 到达前 reclaim 为空。
+        assert_eq!(regs.regs().hc[1].hcchar.get() & (1 << 30), 1 << 30);
+        assert!(endpoint.reclaim_request(id).is_none());
+
+        completions.publish(1, HCINT_CHHLTD);
+        assert!(matches!(
+            endpoint.reclaim_request(id),
+            Some(Err(TransferError::Cancelled))
+        ));
+    }
+
+    #[test]
+    fn disconnect_completes_active_request_without_more_channel_writes() {
+        let (_backing, regs) = tu::test_regs();
+        let kernel = tu::test_kernel();
+        let completions = Dwc2ChannelCompletions::new();
+        let channel_pool = channel_pool(2, &kernel, &completions);
+        let mut endpoint = bulk_endpoint(regs, kernel, channel_pool);
+        let handler = Dwc2EventHandler::new(regs, completions.clone(), Dwc2Stats::new());
+        let mut data = [0u8; 512];
+        let id = endpoint
+            .submit_request(TransferRequest::bulk_in(&mut data))
+            .unwrap();
+
+        regs.regs().gintmsk.set(GINTSTS_DISCONNINT);
+        regs.regs().gintsts.set(GINTSTS_DISCONNINT);
+        assert!(matches!(handler.handle_event(), Event::Stopped));
+        let channel_value = regs.regs().hc[1].hcchar.get();
+
+        endpoint.cancel_request(id).unwrap();
+
+        assert_eq!(regs.regs().hc[1].hcchar.get(), channel_value);
+        assert!(matches!(
+            endpoint.reclaim_request(id),
+            Some(Err(TransferError::Disconnected))
+        ));
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/event.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/event.rs
@@ -1,0 +1,296 @@
+use tock_registers::interfaces::{Readable, Writeable};
+
+use crate::backend::{
+    kmod::dwc2::{
+        channel::Dwc2ChannelCompletions,
+        reg::{
+            DWC2_MAX_CHANNELS, DWC2_RUNTIME_GINTMSK, Dwc2Registers, GINTSTS_DISCONNINT,
+            GINTSTS_HCHINT, GINTSTS_PRTINT, HCINT_CHHLTD, HPRT_CONN_DET, HPRT_ENA_CHG,
+            HPRT_OVRCUR_CHG, HPRT_W1C_MASK,
+        },
+        stats::Dwc2Stats,
+    },
+    ty::{Event, EventHandlerOp},
+};
+
+pub(crate) struct Dwc2EventHandler {
+    regs: Dwc2Registers,
+    channel_completions: Dwc2ChannelCompletions,
+    stats: Dwc2Stats,
+}
+
+unsafe impl Send for Dwc2EventHandler {}
+unsafe impl Sync for Dwc2EventHandler {}
+
+impl Dwc2EventHandler {
+    pub(crate) fn new(
+        regs: Dwc2Registers,
+        channel_completions: Dwc2ChannelCompletions,
+        stats: Dwc2Stats,
+    ) -> Self {
+        Self {
+            regs,
+            channel_completions,
+            stats,
+        }
+    }
+}
+
+impl EventHandlerOp for Dwc2EventHandler {
+    fn handle_event(&self) -> Event {
+        let pending =
+            self.regs.regs().gintsts.get() & self.regs.regs().gintmsk.get() & DWC2_RUNTIME_GINTMSK;
+        if pending == 0 {
+            return Event::Nothing;
+        }
+
+        if pending & GINTSTS_DISCONNINT != 0 {
+            self.channel_completions.disconnect_all_with(|| {
+                self.regs.regs().haintmsk.set(0);
+                let mask = self.regs.regs().gintmsk.get();
+                self.regs.regs().gintmsk.set(mask & !GINTSTS_HCHINT);
+            });
+            self.regs.regs().gintsts.set(GINTSTS_DISCONNINT);
+            return Event::Stopped;
+        }
+
+        if pending & GINTSTS_PRTINT != 0 {
+            let hprt = self.regs.hprt().raw();
+            let changes = hprt & (HPRT_CONN_DET | HPRT_ENA_CHG | HPRT_OVRCUR_CHG);
+            if changes != 0 {
+                // PRTINT is a read-only summary. Linux clears its source by
+                // acknowledging the HPRT0 W1C change bits while writing zero
+                // to HPRT0.ENA so the acknowledgement cannot disable the port.
+                self.regs.hprt().write((hprt & !HPRT_W1C_MASK) | changes);
+            }
+            return Event::PortChange { port: 1 };
+        }
+        if pending & GINTSTS_HCHINT != 0 {
+            self.stats.record_irq_event();
+            let count = self.handle_channel_interrupts();
+            self.regs.regs().gintsts.set(GINTSTS_HCHINT);
+            return Event::TransferActivity {
+                count: count.max(1),
+            };
+        }
+        self.regs.regs().gintsts.set(pending);
+        Event::Stopped
+    }
+}
+
+impl Dwc2EventHandler {
+    fn handle_channel_interrupts(&self) -> usize {
+        let pending = self.regs.regs().haint.get() & self.regs.regs().haintmsk.get();
+        let mut count = 0usize;
+        for channel in 0..DWC2_MAX_CHANNELS {
+            if pending & (1u32 << channel) == 0 {
+                continue;
+            }
+            let channel_regs = self.regs.channel(channel);
+            let Some(hcint) = channel_regs.take_irqs() else {
+                continue;
+            };
+            if hcint & HCINT_CHHLTD == 0 && channel_regs.is_enabled() {
+                if self.channel_completions.is_iso(channel) {
+                    // ISO 常驻通道：XFERCOMPL（IOC）时保持通道使能并继续周期
+                    // 会话，直接发布完成位，由任务侧结算本请求。
+                    self.channel_completions.publish(channel, hcint);
+                    self.stats.record_channel_completion();
+                    count += 1;
+                } else {
+                    self.channel_completions.defer(channel, hcint);
+                    channel_regs.disable();
+                }
+                continue;
+            }
+            self.channel_completions.publish(channel, hcint);
+            self.stats.record_channel_completion();
+            count += 1;
+        }
+        count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use alloc::vec::Vec;
+
+    use super::*;
+    use crate::backend::kmod::dwc2::{
+        reg::{
+            DWC2_COMPLETION_DISCONNECTED, HCINT_CHHLTD, HCINT_STALL, HCINT_XFERCOMPL,
+            HPRT_CONN_DET, HPRT_ENA, HPRT_ENA_CHG, HPRT_OVRCUR_CHG, HPRT_PWR, HPRT_W1C_MASK,
+        },
+        testutil as tu,
+    };
+
+    fn handler_fixture() -> (
+        Vec<u32>,
+        Dwc2Registers,
+        Dwc2ChannelCompletions,
+        Dwc2Stats,
+        Dwc2EventHandler,
+    ) {
+        let (backing, regs) = tu::test_regs();
+        let completions = Dwc2ChannelCompletions::new();
+        let stats = Dwc2Stats::new();
+        let handler = Dwc2EventHandler::new(regs, completions.clone(), stats.clone());
+        (backing, regs, completions, stats, handler)
+    }
+
+    /// 预置一道路 channel 中断（GINTMSK/GINTSTS/HAINTMSK/HAINT 全开通道 0）。
+    fn arm_channel_interrupt(regs: &Dwc2Registers) {
+        regs.regs().gintmsk.set(GINTSTS_HCHINT);
+        regs.regs().gintsts.set(GINTSTS_HCHINT);
+        regs.regs().haintmsk.set(1);
+        regs.regs().haint.set(1);
+    }
+
+    #[test]
+    fn hchint_event_publishes_channel_completion() {
+        let (_backing, regs, completions, stats, handler) = handler_fixture();
+
+        arm_channel_interrupt(&regs);
+        regs.regs().hc[0].hcintmsk.set(HCINT_CHHLTD);
+        regs.regs().hc[0].hcint.set(HCINT_CHHLTD | HCINT_XFERCOMPL);
+
+        match handler.handle_event() {
+            Event::TransferActivity { count } => assert_eq!(count, 1),
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+        assert_eq!(completions.take(0), Some(HCINT_CHHLTD | HCINT_XFERCOMPL));
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.irq_events, 1);
+        assert_eq!(snapshot.channel_completions, 1);
+    }
+
+    #[test]
+    fn channel_interrupt_requires_gintmsk_ack() {
+        let (_backing, regs, completions, _stats, handler) = handler_fixture();
+
+        // 状态位置位但 GINTMSK 未使能：不消费通道中断寄存器。
+        regs.regs().gintsts.set(GINTSTS_HCHINT);
+        regs.regs().gintmsk.set(0);
+        regs.regs().haintmsk.set(1);
+        regs.regs().haint.set(1);
+        regs.regs().hc[0].hcintmsk.set(HCINT_CHHLTD);
+        regs.regs().hc[0].hcint.set(HCINT_CHHLTD | HCINT_XFERCOMPL);
+
+        assert!(matches!(handler.handle_event(), Event::Nothing));
+        assert_eq!(completions.take(0), None);
+        assert_eq!(
+            regs.regs().hc[0].hcint.get(),
+            HCINT_CHHLTD | HCINT_XFERCOMPL
+        );
+    }
+
+    #[test]
+    fn port_interrupt_acknowledges_hprt_change_bits() {
+        let (_backing, regs, completions, _stats, handler) = handler_fixture();
+        let hprt = (1 << 0) | HPRT_ENA | HPRT_CONN_DET | HPRT_ENA_CHG | HPRT_PWR | HPRT_OVRCUR_CHG;
+
+        regs.regs().gintmsk.set(GINTSTS_PRTINT);
+        regs.regs().gintsts.set(GINTSTS_PRTINT);
+        regs.regs().hprt.set(hprt);
+
+        assert!(matches!(
+            handler.handle_event(),
+            Event::PortChange { port: 1 }
+        ));
+        assert_eq!(
+            regs.regs().hprt.get(),
+            (hprt & !HPRT_W1C_MASK) | HPRT_CONN_DET | HPRT_ENA_CHG | HPRT_OVRCUR_CHG
+        );
+        assert_eq!(completions.take(0), None);
+    }
+
+    #[test]
+    fn chhltd_completion_preserves_unmasked_raw_hcint_reason() {
+        let (_backing, regs, completions, _stats, handler) = handler_fixture();
+
+        arm_channel_interrupt(&regs);
+        regs.regs().hc[0].hcintmsk.set(HCINT_CHHLTD);
+        regs.regs().hc[0].hcint.set(HCINT_CHHLTD | HCINT_STALL);
+
+        match handler.handle_event() {
+            Event::TransferActivity { count } => assert_eq!(count, 1),
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+        // 只开 CHHLTD 屏蔽位，故障位仍随原始 hcint 保留。
+        assert_eq!(completions.take(0), Some(HCINT_CHHLTD | HCINT_STALL));
+    }
+
+    #[test]
+    fn xfercomplete_without_channel_halt_is_deferred_until_halt_for_non_iso() {
+        let (_backing, regs, completions, stats, handler) = handler_fixture();
+
+        arm_channel_interrupt(&regs);
+        regs.regs().hc[0]
+            .hcintmsk
+            .set(HCINT_CHHLTD | HCINT_XFERCOMPL);
+        regs.regs().hc[0].hcchar.set(1 << 31); // CHENA
+        regs.regs().hc[0].hcint.set(HCINT_XFERCOMPL);
+
+        match handler.handle_event() {
+            Event::TransferActivity { .. } => {}
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+        // 非 ISO：XFERCOMPL 未伴随 CHHLTD，先请求 halt 后再发布。
+        assert_eq!(completions.take(0), None);
+        assert_eq!(
+            regs.regs().hc[0].hcchar.get() & ((1 << 30) | (1 << 31)),
+            1 << 30
+        );
+        assert_eq!(stats.snapshot().channel_completions, 0);
+
+        // CHHLTD 到达：发布合并 deferred 位的完整完成。
+        regs.regs().gintsts.set(GINTSTS_HCHINT);
+        regs.regs().hc[0].hcchar.set(0);
+        regs.regs().hc[0].hcint.set(HCINT_CHHLTD);
+        match handler.handle_event() {
+            Event::TransferActivity { count } => assert_eq!(count, 1),
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+        assert_eq!(completions.take(0), Some(HCINT_CHHLTD | HCINT_XFERCOMPL));
+        assert_eq!(stats.snapshot().channel_completions, 1);
+    }
+
+    #[test]
+    fn iso_completion_publishes_without_halt_or_disable() {
+        let (_backing, regs, completions, stats, handler) = handler_fixture();
+
+        arm_channel_interrupt(&regs);
+        completions.mark_iso(0, true);
+        regs.regs().hc[0]
+            .hcintmsk
+            .set(HCINT_CHHLTD | HCINT_XFERCOMPL);
+        regs.regs().hc[0].hcchar.set(1 << 31); // ISO 常驻通道保持 CHENA
+        regs.regs().hc[0].hcint.set(HCINT_XFERCOMPL);
+
+        match handler.handle_event() {
+            Event::TransferActivity { count } => assert_eq!(count, 1),
+            event => panic!("expected transfer activity, got {event:?}"),
+        }
+        assert_eq!(completions.take(0), Some(HCINT_XFERCOMPL));
+        assert_eq!(regs.regs().hc[0].hcchar.get() & (1 << 31), 1 << 31);
+        assert_eq!(stats.snapshot().channel_completions, 1);
+    }
+
+    #[test]
+    fn disconnect_event_stops_and_publishes_disconnected_completion() {
+        let (_backing, regs, completions, _stats, handler) = handler_fixture();
+        let channel = completions.try_begin_request(3);
+        assert!(channel);
+
+        regs.regs().gintmsk.set(GINTSTS_DISCONNINT);
+        regs.regs().gintsts.set(GINTSTS_DISCONNINT);
+
+        assert!(matches!(handler.handle_event(), Event::Stopped));
+        assert_eq!(completions.take(3), Some(DWC2_COMPLETION_DISCONNECTED));
+        assert_eq!(regs.regs().haintmsk.get(), 0);
+        assert_eq!(regs.regs().gintmsk.get() & GINTSTS_HCHINT, 0);
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/hub.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/hub.rs
@@ -1,0 +1,114 @@
+use alloc::{vec, vec::Vec};
+use core::time::Duration;
+
+use futures::{FutureExt, future::BoxFuture};
+use usb_if::host::hub::Speed;
+
+use crate::{
+    backend::kmod::{
+        Kernel,
+        dwc2::reg::{Dwc2Registers, HPRT_PWR, HPRT_RST, HPRT_W1C_MASK, Hprt},
+        hub::{HubInfo, HubOp, PortChangeInfo, PortEvent, PortState},
+    },
+    err::Result,
+};
+
+pub(crate) struct Dwc2RootHub {
+    regs: Dwc2Registers,
+    kernel: Kernel,
+    port: PortState,
+    last_logged_hprt: Option<u32>,
+}
+unsafe impl Send for Dwc2RootHub {}
+
+impl Dwc2RootHub {
+    pub(crate) fn new(regs: Dwc2Registers, kernel: Kernel) -> Self {
+        Self {
+            regs,
+            kernel,
+            port: PortState::Uninit,
+            last_logged_hprt: None,
+        }
+    }
+
+    async fn init_port(&mut self, mut info: HubInfo) -> Result<HubInfo> {
+        info.speed = Speed::High;
+        self.regs.hprt().update_safe(|value| value | HPRT_PWR);
+        self.kernel.delay(Duration::from_millis(20));
+        Ok(info)
+    }
+
+    async fn changed_ports_inner(&mut self) -> Result<Vec<PortEvent>> {
+        if matches!(self.port, PortState::Probed) {
+            if !self.regs.hprt().is_connected() {
+                self.port = PortState::Uninit;
+                self.regs.hprt().clear_connect_detect();
+                return Ok(vec![PortEvent::Disconnected { port_id: 1 }]);
+            }
+            return Ok(Vec::new());
+        }
+
+        let hprt = self.regs.hprt();
+        self.log_port_status("scan", &hprt);
+        if !hprt.is_connected() {
+            return Ok(Vec::new());
+        }
+
+        if matches!(self.port, PortState::Uninit) {
+            self.reset_port();
+            self.port = PortState::Reseted;
+            self.log_port_status("reset", &self.regs.hprt());
+        }
+
+        if self.regs.hprt().is_connected() && self.regs.hprt().is_enabled() {
+            self.port = PortState::Probed;
+            Ok(vec![PortEvent::Connected(PortChangeInfo {
+                root_port_id: 1,
+                port_id: 1,
+                port_speed: self.regs.hprt().speed(),
+            })])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    fn reset_port(&self) {
+        self.regs.hprt().clear_connect_detect();
+        self.regs
+            .hprt()
+            .write_safe((self.regs.hprt().raw() & !HPRT_W1C_MASK) | HPRT_PWR | HPRT_RST);
+        self.kernel.delay(Duration::from_millis(60));
+        self.regs
+            .hprt()
+            .write_safe(((self.regs.hprt().raw() & !HPRT_W1C_MASK) | HPRT_PWR) & !HPRT_RST);
+        self.kernel.delay(Duration::from_millis(80));
+    }
+
+    fn log_port_status(&mut self, phase: &str, hprt: &Hprt) {
+        if self.last_logged_hprt == Some(hprt.raw()) {
+            return;
+        }
+        self.last_logged_hprt = Some(hprt.raw());
+        log::info!(
+            "dwc2: root port {phase} hprt0={:#010x} connected={} enabled={} speed={:?}",
+            hprt.raw(),
+            hprt.is_connected(),
+            hprt.is_enabled(),
+            hprt.speed()
+        );
+    }
+}
+
+impl HubOp for Dwc2RootHub {
+    fn init<'a>(&'a mut self, info: HubInfo) -> BoxFuture<'a, Result<HubInfo>> {
+        self.init_port(info).boxed()
+    }
+
+    fn changed_ports<'a>(&'a mut self) -> BoxFuture<'a, Result<Vec<PortEvent>>> {
+        self.changed_ports_inner().boxed()
+    }
+
+    fn slot_id(&self) -> u8 {
+        0
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/mod.rs
@@ -1,152 +1,61 @@
-use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec, vec::Vec};
-use core::{
-    ptr::NonNull,
-    sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
-    task::{Context, Poll},
-    time::Duration,
-};
+mod channel;
+mod dma;
+mod endpoint;
+mod event;
+mod hub;
+mod reg;
+mod stats;
 
-use ax_sync::SpinLock as Mutex;
-use dma_api::CoherentArray;
+#[cfg(test)]
+mod testutil;
+
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc, vec::Vec};
+use core::{task::Poll, time::Duration};
+
 use futures::{
     FutureExt,
     future::{BoxFuture, poll_fn},
-    task::AtomicWaker,
 };
-use mbarrier::mb;
+use reg::*;
+pub use stats::Dwc2TransferStats;
+use tock_registers::interfaces::{ReadWriteable, Readable, Writeable};
 use usb_if::{
     descriptor::{
         ConfigurationDescriptor, DescriptorType, DeviceDescriptor, DeviceDescriptorBase,
         EndpointDescriptor, EndpointType,
     },
-    endpoint::{EndpointInfo, RequestId, TransferCompletion, TransferRequest, TransferStatus},
+    endpoint::EndpointInfo,
     err::{TransferError, USBError},
     host::{ControlSetup, hub::Speed},
-    transfer::{BmRequestType, Direction, Recipient, Request, RequestType},
+    transfer::{Direction, Recipient, Request, RequestType},
 };
 
 use super::{
-    hub::{HubInfo, HubOp, PortChangeInfo, PortEvent, PortState},
+    hub::HubOp,
     kcore::CoreOp,
     osal::{Kernel, KernelOp},
 };
 use crate::{
-    DeviceAddressInfo, Mmio,
-    backend::ty::{
-        DeviceOp, Event, EventHandlerOp, HubParams,
-        ep::{EndpointHandle, EndpointOp},
+    Mmio,
+    backend::{
+        kmod::{
+            DeviceAddressInfo,
+            dwc2::{
+                channel::{Dwc2ChannelCompletions, Dwc2PeriodicSchedule, HostChannelPool},
+                endpoint::{Dwc2Endpoint, Dwc2EndpointParams},
+                event::Dwc2EventHandler,
+                hub::Dwc2RootHub,
+                reg::Dwc2Registers,
+                stats::Dwc2Stats,
+            },
+        },
+        ty::{
+            DeviceOp, EventHandlerOp, HubParams,
+            ep::{EndpointHandle, EndpointOp},
+        },
     },
     err::Result,
 };
-
-const DWC2_DMA_MASK_32: u64 = u32::MAX as u64;
-// Linux DWC2 bounds GRSTCTL register polls to 10,000 reads. Keep the same
-// budget: MMIO reads can be slow on embedded interconnects, and a missing
-// hardware transition must fail initialization instead of monopolizing a CPU.
-const DWC2_WAIT_ITERS: usize = 10_000;
-const DWC2_MAX_CHANNELS: u8 = 16;
-const DWC2_DMA_ALIGN: usize = 64;
-const DWC2_NAK_RETRIES: u32 = 64;
-const DWC2_XACT_RETRIES: u32 = 8;
-
-const GOTGCTL: usize = 0x000;
-const GAHBCFG: usize = 0x008;
-const GUSBCFG: usize = 0x00c;
-const GRSTCTL: usize = 0x010;
-const GINTSTS: usize = 0x014;
-const GINTMSK: usize = 0x018;
-const GRXFSIZ: usize = 0x024;
-const GNPTXFSIZ: usize = 0x028;
-const GSNPSID: usize = 0x040;
-const GHWCFG2: usize = 0x048;
-const GHWCFG4: usize = 0x050;
-const HPTXFSIZ: usize = 0x100;
-const HCFG: usize = 0x400;
-const HFNUM: usize = 0x408;
-const HAINT: usize = 0x414;
-const HAINTMSK: usize = 0x418;
-const HPRT0: usize = 0x440;
-const HC_BASE: usize = 0x500;
-const HC_STRIDE: usize = 0x20;
-const PCGCTL: usize = 0xe00;
-
-const HCCHAR: usize = 0x00;
-const HCSPLT: usize = 0x04;
-const HCINT: usize = 0x08;
-const HCINTMSK: usize = 0x0c;
-const HCTSIZ: usize = 0x10;
-const HCDMA: usize = 0x14;
-
-const GUSBCFG_TOUTCAL_MASK: u32 = 0x7;
-const GUSBCFG_PHYIF16: u32 = 1 << 3;
-const GUSBCFG_ULPI_UTMI_SEL: u32 = 1 << 4;
-const GUSBCFG_FORCEHOSTMODE: u32 = 1 << 29;
-const GUSBCFG_FORCEDEVMODE: u32 = 1 << 30;
-
-const GRSTCTL_CSFTRST: u32 = 1 << 0;
-const GRSTCTL_RXFFLSH: u32 = 1 << 4;
-const GRSTCTL_TXFFLSH: u32 = 1 << 5;
-const GRSTCTL_TXFNUM_ALL: u32 = 0x10 << 6;
-const GRSTCTL_CSFTRST_DONE: u32 = 1 << 29;
-const GRSTCTL_AHBIDLE: u32 = 1 << 31;
-
-const GINTSTS_CURMODE_HOST: u32 = 1 << 0;
-const GINTSTS_PRTINT: u32 = 1 << 24;
-const GINTSTS_HCHINT: u32 = 1 << 25;
-const GINTSTS_DISCONNINT: u32 = 1 << 29;
-const DWC2_RUNTIME_GINTMSK: u32 = GINTSTS_PRTINT | GINTSTS_HCHINT | GINTSTS_DISCONNINT;
-const DWC2_COMPLETION_DISCONNECTED: u32 = 1 << 31;
-
-const GOTGCTL_VBVALOEN: u32 = 1 << 2;
-const GOTGCTL_VBVALOVAL: u32 = 1 << 3;
-const GOTGCTL_AVALOEN: u32 = 1 << 4;
-const GOTGCTL_AVALOVAL: u32 = 1 << 5;
-const GOTGCTL_DBNCE_FLTR_BYPASS: u32 = 1 << 15;
-
-const HPRT_CONN_STS: u32 = 1 << 0;
-const HPRT_CONN_DET: u32 = 1 << 1;
-const HPRT_ENA: u32 = 1 << 2;
-const HPRT_ENA_CHG: u32 = 1 << 3;
-const HPRT_OVRCUR_CHG: u32 = 1 << 5;
-const HPRT_RST: u32 = 1 << 8;
-const HPRT_PWR: u32 = 1 << 12;
-const HPRT_SPD_SHIFT: u32 = 17;
-const HPRT_SPD_MASK: u32 = 0b11 << HPRT_SPD_SHIFT;
-const HPRT_W1C_MASK: u32 = HPRT_CONN_DET | HPRT_ENA | HPRT_ENA_CHG | HPRT_OVRCUR_CHG;
-
-const HCCHAR_CHENA: u32 = 1 << 31;
-const HCCHAR_CHDIS: u32 = 1 << 30;
-const HCCHAR_ODDFRM: u32 = 1 << 29;
-const HCCHAR_EPDIR: u32 = 1 << 15;
-const HCINT_XFERCOMPL: u32 = 1 << 0;
-const HCINT_CHHLTD: u32 = 1 << 1;
-const HCINT_AHBERR: u32 = 1 << 2;
-const HCINT_STALL: u32 = 1 << 3;
-const HCINT_NAK: u32 = 1 << 4;
-const HCINT_XACTERR: u32 = 1 << 7;
-const HCINT_BBLERR: u32 = 1 << 8;
-const HCINT_FRMOVRN: u32 = 1 << 9;
-const HCINT_DATATGLERR: u32 = 1 << 10;
-const HCINT_ALL_W1C: u32 = 0x7ff;
-const HCINT_TRANSFER_MASK: u32 = HCINT_XFERCOMPL
-    | HCINT_CHHLTD
-    | HCINT_AHBERR
-    | HCINT_STALL
-    | HCINT_NAK
-    | HCINT_XACTERR
-    | HCINT_BBLERR
-    | HCINT_FRMOVRN
-    | HCINT_DATATGLERR;
-const HCINT_DMA_IRQ_MASK: u32 = HCINT_CHHLTD
-    | HCINT_AHBERR
-    | HCINT_STALL
-    | HCINT_XACTERR
-    | HCINT_BBLERR
-    | HCINT_FRMOVRN
-    | HCINT_DATATGLERR;
-
-const HCTSIZ_XFERSIZE_MASK: u32 = 0x7ffff;
-const HCTSIZ_MAX_PACKETS: u32 = 1023;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Dwc2UtmiWidth {
@@ -218,474 +127,6 @@ pub struct Dwc2NewParams {
     pub params: Dwc2HostParams,
 }
 
-#[derive(Clone, Copy)]
-struct Dwc2Registers {
-    base: NonNull<u8>,
-}
-
-// SAFETY: `Dwc2Registers` is a copyable handle to a DWC2 MMIO mapping that is
-// owned by the platform USB host for the whole backend lifetime. The type does
-// not provide references into the mapping; all accesses are volatile 32-bit
-// loads/stores through private methods, and higher-level code serializes
-// channel programming with per-channel gates when concurrent task/IRQ paths can
-// touch the same channel registers.
-unsafe impl Send for Dwc2Registers {}
-// SAFETY: Shared references to this handle cannot create Rust aliasing to the
-// MMIO region because MMIO is only accessed by volatile operations. Register
-// ordering and channel-level races are handled by the DWC2 protocol code and
-// the per-channel gates/completion atomics rather than by Rust references.
-unsafe impl Sync for Dwc2Registers {}
-
-impl Dwc2Registers {
-    fn new(base: Mmio) -> Self {
-        Self { base }
-    }
-
-    fn read32(self, offset: usize) -> u32 {
-        // SAFETY: `base` points at the live DWC2 register window supplied by the
-        // board glue. `Dwc2Registers` is private, and every caller passes either
-        // a constant register offset from this file or a channel offset computed
-        // from a bounded host-channel index. Volatile access is required for
-        // MMIO and does not create Rust references into the device memory.
-        unsafe { (self.base.as_ptr().add(offset) as *const u32).read_volatile() }
-    }
-
-    fn write32(self, offset: usize, value: u32) {
-        // SAFETY: Same mapping and offset invariants as `read32`. The write is
-        // volatile because it programs hardware state; callers preserve W1C and
-        // read-modify-write semantics at the register-specific helper layer.
-        unsafe { (self.base.as_ptr().add(offset) as *mut u32).write_volatile(value) }
-    }
-
-    fn update32(self, offset: usize, f: impl FnOnce(u32) -> u32) {
-        let value = self.read32(offset);
-        self.write32(offset, f(value));
-    }
-
-    fn channel_offset(channel: u8, reg: usize) -> usize {
-        HC_BASE + usize::from(channel) * HC_STRIDE + reg
-    }
-
-    fn channel_read32(self, channel: u8, reg: usize) -> u32 {
-        self.read32(Self::channel_offset(channel, reg))
-    }
-
-    fn channel_write32(self, channel: u8, reg: usize, value: u32) {
-        self.write32(Self::channel_offset(channel, reg), value);
-    }
-
-    fn host_channel_count(self) -> u8 {
-        ((((self.read32(GHWCFG2) >> 14) & 0x0f) + 1) as u8).clamp(2, DWC2_MAX_CHANNELS)
-    }
-
-    fn hprt_status(self) -> Dwc2PortStatus {
-        Dwc2PortStatus::from_raw(self.read32(HPRT0))
-    }
-
-    fn hprt_write_safe(self, value: u32) {
-        self.write32(HPRT0, Dwc2PortStatus::from_raw(value).rmw_preserving_w1c());
-    }
-
-    fn hprt_update_safe(self, f: impl FnOnce(u32) -> u32) {
-        let value = self.read32(HPRT0) & !HPRT_W1C_MASK;
-        self.write32(HPRT0, f(value) & !HPRT_W1C_MASK);
-    }
-
-    fn clear_hprt_connect_detect(self) {
-        let current = self.read32(HPRT0);
-        if current & HPRT_CONN_DET != 0 {
-            self.write32(HPRT0, (current & !HPRT_W1C_MASK) | HPRT_CONN_DET);
-        }
-    }
-
-    fn periodic_odd_frame_bit(self) -> u32 {
-        if self.read32(HFNUM) & 1 == 0 {
-            HCCHAR_ODDFRM
-        } else {
-            0
-        }
-    }
-}
-
-struct Dwc2ChannelCompletionSlot {
-    hcint: AtomicU32,
-    deferred_hcint: AtomicU32,
-    busy: AtomicBool,
-    waker: AtomicWaker,
-}
-
-impl Dwc2ChannelCompletionSlot {
-    fn new() -> Self {
-        Self {
-            hcint: AtomicU32::new(0),
-            deferred_hcint: AtomicU32::new(0),
-            busy: AtomicBool::new(false),
-            waker: AtomicWaker::new(),
-        }
-    }
-
-    fn try_begin_request(&self) -> bool {
-        self.busy
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_ok()
-    }
-
-    fn end_request(&self) {
-        self.busy.store(false, Ordering::Release);
-        self.clear();
-    }
-
-    fn clear(&self) {
-        self.hcint.store(0, Ordering::Release);
-        self.deferred_hcint.store(0, Ordering::Release);
-    }
-
-    fn publish(&self, hcint: u32) {
-        let deferred = self.deferred_hcint.swap(0, Ordering::AcqRel);
-        self.hcint.fetch_or(hcint | deferred, Ordering::AcqRel);
-        self.waker.wake();
-    }
-
-    fn defer(&self, hcint: u32) {
-        self.deferred_hcint.fetch_or(hcint, Ordering::AcqRel);
-    }
-
-    fn take(&self) -> Option<u32> {
-        let hcint = self.hcint.swap(0, Ordering::AcqRel);
-        (hcint != 0).then_some(hcint)
-    }
-
-    fn register_waker(&self, cx: &mut Context<'_>) {
-        self.waker.register(cx.waker());
-    }
-}
-
-#[derive(Clone)]
-struct Dwc2ChannelCompletions {
-    slots: Arc<Vec<Dwc2ChannelCompletionSlot>>,
-    connected: Arc<AtomicBool>,
-    lifecycle_gate: Arc<Mutex<()>>,
-}
-
-impl Dwc2ChannelCompletions {
-    fn new() -> Self {
-        Self {
-            slots: Arc::new(
-                (0..usize::from(DWC2_MAX_CHANNELS))
-                    .map(|_| Dwc2ChannelCompletionSlot::new())
-                    .collect(),
-            ),
-            connected: Arc::new(AtomicBool::new(true)),
-            lifecycle_gate: Arc::new(Mutex::new(())),
-        }
-    }
-
-    fn slot(&self, channel: u8) -> &Dwc2ChannelCompletionSlot {
-        self.slots
-            .get(usize::from(channel))
-            .unwrap_or_else(|| &self.slots[0])
-    }
-
-    fn try_begin_request(&self, channel: u8) -> bool {
-        self.slot(channel).try_begin_request()
-    }
-
-    fn end_request(&self, channel: u8) {
-        self.slot(channel).end_request();
-    }
-
-    fn clear(&self, channel: u8) {
-        self.slot(channel).clear();
-    }
-
-    fn publish(&self, channel: u8, hcint: u32) {
-        self.slot(channel).publish(hcint);
-    }
-
-    fn defer(&self, channel: u8, hcint: u32) {
-        self.slot(channel).defer(hcint);
-    }
-
-    fn take(&self, channel: u8) -> Option<u32> {
-        self.slot(channel).take()
-    }
-
-    fn register_waker(&self, channel: u8, cx: &mut Context<'_>) {
-        self.slot(channel).register_waker(cx);
-    }
-
-    fn is_connected(&self) -> bool {
-        self.connected.load(Ordering::Acquire)
-    }
-
-    fn mark_connected(&self, configure_irqs: impl FnOnce()) {
-        let _guard = self.lifecycle_gate.lock_irqsave();
-        configure_irqs();
-        self.connected.store(true, Ordering::Release);
-    }
-
-    fn disconnect_all_with(&self, mask_channel_irqs: impl FnOnce()) {
-        let _guard = self.lifecycle_gate.lock_irqsave();
-        // DISCONNINT is the controller's hardware confirmation that the host
-        // bus transaction has ended. From this point the host-channel
-        // registers may no longer be accessed, so publish terminal ownership
-        // release directly instead of trying to synthesize CHHLTD or CHDIS.
-        self.connected.store(false, Ordering::Release);
-        mask_channel_irqs();
-        for slot in self
-            .slots
-            .iter()
-            .filter(|slot| slot.busy.load(Ordering::Acquire))
-        {
-            slot.publish(DWC2_COMPLETION_DISCONNECTED);
-        }
-    }
-
-    fn with_connected<T>(
-        &self,
-        operation: impl FnOnce() -> core::result::Result<T, TransferError>,
-    ) -> core::result::Result<T, TransferError> {
-        let _guard = self.lifecycle_gate.lock_irqsave();
-        if !self.is_connected() {
-            return Err(TransferError::Disconnected);
-        }
-        operation()
-    }
-}
-
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
-pub struct Dwc2TransferStats {
-    pub transfers: usize,
-    pub stages: usize,
-    pub dma_allocs: usize,
-    pub bounce_to_device_bytes: usize,
-    pub bounce_from_device_bytes: usize,
-    pub naks: usize,
-    pub xact_errors: usize,
-    pub timeouts: usize,
-    pub wait_iters: usize,
-    pub init_wait_iters: usize,
-    pub transfer_busy_wait_iters: usize,
-    pub irq_events: usize,
-    pub channel_completions: usize,
-}
-
-#[derive(Default)]
-struct Dwc2StatsInner {
-    transfers: AtomicUsize,
-    stages: AtomicUsize,
-    dma_allocs: AtomicUsize,
-    bounce_to_device_bytes: AtomicUsize,
-    bounce_from_device_bytes: AtomicUsize,
-    naks: AtomicUsize,
-    xact_errors: AtomicUsize,
-    timeouts: AtomicUsize,
-    init_wait_iters: AtomicUsize,
-    transfer_busy_wait_iters: AtomicUsize,
-    irq_events: AtomicUsize,
-    channel_completions: AtomicUsize,
-}
-
-#[derive(Clone, Default)]
-struct Dwc2Stats {
-    inner: Arc<Dwc2StatsInner>,
-}
-
-impl Dwc2Stats {
-    fn new() -> Self {
-        Self::default()
-    }
-
-    fn reset(&self) {
-        self.inner.transfers.store(0, Ordering::Relaxed);
-        self.inner.stages.store(0, Ordering::Relaxed);
-        self.inner.dma_allocs.store(0, Ordering::Relaxed);
-        self.inner
-            .bounce_to_device_bytes
-            .store(0, Ordering::Relaxed);
-        self.inner
-            .bounce_from_device_bytes
-            .store(0, Ordering::Relaxed);
-        self.inner.naks.store(0, Ordering::Relaxed);
-        self.inner.xact_errors.store(0, Ordering::Relaxed);
-        self.inner.timeouts.store(0, Ordering::Relaxed);
-        self.inner.init_wait_iters.store(0, Ordering::Relaxed);
-        self.inner
-            .transfer_busy_wait_iters
-            .store(0, Ordering::Relaxed);
-        self.inner.irq_events.store(0, Ordering::Relaxed);
-        self.inner.channel_completions.store(0, Ordering::Relaxed);
-    }
-
-    fn snapshot(&self) -> Dwc2TransferStats {
-        let init_wait_iters = self.inner.init_wait_iters.load(Ordering::Relaxed);
-        let transfer_busy_wait_iters = self.inner.transfer_busy_wait_iters.load(Ordering::Relaxed);
-        Dwc2TransferStats {
-            transfers: self.inner.transfers.load(Ordering::Relaxed),
-            stages: self.inner.stages.load(Ordering::Relaxed),
-            dma_allocs: self.inner.dma_allocs.load(Ordering::Relaxed),
-            bounce_to_device_bytes: self.inner.bounce_to_device_bytes.load(Ordering::Relaxed),
-            bounce_from_device_bytes: self.inner.bounce_from_device_bytes.load(Ordering::Relaxed),
-            naks: self.inner.naks.load(Ordering::Relaxed),
-            xact_errors: self.inner.xact_errors.load(Ordering::Relaxed),
-            timeouts: self.inner.timeouts.load(Ordering::Relaxed),
-            wait_iters: init_wait_iters + transfer_busy_wait_iters,
-            init_wait_iters,
-            transfer_busy_wait_iters,
-            irq_events: self.inner.irq_events.load(Ordering::Relaxed),
-            channel_completions: self.inner.channel_completions.load(Ordering::Relaxed),
-        }
-    }
-
-    fn record_transfer(&self) {
-        self.inner.transfers.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn record_stage(&self) {
-        self.inner.stages.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn record_dma_alloc(&self) {
-        self.inner.dma_allocs.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn record_bounce_to_device(&self, bytes: usize) {
-        self.inner
-            .bounce_to_device_bytes
-            .fetch_add(bytes, Ordering::Relaxed);
-    }
-
-    fn record_bounce_from_device(&self, bytes: usize) {
-        self.inner
-            .bounce_from_device_bytes
-            .fetch_add(bytes, Ordering::Relaxed);
-    }
-
-    fn record_fault(&self, fault: Dwc2TransferFault) {
-        match fault {
-            Dwc2TransferFault::Nak => {
-                self.inner.naks.fetch_add(1, Ordering::Relaxed);
-            }
-            Dwc2TransferFault::Xact => {
-                self.inner.xact_errors.fetch_add(1, Ordering::Relaxed);
-            }
-            Dwc2TransferFault::Stall
-            | Dwc2TransferFault::Ahb
-            | Dwc2TransferFault::Babble
-            | Dwc2TransferFault::FrameOverrun
-            | Dwc2TransferFault::DataToggle
-            | Dwc2TransferFault::HaltedWithoutComplete => {}
-        }
-    }
-
-    fn record_timeout(&self) {
-        self.inner.timeouts.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn record_init_wait_iters(&self, iters: usize) {
-        self.inner
-            .init_wait_iters
-            .fetch_add(iters, Ordering::Relaxed);
-    }
-
-    #[cfg(test)]
-    fn record_transfer_busy_wait_iters(&self, iters: usize) {
-        self.inner
-            .transfer_busy_wait_iters
-            .fetch_add(iters, Ordering::Relaxed);
-    }
-
-    fn record_irq_event(&self) {
-        self.inner.irq_events.fetch_add(1, Ordering::Relaxed);
-    }
-
-    fn record_channel_completion(&self) {
-        self.inner
-            .channel_completions
-            .fetch_add(1, Ordering::Relaxed);
-    }
-}
-
-fn build_channel_gates(channel_count: u8) -> Vec<Arc<Mutex<()>>> {
-    (0..usize::from(channel_count.max(1)))
-        .map(|_| Arc::new(Mutex::new(())))
-        .collect()
-}
-
-fn channel_gate(gates: &[Arc<Mutex<()>>], channel: u8) -> Arc<Mutex<()>> {
-    gates
-        .get(usize::from(channel))
-        .or_else(|| gates.first())
-        .expect("DWC2 channel gates must not be empty")
-        .clone()
-}
-
-#[derive(Clone)]
-struct HostChannelPool {
-    channel_count: u8,
-    channel_gates: Arc<Vec<Arc<Mutex<()>>>>,
-    completions: Dwc2ChannelCompletions,
-}
-
-impl HostChannelPool {
-    fn new(channel_count: u8, completions: Dwc2ChannelCompletions) -> Self {
-        let channel_count = channel_count.max(1);
-        Self {
-            channel_count,
-            channel_gates: Arc::new(build_channel_gates(channel_count)),
-            completions,
-        }
-    }
-
-    fn acquire(&self, control: bool) -> core::result::Result<HostChannelLease, TransferError> {
-        if !self.completions.is_connected() {
-            return Err(TransferError::Disconnected);
-        }
-        let channels = if control { 0..1 } else { 1..self.channel_count };
-        for channel in channels {
-            if self.completions.try_begin_request(channel) {
-                self.completions.clear(channel);
-                return Ok(HostChannelLease {
-                    channel,
-                    gate: channel_gate(&self.channel_gates, channel),
-                    completions: self.completions.clone(),
-                    released: false,
-                    hardware_active: AtomicBool::new(false),
-                });
-            }
-        }
-        Err(TransferError::QueueFull)
-    }
-}
-
-struct HostChannelLease {
-    channel: u8,
-    gate: Arc<Mutex<()>>,
-    completions: Dwc2ChannelCompletions,
-    released: bool,
-    hardware_active: AtomicBool,
-}
-
-impl HostChannelLease {
-    fn release(mut self) {
-        self.completions.end_request(self.channel);
-        self.released = true;
-    }
-}
-
-impl Drop for HostChannelLease {
-    fn drop(&mut self) {
-        if !self.released && !self.hardware_active.load(Ordering::Acquire) {
-            self.completions.end_request(self.channel);
-        } else if !self.released {
-            error!(
-                "dwc2: quarantining host channel {} because hardware stop was not confirmed",
-                self.channel
-            );
-        }
-    }
-}
-
 pub struct Dwc2 {
     regs: Dwc2Registers,
     kernel: Kernel,
@@ -697,15 +138,7 @@ pub struct Dwc2 {
     stats: Dwc2Stats,
 }
 
-// SAFETY: `Dwc2` is moved into the kmod core as the unique owner of host state.
-// Public core operations require `&mut self`; the separately exposed IRQ handler
-// owns only cloned register/completion/stat handles. Shared state between the
-// task path and IRQ path is restricted to atomics, wakers, and per-channel gates.
 unsafe impl Send for Dwc2 {}
-// SAFETY: The only `&self` operations exposed by `Dwc2` read/reset atomic
-// statistics or return immutable kernel references. MMIO mutation remains behind
-// `&mut self` core methods or the IRQ handler, whose synchronization invariants
-// are documented on `Dwc2Registers` and `Dwc2EventHandler`.
 unsafe impl Sync for Dwc2 {}
 
 impl Dwc2 {
@@ -721,6 +154,8 @@ impl Dwc2 {
         let stats = Dwc2Stats::new();
         let event_handler = Dwc2EventHandler::new(regs, channel_completions.clone(), stats.clone());
         let channel_count = regs.host_channel_count();
+        let periodic = Dwc2PeriodicSchedule::new(&kernel)
+            .map_err(|err| USBError::Other(anyhow!("DWC2 frame list allocation failed: {err}")))?;
 
         Ok(Self {
             regs,
@@ -729,14 +164,18 @@ impl Dwc2 {
             root_hub: Some(root_hub),
             event_handler: Some(event_handler),
             next_addr: 1,
-            channel_pool: HostChannelPool::new(channel_count, channel_completions),
+            channel_pool: HostChannelPool::new(
+                channel_count,
+                channel_completions,
+                Arc::new(periodic),
+            ),
             stats,
         })
     }
 
     async fn init_controller(&mut self) -> Result<()> {
         self.disable_irq()?;
-        self.regs.write32(GINTSTS, u32::MAX);
+        self.regs.regs().gintsts.set(u32::MAX);
         self.core_soft_reset()?;
         log::debug!("dwc2: initial core reset complete");
         self.force_host_mode()?;
@@ -745,40 +184,47 @@ impl Dwc2 {
         log::debug!("dwc2: host-mode core reset complete");
 
         if self.params.quirks.otg_host_session_override {
-            self.regs.update32(GOTGCTL, |value| {
-                value
+            let gotgctl = self.regs.regs().gotgctl.get();
+            self.regs.regs().gotgctl.set(
+                gotgctl
                     | GOTGCTL_DBNCE_FLTR_BYPASS
                     | GOTGCTL_AVALOEN
                     | GOTGCTL_AVALOVAL
                     | GOTGCTL_VBVALOEN
-                    | GOTGCTL_VBVALOVAL
-            });
+                    | GOTGCTL_VBVALOVAL,
+            );
             self.kernel.delay(Duration::from_micros(200));
         }
 
         self.init_gusbcfg();
-        self.regs.write32(PCGCTL, 0);
+        self.regs.regs().pcgctl.set(0);
 
-        let arch = (self.regs.read32(GHWCFG2) >> 3) & 0b11;
+        let arch = self.regs.regs().ghwcfg2.read(GHWCFG2::ARCHITECTURE);
         let gahbcfg = build_gahbcfg_internal_dma(arch)?;
-        self.regs.write32(GAHBCFG, gahbcfg);
+        self.regs.regs().gahbcfg.set(gahbcfg);
 
-        self.regs.update32(HCFG, |value| value & !0x7);
+        // 硬件不具备 DDMA 能力时直接拒绝，
+        if !self.regs.is_support_ddma() {
+            log::error!("dwc2: controller lacks descriptor DMA capability");
+            return Err(USBError::NotSupported);
+        }
+
+        self.regs
+            .regs()
+            .hcfg
+            .modify(HCFG::FSLSPCLKSEL::CLEAR + HCFG::DESCDMA::SET);
+        log::debug!("dwc2: descriptor DMA enabled");
 
         let fifo = fifo_register_plan(self.params.fifo);
-        self.regs.write32(GRXFSIZ, fifo.grxfsiz);
-        self.regs.write32(GNPTXFSIZ, fifo.gnptxfsiz);
-        self.regs.write32(HPTXFSIZ, fifo.hptxfsiz);
+        self.regs.regs().grxfsiz.set(fifo.grxfsiz);
+        self.regs.regs().gnptxfsiz.set(fifo.gnptxfsiz);
+        self.regs.regs().hptxfsiz.set(fifo.hptxfsiz);
         self.flush_tx_fifo_all()?;
         log::debug!("dwc2: TX FIFOs flushed");
         self.flush_rx_fifo()?;
         log::debug!("dwc2: RX FIFO flushed");
 
         let channel_count = self.regs.host_channel_count();
-        if self.channel_pool.channel_count != channel_count {
-            self.channel_pool =
-                HostChannelPool::new(channel_count, self.channel_pool.completions.clone());
-        }
         self.prepare_runtime_irqs(channel_count);
         log::debug!("dwc2: runtime IRQ state prepared");
         self.port_power_on();
@@ -789,38 +235,34 @@ impl Dwc2 {
     }
 
     fn prepare_runtime_irqs(&self, channel_count: u8) {
-        let channel_mask = if channel_count >= 16 {
-            u16::MAX as u32
-        } else {
-            (1u32 << channel_count) - 1
-        };
+        // channel_count 已钳制到 2..=16，`1 << 16 − 1` 即为全 16 位 HAINTMSK。
+        let channel_mask = (1u32 << channel_count) - 1;
         // The caller registers the controller IRQ before initialization, but
         // only `CoreOp::enable_irq` publishes runtime events. Clear stale
         // status while masked so port power-on cannot re-enter half-built HCD
         // state through PRTINT/HCHINT.
-        self.regs.write32(GINTMSK, 0);
-        self.regs.write32(GINTSTS, u32::MAX);
-        self.regs.write32(HAINTMSK, channel_mask);
+        self.regs.regs().gintmsk.set(0);
+        self.regs.regs().gintsts.set(u32::MAX);
+        self.regs.regs().haintmsk.set(channel_mask);
     }
 
     fn init_gusbcfg(&self) {
         let want_16bit = match self.params.utmi {
             Dwc2UtmiWidth::Eight => false,
             Dwc2UtmiWidth::Sixteen => true,
-            Dwc2UtmiWidth::Auto => ((self.regs.read32(GHWCFG4) >> 14) & 0b11) == 1,
+            Dwc2UtmiWidth::Auto => self.regs.regs().ghwcfg4.read(GHWCFG4::UTMI_PHY_DATA_WIDTH) == 1,
         };
 
-        self.regs.update32(GUSBCFG, |mut value| {
-            value &= !(GUSBCFG_TOUTCAL_MASK
-                | GUSBCFG_PHYIF16
-                | GUSBCFG_ULPI_UTMI_SEL
-                | GUSBCFG_FORCEDEVMODE);
-            value |= GUSBCFG_FORCEHOSTMODE | 0x7;
-            if want_16bit {
-                value |= GUSBCFG_PHYIF16;
-            }
-            value
-        });
+        let mut value = self.regs.regs().gusbcfg.get();
+        value &= !(GUSBCFG_TOUTCAL_MASK
+            | GUSBCFG_PHYIF16
+            | GUSBCFG_ULPI_UTMI_SEL
+            | GUSBCFG_FORCEDEVMODE);
+        value |= GUSBCFG_FORCEHOSTMODE | 0x7;
+        if want_16bit {
+            value |= GUSBCFG_PHYIF16;
+        }
+        self.regs.regs().gusbcfg.set(value);
     }
 
     fn wait_until(&self, stage: &'static str, ready: impl Fn() -> bool) -> Result<()> {
@@ -836,35 +278,38 @@ impl Dwc2 {
         log::warn!(
             "dwc2: {stage} timed out gsnpsid={:#010x} grstctl={:#010x} gusbcfg={:#010x} \
              gintsts={:#010x}",
-            self.regs.read32(GSNPSID),
-            self.regs.read32(GRSTCTL),
-            self.regs.read32(GUSBCFG),
-            self.regs.read32(GINTSTS),
+            self.regs.regs().gsnpsid.get(),
+            self.regs.regs().grstctl.get(),
+            self.regs.regs().gusbcfg.get(),
+            self.regs.regs().gintsts.get(),
         );
         Err(USBError::Timeout)
     }
 
     fn wait_ahb_idle(&self) -> Result<()> {
         self.wait_until("AHB idle", || {
-            self.regs.read32(GRSTCTL) & GRSTCTL_AHBIDLE != 0
+            self.regs.regs().grstctl.get() & GRSTCTL_AHBIDLE != 0
         })
     }
 
     fn core_soft_reset(&self) -> Result<()> {
-        self.regs.update32(GRSTCTL, |value| value | GRSTCTL_CSFTRST);
+        let value = self.regs.regs().grstctl.get();
+        self.regs.regs().grstctl.set(value | GRSTCTL_CSFTRST);
         match self.params.soft_reset_completion {
             Dwc2SoftResetCompletion::StartBitCleared => {
                 self.wait_until("core soft reset clear", || {
-                    self.regs.read32(GRSTCTL) & GRSTCTL_CSFTRST == 0
+                    self.regs.regs().grstctl.get() & GRSTCTL_CSFTRST == 0
                 })?;
             }
             Dwc2SoftResetCompletion::DoneBitSet => {
                 self.wait_until("core soft reset done", || {
-                    self.regs.read32(GRSTCTL) & GRSTCTL_CSFTRST_DONE != 0
+                    self.regs.regs().grstctl.get() & GRSTCTL_CSFTRST_DONE != 0
                 })?;
-                self.regs.update32(GRSTCTL, |value| {
-                    (value & !GRSTCTL_CSFTRST) | GRSTCTL_CSFTRST_DONE
-                });
+                let value = self.regs.regs().grstctl.get();
+                self.regs
+                    .regs()
+                    .grstctl
+                    .set((value & !GRSTCTL_CSFTRST) | GRSTCTL_CSFTRST_DONE);
             }
         }
         self.wait_ahb_idle()?;
@@ -873,36 +318,40 @@ impl Dwc2 {
     }
 
     fn force_host_mode(&self) -> Result<()> {
-        self.regs.update32(GUSBCFG, |value| {
-            (value | GUSBCFG_FORCEHOSTMODE) & !GUSBCFG_FORCEDEVMODE
-        });
+        let value = self.regs.regs().gusbcfg.get();
+        self.regs
+            .regs()
+            .gusbcfg
+            .set((value | GUSBCFG_FORCEHOSTMODE) & !GUSBCFG_FORCEDEVMODE);
         self.kernel.delay(Duration::from_millis(25));
         self.wait_until("force host mode", || {
-            self.regs.read32(GINTSTS) & GINTSTS_CURMODE_HOST != 0
+            self.regs.regs().gintsts.get() & GINTSTS_CURMODE_HOST != 0
         })
     }
 
     fn flush_tx_fifo_all(&self) -> Result<()> {
         self.regs
-            .write32(GRSTCTL, GRSTCTL_TXFFLSH | GRSTCTL_TXFNUM_ALL);
+            .regs()
+            .grstctl
+            .set(GRSTCTL_TXFFLSH | GRSTCTL_TXFNUM_ALL);
         self.wait_until("flush all TX FIFOs", || {
-            self.regs.read32(GRSTCTL) & GRSTCTL_TXFFLSH == 0
+            self.regs.regs().grstctl.get() & GRSTCTL_TXFFLSH == 0
         })?;
         self.kernel.delay(Duration::from_micros(1));
         Ok(())
     }
 
     fn flush_rx_fifo(&self) -> Result<()> {
-        self.regs.write32(GRSTCTL, GRSTCTL_RXFFLSH);
+        self.regs.regs().grstctl.set(GRSTCTL_RXFFLSH);
         self.wait_until("flush RX FIFO", || {
-            self.regs.read32(GRSTCTL) & GRSTCTL_RXFFLSH == 0
+            self.regs.regs().grstctl.get() & GRSTCTL_RXFFLSH == 0
         })?;
         self.kernel.delay(Duration::from_micros(1));
         Ok(())
     }
 
     fn port_power_on(&self) {
-        self.regs.hprt_update_safe(|value| value | HPRT_PWR);
+        self.regs.hprt().update_safe(|value| value | HPRT_PWR);
     }
 
     fn allocate_address(&mut self) -> Result<u8> {
@@ -916,15 +365,11 @@ impl Dwc2 {
 
     async fn new_device(&mut self, info: DeviceAddressInfo) -> Result<Box<dyn DeviceOp>> {
         let channel_count = self.channel_pool.channel_count;
-        let channel_mask = if channel_count >= 16 {
-            u16::MAX as u32
-        } else {
-            (1u32 << channel_count) - 1
-        };
+        let channel_mask = (1u32 << channel_count) - 1;
         self.channel_pool.completions.mark_connected(|| {
-            self.regs.write32(HAINTMSK, channel_mask);
-            self.regs
-                .update32(GINTMSK, |mask| mask | DWC2_RUNTIME_GINTMSK);
+            self.regs.regs().haintmsk.set(channel_mask);
+            let mask = self.regs.regs().gintmsk.get();
+            self.regs.regs().gintmsk.set(mask | DWC2_RUNTIME_GINTMSK);
         });
         let addr = self.allocate_address()?;
         let mut device = Dwc2Device::new(Dwc2DeviceParams {
@@ -969,12 +414,12 @@ impl CoreOp for Dwc2 {
     }
 
     fn enable_irq(&mut self) -> Result<()> {
-        self.regs.write32(GINTMSK, DWC2_RUNTIME_GINTMSK);
+        self.regs.regs().gintmsk.set(DWC2_RUNTIME_GINTMSK);
         Ok(())
     }
 
     fn disable_irq(&mut self) -> Result<()> {
-        self.regs.write32(GINTMSK, 0);
+        self.regs.regs().gintmsk.set(0);
         Ok(())
     }
 
@@ -991,267 +436,23 @@ impl CoreOp for Dwc2 {
     }
 }
 
-struct Dwc2RootHub {
-    regs: Dwc2Registers,
-    kernel: Kernel,
-    port: PortState,
-    last_logged_hprt: Option<u32>,
-}
-
-// SAFETY: The root hub is driven by `HubOp` methods taking `&mut self`, so its
-// port state and cached log value are not concurrently mutated. MMIO access uses
-// the `Dwc2Registers` volatile-access invariants.
-unsafe impl Send for Dwc2RootHub {}
-
-impl Dwc2RootHub {
-    fn new(regs: Dwc2Registers, kernel: Kernel) -> Self {
-        Self {
-            regs,
-            kernel,
-            port: PortState::Uninit,
-            last_logged_hprt: None,
-        }
-    }
-
-    async fn init_port(&mut self, mut info: HubInfo) -> Result<HubInfo> {
-        info.speed = Speed::High;
-        self.regs.hprt_update_safe(|value| value | HPRT_PWR);
-        self.kernel.delay(Duration::from_millis(20));
-        Ok(info)
-    }
-
-    async fn changed_ports_inner(&mut self) -> Result<Vec<PortEvent>> {
-        if matches!(self.port, PortState::Probed) {
-            if !self.regs.hprt_status().connected() {
-                self.port = PortState::Uninit;
-                self.regs.clear_hprt_connect_detect();
-                return Ok(vec![PortEvent::Disconnected { port_id: 1 }]);
-            }
-            return Ok(Vec::new());
-        }
-
-        let mut status = self.regs.hprt_status();
-        self.log_port_status("scan", status);
-        if !status.connected() {
-            return Ok(Vec::new());
-        }
-
-        if matches!(self.port, PortState::Uninit) {
-            self.reset_port();
-            self.port = PortState::Reseted;
-            status = self.regs.hprt_status();
-            self.log_port_status("reset", status);
-        }
-
-        if status.connected() && status.enabled() {
-            self.port = PortState::Probed;
-            Ok(vec![PortEvent::Connected(PortChangeInfo {
-                root_port_id: 1,
-                port_id: 1,
-                port_speed: status.speed(),
-            })])
-        } else {
-            Ok(Vec::new())
-        }
-    }
-
-    fn reset_port(&self) {
-        self.regs.clear_hprt_connect_detect();
-        self.regs
-            .hprt_write_safe((self.regs.read32(HPRT0) & !HPRT_W1C_MASK) | HPRT_PWR | HPRT_RST);
-        self.kernel.delay(Duration::from_millis(60));
-        self.regs
-            .hprt_write_safe(((self.regs.read32(HPRT0) & !HPRT_W1C_MASK) | HPRT_PWR) & !HPRT_RST);
-        self.kernel.delay(Duration::from_millis(80));
-    }
-
-    fn log_port_status(&mut self, phase: &str, status: Dwc2PortStatus) {
-        if self.last_logged_hprt == Some(status.raw()) {
-            return;
-        }
-        self.last_logged_hprt = Some(status.raw());
-        log::info!(
-            "dwc2: root port {phase} hprt0={:#010x} connected={} enabled={} speed={:?}",
-            status.raw(),
-            status.connected(),
-            status.enabled(),
-            status.speed()
-        );
-    }
-}
-
-impl HubOp for Dwc2RootHub {
-    fn init<'a>(&'a mut self, info: HubInfo) -> BoxFuture<'a, Result<HubInfo>> {
-        self.init_port(info).boxed()
-    }
-
-    fn changed_ports<'a>(&'a mut self) -> BoxFuture<'a, Result<Vec<PortEvent>>> {
-        self.changed_ports_inner().boxed()
-    }
-
-    fn slot_id(&self) -> u8 {
-        0
-    }
-}
-
-struct Dwc2EventHandler {
-    regs: Dwc2Registers,
-    channel_completions: Dwc2ChannelCompletions,
-    stats: Dwc2Stats,
-}
-
-// SAFETY: The event handler may be registered on an IRQ path and moved between
-// runtimes. It contains no unsynchronized mutable Rust state: completions and
-// statistics are atomic, and register access is volatile through
-// `Dwc2Registers`.
-unsafe impl Send for Dwc2EventHandler {}
-// SAFETY: `handle_event` only uses `&self`. It acknowledges hardware IRQ bits
-// and publishes completions through atomics/wakers; channel programming races
-// with the task path are bounded by per-channel gates and DWC2 channel-halt
-// completion ordering.
-unsafe impl Sync for Dwc2EventHandler {}
-
-impl Dwc2EventHandler {
-    fn new(
-        regs: Dwc2Registers,
-        channel_completions: Dwc2ChannelCompletions,
-        stats: Dwc2Stats,
-    ) -> Self {
-        Self {
-            regs,
-            channel_completions,
-            stats,
-        }
-    }
-}
-
-impl EventHandlerOp for Dwc2EventHandler {
-    fn handle_event(&self) -> Event {
-        let pending = self.regs.read32(GINTSTS)
-            & self.regs.read32(GINTMSK)
-            & (GINTSTS_PRTINT | GINTSTS_HCHINT | GINTSTS_DISCONNINT);
-        if pending == 0 {
-            return Event::Nothing;
-        }
-
-        if pending & GINTSTS_DISCONNINT != 0 {
-            self.channel_completions.disconnect_all_with(|| {
-                self.regs.write32(HAINTMSK, 0);
-                self.regs.update32(GINTMSK, |mask| mask & !GINTSTS_HCHINT);
-            });
-            self.regs.write32(GINTSTS, GINTSTS_DISCONNINT);
-            return Event::Stopped;
-        }
-
-        if pending & GINTSTS_PRTINT != 0 {
-            let hprt = self.regs.read32(HPRT0);
-            let changes = hprt & (HPRT_CONN_DET | HPRT_ENA_CHG | HPRT_OVRCUR_CHG);
-            if changes != 0 {
-                // PRTINT is a read-only summary. Linux clears its source by
-                // acknowledging the HPRT0 W1C change bits while writing zero
-                // to HPRT0.ENA so the acknowledgement cannot disable the port.
-                self.regs.write32(HPRT0, (hprt & !HPRT_W1C_MASK) | changes);
-            }
-            return Event::PortChange { port: 1 };
-        }
-        if pending & GINTSTS_HCHINT != 0 {
-            self.stats.record_irq_event();
-            let count = self.handle_channel_interrupts();
-            self.regs.write32(GINTSTS, GINTSTS_HCHINT);
-            return Event::TransferActivity {
-                count: count.max(1),
-            };
-        }
-        self.regs.write32(GINTSTS, pending);
-        Event::Stopped
-    }
-}
-
-impl Dwc2EventHandler {
-    fn handle_channel_interrupts(&self) -> usize {
-        let pending = self.regs.read32(HAINT) & self.regs.read32(HAINTMSK);
-        let mut count = 0usize;
-        for channel in 0..DWC2_MAX_CHANNELS {
-            if pending & (1u32 << channel) == 0 {
-                continue;
-            }
-            let hcint_raw = self.regs.channel_read32(channel, HCINT) & HCINT_TRANSFER_MASK;
-            let hcint_masked = hcint_raw & self.regs.channel_read32(channel, HCINTMSK);
-            if hcint_masked == 0 {
-                continue;
-            }
-            self.regs.channel_write32(channel, HCINT, hcint_raw);
-            let hcint = if hcint_masked & HCINT_CHHLTD != 0 {
-                hcint_raw
-            } else {
-                hcint_masked
-            };
-            if hcint & HCINT_CHHLTD == 0 {
-                let hcchar = self.regs.channel_read32(channel, HCCHAR);
-                if hcchar & HCCHAR_CHENA != 0 {
-                    self.channel_completions.defer(channel, hcint);
-                    self.regs.channel_write32(
-                        channel,
-                        HCCHAR,
-                        hcchar | HCCHAR_CHENA | HCCHAR_CHDIS,
-                    );
-                    continue;
-                }
-            }
-            self.channel_completions.publish(channel, hcint);
-            self.stats.record_channel_completion();
-            count += 1;
-        }
-        count
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-struct Dwc2PortStatus(u32);
-
-impl Dwc2PortStatus {
-    const fn from_raw(raw: u32) -> Self {
-        Self(raw)
-    }
-
-    const fn connected(self) -> bool {
-        self.0 & HPRT_CONN_STS != 0
-    }
-
-    const fn raw(self) -> u32 {
-        self.0
-    }
-
-    const fn enabled(self) -> bool {
-        self.0 & HPRT_ENA != 0
-    }
-
-    fn speed(self) -> Speed {
-        match (self.0 & HPRT_SPD_MASK) >> HPRT_SPD_SHIFT {
-            0 => Speed::High,
-            2 => Speed::Low,
-            _ => Speed::Full,
-        }
-    }
-
-    const fn rmw_preserving_w1c(self) -> u32 {
-        self.0 & !HPRT_W1C_MASK
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Dwc2Pid {
     Data0,
+    Data2,
     Data1,
     Setup,
+    MData,
 }
 
 impl Dwc2Pid {
     const fn bits(self) -> u32 {
         match self {
             Self::Data0 => 0,
+            Self::Data2 => 1,
             Self::Data1 => 2,
             Self::Setup => 3,
+            Self::MData => 3,
         }
     }
 }
@@ -1259,6 +460,7 @@ impl Dwc2Pid {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Dwc2EpType {
     Control,
+    Isochronous,
     Bulk,
     Interrupt,
 }
@@ -1267,38 +469,11 @@ impl Dwc2EpType {
     const fn bits(self) -> u32 {
         match self {
             Self::Control => 0,
+            Self::Isochronous => 1,
             Self::Bulk => 2,
             Self::Interrupt => 3,
         }
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct DataStageRetryPolicy {
-    nak_retries: u32,
-}
-
-fn data_stage_retry_policy(ep_type: Dwc2EpType) -> DataStageRetryPolicy {
-    match ep_type {
-        Dwc2EpType::Control | Dwc2EpType::Bulk | Dwc2EpType::Interrupt => DataStageRetryPolicy {
-            nak_retries: DWC2_NAK_RETRIES,
-        },
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct Dwc2TransferStage {
-    pub(crate) hcchar: u32,
-    pub(crate) hctsiz: u32,
-    pub(crate) dma_addr: u32,
-    pub(crate) len: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Dwc2ControlPlan {
-    pub(crate) setup: Dwc2TransferStage,
-    pub(crate) data: Vec<Dwc2TransferStage>,
-    pub(crate) status: Dwc2TransferStage,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -1338,19 +513,20 @@ pub(crate) fn fifo_register_plan(fifo: Dwc2FifoSizes) -> FifoRegisterPlan {
     }
 }
 
-fn hctsiz(pid: Dwc2Pid, packet_count: u32, len: u32) -> u32 {
-    ((pid.bits() & 0b11) << 29)
-        | ((packet_count.min(HCTSIZ_MAX_PACKETS) & 0x03ff) << 19)
-        | (len & HCTSIZ_XFERSIZE_MASK)
+/// HCTSIZ 的 DDMA 编码：PID + NTD（描述符数 − 1）+ SCHINFO。
+/// XFERSIZE/PKTCNT 在 Descriptor DMA 模式不使用（Linux 同）。
+pub(crate) fn hctsiz_ddma(pid: Dwc2Pid, n_descs: u32, schinfo: u32) -> u32 {
+    ((pid.bits() & 0b11) << 29) | ((n_descs.saturating_sub(1).min(0xff)) << 8) | (schinfo & 0xff)
 }
 
-fn hcchar(
+pub(crate) fn hcchar(
     device: u8,
     endpoint: u8,
     direction: Direction,
     ep_type: Dwc2EpType,
     max_packet_size: u16,
     low_speed: bool,
+    mult: u8,
 ) -> u32 {
     let mut value = u32::from(max_packet_size.max(1)) & 0x7ff;
     value |= (u32::from(endpoint) & 0x0f) << 11;
@@ -1359,157 +535,13 @@ fn hcchar(
         value |= 1 << 17;
     }
     value |= ep_type.bits() << 18;
+    // MULTICNT = mult − 1（ISO/INT 多事务计数）。
+    value |= (u32::from(mult.saturating_sub(1)) & 0x3) << 20;
     value |= (u32::from(device) & 0x7f) << 22;
     value
 }
 
-fn stage_actual_length(stage: Dwc2TransferStage, hctsiz_after: u32) -> usize {
-    if stage.len == 0 {
-        return 0;
-    }
-    if stage.hcchar & HCCHAR_EPDIR == 0 {
-        return stage.len;
-    }
-
-    let remaining = (hctsiz_after & HCTSIZ_XFERSIZE_MASK) as usize;
-    stage.len.saturating_sub(remaining)
-}
-
-pub(crate) fn build_control_plan(
-    request: &TransferRequest,
-    device: u8,
-    max_packet_size: u16,
-    setup_dma: u32,
-    data_dma: u32,
-) -> core::result::Result<Dwc2ControlPlan, TransferError> {
-    let TransferRequest::Control {
-        direction, buffer, ..
-    } = request
-    else {
-        return Err(TransferError::InvalidEndpoint);
-    };
-
-    let data_len = buffer.map(|buffer| buffer.len).unwrap_or(0);
-    let setup = Dwc2TransferStage {
-        hcchar: hcchar(
-            device,
-            0,
-            Direction::Out,
-            Dwc2EpType::Control,
-            max_packet_size,
-            false,
-        ),
-        hctsiz: hctsiz(Dwc2Pid::Setup, 1, 8),
-        dma_addr: setup_dma,
-        len: 8,
-    };
-
-    let mut data = Vec::new();
-    if data_len > 0 {
-        let mut offset = 0usize;
-        let mut toggle = DataToggle::data1();
-        for len in split_dma_lengths(data_len, max_packet_size) {
-            let packets = packet_count(len, max_packet_size);
-            data.push(Dwc2TransferStage {
-                hcchar: hcchar(
-                    device,
-                    0,
-                    *direction,
-                    Dwc2EpType::Control,
-                    max_packet_size,
-                    false,
-                ),
-                hctsiz: hctsiz(toggle.pid(), packets, len as u32),
-                dma_addr: data_dma.wrapping_add(offset as u32),
-                len,
-            });
-            toggle.advance(packets);
-            offset += len;
-        }
-    }
-
-    let status_direction = if data_len > 0 {
-        match direction {
-            Direction::In => Direction::Out,
-            Direction::Out => Direction::In,
-        }
-    } else {
-        Direction::In
-    };
-    let status = Dwc2TransferStage {
-        hcchar: hcchar(
-            device,
-            0,
-            status_direction,
-            Dwc2EpType::Control,
-            max_packet_size,
-            false,
-        ),
-        hctsiz: hctsiz(Dwc2Pid::Data1, 1, 0),
-        dma_addr: setup_dma,
-        len: 0,
-    };
-    Ok(Dwc2ControlPlan {
-        setup,
-        data,
-        status,
-    })
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct DataToggle(bool);
-
-impl DataToggle {
-    pub(crate) const fn data0() -> Self {
-        Self(false)
-    }
-
-    pub(crate) const fn data1() -> Self {
-        Self(true)
-    }
-
-    pub(crate) fn pid(self) -> Dwc2Pid {
-        if self.0 {
-            Dwc2Pid::Data1
-        } else {
-            Dwc2Pid::Data0
-        }
-    }
-
-    pub(crate) fn advance(&mut self, packet_count: u32) {
-        if packet_count % 2 == 1 {
-            self.0 = !self.0;
-        }
-    }
-}
-
-fn packet_count(len: usize, max_packet_size: u16) -> u32 {
-    if len == 0 {
-        return 1;
-    }
-    let max_packet_size = u32::from(max_packet_size.max(1));
-    (len as u32).div_ceil(max_packet_size)
-}
-
-fn split_dma_lengths(len: usize, max_packet_size: u16) -> Vec<usize> {
-    if len == 0 {
-        return vec![0];
-    }
-
-    let max_packet_size = usize::from(max_packet_size.max(1));
-    let max_by_packets = max_packet_size * HCTSIZ_MAX_PACKETS as usize;
-    let max_len = max_by_packets.min(HCTSIZ_XFERSIZE_MASK as usize).max(1);
-    let mut left = len;
-    let mut out = Vec::new();
-    while left > 0 {
-        let chunk = left.min(max_len);
-        out.push(chunk);
-        left -= chunk;
-    }
-    out
-}
-
-fn hcint_fault(bits: u32) -> Option<Dwc2TransferFault> {
+pub(crate) fn hcint_fault(bits: u32) -> Option<Dwc2TransferFault> {
     if bits & HCINT_STALL != 0 {
         Some(Dwc2TransferFault::Stall)
     } else if bits & HCINT_NAK != 0 {
@@ -1524,14 +556,14 @@ fn hcint_fault(bits: u32) -> Option<Dwc2TransferFault> {
         Some(Dwc2TransferFault::FrameOverrun)
     } else if bits & HCINT_DATATGLERR != 0 {
         Some(Dwc2TransferFault::DataToggle)
-    } else if bits & HCINT_XFERCOMPL == 0 {
-        Some(Dwc2TransferFault::HaltedWithoutComplete)
-    } else {
+    } else if bits & (HCINT_CHHLTD | HCINT_XFERCOMPL) != 0 {
         None
+    } else {
+        Some(Dwc2TransferFault::HaltedWithoutComplete)
     }
 }
 
-fn fault_to_transfer_error(fault: Dwc2TransferFault, hcint: u32) -> TransferError {
+pub(crate) fn fault_to_transfer_error(fault: Dwc2TransferFault, hcint: u32) -> TransferError {
     match fault {
         Dwc2TransferFault::Stall => TransferError::Stall,
         Dwc2TransferFault::Nak => TransferError::Other(anyhow!("DWC2 transfer NAK")),
@@ -1554,39 +586,22 @@ fn fault_to_transfer_error(fault: Dwc2TransferFault, hcint: u32) -> TransferErro
     }
 }
 
-fn endpoint_number(address: u8) -> u8 {
+pub(crate) fn endpoint_number(address: u8) -> u8 {
     address & 0x0f
 }
 
-fn endpoint_type_to_dwc2(ty: EndpointType) -> Result<Dwc2EpType> {
+pub(crate) fn endpoint_type_to_dwc2(ty: EndpointType) -> Result<Dwc2EpType> {
     match ty {
         EndpointType::Control => Ok(Dwc2EpType::Control),
+        EndpointType::Isochronous => Ok(Dwc2EpType::Isochronous),
         EndpointType::Bulk => Ok(Dwc2EpType::Bulk),
         EndpointType::Interrupt => Ok(Dwc2EpType::Interrupt),
-        EndpointType::Isochronous => Err(USBError::NotSupported),
     }
 }
 
-fn dma_addr32(addr: u64) -> core::result::Result<u32, TransferError> {
+pub(crate) fn dma_addr32(addr: u64) -> core::result::Result<u32, TransferError> {
     u32::try_from(addr)
         .map_err(|_| TransferError::Other(anyhow!("DWC2 DMA address above 32-bit mask: {addr:#x}")))
-}
-
-fn setup_packet_bytes(setup: &ControlSetup, direction: Direction, len: usize) -> [u8; 8] {
-    let request_type = BmRequestType::new(direction, setup.request_type, setup.recipient);
-    let value = setup.value.to_le_bytes();
-    let index = setup.index.to_le_bytes();
-    let len = (len as u16).to_le_bytes();
-    [
-        request_type.into(),
-        setup.request.into(),
-        value[0],
-        value[1],
-        index[0],
-        index[1],
-        len[0],
-        len[1],
-    ]
 }
 
 fn device_descriptor_base_from_bytes(data: [u8; 8]) -> DeviceDescriptorBase {
@@ -1598,135 +613,6 @@ fn device_descriptor_base_from_bytes(data: [u8; 8]) -> DeviceDescriptorBase {
         subclass: data[5],
         protocol: data[6],
         max_packet_size_0: data[7],
-    }
-}
-
-#[derive(Default)]
-struct Dwc2DmaBufferPool {
-    cached: Option<CoherentArray<u8>>,
-}
-
-impl Dwc2DmaBufferPool {
-    fn take(
-        &mut self,
-        kernel: &Kernel,
-        len: usize,
-        stats: &Dwc2Stats,
-    ) -> core::result::Result<Option<CoherentArray<u8>>, TransferError> {
-        if len == 0 {
-            return Ok(None);
-        }
-        if self
-            .cached
-            .as_ref()
-            .is_some_and(|buffer| buffer.len() >= len)
-        {
-            return Ok(self.cached.take());
-        }
-
-        let buffer = kernel
-            .coherent_array_zero_with_align::<u8>(len, DWC2_DMA_ALIGN)
-            .map_err(|err| {
-                TransferError::Other(anyhow!("DWC2 coherent DMA allocation failed: {err}"))
-            })?;
-        stats.record_dma_alloc();
-        Ok(Some(buffer))
-    }
-
-    fn reclaim(&mut self, buffer: Dwc2DmaBuffer) {
-        if let Some(coherent) = buffer.coherent {
-            self.cached = Some(coherent);
-        }
-    }
-}
-
-struct Dwc2DmaBuffer {
-    direction: Direction,
-    request_buffer: Option<(NonNull<u8>, usize)>,
-    coherent: Option<CoherentArray<u8>>,
-    len: usize,
-}
-
-impl Dwc2DmaBuffer {
-    fn new(
-        kernel: &Kernel,
-        pool: &mut Dwc2DmaBufferPool,
-        stats: &Dwc2Stats,
-        request: &TransferRequest,
-    ) -> core::result::Result<Self, TransferError> {
-        let direction = request.direction();
-        let request_buffer = request
-            .buffer()
-            .filter(|buffer| buffer.len > 0)
-            .map(|buffer| (buffer.ptr, buffer.len));
-        let len = request_buffer.map_or(0, |(_, len)| len);
-        let coherent = if let Some((ptr, len)) = request_buffer {
-            let mut coherent = pool.take(kernel, len, stats)?.ok_or_else(|| {
-                TransferError::Other(anyhow!("DWC2 DMA buffer pool returned no buffer"))
-            })?;
-            if matches!(direction, Direction::Out) {
-                // SAFETY: `TransferRequest::buffer` is the usb-host transfer
-                // contract for a live CPU buffer of `len` bytes until the
-                // request completes. We only create a temporary shared slice to
-                // copy OUT payload bytes into the owned coherent bounce buffer.
-                let data = unsafe { core::slice::from_raw_parts(ptr.as_ptr().cast_const(), len) };
-                coherent.write_with_cpu(len, |dst| dst.copy_from_slice(data));
-                stats.record_bounce_to_device(len);
-            } else {
-                coherent.write_with_cpu(len, |dst| dst.fill(0));
-                stats.record_bounce_from_device(len);
-            }
-            Some(coherent)
-        } else {
-            None
-        };
-
-        Ok(Self {
-            direction,
-            request_buffer,
-            coherent,
-            len,
-        })
-    }
-
-    fn buffer_len(&self) -> usize {
-        self.len
-    }
-
-    fn dma_addr(&self) -> u64 {
-        self.coherent
-            .as_ref()
-            .map_or(0, |buffer| buffer.dma_addr().as_u64())
-    }
-
-    fn copy_in_to_request(&self, actual: usize) -> core::result::Result<(), TransferError> {
-        if !matches!(self.direction, Direction::In) || actual == 0 {
-            return Ok(());
-        }
-        let Some((ptr, len)) = self.request_buffer else {
-            return Err(TransferError::Other(anyhow!(
-                "DWC2 IN transfer completed without a request buffer"
-            )));
-        };
-        let Some(coherent) = self.coherent.as_ref() else {
-            return Err(TransferError::Other(anyhow!(
-                "DWC2 IN transfer completed without a DMA buffer"
-            )));
-        };
-        if actual > len || actual > coherent.len() {
-            return Err(TransferError::Other(anyhow!(
-                "DWC2 IN transfer actual length {actual} exceeds buffer len {len}"
-            )));
-        }
-
-        // SAFETY: The request buffer pointer comes from `TransferRequest` and
-        // remains owned by that request until this completion path finishes.
-        // `actual` has been checked against both the request length and the
-        // coherent bounce buffer length, so the mutable slice is in-bounds and
-        // used only for the final IN payload copy.
-        let dst = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), actual) };
-        coherent.read_with_cpu(actual, |src| dst.copy_from_slice(src));
-        Ok(())
     }
 }
 
@@ -1760,10 +646,6 @@ enum Dwc2QuiesceReason {
     Disconnect,
 }
 
-// SAFETY: `Dwc2Device` is owned as a boxed `DeviceOp` and every mutating device
-// operation requires `&mut self`. EndpointHandle objects created from it get their own
-// owned DMA pools and share only atomic completions, per-channel gates, and the
-// volatile register handle.
 unsafe impl Send for Dwc2Device {}
 
 impl Dwc2Device {
@@ -1974,12 +856,8 @@ impl Dwc2Device {
         reason: Dwc2QuiesceReason,
     ) -> Result<()> {
         for endpoint in endpoints {
-            let request_id = endpoint.with_raw_mut::<Dwc2Endpoint, _>(|raw| {
-                raw.active
-                    .as_ref()
-                    .map(|active| active.id)
-                    .or_else(|| raw.completed.as_ref().map(|(id, _)| *id))
-            });
+            let request_id =
+                endpoint.with_raw_mut::<Dwc2Endpoint, _>(|raw| raw.in_flight_request_id());
             let Some(request_id) = request_id else {
                 continue;
             };
@@ -2018,13 +896,6 @@ impl Dwc2Device {
             .to_vec();
         let mut prepared = BTreeMap::new();
         for desc in endpoints {
-            if matches!(desc.transfer_type, EndpointType::Isochronous) {
-                warn!(
-                    "dwc2: isochronous endpoint {:#x} is not supported in v1",
-                    desc.address
-                );
-                continue;
-            }
             let info = EndpointInfo::from(&desc);
             let raw = Dwc2Endpoint::new(Dwc2EndpointParams {
                 regs: self.regs,
@@ -2113,1331 +984,56 @@ impl DeviceOp for Dwc2Device {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-enum Dwc2StageRole {
-    ControlSetup,
-    ControlData,
-    ControlStatus,
-    Data {
-        direction: Direction,
-        max_packet_size: u16,
-    },
-}
-
-#[derive(Clone, Copy, Debug)]
-struct Dwc2QueuedStage {
-    stage: Dwc2TransferStage,
-    role: Dwc2StageRole,
-    nak_retries: u32,
-}
-
-#[derive(Clone, Copy)]
-struct Dwc2InFlightStage {
-    queued: Dwc2QueuedStage,
-    nak_left: u32,
-    xact_left: u32,
-}
-
-struct Dwc2ActiveRequest {
-    id: RequestId,
-    channel: HostChannelLease,
-    transfer: Dwc2DmaBuffer,
-    _setup_dma: Option<CoherentArray<u8>>,
-    stages: Vec<Dwc2QueuedStage>,
-    next_stage: usize,
-    in_flight: Option<Dwc2InFlightStage>,
-    actual_length: usize,
-    cancelled: bool,
-}
-
-struct Dwc2PreparedStages {
-    stages: Vec<Dwc2QueuedStage>,
-    setup_dma: Option<CoherentArray<u8>>,
-}
-
-struct Dwc2Endpoint {
-    regs: Dwc2Registers,
-    kernel: Kernel,
-    device_address: u8,
-    port_speed: Speed,
-    info: EndpointInfo,
-    channel_pool: HostChannelPool,
-    stats: Dwc2Stats,
-    dma_pool: Dwc2DmaBufferPool,
-    data_toggle: DataToggle,
-    next_request_id: u64,
-    active: Option<Dwc2ActiveRequest>,
-    completed: Option<(
-        RequestId,
-        core::result::Result<TransferCompletion, TransferError>,
-    )>,
-}
-
-impl Drop for Dwc2Endpoint {
-    fn drop(&mut self) {
-        if let Some(active) = self.active.take()
-            && active.channel.hardware_active.load(Ordering::Acquire)
-        {
-            error!(
-                "dwc2: leaking request {:?} DMA because channel {} still references it",
-                active.id, active.channel.channel
-            );
-            core::mem::forget(active);
-        }
-    }
-}
-
-// SAFETY: `EndpointOp` methods that mutate transfer state require `&mut self`.
-// The endpoint owns its active DMA buffer and reusable bounce buffer pool; the
-// IRQ path never accesses those buffers directly and only publishes HCINT bits
-// through atomic completion slots. Register programming for the endpoint channel
-// is serialized by `channel_gate`.
-unsafe impl Send for Dwc2Endpoint {}
-
-struct Dwc2EndpointParams {
-    regs: Dwc2Registers,
-    kernel: Kernel,
-    device_address: u8,
-    port_speed: Speed,
-    info: EndpointInfo,
-    channel_pool: HostChannelPool,
-    stats: Dwc2Stats,
-}
-
-impl Dwc2Endpoint {
-    fn new(params: Dwc2EndpointParams) -> Result<Self> {
-        let Dwc2EndpointParams {
-            regs,
-            kernel,
-            device_address,
-            port_speed,
-            info,
-            channel_pool,
-            stats,
-        } = params;
-        endpoint_type_to_dwc2(info.transfer_type)?;
-        Ok(Self {
-            regs,
-            kernel,
-            device_address,
-            port_speed,
-            info,
-            channel_pool,
-            stats,
-            dma_pool: Dwc2DmaBufferPool::default(),
-            data_toggle: DataToggle::data0(),
-            next_request_id: 1,
-            active: None,
-            completed: None,
-        })
-    }
-
-    fn set_device_address(&mut self, address: u8) {
-        self.device_address = address;
-    }
-
-    fn set_max_packet_size(&mut self, max_packet_size: u8) {
-        self.info.max_packet_size = u16::from(max_packet_size).max(8);
-    }
-
-    fn allocate_request_id(&mut self) -> RequestId {
-        let id = self.next_request_id;
-        self.next_request_id = self.next_request_id.wrapping_add(1).max(1);
-        RequestId::new(id)
-    }
-
-    fn prepare_request(
-        &mut self,
-        id: RequestId,
-        channel: HostChannelLease,
-        request: TransferRequest,
-    ) -> core::result::Result<Dwc2ActiveRequest, TransferError> {
-        if matches!(request, TransferRequest::Isochronous { .. }) {
-            return Err(TransferError::NotSupported);
-        }
-
-        self.stats.record_transfer();
-        let transfer = Dwc2DmaBuffer::new(&self.kernel, &mut self.dma_pool, &self.stats, &request)?;
-        let prepared = match &request {
-            TransferRequest::Control { .. } => self.control_stages(&request, &transfer)?,
-            TransferRequest::Bulk { .. } | TransferRequest::Interrupt { .. } => {
-                Dwc2PreparedStages {
-                    stages: self.data_stages(&request, &transfer)?,
-                    setup_dma: None,
-                }
-            }
-            TransferRequest::Isochronous { .. } => return Err(TransferError::NotSupported),
-        };
-
-        Ok(Dwc2ActiveRequest {
-            id,
-            channel,
-            transfer,
-            _setup_dma: prepared.setup_dma,
-            stages: prepared.stages,
-            next_stage: 0,
-            in_flight: None,
-            actual_length: 0,
-            cancelled: false,
-        })
-    }
-
-    fn control_stages(
-        &self,
-        request: &TransferRequest,
-        transfer: &Dwc2DmaBuffer,
-    ) -> core::result::Result<Dwc2PreparedStages, TransferError> {
-        let TransferRequest::Control {
-            setup, direction, ..
-        } = request
-        else {
-            return Err(TransferError::InvalidEndpoint);
-        };
-
-        let mut setup_dma = self
-            .kernel
-            .coherent_array_zero_with_align::<u8>(8, DWC2_DMA_ALIGN)
-            .map_err(|err| {
-                TransferError::Other(anyhow!("DWC2 setup DMA allocation failed: {err}"))
-            })?;
-        self.stats.record_dma_alloc();
-        let setup_bytes = setup_packet_bytes(setup, *direction, transfer.buffer_len());
-        setup_dma.write_with_cpu(8, |dst| dst.copy_from_slice(&setup_bytes));
-        let setup_addr = dma_addr32(setup_dma.dma_addr().as_u64())?;
-        let data_addr = dma_addr32(transfer.dma_addr())?;
-        let plan = build_control_plan(
-            request,
-            self.device_address,
-            self.info.max_packet_size.max(8),
-            setup_addr,
-            data_addr,
-        )?;
-
-        let mut stages = Vec::with_capacity(plan.data.len() + 2);
-        stages.push(Dwc2QueuedStage {
-            stage: plan.setup,
-            role: Dwc2StageRole::ControlSetup,
-            nak_retries: DWC2_NAK_RETRIES,
-        });
-        for stage in plan.data {
-            stages.push(Dwc2QueuedStage {
-                stage,
-                role: Dwc2StageRole::ControlData,
-                nak_retries: DWC2_NAK_RETRIES,
-            });
-        }
-        stages.push(Dwc2QueuedStage {
-            stage: plan.status,
-            role: Dwc2StageRole::ControlStatus,
-            nak_retries: DWC2_NAK_RETRIES,
-        });
-        Ok(Dwc2PreparedStages {
-            stages,
-            setup_dma: Some(setup_dma),
-        })
-    }
-
-    fn data_stages(
-        &self,
-        request: &TransferRequest,
-        transfer: &Dwc2DmaBuffer,
-    ) -> core::result::Result<Vec<Dwc2QueuedStage>, TransferError> {
-        let (direction, ep_type) = match request {
-            TransferRequest::Bulk { direction, .. } => (*direction, Dwc2EpType::Bulk),
-            TransferRequest::Interrupt { direction, .. } => (*direction, Dwc2EpType::Interrupt),
-            _ => return Err(TransferError::InvalidEndpoint),
-        };
-
-        let mps = self.info.max_packet_size.max(1);
-        let endpoint = endpoint_number(self.info.address.raw());
-        let retry_policy = data_stage_retry_policy(ep_type);
-        let mut stages = Vec::new();
-        let mut toggle = self.data_toggle;
-        let mut offset = 0u64;
-        for len in split_dma_lengths(transfer.buffer_len(), mps) {
-            let packets = packet_count(len, mps);
-            let mut stage = Dwc2TransferStage {
-                hcchar: hcchar(
-                    self.device_address,
-                    endpoint,
-                    direction,
-                    ep_type,
-                    mps,
-                    matches!(self.port_speed, Speed::Low),
-                ),
-                hctsiz: hctsiz(toggle.pid(), packets, len as u32),
-                dma_addr: dma_addr32(transfer.dma_addr() + offset)?,
-                len,
-            };
-            if matches!(ep_type, Dwc2EpType::Interrupt) {
-                stage.hcchar |= self.regs.periodic_odd_frame_bit();
-            }
-            stages.push(Dwc2QueuedStage {
-                stage,
-                role: Dwc2StageRole::Data {
-                    direction,
-                    max_packet_size: mps,
-                },
-                nak_retries: retry_policy.nak_retries,
-            });
-            toggle.advance(packets);
-            offset += len as u64;
-        }
-        Ok(stages)
-    }
-
-    fn start_active_request(
-        &mut self,
-        mut active: Dwc2ActiveRequest,
-    ) -> core::result::Result<Dwc2ActiveRequest, TransferError> {
-        self.start_next_stage(&mut active)?;
-        Ok(active)
-    }
-
-    fn start_next_stage(
-        &self,
-        active: &mut Dwc2ActiveRequest,
-    ) -> core::result::Result<bool, TransferError> {
-        let Some(queued) = active.stages.get(active.next_stage).copied() else {
-            return Ok(false);
-        };
-        active.next_stage += 1;
-        self.start_stage(&active.channel, queued.stage)?;
-        active.in_flight = Some(Dwc2InFlightStage {
-            queued,
-            nak_left: queued.nak_retries,
-            xact_left: DWC2_XACT_RETRIES,
-        });
-        Ok(true)
-    }
-
-    fn restart_stage(
-        &self,
-        active: &mut Dwc2ActiveRequest,
-        in_flight: Dwc2InFlightStage,
-    ) -> core::result::Result<(), TransferError> {
-        self.start_stage(&active.channel, in_flight.queued.stage)?;
-        active.in_flight = Some(in_flight);
-        Ok(())
-    }
-
-    fn start_stage(
-        &self,
-        channel: &HostChannelLease,
-        stage: Dwc2TransferStage,
-    ) -> core::result::Result<(), TransferError> {
-        channel.completions.with_connected(|| {
-            if self.regs.channel_read32(channel.channel, HCCHAR) & HCCHAR_CHENA != 0 {
-                return Err(TransferError::QueueFull);
-            }
-
-            self.stats.record_stage();
-            channel.completions.clear(channel.channel);
-            // SAFETY: the lifecycle IRQ-save gate prevents local DWC2 event
-            // re-entry, while the channel lease excludes task-side mutation.
-            let _guard = unsafe { channel.gate.lock_raw() };
-            self.regs.channel_write32(channel.channel, HCSPLT, 0);
-            self.regs
-                .channel_write32(channel.channel, HCINT, HCINT_ALL_W1C);
-            self.regs
-                .channel_write32(channel.channel, HCINTMSK, HCINT_DMA_IRQ_MASK);
-            self.regs
-                .channel_write32(channel.channel, HCTSIZ, stage.hctsiz);
-            mb();
-            self.regs
-                .channel_write32(channel.channel, HCDMA, stage.dma_addr);
-            mb();
-            self.regs
-                .channel_write32(channel.channel, HCCHAR, stage.hcchar | HCCHAR_CHENA);
-            channel.hardware_active.store(true, Ordering::Release);
-            Ok(())
-        })
-    }
-
-    fn poll_active_request(
-        &mut self,
-        mut active: Dwc2ActiveRequest,
-    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
-        let Some(hcint) = active.channel.completions.take(active.channel.channel) else {
-            self.active = Some(active);
-            return None;
-        };
-        active
-            .channel
-            .hardware_active
-            .store(false, Ordering::Release);
-        if hcint & DWC2_COMPLETION_DISCONNECTED != 0 {
-            return Some(self.complete_active_request(active, Err(TransferError::Disconnected)));
-        }
-        if active.cancelled {
-            return Some(self.complete_active_request(active, Err(TransferError::Cancelled)));
-        }
-        let Some(mut in_flight) = active.in_flight.take() else {
-            return Some(self.complete_active_request(
-                active,
-                Err(TransferError::Other(anyhow!(
-                    "DWC2 completion arrived without an in-flight stage"
-                ))),
-            ));
-        };
-
-        if let Some(fault) = hcint_fault(hcint) {
-            self.stats.record_fault(fault);
-            match fault {
-                Dwc2TransferFault::Nak if in_flight.nak_left > 0 => {
-                    in_flight.nak_left -= 1;
-                    if let Err(err) = self.restart_stage(&mut active, in_flight) {
-                        return Some(self.complete_active_request(active, Err(err)));
-                    }
-                    self.active = Some(active);
-                    return None;
-                }
-                Dwc2TransferFault::Xact if in_flight.xact_left > 0 => {
-                    in_flight.xact_left -= 1;
-                    if let Err(err) = self.restart_stage(&mut active, in_flight) {
-                        return Some(self.complete_active_request(active, Err(err)));
-                    }
-                    self.active = Some(active);
-                    return None;
-                }
-                _ => {
-                    warn!(
-                        "dwc2: transfer fault channel={} role={:?} hcint={:#x} nak_left={} \
-                         xact_left={}",
-                        active.channel.channel,
-                        in_flight.queued.role,
-                        hcint,
-                        in_flight.nak_left,
-                        in_flight.xact_left
-                    );
-                    return Some(self.complete_active_request(
-                        active,
-                        Err(fault_to_transfer_error(fault, hcint)),
-                    ));
-                }
-            }
-        }
-
-        let hctsiz_after = self.regs.channel_read32(active.channel.channel, HCTSIZ);
-        let actual = stage_actual_length(in_flight.queued.stage, hctsiz_after);
-        match in_flight.queued.role {
-            Dwc2StageRole::ControlSetup | Dwc2StageRole::ControlStatus => {}
-            Dwc2StageRole::ControlData => {
-                active.actual_length = active.actual_length.saturating_add(actual);
-            }
-            Dwc2StageRole::Data {
-                direction,
-                max_packet_size,
-            } => {
-                active.actual_length = active.actual_length.saturating_add(actual);
-                self.data_toggle.advance(successful_packet_count(
-                    actual,
-                    in_flight.queued.stage.len,
-                    max_packet_size,
-                ));
-                if matches!(direction, Direction::In) && actual < in_flight.queued.stage.len {
-                    return Some(self.complete_active_request(active, Ok(())));
-                }
-            }
-        }
-
-        match self.start_next_stage(&mut active) {
-            Ok(true) => {
-                self.active = Some(active);
-                None
-            }
-            Ok(false) => Some(self.complete_active_request(active, Ok(()))),
-            Err(err) => Some(self.complete_active_request(active, Err(err))),
-        }
-    }
-
-    fn complete_active_request(
-        &mut self,
-        active: Dwc2ActiveRequest,
-        result: core::result::Result<(), TransferError>,
-    ) -> core::result::Result<TransferCompletion, TransferError> {
-        let id = active.id;
-        let completion = result.and_then(|()| {
-            active.transfer.copy_in_to_request(active.actual_length)?;
-            Ok(TransferCompletion {
-                request_id: id,
-                status: TransferStatus::Completed,
-                actual_length: active.actual_length,
-                iso_packets: Vec::new(),
-            })
-        });
-        self.dma_pool.reclaim(active.transfer);
-        active.channel.release();
-        completion
-    }
-}
-
-impl crate::backend::ty::ep::EndpointOp for Dwc2Endpoint {
-    fn submit_request(
-        &mut self,
-        request: TransferRequest,
-    ) -> core::result::Result<RequestId, TransferError> {
-        if self.active.is_some() || self.completed.is_some() {
-            return Err(TransferError::QueueFull);
-        }
-        let id = self.allocate_request_id();
-        let channel = self
-            .channel_pool
-            .acquire(matches!(self.info.transfer_type, EndpointType::Control))?;
-        let active = self.prepare_request(id, channel, request)?;
-        let active = self.start_active_request(active)?;
-        self.active = Some(active);
-        Ok(id)
-    }
-
-    fn reclaim_request(
-        &mut self,
-        id: RequestId,
-    ) -> Option<core::result::Result<TransferCompletion, TransferError>> {
-        if let Some((completed_id, _)) = self.completed.as_ref() {
-            if *completed_id != id {
-                return Some(Err(TransferError::InvalidEndpoint));
-            }
-            return self.completed.take().map(|(_, result)| result);
-        }
-
-        let active = self.active.take()?;
-        if active.id != id {
-            self.active = Some(active);
-            return Some(Err(TransferError::InvalidEndpoint));
-        }
-        self.poll_active_request(active)
-    }
-
-    fn register_waker(&self, id: RequestId, cx: &mut Context<'_>) {
-        if let Some(active) = self.active.as_ref().filter(|active| active.id == id) {
-            active
-                .channel
-                .completions
-                .register_waker(active.channel.channel, cx);
-        }
-    }
-
-    fn cancel_request(&mut self, id: RequestId) -> core::result::Result<(), TransferError> {
-        if self
-            .completed
-            .as_ref()
-            .is_some_and(|(done_id, _)| *done_id == id)
-        {
-            self.completed = Some((id, Err(TransferError::Cancelled)));
-            return Ok(());
-        }
-        let Some(active) = self.active.as_mut() else {
-            return Err(TransferError::InvalidEndpoint);
-        };
-        if active.id != id {
-            return Err(TransferError::InvalidEndpoint);
-        }
-        active.cancelled = true;
-        let channel = active.channel.channel;
-        let result = active.channel.completions.with_connected(|| {
-            let value = self.regs.channel_read32(channel, HCCHAR);
-            if value & HCCHAR_CHENA != 0 {
-                // SAFETY: The lifecycle IRQ-save gate prevents local DWC2
-                // event re-entry, while the channel lease excludes task-side
-                // register mutation.
-                let _guard = unsafe { active.channel.gate.lock_raw() };
-                self.regs
-                    .channel_write32(channel, HCCHAR, value | HCCHAR_CHENA | HCCHAR_CHDIS);
-            }
-            Ok(())
-        });
-        if matches!(result, Err(TransferError::Disconnected)) {
-            return Ok(());
-        }
-        result
-    }
-
-    fn reset(&mut self) -> crate::backend::ty::ep::EndpointResetFuture {
-        let result = if self.active.is_some() || self.completed.is_some() {
-            Err(TransferError::QueueFull)
-        } else {
-            self.data_toggle = DataToggle::data0();
-            Ok(())
-        };
-        Box::pin(async move { result })
-    }
-}
-
-fn successful_packet_count(actual: usize, requested: usize, max_packet_size: u16) -> u32 {
-    if requested == 0 || actual == 0 {
-        1
-    } else {
-        packet_count(actual, max_packet_size)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use alloc::{
-        alloc::{alloc_zeroed, dealloc},
-        vec,
-        vec::Vec,
-    };
-    use core::{
-        alloc::Layout,
-        num::NonZeroUsize,
-        ptr::NonNull,
-        sync::atomic::{AtomicU64, Ordering as AtomicOrdering},
-    };
+    extern crate std;
 
-    use dma_api::{DmaAllocHandle, DmaConstraints, DmaDirection, DmaError, DmaMapHandle, DmaOp};
-    use usb_if::{
-        descriptor::EndpointType,
-        endpoint::{EndpointAddress, EndpointInfo, TransferRequest},
-        err::TransferError,
-        host::{ControlSetup, hub::Speed},
-        transfer::{Direction, Recipient, Request, RequestType},
-    };
-
-    use super::{
-        DataStageRetryPolicy, DataToggle, Dwc2ChannelCompletions, Dwc2DmaBuffer, Dwc2DmaBufferPool,
-        Dwc2Endpoint, Dwc2EndpointParams, Dwc2EpType, Dwc2EventHandler, Dwc2FifoSizes,
-        Dwc2HostParams, Dwc2NewParams, Dwc2Pid, Dwc2PortStatus, Dwc2Stats, Dwc2TransferFault,
-        Dwc2TransferStage, GINTMSK, GINTSTS, GINTSTS_DISCONNINT, GINTSTS_HCHINT, GINTSTS_PRTINT,
-        HAINT, HAINTMSK, HCCHAR, HCCHAR_CHDIS, HCCHAR_CHENA, HCINT, HCINT_AHBERR, HCINT_BBLERR,
-        HCINT_CHHLTD, HCINT_DMA_IRQ_MASK, HCINT_NAK, HCINT_STALL, HCINT_XACTERR, HCINT_XFERCOMPL,
-        HCINTMSK, HPRT_CONN_DET, HPRT_CONN_STS, HPRT_ENA, HPRT_ENA_CHG, HPRT_OVRCUR_CHG, HPRT_PWR,
-        HPRT_W1C_MASK, HPRT0, HostChannelPool, build_channel_gates, build_control_plan,
-        build_gahbcfg_internal_dma, data_stage_retry_policy, fifo_register_plan, hcchar,
-        hcint_fault, hctsiz, packet_count, split_dma_lengths, stage_actual_length,
-        successful_packet_count,
-    };
-    use crate::backend::{
-        kmod::osal::Kernel,
-        ty::{Event, EventHandlerOp, ep::EndpointOp},
-    };
-
-    struct TestKernel;
-
-    static TEST_DMA_ADDR: AtomicU64 = AtomicU64::new(0x1000);
-
-    impl DmaOp for TestKernel {
-        fn page_size(&self) -> usize {
-            4096
-        }
-
-        unsafe fn alloc_contiguous(
-            &self,
-            constraints: DmaConstraints,
-            layout: Layout,
-        ) -> Option<DmaAllocHandle> {
-            // SAFETY: The test kernel models contiguous DMA with the same
-            // heap-backed allocation used for coherent DMA below.
-            unsafe { self.alloc_coherent(constraints, layout) }
-        }
-
-        unsafe fn dealloc_contiguous(&self, handle: DmaAllocHandle) {
-            // SAFETY: Handles returned by `alloc_contiguous` are created by
-            // `alloc_coherent`, so they must be released through the same mock
-            // deallocation path.
-            unsafe { self.dealloc_coherent(handle) }
-                .expect("test coherent DMA release must succeed")
-        }
-
-        unsafe fn alloc_coherent(
-            &self,
-            constraints: DmaConstraints,
-            layout: Layout,
-        ) -> Option<DmaAllocHandle> {
-            // SAFETY: Unit tests request valid `Layout` values. The returned
-            // pointer is either null or points to a heap allocation owned by the
-            // DMA handle until `dealloc_coherent` consumes it.
-            let ptr = unsafe { alloc_zeroed(layout) };
-            let ptr = NonNull::new(ptr)?;
-            let align = constraints.align.max(layout.align()).max(1) as u64;
-            let size = layout.size().max(1) as u64;
-            let current = TEST_DMA_ADDR.fetch_add(size + align, AtomicOrdering::Relaxed);
-            let dma_addr = (current + align - 1) & !(align - 1);
-            // SAFETY: `ptr` and `layout` describe the allocation above, and
-            // `dma_addr` is a deterministic fake bus address used only by unit
-            // tests that never reaches real hardware.
-            Some(unsafe { DmaAllocHandle::new(ptr, dma_addr.into(), layout) })
-        }
-
-        unsafe fn dealloc_coherent(&self, handle: DmaAllocHandle) -> Result<(), DmaError> {
-            // SAFETY: The mock only creates coherent handles from
-            // `alloc_zeroed` with the stored layout, so deallocating with the
-            // same layout releases exactly that allocation.
-            unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) };
-            Ok(())
-        }
-
-        unsafe fn map_streaming(
-            &self,
-            _constraints: DmaConstraints,
-            addr: NonNull<u8>,
-            size: NonZeroUsize,
-            _direction: DmaDirection,
-        ) -> core::result::Result<DmaMapHandle, DmaError> {
-            let layout = Layout::from_size_align(size.get(), 1)?;
-            // SAFETY: This mock streaming map does not transfer ownership of
-            // `addr`; it records the caller-provided live buffer and a fake bus
-            // address for tests that only inspect programming values.
-            Ok(unsafe { DmaMapHandle::new(addr, (addr.as_ptr() as u64).into(), layout, None) })
-        }
-
-        unsafe fn unmap_streaming(&self, _handle: DmaMapHandle) {}
-    }
-
-    impl super::KernelOp for TestKernel {
-        fn delay(&self, _duration: core::time::Duration) {}
-    }
-
-    static TEST_KERNEL: TestKernel = TestKernel;
-
-    const GAHBCFG_GLBL_INTR_EN: u32 = 1 << 0;
-    const GAHBCFG_HBSTLEN_INCR16: u32 = 7 << 1;
-    const GAHBCFG_DMA_EN: u32 = 1 << 5;
-
-    fn test_regs() -> (Vec<u32>, super::Dwc2Registers) {
-        let mut regs = vec![0u32; 1024];
-        let base = NonNull::new(regs.as_mut_ptr().cast::<u8>()).unwrap();
-        (regs, super::Dwc2Registers { base })
-    }
+    use super::*;
 
     #[test]
-    fn gahbcfg_requires_internal_dma_and_enables_incr16() {
-        let value = build_gahbcfg_internal_dma(2).expect("internal DMA architecture is supported");
-
+    fn hctsiz_ddma_encodes_pid_ntd_schinfo() {
+        assert_eq!(hctsiz_ddma(Dwc2Pid::Data0, 1, 0), 0);
+        assert_eq!(hctsiz_ddma(Dwc2Pid::Setup, 1, 0), 3 << 29);
         assert_eq!(
-            value & (GAHBCFG_GLBL_INTR_EN | GAHBCFG_HBSTLEN_INCR16 | GAHBCFG_DMA_EN),
-            GAHBCFG_GLBL_INTR_EN | GAHBCFG_HBSTLEN_INCR16 | GAHBCFG_DMA_EN
+            hctsiz_ddma(Dwc2Pid::Data1, 2, 0x55),
+            (2 << 29) | (1 << 8) | 0x55
         );
-        assert!(build_gahbcfg_internal_dma(1).is_err());
-    }
-
-    #[test]
-    fn fifo_register_plan_matches_sg2002_dtb_defaults() {
-        let plan = fifo_register_plan(Dwc2FifoSizes::sg2002_default());
-
-        assert_eq!(plan.grxfsiz, 536);
-        assert_eq!(plan.gnptxfsiz, (32 << 16) | 536);
-        assert_eq!(plan.hptxfsiz, (768 << 16) | (536 + 32));
-    }
-
-    #[test]
-    fn controller_register_wait_budget_matches_linux_dwc2() {
-        assert_eq!(super::DWC2_WAIT_ITERS, 10_000);
-    }
-
-    #[test]
-    fn sg2002_uses_the_hardware_reset_done_signal() {
+        // NTD 8 位截断。
+        assert_eq!(hctsiz_ddma(Dwc2Pid::Data0, 256, 0), 255 << 8);
+        // ISO MC 编码：DATA2=1、MDATA=3。
         assert_eq!(
-            Dwc2HostParams::sg2002().soft_reset_completion,
-            super::Dwc2SoftResetCompletion::DoneBitSet
+            hctsiz_ddma(Dwc2Pid::Data2, 256, 0xff),
+            (1 << 29) | (255 << 8) | 0xff
         );
-    }
-
-    #[test]
-    fn runtime_irq_mask_enables_channel_port_and_disconnect_events() {
-        let (_backing, regs) = test_regs();
-        let mut host = super::Dwc2::new(Dwc2NewParams {
-            mmio: regs.base,
-            kernel: &TEST_KERNEL,
-            params: Dwc2HostParams::sg2002(),
-        })
-        .unwrap();
-
-        crate::backend::kmod::kcore::CoreOp::enable_irq(&mut host).unwrap();
-
-        assert_eq!(regs.read32(GINTMSK), super::DWC2_RUNTIME_GINTMSK);
-    }
-
-    #[test]
-    fn controller_init_prepares_channels_without_unmasking_irqs() {
-        let (_backing, regs) = test_regs();
-        let host = super::Dwc2::new(Dwc2NewParams {
-            mmio: regs.base,
-            kernel: &TEST_KERNEL,
-            params: Dwc2HostParams::sg2002(),
-        })
-        .unwrap();
-
-        host.prepare_runtime_irqs(8);
-
-        assert_eq!(regs.read32(HAINTMSK), 0xff);
-        assert_eq!(regs.read32(GINTMSK), 0);
-    }
-
-    #[test]
-    fn device_descriptor_base_is_parsed_without_unaligned_struct_access() {
-        let desc =
-            super::device_descriptor_base_from_bytes([18, 1, 0x00, 0x02, 0x08, 0x06, 0x50, 64]);
-
-        assert_eq!(desc.length, 18);
-        assert_eq!(desc.descriptor_type, 1);
-        assert_eq!(desc.usb_version, 0x0200);
-        assert_eq!(desc.class, 0x08);
-        assert_eq!(desc.subclass, 0x06);
-        assert_eq!(desc.protocol, 0x50);
-        assert_eq!(desc.max_packet_size_0, 64);
-    }
-
-    #[test]
-    fn hctsiz_encodes_pid_packet_count_and_transfer_size() {
-        assert_eq!(hctsiz(Dwc2Pid::Setup, 1, 8), (3 << 29) | (1 << 19) | 8);
-        assert_eq!(
-            hctsiz(Dwc2Pid::Data1, 2, 1024),
-            (2 << 29) | (2 << 19) | 1024
-        );
-    }
-
-    #[test]
-    fn hcchar_encodes_control_bulk_and_interrupt_dma_channels() {
-        let control = hcchar(0, 0, Direction::Out, Dwc2EpType::Control, 64, false);
-        assert_eq!(control & 0x7ff, 64);
-        assert_eq!((control >> 18) & 0b11, 0);
-        assert_eq!((control >> 22) & 0x7f, 0);
-
-        let bulk_in = hcchar(5, 2, Direction::In, Dwc2EpType::Bulk, 512, false);
-        assert_eq!(bulk_in & 0x7ff, 512);
-        assert_eq!((bulk_in >> 11) & 0x0f, 2);
-        assert_eq!((bulk_in >> 15) & 1, 1);
-        assert_eq!((bulk_in >> 18) & 0b11, 2);
-        assert_eq!((bulk_in >> 22) & 0x7f, 5);
-
-        let interrupt_low = hcchar(3, 1, Direction::In, Dwc2EpType::Interrupt, 8, true);
-        assert_eq!((interrupt_low >> 17) & 1, 1);
-        assert_eq!((interrupt_low >> 18) & 0b11, 3);
-    }
-
-    #[test]
-    fn control_in_plan_uses_dma_for_setup_data_and_status() {
-        let mut data = [0u8; 18];
-        let request = TransferRequest::control_in(
-            ControlSetup {
-                request_type: RequestType::Standard,
-                recipient: Recipient::Device,
-                request: Request::GetDescriptor,
-                value: 0x0100,
-                index: 0,
-            },
-            &mut data,
-        );
-
-        let plan = build_control_plan(&request, 0, 64, 0x1000, 0x2000).unwrap();
-
-        assert_eq!(plan.setup.dma_addr, 0x1000);
-        assert_eq!(plan.setup.len, 8);
-        assert_eq!(plan.setup.hctsiz, hctsiz(Dwc2Pid::Setup, 1, 8));
-        let data = plan.data.first().expect("control IN has a data stage");
-        assert_eq!(data.dma_addr, 0x2000);
-        assert_eq!(data.hctsiz, hctsiz(Dwc2Pid::Data1, 1, 18));
-        assert_eq!((data.hcchar >> 15) & 1, 1);
-        assert_eq!(plan.status.dma_addr, 0x1000);
-        assert_eq!(plan.status.hctsiz, hctsiz(Dwc2Pid::Data1, 1, 0));
-        assert_eq!((plan.status.hcchar >> 15) & 1, 0);
-    }
-
-    #[test]
-    fn dma_buffer_bounces_in_data_through_coherent_dma_memory() {
-        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
-        let mut pool = Dwc2DmaBufferPool::default();
-        let stats = Dwc2Stats::new();
-        let mut data = [0u8; 4];
-        let request = TransferRequest::bulk_in(&mut data);
-        let mut dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, &request).unwrap();
-
-        assert_eq!(dma.buffer_len(), 4);
-        assert_ne!(dma.dma_addr(), data.as_ptr() as u64);
-        dma.coherent
-            .as_mut()
-            .unwrap()
-            .write_with_cpu(4, |dst| dst.copy_from_slice(&[1, 2, 3, 4]));
-        dma.copy_in_to_request(3).unwrap();
-
-        assert_eq!(data, [1, 2, 3, 0]);
-    }
-
-    #[test]
-    fn dma_buffer_pool_reuses_existing_dma_allocation() {
-        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
-        let stats = Dwc2Stats::new();
-        let mut pool = Dwc2DmaBufferPool::default();
-        let mut first = [0u8; 64];
-        let first_request = TransferRequest::bulk_in(&mut first);
-        let first_dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, &first_request).unwrap();
-        let first_addr = first_dma.dma_addr();
-        pool.reclaim(first_dma);
-
-        let mut smaller = [0u8; 32];
-        let smaller_request = TransferRequest::bulk_in(&mut smaller);
-        let smaller_dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, &smaller_request).unwrap();
-        assert_eq!(smaller_dma.dma_addr(), first_addr);
-        pool.reclaim(smaller_dma);
-
-        let mut larger = [0u8; 128];
-        let larger_request = TransferRequest::bulk_in(&mut larger);
-        let larger_dma = Dwc2DmaBuffer::new(&kernel, &mut pool, &stats, &larger_request).unwrap();
-        assert_eq!(larger_dma.buffer_len(), 128);
-        pool.reclaim(larger_dma);
-
-        let snapshot = stats.snapshot();
-        assert_eq!(snapshot.dma_allocs, 2);
-        assert_eq!(snapshot.bounce_from_device_bytes, 64 + 32 + 128);
-    }
-
-    #[test]
-    fn stats_records_transfer_faults_and_wait_iterations() {
-        let stats = Dwc2Stats::new();
-
-        stats.record_transfer();
-        stats.record_stage();
-        stats.record_fault(Dwc2TransferFault::Nak);
-        stats.record_fault(Dwc2TransferFault::Xact);
-        stats.record_timeout();
-        stats.record_transfer_busy_wait_iters(17);
-        stats.record_init_wait_iters(3);
-        stats.record_irq_event();
-        stats.record_channel_completion();
-
-        let snapshot = stats.snapshot();
-        assert_eq!(snapshot.transfers, 1);
-        assert_eq!(snapshot.stages, 1);
-        assert_eq!(snapshot.naks, 1);
-        assert_eq!(snapshot.xact_errors, 1);
-        assert_eq!(snapshot.timeouts, 1);
-        assert_eq!(snapshot.transfer_busy_wait_iters, 17);
-        assert_eq!(snapshot.init_wait_iters, 3);
-        assert_eq!(snapshot.wait_iters, 20);
-        assert_eq!(snapshot.irq_events, 1);
-        assert_eq!(snapshot.channel_completions, 1);
-    }
-
-    #[test]
-    fn hchint_event_publishes_channel_completion_without_endpoint_polling_hcint() {
-        let (_backing, regs) = test_regs();
-        let completions = Dwc2ChannelCompletions::new();
-        let stats = Dwc2Stats::new();
-        let handler = Dwc2EventHandler::new(regs, completions.clone(), stats.clone());
-        let hcint = HCINT_CHHLTD | HCINT_XFERCOMPL;
-
-        regs.write32(GINTMSK, GINTSTS_HCHINT);
-        regs.write32(GINTSTS, GINTSTS_HCHINT);
-        regs.write32(HAINTMSK, 1);
-        regs.write32(HAINT, 1);
-        regs.channel_write32(0, HCINTMSK, hcint);
-        regs.channel_write32(0, HCINT, hcint);
-
-        match handler.handle_event() {
-            Event::TransferActivity { count } => assert_eq!(count, 1),
-            event => panic!("expected transfer activity, got {event:?}"),
-        }
-        assert_eq!(completions.take(0), Some(hcint));
-
-        let snapshot = stats.snapshot();
-        assert_eq!(snapshot.irq_events, 1);
-        assert_eq!(snapshot.channel_completions, 1);
-    }
-
-    #[test]
-    fn port_interrupt_acknowledges_hprt_change_bits() {
-        let (_backing, regs) = test_regs();
-        let completions = Dwc2ChannelCompletions::new();
-        let stats = Dwc2Stats::new();
-        let handler = Dwc2EventHandler::new(regs, completions, stats);
-        let hprt = HPRT_CONN_STS | HPRT_ENA | HPRT_CONN_DET | HPRT_ENA_CHG | HPRT_PWR;
-
-        regs.write32(GINTMSK, GINTSTS_PRTINT);
-        regs.write32(GINTSTS, GINTSTS_PRTINT);
-        regs.write32(HPRT0, hprt);
-
-        assert!(matches!(
-            handler.handle_event(),
-            Event::PortChange { port: 1 }
-        ));
-        assert_eq!(
-            regs.read32(HPRT0),
-            (hprt & !HPRT_W1C_MASK) | HPRT_CONN_DET | HPRT_ENA_CHG
-        );
-    }
-
-    #[test]
-    fn chhltd_completion_preserves_unmasked_raw_hcint_reason() {
-        let (_backing, regs) = test_regs();
-        let completions = Dwc2ChannelCompletions::new();
-        let stats = Dwc2Stats::new();
-        let handler = Dwc2EventHandler::new(regs, completions.clone(), stats.clone());
-
-        regs.write32(GINTMSK, GINTSTS_HCHINT);
-        regs.write32(GINTSTS, GINTSTS_HCHINT);
-        regs.write32(HAINTMSK, 1);
-        regs.write32(HAINT, 1);
-        regs.channel_write32(0, HCINTMSK, HCINT_CHHLTD);
-        regs.channel_write32(0, HCINT, HCINT_CHHLTD | HCINT_XFERCOMPL);
-
-        match handler.handle_event() {
-            Event::TransferActivity { count } => assert_eq!(count, 1),
-            event => panic!("expected transfer activity, got {event:?}"),
-        }
-        assert_eq!(completions.take(0), Some(HCINT_CHHLTD | HCINT_XFERCOMPL));
-    }
-
-    #[test]
-    fn xfercomplete_without_channel_halt_requests_halt_before_publish() {
-        let (_backing, regs) = test_regs();
-        let completions = Dwc2ChannelCompletions::new();
-        let stats = Dwc2Stats::new();
-        let handler = Dwc2EventHandler::new(regs, completions.clone(), stats.clone());
-
-        regs.write32(GINTMSK, GINTSTS_HCHINT);
-        regs.write32(GINTSTS, GINTSTS_HCHINT);
-        regs.write32(HAINTMSK, 1);
-        regs.write32(HAINT, 1);
-        regs.channel_write32(0, HCCHAR, HCCHAR_CHENA);
-        regs.channel_write32(0, HCINTMSK, HCINT_CHHLTD | HCINT_XFERCOMPL);
-        regs.channel_write32(0, HCINT, HCINT_XFERCOMPL);
-
-        match handler.handle_event() {
-            Event::TransferActivity { .. } => {}
-            event => panic!("expected transfer activity, got {event:?}"),
-        }
-
-        assert_eq!(completions.take(0), None);
-        assert_eq!(regs.channel_read32(0, HCCHAR) & HCCHAR_CHDIS, HCCHAR_CHDIS);
-        assert_eq!(stats.snapshot().channel_completions, 0);
-
-        regs.write32(GINTSTS, GINTSTS_HCHINT);
-        regs.write32(HAINT, 1);
-        regs.channel_write32(0, HCCHAR, 0);
-        regs.channel_write32(0, HCINT, HCINT_CHHLTD);
-
-        match handler.handle_event() {
-            Event::TransferActivity { count } => assert_eq!(count, 1),
-            event => panic!("expected transfer activity, got {event:?}"),
-        }
-
-        assert_eq!(completions.take(0), Some(HCINT_CHHLTD | HCINT_XFERCOMPL));
-        assert_eq!(stats.snapshot().channel_completions, 1);
-    }
-
-    #[test]
-    fn endpoint_submit_waits_for_irq_completion_before_reclaiming() {
-        let (_backing, regs) = test_regs();
-        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
-        let completions = Dwc2ChannelCompletions::new();
-        let stats = Dwc2Stats::new();
-        let channel_pool = HostChannelPool::new(2, completions.clone());
-        let mut endpoint = Dwc2Endpoint::new(Dwc2EndpointParams {
-            regs,
-            kernel,
-            device_address: 2,
-            port_speed: Speed::High,
-            info: EndpointInfo {
-                address: EndpointAddress::new(0x81),
-                transfer_type: EndpointType::Bulk,
-                direction: Direction::In,
-                max_packet_size: 512,
-                packets_per_microframe: 1,
-                interval: 0,
-            },
-            channel_pool,
-            stats: stats.clone(),
-        })
-        .unwrap();
-        let mut data = [0u8; 512];
-        let id = endpoint
-            .submit_request(TransferRequest::bulk_in(&mut data))
-            .unwrap();
-
-        let hcintmsk = regs.channel_read32(1, HCINTMSK);
-        assert_eq!(hcintmsk, HCINT_DMA_IRQ_MASK);
-        assert_eq!(hcintmsk & HCINT_NAK, 0);
-        assert_eq!(hcintmsk & HCINT_XFERCOMPL, 0);
-        assert!(endpoint.reclaim_request(id).is_none());
-
-        completions.publish(1, HCINT_CHHLTD | HCINT_XFERCOMPL);
-        assert!(endpoint.reclaim_request(id).is_some());
-        assert_eq!(stats.snapshot().transfer_busy_wait_iters, 0);
-    }
-
-    #[test]
-    fn cancelled_endpoint_waits_for_real_channel_halt_before_reclaiming() {
-        let (_backing, regs) = test_regs();
-        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
-        let completions = Dwc2ChannelCompletions::new();
-        let stats = Dwc2Stats::new();
-        let channel_pool = HostChannelPool::new(2, completions.clone());
-        let mut endpoint = Dwc2Endpoint::new(Dwc2EndpointParams {
-            regs,
-            kernel,
-            device_address: 2,
-            port_speed: Speed::High,
-            info: EndpointInfo {
-                address: EndpointAddress::new(0x81),
-                transfer_type: EndpointType::Bulk,
-                direction: Direction::In,
-                max_packet_size: 512,
-                packets_per_microframe: 1,
-                interval: 0,
-            },
-            channel_pool,
-            stats,
-        })
-        .unwrap();
-        let mut data = [0u8; 512];
-        let id = endpoint
-            .submit_request(TransferRequest::bulk_in(&mut data))
-            .unwrap();
-
-        endpoint.cancel_request(id).unwrap();
-
-        assert!(endpoint.reclaim_request(id).is_none());
-        assert_eq!(regs.channel_read32(1, HCCHAR) & HCCHAR_CHDIS, HCCHAR_CHDIS);
-
-        completions.publish(1, HCINT_CHHLTD);
-        assert!(matches!(
-            endpoint.reclaim_request(id),
-            Some(Err(TransferError::Cancelled))
-        ));
-    }
-
-    #[test]
-    fn disconnect_completes_active_request_without_more_channel_writes() {
-        let (_backing, regs) = test_regs();
-        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
-        let completions = Dwc2ChannelCompletions::new();
-        let stats = Dwc2Stats::new();
-        let channel_pool = HostChannelPool::new(2, completions.clone());
-        let mut endpoint = Dwc2Endpoint::new(Dwc2EndpointParams {
-            regs,
-            kernel,
-            device_address: 2,
-            port_speed: Speed::High,
-            info: EndpointInfo {
-                address: EndpointAddress::new(0x81),
-                transfer_type: EndpointType::Bulk,
-                direction: Direction::In,
-                max_packet_size: 512,
-                packets_per_microframe: 1,
-                interval: 0,
-            },
-            channel_pool,
-            stats: stats.clone(),
-        })
-        .unwrap();
-        let handler = Dwc2EventHandler::new(regs, completions, stats);
-        let mut data = [0u8; 512];
-        let id = endpoint
-            .submit_request(TransferRequest::bulk_in(&mut data))
-            .unwrap();
-
-        regs.write32(GINTMSK, GINTSTS_DISCONNINT);
-        regs.write32(GINTSTS, GINTSTS_DISCONNINT);
-        assert!(matches!(handler.handle_event(), Event::Stopped));
-        let channel_value = regs.channel_read32(1, HCCHAR);
-
-        endpoint.cancel_request(id).unwrap();
-
-        assert_eq!(regs.channel_read32(1, HCCHAR), channel_value);
-        assert!(matches!(
-            endpoint.reclaim_request(id),
-            Some(Err(TransferError::Disconnected))
-        ));
-    }
-
-    #[test]
-    fn acquired_channel_cannot_start_after_disconnect() {
-        let (_backing, regs) = test_regs();
-        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
-        let completions = Dwc2ChannelCompletions::new();
-        let channel_pool = HostChannelPool::new(2, completions.clone());
-        let endpoint = Dwc2Endpoint::new(Dwc2EndpointParams {
-            regs,
-            kernel,
-            device_address: 2,
-            port_speed: Speed::High,
-            info: EndpointInfo {
-                address: EndpointAddress::new(0x81),
-                transfer_type: EndpointType::Bulk,
-                direction: Direction::In,
-                max_packet_size: 512,
-                packets_per_microframe: 1,
-                interval: 0,
-            },
-            channel_pool: channel_pool.clone(),
-            stats: Dwc2Stats::new(),
-        })
-        .unwrap();
-        let channel = channel_pool.acquire(false).unwrap();
-        let stage = Dwc2TransferStage {
-            hcchar: hcchar(2, 1, Direction::In, Dwc2EpType::Bulk, 512, false),
-            hctsiz: hctsiz(Dwc2Pid::Data0, 1, 31),
-            dma_addr: 0x4000,
-            len: 31,
-        };
-
-        completions.disconnect_all_with(|| {});
-        let hcchar_before = regs.channel_read32(1, HCCHAR);
-
-        assert!(matches!(
-            endpoint.start_stage(&channel, stage),
-            Err(TransferError::Disconnected)
-        ));
-        assert_eq!(regs.channel_read32(1, HCCHAR), hcchar_before);
-        assert!(!channel.hardware_active.load(AtomicOrdering::Acquire));
-    }
-
-    #[test]
-    fn opposite_direction_endpoints_do_not_share_a_host_channel() {
-        let (_backing, regs) = test_regs();
-        let kernel = Kernel::new(u64::MAX, &TEST_KERNEL);
-        let completions = Dwc2ChannelCompletions::new();
-        let channel_pool = HostChannelPool::new(4, completions);
-        let endpoint_info = |address, direction| EndpointInfo {
-            address: EndpointAddress::new(address),
-            transfer_type: EndpointType::Bulk,
-            direction,
-            max_packet_size: 512,
-            packets_per_microframe: 1,
-            interval: 0,
-        };
-
-        let mut in_endpoint = Dwc2Endpoint::new(Dwc2EndpointParams {
-            regs,
-            kernel: kernel.clone(),
-            device_address: 2,
-            port_speed: Speed::High,
-            info: endpoint_info(0x81, Direction::In),
-            channel_pool: channel_pool.clone(),
-            stats: Dwc2Stats::new(),
-        })
-        .unwrap();
-        let mut out_endpoint = Dwc2Endpoint::new(Dwc2EndpointParams {
-            regs,
-            kernel,
-            device_address: 2,
-            port_speed: Speed::High,
-            info: endpoint_info(0x01, Direction::Out),
-            channel_pool,
-            stats: Dwc2Stats::new(),
-        })
-        .unwrap();
-        let mut input = [0u8; 8];
-        let output = [0u8; 8];
-        in_endpoint
-            .submit_request(TransferRequest::bulk_in(&mut input))
-            .unwrap();
-        out_endpoint
-            .submit_request(TransferRequest::bulk_out(&output))
-            .unwrap();
-
-        let in_channel = in_endpoint.active.as_ref().unwrap().channel.channel;
-        let out_channel = out_endpoint.active.as_ref().unwrap().channel.channel;
-
-        assert_ne!(in_channel, out_channel);
-    }
-
-    #[test]
-    fn bulk_and_interrupt_data_stages_retry_nak_like_linux_hcd_flow_control() {
-        assert_eq!(
-            data_stage_retry_policy(Dwc2EpType::Bulk),
-            DataStageRetryPolicy { nak_retries: 64 }
-        );
-        assert_eq!(
-            data_stage_retry_policy(Dwc2EpType::Interrupt),
-            DataStageRetryPolicy { nak_retries: 64 }
-        );
-    }
-
-    #[test]
-    fn channel_gates_are_per_channel_instead_of_one_global_gate() {
-        let gates = build_channel_gates(4);
-
-        assert_eq!(gates.len(), 4);
-        assert!(alloc::sync::Arc::ptr_eq(&gates[1], &gates[1]));
-        assert!(!alloc::sync::Arc::ptr_eq(&gates[1], &gates[2]));
-    }
-
-    #[test]
-    fn out_stage_completion_reports_requested_length() {
-        let stage = Dwc2TransferStage {
-            hcchar: hcchar(2, 2, Direction::Out, Dwc2EpType::Bulk, 512, false),
-            hctsiz: hctsiz(Dwc2Pid::Data0, 1, 31),
-            dma_addr: 0,
-            len: 31,
-        };
-
-        assert_eq!(
-            stage_actual_length(stage, hctsiz(Dwc2Pid::Data0, 1, 31)),
-            31
-        );
-
-        let in_stage = Dwc2TransferStage {
-            hcchar: hcchar(2, 1, Direction::In, Dwc2EpType::Bulk, 512, false),
-            hctsiz: hctsiz(Dwc2Pid::Data0, 1, 31),
-            dma_addr: 0,
-            len: 31,
-        };
-
-        assert_eq!(
-            stage_actual_length(in_stage, hctsiz(Dwc2Pid::Data0, 1, 13)),
-            18
-        );
-    }
-
-    #[test]
-    fn control_data_stage_splits_at_hctsiz_packet_limit_and_toggles_pid() {
-        let mut data = [0u8; 2048];
-        let request = TransferRequest::control_in(
-            ControlSetup {
-                request_type: RequestType::Standard,
-                recipient: Recipient::Device,
-                request: Request::GetDescriptor,
-                value: 0x0200,
-                index: 0,
-            },
-            &mut data,
-        );
-
-        let plan = build_control_plan(&request, 2, 8, 0x1000, 0x2000).unwrap();
-
-        assert_eq!(plan.data.len(), 1);
-        assert_eq!(plan.data[0].hctsiz >> 29, Dwc2Pid::Data1.bits());
-        assert_eq!(split_dma_lengths(8192, 8), [8184, 8]);
-    }
-
-    #[test]
-    fn data_toggle_advances_by_packet_count() {
-        let mut toggle = DataToggle::data0();
-
-        assert_eq!(toggle.pid(), Dwc2Pid::Data0);
-        toggle.advance(packet_count(512, 512));
-        assert_eq!(toggle.pid(), Dwc2Pid::Data1);
-        toggle.advance(packet_count(1024, 512));
-        assert_eq!(toggle.pid(), Dwc2Pid::Data1);
-        toggle.advance(packet_count(1, 512));
-        assert_eq!(toggle.pid(), Dwc2Pid::Data0);
-        assert_eq!(successful_packet_count(0, 64, 64), 1);
-    }
-
-    #[test]
-    fn hprt_status_decodes_speed_and_preserves_w1c_bits_for_rmw() {
-        let status = Dwc2PortStatus::from_raw(
-            HPRT_CONN_STS | HPRT_ENA | HPRT_CONN_DET | HPRT_ENA_CHG | HPRT_OVRCUR_CHG | (2 << 17),
-        );
-
-        assert!(status.connected());
-        assert!(status.enabled());
-        assert_eq!(status.speed(), Speed::Low);
-        assert_eq!(
-            status.rmw_preserving_w1c() & (HPRT_CONN_DET | HPRT_ENA | HPRT_ENA_CHG),
-            0
-        );
+        assert_eq!(hctsiz_ddma(Dwc2Pid::MData, 1, 0), 3 << 29);
     }
 
     #[test]
     fn hcint_fault_maps_nak_stall_xact_and_bus_errors() {
-        assert_eq!(hcint_fault(HCINT_NAK), Some(Dwc2TransferFault::Nak));
         assert_eq!(hcint_fault(HCINT_STALL), Some(Dwc2TransferFault::Stall));
+        assert_eq!(hcint_fault(HCINT_NAK), Some(Dwc2TransferFault::Nak));
         assert_eq!(hcint_fault(HCINT_XACTERR), Some(Dwc2TransferFault::Xact));
         assert_eq!(hcint_fault(HCINT_AHBERR), Some(Dwc2TransferFault::Ahb));
         assert_eq!(hcint_fault(HCINT_BBLERR), Some(Dwc2TransferFault::Babble));
+        assert_eq!(
+            hcint_fault(HCINT_FRMOVRN),
+            Some(Dwc2TransferFault::FrameOverrun)
+        );
+        assert_eq!(
+            hcint_fault(HCINT_DATATGLERR),
+            Some(Dwc2TransferFault::DataToggle)
+        );
+        // CHHLTD（± XFERCOMPL）是正常通道终止，不是故障。
+        assert_eq!(hcint_fault(HCINT_CHHLTD), None);
+        assert_eq!(hcint_fault(HCINT_CHHLTD | HCINT_XFERCOMPL), None);
+        // 非完成位（如 BNA）没有 CHHLTD/XFERCOMPL → 无完成暂停。
+        assert_eq!(
+            hcint_fault(1 << 11),
+            Some(Dwc2TransferFault::HaltedWithoutComplete)
+        );
+        assert_eq!(
+            hcint_fault(0),
+            Some(Dwc2TransferFault::HaltedWithoutComplete)
+        );
     }
 }

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/reg.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/reg.rs
@@ -1,0 +1,739 @@
+use core::ptr::NonNull;
+
+use tock_registers::{
+    interfaces::{ReadWriteable, Readable, Writeable},
+    register_bitfields, register_structs,
+    registers::{ReadOnly, ReadWrite},
+};
+use usb_if::host::hub::Speed;
+
+use crate::Mmio;
+pub(crate) const DWC2_MAX_CHANNELS: u8 = 16;
+
+pub(crate) const DWC2_DMA_MASK_32: u64 = u32::MAX as u64;
+// Linux DWC2 bounds GRSTCTL register polls to 10,000 reads. Keep the same
+// budget: MMIO reads can be slow on embedded interconnects, and a missing
+// hardware transition must fail initialization instead of monopolizing a CPU.
+pub(crate) const DWC2_WAIT_ITERS: usize = 10_000;
+pub(crate) const DWC2_DMA_ALIGN: usize = 64;
+pub(crate) const DWC2_STATUS_BUF_SIZE: usize = 64;
+pub(crate) const DWC2_MAX_DMA_DESCS: usize = 256; // NTD 8 位 → 单链 ≤ 256 desc
+
+pub(crate) const GUSBCFG_TOUTCAL_MASK: u32 = 0x7;
+pub(crate) const GUSBCFG_PHYIF16: u32 = 1 << 3;
+pub(crate) const GUSBCFG_ULPI_UTMI_SEL: u32 = 1 << 4;
+pub(crate) const GUSBCFG_FORCEHOSTMODE: u32 = 1 << 29;
+pub(crate) const GUSBCFG_FORCEDEVMODE: u32 = 1 << 30;
+
+pub(crate) const GRSTCTL_CSFTRST: u32 = 1 << 0;
+pub(crate) const GRSTCTL_RXFFLSH: u32 = 1 << 4;
+pub(crate) const GRSTCTL_TXFFLSH: u32 = 1 << 5;
+pub(crate) const GRSTCTL_TXFNUM_ALL: u32 = 0x10 << 6;
+pub(crate) const GRSTCTL_CSFTRST_DONE: u32 = 1 << 29;
+pub(crate) const GRSTCTL_AHBIDLE: u32 = 1 << 31;
+
+pub(crate) const GINTSTS_CURMODE_HOST: u32 = 1 << 0;
+pub(crate) const GINTSTS_PRTINT: u32 = 1 << 24;
+pub(crate) const GINTSTS_HCHINT: u32 = 1 << 25;
+pub(crate) const GINTSTS_DISCONNINT: u32 = 1 << 29;
+pub(crate) const DWC2_RUNTIME_GINTMSK: u32 = GINTSTS_PRTINT | GINTSTS_HCHINT | GINTSTS_DISCONNINT;
+pub(crate) const DWC2_COMPLETION_DISCONNECTED: u32 = 1 << 31;
+
+pub(crate) const GOTGCTL_VBVALOEN: u32 = 1 << 2;
+pub(crate) const GOTGCTL_VBVALOVAL: u32 = 1 << 3;
+pub(crate) const GOTGCTL_AVALOEN: u32 = 1 << 4;
+pub(crate) const GOTGCTL_AVALOVAL: u32 = 1 << 5;
+pub(crate) const GOTGCTL_DBNCE_FLTR_BYPASS: u32 = 1 << 15;
+
+pub(crate) const HPRT_CONN_DET: u32 = 1 << 1;
+pub(crate) const HPRT_ENA: u32 = 1 << 2;
+pub(crate) const HPRT_ENA_CHG: u32 = 1 << 3;
+pub(crate) const HPRT_OVRCUR_CHG: u32 = 1 << 5;
+pub(crate) const HPRT_RST: u32 = 1 << 8;
+pub(crate) const HPRT_PWR: u32 = 1 << 12;
+pub(crate) const HPRT_W1C_MASK: u32 = HPRT_CONN_DET | HPRT_ENA | HPRT_ENA_CHG | HPRT_OVRCUR_CHG;
+
+pub(crate) const HCCHAR_ODDFRM: u32 = 1 << 29;
+pub(crate) const HCCHAR_EPDIR: u32 = 1 << 15;
+
+// HCFG：周期调度使能与帧列表尺寸（HCFG.PERSCHEDENA / FRLISTEN）。
+pub(crate) const HCFG_PERSCHEDENA: u32 = 1 << 26;
+pub(crate) const HCFG_FRLISTEN_MASK: u32 = 0b11 << 24;
+pub(crate) const HCFG_FRLISTEN_64: u32 = 0b11 << 24;
+
+pub(crate) const HCINT_XFERCOMPL: u32 = 1 << 0;
+pub(crate) const HCINT_CHHLTD: u32 = 1 << 1;
+pub(crate) const HCINT_AHBERR: u32 = 1 << 2;
+pub(crate) const HCINT_STALL: u32 = 1 << 3;
+pub(crate) const HCINT_NAK: u32 = 1 << 4;
+pub(crate) const HCINT_XACTERR: u32 = 1 << 7;
+pub(crate) const HCINT_BBLERR: u32 = 1 << 8;
+pub(crate) const HCINT_FRMOVRN: u32 = 1 << 9;
+pub(crate) const HCINT_DATATGLERR: u32 = 1 << 10;
+pub(crate) const HCINT_ALL_W1C: u32 = 0x7ff;
+pub(crate) const HCINT_TRANSFER_MASK: u32 = HCINT_XFERCOMPL
+    | HCINT_CHHLTD
+    | HCINT_AHBERR
+    | HCINT_STALL
+    | HCINT_NAK
+    | HCINT_XACTERR
+    | HCINT_BBLERR
+    | HCINT_FRMOVRN
+    | HCINT_DATATGLERR;
+
+// ═══════════════════════════════════════════
+// 寄存器位字段定义
+// ═══════════════════════════════════════════
+
+register_bitfields![u32,
+    /// GOTGCTL — OTG 控制
+    pub GOTGCTL [
+        /// OTG 协议版本（host 模式不使用，Linux 在 core_init 清除）
+        OTGVER OFFSET(20) NUMBITS(1) [],
+        /// Connector ID 状态（0 = A 设备）
+        CONID_B OFFSET(16) NUMBITS(1) [],
+        /// 旁路去抖滤波器
+        DBNCE_FLTR_BYPASS OFFSET(15) NUMBITS(1) [],
+        /// A 会话有效覆盖值
+        AVALOVAL OFFSET(5) NUMBITS(1) [],
+        /// A 会话有效覆盖使能
+        AVALOEN OFFSET(4) NUMBITS(1) [],
+        /// B 会话有效覆盖值
+        VBVALOVAL OFFSET(3) NUMBITS(1) [],
+        /// B 会话有效覆盖使能
+        VBVALOEN OFFSET(2) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// GAHBCFG — AHB 配置
+    pub GAHBCFG [
+        /// 周期 TX FIFO 空阈值
+        PTXFEHLVL OFFSET(8) NUMBITS(1) [],
+        /// 非周期 TX FIFO 空阈值
+        NPTXFEHLVL OFFSET(7) NUMBITS(1) [],
+        /// DMA 模式使能
+        DMAEN OFFSET(5) NUMBITS(1) [],
+        /// 突发长度/类型（Linux hw.h GAHBCFG_HBSTLEN_*）
+        HBSTLEN OFFSET(1) NUMBITS(3) [
+            SINGLE = 0,
+            INCR = 1,
+            INCR4 = 3,
+            INCR8 = 5,
+            INCR16 = 7,
+        ],
+        /// 全局中断屏蔽
+        GLBLINTRMSK OFFSET(0) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// GUSBCFG — USB 配置
+    pub GUSBCFG [
+        /// 强制设备模式
+        FORCEDEVMODE OFFSET(30) NUMBITS(1) [],
+        /// 强制主机模式
+        FORCEHOSTMODE OFFSET(29) NUMBITS(1) [],
+        /// ULPI/UTMI+ 选择
+        ULPI_UTMI_SEL OFFSET(4) NUMBITS(1) [],
+        /// PHY 接口 16 位
+        PHYIF16 OFFSET(3) NUMBITS(1) [],
+        /// HS/FS 超时校准（0x0-0x7）
+        TOUTCAL OFFSET(0) NUMBITS(3) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// GRSTCTL — 复位控制
+    pub GRSTCTL [
+        /// AHB 主控空闲
+        AHBIDLE OFFSET(31) NUMBITS(1) [],
+        /// 核软复位完成
+        CSFTRST_DONE OFFSET(29) NUMBITS(1) [],
+        /// 时钟切换定时器（v5.00a+，Linux dwc2_set_clock_switch_timer）
+        CLOCK_SWITH_TIMER OFFSET(11) NUMBITS(3) [],
+        /// TX FIFO 编号（0x10 = 全部）
+        TXFNUM OFFSET(6) NUMBITS(5) [],
+        /// TX FIFO 冲刷
+        TXFFLSH OFFSET(5) NUMBITS(1) [],
+        /// RX FIFO 冲刷
+        RXFFLSH OFFSET(4) NUMBITS(1) [],
+        /// 核软复位
+        CSFTRST OFFSET(0) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// GINTSTS — 中断状态
+    pub GINTSTS [
+        /// 断开检测中断
+        DISCONNINT OFFSET(29) NUMBITS(1) [],
+        /// 主机通道中断
+        HCHINT OFFSET(25) NUMBITS(1) [],
+        /// 端口变化中断
+        PRTINT OFFSET(24) NUMBITS(1) [],
+        /// 当前模式：主机
+        CURMODE_HOST OFFSET(0) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// GINTMSK — 中断屏蔽（与 GINTSTS 同位）
+    pub GINTMSK [
+        DISCONNINT OFFSET(29) NUMBITS(1) [],
+        HCHINT OFFSET(25) NUMBITS(1) [],
+        PRTINT OFFSET(24) NUMBITS(1) [],
+        CURMODE_HOST OFFSET(0) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// GHWCFG2 — 硬件参数 2
+    pub GHWCFG2 [
+        /// OTG IC USB 使能
+        OTG_ENABLE_IC_USB OFFSET(31) NUMBITS(1) [],
+        /// 主机周期 TX 队列深度
+        HOST_PERIO_TX_Q_DEPTH OFFSET(24) NUMBITS(2) [],
+        /// 非周期 TX 队列深度
+        NONPERIO_TX_Q_DEPTH OFFSET(22) NUMBITS(2) [],
+        /// 动态 FIFO 支持
+        DYNAMIC_FIFO OFFSET(19) NUMBITS(1) [],
+        /// 支持周期端点
+        PERIO_EP_SUPPORTED OFFSET(18) NUMBITS(1) [],
+        /// 主机通道数 − 1
+        NUM_HOST_CHAN OFFSET(14) NUMBITS(4) [],
+        /// FS PHY 类型
+        FS_PHY_TYPE OFFSET(8) NUMBITS(2) [],
+        /// HS PHY 类型
+        HS_PHY_TYPE OFFSET(6) NUMBITS(2) [],
+        /// 点对点
+        POINT2POINT OFFSET(5) NUMBITS(1) [],
+        /// 架构
+        ARCHITECTURE OFFSET(3) NUMBITS(2) [
+            SlaveOnly = 0,
+            ExternalDma = 1,
+            InternalDma = 2,
+        ],
+        /// 操作模式
+        OP_MODE OFFSET(0) NUMBITS(3) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// GHWCFG3 — 硬件参数 3
+    pub GHWCFG3 [
+        /// FIFO RAM 总深度（字）
+        DFIFO_DEPTH OFFSET(16) NUMBITS(16) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// GHWCFG4 — 硬件参数 4
+    pub GHWCFG4 [
+        /// 支持描述符 DMA 模式
+        DESC_DMA OFFSET(30) NUMBITS(1) [],
+        /// 存在 IDDIG 去抖滤波器
+        IDDIG_FILT_EN OFFSET(20) NUMBITS(1) [],
+        /// UTMI PHY 数据宽度（0=8 位，1=16 位，2=8/16 可选）
+        UTMI_PHY_DATA_WIDTH OFFSET(14) NUMBITS(2) [
+            Width8 = 0,
+            Width16 = 1,
+        ],
+    ]
+];
+
+register_bitfields![u32,
+    /// HCFG — 主机配置
+    pub HCFG [
+        /// 模式变化时序使能
+        MODECHTIMEN OFFSET(31) NUMBITS(1) [],
+        /// 周期调度使能
+        PERSCHEDENA OFFSET(26) NUMBITS(1) [],
+        /// 帧列表条目（8/16/32/64）
+        FRLISTEN OFFSET(24) NUMBITS(2) [
+            Size8 = 0,
+            Size16 = 1,
+            Size32 = 2,
+            Size64 = 3,
+        ],
+        /// 描述符 DMA 模式
+        DESCDMA OFFSET(23) NUMBITS(1) [],
+        /// FS/LS 时钟选择
+        FSLSPCLKSEL OFFSET(0) NUMBITS(2) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HPRT — 主机端口控制与状态
+    pub HPRT [
+        /// 端口速度
+        SPD OFFSET(17) NUMBITS(2) [
+            High = 0,
+            Full = 1,
+            Low = 2,
+        ],
+        /// 测试控制
+        TSTCTL OFFSET(13) NUMBITS(4) [],
+        /// 端口电源（W1C，写 0 保持）
+        PWR OFFSET(12) NUMBITS(1) [],
+        /// 线状态
+        LNSTS OFFSET(10) NUMBITS(2) [],
+        /// 端口复位（W1C）
+        RST OFFSET(8) NUMBITS(1) [],
+        /// 挂起
+        SUSP OFFSET(7) NUMBITS(1) [],
+        /// 恢复
+        RES OFFSET(6) NUMBITS(1) [],
+        /// 过流变化（W1C）
+        OVRCURRCHG OFFSET(5) NUMBITS(1) [],
+        /// 过流激活
+        OVRCURRACT OFFSET(4) NUMBITS(1) [],
+        /// 端口使能变化（W1C）
+        ENACHG OFFSET(3) NUMBITS(1) [],
+        /// 端口使能（W1C）
+        ENA OFFSET(2) NUMBITS(1) [],
+        /// 连接检测（W1C）
+        CONNDET OFFSET(1) NUMBITS(1) [],
+        /// 当前连接状态
+        CONNSTS OFFSET(0) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HCCHAR — 主机通道特性
+    pub HCCHAR [
+        /// 通道使能
+        CHENA OFFSET(31) NUMBITS(1) [],
+        /// 通道禁用
+        CHDIS OFFSET(30) NUMBITS(1) [],
+        /// 奇帧
+        ODDFRM OFFSET(29) NUMBITS(1) [],
+        /// 设备地址
+        DEVADDR OFFSET(22) NUMBITS(7) [],
+        /// 多事务计数（ISO/INT，mult − 1）
+        MULTICNT OFFSET(20) NUMBITS(2) [],
+        /// 端点类型
+        EPTYPE OFFSET(18) NUMBITS(2) [
+            Control = 0,
+            Isochronous = 1,
+            Bulk = 2,
+            Interrupt = 3,
+        ],
+        /// 低速设备
+        LSPDDEV OFFSET(17) NUMBITS(1) [],
+        /// 端点方向（1=IN）
+        EPDIR OFFSET(15) NUMBITS(1) [],
+        /// 端点号
+        EPNUM OFFSET(11) NUMBITS(4) [],
+        /// 最大包大小
+        MPS OFFSET(0) NUMBITS(11) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HCSPLT — 主机通道拆分控制
+    pub HCSPLT [
+        SPLITEN OFFSET(31) NUMBITS(1) [],
+        COMDONE OFFSET(30) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HCINT / HCINTMSK — 主机通道中断
+    pub HCINT [
+        /// 帧列表回绕
+        FRM_LIST_ROLL OFFSET(13) NUMBITS(1) [],
+        /// 缓冲区不可用
+        BNA OFFSET(11) NUMBITS(1) [],
+        /// 数据翻转错误
+        DATATGLERR OFFSET(10) NUMBITS(1) [],
+        /// 帧过载
+        FRMOVRUN OFFSET(9) NUMBITS(1) [],
+        /// 串扰错误
+        BBLERR OFFSET(8) NUMBITS(1) [],
+        /// 事务错误
+        XACTERR OFFSET(7) NUMBITS(1) [],
+        /// NYET（未就绪）
+        NYET OFFSET(6) NUMBITS(1) [],
+        /// ACK（应答）
+        ACK OFFSET(5) NUMBITS(1) [],
+        /// NAK（否认）
+        NAK OFFSET(4) NUMBITS(1) [],
+        /// STALL（停滞）
+        STALL OFFSET(3) NUMBITS(1) [],
+        /// AHB 错误
+        AHBERR OFFSET(2) NUMBITS(1) [],
+        /// 通道暂停
+        CHHLTD OFFSET(1) NUMBITS(1) [],
+        /// 传输完成
+        XFERCOMPL OFFSET(0) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HCINTMSK — 与 HCINT 同位
+    pub HCINTMSK [
+        FRM_LIST_ROLL OFFSET(13) NUMBITS(1) [],
+        BNA OFFSET(11) NUMBITS(1) [],
+        DATATGLERR OFFSET(10) NUMBITS(1) [],
+        FRMOVRUN OFFSET(9) NUMBITS(1) [],
+        BBLERR OFFSET(8) NUMBITS(1) [],
+        XACTERR OFFSET(7) NUMBITS(1) [],
+        NYET OFFSET(6) NUMBITS(1) [],
+        ACK OFFSET(5) NUMBITS(1) [],
+        NAK OFFSET(4) NUMBITS(1) [],
+        STALL OFFSET(3) NUMBITS(1) [],
+        AHBERR OFFSET(2) NUMBITS(1) [],
+        CHHLTD OFFSET(1) NUMBITS(1) [],
+        XFERCOMPL OFFSET(0) NUMBITS(1) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HCTSIZ — 主机通道传输大小
+    pub HCTSIZ [
+        /// 执行 ping
+        DOPNG OFFSET(31) NUMBITS(1) [],
+        /// SC/MC/PID（非 DDMA 为 PID；ISO 为 MC）
+        PID OFFSET(29) NUMBITS(2) [
+            Data0 = 0,
+            Data2 = 1,
+            Data1 = 2,
+            Setup = 3,
+        ],
+        /// 包计数
+        PKTCNT OFFSET(19) NUMBITS(10) [],
+        /// 传输描述符数 − 1（DDMA）
+        NTD OFFSET(8) NUMBITS(8) [],
+        /// 调度信息（DDMA ISO 微帧位图）
+        SCHINFO OFFSET(0) NUMBITS(8) [],
+        /// 传输大小（非 DDMA）
+        XFERSIZE OFFSET(0) NUMBITS(19) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HFIR — 主机帧间隔
+    pub HFIR [
+        /// 运行期重载控制（Linux reload_ctl；初始配置后不可再改）
+        RLDCTRL OFFSET(16) NUMBITS(1) [],
+        /// 帧间隔（PHY 时钟数 − 1）
+        FRINT OFFSET(0) NUMBITS(16) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HFNUM — 主机帧号
+    pub HFNUM [
+        /// 帧剩余
+        FRREM OFFSET(16) NUMBITS(16) [],
+        /// 帧号
+        FRNUM OFFSET(0) NUMBITS(16) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// HAINT / HAINTMSK — 主机全通道中断
+    pub HAINT [
+        /// 各通道中断位（bit n = 通道 n）
+        CHANNELS OFFSET(0) NUMBITS(16) [],
+    ]
+];
+
+register_bitfields![u32,
+    /// FIFO 深度寄存器（GRXFSIZ/GNPTXFSIZ/HPTXFSIZ）
+    pub FIFO [
+        /// FIFO 深度（字）
+        DEPTH OFFSET(0) NUMBITS(16) [],
+        /// RAM 起始地址（字）
+        STARTADDR OFFSET(16) NUMBITS(16) [],
+    ]
+];
+
+// ═══════════════════════════════════════════
+// 寄存器布局（register_structs!）
+// ═══════════════════════════════════════════
+
+register_structs! {
+    /// 单通道寄存器组（每通道 0x20，HC_BASE + ch × 0x20）
+    pub HcChannelRegs {
+        (0x00 => pub hcchar: ReadWrite<u32, HCCHAR::Register>),
+        (0x04 => pub hcsplt: ReadWrite<u32, HCSPLT::Register>),
+        (0x08 => pub hcint: ReadWrite<u32, HCINT::Register>),
+        (0x0c => pub hcintmsk: ReadWrite<u32, HCINTMSK::Register>),
+        (0x10 => pub hctsiz: ReadWrite<u32, HCTSIZ::Register>),
+        (0x14 => pub hcdma: ReadWrite<u32>),
+        (0x18 => _rsv1),
+        (0x1c => _rsv2),
+        (0x20 => @END),
+    }
+}
+
+register_structs! {
+    /// DWC2 寄存器窗口（全局 0x000 + FIFO 0x100 + 主机 0x400 + 通道 0x500）
+    pub Dwc2Regs {
+        (0x000 => pub gotgctl: ReadWrite<u32, GOTGCTL::Register>),
+        (0x004 => _rsv1),
+        (0x008 => pub gahbcfg: ReadWrite<u32, GAHBCFG::Register>),
+        (0x00c => pub gusbcfg: ReadWrite<u32, GUSBCFG::Register>),
+        (0x010 => pub grstctl: ReadWrite<u32, GRSTCTL::Register>),
+        (0x014 => pub gintsts: ReadWrite<u32, GINTSTS::Register>),
+        (0x018 => pub gintmsk: ReadWrite<u32, GINTMSK::Register>),
+        (0x01c => _rsv2),
+        (0x020 => _rsv3),
+        (0x024 => pub grxfsiz: ReadWrite<u32, FIFO::Register>),
+        (0x028 => pub gnptxfsiz: ReadWrite<u32, FIFO::Register>),
+        (0x02c => _rsv_fifo: [u32; 5]),
+        (0x040 => pub gsnpsid: ReadOnly<u32>),
+        (0x044 => _rsv_g1),
+        (0x048 => pub ghwcfg2: ReadOnly<u32, GHWCFG2::Register>),
+        (0x04c => pub ghwcfg3: ReadOnly<u32, GHWCFG3::Register>),
+        (0x050 => pub ghwcfg4: ReadOnly<u32, GHWCFG4::Register>),
+        (0x054 => _rsv_globals: [u32; 43]),
+        (0x100 => pub hptxfsiz: ReadWrite<u32, FIFO::Register>),
+        (0x104 => _rsv_host0: [u32; 191]),
+        (0x400 => pub hcfg: ReadWrite<u32, HCFG::Register>),
+        (0x404 => pub hfir: ReadWrite<u32, HFIR::Register>),
+        (0x408 => pub hfnum: ReadOnly<u32, HFNUM::Register>),
+        (0x40c => _rsv6),
+        (0x410 => _rsv7),
+        (0x414 => pub haint: ReadWrite<u32, HAINT::Register>),
+        (0x418 => pub haintmsk: ReadWrite<u32, HAINT::Register>),
+        (0x41c => pub hflbaddr: ReadWrite<u32>),
+        (0x420 => _rsv_host1: [u32; 8]),
+        (0x440 => pub hprt: ReadWrite<u32, HPRT::Register>),
+        (0x444 => _rsv_host2: [u32; 47]),
+        (0x500 => pub hc: [HcChannelRegs; DWC2_MAX_CHANNELS as usize]),
+        (0x700 => _rsv_pcg: [u32; 448]),
+        (0xe00 => pub pcgctl: ReadWrite<u32>),
+        (0xe04 => @END),
+    }
+}
+
+/// DWC2 寄存器的能力边界
+#[derive(Clone, Copy)]
+pub(crate) struct Dwc2Registers {
+    pub(crate) base: NonNull<u8>,
+}
+
+unsafe impl Send for Dwc2Registers {}
+unsafe impl Sync for Dwc2Registers {}
+
+impl Dwc2Registers {
+    pub(crate) fn new(base: Mmio) -> Self {
+        Self { base }
+    }
+
+    pub(crate) fn regs(&self) -> &'static Dwc2Regs {
+        unsafe { &*(self.base.as_ptr() as *const Dwc2Regs) }
+    }
+
+    /// 读取主机通道数（NUM_HOST_CHAN + 1，最小 2，最大 DWC2_MAX_CHANNELS）
+    pub(crate) fn host_channel_count(&self) -> u8 {
+        let raw = self.regs().ghwcfg2.read(GHWCFG2::NUM_HOST_CHAN);
+        ((raw + 1) as u8).clamp(2, DWC2_MAX_CHANNELS)
+    }
+
+    /// 控制器是否支持描述符 DMA（GHWCFG4.DESC_DMA，只读硬件参数）。
+    pub(crate) fn is_support_ddma(&self) -> bool {
+        self.regs().ghwcfg4.is_set(GHWCFG4::DESC_DMA)
+    }
+
+    /// HPRT 端口
+    pub(crate) fn hprt(self) -> Hprt<'static> {
+        Hprt::new(&self.regs().hprt)
+    }
+
+    /// host channel 寄存器组
+    pub(crate) fn channel(self, channel: u8) -> HcChannel<'static> {
+        HcChannel::new(&self.regs().hc[usize::from(channel)])
+    }
+
+    /// 返回当前帧号（HFNUM.FRNUM，低 3 位为 HS 微帧位）。
+    pub(crate) fn frame_number(&self) -> u32 {
+        self.regs().hfnum.read(HFNUM::FRNUM)
+    }
+
+    /// 返回当前帧号的奇偶位（HFNUM.FRNUM & 1），用于设置 HCCHAR.ODDFRM
+    pub(crate) fn periodic_odd_frame_bit(&self) -> u32 {
+        if self.regs().hfnum.read(HFNUM::FRNUM) & 1 == 0 {
+            HCCHAR_ODDFRM
+        } else {
+            0
+        }
+    }
+}
+
+/// HPRT 端口的能力边界
+pub(crate) struct Hprt<'a> {
+    reg: &'a ReadWrite<u32, HPRT::Register>,
+}
+
+impl<'a> Hprt<'a> {
+    pub(crate) fn new(reg: &'a ReadWrite<u32, HPRT::Register>) -> Self {
+        Self { reg }
+    }
+
+    /// HPRT 原始值
+    pub(crate) fn raw(&self) -> u32 {
+        self.reg.get()
+    }
+
+    /// 是否连接（CONNSTS；复位完成后硬件置位）
+    pub(crate) fn is_connected(&self) -> bool {
+        self.reg.is_set(HPRT::CONNSTS)
+    }
+
+    /// 端口是否已使能（ENA；复位完成后硬件置位）
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.reg.is_set(HPRT::ENA)
+    }
+
+    pub(crate) fn speed(&self) -> Speed {
+        match self.reg.read(HPRT::SPD) {
+            0 => Speed::High,
+            1 => Speed::Full,
+            2 => Speed::Low,
+            _ => Speed::Full, // 默认值
+        }
+    }
+
+    /// 清除连接检测中断（CONNDET；W1C）
+    pub(crate) fn clear_connect_detect(&self) {
+        let current = self.reg.get();
+        if current & HPRT_CONN_DET != 0 {
+            self.reg.set((current & !HPRT_W1C_MASK) | HPRT_CONN_DET);
+        }
+    }
+
+    pub(crate) fn write_safe(&self, value: u32) {
+        self.reg.set(value & !HPRT_W1C_MASK);
+    }
+
+    pub(crate) fn update_safe(&self, f: impl FnOnce(u32) -> u32) {
+        let value = self.reg.get() & !HPRT_W1C_MASK;
+        self.reg.set(f(value) & !HPRT_W1C_MASK);
+    }
+
+    pub(crate) fn write(&self, value: u32) {
+        self.reg.set(value);
+    }
+}
+
+/// host channel 寄存器组能力边界
+pub(crate) struct HcChannel<'a> {
+    reg: &'a HcChannelRegs,
+}
+
+impl<'a> HcChannel<'a> {
+    pub(crate) fn new(reg: &'a HcChannelRegs) -> Self {
+        Self { reg }
+    }
+
+    /// 通道是否已使能（HCCHAR.CHENA）
+    pub(crate) fn is_enabled(&self) -> bool {
+        self.reg.hcchar.is_set(HCCHAR::CHENA)
+    }
+
+    /// 通道使能：写 HCCHAR 并置 CHENA
+    pub(crate) fn enable(&self, hcchar: u32) {
+        self.reg.hcchar.set(hcchar | u32::from(HCCHAR::CHENA::SET));
+    }
+
+    /// 停止通道：CHENA 时写 CHENA|CHDIS
+    pub(crate) fn disable(&self) {
+        if self.is_enabled() {
+            self.reg
+                .hcchar
+                .modify(HCCHAR::CHENA::CLEAR + HCCHAR::CHDIS::SET);
+        }
+    }
+
+    /// 使能传输终止中断（CHHLTD；DDMA 下故障由硬件 halt 通道后随 CHHLTD 读出）
+    pub(crate) fn enable_irqs(&self) {
+        self.reg.hcintmsk.set(HCINT_CHHLTD);
+    }
+
+    /// 直接编程 HCINTMSK（ISO 路径按传输类型选择 XFERCOMPL + 故障位）。
+    pub(crate) fn set_hcintmsk(&self, value: u32) {
+        self.reg.hcintmsk.set(value);
+    }
+
+    /// 清除该通道所有已置位的中断（HCINT W1C 全清）
+    pub(crate) fn clear_all_irqs(&self) {
+        self.reg.hcint.set(HCINT_ALL_W1C);
+    }
+
+    /// 取走并确认一次通道中断，返回有效中断位（CHHLTD 时返回原始位）
+    pub(crate) fn take_irqs(&self) -> Option<u32> {
+        let raw = self.reg.hcint.get() & HCINT_TRANSFER_MASK;
+        let masked = raw & self.reg.hcintmsk.get();
+        if masked == 0 {
+            return None;
+        }
+        self.reg.hcint.set(raw);
+        Some(if masked & HCINT_CHHLTD != 0 {
+            raw
+        } else {
+            masked
+        })
+    }
+
+    pub(crate) fn set_hctsiz(&self, value: u32) {
+        self.reg.hctsiz.set(value);
+    }
+
+    pub(crate) fn set_hcsplt(&self, value: u32) {
+        self.reg.hcsplt.set(value);
+    }
+
+    /// BDMA: 设置缓冲区地址
+    /// DDMA: 设置描述符表地址
+    pub(crate) fn set_hcdma(&self, value: u32) {
+        self.reg.hcdma.set(value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+
+    #[test]
+    fn host_channel_count_reads_ghwcfg2_and_clamps() {
+        // 未预置（全零）→ NUM_HOST_CHAN = 0 → 钳制到 2。
+        let (mut backing, regs) = crate::backend::kmod::dwc2::testutil::test_regs();
+        assert_eq!(regs.host_channel_count(), 2);
+        assert!(!regs.is_support_ddma());
+
+        // 预置 8 通道 + DDMA。
+        crate::backend::kmod::dwc2::testutil::preset_hw_caps(&mut backing);
+        assert_eq!(regs.host_channel_count(), 8);
+        assert!(regs.is_support_ddma());
+    }
+
+    #[test]
+    fn hcchannel_take_irqs_returns_raw_reason_on_channel_halt() {
+        let (_backing, regs) = crate::backend::kmod::dwc2::testutil::test_regs();
+        let channel = regs.channel(5);
+
+        // 屏蔽位只有 CHHLTD：halt 时返回原始完整位（故障位随行）。
+        channel.set_hcintmsk(HCINT_CHHLTD);
+        regs.regs().hc[5].hcint.set(HCINT_CHHLTD | HCINT_STALL);
+        assert_eq!(channel.take_irqs(), Some(HCINT_CHHLTD | HCINT_STALL));
+
+        // CHHLTD 已置位时，未屏蔽的 NAK 等状态位也随原始值保留。
+        regs.regs().hc[5]
+            .hcint
+            .set(HCINT_CHHLTD | HCINT_STALL | HCINT_NAK);
+        assert_eq!(
+            channel.take_irqs(),
+            Some(HCINT_CHHLTD | HCINT_STALL | HCINT_NAK)
+        );
+
+        // 中断位已消费且无新事件 → None（内存兜底寄存器需显式清 W1C 状态）。
+        regs.regs().hc[5].hcint.set(0);
+        assert_eq!(channel.take_irqs(), None);
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/stats.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/stats.rs
@@ -1,0 +1,197 @@
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use super::Dwc2TransferFault;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct Dwc2TransferStats {
+    pub transfers: usize,
+    pub stages: usize,
+    pub dma_allocs: usize,
+    pub bounce_to_device_bytes: usize,
+    pub bounce_from_device_bytes: usize,
+    pub naks: usize,
+    pub xact_errors: usize,
+    pub timeouts: usize,
+    pub wait_iters: usize,
+    pub init_wait_iters: usize,
+    pub transfer_busy_wait_iters: usize,
+    pub irq_events: usize,
+    pub channel_completions: usize,
+}
+
+#[derive(Default)]
+pub(crate) struct Dwc2StatsInner {
+    transfers: AtomicUsize,
+    stages: AtomicUsize,
+    dma_allocs: AtomicUsize,
+    bounce_to_device_bytes: AtomicUsize,
+    bounce_from_device_bytes: AtomicUsize,
+    naks: AtomicUsize,
+    xact_errors: AtomicUsize,
+    timeouts: AtomicUsize,
+    init_wait_iters: AtomicUsize,
+    transfer_busy_wait_iters: AtomicUsize,
+    irq_events: AtomicUsize,
+    channel_completions: AtomicUsize,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct Dwc2Stats {
+    inner: Arc<Dwc2StatsInner>,
+}
+
+impl Dwc2Stats {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn reset(&self) {
+        self.inner.transfers.store(0, Ordering::Relaxed);
+        self.inner.stages.store(0, Ordering::Relaxed);
+        self.inner.dma_allocs.store(0, Ordering::Relaxed);
+        self.inner
+            .bounce_to_device_bytes
+            .store(0, Ordering::Relaxed);
+        self.inner
+            .bounce_from_device_bytes
+            .store(0, Ordering::Relaxed);
+        self.inner.naks.store(0, Ordering::Relaxed);
+        self.inner.xact_errors.store(0, Ordering::Relaxed);
+        self.inner.timeouts.store(0, Ordering::Relaxed);
+        self.inner.init_wait_iters.store(0, Ordering::Relaxed);
+        self.inner
+            .transfer_busy_wait_iters
+            .store(0, Ordering::Relaxed);
+        self.inner.irq_events.store(0, Ordering::Relaxed);
+        self.inner.channel_completions.store(0, Ordering::Relaxed);
+    }
+
+    pub(crate) fn snapshot(&self) -> Dwc2TransferStats {
+        let init_wait_iters = self.inner.init_wait_iters.load(Ordering::Relaxed);
+        let transfer_busy_wait_iters = self.inner.transfer_busy_wait_iters.load(Ordering::Relaxed);
+        Dwc2TransferStats {
+            transfers: self.inner.transfers.load(Ordering::Relaxed),
+            stages: self.inner.stages.load(Ordering::Relaxed),
+            dma_allocs: self.inner.dma_allocs.load(Ordering::Relaxed),
+            bounce_to_device_bytes: self.inner.bounce_to_device_bytes.load(Ordering::Relaxed),
+            bounce_from_device_bytes: self.inner.bounce_from_device_bytes.load(Ordering::Relaxed),
+            naks: self.inner.naks.load(Ordering::Relaxed),
+            xact_errors: self.inner.xact_errors.load(Ordering::Relaxed),
+            timeouts: self.inner.timeouts.load(Ordering::Relaxed),
+            wait_iters: init_wait_iters + transfer_busy_wait_iters,
+            init_wait_iters,
+            transfer_busy_wait_iters,
+            irq_events: self.inner.irq_events.load(Ordering::Relaxed),
+            channel_completions: self.inner.channel_completions.load(Ordering::Relaxed),
+        }
+    }
+
+    pub(crate) fn record_transfer(&self) {
+        self.inner.transfers.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_stage(&self) {
+        self.inner.stages.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_dma_alloc(&self) {
+        self.inner.dma_allocs.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_bounce_to_device(&self, bytes: usize) {
+        self.inner
+            .bounce_to_device_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_bounce_from_device(&self, bytes: usize) {
+        self.inner
+            .bounce_from_device_bytes
+            .fetch_add(bytes, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_fault(&self, fault: Dwc2TransferFault) {
+        match fault {
+            Dwc2TransferFault::Nak => {
+                self.inner.naks.fetch_add(1, Ordering::Relaxed);
+            }
+            Dwc2TransferFault::Xact => {
+                self.inner.xact_errors.fetch_add(1, Ordering::Relaxed);
+            }
+            Dwc2TransferFault::Stall
+            | Dwc2TransferFault::Ahb
+            | Dwc2TransferFault::Babble
+            | Dwc2TransferFault::FrameOverrun
+            | Dwc2TransferFault::DataToggle
+            | Dwc2TransferFault::HaltedWithoutComplete => {}
+        }
+    }
+
+    pub(crate) fn record_timeout(&self) {
+        self.inner.timeouts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_init_wait_iters(&self, iters: usize) {
+        self.inner
+            .init_wait_iters
+            .fetch_add(iters, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn record_transfer_busy_wait_iters(&self, iters: usize) {
+        self.inner
+            .transfer_busy_wait_iters
+            .fetch_add(iters, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_irq_event(&self) {
+        self.inner.irq_events.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_channel_completion(&self) {
+        self.inner
+            .channel_completions
+            .fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use super::*;
+
+    #[test]
+    fn stats_records_transfer_faults_and_wait_iterations() {
+        let stats = Dwc2Stats::new();
+
+        stats.record_transfer();
+        stats.record_stage();
+        stats.record_dma_alloc();
+        stats.record_bounce_to_device(9);
+        stats.record_bounce_from_device(9);
+        stats.record_fault(Dwc2TransferFault::Nak);
+        stats.record_fault(Dwc2TransferFault::Xact);
+        stats.record_timeout();
+        stats.record_transfer_busy_wait_iters(17);
+        stats.record_init_wait_iters(3);
+        stats.record_irq_event();
+        stats.record_channel_completion();
+
+        let snapshot = stats.snapshot();
+        assert_eq!(snapshot.transfers, 1);
+        assert_eq!(snapshot.stages, 1);
+        assert_eq!(snapshot.dma_allocs, 1);
+        assert_eq!(snapshot.bounce_to_device_bytes, 9);
+        assert_eq!(snapshot.bounce_from_device_bytes, 9);
+        assert_eq!(snapshot.naks, 1);
+        assert_eq!(snapshot.xact_errors, 1);
+        assert_eq!(snapshot.timeouts, 1);
+        assert_eq!(snapshot.transfer_busy_wait_iters, 17);
+        assert_eq!(snapshot.init_wait_iters, 3);
+        assert_eq!(snapshot.wait_iters, 20);
+        assert_eq!(snapshot.irq_events, 1);
+        assert_eq!(snapshot.channel_completions, 1);
+    }
+}

--- a/drivers/usb/usb-host/src/backend/kmod/dwc2/testutil.rs
+++ b/drivers/usb/usb-host/src/backend/kmod/dwc2/testutil.rs
@@ -1,0 +1,157 @@
+//! 共享的 host 单元测试基础设施：
+//! - `TestKernel`：确定性 DMA 假分配器（与 ehci 测试同款 mock）
+//! - 内存兜底寄存器窗口（`Vec<u32>` + `Dwc2Registers`），按
+//!   `register_structs!` 布局直接映射，无需真实硬件
+//! - `Dwc2::new` 需要的只读硬件参数（GHWCFG2/GHWCFG4）预置
+
+extern crate std;
+
+use alloc::{
+    alloc::{alloc_zeroed, dealloc},
+    sync::Arc,
+    vec,
+    vec::Vec,
+};
+use core::{
+    alloc::Layout,
+    num::NonZeroUsize,
+    ptr::NonNull,
+    sync::atomic::{AtomicU64, Ordering as AtomicOrdering},
+};
+
+use dma_api::{DmaAllocHandle, DmaConstraints, DmaDirection, DmaError, DmaMapHandle, DmaOp};
+
+use super::{
+    channel::{Dwc2ChannelCompletions, Dwc2PeriodicSchedule, HostChannelPool},
+    reg::{Dwc2Registers, GHWCFG2, GHWCFG4},
+};
+use crate::backend::kmod::osal::{Kernel, KernelOp};
+
+pub struct TestKernel;
+
+static TEST_DMA_ADDR: AtomicU64 = AtomicU64::new(0x1000);
+
+impl DmaOp for TestKernel {
+    fn page_size(&self) -> usize {
+        4096
+    }
+
+    unsafe fn alloc_contiguous(
+        &self,
+        constraints: DmaConstraints,
+        layout: Layout,
+    ) -> Option<DmaAllocHandle> {
+        // SAFETY: The test kernel models contiguous DMA with the same
+        // heap-backed allocation used for coherent DMA below.
+        unsafe { self.alloc_coherent(constraints, layout) }
+    }
+
+    unsafe fn dealloc_contiguous(&self, handle: DmaAllocHandle) {
+        // SAFETY: Handles returned by `alloc_contiguous` are created by
+        // `alloc_coherent`, so they must be released through the same mock
+        // deallocation path.
+        unsafe { self.dealloc_coherent(handle) }.expect("test coherent DMA release must succeed")
+    }
+
+    unsafe fn alloc_coherent(
+        &self,
+        constraints: DmaConstraints,
+        layout: Layout,
+    ) -> Option<DmaAllocHandle> {
+        // SAFETY: Unit tests request valid `Layout` values. The returned
+        // pointer is either null or points to a heap allocation owned by the
+        // DMA handle until `dealloc_coherent` consumes it.
+        let ptr = unsafe { alloc_zeroed(layout) };
+        let ptr = NonNull::new(ptr)?;
+        let align = constraints.align.max(layout.align()).max(1) as u64;
+        let size = layout.size().max(1) as u64;
+        let current = TEST_DMA_ADDR.fetch_add(size + align, AtomicOrdering::Relaxed);
+        let dma_addr = (current + align - 1) & !(align - 1);
+        // SAFETY: `ptr` and `layout` describe the allocation above, and
+        // `dma_addr` is a deterministic fake bus address used only by unit
+        // tests that never reaches real hardware.
+        Some(unsafe { DmaAllocHandle::new(ptr, dma_addr.into(), layout) })
+    }
+
+    unsafe fn dealloc_coherent(&self, handle: DmaAllocHandle) -> Result<(), DmaError> {
+        // SAFETY: The mock only creates coherent handles from `alloc_zeroed`
+        // with the stored layout, so deallocating with the same layout
+        // releases exactly that allocation.
+        unsafe { dealloc(handle.as_ptr().as_ptr(), handle.layout()) };
+        Ok(())
+    }
+
+    unsafe fn map_streaming(
+        &self,
+        _constraints: DmaConstraints,
+        addr: NonNull<u8>,
+        size: NonZeroUsize,
+        _direction: DmaDirection,
+    ) -> core::result::Result<DmaMapHandle, DmaError> {
+        let layout = Layout::from_size_align(size.get(), 1)?;
+        // SAFETY: This mock streaming map does not transfer ownership of
+        // `addr`; it records the caller-provided live buffer and a fake bus
+        // address for tests that only inspect programming values.
+        Ok(unsafe { DmaMapHandle::new(addr, (addr.as_ptr() as u64).into(), layout, None) })
+    }
+
+    unsafe fn unmap_streaming(&self, _handle: DmaMapHandle) {}
+}
+
+impl KernelOp for TestKernel {
+    fn delay(&self, _duration: core::time::Duration) {}
+}
+
+pub static TEST_KERNEL: TestKernel = TestKernel;
+
+pub fn test_kernel() -> Kernel {
+    Kernel::new(u64::MAX, &TEST_KERNEL)
+}
+
+/// 测试寄存器窗口：4KB 零初始化，按 `Dwc2Regs` 布局映射。
+/// 返回持有内存的 `Vec` 与指向同一内存的寄存器句柄；`Vec` 存活期内
+/// 不得重新分配。
+pub fn test_regs() -> (Vec<u32>, Dwc2Registers) {
+    let mut backing = vec![0u32; 1024];
+    let base = NonNull::new(backing.as_mut_ptr().cast::<u8>()).unwrap();
+    (backing, Dwc2Registers::new(base))
+}
+
+/// 预置只读硬件参数（GHWCFG2 为 InternalDMA + 8 通道，GHWCFG4 支持
+/// 描述符 DMA 与 16 位 UTMI）。只读寄存器无法经 tock 写入，直接按
+/// `register_structs!` 布局写回兜底内存。
+pub fn preset_hw_caps(backing: &mut Vec<u32>) {
+    let base = backing.as_mut_ptr().cast::<u8>();
+    unsafe {
+        // GHWCFG2 @ 0x048（InternalDMA、NUM_HOST_CHAN = 7 → 8 通道）。
+        core::ptr::write_volatile(
+            base.add(0x048).cast::<u32>(),
+            (GHWCFG2::ARCHITECTURE::InternalDma + GHWCFG2::NUM_HOST_CHAN.val(7)).value,
+        );
+        // GHWCFG4 @ 0x050（DESC_DMA 支持、UTMI 16 位）。
+        core::ptr::write_volatile(
+            base.add(0x050).cast::<u32>(),
+            (GHWCFG4::DESC_DMA::SET + GHWCFG4::UTMI_PHY_DATA_WIDTH::Width16).value,
+        );
+    }
+}
+
+/// 构造通道池基础设施
+/// 返回的 `Vec<u32>` 是寄存器兜底内存，调用方必须保持存活到测试结束。
+#[allow(clippy::type_complexity)]
+pub fn channel_fixture(
+    channels: u8,
+) -> (
+    Vec<u32>,
+    Dwc2Registers,
+    Kernel,
+    Dwc2ChannelCompletions,
+    HostChannelPool,
+) {
+    let (backing, regs) = test_regs();
+    let kernel = test_kernel();
+    let completions = Dwc2ChannelCompletions::new();
+    let periodic = Arc::new(Dwc2PeriodicSchedule::new(&kernel).unwrap());
+    let pool = HostChannelPool::new(channels, completions.clone(), periodic);
+    (backing, regs, kernel, completions, pool)
+}


### PR DESCRIPTION
## Summary

Migrate the DWC2 host backend from the monolithic buffer-DMA implementation on `dev` to the modular stream/Plan/DDMA implementation from the `v4l2` branch.

No V4L2 changes are included.

## Changes

- Replace `kmod/dwc2/mod.rs` with modular `channel`/`dma`/`reg`/`params` layout
- Port non-ISO Plan/phase DDMA path and ISO resident-stream path
- Adapt DWC2 endpoint lifecycle to current `DeviceOp`/`EndpointHandle` API
- Adapt `IrqSlotLock` to `ax_sync::SpinLock` IRQ-save mode
- Add root-port disconnect reporting
- Move SG2002 board defaults to `ax-driver` platform glue
- Remove obsolete `Dwc2TransferStats` API and board busy-wait check
- Add `crab-usb` to the std test whitelist

## Validation

- `cargo fmt --all -- --check`
- `cargo xtask test` (all std tests, including `crab-usb` 49 tests)
- `cargo xtask clippy --package crab-usb` 4/4
- `cargo xtask clippy --package arceos-axtest-sg2002-usb-msc` 2/2
- `cargo clippy -p ax-driver --no-deps --features sg2002-dwc2 -- -D warnings`
- `cargo clippy -p starry-kernel --no-deps --features 'sg2002 ax-driver/sg2002-dwc2' -- -D warnings`
- `cargo xtask sync-lint --since origin/dev`
- `cargo xtask lock-lint`

Board-level DWC2 USB MSC regression still needs `aka-00-sg2002` self-hosted CI/manual board run.