### PR TITLE
test(starry): prevent system test cleanup stalls

### DIFF
--- a/test-suit/starryos/qemu/system/syscall-test-session-syscalls/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-session-syscalls/src/main.c
@@ -251,7 +251,8 @@ static void test_setsid(void)
 #define SETSID_RACERS 8
 
 struct setsid_race_result {
-    pthread_barrier_t *start;
+    int ready_fd;
+    int release_fd;
     pid_t result;
     int error;
 };
@@ -259,12 +260,13 @@ struct setsid_race_result {
 static void *setsid_racer(void *opaque)
 {
     struct setsid_race_result *race = opaque;
-    int barrier_result = pthread_barrier_wait(race->start);
-    if (barrier_result != 0 && barrier_result != PTHREAD_BARRIER_SERIAL_THREAD) {
-        race->result = -1;
-        race->error = barrier_result;
-        return NULL;
-    }
+
+    /* A pipe gives every racer one explicit ready/release token.  Unlike a
+     * pthread barrier, this keeps the test's start protocol independent of
+     * the libc's futex/barrier implementation while still releasing all
+     * threads together from the parent worker. */
+    sync_child_ready(race->ready_fd);
+    wait_child_ready(race->release_fd);
 
     errno = 0;
     race->result = setsid();
@@ -281,22 +283,31 @@ static void test_concurrent_setsid(void)
     if (child < 0)
         return;
     if (child == 0) {
-        pthread_barrier_t start;
+        int ready[2];
+        int release[2];
         pthread_t threads[SETSID_RACERS];
         struct setsid_race_result results[SETSID_RACERS] = {0};
 
-        if (pthread_barrier_init(&start, NULL, SETSID_RACERS) != 0)
+        if (pipe(ready) != 0 || pipe(release) != 0)
             _exit(1);
         for (size_t i = 0; i < SETSID_RACERS; ++i) {
-            results[i].start = &start;
+            results[i].ready_fd = ready[1];
+            results[i].release_fd = release[0];
             if (pthread_create(&threads[i], NULL, setsid_racer, &results[i]) != 0)
                 _exit(1);
         }
+        for (size_t i = 0; i < SETSID_RACERS; ++i)
+            wait_child_ready(ready[0]);
+        for (size_t i = 0; i < SETSID_RACERS; ++i)
+            sync_child_ready(release[1]);
         for (size_t i = 0; i < SETSID_RACERS; ++i) {
             if (pthread_join(threads[i], NULL) != 0)
                 _exit(1);
         }
-        pthread_barrier_destroy(&start);
+        close(ready[0]);
+        close(ready[1]);
+        close(release[0]);
+        close(release[1]);
 
         size_t successes = 0;
         size_t permission_denied = 0;

--- a/test-suit/starryos/qemu/system/test-ext4-inode-unique/src/main.c
+++ b/test-suit/starryos/qemu/system/test-ext4-inode-unique/src/main.c
@@ -46,14 +46,6 @@ static int create_and_stat(struct file_identity *id)
         return fail_errno("open O_CREAT|O_EXCL");
     }
 
-    if (write(id->fd, id->path, strlen(id->path)) < 0) {
-        return fail_errno("write marker");
-    }
-
-    if (fsync(id->fd) != 0) {
-        return fail_errno("fsync marker");
-    }
-
     if (stat(id->path, &id->st_path) != 0) {
         return fail_errno("stat path");
     }

--- a/test-suit/starryos/qemu/system/test-nix-builder-init/src/main.c
+++ b/test-suit/starryos/qemu/system/test-nix-builder-init/src/main.c
@@ -16,8 +16,18 @@
 #include <termios.h>
 #include <unistd.h>
 
+/* The parent must retain a kill handle after the child creates a new session. */
+static volatile sig_atomic_t child_to_cleanup = -1;
+
 static void fail(const char *stage)
 {
+    int saved_errno = errno;
+    pid_t child = (pid_t)child_to_cleanup;
+    if (child > 0) {
+        (void)kill(child, SIGKILL);
+        child_to_cleanup = -1;
+    }
+    errno = saved_errno;
     printf("TEST_NIX_BUILDER_INIT_FAILED stage=%s errno=%d (%s)\n", stage,
            errno, strerror(errno));
     exit(1);
@@ -34,6 +44,9 @@ static void child_fail(const char *stage)
 static void timeout_handler(int signo)
 {
     (void)signo;
+    pid_t child = (pid_t)child_to_cleanup;
+    if (child > 0)
+        (void)kill(child, SIGKILL);
     static const char marker[] =
         "TEST_NIX_BUILDER_INIT_FAILED stage=timeout\n";
     ssize_t ignored = write(STDOUT_FILENO, marker, sizeof(marker) - 1);
@@ -145,6 +158,8 @@ int main(void)
         child_fail("exec");
     }
 
+    child_to_cleanup = child;
+
     char line[256];
     ssize_t length = read_line(master, line, sizeof(line));
     if (length < 0)
@@ -166,6 +181,7 @@ int main(void)
         fail("child-status");
     }
 
+    child_to_cleanup = -1;
     close(master);
     alarm(0);
     puts("TEST_NIX_BUILDER_INIT_PASSED");

--- a/test-suit/starryos/qemu/system/test-nix-builder-init/src/main.c
+++ b/test-suit/starryos/qemu/system/test-nix-builder-init/src/main.c
@@ -176,12 +176,12 @@ int main(void)
     int status;
     if (waitpid(child, &status, 0) != child)
         fail("waitpid");
+    child_to_cleanup = -1;
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
         errno = ECHILD;
         fail("child-status");
     }
 
-    child_to_cleanup = -1;
     close(master);
     alarm(0);
     puts("TEST_NIX_BUILDER_INIT_PASSED");

--- a/test-suit/starryos/qemu/system/test-nix-builder-lifecycle/src/main.c
+++ b/test-suit/starryos/qemu/system/test-nix-builder-lifecycle/src/main.c
@@ -166,13 +166,23 @@ static void *thread_fork_exec_wait(void *arg)
 
     unlink(ctx->marker_path);
 
+    /*
+     * POSIX permits only async-signal-safe calls in the child of a
+     * multi-threaded fork before exec.  In particular, formatting the command
+     * there can inherit a libc lock held by another thread and turn this
+     * regression test into a host-libc-dependent deadlock.  Build the argv in
+     * the parent so the child performs only execve() or _exit().
+     */
+    char cmd[256];
+    int cmd_len = snprintf(cmd, sizeof(cmd),
+                           "echo THREAD_BUILDER_OK > %s", ctx->marker_path);
+    if (cmd_len < 0 || (size_t)cmd_len >= sizeof(cmd)) return NULL;
+    char *const argv[] = { "/bin/sh", "-c", cmd, NULL };
+
     pid_t pid = fork();
     if (pid < 0) return NULL;
 
     if (pid == 0) {
-        char cmd[256];
-        snprintf(cmd, sizeof(cmd), "echo THREAD_BUILDER_OK > %s", ctx->marker_path);
-        char *argv[] = { "/bin/sh", "-c", cmd, NULL };
         execve("/bin/sh", argv, environ);
         _exit(126);
     }

--- a/test-suit/starryos/qemu/system/test-per-ns-mounts/src/main.c
+++ b/test-suit/starryos/qemu/system/test-per-ns-mounts/src/main.c
@@ -23,6 +23,13 @@ static char *read_file(const char *path, char *buf, size_t size) {
 int main(void) {
     mkdir("/mnt", 0755);
 
+    int ready_pipe[2];
+    int release_pipe[2];
+    if (pipe(ready_pipe) < 0 || pipe(release_pipe) < 0) {
+        perror("pipe");
+        return 1;
+    }
+
     pid_t pid = fork();
     if (pid < 0) {
         perror("fork");
@@ -30,6 +37,9 @@ int main(void) {
     }
 
     if (pid == 0) {
+        close(ready_pipe[0]);
+        close(release_pipe[1]);
+
         /* Child: unshare mount namespace */
         if (unshare(CLONE_NEWNS) < 0) {
             perror("unshare(CLONE_NEWNS)");
@@ -54,9 +64,19 @@ int main(void) {
             _exit(1);
         }
 
-        /* Tear the private mount down explicitly before process exit. This
-         * keeps namespace teardown from carrying a live tmpfs into the child
-         * reaper path exercised by later system-test processes. */
+        char ready = 'R';
+        if (write(ready_pipe[1], &ready, 1) != 1) {
+            perror("write mount-ready");
+            _exit(1);
+        }
+
+        char release;
+        if (read(release_pipe[0], &release, 1) != 1) {
+            perror("read mount-release");
+            _exit(1);
+        }
+
+        /* Tear the private mount down explicitly before process exit. */
         if (umount("/mnt") < 0) {
             perror("umount /mnt");
             _exit(1);
@@ -65,25 +85,42 @@ int main(void) {
         _exit(0);
     }
 
-    /* Parent: wait for child */
+    close(ready_pipe[1]);
+    close(release_pipe[0]);
+
+    char ready = 0;
+    int parent_ok = read(ready_pipe[0], &ready, 1) == 1 && ready == 'R';
+    close(ready_pipe[0]);
+    if (!parent_ok) {
+        fputs("FAIL: child did not finish its private mount setup\n", stderr);
+    }
+
+    /* Check isolation while the child mount is still alive. */
+    if (parent_ok) {
+        char buf[BUF_SIZE];
+        if (!read_file("/proc/self/mounts", buf, sizeof(buf))) {
+            fprintf(stderr, "parent: cannot read /proc/self/mounts\n");
+            parent_ok = 0;
+        } else if (strstr(buf, "/mnt") != NULL) {
+            fprintf(stderr, "FAIL: /mnt leaked into parent namespace\n");
+            parent_ok = 0;
+        }
+    }
+
+    if (parent_ok && write(release_pipe[1], "R", 1) != 1) {
+        perror("write mount-release");
+        parent_ok = 0;
+    }
+    close(release_pipe[1]);
+
     int status;
     waitpid(pid, &status, 0);
     if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
         fprintf(stderr, "FAIL: child exited with status %d\n", status);
-        return 1;
+        parent_ok = 0;
     }
-
-    /* Verify /mnt does NOT appear in parent's /proc/self/mounts */
-    char buf[BUF_SIZE];
-    if (!read_file("/proc/self/mounts", buf, sizeof(buf))) {
-        fprintf(stderr, "parent: cannot read /proc/self/mounts\n");
+    if (!parent_ok)
         return 1;
-    }
-
-    if (strstr(buf, "/mnt") != NULL) {
-        fprintf(stderr, "FAIL: /mnt leaked into parent namespace\n");
-        return 1;
-    }
 
     rmdir("/mnt");
     printf("TEST_PER_NS_MOUNTS_PASSED\n");

--- a/test-suit/starryos/qemu/system/test-per-ns-mounts/src/main.c
+++ b/test-suit/starryos/qemu/system/test-per-ns-mounts/src/main.c
@@ -54,6 +54,14 @@ int main(void) {
             _exit(1);
         }
 
+        /* Tear the private mount down explicitly before process exit. This
+         * keeps namespace teardown from carrying a live tmpfs into the child
+         * reaper path exercised by later system-test processes. */
+        if (umount("/mnt") < 0) {
+            perror("umount /mnt");
+            _exit(1);
+        }
+
         _exit(0);
     }
 

--- a/test-suit/starryos/qemu/system/test-per-ns-mounts/src/main.c
+++ b/test-suit/starryos/qemu/system/test-per-ns-mounts/src/main.c
@@ -89,9 +89,10 @@ int main(void) {
     close(release_pipe[0]);
 
     char ready = 0;
-    int parent_ok = read(ready_pipe[0], &ready, 1) == 1 && ready == 'R';
+    int child_ready = read(ready_pipe[0], &ready, 1) == 1 && ready == 'R';
     close(ready_pipe[0]);
-    if (!parent_ok) {
+    int parent_ok = child_ready;
+    if (!child_ready) {
         fputs("FAIL: child did not finish its private mount setup\n", stderr);
     }
 
@@ -107,7 +108,12 @@ int main(void) {
         }
     }
 
-    if (parent_ok && write(release_pipe[1], "R", 1) != 1) {
+    /*
+     * Once the ready byte has arrived, the child is blocked on release_pipe.
+     * Always release it, even when the parent-side assertion failed, so a
+     * diagnostic failure cannot turn into an unbounded waitpid hang.
+     */
+    if (child_ready && write(release_pipe[1], "R", 1) != 1) {
         perror("write mount-release");
         parent_ok = 0;
     }


### PR DESCRIPTION
## Summary
- remove the inode-identity test's 2,048 marker writes and `fsync`s, which do not contribute to its inode assertions
- keep the namespace-isolation mount live while the parent checks it, then always release the child so a failed assertion cannot become a `waitpid` hang
- explicitly kill the Nix builder setup child from its parent's failure and timeout paths, including after that child has created a new session
- synchronize the eight `setsid()` racers with per-thread pipe tokens instead of a libc barrier, while retaining the one-success/seven-`EPERM` race assertion

## Rationale
`test-ext4-inode-unique` retains `O_CREAT | O_EXCL`, `stat`/`fstat` identity checks, and pairwise `(st_dev, st_ino)` uniqueness checks. Its synchronous marker writes only add filesystem work.

`test-per-ns-mounts` uses a ready/release pipe handshake: the parent verifies that `/mnt` is absent from its own mount table while the child tmpfs is live, then releases the child to unmount it. The release is unconditional once setup is acknowledged, so the test fails normally instead of leaving its child blocked.

The failing RISC-V system-test logs also show `test-nix-builder-init` emitting its own timeout marker and then stalling the enclosing QEMU run. Its setup child calls `setsid()`; keeping its PID in the parent and sending `SIGKILL` from every parent failure path ensures the supervisor does not depend solely on parent-death cleanup across that session transition.

The same suite has also stalled during the `setsid` race. The replacement protocol waits for one ready byte from each worker, then releases one byte per worker. It preserves concurrent entry to `setsid()` without depending on the libc barrier path.

## Testing
- `git diff --check`
- host compile with `-std=c11 -Wall -Wextra -Werror -pthread`
- host execution of `test-session-syscalls`: 19 pass, 0 fail
- fresh upstream CI for head `71afb2175` is queued; local Linux/QEMU execution remains unavailable because this workspace's Docker content store has an I/O error