### PR TITLE
fix(ax-cpu): harden user access and architecture state transitions

### DIFF
--- a/book/design/ax-cpu-user-transition-prerequisites.md
+++ b/book/design/ax-cpu-user-transition-prerequisites.md
@@ -1,0 +1,140 @@
+# `ax-cpu` 用户态转换前置改进
+
+## 状态与范围
+
+本文定义从 PR #1775 独立提取的三个前置改进：可恢复的 nofault 用户内存访问、
+缺页完成后的本地 MMU 同步，以及 x86 LinuxCurrent 用户 TLS 懒安装。三者都位于
+用户态指令与内核状态转换的边界，目标是在不迁移 #1775 整体任务运行时架构的前提下，
+先消除可以独立验证的正确性风险和固定开销。
+
+本次明确不包含：
+
+- IRQ-off idle 与 clockevent 事务；
+- active-mm、页表根及 CPU mask 所有权迁移；
+- 跨 CPU TLB shootdown 或新增 IPI；
+- x86 double-fault IST 路径；
+- `UserContext` 的 bytemuck 化和整套 trapframe 重构；
+- robust-list 等不持有 futex 队列锁的用户内存访问迁移。
+
+因此本改进能解除 #1775 的部分底层耦合，但不代表 #1775 的其余调度、时钟和地址空间
+所有权问题已经完成。
+
+## 问题与成功条件
+
+### Futex 锁内用户访问
+
+`WAIT` 的条件复查、`CMP_REQUEUE` 的比较和 `WAKE_OP` 的原子读改写都必须与 futex
+队列锁保护的状态变更组成一个事务。普通 faultable 用户访问可能在持锁期间进入缺页
+处理、等待内存或调度，破坏锁的执行上下文约束；若把读取提前到加锁前，用户映射和值
+又可能在加锁前后发生变化。
+
+成功条件是：锁内访问只返回成功、`Fault` 或 `Retry`，不进入缺页处理；`Fault` 和
+`Retry` 都不得唤醒、重排或留下 waiter。需要补页时先释放全部 futex 队列锁，再执行
+fault-in、yield 并从事务起点重试。
+
+### 缺页完成后的本地可见性
+
+地址空间后端成功安装 PTE 后，故障 CPU 可能仍保留无效项或软件 refill 产生的占位项。
+若不在重试故障指令前完成架构要求的本地同步，刚安装的映射仍可能再次故障。
+
+成功条件是：只有成功处理的缺页恰好执行一次、按页对齐的本地
+`update_mmu_cache`；拒绝路径不执行。该操作不承担远端 CPU 的映射失效，也不改变
+地址空间或页表根所有权。
+
+### x86 用户 TLS 固定 MSR 开销
+
+原实现每次进入用户态都读取内核 FS 并写用户 FS/GS，每次退出又读取用户 FS/GS 并
+恢复内核 FS。LinuxCurrent 模式已经禁止内核 TLS，且 `CR4.FSGSBASE` 关闭时用户不能
+绕过内核修改 FS/GS base，因此 `UserContext` 与 CPU-local 镜像可以成为完整的状态源。
+
+成功条件是：CPU 首次初始化用户 TLS 镜像；进入用户态前只写发生变化的 MSR；相同
+FS/GS 不写 MSR；单字段变化只写对应 MSR；generation 回绕时跳过 0，使 0 始终表示
+“未初始化”。普通 trap/syscall 汇编不再保存和恢复 FS/GS MSR。
+
+## 接口与所有权
+
+```mermaid
+flowchart LR
+    Futex["Starry futex 事务"] -->|"锁内 nofault"| UserAccess["ax-cpu user access"]
+    Futex -->|"解锁后 Fault"| FaultIn["Starry fault-in + retry"]
+    PageFault["ArceOS / Starry page fault"] -->|"PTE 安装成功"| Cache["ax-hal update_mmu_cache"]
+    Cache -->|"仅本 CPU"| ArchMmu["ax-cpu arch MMU primitive"]
+    UserContext["x86 UserContext FS/GS"] -->|"IRQ-off owner transition"| CpuTls["CPU-local TLS mirror"]
+    CpuTls -->|"仅变化字段"| Msr["FS_BASE / KERNEL_GS_BASE MSR"]
+```
+
+### Nofault 用户访问
+
+`ax-cpu` 暴露 `user_read_u32` 和 `user_atomic_u32`，错误由
+`UserAccessError`/`UserAtomicError` 明确区分。四个架构的汇编访问点都登记在独立
+`__nofault_ex_table` 中；trap 必须先尝试 nofault fixup，失败后才能进入普通 OS 缺页
+处理。RISC-V 的原子实现显式声明 `zaamo`，不依赖目标配置的隐式指令能力。
+
+原子操作支持 futex `WAKE_OP` 需要的 Set、Add、Or、And-not、Xor。无效地址必须在
+任何存储生效前恢复为 `Fault`；比较交换竞争返回 `Retry`，由上层释放锁、yield 后重试。
+Starry 的 fault-in 包装只负责让映射可访问，不替代锁内的条件复查。
+
+### 本地 MMU 同步
+
+`ax_cpu::asm::update_mmu_cache` 是架构原语，`ax_hal::cache::update_mmu_cache` 负责
+统一按 4 KiB 页对齐。行为矩阵如下：
+
+| 架构 | 本地行为 | 原因 |
+| --- | --- | --- |
+| RISC-V | 对目标页执行 `SFENCE.VMA` | 允许缓存无效 PTE |
+| LoongArch | 对目标页执行本地 TLB 失效 | refill 可能保留不可读/不可执行占位项 |
+| x86_64 | 空操作 | 不缓存无效叶项 |
+| AArch64 | 空操作 | 页表遍历与该缺页安装路径无需无条件本地失效 |
+
+ArceOS `ax-mm` 和 Starry 地址空间只在后端报告已成功处理后调用该边界，并且调用发生在
+返回 trap、重试原故障指令之前。
+
+### x86 LinuxCurrent TLS
+
+每 CPU 的架构保留区保存 `{fs_base, gs_base, generation}`。访问该区域必须满足：CPU
+area 已安装、当前 GS 指向内核 CPU area、本地 IRQ 已关闭。初始化先把物理 FS 和
+inactive `IA32_KERNEL_GS_BASE` 清零，再最后发布非零 generation；后续更新也始终最后
+发布 generation。
+
+`UserContext::run` 在关闭 IRQ 后比较上下文与 CPU 镜像，按需执行 `WRMSR`。用户态
+trap 入口仍通过 `SWAPGS` 恢复内核 CPU area；由于 `CR4.FSGSBASE` 在初始化时被显式
+断言关闭，trap 期间用户 FS/GS 值不会自行改变，退出用户态时不必再次 `RDMSR`。
+`UserContext` 的私有 continuation 字段只保存内核栈指针，并用显式保留字段与编译期
+offset/size 断言固定真实 16 字节对齐布局。
+
+## 安全契约
+
+- nofault 接口的调用方必须保证指针描述预期的用户 `u32`；异常表只把同步访问故障
+  转成错误，不赋予地址有效性，也不替代上层权限检查。
+- futex 队列锁持有期间不得调用 fault-in、yield 或普通 faultable 用户访问；错误退出
+  前不得提交任何队列副作用。
+- `update_mmu_cache` 只能表示“本 CPU 刚完成一次缺页安装”，不能被当作远端 shootdown
+  或页表生命周期屏障。
+- x86 TLS 镜像只有当前 CPU 可修改；读、MSR 写与镜像发布期间 IRQ 必须保持关闭。
+- `CR4.FSGSBASE` 必须保持关闭。若未来允许用户直接执行 FSGSBASE 指令，必须重新设计
+  用户上下文捕获和镜像失效协议，不能继续信任当前缓存。
+
+## 备选方案
+
+- 在 futex 锁内继续使用 faultable API：会把缺页和调度带入不可睡眠临界区，拒绝。
+- 加锁前预读或 fault-in 一次：不能阻止加锁前后映射和值变化，只能作为解锁后的准备
+  动作，拒绝作为条件复查。
+- 每次成功缺页做全局 TLB shootdown：扩大了本地完成边界，并混入 #1775 的 CPU mask
+  与 active-mm 所有权，拒绝。
+- x86 每次进入/退出无条件读写 MSR：语义正确但保留固定串行化开销，作为改进前基线。
+- 启用 FSGSBASE 让用户直接维护 TLS：需要新的捕获和安全模型，不属于本前置改进。
+
+## 验证契约
+
+确定性回归必须先在旧策略上失败，再让同一测试转绿：
+
+- nofault：真实无效地址通过异常表恢复；五种 RMW；`Fault`/`Retry` 零副作用；fault-in
+  观察点证明所有 futex 锁已释放。
+- MMU：成功缺页一次页对齐本地同步，拒绝路径零次同步。
+- TLS：相同值零 MSR 写，单字段变化只写对应寄存器，未初始化强制写双寄存器，
+  generation 回绕保持非零。
+
+真实系统回归继续使用现有 `qemu/system` 分组：futex 覆盖 lazy fault、比较和 RMW
+事务；x86 `arch_prctl` 覆盖重复 FS/GS 设置；pthread 覆盖 `CLONE_SETTLS` 并通过多线程
+反复 `sched_yield` 验证 TLS 隔离。任何子用例失败都必须由 grouped runner 汇总为失败，
+不能新增绕过现有分组的独立 QEMU 配置。

--- a/components/axcpu/src/aarch64/asm.rs
+++ b/components/axcpu/src/aarch64/asm.rs
@@ -152,6 +152,15 @@ pub fn flush_tlb(vaddr: Option<VirtAddr>) {
     }
 }
 
+/// Makes a page-table entry installed by the local page-fault handler visible
+/// before retrying the faulting instruction.
+///
+/// AArch64 page-table updates are coherent with the hardware walker. A rare
+/// spurious refault is safe to handle again, so no unconditional barrier is
+/// needed on the minor-fault fast path.
+#[inline]
+pub fn update_mmu_cache(_vaddr: VirtAddr) {}
+
 /// Flushes the entire instruction cache.
 #[inline]
 pub fn flush_icache_all() {

--- a/components/axcpu/src/aarch64/asm.rs
+++ b/components/axcpu/src/aarch64/asm.rs
@@ -263,7 +263,7 @@ pub fn enable_fp() {
 }
 
 #[cfg(feature = "uspace")]
-core::arch::global_asm!(include_str!("user_copy.S"));
+core::arch::global_asm!(include_str!("user_copy.S"), include_str!("user_atomic.S"),);
 
 #[cfg(feature = "uspace")]
 unsafe extern "C" {

--- a/components/axcpu/src/aarch64/trap.rs
+++ b/components/axcpu/src/aarch64/trap.rs
@@ -171,6 +171,10 @@ fn handle_breakpoint(tf: &mut KernelTrapFrame<'_>) {
 
 fn handle_page_fault(tf: &mut KernelTrapFrame<'_>, access_flags: PageFaultFlags) {
     let vaddr = va!(fault_addr());
+    #[cfg(feature = "exception-table")]
+    if tf.raw.0.fixup_nofault_exception() {
+        return;
+    }
     if crate::trap::call_page_fault_handler_with_parent_irqs(
         vaddr,
         access_flags,

--- a/components/axcpu/src/aarch64/user_atomic.S
+++ b/components/axcpu/src/aarch64/user_atomic.S
@@ -1,0 +1,69 @@
+.macro _asm_nofault_extable from, to
+    .pushsection __nofault_ex_table, "a"
+    .balign 4
+    .word \from - .
+    .word \to - .
+    .popsection
+.endm
+
+.section .text
+.global __axcpu_user_read_u32
+.type __axcpu_user_read_u32, %function
+__axcpu_user_read_u32:
+1:
+    ldr w2, [x0]
+    str w2, [x1]
+    mov w0, #0
+    ret
+.Luser_read_fault:
+    mov w0, #1
+    ret
+    _asm_nofault_extable 1b, .Luser_read_fault
+.size __axcpu_user_read_u32, . - __axcpu_user_read_u32
+
+.global __axcpu_user_atomic_u32
+.type __axcpu_user_atomic_u32, %function
+__axcpu_user_atomic_u32:
+    mov w7, #128
+1:
+    ldxr w4, [x0]
+    cmp w1, #0
+    b.eq .Luser_atomic_set
+    cmp w1, #1
+    b.eq .Luser_atomic_add
+    cmp w1, #2
+    b.eq .Luser_atomic_or
+    cmp w1, #3
+    b.eq .Luser_atomic_and_not
+    eor w5, w4, w2
+    b 2f
+.Luser_atomic_set:
+    mov w5, w2
+    b 2f
+.Luser_atomic_add:
+    add w5, w4, w2
+    b 2f
+.Luser_atomic_or:
+    orr w5, w4, w2
+    b 2f
+.Luser_atomic_and_not:
+    bic w5, w4, w2
+2:
+    stlxr w6, w5, [x0]
+    cbz w6, .Luser_atomic_success
+    subs w7, w7, #1
+    b.ne 1b
+    mov w0, #2
+    dmb ish
+    ret
+.Luser_atomic_success:
+    dmb ish
+    str w4, [x3]
+    mov w0, #0
+    ret
+.Luser_atomic_fault:
+    mov w0, #1
+    ret
+    _asm_nofault_extable 1b, .Luser_atomic_fault
+    _asm_nofault_extable 2b, .Luser_atomic_fault
+.size __axcpu_user_atomic_u32, . - __axcpu_user_atomic_u32

--- a/components/axcpu/src/exception_table.rs
+++ b/components/axcpu/src/exception_table.rs
@@ -7,6 +7,13 @@ struct ExceptionTableEntry {
     to: i32,
 }
 
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq)]
+struct NofaultExceptionTableEntry {
+    from: i32,
+    to: i32,
+}
+
 impl ExceptionTableEntry {
     #[inline]
     fn source_addr(&self) -> usize {
@@ -16,6 +23,18 @@ impl ExceptionTableEntry {
     #[inline]
     fn to_addr(&self) -> usize {
         exception_addr(&self.to)
+    }
+}
+
+impl NofaultExceptionTableEntry {
+    #[inline]
+    fn source_addr(&self) -> usize {
+        nofault_exception_addr(&self.from)
+    }
+
+    #[inline]
+    fn to_addr(&self) -> usize {
+        nofault_exception_addr(&self.to)
     }
 }
 
@@ -49,12 +68,69 @@ fn exception_addr(offset: &i32) -> usize {
     }
 }
 
+#[inline]
+fn nofault_exception_addr(offset: &i32) -> usize {
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "loongarch64",
+        target_arch = "x86_64"
+    ))]
+    {
+        let base = (offset as *const i32) as isize;
+        (base + *offset as isize) as usize
+    }
+
+    #[cfg(any(target_arch = "riscv32", target_arch = "riscv64"))]
+    {
+        let base = unsafe { _nofault_ex_table_start.as_ptr() } as isize;
+        (base + *offset as isize) as usize
+    }
+}
+
 unsafe extern "C" {
     static _ex_table_start: [ExceptionTableEntry; 0];
     static _ex_table_end: [ExceptionTableEntry; 0];
+    static _nofault_ex_table_start: [NofaultExceptionTableEntry; 0];
+    static _nofault_ex_table_end: [NofaultExceptionTableEntry; 0];
 }
 
 impl TrapFrame {
+    pub(crate) fn fixup_nofault_exception(&mut self) -> bool {
+        let entries = unsafe {
+            core::slice::from_raw_parts(
+                _nofault_ex_table_start.as_ptr(),
+                _nofault_ex_table_end
+                    .as_ptr()
+                    .offset_from_unsigned(_nofault_ex_table_start.as_ptr()),
+            )
+        };
+        #[cfg(target_arch = "x86_64")]
+        {
+            match entries
+                .iter()
+                .find(|entry| entry.source_addr() == self.ip())
+            {
+                Some(entry) => {
+                    self.set_ip(entry.to_addr());
+                    true
+                }
+                None => false,
+            }
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        {
+            match entries.binary_search_by_key(&self.ip(), NofaultExceptionTableEntry::source_addr)
+            {
+                Ok(entry) => {
+                    self.set_ip(entries[entry].to_addr());
+                    true
+                }
+                Err(_) => false,
+            }
+        }
+    }
+
     pub(crate) fn fixup_exception(&mut self) -> bool {
         let entries = unsafe {
             core::slice::from_raw_parts(
@@ -103,5 +179,14 @@ pub(crate) fn init_exception_table() {
             )
         };
         ex_table.sort_unstable_by_key(ExceptionTableEntry::source_addr);
+        let nofault_ex_table = unsafe {
+            core::slice::from_raw_parts_mut(
+                _nofault_ex_table_start.as_ptr().cast_mut(),
+                _nofault_ex_table_end
+                    .as_ptr()
+                    .offset_from_unsigned(_nofault_ex_table_start.as_ptr()),
+            )
+        };
+        nofault_ex_table.sort_unstable_by_key(NofaultExceptionTableEntry::source_addr);
     }
 }

--- a/components/axcpu/src/lib.rs
+++ b/components/axcpu/src/lib.rs
@@ -60,7 +60,13 @@ impl KernelTlsBase {
 #[cfg(feature = "exception-table")]
 mod exception_table;
 #[cfg(feature = "uspace")]
+mod user_access;
+#[cfg(feature = "uspace")]
 mod uspace_common;
+#[cfg(feature = "uspace")]
+pub use user_access::{
+    UserAccessError, UserAtomicError, UserAtomicU32Op, user_atomic_u32, user_read_u32,
+};
 
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "x86_64")] {

--- a/components/axcpu/src/loongarch64/asm.rs
+++ b/components/axcpu/src/loongarch64/asm.rs
@@ -142,6 +142,17 @@ pub fn flush_tlb(vaddr: Option<VirtAddr>) {
     }
 }
 
+/// Makes a page-table entry installed by the local page-fault handler visible
+/// before retrying the faulting instruction.
+///
+/// The software refill path may cache a non-readable and non-executable
+/// placeholder for a missing page-table level. Invalidate that local entry so
+/// the retry refills from the newly installed PTE.
+#[inline]
+pub fn update_mmu_cache(vaddr: VirtAddr) {
+    flush_tlb(Some(vaddr));
+}
+
 /// Writes the Exception Entry Base Address register (`EENTRY`).
 ///
 /// It also set the Exception Configuration register (`ECFG`) to `VS=0`.

--- a/components/axcpu/src/loongarch64/asm.rs
+++ b/components/axcpu/src/loongarch64/asm.rs
@@ -232,7 +232,11 @@ pub fn enable_lasx() {
 }
 
 #[cfg(feature = "uspace")]
-core::arch::global_asm!(include_asm_macros!(), include_str!("user_copy.S"));
+core::arch::global_asm!(
+    include_asm_macros!(),
+    include_str!("user_copy.S"),
+    include_str!("user_atomic.S"),
+);
 
 #[cfg(feature = "uspace")]
 unsafe extern "C" {

--- a/components/axcpu/src/loongarch64/trap.rs
+++ b/components/axcpu/src/loongarch64/trap.rs
@@ -96,6 +96,10 @@ fn handle_breakpoint(tf: &mut KernelTrapFrame<'_>) {
 
 fn handle_page_fault(tf: &mut KernelTrapFrame<'_>, access_flags: PageFaultFlags) {
     let vaddr = va!(badv::read().vaddr());
+    #[cfg(feature = "exception-table")]
+    if tf.raw.0.fixup_nofault_exception() {
+        return;
+    }
     if crate::trap::call_page_fault_handler_with_parent_irqs(
         vaddr,
         access_flags,

--- a/components/axcpu/src/loongarch64/user_atomic.S
+++ b/components/axcpu/src/loongarch64/user_atomic.S
@@ -1,0 +1,69 @@
+.macro _asm_nofault_extable from, to
+    .pushsection __nofault_ex_table, "a"
+    .balign 4
+    .word \from - .
+    .word \to - .
+    .popsection
+.endm
+
+.section .text
+.global __axcpu_user_read_u32
+.type __axcpu_user_read_u32, @function
+__axcpu_user_read_u32:
+1:
+    ld.wu $t0, $a0, 0
+    st.w $t0, $a1, 0
+    move $a0, $zero
+    jr $ra
+.Luser_read_fault:
+    addi.w $a0, $zero, 1
+    jr $ra
+    _asm_nofault_extable 1b, .Luser_read_fault
+.size __axcpu_user_read_u32, . - __axcpu_user_read_u32
+
+.global __axcpu_user_atomic_u32
+.type __axcpu_user_atomic_u32, @function
+__axcpu_user_atomic_u32:
+    li.w $t3, 128
+1:
+    ll.w $t0, $a0, 0
+    beqz $a1, .Luser_atomic_set
+    addi.w $t2, $zero, 1
+    beq $a1, $t2, .Luser_atomic_add
+    addi.w $t2, $zero, 2
+    beq $a1, $t2, .Luser_atomic_or
+    addi.w $t2, $zero, 3
+    beq $a1, $t2, .Luser_atomic_and_not
+    xor $t1, $t0, $a2
+    b 2f
+.Luser_atomic_set:
+    move $t1, $a2
+    b 2f
+.Luser_atomic_add:
+    add.w $t1, $t0, $a2
+    b 2f
+.Luser_atomic_or:
+    or $t1, $t0, $a2
+    b 2f
+.Luser_atomic_and_not:
+    nor $t2, $a2, $zero
+    and $t1, $t0, $t2
+2:
+    sc.w $t1, $a0, 0
+    bnez $t1, .Luser_atomic_success
+    addi.w $t3, $t3, -1
+    bnez $t3, 1b
+    dbar 0
+    addi.w $a0, $zero, 2
+    jr $ra
+.Luser_atomic_success:
+    dbar 0
+    st.w $t0, $a3, 0
+    move $a0, $zero
+    jr $ra
+.Luser_atomic_fault:
+    addi.w $a0, $zero, 1
+    jr $ra
+    _asm_nofault_extable 1b, .Luser_atomic_fault
+    _asm_nofault_extable 2b, .Luser_atomic_fault
+.size __axcpu_user_atomic_u32, . - __axcpu_user_atomic_u32

--- a/components/axcpu/src/loongarch64/uspace.rs
+++ b/components/axcpu/src/loongarch64/uspace.rs
@@ -102,10 +102,9 @@ impl UserContext {
                 // user access can also arrive here after the low-level TLB
                 // refill path installs a non-user placeholder entry. Treat it
                 // as a user page fault so the VM layer can populate a lazy user
-                // mapping or reject a real permission violation. Flush the
-                // address first in case the exception came from such an entry
-                // or a stale kernel-only TLB entry for the same VA.
-                crate::asm::flush_tlb(Some(va!(badv)));
+                // mapping or reject a real permission violation. The common
+                // page-fault completion path synchronizes the installed PTE
+                // through `update_mmu_cache` before retrying user mode.
                 ReturnReason::PageFault(va!(badv), PageFaultFlags::USER)
             }
             Trap::Exception(e) => ReturnReason::Exception(ExceptionInfo {

--- a/components/axcpu/src/riscv/asm.rs
+++ b/components/axcpu/src/riscv/asm.rs
@@ -157,7 +157,11 @@ pub unsafe fn write_thread_pointer(tls_base: KernelTlsBase) {
 }
 
 #[cfg(feature = "uspace")]
-core::arch::global_asm!(include_asm_macros!(), include_str!("user_copy.S"));
+core::arch::global_asm!(
+    include_asm_macros!(),
+    include_str!("user_copy.S"),
+    include_str!("user_atomic.S"),
+);
 
 #[cfg(feature = "uspace")]
 unsafe extern "C" {

--- a/components/axcpu/src/riscv/asm.rs
+++ b/components/axcpu/src/riscv/asm.rs
@@ -115,6 +115,16 @@ pub fn flush_tlb(vaddr: Option<VirtAddr>) {
     }
 }
 
+/// Makes a page-table entry installed by the local page-fault handler visible
+/// before retrying the faulting instruction.
+///
+/// RISC-V permits implementations to cache invalid entries, so an `SFENCE.VMA`
+/// is required after turning an invalid entry into a valid one.
+#[inline]
+pub fn update_mmu_cache(vaddr: VirtAddr) {
+    flush_tlb(Some(vaddr));
+}
+
 /// Writes the Supervisor Trap Vector Base Address register (`stvec`).
 ///
 /// # Safety

--- a/components/axcpu/src/riscv/trap.rs
+++ b/components/axcpu/src/riscv/trap.rs
@@ -128,6 +128,10 @@ fn handle_breakpoint(tf: &mut KernelTrapFrame<'_>) {
 
 fn handle_page_fault(tf: &mut KernelTrapFrame<'_>, access_flags: PageFaultFlags) {
     let vaddr = va!(stval::read());
+    #[cfg(feature = "exception-table")]
+    if tf.raw.0.fixup_nofault_exception() {
+        return;
+    }
     if crate::trap::call_page_fault_handler_with_parent_irqs(
         vaddr,
         access_flags,

--- a/components/axcpu/src/riscv/user_atomic.S
+++ b/components/axcpu/src/riscv/user_atomic.S
@@ -1,0 +1,71 @@
+.macro _asm_nofault_extable from, to
+    .pushsection __nofault_ex_table, "a"
+    .balign 4
+    .word \from - _nofault_ex_table_start
+    .word \to - _nofault_ex_table_start
+    .popsection
+.endm
+
+.section .text
+.global __axcpu_user_read_u32
+.type __axcpu_user_read_u32, @function
+__axcpu_user_read_u32:
+1:
+    lw t0, 0(a0)
+    sw t0, 0(a1)
+    li a0, 0
+    ret
+.Luser_read_fault:
+    li a0, 1
+    ret
+    _asm_nofault_extable 1b, .Luser_read_fault
+.size __axcpu_user_read_u32, . - __axcpu_user_read_u32
+
+/*
+ * LLVM validates the ratified A extension as split Zaamo/Zalrsc features,
+ * while Rust's riscv64gc target still advertises the aggregate +a feature.
+ * This routine uses only AMO instructions, so declare that subset locally.
+ */
+.option push
+.option arch, +zaamo
+
+.global __axcpu_user_atomic_u32
+.type __axcpu_user_atomic_u32, @function
+__axcpu_user_atomic_u32:
+    beqz a1, .Luser_atomic_set
+    li t1, 1
+    beq a1, t1, .Luser_atomic_add
+    li t1, 2
+    beq a1, t1, .Luser_atomic_or
+    li t1, 3
+    beq a1, t1, .Luser_atomic_and_not
+.Luser_atomic_xor:
+1:  amoxor.w.aqrl t0, a2, (a0)
+    j .Luser_atomic_success
+.Luser_atomic_set:
+2:  amoswap.w.aqrl t0, a2, (a0)
+    j .Luser_atomic_success
+.Luser_atomic_add:
+3:  amoadd.w.aqrl t0, a2, (a0)
+    j .Luser_atomic_success
+.Luser_atomic_or:
+4:  amoor.w.aqrl t0, a2, (a0)
+    j .Luser_atomic_success
+.Luser_atomic_and_not:
+    not t1, a2
+5:  amoand.w.aqrl t0, t1, (a0)
+.Luser_atomic_success:
+    sw t0, 0(a3)
+    li a0, 0
+    ret
+.Luser_atomic_fault:
+    li a0, 1
+    ret
+    _asm_nofault_extable 1b, .Luser_atomic_fault
+    _asm_nofault_extable 2b, .Luser_atomic_fault
+    _asm_nofault_extable 3b, .Luser_atomic_fault
+    _asm_nofault_extable 4b, .Luser_atomic_fault
+    _asm_nofault_extable 5b, .Luser_atomic_fault
+.size __axcpu_user_atomic_u32, . - __axcpu_user_atomic_u32
+
+.option pop

--- a/components/axcpu/src/user_access.rs
+++ b/components/axcpu/src/user_access.rs
@@ -1,0 +1,89 @@
+//! Nofault access to user-space words.
+
+/// Failure returned by a nofault user read.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UserAccessError {
+    /// The user word was not accessible without resolving a page fault.
+    Fault,
+}
+
+/// Atomic operation supported by [`user_atomic_u32`].
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UserAtomicU32Op {
+    /// Replaces the word with the supplied argument.
+    Set    = 0,
+    /// Adds the supplied argument with wrapping semantics.
+    Add    = 1,
+    /// ORs the word with the supplied argument.
+    Or     = 2,
+    /// ANDs the word with the inverse of the supplied argument.
+    AndNot = 3,
+    /// XORs the word with the supplied argument.
+    Xor    = 4,
+}
+
+/// Failure returned by a nofault user atomic operation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum UserAtomicError {
+    /// The user word was not accessible without resolving a page fault.
+    Fault,
+    /// A bounded load-linked/store-conditional sequence made no progress.
+    Retry,
+}
+
+unsafe extern "C" {
+    fn __axcpu_user_read_u32(address: *const u32, value: *mut u32) -> u32;
+
+    fn __axcpu_user_atomic_u32(
+        address: *mut u32,
+        operation: u32,
+        argument: u32,
+        old_value: *mut u32,
+    ) -> u32;
+}
+
+/// Reads one aligned user-space word without resolving faults.
+///
+/// # Safety
+///
+/// `address` must be aligned for `u32` and point into the calling task's user
+/// address range. The caller must resolve [`UserAccessError::Fault`] only after
+/// releasing every lock whose critical section must remain nofault.
+pub unsafe fn user_read_u32(address: *const u32) -> Result<u32, UserAccessError> {
+    let mut value = 0;
+    let status = unsafe { __axcpu_user_read_u32(address, &mut value) };
+    match status {
+        0 => Ok(value),
+        1 => Err(UserAccessError::Fault),
+        _ => unreachable!("architecture returned an invalid user read status"),
+    }
+}
+
+/// Atomically updates one aligned user-space word without resolving faults.
+///
+/// The previous value is returned on success. A fault is redirected through
+/// the dedicated nofault exception table before the OS page-fault handler is
+/// invoked, so this function never sleeps or allocates.
+///
+/// # Safety
+///
+/// `address` must be aligned for `u32` and point into the calling task's user
+/// address range. The caller must serialize this operation with the protocol
+/// that consumes its result and must resolve [`UserAtomicError::Fault`] only
+/// after releasing every lock whose critical section must remain nofault.
+pub unsafe fn user_atomic_u32(
+    address: *mut u32,
+    operation: UserAtomicU32Op,
+    argument: u32,
+) -> Result<u32, UserAtomicError> {
+    let mut old_value = 0;
+    let status =
+        unsafe { __axcpu_user_atomic_u32(address, operation as u32, argument, &mut old_value) };
+    match status {
+        0 => Ok(old_value),
+        1 => Err(UserAtomicError::Fault),
+        2 => Err(UserAtomicError::Retry),
+        _ => unreachable!("architecture returned an invalid user atomic status"),
+    }
+}

--- a/components/axcpu/src/x86_64/asm.rs
+++ b/components/axcpu/src/x86_64/asm.rs
@@ -115,6 +115,13 @@ pub fn flush_tlb(vaddr: Option<VirtAddr>) {
     }
 }
 
+/// Makes a page-table entry installed by the local page-fault handler visible
+/// before retrying the faulting instruction.
+///
+/// x86 does not cache invalid leaf entries, so the page-table write is enough.
+#[inline]
+pub fn update_mmu_cache(_vaddr: VirtAddr) {}
+
 /// Reads the current kernel task's TLS base (`FS_BASE`).
 ///
 /// It is used to implement TLS (Thread Local Storage).

--- a/components/axcpu/src/x86_64/asm.rs
+++ b/components/axcpu/src/x86_64/asm.rs
@@ -138,7 +138,7 @@ pub unsafe fn write_thread_pointer(kernel_tls: KernelTlsBase) {
 }
 
 #[cfg(feature = "uspace")]
-core::arch::global_asm!(include_str!("user_copy.S"));
+core::arch::global_asm!(include_str!("user_copy.S"), include_str!("user_atomic.S"),);
 
 #[cfg(feature = "uspace")]
 unsafe extern "C" {

--- a/components/axcpu/src/x86_64/local_state.rs
+++ b/components/axcpu/src/x86_64/local_state.rs
@@ -1,0 +1,246 @@
+//! Lazy x86 LinuxCurrent user-TLS ownership.
+
+#[cfg(not(feature = "host-test"))]
+use core::mem::offset_of;
+use core::mem::size_of;
+
+#[cfg(not(feature = "host-test"))]
+use cpu_local::CPU_AREA_ARCH_STATE_OFFSET;
+use cpu_local::CPU_AREA_ARCH_STATE_SIZE;
+
+const IA32_FS_BASE: u32 = 0xc000_0100;
+const IA32_KERNEL_GS_BASE: u32 = 0xc000_0102;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct UserTlsValues {
+    fs_base: usize,
+    gs_base: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct UserTlsWrites {
+    fs_base: bool,
+    gs_base: bool,
+}
+
+/// CPU-owned physical user-TLS image and its publication generation.
+#[repr(C)]
+struct CpuUserTlsState {
+    fs_base: usize,
+    gs_base: usize,
+    generation: usize,
+}
+
+#[cfg(not(feature = "host-test"))]
+const CPU_USER_FS_BASE_OFFSET: usize =
+    CPU_AREA_ARCH_STATE_OFFSET + offset_of!(CpuUserTlsState, fs_base);
+#[cfg(not(feature = "host-test"))]
+const CPU_USER_GS_BASE_OFFSET: usize =
+    CPU_AREA_ARCH_STATE_OFFSET + offset_of!(CpuUserTlsState, gs_base);
+#[cfg(not(feature = "host-test"))]
+const CPU_USER_TLS_GENERATION_OFFSET: usize =
+    CPU_AREA_ARCH_STATE_OFFSET + offset_of!(CpuUserTlsState, generation);
+
+const _: () = assert!(size_of::<CpuUserTlsState>() <= CPU_AREA_ARCH_STATE_SIZE);
+
+fn changed_user_tls(
+    previous: UserTlsValues,
+    next: UserTlsValues,
+    initialized: bool,
+) -> UserTlsWrites {
+    UserTlsWrites {
+        fs_base: !initialized || previous.fs_base != next.fs_base,
+        gs_base: !initialized || previous.gs_base != next.gs_base,
+    }
+}
+
+fn next_generation(previous: usize) -> usize {
+    match previous.wrapping_add(1) {
+        0 => 1,
+        generation => generation,
+    }
+}
+
+#[cfg(not(feature = "host-test"))]
+fn current_cpu_user_tls() -> (UserTlsValues, usize) {
+    let fs_base: usize;
+    let gs_base: usize;
+    let generation: usize;
+    // SAFETY: this runs with local IRQs disabled after the CPU area has been
+    // installed. The three fields are owned by this CPU and no remote path
+    // reads or writes the architecture reserve.
+    unsafe {
+        core::arch::asm!(
+            "mov {fs_base}, gs:[{fs_offset}]",
+            "mov {gs_base}, gs:[{gs_offset}]",
+            "mov {generation}, gs:[{generation_offset}]",
+            fs_base = out(reg) fs_base,
+            gs_base = out(reg) gs_base,
+            generation = out(reg) generation,
+            fs_offset = const CPU_USER_FS_BASE_OFFSET,
+            gs_offset = const CPU_USER_GS_BASE_OFFSET,
+            generation_offset = const CPU_USER_TLS_GENERATION_OFFSET,
+            options(nostack, preserves_flags, readonly),
+        );
+    }
+    (UserTlsValues { fs_base, gs_base }, generation)
+}
+
+#[cfg(feature = "host-test")]
+fn current_cpu_user_tls() -> (UserTlsValues, usize) {
+    (UserTlsValues::default(), 0)
+}
+
+#[cfg(not(feature = "host-test"))]
+fn publish_current_cpu_user_tls(values: UserTlsValues, generation: usize) {
+    // SAFETY: the caller retains the same IRQ-disabled CPU ownership used by
+    // current_cpu_user_tls. Publishing the generation last makes a future
+    // diagnostic reader reject a partially updated cache image.
+    unsafe {
+        core::arch::asm!(
+            "mov gs:[{fs_offset}], {fs_base}",
+            "mov gs:[{gs_offset}], {gs_base}",
+            "mov gs:[{generation_offset}], {generation}",
+            fs_offset = const CPU_USER_FS_BASE_OFFSET,
+            gs_offset = const CPU_USER_GS_BASE_OFFSET,
+            generation_offset = const CPU_USER_TLS_GENERATION_OFFSET,
+            fs_base = in(reg) values.fs_base,
+            gs_base = in(reg) values.gs_base,
+            generation = in(reg) generation,
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+#[cfg(feature = "host-test")]
+fn publish_current_cpu_user_tls(_values: UserTlsValues, _generation: usize) {
+    // Host tests cannot address the kernel GS CPU area.
+}
+
+fn write_changed_user_tls(previous: UserTlsValues, next: UserTlsValues, initialized: bool) {
+    let writes = changed_user_tls(previous, next, initialized);
+    if writes.fs_base {
+        write_user_tls_msr(IA32_FS_BASE, next.fs_base);
+    }
+    if writes.gs_base {
+        write_user_tls_msr(IA32_KERNEL_GS_BASE, next.gs_base);
+    }
+}
+
+#[cfg(not(feature = "host-test"))]
+fn write_user_tls_msr(msr: u32, value: usize) {
+    let value = value as u64;
+    // SAFETY: LinuxCurrent does not use FS for kernel TLS, and SWAPGS keeps
+    // IA32_KERNEL_GS_BASE inactive while Rust executes. The caller holds this
+    // CPU with IRQs disabled, so both writes update only its user return image.
+    unsafe {
+        core::arch::asm!(
+            "wrmsr",
+            in("ecx") msr,
+            in("eax") value as u32,
+            in("edx") (value >> 32) as u32,
+            options(nostack, preserves_flags),
+        );
+    }
+}
+
+#[cfg(feature = "host-test")]
+fn write_user_tls_msr(_msr: u32, _value: usize) {
+    // Host scheduler tests model the decision but cannot execute WRMSR.
+}
+
+/// Establishes the physical reset image before this CPU can enter userspace.
+pub(super) fn initialize_cpu_user_tls() {
+    #[cfg(not(feature = "host-test"))]
+    debug_assert!(!super::asm::irqs_enabled());
+    let values = UserTlsValues::default();
+    write_changed_user_tls(UserTlsValues::default(), values, false);
+    publish_current_cpu_user_tls(values, 1);
+}
+
+/// Lazily installs a user context without disturbing it in kernel-only tasks.
+pub(super) fn install_current_user_tls(fs_base: usize, gs_base: usize) {
+    #[cfg(not(feature = "host-test"))]
+    debug_assert!(!super::asm::irqs_enabled());
+    let (previous, generation) = current_cpu_user_tls();
+    let next = UserTlsValues { fs_base, gs_base };
+    let initialized = generation != 0;
+    let writes = changed_user_tls(previous, next, initialized);
+    if !writes.fs_base && !writes.gs_base {
+        return;
+    }
+    write_changed_user_tls(previous, next, initialized);
+    publish_current_cpu_user_tls(next, next_generation(generation));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unchanged_user_tls_requires_no_msr_write() {
+        let values = UserTlsValues {
+            fs_base: 0x1000,
+            gs_base: 0x2000,
+        };
+        assert_eq!(
+            changed_user_tls(values, values, true),
+            UserTlsWrites {
+                fs_base: false,
+                gs_base: false,
+            }
+        );
+    }
+
+    #[test]
+    fn user_tls_transition_writes_only_the_changed_msr() {
+        let previous = UserTlsValues {
+            fs_base: 0x1000,
+            gs_base: 0x2000,
+        };
+        assert_eq!(
+            changed_user_tls(
+                previous,
+                UserTlsValues {
+                    fs_base: 0x3000,
+                    gs_base: previous.gs_base,
+                },
+                true,
+            ),
+            UserTlsWrites {
+                fs_base: true,
+                gs_base: false,
+            }
+        );
+        assert_eq!(
+            changed_user_tls(
+                previous,
+                UserTlsValues {
+                    fs_base: previous.fs_base,
+                    gs_base: 0x4000,
+                },
+                true,
+            ),
+            UserTlsWrites {
+                fs_base: false,
+                gs_base: true,
+            }
+        );
+    }
+
+    #[test]
+    fn uninitialized_cpu_image_forces_both_register_writes() {
+        assert_eq!(
+            changed_user_tls(UserTlsValues::default(), UserTlsValues::default(), false),
+            UserTlsWrites {
+                fs_base: true,
+                gs_base: true,
+            }
+        );
+    }
+
+    #[test]
+    fn user_tls_generation_remains_a_nonzero_initialized_marker() {
+        assert_eq!(next_generation(usize::MAX), 1);
+    }
+}

--- a/components/axcpu/src/x86_64/mod.rs
+++ b/components/axcpu/src/x86_64/mod.rs
@@ -1,6 +1,8 @@
 mod context;
 mod gdt;
 mod idt;
+#[cfg(feature = "uspace")]
+mod local_state;
 
 pub mod asm;
 pub mod init;

--- a/components/axcpu/src/x86_64/trap.S
+++ b/components/axcpu/src/x86_64/trap.S
@@ -3,8 +3,6 @@
 
 .code64
 .equ NUM_INT, 256
-.equ IA32_FS_BASE, 0xc0000100
-.equ IA32_KERNEL_GS_BASE, 0xc0000102
 
 .altmacro
 .macro DEF_HANDLER, i
@@ -117,30 +115,10 @@ syscall_entry:
 .Lexit_user:
     PUSH_GENERAL_REGS
 
-    # The user register image is complete now, so caller-saved registers may be
-    # used to restore CPU-owned kernel state without corrupting user state.
-    mov     r8, [rsp + {trapframe_size}]
-
-    # After SWAPGS, IA32_KERNEL_GS_BASE contains the user-owned GS base.
-    mov     ecx, IA32_KERNEL_GS_BASE
-    rdmsr
-    shl     rdx, 32
-    or      rax, rdx
-    mov     [rsp + {user_gs_base_offset}], rax
-
-    mov     ecx, IA32_FS_BASE
-    rdmsr
-    shl     rdx, 32
-    or      rax, rdx
-    mov     [rsp + {user_fs_base_offset}], rax
-
-    mov     rax, [rsp + {kernel_fs_base_offset}]
-    mov     rdx, rax
-    shr     rdx, 32
-    mov     ecx, IA32_FS_BASE
-    wrmsr
-
-    # Return to Rust only after the task-owned kernel TLS base is live again.
+    # LinuxCurrent kernels do not own FS and CR4.FSGSBASE is disabled. The
+    # user TLS image therefore remains authoritative across the trap; only GS
+    # is swapped to the CPU area before returning to Rust.
+    mov     r8, [rsp + {kernel_stack_pointer_offset}]
     mov     rsp, r8
     pop     r15
     pop     r14
@@ -159,27 +137,8 @@ enter_user:
     push r13
     push r14
     push r15
-    # Save CPU state and install user-owned TLS inside this assembly-only
-    # window. No Rust executes while IA32_FS_BASE contains a user value.
-    mov     ecx, IA32_FS_BASE
-    rdmsr
-    shl     rdx, 32
-    or      rax, rdx
-    mov     [rdi + {kernel_fs_base_offset}], rax
 
-    mov     rax, [rdi + {user_gs_base_offset}]
-    mov     rdx, rax
-    shr     rdx, 32
-    mov     ecx, IA32_KERNEL_GS_BASE
-    wrmsr
-
-    mov     rax, [rdi + {user_fs_base_offset}]
-    mov     rdx, rax
-    shr     rdx, 32
-    mov     ecx, IA32_FS_BASE
-    wrmsr
-
-    mov [rdi + {trapframe_size}], rsp
+    mov [rdi + {kernel_stack_pointer_offset}], rsp
 
     mov rsp, rdi
     add rdi, {trapframe_size}

--- a/components/axcpu/src/x86_64/trap.rs
+++ b/components/axcpu/src/x86_64/trap.rs
@@ -162,6 +162,14 @@ fn handle_page_fault(tf: &mut KernelTrapFrame<'_>) {
     let access_flags = err_code_to_flags(tf.raw.error_code)
         .unwrap_or_else(|e| panic!("Invalid #PF error code: {:#x}", e));
     let vaddr = va!(unsafe { cr2() });
+    #[cfg(feature = "exception-table")]
+    {
+        let mut updated = tf.snapshot();
+        if updated.fixup_nofault_exception() {
+            tf.apply_registers(&updated);
+            return;
+        }
+    }
     if crate::trap::call_page_fault_handler_with_parent_irqs(
         vaddr,
         access_flags,

--- a/components/axcpu/src/x86_64/trap.rs
+++ b/components/axcpu/src/x86_64/trap.rs
@@ -146,9 +146,8 @@ impl core::fmt::Debug for KernelTrapFrame<'_> {
 core::arch::global_asm!(
     include_str!("trap.S"),
     trapframe_size = const core::mem::size_of::<TrapFrame>(),
-    user_fs_base_offset = const core::mem::size_of::<TrapFrame>(),
-    user_gs_base_offset = const core::mem::size_of::<TrapFrame>() + core::mem::size_of::<u64>(),
-    kernel_fs_base_offset = const core::mem::size_of::<TrapFrame>() + 2 * core::mem::size_of::<u64>(),
+    kernel_stack_pointer_offset = const core::mem::size_of::<TrapFrame>()
+        + 2 * core::mem::size_of::<u64>(),
     UDATA = const gdt::UDATA.0,
     UCODE64 = const gdt::UCODE64.0,
     SYSCALL_VECTOR = const LEGACY_SYSCALL_VECTOR,

--- a/components/axcpu/src/x86_64/user_atomic.S
+++ b/components/axcpu/src/x86_64/user_atomic.S
@@ -1,0 +1,103 @@
+.macro _asm_nofault_extable from, to
+    .pushsection __nofault_ex_table, "a"
+    .balign 4
+    .long \from - .
+    .long \to - .
+    .popsection
+.endm
+
+.section .text
+.global __axcpu_user_read_u32
+.type __axcpu_user_read_u32, @function
+__axcpu_user_read_u32:
+.Luser_read:
+    mov eax, dword ptr [rdi]
+    mov dword ptr [rsi], eax
+    xor eax, eax
+    ret
+.Luser_read_fault:
+    mov eax, 1
+    ret
+    _asm_nofault_extable .Luser_read, .Luser_read_fault
+.size __axcpu_user_read_u32, . - __axcpu_user_read_u32
+
+.global __axcpu_user_atomic_u32
+.type __axcpu_user_atomic_u32, @function
+__axcpu_user_atomic_u32:
+    mov r8, rcx
+    cmp esi, 0
+    je .Luser_atomic_set
+    cmp esi, 1
+    je .Luser_atomic_add
+    cmp esi, 2
+    je .Luser_atomic_or
+    cmp esi, 3
+    je .Luser_atomic_and_not
+    mov r10d, 128
+.Luser_atomic_xor_load:
+    mov eax, dword ptr [rdi]
+.Luser_atomic_xor_retry:
+    mov r9d, eax
+    xor r9d, edx
+.Luser_atomic_xor_cmpxchg:
+    lock cmpxchg dword ptr [rdi], r9d
+    jz .Luser_atomic_success
+    dec r10d
+    jnz .Luser_atomic_xor_retry
+    jmp .Luser_atomic_retry
+.Luser_atomic_set:
+    mov eax, edx
+.Luser_atomic_set_xchg:
+    xchg dword ptr [rdi], eax
+    jmp .Luser_atomic_success
+.Luser_atomic_add:
+    mov eax, edx
+.Luser_atomic_add_xadd:
+    lock xadd dword ptr [rdi], eax
+    jmp .Luser_atomic_success
+.Luser_atomic_or:
+    mov r10d, 128
+.Luser_atomic_or_load:
+    mov eax, dword ptr [rdi]
+.Luser_atomic_or_retry:
+    mov r9d, eax
+    or r9d, edx
+.Luser_atomic_or_cmpxchg:
+    lock cmpxchg dword ptr [rdi], r9d
+    jz .Luser_atomic_success
+    dec r10d
+    jnz .Luser_atomic_or_retry
+    jmp .Luser_atomic_retry
+.Luser_atomic_and_not:
+    not edx
+    mov r10d, 128
+.Luser_atomic_and_not_load:
+    mov eax, dword ptr [rdi]
+.Luser_atomic_and_not_retry:
+    mov r9d, eax
+    and r9d, edx
+.Luser_atomic_and_not_cmpxchg:
+    lock cmpxchg dword ptr [rdi], r9d
+    jz .Luser_atomic_success
+    dec r10d
+    jnz .Luser_atomic_and_not_retry
+    jmp .Luser_atomic_retry
+.Luser_atomic_success:
+    mov dword ptr [r8], eax
+    xor eax, eax
+    ret
+.Luser_atomic_fault:
+    mov eax, 1
+    ret
+.Luser_atomic_retry:
+    mov eax, 2
+    ret
+    _asm_nofault_extable .Luser_atomic_xor_load, .Luser_atomic_fault
+    _asm_nofault_extable .Luser_atomic_xor_cmpxchg, .Luser_atomic_fault
+    _asm_nofault_extable .Luser_atomic_set_xchg, .Luser_atomic_fault
+    _asm_nofault_extable .Luser_atomic_add_xadd, .Luser_atomic_fault
+    _asm_nofault_extable .Luser_atomic_or_load, .Luser_atomic_fault
+    _asm_nofault_extable .Luser_atomic_or_cmpxchg, .Luser_atomic_fault
+    _asm_nofault_extable .Luser_atomic_and_not_load, .Luser_atomic_fault
+    _asm_nofault_extable .Luser_atomic_and_not_cmpxchg, .Luser_atomic_fault
+.size __axcpu_user_atomic_u32, . - __axcpu_user_atomic_u32

--- a/components/axcpu/src/x86_64/uspace.rs
+++ b/components/axcpu/src/x86_64/uspace.rs
@@ -8,7 +8,7 @@ use core::{
 use ax_memory_addr::VirtAddr;
 use x86_64::{
     registers::{
-        control::Cr2,
+        control::{Cr2, Cr4, Cr4Flags},
         model_specific::{Efer, EferFlags, LStar, SFMask, Star},
         rflags::RFlags,
     },
@@ -26,12 +26,17 @@ pub use crate::uspace_common::{ExceptionKind, ExceptionSyndrome, ReturnReason};
 #[repr(C, align(16))]
 pub struct UserContext {
     tf: TrapFrame,
-    /// FS Segment Base
+    /// User-owned FS segment base.
+    ///
+    /// `CR4.FSGSBASE` stays disabled, so userspace cannot modify this value
+    /// without an `arch_prctl`-style kernel operation updating this image.
     pub fs_base: u64,
-    /// GS Segment Base
+    /// User-owned GS segment base.
     pub gs_base: u64,
-    /// Kernel FS base saved and restored exclusively by `enter_user`.
-    kernel_fs_base: u64,
+    /// Kernel continuation stack saved while this context executes in ring 3.
+    kernel_stack_pointer: u64,
+    /// Explicitly initialized tail required by the 16-byte ABI alignment.
+    _reserved: u64,
 }
 
 const _: () = {
@@ -45,8 +50,11 @@ const _: () = {
     assert!(offset_of!(UserContext, fs_base) == size_of::<TrapFrame>());
     assert!(offset_of!(UserContext, gs_base) == size_of::<TrapFrame>() + size_of::<u64>());
     assert!(
-        offset_of!(UserContext, kernel_fs_base) == size_of::<TrapFrame>() + 2 * size_of::<u64>()
+        offset_of!(UserContext, kernel_stack_pointer)
+            == size_of::<TrapFrame>() + 2 * size_of::<u64>()
     );
+    assert!(offset_of!(UserContext, _reserved) == size_of::<TrapFrame>() + 3 * size_of::<u64>());
+    assert!(size_of::<UserContext>() == size_of::<TrapFrame>() + 4 * size_of::<u64>());
 };
 
 impl UserContext {
@@ -66,7 +74,8 @@ impl UserContext {
             },
             fs_base: 0,
             gs_base: 0,
-            kernel_fs_base: 0,
+            kernel_stack_pointer: 0,
+            _reserved: 0,
         }
     }
 
@@ -119,6 +128,7 @@ impl UserContext {
         assert_eq!(self.ss, gdt::UDATA.0 as _);
 
         crate::asm::disable_irqs();
+        super::local_state::install_current_user_tls(self.fs_base as _, self.gs_base as _);
 
         unsafe { enter_user(self) };
 
@@ -208,6 +218,11 @@ pub(super) fn init_syscall() {
         fn syscall_entry();
     }
 
+    assert!(
+        !Cr4::read().contains(Cr4Flags::FSGSBASE),
+        "LinuxCurrent user TLS requires trapping all FS/GS base changes"
+    );
+    super::local_state::initialize_cpu_user_tls();
     LStar::write(x86_64::VirtAddr::new_truncate(
         syscall_entry as *const () as usize as _,
     ));

--- a/components/axcpu/tests/typed_trapframe_boundary.rs
+++ b/components/axcpu/tests/typed_trapframe_boundary.rs
@@ -130,22 +130,6 @@ fn public_api_exposes_user_registers_but_not_the_internal_trap_layout() {
     }
 }
 
-#[test]
-fn x86_user_tls_changes_are_confined_to_the_assembly_entry_window() {
-    let user = read_source("x86_64/uspace.rs");
-    let run = function_body(&user, "pub fn run");
-    assert!(!run.contains("write_user_thread_pointer"));
-    assert!(!run.contains("write_thread_pointer"));
-    assert!(!run.contains("KernelGsBase::write"));
-    assert!(!run.contains("KernelGsBase::read"));
-
-    let entry = read_source("x86_64/trap.S");
-    assert!(entry.contains("IA32_FS_BASE"));
-    assert!(entry.contains("IA32_KERNEL_GS_BASE"));
-    assert!(entry.contains("user_fs_base_offset"));
-    assert!(entry.contains("kernel_fs_base_offset"));
-}
-
 #[cfg(all(target_arch = "x86_64", feature = "uspace"))]
 #[test]
 fn x86_user_context_keeps_the_tss_trap_stack_top_aligned() {

--- a/os/StarryOS/kernel/src/axtest_exports.rs
+++ b/os/StarryOS/kernel/src/axtest_exports.rs
@@ -400,6 +400,21 @@ pub fn futex_op_and_compare_rules_hold() -> bool {
     super::syscall::futex_op_and_compare_rules_hold_for_test()
 }
 
+pub fn nofault_user_read_recovers_unmapped_address() -> bool {
+    // SAFETY: the address is aligned and belongs to the configured user range.
+    // The test intentionally leaves it unmapped to exercise exception fixup.
+    matches!(
+        unsafe {
+            ax_runtime::hal::cpu::user_read_u32(super::config::USER_SPACE_BASE as *const u32)
+        },
+        Err(ax_runtime::hal::cpu::UserAccessError::Fault)
+    )
+}
+
+pub fn futex_nofault_failure_is_transactional() -> bool {
+    super::task::futex_nofault_failure_is_transactional_for_test()
+}
+
 pub fn mmap_capped_device_map_len_rules_hold() -> bool {
     super::syscall::mmap_capped_device_map_len_rules_hold_for_test()
 }

--- a/os/StarryOS/kernel/src/axtest_exports.rs
+++ b/os/StarryOS/kernel/src/axtest_exports.rs
@@ -415,6 +415,11 @@ pub fn futex_nofault_failure_is_transactional() -> bool {
     super::task::futex_nofault_failure_is_transactional_for_test()
 }
 
+pub fn page_fault_completion_updates_only_success() -> bool {
+    super::mm::page_fault_completion_updates_only_success_for_test()
+        && ax_runtime::hal::cache::update_mmu_cache_alignment_for_test()
+}
+
 pub fn mmap_capped_device_map_len_rules_hold() -> bool {
     super::syscall::mmap_capped_device_map_len_rules_hold_for_test()
 }

--- a/os/StarryOS/kernel/src/mm/access.rs
+++ b/os/StarryOS/kernel/src/mm/access.rs
@@ -3,7 +3,7 @@ use core::{
     alloc::Layout,
     ffi::c_char,
     hint::{spin_loop, unlikely},
-    mem::{MaybeUninit, transmute},
+    mem::{MaybeUninit, size_of, transmute},
     ptr, slice,
     sync::atomic::{AtomicU32, AtomicU64, Ordering},
 };
@@ -12,8 +12,10 @@ use ax_io::{IoError, prelude::*};
 use ax_memory_addr::{MemoryAddr, VirtAddr};
 use ax_runtime::hal::{
     cpu::{
+        UserAccessError, UserAtomicError, UserAtomicU32Op,
         asm::user_copy,
         trap::{PageFaultFlags, page_fault_handler},
+        user_atomic_u32, user_read_u32,
     },
     paging::MappingFlags,
 };
@@ -169,6 +171,63 @@ pub fn atomic_update_user_u32(
             }
         }
     })
+}
+
+/// Atomically updates a futex word without invoking the page-fault handler.
+pub fn atomic_update_user_u32_nofault(
+    ptr: *mut u32,
+    operation: UserAtomicU32Op,
+    argument: u32,
+) -> Result<u32, UserAtomicError> {
+    if ax_runtime::hal::irq::in_irq_context()
+        || !ptr.addr().is_multiple_of(size_of::<u32>())
+        || check_access(ptr.addr(), size_of::<u32>()).is_err()
+    {
+        return Err(UserAtomicError::Fault);
+    }
+
+    // SAFETY: the checks above establish alignment and the architecture user
+    // range contract. A concurrent mapping change is redirected through the
+    // dedicated nofault exception table.
+    unsafe { user_atomic_u32(ptr, operation, argument) }
+}
+
+/// Reads a futex word without invoking the page-fault handler.
+pub fn read_user_u32_nofault(ptr: *const u32) -> Result<u32, UserAccessError> {
+    if ax_runtime::hal::irq::in_irq_context()
+        || !ptr.addr().is_multiple_of(size_of::<u32>())
+        || check_access(ptr.addr(), size_of::<u32>()).is_err()
+    {
+        return Err(UserAccessError::Fault);
+    }
+
+    // SAFETY: the checks above establish alignment and the architecture user
+    // range contract. A concurrent mapping change is redirected through the
+    // dedicated nofault exception table.
+    unsafe { user_read_u32(ptr) }
+}
+
+/// Resolves and validates a readable futex word outside futex queue locks.
+pub fn fault_in_user_u32_read(ptr: *const u32) -> StarryResult<()> {
+    fault_in_user_u32(ptr.addr(), MappingFlags::READ)
+}
+
+/// Resolves and validates a writable futex word outside futex queue locks.
+pub fn fault_in_user_u32_write(ptr: *mut u32) -> StarryResult<()> {
+    fault_in_user_u32(ptr.addr(), MappingFlags::READ.union(MappingFlags::WRITE))
+}
+
+fn fault_in_user_u32(address: usize, access_flags: MappingFlags) -> StarryResult<()> {
+    if !address.is_multiple_of(size_of::<u32>()) {
+        return Err(StarryError::InvalidInput);
+    }
+    prepare_user_memory(
+        "fault in futex word",
+        address,
+        size_of::<u32>(),
+        access_flags,
+    )
+    .map_err(Into::into)
 }
 
 /// An immutable pointer to user space memory.

--- a/os/StarryOS/kernel/src/mm/aspace/mod.rs
+++ b/os/StarryOS/kernel/src/mm/aspace/mod.rs
@@ -21,6 +21,17 @@ use crate::{
     sync::{LockdepMutexExt, Mutex},
 };
 
+fn complete_page_fault_with(
+    handled: bool,
+    vaddr: VirtAddr,
+    update_mmu_cache: impl FnOnce(VirtAddr),
+) -> bool {
+    if handled {
+        update_mmu_cache(vaddr);
+    }
+    handled
+}
+
 mod accounting;
 mod backend;
 
@@ -607,7 +618,7 @@ impl AddrSpace {
                     Some(&self.rss),
                     &mut self.pt,
                 );
-                return match populate_result {
+                let handled = match populate_result {
                     Ok((n, callback)) => {
                         if let Some(cb) = callback {
                             cb(self);
@@ -624,6 +635,11 @@ impl AddrSpace {
                         false
                     }
                 };
+                return complete_page_fault_with(
+                    handled,
+                    vaddr,
+                    ax_runtime::hal::cache::update_mmu_cache,
+                );
             }
         }
         false
@@ -731,6 +747,23 @@ impl AddrSpace {
         }
         result
     }
+}
+
+#[cfg(axtest)]
+pub(crate) fn page_fault_completion_updates_only_success_for_test() -> bool {
+    use core::cell::Cell;
+
+    let calls = Cell::new(0);
+    let observed = Cell::new(VirtAddr::from(0));
+    let success = complete_page_fault_with(true, VirtAddr::from(0x4567), |vaddr| {
+        calls.set(calls.get() + 1);
+        observed.set(vaddr);
+    });
+    let rejected = complete_page_fault_with(false, VirtAddr::from(0x89ab), |_| {
+        calls.set(calls.get() + 1);
+    });
+
+    success && !rejected && calls.get() == 1 && observed.get() == VirtAddr::from(0x4567)
 }
 
 /// Increment how many [`crate::task::ProcessData`] slots refer to `aspace`.

--- a/os/StarryOS/kernel/src/syscall/sync/futex.rs
+++ b/os/StarryOS/kernel/src/syscall/sync/futex.rs
@@ -1,6 +1,9 @@
 use core::mem::align_of;
 
-use ax_runtime::hal::time::{TimeValue, monotonic_time, wall_time};
+use ax_runtime::hal::{
+    cpu::{UserAccessError, UserAtomicError, UserAtomicU32Op},
+    time::{TimeValue, monotonic_time, wall_time},
+};
 use ax_task::current;
 use linux_raw_sys::general::{
     FUTEX_CLOCK_REALTIME, FUTEX_CMP_REQUEUE, FUTEX_OP_ADD, FUTEX_OP_ANDN, FUTEX_OP_CMP_EQ,
@@ -12,8 +15,14 @@ use starry_vm::{VmMutPtr, VmPtr};
 
 use crate::{
     StarryError, StarryResult,
-    mm::atomic_update_user_u32,
-    task::{AsThread, FutexKey, FutexKeyMode, TidNumber, futex_table_for, get_user_task_by_number},
+    mm::{
+        atomic_update_user_u32_nofault, fault_in_user_u32_read, fault_in_user_u32_write,
+        read_user_u32_nofault,
+    },
+    task::{
+        AsThread, FutexAccessError, FutexKey, FutexKeyMode, TidNumber, futex_table_for,
+        get_user_task_by_number, retry_futex_nofault,
+    },
     time::TimeValueLike,
 };
 
@@ -66,6 +75,7 @@ fn futex_wake_op_arg(raw_op: u32, encoded_op: u32) -> i32 {
     oparg
 }
 
+#[cfg(axtest)]
 fn apply_futex_wake_op(old_value: u32, raw_op: u32, oparg: i32) -> StarryResult<u32> {
     let op = raw_op & !FUTEX_OP_OPARG_SHIFT;
     let new_value = match op {
@@ -93,20 +103,66 @@ fn compare_futex_wake_op(old_value: u32, raw_cmp: u32, cmparg: i32) -> StarryRes
     Ok(matched)
 }
 
-fn futex_atomic_op_in_user(uaddr: *mut u32, encoded_op: u32) -> StarryResult<bool> {
+struct ParsedFutexWakeOp {
+    operation: UserAtomicU32Op,
+    argument: u32,
+    raw_cmp: u32,
+    cmparg: i32,
+}
+
+fn parse_futex_wake_op(encoded_op: u32) -> StarryResult<ParsedFutexWakeOp> {
+    let raw_op = (encoded_op >> 28) & 0xf;
+    let operation = match raw_op & !FUTEX_OP_OPARG_SHIFT {
+        FUTEX_OP_SET => UserAtomicU32Op::Set,
+        FUTEX_OP_ADD => UserAtomicU32Op::Add,
+        FUTEX_OP_OR => UserAtomicU32Op::Or,
+        FUTEX_OP_ANDN => UserAtomicU32Op::AndNot,
+        FUTEX_OP_XOR => UserAtomicU32Op::Xor,
+        _ => return Err(StarryError::Unsupported),
+    };
+    let raw_cmp = (encoded_op >> 24) & 0xf;
+    if !matches!(
+        raw_cmp,
+        FUTEX_OP_CMP_EQ
+            | FUTEX_OP_CMP_NE
+            | FUTEX_OP_CMP_LT
+            | FUTEX_OP_CMP_LE
+            | FUTEX_OP_CMP_GT
+            | FUTEX_OP_CMP_GE
+    ) {
+        return Err(StarryError::Unsupported);
+    }
+    Ok(ParsedFutexWakeOp {
+        operation,
+        argument: futex_wake_op_arg(raw_op, encoded_op) as u32,
+        raw_cmp,
+        cmparg: sign_extend_12(encoded_op & 0xfff),
+    })
+}
+
+fn futex_atomic_op_in_user_nofault(
+    uaddr: *mut u32,
+    operation: &ParsedFutexWakeOp,
+) -> Result<bool, FutexAccessError> {
     if !uaddr.addr().is_multiple_of(align_of::<u32>()) {
-        return Err(StarryError::InvalidInput);
+        return Err(FutexAccessError::Operation(StarryError::InvalidInput));
     }
 
-    let raw_op = (encoded_op >> 28) & 0xf;
-    let raw_cmp = (encoded_op >> 24) & 0xf;
-    let oparg = futex_wake_op_arg(raw_op, encoded_op);
-    let cmparg = sign_extend_12(encoded_op & 0xfff);
+    let old_value =
+        match atomic_update_user_u32_nofault(uaddr, operation.operation, operation.argument) {
+            Ok(value) => value,
+            Err(UserAtomicError::Fault) => return Err(FutexAccessError::Fault),
+            Err(UserAtomicError::Retry) => return Err(FutexAccessError::Retry),
+        };
+    compare_futex_wake_op(old_value, operation.raw_cmp, operation.cmparg)
+        .map_err(FutexAccessError::Operation)
+}
 
-    let old_value = atomic_update_user_u32(uaddr, |old_value| {
-        apply_futex_wake_op(old_value, raw_op, oparg)
-    })?;
-    compare_futex_wake_op(old_value, raw_cmp, cmparg)
+fn futex_value_matches_nofault(uaddr: *const u32, expected: u32) -> Result<bool, FutexAccessError> {
+    match read_user_u32_nofault(uaddr) {
+        Ok(value) => Ok(value == expected),
+        Err(UserAccessError::Fault) => Err(FutexAccessError::Fault),
+    }
 }
 
 fn parse_futex_op(futex_op: u32) -> StarryResult<ParsedFutexOp> {
@@ -218,12 +274,18 @@ pub fn sys_futex(
                 u32::MAX
             };
 
-            if !futex
-                .wq
-                .wait_if_with_cleanup(bitset, timeout, Some(cleanup), || {
-                    uaddr.vm_read() == Ok(value)
-                })?
-            {
+            let waited = retry_futex_nofault(
+                || {
+                    futex.wq.wait_if_with_cleanup_nofault(
+                        bitset,
+                        timeout,
+                        Some(cleanup.clone()),
+                        || futex_value_matches_nofault(uaddr, value),
+                    )
+                },
+                || fault_in_user_u32_read(uaddr),
+            )?;
+            if !waited {
                 return Err(StarryError::WouldBlock);
             }
 
@@ -259,26 +321,33 @@ pub fn sys_futex(
             let target = table2.get_or_insert(&key2);
             let target_cleanup = table2.cleanup_for(&key2);
 
-            let Some(source) = futex_table.get(&key) else {
-                if op.command == FutexCommand::CmpRequeue && uaddr.vm_read()? != value3 {
-                    return Err(StarryError::WouldBlock);
-                }
-                return Ok(0);
-            };
-
-            let count = source.wq.wake_requeue_if(
-                wake_count,
-                u32::MAX,
-                requeue_count,
-                target_cleanup,
-                &target.wq,
+            let count = retry_futex_nofault(
                 || {
-                    if op.command == FutexCommand::CmpRequeue {
-                        Ok(uaddr.vm_read()? == value3)
-                    } else {
-                        Ok(true)
-                    }
+                    let Some(source) = futex_table.get(&key) else {
+                        return if op.command == FutexCommand::CmpRequeue {
+                            futex_value_matches_nofault(uaddr, value3)
+                                .map(|matches| if matches { Some(0) } else { None })
+                        } else {
+                            Ok(Some(0))
+                        };
+                    };
+
+                    source.wq.wake_requeue_if(
+                        wake_count,
+                        u32::MAX,
+                        requeue_count,
+                        target_cleanup.clone(),
+                        &target.wq,
+                        || {
+                            if op.command == FutexCommand::CmpRequeue {
+                                futex_value_matches_nofault(uaddr, value3)
+                            } else {
+                                Ok(true)
+                            }
+                        },
+                    )
                 },
+                || fault_in_user_u32_read(uaddr),
             )?;
 
             let Some(count) = count else {
@@ -293,16 +362,22 @@ pub fn sys_futex(
         FutexCommand::WakeOp => {
             let wake_count = value as usize;
             let wake2_count = timeout.addr();
+            let operation = parse_futex_wake_op(value3)?;
             validate_futex_word(uaddr)?;
 
             let key2 = FutexKey::new_current(uaddr2.addr(), op.key_mode);
             let table2 = futex_table_for(&key2);
 
-            let source = futex_table.get_or_insert(&key);
-            let target = table2.get_or_insert(&key2);
-            let count = source.wq.wake_op(wake_count, &target.wq, wake2_count, || {
-                futex_atomic_op_in_user(uaddr2, value3)
-            })?;
+            let count = retry_futex_nofault(
+                || {
+                    let source = futex_table.get_or_insert(&key);
+                    let target = table2.get_or_insert(&key2);
+                    source.wq.wake_op(wake_count, &target.wq, wake2_count, || {
+                        futex_atomic_op_in_user_nofault(uaddr2, &operation)
+                    })
+                },
+                || fault_in_user_u32_write(uaddr2),
+            )?;
 
             if count > 0 {
                 ax_task::yield_now();

--- a/os/StarryOS/kernel/src/task/futex.rs
+++ b/os/StarryOS/kernel/src/task/futex.rs
@@ -23,13 +23,44 @@ use ax_task::{
 use hashbrown::HashMap;
 
 use crate::{
-    StarryResult,
+    StarryError, StarryResult,
     mm::{AddrSpace, Backend, SharedPages},
     sync::{LockdepMutexExt, Mutex},
     task::{AsThread, ProcessData},
 };
 
 const NESTED_WAIT_QUEUE_LOCK_SUBCLASS: u32 = 1;
+
+/// Result of a user-memory operation performed while futex queues are locked.
+pub enum FutexAccessError {
+    /// The user mapping must be faulted in after releasing the queue locks.
+    Fault,
+    /// A bounded architecture atomic sequence must be retried later.
+    Retry,
+    /// The futex operation failed independently of user-memory residency.
+    Operation(StarryError),
+}
+
+/// Retries one futex operation whose locked section may only use nofault user
+/// access.
+///
+/// `operation` must release all futex queue locks before returning an error.
+/// Page population is therefore performed by `fault_in` only after the locked
+/// transaction has aborted without queue side effects.
+pub fn retry_futex_nofault<T>(
+    mut operation: impl FnMut() -> Result<T, FutexAccessError>,
+    mut fault_in: impl FnMut() -> StarryResult<()>,
+) -> StarryResult<T> {
+    loop {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(FutexAccessError::Fault) => fault_in()?,
+            Err(FutexAccessError::Retry) => {}
+            Err(FutexAccessError::Operation(error)) => return Err(error),
+        }
+        ax_task::yield_now();
+    }
+}
 
 /// Wait queue used by futex.
 #[derive(Default)]
@@ -94,15 +125,15 @@ struct WaitIfFuture<'a, F> {
     state: Option<Arc<WaiterState>>,
 }
 
-impl<F: FnOnce() -> bool + Unpin> Future for WaitIfFuture<'_, F> {
-    type Output = StarryResult<bool>;
+impl<F: FnOnce() -> Result<bool, FutexAccessError> + Unpin> Future for WaitIfFuture<'_, F> {
+    type Output = Result<bool, FutexAccessError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut core::task::Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 
         if let Some(condition) = this.condition.take() {
             let mut inner = this.queue.inner.lock();
-            if !condition() {
+            if !condition()? {
                 return Poll::Ready(Ok(false));
             }
 
@@ -185,7 +216,24 @@ impl WaitQueue {
         cleanup: Option<FutexWaitCleanup>,
         condition: impl FnOnce() -> bool + Unpin,
     ) -> StarryResult<bool> {
-        block_on(interruptible(future::timeout(
+        match self.wait_if_with_cleanup_nofault(bitset, timeout, cleanup, || Ok(condition())) {
+            Ok(waited) => Ok(waited),
+            Err(FutexAccessError::Operation(error)) => Err(error),
+            Err(FutexAccessError::Fault | FutexAccessError::Retry) => {
+                unreachable!("infallible wait condition returned a user access error")
+            }
+        }
+    }
+
+    /// Waits after checking a nofault condition while holding the queue lock.
+    pub fn wait_if_with_cleanup_nofault(
+        &self,
+        bitset: u32,
+        timeout: Option<Duration>,
+        cleanup: Option<FutexWaitCleanup>,
+        condition: impl FnOnce() -> Result<bool, FutexAccessError> + Unpin,
+    ) -> Result<bool, FutexAccessError> {
+        let timed = block_on(interruptible(future::timeout(
             timeout,
             WaitIfFuture {
                 queue: self,
@@ -194,7 +242,9 @@ impl WaitQueue {
                 condition: Some(condition),
                 state: None,
             },
-        )))??
+        )))
+        .map_err(|error| FutexAccessError::Operation(error.into()))?;
+        timed.map_err(|error| FutexAccessError::Operation(error.into()))?
     }
 
     fn wake_locked(queue: &mut VecDeque<Waiter>, count: usize, mask: u32, wakers: &mut Vec<Waker>) {
@@ -234,8 +284,8 @@ impl WaitQueue {
         wake_count: usize,
         target: &WaitQueue,
         wake2_count: usize,
-        condition: impl FnOnce() -> StarryResult<bool>,
-    ) -> StarryResult<usize> {
+        condition: impl FnOnce() -> Result<bool, FutexAccessError>,
+    ) -> Result<usize, FutexAccessError> {
         let mut condition = Some(condition);
         let mut wakers = Vec::new();
 
@@ -324,8 +374,8 @@ impl WaitQueue {
         requeue_count: usize,
         target_cleanup: FutexWaitCleanup,
         target: &WaitQueue,
-        condition: impl FnOnce() -> StarryResult<bool>,
-    ) -> StarryResult<Option<usize>> {
+        condition: impl FnOnce() -> Result<bool, FutexAccessError>,
+    ) -> Result<Option<usize>, FutexAccessError> {
         let mut condition = Some(condition);
         let mut wakers = Vec::new();
 
@@ -627,6 +677,87 @@ impl Drop for FutexGuard<'_> {
             bucket.remove(&self.key);
         }
     }
+}
+
+#[cfg(axtest)]
+pub(crate) fn futex_nofault_failure_is_transactional_for_test() -> bool {
+    use core::{cell::Cell, task::Context};
+
+    let wait_queue = WaitQueue::new();
+    let mut wait = alloc::boxed::Box::pin(WaitIfFuture {
+        queue: &wait_queue,
+        bitset: u32::MAX,
+        cleanup: None,
+        condition: Some(|| Err(FutexAccessError::Fault)),
+        state: None,
+    });
+    let mut context = Context::from_waker(Waker::noop());
+    if !matches!(
+        wait.as_mut().poll(&mut context),
+        Poll::Ready(Err(FutexAccessError::Fault))
+    ) || !wait_queue.is_empty()
+    {
+        return false;
+    }
+
+    let source = WaitQueue::new();
+    let target = WaitQueue::new();
+    let state = Arc::new(WaiterState::new(None));
+    source.inner.lock().queue.push_back(Waiter {
+        waker: Waker::noop().clone(),
+        bitset: u32::MAX,
+        state: state.clone(),
+    });
+
+    if !matches!(
+        source.wake_op(1, &target, 1, || Err(FutexAccessError::Fault)),
+        Err(FutexAccessError::Fault)
+    ) || source.inner.lock().queue.len() != 1
+        || state.woken.load(AtomicOrdering::SeqCst)
+    {
+        return false;
+    }
+
+    let target_cleanup = FutexWaitCleanup {
+        table: Arc::new(FutexTable::new()),
+        key: 0x2000,
+    };
+    if !matches!(
+        source.wake_requeue_if(1, u32::MAX, 1, target_cleanup, &target, || {
+            Err(FutexAccessError::Retry)
+        }),
+        Err(FutexAccessError::Retry)
+    ) || source.inner.lock().queue.len() != 1
+        || !target.is_empty()
+        || state.woken.load(AtomicOrdering::SeqCst)
+    {
+        return false;
+    }
+
+    let attempts = Cell::new(0);
+    let fault_in_unlocked = Cell::new(false);
+    let result = retry_futex_nofault(
+        || {
+            attempts.set(attempts.get() + 1);
+            if attempts.get() == 1 {
+                source.wake_op(0, &target, 0, || Err(FutexAccessError::Fault))
+            } else {
+                source.wake_op(0, &target, 0, || Ok(false))
+            }
+        },
+        || {
+            let source_unlocked = !unsafe { source.inner.raw() }.is_owned_by_current();
+            let target_unlocked = !unsafe { target.inner.raw() }.is_owned_by_current();
+            fault_in_unlocked.set(source_unlocked && target_unlocked);
+            Ok(())
+        },
+    );
+
+    matches!(result, Ok(0))
+        && attempts.get() == 2
+        && fault_in_unlocked.get()
+        && source.inner.lock().queue.len() == 1
+        && !state.woken.load(AtomicOrdering::SeqCst)
 }
 
 struct FutexTables {

--- a/os/StarryOS/kernel/tests/cases/axtest_memory.rs
+++ b/os/StarryOS/kernel/tests/cases/axtest_memory.rs
@@ -2,6 +2,11 @@ use axtest::prelude::*;
 use starry_kernel::axtest_exports;
 
 #[axtest]
+fn nofault_user_read_recovers_unmapped_address() {
+    ax_assert!(axtest_exports::nofault_user_read_recovers_unmapped_address());
+}
+
+#[axtest]
 fn process_mem_stats_formats_linux_fields() {
     ax_assert!(axtest_exports::process_mem_stats_formats_linux_fields());
 }

--- a/os/StarryOS/kernel/tests/cases/axtest_memory.rs
+++ b/os/StarryOS/kernel/tests/cases/axtest_memory.rs
@@ -7,6 +7,11 @@ fn nofault_user_read_recovers_unmapped_address() {
 }
 
 #[axtest]
+fn page_fault_completion_updates_only_success() {
+    ax_assert!(axtest_exports::page_fault_completion_updates_only_success());
+}
+
+#[axtest]
 fn process_mem_stats_formats_linux_fields() {
     ax_assert!(axtest_exports::process_mem_stats_formats_linux_fields());
 }

--- a/os/StarryOS/kernel/tests/cases/axtest_syscall.rs
+++ b/os/StarryOS/kernel/tests/cases/axtest_syscall.rs
@@ -127,6 +127,11 @@ fn futex_op_and_compare_rules_hold() {
 }
 
 #[axtest]
+fn futex_nofault_failure_is_transactional() {
+    ax_assert!(axtest_exports::futex_nofault_failure_is_transactional());
+}
+
+#[axtest]
 fn mmap_capped_device_map_len_rules_hold() {
     ax_assert!(axtest_exports::mmap_capped_device_map_len_rules_hold());
 }

--- a/os/arceos/modules/axhal/src/cache.rs
+++ b/os/arceos/modules/axhal/src/cache.rs
@@ -1,6 +1,6 @@
 //! Cache, TLB, and modified-text synchronization helpers.
 
-use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr};
+use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
 
 /// Failure while synchronously invalidating a kernel TLB range.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
@@ -24,6 +24,33 @@ pub fn flush_tlb_range(start: VirtAddr, size: usize) {
     for offset in (0..size).step_by(PAGE_SIZE_4K) {
         ax_cpu::asm::flush_tlb(Some(start + offset));
     }
+}
+
+fn update_mmu_cache_with(vaddr: VirtAddr, update: impl FnOnce(VirtAddr)) {
+    update(vaddr.align_down_4k());
+}
+
+/// Synchronizes a page-table update performed by the local page-fault handler.
+///
+/// This boundary corresponds to Linux's `update_mmu_cache()`. It is local to
+/// the faulting CPU and must not be replaced by a cross-CPU shootdown.
+#[inline]
+pub fn update_mmu_cache(vaddr: VirtAddr) {
+    update_mmu_cache_with(vaddr, ax_cpu::asm::update_mmu_cache);
+}
+
+#[cfg(axtest)]
+/// Verifies page alignment at the local page-fault completion boundary.
+pub fn update_mmu_cache_alignment_for_test() -> bool {
+    use core::cell::Cell;
+
+    let calls = Cell::new(0);
+    let observed = Cell::new(VirtAddr::from(0));
+    update_mmu_cache_with(VirtAddr::from(0x4567), |vaddr| {
+        calls.set(calls.get() + 1);
+        observed.set(vaddr);
+    });
+    calls.get() == 1 && observed.get() == VirtAddr::from(0x4000)
 }
 
 /// Flushes the TLB entries covering a virtual-address range on all available CPUs.

--- a/os/arceos/modules/axmm/src/aspace.rs
+++ b/os/arceos/modules/axmm/src/aspace.rs
@@ -337,9 +337,13 @@ impl AddrSpace {
         if let Some(area) = self.areas.find(vaddr) {
             let orig_flags = area.flags();
             if orig_flags.contains(access_flags) {
-                return area
+                let handled = area
                     .backend()
                     .handle_page_fault(vaddr, orig_flags, &mut self.pt);
+                if handled {
+                    ax_hal::cache::update_mmu_cache(vaddr);
+                }
+                return handled;
             }
         }
         false

--- a/os/arceos/modules/axruntime/runtime.ld
+++ b/os/arceos/modules/axruntime/runtime.ld
@@ -18,6 +18,11 @@ SECTIONS {
         _ex_table_end = .;
 
         . = ALIGN(0x10);
+        _nofault_ex_table_start = .;
+        KEEP(*(__nofault_ex_table))
+        _nofault_ex_table_end = .;
+
+        . = ALIGN(0x10);
         __axtest_array = .;
         KEEP(*(SORT(.axtest_array)))
         __axtest_array_end = .;

--- a/test-suit/starryos/qemu/system/syscall-test-archprctl-tls/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-archprctl-tls/src/main.c
@@ -99,9 +99,11 @@ static int test_arch_prctl_fs(void)
 
     syscall(SYS_arch_prctl, ARCH_GET_FS, &orig); /* 存原 musl TLS */
     syscall(SYS_arch_prctl, ARCH_SET_FS, testv);
+    long repeat_r = syscall(SYS_arch_prctl, ARCH_SET_FS, testv);
     syscall(SYS_arch_prctl, ARCH_GET_FS, &got);
     syscall(SYS_arch_prctl, ARCH_SET_FS, orig); /* 恢复! 之后才可 CHECK/printf */
 
+    CHECK(repeat_r == 0, "重复 ARCH_SET_FS 同值成功(懒安装零额外写路径)");
     CHECK(got == testv, "ARCH_SET_FS 后 GET_FS 读回同值");
     CHECK(read_tls_reg() == orig, "ARCH_SET_FS 恢复原 TLS 成功");
     if (page != MAP_FAILED) munmap(page, 4096);
@@ -115,6 +117,8 @@ static int test_arch_prctl_gs_errno(void)
     unsigned long gv = 0xdead000;
     long r = syscall(SYS_arch_prctl, ARCH_SET_GS, gv);
     CHECK(r == 0, "ARCH_SET_GS 成功(恒不返错)");
+    r = syscall(SYS_arch_prctl, ARCH_SET_GS, gv);
+    CHECK(r == 0, "重复 ARCH_SET_GS 同值成功(懒安装零额外写路径)");
     unsigned long got = 0;
     r = syscall(SYS_arch_prctl, ARCH_GET_GS, &got);
     CHECK(r == 0 && got == gv, "ARCH_GET_GS 读回同值");

--- a/test-suit/starryos/qemu/system/syscall-test-clone-tls/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-clone-tls/src/main.c
@@ -45,6 +45,7 @@
 
 #define STK (64 * 1024)
 #define NTHREAD 8
+#define TLS_SWITCH_ROUNDS 64
 
 static long my_gettid(void) { return syscall(SYS_gettid); }
 static long my_set_tid_address(int *p) { return syscall(SYS_set_tid_address, p); }
@@ -166,8 +167,17 @@ static int test_pthread_join(void)
 
 /* ===== E. __thread 隔离 = CLONE_SETTLS per-thread TLS ===== */
 static __thread int tls_var = 42;
+static __thread unsigned long tls_switch_value;
 static volatile int child_tls_after_set;
 static volatile int child_saw_parent_write;
+static int tls_switch_ready;
+static int tls_switch_start;
+
+struct tls_switch_arg {
+    unsigned long expected;
+    int failures;
+};
+
 static void *tls_thr(void *a)
 {
     (void)a;
@@ -176,6 +186,21 @@ static void *tls_thr(void *a)
     child_tls_after_set = tls_var;
     return NULL;
 }
+
+static void *tls_switch_thr(void *opaque)
+{
+    struct tls_switch_arg *arg = opaque;
+    tls_switch_value = arg->expected;
+    __atomic_add_fetch(&tls_switch_ready, 1, __ATOMIC_RELEASE);
+    while (!__atomic_load_n(&tls_switch_start, __ATOMIC_ACQUIRE)) sched_yield();
+    for (int round = 0; round < TLS_SWITCH_ROUNDS; round++) {
+        if (tls_switch_value != arg->expected) arg->failures++;
+        sched_yield();
+        if (tls_switch_value != arg->expected) arg->failures++;
+    }
+    return NULL;
+}
+
 static int test_pthread_tls(void)
 {
     TEST_START("E. __thread 隔离(CLONE_SETTLS per-thread TLS)");
@@ -191,6 +216,25 @@ static int test_pthread_tls(void)
         CHECK(child_tls_after_set == 99, "子线程改自己 __thread 为 99");
         CHECK(tls_var == 7, "主线程 __thread 不受子影响(SETTLS 隔离)");
     }
+
+    pthread_t workers[NTHREAD];
+    struct tls_switch_arg args[NTHREAD];
+    __atomic_store_n(&tls_switch_ready, 0, __ATOMIC_RELAXED);
+    __atomic_store_n(&tls_switch_start, 0, __ATOMIC_RELAXED);
+    int created = 0;
+    for (int i = 0; i < NTHREAD; i++) {
+        args[i].expected = 0x10000UL + (unsigned long)i;
+        args[i].failures = 0;
+        if (pthread_create(&workers[i], NULL, tls_switch_thr, &args[i]) != 0) break;
+        created++;
+    }
+    CHECK(created == NTHREAD, "创建多线程 TLS 切换压力任务成功");
+    while (__atomic_load_n(&tls_switch_ready, __ATOMIC_ACQUIRE) != created) sched_yield();
+    __atomic_store_n(&tls_switch_start, 1, __ATOMIC_RELEASE);
+    for (int i = 0; i < created; i++) pthread_join(workers[i], NULL);
+    int failures = 0;
+    for (int i = 0; i < created; i++) failures += args[i].failures;
+    CHECK(failures == 0, "反复 sched_yield 后每线程 TLS 仍保持隔离");
     TEST_DONE();
 }
 

--- a/test-suit/starryos/qemu/system/syscall-test-futex-wake-op/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-futex-wake-op/src/main.c
@@ -8,6 +8,7 @@
 #include <sched.h>
 #include <stdint.h>
 #include <stdatomic.h>
+#include <sys/mman.h>
 #include <sys/syscall.h>
 #include <time.h>
 #include <unistd.h>
@@ -394,10 +395,66 @@ static void test_wake_op_validation(void)
                         futex_count_arg(0), &op_word,
                         FUTEX_OP_ENCODE(0xf, 1, FUTEX_OP_CMP_EQ, 0)),
               ENOSYS, "WAKE_OP rejects an unknown arithmetic op");
+    op_word = 0x12345678;
     CHECK_ERR(raw_futex(&wake_word, FUTEX_WAKE_OP | FUTEX_PRIVATE_FLAG, 0,
                         futex_count_arg(0), &op_word,
                         FUTEX_OP_ENCODE(FUTEX_OP_ADD, 1, 0xf, 0)),
               ENOSYS, "WAKE_OP rejects an unknown comparison op");
+    CHECK(op_word == 0x12345678,
+          "invalid comparison is rejected before modifying uaddr2");
+}
+
+static void test_wake_op_fault_retry_and_transaction(void)
+{
+    printf("\n--- FUTEX_WAKE_OP nofault retry and failure transaction ---\n");
+    const size_t page_size = (size_t)sysconf(_SC_PAGESIZE);
+    uint32_t *lazy_word = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    CHECK(lazy_word != MAP_FAILED, "mmap creates a lazy futex page");
+    if (lazy_word == MAP_FAILED) {
+        return;
+    }
+
+    reset_words(0, 0);
+    CHECK_RET(raw_futex(&wake_word, FUTEX_WAKE_OP | FUTEX_PRIVATE_FLAG, 0,
+                        futex_count_arg(0), lazy_word,
+                        FUTEX_OP_ENCODE(FUTEX_OP_SET, 37,
+                                        FUTEX_OP_CMP_EQ, 0)),
+              0, "WAKE_OP faults in uaddr2 outside queue locks and retries");
+    CHECK(*lazy_word == 37, "retried WAKE_OP commits the requested RMW");
+    CHECK(munmap(lazy_word, page_size) == 0, "munmap releases the lazy page");
+
+    pthread_t waiter;
+    struct waiter_args args;
+    reset_words(0, 0);
+    args = (struct waiter_args) {
+        .word = &wake_word,
+        .expected = 0,
+        .ready = &waiter1_ready,
+        .result = &waiter1_ret,
+    };
+    int err = pthread_create(&waiter, NULL, futex_waiter_thread, &args);
+    CHECK(err == 0, "pthread_create waiter for EFAULT transaction succeeds");
+    if (err != 0) {
+        return;
+    }
+    wait_until_ready(&waiter1_ready);
+    short_settle();
+
+    CHECK_ERR(raw_futex(&wake_word, FUTEX_WAKE_OP | FUTEX_PRIVATE_FLAG, 1,
+                        futex_count_arg(0), NULL,
+                        FUTEX_OP_ENCODE(FUTEX_OP_ADD, 1,
+                                        FUTEX_OP_CMP_EQ, 0)),
+              EFAULT, "WAKE_OP reports an inaccessible uaddr2");
+    short_settle();
+    CHECK(atomic_load_explicit(&waiter1_ret, memory_order_acquire) == INT_MIN,
+          "EFAULT does not wake the primary futex waiter");
+    CHECK_RET(raw_futex(&wake_word, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, 1,
+                        NULL, NULL, 0),
+              1, "manual wake releases the waiter after failed WAKE_OP");
+    join_thread(waiter);
+    CHECK(atomic_load_explicit(&waiter1_ret, memory_order_acquire) == 0,
+          "waiter returns only after the explicit wake");
 }
 
 int main(void)
@@ -409,6 +466,7 @@ int main(void)
     test_wake_op_comparison_controls_second_wake();
     test_wake_op_comparisons();
     test_wake_op_validation();
+    test_wake_op_fault_retry_and_transaction();
 
     TEST_DONE();
 }


### PR DESCRIPTION
## 问题

#1775 同时包含调度器重构、架构状态迁移和若干独立正确性修复，整体依赖较重。其中三组 `ax-cpu` 改动可以先从最新 `dev` 独立落地：

1. futex 在持有哈希桶锁时使用可缺页的用户访问，缺页处理可能睡眠或重入锁路径；
2. 缺页成功安装 PTE 后，RISC-V/LoongArch 缺少故障 CPU 上的目标页本地 TLB 同步；
3. x86 用户态每次进出都无条件读写 FS/GS MSR，热路径开销高，且状态所有权分散在 trapframe 与 CPU 之间。

这些问题会增加 #1775 的架构耦合和审查面，因此本 PR 仅提取可独立验证的前置改进，不关闭 #1775。

## 改动

### 1. nofault 用户访问与 futex 锁边界

- 在 `ax-cpu` 增加 `UserAccessError`、`UserAtomicError`、`UserAtomicU32Op`、`user_read_u32` 和 `user_atomic_u32`。
- 为四架构增加 nofault 原子汇编、独立 `__nofault_ex_table`、链接脚本保留规则，以及 trap 的优先 fixup；RISC-V 汇编显式启用 AMO 指令能力。
- Starry 将 `WAIT` 条件复查、`CMP_REQUEUE` 比较和 `WAKE_OP` RMW 改为锁内 nofault；遇到 Fault/Retry 时先释放锁，再 fault-in/yield/retry。
- Fault/Retry 不执行唤醒、重排，也不会遗留 waiter；robust-list 等锁外路径继续使用现有 faultable API。

这样把“可睡眠的缺页处理”和“不可睡眠的 futex 队列锁临界区”明确分离，同时保持 Linux futex 的比较与 RMW 原子性。

### 2. 缺页完成后的本地 MMU 同步

- 增加 `ax_cpu::asm::update_mmu_cache` 和 `ax_hal::cache::update_mmu_cache`。
- RISC-V、LoongArch 对页对齐后的故障地址执行本地 TLB 更新；x86_64、AArch64 为明确的空操作。
- ArceOS `ax-mm` 与 Starry 地址空间只在 PTE 成功安装后、重试故障指令前调用。

该边界只负责故障 CPU 的本地同步，不发送跨核 IPI，也不引入 #1775 的 active-mm、CPU mask 或 shootdown 所有权重构。

### 3. x86 用户 TLS 懒安装

- 增加 CPU-local `{fs_base, gs_base, generation}` 镜像，在 CPU 初始化时建立状态。
- 保持并断言 FSGSBASE 禁用；进入用户态前仅写入发生变化的 FS/GS MSR。
- generation 发布在状态字段之后，回绕时跳过 0，0 始终表示未初始化。
- 调整 `UserContext` 私有 continuation 字段及真实布局断言；不引入 bytemuck 或整套 trapframe 重构。

这消除了每次用户态进出无条件读写两个 MSR 的成本，并把物理 TLS 镜像的所有权收敛到 CPU-local 状态。

## 范围与非目标

设计、安全契约、Linux 语义、替代方案和验证约束记录在 `book/design/ax-cpu-user-transition-prerequisites.md`。

明确不包含：IRQ-off idle/clockevent 事务、active-mm 与页表根所有权、跨核 shootdown/CPU mask、x86 double-fault IST、bytemuck/完整 trapframe 重构。这些仍由 #1775 处理。

关联：#1775。

## 验证

确定性红绿证据：

- nofault：修复前 RISC-V 对未映射地址访问直接进入普通 page fault；修复后异常表恢复通过，并覆盖五种 RMW 及 Fault/Retry 无副作用。
- MMU：修复前成功缺页的私有观察测试未记录同步；修复后成功路径恰好一次、地址页对齐，拒绝路径为零次。
- TLS：修复前三个单元断言暴露无条件双 MSR 写和 generation 回绕为 0；修复后相同测试通过，并覆盖单字段变化与初始化。

已完成：

- `cargo fmt`
- `cargo xtask clippy --package ax-cpu --package ax-hal --package ax-mm --package starry-kernel`（69/69）
- `cargo xtask sync-lint --since origin/dev`
- `cargo xtask lock-lint`
- 四架构 `starry-kernel` QEMU axtest：x86_64 415/415、aarch64 413/413、riscv64 412/412、loongarch64 412/412
- 四架构 `cargo xtask arceos test qemu`，包括 Rust/C 套件及 LoongArch unaligned-fixup
- Starry `qemu/system`：x86_64 447/447、aarch64 447/447
- x86 TLS host 单元测试、typed trapframe 测试，以及聚焦的 futex/TLS grouped QEMU 用例

按交付安排，riscv64 完整 `qemu/system` 在运行中停止，loongarch64 完整 `qemu/system` 未继续；剩余矩阵交由 PR CI 验证。物理板测试不在本 PR 范围内。