### PR TITLE
refactor(cpu-local): define scheduler-neutral execution context boundary

### DIFF
--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -50,13 +50,14 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
   objects additionally require `ExclusiveCpu` after excluding IRQ/re-entry and conflicting remote
   access. Context switches keep IRQs off and consume prepared/previous transaction tokens.
   AArch64 may lend SP_EL0 to userspace only after spilling the sole current header in the pinned
-  kernel stack and must restore it before returning to Rust. Preemption tokens are linear and
-  retain their entry owner: x86_64 uses the CPU anchor, while load/store architectures use the
-  current context header. A runtime must claim its scheduler baton before releasing a final
-  pending preemption depth; task policy and baton state do not belong in `cpu-local`. On a
-  CPU-owned preemption architecture, a context's first-entry tail must finish the switch depth
-  because it has no suspended incoming guard; context-owned architectures start that header at
-  depth zero.
+  kernel stack and must restore it before returning to Rust. Preemption tokens are linear.
+  Load/store architectures retain the current-context owner across migration. x86_64 uses the
+  CPU anchor, so a suspended switch guard resuming on another CPU must consume its old proof and
+  adopt the equivalent depth left by the destination CPU's outgoing context. A runtime must claim
+  its scheduler baton before releasing a final pending preemption depth; task policy and baton
+  state do not belong in `cpu-local`. On a CPU-owned preemption architecture, a context's
+  first-entry tail must finish the switch depth because it has no suspended incoming guard;
+  context-owned architectures start that header at depth zero.
 - **Build system**: wire arch/target mapping in `scripts/axbuild`, dynamic platform defaults, feature propagation, kernel format conversion, UEFI/to-bin behavior, rootfs handling, and per-OS test discovery.
 - **QEMU and firmware**: verify QEMU binary, machine type, CPU, SMP count, pflash/OVMF files, serial console, disk/rootfs device, `-snapshot`, debug flags, timeout, and success/fail regexes.
   Obtain OVMF CODE/VARS through `cargo xtask ovmf --arch <arch>`, which reuses Ostool's pinned

--- a/.claude/skills/arch-platform-porting/SKILL.md
+++ b/.claude/skills/arch-platform-porting/SKILL.md
@@ -27,18 +27,19 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
   and must not contain kernel TLS. Axvisor remains a std/musl PIE and explicitly enables TLS.
   ArceOS enables TLS by default, but configuration must reject `uspace + tls` rather than
   constructing an image with overlapping register ownership.
-- **CPU-local register ABI**: `cpu-local` owns the register contract and `ax-percpu` owns only
-  typed layout/storage. Do not create a second current-task per-CPU pointer. The active image
+- **CPU-local execution-context ABI**: `cpu-local` owns current-source selection, context binding,
+  switch transactions, and architecture-selected preemption state; `ax-percpu` owns only typed
+  layout/storage. Do not create a second current-context per-CPU pointer. The active image
   mode determines the register assignment. The exact initialized `CpuAreaRef` address is the
   area identity; do not add in-image ABI versions, generation counters, cookies, provider-trait
   FFI, or raw TP access:
 
   | Architecture | CPU area | `LinuxCurrent` | `UnikernelTls` |
   | --- | --- | --- | --- |
-  | x86_64 | GS base | current header in the GS runtime anchor | FS base |
-  | AArch64 | TPIDR_EL1/EL2 | SP_EL0 | TPIDR_EL0 |
-  | RISC-V | current-header backtrace or sscratch | `tp = current`, `sscratch = 0` | `tp = TLS`, `sscratch = CPU base` |
-  | LoongArch | r21 with KS3 mirror | `tp = current` | `tp = TLS` |
+  | x86_64 | GS base | GS runtime anchor; FS unused | GS runtime anchor; FS is TLS |
+  | AArch64 | TPIDR_EL1/EL2 | SP_EL0; TPIDR_EL0 unused | SP_EL0; TPIDR_EL0 is TLS |
+  | RISC-V | current-header backtrace or sscratch | `tp = current`, `sscratch = 0` | anchor current; `tp = TLS`, `sscratch = CPU base` |
+  | LoongArch | r21 with KS3 mirror | `tp = current` | anchor current; `tp = TLS` |
 
   Keep LoongArch KS4/KS5 reserved for vCPU scratch. On RISC-V, `gp` is the ordinary global
   pointer again; target specs still need `--no-relax` where the PIE relocation model requires
@@ -47,7 +48,15 @@ Current Axvisor LoongArch QEMU bring-up uses the dynamic UEFI platform path. The
   the live CPU base, area self pointer/index, and current header. Atomic scalars require migration
   exclusion; shared `T: Sync` objects also rely on object-owned synchronization; mutable local
   objects additionally require `ExclusiveCpu` after excluding IRQ/re-entry and conflicting remote
-  access. Scheduler switches keep IRQs off and consume prepared/previous transaction tokens.
+  access. Context switches keep IRQs off and consume prepared/previous transaction tokens.
+  AArch64 may lend SP_EL0 to userspace only after spilling the sole current header in the pinned
+  kernel stack and must restore it before returning to Rust. Preemption tokens are linear and
+  retain their entry owner: x86_64 uses the CPU anchor, while load/store architectures use the
+  current context header. A runtime must claim its scheduler baton before releasing a final
+  pending preemption depth; task policy and baton state do not belong in `cpu-local`. On a
+  CPU-owned preemption architecture, a context's first-entry tail must finish the switch depth
+  because it has no suspended incoming guard; context-owned architectures start that header at
+  depth zero.
 - **Build system**: wire arch/target mapping in `scripts/axbuild`, dynamic platform defaults, feature propagation, kernel format conversion, UEFI/to-bin behavior, rootfs handling, and per-OS test discovery.
 - **QEMU and firmware**: verify QEMU binary, machine type, CPU, SMP count, pflash/OVMF files, serial console, disk/rootfs device, `-snapshot`, debug flags, timeout, and success/fail regexes.
   Obtain OVMF CODE/VARS through `cargo xtask ovmf --arch <arch>`, which reuses Ostool's pinned

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -83,17 +83,18 @@ must remain trapped, and guest writes must never mutate host GICD/GICR state.
 
 ## CPU-local Register Ownership
 
-`cpu-local` is the single owner of host CPU-area, current-thread, and kernel-TLS register
-semantics. `ax-percpu` supplies the typed template/layout/area implementation but must not choose
+`cpu-local` is the single owner of host CPU-area, current-context, kernel-TLS register, context
+binding, and architecture-selected preemption semantics. `ax-percpu` supplies the typed
+template/layout/area implementation but must not choose
 an architecture register independently. The two image modes are mutually exclusive at a final
 image boundary:
 
 | Architecture | CPU area | Linux-current image | Unikernel-TLS image |
 | --- | --- | --- | --- |
-| x86_64 | GS base | current header in `CpuRuntimeAnchor` | FS base is task TLS |
-| AArch64 | TPIDR_EL1 at EL1, TPIDR_EL2 at EL2 | SP_EL0 is current | TPIDR_EL0 is task TLS |
-| RISC-V | recover from current header, or sscratch | tp is current and sscratch is zero in kernel Rust | tp is task TLS and sscratch is CPU base |
-| LoongArch | r21, mirrored in KS3 | tp is current | tp is task TLS |
+| x86_64 | GS base | anchor current; FS unused | anchor current; FS is context TLS |
+| AArch64 | TPIDR_EL1 at EL1, TPIDR_EL2 at EL2 | SP_EL0 current; TPIDR_EL0 unused | SP_EL0 current; TPIDR_EL0 is context TLS |
+| RISC-V | recover from current header, or sscratch | tp current; sscratch zero | anchor current; tp is TLS; sscratch is CPU base |
+| LoongArch | r21, mirrored in KS3 | tp current | anchor current; tp is TLS |
 
 The final ELF owns exactly one `.percpu.template`, one `.percpu.init` descriptor table, and one
 `.percpu.align` table. someboot or another platform allocates the runtime areas dynamically from
@@ -111,17 +112,27 @@ remote access are excluded. CPU-area construction is permitted only while that C
 the raw destination is exclusively owned.
 
 Context-switch publication follows one ordering: validate the outgoing binding, bind the next
-stable task header, prepare every fallible state transition, commit the architecture register,
+stable execution-context header, prepare every fallible state transition, commit the selected source,
 perform the naked switch, and unbind the previous header in the incoming tail. The interrupt-off
 `CpuPin` spans that sequence. An uncommitted prepared token rolls the next binding back, while the
-previous binding epoch rejects a stale incoming tail after task rebinding; that epoch is a runtime
+previous binding epoch rejects a stale incoming tail after context rebinding; that epoch is a runtime
 concurrency guard, not an ABI version. vCPU exits must restore the host register contract before returning
 to host Rust; LoongArch KS4/KS5 remain vCPU scratch and AArch64 must restore host TPIDR_EL0 before
-calling Rust exception handlers.
+calling Rust exception handlers. AArch64 must spill its sole SP_EL0 current header in the pinned
+kernel stack before lending SP_EL0 to userspace and restore it before returning to Rust; a CPU
+anchor mirror is not a valid fallback.
+
+Preemption entry returns a linear token bound to the selected owner. x86_64 uses the CPU anchor;
+load/store architectures use the current context header. A final pending exit retains depth one
+until the runtime has claimed its per-CPU scheduler baton. `cpu-local` must not contain the baton,
+task pending policy, a runtime owner cookie, or any `scheduler_*` API.
+On CPU-owned preemption architectures, verify that a newly entered context explicitly finishes
+the switch depth; resumed contexts finish it through their suspended guard, while context-owned
+architectures begin the new header at depth zero.
 
 For boot debugging, verify the typed per-CPU layout is finalized and frozen before CPU binding.
 Check both the architectural register and its defined mirror (RISC-V sscratch or LoongArch KS3)
-on secondaries. A separate current-task per-CPU variable can mask a stale register during normal
+on secondaries. A separate current-context per-CPU variable can mask a stale register during normal
 execution and then fail only on traps or vCPU exits, so it is not a valid fallback.
 
 ## Final Image Runtime Modes

--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -127,8 +127,9 @@ load/store architectures use the current context header. A final pending exit re
 until the runtime has claimed its per-CPU scheduler baton. `cpu-local` must not contain the baton,
 task pending policy, a runtime owner cookie, or any `scheduler_*` API.
 On CPU-owned preemption architectures, verify that a newly entered context explicitly finishes
-the switch depth; resumed contexts finish it through their suspended guard, while context-owned
-architectures begin the new header at depth zero.
+the switch depth. A suspended guard resuming on another CPU must consume its old proof and adopt
+the equivalent switch depth left by the destination CPU's outgoing context. Context-owned
+architectures retain the token owner across migration and begin a new header at depth zero.
 
 For boot debugging, verify the typed per-CPU layout is finalized and frozen before CPU binding.
 Check both the architectural register and its defined mirror (RISC-V sscratch or LoongArch KS3)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,6 +1176,7 @@ dependencies = [
  "axpoll",
  "cfg-if",
  "chrono",
+ "cpu-local",
  "dma-api",
  "indoc",
  "irq-framework",

--- a/book/design/cpu-local-execution-context-boundary.md
+++ b/book/design/cpu-local-execution-context-boundary.md
@@ -29,8 +29,9 @@ The boundary succeeds when:
   wrapper without a second identity publication;
 - switch preparation rolls back when abandoned and stale previous bindings
   cannot be consumed twice;
-- preemption entry and pending exit are linear and retain their exact state
-  owner across suspension or modeled migration;
+- preemption entry and pending exit are linear; context-owned tokens retain
+  their exact state owner, while a CPU-owned switch token can transfer only at
+  the context-switch resume boundary;
 - existing ArceOS consumers build and run without changing scheduling policy.
 
 ## Non-goals
@@ -85,7 +86,8 @@ at commit. No fallible or ownership-sensitive Rust work follows commit.
 The preemption word uses an inverted pending bit and a nesting depth. x86_64
 stores it in the fixed CPU anchor, while load/store architectures store it in
 the execution-context header. `PreemptionToken` captures the selected word at
-entry, so exit never re-resolves a possibly migrated owner.
+entry. Ordinary exit finishes that exact owner; only the explicit x86_64
+context-switch resume handoff may replace a CPU-owned switch token.
 
 `finish_preemption` consumes a nested or non-pending final depth. A final
 pending exit returns `PendingPreemption` while depth one remains published.
@@ -97,11 +99,17 @@ then invokes the task safe point. The task layer never manipulates the word and
 Bootstrap contexts start at depth one. The runtime releases that exact depth
 once, after current context and local run-queue state are published.
 
-On x86_64, a scheduler guard's CPU-owned depth crosses the raw context switch.
-A resumed context finishes that depth through its suspended guard. A context
-running for the first time has no suspended caller, so its first-entry runtime
-tail invokes `release_initial_context_preemption`; load/store architectures
-start the new context-owned word at depth zero and take no action.
+On x86_64, a runtime guard's CPU-owned exclusion covers the raw context switch.
+If the suspended context resumes on the same CPU, its token retains the same
+owner. If it resumes on another CPU, the old CPU's incoming context has consumed
+the old switch depth and the destination CPU's outgoing context has left an
+equivalent depth. The incoming runtime tail therefore consumes the old linear
+proof and uses `handoff_preemption_after_context_switch` to adopt the destination
+CPU's depth before finishing the guard. A context running for the first time has
+no suspended caller, so its first-entry runtime tail invokes
+`release_initial_context_preemption`. Load/store architectures migrate the
+context-owned word itself, reject any owner change, and start a new context at
+depth zero.
 
 ## Alternatives rejected
 

--- a/book/design/cpu-local-execution-context-boundary.md
+++ b/book/design/cpu-local-execution-context-boundary.md
@@ -1,0 +1,125 @@
+# CPU-local execution-context boundary
+
+## Problem
+
+PR #1775 needs a stable low-level current/preemption mechanism, but its task and
+runtime refactor must not become an implicit dependency of `cpu-local`. The old
+surface also encoded upper-layer concepts in names and data: current task
+identity, scheduler publication, and task-owned preemption counters. Copying
+that directory would reverse the intended dependency and make the mechanism
+impossible to reuse outside one scheduler implementation.
+
+This design establishes the independently mergeable boundary used by current
+ArceOS and later by #1775. It changes no syscall, scheduling policy, task API,
+or `someboot` startup behavior.
+
+## Users and success criteria
+
+The direct users are architecture switch/trap code, `ax-runtime`, and typed
+per-CPU layout code. Task systems consume the runtime capability rather than
+the architecture mechanism.
+
+The boundary succeeds when:
+
+- `cpu-local` has no `ax-task` or `ax-runtime` dependency and exposes no
+  scheduler-named operation, runtime cookie, task owner, run queue, IPI, or
+  baton;
+- every final image has one authoritative current-context source;
+- an execution context can be embedded at offset zero in a runtime-owned
+  wrapper without a second identity publication;
+- switch preparation rolls back when abandoned and stale previous bindings
+  cannot be consumed twice;
+- preemption entry and pending exit are linear and retain their exact state
+  owner across suspension or modeled migration;
+- existing ArceOS consumers build and run without changing scheduling policy.
+
+## Non-goals
+
+This change does not import #1775's TaskSystem, RT/Deadline policy, IPI delivery,
+thread publication, or scheduler implementation. It does not add physical-board
+behavior, CPU hotplug, a versioned runtime ABI, or a compatibility cookie.
+
+## Ownership and dependency direction
+
+`cpu-local` owns fixed CPU-area metadata, current-context register selection,
+context CPU binding, switch transactions, and the preemption word.
+`ax-percpu` owns typed layout, template initialization, and layout freeze.
+`ax-runtime` owns IRQ exclusion, bootstrap release, the scheduler baton, and the
+safe-point adapter. The task layer owns `need_resched`, `force_resched`, run
+queues, policy, and remote requests.
+
+The legacy ArceOS task implementation uses a narrow `RuntimePreemption`
+capability so the runtime, not the task crate, consumes CPU-local tokens. PR
+#1775 can replace that compatibility capability with `TaskRuntime` without
+changing the CPU-local API.
+
+## Current-context sources
+
+| Architecture/image | Authoritative current source |
+| --- | --- |
+| x86_64, with or without TLS | CPU runtime anchor addressed through GS |
+| AArch64, with or without TLS | SP_EL0 |
+| RISC-V/LoongArch64 without TLS | architecture `tp` register |
+| RISC-V/LoongArch64 with TLS | CPU runtime anchor |
+
+The CPU anchor remains storage for x86_64 and TLS-conflicting architectures; it
+is not a mirror in modes that use an architecture register. AArch64 user entry
+temporarily borrows SP_EL0 for user SP and therefore spills the header in the
+pinned kernel stack until exception return restores it.
+
+`ExecutionContextHeader` begins with its CPU-area binding. Runtime wrappers use
+`#[repr(C)]` and place the header first. The current header address is the sole
+architecture identity; a wrapper may store its own task owner beside it.
+
+## Switch transaction
+
+`prepare_context_switch` validates the outgoing source, captures its binding
+epoch, and binds the incoming context. `PreparedContextSwitch` owns rollback of
+the incoming binding until `commit`. `PreviousContextBinding` owns exactly one
+withdrawal of the outgoing epoch after the raw switch. Architecture-register
+modes write current only in the naked tail; anchor modes publish the atomic slot
+at commit. No fallible or ownership-sensitive Rust work follows commit.
+
+## Preemption transaction
+
+The preemption word uses an inverted pending bit and a nesting depth. x86_64
+stores it in the fixed CPU anchor, while load/store architectures store it in
+the execution-context header. `PreemptionToken` captures the selected word at
+entry, so exit never re-resolves a possibly migrated owner.
+
+`finish_preemption` consumes a nested or non-pending final depth. A final
+pending exit returns `PendingPreemption` while depth one remains published.
+`ax-runtime` masks local IRQs, mirrors task work into the pending bit, claims a
+per-CPU scheduler baton, releases the pending depth, clears the mirror, and only
+then invokes the task safe point. The task layer never manipulates the word and
+`cpu-local` never decides whether to schedule.
+
+Bootstrap contexts start at depth one. The runtime releases that exact depth
+once, after current context and local run-queue state are published.
+
+On x86_64, a scheduler guard's CPU-owned depth crosses the raw context switch.
+A resumed context finishes that depth through its suspended guard. A context
+running for the first time has no suspended caller, so its first-entry runtime
+tail invokes `release_initial_context_preemption`; load/store architectures
+start the new context-owned word at depth zero and take no action.
+
+## Alternatives rejected
+
+- Keeping a task pointer in both an architecture register and CPU anchor was
+  rejected because the two values can diverge across traps, user transitions,
+  or vCPU exits.
+- Keeping a runtime cookie in `ExecutionContextHeader` was rejected because the
+  wrapper address already provides identity and the cookie leaks ownership
+  upward.
+- Keeping the preemption counter in the task object was rejected because x86_64
+  requires CPU ownership while other architectures require context ownership.
+- Copying or cherry-picking #1775 was rejected because it also carries task
+  system and scheduler changes that are not independently required here.
+
+## Evidence
+
+Host tests cover dependency vocabulary, current-source selection, offset-zero
+embedding, switch rollback and stale epochs, nested/final/pending preemption,
+bootstrap depth, malformed raw tokens, and owner retention. Cross-target clippy
+checks all four architecture backends. ArceOS QEMU covers task switching and
+preemption; Starry covers non-TLS current modes; Axvisor covers TLS modes.

--- a/components/axcpu/src/aarch64/context.rs
+++ b/components/axcpu/src/aarch64/context.rs
@@ -6,7 +6,7 @@ use core::{
 };
 
 use ax_memory_addr::VirtAddr;
-use cpu_local::{CurrentThreadHeader, PreparedThreadSwitch};
+use cpu_local::{ExecutionContextHeader, PreparedContextSwitch};
 
 use crate::{KernelTlsBase, TaskLocalState};
 
@@ -253,14 +253,14 @@ impl TaskContext {
         self.task_local.set_kernel_tls(kernel_tls);
     }
 
-    /// Sets the pinned task-owned current-thread header.
-    pub fn set_current_header(&mut self, header: NonNull<CurrentThreadHeader>) {
-        self.task_local.set_current_header(header);
+    /// Sets the pinned task-owned execution-context header.
+    pub fn set_context_header(&mut self, header: NonNull<ExecutionContextHeader>) {
+        self.task_local.set_context_header(header);
     }
 
-    /// Returns the configured task-owned current-thread header.
-    pub const fn current_header(&self) -> Option<NonNull<CurrentThreadHeader>> {
-        self.task_local.current_header()
+    /// Returns the configured task-owned execution-context header.
+    pub const fn context_header(&self) -> Option<NonNull<ExecutionContextHeader>> {
+        self.task_local.context_header()
     }
 
     /// Changes the page table root restored for this task.
@@ -269,7 +269,7 @@ impl TaskContext {
         self.page_table_root = page_table_root;
     }
 
-    /// Completes FP/SIMD work before current-thread publication.
+    /// Completes FP/SIMD work before current-context publication.
     pub fn prepare_switch_to(&mut self, _next_ctx: &Self) {
         #[cfg(feature = "fp-simd")]
         {
@@ -294,10 +294,10 @@ impl TaskContext {
     pub unsafe fn switch_to_prepared(
         &mut self,
         next_ctx: &Self,
-        prepared: PreparedThreadSwitch<'_>,
+        prepared: PreparedContextSwitch<'_>,
     ) {
         assert_eq!(
-            next_ctx.current_header(),
+            next_ctx.context_header(),
             Some(prepared.next_header()),
             "prepared switch token must belong to the next task context",
         );
@@ -334,7 +334,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         ldp     x25, x26, [x1, {r25_offset}]
         ldp     x27, x28, [x1, {r27_offset}]
         ldp     x29, x30, [x1, {r29_offset}]
-        ldr     x9, [x1, {current_header_offset}]
+        ldr     x9, [x1, {context_header_offset}]
         msr     sp_el0, x9
 
         ret",
@@ -345,8 +345,8 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         r25_offset = const offset_of!(TaskContext, r25),
         r27_offset = const offset_of!(TaskContext, r27),
         r29_offset = const offset_of!(TaskContext, r29),
-        current_header_offset = const offset_of!(TaskContext, task_local)
-            + offset_of!(TaskLocalState, current_header),
+        context_header_offset = const offset_of!(TaskContext, task_local)
+            + offset_of!(TaskLocalState, context_header),
         kernel_tls_offset = const offset_of!(TaskContext, task_local)
             + offset_of!(TaskLocalState, kernel_tls),
     )
@@ -377,7 +377,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         ldp     x25, x26, [x1, {r25_offset}]
         ldp     x27, x28, [x1, {r27_offset}]
         ldp     x29, x30, [x1, {r29_offset}]
-        ldr     x9, [x1, {current_header_offset}]
+        ldr     x9, [x1, {context_header_offset}]
         msr     sp_el0, x9
         ret",
         sp_offset = const offset_of!(TaskContext, sp),
@@ -387,8 +387,8 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         r25_offset = const offset_of!(TaskContext, r25),
         r27_offset = const offset_of!(TaskContext, r27),
         r29_offset = const offset_of!(TaskContext, r29),
-        current_header_offset = const offset_of!(TaskContext, task_local)
-            + offset_of!(TaskLocalState, current_header),
+        context_header_offset = const offset_of!(TaskContext, task_local)
+            + offset_of!(TaskLocalState, context_header),
     )
 }
 

--- a/components/axcpu/src/aarch64/trap.S
+++ b/components/axcpu/src/aarch64/trap.S
@@ -113,15 +113,9 @@ exception_vector_base:
     ldp     x10, x11, [x1, {trapframe_size}]
     stp     x8, x9, [x1, {trapframe_size}]
 
-    // LinuxCurrent temporarily lends SP_EL0 to userspace. Once user SP/TLS are
-    // in UserContext, recover the task-owned current header from the CPU slot
-    // before returning to any Rust instruction.
-    .ifdef arm_el2
-    mrs     x12, tpidr_el2
-    .else
-    mrs     x12, tpidr_el1
-    .endif
-    ldr     x12, [x12, {current_thread_offset}]
+    // SP_EL0 is the sole current-context source. `enter_user` spills it in the
+    // pinned kernel stack frame before lending SP_EL0 to userspace.
+    ldr     x12, [x10, 12 * 8]
     msr     sp_el0, x12
 
     mov     sp, x10
@@ -133,19 +127,21 @@ exception_vector_base:
     ldp     x25, x26, [sp, 6 * 8]
     ldp     x27, x28, [sp, 8 * 8]
     ldp     x29, x30, [sp, 10 * 8]
-    add     sp, sp, 12 * 8
+    add     sp, sp, 14 * 8
 
     ret
 
 .global enter_user
 enter_user:
-    sub     sp, sp, 12 * 8
+    sub     sp, sp, 14 * 8
     stp     x29, x30, [sp, 10 * 8]
     stp     x27, x28, [sp, 8 * 8]
     stp     x25, x26, [sp, 6 * 8]
     stp     x23, x24, [sp, 4 * 8]
     stp     x21, x22, [sp, 2 * 8]
     stp     x19, x20, [sp]
+    mrs     x12, sp_el0
+    str     x12, [sp, 12 * 8]
 
     mov     x10, sp
     mrs     x11, tpidr_el0

--- a/components/axcpu/src/aarch64/trap.rs
+++ b/components/axcpu/src/aarch64/trap.rs
@@ -119,7 +119,6 @@ core::arch::global_asm!(
     #[cfg(feature = "arm-el2")]
     concat!(".equ arm_el2, 1\n", include_str!("trap.S")),
     trapframe_size = const core::mem::size_of::<RawTrapFrame>(),
-    current_thread_offset = const cpu_local::CPU_AREA_CURRENT_THREAD_OFFSET,
     TRAP_KIND_SYNC = const TrapKind::Synchronous as u8,
     TRAP_KIND_IRQ = const TrapKind::Irq as u8,
     TRAP_KIND_FIQ = const TrapKind::Fiq as u8,

--- a/components/axcpu/src/loongarch64/context.rs
+++ b/components/axcpu/src/loongarch64/context.rs
@@ -5,7 +5,7 @@ use core::{
 };
 
 use ax_memory_addr::VirtAddr;
-use cpu_local::{CurrentThreadHeader, PreparedThreadSwitch};
+use cpu_local::{ExecutionContextHeader, PreparedContextSwitch};
 
 use crate::{KernelTlsBase, TaskLocalState};
 
@@ -325,14 +325,14 @@ impl TaskContext {
         self.task_local.set_kernel_tls(kernel_tls);
     }
 
-    /// Sets the pinned task-owned current-thread header.
-    pub fn set_current_header(&mut self, header: NonNull<CurrentThreadHeader>) {
-        self.task_local.set_current_header(header);
+    /// Sets the pinned task-owned execution-context header.
+    pub fn set_context_header(&mut self, header: NonNull<ExecutionContextHeader>) {
+        self.task_local.set_context_header(header);
     }
 
-    /// Returns the configured task-owned current-thread header.
-    pub const fn current_header(&self) -> Option<NonNull<CurrentThreadHeader>> {
-        self.task_local.current_header()
+    /// Returns the configured task-owned execution-context header.
+    pub const fn context_header(&self) -> Option<NonNull<ExecutionContextHeader>> {
+        self.task_local.context_header()
     }
 
     /// Changes the page table root restored for this task.
@@ -341,7 +341,7 @@ impl TaskContext {
         self.page_table_root = page_table_root.as_usize();
     }
 
-    /// Completes FPU work before current-thread publication.
+    /// Completes FPU work before current-context publication.
     pub fn prepare_switch_to(&mut self, _next_ctx: &Self) {
         #[cfg(feature = "fp-simd")]
         {
@@ -370,10 +370,10 @@ impl TaskContext {
     pub unsafe fn switch_to_prepared(
         &mut self,
         next_ctx: &Self,
-        prepared: PreparedThreadSwitch<'_>,
+        prepared: PreparedContextSwitch<'_>,
     ) {
         assert_eq!(
-            next_ctx.current_header(),
+            next_ctx.context_header(),
             Some(prepared.next_header()),
             "prepared switch token must belong to the next task context",
         );
@@ -535,7 +535,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         ld.d    $s0, $a1, {s0_offset}
         ld.d    $sp, $a1, {sp_offset}
         ld.d    $ra, $a1, {ra_offset}
-        ld.d    $tp, $a1, {current_header_offset}
+        ld.d    $tp, $a1, {context_header_offset}
         ret",
         ra_offset = const offset_of!(TaskContext, ra),
         sp_offset = const offset_of!(TaskContext, sp),
@@ -549,7 +549,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         s7_offset = const offset_of!(TaskContext, s) + size_of::<[usize; 7]>(),
         s8_offset = const offset_of!(TaskContext, s) + size_of::<[usize; 8]>(),
         frame_pointer_offset = const offset_of!(TaskContext, s) + size_of::<[usize; 9]>(),
-        current_header_offset = const offset_of!(TaskContext, task_local)
-            + offset_of!(TaskLocalState, current_header),
+        context_header_offset = const offset_of!(TaskContext, task_local)
+            + offset_of!(TaskLocalState, context_header),
     )
 }

--- a/components/axcpu/src/riscv/context.rs
+++ b/components/axcpu/src/riscv/context.rs
@@ -5,7 +5,7 @@ use core::{
 };
 
 use ax_memory_addr::VirtAddr;
-use cpu_local::{CurrentThreadHeader, PreparedThreadSwitch};
+use cpu_local::{ExecutionContextHeader, PreparedContextSwitch};
 use riscv::register::sstatus::{self, FS};
 
 use crate::{KernelTlsBase, TaskLocalState};
@@ -353,14 +353,14 @@ impl TaskContext {
         self.task_local.set_kernel_tls(tls_area);
     }
 
-    /// Sets the pinned task-owned current-thread header.
-    pub fn set_current_header(&mut self, header: NonNull<CurrentThreadHeader>) {
-        self.task_local.set_current_header(header);
+    /// Sets the pinned task-owned execution-context header.
+    pub fn set_context_header(&mut self, header: NonNull<ExecutionContextHeader>) {
+        self.task_local.set_context_header(header);
     }
 
-    /// Returns the configured task-owned current-thread header.
-    pub const fn current_header(&self) -> Option<NonNull<CurrentThreadHeader>> {
-        self.task_local.current_header()
+    /// Returns the configured task-owned execution-context header.
+    pub const fn context_header(&self) -> Option<NonNull<ExecutionContextHeader>> {
+        self.task_local.context_header()
     }
 
     /// Changes the page table root restored for this task.
@@ -369,7 +369,7 @@ impl TaskContext {
         self.page_table_root = page_table_root;
     }
 
-    /// Completes FP/SIMD work before current-thread publication.
+    /// Completes FP/SIMD work before current-context publication.
     pub fn prepare_switch_to(&mut self, _next_ctx: &Self) {
         #[cfg(feature = "fp-simd")]
         {
@@ -393,10 +393,10 @@ impl TaskContext {
     pub unsafe fn switch_to_prepared(
         &mut self,
         next_ctx: &Self,
-        prepared: PreparedThreadSwitch<'_>,
+        prepared: PreparedContextSwitch<'_>,
     ) {
         assert_eq!(
-            next_ctx.current_header(),
+            next_ctx.context_header(),
             Some(prepared.next_header()),
             "prepared switch token must belong to the next task context",
         );
@@ -540,7 +540,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         LDR     s1, a1, {s1_index}
         LDR     s0, a1, {s0_index}
         LDR     sp, a1, {sp_index}
-        LDR     tp, a1, {current_header_index}
+        LDR     tp, a1, {context_header_index}
         LDR     ra, a1, {ra_index}
         ret",
         ra_index = const offset_of!(TaskContext, ra) / size_of::<usize>(),
@@ -557,7 +557,7 @@ unsafe extern "C" fn context_switch_raw(_current_task: &mut TaskContext, _next_t
         s9_index = const offset_of!(TaskContext, s9) / size_of::<usize>(),
         s10_index = const offset_of!(TaskContext, s10) / size_of::<usize>(),
         s11_index = const offset_of!(TaskContext, s11) / size_of::<usize>(),
-        current_header_index = const (offset_of!(TaskContext, task_local)
-            + offset_of!(TaskLocalState, current_header)) / size_of::<usize>(),
+        context_header_index = const (offset_of!(TaskContext, task_local)
+            + offset_of!(TaskLocalState, context_header)) / size_of::<usize>(),
     )
 }

--- a/components/axcpu/src/riscv/local_state.rs
+++ b/components/axcpu/src/riscv/local_state.rs
@@ -3,9 +3,9 @@
 use core::mem::{offset_of, size_of};
 
 #[cfg(not(feature = "tls"))]
-use cpu_local::CURRENT_THREAD_ARCH_STATE_OFFSET;
+use cpu_local::EXECUTION_CONTEXT_ARCH_STATE_OFFSET;
 use cpu_local::{
-    CPU_AREA_ARCH_STATE_OFFSET, CPU_AREA_ARCH_STATE_SIZE, CURRENT_THREAD_ARCH_STATE_SIZE,
+    CPU_AREA_ARCH_STATE_OFFSET, CPU_AREA_ARCH_STATE_SIZE, EXECUTION_CONTEXT_ARCH_STATE_SIZE,
 };
 
 /// CPU-owned state used by user/kernel trap stack handoff.
@@ -36,12 +36,12 @@ pub(super) const CPU_ENTRY_SCRATCH1_OFFSET: usize =
     CPU_AREA_ARCH_STATE_OFFSET + offset_of!(CpuTrapState, entry_scratch1);
 #[cfg(not(feature = "tls"))]
 pub(super) const THREAD_SCRATCH0_OFFSET: usize =
-    CURRENT_THREAD_ARCH_STATE_OFFSET + offset_of!(ThreadTrapState, scratch0);
+    EXECUTION_CONTEXT_ARCH_STATE_OFFSET + offset_of!(ThreadTrapState, scratch0);
 #[cfg(not(feature = "tls"))]
 pub(super) const THREAD_SCRATCH1_OFFSET: usize =
-    CURRENT_THREAD_ARCH_STATE_OFFSET + offset_of!(ThreadTrapState, scratch1);
+    EXECUTION_CONTEXT_ARCH_STATE_OFFSET + offset_of!(ThreadTrapState, scratch1);
 
 const _: () = {
     assert!(size_of::<CpuTrapState>() <= CPU_AREA_ARCH_STATE_SIZE);
-    assert!(size_of::<ThreadTrapState>() <= CURRENT_THREAD_ARCH_STATE_SIZE);
+    assert!(size_of::<ThreadTrapState>() <= EXECUTION_CONTEXT_ARCH_STATE_SIZE);
 };

--- a/components/axcpu/src/riscv/trap.S
+++ b/components/axcpu/src/riscv/trap.S
@@ -2,7 +2,7 @@
 .balign 4
 .global trap_vector_base
 trap_vector_base:
-    // LinuxCurrent owns tp as the pinned current-thread header. In kernel
+    // LinuxCurrent owns tp as the pinned execution-context header. In kernel
     // mode sscratch is zero; immediately before sret to user it carries the
     // kernel tp while user tp is live. This swap identifies the trap origin
     // without ever treating a userspace value as a CPU-area pointer.

--- a/components/axcpu/src/riscv/trap.rs
+++ b/components/axcpu/src/riscv/trap.rs
@@ -1,7 +1,7 @@
 use core::mem::size_of;
 
 #[cfg(not(feature = "tls"))]
-use cpu_local::CURRENT_THREAD_CPU_BASE_OFFSET;
+use cpu_local::EXECUTION_CONTEXT_CPU_BASE_OFFSET;
 #[cfg(feature = "fp-simd")]
 use riscv::register::sstatus;
 use riscv::{
@@ -102,7 +102,7 @@ core::arch::global_asm!(
     trapframe_size = const size_of::<RawTrapFrame>(),
     kernel_stack_pointer_index = const CPU_KERNEL_STACK_POINTER_OFFSET / size_of::<usize>(),
     user_trap_frame_index = const CPU_USER_TRAP_FRAME_OFFSET / size_of::<usize>(),
-    thread_cpu_base_index = const CURRENT_THREAD_CPU_BASE_OFFSET / size_of::<usize>(),
+    thread_cpu_base_index = const EXECUTION_CONTEXT_CPU_BASE_OFFSET / size_of::<usize>(),
     thread_scratch0_index = const THREAD_SCRATCH0_OFFSET / size_of::<usize>(),
     thread_scratch1_index = const THREAD_SCRATCH1_OFFSET / size_of::<usize>(),
 );

--- a/components/axcpu/src/task_local.rs
+++ b/components/axcpu/src/task_local.rs
@@ -1,6 +1,6 @@
 use core::ptr::NonNull;
 
-use cpu_local::CurrentThreadHeader;
+use cpu_local::ExecutionContextHeader;
 
 use crate::KernelTlsBase;
 
@@ -13,7 +13,7 @@ use crate::KernelTlsBase;
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct TaskLocalState {
-    pub(crate) current_header: usize,
+    pub(crate) context_header: usize,
     pub(crate) kernel_tls: KernelTlsBase,
 }
 
@@ -21,7 +21,7 @@ impl TaskLocalState {
     /// Creates empty task-local switch state.
     pub const fn new() -> Self {
         Self {
-            current_header: 0,
+            context_header: 0,
             kernel_tls: KernelTlsBase::new(0),
         }
     }
@@ -31,14 +31,14 @@ impl TaskLocalState {
         self.kernel_tls = KernelTlsBase::for_task_context(kernel_tls);
     }
 
-    /// Sets the stable task-owned current-thread header.
-    pub fn set_current_header(&mut self, header: NonNull<CurrentThreadHeader>) {
-        self.current_header = header.as_ptr() as usize;
+    /// Sets the stable task-owned execution-context header.
+    pub fn set_context_header(&mut self, header: NonNull<ExecutionContextHeader>) {
+        self.context_header = header.as_ptr() as usize;
     }
 
-    /// Returns the configured task-owned current-thread header.
-    pub const fn current_header(&self) -> Option<NonNull<CurrentThreadHeader>> {
-        NonNull::new(self.current_header as *mut CurrentThreadHeader)
+    /// Returns the configured task-owned execution-context header.
+    pub const fn context_header(&self) -> Option<NonNull<ExecutionContextHeader>> {
+        NonNull::new(self.context_header as *mut ExecutionContextHeader)
     }
 }
 

--- a/components/axcpu/src/x86_64/context.rs
+++ b/components/axcpu/src/x86_64/context.rs
@@ -6,7 +6,7 @@ use core::{
 };
 
 use ax_memory_addr::VirtAddr;
-use cpu_local::{CurrentThreadHeader, PreparedThreadSwitch};
+use cpu_local::{ExecutionContextHeader, PreparedContextSwitch};
 
 use crate::{KernelTlsBase, TaskLocalState};
 
@@ -430,15 +430,15 @@ impl TaskContext {
         self.task_local.set_kernel_tls(kernel_tls);
     }
 
-    /// Sets the pinned task-owned current-thread header restored by the raw
+    /// Sets the pinned task-owned execution-context header restored by the raw
     /// switch tail in LinuxCurrent images.
-    pub fn set_current_header(&mut self, header: NonNull<CurrentThreadHeader>) {
-        self.task_local.set_current_header(header);
+    pub fn set_context_header(&mut self, header: NonNull<ExecutionContextHeader>) {
+        self.task_local.set_context_header(header);
     }
 
-    /// Returns the configured task-owned current-thread header.
-    pub const fn current_header(&self) -> Option<NonNull<CurrentThreadHeader>> {
-        self.task_local.current_header()
+    /// Returns the configured task-owned execution-context header.
+    pub const fn context_header(&self) -> Option<NonNull<ExecutionContextHeader>> {
+        self.task_local.context_header()
     }
 
     /// Changes the page table root restored for this task.
@@ -462,7 +462,7 @@ impl TaskContext {
         }
     }
 
-    /// Commits current-thread publication and performs the raw transfer.
+    /// Commits current-context publication and performs the raw transfer.
     ///
     /// # Safety
     ///
@@ -473,10 +473,10 @@ impl TaskContext {
     pub unsafe fn switch_to_prepared(
         &mut self,
         next_ctx: &Self,
-        prepared: PreparedThreadSwitch<'_>,
+        prepared: PreparedContextSwitch<'_>,
     ) {
         assert_eq!(
-            next_ctx.current_header(),
+            next_ctx.context_header(),
             Some(prepared.next_header()),
             "prepared switch token must belong to the next task context",
         );

--- a/components/axcpu/tests/image_register_mode_contract.rs
+++ b/components/axcpu/tests/image_register_mode_contract.rs
@@ -26,7 +26,7 @@ fn tls_feature_selects_register_semantics_without_changing_context_layout() {
             "image mode must not change TaskContext ABI"
         );
     }
-    assert!(TASK_LOCAL.contains("current_header: usize"));
+    assert!(TASK_LOCAL.contains("context_header: usize"));
     assert!(TASK_LOCAL.contains("kernel_tls: KernelTlsBase"));
     assert!(LIB.contains("fn for_task_context"));
     assert!(LIB.contains("requested.0 == 0"));
@@ -80,21 +80,20 @@ fn context_switches_select_tls_only_for_unikernel_images() {
 #[test]
 fn aarch64_user_exit_restores_linux_current_before_rust() {
     let exit = section(AARCH_TRAP, ".Lexit_user:", ".global enter_user");
-    assert_in_order(exit, "stp     x8, x9", "mrs     x12, tpidr_el1");
     assert_in_order(
         exit,
-        "mrs     x12, tpidr_el1",
-        "ldr     x12, [x12, {current_thread_offset}]",
+        "ldp     x10, x11, [x1, {trapframe_size}]",
+        "ldr     x12, [x10, 12 * 8]",
     );
-    assert_in_order(
-        exit,
-        "ldr     x12, [x12, {current_thread_offset}]",
-        "msr     sp_el0, x12",
-    );
+    assert_in_order(exit, "ldr     x12, [x10, 12 * 8]", "msr     sp_el0, x12");
     assert_in_order(exit, "msr     sp_el0, x12", "\n    ret");
+    assert!(!exit.contains("tpidr_el1"));
+    assert!(!exit.contains("tpidr_el2"));
+    assert!(!exit.contains("current_context_offset"));
 
     let enter = section(AARCH_TRAP, "enter_user:", ".Lexception_return:");
-    assert_in_order(enter, "ldp     x8, x9", "msr     sp_el0, x8");
+    assert_in_order(enter, "mrs     x12, sp_el0", "str     x12, [sp, 12 * 8]");
+    assert_in_order(enter, "str     x12, [sp, 12 * 8]", "msr     sp_el0, x8");
     assert_in_order(enter, "msr     sp_el0, x8", "msr     tpidr_el0, x9");
     assert_in_order(enter, "msr     tpidr_el0, x9", "mov     sp, x0");
 }

--- a/components/axcpu/tests/riscv_register_contract.rs
+++ b/components/axcpu/tests/riscv_register_contract.rs
@@ -70,10 +70,10 @@ fn task_context_switches_tp_inside_the_naked_handoff() {
     let linux_switch = section(
         CONTEXT,
         "#[cfg(not(feature = \"tls\"))]\n#[unsafe(naked)]",
-        "+ offset_of!(TaskLocalState, current_header)) / size_of::<usize>(),",
+        "+ offset_of!(TaskLocalState, context_header)) / size_of::<usize>(),",
     );
     assert!(!linux_switch.contains("STR     tp"));
-    assert!(linux_switch.contains("LDR     tp, a1, {current_header_index}"));
+    assert!(linux_switch.contains("LDR     tp, a1, {context_header_index}"));
     assert_in_order(linux_switch, "LDR     sp", "LDR     tp");
     assert_in_order(linux_switch, "LDR     tp", "\n        ret\"");
 }
@@ -114,10 +114,10 @@ fn task_context_owns_kernel_tls_and_preserves_current_address_space_model() {
         CONTEXT.contains("kernel_tls_index = const (offset_of!(TaskContext, task_local)")
             && CONTEXT.contains("offset_of!(TaskLocalState, kernel_tls)")
             && CONTEXT
-                .contains("current_header_index = const (offset_of!(TaskContext, task_local)")
-            && CONTEXT.contains("offset_of!(TaskLocalState, current_header)")
+                .contains("context_header_index = const (offset_of!(TaskContext, task_local)")
+            && CONTEXT.contains("offset_of!(TaskLocalState, context_header)")
             && TASK_LOCAL.contains("kernel_tls: KernelTlsBase")
-            && TASK_LOCAL.contains("current_header: usize"),
+            && TASK_LOCAL.contains("context_header: usize"),
         "both image-mode assembly offsets must derive from TaskContext"
     );
 
@@ -189,7 +189,7 @@ fn trap_entry_uses_privilege_origin_and_restores_cpu_anchor_before_rust() {
         "LinuxCurrent must not treat sscratch as the permanent CPU prefix"
     );
 
-    assert!(TRAP_GLUE.contains("CURRENT_THREAD_CPU_BASE_OFFSET"));
+    assert!(TRAP_GLUE.contains("EXECUTION_CONTEXT_CPU_BASE_OFFSET"));
     for field in [
         "CPU_KERNEL_STACK_POINTER_OFFSET",
         "CPU_USER_TRAP_FRAME_OFFSET",
@@ -205,7 +205,7 @@ fn trap_entry_uses_privilege_origin_and_restores_cpu_anchor_before_rust() {
         "struct CpuTrapState",
         "struct ThreadTrapState",
         "CPU_AREA_ARCH_STATE_OFFSET",
-        "CURRENT_THREAD_ARCH_STATE_OFFSET",
+        "EXECUTION_CONTEXT_ARCH_STATE_OFFSET",
     ] {
         assert!(
             LOCAL_STATE.contains(field),

--- a/components/axcpu/tests/task_context_layout_contract.rs
+++ b/components/axcpu/tests/task_context_layout_contract.rs
@@ -44,7 +44,7 @@ fn every_task_context_has_a_compile_time_layout_contract() {
             );
         }
     }
-    assert!(TASK_LOCAL.contains("current_header: usize"));
+    assert!(TASK_LOCAL.contains("context_header: usize"));
     assert!(TASK_LOCAL.contains("kernel_tls: KernelTlsBase"));
     assert!(TASK_LOCAL.contains("size_of::<TaskLocalState>()"));
 }
@@ -81,8 +81,8 @@ fn aarch64_switch_uses_only_rust_derived_task_offsets() {
             "AArch64 context switch must use the named `{field}` offset",
         );
     }
-    assert_task_local_derived_offset(AARCH64_CONTEXT, "current_header", "offset");
-    assert!(AARCH64_CONTEXT.contains("{current_header_offset}"));
+    assert_task_local_derived_offset(AARCH64_CONTEXT, "context_header", "offset");
+    assert!(AARCH64_CONTEXT.contains("{context_header_offset}"));
     for base in ["x0", "x1"] {
         assert!(!context_switch.contains(&format!("[{base}]")));
         for index in 0..=12 {
@@ -107,9 +107,9 @@ fn riscv_switch_uses_only_rust_derived_task_offsets() {
         );
     }
     assert_task_local_derived_offset(RISCV_CONTEXT, "kernel_tls", "index");
-    assert_task_local_derived_offset(RISCV_CONTEXT, "current_header", "index");
+    assert_task_local_derived_offset(RISCV_CONTEXT, "context_header", "index");
     assert!(RISCV_CONTEXT.contains("{kernel_tls_index}"));
-    assert!(RISCV_CONTEXT.contains("{current_header_index}"));
+    assert!(RISCV_CONTEXT.contains("{context_header_index}"));
     assert_no_numeric_macro_slots(context_switch, "a0", 0..=13);
     assert_no_numeric_macro_slots(context_switch, "a1", 0..=13);
 }
@@ -141,8 +141,8 @@ fn loongarch_switch_uses_only_rust_derived_task_offsets() {
         assert_rust_derived_offset(LOONGARCH_CONTEXT, field, "offset");
     }
     assert_task_local_derived_offset(LOONGARCH_CONTEXT, "kernel_tls", "offset");
-    assert_task_local_derived_offset(LOONGARCH_CONTEXT, "current_header", "offset");
-    assert!(LOONGARCH_CONTEXT.contains("{current_header_offset}"));
+    assert_task_local_derived_offset(LOONGARCH_CONTEXT, "context_header", "offset");
+    assert!(LOONGARCH_CONTEXT.contains("{context_header_offset}"));
     assert!(
         LOONGARCH_CONTEXT.contains("s0_offset = const offset_of!(TaskContext, s)"),
         "LoongArch saved-register array offsets must derive from its Rust field",

--- a/components/axcpu/tests/x86_aarch_context_boundary.rs
+++ b/components/axcpu/tests/x86_aarch_context_boundary.rs
@@ -29,7 +29,7 @@ fn aarch64_task_context_restores_current_and_tls_in_the_naked_window() {
     assert!(!naked_switch.contains("write_user_page_table"));
     assert!(naked_switch.contains("tpidr_el0"));
     assert!(naked_switch.contains("sp_el0"));
-    assert!(naked_switch.contains("current_header_offset"));
+    assert!(naked_switch.contains("context_header_offset"));
     assert!(!source.contains("pub fn switch_to("));
     assert!(!task_context_definition(&source).contains("ttbr0_el1"));
 }

--- a/components/cpu-local/README.md
+++ b/components/cpu-local/README.md
@@ -1,56 +1,79 @@
 # cpu-local
 
-Typed ownership boundary for CPU-local architecture registers.
+Typed ownership boundary for CPU-local architecture registers and synchronous
+execution-context state.
 
-The crate owns the fixed `CpuAreaPrefix`, CPU binding/epoch validation,
-current-thread publication, and task-pointer register operations. It does not
-allocate CPU areas, define per-CPU variables, schedule tasks, or choose IRQ
-policy; those responsibilities remain in `ax-percpu`, platform boot code, and
-the scheduler.
+The crate owns the fixed `CpuAreaPrefix`, architecture current-context source,
+context CPU binding epochs, context-switch transactions, and the
+architecture-selected preemption word. It does not allocate CPU areas, define
+per-CPU variables, own tasks or run queues, choose scheduling policy, manage
+IRQs, or deliver IPIs. Those responsibilities remain in `ax-percpu`, platform
+boot code, `ax-runtime`, and the task layer.
 
-| Architecture | CPU area | Current thread | TLS |
+| Architecture/image | CPU area | Current context | Kernel TLS |
 | --- | --- | --- | --- |
-| x86_64 | GS base | GS runtime anchor | FS base |
-| AArch64 | TPIDR_EL1/EL2 | SP_EL0 | TPIDR_EL0 |
-| RISC-V | prefix recovery or `sscratch` | `tp` without TLS; CPU runtime anchor with TLS | `tp=TLS`, `sscratch=CPU base` |
-| LoongArch64 | r21, mirrored in KS3 | `tp` without TLS; CPU runtime anchor with TLS | `tp=TLS` |
+| x86_64 | GS base | GS runtime anchor | FS base when enabled |
+| AArch64 | TPIDR_EL1/EL2 | SP_EL0 | TPIDR_EL0 when enabled |
+| RISC-V without TLS | header back-reference | `tp` | unavailable |
+| RISC-V with TLS | `sscratch` | CPU runtime anchor | `tp` |
+| LoongArch64 without TLS | r21, mirrored in KS3 | `tp` | unavailable |
+| LoongArch64 with TLS | r21, mirrored in KS3 | CPU runtime anchor | `tp` |
 
-LoongArch KS4 and KS5 are deliberately outside this contract and remain
-available to vCPU scratch state.
+Each final image selects exactly one current-context source. There is no second
+pointer that is updated and cross-checked. AArch64 temporarily lends SP_EL0 to
+userspace, so its user-transition assembly spills the current header in the
+pinned kernel stack and restores it before returning to Rust. LoongArch KS4 and
+KS5 remain outside this contract for vCPU scratch state.
 
-The `tls` feature enables task-owned kernel TLS. It does not choose current
-ownership globally. x86_64 keeps current in GS while FS owns TLS, and AArch64
-keeps current in SP_EL0 while TPIDR_EL0 owns TLS. RISC-V and LoongArch64 use the
-CPU runtime anchor for current only when their task register is occupied by
-kernel TLS. `host-test` provides a thread-local register model for host-side
-tests. These are the crate's only features; no runtime ABI mode is retained
-inside one final image.
+The `tls` feature selects the final-image register assignment. `host-test`
+provides a thread-local register model. These are the crate's only features;
+there is no runtime ABI mode inside one final image.
 
-Scheduler publication follows a strict sequence: validate the pinned binding,
-bind the next task header, prepare all fallible architecture work, consume a
-`PreparedThreadSwitch` to publish the CPU runtime anchor immediately before the
-raw switch, update a dedicated task register in that raw tail when the backend
-has one, then consume `PreviousThreadBinding` in the incoming tail. On AArch64
-the anchor is also the exception-entry backup while SP_EL0 is temporarily lent
-to userspace. Dropping an uncommitted prepared token rolls the next binding
-back. The binding epoch is a runtime stale-tail guard, not an ABI version.
+Context publication follows a strict transaction: validate the outgoing
+binding, bind the next `ExecutionContextHeader`, prepare fallible architecture
+work, consume `PreparedContextSwitch` at the final IRQ-disabled boundary,
+install the selected current source in the naked switch tail when required,
+then consume `PreviousContextBinding` in the incoming tail. Dropping an
+uncommitted prepared token rolls the next binding back. The binding epoch is a
+stale-tail guard, not an ABI version.
+
+`ExecutionContextHeader` starts with the CPU binding at offset zero and contains
+only architecture/context mechanisms. A runtime may embed it as the first
+field of its own wrapper and recover that wrapper directly from the current
+header address. `cpu-local` has no task owner pointer, runtime cookie, run-queue
+publication, or scheduler baton.
+
+Preemption is an architecture-selected linear capability. x86_64 owns its word
+in the CPU runtime anchor; load/store architectures own it in the current
+execution-context header. `enter_preemption` returns a non-`Send`, non-`Sync`,
+non-`Copy` `PreemptionToken` bound to that exact word. A final pending exit
+returns `PendingPreemption` without consuming the last depth. The runtime must
+first claim its scheduler baton, then call `release` and enter its safe point.
+Task policy and baton state never enter this crate.
+
+On a CPU-owned preemption architecture, the exclusion covering a raw context
+switch is normally finished by the suspended incoming caller. A context running
+for the first time has no such caller, so its first-entry tail uses the hidden
+`release_initial_context_preemption` handoff. Context-owned architectures start
+the new header enabled and perform no release.
 
 `CpuPin` can only be created by the higher-ranked `with_cpu_pin` boundary and
 cannot escape its migration guard. `ExclusiveCpu` additionally represents
-excluded local IRQ/re-entry and conflicting remote access. This crate validates
-those capabilities but does not itself disable preemption or interrupts.
+excluded local IRQ/re-entry and conflicting remote access. The crate validates
+those capabilities but does not itself mask interrupts.
 
 The exact initialized `CpuAreaRef` address is the layout identity. There is no
-ABI version, generation, or cookie inside one final image. The task binding
-epoch is intentionally retained because it rejects an obsolete incoming switch
-tail after the same task has been rebound.
+ABI version, layout generation, owner cookie, or provider FFI inside one final
+image. `someboot` still performs only raw area allocation and CPU startup;
+`axplat-dyn` validates the frozen layout before binding each `CpuAreaRef`.
 
 | Operation | Required protection |
 | --- | --- |
 | Atomic per-CPU scalar | Migration disabled; local IRQs may remain enabled |
 | Shared `T: Sync` object | Migration disabled; object-owned synchronization |
 | Local mutable object | Migration, IRQ/re-entry, and remote conflicts excluded |
-| Scheduler switch | IRQs and migration disabled; prepared/previous tokens consumed |
+| Context switch | IRQs and migration disabled; prepared/previous tokens consumed |
+| Preemption safe point | IRQs disabled; runtime baton claimed before pending release |
 | vCPU execution | Migration disabled; host registers restored before host Rust |
 | CPU-area installation | CPU offline, traps disabled, area exclusively owned |
 

--- a/components/cpu-local/README.md
+++ b/components/cpu-local/README.md
@@ -52,10 +52,14 @@ first claim its scheduler baton, then call `release` and enter its safe point.
 Task policy and baton state never enter this crate.
 
 On a CPU-owned preemption architecture, the exclusion covering a raw context
-switch is normally finished by the suspended incoming caller. A context running
-for the first time has no such caller, so its first-entry tail uses the hidden
-`release_initial_context_preemption` handoff. Context-owned architectures start
-the new header enabled and perform no release.
+switch belongs to the CPU where each side executes. If a suspended context
+resumes on another CPU, the runtime uses the hidden
+`handoff_preemption_after_context_switch` operation to consume its old linear
+proof and adopt the equivalent switch depth left on the resumed CPU. A context
+running for the first time has no suspended caller, so its first-entry tail uses
+the hidden `release_initial_context_preemption` operation. Context-owned
+architectures keep the original token owner, start the new header enabled, and
+perform neither CPU-owner transfer nor initial release.
 
 `CpuPin` can only be created by the higher-ranked `with_cpu_pin` boundary and
 cannot escape its migration guard. `ExclusiveCpu` additionally represents

--- a/components/cpu-local/src/area.rs
+++ b/components/cpu-local/src/area.rs
@@ -1,49 +1,73 @@
+#[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
+use core::sync::atomic::Ordering;
 use core::{
     mem::{MaybeUninit, align_of, offset_of, size_of},
     ptr::NonNull,
-    sync::atomic::{AtomicUsize, Ordering},
+    sync::atomic::AtomicUsize,
 };
 
-use crate::{CpuIndex, CpuLocalError, CurrentThreadHeader};
+use crate::{CpuIndex, CpuLocalError, ExecutionContextHeader, preempt::PreemptionState};
 
-/// CPU-local scalar state shared by trap entry and scheduler publication.
+const fn runtime_anchor_reserved_size() -> usize {
+    64 - 5 * size_of::<usize>() - size_of::<PreemptionState>()
+}
+
+/// CPU-local scalar state shared by trap entry and context publication.
 #[repr(C, align(64))]
 pub struct CpuRuntimeAnchor {
-    current_thread: AtomicUsize,
+    current_context: AtomicUsize,
     architecture_state: [AtomicUsize; 4],
-    reserved: [u8; 64 - 5 * size_of::<usize>()],
+    preemption_state: PreemptionState,
+    reserved: [u8; runtime_anchor_reserved_size()],
 }
 
 impl CpuRuntimeAnchor {
-    const fn for_boot_thread(boot_thread: usize) -> Self {
+    const fn for_boot_context(boot_context: usize) -> Self {
+        let current_context = if cfg!(all(target_arch = "x86_64", not(feature = "host-test")))
+            || cfg!(all(
+                feature = "tls",
+                not(all(target_arch = "aarch64", not(feature = "host-test")))
+            )) {
+            boot_context
+        } else {
+            0
+        };
         Self {
-            current_thread: AtomicUsize::new(boot_thread),
+            current_context: AtomicUsize::new(current_context),
             architecture_state: [const { AtomicUsize::new(0) }; 4],
-            reserved: [0; 64 - 5 * size_of::<usize>()],
+            preemption_state: PreemptionState::bootstrap_disabled(),
+            reserved: [0; runtime_anchor_reserved_size()],
         }
     }
 
-    /// Acquires the current-thread pointer published by the scheduler.
-    pub fn current_thread_raw(&self) -> usize {
-        self.current_thread.load(Ordering::Acquire)
+    /// Acquires the context pointer in an anchor-backed image mode.
+    #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
+    pub(crate) fn current_context_raw(&self) -> usize {
+        self.current_context.load(Ordering::Acquire)
     }
 
-    pub(crate) const fn current_thread_slot(&self) -> &AtomicUsize {
-        &self.current_thread
+    #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
+    pub(crate) const fn current_context_slot(&self) -> &AtomicUsize {
+        &self.current_context
+    }
+
+    #[cfg(all(target_arch = "x86_64", not(feature = "host-test")))]
+    pub(crate) const fn preemption_state(&self) -> &PreemptionState {
+        &self.preemption_state
     }
 }
 
-/// Permanent current header used before the scheduler publishes a task.
+/// Permanent context header used before the runtime publishes a context.
 #[repr(transparent)]
-pub struct BootThreadHeader(CurrentThreadHeader);
+pub struct BootContextHeader(ExecutionContextHeader);
 
-impl BootThreadHeader {
+impl BootContextHeader {
     const fn for_area(area_base: usize) -> Self {
-        Self(CurrentThreadHeader::boot(area_base))
+        Self(ExecutionContextHeader::boot(area_base))
     }
 
     /// Returns the permanent pinned header.
-    pub const fn header(&self) -> &CurrentThreadHeader {
+    pub const fn header(&self) -> &ExecutionContextHeader {
         &self.0
     }
 }
@@ -90,7 +114,7 @@ impl CpuAreaHeader {
 pub struct CpuAreaPrefix {
     header: CpuAreaHeader,
     runtime: CpuRuntimeAnchor,
-    boot_thread: BootThreadHeader,
+    boot_context: BootContextHeader,
 }
 
 impl CpuAreaPrefix {
@@ -99,16 +123,16 @@ impl CpuAreaPrefix {
     /// # Errors
     ///
     /// Returns an address error when `area_base` is null, misaligned, or its
-    /// fixed boot-thread address overflows.
+    /// fixed boot-context address overflows.
     pub fn initialize(cpu_index: CpuIndex, area_base: usize) -> Result<Self, CpuLocalError> {
         validate_area_base(area_base)?;
         area_base
-            .checked_add(CPU_AREA_BOOT_THREAD_OFFSET)
+            .checked_add(CPU_AREA_BOOT_CONTEXT_OFFSET)
             .ok_or(CpuLocalError::AddressOverflow)?;
         Ok(Self {
             header: CpuAreaHeader::new(cpu_index, area_base),
-            runtime: CpuRuntimeAnchor::for_boot_thread(area_base + CPU_AREA_BOOT_THREAD_OFFSET),
-            boot_thread: BootThreadHeader::for_area(area_base),
+            runtime: CpuRuntimeAnchor::for_boot_context(area_base + CPU_AREA_BOOT_CONTEXT_OFFSET),
+            boot_context: BootContextHeader::for_area(area_base),
         })
     }
 
@@ -122,9 +146,9 @@ impl CpuAreaPrefix {
         &self.runtime
     }
 
-    /// Returns the permanent boot current-thread header.
-    pub const fn boot_thread(&self) -> &BootThreadHeader {
-        &self.boot_thread
+    /// Returns the permanent boot execution-context header.
+    pub const fn boot_context(&self) -> &BootContextHeader {
+        &self.boot_context
     }
 }
 
@@ -163,20 +187,16 @@ impl CpuAreaRef {
             return Err(CpuLocalError::AreaIdentityMismatch);
         }
         let expected_boot = area_base
-            .checked_add(CPU_AREA_BOOT_THREAD_OFFSET)
+            .checked_add(CPU_AREA_BOOT_CONTEXT_OFFSET)
             .ok_or(CpuLocalError::AddressOverflow)?;
         if unsafe { prefix.as_ref() }
-            .runtime_anchor()
-            .current_thread_raw()
-            == 0
-            || unsafe { prefix.as_ref() }
-                .boot_thread()
-                .header()
-                .raw_cpu_binding()
-                .map(|(boot_area, _)| boot_area)
-                != Some(area_base)
+            .boot_context()
+            .header()
+            .raw_cpu_binding()
+            .map(|(boot_area, _)| boot_area)
+            != Some(area_base)
             || expected_boot
-                != core::ptr::addr_of!(unsafe { prefix.as_ref() }.boot_thread.0) as usize
+                != core::ptr::addr_of!(unsafe { prefix.as_ref() }.boot_context.0) as usize
         {
             return Err(CpuLocalError::AreaIdentityMismatch);
         }
@@ -217,32 +237,35 @@ fn validate_area_base(area_base: usize) -> Result<(), CpuLocalError> {
 pub const CPU_AREA_HEADER_SIZE: usize = size_of::<CpuAreaHeader>();
 /// Byte offset of CPU runtime/trap state.
 pub const CPU_AREA_RUNTIME_ANCHOR_OFFSET: usize = offset_of!(CpuAreaPrefix, runtime);
-/// Byte offset of the permanent boot current-thread header.
-pub const CPU_AREA_BOOT_THREAD_OFFSET: usize = offset_of!(CpuAreaPrefix, boot_thread);
+/// Byte offset of the permanent boot execution-context header.
+pub const CPU_AREA_BOOT_CONTEXT_OFFSET: usize = offset_of!(CpuAreaPrefix, boot_context);
 /// Byte offset of the runtime self pointer.
 pub const CPU_AREA_SELF_BASE_OFFSET: usize = offset_of!(CpuAreaHeader, self_base);
 /// Byte offset of the logical CPU index.
 pub const CPU_AREA_CPU_INDEX_OFFSET: usize = offset_of!(CpuAreaHeader, cpu_index);
-/// Byte offset of the current-thread slot.
-pub const CPU_AREA_CURRENT_THREAD_OFFSET: usize =
-    CPU_AREA_RUNTIME_ANCHOR_OFFSET + offset_of!(CpuRuntimeAnchor, current_thread);
+/// Byte offset of the current-context slot used by anchor-backed image modes.
+pub const CPU_AREA_CURRENT_CONTEXT_OFFSET: usize =
+    CPU_AREA_RUNTIME_ANCHOR_OFFSET + offset_of!(CpuRuntimeAnchor, current_context);
 /// Byte offset of architecture-owned CPU trap state.
 pub const CPU_AREA_ARCH_STATE_OFFSET: usize =
     CPU_AREA_RUNTIME_ANCHOR_OFFSET + offset_of!(CpuRuntimeAnchor, architecture_state);
 /// Reserved bytes available to the architecture-owned CPU trap state.
 pub const CPU_AREA_ARCH_STATE_SIZE: usize = 4 * size_of::<usize>();
+/// Byte offset of the x86_64 CPU-owned preemption word.
+pub const CPU_AREA_PREEMPTION_STATE_OFFSET: usize =
+    CPU_AREA_RUNTIME_ANCHOR_OFFSET + offset_of!(CpuRuntimeAnchor, preemption_state);
 
 const _: () = {
     assert!(size_of::<CpuAreaHeader>() == 64);
     assert!(align_of::<CpuAreaHeader>() == 64);
     assert!(size_of::<CpuRuntimeAnchor>() == 64);
     assert!(align_of::<CpuRuntimeAnchor>() == 64);
-    assert!(size_of::<BootThreadHeader>() == 64);
-    assert!(align_of::<BootThreadHeader>() == 64);
+    assert!(size_of::<BootContextHeader>() == 64);
+    assert!(align_of::<BootContextHeader>() == 64);
     assert!(size_of::<CpuAreaPrefix>() == 192);
     assert!(align_of::<CpuAreaPrefix>() == 64);
     assert!(CPU_AREA_RUNTIME_ANCHOR_OFFSET == 64);
-    assert!(CPU_AREA_BOOT_THREAD_OFFSET == 128);
+    assert!(CPU_AREA_BOOT_CONTEXT_OFFSET == 128);
 };
 
 #[doc(hidden)]

--- a/components/cpu-local/src/error.rs
+++ b/components/cpu-local/src/error.rs
@@ -22,27 +22,27 @@ pub enum CpuLocalError {
         /// Architecture-specific live exception level.
         level: usize,
     },
-    /// The CPU runtime slot and architecture current-thread register disagree.
-    #[error("current-thread register and CPU runtime slot disagree")]
-    CurrentThreadMismatch,
+    /// The selected current-context source does not identify a valid context.
+    #[error("current-context source does not identify this CPU's execution context")]
+    CurrentContextMismatch,
 }
 
-/// Failure while preparing or completing a scheduler thread switch.
+/// Failure while preparing or completing an execution-context switch.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
-pub enum ThreadSwitchError {
+pub enum ContextSwitchError {
     /// CPU-local state could not be validated.
     #[error(transparent)]
     CpuLocal(#[from] CpuLocalError),
-    /// The outgoing header is not the thread currently published on this CPU.
-    #[error("outgoing task does not match the published current thread")]
-    CurrentThreadMismatch,
-    /// The incoming switch tail was paired with another previous task.
-    #[error("previous-task token does not match the supplied task header")]
-    PreviousThreadMismatch,
-    /// The next task is already running or is in another binding transition.
-    #[error("next task is already bound to a CPU")]
-    NextThreadAlreadyBound,
+    /// The outgoing header is not the context currently selected on this CPU.
+    #[error("outgoing context does not match the selected current context")]
+    CurrentContextMismatch,
+    /// The switch tail was paired with another previous context.
+    #[error("previous-context token does not match the supplied context header")]
+    PreviousContextMismatch,
+    /// The next context is already running or is in another binding transition.
+    #[error("next context is already bound to a CPU")]
+    NextContextAlreadyBound,
     /// The incoming switch tail attempted to consume an obsolete binding epoch.
-    #[error("previous-task binding epoch is stale")]
+    #[error("previous-context binding epoch is stale")]
     StalePreviousBinding,
 }

--- a/components/cpu-local/src/lib.rs
+++ b/components/cpu-local/src/lib.rs
@@ -10,6 +10,7 @@ mod identity;
 #[cfg(target_arch = "loongarch64")]
 pub mod loongarch64;
 mod pin;
+mod preempt;
 mod register;
 mod switch;
 mod symbol;
@@ -19,15 +20,19 @@ pub use area::*;
 pub use error::*;
 pub use identity::*;
 pub use pin::*;
-pub use register::current_thread;
+pub use preempt::*;
+pub use register::current_context;
 #[cfg(feature = "tls")]
 #[doc(hidden)]
 pub use register::install_kernel_tls;
 #[cfg(feature = "tls")]
 pub use register::kernel_tls;
 #[doc(hidden)]
-pub use register::{install_bootstrap_thread, install_cpu_area, scheduler_current_thread};
-pub use switch::{PreparedThreadSwitch, PreviousThreadBinding, prepare_thread_switch};
+pub use register::{
+    current_context_unpinned, install_bootstrap_context, install_cpu_area,
+    is_permanent_boot_context,
+};
+pub use switch::{PreparedContextSwitch, PreviousContextBinding, prepare_context_switch};
 #[doc(hidden)]
 pub use symbol::{cpu_area_template_base, cpu_area_template_size};
 pub use thread::*;

--- a/components/cpu-local/src/pin.rs
+++ b/components/cpu-local/src/pin.rs
@@ -81,10 +81,9 @@ pub unsafe fn with_cpu_pin<R>(
         _scope: PhantomData,
         _not_send_or_sync: PhantomData,
     };
-    // Validate the second architecture-owned source before exposing any
-    // typed access. This catches a restored CPU base paired with a stale task
-    // register (notably after a vCPU exit) at the pin boundary.
-    register::current_thread(&pin)?;
+    // Validate the image's selected current-context source before exposing
+    // typed access. Each image mode has exactly one authoritative source.
+    register::current_context(&pin)?;
     Ok(operation(&pin))
 }
 

--- a/components/cpu-local/src/preempt.rs
+++ b/components/cpu-local/src/preempt.rs
@@ -214,6 +214,18 @@ impl PreemptionToken {
         // owner to remain live through this token's single finish operation.
         unsafe { self.owner.as_ref() }
     }
+
+    #[cfg(any(all(target_arch = "x86_64", not(feature = "host-test")), test))]
+    fn handoff_after_context_switch(self, resumed_owner: &PreemptionState) -> Self {
+        if self.owner == NonNull::from(resumed_owner) {
+            self
+        } else {
+            // The old CPU's incoming context consumed the depth represented by
+            // this proof. Consume the proof itself and adopt the equivalent
+            // depth left by the outgoing context on the resumed CPU.
+            Self::new(resumed_owner)
+        }
+    }
 }
 
 impl PendingPreemption {
@@ -281,6 +293,43 @@ pub fn clear_preemption_pending(pin: &CpuPin<'_>) -> Result<(), CpuLocalError> {
 /// Finishes the exact owner captured by [`enter_preemption`].
 pub fn finish_preemption(token: PreemptionToken) -> PreemptionExit {
     token.state().finish()
+}
+
+/// Transfers a CPU-owned switch exclusion to the CPU where its context resumed.
+///
+/// Context-owned tokens keep their original owner across migration. A CPU-owned
+/// token is replaced only when a context switch resumes it on another CPU: the
+/// old CPU's incoming context has already consumed the old switch depth, while
+/// this CPU's outgoing context left the matching depth for the resumed guard.
+///
+/// # Errors
+///
+/// Returns an error when the pinned CPU has no valid selected preemption owner.
+///
+/// # Panics
+///
+/// Panics when a context-owned architecture observes a different owner after
+/// the context switch. Such architectures migrate the owner with the context.
+#[doc(hidden)]
+pub fn handoff_preemption_after_context_switch(
+    pin: &CpuPin<'_>,
+    token: PreemptionToken,
+) -> Result<PreemptionToken, CpuLocalError> {
+    let owner = selected_state(pin)?;
+    #[cfg(all(target_arch = "x86_64", not(feature = "host-test")))]
+    {
+        Ok(token.handoff_after_context_switch(owner))
+    }
+
+    #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+    {
+        assert_eq!(
+            token.owner,
+            NonNull::from(owner),
+            "context-owned preemption token changed owner across a context switch"
+        );
+        Ok(token)
+    }
 }
 
 /// Releases the single preemption depth inherited by a bootstrap context.
@@ -431,6 +480,28 @@ mod tests {
         assert_eq!(original_cpu.snapshot().depth(), 0);
         assert_eq!(migrated_context.snapshot().depth(), 1);
         assert_eq!(migrated_cpu.snapshot().depth(), 1);
+    }
+
+    #[test]
+    fn cpu_owned_switch_token_handoff_follows_the_resumed_cpu() {
+        let original_cpu = PreemptionState::new();
+        let resumed_cpu = PreemptionState::new();
+
+        let suspended_switch = enter_on(&original_cpu);
+        // Another incoming context consumes the switch depth left on the old
+        // CPU while this context is suspended.
+        assert!(original_cpu.release_initial_switch());
+        // The outgoing context on the destination CPU leaves the equivalent
+        // switch depth for the context that is about to resume there.
+        resumed_cpu.enter();
+
+        let resumed_switch = suspended_switch.handoff_after_context_switch(&resumed_cpu);
+        assert!(matches!(
+            finish_preemption(resumed_switch),
+            PreemptionExit::Enabled
+        ));
+        assert_eq!(original_cpu.snapshot().depth(), 0);
+        assert_eq!(resumed_cpu.snapshot().depth(), 0);
     }
 
     #[test]

--- a/components/cpu-local/src/preempt.rs
+++ b/components/cpu-local/src/preempt.rs
@@ -1,0 +1,441 @@
+use core::{
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    ptr::NonNull,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+use crate::{CpuLocalError, CpuPin};
+
+const PREEMPT_NO_PENDING: u32 = 1 << 31;
+const PREEMPT_DEPTH_MASK: u32 = !PREEMPT_NO_PENDING;
+
+/// Snapshot of one architecture-selected preemption state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PreemptionSnapshot {
+    depth: u32,
+    pending: bool,
+}
+
+impl PreemptionSnapshot {
+    /// Returns the number of active preemption exclusions.
+    pub const fn depth(self) -> u32 {
+        self.depth
+    }
+
+    /// Returns whether work is pending at the next preemptible boundary.
+    pub const fn is_pending(self) -> bool {
+        self.pending
+    }
+}
+
+/// Linear proof of one entered preemption exclusion.
+#[must_use = "every entered preemption token must be finished exactly once"]
+pub struct PreemptionToken {
+    owner: NonNull<PreemptionState>,
+    _not_send_or_sync: PhantomData<*mut ()>,
+}
+
+/// Linear proof that the final preemption depth is reserved for a safe point.
+#[must_use = "pending preemption must be released by the external safe-point owner"]
+pub struct PendingPreemption {
+    owner: NonNull<PreemptionState>,
+    _not_send_or_sync: PhantomData<*mut ()>,
+}
+
+/// Result of finishing one preemption exclusion.
+#[must_use]
+pub enum PreemptionExit {
+    /// A nested depth was consumed; preemption remains excluded.
+    Nested,
+    /// The final depth was consumed and execution is preemptible.
+    Enabled,
+    /// The final depth remains reserved until an external safe point claims it.
+    Pending(PendingPreemption),
+}
+
+/// Architecture-neutral preemption word.
+///
+/// The high bit uses inverted pending polarity, allowing a newly initialized
+/// context to start enabled without a runtime initialization write. The low
+/// bits contain the exclusion depth. All updates are local to the selected CPU
+/// or pinned context; external safe-point serialization provides ordering for
+/// protected state, so this word does not publish cross-CPU data.
+#[repr(transparent)]
+pub(crate) struct PreemptionState(AtomicU32);
+
+impl PreemptionState {
+    pub(crate) const fn new() -> Self {
+        Self(AtomicU32::new(PREEMPT_NO_PENDING))
+    }
+
+    pub(crate) const fn bootstrap_disabled() -> Self {
+        Self(AtomicU32::new(PREEMPT_NO_PENDING | 1))
+    }
+
+    fn snapshot(&self) -> PreemptionSnapshot {
+        let state = self.0.load(Ordering::Relaxed);
+        PreemptionSnapshot {
+            depth: state & PREEMPT_DEPTH_MASK,
+            pending: state & PREEMPT_NO_PENDING == 0,
+        }
+    }
+
+    fn set_pending(&self) {
+        self.0.fetch_and(PREEMPT_DEPTH_MASK, Ordering::Relaxed);
+    }
+
+    fn clear_pending(&self) {
+        self.0.fetch_or(PREEMPT_NO_PENDING, Ordering::Relaxed);
+    }
+
+    #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+    fn enter(&self) {
+        let previous = self.0.fetch_add(1, Ordering::Relaxed);
+        assert_ne!(
+            previous & PREEMPT_DEPTH_MASK,
+            PREEMPT_DEPTH_MASK,
+            "preemption nesting overflow"
+        );
+    }
+
+    fn finish(&self) -> PreemptionExit {
+        loop {
+            let state = self.0.load(Ordering::Relaxed);
+            let depth = state & PREEMPT_DEPTH_MASK;
+            assert!(depth > 0, "unbalanced preemption exit");
+
+            if depth == 1 && state & PREEMPT_NO_PENDING == 0 {
+                return PreemptionExit::Pending(PendingPreemption::new(self));
+            }
+
+            let next = state - 1;
+            if self
+                .0
+                .compare_exchange_weak(state, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return if depth == 1 {
+                    PreemptionExit::Enabled
+                } else {
+                    PreemptionExit::Nested
+                };
+            }
+        }
+    }
+
+    fn release_pending(&self) {
+        assert_eq!(
+            self.0
+                .compare_exchange(1, 0, Ordering::Relaxed, Ordering::Relaxed),
+            Ok(1),
+            "pending preemption no longer owns the final depth"
+        );
+    }
+
+    fn release_bootstrap(&self) {
+        assert_eq!(
+            self.0.compare_exchange(
+                PREEMPT_NO_PENDING | 1,
+                PREEMPT_NO_PENDING,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ),
+            Ok(PREEMPT_NO_PENDING | 1),
+            "bootstrap preemption depth must be released exactly once"
+        );
+    }
+
+    #[cfg(any(all(target_arch = "x86_64", not(feature = "host-test")), test))]
+    fn release_initial_switch(&self) -> bool {
+        loop {
+            let state = self.0.load(Ordering::Relaxed);
+            if state == PREEMPT_NO_PENDING {
+                return false;
+            }
+            if state != (PREEMPT_NO_PENDING | 1) && state != 1 {
+                panic!("initial context switch found invalid preemption state {state:#x}");
+            }
+            // A nested outgoing guard may mirror its owner's pending bit after
+            // the switch guard was entered. The incoming context has its own
+            // upper-layer publication, so consume the inherited depth and
+            // reset that stale mirror as one transition.
+            if self
+                .0
+                .compare_exchange_weak(
+                    state,
+                    PREEMPT_NO_PENDING,
+                    Ordering::Relaxed,
+                    Ordering::Relaxed,
+                )
+                .is_ok()
+            {
+                return true;
+            }
+        }
+    }
+}
+
+impl PreemptionToken {
+    fn new(owner: &PreemptionState) -> Self {
+        Self {
+            owner: NonNull::from(owner),
+            _not_send_or_sync: PhantomData,
+        }
+    }
+
+    /// Converts this token into an opaque value for an ABI that transports
+    /// guard state as one machine word.
+    #[doc(hidden)]
+    pub fn into_raw(self) -> usize {
+        let token = ManuallyDrop::new(self);
+        token.owner.as_ptr() as usize
+    }
+
+    /// Reconstructs a token produced by [`Self::into_raw`].
+    ///
+    /// # Safety
+    ///
+    /// `raw` must come from one still-live token, refer to a live CPU-local
+    /// preemption owner, and be reconstructed and finished exactly once.
+    #[doc(hidden)]
+    pub unsafe fn from_raw(raw: usize) -> Option<Self> {
+        if !raw.is_multiple_of(core::mem::align_of::<PreemptionState>()) {
+            return None;
+        }
+        NonNull::new(raw as *mut PreemptionState).map(|owner| Self {
+            owner,
+            _not_send_or_sync: PhantomData,
+        })
+    }
+
+    fn state(&self) -> &PreemptionState {
+        // SAFETY: construction and raw reconstruction require the selected
+        // owner to remain live through this token's single finish operation.
+        unsafe { self.owner.as_ref() }
+    }
+}
+
+impl PendingPreemption {
+    fn new(owner: &PreemptionState) -> Self {
+        Self {
+            owner: NonNull::from(owner),
+            _not_send_or_sync: PhantomData,
+        }
+    }
+
+    /// Atomically consumes the final reserved preemption depth.
+    pub fn release(self) {
+        // SAFETY: the linear token retains its exact owner until this consume.
+        unsafe { self.owner.as_ref() }.release_pending();
+    }
+}
+
+/// Enters preemption exclusion on the owner selected by this architecture.
+#[inline(always)]
+pub fn enter_preemption() -> PreemptionToken {
+    #[cfg(all(target_arch = "x86_64", not(feature = "host-test")))]
+    {
+        // Increment through GS before resolving the token owner. Once the
+        // increment is visible this execution cannot migrate away from it.
+        unsafe { crate::register::enter_x86_preemption() };
+        let owner = crate::register::current_area()
+            .unwrap_or_else(|_| crate::register::fatal_register_invariant())
+            .runtime_anchor()
+            .preemption_state();
+        PreemptionToken::new(owner)
+    }
+
+    #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+    {
+        let current = unsafe { crate::current_context_unpinned() }
+            .unwrap_or_else(|_| crate::register::fatal_register_invariant());
+        // SAFETY: the architecture current register identifies the executing
+        // context itself. An interrupt may suspend and later migrate that
+        // context between this read and the increment, but it cannot resume
+        // this instruction stream as a different context; the pinned header
+        // stays live and therefore remains the exact token owner.
+        let owner = unsafe { current.as_ref() }.preemption_state();
+        owner.enter();
+        PreemptionToken::new(owner)
+    }
+}
+
+/// Observes the current architecture-selected preemption state.
+pub fn preemption_snapshot(pin: &CpuPin<'_>) -> Result<PreemptionSnapshot, CpuLocalError> {
+    Ok(selected_state(pin)?.snapshot())
+}
+
+/// Marks work pending at the current preemptible boundary.
+pub fn set_preemption_pending(pin: &CpuPin<'_>) -> Result<(), CpuLocalError> {
+    selected_state(pin)?.set_pending();
+    Ok(())
+}
+
+/// Clears the pending mark after the external owner has drained its work.
+pub fn clear_preemption_pending(pin: &CpuPin<'_>) -> Result<(), CpuLocalError> {
+    selected_state(pin)?.clear_pending();
+    Ok(())
+}
+
+/// Finishes the exact owner captured by [`enter_preemption`].
+pub fn finish_preemption(token: PreemptionToken) -> PreemptionExit {
+    token.state().finish()
+}
+
+/// Releases the single preemption depth inherited by a bootstrap context.
+///
+/// The caller uses this only after the context and every local safe-point
+/// dependency have been published.
+#[doc(hidden)]
+pub fn release_bootstrap_preemption(pin: &CpuPin<'_>) -> Result<(), CpuLocalError> {
+    selected_state(pin)?.release_bootstrap();
+    Ok(())
+}
+
+/// Releases the preemption exclusion transferred to a context on its first
+/// architecture switch.
+///
+/// CPU-owned preemption architectures carry the outgoing switch exclusion
+/// across the raw transfer, but a new context has no suspended caller whose
+/// guard can finish it. Context-owned architectures need no action because the
+/// new header begins enabled.
+#[doc(hidden)]
+pub fn release_initial_context_preemption(pin: &CpuPin<'_>) -> Result<bool, CpuLocalError> {
+    #[cfg(all(target_arch = "x86_64", not(feature = "host-test")))]
+    {
+        Ok(selected_state(pin)?.release_initial_switch())
+    }
+
+    #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+    {
+        let snapshot = selected_state(pin)?.snapshot();
+        assert_eq!(
+            snapshot.depth(),
+            0,
+            "new context-owned preemption state must start enabled"
+        );
+        Ok(false)
+    }
+}
+
+fn selected_state(pin: &CpuPin<'_>) -> Result<&'static PreemptionState, CpuLocalError> {
+    #[cfg(all(target_arch = "x86_64", not(feature = "host-test")))]
+    {
+        Ok(pin.area().runtime_anchor().preemption_state())
+    }
+
+    #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+    {
+        let current = crate::current_context(pin)?;
+        // SAFETY: current publication keeps the pinned context live, and the
+        // caller's CpuPin prevents it from changing during this observation.
+        Ok(unsafe { current.as_ref() }.preemption_state())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn enter_on(state: &PreemptionState) -> PreemptionToken {
+        state.enter();
+        PreemptionToken::new(state)
+    }
+
+    #[test]
+    fn nested_and_final_exits_are_linear() {
+        let state = PreemptionState::new();
+        let outer = enter_on(&state);
+        let inner = enter_on(&state);
+
+        assert!(matches!(finish_preemption(inner), PreemptionExit::Nested));
+        assert_eq!(state.snapshot().depth(), 1);
+        assert!(matches!(finish_preemption(outer), PreemptionExit::Enabled));
+        assert_eq!(state.snapshot().depth(), 0);
+    }
+
+    #[test]
+    fn pending_exit_reserves_depth_until_release() {
+        let state = PreemptionState::new();
+        let token = enter_on(&state);
+        state.set_pending();
+
+        let PreemptionExit::Pending(pending) = finish_preemption(token) else {
+            panic!("final pending exit must retain its depth");
+        };
+        assert_eq!(state.snapshot().depth(), 1);
+        pending.release();
+        assert_eq!(state.snapshot().depth(), 0);
+        assert!(state.snapshot().is_pending());
+    }
+
+    #[test]
+    fn bootstrap_starts_disabled() {
+        let state = PreemptionState::bootstrap_disabled();
+        assert_eq!(state.snapshot().depth(), 1);
+        assert!(!state.snapshot().is_pending());
+    }
+
+    #[test]
+    fn initial_switch_discards_outgoing_pending_mirror() {
+        let state = PreemptionState::bootstrap_disabled();
+        state.set_pending();
+
+        assert!(state.release_initial_switch());
+        assert_eq!(state.snapshot().depth(), 0);
+        assert!(!state.snapshot().is_pending());
+    }
+
+    #[test]
+    #[should_panic(expected = "pending preemption no longer owns the final depth")]
+    fn pending_depth_cannot_be_consumed_twice() {
+        let state = PreemptionState(AtomicU32::new(1));
+        let first = PendingPreemption::new(&state);
+        let duplicate = PendingPreemption::new(&state);
+
+        first.release();
+        duplicate.release();
+    }
+
+    #[test]
+    #[should_panic(expected = "bootstrap preemption depth must be released exactly once")]
+    fn bootstrap_depth_cannot_be_released_twice() {
+        let state = PreemptionState::bootstrap_disabled();
+
+        state.release_bootstrap();
+        state.release_bootstrap();
+    }
+
+    #[test]
+    fn token_stays_bound_to_the_entry_owner() {
+        let original_context = PreemptionState::new();
+        let migrated_context = PreemptionState::new();
+        let original_cpu = PreemptionState::new();
+        let migrated_cpu = PreemptionState::new();
+
+        let context_token = enter_on(&original_context);
+        let cpu_token = enter_on(&original_cpu);
+        migrated_context.enter();
+        migrated_cpu.enter();
+
+        assert!(matches!(
+            finish_preemption(context_token),
+            PreemptionExit::Enabled
+        ));
+        assert!(matches!(
+            finish_preemption(cpu_token),
+            PreemptionExit::Enabled
+        ));
+        assert_eq!(original_context.snapshot().depth(), 0);
+        assert_eq!(original_cpu.snapshot().depth(), 0);
+        assert_eq!(migrated_context.snapshot().depth(), 1);
+        assert_eq!(migrated_cpu.snapshot().depth(), 1);
+    }
+
+    #[test]
+    fn malformed_raw_owner_is_rejected() {
+        // SAFETY: no token is reconstructed because the value is misaligned.
+        assert!(unsafe { PreemptionToken::from_raw(1) }.is_none());
+    }
+}

--- a/components/cpu-local/src/register/aarch64.rs
+++ b/components/cpu-local/src/register/aarch64.rs
@@ -1,7 +1,8 @@
 use super::*;
 
 pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
-    current_source_aliases_kernel_tls: false,
+    linux_current: CurrentContextSource::ArchitectureRegister,
+    unikernel_tls: CurrentContextSource::ArchitectureRegister,
 };
 
 fn current_el() -> Result<usize, CpuLocalError> {
@@ -19,13 +20,13 @@ pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
     current_el().map(|_| ())
 }
 
-pub(super) unsafe fn install_cpu_base(area_base: usize, boot_thread: usize) {
+pub(super) unsafe fn install_cpu_base(area_base: usize, boot_context: usize) {
     match current_el().unwrap_or_else(|_| super::fatal_register_invariant()) {
         1 => unsafe { core::arch::asm!("msr TPIDR_EL1, {base}", base = in(reg) area_base) },
         2 => unsafe { core::arch::asm!("msr TPIDR_EL2, {base}", base = in(reg) area_base) },
         _ => unreachable!(),
     }
-    unsafe { core::arch::asm!("msr SP_EL0, {current}", current = in(reg) boot_thread) };
+    unsafe { core::arch::asm!("msr SP_EL0, {current}", current = in(reg) boot_context) };
 }
 
 pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
@@ -38,13 +39,13 @@ pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
     Ok(area_base)
 }
 
-pub(super) unsafe fn read_current_thread(_area_base: usize) -> usize {
+pub(super) unsafe fn read_current_context(_area_base: usize) -> usize {
     let current: usize;
     unsafe { core::arch::asm!("mrs {current}, SP_EL0", current = out(reg) current) };
     current
 }
 
-pub(super) unsafe fn write_current_thread(value: usize) {
+pub(super) unsafe fn write_current_context(value: usize) {
     unsafe { core::arch::asm!("msr SP_EL0, {value}", value = in(reg) value) };
 }
 

--- a/components/cpu-local/src/register/host.rs
+++ b/components/cpu-local/src/register/host.rs
@@ -3,11 +3,13 @@ use core::cell::Cell;
 use super::*;
 
 pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
-    current_source_aliases_kernel_tls: false,
+    linux_current: CurrentContextSource::ArchitectureRegister,
+    unikernel_tls: CurrentContextSource::RuntimeAnchor,
 };
 
 std::thread_local! {
     static CPU_BASE: Cell<usize> = const { Cell::new(0) };
+    static ARCHITECTURE_CURRENT: Cell<usize> = const { Cell::new(0) };
     static KERNEL_TLS: Cell<usize> = const { Cell::new(0) };
     #[cfg(test)]
     static MIGRATION_TARGET: Cell<usize> = const { Cell::new(0) };
@@ -17,15 +19,20 @@ pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
     Ok(())
 }
 
-pub(super) unsafe fn install_cpu_base(area_base: usize, _boot_thread: usize) {
+pub(super) unsafe fn install_cpu_base(area_base: usize, boot_context: usize) {
     CPU_BASE.set(area_base);
+    ARCHITECTURE_CURRENT.set(if cfg!(feature = "tls") {
+        0
+    } else {
+        boot_context
+    });
 }
 
 pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
     Ok(CPU_BASE.get())
 }
 
-pub(super) unsafe fn read_current_thread(_area_base: usize) -> usize {
+pub(super) unsafe fn read_current_context(area_base: usize) -> usize {
     #[cfg(test)]
     MIGRATION_TARGET.with(|target| {
         let target = target.replace(0);
@@ -33,17 +40,22 @@ pub(super) unsafe fn read_current_thread(_area_base: usize) -> usize {
             CPU_BASE.set(target);
         }
     });
-    // Host tests execute on x86_64, whose current pointer is the GS runtime
-    // anchor itself. Read the live modeled CPU, rather than a previously
-    // sampled base, so tests can reproduce migration between the two reads.
-    let area_base = CPU_BASE.get();
-    if area_base == 0 {
-        return 0;
+    if cfg!(feature = "tls") {
+        // SAFETY: the shared caller validated the sampled shutdown-lifetime
+        // CPU area before asking the host backend for its selected source.
+        return unsafe { area_runtime_anchor(area_base) }.current_context_raw();
     }
-    unsafe { area_runtime_anchor(area_base) }.current_thread_raw()
+    ARCHITECTURE_CURRENT
+        .with(|current| {
+            let current = current.get();
+            (current != 0).then_some(current)
+        })
+        .unwrap_or(0)
 }
 
-pub(super) unsafe fn write_current_thread(_value: usize) {}
+pub(super) unsafe fn write_current_context(value: usize) {
+    ARCHITECTURE_CURRENT.set(value);
+}
 
 #[cfg(feature = "tls")]
 pub(super) unsafe fn read_kernel_tls() -> usize {
@@ -55,13 +67,19 @@ pub(super) unsafe fn write_kernel_tls(value: usize) {
     KERNEL_TLS.set(value);
 }
 
-unsafe fn area_runtime_anchor(area_base: usize) -> &'static crate::CpuRuntimeAnchor {
-    unsafe {
-        &*((area_base + crate::CPU_AREA_RUNTIME_ANCHOR_OFFSET) as *const crate::CpuRuntimeAnchor)
-    }
-}
-
 #[cfg(test)]
 pub(super) fn migrate_on_next_current_read(area_base: usize) {
     MIGRATION_TARGET.set(area_base);
+}
+
+#[cfg(all(test, not(feature = "tls")))]
+pub(super) fn set_architecture_current(current: usize) {
+    ARCHITECTURE_CURRENT.set(current);
+}
+
+unsafe fn area_runtime_anchor(area_base: usize) -> &'static crate::CpuRuntimeAnchor {
+    // SAFETY: forwarded caller contract supplies a validated CPU-area base.
+    unsafe {
+        &*((area_base + crate::CPU_AREA_RUNTIME_ANCHOR_OFFSET) as *const crate::CpuRuntimeAnchor)
+    }
 }

--- a/components/cpu-local/src/register/loongarch64.rs
+++ b/components/cpu-local/src/register/loongarch64.rs
@@ -1,14 +1,15 @@
 use super::*;
 
 pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
-    current_source_aliases_kernel_tls: true,
+    linux_current: CurrentContextSource::ArchitectureRegister,
+    unikernel_tls: CurrentContextSource::RuntimeAnchor,
 };
 
 pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
     Ok(())
 }
 
-pub(super) unsafe fn install_cpu_base(area_base: usize, boot_thread: usize) {
+pub(super) unsafe fn install_cpu_base(area_base: usize, boot_context: usize) {
     let shadow = area_base;
     unsafe {
         core::arch::asm!(
@@ -20,7 +21,7 @@ pub(super) unsafe fn install_cpu_base(area_base: usize, boot_thread: usize) {
     }
     if !cfg!(feature = "tls") {
         unsafe {
-            core::arch::asm!("move $tp, {current}", current = in(reg) boot_thread, options(nostack))
+            core::arch::asm!("move $tp, {current}", current = in(reg) boot_context, options(nostack))
         };
     }
 }
@@ -43,9 +44,9 @@ pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
     Ok(area_base)
 }
 
-pub(super) unsafe fn read_current_thread(area_base: usize) -> usize {
+pub(super) unsafe fn read_current_context(area_base: usize) -> usize {
     if cfg!(feature = "tls") {
-        unsafe { area_runtime_anchor(area_base) }.current_thread_raw()
+        unsafe { area_runtime_anchor(area_base) }.current_context_raw()
     } else {
         let current: usize;
         unsafe { core::arch::asm!("move {current}, $tp", current = out(reg) current) };
@@ -53,7 +54,7 @@ pub(super) unsafe fn read_current_thread(area_base: usize) -> usize {
     }
 }
 
-pub(super) unsafe fn write_current_thread(value: usize) {
+pub(super) unsafe fn write_current_context(value: usize) {
     if !cfg!(feature = "tls") {
         unsafe { core::arch::asm!("move $tp, {value}", value = in(reg) value) };
     }

--- a/components/cpu-local/src/register/mod.rs
+++ b/components/cpu-local/src/register/mod.rs
@@ -2,7 +2,7 @@
 
 use core::{pin::Pin, ptr::NonNull, sync::atomic::Ordering};
 
-use crate::{CpuAreaRef, CpuLocalError, CpuPin, CurrentThreadHeader, ThreadSwitchError};
+use crate::{ContextSwitchError, CpuAreaRef, CpuLocalError, CpuPin, ExecutionContextHeader};
 
 #[cfg(all(not(feature = "host-test"), target_arch = "aarch64"))]
 mod aarch64;
@@ -46,21 +46,24 @@ compile_error!("cpu-local supports x86_64, AArch64, RISC-V, and LoongArch64 only
 
 #[derive(Clone, Copy, Debug)]
 pub(super) struct ArchitectureCurrentModel {
-    pub(super) current_source_aliases_kernel_tls: bool,
+    pub(super) linux_current: CurrentContextSource,
+    pub(super) unikernel_tls: CurrentContextSource,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum CurrentThreadSource {
-    Architecture,
-    CpuRuntimeAnchor,
+pub(super) enum CurrentContextSource {
+    #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+    ArchitectureRegister,
+    #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
+    RuntimeAnchor,
 }
 
 impl ArchitectureCurrentModel {
-    const fn current_thread_source(self, tls_enabled: bool) -> CurrentThreadSource {
-        if tls_enabled && self.current_source_aliases_kernel_tls {
-            CurrentThreadSource::CpuRuntimeAnchor
+    const fn current_context_source(self, tls_enabled: bool) -> CurrentContextSource {
+        if tls_enabled {
+            self.unikernel_tls
         } else {
-            CurrentThreadSource::Architecture
+            self.linux_current
         }
     }
 }
@@ -74,8 +77,8 @@ impl ArchitectureCurrentModel {
 #[doc(hidden)]
 pub unsafe fn install_cpu_area(area: CpuAreaRef) -> Result<(), CpuLocalError> {
     imp::validate_environment()?;
-    let boot_thread = area.prefix().boot_thread().header();
-    let boot_pointer = boot_thread as *const CurrentThreadHeader as usize;
+    let boot_context = area.prefix().boot_context().header();
+    let boot_pointer = boot_context as *const ExecutionContextHeader as usize;
     // SAFETY: the caller owns the offline register installation boundary.
     unsafe { imp::install_cpu_base(area.base(), boot_pointer) };
     if unsafe { imp::read_cpu_base()? } != area.base() {
@@ -94,72 +97,103 @@ pub(crate) fn current_area() -> Result<CpuAreaRef, CpuLocalError> {
     unsafe { CpuAreaRef::from_initialized_base(area_base) }
 }
 
-/// Publishes the scheduler anchor before the architecture switch tail.
+/// Commits the current-context source before the architecture switch tail.
 ///
 /// # Safety
 ///
 /// The caller must own the final IRQ-disabled context-switch boundary. `value`
 /// must identify the prepared pinned header and remain alive while current.
-pub(crate) unsafe fn commit_current_thread(area: CpuAreaRef, value: usize) {
-    area.runtime_anchor()
-        .current_thread_slot()
-        .store(value, Ordering::Release);
+pub(crate) unsafe fn commit_current_context(_area: CpuAreaRef, _value: usize) {
+    match imp::CURRENT_MODEL.current_context_source(cfg!(feature = "tls")) {
+        #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
+        CurrentContextSource::RuntimeAnchor => _area
+            .runtime_anchor()
+            .current_context_slot()
+            .store(_value, Ordering::Release),
+        #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+        CurrentContextSource::ArchitectureRegister => {
+            core::sync::atomic::compiler_fence(Ordering::Release);
+            #[cfg(feature = "host-test")]
+            unsafe {
+                imp::write_current_context(_value)
+            };
+        }
+    }
 }
 
-/// Returns the pinned current-thread header after checking both sources.
-pub fn current_thread(pin: &CpuPin<'_>) -> Result<NonNull<CurrentThreadHeader>, CpuLocalError> {
+/// Returns the pinned header selected by this image's sole current source.
+pub fn current_context(pin: &CpuPin<'_>) -> Result<NonNull<ExecutionContextHeader>, CpuLocalError> {
     let area = pin.area();
-    let slot = area.runtime_anchor().current_thread_raw();
-    let register = unsafe { imp::read_current_thread(area.base()) };
-    if slot == 0
-        || slot != register
-        || !slot.is_multiple_of(core::mem::align_of::<CurrentThreadHeader>())
-    {
-        return Err(CpuLocalError::CurrentThreadMismatch);
-    }
-    let pointer = NonNull::new(slot as *mut CurrentThreadHeader)
-        .ok_or(CpuLocalError::CurrentThreadMismatch)?;
-    // SAFETY: scheduler publication only accepts pinned headers that remain
-    // alive while current, and the caller holds the required CPU pin.
-    let thread_area = unsafe { pointer.as_ref() }
+    let raw = match imp::CURRENT_MODEL.current_context_source(cfg!(feature = "tls")) {
+        #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+        CurrentContextSource::ArchitectureRegister => unsafe {
+            imp::read_current_context(area.base())
+        },
+        #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
+        CurrentContextSource::RuntimeAnchor => area.runtime_anchor().current_context_raw(),
+    };
+    let pointer = validated_context_pointer(raw)?;
+    // SAFETY: context publication only accepts pinned headers that remain
+    // alive while current, and the caller retains the required CPU pin.
+    let context_area = unsafe { pointer.as_ref() }
         .cpu_area()
-        .ok_or(CpuLocalError::CurrentThreadMismatch)?;
-    if thread_area != area {
-        return Err(CpuLocalError::CurrentThreadMismatch);
+        .ok_or(CpuLocalError::CurrentContextMismatch)?;
+    if context_area != area {
+        return Err(CpuLocalError::CurrentContextMismatch);
     }
     Ok(pointer)
 }
 
-/// Reads the current header before the scheduler can construct its guard.
+/// Reads the current header before a caller can construct its migration guard.
 ///
 /// # Safety
 ///
-/// The caller must keep the scheduler-owned current task alive and must not
+/// The caller must keep the owning execution context alive and must not
 /// dereference the result after a context switch.
 #[doc(hidden)]
-pub unsafe fn scheduler_current_thread() -> Result<NonNull<CurrentThreadHeader>, CpuLocalError> {
-    match imp::CURRENT_MODEL.current_thread_source(cfg!(feature = "tls")) {
-        CurrentThreadSource::Architecture => {
+pub unsafe fn current_context_unpinned() -> Result<NonNull<ExecutionContextHeader>, CpuLocalError> {
+    match imp::CURRENT_MODEL.current_context_source(cfg!(feature = "tls")) {
+        #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+        CurrentContextSource::ArchitectureRegister => {
             // The architecture current source does not require a sampled CPU
             // area. Reading one first would race migration because this
             // function is itself used to construct the preemption guard.
-            let register = unsafe { imp::read_current_thread(0) };
-            NonNull::new(register as *mut CurrentThreadHeader)
-                .ok_or(CpuLocalError::CurrentThreadMismatch)
+            let register = unsafe { imp::read_current_context(0) };
+            validated_context_pointer(register)
         }
-        CurrentThreadSource::CpuRuntimeAnchor => loop {
+        #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
+        CurrentContextSource::RuntimeAnchor => loop {
             // Architectures whose current source is also the kernel TLS base
             // keep current in the CPU runtime anchor. Retry if migration
             // changes the area before the guard can be constructed.
             let area = current_area()?;
-            let register = unsafe { imp::read_current_thread(area.base()) };
+            let register = unsafe { imp::read_current_context(area.base()) };
             if unsafe { imp::read_cpu_base()? } != area.base() {
                 continue;
             }
-            return NonNull::new(register as *mut CurrentThreadHeader)
-                .ok_or(CpuLocalError::CurrentThreadMismatch);
+            return validated_context_pointer(register);
         },
     }
+}
+
+/// Reports whether `context` is the CPU area's permanent boot context.
+///
+/// Runtime layers use this distinction before they publish their first owned
+/// execution context. The check compares identities only; the boot context
+/// does not carry a runtime kind, task cookie, or consumer pointer.
+#[doc(hidden)]
+pub fn is_permanent_boot_context(
+    context: NonNull<ExecutionContextHeader>,
+) -> Result<bool, CpuLocalError> {
+    let area = current_area()?;
+    Ok(context == NonNull::from(area.prefix().boot_context().header()))
+}
+
+fn validated_context_pointer(raw: usize) -> Result<NonNull<ExecutionContextHeader>, CpuLocalError> {
+    if raw == 0 || !raw.is_multiple_of(core::mem::align_of::<ExecutionContextHeader>()) {
+        return Err(CpuLocalError::CurrentContextMismatch);
+    }
+    NonNull::new(raw as *mut ExecutionContextHeader).ok_or(CpuLocalError::CurrentContextMismatch)
 }
 
 #[cfg(all(test, feature = "host-test"))]
@@ -182,39 +216,40 @@ mod tests {
     #[test]
     fn independent_current_register_ignores_kernel_tls_feature() {
         let independent = ArchitectureCurrentModel {
-            current_source_aliases_kernel_tls: false,
+            linux_current: CurrentContextSource::ArchitectureRegister,
+            unikernel_tls: CurrentContextSource::ArchitectureRegister,
         };
         assert_eq!(
-            independent.current_thread_source(false),
-            CurrentThreadSource::Architecture,
+            independent.current_context_source(false),
+            CurrentContextSource::ArchitectureRegister,
         );
         assert_eq!(
-            independent.current_thread_source(true),
-            CurrentThreadSource::Architecture,
+            independent.current_context_source(true),
+            CurrentContextSource::ArchitectureRegister,
         );
     }
 
     #[test]
     fn aliased_current_register_follows_kernel_tls_feature() {
         let aliased = ArchitectureCurrentModel {
-            current_source_aliases_kernel_tls: true,
+            linux_current: CurrentContextSource::ArchitectureRegister,
+            unikernel_tls: CurrentContextSource::RuntimeAnchor,
         };
         assert_eq!(
-            aliased.current_thread_source(false),
-            CurrentThreadSource::Architecture,
+            aliased.current_context_source(false),
+            CurrentContextSource::ArchitectureRegister,
         );
         assert_eq!(
-            aliased.current_thread_source(true),
-            CurrentThreadSource::CpuRuntimeAnchor,
+            aliased.current_context_source(true),
+            CurrentContextSource::RuntimeAnchor,
         );
     }
 
     #[test]
-    fn scheduler_current_thread_survives_migration_during_bootstrap_read() {
+    fn current_context_unpinned_survives_migration_during_bootstrap_read() {
         let first = modeled_area(0);
         let second = modeled_area(1);
-        let first_boot = first.prefix().boot_thread().header();
-        let second_boot = second.prefix().boot_thread().header();
+        let first_boot = first.prefix().boot_context().header();
 
         // SAFETY: this host thread serially owns both leaked CPU fixtures.
         unsafe { imp::install_cpu_base(first.base(), first_boot as *const _ as usize) };
@@ -222,46 +257,93 @@ mod tests {
 
         assert_eq!(
             // SAFETY: both boot headers have process-lifetime storage.
-            unsafe { scheduler_current_thread() },
-            Ok(NonNull::from(second_boot)),
+            unsafe { current_context_unpinned() },
+            if cfg!(feature = "tls") {
+                Ok(NonNull::from(second.prefix().boot_context().header()))
+            } else {
+                Ok(NonNull::from(first_boot))
+            },
         );
     }
 
     #[test]
-    fn scheduler_current_thread_rejects_an_uninstalled_host_area() {
+    fn current_context_unpinned_rejects_an_uninstalled_host_area() {
         let rejected = std::thread::spawn(move || {
             // SAFETY: the fresh host thread has no installed CPU area, so no
-            // scheduler-owned pointer can be returned.
-            matches!(
-                unsafe { scheduler_current_thread() },
-                Err(CpuLocalError::CurrentThreadMismatch)
-            )
+            // execution-context pointer can be returned.
+            unsafe { current_context_unpinned() }.is_err()
         })
         .join()
-        .expect("host current-thread probe panicked");
+        .expect("host current-context probe panicked");
 
         assert!(rejected);
     }
+
+    #[test]
+    fn permanent_boot_context_is_classified_by_area_identity() {
+        let area = modeled_area(0);
+        let boot = area.prefix().boot_context().header();
+        let runtime_context = Box::pin(ExecutionContextHeader::new());
+
+        // SAFETY: this host thread serially owns the leaked CPU fixture.
+        unsafe { imp::install_cpu_base(area.base(), boot as *const _ as usize) };
+
+        assert_eq!(is_permanent_boot_context(NonNull::from(boot)), Ok(true));
+        assert_eq!(
+            is_permanent_boot_context(runtime_context.as_ref().as_non_null()),
+            Ok(false)
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "tls"))]
+    fn architecture_current_is_authoritative_when_anchor_is_stale() {
+        let area = modeled_area(0);
+        let boot = area.prefix().boot_context().header();
+        let next = Box::pin(ExecutionContextHeader::new());
+
+        // SAFETY: this host thread serially owns the modeled CPU and both
+        // process-lifetime context headers.
+        unsafe { imp::install_cpu_base(area.base(), boot as *const _ as usize) };
+        unsafe {
+            crate::with_cpu_pin(|pin| {
+                let next_epoch = next.as_ref().bind_cpu(area).unwrap();
+                imp::set_architecture_current(next.as_ref().as_non_null().as_ptr() as usize);
+
+                assert_eq!(current_context(pin), Ok(next.as_ref().as_non_null()));
+
+                imp::set_architecture_current(0);
+                next.as_ref().unbind_cpu(next_epoch).unwrap();
+            })
+        }
+        .unwrap();
+    }
 }
 
-/// Binds and publishes the first scheduler task on an offline CPU.
+/// Binds and publishes the first execution context on an offline CPU.
 ///
 /// # Safety
 ///
 /// The CPU must remain offline and trap-free. `header` must stay pinned and
-/// alive until the scheduler replaces it through a prepared switch.
+/// alive until its owner replaces it through a prepared switch.
 #[doc(hidden)]
-pub unsafe fn install_bootstrap_thread(
+pub unsafe fn install_bootstrap_context(
     pin: &CpuPin<'_>,
-    header: Pin<&CurrentThreadHeader>,
-) -> Result<(), ThreadSwitchError> {
+    header: Pin<&ExecutionContextHeader>,
+) -> Result<(), ContextSwitchError> {
     let epoch = unsafe { header.bind_cpu(pin.area()) }?;
     let pointer = header.as_non_null().as_ptr() as usize;
-    unsafe { commit_current_thread(pin.area(), pointer) };
-    // Bootstrap has no raw switch tail. Install the architecture-owned current
-    // register directly while this CPU remains offline and trap-free.
-    unsafe { imp::write_current_thread(pointer) };
-    if current_thread(pin) != Ok(header.as_non_null()) {
+    match imp::CURRENT_MODEL.current_context_source(cfg!(feature = "tls")) {
+        #[cfg(not(all(target_arch = "aarch64", not(feature = "host-test"))))]
+        CurrentContextSource::RuntimeAnchor => unsafe {
+            commit_current_context(pin.area(), pointer)
+        },
+        #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+        CurrentContextSource::ArchitectureRegister => unsafe {
+            imp::write_current_context(pointer)
+        },
+    }
+    if current_context(pin) != Ok(header.as_non_null()) {
         // The register is already committed, so continuing would make all
         // later Rust execution unsound. Rollback is intentionally impossible.
         let _ = epoch;
@@ -270,17 +352,17 @@ pub unsafe fn install_bootstrap_thread(
     Ok(())
 }
 
-/// Reads task-owned kernel TLS under an explicit CPU pin.
+/// Reads execution-context-owned kernel TLS under an explicit CPU pin.
 #[cfg(feature = "tls")]
 pub fn kernel_tls(_pin: &CpuPin<'_>) -> usize {
     unsafe { imp::read_kernel_tls() }
 }
 
-/// Installs task-owned kernel TLS at an offline bootstrap boundary.
+/// Installs execution-context-owned kernel TLS at an offline bootstrap boundary.
 ///
 /// # Safety
 ///
-/// The caller must own the offline CPU or IRQ-disabled final task switch, and
+/// The caller must own the offline CPU or IRQ-disabled final context switch, and
 /// `value` must remain a valid TLS base for the installed execution context.
 #[cfg(feature = "tls")]
 #[doc(hidden)]
@@ -290,6 +372,12 @@ pub unsafe fn install_kernel_tls(_pin: &CpuPin<'_>, value: usize) {
 
 #[cold]
 #[inline(never)]
-fn fatal_register_invariant() -> ! {
+pub(crate) fn fatal_register_invariant() -> ! {
     panic!("CPU-local register commit did not retain the validated state")
+}
+
+#[cfg(all(target_arch = "x86_64", not(feature = "host-test")))]
+#[inline(always)]
+pub(crate) unsafe fn enter_x86_preemption() {
+    unsafe { imp::enter_preemption() };
 }

--- a/components/cpu-local/src/register/riscv.rs
+++ b/components/cpu-local/src/register/riscv.rs
@@ -1,14 +1,15 @@
 use super::*;
 
 pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
-    current_source_aliases_kernel_tls: true,
+    linux_current: CurrentContextSource::ArchitectureRegister,
+    unikernel_tls: CurrentContextSource::RuntimeAnchor,
 };
 
 pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
     Ok(())
 }
 
-pub(super) unsafe fn install_cpu_base(area_base: usize, boot_thread: usize) {
+pub(super) unsafe fn install_cpu_base(area_base: usize, boot_context: usize) {
     if cfg!(feature = "tls") {
         unsafe { core::arch::asm!("csrw sscratch, {base}", base = in(reg) area_base) };
     } else {
@@ -16,7 +17,7 @@ pub(super) unsafe fn install_cpu_base(area_base: usize, boot_thread: usize) {
             core::arch::asm!(
                 "mv tp, {current}",
                 "csrw sscratch, zero",
-                current = in(reg) boot_thread,
+                current = in(reg) boot_context,
             )
         };
     }
@@ -34,15 +35,15 @@ pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
             return Ok(0);
         }
         // SAFETY: LinuxCurrent tp is written only with a pinned current header.
-        unsafe { &*(current as *const CurrentThreadHeader) }
+        unsafe { &*(current as *const ExecutionContextHeader) }
             .cpu_area_base()
-            .ok_or(CpuLocalError::CurrentThreadMismatch)
+            .ok_or(CpuLocalError::CurrentContextMismatch)
     }
 }
 
-pub(super) unsafe fn read_current_thread(area_base: usize) -> usize {
+pub(super) unsafe fn read_current_context(area_base: usize) -> usize {
     if cfg!(feature = "tls") {
-        unsafe { area_runtime_anchor(area_base) }.current_thread_raw()
+        unsafe { area_runtime_anchor(area_base) }.current_context_raw()
     } else {
         let current: usize;
         unsafe { core::arch::asm!("mv {current}, tp", current = out(reg) current) };
@@ -50,7 +51,7 @@ pub(super) unsafe fn read_current_thread(area_base: usize) -> usize {
     }
 }
 
-pub(super) unsafe fn write_current_thread(value: usize) {
+pub(super) unsafe fn write_current_context(value: usize) {
     if !cfg!(feature = "tls") {
         unsafe { core::arch::asm!("mv tp, {value}", value = in(reg) value) };
     }

--- a/components/cpu-local/src/register/x86_64.rs
+++ b/components/cpu-local/src/register/x86_64.rs
@@ -1,19 +1,22 @@
 use super::*;
-use crate::{CPU_AREA_CURRENT_THREAD_OFFSET, CPU_AREA_SELF_BASE_OFFSET};
+use crate::{
+    CPU_AREA_CURRENT_CONTEXT_OFFSET, CPU_AREA_PREEMPTION_STATE_OFFSET, CPU_AREA_SELF_BASE_OFFSET,
+};
 
 const IA32_GS_BASE: u32 = 0xc000_0101;
 #[cfg(feature = "tls")]
 const IA32_FS_BASE: u32 = 0xc000_0100;
 
 pub(super) const CURRENT_MODEL: ArchitectureCurrentModel = ArchitectureCurrentModel {
-    current_source_aliases_kernel_tls: false,
+    linux_current: CurrentContextSource::RuntimeAnchor,
+    unikernel_tls: CurrentContextSource::RuntimeAnchor,
 };
 
 pub(super) fn validate_environment() -> Result<(), CpuLocalError> {
     Ok(())
 }
 
-pub(super) unsafe fn install_cpu_base(area_base: usize, _boot_thread: usize) {
+pub(super) unsafe fn install_cpu_base(area_base: usize, _boot_context: usize) {
     let area_base = area_base as u64;
     unsafe {
         core::arch::asm!(
@@ -39,23 +42,29 @@ pub(super) unsafe fn read_cpu_base() -> Result<usize, CpuLocalError> {
     Ok(area_base)
 }
 
-pub(super) unsafe fn read_current_thread(_area_base: usize) -> usize {
-    let current_thread: usize;
+pub(super) unsafe fn read_current_context(_area_base: usize) -> usize {
+    let current_context: usize;
     unsafe {
         core::arch::asm!(
             "mov {current}, gs:[{offset}]",
-            current = out(reg) current_thread,
-            offset = const CPU_AREA_CURRENT_THREAD_OFFSET,
+            current = out(reg) current_context,
+            offset = const CPU_AREA_CURRENT_CONTEXT_OFFSET,
             options(nostack, preserves_flags, readonly),
         );
     }
-    current_thread
+    current_context
 }
 
-// x86_64 stores current directly in the GS runtime anchor. The shared atomic
-// publication is therefore the architecture commit; there is no second task
-// pointer register to update.
-pub(super) unsafe fn write_current_thread(_value: usize) {}
+#[inline(always)]
+pub(super) unsafe fn enter_preemption() {
+    unsafe {
+        core::arch::asm!(
+            "inc dword ptr gs:[{offset}]",
+            offset = const CPU_AREA_PREEMPTION_STATE_OFFSET,
+            options(nostack),
+        );
+    }
+}
 
 #[cfg(feature = "tls")]
 pub(super) unsafe fn read_kernel_tls() -> usize {

--- a/components/cpu-local/src/switch.rs
+++ b/components/cpu-local/src/switch.rs
@@ -1,32 +1,33 @@
 use core::{marker::PhantomData, mem::ManuallyDrop, pin::Pin, ptr::NonNull};
 
 use crate::{
-    CpuBindingEpoch, CpuLocalError, CpuPin, CurrentThreadHeader, ThreadSwitchError, current_thread,
+    ContextSwitchError, CpuBindingEpoch, CpuLocalError, CpuPin, ExecutionContextHeader,
+    current_context,
 };
 
-/// Prepared current-thread publication owned by the final context-switch tail.
+/// Prepared current-context publication owned by the final switch tail.
 #[must_use = "dropping an uncommitted switch rolls back the next CPU binding"]
-pub struct PreparedThreadSwitch<'switch> {
-    next: NonNull<CurrentThreadHeader>,
+pub struct PreparedContextSwitch<'switch> {
+    next: NonNull<ExecutionContextHeader>,
     next_epoch: CpuBindingEpoch,
-    current_thread: usize,
+    current_context: usize,
     area: crate::CpuAreaRef,
     _scope: PhantomData<&'switch mut &'switch ()>,
     _not_send_or_sync: PhantomData<*mut ()>,
 }
 
-impl PreparedThreadSwitch<'_> {
+impl PreparedContextSwitch<'_> {
     /// Returns the exact next header bound by this transaction.
     #[doc(hidden)]
-    pub const fn next_header(&self) -> NonNull<CurrentThreadHeader> {
+    pub const fn next_header(&self) -> NonNull<ExecutionContextHeader> {
         self.next
     }
 
-    /// Publishes the prepared CPU runtime slot immediately before naked switch.
+    /// Publishes the prepared CPU anchor slot immediately before naked switch.
     ///
     /// # Safety
     ///
-    /// The scheduler serialization and IRQ exclusion used during preparation
+    /// The caller serialization and IRQ exclusion used during preparation
     /// must still be active. The caller must enter the architecture switch
     /// without performing fallible or ownership-sensitive Rust work.
     #[doc(hidden)]
@@ -36,91 +37,91 @@ impl PreparedThreadSwitch<'_> {
         // is no destructor state update or ownership-sensitive Rust work; the
         // architecture wrapper enters its naked switch tail immediately.
         let prepared = ManuallyDrop::new(self);
-        unsafe { crate::register::commit_current_thread(prepared.area, prepared.current_thread) };
+        unsafe { crate::register::commit_current_context(prepared.area, prepared.current_context) };
     }
 }
 
-impl Drop for PreparedThreadSwitch<'_> {
+impl Drop for PreparedContextSwitch<'_> {
     fn drop(&mut self) {
         // SAFETY: an uncommitted token still owns the next binding, and its
-        // invariant lifetime keeps the scheduler critical section live. The
+        // invariant lifetime keeps the caller's critical section live. The
         // preparation contract keeps the pinned header alive until this drop.
         let next = unsafe { Pin::new_unchecked(self.next.as_ref()) };
         if unsafe { next.unbind_cpu(self.next_epoch) }.is_err() {
-            panic!("prepared thread-switch rollback lost the next CPU binding");
+            panic!("prepared context-switch rollback lost the next CPU binding");
         }
     }
 }
 
-/// Opaque previous-task binding consumed by the incoming switch tail.
-#[must_use = "the incoming task must withdraw the previous CPU binding"]
+/// Opaque previous-context binding consumed by the incoming switch tail.
+#[must_use = "the incoming context must withdraw the previous CPU binding"]
 #[derive(Debug)]
-pub struct PreviousThreadBinding {
-    previous: NonNull<CurrentThreadHeader>,
+pub struct PreviousContextBinding {
+    previous: NonNull<ExecutionContextHeader>,
     epoch: CpuBindingEpoch,
 }
 
-impl PreviousThreadBinding {
+impl PreviousContextBinding {
     /// Withdraws the exact previous binding after architecture registers have
-    /// switched to the incoming task.
+    /// switched to the incoming context.
     ///
     /// # Errors
     ///
-    /// Returns [`ThreadSwitchError::PreviousThreadMismatch`] if `previous`
-    /// differs from the prepared task, or
-    /// [`ThreadSwitchError::StalePreviousBinding`] for an obsolete tail.
+    /// Returns [`ContextSwitchError::PreviousContextMismatch`] if `previous`
+    /// differs from the prepared context, or
+    /// [`ContextSwitchError::StalePreviousBinding`] for an obsolete tail.
     ///
     /// # Safety
     ///
     /// The incoming switch tail must be the sole owner of this token and the
-    /// previous task allocation must remain pinned and alive.
+    /// previous context allocation must remain pinned and alive.
     pub unsafe fn finish(
         self,
-        previous: Pin<&CurrentThreadHeader>,
-    ) -> Result<(), ThreadSwitchError> {
+        previous: Pin<&ExecutionContextHeader>,
+    ) -> Result<(), ContextSwitchError> {
         if previous.as_non_null() != self.previous {
-            return Err(ThreadSwitchError::PreviousThreadMismatch);
+            return Err(ContextSwitchError::PreviousContextMismatch);
         }
         unsafe { previous.unbind_cpu(self.epoch) }
     }
 }
 
-/// Validates and binds a complete scheduler thread switch transaction.
+/// Validates and binds a complete execution-context switch transaction.
 ///
 /// All fallible validation occurs before the returned prepared token can be
 /// committed. Dropping the prepared token automatically rolls back `next`.
 ///
 /// # Safety
 ///
-/// The caller must own the IRQ-disabled scheduler switch path. Both headers
+/// The caller must own the IRQ-disabled context-switch path. Both headers
 /// must remain pinned and alive through the raw switch and incoming tail.
-pub unsafe fn prepare_thread_switch<'switch>(
+pub unsafe fn prepare_context_switch<'switch>(
     pin: &'switch CpuPin<'_>,
-    previous: Pin<&CurrentThreadHeader>,
-    next: Pin<&CurrentThreadHeader>,
-) -> Result<(PreparedThreadSwitch<'switch>, PreviousThreadBinding), ThreadSwitchError> {
-    let published = current_thread(pin).map_err(|error| match error {
-        CpuLocalError::CurrentThreadMismatch => ThreadSwitchError::CurrentThreadMismatch,
-        other => ThreadSwitchError::CpuLocal(other),
+    previous: Pin<&ExecutionContextHeader>,
+    next: Pin<&ExecutionContextHeader>,
+) -> Result<(PreparedContextSwitch<'switch>, PreviousContextBinding), ContextSwitchError> {
+    let published = current_context(pin).map_err(|error| match error {
+        CpuLocalError::CurrentContextMismatch => ContextSwitchError::CurrentContextMismatch,
+        other => ContextSwitchError::CpuLocal(other),
     })?;
     if published != previous.as_non_null() {
-        return Err(ThreadSwitchError::CurrentThreadMismatch);
+        return Err(ContextSwitchError::CurrentContextMismatch);
     }
     let previous_binding = previous
         .cpu_binding()
         .filter(|binding| binding.area == pin.area())
-        .ok_or(ThreadSwitchError::CurrentThreadMismatch)?;
+        .ok_or(ContextSwitchError::CurrentContextMismatch)?;
     let next_epoch = unsafe { next.bind_cpu(pin.area()) }?;
     Ok((
-        PreparedThreadSwitch {
+        PreparedContextSwitch {
             next: next.as_non_null(),
             next_epoch,
-            current_thread: next.as_non_null().as_ptr() as usize,
+            current_context: next.as_non_null().as_ptr() as usize,
             area: pin.area(),
             _scope: PhantomData,
             _not_send_or_sync: PhantomData,
         },
-        PreviousThreadBinding {
+        PreviousContextBinding {
             previous: previous.as_non_null(),
             epoch: previous_binding.epoch,
         },
@@ -133,8 +134,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        CpuAreaPrefix, CpuAreaRef, CpuIndex, CurrentContext, install_bootstrap_thread,
-        install_cpu_area, with_cpu_pin,
+        CpuAreaPrefix, CpuAreaRef, CpuIndex, install_bootstrap_context, install_cpu_area,
+        with_cpu_pin,
     };
 
     fn on_fresh_modeled_cpu(operation: impl FnOnce(CpuAreaRef) + Send + 'static) {
@@ -154,30 +155,28 @@ mod tests {
         .unwrap();
     }
 
-    fn task_header(identity: usize) -> Pin<Box<CurrentThreadHeader>> {
-        Box::pin(CurrentThreadHeader::new(
-            CurrentContext::from_raw(identity).unwrap(),
-        ))
+    fn context_header() -> Pin<Box<ExecutionContextHeader>> {
+        Box::pin(ExecutionContextHeader::new())
     }
 
     #[test]
     fn abandoned_prepare_rolls_back_next_binding() {
         on_fresh_modeled_cpu(|area| {
-            let previous = task_header(1);
-            let next = task_header(2);
+            let previous = context_header();
+            let next = context_header();
 
             // SAFETY: the modeled CPU cannot migrate or receive interrupts.
             unsafe {
                 with_cpu_pin(|pin| {
-                    install_bootstrap_thread(pin, previous.as_ref()).unwrap();
+                    install_bootstrap_context(pin, previous.as_ref()).unwrap();
                     let (prepared, _previous_binding) =
-                        prepare_thread_switch(pin, previous.as_ref(), next.as_ref()).unwrap();
-                    assert_eq!(current_thread(pin), Ok(previous.as_ref().as_non_null()));
+                        prepare_context_switch(pin, previous.as_ref(), next.as_ref()).unwrap();
+                    assert_eq!(current_context(pin), Ok(previous.as_ref().as_non_null()));
                     assert_eq!(next.cpu_area(), Some(area));
 
                     drop(prepared);
 
-                    assert_eq!(current_thread(pin), Ok(previous.as_ref().as_non_null()));
+                    assert_eq!(current_context(pin), Ok(previous.as_ref().as_non_null()));
                     assert_eq!(next.cpu_area(), None);
                 })
             }
@@ -188,18 +187,19 @@ mod tests {
     #[test]
     fn prepare_reports_the_domain_mismatch_before_binding_next() {
         on_fresh_modeled_cpu(|_| {
-            let published = task_header(1);
-            let wrong_previous = task_header(2);
-            let next = task_header(3);
+            let published = context_header();
+            let wrong_previous = context_header();
+            let next = context_header();
 
             // SAFETY: the modeled CPU cannot migrate or receive interrupts.
             unsafe {
                 with_cpu_pin(|pin| {
-                    install_bootstrap_thread(pin, published.as_ref()).unwrap();
-                    let result = prepare_thread_switch(pin, wrong_previous.as_ref(), next.as_ref());
+                    install_bootstrap_context(pin, published.as_ref()).unwrap();
+                    let result =
+                        prepare_context_switch(pin, wrong_previous.as_ref(), next.as_ref());
                     assert!(matches!(
                         result,
-                        Err(ThreadSwitchError::CurrentThreadMismatch)
+                        Err(ContextSwitchError::CurrentContextMismatch)
                     ));
                     assert_eq!(next.cpu_area(), None);
                 })
@@ -211,24 +211,24 @@ mod tests {
     #[test]
     fn publication_precedes_incoming_unbind() {
         on_fresh_modeled_cpu(|area| {
-            let previous = task_header(1);
-            let next = task_header(2);
+            let previous = context_header();
+            let next = context_header();
 
             // SAFETY: this host model serializes the entire switch. Returning
             // from `commit` represents resuming after the naked switch tail.
             unsafe {
                 with_cpu_pin(|pin| {
-                    install_bootstrap_thread(pin, previous.as_ref()).unwrap();
+                    install_bootstrap_context(pin, previous.as_ref()).unwrap();
                     let (prepared, previous_binding) =
-                        prepare_thread_switch(pin, previous.as_ref(), next.as_ref()).unwrap();
+                        prepare_context_switch(pin, previous.as_ref(), next.as_ref()).unwrap();
 
-                    assert_eq!(current_thread(pin), Ok(previous.as_ref().as_non_null()));
+                    assert_eq!(current_context(pin), Ok(previous.as_ref().as_non_null()));
                     assert_eq!(previous.cpu_area(), Some(area));
                     assert_eq!(next.cpu_area(), Some(area));
 
                     prepared.commit();
 
-                    assert_eq!(current_thread(pin), Ok(next.as_ref().as_non_null()));
+                    assert_eq!(current_context(pin), Ok(next.as_ref().as_non_null()));
                     assert_eq!(previous.cpu_area(), Some(area));
                     previous_binding.finish(previous.as_ref()).unwrap();
                     assert_eq!(previous.cpu_area(), None);
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn stale_epoch_cannot_unbind_a_new_binding() {
         on_fresh_modeled_cpu(|area| {
-            let header = task_header(1);
+            let header = context_header();
             // SAFETY: this fresh modeled CPU exclusively owns the header.
             let stale = unsafe { header.as_ref().bind_cpu(area) }.unwrap();
             unsafe { header.as_ref().unbind_cpu(stale) }.unwrap();
@@ -250,7 +250,7 @@ mod tests {
 
             assert_eq!(
                 unsafe { header.as_ref().unbind_cpu(stale) },
-                Err(ThreadSwitchError::StalePreviousBinding)
+                Err(ContextSwitchError::StalePreviousBinding)
             );
             assert_eq!(header.cpu_area(), Some(area));
             unsafe { header.as_ref().unbind_cpu(current) }.unwrap();

--- a/components/cpu-local/src/thread.rs
+++ b/components/cpu-local/src/thread.rs
@@ -5,24 +5,7 @@ use core::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use crate::{CpuAreaRef, ThreadSwitchError};
-
-/// Stable opaque identity of one runtime-owned execution context.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[repr(transparent)]
-pub struct CurrentContext(usize);
-
-impl CurrentContext {
-    /// Converts a non-null opaque execution-context handle.
-    pub const fn from_raw(raw: usize) -> Option<Self> {
-        if raw == 0 { None } else { Some(Self(raw)) }
-    }
-
-    /// Returns the opaque scalar representation.
-    pub const fn as_usize(self) -> usize {
-        self.0
-    }
-}
+use crate::{ContextSwitchError, CpuAreaRef, preempt::PreemptionState};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct CpuBindingEpoch(usize);
@@ -39,49 +22,59 @@ const CPU_BINDING: usize = 0b01;
 const CPU_BOUND: usize = 0b10;
 const CPU_UNBINDING: usize = 0b11;
 
-const fn current_thread_reserved_size() -> usize {
-    64 - 5 * size_of::<usize>()
+const fn execution_context_reserved_size() -> usize {
+    64 - 4 * size_of::<usize>() - size_of::<PreemptionState>()
 }
 
-/// Pinned scheduler/architecture header for one execution context.
+/// Pinned architecture header for one execution context.
 ///
 /// CPU binding uses a four-phase publication word:
 /// `Unbound -> Binding -> Bound -> Unbinding -> next Unbound`. The epoch is
 /// retained solely to reject a stale incoming switch tail.
 #[repr(C, align(64))]
-pub struct CurrentThreadHeader {
-    context: usize,
+pub struct ExecutionContextHeader {
     cpu_area: AtomicUsize,
     binding_epoch: AtomicUsize,
     architecture_state: [AtomicUsize; 2],
-    reserved: [u8; current_thread_reserved_size()],
+    preemption_state: PreemptionState,
+    reserved: [u8; execution_context_reserved_size()],
 }
 
-impl CurrentThreadHeader {
+impl ExecutionContextHeader {
     /// Creates an unbound header before placing it in stable pinned storage.
-    pub const fn new(context: CurrentContext) -> Self {
+    pub const fn new() -> Self {
         Self {
-            context: context.0,
             cpu_area: AtomicUsize::new(0),
             binding_epoch: AtomicUsize::new(CPU_UNBOUND),
             architecture_state: [const { AtomicUsize::new(0) }; 2],
-            reserved: [0; current_thread_reserved_size()],
+            preemption_state: PreemptionState::new(),
+            reserved: [0; execution_context_reserved_size()],
         }
     }
 
     pub(crate) const fn boot(area_base: usize) -> Self {
         Self {
-            context: 0,
             cpu_area: AtomicUsize::new(area_base),
             binding_epoch: AtomicUsize::new(CPU_BOUND),
             architecture_state: [const { AtomicUsize::new(0) }; 2],
-            reserved: [0; current_thread_reserved_size()],
+            preemption_state: PreemptionState::bootstrap_disabled(),
+            reserved: [0; execution_context_reserved_size()],
         }
     }
 
-    /// Returns the immutable runtime context identity, if this is a task.
-    pub const fn current_context(&self) -> Option<CurrentContext> {
-        CurrentContext::from_raw(self.context)
+    /// Creates the execution owner's continuation of the boot context.
+    ///
+    /// Its initial depth retains bootstrap exclusion until the owner has
+    /// published all state required by its external safe point.
+    #[doc(hidden)]
+    pub const fn new_bootstrap() -> Self {
+        Self {
+            cpu_area: AtomicUsize::new(0),
+            binding_epoch: AtomicUsize::new(CPU_UNBOUND),
+            architecture_state: [const { AtomicUsize::new(0) }; 2],
+            preemption_state: PreemptionState::bootstrap_disabled(),
+            reserved: [0; execution_context_reserved_size()],
+        }
     }
 
     /// Returns the stable CPU area while this header is fully bound.
@@ -97,11 +90,11 @@ impl CurrentThreadHeader {
     pub(crate) unsafe fn bind_cpu(
         self: Pin<&Self>,
         area: CpuAreaRef,
-    ) -> Result<CpuBindingEpoch, ThreadSwitchError> {
+    ) -> Result<CpuBindingEpoch, ContextSwitchError> {
         let this = self.get_ref();
         let unbound = this.binding_epoch.load(Ordering::Acquire);
         if unbound & CPU_PHASE_MASK != CPU_UNBOUND {
-            return Err(ThreadSwitchError::NextThreadAlreadyBound);
+            return Err(ContextSwitchError::NextContextAlreadyBound);
         }
         this.binding_epoch
             .compare_exchange(
@@ -110,7 +103,7 @@ impl CurrentThreadHeader {
                 Ordering::AcqRel,
                 Ordering::Acquire,
             )
-            .map_err(|_| ThreadSwitchError::NextThreadAlreadyBound)?;
+            .map_err(|_| ContextSwitchError::NextContextAlreadyBound)?;
         this.cpu_area.store(area.base(), Ordering::Relaxed);
         let bound = (unbound & !CPU_PHASE_MASK) | CPU_BOUND;
         this.binding_epoch.store(bound, Ordering::Release);
@@ -120,15 +113,15 @@ impl CurrentThreadHeader {
     pub(crate) unsafe fn unbind_cpu(
         self: Pin<&Self>,
         expected: CpuBindingEpoch,
-    ) -> Result<(), ThreadSwitchError> {
+    ) -> Result<(), ContextSwitchError> {
         if expected.0 & CPU_PHASE_MASK != CPU_BOUND {
-            return Err(ThreadSwitchError::StalePreviousBinding);
+            return Err(ContextSwitchError::StalePreviousBinding);
         }
         let this = self.get_ref();
         let unbinding = (expected.0 & !CPU_PHASE_MASK) | CPU_UNBINDING;
         this.binding_epoch
             .compare_exchange(expected.0, unbinding, Ordering::AcqRel, Ordering::Acquire)
-            .map_err(|_| ThreadSwitchError::StalePreviousBinding)?;
+            .map_err(|_| ContextSwitchError::StalePreviousBinding)?;
         this.cpu_area.store(0, Ordering::Relaxed);
         let next_unbound = (expected.0 & !CPU_PHASE_MASK).wrapping_add(4);
         this.binding_epoch.store(next_unbound, Ordering::Release);
@@ -158,21 +151,43 @@ impl CurrentThreadHeader {
         }
     }
 
-    /// Returns the stable pointer installed in the current-thread register.
+    /// Returns the stable pointer installed in the current-context source.
     pub fn as_non_null(self: Pin<&Self>) -> NonNull<Self> {
         NonNull::from(self.get_ref())
     }
+
+    #[cfg(any(not(target_arch = "x86_64"), feature = "host-test"))]
+    pub(crate) const fn preemption_state(&self) -> &PreemptionState {
+        &self.preemption_state
+    }
 }
 
-/// Byte offset of the current header's bound CPU-area base.
-pub const CURRENT_THREAD_CPU_BASE_OFFSET: usize = offset_of!(CurrentThreadHeader, cpu_area);
-/// Byte offset of architecture-owned task trap state.
-pub const CURRENT_THREAD_ARCH_STATE_OFFSET: usize =
-    offset_of!(CurrentThreadHeader, architecture_state);
-/// Reserved bytes available to architecture-owned task trap state.
-pub const CURRENT_THREAD_ARCH_STATE_SIZE: usize = 2 * size_of::<usize>();
+impl Default for ExecutionContextHeader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Byte offset of the execution context's bound CPU-area base.
+pub const EXECUTION_CONTEXT_CPU_BASE_OFFSET: usize = offset_of!(ExecutionContextHeader, cpu_area);
+/// Byte offset of architecture-owned execution-context trap state.
+pub const EXECUTION_CONTEXT_ARCH_STATE_OFFSET: usize =
+    offset_of!(ExecutionContextHeader, architecture_state);
+/// Reserved bytes available to architecture-owned execution-context trap state.
+pub const EXECUTION_CONTEXT_ARCH_STATE_SIZE: usize = 2 * size_of::<usize>();
 
 const _: () = {
-    assert!(size_of::<CurrentThreadHeader>() == 64);
-    assert!(core::mem::align_of::<CurrentThreadHeader>() == 64);
+    assert!(EXECUTION_CONTEXT_CPU_BASE_OFFSET == 0);
+    assert!(size_of::<ExecutionContextHeader>() == 64);
+    assert!(core::mem::align_of::<ExecutionContextHeader>() == 64);
 };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn execution_context_header_starts_with_cpu_binding() {
+        assert_eq!(EXECUTION_CONTEXT_CPU_BASE_OFFSET, 0);
+    }
+}

--- a/components/cpu-local/tests/register_mode_contract.rs
+++ b/components/cpu-local/tests/register_mode_contract.rs
@@ -30,17 +30,21 @@ fn image_mode_is_additive_but_the_prefix_layout_is_not() {
     assert!(
         HEADER.contains("pub struct CpuAreaPrefix")
             && HEADER.contains("pub struct CpuRuntimeAnchor")
-            && HEADER.contains("pub struct BootThreadHeader")
-            && HEADER.contains("pub struct CurrentThreadHeader"),
+            && HEADER.contains("pub struct BootContextHeader")
+            && HEADER.contains("pub struct ExecutionContextHeader"),
         "the prefix must reserve runtime-anchor and boot-thread cache lines"
     );
     assert!(
         HEADER.contains("CPU_AREA_RUNTIME_ANCHOR_OFFSET")
-            && HEADER.contains("CPU_AREA_BOOT_THREAD_OFFSET")
+            && HEADER.contains("CPU_AREA_BOOT_CONTEXT_OFFSET")
             && HEADER.contains("size_of::<CpuAreaPrefix>() == 192"),
         "the prefix must keep runtime state at 64 and the boot header at 128"
     );
-    for type_name in ["CpuRuntimeAnchor", "CpuAreaPrefix", "CurrentThreadHeader"] {
+    for type_name in [
+        "CpuRuntimeAnchor",
+        "CpuAreaPrefix",
+        "ExecutionContextHeader",
+    ] {
         let definition = HEADER
             .split_once(&format!("pub struct {type_name}"))
             .unwrap_or_else(|| panic!("{type_name} must exist"))
@@ -56,25 +60,37 @@ fn image_mode_is_additive_but_the_prefix_layout_is_not() {
 }
 
 #[test]
-fn current_thread_header_is_task_owned_and_resource_free() {
+fn execution_context_header_is_scheduler_neutral_and_resource_free() {
     let header = HEADER
-        .split_once("pub struct CurrentThreadHeader")
-        .expect("CurrentThreadHeader must exist")
+        .split_once("pub struct ExecutionContextHeader")
+        .expect("ExecutionContextHeader must exist")
         .1
         .split_once("\n}")
-        .expect("CurrentThreadHeader must have a bounded definition")
+        .expect("ExecutionContextHeader must have a bounded definition")
         .0;
 
-    for field in ["context", "cpu_area", "binding_epoch", "architecture_state"] {
+    for field in [
+        "cpu_area",
+        "binding_epoch",
+        "architecture_state",
+        "preemption_state",
+    ] {
         assert!(
             header.contains(field),
-            "CurrentThreadHeader is missing {field}"
+            "ExecutionContextHeader is missing {field}"
         );
     }
-    for forbidden in ["kernel_tls", "stack", "TaskContext", "address_space"] {
+    for forbidden in [
+        "CurrentContext",
+        "RuntimeThreadCookie",
+        "kernel_tls",
+        "stack",
+        "TaskContext",
+        "address_space",
+    ] {
         assert!(
             !header.contains(forbidden),
-            "CurrentThreadHeader must not own {forbidden}"
+            "ExecutionContextHeader must not own {forbidden}"
         );
     }
 
@@ -85,8 +101,37 @@ fn current_thread_header_is_task_owned_and_resource_free() {
     ] {
         assert!(
             HEADER.contains(api),
-            "CurrentThreadHeader is missing `{api}`"
+            "ExecutionContextHeader is missing `{api}`"
         );
+    }
+}
+
+#[test]
+fn cpu_local_has_no_upper_layer_dependency_or_scheduler_vocabulary() {
+    for forbidden in ["ax-task", "ax-runtime"] {
+        assert!(
+            !MANIFEST.contains(forbidden),
+            "cpu-local must not depend on {forbidden}"
+        );
+    }
+    for forbidden in ["scheduler_", "RuntimeThreadCookie"] {
+        assert!(
+            !HEADER.contains(forbidden) && !REGISTER.contains(forbidden),
+            "cpu-local public mechanism still exposes {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn each_image_mode_selects_one_current_context_source() {
+    for (backend, linux, tls) in [
+        (X86_64, "RuntimeAnchor", "RuntimeAnchor"),
+        (AARCH64, "ArchitectureRegister", "ArchitectureRegister"),
+        (RISCV, "ArchitectureRegister", "RuntimeAnchor"),
+        (LOONGARCH64, "ArchitectureRegister", "RuntimeAnchor"),
+    ] {
+        assert!(backend.contains(&format!("linux_current: CurrentContextSource::{linux}")));
+        assert!(backend.contains(&format!("unikernel_tls: CurrentContextSource::{tls}")));
     }
 }
 

--- a/components/cpu-local/tests/register_ownership_contract.rs
+++ b/components/cpu-local/tests/register_ownership_contract.rs
@@ -74,10 +74,10 @@ fn register_validation_returns_a_typed_cpu_area() {
 }
 
 #[test]
-fn register_leaf_does_not_export_raw_area_or_thread_access() {
+fn register_leaf_does_not_export_raw_area_or_context_access() {
     assert!(
         !REGISTER.contains("pub unsafe fn current_area_base_raw(")
-            && !REGISTER.contains("pub unsafe fn current_thread_raw("),
+            && !REGISTER.contains("pub unsafe fn current_context_raw("),
         "architecture values must remain behind shared typed validation"
     );
     assert!(
@@ -122,11 +122,11 @@ fn riscv_uses_linux_current_or_unikernel_scratch_by_image_mode() {
 }
 
 #[test]
-fn x86_and_aarch64_keep_task_tls_separate_from_the_cpu_anchor() {
+fn x86_and_aarch64_keep_context_tls_separate_from_the_cpu_anchor() {
     let x86 = X86_64;
     assert!(x86.contains("IA32_GS_BASE"));
     assert!(x86.contains("gs:[{offset}]") && x86.contains("CPU_AREA_SELF_BASE_OFFSET"));
-    assert!(x86.contains("CPU_AREA_CURRENT_THREAD_OFFSET"));
+    assert!(x86.contains("CPU_AREA_CURRENT_CONTEXT_OFFSET"));
     let x86_install = x86
         .split_once("unsafe fn install_cpu_base")
         .unwrap()
@@ -150,7 +150,7 @@ fn x86_and_aarch64_keep_task_tls_separate_from_the_cpu_anchor() {
         .split_once("unsafe fn read_cpu_base")
         .unwrap()
         .1
-        .split_once("unsafe fn read_current_thread")
+        .split_once("unsafe fn read_current_context")
         .unwrap()
         .0;
     assert!(!install.contains("TPIDR_EL0"));
@@ -173,17 +173,17 @@ fn aarch64_current_stays_in_sp_el0_when_tls_is_enabled() {
     assert!(!install.contains("cfg!(feature = \"tls\")"));
 
     let read_current = AARCH64
-        .split_once("unsafe fn read_current_thread")
+        .split_once("unsafe fn read_current_context")
         .unwrap()
         .1
-        .split_once("unsafe fn write_current_thread")
+        .split_once("unsafe fn write_current_context")
         .unwrap()
         .0;
     assert!(read_current.contains("SP_EL0"));
     assert!(!read_current.contains("area_runtime_anchor"));
 
     let write_current = AARCH64
-        .split_once("unsafe fn write_current_thread")
+        .split_once("unsafe fn write_current_context")
         .unwrap()
         .1
         .split_once("unsafe fn read_kernel_tls")

--- a/components/cpu-local/tests/typed_api_contract.rs
+++ b/components/cpu-local/tests/typed_api_contract.rs
@@ -53,8 +53,8 @@ fn public_errors_use_thiserror_without_manual_trait_impls() {
     assert!(source.contains("thiserror::Error"));
     assert!(!source.contains("impl fmt::Display for Cpu"));
     assert!(!source.contains("impl core::error::Error for Cpu"));
-    assert!(!source.contains("impl fmt::Display for ThreadSwitchError"));
-    assert!(!source.contains("impl core::error::Error for ThreadSwitchError"));
+    assert!(!source.contains("impl fmt::Display for ContextSwitchError"));
+    assert!(!source.contains("impl core::error::Error for ContextSwitchError"));
 }
 
 #[test]
@@ -65,4 +65,23 @@ fn pin_is_scoped_and_cannot_be_forged_directly() {
     assert!(pin.contains("pub unsafe fn with_cpu_pin"));
     assert!(!pin.contains("CpuPin::new_unchecked"));
     assert!(!pin.contains("pub const unsafe fn new_unchecked"));
+}
+
+#[test]
+fn preemption_handoff_is_linear_and_scheduler_neutral() {
+    let preempt = fs::read_to_string(crate_root().join("src/preempt.rs")).unwrap();
+    for declaration in [
+        "pub struct PreemptionToken",
+        "pub struct PendingPreemption",
+        "pub enum PreemptionExit",
+        "pub fn enter_preemption() -> PreemptionToken",
+        "pub fn finish_preemption(token: PreemptionToken) -> PreemptionExit",
+        "pub fn release_initial_context_preemption(",
+    ] {
+        assert!(preempt.contains(declaration), "missing `{declaration}`");
+    }
+    assert!(preempt.matches("#[must_use").count() >= 3);
+    assert!(!preempt.contains("scheduler"));
+    assert!(!preempt.contains("baton"));
+    assert!(!preempt.contains("RuntimeThreadCookie"));
 }

--- a/components/cpu-local/tests/typed_api_contract.rs
+++ b/components/cpu-local/tests/typed_api_contract.rs
@@ -75,6 +75,7 @@ fn preemption_handoff_is_linear_and_scheduler_neutral() {
         "pub struct PendingPreemption",
         "pub enum PreemptionExit",
         "pub fn enter_preemption() -> PreemptionToken",
+        "pub fn handoff_preemption_after_context_switch(",
         "pub fn finish_preemption(token: PreemptionToken) -> PreemptionExit",
         "pub fn release_initial_context_preemption(",
     ] {

--- a/components/scope-local/Cargo.toml
+++ b/components/scope-local/Cargo.toml
@@ -10,18 +10,18 @@ license = "Apache-2.0"
 
 [features]
 axtest = ["dep:axtest"]
-host-test = ["ax-sync/host-test"]
+host-test = ["ax-sync/host-test", "cpu-local/host-test"]
 
 [dependencies]
 ax-lazyinit.workspace = true
 ax-percpu.workspace = true
 ax-sync.workspace = true
+cpu-local.workspace = true
 axtest = { workspace = true, optional = true }
 
 [dev-dependencies]
 ax-sync.workspace = true
 ctor = "0.6"
-cpu-local = { workspace = true, features = ["host-test"] }
 ax-percpu = { workspace = true, features = ["host-test"] }
 
 [lints.rust]

--- a/components/scope-local/src/scope.rs
+++ b/components/scope-local/src/scope.rs
@@ -216,13 +216,16 @@ impl ActiveScope {
 
 fn current_context_identity() -> usize {
     let _guard = PreemptGuard::new();
-    // SAFETY: the guard keeps the current thread header stable while its opaque
-    // identity is acquired. The header itself is pinned for the task lifetime,
-    // so this identity remains valid if the task later migrates during an
-    // initializer.
+    // SAFETY: the guard keeps the architecture-selected current context stable
+    // while its header address is acquired. That header stays pinned for the
+    // context lifetime, so the identity survives later migration.
     let context = unsafe {
-        ax_percpu::with_cpu_pin(|pin| pin.area().runtime_anchor().current_thread_raw())
-            .expect("scope-local access requires an installed CPU area")
+        ax_percpu::with_cpu_pin(|pin| {
+            cpu_local::current_context(pin)
+                .expect("scope-local current context must be valid")
+                .as_ptr() as usize
+        })
+        .expect("scope-local access requires an installed CPU area")
     };
     assert!(
         context > GlobalScopeState::Ready as usize,

--- a/os/arceos/modules/axhal/src/percpu.rs
+++ b/os/arceos/modules/axhal/src/percpu.rs
@@ -8,9 +8,8 @@ pub use ax_plat::percpu::{
     init_primary, this_cpu_id, this_cpu_id_pinned, this_cpu_is_bsp, this_cpu_is_bsp_pinned,
 };
 pub use cpu_local::{
-    CpuAreaRef, CpuLocalError, CpuPin, CurrentContext, CurrentThreadHeader, ExclusiveCpu,
-    PreparedThreadSwitch, PreviousThreadBinding, ThreadSwitchError, with_cpu_pin,
-    with_exclusive_cpu,
+    ContextSwitchError, CpuAreaRef, CpuLocalError, CpuPin, ExclusiveCpu, ExecutionContextHeader,
+    PreparedContextSwitch, PreviousContextBinding, with_cpu_pin, with_exclusive_cpu,
 };
 
 /// Returns the direct current CPU-area base under an explicit pin.
@@ -25,33 +24,42 @@ pub const fn current_cpu_area(pin: &CpuPin<'_>) -> CpuAreaRef {
 }
 
 /// Returns the pinned current execution-context header.
-pub fn current_thread(pin: &CpuPin<'_>) -> Result<NonNull<CurrentThreadHeader>, CpuLocalError> {
-    cpu_local::current_thread(pin)
+pub fn current_context(pin: &CpuPin<'_>) -> Result<NonNull<ExecutionContextHeader>, CpuLocalError> {
+    cpu_local::current_context(pin)
 }
 
-/// Reads current-thread identity before constructing a scheduler guard.
+/// Reads the current context before constructing a migration guard.
 ///
 /// # Safety
 ///
-/// The caller must keep the scheduler-owned current task alive and must not
+/// The caller must keep the owning execution context alive and must not
 /// dereference the result after a context switch.
-pub unsafe fn current_thread_raw() -> *const CurrentThreadHeader {
-    unsafe { cpu_local::scheduler_current_thread() }
+pub unsafe fn current_context_raw() -> *const ExecutionContextHeader {
+    unsafe { cpu_local::current_context_unpinned() }
         .map_or(core::ptr::null(), |pointer| pointer.as_ptr().cast_const())
 }
 
-/// Prepares a complete current-thread switch transaction.
+/// Reports whether a raw context is the permanent pre-runtime boot context.
+///
+/// Returns `false` for a null or invalid pointer. Callers must still satisfy
+/// the lifetime requirements of [`current_context_raw`].
+#[doc(hidden)]
+pub fn is_permanent_boot_context(context: NonNull<ExecutionContextHeader>) -> bool {
+    cpu_local::is_permanent_boot_context(context).unwrap_or(false)
+}
+
+/// Prepares a complete execution-context switch transaction.
 ///
 /// # Safety
 ///
 /// The caller must own the IRQ-disabled scheduler path and keep both task
 /// allocations pinned through the raw switch and incoming tail.
-pub unsafe fn prepare_thread_switch<'switch>(
+pub unsafe fn prepare_context_switch<'switch>(
     pin: &'switch CpuPin<'_>,
-    previous: Pin<&CurrentThreadHeader>,
-    next: Pin<&CurrentThreadHeader>,
-) -> Result<(PreparedThreadSwitch<'switch>, PreviousThreadBinding), ThreadSwitchError> {
-    unsafe { cpu_local::prepare_thread_switch(pin, previous, next) }
+    previous: Pin<&ExecutionContextHeader>,
+    next: Pin<&ExecutionContextHeader>,
+) -> Result<(PreparedContextSwitch<'switch>, PreviousContextBinding), ContextSwitchError> {
+    unsafe { cpu_local::prepare_context_switch(pin, previous, next) }
 }
 
 /// Installs the scheduler bootstrap task on an offline CPU.
@@ -59,11 +67,11 @@ pub unsafe fn prepare_thread_switch<'switch>(
 /// # Safety
 ///
 /// The CPU must be offline and trap-free, and `header` must remain pinned.
-pub unsafe fn install_bootstrap_thread(
+pub unsafe fn install_bootstrap_context(
     pin: &CpuPin<'_>,
-    header: Pin<&CurrentThreadHeader>,
-) -> Result<(), ThreadSwitchError> {
-    unsafe { cpu_local::install_bootstrap_thread(pin, header) }
+    header: Pin<&ExecutionContextHeader>,
+) -> Result<(), ContextSwitchError> {
+    unsafe { cpu_local::install_bootstrap_context(pin, header) }
 }
 
 /// Reads the current task-owned kernel TLS base.

--- a/os/arceos/modules/axruntime/Cargo.toml
+++ b/os/arceos/modules/axruntime/Cargo.toml
@@ -17,6 +17,7 @@ host-test = [
   "ax-ipi?/host-test",
   "ax-percpu?/host-test",
   "ax-task/host-test",
+  "cpu-local/host-test",
 ]
 ipi = ["irq", "dep:ax-ipi", "ax-hal/ipi", "ax-task/ipi"]
 # Register a lightweight IPI IRQ handler that only acknowledges SGIs so idle
@@ -101,6 +102,7 @@ ax-percpu = {workspace = true, optional = true}
 ax-plat = {workspace = true}
 ax-sync.workspace = true
 ax-task = {workspace = true, features = ["lock-api"]}
+cpu-local.workspace = true
 axbacktrace = {workspace = true}
 axpoll = {workspace = true, optional = true}
 axklib.workspace = true

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -53,6 +53,8 @@ mod mp;
 #[cfg(feature = "paging")]
 mod kernel_mapping;
 mod klib;
+#[cfg(feature = "multitask")]
+mod preempt;
 
 mod devices;
 mod error;
@@ -286,7 +288,10 @@ pub fn rust_main(cpu_id: usize, arg: usize) -> ! {
     }
 
     #[cfg(feature = "multitask")]
-    ax_task::init_scheduler();
+    {
+        ax_task::init_scheduler();
+        preempt::release_bootstrap();
+    }
 
     #[cfg(feature = "ipi")]
     {

--- a/os/arceos/modules/axruntime/src/mp.rs
+++ b/os/arceos/modules/axruntime/src/mp.rs
@@ -87,6 +87,7 @@ pub fn rust_main_secondary(cpu_id: usize) -> ! {
     {
         let (stack_ptr, stack_size) = secondary_boot_stack_bounds(cpu_id);
         ax_task::init_scheduler_secondary(stack_ptr, stack_size);
+        super::preempt::release_bootstrap();
     }
 
     #[cfg(feature = "ipi")]

--- a/os/arceos/modules/axruntime/src/preempt.rs
+++ b/os/arceos/modules/axruntime/src/preempt.rs
@@ -1,0 +1,125 @@
+//! Architecture preemption adapter and scheduler safe-point baton.
+
+#[cfg(feature = "irq")]
+use core::sync::atomic::{AtomicBool, Ordering};
+
+#[cfg(feature = "irq")]
+#[ax_percpu::def_percpu]
+static SCHEDULER_BATON: AtomicBool = AtomicBool::new(false);
+
+struct RuntimePreemptionOps;
+
+#[ax_crate_interface::impl_interface]
+impl ax_task::runtime_preempt::RuntimePreemption for RuntimePreemptionOps {
+    fn enter() -> usize {
+        cpu_local::enter_preemption().into_raw()
+    }
+
+    fn exit(token: usize) {
+        exit_preemption(token);
+    }
+
+    fn depth() -> usize {
+        let irqs_were_enabled = ax_hal::asm::irqs_enabled();
+        ax_hal::asm::disable_irqs();
+        let depth =
+            with_cpu_pin(|pin| cpu_local::preemption_snapshot(pin).map(|state| state.depth()))
+                .unwrap_or_else(|error| panic!("runtime preemption state is invalid: {error}"));
+        if irqs_were_enabled {
+            ax_hal::asm::enable_irqs();
+        }
+        depth as usize
+    }
+
+    fn finish_initial_context_switch() {
+        debug_assert!(!ax_hal::asm::irqs_enabled());
+        with_cpu_pin(cpu_local::release_initial_context_preemption)
+            .unwrap_or_else(|error| panic!("initial preemption handoff is invalid: {error}"));
+    }
+}
+
+pub(crate) fn release_bootstrap() {
+    with_cpu_pin(cpu_local::release_bootstrap_preemption)
+        .unwrap_or_else(|error| panic!("bootstrap preemption state is invalid: {error}"));
+}
+
+fn exit_preemption(raw: usize) {
+    // SAFETY: axtask transports the exact opaque value returned by `enter`
+    // through one non-Send guard and consumes it here exactly once.
+    let token = unsafe { cpu_local::PreemptionToken::from_raw(raw) }
+        .expect("runtime preemption token must retain its aligned owner");
+    let irqs_were_enabled = ax_hal::asm::irqs_enabled();
+    ax_hal::asm::disable_irqs();
+
+    let pending = ax_task::runtime_preemption_pending();
+    with_cpu_pin(|pin| {
+        if pending {
+            cpu_local::set_preemption_pending(pin)
+        } else {
+            cpu_local::clear_preemption_pending(pin)
+        }
+    })
+    .unwrap_or_else(|error| panic!("runtime preemption publication failed: {error}"));
+
+    match cpu_local::finish_preemption(token) {
+        cpu_local::PreemptionExit::Nested | cpu_local::PreemptionExit::Enabled => {}
+        cpu_local::PreemptionExit::Pending(pending) => {
+            claim_scheduler_baton();
+            pending.release();
+            with_cpu_pin(cpu_local::clear_preemption_pending).unwrap_or_else(|error| {
+                panic!("runtime preemption clear failed before scheduling: {error}")
+            });
+            release_scheduler_baton();
+            ax_task::runtime_preempt_current();
+        }
+    }
+
+    if irqs_were_enabled {
+        ax_hal::asm::enable_irqs();
+    }
+}
+
+#[cfg(feature = "irq")]
+fn claim_scheduler_baton() {
+    with_cpu_pin(|pin| {
+        SCHEDULER_BATON.with_current(pin, |baton| {
+            assert!(
+                baton
+                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                    .is_ok(),
+                "runtime scheduler baton is already active"
+            );
+        })
+    });
+}
+
+#[cfg(not(feature = "irq"))]
+fn claim_scheduler_baton() {
+    panic!("pending preemption requires the runtime IRQ capability");
+}
+
+#[cfg(feature = "irq")]
+fn release_scheduler_baton() {
+    with_cpu_pin(|pin| {
+        SCHEDULER_BATON.with_current(pin, |baton| {
+            assert!(
+                baton
+                    .compare_exchange(true, false, Ordering::Release, Ordering::Relaxed)
+                    .is_ok(),
+                "runtime scheduler baton was not active"
+            );
+        })
+    });
+}
+
+#[cfg(not(feature = "irq"))]
+fn release_scheduler_baton() {
+    unreachable!("a runtime without IRQ capability cannot claim the baton");
+}
+
+fn with_cpu_pin<R>(operation: impl for<'scope> FnOnce(&cpu_local::CpuPin<'scope>) -> R) -> R {
+    // SAFETY: callers mask local IRQs for the complete operation, so this
+    // execution cannot migrate while the scoped CPU capability is live.
+    unsafe { cpu_local::with_cpu_pin(operation) }
+        .unwrap_or_else(|error| panic!("runtime CPU-local state is invalid: {error}"))
+}

--- a/os/arceos/modules/axruntime/src/preempt.rs
+++ b/os/arceos/modules/axruntime/src/preempt.rs
@@ -51,6 +51,9 @@ fn exit_preemption(raw: usize) {
     let irqs_were_enabled = ax_hal::asm::irqs_enabled();
     ax_hal::asm::disable_irqs();
 
+    let token = with_cpu_pin(|pin| cpu_local::handoff_preemption_after_context_switch(pin, token))
+        .unwrap_or_else(|error| panic!("context-switch preemption handoff failed: {error}"));
+
     let pending = ax_task::runtime_preemption_pending();
     with_cpu_pin(|pin| {
         if pending {

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -84,20 +84,46 @@ pub fn current() -> CurrentTask {
 
 /// Disables preemption for the current task when preemption is configured.
 #[doc(hidden)]
-pub fn disable_preempt() {
+pub fn disable_preempt() -> usize {
     #[cfg(feature = "preempt")]
-    if let Some(curr) = current_may_uninit() {
-        curr.disable_preempt();
+    {
+        crate::runtime_preempt::enter()
+    }
+    #[cfg(not(feature = "preempt"))]
+    {
+        0
     }
 }
 
 /// Enables preemption for the current task when preemption is configured.
 #[doc(hidden)]
-pub fn enable_preempt() {
+pub fn enable_preempt(token: usize) {
     #[cfg(feature = "preempt")]
-    if let Some(curr) = current_may_uninit() {
-        curr.enable_preempt(true);
+    {
+        crate::runtime_preempt::exit(token);
     }
+    #[cfg(not(feature = "preempt"))]
+    let _ = token;
+}
+
+/// Reports scheduler work to the runtime preemption safe-point adapter.
+#[doc(hidden)]
+pub fn runtime_preemption_pending() -> bool {
+    #[cfg(feature = "preempt")]
+    {
+        current_may_uninit().is_some_and(|curr| curr.preemption_pending())
+    }
+    #[cfg(not(feature = "preempt"))]
+    {
+        false
+    }
+}
+
+/// Runs the legacy scheduler action after the runtime claims its baton.
+#[doc(hidden)]
+pub fn runtime_preempt_current() {
+    #[cfg(feature = "preempt")]
+    crate::task::TaskInner::current_check_preempt_pending();
 }
 
 #[cfg(feature = "lockdep")]

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -78,6 +78,8 @@ cfg_if::cfg_if! {
         mod interrupt;
         mod task;
         mod api;
+        #[doc(hidden)]
+        pub mod runtime_preempt;
         #[cfg(feature = "lockdep")]
         mod lockdep;
         #[cfg(feature = "tracepoint-hooks")]

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -3,7 +3,7 @@ use alloc::{collections::VecDeque, sync::Arc};
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::{mem::MaybeUninit, ops::Deref, ptr::NonNull};
 
-use ax_hal::percpu::{PreviousThreadBinding, this_cpu_id};
+use ax_hal::percpu::{PreviousContextBinding, this_cpu_id};
 use ax_lazyinit::LazyInit;
 use ax_memory_addr::VirtAddr;
 use ax_sched::BaseScheduler;
@@ -24,7 +24,7 @@ use crate::{
 
 struct PreviousTask {
     task: NonNull<crate::AxTask>,
-    binding: PreviousThreadBinding,
+    binding: PreviousContextBinding,
 }
 
 macro_rules! percpu_static {
@@ -1213,15 +1213,15 @@ impl AxRunQueue {
 
             // The enclosing run-queue guard has already disabled migration and
             // local IRQs for the complete switch lifetime.
-            let prev_header_pointer = prev_task.current_header().as_non_null();
-            let next_header_pointer = next_task.current_header().as_non_null();
+            let prev_header_pointer = prev_task.context_header().as_non_null();
+            let next_header_pointer = next_task.context_header().as_non_null();
             ax_hal::percpu::with_cpu_pin(|pin| {
                 // SAFETY: both Arc allocations remain alive across the raw
                 // switch; the header fields are permanently pinned within them.
                 let prev_header = core::pin::Pin::new_unchecked(prev_header_pointer.as_ref());
                 let next_header = core::pin::Pin::new_unchecked(next_header_pointer.as_ref());
                 let (prepared, previous_binding) =
-                    ax_hal::percpu::prepare_thread_switch(pin, prev_header, next_header)
+                    ax_hal::percpu::prepare_context_switch(pin, prev_header, next_header)
                         .expect("scheduler thread switch must validate before publication");
 
                 // FP, address-space, Arc, and PREV_TASK work all remain before
@@ -1362,7 +1362,7 @@ pub(crate) unsafe fn clear_prev_task_on_cpu() {
     let prev = unsafe { previous.task.as_ref() };
     // SAFETY: current publication and architecture registers already identify
     // the incoming task, and this is the sole owner of the recorded epoch.
-    unsafe { previous.binding.finish(prev.current_header()) }
+    unsafe { previous.binding.finish(prev.context_header()) }
         .expect("incoming switch tail must withdraw prev_task CPU binding");
     // Publish that the context is fully saved. The SeqCst store pairs with the
     // waker's `on_cpu()`/`take_wake()` handshake in `put_task_with_state`.

--- a/os/arceos/modules/axtask/src/runtime_preempt.rs
+++ b/os/arceos/modules/axtask/src/runtime_preempt.rs
@@ -1,0 +1,46 @@
+//! Narrow runtime capability used by legacy ArceOS task guards.
+//!
+//! The task layer owns scheduling policy and pending-work decisions. The
+//! runtime owns architecture preemption state, IRQ exclusion, and the baton
+//! that admits a scheduling safe point.
+
+#[ax_crate_interface::def_interface]
+pub trait RuntimePreemption {
+    /// Enters architecture preemption exclusion and returns a linear token.
+    fn enter() -> usize;
+
+    /// Finishes the exact token returned by [`Self::enter`].
+    fn exit(token: usize);
+
+    /// Returns the architecture-selected preemption depth.
+    fn depth() -> usize;
+
+    /// Completes the preemption handoff for a context's first switch-in.
+    fn finish_initial_context_switch();
+}
+
+#[inline(always)]
+#[cfg(feature = "preempt")]
+pub(crate) fn enter() -> usize {
+    ax_crate_interface::call_interface!(RuntimePreemption::enter)
+}
+
+#[inline(always)]
+#[cfg(feature = "preempt")]
+pub(crate) fn exit(token: usize) {
+    ax_crate_interface::call_interface!(RuntimePreemption::exit, token)
+}
+
+#[inline(always)]
+#[cfg(all(feature = "preempt", not(feature = "host-test")))]
+pub(crate) fn depth() -> usize {
+    ax_crate_interface::call_interface!(RuntimePreemption::depth)
+}
+
+#[inline(always)]
+pub(crate) fn finish_initial_context_switch() {
+    #[cfg(all(feature = "preempt", not(feature = "host-test")))]
+    ax_crate_interface::call_interface!(RuntimePreemption::finish_initial_context_switch);
+    #[cfg(all(feature = "preempt", feature = "host-test"))]
+    crate::sync::finish_initial_host_context_switch();
+}

--- a/os/arceos/modules/axtask/src/sync/bridge.rs
+++ b/os/arceos/modules/axtask/src/sync/bridge.rs
@@ -82,10 +82,7 @@ struct LockdepAcquireRequest<'a> {
 pub fn context_enter(context: u8) -> usize {
     match context {
         CONTEXT_RAW => 0,
-        CONTEXT_PREEMPT => {
-            PreemptState::acquire();
-            0
-        }
+        CONTEXT_PREEMPT => PreemptState::acquire(),
         CONTEXT_IRQSAVE => IrqSaveState::acquire(),
         CONTEXT_PREEMPT_IRQSAVE => PreemptIrqSaveState::acquire(),
         _ => panic!("unknown lock context mode {context}"),
@@ -96,7 +93,7 @@ pub fn context_enter(context: u8) -> usize {
 pub fn context_exit(context: u8, state: usize) {
     match context {
         CONTEXT_RAW => {}
-        CONTEXT_PREEMPT => PreemptState::release(()),
+        CONTEXT_PREEMPT => PreemptState::release(state),
         CONTEXT_IRQSAVE => IrqSaveState::release(state),
         CONTEXT_PREEMPT_IRQSAVE => PreemptIrqSaveState::release(state),
         _ => panic!("unknown lock context mode {context}"),

--- a/os/arceos/modules/axtask/src/sync/context.rs
+++ b/os/arceos/modules/axtask/src/sync/context.rs
@@ -103,16 +103,16 @@ impl GuardState for RawState {
 }
 
 impl GuardState for PreemptState {
-    type State = ();
+    type State = usize;
 
     #[inline(always)]
     fn acquire() -> Self::State {
-        imp::disable_preempt();
+        imp::disable_preempt()
     }
 
     #[inline(always)]
-    fn release(_state: Self::State) {
-        imp::enable_preempt();
+    fn release(state: Self::State) {
+        imp::enable_preempt(state);
     }
 
     fn lockdep_enabled() -> bool {
@@ -139,14 +139,15 @@ impl GuardState for PreemptIrqSaveState {
 
     #[inline(always)]
     fn acquire() -> Self::State {
-        imp::disable_preempt();
-        imp::irq_save_and_disable()
+        let preemption = imp::disable_preempt();
+        assert_eq!(preemption & 1, 0, "preemption token must be aligned");
+        preemption | (imp::irq_save_and_disable() & 1)
     }
 
     #[inline(always)]
     fn release(state: Self::State) {
-        imp::irq_restore(state);
-        imp::enable_preempt();
+        imp::irq_restore(state & 1);
+        imp::enable_preempt(state & !1);
     }
 
     fn lockdep_enabled() -> bool {
@@ -164,14 +165,15 @@ impl GuardState for PreemptIrqSaveState {
 /// require_send::<ax_task::sync::PreemptGuard>();
 /// ```
 pub struct PreemptGuard {
+    state: <PreemptState as GuardState>::State,
     _not_send: PhantomData<*mut ()>,
 }
 
 impl PreemptGuard {
     /// Disables preemption and creates a guard which restores it on drop.
     pub fn new() -> Self {
-        PreemptState::acquire();
         Self {
+            state: PreemptState::acquire(),
             _not_send: PhantomData,
         }
     }
@@ -185,7 +187,7 @@ impl Default for PreemptGuard {
 
 impl Drop for PreemptGuard {
     fn drop(&mut self) {
-        PreemptState::release(());
+        PreemptState::release(self.state);
     }
 }
 
@@ -274,23 +276,14 @@ mod imp {
         static EVENTS: RefCell<std::vec::Vec<&'static str>> = const { RefCell::new(std::vec::Vec::new()) };
     }
 
-    pub(super) fn disable_preempt() {
+    pub(super) fn disable_preempt() -> usize {
         EVENTS.with_borrow_mut(|events| events.push("preempt-disable"));
-        #[cfg(feature = "multitask")]
-        if crate::current_may_uninit().is_some() {
-            crate::disable_preempt();
-            return;
-        }
         PREEMPT_DEPTH.set(PREEMPT_DEPTH.get() + 1);
+        0
     }
 
-    pub(super) fn enable_preempt() {
+    pub(super) fn enable_preempt(_state: usize) {
         EVENTS.with_borrow_mut(|events| events.push("preempt-enable"));
-        #[cfg(feature = "multitask")]
-        if crate::current_may_uninit().is_some() {
-            crate::enable_preempt();
-            return;
-        }
         PREEMPT_DEPTH.set(
             PREEMPT_DEPTH
                 .get()
@@ -322,20 +315,34 @@ mod imp {
     pub(super) fn preempt_depth() -> usize {
         PREEMPT_DEPTH.get()
     }
+
+    #[cfg(feature = "preempt")]
+    pub(super) fn finish_initial_context_switch() {
+        assert_eq!(
+            PREEMPT_DEPTH.get(),
+            1,
+            "initial host context switch must inherit one exclusion depth"
+        );
+        PREEMPT_DEPTH.set(0);
+    }
 }
 
 #[cfg(not(all(feature = "host-test", not(target_os = "none"))))]
 mod imp {
     #[inline(always)]
-    pub(super) fn disable_preempt() {
+    pub(super) fn disable_preempt() -> usize {
         #[cfg(feature = "multitask")]
-        crate::disable_preempt();
+        return crate::disable_preempt();
+        #[cfg(not(feature = "multitask"))]
+        0
     }
 
     #[inline(always)]
-    pub(super) fn enable_preempt() {
+    pub(super) fn enable_preempt(state: usize) {
         #[cfg(feature = "multitask")]
-        crate::enable_preempt();
+        crate::enable_preempt(state);
+        #[cfg(not(feature = "multitask"))]
+        let _ = state;
     }
 
     #[inline(always)]
@@ -360,6 +367,11 @@ mod imp {
 #[doc(hidden)]
 pub fn host_preempt_depth() -> usize {
     imp::preempt_depth()
+}
+
+#[cfg(all(feature = "preempt", feature = "host-test", not(target_os = "none")))]
+pub(crate) fn finish_initial_host_context_switch() {
+    imp::finish_initial_context_switch();
 }
 
 #[cfg(all(feature = "host-test", not(target_os = "none")))]

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -3,14 +3,13 @@ use alloc::{boxed::Box, string::String, sync::Arc};
 use core::alloc::Layout;
 #[cfg(feature = "smp")]
 use core::sync::atomic::AtomicPtr;
-#[cfg(feature = "preempt")]
-use core::sync::atomic::AtomicUsize;
 use core::{
     cell::{Cell, UnsafeCell},
     fmt,
-    mem::ManuallyDrop,
+    mem::{ManuallyDrop, offset_of},
     ops::Deref,
     pin::Pin,
+    ptr::NonNull,
     sync::atomic::{AtomicBool, AtomicI32, AtomicU8, AtomicU32, AtomicU64, Ordering},
     task::{Context, Poll},
 };
@@ -19,7 +18,7 @@ use core::{
 use ax_hal::tls::TlsArea;
 use ax_hal::{
     context::{KernelTlsBase, TaskContext},
-    percpu::{CurrentContext, CurrentThreadHeader},
+    percpu::ExecutionContextHeader,
 };
 use ax_lazyinit::LazyInit;
 #[cfg(feature = "stack-guard-page")]
@@ -62,6 +61,41 @@ pub enum TaskState {
     /// Task is exited and waiting for being dropped.
     Exited  = 4,
 }
+
+/// Task-owned wrapper around the scheduler-neutral architecture header.
+///
+/// The header is the first field so the architecture `current` identity can
+/// be converted directly to this wrapper without a second publication slot.
+#[repr(C)]
+struct TaskExecutionContext {
+    header: ExecutionContextHeader,
+    owner: NonNull<AxTask>,
+}
+
+impl TaskExecutionContext {
+    fn new(owner: NonNull<AxTask>, bootstrap: bool) -> Self {
+        Self {
+            header: if bootstrap {
+                ExecutionContextHeader::new_bootstrap()
+            } else {
+                ExecutionContextHeader::new()
+            },
+            owner,
+        }
+    }
+
+    /// Reconstructs the task wrapper whose offset-zero header is current.
+    ///
+    /// # Safety
+    ///
+    /// `header` must point to the header of a live `TaskExecutionContext`, and
+    /// the scheduler must retain the raw current-task reference while used.
+    unsafe fn from_header(header: NonNull<ExecutionContextHeader>) -> &'static Self {
+        unsafe { &*header.as_ptr().cast::<Self>() }
+    }
+}
+
+const _: () = assert!(offset_of!(TaskExecutionContext, header) == 0);
 
 /// User-defined task extended data.
 #[cfg(feature = "task-ext")]
@@ -126,8 +160,6 @@ pub struct TaskInner {
     need_resched: AtomicBool,
     #[cfg(feature = "preempt")]
     force_resched: AtomicBool,
-    #[cfg(feature = "preempt")]
-    preempt_disable_count: AtomicUsize,
 
     interrupted: InterruptState,
     interrupt_waker: AtomicWaker,
@@ -138,7 +170,7 @@ pub struct TaskInner {
     kstack: TaskStack,
     ctx: UnsafeCell<TaskContext>,
     /// Pinned identity and CPU-binding state published by the switch tail.
-    current_header: LazyInit<CurrentThreadHeader>,
+    execution_context: LazyInit<TaskExecutionContext>,
     #[cfg(feature = "lockdep")]
     held_locks: UnsafeCell<HeldLockStack>,
 
@@ -403,15 +435,13 @@ impl TaskInner {
             need_resched: AtomicBool::new(false),
             #[cfg(feature = "preempt")]
             force_resched: AtomicBool::new(false),
-            #[cfg(feature = "preempt")]
-            preempt_disable_count: AtomicUsize::new(0),
             interrupted: InterruptState::new(),
             interrupt_waker: AtomicWaker::new(),
             exit_code: AtomicI32::new(0),
             wait_for_exit: WaitQueue::new(),
             kstack,
             ctx: UnsafeCell::new(TaskContext::new()),
-            current_header: LazyInit::new(),
+            execution_context: LazyInit::new(),
             #[cfg(feature = "lockdep")]
             held_locks: UnsafeCell::new(HeldLockStack::new()),
             #[cfg(feature = "task-ext")]
@@ -442,28 +472,27 @@ impl TaskInner {
 
     pub(crate) fn into_arc(self) -> AxTaskRef {
         let task = Arc::new(AxTask::new(self));
-        let current_context = CurrentContext::from_raw(Arc::as_ptr(&task) as usize)
-            .expect("Arc task pointer must be non-null");
-        let header = task
-            .current_header
-            .init_once(CurrentThreadHeader::new(current_context));
-        // SAFETY: `header` is stored inside the Arc allocation that owns the
-        // task. That allocation is stable until the last task reference drops.
-        let header = unsafe { Pin::new_unchecked(header) };
+        let owner = NonNull::from(Arc::as_ref(&task));
+        let execution_context = task
+            .execution_context
+            .init_once(TaskExecutionContext::new(owner, task.is_init()));
+        // SAFETY: the header is stored in the Arc-owned task and never moves
+        // after this task becomes visible to a scheduler.
+        let header = unsafe { Pin::new_unchecked(&execution_context.header) };
         // SAFETY: the Arc is not visible to any scheduler yet, so this is the
         // only access to its architecture context.
-        unsafe { (*task.ctx_mut_ptr()).set_current_header(header.as_non_null()) };
+        unsafe { (*task.ctx_mut_ptr()).set_context_header(header.as_non_null()) };
         task
     }
 
-    pub(crate) fn current_header(&self) -> Pin<&CurrentThreadHeader> {
-        let header = self
-            .current_header
+    pub(crate) fn context_header(&self) -> Pin<&ExecutionContextHeader> {
+        let execution_context = self
+            .execution_context
             .get()
-            .expect("task header must be initialized after Arc allocation");
+            .expect("task execution context must be initialized after Arc allocation");
         // SAFETY: `into_arc` initializes this field only after the containing
         // scheduler task reaches its permanent Arc allocation.
-        unsafe { Pin::new_unchecked(header) }
+        unsafe { Pin::new_unchecked(&execution_context.header) }
     }
 
     /// Returns the current state of the task.
@@ -567,6 +596,12 @@ impl TaskInner {
     }
 
     #[inline]
+    #[cfg(feature = "preempt")]
+    pub(crate) fn preemption_pending(&self) -> bool {
+        self.force_resched_pending() || self.need_resched.load(Ordering::Acquire)
+    }
+
+    #[inline]
     #[cfg(all(
         test,
         feature = "preempt",
@@ -599,41 +634,25 @@ impl TaskInner {
     #[inline]
     #[cfg(feature = "preempt")]
     pub(crate) fn preempt_count(&self) -> usize {
-        self.preempt_disable_count.load(Ordering::Acquire)
+        #[cfg(feature = "host-test")]
+        return 0;
+        #[cfg(not(feature = "host-test"))]
+        crate::runtime_preempt::depth()
     }
 
     #[inline]
     #[cfg(feature = "preempt")]
     pub(crate) fn can_preempt(&self, current_disable_count: usize) -> bool {
-        self.preempt_disable_count.load(Ordering::Acquire) == current_disable_count
-    }
-
-    #[inline]
-    #[cfg(feature = "preempt")]
-    pub(crate) fn disable_preempt(&self) {
-        self.preempt_disable_count.fetch_add(1, Ordering::Release);
-    }
-
-    #[inline]
-    #[cfg(feature = "preempt")]
-    pub(crate) fn enable_preempt(&self, resched: bool) {
-        if self.preempt_disable_count.fetch_sub(1, Ordering::Release) == 1 && resched {
-            // Keep local IRQs masked until the preemption check has completely
-            // unwound. A device IRQ may wake a pinned maintenance task and
-            // immediately become pending again when that task rearms the
-            // source. If IRQs are restored by the scheduler's inner guard
-            // before this frame returns, every pending IRQ can recursively
-            // enter another preemption check on the interrupted task's stack.
-            // The outer IRQ guard turns that chain into successive IRQ exits
-            // instead of unbounded scheduler-stack growth.
-            let _irq_guard = crate::sync::IrqSaveGuard::new();
-            // If current task is pending to be preempted, do rescheduling.
-            Self::current_check_preempt_pending();
+        #[cfg(feature = "host-test")]
+        return crate::sync::host_preempt_depth() == current_disable_count;
+        #[cfg(not(feature = "host-test"))]
+        {
+            crate::runtime_preempt::depth() == current_disable_count
         }
     }
 
     #[cfg(feature = "preempt")]
-    fn current_check_preempt_pending() {
+    pub(crate) fn current_check_preempt_pending() {
         use crate::sync::PreemptIrqSaveState;
         let curr = crate::current();
         if (curr.force_resched_pending() || curr.need_resched.load(Ordering::Acquire))
@@ -1047,13 +1066,16 @@ impl CurrentTask {
         // task until `set_current` transfers ownership to the next task. This
         // bootstrap read is also used by the preemption guard implementation,
         // so it cannot require that same guard to have been acquired already.
-        let header = unsafe { ax_hal::percpu::current_thread_raw().as_ref()? };
-        let ptr = header.current_context()?.as_usize() as *const super::AxTask;
-        if !ptr.is_null() {
-            Some(Self(unsafe { ManuallyDrop::new(AxTaskRef::from_raw(ptr)) }))
-        } else {
-            None
+        let header = NonNull::new(unsafe { ax_hal::percpu::current_context_raw() }.cast_mut())?;
+        if ax_hal::percpu::is_permanent_boot_context(header) {
+            return None;
         }
+        // SAFETY: scheduler publication accepts only the offset-zero header of
+        // a live task wrapper and retains a raw strong reference while current.
+        let context = unsafe { TaskExecutionContext::from_header(header) };
+        Some(Self(unsafe {
+            ManuallyDrop::new(AxTaskRef::from_raw(context.owner.as_ptr()))
+        }))
     }
 
     pub(crate) fn get() -> Self {
@@ -1075,7 +1097,7 @@ impl CurrentTask {
         assert!(init_task.is_init());
         // SAFETY: scheduler initialization runs on an offline CPU before any
         // task switch or migration can occur.
-        let header = init_task.current_header();
+        let header = init_task.context_header();
         unsafe {
             ax_hal::percpu::with_cpu_pin(|pin| {
                 #[cfg(feature = "tls")]
@@ -1083,11 +1105,11 @@ impl CurrentTask {
                     pin,
                     KernelTlsBase::new(init_task.tls.tls_ptr() as usize),
                 );
-                ax_hal::percpu::install_bootstrap_thread(pin, header)
+                ax_hal::percpu::install_bootstrap_context(pin, header)
             })
         }
         .expect("CPU-local area must precede task initialization")
-        .expect("bootstrap current-thread state must install");
+        .expect("bootstrap current-context state must install");
         let _ = Arc::into_raw(init_task);
     }
 
@@ -1095,6 +1117,19 @@ impl CurrentTask {
         let Self(arc) = prev;
         ManuallyDrop::into_inner(arc); // `call Arc::drop()` to decrease prev task reference count.
         let _ = Arc::into_raw(next);
+    }
+}
+
+#[cfg(all(test, feature = "host-test", feature = "multitask"))]
+mod current_task_tests {
+    #[test]
+    fn permanent_boot_context_is_not_a_published_task() {
+        std::thread::spawn(|| {
+            ax_hal::percpu::initialize_host_test_cpu();
+            assert!(super::CurrentTask::try_get().is_none());
+        })
+        .join()
+        .expect("boot-context probe panicked");
     }
 }
 
@@ -1111,6 +1146,10 @@ extern "C" fn task_entry() -> ! {
         // Clear the prev task on CPU before running the task entry function.
         crate::run_queue::clear_prev_task_on_cpu();
     }
+    // A CPU-owned preemption word carries the switch guard across the raw
+    // transfer. Unlike a resumed task, a new task has no suspended caller to
+    // finish that guard, so its first-entry tail completes the handoff here.
+    crate::runtime_preempt::finish_initial_context_switch();
     // Enable irq (if feature "irq" is enabled) before running the task entry function.
     #[cfg(all(feature = "irq", not(feature = "host-test")))]
     ax_hal::asm::enable_irqs();

--- a/os/arceos/modules/axtask/src/tests.rs
+++ b/os/arceos/modules/axtask/src/tests.rs
@@ -15,7 +15,9 @@ use axpoll::{IoEvents, Pollable};
 #[cfg(feature = "irq")]
 use crate::IrqNotify;
 #[cfg(feature = "preempt")]
-use crate::sync::{PreemptGuard, SpinLock};
+use crate::sync::PreemptGuard;
+#[cfg(all(feature = "lockdep", feature = "preempt"))]
+use crate::sync::SpinLock;
 use crate::{
     WaitQueue, api as ax_task, current,
     future::{TaskError, TaskResult},


### PR DESCRIPTION
## 问题

PR #1775 需要把 CPU current、context switch 与抢占状态作为底层能力复用，但原方案把 `scheduler_*`、runtime cookie 和 scheduler baton 等上层概念带进了 `cpu-local`。这会反转依赖方向，使基础库知道 task/runtime 的所有权模型，也让不同 image mode 同时维护并核对多份 current 指针。

本 PR 作为 #1775 的前置改动，从当前 `dev` 独立实现底层边界，不提取 #1775 的提交历史，也不复制其整个目录。

## 修改

- 将 thread/scheduler 命名收敛为中性的 execution-context API：
  - `ExecutionContextHeader`
  - `PreparedContextSwitch`
  - `PreviousContextBinding`
  - `prepare_context_switch` / `install_bootstrap_context`
- 从 header 删除 consumer pointer/runtime cookie；current header 地址本身作为唯一架构 identity。
- 每种 image mode 只选择一个 current 来源：
  - x86_64 及复用 TLS current 寄存器的模式使用 CPU runtime anchor；
  - AArch64、非 TLS RISC-V/LoongArch 使用专用架构 current 寄存器。
- 增加 scheduler-neutral 的线性抢占能力：`PreemptionToken`、`PendingPreemption`、`PreemptionExit`。context-owned token 精确绑定进入时的 context 状态；x86 CPU-owned switch token 只允许在 context-switch resume 边界线性交接到恢复 CPU。
- 在 `ax-runtime` 实现 IRQ/preempt 生命周期、bootstrap/initial handoff、跨 CPU resume handoff 与 scheduler baton；`cpu-local` 不认识 task、runqueue、IPI 或 baton。
- `ax-task` 通过 `RuntimePreemption` 能力使用 runtime，继续拥有 `need_resched`、runqueue、task publication 和调度策略；它不直接依赖 `cpu-local`。
- 使用 offset-zero `TaskExecutionContext` 包装 header 与 task owner；永久 boot context 通过 CPU-area identity 区分，不增加第二个 cookie/current 指针。
- 同步迁移 `axcpu` 四架构 context/trap、`axhal`、`scope-local` 以及现有 `axtask`/`axruntime` 消费者。
- 更新 CPU-local 设计文档、README 和 `arch-platform-porting` current/preemption 契约；未修改 someboot 行为。

## 实现逻辑

1. `cpu-local` 只负责 CPU area、架构 current 来源、context CPU 绑定、切换事务和架构选择的抢占字。
2. `ax-runtime` 是硬件执行上下文与 task 系统之间唯一主动适配层；只有取得 runtime scheduler baton 后才消费最终 pending depth。
3. `ax-task` 只提供当前 task 的待调度事实并执行调度动作，不持有底层寄存器/抢占实现。
4. CPU-owned 抢占状态在首次切入新 context 时由 incoming tail 释放；已挂起 context 跨 CPU 恢复时，runtime 消费旧 token 并接管目标 CPU outgoing context 留下的等价 switch depth。context-owned 架构始终保留原 owner。

## 验证

- `cargo test -p cpu-local --features host-test -- --skip non_aarch64_final_images_never_select_arm_el2`
- `cargo test -p cpu-local --features host-test,tls -- --skip non_aarch64_final_images_never_select_arm_el2`
- `cargo test -p ax-percpu --features host-test`
- boot-context、initial pending handoff、host FP context-switch 与 x86 跨 CPU switch-token handoff 确定性红/绿回归
- `cargo xtask clippy --package cpu-local`（3/3）
- `cargo xtask clippy --package ax-task`（18/18）
- `cargo xtask clippy --package ax-runtime`（25/25）
- 其余受影响 crate 的 targeted clippy：`ax-cpu`、`ax-hal`、`ax-percpu`、`scope-local`
- `cargo fmt --all --check`
- ArceOS `task-yield`：x86_64 / RISC-V / AArch64 / LoongArch64
- ArceOS x86_64 `sched-rr`
- StarryOS x86_64 `qemu/system/block-io-smoke`
- `cargo xtask starry test qemu --arch x86_64`：4/4 case 通过，其中 system 447/447

合并后，#1775 可 rebase 到最新 `dev`，删除其中重复的 `scheduler_*`、runtime cookie 与 preemption 接口，只保留 TaskSystem、RT/Deadline、IPI delivery 等上层改动。