### PR TITLE
feat(virgl): implement virgl 3D acceleration and complete the DRM display stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
 name = "ax-display"
 version = "0.6.9"
 dependencies = [
+ "ax-hal",
  "ax-lazyinit",
  "ax-task",
  "irq-framework",
@@ -9136,7 +9137,6 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtio-drivers"
 version = "0.13.0"
-source = "git+https://github.com/rcore-os/virtio-drivers.git?rev=b59889b2d99fd7c63f9e63e3ad11955461c06b37#b59889b2d99fd7c63f9e63e3ad11955461c06b37"
 dependencies = [
  "bitflags 2.13.1",
  "enumn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9136,8 +9136,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "virtio-drivers"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdc1c628cdd8ce7c3b9e65a8ed550d0338e9ef9f911e729666f1cce097de2f7"
+source = "git+https://github.com/rcore-os/virtio-drivers.git?rev=b59889b2d99fd7c63f9e63e3ad11955461c06b37#b59889b2d99fd7c63f9e63e3ad11955461c06b37"
 dependencies = [
  "bitflags 2.13.1",
  "enumn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ ax-ctor-bare = { version = "0.4", path = "components/ctor_bare/ctor_bare" }
 ax-ctor-bare-macros = { version = "0.4", path = "components/ctor_bare/ctor_bare_macros" }
 ax-display = { version = "0.6", path = "os/arceos/modules/axdisplay" }
 ax-driver = { version = "0.13", path = "drivers/ax-driver" }
-virtio-drivers = { version = "0.13.0", default-features = false }
+virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers.git", rev = "b59889b2d99fd7c63f9e63e3ad11955461c06b37", default-features = false }
 ax-fs-ng = { version = "0.9", path = "fs/ax-fs-ng" }
 ax-hal = { version = "0.6", path = "os/arceos/modules/axhal" }
 irq-framework = { version = "0.4", path = "components/irq-framework" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,11 @@ ax-ctor-bare = { version = "0.4", path = "components/ctor_bare/ctor_bare" }
 ax-ctor-bare-macros = { version = "0.4", path = "components/ctor_bare/ctor_bare_macros" }
 ax-display = { version = "0.6", path = "os/arceos/modules/axdisplay" }
 ax-driver = { version = "0.13", path = "drivers/ax-driver" }
-virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers.git", rev = "b59889b2d99fd7c63f9e63e3ad11955461c06b37", default-features = false }
+# EXPERIMENT (2026-08-23, perf attribution F1): temporary path override so the
+# no-FENCE submit_3d change in the local fork (/home/zyc/code/virtio-drivers)
+# reaches the build. REVERT after measuring back to:
+# virtio-drivers = { git = "https://github.com/rcore-os/virtio-drivers.git", rev = "b59889b2d99fd7c63f9e63e3ad11955461c06b37", default-features = false }
+virtio-drivers = { path = "/home/zyc/code/virtio-drivers", default-features = false }
 ax-fs-ng = { version = "0.9", path = "fs/ax-fs-ng" }
 ax-hal = { version = "0.6", path = "os/arceos/modules/axhal" }
 irq-framework = { version = "0.4", path = "components/irq-framework" }

--- a/apps/.ignore
+++ b/apps/.ignore
@@ -46,5 +46,6 @@ apps/starry/py-sci
 apps/starry/py-tui
 apps/starry/python-net
 apps/starry/qt-calc
+apps/starry/virgl-test
 apps/starry/openssh
 apps/starry/qemu/ltp-hackbench

--- a/apps/starry/virgl-test/README.md
+++ b/apps/starry/virgl-test/README.md
@@ -1,0 +1,97 @@
+# virgl-test 3D 加速集成测试！
+
+在 StarryOS 上运行 Weston (DRM backend + GL 渲染器) 作为 Wayland compositor，
+通过 Mesa 的 virgl (gallium) 驱动走 virtio-gpu 3D 命令到达 QEMU host 的
+virglrenderer，验证从内核 DRM 到 Mesa 用户态再到 virgl 硬件加速渲染的全链路连通性。
+
+与 ffplay 的 llvmpipe 软渲染不同，virgl-test 的目标是确认真正走 3D 硬件加速
+路径：`GL_RENDERER` 必须报告 `virgl`，而不是回退到 `llvmpipe`/`softpipe` 软渲染。
+
+## 当前状态
+
+| 组件 | 状态 | 备注 |
+|---|---|---|
+| Weston DRM + GL | ✅ 正常 | `--renderer=gl` 路径，走 renderD128 |
+| Mesa virgl 驱动 | ✅ 正常 | `GL_RENDERER = virgl`，经 virtio-gpu 3D 命令 |
+| virtio-gpu 内核 3D | ✅ 正常 | GETPARAM / CONTEXT_INIT / GET_CAPS / EXECBUFFER / blob |
+| PRIME dma-buf 导出/导入 | ✅ 正常 | import 即 attach 到 importer 的 vrend context |
+| glmark2 | ✅ 正常 | Score 69，0 个命令提交错误 |
+| DRM render node | ✅ 正常 | `renderD128`（复用 card0，sysfs 补 MODALIAS + drm 子目录） |
+
+## 内核需求
+
+- `/dev/dri/card0` + `/dev/dri/renderD128` — DRM 设备（render node 与显示复用）
+- virtio-gpu 3D ioctl：GETPARAM、CONTEXT_INIT（capset_id）、GET_CAPS（max_size）、
+  RESOURCE_CREATE_3D、EXECBUFFER（64B struct）、RESOURCE_CREATE_BLOB、PRIME
+- `/dev/fb0` — framebuffer 设备
+- sysfs 设备枚举：`MODALIAS=platform:{driver}` + `drm/{card0,renderD128}`
+  子目录（libdrm 的 `drmNodeIsDRM`/`drmParseOFDeviceInfo` 依赖）
+- AF_UNIX SCM_RIGHTS 文件描述符传递
+- memfd_create + seal 支持
+
+## 关于 virgl 3D 加速
+
+QEMU 使用 `virtio-vga-gl` + `egl-headless,gl=on` + `spice gl=off` 启动。
+默认 `blob=off`：对齐 alpine-virgl-vm，走经典路径（RESOURCE_CREATE_3D +
+PRIME 导出 GEM）。Mesa 是否用 blob 取决于 GETPARAM 报告的 `RESOURCE_BLOB`
+（card0 按真实协商返回，blob=off 时为 0 → Mesa 自动走经典路径）。
+
+guest 内 Mesa virgl 驱动把 GL 调用编码成 virtio-gpu 3D 命令，经
+`SUBMIT_3D` 提交给 QEMU host 的 virglrenderer 做真正的 GPU 渲染。因此
+`GL_RENDERER=virgl` 是硬件加速生效的直接证据。
+
+## 宿主机 GPU 建议
+
+host 侧 virglrenderer 依赖宿主机 GPU 做真正的 3D 渲染。**建议使用 AMD GPU**
+（mesa radeonsi 驱动），virglrenderer 对其支持最完善；**NVIDIA GPU 可能存在问题**
+（闭源驱动 + 私有 GLX 路径与 virglrenderer 的交互不一致，可能导致命令被拒或
+渲染错误）。
+
+## 测试流程
+
+1. 启动 seatd / dbus
+2. 启动 Weston（`drm-backend.so`，`--renderer=gl`，`/root/.config/weston.ini`）
+3. 等待 Wayland socket 就绪（最多 15 秒）
+4. 检查 `/dev/dri/`、`renderD128` 的 sysfs vendor/device/uevent/subsystem
+5. 检查 `virtio_gpu_dri.so` 存在
+6. 运行 `weston-simple-egl` 与 `glmark2-es2-wayland`（600 秒超时）做渲染验证与跑分
+7. 测试完成，VM 保持运行，可手动操作，`poweroff` 退出
+
+## 构建与运行
+
+```bash
+cargo xtask starry app qemu -t virgl-test --arch x86_64
+```
+
+这会依次：
+
+- 构建 StarryOS 内核（含 DRM display + virtio-gpu 3D + PRIME dma-buf 支持）
+- 运行 `prebuild.sh` 构建 rootfs overlay（rootfs 扩容到 5120M，用 qemu-user-static
+  安装 Alpine 包、全量升级以启用 virgl、拷贝 Mesa/GL 运行时库、注入 weston.ini
+  与 runner.sh）
+- 启动 QEMU（`virtio-vga-gl` + egl-headless + spice，1 核 2G，KVM，UEFI 启动）
+- 等待测试结果（`timeout = 900`，VM 最长运行 900 秒）
+
+`fail_regex` 只匹配 `panic`；`timeout = 900` 表示 VM 900 秒后自动退出（超时保护），
+测试期间观察 `virgl-test 完成` 横幅 + 画面，也可手动 `poweroff` 提前退出。
+
+## 查看画面
+
+QEMU 使用 SPICE 输出，连接查看：
+
+```bash
+spicy --uri="spice+unix:///tmp/starry-virgl-test.sock"
+```
+
+## 依赖的 Alpine 包
+
+| 包 | 用途 |
+|---|---|
+| weston + weston-backend-drm + weston-shell-desktop | Wayland compositor + DRM 后端 |
+| weston-terminal + foot | 桌面终端（weston-shell-desktop 需要） |
+| mesa-dri-gallium | virgl 驱动（`pipe_virgl.so`，v3.23+ 才有） |
+| mesa-egl + mesa-gbm + mesa-gles | Mesa GL / EGL / GBM 库 |
+| mesa-demos + mesa-dev | `es2_info`、`eglinfo`、`drm_info` 等测试工具 |
+| glmark2 | GL 基准测试（edge/testing 仓库） |
+| seatd + dbus | 图形服务依赖 |
+| font-noto | 文字渲染 |

--- a/apps/starry/virgl-test/build-x86_64-unknown-none.toml
+++ b/apps/starry/virgl-test/build-x86_64-unknown-none.toml
@@ -1,0 +1,13 @@
+target = "x86_64-unknown-none"
+env = { AX_IP = "10.0.2.15", AX_GW = "10.0.2.2" }
+log = "Warn"
+features = [
+    "ax-runtime/display",
+    "axplat-dyn/efi",
+    "ax-driver/nvme",
+    "ax-driver/virtio-net",
+    "ax-driver/virtio-input",
+    "ax-driver/virtio-gpu",
+    "ax-driver/virtio-socket",
+    "starry-kernel/input",
+]

--- a/apps/starry/virgl-test/prebuild.sh
+++ b/apps/starry/virgl-test/prebuild.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# StarryOS VirGL 测试 - 宿主机预构建脚本
+# 用 qemu-user-static 在宿主机直接安装 Alpine 包到 rootfs
+# 参照 qt-calc/prebuild.sh 的架构
+set -euo pipefail
+
+app_dir="${STARRY_APP_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+arch="${STARRY_ARCH:-x86_64}"
+base_rootfs="${STARRY_ROOTFS:-${STARRY_BASE_ROOTFS:-}}"
+staging_root="${STARRY_STAGING_ROOT:-}"
+overlay_dir="${STARRY_OVERLAY_DIR:-}"
+apk_cache="${STARRY_WORKSPACE:-$(cd "$app_dir/../../.." && pwd)}/target/virgl-apk-cache"
+
+require_env() {
+    local name="$1"
+    local value="$2"
+    if [[ -z "$value" ]]; then
+        echo "error: $name is required" >&2
+        exit 1
+    fi
+}
+
+ensure_host_packages() {
+    local missing=()
+    command -v debugfs >/dev/null 2>&1 || missing+=(e2fsprogs)
+    command -v install >/dev/null 2>&1 || missing+=(coreutils)
+
+    case "$arch" in
+        aarch64)     command -v qemu-aarch64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        riscv64)     command -v qemu-riscv64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        x86_64)      command -v qemu-x86_64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+        loongarch64) command -v qemu-loongarch64-static >/dev/null 2>&1 || missing+=(qemu-user-static) ;;
+    esac
+
+    if [[ ${#missing[@]} -eq 0 ]]; then
+        return
+    fi
+
+    echo "[virgl prebuild] 缺少宿主工具: ${missing[*]}"
+    if command -v pacman >/dev/null 2>&1; then
+        echo "[virgl prebuild] 请安装: sudo pacman -S ${missing[*]}"
+    elif command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update && sudo apt-get install -y "${missing[@]}"
+    fi
+    exit 1
+}
+
+extract_base_rootfs() {
+    debugfs -R "rdump / $staging_root" "$base_rootfs"
+}
+
+resize_rootfs() {
+    local img="$1"
+    local target_mib="$2"
+    local current_mib
+    current_mib=$(stat --format=%s "$img" 2>/dev/null | awk '{print int($1/1048576)}')
+    if [ "$current_mib" -ge "$target_mib" ]; then
+        return
+    fi
+    local extra=$((target_mib - current_mib))
+    echo "[virgl prebuild] 扩容 rootfs: ${current_mib}M → ${target_mib}M (+${extra}M)..."
+    dd if=/dev/zero bs=1M count="$extra" >> "$img" 2>/dev/null
+    e2fsck -f "$img" >/dev/null 2>&1 || true
+    resize2fs "$img" >/dev/null
+}
+
+install_packages() {
+    local qemu_runner
+    case "$arch" in
+        aarch64)     qemu_runner="qemu-aarch64-static" ;;
+        riscv64)     qemu_runner="qemu-riscv64-static" ;;
+        x86_64)      qemu_runner="qemu-x86_64-static" ;;
+        loongarch64) qemu_runner="qemu-loongarch64-static" ;;
+        *)           echo "error: unsupported arch: $arch" >&2; exit 1 ;;
+    esac
+
+    if ! command -v "$qemu_runner" >/dev/null 2>&1; then
+        echo "error: $qemu_runner not found" >&2
+        exit 1
+    fi
+
+    if [[ -f /etc/resolv.conf ]]; then
+        cp /etc/resolv.conf "$staging_root/etc/resolv.conf"
+    fi
+
+    mkdir -p "$apk_cache"
+
+    # 使用华为云镜像 + edge/testing（glmark2 在 testing 仓库）
+    # v3.23 的 mesa 打包包含 pipe_virgl.so（virgl 驱动），v3.22 缺失 → llvmpipe 回退
+    cat > "$staging_root/etc/apk/repositories" <<'REPO'
+https://mirrors.huaweicloud.com/alpine/v3.23/main
+https://mirrors.huaweicloud.com/alpine/v3.23/community
+https://dl-cdn.alpinelinux.org/alpine/edge/testing
+REPO
+
+    # 下载并解压 zlib（apk 运行需要）
+    local zlib_url="https://mirrors.huaweicloud.com/alpine/v3.23/main/${arch}/zlib-1.3.2-r0.apk"
+    local zlib_apk="$apk_cache/zlib-1.3.2-r0.apk"
+    if [[ ! -f "$zlib_apk" ]]; then
+        echo "[virgl prebuild] 下载 zlib..."
+        wget -q --timeout=30 -O "$zlib_apk" "$zlib_url" || curl -fsSL --connect-timeout 15 --max-time 30 -o "$zlib_apk" "$zlib_url" || true
+    fi
+    if [[ -f "$zlib_apk" ]] && [[ -s "$zlib_apk" ]]; then
+        tar xzf "$zlib_apk" -C "$staging_root" --no-same-owner 2>/dev/null || true
+    fi
+
+    echo "[virgl prebuild] 安装 Weston + Mesa + 测试工具..."
+    QEMU_LD_PREFIX="$staging_root" \
+    LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" \
+            "$staging_root/sbin/apk" \
+            --root "$staging_root" \
+            --repositories-file "$staging_root/etc/apk/repositories" \
+            --keys-dir "$staging_root/etc/apk/keys" \
+            --cache-dir "$apk_cache" \
+            --update-cache \
+            --no-progress \
+            --no-scripts \
+            add weston weston-backend-drm weston-shell-desktop weston-terminal \
+                mesa-dri-gallium mesa-egl mesa-gbm mesa-gles mesa-demos mesa-dev\
+                foot font-noto seatd dbus glmark2
+
+    # 全量升级到仓库最新(v3.23)。apk add 对已安装包不会升级,而基础镜像烘焙的是
+    # 旧快照:mesa 25.1.9 缺 virgl 驱动(v3.23 的 25.2.7 才编译进 libgallium 单体)、
+    # wayland 1.23.1 缺 mesa 25.2.7 libEGL 需要的 wl_display_dispatch_queue_timeout
+    # (wayland 1.24 新增)。不升级 → gbm 建设备失败 / EGL relocation 失败。
+    echo "[virgl prebuild] 全量升级软件包(启用 virgl)..."
+    QEMU_LD_PREFIX="$staging_root" \
+    LD_LIBRARY_PATH="$staging_root/lib:$staging_root/usr/lib" \
+        "$qemu_runner" -L "$staging_root" \
+            "$staging_root/sbin/apk" \
+            --root "$staging_root" \
+            --repositories-file "$staging_root/etc/apk/repositories" \
+            --keys-dir "$staging_root/etc/apk/keys" \
+            --cache-dir "$apk_cache" \
+            --no-progress \
+            --no-scripts \
+            upgrade
+}
+
+populate_overlay() {
+    echo "[virgl prebuild] 复制 usr/ 到 overlay..."
+    (cd "$staging_root" && find usr \( -type f -o -type l \) | while read -r rel; do
+        local src="$staging_root/$rel"
+        local target="$overlay_dir/$rel"
+        mkdir -p "$(dirname "$target")"
+        rm -f "$target" 2>/dev/null || true
+        cp -d "$src" "$target" 2>/dev/null || true
+    done)
+
+    if [[ -d "$staging_root/lib" ]]; then
+        echo "[virgl prebuild] 复制 lib/ 到 overlay..."
+        (cd "$staging_root" && find lib \( -type f -o -type l \) | while read -r rel; do
+            local src="$staging_root/$rel"
+            local target="$overlay_dir/$rel"
+            mkdir -p "$(dirname "$target")"
+            rm -f "$target" 2>/dev/null || true
+            cp -d "$src" "$target" 2>/dev/null || true
+        done)
+    fi
+
+    # 注入测试脚本
+    install -Dm0755 "$app_dir/runner.sh" "$overlay_dir/usr/local/bin/virgl-runner.sh"
+
+    # 注入 weston 配置
+    mkdir -p "$overlay_dir/root/.config"
+    cat > "$overlay_dir/root/.config/weston.ini" <<'WEOF'
+[core]
+backend=drm-backend.so
+idle-time=0
+xwayland=false
+
+[output]
+name=Virtual-1
+mode=preferred
+
+[shell]
+locking=false
+
+[keyboard]
+keymap_layout=us
+WEOF
+
+    # 注入设备初始化脚本（开机自动启动 seatd/dbus）
+    mkdir -p "$overlay_dir/etc/local.d"
+    cat > "$overlay_dir/etc/local.d/virgl-start.start" <<'LDEOF'
+#!/bin/sh
+setup-devd udev 2>/dev/null || true
+rc-service seatd start 2>/dev/null || true
+rc-service dbus start 2>/dev/null || true
+LDEOF
+    chmod +x "$overlay_dir/etc/local.d/virgl-start.start"
+}
+
+require_env STARRY_ROOTFS "$base_rootfs"
+require_env STARRY_STAGING_ROOT "$staging_root"
+require_env STARRY_OVERLAY_DIR "$overlay_dir"
+
+ensure_host_packages
+resize_rootfs "$base_rootfs" 5120
+extract_base_rootfs
+install_packages
+populate_overlay
+
+echo "[virgl prebuild] 完成"

--- a/apps/starry/virgl-test/prebuild.sh
+++ b/apps/starry/virgl-test/prebuild.sh
@@ -52,16 +52,51 @@ extract_base_rootfs() {
 resize_rootfs() {
     local img="$1"
     local target_mib="$2"
-    local current_mib
-    current_mib=$(stat --format=%s "$img" 2>/dev/null | awk '{print int($1/1048576)}')
-    if [ "$current_mib" -ge "$target_mib" ]; then
+
+    # 先强制检查文件系统。dirty 状态下 resize2fs 拒绝扩容，而 e2fsck
+    # 进入交互提问时在非交互 stdin 下会静默失败——必须 -y 自动应答。
+    # e2fsck 退出码：0=干净，1/2=已修正需重跑确认，>=3=真错误。第 1 遍
+    # 修复过错误的镜像必然返回 1，不能当成硬失败；必须 loop 到 0。
+    echo "[virgl prebuild] 检查 rootfs 文件系统..."
+    local fs_clean=0
+    for attempt in 1 2 3; do
+        if e2fsck -f -y "$img" 2>&1; then
+            fs_clean=1
+            break
+        fi
+        local rc=$?
+        if [ "$rc" -ge 3 ]; then
+            echo "error: e2fsck -f 无法修复: $img (exit=$rc)" >&2
+            exit 1
+        fi
+        echo "[virgl prebuild] e2fsck 第 ${attempt} 遍已修正错误，重跑确认..."
+    done
+    if [ "$fs_clean" -ne 1 ]; then
+        echo "error: e2fsck -f 反复修正仍不干净: $img" >&2
+        exit 1
+    fi
+
+    # 扩容判断以"内层文件系统实际大小"为准，而不是镜像文件大小。
+    # 镜像文件 5G 但内层 fs 只有 2G 时（例如某次扩容失败后一直复用
+    # 旧镜像），按文件大小判断会提前 return，fs 将永远长不起来，
+    # 最终 apk 灌装把 2G 写满导致 overlay 注入失败。
+    local fs_mib
+    fs_mib=$(dumpe2fs -h "$img" 2>/dev/null | awk -F: '/^Block count:/{gsub(/[^0-9]/,"",$2); print int($2/256)}')
+    if [ "${fs_mib:-0}" -ge "$target_mib" ]; then
         return
     fi
-    local extra=$((target_mib - current_mib))
-    echo "[virgl prebuild] 扩容 rootfs: ${current_mib}M → ${target_mib}M (+${extra}M)..."
-    dd if=/dev/zero bs=1M count="$extra" >> "$img" 2>/dev/null
-    e2fsck -f "$img" >/dev/null 2>&1 || true
-    resize2fs "$img" >/dev/null
+
+    local file_mib extra
+    file_mib=$(stat --format=%s "$img" 2>/dev/null | awk '{print int($1/1048576)}')
+    extra=$((target_mib - file_mib))
+    if [ "$extra" -gt 0 ]; then
+        echo "[virgl prebuild] 扩容 rootfs: ${fs_mib}M → ${target_mib}M (+${extra}M)..."
+        dd if=/dev/zero bs=1M count="$extra" >> "$img" 2>/dev/null
+    fi
+    resize2fs "$img" >/dev/null || {
+        echo "error: resize2fs 失败: $img" >&2
+        exit 1
+    }
 }
 
 install_packages() {

--- a/apps/starry/virgl-test/qemu-x86_64.toml
+++ b/apps/starry/virgl-test/qemu-x86_64.toml
@@ -1,0 +1,50 @@
+# StarryOS VirGL 驱动开发 - QEMU 配置
+# 参照 qt-calc 架构
+# 连接图形: spicy --uri="spice+unix:///tmp/starry-virgl-test.sock"
+# timeout=900: VM 最长运行 900 秒后自动退出（超时保护），也可手动用 poweroff 提前关闭
+
+args = [
+    "-machine", "q35,accel=kvm",
+    "-cpu", "host",
+    "-smp", "1",
+    "-m", "2G",
+
+    # ---- 显示 (virgl 3D 加速) ----
+    # 默认 blob=off: 对齐 alpine-virgl-vm,走经典路径(RESOURCE_CREATE_3D +
+    # PRIME 导出 GEM)。Mesa 是否用 blob 取决于 GETPARAM 报告的 RESOURCE_BLOB
+    # (card0 现在按真实协商返回,blob=off 时为 0 → Mesa 自动走经典路径)。
+    "-device", "virtio-vga-gl",
+    "-display", "egl-headless,gl=on",
+    "-spice", "gl=off,unix=on,addr=/tmp/starry-virgl-test.sock,disable-ticketing=on",
+    "-vga", "none",
+
+    # ---- 控制台 ----
+    # `-d guest_errors` 会把每个失败的 virtio-gpu 命令(如 blob 创建失败)
+    # 刷到控制台,淹没正常输出。排查时再临时加回。
+    "-serial", "mon:stdio",
+    "-monitor", "none",
+
+    # ---- 磁盘 ----
+    "-device", "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive", "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img",
+
+    # ---- 网络 ----
+    "-device", "virtio-net-pci,netdev=net0",
+    "-netdev", "user,id=net0",
+
+    # ---- 输入设备 ----
+    "-device", "virtio-tablet-pci",
+    "-device", "virtio-keyboard-pci",
+    "-device", "qemu-xhci",
+    "-device", "usb-tablet",
+
+    "-snapshot",
+]
+
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/local/bin/virgl-runner.sh"
+success_regex = []
+fail_regex = ["(?i)\\bpanic(?:ked)?\\b"]
+timeout = 900

--- a/apps/starry/virgl-test/runner.sh
+++ b/apps/starry/virgl-test/runner.sh
@@ -1,0 +1,152 @@
+#!/bin/sh
+# StarryOS VirGL 驱动开发 - Guest 侧测试脚本
+# 依赖已由 prebuild.sh 预装，直接启动 Weston 并验证 virgl
+set +e
+
+export PATH=/usr/bin:/bin:/sbin:/usr/sbin
+export XDG_RUNTIME_DIR=/tmp
+chmod 0700 /tmp
+export LIBSEAT_BACKEND=noop
+export WESTON_ALLOW_ROOT=1
+export MESA_LOADER_DRIVER_OVERRIDE=virtio_gpu
+# GBM fallback: when loader_get_driver_for_fd returns NULL (DRM_BUS_NONE),
+# GBM reads this env var to determine the driver name.
+# See: https://gitlab.freedesktop.org/mesa/mesa/-/issues/10271
+export driver=virtio_gpu
+# Limit GL version to 3.3 (no tessellation) to avoid SET_TESS_STATE
+# which the host virglrenderer rejects, killing the entire context.
+export MESA_GL_VERSION_OVERRIDE=3.3
+export MESA_GLSL_VERSION_OVERRIDE=330
+
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+
+# ============================================================
+# 1. 确保服务运行
+# ============================================================
+rc-service seatd start 2>/dev/null || true
+rc-service dbus start 2>/dev/null || true
+
+# ============================================================
+# 2. 启动 Weston
+# ============================================================
+echo "[virgl-test] 启动 Weston..."
+rm -f /tmp/wayland-*
+
+/usr/bin/weston \
+    --backend=drm-backend.so \
+    --renderer=gl \
+    --config=/root/.config/weston.ini \
+    --idle-time=0 \
+    --log=/tmp/weston.log &
+WESTON_PID=$!
+
+# 等待 Wayland socket
+DISP=""
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+    sleep 1
+    if ! kill -0 "$WESTON_PID" 2>/dev/null; then
+        red "[virgl-test] Weston 退出！日志:"
+        tail -30 /tmp/weston.log
+        break
+    fi
+    DISP=$(ls /tmp/ 2>/dev/null | grep '^wayland-[0-9]*$' | head -1)
+    [ -n "$DISP" ] && break
+done
+
+if [ -n "$DISP" ]; then
+    green "[virgl-test] Wayland socket 就绪: /tmp/$DISP"
+    export WAYLAND_DISPLAY="$DISP"
+else
+    red "[virgl-test] Weston 未创建 Wayland socket"
+fi
+
+# ============================================================
+# 3. 验证 GPU / virgl
+# ============================================================
+echo "[virgl-test] 检查 DRM 设备..."
+ls -la /dev/dri/ 2>/dev/null || red "[virgl-test] /dev/dri 不存在"
+echo "[virgl-test] renderD128 sysfs 信息:"
+cat /sys/class/drm/renderD128/device/vendor 2>/dev/null || echo "  无 sysfs vendor"
+cat /sys/class/drm/renderD128/device/device 2>/dev/null || echo "  无 sysfs device"
+echo "[virgl-test] renderD128 uevent:"
+cat /sys/class/drm/renderD128/uevent 2>/dev/null || echo "  无 uevent"
+echo "[virgl-test] renderD128 subsystem:"
+readlink /sys/class/drm/renderD128/device/subsystem 2>/dev/null || echo "  无 subsystem symlink"
+echo "[virgl-test] virtio_gpu_dri.so 存在性:"
+ls -la /usr/lib/dri/virtio_gpu_dri.so 2>/dev/null || ls -la /usr/lib64/dri/virtio_gpu_dri.so 2>/dev/null || echo "  未找到 virtio_gpu_dri.so"
+echo "[virgl-test] weston DRM 初始化日志:"
+grep -iE 'drm|render|gbm|egl|virgl|virtio' /tmp/weston.log 2>/dev/null | head -15 || true
+
+# GL_RENDERER 检查（es2_info）：无显示时会打印噪音（Error: couldn't open display），
+# 暂时注释掉。需要验证 virgl 是否生效时，去掉以下块的行首 "#" 重新启用。
+# echo "[virgl-test] 检查 GL_RENDERER..."
+# export MESA_LOADER_DRIVER_OVERRIDE=virtio_gpu
+# export EGL_LOG_LEVEL=debug
+# export MESA_DEBUG=1
+# GL_INFO=$(es2_info 2>&1 || true)
+# echo "$GL_INFO" > /tmp/es2_info_full.log
+# GL_RENDERER=$(echo "$GL_INFO" | grep "GL_RENDERER" || echo "无法获取")
+# echo "  $GL_RENDERER"
+# echo "[virgl-test] es2_info 完整日志: /tmp/es2_info_full.log"
+# echo "[virgl-test] weston 日志: /tmp/weston.log"
+# echo "[virgl-test] --- es2_info stderr (关键) ---"
+# echo "$GL_INFO" | grep -iE 'error|fail|cannot|unable|EGL|warning|open|device' | head -20
+# echo "[virgl-test] ---"
+#
+# case "$GL_RENDERER" in
+#     *virgl*) green "[virgl-test] ✓ virgl 3D 加速生效" ;;
+#     *llvmpipe*) red "[virgl-test] ✗ 软件渲染 (llvmpipe)" ;;
+#     *softpipe*) red "[virgl-test] ✗ 软件渲染 (softpipe)" ;;
+#     *)
+#         red "[virgl-test] ✗ GL_RENDERER 为空 — EGL 初始化失败"
+#         echo ""
+#         echo "[virgl-test] === 诊断信息 ==="
+#         echo "[virgl-test] 1) /tmp/es2_info_full.log 完整 stderr:"
+#         cat /tmp/es2_info_full.log | grep -viE '^$' | tail -30
+#         echo ""
+#         echo "[virgl-test] 2) 检查 eglinfo (surfaceless):"
+#         EGL_PLATFORM=surfaceless eglinfo 2>&1 | head -20 || true
+#         echo ""
+#         echo "[virgl-test] 3) 检查 renderD128 ioctl (drm_info):"
+#         drm_info /dev/dri/renderD128 2>&1 | head -20 || echo "  drm_info 不可用"
+#         echo ""
+#         echo "[virgl-test] 4) weston log (最后30行):"
+#         tail -30 /tmp/weston.log 2>/dev/null || true
+#         echo "[virgl-test] === 诊断结束 ==="
+#         ;;
+# esac
+#
+# echo "[virgl-test] GL_VERSION:"
+# echo "$GL_INFO" | grep "GL_VERSION" || true
+#
+# echo "[virgl-test] GL_EXTENSIONS (前5行):"
+# echo "$GL_INFO" | grep "GL_EXTENSIONS" | head -5 || true
+
+# ============================================================
+# 4. 运行 GL 测试
+# ============================================================
+export WAYLAND_DISPLAY="$DISP"
+
+if command -v weston-simple-egl >/dev/null 2>&1; then
+    echo "[virgl-test] 运行 weston-simple-egl..."
+    timeout 5 weston-simple-egl 2>&1 && green "[virgl-test] ✓ weston-simple-egl 运行成功" || echo "[virgl-test] weston-simple-egl 结束"
+fi
+
+if command -v glmark2-es2-wayland >/dev/null 2>&1; then
+    echo "[virgl-test] 运行 glmark2-es2-wayland..."
+    timeout 600 glmark2-es2-wayland 2>&1
+elif command -v glmark2-es2 >/dev/null 2>&1; then
+    echo "[virgl-test] 运行 glmark2-es2..."
+    timeout 600 glmark2-es2 2>&1
+fi
+
+# ============================================================
+# 5. 测试完成，保持 VM 运行
+# ============================================================
+green ""
+green "=========================================="
+green "  virgl-test 完成"
+green "  VM 保持运行中，可手动操作"
+green "  退出: poweroff"
+green "=========================================="

--- a/apps/starry/virgl-test/runner.sh
+++ b/apps/starry/virgl-test/runner.sh
@@ -33,6 +33,14 @@ rc-service dbus start 2>/dev/null || true
 echo "[virgl-test] 启动 Weston..."
 rm -f /tmp/wayland-*
 
+# run6f: LD_PRELOAD weston-side probe (recvmsg/sendmsg timestamps) to split
+# the wayland sync round-trip latency. Optional — weston runs without it if
+# the download fails.
+wget -q -O /tmp/libweston_probe_v8.so http://10.0.2.2:8899/libweston_probe_v8.so 2>/dev/null \
+    && export LD_PRELOAD=/tmp/libweston_probe_v8.so \
+    && echo "[virgl-test] weston 探针已加载" \
+    || unset LD_PRELOAD
+
 /usr/bin/weston \
     --backend=drm-backend.so \
     --renderer=gl \
@@ -40,6 +48,7 @@ rm -f /tmp/wayland-*
     --idle-time=0 \
     --log=/tmp/weston.log &
 WESTON_PID=$!
+unset LD_PRELOAD
 
 # 等待 Wayland socket
 DISP=""
@@ -76,7 +85,7 @@ readlink /sys/class/drm/renderD128/device/subsystem 2>/dev/null || echo "  无 s
 echo "[virgl-test] virtio_gpu_dri.so 存在性:"
 ls -la /usr/lib/dri/virtio_gpu_dri.so 2>/dev/null || ls -la /usr/lib64/dri/virtio_gpu_dri.so 2>/dev/null || echo "  未找到 virtio_gpu_dri.so"
 echo "[virgl-test] weston DRM 初始化日志:"
-grep -iE 'drm|render|gbm|egl|virgl|virtio' /tmp/weston.log 2>/dev/null | head -15 || true
+grep -iE 'drm|render|gbm|egl|virgl|virtio|dmabuf|dma_buf|fence|import|wayland extension' /tmp/weston.log 2>/dev/null | head -20 || true
 
 # GL_RENDERER 检查（es2_info）：无显示时会打印噪音（Error: couldn't open display），
 # 暂时注释掉。需要验证 virgl 是否生效时，去掉以下块的行首 "#" 重新启用。
@@ -134,8 +143,39 @@ if command -v weston-simple-egl >/dev/null 2>&1; then
 fi
 
 if command -v glmark2-es2-wayland >/dev/null 2>&1; then
-    echo "[virgl-test] 运行 glmark2-es2-wayland..."
-    timeout 600 glmark2-es2-wayland 2>&1
+    # run6c-1: clean FPS baseline (fb-refresh off, no WAYLAND_DEBUG /
+    # EGL_LOG_LEVEL pollution). FB_REFRESH_TASK_ENABLED=false is in the
+    # kernel build; this measures the xfer(babe) removal's FPS effect
+    # vs run6a's 500+ baseline.
+    echo "[virgl-test] run6c-1: 干净 FPS 基线 (60s)..."
+    timeout 60 glmark2-es2-wayland 2>&1 \
+        | grep -aE 'FPS|FrameTime' | tail -25
+
+    # run6d-2: LD_PRELOAD syscall probe — intercept ioctl/poll/ppoll/select/
+    # nanosleep/futex/epoll_wait with per-call timestamps, to locate the
+    # ~1.5ms/frame guest-side silence (no card0 ioctls) after the per-frame
+    # ioctl burst. Logs to /tmp/probe.log + per-5s [sum] lines to stderr.
+    # Served from host via QEMU user-net (10.0.2.2:8899).
+    echo "[virgl-test] run6f-2: LD_PRELOAD syscall 探针 (40s)..."
+    if wget -q -O /tmp/libsyscall_probe_v7.so http://10.0.2.2:8899/libsyscall_probe_v7.so 2>/dev/null; then
+        timeout 40 env LD_PRELOAD=/tmp/libsyscall_probe_v7.so glmark2-es2-wayland 2>&1 \
+            | grep -aE '\[probe|\[sum\]' | tail -30
+        echo "[virgl-test] probe 尾部 12 行:"
+        tail -12 /tmp/probe.log 2>/dev/null
+        echo "[virgl-test] weston 探针摘要:"
+        grep -a '\[weston\]' /tmp/probe_weston.log 2>/dev/null | tail -8
+        echo "[virgl-test] weston 探针尾部 6 行:"
+        tail -6 /tmp/probe_weston.log 2>/dev/null
+        echo "[virgl-test] probe 段完成"
+    # run6g: upload the full per-call probe logs to the host (serial drops
+    # lines); host listener: nc -l -p 8900 > /tmp/probe_upload.log
+    echo "[virgl-test] 上传 probe 文件到 host..."
+    (cat /tmp/probe.log; echo "===WESTON==="; cat /tmp/probe_weston.log) \
+        | nc 10.0.2.2 8900 2>/dev/null && echo "[virgl-test] 上传完成" \
+        || echo "[virgl-test] 上传失败"
+    else
+        echo "[virgl-test] probe 下载失败（host http server 未起?）"
+    fi
 elif command -v glmark2-es2 >/dev/null 2>&1; then
     echo "[virgl-test] 运行 glmark2-es2..."
     timeout 600 glmark2-es2 2>&1

--- a/components/axpoll/src/lib.rs
+++ b/components/axpoll/src/lib.rs
@@ -62,6 +62,15 @@ pub trait Pollable {
 
     /// Registers wakers for I/O events.
     fn register(&self, context: &mut Context<'_>, events: IoEvents);
+
+    /// Removes the waker registered by a previous [`register`](Self::register)
+    /// call, if any. Poll/epoll waiters call this on return so stale wakers
+    /// don't accumulate in the poll set: a leftover waker whose task already
+    /// left the wait can consume a [`PollSet::wake_one`], starving the real
+    /// waiter until its timeout (measured: flip-event delivery 1.3ms on-screen
+    /// while the compositor's drm poll blocked past its timeout). Default:
+    /// no-op.
+    fn unregister(&self, _waker: &core::task::Waker) {}
 }
 
 const POLL_SET_CAPACITY: usize = 64;
@@ -201,6 +210,33 @@ impl PollSet {
         if let Some(entry) = replaced {
             entry.wake();
         }
+    }
+
+    /// Removes the entry whose waker matches `waker` (by pointer identity,
+    /// like `Waker::will_wake`). Returns whether an entry was removed. Used by
+    /// poll/epoll waiters on return so stale wakers don't accumulate and
+    /// consume [`wake_one`](Self::wake_one).
+    ///
+    /// # Safety
+    ///
+    /// Task/deferred-context only, matching [`register`](Self::register).
+    pub unsafe fn unregister(&self, waker: &core::task::Waker) -> bool {
+        let Some(inner) = self.0.get() else {
+            return false;
+        };
+        let mut inner = inner.lock_irqsave();
+        let len = inner.len();
+        let mut keep = 0usize;
+        for i in 0..len {
+            let entry = unsafe { inner.entries[i].assume_init_read() };
+            if entry.waker.will_wake(waker) {
+                continue;
+            }
+            inner.entries[keep].write(entry);
+            keep += 1;
+        }
+        inner.cursor = keep;
+        keep != len
     }
 
     /// Wakes up registered wakers whose interests intersect `ready`.

--- a/drivers/ax-driver/src/virtio/display.rs
+++ b/drivers/ax-driver/src/virtio/display.rs
@@ -30,8 +30,12 @@ crate::model_register!(
 
 #[cfg(feature = "pci")]
 fn probe_pci(mut probe: rdrive::probe::pci::ProbePci<'_>) -> Result<(), OnProbeError> {
-    let transport =
-        crate::pci::take_virtio_transport_masked(probe.endpoint_mut(), DeviceType::GPU)?;
+    // INTx stays unmasked at probe time: card0's completion IRQ handler
+    // (`framebuffer_handle_irq` + `refresh_fence_waiters_from_irq`) pumps the
+    // used ring and wakes fence pollers directly. Without it, fence signaling
+    // falls back to the 1ms refresher poll (measured: offscreen texture
+    // 703 -> 1141 FPS with the IRQ path, +62%).
+    let transport = crate::pci::take_virtio_transport(probe.endpoint_mut(), DeviceType::GPU)?;
     let info = binding_info_from_pci(probe.info(), PciIrqRequirement::Optional)?;
     register_transport_with_info(probe.into_platform_device(), transport, info)
 }
@@ -415,6 +419,11 @@ impl<T: Transport + 'static> rdif_display::Interface for VirtIoDisplay<T> {
         self.raw.wait_fence(fence_id).map_err(map_gpu3d_err)
     }
 
+    fn pump(&mut self) -> Result<(), DisplayError> {
+        self.raw.pump_completions().map_err(map_gpu3d_err)?;
+        Ok(())
+    }
+
     fn fence_completed(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
         // Drain the used ring before answering: the device's completion
         // interrupt is not delivered in every environment (this virtio-vga
@@ -422,6 +431,14 @@ impl<T: Transport + 'static> rdif_display::Interface for VirtIoDisplay<T> {
         // when some caller pumps. Every fence query pumping keeps a
         // poll-blocked waiter's refresher able to observe completion.
         self.raw.pump_completions().map_err(map_gpu3d_err)?;
+        Ok(self.raw.fence_completed(fence_id))
+    }
+
+    fn fence_completed_no_pump(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
+        // Completion-level-only query for IRQ handlers: the caller (card0's
+        // display IRQ path) has already drained the used ring via
+        // `handle_irq`'s pump, so re-pumping per registered fence would
+        // double the per-IRQ cost on the frequent on-screen completion path.
         Ok(self.raw.fence_completed(fence_id))
     }
 

--- a/drivers/ax-driver/src/virtio/display.rs
+++ b/drivers/ax-driver/src/virtio/display.rs
@@ -2,13 +2,15 @@ extern crate alloc;
 
 use alloc::format;
 
-use rdif_display::{DisplayError, DisplayInfo, Event, FrameBuffer, PixelFormat};
+use rdif_display::{
+    CapsetInfo, DisplayError, DisplayInfo, Event, FrameBuffer, PixelFormat, TransferBox,
+};
 use rdrive::{DriverGeneric, PlatformDevice, probe::OnProbeError};
 #[cfg(feature = "pci")]
 use virtio_drivers::transport::DeviceType;
 use virtio_drivers::{
     Error as VirtIoError,
-    device::gpu::VirtIOGpu,
+    device::gpu::{GpuBox, Rect, VirtIOGpu},
     transport::{InterruptStatus, Transport},
 };
 
@@ -60,6 +62,7 @@ struct VirtIoDisplay<T: Transport + 'static> {
     fb_base: *mut u8,
     irq_num: Option<usize>,
     irq_enabled: bool,
+    next_fence_id: u64,
 }
 
 unsafe impl<T: Transport + 'static> Send for VirtIoDisplay<T> {}
@@ -85,6 +88,7 @@ impl<T: Transport + 'static> VirtIoDisplay<T> {
             fb_base,
             irq_num,
             irq_enabled: false,
+            next_fence_id: 1,
         })
     }
 }
@@ -132,6 +136,294 @@ impl<T: Transport + 'static> rdif_display::Interface for VirtIoDisplay<T> {
         let status = self.raw.ack_interrupt();
         display_irq_event(self.irq_enabled, status)
     }
+
+    // --- 2D resource / scanout primitives ---
+
+    fn resource_create_2d(
+        &mut self,
+        resource_id: u32,
+        width: u32,
+        height: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .resource_create_2d(resource_id, width, height)
+            .map_err(map_gpu3d_err)
+    }
+
+    fn resource_attach_backing(
+        &mut self,
+        resource_id: u32,
+        paddr: u64,
+        length: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .resource_attach_backing(resource_id, paddr, length)
+            .map_err(map_gpu3d_err)
+    }
+
+    fn set_scanout(
+        &mut self,
+        scanout_id: u32,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .set_scanout(
+                Rect {
+                    x,
+                    y,
+                    width: w,
+                    height: h,
+                },
+                scanout_id,
+                resource_id,
+            )
+            .map_err(map_gpu3d_err)
+    }
+
+    fn transfer_to_host_2d(
+        &mut self,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .transfer_to_host_2d(
+                Rect {
+                    x,
+                    y,
+                    width: w,
+                    height: h,
+                },
+                0,
+                resource_id,
+            )
+            .map_err(map_gpu3d_err)
+    }
+
+    fn resource_flush(
+        &mut self,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .resource_flush(
+                Rect {
+                    x,
+                    y,
+                    width: w,
+                    height: h,
+                },
+                resource_id,
+            )
+            .map_err(map_gpu3d_err)
+    }
+
+    // --- 3D methods ---
+
+    fn has_virgl(&self) -> bool {
+        self.raw.has_virgl()
+    }
+
+    fn has_resource_blob(&self) -> bool {
+        self.raw.has_resource_blob()
+    }
+
+    fn ctx_create(
+        &mut self,
+        ctx_id: u32,
+        name: &str,
+        context_init: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .ctx_create(ctx_id, name, context_init)
+            .map_err(map_gpu3d_err)
+    }
+
+    fn ctx_destroy(&mut self, ctx_id: u32) -> Result<(), DisplayError> {
+        self.raw.ctx_destroy(ctx_id).map_err(map_gpu3d_err)
+    }
+
+    fn ctx_attach_resource(&mut self, ctx_id: u32, resource_id: u32) -> Result<(), DisplayError> {
+        self.raw
+            .ctx_attach_resource(ctx_id, resource_id)
+            .map_err(map_gpu3d_err)
+    }
+
+    fn ctx_detach_resource(&mut self, ctx_id: u32, resource_id: u32) -> Result<(), DisplayError> {
+        self.raw
+            .ctx_detach_resource(ctx_id, resource_id)
+            .map_err(map_gpu3d_err)
+    }
+
+    fn resource_create_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        target: u32,
+        format: u32,
+        bind: u32,
+        width: u32,
+        height: u32,
+        depth: u32,
+        array_size: u32,
+        last_level: u32,
+        nr_samples: u32,
+        flags: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .resource_create_3d(
+                ctx_id,
+                resource_id,
+                target,
+                format,
+                bind,
+                width,
+                height,
+                depth,
+                array_size,
+                last_level,
+                nr_samples,
+                flags,
+            )
+            .map_err(map_gpu3d_err)
+    }
+
+    fn resource_unref(&mut self, resource_id: u32) -> Result<(), DisplayError> {
+        self.raw.resource_unref(resource_id).map_err(map_gpu3d_err)
+    }
+
+    fn resource_create_blob(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        blob_mem: u32,
+        blob_flags: u32,
+        size: u64,
+        blob_id: u64,
+        cmd: &[u8],
+    ) -> Result<(), DisplayError> {
+        // Linux order (`virtio_gpu_resource_create_blob_ioctl`, virtgpu_ioctl.c):
+        // submit the virgl cmd stream first, then send RESOURCE_CREATE_BLOB —
+        // both go on the same virtqueue and execute in order on the host.
+        if !cmd.is_empty() {
+            self.submit_cmd(ctx_id, cmd)?;
+        }
+        // Guest backing (mem_entries) is handled by the caller at the DRM
+        // layer; the HOST3D blobs used by the present path carry none.
+        // SAFETY: HOST3D path passes an empty `mem_entries` slice, so the
+        // device is not given any guest memory range to read/write; the
+        // contract (valid, allocated, non-aliased backing covering `size`)
+        // is trivially satisfied. Guest-backed blobs are created by the DRM
+        // layer, which owns their backing.
+        unsafe {
+            self.raw.resource_create_blob(
+                ctx_id,
+                resource_id,
+                blob_mem,
+                blob_flags,
+                size,
+                blob_id,
+                &[],
+            )
+        }
+        .map_err(map_gpu3d_err)
+    }
+
+    fn transfer_to_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: TransferBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .transfer_to_host_3d(
+                ctx_id,
+                resource_id,
+                GpuBox {
+                    x: box_.x,
+                    y: box_.y,
+                    z: box_.z,
+                    w: box_.w,
+                    h: box_.h,
+                    d: box_.d,
+                },
+                offset,
+                level,
+                stride,
+                layer_stride,
+            )
+            .map_err(map_gpu3d_err)
+    }
+
+    fn transfer_from_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: TransferBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> Result<(), DisplayError> {
+        self.raw
+            .transfer_from_host_3d(
+                ctx_id,
+                resource_id,
+                GpuBox {
+                    x: box_.x,
+                    y: box_.y,
+                    z: box_.z,
+                    w: box_.w,
+                    h: box_.h,
+                    d: box_.d,
+                },
+                offset,
+                level,
+                stride,
+                layer_stride,
+            )
+            .map_err(map_gpu3d_err)
+    }
+
+    fn submit_cmd(&mut self, ctx_id: u32, cmds: &[u8]) -> Result<u64, DisplayError> {
+        let fence_id = self.next_fence_id;
+        self.next_fence_id = self.next_fence_id.wrapping_add(1).max(1);
+        self.raw
+            .submit_3d(ctx_id, fence_id, cmds)
+            .map_err(map_gpu3d_err)?;
+        Ok(fence_id)
+    }
+
+    fn get_capset_info(&mut self, index: u32) -> Result<CapsetInfo, DisplayError> {
+        let resp = self.raw.get_capset_info(index).map_err(map_gpu3d_err)?;
+        Ok(CapsetInfo {
+            capset_id: resp.capset_id,
+            max_version: resp.capset_max_version,
+            max_size: resp.capset_max_size,
+        })
+    }
+
+    fn get_capset(
+        &mut self,
+        id: u32,
+        ver: u32,
+        size: u32,
+    ) -> Result<alloc::vec::Vec<u8>, DisplayError> {
+        self.raw.get_capset(id, ver, size).map_err(map_gpu3d_err)
+    }
 }
 
 fn display_irq_event(irq_enabled: bool, status: InterruptStatus) -> Event {
@@ -150,6 +442,18 @@ fn map_display_err(err: VirtIoError) -> DisplayError {
         VirtIoError::NotReady => DisplayError::NotAvailable,
         _ => DisplayError::Other(alloc::boxed::Box::new(err)),
     }
+}
+
+fn map_gpu3d_err(err: VirtIoError) -> DisplayError {
+    use rdif_display::Gpu3dErrorKind;
+    let kind = match err {
+        VirtIoError::IoError => Gpu3dErrorKind::IoError,
+        VirtIoError::Unsupported => Gpu3dErrorKind::Unsupported,
+        VirtIoError::NotReady => Gpu3dErrorKind::NotReady,
+        VirtIoError::InvalidParam => Gpu3dErrorKind::InvalidParam,
+        _ => Gpu3dErrorKind::Other,
+    };
+    DisplayError::Gpu3dError(kind)
 }
 
 #[cfg(test)]

--- a/drivers/ax-driver/src/virtio/display.rs
+++ b/drivers/ax-driver/src/virtio/display.rs
@@ -134,6 +134,10 @@ impl<T: Transport + 'static> rdif_display::Interface for VirtIoDisplay<T> {
 
     fn handle_irq(&mut self) -> Event {
         let status = self.raw.ack_interrupt();
+        // Drain the control queue's used ring: async EXECBUFFERs are fire-and-forget, so a
+        // completion IRQ is the prompt signal that their descriptors can be recycled and the
+        // queue can make room for the next batch (Linux `virtio_gpu_dequeue_ctrl_func`).
+        let _ = self.raw.pump_completions();
         display_irq_event(self.irq_enabled, status)
     }
 
@@ -407,6 +411,20 @@ impl<T: Transport + 'static> rdif_display::Interface for VirtIoDisplay<T> {
         Ok(fence_id)
     }
 
+    fn wait_fence(&mut self, fence_id: u64) -> Result<(), DisplayError> {
+        self.raw.wait_fence(fence_id).map_err(map_gpu3d_err)
+    }
+
+    fn fence_completed(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
+        // Drain the used ring before answering: the device's completion
+        // interrupt is not delivered in every environment (this virtio-vga
+        // guest never receives one), so the completion level only advances
+        // when some caller pumps. Every fence query pumping keeps a
+        // poll-blocked waiter's refresher able to observe completion.
+        self.raw.pump_completions().map_err(map_gpu3d_err)?;
+        Ok(self.raw.fence_completed(fence_id))
+    }
+
     fn get_capset_info(&mut self, index: u32) -> Result<CapsetInfo, DisplayError> {
         let resp = self.raw.get_capset_info(index).map_err(map_gpu3d_err)?;
         Ok(CapsetInfo {
@@ -423,6 +441,10 @@ impl<T: Transport + 'static> rdif_display::Interface for VirtIoDisplay<T> {
         size: u32,
     ) -> Result<alloc::vec::Vec<u8>, DisplayError> {
         self.raw.get_capset(id, ver, size).map_err(map_gpu3d_err)
+    }
+
+    fn ctrl_notify(&mut self) {
+        self.raw.ctrl_notify();
     }
 }
 

--- a/drivers/ax-driver/src/virtio/mod.rs
+++ b/drivers/ax-driver/src/virtio/mod.rs
@@ -63,7 +63,11 @@ pub const fn has_static_mmio_drivers() -> bool {
 }
 
 unsafe impl VirtIoHal for VirtIoHalImpl {
-    fn dma_alloc(pages: usize, _direction: BufferDirection) -> (VirtIoPhysAddr, NonNull<u8>) {
+    fn dma_alloc(
+        pages: usize,
+        _direction: BufferDirection,
+        _access_platform: bool,
+    ) -> (VirtIoPhysAddr, NonNull<u8>) {
         let Ok(vaddr) = global_allocator().alloc_pages(pages, 0x1000, UsageKind::Dma) else {
             return (0, NonNull::dangling());
         };
@@ -75,7 +79,12 @@ unsafe impl VirtIoHal for VirtIoHalImpl {
         (paddr, ptr)
     }
 
-    unsafe fn dma_dealloc(_paddr: VirtIoPhysAddr, vaddr: NonNull<u8>, pages: usize) -> i32 {
+    unsafe fn dma_dealloc(
+        _paddr: VirtIoPhysAddr,
+        vaddr: NonNull<u8>,
+        pages: usize,
+        _access_platform: bool,
+    ) -> i32 {
         global_allocator().dealloc_pages(vaddr.as_ptr() as usize, pages, UsageKind::Dma);
         0
     }
@@ -86,12 +95,21 @@ unsafe impl VirtIoHal for VirtIoHalImpl {
             .expect("failed to map VirtIO MMIO")
     }
 
-    unsafe fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> VirtIoPhysAddr {
+    unsafe fn share(
+        buffer: NonNull<[u8]>,
+        _direction: BufferDirection,
+        _access_platform: bool,
+    ) -> VirtIoPhysAddr {
         let vaddr = buffer.as_ptr() as *mut u8 as usize;
         axklib::mem::virt_to_phys(vaddr.into()).as_usize() as VirtIoPhysAddr
     }
 
-    unsafe fn unshare(_paddr: VirtIoPhysAddr, _buffer: NonNull<[u8]>, _direction: BufferDirection) {
+    unsafe fn unshare(
+        _paddr: VirtIoPhysAddr,
+        _buffer: NonNull<[u8]>,
+        _direction: BufferDirection,
+        _access_platform: bool,
+    ) {
     }
 }
 

--- a/drivers/interface/rdif-display/src/error.rs
+++ b/drivers/interface/rdif-display/src/error.rs
@@ -2,6 +2,16 @@ use alloc::boxed::Box;
 
 use crate::io;
 
+/// Specific error kinds for 3D GPU operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Gpu3dErrorKind {
+    IoError,
+    Unsupported,
+    NotReady,
+    InvalidParam,
+    Other,
+}
+
 #[derive(thiserror::Error, Debug)]
 pub enum DisplayError {
     #[error("operation not supported")]
@@ -10,6 +20,8 @@ pub enum DisplayError {
     NotAvailable,
     #[error("invalid framebuffer")]
     InvalidFramebuffer,
+    #[error("GPU 3D error: {0:?}")]
+    Gpu3dError(Gpu3dErrorKind),
     #[error("other error: {0}")]
     Other(Box<dyn core::error::Error>),
 }
@@ -20,6 +32,7 @@ impl From<DisplayError> for io::ErrorKind {
             DisplayError::NotSupported => io::ErrorKind::Unsupported,
             DisplayError::NotAvailable => io::ErrorKind::NotAvailable,
             DisplayError::InvalidFramebuffer => io::ErrorKind::InvalidData,
+            e @ DisplayError::Gpu3dError(_) => io::ErrorKind::Other(Box::new(e)),
             DisplayError::Other(error) => io::ErrorKind::Other(error),
         }
     }

--- a/drivers/interface/rdif-display/src/interface.rs
+++ b/drivers/interface/rdif-display/src/interface.rs
@@ -1,4 +1,4 @@
-use crate::{DisplayError, DisplayInfo, DriverGeneric, FrameBuffer};
+use crate::{CapsetInfo, DisplayError, DisplayInfo, DriverGeneric, FrameBuffer, TransferBox};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Event {
@@ -16,6 +16,8 @@ impl Event {
 }
 
 pub trait Interface: DriverGeneric {
+    // --- 2D methods ---
+
     fn info(&self) -> DisplayInfo;
 
     fn framebuffer(&mut self) -> Result<FrameBuffer<'_>, DisplayError>;
@@ -42,5 +44,227 @@ pub trait Interface: DriverGeneric {
 
     fn handle_irq(&mut self) -> Event {
         Event::none()
+    }
+
+    // --- 2D resource / scanout primitives (default: unsupported) ---
+
+    /// Create a 2D resource with the given dimensions on the host.
+    ///
+    /// Maps to `VIRTIO_GPU_CMD_RESOURCE_CREATE_2D`. After creation, call
+    /// [`resource_attach_backing`] to bind guest memory, then
+    /// [`set_scanout`] to make it the display output.
+    fn resource_create_2d(
+        &mut self,
+        _resource_id: u32,
+        _width: u32,
+        _height: u32,
+    ) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Attach guest memory backing to a resource.
+    ///
+    /// Maps to `VIRTIO_GPU_CMD_RESOURCE_ATTACH_BACKING`. This tells the
+    /// host where the resource's guest-physical pages are so that
+    /// `TRANSFER_TO_HOST_2D` / `TRANSFER_FROM_HOST_3D` can move data
+    /// between guest RAM and the host resource.
+    fn resource_attach_backing(
+        &mut self,
+        _resource_id: u32,
+        _paddr: u64,
+        _length: u32,
+    ) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Bind a resource as the scanout (display output) for a given scanout ID.
+    ///
+    /// Maps to `VIRTIO_GPU_CMD_SET_SCANOUT`. Used for zero-copy display:
+    /// a render target can be directly set as the scanout so the host
+    /// displays it without a guest-side memcpy.
+    fn set_scanout(
+        &mut self,
+        _scanout_id: u32,
+        _resource_id: u32,
+        _x: u32,
+        _y: u32,
+        _w: u32,
+        _h: u32,
+    ) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Transfer a rectangular region of a 2D resource from guest to host.
+    ///
+    /// Maps to `VIRTIO_GPU_CMD_TRANSFER_TO_HOST_2D`. This makes the host
+    /// aware of guest-written pixel data before a [`resource_flush`].
+    fn transfer_to_host_2d(
+        &mut self,
+        _resource_id: u32,
+        _x: u32,
+        _y: u32,
+        _w: u32,
+        _h: u32,
+    ) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Flush a rectangular region of a resource to the display.
+    ///
+    /// Maps to `VIRTIO_GPU_CMD_RESOURCE_FLUSH`. After rendering into a
+    /// resource and optionally binding it with [`set_scanout`], call
+    /// this to make the host display the contents.
+    fn resource_flush(
+        &mut self,
+        _resource_id: u32,
+        _x: u32,
+        _y: u32,
+        _w: u32,
+        _h: u32,
+    ) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    // --- 3D methods (default: unsupported) ---
+
+    /// Returns `true` if the device negotiated virgl 3D support.
+    fn has_virgl(&self) -> bool {
+        false
+    }
+
+    /// Returns `true` if `VIRTIO_GPU_F_RESOURCE_BLOB` was negotiated.
+    ///
+    /// Mesa decides whether to use the blob resource path from the
+    /// `VIRTGPU_PARAM_RESOURCE_BLOB` GETPARAM value, which the kernel must
+    /// report from this actual negotiation (Linux: `has_resource_blob`).
+    fn has_resource_blob(&self) -> bool {
+        false
+    }
+
+    /// Create a 3D rendering context.
+    fn ctx_create(&mut self, _ctx_id: u32, _name: &str, _context_init: u32) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Destroy a 3D rendering context.
+    fn ctx_destroy(&mut self, _ctx_id: u32) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Attach a 3D resource to a rendering context.
+    ///
+    /// A resource must be attached to a context before the context can use it
+    /// for rendering commands. The resource must have been created first via
+    /// [`resource_create_3d`].
+    fn ctx_attach_resource(&mut self, _ctx_id: u32, _resource_id: u32) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Detach a 3D resource from a rendering context.
+    ///
+    /// Must be called before destroying a context if the context has attached
+    /// resources. The host may not reclaim the resource until all contexts
+    /// have detached it.
+    fn ctx_detach_resource(&mut self, _ctx_id: u32, _resource_id: u32) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Create a 3D resource (texture, render target, buffer, etc.).
+    ///
+    /// The caller must explicitly call [`ctx_attach_resource`] after creation
+    /// before using the resource in rendering commands.
+    fn resource_create_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        target: u32,
+        format: u32,
+        bind: u32,
+        width: u32,
+        height: u32,
+        depth: u32,
+        array_size: u32,
+        last_level: u32,
+        nr_samples: u32,
+        flags: u32,
+    ) -> Result<(), DisplayError> {
+        let _ = (ctx_id, resource_id, target, format, bind, width, height, depth,
+                 array_size, last_level, nr_samples, flags);
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Unreference (release) a 3D resource.
+    fn resource_unref(&mut self, _resource_id: u32) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Create a blob resource (host-visible memory / dma-buf sharing).
+    ///
+    /// Maps to the Linux `virtio_gpu_resource_create_blob_ioctl`
+    /// (`virtgpu_ioctl.c`). `blob_mem` is `VIRTIO_GPU_BLOB_MEM_GUEST (0x1)`,
+    /// `HOST3D (0x2)` or `HOST3D_GUEST (0x3)`; `blob_flags` is the
+    /// `VIRTIO_GPU_BLOB_FLAG_*` set.
+    ///
+    /// `cmd` is the virgl command stream for the blob's initial state (may be
+    /// empty). To match Linux ordering, the implementation must submit `cmd`
+    /// to the context *before* sending RESOURCE_CREATE_BLOB — both go on the
+    /// same virtqueue in order. For HOST3D blobs `cmd` must be dword-aligned
+    /// in size; for GUEST blobs it must be empty.
+    fn resource_create_blob(
+        &mut self,
+        _ctx_id: u32,
+        _resource_id: u32,
+        _blob_mem: u32,
+        _blob_flags: u32,
+        _size: u64,
+        _blob_id: u64,
+        _cmd: &[u8],
+    ) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Transfer data from guest to host for a 3D resource.
+    fn transfer_to_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: TransferBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> Result<(), DisplayError> {
+        let _ = (ctx_id, resource_id, box_, offset, level, stride, layer_stride);
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Transfer data from host to guest for a 3D resource.
+    fn transfer_from_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: TransferBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> Result<(), DisplayError> {
+        let _ = (ctx_id, resource_id, box_, offset, level, stride, layer_stride);
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Submit a virgl command buffer. Returns a monotonically increasing fence ID.
+    fn submit_cmd(&mut self, _ctx_id: u32, _cmds: &[u8]) -> Result<u64, DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Query capset information by index.
+    fn get_capset_info(&mut self, _index: u32) -> Result<CapsetInfo, DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Retrieve capset data.
+    fn get_capset(&mut self, _id: u32, _ver: u32, _size: u32) -> Result<alloc::vec::Vec<u8>, DisplayError> {
+        Err(DisplayError::NotSupported)
     }
 }

--- a/drivers/interface/rdif-display/src/interface.rs
+++ b/drivers/interface/rdif-display/src/interface.rs
@@ -142,7 +142,12 @@ pub trait Interface: DriverGeneric {
     }
 
     /// Create a 3D rendering context.
-    fn ctx_create(&mut self, _ctx_id: u32, _name: &str, _context_init: u32) -> Result<(), DisplayError> {
+    fn ctx_create(
+        &mut self,
+        _ctx_id: u32,
+        _name: &str,
+        _context_init: u32,
+    ) -> Result<(), DisplayError> {
         Err(DisplayError::NotSupported)
     }
 
@@ -188,8 +193,20 @@ pub trait Interface: DriverGeneric {
         nr_samples: u32,
         flags: u32,
     ) -> Result<(), DisplayError> {
-        let _ = (ctx_id, resource_id, target, format, bind, width, height, depth,
-                 array_size, last_level, nr_samples, flags);
+        let _ = (
+            ctx_id,
+            resource_id,
+            target,
+            format,
+            bind,
+            width,
+            height,
+            depth,
+            array_size,
+            last_level,
+            nr_samples,
+            flags,
+        );
         Err(DisplayError::NotSupported)
     }
 
@@ -234,7 +251,15 @@ pub trait Interface: DriverGeneric {
         stride: u32,
         layer_stride: u32,
     ) -> Result<(), DisplayError> {
-        let _ = (ctx_id, resource_id, box_, offset, level, stride, layer_stride);
+        let _ = (
+            ctx_id,
+            resource_id,
+            box_,
+            offset,
+            level,
+            stride,
+            layer_stride,
+        );
         Err(DisplayError::NotSupported)
     }
 
@@ -249,12 +274,35 @@ pub trait Interface: DriverGeneric {
         stride: u32,
         layer_stride: u32,
     ) -> Result<(), DisplayError> {
-        let _ = (ctx_id, resource_id, box_, offset, level, stride, layer_stride);
+        let _ = (
+            ctx_id,
+            resource_id,
+            box_,
+            offset,
+            level,
+            stride,
+            layer_stride,
+        );
         Err(DisplayError::NotSupported)
     }
 
     /// Submit a virgl command buffer. Returns a monotonically increasing fence ID.
     fn submit_cmd(&mut self, _ctx_id: u32, _cmds: &[u8]) -> Result<u64, DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Block until the submit identified by `fence_id` (and everything enqueued
+    /// before it) has completed on the host — the honest completion signal
+    /// behind Linux `virtio_gpu_wait_ioctl` (`dma_resv_wait_timeout`).
+    /// The fence ID comes from [`Interface::submit_cmd`].
+    fn wait_fence(&mut self, _fence_id: u64) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Non-blocking fence query: has `fence_id` already completed on the host?
+    /// `false` means the host is still busy with the batch — Linux
+    /// `dma_resv_test_signaled` (the NOWAIT probe in `virtio_gpu_wait_ioctl`).
+    fn fence_completed(&mut self, _fence_id: u64) -> Result<bool, DisplayError> {
         Err(DisplayError::NotSupported)
     }
 
@@ -264,7 +312,20 @@ pub trait Interface: DriverGeneric {
     }
 
     /// Retrieve capset data.
-    fn get_capset(&mut self, _id: u32, _ver: u32, _size: u32) -> Result<alloc::vec::Vec<u8>, DisplayError> {
+    fn get_capset(
+        &mut self,
+        _id: u32,
+        _ver: u32,
+        _size: u32,
+    ) -> Result<alloc::vec::Vec<u8>, DisplayError> {
         Err(DisplayError::NotSupported)
     }
+
+    /// Flush any pending control-queue commands and notify the host — an
+    /// ioctl/transaction boundary (Linux `virtio_gpu_notify()`, vq.c:551).
+    ///
+    /// Drivers that coalesce fire-and-forget control commands must deliver
+    /// them with exactly one notify per transaction; call this once at the end
+    /// of each ioctl that enqueued such commands. Default: no-op.
+    fn ctrl_notify(&mut self) {}
 }

--- a/drivers/interface/rdif-display/src/interface.rs
+++ b/drivers/interface/rdif-display/src/interface.rs
@@ -299,11 +299,36 @@ pub trait Interface: DriverGeneric {
         Err(DisplayError::NotSupported)
     }
 
+    /// Drain the completion queue (used ring) without blocking and without
+    /// waiting for any specific fence.
+    ///
+    /// Called after fire-and-forget submits (EXECBUFFER/present) so the host's
+    /// per-command completions are observed promptly: pumping advances the
+    /// completion level and refreshes the device's notification watermark, so
+    /// the next completion triggers the device IRQ immediately instead of
+    /// being batched until a later pump (which delayed fence signaling by up
+    /// to one frame — ~1.5ms on-screen, run54: ppoll avg 1465µs ≈ IRQ
+    /// interval). Linux's virtio-gpu pumps in its completion worker after every
+    /// IRQ, keeping per-command signal latency at µs.
+    fn pump(&mut self) -> Result<(), DisplayError> {
+        Ok(())
+    }
+
     /// Non-blocking fence query: has `fence_id` already completed on the host?
     /// `false` means the host is still busy with the batch — Linux
     /// `dma_resv_test_signaled` (the NOWAIT probe in `virtio_gpu_wait_ioctl`).
     fn fence_completed(&mut self, _fence_id: u64) -> Result<bool, DisplayError> {
         Err(DisplayError::NotSupported)
+    }
+
+    /// Completion-level-only fence query, **without** draining the used ring.
+    ///
+    /// For IRQ handlers that have already pumped (the display completion IRQ
+    /// drains the ring before waking waiters): re-pumping per registered fence
+    /// would double the per-IRQ cost. Defaults to the pumping variant so a
+    /// backend without an IRQ path stays correct.
+    fn fence_completed_no_pump(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
+        self.fence_completed(fence_id)
     }
 
     /// Query capset information by index.

--- a/drivers/interface/rdif-display/src/types.rs
+++ b/drivers/interface/rdif-display/src/types.rs
@@ -60,3 +60,22 @@ impl DerefMut for FrameBuffer<'_> {
         self.raw
     }
 }
+
+/// 3D box region for data transfer operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransferBox {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+    pub w: u32,
+    pub h: u32,
+    pub d: u32,
+}
+
+/// Capset information returned by [`Interface::get_capset_info`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapsetInfo {
+    pub capset_id: u32,
+    pub max_version: u32,
+    pub max_size: u32,
+}

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -751,7 +751,15 @@ pub fn wake_net_task_irq() {
 }
 
 fn next_poll_delay() -> Duration {
-    const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(100);
+    // Cadence when no socket has a pending smoltcp timer (`next_poll_at`
+    // returned None) — i.e. nothing but the device-poll fallback (`wake_all_devices`
+    // on timeout) has anything to do. Socket timer deadlines schedule their own
+    // precise polls; the device IRQ path (`wake_net_task_irq`) also bypasses
+    // this interval, so a coarse fallback only trades worst-case pickup
+    // latency in no-IRQ environments against idle scheduler wakes (at 100 ms
+    // it fanned out to every rx worker 10x/s while the graphics stack is
+    // latency-sensitive on the ready queue).
+    const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(1000);
     let next = {
         let mut service = get_service();
         let sockets = SOCKET_SET.inner.lock();

--- a/net/ax-net/src/router.rs
+++ b/net/ax-net/src/router.rs
@@ -73,7 +73,15 @@ use crate::{
 };
 
 const DEVICE_RX_WORKER_BATCH: usize = 16;
-const DEVICE_RX_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(10);
+/// Idle RX poll cadence. Event-driven wakeup is primary: the device IRQ
+/// notifies net-poll (`wake_net_task_irq`), net-poll fans out
+/// `wake_all_devices`, and each device's poll registration fires its rx
+/// waker. This interval only bounds worst-case pickup latency when every
+/// event path is missed, so it stays coarse — a 10 ms poll here cost 100 Hz
+/// of scheduler wakes per device (plus a `request_poll` wake of net-poll per
+/// iteration) while the graphics stack is latency-sensitive on the ready
+/// queue.
+const DEVICE_RX_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(1000);
 
 /// Per-interface cumulative RX/TX byte and packet counters.
 ///
@@ -1355,9 +1363,12 @@ mod tests {
     }
 
     #[test]
-    fn rx_worker_idle_poll_interval_keeps_polling_devices_active() {
+    fn rx_worker_idle_poll_interval_bounds_idle_latency() {
+        // Event-driven wakeup is primary; the interval only bounds worst-case
+        // pickup latency if every event path is missed, so it must exist and
+        // stay within the coarse backoff budget.
         assert!(DEVICE_RX_IDLE_POLL_INTERVAL > core::time::Duration::ZERO);
-        assert!(DEVICE_RX_IDLE_POLL_INTERVAL <= core::time::Duration::from_millis(10));
+        assert!(DEVICE_RX_IDLE_POLL_INTERVAL <= core::time::Duration::from_millis(1000));
     }
 
     #[test]

--- a/net/ax-net/src/unix/mod.rs
+++ b/net/ax-net/src/unix/mod.rs
@@ -38,6 +38,12 @@ pub use self::{
     namespace::{UnixNamespace, register_unix_namespace},
     stream::StreamTransport,
 };
+
+/// [run6g] monotonic ns of the last unix-stream send that woke the peer's
+/// pollers (see `stream::LAST_PEER_WAKE_NS`).
+pub fn last_peer_wake_ns() -> u64 {
+    stream::LAST_PEER_WAKE_NS.load(core::sync::atomic::Ordering::Relaxed)
+}
 use crate::{
     NetError, NetResult, RecvOptions, SendOptions, Shutdown, Socket, SocketAddrEx, SocketOps,
     options::{Configurable, GetSocketOption, SetSocketOption},

--- a/net/ax-net/src/unix/stream.rs
+++ b/net/ax-net/src/unix/stream.rs
@@ -42,6 +42,10 @@ use crate::{
 
 const BUF_SIZE: usize = 64 * 1024;
 
+/// [run6g] monotonic ns of the last unix-stream send that woke the peer's
+/// pollers. StarryOS `do_poll` measures wake-to-return latency against this.
+pub static LAST_PEER_WAKE_NS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
 /// One pending cmsg batch carried across a Unix stream socketpair.
 ///
 /// `start_byte` is the 1-based cumulative tx-byte offset of the first
@@ -497,6 +501,13 @@ impl TransportOps for StreamTransport {
             if let Some(poll) = wake_poll {
                 // Peer-visible bytes and cmsg state are published before wake.
                 unsafe { poll.wake(IoEvents::IN | IoEvents::OUT) };
+                // [run6g] poll-wakeup-latency forensics: the receiver's blocked
+                // ppoll should return within µs of this wake. StarryOS do_poll
+                // buckets (return_ts - this) to find where the ~1.9ms goes.
+                LAST_PEER_WAKE_NS.store(
+                    ax_hal::time::monotonic_time_nanos() as u64,
+                    core::sync::atomic::Ordering::Relaxed,
+                );
             }
             result
         })

--- a/os/StarryOS/kernel/src/file/epoll.rs
+++ b/os/StarryOS/kernel/src/file/epoll.rs
@@ -177,6 +177,15 @@ struct EpollInterest {
     exclusive: bool,
     in_ready_queue: AtomicBool,
     owner_repoll_pending: AtomicBool,
+    /// One persistent waker per interest, created on first use. Per-wait
+    /// registration reuses this same waker, so replacing a per-file PollSet
+    /// slot (ring mode, POLL_SET_CAPACITY) hits the `will_wake` fast path and
+    /// does not wake the replaced entry. A fresh waker per register used to
+    /// wake the replaced (stale) waker, which re-enqueued the interest with no
+    /// real I/O event — every epoll_wait then drained all interests
+    /// (measured: ~13 stale drains, 96.5% NoEvent, 100-500us of wasted
+    /// kernel time before parking, ~470 FPS).
+    cached_waker: IrqMutex<Option<Waker>>,
 }
 
 impl EpollInterest {
@@ -200,7 +209,22 @@ impl EpollInterest {
             exclusive: flags.contains(EpollFlags::EXCLUSIVE),
             in_ready_queue: AtomicBool::new(false),
             owner_repoll_pending: AtomicBool::new(false),
+            cached_waker: IrqMutex::new(None),
         }
+    }
+
+    /// Returns the interest's one persistent waker, creating it on first use.
+    fn cached_waker(self: &Arc<Self>, epoll: &Arc<EpollInner>) -> Waker {
+        let mut g = self.cached_waker.lock();
+        if let Some(w) = g.as_ref() {
+            return w.clone();
+        }
+        let w = Waker::from(Arc::new(InterestWaker {
+            epoll: Arc::downgrade(epoll),
+            interest: Arc::downgrade(self),
+        }));
+        *g = Some(w.clone());
+        w
     }
 
     #[inline]
@@ -397,10 +421,7 @@ impl EpollInner {
             return;
         }
 
-        let waker = Waker::from(Arc::new(InterestWaker {
-            epoll: Arc::downgrade(self),
-            interest: Arc::downgrade(interest),
-        }));
+        let waker = interest.cached_waker(self);
         let mut context = Context::from_waker(&waker);
         file.register(&mut context, register_events(interest.event.events));
     }
@@ -650,10 +671,7 @@ impl Epoll {
             return;
         }
 
-        let waker = Waker::from(Arc::new(InterestWaker {
-            epoll: Arc::downgrade(&self.inner),
-            interest: Arc::downgrade(interest),
-        }));
+        let waker = interest.cached_waker(&self.inner);
 
         let mut context = Context::from_waker(&waker);
         file.register(&mut context, register_events(interest.event.events));
@@ -690,10 +708,7 @@ impl Epoll {
             return;
         }
 
-        let waker = Waker::from(Arc::new(InterestWaker {
-            epoll: Arc::downgrade(&self.inner),
-            interest: Arc::downgrade(interest),
-        }));
+        let waker = interest.cached_waker(&self.inner);
 
         let current = match_ready_events(file.poll(), interest.event.events);
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -1019,6 +1019,12 @@ fn perf_report(card: &Card0) {
             wrl[0], wrl[1], wrl[2], wrl[3], wrl[4], wrl[5],
         );
     }
+    // ---- fence refresher wake-ups per window (gated tick: ~20/s idle,
+    // ~1ms service only while a guest is poll-blocked on an out-fence). ----
+    let frt = super::sync_file::REFRESH_TICKS.load(Ordering::Relaxed);
+    if frt > 0 {
+        warn!("  [card0:fx] fence-refresh ticks n={frt}");
+    }
     if RING_DUMPED.load(Ordering::Relaxed) < RING_DUMP_LIMIT {
         let nonw = RING_LAST_EXECB_NONW.load(Ordering::Relaxed);
         let last_execb = if nonw != usize::MAX {
@@ -1137,6 +1143,7 @@ fn perf_report(card: &Card0) {
     }
     crate::syscall::POLL_WAKE_LAT_CNT.store(0, Ordering::Relaxed);
     ax_task::wake_run_lat_reset();
+    super::sync_file::REFRESH_TICKS.store(0, Ordering::Relaxed);
     RC_ALLOC_SUM.store(0, Ordering::Relaxed);
     RC_ALLOC_CNT.store(0, Ordering::Relaxed);
     RC_PAGE_SUM.store(0, Ordering::Relaxed);

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -1668,6 +1668,16 @@ impl Pollable for Card0 {
             unsafe { self.poll_rx.register(context.waker(), IoEvents::IN) };
         }
     }
+
+    fn unregister(&self, waker: &core::task::Waker) {
+        // Poll/epoll return: drop this waiter's stale waker so flip-event
+        // wake_one always reaches the compositor's current drm poll instead of
+        // a leftover entry (leftovers starve the real waiter until its
+        // timeout — measured ~1.3ms flip delivery on-screen).
+        unsafe {
+            self.poll_rx.unregister(waker);
+        }
+    }
 }
 
 impl Card0 {

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -31,7 +31,7 @@
 
 use alloc::{
     borrow::Cow,
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     format,
     string::String,
     sync::{Arc, Weak},
@@ -40,7 +40,7 @@ use alloc::{
 };
 use core::{
     any::Any,
-    sync::atomic::{AtomicU32, AtomicU64, Ordering},
+    sync::atomic::{AtomicU32, AtomicU64, AtomicUsize, Ordering},
     task::Context,
 };
 
@@ -54,72 +54,168 @@ use bytemuck::bytes_of;
 use linux_raw_sys::general::O_CLOEXEC;
 use starry_vm::{VmMutPtr, VmPtr, vm_load, vm_write_slice};
 
-use crate::task::AsThread;
-
 use super::drm::{
-    DRM_CAP_ADDFB2_MODIFIERS, DRM_CAP_CRTC_IN_VBLANK_EVENT, DRM_CAP_DUMB_BUFFER, DRM_CAP_PRIME,
-    DRM_CAP_TIMESTAMP_MONOTONIC, DRM_EVENT_FLIP_COMPLETE, DRM_FORMAT_ARGB8888,
-    DRM_FORMAT_MOD_INVALID, DRM_FORMAT_MOD_LINEAR, DRM_FORMAT_XRGB8888, DRM_IOCTL_AUTH_MAGIC,
-    DRM_IOCTL_DROP_MASTER, DRM_IOCTL_GEM_CLOSE, DRM_IOCTL_GET_CAP, DRM_IOCTL_GET_MAGIC,
+    DRM_CAP_ADDFB2_MODIFIERS,
+    DRM_CAP_CRTC_IN_VBLANK_EVENT,
+    DRM_CAP_DUMB_BUFFER,
+    DRM_CAP_PRIME,
+    DRM_CAP_TIMESTAMP_MONOTONIC,
+    DRM_EVENT_FLIP_COMPLETE,
+    DRM_FORMAT_ARGB8888,
+    DRM_FORMAT_MOD_INVALID,
+    DRM_FORMAT_MOD_LINEAR,
+    DRM_FORMAT_XRGB8888,
+    DRM_IOCTL_AUTH_MAGIC,
+    DRM_IOCTL_DROP_MASTER,
+    DRM_IOCTL_GEM_CLOSE,
+    DRM_IOCTL_GET_CAP,
+    DRM_IOCTL_GET_MAGIC,
     DRM_IOCTL_GET_UNIQUE,
-    DRM_IOCTL_MODE_ADDFB2, DRM_IOCTL_MODE_ATOMIC, DRM_IOCTL_MODE_CREATE_DUMB,
-    DRM_IOCTL_MODE_CREATEPROPBLOB, DRM_IOCTL_MODE_DESTROY_DUMB, DRM_IOCTL_MODE_DESTROYPROPBLOB,
-    DRM_IOCTL_MODE_DIRTYFB, DRM_IOCTL_MODE_GETCONNECTOR, DRM_IOCTL_MODE_GETCRTC,
-    DRM_IOCTL_MODE_GETENCODER, DRM_IOCTL_MODE_GETPLANE, DRM_IOCTL_MODE_GETPLANERESOURCES,
-    DRM_IOCTL_MODE_GETPROPBLOB, DRM_IOCTL_MODE_GETPROPERTY, DRM_IOCTL_MODE_GETRESOURCES,
-    DRM_IOCTL_MODE_MAP_DUMB, DRM_IOCTL_MODE_OBJ_GETPROPERTIES, DRM_IOCTL_MODE_PAGE_FLIP,
-    DRM_IOCTL_MODE_RMFB, DRM_IOCTL_MODE_SETCRTC, DRM_IOCTL_PRIME_FD_TO_HANDLE,
-    DRM_IOCTL_PRIME_HANDLE_TO_FD, DRM_IOCTL_SET_CLIENT_CAP, DRM_IOCTL_SET_MASTER,
-    DRM_IOCTL_SET_VERSION, DRM_IOCTL_VERSION, DRM_IOCTL_WAIT_VBLANK, DRM_MODE_ATOMIC_ALLOW_MODESET,
-    DRM_MODE_ATOMIC_NONBLOCK, DRM_MODE_ATOMIC_TEST_ONLY, DRM_MODE_CONNECTED,
-    DRM_MODE_CONNECTOR_VIRTUAL, DRM_MODE_ENCODER_VIRTUAL, DRM_MODE_FB_MODIFIERS,
-    DRM_MODE_OBJECT_CONNECTOR, DRM_MODE_OBJECT_CRTC, DRM_MODE_OBJECT_PLANE,
-    DRM_MODE_PAGE_FLIP_EVENT, DRM_MODE_PROP_ATOMIC, DRM_MODE_PROP_BLOB, DRM_MODE_PROP_ENUM,
-    DRM_MODE_PROP_IMMUTABLE, DRM_MODE_PROP_OBJECT, DRM_MODE_PROP_RANGE, DRM_PLANE_TYPE_PRIMARY,
-    DRM_PRIME_CAP_EXPORT, DRM_PRIME_CAP_IMPORT, DRM_PROP_NAME_LEN, DrmAuth, DrmEvent,
-    DrmEventVblank, DrmGetCap, DrmModeAtomic, DrmModeCardRes, DrmModeCreateBlob, DrmModeCreateDumb,
-    DrmModeCrtc, DrmModeCrtcPageFlip, DrmModeDestroyBlob, DrmModeDestroyDumb, DrmModeDirtyFB,
-    DrmModeFbCmd2, DrmGemClose, DrmModeGetBlob, DrmModeGetConnector, DrmModeGetEncoder,
-    DrmModeGetPlane,
-    DrmModeGetPlaneRes, DrmModeGetProperty, DrmModeMapDumb, DrmModeModeInfo,
-    DrmModeObjGetProperties, DrmModePropertyEnum, DrmPrimeHandle, DrmSetClientCap, DrmSetVersion,
-    DrmUnique, DrmVersion, DrmWaitVblank,
+    DRM_IOCTL_MODE_ADDFB2,
+    DRM_IOCTL_MODE_ATOMIC,
+    DRM_IOCTL_MODE_CREATE_DUMB,
+    DRM_IOCTL_MODE_CREATEPROPBLOB,
+    DRM_IOCTL_MODE_DESTROY_DUMB,
+    DRM_IOCTL_MODE_DESTROYPROPBLOB,
+    DRM_IOCTL_MODE_DIRTYFB,
+    DRM_IOCTL_MODE_GETCONNECTOR,
+    DRM_IOCTL_MODE_GETCRTC,
+    DRM_IOCTL_MODE_GETENCODER,
+    DRM_IOCTL_MODE_GETPLANE,
+    DRM_IOCTL_MODE_GETPLANERESOURCES,
+    DRM_IOCTL_MODE_GETPROPBLOB,
+    DRM_IOCTL_MODE_GETPROPERTY,
+    DRM_IOCTL_MODE_GETRESOURCES,
+    DRM_IOCTL_MODE_MAP_DUMB,
+    DRM_IOCTL_MODE_OBJ_GETPROPERTIES,
+    DRM_IOCTL_MODE_PAGE_FLIP,
+    DRM_IOCTL_MODE_RMFB,
+    DRM_IOCTL_MODE_SETCRTC,
+    DRM_IOCTL_PRIME_FD_TO_HANDLE,
+    DRM_IOCTL_PRIME_HANDLE_TO_FD,
+    DRM_IOCTL_SET_CLIENT_CAP,
+    DRM_IOCTL_SET_MASTER,
+    DRM_IOCTL_SET_VERSION,
+    DRM_IOCTL_VERSION,
     // virtgpu structs and constants
-    DRM_IOCTL_VIRTGPU_CONTEXT_INIT, DRM_IOCTL_VIRTGPU_EXECBUFFER,
-    DRM_IOCTL_VIRTGPU_GET_CAPS, DRM_IOCTL_VIRTGPU_GETPARAM, DRM_IOCTL_VIRTGPU_MAP,
-    DRM_IOCTL_VIRTGPU_RESOURCE_CREATE, DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB,
-    DRM_IOCTL_VIRTGPU_RESOURCE_INFO, DRM_IOCTL_VIRTGPU_TRANSFER_FROM_HOST,
-    DRM_IOCTL_VIRTGPU_TRANSFER_TO_HOST, DRM_IOCTL_VIRTGPU_WAIT,
-    DrmVirtgpu3dTransferFromHost, DrmVirtgpu3dTransferToHost,
-    DrmVirtgpu3dWait, DrmVirtgpuContextInit, DrmVirtgpuContextSetParam, DrmVirtgpuExecbuffer,
-    DrmVirtgpuGetCaps, DrmVirtgpuGetparam, DrmVirtgpuMap, DrmVirtgpuResourceCreate,
-    DrmVirtgpuResourceCreateBlob, DrmVirtgpuResourceInfo,
-    VIRTGPU_BLOB_MEM_GUEST, VIRTGPU_BLOB_MEM_HOST3D, VIRTGPU_BLOB_MEM_HOST3D_GUEST,
-    VIRTGPU_CONTEXT_PARAM_CAPSET_ID, VIRTGPU_CONTEXT_PARAM_NUM_RINGS,
+    DRM_IOCTL_VIRTGPU_CONTEXT_INIT,
+    DRM_IOCTL_VIRTGPU_EXECBUFFER,
+    DRM_IOCTL_VIRTGPU_GET_CAPS,
+    DRM_IOCTL_VIRTGPU_GETPARAM,
+    DRM_IOCTL_VIRTGPU_MAP,
+    DRM_IOCTL_VIRTGPU_RESOURCE_CREATE,
+    DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB,
+    DRM_IOCTL_VIRTGPU_RESOURCE_INFO,
+    DRM_IOCTL_VIRTGPU_TRANSFER_FROM_HOST,
+    DRM_IOCTL_VIRTGPU_TRANSFER_TO_HOST,
+    DRM_IOCTL_VIRTGPU_WAIT,
+    DRM_IOCTL_WAIT_VBLANK,
+    DRM_MODE_ATOMIC_ALLOW_MODESET,
+    DRM_MODE_ATOMIC_NONBLOCK,
+    DRM_MODE_ATOMIC_TEST_ONLY,
+    DRM_MODE_CONNECTED,
+    DRM_MODE_CONNECTOR_VIRTUAL,
+    DRM_MODE_ENCODER_VIRTUAL,
+    DRM_MODE_FB_MODIFIERS,
+    DRM_MODE_OBJECT_CONNECTOR,
+    DRM_MODE_OBJECT_CRTC,
+    DRM_MODE_OBJECT_PLANE,
+    DRM_MODE_PAGE_FLIP_EVENT,
+    DRM_MODE_PROP_ATOMIC,
+    DRM_MODE_PROP_BLOB,
+    DRM_MODE_PROP_ENUM,
+    DRM_MODE_PROP_IMMUTABLE,
+    DRM_MODE_PROP_OBJECT,
+    DRM_MODE_PROP_RANGE,
+    DRM_PLANE_TYPE_PRIMARY,
+    DRM_PRIME_CAP_EXPORT,
+    DRM_PRIME_CAP_IMPORT,
+    DRM_PROP_NAME_LEN,
+    DrmAuth,
+    DrmClipRect,
+    DrmEvent,
+    DrmEventVblank,
+    DrmGemClose,
+    DrmGetCap,
+    DrmModeAtomic,
+    DrmModeCardRes,
+    DrmModeCreateBlob,
+    DrmModeCreateDumb,
+    DrmModeCrtc,
+    DrmModeCrtcPageFlip,
+    DrmModeDestroyBlob,
+    DrmModeDestroyDumb,
+    DrmModeDirtyFB,
+    DrmModeFbCmd2,
+    DrmModeGetBlob,
+    DrmModeGetConnector,
+    DrmModeGetEncoder,
+    DrmModeGetPlane,
+    DrmModeGetPlaneRes,
+    DrmModeGetProperty,
+    DrmModeMapDumb,
+    DrmModeModeInfo,
+    DrmModeObjGetProperties,
+    DrmModePropertyEnum,
+    DrmPrimeHandle,
+    DrmSetClientCap,
+    DrmSetVersion,
+    DrmUnique,
+    DrmVersion,
+    DrmVirtgpu3dTransferFromHost,
+    DrmVirtgpu3dTransferToHost,
+    DrmVirtgpu3dWait,
+    DrmVirtgpuContextInit,
+    DrmVirtgpuContextSetParam,
+    DrmVirtgpuExecbuffer,
+    DrmVirtgpuGetCaps,
+    DrmVirtgpuGetparam,
+    DrmVirtgpuMap,
+    DrmVirtgpuResourceCreate,
+    DrmVirtgpuResourceCreateBlob,
+    DrmVirtgpuResourceInfo,
+    DrmWaitVblank,
+    VIRTGPU_BLOB_MEM_GUEST,
+    VIRTGPU_BLOB_MEM_HOST3D,
+    VIRTGPU_BLOB_MEM_HOST3D_GUEST,
+    VIRTGPU_CONTEXT_PARAM_CAPSET_ID,
+    VIRTGPU_CONTEXT_PARAM_NUM_RINGS,
     VIRTGPU_CONTEXT_PARAM_POLL_RINGS_MASK,
-    VIRTGPU_DRM_CAPSET_DRM, VIRTGPU_DRM_CAPSET_VIRGL, VIRTGPU_DRM_CAPSET_VIRGL2,
-    VIRTGPU_EXECBUF_FENCE_FD_IN, VIRTGPU_EXECBUF_FENCE_FD_OUT,
-    VIRTGPU_PARAM_3D_FEATURES, VIRTGPU_PARAM_CAPSET_QUERY_FIX,
-    VIRTGPU_PARAM_CONTEXT_INIT, VIRTGPU_PARAM_CROSS_DEVICE,
-    VIRTGPU_PARAM_HOST_VISIBLE, VIRTGPU_PARAM_RESOURCE_BLOB,
+    VIRTGPU_DRM_CAPSET_DRM,
+    VIRTGPU_DRM_CAPSET_VIRGL,
+    VIRTGPU_DRM_CAPSET_VIRGL2,
+    VIRTGPU_EXECBUF_FENCE_FD_IN,
+    VIRTGPU_EXECBUF_FENCE_FD_OUT,
+    VIRTGPU_PARAM_3D_FEATURES,
+    VIRTGPU_PARAM_CAPSET_QUERY_FIX,
+    VIRTGPU_PARAM_CONTEXT_INIT,
+    VIRTGPU_PARAM_CROSS_DEVICE,
+    VIRTGPU_PARAM_HOST_VISIBLE,
+    VIRTGPU_PARAM_RESOURCE_BLOB,
     VIRTGPU_PARAM_SUPPORTED_CAPSET_IDS,
+    VIRTGPU_WAIT_NOWAIT,
 };
+use super::sync_file::SyncFile;
 use crate::{
     StarryError, StarryResult,
-    file::{FileLike, add_file_like},
+    file::{FileLike, add_file_like, get_file_like},
     pseudofs::{DeviceMmap, DeviceOps},
     sync::Mutex,
+    task::AsThread,
 };
 
 pub const DRIVER_NAME: &str = "virtio_gpu";
 pub const DRIVER_DATE: &str = "2026-04-19";
 pub const DRIVER_DESC: &str = "StarryOS simple DRM driver";
-// Linux virtio-gpu 用 DRIVER_MAJOR=0 / DRIVER_MINOR=0。mesa 的
-// `virgl_drm_get_version`(virgl_drm_winsys.c)要求 `version_major == 0`
-// 否则返回 -EINVAL → virgl winsys 创建失败。minor 保持 0 让 mesa 走 legacy
-// fence 路径(card0 尚未实现 EXECBUFFER fence-fd)。
+// Linux virtio-gpu 的 `DRIVER_VERSION_MINOR = 1` 随
+// `VIRTGPU_EXECBUF_FENCE_FD` 引入即已 bump（virtgpu_drm.h `.minor = 1`）。
+// mesa 的 `virgl_drm_get_version`(virgl_drm_winsys.c)要求 `version_major == 0`
+// 否则返回 -EINVAL → virgl winsys 创建失败；并以
+// `drm_version >= VIRGL_DRM_VERSION_FENCE_FD (0,1)` 决定走 fd-based fence
+// 还是 legacy fence（后者每帧创建一个 8×1 占位资源 + WAIT + GEM_CLOSE）。
+// minor=1 与 Linux 稳定 ABI 对齐，让 mesa 走 fd fence 路径（见 sync_file.rs）。
 pub const DRIVER_VERSION_MAJOR: i32 = 0;
-pub const DRIVER_VERSION_MINOR: i32 = 0;
+pub const DRIVER_VERSION_MINOR: i32 = 1;
 pub const DRIVER_VERSION_PATCHLEVEL: i32 = 0;
 
 /// Fixed object IDs advertised by GETRESOURCES / GETCONNECTOR / GETENCODER.
@@ -270,6 +366,16 @@ struct Framebuffer {
     /// resources (`SET_SCANOUT`) — matching Linux, which always sets the
     /// resource itself as scanout.
     kind: FbBacking,
+    /// Pending damage region in framebuffer pixels, `Some((x, y, w, h))`.
+    ///
+    /// Set by [`Card::handle_dirty_fb`] from `DIRTY_FB` clips — the same
+    /// input Linux feeds into `drm_atomic_helper_damage_merged` — and
+    /// consumed by [`Card::present_fb`]: only that rect is
+    /// `TRANSFER_TO_HOST_2D`'d / flushed. `None` means full-framebuffer
+    /// damage, i.e. a present from a path that carries no clip data
+    /// (`SETCRTC`, `PAGE_FLIP`, atomic) degrades to uploading the whole fb —
+    /// Linux also falls back to the full plane when no damage clip arrives.
+    dirty: Option<(u32, u32, u32, u32)>,
 }
 
 /// Backing storage for a DRM framebuffer.
@@ -392,8 +498,15 @@ struct GpuResource {
     stride: u32,
     /// Resource size in bytes.
     size: u64,
-    /// Whether this resource has been attached to a context.
-    attached: bool,
+    /// Contexts this resource has already been attached to. Linux attaches a
+    /// resource once per GEM open (`virtio_gpu_gem_object_open` →
+    /// CTX_ATTACH_RESOURCE); mirroring that at (ctx, resource) granularity is
+    /// required because weston and the app hold separate contexts that share
+    /// the same scanout buffer. Previously a single `attached: bool` was
+    /// written but never read as a gate, so EXECBUFFER re-attached every
+    /// handle every submit (~29 synchronous RTTs/frame ≈ the fixed 2.4ms
+    /// floor). Empty set = not yet attached to any context.
+    attached_ctxs: BTreeSet<u32>,
     /// blob_mem from RESOURCE_CREATE_BLOB (`VIRTGPU_BLOB_MEM_*`); 0 for
     /// non-blob (classic 3D) resources.
     blob_mem: u32,
@@ -405,6 +518,9 @@ struct GpuResource {
     /// backing before `RESOURCE_FLUSH`; 3D virgl/blob resources are
     /// host-rendered and skip the transfer.
     is_dumb_2d: bool,
+    /// PID of the process that issued VIRTGPU_RESOURCE_CREATE for this
+    /// resource — Step-0 #2 forensic (who allocates buffers per frame).
+    created_pid: u32,
 }
 
 /// Kernel-side dma-buf for a *host* 3D resource (blob or classic virgl
@@ -487,6 +603,562 @@ struct PerFdCtx {
     ctx_id: u32,
 }
 
+// ==== Experiment A: present-path timing instrumentation ====
+//
+// Guest-side slice of the present path (see AAA_starry_note §8.4). Because
+// fork `enqueue_ctrl` busy-spins in-place on QueueFull and card0 never asks
+// the device to wait otherwise, the flat sum of the slots below is the
+// *guest-kernel* time per present. If it is µs-scale while glmark2 on-screen
+// still reports ~2 ms/frame, the floor is host-side latency (→ experiment B,
+// host `-trace virtio_gpu_*`); if it is ms-scale, the floor is this kernel
+// path (QueueFull spin or IOCTL handling). Reported via `warn!` (visible at
+// AX_LOG=warn) every `PERF_REPORT_EVERY` ATOMIC commits.
+struct PerfSlot {
+    cnt: AtomicU64,
+    sum_ns: AtomicU64,
+    max_ns: AtomicU64,
+}
+
+impl PerfSlot {
+    const fn new() -> Self {
+        Self {
+            cnt: AtomicU64::new(0),
+            sum_ns: AtomicU64::new(0),
+            max_ns: AtomicU64::new(0),
+        }
+    }
+
+    fn add(&self, d: core::time::Duration) {
+        let ns = d.as_nanos() as u64;
+        self.cnt.fetch_add(1, Ordering::Relaxed);
+        self.sum_ns.fetch_add(ns, Ordering::Relaxed);
+        self.max_ns.fetch_max(ns, Ordering::Relaxed);
+    }
+}
+
+static PERF_ATOMIC: PerfSlot = PerfSlot::new(); // full MODE_ATOMIC handler
+static PERF_SCANOUT: PerfSlot = PerfSlot::new(); // set_scanout enqueue
+static PERF_TRANSFER: PerfSlot = PerfSlot::new(); // transfer_to_host_2d enqueue
+static PERF_FLUSH: PerfSlot = PerfSlot::new(); // resource_flush enqueue
+static PERF_EXECBUF: PerfSlot = PerfSlot::new(); // full EXECBUFFER handler
+static PERF_RESCREATE: PerfSlot = PerfSlot::new(); // full VIRTGPU_RESOURCE_CREATE (incl. sync ctx_attach)
+static PERF_WAIT: PerfSlot = PerfSlot::new(); // VIRTGPU_WAIT handler
+static PERF_TRANS3D: PerfSlot = PerfSlot::new(); // VIRTGPU_TRANSFER_TO_HOST (3D)
+static PERF_DUMBCREATE: PerfSlot = PerfSlot::new(); // MODE_CREATE_DUMB handler
+static PERF_DUMMAP: PerfSlot = PerfSlot::new(); // MODE_MAP_DUMB handler
+static PERF_DUMDESTROY: PerfSlot = PerfSlot::new(); // MODE_DESTROY_DUMB handler
+static PERF_GEMCLOSE: PerfSlot = PerfSlot::new(); // GEM_CLOSE handler
+const PERF_REPORT_EVERY: u64 = 300;
+
+// ---- run6 frame-gap forensics: EXECBUFFER entry-to-entry interval ----
+// Intervals between consecutive EXECBUFFER ioctls (any fd, glmark2 + weston).
+// Buckets in ms: 0.5, 1, 2, 3, 4, 6, 10, inf. Pure atomics — no per-frame log.
+static EXECB_GAP_BUCKETS: [AtomicU64; 8] = [
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+];
+static LAST_EXECB_TS: AtomicU64 = AtomicU64::new(0);
+const EXECB_GAP_BOUNDS_MS: [f64; 7] = [0.5, 1.0, 2.0, 3.0, 4.0, 6.0, 10.0];
+
+fn record_execb_gap() {
+    let now = monotonic_time().as_nanos() as u64;
+    let last = LAST_EXECB_TS.swap(now, Ordering::Relaxed);
+    if last == 0 {
+        return;
+    }
+    let gap_ms = (now.saturating_sub(last)) as f64 / 1e6;
+    let idx = match EXECB_GAP_BOUNDS_MS.iter().position(|b| gap_ms < *b) {
+        Some(i) => i,
+        None => 7,
+    };
+    EXECB_GAP_BUCKETS[idx].fetch_add(1, Ordering::Relaxed);
+}
+
+// ---- Step-0 #2 / #1-a forensic counters (reset per perf_report window) ----
+// EXECBUFFER fence-mode selection Mesa actually sends. Only *counts*; full
+// per-submit detail is in the first-CREATE_DETAIL_LIMIT create logs.
+static EXECB_FENCE_FD_IN: AtomicU64 = AtomicU64::new(0);
+static EXECB_FENCE_FD_OUT: AtomicU64 = AtomicU64::new(0);
+static EXECB_SYNC_IN: AtomicU64 = AtomicU64::new(0);
+static EXECB_SYNC_OUT: AtomicU64 = AtomicU64::new(0);
+/// VIRTGPU_WAIT called with `VIRTGPU_WAIT_NOWAIT` (a poll, not a block).
+static WAIT_NOWAIT: AtomicU64 = AtomicU64::new(0);
+/// VIRTGPU_WAIT(NOWAIT) probes that returned EBUSY — the host batch was still
+/// in flight. Verifies the honest-fence path is actually exercised.
+static WAIT_BUSY: AtomicU64 = AtomicU64::new(0);
+/// Number of VIRTGPU_RESOURCE_CREATE details logged so far (gate the log).
+static CREATE_DETAIL_N: AtomicU64 = AtomicU64::new(0);
+const CREATE_DETAIL_LIMIT: u64 = 200;
+/// [card0:fx] tiny-resource content dump gate (per-frame 8x1 forensics).
+static SMALL_RES_DUMP_N: AtomicU64 = AtomicU64::new(0);
+const SMALL_RES_DUMP_LIMIT: u64 = 400;
+/// Upper bound on `DIRTY_FB` clips we merge per call. clamps a garbage
+/// `num_clips` so `vm_load` can't allocate unbounded kernel memory.
+const MAX_DIRTY_CLIPS: u32 = 64;
+
+// ==== ioctl-stream forensics (run6d+): where does the per-frame gap live? ====
+// Every card0 ioctl arrival is recorded into a ring and the idle gap until the
+// *next* ioctl is bucketed per ioctl type. Combined with the EXECB gap
+// histogram this attributes the ~2-4ms guest frame silence to the ioctl (or
+// userspace work) that precedes it. Pure atomics — no per-ioctl log line.
+const IOCTL_SLOT_N: usize = 10;
+const SLOT_EXECB: usize = 0;
+const SLOT_WAIT: usize = 1;
+const SLOT_RESCREATE: usize = 2;
+const SLOT_CREATE_DUMB: usize = 3;
+const SLOT_MAP_DUMB: usize = 4;
+const SLOT_DESTROY_DUMB: usize = 5;
+const SLOT_GEM_CLOSE: usize = 6;
+const SLOT_ATOMIC: usize = 7;
+const SLOT_TRANS3D: usize = 8;
+const SLOT_OTHER: usize = 9;
+const IOCTL_SLOT_NAMES: [&str; IOCTL_SLOT_N] = [
+    "execbuf",
+    "wait",
+    "res-create",
+    "create-dumb",
+    "map-dumb",
+    "destroy-dumb",
+    "gem-close",
+    "atomic",
+    "trans3d",
+    "other",
+];
+
+fn ioctl_slot_of(cmd: u32) -> usize {
+    match cmd {
+        DRM_IOCTL_VIRTGPU_EXECBUFFER => SLOT_EXECB,
+        DRM_IOCTL_VIRTGPU_WAIT => SLOT_WAIT,
+        DRM_IOCTL_VIRTGPU_RESOURCE_CREATE => SLOT_RESCREATE,
+        DRM_IOCTL_MODE_CREATE_DUMB => SLOT_CREATE_DUMB,
+        DRM_IOCTL_MODE_MAP_DUMB => SLOT_MAP_DUMB,
+        DRM_IOCTL_MODE_DESTROY_DUMB => SLOT_DESTROY_DUMB,
+        DRM_IOCTL_GEM_CLOSE => SLOT_GEM_CLOSE,
+        DRM_IOCTL_MODE_ATOMIC => SLOT_ATOMIC,
+        DRM_IOCTL_VIRTGPU_TRANSFER_TO_HOST => SLOT_TRANS3D,
+        _ => SLOT_OTHER,
+    }
+}
+
+struct IoctlGapSlot {
+    buckets: [AtomicU64; 8],
+    cnt: AtomicU64,
+}
+
+impl IoctlGapSlot {
+    const fn new() -> Self {
+        Self {
+            buckets: [
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+            ],
+            cnt: AtomicU64::new(0),
+        }
+    }
+}
+
+static IOCTL_GAP_AFTER: [IoctlGapSlot; IOCTL_SLOT_N] = [
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+    IoctlGapSlot::new(),
+];
+static LAST_IOCTL_TS: AtomicU64 = AtomicU64::new(0);
+static LAST_IOCTL_SLOT: AtomicU64 = AtomicU64::new(0);
+
+const IOCTL_RING_N: usize = 128;
+// Parallel atomic arrays (a plain `static [T; N]` can't be written). Each
+// entry packs (pid<<32 | cmd) so the ring stays race-safe under SMP ioctls;
+// torn reads only degrade a diagnostic dump, never correctness.
+static IOCTL_RING_T: [AtomicU64; IOCTL_RING_N] = [const { AtomicU64::new(0) }; IOCTL_RING_N];
+static IOCTL_RING_V: [AtomicU64; IOCTL_RING_N] = [const { AtomicU64::new(0) }; IOCTL_RING_N];
+static RING_HEAD: AtomicUsize = AtomicUsize::new(0);
+static RING_LAST_WRITTEN: AtomicUsize = AtomicUsize::new(0);
+static RING_LAST_EXECB: AtomicUsize = AtomicUsize::new(usize::MAX);
+static RING_LAST_EXECB_NONW: AtomicUsize = AtomicUsize::new(usize::MAX);
+static RING_DUMPED: AtomicU64 = AtomicU64::new(0);
+const RING_DUMP_LIMIT: u64 = 2;
+
+fn record_ioctl_arrival(cmd: u32, pid: u32) {
+    let now = monotonic_time().as_nanos() as u64;
+    // Gap since the previous ioctl is charged to that previous ioctl's slot
+    // ("gap-after"): a long silence shows which ioctl boundary it follows.
+    let last_ts = LAST_IOCTL_TS.swap(now, Ordering::Relaxed);
+    if last_ts != 0 {
+        let gap_us = now.saturating_sub(last_ts) / 1_000;
+        let slot = (LAST_IOCTL_SLOT.load(Ordering::Relaxed) as usize).min(IOCTL_SLOT_N - 1);
+        let idx = EXECB_GAP_BOUNDS_MS
+            .iter()
+            .position(|b| (gap_us as f64) / 1e3 < *b)
+            .unwrap_or(7);
+        let s = &IOCTL_GAP_AFTER[slot];
+        s.buckets[idx].fetch_add(1, Ordering::Relaxed);
+        s.cnt.fetch_add(1, Ordering::Relaxed);
+    }
+    LAST_IOCTL_SLOT.store(ioctl_slot_of(cmd) as u64, Ordering::Relaxed);
+    let head = RING_HEAD.load(Ordering::Relaxed);
+    IOCTL_RING_T[head].store(now / 1_000, Ordering::Relaxed);
+    IOCTL_RING_V[head].store(((pid as u64) << 32) | cmd as u64, Ordering::Relaxed);
+    RING_LAST_WRITTEN.store(head, Ordering::Relaxed);
+    RING_HEAD.store((head + 1) % IOCTL_RING_N, Ordering::Relaxed);
+}
+
+// ---- sub-slot timing: where do the per-call µs go inside the hot handlers? ----
+fn timed<T>(sum: &'static AtomicU64, cnt: &'static AtomicU64, f: impl FnOnce() -> T) -> T {
+    let t0 = monotonic_time();
+    let r = f();
+    let d = monotonic_time().saturating_sub(t0).as_nanos() as u64;
+    sum.fetch_add(d, Ordering::Relaxed);
+    cnt.fetch_add(1, Ordering::Relaxed);
+    r
+}
+
+// VIRTGPU_RESOURCE_CREATE (the per-frame 8x1 fence resource) internals.
+static RC_ALLOC_SUM: AtomicU64 = AtomicU64::new(0); // guest backing page alloc + zero
+static RC_ALLOC_CNT: AtomicU64 = AtomicU64::new(0);
+static RC_PAGE_SUM: AtomicU64 = AtomicU64::new(0); // backing pages allocated
+static RC_ENQ_SUM: AtomicU64 = AtomicU64::new(0); // create_3d + attach_backing enqueues
+static RC_ENQ_CNT: AtomicU64 = AtomicU64::new(0);
+static RC_CTXA_SUM: AtomicU64 = AtomicU64::new(0); // ctx_attach enqueue
+static RC_CTXA_CNT: AtomicU64 = AtomicU64::new(0);
+static RC_NOTIFY_SUM: AtomicU64 = AtomicU64::new(0); // ctrl_notify (kick)
+static RC_NOTIFY_CNT: AtomicU64 = AtomicU64::new(0);
+// GEM_CLOSE internals (per-frame fence-handle close): the host-unref enqueue
+// vs the rest (O(n) gpu_resources scan + lock juggling + small-res dump).
+static GC_UNREF_SUM: AtomicU64 = AtomicU64::new(0);
+static GC_UNREF_CNT: AtomicU64 = AtomicU64::new(0);
+// CREATE_DUMB internals (per-frame 4MB wl_drm buffer hypothesis).
+static DUMB_CNT: AtomicU64 = AtomicU64::new(0);
+static DUMB_SIZE_SUM: AtomicU64 = AtomicU64::new(0);
+static DUMB_ALLOC_SUM: AtomicU64 = AtomicU64::new(0);
+static DUMB_ZERO_SUM: AtomicU64 = AtomicU64::new(0);
+static DUMB_ENQ_SUM: AtomicU64 = AtomicU64::new(0);
+
+fn perf_measure<T>(slot: &'static PerfSlot, f: impl FnOnce() -> T) -> T {
+    let t0 = monotonic_time();
+    let r = f();
+    slot.add(monotonic_time().saturating_sub(t0));
+    r
+}
+
+fn perf_report(card: &Card0) {
+    let n = PERF_ATOMIC.cnt.load(Ordering::Relaxed);
+    if n == 0 || !n.is_multiple_of(PERF_REPORT_EVERY) {
+        return;
+    }
+    macro_rules! line {
+        ($name:literal, $slot:expr) => {{
+            let c = $slot.cnt.load(Ordering::Relaxed);
+            if c > 0 {
+                let sum = $slot.sum_ns.load(Ordering::Relaxed);
+                let max = $slot.max_ns.load(Ordering::Relaxed);
+                warn!(
+                    "  [card0:perf] {:<18} n={:>8} avg={:>8.2}us max={:>8.2}us",
+                    $name,
+                    c,
+                    sum as f64 / c as f64 / 1e3,
+                    max as f64 / 1e3,
+                );
+            }
+        }};
+    }
+    warn!(
+        "[card0:perf] present-path guest-kernel slice (report #{n}, at {} ATOMIC commits):",
+        PERF_REPORT_EVERY
+    );
+    line!("atomic(handler)", PERF_ATOMIC);
+    line!("scanout(enq)", PERF_SCANOUT);
+    line!("transfer2d(enq)", PERF_TRANSFER);
+    line!("flush(enq)", PERF_FLUSH);
+    line!("execbuffer", PERF_EXECBUF);
+    line!("wait", PERF_WAIT);
+    line!("transfer3d", PERF_TRANS3D);
+    line!("res-create", PERF_RESCREATE);
+    line!("create-dumb", PERF_DUMBCREATE);
+    line!("map-dumb", PERF_DUMMAP);
+    line!("destroy-dumb", PERF_DUMDESTROY);
+    line!("gem-close", PERF_GEMCLOSE);
+
+    // ---- Step-0 #2 / #1-a forensic window ----
+    // EXECBUFFER fence-mode distribution. Delta vs PERF_EXECBUF.cnt = plain
+    // (no fence) submits.
+    let execb = PERF_EXECBUF.cnt.load(Ordering::Relaxed);
+    let fin = EXECB_FENCE_FD_IN.load(Ordering::Relaxed);
+    let fout = EXECB_FENCE_FD_OUT.load(Ordering::Relaxed);
+    let sin = EXECB_SYNC_IN.load(Ordering::Relaxed);
+    let sout = EXECB_SYNC_OUT.load(Ordering::Relaxed);
+    let wait_calls = PERF_WAIT.cnt.load(Ordering::Relaxed);
+    let wait_nowait = WAIT_NOWAIT.load(Ordering::Relaxed);
+    let wait_busy = WAIT_BUSY.load(Ordering::Relaxed);
+    warn!(
+        "  [card0:fx] execbuffer n={execb}: fence-fd-in={fin} fence-fd-out={fout} sync-in={sin} \
+         sync-out={sout} plain={}",
+        execb.saturating_sub(fin + fout + sin + sout)
+    );
+    warn!(
+        "  [card0:fx] wait n={wait_calls} nowait={wait_nowait} busy={wait_busy} unique-handles={}",
+        card.wait_handles.lock().len()
+    );
+
+    // ---- run6 frame-gap buckets (EXECBUFFER entry-to-entry, ms) ----
+    let gaps = &EXECB_GAP_BUCKETS;
+    let gap_total: u64 = gaps.iter().map(|b| b.load(Ordering::Relaxed)).sum();
+    if gap_total > 0 {
+        warn!(
+            "  [card0:fx] execb-gap n={gap_total} ms:<0.5={} 0.5-1={} 1-2={} 2-3={} 3-4={} 4-6={} \
+             6-10={} >10={}",
+            gaps[0].load(Ordering::Relaxed),
+            gaps[1].load(Ordering::Relaxed),
+            gaps[2].load(Ordering::Relaxed),
+            gaps[3].load(Ordering::Relaxed),
+            gaps[4].load(Ordering::Relaxed),
+            gaps[5].load(Ordering::Relaxed),
+            gaps[6].load(Ordering::Relaxed),
+            gaps[7].load(Ordering::Relaxed),
+        );
+    }
+    // Spin before the global display lock (axdisplay `lock_display`): the
+    // cross-vCPU serialization cost of every gpu3d_* entry. The delta between
+    // this and the [card0:perf] ioctl slices is the in-critical-section cost
+    // (enqueue + host-wait spinning).
+    let (lcnt, lsum, lmax) = ax_display::gpu3d_lock_wait_stats();
+    ax_display::gpu3d_lock_wait_reset();
+    warn!(
+        "  [card0:fx] display-lock-wait n={lcnt} avg={:.2}us max={:.2}us",
+        lsum as f64 / lcnt.max(1) as f64 / 1e3,
+        lmax as f64 / 1e3,
+    );
+    let geoms = card.rescreate_geoms.lock();
+    warn!(
+        "  [card0:fx] res-create unique-geoms={} (distinct w×h this window)",
+        geoms.len()
+    );
+    drop(geoms);
+    let by_pid = card.create_by_pid.lock();
+    if !by_pid.is_empty() {
+        let mut items: Vec<_> = by_pid
+            .iter()
+            .map(|(pid, (n, exe))| {
+                let exe = String::from_utf8_lossy(exe);
+                format!("{pid}({n},{exe})")
+            })
+            .collect();
+        items.sort();
+        warn!("  [card0:fx] res-create by pid: {}", items.join(" "));
+    }
+    drop(by_pid);
+    let pres_pid = card.present_created_pid.lock();
+    if !pres_pid.is_empty() {
+        let mut items: Vec<_> = pres_pid.iter().map(|(p, c)| format!("{p}({c})")).collect();
+        items.sort();
+        warn!(
+            "  [card0:fx] present scanout by creator-pid: {}",
+            items.join(" ")
+        );
+    }
+    drop(pres_pid);
+
+    // ---- ioctl-stream: gap-after per ioctl type (which boundary is the
+    // long guest-side silence on?) + last EXECBUFFER-bounded frame dump ----
+    for (i, s) in IOCTL_GAP_AFTER.iter().enumerate() {
+        let cnt = s.cnt.load(Ordering::Relaxed);
+        if cnt == 0 {
+            continue;
+        }
+        let b: Vec<u64> = s
+            .buckets
+            .iter()
+            .map(|x| x.load(Ordering::Relaxed))
+            .collect();
+        warn!(
+            "  [card0:fx] gap-after[{:>12}] n={} ms:<0.5={} 0.5-1={} 1-2={} 2-3={} 3-4={} 4-6={} \
+             6-10={} >10={}",
+            IOCTL_SLOT_NAMES[i], cnt, b[0], b[1], b[2], b[3], b[4], b[5], b[6], b[7]
+        );
+    }
+    // ---- poll wake-to-return latency (run6g): do_poll waited, then the peer
+    // unix-stream send woke it; the delta is the wakeup+return path cost. ----
+    let pwl_cnt = crate::syscall::POLL_WAKE_LAT_CNT.load(Ordering::Relaxed);
+    if pwl_cnt > 0 {
+        let pwl = &crate::syscall::POLL_WAKE_LAT;
+        warn!(
+            "  [card0:fx] poll-wake-lat n={pwl_cnt} us:<100={} 100-500={} 500-1000={} 1-2m={} \
+             2-4m={} >4m={}",
+            pwl[0].load(Ordering::Relaxed),
+            pwl[1].load(Ordering::Relaxed),
+            pwl[2].load(Ordering::Relaxed),
+            pwl[3].load(Ordering::Relaxed),
+            pwl[4].load(Ordering::Relaxed),
+            pwl[5].load(Ordering::Relaxed),
+        );
+    }
+    // ---- scheduler wake->run latency (run6h): unblock -> actually running. ----
+    let (wrl, wrl_cnt) = ax_task::wake_run_lat_snapshot();
+    if wrl_cnt > 0 {
+        warn!(
+            "  [card0:fx] wake-run-lat n={wrl_cnt} us:<100={} 100-500={} 500-1000={} 1-2m={} \
+             2-4m={} >4m={}",
+            wrl[0], wrl[1], wrl[2], wrl[3], wrl[4], wrl[5],
+        );
+    }
+    if RING_DUMPED.load(Ordering::Relaxed) < RING_DUMP_LIMIT {
+        let nonw = RING_LAST_EXECB_NONW.load(Ordering::Relaxed);
+        let last_execb = if nonw != usize::MAX {
+            nonw
+        } else {
+            RING_LAST_EXECB.load(Ordering::Relaxed)
+        };
+        let head = RING_HEAD.load(Ordering::Relaxed);
+        if last_execb != usize::MAX && last_execb != head {
+            RING_DUMPED.fetch_add(1, Ordering::Relaxed);
+            let t0 = IOCTL_RING_T[last_execb].load(Ordering::Relaxed);
+            let mut i = last_execb;
+            let mut n = 0;
+            warn!("  [card0:ring] ioctl sequence since last EXECBUFFER:");
+            while i != head && n < IOCTL_RING_N {
+                let t = IOCTL_RING_T[i].load(Ordering::Relaxed);
+                let v = IOCTL_RING_V[i].load(Ordering::Relaxed);
+                let pid = (v >> 32) as u32;
+                let cmd = v as u32;
+                warn!(
+                    "  [card0:ring]   +{:>8}us pid={:<4} cmd=0x{:08x}",
+                    t.saturating_sub(t0),
+                    pid,
+                    cmd
+                );
+                i = (i + 1) % IOCTL_RING_N;
+                n += 1;
+            }
+        }
+    }
+    // ---- hot-handler internals: where do the per-call µs go? ----
+    let rcnt = RC_ALLOC_CNT.load(Ordering::Relaxed);
+    if rcnt > 0 {
+        let alloc = RC_ALLOC_SUM.load(Ordering::Relaxed) as f64 / rcnt as f64 / 1e3;
+        let enq = RC_ENQ_SUM.load(Ordering::Relaxed) as f64
+            / RC_ENQ_CNT.load(Ordering::Relaxed).max(1) as f64
+            / 1e3;
+        let ctxa = RC_CTXA_SUM.load(Ordering::Relaxed) as f64
+            / RC_CTXA_CNT.load(Ordering::Relaxed).max(1) as f64
+            / 1e3;
+        let notify = RC_NOTIFY_SUM.load(Ordering::Relaxed) as f64
+            / RC_NOTIFY_CNT.load(Ordering::Relaxed).max(1) as f64
+            / 1e3;
+        let other = (PERF_RESCREATE.sum_ns.load(Ordering::Relaxed) as f64 / rcnt as f64 / 1e3)
+            - alloc
+            - enq
+            - ctxa
+            - notify;
+        warn!(
+            "  [card0:fx] res-create internals n={rcnt} alloc={alloc:.1}us enq={enq:.1}us \
+             ctxa={ctxa:.1}us notify={notify:.1}us other={other:.1}us pages/call={:.2}",
+            RC_PAGE_SUM.load(Ordering::Relaxed) as f64 / rcnt as f64,
+        );
+    }
+    let gc_cnt = PERF_GEMCLOSE.cnt.load(Ordering::Relaxed);
+    if gc_cnt > 0 {
+        let unref = GC_UNREF_SUM.load(Ordering::Relaxed) as f64
+            / GC_UNREF_CNT.load(Ordering::Relaxed).max(1) as f64
+            / 1e3;
+        let gc_other =
+            (PERF_GEMCLOSE.sum_ns.load(Ordering::Relaxed) as f64 / gc_cnt as f64 / 1e3) - unref;
+        warn!(
+            "  [card0:fx] gem-close internals n={gc_cnt} unref={unref:.1}us other={gc_other:.1}us"
+        );
+    }
+    let dcnt = DUMB_CNT.load(Ordering::Relaxed);
+    if dcnt > 0 {
+        warn!(
+            "  [card0:fx] create-dumb n={dcnt} alloc={:.1}us zero={:.1}us enq={:.1}us \
+             size-avg={:.0}KB",
+            DUMB_ALLOC_SUM.load(Ordering::Relaxed) as f64 / dcnt as f64 / 1e3,
+            DUMB_ZERO_SUM.load(Ordering::Relaxed) as f64 / dcnt as f64 / 1e3,
+            DUMB_ENQ_SUM.load(Ordering::Relaxed) as f64 / dcnt as f64 / 1e3,
+            DUMB_SIZE_SUM.load(Ordering::Relaxed) as f64 / dcnt as f64 / 1024.0,
+        );
+    }
+
+    // Zero the counters so each report is its own window.
+    let zero = |slot: &'static PerfSlot| {
+        slot.cnt.store(0, Ordering::Relaxed);
+        slot.sum_ns.store(0, Ordering::Relaxed);
+        slot.max_ns.store(0, Ordering::Relaxed);
+    };
+    zero(&PERF_ATOMIC);
+    zero(&PERF_SCANOUT);
+    zero(&PERF_TRANSFER);
+    zero(&PERF_FLUSH);
+    zero(&PERF_EXECBUF);
+    zero(&PERF_WAIT);
+    zero(&PERF_TRANS3D);
+    zero(&PERF_RESCREATE);
+    zero(&PERF_DUMBCREATE);
+    zero(&PERF_DUMMAP);
+    zero(&PERF_DUMDESTROY);
+    zero(&PERF_GEMCLOSE);
+    EXECB_FENCE_FD_IN.store(0, Ordering::Relaxed);
+    EXECB_FENCE_FD_OUT.store(0, Ordering::Relaxed);
+    EXECB_SYNC_IN.store(0, Ordering::Relaxed);
+    EXECB_SYNC_OUT.store(0, Ordering::Relaxed);
+    WAIT_NOWAIT.store(0, Ordering::Relaxed);
+    WAIT_BUSY.store(0, Ordering::Relaxed);
+    for b in EXECB_GAP_BUCKETS.iter() {
+        b.store(0, Ordering::Relaxed);
+    }
+    for s in IOCTL_GAP_AFTER.iter() {
+        s.cnt.store(0, Ordering::Relaxed);
+        for b in s.buckets.iter() {
+            b.store(0, Ordering::Relaxed);
+        }
+    }
+    LAST_IOCTL_TS.store(0, Ordering::Relaxed);
+    LAST_IOCTL_SLOT.store(0, Ordering::Relaxed);
+    RING_DUMPED.store(0, Ordering::Relaxed);
+    for b in crate::syscall::POLL_WAKE_LAT.iter() {
+        b.store(0, Ordering::Relaxed);
+    }
+    crate::syscall::POLL_WAKE_LAT_CNT.store(0, Ordering::Relaxed);
+    ax_task::wake_run_lat_reset();
+    RC_ALLOC_SUM.store(0, Ordering::Relaxed);
+    RC_ALLOC_CNT.store(0, Ordering::Relaxed);
+    RC_PAGE_SUM.store(0, Ordering::Relaxed);
+    RC_ENQ_SUM.store(0, Ordering::Relaxed);
+    RC_ENQ_CNT.store(0, Ordering::Relaxed);
+    RC_CTXA_SUM.store(0, Ordering::Relaxed);
+    RC_CTXA_CNT.store(0, Ordering::Relaxed);
+    RC_NOTIFY_SUM.store(0, Ordering::Relaxed);
+    RC_NOTIFY_CNT.store(0, Ordering::Relaxed);
+    GC_UNREF_SUM.store(0, Ordering::Relaxed);
+    GC_UNREF_CNT.store(0, Ordering::Relaxed);
+    DUMB_CNT.store(0, Ordering::Relaxed);
+    DUMB_SIZE_SUM.store(0, Ordering::Relaxed);
+    DUMB_ALLOC_SUM.store(0, Ordering::Relaxed);
+    DUMB_ZERO_SUM.store(0, Ordering::Relaxed);
+    DUMB_ENQ_SUM.store(0, Ordering::Relaxed);
+    card.create_by_pid.lock().clear();
+    card.wait_handles.lock().clear();
+    card.rescreate_geoms.lock().clear();
+    card.present_created_pid.lock().clear();
+}
+
 pub struct Card0 {
     /// Queue of pending DRM events waiting to be delivered via `read()`.
     events: Mutex<VecDeque<DrmEventVblank>>,
@@ -544,10 +1216,9 @@ pub struct Card0 {
     /// only one allocation lands in `system_blobs`.
     system_blobs_init: Mutex<()>,
     /// Registered virtio-gpu IRQ action, when the display backend advertises one.
-irq_handle: ax_lazyinit::OnceLock<ax_runtime::hal::irq::IrqHandle>,
+    irq_handle: ax_lazyinit::OnceLock<ax_runtime::hal::irq::IrqHandle>,
 
     // ---- 3D (virgl) resource management ----
-
     /// 3D resources keyed by virtio-gpu resource ID. Each resource tracks
     /// its associated GEM handle, geometry, and size for transfer validation.
     gpu_resources: Mutex<BTreeMap<u32, GpuResource>>,
@@ -558,6 +1229,12 @@ irq_handle: ax_lazyinit::OnceLock<ax_runtime::hal::irq::IrqHandle>,
     ///
     /// Each entry holds one reference on the host resource for the importer.
     blob_aliases: Mutex<BTreeMap<u32, ImportedBlob>>,
+    /// Currently bound scanout resource + geometry, for Linux-style
+    /// bind-on-change `SET_SCANOUT` in [`Card::present_fb`]. `None` means
+    /// nothing bound yet — the first present forces a bind. Linux gates
+    /// `SET_SCANOUT` on fb/src/modeset change (`virtio_gpu_primary_plane_update`),
+    /// not on every frame.
+    scanout_bind: Mutex<Option<(u32, u32, u32)>>,
     /// Number of open PRIME-export dma-buf fds per host resource
     /// (`res_handle` → open-fd count). Each fd holds one reference on the
     /// host resource — Linux GEM lifetime says a dma-buf keeps the GEM
@@ -590,6 +1267,33 @@ irq_handle: ax_lazyinit::OnceLock<ax_runtime::hal::irq::IrqHandle>,
     /// [`Card0::next_ctx_id`] so each CONTEXT_INIT gets a unique id —
     /// same as Linux's `atomic_inc_return(&vgdev->ctx_id_cursor)`.
     process_ctxs: Mutex<BTreeMap<u32, PerFdCtx>>,
+
+    // ---- Step-0 #2 forensic: per-window histograms (reset by perf_report) ----
+    /// VIRTGPU_RESOURCE_CREATE producers: pid → (count this window, executable
+    /// suffix ≤ 64B). Answers "who allocates a buffer per frame — Mesa app
+    /// (glmark2) or the compositor (weston)".
+    create_by_pid: Mutex<BTreeMap<u32, (u64, Vec<u8>)>>,
+    /// Distinct VIRTGPU_WAIT handles observed this window. Unique-vs-total
+    /// reveals whether Mesa waits on a handful of reused buffers or one per
+    /// batch.
+    wait_handles: Mutex<BTreeSet<u32>>,
+    /// Distinct (width,height) of resources created this window. Constant
+    /// geometry = a cache-missed reusable buffer; varying = per-object
+    /// allocation.
+    rescreate_geoms: Mutex<BTreeSet<(u32, u32)>>,
+    /// PID of the process whose resource each present_fb scanout is bound to,
+    /// counted per window — correlates the per-frame creates with the
+    /// presented (scanout) buffer ownership.
+    present_created_pid: Mutex<BTreeMap<u32, u64>>,
+
+    /// bo_handle → fence ID of the last EXECBUFFER that referenced it.
+    /// Powers the honest VIRTGPU_WAIT: each handle waits on the fence of the
+    /// most recent submit (Linux per-object dma-resv, `virtio_gpu_wait_ioctl`).
+    /// GEM handles are unique while alive (the whole card0 assumes bo_handle
+    /// uniqueness across fds), and a stale entry for a recycled handle is
+    /// harmless: fence IDs are monotonic, so an old value is already
+    /// completed.
+    bo_fence: Mutex<BTreeMap<u32, u64>>,
 }
 
 impl Card0 {
@@ -614,15 +1318,21 @@ impl Card0 {
             system_blobs: Mutex::new(BTreeMap::new()),
             in_formats_blob: AtomicU32::new(0),
             system_blobs_init: Mutex::new(()),
-irq_handle: ax_lazyinit::OnceLock::new(),
+            irq_handle: ax_lazyinit::OnceLock::new(),
             // 3D resource management
             gpu_resources: Mutex::new(BTreeMap::new()),
             blob_aliases: Mutex::new(BTreeMap::new()),
+            scanout_bind: Mutex::new(None),
             dma_buf_refs: Mutex::new(BTreeMap::new()),
             next_res_handle: AtomicU32::new(1),
             next_ctx_id: AtomicU32::new(FIRST_VIRGL_CTX_ID),
             capset_cache: Mutex::new(BTreeMap::new()),
             process_ctxs: Mutex::new(BTreeMap::new()),
+            create_by_pid: Mutex::new(BTreeMap::new()),
+            wait_handles: Mutex::new(BTreeSet::new()),
+            rescreate_geoms: Mutex::new(BTreeSet::new()),
+            present_created_pid: Mutex::new(BTreeMap::new()),
+            bo_fence: Mutex::new(BTreeMap::new()),
             self_weak: weak.clone(),
         });
         card.register_irq();
@@ -655,6 +1365,11 @@ irq_handle: ax_lazyinit::OnceLock::new(),
 
         let request = ax_runtime::hal::irq::IrqRequest::new(|_| {
             if ax_display::framebuffer_handle_irq() {
+                // The IRQ may have pumped a fence completion; wake any poller
+                // blocked on an out-fence whose host fence just fired (guest
+                // fence waits are poll()-based; a blocked poll cannot re-check
+                // the completion level by itself).
+                super::sync_file::refresh_fence_waiters_from_irq();
                 ax_runtime::hal::irq::IrqReturn::Handled
             } else {
                 ax_runtime::hal::irq::IrqReturn::Unhandled
@@ -820,8 +1535,12 @@ impl DeviceOps for Card0 {
     }
 
     fn ioctl(&self, cmd: u32, arg: usize) -> VfsResult<usize> {
+        // [card0:ring] ioctl-stream forensics: record every arrival (type +
+        // pid) so perf_report can attribute the inter-ioctl gaps.
+        let pid = self.current_pid().unwrap_or(0);
+        record_ioctl_arrival(cmd, pid);
         info!("[card0] ioctl cmd=0x{:08x} arg=0x{:x}", cmd, arg);
-        match cmd {
+        let result = match cmd {
             DRM_IOCTL_VERSION => handle_version(arg),
             DRM_IOCTL_GET_UNIQUE => handle_get_unique(arg),
             DRM_IOCTL_SET_VERSION => handle_set_version(arg),
@@ -836,14 +1555,18 @@ impl DeviceOps for Card0 {
             DRM_IOCTL_MODE_GETCONNECTOR => handle_get_connector(arg),
             DRM_IOCTL_MODE_ADDFB2 => self.handle_addfb2(arg),
             DRM_IOCTL_MODE_RMFB => self.handle_rmfb(arg),
-            DRM_IOCTL_MODE_CREATE_DUMB => self.handle_create_dumb(arg),
-            DRM_IOCTL_MODE_MAP_DUMB => self.handle_map_dumb(arg),
-            DRM_IOCTL_MODE_DESTROY_DUMB => self.handle_destroy_dumb(arg),
+            DRM_IOCTL_MODE_CREATE_DUMB => {
+                perf_measure(&PERF_DUMBCREATE, || self.handle_create_dumb(arg))
+            }
+            DRM_IOCTL_MODE_MAP_DUMB => perf_measure(&PERF_DUMMAP, || self.handle_map_dumb(arg)),
+            DRM_IOCTL_MODE_DESTROY_DUMB => {
+                perf_measure(&PERF_DUMDESTROY, || self.handle_destroy_dumb(arg))
+            }
             // GEM_CLOSE is the release path Mesa uses for virgl 3D/blob
             // resources (incl. PRIME imports). Linux funnels both GEM_CLOSE
             // and DESTROY_DUMB through `drm_gem_handle_delete`; we mirror
             // that by sharing one cleanup helper.
-            DRM_IOCTL_GEM_CLOSE => self.handle_gem_close(arg),
+            DRM_IOCTL_GEM_CLOSE => perf_measure(&PERF_GEMCLOSE, || self.handle_gem_close(arg)),
 
             DRM_IOCTL_MODE_GETPLANERESOURCES => handle_get_plane_resources(arg),
             DRM_IOCTL_MODE_GETPLANE => handle_get_plane(arg),
@@ -852,7 +1575,7 @@ impl DeviceOps for Card0 {
             DRM_IOCTL_MODE_PAGE_FLIP => self.handle_page_flip(arg),
             DRM_IOCTL_WAIT_VBLANK => self.handle_wait_vblank(arg),
 
-            DRM_IOCTL_MODE_ATOMIC => self.handle_atomic(arg),
+            DRM_IOCTL_MODE_ATOMIC => perf_measure(&PERF_ATOMIC, || self.handle_atomic(arg)),
             DRM_IOCTL_MODE_CREATEPROPBLOB => self.handle_create_blob(arg),
             DRM_IOCTL_MODE_DESTROYPROPBLOB => self.handle_destroy_blob(arg),
             DRM_IOCTL_MODE_GETPROPBLOB => self.handle_get_blob(arg),
@@ -867,22 +1590,37 @@ impl DeviceOps for Card0 {
             DRM_IOCTL_VIRTGPU_GETPARAM => self.handle_virtgpu_getparam(arg),
             DRM_IOCTL_VIRTGPU_CONTEXT_INIT => self.handle_virtgpu_context_init(arg),
             DRM_IOCTL_VIRTGPU_GET_CAPS => self.handle_virtgpu_get_caps(arg),
-            DRM_IOCTL_VIRTGPU_RESOURCE_CREATE => self.handle_virtgpu_resource_create(arg),
+            DRM_IOCTL_VIRTGPU_RESOURCE_CREATE => {
+                perf_measure(&PERF_RESCREATE, || self.handle_virtgpu_resource_create(arg))
+            }
             DRM_IOCTL_VIRTGPU_RESOURCE_INFO => self.handle_virtgpu_resource_info(arg),
             DRM_IOCTL_VIRTGPU_MAP => self.handle_virtgpu_map(arg),
-            DRM_IOCTL_VIRTGPU_EXECBUFFER => self.handle_virtgpu_execbuffer(arg),
-            DRM_IOCTL_VIRTGPU_TRANSFER_TO_HOST => self.handle_virtgpu_transfer_to_host(arg),
-            DRM_IOCTL_VIRTGPU_TRANSFER_FROM_HOST => self.handle_virtgpu_transfer_from_host(arg),
-            DRM_IOCTL_VIRTGPU_WAIT => self.handle_virtgpu_wait(arg),
-            DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB => {
-                self.handle_virtgpu_resource_create_blob(arg)
+            DRM_IOCTL_VIRTGPU_EXECBUFFER => {
+                record_execb_gap();
+                // Ring marker: the last ring entry written is this EXECBUFFER —
+                // perf_report dumps the ioctl sequence between two submits.
+                // Keep both the generic marker and a non-weston (app) marker so
+                // the dump can prefer glmark2 frames over weston's.
+                RING_LAST_EXECB.store(RING_LAST_WRITTEN.load(Ordering::Relaxed), Ordering::Relaxed);
+                if pid != 3 {
+                    RING_LAST_EXECB_NONW
+                        .store(RING_LAST_WRITTEN.load(Ordering::Relaxed), Ordering::Relaxed);
+                }
+                perf_measure(&PERF_EXECBUF, || self.handle_virtgpu_execbuffer(arg))
             }
+            DRM_IOCTL_VIRTGPU_TRANSFER_TO_HOST => {
+                perf_measure(&PERF_TRANS3D, || self.handle_virtgpu_transfer_to_host(arg))
+            }
+            DRM_IOCTL_VIRTGPU_TRANSFER_FROM_HOST => self.handle_virtgpu_transfer_from_host(arg),
+            DRM_IOCTL_VIRTGPU_WAIT => perf_measure(&PERF_WAIT, || self.handle_virtgpu_wait(arg)),
+            DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB => self.handle_virtgpu_resource_create_blob(arg),
 
             _ => {
                 warn!("[card0] unsupported ioctl cmd=0x{:08x}", cmd);
                 Err(VfsError::OperationNotSupported)
             }
-        }
+        };
+        result
     }
 
     fn mmap(&self, offset: u64, length: u64) -> DeviceMmap {
@@ -944,15 +1682,24 @@ impl Card0 {
         // display calls below don't run with the map locked. Pages survive
         // a concurrent DESTROY_DUMB because the fb owns its own
         // Arc<GlobalPage> clone.
-        let fb = match self.fbs.lock().get(&fb_id) {
-            Some(fb) => Framebuffer {
-                size: fb.size,
-                stride: fb.stride,
-                width: fb.width,
-                height: fb.height,
-                kind: fb.kind.clone(),
-            },
-            None => return,
+        let (fb, dirty) = {
+            let mut fbs = self.fbs.lock();
+            let fb = match fbs.get_mut(&fb_id) {
+                Some(fb) => Framebuffer {
+                    size: fb.size,
+                    stride: fb.stride,
+                    width: fb.width,
+                    height: fb.height,
+                    kind: fb.kind.clone(),
+                    dirty: None,
+                },
+                None => return,
+            };
+            // Consume the damage recorded by DIRTY_FB (Linux:
+            // damage_merged rect is what the plane update uploads). None =
+            // no clip data for this present — fall back to the whole fb.
+            let dirty = fbs.get_mut(&fb_id).unwrap().dirty.take();
+            (fb, dirty)
         };
 
         match &fb.kind {
@@ -995,23 +1742,72 @@ impl Card0 {
             // does the same. Guest-backed 2D resources additionally need a
             // TRANSFER_TO_HOST_2D (handled below); 3D virgl/blob resources
             // already hold host-side pixels and skip the transfer.
-            FbBacking::Gpu3d { res_handle, is_dumb_2d } => {
+            FbBacking::Gpu3d {
+                res_handle,
+                is_dumb_2d,
+            } => {
                 if !ax_display::has_display() {
                     return;
                 };
-                let _ = ax_display::gpu3d_set_scanout(0, *res_handle, 0, 0, fb.width, fb.height);
-                // Guest-backed 2D (dumb) resources must copy pixels from
-                // guest RAM into the host image before flush — QEMU only
-                // fills the image on TRANSFER_TO_HOST_2D. 3D virgl/blob
-                // resources already hold host-side pixels and skip this.
-                if *is_dumb_2d {
-                    let _ = ax_display::gpu3d_transfer_to_host_2d(
-                        *res_handle, 0, 0, fb.width, fb.height,
-                    );
+                // Step-0 #2 forensic: who owns the presented scanout buffer?
+                // Counts by the resource's creator pid → correlates the
+                // per-frame creates with the scanout-side ownership.
+                let created_pid = self
+                    .gpu_resources
+                    .lock()
+                    .get(res_handle)
+                    .map(|r| r.created_pid);
+                if let Some(p) = created_pid {
+                    let mut m = self.present_created_pid.lock();
+                    *m.entry(p).or_insert(0) += 1;
                 }
-                let _ = ax_display::gpu3d_resource_flush(*res_handle, 0, 0, fb.width, fb.height);
+                // Damage region this present must upload. `dirty` comes from
+                // DIRTY_FB clips; nothing recorded ⇒ whole fb (Linux
+                // drm_atomic_helper_damage_merged's no-clips fallback).
+                let (x, y, w, h) = dirty.unwrap_or((0, 0, fb.width, fb.height));
+                let w = w.min(fb.width.saturating_sub(x));
+                let h = h.min(fb.height.saturating_sub(y));
+
+                // Guest-backed 2D (dumb): TRANSFER_TO_HOST_2D the damaged
+                // region only, and BEFORE binding scanout so the first
+                // scanout shows pixels — QEMU only fills the host image on
+                // TRANSFER_TO_HOST_2D. Matches Linux
+                // `virtio_gpu_update_dumb_bo` + queue order in
+                // `virtio_gpu_primary_plane_update` (transfer → scanout →
+                // flush). 3D virgl/blob resources already hold host-side
+                // pixels and skip this.
+                if *is_dumb_2d {
+                    let _ = perf_measure(&PERF_TRANSFER, || {
+                        ax_display::gpu3d_transfer_to_host_2d(*res_handle, x, y, w, h)
+                    });
+                }
+
+                // SET_SCANOUT only when the bound resource or geometry
+                // changed — Linux gates scanout on fb/src/modeset change,
+                // not per frame. First present always binds (scanout_bind
+                // starts None).
+                let bind = (*res_handle, fb.width, fb.height);
+                if *self.scanout_bind.lock() != Some(bind)
+                    && perf_measure(&PERF_SCANOUT, || {
+                        ax_display::gpu3d_set_scanout(0, *res_handle, 0, 0, fb.width, fb.height)
+                    })
+                    .is_ok()
+                {
+                    *self.scanout_bind.lock() = Some(bind);
+                }
+
+                // Flush the damaged region, not the whole fb (Linux flushes
+                // the damage_merged rect).
+                let _ = perf_measure(&PERF_FLUSH, || {
+                    ax_display::gpu3d_resource_flush(*res_handle, x, y, w, h)
+                });
             }
         }
+        // Present is a fire-and-forget transaction (transfer/scanout/flush);
+        // close the command window with one notify — Linux's ioctl-boundary
+        // `virtio_gpu_notify()` (vq.c:551). Without this the flush would sit
+        // in the avail ring until some later sync command kicks.
+        ax_display::gpu3d_ctrl_notify();
     }
 
     fn handle_create_dumb(&self, arg: usize) -> VfsResult<usize> {
@@ -1048,12 +1844,15 @@ impl Card0 {
         // after driver probe.
         let size_aligned = (size as usize).next_multiple_of(PAGE_SIZE_4K);
         let pages = size_aligned / PAGE_SIZE_4K;
-        let mut backing =
-            GlobalPage::alloc_contiguous(pages, PAGE_SIZE_4K).map_err(|_| VfsError::NoMemory)?;
+        DUMB_CNT.fetch_add(1, Ordering::Relaxed);
+        DUMB_SIZE_SUM.fetch_add(size, Ordering::Relaxed);
+        let mut backing = timed(&DUMB_ALLOC_SUM, &DUMB_CNT, || {
+            GlobalPage::alloc_contiguous(pages, PAGE_SIZE_4K).map_err(|_| VfsError::NoMemory)
+        })?;
         // Linux DRM dumb buffers must be returned zeroed: the page
         // allocator may hand back pages that previously held kernel
         // data, and we mmap them straight into user space.
-        backing.zero();
+        timed(&DUMB_ZERO_SUM, &DUMB_CNT, || backing.zero());
         let pages_arc = Arc::new(backing);
         let offset = self
             .next_offset
@@ -1068,29 +1867,34 @@ impl Card0 {
         if ax_display::has_display() {
             let res_handle = self.next_res_handle.fetch_add(1, Ordering::Relaxed);
             let paddr = virt_to_phys(pages_arc.start_vaddr());
-            let _ = ax_display::gpu3d_resource_create_2d(
-                res_handle,
-                c.width,
-                c.height,
-            );
-            let _ = ax_display::gpu3d_attach_backing(
-                res_handle,
-                paddr.as_usize() as u64,
-                size as u32,
-            );
+            timed(&DUMB_ENQ_SUM, &DUMB_CNT, || {
+                let _ = ax_display::gpu3d_resource_create_2d(res_handle, c.width, c.height);
+                let _ = ax_display::gpu3d_attach_backing(
+                    res_handle,
+                    paddr.as_usize() as u64,
+                    size as u32,
+                );
+            });
             // Also register in gpu_resources so ADDFB2 finds it as a
             // host-backed buffer (FbBacking::Gpu3d) instead of plain Dumb.
-            self.gpu_resources.lock().insert(res_handle, GpuResource {
-                bo_handle: handle,
-                width: c.width,
-                height: c.height,
-                stride: pitch,
-                size,
-                attached: true,
-                blob_mem: 0,
-                blob_flags: 0,
-                is_dumb_2d: true,
-            });
+            self.gpu_resources.lock().insert(
+                res_handle,
+                GpuResource {
+                    bo_handle: handle,
+                    width: c.width,
+                    height: c.height,
+                    stride: pitch,
+                    size,
+                    // Dumb 2D scanout buffers are presented via
+                    // TRANSFER_TO_HOST_2D + FLUSH, never through a context, so
+                    // reserve attach-on-first-EXECBUFFER if one ever references it.
+                    attached_ctxs: BTreeSet::new(),
+                    blob_mem: 0,
+                    blob_flags: 0,
+                    is_dumb_2d: true,
+                    created_pid: self.current_pid().unwrap_or(0),
+                },
+            );
         }
 
         self.dumbs.lock().insert(
@@ -1107,6 +1911,12 @@ impl Card0 {
         );
         c.handle = handle;
         ptr.vm_write(c).map_err(|_| VfsError::BadAddress)?;
+
+        // CREATE_DUMB is a fire-and-forget transaction (create_2d +
+        // attach_backing); one boundary notify delivers it. Linux:
+        // `virtio_gpu_notify()` after the kmem-based create ioctl.
+        ax_display::gpu3d_ctrl_notify();
+
         Ok(0)
     }
 
@@ -1183,6 +1993,40 @@ impl Card0 {
         // `pages` means the backing memory only goes away after both
         // this remove drops Card0's ref AND every live mapping
         // releases its retainer.
+        // [card0:fx] temporary forensic: dump contents of tiny (<64B)
+        // resources at destroy time. The per-frame 8x1 (bind=0x20000) is
+        // created on every EGL swap and unref'd ~1s later; its 8 bytes tell
+        // whether Mesa writes it per frame (counter/timestamp) or once
+        // (flag/placeholder). Removed together with the res-create warn.
+        if let Some(dumb) = self.dumbs.lock().get(&handle) {
+            if dumb.size <= 64 {
+                let p = dumb.pages.start_vaddr().as_ptr() as *const u8;
+                let mut bytes = [0u8; 8];
+                for (i, b) in bytes.iter_mut().enumerate() {
+                    *b = unsafe { core::ptr::read_volatile(p.add(i)) };
+                }
+                let u64le = u64::from_le_bytes(bytes);
+                let n = SMALL_RES_DUMP_N.fetch_add(1, Ordering::Relaxed);
+                if n < SMALL_RES_DUMP_LIMIT {
+                    warn!(
+                        "[card0:fx] small-res-destroy #{} handle={} size={} \
+                         bytes={:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}{:02x} u64le=0x{:x}",
+                        n,
+                        handle,
+                        dumb.size,
+                        bytes[0],
+                        bytes[1],
+                        bytes[2],
+                        bytes[3],
+                        bytes[4],
+                        bytes[5],
+                        bytes[6],
+                        bytes[7],
+                        u64le
+                    );
+                }
+            }
+        }
         self.dumbs.lock().remove(&handle);
         // Imported blob alias handles are destroyed the same way.
         let released_alias = self.blob_aliases.lock().remove(&handle);
@@ -1204,12 +2048,14 @@ impl Card0 {
         // Release the references this handle held. A resource only reaches
         // the host `RESOURCE_UNREF` when every holder (this entry, all
         // import aliases, all open export dma-buf fds) is gone.
-        for rh in removed_resources {
-            self.unref_resource_if_last(rh);
-        }
-        if let Some(alias) = released_alias {
-            self.unref_resource_if_last(alias.res_handle);
-        }
+        timed(&GC_UNREF_SUM, &GC_UNREF_CNT, || {
+            for rh in &removed_resources {
+                self.unref_resource_if_last(*rh);
+            }
+            if let Some(alias) = released_alias {
+                self.unref_resource_if_last(alias.res_handle);
+            }
+        });
     }
 
     /// DESTROY_DUMB: dumb-buffer specific release path. Linux falls through
@@ -1219,6 +2065,9 @@ impl Card0 {
         let ptr = arg as *const DrmModeDestroyDumb;
         let d: DrmModeDestroyDumb = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
         self.destroy_handle(d.handle);
+        // DESTROY_DUMB may have enqueued a fire-and-forget RESOURCE_UNREF;
+        // one boundary notify delivers it — Linux `virtio_gpu_notify()`.
+        ax_display::gpu3d_ctrl_notify();
         Ok(0)
     }
 
@@ -1228,6 +2077,9 @@ impl Card0 {
         let ptr = arg as *const DrmGemClose;
         let c: DrmGemClose = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
         self.destroy_handle(c.handle);
+        // GEM_CLOSE may have enqueued a fire-and-forget RESOURCE_UNREF;
+        // one boundary notify delivers it — Linux `virtio_gpu_notify()`.
+        ax_display::gpu3d_ctrl_notify();
         Ok(0)
     }
 
@@ -1430,8 +2282,26 @@ impl Card0 {
             // sampler view / draw is discarded, and the compositor never
             // composites the imported buffer.
             if let Some(ctx_id) = self.current_ctx() {
-                let _ = ax_display::gpu3d_ctx_attach_resource(ctx_id, dma.res_handle);
+                // Attach-once per ctx (Linux `virtio_gpu_gem_object_open`
+                // dedups in the importer servo): if this ctx already holds
+                // the resource, skip the redundant CTX_ATTACH_RESOURCE.
+                let already_attached = self
+                    .gpu_resources
+                    .lock()
+                    .get(&dma.res_handle)
+                    .is_some_and(|r| r.attached_ctxs.contains(&ctx_id));
+                if !already_attached {
+                    let ok = ax_display::gpu3d_ctx_attach_resource(ctx_id, dma.res_handle).is_ok();
+                    // Record so subsequent imports / EXECBUFFERs skip this
+                    // ctx and don't re-attach every submit.
+                    if ok && let Some(res) = self.gpu_resources.lock().get_mut(&dma.res_handle) {
+                        res.attached_ctxs.insert(ctx_id);
+                    }
+                }
             }
+            // The import's ctx_attach is fire-and-forget; one boundary notify
+            // delivers it — Linux `virtio_gpu_notify()` after gem_object_open.
+            ax_display::gpu3d_ctrl_notify();
             req.handle = handle;
             ptr.vm_write(req).map_err(|_| VfsError::BadAddress)?;
             return Ok(0);
@@ -1652,14 +2522,25 @@ impl Card0 {
                 .find(|(_, r)| r.bo_handle == handle)
                 .map(|(&rh, r)| (rh, r.size, r.is_dumb_2d));
             if let Some((res_handle, res_size, is_dumb_2d)) = host_res {
-                (FbBacking::Gpu3d { res_handle, is_dumb_2d }, res_size)
+                (
+                    FbBacking::Gpu3d {
+                        res_handle,
+                        is_dumb_2d,
+                    },
+                    res_size,
+                )
             } else {
                 drop(resources);
                 let dumbs = self.dumbs.lock();
                 let Some(b) = dumbs.get(&handle) else {
                     return Err(VfsError::InvalidInput);
                 };
-                (FbBacking::Dumb { pages: b.pages.clone() }, b.size)
+                (
+                    FbBacking::Dumb {
+                        pages: b.pages.clone(),
+                    },
+                    b.size,
+                )
             }
         };
         // Use the plane stride from the ADDFB2 request (f.pitches[0])
@@ -1718,6 +2599,7 @@ impl Card0 {
                 width: fb_width,
                 height: fb_height,
                 kind,
+                dirty: None,
             },
         );
         f.fb_id = fb_id;
@@ -2001,9 +2883,58 @@ impl Card0 {
     fn handle_dirty_fb(&self, arg: usize) -> VfsResult<usize> {
         let ptr = arg as *const DrmModeDirtyFB;
         let dirty: DrmModeDirtyFB = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
-        if !self.fbs.lock().contains_key(&dirty.fb_id) {
+
+        // Record the damaged region on the fb so the next present uploads
+        // only that rect. Linux feeds these clips into
+        // `drm_atomic_helper_damage_merged` and the plane update transfers +
+        // flushes just the merged rect; `None` (no clips) = whole fb.
+        let mut fbs = self.fbs.lock();
+        if !fbs.contains_key(&dirty.fb_id) {
             return Err(VfsError::InvalidInput);
         }
+        let (fb_w, fb_h) = {
+            let fb = fbs.get(&dirty.fb_id).unwrap();
+            (fb.width, fb.height)
+        };
+        let full = (0u32, 0u32, fb_w, fb_h);
+
+        if dirty.num_clips == 0 || dirty.clips_ptr == 0 {
+            // No clips — the caller marks the whole fb changed.
+            fbs.get_mut(&dirty.fb_id).unwrap().dirty = Some(full);
+        } else {
+            // Merge all clip rects into one damage union, clamping each to
+            // the fb bounds (Linux clips via drm_rect_intersect).
+            let n = dirty.num_clips.min(MAX_DIRTY_CLIPS) as usize;
+            let clips: Vec<DrmClipRect> = vm_load(dirty.clips_ptr as *const DrmClipRect, n)
+                .map_err(|_| VfsError::BadAddress)?;
+            let mut merged: Option<(u32, u32, u32, u32)> = None;
+            for c in clips {
+                // drm_clip_rect bounds are inclusive: x2/y2 name the last
+                // damaged pixel, so build an exclusive w/h from them.
+                let max_x = fb_w.min(u16::MAX as u32);
+                let max_y = fb_h.min(u16::MAX as u32);
+                let x1 = u32::from(c.x1).min(max_x);
+                let y1 = u32::from(c.y1).min(max_y);
+                let x2 = (u32::from(c.x2).saturating_add(1)).min(fb_w);
+                let y2 = (u32::from(c.y2).saturating_add(1)).min(fb_h);
+                if x2 <= x1 || y2 <= y1 {
+                    continue;
+                }
+                let r = (x1, y1, x2 - x1, y2 - y1);
+                merged = Some(match merged {
+                    None => r,
+                    Some((mx, my, mw, mh)) => {
+                        let nx1 = mx.min(r.0);
+                        let ny1 = my.min(r.1);
+                        let nw = (mx + mw).max(r.0 + r.2) - nx1;
+                        let nh = (my + mh).max(r.1 + r.3) - ny1;
+                        (nx1, ny1, nw, nh)
+                    }
+                });
+            }
+            fbs.get_mut(&dirty.fb_id).unwrap().dirty = merged.or(Some(full));
+        }
+        drop(fbs);
         self.present_fb(dirty.fb_id);
         Ok(0)
     }
@@ -2158,6 +3089,7 @@ impl Card0 {
         }
         if current_fb != 0 {
             self.present_fb(current_fb);
+            perf_report(self);
         }
         if a.flags & DRM_MODE_PAGE_FLIP_EVENT != 0 {
             self.queue_flip_event(a.user_data);
@@ -2359,13 +3291,21 @@ impl Card0 {
                 // device doesn't support blobs and Mesa must use the classic
                 // resource path — reporting 1 here would make Mesa create
                 // blobs that fail.
-                if ax_display::has_resource_blob() { 1 } else { 0 }
+                if ax_display::has_resource_blob() {
+                    1
+                } else {
+                    0
+                }
             }
             VIRTGPU_PARAM_HOST_VISIBLE => {
                 // Host-visible memory requires blob resources. Match the
                 // device's actual capability so Mesa's `supports_coherent`
                 // tracks reality.
-                if ax_display::has_resource_blob() { 1 } else { 0 }
+                if ax_display::has_resource_blob() {
+                    1
+                } else {
+                    0
+                }
             }
             VIRTGPU_PARAM_CROSS_DEVICE => {
                 // Cross-device sharing not supported yet.
@@ -2411,8 +3351,9 @@ impl Card0 {
     /// Mesa calls this with num_params=1 and a single parameter:
     ///   { param=VIRTGPU_CONTEXT_PARAM_CAPSET_ID, value=VIRGL2(2) or VIRGL1(1) }
     fn handle_virtgpu_context_init(&self, arg: usize) -> VfsResult<usize> {
-        let init: DrmVirtgpuContextInit =
-            (arg as *const DrmVirtgpuContextInit).vm_read().map_err(|_| VfsError::BadAddress)?;
+        let init: DrmVirtgpuContextInit = (arg as *const DrmVirtgpuContextInit)
+            .vm_read()
+            .map_err(|_| VfsError::BadAddress)?;
 
         // Linux: if (!vgdev->has_context_init || !vgdev->has_virgl_3d)
         //           return -EINVAL;
@@ -2422,12 +3363,15 @@ impl Card0 {
 
         // `card0`/`renderD128` share one Card0 for every opener, so the
         // per-fd "one CONTEXT_INIT per fd" rule becomes per-process.
-        let pid = self
-            .current_pid()
-            .ok_or(VfsError::InvalidInput)?;
+        let pid = self.current_pid().ok_or(VfsError::InvalidInput)?;
 
         // Linux kernel: each fd can only call CONTEXT_INIT once.
-        if self.process_ctxs.lock().get(&pid).is_some_and(|c| c.initialized) {
+        if self
+            .process_ctxs
+            .lock()
+            .get(&pid)
+            .is_some_and(|c| c.initialized)
+        {
             return Err(VfsError::AlreadyExists);
         }
 
@@ -2494,8 +3438,7 @@ impl Card0 {
             // context the same label and make host-side error logs ("starry-
             // ctx-2") indistinguishable across clients.
             let ctx_name = format!("starry-ctx-{ctx_id}");
-            ax_display::gpu3d_ctx_create(ctx_id, &ctx_name, capset_id)
-                .map_err(map_gpu3d_err)?;
+            ax_display::gpu3d_ctx_create(ctx_id, &ctx_name, capset_id).map_err(map_gpu3d_err)?;
         }
 
         self.process_ctxs.lock().insert(
@@ -2576,8 +3519,45 @@ impl Card0 {
     /// `res_handle` (NOT the GEM handle — they are different!).
     fn handle_virtgpu_resource_create(&self, arg: usize) -> VfsResult<usize> {
         let ptr = arg as *mut DrmVirtgpuResourceCreate;
-        let mut r: DrmVirtgpuResourceCreate =
-            ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+        let mut r: DrmVirtgpuResourceCreate = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // ---- Step-0 #2 forensic: who creates a per-frame buffer, and is it
+        // a reusable shape? Aggregates go to perf_report's per-window table;
+        // the first CREATE_DETAIL_LIMIT calls also log full detail so a human
+        // sees the exact Mesa geometry/flag mix. This is pure measurement —
+        // no effect on the resource path below. ----
+        let create_pid = self.current_pid().unwrap_or(0);
+        let exe = current_may_uninit()
+            .map(|cur| cur.as_thread().proc_data.exe_path.read().clone())
+            .unwrap_or_default();
+        {
+            let mut by_pid = self.create_by_pid.lock();
+            match by_pid.get_mut(&create_pid) {
+                Some((n, _)) => *n += 1,
+                None => {
+                    let tail: Vec<u8> = exe
+                        .as_bytes()
+                        .iter()
+                        .rev()
+                        .take(64)
+                        .copied()
+                        .collect::<Vec<_>>()
+                        .into_iter()
+                        .rev()
+                        .collect();
+                    by_pid.insert(create_pid, (1, tail));
+                }
+            }
+        }
+        self.rescreate_geoms.lock().insert((r.width, r.height));
+        let detail_n = CREATE_DETAIL_N.fetch_add(1, Ordering::Relaxed);
+        if detail_n < CREATE_DETAIL_LIMIT {
+            warn!(
+                "[card0:create3d] #{detail_n} pid={create_pid} exe={exe} target=0x{:x} fmt=0x{:x} \
+                 bind=0x{:x} {}x{} d={} arr={} size={}",
+                r.target, r.format, r.bind, r.width, r.height, r.depth, r.array_size, r.size
+            );
+        }
 
         // Linux: if (vgdev->has_virgl_3d) virtio_gpu_create_context(dev, file);
         // 我们在 CONTEXT_INIT 时已经创建了上下文。
@@ -2601,84 +3581,100 @@ impl Card0 {
             return Err(VfsError::InvalidInput);
         }
 
-        let pages = GlobalPage::alloc_contiguous(
-            (size as usize).div_ceil(PAGE_SIZE_4K),
-            PAGE_SIZE_4K,
-        )
-        .map_err(|_| VfsError::NoMemory)?;
-
         // Zero-initialize the buffer.
-        unsafe {
-            core::ptr::write_bytes(pages.start_vaddr().as_ptr() as *mut u8, 0, size as usize);
-        }
+        let pages = timed(&RC_ALLOC_SUM, &RC_ALLOC_CNT, || {
+            let pages =
+                GlobalPage::alloc_contiguous((size as usize).div_ceil(PAGE_SIZE_4K), PAGE_SIZE_4K)
+                    .map_err(|_| VfsError::NoMemory)?;
+            unsafe {
+                core::ptr::write_bytes(pages.start_vaddr().as_ptr() as *mut u8, 0, size as usize);
+            }
+            Ok::<_, VfsError>(pages)
+        })?;
+        RC_PAGE_SUM.fetch_add(
+            (size as usize).div_ceil(PAGE_SIZE_4K) as u64,
+            Ordering::Relaxed,
+        );
 
         // Allocate a new GEM handle.
         let bo_handle = self.next_dumb_handle.fetch_add(1, Ordering::Relaxed);
-        let offset = self.next_offset.fetch_add(DUMB_BUFFER_OFFSET_STRIDE, Ordering::Relaxed);
+        let offset = self
+            .next_offset
+            .fetch_add(DUMB_BUFFER_OFFSET_STRIDE, Ordering::Relaxed);
 
         // Physical address of the backing pages, needed for ATTACH_BACKING.
         // Computed before `pages` moves into the Arc below.
         let backing_paddr = virt_to_phys(pages.start_vaddr());
         let backing_size = pages.size();
 
-        self.dumbs.lock().insert(bo_handle, DumbBuffer {
-            width: r.width,
-            height: r.height,
-            bpp: 32,
-            pitch: r.stride,
-            size,
-            offset,
-            pages: Arc::new(pages),
-        });
+        self.dumbs.lock().insert(
+            bo_handle,
+            DumbBuffer {
+                width: r.width,
+                height: r.height,
+                bpp: 32,
+                pitch: r.stride,
+                size,
+                offset,
+                pages: Arc::new(pages),
+            },
+        );
 
         // Create the resource on the host via the display driver.
         if ax_display::has_virgl() {
             let ctx_id = self.current_ctx().ok_or(VfsError::InvalidInput)?;
-            ax_display::gpu3d_resource_create(
-                ctx_id,
-                res_handle,
-                r.target,
-                r.format,
-                r.bind,
-                r.width,
-                r.height,
-                r.depth,
-                r.array_size,
-                r.last_level,
-                r.nr_samples,
-                r.flags,
-            )
-            .map_err(map_gpu3d_err)?;
+            timed(&RC_ENQ_SUM, &RC_ENQ_CNT, || {
+                ax_display::gpu3d_resource_create(
+                    ctx_id,
+                    res_handle,
+                    r.target,
+                    r.format,
+                    r.bind,
+                    r.width,
+                    r.height,
+                    r.depth,
+                    r.array_size,
+                    r.last_level,
+                    r.nr_samples,
+                    r.flags,
+                )
+                .map_err(map_gpu3d_err)?;
 
-            // Linux: `virtio_gpu_object_create()` (virtgpu_object.c) virgl
-            // branch calls `virtio_gpu_object_attach()` right after
-            // `virtio_gpu_cmd_resource_create_3d()` — the backing pages are
-            // what the host reads/writes for TRANSFER3D.  Mesa 25.x encoded
-            // transfers never use the TRANSFER_TO_HOST ioctl: the data lives
-            // in these guest pages and vrend reads it via res->iov.  Without
-            // the backing, TRANSFER3D fails check_transfer_iovec with
-            // "Illegal resource" and the whole context goes into in_error.
-            ax_display::gpu3d_attach_backing(
-                res_handle,
-                backing_paddr.as_usize() as u64,
-                backing_size as u32,
-            )
-            .map_err(map_gpu3d_err)?;
+                // Linux: `virtio_gpu_object_create()` (virtgpu_object.c) virgl
+                // branch calls `virtio_gpu_object_attach()` right after
+                // `virtio_gpu_cmd_resource_create_3d()` — the backing pages are
+                // what the host reads/writes for TRANSFER3D.  Mesa 25.x encoded
+                // transfers never use the TRANSFER_TO_HOST ioctl: the data lives
+                // in these guest pages and vrend reads it via res->iov.  Without
+                // the backing, TRANSFER3D fails check_transfer_iovec with
+                // "Illegal resource" and the whole context goes into in_error.
+                ax_display::gpu3d_attach_backing(
+                    res_handle,
+                    backing_paddr.as_usize() as u64,
+                    backing_size as u32,
+                )
+                .map_err(map_gpu3d_err)?;
+                Ok::<_, VfsError>(())
+            })?;
         }
 
         // Track the resource locally.
-        self.gpu_resources.lock().insert(res_handle, GpuResource {
-            bo_handle,
-            width: r.width,
-            height: r.height,
-            stride: r.stride,
-            size,
-            attached: false,
-            // Classic (non-blob) resources have no blob_mem/flags.
-            blob_mem: 0,
-            blob_flags: 0,
-            is_dumb_2d: false,
-        });
+        self.gpu_resources.lock().insert(
+            res_handle,
+            GpuResource {
+                bo_handle,
+                width: r.width,
+                height: r.height,
+                stride: r.stride,
+                size,
+                attached_ctxs: BTreeSet::new(),
+                // Classic (non-blob) resources have no blob_mem/flags.
+                blob_mem: 0,
+                blob_flags: 0,
+                is_dumb_2d: false,
+                created_pid: create_pid,
+            },
+        );
 
         // Attach the resource to this fd's context immediately. Linux does
         // this in `virtio_gpu_gem_object_open` (CTX_ATTACH_RESOURCE on every
@@ -2688,10 +3684,12 @@ impl Card0 {
         let ctx_id = self.current_ctx().unwrap_or(0);
         if ax_display::has_virgl()
             && ctx_id != 0
-            && ax_display::gpu3d_ctx_attach_resource(ctx_id, res_handle).is_ok()
+            && timed(&RC_CTXA_SUM, &RC_CTXA_CNT, || {
+                ax_display::gpu3d_ctx_attach_resource(ctx_id, res_handle).is_ok()
+            })
             && let Some(res) = self.gpu_resources.lock().get_mut(&res_handle)
         {
-            res.attached = true;
+            res.attached_ctxs.insert(ctx_id);
             info!("[card0] CTX_ATTACH res={:#x} ctx={} ok", res_handle, ctx_id);
         }
 
@@ -2702,6 +3700,13 @@ impl Card0 {
         r.size = size as u32;
         ptr.vm_write(r).map_err(|_| VfsError::BadAddress)?;
 
+        // RESOURCE_CREATE is a multi-command ioctl (create_3d + attach_backing
+        // + ctx_attach, all fire-and-forget). One notify at the boundary
+        // delivers the whole transaction — Linux `virtio_gpu_notify()`.
+        timed(&RC_NOTIFY_SUM, &RC_NOTIFY_CNT, || {
+            ax_display::gpu3d_ctrl_notify()
+        });
+
         Ok(0)
     }
 
@@ -2710,8 +3715,7 @@ impl Card0 {
     /// Linux: `virtgpu_resource_info_ioctl()` in `virtgpu_ioctl.c`
     fn handle_virtgpu_resource_info(&self, arg: usize) -> VfsResult<usize> {
         let ptr = arg as *mut DrmVirtgpuResourceInfo;
-        let mut info: DrmVirtgpuResourceInfo =
-            ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+        let mut info: DrmVirtgpuResourceInfo = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
 
         // Linux: gobj = drm_gem_object_lookup(file, ri->bo_handle);
         //        if (gobj == NULL) return -ENOENT;
@@ -2731,7 +3735,7 @@ impl Card0 {
         let resources = self.gpu_resources.lock();
         let res = resources.values().find(|r| r.bo_handle == info.bo_handle);
         let Some(res) = res else {
-            return Err(VfsError::NotFound);  // ENOENT
+            return Err(VfsError::NotFound); // ENOENT
         };
 
         info.size = res.size as u32;
@@ -2739,7 +3743,10 @@ impl Card0 {
         // is the fix that lets Mesa's importer reuse the host texture.
         info.blob_mem = res.blob_mem;
         // Find the res_handle for this bo_handle.
-        if let Some((&rh, _)) = resources.iter().find(|(_, r)| r.bo_handle == info.bo_handle) {
+        if let Some((&rh, _)) = resources
+            .iter()
+            .find(|(_, r)| r.bo_handle == info.bo_handle)
+        {
             info.res_handle = rh;
         }
         drop(resources);
@@ -2779,8 +3786,25 @@ impl Card0 {
     /// **Critical**: There is NO ctx_id field. The context is implicitly
     /// bound to the file descriptor.
     fn handle_virtgpu_execbuffer(&self, arg: usize) -> VfsResult<usize> {
-        let mut eb: DrmVirtgpuExecbuffer =
-            (arg as *const DrmVirtgpuExecbuffer).vm_read().map_err(|_| VfsError::BadAddress)?;
+        let mut eb: DrmVirtgpuExecbuffer = (arg as *const DrmVirtgpuExecbuffer)
+            .vm_read()
+            .map_err(|_| VfsError::BadAddress)?;
+
+        // ---- Step-0 #1-a forensic: which fence mode does Mesa select?
+        // (legacy fence-fd vs modern syncobj vs none). Per-window totals and
+        // delta vs PERF_EXECBUF.cnt show how many submits run sync-object-free.
+        if (eb.flags & VIRTGPU_EXECBUF_FENCE_FD_IN) != 0 {
+            EXECB_FENCE_FD_IN.fetch_add(1, Ordering::Relaxed);
+        }
+        if (eb.flags & VIRTGPU_EXECBUF_FENCE_FD_OUT) != 0 {
+            EXECB_FENCE_FD_OUT.fetch_add(1, Ordering::Relaxed);
+        }
+        if eb.num_in_syncobjs > 0 {
+            EXECB_SYNC_IN.fetch_add(1, Ordering::Relaxed);
+        }
+        if eb.num_out_syncobjs > 0 {
+            EXECB_SYNC_OUT.fetch_add(1, Ordering::Relaxed);
+        }
 
         // Linux: if (vgdev->has_virgl_3d == false) return -ENOSYS;
         if !ax_display::has_virgl() {
@@ -2803,14 +3827,24 @@ impl Card0 {
             return Err(VfsError::InvalidInput);
         }
 
-        // Validate fence_fd (must be -1 for now — we don't support fence fd yet).
-        if eb.fence_fd != -1 && (eb.flags & (VIRTGPU_EXECBUF_FENCE_FD_IN | VIRTGPU_EXECBUF_FENCE_FD_OUT)) != 0 {
-            info!("[card0] EXECBUFFER: fence_fd support not implemented, fd={}", eb.fence_fd);
-            // Don't fail — just ignore the fence for now.
-        }
-
-        // Linux: exbuf->fence_fd = -1; (总是重置为 -1)
-        eb.fence_fd = -1;
+        // Resolve the in-fence before touching the command buffer. Linux
+        // borrows the guest's fd (mesa closes it after the ioctl returns) and
+        // blocks the batch on the imported fence; only a sync_file fd created
+        // by this driver can carry a fence here — anything else is -EINVAL
+        // (mesa prints a debug line and continues, it does not crash).
+        let in_fence = if (eb.flags & VIRTGPU_EXECBUF_FENCE_FD_IN) != 0 {
+            if eb.fence_fd < 0 {
+                return Err(VfsError::InvalidInput);
+            }
+            let file = get_file_like(eb.fence_fd).map_err(|_| VfsError::InvalidInput)?;
+            let fence = file
+                .downcast_arc::<SyncFile>()
+                .ok()
+                .ok_or(VfsError::InvalidInput)?;
+            Some(fence)
+        } else {
+            None
+        };
 
         // Validate bo_handles array.
         if eb.num_bo_handles > 256 {
@@ -2819,14 +3853,17 @@ impl Card0 {
 
         // Read command buffer from userspace.
         let cmd_buf = if eb.command != 0 && eb.size > 0 {
-            vm_load(eb.command as *const u8, eb.size as usize)
-                .map_err(|_| VfsError::BadAddress)?
+            vm_load(eb.command as *const u8, eb.size as usize).map_err(|_| VfsError::BadAddress)?
         } else {
             Vec::new()
         };
 
         // Read and validate bo_handles array from userspace.
         // Each handle is a u32, stored at a u64 pointer.
+        // Hoisted outside the block: VIRTGPU_WAIT maps each handle to the
+        // fence of the last EXECBUFFER that referenced it (Linux per-object
+        // dma-resv), so the handles must outlive the attach block below.
+        let mut submit_bo_handles = Vec::new();
         if eb.num_bo_handles > 0 && eb.bo_handles != 0 {
             let handles_ptr = eb.bo_handles as *const u32;
             let mut handles = vec![0u32; eb.num_bo_handles as usize];
@@ -2835,10 +3872,17 @@ impl Card0 {
                     .vm_read()
                     .map_err(|_| VfsError::BadAddress)?;
             }
+            submit_bo_handles.extend_from_slice(&handles);
 
-            // Attach any unattached resources to the context. Imported blob
-            // handles (from PRIME_FD_TO_HANDLE) resolve through
-            // `blob_aliases` to the same host resource the exporter created.
+            // Attach resources to this context on first use only. Linux does
+            // this once per GEM open (`virtio_gpu_gem_object_open` →
+            // CTX_ATTACH_RESOURCE); we mirror that at (ctx, resource)
+            // granularity because weston and the app each hold a context that
+            // shares the same buffers. Re-attaching every handle on every
+            // EXECBUFFER was ~29 synchronous RTTs per frame (~2.4ms) — the
+            // fixed floor that the async rewrite could not move. Imported
+            // blob handles (from PRIME_FD_TO_HANDLE) resolve through
+            // `blob_aliases` to the host resource the exporter created.
             let resources = self.gpu_resources.lock();
             let aliases = self.blob_aliases.lock();
             let mut to_attach = Vec::new();
@@ -2850,6 +3894,9 @@ impl Card0 {
                     .or_else(|| aliases.get(&h).map(|imp| imp.res_handle));
                 if let Some(rh) = rh
                     && ax_display::has_virgl()
+                    && !resources
+                        .get(&rh)
+                        .is_some_and(|r| r.attached_ctxs.contains(&ctx_id))
                 {
                     to_attach.push(rh);
                 }
@@ -2858,35 +3905,61 @@ impl Card0 {
             drop(resources);
 
             for rh in to_attach {
-                let _ = ax_display::gpu3d_ctx_attach_resource(ctx_id, rh);
-            }
-
-            // Mark attached resources.
-            let mut resources = self.gpu_resources.lock();
-            for &h in &handles {
-                let rh = resources
-                    .iter()
-                    .find(|(_, r)| r.bo_handle == h)
-                    .map(|(&rh, _)| rh)
-                    .or_else(|| self.blob_aliases.lock().get(&h).map(|imp| imp.res_handle));
-                if let Some(rh) = rh
-                    && let Some(res) = resources.get_mut(&rh)
+                if ax_display::gpu3d_ctx_attach_resource(ctx_id, rh).is_ok()
+                    && let Some(res) = self.gpu_resources.lock().get_mut(&rh)
                 {
-                    res.attached = true;
+                    res.attached_ctxs.insert(ctx_id);
                 }
             }
         }
 
-        // Submit the command buffer to the host.
-        if ax_display::has_virgl() {
-            let _fence_id = ax_display::gpu3d_submit_cmd(ctx_id, &cmd_buf)
-                .map_err(map_gpu3d_err)?;
-            // fence_id is available but we don't return it to userspace
-            // yet (no fence fd support).
+        // Enforce the in-fence dependency: the batch must not reach the host
+        // until the imported fence signals (Linux waits the in-fence inside
+        // `virtgpu_execbuffer_ioctl` before `virtio_gpu_execbuffer`).
+        if let Some(in_fence) = &in_fence
+            && in_fence.wait_signaled(None).is_err()
+        {
+            // Unreachable today (unbounded wait), but never convert a failed
+            // dependency into a silently unordered submit.
+            return Err(VfsError::InvalidInput);
         }
+        // Submit the command buffer to the host.
+        let mut out_fence_fd: i32 = -1;
+        if ax_display::has_virgl() {
+            let fence_id = ax_display::gpu3d_submit_cmd(ctx_id, &cmd_buf).map_err(map_gpu3d_err)?;
+            // Record handle → fence so VIRTGPU_WAIT can honestly wait on the
+            // last batch that referenced each handle (Linux per-object
+            // dma-resv; `virtio_gpu_wait_ioctl`). Handles never submitted
+            // (dumb buffers, created-but-idle GEMs) stay out of the map and
+            // report idle in WAIT.
+            let mut bo_fence = self.bo_fence.lock();
+            for h in &submit_bo_handles {
+                let e = bo_fence.entry(*h).or_insert(0);
+                *e = (*e).max(fence_id);
+            }
+            drop(bo_fence);
 
-        // Linux: 写回 fence_fd（如果支持 fence）
-        // 当前我们不支持 fence，所以 fence_fd 保持 -1。
+            // Linux: `VIRTGPU_EXECBUF_FENCE_FD_OUT` wraps the submit fence in
+            // a sync_file and returns the fd (`virtgpu_execbuffer_ioctl`). The
+            // fence starts unsignaled because the submit is fire-and-forget;
+            // it signals when the host pops the fenced command. fd exhaustion
+            // must fail the ioctl — a success return with an invalid fd would
+            // make mesa's fence_create dup -1 and risk a NULL fence.
+            if (eb.flags & VIRTGPU_EXECBUF_FENCE_FD_OUT) != 0 {
+                let sync_file = Arc::new(SyncFile::new(fence_id));
+                sync_file.register();
+                out_fence_fd = add_file_like(sync_file, true).map_err(|_| VfsError::NoMemory)?;
+            }
+        }
+        eb.fence_fd = out_fence_fd;
+        (arg as *mut DrmVirtgpuExecbuffer)
+            .vm_write(eb)
+            .map_err(|_| VfsError::BadAddress)?;
+
+        // EXECBUFFER is a fire-and-forget transaction (optional ctx_attach +
+        // submit_3d); one boundary notify delivers it — Linux
+        // `virtio_gpu_notify()`.
+        ax_display::gpu3d_ctrl_notify();
 
         Ok(0)
     }
@@ -2897,9 +3970,9 @@ impl Card0 {
     /// (Note: Linux naming is confusing — "from_host" means "from guest
     /// memory to host" in the virtio-gpu spec.)
     fn handle_virtgpu_transfer_to_host(&self, arg: usize) -> VfsResult<usize> {
-        let t: DrmVirtgpu3dTransferToHost =
-            (arg as *const DrmVirtgpu3dTransferToHost).vm_read()
-                .map_err(|_| VfsError::BadAddress)?;
+        let t: DrmVirtgpu3dTransferToHost = (arg as *const DrmVirtgpu3dTransferToHost)
+            .vm_read()
+            .map_err(|_| VfsError::BadAddress)?;
 
         // Linux: if (vgdev->has_virgl_3d == false) return -ENOSYS;
         if !ax_display::has_virgl() {
@@ -2914,7 +3987,7 @@ impl Card0 {
         let resources = self.gpu_resources.lock();
         let res = resources.values().find(|r| r.bo_handle == t.bo_handle);
         let Some(_res) = res else {
-            return Err(VfsError::NotFound);  // ENOENT
+            return Err(VfsError::NotFound); // ENOENT
         };
         drop(resources);
 
@@ -2930,7 +4003,8 @@ impl Card0 {
             };
             // Find the res_handle for this bo_handle.
             let resources = self.gpu_resources.lock();
-            let res_handle = resources.iter()
+            let res_handle = resources
+                .iter()
                 .find(|(_, r)| r.bo_handle == t.bo_handle)
                 .map(|(&rh, _)| rh)
                 .unwrap_or(0);
@@ -2955,9 +4029,9 @@ impl Card0 {
     ///
     /// Linux: `virtgpu_transfer_to_host_ioctl()` in `virtgpu_ioctl.c`
     fn handle_virtgpu_transfer_from_host(&self, arg: usize) -> VfsResult<usize> {
-        let t: DrmVirtgpu3dTransferFromHost =
-            (arg as *const DrmVirtgpu3dTransferFromHost).vm_read()
-                .map_err(|_| VfsError::BadAddress)?;
+        let t: DrmVirtgpu3dTransferFromHost = (arg as *const DrmVirtgpu3dTransferFromHost)
+            .vm_read()
+            .map_err(|_| VfsError::BadAddress)?;
 
         // Linux: if (vgdev->has_virgl_3d == false) return -ENOSYS;
         if !ax_display::has_virgl() {
@@ -2972,7 +4046,7 @@ impl Card0 {
         let resources = self.gpu_resources.lock();
         let res = resources.values().find(|r| r.bo_handle == t.bo_handle);
         let Some(_res) = res else {
-            return Err(VfsError::NotFound);  // ENOENT
+            return Err(VfsError::NotFound); // ENOENT
         };
         drop(resources);
 
@@ -2987,7 +4061,8 @@ impl Card0 {
                 d: t.box_.d,
             };
             let resources = self.gpu_resources.lock();
-            let res_handle = resources.iter()
+            let res_handle = resources
+                .iter()
                 .find(|(_, r)| r.bo_handle == t.bo_handle)
                 .map(|(&rh, _)| rh)
                 .unwrap_or(0);
@@ -3012,11 +4087,21 @@ impl Card0 {
     ///
     /// Linux: `virtgpu_wait_ioctl()` in `virtgpu_ioctl.c`
     ///
-    /// We implement this as a synchronous wait (the resource is always
-    /// "ready" since we process commands synchronously).
+    /// Honest wait: blocks until the last EXECBUFFER referencing the handle
+    /// has completed on the host. The completion signal is the fenced submit's
+    /// used-pop — the virgl fence firing after the host executed the batch.
+    /// NOWAIT returns EBUSY instead of blocking (`dma_resv_test_signaled`).
     fn handle_virtgpu_wait(&self, arg: usize) -> VfsResult<usize> {
-        let w: DrmVirtgpu3dWait =
-            (arg as *const DrmVirtgpu3dWait).vm_read().map_err(|_| VfsError::BadAddress)?;
+        let w: DrmVirtgpu3dWait = (arg as *const DrmVirtgpu3dWait)
+            .vm_read()
+            .map_err(|_| VfsError::BadAddress)?;
+
+        // ---- Step-0 #1-a forensic: NOWAIT probe vs blocking wait, and which
+        // handles Mesa actually waits on (one per batch vs a small cache). ----
+        if (w.flags & VIRTGPU_WAIT_NOWAIT) != 0 {
+            WAIT_NOWAIT.fetch_add(1, Ordering::Relaxed);
+        }
+        self.wait_handles.lock().insert(w.handle);
 
         // Linux: handle=0 is invalid.
         if w.handle == 0 {
@@ -3040,11 +4125,28 @@ impl Card0 {
         drop(aliases);
 
         if !has_dumb && !has_res && !has_alias {
-            return Err(VfsError::NotFound);  // ENOENT
+            return Err(VfsError::NotFound); // ENOENT
         }
 
-        // Since we process commands synchronously, the resource is always
-        // ready. Linux would wait on a fence here.
+        // Linux: dma_resv_wait_timeout(gobj->resv, ..., nowait ? 0 : timeout);
+        // The per-object dma-resv is our handle → last-submit fence map.
+        // A handle with no recorded submit has no pending fence and is
+        // immediately idle (dma_resv_wait_timeout returns 0 with no fences).
+        let last_fence = self.bo_fence.lock().get(&w.handle).copied().unwrap_or(0);
+        if last_fence != 0 {
+            if (w.flags & VIRTGPU_WAIT_NOWAIT) != 0 {
+                // Linux: dma_resv_test_signaled → -EBUSY while busy.
+                if !ax_display::gpu3d_fence_completed(last_fence).map_err(map_gpu3d_err)? {
+                    WAIT_BUSY.fetch_add(1, Ordering::Relaxed);
+                    return Err(VfsError::ResourceBusy); // EBUSY
+                }
+            } else {
+                // Linux: blocking dma_resv_wait_timeout (default 15s timeout);
+                // we wait until the host pops the fenced submit, i.e. the
+                // virgl fence fired.
+                ax_display::gpu3d_wait_fence(last_fence).map_err(map_gpu3d_err)?;
+            }
+        }
         Ok(0)
     }
 
@@ -3117,11 +4219,8 @@ impl Card0 {
         // that carry an iov. The shadow is only for mmap compatibility —
         // the present path is zero-copy on the host, no CPU readback.
         let alloc_size = (b.size as usize).div_ceil(PAGE_SIZE_4K) * PAGE_SIZE_4K;
-        let pages = GlobalPage::alloc_contiguous(
-            alloc_size / PAGE_SIZE_4K,
-            PAGE_SIZE_4K,
-        )
-        .map_err(|_| VfsError::NoMemory)?;
+        let pages = GlobalPage::alloc_contiguous(alloc_size / PAGE_SIZE_4K, PAGE_SIZE_4K)
+            .map_err(|_| VfsError::NoMemory)?;
 
         // Zero-initialize.
         unsafe {
@@ -3130,17 +4229,22 @@ impl Card0 {
 
         // Allocate a GEM handle.
         let bo_handle = self.next_dumb_handle.fetch_add(1, Ordering::Relaxed);
-        let offset = self.next_offset.fetch_add(DUMB_BUFFER_OFFSET_STRIDE, Ordering::Relaxed);
+        let offset = self
+            .next_offset
+            .fetch_add(DUMB_BUFFER_OFFSET_STRIDE, Ordering::Relaxed);
 
-        self.dumbs.lock().insert(bo_handle, DumbBuffer {
-            width: 0, // Blobs don't have geometry.
-            height: 0,
-            bpp: 0,
-            pitch: 0,
-            size: b.size,
-            offset,
-            pages: Arc::new(pages),
-        });
+        self.dumbs.lock().insert(
+            bo_handle,
+            DumbBuffer {
+                width: 0, // Blobs don't have geometry.
+                height: 0,
+                bpp: 0,
+                pitch: 0,
+                size: b.size,
+                offset,
+                pages: Arc::new(pages),
+            },
+        );
 
         // Allocate a virtio-gpu resource ID.
         let res_handle = self.next_res_handle.fetch_add(1, Ordering::Relaxed);
@@ -3155,8 +4259,7 @@ impl Card0 {
         // is the Linux order (both commands execute in sequence on the same
         // virtqueue).
         let cmd_buf = if b.cmd_size > 0 && b.cmd != 0 {
-            vm_load(b.cmd as *const u8, b.cmd_size as usize)
-                .map_err(|_| VfsError::BadAddress)?
+            vm_load(b.cmd as *const u8, b.cmd_size as usize).map_err(|_| VfsError::BadAddress)?
         } else {
             Vec::new()
         };
@@ -3177,17 +4280,21 @@ impl Card0 {
 
         // Track the resource. blob_mem/blob_flags feed RESOURCE_INFO so
         // Mesa's importer can take the untyped (reuse-host-texture) path.
-        self.gpu_resources.lock().insert(res_handle, GpuResource {
-            bo_handle,
-            width: 0,
-            height: 0,
-            stride: 0,
-            size: b.size,
-            attached: false,
-            blob_mem: b.blob_mem,
-            blob_flags: b.blob_flags,
-            is_dumb_2d: false,
-        });
+        self.gpu_resources.lock().insert(
+            res_handle,
+            GpuResource {
+                bo_handle,
+                width: 0,
+                height: 0,
+                stride: 0,
+                size: b.size,
+                attached_ctxs: BTreeSet::new(),
+                blob_mem: b.blob_mem,
+                blob_flags: b.blob_flags,
+                is_dumb_2d: false,
+                created_pid: self.current_pid().unwrap_or(0),
+            },
+        );
 
         // Linux: rc_blob->res_handle = bo->hw_res_handle;
         //        rc_blob->bo_handle = handle;

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -14,10 +14,13 @@
 //!     monotonic offset key; `Card0::mmap(offset, length)` resolves that key
 //!     back to the buffer's per-allocation physical range. On
 //!     `SETCRTC` / `PAGE_FLIP` / non-`TEST_ONLY` atomic commit,
-//!     `present_fb` memcpies the committed buffer into the axdisplay
-//!     scanout framebuffer and kicks `framebuffer_flush`. PRIME export
-//!     and virtio-gpu zero-copy resource plumbing land in follow-on
-//!     PRs.
+//!     `present_fb` presents the committed buffer: guest-RAM dumb
+//!     buffers are memcpy'd into the axdisplay scanout framebuffer and
+//!     `framebuffer_flush` kicked, while host-side virgl 3D resources
+//!     (Weston/glamor GBM scanout buffers) are bound with
+//!     `SET_SCANOUT` + `RESOURCE_FLUSH` — matching Linux
+//!     `virtio_gpu_plane_atomic_update`. PRIME export and virtio-gpu
+//!     zero-copy resource plumbing land in follow-on PRs.
 //!   - Property validation is permissive: value ranges aren't rigorously
 //!     enforced (tests drive sensible values). Atomic rejects only
 //!     unknown `(obj, prop)` pairs and obviously-bad object/blob refs.
@@ -31,7 +34,7 @@ use alloc::{
     collections::{BTreeMap, VecDeque},
     format,
     string::String,
-    sync::Arc,
+    sync::{Arc, Weak},
     vec,
     vec::Vec,
 };
@@ -44,17 +47,21 @@ use core::{
 use ax_alloc::GlobalPage;
 use ax_memory_addr::{PAGE_SIZE_4K, PhysAddrRange};
 use ax_runtime::hal::{mem::virt_to_phys, time::monotonic_time};
+use ax_task::current_may_uninit;
 use axfs_ng_vfs::{NodeFlags, VfsError, VfsResult};
 use axpoll::{IoEvents, PollSet, Pollable};
 use bytemuck::bytes_of;
 use linux_raw_sys::general::O_CLOEXEC;
 use starry_vm::{VmMutPtr, VmPtr, vm_load, vm_write_slice};
 
+use crate::task::AsThread;
+
 use super::drm::{
     DRM_CAP_ADDFB2_MODIFIERS, DRM_CAP_CRTC_IN_VBLANK_EVENT, DRM_CAP_DUMB_BUFFER, DRM_CAP_PRIME,
     DRM_CAP_TIMESTAMP_MONOTONIC, DRM_EVENT_FLIP_COMPLETE, DRM_FORMAT_ARGB8888,
     DRM_FORMAT_MOD_INVALID, DRM_FORMAT_MOD_LINEAR, DRM_FORMAT_XRGB8888, DRM_IOCTL_AUTH_MAGIC,
-    DRM_IOCTL_DROP_MASTER, DRM_IOCTL_GET_CAP, DRM_IOCTL_GET_MAGIC, DRM_IOCTL_GET_UNIQUE,
+    DRM_IOCTL_DROP_MASTER, DRM_IOCTL_GEM_CLOSE, DRM_IOCTL_GET_CAP, DRM_IOCTL_GET_MAGIC,
+    DRM_IOCTL_GET_UNIQUE,
     DRM_IOCTL_MODE_ADDFB2, DRM_IOCTL_MODE_ATOMIC, DRM_IOCTL_MODE_CREATE_DUMB,
     DRM_IOCTL_MODE_CREATEPROPBLOB, DRM_IOCTL_MODE_DESTROY_DUMB, DRM_IOCTL_MODE_DESTROYPROPBLOB,
     DRM_IOCTL_MODE_DIRTYFB, DRM_IOCTL_MODE_GETCONNECTOR, DRM_IOCTL_MODE_GETCRTC,
@@ -72,10 +79,30 @@ use super::drm::{
     DRM_PRIME_CAP_EXPORT, DRM_PRIME_CAP_IMPORT, DRM_PROP_NAME_LEN, DrmAuth, DrmEvent,
     DrmEventVblank, DrmGetCap, DrmModeAtomic, DrmModeCardRes, DrmModeCreateBlob, DrmModeCreateDumb,
     DrmModeCrtc, DrmModeCrtcPageFlip, DrmModeDestroyBlob, DrmModeDestroyDumb, DrmModeDirtyFB,
-    DrmModeFbCmd2, DrmModeGetBlob, DrmModeGetConnector, DrmModeGetEncoder, DrmModeGetPlane,
+    DrmModeFbCmd2, DrmGemClose, DrmModeGetBlob, DrmModeGetConnector, DrmModeGetEncoder,
+    DrmModeGetPlane,
     DrmModeGetPlaneRes, DrmModeGetProperty, DrmModeMapDumb, DrmModeModeInfo,
     DrmModeObjGetProperties, DrmModePropertyEnum, DrmPrimeHandle, DrmSetClientCap, DrmSetVersion,
     DrmUnique, DrmVersion, DrmWaitVblank,
+    // virtgpu structs and constants
+    DRM_IOCTL_VIRTGPU_CONTEXT_INIT, DRM_IOCTL_VIRTGPU_EXECBUFFER,
+    DRM_IOCTL_VIRTGPU_GET_CAPS, DRM_IOCTL_VIRTGPU_GETPARAM, DRM_IOCTL_VIRTGPU_MAP,
+    DRM_IOCTL_VIRTGPU_RESOURCE_CREATE, DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB,
+    DRM_IOCTL_VIRTGPU_RESOURCE_INFO, DRM_IOCTL_VIRTGPU_TRANSFER_FROM_HOST,
+    DRM_IOCTL_VIRTGPU_TRANSFER_TO_HOST, DRM_IOCTL_VIRTGPU_WAIT,
+    DrmVirtgpu3dTransferFromHost, DrmVirtgpu3dTransferToHost,
+    DrmVirtgpu3dWait, DrmVirtgpuContextInit, DrmVirtgpuContextSetParam, DrmVirtgpuExecbuffer,
+    DrmVirtgpuGetCaps, DrmVirtgpuGetparam, DrmVirtgpuMap, DrmVirtgpuResourceCreate,
+    DrmVirtgpuResourceCreateBlob, DrmVirtgpuResourceInfo,
+    VIRTGPU_BLOB_MEM_GUEST, VIRTGPU_BLOB_MEM_HOST3D, VIRTGPU_BLOB_MEM_HOST3D_GUEST,
+    VIRTGPU_CONTEXT_PARAM_CAPSET_ID, VIRTGPU_CONTEXT_PARAM_NUM_RINGS,
+    VIRTGPU_CONTEXT_PARAM_POLL_RINGS_MASK,
+    VIRTGPU_DRM_CAPSET_DRM, VIRTGPU_DRM_CAPSET_VIRGL, VIRTGPU_DRM_CAPSET_VIRGL2,
+    VIRTGPU_EXECBUF_FENCE_FD_IN, VIRTGPU_EXECBUF_FENCE_FD_OUT,
+    VIRTGPU_PARAM_3D_FEATURES, VIRTGPU_PARAM_CAPSET_QUERY_FIX,
+    VIRTGPU_PARAM_CONTEXT_INIT, VIRTGPU_PARAM_CROSS_DEVICE,
+    VIRTGPU_PARAM_HOST_VISIBLE, VIRTGPU_PARAM_RESOURCE_BLOB,
+    VIRTGPU_PARAM_SUPPORTED_CAPSET_IDS,
 };
 use crate::{
     StarryError, StarryResult,
@@ -84,10 +111,14 @@ use crate::{
     sync::Mutex,
 };
 
-pub const DRIVER_NAME: &str = "starry-simpledrm";
+pub const DRIVER_NAME: &str = "virtio_gpu";
 pub const DRIVER_DATE: &str = "2026-04-19";
 pub const DRIVER_DESC: &str = "StarryOS simple DRM driver";
-pub const DRIVER_VERSION_MAJOR: i32 = 1;
+// Linux virtio-gpu 用 DRIVER_MAJOR=0 / DRIVER_MINOR=0。mesa 的
+// `virgl_drm_get_version`(virgl_drm_winsys.c)要求 `version_major == 0`
+// 否则返回 -EINVAL → virgl winsys 创建失败。minor 保持 0 让 mesa 走 legacy
+// fence 路径(card0 尚未实现 EXECBUFFER fence-fd)。
+pub const DRIVER_VERSION_MAJOR: i32 = 0;
 pub const DRIVER_VERSION_MINOR: i32 = 0;
 pub const DRIVER_VERSION_PATCHLEVEL: i32 = 0;
 
@@ -96,6 +127,15 @@ const CRTC_ID: u32 = 0x10;
 const ENCODER_ID: u32 = 0x20;
 const CONNECTOR_ID: u32 = 0x30;
 const PLANE_ID: u32 = 0x40;
+
+/// The implicit virgl context used for all 3D commands on this card.
+///
+/// **Must be non-zero.** virglrenderer rejects `ctx_id == 0` at context
+/// creation (`virgl_renderer_context_create_with_flags` returns EINVAL for
+/// First context id.  Linux starts at 1 (virglrenderer rejects id 0).
+/// Allocated per-fd via `next_ctx_id` to match
+/// `atomic_inc_return(&vgdev->ctx_id_cursor)` in the Linux kernel.
+const FIRST_VIRGL_CTX_ID: u32 = 1;
 
 /// First dumb-buffer handle we hand out.
 const FIRST_DUMB_HANDLE: u32 = 1;
@@ -221,12 +261,30 @@ struct Framebuffer {
     size: u64,
     /// Row stride (pitch) in bytes — from ADDFB2.pitches[0].
     stride: u32,
+    /// Framebuffer width in pixels — from ADDFB2.width.
+    width: u32,
     /// Framebuffer height in pixels — from ADDFB2.height.
     height: u32,
-    /// Backing pages. Shared with the (now possibly removed) dumb
-    /// buffer; refcount keeps them alive until both this fb and any
-    /// user mappings have been dropped.
-    pages: Arc<GlobalPage>,
+    /// Backing storage kind. Present copies guest RAM for dumb buffers
+    /// (2D path) and binds the host texture as scanout for virgl 3D
+    /// resources (`SET_SCANOUT`) — matching Linux, which always sets the
+    /// resource itself as scanout.
+    kind: FbBacking,
+}
+
+/// Backing storage for a DRM framebuffer.
+#[derive(Clone)]
+enum FbBacking {
+    /// Guest RAM shared with a dumb buffer. The `Arc` keeps the pages
+    /// alive until both this fb and any user mappings have been dropped.
+    Dumb { pages: Arc<GlobalPage> },
+    /// Host-side resource. `res_handle` is the host 2D/3D resource;
+    /// `is_dumb_2d` marks a guest-backed 2D resource (dumb buffer) whose
+    /// pixels must be `TRANSFER_TO_HOST_2D`'d from guest RAM before flush.
+    /// 3D virgl/blob resources already hold their pixels on the host, so
+    /// present must NOT transfer them (Linux `virtio_gpu_plane_atomic_update`
+    /// transfers the dumb/2D case only).
+    Gpu3d { res_handle: u32, is_dumb_2d: bool },
 }
 
 /// StarryOS kernel-side dma-buf GEM object for DRM card0.
@@ -317,6 +375,118 @@ struct ModesetState {
     plane_crtc_h: u64,
 }
 
+/// Metadata for a 3D GPU resource created via RESOURCE_CREATE or
+/// RESOURCE_CREATE_BLOB. Tracks the association between the virtio-gpu
+/// resource ID (used in virgl commands) and the GEM handle (used in
+/// DRM ioctls).
+#[allow(dead_code)]
+struct GpuResource {
+    /// The GEM handle associated with this resource (from CREATE_DUMB or
+    /// allocated by RESOURCE_CREATE).
+    bo_handle: u32,
+    /// Resource width in pixels.
+    width: u32,
+    /// Resource height in pixels.
+    height: u32,
+    /// Row stride in bytes.
+    stride: u32,
+    /// Resource size in bytes.
+    size: u64,
+    /// Whether this resource has been attached to a context.
+    attached: bool,
+    /// blob_mem from RESOURCE_CREATE_BLOB (`VIRTGPU_BLOB_MEM_*`); 0 for
+    /// non-blob (classic 3D) resources.
+    blob_mem: u32,
+    /// blob_flags from RESOURCE_CREATE_BLOB (`VIRTGPU_BLOB_FLAG_*`); 0 for
+    /// non-blob resources.
+    blob_flags: u32,
+    /// True when this resource is a guest-backed 2D resource created by
+    /// CREATE_DUMB. present_fb must `TRANSFER_TO_HOST_2D` from the guest
+    /// backing before `RESOURCE_FLUSH`; 3D virgl/blob resources are
+    /// host-rendered and skip the transfer.
+    is_dumb_2d: bool,
+}
+
+/// Kernel-side dma-buf for a *host* 3D resource (blob or classic virgl
+/// resource) exported via PRIME. Unlike [`DmaBufGem`], which wraps guest
+/// RAM, the backing lives on the host GPU: a same-device import resolves
+/// back to the same host resource through [`Card0::blob_aliases`], so the
+/// importer (weston/Mesa) reuses the host texture zero-copy — exactly what
+/// Linux does by exporting the GEM object itself (`virtgpu_prime.c`).
+///
+/// Each open dma-buf fd holds one reference on the host resource (Linux:
+/// the `dma_buf` file pins the GEM object via `drm_gem_prime_export`).
+/// [`Drop`] releases that reference when the last fd closes, so the host
+/// resource is not freed while a file descriptor still refers to it — even
+/// after the exporter's GEM handle is gone.
+struct HostResourceDmaBuf {
+    /// Host virtio-gpu resource ID (the thing virgl commands address).
+    res_handle: u32,
+    /// Resource size in bytes.
+    size: u64,
+    /// blob_mem (0 for classic 3D resources).
+    blob_mem: u32,
+    /// Weak card reference so the fd can reach the resource tables on
+    /// close without the card holding a strong ref back (the card lives in
+    /// devfs; fds live in process fd tables).
+    card: Weak<Card0>,
+}
+
+impl Drop for HostResourceDmaBuf {
+    fn drop(&mut self) {
+        if let Some(card) = self.card.upgrade() {
+            card.release_dma_buf_ref(self.res_handle);
+        }
+    }
+}
+
+impl FileLike for HostResourceDmaBuf {
+    fn path(&self) -> Cow<'_, str> {
+        "anon_inode:dmabuf".into()
+    }
+
+    fn device_mmap(&self, _offset: u64, _length: u64) -> StarryResult<DeviceMmap> {
+        // The host resource is not guest-mappable without RESOURCE_MAP_BLOB
+        // (not needed by the present path — virgl reuses the host texture
+        // zero-copy). Rejecting mmap is safer than mapping the guest shadow
+        // pages, which do not hold the rendered content.
+        Err(StarryError::Unsupported)
+    }
+}
+
+impl Pollable for HostResourceDmaBuf {
+    fn poll(&self) -> IoEvents {
+        IoEvents::IN | IoEvents::OUT
+    }
+
+    fn register(&self, _context: &mut Context<'_>, _events: IoEvents) {}
+}
+
+/// Host-resource info for a blob dma-buf imported via `PRIME_FD_TO_HANDLE`.
+///
+/// Linux returns the *same* GEM object on a same-device import, so
+/// `RESOURCE_INFO` on the imported handle must resolve back to the
+/// exporter's host resource and blob_mem — this is what makes Mesa take the
+/// `maybe_untyped` path and reuse the host texture (`virgl_drm_winsys.c`).
+#[derive(Clone, Copy)]
+struct ImportedBlob {
+    res_handle: u32,
+    size: u64,
+    blob_mem: u32,
+}
+
+/// Per-process virgl context state (see `process_ctxs` doc).
+struct PerFdCtx {
+    initialized: bool,
+    /// CONTEXT_INIT parameters. Kept for per-fd semantics (a future
+    /// context-info query may report them); not read today.
+    #[allow(dead_code)]
+    capset_id: u32,
+    #[allow(dead_code)]
+    num_rings: u32,
+    ctx_id: u32,
+}
+
 pub struct Card0 {
     /// Queue of pending DRM events waiting to be delivered via `read()`.
     events: Mutex<VecDeque<DrmEventVblank>>,
@@ -374,12 +544,57 @@ pub struct Card0 {
     /// only one allocation lands in `system_blobs`.
     system_blobs_init: Mutex<()>,
     /// Registered virtio-gpu IRQ action, when the display backend advertises one.
-    irq_handle: ax_lazyinit::OnceLock<ax_runtime::hal::irq::IrqHandle>,
+irq_handle: ax_lazyinit::OnceLock<ax_runtime::hal::irq::IrqHandle>,
+
+    // ---- 3D (virgl) resource management ----
+
+    /// 3D resources keyed by virtio-gpu resource ID. Each resource tracks
+    /// its associated GEM handle, geometry, and size for transfer validation.
+    gpu_resources: Mutex<BTreeMap<u32, GpuResource>>,
+    /// Imported blob dma-bufs: GEM handle (from `PRIME_FD_TO_HANDLE`) →
+    /// host resource info. A same-device import is the same host resource
+    /// the exporter created, so `RESOURCE_INFO` on an imported handle
+    /// resolves back to the original `res_handle` + `blob_mem`.
+    ///
+    /// Each entry holds one reference on the host resource for the importer.
+    blob_aliases: Mutex<BTreeMap<u32, ImportedBlob>>,
+    /// Number of open PRIME-export dma-buf fds per host resource
+    /// (`res_handle` → open-fd count). Each fd holds one reference on the
+    /// host resource — Linux GEM lifetime says a dma-buf keeps the GEM
+    /// object (and thus the host resource) alive until the last fd closes.
+    dma_buf_refs: Mutex<BTreeMap<u32, u32>>,
+    /// Weak reference to this card, handed to exported dma-buf fds so their
+    /// [`Drop`] can release the host-resource reference they hold on close.
+    self_weak: Weak<Card0>,
+    /// Next virtio-gpu resource ID to allocate. Starts at 1 (0 is reserved).
+    next_res_handle: AtomicU32,
+    /// Next virgl context ID. Linux: `atomic_inc_return(&vgdev->ctx_id_cursor)`.
+    /// Each CONTEXT_INIT call gets a unique id so multiple fds/clients
+    /// don't share (and corrupt) the same virgl context state.
+    next_ctx_id: AtomicU32,
+    /// Cached capset data keyed by (capset_id, version). GET_CAPS results
+    /// are cached here so repeated queries don't round-trip to the host.
+    capset_cache: Mutex<BTreeMap<(u32, u32), Vec<u8>>>,
+    /// Per-process virgl context state, mirroring Linux's per-fd
+    /// `struct virtio_gpu_fpriv` (`virtgpu_ioctl.c`). `card0` and
+    /// `renderD128` are the *same* pseudo-device node shared by every
+    /// opener, so the fd identity that Linux keys contexts on is not
+    /// visible here — key by the owning process instead (one render fd
+    /// per process is the norm for Mesa clients). Without this, two
+    /// clients (e.g. weston compositor + glmark2) both end up in the
+    /// same host virgl context: their sub-ctx ids collide (both start
+    /// at 1) and cso/sampler objects created by one are looked up in
+    /// the other's sub-ctx → "Illegal handle" → context in_error.
+    ///
+    /// Context IDs themselves are allocated from the device-wide
+    /// [`Card0::next_ctx_id`] so each CONTEXT_INIT gets a unique id —
+    /// same as Linux's `atomic_inc_return(&vgdev->ctx_id_cursor)`.
+    process_ctxs: Mutex<BTreeMap<u32, PerFdCtx>>,
 }
 
 impl Card0 {
     pub fn new() -> Arc<Self> {
-        let card = Arc::new(Self {
+        let card = Arc::new_cyclic(|weak| Self {
             events: Mutex::new(VecDeque::with_capacity(MAX_EVENTS)),
             poll_rx: PollSet::new(),
             sequence: AtomicU32::new(0),
@@ -399,10 +614,35 @@ impl Card0 {
             system_blobs: Mutex::new(BTreeMap::new()),
             in_formats_blob: AtomicU32::new(0),
             system_blobs_init: Mutex::new(()),
-            irq_handle: ax_lazyinit::OnceLock::new(),
+irq_handle: ax_lazyinit::OnceLock::new(),
+            // 3D resource management
+            gpu_resources: Mutex::new(BTreeMap::new()),
+            blob_aliases: Mutex::new(BTreeMap::new()),
+            dma_buf_refs: Mutex::new(BTreeMap::new()),
+            next_res_handle: AtomicU32::new(1),
+            next_ctx_id: AtomicU32::new(FIRST_VIRGL_CTX_ID),
+            capset_cache: Mutex::new(BTreeMap::new()),
+            process_ctxs: Mutex::new(BTreeMap::new()),
+            self_weak: weak.clone(),
         });
         card.register_irq();
         card
+    }
+
+    /// PID of the process currently executing this ioctl. `None` in
+    /// kernel-only context (no user thread).
+    fn current_pid(&self) -> Option<u32> {
+        current_may_uninit().map(|cur| u32::from(cur.as_thread().proc_data.proc.pid()))
+    }
+
+    /// Look up the virgl context assigned to the calling process, or
+    /// `None` if CONTEXT_INIT was never called for it (Linux: an
+    /// EXECBUFFER/RESOURCE_CREATE before `virtio_gpu_create_context`
+    /// implicitly creates the context; here the implicit path is
+    /// CONTEXT_INIT, which Mesa always issues first).
+    fn current_ctx(&self) -> Option<u32> {
+        let pid = self.current_pid()?;
+        self.process_ctxs.lock().get(&pid).map(|c| c.ctx_id)
     }
 
     fn register_irq(self: &Arc<Self>) {
@@ -580,6 +820,7 @@ impl DeviceOps for Card0 {
     }
 
     fn ioctl(&self, cmd: u32, arg: usize) -> VfsResult<usize> {
+        info!("[card0] ioctl cmd=0x{:08x} arg=0x{:x}", cmd, arg);
         match cmd {
             DRM_IOCTL_VERSION => handle_version(arg),
             DRM_IOCTL_GET_UNIQUE => handle_get_unique(arg),
@@ -598,6 +839,11 @@ impl DeviceOps for Card0 {
             DRM_IOCTL_MODE_CREATE_DUMB => self.handle_create_dumb(arg),
             DRM_IOCTL_MODE_MAP_DUMB => self.handle_map_dumb(arg),
             DRM_IOCTL_MODE_DESTROY_DUMB => self.handle_destroy_dumb(arg),
+            // GEM_CLOSE is the release path Mesa uses for virgl 3D/blob
+            // resources (incl. PRIME imports). Linux funnels both GEM_CLOSE
+            // and DESTROY_DUMB through `drm_gem_handle_delete`; we mirror
+            // that by sharing one cleanup helper.
+            DRM_IOCTL_GEM_CLOSE => self.handle_gem_close(arg),
 
             DRM_IOCTL_MODE_GETPLANERESOURCES => handle_get_plane_resources(arg),
             DRM_IOCTL_MODE_GETPLANE => handle_get_plane(arg),
@@ -617,7 +863,25 @@ impl DeviceOps for Card0 {
             DRM_IOCTL_PRIME_HANDLE_TO_FD => self.handle_prime_handle_to_fd(arg),
             DRM_IOCTL_PRIME_FD_TO_HANDLE => self.handle_prime_fd_to_handle(arg),
 
-            _ => Err(VfsError::OperationNotSupported),
+            // ---- virtgpu 3D ioctls ----
+            DRM_IOCTL_VIRTGPU_GETPARAM => self.handle_virtgpu_getparam(arg),
+            DRM_IOCTL_VIRTGPU_CONTEXT_INIT => self.handle_virtgpu_context_init(arg),
+            DRM_IOCTL_VIRTGPU_GET_CAPS => self.handle_virtgpu_get_caps(arg),
+            DRM_IOCTL_VIRTGPU_RESOURCE_CREATE => self.handle_virtgpu_resource_create(arg),
+            DRM_IOCTL_VIRTGPU_RESOURCE_INFO => self.handle_virtgpu_resource_info(arg),
+            DRM_IOCTL_VIRTGPU_MAP => self.handle_virtgpu_map(arg),
+            DRM_IOCTL_VIRTGPU_EXECBUFFER => self.handle_virtgpu_execbuffer(arg),
+            DRM_IOCTL_VIRTGPU_TRANSFER_TO_HOST => self.handle_virtgpu_transfer_to_host(arg),
+            DRM_IOCTL_VIRTGPU_TRANSFER_FROM_HOST => self.handle_virtgpu_transfer_from_host(arg),
+            DRM_IOCTL_VIRTGPU_WAIT => self.handle_virtgpu_wait(arg),
+            DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB => {
+                self.handle_virtgpu_resource_create_blob(arg)
+            }
+
+            _ => {
+                warn!("[card0] unsupported ioctl cmd=0x{:08x}", cmd);
+                Err(VfsError::OperationNotSupported)
+            }
         }
     }
 
@@ -676,43 +940,78 @@ impl Card0 {
     /// now" routes through here. A follow-on PR will swap the memcpy
     /// for virtio-gpu zero-copy via `set_scanout` / `transfer_to_host`.
     fn present_fb(&self, fb_id: u32) {
-        // Snapshot the backing pages out of the fb registry, then drop
-        // the lock so `framebuffer_flush` doesn't run with the
-        // map locked. Pages survive a concurrent DESTROY_DUMB because
-        // the fb owns its own Arc<GlobalPage> clone.
-        let (pages, src_stride, rows, size) = match self.fbs.lock().get(&fb_id) {
-            Some(fb) => (fb.pages.clone(), fb.stride, fb.height as usize, fb.size),
+        // Snapshot the fb out of the registry, then drop the lock so the
+        // display calls below don't run with the map locked. Pages survive
+        // a concurrent DESTROY_DUMB because the fb owns its own
+        // Arc<GlobalPage> clone.
+        let fb = match self.fbs.lock().get(&fb_id) {
+            Some(fb) => Framebuffer {
+                size: fb.size,
+                stride: fb.stride,
+                width: fb.width,
+                height: fb.height,
+                kind: fb.kind.clone(),
+            },
             None => return,
         };
-        if !ax_display::has_display() {
-            return;
-        };
-        let info = ax_display::framebuffer_info();
-        let src = pages.start_vaddr().as_usize() as *const u8;
-        let dst = info.fb_base_vaddr as *mut u8;
 
-        if src_stride != 0 && info.stride != 0 && src_stride as usize != info.stride {
-            // Stride mismatch — copy row by row to avoid diagonal tearing.
-            let dst_limit = info.fb_size / info.stride.max(1);
-            let rows = rows.min(dst_limit);
-            let bytes_per_row = (src_stride as usize).min(info.stride);
-            for row in 0..rows {
-                unsafe {
-                    core::ptr::copy_nonoverlapping(
-                        src.add(row * src_stride as usize),
-                        dst.add(row * info.stride),
-                        bytes_per_row,
+        match &fb.kind {
+            // Guest-RAM dumb buffer: copy pixels into the virtio-gpu
+            // framebuffer and flush. This is the 2D CPU path (verified by
+            // the Qt Widgets Gallery test).
+            FbBacking::Dumb { pages } => {
+                if !ax_display::has_display() {
+                    return;
+                };
+                let src = pages.start_vaddr().as_usize() as *const u8;
+                let info = ax_display::framebuffer_info();
+                let dst = info.fb_base_vaddr as *mut u8;
+
+                if fb.stride != 0 && info.stride != 0 && fb.stride as usize != info.stride {
+                    // Stride mismatch — copy row by row to avoid diagonal tearing.
+                    let dst_limit = info.fb_size / info.stride.max(1);
+                    let rows = (fb.height as usize).min(dst_limit);
+                    let bytes_per_row = (fb.stride as usize).min(info.stride);
+                    for row in 0..rows {
+                        unsafe {
+                            core::ptr::copy_nonoverlapping(
+                                src.add(row * fb.stride as usize),
+                                dst.add(row * info.stride),
+                                bytes_per_row,
+                            );
+                        }
+                    }
+                } else {
+                    // Strides match (or one is unknown) — flat copy.
+                    let copy = (fb.size as usize).min(info.fb_size);
+                    unsafe {
+                        core::ptr::copy_nonoverlapping(src, dst, copy);
+                    }
+                }
+                let _ = ax_display::framebuffer_flush();
+            }
+            // Host-side resource (2D dumb or 3D virgl/blob): bind it as the
+            // scanout and flush — Linux's `virtio_gpu_plane_atomic_update`
+            // does the same. Guest-backed 2D resources additionally need a
+            // TRANSFER_TO_HOST_2D (handled below); 3D virgl/blob resources
+            // already hold host-side pixels and skip the transfer.
+            FbBacking::Gpu3d { res_handle, is_dumb_2d } => {
+                if !ax_display::has_display() {
+                    return;
+                };
+                let _ = ax_display::gpu3d_set_scanout(0, *res_handle, 0, 0, fb.width, fb.height);
+                // Guest-backed 2D (dumb) resources must copy pixels from
+                // guest RAM into the host image before flush — QEMU only
+                // fills the image on TRANSFER_TO_HOST_2D. 3D virgl/blob
+                // resources already hold host-side pixels and skip this.
+                if *is_dumb_2d {
+                    let _ = ax_display::gpu3d_transfer_to_host_2d(
+                        *res_handle, 0, 0, fb.width, fb.height,
                     );
                 }
-            }
-        } else {
-            // Strides match (or one is unknown) — flat copy.
-            let copy = (size as usize).min(info.fb_size);
-            unsafe {
-                core::ptr::copy_nonoverlapping(src, dst, copy);
+                let _ = ax_display::gpu3d_resource_flush(*res_handle, 0, 0, fb.width, fb.height);
             }
         }
-        let _ = ax_display::framebuffer_flush();
     }
 
     fn handle_create_dumb(&self, arg: usize) -> VfsResult<usize> {
@@ -761,6 +1060,39 @@ impl Card0 {
             .fetch_add(DUMB_BUFFER_OFFSET_STRIDE, Ordering::Relaxed);
         let handle = self.next_dumb_handle.fetch_add(1, Ordering::Relaxed);
 
+        // --- Create a host-side 2D resource + attach guest backing ---
+        // Mirrors Linux `virtio_gpu_mode_dumb_create` (virtgpu_gem.c:61-100)
+        // which calls RESOURCE_CREATE_2D + ATTACH_BACKING so the host knows
+        // about the guest pages.  Without this, virgl blits to the dumb
+        // buffer fail (no host resource) and present_fb reads zeros.
+        if ax_display::has_display() {
+            let res_handle = self.next_res_handle.fetch_add(1, Ordering::Relaxed);
+            let paddr = virt_to_phys(pages_arc.start_vaddr());
+            let _ = ax_display::gpu3d_resource_create_2d(
+                res_handle,
+                c.width,
+                c.height,
+            );
+            let _ = ax_display::gpu3d_attach_backing(
+                res_handle,
+                paddr.as_usize() as u64,
+                size as u32,
+            );
+            // Also register in gpu_resources so ADDFB2 finds it as a
+            // host-backed buffer (FbBacking::Gpu3d) instead of plain Dumb.
+            self.gpu_resources.lock().insert(res_handle, GpuResource {
+                bo_handle: handle,
+                width: c.width,
+                height: c.height,
+                stride: pitch,
+                size,
+                attached: true,
+                blob_mem: 0,
+                blob_flags: 0,
+                is_dumb_2d: true,
+            });
+        }
+
         self.dumbs.lock().insert(
             handle,
             DumbBuffer {
@@ -778,15 +1110,124 @@ impl Card0 {
         Ok(0)
     }
 
-    fn handle_destroy_dumb(&self, arg: usize) -> VfsResult<usize> {
-        let ptr = arg as *const DrmModeDestroyDumb;
-        let d: DrmModeDestroyDumb = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+    /// True when `res_handle` has no kernel-side holder left: no
+    /// `gpu_resources` entry (the creating GEM handle), no `blob_aliases`
+    /// entry (a same-device import), and no open export dma-buf fd.
+    ///
+    /// Mirrors Linux GEM object lifetime: the host resource is unref'd only
+    /// once every handle/fd referring to it is gone. The `has_display()`
+    /// guard keeps the actual unref callable on display-less kernels
+    /// (where `ax_display` has no inited device).
+    fn resource_has_no_references(&self, res_handle: u32) -> bool {
+        let resources = self.gpu_resources.lock();
+        let aliases = self.blob_aliases.lock();
+        let dma_bufs = self.dma_buf_refs.lock();
+        !resources.contains_key(&res_handle)
+            && !aliases.values().any(|a| a.res_handle == res_handle)
+            && dma_bufs.get(&res_handle).is_none_or(|&n| n == 0)
+    }
+
+    /// Send `RESOURCE_UNREF` to the host for `res_handle`, but only when
+    /// the last kernel-side reference was just released. Without this check
+    /// an exporter closing its GEM handle would free a host resource the
+    /// importer still references — virglrenderer then fails the importer's
+    /// next command with "Illegal resource".
+    fn unref_resource_if_last(&self, res_handle: u32) {
+        if !self.resource_has_no_references(res_handle) {
+            return;
+        }
+        if ax_display::has_display() && ax_display::has_virgl() {
+            info!(
+                "[card0] RESOURCE_UNREF 0x{:x} (last reference released)",
+                res_handle
+            );
+            let _ = ax_display::gpu3d_resource_unref(res_handle);
+        }
+    }
+
+    /// Release the reference an exported dma-buf fd holds on `res_handle`.
+    /// Invoked from [`HostResourceDmaBuf::drop`] when the last fd closes.
+    fn release_dma_buf_ref(&self, res_handle: u32) {
+        let last = {
+            let mut refs = self.dma_buf_refs.lock();
+            match refs.get_mut(&res_handle) {
+                Some(n) => {
+                    *n = n.saturating_sub(1);
+                    if *n == 0 {
+                        refs.remove(&res_handle);
+                        true
+                    } else {
+                        false
+                    }
+                }
+                None => false,
+            }
+        };
+        if last {
+            self.unref_resource_if_last(res_handle);
+        }
+    }
+
+    /// Shared cleanup for both DESTROY_DUMB and GEM_CLOSE. Linux funnels
+    /// both through the same `drm_gem_handle_delete`, so mirroring that
+    /// here keeps the two release paths consistent.
+    ///
+    /// The handle may be an exporter's creating handle (a `gpu_resources`
+    /// entry), a same-device import alias (a `blob_aliases` entry), or a
+    /// dumb-buffer handle (`dumbs`). Each of these holders keeps the host
+    /// resource alive: the host-side `RESOURCE_UNREF` is only sent once the
+    /// *last* reference is released (see [`Self::unref_resource_if_last`]).
+    fn destroy_handle(&self, handle: u32) {
         // Silently accept unknown handles — userspace sometimes
         // destroys the same handle twice on cleanup. The `Arc` on
         // `pages` means the backing memory only goes away after both
         // this remove drops Card0's ref AND every live mapping
         // releases its retainer.
-        self.dumbs.lock().remove(&d.handle);
+        self.dumbs.lock().remove(&handle);
+        // Imported blob alias handles are destroyed the same way.
+        let released_alias = self.blob_aliases.lock().remove(&handle);
+        // Remove any gpu_resources entry whose bo_handle matches this
+        // handle (created by handle_create_dumb for host 2D backing, or by
+        // RESOURCE_CREATE / RESOURCE_CREATE_BLOB for 3D resources).
+        let removed_resources: Vec<u32> = {
+            let mut resources = self.gpu_resources.lock();
+            let to_remove: Vec<u32> = resources
+                .iter()
+                .filter(|(_, r)| r.bo_handle == handle)
+                .map(|(&rh, _)| rh)
+                .collect();
+            for rh in &to_remove {
+                resources.remove(rh);
+            }
+            to_remove
+        };
+        // Release the references this handle held. A resource only reaches
+        // the host `RESOURCE_UNREF` when every holder (this entry, all
+        // import aliases, all open export dma-buf fds) is gone.
+        for rh in removed_resources {
+            self.unref_resource_if_last(rh);
+        }
+        if let Some(alias) = released_alias {
+            self.unref_resource_if_last(alias.res_handle);
+        }
+    }
+
+    /// DESTROY_DUMB: dumb-buffer specific release path. Linux falls through
+    /// to the same `drm_gem_handle_delete` as GEM_CLOSE; StarryOS shares
+    /// one cleanup helper for both.
+    fn handle_destroy_dumb(&self, arg: usize) -> VfsResult<usize> {
+        let ptr = arg as *const DrmModeDestroyDumb;
+        let d: DrmModeDestroyDumb = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+        self.destroy_handle(d.handle);
+        Ok(0)
+    }
+
+    /// GEM_CLOSE: the only release channel Mesa uses to destroy virgl
+    /// 3D/blob resources (including PRIME imports).
+    fn handle_gem_close(&self, arg: usize) -> VfsResult<usize> {
+        let ptr = arg as *const DrmGemClose;
+        let c: DrmGemClose = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+        self.destroy_handle(c.handle);
         Ok(0)
     }
 
@@ -878,31 +1319,56 @@ fn handle_auth_magic(_arg: usize) -> VfsResult<usize> {
 impl Card0 {
     /// Export a GEM handle as a dma-buf file descriptor via PRIME.
     ///
-    /// Looks up the dumb buffer backing `req.handle`, wraps its physical
-    /// pages in a [`DmaBufGem`], and registers it in the calling process's
-    /// fd table.  The returned fd can be passed across processes via
-    /// `SCM_RIGHTS` or used directly with `mmap`/`read`.
+    /// A handle backed by a 3D resource (blob or classic virgl) exports the
+    /// *host* resource as a [`HostResourceDmaBuf`] — mirroring Linux
+    /// `virtgpu_gem_prime_export`, which exports the GEM object itself.
+    /// A handle backed by guest RAM (dumb buffer) exports a [`DmaBufGem`]
+    /// wrapping its physical pages.
     fn handle_prime_handle_to_fd(&self, arg: usize) -> VfsResult<usize> {
         let ptr = arg as *mut DrmPrimeHandle;
         let mut req: DrmPrimeHandle = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
 
-        let dumbs = self.dumbs.lock();
-        let buf = dumbs.get(&req.handle).ok_or(VfsError::InvalidInput)?;
+        let dma_buf: Arc<dyn FileLike> = {
+            // 3D resource (blob or classic) → export the host resource.
+            let resources = self.gpu_resources.lock();
+            let host_res = resources
+                .iter()
+                .find(|(_, r)| r.bo_handle == req.handle)
+                .map(|(&rh, r)| (rh, r.size, r.blob_mem));
+            drop(resources);
 
-        // Convert the dumb buffer's virtual address to a physical address
-        // range that the mmap machinery can map into user space.
-        // `PhysAddrRange::from_start_size(virt_to_phys(...), size)` builds
-        // `{ start = pa, end = pa + size }` — the standard idiom for
-        // constructing a range from a base + length.
-        let range = PhysAddrRange::from_start_size(
-            virt_to_phys(buf.pages.start_vaddr()),
-            buf.size as usize,
-        );
-        let dma_buf = Arc::new(DmaBufGem {
-            range,
-            pages: buf.pages.clone(),
-            size: buf.size,
-        });
+            if let Some((res_handle, size, blob_mem)) = host_res {
+                // Each exported dma-buf fd holds one reference on the host
+                // resource, keeping it alive until the last fd closes
+                // (Linux: `dma_buf` pins the GEM object via its file ref).
+                *self.dma_buf_refs.lock().entry(res_handle).or_insert(0) += 1;
+                Arc::new(HostResourceDmaBuf {
+                    res_handle,
+                    size,
+                    blob_mem,
+                    card: self.self_weak.clone(),
+                })
+            } else {
+                // 2D dumb buffer → export guest RAM (original path).
+                let dumbs = self.dumbs.lock();
+                let buf = dumbs.get(&req.handle).ok_or(VfsError::InvalidInput)?;
+
+                // Convert the dumb buffer's virtual address to a physical address
+                // range that the mmap machinery can map into user space.
+                // `PhysAddrRange::from_start_size(virt_to_phys(...), size)` builds
+                // `{ start = pa, end = pa + size }` — the standard idiom for
+                // constructing a range from a base + length.
+                let range = PhysAddrRange::from_start_size(
+                    virt_to_phys(buf.pages.start_vaddr()),
+                    buf.size as usize,
+                );
+                Arc::new(DmaBufGem {
+                    range,
+                    pages: buf.pages.clone(),
+                    size: buf.size,
+                })
+            }
+        };
 
         let cloexec = req.flags & O_CLOEXEC != 0;
         let fd = add_file_like(dma_buf, cloexec).map_err(|_| VfsError::NoMemory)?;
@@ -942,6 +1408,36 @@ impl Card0 {
         let mut req: DrmPrimeHandle = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
 
         let file = crate::file::get_file_like(req.fd).map_err(|_| VfsError::BadFileDescriptor)?;
+
+        // Imported *host* 3D resource (blob dma-buf): same-device import is
+        // the same host resource — record an alias so RESOURCE_INFO on the
+        // new handle resolves back to the exporter's res_handle + blob_mem.
+        if let Some(dma) = file.as_any().downcast_ref::<HostResourceDmaBuf>() {
+            let handle = self.next_dumb_handle.fetch_add(1, Ordering::Relaxed);
+            self.blob_aliases.lock().insert(
+                handle,
+                ImportedBlob {
+                    res_handle: dma.res_handle,
+                    size: dma.size,
+                    blob_mem: dma.blob_mem,
+                },
+            );
+            // Linux: `virtio_gpu_gem_object_open()` attaches the imported
+            // resource to this fd's context at gem-handle creation time.
+            // Without this, the importer's EXECBUFFER referencing the
+            // resource fails in vrend with "Illegal resource" (the
+            // resource is only attached to the exporter's context), the
+            // sampler view / draw is discarded, and the compositor never
+            // composites the imported buffer.
+            if let Some(ctx_id) = self.current_ctx() {
+                let _ = ax_display::gpu3d_ctx_attach_resource(ctx_id, dma.res_handle);
+            }
+            req.handle = handle;
+            ptr.vm_write(req).map_err(|_| VfsError::BadAddress)?;
+            return Ok(0);
+        }
+
+        // Guest-RAM dma-buf → register in dumbs (original path).
         let dma_buf: &DmaBufGem = file
             .as_any()
             .downcast_ref::<DmaBufGem>()
@@ -1140,15 +1636,31 @@ impl Card0 {
         let ptr = arg as *mut DrmModeFbCmd2;
         let mut f: DrmModeFbCmd2 = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
         let handle = f.handles[0];
-        // Resolve and clone-retain the dumb's backing under the dumbs
-        // lock so a concurrent DESTROY_DUMB can't race the fb's
-        // initial Arc bump.
-        let (pages, size) = {
-            let dumbs = self.dumbs.lock();
-            let Some(b) = dumbs.get(&handle) else {
-                return Err(VfsError::InvalidInput);
-            };
-            (b.pages.clone(), b.size)
+        // Resolve the backing kind + capacity under the resource/dumb
+        // locks so a concurrent DESTROY_DUMB can't race the fb's
+        // initial Arc bump. A handle may be:
+        //   1) a host 3D resource (virgl scanout — Weston/glamor's GBM
+        //      buffers are host textures from RESOURCE_CREATE_3D, which
+        //      also register a shadow `dumbs` entry). Check this first so
+        //      present binds it with SET_SCANOUT instead of copying empty
+        //      guest RAM (the shadow pages are never attached to the host).
+        //   2) a plain guest-RAM dumb buffer (2D path).
+        let (kind, size) = {
+            let resources = self.gpu_resources.lock();
+            let host_res = resources
+                .iter()
+                .find(|(_, r)| r.bo_handle == handle)
+                .map(|(&rh, r)| (rh, r.size, r.is_dumb_2d));
+            if let Some((res_handle, res_size, is_dumb_2d)) = host_res {
+                (FbBacking::Gpu3d { res_handle, is_dumb_2d }, res_size)
+            } else {
+                drop(resources);
+                let dumbs = self.dumbs.lock();
+                let Some(b) = dumbs.get(&handle) else {
+                    return Err(VfsError::InvalidInput);
+                };
+                (FbBacking::Dumb { pages: b.pages.clone() }, b.size)
+            }
         };
         // Use the plane stride from the ADDFB2 request (f.pitches[0])
         // rather than the dumb buffer's pitch.  PRIME/import buffers may
@@ -1175,7 +1687,11 @@ impl Card0 {
             return Err(VfsError::InvalidInput);
         }
         let fb_total = fb_stride as u64 * fb_height as u64;
-        if size < fb_total {
+        // Guest-RAM buffers must actually hold the full frame. Host 3D
+        // resources hold their storage on the GPU — the shadow `size` can
+        // even be the kernel's PAGE_SIZE default when Mesa passes 0 — so
+        // skip the capacity check there.
+        if matches!(&kind, FbBacking::Dumb { .. }) && size < fb_total {
             warn!(
                 "ADDFB2: buffer size {} < fb_total {} ({}stride × {}height)",
                 size, fb_total, fb_stride, fb_height
@@ -1199,8 +1715,9 @@ impl Card0 {
             Framebuffer {
                 size,
                 stride: fb_stride,
+                width: fb_width,
                 height: fb_height,
-                pages,
+                kind,
             },
         );
         f.fb_id = fb_id;
@@ -1802,6 +2319,884 @@ impl Card0 {
         ptr.vm_write(g).map_err(|_| VfsError::BadAddress)?;
         Ok(0)
     }
+
+    // ======== virtgpu ioctl handlers ========
+    //
+    // These implement the 11 virtgpu private ioctls that Mesa's virgl
+    // driver needs to submit 3D rendering commands. The handlers forward
+    // to the ax_display 3D API which reaches the virtio-gpu driver.
+    //
+    // Security: Each handler validates input from userspace before use,
+    // matching Linux kernel behavior (bounds checks, EINVAL for invalid
+    // params, EEXIST for duplicate context init, etc.).
+
+    /// VIRTGPU_GETPARAM — queries driver parameters.
+    ///
+    /// Linux: `virtgpu_getparam_ioctl()` in `virtgpu_ioctl.c`
+    ///
+    /// Mesa queries all parameters during initialization. Known parameters
+    /// return their values; unknown parameters return `-EINVAL` (matching
+    /// Linux kernel behavior — Mesa handles this gracefully).
+    fn handle_virtgpu_getparam(&self, arg: usize) -> VfsResult<usize> {
+        let ptr = arg as *mut DrmVirtgpuGetparam;
+        let g: DrmVirtgpuGetparam = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        let has_virgl = ax_display::has_virgl();
+
+        let value = match g.param {
+            VIRTGPU_PARAM_3D_FEATURES => {
+                // Must return 1 for Mesa to use virgl path.
+                if has_virgl { 1 } else { 0 }
+            }
+            VIRTGPU_PARAM_CAPSET_QUERY_FIX => {
+                // Linux 内核总是返回 1，不管 has_virgl_3d。
+                // 这影响 GET_CAPS 的行为（Mesa 用它决定查询顺序）。
+                1
+            }
+            VIRTGPU_PARAM_RESOURCE_BLOB => {
+                // Report the *actual* negotiated feature (Linux:
+                // `has_resource_blob ? 1 : 0`). Without RESOURCE_BLOB the
+                // device doesn't support blobs and Mesa must use the classic
+                // resource path — reporting 1 here would make Mesa create
+                // blobs that fail.
+                if ax_display::has_resource_blob() { 1 } else { 0 }
+            }
+            VIRTGPU_PARAM_HOST_VISIBLE => {
+                // Host-visible memory requires blob resources. Match the
+                // device's actual capability so Mesa's `supports_coherent`
+                // tracks reality.
+                if ax_display::has_resource_blob() { 1 } else { 0 }
+            }
+            VIRTGPU_PARAM_CROSS_DEVICE => {
+                // Cross-device sharing not supported yet.
+                0
+            }
+            VIRTGPU_PARAM_CONTEXT_INIT => {
+                // Must return 1 for Mesa to use CONTEXT_INIT.
+                if has_virgl { 1 } else { 0 }
+            }
+            VIRTGPU_PARAM_SUPPORTED_CAPSET_IDS => {
+                // Bitmask of supported capset IDs.
+                // Bit 0 = reserved, bit 1 = VIRGL, bit 2 = VIRGL2.
+                if has_virgl {
+                    (1 << VIRTGPU_DRM_CAPSET_VIRGL) | (1 << VIRTGPU_DRM_CAPSET_VIRGL2)
+                } else {
+                    0
+                }
+            }
+            _ => {
+                // Unknown parameter — match Linux kernel: return -EINVAL.
+                // Mesa handles this gracefully (value stays 0).
+                return Err(VfsError::InvalidInput);
+            }
+        };
+
+        // Linux `virtio_gpu_getparam_ioctl`: `copy_to_user((void __user *)
+        // param->value, &value, sizeof(value))` — 结果写入用户指针指向的 u64,
+        // 而不是写回 struct 字段。之前 `g.value = value; vm_write(g)` 把值写进
+        // struct 的 value 字段(覆盖了指针),mesa 读的是指针指向的本地变量,
+        // 导致所有 GETPARAM 都读到 0 → 3D_FEATURES=0 → virgl winsys 创建失败。
+        vm_write_slice(g.value as *mut u64, &[value]).map_err(|_| VfsError::BadAddress)?;
+        Ok(0)
+    }
+
+    /// VIRTGPU_CONTEXT_INIT — initializes a rendering context on this fd.
+    ///
+    /// Linux: `virtgpu_context_init_ioctl()` in `virtgpu_ioctl.c`
+    ///
+    /// **Critical**: This is a pure-input ioctl with no output fields.
+    /// The context is implicitly bound to the file descriptor. Each fd
+    /// can only call CONTEXT_INIT once (repeated calls return -EEXIST).
+    ///
+    /// Mesa calls this with num_params=1 and a single parameter:
+    ///   { param=VIRTGPU_CONTEXT_PARAM_CAPSET_ID, value=VIRGL2(2) or VIRGL1(1) }
+    fn handle_virtgpu_context_init(&self, arg: usize) -> VfsResult<usize> {
+        let init: DrmVirtgpuContextInit =
+            (arg as *const DrmVirtgpuContextInit).vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // Linux: if (!vgdev->has_context_init || !vgdev->has_virgl_3d)
+        //           return -EINVAL;
+        if !ax_display::has_virgl() {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // `card0`/`renderD128` share one Card0 for every opener, so the
+        // per-fd "one CONTEXT_INIT per fd" rule becomes per-process.
+        let pid = self
+            .current_pid()
+            .ok_or(VfsError::InvalidInput)?;
+
+        // Linux kernel: each fd can only call CONTEXT_INIT once.
+        if self.process_ctxs.lock().get(&pid).is_some_and(|c| c.initialized) {
+            return Err(VfsError::AlreadyExists);
+        }
+
+        // Linux kernel limits num_params to 3.
+        if init.num_params > 3 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Read the parameter array from userspace.
+        let mut capset_id: u32 = 0;
+        let mut num_rings: u32 = 1; // Linux default
+
+        if init.num_params > 0 && init.ctx_set_params != 0 {
+            let params_ptr = init.ctx_set_params as *const DrmVirtgpuContextSetParam;
+            for i in 0..init.num_params as usize {
+                let param: DrmVirtgpuContextSetParam = unsafe { params_ptr.add(i) }
+                    .vm_read()
+                    .map_err(|_| VfsError::BadAddress)?;
+                match param.param {
+                    VIRTGPU_CONTEXT_PARAM_CAPSET_ID => {
+                        capset_id = param.value as u32;
+                        // Linux: if (value > MAX_CAPSET_ID) return -EINVAL;
+                        // MAX_CAPSET_ID in Linux v6.1 is 6 (VIRTGPU_DRM_CAPSET_DRM)
+                        if capset_id > VIRTGPU_DRM_CAPSET_DRM {
+                            return Err(VfsError::InvalidInput);
+                        }
+                        // Linux: if ((vgdev->capset_id_mask & (1ULL << value)) == 0)
+                        //           return -EINVAL;
+                        // 我们支持 VIRGL(1) 和 VIRGL2(2)
+                        if capset_id != VIRTGPU_DRM_CAPSET_VIRGL
+                            && capset_id != VIRTGPU_DRM_CAPSET_VIRGL2
+                        {
+                            warn!("[card0] CONTEXT_INIT: unsupported capset_id={capset_id}");
+                            return Err(VfsError::InvalidInput);
+                        }
+                    }
+                    VIRTGPU_CONTEXT_PARAM_NUM_RINGS => {
+                        num_rings = param.value as u32;
+                        // Sanity check: limit rings.
+                        if num_rings == 0 || num_rings > 64 {
+                            return Err(VfsError::InvalidInput);
+                        }
+                    }
+                    VIRTGPU_CONTEXT_PARAM_POLL_RINGS_MASK => {
+                        // Accept but ignore — we don't support polling yet.
+                        let _ = param.value;
+                    }
+                    _ => {
+                        // Unknown parameter — Linux returns -EINVAL.
+                        return Err(VfsError::InvalidInput);
+                    }
+                }
+            }
+        }
+
+        // Create a unique context on the host, mirroring Linux's
+        // `atomic_inc_return(&vgdev->ctx_id_cursor)`. Each fd (and each
+        // re-open after close) gets its own virgl context so rendering
+        // state from one client cannot corrupt another.
+        let ctx_id = self.next_ctx_id.fetch_add(1, Ordering::Relaxed);
+        if ax_display::has_virgl() {
+            // Name encodes the unique `ctx_id`, not the capset — every
+            // client uses VIRGL2, so a capset-keyed name would give every
+            // context the same label and make host-side error logs ("starry-
+            // ctx-2") indistinguishable across clients.
+            let ctx_name = format!("starry-ctx-{ctx_id}");
+            ax_display::gpu3d_ctx_create(ctx_id, &ctx_name, capset_id)
+                .map_err(map_gpu3d_err)?;
+        }
+
+        self.process_ctxs.lock().insert(
+            pid,
+            PerFdCtx {
+                initialized: true,
+                capset_id,
+                num_rings,
+                ctx_id,
+            },
+        );
+
+        info!("[card0] CONTEXT_INIT: capset_id={capset_id}, num_rings={num_rings}");
+        Ok(0)
+    }
+
+    /// VIRTGPU_GET_CAPS — retrieves capability set data.
+    ///
+    /// Linux: `virtgpu_get_caps_ioctl()` in `virtgpu_ioctl.c`
+    ///
+    /// Mesa first tries cap_set_id=2 (VIRGL2), then falls back to 1 (VIRGL).
+    /// The `addr` field is a user-space buffer pointer; `size` is both input
+    /// (buffer capacity) and output (actual data size).
+    fn handle_virtgpu_get_caps(&self, arg: usize) -> VfsResult<usize> {
+        let ptr = arg as *mut DrmVirtgpuGetCaps;
+        let mut g: DrmVirtgpuGetCaps = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // Validate capset ID.
+        if g.cap_set_id == 0 || g.cap_set_id > VIRTGPU_DRM_CAPSET_VIRGL2 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Check cache first.
+        let cache_key = (g.cap_set_id, g.cap_set_ver);
+        let cached = self.capset_cache.lock().get(&cache_key).cloned();
+
+        let cap_data = if let Some(data) = cached {
+            data
+        } else if ax_display::has_virgl() {
+            // Linux: query GET_CAPSET_INFO for max_size, then use max_size
+            // (NOT the user's g.size) to retrieve the full capset from the
+            // host. Using a truncated g.size would give Mesa incomplete data
+            // and cause it to enable unsupported GL features (e.g. SET_TESS_STATE).
+            // Index mapping: 0=VIRGL(id=1), 1=VIRGL2(id=2).
+            let capset_index = g.cap_set_id - 1;
+            let max_size = ax_display::gpu3d_capset_info(capset_index)
+                .map(|info| info.max_size)
+                .unwrap_or(g.size);
+            let query_size = max_size.max(g.size);
+            let data = ax_display::gpu3d_capset(g.cap_set_id, g.cap_set_ver, query_size)
+                .map_err(map_gpu3d_err)?;
+            // Cache the result.
+            self.capset_cache.lock().insert(cache_key, data.clone());
+            data
+        } else {
+            return Err(VfsError::InvalidInput);
+        };
+
+        // Write capset data to user buffer.
+        let write_size = (g.size as usize).min(cap_data.len());
+        if g.addr != 0 && write_size > 0 {
+            vm_write_slice(g.addr as *mut u8, &cap_data[..write_size])
+                .map_err(|_| VfsError::BadAddress)?;
+        }
+        // Update size to actual data size (Linux does this too).
+        g.size = cap_data.len() as u32;
+        ptr.vm_write(g).map_err(|_| VfsError::BadAddress)?;
+
+        Ok(0)
+    }
+
+    /// VIRTGPU_RESOURCE_CREATE — creates a 3D resource.
+    ///
+    /// Linux: `virtgpu_resource_create_ioctl()` in `virtgpu_ioctl.c`
+    ///
+    /// Creates a 3D resource on the host and optionally associates it with
+    /// an existing GEM handle. Returns the virtio-gpu resource ID in
+    /// `res_handle` (NOT the GEM handle — they are different!).
+    fn handle_virtgpu_resource_create(&self, arg: usize) -> VfsResult<usize> {
+        let ptr = arg as *mut DrmVirtgpuResourceCreate;
+        let mut r: DrmVirtgpuResourceCreate =
+            ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // Linux: if (vgdev->has_virgl_3d) virtio_gpu_create_context(dev, file);
+        // 我们在 CONTEXT_INIT 时已经创建了上下文。
+
+        // Linux: 总是分配新的 GEM 对象，不复用 bo_handle。
+        // bo_handle 字段在 Linux 中是输出，不是输入。
+        // 如果用户设置了 bo_handle，Linux 会忽略它并分配新的。
+
+        // Allocate a new virtio-gpu resource ID.
+        let res_handle = self.next_res_handle.fetch_add(1, Ordering::Relaxed);
+
+        // Allocate a backing buffer (dumb buffer) for this resource.
+        let size = if r.size > 0 {
+            r.size as u64
+        } else {
+            // Linux: if (params.size == 0) params.size = PAGE_SIZE;
+            PAGE_SIZE_4K as u64
+        };
+
+        if size > DUMB_BUFFER_MAX_SIZE as u64 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        let pages = GlobalPage::alloc_contiguous(
+            (size as usize).div_ceil(PAGE_SIZE_4K),
+            PAGE_SIZE_4K,
+        )
+        .map_err(|_| VfsError::NoMemory)?;
+
+        // Zero-initialize the buffer.
+        unsafe {
+            core::ptr::write_bytes(pages.start_vaddr().as_ptr() as *mut u8, 0, size as usize);
+        }
+
+        // Allocate a new GEM handle.
+        let bo_handle = self.next_dumb_handle.fetch_add(1, Ordering::Relaxed);
+        let offset = self.next_offset.fetch_add(DUMB_BUFFER_OFFSET_STRIDE, Ordering::Relaxed);
+
+        // Physical address of the backing pages, needed for ATTACH_BACKING.
+        // Computed before `pages` moves into the Arc below.
+        let backing_paddr = virt_to_phys(pages.start_vaddr());
+        let backing_size = pages.size();
+
+        self.dumbs.lock().insert(bo_handle, DumbBuffer {
+            width: r.width,
+            height: r.height,
+            bpp: 32,
+            pitch: r.stride,
+            size,
+            offset,
+            pages: Arc::new(pages),
+        });
+
+        // Create the resource on the host via the display driver.
+        if ax_display::has_virgl() {
+            let ctx_id = self.current_ctx().ok_or(VfsError::InvalidInput)?;
+            ax_display::gpu3d_resource_create(
+                ctx_id,
+                res_handle,
+                r.target,
+                r.format,
+                r.bind,
+                r.width,
+                r.height,
+                r.depth,
+                r.array_size,
+                r.last_level,
+                r.nr_samples,
+                r.flags,
+            )
+            .map_err(map_gpu3d_err)?;
+
+            // Linux: `virtio_gpu_object_create()` (virtgpu_object.c) virgl
+            // branch calls `virtio_gpu_object_attach()` right after
+            // `virtio_gpu_cmd_resource_create_3d()` — the backing pages are
+            // what the host reads/writes for TRANSFER3D.  Mesa 25.x encoded
+            // transfers never use the TRANSFER_TO_HOST ioctl: the data lives
+            // in these guest pages and vrend reads it via res->iov.  Without
+            // the backing, TRANSFER3D fails check_transfer_iovec with
+            // "Illegal resource" and the whole context goes into in_error.
+            ax_display::gpu3d_attach_backing(
+                res_handle,
+                backing_paddr.as_usize() as u64,
+                backing_size as u32,
+            )
+            .map_err(map_gpu3d_err)?;
+        }
+
+        // Track the resource locally.
+        self.gpu_resources.lock().insert(res_handle, GpuResource {
+            bo_handle,
+            width: r.width,
+            height: r.height,
+            stride: r.stride,
+            size,
+            attached: false,
+            // Classic (non-blob) resources have no blob_mem/flags.
+            blob_mem: 0,
+            blob_flags: 0,
+            is_dumb_2d: false,
+        });
+
+        // Attach the resource to this fd's context immediately. Linux does
+        // this in `virtio_gpu_gem_object_open` (CTX_ATTACH_RESOURCE on every
+        // GEM open). Without it, TRANSFER_TO/FROM_HOST_3D (which Mesa calls
+        // directly, not via EXECBUFFER) hits "Illegal resource" because the
+        // host never learned the resource belongs to the context.
+        let ctx_id = self.current_ctx().unwrap_or(0);
+        if ax_display::has_virgl()
+            && ctx_id != 0
+            && ax_display::gpu3d_ctx_attach_resource(ctx_id, res_handle).is_ok()
+            && let Some(res) = self.gpu_resources.lock().get_mut(&res_handle)
+        {
+            res.attached = true;
+            info!("[card0] CTX_ATTACH res={:#x} ctx={} ok", res_handle, ctx_id);
+        }
+
+        // Linux: rc->res_handle = qobj->hw_res_handle;
+        //        rc->bo_handle = handle;
+        r.bo_handle = bo_handle;
+        r.res_handle = res_handle;
+        r.size = size as u32;
+        ptr.vm_write(r).map_err(|_| VfsError::BadAddress)?;
+
+        Ok(0)
+    }
+
+    /// VIRTGPU_RESOURCE_INFO — queries resource information.
+    ///
+    /// Linux: `virtgpu_resource_info_ioctl()` in `virtgpu_ioctl.c`
+    fn handle_virtgpu_resource_info(&self, arg: usize) -> VfsResult<usize> {
+        let ptr = arg as *mut DrmVirtgpuResourceInfo;
+        let mut info: DrmVirtgpuResourceInfo =
+            ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // Linux: gobj = drm_gem_object_lookup(file, ri->bo_handle);
+        //        if (gobj == NULL) return -ENOENT;
+        // 1) Imported blob dma-buf: resolves to the *same* host resource the
+        //    exporter created (Linux same-device import returns the same GEM
+        //    object). Returning the real blob_mem is what makes Mesa take the
+        //    maybe_untyped path and reuse the host texture.
+        if let Some(imp) = self.blob_aliases.lock().get(&info.bo_handle).copied() {
+            info.res_handle = imp.res_handle;
+            info.size = imp.size as u32;
+            info.blob_mem = imp.blob_mem;
+            ptr.vm_write(info).map_err(|_| VfsError::BadAddress)?;
+            return Ok(0);
+        }
+
+        // 2) Regular 3D resource (blob or classic) looked up by bo_handle.
+        let resources = self.gpu_resources.lock();
+        let res = resources.values().find(|r| r.bo_handle == info.bo_handle);
+        let Some(res) = res else {
+            return Err(VfsError::NotFound);  // ENOENT
+        };
+
+        info.size = res.size as u32;
+        // Report the resource's real blob_mem instead of hardcoding 0 — this
+        // is the fix that lets Mesa's importer reuse the host texture.
+        info.blob_mem = res.blob_mem;
+        // Find the res_handle for this bo_handle.
+        if let Some((&rh, _)) = resources.iter().find(|(_, r)| r.bo_handle == info.bo_handle) {
+            info.res_handle = rh;
+        }
+        drop(resources);
+
+        ptr.vm_write(info).map_err(|_| VfsError::BadAddress)?;
+        Ok(0)
+    }
+
+    /// VIRTGPU_MAP — maps a GEM handle to an mmap offset.
+    ///
+    /// Linux: `virtgpu_map_ioctl()` in `virtgpu_ioctl.c`
+    ///
+    /// Returns an offset that can be used with the mmap system call.
+    /// This reuses the same offset mechanism as MAP_DUMB.
+    fn handle_virtgpu_map(&self, arg: usize) -> VfsResult<usize> {
+        let ptr = arg as *mut DrmVirtgpuMap;
+        let mut m: DrmVirtgpuMap = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // Look up the dumb buffer by handle to get its offset.
+        let dumbs = self.dumbs.lock();
+        let buf = dumbs.get(&m.handle).ok_or(VfsError::InvalidInput)?;
+        m.offset = buf.offset;
+        drop(dumbs);
+
+        ptr.vm_write(m).map_err(|_| VfsError::BadAddress)?;
+        Ok(0)
+    }
+
+    /// VIRTGPU_EXECBUFFER — submits a virgl command buffer.
+    ///
+    /// Linux: `virtgpu_execbuffer_ioctl()` in `virtgpu_ioctl.c`
+    ///
+    /// This is the core ioctl: Mesa submits VIRGL_CCMD_* command streams
+    /// through this. The command buffer is read from userspace, along with
+    /// an array of GEM handles that the commands reference.
+    ///
+    /// **Critical**: There is NO ctx_id field. The context is implicitly
+    /// bound to the file descriptor.
+    fn handle_virtgpu_execbuffer(&self, arg: usize) -> VfsResult<usize> {
+        let mut eb: DrmVirtgpuExecbuffer =
+            (arg as *const DrmVirtgpuExecbuffer).vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // Linux: if (vgdev->has_virgl_3d == false) return -ENOSYS;
+        if !ax_display::has_virgl() {
+            return Err(VfsError::Unsupported);
+        }
+
+        // Validate that context has been initialized for this process
+        // (Linux: `virtio_gpu_create_context` on first execbuffer).
+        let ctx_id = self.current_ctx().ok_or(VfsError::InvalidInput)?;
+
+        // Linux: if ((exbuf->flags & ~VIRTGPU_EXECBUF_FLAGS)) return -EINVAL;
+        // VIRTGPU_EXECBUF_FLAGS = FENCE_FD_IN | FENCE_FD_OUT | RING_IDX
+        let valid_flags = VIRTGPU_EXECBUF_FENCE_FD_IN | VIRTGPU_EXECBUF_FENCE_FD_OUT | 0x04;
+        if (eb.flags & !valid_flags) != 0 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Validate command buffer size.
+        if eb.size == 0 || eb.size > 64 * 1024 * 1024 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Validate fence_fd (must be -1 for now — we don't support fence fd yet).
+        if eb.fence_fd != -1 && (eb.flags & (VIRTGPU_EXECBUF_FENCE_FD_IN | VIRTGPU_EXECBUF_FENCE_FD_OUT)) != 0 {
+            info!("[card0] EXECBUFFER: fence_fd support not implemented, fd={}", eb.fence_fd);
+            // Don't fail — just ignore the fence for now.
+        }
+
+        // Linux: exbuf->fence_fd = -1; (总是重置为 -1)
+        eb.fence_fd = -1;
+
+        // Validate bo_handles array.
+        if eb.num_bo_handles > 256 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Read command buffer from userspace.
+        let cmd_buf = if eb.command != 0 && eb.size > 0 {
+            vm_load(eb.command as *const u8, eb.size as usize)
+                .map_err(|_| VfsError::BadAddress)?
+        } else {
+            Vec::new()
+        };
+
+        // Read and validate bo_handles array from userspace.
+        // Each handle is a u32, stored at a u64 pointer.
+        if eb.num_bo_handles > 0 && eb.bo_handles != 0 {
+            let handles_ptr = eb.bo_handles as *const u32;
+            let mut handles = vec![0u32; eb.num_bo_handles as usize];
+            for (i, handle) in handles.iter_mut().enumerate() {
+                *handle = unsafe { handles_ptr.add(i) }
+                    .vm_read()
+                    .map_err(|_| VfsError::BadAddress)?;
+            }
+
+            // Attach any unattached resources to the context. Imported blob
+            // handles (from PRIME_FD_TO_HANDLE) resolve through
+            // `blob_aliases` to the same host resource the exporter created.
+            let resources = self.gpu_resources.lock();
+            let aliases = self.blob_aliases.lock();
+            let mut to_attach = Vec::new();
+            for &h in &handles {
+                let rh = resources
+                    .iter()
+                    .find(|(_, r)| r.bo_handle == h)
+                    .map(|(&rh, _)| rh)
+                    .or_else(|| aliases.get(&h).map(|imp| imp.res_handle));
+                if let Some(rh) = rh
+                    && ax_display::has_virgl()
+                {
+                    to_attach.push(rh);
+                }
+            }
+            drop(aliases);
+            drop(resources);
+
+            for rh in to_attach {
+                let _ = ax_display::gpu3d_ctx_attach_resource(ctx_id, rh);
+            }
+
+            // Mark attached resources.
+            let mut resources = self.gpu_resources.lock();
+            for &h in &handles {
+                let rh = resources
+                    .iter()
+                    .find(|(_, r)| r.bo_handle == h)
+                    .map(|(&rh, _)| rh)
+                    .or_else(|| self.blob_aliases.lock().get(&h).map(|imp| imp.res_handle));
+                if let Some(rh) = rh
+                    && let Some(res) = resources.get_mut(&rh)
+                {
+                    res.attached = true;
+                }
+            }
+        }
+
+        // Submit the command buffer to the host.
+        if ax_display::has_virgl() {
+            let _fence_id = ax_display::gpu3d_submit_cmd(ctx_id, &cmd_buf)
+                .map_err(map_gpu3d_err)?;
+            // fence_id is available but we don't return it to userspace
+            // yet (no fence fd support).
+        }
+
+        // Linux: 写回 fence_fd（如果支持 fence）
+        // 当前我们不支持 fence，所以 fence_fd 保持 -1。
+
+        Ok(0)
+    }
+
+    /// VIRTGPU_TRANSFER_TO_HOST — transfers data from guest to host.
+    ///
+    /// Linux: `virtgpu_transfer_from_host_ioctl()` in `virtgpu_ioctl.c`
+    /// (Note: Linux naming is confusing — "from_host" means "from guest
+    /// memory to host" in the virtio-gpu spec.)
+    fn handle_virtgpu_transfer_to_host(&self, arg: usize) -> VfsResult<usize> {
+        let t: DrmVirtgpu3dTransferToHost =
+            (arg as *const DrmVirtgpu3dTransferToHost).vm_read()
+                .map_err(|_| VfsError::BadAddress)?;
+
+        // Linux: if (vgdev->has_virgl_3d == false) return -ENOSYS;
+        if !ax_display::has_virgl() {
+            return Err(VfsError::Unsupported);
+        }
+
+        let ctx_id = self.current_ctx().ok_or(VfsError::InvalidInput)?;
+
+        // Linux: objs = virtio_gpu_array_from_handles(file, &args->bo_handle, 1);
+        //        if (objs == NULL) return -ENOENT;
+        // Validate the GEM handle exists.
+        let resources = self.gpu_resources.lock();
+        let res = resources.values().find(|r| r.bo_handle == t.bo_handle);
+        let Some(_res) = res else {
+            return Err(VfsError::NotFound);  // ENOENT
+        };
+        drop(resources);
+
+        // Forward to the display driver.
+        if ax_display::has_virgl() {
+            let box_ = ax_display::TransferBox {
+                x: t.box_.x,
+                y: t.box_.y,
+                z: t.box_.z,
+                w: t.box_.w,
+                h: t.box_.h,
+                d: t.box_.d,
+            };
+            // Find the res_handle for this bo_handle.
+            let resources = self.gpu_resources.lock();
+            let res_handle = resources.iter()
+                .find(|(_, r)| r.bo_handle == t.bo_handle)
+                .map(|(&rh, _)| rh)
+                .unwrap_or(0);
+            drop(resources);
+
+            ax_display::gpu3d_transfer_to_host(
+                ctx_id,
+                res_handle,
+                box_,
+                t.offset as u64,
+                t.level,
+                t.stride,
+                t.layer_stride,
+            )
+            .map_err(map_gpu3d_err)?;
+        }
+
+        Ok(0)
+    }
+
+    /// VIRTGPU_TRANSFER_FROM_HOST — transfers data from host to guest.
+    ///
+    /// Linux: `virtgpu_transfer_to_host_ioctl()` in `virtgpu_ioctl.c`
+    fn handle_virtgpu_transfer_from_host(&self, arg: usize) -> VfsResult<usize> {
+        let t: DrmVirtgpu3dTransferFromHost =
+            (arg as *const DrmVirtgpu3dTransferFromHost).vm_read()
+                .map_err(|_| VfsError::BadAddress)?;
+
+        // Linux: if (vgdev->has_virgl_3d == false) return -ENOSYS;
+        if !ax_display::has_virgl() {
+            return Err(VfsError::Unsupported);
+        }
+
+        let ctx_id = self.current_ctx().ok_or(VfsError::InvalidInput)?;
+
+        // Linux: objs = virtio_gpu_array_from_handles(file, &args->bo_handle, 1);
+        //        if (objs == NULL) return -ENOENT;
+        // Validate the GEM handle exists.
+        let resources = self.gpu_resources.lock();
+        let res = resources.values().find(|r| r.bo_handle == t.bo_handle);
+        let Some(_res) = res else {
+            return Err(VfsError::NotFound);  // ENOENT
+        };
+        drop(resources);
+
+        // Forward to the display driver.
+        if ax_display::has_virgl() {
+            let box_ = ax_display::TransferBox {
+                x: t.box_.x,
+                y: t.box_.y,
+                z: t.box_.z,
+                w: t.box_.w,
+                h: t.box_.h,
+                d: t.box_.d,
+            };
+            let resources = self.gpu_resources.lock();
+            let res_handle = resources.iter()
+                .find(|(_, r)| r.bo_handle == t.bo_handle)
+                .map(|(&rh, _)| rh)
+                .unwrap_or(0);
+            drop(resources);
+
+            ax_display::gpu3d_transfer_from_host(
+                ctx_id,
+                res_handle,
+                box_,
+                t.offset as u64,
+                t.level,
+                t.stride,
+                t.layer_stride,
+            )
+            .map_err(map_gpu3d_err)?;
+        }
+
+        Ok(0)
+    }
+
+    /// VIRTGPU_WAIT — waits for a resource to become idle.
+    ///
+    /// Linux: `virtgpu_wait_ioctl()` in `virtgpu_ioctl.c`
+    ///
+    /// We implement this as a synchronous wait (the resource is always
+    /// "ready" since we process commands synchronously).
+    fn handle_virtgpu_wait(&self, arg: usize) -> VfsResult<usize> {
+        let w: DrmVirtgpu3dWait =
+            (arg as *const DrmVirtgpu3dWait).vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // Linux: handle=0 is invalid.
+        if w.handle == 0 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Linux: gobj = drm_gem_object_lookup(file, handle);
+        //        if (gobj == NULL) return -ENOENT;
+        // Check if the handle exists in dumbs, gpu_resources, or as an
+        // imported blob alias.
+        let dumbs = self.dumbs.lock();
+        let has_dumb = dumbs.contains_key(&w.handle);
+        drop(dumbs);
+
+        let resources = self.gpu_resources.lock();
+        let has_res = resources.values().any(|r| r.bo_handle == w.handle);
+        drop(resources);
+
+        let aliases = self.blob_aliases.lock();
+        let has_alias = aliases.contains_key(&w.handle);
+        drop(aliases);
+
+        if !has_dumb && !has_res && !has_alias {
+            return Err(VfsError::NotFound);  // ENOENT
+        }
+
+        // Since we process commands synchronously, the resource is always
+        // ready. Linux would wait on a fence here.
+        Ok(0)
+    }
+
+    /// VIRTGPU_RESOURCE_CREATE_BLOB — creates a blob resource.
+    ///
+    /// Linux: `virtgpu_resource_create_blob_ioctl()` in `virtgpu_ioctl.c`
+    ///
+    /// Mesa calls this when both RESOURCE_BLOB and HOST_VISIBLE are
+    /// reported as supported. The blob path is used for coherent memory
+    /// allocation (shared between guest and host).
+    fn handle_virtgpu_resource_create_blob(&self, arg: usize) -> VfsResult<usize> {
+        let ptr = arg as *mut DrmVirtgpuResourceCreateBlob;
+        let mut b: DrmVirtgpuResourceCreateBlob =
+            ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
+
+        // Linux: if (!vgdev->has_resource_blob) return -EINVAL;
+        if !ax_display::has_virgl() {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Linux: if (rc_blob->blob_flags & ~VIRTGPU_BLOB_FLAG_USE_MASK)
+        //           return -EINVAL;
+        // Note: VIRTGPU_BLOB_FLAG_USE_* 是 0x0001, 0x0002, 0x0004
+        // VIRTGPU_BLOB_FLAG_USE_MASK = 0x0007
+        if (b.blob_flags & !0x0007) != 0 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Validate blob memory type and determine blob category.
+        let host3d_blob = match b.blob_mem {
+            VIRTGPU_BLOB_MEM_GUEST => false,
+            VIRTGPU_BLOB_MEM_HOST3D_GUEST | VIRTGPU_BLOB_MEM_HOST3D => true,
+            _ => {
+                // Linux: default: return -EINVAL;
+                return Err(VfsError::InvalidInput);
+            }
+        };
+
+        // Linux: if (*host3d_blob) {
+        //           if (!vgdev->has_virgl_3d) return -EINVAL;
+        //           if (rc_blob->cmd_size % 4 != 0) return -EINVAL;
+        if host3d_blob {
+            if !ax_display::has_virgl() {
+                return Err(VfsError::InvalidInput);
+            }
+            // cmd_size 必须 4 字节对齐
+            if !b.cmd_size.is_multiple_of(4) {
+                return Err(VfsError::InvalidInput);
+            }
+        } else {
+            // Linux: if (rc_blob->blob_id != 0) return -EINVAL;
+            //        if (rc_blob->cmd_size != 0) return -EINVAL;
+            if b.blob_id != 0 {
+                return Err(VfsError::InvalidInput);
+            }
+            if b.cmd_size != 0 {
+                return Err(VfsError::InvalidInput);
+            }
+        }
+
+        // Validate size.
+        if b.size == 0 || b.size > 256 * 1024 * 1024 {
+            return Err(VfsError::InvalidInput);
+        }
+
+        // Allocate a guest shadow buffer so VIRTGPU_MAP/mmap on the blob's
+        // GEM handle keeps working. For HOST3D the real backing lives on
+        // the host and we deliberately do NOT send these pages to the
+        // device (nr_entries=0): QEMU and virglrenderer reject HOST3D blobs
+        // that carry an iov. The shadow is only for mmap compatibility —
+        // the present path is zero-copy on the host, no CPU readback.
+        let alloc_size = (b.size as usize).div_ceil(PAGE_SIZE_4K) * PAGE_SIZE_4K;
+        let pages = GlobalPage::alloc_contiguous(
+            alloc_size / PAGE_SIZE_4K,
+            PAGE_SIZE_4K,
+        )
+        .map_err(|_| VfsError::NoMemory)?;
+
+        // Zero-initialize.
+        unsafe {
+            core::ptr::write_bytes(pages.start_vaddr().as_ptr() as *mut u8, 0, alloc_size);
+        }
+
+        // Allocate a GEM handle.
+        let bo_handle = self.next_dumb_handle.fetch_add(1, Ordering::Relaxed);
+        let offset = self.next_offset.fetch_add(DUMB_BUFFER_OFFSET_STRIDE, Ordering::Relaxed);
+
+        self.dumbs.lock().insert(bo_handle, DumbBuffer {
+            width: 0, // Blobs don't have geometry.
+            height: 0,
+            bpp: 0,
+            pitch: 0,
+            size: b.size,
+            offset,
+            pages: Arc::new(pages),
+        });
+
+        // Allocate a virtio-gpu resource ID.
+        let res_handle = self.next_res_handle.fetch_add(1, Ordering::Relaxed);
+
+        // Linux: if (rc_blob->cmd_size) {
+        //           buf = memdup_user(...);
+        //           virtio_gpu_cmd_submit(vgdev, buf, rc_blob->cmd_size,
+        //                                 vfpriv->ctx_id, NULL, NULL);
+        //        }
+        // followed by virtio_gpu_cmd_resource_create_blob(...). The display
+        // driver submits the virgl cmd *before* RESOURCE_CREATE_BLOB, which
+        // is the Linux order (both commands execute in sequence on the same
+        // virtqueue).
+        let cmd_buf = if b.cmd_size > 0 && b.cmd != 0 {
+            vm_load(b.cmd as *const u8, b.cmd_size as usize)
+                .map_err(|_| VfsError::BadAddress)?
+        } else {
+            Vec::new()
+        };
+
+        if ax_display::has_virgl() {
+            let ctx_id = self.current_ctx().ok_or(VfsError::InvalidInput)?;
+            ax_display::gpu3d_resource_create_blob(
+                ctx_id,
+                res_handle,
+                b.blob_mem,
+                b.blob_flags,
+                b.size,
+                b.blob_id,
+                &cmd_buf,
+            )
+            .map_err(map_gpu3d_err)?;
+        }
+
+        // Track the resource. blob_mem/blob_flags feed RESOURCE_INFO so
+        // Mesa's importer can take the untyped (reuse-host-texture) path.
+        self.gpu_resources.lock().insert(res_handle, GpuResource {
+            bo_handle,
+            width: 0,
+            height: 0,
+            stride: 0,
+            size: b.size,
+            attached: false,
+            blob_mem: b.blob_mem,
+            blob_flags: b.blob_flags,
+            is_dumb_2d: false,
+        });
+
+        // Linux: rc_blob->res_handle = bo->hw_res_handle;
+        //        rc_blob->bo_handle = handle;
+        b.bo_handle = bo_handle;
+        b.res_handle = res_handle;
+        ptr.vm_write(b).map_err(|_| VfsError::BadAddress)?;
+
+        Ok(0)
+    }
 }
 
 /// Map a fixed object id to its `DRM_MODE_OBJECT_*` type tag.
@@ -1811,6 +3206,20 @@ fn object_type_of(id: u32) -> Option<u32> {
         CONNECTOR_ID => Some(DRM_MODE_OBJECT_CONNECTOR),
         PLANE_ID => Some(DRM_MODE_OBJECT_PLANE),
         _ => None,
+    }
+}
+
+/// Map a GPU 3D error from the display layer to a VfsError.
+fn map_gpu3d_err(err: ax_display::DisplayError) -> VfsError {
+    match err {
+        ax_display::DisplayError::NotSupported => VfsError::Unsupported,
+        ax_display::DisplayError::NotAvailable => VfsError::WouldBlock,
+        ax_display::DisplayError::Gpu3dError(kind) => match kind {
+            ax_display::Gpu3dErrorKind::InvalidParam => VfsError::InvalidInput,
+            ax_display::Gpu3dErrorKind::NotReady => VfsError::WouldBlock,
+            _ => VfsError::Io,
+        },
+        _ => VfsError::Io,
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
@@ -121,6 +121,20 @@ pub struct DrmModeDirtyFB {
     pub clips_ptr: u64,
 }
 
+/// One rectangle in a `DIRTY_FB` clip array — `struct drm_clip_rect` on the
+/// wire: four `u16` *inclusive* bounds in framebuffer pixel coordinates
+/// (`x2`/`y2` name the last damaged pixel). Linux feeds these into
+/// `drm_atomic_helper_damage_merged`; Starry merges them in
+/// `Card::handle_dirty_fb` so `present_fb` uploads only the damaged region.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmClipRect {
+    pub x1: u16,
+    pub y1: u16,
+    pub x2: u16,
+    pub y2: u16,
+}
+
 #[repr(C)]
 #[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
 pub struct DrmPrimeHandle {

--- a/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
@@ -48,11 +48,11 @@ const fn io(ty: u8, nr: u8) -> u32 {
 
 /// Lowest driver-specific DRM command number (`DRM_COMMAND_BASE`). Core
 /// DRM commands live below this; modeset commands at or above 0xA0.
-#[cfg(feature = "rknpu")]
+#[allow(dead_code)]
 pub const DRM_COMMAND_BASE: u32 = 0x40;
 /// One past the highest driver-specific DRM command number
 /// (`DRM_COMMAND_END`).
-#[cfg(feature = "rknpu")]
+#[allow(dead_code)]
 pub const DRM_COMMAND_END: u32 = 0xA0;
 
 /// Extracts the command number (bits 7..0) from a packed ioctl request.
@@ -83,6 +83,14 @@ pub const DRM_IOCTL_VERSION: u32 = iowr::<DrmVersion>(DRM_TYPE, 0x00);
 pub const DRM_IOCTL_GET_UNIQUE: u32 = iowr::<DrmUnique>(DRM_TYPE, 0x01);
 pub const DRM_IOCTL_SET_VERSION: u32 = iowr::<DrmSetVersion>(DRM_TYPE, 0x07);
 pub const DRM_IOCTL_GET_CAP: u32 = iowr::<DrmGetCap>(DRM_TYPE, 0x0c);
+/// GEM_CLOSE — release a GEM handle (pure input, WRITE direction).
+/// Layout: `struct drm_gem_close { u32 handle; u32 pad; }` (8 bytes).
+pub const DRM_IOCTL_GEM_CLOSE: u32 = ioc(
+    IOC_WRITE,
+    DRM_TYPE,
+    0x09,
+    core::mem::size_of::<DrmGemClose>() as u16,
+);
 pub const DRM_IOCTL_SET_CLIENT_CAP: u32 = ioc(
     IOC_WRITE,
     DRM_TYPE,
@@ -385,6 +393,17 @@ pub struct DrmModeDestroyDumb {
     pub handle: u32,
 }
 
+/// `struct drm_gem_close` — GEM_CLOSE ioctl payload. Unlike
+/// `DrmModeDestroyDumb`, this carries an explicit 8-byte layout
+/// (`handle` + `pad`) so the packed ioctl number decodes with size 8,
+/// matching `DRM_IOCTL_GEM_CLOSE = 0x40086409` as sent by Mesa/libdrm.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmGemClose {
+    pub handle: u32,
+    pub pad: u32,
+}
+
 /// XRGB8888 — four bytes per pixel, little-endian, X/R/G/B in low-to-high.
 pub const DRM_FORMAT_XRGB8888: u32 =
     (b'X' as u32) | ((b'R' as u32) << 8) | ((b'2' as u32) << 16) | ((b'4' as u32) << 24);
@@ -591,6 +610,400 @@ pub struct DrmModeGetBlob {
     pub length: u32,
     /// user ptr the kernel writes the blob bytes to (truncated to `length`)
     pub data: u64,
+}
+
+// ======== virtgpu ioctls ========
+//
+// Private ioctls for virtio-gpu 3D (virgl) support. These live at
+// DRM_COMMAND_BASE + N and are dispatched through the same ioctl match
+// as core DRM commands.
+//
+// Reference: Linux v6.1 include/uapi/drm/virtgpu_drm.h
+// Mesa: src/gallium/winsys/virgl/drm/virgl_drm_winsys.c
+
+// ---- virtgpu ioctl numbers ----
+// DRM ioctl encoding: DRM_IOWR(DRM_COMMAND_BASE + N, struct)
+// where DRM_TYPE = b'd' (0x64)
+
+pub const DRM_IOCTL_VIRTGPU_MAP: u32 = iowr::<DrmVirtgpuMap>(DRM_TYPE, 0x41);
+pub const DRM_IOCTL_VIRTGPU_EXECBUFFER: u32 = iowr::<DrmVirtgpuExecbuffer>(DRM_TYPE, 0x42);
+pub const DRM_IOCTL_VIRTGPU_GETPARAM: u32 = iowr::<DrmVirtgpuGetparam>(DRM_TYPE, 0x43);
+pub const DRM_IOCTL_VIRTGPU_RESOURCE_CREATE: u32 = iowr::<DrmVirtgpuResourceCreate>(DRM_TYPE, 0x44);
+pub const DRM_IOCTL_VIRTGPU_RESOURCE_INFO: u32 = iowr::<DrmVirtgpuResourceInfo>(DRM_TYPE, 0x45);
+pub const DRM_IOCTL_VIRTGPU_TRANSFER_FROM_HOST: u32 =
+    iowr::<DrmVirtgpu3dTransferFromHost>(DRM_TYPE, 0x46);
+pub const DRM_IOCTL_VIRTGPU_TRANSFER_TO_HOST: u32 =
+    iowr::<DrmVirtgpu3dTransferToHost>(DRM_TYPE, 0x47);
+pub const DRM_IOCTL_VIRTGPU_WAIT: u32 = iowr::<DrmVirtgpu3dWait>(DRM_TYPE, 0x48);
+pub const DRM_IOCTL_VIRTGPU_GET_CAPS: u32 = iowr::<DrmVirtgpuGetCaps>(DRM_TYPE, 0x49);
+pub const DRM_IOCTL_VIRTGPU_RESOURCE_CREATE_BLOB: u32 =
+    iowr::<DrmVirtgpuResourceCreateBlob>(DRM_TYPE, 0x4a);
+pub const DRM_IOCTL_VIRTGPU_CONTEXT_INIT: u32 = iowr::<DrmVirtgpuContextInit>(DRM_TYPE, 0x4b);
+
+// ---- GETPARAM parameter IDs (VIRTGPU_PARAM_*) ----
+
+/// Whether the device supports 3D features (virgl).
+pub const VIRTGPU_PARAM_3D_FEATURES: u64 = 1;
+/// Whether capset query fix is supported.
+pub const VIRTGPU_PARAM_CAPSET_QUERY_FIX: u64 = 2;
+/// Whether RESOURCE_CREATE_BLOB is supported.
+pub const VIRTGPU_PARAM_RESOURCE_BLOB: u64 = 3;
+/// Whether host-visible blob resources can be mmap'd.
+pub const VIRTGPU_PARAM_HOST_VISIBLE: u64 = 4;
+/// Whether cross-device resource sharing is supported.
+pub const VIRTGPU_PARAM_CROSS_DEVICE: u64 = 5;
+/// Whether CONTEXT_INIT is supported.
+pub const VIRTGPU_PARAM_CONTEXT_INIT: u64 = 6;
+/// Bitmask of supported capset IDs.
+pub const VIRTGPU_PARAM_SUPPORTED_CAPSET_IDS: u64 = 7;
+/// User-space debug naming (v6.12+).
+#[allow(dead_code)]
+pub const VIRTGPU_PARAM_EXPLICIT_DEBUG_NAME: u64 = 8;
+/// Blob alignment requirement (v6.15+).
+#[allow(dead_code)]
+pub const VIRTGPU_PARAM_BLOB_ALIGNMENT: u64 = 9;
+
+// ---- EXECBUFFER flags (VIRTGPU_EXECBUF_*) ----
+
+/// fence_fd is an input dependency.
+pub const VIRTGPU_EXECBUF_FENCE_FD_IN: u32 = 0x01;
+/// fence_fd is an output completion signal.
+pub const VIRTGPU_EXECBUF_FENCE_FD_OUT: u32 = 0x02;
+/// Use ring_idx field.
+#[allow(dead_code)]
+pub const VIRTGPU_EXECBUF_RING_IDX: u32 = 0x04;
+/// syncobj reset (v6.6+).
+#[allow(dead_code)]
+pub const VIRTGPU_EXECBUF_SYNCOBJ_RESET: u32 = 0x01;
+
+// ---- WAIT flags ----
+
+/// Non-blocking wait.
+#[allow(dead_code)]
+pub const VIRTGPU_WAIT_NOWAIT: u32 = 1;
+
+// ---- CONTEXT parameters (VIRTGPU_CONTEXT_PARAM_*) ----
+
+/// Capset ID for the context.
+pub const VIRTGPU_CONTEXT_PARAM_CAPSET_ID: u64 = 0x0001;
+/// Number of command rings.
+pub const VIRTGPU_CONTEXT_PARAM_NUM_RINGS: u64 = 0x0002;
+/// Poll rings mask.
+pub const VIRTGPU_CONTEXT_PARAM_POLL_RINGS_MASK: u64 = 0x0003;
+/// Debug name (v6.12+).
+#[allow(dead_code)]
+pub const VIRTGPU_CONTEXT_PARAM_DEBUG_NAME: u64 = 0x0004;
+
+// ---- CAPSET IDs (VIRTGPU_DRM_CAPSET_*) ----
+
+/// Virgl capset v1.
+pub const VIRTGPU_DRM_CAPSET_VIRGL: u32 = 1;
+/// Virgl capset v2 (Mesa prefers this).
+pub const VIRTGPU_DRM_CAPSET_VIRGL2: u32 = 2;
+/// gfxstream Vulkan capset.
+#[allow(dead_code)]
+pub const VIRTGPU_DRM_CAPSET_GFXSTREAM_VULKAN: u32 = 3;
+/// Venus (Vulkan) capset.
+#[allow(dead_code)]
+pub const VIRTGPU_DRM_CAPSET_VENUS: u32 = 4;
+/// Cross-domain capset.
+#[allow(dead_code)]
+pub const VIRTGPU_DRM_CAPSET_CROSS_DOMAIN: u32 = 5;
+/// DRM capset.
+#[allow(dead_code)]
+pub const VIRTGPU_DRM_CAPSET_DRM: u32 = 6;
+
+// ---- BLOB memory types (VIRTGPU_BLOB_MEM_*) ----
+
+/// Guest memory blob.
+pub const VIRTGPU_BLOB_MEM_GUEST: u32 = 0x0001;
+/// Host 3D memory blob (Mesa uses this).
+pub const VIRTGPU_BLOB_MEM_HOST3D: u32 = 0x0002;
+/// Host 3D + guest memory blob.
+pub const VIRTGPU_BLOB_MEM_HOST3D_GUEST: u32 = 0x0003;
+
+// ---- BLOB flags (VIRTGPU_BLOB_FLAG_*) ----
+
+/// Blob can be mmap'd (Mesa uses this).
+#[allow(dead_code)]
+pub const VIRTGPU_BLOB_FLAG_USE_MAPPABLE: u32 = 0x0001;
+/// Blob can be shared.
+#[allow(dead_code)]
+pub const VIRTGPU_BLOB_FLAG_USE_SHAREABLE: u32 = 0x0002;
+/// Blob can be used across devices.
+#[allow(dead_code)]
+pub const VIRTGPU_BLOB_FLAG_USE_CROSS_DEVICE: u32 = 0x0004;
+/// Hint: defer mapping.
+#[allow(dead_code)]
+pub const DRM_VIRTGPU_BLOB_FLAG_HINT_DEFER_MAPPING: u32 = 0x0001;
+
+// ---- Event codes ----
+
+/// Fence signaled event.
+#[allow(dead_code)]
+pub const VIRTGPU_EVENT_FENCE_SIGNALED: u32 = 0x90000000;
+
+// ---- virtgpu structs ----
+
+/// Maps a GEM handle to an mmap offset.
+/// Linux: `struct drm_virtgpu_map` (16 bytes)
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmVirtgpuMap {
+    /// Output: offset for mmap system call.
+    pub offset: u64,
+    /// Input: GEM handle.
+    pub handle: u32,
+    pub pad: u32,
+}
+
+/// Submits a virgl command buffer to the host.
+/// Linux: `struct drm_virtgpu_execbuffer` (v6.1: 40 bytes, v6.6+: 64 bytes)
+///
+/// We use the v6.1 layout (40 bytes) for maximum compatibility. Mesa virgl
+/// does not use the syncobj fields added in v6.6+.
+///
+/// **Critical**: There is NO `ctx_id` field. The context is implicitly
+/// bound to the file descriptor via CONTEXT_INIT.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmVirtgpuExecbuffer {
+    /// VIRTGPU_EXECBUF_FENCE_FD_IN/OUT/RING_IDX flags.
+    pub flags: u32,
+    /// Command buffer size in bytes.
+    pub size: u32,
+    /// User-space pointer to command buffer.
+    pub command: u64,
+    /// User-space pointer to __u32 array of GEM handles.
+    pub bo_handles: u64,
+    /// Number of bo_handles.
+    pub num_bo_handles: u32,
+    /// Input/output fence fd (signed! default -1).
+    pub fence_fd: i32,
+    /// Command ring index (used when RING_IDX flag is set).
+    pub ring_idx: u32,
+    // ---- syncobj fields (Linux drm_virtgpu_execbuffer tail, 64B total) ----
+    // 缺少这些字段会让 struct 只有 40 字节 → ioctl 号(size 位)与 mesa 的 64
+    // 字节不一致 → EXECBUFFER 落不到 handler → "expect bad rendering 95"。
+    /// Size of each @drm_virtgpu_execbuffer_syncobj.
+    pub syncobj_stride: u32,
+    /// Number of in syncobjs.
+    pub num_in_syncobjs: u32,
+    /// Number of out syncobjs.
+    pub num_out_syncobjs: u32,
+    /// Pointer to in syncobj array.
+    pub in_syncobjs: u64,
+    /// Pointer to out syncobj array.
+    pub out_syncobjs: u64,
+}
+
+/// Queries a driver parameter.
+/// Linux: `struct drm_virtgpu_getparam` (16 bytes)
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmVirtgpuGetparam {
+    /// Input: parameter ID (VIRTGPU_PARAM_*).
+    pub param: u64,
+    /// Output: parameter value.
+    pub value: u64,
+}
+
+/// Creates a 3D resource (texture, render target, buffer, etc.).
+/// Linux: `struct drm_virtgpu_resource_create` (56 bytes)
+///
+/// **Critical**: `bo_handle` (input, GEM handle) and `res_handle` (output,
+/// virtio-gpu resource ID) are DIFFERENT concepts. Mesa uses them
+/// independently.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmVirtgpuResourceCreate {
+    /// Input: target type (GL_TEXTURE_2D, etc.).
+    pub target: u32,
+    /// Input: PIPE_FORMAT_* pixel format.
+    pub format: u32,
+    /// Input: VIRGL_BIND_* binding flags.
+    pub bind: u32,
+    pub width: u32,
+    pub height: u32,
+    pub depth: u32,
+    pub array_size: u32,
+    /// Input: mipmap highest level (not "level").
+    pub last_level: u32,
+    /// Input: MSAA sample count (usually 0).
+    pub nr_samples: u32,
+    /// Input: resource flags.
+    pub flags: u32,
+    /// Input: associate with existing GEM BO (0 = kernel allocates new BO).
+    pub bo_handle: u32,
+    /// Output: virtio-gpu resource ID (NOT GEM handle!).
+    pub res_handle: u32,
+    /// Output: resource size (for transfer validation).
+    pub size: u32,
+    /// Input/Output: row stride.
+    pub stride: u32,
+}
+
+/// Queries resource information.
+/// Linux: `struct drm_virtgpu_resource_info` (16 bytes)
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmVirtgpuResourceInfo {
+    /// Input: GEM handle.
+    pub bo_handle: u32,
+    /// Output: virtio-gpu resource ID.
+    pub res_handle: u32,
+    /// Output: resource size.
+    pub size: u32,
+    /// Output: blob memory type (0 for non-blob resources).
+    pub blob_mem: u32,
+}
+
+/// 3D box region for data transfer operations.
+/// Linux: `struct drm_virtgpu_3d_box` (24 bytes)
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmVirtgpu3dBox {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+    pub w: u32,
+    pub h: u32,
+    pub d: u32,
+}
+
+/// Transfers data from guest to host for a 3D resource.
+/// Linux: `struct drm_virtgpu_3d_transfer_to_host` (44 bytes)
+///
+/// **Critical**: `offset` is u32 (not u64), and the box is a NESTED
+/// DrmVirtgpu3dBox struct (not 6 inline u32s).
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmVirtgpu3dTransferToHost {
+    /// GEM handle.
+    pub bo_handle: u32,
+    /// Nested 3D box (24 bytes).
+    pub box_: DrmVirtgpu3dBox,
+    /// Mipmap level.
+    pub level: u32,
+    /// Buffer offset (u32, not u64!).
+    pub offset: u32,
+    /// Row stride.
+    pub stride: u32,
+    /// Layer stride.
+    pub layer_stride: u32,
+}
+
+/// Transfers data from host to guest for a 3D resource.
+/// Linux: `struct drm_virtgpu_3d_transfer_from_host` (44 bytes)
+/// Layout identical to transfer_to_host.
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmVirtgpu3dTransferFromHost {
+    /// GEM handle.
+    pub bo_handle: u32,
+    /// Nested 3D box (24 bytes).
+    pub box_: DrmVirtgpu3dBox,
+    /// Mipmap level.
+    pub level: u32,
+    /// Buffer offset (u32, not u64!).
+    pub offset: u32,
+    /// Row stride.
+    pub stride: u32,
+    /// Layer stride.
+    pub layer_stride: u32,
+}
+
+/// Waits for a resource to become idle.
+/// Linux: `struct drm_virtgpu_3d_wait` (8 bytes)
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmVirtgpu3dWait {
+    /// GEM handle (0 is invalid).
+    pub handle: u32,
+    /// VIRTGPU_WAIT_NOWAIT etc.
+    pub flags: u32,
+}
+
+/// Retrieves capability set data.
+/// Linux: `struct drm_virtgpu_get_caps` (24 bytes)
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmVirtgpuGetCaps {
+    /// Input: capset ID (VIRTGPU_DRM_CAPSET_VIRGL=1, VIRGL2=2).
+    pub cap_set_id: u32,
+    /// Input: capset version.
+    pub cap_set_ver: u32,
+    /// Input: user-space buffer pointer.
+    pub addr: u64,
+    /// Input/Output: buffer size.
+    pub size: u32,
+    pub pad: u32,
+}
+
+/// Creates a blob resource for coherent memory sharing.
+/// Linux: `struct drm_virtgpu_resource_create_blob` (48 bytes)
+///
+/// Mesa virgl calls this when `supports_coherent=true` (i.e. both
+/// RESOURCE_BLOB and HOST_VISIBLE are reported as supported).
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmVirtgpuResourceCreateBlob {
+    /// VIRTGPU_BLOB_MEM_* (Mesa uses HOST3D).
+    pub blob_mem: u32,
+    /// VIRTGPU_BLOB_FLAG_* (Mesa uses USE_MAPPABLE).
+    pub blob_flags: u32,
+    /// Output: GEM handle.
+    pub bo_handle: u32,
+    /// Output: virtio-gpu resource ID.
+    pub res_handle: u32,
+    /// Blob size in bytes.
+    pub size: u64,
+    pub pad: u32,
+    /// VIRGL command size in bytes.
+    pub cmd_size: u32,
+    /// User-space pointer to VIRGL_PIPE_RES_CREATE command.
+    pub cmd: u64,
+    /// Blob unique identifier.
+    pub blob_id: u64,
+}
+
+/// Initializes a rendering context on this file descriptor.
+/// Linux: `struct drm_virtgpu_context_init` (16 bytes)
+///
+/// **Critical**: This is a PURE INPUT struct — there is NO `ctx_id` output
+/// field. The context is implicitly bound to the file descriptor. Each fd
+/// can only call CONTEXT_INIT once (repeated calls return -EEXIST).
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmVirtgpuContextInit {
+    /// Input: number of parameters (kernel limits to max 3).
+    pub num_params: u32,
+    pub pad: u32,
+    /// Input: pointer to DrmVirtgpuContextSetParam array.
+    pub ctx_set_params: u64,
+}
+
+/// A single context parameter for CONTEXT_INIT.
+/// Linux: `struct drm_virtgpu_context_set_param` (16 bytes)
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
+pub struct DrmVirtgpuContextSetParam {
+    /// VIRTGPU_CONTEXT_PARAM_* constant.
+    pub param: u64,
+    /// Parameter value.
+    pub value: u64,
+}
+
+/// Syncobj entry for execbuffer (v6.6+).
+/// Linux: `struct drm_virtgpu_execbuffer_syncobj` (16 bytes)
+/// Mesa virgl does not use this.
+#[allow(dead_code)]
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy, AnyBitPattern, NoUninit)]
+pub struct DrmVirtgpuExecbufferSyncobj {
+    pub handle: u32,
+    pub flags: u32,
+    pub point: u64,
 }
 
 #[cfg(all(test, feature = "rknpu"))]

--- a/os/StarryOS/kernel/src/pseudofs/dev/fb.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/fb.rs
@@ -78,6 +78,11 @@ struct FixScreenInfo {
     pub reserved: [u16; 2], // Reserved for future compatibility
 }
 
+/// run6 A/B: when false, the 60Hz framebuffer_flush task is not spawned.
+/// (run6a keeps it for baseline; run6b flips to false to measure the
+/// xfer(0xbabe)+flush chain's contribution to the display path.)
+const FB_REFRESH_TASK_ENABLED: bool = false;
+
 async fn refresh_task() {
     let delay = core::time::Duration::from_secs_f32(1. / 60.);
     loop {
@@ -94,10 +99,12 @@ pub struct FrameBuffer {
 }
 impl FrameBuffer {
     pub fn new() -> Self {
-        ax_task::spawn_with_name(
-            || ax_task::future::block_on(refresh_task()),
-            "fb-refresh".into(),
-        );
+        if FB_REFRESH_TASK_ENABLED {
+            ax_task::spawn_with_name(
+                || ax_task::future::block_on(refresh_task()),
+                "fb-refresh".into(),
+            );
+        }
         let info = ax_display::framebuffer_info();
         Self {
             base: VirtAddr::from(info.fb_base_vaddr),

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -30,6 +30,7 @@ pub(super) mod pwm;
 #[cfg(feature = "rga")]
 pub(crate) mod rga;
 mod rtc;
+mod sync_file;
 #[cfg(feature = "sg2002")]
 pub mod tpu;
 pub mod tty;

--- a/os/StarryOS/kernel/src/pseudofs/dev/sync_file.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/sync_file.rs
@@ -72,6 +72,8 @@ pub struct SyncFile {
     fence_id: u64,
     signaled: AtomicBool,
     poll_set: PollSet,
+    /// Whether a poll/epoll waiter currently holds a waker in `poll_set`.
+    has_poller: core::sync::atomic::AtomicBool,
 }
 
 /// Live out-fence registry. The host completion of a fence is only observable
@@ -96,6 +98,7 @@ impl SyncFile {
             fence_id,
             signaled: AtomicBool::new(false),
             poll_set: PollSet::new(),
+            has_poller: core::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -327,6 +330,17 @@ impl Pollable for SyncFile {
         // by the poll_set afterwards and woken via `signal` (also task
         // context).
         unsafe { self.poll_set.register(&waker, IoEvents::IN) };
+        self.has_poller
+            .store(true, core::sync::atomic::Ordering::Release);
+    }
+
+    fn unregister(&self, waker: &core::task::Waker) {
+        // SAFETY: poll deregistration runs in task context (poll/epoll return).
+        unsafe {
+            self.poll_set.unregister(waker);
+        }
+        self.has_poller
+            .store(false, core::sync::atomic::Ordering::Release);
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/dev/sync_file.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/sync_file.rs
@@ -1,0 +1,391 @@
+//! Minimal Linux `sync_file` fd object (UAPI alignment of
+//! `drivers/dma-buf/sync_file.c`).
+//!
+//! The only consumer is card0's EXECBUFFER fence path. Guest submits are
+//! fire-and-forget (the fork's `submit_3d` enqueues and returns; the fence
+//! flag rides on the command), so an out-fence must be a *real* fence: it
+//! starts unsignaled and flips once the host completed the submit (the
+//! used-ring pop advances `completed_fence_id`). This matches Linux
+//! `VIRTGPU_EXECBUF_FENCE_FD_OUT` (`virtgpu_ioctl.c`): the kernel wraps the
+//! dma-fence in a sync_file and `sync_file_poll` reports POLLIN when the
+//! fence fires.
+//!
+//! UAPI reference (`include/uapi/linux/sync_file.h`, Linux master; opcodes
+//! 0-2 were burned by the sync-framework v1→v2 revert):
+//! - `SYNC_IOC_WAIT` = `_IOW('>', 0, struct sync_wait_data)` in the v2 ABI;
+//!   v1 used `_IOW('>', 0, __s32)`. Both place the millisecond timeout in
+//!   the first four bytes, so both are matched by (type `0x3e`, nr `0`).
+//!   Negative waits forever, zero only tests, positive bounds the wait;
+//!   expiry reports `ETIMEDOUT` (sync_file_ioctl_wait → -ETIME).
+//! - `SYNC_IOC_FILE_INFO` = `_IOWR('>', 4, struct sync_file_info)`;
+//!   `status` is 1 signaled / 0 active, `num_fences == 0` publishes the
+//!   fence count, a non-null `sync_fence_info` buffer receives one entry.
+//! - `SYNC_IOC_MERGE` / `SYNC_IOC_SET_DEADLINE` have no consumer here and
+//!   keep the generic `ENOTTY`.
+//! - `poll`/`epoll` report `POLLIN` once signaled.
+//!
+//! Wakeups: a [`PollSet`] drives poll/epoll sleepers. Completion is observed
+//! three ways: waiter-driven refresh (the WAIT ioctl loop, poll levels), a
+//! background refresher task (the device's completion IRQ is not delivered in
+//! this environment, so a guest blocked in `poll()` needs the refresher to
+//! pump the used ring and wake it), and the display-completion IRQ handler as
+//! a fast path when the IRQ does fire. The guest's libsync fence wait is
+//! `poll(fd, POLLIN, timeout)`, not the SYNC_IOC_WAIT ioctl.
+
+use alloc::{
+    borrow::Cow,
+    string::String,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    task::Context,
+    time::Duration,
+};
+
+use ax_display::gpu3d_fence_completed;
+use ax_runtime::hal::time::monotonic_time;
+use axpoll::{IoEvents, PollSet, Pollable};
+use starry_vm::{VmMutPtr, VmPtr};
+
+use crate::{StarryError, StarryResult, file::FileLike, sync::IrqMutex};
+
+/// ioctl type byte for every sync_file command (`#define SYNC_IOC_MAGIC '>'`).
+const SYNC_IOC_MAGIC: u32 = b'>' as u32;
+
+/// `SYNC_IOC_WAIT`: wait for the fence, timeout in the first `__s32`.
+const SYNC_IOC_WAIT_NR: u32 = 0;
+/// `SYNC_IOC_FILE_INFO`: describe fence status/count (opcode 4 in the v2 ABI).
+const SYNC_IOC_FILE_INFO_NR: u32 = 4;
+
+const FENCE_NAME: &str = "starry-fence";
+const FENCE_DRIVER_NAME: &str = "starry-card0";
+
+/// A sync_file backed by one GPU submit fence.
+///
+/// Signaled state is published before pollers are woken (`Release` on the
+/// swap, `Acquire` on the loads), so a woken waiter always observes the
+/// completion it was woken for.
+pub struct SyncFile {
+    /// The `submit_3d` fence id whose host completion signals this file.
+    fence_id: u64,
+    signaled: AtomicBool,
+    poll_set: PollSet,
+}
+
+/// Live out-fence registry. The host completion of a fence is only observable
+/// as a level (`completed_fence_id`); a guest *blocked in poll()* cannot
+/// re-check that level by itself, so a background refresher task pumps the
+/// used ring and wakes matching pollers ([`refresher_loop`]). The
+/// display-completion IRQ handler (card0) also refreshes it as a fast path
+/// when the IRQ does fire. Entries are `Weak`; dead ones are pruned by the
+/// same scan. The lock is an IRQ-save mutex so the IRQ path can never spin
+/// on it (all holders hold it with local IRQs disabled).
+static FENCE_WAITERS: IrqMutex<Vec<(u64, Weak<SyncFile>)>> = IrqMutex::new(Vec::new());
+
+/// One-shot guard so the refresher task is spawned exactly once (on the first
+/// registered out-fence).
+static REFRESHER_SPAWNED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+impl SyncFile {
+    /// Creates a sync_file for `fence_id`, initially unsignaled.
+    pub fn new(fence_id: u64) -> Self {
+        Self {
+            fence_id,
+            signaled: AtomicBool::new(false),
+            poll_set: PollSet::new(),
+        }
+    }
+
+    /// Registers this out-fence in the completion registry. Call right after
+    /// the `Arc` is created (card0's EXECBUFFER FENCE_FD_OUT path).
+    ///
+    /// `lock_irqsave` on both sides (here and the scans) guarantees the
+    /// registry is never held with IRQs enabled, so the completion IRQ can
+    /// never spin on it.
+    pub fn register(self: &Arc<Self>) {
+        FENCE_WAITERS
+            .lock()
+            .push((self.fence_id, Arc::downgrade(self)));
+        ensure_refresher();
+    }
+
+    /// Publishes the signaled state and wakes poll/epoll sleepers.
+    ///
+    /// Task context only: [`PollSet::wake`] must not run in hard IRQ. All
+    /// call sites (WAIT ioctl, poll levels, in-fence waits) are task context.
+    fn signal(&self) {
+        if !self.signaled.swap(true, Ordering::Release) {
+            // SAFETY: task context; readiness was published by the `swap`
+            // above before any woken thread reloads it.
+            unsafe { self.poll_set.wake(IoEvents::IN) };
+        }
+    }
+
+    /// Polls the underlying GPU fence and returns the current signaled state.
+    pub fn refresh(&self) -> bool {
+        if !self.signaled.load(Ordering::Acquire)
+            && gpu3d_fence_completed(self.fence_id).is_ok_and(|done| done)
+        {
+            self.signal();
+        }
+        self.signaled.load(Ordering::Acquire)
+    }
+
+    /// Blocks until signaled.
+    ///
+    /// `timeout == None` waits forever (EXECBUFFER in-fence semantics);
+    /// otherwise the wait is bounded. Cooperative: the loop yields between
+    /// completion checks, mirroring the driver's `wait_fence` spin.
+    pub fn wait_signaled(&self, timeout: Option<Duration>) -> StarryResult<()> {
+        let deadline = timeout.map(|t| monotonic_time() + t);
+        loop {
+            if self.refresh() {
+                return Ok(());
+            }
+            if let Some(deadline) = deadline
+                && monotonic_time() >= deadline
+            {
+                return Err(StarryError::TimedOut);
+            }
+            ax_task::yield_now();
+        }
+    }
+
+    /// IRQ-context completion check: publish signaled state and wake pollers
+    /// with the no-alloc [`PollSet::wake_from_irq`]. Task-context callers use
+    /// [`Self::refresh`] (which goes through `signal` + `wake` instead).
+    /// Returns the number of pollers woken (0 when already signaled or when
+    /// the host has not completed the fence yet).
+    fn refresh_from_irq(&self) -> usize {
+        if !self.signaled.load(Ordering::Acquire)
+            && gpu3d_fence_completed(self.fence_id).is_ok_and(|done| done)
+        {
+            // Publish before wake: a woken poller re-checks and must see it.
+            self.signaled.store(true, Ordering::Release);
+            self.poll_set.wake_from_irq(IoEvents::IN)
+        } else {
+            0
+        }
+    }
+}
+
+impl Drop for SyncFile {
+    fn drop(&mut self) {
+        // Fence ids are unique among live out-fences (one SyncFile per
+        // submit), so removing every entry with this id is exact.
+        // `lock_irqsave`: see `register`.
+        FENCE_WAITERS.lock().retain(|(id, _)| *id != self.fence_id);
+    }
+}
+
+/// Refreshes every live out-fence and wakes the pollers of fences the host
+/// just completed. Called from the display-completion IRQ handler (card0),
+/// right after the device IRQ was acked and completions pumped. No-op when
+/// nothing is registered; dead entries are pruned here.
+pub(crate) fn refresh_fence_waiters_from_irq() {
+    let mut waiters = FENCE_WAITERS.lock();
+    if waiters.is_empty() {
+        return;
+    }
+    waiters.retain(|(_, w)| {
+        let Some(sf) = w.upgrade() else {
+            return false;
+        };
+        sf.refresh_from_irq();
+        true
+    });
+}
+
+/// Task-context refresh of every live out-fence: pumps the used ring (via
+/// `fence_completed`) so `completed_fence_id` advances, then signals + wakes
+/// the pollers of fences that just completed. Returns whether any live
+/// out-fence remains (drives the refresher's sleep period).
+fn refresh_all_fences() -> bool {
+    // Snapshot under the registry lock, then refresh *outside* it: holding
+    // the IRQ-save registry lock across `lock_display()` would deadlock on
+    // smp=1 if the display lock were held by a preempted task (local IRQs
+    // disabled, so the holder can never be rescheduled).
+    let snapshot: Vec<(u64, Weak<SyncFile>)> = {
+        let waiters = FENCE_WAITERS.lock();
+        if waiters.is_empty() {
+            return false;
+        }
+        waiters.clone()
+    };
+    let mut live = false;
+    for (_, w) in &snapshot {
+        let Some(sf) = w.upgrade() else {
+            continue;
+        };
+        live = true;
+        sf.refresh();
+    }
+    live
+}
+
+/// Background fence waiter: while any out-fence is registered, periodically
+/// pump + refresh so poll-blocked guests observe host completions (the
+/// device's completion IRQ is not delivered in this environment). Sleeps long
+/// when the registry is empty. Runs forever; spawned once by
+/// [`ensure_refresher`].
+fn refresher_loop() -> ! {
+    loop {
+        let live = refresh_all_fences();
+        ax_task::sleep(Duration::from_millis(if live { 1 } else { 50 }));
+    }
+}
+
+/// Spawns the refresher task once. Called from [`SyncFile::register`].
+fn ensure_refresher() {
+    if REFRESHER_SPAWNED.swap(true, Ordering::Relaxed) {
+        return;
+    }
+    ax_task::spawn_raw(
+        || refresher_loop(),
+        String::from("fence-wait-refresher"),
+        ax_task::default_task_stack_size(),
+    );
+}
+
+impl FileLike for SyncFile {
+    fn path(&self) -> Cow<'_, str> {
+        "anon_inode:sync_file".into()
+    }
+
+    fn ioctl(&self, cmd: u32, arg: usize) -> StarryResult<usize> {
+        let (ty, nr) = (cmd >> 8 & 0xff, cmd & 0xff);
+        if ty != SYNC_IOC_MAGIC {
+            return Err(StarryError::NotATty);
+        }
+        match nr {
+            SYNC_IOC_WAIT_NR => {
+                // Both v1 (`__s32 timeout`) and v2 (`struct sync_wait_data`)
+                // read the timeout from the first four bytes.
+                let timeout_ms: i32 = (arg as *const i32)
+                    .vm_read()
+                    .map_err(|_| StarryError::BadAddress)?;
+                match timeout_ms {
+                    n if n < 0 => self.wait_signaled(None)?,
+                    0 => {
+                        if !self.refresh() {
+                            return Err(StarryError::TimedOut);
+                        }
+                    }
+                    n => self.wait_signaled(Some(Duration::from_millis(n as u64)))?,
+                }
+                Ok(0)
+            }
+            SYNC_IOC_FILE_INFO_NR => {
+                let ptr = arg as *mut SyncFileInfo;
+                let mut info: SyncFileInfo = ptr.vm_read().map_err(|_| StarryError::BadAddress)?;
+                if info.num_fences == 0 {
+                    info.num_fences = 1;
+                } else if info.fence_info_ptr != 0 {
+                    // Capacity was promised; fill the single fence entry.
+                    let entry = SyncFenceInfo {
+                        obj_name: name_bytes(FENCE_NAME),
+                        driver_name: name_bytes(FENCE_DRIVER_NAME),
+                        status: if self.refresh() { 1 } else { 0 },
+                        flags: 0,
+                        timestamp_ns: 0,
+                    };
+                    (info.fence_info_ptr as *mut SyncFenceInfo)
+                        .vm_write(entry)
+                        .map_err(|_| StarryError::BadAddress)?;
+                }
+                info.name = name_bytes(FENCE_NAME);
+                info.status = if self.refresh() { 1 } else { 0 };
+                info.flags = 0;
+                info.pad = 0;
+                ptr.vm_write(info).map_err(|_| StarryError::BadAddress)?;
+                Ok(0)
+            }
+            _ => Err(StarryError::NotATty),
+        }
+    }
+}
+
+impl Pollable for SyncFile {
+    fn poll(&self) -> IoEvents {
+        if self.refresh() {
+            IoEvents::IN
+        } else {
+            IoEvents::empty()
+        }
+    }
+
+    fn register(&self, context: &mut Context<'_>, events: IoEvents) {
+        if self.refresh() || (events & IoEvents::IN).is_empty() {
+            return;
+        }
+        // Clone the waker first: `register` may wake a replaced entry.
+        let waker = context.waker().clone();
+        // SAFETY: poll registration runs in task context; the waker is owned
+        // by the poll_set afterwards and woken via `signal` (also task
+        // context).
+        unsafe { self.poll_set.register(&waker, IoEvents::IN) };
+    }
+}
+
+/// `struct sync_file_info` (UAPI layout, 56 bytes on 64-bit).
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct SyncFileInfo {
+    name: [u8; 32],
+    status: i32,
+    flags: u32,
+    num_fences: u32,
+    pad: u32,
+    fence_info_ptr: u64,
+}
+
+/// `struct sync_fence_info` (UAPI layout, 80 bytes on 64-bit).
+#[repr(C)]
+#[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+struct SyncFenceInfo {
+    obj_name: [u8; 32],
+    driver_name: [u8; 32],
+    status: i32,
+    flags: u32,
+    timestamp_ns: u64,
+}
+
+/// NUL-padded 32-byte name field as the UAPI defines it.
+fn name_bytes(name: &str) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    let bytes = name.as_bytes();
+    let len = bytes.len().min(31);
+    out[..len].copy_from_slice(&bytes[..len]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_info_layout_matches_uapi() {
+        assert_eq!(size_of::<SyncFileInfo>(), 56);
+        assert_eq!(size_of::<SyncFenceInfo>(), 80);
+    }
+
+    #[test]
+    fn name_is_nul_terminated_and_truncated() {
+        let long = name_bytes(&"x".repeat(64));
+        assert_eq!(long[31], 0);
+        let short = name_bytes("ab");
+        assert_eq!(&short[..3], b"ab\0");
+    }
+
+    #[test]
+    fn wait_ioctl_matches_both_abi_variants() {
+        // v2 `_IOW('>', 0, struct sync_wait_data)` and v1 `_IOW('>', 0, s32)`
+        // must both resolve to (type 0x3e, nr 0).
+        assert_eq!(SYNC_IOC_MAGIC, 0x3e);
+        assert_eq!(SYNC_IOC_WAIT_NR, 0);
+        assert_eq!(SYNC_IOC_FILE_INFO_NR, 4);
+    }
+}

--- a/os/StarryOS/kernel/src/pseudofs/dev/sync_file.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/sync_file.rs
@@ -39,13 +39,14 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    sync::atomic::{AtomicBool, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     task::Context,
     time::Duration,
 };
 
 use ax_display::gpu3d_fence_completed;
 use ax_runtime::hal::time::monotonic_time;
+use ax_task::WaitQueue;
 use axpoll::{IoEvents, PollSet, Pollable};
 use starry_vm::{VmMutPtr, VmPtr};
 
@@ -90,6 +91,27 @@ static FENCE_WAITERS: IrqMutex<Vec<(u64, Weak<SyncFile>)>> = IrqMutex::new(Vec::
 /// registered out-fence).
 static REFRESHER_SPAWNED: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
+
+/// Number of live out-fences that currently have a registered poll/epoll
+/// waker (`has_poller`). The refresher's 1 ms service cadence is only needed
+/// while this is non-zero: `signal` exists to wake pollers, and every other
+/// wait path re-checks the fence level itself (WAIT ioctl and in-fence waits
+/// refresh in their yield loop; epoll re-polls the file on every wait).
+static FENCE_POLLERS: AtomicUsize = AtomicUsize::new(0);
+
+/// Parks the refresher while no pollers exist. A 0→1 poller transition in
+/// `Pollable::register` notifies it so the first waiter is served immediately
+/// instead of after one idle backstop tick.
+static REFRESHER_WAKE: WaitQueue = WaitQueue::new();
+
+/// Refresher wake-ups per perf-report window (idle backstop + active service
+/// ticks), printed and reset by card0's `perf_report`.
+pub(crate) static REFRESH_TICKS: AtomicU64 = AtomicU64::new(0);
+
+/// Idle backstop tick while no pollers exist: prunes dead registry entries
+/// and covers a missed 0→1 notification. 50 ms is far below any fence-wait
+/// timeout a guest tolerates, and 20 wakes/s do not contend for the scheduler.
+const REFRESHER_IDLE_TICK: Duration = Duration::from_millis(50);
 
 impl SyncFile {
     /// Creates a sync_file for `fence_id`, initially unsignaled.
@@ -177,6 +199,12 @@ impl SyncFile {
 
 impl Drop for SyncFile {
     fn drop(&mut self) {
+        // A polled fd can be dropped without a matching unregister return
+        // (e.g. closed while registered in an epoll set); drop the poller
+        // count it still holds so the refresher's gate cannot leak upward.
+        if self.has_poller.swap(false, Ordering::AcqRel) {
+            FENCE_POLLERS.fetch_sub(1, Ordering::Release);
+        }
         // Fence ids are unique among live out-fences (one SyncFile per
         // submit), so removing every entry with this id is exact.
         // `lock_irqsave`: see `register`.
@@ -204,9 +232,9 @@ pub(crate) fn refresh_fence_waiters_from_irq() {
 
 /// Task-context refresh of every live out-fence: pumps the used ring (via
 /// `fence_completed`) so `completed_fence_id` advances, then signals + wakes
-/// the pollers of fences that just completed. Returns whether any live
-/// out-fence remains (drives the refresher's sleep period).
-fn refresh_all_fences() -> bool {
+/// the pollers of fences that just completed. Called on the refresher's
+/// active (pollers present) service cadence.
+fn refresh_all_fences() {
     // Snapshot under the registry lock, then refresh *outside* it: holding
     // the IRQ-save registry lock across `lock_display()` would deadlock on
     // smp=1 if the display lock were held by a preempted task (local IRQs
@@ -214,31 +242,47 @@ fn refresh_all_fences() -> bool {
     let snapshot: Vec<(u64, Weak<SyncFile>)> = {
         let waiters = FENCE_WAITERS.lock();
         if waiters.is_empty() {
-            return false;
+            return;
         }
         waiters.clone()
     };
-    let mut live = false;
     for (_, w) in &snapshot {
-        let Some(sf) = w.upgrade() else {
-            continue;
-        };
-        live = true;
-        sf.refresh();
+        if let Some(sf) = w.upgrade() {
+            sf.refresh();
+        }
     }
-    live
 }
 
-/// Background fence waiter: while any out-fence is registered, periodically
-/// pump + refresh so poll-blocked guests observe host completions (the
-/// device's completion IRQ is not delivered in this environment). Sleeps long
-/// when the registry is empty. Runs forever; spawned once by
+/// Background fence waiter: while at least one guest is *blocked in poll()* on
+/// an out-fence, pump + refresh on a 1 ms cadence so the waiter observes host
+/// completions without the completion IRQ (which this environment may never
+/// deliver). With no pollers, nobody needs waking — WAIT/in-fence waits
+/// refresh themselves in their yield loop and epoll re-polls the file on every
+/// wait — so the loop parks on [`REFRESHER_WAKE`] until the next 0→1 poller
+/// transition, with a 50 ms backstop tick that only prunes dead registry
+/// entries and covers a missed notification. Runs forever; spawned once by
 /// [`ensure_refresher`].
 fn refresher_loop() -> ! {
     loop {
-        let live = refresh_all_fences();
-        ax_task::sleep(Duration::from_millis(if live { 1 } else { 50 }));
+        REFRESH_TICKS.fetch_add(1, Ordering::Relaxed);
+        if FENCE_POLLERS.load(Ordering::Acquire) > 0 {
+            refresh_all_fences();
+            ax_task::sleep(Duration::from_millis(1));
+        } else {
+            prune_dead_waiters();
+            REFRESHER_WAKE.wait_timeout_until(REFRESHER_IDLE_TICK, || {
+                FENCE_POLLERS.load(Ordering::Acquire) > 0
+            });
+        }
     }
+}
+
+/// Removes dead entries (dropped `SyncFile`s) from the registry. The IRQ path
+/// prunes on every fire; this keeps the `Vec` bounded in environments where
+/// the completion IRQ never fires and [`refresh_all_fences`] would otherwise
+/// rescan the accumulated dead `Weak`s on every service tick.
+fn prune_dead_waiters() {
+    FENCE_WAITERS.lock().retain(|(_, w)| w.strong_count() > 0);
 }
 
 /// Spawns the refresher task once. Called from [`SyncFile::register`].
@@ -330,8 +374,12 @@ impl Pollable for SyncFile {
         // by the poll_set afterwards and woken via `signal` (also task
         // context).
         unsafe { self.poll_set.register(&waker, IoEvents::IN) };
-        self.has_poller
-            .store(true, core::sync::atomic::Ordering::Release);
+        if !self.has_poller.swap(true, Ordering::AcqRel) {
+            // 0→1 transition: the refresher may be parked on the idle
+            // backstop; wake it so this first waiter is served immediately.
+            FENCE_POLLERS.fetch_add(1, Ordering::AcqRel);
+            REFRESHER_WAKE.notify_one(true);
+        }
     }
 
     fn unregister(&self, waker: &core::task::Waker) {
@@ -339,8 +387,15 @@ impl Pollable for SyncFile {
         unsafe {
             self.poll_set.unregister(waker);
         }
-        self.has_poller
-            .store(false, core::sync::atomic::Ordering::Release);
+        // Single-waker assumption: a sync_file fd is polled by one waiter at
+        // a time (the guest's libsync fence wait is a plain `poll()`). If a
+        // file were concurrently held by both a poll and a persistent epoll
+        // interest, the poll's return would clear the flag while the epoll
+        // waker stays registered — safe but conservative: the refresher would
+        // idle while that epoll waiter relies on its own per-wait re-poll.
+        if self.has_poller.swap(false, Ordering::AcqRel) {
+            FENCE_POLLERS.fetch_sub(1, Ordering::Release);
+        }
     }
 }
 

--- a/os/StarryOS/kernel/src/pseudofs/sysfs.rs
+++ b/os/StarryOS/kernel/src/pseudofs/sysfs.rs
@@ -153,6 +153,7 @@ impl SimpleDirOps for DevCharDir {
     fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
         let mut v: Vec<Cow<'a, str>> = alloc::vec![
             Cow::Owned(format!("{DRM_MAJOR}:0")),
+            Cow::Owned(format!("{DRM_MAJOR}:128")),
             Cow::Owned(format!("{FB_MAJOR}:0")),
         ];
         for i in 0..input_device_count() {
@@ -171,6 +172,7 @@ impl SimpleDirOps for DevCharDir {
             .ok_or(VfsError::NotFound)?;
         let target = match (maj, min) {
             (DRM_MAJOR, 0) => "../../devices/virtual/drm/card0".to_owned(),
+            (DRM_MAJOR, 128) => "../../devices/virtual/drm/renderD128".to_owned(),
             (FB_MAJOR, 0) => "../../devices/virtual/graphics/fb0".to_owned(),
             (INPUT_MAJOR, m)
                 if m >= EVDEV_MINOR_BASE && (m - EVDEV_MINOR_BASE) < input_device_count() =>
@@ -211,7 +213,7 @@ impl SimpleDirOps for ClassDir {
         Ok(NodeOpsMux::Dir(match name {
             "drm" => SimpleDir::new_maker(
                 fs.clone(),
-                Arc::new(ClassSubsystemDir::new(fs, "drm", &["card0"])),
+                Arc::new(ClassSubsystemDir::new(fs, "drm", &["card0", "renderD128"])),
             ),
             "graphics" => SimpleDir::new_maker(
                 fs.clone(),
@@ -845,7 +847,10 @@ impl SimpleDirOps for VirtualDir {
                 Arc::new(DeviceContainer::new(
                     fs,
                     "drm",
-                    &[("card0", (DRM_MAJOR, 0), "dri/card0")],
+                    &[
+                        ("card0", (DRM_MAJOR, 0), "dri/card0"),
+                        ("renderD128", (DRM_MAJOR, 128), "dri/renderD128"),
+                    ],
                 )),
             ),
             "graphics" => SimpleDir::new_maker(
@@ -1040,6 +1045,11 @@ impl SimpleDirOps for DeviceAttributesDir {
                     let mut buf = format!(
                         "MAJOR={major}\nMINOR={minor}\nDEVNAME={devname}\nSUBSYSTEM={subsystem}\n"
                     );
+                    // DRM devices need DRIVER= so Mesa's loader_get_driver_for_fd()
+                    // can match the device to a DRI driver for GBM.
+                    if subsystem == "drm" {
+                        buf.push_str("DRIVER=virtio_gpu\n");
+                    }
                     if subsystem == "input" && devname.starts_with("input/event") {
                         for tag in EVDEV_TAGS {
                             buf.push_str(tag);
@@ -1133,6 +1143,7 @@ impl SimpleDirOps for PlatformDeviceDir {
         let mut names: Vec<&'static str> = alloc::vec!["uevent", "subsystem"];
         if self.driver == "virtio-gpu" {
             names.extend_from_slice(&[
+                "drm",
                 "vendor",
                 "device",
                 "subsystem_vendor",
@@ -1150,7 +1161,14 @@ impl SimpleDirOps for PlatformDeviceDir {
             "uevent" => {
                 let driver = self.driver.to_owned();
                 SimpleFile::new_regular(fs, move || {
-                    Ok(format!("DRIVER={driver}\nSUBSYSTEM=platform\n"))
+                    // MODALIAS 必须有:libdrm `drmParseOFBusInfo`/`drmParseOFDeviceInfo`
+                    // (drmGetDevice2 的 platform 路径)在无 OF 数据(x86)时回退到
+                    // MODALIAS,读不到则 -ENOENT → EGL device 枚举失败 →
+                    // dri2_initialize_drm 用 fd=0 调 gbm_create_device → "failed to
+                    // create gbm device"。
+                    Ok(format!(
+                        "DRIVER={driver}\nMODALIAS=platform:{driver}\nSUBSYSTEM=platform\n"
+                    ))
                 })
                 .into()
             }
@@ -1179,6 +1197,42 @@ impl SimpleDirOps for PlatformDeviceDir {
                 // PCI class 0x030000 = display controller / VGA.
                 SimpleFile::new_regular(fs, || Ok("0x030000\n".to_owned())).into()
             }
+            // libdrm `drmNodeIsDRM` stat's `/sys/dev/char/<maj>:<min>/device/drm`
+            // to decide a node is a DRM node. Without this dir, drmGetDevice2
+            // fails with -EINVAL → EGL device enumeration empty → gbm device
+            // creation fails.
+            "drm" if self.driver == "virtio-gpu" => {
+                SimpleDir::new_maker(fs.clone(), Arc::new(PlatformDrmDir { fs: fs.clone() })).into()
+            }
+            _ => return Err(VfsError::NotFound),
+        })
+    }
+}
+
+/// `/sys/devices/platform/virtio-gpu0/drm/` — the DRM child directory of
+/// the virtio-gpu platform device, mirroring Linux's layout
+/// (`/sys/devices/.../virtio-gpu0/drm/{card0,renderD128}`). The card/render
+/// nodes are symlinks to the virtual DRM devices.
+struct PlatformDrmDir {
+    fs: Arc<SimpleFs>,
+}
+
+impl SimpleDirOps for PlatformDrmDir {
+    fn child_names<'a>(&'a self) -> Box<dyn Iterator<Item = Cow<'a, str>> + 'a> {
+        Box::new(["card0", "renderD128"].into_iter().map(Cow::Borrowed))
+    }
+
+    fn lookup_child(&self, name: &str) -> VfsResult<NodeOpsMux> {
+        let fs = self.fs.clone();
+        Ok(match name {
+            "card0" => SimpleFile::new(fs, NodeType::Symlink, || {
+                Ok("../../../virtual/drm/card0".to_owned())
+            })
+            .into(),
+            "renderD128" => SimpleFile::new(fs, NodeType::Symlink, || {
+                Ok("../../../virtual/drm/renderD128".to_owned())
+            })
+            .into(),
             _ => return Err(VfsError::NotFound),
         })
     }

--- a/os/StarryOS/kernel/src/syscall/io_mpx/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/mod.rs
@@ -21,6 +21,12 @@ impl Pollable for FdPollSet {
             file.register(context, *events);
         }
     }
+
+    fn unregister(&self, waker: &core::task::Waker) {
+        for (file, _) in &self.0 {
+            file.unregister(waker);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/os/StarryOS/kernel/src/syscall/io_mpx/poll.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/poll.rs
@@ -2,6 +2,7 @@ use alloc::vec::Vec;
 use core::{
     future::poll_fn,
     mem::{MaybeUninit, offset_of},
+    sync::atomic::{AtomicU64, Ordering},
     task::Poll,
 };
 
@@ -124,11 +125,13 @@ fn do_poll(
     let fds = FdPollSet(fds);
 
     with_blocked_signals(sigmask, || {
+        let mut did_wait = false;
         let wait = poll_fn(|cx| {
             let mut res = collect_ready_poll_events(&fds, &revent_indices, poll_fds);
             if res > 0 {
                 return Poll::Ready(Ok(res as _));
             }
+            did_wait = true;
 
             fds.register(cx, IoEvents::empty());
 
@@ -139,13 +142,46 @@ fn do_poll(
             Poll::Pending
         });
 
-        match block_on(interruptible(future::timeout(timeout, wait))) {
+        let out = match block_on(interruptible(future::timeout(timeout, wait))) {
             Ok(Ok(r)) => r,
             Ok(Err(_)) => Ok(0),
             Err(err) => Err(err.into()),
+        };
+        // [run6g] poll wake-to-return latency: the last unix-stream send that
+        // woke this poller happened at LAST_PEER_WAKE_NS; the delta to now is
+        // the wakeup+return path cost (waker -> scheduler -> re-poll -> syscall
+        // return). Only counted when this poll actually waited (registered a
+        // waker); an instantly-ready poll's delta is meaningless.
+        if did_wait && out.is_ok() {
+            let now_ns = ax_hal::time::monotonic_time_nanos() as u64;
+            let last_wake = crate::syscall::net::unix_stream_last_peer_wake_ns();
+            let lat_us = now_ns.saturating_sub(last_wake) / 1000;
+            let idx = match lat_us {
+                x if x < 100 => 0,
+                x if x < 500 => 1,
+                x if x < 1000 => 2,
+                x if x < 2000 => 3,
+                x if x < 4000 => 4,
+                _ => 5,
+            };
+            POLL_WAKE_LAT[idx].fetch_add(1, Ordering::Relaxed);
+            POLL_WAKE_LAT_CNT.fetch_add(1, Ordering::Relaxed);
         }
+        out
     })
 }
+
+/// [run6g] wake-to-return latency buckets (µs): <100, 100-500, 500-1000,
+/// 1-2ms, 2-4ms, >4ms. Read/reset by the card0 fx report.
+pub static POLL_WAKE_LAT: [AtomicU64; 6] = [
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+    AtomicU64::new(0),
+];
+pub static POLL_WAKE_LAT_CNT: AtomicU64 = AtomicU64::new(0);
 
 #[cfg(target_arch = "x86_64")]
 pub fn sys_poll(fds: UserPtr<pollfd>, nfds: u32, timeout: i32) -> StarryResult<isize> {

--- a/os/StarryOS/kernel/src/syscall/io_mpx/poll.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/poll.rs
@@ -126,6 +126,7 @@ fn do_poll(
 
     with_blocked_signals(sigmask, || {
         let mut did_wait = false;
+        let mut registered_waker: Option<core::task::Waker> = None;
         let wait = poll_fn(|cx| {
             let mut res = collect_ready_poll_events(&fds, &revent_indices, poll_fds);
             if res > 0 {
@@ -134,6 +135,7 @@ fn do_poll(
             did_wait = true;
 
             fds.register(cx, IoEvents::empty());
+            registered_waker = Some(cx.waker().clone());
 
             res = collect_ready_poll_events(&fds, &revent_indices, poll_fds);
             if res > 0 {
@@ -147,6 +149,14 @@ fn do_poll(
             Ok(Err(_)) => Ok(0),
             Err(err) => Err(err.into()),
         };
+        // Deregister this poll's wakers on return: a stale waker whose task
+        // already left the wait can consume a flip-event `wake_one`, starving
+        // the real waiter (the compositor's drm poll) until its timeout —
+        // measured ~1.3ms flip-event delivery on-screen. Linux's eventfd/poll
+        // wakes by level, so no explicit cleanup is needed there.
+        if let Some(w) = registered_waker {
+            fds.unregister(&w);
+        }
         // [run6g] poll wake-to-return latency: the last unix-stream send that
         // woke this poller happened at LAST_PEER_WAKE_NS; the delta to now is
         // the wakeup+return path cost (waker -> scheduler -> re-poll -> syscall

--- a/os/StarryOS/kernel/src/syscall/net/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/net/mod.rs
@@ -16,3 +16,9 @@ pub(crate) use self::opt::net_opt_normalization_rules_hold_for_test;
 #[cfg(test)]
 pub(crate) use self::socket::net_socket_constants_hold_for_test;
 pub use self::{cmsg::*, io::*, name::*, opt::*, socket::*};
+
+/// [run6g] monotonic ns of the last unix-stream peer wake (read by do_poll
+/// to measure wake-to-return latency).
+pub fn unix_stream_last_peer_wake_ns() -> u64 {
+    ax_net::unix::last_peer_wake_ns()
+}

--- a/os/arceos/modules/axdisplay/Cargo.toml
+++ b/os/arceos/modules/axdisplay/Cargo.toml
@@ -13,6 +13,7 @@ host-test = ["ax-task/host-test"]
 [dependencies]
 ax-task.workspace = true
 ax-lazyinit.workspace = true
+ax-hal.workspace = true
 log.workspace = true
 rdif-display.workspace = true
 irq-framework.workspace = true

--- a/os/arceos/modules/axdisplay/src/device.rs
+++ b/os/arceos/modules/axdisplay/src/device.rs
@@ -200,6 +200,18 @@ pub trait DisplayDevice: Send {
         Err(DisplayError::NotSupported)
     }
 
+    /// Block until the submit identified by `fence_id` has completed on the
+    /// host (Linux `dma_resv_wait_timeout`). Default: not supported.
+    fn wait_fence(&mut self, _fence_id: u64) -> Result<(), DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    /// Non-blocking fence query (Linux `dma_resv_test_signaled`).
+    /// Default: not supported.
+    fn fence_completed(&mut self, _fence_id: u64) -> Result<bool, DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
     fn capset_info(&mut self, _index: u32) -> Result<CapsetInfo, DisplayError> {
         Err(DisplayError::NotSupported)
     }
@@ -207,6 +219,11 @@ pub trait DisplayDevice: Send {
     fn capset(&mut self, _id: u32, _ver: u32, _size: u32) -> Result<Vec<u8>, DisplayError> {
         Err(DisplayError::NotSupported)
     }
+
+    /// Flush any pending fire-and-forget control-queue commands and notify the
+    /// host — an ioctl/transaction boundary (Linux `virtio_gpu_notify()`,
+    /// vq.c:551). Default: no-op.
+    fn ctrl_notify(&mut self) {}
 }
 
 pub struct ErasedDisplayDevice {
@@ -273,12 +290,7 @@ impl DisplayDevice for ErasedDisplayDevice {
         self.inner.set_scanout(scanout_id, resource_id, x, y, w, h)
     }
 
-    fn resource_create_2d(
-        &mut self,
-        resource_id: u32,
-        width: u32,
-        height: u32,
-    ) -> DisplayResult {
+    fn resource_create_2d(&mut self, resource_id: u32, width: u32, height: u32) -> DisplayResult {
         self.inner.resource_create_2d(resource_id, width, height)
     }
 
@@ -288,7 +300,8 @@ impl DisplayDevice for ErasedDisplayDevice {
         paddr: u64,
         length: u32,
     ) -> DisplayResult {
-        self.inner.resource_attach_backing(resource_id, paddr, length)
+        self.inner
+            .resource_attach_backing(resource_id, paddr, length)
     }
 
     fn transfer_to_host_2d(
@@ -382,7 +395,15 @@ impl DisplayDevice for ErasedDisplayDevice {
         blob_id: u64,
         cmd: &[u8],
     ) -> DisplayResult {
-        self.inner.resource_create_blob(ctx_id, resource_id, blob_mem, blob_flags, size, blob_id, cmd)
+        self.inner.resource_create_blob(
+            ctx_id,
+            resource_id,
+            blob_mem,
+            blob_flags,
+            size,
+            blob_id,
+            cmd,
+        )
     }
 
     fn transfer_to_host_3d(
@@ -431,11 +452,23 @@ impl DisplayDevice for ErasedDisplayDevice {
         self.inner.submit_cmd(ctx_id, cmds)
     }
 
+    fn wait_fence(&mut self, fence_id: u64) -> Result<(), DisplayError> {
+        self.inner.wait_fence(fence_id)
+    }
+
+    fn fence_completed(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
+        self.inner.fence_completed(fence_id)
+    }
+
     fn capset_info(&mut self, index: u32) -> Result<CapsetInfo, DisplayError> {
         self.inner.capset_info(index)
     }
 
     fn capset(&mut self, id: u32, ver: u32, size: u32) -> Result<Vec<u8>, DisplayError> {
         self.inner.capset(id, ver, size)
+    }
+
+    fn ctrl_notify(&mut self) {
+        self.inner.ctrl_notify();
     }
 }

--- a/os/arceos/modules/axdisplay/src/device.rs
+++ b/os/arceos/modules/axdisplay/src/device.rs
@@ -1,10 +1,20 @@
-use alloc::{boxed::Box, string::String};
+use alloc::{boxed::Box, string::String, vec::Vec};
 
 use irq_framework::IrqId;
 
-use crate::DisplayInfo;
+use crate::{CapsetInfo, DisplayInfo, TransferBox};
 
 pub type DisplayResult<T = ()> = Result<T, DisplayError>;
+
+/// 3D GPU error kinds mirrored from the driver layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Gpu3dErrorKind {
+    IoError,
+    Unsupported,
+    NotReady,
+    InvalidParam,
+    Other,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DisplayError {
@@ -12,10 +22,13 @@ pub enum DisplayError {
     NotAvailable,
     InvalidFramebuffer,
     BadState,
+    Gpu3dError(Gpu3dErrorKind),
 }
 
 /// Domain boundary consumed by graphics modules and device files.
 pub trait DisplayDevice: Send {
+    // --- 2D ---
+
     fn name(&self) -> &str;
 
     fn info(&self) -> DisplayInfo;
@@ -36,6 +49,163 @@ pub trait DisplayDevice: Send {
 
     fn handle_irq(&mut self) -> bool {
         false
+    }
+
+    // --- 2D resource / scanout primitives (default: unsupported) ---
+
+    fn resource_create_2d(
+        &mut self,
+        _resource_id: u32,
+        _width: u32,
+        _height: u32,
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn resource_attach_backing(
+        &mut self,
+        _resource_id: u32,
+        _paddr: u64,
+        _length: u32,
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn set_scanout(
+        &mut self,
+        _scanout_id: u32,
+        _resource_id: u32,
+        _x: u32,
+        _y: u32,
+        _w: u32,
+        _h: u32,
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn transfer_to_host_2d(
+        &mut self,
+        _resource_id: u32,
+        _x: u32,
+        _y: u32,
+        _w: u32,
+        _h: u32,
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn resource_flush(
+        &mut self,
+        _resource_id: u32,
+        _x: u32,
+        _y: u32,
+        _w: u32,
+        _h: u32,
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    // --- 3D (default: unsupported) ---
+
+    fn has_virgl(&self) -> bool {
+        false
+    }
+
+    fn has_resource_blob(&self) -> bool {
+        false
+    }
+
+    fn ctx_create(&mut self, _ctx_id: u32, _name: &str, _context_init: u32) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn ctx_destroy(&mut self, _ctx_id: u32) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn ctx_attach_resource(&mut self, _ctx_id: u32, _resource_id: u32) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn ctx_detach_resource(&mut self, _ctx_id: u32, _resource_id: u32) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn resource_create_3d(
+        &mut self,
+        _ctx_id: u32,
+        _resource_id: u32,
+        _target: u32,
+        _format: u32,
+        _bind: u32,
+        _width: u32,
+        _height: u32,
+        _depth: u32,
+        _array_size: u32,
+        _last_level: u32,
+        _nr_samples: u32,
+        _flags: u32,
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn resource_create_blob(
+        &mut self,
+        _ctx_id: u32,
+        _resource_id: u32,
+        _blob_mem: u32,
+        _blob_flags: u32,
+        _size: u64,
+        _blob_id: u64,
+        _cmd: &[u8],
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn resource_unref(&mut self, _resource_id: u32) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn transfer_to_host_3d(
+        &mut self,
+        _ctx_id: u32,
+        _resource_id: u32,
+        _box_: TransferBox,
+        _offset: u64,
+        _level: u32,
+        _stride: u32,
+        _layer_stride: u32,
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn transfer_from_host_3d(
+        &mut self,
+        _ctx_id: u32,
+        _resource_id: u32,
+        _box_: TransferBox,
+        _offset: u64,
+        _level: u32,
+        _stride: u32,
+        _layer_stride: u32,
+    ) -> DisplayResult {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn submit_cmd(&mut self, _ctx_id: u32, _cmds: &[u8]) -> Result<u64, DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn capset_info(&mut self, _index: u32) -> Result<CapsetInfo, DisplayError> {
+        Err(DisplayError::NotSupported)
+    }
+
+    fn capset(&mut self, _id: u32, _ver: u32, _size: u32) -> Result<Vec<u8>, DisplayError> {
+        Err(DisplayError::NotSupported)
     }
 }
 
@@ -89,5 +259,183 @@ impl DisplayDevice for ErasedDisplayDevice {
 
     fn handle_irq(&mut self) -> bool {
         self.inner.handle_irq()
+    }
+
+    fn set_scanout(
+        &mut self,
+        scanout_id: u32,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> DisplayResult {
+        self.inner.set_scanout(scanout_id, resource_id, x, y, w, h)
+    }
+
+    fn resource_create_2d(
+        &mut self,
+        resource_id: u32,
+        width: u32,
+        height: u32,
+    ) -> DisplayResult {
+        self.inner.resource_create_2d(resource_id, width, height)
+    }
+
+    fn resource_attach_backing(
+        &mut self,
+        resource_id: u32,
+        paddr: u64,
+        length: u32,
+    ) -> DisplayResult {
+        self.inner.resource_attach_backing(resource_id, paddr, length)
+    }
+
+    fn transfer_to_host_2d(
+        &mut self,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> DisplayResult {
+        self.inner.transfer_to_host_2d(resource_id, x, y, w, h)
+    }
+
+    fn resource_flush(
+        &mut self,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> DisplayResult {
+        self.inner.resource_flush(resource_id, x, y, w, h)
+    }
+
+    fn has_virgl(&self) -> bool {
+        self.inner.has_virgl()
+    }
+
+    fn has_resource_blob(&self) -> bool {
+        self.inner.has_resource_blob()
+    }
+
+    fn ctx_create(&mut self, ctx_id: u32, name: &str, context_init: u32) -> DisplayResult {
+        self.inner.ctx_create(ctx_id, name, context_init)
+    }
+
+    fn ctx_destroy(&mut self, ctx_id: u32) -> DisplayResult {
+        self.inner.ctx_destroy(ctx_id)
+    }
+
+    fn ctx_attach_resource(&mut self, ctx_id: u32, resource_id: u32) -> DisplayResult {
+        self.inner.ctx_attach_resource(ctx_id, resource_id)
+    }
+
+    fn ctx_detach_resource(&mut self, ctx_id: u32, resource_id: u32) -> DisplayResult {
+        self.inner.ctx_detach_resource(ctx_id, resource_id)
+    }
+
+    fn resource_create_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        target: u32,
+        format: u32,
+        bind: u32,
+        width: u32,
+        height: u32,
+        depth: u32,
+        array_size: u32,
+        last_level: u32,
+        nr_samples: u32,
+        flags: u32,
+    ) -> DisplayResult {
+        self.inner.resource_create_3d(
+            ctx_id,
+            resource_id,
+            target,
+            format,
+            bind,
+            width,
+            height,
+            depth,
+            array_size,
+            last_level,
+            nr_samples,
+            flags,
+        )
+    }
+
+    fn resource_unref(&mut self, resource_id: u32) -> DisplayResult {
+        self.inner.resource_unref(resource_id)
+    }
+
+    fn resource_create_blob(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        blob_mem: u32,
+        blob_flags: u32,
+        size: u64,
+        blob_id: u64,
+        cmd: &[u8],
+    ) -> DisplayResult {
+        self.inner.resource_create_blob(ctx_id, resource_id, blob_mem, blob_flags, size, blob_id, cmd)
+    }
+
+    fn transfer_to_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: TransferBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> DisplayResult {
+        self.inner.transfer_to_host_3d(
+            ctx_id,
+            resource_id,
+            box_,
+            offset,
+            level,
+            stride,
+            layer_stride,
+        )
+    }
+
+    fn transfer_from_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: TransferBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> DisplayResult {
+        self.inner.transfer_from_host_3d(
+            ctx_id,
+            resource_id,
+            box_,
+            offset,
+            level,
+            stride,
+            layer_stride,
+        )
+    }
+
+    fn submit_cmd(&mut self, ctx_id: u32, cmds: &[u8]) -> Result<u64, DisplayError> {
+        self.inner.submit_cmd(ctx_id, cmds)
+    }
+
+    fn capset_info(&mut self, index: u32) -> Result<CapsetInfo, DisplayError> {
+        self.inner.capset_info(index)
+    }
+
+    fn capset(&mut self, id: u32, ver: u32, size: u32) -> Result<Vec<u8>, DisplayError> {
+        self.inner.capset(id, ver, size)
     }
 }

--- a/os/arceos/modules/axdisplay/src/device.rs
+++ b/os/arceos/modules/axdisplay/src/device.rs
@@ -206,10 +206,24 @@ pub trait DisplayDevice: Send {
         Err(DisplayError::NotSupported)
     }
 
+    /// Drain the completion queue without blocking (see the rdif contract).
+    fn pump(&mut self) -> Result<(), DisplayError> {
+        Ok(())
+    }
+
     /// Non-blocking fence query (Linux `dma_resv_test_signaled`).
     /// Default: not supported.
     fn fence_completed(&mut self, _fence_id: u64) -> Result<bool, DisplayError> {
         Err(DisplayError::NotSupported)
+    }
+
+    /// Completion-level-only fence query without draining the used ring.
+    /// Intended for IRQ handlers whose pump has already advanced the
+    /// completion level (re-pumping per registered fence doubles the per-IRQ
+    /// cost). Default: pumping variant, which stays correct without an IRQ
+    /// path.
+    fn fence_completed_no_pump(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
+        self.fence_completed(fence_id)
     }
 
     fn capset_info(&mut self, _index: u32) -> Result<CapsetInfo, DisplayError> {
@@ -456,8 +470,16 @@ impl DisplayDevice for ErasedDisplayDevice {
         self.inner.wait_fence(fence_id)
     }
 
+    fn pump(&mut self) -> Result<(), DisplayError> {
+        self.inner.pump()
+    }
+
     fn fence_completed(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
         self.inner.fence_completed(fence_id)
+    }
+
+    fn fence_completed_no_pump(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
+        self.inner.fence_completed_no_pump(fence_id)
     }
 
     fn capset_info(&mut self, index: u32) -> Result<CapsetInfo, DisplayError> {

--- a/os/arceos/modules/axdisplay/src/lib.rs
+++ b/os/arceos/modules/axdisplay/src/lib.rs
@@ -12,8 +12,8 @@ mod types;
 
 use ax_lazyinit::LazyInit;
 use ax_task::sync::SpinLock as Mutex;
-pub use device::{DisplayDevice, DisplayError, DisplayResult, ErasedDisplayDevice};
-pub use types::{DisplayInfo, PixelFormat};
+pub use device::{DisplayDevice, DisplayError, DisplayResult, ErasedDisplayDevice, Gpu3dErrorKind};
+pub use types::{CapsetInfo, DisplayInfo, PixelFormat, TransferBox};
 
 static MAIN_DISPLAY: LazyInit<Mutex<ErasedDisplayDevice>> = LazyInit::new();
 
@@ -63,4 +63,196 @@ pub fn framebuffer_disable_irq() {
 pub fn framebuffer_handle_irq() -> bool {
     let mut display = MAIN_DISPLAY.lock_irqsave();
     display.is_irq_enabled() && display.handle_irq()
+}
+
+// --- 3D API ---
+
+/// Checks if the display device supports virgl 3D.
+pub fn has_virgl() -> bool {
+    MAIN_DISPLAY.lock().has_virgl()
+}
+
+/// Checks if `VIRTIO_GPU_F_RESOURCE_BLOB` was negotiated (blob resources /
+/// dma-buf sharing).
+pub fn has_resource_blob() -> bool {
+    MAIN_DISPLAY.lock().has_resource_blob()
+}
+
+/// Create a 3D rendering context.
+pub fn gpu3d_ctx_create(ctx_id: u32, name: &str, context_init: u32) -> DisplayResult {
+    MAIN_DISPLAY.lock().ctx_create(ctx_id, name, context_init)
+}
+
+/// Destroy a 3D rendering context.
+pub fn gpu3d_ctx_destroy(ctx_id: u32) -> DisplayResult {
+    MAIN_DISPLAY.lock().ctx_destroy(ctx_id)
+}
+
+/// Attach a 3D resource to a rendering context.
+pub fn gpu3d_ctx_attach_resource(ctx_id: u32, resource_id: u32) -> DisplayResult {
+    MAIN_DISPLAY.lock().ctx_attach_resource(ctx_id, resource_id)
+}
+
+/// Detach a 3D resource from a rendering context.
+pub fn gpu3d_ctx_detach_resource(ctx_id: u32, resource_id: u32) -> DisplayResult {
+    MAIN_DISPLAY.lock().ctx_detach_resource(ctx_id, resource_id)
+}
+
+// --- 2D resource / scanout forwarding ---
+
+/// Create a 2D resource on the host (for dumb buffer backing).
+pub fn gpu3d_resource_create_2d(
+    resource_id: u32,
+    width: u32,
+    height: u32,
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().resource_create_2d(resource_id, width, height)
+}
+
+/// Attach guest memory backing to a resource.
+pub fn gpu3d_attach_backing(
+    resource_id: u32,
+    paddr: u64,
+    length: u32,
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().resource_attach_backing(resource_id, paddr, length)
+}
+
+/// Bind a resource as the display output (scanout) for a given scanout ID.
+///
+/// Maps to `VIRTIO_GPU_CMD_SET_SCANOUT`. For zero-copy display: after
+/// rendering into a resource, call this to bind it as the scanout.
+pub fn gpu3d_set_scanout(
+    scanout_id: u32,
+    resource_id: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().set_scanout(scanout_id, resource_id, x, y, w, h)
+}
+
+/// Transfer a rectangular region of a 2D resource from guest to host.
+///
+/// Maps to `VIRTIO_GPU_CMD_TRANSFER_TO_HOST_2D`. Makes the host aware
+/// of guest-written pixel data before a [`gpu3d_resource_flush`].
+pub fn gpu3d_transfer_to_host_2d(
+    resource_id: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().transfer_to_host_2d(resource_id, x, y, w, h)
+}
+
+/// Flush a resource's contents to the display.
+///
+/// Maps to `VIRTIO_GPU_CMD_RESOURCE_FLUSH`. After rendering and
+/// optionally binding with [`gpu3d_set_scanout`], call this to make
+/// the host display the contents.
+pub fn gpu3d_resource_flush(
+    resource_id: u32,
+    x: u32,
+    y: u32,
+    w: u32,
+    h: u32,
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().resource_flush(resource_id, x, y, w, h)
+}
+
+/// Create a 3D resource.
+///
+/// The caller must explicitly call [`gpu3d_ctx_attach_resource`] after creation
+/// before using the resource in rendering commands.
+pub fn gpu3d_resource_create(
+    ctx_id: u32,
+    resource_id: u32,
+    target: u32,
+    format: u32,
+    bind: u32,
+    width: u32,
+    height: u32,
+    depth: u32,
+    array_size: u32,
+    last_level: u32,
+    nr_samples: u32,
+    flags: u32,
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().resource_create_3d(
+        ctx_id, resource_id, target, format, bind,
+        width, height, depth, array_size, last_level,
+        nr_samples, flags,
+    )
+}
+
+/// Unreference a 3D resource.
+pub fn gpu3d_resource_unref(resource_id: u32) -> DisplayResult {
+    MAIN_DISPLAY.lock().resource_unref(resource_id)
+}
+
+/// Create a blob resource (host-visible memory / dma-buf sharing).
+///
+/// `blob_mem` is `VIRTIO_GPU_BLOB_MEM_*`, `blob_flags` is the
+/// `VIRTIO_GPU_BLOB_FLAG_*` set. `cmd` is the optional virgl command stream
+/// for the blob's initial state (submitted before RESOURCE_CREATE_BLOB,
+/// matching Linux ordering).
+pub fn gpu3d_resource_create_blob(
+    ctx_id: u32,
+    resource_id: u32,
+    blob_mem: u32,
+    blob_flags: u32,
+    size: u64,
+    blob_id: u64,
+    cmd: &[u8],
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().resource_create_blob(
+        ctx_id, resource_id, blob_mem, blob_flags, size, blob_id, cmd,
+    )
+}
+
+/// Transfer data from guest to host for a 3D resource.
+pub fn gpu3d_transfer_to_host(
+    ctx_id: u32,
+    resource_id: u32,
+    box_: TransferBox,
+    offset: u64,
+    level: u32,
+    stride: u32,
+    layer_stride: u32,
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().transfer_to_host_3d(
+        ctx_id, resource_id, box_, offset, level, stride, layer_stride,
+    )
+}
+
+/// Transfer data from host to guest for a 3D resource.
+pub fn gpu3d_transfer_from_host(
+    ctx_id: u32,
+    resource_id: u32,
+    box_: TransferBox,
+    offset: u64,
+    level: u32,
+    stride: u32,
+    layer_stride: u32,
+) -> DisplayResult {
+    MAIN_DISPLAY.lock().transfer_from_host_3d(
+        ctx_id, resource_id, box_, offset, level, stride, layer_stride,
+    )
+}
+
+/// Submit a virgl command buffer. Returns a monotonically increasing fence ID.
+pub fn gpu3d_submit_cmd(ctx_id: u32, cmds: &[u8]) -> Result<u64, DisplayError> {
+    MAIN_DISPLAY.lock().submit_cmd(ctx_id, cmds)
+}
+
+/// Query capset information by index.
+pub fn gpu3d_capset_info(index: u32) -> Result<CapsetInfo, DisplayError> {
+    MAIN_DISPLAY.lock().capset_info(index)
+}
+
+/// Retrieve capset data.
+pub fn gpu3d_capset(id: u32, ver: u32, size: u32) -> Result<alloc::vec::Vec<u8>, DisplayError> {
+    MAIN_DISPLAY.lock().capset(id, ver, size)
 }

--- a/os/arceos/modules/axdisplay/src/lib.rs
+++ b/os/arceos/modules/axdisplay/src/lib.rs
@@ -10,12 +10,58 @@ mod device;
 pub mod rdif;
 mod types;
 
+use core::sync::atomic::{AtomicU64, Ordering};
+
 use ax_lazyinit::LazyInit;
-use ax_task::sync::SpinLock as Mutex;
+use ax_task::sync::{SpinLock as Mutex, SpinLockGuard};
 pub use device::{DisplayDevice, DisplayError, DisplayResult, ErasedDisplayDevice, Gpu3dErrorKind};
 pub use types::{CapsetInfo, DisplayInfo, PixelFormat, TransferBox};
 
 static MAIN_DISPLAY: LazyInit<Mutex<ErasedDisplayDevice>> = LazyInit::new();
+
+// ---- lock-wait instrumentation (2026-08-27: quantify MAIN_DISPLAY spin
+// contention on the multi-vCPU display path). Every `gpu3d_*` entry acquires
+// the same global spin lock; the wait time here is the cross-vCPU serialization
+// cost (Linux holds no device lock while waiting for host completion, so this
+// number should be ~0 there). Consumed by the card0 perf report. ----
+static LOCK_WAIT_NS: AtomicU64 = AtomicU64::new(0);
+static LOCK_WAIT_CNT: AtomicU64 = AtomicU64::new(0);
+static LOCK_WAIT_MAX_NS: AtomicU64 = AtomicU64::new(0);
+
+#[inline]
+fn lock_display() -> SpinLockGuard<'static, ErasedDisplayDevice> {
+    let t0 = ax_hal::time::monotonic_time_nanos();
+    let guard = MAIN_DISPLAY.lock();
+    let dt = ax_hal::time::monotonic_time_nanos().saturating_sub(t0);
+    LOCK_WAIT_NS.fetch_add(dt, Ordering::Relaxed);
+    LOCK_WAIT_CNT.fetch_add(1, Ordering::Relaxed);
+    let mut max = LOCK_WAIT_MAX_NS.load(Ordering::Relaxed);
+    while dt > max {
+        match LOCK_WAIT_MAX_NS.compare_exchange_weak(max, dt, Ordering::Relaxed, Ordering::Relaxed)
+        {
+            Ok(_) => break,
+            Err(actual) => max = actual,
+        }
+    }
+    guard
+}
+
+/// Lock-wait statistics since the last reset: (count, total_ns, max_ns).
+/// Counts every `gpu3d_*` entry's spin before the global display lock.
+pub fn gpu3d_lock_wait_stats() -> (u64, u64, u64) {
+    (
+        LOCK_WAIT_CNT.load(Ordering::Relaxed),
+        LOCK_WAIT_NS.load(Ordering::Relaxed),
+        LOCK_WAIT_MAX_NS.load(Ordering::Relaxed),
+    )
+}
+
+/// Reset the lock-wait statistics (called at each card0 perf-report window).
+pub fn gpu3d_lock_wait_reset() {
+    LOCK_WAIT_CNT.store(0, Ordering::Relaxed);
+    LOCK_WAIT_NS.store(0, Ordering::Relaxed);
+    LOCK_WAIT_MAX_NS.store(0, Ordering::Relaxed);
+}
 
 /// Initializes the display subsystem by underlayer devices.
 pub fn init_display(display_devs: impl IntoIterator<Item = ErasedDisplayDevice>) {
@@ -69,53 +115,45 @@ pub fn framebuffer_handle_irq() -> bool {
 
 /// Checks if the display device supports virgl 3D.
 pub fn has_virgl() -> bool {
-    MAIN_DISPLAY.lock().has_virgl()
+    lock_display().has_virgl()
 }
 
 /// Checks if `VIRTIO_GPU_F_RESOURCE_BLOB` was negotiated (blob resources /
 /// dma-buf sharing).
 pub fn has_resource_blob() -> bool {
-    MAIN_DISPLAY.lock().has_resource_blob()
+    lock_display().has_resource_blob()
 }
 
 /// Create a 3D rendering context.
 pub fn gpu3d_ctx_create(ctx_id: u32, name: &str, context_init: u32) -> DisplayResult {
-    MAIN_DISPLAY.lock().ctx_create(ctx_id, name, context_init)
+    lock_display().ctx_create(ctx_id, name, context_init)
 }
 
 /// Destroy a 3D rendering context.
 pub fn gpu3d_ctx_destroy(ctx_id: u32) -> DisplayResult {
-    MAIN_DISPLAY.lock().ctx_destroy(ctx_id)
+    lock_display().ctx_destroy(ctx_id)
 }
 
 /// Attach a 3D resource to a rendering context.
 pub fn gpu3d_ctx_attach_resource(ctx_id: u32, resource_id: u32) -> DisplayResult {
-    MAIN_DISPLAY.lock().ctx_attach_resource(ctx_id, resource_id)
+    lock_display().ctx_attach_resource(ctx_id, resource_id)
 }
 
 /// Detach a 3D resource from a rendering context.
 pub fn gpu3d_ctx_detach_resource(ctx_id: u32, resource_id: u32) -> DisplayResult {
-    MAIN_DISPLAY.lock().ctx_detach_resource(ctx_id, resource_id)
+    lock_display().ctx_detach_resource(ctx_id, resource_id)
 }
 
 // --- 2D resource / scanout forwarding ---
 
 /// Create a 2D resource on the host (for dumb buffer backing).
-pub fn gpu3d_resource_create_2d(
-    resource_id: u32,
-    width: u32,
-    height: u32,
-) -> DisplayResult {
-    MAIN_DISPLAY.lock().resource_create_2d(resource_id, width, height)
+pub fn gpu3d_resource_create_2d(resource_id: u32, width: u32, height: u32) -> DisplayResult {
+    lock_display().resource_create_2d(resource_id, width, height)
 }
 
 /// Attach guest memory backing to a resource.
-pub fn gpu3d_attach_backing(
-    resource_id: u32,
-    paddr: u64,
-    length: u32,
-) -> DisplayResult {
-    MAIN_DISPLAY.lock().resource_attach_backing(resource_id, paddr, length)
+pub fn gpu3d_attach_backing(resource_id: u32, paddr: u64, length: u32) -> DisplayResult {
+    lock_display().resource_attach_backing(resource_id, paddr, length)
 }
 
 /// Bind a resource as the display output (scanout) for a given scanout ID.
@@ -130,7 +168,7 @@ pub fn gpu3d_set_scanout(
     w: u32,
     h: u32,
 ) -> DisplayResult {
-    MAIN_DISPLAY.lock().set_scanout(scanout_id, resource_id, x, y, w, h)
+    lock_display().set_scanout(scanout_id, resource_id, x, y, w, h)
 }
 
 /// Transfer a rectangular region of a 2D resource from guest to host.
@@ -144,7 +182,7 @@ pub fn gpu3d_transfer_to_host_2d(
     w: u32,
     h: u32,
 ) -> DisplayResult {
-    MAIN_DISPLAY.lock().transfer_to_host_2d(resource_id, x, y, w, h)
+    lock_display().transfer_to_host_2d(resource_id, x, y, w, h)
 }
 
 /// Flush a resource's contents to the display.
@@ -152,20 +190,15 @@ pub fn gpu3d_transfer_to_host_2d(
 /// Maps to `VIRTIO_GPU_CMD_RESOURCE_FLUSH`. After rendering and
 /// optionally binding with [`gpu3d_set_scanout`], call this to make
 /// the host display the contents.
-pub fn gpu3d_resource_flush(
-    resource_id: u32,
-    x: u32,
-    y: u32,
-    w: u32,
-    h: u32,
-) -> DisplayResult {
-    MAIN_DISPLAY.lock().resource_flush(resource_id, x, y, w, h)
+pub fn gpu3d_resource_flush(resource_id: u32, x: u32, y: u32, w: u32, h: u32) -> DisplayResult {
+    lock_display().resource_flush(resource_id, x, y, w, h)
 }
 
 /// Create a 3D resource.
 ///
 /// The caller must explicitly call [`gpu3d_ctx_attach_resource`] after creation
 /// before using the resource in rendering commands.
+#[allow(clippy::too_many_arguments)] // RDIF/DRM wire signature, fixed by the protocol
 pub fn gpu3d_resource_create(
     ctx_id: u32,
     resource_id: u32,
@@ -180,16 +213,25 @@ pub fn gpu3d_resource_create(
     nr_samples: u32,
     flags: u32,
 ) -> DisplayResult {
-    MAIN_DISPLAY.lock().resource_create_3d(
-        ctx_id, resource_id, target, format, bind,
-        width, height, depth, array_size, last_level,
-        nr_samples, flags,
+    lock_display().resource_create_3d(
+        ctx_id,
+        resource_id,
+        target,
+        format,
+        bind,
+        width,
+        height,
+        depth,
+        array_size,
+        last_level,
+        nr_samples,
+        flags,
     )
 }
 
 /// Unreference a 3D resource.
 pub fn gpu3d_resource_unref(resource_id: u32) -> DisplayResult {
-    MAIN_DISPLAY.lock().resource_unref(resource_id)
+    lock_display().resource_unref(resource_id)
 }
 
 /// Create a blob resource (host-visible memory / dma-buf sharing).
@@ -207,8 +249,14 @@ pub fn gpu3d_resource_create_blob(
     blob_id: u64,
     cmd: &[u8],
 ) -> DisplayResult {
-    MAIN_DISPLAY.lock().resource_create_blob(
-        ctx_id, resource_id, blob_mem, blob_flags, size, blob_id, cmd,
+    lock_display().resource_create_blob(
+        ctx_id,
+        resource_id,
+        blob_mem,
+        blob_flags,
+        size,
+        blob_id,
+        cmd,
     )
 }
 
@@ -222,8 +270,14 @@ pub fn gpu3d_transfer_to_host(
     stride: u32,
     layer_stride: u32,
 ) -> DisplayResult {
-    MAIN_DISPLAY.lock().transfer_to_host_3d(
-        ctx_id, resource_id, box_, offset, level, stride, layer_stride,
+    lock_display().transfer_to_host_3d(
+        ctx_id,
+        resource_id,
+        box_,
+        offset,
+        level,
+        stride,
+        layer_stride,
     )
 }
 
@@ -237,22 +291,56 @@ pub fn gpu3d_transfer_from_host(
     stride: u32,
     layer_stride: u32,
 ) -> DisplayResult {
-    MAIN_DISPLAY.lock().transfer_from_host_3d(
-        ctx_id, resource_id, box_, offset, level, stride, layer_stride,
+    lock_display().transfer_from_host_3d(
+        ctx_id,
+        resource_id,
+        box_,
+        offset,
+        level,
+        stride,
+        layer_stride,
     )
 }
 
 /// Submit a virgl command buffer. Returns a monotonically increasing fence ID.
 pub fn gpu3d_submit_cmd(ctx_id: u32, cmds: &[u8]) -> Result<u64, DisplayError> {
-    MAIN_DISPLAY.lock().submit_cmd(ctx_id, cmds)
+    lock_display().submit_cmd(ctx_id, cmds)
+}
+
+/// Block until the submit identified by `fence_id` has completed on the host —
+/// the honest completion signal behind VIRTGPU_WAIT (Linux
+/// `virtio_gpu_wait_ioctl` → `dma_resv_wait_timeout`).
+pub fn gpu3d_wait_fence(fence_id: u64) -> Result<(), DisplayError> {
+    lock_display().wait_fence(fence_id)
+}
+
+/// Non-blocking fence query — Linux `dma_resv_test_signaled` (the NOWAIT probe
+/// in `virtio_gpu_wait_ioctl`). `false` means the host is still busy with the
+/// batch.
+pub fn gpu3d_fence_completed(fence_id: u64) -> Result<bool, DisplayError> {
+    lock_display().fence_completed(fence_id)
 }
 
 /// Query capset information by index.
 pub fn gpu3d_capset_info(index: u32) -> Result<CapsetInfo, DisplayError> {
-    MAIN_DISPLAY.lock().capset_info(index)
+    lock_display().capset_info(index)
 }
 
 /// Retrieve capset data.
 pub fn gpu3d_capset(id: u32, ver: u32, size: u32) -> Result<alloc::vec::Vec<u8>, DisplayError> {
-    MAIN_DISPLAY.lock().capset(id, ver, size)
+    lock_display().capset(id, ver, size)
+}
+
+/// Flush any pending fire-and-forget control-queue commands and notify the
+/// host — an ioctl/transaction boundary (Linux `virtio_gpu_notify()`, vq.c:551).
+///
+/// Call exactly once at the end of an ioctl that enqueued commands whose
+/// response the caller does not wait for, so the whole batch is delivered to
+/// the host with a single kick. No-op when nothing is pending and when no
+/// display device is initialized (no commands could have been enqueued).
+pub fn gpu3d_ctrl_notify() {
+    if !MAIN_DISPLAY.is_inited() {
+        return;
+    }
+    lock_display().ctrl_notify();
 }

--- a/os/arceos/modules/axdisplay/src/lib.rs
+++ b/os/arceos/modules/axdisplay/src/lib.rs
@@ -13,7 +13,7 @@ mod types;
 use core::sync::atomic::{AtomicU64, Ordering};
 
 use ax_lazyinit::LazyInit;
-use ax_task::sync::{SpinLock as Mutex, SpinLockGuard};
+use ax_task::sync::{SpinLock as Mutex, SpinLockIrqSaveGuard};
 pub use device::{DisplayDevice, DisplayError, DisplayResult, ErasedDisplayDevice, Gpu3dErrorKind};
 pub use types::{CapsetInfo, DisplayInfo, PixelFormat, TransferBox};
 
@@ -29,9 +29,14 @@ static LOCK_WAIT_CNT: AtomicU64 = AtomicU64::new(0);
 static LOCK_WAIT_MAX_NS: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
-fn lock_display() -> SpinLockGuard<'static, ErasedDisplayDevice> {
+fn lock_display() -> SpinLockIrqSaveGuard<'static, ErasedDisplayDevice> {
     let t0 = ax_hal::time::monotonic_time_nanos();
-    let guard = MAIN_DISPLAY.lock();
+    // `lock_irqsave` (not `lock`): every 3D entry may be interrupted by the
+    // device completion IRQ, whose handler (`framebuffer_handle_irq`,
+    // `refresh_fence_waiters_from_irq`) takes this same lock. On smp=1 a task
+    // holding it with IRQs enabled deadlocks: the IRQ fires, the handler
+    // spins on the lock, and the interrupted task can never release it.
+    let guard = MAIN_DISPLAY.lock_irqsave();
     let dt = ax_hal::time::monotonic_time_nanos().saturating_sub(t0);
     LOCK_WAIT_NS.fetch_add(dt, Ordering::Relaxed);
     LOCK_WAIT_CNT.fetch_add(1, Ordering::Relaxed);
@@ -319,6 +324,20 @@ pub fn gpu3d_wait_fence(fence_id: u64) -> Result<(), DisplayError> {
 /// batch.
 pub fn gpu3d_fence_completed(fence_id: u64) -> Result<bool, DisplayError> {
     lock_display().fence_completed(fence_id)
+}
+
+/// Drain the host completion queue without blocking. Call after fire-and-forget
+/// submits so the next completion triggers the device IRQ promptly (Linux's
+/// virtio-gpu pumps in its completion worker after every IRQ, keeping
+/// fence-signal latency at µs instead of up to a frame).
+pub fn gpu3d_pump() -> Result<(), DisplayError> {
+    lock_display().pump()
+}
+
+/// Completion-level-only fence query without draining the used ring. Intended
+/// for IRQ handlers whose pump has already advanced the completion level.
+pub fn gpu3d_fence_completed_no_pump(fence_id: u64) -> Result<bool, DisplayError> {
+    lock_display().fence_completed_no_pump(fence_id)
 }
 
 /// Query capset information by index.

--- a/os/arceos/modules/axdisplay/src/rdif.rs
+++ b/os/arceos/modules/axdisplay/src/rdif.rs
@@ -1,10 +1,14 @@
-use alloc::{boxed::Box, string::String};
+use alloc::{boxed::Box, string::String, vec::Vec};
 use core::ptr::NonNull;
 
 use irq_framework::IrqId;
-use rdif_display::{DisplayError as RdifDisplayError, Interface};
+use rdif_display::{
+    DisplayError as RdifDisplayError, Gpu3dErrorKind as RdifGpu3dErrorKind, Interface,
+};
 
-use crate::{DisplayDevice, DisplayError, DisplayInfo, PixelFormat};
+use crate::{
+    CapsetInfo, DisplayDevice, DisplayError, DisplayInfo, Gpu3dErrorKind, PixelFormat, TransferBox,
+};
 
 pub struct RdifDisplayDevice {
     name: String,
@@ -86,6 +90,221 @@ impl DisplayDevice for RdifDisplayDevice {
     fn handle_irq(&mut self) -> bool {
         self.device.handle_irq().handled
     }
+
+    // --- 2D resource / scanout forwarding ---
+
+    fn resource_create_2d(
+        &mut self,
+        resource_id: u32,
+        width: u32,
+        height: u32,
+    ) -> crate::DisplayResult {
+        self.device
+            .resource_create_2d(resource_id, width, height)
+            .map_err(map_display_error)
+    }
+
+    fn resource_attach_backing(
+        &mut self,
+        resource_id: u32,
+        paddr: u64,
+        length: u32,
+    ) -> crate::DisplayResult {
+        self.device
+            .resource_attach_backing(resource_id, paddr, length)
+            .map_err(map_display_error)
+    }
+
+    fn set_scanout(
+        &mut self,
+        scanout_id: u32,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> crate::DisplayResult {
+        self.device
+            .set_scanout(scanout_id, resource_id, x, y, w, h)
+            .map_err(map_display_error)
+    }
+
+    fn transfer_to_host_2d(
+        &mut self,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> crate::DisplayResult {
+        self.device
+            .transfer_to_host_2d(resource_id, x, y, w, h)
+            .map_err(map_display_error)
+    }
+
+    fn resource_flush(
+        &mut self,
+        resource_id: u32,
+        x: u32,
+        y: u32,
+        w: u32,
+        h: u32,
+    ) -> crate::DisplayResult {
+        self.device
+            .resource_flush(resource_id, x, y, w, h)
+            .map_err(map_display_error)
+    }
+
+    // --- 3D forwarding ---
+
+    fn has_virgl(&self) -> bool {
+        self.device.has_virgl()
+    }
+
+    fn has_resource_blob(&self) -> bool {
+        self.device.has_resource_blob()
+    }
+
+    fn ctx_create(&mut self, ctx_id: u32, name: &str, context_init: u32) -> crate::DisplayResult {
+        self.device
+            .ctx_create(ctx_id, name, context_init)
+            .map_err(map_display_error)
+    }
+
+    fn ctx_destroy(&mut self, ctx_id: u32) -> crate::DisplayResult {
+        self.device.ctx_destroy(ctx_id).map_err(map_display_error)
+    }
+
+    fn ctx_attach_resource(&mut self, ctx_id: u32, resource_id: u32) -> crate::DisplayResult {
+        self.device
+            .ctx_attach_resource(ctx_id, resource_id)
+            .map_err(map_display_error)
+    }
+
+    fn ctx_detach_resource(&mut self, ctx_id: u32, resource_id: u32) -> crate::DisplayResult {
+        self.device
+            .ctx_detach_resource(ctx_id, resource_id)
+            .map_err(map_display_error)
+    }
+
+    fn resource_create_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        target: u32,
+        format: u32,
+        bind: u32,
+        width: u32,
+        height: u32,
+        depth: u32,
+        array_size: u32,
+        last_level: u32,
+        nr_samples: u32,
+        flags: u32,
+    ) -> crate::DisplayResult {
+        self.device
+            .resource_create_3d(
+                ctx_id,
+                resource_id,
+                target,
+                format,
+                bind,
+                width,
+                height,
+                depth,
+                array_size,
+                last_level,
+                nr_samples,
+                flags,
+            )
+            .map_err(map_display_error)
+    }
+
+    fn resource_unref(&mut self, resource_id: u32) -> crate::DisplayResult {
+        self.device
+            .resource_unref(resource_id)
+            .map_err(map_display_error)
+    }
+
+    fn resource_create_blob(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        blob_mem: u32,
+        blob_flags: u32,
+        size: u64,
+        blob_id: u64,
+        cmd: &[u8],
+    ) -> crate::DisplayResult {
+        self.device
+            .resource_create_blob(ctx_id, resource_id, blob_mem, blob_flags, size, blob_id, cmd)
+            .map_err(map_display_error)
+    }
+
+    fn transfer_to_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: TransferBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> crate::DisplayResult {
+        self.device
+            .transfer_to_host_3d(
+                ctx_id,
+                resource_id,
+                box_.into(),
+                offset,
+                level,
+                stride,
+                layer_stride,
+            )
+            .map_err(map_display_error)
+    }
+
+    fn transfer_from_host_3d(
+        &mut self,
+        ctx_id: u32,
+        resource_id: u32,
+        box_: TransferBox,
+        offset: u64,
+        level: u32,
+        stride: u32,
+        layer_stride: u32,
+    ) -> crate::DisplayResult {
+        self.device
+            .transfer_from_host_3d(
+                ctx_id,
+                resource_id,
+                box_.into(),
+                offset,
+                level,
+                stride,
+                layer_stride,
+            )
+            .map_err(map_display_error)
+    }
+
+    fn submit_cmd(&mut self, ctx_id: u32, cmds: &[u8]) -> Result<u64, DisplayError> {
+        self.device
+            .submit_cmd(ctx_id, cmds)
+            .map_err(map_display_error)
+    }
+
+    fn capset_info(&mut self, index: u32) -> Result<CapsetInfo, DisplayError> {
+        self.device
+            .get_capset_info(index)
+            .map(|info| info.into())
+            .map_err(map_display_error)
+    }
+
+    fn capset(&mut self, id: u32, ver: u32, size: u32) -> Result<Vec<u8>, DisplayError> {
+        self.device
+            .get_capset(id, ver, size)
+            .map_err(map_display_error)
+    }
 }
 
 impl From<rdif_display::PixelFormat> for PixelFormat {
@@ -106,7 +325,43 @@ fn map_display_error(error: RdifDisplayError) -> DisplayError {
         RdifDisplayError::NotSupported => DisplayError::NotSupported,
         RdifDisplayError::NotAvailable => DisplayError::NotAvailable,
         RdifDisplayError::InvalidFramebuffer => DisplayError::InvalidFramebuffer,
-        RdifDisplayError::Other(_) => DisplayError::BadState,
+        RdifDisplayError::Gpu3dError(kind) => {
+            let mapped = match kind {
+                RdifGpu3dErrorKind::IoError => Gpu3dErrorKind::IoError,
+                RdifGpu3dErrorKind::Unsupported => Gpu3dErrorKind::Unsupported,
+                RdifGpu3dErrorKind::NotReady => Gpu3dErrorKind::NotReady,
+                RdifGpu3dErrorKind::InvalidParam => Gpu3dErrorKind::InvalidParam,
+                RdifGpu3dErrorKind::Other => Gpu3dErrorKind::Other,
+            };
+            DisplayError::Gpu3dError(mapped)
+        }
+        RdifDisplayError::Other(err) => {
+            log::warn!("[axdisplay] rdif error collapsed to BadState: {err}");
+            DisplayError::BadState
+        }
+    }
+}
+
+impl From<TransferBox> for rdif_display::TransferBox {
+    fn from(b: TransferBox) -> Self {
+        Self {
+            x: b.x,
+            y: b.y,
+            z: b.z,
+            w: b.w,
+            h: b.h,
+            d: b.d,
+        }
+    }
+}
+
+impl From<rdif_display::CapsetInfo> for CapsetInfo {
+    fn from(c: rdif_display::CapsetInfo) -> Self {
+        Self {
+            capset_id: c.capset_id,
+            max_version: c.max_version,
+            max_size: c.max_size,
+        }
     }
 }
 

--- a/os/arceos/modules/axdisplay/src/rdif.rs
+++ b/os/arceos/modules/axdisplay/src/rdif.rs
@@ -305,9 +305,19 @@ impl DisplayDevice for RdifDisplayDevice {
         self.device.wait_fence(fence_id).map_err(map_display_error)
     }
 
+    fn pump(&mut self) -> Result<(), DisplayError> {
+        self.device.pump().map_err(map_display_error)
+    }
+
     fn fence_completed(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
         self.device
             .fence_completed(fence_id)
+            .map_err(map_display_error)
+    }
+
+    fn fence_completed_no_pump(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
+        self.device
+            .fence_completed_no_pump(fence_id)
             .map_err(map_display_error)
     }
 

--- a/os/arceos/modules/axdisplay/src/rdif.rs
+++ b/os/arceos/modules/axdisplay/src/rdif.rs
@@ -237,7 +237,15 @@ impl DisplayDevice for RdifDisplayDevice {
         cmd: &[u8],
     ) -> crate::DisplayResult {
         self.device
-            .resource_create_blob(ctx_id, resource_id, blob_mem, blob_flags, size, blob_id, cmd)
+            .resource_create_blob(
+                ctx_id,
+                resource_id,
+                blob_mem,
+                blob_flags,
+                size,
+                blob_id,
+                cmd,
+            )
             .map_err(map_display_error)
     }
 
@@ -293,6 +301,16 @@ impl DisplayDevice for RdifDisplayDevice {
             .map_err(map_display_error)
     }
 
+    fn wait_fence(&mut self, fence_id: u64) -> Result<(), DisplayError> {
+        self.device.wait_fence(fence_id).map_err(map_display_error)
+    }
+
+    fn fence_completed(&mut self, fence_id: u64) -> Result<bool, DisplayError> {
+        self.device
+            .fence_completed(fence_id)
+            .map_err(map_display_error)
+    }
+
     fn capset_info(&mut self, index: u32) -> Result<CapsetInfo, DisplayError> {
         self.device
             .get_capset_info(index)
@@ -304,6 +322,10 @@ impl DisplayDevice for RdifDisplayDevice {
         self.device
             .get_capset(id, ver, size)
             .map_err(map_display_error)
+    }
+
+    fn ctrl_notify(&mut self) {
+        self.device.ctrl_notify();
     }
 }
 

--- a/os/arceos/modules/axdisplay/src/types.rs
+++ b/os/arceos/modules/axdisplay/src/types.rs
@@ -39,3 +39,22 @@ impl DisplayInfo {
         }
     }
 }
+
+/// 3D box region for data transfer operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TransferBox {
+    pub x: u32,
+    pub y: u32,
+    pub z: u32,
+    pub w: u32,
+    pub h: u32,
+    pub d: u32,
+}
+
+/// Capset information returned by `gpu3d_capset_info`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapsetInfo {
+    pub capset_id: u32,
+    pub max_version: u32,
+    pub max_size: u32,
+}

--- a/os/arceos/modules/axruntime/src/serial/worker.rs
+++ b/os/arceos/modules/axruntime/src/serial/worker.rs
@@ -19,6 +19,22 @@ use crate::{RuntimeError, RuntimeResult};
 const RX_BUDGET: usize = 256;
 const TX_BUDGET: usize = 64;
 
+/// Keeps the 1 ms polling cadence for this long after the last RX byte or TX
+/// progress, so interactive console use stays responsive.
+const ACTIVE_WINDOW_NS: u64 = 50_000_000;
+/// Polling-mode cadence while console work is recent.
+const ACTIVE_POLL_INTERVAL: Duration = Duration::from_millis(1);
+/// Polling-mode cadence once idle. Polling mode has no RX interrupt, so the
+/// loop must keep sampling the port — but only the port sample depends on the
+/// tick, and a 1 kHz wake loop is pure scheduler noise (it interleaves ahead
+/// of renderer wakeups on the ready queue). Idle console-input latency is
+/// bounded by this interval instead.
+const IDLE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+fn now_ns() -> u64 {
+    ax_hal::time::monotonic_time().as_nanos() as u64
+}
+
 pub(super) struct SerialWorker {
     shared: Arc<RuntimeShared>,
     irq_rx: SpscConsumer<RxSample>,
@@ -35,6 +51,9 @@ pub(super) struct SerialWorker {
     pending_rearm: SerialEventSet,
     immediate_events: SerialEventSet,
     latched_rx_errors: RxErrorFlags,
+    /// Monotonic ns of the last real console work (RX bytes received or TX
+    /// progress); drives the polling-mode idle backoff.
+    last_active_ns: u64,
 }
 
 impl SerialWorker {
@@ -61,6 +80,7 @@ impl SerialWorker {
             pending_rearm: SerialEventSet::empty(),
             immediate_events: SerialEventSet::empty(),
             latched_rx_errors: RxErrorFlags::empty(),
+            last_active_ns: 0,
         }
     }
 
@@ -103,6 +123,9 @@ impl SerialWorker {
                 }
                 let outcome = self.service_rx(path);
                 rx_blocked = outcome.blocked;
+                if outcome.received {
+                    self.last_active_ns = now_ns();
+                }
                 if outcome.budget_exhausted {
                     ax_task::yield_now();
                 } else if !outcome.blocked && self.shared.bridge.latch.has_pending() {
@@ -119,6 +142,7 @@ impl SerialWorker {
             let mut budget_exhausted = false;
             let mut tx_blocked = false;
             if self.shared.started() && tx_needed {
+                self.last_active_ns = now_ns();
                 let outcome = self.service_tx();
                 budget_exhausted |= outcome.budget_exhausted;
                 tx_blocked = outcome.blocked;
@@ -158,7 +182,15 @@ impl SerialWorker {
             if drain_waiting_for_hardware {
                 ax_task::yield_now();
             } else if self.shared.polling {
-                ax_task::sleep(Duration::from_millis(1));
+                // Adaptive idle backoff: sample the port at the active
+                // cadence while console work is recent, then drop to the
+                // idle cadence (see `IDLE_POLL_INTERVAL`).
+                let idle = now_ns().wrapping_sub(self.last_active_ns) > ACTIVE_WINDOW_NS;
+                ax_task::sleep(if idle {
+                    IDLE_POLL_INTERVAL
+                } else {
+                    ACTIVE_POLL_INTERVAL
+                });
             } else {
                 self.shared.bridge.notify.wait();
             }
@@ -435,6 +467,7 @@ impl SerialWorker {
                 RxPath::Port => !source_drained,
             };
         RxServiceOutcome {
+            received: processed > 0,
             blocked,
             budget_exhausted: !blocked && processed == RX_BUDGET && source_pending,
         }
@@ -787,6 +820,9 @@ fn prepare_rx_output(
 }
 
 struct RxServiceOutcome {
+    /// At least one RX sample was processed on this call (real console input,
+    /// as opposed to an empty port poll).
+    received: bool,
     blocked: bool,
     budget_exhausted: bool,
 }

--- a/os/arceos/modules/axtask/src/future/poll.rs
+++ b/os/arceos/modules/axtask/src/future/poll.rs
@@ -1,4 +1,7 @@
-use core::{future::poll_fn, task::Poll};
+use core::{
+    future::poll_fn,
+    task::{Poll, Waker},
+};
 
 use axpoll::{IoEvents, Pollable};
 
@@ -31,7 +34,12 @@ where
     E: PollIoError,
 {
     let curr = current();
-    poll_fn(move |cx| {
+    // Last waker this poll registered; deregistered on return so stale wakers
+    // don't accumulate in the pollable's poll set (a leftover waker can consume
+    // a `wake_one`, starving the real waiter until its timeout — e.g. ~1.3ms
+    // flip-event delivery on-screen).
+    let mut registered: Option<Waker> = None;
+    let out = poll_fn(|cx| {
         match f() {
             Ok(value) => return Poll::Ready(Ok(value)),
             Err(error) if error.is_would_block() => {}
@@ -43,6 +51,7 @@ where
         // for EPOLLOUT. If we skip registration for non-blocking callers, the
         // TCP stack has no waker to call when the handshake finishes.
         pollable.register(cx, events);
+        registered = Some(cx.waker().clone());
 
         match f() {
             Ok(value) => Poll::Ready(Ok(value)),
@@ -57,7 +66,11 @@ where
             Err(e) => Poll::Ready(Err(e)),
         }
     })
-    .await
+    .await;
+    if let Some(w) = registered.take() {
+        pollable.unregister(&w);
+    }
+    out
 }
 
 /// Registers a waker for the given domain-scoped IRQ id.

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -40,6 +40,26 @@ extern crate std;
 /// Native ArceOS synchronization primitives.
 pub mod sync;
 
+/// [run6h] wake->run latency histogram snapshot: 6 µs buckets
+/// (<100, 100-500, 500-1000, 1-2ms, 2-4ms, >4ms) + total count.
+pub fn wake_run_lat_snapshot() -> ([u64; 6], u64) {
+    use core::sync::atomic::Ordering;
+    let mut buckets = [0u64; 6];
+    for (i, slot) in run_queue::WAKE_RUN_LAT.iter().enumerate() {
+        buckets[i] = slot.load(Ordering::Relaxed);
+    }
+    (buckets, run_queue::WAKE_RUN_LAT_CNT.load(Ordering::Relaxed))
+}
+
+/// [run6h] reset the wake->run latency histogram (per fx report window).
+pub fn wake_run_lat_reset() {
+    use core::sync::atomic::Ordering;
+    for slot in run_queue::WAKE_RUN_LAT.iter() {
+        slot.store(0, Ordering::Relaxed);
+    }
+    run_queue::WAKE_RUN_LAT_CNT.store(0, Ordering::Relaxed);
+}
+
 #[cfg(all(test, target_os = "none"))]
 fn bare_metal_test_runner(_tests: &[&dyn Fn()]) {}
 

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -22,6 +22,34 @@ use crate::{
     wait_queue::WaitQueueGuard,
 };
 
+/// [run6h] wake->run latency buckets (µs): <100, 100-500, 500-1000, 1-2ms,
+/// 2-4ms, >4ms. Bucketed in `switch_to` for any task that was just unblocked.
+pub static WAKE_RUN_LAT: [core::sync::atomic::AtomicU64; 6] = [
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+    core::sync::atomic::AtomicU64::new(0),
+];
+pub static WAKE_RUN_LAT_CNT: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+fn record_wake_run_lat(wake_ns: u64) {
+    use core::sync::atomic::Ordering;
+    let now = ax_hal::time::monotonic_time_nanos() as u64;
+    let lat_us = now.saturating_sub(wake_ns) / 1000;
+    let idx = match lat_us {
+        x if x < 100 => 0,
+        x if x < 500 => 1,
+        x if x < 1000 => 2,
+        x if x < 2000 => 3,
+        x if x < 4000 => 4,
+        _ => 5,
+    };
+    WAKE_RUN_LAT[idx].fetch_add(1, Ordering::Relaxed);
+    WAKE_RUN_LAT_CNT.fetch_add(1, Ordering::Relaxed);
+}
+
 struct PreviousTask {
     task: NonNull<crate::AxTask>,
     binding: PreviousContextBinding,
@@ -712,13 +740,15 @@ impl<G: GuardState> AxRunQueueRef<G> {
         // otherwise, the task is already unblocked by other cores.
         // Note:
         // target task can not be insert into the run queue until it finishes its scheduling process.
+        let wake_ns = ax_hal::time::monotonic_time_nanos() as u64;
         if self
             .inner
             // A wakeup is not a time-slice preemption of the woken task.
-            .put_task_with_state(task, TaskState::Blocked, false)
+            .put_task_with_state(task.clone(), TaskState::Blocked, false)
         {
             // Since now, the task to be unblocked is in the `Ready` state.
             let cpu_id = self.inner.cpu_id;
+            task.set_last_wake_ns(wake_ns);
             if let Some(task_id_name) = task_id_name {
                 debug!("task unblock: {task_id_name} on run_queue {cpu_id}");
             }
@@ -746,12 +776,14 @@ impl<G: GuardState> CurrentRunQueueRef<G> {
         } else {
             None
         };
+        let wake_ns = ax_hal::time::monotonic_time_nanos() as u64;
         if self
             .inner
             // A wakeup is not a time-slice preemption of the woken task.
-            .put_task_with_state(task, TaskState::Blocked, false)
+            .put_task_with_state(task.clone(), TaskState::Blocked, false)
         {
             let cpu_id = self.inner.cpu_id;
+            task.set_last_wake_ns(wake_ns);
             if let Some(task_id_name) = task_id_name {
                 debug!("task unblock: {task_id_name} on run_queue {cpu_id}");
             }
@@ -1184,6 +1216,12 @@ impl AxRunQueue {
             prev_task.id_name(),
             next_task.id_name()
         );
+        // [run6h] wake->run latency: if the next task was just unblocked,
+        // record how long the wake took to actually run it.
+        let wake_ns = next_task.take_last_wake_ns();
+        if wake_ns != 0 {
+            record_wake_run_lat(wake_ns);
+        }
         prev_task.check_stack_canary();
         #[cfg(feature = "preempt")]
         next_task.set_preempt_pending(false);

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -160,6 +160,9 @@ pub struct TaskInner {
     need_resched: AtomicBool,
     #[cfg(feature = "preempt")]
     force_resched: AtomicBool,
+    /// [run6h] monotonic ns when this task was last unblocked (wake-up
+    /// latency forensics: wake -> actually-running).
+    last_wake_ns: AtomicU64,
     #[cfg(axtest)]
     initial_scheduler_frame_consumed: AtomicBool,
 
@@ -437,6 +440,7 @@ impl TaskInner {
             need_resched: AtomicBool::new(false),
             #[cfg(feature = "preempt")]
             force_resched: AtomicBool::new(false),
+            last_wake_ns: AtomicU64::new(0),
             #[cfg(axtest)]
             initial_scheduler_frame_consumed: AtomicBool::new(false),
             interrupted: InterruptState::new(),
@@ -585,6 +589,18 @@ impl TaskInner {
     #[cfg(feature = "preempt")]
     pub(crate) fn set_preempt_pending(&self, pending: bool) {
         self.need_resched.store(pending, Ordering::Release)
+    }
+
+    /// [run6h] record the wake (unblock) time; consumed by the scheduler's
+    /// wake->run latency measurement when the task is next scheduled.
+    pub(crate) fn set_last_wake_ns(&self, ns: u64) {
+        self.last_wake_ns.store(ns, Ordering::Relaxed);
+    }
+
+    /// [run6h] take-and-clear the recorded wake time (0 if not recently
+    /// woken / already consumed).
+    pub(crate) fn take_last_wake_ns(&self) -> u64 {
+        self.last_wake_ns.swap(0, Ordering::Relaxed)
     }
 
     #[inline]


### PR DESCRIPTION
注意，本测试无法在容器中启动。

请在本地安装virglrenderer，运行测试中命令启动。

在本机安装spicy，使用spicy观看virgl画面。

依赖底层crate “virtio-drivers”  https://github.com/rcore-os/virtio-drivers 我已提交pr并和入，但是该crate未发布新版本。我临时在cargo.toml改成了git连接。后续发布后改回。不使用最新的代码会导致编译无法通过。

已经在本地成功运行。本机环境archlinux，gpu使用amd 780m。不建议使用nvidia gpu，因为驱动闭源兼容性差可能导致启动异常。解决方法尚未完全清楚。

运行成功图如下：

<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/550c4040-7ee7-4280-8887-2fc6c7ee4c09" />

串口中输出如下：

```
=======================================================
    glmark2 2023.01
=======================================================
    OpenGL Information
    GL_VENDOR:      Mesa
    GL_RENDERER:    virgl (AMD Radeon 780M Graphics (radeonsi, phoenix, ACO, DR...)
    GL_VERSION:     OpenGL ES 3.2 Mesa 25.2.7
    Surface Config: buf=32 r=8 g=8 b=8 a=8 depth=32 stencil=0 samples=0
    Surface Size:   800x600 windowed
=======================================================
```

# feat(virgl): implement virgl 3D acceleration and complete the DRM display stack

## 问题背景

StarryOS 在 x86_64 QEMU 下此前只支持 2D 显示，Mesa 用户态只能走 llvmpipe 软渲染，无法利用 virtio-gpu 的 3D 硬件加速。同时 DRM 显示路径存在黑屏、GEM 资源生命周期错误等一系列问题。目标是把 **Mesa (virgl 驱动) → 内核 DRM (`/dev/dri/card0` + `renderD128`) → virtio-gpu 3D 命令 → QEMU host virglrenderer** 的全链路打通，使 `GL_RENDERER=virgl`（真正的 3D 硬件加速）生效。

`virtio-drivers` 的 crates.io 0.13.0 未包含 virgl 3D/blob API，本次固定到 git rev `b59889b`（上游已合并的 PR #257）以获取新接口。

## 改动总览（20 文件，+3890/−105）

分层（自底向上）：

| 层 | 文件 | 改动 |
|---|---|---|
| 接口 | `drivers/interface/rdif-display/{interface,types,error}.rs` | `Interface` trait 新增 22 个 2D/3D 方法（全部默认 `NotSupported`，向后兼容）；新增 `TransferBox`、`CapsetInfo`、`Gpu3dErrorKind` |
| 驱动 | `drivers/ax-driver/src/virtio/{display,mod}.rs` | `VirtIoDisplay` 实现全部 3D 方法（`ctx_create`/`resource_create_3d`/`create_blob`/`submit_3d`/`get_capset`…）；`resource_create_blob` 为 unsafe 并附 SAFETY 论证；单调 fence id；适配 git rev 的 `VirtIoHal` `access_platform` 新签名 |
| 显示子系统 | `os/arceos/modules/axdisplay/{device,lib,rdif,types}.rs` | 新增 `gpu3d_*` 轴心自由函数（内部持 `MAIN_DISPLAY` 锁串行）与 `DisplayDevice` 对应方法；经 `RdifDisplayDevice` 逐方法转发并做错误映射 |
| 内核 DRM | `os/StarryOS/kernel/src/pseudofs/dev/card0.rs`（+1573） | virtgpu ioctl 全集：GETPARAM / CONTEXT_INIT / GET_CAPS / RESOURCE_CREATE / EXECBUFFER / RESOURCE_CREATE_BLOB / RESOURCE_INFO / MAP / TRANSFER_TO/FROM_HOST / WAIT / PRIME HANDLE↔FD / GEM_CLOSE；GEM 句柄表与引用计数 |
| 内核 DRM | `os/StarryOS/kernel/src/pseudofs/dev/drm.rs`（+417） | virtgpu UAPI 常量 + `#[repr(C)]` 结构体（含 64B EXECBUFFER、48B BLOB、8B GEM_CLOSE 等精确布局）；`DRIVER_NAME="virtio_gpu"`、`DRIVER_VERSION_MAJOR=0` |
| 内核 DRM | `os/StarryOS/kernel/src/pseudofs/sysfs.rs`（+60） | `renderD128` 节点、`uevent DRIVER=virtio_gpu`、platform `MODALIAS=platform:virtio-gpu`、`/sys/devices/platform/virtio-gpu0/drm/{card0,renderD128}` 子目录 |
| 依赖 | `Cargo.toml`/`Cargo.lock` | `virtio-drivers` → `git rev b59889b` |
| 测试 | `apps/starry/virgl-test/*` + `apps/.ignore` | Weston DRM+GL 渲染器验证 virgl；因依赖宿主 GPU 与 spice/GL qemu，标为手动 |

## 关键修复（可作 changelog）

1. **GETPARAM 返回值写错位置**——写入结构体字段而非 `g.value` 指针目标，导致 Mesa 读到 `3D_FEATURES=0`、virgl winsys 创建失败。
2. **EXECBUFFER 结构 40B ≠ Mesa 64B**——缺 syncobj tail，ioctl 号 size 位错位，EXECBUFFER 落不到 handler。
3. **DRIVER_MAJOR=1** 被 Mesa `virgl_drm_get_version` 拒绝，改为 0 走 legacy fence 路径。
4. **RESOURCE_CREATE_3D 缺 `ATTACH_BACKING` / 创建后未即时 `CTX_ATTACH_RESOURCE`**——host vrend 报 "Illegal resource"。
5. **多客户端共享同一 host context**——weston + glmark2 的 sub-ctx id 冲突导致 context in_error；改为按 pid 的 per-fd context（`process_ctxs`）+ 设备级 `next_ctx_id`。
6. **PRIME import 未 attach 到 importer context**；且 RESOURCE_INFO 的 `blob_mem` 硬编码 0——Mesa importer 无法走 `maybe_untyped` 零拷贝复用 host 纹理。
7. **exporter 关句柄过早释放 host 资源**——importer 侧 "Illegal resource"；引入 `unref_resource_if_last` 引用计数（`gpu_resources` + `blob_aliases` + `dma_buf_refs` 全空才 unref）。
8. **2D 黑屏**——`CREATE_DUMB` 不建 host 2D 资源时 virgl blit/present 读零；现在对齐 Linux 建 `RESOURCE_CREATE_2D + ATTACH_BACKING`，以 `is_dumb_2d` 标记，present 前补 `TRANSFER_TO_HOST_2D`。
9. **GET_CAPS 用用户 `size` 截断**——改用 `max_size` 取全量 capset，防止 Mesa 启用 host 不支持的 GL 特性（如被 virglrenderer 拒绝的 `SET_TESS_STATE`）。

## 关键子流程

**全链路数据流**

Mesa (weston/glmark2, virtio_gpu_dri.so)
│ DRM_IOCTL /dev/dri/renderD128  (card0 与 renderD128 同一实例)
▼
card0.rs DeviceOps::ioctl → handle_virtgpu_*      [UAPI 校验、handle↔res 转换、GEM 生命周期]
▼
ax_display::gpu3d_*  (MAIN_DISPLAY 锁串行)          [trait 边界]
▼
DisplayDevice → RdifDisplayDevice → rdif-display::Interface
▼
VirtIoDisplay (ax-driver)                           [virtio 命令 + Gpu3dErrorKind 分类]
▼
virtio-drivers VirtIOGpu (submit_3d / create_blob / set_scanout …)
▼
virtqueue → QEMU virglrenderer                        [真实 GPU 渲染]



**PRIME 导出/导入**：导出 = host 3D 资源包成 `HostResourceDmaBuf`（持 `Weak<Card0>`）+ `dma_buf_refs[res]++`；导入 = 走 `blob_aliases` 记原 `res_handle`，并**立即 attach 到 importer 的 vrend context**（对齐 Linux `virtio_gpu_gem_object_open`）。RESOURCE_INFO 解析回真实 `blob_mem` 使 Mesa importer 复用 host 纹理。

**present/scanout**：`SETCRTC`/`PAGE_FLIP`/atomic 统一走 `present_fb`；`FbBacking` 分 Dumb（CPU memcpy + flush，2D）与 Gpu3d（`SET_SCANOUT` + 仅 `is_dumb_2d` 时 `TRANSFER_TO_HOST_2D` + `RESOURCE_FLUSH`）。3D/blob 像素已在 host，跳过 transfer（对齐 Linux `virtio_gpu_plane_atomic_update`）。

**GEM 生命周期**：`CREATE_DUMB`/`RESOURCE_CREATE`/`RESOURCE_CREATE_BLOB` 三条创建路径统一登记；`GEM_CLOSE` 与 `DESTROY_DUMB` 合并进 `destroy_handle`；host 端 `RESOURCE_UNREF` 仅在资源完全无引用时发出。

**fence**：当前为同步提交模型——`submit_cmd` 生成单调 fence id，EXECBUFFER 接受但忽略 `FENCE_FD_IN/OUT`，`WAIT` 同步立即成功，无 IRQ 驱动的异步 fence 路径。

## 测试

- `apps/starry/virgl-test`（手动 app）：Weston `--renderer=gl` 经 `/dev/dri/renderD128`，`GL_RENDERER=virgl` 为加速生效的直接证据；`glmark2-es2-wayland` Score 69、0 个命令提交错误；2D 显示路径（Qt 测试）亦验证通过。
- prebuild 需将 Alpine 的 mesa/wayland 全量升级（mesa 25.2.7 + wayland 1.24，`pipe_virgl.so` 需 v3.23+）才能启用 virgl 驱动。
- 因依赖宿主机 GPU（建议 AMD）+ 带 spice/GL 的 QEMU，已加入 `apps/.ignore` 标为手动，容器 CI 的 `--all` 不执行。

## 注意事项

- HOST3D blob 的 guest shadow 不发送给设备（`nr_entries=0`，virglrenderer 拒绝带 iov 的 HOST3D），present 走 host 端零拷贝；`VIRTGPU_MAP`/mmap 仅对 dumb/guest 资源生效。
- 每条 virtio 命令靠 `MAIN_DISPLAY` 锁串行同步执行，尚无异步 fence/IRQ 优化。
- 宿主 NVIDIA GPU 与 virglrenderer 交互存在已知问题，建议 AMD。