### PR TITLE
fix(ax-mm): roll back failed populated mappings

### DIFF
--- a/os/arceos/modules/axmm/src/backend/alloc.rs
+++ b/os/arceos/modules/axmm/src/backend/alloc.rs
@@ -47,17 +47,11 @@ impl Backend {
             populate
         );
         if populate {
-            // allocate all possible physical frames for populated mapping.
-            for addr in PageIter4K::new(start, start + size).unwrap() {
-                if let Some(frame) = alloc_frame(true) {
-                    if pt.map_page(addr, frame, PAGE_SIZE_4K, flags).is_err() {
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            }
-            true
+            let mut populate = PageTablePopulate {
+                page_table: pt,
+                flags,
+            };
+            populate_pages(&mut populate, start, size)
         } else {
             // Map to a empty entry for on-demand mapping.
             let flags = MappingFlags::empty();
@@ -103,6 +97,161 @@ impl Backend {
             pt.remap_page(vaddr, frame, orig_flags).is_ok()
         } else {
             false
+        }
+    }
+}
+
+trait PopulatePageOps {
+    fn alloc_frame(&mut self) -> Option<PhysAddr>;
+
+    fn map_frame(&mut self, addr: VirtAddr, frame: PhysAddr) -> bool;
+
+    fn unmap_frame(&mut self, addr: VirtAddr) -> Option<PhysAddr>;
+
+    fn dealloc_frame(&mut self, frame: PhysAddr);
+}
+
+struct PageTablePopulate<'a> {
+    page_table: &'a mut PageTable,
+    flags: MappingFlags,
+}
+
+impl PopulatePageOps for PageTablePopulate<'_> {
+    fn alloc_frame(&mut self) -> Option<PhysAddr> {
+        alloc_frame(true)
+    }
+
+    fn map_frame(&mut self, addr: VirtAddr, frame: PhysAddr) -> bool {
+        self.page_table
+            .map_page(addr, frame, PAGE_SIZE_4K, self.flags)
+            .is_ok()
+    }
+
+    fn unmap_frame(&mut self, addr: VirtAddr) -> Option<PhysAddr> {
+        let (frame, _, page_size) = self.page_table.unmap_page(addr).ok()?;
+        assert_eq!(
+            page_size, PAGE_SIZE_4K,
+            "a populated 4K mapping must be rolled back as a 4K page"
+        );
+        Some(frame)
+    }
+
+    fn dealloc_frame(&mut self, frame: PhysAddr) {
+        dealloc_frame(frame);
+    }
+}
+
+fn populate_pages(ops: &mut impl PopulatePageOps, start: VirtAddr, size: usize) -> bool {
+    for addr in PageIter4K::new(start, start + size).unwrap() {
+        let Some(frame) = ops.alloc_frame() else {
+            rollback_populated_pages(ops, start, addr);
+            return false;
+        };
+        if !ops.map_frame(addr, frame) {
+            ops.dealloc_frame(frame);
+            rollback_populated_pages(ops, start, addr);
+            return false;
+        }
+    }
+    true
+}
+
+fn rollback_populated_pages(ops: &mut impl PopulatePageOps, start: VirtAddr, mapped_end: VirtAddr) {
+    for addr in PageIter4K::new(start, mapped_end).unwrap() {
+        let frame = ops
+            .unmap_frame(addr)
+            .expect("a page mapped by the current populate operation must remain mapped");
+        ops.dealloc_frame(frame);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    const START: usize = 0x4000_0000;
+
+    #[test]
+    fn rolls_back_current_and_mapped_frames_when_map_fails() {
+        let start = VirtAddr::from(START);
+        let mut ops = MockPopulatePageOps::with_map_failure(start + PAGE_SIZE_4K);
+
+        assert!(!populate_pages(&mut ops, start, 3 * PAGE_SIZE_4K));
+        assert!(ops.mapped.is_empty());
+        assert_eq!(ops.deallocated.len(), 2);
+        assert!(ops.deallocated.contains(&PhysAddr::from(PAGE_SIZE_4K)));
+        assert!(ops.deallocated.contains(&PhysAddr::from(2 * PAGE_SIZE_4K)));
+    }
+
+    #[test]
+    fn rolls_back_mapped_frames_when_allocation_fails() {
+        let start = VirtAddr::from(START);
+        let mut ops = MockPopulatePageOps::with_allocation_limit(1);
+
+        assert!(!populate_pages(&mut ops, start, 3 * PAGE_SIZE_4K));
+        assert!(ops.mapped.is_empty());
+        assert_eq!(ops.deallocated, [PhysAddr::from(PAGE_SIZE_4K)]);
+    }
+
+    struct MockPopulatePageOps {
+        allocations: usize,
+        allocation_limit: Option<usize>,
+        map_failure: Option<VirtAddr>,
+        mapped: Vec<(VirtAddr, PhysAddr)>,
+        deallocated: Vec<PhysAddr>,
+    }
+
+    impl MockPopulatePageOps {
+        fn with_map_failure(addr: VirtAddr) -> Self {
+            Self {
+                allocations: 0,
+                allocation_limit: None,
+                map_failure: Some(addr),
+                mapped: Vec::new(),
+                deallocated: Vec::new(),
+            }
+        }
+
+        fn with_allocation_limit(limit: usize) -> Self {
+            Self {
+                allocations: 0,
+                allocation_limit: Some(limit),
+                map_failure: None,
+                mapped: Vec::new(),
+                deallocated: Vec::new(),
+            }
+        }
+    }
+
+    impl PopulatePageOps for MockPopulatePageOps {
+        fn alloc_frame(&mut self) -> Option<PhysAddr> {
+            if self.allocation_limit == Some(self.allocations) {
+                return None;
+            }
+            self.allocations += 1;
+            Some(PhysAddr::from(self.allocations * PAGE_SIZE_4K))
+        }
+
+        fn map_frame(&mut self, addr: VirtAddr, frame: PhysAddr) -> bool {
+            if self.map_failure == Some(addr) {
+                return false;
+            }
+            self.mapped.push((addr, frame));
+            true
+        }
+
+        fn unmap_frame(&mut self, addr: VirtAddr) -> Option<PhysAddr> {
+            let index = self
+                .mapped
+                .iter()
+                .position(|(mapped_addr, _)| *mapped_addr == addr)?;
+            Some(self.mapped.remove(index).1)
+        }
+
+        fn dealloc_frame(&mut self, frame: PhysAddr) {
+            self.deallocated.push(frame);
         }
     }
 }


### PR DESCRIPTION
## 问题

`MemorySet::map` 仅在整个 `map_area` 成功后登记 area；但 `map_alloc(populate = true)` 在中途 frame 分配或 `map_page` 失败时直接返回，已经安装的叶子 PTE 和对应 frame 因而成为未跟踪资源。`map_page` 失败时，当前刚分配且尚未由页表接管的 frame 也会泄漏。

## 修改

- 将 populated mapping 的逐页操作收敛到私有操作边界，生产页表路径和回归测试共用同一编排逻辑。
- 后续 frame 分配失败时，撤销本次调用已经成功映射的地址前缀，并释放每个叶子 PTE 返回的 frame。
- `map_page` 失败时，先释放当前未映射的 frame，再撤销并释放此前成功映射的前缀。
- 增加确定性回归测试，覆盖第二页映射失败和第二页分配失败两条路径。

## 实现逻辑

回滚区间严格限定为 `[start, failed_addr)`，其中每一页都由当前调用成功安装，因此不会误删失败地址处可能既存的映射。当前失败页的 frame 未进入页表，单独直接释放；此前页面则先解除叶子映射，再按页表返回的物理地址释放 frame。这样失败返回时不会遗留未被 `MemorySet` 跟踪的映射或物理页。

## 验证

- `cargo fmt --all --check`
- `cargo test -p ax-mm --features ax-hal/host-test,ax-sync/host-test`
- `cargo xtask clippy --package ax-mm`
- `cargo clippy -p ax-mm --tests --features ax-hal/host-test,ax-sync/host-test -- -D warnings`
- 回归测试在修复前稳定失败，修复后 3 个 `ax-mm` 单元测试全部通过。

附加验证受现有链接环境限制：`cargo xtask cross-test --arch x86_64 --package ax-mm --lib` 在链接阶段缺少 `STACK_SIZE`、`PAGE_SIZE`、per-CPU 模板和 `SpinOps` 符号；x86_64 与 riscv64 的 ArceOS QEMU axtest 均在进入测试前因动态 std 预构建找不到 `linker.x` 而停止。