### PR TITLE
fix(riscv-vcpu)!: persist VSEIP while unbound

### DIFF
--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -74,6 +74,9 @@ echo "==> axvisor riscv64 IPI cross-test"
 cargo xtask cross-test --arch riscv64 \
   --package riscv_vcpu --package axvm \
   --features axvm/host-test --no-default-features --lib ipi
+echo "==> axvisor riscv64 VSEIP unbound-state cross-test"
+cargo xtask cross-test --arch riscv64 --package riscv_vcpu --lib \
+  controller_vseip_line_updates_saved_state_while_unbound
 echo "==> axvisor riscv64 backtrace panic"
 cargo xtask axvisor test qemu --arch riscv64 --test-case backtrace-panic
 echo "==> axvisor riscv64 no-backtrace panic"

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -259,7 +259,8 @@ fn vplic_runtime(vm: &crate::AxVM) -> AxVmResult<Arc<irq::RiscvPlicRuntime>> {
 
 fn sync_vplic_vseip(vm: &crate::AxVMRef, vcpu: &crate::vm::AxVCpuRef<AxvmRiscvVcpu>) -> AxVmResult {
     let asserted = vplic_runtime(vm)?.vcpu_has_deliverable_irq(vcpu.id())?;
-    vcpu.get_arch_vcpu().sync_bound_vseip(asserted)
+    vcpu.get_arch_vcpu().set_vseip_level(asserted);
+    Ok(())
 }
 
 fn handle_riscv_nested_page_fault(
@@ -354,9 +355,8 @@ impl AxvmRiscvVcpu {
         self.0.decode_mmio_fault(addr, access_flags)
     }
 
-    fn sync_bound_vseip(&mut self, asserted: bool) -> AxVmResult {
-        riscv_result(self.0.sync_bound_vseip(asserted))
-            .map_err(|error| crate::AxVmError::vcpu("synchronize RISC-V VSEIP", error))
+    fn set_vseip_level(&mut self, asserted: bool) {
+        self.0.set_vseip_level(asserted);
     }
 
     fn complete_ipi(&mut self, request: RiscvIpiRequest, completion: RiscvIpiCompletion) {

--- a/virtualization/riscv_vcpu/src/vcpu.rs
+++ b/virtualization/riscv_vcpu/src/vcpu.rs
@@ -346,26 +346,24 @@ impl<H: RiscvHostOps> RiscvVcpu<H> {
         self.set_virtual_interrupt_pending(vector, true)
     }
 
-    /// Synchronizes controller-derived VSEIP state for the bound vCPU.
+    /// Sets the controller-derived VSEIP line level for this vCPU.
     ///
     /// The virtual PLIC remains the owner of pending and delivery state. This
-    /// method only reflects its derived line value into the currently bound
-    /// hardware context and the vCPU's saved CSR image.
-    pub fn sync_bound_vseip(&mut self, asserted: bool) -> RiscvVcpuResult {
-        if !self.bound {
-            return Err(RiscvVcpuError::BadState);
-        }
+    /// method always updates the vCPU-owned saved CSR image and reflects the
+    /// line into hardware only while the vCPU is loaded on the current CPU.
+    pub fn set_vseip_level(&mut self, asserted: bool) {
         let mut saved = hvip::Hvip::from_bits(self.regs.virtual_hs_csrs.hvip);
         saved.set_vseip(asserted);
         self.regs.virtual_hs_csrs.hvip = saved.bits();
-        unsafe {
-            if asserted {
-                hvip::set_vseip();
-            } else {
-                hvip::clear_vseip();
+        if self.bound {
+            unsafe {
+                if asserted {
+                    hvip::set_vseip();
+                } else {
+                    hvip::clear_vseip();
+                }
             }
         }
-        Ok(())
     }
 
     /// Sets the guest return value register.
@@ -1284,5 +1282,16 @@ mod tests {
             assert_eq!(vcpu.get_gpr(GprIndex::A0), expected.error);
             assert_eq!(vcpu.get_gpr(GprIndex::A1), expected.value);
         }
+    }
+
+    #[test]
+    fn controller_vseip_line_updates_saved_state_while_unbound() {
+        let mut vcpu = RiscvVcpu::<TestHost>::default();
+
+        vcpu.set_vseip_level(true);
+        assert!(hvip::Hvip::from_bits(vcpu.regs.virtual_hs_csrs.hvip).vseip());
+
+        vcpu.set_vseip_level(false);
+        assert!(!hvip::Hvip::from_bits(vcpu.regs.virtual_hs_csrs.hvip).vseip());
     }
 }


### PR DESCRIPTION
## 问题

虚拟 PLIC 拥有 VSEIP 的 pending/delivery 状态，但 `riscv_vcpu` 原有同步接口只允许在 vCPU 已绑定到物理 CPU 时调用。vCPU 未绑定期间控制器电平发生变化时，接口返回 `BadState`，保存的 HVIP 镜像也不会更新；后续 bind 从旧镜像恢复后会丢失这一电平。

本改动从 #1775 中独立提取，只修复 `riscv_vcpu` 保存态与绑定态 CSR 的同步边界，不依赖新的 ax-task/ax-runtime 生命周期。

## 变更

- 新增 `set_vseip_level`，名称直接表达“设置控制器派生的 VSEIP 电平”，同步 AxVM 的 RISC-V PLIC 调用点。
- 始终更新 vCPU 自己保存的 `HVIP.VSEIP`；仅在 vCPU 当前 bound 时写入硬件 HVIP CSR。
- 删除旧的 bound-only `sync_bound_vseip`，只保留语义明确且覆盖完整生命周期的 `set_vseip_level`；下游迁移为同参数调用，并移除对 `BadState` 返回值的处理。
- 新增 `controller_vseip_line_updates_saved_state_while_unbound`，覆盖未绑定状态下 VSEIP assert/deassert 的保存态变化。
- 在 AxVisor RISC-V CI 中显式执行该精确 cross-test，避免它被既有 `--lib ipi` 过滤条件排除。
- 以 Conventional Commits 的 breaking-change 元数据声明公开 API 变更，不手工修改版本或 changelog；由 release-plz 统一生成发布变更。

## 实现逻辑与替代方案

虚拟 PLIC 继续作为电平真值来源，`riscv_vcpu` 只负责把派生电平写入 vCPU 保存镜像，并在 backend 已加载时同步硬件 CSR。这样 bind 仍从统一保存镜像恢复状态，同时避免未绑定路径触碰当前物理 CPU 的 CSR。

直接改变 `sync_bound_vseip` 的语义会让旧调用方在未绑定状态下从错误返回变成静默成功，因此不复用这个容易误导的名称，也不保留只覆盖 bound 状态的兼容旁路。该 API 清理通过 breaking-change 元数据和上述迁移说明显式交付。无条件写硬件 CSR 会污染当前 CPU 上不属于该 vCPU 的执行上下文，因此也未采用。

## API 迁移

下游将：

    vcpu.sync_bound_vseip(asserted)?;

替换为：

    vcpu.set_vseip_level(asserted);

新接口不返回 `BadState`：未绑定时更新 vCPU 保存态，已绑定时同时更新硬件 CSR。PR 标题和唯一提交均使用 `!`，提交正文包含 `BREAKING CHANGE`；版本与 changelog 由项目的 release-plz 流程统一生成，本 PR 不手工修改版本文件或 changelog。

## 红绿证据

先加入最终测试但保留旧 `BadState` 行为：

    cargo xtask cross-test --arch riscv64 --package riscv_vcpu --lib controller_vseip_line_updates_saved_state_while_unbound

测试完成交叉编译并在首个 `unwrap` 处确定性失败，错误为 `Err(BadState)`。实现修复后重复同一命令，1/1 通过；全量 `riscv_vcpu` 为 8/8 通过。

## 验证

当前 head `3c571dd0fa` 已线性 rebase 到 `dev@b510fe4e91`（已包含 #2092、#2093），并整理为一个带 `BREAKING CHANGE` 元数据的提交。本地通过：

- `cargo fmt --all --check`
- `git diff --check origin/dev...HEAD`
- `cargo xtask cross-test --arch riscv64 --package riscv_vcpu --lib controller_vseip_line_updates_saved_state_while_unbound`（1/1，精确测试名可见）
- `cargo xtask cross-test --arch riscv64 --package riscv_vcpu --lib`（8/8）
- `cargo xtask clippy --package riscv_vcpu`
- `cargo xtask clippy --package axvm`
- `cargo xtask cross-test --arch riscv64 --package riscv_vcpu --package axvm --features axvm/host-test --no-default-features --lib ipi`（AxVM 8/8，`riscv_vcpu` 5/5）

按要求在上述目标测试和 clippy 通过后直接推送，本次 rebase head 未等待本地 QEMU；以远端当前 head 的 AxVisor RISC-V required check 作为真实运行终态，不沿用旧 head 的 QEMU 结果。

## 风险与非目标

风险集中在 bound/unbound 的 CSR 同步分支和公开 API 迁移；确定性单测覆盖未绑定保存态，远端 RISC-V AxVisor check 覆盖绑定态真实运行。`sync_bound_vseip` 的外部调用方需要迁移到 `set_vseip_level`，版本与 changelog 由 release-plz 根据 breaking-change 元数据处理。不改变 PLIC 路由、SBI IPI ABI、vCPU 调度、AxVM runtime 或 Starry Linux ABI。
