### PR TITLE
fix(axklib): enforce valid DMA CPU mappings

### DIFF
--- a/book/design/dma-coherent-remap.md
+++ b/book/design/dma-coherent-remap.md
@@ -88,14 +88,32 @@ distinct values and owners:
   access while the coherent allocation is live;
 - layout: the allocation extent shared by all three views.
 
+The address-space allocator still operates on numerical `VirtAddr` values, so
+address zero remains representable for explicit, guest, and user mappings. The
+DMA capability boundary is stricter: every non-empty CPU-visible allocation or
+alias is represented as `NonNull<u8>`. Device-visible `DmaAddr` remains an
+independent numerical address and may legitimately be zero. A zero-length DMA
+allocation uses a dangling non-null CPU pointer, DMA address zero, and never
+calls the page allocator or deallocator.
+
 Non-coherent alias allocation performs these transitions:
 
 1. allocate physically contiguous pages and calculate the DMA address;
 2. clean and invalidate the cache through the allocator address;
-3. reserve a free kernel VA and map the physical pages there as
+3. reserve a free non-null kernel VA and map the physical pages there as
    `READ | WRITE | UNCACHED`;
 4. complete cross-CPU TLB invalidation and platform ordering;
-5. zero memory through the uncached alias and publish the handle.
+5. atomically publish the validated CPU alias, allocator address, DMA address,
+   and layout as one handle;
+6. zero memory through that published handle before returning it to the typed
+   DMA container.
+
+The temporary page owner is an internal transaction guard. It releases pages
+automatically until ownership is transferred into `DmaAllocHandle`. A
+`NotStarted` mapping failure therefore rolls back through normal guard drop,
+while `StateUncertain` explicitly disarms the guard and quarantines both pages
+and any partially visible alias. No fallible conversion or raw-pointer access
+is allowed between a successful alias mapping and handle publication.
 
 Alias release performs the reverse ownership transition: stop device access,
 remove the alias, complete cross-CPU TLB invalidation, and only then free the
@@ -113,6 +131,9 @@ occurs only for non-coherent devices.
   pages can be returned to the allocator.
 - After alias installation begins, a shootdown or ordering failure is
   `StateUncertain`; the alias and pages are quarantined.
+- A successful alias mapping can only contain a non-null CPU pointer. Kernel
+  address spaces whose numerical base is zero reserve the first page for
+  allocation-like CPU mappings instead of publishing a null pointer.
 - During alias release, any unmap or shootdown failure quarantines the
   allocation and prevents the original pages from being reused.
 

--- a/components/axklib/src/dma.rs
+++ b/components/axklib/src/dma.rs
@@ -1,6 +1,6 @@
 use core::{alloc::Layout, num::NonZeroUsize, ptr::NonNull};
 
-use ax_memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
+use ax_memory_addr::{PAGE_SIZE_4K, VirtAddr};
 use dma_api::{
     DeviceDma, DmaAllocHandle, DmaCoherency, DmaConstraints, DmaDirection, DmaDomainId, DmaError,
     DmaMapHandle, DmaOp,
@@ -29,9 +29,33 @@ struct DmaPages {
     cpu_addr: NonNull<u8>,
     dma_addr: u64,
     num_pages: usize,
+    state: DmaPagesState,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DmaPagesState {
+    Owned,
+    Transferred,
+    Quarantined,
+}
+
+impl DmaPagesState {
+    const fn releases_pages_on_drop(self) -> bool {
+        matches!(self, Self::Owned)
+    }
 }
 
 impl DmaPages {
+    fn empty() -> Self {
+        let (cpu_addr, dma_addr, num_pages) = empty_dma_page_parts();
+        Self {
+            cpu_addr,
+            dma_addr,
+            num_pages,
+            state: DmaPagesState::Owned,
+        }
+    }
+
     fn layout_pages(layout: Layout) -> usize {
         layout.size().div_ceil(PAGE_SIZE_4K)
     }
@@ -45,72 +69,104 @@ impl DmaPages {
     /// `dma_alloc_pages` is expected to honor `addr_mask` and the requested
     /// alignment. The checks below are defensive validation so a bad platform
     /// allocator fails before the buffer is handed to a device.
-    unsafe fn alloc_for_layout(
-        constraints: DmaConstraints,
-        layout: Layout,
-    ) -> Result<Self, DmaError> {
+    fn alloc_for_layout(constraints: DmaConstraints, layout: Layout) -> Result<Self, DmaError> {
         if layout.size() == 0 {
-            return Ok(Self {
-                cpu_addr: NonNull::dangling(),
-                dma_addr: 0,
-                num_pages: 0,
-            });
+            return Ok(Self::empty());
         }
 
         let num_pages = Self::layout_pages(layout);
         let align = Self::layout_align(layout, constraints);
-        let cpu_vaddr = crate::klib::dma_alloc_pages(constraints.addr_mask, num_pages, align)
+        let cpu_addr = crate::klib::dma_alloc_pages(constraints.addr_mask, num_pages, align)
             .map_err(|_| DmaError::NoMemory)?;
-        let cpu_addr = NonNull::new(cpu_vaddr.as_mut_ptr()).ok_or(DmaError::NoMemory)?;
-        let dma_addr = dma_addr_from_vaddr(cpu_vaddr);
+        let dma_addr = dma_addr_from_ptr(cpu_addr);
+        let pages = Self {
+            cpu_addr,
+            dma_addr,
+            num_pages,
+            state: DmaPagesState::Owned,
+        };
 
         if !dma_range_fits_mask(dma_addr, layout.size(), constraints.addr_mask) {
-            unsafe { Self::dealloc_pages(cpu_addr, num_pages) };
             return Err(DmaError::DmaMaskNotMatch {
                 addr: dma_addr.into(),
                 mask: constraints.addr_mask,
             });
         }
         if !dma_addr_is_aligned(dma_addr, constraints.align.max(layout.align())) {
-            unsafe { Self::dealloc_pages(cpu_addr, num_pages) };
             return Err(DmaError::AlignMismatch {
                 required: constraints.align.max(layout.align()),
                 address: dma_addr.into(),
             });
         }
 
-        Ok(Self {
-            cpu_addr,
-            dma_addr,
-            num_pages,
-        })
+        Ok(pages)
     }
 
+    /// # Safety
+    ///
+    /// `cpu_addr` and `num_pages` must describe a live allocation returned by
+    /// the kernel DMA page allocator, and no published handle may still own it.
     unsafe fn dealloc_pages(cpu_addr: NonNull<u8>, num_pages: usize) {
         if num_pages == 0 {
             return;
         }
-        crate::klib::dma_dealloc_pages(VirtAddr::from_usize(cpu_addr.as_ptr() as usize), num_pages);
+        crate::klib::dma_dealloc_pages(cpu_addr, num_pages);
+    }
+
+    fn into_contiguous_handle(mut self, layout: Layout) -> DmaAllocHandle {
+        self.state = DmaPagesState::Transferred;
+        // SAFETY: `self` owns the live allocation and its matching DMA address
+        // until this method transfers both values into the handle.
+        unsafe { DmaAllocHandle::new(self.cpu_addr, self.dma_addr.into(), layout) }
+    }
+
+    /// Transfers the allocator pages to a coherent handle using `alias` for CPU access.
+    ///
+    /// # Safety
+    ///
+    /// `alias` must map the same physical pages as `self.cpu_addr` for the
+    /// complete `layout` and must remain valid until coherent deallocation.
+    unsafe fn into_coherent_handle(mut self, alias: NonNull<u8>, layout: Layout) -> DmaAllocHandle {
+        self.state = DmaPagesState::Transferred;
+        unsafe {
+            DmaAllocHandle::new_with_allocation(alias, self.cpu_addr, self.dma_addr.into(), layout)
+        }
+    }
+
+    fn into_bounce_parts(mut self) -> (NonNull<u8>, u64) {
+        self.state = DmaPagesState::Transferred;
+        (self.cpu_addr, self.dma_addr)
+    }
+
+    fn quarantine(mut self) {
+        self.state = DmaPagesState::Quarantined;
+    }
+}
+
+fn empty_dma_page_parts() -> (NonNull<u8>, u64, usize) {
+    (NonNull::dangling(), 0, 0)
+}
+
+impl Drop for DmaPages {
+    fn drop(&mut self) {
+        if self.state.releases_pages_on_drop() {
+            // SAFETY: the guard still owns exactly the pages returned by the
+            // kernel DMA allocator and has not published them in a handle.
+            unsafe { Self::dealloc_pages(self.cpu_addr, self.num_pages) };
+        }
     }
 }
 
 struct CoherentDmaPolicy;
 
 impl CoherentDmaPolicy {
-    fn map_uncached(pages: &DmaPages, layout: Layout) -> DmaCoherentMappingOutcome {
+    fn map_uncached(pages: &DmaPages) -> DmaCoherentMappingOutcome {
         if pages.num_pages == 0 {
-            return DmaCoherentMappingOutcome::Mapped(VirtAddr::from_usize(
-                pages.cpu_addr.as_ptr() as usize,
-            ));
+            return DmaCoherentMappingOutcome::Mapped(pages.cpu_addr);
         }
 
         let range_size = pages.num_pages * PAGE_SIZE_4K;
-        let start = VirtAddr::from_usize(pages.cpu_addr.as_ptr() as usize).align_down_4k();
-        let outcome = crate::klib::mem_map_dma_coherent_uncached(start, range_size);
-        if let DmaCoherentMappingOutcome::Mapped(alias) = outcome {
-            unsafe { alias.as_mut_ptr().write_bytes(0, layout.size()) };
-        }
-        outcome
+        crate::klib::mem_map_dma_coherent_uncached(pages.cpu_addr, range_size)
     }
 
     fn unmap_alias(alias: NonNull<u8>, num_pages: usize) -> Result<(), DmaError> {
@@ -118,8 +174,7 @@ impl CoherentDmaPolicy {
             return Ok(());
         }
 
-        let start = VirtAddr::from_usize(alias.as_ptr() as usize).align_down_4k();
-        crate::klib::mem_unmap_dma_coherent(start, num_pages * PAGE_SIZE_4K)
+        crate::klib::mem_unmap_dma_coherent(alias, num_pages * PAGE_SIZE_4K)
             .map_err(|_| DmaError::NoMemory)
     }
 }
@@ -133,20 +188,22 @@ fn release_coherent_pages(
     Ok(())
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CoherentMappingFailure {
+    Reclaim,
+    Quarantine,
+}
+
 fn finish_coherent_mapping(
     outcome: DmaCoherentMappingOutcome,
-    dealloc_pages: impl FnOnce(),
-) -> Option<VirtAddr> {
+) -> Result<NonNull<u8>, CoherentMappingFailure> {
     match outcome {
-        DmaCoherentMappingOutcome::Mapped(alias) => Some(alias),
-        DmaCoherentMappingOutcome::NotStarted(_) => {
-            dealloc_pages();
-            None
-        }
+        DmaCoherentMappingOutcome::Mapped(alias) => Ok(alias),
+        DmaCoherentMappingOutcome::NotStarted(_) => Err(CoherentMappingFailure::Reclaim),
         // The PTE update may already be visible on only part of the CPU set.
         // Returning these pages to the allocator could let cached and uncached
         // aliases race with a new owner, so quarantine them permanently.
-        DmaCoherentMappingOutcome::StateUncertain(_) => None,
+        DmaCoherentMappingOutcome::StateUncertain(_) => Err(CoherentMappingFailure::Quarantine),
     }
 }
 
@@ -160,8 +217,8 @@ impl DmaOp for KlibDma {
         constraints: DmaConstraints,
         layout: Layout,
     ) -> Option<DmaAllocHandle> {
-        let pages = unsafe { DmaPages::alloc_for_layout(constraints, layout).ok()? };
-        Some(unsafe { DmaAllocHandle::new(pages.cpu_addr, pages.dma_addr.into(), layout) })
+        let pages = DmaPages::alloc_for_layout(constraints, layout).ok()?;
+        Some(pages.into_contiguous_handle(layout))
     }
 
     unsafe fn dealloc_contiguous(&self, handle: DmaAllocHandle) {
@@ -174,21 +231,17 @@ impl DmaOp for KlibDma {
         constraints: DmaConstraints,
         layout: Layout,
     ) -> Option<DmaAllocHandle> {
-        let pages = unsafe { DmaPages::alloc_for_layout(constraints, layout).ok()? };
-        let alias =
-            finish_coherent_mapping(CoherentDmaPolicy::map_uncached(&pages, layout), || unsafe {
-                DmaPages::dealloc_pages(pages.cpu_addr, pages.num_pages)
-            })?;
-        let alias = NonNull::new(alias.as_mut_ptr())?;
+        let pages = DmaPages::alloc_for_layout(constraints, layout).ok()?;
+        let alias = match finish_coherent_mapping(CoherentDmaPolicy::map_uncached(&pages)) {
+            Ok(alias) => alias,
+            Err(CoherentMappingFailure::Reclaim) => return None,
+            Err(CoherentMappingFailure::Quarantine) => {
+                pages.quarantine();
+                return None;
+            }
+        };
 
-        Some(unsafe {
-            DmaAllocHandle::new_with_allocation(
-                alias,
-                pages.cpu_addr,
-                pages.dma_addr.into(),
-                layout,
-            )
-        })
+        Some(unsafe { pages.into_coherent_handle(alias, layout) })
     }
 
     unsafe fn dealloc_coherent(&self, handle: DmaAllocHandle) -> Result<(), DmaError> {
@@ -217,15 +270,9 @@ impl DmaOp for KlibDma {
             return Ok(unsafe { DmaMapHandle::new(addr, dma_addr.into(), layout, None) });
         }
 
-        let map_pages = unsafe { DmaPages::alloc_for_layout(constraints, layout)? };
-        Ok(unsafe {
-            DmaMapHandle::new(
-                addr,
-                map_pages.dma_addr.into(),
-                layout,
-                Some(map_pages.cpu_addr),
-            )
-        })
+        let map_pages = DmaPages::alloc_for_layout(constraints, layout)?;
+        let (bounce_ptr, bounce_dma_addr) = map_pages.into_bounce_parts();
+        Ok(unsafe { DmaMapHandle::new(addr, bounce_dma_addr.into(), layout, Some(bounce_ptr)) })
     }
 
     unsafe fn unmap_streaming(&self, handle: DmaMapHandle) {
@@ -253,11 +300,7 @@ impl DmaOp for KlibDma {
 }
 
 fn dma_addr_from_ptr(ptr: NonNull<u8>) -> u64 {
-    dma_addr_from_vaddr(VirtAddr::from_usize(ptr.as_ptr() as usize))
-}
-
-fn dma_addr_from_vaddr(vaddr: VirtAddr) -> u64 {
-    crate::klib::mem_virt_to_phys(vaddr).as_usize() as u64
+    crate::klib::mem_virt_to_phys(VirtAddr::from_usize(ptr.as_ptr() as usize)).as_usize() as u64
 }
 
 fn dma_range_fits_mask(dma_addr: u64, size: usize, dma_mask: u64) -> bool {
@@ -329,45 +372,57 @@ mod tests {
     }
 
     #[test]
-    fn coherent_allocation_reclaims_pages_when_mapping_did_not_start() {
-        let events = Rc::new(RefCell::new(Vec::new()));
-        let free_events = events.clone();
+    fn coherent_mapping_marks_not_started_pages_as_reclaimable() {
+        let result = finish_coherent_mapping(DmaCoherentMappingOutcome::NotStarted(
+            KlibError::Unsupported,
+        ));
 
-        let result = finish_coherent_mapping(
-            DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported),
-            move || free_events.borrow_mut().push("free"),
-        );
-
-        assert_eq!(result, None);
-        assert_eq!(*events.borrow(), ["free"]);
+        assert_eq!(result, Err(CoherentMappingFailure::Reclaim));
     }
 
     #[test]
-    fn coherent_allocation_quarantines_pages_when_mapping_state_is_uncertain() {
-        let events = Rc::new(RefCell::new(Vec::new()));
-        let free_events = events.clone();
+    fn coherent_mapping_marks_uncertain_pages_for_quarantine() {
+        let result = finish_coherent_mapping(DmaCoherentMappingOutcome::StateUncertain(
+            KlibError::TimedOut,
+        ));
 
-        let result = finish_coherent_mapping(
-            DmaCoherentMappingOutcome::StateUncertain(KlibError::TimedOut),
-            move || free_events.borrow_mut().push("free"),
-        );
+        assert_eq!(result, Err(CoherentMappingFailure::Quarantine));
+    }
 
-        assert_eq!(result, None);
-        assert!(events.borrow().is_empty());
+    #[test]
+    fn dma_page_guard_only_releases_owned_pages() {
+        assert!(DmaPagesState::Owned.releases_pages_on_drop());
+        assert!(!DmaPagesState::Transferred.releases_pages_on_drop());
+        assert!(!DmaPagesState::Quarantined.releases_pages_on_drop());
     }
 
     #[test]
     fn coherent_allocation_publishes_the_independent_cpu_alias() {
-        let alias = VirtAddr::from_usize(0x8000);
-        let events = Rc::new(RefCell::new(Vec::new()));
-        let free_events = events.clone();
+        let alias = NonNull::new(0x8000 as *mut u8).unwrap();
+        let mapped = finish_coherent_mapping(DmaCoherentMappingOutcome::Mapped(alias));
 
-        let mapped = finish_coherent_mapping(DmaCoherentMappingOutcome::Mapped(alias), move || {
-            free_events.borrow_mut().push("free")
-        });
+        assert_eq!(mapped, Ok(alias));
+    }
 
-        assert_eq!(mapped, Some(alias));
-        assert!(events.borrow().is_empty());
+    #[test]
+    fn zero_length_dma_pages_use_a_dangling_cpu_pointer_and_zero_dma_address() {
+        let layout = Layout::from_size_align(0, 1).unwrap();
+        let (cpu_addr, dma_addr, num_pages) = empty_dma_page_parts();
+
+        assert_eq!(cpu_addr, NonNull::dangling());
+        assert_eq!(dma_addr, 0);
+        assert_eq!(num_pages, 0);
+
+        let handle = unsafe { DmaAllocHandle::new(cpu_addr, dma_addr.into(), layout) };
+        assert_eq!(handle.as_ptr(), NonNull::dangling());
+        assert_eq!(handle.dma_addr().as_u64(), 0);
+        assert_eq!(handle.size(), 0);
+    }
+
+    #[test]
+    fn zero_device_dma_address_remains_a_valid_numerical_address() {
+        assert!(dma_range_fits_mask(0, PAGE_SIZE_4K, u64::MAX));
+        assert!(dma_addr_is_aligned(0, PAGE_SIZE_4K));
     }
 
     #[test]

--- a/components/axklib/src/lib.rs
+++ b/components/axklib/src/lib.rs
@@ -43,7 +43,7 @@
 
 extern crate alloc;
 
-use core::time::Duration;
+use core::{ptr::NonNull, time::Duration};
 
 pub use ax_memory_addr::{PhysAddr, VirtAddr};
 pub use irq_framework::{
@@ -89,8 +89,8 @@ pub fn IrqNumber(raw: usize) -> Result<IrqId, IrqError> {
 #[must_use = "the outcome determines whether coherent pages can be reclaimed or must be quarantined"]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum DmaCoherentMappingOutcome {
-    /// The alias mapping and required cross-CPU synchronization completed.
-    Mapped(VirtAddr),
+    /// The non-null CPU alias and required cross-CPU synchronization completed.
+    Mapped(NonNull<u8>),
     /// The mapping transaction did not start, so the allocated pages remain safe to reclaim.
     NotStarted(KlibError),
     /// The alias transaction started but its final cross-CPU state cannot be proven.
@@ -138,6 +138,8 @@ pub trait Klib {
     /// The cacheable allocator mapping remains installed but must not be used
     /// while the returned alias is owned by the coherent allocation. The DMA
     /// address continues to refer to the original physical pages.
+    /// A successful mapping returns a non-null CPU pointer; numerical virtual
+    /// address zero is not a valid CPU mapping capability.
     ///
     /// Implementations must perform the required cache maintenance, create a
     /// distinct virtual mapping, invalidate TLBs, and apply ordering barriers
@@ -147,7 +149,7 @@ pub trait Klib {
     /// started, failures must return
     /// [`DmaCoherentMappingOutcome::StateUncertain`] so callers quarantine the
     /// pages.
-    fn mem_map_dma_coherent_uncached(addr: VirtAddr, size: usize) -> DmaCoherentMappingOutcome;
+    fn mem_map_dma_coherent_uncached(addr: NonNull<u8>, size: usize) -> DmaCoherentMappingOutcome;
 
     /// Removes an uncached alias created by
     /// [`Klib::mem_map_dma_coherent_uncached`].
@@ -156,7 +158,7 @@ pub trait Klib {
     /// Implementations must perform the required TLB invalidation and ordering
     /// barriers internally before the original pages are returned to the page
     /// allocator. On failure, callers quarantine both the alias and the pages.
-    fn mem_unmap_dma_coherent(addr: VirtAddr, size: usize) -> KlibResult;
+    fn mem_unmap_dma_coherent(addr: NonNull<u8>, size: usize) -> KlibResult;
 
     /// Cleans a CPU cache range before device ownership.
     fn dma_cache_clean(_addr: VirtAddr, _size: usize) {}
@@ -170,11 +172,13 @@ pub trait Klib {
     /// Allocates contiguous DMA pages.
     ///
     /// `dma_mask` is the device-visible address mask. Implementations should
-    /// use a DMA32-capable allocator when the mask requires it.
-    fn dma_alloc_pages(dma_mask: u64, num_pages: usize, align: usize) -> KlibResult<VirtAddr>;
+    /// use a DMA32-capable allocator when the mask requires it. A non-empty
+    /// allocation must return a non-null CPU pointer. A zero-page request may
+    /// return [`NonNull::dangling`] and must be a deallocation no-op.
+    fn dma_alloc_pages(dma_mask: u64, num_pages: usize, align: usize) -> KlibResult<NonNull<u8>>;
 
     /// Releases pages previously allocated by [`Klib::dma_alloc_pages`].
-    fn dma_dealloc_pages(addr: VirtAddr, num_pages: usize);
+    fn dma_dealloc_pages(addr: NonNull<u8>, num_pages: usize);
 
     /// Busy-wait the current execution context for the provided duration.
     ///

--- a/drivers/ax-driver/src/block/phytium_mci.rs
+++ b/drivers/ax-driver/src/block/phytium_mci.rs
@@ -125,13 +125,16 @@ mod tests {
             }
 
             fn mem_map_dma_coherent_uncached(
-                _addr: VirtAddr,
+                _addr: core::ptr::NonNull<u8>,
                 _size: usize,
             ) -> axklib::DmaCoherentMappingOutcome {
                 axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
             }
 
-            fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+            fn mem_unmap_dma_coherent(
+                _addr: core::ptr::NonNull<u8>,
+                _size: usize,
+            ) -> KlibResult {
                 Err(KlibError::Unsupported)
             }
 
@@ -145,11 +148,11 @@ mod tests {
                 _dma_mask: u64,
                 _num_pages: usize,
                 _align: usize,
-            ) -> KlibResult<VirtAddr> {
+            ) -> KlibResult<core::ptr::NonNull<u8>> {
                 Err(KlibError::Unsupported)
             }
 
-            fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+            fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
             fn time_busy_wait(_dur: core::time::Duration) {}
 

--- a/drivers/ax-driver/src/block/starfive_mmc.rs
+++ b/drivers/ax-driver/src/block/starfive_mmc.rs
@@ -244,13 +244,16 @@ mod tests {
             }
 
             fn mem_map_dma_coherent_uncached(
-                _addr: VirtAddr,
+                _addr: core::ptr::NonNull<u8>,
                 _size: usize,
             ) -> axklib::DmaCoherentMappingOutcome {
                 axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
             }
 
-            fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+            fn mem_unmap_dma_coherent(
+                _addr: core::ptr::NonNull<u8>,
+                _size: usize,
+            ) -> KlibResult {
                 Err(KlibError::Unsupported)
             }
 
@@ -264,11 +267,11 @@ mod tests {
                 _dma_mask: u64,
                 _num_pages: usize,
                 _align: usize,
-            ) -> KlibResult<VirtAddr> {
+            ) -> KlibResult<core::ptr::NonNull<u8>> {
                 Err(KlibError::Unsupported)
             }
 
-            fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+            fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
             fn time_busy_wait(_dur: core::time::Duration) {}
 

--- a/drivers/ax-driver/src/pci/mod.rs
+++ b/drivers/ax-driver/src/pci/mod.rs
@@ -585,13 +585,16 @@ mod tests {
             }
 
             fn mem_map_dma_coherent_uncached(
-                _addr: VirtAddr,
+                _addr: core::ptr::NonNull<u8>,
                 _size: usize,
             ) -> axklib::DmaCoherentMappingOutcome {
                 axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
             }
 
-            fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+            fn mem_unmap_dma_coherent(
+                _addr: core::ptr::NonNull<u8>,
+                _size: usize,
+            ) -> KlibResult {
                 Err(KlibError::Unsupported)
             }
 
@@ -605,11 +608,11 @@ mod tests {
                 _dma_mask: u64,
                 _num_pages: usize,
                 _align: usize,
-            ) -> KlibResult<VirtAddr> {
+            ) -> KlibResult<core::ptr::NonNull<u8>> {
                 Err(KlibError::Unsupported)
             }
 
-            fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+            fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
             fn time_busy_wait(_dur: core::time::Duration) {}
 

--- a/drivers/ax-driver/src/soc/rockchip/pinctrl/rdif_glue.rs
+++ b/drivers/ax-driver/src/soc/rockchip/pinctrl/rdif_glue.rs
@@ -235,13 +235,16 @@ mod tests {
             }
 
             fn mem_map_dma_coherent_uncached(
-                _addr: VirtAddr,
+                _addr: core::ptr::NonNull<u8>,
                 _size: usize,
             ) -> axklib::DmaCoherentMappingOutcome {
                 axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
             }
 
-            fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+            fn mem_unmap_dma_coherent(
+                _addr: core::ptr::NonNull<u8>,
+                _size: usize,
+            ) -> KlibResult {
                 Err(KlibError::Unsupported)
             }
 
@@ -255,11 +258,11 @@ mod tests {
                 _dma_mask: u64,
                 _num_pages: usize,
                 _align: usize,
-            ) -> KlibResult<VirtAddr> {
+            ) -> KlibResult<core::ptr::NonNull<u8>> {
                 Err(KlibError::Unsupported)
             }
 
-            fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+            fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
             fn time_busy_wait(_dur: core::time::Duration) {}
 

--- a/drivers/ax-driver/src/time/mod.rs
+++ b/drivers/ax-driver/src/time/mod.rs
@@ -70,13 +70,16 @@ mod tests {
             }
 
             fn mem_map_dma_coherent_uncached(
-                _addr: VirtAddr,
+                _addr: core::ptr::NonNull<u8>,
                 _size: usize,
             ) -> axklib::DmaCoherentMappingOutcome {
                 axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
             }
 
-            fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+            fn mem_unmap_dma_coherent(
+                _addr: core::ptr::NonNull<u8>,
+                _size: usize,
+            ) -> KlibResult {
                 Err(KlibError::Unsupported)
             }
 
@@ -90,11 +93,11 @@ mod tests {
                 _dma_mask: u64,
                 _num_pages: usize,
                 _align: usize,
-            ) -> KlibResult<VirtAddr> {
+            ) -> KlibResult<core::ptr::NonNull<u8>> {
                 Err(KlibError::Unsupported)
             }
 
-            fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+            fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
             fn time_busy_wait(_dur: core::time::Duration) {}
 

--- a/drivers/ax-driver/tests/binding_info.rs
+++ b/drivers/ax-driver/tests/binding_info.rs
@@ -55,13 +55,13 @@ impl_trait! {
         }
 
         fn mem_map_dma_coherent_uncached(
-            _addr: VirtAddr,
+            _addr: core::ptr::NonNull<u8>,
             _size: usize,
         ) -> axklib::DmaCoherentMappingOutcome {
             axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
         }
 
-        fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+        fn mem_unmap_dma_coherent(_addr: core::ptr::NonNull<u8>, _size: usize) -> KlibResult {
             Err(KlibError::Unsupported)
         }
 
@@ -71,11 +71,15 @@ impl_trait! {
 
         fn dma_cache_clean_invalidate(_addr: VirtAddr, _size: usize) {}
 
-        fn dma_alloc_pages(_dma_mask: u64, _num_pages: usize, _align: usize) -> KlibResult<VirtAddr> {
+        fn dma_alloc_pages(
+            _dma_mask: u64,
+            _num_pages: usize,
+            _align: usize,
+        ) -> KlibResult<core::ptr::NonNull<u8>> {
             Err(KlibError::Unsupported)
         }
 
-        fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+        fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
         fn time_busy_wait(_dur: Duration) {}
 

--- a/drivers/ax-driver/tests/model_register.rs
+++ b/drivers/ax-driver/tests/model_register.rs
@@ -22,13 +22,13 @@ impl_trait! {
         }
 
         fn mem_map_dma_coherent_uncached(
-            _addr: VirtAddr,
+            _addr: core::ptr::NonNull<u8>,
             _size: usize,
         ) -> axklib::DmaCoherentMappingOutcome {
             axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
         }
 
-        fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+        fn mem_unmap_dma_coherent(_addr: core::ptr::NonNull<u8>, _size: usize) -> KlibResult {
             Err(KlibError::Unsupported)
         }
 
@@ -42,11 +42,11 @@ impl_trait! {
             _dma_mask: u64,
             _num_pages: usize,
             _align: usize,
-        ) -> KlibResult<VirtAddr> {
+        ) -> KlibResult<core::ptr::NonNull<u8>> {
             Err(KlibError::Unsupported)
         }
 
-        fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+        fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
         fn time_busy_wait(_dur: core::time::Duration) {}
 

--- a/drivers/ax-driver/tests/starfive_syscrg_fdt.rs
+++ b/drivers/ax-driver/tests/starfive_syscrg_fdt.rs
@@ -50,13 +50,13 @@ impl_trait! {
         }
 
         fn mem_map_dma_coherent_uncached(
-            _addr: VirtAddr,
+            _addr: core::ptr::NonNull<u8>,
             _size: usize,
         ) -> axklib::DmaCoherentMappingOutcome {
             axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
         }
 
-        fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+        fn mem_unmap_dma_coherent(_addr: core::ptr::NonNull<u8>, _size: usize) -> KlibResult {
             Err(KlibError::Unsupported)
         }
 
@@ -66,11 +66,15 @@ impl_trait! {
 
         fn dma_cache_clean_invalidate(_addr: VirtAddr, _size: usize) {}
 
-        fn dma_alloc_pages(_dma_mask: u64, _num_pages: usize, _align: usize) -> KlibResult<VirtAddr> {
+        fn dma_alloc_pages(
+            _dma_mask: u64,
+            _num_pages: usize,
+            _align: usize,
+        ) -> KlibResult<core::ptr::NonNull<u8>> {
             Err(KlibError::Unsupported)
         }
 
-        fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+        fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
         fn time_busy_wait(_dur: Duration) {}
 

--- a/drivers/test_crates/driver-tests/tests/serial_fdt.rs
+++ b/drivers/test_crates/driver-tests/tests/serial_fdt.rs
@@ -40,13 +40,13 @@ impl_trait! {
         }
 
         fn mem_map_dma_coherent_uncached(
-            _addr: VirtAddr,
+            _addr: core::ptr::NonNull<u8>,
             _size: usize,
         ) -> axklib::DmaCoherentMappingOutcome {
             axklib::DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
         }
 
-        fn mem_unmap_dma_coherent(_addr: VirtAddr, _size: usize) -> KlibResult {
+        fn mem_unmap_dma_coherent(_addr: core::ptr::NonNull<u8>, _size: usize) -> KlibResult {
             Err(KlibError::Unsupported)
         }
 
@@ -60,11 +60,11 @@ impl_trait! {
             _dma_mask: u64,
             _num_pages: usize,
             _align: usize,
-        ) -> KlibResult<VirtAddr> {
+        ) -> KlibResult<core::ptr::NonNull<u8>> {
             Err(KlibError::Unsupported)
         }
 
-        fn dma_dealloc_pages(_addr: VirtAddr, _num_pages: usize) {}
+        fn dma_dealloc_pages(_addr: core::ptr::NonNull<u8>, _num_pages: usize) {}
 
         fn time_busy_wait(_dur: Duration) {}
 

--- a/os/arceos/modules/axmm/src/aspace.rs
+++ b/os/arceos/modules/axmm/src/aspace.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use core::{fmt, ptr::NonNull};
 
 use ax_hal::{
     mem::phys_to_virt,
@@ -16,6 +16,10 @@ use crate::{MmError, MmResult, backend::Backend};
 enum LinearMappingKind {
     Mutable,
     Boot,
+}
+
+fn dma_alias_search_start(address_space_base: VirtAddr) -> VirtAddr {
+    VirtAddr::from_usize(address_space_base.as_usize().max(PAGE_SIZE_4K))
 }
 
 /// The virtual memory address space.
@@ -187,7 +191,7 @@ impl AddrSpace {
         &mut self,
         start_paddr: PhysAddr,
         size: usize,
-    ) -> MmResult<VirtAddr> {
+    ) -> MmResult<NonNull<u8>> {
         if !start_paddr.is_aligned_4k() || !is_aligned_4k(size) || size == 0 {
             return Err(MmError::InvalidInput(
                 "DMA coherent range is not page aligned",
@@ -199,21 +203,25 @@ impl AddrSpace {
             .ok_or(MmError::InvalidInput("DMA coherent range overflows"))?;
 
         let range = VirtAddrRange::new(self.base(), self.end());
+        let search_start = dma_alias_search_start(self.base());
         let alias = self
-            .find_free_area(self.base(), size, range)
+            .find_free_area(search_start, size, range)
             .ok_or(MmError::NoMemory)?;
+        let alias_ptr = NonNull::new(alias.as_mut_ptr()).ok_or(MmError::BadState(
+            "DMA alias allocator returned the null page",
+        ))?;
         self.map_linear(
             alias,
             start_paddr,
             size,
             MappingFlags::READ | MappingFlags::WRITE | MappingFlags::UNCACHED,
         )?;
-        Ok(alias)
+        Ok(alias_ptr)
     }
 
     /// Removes a DMA-coherent alias without releasing its physical pages.
-    pub fn unmap_dma_coherent_alias(&mut self, alias: VirtAddr, size: usize) -> MmResult {
-        self.unmap(alias, size)
+    pub fn unmap_dma_coherent_alias(&mut self, alias: NonNull<u8>, size: usize) -> MmResult {
+        self.unmap(VirtAddr::from_usize(alias.as_ptr() as usize), size)
     }
 
     /// Add or replace a linear mapping.
@@ -443,5 +451,21 @@ impl fmt::Debug for AddrSpace {
 impl Drop for AddrSpace {
     fn drop(&mut self) {
         self.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dma_alias_search_reserves_the_null_page() {
+        assert_eq!(
+            dma_alias_search_start(VirtAddr::from_usize(0)),
+            VirtAddr::from_usize(PAGE_SIZE_4K)
+        );
+
+        let high_base = VirtAddr::from_usize(0xffff_0000_0000_0000);
+        assert_eq!(dma_alias_search_start(high_base), high_base);
     }
 }

--- a/os/arceos/modules/axruntime/src/kernel_mapping.rs
+++ b/os/arceos/modules/axruntime/src/kernel_mapping.rs
@@ -1,3 +1,5 @@
+use core::ptr::NonNull;
+
 #[cfg(feature = "multitask")]
 use ax_hal::paging::MappingFlags;
 use ax_memory_addr::{PhysAddr, VirtAddr};
@@ -31,7 +33,7 @@ pub(crate) fn protect_kernel_range(
 pub(crate) fn map_dma_coherent_alias(
     paddr: PhysAddr,
     size: usize,
-) -> Result<VirtAddr, MappingTransactionError> {
+) -> Result<NonNull<u8>, MappingTransactionError> {
     let mut kernel_aspace = ax_mm::kernel_aspace().lock();
     map_alias_transaction(
         || {
@@ -40,13 +42,14 @@ pub(crate) fn map_dma_coherent_alias(
                 .map_err(Into::into)
         },
         |alias| {
-            ax_hal::cache::flush_tlb_range_all_cpus(alias, size)?;
+            let alias_vaddr = VirtAddr::from_usize(alias.as_ptr() as usize);
+            ax_hal::cache::flush_tlb_range_all_cpus(alias_vaddr, size)?;
             Ok(())
         },
     )
 }
 
-pub(crate) fn unmap_dma_coherent_alias(alias: VirtAddr, size: usize) -> RuntimeResult {
+pub(crate) fn unmap_dma_coherent_alias(alias: NonNull<u8>, size: usize) -> RuntimeResult {
     // Keep the address-space lock across the shootdown so another allocation
     // cannot reuse this VA while any CPU may retain its old translation.
     let mut kernel_aspace = ax_mm::kernel_aspace().lock();
@@ -56,16 +59,17 @@ pub(crate) fn unmap_dma_coherent_alias(alias: VirtAddr, size: usize) -> RuntimeR
             Ok(())
         },
         || {
-            ax_hal::cache::flush_tlb_range_all_cpus(alias, size)?;
+            let alias_vaddr = VirtAddr::from_usize(alias.as_ptr() as usize);
+            ax_hal::cache::flush_tlb_range_all_cpus(alias_vaddr, size)?;
             Ok(())
         },
     )
 }
 
 fn map_alias_transaction(
-    map: impl FnOnce() -> RuntimeResult<VirtAddr>,
-    shootdown: impl FnOnce(VirtAddr) -> RuntimeResult,
-) -> Result<VirtAddr, MappingTransactionError> {
+    map: impl FnOnce() -> RuntimeResult<NonNull<u8>>,
+    shootdown: impl FnOnce(NonNull<u8>) -> RuntimeResult,
+) -> Result<NonNull<u8>, MappingTransactionError> {
     let alias = map().map_err(MappingTransactionError::NotStarted)?;
     shootdown(alias).map_err(MappingTransactionError::StateUncertain)?;
     Ok(alias)
@@ -157,7 +161,7 @@ mod tests {
             )))
         ));
 
-        let alias = VirtAddr::from_usize(0x4000);
+        let alias = NonNull::new(0x4000 as *mut u8).unwrap();
         let uncertain = map_alias_transaction(
             || Ok(alias),
             |_| Err(RuntimeError::from(TlbShootdownError::Timeout)),

--- a/os/arceos/modules/axruntime/src/klib.rs
+++ b/os/arceos/modules/axruntime/src/klib.rs
@@ -10,7 +10,7 @@
 //! shims expected by consumers. Documentation here focuses on the behavior
 //! and expectations of each exported function.
 
-use core::time::Duration;
+use core::{ptr::NonNull, time::Duration};
 
 #[cfg(feature = "paging")]
 use ax_memory_addr::MemoryAddr;
@@ -34,11 +34,12 @@ pub(crate) fn map_mm_error(err: ax_mm::MmError) -> KlibError {
 }
 
 #[cfg(feature = "paging")]
-fn dma_coherent_range(addr: VirtAddr, size: usize) -> Option<(VirtAddr, usize)> {
+fn dma_coherent_range(addr: NonNull<u8>, size: usize) -> Option<(VirtAddr, usize)> {
     if size == 0 {
         return None;
     }
 
+    let addr = VirtAddr::from_usize(addr.as_ptr() as usize);
     let start = addr.align_down_4k();
     let end = (addr + size).align_up_4k();
     Some((start, end - start))
@@ -59,6 +60,22 @@ fn map_irq_error(err: IrqError) -> KlibError {
 
 fn dma_cache_range(op: ax_hal::mem::DCacheOp, addr: VirtAddr, size: usize) {
     ax_hal::mem::dcache_range(op, addr, size);
+}
+
+fn validate_dma_allocation(
+    addr: usize,
+    num_pages: usize,
+    dealloc: impl FnOnce(usize, usize),
+) -> KlibResult<NonNull<u8>> {
+    if num_pages == 0 {
+        return Ok(NonNull::dangling());
+    }
+    if let Some(ptr) = NonNull::new(addr as *mut u8) {
+        return Ok(ptr);
+    }
+
+    dealloc(addr, num_pages);
+    Err(KlibError::BadState)
 }
 
 impl_trait! {
@@ -96,7 +113,7 @@ impl_trait! {
         }
 
         fn mem_map_dma_coherent_uncached(
-            addr: VirtAddr,
+            addr: NonNull<u8>,
             size: usize,
         ) -> DmaCoherentMappingOutcome {
             #[cfg(feature = "paging")]
@@ -130,7 +147,7 @@ impl_trait! {
             }
         }
 
-        fn mem_unmap_dma_coherent(addr: VirtAddr, size: usize) -> KlibResult {
+        fn mem_unmap_dma_coherent(addr: NonNull<u8>, size: usize) -> KlibResult {
             #[cfg(feature = "paging")]
             {
                 let Some((start, size)) = dma_coherent_range(addr, size) else {
@@ -138,7 +155,7 @@ impl_trait! {
                 };
 
                 ax_hal::mem::dma_coherent_before_unmap_uncached(start, size);
-                crate::kernel_mapping::unmap_dma_coherent_alias(start, size)
+                crate::kernel_mapping::unmap_dma_coherent_alias(addr, size)
                 .map_err(crate::error::runtime_error_to_klib_error)?;
                 ax_hal::mem::dma_coherent_after_mapping_update();
                 Ok(())
@@ -150,7 +167,14 @@ impl_trait! {
             }
         }
 
-        fn dma_alloc_pages(dma_mask: u64, num_pages: usize, align: usize) -> KlibResult<VirtAddr> {
+        fn dma_alloc_pages(
+            dma_mask: u64,
+            num_pages: usize,
+            align: usize,
+        ) -> KlibResult<NonNull<u8>> {
+            if num_pages == 0 {
+                return Ok(NonNull::dangling());
+            }
             let addr = if dma_mask <= u32::MAX as u64 {
                 ax_alloc::global_allocator().alloc_dma32_pages(
                     num_pages,
@@ -165,12 +189,21 @@ impl_trait! {
                 )
             }
             .map_err(|_| KlibError::NoMemory)?;
-            Ok(VirtAddr::from(addr))
+            validate_dma_allocation(addr, num_pages, |addr, num_pages| {
+                ax_alloc::global_allocator().dealloc_pages(
+                    addr,
+                    num_pages,
+                    ax_alloc::UsageKind::Dma,
+                );
+            })
         }
 
-        fn dma_dealloc_pages(addr: VirtAddr, num_pages: usize) {
+        fn dma_dealloc_pages(addr: NonNull<u8>, num_pages: usize) {
+            if num_pages == 0 {
+                return;
+            }
             ax_alloc::global_allocator().dealloc_pages(
-                addr.as_usize(),
+                addr.as_ptr() as usize,
                 num_pages,
                 ax_alloc::UsageKind::Dma,
             );
@@ -318,8 +351,23 @@ mod tests {
     #[test]
     fn coherent_mapping_reports_not_started_without_paging() {
         assert_eq!(
-            KlibImpl::mem_map_dma_coherent_uncached(VirtAddr::from_usize(0x1000), 0x1000),
+            KlibImpl::mem_map_dma_coherent_uncached(
+                NonNull::new(0x1000 as *mut u8).unwrap(),
+                0x1000,
+            ),
             DmaCoherentMappingOutcome::NotStarted(KlibError::Unsupported)
         );
+    }
+
+    #[test]
+    fn null_dma_page_allocation_is_reclaimed_before_error() {
+        let mut released = None;
+
+        let result = validate_dma_allocation(0, 3, |addr, num_pages| {
+            released = Some((addr, num_pages));
+        });
+
+        assert_eq!(result, Err(KlibError::BadState));
+        assert_eq!(released, Some((0, 3)));
     }
 }


### PR DESCRIPTION
## 问题

OrangePi CI 的致命首错不是可选 eMMC 控制器上的 CMD1 timed out，而是 SD 根盘控制器建立 IDMAC ring 时 coherent DMA 配置失败。#1775 的 EL2 内核地址空间从 VA 0 开始，DMA alias 搜索会选中 VA 0；底层已经分配物理页、映射并清零，上层随后把 CPU 地址转换为 NonNull 时却判定失败，导致已成功的底层操作被发布为失败并泄漏资源。

本地 OrangePi Linux 6.1 的 dma_direct_alloc/remap 路径也保持同一不变量：CPU pointer 与 DMA address 作为完整 allocation 一起发布，CPU pointer 失败时回滚；DMA address 本身仍可为 0。

## 修改

- 将 Klib coherent DMA、页分配和释放边界的 CPU 地址改为 NonNull<u8>，DmaAddr 继续保留数值语义。
- 为 kernel CPU pointer alias 增加专用搜索策略：零基址地址空间从 PAGE_SIZE_4K 开始，高半地址空间仍从原 base 开始；通用 find_free_area 和 VirtAddr 的零地址语义不变。
- 将 DmaPages 改为事务 guard：NotStarted 自动且仅回收一次，StateUncertain 显式 quarantine，成功后才转移到 DmaAllocHandle。
- coherent 分配只在完整 handle 发布后清零；释放顺序继续保持 unmap alias、全核 TLB 同步、释放原始页。
- 更新 Klib mocks 与 coherent DMA 设计文档；mem_iomap 生命周期不在本次变更范围。

## 红绿回归

同一测试 dma_alias_search_reserves_the_null_page 在旧策略上确定性失败：EL2 base=0 时实际返回 VA 0，期望 VA 0x1000；实现专用策略后通过。另覆盖：null CPU alias 不可表示、异常零地址页分配立即回收并返回 BadState、NotStarted/StateUncertain 所有权、成功发布前不清零、unmap-before-free、DMA address 0 与零长度 allocation。

## 验证

- cargo test -p axklib --lib：9 passed
- ax-mm 零基址 alias 回归：passed
- ax-runtime 异常零地址回收回归：passed
- cargo check -p dma-api --tests：passed
- cargo xtask clippy --package axklib --package ax-mm --package dma-api --package ax-runtime --package ax-driver --package driver-tests：88/88 passed
- cargo fmt --all --check、git diff --check：passed
- AArch64 EL2 QEMU smoke：kernel aspace base=0，NVMe 根盘读写通过，AXVISOR_NVME_ROOTFS_RW_PASSED
- OrangePi-5-Plus robot Starry 板测：SD 根盘成功启动，ROBOT_CI RESULT=PASS attempts=1；可选 eMMC 的 CMD1 timed out 仍可出现且不影响结果

Refs #1986