### PR TITLE
feat(starry-kernel): transparent huge pages (2 MiB THP-lite) for private anonymous memory

### DIFF
--- a/memory/ax-alloc/src/buddy_slab.rs
+++ b/memory/ax-alloc/src/buddy_slab.rs
@@ -288,6 +288,15 @@ impl GlobalAllocator {
             .dealloc(kind, num_pages * PAGE_SIZE);
     }
 
+    /// Explodes a contiguous page allocation at `pos` into independently
+    /// freeable 4 KiB pages (transparent-huge-page → 4 KiB split). The block's
+    /// pages stay allocated and their total byte count is unchanged, so the
+    /// usage counters are untouched here; each 4 KiB page is later released via
+    /// [`dealloc_pages`](Self::dealloc_pages)`(.., 1, ..)`.
+    pub fn split_pages(&self, pos: usize) {
+        self.inner.lock_irqsave().split_pages(pos);
+    }
+
     /// Returns the number of allocated bytes in the allocator backend.
     pub fn used_bytes(&self) -> usize {
         self.inner.lock_irqsave().allocated_bytes()

--- a/memory/buddy-slab-allocator/Cargo.toml
+++ b/memory/buddy-slab-allocator/Cargo.toml
@@ -42,6 +42,9 @@ log = "0.4"
 
 [features]
 axtest = ["dep:axtest"]
+# Pull ax-sync's std `SpinOps` implementation so the crate's host tests
+# (which exercise `GlobalAllocator`) link off-target under `cargo xtask test`.
+host-test = ["ax-sync/host-test"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(axtest)'] }

--- a/memory/buddy-slab-allocator/src/buddy/mod.rs
+++ b/memory/buddy-slab-allocator/src/buddy/mod.rs
@@ -748,6 +748,57 @@ impl<const PAGE_SIZE: usize> BuddyAllocator<PAGE_SIZE> {
         Self::dealloc_in_section(section, pfn, order);
     }
 
+    /// Explode an allocated block into independently-freeable order-0 pages.
+    ///
+    /// `addr` must be the head address of a block previously obtained from
+    /// [`alloc_pages`](Self::alloc_pages) that is still allocated. After this
+    /// call every 4 KiB page in the original block is an independent order-0
+    /// `Allocated` block, so each page can be freed one at a time via
+    /// `dealloc_pages(page_addr, 1)` and coalesces normally with its buddies on
+    /// free. This performs a metadata rewrite only — no page contents move and
+    /// the total allocated byte count is unchanged.
+    ///
+    /// This is the physical-frame half of a transparent-huge-page → 4 KiB
+    /// split: the 2 MiB VMSAv8 block PTE is re-mapped as 512 leaf PTEs while
+    /// the underlying order-9 buddy block is exploded here so the 512 pages can
+    /// later be unmapped/freed individually.
+    pub fn split_pages(&mut self, addr: usize) {
+        let Some(section) = self.find_section_by_addr_mut(addr) else {
+            debug_assert!(
+                false,
+                "split_pages called with address outside all sections"
+            );
+            return;
+        };
+
+        debug_assert!(is_aligned(addr, PAGE_SIZE));
+        let head_pfn = (addr - section.heap_start) / PAGE_SIZE;
+        debug_assert!(head_pfn < section.max_pages);
+        let stored = unsafe { &*section.meta.add(head_pfn) };
+        debug_assert!(
+            stored.flags == PageFlags::Allocated,
+            "split_pages called on non-allocated block"
+        );
+        let order = stored.order as usize;
+        let count = 1usize << order;
+        debug_assert!(head_pfn + count <= section.max_pages);
+
+        // Re-tag every page (head included) as an independent order-0 allocated
+        // block. Free-list links are irrelevant for allocated pages, but reset
+        // them so a later `dealloc_in_section` sees clean metadata before it
+        // pushes the freed page onto a free list.
+        for i in 0..count {
+            let pfn = head_pfn + i;
+            unsafe {
+                let m = &mut *section.meta.add(pfn);
+                m.flags = PageFlags::Allocated;
+                m.order = 0;
+                m.prev = PFN_NONE;
+                m.next = PFN_NONE;
+            }
+        }
+    }
+
     /// Mark the page at `addr` with the given flags (used by slab to tag pages).
     ///
     /// # Safety

--- a/memory/buddy-slab-allocator/src/global.rs
+++ b/memory/buddy-slab-allocator/src/global.rs
@@ -205,6 +205,12 @@ impl<const PAGE_SIZE: usize> GlobalAllocator<PAGE_SIZE> {
         self.buddy().dealloc_pages(addr, count);
     }
 
+    /// Explode an allocated block at `addr` into independently-freeable order-0
+    /// pages. See [`BuddyAllocator::split_pages`](crate::buddy::BuddyAllocator::split_pages).
+    pub fn split_pages(&self, addr: usize) {
+        self.buddy().split_pages(addr);
+    }
+
     /// Allocate pages with physical address below 4 GiB.
     pub fn alloc_pages_lowmem(&self, count: usize, align: usize) -> AllocResult<usize> {
         self.buddy().alloc_pages_lowmem(count, align)

--- a/memory/buddy-slab-allocator/tests/integration_test.rs
+++ b/memory/buddy-slab-allocator/tests/integration_test.rs
@@ -79,6 +79,72 @@ fn buddy_basic_alloc_dealloc() {
 }
 
 #[test]
+fn buddy_split_pages_explodes_block_into_freeable_4k_pages() {
+    // A 2 MiB (order-9) block must be splittable into 512 independently
+    // freeable 4 KiB pages, and freeing all of them must coalesce back to the
+    // original block (re-allocatable as one 2 MiB block again).
+    const ALIGN_2M: usize = 2 * 1024 * 1024;
+    const PAGES_2M: usize = ALIGN_2M / PAGE_SIZE; // 512
+    let mut region = HostRegion::new(buddy_region_size(TEST_HEAP_SIZE) + ALIGN_2M, ALIGN_2M);
+    let mut buddy = BuddyAllocator::<PAGE_SIZE>::new();
+    let _section = init_buddy_with_heap_alignment(&mut buddy, &mut region, ALIGN_2M);
+
+    let free_start = buddy.free_pages();
+
+    // One contiguous, 2 MiB-aligned order-9 block.
+    let block = buddy.alloc_pages(PAGES_2M, ALIGN_2M).unwrap();
+    assert_eq!(block % ALIGN_2M, 0);
+    assert_eq!(buddy.free_pages(), free_start - PAGES_2M);
+
+    // Explode it: every 4 KiB page becomes an independent order-0 allocation.
+    buddy.split_pages(block);
+    // Splitting is metadata-only; occupancy is unchanged.
+    assert_eq!(buddy.free_pages(), free_start - PAGES_2M);
+
+    // Free all 512 sub-pages individually, in a shuffled order to exercise
+    // buddy coalescing from both directions.
+    let mut order: Vec<usize> = (0..PAGES_2M).collect();
+    order.rotate_left(37);
+    for i in order {
+        buddy.dealloc_pages(block + i * PAGE_SIZE, 1);
+    }
+    assert_eq!(buddy.free_pages(), free_start);
+
+    // Full coalescing back to order-9: the 2 MiB block is allocatable again.
+    let block2 = buddy.alloc_pages(PAGES_2M, ALIGN_2M).unwrap();
+    assert_eq!(block2, block);
+    buddy.dealloc_pages(block2, PAGES_2M);
+    assert_eq!(buddy.free_pages(), free_start);
+}
+
+#[test]
+fn buddy_split_pages_allows_partial_free_of_exploded_block() {
+    // After split, freeing only a sub-range leaves the rest allocated; the
+    // remaining pages stay usable and freeable independently.
+    const ALIGN_2M: usize = 2 * 1024 * 1024;
+    const PAGES_2M: usize = ALIGN_2M / PAGE_SIZE;
+    let mut region = HostRegion::new(buddy_region_size(TEST_HEAP_SIZE) + ALIGN_2M, ALIGN_2M);
+    let mut buddy = BuddyAllocator::<PAGE_SIZE>::new();
+    let _section = init_buddy_with_heap_alignment(&mut buddy, &mut region, ALIGN_2M);
+
+    let free_start = buddy.free_pages();
+    let block = buddy.alloc_pages(PAGES_2M, ALIGN_2M).unwrap();
+    buddy.split_pages(block);
+
+    // Free the first half only.
+    for i in 0..PAGES_2M / 2 {
+        buddy.dealloc_pages(block + i * PAGE_SIZE, 1);
+    }
+    assert_eq!(buddy.free_pages(), free_start - PAGES_2M / 2);
+
+    // Free the second half; everything coalesces back.
+    for i in PAGES_2M / 2..PAGES_2M {
+        buddy.dealloc_pages(block + i * PAGE_SIZE, 1);
+    }
+    assert_eq!(buddy.free_pages(), free_start);
+}
+
+#[test]
 fn buddy_alignment() {
     // Heap must be aligned to the highest alignment we test (PAGE_SIZE * 4)
     let mut region = HostRegion::new(

--- a/memory/page-table-generic/src/frame.rs
+++ b/memory/page-table-generic/src/frame.rs
@@ -224,6 +224,75 @@ where
         child.remap_recursive(vaddr, paddr, config, level - 1)
     }
 
+    /// Break-before-make split of the huge block covering `vaddr` into a child table
+    /// of finer-granule entries, using the caller-reserved, pre-zeroed `reserved`
+    /// table so the commit cannot fail for lack of memory.
+    ///
+    /// Handles a present block and a *not-present* block (an `mprotect(PROT_NONE)`
+    /// over a huge area) uniformly: every arch encodes `huge(is_dir)` structurally
+    /// (present-independent), so both are reached through the same short-circuit as
+    /// [`Self::protect_recursive`] — no separate not-present path is needed.
+    ///
+    /// The `reserved` frame is consumed only on success (installed as the new table).
+    /// On any error it is left untouched for the caller to reclaim. Returns the size
+    /// of the block that was split; `NotMapped` if `vaddr` is not covered by a block.
+    pub fn split_huge_page_recursive(
+        &mut self,
+        vaddr: VirtAddr,
+        level: usize,
+        mut reserved: Frame<T, A>,
+    ) -> PagingResult<usize> {
+        let index = Self::virt_to_index(vaddr, level);
+        let entry = self.as_slice()[index];
+        if entry.unused() {
+            return Err(PagingError::not_mapped());
+        }
+        let is_dir = level > 1;
+        // A block (present OR not-present) reports `huge()==true` on every arch — the
+        // same short-circuit `protect_recursive`/`find_occupied_leaf` use — so there
+        // is no separate not-present path. `level == 1` is never `huge` (is_dir is
+        // false there), so reaching this branch implies `level >= 2`.
+        if entry.huge(is_dir) {
+            let block_paddr = entry.paddr(is_dir);
+            let block_config = entry.config(is_dir);
+            let child_level = level - 1;
+            // A 1 GiB block splits into 2 MiB blocks, which are themselves huge.
+            let child_is_huge = child_level > 1;
+            let child_stride = Self::level_size(child_level);
+
+            // Populate the reserved child table fully BEFORE the commit, so the
+            // instant it is installed its leaves are already live (no transient empty
+            // table window). A block frame is never physical 0, so a not-present
+            // block's empty config still yields framed (non-`unused`) leaves.
+            let leaves = reserved.as_slice_mut();
+            for (i, slot) in leaves.iter_mut().enumerate() {
+                let sub = PhysAddr::from_usize(block_paddr.as_usize() + i * child_stride);
+                *slot = T::P::new_page(sub, block_config, child_is_huge);
+            }
+
+            // Break-before-make, mirroring the reclaim ordering in `unmap`
+            // (clear -> flush -> free): clear the live block, invalidate its VA, then
+            // install the table. Installing over the now-invalid slot is a
+            // not-present -> present transition needing no further flush.
+            self.as_slice_mut()[index].clear();
+            T::flush(Some(vaddr));
+            self.as_slice_mut()[index] = T::P::new_table(reserved.paddr);
+            return Ok(Self::level_size(level));
+        }
+        if level == 1 {
+            // A plain finest-granule leaf: nothing to split.
+            return Err(PagingError::not_mapped());
+        }
+        if !entry.present() {
+            return Err(PagingError::hierarchy_error(
+                "non-present intermediate entry is not a leaf",
+            ));
+        }
+
+        let mut child = Self::from_paddr(entry.paddr(is_dir), self.allocator.clone());
+        child.split_huge_page_recursive(vaddr, level - 1, reserved)
+    }
+
     /// 重建完整的虚拟地址
     /// 从基地址和索引计算完整的虚拟地址
     pub fn reconstruct_vaddr(index: usize, level: usize, base_vaddr: VirtAddr) -> VirtAddr {

--- a/memory/page-table-generic/src/frame.rs
+++ b/memory/page-table-generic/src/frame.rs
@@ -20,6 +20,18 @@ impl<T: TableMeta, A: FrameAllocator> core::fmt::Debug for Frame<T, A> {
     }
 }
 
+/// How [`Frame::split_huge_page_recursive`] seeds the reserved child table.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SplitFill {
+    /// Inherit the block's frame + flags into all child leaves, so the mapping is
+    /// unchanged at a finer granularity (the transparent `split_huge_page` path).
+    Inherit,
+    /// Leave the reserved frame zeroed for the caller to populate with per-leaf
+    /// (possibly non-contiguous) mappings — the scattered COW-break path, where the
+    /// caller maps 512 arbitrary frames itself.
+    Empty,
+}
+
 impl<T, A> Frame<T, A>
 where
     T: TableMeta,
@@ -233,15 +245,21 @@ where
     /// (present-independent), so both are reached through the same short-circuit as
     /// [`Self::protect_recursive`] — no separate not-present path is needed.
     ///
+    /// `fill` selects whether the child leaves inherit the block's mapping
+    /// ([`SplitFill::Inherit`]) or are left unmapped for the caller to populate
+    /// ([`SplitFill::Empty`]).
+    ///
     /// The `reserved` frame is consumed only on success (installed as the new table).
-    /// On any error it is left untouched for the caller to reclaim. Returns the size
-    /// of the block that was split; `NotMapped` if `vaddr` is not covered by a block.
-    pub fn split_huge_page_recursive(
+    /// On any error it is left untouched for the caller to reclaim. Returns the split
+    /// block's old `(paddr, config, size)`; `NotMapped` if `vaddr` is not covered by a
+    /// block.
+    pub(crate) fn split_huge_page_recursive(
         &mut self,
         vaddr: VirtAddr,
         level: usize,
         mut reserved: Frame<T, A>,
-    ) -> PagingResult<usize> {
+        fill: SplitFill,
+    ) -> PagingResult<(PhysAddr, PteConfigOf<T>, usize)> {
         // A child table is one frame; `ReservedTable` enforces this at the type level,
         // and the fill/install below address only the first frame.
         debug_assert_eq!(
@@ -261,19 +279,24 @@ where
         if entry.huge(is_dir) {
             let block_paddr = entry.paddr(is_dir);
             let block_config = entry.config(is_dir);
-            let child_level = level - 1;
-            // A 1 GiB block splits into 2 MiB blocks, which are themselves huge.
-            let child_is_huge = child_level > 1;
-            let child_stride = Self::level_size(child_level);
 
-            // Populate the reserved child table fully BEFORE the commit, so the
-            // instant it is installed its leaves are already live (no transient empty
-            // table window). A block frame is never physical 0, so a not-present
+            // Only a transparent (`Inherit`) split pre-populates the child leaves, so
+            // the mapping is unchanged the instant the table is installed (no live
+            // empty-table window). `Empty` leaves the reserved frame zeroed
+            // (`Frame::new` zeroed it) so the caller can install scattered per-leaf
+            // maps — auto-inherited leaves would make the caller's `map` hit
+            // `MappingConflict`. A block frame is never physical 0, so a not-present
             // block's empty config still yields framed (non-`unused`) leaves.
-            let leaves = reserved.as_slice_mut();
-            for (i, slot) in leaves.iter_mut().enumerate() {
-                let sub = PhysAddr::from_usize(block_paddr.as_usize() + i * child_stride);
-                *slot = T::P::new_page(sub, block_config, child_is_huge);
+            if fill == SplitFill::Inherit {
+                let child_level = level - 1;
+                // A 1 GiB block splits into 2 MiB blocks, which are themselves huge.
+                let child_is_huge = child_level > 1;
+                let child_stride = Self::level_size(child_level);
+                let leaves = reserved.as_slice_mut();
+                for (i, slot) in leaves.iter_mut().enumerate() {
+                    let sub = PhysAddr::from_usize(block_paddr.as_usize() + i * child_stride);
+                    *slot = T::P::new_page(sub, block_config, child_is_huge);
+                }
             }
 
             // Break-before-make, mirroring the reclaim ordering in `unmap`
@@ -283,7 +306,7 @@ where
             self.as_slice_mut()[index].clear();
             T::flush(Some(vaddr));
             self.as_slice_mut()[index] = T::P::new_table(reserved.paddr);
-            return Ok(Self::level_size(level));
+            return Ok((block_paddr, block_config, Self::level_size(level)));
         }
         if level == 1 {
             // A plain finest-granule leaf: nothing to split.
@@ -296,7 +319,7 @@ where
         }
 
         let mut child = Self::from_paddr(entry.paddr(is_dir), self.allocator.clone());
-        child.split_huge_page_recursive(vaddr, level - 1, reserved)
+        child.split_huge_page_recursive(vaddr, level - 1, reserved, fill)
     }
 
     /// 重建完整的虚拟地址

--- a/memory/page-table-generic/src/frame.rs
+++ b/memory/page-table-generic/src/frame.rs
@@ -242,6 +242,12 @@ where
         level: usize,
         mut reserved: Frame<T, A>,
     ) -> PagingResult<usize> {
+        // A child table is one frame; `ReservedTable` enforces this at the type level,
+        // and the fill/install below address only the first frame.
+        debug_assert_eq!(
+            reserved.frames, 1,
+            "split reserves exactly one child-table frame"
+        );
         let index = Self::virt_to_index(vaddr, level);
         let entry = self.as_slice()[index];
         if entry.unused() {

--- a/memory/page-table-generic/src/lib.rs
+++ b/memory/page-table-generic/src/lib.rs
@@ -96,10 +96,17 @@ pub trait PageTableEntry: Debug + Sync + Send + Clone + Copy + Sized + 'static {
 
     /// Returns whether this entry is a block mapping at the current level.
     ///
-    /// This MUST be **present-independent** (a structural marker): a not-present
-    /// block — e.g. one left by an `mprotect(PROT_NONE)` over a huge area — must
-    /// still report `true`. The walk (`find_occupied_leaf`), `unmap`, and the huge
-    /// split rely on it to tell a not-present block apart from a table pointer.
+    /// A *present* block must report `true` on every format. Recognizing a
+    /// *not-present* block (e.g. one left by an `mprotect(PROT_NONE)` over a huge
+    /// area, which keeps the physical address but clears the permission bits) is
+    /// **format-dependent**: CPU page tables preserve the block descriptor and
+    /// report `true`, whereas nested/second-stage formats (EPT/NPT) that encode an
+    /// empty-permission entry as a bare zero report `false`. The not-present-block
+    /// operations — `peek_huge_block` and the huge `split_huge_page` — need the
+    /// present-independent form; on a format that drops it they see the entry as
+    /// unmapped and return `NotMapped` (a *present* block still splits on every
+    /// format). `find_occupied_leaf`, `unmap`, and the split use this to tell a
+    /// block apart from a table pointer.
     fn huge(&self, is_dir: bool) -> bool;
 
     /// Returns whether this entry contains no descriptor state at all.

--- a/memory/page-table-generic/src/lib.rs
+++ b/memory/page-table-generic/src/lib.rs
@@ -95,6 +95,11 @@ pub trait PageTableEntry: Debug + Sync + Send + Clone + Copy + Sized + 'static {
     fn present(&self) -> bool;
 
     /// Returns whether this entry is a block mapping at the current level.
+    ///
+    /// This MUST be **present-independent** (a structural marker): a not-present
+    /// block — e.g. one left by an `mprotect(PROT_NONE)` over a huge area — must
+    /// still report `true`. The walk (`find_occupied_leaf`), `unmap`, and the huge
+    /// split rely on it to tell a not-present block apart from a table pointer.
     fn huge(&self, is_dir: bool) -> bool;
 
     /// Returns whether this entry contains no descriptor state at all.

--- a/memory/page-table-generic/src/map.rs
+++ b/memory/page-table-generic/src/map.rs
@@ -257,6 +257,17 @@ where
                     // 子页表完全为空，可以回收
                     // 清除指向子页表的PTE
                     pte_ref.clear();
+                    // Invalidate the TLB for the range this table covered BEFORE
+                    // returning its frame to the allocator. The leaf entries were
+                    // already flushed by the recursive unmap above, but the
+                    // now-cleared parent descriptor / table-walk cache is not — so
+                    // without this a concurrent core can reallocate and write the
+                    // freed frame while a stale walk still reads it as page-table
+                    // entries, translating to arbitrary physical memory. This
+                    // completes break-before-free for the intermediate table.
+                    if config.flush {
+                        T::flush(Some(vaddr));
+                    }
                     allocator.dealloc_frame(child_paddr);
                 } else {
                     // 子页表仍有有效映射，不能回收

--- a/memory/page-table-generic/src/table.rs
+++ b/memory/page-table-generic/src/table.rs
@@ -363,7 +363,10 @@ impl<T: TableMeta, A: FrameAllocator> PageTableRef<T, A> {
     ///
     /// Unlike [`Self::translate`], this also finds a *not-present* block (e.g. one
     /// left by `mprotect(PROT_NONE)` over a huge area), since `find_occupied_leaf`
-    /// stops at `huge()` before the present check.
+    /// stops at `huge()` before the present check — but only on PTE formats whose
+    /// [`PageTableEntry::huge`] is present-independent. On a nested/second-stage
+    /// format (EPT/NPT) that encodes a not-present block as a bare zero, such a
+    /// block reads as unmapped and this returns `None`.
     pub fn peek_huge_block(&self, vaddr: VirtAddr) -> Option<(PhysAddr, PteConfigOf<T>, usize)> {
         let (pte, level) = self
             .root
@@ -409,6 +412,11 @@ impl<T: TableMeta, A: FrameAllocator> PageTableRef<T, A> {
     /// Convenience: reserve a table and split the huge block covering `vaddr` in one
     /// call (the transparent-huge-page fault path). Errors with `NotMapped` if
     /// `vaddr` is not covered by a block, or `NoMemory` if the reservation fails.
+    ///
+    /// A *present* block splits on any format. Splitting a *not-present* block
+    /// requires a present-independent [`PageTableEntry::huge`] (CPU page tables);
+    /// on a nested/second-stage format (EPT/NPT) that zeroes such an entry the
+    /// block reads as unmapped and this returns `NotMapped`.
     pub fn split_huge_page(&mut self, vaddr: VirtAddr) -> PagingResult<usize> {
         let reserved = Frame::<T, A>::new(self.root.allocator.clone())?;
         self.split_huge_page_with(vaddr, reserved)

--- a/memory/page-table-generic/src/table.rs
+++ b/memory/page-table-generic/src/table.rs
@@ -339,6 +339,81 @@ impl<T: TableMeta, A: FrameAllocator> PageTableRef<T, A> {
         Ok(page_size)
     }
 
+    /// Reserve a pre-zeroed child table for an upcoming [`Self::split_huge_page_with`].
+    ///
+    /// Reserving the frame up front (before, say, an address-space lock is taken)
+    /// lets the split itself commit infallibly — it never allocates in the
+    /// break-before-make window.
+    pub fn alloc_intermediate_table(&self) -> PagingResult<Frame<T, A>> {
+        Frame::<T, A>::new(self.root.allocator.clone())
+    }
+
+    /// Return a reserved table that a split did not consume (the rollback path).
+    ///
+    /// Freeing an *uninstalled* reserved frame needs no TLB flush: it was never
+    /// reachable by any page-table walk (contrast reclaiming a live table in
+    /// `unmap`, which must flush before freeing).
+    pub fn dealloc_intermediate_table(&self, table: Frame<T, A>) {
+        self.root.allocator.dealloc_frame(table.paddr);
+    }
+
+    /// Peek the huge block (present or not-present) covering `vaddr`: its frame,
+    /// leaf config, and page size — without mutating. Returns `None` if `vaddr` is
+    /// not covered by a block (a plain finest-granule leaf, or unmapped).
+    ///
+    /// Unlike [`Self::translate`], this also finds a *not-present* block (e.g. one
+    /// left by `mprotect(PROT_NONE)` over a huge area), since `find_occupied_leaf`
+    /// stops at `huge()` before the present check.
+    pub fn peek_huge_block(&self, vaddr: VirtAddr) -> Option<(PhysAddr, PteConfigOf<T>, usize)> {
+        let (pte, level) = self
+            .root
+            .find_occupied_leaf(vaddr, Frame::<T, A>::PT_LEVEL)
+            .ok()?;
+        let is_dir = level > 1;
+        if !pte.huge(is_dir) {
+            return None; // a plain finest-granule leaf, not a block
+        }
+        Some((
+            pte.paddr(is_dir),
+            pte.config(is_dir),
+            Frame::<T, A>::level_size(level),
+        ))
+    }
+
+    /// Split the huge block covering `vaddr` into a child table of finer-granule
+    /// entries, using a `reserved` table from [`Self::alloc_intermediate_table`].
+    /// The child inherits the block's frame and flags, so the mapping is unchanged
+    /// at a finer granularity. Frees the reservation on error. Returns the split
+    /// block's size, or `NotMapped` if `vaddr` is not covered by a block.
+    pub fn split_huge_page_with(
+        &mut self,
+        vaddr: VirtAddr,
+        reserved: Frame<T, A>,
+    ) -> PagingResult<usize> {
+        let reserved_paddr = reserved.paddr;
+        match self
+            .root
+            .split_huge_page_recursive(vaddr, Frame::<T, A>::PT_LEVEL, reserved)
+        {
+            Ok(size) => Ok(size),
+            Err(err) => {
+                // Only the block branch installs the reservation; on any error it was
+                // never installed, so roll it back. No flush: an uninstalled frame is
+                // unreachable by any TLB walk.
+                self.root.allocator.dealloc_frame(reserved_paddr);
+                Err(err)
+            }
+        }
+    }
+
+    /// Convenience: reserve a table and split the huge block covering `vaddr` in one
+    /// call (the transparent-huge-page fault path). Errors with `NotMapped` if
+    /// `vaddr` is not covered by a block, or `NoMemory` if the reservation fails.
+    pub fn split_huge_page(&mut self, vaddr: VirtAddr) -> PagingResult<usize> {
+        let reserved = Frame::<T, A>::new(self.root.allocator.clone())?;
+        self.split_huge_page_with(vaddr, reserved)
+    }
+
     /// Changes flags for a region. Unmapped base pages are skipped.
     pub fn protect_region(
         &mut self,

--- a/memory/page-table-generic/src/table.rs
+++ b/memory/page-table-generic/src/table.rs
@@ -5,7 +5,7 @@ use ax_memory_addr::MemoryAddr;
 use crate::{
     FrameAllocator, PageTableEntry, PagingError, PagingResult, PhysAddr, PteConfigOf, TableMeta,
     VirtAddr,
-    frame::Frame,
+    frame::{Frame, SplitFill},
     map::{MapConfig, MapRecursiveConfig, UnmapConfig, UnmapRecursiveConfig},
     walk::{PageTableWalker, WalkConfig},
 };
@@ -415,15 +415,54 @@ impl<T: TableMeta, A: FrameAllocator> PageTableRef<T, A> {
         // so the split installs and (on error) reclaims the whole reservation.
         let reserved = reserved.frame;
         let reserved_paddr = reserved.paddr;
-        match self
-            .root
-            .split_huge_page_recursive(vaddr, Frame::<T, A>::PT_LEVEL, reserved)
-        {
-            Ok(size) => Ok(size),
+        match self.root.split_huge_page_recursive(
+            vaddr,
+            Frame::<T, A>::PT_LEVEL,
+            reserved,
+            SplitFill::Inherit,
+        ) {
+            Ok((_, _, size)) => Ok(size),
             Err(err) => {
                 // Only the block branch installs the reservation; on any error it was
                 // never installed, so roll it back. No flush: an uninstalled frame is
                 // unreachable by any TLB walk.
+                self.root.allocator.dealloc_frame(reserved_paddr);
+                Err(err)
+            }
+        }
+    }
+
+    /// Split the huge block covering `vaddr` into an **empty** (zeroed) child table,
+    /// using a `reserved` table from [`Self::alloc_intermediate_table`], and return
+    /// the old block's `(paddr, config, size)`.
+    ///
+    /// Unlike [`Self::split_huge_page_with`], the child leaves are left unmapped: the
+    /// caller installs them itself (e.g. 512 non-contiguous 4 KiB frames from a
+    /// fragmented COW break) via [`Self::map`], which would otherwise hit
+    /// `MappingConflict` against auto-inherited leaves. The block's VA range reads as
+    /// unmapped between this call and the caller's leaf maps, so callers must hold the
+    /// address-space lock across both. Frees the reservation on error (no flush — it
+    /// was never installed); `NotMapped` if `vaddr` is not covered by a block.
+    ///
+    /// The single-frame `ReservedTable` invariant and the not-present-block handling
+    /// are inherited from [`Self::split_huge_page_with`] (a not-present block splits
+    /// only on a present-independent [`PageTableEntry::huge`]; a zeroing EPT/NPT format
+    /// degrades to `NotMapped`).
+    pub fn split_huge_block_to_empty_table(
+        &mut self,
+        vaddr: VirtAddr,
+        reserved: ReservedTable<T, A>,
+    ) -> PagingResult<(PhysAddr, PteConfigOf<T>, usize)> {
+        let reserved = reserved.frame;
+        let reserved_paddr = reserved.paddr;
+        match self.root.split_huge_page_recursive(
+            vaddr,
+            Frame::<T, A>::PT_LEVEL,
+            reserved,
+            SplitFill::Empty,
+        ) {
+            Ok(triple) => Ok(triple),
+            Err(err) => {
                 self.root.allocator.dealloc_frame(reserved_paddr);
                 Err(err)
             }

--- a/memory/page-table-generic/src/table.rs
+++ b/memory/page-table-generic/src/table.rs
@@ -12,6 +12,20 @@ use crate::{
 
 const TARGETED_FLUSH_LIMIT: usize = 32;
 
+/// A single reserved child-table frame from [`PageTableRef::alloc_intermediate_table`],
+/// consumed by [`PageTableRef::split_huge_page_with`].
+///
+/// An intermediate (child) page table is always exactly one frame. Keeping the
+/// reservation a distinct, move-only single-frame type — rather than the general,
+/// possibly multi-frame [`Frame`] (a root spans [`Frame::new_root`]'s several
+/// frames) — makes it impossible to hand the split a multi-frame reservation, whose
+/// extra frames it would neither install nor reclaim (leaking them and building a
+/// malformed table). The wrapped frame is always single-frame: the only constructor
+/// allocates it via the single-frame [`Frame::new`].
+pub struct ReservedTable<T: TableMeta, A: FrameAllocator> {
+    frame: Frame<T, A>,
+}
+
 pub struct PageTable<T: TableMeta, A: FrameAllocator> {
     inner: PageTableRef<T, A>,
     #[cfg(feature = "copy-from")]
@@ -339,13 +353,17 @@ impl<T: TableMeta, A: FrameAllocator> PageTableRef<T, A> {
         Ok(page_size)
     }
 
-    /// Reserve a pre-zeroed child table for an upcoming [`Self::split_huge_page_with`].
+    /// Reserve a pre-zeroed, single-frame child table for an upcoming
+    /// [`Self::split_huge_page_with`].
     ///
     /// Reserving the frame up front (before, say, an address-space lock is taken)
     /// lets the split itself commit infallibly — it never allocates in the
-    /// break-before-make window.
-    pub fn alloc_intermediate_table(&self) -> PagingResult<Frame<T, A>> {
-        Frame::<T, A>::new(self.root.allocator.clone())
+    /// break-before-make window. The [`ReservedTable`] is a single frame, the size
+    /// of every intermediate page table.
+    pub fn alloc_intermediate_table(&self) -> PagingResult<ReservedTable<T, A>> {
+        Ok(ReservedTable {
+            frame: Frame::<T, A>::new(self.root.allocator.clone())?,
+        })
     }
 
     /// Return a reserved table that a split did not consume (the rollback path).
@@ -353,8 +371,8 @@ impl<T: TableMeta, A: FrameAllocator> PageTableRef<T, A> {
     /// Freeing an *uninstalled* reserved frame needs no TLB flush: it was never
     /// reachable by any page-table walk (contrast reclaiming a live table in
     /// `unmap`, which must flush before freeing).
-    pub fn dealloc_intermediate_table(&self, table: Frame<T, A>) {
-        self.root.allocator.dealloc_frame(table.paddr);
+    pub fn dealloc_intermediate_table(&self, table: ReservedTable<T, A>) {
+        self.root.allocator.dealloc_frame(table.frame.paddr);
     }
 
     /// Peek the huge block (present or not-present) covering `vaddr`: its frame,
@@ -391,8 +409,11 @@ impl<T: TableMeta, A: FrameAllocator> PageTableRef<T, A> {
     pub fn split_huge_page_with(
         &mut self,
         vaddr: VirtAddr,
-        reserved: Frame<T, A>,
+        reserved: ReservedTable<T, A>,
     ) -> PagingResult<usize> {
+        // `ReservedTable` guarantees exactly one frame — the size of a child table —
+        // so the split installs and (on error) reclaims the whole reservation.
+        let reserved = reserved.frame;
         let reserved_paddr = reserved.paddr;
         match self
             .root
@@ -418,7 +439,7 @@ impl<T: TableMeta, A: FrameAllocator> PageTableRef<T, A> {
     /// on a nested/second-stage format (EPT/NPT) that zeroes such an entry the
     /// block reads as unmapped and this returns `NotMapped`.
     pub fn split_huge_page(&mut self, vaddr: VirtAddr) -> PagingResult<usize> {
-        let reserved = Frame::<T, A>::new(self.root.allocator.clone())?;
+        let reserved = self.alloc_intermediate_table()?;
         self.split_huge_page_with(vaddr, reserved)
     }
 

--- a/memory/page-table-generic/tests/huge_split.rs
+++ b/memory/page-table-generic/tests/huge_split.rs
@@ -262,3 +262,146 @@ fn failed_split_rolls_back_reserved_table_without_flushing() {
         "an uninstalled reserved frame is never live, so no flush: {ops:?}"
     );
 }
+
+// ---- Nested/second-stage (EPT/NPT-style) format: the narrowed `huge()` contract ----
+
+/// A nested-page-table PTE mirroring the EPT/NPT adapters
+/// (`virtualization/axvm/src/arch/*/npt.rs`, `ept.rs`): an entry built with empty
+/// permissions collapses to a bare zero, dropping both the physical address and the
+/// block marker. `huge()` therefore reports a *not-present* block as not-huge — the
+/// format on which the not-present-block split is unsupported and must degrade to
+/// `NotMapped` rather than misbehave.
+#[derive(Clone, Copy, Debug)]
+struct NestedPte(u64);
+
+impl NestedPte {
+    const VALID: u64 = 1 << 0;
+    const BLOCK: u64 = 1 << 1;
+    const TABLE: u64 = 1 << 2;
+    const PADDR: u64 = !0xfff;
+}
+
+impl PageTableEntry for NestedPte {
+    type PteConfig = PteConfig;
+
+    fn new_page(paddr: PhysAddr, config: Self::PteConfig, is_huge: bool) -> Self {
+        // EPT/NPT: an empty-permission mapping is encoded as all-zero, losing the
+        // physical address and the block marker.
+        if !config.valid {
+            return Self(0);
+        }
+        let mut bits = (paddr.as_usize() as u64 & Self::PADDR) | Self::VALID;
+        if is_huge {
+            bits |= Self::BLOCK;
+        }
+        Self(bits)
+    }
+
+    fn new_table(paddr: PhysAddr) -> Self {
+        Self((paddr.as_usize() as u64 & Self::PADDR) | Self::VALID | Self::TABLE)
+    }
+
+    fn paddr(&self, _is_dir: bool) -> PhysAddr {
+        PhysAddr::from_usize((self.0 & Self::PADDR) as usize)
+    }
+
+    fn config(&self, is_dir: bool) -> Self::PteConfig {
+        PteConfig {
+            paddr: self.paddr(is_dir),
+            valid: self.present(),
+            read: true,
+            writable: true,
+            executable: true,
+            is_dir,
+            huge: self.huge(is_dir),
+            ..Default::default()
+        }
+    }
+
+    fn present(&self) -> bool {
+        self.0 & Self::VALID != 0
+    }
+
+    fn huge(&self, is_dir: bool) -> bool {
+        is_dir && (self.0 & Self::BLOCK != 0)
+    }
+
+    fn unused(&self) -> bool {
+        self.0 == 0
+    }
+
+    fn clear(&mut self) {
+        self.0 = 0;
+    }
+}
+
+#[derive(Clone, Copy)]
+struct NestedL4;
+
+impl TableMeta for NestedL4 {
+    type P = NestedPte;
+
+    const PAGE_SIZE: usize = 0x1000;
+    const LEVEL_BITS: &[usize] = &[9, 9, 9, 9];
+    const MAX_BLOCK_LEVEL: usize = 3;
+
+    fn flush(_vaddr: Option<VirtAddr>) {}
+}
+
+/// F-001: on a format whose `huge()` is *not* present-independent (the nested
+/// EPT/NPT adapters zero an empty-permission entry), a *present* huge block still
+/// splits, but a *not-present* block degrades to `NotMapped` instead of a
+/// preserved-frame split — with no panic and no page-table-frame leak.
+#[test]
+fn not_present_block_on_a_zeroing_format_degrades_to_not_mapped() {
+    let alloc = TrackedFram4k::default();
+    let mut pt = PageTable::<NestedL4, TrackedFram4k>::new(alloc.clone()).unwrap();
+
+    // A present 2 MiB block splits on this format like any other (its `huge()` bit
+    // is set), so the not-present degradation below is specific to the zeroed entry.
+    let va_present = VirtAddr::from_usize(VA);
+    pt.map(&MapConfig {
+        vaddr: va_present,
+        paddr: PhysAddr::from_usize(0x1000_0000),
+        size: HUGE_2M,
+        pte: PteImpl::kernel_mode_config(),
+        allow_huge: true,
+        flush: false,
+    })
+    .unwrap();
+    assert_eq!(
+        pt.split_huge_page(va_present).unwrap(),
+        HUGE_2M,
+        "a present huge block splits on every format"
+    );
+
+    // A separate block, then `mprotect(PROT_NONE)`: on this format the entry
+    // collapses to a bare zero (no paddr, no block bit), so `huge()` is false.
+    let va_np = VirtAddr::from_usize(VA + 4 * HUGE_2M);
+    pt.map(&MapConfig {
+        vaddr: va_np,
+        paddr: PhysAddr::from_usize(0x3000_0000),
+        size: HUGE_2M,
+        pte: PteImpl::kernel_mode_config(),
+        allow_huge: true,
+        flush: false,
+    })
+    .unwrap();
+    pt.protect_page(va_np, PteConfig::default()).unwrap();
+
+    assert_eq!(
+        pt.peek_huge_block(va_np),
+        None,
+        "a zeroing format reports a not-present block as unmapped"
+    );
+    assert_eq!(
+        pt.split_huge_page(va_np).err(),
+        Some(PagingError::NotMapped),
+        "splitting a not-present block on a zeroing format degrades to NotMapped"
+    );
+
+    // `Drop` deallocates every page-table frame (the split's child table + the
+    // tables above the zeroed block); none may leak.
+    drop(pt);
+    assert!(!alloc.has_leaks(), "no page-table frame may leak");
+}

--- a/memory/page-table-generic/tests/huge_split.rs
+++ b/memory/page-table-generic/tests/huge_split.rs
@@ -1,0 +1,264 @@
+//! Break-before-make split of a huge block into a finer-granule table.
+//!
+//! Transparent huge pages need to split a live 2 MiB block into 512 × 4 KiB
+//! leaves (on a partial unmap/protect) and, later, re-promote the same VA back to
+//! a 2 MiB block. These tests cover:
+//!   1. the functional round trip (map 2M -> split -> unmap -> re-promote) with no
+//!      page-table-frame leak — the regression that a stranded emptied table used
+//!      to block re-promotion (`AlreadyMapped`);
+//!   2. splitting a *not-present* block (an `mprotect(PROT_NONE)` over a huge area)
+//!      without ever freeing its data frame;
+//!   3. the break-before-make ordering (clear -> flush -> install: exactly one
+//!      flush, zero frees on a successful split);
+//!   4. the rollback contract (a split that finds no block frees the reserved table
+//!      exactly once, and never flushes, since the reservation was never installed).
+
+#![cfg(not(target_os = "none"))]
+
+use std::{
+    alloc::{Layout, alloc, dealloc},
+    sync::Mutex,
+};
+
+use page_table_generic::*;
+
+mod mocks;
+
+use mocks::{PteConfig, PteImpl, T4kL4, TrackedFram4k};
+
+const HUGE_2M: usize = 0x20_0000;
+const PG: usize = 0x1000;
+const VA: usize = 0x40_0000;
+
+fn map_huge(pt: &mut PageTable<T4kL4, TrackedFram4k>, vaddr: usize, paddr: usize) {
+    pt.map(&MapConfig {
+        vaddr: VirtAddr::from_usize(vaddr),
+        paddr: PhysAddr::from_usize(paddr),
+        size: HUGE_2M,
+        pte: PteImpl::kernel_mode_config(),
+        allow_huge: true,
+        flush: false,
+    })
+    .unwrap();
+}
+
+/// Functional round trip + no leak (mirrors the reference thp_remap regression).
+#[test]
+fn split_2m_then_unmap_then_repromote_leaves_no_frame_leaked() {
+    let alloc = TrackedFram4k::default();
+    let mut pt = PageTable::<T4kL4, TrackedFram4k>::new(alloc.clone()).unwrap();
+    let va = VirtAddr::from_usize(VA);
+    let pa = 0x1000_0000;
+
+    // 1) a 2 MiB block; a 4 KiB map inside it conflicts — the split entry point.
+    map_huge(&mut pt, VA, pa);
+    assert!(
+        matches!(
+            pt.map(&MapConfig {
+                vaddr: va,
+                paddr: PhysAddr::from_usize(pa),
+                size: PG,
+                pte: PteImpl::kernel_mode_config(),
+                allow_huge: false,
+                flush: false,
+            }),
+            Err(PagingError::MappingConflict { .. })
+        ),
+        "a 4 KiB map inside a live 2 MiB block must conflict"
+    );
+
+    // 2) split -> 512 leaves auto-populated from the block's frame + flags.
+    assert_eq!(pt.split_huge_page(va).unwrap(), HUGE_2M);
+    for i in 0..(HUGE_2M / PG) {
+        let (got, _pte) = pt.translate(va + i * PG).unwrap();
+        assert_eq!(
+            got.as_usize(),
+            pa + i * PG,
+            "leaf {i} must translate at 4 KiB granularity to the split frame"
+        );
+    }
+
+    // 3) unmap the whole range: #2009 reclaims the now-empty split table inline.
+    pt.unmap(va, HUGE_2M).unwrap();
+
+    // 4) re-promote: a fresh 2 MiB block at the same VA must succeed (a stranded
+    //    emptied table used to leave the L2 slot occupied -> `AlreadyMapped`).
+    let pa2 = 0x2000_0000;
+    map_huge(&mut pt, VA, pa2);
+    let (got, _pte, level) = pt.translate_with_level(va).unwrap();
+    assert_eq!(
+        Frame::<T4kL4, TrackedFram4k>::level_size(level),
+        HUGE_2M,
+        "re-promoted mapping must be a single 2 MiB block"
+    );
+    assert_eq!(got.as_usize(), pa2);
+
+    // 5) teardown: no page-table frame may leak.
+    pt.unmap(va, HUGE_2M).unwrap();
+    drop(pt);
+    assert!(
+        !alloc.has_leaks(),
+        "leaked page-table frame(s) after teardown"
+    );
+}
+
+/// A not-present block (PROT_NONE over a huge area) splits, and its data frame is
+/// never handed to the allocator (TrackedFram4k panics on a foreign free).
+#[test]
+fn split_not_present_2m_block_preserves_the_data_frame() {
+    let alloc = TrackedFram4k::default();
+    let mut pt = PageTable::<T4kL4, TrackedFram4k>::new(alloc.clone()).unwrap();
+    let va = VirtAddr::from_usize(VA);
+    // A dummy data frame NOT owned by the tracking allocator: if the split ever
+    // frees it, TrackedFram4k::dealloc_frame panics on the untracked paddr.
+    let data = 0x1000_0000;
+
+    map_huge(&mut pt, VA, data);
+    // mprotect(PROT_NONE): default config is `valid: false` -> a not-present huge
+    // block (the frame is preserved, the present bit cleared).
+    pt.protect_page(va, PteConfig::default()).unwrap();
+    assert_eq!(
+        pt.translate(va).err(),
+        Some(PagingError::NotMapped),
+        "the block must now be not-present"
+    );
+
+    // peek finds the not-present block without mutating.
+    let (p, _cfg, sz) = pt
+        .peek_huge_block(va)
+        .expect("peek must find the not-present huge block");
+    assert_eq!((p.as_usize(), sz), (data, HUGE_2M));
+
+    // split it: reached through the same `huge()` short-circuit as a present block.
+    pt.split_huge_page(va)
+        .expect("splitting a not-present huge block must succeed");
+
+    // teardown: unmap clears the not-present leaves + reclaims the split table; the
+    // data frame is never freed -> no foreign free, no leak.
+    pt.unmap(va, HUGE_2M).unwrap();
+    drop(pt);
+    assert!(!alloc.has_leaks(), "leaked table frame(s) after teardown");
+}
+
+// ---- Ordering harness (same shape as tests/reclaim_flush_order.rs) ----
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Flush,
+    Dealloc(usize),
+}
+
+static OPS: Mutex<Vec<Op>> = Mutex::new(Vec::new());
+static SERIALIZE: Mutex<()> = Mutex::new(());
+
+#[derive(Clone, Copy)]
+struct RecordingMeta;
+
+impl TableMeta for RecordingMeta {
+    type P = PteImpl;
+
+    const PAGE_SIZE: usize = 0x1000;
+    const LEVEL_BITS: &[usize] = &[9, 9, 9, 9];
+    const MAX_BLOCK_LEVEL: usize = 3;
+
+    fn flush(vaddr: Option<VirtAddr>) {
+        if vaddr.is_some() {
+            OPS.lock().unwrap().push(Op::Flush);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct RecordingFram4k;
+
+impl FrameAllocator for RecordingFram4k {
+    fn alloc_frame(&self) -> Option<PhysAddr> {
+        let layout = Layout::from_size_align(4096, 4096).unwrap();
+        let ptr = unsafe { alloc(layout) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(PhysAddr::from_usize(ptr as usize))
+        }
+    }
+
+    fn dealloc_frame(&self, frame: PhysAddr) {
+        OPS.lock().unwrap().push(Op::Dealloc(frame.as_usize()));
+        let layout = Layout::from_size_align(4096, 4096).unwrap();
+        unsafe { dealloc(frame.as_usize() as *mut u8, layout) };
+    }
+
+    fn phys_to_virt(&self, paddr: PhysAddr) -> *mut u8 {
+        paddr.as_usize() as *mut u8
+    }
+}
+
+/// A successful split does a single break-before-make flush and frees nothing.
+#[test]
+fn split_emits_one_flush_and_frees_nothing() {
+    let _guard = SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+    OPS.lock().unwrap().clear();
+
+    let mut pt = PageTable::<RecordingMeta, RecordingFram4k>::new(RecordingFram4k).unwrap();
+    pt.map(&MapConfig {
+        vaddr: VirtAddr::from_usize(VA),
+        paddr: PhysAddr::from_usize(0x1000_0000),
+        size: HUGE_2M,
+        pte: PteImpl::kernel_mode_config(),
+        allow_huge: true,
+        flush: false,
+    })
+    .unwrap();
+    OPS.lock().unwrap().clear();
+
+    pt.split_huge_page(VirtAddr::from_usize(VA)).unwrap();
+
+    let ops = OPS.lock().unwrap().clone();
+    assert_eq!(
+        ops.iter().filter(|o| matches!(o, Op::Dealloc(_))).count(),
+        0,
+        "a successful split installs a table and frees nothing: {ops:?}"
+    );
+    assert_eq!(
+        ops.iter().filter(|o| matches!(o, Op::Flush)).count(),
+        1,
+        "exactly one break-before-make flush (clear -> flush -> install): {ops:?}"
+    );
+}
+
+/// A split that finds no block (a plain 4 KiB leaf) rolls back the reserved table
+/// exactly once, and never flushes (the reservation was never installed).
+#[test]
+fn failed_split_rolls_back_reserved_table_without_flushing() {
+    let _guard = SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+    OPS.lock().unwrap().clear();
+
+    let mut pt = PageTable::<RecordingMeta, RecordingFram4k>::new(RecordingFram4k).unwrap();
+    pt.map(&MapConfig {
+        vaddr: VirtAddr::from_usize(VA),
+        paddr: PhysAddr::from_usize(0x1000_0000),
+        size: PG,
+        pte: PteImpl::kernel_mode_config(),
+        allow_huge: false,
+        flush: false,
+    })
+    .unwrap();
+    OPS.lock().unwrap().clear();
+
+    assert!(
+        pt.split_huge_page(VirtAddr::from_usize(VA)).is_err(),
+        "splitting a plain 4 KiB leaf must fail"
+    );
+
+    let ops = OPS.lock().unwrap().clone();
+    assert_eq!(
+        ops.iter().filter(|o| matches!(o, Op::Dealloc(_))).count(),
+        1,
+        "rollback frees the reserved table exactly once: {ops:?}"
+    );
+    assert_eq!(
+        ops.iter().filter(|o| matches!(o, Op::Flush)).count(),
+        0,
+        "an uninstalled reserved frame is never live, so no flush: {ops:?}"
+    );
+}

--- a/memory/page-table-generic/tests/huge_split.rs
+++ b/memory/page-table-generic/tests/huge_split.rs
@@ -405,3 +405,145 @@ fn not_present_block_on_a_zeroing_format_degrades_to_not_mapped() {
     drop(pt);
     assert!(!alloc.has_leaks(), "no page-table frame may leak");
 }
+
+// ---- Empty-splice variant: install a zeroed child table, caller maps the leaves ----
+
+/// The empty splice installs the child table but leaves its 512 leaves unmapped, so
+/// the caller can install arbitrary (here non-contiguous) 4 KiB frames — exactly the
+/// `CopiedScattered` COW-break case the auto-populating `split_huge_page` cannot
+/// serve (its inherited leaves would make the caller's `map_page` hit
+/// `MappingConflict`).
+#[test]
+fn empty_splice_leaves_child_table_unmapped_then_accepts_scattered_leaves() {
+    let alloc = TrackedFram4k::default();
+    let mut pt = PageTable::<T4kL4, TrackedFram4k>::new(alloc.clone()).unwrap();
+    let va = VirtAddr::from_usize(VA);
+    let pa = 0x1000_0000;
+
+    map_huge(&mut pt, VA, pa);
+
+    // Empty splice: zeroed child table, NO leaf population; returns the old block.
+    let reserved = pt.alloc_intermediate_table().unwrap();
+    let (old_pa, _cfg, size) = pt.split_huge_block_to_empty_table(va, reserved).unwrap();
+    assert_eq!(size, HUGE_2M);
+    assert_eq!(old_pa.as_usize(), pa, "returns the split block's old paddr");
+
+    // The child table is present, but every leaf is unmapped, and the slot is now a
+    // table pointer rather than a block.
+    for i in 0..(HUGE_2M / PG) {
+        assert_eq!(
+            pt.translate(va + i * PG).err(),
+            Some(PagingError::NotMapped),
+            "leaf {i} must be unmapped after an empty splice"
+        );
+    }
+    assert_eq!(
+        pt.peek_huge_block(va),
+        None,
+        "the block is now a table, not a block"
+    );
+
+    // Install 512 NON-CONTIGUOUS leaves (stride 8 KiB, so no two are adjacent): the
+    // auto-populating split would `MappingConflict` here; the empty table must not.
+    let scattered = |i: usize| 0x5000_0000 + i * 2 * PG;
+    for i in 0..(HUGE_2M / PG) {
+        pt.map_page(
+            va + i * PG,
+            PhysAddr::from_usize(scattered(i)),
+            PG,
+            PteImpl::kernel_mode_config(),
+        )
+        .unwrap();
+    }
+    for i in 0..(HUGE_2M / PG) {
+        let (got, _pte) = pt.translate(va + i * PG).unwrap();
+        assert_eq!(
+            got.as_usize(),
+            scattered(i),
+            "leaf {i} resolves to its own scattered frame"
+        );
+    }
+
+    pt.unmap(va, HUGE_2M).unwrap();
+    drop(pt);
+    assert!(
+        !alloc.has_leaks(),
+        "leaked page-table frame(s) after teardown"
+    );
+}
+
+/// A successful empty splice does a single break-before-make flush and frees nothing
+/// — same ordering as the inheriting split, since the only difference is the skipped
+/// leaf-fill.
+#[test]
+fn empty_splice_emits_one_flush_and_frees_nothing() {
+    let _guard = SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+    OPS.lock().unwrap().clear();
+
+    let mut pt = PageTable::<RecordingMeta, RecordingFram4k>::new(RecordingFram4k).unwrap();
+    pt.map(&MapConfig {
+        vaddr: VirtAddr::from_usize(VA),
+        paddr: PhysAddr::from_usize(0x1000_0000),
+        size: HUGE_2M,
+        pte: PteImpl::kernel_mode_config(),
+        allow_huge: true,
+        flush: false,
+    })
+    .unwrap();
+    OPS.lock().unwrap().clear();
+
+    let reserved = pt.alloc_intermediate_table().unwrap();
+    pt.split_huge_block_to_empty_table(VirtAddr::from_usize(VA), reserved)
+        .unwrap();
+
+    let ops = OPS.lock().unwrap().clone();
+    assert_eq!(
+        ops.iter().filter(|o| matches!(o, Op::Dealloc(_))).count(),
+        0,
+        "an empty splice installs a table and frees nothing: {ops:?}"
+    );
+    assert_eq!(
+        ops.iter().filter(|o| matches!(o, Op::Flush)).count(),
+        1,
+        "exactly one break-before-make flush (clear -> flush -> install): {ops:?}"
+    );
+}
+
+/// An empty splice over a plain 4 KiB leaf finds no block: it rolls back the reserved
+/// table exactly once and never flushes (the reservation was never installed).
+#[test]
+fn failed_empty_splice_rolls_back_reserved_table_without_flushing() {
+    let _guard = SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+    OPS.lock().unwrap().clear();
+
+    let mut pt = PageTable::<RecordingMeta, RecordingFram4k>::new(RecordingFram4k).unwrap();
+    pt.map(&MapConfig {
+        vaddr: VirtAddr::from_usize(VA),
+        paddr: PhysAddr::from_usize(0x1000_0000),
+        size: PG,
+        pte: PteImpl::kernel_mode_config(),
+        allow_huge: false,
+        flush: false,
+    })
+    .unwrap();
+    OPS.lock().unwrap().clear();
+
+    let reserved = pt.alloc_intermediate_table().unwrap();
+    assert!(
+        pt.split_huge_block_to_empty_table(VirtAddr::from_usize(VA), reserved)
+            .is_err(),
+        "an empty splice over a plain 4 KiB leaf must fail"
+    );
+
+    let ops = OPS.lock().unwrap().clone();
+    assert_eq!(
+        ops.iter().filter(|o| matches!(o, Op::Dealloc(_))).count(),
+        1,
+        "rollback frees the reserved table exactly once: {ops:?}"
+    );
+    assert_eq!(
+        ops.iter().filter(|o| matches!(o, Op::Flush)).count(),
+        0,
+        "an uninstalled reserved frame is never live, so no flush: {ops:?}"
+    );
+}

--- a/memory/page-table-generic/tests/reclaim_flush_order.rs
+++ b/memory/page-table-generic/tests/reclaim_flush_order.rs
@@ -1,0 +1,158 @@
+//! Break-before-free ordering for intermediate page-table reclaim.
+//!
+//! When `unmap` empties an intermediate table it returns that frame to the
+//! allocator. The frame's translation must be invalidated from the TLB *before*
+//! it is freed: otherwise a concurrent core can reallocate and overwrite the
+//! frame while a stale table-walk still reads it as page-table entries, mapping
+//! to arbitrary physical memory. These tests record `flush` and `dealloc_frame`
+//! into one ordered log and assert every reclaimed frame is flushed before it is
+//! freed (and that `flush: false` suppresses the flush while still reclaiming).
+
+#![cfg(not(target_os = "none"))]
+
+use std::{
+    alloc::{Layout, alloc, dealloc},
+    sync::Mutex,
+};
+
+use page_table_generic::*;
+
+mod mocks;
+
+use mocks::PteImpl;
+
+/// One entry in the ordered operation log shared by the recording `TableMeta`
+/// and `FrameAllocator` below.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Op {
+    Flush,
+    Dealloc(usize),
+}
+
+/// `TableMeta::flush` is a static method with no instance state, so the log has
+/// to be a static. `SERIALIZE` keeps the two tests from interleaving on it.
+static OPS: Mutex<Vec<Op>> = Mutex::new(Vec::new());
+static SERIALIZE: Mutex<()> = Mutex::new(());
+
+/// 4-level table so a single 4 KiB unmap reclaims a *chain* of intermediate
+/// tables (L1, L2, L3) — the chained reclaim is what exposes the missing flush
+/// as back-to-back `Dealloc`s with no `Flush` between them.
+#[derive(Clone, Copy)]
+struct RecordingMeta;
+
+impl TableMeta for RecordingMeta {
+    type P = PteImpl;
+
+    const PAGE_SIZE: usize = 0x1000;
+    const LEVEL_BITS: &[usize] = &[9, 9, 9, 9];
+    const MAX_BLOCK_LEVEL: usize = 3;
+
+    fn flush(vaddr: Option<VirtAddr>) {
+        if vaddr.is_some() {
+            OPS.lock().unwrap().push(Op::Flush);
+        }
+    }
+}
+
+/// Real-backing allocator (so page walks are valid and nothing leaks) that also
+/// records every `dealloc_frame` into the shared ordered log.
+#[derive(Clone, Copy)]
+struct RecordingFram4k;
+
+impl FrameAllocator for RecordingFram4k {
+    fn alloc_frame(&self) -> Option<PhysAddr> {
+        let layout = Layout::from_size_align(4096, 4096).unwrap();
+        let ptr = unsafe { alloc(layout) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(PhysAddr::from_usize(ptr as usize))
+        }
+    }
+
+    fn dealloc_frame(&self, frame: PhysAddr) {
+        OPS.lock().unwrap().push(Op::Dealloc(frame.as_usize()));
+        let layout = Layout::from_size_align(4096, 4096).unwrap();
+        unsafe { dealloc(frame.as_usize() as *mut u8, layout) };
+    }
+
+    fn phys_to_virt(&self, paddr: PhysAddr) -> *mut u8 {
+        paddr.as_usize() as *mut u8
+    }
+}
+
+/// Map a single 4 KiB page, then reset the log and record only the unmap.
+fn map_one_page_then_reset() -> PageTable<RecordingMeta, RecordingFram4k> {
+    let mut page_table = PageTable::<RecordingMeta, RecordingFram4k>::new(RecordingFram4k).unwrap();
+    page_table
+        .map(&MapConfig {
+            vaddr: VirtAddr::from_usize(0x20_0000),
+            paddr: PhysAddr::from_usize(0x20_0000),
+            size: RecordingMeta::PAGE_SIZE,
+            pte: PteImpl::kernel_mode_config(),
+            allow_huge: false,
+            flush: false,
+        })
+        .unwrap();
+    OPS.lock().unwrap().clear();
+    page_table
+}
+
+#[test]
+fn reclaimed_table_is_flushed_before_it_is_freed() {
+    let _guard = SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+    OPS.lock().unwrap().clear();
+
+    let mut page_table = map_one_page_then_reset();
+    page_table
+        .unmap(VirtAddr::from_usize(0x20_0000), RecordingMeta::PAGE_SIZE)
+        .unwrap();
+
+    let ops = OPS.lock().unwrap().clone();
+    let deallocs = ops.iter().filter(|o| matches!(o, Op::Dealloc(_))).count();
+    assert!(
+        deallocs >= 2,
+        "expected the single-page unmap to reclaim a chain of >=2 intermediate tables (otherwise \
+         this test cannot detect the ordering bug), got {deallocs}: {ops:?}"
+    );
+
+    // Break-before-free: every reclaimed frame must be flushed immediately
+    // before it is freed. Without the fix the chained reclaims emit back-to-back
+    // `Dealloc`s, so a `Dealloc` is preceded by another `Dealloc`, not a `Flush`.
+    for (i, op) in ops.iter().enumerate() {
+        if matches!(op, Op::Dealloc(_)) {
+            assert!(
+                i > 0 && ops[i - 1] == Op::Flush,
+                "intermediate table freed without a preceding TLB flush (break-before-free \
+                 violated) at op {i}: {ops:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn reclaim_with_flush_disabled_emits_no_flush() {
+    let _guard = SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+    OPS.lock().unwrap().clear();
+
+    let mut page_table = map_one_page_then_reset();
+    page_table
+        .unmap_with_config(&UnmapConfig {
+            start_vaddr: VirtAddr::from_usize(0x20_0000),
+            size: RecordingMeta::PAGE_SIZE,
+            flush: false,
+        })
+        .unwrap();
+
+    let ops = OPS.lock().unwrap().clone();
+    let deallocs = ops.iter().filter(|o| matches!(o, Op::Dealloc(_))).count();
+    let flushes = ops.iter().filter(|o| matches!(o, Op::Flush)).count();
+    assert!(
+        deallocs >= 2,
+        "reclaim must still free the chained tables when flush is disabled: {ops:?}"
+    );
+    assert_eq!(
+        flushes, 0,
+        "no TLB flush must be emitted when flush is disabled: {ops:?}"
+    );
+}

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -65,6 +65,10 @@ SMP = "4"
 [features]
 default = ["dynamic_debug"]
 dev-log = []
+# Transparent 2 MiB huge pages ("THP-lite") for private anonymous memory. Opt-in
+# and OFF by default: with this disabled the promotion and huge->4K split code is
+# not compiled, so the page-fault/mmap hot paths are byte-for-byte unchanged.
+thp = []
 ext4 = ["ax-fs-ng/ext4"]
 fat = ["ax-fs-ng/fat"]
 input = ["dep:ax-input", "ax-runtime/input"]

--- a/os/StarryOS/kernel/src/axtest_exports.rs
+++ b/os/StarryOS/kernel/src/axtest_exports.rs
@@ -131,7 +131,7 @@ pub fn memory_accounting_tracks_cow_charge_transitions() -> bool {
     let file_page = VirtAddr::from(0x1000usize);
     let moved_page = VirtAddr::from(0x2000usize);
 
-    acct.record_charge(file_page, RssKind::File).is_ok()
+    acct.record_charge(file_page, RssKind::File, 1).is_ok()
         && acct.rss_file_pages() == 1
         && acct.cow_file_write_to_anon(file_page)
         && acct.rss_file_pages() == 0
@@ -152,9 +152,9 @@ pub fn memory_accounting_rejects_duplicate_and_conflicting_charges() -> bool {
     let dst = VirtAddr::from(0x4000usize);
     let orphan = VirtAddr::from(0x5000usize);
 
-    acct.record_charge(src, RssKind::File).is_ok()
-        && acct.record_charge(src, RssKind::Anon).is_err()
-        && acct.record_charge(dst, RssKind::Shmem).is_ok()
+    acct.record_charge(src, RssKind::File, 1).is_ok()
+        && acct.record_charge(src, RssKind::Anon, 1).is_err()
+        && acct.record_charge(dst, RssKind::Shmem, 1).is_ok()
         && acct.move_charge(src, dst).is_err()
         && acct.charge_entries().contains(&(src, RssKind::File))
         && acct.charge_entries().contains(&(dst, RssKind::Shmem))

--- a/os/StarryOS/kernel/src/mm/aspace/accounting.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/accounting.rs
@@ -147,6 +147,24 @@ impl MemoryAccounting {
         Ok(())
     }
 
+    /// Infallible per-VA charge insert for a freshly-uncharged page. Used by a THP
+    /// 2 MiB -> 4 KiB split to expand one 2 MiB charge into 512 4 KiB charges: the
+    /// sub-page VAs were never charged (only the 2 MiB VA was), so the insert cannot
+    /// collide and must not fail partway through the 512. Debug builds assert the
+    /// freshness invariant.
+    #[cfg(feature = "thp")]
+    pub fn record_charge_fresh(&self, vaddr: VirtAddr, kind: RssKind) {
+        // SAFETY: `AddrSpace` lock held by all callers.
+        let charges = unsafe { &mut *self.charges.get() };
+        debug_assert!(
+            !charges.contains_key(&vaddr),
+            "record_charge_fresh: duplicate charge for {vaddr:?}"
+        );
+        charges.insert(vaddr, kind);
+        self.inc(kind, 1);
+        self.generation.fetch_add(1, Ordering::Relaxed);
+    }
+
     /// Remove charge after PTE unmap. Debug builds assert the entry exists.
     pub fn remove_charge(&self, vaddr: VirtAddr) -> Option<RssKind> {
         // SAFETY: `AddrSpace` lock held by all callers.

--- a/os/StarryOS/kernel/src/mm/aspace/accounting.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/accounting.rs
@@ -29,6 +29,16 @@ pub enum RssKind {
     Shmem,
 }
 
+/// One Cow charge entry: its kind and the number of 4 KiB resident pages it
+/// accounts for. Almost always 1 (a 4 KiB page); a transparent-huge-page 2 MiB
+/// block is a single entry accounting for its 512 resident pages, so VmRSS/VmHWM
+/// reflect the whole block rather than one page.
+#[derive(Debug, Clone, Copy)]
+struct RssCharge {
+    kind: RssKind,
+    pages: u32,
+}
+
 /// Incremental RSS counters for one [`super::AddrSpace`].
 ///
 /// Cow-backend per-VA charges live in `charges` and are mutated only while the
@@ -40,8 +50,10 @@ pub struct MemoryAccounting {
     hiwater_rss: AtomicU64,
     /// Monotonic generation counter, incremented on every charge map mutation.
     generation: AtomicU64,
-    /// Cow resident pages keyed by user VA (4 KiB granularity today).
-    charges: UnsafeCell<BTreeMap<VirtAddr, RssKind>>,
+    /// Cow resident charges keyed by user VA. Each entry accounts for its
+    /// [`RssCharge::pages`] resident 4 KiB pages (1 for a 4 KiB page, 512 for a THP
+    /// 2 MiB block).
+    charges: UnsafeCell<BTreeMap<VirtAddr, RssCharge>>,
 }
 
 // SAFETY: `charges` is only accessed while `AddrSpace` is locked.
@@ -131,18 +143,26 @@ impl MemoryAccounting {
     pub(crate) fn charge_kind(&self, vaddr: VirtAddr) -> Option<RssKind> {
         // SAFETY: `AddrSpace` lock held by all callers.
         let charges = unsafe { &*self.charges.get() };
+        charges.get(&vaddr).map(|c| c.kind)
+    }
+
+    /// The full charge entry (kind + resident page count) at `vaddr`, if any.
+    fn charge_at(&self, vaddr: VirtAddr) -> Option<RssCharge> {
+        // SAFETY: `AddrSpace` lock held by all callers.
+        let charges = unsafe { &*self.charges.get() };
         charges.get(&vaddr).copied()
     }
 
-    /// Record a Cow resident page after PTE mapping succeeds.
-    pub fn record_charge(&self, vaddr: VirtAddr, kind: RssKind) -> StarryResult<()> {
+    /// Record a Cow resident charge of `pages` 4 KiB pages after PTE mapping
+    /// succeeds. `pages` is 1 for a 4 KiB page, 512 for a THP 2 MiB block.
+    pub fn record_charge(&self, vaddr: VirtAddr, kind: RssKind, pages: u32) -> StarryResult<()> {
         // SAFETY: `AddrSpace` lock held by all callers.
         let charges = unsafe { &mut *self.charges.get() };
         if charges.contains_key(&vaddr) {
             return Err(StarryError::InvalidInput);
         }
-        charges.insert(vaddr, kind);
-        self.inc(kind, 1);
+        charges.insert(vaddr, RssCharge { kind, pages });
+        self.inc(kind, pages as u64);
         self.generation.fetch_add(1, Ordering::Relaxed);
         Ok(())
     }
@@ -160,21 +180,21 @@ impl MemoryAccounting {
             !charges.contains_key(&vaddr),
             "record_charge_fresh: duplicate charge for {vaddr:?}"
         );
-        charges.insert(vaddr, kind);
+        charges.insert(vaddr, RssCharge { kind, pages: 1 });
         self.inc(kind, 1);
         self.generation.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Remove charge after PTE unmap. Debug builds assert the entry exists.
+    /// Remove the charge after PTE unmap, decrementing by its resident page count
+    /// (512 for a THP 2 MiB block). Debug builds assert the entry exists.
     pub fn remove_charge(&self, vaddr: VirtAddr) -> Option<RssKind> {
         // SAFETY: `AddrSpace` lock held by all callers.
         let charges = unsafe { &mut *self.charges.get() };
-        let kind = charges.remove(&vaddr);
-        match kind {
-            Some(k) => {
-                self.dec(k, 1);
+        match charges.remove(&vaddr) {
+            Some(c) => {
+                self.dec(c.kind, c.pages as u64);
                 self.generation.fetch_add(1, Ordering::Relaxed);
-                Some(k)
+                Some(c.kind)
             }
             None => {
                 debug_assert!(false, "remove_charge: missing entry for {vaddr:?}");
@@ -214,7 +234,7 @@ impl MemoryAccounting {
             }
             Some(RssKind::File) => {
                 self.remove_charge(vaddr);
-                if self.record_charge(vaddr, RssKind::Anon).is_err() {
+                if self.record_charge(vaddr, RssKind::Anon, 1).is_err() {
                     return false;
                 }
                 self.sync_rss_atomics_from_charges();
@@ -231,7 +251,7 @@ impl MemoryAccounting {
     /// Establish an Anon charge after a file-backed COW write when no File
     /// charge exists at `vaddr` (accounting drift recovery).
     pub fn adopt_cow_write_as_anon(&self, vaddr: VirtAddr) -> StarryResult<()> {
-        self.record_charge(vaddr, RssKind::Anon)?;
+        self.record_charge(vaddr, RssKind::Anon, 1)?;
         if self.rss_file_pages() > 0 {
             self.dec(RssKind::File, 1);
         }
@@ -243,30 +263,33 @@ impl MemoryAccounting {
     pub fn charge_entries(&self) -> alloc::vec::Vec<(VirtAddr, RssKind)> {
         // SAFETY: `AddrSpace` lock held by all callers.
         let charges = unsafe { &*self.charges.get() };
-        charges.iter().map(|(&va, &kind)| (va, kind)).collect()
+        charges.iter().map(|(&va, c)| (va, c.kind)).collect()
     }
 
-    /// Count resident Cow charges by kind. Only valid while [`super::AddrSpace`] is locked.
+    /// Count resident Cow pages by kind (a THP block counts its 512 pages). Only
+    /// valid while [`super::AddrSpace`] is locked.
     pub fn snapshot_resident_charges(&self) -> (u64, u64, u64) {
         // SAFETY: `AddrSpace` lock held by all callers.
         let charges = unsafe { &*self.charges.get() };
         let mut anon = 0u64;
         let mut file = 0u64;
         let mut shmem = 0u64;
-        for kind in charges.values() {
-            match kind {
-                RssKind::Anon => anon += 1,
-                RssKind::File => file += 1,
-                RssKind::Shmem => shmem += 1,
+        for c in charges.values() {
+            let pages = c.pages as u64;
+            match c.kind {
+                RssKind::Anon => anon += pages,
+                RssKind::File => file += pages,
+                RssKind::Shmem => shmem += pages,
             }
         }
         (anon, file, shmem)
     }
 
-    /// Fork: copy parent's bucket after child PTE maps the shared page.
+    /// Fork: copy parent's bucket after child PTE maps the shared page, preserving
+    /// the page count (a shared THP block stays a 512-page charge in the child).
     pub fn copy_charge_from(&self, parent: &Self, vaddr: VirtAddr) -> StarryResult<()> {
-        let kind = parent.charge_kind(vaddr).ok_or(StarryError::InvalidInput)?;
-        self.record_charge(vaddr, kind)?;
+        let charge = parent.charge_at(vaddr).ok_or(StarryError::InvalidInput)?;
+        self.record_charge(vaddr, charge.kind, charge.pages)?;
         Ok(())
     }
 
@@ -318,15 +341,15 @@ impl MemoryAccounting {
     pub fn move_charge(&self, src: VirtAddr, dst: VirtAddr) -> StarryResult<()> {
         // SAFETY: `AddrSpace` lock held by all callers.
         let charges = unsafe { &mut *self.charges.get() };
-        let Some(kind) = charges.remove(&src) else {
+        let Some(charge) = charges.remove(&src) else {
             return Ok(());
         };
         if charges.contains_key(&dst) {
             debug_assert!(false, "move_charge: dst {dst:?} already charged");
-            charges.insert(src, kind);
+            charges.insert(src, charge);
             return Err(StarryError::InvalidInput);
         }
-        charges.insert(dst, kind);
+        charges.insert(dst, charge);
         Ok(())
     }
 }
@@ -334,10 +357,10 @@ impl MemoryAccounting {
 impl Drop for MemoryAccounting {
     fn drop(&mut self) {
         let charges = self.charges.get_mut();
-        let kinds: alloc::vec::Vec<_> = charges.values().copied().collect();
+        let entries: alloc::vec::Vec<_> = charges.values().copied().collect();
         charges.clear();
-        for kind in kinds {
-            self.dec(kind, 1);
+        for c in entries {
+            self.dec(c.kind, c.pages as u64);
         }
     }
 }
@@ -406,9 +429,9 @@ pub(crate) fn accounting_edge_cases_and_snapshot_rules_hold_for_test() -> bool {
     let va1 = VirtAddr::from(0x1000usize);
     let va2 = VirtAddr::from(0x2000usize);
     let va3 = VirtAddr::from(0x3000usize);
-    acct.record_charge(va1, RssKind::Anon).unwrap();
-    acct.record_charge(va2, RssKind::File).unwrap();
-    acct.record_charge(va3, RssKind::File).unwrap();
+    acct.record_charge(va1, RssKind::Anon, 1).unwrap();
+    acct.record_charge(va2, RssKind::File, 1).unwrap();
+    acct.record_charge(va3, RssKind::File, 1).unwrap();
     let (anon, file, shmem) = acct.snapshot_resident_charges();
     assert_eq!(anon, 1); // va1
     assert_eq!(file, 2); // va2 + va3
@@ -424,6 +447,40 @@ pub(crate) fn accounting_edge_cases_and_snapshot_rules_hold_for_test() -> bool {
     let ghost = VirtAddr::from(0xDEADusize);
     assert!(acct.move_charge(ghost, VirtAddr::from(0xBEEFusize)).is_ok());
     assert!(acct.charge_kind(ghost).is_none());
+
+    // A transparent-huge-page 2 MiB block is a single charge entry that accounts
+    // for its 512 resident 4 KiB pages, so VmRSS/VmHWM reflect the whole block.
+    // Regression: a resident 2 MiB block previously counted as 1 page, so touching
+    // a THP-promoted mmap under-grew VmHWM (`proc-test-vmpeak-hwm`). This asserts
+    // the block charge counts, peaks, and decrements as 512 pages.
+    let huge = MemoryAccounting::new();
+    let hva = VirtAddr::from(0x20_0000usize);
+    huge.record_charge(hva, RssKind::Anon, 512).unwrap();
+    assert_eq!(huge.rss_anon_pages(), 512);
+    assert_eq!(huge.rss_total_pages(), 512);
+    assert_eq!(huge.hiwater_rss_pages(), 512);
+    let (ha, hf, hs) = huge.snapshot_resident_charges();
+    assert_eq!(ha, 512);
+    assert_eq!(hf, 0);
+    assert_eq!(hs, 0);
+    huge.remove_charge(hva);
+    assert_eq!(huge.rss_total_pages(), 0);
+    // hiwater keeps the 512 peak even after the block is unmapped.
+    assert_eq!(huge.hiwater_rss_pages(), 512);
+
+    // 2 MiB -> 4 KiB split conservation: replacing one 512-page block charge with
+    // 512 single-page charges leaves VmRSS unchanged (-512 + 512 * 1 == 0).
+    let split = MemoryAccounting::new();
+    let base = VirtAddr::from(0x40_0000usize);
+    split.record_charge(base, RssKind::Anon, 512).unwrap();
+    assert_eq!(split.rss_total_pages(), 512);
+    split.remove_charge(base);
+    for i in 0..512usize {
+        split
+            .record_charge(base + i * 0x1000, RssKind::Anon, 1)
+            .unwrap();
+    }
+    assert_eq!(split.rss_total_pages(), 512);
 
     true
 }
@@ -449,7 +506,7 @@ mod tests {
     fn record_remove_and_reclassify() {
         let acct = MemoryAccounting::new();
         let va = VirtAddr::from(0x1000usize);
-        acct.record_charge(va, RssKind::File).unwrap();
+        acct.record_charge(va, RssKind::File, 1).unwrap();
         assert_eq!(acct.rss_file_pages(), 1);
         assert!(acct.cow_file_write_to_anon(va));
         assert_eq!(acct.rss_file_pages(), 0);
@@ -463,7 +520,7 @@ mod tests {
         let acct = MemoryAccounting::new();
         let src = VirtAddr::from(0x1000usize);
         let dst = VirtAddr::from(0x2000usize);
-        acct.record_charge(src, RssKind::File).unwrap();
+        acct.record_charge(src, RssKind::File, 1).unwrap();
         acct.move_charge(src, dst).unwrap();
         assert!(acct.charge_kind(src).is_none());
         assert_eq!(acct.charge_kind(dst), Some(RssKind::File));
@@ -475,7 +532,7 @@ mod tests {
         let parent = MemoryAccounting::new();
         let child = MemoryAccounting::new();
         let va = VirtAddr::from(0x3000usize);
-        parent.record_charge(va, RssKind::File).unwrap();
+        parent.record_charge(va, RssKind::File, 1).unwrap();
         child.copy_charge_from(&parent, va).unwrap();
         assert_eq!(parent.rss_file_pages(), 1);
         assert_eq!(child.rss_file_pages(), 1);
@@ -491,7 +548,7 @@ mod tests {
             (VirtAddr::from(0x9000usize), RssKind::File),
         ];
         for (va, kind) in pages {
-            parent.record_charge(va, kind).unwrap();
+            parent.record_charge(va, kind, 1).unwrap();
         }
         for (va, _) in pages {
             child.copy_charge_from(&parent, va).unwrap();
@@ -511,7 +568,7 @@ mod tests {
         let parent = MemoryAccounting::new();
         let child = MemoryAccounting::new();
         let va = VirtAddr::from(0x9000usize);
-        parent.record_charge(va, RssKind::File).unwrap();
+        parent.record_charge(va, RssKind::File, 1).unwrap();
         child.copy_charge_from(&parent, va).unwrap();
         let (parent_anon, ..) = parent.snapshot_resident_charges();
         assert!(child.cow_file_write_to_anon(va));

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -590,7 +590,9 @@ impl CowBackend {
             return Err(err.into());
         }
         if let Some(acct) = acct {
-            acct.record_charge(vaddr, kind)?;
+            // A THP 2 MiB block is one charge accounting for its 512 resident pages,
+            // so VmRSS/VmHWM reflect the whole block, not a single page.
+            acct.record_charge(vaddr, kind, (self.size / PAGE_SIZE_4K) as u32)?;
         }
         Ok(())
     }
@@ -638,7 +640,7 @@ impl CowBackend {
                 return Err(err.into());
             }
             if let Some(acct) = acct {
-                acct.record_charge(addr, kind)?;
+                acct.record_charge(addr, kind, (self.size / PAGE_SIZE_4K) as u32)?;
             }
         }
         Ok(n)

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -11,6 +11,8 @@ use ax_runtime::hal::{
     mem::phys_to_virt,
     paging::{MappingFlags, PageTable, PagingError},
 };
+#[cfg(feature = "thp")]
+use ax_runtime::hal::paging::ReservedTable;
 
 use super::{
     AddrSpace, Backend, BackendFileInfo, BackendOps, CloneMapAccounting, MemoryAccounting,
@@ -81,6 +83,272 @@ impl FrameTableRefCount {
 }
 
 static FRAME_TABLE: IrqMutex<FrameTableRefCount> = IrqMutex::new(FrameTableRefCount::new());
+
+// ---- Transparent-huge-page 2 MiB -> 4 KiB split (feature `thp`) ----
+
+/// The 2 MiB huge-page size.
+#[cfg(feature = "thp")]
+const HUGE_2M: usize = 0x20_0000;
+/// Number of 4 KiB sub-pages in a 2 MiB block.
+#[cfg(feature = "thp")]
+const HUGE_2M_SUBPAGES: usize = HUGE_2M / PAGE_SIZE_4K; // 512
+
+/// How a prepared 2 MiB block split will be committed. Any allocation needed to
+/// break COW is done up front in [`prepare_huge_split_2m`], so committing is
+/// (buddy metadata + page-table) work that does not allocate a data frame.
+#[cfg(feature = "thp")]
+pub(crate) enum HugeSplitTarget {
+    /// Exclusive frame (refcount 1): explode the same 2 MiB buddy block in place
+    /// and re-map the 512 leaf PTEs to the *same* physical pages (no copy).
+    InPlace,
+    /// COW break into a fresh contiguous 2 MiB frame (already copied): drop the
+    /// shared ref and explode the new block.
+    CopiedContiguous(PhysAddr),
+    /// COW break into 512 independent 4 KiB frames (already copied) under
+    /// fragmentation: drop the shared ref; the frames are already order-0.
+    CopiedScattered(alloc::vec::Vec<PhysAddr>),
+}
+
+/// A resident 2 MiB block ready to be split to 4 KiB, with any COW-break copy
+/// **and** the 4 KiB leaf page table already allocated. Produced by
+/// [`prepare_huge_split_2m`], consumed by [`commit_huge_split_2m`], or released by
+/// [`abort_huge_split_2m`].
+#[cfg(feature = "thp")]
+pub(crate) struct HugeSplitPlan {
+    block_va: VirtAddr,
+    old_paddr: PhysAddr,
+    flags: MappingFlags,
+    target: HugeSplitTarget,
+    /// Pre-reserved, zeroed leaf page table spliced in at commit. Reserving it here
+    /// (not on the first `map` after unmapping the block) is what makes the commit
+    /// allocation-free, hence atomic against a fragmented / OOM heap.
+    table: ReservedTable,
+}
+
+/// Phase 1 (fallible, no page-table / refcount / charge mutation): decide how to
+/// split the resident 2 MiB block at `block_va`, pre-allocate + fill any COW-break
+/// copy, and reserve the 4 KiB leaf page table the commit will splice in. Returns
+/// `Ok(None)` when the block is not a resident 2 MiB block (lazy / already split).
+/// On allocation failure returns `Err` with nothing left allocated, so the caller
+/// can split a whole area atomically: prepare every block first, and only if all
+/// succeed commit them (an infallible, allocation-free phase 2).
+#[cfg(feature = "thp")]
+pub(crate) fn prepare_huge_split_2m(
+    block_va: VirtAddr,
+    pt: &PageTable,
+) -> StarryResult<Option<HugeSplitPlan>> {
+    debug_assert!(block_va.is_aligned(HUGE_2M), "block_va not 2M-aligned");
+
+    // `peek_huge_block` finds a present block AND a not-present one (an
+    // `mprotect(PROT_NONE)` over this THP block, which still owns a frame and must be
+    // split so a partial op can cut through it), returning `None` for a lazy /
+    // already-split / non-block address. Its config is the block's `MappingFlags`,
+    // preserved onto the 512 leaves so COW write-protection survives the split.
+    let (old_paddr, flags, size) = match pt.peek_huge_block(block_va) {
+        Some(v) => v,
+        None => return Ok(None),
+    };
+    if size != HUGE_2M {
+        return Ok(None);
+    }
+
+    // Classify the frame as exclusive or COW-shared.
+    let frame_ref = FRAME_TABLE
+        .lock()
+        .get_frame_ref(old_paddr)
+        .ok_or(StarryError::BadAddress)?;
+    let shared = {
+        let cnt = frame_ref.lock();
+        assert!(cnt.count > 0, "splitting unreferenced huge frame");
+        cnt.count > 1
+    };
+
+    let target = if !shared {
+        HugeSplitTarget::InPlace
+    } else if let Ok(new_paddr) = alloc_frame(false, HUGE_2M) {
+        // SAFETY: source and destination are distinct 2 MiB physical frames the
+        // kernel maps linearly; the destination is freshly allocated (exclusive).
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                phys_to_virt(old_paddr).as_ptr(),
+                phys_to_virt(new_paddr).as_mut_ptr(),
+                HUGE_2M,
+            );
+        }
+        HugeSplitTarget::CopiedContiguous(new_paddr)
+    } else {
+        // Scatter fallback: copy into 512 independent 4 KiB frames when no order-9
+        // block is available, so a COW break never fails for lack of a huge frame.
+        let mut frames = alloc::vec::Vec::with_capacity(HUGE_2M_SUBPAGES);
+        for i in 0..HUGE_2M_SUBPAGES {
+            match alloc_frame(false, PAGE_SIZE_4K) {
+                Ok(f) => {
+                    // SAFETY: distinct 4 KiB frames, destination freshly allocated.
+                    unsafe {
+                        core::ptr::copy_nonoverlapping(
+                            phys_to_virt(old_paddr + i * PAGE_SIZE_4K).as_ptr(),
+                            phys_to_virt(f).as_mut_ptr(),
+                            PAGE_SIZE_4K,
+                        );
+                    }
+                    frames.push(f);
+                }
+                Err(err) => {
+                    // Roll back the partial scatter; the shared 2 MiB frame is
+                    // untouched (ref not dropped) so peers stay safe.
+                    for f in frames {
+                        dealloc_frame(f, PAGE_SIZE_4K);
+                    }
+                    return Err(err);
+                }
+            }
+        }
+        HugeSplitTarget::CopiedScattered(frames)
+    };
+
+    // Reserve the 4 KiB leaf page table now, so the commit is allocation-free and
+    // therefore atomic against OOM. On failure roll back any COW-break copy and leave
+    // nothing allocated.
+    let table = match pt.alloc_intermediate_table() {
+        Ok(t) => t,
+        Err(_) => {
+            dealloc_split_target(target);
+            return Err(StarryError::NoMemory);
+        }
+    };
+
+    Ok(Some(HugeSplitPlan {
+        block_va,
+        old_paddr,
+        flags,
+        target,
+        table,
+    }))
+}
+
+/// Free the data frames a [`HugeSplitTarget`] holds (the pre-allocated COW-break
+/// copy, if any). Shared by the prepare rollback and [`abort_huge_split_2m`].
+#[cfg(feature = "thp")]
+fn dealloc_split_target(target: HugeSplitTarget) {
+    match target {
+        HugeSplitTarget::InPlace => {}
+        HugeSplitTarget::CopiedContiguous(new_paddr) => dealloc_frame(new_paddr, HUGE_2M),
+        HugeSplitTarget::CopiedScattered(frames) => {
+            for f in frames {
+                dealloc_frame(f, PAGE_SIZE_4K);
+            }
+        }
+    }
+}
+
+/// Release a prepared-but-not-committed split (frees the COW-break copy and the
+/// reserved leaf page table). Used to roll back an atomic whole-area split when a
+/// later block fails to prepare.
+#[cfg(feature = "thp")]
+pub(crate) fn abort_huge_split_2m(pt: &PageTable, plan: HugeSplitPlan) {
+    pt.dealloc_intermediate_table(plan.table);
+    dealloc_split_target(plan.target);
+}
+
+/// Phase 2 (commit): apply a prepared split — splice the 2 MiB block PTE into 512
+/// leaf PTEs, convert the [`FRAME_TABLE`] refcount and RSS charge to 4 KiB, and (for
+/// a COW break) drop this address space's reference to the shared frame. Preserves
+/// the block's current PTE permissions on the 512 leaf PTEs, so COW write-protection
+/// (lazy first-write copy) is not broken by the split.
+///
+/// Infallible: both the COW-break copy and the leaf page table were reserved in
+/// [`prepare_huge_split_2m`], so this performs no *recoverable* allocation and cannot
+/// leave a half-split (torn) mapping. Must be called with the owning
+/// [`super::AddrSpace`] locked.
+#[cfg(feature = "thp")]
+pub(crate) fn commit_huge_split_2m(
+    plan: HugeSplitPlan,
+    acct: Option<&MemoryAccounting>,
+    pt: &mut PageTable,
+) {
+    let HugeSplitPlan {
+        block_va,
+        old_paddr,
+        flags,
+        target,
+        table,
+    } = plan;
+
+    // Splice in the pre-reserved (zeroed) leaf page table over the 2 MiB block: the
+    // break-before-make (invalidate the block + flush, then install the empty table)
+    // happens inside `split_huge_block_to_empty_table`, which leaves the 512 leaves
+    // unmapped for the loop below to install. The block stayed a present 2 MiB page
+    // under the address-space lock from prepare to here, so this cannot fail.
+    pt.split_huge_block_to_empty_table(block_va, table)
+        .expect("prepared 2 MiB block is no longer a huge mapping at commit");
+
+    // Establish the 512 target sub-frame physical addresses + buddy state.
+    let sub_paddrs: alloc::vec::Vec<PhysAddr> = match target {
+        HugeSplitTarget::InPlace => {
+            // Retag the same buddy block. Remove the single 2 MiB refcount entry
+            // first; it is re-registered as 512 4 KiB entries below.
+            FRAME_TABLE.lock().remove_frame(old_paddr);
+            super::split_frame(old_paddr);
+            (0..HUGE_2M_SUBPAGES)
+                .map(|i| old_paddr + i * PAGE_SIZE_4K)
+                .collect()
+        }
+        HugeSplitTarget::CopiedContiguous(new_paddr) => {
+            drop_shared_huge_ref(old_paddr);
+            super::split_frame(new_paddr);
+            (0..HUGE_2M_SUBPAGES)
+                .map(|i| new_paddr + i * PAGE_SIZE_4K)
+                .collect()
+        }
+        HugeSplitTarget::CopiedScattered(frames) => {
+            drop_shared_huge_ref(old_paddr);
+            frames
+        }
+    };
+
+    {
+        let mut frame_table = FRAME_TABLE.lock();
+        for &pa in &sub_paddrs {
+            frame_table.init_frame(pa);
+        }
+    }
+
+    // Install the 512 leaf PTEs into the pre-reserved table, preserving the block's
+    // permissions. These cannot allocate (the table already exists) and the slots are
+    // freshly zeroed, so none of these `map`s can fail.
+    for (i, &pa) in sub_paddrs.iter().enumerate() {
+        pt.map_page(block_va + i * PAGE_SIZE_4K, pa, PAGE_SIZE_4K, flags)
+            .expect("leaf map into the pre-reserved split table cannot fail");
+    }
+
+    // Convert the single 2 MiB RSS charge into 512 4 KiB charges so a per-4 KiB
+    // unmap/reclassify finds an entry at each page VA. The sub-page VAs are fresh
+    // (only the 2 MiB VA was charged), so `record_charge_fresh` is infallible.
+    if let Some(acct) = acct {
+        let kind = match acct.charge_kind(block_va) {
+            Some(k) => {
+                acct.remove_charge(block_va);
+                k
+            }
+            None => RssKind::Anon,
+        };
+        for i in 0..HUGE_2M_SUBPAGES {
+            acct.record_charge_fresh(block_va + i * PAGE_SIZE_4K, kind);
+        }
+    }
+}
+
+/// Drop this address space's reference to a COW-shared 2 MiB frame after copying it
+/// privately. Peers keep their intact 2 MiB block view; the frame is freed only when
+/// the last sharer drops it.
+#[cfg(feature = "thp")]
+fn drop_shared_huge_ref(old_paddr: PhysAddr) {
+    let frame_ref = FRAME_TABLE
+        .lock()
+        .get_frame_ref(old_paddr)
+        .expect("shared huge frame vanished before commit");
+    frame_ref.lock().drop_frame(old_paddr, HUGE_2M);
+}
 
 fn cow_file_max_read_len(
     file_len: u64,

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -13,6 +13,8 @@ use ax_runtime::hal::{
 };
 #[cfg(feature = "thp")]
 use ax_runtime::hal::paging::ReservedTable;
+#[cfg(feature = "thp")]
+use super::HUGE_2M;
 
 use super::{
     AddrSpace, Backend, BackendFileInfo, BackendOps, CloneMapAccounting, MemoryAccounting,
@@ -86,9 +88,6 @@ static FRAME_TABLE: IrqMutex<FrameTableRefCount> = IrqMutex::new(FrameTableRefCo
 
 // ---- Transparent-huge-page 2 MiB -> 4 KiB split (feature `thp`) ----
 
-/// The 2 MiB huge-page size.
-#[cfg(feature = "thp")]
-const HUGE_2M: usize = 0x20_0000;
 /// Number of 4 KiB sub-pages in a 2 MiB block.
 #[cfg(feature = "thp")]
 const HUGE_2M_SUBPAGES: usize = HUGE_2M / PAGE_SIZE_4K; // 512

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -249,15 +249,30 @@ pub(crate) fn abort_huge_split_2m(pt: &PageTable, plan: HugeSplitPlan) {
     dealloc_split_target(plan.target);
 }
 
+/// Where a commit sources the 512 4 KiB sub-frames — computed allocation-free so the
+/// commit never builds a `Vec` that could `handle_alloc_error`-abort mid-split.
+#[cfg(feature = "thp")]
+enum SubFrames {
+    /// A retagged-in-place or freshly-copied contiguous 2 MiB frame: the `i`-th
+    /// sub-frame is `base + i * 4 KiB`.
+    Contiguous(PhysAddr),
+    /// The scattered 4 KiB frames pre-allocated in [`prepare_huge_split_2m`] (phase 1),
+    /// so holding them here is not a phase-2 allocation.
+    Scattered(alloc::vec::Vec<PhysAddr>),
+}
+
 /// Phase 2 (commit): apply a prepared split — splice the 2 MiB block PTE into 512
 /// leaf PTEs, convert the [`FRAME_TABLE`] refcount and RSS charge to 4 KiB, and (for
 /// a COW break) drop this address space's reference to the shared frame. Preserves
 /// the block's current PTE permissions on the 512 leaf PTEs, so COW write-protection
 /// (lazy first-write copy) is not broken by the split.
 ///
-/// Infallible: both the COW-break copy and the leaf page table were reserved in
-/// [`prepare_huge_split_2m`], so this performs no *recoverable* allocation and cannot
-/// leave a half-split (torn) mapping. Must be called with the owning
+/// Never leaves a *torn* (half-split) mapping: the COW-break copy and the leaf page
+/// table were reserved in [`prepare_huge_split_2m`], and the 512 sub-frame paddrs are
+/// derived allocation-free (base + index, or the pre-reserved scattered frames), so
+/// there is no *recoverable* allocation to fail. The `FRAME_TABLE` / RSS book-keeping
+/// inserts do use the infallible global allocator, which *aborts* (never tears) on
+/// true OOM, as everywhere else in the kernel. Must be called with the owning
 /// [`super::AddrSpace`] locked.
 #[cfg(feature = "thp")]
 pub(crate) fn commit_huge_split_2m(
@@ -281,43 +296,51 @@ pub(crate) fn commit_huge_split_2m(
     pt.split_huge_block_to_empty_table(block_va, table)
         .expect("prepared 2 MiB block is no longer a huge mapping at commit");
 
-    // Establish the 512 target sub-frame physical addresses + buddy state.
-    let sub_paddrs: alloc::vec::Vec<PhysAddr> = match target {
+    // Establish where the 512 target sub-frames come from + fix up buddy state.
+    // Deriving each sub-frame paddr allocation-free (base + index, or the phase-1
+    // pre-reserved scattered frames) keeps the commit torn-free: no `Vec` is built
+    // here, so nothing in this phase can `handle_alloc_error`-abort mid-split.
+    let sub_frames = match target {
         HugeSplitTarget::InPlace => {
             // Retag the same buddy block. Remove the single 2 MiB refcount entry
             // first; it is re-registered as 512 4 KiB entries below.
             FRAME_TABLE.lock().remove_frame(old_paddr);
             super::split_frame(old_paddr);
-            (0..HUGE_2M_SUBPAGES)
-                .map(|i| old_paddr + i * PAGE_SIZE_4K)
-                .collect()
+            SubFrames::Contiguous(old_paddr)
         }
         HugeSplitTarget::CopiedContiguous(new_paddr) => {
             drop_shared_huge_ref(old_paddr);
             super::split_frame(new_paddr);
-            (0..HUGE_2M_SUBPAGES)
-                .map(|i| new_paddr + i * PAGE_SIZE_4K)
-                .collect()
+            SubFrames::Contiguous(new_paddr)
         }
         HugeSplitTarget::CopiedScattered(frames) => {
             drop_shared_huge_ref(old_paddr);
-            frames
+            SubFrames::Scattered(frames)
         }
+    };
+    let sub_paddr = |i: usize| match &sub_frames {
+        SubFrames::Contiguous(base) => *base + i * PAGE_SIZE_4K,
+        SubFrames::Scattered(frames) => frames[i],
     };
 
     {
         let mut frame_table = FRAME_TABLE.lock();
-        for &pa in &sub_paddrs {
-            frame_table.init_frame(pa);
+        for i in 0..HUGE_2M_SUBPAGES {
+            frame_table.init_frame(sub_paddr(i));
         }
     }
 
     // Install the 512 leaf PTEs into the pre-reserved table, preserving the block's
     // permissions. These cannot allocate (the table already exists) and the slots are
     // freshly zeroed, so none of these `map`s can fail.
-    for (i, &pa) in sub_paddrs.iter().enumerate() {
-        pt.map_page(block_va + i * PAGE_SIZE_4K, pa, PAGE_SIZE_4K, flags)
-            .expect("leaf map into the pre-reserved split table cannot fail");
+    for i in 0..HUGE_2M_SUBPAGES {
+        pt.map_page(
+            block_va + i * PAGE_SIZE_4K,
+            sub_paddr(i),
+            PAGE_SIZE_4K,
+            flags,
+        )
+        .expect("leaf map into the pre-reserved split table cannot fail");
     }
 
     // Convert the single 2 MiB RSS charge into 512 4 KiB charges so a per-4 KiB

--- a/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/cow.rs
@@ -7,15 +7,15 @@ use core::{cell::Cell, slice};
 
 use ax_fs_ng::vfs::FileBackend;
 use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, PhysAddr, VirtAddr, VirtAddrRange, align_down_4k};
+#[cfg(feature = "thp")]
+use ax_runtime::hal::paging::ReservedTable;
 use ax_runtime::hal::{
     mem::phys_to_virt,
     paging::{MappingFlags, PageTable, PagingError},
 };
-#[cfg(feature = "thp")]
-use ax_runtime::hal::paging::ReservedTable;
+
 #[cfg(feature = "thp")]
 use super::HUGE_2M;
-
 use super::{
     AddrSpace, Backend, BackendFileInfo, BackendOps, CloneMapAccounting, MemoryAccounting,
     PopulateCallback, RssKind, alloc_frame, dealloc_frame, pages_in,

--- a/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
@@ -25,6 +25,12 @@ mod shared;
 pub(crate) use self::cow::{
     cow_file_max_read_len_boundary_rules_hold_for_test, private_mmap_eof_check_for_test,
 };
+/// The transparent-huge-page block size (2 MiB), shared by the split machinery and
+/// the aspace driver/hooks.
+#[cfg(feature = "thp")]
+pub(crate) const HUGE_2M: usize = 0x20_0000;
+#[cfg(feature = "thp")]
+pub(crate) use self::cow::{abort_huge_split_2m, commit_huge_split_2m, prepare_huge_split_2m};
 pub use self::shared::SharedPages;
 pub use super::accounting::RssKind;
 use super::{
@@ -71,7 +77,7 @@ fn pages_in(range: VirtAddrRange, align: usize) -> StarryResult<DynPageIter<Virt
     DynPageIter::new(range.start, range.end, align).ok_or(StarryError::InvalidInput)
 }
 
-type PopulateCallback = Box<dyn FnOnce(&mut AddrSpace)>;
+pub(crate) type PopulateCallback = Box<dyn FnOnce(&mut AddrSpace)>;
 
 #[enum_dispatch]
 pub trait BackendOps {

--- a/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/backend/mod.rs
@@ -58,6 +58,15 @@ pub(crate) fn dealloc_frame(frame: PhysAddr, align: usize) {
     global_allocator().dealloc_pages(vaddr.as_usize(), num_pages, UsageKind::VirtMem);
 }
 
+/// Retag a contiguous order-N buddy block as independent order-0 4 KiB frames, so a
+/// transparent-huge-page 2 MiB block can be split into 512 individually-freeable
+/// pages without copying (the physical-frame half of a huge->4K split).
+#[cfg(feature = "thp")]
+pub(crate) fn split_frame(frame: PhysAddr) {
+    let vaddr = phys_to_virt(frame);
+    global_allocator().split_pages(vaddr.as_usize());
+}
+
 fn pages_in(range: VirtAddrRange, align: usize) -> StarryResult<DynPageIter<VirtAddr>> {
     DynPageIter::new(range.start, range.end, align).ok_or(StarryError::InvalidInput)
 }

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -233,21 +233,55 @@ impl AddrSpace {
         let end = start + size;
 
         loop {
+            #[cfg(feature = "thp")]
+            let mut downgrade_area: Option<VirtAddr> = None;
             let (area_end, callback) = {
                 let Some(area) = self.areas.find(start) else {
                     break;
                 };
+                #[cfg(feature = "thp")]
+                let page_size = area.backend().page_size();
+                #[cfg(feature = "thp")]
+                let area_start = area.start();
+                // THP: align the fill range to the AREA's page size, not the
+                // caller's. A 2 MiB backend's `populate` requires a 2 MiB-aligned
+                // range (`pages_in`); a 4 KiB user-access range would fault
+                // `InvalidInput`, surfacing as a spurious EFAULT on a valid pointer.
+                // A 4 KiB area is already 4 KiB-aligned, so the non-thp build keeps
+                // the exact old range.
+                #[cfg(feature = "thp")]
+                let range = VirtAddrRange::new(
+                    start.align_down(page_size).max(area.start()),
+                    area.end().min(end.align_up(page_size)),
+                );
+                #[cfg(not(feature = "thp"))]
                 let range = VirtAddrRange::new(start, area.end().min(end));
                 let flags = area.flags();
-                let (_, callback) = area.backend().populate(
+                match area.backend().populate(
                     range,
                     flags,
                     access_flags,
                     Some(&self.rss),
                     &mut self.pt,
-                )?;
-                (area.end(), callback)
+                ) {
+                    Ok((_, callback)) => (area.end(), callback),
+                    // THP fragmentation fallback: a 2 MiB anon area that cannot
+                    // obtain an order-9 frame is downgraded to 4 KiB and the same
+                    // `start` retried at 4 KiB below (never fail an eager fill on a
+                    // fragmented heap).
+                    #[cfg(feature = "thp")]
+                    Err(StarryError::NoMemory) if page_size == backend::HUGE_2M => {
+                        downgrade_area = Some(area_start);
+                        (area.end(), None)
+                    }
+                    Err(err) => return Err(err),
+                }
             };
+            #[cfg(feature = "thp")]
+            if let Some(area_start) = downgrade_area {
+                self.split_huge_area(area_start)?;
+                continue;
+            }
             // Run the eviction cleanup the populate deferred (unmap + TLB flush
             // for page-cache pages evicted during this fill). Dropping it — as
             // the old code did — frees an evicted frame while its user PTE still
@@ -276,6 +310,11 @@ impl AddrSpace {
     pub fn discard_range(&mut self, start: VirtAddr, size: usize) -> StarryResult {
         self.validate_region(start, size)?;
         let end = start + size;
+
+        // THP: a sub-2 MiB DONTNEED on a promoted huge area rounds inward to a
+        // no-op (regression) unless the partially-covered area is split to 4 KiB.
+        #[cfg(feature = "thp")]
+        self.split_huge_for_partial_op(start, end)?;
 
         let mut frags: alloc::vec::Vec<(VirtAddrRange, Backend)> = alloc::vec::Vec::new();
         for area in self.areas.iter() {
@@ -315,6 +354,12 @@ impl AddrSpace {
 
         // Compute the actual mapped bytes being removed (unmap is already O(n)).
         let end = start + size;
+
+        // THP: split any huge area an unmap boundary bisects to 4 KiB first, so a
+        // sub-2 MiB unmap is well-formed (a whole-block unmap is left as a block).
+        #[cfg(feature = "thp")]
+        self.split_huge_for_partial_op(start, end)?;
+
         let removed_pages: u64 = self
             .areas
             .iter()
@@ -528,6 +573,11 @@ impl AddrSpace {
     ) -> StarryResult {
         self.validate_region(start, size)?;
 
+        // THP: split any huge area an mprotect boundary bisects to 4 KiB first, so a
+        // sub-2 MiB protect is well-formed.
+        #[cfg(feature = "thp")]
+        self.split_huge_for_partial_op(start, start + size)?;
+
         let touched_memfds =
             crate::syscall::memfd_collect_metas_touching_mprotect_range(self, start, size);
         let _rss = RssAccountingGuard::enter(&self.rss);
@@ -591,42 +641,218 @@ impl AddrSpace {
     ///
     /// Returns `true` if the page fault is handled successfully (not a real
     /// fault).
+    /// Populate `range` from its area's backend, re-finding the area (a preceding
+    /// THP split may have replaced it). Returns the pages filled and the deferred
+    /// eviction cleanup.
+    fn populate_range(
+        &mut self,
+        range: VirtAddrRange,
+        flags: MappingFlags,
+        access_flags: MappingFlags,
+    ) -> StarryResult<(usize, Option<backend::PopulateCallback>)> {
+        let Some(area) = self.areas.find(range.start) else {
+            return Ok((0, None));
+        };
+        area.backend()
+            .populate(range, flags, access_flags, Some(&self.rss), &mut self.pt)
+    }
+
+    /// THP: collect the start VAs of `Size2M` anonymous areas overlapping
+    /// `[start, end)`. With `partial_only`, only areas an op boundary strictly
+    /// bisects are returned; otherwise every overlapping huge area. Read-only
+    /// pre-pass for the split helpers, which call [`split_huge_area`](Self::split_huge_area)
+    /// on each collected start.
+    #[cfg(feature = "thp")]
+    fn collect_huge_area_starts(
+        &self,
+        start: VirtAddr,
+        end: VirtAddr,
+        partial_only: bool,
+    ) -> alloc::vec::Vec<VirtAddr> {
+        let mut to_split = alloc::vec::Vec::new();
+        for area in self.areas.iter() {
+            if area.start() >= end {
+                break;
+            }
+            if area.end() <= start {
+                continue;
+            }
+            let is_huge = matches!(
+                area.backend(),
+                Backend::Cow(c) if c.is_anonymous() && c.page_size() == backend::HUGE_2M
+            );
+            // Partial coverage: an op boundary lies strictly inside the area.
+            let partial = area.start() < start || end < area.end();
+            if is_huge && (!partial_only || partial) {
+                to_split.push(area.start());
+            }
+        }
+        to_split
+    }
+
+    /// THP: split every `Size2M` anonymous area that `[start, end)` only
+    /// *partially* covers into 4 KiB PTEs, so a following sub-2 MiB
+    /// unmap/protect/discard on it is well-formed. Areas fully contained in
+    /// `[start, end)` are left as 2 MiB blocks (whole-block ops stay valid).
+    #[cfg(feature = "thp")]
+    fn split_huge_for_partial_op(&mut self, start: VirtAddr, end: VirtAddr) -> StarryResult {
+        for area_start in self.collect_huge_area_starts(start, end, true) {
+            self.split_huge_area(area_start)?;
+        }
+        Ok(())
+    }
+
+    /// THP: split *every* `Size2M` anonymous area overlapping `[start, end)` down
+    /// to 4 KiB — including fully-covered ones — implementing `MADV_NOHUGEPAGE`.
+    /// THP-lite only promotes at mmap time and never re-promotes, so splitting is
+    /// sufficient to clear huge pages from the range.
+    #[cfg(feature = "thp")]
+    fn split_huge_range(&mut self, start: VirtAddr, end: VirtAddr) -> StarryResult {
+        for area_start in self.collect_huge_area_starts(start, end, false) {
+            self.split_huge_area(area_start)?;
+        }
+        Ok(())
+    }
+
+    /// Split any transparent huge pages in `[start, start+size)` back to 4 KiB,
+    /// implementing Linux `MADV_NOHUGEPAGE`. A no-op without the `thp` feature (no
+    /// huge pages exist) or when the range holds none. May COW-break a shared huge
+    /// block, so it can return `NoMemory` where Linux — which only sets a VMA
+    /// flag — would not.
+    pub fn split_huge_pages(&mut self, start: VirtAddr, size: usize) -> StarryResult {
+        self.validate_region(start, size)?;
+        #[cfg(feature = "thp")]
+        self.split_huge_range(start, start + size)?;
+        Ok(())
+    }
+
+    /// THP: convert one entire `Size2M` anonymous area to 4 KiB granularity,
+    /// atomically against allocation failure. Phase 1
+    /// ([`prepare_huge_split_2m`](backend::prepare_huge_split_2m)) pre-allocates
+    /// every COW-break copy *and* leaf page table; if any block cannot be prepared
+    /// the prepared ones are released ([`abort_huge_split_2m`](backend::abort_huge_split_2m))
+    /// and the area is left a valid `Size2M` area. Phase 2
+    /// ([`commit_huge_split_2m`](backend::commit_huge_split_2m)) splices the
+    /// reserved tables and re-maps the leaves without allocating, so it cannot fail
+    /// partway — either the whole area splits or none of it does.
+    #[cfg(feature = "thp")]
+    fn split_huge_area(&mut self, area_start: VirtAddr) -> StarryResult {
+        let (start, end, size, flags, reported_flags) = {
+            let Some(area) = self.areas.find(area_start) else {
+                return Ok(());
+            };
+            match area.backend() {
+                Backend::Cow(c) if c.is_anonymous() && c.page_size() == backend::HUGE_2M => {}
+                _ => return Ok(()),
+            }
+            (
+                area.start(),
+                area.end(),
+                area.size(),
+                area.flags(),
+                area.reported_flags(),
+            )
+        };
+
+        // Phase 1: prepare every resident block (pre-allocates COW-break copies and
+        // leaf page tables). On any failure release what was prepared and leave the
+        // area untouched.
+        let mut plans = alloc::vec::Vec::new();
+        let mut va = start;
+        let mut prepare_err = None;
+        while va < end {
+            match backend::prepare_huge_split_2m(va, &self.pt) {
+                Ok(Some(plan)) => plans.push(plan),
+                Ok(None) => {}
+                Err(err) => {
+                    prepare_err = Some(err);
+                    break;
+                }
+            }
+            va += backend::HUGE_2M;
+        }
+        if let Some(err) = prepare_err {
+            for plan in plans {
+                backend::abort_huge_split_2m(&self.pt, plan);
+            }
+            return Err(err);
+        }
+
+        // Phase 2: commit each prepared block. Commit is infallible (the leaf table
+        // and any COW-break copy were reserved in phase 1), so once phase 1 succeeds
+        // the whole area splits — it can never be left partway.
+        for plan in plans {
+            backend::commit_huge_split_2m(plan, Some(&self.rss), &mut self.pt);
+        }
+
+        // PTEs are now 4 KiB; downgrade the VMA to a fresh 4 KiB anon backend.
+        let new_backend = Backend::new_alloc(start, PAGE_SIZE_4K, "");
+        self.replace_area_metadata_with_reported_flags(
+            start,
+            size,
+            flags,
+            reported_flags,
+            new_backend,
+        )?;
+        Ok(())
+    }
+
     pub fn handle_page_fault(&mut self, vaddr: VirtAddr, access_flags: PageFaultFlags) -> bool {
         if !self.va_range.contains(vaddr) {
             return false;
         }
         let access_flags = MappingFlags::from(access_flags);
-        if let Some(area) = self.areas.find(vaddr) {
-            let flags = area.flags();
-            if flags.contains(access_flags) {
-                let page_size = area.backend().page_size();
-                let populate_result = area.backend().populate(
-                    VirtAddrRange::from_start_size(vaddr.align_down(page_size), page_size as _),
-                    flags,
-                    access_flags,
-                    Some(&self.rss),
-                    &mut self.pt,
-                );
-                return match populate_result {
-                    Ok((n, callback)) => {
-                        if let Some(cb) = callback {
-                            cb(self);
-                        }
-                        if n == 0 {
-                            warn!("No pages populated for {vaddr:?} ({flags:?})");
-                            false
-                        } else {
-                            true
-                        }
-                    }
-                    Err(err) => {
-                        warn!("Failed to populate pages for {vaddr:?} ({flags:?}): {err}");
-                        false
-                    }
-                };
+        // Extract the area's fields up front so the borrow is released before a THP
+        // split (which needs `&mut self`) or the re-find in `populate_range`.
+        let Some((flags, page_size, _area_start)) = self
+            .areas
+            .find(vaddr)
+            .map(|area| (area.flags(), area.backend().page_size(), area.start()))
+        else {
+            return false;
+        };
+        if !flags.contains(access_flags) {
+            return false;
+        }
+
+        let range = VirtAddrRange::from_start_size(vaddr.align_down(page_size), page_size);
+        // `mut` only under `thp`, where the fragmentation fallback below reassigns it.
+        #[cfg(feature = "thp")]
+        let mut populate_result = self.populate_range(range, flags, access_flags);
+        #[cfg(not(feature = "thp"))]
+        let populate_result = self.populate_range(range, flags, access_flags);
+
+        // THP fragmentation fallback: a 2 MiB anon block that cannot obtain an
+        // order-9 buddy frame downgrades its whole area to 4 KiB and re-faults at
+        // 4 KiB, so a fragmented heap never turns a huge promotion into a fatal
+        // fault. The exclusive in-place split needs no allocation.
+        #[cfg(feature = "thp")]
+        if matches!(populate_result, Err(StarryError::NoMemory))
+            && page_size == backend::HUGE_2M
+            && self.split_huge_area(_area_start).is_ok()
+        {
+            let range4k =
+                VirtAddrRange::from_start_size(vaddr.align_down(PAGE_SIZE_4K), PAGE_SIZE_4K);
+            populate_result = self.populate_range(range4k, flags, access_flags);
+        }
+
+        match populate_result {
+            Ok((n, callback)) => {
+                if let Some(cb) = callback {
+                    cb(self);
+                }
+                if n == 0 {
+                    warn!("No pages populated for {vaddr:?} ({flags:?})");
+                    false
+                } else {
+                    true
+                }
+            }
+            Err(err) => {
+                warn!("Failed to populate pages for {vaddr:?} ({flags:?}): {err}");
+                false
             }
         }
-        false
     }
 
     /// Attempts to clone the current address space into a new one.

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -68,6 +68,93 @@ impl From<MmapProt> for MappingFlags {
     }
 }
 
+/// THP-lite: is this mmap a candidate for transparent 2 MiB huge-page promotion?
+/// Gated on a writable mapping of at least one 2 MiB block that does not opt out
+/// via `MAP_NORESERVE` (sparse touch would inflate RSS/VA) or a per-process
+/// `PR_SET_THP_DISABLE`.
+#[cfg(feature = "thp")]
+fn thp_eligible(
+    map_flags: MmapFlags,
+    mapping_flags: MappingFlags,
+    length: usize,
+    thp_disabled: bool,
+) -> bool {
+    length >= PAGE_SIZE_2M
+        && mapping_flags.contains(MappingFlags::WRITE)
+        && !map_flags.contains(MmapFlags::NORESERVE)
+        && !thp_disabled
+}
+
+/// THP-lite: back the interior of a large private-anonymous mapping with 2 MiB
+/// blocks. The region is carved into `[4 KiB head][2 MiB body][4 KiB tail]` — only
+/// the 2 MiB-aligned interior gets a `Size2M` backend; the unaligned edges stay
+/// `Size4K`. The area is never rounded up to 2 MiB (that would break `/proc/*/maps`
+/// and the mmap return length).
+///
+/// Returns `Ok(true)` when installed, `Ok(false)` when alignment leaves no full
+/// 2 MiB block (caller falls back to a plain 4 KiB mapping). On a mid-carve error
+/// the whole region is unmapped so no partial mapping leaks.
+#[cfg(feature = "thp")]
+fn thp_map_promoted_anon(
+    aspace: &mut crate::mm::AddrSpace,
+    start: VirtAddr,
+    length: usize,
+    flags: MappingFlags,
+    reported_flags: MappingFlags,
+    populate: bool,
+) -> StarryResult<bool> {
+    let region_end = start + length;
+    let body_start = start.align_up(PAGE_SIZE_2M);
+    let body_end = region_end.align_down(PAGE_SIZE_2M);
+    if body_start >= body_end {
+        // Misalignment leaves no full 2 MiB block; use the plain 4 KiB path.
+        return Ok(false);
+    }
+
+    let carve = |aspace: &mut crate::mm::AddrSpace| -> StarryResult {
+        if start < body_start {
+            aspace.map_with_reported_flags(
+                start,
+                body_start - start,
+                flags,
+                reported_flags,
+                populate,
+                Backend::new_alloc(start, PAGE_SIZE_4K, ""),
+            )?;
+        }
+        aspace.map_with_reported_flags(
+            body_start,
+            body_end - body_start,
+            flags,
+            reported_flags,
+            populate,
+            Backend::new_alloc(body_start, PAGE_SIZE_2M, ""),
+        )?;
+        if body_end < region_end {
+            aspace.map_with_reported_flags(
+                body_end,
+                region_end - body_end,
+                flags,
+                reported_flags,
+                populate,
+                Backend::new_alloc(body_end, PAGE_SIZE_4K, ""),
+            )?;
+        }
+        Ok(())
+    };
+
+    match carve(aspace) {
+        Ok(()) => Ok(true),
+        Err(err) => {
+            // Roll back any sub-area already mapped so the mmap fails atomically.
+            if let Err(e) = aspace.unmap(start, length) {
+                warn!("THP promote rollback unmap failed: {e:?}");
+            }
+            Err(err)
+        }
+    }
+}
+
 fn reported_mapping_flags_from_prot(value: MmapProt) -> MappingFlags {
     let mut flags = MappingFlags::empty();
     if value.contains(MmapProt::READ) {
@@ -355,6 +442,32 @@ pub fn sys_mmap(
 
     let mut mapping_flags: MappingFlags = permission_flags.into();
     let reported_mapping_flags = reported_mapping_flags_from_prot(permission_flags);
+
+    // THP-lite: promote an eligible writable private-anonymous mapping to 2 MiB
+    // blocks before the plain 4 KiB backend path. `page_size == PAGE_SIZE_4K`
+    // excludes explicit hugetlb (`MAP_HUGE_*`) requests.
+    #[cfg(feature = "thp")]
+    if anonymous
+        && matches!(map_type, MmapFlags::PRIVATE)
+        && page_size == PAGE_SIZE_4K
+        && thp_eligible(
+            map_flags,
+            mapping_flags,
+            length,
+            current().as_thread().proc_data.thp_disable() != 0,
+        )
+        && thp_map_promoted_anon(
+            &mut aspace,
+            start,
+            length,
+            mapping_flags,
+            reported_mapping_flags,
+            map_flags.contains(MmapFlags::POPULATE),
+        )?
+    {
+        drop(aspace);
+        return Ok(start.as_usize() as _);
+    }
 
     let backend = match map_type {
         MmapFlags::SHARED => {
@@ -1053,6 +1166,14 @@ pub fn sys_madvise(addr: usize, length: usize, advice: i32) -> StarryResult<isiz
                 }
             }
             aspace.discard_range(start_va, length)?;
+            None
+        }
+        MADV_NOHUGEPAGE => {
+            // Split any transparent huge pages in the range back to 4 KiB. THP-lite
+            // promotes only at mmap time and never re-promotes, so MADV_HUGEPAGE is
+            // accepted as a no-op (handled by the accepted-advice list above), and
+            // this call is a validate-only no-op without the `thp` feature.
+            aspace.split_huge_pages(start_va, align_up_4k(length))?;
             None
         }
         MADV_REMOVE => {

--- a/os/StarryOS/kernel/src/syscall/mm/mmap.rs
+++ b/os/StarryOS/kernel/src/syscall/mm/mmap.rs
@@ -939,6 +939,34 @@ pub fn sys_mremap(
     let aspace_ref = &curr.as_thread().proc_data.aspace();
     let mut aspace = aspace_ref.lock();
 
+    // THP: Linux `mremap` operates at 4 KiB granularity. A THP-promoted source
+    // area reports a 2 MiB `page_size`, which the logic below would treat as the
+    // ABI granularity — forcing 2 MiB alignment, rounding `old_size`/`new_size`
+    // up to 2 MiB, and moving whole 2 MiB blocks (so a 4 KiB `MREMAP_FIXED` of a
+    // promoted block head would `EINVAL` on a 4 KiB-aligned target or move the
+    // entire block). When the request is not a whole 2 MiB-aligned move, split the
+    // affected THP area back to 4 KiB first — which downgrades its VMA to a 4 KiB
+    // backend — so the code below uses the 4 KiB granularity and moves only the
+    // requested pages. A fully 2 MiB-aligned move keeps the huge mapping.
+    #[cfg(feature = "thp")]
+    if old_size != 0 {
+        let thp_area = aspace.find_area(addr).and_then(|area| {
+            let backend = area.backend();
+            let is_thp = matches!(backend, Backend::Cow(cow) if cow.is_anonymous())
+                && backend.page_size() == PAGE_SIZE_2M;
+            is_thp.then(|| (area.start(), area.size()))
+        });
+        if let Some((area_start, area_size)) = thp_area {
+            let whole_2m_move = addr.is_aligned(PAGE_SIZE_2M)
+                && old_size.is_multiple_of(PAGE_SIZE_2M)
+                && new_size.is_multiple_of(PAGE_SIZE_2M)
+                && (!fixed || new_addr.is_multiple_of(PAGE_SIZE_2M));
+            if !whole_2m_move {
+                aspace.split_huge_pages(area_start, area_size)?;
+            }
+        }
+    }
+
     let (vma_start, vma_end, vma_flags, vma_reported_flags, src_backend, shared_pages, page_size) = {
         let area = aspace.find_area(addr).ok_or(StarryError::BadAddress)?;
         let shared_pages = match area.backend() {

--- a/os/arceos/modules/axhal/src/paging.rs
+++ b/os/arceos/modules/axhal/src/paging.rs
@@ -44,3 +44,5 @@ impl FrameAllocator for PagingAllocator {
 pub type PageTable = page_table_generic::PageTable<ArchPagingMeta, PagingAllocator>;
 /// A non-owning reference to an architecture-specific page table.
 pub type PageTableRef = page_table_generic::PageTableRef<ArchPagingMeta, PagingAllocator>;
+/// A single reserved child-table frame for a break-before-make huge-page split.
+pub type ReservedTable = page_table_generic::ReservedTable<ArchPagingMeta, PagingAllocator>;

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -254,10 +254,21 @@ fn run_std_tests<R: CargoRunner>(
 
 fn package_feature_profiles(package: &str) -> Option<&'static [PackageFeatureProfile]> {
     match package {
-        "arm_vgic" | "axdevice" | "axfs-ng-vfs" | "rsext4" | "scope-local" | "ax-sync" | "axvm"
-        | "ax-display" | "ax-input" | "ax-ipi" | "ax-log" | "ax-runtime" | "ax-api" | "rdrive" => {
-            Some(HOST_TEST_FEATURE_PROFILES)
-        }
+        "arm_vgic"
+        | "axdevice"
+        | "axfs-ng-vfs"
+        | "rsext4"
+        | "scope-local"
+        | "ax-sync"
+        | "axvm"
+        | "ax-display"
+        | "ax-input"
+        | "ax-ipi"
+        | "ax-log"
+        | "ax-runtime"
+        | "ax-api"
+        | "rdrive"
+        | "buddy-slab-allocator" => Some(HOST_TEST_FEATURE_PROFILES),
         "ax-task" => Some(AX_TASK_FEATURE_PROFILES),
         "ax-driver" => Some(AX_DRIVER_FEATURE_PROFILES),
         _ => None,

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -27,6 +27,7 @@ starry-signal
 starry-vm
 ax-timer-list
 ax-alloc
+page-table-generic
 ax-display
 ax-driver
 rdrive

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -28,6 +28,7 @@ starry-vm
 ax-timer-list
 ax-alloc
 page-table-generic
+buddy-slab-allocator
 ax-display
 ax-driver
 rdrive

--- a/test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -10,11 +10,6 @@ features = [
   "ax-driver/xhci-pci",
   "starry-kernel/input",
   "starry-kernel/vsock",
-  # Exercise transparent huge pages across the whole aarch64 suite: every large
-  # writable private-anon mmap promotes to 2 MiB blocks and any sub-2 MiB op
-  # splits them, so the full suite is an end-to-end THP regression (the dedicated
-  # `bugfix-thp-split-subpage` case pins the core promote/split path).
-  "starry-kernel/thp",
 ]
 max_cpu_num = 4
 log = "Warn"

--- a/test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -10,6 +10,11 @@ features = [
   "ax-driver/xhci-pci",
   "starry-kernel/input",
   "starry-kernel/vsock",
+  # Exercise transparent huge pages across the whole aarch64 suite: every large
+  # writable private-anon mmap promotes to 2 MiB blocks and any sub-2 MiB op
+  # splits them, so the full suite is an end-to-end THP regression (the dedicated
+  # `bugfix-thp-split-subpage` case pins the core promote/split/COW path).
+  "starry-kernel/thp",
 ]
 max_cpu_num = 4
 log = "Warn"

--- a/test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/starryos/qemu/build-aarch64-unknown-none-softfloat.toml
@@ -10,6 +10,11 @@ features = [
   "ax-driver/xhci-pci",
   "starry-kernel/input",
   "starry-kernel/vsock",
+  # Exercise transparent huge pages across the whole aarch64 suite: every large
+  # writable private-anon mmap promotes to 2 MiB blocks and any sub-2 MiB op
+  # splits them, so the full suite is an end-to-end THP regression (the dedicated
+  # `bugfix-thp-split-subpage` case pins the core promote/split path).
+  "starry-kernel/thp",
 ]
 max_cpu_num = 4
 log = "Warn"

--- a/test-suit/starryos/qemu/system/bugfix-thp-split-subpage/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-thp-split-subpage/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(thp-split-subpage C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(thp-split-subpage src/main.c)
+target_compile_options(thp-split-subpage PRIVATE -Wall -Wextra -Werror)
+install(TARGETS thp-split-subpage RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-thp-split-subpage/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-thp-split-subpage/src/main.c
@@ -104,6 +104,65 @@ static void fork_cow_split_isolation(void)
     munmap(raw, HUGE + HUGE);
 }
 
+// mremap on a THP-promoted region must keep Linux's 4 KiB ABI. A 4 KiB
+// MREMAP_FIXED move of a promoted block's head to a 4 KiB-aligned (but not
+// 2 MiB-aligned) target must succeed, move only that 4 KiB (preserving its data),
+// and leave the rest of the source block in place. Without the split-on-mremap
+// fix the area's 2 MiB backend page_size forces 2 MiB granularity, so this either
+// EINVALs (target not 2 MiB-aligned) or moves the whole 2 MiB block.
+static void mremap_4k_of_promoted_block_keeps_4k_abi(void)
+{
+    long ps_signed = sysconf(_SC_PAGESIZE);
+    if (ps_signed <= 0) {
+        note_fail("sysconf (mremap)", strerror(errno));
+        return;
+    }
+    size_t ps = (size_t)ps_signed;
+
+    // 2 MiB-aligned, >= 2 MiB writable private-anon region -> THP-promoted body.
+    char *raw = mmap(NULL, HUGE + HUGE, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (raw == MAP_FAILED) {
+        note_fail("mmap (mremap)", strerror(errno));
+        return;
+    }
+    char *base = (char *)(((uintptr_t)raw + HUGE - 1) & ~(HUGE - 1));
+    base[0] = 0x71;  // first-touch the promoted block
+    base[ps] = 0x72; // its second 4 KiB page
+
+    // Reserve a scratch region and pick a 4 KiB-aligned, NON-2 MiB-aligned target.
+    char *scratch = mmap(NULL, HUGE + HUGE, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (scratch == MAP_FAILED) {
+        note_fail("mmap scratch (mremap)", strerror(errno));
+        munmap(raw, HUGE + HUGE);
+        return;
+    }
+    char *target =
+        (char *)((((uintptr_t)scratch + HUGE - 1) & ~(HUGE - 1)) + ps);
+
+    void *ret = mremap(base, ps, ps, MREMAP_MAYMOVE | MREMAP_FIXED, target);
+    if (ret == MAP_FAILED) {
+        note_fail("mremap 4 KiB of promoted block", strerror(errno));
+        munmap(raw, HUGE + HUGE);
+        munmap(scratch, HUGE + HUGE);
+        return;
+    }
+    if (ret != target) {
+        note_fail("mremap 4 KiB target", "returned addr != requested fixed target");
+    } else if (*(unsigned char *)target != 0x71) {
+        note_fail("mremap 4 KiB data", "moved page lost its data");
+    }
+    // Only 4 KiB moved: the block's second page stays mapped and intact (a whole
+    // 2 MiB over-move would unmap it).
+    if (base[ps] != 0x72) {
+        note_fail("mremap 4 KiB over-move", "second page of source block disturbed");
+    }
+
+    munmap(raw, HUGE + HUGE);
+    munmap(scratch, HUGE + HUGE);
+}
+
 int main(void)
 {
     printf("=== thp-split-subpage ===\n");
@@ -176,6 +235,9 @@ int main(void)
     // COW-break split path: fork a shared THP, split it in the child, assert
     // parent/child isolation and refcount-correct data preservation.
     fork_cow_split_isolation();
+
+    // mremap must keep the 4 KiB ABI on a THP-promoted region.
+    mremap_4k_of_promoted_block_keeps_4k_abi();
 
     if (failed == 0) {
         printf("ALL TESTS PASSED\n");

--- a/test-suit/starryos/qemu/system/bugfix-thp-split-subpage/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-thp-split-subpage/src/main.c
@@ -1,0 +1,109 @@
+// Transparent-huge-page promotion + huge->4K split correctness.
+//
+// A large writable private-anonymous mmap is promoted to 2 MiB blocks (with the
+// `thp` kernel feature). Any sub-2 MiB `mprotect`/`madvise` must split the block
+// into 512 4 KiB leaves *content-preservingly* — the untouched sub-pages keep
+// their data, the mprotected sub-page keeps its data at the new permission, and a
+// write to another sub-page still works. This exercises the whole pipeline
+// (mmap promotion carve -> first-touch 2 MiB fault -> break-before-make split ->
+// per-leaf remap). With the feature off there is no promotion, so the same
+// sequence runs on 4 KiB pages and still passes (a mmap/mprotect/madvise smoke).
+#define _GNU_SOURCE
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#define HUGE (0x200000UL) // 2 MiB
+
+static int failed;
+
+static void note_fail(const char *what, const char *detail)
+{
+    printf("FAIL: %s: %s\n", what, detail);
+    failed++;
+}
+
+static unsigned char pat(size_t page_index)
+{
+    return (unsigned char)((page_index * 7 + 3) & 0xff);
+}
+
+int main(void)
+{
+    printf("=== thp-split-subpage ===\n");
+
+    long ps_signed = sysconf(_SC_PAGESIZE);
+    if (ps_signed <= 0) {
+        note_fail("sysconf", strerror(errno));
+        printf("SOME TESTS FAILED\n");
+        return 1;
+    }
+    size_t ps = (size_t)ps_signed;
+    size_t len = 2 * HUGE; // two 2 MiB blocks
+
+    // Reserve len + HUGE so we can 2 MiB-align the base within the reservation:
+    // a 2 MiB-aligned, >= 2 MiB writable private-anon region is THP-eligible.
+    char *raw = mmap(NULL, len + HUGE, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (raw == MAP_FAILED) {
+        note_fail("mmap", strerror(errno));
+        printf("SOME TESTS FAILED\n");
+        return 1;
+    }
+    char *base = (char *)(((uintptr_t)raw + HUGE - 1) & ~(HUGE - 1));
+    size_t npages = len / ps;
+
+    // First-touch every page: with THP each 2 MiB block faults in as one block.
+    for (size_t i = 0; i < npages; i++) {
+        base[i * ps] = pat(i);
+    }
+
+    // mprotect a middle 4 KiB sub-page of the SECOND block read-only. On a THP
+    // build this forces that 2 MiB block to split into 512 4 KiB leaves.
+    size_t mid_page = (HUGE / ps) + 8; // 8 pages into the 2nd block
+    if (mprotect(base + mid_page * ps, ps, PROT_READ) != 0) {
+        note_fail("mprotect RO", strerror(errno));
+    }
+
+    // Every sub-page must keep its first-touch data across the split.
+    for (size_t i = 0; i < npages; i++) {
+        if (base[i * ps] != (char)pat(i)) {
+            char d[96];
+            snprintf(d, sizeof(d), "page %zu: got %d want %d", i, base[i * ps],
+                     (int)pat(i));
+            note_fail("data preserved across split", d);
+            break;
+        }
+    }
+
+    // A write to another (now 4 KiB) sub-page of the split block still works.
+    size_t other_page = (HUGE / ps) + 100;
+    base[other_page * ps] = 0x5a;
+    if (base[other_page * ps] != 0x5a) {
+        note_fail("write after split", "readback mismatch");
+    }
+
+    // MADV_NOHUGEPAGE over the first (still-huge) block splits it to 4 KiB too,
+    // without error, and its data survives.
+    if (madvise(base, HUGE, MADV_NOHUGEPAGE) != 0) {
+        note_fail("madvise NOHUGEPAGE", strerror(errno));
+    }
+    for (size_t i = 0; i < HUGE / ps; i++) {
+        if (base[i * ps] != (char)pat(i)) {
+            note_fail("data preserved across MADV_NOHUGEPAGE", "mismatch");
+            break;
+        }
+    }
+
+    munmap(raw, len + HUGE);
+
+    if (failed == 0) {
+        printf("ALL TESTS PASSED\n");
+        return 0;
+    }
+    printf("SOME TESTS FAILED\n");
+    return 1;
+}

--- a/test-suit/starryos/qemu/system/bugfix-thp-split-subpage/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-thp-split-subpage/src/main.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #define HUGE (0x200000UL) // 2 MiB
@@ -29,6 +30,78 @@ static void note_fail(const char *what, const char *detail)
 static unsigned char pat(size_t page_index)
 {
     return (unsigned char)((page_index * 7 + 3) & 0xff);
+}
+
+// After fork, a promoted 2 MiB block is COW-shared (refcount 2). A sub-2 MiB op in
+// the child must COW-break it — copy the block into a private frame, drop the shared
+// ref, register 512 fresh 4 KiB refcounts, and re-map — then split to 4 KiB, all
+// without disturbing the parent's still-2 MiB view. This is the path
+// (`prepare_huge_split_2m` CopiedContiguous / CopiedScattered) the same-process
+// split cannot reach; a refcount or isolation bug here surfaces only after fork.
+static void fork_cow_split_isolation(void)
+{
+    long ps_signed = sysconf(_SC_PAGESIZE);
+    if (ps_signed <= 0) {
+        note_fail("sysconf (cow)", strerror(errno));
+        return;
+    }
+    size_t ps = (size_t)ps_signed;
+    size_t npages = HUGE / ps;
+
+    char *raw = mmap(NULL, HUGE + HUGE, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (raw == MAP_FAILED) {
+        note_fail("mmap (cow)", strerror(errno));
+        return;
+    }
+    char *base = (char *)(((uintptr_t)raw + HUGE - 1) & ~(HUGE - 1));
+    for (size_t i = 0; i < npages; i++) {
+        base[i * ps] = pat(i); // first-touch -> one private 2 MiB block
+    }
+
+    pid_t pid = fork(); // now the 2 MiB block is COW-shared between parent + child
+    if (pid < 0) {
+        note_fail("fork", strerror(errno));
+        munmap(raw, HUGE + HUGE);
+        return;
+    }
+    if (pid == 0) {
+        // Child: mprotect a sub-page RO -> splits the SHARED block (COW-break to a
+        // private copy, then 4 KiB leaves). Then write a child-only marker.
+        size_t wp = 50;
+        if (mprotect(base + 8 * ps, ps, PROT_READ) != 0) {
+            _exit(11);
+        }
+        base[wp * ps] = 0x33; // child-private write after the split
+        for (size_t i = 0; i < npages; i++) {
+            if (i == wp) {
+                continue;
+            }
+            if (base[i * ps] != (char)pat(i)) {
+                _exit(12); // data lost across the COW-break split
+            }
+        }
+        _exit(base[wp * ps] == 0x33 ? 0 : 13);
+    }
+
+    int st = 0;
+    waitpid(pid, &st, 0);
+    if (!(WIFEXITED(st) && WEXITSTATUS(st) == 0)) {
+        char d[64];
+        snprintf(d, sizeof(d), "child status=%d", st);
+        note_fail("child COW-break split", d);
+    }
+    // Parent isolation: the child's private COW-break + write must not have touched
+    // the parent's block.
+    for (size_t i = 0; i < npages; i++) {
+        if (base[i * ps] != (char)pat(i)) {
+            char d[64];
+            snprintf(d, sizeof(d), "parent page %zu changed to %d", i, base[i * ps]);
+            note_fail("parent isolation after child COW split", d);
+            break;
+        }
+    }
+    munmap(raw, HUGE + HUGE);
 }
 
 int main(void)
@@ -99,6 +172,10 @@ int main(void)
     }
 
     munmap(raw, len + HUGE);
+
+    // COW-break split path: fork a shared THP, split it in the child, assert
+    // parent/child isolation and refcount-correct data preservation.
+    fork_cow_split_isolation();
 
     if (failed == 0) {
         printf("ALL TESTS PASSED\n");


### PR DESCRIPTION
## 问题
StarryOS 对大块私有匿名内存始终以 4 KiB 页映射，缺少透明大页（THP）：大工作集 TLB 覆盖不足、缺页多。上游 dev 已具备 THP 所需的底层设施（COW 帧引用计数 `FRAME_TABLE`、per-VA RSS accounting、`thp_disable` 的 prctl/clone/meminfo 管线），但缺两块拼图——页表侧的大页拆分原语与 buddy `split_pages`——以及把它们接起来的内核 THP 逻辑。

## 依赖（前置 PR，请先合入）
- **#1990**（`feat/buddy-split-pages`）——buddy `split_pages`，把连续大块原地重标为 512 个可独立释放的 4 KiB 帧。
- **#2065**（`feat/ptg-huge-pte-split`，自身栈叠 **#2009**）——`page-table-generic` 的 break-before-make 大页拆分。

本分支前若干提交属于 #2009/#2065/#1990；合入后本 PR 会 rebase 收敛。

## 改动（全部在 `thp` feature 之下，**默认关闭**）
1. **`page-table-generic`**（本 PR 追加）：`split_huge_block_to_empty_table`——只安装空子表、由调用方安装 512 个（可非连续）叶子；经私有 `SplitFill { Inherit, Empty }` 复用既有拆分核心（唯一区别是跳过叶子填充）。THP 的 `CopiedScattered`（碎片下的 COW-break）需要它，否则自动填充的叶子会让调用方 `map` 触发 `MappingConflict`。
2. **`cow.rs`**：`prepare/commit/abort_huge_split_2m` 两阶段拆分。Phase 1（可失败）分类独占/COW-共享、预拷贝 COW-break（连续 2M 或 512 散帧）、预留叶子页表；Phase 2（不可失败）用空-splice 换入子表、重标/拷贝帧、注册 512 个 4 KiB 引用计数、安装 512 叶子（保留块权限）、把 1 个 2M RSS charge 拆成 512。
3. **`aspace/mod.rs`**：`split_huge_area` 原子 2 阶段驱动 + `split_huge_pages`（MADV_NOHUGEPAGE 入口）；unmap/mprotect/MADV_DONTNEED 先把被边界跨越的大页降级为 4 KiB；populate/缺页在拿不到 order-9 帧时回退到 4 KiB 拆分 + 重试。
4. **`mmap.rs`**：`thp_map_promoted_anon` 把可提升的大块私有匿名映射按 `[4K 头][2M 体][4K 尾]` carve，只让 2M 对齐的内部用 2M backend（不整体上取整，`/proc/*/maps` 与返回长度保持精确）。
5. `backend::split_frame`（→ #1990）、`accounting::record_charge_fresh`、`axhal::paging::ReservedTable` 别名。
6. **RSS accounting（`accounting.rs`）**：一个常驻 THP 2 MiB 块按 **512** 个常驻 4 KiB 页计入 `VmRSS`/`VmHWM`。`RssCharge { kind, pages }` 让每条 per-VA charge 携带其常驻页数（4 KiB 页为 1，2 MiB 块为 512），`record_charge`/`remove_charge`/`snapshot_resident_charges`/`copy_charge_from`/`move_charge`/`Drop` 均按该页数增减原子计数器。修复前一个 2M 块只计 1 页，touch 一块 THP 提升的 mmap 后 `VmHWM` 增长不足（`proc-test-vmpeak-hwm` 失败）。
7. **`mmap.rs` `sys_mremap`**：THP 提升区在 `mremap` 上保持 Linux 的 4 KiB ABI。原本 `sys_mremap` 用 `area.backend().page_size()`（THP 区为 2 MiB）当作 ABI 粒度——强制 2 MiB 对齐、把 `old_size`/`new_size` 上取整到 2 MiB、按 2 MiB 搬移，导致对提升块首页做 4 KiB `MREMAP_FIXED` 到 4 KiB 对齐目标会 `EINVAL` 或把整个 2 MiB 块搬走。改为：非整-2 MiB-对齐的请求先把相关 THP 区拆回 4 KiB（`split_huge_area` 已把 VMA 降级为 4 KiB backend），随后按 4 KiB 粒度对齐/搬移，`move_pages` 按 per-PTE 粒度只搬所需页；整-2 MiB-对齐的搬移保留大页。StarryOS 没有独立 hugetlb 路径（mprotect/unmap/madvise 已把所有 2 MiB 匿名区当作可拆分），故无需额外标记。

## 逻辑
- 提升只在 mmap 时（THP-lite，不 re-promote、无 khugepaged）；`thp_eligible`：可写、≥2M、非 `MAP_NORESERVE`、非 `PR_SET_THP_DISABLE`。
- 拆分严格两阶段：所有分配在 Phase 1 预付，Phase 2 不分配且不可失败，故碎片/OOM 下要么整个 area 拆分、要么原样保留，绝不留下 2M/4K 混合的半拆状态。
- break-before-make（清块 → flush → 装空子表 → 装 512 叶子）保留块的 PTE 权限，故 COW 写保护不被破坏。
- not-present 大块（`mprotect(PROT_NONE)` 覆盖 THP）经 present-independent 的 `peek_huge_block` 一并拆分，数据帧不被释放。

## 测试
- **`page-table-generic` host 单测**（`tests/huge_split.rs`，8 例全绿）：拆分往返无泄漏、not-present 块拆分保留数据帧、zeroing-format(EPT/NPT) 优雅降级为 `NotMapped`、以及新增 empty-splice 三例（空子表→装 512 散叶→无泄漏；单次 break-before-make flush；失败回滚一次且不 flush）。
- **`bugfix-thp-split-subpage` QEMU 用例**：2M 提升 → mprotect 子页强制拆分 → 断言各子页数据跨拆分保留 + 拆后写入可用 + MADV_NOHUGEPAGE 拆分无误。
- **`bugfix-thp-split-subpage` 的 fork COW-break 段**：first-touch 2M 块 → `fork`（COW-共享）→ 子进程对子页 `mprotect` 触发**共享块**的 COW-break 拆分（`CopiedContiguous` 拷贝 + drop 旧引用 + 512 子帧引用 + 重建图）→ 断言子进程数据跨拆分无损、且父进程（仍 2M）数据被隔离不受影响。覆盖 `prepare_huge_split_2m` 中 fork 后才可达的 COW-break/引用计数/隔离路径。
- **RSS accounting axtest 回归**（`accounting_edge_cases_and_snapshot_rules_hold`）：一条 2 MiB 块 charge 断言 `VmRSS`/`VmHWM`/snapshot 均计 512 页、`remove_charge` 归零、hiwater 保留 512 峰值，并断言 2M→4K 拆分（512 个单页 charge）守恒（−512 + 512×1 = 0）。先复现 buggy（块计 1 页）确认该用例必然失败（`panic left: 1, right: 512`），恢复修复后 `axtest_kernel` 组 **405/405** 全绿。
- **`bugfix-thp-split-subpage` 的 mremap 4 KiB-ABI 段**：对 2 MiB 提升块的首个 4 KiB 页做 `MREMAP_FIXED|MREMAP_MAYMOVE` 搬到一个 4 KiB 对齐、**非** 2 MiB 对齐的目标 → 断言成功（非 `EINVAL`）、目标数据正确、源块第二页仍在原位（未整块搬走）。修复前该请求会因 2 MiB 粒度 `EINVAL`；thp 关闭时该块不提升，用例退化为普通 4 KiB mremap，仍通过。
- **在 aarch64 QEMU 构建启用 `starry-kernel/thp`**：整套 aarch64 system 组以 THP 开启运行 = 端到端回归（含 `proc-test-vmpeak-hwm` 校验上述 RSS 修复；其它架构保持 THP 关闭）。
- `thp` 开/关两配置均编译通过；`cargo clippy -p starry-kernel --no-deps -- -D warnings`（两配置）、`cargo fmt --all -- --check`、`cargo test -p page-table-generic` 均通过。**默认（`thp` 关）构建的 mmap / 缺页 / unmap 热路径逐字节未变**（相关改动均已 `#[cfg]` 门控）。
- 板级 oracle（`thp_{narrow,nohugepage,protnone,reenable,bw}.c`）留作后续板测 PR。

## 验证状态说明
本地已完成：两配置编译、`clippy --no-deps -D warnings`（两配置）、`fmt`、`page-table-generic` host 单测、**`axtest_kernel` 内核测试组在 QEMU 中 405/405 全绿（含上文 RSS 512 页回归 + 其 red-check）**、smoke 用例在 Linux 上编译+通过、基础内核在 QEMU 中启动并通过用例（同基线 sibling 组 23/0）；`thp` 内核可成功构建。整套 **thp-on 的 aarch64 QEMU system 组端到端回归（含 `proc-test-vmpeak-hwm`）由 CI 运行**——本地跑整组受环境限制（qemu-user 预装 49 个 apk 包很慢 + 内存不足，多次在启动前超时），故以 CI 为该组的运行期闸门。

---
本 PR 栈叠在 **#1990** + **#2065**（后者又栈叠 **#2009**）之上；请与它们一同评审/合入。


