### PR TITLE
refactor(ci): modularize checks and reduce skipped jobs

### DIFF
--- a/.github/actions/publish-container/action.yml
+++ b/.github/actions/publish-container/action.yml
@@ -1,0 +1,51 @@
+name: Publish container image
+description: Build and publish one TGOSKits container image with GHA caching.
+
+inputs:
+  image_name:
+    description: Full image name to publish.
+    required: true
+  dockerfile:
+    description: Dockerfile path relative to the repository root.
+    required: true
+  cache_scope:
+    description: GHA cache scope for docker build cache.
+    required: true
+  build_args:
+    description: Optional docker build arguments.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Normalize image name
+      id: prep
+      shell: bash
+      env:
+        IMAGE_NAME: ${{ inputs.image_name }}
+      run: |
+        set -euo pipefail
+        image="$(printf '%s' "$IMAGE_NAME" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
+        echo "image=${image}" >> "$GITHUB_OUTPUT"
+
+    - name: Extract image metadata
+      id: meta
+      uses: docker/metadata-action@v6
+      with:
+        images: ${{ steps.prep.outputs.image }}
+        tags: |
+          type=ref,event=tag
+          type=raw,value=latest
+
+    - name: Build and push container image
+      uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: ${{ inputs.dockerfile }}
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: ${{ inputs.build_args }}
+        cache-from: type=gha,scope=${{ inputs.cache_scope }}
+        cache-to: type=gha,mode=max,scope=${{ inputs.cache_scope }}

--- a/.github/ci/checks/arceos.toml
+++ b/.github/ci/checks/arceos.toml
@@ -1,0 +1,53 @@
+schema_version = 1
+phase = "test"
+group = "ArceOS"
+
+[[check]]
+id = "test-arceos-x86-64-qemu"
+name = "Test arceos x86_64 qemu"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+command = '''
+cargo xtask arceos test qemu --arch x86_64
+'''
+
+[[check]]
+id = "test-arceos-riscv64-qemu"
+name = "Test arceos riscv64 qemu"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+command = '''
+cargo xtask arceos test qemu --arch riscv64
+taskset -c 0 cargo xtask arceos test qemu --arch riscv64 \
+  --test-group rust --test-case task-ipi
+'''
+
+[[check]]
+id = "test-arceos-aarch64-qemu-app-suites"
+name = "Test arceos aarch64 qemu (app + suites)"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+command = '''
+echo "==> arceos aarch64 GICv2 SMP4 default app boot"
+cargo xtask arceos qemu --arch aarch64 --smp 4 \
+  --qemu-config os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
+echo "==> arceos aarch64 test suites (Rust GICv2 SMP4 IPI + C GICv3 SMP4)"
+cargo xtask arceos test qemu --arch aarch64
+'''
+
+[[check]]
+id = "test-arceos-loongarch64-qemu"
+name = "Test arceos loongarch64 qemu"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+command = '''
+cargo xtask arceos test qemu --arch loongarch64
+'''

--- a/.github/ci/checks/arceos.toml
+++ b/.github/ci/checks/arceos.toml
@@ -4,7 +4,7 @@ group = "ArceOS"
 
 [[check]]
 id = "test-arceos-x86-64-qemu"
-name = "Test arceos x86_64 qemu"
+name = "x86_64 QEMU · Suites"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -15,7 +15,7 @@ cargo xtask arceos test qemu --arch x86_64
 
 [[check]]
 id = "test-arceos-riscv64-qemu"
-name = "Test arceos riscv64 qemu"
+name = "riscv64 QEMU · Suites + task IPI"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -28,7 +28,7 @@ taskset -c 0 cargo xtask arceos test qemu --arch riscv64 \
 
 [[check]]
 id = "test-arceos-aarch64-qemu-app-suites"
-name = "Test arceos aarch64 qemu (app + suites)"
+name = "aarch64 QEMU · GICv2 SMP4 boot + suites"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -43,7 +43,7 @@ cargo xtask arceos test qemu --arch aarch64
 
 [[check]]
 id = "test-arceos-loongarch64-qemu"
-name = "Test arceos loongarch64 qemu"
+name = "loongarch64 QEMU · Suites"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -1,0 +1,221 @@
+schema_version = 1
+phase = "test"
+group = "AxVisor"
+
+[[check]]
+id = "test-axvisor-aarch64-qemu-smoke-axtest-timer-stress"
+name = "Test axvisor aarch64 qemu (smoke + axtest + timer stress)"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+timeout_minutes = 30
+command = '''
+echo "==> axvisor aarch64 smoke"
+cargo xtask axvisor test qemu --arch aarch64 --test-case smoke
+echo "==> axvisor aarch64 virtio-blk ArceOS guest"
+timeout 240s apps/arceos/virtio-blk-test/run.sh
+echo "==> axvisor aarch64 axtest"
+cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
+echo "==> pull qemu-aarch64 image"
+cargo xtask image pull qemu-aarch64 --output-dir tmp/axbuild/images
+echo "==> axvisor aarch64 gicv2 timer stress"
+cargo xtask axvisor test qemu --arch aarch64 --test-case gicv2-timer-stress
+echo "==> axvisor aarch64 gicv3 timer stress"
+cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress
+'''
+
+[[check]]
+id = "test-axvisor-aarch64-qemu-panic-modes"
+name = "Test axvisor aarch64 qemu (panic modes)"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+timeout_minutes = 30
+command = '''
+echo "==> axvisor aarch64 backtrace panic"
+cargo xtask axvisor test qemu --arch aarch64 --test-case backtrace-panic
+echo "==> axvisor aarch64 no-backtrace panic"
+cargo xtask axvisor test qemu --arch aarch64 --test-case no-backtrace
+'''
+
+[[check]]
+id = "test-axvisor-riscv64-qemu-smoke-panic-modes"
+name = "Test axvisor riscv64 qemu (smoke + panic modes)"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+timeout_minutes = 30
+command = '''
+echo "==> axvisor riscv64 smoke"
+cargo xtask axvisor test qemu --arch riscv64 --test-case smoke
+echo "==> axvisor riscv64 IPI cross-test"
+cargo xtask cross-test --arch riscv64 \
+  --package riscv_vcpu --package axvm \
+  --features axvm/host-test --no-default-features --lib ipi
+echo "==> axvisor riscv64 backtrace panic"
+cargo xtask axvisor test qemu --arch riscv64 --test-case backtrace-panic
+echo "==> axvisor riscv64 no-backtrace panic"
+cargo xtask axvisor test qemu --arch riscv64 --test-case no-backtrace
+'''
+
+[[check]]
+id = "test-axvisor-loongarch64-qemu"
+name = "Test axvisor loongarch64 qemu"
+runs_on = ["ubuntu-latest"]
+environment = "axvisor-lvz"
+cache_key = "test-axvisor-loongarch64"
+download_xtask_bin_artifact = true
+command = '''
+target/debug/tg-xtask axvisor test qemu --arch loongarch64
+'''
+
+[[check]]
+id = "test-axvisor-qemu-ivc"
+name = "Test axvisor qemu ivc"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+command = '''
+cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qemu-ivc
+'''
+
+[[check]]
+id = "test-axvisor-self-hosted-x86-64-svm-smoke-acpi"
+name = "Test axvisor self-hosted x86_64 (svm smoke + ACPI)"
+runs_on = ["self-hosted", "linux", "amd", "kvm"]
+environment = "host"
+required_owner = "rcore-os"
+timeout_minutes = 30
+require_kvm = true
+command = '''
+echo "==> axvisor x86_64 svm smoke"
+cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm
+echo "==> pull qemu-x86_64 image"
+cargo xtask image pull qemu-x86_64 --output-dir tmp/axbuild/images
+echo "==> axvisor x86_64 svm direct ACPI boot"
+cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-svm
+echo "==> axvisor x86_64 svm nested OVMF ACPI boot"
+cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-svm
+'''
+
+[[check]]
+id = "test-axvisor-self-hosted-x86-64-vmx"
+name = "Test axvisor self-hosted x86_64(vmx)"
+runs_on = ["self-hosted", "linux", "intel", "kvm"]
+environment = "host"
+required_owner = "rcore-os"
+require_kvm = true
+command = '''
+cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx
+'''
+
+[[check]]
+id = "test-axloader-http-smoke"
+name = "Test axloader HTTP smoke"
+runs_on = ["self-hosted", "linux", "intel", "kvm"]
+environment = "host"
+required_owner = "rcore-os"
+timeout_minutes = 25
+require_kvm = true
+command = '''
+rustup target add x86_64-unknown-uefi
+cargo xtask axloader test qemu --target x86_64-unknown-uefi
+'''
+
+[[check]]
+id = "test-axvisor-x86-64-acpi-direct-and-ovmf-boot-vmx"
+name = "Test axvisor x86_64 ACPI direct and OVMF boot (vmx)"
+runs_on = ["self-hosted", "linux", "intel", "kvm"]
+environment = "host"
+required_owner = "rcore-os"
+timeout_minutes = 45
+require_kvm = true
+command = '''
+cargo xtask image pull qemu-x86_64 --output-dir tmp/axbuild/images
+cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-vmx
+cargo xtask axvisor test qemu --arch x86_64 --test-case mp-fallback-vmx
+cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx
+'''
+
+[[check]]
+id = "test-axvisor-self-hosted-board-orangepi-5-plus-linux"
+name = "Test axvisor self-hosted board orangepi-5-plus-linux"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+command = '''
+cargo xtask axvisor test board --board orangepi-5-plus-linux
+'''
+
+[[check]]
+id = "test-axvisor-self-hosted-board-orangepi-5-plus-starry"
+name = "Test axvisor self-hosted board orangepi-5-plus-starry"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+command = '''
+cargo xtask axvisor test board --board orangepi-5-plus-starry
+'''
+
+[[check]]
+id = "test-axvisor-self-hosted-board-roc-rk3568-pc-linux"
+name = "Test axvisor self-hosted board roc-rk3568-pc-linux"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+command = '''
+cargo xtask axvisor test board --board roc-rk3568-pc-linux
+'''
+
+[[check]]
+id = "test-axvisor-self-hosted-board-phytiumpi-linux"
+name = "Test axvisor self-hosted board phytiumpi-linux"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+command = '''
+cargo xtask axvisor test board --board phytiumpi-linux
+'''
+
+[[check]]
+id = "test-axvisor-self-hosted-board-asus-nuc15crh-linux"
+name = "Test axvisor self-hosted board asus-nuc15crh-linux"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+timeout_minutes = 20
+command = '''
+mkdir -p tmp
+cargo xtask image pull qemu-x86_64 --output-dir tmp
+cargo xtask image pull initramfs-x86_64-busybox.cpio.gz --output-dir tmp
+gzip -dc \
+  tmp/initramfs-x86_64-busybox.cpio.gz/initramfs-x86_64-busybox.cpio.gz \
+  > tmp/initramfs-x86_64-busybox.cpio
+cargo xtask axvisor test board --board asus-nuc15crh-linux
+'''
+
+[[check]]
+id = "test-orangepi-5-plus-robot-axvisor-starryos-guest"
+name = "Test OrangePi 5 Plus robot AxVisor StarryOS guest"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+timeout_minutes = 90
+command = '''
+cargo xtask axvisor test board --board orangepi-5-plus-robot-starry
+'''
+
+[[check]]
+id = "test-orangepi-5-plus-robot-axvisor-linux-guest"
+name = "Test OrangePi 5 Plus robot AxVisor Linux guest"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+timeout_minutes = 90
+command = '''
+cargo xtask axvisor test board --board orangepi-5-plus-robot-linux
+'''

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -4,7 +4,7 @@ group = "AxVisor"
 
 [[check]]
 id = "test-axvisor-aarch64-qemu-smoke-axtest-timer-stress"
-name = "Test axvisor aarch64 qemu (smoke + axtest + timer stress)"
+name = "aarch64 QEMU · Smoke + virtio-blk guest + axtest + timer stress"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -27,7 +27,7 @@ cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress
 
 [[check]]
 id = "test-axvisor-aarch64-qemu-panic-modes"
-name = "Test axvisor aarch64 qemu (panic modes)"
+name = "aarch64 QEMU · Panic modes"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -42,7 +42,7 @@ cargo xtask axvisor test qemu --arch aarch64 --test-case no-backtrace
 
 [[check]]
 id = "test-axvisor-riscv64-qemu-smoke-panic-modes"
-name = "Test axvisor riscv64 qemu (smoke + panic modes)"
+name = "riscv64 QEMU · Smoke + IPI + panic modes"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -63,7 +63,7 @@ cargo xtask axvisor test qemu --arch riscv64 --test-case no-backtrace
 
 [[check]]
 id = "test-axvisor-loongarch64-qemu"
-name = "Test axvisor loongarch64 qemu"
+name = "loongarch64 QEMU · Suites"
 runs_on = ["ubuntu-latest"]
 environment = "axvisor-lvz"
 cache_key = "test-axvisor-loongarch64"
@@ -74,7 +74,7 @@ target/debug/tg-xtask axvisor test qemu --arch loongarch64
 
 [[check]]
 id = "test-axvisor-qemu-ivc"
-name = "Test axvisor qemu ivc"
+name = "aarch64 QEMU · IVC"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -85,7 +85,7 @@ cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qem
 
 [[check]]
 id = "test-axvisor-self-hosted-x86-64-svm-smoke-acpi"
-name = "Test axvisor self-hosted x86_64 (svm smoke + ACPI)"
+name = "x86_64 SVM · Smoke + direct/OVMF ACPI"
 runs_on = ["self-hosted", "linux", "amd", "kvm"]
 environment = "host"
 required_owner = "rcore-os"
@@ -104,7 +104,7 @@ cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-svm
 
 [[check]]
 id = "test-axvisor-self-hosted-x86-64-vmx"
-name = "Test axvisor self-hosted x86_64(vmx)"
+name = "x86_64 VMX · Smoke"
 runs_on = ["self-hosted", "linux", "intel", "kvm"]
 environment = "host"
 required_owner = "rcore-os"
@@ -115,7 +115,7 @@ cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx
 
 [[check]]
 id = "test-axloader-http-smoke"
-name = "Test axloader HTTP smoke"
+name = "x86_64 UEFI · AxLoader HTTP boot"
 runs_on = ["self-hosted", "linux", "intel", "kvm"]
 environment = "host"
 required_owner = "rcore-os"
@@ -128,7 +128,7 @@ cargo xtask axloader test qemu --target x86_64-unknown-uefi
 
 [[check]]
 id = "test-axvisor-x86-64-acpi-direct-and-ovmf-boot-vmx"
-name = "Test axvisor x86_64 ACPI direct and OVMF boot (vmx)"
+name = "x86_64 VMX · Direct + MP fallback + OVMF ACPI"
 runs_on = ["self-hosted", "linux", "intel", "kvm"]
 environment = "host"
 required_owner = "rcore-os"
@@ -143,7 +143,7 @@ cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx
 
 [[check]]
 id = "test-axvisor-self-hosted-board-orangepi-5-plus-linux"
-name = "Test axvisor self-hosted board orangepi-5-plus-linux"
+name = "OrangePi 5 Plus board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -153,7 +153,7 @@ cargo xtask axvisor test board --board orangepi-5-plus-linux
 
 [[check]]
 id = "test-axvisor-self-hosted-board-orangepi-5-plus-starry"
-name = "Test axvisor self-hosted board orangepi-5-plus-starry"
+name = "OrangePi 5 Plus board · StarryOS guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -163,7 +163,7 @@ cargo xtask axvisor test board --board orangepi-5-plus-starry
 
 [[check]]
 id = "test-axvisor-self-hosted-board-roc-rk3568-pc-linux"
-name = "Test axvisor self-hosted board roc-rk3568-pc-linux"
+name = "ROC-RK3568-PC board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -173,7 +173,7 @@ cargo xtask axvisor test board --board roc-rk3568-pc-linux
 
 [[check]]
 id = "test-axvisor-self-hosted-board-phytiumpi-linux"
-name = "Test axvisor self-hosted board phytiumpi-linux"
+name = "Phytium Pi board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -183,7 +183,7 @@ cargo xtask axvisor test board --board phytiumpi-linux
 
 [[check]]
 id = "test-axvisor-self-hosted-board-asus-nuc15crh-linux"
-name = "Test axvisor self-hosted board asus-nuc15crh-linux"
+name = "ASUS NUC15CRH board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -200,7 +200,7 @@ cargo xtask axvisor test board --board asus-nuc15crh-linux
 
 [[check]]
 id = "test-orangepi-5-plus-robot-axvisor-starryos-guest"
-name = "Test OrangePi 5 Plus robot AxVisor StarryOS guest"
+name = "OrangePi 5 Plus robot board · StarryOS guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -211,7 +211,7 @@ cargo xtask axvisor test board --board orangepi-5-plus-robot-starry
 
 [[check]]
 id = "test-orangepi-5-plus-robot-axvisor-linux-guest"
-name = "Test OrangePi 5 Plus robot AxVisor Linux guest"
+name = "OrangePi 5 Plus robot board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"

--- a/.github/ci/checks/starry-apps.toml
+++ b/.github/ci/checks/starry-apps.toml
@@ -23,7 +23,6 @@ environment = "base"
 cache_key = "starry-apps-x86_64"
 apk_region = "us"
 container_preflight = "qemu-user"
-events = ["schedule", "workflow_dispatch"]
 command = '''
 cargo xtask starry app qemu --all --arch x86_64
 '''
@@ -36,7 +35,6 @@ environment = "base"
 cache_key = "starry-apps-aarch64"
 apk_region = "us"
 container_preflight = "qemu-user"
-events = ["schedule", "workflow_dispatch"]
 command = '''
 cargo xtask starry app qemu --all --arch aarch64
 '''
@@ -49,7 +47,6 @@ environment = "base"
 cache_key = "starry-apps-riscv64"
 apk_region = "us"
 container_preflight = "qemu-user"
-events = ["schedule", "workflow_dispatch"]
 command = '''
 cargo xtask starry app qemu --all --arch riscv64
 '''
@@ -62,7 +59,6 @@ environment = "base"
 cache_key = "starry-apps-loongarch64"
 apk_region = "us"
 container_preflight = "qemu-user"
-events = ["schedule", "workflow_dispatch"]
 command = '''
 cargo xtask starry app qemu --all --arch loongarch64
 '''

--- a/.github/ci/checks/starry-apps.toml
+++ b/.github/ci/checks/starry-apps.toml
@@ -4,7 +4,7 @@ group = "Starry Apps"
 
 [[check]]
 id = "starry-apps-clippy-all"
-name = "Scheduled clippy all"
+name = "Workspace · Full Clippy"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "starry-apps-clippy-all"
@@ -17,7 +17,7 @@ cargo xtask clippy --all
 
 [[check]]
 id = "starry-app-smoke-x86-64"
-name = "Starry app smoke x86_64"
+name = "x86_64 QEMU · App smoke"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "starry-apps-x86_64"
@@ -30,7 +30,7 @@ cargo xtask starry app qemu --all --arch x86_64
 
 [[check]]
 id = "starry-app-smoke-aarch64"
-name = "Starry app smoke aarch64"
+name = "aarch64 QEMU · App smoke"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "starry-apps-aarch64"
@@ -43,7 +43,7 @@ cargo xtask starry app qemu --all --arch aarch64
 
 [[check]]
 id = "starry-app-smoke-riscv64"
-name = "Starry app smoke riscv64"
+name = "riscv64 QEMU · App smoke"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "starry-apps-riscv64"
@@ -56,7 +56,7 @@ cargo xtask starry app qemu --all --arch riscv64
 
 [[check]]
 id = "starry-app-smoke-loongarch64"
-name = "Starry app smoke loongarch64"
+name = "loongarch64 QEMU · App smoke"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "starry-apps-loongarch64"

--- a/.github/ci/checks/starry-apps.toml
+++ b/.github/ci/checks/starry-apps.toml
@@ -1,0 +1,88 @@
+schema_version = 1
+phase = "starry_apps"
+group = "Starry Apps"
+
+[[check]]
+id = "starry-apps-clippy-all"
+name = "Scheduled clippy all"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "starry-apps-clippy-all"
+container_preflight = "none"
+events = ["schedule"]
+enable_boolean_input = "run_clippy_all"
+command = '''
+cargo xtask clippy --all
+'''
+
+[[check]]
+id = "starry-app-smoke-x86-64"
+name = "Starry app smoke x86_64"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "starry-apps-x86_64"
+apk_region = "us"
+container_preflight = "qemu-user"
+events = ["schedule", "workflow_dispatch"]
+command = '''
+cargo xtask starry app qemu --all --arch x86_64
+'''
+
+[[check]]
+id = "starry-app-smoke-aarch64"
+name = "Starry app smoke aarch64"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "starry-apps-aarch64"
+apk_region = "us"
+container_preflight = "qemu-user"
+events = ["schedule", "workflow_dispatch"]
+command = '''
+cargo xtask starry app qemu --all --arch aarch64
+'''
+
+[[check]]
+id = "starry-app-smoke-riscv64"
+name = "Starry app smoke riscv64"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "starry-apps-riscv64"
+apk_region = "us"
+container_preflight = "qemu-user"
+events = ["schedule", "workflow_dispatch"]
+command = '''
+cargo xtask starry app qemu --all --arch riscv64
+'''
+
+[[check]]
+id = "starry-app-smoke-loongarch64"
+name = "Starry app smoke loongarch64"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "starry-apps-loongarch64"
+apk_region = "us"
+container_preflight = "qemu-user"
+events = ["schedule", "workflow_dispatch"]
+command = '''
+cargo xtask starry app qemu --all --arch loongarch64
+'''
+
+[[check]]
+id = "starry-nixos-x86-64-qemu"
+name = "x86_64 QEMU · NixOS Stage-2"
+runs_on = ["ubuntu-latest"]
+environment = "host"
+timeout_minutes = 45
+container_preflight = "none"
+command = '''
+docker run --rm \
+  --env NIX_CONFIG=$'experimental-features = nix-command flakes\nsandbox = false' \
+  --volume "$PWD:/workspace" \
+  --workdir /workspace \
+  docker.io/nixos/nix:2.33.1 \
+  sh -lc '
+    git config --global --add safe.directory /workspace
+    nix develop --accept-flake-config -c \
+      cargo xtask starry app qemu -t nixos --arch x86_64 --cap nix
+  '
+'''

--- a/.github/ci/checks/starry.toml
+++ b/.github/ci/checks/starry.toml
@@ -1,0 +1,110 @@
+schema_version = 1
+phase = "test"
+group = "Starry"
+
+# Visual and stress checks remain disabled until their prerequisites and
+# verified golden outputs are available. The rock-4d board check also remains
+# disabled, matching the previous workflow matrix.
+
+[[check]]
+id = "test-starry-riscv64-qemu"
+name = "Test starry riscv64 qemu"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "test-starry-riscv64"
+apk_region = "us"
+download_xtask_bin_artifact = true
+command = '''
+target/debug/tg-xtask starry test qemu --arch riscv64
+'''
+
+[[check]]
+id = "test-starry-aarch64-qemu"
+name = "Test starry aarch64 qemu"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "test-starry-aarch64"
+apk_region = "us"
+download_xtask_bin_artifact = true
+command = '''
+echo "==> starry aarch64 GICv2 SMP4 boot"
+target/debug/tg-xtask starry qemu --arch aarch64 --smp 4 \
+  --qemu-config os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml
+echo "==> starry aarch64 test suites"
+target/debug/tg-xtask starry test qemu --arch aarch64
+'''
+
+[[check]]
+id = "test-starry-loongarch64-qemu"
+name = "Test starry loongarch64 qemu"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "test-starry-loongarch64"
+apk_region = "us"
+download_xtask_bin_artifact = true
+command = '''
+target/debug/tg-xtask starry test qemu --arch loongarch64
+'''
+
+[[check]]
+id = "test-starry-x86-64-qemu"
+name = "Test starry x86_64 qemu"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+cache_key = "test-starry-x86_64"
+apk_region = "us"
+download_xtask_bin_artifact = true
+command = '''
+target/debug/tg-xtask starry test qemu --arch x86_64
+'''
+
+[[check]]
+id = "test-starry-self-hosted-board-orangepi-5-plus"
+name = "Test starry self-hosted board orangepi-5-plus"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+command = '''
+cargo xtask starry test board --board orangepi-5-plus
+'''
+
+[[check]]
+id = "test-orangepi-5-plus-robot-native-starryos"
+name = "Test OrangePi 5 Plus robot native StarryOS"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+timeout_minutes = 90
+command = '''
+cargo xtask starry test board --board orangepi-5-plus-robot
+'''
+
+[[check]]
+id = "test-starry-self-hosted-board-aka-00-sg2002"
+name = "Test starry self-hosted board aka-00-sg2002"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+command = '''
+cargo xtask starry test board --board aka-00-sg2002
+'''
+
+[[check]]
+id = "test-starry-self-hosted-board-visionfive2"
+name = "Test starry self-hosted board visionfive2"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+command = '''
+cargo xtask starry test board --board visionfive2
+'''
+
+[[check]]
+id = "test-starry-self-hosted-board-jl-lsgd2k10"
+name = "Test starry self-hosted board jl-lsgd2k10"
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+command = '''
+cargo xtask starry test board --board jl-lsgd2k10
+'''

--- a/.github/ci/checks/starry.toml
+++ b/.github/ci/checks/starry.toml
@@ -8,7 +8,7 @@ group = "Starry"
 
 [[check]]
 id = "test-starry-riscv64-qemu"
-name = "Test starry riscv64 qemu"
+name = "riscv64 QEMU · Suites"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "test-starry-riscv64"
@@ -20,7 +20,7 @@ target/debug/tg-xtask starry test qemu --arch riscv64
 
 [[check]]
 id = "test-starry-aarch64-qemu"
-name = "Test starry aarch64 qemu"
+name = "aarch64 QEMU · GICv2 SMP4 boot + suites"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "test-starry-aarch64"
@@ -36,7 +36,7 @@ target/debug/tg-xtask starry test qemu --arch aarch64
 
 [[check]]
 id = "test-starry-loongarch64-qemu"
-name = "Test starry loongarch64 qemu"
+name = "loongarch64 QEMU · Suites"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "test-starry-loongarch64"
@@ -48,7 +48,7 @@ target/debug/tg-xtask starry test qemu --arch loongarch64
 
 [[check]]
 id = "test-starry-x86-64-qemu"
-name = "Test starry x86_64 qemu"
+name = "x86_64 QEMU · Suites"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 cache_key = "test-starry-x86_64"
@@ -60,7 +60,7 @@ target/debug/tg-xtask starry test qemu --arch x86_64
 
 [[check]]
 id = "test-starry-self-hosted-board-orangepi-5-plus"
-name = "Test starry self-hosted board orangepi-5-plus"
+name = "OrangePi 5 Plus board · Suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -70,7 +70,7 @@ cargo xtask starry test board --board orangepi-5-plus
 
 [[check]]
 id = "test-orangepi-5-plus-robot-native-starryos"
-name = "Test OrangePi 5 Plus robot native StarryOS"
+name = "OrangePi 5 Plus robot board · Native suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -81,7 +81,7 @@ cargo xtask starry test board --board orangepi-5-plus-robot
 
 [[check]]
 id = "test-starry-self-hosted-board-aka-00-sg2002"
-name = "Test starry self-hosted board aka-00-sg2002"
+name = "AKA-00 SG2002 board · Suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -91,7 +91,7 @@ cargo xtask starry test board --board aka-00-sg2002
 
 [[check]]
 id = "test-starry-self-hosted-board-visionfive2"
-name = "Test starry self-hosted board visionfive2"
+name = "VisionFive 2 board · Suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"
@@ -101,7 +101,7 @@ cargo xtask starry test board --board visionfive2
 
 [[check]]
 id = "test-starry-self-hosted-board-jl-lsgd2k10"
-name = "Test starry self-hosted board jl-lsgd2k10"
+name = "JL LSGD2K10 board · Suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
 required_owner = "rcore-os"

--- a/.github/ci/checks/static.toml
+++ b/.github/ci/checks/static.toml
@@ -4,7 +4,7 @@ group = "Static"
 
 [[check]]
 id = "check-formatting"
-name = "Check formatting"
+name = "Formatting + publish dry-run"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -16,7 +16,7 @@ cargo publish --workspace --dry-run --no-verify
 
 [[check]]
 id = "run-sync-lint"
-name = "Run sync-lint"
+name = "Incremental synchronization lint"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 fetch_depth = "full"
@@ -27,7 +27,7 @@ cargo xtask sync-lint --since "$SINCE_REF"
 
 [[check]]
 id = "run-lock-lint"
-name = "Run lock-lint"
+name = "Locking policy"
 runs_on = ["ubuntu-latest"]
 environment = "base"
 command = '''

--- a/.github/ci/checks/static.toml
+++ b/.github/ci/checks/static.toml
@@ -1,0 +1,35 @@
+schema_version = 1
+phase = "static"
+group = "Static"
+
+[[check]]
+id = "check-formatting"
+name = "Check formatting"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+command = '''
+cargo fmt --all -- --check
+cargo publish --workspace --dry-run --no-verify
+'''
+
+[[check]]
+id = "run-sync-lint"
+name = "Run sync-lint"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+fetch_depth = "full"
+upload_xtask_bin_artifact = true
+command = '''
+cargo xtask sync-lint --since "$SINCE_REF"
+'''
+
+[[check]]
+id = "run-lock-lint"
+name = "Run lock-lint"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+command = '''
+cargo xtask lock-lint
+'''

--- a/.github/ci/checks/workspace.toml
+++ b/.github/ci/checks/workspace.toml
@@ -4,7 +4,7 @@ group = "Workspace"
 
 [[check]]
 id = "run-clippy"
-name = "Run clippy"
+name = "Incremental Clippy"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"
@@ -17,7 +17,7 @@ cargo xtask clippy --since "$SINCE_REF"
 
 [[check]]
 id = "test-with-std"
-name = "Test with std"
+name = "std tests"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
 self_hosted_owner = "rcore-os"

--- a/.github/ci/checks/workspace.toml
+++ b/.github/ci/checks/workspace.toml
@@ -1,0 +1,27 @@
+schema_version = 1
+phase = "test"
+group = "Workspace"
+
+[[check]]
+id = "run-clippy"
+name = "Run clippy"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+fetch_depth = "full"
+download_xtask_bin_artifact = true
+command = '''
+cargo xtask clippy --since "$SINCE_REF"
+'''
+
+[[check]]
+id = "test-with-std"
+name = "Test with std"
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+command = '''
+cargo xtask test
+'''

--- a/.github/workflows/ci-branch-push.yml
+++ b/.github/workflows/ci-branch-push.yml
@@ -67,8 +67,6 @@ jobs:
           gh workflow run ci.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref "$REF_NAME" \
-            -f run_target=ci \
-            -f container_target=both \
             -f since_sha="$BEFORE_SHA"
 
           {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,34 +13,36 @@ on:
       - "**/docs/**"
       - "**/doc/**"
   pull_request:
-    paths-ignore:
-      - "**/*.md"
-      - "**/*.rst"
-      - "**/*.adoc"
-      - "docs/**"
-      - "**/docs/**"
-      - "**/doc/**"
+    paths:
+      - ".cargo/**"
+      - ".github/actions/publish-container/action.yml"
+      - ".github/ci/**"
+      - ".github/workflows/ci-branch-push.yml"
+      - ".github/workflows/container-publish.yml"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/reusable-check-matrix.yml"
+      - ".github/workflows/starry-apps.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "apps/**"
+      - "bootloader/**"
+      - "components/**"
+      - "drivers/**"
+      - "fs/**"
+      - "memory/**"
+      - "net/**"
+      - "os/**"
+      - "platforms/**"
+      - "scripts/**"
+      - "test-suit/**"
+      - "tools/**"
+      - "virtualization/**"
+      - "xtask/**"
   workflow_dispatch:
     inputs:
-      run_target:
-        description: Run CI checks or publish container images.
-        required: false
-        default: container
-        type: choice
-        options:
-          - container
-          - ci
-      container_target:
-        description: Container image(s) to publish manually.
-        required: false
-        default: both
-        type: choice
-        options:
-          - base
-          - axvisor-lvz
-          - both
       since_sha:
-        description: Base commit for CI diff checks when run_target is ci.
+        description: Base commit for incremental CI checks.
         required: false
         default: ""
         type: string
@@ -135,825 +137,105 @@ jobs:
             done <<< "$runs"
           done
 
-  detect_changes:
-    name: Detect changed paths
+  plan_ci:
+    name: Plan CI
     needs: cancel_stale_runs
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     outputs:
-      ci_checks: ${{ steps.outputs.outputs.ci_checks }}
-      since_ref: ${{ steps.outputs.outputs.since_ref }}
-      base_container_publish: ${{ steps.outputs.outputs.base_container_publish }}
-      axvisor_lvz_container_publish: ${{ steps.outputs.outputs.axvisor_lvz_container_publish }}
-      base_container_image: ${{ steps.outputs.outputs.base_container_image }}
-      axvisor_lvz_container_image: ${{ steps.outputs.outputs.axvisor_lvz_container_image }}
+      since_ref: ${{ steps.since.outputs.since_ref }}
+      static_matrix: ${{ steps.matrix.outputs.static_matrix }}
+      test_matrix: ${{ steps.matrix.outputs.test_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
-      - name: Validate CI source paths
+      - name: Validate CI configuration
         run: |
+          set -euo pipefail
           python3 scripts/test/check_ci_paths.py
-
-      - name: Validate CI routing
-        run: |
           python3 scripts/test/check_ci_routing.py
+          python3 scripts/test/check_workflow_layout.py
+          python3 -m unittest scripts/test/test_ci_plan.py
 
-      - name: Detect CI-relevant changes
-        id: filter
-        if: github.event_name != 'workflow_dispatch'
-        uses: dorny/paths-filter@v4
-        with:
-          base: ${{ github.event_name == 'push' && github.ref || '' }}
-          token: ""
-          filters: |
-            ci_checks:
-              - ".cargo/**"
-              - ".github/workflows/ci-branch-push.yml"
-              - ".github/workflows/container-publish.yml"
-              - ".github/workflows/ci.yml"
-              - ".github/workflows/reusable-command.yml"
-              - "Cargo.toml"
-              - "Cargo.lock"
-              - "rust-toolchain.toml"
-              - "apps/**"
-              - "bootloader/**"
-              - "components/**"
-              - "drivers/**"
-              - "fs/**"
-              - "memory/**"
-              - "net/**"
-              - "os/**"
-              - "platforms/**"
-              - "scripts/**"
-              - "test-suit/**"
-              - "tools/**"
-              - "virtualization/**"
-              - "xtask/**"
-            base_container_publish:
-              - "container/Dockerfile"
-              - "rust-toolchain.toml"
-            axvisor_lvz_container_publish:
-              - "container/Dockerfile.axvisor-lvz"
-              - "rust-toolchain.toml"
-
-      - name: Resolve workflow outputs
-        id: outputs
+      - name: Resolve incremental base revision
+        id: since
         env:
           EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
-          RUN_TARGET: ${{ github.event.inputs.run_target || 'container' }}
-          MANUAL_TARGET: ${{ github.event.inputs.container_target }}
-          SINCE_SHA: ${{ github.event.inputs.since_sha }}
+          SINCE_SHA: ${{ inputs.since_sha || '' }}
           PUSH_BEFORE_SHA: ${{ github.event.before || '' }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          FILTER_CI_CHECKS: ${{ steps.filter.outputs.ci_checks }}
-          FILTER_BASE_CONTAINER_PUBLISH: ${{ steps.filter.outputs.base_container_publish }}
-          FILTER_AXVISOR_LVZ_CONTAINER_PUBLISH: ${{ steps.filter.outputs.axvisor_lvz_container_publish }}
         run: |
-          repository="$(printf '%s' "$GITHUB_REPOSITORY" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
-          base_container_image="ghcr.io/${repository}-container"
-          axvisor_lvz_container_image="ghcr.io/${repository}-container-axvisor-lvz"
+          set -euo pipefail
 
           is_empty_or_zero_sha() {
             local value="$1"
             [ -z "$value" ] || [ "$value" = "0000000000000000000000000000000000000000" ]
           }
 
-          resolve_since_ref() {
-            if [ "$EVENT_NAME" = "pull_request" ]; then
-              printf '%s\n' "$PR_BASE_SHA"
-              return
-            fi
-
-            if [ "$EVENT_NAME" = "push" ]; then
-              if ! is_empty_or_zero_sha "$PUSH_BEFORE_SHA"; then
-                printf '%s\n' "$PUSH_BEFORE_SHA"
-                return
-              fi
-            elif [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$RUN_TARGET" = "ci" ]; then
-              if ! is_empty_or_zero_sha "$SINCE_SHA"; then
-                printf '%s\n' "$SINCE_SHA"
-                return
-              fi
-            fi
-
-            if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
-              git rev-parse HEAD~1
-              return
-            fi
-
-            git fetch --no-tags --depth=1 origin dev:refs/remotes/origin/dev >/dev/null 2>&1 || true
-            merge_base="$(git merge-base HEAD origin/dev 2>/dev/null || true)"
-            if [ -n "$merge_base" ]; then
-              printf '%s\n' "$merge_base"
-              return
-            fi
-
-            git rev-parse HEAD
-          }
-
-          since_ref="$(resolve_since_ref)"
-
-          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$RUN_TARGET" = "ci" ]; then
-            ci_checks=true
-            base_container_publish=false
-            axvisor_lvz_container_publish=false
-          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            ci_checks=false
-            case "$RUN_TARGET" in
-              container)
-                case "$MANUAL_TARGET" in
-                  base)
-                    base_container_publish=true
-                    axvisor_lvz_container_publish=false
-                    ;;
-                  axvisor-lvz)
-                    base_container_publish=false
-                    axvisor_lvz_container_publish=true
-                    ;;
-                  both)
-                    base_container_publish=true
-                    axvisor_lvz_container_publish=true
-                    ;;
-                  *)
-                    echo "Unexpected container_target: $MANUAL_TARGET" >&2
-                    exit 1
-                    ;;
-                esac
-                ;;
-              *)
-                echo "Unexpected run_target: $RUN_TARGET" >&2
-                exit 1
-                ;;
-            esac
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            since_ref="$PR_BASE_SHA"
+          elif [ "$EVENT_NAME" = "push" ] && ! is_empty_or_zero_sha "$PUSH_BEFORE_SHA"; then
+            since_ref="$PUSH_BEFORE_SHA"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ] && ! is_empty_or_zero_sha "$SINCE_SHA"; then
+            since_ref="$SINCE_SHA"
+          elif git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+            since_ref="$(git rev-parse HEAD~1)"
           else
-            if [ "$EVENT_NAME" = "push" ] && { [ "$REF_NAME" = "main" ] || [ "$REF_NAME" = "dev" ]; }; then
-              ci_checks=true
-            else
-              ci_checks="${FILTER_CI_CHECKS}"
-            fi
-            base_container_publish="${FILTER_BASE_CONTAINER_PUBLISH}"
-            axvisor_lvz_container_publish="${FILTER_AXVISOR_LVZ_CONTAINER_PUBLISH}"
+            git fetch --no-tags --depth=1 origin dev:refs/remotes/origin/dev >/dev/null 2>&1 || true
+            since_ref="$(git merge-base HEAD origin/dev 2>/dev/null || git rev-parse HEAD)"
           fi
 
-          {
-            echo "ci_checks=${ci_checks}"
-            echo "since_ref=${since_ref}"
-            echo "base_container_publish=${base_container_publish}"
-            echo "axvisor_lvz_container_publish=${axvisor_lvz_container_publish}"
-            echo "base_container_image=${base_container_image}"
-            echo "axvisor_lvz_container_image=${axvisor_lvz_container_image}"
-          } >> "$GITHUB_OUTPUT"
+          echo "since_ref=${since_ref}" >> "$GITHUB_OUTPUT"
 
-      - name: Summarize skipped CI checks
-        if: steps.outputs.outputs.ci_checks != 'true'
+      - name: Plan check matrices
+        id: matrix
         env:
           EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          PR_HEAD_REPOSITORY_OWNER: >-
+            ${{ github.event.pull_request.head.repo.owner.login || '' }}
         run: |
-          {
-            echo "## CI checks skipped"
-            echo ""
-            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-              echo "This manual run is scoped to container publishing, so static checks and follow-up CI checks were skipped."
-            else
-              echo "Changed files do not match the test-relevant path set, so static checks and follow-up CI checks were skipped."
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Summarize manual container branch restriction
-        if: >-
-          ${{
-            github.event_name == 'workflow_dispatch'
-            && (github.event.inputs.run_target || 'container') == 'container'
-            && github.ref_name != 'main'
-            && github.ref_name != 'dev'
-          }}
-        run: |
-          {
-            echo "## Container publish skipped"
-            echo ""
-            echo "Manual container publishing only runs from the \`main\` or \`dev\` branch. This run targeted \`${{ github.ref_name }}\`, so publish jobs were skipped."
-          } >> "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          source_repository_owner="$REPOSITORY_OWNER"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            source_repository_owner="$PR_HEAD_REPOSITORY_OWNER"
+          fi
+          python3 scripts/test/ci_plan.py \
+            --mode main \
+            --repository "$GITHUB_REPOSITORY" \
+            --repository-owner "$source_repository_owner" \
+            --event-name "$EVENT_NAME" \
+            --base-ref "$BASE_REF" \
+            --output-file "$GITHUB_OUTPUT"
 
   static_checks:
-    name: ${{ matrix.name }}
-    needs: detect_changes
-    if: needs.detect_changes.outputs.ci_checks == 'true'
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - name: Check formatting
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: |
-              cargo fmt --all -- --check
-              cargo publish --workspace --dry-run --no-verify
-            cache_key: ""
-            container_image: base
-            fetch_depth: "1"
-          - name: Run sync-lint
-            use_container: true
-            runs_on: '["ubuntu-latest"]'
-            command: cargo xtask sync-lint --since "${{ needs.detect_changes.outputs.since_ref }}"
-            cache_key: ""
-            container_image: base
-            fetch_depth: full
-            upload_xtask_bin_artifact: true
-          - name: Run lock-lint
-            use_container: true
-            runs_on: '["ubuntu-latest"]'
-            command: cargo xtask lock-lint
-            cache_key: ""
-            container_image: base
-            fetch_depth: "1"
-    uses: ./.github/workflows/reusable-command.yml
+    name: Static checks
+    needs: plan_ci
+    uses: ./.github/workflows/reusable-check-matrix.yml
     with:
-      runs_on: >-
-        ${{
-          matrix.self_hosted_owner != ''
-          && github.repository_owner != matrix.self_hosted_owner
-          && '["ubuntu-latest"]'
-          || matrix.runs_on
-        }}
-      use_container: >-
-        ${{
-          matrix.use_container
-          || (
-            matrix.self_hosted_owner != ''
-            && github.repository_owner != matrix.self_hosted_owner
-          )
-        }}
-      command: ${{ matrix.command }}
-      cache_key: ${{ matrix.cache_key }}
-      container_image: >-
-        ${{
-          matrix.container_image == 'base'
-          && format('{0}:latest', needs.detect_changes.outputs.base_container_image)
-          || matrix.container_image
-        }}
-      fetch_depth: >-
-        ${{
-          contains(matrix.runs_on, 'self-hosted')
-          && !(
-            matrix.self_hosted_owner != ''
-            && github.repository_owner != matrix.self_hosted_owner
-          )
-          && matrix.fetch_depth == 'full'
-          && '2'
-          || (matrix.fetch_depth == 'full' && '0' || '1')
-        }}
-      upload_xtask_bin_artifact: ${{ matrix.upload_xtask_bin_artifact || false }}
-      xtask_bin_artifact_name: tg-xtask-bin
-
-  test_checks:
-    name: ${{ matrix.name }}
-    if: needs.detect_changes.outputs.ci_checks == 'true'
-    needs:
-      - detect_changes
-      - static_checks
-    strategy:
-      fail-fast: true
-      matrix:
-        include:
-          - name: Run clippy
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask clippy --since "${{ needs.detect_changes.outputs.since_ref }}"
-            cache_key: ""
-            container_image: base
-            fetch_depth: full
-            download_xtask_bin_artifact: true
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test with std
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask test
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor aarch64 qemu (smoke + axtest + timer stress)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            timeout_minutes: 30
-            command: |
-              echo "==> axvisor aarch64 smoke"
-              cargo xtask axvisor test qemu --arch aarch64 --test-case smoke
-              echo "==> axvisor aarch64 virtio-blk ArceOS guest"
-              timeout 240s apps/arceos/virtio-blk-test/run.sh
-              echo "==> axvisor aarch64 axtest"
-              cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
-              echo "==> pull qemu-aarch64 image"
-              cargo xtask image pull qemu-aarch64 --output-dir tmp/axbuild/images
-              echo "==> axvisor aarch64 gicv2 timer stress"
-              cargo xtask axvisor test qemu --arch aarch64 --test-case gicv2-timer-stress
-              echo "==> axvisor aarch64 gicv3 timer stress"
-              cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor aarch64 qemu (panic modes)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            timeout_minutes: 30
-            command: |
-              echo "==> axvisor aarch64 backtrace panic"
-              cargo xtask axvisor test qemu --arch aarch64 --test-case backtrace-panic
-              echo "==> axvisor aarch64 no-backtrace panic"
-              cargo xtask axvisor test qemu --arch aarch64 --test-case no-backtrace
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor riscv64 qemu (smoke + panic modes)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            timeout_minutes: 30
-            command: |
-              echo "==> axvisor riscv64 smoke"
-              cargo xtask axvisor test qemu --arch riscv64 --test-case smoke
-              echo "==> axvisor riscv64 IPI cross-test"
-              cargo xtask cross-test --arch riscv64 \
-                --package riscv_vcpu --package axvm \
-                --features axvm/host-test --no-default-features --lib ipi
-              echo "==> axvisor riscv64 backtrace panic"
-              cargo xtask axvisor test qemu --arch riscv64 --test-case backtrace-panic
-              echo "==> axvisor riscv64 no-backtrace panic"
-              cargo xtask axvisor test qemu --arch riscv64 --test-case no-backtrace
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test axvisor loongarch64 qemu
-            use_container: true
-            runs_on: '["ubuntu-latest"]'
-            command: target/debug/tg-xtask axvisor test qemu --arch loongarch64
-            cache_key: test-axvisor-loongarch64
-            container_image: axvisor-lvz
-            limit_to_owner: ""
-            main_pr_only: false
-            download_xtask_bin_artifact: true
-          - name: Test axvisor qemu ivc
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qemu-ivc
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test starry riscv64 qemu
-            use_container: true
-            runs_on: '["ubuntu-latest"]'
-            command: target/debug/tg-xtask starry test qemu --arch riscv64
-            cache_key: test-starry-riscv64
-            container_image: base
-            apk_region: us
-            limit_to_owner: ""
-            main_pr_only: false
-            download_xtask_bin_artifact: true
-          - name: Test starry aarch64 qemu
-            use_container: true
-            runs_on: '["ubuntu-latest"]'
-            command: |
-              echo "==> starry aarch64 GICv2 SMP4 boot"
-              target/debug/tg-xtask starry qemu --arch aarch64 --smp 4 \
-                --qemu-config os/StarryOS/configs/qemu/qemu-aarch64-gicv2-boot.toml
-              echo "==> starry aarch64 test suites"
-              target/debug/tg-xtask starry test qemu --arch aarch64
-            cache_key: test-starry-aarch64
-            container_image: base
-            apk_region: us
-            limit_to_owner: ""
-            main_pr_only: false
-            download_xtask_bin_artifact: true
-          - name: Test starry loongarch64 qemu
-            use_container: true
-            runs_on: '["ubuntu-latest"]'
-            command: target/debug/tg-xtask starry test qemu --arch loongarch64
-            cache_key: test-starry-loongarch64
-            container_image: base
-            apk_region: us
-            limit_to_owner: ""
-            main_pr_only: false
-            download_xtask_bin_artifact: true
-          - name: Test starry x86_64 qemu
-            use_container: true
-            runs_on: '["ubuntu-latest"]'
-            command: target/debug/tg-xtask starry test qemu --arch x86_64
-            cache_key: test-starry-x86_64
-            container_image: base
-            apk_region: us
-            limit_to_owner: ""
-            main_pr_only: false
-            download_xtask_bin_artifact: true
-          - name: Test arceos x86_64 qemu
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask arceos test qemu --arch x86_64
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test arceos riscv64 qemu
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: |
-              cargo xtask arceos test qemu --arch riscv64
-              taskset -c 0 cargo xtask arceos test qemu --arch riscv64 \
-                --test-group rust --test-case task-ipi
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test arceos aarch64 qemu (app + suites)
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: |
-              echo "==> arceos aarch64 GICv2 SMP4 default app boot"
-              cargo xtask arceos qemu --arch aarch64 --smp 4 \
-                --qemu-config os/arceos/configs/qemu/qemu-aarch64-gicv2-boot.toml
-              echo "==> arceos aarch64 test suites (Rust GICv2 SMP4 IPI + C GICv3 SMP4)"
-              cargo xtask arceos test qemu --arch aarch64
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          - name: Test arceos loongarch64 qemu
-            use_container: false
-            runs_on: '["self-hosted","linux","qcs"]'
-            self_hosted_owner: rcore-os
-            command: cargo xtask arceos test qemu --arch loongarch64
-            cache_key: ""
-            container_image: base
-            limit_to_owner: ""
-            main_pr_only: false
-          # Visual regression matrix: re-enable per arch once at least one
-          # scenario has that arch listed in its `arches` file and a verified
-          # golden is committed. Until then run_all.sh exits 1 (no scenarios
-          # ran), so the matrix would be uniformly red. The DRM card0 PR (#506)
-          # is the current prerequisite for weston_shm_baseline / xwayland_xeyes.
-          # - name: Visual starry riscv64
-          #   use_container: true
-          #   runs_on: '["ubuntu-latest"]'
-          #   command: |
-          #     apt-get update && apt-get install -y --no-install-recommends e2tools
-          #     cargo xtask starry build --arch riscv64
-          #     cargo xtask starry rootfs --arch riscv64
-          #     python3 scripts/visual-test/prepare_rootfs_extras.py --arch riscv64 --scenario xwayland_xeyes
-          #     bash scripts/visual-test/run_all.sh --arch riscv64
-          #   cache_key: test-visual-riscv64
-          #   container_image: base
-          #   apk_region: us
-          #   limit_to_owner: ""
-          #   main_pr_only: false
-          # - name: Visual starry aarch64
-          #   use_container: true
-          #   runs_on: '["ubuntu-latest"]'
-          #   command: |
-          #     apt-get update && apt-get install -y --no-install-recommends e2tools
-          #     cargo xtask starry build --arch aarch64
-          #     cargo xtask starry rootfs --arch aarch64
-          #     python3 scripts/visual-test/prepare_rootfs_extras.py --arch aarch64 --scenario xwayland_xeyes
-          #     bash scripts/visual-test/run_all.sh --arch aarch64
-          #   cache_key: test-visual-aarch64
-          #   container_image: base
-          #   apk_region: us
-          #   limit_to_owner: ""
-          #   main_pr_only: false
-          # - name: Visual starry x86_64
-          #   use_container: true
-          #   runs_on: '["ubuntu-latest"]'
-          #   command: |
-          #     apt-get update && apt-get install -y --no-install-recommends e2tools
-          #     cargo xtask starry build --arch x86_64
-          #     cargo xtask starry rootfs --arch x86_64
-          #     python3 scripts/visual-test/prepare_rootfs_extras.py --arch x86_64 --scenario xwayland_xeyes
-          #     bash scripts/visual-test/run_all.sh --arch x86_64
-          #   cache_key: test-visual-x86_64
-          #   container_image: base
-          #   apk_region: us
-          #   limit_to_owner: ""
-          #   main_pr_only: false
-          # Stress tests: uncomment to enable (runs only on PRs targeting main).
-          # - name: Stress starry aarch64
-          #   use_container: true
-          #   runs_on: '["ubuntu-latest"]'
-          #   command: cargo xtask starry app qemu -t stress/git --arch aarch64
-          #   cache_key: test-starry-stress-aarch64
-          #   container_image: base
-          #   apk_region: us
-          #   limit_to_owner: ""
-          #   main_pr_only: true
-          # - name: Stress starry riscv64
-          #   use_container: true
-          #   runs_on: '["ubuntu-latest"]'
-          #   command: cargo xtask starry app qemu -t stress/git --arch riscv64
-          #   cache_key: test-starry-stress-riscv64
-          #   container_image: base
-          #   apk_region: us
-          #   limit_to_owner: ""
-          #   main_pr_only: true
-          # - name: Stress starry loongarch64
-          #   use_container: true
-          #   runs_on: '["ubuntu-latest"]'
-          #   command: cargo xtask starry app qemu -t stress/git --arch loongarch64
-          #   cache_key: test-starry-stress-loongarch64
-          #   container_image: base
-          #   apk_region: us
-          #   limit_to_owner: ""
-          #   main_pr_only: true
-          # - name: Stress starry x86_64
-          #   use_container: true
-          #   runs_on: '["ubuntu-latest"]'
-          #   command: cargo xtask starry app qemu -t stress/git --arch x86_64
-          #   cache_key: test-starry-stress-x86_64
-          #   container_image: base
-          #   apk_region: us
-          #   limit_to_owner: ""
-          #   main_pr_only: true
-          - name: Test axvisor self-hosted x86_64 (svm smoke + ACPI)
-            use_container: false
-            runs_on: '["self-hosted","linux","amd","kvm"]'
-            require_kvm: true
-            timeout_minutes: 30
-            command: |
-              echo "==> axvisor x86_64 svm smoke"
-              cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm
-              echo "==> pull qemu-x86_64 image"
-              cargo xtask image pull qemu-x86_64 --output-dir tmp/axbuild/images
-              echo "==> axvisor x86_64 svm direct ACPI boot"
-              cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-svm
-              echo "==> axvisor x86_64 svm nested OVMF ACPI boot"
-              cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-svm
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axvisor self-hosted x86_64(vmx)
-            use_container: false
-            runs_on: '["self-hosted","linux","intel","kvm"]'
-            require_kvm: true
-            command: cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axloader HTTP smoke
-            use_container: false
-            runs_on: '["self-hosted","linux","intel","kvm"]'
-            require_kvm: true
-            timeout_minutes: 25
-            command: |
-              rustup target add x86_64-unknown-uefi
-              cargo xtask axloader test qemu --target x86_64-unknown-uefi
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axvisor x86_64 ACPI direct and OVMF boot (vmx)
-            use_container: false
-            runs_on: '["self-hosted","linux","intel","kvm"]'
-            require_kvm: true
-            timeout_minutes: 45
-            command: |
-              cargo xtask image pull qemu-x86_64 --output-dir tmp/axbuild/images
-              cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-vmx
-              cargo xtask axvisor test qemu --arch x86_64 --test-case mp-fallback-vmx
-              cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axvisor self-hosted board orangepi-5-plus-linux
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask axvisor test board --board orangepi-5-plus-linux
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axvisor self-hosted board orangepi-5-plus-starry
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask axvisor test board --board orangepi-5-plus-starry
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axvisor self-hosted board roc-rk3568-pc-linux
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask axvisor test board --board roc-rk3568-pc-linux
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axvisor self-hosted board phytiumpi-linux
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask axvisor test board --board phytiumpi-linux
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test axvisor self-hosted board asus-nuc15crh-linux
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            timeout_minutes: 20
-            command: |
-              mkdir -p tmp
-              cargo xtask image pull qemu-x86_64 --output-dir tmp
-              cargo xtask image pull initramfs-x86_64-busybox.cpio.gz --output-dir tmp
-              gzip -dc \
-                tmp/initramfs-x86_64-busybox.cpio.gz/initramfs-x86_64-busybox.cpio.gz \
-                > tmp/initramfs-x86_64-busybox.cpio
-              cargo xtask axvisor test board --board asus-nuc15crh-linux
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test starry self-hosted board orangepi-5-plus
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask starry test board --board orangepi-5-plus
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test OrangePi 5 Plus robot native StarryOS
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            timeout_minutes: 90
-            command: cargo xtask starry test board --board orangepi-5-plus-robot
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test OrangePi 5 Plus robot AxVisor StarryOS guest
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            timeout_minutes: 90
-            command: cargo xtask axvisor test board --board orangepi-5-plus-robot-starry
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test OrangePi 5 Plus robot AxVisor Linux guest
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            timeout_minutes: 90
-            command: cargo xtask axvisor test board --board orangepi-5-plus-robot-linux
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          # - name: Test starry self-hosted board rock-4d
-          #   use_container: false
-          #   runs_on: '["self-hosted","linux","board"]'
-          #   command: cargo xtask starry test board --board rock-4d
-          #   cache_key: ""
-          #   container_image: ""
-          #   limit_to_owner: rcore-os
-          #   main_pr_only: false
-          - name: Test starry self-hosted board aka-00-sg2002
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask starry test board --board aka-00-sg2002
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test starry self-hosted board visionfive2
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask starry test board --board visionfive2
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-          - name: Test starry self-hosted board jl-lsgd2k10
-            use_container: false
-            runs_on: '["self-hosted","linux","board"]'
-            command: cargo xtask starry test board --board jl-lsgd2k10
-            cache_key: ""
-            container_image: ""
-            limit_to_owner: rcore-os
-            main_pr_only: false
-    uses: ./.github/workflows/reusable-command.yml
-    with:
-      runs_on: >-
-        ${{
-          matrix.self_hosted_owner != ''
-          && github.repository_owner != matrix.self_hosted_owner
-          && '["ubuntu-latest"]'
-          || matrix.runs_on
-        }}
-      use_container: >-
-        ${{
-          matrix.use_container
-          || (
-            matrix.self_hosted_owner != ''
-            && github.repository_owner != matrix.self_hosted_owner
-          )
-        }}
-      command: ${{ matrix.command }}
-      cache_key: ${{ matrix.cache_key }}
-      container_image: >-
-        ${{
-          matrix.container_image == 'base'
-          && format('{0}:latest', needs.detect_changes.outputs.base_container_image)
-          || matrix.container_image == 'axvisor-lvz'
-          && format('{0}:latest', needs.detect_changes.outputs.axvisor_lvz_container_image)
-          || matrix.container_image
-        }}
-      apk_region: ${{ matrix.apk_region || 'china' }}
-      limit_to_owner: ${{ matrix.limit_to_owner }}
-      main_pr_only: ${{ matrix.main_pr_only }}
-      fetch_depth: >-
-        ${{
-          contains(matrix.runs_on, 'self-hosted')
-          && !(
-            matrix.self_hosted_owner != ''
-            && github.repository_owner != matrix.self_hosted_owner
-          )
-          && matrix.fetch_depth == 'full'
-          && '2'
-          || (matrix.fetch_depth == 'full' && '0' || '1')
-        }}
-      timeout_minutes: ${{ matrix.timeout_minutes || 360 }}
-      require_kvm: ${{ matrix.require_kvm || false }}
-      download_xtask_bin_artifact: >-
-        ${{
-          matrix.download_xtask_bin_artifact
-          || (
-            matrix.self_hosted_owner != ''
-            && github.repository_owner != matrix.self_hosted_owner
-          )
-        }}
-      xtask_bin_artifact_name: tg-xtask-bin
+      matrix_json: ${{ needs.plan_ci.outputs.static_matrix }}
+      fail_fast: true
+      save_cache: ${{ github.event_name == 'push' }}
+      since_ref: ${{ needs.plan_ci.outputs.since_ref }}
     secrets:
       CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
 
-  publish_base_container:
-    name: Publish base container image
-    if: >-
-      ${{
-        (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        && (github.ref_name == 'main' || github.ref_name == 'dev')
-        && needs.detect_changes.outputs.base_container_publish == 'true'
-      }}
+  test_checks:
+    name: Test checks
     needs:
-      - detect_changes
-    uses: ./.github/workflows/container-publish.yml
+      - plan_ci
+      - static_checks
+    uses: ./.github/workflows/reusable-check-matrix.yml
     with:
-      image_name: ${{ needs.detect_changes.outputs.base_container_image }}
-      dockerfile: container/Dockerfile
-      cache_scope: container
-    permissions:
-      contents: read
-      packages: write
-
-  publish_axvisor_lvz_container:
-    name: Publish axvisor-lvz container image
-    if: >-
-      ${{
-        always()
-        && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-        && (github.ref_name == 'main' || github.ref_name == 'dev')
-        && needs.detect_changes.outputs.axvisor_lvz_container_publish == 'true'
-        && (
-          needs.detect_changes.outputs.base_container_publish != 'true'
-          || needs.publish_base_container.result == 'success'
-        )
-      }}
-    needs:
-      - detect_changes
-      - publish_base_container
-    uses: ./.github/workflows/container-publish.yml
-    with:
-      image_name: ${{ needs.detect_changes.outputs.axvisor_lvz_container_image }}
-      dockerfile: container/Dockerfile.axvisor-lvz
-      cache_scope: container-axvisor-lvz
-      build_args: |
-        BASE_IMAGE=${{ needs.detect_changes.outputs.base_container_image }}:latest
-    permissions:
-      contents: read
-      packages: write
+      matrix_json: ${{ needs.plan_ci.outputs.test_matrix }}
+      fail_fast: true
+      save_cache: ${{ github.event_name == 'push' }}
+      since_ref: ${{ needs.plan_ci.outputs.since_ref }}
+    secrets:
+      CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
             --output-file "$GITHUB_OUTPUT"
 
   static_checks:
-    name: Static checks
+    name: Static
     needs: plan_ci
     uses: ./.github/workflows/reusable-check-matrix.yml
     with:
@@ -227,7 +227,7 @@ jobs:
       CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
 
   test_checks:
-    name: Test checks
+    name: Tests
     needs:
       - plan_ci
       - static_checks

--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -1,73 +1,151 @@
-name: Reusable Container Publish
+name: Container Images
 
 on:
-  workflow_call:
+  push:
+    branches:
+      - main
+      - dev
+    paths:
+      - "container/Dockerfile"
+      - "container/Dockerfile.axvisor-lvz"
+      - "rust-toolchain.toml"
+  workflow_dispatch:
     inputs:
-      image_name:
-        description: Full image name to publish.
-        required: true
-        type: string
-      dockerfile:
-        description: Dockerfile path relative to the repository root.
-        required: true
-        type: string
-      cache_scope:
-        description: GHA cache scope for docker build cache.
-        required: true
-        type: string
-      build_args:
-        description: Optional docker build args block.
+      target:
+        description: Container image(s) to publish.
         required: false
-        default: ""
-        type: string
+        default: both
+        type: choice
+        options:
+          - base
+          - axvisor-lvz
+          - both
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: container-images-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   publish:
-    name: Publish container image
+    name: Publish container images
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-      - name: Checkout
+      - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
 
-      - name: Prepare image name
-        id: prep
+      - name: Detect changed image inputs
+        id: filter
+        if: github.event_name == 'push'
+        uses: dorny/paths-filter@v4
+        with:
+          base: ${{ github.ref }}
+          token: ""
+          filters: |
+            base:
+              - "container/Dockerfile"
+              - "rust-toolchain.toml"
+            axvisor:
+              - "container/Dockerfile.axvisor-lvz"
+              - "rust-toolchain.toml"
+
+      - name: Resolve publish targets
+        id: plan
         env:
-          IMAGE_NAME: ${{ inputs.image_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          MANUAL_TARGET: ${{ inputs.target || 'both' }}
+          FILTER_BASE: ${{ steps.filter.outputs.base }}
+          FILTER_AXVISOR: ${{ steps.filter.outputs.axvisor }}
         run: |
-          image="$(printf '%s' "$IMAGE_NAME" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
-          echo "image=${image}" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+
+          base=false
+          axvisor=false
+          reason="No container source changes selected an image."
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$REF_NAME" != "main" ] && [ "$REF_NAME" != "dev" ]; then
+              reason="Manual container publishing is only available from main or dev."
+            else
+              case "$MANUAL_TARGET" in
+                base)
+                  base=true
+                  ;;
+                axvisor-lvz)
+                  axvisor=true
+                  ;;
+                both)
+                  base=true
+                  axvisor=true
+                  ;;
+                *)
+                  echo "Unexpected container target: $MANUAL_TARGET" >&2
+                  exit 1
+                  ;;
+              esac
+              reason="Manual target: ${MANUAL_TARGET}."
+            fi
+          else
+            base="${FILTER_BASE:-false}"
+            axvisor="${FILTER_AXVISOR:-false}"
+            reason="Targets selected from changed container inputs."
+          fi
+
+          repository="$(printf '%s' "$GITHUB_REPOSITORY" | LC_ALL=C tr '[:upper:]' '[:lower:]')"
+          any=false
+          if [ "$base" = "true" ] || [ "$axvisor" = "true" ]; then
+            any=true
+          fi
+
+          {
+            echo "base=${base}"
+            echo "axvisor=${axvisor}"
+            echo "any=${any}"
+            echo "reason=${reason}"
+            echo "base_image=ghcr.io/${repository}-container"
+            echo "axvisor_image=ghcr.io/${repository}-container-axvisor-lvz"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Container publish plan"
+            echo ""
+            echo "- Base image: \`${base}\`"
+            echo "- AxVisor LVZ image: \`${axvisor}\`"
+            echo "- Reason: ${reason}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Set up Docker Buildx
+        if: steps.plan.outputs.any == 'true'
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
+        if: steps.plan.outputs.any == 'true'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@v6
+      - name: Publish base container image
+        if: steps.plan.outputs.base == 'true'
+        uses: ./.github/actions/publish-container
         with:
-          images: ${{ steps.prep.outputs.image }}
-          tags: |
-            type=ref,event=tag
-            type=raw,value=latest
+          image_name: ${{ steps.plan.outputs.base_image }}
+          dockerfile: container/Dockerfile
+          cache_scope: container
 
-      - name: Build and push container image
-        uses: docker/build-push-action@v7
+      - name: Publish AxVisor LVZ container image
+        if: steps.plan.outputs.axvisor == 'true'
+        uses: ./.github/actions/publish-container
         with:
-          context: .
-          file: ${{ inputs.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: ${{ inputs.build_args }}
-          cache-from: type=gha,scope=${{ inputs.cache_scope }}
-          cache-to: type=gha,mode=max,scope=${{ inputs.cache_scope }}
+          image_name: ${{ steps.plan.outputs.axvisor_image }}
+          dockerfile: container/Dockerfile.axvisor-lvz
+          cache_scope: container-axvisor-lvz
+          build_args: |
+            BASE_IMAGE=${{ steps.plan.outputs.base_image }}:latest

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -19,15 +19,33 @@ concurrency:
 
 jobs:
   release-plz-release:
-    name: Release-plz release
-    if: ${{ github.repository == 'rcore-os/tgoskits' && (github.event_name == 'workflow_dispatch' || github.ref_name == 'dev') }}
+    name: >-
+      ${{ github.repository == 'rcore-os/tgoskits' && (github.event_name == 'workflow_dispatch' || github.ref_name == 'dev') && 'Release-plz release' || 'Release-plz release (not applicable)' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: read
     steps:
+      - &eligibility
+        name: Check release eligibility
+        id: eligibility
+        env:
+          RELEASE_ELIGIBLE: >-
+            ${{ github.repository == 'rcore-os/tgoskits' && (github.event_name == 'workflow_dispatch' || github.ref_name == 'dev') }}
+        run: |
+          set -euo pipefail
+          echo "run=${RELEASE_ELIGIBLE}" >> "$GITHUB_OUTPUT"
+          if [ "$RELEASE_ELIGIBLE" != "true" ]; then
+            {
+              echo "## Release not applicable"
+              echo ""
+              echo "Release-plz only runs in \`rcore-os/tgoskits\` on a dev push or an explicit manual dispatch."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - &checkout
         name: Checkout repository
+        if: steps.eligibility.outputs.run == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -35,12 +53,15 @@ jobs:
 
       - &install-rust
         name: Install Rust toolchain
+        if: steps.eligibility.outputs.run == 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Preflight workspace packages
+        if: steps.eligibility.outputs.run == 'true'
         run: cargo publish --workspace --dry-run --no-verify
 
       - name: Run release-plz
+        if: steps.eligibility.outputs.run == 'true'
         uses: release-plz/action@v0.5
         with:
           command: release
@@ -50,17 +71,19 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release-plz-pr:
-    name: Release-plz PR
-    if: ${{ github.repository == 'rcore-os/tgoskits' && (github.event_name == 'workflow_dispatch' || github.ref_name == 'dev') }}
+    name: >-
+      ${{ github.repository == 'rcore-os/tgoskits' && (github.event_name == 'workflow_dispatch' || github.ref_name == 'dev') && 'Release-plz PR' || 'Release-plz PR (not applicable)' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
+      - *eligibility
       - *checkout
       - *install-rust
 
       - name: Run release-plz
+        if: steps.eligibility.outputs.run == 'true'
         uses: release-plz/action@v0.5
         with:
           command: release-pr

--- a/.github/workflows/reusable-check-matrix.yml
+++ b/.github/workflows/reusable-check-matrix.yml
@@ -1,102 +1,58 @@
-name: Reusable Command
+name: Reusable Check Matrix
 
 on:
   workflow_call:
     inputs:
-      runs_on:
-        description: JSON-encoded runner labels for runs-on.
-        required: false
-        type: string
-        default: '["ubuntu-latest"]'
-      use_container:
-        description: Whether to execute the command inside the CI container.
-        required: false
-        type: boolean
-        default: false
-      command:
-        description: Shell command to execute.
+      matrix_json:
+        description: JSON matrix emitted by scripts/test/ci_plan.py.
         required: true
         type: string
-      cache_key:
-        description: Shared cache key for rust-cache. Leave empty to disable cache.
+      fail_fast:
+        description: Cancel sibling matrix entries after a failure.
+        required: false
+        type: boolean
+        default: true
+      save_cache:
+        description: Allow rust-cache to save updated entries.
+        required: false
+        type: boolean
+        default: false
+      since_ref:
+        description: Base revision exposed to incremental check commands.
         required: false
         type: string
         default: ""
-      container_image:
-        description: Container image used for the job when use_container is true.
-        required: false
-        type: string
-        default: ""
-      apk_region:
-        description: APK mirror region passed through to Starry prebuild flows.
-        required: false
-        type: string
-        default: china
-      limit_to_owner:
-        description: Only run for this repository owner. Leave empty to run everywhere.
-        required: false
-        type: string
-        default: ""
-      main_pr_only:
-        description: Only run for pull requests targeting the main branch.
-        required: false
-        type: boolean
-        default: false
-      fetch_depth:
-        description: Checkout fetch depth. Use 0 when the command needs full git history.
-        required: false
-        type: string
-        default: "1"
-      timeout_minutes:
-        description: Maximum minutes to allow the command job to run.
-        required: false
-        type: number
-        default: 360
-      require_kvm:
-        description: Require readable and writable /dev/kvm on self-hosted host jobs.
-        required: false
-        type: boolean
-        default: false
-      upload_xtask_bin_artifact:
-        description: Upload the tg-xtask binary as a workflow artifact after the command succeeds.
-        required: false
-        type: boolean
-        default: false
-      download_xtask_bin_artifact:
-        description: Download and restore the tg-xtask binary artifact before running the command.
-        required: false
-        type: boolean
-        default: false
-      xtask_bin_artifact_name:
-        description: Artifact name used for the tarred tg-xtask binary.
-        required: false
-        type: string
-        default: tg-xtask-bin
     secrets:
       CLAW_API_KEY:
         required: false
+
 jobs:
-  run_host:
-    if: >-
-      ${{
-        !inputs.use_container
-        && (inputs.limit_to_owner == '' || github.repository_owner == inputs.limit_to_owner)
-        && (!inputs.main_pr_only || (github.event_name == 'pull_request' && github.base_ref == 'main'))
-      }}
-    runs-on: ${{ fromJson(inputs.runs_on) }}
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+  run:
+    name: ${{ matrix.name }}
+    strategy:
+      fail-fast: ${{ inputs.fail_fast }}
+      matrix: ${{ fromJSON(inputs.matrix_json) }}
+    runs-on: ${{ matrix.runs_on }}
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    container:
+      image: ${{ matrix.container_image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          fetch-depth: ${{ inputs.fetch_depth }}
+          fetch-depth: ${{ matrix.fetch_depth }}
 
       - name: Preflight self-hosted host runner
-        if: contains(inputs.runs_on, 'self-hosted')
-        shell: bash
+        if: contains(toJSON(matrix.runs_on), 'self-hosted')
         env:
-          REQUIRED_RUNNER_LABELS: ${{ inputs.runs_on }}
-          REQUIRE_KVM: ${{ inputs.require_kvm }}
+          REQUIRED_RUNNER_LABELS: ${{ toJSON(matrix.runs_on) }}
+          REQUIRE_KVM: ${{ matrix.require_kvm }}
         run: |
           set -euo pipefail
 
@@ -173,95 +129,8 @@ jobs:
             exit 1
           fi
 
-      - name: Restore Rust cache
-        if: inputs.cache_key != ''
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ${{ inputs.cache_key }}
-          save-if: ${{ github.event_name == 'push' }}
-
-      - name: Download tg-xtask binary artifact
-        if: inputs.download_xtask_bin_artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ inputs.xtask_bin_artifact_name }}
-          path: ${{ runner.temp }}/xtask-bin
-
-      - name: Restore tg-xtask binary artifact
-        if: inputs.download_xtask_bin_artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          artifact_path="${RUNNER_TEMP}/xtask-bin/tg-xtask-bin.tar"
-          xtask_path="${GITHUB_WORKSPACE}/target/debug/tg-xtask"
-          if ! tar -xf "${artifact_path}" -C "${GITHUB_WORKSPACE}"; then
-            echo "::error::failed to extract tg-xtask artifact: ${artifact_path}"
-            exit 1
-          fi
-          if [ ! -f "${xtask_path}" ]; then
-            echo "::error::tg-xtask artifact did not contain the expected binary: ${xtask_path}"
-            exit 1
-          fi
-          if ! chmod +x "${xtask_path}" || [ ! -x "${xtask_path}" ]; then
-            echo "::error::restored tg-xtask binary could not be made executable: ${xtask_path}"
-            exit 1
-          fi
-
-      - name: Show Rust version
-        run: rustc --version
-
-      - name: Run command
-        shell: bash
-        env:
-          STARRY_APK_REGION: ${{ inputs.apk_region }}
-          TGOS_IMAGE_LOCAL_STORAGE: >-
-            ${{ contains(inputs.runs_on, 'self-hosted') && format('/tmp/tgoskits-images-{0}-{1}', github.repository_id, runner.name) || '' }}
-          CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
-          REUSABLE_COMMAND: ${{ inputs.command }}
-          USE_XTASK_BIN: ${{ inputs.download_xtask_bin_artifact }}
-        run: |
-          set -eo pipefail
-
-          command_text="${REUSABLE_COMMAND}"
-          if [ "${USE_XTASK_BIN}" = "true" ] && [[ "${command_text}" != *$'\n'* ]]; then
-            if [[ "${command_text}" == "cargo xtask" || "${command_text}" == cargo\ xtask\ * ]]; then
-              command_text="target/debug/tg-xtask${command_text#cargo xtask}"
-            fi
-          fi
-
-          command_file="${RUNNER_TEMP}/reusable-command.sh"
-          printf '%s\n' "${command_text}" > "${command_file}"
-          if bash -e -o pipefail "${command_file}"; then
-            :
-          else
-            status=$?
-            echo "Command failed; resolved command:"
-            sed 's/^/+ /' "${command_file}"
-            exit "${status}"
-          fi
-
-  run_container:
-    if: >-
-      ${{
-        inputs.use_container
-        && (inputs.limit_to_owner == '' || github.repository_owner == inputs.limit_to_owner)
-        && (!inputs.main_pr_only || (github.event_name == 'pull_request' && github.base_ref == 'main'))
-      }}
-    runs-on: ${{ fromJson(inputs.runs_on) }}
-    timeout-minutes: ${{ inputs.timeout_minutes }}
-    container:
-      image: ${{ inputs.container_image }}
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: ${{ inputs.fetch_depth }}
-
-      - name: Show checkout state
-        shell: bash
+      - name: Show container checkout state
+        if: matrix.container_preflight != 'none'
         run: |
           set -euo pipefail
           command -v git
@@ -269,7 +138,7 @@ jobs:
           git -c safe.directory="${GITHUB_WORKSPACE}" rev-parse --is-inside-work-tree
 
       - name: Ensure qemu user emulators
-        shell: bash
+        if: matrix.container_preflight == 'qemu-user' || matrix.container_preflight == 'full'
         run: |
           set -euo pipefail
           for emulator in \
@@ -285,7 +154,7 @@ jobs:
           done
 
       - name: Ensure musl cross toolchains
-        shell: bash
+        if: matrix.container_preflight == 'full'
         run: |
           set -euo pipefail
           for arch in aarch64 riscv64 x86_64 loongarch64; do
@@ -297,22 +166,21 @@ jobs:
           done
 
       - name: Restore Rust cache
-        if: inputs.cache_key != ''
+        if: matrix.cache_key != ''
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ inputs.cache_key }}
-          save-if: ${{ github.event_name == 'push' }}
+          shared-key: ${{ matrix.cache_key }}
+          save-if: ${{ inputs.save_cache }}
 
       - name: Download tg-xtask binary artifact
-        if: inputs.download_xtask_bin_artifact
+        if: matrix.download_xtask_bin_artifact
         uses: actions/download-artifact@v8
         with:
-          name: ${{ inputs.xtask_bin_artifact_name }}
+          name: ${{ matrix.xtask_bin_artifact_name }}
           path: ${{ runner.temp }}/xtask-bin
 
       - name: Restore tg-xtask binary artifact
-        if: inputs.download_xtask_bin_artifact
-        shell: bash
+        if: matrix.download_xtask_bin_artifact
         run: |
           set -euo pipefail
           artifact_path="${RUNNER_TEMP}/xtask-bin/tg-xtask-bin.tar"
@@ -334,12 +202,14 @@ jobs:
         run: rustc --version
 
       - name: Run command
-        shell: bash
         env:
-          STARRY_APK_REGION: ${{ inputs.apk_region }}
+          STARRY_APK_REGION: ${{ matrix.apk_region }}
+          SINCE_REF: ${{ inputs.since_ref }}
+          TGOS_IMAGE_LOCAL_STORAGE: >-
+            ${{ contains(toJSON(matrix.runs_on), 'self-hosted') && format('/tmp/tgoskits-images-{0}-{1}', github.repository_id, runner.name) || '' }}
           CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
-          REUSABLE_COMMAND: ${{ inputs.command }}
-          USE_XTASK_BIN: ${{ inputs.download_xtask_bin_artifact }}
+          REUSABLE_COMMAND: ${{ matrix.command }}
+          USE_XTASK_BIN: ${{ matrix.download_xtask_bin_artifact }}
         run: |
           set -eo pipefail
 
@@ -362,8 +232,7 @@ jobs:
           fi
 
       - name: Package tg-xtask binary artifact
-        if: success() && inputs.upload_xtask_bin_artifact
-        shell: bash
+        if: success() && matrix.upload_xtask_bin_artifact
         run: |
           set -euo pipefail
           if [ ! -x target/debug/tg-xtask ]; then
@@ -373,10 +242,10 @@ jobs:
           tar -cf "${RUNNER_TEMP}/tg-xtask-bin.tar" target/debug/tg-xtask
 
       - name: Upload tg-xtask binary artifact
-        if: success() && inputs.upload_xtask_bin_artifact
+        if: success() && matrix.upload_xtask_bin_artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ inputs.xtask_bin_artifact_name }}
+          name: ${{ matrix.xtask_bin_artifact_name }}
           path: ${{ runner.temp }}/tg-xtask-bin.tar
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/starry-apps.yml
+++ b/.github/workflows/starry-apps.yml
@@ -28,123 +28,39 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  scheduled_clippy_all:
-    name: Scheduled clippy all
-    if: github.event_name == 'schedule' || inputs.run_clippy_all
+  plan:
+    name: Plan Starry Apps
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/rcore-os/tgoskits-container:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      matrix: ${{ steps.matrix.outputs.starry_apps_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: starry-apps-clippy-all
-          save-if: ${{ github.event_name == 'schedule' }}
-
-      - name: Show Rust version
-        run: rustc --version
-
-      - name: Run clippy all
-        shell: bash
-        run: |
-          set -euxo pipefail
-          cargo xtask clippy --all
-
-  starry_apps:
-    name: ${{ matrix.name }}
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/rcore-os/tgoskits-container:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Starry app smoke x86_64
-            cache_key: starry-apps-x86_64
-            arch: x86_64
-          - name: Starry app smoke aarch64
-            cache_key: starry-apps-aarch64
-            arch: aarch64
-          - name: Starry app smoke riscv64
-            cache_key: starry-apps-riscv64
-            arch: riscv64
-          - name: Starry app smoke loongarch64
-            cache_key: starry-apps-loongarch64
-            arch: loongarch64
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Show checkout state
-        shell: bash
-        run: |
-          set -eux
-          command -v git
-          git -c safe.directory="${GITHUB_WORKSPACE}" rev-parse --show-toplevel
-          git -c safe.directory="${GITHUB_WORKSPACE}" rev-parse --is-inside-work-tree
-
-      - name: Ensure qemu user emulators
-        shell: bash
-        run: |
-          set -eux
-          for emulator in \
-            qemu-aarch64-static \
-            qemu-riscv64-static \
-            qemu-loongarch64-static \
-            qemu-x86_64-static
-          do
-            if ! command -v "${emulator}" >/dev/null 2>&1; then
-              echo "::error::${emulator} not found; rebuild the CI container image to include qemu-user-static"
-              exit 1
-            fi
-          done
-
-      - name: Restore Rust cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ${{ matrix.cache_key }}
-          save-if: ${{ github.event_name == 'schedule' }}
-
-      - name: Show Rust version
-        run: rustc --version
-
-      - name: Run Starry app smoke
+      - name: Plan check matrix
+        id: matrix
         env:
-          STARRY_APK_REGION: us
-        shell: bash
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_CLIPPY_ALL: ${{ inputs.run_clippy_all || false }}
         run: |
-          set -euxo pipefail
-          cargo xtask starry app qemu --all --arch "${{ matrix.arch }}"
+          set -euo pipefail
+          args=(
+            --mode starry-apps
+            --repository "$GITHUB_REPOSITORY"
+            --repository-owner "$GITHUB_REPOSITORY_OWNER"
+            --event-name "$EVENT_NAME"
+            --output-file "$GITHUB_OUTPUT"
+          )
+          if [ "$RUN_CLIPPY_ALL" = "true" ]; then
+            args+=(--boolean-input run_clippy_all)
+          fi
+          python3 scripts/test/ci_plan.py "${args[@]}"
 
-  starry_nixos:
-    name: StarryNixOS x86_64 QEMU
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Build and run StarryNixOS
-        shell: bash
-        run: |
-          set -euxo pipefail
-          docker run --rm \
-            --env NIX_CONFIG=$'experimental-features = nix-command flakes\nsandbox = false' \
-            --volume "$PWD:/workspace" \
-            --workdir /workspace \
-            docker.io/nixos/nix:2.33.1 \
-            sh -lc '
-              git config --global --add safe.directory /workspace
-              nix develop --accept-flake-config -c \
-                cargo xtask starry app qemu -t nixos --arch x86_64 --cap nix
-            '
+  checks:
+    name: Starry Apps checks
+    needs: plan
+    uses: ./.github/workflows/reusable-check-matrix.yml
+    with:
+      matrix_json: ${{ needs.plan.outputs.matrix }}
+      fail_fast: false
+      save_cache: ${{ github.event_name == 'schedule' }}

--- a/.github/workflows/starry-apps.yml
+++ b/.github/workflows/starry-apps.yml
@@ -1,10 +1,6 @@
 name: Starry Apps
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/starry-apps.yml"
-      - "apps/starry/nixos/**"
   schedule:
     # GitHub cron uses UTC. This runs at 02:00 Beijing time (UTC+8).
     - cron: "0 18 * * *"

--- a/.github/workflows/starry-apps.yml
+++ b/.github/workflows/starry-apps.yml
@@ -57,7 +57,7 @@ jobs:
           python3 scripts/test/ci_plan.py "${args[@]}"
 
   checks:
-    name: Starry Apps checks
+    name: Starry Apps
     needs: plan
     uses: ./.github/workflows/reusable-check-matrix.yml
     with:

--- a/scripts/test/check_ci_paths.py
+++ b/scripts/test/check_ci_paths.py
@@ -34,10 +34,10 @@ def workspace_source_roots() -> set[str]:
 
 def ci_check_paths() -> set[str]:
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
-    ci_checks = workflow.split("            ci_checks:\n", maxsplit=1)[1].split(
-        "            base_container_publish:\n", maxsplit=1
+    pull_request = workflow.split("  pull_request:\n", maxsplit=1)[1].split(
+        "  workflow_dispatch:\n", maxsplit=1
     )[0]
-    return set(re.findall(r'^\s+- "([^"]+)"$', ci_checks, flags=re.MULTILINE))
+    return set(re.findall(r'^\s{6}- "([^"]+)"$', pull_request, flags=re.MULTILINE))
 
 
 if __name__ == "__main__":

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -7,27 +7,60 @@ from pathlib import Path
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
 BRANCH_PUSH_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci-branch-push.yml"
+CONTAINER_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/container-publish.yml"
+STATIC_CHECKS = WORKSPACE_ROOT / ".github/ci/checks/static.toml"
+WORKSPACE_CHECKS = WORKSPACE_ROOT / ".github/ci/checks/workspace.toml"
 MAIN_BRANCHES = {"main", "dev"}
+CI_CHECK_PATHS = {
+    ".cargo/**",
+    ".github/actions/publish-container/action.yml",
+    ".github/ci/**",
+    ".github/workflows/ci-branch-push.yml",
+    ".github/workflows/container-publish.yml",
+    ".github/workflows/ci.yml",
+    ".github/workflows/reusable-check-matrix.yml",
+    ".github/workflows/starry-apps.yml",
+    "Cargo.toml",
+    "Cargo.lock",
+    "rust-toolchain.toml",
+    "apps/**",
+    "bootloader/**",
+    "components/**",
+    "drivers/**",
+    "fs/**",
+    "memory/**",
+    "net/**",
+    "os/**",
+    "platforms/**",
+    "scripts/**",
+    "test-suit/**",
+    "tools/**",
+    "virtualization/**",
+    "xtask/**",
+}
 
 
 def main() -> int:
     errors: list[str] = []
 
-    if not BRANCH_PUSH_WORKFLOW.is_file():
-        errors.append(
-            "feature branch pushes must be handled by .github/workflows/ci-branch-push.yml"
-        )
+    required_files = (CI_WORKFLOW, BRANCH_PUSH_WORKFLOW, CONTAINER_WORKFLOW)
+    for required_file in required_files:
+        if not required_file.is_file():
+            errors.append(f"missing workflow: {required_file.relative_to(WORKSPACE_ROOT)}")
+    if errors:
         return report(errors)
 
     ci_workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     branch_push_workflow = BRANCH_PUSH_WORKFLOW.read_text(encoding="utf-8")
+    container_workflow = CONTAINER_WORKFLOW.read_text(encoding="utf-8")
+    static_checks = STATIC_CHECKS.read_text(encoding="utf-8")
+    workspace_checks = WORKSPACE_CHECKS.read_text(encoding="utf-8")
 
     ci_triggers = mapping_block(ci_workflow, "on", 0)
     ci_push = mapping_block(ci_triggers, "push", 2)
     ci_pull_request = mapping_block(ci_triggers, "pull_request", 2)
     ci_dispatch = mapping_block(ci_triggers, "workflow_dispatch", 2)
     ci_dispatch_inputs = mapping_block(ci_dispatch, "inputs", 4)
-    run_target = mapping_block(ci_dispatch_inputs, "run_target", 6)
     since_sha = mapping_block(ci_dispatch_inputs, "since_sha", 6)
 
     router_push = mapping_block(
@@ -53,58 +86,97 @@ def main() -> int:
         list_items(ci_push, "paths-ignore", 4),
         list_items(router_push, "paths-ignore", 4),
     )
-    if not ci_pull_request:
-        errors.append("main CI must retain the pull_request trigger")
-
     require_equal(
         errors,
-        "run_target options",
-        list_items(run_target, "options", 8),
-        {"container", "ci"},
+        "main CI pull_request paths",
+        list_items(ci_pull_request, "paths", 4),
+        CI_CHECK_PATHS,
     )
-    if scalar_value(run_target, "default", 8) != "container":
-        errors.append("run_target must default to container publishing")
     if scalar_value(since_sha, "type", 8) != "string":
         errors.append("since_sha must be a workflow_dispatch string input")
+    for removed_input in ("run_target", "container_target"):
+        if mapping_block(ci_dispatch_inputs, removed_input, 6):
+            errors.append(f"main CI must not retain the {removed_input} input")
 
     require_contains(
         errors,
         ci_workflow,
-        "since_ref: ${{ steps.outputs.outputs.since_ref }}",
-        "detect_changes must publish the resolved since_ref",
+        "since_ref: ${{ steps.since.outputs.since_ref }}",
+        "plan_ci must publish the resolved since_ref",
     )
     require_contains(
         errors,
         ci_workflow,
-        'cargo xtask sync-lint --since "${{ needs.detect_changes.outputs.since_ref }}"',
-        "sync-lint must consume the resolved since_ref",
+        "github.event.pull_request.head.repo.owner.login || ''",
+        "PR planning must select checks using the source repository owner",
     )
     require_contains(
         errors,
         ci_workflow,
-        'cargo xtask clippy --since "${{ needs.detect_changes.outputs.since_ref }}"',
-        "clippy must consume the resolved since_ref",
+        'source_repository_owner="$PR_HEAD_REPOSITORY_OWNER"',
+        "PR planning must not fall back to the base owner when head metadata is absent",
     )
     require_contains(
         errors,
         ci_workflow,
+        '--repository-owner "$source_repository_owner"',
+        "the planner must receive the resolved source repository owner",
+    )
+    require_contains(
+        errors,
+        static_checks,
+        'cargo xtask sync-lint --since "$SINCE_REF"',
+        "sync-lint must consume SINCE_REF from the reusable runner",
+    )
+    require_contains(
+        errors,
+        workspace_checks,
+        'cargo xtask clippy --since "$SINCE_REF"',
+        "clippy must consume SINCE_REF from the reusable runner",
+    )
+    for event_branch in (
         'if [ "$EVENT_NAME" = "pull_request" ]; then',
-        "since_ref resolution must handle pull_request events",
-    )
-    require_contains(
+        'elif [ "$EVENT_NAME" = "push" ]',
+        'elif [ "$EVENT_NAME" = "workflow_dispatch" ]',
+    ):
+        require_contains(
+            errors,
+            ci_workflow,
+            event_branch,
+            f"since_ref resolution is missing {event_branch}",
+        )
+    if "publish_base_container" in ci_workflow or "container_target" in ci_workflow:
+        errors.append("container publishing must not remain in the main CI workflow")
+
+    container_triggers = mapping_block(container_workflow, "on", 0)
+    container_push = mapping_block(container_triggers, "push", 2)
+    container_dispatch = mapping_block(container_triggers, "workflow_dispatch", 2)
+    container_inputs = mapping_block(container_dispatch, "inputs", 4)
+    target = mapping_block(container_inputs, "target", 6)
+    require_equal(
         errors,
-        ci_workflow,
-        '[ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$RUN_TARGET" = "ci" ]',
-        "since_ref resolution must handle routed workflow_dispatch events",
+        "container publish branches",
+        list_items(container_push, "branches", 4),
+        MAIN_BRANCHES,
     )
-    require_contains(
+    require_equal(
         errors,
-        ci_workflow,
-        'printf \'%s\\n\' "$SINCE_SHA"',
-        "routed CI must use the push base SHA supplied by the router",
+        "container publish paths",
+        list_items(container_push, "paths", 4),
+        {
+            "container/Dockerfile",
+            "container/Dockerfile.axvisor-lvz",
+            "rust-toolchain.toml",
+        },
     )
-    if "skip_duplicate_push_ci" in ci_workflow:
-        errors.append("duplicate-push detection must not remain in the main CI workflow")
+    require_equal(
+        errors,
+        "container target options",
+        list_items(target, "options", 8),
+        {"base", "axvisor-lvz", "both"},
+    )
+    if scalar_value(target, "default", 8) != "both":
+        errors.append("container target must default to both")
 
     expected_permissions = {
         "actions": "write",
@@ -121,48 +193,23 @@ def main() -> int:
             f"expected {expected_permissions}, got {actual_permissions}"
         )
 
-    require_contains(
-        errors,
-        branch_push_workflow,
-        "gh pr list",
-        "router must detect an existing open pull request",
-    )
-    require_contains(
-        errors,
-        branch_push_workflow,
-        "--state open",
-        "router pull request lookup must ignore closed pull requests",
-    )
-    require_contains(
-        errors,
-        branch_push_workflow,
-        "headRepositoryOwner.login == env.REPOSITORY_OWNER",
-        "router must match the pull request head repository owner",
-    )
-    require_contains(
-        errors,
-        branch_push_workflow,
-        "headRefName == env.REF_NAME",
-        "router must match the pull request head branch",
-    )
-    require_contains(
-        errors,
-        branch_push_workflow,
-        "gh workflow run ci.yml",
-        "router must dispatch the main CI when no pull request exists",
-    )
-    require_contains(
-        errors,
-        branch_push_workflow,
-        "-f run_target=ci",
-        "router dispatch must select CI checks",
-    )
-    require_contains(
-        errors,
-        branch_push_workflow,
-        '-f since_sha="$BEFORE_SHA"',
-        "router dispatch must preserve the push base SHA",
-    )
+    for needle, message in (
+        ("gh pr list", "router must detect an existing open pull request"),
+        ("--state open", "router lookup must ignore closed pull requests"),
+        (
+            "headRepositoryOwner.login == env.REPOSITORY_OWNER",
+            "router must match the pull request head repository owner",
+        ),
+        (
+            "headRefName == env.REF_NAME",
+            "router must match the pull request head branch",
+        ),
+        ("gh workflow run ci.yml", "router must dispatch main CI"),
+        ('-f since_sha="$BEFORE_SHA"', "router must preserve the push base SHA"),
+    ):
+        require_contains(errors, branch_push_workflow, needle, message)
+    if "run_target" in branch_push_workflow or "container_target" in branch_push_workflow:
+        errors.append("branch router must not pass removed CI dispatch inputs")
 
     skip_index = branch_push_workflow.find("exit 0")
     dispatch_index = branch_push_workflow.find("gh workflow run ci.yml")

--- a/scripts/test/check_workflow_layout.py
+++ b/scripts/test/check_workflow_layout.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from pathlib import Path
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = WORKSPACE_ROOT / ".github" / "workflows"
+CHECKS = WORKSPACE_ROOT / ".github" / "ci" / "checks"
+PUBLISH_ACTION = (
+    WORKSPACE_ROOT / ".github" / "actions" / "publish-container" / "action.yml"
+)
+
+
+def main() -> int:
+    errors: list[str] = []
+    affected_workflows = (
+        "ci-branch-push.yml",
+        "ci.yml",
+        "container-publish.yml",
+        "release-plz.yml",
+        "reusable-check-matrix.yml",
+        "starry-apps.yml",
+    )
+    texts: dict[str, str] = {}
+    for name in affected_workflows:
+        path = WORKFLOWS / name
+        if not path.is_file():
+            errors.append(f"missing workflow: .github/workflows/{name}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        texts[name] = text
+        if re.search(r"^    if:", text, flags=re.MULTILINE):
+            errors.append(f"{name} contains a job-level applicability condition")
+
+    reusable = texts.get("reusable-check-matrix.yml", "")
+    if count_jobs(reusable) != 1:
+        errors.append("reusable-check-matrix.yml must define exactly one job")
+    for legacy_name in ("run_host:", "run_container:", "reusable-command.yml"):
+        if legacy_name in reusable:
+            errors.append(f"reusable matrix retains legacy branch: {legacy_name}")
+
+    ci = texts.get("ci.yml", "")
+    for required_call in (
+        "name: Static checks",
+        "name: Test checks",
+        "uses: ./.github/workflows/reusable-check-matrix.yml",
+    ):
+        if required_call not in ci:
+            errors.append(f"main CI is missing: {required_call}")
+    if "dorny/paths-filter" in ci:
+        errors.append("main CI must not create a detect-and-skip path-filter job")
+
+    starry_apps = texts.get("starry-apps.yml", "")
+    if "scheduled_clippy_all:" in starry_apps:
+        errors.append("Starry Apps must select clippy through its planned matrix")
+
+    container = texts.get("container-publish.yml", "")
+    if count_jobs(container) != 1:
+        errors.append("container-publish.yml must expose one publish job")
+    if "uses: ./.github/actions/publish-container" not in container:
+        errors.append("container publishing must use the shared composite action")
+    if not PUBLISH_ACTION.is_file():
+        errors.append("missing publish-container composite action")
+    else:
+        action = PUBLISH_ACTION.read_text(encoding="utf-8")
+        for required_fragment in (
+            "using: composite",
+            "uses: docker/metadata-action@v6",
+            "uses: docker/build-push-action@v7",
+            "cache-from: type=gha,scope=${{ inputs.cache_scope }}",
+            "cache-to: type=gha,mode=max,scope=${{ inputs.cache_scope }}",
+        ):
+            if required_fragment not in action:
+                errors.append(
+                    f"publish-container action is missing: {required_fragment}"
+                )
+
+    for manifest in CHECKS.glob("*.toml"):
+        if "${{" in manifest.read_text(encoding="utf-8"):
+            errors.append(f"{manifest.name} embeds a GitHub expression")
+
+    legacy_workflow = WORKFLOWS / "reusable-command.yml"
+    if legacy_workflow.exists():
+        errors.append("legacy reusable-command.yml must be removed")
+
+    return report(errors)
+
+
+def count_jobs(workflow: str) -> int:
+    in_jobs = False
+    count = 0
+    for line in workflow.splitlines():
+        if line == "jobs:":
+            in_jobs = True
+            continue
+        if in_jobs and line and not line.startswith(" "):
+            break
+        if in_jobs and re.fullmatch(r"  [A-Za-z_][A-Za-z0-9_-]*:", line):
+            count += 1
+    return count
+
+
+def report(errors: list[str]) -> int:
+    if not errors:
+        print("Workflow layout checks passed")
+        return 0
+    print("Workflow layout checks failed:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test/check_workflow_layout.py
+++ b/scripts/test/check_workflow_layout.py
@@ -57,6 +57,11 @@ def main() -> int:
         errors.append("Starry Apps must select clippy through its planned matrix")
     if "  checks:\n    name: Starry Apps\n" not in starry_apps:
         errors.append("Starry Apps reusable call must use the concise display name")
+    if re.search(r"^  pull_request:", starry_apps, flags=re.MULTILINE):
+        errors.append("Starry Apps must not run on pull requests")
+    for required_event in ("schedule", "workflow_dispatch"):
+        if not re.search(rf"^  {required_event}:", starry_apps, flags=re.MULTILINE):
+            errors.append(f"Starry Apps must run on {required_event}")
 
     container = texts.get("container-publish.yml", "")
     if count_jobs(container) != 1:

--- a/scripts/test/check_workflow_layout.py
+++ b/scripts/test/check_workflow_layout.py
@@ -43,8 +43,8 @@ def main() -> int:
 
     ci = texts.get("ci.yml", "")
     for required_call in (
-        "name: Static checks",
-        "name: Test checks",
+        "name: Static",
+        "name: Tests",
         "uses: ./.github/workflows/reusable-check-matrix.yml",
     ):
         if required_call not in ci:
@@ -55,6 +55,8 @@ def main() -> int:
     starry_apps = texts.get("starry-apps.yml", "")
     if "scheduled_clippy_all:" in starry_apps:
         errors.append("Starry Apps must select clippy through its planned matrix")
+    if "  checks:\n    name: Starry Apps\n" not in starry_apps:
+        errors.append("Starry Apps reusable call must use the concise display name")
 
     container = texts.get("container-publish.yml", "")
     if count_jobs(container) != 1:

--- a/scripts/test/ci_plan.py
+++ b/scripts/test/ci_plan.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import re
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+CHECKS_ROOT = WORKSPACE_ROOT / ".github" / "ci" / "checks"
+MAIN_MANIFESTS = (
+    CHECKS_ROOT / "static.toml",
+    CHECKS_ROOT / "workspace.toml",
+    CHECKS_ROOT / "arceos.toml",
+    CHECKS_ROOT / "axvisor.toml",
+    CHECKS_ROOT / "starry.toml",
+)
+STARRY_APPS_MANIFEST = CHECKS_ROOT / "starry-apps.toml"
+
+SUPPORTED_PHASES = {"static", "test", "starry_apps"}
+SUPPORTED_ENVIRONMENTS = {"host", "base", "axvisor-lvz"}
+SUPPORTED_PREFLIGHTS = {"none", "qemu-user", "full"}
+CHECK_ID_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+TOP_LEVEL_FIELDS = {"schema_version", "phase", "group", "check"}
+CHECK_FIELDS = {
+    "id",
+    "name",
+    "runs_on",
+    "environment",
+    "command",
+    "self_hosted_owner",
+    "fallback_environment",
+    "required_owner",
+    "required_base_branch",
+    "fetch_depth",
+    "timeout_minutes",
+    "require_kvm",
+    "cache_key",
+    "apk_region",
+    "upload_xtask_bin_artifact",
+    "download_xtask_bin_artifact",
+    "xtask_bin_artifact_name",
+    "container_preflight",
+    "events",
+    "enable_boolean_input",
+}
+REQUIRED_CHECK_FIELDS = {"id", "name", "runs_on", "environment", "command"}
+BOOLEAN_CHECK_FIELDS = {
+    "require_kvm",
+    "upload_xtask_bin_artifact",
+    "download_xtask_bin_artifact",
+}
+
+
+class PlanError(ValueError):
+    """Raised when a CI check manifest violates the planner contract."""
+
+
+@dataclass(frozen=True)
+class PlanContext:
+    repository: str
+    repository_owner: str
+    event_name: str
+    base_ref: str = ""
+    enabled_boolean_inputs: frozenset[str] = frozenset()
+
+
+def load_catalog(manifests: Iterable[Path]) -> list[dict[str, Any]]:
+    checks: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    for manifest in manifests:
+        document = _load_manifest(manifest)
+        phase = document["phase"]
+        group = document["group"]
+        for index, raw_check in enumerate(document["check"], start=1):
+            location = f"{manifest}:{index}"
+            check = _validate_check(raw_check, location)
+            check_id = check["id"]
+            if check_id in seen_ids:
+                raise PlanError(f"duplicate check id '{check_id}' at {location}")
+            seen_ids.add(check_id)
+            check["phase"] = phase
+            check["group"] = group
+            check["source"] = str(manifest.relative_to(WORKSPACE_ROOT))
+            checks.append(check)
+
+    _validate_artifact_contract(checks)
+    return checks
+
+
+def build_main_plan(context: PlanContext) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    checks = load_catalog(MAIN_MANIFESTS)
+    static_rows = _plan_phase(checks, "static", context)
+    test_rows = _plan_phase(checks, "test", context)
+    if not static_rows or not test_rows:
+        raise PlanError("main CI must resolve to non-empty static and test matrices")
+    return {
+        "static_matrix": {"include": static_rows},
+        "test_matrix": {"include": test_rows},
+    }
+
+
+def build_starry_apps_plan(
+    context: PlanContext,
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    checks = load_catalog((STARRY_APPS_MANIFEST,))
+    rows = _plan_phase(checks, "starry_apps", context)
+    if not rows:
+        raise PlanError("Starry Apps must resolve to a non-empty matrix")
+    return {"starry_apps_matrix": {"include": rows}}
+
+
+def write_github_outputs(outputs: dict[str, Any], output_file: Path) -> None:
+    with output_file.open("a", encoding="utf-8") as output:
+        for name, value in outputs.items():
+            encoded = json.dumps(value, separators=(",", ":"))
+            output.write(f"{name}={encoded}\n")
+
+
+def _load_manifest(manifest: Path) -> dict[str, Any]:
+    if not manifest.is_file():
+        raise PlanError(f"missing CI check manifest: {manifest}")
+    with manifest.open("rb") as source:
+        document = tomllib.load(source)
+
+    unknown_fields = set(document) - TOP_LEVEL_FIELDS
+    if unknown_fields:
+        raise PlanError(
+            f"{manifest} has unknown top-level fields: {sorted(unknown_fields)}"
+        )
+    if document.get("schema_version") != 1:
+        raise PlanError(f"{manifest} must declare schema_version = 1")
+    if document.get("phase") not in SUPPORTED_PHASES:
+        raise PlanError(f"{manifest} has an unsupported phase")
+    if not isinstance(document.get("group"), str) or not document["group"].strip():
+        raise PlanError(f"{manifest} must declare a non-empty group")
+    if not isinstance(document.get("check"), list) or not document["check"]:
+        raise PlanError(f"{manifest} must contain at least one [[check]] entry")
+    return document
+
+
+def _validate_check(raw_check: Any, location: str) -> dict[str, Any]:
+    if not isinstance(raw_check, dict):
+        raise PlanError(f"{location} check entry must be a table")
+    unknown_fields = set(raw_check) - CHECK_FIELDS
+    if unknown_fields:
+        raise PlanError(f"{location} has unknown fields: {sorted(unknown_fields)}")
+    missing_fields = REQUIRED_CHECK_FIELDS - set(raw_check)
+    if missing_fields:
+        raise PlanError(f"{location} is missing fields: {sorted(missing_fields)}")
+
+    check = dict(raw_check)
+    for field in ("id", "name", "environment", "command"):
+        if not isinstance(check[field], str) or not check[field].strip():
+            raise PlanError(f"{location} field '{field}' must be a non-empty string")
+    if CHECK_ID_PATTERN.fullmatch(check["id"]) is None:
+        raise PlanError(f"{location} field 'id' must use lowercase kebab-case")
+    if check["environment"] not in SUPPORTED_ENVIRONMENTS:
+        raise PlanError(f"{location} has an unsupported environment")
+
+    runs_on = check["runs_on"]
+    if (
+        not isinstance(runs_on, list)
+        or not runs_on
+        or any(not isinstance(label, str) or not label for label in runs_on)
+    ):
+        raise PlanError(f"{location} runs_on must be a non-empty string array")
+
+    fallback_environment = check.get("fallback_environment")
+    if fallback_environment is not None:
+        if not check.get("self_hosted_owner"):
+            raise PlanError(
+                f"{location} fallback_environment requires self_hosted_owner"
+            )
+        if fallback_environment not in SUPPORTED_ENVIRONMENTS - {"host"}:
+            raise PlanError(f"{location} has an unsupported fallback_environment")
+
+    for field in ("self_hosted_owner", "required_owner", "required_base_branch"):
+        value = check.get(field)
+        if value is not None and (not isinstance(value, str) or not value):
+            raise PlanError(f"{location} field '{field}' must be a non-empty string")
+    if check.get("self_hosted_owner") and "self-hosted" not in runs_on:
+        raise PlanError(f"{location} self_hosted_owner requires a self-hosted runner")
+
+    for field in BOOLEAN_CHECK_FIELDS:
+        value = check.get(field)
+        if value is not None and not isinstance(value, bool):
+            raise PlanError(f"{location} field '{field}' must be boolean")
+
+    timeout = check.get("timeout_minutes", 360)
+    if not isinstance(timeout, int) or timeout <= 0:
+        raise PlanError(f"{location} timeout_minutes must be positive")
+
+    fetch_depth = str(check.get("fetch_depth", "1"))
+    if fetch_depth not in {"0", "1", "2", "full"}:
+        raise PlanError(f"{location} has an unsupported fetch_depth")
+
+    preflight = check.get("container_preflight")
+    if preflight is not None and preflight not in SUPPORTED_PREFLIGHTS:
+        raise PlanError(f"{location} has an unsupported container_preflight")
+
+    events = check.get("events")
+    if events is not None and (
+        not isinstance(events, list)
+        or not events
+        or any(not isinstance(event, str) or not event for event in events)
+    ):
+        raise PlanError(f"{location} events must be a non-empty string array")
+    boolean_input = check.get("enable_boolean_input")
+    if boolean_input is not None and (
+        not isinstance(boolean_input, str) or not boolean_input
+    ):
+        raise PlanError(
+            f"{location} enable_boolean_input must be a non-empty string"
+        )
+
+    cache_key = check.get("cache_key", "")
+    if not isinstance(cache_key, str):
+        raise PlanError(f"{location} cache_key must be a string")
+    if "self-hosted" in runs_on and cache_key:
+        raise PlanError(f"{location} self-hosted checks must use an empty cache_key")
+
+    artifact_name = check.get("xtask_bin_artifact_name")
+    if artifact_name is not None and (
+        not isinstance(artifact_name, str) or not artifact_name
+    ):
+        raise PlanError(
+            f"{location} xtask_bin_artifact_name must be a non-empty string"
+        )
+    if check.get("upload_xtask_bin_artifact") and check.get(
+        "download_xtask_bin_artifact"
+    ):
+        raise PlanError(f"{location} cannot both upload and download the artifact")
+
+    return check
+
+
+def _validate_artifact_contract(checks: list[dict[str, Any]]) -> None:
+    main_checks = [check for check in checks if check["phase"] in {"static", "test"}]
+    if not main_checks:
+        return
+
+    producers = [
+        check for check in main_checks if check.get("upload_xtask_bin_artifact", False)
+    ]
+    if len(producers) != 1 or producers[0]["phase"] != "static":
+        raise PlanError("main CI must define exactly one static xtask artifact producer")
+
+    producer_name = producers[0].get("xtask_bin_artifact_name", "tg-xtask-bin")
+    for check in main_checks:
+        if not check.get("download_xtask_bin_artifact", False):
+            continue
+        consumer_name = check.get("xtask_bin_artifact_name", "tg-xtask-bin")
+        if consumer_name != producer_name:
+            raise PlanError(
+                f"check '{check['id']}' consumes unknown artifact '{consumer_name}'"
+            )
+
+
+def _plan_phase(
+    checks: list[dict[str, Any]], phase: str, context: PlanContext
+) -> list[dict[str, Any]]:
+    return [
+        _normalize_check(check, context)
+        for check in checks
+        if check["phase"] == phase and _is_enabled(check, context)
+    ]
+
+
+def _is_enabled(check: dict[str, Any], context: PlanContext) -> bool:
+    required_owner = check.get("required_owner")
+    if required_owner and context.repository_owner != required_owner:
+        return False
+
+    required_base = check.get("required_base_branch")
+    if required_base and (
+        context.event_name != "pull_request" or context.base_ref != required_base
+    ):
+        return False
+
+    events = check.get("events", [])
+    boolean_input = check.get("enable_boolean_input")
+    if events or boolean_input:
+        event_matches = context.event_name in events
+        input_matches = boolean_input in context.enabled_boolean_inputs
+        if not event_matches and not input_matches:
+            return False
+
+    return True
+
+
+def _normalize_check(
+    check: dict[str, Any], context: PlanContext
+) -> dict[str, Any]:
+    runs_on = list(check["runs_on"])
+    environment = check["environment"]
+    fallback = bool(
+        check.get("self_hosted_owner")
+        and context.repository_owner != check["self_hosted_owner"]
+    )
+    if fallback:
+        runs_on = ["ubuntu-latest"]
+        environment = check["fallback_environment"]
+
+    fetch_depth = str(check.get("fetch_depth", "1"))
+    if fetch_depth == "full":
+        fetch_depth = "2" if "self-hosted" in runs_on and not fallback else "0"
+
+    container_image = _container_image(environment, context.repository)
+    preflight = check.get("container_preflight")
+    if preflight is None:
+        preflight = "full" if container_image else "none"
+
+    name = check["name"]
+    if check["phase"] == "test":
+        name = f"{check['group']} / {name}"
+
+    download_xtask = check.get("download_xtask_bin_artifact", False)
+    if fallback and check["phase"] == "test":
+        download_xtask = True
+
+    return {
+        "id": check["id"],
+        "name": name,
+        "group": check["group"],
+        "runs_on": runs_on,
+        "container_image": container_image,
+        "container_preflight": preflight,
+        "command": check["command"].strip(),
+        "cache_key": check.get("cache_key", ""),
+        "apk_region": check.get("apk_region", "china"),
+        "fetch_depth": fetch_depth,
+        "timeout_minutes": check.get("timeout_minutes", 360),
+        "require_kvm": check.get("require_kvm", False),
+        "upload_xtask_bin_artifact": check.get(
+            "upload_xtask_bin_artifact", False
+        ),
+        "download_xtask_bin_artifact": download_xtask,
+        "xtask_bin_artifact_name": check.get(
+            "xtask_bin_artifact_name", "tg-xtask-bin"
+        ),
+        "source": check["source"],
+    }
+
+
+def _container_image(environment: str, repository: str) -> str:
+    repository = repository.lower()
+    if environment == "host":
+        return ""
+    if environment == "base":
+        return f"ghcr.io/{repository}-container:latest"
+    if environment == "axvisor-lvz":
+        return f"ghcr.io/{repository}-container-axvisor-lvz:latest"
+    raise PlanError(f"unsupported environment: {environment}")
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Plan TGOSKits CI matrices")
+    parser.add_argument("--mode", choices=("main", "starry-apps"), required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--repository-owner", required=True)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--boolean-input", action="append", default=[])
+    parser.add_argument(
+        "--output-file",
+        type=Path,
+        default=(
+            Path(os.environ["GITHUB_OUTPUT"])
+            if "GITHUB_OUTPUT" in os.environ
+            else None
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    context = PlanContext(
+        repository=args.repository,
+        repository_owner=args.repository_owner,
+        event_name=args.event_name,
+        base_ref=args.base_ref,
+        enabled_boolean_inputs=frozenset(args.boolean_input),
+    )
+    try:
+        if args.mode == "main":
+            outputs = build_main_plan(context)
+        else:
+            outputs = build_starry_apps_plan(context)
+    except (OSError, PlanError, tomllib.TOMLDecodeError) as error:
+        print(f"CI planning failed: {error}", file=sys.stderr)
+        return 1
+
+    if args.output_file is not None:
+        write_github_outputs(outputs, args.output_file)
+    else:
+        print(json.dumps(outputs, indent=2))
+
+    for name, matrix in outputs.items():
+        print(f"{name}: {len(matrix['include'])} checks", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test/ci_plan.py
+++ b/scripts/test/ci_plan.py
@@ -26,6 +26,9 @@ SUPPORTED_PHASES = {"static", "test", "starry_apps"}
 SUPPORTED_ENVIRONMENTS = {"host", "base", "axvisor-lvz"}
 SUPPORTED_PREFLIGHTS = {"none", "qemu-user", "full"}
 CHECK_ID_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+REDUNDANT_NAME_PREFIX_PATTERN = re.compile(
+    r"^(?:check|run|scheduled|tests?)\b", re.IGNORECASE
+)
 TOP_LEVEL_FIELDS = {"schema_version", "phase", "group", "check"}
 CHECK_FIELDS = {
     "id",
@@ -80,7 +83,7 @@ def load_catalog(manifests: Iterable[Path]) -> list[dict[str, Any]]:
         group = document["group"]
         for index, raw_check in enumerate(document["check"], start=1):
             location = f"{manifest}:{index}"
-            check = _validate_check(raw_check, location)
+            check = _validate_check(raw_check, location, group)
             check_id = check["id"]
             if check_id in seen_ids:
                 raise PlanError(f"duplicate check id '{check_id}' at {location}")
@@ -145,7 +148,9 @@ def _load_manifest(manifest: Path) -> dict[str, Any]:
     return document
 
 
-def _validate_check(raw_check: Any, location: str) -> dict[str, Any]:
+def _validate_check(
+    raw_check: Any, location: str, group: str = ""
+) -> dict[str, Any]:
     if not isinstance(raw_check, dict):
         raise PlanError(f"{location} check entry must be a table")
     unknown_fields = set(raw_check) - CHECK_FIELDS
@@ -159,6 +164,8 @@ def _validate_check(raw_check: Any, location: str) -> dict[str, Any]:
     for field in ("id", "name", "environment", "command"):
         if not isinstance(check[field], str) or not check[field].strip():
             raise PlanError(f"{location} field '{field}' must be a non-empty string")
+    check["name"] = check["name"].strip()
+    _validate_display_name(check["name"], group, location)
     if CHECK_ID_PATTERN.fullmatch(check["id"]) is None:
         raise PlanError(f"{location} field 'id' must use lowercase kebab-case")
     if check["environment"] not in SUPPORTED_ENVIRONMENTS:
@@ -239,6 +246,22 @@ def _validate_check(raw_check: Any, location: str) -> dict[str, Any]:
         raise PlanError(f"{location} cannot both upload and download the artifact")
 
     return check
+
+
+def _validate_display_name(name: str, group: str, location: str) -> None:
+    if REDUNDANT_NAME_PREFIX_PATTERN.search(name):
+        raise PlanError(
+            f"{location} name must not start with Test/Run/Check/Scheduled"
+        )
+    if "self-hosted" in name.casefold():
+        raise PlanError(f"{location} name must not expose the self-hosted runner")
+    if group:
+        group_pattern = re.compile(
+            rf"(?<![A-Za-z0-9]){re.escape(group)}(?![A-Za-z0-9])",
+            re.IGNORECASE,
+        )
+        if group_pattern.search(name):
+            raise PlanError(f"{location} name must not repeat group '{group}'")
 
 
 def _validate_artifact_contract(checks: list[dict[str, Any]]) -> None:

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("ci_plan.py")
+SPEC = importlib.util.spec_from_file_location("ci_plan", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+ci_plan = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ci_plan)
+
+
+class CiPlanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.upstream = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            base_ref="dev",
+        )
+
+    def test_upstream_main_plan_preserves_all_checks(self) -> None:
+        plan = ci_plan.build_main_plan(self.upstream)
+
+        self.assertEqual(len(plan["static_matrix"]["include"]), 3)
+        self.assertEqual(len(plan["test_matrix"]["include"]), 31)
+        self.assertTrue(
+            all(" / " in row["name"] for row in plan["test_matrix"]["include"])
+        )
+
+    def test_fork_filters_owner_checks_and_falls_back_from_qcs(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="contributor",
+            event_name="pull_request",
+            base_ref="dev",
+        )
+        plan = ci_plan.build_main_plan(context)
+        static_rows = {row["id"]: row for row in plan["static_matrix"]["include"]}
+        test_rows = {row["id"]: row for row in plan["test_matrix"]["include"]}
+
+        self.assertEqual(len(test_rows), 15)
+        self.assertFalse(any("board" in row["id"] for row in test_rows.values()))
+        self.assertEqual(static_rows["check-formatting"]["runs_on"], ["ubuntu-latest"])
+        self.assertEqual(
+            static_rows["check-formatting"]["container_image"],
+            "ghcr.io/rcore-os/tgoskits-container:latest",
+        )
+        self.assertFalse(
+            static_rows["check-formatting"]["download_xtask_bin_artifact"]
+        )
+        clippy = test_rows["run-clippy"]
+        self.assertEqual(clippy["runs_on"], ["ubuntu-latest"])
+        self.assertEqual(clippy["fetch_depth"], "0")
+        self.assertTrue(clippy["download_xtask_bin_artifact"])
+
+    def test_upstream_full_history_uses_bounded_self_hosted_checkout(self) -> None:
+        plan = ci_plan.build_main_plan(self.upstream)
+        rows = {row["id"]: row for row in plan["test_matrix"]["include"]}
+
+        self.assertEqual(rows["run-clippy"]["fetch_depth"], "2")
+
+    def test_default_values_are_materialized(self) -> None:
+        plan = ci_plan.build_main_plan(self.upstream)
+        rows = {row["id"]: row for row in plan["test_matrix"]["include"]}
+        defaults = rows["test-with-std"]
+
+        self.assertEqual(defaults["cache_key"], "")
+        self.assertEqual(defaults["apk_region"], "china")
+        self.assertEqual(defaults["fetch_depth"], "1")
+        self.assertEqual(defaults["timeout_minutes"], 360)
+        self.assertFalse(defaults["require_kvm"])
+        self.assertFalse(defaults["upload_xtask_bin_artifact"])
+        self.assertFalse(defaults["download_xtask_bin_artifact"])
+
+    def test_base_event_and_boolean_input_selection(self) -> None:
+        base_check = {"required_base_branch": "dev"}
+        event_or_input_check = {
+            "events": ["schedule"],
+            "enable_boolean_input": "run_clippy_all",
+        }
+        pull_request_dev = self.upstream
+        pull_request_main = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            base_ref="main",
+        )
+        scheduled = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="schedule",
+        )
+        manual = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="workflow_dispatch",
+        )
+        manual_enabled = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="workflow_dispatch",
+            enabled_boolean_inputs=frozenset({"run_clippy_all"}),
+        )
+
+        self.assertTrue(ci_plan._is_enabled(base_check, pull_request_dev))
+        self.assertFalse(ci_plan._is_enabled(base_check, pull_request_main))
+        self.assertFalse(ci_plan._is_enabled(base_check, scheduled))
+        self.assertTrue(ci_plan._is_enabled(event_or_input_check, scheduled))
+        self.assertFalse(ci_plan._is_enabled(event_or_input_check, manual))
+        self.assertTrue(ci_plan._is_enabled(event_or_input_check, manual_enabled))
+
+    def test_incremental_commands_use_since_ref_environment(self) -> None:
+        plan = ci_plan.build_main_plan(self.upstream)
+        rows = plan["static_matrix"]["include"] + plan["test_matrix"]["include"]
+        commands = {row["id"]: row["command"] for row in rows}
+
+        self.assertIn('"$SINCE_REF"', commands["run-sync-lint"])
+        self.assertIn('"$SINCE_REF"', commands["run-clippy"])
+        self.assertNotIn("${{", commands["run-sync-lint"])
+        self.assertNotIn("${{", commands["run-clippy"])
+
+    def test_starry_apps_schedule_and_manual_selection(self) -> None:
+        manual = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="workflow_dispatch",
+        )
+        manual_with_clippy = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="workflow_dispatch",
+            enabled_boolean_inputs=frozenset({"run_clippy_all"}),
+        )
+        scheduled = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="schedule",
+        )
+
+        self.assertEqual(
+            len(ci_plan.build_starry_apps_plan(manual)["starry_apps_matrix"]["include"]),
+            5,
+        )
+        self.assertEqual(
+            len(
+                ci_plan.build_starry_apps_plan(manual_with_clippy)[
+                    "starry_apps_matrix"
+                ]["include"]
+            ),
+            6,
+        )
+        self.assertEqual(
+            len(
+                ci_plan.build_starry_apps_plan(scheduled)["starry_apps_matrix"][
+                    "include"
+                ]
+            ),
+            6,
+        )
+
+    def test_starry_apps_pull_request_selects_only_nixos(self) -> None:
+        pull_request = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            base_ref="dev",
+        )
+
+        rows = ci_plan.build_starry_apps_plan(pull_request)["starry_apps_matrix"][
+            "include"
+        ]
+
+        self.assertEqual([row["id"] for row in rows], ["starry-nixos-x86-64-qemu"])
+        nixos = rows[0]
+        self.assertEqual(nixos["container_image"], "")
+        self.assertEqual(nixos["timeout_minutes"], 45)
+        self.assertIn("starry app qemu -t nixos", nixos["command"])
+        self.assertNotIn("starry test", nixos["command"])
+
+    def test_catalog_has_one_artifact_producer_and_empty_self_hosted_caches(self) -> None:
+        checks = ci_plan.load_catalog(ci_plan.MAIN_MANIFESTS)
+        producers = [
+            check for check in checks if check.get("upload_xtask_bin_artifact", False)
+        ]
+        consumers = [
+            check
+            for check in checks
+            if check.get("download_xtask_bin_artifact", False)
+        ]
+
+        self.assertEqual([check["id"] for check in producers], ["run-sync-lint"])
+        self.assertTrue(consumers)
+        self.assertEqual(
+            {check.get("xtask_bin_artifact_name", "tg-xtask-bin") for check in consumers},
+            {"tg-xtask-bin"},
+        )
+        for check in checks:
+            if "self-hosted" in check["runs_on"]:
+                self.assertEqual(check.get("cache_key", ""), "", check["id"])
+
+    def test_duplicate_ids_are_rejected(self) -> None:
+        manifest = ci_plan.MAIN_MANIFESTS[0]
+
+        with self.assertRaisesRegex(ci_plan.PlanError, "duplicate check id"):
+            ci_plan.load_catalog((manifest, manifest))
+
+    def test_invalid_environment_empty_command_and_id_are_rejected(self) -> None:
+        valid = {
+            "id": "valid-check",
+            "name": "Valid check",
+            "runs_on": ["ubuntu-latest"],
+            "environment": "base",
+            "command": "true",
+        }
+        invalid_cases = (
+            ({**valid, "environment": "unknown"}, "unsupported environment"),
+            ({**valid, "command": ""}, "non-empty string"),
+            ({**valid, "id": "INVALID_ID"}, "lowercase kebab-case"),
+        )
+
+        for check, error in invalid_cases:
+            with self.subTest(error=error):
+                with self.assertRaisesRegex(ci_plan.PlanError, error):
+                    ci_plan._validate_check(check, "test")
+
+    def test_empty_main_matrix_is_rejected(self) -> None:
+        with mock.patch.object(
+            ci_plan, "MAIN_MANIFESTS", (ci_plan.STARRY_APPS_MANIFEST,)
+        ):
+            with self.assertRaisesRegex(ci_plan.PlanError, "non-empty"):
+                ci_plan.build_main_plan(self.upstream)
+
+    def test_artifact_producer_and_consumer_contract_is_enforced(self) -> None:
+        producer = {
+            "id": "producer",
+            "phase": "static",
+            "upload_xtask_bin_artifact": True,
+        }
+        consumer = {
+            "id": "consumer",
+            "phase": "test",
+            "download_xtask_bin_artifact": True,
+            "xtask_bin_artifact_name": "unknown-artifact",
+        }
+
+        with self.assertRaisesRegex(ci_plan.PlanError, "exactly one"):
+            ci_plan._validate_artifact_contract([producer, producer])
+        with self.assertRaisesRegex(ci_plan.PlanError, "unknown artifact"):
+            ci_plan._validate_artifact_contract([producer, consumer])
+
+    def test_invalid_self_hosted_cache_is_rejected(self) -> None:
+        check = {
+            "id": "invalid-cache",
+            "name": "Invalid cache",
+            "runs_on": ["self-hosted", "linux"],
+            "environment": "host",
+            "cache_key": "must-not-be-set",
+            "command": "true",
+        }
+
+        with self.assertRaisesRegex(ci_plan.PlanError, "empty cache_key"):
+            ci_plan._validate_check(check, "test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -31,6 +31,34 @@ class CiPlanTests(unittest.TestCase):
             all(" / " in row["name"] for row in plan["test_matrix"]["include"])
         )
 
+    def test_display_names_expose_target_and_purpose(self) -> None:
+        plan = ci_plan.build_main_plan(self.upstream)
+        static_rows = {
+            row["id"]: row["name"] for row in plan["static_matrix"]["include"]
+        }
+        test_rows = {
+            row["id"]: row["name"] for row in plan["test_matrix"]["include"]
+        }
+
+        self.assertEqual(
+            static_rows["check-formatting"], "Formatting + publish dry-run"
+        )
+        self.assertEqual(
+            test_rows["run-clippy"], "Workspace / Incremental Clippy"
+        )
+        self.assertEqual(
+            test_rows["test-arceos-aarch64-qemu-app-suites"],
+            "ArceOS / aarch64 QEMU · GICv2 SMP4 boot + suites",
+        )
+        self.assertEqual(
+            test_rows["test-axvisor-aarch64-qemu-panic-modes"],
+            "AxVisor / aarch64 QEMU · Panic modes",
+        )
+        self.assertEqual(
+            test_rows["test-starry-self-hosted-board-visionfive2"],
+            "Starry / VisionFive 2 board · Suites",
+        )
+
     def test_fork_filters_owner_checks_and_falls_back_from_qcs(self) -> None:
         context = ci_plan.PlanContext(
             repository="rcore-os/tgoskits",
@@ -226,6 +254,48 @@ class CiPlanTests(unittest.TestCase):
             with self.subTest(error=error):
                 with self.assertRaisesRegex(ci_plan.PlanError, error):
                     ci_plan._validate_check(check, "test")
+
+    def test_redundant_display_names_are_rejected(self) -> None:
+        valid = {
+            "id": "invalid-name",
+            "name": "aarch64 QEMU · Suites",
+            "runs_on": ["ubuntu-latest"],
+            "environment": "base",
+            "command": "true",
+        }
+        invalid_cases = (
+            ("Test aarch64 QEMU", "must not start"),
+            ("Run Clippy", "must not start"),
+            ("Check formatting", "must not start"),
+            ("Scheduled Clippy", "must not start"),
+            ("Board self-hosted suites", "must not expose"),
+            ("aarch64 AxVisor suites", "must not repeat group"),
+        )
+
+        for name, error in invalid_cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ci_plan.PlanError, error):
+                    ci_plan._validate_check(
+                        {**valid, "name": name}, "test", "AxVisor"
+                    )
+
+    def test_starry_apps_display_names_are_leaf_labels(self) -> None:
+        scheduled = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="schedule",
+        )
+        rows = {
+            row["id"]: row["name"]
+            for row in ci_plan.build_starry_apps_plan(scheduled)[
+                "starry_apps_matrix"
+            ]["include"]
+        }
+
+        self.assertEqual(rows["starry-apps-clippy-all"], "Workspace · Full Clippy")
+        self.assertEqual(
+            rows["starry-app-smoke-x86-64"], "x86_64 QEMU · App smoke"
+        )
 
     def test_empty_main_matrix_is_rejected(self) -> None:
         with mock.patch.object(

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -190,20 +190,17 @@ class CiPlanTests(unittest.TestCase):
             6,
         )
 
-    def test_starry_apps_pull_request_selects_only_nixos(self) -> None:
-        pull_request = ci_plan.PlanContext(
+    def test_starry_apps_manual_nixos_uses_app_runner(self) -> None:
+        manual = ci_plan.PlanContext(
             repository="rcore-os/tgoskits",
             repository_owner="rcore-os",
-            event_name="pull_request",
-            base_ref="dev",
+            event_name="workflow_dispatch",
         )
 
-        rows = ci_plan.build_starry_apps_plan(pull_request)["starry_apps_matrix"][
-            "include"
-        ]
+        rows = ci_plan.build_starry_apps_plan(manual)["starry_apps_matrix"]["include"]
+        rows_by_id = {row["id"]: row for row in rows}
 
-        self.assertEqual([row["id"] for row in rows], ["starry-nixos-x86-64-qemu"])
-        nixos = rows[0]
+        nixos = rows_by_id["starry-nixos-x86-64-qemu"]
         self.assertEqual(nixos["container_image"], "")
         self.assertEqual(nixos["timeout_minutes"], 45)
         self.assertIn("starry app qemu -t nixos", nixos["command"])


### PR DESCRIPTION
## 问题

当前主 CI 通过 reusable workflow 同时声明 host/container 两个 job，再用 job-level `if` 选择实际执行环境。GitHub 会把未选择的一侧展示为 skipped；最近一次成功 PR 的 72 个 job 中有 36 个 skipped，真实检查与结构性占位混在一起，定位失败和判断覆盖范围都比较困难。

检查矩阵、owner/分支条件、runner fallback、镜像发布逻辑也集中在较大的 workflow 中，领域边界和重复配置不易维护。原测试标题还同时包含 workflow、领域和 `Test/Run/Check` 等重复前缀，例如 `Test checks / AxVisor / Test axvisor ...`，不便快速识别测试目的。

## 改动

- 按 Static、Workspace、ArceOS、AxVisor、Starry、Starry Apps 拆分 `.github/ci/checks/*.toml` 声明。
- 标题统一为 `Static / <目的>`、`Tests / <领域> / <目标> · <目的>` 和 `Starry Apps / <目标> · <目的>`；清单末级名称不再重复动作、runner 或领域信息。
- 新增 `tomllib` planner，在矩阵展开前校验并过滤 owner、PR base、事件和手工输入条件：
  - upstream PR 生成 3 个 static 和 31 个 test 检查；
  - fork PR 移除 owner-only/KVM/板卡项，并把 QCS 项转换为 Ubuntu + container fallback；
  - 禁止 self-hosted 项设置非空 `cache_key`；
  - 校验唯一 ID、环境、runner、命令、末级显示名和 xtask artifact 生产/消费契约。
- 用单 matrix job 的 `reusable-check-matrix.yml` 取代原 host/container 双 job，通过空容器名运行 host、实际镜像运行 container；checkout、preflight、cache、artifact、环境变量和命令执行集中复用。
- 主 CI 精简为 `Cancel stale runs -> Plan CI -> Static -> Tests`，保留两个全局矩阵的 `fail-fast` 和 Static/Test 依赖顺序。
- Starry Apps 复用同一 planner：NixOS 与 4 个 smoke 一样作为普通 catalog 数据，只由 workflow 顶层统一控制 `schedule`/`workflow_dispatch`，不在 pull request CI 运行；schedule 或 `run_clippy_all=true` 时再加入 clippy。rebase 到最新 `dev` 后，#1923 的 45 分钟上限、Nix 容器环境和 app 命令被保留，但不保留其 PR 特例；planner 不识别 NixOS case。
- 镜像发布拆为独立 workflow，保留 base/axvisor-lvz/both、main/dev 限制和 base -> AxVisor LVZ 顺序；metadata/build/cache 由本地 composite action 复用。
- Release-plz 将适用性判断移到首个 eligibility step；不适用时 job 名称和 summary 明确显示 `not applicable`，两个 release job 仍并行并保持各自最小权限。
- branch-push router 只传递 `since_sha`；PR 路径改为正向 CI allowlist，纯容器源码 PR 不创建主 CI run。

## 设计与替代方案

选择“声明清单 + planner 预过滤 + 单执行器”，因为 GitHub 对 `jobs.<job_id>.if: false` 必然展示 skipped，继续调整 job-level 条件无法解决展示问题。保留多套领域 workflow 虽然改动更小，但会复制 runner/container、cache 和 artifact 逻辑，也会改变当前跨领域 fail-fast 语义。

TOML 只保存项目检查语义，GitHub expression 和事件上下文留在 planner/workflow 边界；因此检查命令可独立校验，执行器也不需要理解具体领域。显示名采用“目标 + 目的”，既删除重复信息，又保留架构、QEMU/KVM/Board 等区分测试覆盖所必需的信息。

本次不改变任何 Rust、内核、板卡或测试语义。依赖失败导致的后续 skipped 仍按 GitHub 原始结果展示，不伪装为成功。

## 兼容性

- 逐项比对原有 34 个 static/test 条目，命令、runner、容器、缓存、超时、KVM 和 artifact 配置保持一致。
- 后续标题调整对原有 39 个 TOML 条目执行 name-only 比对；另新增 1 个 NixOS app 条目，原有 `id` 均保持不变。
- 保留全局 fail-fast、self-hosted fallback、APK region、xtask artifact 和 `TGOS_IMAGE_LOCAL_STORAGE` 行为。
- 已复核开放 PR #2025，保留其 image `--output-dir` 参数和本地镜像存储语义。

## 验证

- `python3 scripts/test/check_ci_paths.py`
- `python3 scripts/test/check_ci_routing.py`
- `python3 scripts/test/check_workflow_layout.py`
- `python3 -m unittest scripts/test/test_ci_plan.py`（17 项，含 NixOS app runner/config 契约）
- planner CLI：upstream `3 + 31`；Starry Apps manual `5`、manual + clippy `6`、schedule `6`
- 34 项旧/新检查声明迁移等价性比对
- 39 项标题变更 name-only 比对
- `cargo xtask sync-lint --since origin/dev`
- `cargo xtask lock-lint`；`cargo xtask clippy --package axbuild`
- `cargo fmt --all -- --check`
- actionlint v1.7.12：全部 workflow（仅忽略上游 actionlint 尚不识别的 `concurrency.queue`）
- workflow YAML 与本地 composite action manifest 解析

物理板和 self-hosted 流程未在本地执行。NixOS rootfs/QEMU app 命令已在本 PR 调整触发策略前的同一迁移版本中完成一次 GitHub Actions 实跑；最终配置只在定时或手工 Starry Apps workflow 中触发。
