### PR TITLE
feat(ax-cgroup): expose pids.peak

### DIFF
--- a/components/ax-cgroup/src/membership.rs
+++ b/components/ax-cgroup/src/membership.rs
@@ -603,21 +603,27 @@ mod tests {
         target.write_pids_max("0").unwrap();
 
         assert_eq!(source.pids_current_text().unwrap(), "2\n");
+        assert_eq!(source.pids_peak_text().unwrap(), "2\n");
         assert_eq!(parent.pids_current_text().unwrap(), "2\n");
+        assert_eq!(parent.pids_peak_text().unwrap(), "2\n");
         migrate_process(pid, Arc::clone(&target)).unwrap();
 
         assert!(!source.has_member(pid));
         assert!(target.has_member(pid));
         assert_eq!(source.pids_current_text().unwrap(), "0\n");
         assert_eq!(target.pids_current_text().unwrap(), "2\n");
+        assert_eq!(target.pids_peak_text().unwrap(), "2\n");
         assert_eq!(parent.pids_current_text().unwrap(), "2\n");
+        assert_eq!(parent.pids_peak_text().unwrap(), "2\n");
 
         exit_task(pid, tid, CgroupTaskExit::Thread).unwrap();
         assert_eq!(target.pids_current_text().unwrap(), "1\n");
         assert_eq!(parent.pids_current_text().unwrap(), "1\n");
         exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
         assert_eq!(target.pids_current_text().unwrap(), "0\n");
+        assert_eq!(target.pids_peak_text().unwrap(), "2\n");
         assert_eq!(parent.pids_current_text().unwrap(), "0\n");
+        assert_eq!(parent.pids_peak_text().unwrap(), "2\n");
     }
 
     #[test]
@@ -742,6 +748,37 @@ mod tests {
         assert_eq!(parent.pids_events_text().unwrap(), "max 1\n");
 
         exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+    }
+
+    #[test]
+    fn ancestor_rejection_rolls_back_current_but_retains_leaf_peak() {
+        let _guard = setup();
+        let root = crate::root();
+        let parent = root.create_child("peak-rollback-parent").unwrap();
+        root.write_subtree_control("+pids").unwrap();
+        parent.write_subtree_control("+pids").unwrap();
+        let child = parent.create_child("peak-rollback-child").unwrap();
+        let pid = process_id(1034);
+        let tid = process_id(1035);
+        commit_process(&child, pid);
+        parent.write_pids_max("1").unwrap();
+
+        assert!(matches!(
+            begin_task_at(Arc::clone(&child), pid, tid, CgroupChildKind::Thread),
+            Err(CgroupError::LimitExceeded)
+        ));
+        assert_eq!(parent.pids_current_text().unwrap(), "1\n");
+        assert_eq!(parent.pids_peak_text().unwrap(), "1\n");
+        assert_eq!(child.pids_current_text().unwrap(), "1\n");
+        assert_eq!(child.pids_peak_text().unwrap(), "2\n");
+        assert_eq!(parent.pids_events_text().unwrap(), "max 1\n");
+        assert_eq!(child.pids_events_text().unwrap(), "max 0\n");
+
+        exit_task(pid, pid, CgroupTaskExit::LastProcessTask).unwrap();
+        assert_eq!(parent.pids_current_text().unwrap(), "0\n");
+        assert_eq!(parent.pids_peak_text().unwrap(), "1\n");
+        assert_eq!(child.pids_current_text().unwrap(), "0\n");
+        assert_eq!(child.pids_peak_text().unwrap(), "2\n");
     }
 
     #[test]

--- a/components/ax-cgroup/src/node.rs
+++ b/components/ax-cgroup/src/node.rs
@@ -114,6 +114,12 @@ impl CgroupNode {
         Ok(self.pids.current_text())
     }
 
+    /// Render the lifetime high-water mark from `pids.peak`.
+    pub fn pids_peak_text(&self) -> CgroupResult<String> {
+        self.require_pids_interface()?;
+        Ok(self.pids.peak_text())
+    }
+
     /// Render `pids.events`.
     pub fn pids_events_text(&self) -> CgroupResult<String> {
         self.require_pids_interface()?;
@@ -329,11 +335,13 @@ mod tests {
         assert_eq!(root.available_controllers(), ["pids"]);
         assert!(!child.has_pids_interface());
         assert_eq!(child.pids_max_text(), Err(CgroupError::NotFound));
+        assert_eq!(child.pids_peak_text(), Err(CgroupError::NotFound));
 
         root.write_subtree_control("+pids").unwrap();
 
         assert!(child.has_pids_interface());
         assert_eq!(child.pids_max_text(), Ok(String::from("max\n")));
+        assert_eq!(child.pids_peak_text(), Ok(String::from("0\n")));
     }
 
     #[test]

--- a/components/ax-cgroup/src/pids.rs
+++ b/components/ax-cgroup/src/pids.rs
@@ -13,6 +13,7 @@ const UNLIMITED: u64 = u64::MAX;
 
 pub(crate) struct PidsState {
     current: AtomicU64,
+    peak: AtomicU64,
     maximum: AtomicU64,
     max_events: AtomicU64,
 }
@@ -21,6 +22,7 @@ impl PidsState {
     pub(crate) const fn new() -> Self {
         Self {
             current: AtomicU64::new(0),
+            peak: AtomicU64::new(0),
             maximum: AtomicU64::new(UNLIMITED),
             max_events: AtomicU64::new(0),
         }
@@ -40,6 +42,7 @@ impl PidsState {
                 .compare_exchange(current, current + 1, Ordering::AcqRel, Ordering::Acquire)
                 .is_ok()
             {
+                self.peak.fetch_max(current + 1, Ordering::AcqRel);
                 return Ok(());
             }
         }
@@ -49,6 +52,7 @@ impl PidsState {
     pub(crate) fn charge_unchecked(&self, count: u64) {
         let previous = self.current.fetch_add(count, Ordering::AcqRel);
         debug_assert!(previous <= UNLIMITED - count, "pids.current overflow");
+        self.peak.fetch_max(previous + count, Ordering::AcqRel);
     }
 
     /// Release a task count that was previously charged to this node.
@@ -73,6 +77,10 @@ impl PidsState {
 
     pub(crate) fn current_text(&self) -> String {
         format!("{}\n", self.current.load(Ordering::Acquire))
+    }
+
+    pub(crate) fn peak_text(&self) -> String {
+        format!("{}\n", self.peak.load(Ordering::Acquire))
     }
 
     pub(crate) fn events_text(&self) -> String {
@@ -114,6 +122,7 @@ mod tests {
         assert_eq!(state.try_charge(), Err(CgroupError::LimitExceeded));
         state.record_max_event();
         assert_eq!(state.current_text(), "1\n");
+        assert_eq!(state.peak_text(), "1\n");
         assert_eq!(state.events_text(), "max 1\n");
     }
 
@@ -125,7 +134,12 @@ mod tests {
         state.charge_unchecked(2);
 
         assert_eq!(state.current_text(), "2\n");
+        assert_eq!(state.peak_text(), "2\n");
         assert_eq!(state.try_charge(), Err(CgroupError::LimitExceeded));
+
+        state.uncharge(2);
+        assert_eq!(state.current_text(), "0\n");
+        assert_eq!(state.peak_text(), "2\n");
     }
 
     #[test]
@@ -163,8 +177,10 @@ mod tests {
 
         assert_eq!(successes.load(Ordering::Acquire), LIMIT);
         assert_eq!(state.current_text(), "8\n");
+        assert_eq!(state.peak_text(), "8\n");
 
         state.uncharge(LIMIT as u64);
         assert_eq!(state.current_text(), "0\n");
+        assert_eq!(state.peak_text(), "8\n");
     }
 }

--- a/docs/design/starry-cgroup-pids-l4.md
+++ b/docs/design/starry-cgroup-pids-l4.md
@@ -13,11 +13,12 @@ implementation lets a process move into a non-root pids-enabled cgroup, set
 `pids.max`, and observe that the next task-creating `fork` or `clone` fails
 with `EAGAIN` once the hierarchical limit is exhausted. The counters must
 remain balanced across fork rollback, thread exit, process exit, and process
-migration.
+migration. The read-only `pids.peak` interface reports the highest
+`pids.current` value reached during the cgroup node's lifetime.
 
 This is deliberately not a CPU, memory, cpuset, or I/O implementation. It
 does not add cgroup v2 threaded mode, delegation, notifications,
-`pids.events.local`, `pids.peak`, controller disabling, or the cgroup core's
+`pids.events.local`, controller disabling, or the cgroup core's
 no-internal-process rule. Those features require their own observable behavior
 and validation.
 
@@ -55,9 +56,13 @@ thread accounting, migration serialization, reservation rollback, or
 ## State, ownership, and synchronization
 
 Every `CgroupNode` owns a private pids state. The state retains a task count,
-an optional maximum, and the hierarchical `pids.events` max counter. Counts
-and max events are maintained for the affected non-root ancestors so they
-match the cgroup v2 hierarchy before an interface becomes visible.
+its lifetime high-water mark, an optional maximum, and the hierarchical
+`pids.events` max counter. Counts, peaks, and max events are maintained for
+the affected non-root ancestors so they match the cgroup v2 hierarchy before
+an interface becomes visible. Each successful per-node checked or migration
+charge raises the peak atomically; rollback and task exit lower only
+`pids.current`. As in Linux's hierarchical try-charge path, a lower node may
+retain a peak from a charge that an ancestor later rejects.
 The root owns accounting state but does not expose `pids.*` files; those files
 exist only in non-root cgroups whose parent enabled pids in
 `cgroup.subtree_control`.
@@ -120,17 +125,21 @@ existing entry points:
 The cgroupfs interface is observed through existing `mount`, `openat`, `read`,
 `write`, and `getdents64` paths. The change adds dynamic controller and
 `pids.*` entries to the existing cgroup2 filesystem adapter; it does not alter
-the generic syscall ABI. The QEMU cases validate file visibility, permissions,
-input errors, `cgroup.procs` migration, and read-back results.
+the generic syscall ABI. `pids.peak` is exposed beside the other non-root pids
+files after the parent enables the controller and is read-only. The QEMU cases
+validate file visibility, permissions, input errors, `cgroup.procs` migration,
+and read-back results.
 
 ## Validation evidence
 
 Host tests cover parse and read-back behavior, hierarchical charges, CAS limit
-races, rollback, thread accounting, idempotent exit, and migration above a
+races, peak updates after checked and unchecked charges, a stable peak after
+uncharge, rollback, thread accounting, idempotent exit, and migration above a
 limit. The Starry QEMU system test performs the user-visible sequence of
 enabling pids, migration, `pids.max` update, successful first fork, failed
 second fork with `EAGAIN`, a rejected raw `clone(CLONE_PARENT_SETTID)`,
-hierarchical event observation, and counter recovery after exit. The grouped
+hierarchical event observation, counter recovery after exit, and a persistent
+`pids.peak` high-water mark. The grouped
 `cgroup-basic` case also verifies that a successful
 `clone3(CLONE_INTO_CGROUP)` publishes the child in the target cgroup. The pids
 case verifies that a target with `pids.max=0` rejects that clone3 request,
@@ -144,22 +153,22 @@ The initial implementation received a four-architecture focused QEMU run on
 red/green `CLONE_PARENT_SETTID` ordering result, but it does not replace
 validation of later membership-ledger or clone3 target-selection repairs.
 
-The current repair was validated on `origin/dev` at
-`6bca19eb0a6e2488f38a8302df5647d4e2f06180` on 2026-08-17
+The `pids.peak` increment was rebased and validated on `origin/dev` at
+`35aaf4003137575375bb2c4ef481a718c86f7286` on 2026-08-18
 (Asia/Shanghai):
 
 | Gate | Result |
 | --- | --- |
 | `cargo fmt --all -- --check` | passed |
 | `git diff --check` | passed |
-| `cargo test --manifest-path components/ax-cgroup/Cargo.toml --all-features` | 25 passed |
-| `cargo clippy --manifest-path components/ax-cgroup/Cargo.toml --all-features -- -D warnings` | passed |
-| `cargo check -p starry-kernel` | passed |
-| loongarch64 `qemu/system/cgroup-basic` | passed, 1/1; successful `CLONE_INTO_CGROUP` observed in the target |
-| loongarch64 `qemu/system/cgroup-pids` | passed, 1/1; target rejection, rollback, event, and parent-TID checks passed |
+| `cargo test --manifest-path components/ax-cgroup/Cargo.toml --all-features` | 26 passed, including ancestor-rejection peak rollback |
+| `cargo xtask clippy --package ax-cgroup` | passed, 1/1 |
+| `cargo xtask clippy --package starry-kernel` | passed, 25/25 feature/configuration checks; the transient AIC8800 firmware EOF passed on an isolated retry |
+| loongarch64 `qemu/system/cgroup-basic` | passed, 1/1; the controller-disabled child still hides `pids.peak` |
+| loongarch64 `qemu/system/cgroup-pids` | passed, 1/1; direct rejection, hierarchical rollback peaks, exit, and migration checks passed |
 
-A diagnostic loongarch64 grouped-system run also passed both cgroup binaries in
-their real order. It was stopped after the unrelated I/O-heavy
+A historical diagnostic loongarch64 grouped-system run also passed both cgroup
+binaries in their real order. It was stopped after the unrelated I/O-heavy
 `test-ext4-inode-unique` and `test-pagecache-cap` cases each reached their
 existing 240-second per-binary budget; it is not recorded as a full-suite pass.
 A direct `starry-kernel` lib-test attempt is currently blocked before test

--- a/os/StarryOS/kernel/src/cgroup/mod.rs
+++ b/os/StarryOS/kernel/src/cgroup/mod.rs
@@ -14,12 +14,13 @@ use crate::{
     task::{AsThread, PidIdentity, PidIdentityId, Tgid, TgidNumber, current_pid_view},
 };
 
-const INTERFACE_FILES: [&str; 6] = [
+const INTERFACE_FILES: [&str; 7] = [
     "cgroup.procs",
     "cgroup.controllers",
     "cgroup.subtree_control",
     "pids.max",
     "pids.current",
+    "pids.peak",
     "pids.events",
 ];
 
@@ -165,6 +166,10 @@ pub fn pids_max_text(node: &CgroupNode) -> Result<String, StarryError> {
 
 pub fn pids_current_text(node: &CgroupNode) -> Result<String, StarryError> {
     node.pids_current_text().map_err(StarryError::from)
+}
+
+pub fn pids_peak_text(node: &CgroupNode) -> Result<String, StarryError> {
+    node.pids_peak_text().map_err(StarryError::from)
 }
 
 pub fn pids_events_text(node: &CgroupNode) -> Result<String, StarryError> {

--- a/os/StarryOS/kernel/src/pseudofs/cgroup.rs
+++ b/os/StarryOS/kernel/src/pseudofs/cgroup.rs
@@ -21,6 +21,7 @@ enum CgroupFileKind {
     SubtreeControl,
     PidsMax,
     PidsCurrent,
+    PidsPeak,
     PidsEvents,
 }
 
@@ -32,6 +33,7 @@ impl CgroupFileKind {
             "cgroup.subtree_control" => Some(Self::SubtreeControl),
             "pids.max" => Some(Self::PidsMax),
             "pids.current" => Some(Self::PidsCurrent),
+            "pids.peak" => Some(Self::PidsPeak),
             "pids.events" => Some(Self::PidsEvents),
             _ => None,
         }
@@ -44,30 +46,34 @@ impl CgroupFileKind {
             Self::SubtreeControl => "cgroup.subtree_control",
             Self::PidsMax => "pids.max",
             Self::PidsCurrent => "pids.current",
+            Self::PidsPeak => "pids.peak",
             Self::PidsEvents => "pids.events",
         }
     }
 
     fn permission(self) -> NodePermission {
         let mode = match self {
-            Self::Controllers | Self::PidsCurrent | Self::PidsEvents => 0o444,
+            Self::Controllers | Self::PidsCurrent | Self::PidsPeak | Self::PidsEvents => 0o444,
             Self::Procs | Self::SubtreeControl | Self::PidsMax => 0o644,
         };
         NodePermission::from_bits_truncate(mode)
     }
 
     fn is_available(self, cgroup: &CgroupNode) -> bool {
-        !matches!(self, Self::PidsMax | Self::PidsCurrent | Self::PidsEvents)
-            || cgroup.has_pids_interface()
+        !matches!(
+            self,
+            Self::PidsMax | Self::PidsCurrent | Self::PidsPeak | Self::PidsEvents
+        ) || cgroup.has_pids_interface()
     }
 }
 
-const CGROUP_FILES: [CgroupFileKind; 6] = [
+const CGROUP_FILES: [CgroupFileKind; 7] = [
     CgroupFileKind::Controllers,
     CgroupFileKind::Procs,
     CgroupFileKind::SubtreeControl,
     CgroupFileKind::PidsMax,
     CgroupFileKind::PidsCurrent,
+    CgroupFileKind::PidsPeak,
     CgroupFileKind::PidsEvents,
 ];
 
@@ -90,6 +96,7 @@ impl CgroupFile {
             CgroupFileKind::PidsCurrent => {
                 crate::cgroup::pids_current_text(&self.cgroup)?.into_bytes()
             }
+            CgroupFileKind::PidsPeak => crate::cgroup::pids_peak_text(&self.cgroup)?.into_bytes(),
             CgroupFileKind::PidsEvents => {
                 crate::cgroup::pids_events_text(&self.cgroup)?.into_bytes()
             }
@@ -121,7 +128,7 @@ impl DirectRwFsFileOps for CgroupFile {
                 crate::cgroup::write_subtree_control(&self.cgroup, buf)?
             }
             CgroupFileKind::PidsMax => crate::cgroup::write_pids_max(&self.cgroup, buf)?,
-            CgroupFileKind::PidsCurrent | CgroupFileKind::PidsEvents => {
+            CgroupFileKind::PidsCurrent | CgroupFileKind::PidsPeak | CgroupFileKind::PidsEvents => {
                 return Err(VfsError::OperationNotPermitted);
             }
         }

--- a/test-suit/starryos/qemu/system/cgroup-basic/src/main.c
+++ b/test-suit/starryos/qemu/system/cgroup-basic/src/main.c
@@ -337,6 +337,8 @@ int main(void)
                         "child pids.max is hidden before parent enables pids");
     expect_path_missing(CGROUP2_PATH "/a/pids.current",
                         "child pids.current is hidden before parent enables pids");
+    expect_path_missing(CGROUP2_PATH "/a/pids.peak",
+                        "child pids.peak is hidden before parent enables pids");
     expect_path_missing(CGROUP2_PATH "/a/pids.events",
                         "child pids.events is hidden before parent enables pids");
     expect_mkdir_errno(CGROUP2_PATH "/a", EEXIST,

--- a/test-suit/starryos/qemu/system/cgroup-pids/src/main.c
+++ b/test-suit/starryos/qemu/system/cgroup-pids/src/main.c
@@ -181,12 +181,16 @@ int main(void)
                    "pids.max is absent before parent enables pids");
     expect_missing(CGROUP2_PATH "/pids.max",
                    "root does not expose pids interface files");
+    expect_missing(CGROUP2_PATH "/pids.peak",
+                   "root does not expose pids.peak");
     CHECK(write_text(CGROUP2_PATH "/cgroup.subtree_control", "+pids") == 0,
           "enable pids for child cgroups");
     CHECK(access(PRE_ENABLE_PATH "/pids.max", F_OK) == 0,
           "existing child gains pids.max after enable");
     CHECK(access(PRE_ENABLE_PATH "/pids.current", F_OK) == 0,
           "existing child gains pids.current after enable");
+    CHECK(access(PRE_ENABLE_PATH "/pids.peak", F_OK) == 0,
+          "existing child gains pids.peak after enable");
     CHECK(access(PRE_ENABLE_PATH "/pids.events", F_OK) == 0,
           "existing child gains pids.events after enable");
     CHECK(mkdir(CHILD_PATH, 0755) == 0 || errno == EEXIST,
@@ -195,6 +199,8 @@ int main(void)
           "child exposes pids.max");
     CHECK(access(CHILD_PATH "/pids.current", F_OK) == 0,
           "child exposes pids.current");
+    CHECK(access(CHILD_PATH "/pids.peak", F_OK) == 0,
+          "child exposes pids.peak");
     CHECK(access(CHILD_PATH "/pids.events", F_OK) == 0,
           "child exposes pids.events");
     expect_text(CHILD_PATH "/pids.max", "max\n",
@@ -205,8 +211,12 @@ int main(void)
                 "invalid pids.max write leaves limit unchanged");
     expect_text(CHILD_PATH "/pids.events", "max 0\n",
                 "pids.events starts at zero");
+    expect_text(CHILD_PATH "/pids.peak", "0\n",
+                "pids.peak starts at zero");
     expect_write_permission_denied(CHILD_PATH "/pids.current", "0",
                                    "pids.current is read-only");
+    expect_write_permission_denied(CHILD_PATH "/pids.peak", "0",
+                                   "pids.peak is read-only");
     expect_write_permission_denied(CHILD_PATH "/pids.events", "max 0",
                                    "pids.events is read-only");
 
@@ -214,6 +224,8 @@ int main(void)
           "migrate current process into child");
     CHECK(read_number(CHILD_PATH "/pids.current") == 1,
           "migration charges the current task");
+    CHECK(read_number(CHILD_PATH "/pids.peak") == 1,
+          "migration raises pids.peak");
     CHECK(write_text(CHILD_PATH "/pids.max", "2") == 0,
           "set pids.max to two tasks");
     expect_text(CHILD_PATH "/pids.max", "2\n",
@@ -251,6 +263,8 @@ int main(void)
     }
     CHECK(read_number(CHILD_PATH "/pids.current") == 2,
           "pids.current includes parent and held child");
+    CHECK(read_number(CHILD_PATH "/pids.peak") == 2,
+          "held child raises pids.peak");
 
     void *clone_stack = malloc(CLONE_STACK_SIZE);
     CHECK(clone_stack != NULL, "allocate clone stack");
@@ -284,10 +298,14 @@ int main(void)
     CHECK(waitpid(first, NULL, 0) == first, "child exit is observed");
     CHECK(read_number(CHILD_PATH "/pids.current") == 1,
           "child exit releases one pids charge");
+    CHECK(read_number(CHILD_PATH "/pids.peak") == 2,
+          "child exit does not lower pids.peak");
     CHECK(write_text(CGROUP2_PATH "/cgroup.procs", "0") == 0,
           "echo 0 returns current process to root");
     CHECK(read_number(CHILD_PATH "/pids.current") == 0,
           "migration back to root releases child charge");
+    CHECK(read_number(CHILD_PATH "/pids.peak") == 2,
+          "migration back does not lower pids.peak");
 
     CHECK(mkdir(CLONE_INTO_PATH, 0755) == 0 || errno == EEXIST,
           "create clone3 target cgroup");
@@ -321,6 +339,8 @@ int main(void)
     }
     CHECK(read_number(CLONE_INTO_PATH "/pids.current") == 0,
           "denied clone3 leaves target pids.current unchanged");
+    CHECK(read_number(CLONE_INTO_PATH "/pids.peak") == 0,
+          "denied clone3 at the target limit leaves pids.peak unchanged");
     expect_text(CLONE_INTO_PATH "/pids.events", "max 1\n",
                 "clone3 target records its own limit failure");
     CHECK(rmdir(CLONE_INTO_PATH) == 0,
@@ -355,6 +375,10 @@ int main(void)
           "ancestor charge remains stable after denied nested fork");
     CHECK(read_number(NESTED_CHILD_PATH "/pids.current") == 1,
           "leaf charge rolls back after ancestor rejects fork");
+    CHECK(read_number(NESTED_PARENT_PATH "/pids.peak") == 1,
+          "ancestor rejection does not raise ancestor pids.peak");
+    CHECK(read_number(NESTED_CHILD_PATH "/pids.peak") == 2,
+          "leaf pids.peak retains the rolled-back hierarchical charge");
     expect_text(NESTED_PARENT_PATH "/pids.events", "max 1\n",
                 "ancestor records the denied nested fork");
     expect_text(NESTED_CHILD_PATH "/pids.events", "max 0\n",
@@ -382,6 +406,10 @@ int main(void)
           "migration back clears ancestor pids charge");
     CHECK(read_number(NESTED_CHILD_PATH "/pids.current") == 0,
           "migration back clears leaf pids charge");
+    CHECK(read_number(NESTED_PARENT_PATH "/pids.peak") == 1,
+          "migration back preserves ancestor pids.peak");
+    CHECK(read_number(NESTED_CHILD_PATH "/pids.peak") == 2,
+          "migration back preserves leaf pids.peak");
 
     printf("------------------------------------------------\n");
     printf("  DONE: %d pass, %d fail\n", pass_count, fail_count);


### PR DESCRIPTION
## 概述

- 为启用了 pids controller 的非根 cgroup v2 节点增加与 Linux 兼容的只读 `pids.peak` 接口。
- 复用现有的层级化 pids 任务计数，在普通任务预留和迁移计数路径中记录生命周期峰值。
- 在回滚、任务迁移和任务退出后保留历史峰值。
- 增加 host 单元测试和 LoongArch64 QEMU 回归测试，并更新 pids controller 设计文档。

这是 #2014 的一个聚焦型后续增量。

## 语义

实现遵循 Linux v6.12 pids controller 的行为：

- 只有父 cgroup 启用 pids controller 后，非根子 cgroup 才会暴露 `pids.peak`。
- `pids.peak` 为只读文件，不提供重置接口。
- 如果任务在实际计数前就因本级限制被拒绝，不会抬高峰值。
- 在层级化预留过程中，如果叶子 cgroup 已成功计数、随后被祖先 cgroup 拒绝，则 `pids.current` 会回滚，但叶子 cgroup 已观测到的生命周期峰值会保留。
- 取消计数、任务迁出、预留回滚和任务退出都不会降低峰值。

## 改动范围

本 PR 复用 #2014 已合入的 pids 层级结构和任务账本。

本次没有修改生产环境中的 clone、exec、exit、调度器、memory controller 或任务迁移生命周期路径。`membership.rs` 的改动仅用于增加回归测试。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check origin/dev...HEAD`
- `cargo test --manifest-path components/ax-cgroup/Cargo.toml --all-features`——26 项通过
- `cargo clippy --manifest-path components/ax-cgroup/Cargo.toml --all-features -- -D warnings`
- `cargo xtask clippy --package ax-cgroup`——1/1 通过
- `cargo xtask clippy --package starry-kernel`——25/25 通过
- `cargo check -p starry-kernel`
- `cargo xtask starry test qemu --arch loongarch64 --test-case qemu/system/cgroup-pids`——1/1 通过
- `cargo xtask starry test qemu --arch loongarch64 --test-case qemu/system/cgroup-basic`——1/1 通过