### PR TITLE
fix(axdevice)!: bind device access to the issuing vCPU

### DIFF
--- a/docs/design/arm-vgic-interrupt-topology.md
+++ b/docs/design/arm-vgic-interrupt-topology.md
@@ -33,9 +33,34 @@ arm_vgic / arm_vcpu / host GIC backend
 
 每个 VM 只有一个 `Arc<VgicCore>`。enable、pending latch、当前 line level、active、priority、group、trigger、target/route 和 backing 都只保存在该 core 中。GICD、GICC/GICR、ICC 和 ITS 前端只负责架构访问解码，不保存第二份状态，也不向 host GICD/GICR 透传客户机写入。
 
+GICv2 与 GICv3 只表示 guest 可见的硬件协议和 MMIO 拓扑，不形成两套内部状态模型。`ArmVgicConfig` 在构造时一次性选择 banked distributor + GICC，或 shared/affinity distributor + GICR/ICC/ITS；构造后的设备不保存 distributor 版本字段，也不在访问热路径动态查询版本。两类前端最终读写同一个 `VgicCore` canonical state。
+
 同一个 `Arc<VgicCore>` 同时以具体类型服务 vCPU、EOI 和物理 backing，并转换为 `Arc<dyn VirtualInterruptController>` 注册给设备框架。这里没有转发状态机和 `InterruptFabric`。
 
 `WiredIrqInput` 只表达电气 source 聚合：edge 调用 `pulse()`；level 调用 `assert()/deassert()`；shared-level 使用 wired-OR；source drop 自动撤销断言。LR 只是规范状态的有限硬件缓存，满时保留在软件 overflow 队列，不 panic。
+
+### MMIO 访问者身份
+
+触发 MMIO exit 的 VM-local vCPU 是访问者身份的唯一所有者。各架构 exit handler 在仍持有实际 `AxVCpuRef` 时取得 `vcpu.id()`，转换为类型化 `DeviceVcpuId`，再经共享 MMIO handler、`DeviceRuntime` 和一次访问生命周期内的 `DeviceAccess` 传到设备。该身份描述 guest architectural accessor，与承载回调的 host CPU、任务或 TLS 无关；调度、抢占或 host CPU 迁移不能改变它。
+
+数据流固定为：
+
+```text
+architecture VM exit -> DeviceVcpuId -> DeviceRuntime
+  -> DeviceAccess -> Device::read/write -> VGIC banked register
+```
+
+GICv2 CPU interface 以及 distributor 中的 SGI/PPI banked 寄存器必须读取 `DeviceAccess::source_vcpu()`。所有 guest MMIO、PIO 和 SysReg 请求都必须在构造时给出 source，不存在可选 identity 或无身份 guest helper。management/debug 操作应使用专门的 typed service，不能伪装为 guest access。GICv3 distributor 的共享寄存器和由 MMIO 地址直接选择 frame 的 redistributor 不依赖当前访问者。
+
+`DeviceAccess` 只保存本次 transaction 的 source vCPU、bus、address 与 width；`DeviceContext` 只保存 DMA、timer、wake、VM control 等运行能力。IRQ target vCPU 仍由 VGIC 路由状态决定，不能用 access source 代替。例如 source vCPU 0 可以配置并触发 target vCPU 1 的 SPI。
+
+不采用以下替代方案：
+
+- host TLS/current-vCPU 查询：身份会被执行位置隐式决定，无法承受迁移、嵌套回调或异步处理；
+- VM-global 可变 current-vCPU slot：并发 vCPU exit 会互相覆盖，且需要额外锁和回滚；
+- 各设备单独传递裸 `usize`：会绕过统一 dispatch boundary，无法由类型系统保证 identity 完整性。
+
+本改动不引入新的 vCPU 生命周期、task binding、异步 MMIO completion 或 GIC 状态模型，也不改变无需 per-vCPU bank 的设备访问语义。
 
 ## 配置与不可变计划
 
@@ -129,7 +154,7 @@ resource claim -> device/controller registry -> VGIC state -> backend LR/route s
 | planner | fixed 优先、输入顺序无关、lowest-first、溢出/耗尽、失败后最低资源重试 |
 | namespace | 跨 controller 同号、exclusive 冲突、shared trigger 不匹配、ITS 隔离、全局 LPI |
 | claim/runtime | 重复/未消费、bundle 回滚、controller 缺失/重复/ID 不匹配、seal |
-| VGIC | SGI/PPI/SPI、line/latch、pending/active、priority/route、overflow、maintenance、EOI/DIR |
+| VGIC | SGI/PPI/SPI、line/latch、pending/active、priority/route、overflow、maintenance、EOI/DIR、显式 MMIO vCPU identity、GICv2 banked 隔离和缺失 identity 拒绝 |
 | firmware | VGIC config、设备资源、GIC/ITS/interrupts 来自同一计划 |
 | physical | 固定 identity/trigger/route、重复 host SPI、quiesce/drain、EOI/DIR 到 deactivate |
 | system | QEMU GICv2 2-vCPU、GICv3+ITS 4-vCPU timer stress 和四架构 smoke |

--- a/docs/design/axvisor-virtio-net.md
+++ b/docs/design/axvisor-virtio-net.md
@@ -1,103 +1,97 @@
-# AxVisor virtio-net device design
+# Axvisor virtio-net 设备设计
 
-## Problem and success criteria
+## 问题与成功标准
 
-AxVisor must boot two ArceOS guests, expose one VirtIO MMIO network device to
-each guest, and forward Ethernet frames between them. Completion requires both
-guests to discover their device and pass a deterministic bidirectional network
-test without MMIO faults, queue stalls, or descriptor leaks.
+Axvisor 必须能够启动两个 ArceOS 客户机，为每个客户机提供一个 VirtIO MMIO
+网络设备，并在二者之间转发以太网帧。完成标准是两个客户机都能发现设备，
+并通过确定性的双向网络测试；测试期间不得发生 MMIO fault、队列停滞或描述符泄漏。
 
-The initial scope is an in-process layer-2 switch. A physical host NIC uplink,
-multi-queue VirtIO, offloads, live migration, and passthrough are non-goals.
+初始范围只包含进程内二层交换机。物理宿主网卡上联、多队列 VirtIO、卸载、
+在线迁移和直通均不在本设计范围内。
 
-## Existing code and rejected reuse
+## 现有代码与未采用的复用方案
 
-`debin/virtio-net-2` contains reusable `axvirtio-common` and `axvirtio-net`
-crates plus an older AxVisor adapter. Those network-related crates and their
-tests are retained; `axvirtio-blk` is deferred to a separate change with a real
-block-device consumer. The adapter is not copied unchanged because current
-`axdevice` grants guest-memory DMA only through a scoped `DeviceAccess` port.
-The old adapter retained a VM-wide guest-memory accessor in a background
-worker, bypassing that capability boundary.
+`debin/virtio-net-2` 包含可复用的 `axvirtio-common`、`axvirtio-net` crate
+以及一份旧 Axvisor 适配器。网络相关 crate 及其测试予以保留；`axvirtio-blk`
+延后到有真实块设备消费者的独立改动。旧适配器不能原样复制，因为当前
+`axdevice` 只允许设备通过作用域受限的 `DeviceContext` 获得客户机内存 DMA
+能力。旧适配器在后台 worker 中长期持有 VM 级客户机内存访问器，绕过了这条
+能力边界。
 
-## Selected architecture
+## 选定架构
 
-The implementation has four explicit layers:
+实现明确分为四层：
 
-1. `axvirtio-common` owns VirtIO MMIO state and split-ring mechanics. Queue
-   layout persists, but every operation that reads or writes guest memory
-   receives a scoped memory capability.
-2. `axvirtio-net` owns RX/TX descriptor validation and the device state
-   machine. It has no AxVisor or ArceOS dependency.
-3. `axdevice` adds a DMA-pollable capability registered against a concrete
-   bundled device and a `DmaGrant`. The runtime reconstructs a scoped
-   `DeviceAccess` for each poll; the capability cannot retain it.
-4. AxVisor registers a `virtio-net` `DeviceModel`. Each instance owns one
-   switch port, MMIO allocation, wired IRQ, and DMA grant. Device polling drains
-   bounded ingress frames into the guest RX ring and pulses the IRQ only after
-   publishing used descriptors.
+1. `axvirtio-common` 持有 VirtIO MMIO 状态与 split-ring 机制。队列布局长期
+   保存，但每次读写客户机内存的操作都必须取得作用域受限的内存能力。
+2. `axvirtio-net` 持有 RX/TX 描述符校验和设备状态机，不依赖 Axvisor 或
+   ArceOS。
+3. `axdevice` 提供与具体 bundle 设备和 `DmaGrant` 绑定的 DMA pollable
+   能力。runtime 每次轮询都重新构造作用域受限的 `DeviceContext`，设备能力
+   不能保存该上下文。
+4. Axvisor 注册 `virtio-net` `DeviceModel`。每个实例持有一个交换机端口、
+   MMIO 分配、wired IRQ 和 DMA grant。设备轮询将有界 ingress 帧写入客户机
+   RX ring，且只在发布 used descriptor 后触发 IRQ。
 
 ```text
-guest TX kick
-  -> Device::access(scoped DMA)
-  -> validate/read TX chain
-  -> switch classifies frame
-  -> destination bounded ingress queue
+客户机 TX kick
+  -> Device::write(DeviceAccess, 作用域受限的 DeviceContext)
+  -> 校验并读取 TX 描述符链
+  -> 交换机分类帧
+  -> 目标端口的有界 ingress 队列
 
-vCPU0 device poll
-  -> DMA-poll capability(scoped DMA)
-  -> write destination RX chain and used ring
-  -> publish interrupt status
-  -> pulse destination wired IRQ
+vCPU0 设备轮询
+  -> DMA poll 能力（作用域受限的 DMA）
+  -> 写入目标 RX 描述符链与 used ring
+  -> 发布中断状态
+  -> 触发目标 wired IRQ
 ```
 
-## Ownership and synchronization
+## 所有权与同步
 
-- `DeviceModel` owns immutable per-NIC configuration.
-- The built device owns VirtIO state and its DMA grant.
-- Each switch attachment has a unique generation-bearing port identity; its
-  RAII registration removes the port on teardown.
-- TX processing occurs under the device queue lock. The switch backend only
-  enqueues copies and never re-enters a VirtIO device.
-- RX ingress is bounded. A full port drops only that destination copy.
-- Device polling owns RX advancement. IRQ injection happens after guest-memory
-  writes complete and outside queue mutation where practical.
-- The scoped `DeviceAccess` reference is never stored, shared, or moved into a
-  task. This preserves VM lifetime and DMA authorization.
+- `DeviceModel` 持有每个网卡的不可变配置。
+- 构建后的设备持有 VirtIO 状态及其 DMA grant。
+- 每个交换机 attachment 都有一个携带 generation 的唯一端口身份；其 RAII
+  注册在销毁时移除端口。
+- TX 处理在设备队列锁内执行。交换机 backend 只将帧副本放入队列，绝不回调
+  VirtIO 设备。
+- RX ingress 队列有容量上限。端口队列已满时只丢弃发往该端口的副本。
+- 设备轮询负责推进 RX。IRQ 注入发生在客户机内存写入完成之后，并尽量避开
+  队列状态修改区间。
+- 作用域受限的 `DeviceContext` 引用不会被保存、共享或移动到任务中，从而
+  维持 VM 生命周期和 DMA 授权边界。
 
-## Failure behavior
+## 失败语义
 
-Invalid descriptors, inaccessible guest memory, unsupported features, and
-resource-planning failures return typed errors. Queue exhaustion and absent RX
-buffers are observable flow-control outcomes, not fabricated success. No path
-falls back to a guessed MMIO address, IRQ, MAC address, or host interface.
+无效描述符、不可访问的客户机内存、不支持的功能和资源规划失败均返回类型化
+错误。队列耗尽和缺少 RX buffer 是可观察的流控结果，不能伪造成成功。任何路径
+都不得猜测默认 MMIO 地址、IRQ、MAC 地址或宿主接口。
 
-## Alternatives
+## 备选方案
 
-| Alternative | Decision |
+| 方案 | 结论 |
 | --- | --- |
-| Retain a weak `AxVM` guest-memory accessor in a worker | Rejected: bypasses access-scoped DMA grants and couples the device to AxVM. |
-| Deliver RX only on guest MMIO kicks | Rejected: frames arriving after the last RX kick can stall forever. |
-| Add a generic DMA-pollable capability | Selected: keeps authorization explicit and supports asynchronous device progress without retaining VM memory. |
-| Start with a physical uplink worker | Deferred: unnecessary for proving two-guest VirtIO networking and adds host-driver ownership risk. |
+| 在 worker 中保存弱引用 `AxVM` 客户机内存访问器 | 不采用：它绕过按访问作用域授予的 DMA grant，并将设备耦合到 AxVM。 |
+| 只在客户机 MMIO kick 时投递 RX | 不采用：最后一次 RX kick 后到达的帧可能永久停滞。 |
+| 增加通用 DMA pollable 能力 | 采用：在不保存 VM 内存访问器的前提下保持显式授权并支持异步设备推进。 |
+| 从物理上联 worker 起步 | 延后：证明双客户机 VirtIO 网络不需要该能力，而且会引入宿主驱动所有权风险。 |
 
-## Validation
+## 验证
 
-- Existing split-ring, MMIO, block, net, and switch tests must continue to pass.
-- Add capability tests proving an unregistered/wrong DMA grant is rejected and
-  the correct device receives scoped memory during polling.
-- Add AxVisor model tests for options, resource requirements, and bundle grants.
-- Boot two ArceOS guests under QEMU/AxVisor and require deterministic two-way
-  packet exchange. From a clean checkout, build each image before launching
-  AxVisor (the VM TOML files intentionally reference these generated files):
+- 现有 split-ring、MMIO、block、net 和 switch 测试必须继续通过。
+- 增加能力测试，证明未注册或不匹配的 DMA grant 会被拒绝，且正确设备在轮询
+  期间能获得作用域受限的内存能力。
+- 增加 Axvisor model 测试，覆盖 options、资源需求和 bundle grant。
+- 在 QEMU/Axvisor 下启动两个 ArceOS 客户机，并要求确定性的双向数据包交换。
+  从干净 checkout 开始时，应先构建每个镜像再启动 Axvisor（VM TOML 文件有意
+  引用这些生成文件）：
 
   ```bash
   apps/arceos/virtio-net-peer/run.sh
   ```
 
-  Set `LLVM_OBJCOPY` when the toolchain is installed outside the pinned Rust
-  sysroot.
+  工具链安装在固定 Rust sysroot 之外时，需要设置 `LLVM_OBJCOPY`。
 
-  The QEMU runner requires both `VM1_VIRTIO_NET_PASS` and
-  `VM2_VIRTIO_NET_PASS`; either `*_FAIL` marker or a panic is a failure.
-- Run `cargo fmt` and targeted clippy for every changed crate.
+  QEMU runner 必须同时看到 `VM1_VIRTIO_NET_PASS` 和 `VM2_VIRTIO_NET_PASS`；
+  任一 `*_FAIL` 标记或 panic 都表示失败。
+- 对每个改动的 crate 运行 `cargo fmt` 和定向 clippy。

--- a/docs/docs/architecture/axvisor/emulated-devices.md
+++ b/docs/docs/architecture/axvisor/emulated-devices.md
@@ -19,7 +19,7 @@ Axvisor 的模拟设备由 Hypervisor 在软件中实现，客户机通过 MMIO�
 
 | 位置 | 主要内容 | 运行阶段 |
 | --- | --- | --- |
-| `virtualization/axdevice_base/src/lib.rs` | `Device`、`DeviceAccess`、`BusAccess`、`Resource`、grant、IRQ 与 MSI 基础接口 | 注册与访问热路径 |
+| `virtualization/axdevice_base/src/lib.rs` | `Device`、`DeviceAccess`、`DeviceContext`、`GuestMemoryAccess`、`Resource`、grant、IRQ 与 MSI 基础接口 | 注册与访问热路径 |
 | `virtualization/axdevice/src/model.rs` | `DeviceModel`、`DeviceFirmwareSpec` | 设备声明与构建 |
 | `virtualization/axdevice/src/graph/*` | `DeviceNodeSpec`、`DeviceGraphBuilder`、`ResolvedDeviceGraph` | VM prepare |
 | `virtualization/axdevice/src/resources/*` | `DeviceRequirements`、`ResourcePools`、`VmResourcePlanner`、claim/lease | 资源规划与构建校验 |
@@ -54,7 +54,7 @@ flowchart TB
             Grants["DMA / timer / wake / stop grants"]
         end
         subgraph BASE["axdevice_base"]
-            Contract["Device / Resource / BusAccess"]
+            Contract["Device / DeviceAccess / DeviceContext / Resource"]
             Interrupt["IrqLine / MSI endpoint"]
         end
         Arch["axvm::arch：GIC、PLIC、IOAPIC、PCH-PIC、fw_cfg 等"]
@@ -105,7 +105,7 @@ model = "ivc-channel"
 
 ### 1.3 总体流程
 
-从 TOML 到一次设备访问，主路径分为 prepare 和 VM-exit 两段。prepare 生成静态设备图和资源计划；VM-exit 热路径只做索引查找、访问上下文创建和 `Device::access()` 调用。
+从 TOML 到一次设备访问，主路径分为 prepare 和 VM-exit 两段。prepare 生成静态设备图和资源计划；VM-exit 热路径只构造包含 source vCPU 的不可变请求、查找索引、创建能力上下文，并调用 `Device::read()` 或 `Device::write()`。
 
 ```mermaid
 flowchart LR
@@ -118,8 +118,8 @@ flowchart LR
     Resolved["ResolvedDeviceGraph"]
     Runtime["sealed DeviceRuntime"]
     Exit["vCPU VM-exit"]
-    Access["BusAccess"]
-    Device["Device::access"]
+    Access["DeviceAccess<br/>source + bus + address + width"]
+    Device["Device::read / Device::write"]
 
     Toml --> Request --> Catalog --> Nodes
     Nodes --> Graph
@@ -377,7 +377,7 @@ grant 使用 bundle-local 设备下标记录归属，直到注册成功后才换
 
 ## 5. 设备与访问模型
 
-运行时只认识统一的 `Device` trait。设备协议状态保存在具体实现内部，框架通过静态 `resources()` 建立分派索引，通过 `access()` 处理一次已经解码的客户机访问。
+运行时只认识统一的 `Device` trait。设备协议状态保存在具体实现内部，框架通过静态 `resources()` 建立分派索引，通过 `read()` 或 `write()` 处理一次已经解码的客户机访问。
 
 ### 5.1 `Device` trait
 
@@ -387,30 +387,37 @@ grant 使用 bundle-local 设备下标记录归属，直到注册成功后才换
 pub trait Device: Send + Sync {
     fn name(&self) -> &str;
     fn resources(&self) -> &[Resource];
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError>;
+        access: &DeviceAccess,
+        context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError>;
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError>;
 }
 ```
 
 `resources()` 返回的 slice 在设备构造时确定，注册后不再变化。设备内部需要修改的寄存器、FIFO、队列或 pending 状态由实现自己的锁、原子变量或后端状态机保护。
 
-### 5.2 `BusAccess` 与 `BusResponse`
+### 5.2 `DeviceAccess` 请求
 
-架构 VM-exit 被归一化为 `BusAccess`。runtime 不解析 VMCS、ESR、trap frame 或具体指令格式。
+架构 VM-exit 被归一化为不可变的 `DeviceAccess`。runtime 不解析 VMCS、ESR、trap frame 或具体指令格式。构造函数要求四个字段完整给出，字段保持私有，因此 guest MMIO、PIO 和 SysReg 请求不存在“缺少 source vCPU”的可表示状态。
 
 | 字段或类型 | 可取值 | 说明 |
 | --- | --- | --- |
+| `DeviceAccess.source_vcpu()` | `DeviceVcpuId` | 发起本次访问的 VM-local vCPU，不能从 host CPU、任务或 TLS 推导 |
 | `BusKind` | `Mmio`、`Port`、`SysReg` | 三类地址域彼此独立 |
 | `AccessWidth` | `Byte`、`Word`、`Dword`、`Qword` | 1、2、4、8 字节 |
-| `BusAccess.addr` | `u64` | 原始总线地址；Port/SysReg 会再收窄校验 |
-| `BusAccess.data` | `u64` | 写入数据低位 |
-| `BusResponse::Read` | `{ value: u64 }` | 读操作返回值 |
-| `BusResponse::Write` | 无数据 | 写操作完成确认 |
+| `DeviceAccess.address()` | `u64` | 原始总线地址；Port/SysReg 会再收窄校验 |
+| `DeviceAccess.width()` | `AccessWidth` | 本次 transaction 的访问宽度 |
 
-MMIO 读、Port 读和 SysReg 读都会拒绝写响应。MMIO 写和带 memory 的 Port 写会检查设备返回 `BusResponse::Write`；现有普通 `handle_port_write()` 与 `handle_sys_reg_write()` 只传播 `dispatch()` 错误，不再次校验响应 variant。
+读写方向不再是请求中的布尔字段。`read()` 只能返回 `u64`，`write()` 接收独立的 `value: u64` 并只能返回 `()`；不存在运行时响应 variant 混淆，也不存在读写复用数据槽。
+
+`source_vcpu` 只描述 architectural accessor。中断路由中的 target vCPU 由 GIC/PLIC/APIC 的路由状态决定，两者即使数值相同也不能复用为一个概念。例如 vCPU 0 写 GIC distributor 将 SPI 路由给 vCPU 1 时，请求 source 仍是 0，IRQ target 是 1。
 
 ### 5.3 `Resource`
 
@@ -438,7 +445,7 @@ fn lookup_mmio(&self, addr: u64, width: AccessWidth) -> Option<usize> {
 
 如果设备声明 `[0x1000, 0x1004)`，从 `0x1002` 发起 4 字节访问虽然起始地址位于窗口内，但结束地址越过 `0x1004`，runtime 会按未命中处理。地址加访问宽度溢出时同样不会命中。
 
-### 5.5 VM-exit 到 `dispatch()`
+### 5.5 VM-exit 到 `try_read()` / `try_write()`
 
 四个架构的 MMIO fault、x86 I/O instruction 和 AArch64 系统寄存器退出最终都会构造公共访问对象并进入 `DeviceRuntime`。
 
@@ -449,25 +456,26 @@ sequenceDiagram
     participant RT as DeviceRuntime
     participant DEV as Device
 
-    VCPU->>VM: VM-exit(addr, width, read/write, data)
-    VM->>RT: handle_mmio/port/sys_reg_*()
+    VCPU->>VM: VM-exit(vCPU, addr, width, direction, data)
+    VM->>VM: construct mandatory DeviceAccess
+    VM->>RT: try_read(access) / try_write(access, value, memory)
     RT->>RT: lookup complete access range
-    RT->>RT: create RuntimeDeviceAccess
-    RT->>DEV: access(BusAccess, DeviceAccess)
-    DEV-->>RT: BusResponse or DeviceError
+    RT->>RT: create RuntimeDeviceContext
+    RT->>DEV: read(access, context) / write(access, value, context)
+    DEV-->>RT: u64 / () / DeviceError
     RT-->>VM: value, success, None, or DeviceManagerError
     VM-->>VCPU: complete emulation or fall through
 ```
 
-`try_handle_mmio_read()`、`try_handle_port_read()` 和带 memory 的 try-write 入口在未命中时返回 `None`/`false`，便于架构 fault handler 继续执行 stage-2 映射策略；强制处理入口则把未命中包装成 `DeviceError::NotFound`。
+`DeviceRuntime` 只暴露 `try_read()` 与 `try_write()` 两个路由入口。未命中分别返回 `None` 和 `false`，便于架构 fault handler 继续 stage-2 或未映射总线策略。MMIO、PIO、SysReg 的差异只体现在 `DeviceAccess.bus()` 和架构退出完成方式，不形成无 source 的旁路 helper。
 
 ## 6. 访问上下文与运行时能力
 
-设备访问寄存器时可能需要读写 guest memory、设置定时器、唤醒 vCPU 或请求停止 VM。这些能力通过一次访问期间的 `DeviceAccess` 和不可伪造 grant 控制。
+设备访问寄存器时可能需要读写 guest memory、设置定时器、唤醒 vCPU 或请求停止 VM。这些运行能力通过一次回调期间的 `DeviceContext` 和不可伪造 grant 控制；它们不属于描述请求事实的 `DeviceAccess`。
 
-### 6.1 `DeviceAccess` 与 grant
+### 6.1 `DeviceContext`、`GuestMemoryAccess` 与 grant
 
-`RuntimeDeviceAccess` 在栈上创建，生命周期严格限制在一次 `Device::access()` 或一次 `DmaPollableDeviceOps::poll_dma()` 调用内。它同时检查正在访问的 `DeviceId` 和 grant token 是否与 runtime 注册记录匹配。
+`RuntimeDeviceContext` 在栈上创建，生命周期严格限制在一次 `Device::read()`、`Device::write()` 或 `DmaPollableDeviceOps::poll_dma()` 调用内。它同时检查正在访问的 `DeviceId` 和 grant token 是否与 runtime 注册记录匹配。
 
 | 能力 | Grant | 使用路径 |
 | --- | --- | --- |
@@ -480,7 +488,9 @@ sequenceDiagram
 
 ### 6.2 DMA 与 DMA pollable
 
-guest-memory 端口不会长期保存在设备中。普通 MMIO/Port dispatch 默认没有 memory port；只有 VM 判断该访问需要 DMA，或 VM 主动调用 `poll_dma_devices()` 时，runtime 才创建带 `memory: Some(...)` 的 `RuntimeDeviceAccess`。
+VM 内存由独立的 `GuestMemoryAccess` capability 实现。该 trait 不携带 device identity 或 grant；`DeviceRuntime` 在委托前已经用 `DeviceContext` 验证当前设备和 `DmaGrant`。设备不能从 `DeviceAccess`、source vCPU 或 `DeviceContext` 反向取得 `AxVM`。
+
+guest-memory 端口不会长期保存在设备中。guest 写路径可以给 runtime 注入临时 memory port；读路径没有隐式 VM 内存能力。VM 主动调用 `poll_dma_devices()` 时也会创建一次性 `RuntimeDeviceContext`。
 
 ```mermaid
 sequenceDiagram
@@ -489,8 +499,8 @@ sequenceDiagram
     participant DEV as DMA device
     participant MEM as guest-memory port
 
-    VM->>RT: handle_mmio_write_with_memory(...)
-    RT->>DEV: access(..., RuntimeDeviceAccess)
+    VM->>RT: try_write(DeviceAccess, value, GuestMemoryAccess)
+    RT->>DEV: write(..., RuntimeDeviceContext)
     DEV->>RT: read_guest_memory(DmaGrant, gpa, buf)
     RT->>MEM: read(gpa, buf)
     DEV->>RT: write_guest_memory(DmaGrant, gpa, data)
@@ -651,7 +661,6 @@ fixed MMIO inside guest RAM 会被资源池报告为与 `guest-memory-*` 冲突�
 | `NotFound` | runtime 索引未命中；检查地址窗口、完整访问宽度和 BusKind |
 | `OutOfRange` | 已命中设备，但设备内部 offset/宽度检查拒绝访问 |
 | `Unsupported` | 设备或 access port 不支持该操作，例如 Qword x86 port I/O |
-| `UnexpectedResponse` | 读请求收到写确认，或写请求收到读数据 |
 
 DMA 失败时应额外检查：设备是否注册了同一个 `DmaGrant`，本次入口是否带 memory port，以及 poll_dma/access 回调是否在作用域内完成 guest-memory 操作。
 

--- a/os/axvisor/src/virtio_blk.rs
+++ b/os/axvisor/src/virtio_blk.rs
@@ -6,7 +6,7 @@ use std::sync::Mutex;
 
 use axdevice::*;
 use axdevice_base::{
-    BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DmaGrant, InterruptSharing,
+    BusKind, Device, DeviceAccess, DeviceContext, DeviceError, DmaGrant, InterruptSharing,
     InterruptTrigger, IrqLine, Resource,
 };
 use axvirtio_blk::{BlockBackend, BlockDeviceEvent, VirtioBlockConfig, VirtioMmioBlockDevice};
@@ -639,19 +639,19 @@ impl BlockBackend for RamDiskBackend {
 }
 
 struct ScopedDeviceMemory<'a> {
-    access: &'a mut dyn DeviceAccess,
+    context: &'a mut dyn DeviceContext,
     grant: &'a DmaGrant,
 }
 
 impl GuestMemory for ScopedDeviceMemory<'_> {
     fn read(&mut self, guest_addr: GuestPhysAddr, data: &mut [u8]) -> VirtioResult<()> {
-        self.access
+        self.context
             .read_guest_memory(self.grant, guest_addr, data)
             .map_err(|_| VirtioError::InvalidAddress)
     }
 
     fn write(&mut self, guest_addr: GuestPhysAddr, data: &[u8]) -> VirtioResult<()> {
-        self.access
+        self.context
             .write_guest_memory(self.grant, guest_addr, data)
             .map_err(|_| VirtioError::InvalidAddress)
     }
@@ -674,31 +674,48 @@ impl Device for VirtioBlkRuntimeDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
-        let address = GuestPhysAddr::from(access.addr as usize);
-        if access.is_read {
-            return self
-                .model
-                .mmio_read(address, access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-                .map_err(map_virtio_error);
+        self.model
+            .mmio_read(
+                GuestPhysAddr::from(access.address() as usize),
+                access.width(),
+            )
+            .map(|value| value as u64)
+            .map_err(map_virtio_error)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
         let mut memory = ScopedDeviceMemory {
-            access: context,
+            context,
             grant: &self.grant,
         };
         let event = self
             .model
-            .mmio_write_with_memory(address, access.width, access.data as usize, &mut memory)
+            .mmio_write_with_memory(
+                GuestPhysAddr::from(access.address() as usize),
+                access.width(),
+                value as usize,
+                &mut memory,
+            )
             .map_err(map_virtio_error)?;
         match event {
             BlockDeviceEvent::InterruptPending => {
@@ -719,7 +736,7 @@ impl Device for VirtioBlkRuntimeDevice {
             }
             BlockDeviceEvent::None => {}
         }
-        Ok(BusResponse::Write)
+        Ok(())
     }
 }
 
@@ -727,13 +744,13 @@ impl DmaPollableDeviceOps for VirtioBlkRuntimeDevice {
     fn poll_dma(
         &self,
         _now_ns: u64,
-        access: &mut dyn DeviceAccess,
+        context: &mut dyn DeviceContext,
         grant: &DmaGrant,
     ) -> DeviceManagerResult {
         if !self.queue_pending.swap(false, Ordering::AcqRel) {
             return Ok(());
         }
-        let mut memory = ScopedDeviceMemory { access, grant };
+        let mut memory = ScopedDeviceMemory { context, grant };
         let event = self
             .model
             .process_pending_queue(0, &mut memory)

--- a/os/axvisor/src/virtio_net.rs
+++ b/os/axvisor/src/virtio_net.rs
@@ -6,7 +6,7 @@ use std::sync::{Mutex, MutexGuard};
 
 use axdevice::*;
 use axdevice_base::{
-    BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DmaGrant, InterruptSharing,
+    BusKind, Device, DeviceAccess, DeviceContext, DeviceError, DmaGrant, InterruptSharing,
     InterruptTrigger, IrqLine, Resource,
 };
 use axvirtio_common::{GuestMemory, NoGuestMemoryAccessor, VirtioError};
@@ -307,19 +307,19 @@ impl SwitchPort for PortEndpoint {
 }
 
 struct ScopedDeviceMemory<'a> {
-    access: &'a mut dyn DeviceAccess,
+    context: &'a mut dyn DeviceContext,
     grant: &'a DmaGrant,
 }
 
 impl GuestMemory for ScopedDeviceMemory<'_> {
     fn read(&mut self, guest_addr: GuestPhysAddr, data: &mut [u8]) -> Result<(), VirtioError> {
-        self.access
+        self.context
             .read_guest_memory(self.grant, guest_addr, data)
             .map_err(|_| VirtioError::InvalidAddress)
     }
 
     fn write(&mut self, guest_addr: GuestPhysAddr, data: &[u8]) -> Result<(), VirtioError> {
-        self.access
+        self.context
             .write_guest_memory(self.grant, guest_addr, data)
             .map_err(|_| VirtioError::InvalidAddress)
     }
@@ -343,34 +343,51 @@ impl Device for VirtioNetRuntimeDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
-        let address = GuestPhysAddr::from(access.addr as usize);
-        if access.is_read {
-            return self
-                .model
-                .mmio_read(address, access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-                .map_err(map_virtio_error);
+        self.model
+            .mmio_read(
+                GuestPhysAddr::from(access.address() as usize),
+                access.width(),
+            )
+            .map(|value| value as u64)
+            .map_err(map_virtio_error)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
         let mut memory = ScopedDeviceMemory {
-            access: context,
+            context,
             grant: &self.grant,
         };
         let event = self
             .model
-            .mmio_write_with_memory(address, access.width, access.data as usize, &mut memory)
+            .mmio_write_with_memory(
+                GuestPhysAddr::from(access.address() as usize),
+                access.width(),
+                value as usize,
+                &mut memory,
+            )
             .map_err(map_virtio_error)?;
         self.pulse_if_pending(event)?;
-        Ok(BusResponse::Write)
+        Ok(())
     }
 }
 
@@ -378,10 +395,10 @@ impl DmaPollableDeviceOps for VirtioNetRuntimeDevice {
     fn poll_dma(
         &self,
         _now_ns: u64,
-        access: &mut dyn DeviceAccess,
+        context: &mut dyn DeviceContext,
         grant: &DmaGrant,
     ) -> DeviceManagerResult {
-        let mut memory = ScopedDeviceMemory { access, grant };
+        let mut memory = ScopedDeviceMemory { context, grant };
         while let Some(frame) = self.endpoint.pop_ingress() {
             match self.model.receive_frame_with_memory(&frame, &mut memory) {
                 Ok(RxOutcome::Delivered { notify, .. }) => {

--- a/virtualization/arm_vgic/src/devices.rs
+++ b/virtualization/arm_vgic/src/devices.rs
@@ -2,15 +2,9 @@
 
 use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 
-use axdevice_base::{BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, Resource};
+use axdevice_base::{BusKind, Device, DeviceAccess, DeviceContext, DeviceError, Resource};
 
 use crate::{ArmVgicConfig, GicVcpuId, ItsConfig, VgicCore, VgicMmioRegion, VgicResult};
-
-/// Architecture-owned source of the vCPU issuing a trapped register access.
-pub trait VgicAccessContext: Send + Sync {
-    /// Returns the current VM-local vCPU identifier.
-    fn current_vcpu(&self) -> Option<usize>;
-}
 
 /// Complete set of bus devices exposing one [`VgicCore`].
 pub struct VgicDeviceSet {
@@ -19,31 +13,23 @@ pub struct VgicDeviceSet {
 
 impl VgicDeviceSet {
     /// Creates all MMIO frontends from the same immutable controller config.
-    pub fn new(
-        core: Arc<VgicCore>,
-        access_context: Arc<dyn VgicAccessContext>,
-    ) -> VgicResult<Self> {
+    pub fn new(core: Arc<VgicCore>) -> VgicResult<Self> {
         let mut devices: Vec<Arc<dyn Device>> = Vec::new();
         match core.config() {
             ArmVgicConfig::V2(config) => {
-                devices.push(Arc::new(VgicDistributorDevice::new(
+                devices.push(Arc::new(BankedDistributorDevice::new(
                     core.clone(),
-                    access_context.clone(),
                     config.distributor(),
-                    DistributorVersion::V2,
                 )));
                 devices.push(Arc::new(VgicV2CpuInterfaceDevice::new(
                     core.clone(),
-                    access_context,
                     config.cpu_interface(),
                 )));
             }
             ArmVgicConfig::V3(config) => {
-                devices.push(Arc::new(VgicDistributorDevice::new(
+                devices.push(Arc::new(SharedDistributorDevice::new(
                     core.clone(),
-                    access_context,
                     config.distributor(),
-                    DistributorVersion::V3,
                 )));
                 let mut first_vcpu = 0;
                 for (region_index, region) in config.redistributors().iter().copied().enumerate() {
@@ -77,38 +63,24 @@ impl VgicDeviceSet {
     }
 }
 
-#[derive(Clone, Copy)]
-enum DistributorVersion {
-    V2,
-    V3,
-}
-
-struct VgicDistributorDevice {
+/// Frontend for a distributor whose SGI/PPI registers are banked by accessor.
+struct BankedDistributorDevice {
     core: Arc<VgicCore>,
-    access_context: Arc<dyn VgicAccessContext>,
     region: VgicMmioRegion,
     resources: Box<[Resource]>,
-    version: DistributorVersion,
 }
 
-impl VgicDistributorDevice {
-    fn new(
-        core: Arc<VgicCore>,
-        access_context: Arc<dyn VgicAccessContext>,
-        region: VgicMmioRegion,
-        version: DistributorVersion,
-    ) -> Self {
+impl BankedDistributorDevice {
+    fn new(core: Arc<VgicCore>, region: VgicMmioRegion) -> Self {
         Self {
             core,
-            access_context,
             region,
             resources: mmio_resources(region),
-            version,
         }
     }
 }
 
-impl Device for VgicDistributorDevice {
+impl Device for BankedDistributorDevice {
     fn name(&self) -> &str {
         "arm-vgic-distributor"
     }
@@ -117,57 +89,92 @@ impl Device for VgicDistributorDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
         let offset = mmio_offset(access, self.region)?;
-        let result = match (self.version, access.is_read) {
-            (DistributorVersion::V2, true) => self
-                .core
-                .read_v2_distributor(current_vcpu(&*self.access_context)?, offset, access.width)
-                .map(|value| BusResponse::Read { value }),
-            (DistributorVersion::V2, false) => self
-                .core
-                .write_v2_distributor(
-                    current_vcpu(&*self.access_context)?,
-                    offset,
-                    access.width,
-                    access.data,
-                )
-                .map(|()| BusResponse::Write),
-            (DistributorVersion::V3, true) => self
-                .core
-                .controller()
-                .read_distributor(offset, access.width)
-                .map(|value| BusResponse::Read { value }),
-            (DistributorVersion::V3, false) => self
-                .core
-                .controller()
-                .write_distributor(offset, access.width, access.data)
-                .map(|()| BusResponse::Write),
-        };
-        result.map_err(Into::into)
+        self.core
+            .read_v2_distributor(source_vcpu(access), offset, access.width())
+            .map_err(Into::into)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        let offset = mmio_offset(access, self.region)?;
+        self.core
+            .write_v2_distributor(source_vcpu(access), offset, access.width(), value)
+            .map_err(Into::into)
+    }
+}
+
+/// Frontend for a distributor whose state is shared and routes SPIs by affinity.
+struct SharedDistributorDevice {
+    core: Arc<VgicCore>,
+    region: VgicMmioRegion,
+    resources: Box<[Resource]>,
+}
+
+impl SharedDistributorDevice {
+    fn new(core: Arc<VgicCore>, region: VgicMmioRegion) -> Self {
+        Self {
+            core,
+            region,
+            resources: mmio_resources(region),
+        }
+    }
+}
+
+impl Device for SharedDistributorDevice {
+    fn name(&self) -> &str {
+        "arm-vgic-distributor"
+    }
+
+    fn resources(&self) -> &[Resource] {
+        &self.resources
+    }
+
+    fn read(
+        &self,
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        let offset = mmio_offset(access, self.region)?;
+        self.core
+            .controller()
+            .read_distributor(offset, access.width())
+            .map_err(Into::into)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        let offset = mmio_offset(access, self.region)?;
+        self.core
+            .controller()
+            .write_distributor(offset, access.width(), value)
+            .map_err(Into::into)
     }
 }
 
 struct VgicV2CpuInterfaceDevice {
     core: Arc<VgicCore>,
-    access_context: Arc<dyn VgicAccessContext>,
     region: VgicMmioRegion,
     resources: Box<[Resource]>,
 }
 
 impl VgicV2CpuInterfaceDevice {
-    fn new(
-        core: Arc<VgicCore>,
-        access_context: Arc<dyn VgicAccessContext>,
-        region: VgicMmioRegion,
-    ) -> Self {
+    fn new(core: Arc<VgicCore>, region: VgicMmioRegion) -> Self {
         Self {
             core,
-            access_context,
             region,
             resources: mmio_resources(region),
         }
@@ -183,24 +190,27 @@ impl Device for VgicV2CpuInterfaceDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
         let offset = mmio_offset(access, self.region)?;
-        let vcpu = current_vcpu(&*self.access_context)?;
-        if access.is_read {
-            self.core
-                .read_v2_cpu_interface(vcpu, offset, access.width)
-                .map(|value| BusResponse::Read { value })
-                .map_err(Into::into)
-        } else {
-            self.core
-                .write_v2_cpu_interface(vcpu, offset, access.width, access.data)
-                .map(|()| BusResponse::Write)
-                .map_err(Into::into)
-        }
+        self.core
+            .read_v2_cpu_interface(source_vcpu(access), offset, access.width())
+            .map_err(Into::into)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        let offset = mmio_offset(access, self.region)?;
+        self.core
+            .write_v2_cpu_interface(source_vcpu(access), offset, access.width(), value)
+            .map_err(Into::into)
     }
 }
 
@@ -244,39 +254,39 @@ impl Device for VgicRedistributorDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
         let region_offset = mmio_offset(access, self.region)?;
         let vcpu = self.first_vcpu + (region_offset / self.stride) as usize;
         if vcpu >= self.vcpu_count {
-            return Ok(if access.is_read {
-                BusResponse::Read { value: 0 }
-            } else {
-                BusResponse::Write
-            });
+            return Ok(0);
         }
         let frame_offset = region_offset % self.stride;
-        if access.is_read {
-            self.core
-                .controller()
-                .read_redistributor(GicVcpuId::new(vcpu), frame_offset, access.width)
-                .map(|value| BusResponse::Read { value })
-                .map_err(Into::into)
-        } else {
-            self.core
-                .controller()
-                .write_redistributor(
-                    GicVcpuId::new(vcpu),
-                    frame_offset,
-                    access.width,
-                    access.data,
-                )
-                .map(|()| BusResponse::Write)
-                .map_err(Into::into)
+        self.core
+            .controller()
+            .read_redistributor(GicVcpuId::new(vcpu), frame_offset, access.width())
+            .map_err(Into::into)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        let region_offset = mmio_offset(access, self.region)?;
+        let vcpu = self.first_vcpu + (region_offset / self.stride) as usize;
+        if vcpu >= self.vcpu_count {
+            return Ok(());
         }
+        let frame_offset = region_offset % self.stride;
+        self.core
+            .controller()
+            .write_redistributor(GicVcpuId::new(vcpu), frame_offset, access.width(), value)
+            .map_err(Into::into)
     }
 }
 
@@ -307,25 +317,29 @@ impl Device for VgicItsDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
         let offset = mmio_offset(access, self.config.registers())?;
-        if access.is_read {
-            self.core
-                .controller()
-                .read_its_for(self.config.id(), offset, access.width)
-                .map(|value| BusResponse::Read { value })
-                .map_err(Into::into)
-        } else {
-            self.core
-                .controller()
-                .write_its_for(self.config.id(), offset, access.width, access.data)
-                .map(|()| BusResponse::Write)
-                .map_err(Into::into)
-        }
+        self.core
+            .controller()
+            .read_its_for(self.config.id(), offset, access.width())
+            .map_err(Into::into)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        let offset = mmio_offset(access, self.config.registers())?;
+        self.core
+            .controller()
+            .write_its_for(self.config.id(), offset, access.width(), value)
+            .map_err(Into::into)
     }
 }
 
@@ -337,19 +351,15 @@ fn mmio_resources(region: VgicMmioRegion) -> Box<[Resource]> {
     .into_boxed_slice()
 }
 
-fn mmio_offset(access: &BusAccess, region: VgicMmioRegion) -> Result<u64, DeviceError> {
-    if access.kind != BusKind::Mmio || !region.contains(access.addr, access.width.size()) {
-        return Err(DeviceError::OutOfRange { addr: access.addr });
+fn mmio_offset(access: &DeviceAccess, region: VgicMmioRegion) -> Result<u64, DeviceError> {
+    if access.bus() != BusKind::Mmio || !region.contains(access.address(), access.width().size()) {
+        return Err(DeviceError::OutOfRange {
+            addr: access.address(),
+        });
     }
-    Ok(access.addr - region.base())
+    Ok(access.address() - region.base())
 }
 
-fn current_vcpu(context: &dyn VgicAccessContext) -> Result<GicVcpuId, DeviceError> {
-    context
-        .current_vcpu()
-        .map(GicVcpuId::new)
-        .ok_or_else(|| DeviceError::InvalidState {
-            operation: "access per-vCPU VGIC register",
-            detail: "no current vCPU is installed in the architecture runtime".into(),
-        })
+const fn source_vcpu(access: &DeviceAccess) -> GicVcpuId {
+    GicVcpuId::new(access.source_vcpu().as_usize())
 }

--- a/virtualization/arm_vgic/src/lib.rs
+++ b/virtualization/arm_vgic/src/lib.rs
@@ -45,7 +45,7 @@ pub use backend::*;
 pub use config::*;
 pub use controller::*;
 pub use cpu_interface::*;
-pub use devices::{VgicAccessContext, VgicDeviceSet};
+pub use devices::VgicDeviceSet;
 pub(crate) use distributor::DistributorState;
 pub use error::*;
 pub(crate) use interrupt::InterruptRecord;

--- a/virtualization/arm_vgic/tests/gicv2_delivery.rs
+++ b/virtualization/arm_vgic/tests/gicv2_delivery.rs
@@ -1,11 +1,14 @@
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Barrier, Mutex};
 
 use arm_vgic::{
     ArmVgicConfig, CpuInterfaceState, GicAffinity, GicV3BackendError, GicV3VcpuWake, GicVcpuId,
     HostGicVersion, IntId, InterruptState, VgicBackend, VgicBackendCapabilities, VgicCore,
-    VgicMmioRegion, VgicResult, VgicV2Config,
+    VgicDeviceSet, VgicMmioRegion, VgicResult, VgicV2Config,
 };
-use axdevice_base::{InterruptControllerId, InterruptTrigger};
+use axdevice_base::{
+    BusKind, DeviceAccess, DeviceId, DeviceVcpuId, InterruptControllerId, InterruptTrigger,
+    NoopDeviceContext,
+};
 use axvm_types::AccessWidth;
 
 const GICD_CTLR: u64 = 0x0000;
@@ -111,28 +114,175 @@ fn core() -> (VgicCore, Arc<TestBackend>) {
 }
 
 #[test]
+fn v2_mmio_cpu_interface_uses_explicit_accessor_without_current_vcpu() {
+    let (core, _) = core();
+    let _vcpu0 = core.attach_vcpu(0, Arc::new(Wake)).unwrap();
+    let _vcpu1 = core.attach_vcpu(1, Arc::new(Wake)).unwrap();
+    let devices = VgicDeviceSet::new(Arc::new(core)).unwrap();
+    let cpu_interface = &devices.devices()[1];
+
+    let write_pmr = |vcpu_id, value| {
+        let mut context = NoopDeviceContext::new(DeviceId::new(0));
+        cpu_interface
+            .write(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(vcpu_id),
+                    BusKind::Mmio,
+                    0x0801_0000 + GICC_PMR,
+                    AccessWidth::Dword,
+                ),
+                value,
+                &mut context,
+            )
+            .unwrap();
+    };
+    let read_pmr = |vcpu_id| {
+        let mut context = NoopDeviceContext::new(DeviceId::new(0));
+        cpu_interface
+            .read(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(vcpu_id),
+                    BusKind::Mmio,
+                    0x0801_0000 + GICC_PMR,
+                    AccessWidth::Dword,
+                ),
+                &mut context,
+            )
+            .unwrap()
+    };
+
+    write_pmr(0, 0x11);
+    write_pmr(1, 0x22);
+    assert_eq!(read_pmr(0), 0x11);
+    assert_eq!(read_pmr(1), 0x22);
+}
+
+#[test]
+fn v2_mmio_cpu_interface_keeps_banked_state_isolated_across_host_threads() {
+    let (core, _) = core();
+    let _vcpu0 = core.attach_vcpu(0, Arc::new(Wake)).unwrap();
+    let _vcpu1 = core.attach_vcpu(1, Arc::new(Wake)).unwrap();
+    let devices = VgicDeviceSet::new(Arc::new(core)).unwrap();
+    let cpu_interface = devices.devices()[1].clone();
+    let barrier = Arc::new(Barrier::new(2));
+
+    let workers = [(0, 0x11), (1, 0x22)].map(|(vcpu_id, value)| {
+        let cpu_interface = cpu_interface.clone();
+        let barrier = barrier.clone();
+        std::thread::spawn(move || {
+            barrier.wait();
+            for _ in 0..256 {
+                let mut context = NoopDeviceContext::new(DeviceId::new(0));
+                cpu_interface
+                    .write(
+                        &DeviceAccess::new(
+                            DeviceVcpuId::new(vcpu_id),
+                            BusKind::Mmio,
+                            0x0801_0000 + GICC_PMR,
+                            AccessWidth::Dword,
+                        ),
+                        value,
+                        &mut context,
+                    )
+                    .unwrap();
+                assert_eq!(
+                    cpu_interface
+                        .read(
+                            &DeviceAccess::new(
+                                DeviceVcpuId::new(vcpu_id),
+                                BusKind::Mmio,
+                                0x0801_0000 + GICC_PMR,
+                                AccessWidth::Dword,
+                            ),
+                            &mut context,
+                        )
+                        .unwrap(),
+                    value
+                );
+            }
+        })
+    });
+
+    for worker in workers {
+        worker.join().unwrap();
+    }
+}
+
+#[test]
+fn v2_mmio_distributor_uses_explicit_accessor_for_banked_state() {
+    let (core, _) = core();
+    let _vcpu0 = core.attach_vcpu(0, Arc::new(Wake)).unwrap();
+    let _vcpu1 = core.attach_vcpu(1, Arc::new(Wake)).unwrap();
+    let devices = VgicDeviceSet::new(Arc::new(core)).unwrap();
+    let distributor = &devices.devices()[0];
+
+    let write_enabled = |vcpu_id, bit| {
+        let mut context = NoopDeviceContext::new(DeviceId::new(0));
+        distributor
+            .write(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(vcpu_id),
+                    BusKind::Mmio,
+                    0x0800_0000 + GICD_ISENABLER,
+                    AccessWidth::Dword,
+                ),
+                1u64 << bit,
+                &mut context,
+            )
+            .unwrap();
+    };
+    let read_enabled = |vcpu_id| {
+        let mut context = NoopDeviceContext::new(DeviceId::new(0));
+        distributor
+            .read(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(vcpu_id),
+                    BusKind::Mmio,
+                    0x0800_0000 + GICD_ISENABLER,
+                    AccessWidth::Dword,
+                ),
+                &mut context,
+            )
+            .unwrap()
+    };
+
+    write_enabled(0, 27);
+    write_enabled(1, 30);
+    assert_eq!(read_enabled(0) & ((1 << 27) | (1 << 30)), 1 << 27);
+    assert_eq!(read_enabled(1) & ((1 << 27) | (1 << 30)), 1 << 30);
+}
+
+#[test]
 fn v2_distributor_clear_enable_and_cpu_target_share_canonical_state() {
     let (core, backend) = core();
+    let core = Arc::new(core);
     let vcpu0 = core.attach_vcpu(0, Arc::new(Wake)).unwrap();
     let vcpu1 = core.attach_vcpu(1, Arc::new(Wake)).unwrap();
+    let devices = VgicDeviceSet::new(core.clone()).unwrap();
+    let distributor = &devices.devices()[0];
     let spi = 40u32;
+    let write_distributor = |address, width, value| {
+        let mut context = NoopDeviceContext::new(DeviceId::new(0));
+        distributor
+            .write(
+                &DeviceAccess::new(DeviceVcpuId::new(0), BusKind::Mmio, address, width),
+                value,
+                &mut context,
+            )
+            .unwrap();
+    };
 
-    core.write_v2_distributor(GicVcpuId::new(0), GICD_CTLR, AccessWidth::Dword, 1)
-        .unwrap();
-    core.write_v2_distributor(
-        GicVcpuId::new(0),
-        GICD_ITARGETSR + u64::from(spi),
+    write_distributor(0x0800_0000 + GICD_CTLR, AccessWidth::Dword, 1);
+    write_distributor(
+        0x0800_0000 + GICD_ITARGETSR + u64::from(spi),
         AccessWidth::Byte,
         0b10,
-    )
-    .unwrap();
-    core.write_v2_distributor(
-        GicVcpuId::new(0),
-        GICD_ISENABLER + 4,
+    );
+    write_distributor(
+        0x0800_0000 + GICD_ISENABLER + 4,
         AccessWidth::Dword,
         1 << (spi - 32),
-    )
-    .unwrap();
+    );
     core.controller()
         .configure_spi_input(
             arm_vgic::SpiId::new(spi).unwrap(),
@@ -150,13 +300,11 @@ fn v2_distributor_clear_enable_and_cpu_target_share_canonical_state() {
 
     vcpu0.save().unwrap();
     vcpu1.save().unwrap();
-    core.write_v2_distributor(
-        GicVcpuId::new(0),
-        GICD_ICENABLER + 4,
+    write_distributor(
+        0x0800_0000 + GICD_ICENABLER + 4,
         AccessWidth::Dword,
         1 << (spi - 32),
-    )
-    .unwrap();
+    );
     assert_eq!(
         core.read_v2_distributor(GicVcpuId::new(0), GICD_ISENABLER + 4, AccessWidth::Dword,)
             .unwrap()

--- a/virtualization/axdevice/src/device.rs
+++ b/virtualization/axdevice/src/device.rs
@@ -133,8 +133,9 @@ fn validate_bundle_grant_indices<T>(
 ///
 /// Construction mutates the registry through [`DeviceRegistry`]. Once shared
 /// with vCPUs, routing is read-only and every access enters through
-/// [`BusRouter::dispatch`]. Production construction always uses a factory and
-/// an atomic [`DeviceBundle`] registration.
+/// [`DeviceRuntime::try_read`] or [`DeviceRuntime::try_write`]. Production
+/// construction always uses a factory and an atomic [`DeviceBundle`]
+/// registration.
 pub struct DeviceRuntime {
     /// Registered devices (append-only; index is the DeviceId).
     devices: Vec<Arc<dyn Device>>,
@@ -156,8 +157,8 @@ pub struct DeviceRuntime {
     planned: PlannedRuntimeResources,
     /// Devices explicitly granted access to guest memory during a routed access.
     ///
-    /// The grant is intentionally narrow: it is supplied only by the VM's MMIO
-    /// write path and exists only for the duration of that one access.
+    /// The grant is intentionally narrow: the VM supplies a guest-memory port
+    /// only for the duration of one device write or DMA poll callback.
     dma_grants: Vec<(DeviceId, DmaGrant)>,
     /// Devices explicitly granted timer scheduling during a routed access.
     timer_grants: Vec<(DeviceId, TimerGrant)>,
@@ -172,17 +173,17 @@ pub struct DeviceRuntime {
 }
 
 /// Stack-scoped metadata for one routed device access.
-struct RuntimeDeviceAccess<'a> {
+struct RuntimeDeviceContext<'runtime, 'memory> {
     device_id: DeviceId,
-    memory: Option<&'a mut dyn DeviceAccess>,
-    dma_grants: &'a [(DeviceId, DmaGrant)],
-    timer_grants: &'a [(DeviceId, TimerGrant)],
-    wake_grants: &'a [(DeviceId, WakeGrant)],
-    stop_grants: &'a [(DeviceId, StopGrant)],
-    access_ports: &'a RuntimeAccessPorts,
+    memory: Option<&'memory mut dyn GuestMemoryAccess>,
+    dma_grants: &'runtime [(DeviceId, DmaGrant)],
+    timer_grants: &'runtime [(DeviceId, TimerGrant)],
+    wake_grants: &'runtime [(DeviceId, WakeGrant)],
+    stop_grants: &'runtime [(DeviceId, StopGrant)],
+    access_ports: &'runtime RuntimeAccessPorts,
 }
 
-impl RuntimeDeviceAccess<'_> {
+impl RuntimeDeviceContext<'_, '_> {
     fn has_grant<T>(&self, grants: &[(DeviceId, T)], matches_token: impl Fn(&T) -> bool) -> bool {
         grants.iter().any(|(device_id, registered)| {
             *device_id == self.device_id && matches_token(registered)
@@ -190,10 +191,11 @@ impl RuntimeDeviceAccess<'_> {
     }
 }
 
-impl DeviceAccess for RuntimeDeviceAccess<'_> {
+impl DeviceContext for RuntimeDeviceContext<'_, '_> {
     fn device_id(&self) -> DeviceId {
         self.device_id
     }
+
     fn read_guest_memory(
         &mut self,
         grant: &DmaGrant,
@@ -213,7 +215,7 @@ impl DeviceAccess for RuntimeDeviceAccess<'_> {
                 operation: "read guest memory from device access",
                 detail: "this bus access has no DMA memory port".into(),
             })?;
-        memory.read_guest_memory(grant, addr, data)
+        memory.read(addr, data)
     }
     fn write_guest_memory(
         &mut self,
@@ -234,7 +236,7 @@ impl DeviceAccess for RuntimeDeviceAccess<'_> {
                 operation: "write guest memory from device access",
                 detail: "this bus access has no DMA memory port".into(),
             })?;
-        memory.write_guest_memory(grant, addr, data)
+        memory.write(addr, data)
     }
 
     fn schedule_timer(&mut self, grant: &TimerGrant, deadline_ns: u64) -> Result<(), DeviceError> {
@@ -809,11 +811,11 @@ impl DeviceRuntime {
     pub fn poll_dma_devices(
         &self,
         now_ns: u64,
-        memory: &mut dyn DeviceAccess,
+        memory: &mut dyn GuestMemoryAccess,
         mut observe: impl FnMut(DeviceManagerResult),
     ) {
         for (device_id, pollable, grant) in &self.dma_pollable_devices {
-            let mut context = RuntimeDeviceAccess {
+            let mut context = RuntimeDeviceContext {
                 device_id: *device_id,
                 memory: Some(&mut *memory),
                 dma_grants: &self.dma_grants,
@@ -871,298 +873,76 @@ impl DeviceRuntime {
         Ok(())
     }
 
-    // ─── Hot-path dispatch handlers ─────────────────────────────────
+    // ─── Hot-path dispatch ──────────────────────────────────────────
 
-    /// Handle the MMIO read by GuestPhysAddr and data width.
-    pub fn handle_mmio_read(
-        &self,
-        addr: GuestPhysAddr,
-        width: AccessWidth,
-    ) -> DeviceManagerResult<usize> {
-        self.try_handle_mmio_read(addr, width)?
-            .ok_or_else(|| missing_access("read", BusKind::Mmio, addr.as_usize() as u64, width))
-    }
-
-    /// Handles one MMIO read when the address belongs to this runtime.
+    /// Reads from the device selected by `access`.
     ///
-    /// A missing mapping is returned as `None` so architecture fault handlers
-    /// can fall through to their stage-2 mapping policy without a second
+    /// A missing mapping is returned as `None`, allowing architecture fault
+    /// handlers to continue with their non-device policy without a second
     /// interval lookup.
-    pub fn try_handle_mmio_read(
-        &self,
-        addr: GuestPhysAddr,
-        width: AccessWidth,
-    ) -> DeviceManagerResult<Option<usize>> {
-        let access = BusAccess {
-            kind: BusKind::Mmio,
-            is_read: true,
-            addr: addr.as_usize() as u64,
-            width,
-            data: 0,
-        };
-        match self
-            .dispatch_optional(&access, None)
-            .map_err(|source| access_error("read", &access, source))?
-        {
-            Some(BusResponse::Read { value }) => Ok(Some(value as usize)),
-            None => Ok(None),
-            Some(BusResponse::Write) => Err(DeviceManagerError::UnexpectedResponse {
-                operation: "read MMIO device",
-                detail: "device returned a write acknowledgement".into(),
-            }),
-        }
-    }
-
-    /// Handle the MMIO write by GuestPhysAddr, data width and the value need to write.
-    pub fn handle_mmio_write(
-        &self,
-        addr: GuestPhysAddr,
-        width: AccessWidth,
-        val: usize,
-    ) -> DeviceManagerResult {
-        let access = BusAccess {
-            kind: BusKind::Mmio,
-            is_read: false,
-            addr: addr.as_usize() as u64,
-            width,
-            data: val as u64,
-        };
-        let response = self
-            .dispatch(&access)
-            .map_err(|source| DeviceManagerError::Access {
-                operation: "write",
-                bus: BusKind::Mmio,
-                addr: access.addr,
-                width,
-                source,
-            })?;
-        Self::expect_write_response(response, "write MMIO device")
-    }
-
-    /// Handles MMIO with a VM-provided, access-scoped guest-memory capability.
-    pub fn handle_mmio_write_with_memory(
-        &self,
-        addr: GuestPhysAddr,
-        width: AccessWidth,
-        val: usize,
-        memory: &mut dyn axdevice_base::DeviceAccess,
-    ) -> DeviceManagerResult {
-        self.try_handle_mmio_write_with_memory(addr, width, val, memory)?
-            .then_some(())
-            .ok_or_else(|| missing_access("write", BusKind::Mmio, addr.as_usize() as u64, width))
-    }
-
-    /// Handles one MMIO write when the address belongs to this runtime.
-    pub fn try_handle_mmio_write_with_memory(
-        &self,
-        addr: GuestPhysAddr,
-        width: AccessWidth,
-        val: usize,
-        memory: &mut dyn axdevice_base::DeviceAccess,
-    ) -> DeviceManagerResult<bool> {
-        let access = BusAccess {
-            kind: BusKind::Mmio,
-            is_read: false,
-            addr: addr.as_usize() as u64,
-            width,
-            data: val as u64,
-        };
-        let Some(response) = self
-            .dispatch_optional(&access, Some(memory))
-            .map_err(|source| access_error("write", &access, source))?
+    pub fn try_read(&self, access: &DeviceAccess) -> DeviceManagerResult<Option<u64>> {
+        let Some(index) = self
+            .lookup_access(access)
+            .map_err(|source| access_error("read", access, source))?
         else {
-            return Ok(false);
-        };
-        Self::expect_write_response(response, "write MMIO device")?;
-        Ok(true)
-    }
-
-    fn expect_write_response(
-        response: BusResponse,
-        operation: &'static str,
-    ) -> DeviceManagerResult {
-        match response {
-            BusResponse::Write => Ok(()),
-            BusResponse::Read { .. } => Err(DeviceManagerError::UnexpectedResponse {
-                operation,
-                detail: "device returned read data for a write request".into(),
-            }),
-        }
-    }
-
-    /// Handle the system register read by SysRegAddr and data width.
-    pub fn handle_sys_reg_read(
-        &self,
-        addr: SysRegAddr,
-        width: AccessWidth,
-    ) -> DeviceManagerResult<usize> {
-        let access = BusAccess {
-            kind: BusKind::SysReg,
-            is_read: true,
-            addr: addr.0 as u64,
-            width,
-            data: 0,
-        };
-        match self
-            .dispatch(&access)
-            .map_err(|source| DeviceManagerError::Access {
-                operation: "read",
-                bus: BusKind::SysReg,
-                addr: access.addr,
-                width,
-                source,
-            })? {
-            BusResponse::Read { value } => Ok(value as usize),
-            BusResponse::Write => Err(DeviceManagerError::UnexpectedResponse {
-                operation: "read system register device",
-                detail: "device returned a write acknowledgement".into(),
-            }),
-        }
-    }
-
-    /// Handle the system register write by SysRegAddr, data width and the value need to write.
-    pub fn handle_sys_reg_write(
-        &self,
-        addr: SysRegAddr,
-        width: AccessWidth,
-        val: usize,
-    ) -> DeviceManagerResult {
-        let access = BusAccess {
-            kind: BusKind::SysReg,
-            is_read: false,
-            addr: addr.0 as u64,
-            width,
-            data: val as u64,
-        };
-        self.dispatch(&access)
-            .map_err(|source| DeviceManagerError::Access {
-                operation: "write",
-                bus: BusKind::SysReg,
-                addr: access.addr,
-                width,
-                source,
-            })?;
-        Ok(())
-    }
-
-    /// Handle the port read by port number and data width.
-    pub fn handle_port_read(&self, port: Port, width: AccessWidth) -> DeviceManagerResult<usize> {
-        self.try_handle_port_read(port, width)?
-            .ok_or_else(|| missing_access("read", BusKind::Port, u64::from(port.number()), width))
-    }
-
-    /// Handles one port read when the address belongs to this runtime.
-    pub fn try_handle_port_read(
-        &self,
-        port: Port,
-        width: AccessWidth,
-    ) -> DeviceManagerResult<Option<usize>> {
-        let access = BusAccess {
-            kind: BusKind::Port,
-            is_read: true,
-            addr: port.0 as u64,
-            width,
-            data: 0,
-        };
-        match self
-            .dispatch_optional(&access, None)
-            .map_err(|source| access_error("read", &access, source))?
-        {
-            Some(BusResponse::Read { value }) => Ok(Some(value as usize)),
-            None => Ok(None),
-            Some(BusResponse::Write) => Err(DeviceManagerError::UnexpectedResponse {
-                operation: "read port device",
-                detail: "device returned a write acknowledgement".into(),
-            }),
-        }
-    }
-
-    /// Handle the port write by port number, data width and the value need to write.
-    pub fn handle_port_write(
-        &self,
-        port: Port,
-        width: AccessWidth,
-        val: usize,
-    ) -> DeviceManagerResult {
-        let access = BusAccess {
-            kind: BusKind::Port,
-            is_read: false,
-            addr: port.0 as u64,
-            width,
-            data: val as u64,
-        };
-        self.dispatch(&access)
-            .map_err(|source| DeviceManagerError::Access {
-                operation: "write",
-                bus: BusKind::Port,
-                addr: access.addr,
-                width,
-                source,
-            })?;
-        Ok(())
-    }
-
-    /// Handles a port write with a VM-provided, access-scoped guest-memory capability.
-    pub fn handle_port_write_with_memory(
-        &self,
-        port: Port,
-        width: AccessWidth,
-        val: usize,
-        memory: &mut dyn axdevice_base::DeviceAccess,
-    ) -> DeviceManagerResult {
-        self.try_handle_port_write_with_memory(port, width, val, memory)?
-            .then_some(())
-            .ok_or_else(|| missing_access("write", BusKind::Port, u64::from(port.number()), width))
-    }
-
-    /// Handles one port write when the address belongs to this runtime.
-    pub fn try_handle_port_write_with_memory(
-        &self,
-        port: Port,
-        width: AccessWidth,
-        val: usize,
-        memory: &mut dyn axdevice_base::DeviceAccess,
-    ) -> DeviceManagerResult<bool> {
-        let access = BusAccess {
-            kind: BusKind::Port,
-            is_read: false,
-            addr: u64::from(port.number()),
-            width,
-            data: val as u64,
-        };
-        let Some(response) = self
-            .dispatch_optional(&access, Some(memory))
-            .map_err(|source| access_error("write", &access, source))?
-        else {
-            return Ok(false);
-        };
-        Self::expect_write_response(response, "write port device")?;
-        Ok(true)
-    }
-
-    fn dispatch_optional<'a>(
-        &'a self,
-        access: &BusAccess,
-        memory: Option<&'a mut dyn axdevice_base::DeviceAccess>,
-    ) -> Result<Option<BusResponse>, DeviceError> {
-        let index = match access.kind {
-            BusKind::Mmio => self.lookup_mmio(access.addr, access.width),
-            BusKind::Port => {
-                let port = u16::try_from(access.addr)
-                    .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
-                self.lookup_port(port, access.width)
-            }
-            BusKind::SysReg => {
-                let register = u32::try_from(access.addr)
-                    .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
-                self.lookup_sysreg(register)
-            }
-        };
-        let Some(index) = index else {
             return Ok(None);
         };
+        let mut context = self.context_for(index, None);
+        self.devices[index]
+            .read(access, &mut context)
+            .map(Some)
+            .map_err(|source| access_error("read", access, source))
+    }
 
-        let mut context = RuntimeDeviceAccess {
+    /// Writes to the device selected by `access`.
+    ///
+    /// `memory` is an optional VM-owned guest-memory port. Devices still need
+    /// their matching [`DmaGrant`] before the context delegates to this port.
+    pub fn try_write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        memory: Option<&mut dyn GuestMemoryAccess>,
+    ) -> DeviceManagerResult<bool> {
+        let Some(index) = self
+            .lookup_access(access)
+            .map_err(|source| access_error("write", access, source))?
+        else {
+            return Ok(false);
+        };
+        let mut context = self.context_for(index, memory);
+        self.devices[index]
+            .write(access, value, &mut context)
+            .map(|()| true)
+            .map_err(|source| access_error("write", access, source))
+    }
+
+    fn lookup_access(&self, access: &DeviceAccess) -> DeviceResult<Option<usize>> {
+        match access.bus() {
+            BusKind::Mmio => Ok(self.lookup_mmio(access.address(), access.width())),
+            BusKind::Port => {
+                let port =
+                    u16::try_from(access.address()).map_err(|_| DeviceError::OutOfRange {
+                        addr: access.address(),
+                    })?;
+                Ok(self.lookup_port(port, access.width()))
+            }
+            BusKind::SysReg => {
+                let register =
+                    u32::try_from(access.address()).map_err(|_| DeviceError::OutOfRange {
+                        addr: access.address(),
+                    })?;
+                Ok(self.lookup_sysreg(register))
+            }
+        }
+    }
+
+    fn context_for<'runtime, 'memory>(
+        &'runtime self,
+        index: usize,
+        memory: Option<&'memory mut dyn GuestMemoryAccess>,
+    ) -> RuntimeDeviceContext<'runtime, 'memory> {
+        RuntimeDeviceContext {
             device_id: DeviceId::new(index as u32),
             memory,
             dma_grants: &self.dma_grants,
@@ -1170,37 +950,21 @@ impl DeviceRuntime {
             wake_grants: &self.wake_grants,
             stop_grants: &self.stop_grants,
             access_ports: &self.access_ports,
-        };
-        self.devices[index].access(access, &mut context).map(Some)
+        }
     }
 }
 
 fn access_error(
     operation: &'static str,
-    access: &BusAccess,
+    access: &DeviceAccess,
     source: DeviceError,
 ) -> DeviceManagerError {
     DeviceManagerError::Access {
         operation,
-        bus: access.kind,
-        addr: access.addr,
-        width: access.width,
+        bus: access.bus(),
+        addr: access.address(),
+        width: access.width(),
         source,
-    }
-}
-
-fn missing_access(
-    operation: &'static str,
-    bus: BusKind,
-    addr: u64,
-    width: AccessWidth,
-) -> DeviceManagerError {
-    DeviceManagerError::Access {
-        operation,
-        bus,
-        addr,
-        width,
-        source: DeviceError::NotFound,
     }
 }
 
@@ -1231,41 +995,15 @@ impl DeviceRegistry for DeviceRuntime {
     }
 }
 
-impl BusRouter for DeviceRuntime {
-    fn dispatch(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
-        self.dispatch_optional(access, None)?
-            .ok_or(DeviceError::NotFound)
-    }
-
-    fn lookup(&self, access: &BusAccess) -> Result<Arc<dyn Device>, DeviceError> {
-        let idx = match access.kind {
-            BusKind::Mmio => self.lookup_mmio(access.addr, access.width),
-            BusKind::Port => {
-                let port = u16::try_from(access.addr)
-                    .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
-                self.lookup_port(port, access.width)
-            }
-            BusKind::SysReg => {
-                let reg = u32::try_from(access.addr)
-                    .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
-                self.lookup_sysreg(reg)
-            }
-        }
-        .ok_or(DeviceError::NotFound)?;
-
-        Ok(Arc::clone(&self.devices[idx]))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use alloc::sync::Arc;
     use core::sync::atomic::{AtomicUsize, Ordering};
 
     use axdevice_base::{
-        AccessWidth, BusAccess, BusKind, BusResponse, BusRouter, Device, DeviceAccess, DeviceError,
-        DeviceId, DeviceRegistry, DmaGrant, InvalidResourceReason, Port, RegistryError, Resource,
-        StopGrant, SysRegAddr, TimerGrant, WakeGrant,
+        AccessWidth, BusKind, Device, DeviceAccess, DeviceContext, DeviceError, DeviceId,
+        DeviceRegistry, DeviceVcpuId, DmaGrant, GuestMemoryAccess, InvalidResourceReason,
+        RegistryError, Resource, StopGrant, TimerGrant, WakeGrant,
     };
     use axvm_types::GuestPhysAddr;
 
@@ -1298,6 +1036,7 @@ mod tests {
 
     struct AccessAwareDevice {
         resources: alloc::vec::Vec<Resource>,
+        expected_vcpu: DeviceVcpuId,
     }
 
     struct GuestMemoryRequestDevice {
@@ -1364,12 +1103,21 @@ mod tests {
             &self.resources
         }
 
-        fn access(
+        fn read(
             &self,
-            _access: &BusAccess,
-            _context: &mut dyn DeviceAccess,
-        ) -> Result<BusResponse, DeviceError> {
-            Ok(BusResponse::Read { value: 0 })
+            _access: &DeviceAccess,
+            _context: &mut dyn DeviceContext,
+        ) -> Result<u64, DeviceError> {
+            Ok(0)
+        }
+
+        fn write(
+            &self,
+            _access: &DeviceAccess,
+            _value: u64,
+            _context: &mut dyn DeviceContext,
+        ) -> Result<(), DeviceError> {
+            Ok(())
         }
     }
 
@@ -1405,13 +1153,25 @@ mod tests {
             &self.resources
         }
 
-        fn access(
+        fn read(
             &self,
-            _access: &BusAccess,
-            context: &mut dyn DeviceAccess,
-        ) -> Result<BusResponse, DeviceError> {
+            access: &DeviceAccess,
+            context: &mut dyn DeviceContext,
+        ) -> Result<u64, DeviceError> {
             assert_eq!(context.device_id(), DeviceId::new(0));
-            Ok(BusResponse::Read { value: 0xfeed })
+            assert_eq!(access.source_vcpu(), self.expected_vcpu);
+            Ok(0xfeed)
+        }
+
+        fn write(
+            &self,
+            access: &DeviceAccess,
+            _value: u64,
+            context: &mut dyn DeviceContext,
+        ) -> Result<(), DeviceError> {
+            assert_eq!(context.device_id(), DeviceId::new(0));
+            assert_eq!(access.source_vcpu(), self.expected_vcpu);
+            Ok(())
         }
     }
 
@@ -1424,14 +1184,23 @@ mod tests {
             &self.resources
         }
 
-        fn access(
+        fn read(
             &self,
-            _access: &BusAccess,
-            context: &mut dyn DeviceAccess,
-        ) -> Result<BusResponse, DeviceError> {
+            _access: &DeviceAccess,
+            _context: &mut dyn DeviceContext,
+        ) -> Result<u64, DeviceError> {
+            Err(DeviceError::WriteOnly)
+        }
+
+        fn write(
+            &self,
+            _access: &DeviceAccess,
+            _value: u64,
+            context: &mut dyn DeviceContext,
+        ) -> Result<(), DeviceError> {
             let mut byte = [0u8; 1];
             context.read_guest_memory(&self.dma_grant, GuestPhysAddr::from_usize(0), &mut byte)?;
-            Ok(BusResponse::Write)
+            Ok(())
         }
     }
 
@@ -1444,11 +1213,20 @@ mod tests {
             &self.resources
         }
 
-        fn access(
+        fn read(
             &self,
-            _access: &BusAccess,
-            context: &mut dyn DeviceAccess,
-        ) -> Result<BusResponse, DeviceError> {
+            _access: &DeviceAccess,
+            _context: &mut dyn DeviceContext,
+        ) -> Result<u64, DeviceError> {
+            Err(DeviceError::WriteOnly)
+        }
+
+        fn write(
+            &self,
+            _access: &DeviceAccess,
+            _value: u64,
+            context: &mut dyn DeviceContext,
+        ) -> Result<(), DeviceError> {
             match self.kind {
                 SensitiveGrantKind::Timer => context.schedule_timer(&self.timer_grant, 42)?,
                 SensitiveGrantKind::Wake => context.wake_vcpu(&self.wake_grant, 0)?,
@@ -1456,23 +1234,18 @@ mod tests {
                     context.request_vm_stop(&self.stop_grant, "test stop request")?
                 }
             }
-            Ok(BusResponse::Write)
+            Ok(())
         }
     }
 
     struct TestMemoryPort;
 
-    impl DeviceAccess for TestMemoryPort {
-        fn device_id(&self) -> DeviceId {
-            DeviceId::new(0)
+    impl GuestMemoryAccess for TestMemoryPort {
+        fn read(&mut self, _addr: GuestPhysAddr, _data: &mut [u8]) -> Result<(), DeviceError> {
+            Ok(())
         }
 
-        fn read_guest_memory(
-            &mut self,
-            _grant: &DmaGrant,
-            _addr: GuestPhysAddr,
-            _data: &mut [u8],
-        ) -> Result<(), DeviceError> {
+        fn write(&mut self, _addr: GuestPhysAddr, _data: &[u8]) -> Result<(), DeviceError> {
             Ok(())
         }
     }
@@ -1486,11 +1259,11 @@ mod tests {
         fn poll_dma(
             &self,
             _now_ns: u64,
-            access: &mut dyn DeviceAccess,
+            context: &mut dyn DeviceContext,
             _registered_grant: &DmaGrant,
         ) -> DeviceManagerResult {
             let mut byte = [0u8; 1];
-            access
+            context
                 .read_guest_memory(&self.grant, GuestPhysAddr::from_usize(0), &mut byte)
                 .map_err(DeviceManagerError::Device)?;
             self.polls.fetch_add(1, Ordering::Relaxed);
@@ -1498,27 +1271,6 @@ mod tests {
         }
     }
 
-    struct ReadOnWriteDevice {
-        resources: alloc::vec::Vec<Resource>,
-    }
-
-    impl Device for ReadOnWriteDevice {
-        fn name(&self) -> &str {
-            "read-on-write"
-        }
-
-        fn resources(&self) -> &[Resource] {
-            &self.resources
-        }
-
-        fn access(
-            &self,
-            _access: &BusAccess,
-            _context: &mut dyn DeviceAccess,
-        ) -> Result<BusResponse, DeviceError> {
-            Ok(BusResponse::Read { value: 0 })
-        }
-    }
     impl Device for D {
         fn name(&self) -> &str {
             self.n
@@ -1526,12 +1278,21 @@ mod tests {
         fn resources(&self) -> &[Resource] {
             &self.resources
         }
-        fn access(
+        fn read(
             &self,
-            _a: &BusAccess,
-            _context: &mut dyn DeviceAccess,
-        ) -> Result<BusResponse, DeviceError> {
-            Ok(BusResponse::Read { value: 0 })
+            _access: &DeviceAccess,
+            _context: &mut dyn DeviceContext,
+        ) -> Result<u64, DeviceError> {
+            Ok(0)
+        }
+
+        fn write(
+            &self,
+            _access: &DeviceAccess,
+            _value: u64,
+            _context: &mut dyn DeviceContext,
+        ) -> Result<(), DeviceError> {
+            Ok(())
         }
     }
 
@@ -1580,27 +1341,84 @@ mod tests {
     }
 
     #[test]
-    fn dispatch_uses_access_context_for_v3_devices() {
+    fn vcpu_mmio_dispatch_propagates_the_explicit_accessor() {
         let mut devices = DeviceRuntime::empty();
+        let vcpu_id = DeviceVcpuId::new(7);
         devices
             .register(Arc::new(AccessAwareDevice {
                 resources: alloc::vec![Resource::MmioRange {
                     base: 0x4000,
                     size: 0x100,
                 }],
+                expected_vcpu: vcpu_id,
             }))
             .unwrap();
 
-        assert!(matches!(
-            devices.dispatch(&BusAccess {
-                kind: BusKind::Mmio,
-                is_read: true,
-                addr: 0x4000,
-                width: AccessWidth::Dword,
-                data: 0,
-            }),
-            Ok(BusResponse::Read { value: 0xfeed })
-        ));
+        assert_eq!(
+            devices
+                .try_read(&DeviceAccess::new(
+                    vcpu_id,
+                    BusKind::Mmio,
+                    0x4000,
+                    AccessWidth::Dword,
+                ))
+                .unwrap(),
+            Some(0xfeed_u64)
+        );
+    }
+
+    #[test]
+    fn vcpu_port_dispatch_propagates_the_explicit_accessor() {
+        let mut devices = DeviceRuntime::empty();
+        let vcpu_id = DeviceVcpuId::new(7);
+        devices
+            .register(Arc::new(AccessAwareDevice {
+                resources: alloc::vec![Resource::PortRange {
+                    base: 0x4000,
+                    size: 0x100,
+                }],
+                expected_vcpu: vcpu_id,
+            }))
+            .unwrap();
+
+        assert_eq!(
+            devices
+                .try_read(&DeviceAccess::new(
+                    vcpu_id,
+                    BusKind::Port,
+                    0x4000,
+                    AccessWidth::Dword,
+                ))
+                .unwrap(),
+            Some(0xfeed_u64)
+        );
+    }
+
+    #[test]
+    fn vcpu_sysreg_dispatch_propagates_the_explicit_accessor() {
+        let mut devices = DeviceRuntime::empty();
+        let vcpu_id = DeviceVcpuId::new(7);
+        devices
+            .register(Arc::new(AccessAwareDevice {
+                resources: alloc::vec![Resource::SysReg {
+                    addr: 0x4000,
+                    count: 1,
+                }],
+                expected_vcpu: vcpu_id,
+            }))
+            .unwrap();
+
+        assert_eq!(
+            devices
+                .try_read(&DeviceAccess::new(
+                    vcpu_id,
+                    BusKind::SysReg,
+                    0x4000,
+                    AccessWidth::Qword,
+                ))
+                .unwrap(),
+            Some(0xfeed_u64)
+        );
     }
 
     #[test]
@@ -1618,11 +1436,15 @@ mod tests {
         let mut memory = TestMemoryPort;
 
         let error = devices
-            .handle_mmio_write_with_memory(
-                GuestPhysAddr::from_usize(0x5000),
-                AccessWidth::Dword,
+            .try_write(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(0),
+                    BusKind::Mmio,
+                    0x5000,
+                    AccessWidth::Dword,
+                ),
                 0,
-                &mut memory,
+                Some(&mut memory),
             )
             .unwrap_err();
 
@@ -1653,14 +1475,20 @@ mod tests {
             .unwrap();
         let mut memory = TestMemoryPort;
 
-        devices
-            .handle_mmio_write_with_memory(
-                GuestPhysAddr::from_usize(0x6000),
-                AccessWidth::Dword,
-                0,
-                &mut memory,
-            )
-            .unwrap();
+        assert!(
+            devices
+                .try_write(
+                    &DeviceAccess::new(
+                        DeviceVcpuId::new(0),
+                        BusKind::Mmio,
+                        0x6000,
+                        AccessWidth::Dword,
+                    ),
+                    0,
+                    Some(&mut memory),
+                )
+                .unwrap()
+        );
     }
 
     #[test]
@@ -1722,14 +1550,20 @@ mod tests {
     fn dispatch_sensitive_grant_probe(
         devices: &DeviceRuntime,
         base: u64,
-    ) -> Result<BusResponse, DeviceError> {
-        devices.dispatch(&BusAccess {
-            kind: BusKind::Mmio,
-            is_read: false,
-            addr: base,
-            width: AccessWidth::Dword,
-            data: 0,
-        })
+    ) -> Result<(), DeviceError> {
+        devices
+            .try_write(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(0),
+                    BusKind::Mmio,
+                    base,
+                    AccessWidth::Dword,
+                ),
+                0,
+                None,
+            )
+            .map(|_| ())
+            .map_err(Into::into)
     }
 
     #[test]
@@ -1871,24 +1705,6 @@ mod tests {
         assert_eq!(stop_calls.load(Ordering::Relaxed), 1);
     }
 
-    #[test]
-    fn mmio_write_rejects_a_read_response() {
-        let mut devices = DeviceRuntime::empty();
-        devices
-            .register(Arc::new(ReadOnWriteDevice {
-                resources: alloc::vec![Resource::MmioRange {
-                    base: 0x7000,
-                    size: 0x100,
-                }],
-            }))
-            .unwrap();
-
-        assert!(matches!(
-            devices.handle_mmio_write(GuestPhysAddr::from_usize(0x7000), AccessWidth::Dword, 0,),
-            Err(DeviceManagerError::UnexpectedResponse { .. })
-        ));
-    }
-
     #[cfg(target_arch = "x86_64")]
     #[test]
     fn x86_ioapic_registration_publishes_typed_service() {
@@ -1972,59 +1788,6 @@ mod tests {
     }
 
     #[test]
-    fn test_read_request_rejects_write_response() {
-        // A device that incorrectly returns BusResponse::Write for a read
-        // should cause the handle_*_read methods to return an error.
-        // The device declares a resource on each bus so that the lookup
-        // actually finds it instead of returning NotFound.
-        struct WriteOnlyDevice;
-        impl Device for WriteOnlyDevice {
-            fn name(&self) -> &str {
-                "write-only"
-            }
-            fn resources(&self) -> &[Resource] {
-                static R: [Resource; 3] = [
-                    Resource::MmioRange {
-                        base: 0x1000,
-                        size: 0x100,
-                    },
-                    Resource::PortRange {
-                        base: 0x1000,
-                        size: 0x10,
-                    },
-                    Resource::SysReg {
-                        addr: 0x1000,
-                        count: 1,
-                    },
-                ];
-                &R
-            }
-            fn access(
-                &self,
-                _access: &BusAccess,
-                _context: &mut dyn DeviceAccess,
-            ) -> Result<BusResponse, DeviceError> {
-                Ok(BusResponse::Write)
-            }
-        }
-
-        let mut m = DeviceRuntime::empty();
-        m.register(Arc::new(WriteOnlyDevice)).unwrap();
-
-        // handle_mmio_read should detect the mismatched response.
-        let result = m.handle_mmio_read(GuestPhysAddr::from(0x1000), AccessWidth::Dword);
-        assert!(result.is_err());
-
-        // handle_sys_reg_read should also detect it.
-        let result = m.handle_sys_reg_read(SysRegAddr::new(0x1000), AccessWidth::Qword);
-        assert!(result.is_err());
-
-        // handle_port_read should also detect it.
-        let result = m.handle_port_read(Port::new(0x1000), AccessWidth::Byte);
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn test_zero_size_returns_invalid_resource() {
         let mut m = DeviceRuntime::empty();
         let result = m.register(Arc::new(D::new_mmio(0x1000, 0, "zero")));
@@ -2051,11 +1814,20 @@ mod tests {
                 }];
                 &R
             }
-            fn access(
+            fn read(
                 &self,
-                _: &BusAccess,
-                _context: &mut dyn DeviceAccess,
-            ) -> Result<BusResponse, DeviceError> {
+                _: &DeviceAccess,
+                _context: &mut dyn DeviceContext,
+            ) -> Result<u64, DeviceError> {
+                Err(DeviceError::NotFound)
+            }
+
+            fn write(
+                &self,
+                _: &DeviceAccess,
+                _value: u64,
+                _context: &mut dyn DeviceContext,
+            ) -> Result<(), DeviceError> {
                 Err(DeviceError::NotFound)
             }
         }
@@ -2076,27 +1848,26 @@ mod tests {
         let mut m = DeviceRuntime::empty();
         m.register(Arc::new(D::new_mmio(0x1000, 0x8, "small")))
             .unwrap();
-        assert!(matches!(
-            m.dispatch(&BusAccess {
-                kind: BusKind::Mmio,
-                is_read: false,
-                addr: 0x1004,
-                width: AccessWidth::Qword,
-                data: 0,
-            }),
-            Err(DeviceError::NotFound)
-        ));
+        let vcpu = DeviceVcpuId::new(0);
+        assert!(
+            !m.try_write(
+                &DeviceAccess::new(vcpu, BusKind::Mmio, 0x1004, AccessWidth::Qword),
+                0,
+                None,
+            )
+            .unwrap()
+        );
         // 0x1008 == base + size — NotFound.
-        assert!(matches!(
-            m.dispatch(&BusAccess {
-                kind: BusKind::Mmio,
-                is_read: true,
-                addr: 0x1008,
-                width: AccessWidth::Dword,
-                data: 0
-            }),
-            Err(DeviceError::NotFound)
-        ));
+        assert_eq!(
+            m.try_read(&DeviceAccess::new(
+                vcpu,
+                BusKind::Mmio,
+                0x1008,
+                AccessWidth::Dword,
+            ))
+            .unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -2105,16 +1876,16 @@ mod tests {
         m.register(Arc::new(D::new_port(0x80, 2, "small-port")))
             .unwrap();
 
-        assert!(matches!(
-            m.dispatch(&BusAccess {
-                kind: BusKind::Port,
-                is_read: true,
-                addr: 0x81,
-                width: AccessWidth::Word,
-                data: 0,
-            }),
-            Err(DeviceError::NotFound)
-        ));
+        assert_eq!(
+            m.try_read(&DeviceAccess::new(
+                DeviceVcpuId::new(0),
+                BusKind::Port,
+                0x81,
+                AccessWidth::Word,
+            ))
+            .unwrap(),
+            None
+        );
     }
 
     #[test]
@@ -2140,16 +1911,17 @@ mod tests {
             ))
         ));
         assert_eq!(devices.device_count(), 1);
-        assert!(matches!(
-            devices.dispatch(&BusAccess {
-                kind: BusKind::Mmio,
-                is_read: true,
-                addr: 0x2000,
-                width: AccessWidth::Dword,
-                data: 0,
-            }),
-            Err(DeviceError::NotFound)
-        ));
+        assert_eq!(
+            devices
+                .try_read(&DeviceAccess::new(
+                    DeviceVcpuId::new(0),
+                    BusKind::Mmio,
+                    0x2000,
+                    AccessWidth::Dword,
+                ))
+                .unwrap(),
+            None
+        );
     }
 
     #[test]

--- a/virtualization/axdevice/src/error.rs
+++ b/virtualization/axdevice/src/error.rs
@@ -66,14 +66,6 @@ pub enum DeviceManagerError {
         /// Diagnostic detail describing the limitation.
         detail: String,
     },
-    /// A device returned a response that does not match the request.
-    #[error("unexpected response during device operation {operation}: {detail}")]
-    UnexpectedResponse {
-        /// The operation that received the response.
-        operation: &'static str,
-        /// Diagnostic detail describing the response.
-        detail: String,
-    },
     /// A bus access failed with address and width context.
     #[error("device {operation} failed on {bus:?} bus at {addr:#x} with width {width:?}: {source}")]
     Access {
@@ -137,9 +129,6 @@ impl From<DeviceManagerError> for DeviceError {
                 operation,
                 resource: detail,
             },
-            DeviceManagerError::UnexpectedResponse { operation, detail } => {
-                Self::InvalidState { operation, detail }
-            }
             DeviceManagerError::Access { source, .. } => source,
             DeviceManagerError::Registry(error) => Self::InvalidInput {
                 operation: "register device",

--- a/virtualization/axdevice/src/fw_cfg/factory.rs
+++ b/virtualization/axdevice/src/fw_cfg/factory.rs
@@ -353,37 +353,43 @@ impl Device for FwCfgDmaDevice {
     fn resources(&self) -> &[Resource] {
         &self.resources
     }
-    fn access(
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
+        }
+        let addr = GuestPhysAddr::from_usize(access.address() as usize);
+        self.inner
+            .read_register(addr, access.width())
+            .map(|value| value as u64)
+    }
+
+    fn write(
         &self,
-        access: &BusAccess,
-        context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
-        let addr = GuestPhysAddr::from_usize(access.addr as usize);
-        if access.is_read {
-            return self
-                .inner
-                .read_register(addr, access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                });
-        }
+        let addr = GuestPhysAddr::from_usize(access.address() as usize);
         if !self.inner.is_dma_address(addr) {
             return self
                 .inner
-                .write_register(addr, access.width, access.data as usize)
-                .map(|_| BusResponse::Write);
+                .write_register(addr, access.width(), value as usize);
         }
         let Some(descriptor) = self
             .inner
-            .write_dma_address(addr, access.width, access.data as usize)
+            .write_dma_address(addr, access.width(), value as usize)
             .map_err(DeviceError::from)?
         else {
             // A 32-bit write of the descriptor's high half only updates the
             // latch; the low-half write starts the DMA transaction.
-            return Ok(BusResponse::Write);
+            return Ok(());
         };
         let context = RefCell::new(context);
         self.inner
@@ -403,6 +409,6 @@ impl Device for FwCfgDmaDevice {
                 },
             )
             .map_err(DeviceError::from)?;
-        Ok(BusResponse::Write)
+        Ok(())
     }
 }

--- a/virtualization/axdevice/src/fw_cfg/pio.rs
+++ b/virtualization/axdevice/src/fw_cfg/pio.rs
@@ -55,11 +55,13 @@ impl FwCfgPioDevice {
         })
     }
 
-    fn port_offset(&self, access: &BusAccess) -> Result<(PortWindow, usize), DeviceError> {
-        if access.kind != BusKind::Port || access.addr > u64::from(u16::MAX) {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+    fn port_offset(&self, access: &DeviceAccess) -> Result<(PortWindow, usize), DeviceError> {
+        if access.bus() != BusKind::Port || access.address() > u64::from(u16::MAX) {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
-        let port = access.addr as u16;
+        let port = access.address() as u16;
         if let Some(offset) = port.checked_sub(self.selector_base)
             && offset < self.selector_size
         {
@@ -70,21 +72,24 @@ impl FwCfgPioDevice {
         {
             return Ok((PortWindow::Dma, usize::from(offset)));
         }
-        Err(DeviceError::OutOfRange { addr: access.addr })
+        Err(DeviceError::OutOfRange {
+            addr: access.address(),
+        })
     }
 
     fn write_dma(
         &self,
         offset: usize,
-        access: &BusAccess,
-        context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
         let Some(descriptor) = self
             .inner
-            .write_dma_port(offset, access.width, access.data as usize)
+            .write_dma_port(offset, access.width(), value as usize)
             .map_err(DeviceError::from)?
         else {
-            return Ok(BusResponse::Write);
+            return Ok(());
         };
         let context = RefCell::new(context);
         self.inner
@@ -104,7 +109,7 @@ impl FwCfgPioDevice {
                 },
             )
             .map_err(DeviceError::from)?;
-        Ok(BusResponse::Write)
+        Ok(())
     }
 }
 
@@ -122,27 +127,35 @@ impl Device for FwCfgPioDevice {
         &self.resources
     }
 
-    fn access(
-        &self,
-        access: &BusAccess,
-        context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
         let (window, offset) = self.port_offset(access)?;
-        match (window, access.is_read, offset) {
-            (PortWindow::SelectorData, true, 0) => Ok(BusResponse::Read {
-                value: u64::from(self.inner.read_selector()),
+        match (window, offset) {
+            (PortWindow::SelectorData, 0) => Ok(u64::from(self.inner.read_selector())),
+            (PortWindow::SelectorData, 1) => Ok(self.inner.read_data(access.width()) as u64),
+            (PortWindow::Dma, _) => Ok(0),
+            _ => Err(DeviceError::OutOfRange {
+                addr: access.address(),
             }),
-            (PortWindow::SelectorData, true, 1) => Ok(BusResponse::Read {
-                value: self.inner.read_data(access.width) as u64,
-            }),
-            (PortWindow::SelectorData, false, 0) => {
-                self.inner.select(access.data as u16);
-                Ok(BusResponse::Write)
+        }
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        let (window, offset) = self.port_offset(access)?;
+        match (window, offset) {
+            (PortWindow::SelectorData, 0) => {
+                self.inner.select(value as u16);
+                Ok(())
             }
-            (PortWindow::SelectorData, false, 1) => Ok(BusResponse::Write),
-            (PortWindow::Dma, true, _) => Ok(BusResponse::Read { value: 0 }),
-            (PortWindow::Dma, false, offset) => self.write_dma(offset, access, context),
-            _ => Err(DeviceError::OutOfRange { addr: access.addr }),
+            (PortWindow::SelectorData, 1) => Ok(()),
+            (PortWindow::Dma, offset) => self.write_dma(offset, access, value, context),
+            _ => Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            }),
         }
     }
 }

--- a/virtualization/axdevice/src/fw_cfg/tests.rs
+++ b/virtualization/axdevice/src/fw_cfg/tests.rs
@@ -83,17 +83,8 @@ struct TestGuestMemory {
 }
 
 #[cfg(feature = "host-test")]
-impl DeviceAccess for TestGuestMemory {
-    fn device_id(&self) -> axdevice_base::DeviceId {
-        axdevice_base::DeviceId::new(0)
-    }
-
-    fn read_guest_memory(
-        &mut self,
-        _grant: &DmaGrant,
-        addr: GuestPhysAddr,
-        data: &mut [u8],
-    ) -> DeviceResult {
+impl GuestMemoryAccess for TestGuestMemory {
+    fn read(&mut self, addr: GuestPhysAddr, data: &mut [u8]) -> DeviceResult {
         let start = addr.as_usize();
         let end = start
             .checked_add(data.len())
@@ -103,12 +94,7 @@ impl DeviceAccess for TestGuestMemory {
         Ok(())
     }
 
-    fn write_guest_memory(
-        &mut self,
-        _grant: &DmaGrant,
-        addr: GuestPhysAddr,
-        data: &[u8],
-    ) -> DeviceResult {
+    fn write(&mut self, addr: GuestPhysAddr, data: &[u8]) -> DeviceResult {
         let start = addr.as_usize();
         let end = start
             .checked_add(data.len())
@@ -117,6 +103,26 @@ impl DeviceAccess for TestGuestMemory {
         self.bytes[start..end].copy_from_slice(data);
         Ok(())
     }
+}
+
+#[cfg(feature = "host-test")]
+fn guest_access(bus: BusKind, address: u64, width: AccessWidth) -> DeviceAccess {
+    DeviceAccess::new(DeviceVcpuId::new(0), bus, address, width)
+}
+
+#[cfg(feature = "host-test")]
+fn read(runtime: &crate::DeviceRuntime, access: DeviceAccess) -> u64 {
+    runtime.try_read(&access).unwrap().unwrap()
+}
+
+#[cfg(feature = "host-test")]
+fn write(
+    runtime: &crate::DeviceRuntime,
+    access: DeviceAccess,
+    value: u64,
+    memory: Option<&mut dyn GuestMemoryAccess>,
+) {
+    assert!(runtime.try_write(&access, value, memory).unwrap());
 }
 
 #[cfg(feature = "host-test")]
@@ -146,14 +152,16 @@ fn dma_descriptor_uses_the_runtime_granted_memory_port() {
     memory.bytes[DESCRIPTOR + 4..DESCRIPTOR + 8].copy_from_slice(&4u32.to_be_bytes());
     memory.bytes[DESCRIPTOR + 8..DESCRIPTOR + 16].copy_from_slice(&(BUFFER as u64).to_be_bytes());
 
-    runtime
-        .handle_mmio_write_with_memory(
-            GuestPhysAddr::from_usize(BASE + FW_CFG_DMA_OFFSET),
+    write(
+        &runtime,
+        guest_access(
+            BusKind::Mmio,
+            (BASE + FW_CFG_DMA_OFFSET) as u64,
             AccessWidth::Qword,
-            (DESCRIPTOR as u64).swap_bytes() as usize,
-            &mut memory,
-        )
-        .unwrap();
+        ),
+        (DESCRIPTOR as u64).swap_bytes(),
+        Some(&mut memory),
+    );
 
     assert_eq!(&memory.bytes[BUFFER..BUFFER + 4], b"QEMU");
     assert_eq!(&memory.bytes[DESCRIPTOR..DESCRIPTOR + 4], &[0, 0, 0, 0]);
@@ -187,65 +195,63 @@ fn pio_selector_data_and_dma_share_one_fw_cfg_state() {
     let mut runtime = crate::DeviceRuntime::empty();
     runtime.register_bundle(bundle).unwrap();
 
-    runtime
-        .handle_port_write(
-            axdevice_base::Port::new(0x510),
-            AccessWidth::Word,
-            FW_CFG_SIGNATURE.swap_bytes() as usize,
-        )
-        .unwrap();
+    write(
+        &runtime,
+        guest_access(BusKind::Port, 0x510, AccessWidth::Word),
+        FW_CFG_SIGNATURE.swap_bytes() as u64,
+        None,
+    );
     let signature = (0..4)
         .map(|_| {
-            runtime
-                .handle_port_read(axdevice_base::Port::new(0x511), AccessWidth::Byte)
-                .unwrap() as u8
+            read(
+                &runtime,
+                guest_access(BusKind::Port, 0x511, AccessWidth::Byte),
+            ) as u8
         })
         .collect::<Vec<_>>();
     assert_eq!(signature, b"QEMU");
 
-    runtime
-        .handle_port_write(
-            axdevice_base::Port::new(0x510),
-            AccessWidth::Word,
-            FW_CFG_ID as usize,
-        )
-        .unwrap();
-    let version = (0..4).fold(0usize, |version, shift| {
+    write(
+        &runtime,
+        guest_access(BusKind::Port, 0x510, AccessWidth::Word),
+        FW_CFG_ID as u64,
+        None,
+    );
+    let version = (0..4).fold(0u64, |version, shift| {
         version
-            | runtime
-                .handle_port_read(axdevice_base::Port::new(0x511), AccessWidth::Byte)
-                .unwrap()
-                << (shift * 8)
+            | read(
+                &runtime,
+                guest_access(BusKind::Port, 0x511, AccessWidth::Byte),
+            ) << (shift * 8)
     });
-    assert_eq!(version, (FW_CFG_VERSION | FW_CFG_VERSION_DMA) as usize);
+    assert_eq!(version, (FW_CFG_VERSION | FW_CFG_VERSION_DMA) as u64);
 
-    runtime
-        .handle_port_write(
-            axdevice_base::Port::new(0x510),
-            AccessWidth::Word,
-            FW_CFG_KERNEL_SETUP_SIZE as usize,
-        )
-        .unwrap();
-    let setup_size = (0..4).fold(0usize, |size, shift| {
-        size | runtime
-            .handle_port_read(axdevice_base::Port::new(0x511), AccessWidth::Byte)
-            .unwrap()
-            << (shift * 8)
+    write(
+        &runtime,
+        guest_access(BusKind::Port, 0x510, AccessWidth::Word),
+        FW_CFG_KERNEL_SETUP_SIZE as u64,
+        None,
+    );
+    let setup_size = (0..4).fold(0u64, |size, shift| {
+        size | read(
+            &runtime,
+            guest_access(BusKind::Port, 0x511, AccessWidth::Byte),
+        ) << (shift * 8)
     });
-    assert_eq!(setup_size, b"setup".len());
+    assert_eq!(setup_size, b"setup".len() as u64);
 
-    runtime
-        .handle_port_write(
-            axdevice_base::Port::new(0x510),
-            AccessWidth::Word,
-            FW_CFG_KERNEL_SETUP_DATA as usize,
-        )
-        .unwrap();
+    write(
+        &runtime,
+        guest_access(BusKind::Port, 0x510, AccessWidth::Word),
+        FW_CFG_KERNEL_SETUP_DATA as u64,
+        None,
+    );
     let setup = (0..setup_size)
         .map(|_| {
-            runtime
-                .handle_port_read(axdevice_base::Port::new(0x511), AccessWidth::Byte)
-                .unwrap() as u8
+            read(
+                &runtime,
+                guest_access(BusKind::Port, 0x511, AccessWidth::Byte),
+            ) as u8
         })
         .collect::<Vec<_>>();
     assert_eq!(setup, b"setup");
@@ -257,14 +263,12 @@ fn pio_selector_data_and_dma_share_one_fw_cfg_state() {
     memory.bytes[DESCRIPTOR..DESCRIPTOR + 4].copy_from_slice(&control.to_be_bytes());
     memory.bytes[DESCRIPTOR + 4..DESCRIPTOR + 8].copy_from_slice(&4u32.to_be_bytes());
     memory.bytes[DESCRIPTOR + 8..DESCRIPTOR + 16].copy_from_slice(&(BUFFER as u64).to_be_bytes());
-    runtime
-        .handle_port_write_with_memory(
-            axdevice_base::Port::new(0x514),
-            AccessWidth::Qword,
-            (DESCRIPTOR as u64).swap_bytes() as usize,
-            &mut memory,
-        )
-        .unwrap();
+    write(
+        &runtime,
+        guest_access(BusKind::Port, 0x514, AccessWidth::Qword),
+        (DESCRIPTOR as u64).swap_bytes(),
+        Some(&mut memory),
+    );
     assert_eq!(&memory.bytes[BUFFER..BUFFER + 4], b"QEMU");
 }
 
@@ -296,35 +300,29 @@ fn pio_dma_fault_does_not_poison_the_next_32_bit_transfer() {
         bytes: alloc::vec![0; 0x200],
     };
 
-    runtime
-        .handle_port_write_with_memory(
-            axdevice_base::Port::new(0x514),
-            AccessWidth::Dword,
-            0xdead_beefu32.swap_bytes() as usize,
-            &mut memory,
-        )
-        .unwrap();
-    runtime
-        .handle_port_write_with_memory(
-            axdevice_base::Port::new(0x518),
-            AccessWidth::Dword,
-            0x8000u32.swap_bytes() as usize,
-            &mut memory,
-        )
-        .unwrap();
+    write(
+        &runtime,
+        guest_access(BusKind::Port, 0x514, AccessWidth::Dword),
+        0xdead_beefu32.swap_bytes() as u64,
+        Some(&mut memory),
+    );
+    write(
+        &runtime,
+        guest_access(BusKind::Port, 0x518, AccessWidth::Dword),
+        0x8000u32.swap_bytes() as u64,
+        Some(&mut memory),
+    );
 
     let control = FW_CFG_DMA_CTL_SELECT | FW_CFG_DMA_CTL_READ;
     memory.bytes[DESCRIPTOR..DESCRIPTOR + 4].copy_from_slice(&control.to_be_bytes());
     memory.bytes[DESCRIPTOR + 4..DESCRIPTOR + 8].copy_from_slice(&4u32.to_be_bytes());
     memory.bytes[DESCRIPTOR + 8..DESCRIPTOR + 16].copy_from_slice(&(BUFFER as u64).to_be_bytes());
-    runtime
-        .handle_port_write_with_memory(
-            axdevice_base::Port::new(0x518),
-            AccessWidth::Dword,
-            (DESCRIPTOR as u32).swap_bytes() as usize,
-            &mut memory,
-        )
-        .unwrap();
+    write(
+        &runtime,
+        guest_access(BusKind::Port, 0x518, AccessWidth::Dword),
+        (DESCRIPTOR as u32).swap_bytes() as u64,
+        Some(&mut memory),
+    );
 
     assert_eq!(&memory.bytes[BUFFER..BUFFER + 4], b"QEMU");
 }

--- a/virtualization/axdevice/src/loongarch_pch_pic.rs
+++ b/virtualization/axdevice/src/loongarch_pch_pic.rs
@@ -341,28 +341,40 @@ impl Device for LoongArchPchPic {
         &self.resources
     }
 
-    fn access(
-        &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
-        let addr = GuestPhysAddr::from_usize(access.addr as usize);
+        let addr = GuestPhysAddr::from_usize(access.address() as usize);
         if !self.contains(addr) {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
+        self.read_register(addr, access.width())
+            .map(|value| value as u64)
+    }
 
-        if access.is_read {
-            self.read_register(addr, access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-        } else {
-            self.write_register(addr, access.width, access.data as usize)
-                .map(|_| BusResponse::Write)
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
+        let addr = GuestPhysAddr::from_usize(access.address() as usize);
+        if !self.contains(addr) {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
+        }
+        self.write_register(addr, access.width(), value as usize)
     }
 }
 

--- a/virtualization/axdevice/src/registration.rs
+++ b/virtualization/axdevice/src/registration.rs
@@ -36,7 +36,7 @@ pub trait DmaPollableDeviceOps: Send + Sync {
     fn poll_dma(
         &self,
         now_ns: u64,
-        access: &mut dyn DeviceAccess,
+        context: &mut dyn DeviceContext,
         grant: &DmaGrant,
     ) -> DeviceManagerResult;
 }

--- a/virtualization/axdevice/src/serial/device.rs
+++ b/virtualization/axdevice/src/serial/device.rs
@@ -3,8 +3,8 @@
 use alloc::{boxed::Box, sync::Arc};
 
 use axdevice_base::{
-    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError,
-    InterruptTriggerMode, IrqLine, Resource,
+    AccessWidth, BusKind, Device, DeviceAccess, DeviceContext, DeviceError, InterruptTriggerMode,
+    IrqLine, Resource,
 };
 
 use crate::{
@@ -47,25 +47,46 @@ impl Device for Uart16550PortDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Port {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
-        }
-        let offset = u16::try_from(access.addr)
-            .ok()
-            .and_then(|port| port.checked_sub(self.base))
-            .ok_or(DeviceError::OutOfRange { addr: access.addr })? as usize;
-        if access.width != AccessWidth::Byte {
-            return Err(DeviceError::InvalidWidth {
-                expected: AccessWidth::Byte,
-                actual: access.width,
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        let offset = self.offset(access)?;
+        self.core.read(offset, AccessWidth::Byte)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        let offset = self.offset(access)?;
+        self.core.write(offset, AccessWidth::Byte, value)
+    }
+}
+
+impl Uart16550PortDevice {
+    fn offset(&self, access: &DeviceAccess) -> Result<usize, DeviceError> {
+        if access.bus() != BusKind::Port {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
             });
         }
-        handle_16550(&self.core, offset, access)
+        let offset = u16::try_from(access.address())
+            .ok()
+            .and_then(|port| port.checked_sub(self.base))
+            .ok_or(DeviceError::OutOfRange {
+                addr: access.address(),
+            })? as usize;
+        if access.width() != AccessWidth::Byte {
+            return Err(DeviceError::InvalidWidth {
+                expected: AccessWidth::Byte,
+                actual: access.width(),
+            });
+        }
+        Ok(offset)
     }
 }
 
@@ -116,21 +137,41 @@ impl Device for Uart16550MmioDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        self.core.read(self.register(access)?, AccessWidth::Byte)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        self.core
+            .write(self.register(access)?, AccessWidth::Byte, value)
+    }
+}
+
+impl Uart16550MmioDevice {
+    fn register(&self, access: &DeviceAccess) -> Result<usize, DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
         let offset = access
-            .addr
+            .address()
             .checked_sub(self.base)
-            .ok_or(DeviceError::OutOfRange { addr: access.addr })?;
-        let register = usize::try_from(offset >> self.register_shift)
-            .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
-        handle_16550(&self.core, register, access)
+            .ok_or(DeviceError::OutOfRange {
+                addr: access.address(),
+            })?;
+        usize::try_from(offset >> self.register_shift).map_err(|_| DeviceError::OutOfRange {
+            addr: access.address(),
+        })
     }
 }
 
@@ -178,28 +219,40 @@ impl Device for Pl011MmioDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        self.core.read(self.offset(access)?, access.width())
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        self.core.write(self.offset(access)?, access.width(), value)
+    }
+}
+
+impl Pl011MmioDevice {
+    fn offset(&self, access: &DeviceAccess) -> Result<usize, DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
         let offset = access
-            .addr
+            .address()
             .checked_sub(self.base)
-            .ok_or(DeviceError::OutOfRange { addr: access.addr })?;
-        let offset =
-            usize::try_from(offset).map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
-        if access.is_read {
-            self.core
-                .read(offset, access.width)
-                .map(|value| BusResponse::Read { value })
-        } else {
-            self.core.write(offset, access.width, access.data)?;
-            Ok(BusResponse::Write)
-        }
+            .ok_or(DeviceError::OutOfRange {
+                addr: access.address(),
+            })?;
+        usize::try_from(offset).map_err(|_| DeviceError::OutOfRange {
+            addr: access.address(),
+        })
     }
 }
 
@@ -261,22 +314,6 @@ where
     DeviceBundle::new()
         .with_registration(DeviceRegistration::Device(device.clone()))
         .with_registration(DeviceRegistration::Pollable(device))
-}
-
-fn handle_16550(
-    core: &Uart16550,
-    register: usize,
-    access: &BusAccess,
-) -> Result<BusResponse, DeviceError> {
-    // QEMU's serial-mm adapter uses the access address only to select the
-    // register and always transfers the low byte to the 16550 core.
-    if access.is_read {
-        core.read(register, AccessWidth::Byte)
-            .map(|value| BusResponse::Read { value })
-    } else {
-        core.write(register, AccessWidth::Byte, access.data)?;
-        Ok(BusResponse::Write)
-    }
 }
 
 fn irq_resource(irq_id: usize) -> Resource {
@@ -355,7 +392,8 @@ mod tests {
             backend.clone(),
             level_irq(365),
         );
-        let mut context = axdevice_base::NoopDeviceAccess::new(axdevice_base::DeviceId::new(0));
+        let source = axdevice_base::DeviceVcpuId::new(0);
+        let mut context = axdevice_base::NoopDeviceContext::new(axdevice_base::DeviceId::new(0));
 
         for width in [
             AccessWidth::Byte,
@@ -364,14 +402,9 @@ mod tests {
             AccessWidth::Qword,
         ] {
             device
-                .access(
-                    &BusAccess {
-                        kind: BusKind::Mmio,
-                        is_read: false,
-                        addr: BASE,
-                        width,
-                        data: 0xfeed_0000_0000_005a,
-                    },
+                .write(
+                    &DeviceAccess::new(source, BusKind::Mmio, BASE, width),
+                    0xfeed_0000_0000_005a,
                     &mut context,
                 )
                 .unwrap();
@@ -379,47 +412,30 @@ mod tests {
         assert_eq!(backend.output.lock().unwrap().as_slice(), b"ZZZZ");
 
         device
-            .access(
-                &BusAccess {
-                    kind: BusKind::Mmio,
-                    is_read: false,
-                    addr: BASE + 4,
-                    width: AccessWidth::Byte,
-                    data: 1,
-                },
+            .write(
+                &DeviceAccess::new(source, BusKind::Mmio, BASE + 4, AccessWidth::Byte),
+                1,
                 &mut context,
             )
             .unwrap();
-        assert!(matches!(
+        assert_eq!(
             device
-                .access(
-                    &BusAccess {
-                        kind: BusKind::Mmio,
-                        is_read: true,
-                        addr: BASE + 4,
-                        width: AccessWidth::Byte,
-                        data: 0,
-                    },
+                .read(
+                    &DeviceAccess::new(source, BusKind::Mmio, BASE + 4, AccessWidth::Byte),
                     &mut context,
                 )
                 .unwrap(),
-            BusResponse::Read { value: 1 }
-        ));
+            1
+        );
 
-        assert!(matches!(
+        assert_eq!(
             device
-                .access(
-                    &BusAccess {
-                        kind: BusKind::Mmio,
-                        is_read: true,
-                        addr: BASE + 0x88,
-                        width: AccessWidth::Dword,
-                        data: 0,
-                    },
+                .read(
+                    &DeviceAccess::new(source, BusKind::Mmio, BASE + 0x88, AccessWidth::Dword,),
                     &mut context,
                 )
                 .unwrap(),
-            BusResponse::Read { value: 0 }
-        ));
+            0
+        );
     }
 }

--- a/virtualization/axdevice/src/x86.rs
+++ b/virtualization/axdevice/src/x86.rs
@@ -160,29 +160,25 @@ impl Device for X86IoApicDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        let addr = ioapic_address(access)?;
+        self.inner
+            .handle_read(addr, x86_access_width(access.width()))
+            .map(|value| value as u64)
+            .map_err(|_| DeviceError::Internal)
+    }
+
+    fn write(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn axdevice_base::DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
-        }
-        let addr = X86GuestPhysAddr::from_usize(access.addr as usize);
-        let width = x86_access_width(access.width);
-        if access.is_read {
-            self.inner
-                .handle_read(addr, width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-                .map_err(|_| DeviceError::Internal)
-        } else {
-            self.inner
-                .handle_write(addr, width, access.data as usize)
-                .map(|_| BusResponse::Write)
-                .map_err(|_| DeviceError::Internal)
-        }
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        let addr = ioapic_address(access)?;
+        self.inner
+            .handle_write(addr, x86_access_width(access.width()), value as usize)
+            .map(|_| ())
+            .map_err(|_| DeviceError::Internal)
     }
 }
 
@@ -242,33 +238,48 @@ impl<H: X86VlapicHostOps + 'static> Device for X86PitDevice<H> {
         &self.resources
     }
 
-    fn access(
-        &self,
-        access: &BusAccess,
-        _context: &mut dyn axdevice_base::DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Port {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
-        }
-        let port = X86Port::new(
-            u16::try_from(access.addr)
-                .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?,
-        );
-        let width = x86_access_width(access.width);
-        if access.is_read {
-            self.inner
-                .handle_read(port, width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-                .map_err(|_| DeviceError::Internal)
-        } else {
-            self.inner
-                .handle_write(port, width, access.data as usize)
-                .map(|_| BusResponse::Write)
-                .map_err(|_| DeviceError::Internal)
-        }
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        let port = pit_port(access)?;
+        self.inner
+            .handle_read(port, x86_access_width(access.width()))
+            .map(|value| value as u64)
+            .map_err(|_| DeviceError::Internal)
     }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        let port = pit_port(access)?;
+        self.inner
+            .handle_write(port, x86_access_width(access.width()), value as usize)
+            .map(|_| ())
+            .map_err(|_| DeviceError::Internal)
+    }
+}
+
+fn ioapic_address(access: &DeviceAccess) -> DeviceResult<X86GuestPhysAddr> {
+    if access.bus() != BusKind::Mmio {
+        return Err(DeviceError::OutOfRange {
+            addr: access.address(),
+        });
+    }
+    Ok(X86GuestPhysAddr::from_usize(access.address() as usize))
+}
+
+fn pit_port(access: &DeviceAccess) -> DeviceResult<X86Port> {
+    if access.bus() != BusKind::Port {
+        return Err(DeviceError::OutOfRange {
+            addr: access.address(),
+        });
+    }
+    u16::try_from(access.address())
+        .map(X86Port::new)
+        .map_err(|_| DeviceError::OutOfRange {
+            addr: access.address(),
+        })
 }
 
 fn x86_access_width(width: AccessWidth) -> X86AccessWidth {

--- a/virtualization/axdevice/src/x86/acpi_pm_timer.rs
+++ b/virtualization/axdevice/src/x86/acpi_pm_timer.rs
@@ -81,8 +81,8 @@ impl X86AcpiPmTimerDevice {
         pm_timer_counter((self.monotonic_nanos)())
     }
 
-    fn access_size(access: &BusAccess) -> Result<u64, DeviceError> {
-        match access.width {
+    fn access_size(access: &DeviceAccess) -> Result<u64, DeviceError> {
+        match access.width() {
             AccessWidth::Byte => Ok(1),
             AccessWidth::Word => Ok(2),
             AccessWidth::Dword => Ok(4),
@@ -93,18 +93,22 @@ impl X86AcpiPmTimerDevice {
         }
     }
 
-    fn offset(&self, access: &BusAccess, width: u64) -> Result<u64, DeviceError> {
+    fn offset(&self, access: &DeviceAccess, width: u64) -> Result<u64, DeviceError> {
         let offset = access
-            .addr
+            .address()
             .checked_sub(u64::from(Self::PORT_BASE))
-            .ok_or(DeviceError::OutOfRange { addr: access.addr })?;
+            .ok_or(DeviceError::OutOfRange {
+                addr: access.address(),
+            })?;
         if offset + width > u64::from(Self::PORT_SIZE) {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
         Ok(offset)
     }
 
-    fn read(&self, access: &BusAccess) -> Result<u64, DeviceError> {
+    fn read_registers(&self, access: &DeviceAccess) -> Result<u64, DeviceError> {
         let width = Self::access_size(access)?;
         let offset = self.offset(access, width)?;
         let timer = self.counter().to_le_bytes();
@@ -126,7 +130,12 @@ impl X86AcpiPmTimerDevice {
         Ok(value)
     }
 
-    fn write(&self, access: &BusAccess, context: &mut dyn DeviceAccess) -> Result<(), DeviceError> {
+    fn write_registers(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
         let width = Self::access_size(access)?;
         let offset = self.offset(access, width)?;
         let mut status_clear = 0u16;
@@ -136,7 +145,7 @@ impl X86AcpiPmTimerDevice {
         let mut control_value = 0u16;
         for index in 0..width {
             let register = offset + index;
-            let byte = ((access.data >> (index * 8)) & 0xff) as u16;
+            let byte = ((value >> (index * 8)) & 0xff) as u16;
             match register {
                 0..=1 => status_clear |= byte << (register * 8),
                 2..=3 => {
@@ -187,19 +196,27 @@ impl Device for X86AcpiPmTimerDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        if access.bus() != BusKind::Port {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
+        }
+        self.read_registers(access)
+    }
+
+    fn write(
         &self,
-        access: &BusAccess,
-        context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Port {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        if access.bus() != BusKind::Port {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
-        if access.is_read {
-            self.read(access).map(|value| BusResponse::Read { value })
-        } else {
-            self.write(access, context).map(|()| BusResponse::Write)
-        }
+        self.write_registers(access, value, context)
     }
 }
 
@@ -227,7 +244,7 @@ mod tests {
 
     struct NoMemory;
 
-    impl DeviceAccess for NoMemory {
+    impl DeviceContext for NoMemory {
         fn device_id(&self) -> DeviceId {
             DeviceId::new(0)
         }
@@ -238,7 +255,7 @@ mod tests {
         requested: bool,
     }
 
-    impl DeviceAccess for StopAccess {
+    impl DeviceContext for StopAccess {
         fn device_id(&self) -> DeviceId {
             DeviceId::new(0)
         }
@@ -282,22 +299,16 @@ mod tests {
         NOW_NANOS.store(0, Ordering::Relaxed);
         let timer = X86AcpiPmTimerDevice::new(now_nanos, sci_line(), StopGrant::new()).unwrap();
         let mut memory = NoMemory;
-        let access = BusAccess {
-            kind: BusKind::Port,
-            is_read: true,
-            addr: u64::from(X86AcpiPmTimerDevice::PORT_BASE) + X86AcpiPmTimerDevice::TIMER_OFFSET,
-            width: AccessWidth::Dword,
-            data: 0,
-        };
+        let access = DeviceAccess::new(
+            DeviceVcpuId::new(0),
+            BusKind::Port,
+            u64::from(X86AcpiPmTimerDevice::PORT_BASE) + X86AcpiPmTimerDevice::TIMER_OFFSET,
+            AccessWidth::Dword,
+        );
 
-        let BusResponse::Read { value: first } = timer.access(&access, &mut memory).unwrap() else {
-            panic!("PM timer read returned a write response");
-        };
+        let first = timer.read(&access, &mut memory).unwrap();
         NOW_NANOS.store(NANOSECONDS_PER_SECOND, Ordering::Relaxed);
-        let BusResponse::Read { value: second } = timer.access(&access, &mut memory).unwrap()
-        else {
-            panic!("PM timer read returned a write response");
-        };
+        let second = timer.read(&access, &mut memory).unwrap();
 
         assert_eq!(first, 0);
         assert_eq!(second, PM_TIMER_FREQUENCY_HZ);
@@ -312,15 +323,15 @@ mod tests {
             requested: false,
         };
         timer
-            .access(
-                &BusAccess {
-                    kind: BusKind::Port,
-                    is_read: false,
-                    addr: u64::from(X86AcpiPmTimerDevice::PORT_BASE)
+            .write(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(0),
+                    BusKind::Port,
+                    u64::from(X86AcpiPmTimerDevice::PORT_BASE)
                         + X86AcpiPmTimerDevice::CONTROL_OFFSET,
-                    width: AccessWidth::Word,
-                    data: 1 << 13,
-                },
+                    AccessWidth::Word,
+                ),
+                1 << 13,
                 &mut access_context,
             )
             .unwrap();

--- a/virtualization/axdevice/src/x86/cmos.rs
+++ b/virtualization/axdevice/src/x86/cmos.rs
@@ -87,58 +87,67 @@ impl Device for X86CmosDevice {
         &self.resources
     }
 
-    fn access(
-        &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Port || access.width != AccessWidth::Byte {
-            return Err(DeviceError::Unsupported {
-                operation: "access x86 CMOS",
-                detail: "CMOS supports byte port accesses only".into(),
-            });
-        }
-
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        validate_access(access)?;
         let mut state = self.state.lock_irqsave();
-        match (access.addr, access.is_read) {
-            (addr, false) if addr == u64::from(INDEX_PORT) => {
-                state.index = access.data as u8 & 0x7f;
-                Ok(BusResponse::Write)
-            }
-            (addr, true) if addr == u64::from(INDEX_PORT) => Ok(BusResponse::Read {
-                value: u64::from(state.index),
-            }),
-            (addr, false) if addr == u64::from(DATA_PORT) => {
-                let index = usize::from(state.index);
-                if !matches!(index, RTC_REGISTER_C | RTC_REGISTER_D) {
-                    state.bytes[index] = access.data as u8;
-                }
-                Ok(BusResponse::Write)
-            }
-            (addr, true) if addr == u64::from(DATA_PORT) => {
+        match access.address() {
+            addr if addr == u64::from(INDEX_PORT) => Ok(u64::from(state.index)),
+            addr if addr == u64::from(DATA_PORT) => {
                 let index = usize::from(state.index);
                 let value = state.bytes[index];
                 if index == RTC_REGISTER_C {
                     state.bytes[index] = 0;
                 }
-                Ok(BusResponse::Read {
-                    value: u64::from(value),
-                })
+                Ok(u64::from(value))
             }
-            _ => Err(DeviceError::OutOfRange { addr: access.addr }),
+            addr => Err(DeviceError::OutOfRange { addr }),
+        }
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        validate_access(access)?;
+        let mut state = self.state.lock_irqsave();
+        match access.address() {
+            addr if addr == u64::from(INDEX_PORT) => {
+                state.index = value as u8 & 0x7f;
+                Ok(())
+            }
+            addr if addr == u64::from(DATA_PORT) => {
+                let index = usize::from(state.index);
+                if !matches!(index, RTC_REGISTER_C | RTC_REGISTER_D) {
+                    state.bytes[index] = value as u8;
+                }
+                Ok(())
+            }
+            addr => Err(DeviceError::OutOfRange { addr }),
         }
     }
 }
 
+fn validate_access(access: &DeviceAccess) -> DeviceResult {
+    if access.bus() != BusKind::Port || access.width() != AccessWidth::Byte {
+        return Err(DeviceError::Unsupported {
+            operation: "access x86 CMOS",
+            detail: "CMOS supports byte port accesses only".into(),
+        });
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
-    use axdevice_base::{DeviceAccess, DeviceId};
+    use axdevice_base::{DeviceContext, DeviceId, DeviceVcpuId};
 
     use super::*;
 
     struct NoMemory;
 
-    impl DeviceAccess for NoMemory {
+    impl DeviceContext for NoMemory {
         fn device_id(&self) -> DeviceId {
             DeviceId::new(0)
         }
@@ -147,58 +156,53 @@ mod tests {
     fn read_register(device: &X86CmosDevice, register: u8) -> u8 {
         let mut memory = NoMemory;
         device
-            .access(
-                &BusAccess {
-                    kind: BusKind::Port,
-                    is_read: false,
-                    addr: u64::from(INDEX_PORT),
-                    width: AccessWidth::Byte,
-                    data: u64::from(register),
-                },
+            .write(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(0),
+                    BusKind::Port,
+                    u64::from(INDEX_PORT),
+                    AccessWidth::Byte,
+                ),
+                u64::from(register),
                 &mut memory,
             )
             .unwrap();
-        match device
-            .access(
-                &BusAccess {
-                    kind: BusKind::Port,
-                    is_read: true,
-                    addr: u64::from(DATA_PORT),
-                    width: AccessWidth::Byte,
-                    data: 0,
-                },
+        device
+            .read(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(0),
+                    BusKind::Port,
+                    u64::from(DATA_PORT),
+                    AccessWidth::Byte,
+                ),
                 &mut memory,
             )
-            .unwrap()
-        {
-            BusResponse::Read { value } => value as u8,
-            BusResponse::Write => unreachable!(),
-        }
+            .unwrap() as u8
     }
 
     fn write_register(device: &X86CmosDevice, register: u8, value: u8) {
         let mut memory = NoMemory;
         device
-            .access(
-                &BusAccess {
-                    kind: BusKind::Port,
-                    is_read: false,
-                    addr: u64::from(INDEX_PORT),
-                    width: AccessWidth::Byte,
-                    data: u64::from(register),
-                },
+            .write(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(0),
+                    BusKind::Port,
+                    u64::from(INDEX_PORT),
+                    AccessWidth::Byte,
+                ),
+                u64::from(register),
                 &mut memory,
             )
             .unwrap();
         device
-            .access(
-                &BusAccess {
-                    kind: BusKind::Port,
-                    is_read: false,
-                    addr: u64::from(DATA_PORT),
-                    width: AccessWidth::Byte,
-                    data: u64::from(value),
-                },
+            .write(
+                &DeviceAccess::new(
+                    DeviceVcpuId::new(0),
+                    BusKind::Port,
+                    u64::from(DATA_PORT),
+                    AccessWidth::Byte,
+                ),
+                u64::from(value),
                 &mut memory,
             )
             .unwrap();

--- a/virtualization/axdevice/src/x86/pci_config.rs
+++ b/virtualization/axdevice/src/x86/pci_config.rs
@@ -54,6 +54,19 @@ impl X86PciConfigDevice {
             }),
         }
     }
+
+    fn decode_access(access: &DeviceAccess) -> Result<(u16, usize), DeviceError> {
+        if access.bus() != BusKind::Port {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
+        }
+        let size = Self::access_size(access.width())?;
+        let port = u16::try_from(access.address()).map_err(|_| DeviceError::OutOfRange {
+            addr: access.address(),
+        })?;
+        Ok((port, size))
+    }
 }
 
 impl Default for X86PciConfigDevice {
@@ -71,65 +84,70 @@ impl Device for X86PciConfigDevice {
         &self.resources
     }
 
-    fn access(
-        &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Port {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
-        }
-        let size = Self::access_size(access.width)?;
-        let port = u16::try_from(access.addr)
-            .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?;
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        let (port, size) = Self::decode_access(access)?;
         let mut state = self.state.lock_irqsave();
 
         if (CONFIG_ADDRESS_PORT..CONFIG_DATA_PORT).contains(&port) {
             let offset = usize::from(port - CONFIG_ADDRESS_PORT);
             if offset + size > 4 {
-                return Err(DeviceError::OutOfRange { addr: access.addr });
-            }
-            if access.is_read {
-                return Ok(BusResponse::Read {
-                    value: read_bytes(&state.address.to_le_bytes(), offset, size),
+                return Err(DeviceError::OutOfRange {
+                    addr: access.address(),
                 });
             }
-            let mut address = state.address.to_le_bytes();
-            write_bytes(&mut address, offset, size, access.data, &[u8::MAX; 4]);
-            state.address = u32::from_le_bytes(address);
-            return Ok(BusResponse::Write);
+            return Ok(read_bytes(&state.address.to_le_bytes(), offset, size));
         }
 
         if (CONFIG_DATA_PORT..CONFIG_DATA_PORT + 4).contains(&port) {
             let data_offset = usize::from(port - CONFIG_DATA_PORT);
             let Some((bus, device, function, register)) = state.selection(data_offset, size) else {
-                return Ok(if access.is_read {
-                    BusResponse::Read {
-                        value: all_ones(size),
-                    }
-                } else {
-                    BusResponse::Write
-                });
+                return Ok(all_ones(size));
             };
             let Some(config) = state.function_mut(bus, device, function) else {
-                return Ok(if access.is_read {
-                    BusResponse::Read {
-                        value: all_ones(size),
-                    }
-                } else {
-                    BusResponse::Write
-                });
+                return Ok(all_ones(size));
             };
-            if access.is_read {
-                Ok(BusResponse::Read {
-                    value: config.read(register, size),
-                })
-            } else {
-                config.write(register, size, access.data);
-                Ok(BusResponse::Write)
-            }
+            Ok(config.read(register, size))
         } else {
-            Err(DeviceError::OutOfRange { addr: access.addr })
+            Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            })
+        }
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        let (port, size) = Self::decode_access(access)?;
+        let mut state = self.state.lock_irqsave();
+
+        if (CONFIG_ADDRESS_PORT..CONFIG_DATA_PORT).contains(&port) {
+            let offset = usize::from(port - CONFIG_ADDRESS_PORT);
+            if offset + size > 4 {
+                return Err(DeviceError::OutOfRange {
+                    addr: access.address(),
+                });
+            }
+            let mut address = state.address.to_le_bytes();
+            write_bytes(&mut address, offset, size, value, &[u8::MAX; 4]);
+            state.address = u32::from_le_bytes(address);
+            return Ok(());
+        }
+
+        if (CONFIG_DATA_PORT..CONFIG_DATA_PORT + 4).contains(&port) {
+            let data_offset = usize::from(port - CONFIG_DATA_PORT);
+            if let Some((bus, device, function, register)) = state.selection(data_offset, size)
+                && let Some(config) = state.function_mut(bus, device, function)
+            {
+                config.write(register, size, value);
+            }
+            Ok(())
+        } else {
+            Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            })
         }
     }
 }
@@ -236,13 +254,13 @@ fn all_ones(size: usize) -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use axdevice_base::{DeviceAccess, DeviceId};
+    use axdevice_base::{DeviceContext, DeviceId, DeviceVcpuId};
 
     use super::*;
 
     struct NoMemory;
 
-    impl DeviceAccess for NoMemory {
+    impl DeviceContext for NoMemory {
         fn device_id(&self) -> DeviceId {
             DeviceId::new(0)
         }
@@ -250,36 +268,21 @@ mod tests {
 
     fn write(device: &X86PciConfigDevice, port: u16, width: AccessWidth, value: u64) {
         device
-            .access(
-                &BusAccess {
-                    kind: BusKind::Port,
-                    is_read: false,
-                    addr: u64::from(port),
-                    width,
-                    data: value,
-                },
+            .write(
+                &DeviceAccess::new(DeviceVcpuId::new(0), BusKind::Port, u64::from(port), width),
+                value,
                 &mut NoMemory,
             )
             .unwrap();
     }
 
     fn read(device: &X86PciConfigDevice, port: u16, width: AccessWidth) -> u64 {
-        match device
-            .access(
-                &BusAccess {
-                    kind: BusKind::Port,
-                    is_read: true,
-                    addr: u64::from(port),
-                    width,
-                    data: 0,
-                },
+        device
+            .read(
+                &DeviceAccess::new(DeviceVcpuId::new(0), BusKind::Port, u64::from(port), width),
                 &mut NoMemory,
             )
             .unwrap()
-        {
-            BusResponse::Read { value } => value,
-            BusResponse::Write => unreachable!(),
-        }
     }
 
     #[test]

--- a/virtualization/axdevice/src/x86/pic.rs
+++ b/virtualization/axdevice/src/x86/pic.rs
@@ -49,31 +49,38 @@ impl Device for X86PicDevice {
         &self.resources
     }
 
-    fn access(
-        &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Port {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
-        }
-        let port = X86Port::new(
-            u16::try_from(access.addr)
-                .map_err(|_| DeviceError::OutOfRange { addr: access.addr })?,
-        );
-        let width = x86_access_width(access.width);
-        if access.is_read {
-            self.inner
-                .handle_read(port, width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-                .map_err(|_| DeviceError::Internal)
-        } else {
-            self.inner
-                .handle_write(port, width, access.data as usize)
-                .map(|()| BusResponse::Write)
-                .map_err(|_| DeviceError::Internal)
-        }
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        let (port, width) = decode_access(access)?;
+        self.inner
+            .handle_read(port, width)
+            .map(|value| value as u64)
+            .map_err(|_| DeviceError::Internal)
     }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        let (port, width) = decode_access(access)?;
+        self.inner
+            .handle_write(port, width, value as usize)
+            .map_err(|_| DeviceError::Internal)
+    }
+}
+
+fn decode_access(access: &DeviceAccess) -> DeviceResult<(X86Port, x86_vlapic::X86AccessWidth)> {
+    if access.bus() != BusKind::Port {
+        return Err(DeviceError::OutOfRange {
+            addr: access.address(),
+        });
+    }
+    let port =
+        X86Port::new(
+            u16::try_from(access.address()).map_err(|_| DeviceError::OutOfRange {
+                addr: access.address(),
+            })?,
+        );
+    Ok((port, x86_access_width(access.width())))
 }

--- a/virtualization/axdevice/tests/runtime_controllers.rs
+++ b/virtualization/axdevice/tests/runtime_controllers.rs
@@ -87,11 +87,20 @@ impl Device for LineDevice {
         &[]
     }
 
-    fn access(
+    fn read(
         &self,
-        _access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
+        _access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        Err(DeviceError::NotFound)
+    }
+
+    fn write(
+        &self,
+        _access: &DeviceAccess,
+        _value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
         Err(DeviceError::NotFound)
     }
 }
@@ -152,11 +161,20 @@ impl Device for MmioDevice {
         &self.resource
     }
 
-    fn access(
+    fn read(
         &self,
-        _access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
+        _access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        Err(DeviceError::NotFound)
+    }
+
+    fn write(
+        &self,
+        _access: &DeviceAccess,
+        _value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
         Err(DeviceError::NotFound)
     }
 }

--- a/virtualization/axdevice_base/src/device.rs
+++ b/virtualization/axdevice_base/src/device.rs
@@ -7,6 +7,8 @@ use ax_memory_addr::AddrRange;
 use axvm_types::GuestPhysAddr;
 pub use axvm_types::{AccessWidth, Port, SysRegAddr};
 
+use crate::DeviceVcpuId;
+
 /// An address-like type that can be used to access devices.
 pub trait DeviceAddr: Copy + Eq + Ord + core::fmt::Debug {}
 
@@ -137,7 +139,7 @@ impl LowerHex for PortRange {
 }
 
 // ---------------------------------------------------------------------------
-// Unified bus-access types
+// Device access types
 // ---------------------------------------------------------------------------
 
 /// The kind of bus a device is connected to.
@@ -151,31 +153,53 @@ pub enum BusKind {
     SysReg,
 }
 
-/// An access issued by a vCPU to a device on a bus.
-#[derive(Debug, Clone, Copy)]
-pub struct BusAccess {
-    /// The kind of bus being accessed.
-    pub kind: BusKind,
-    /// `true` if this is a read access; `false` for write.
-    pub is_read: bool,
-    /// The address being accessed.
-    pub addr: u64,
-    /// The width of the access.
-    pub width: AccessWidth,
-    /// The data to write (ignored for reads).
-    pub data: u64,
+/// Immutable metadata for one device access issued by a guest vCPU.
+///
+/// The source vCPU is an architectural identity within the VM. It must not be
+/// inferred from the host CPU or execution context handling the exit.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DeviceAccess {
+    source_vcpu: DeviceVcpuId,
+    bus: BusKind,
+    address: u64,
+    width: AccessWidth,
 }
 
-/// The result of a bus access dispatched to a device.
-#[derive(Debug, Clone, Copy)]
-pub enum BusResponse {
-    /// A read response with the value.
-    Read {
-        /// The value read from the device.
-        value: u64,
-    },
-    /// A write acknowledgment.
-    Write,
+impl DeviceAccess {
+    /// Creates complete metadata for one guest device access.
+    pub const fn new(
+        source_vcpu: DeviceVcpuId,
+        bus: BusKind,
+        address: u64,
+        width: AccessWidth,
+    ) -> Self {
+        Self {
+            source_vcpu,
+            bus,
+            address,
+            width,
+        }
+    }
+
+    /// Returns the vCPU that issued the access.
+    pub const fn source_vcpu(self) -> DeviceVcpuId {
+        self.source_vcpu
+    }
+
+    /// Returns the accessed bus.
+    pub const fn bus(self) -> BusKind {
+        self.bus
+    }
+
+    /// Returns the address in the selected bus address space.
+    pub const fn address(self) -> u64 {
+        self.address
+    }
+
+    /// Returns the access width.
+    pub const fn width(self) -> AccessWidth {
+        self.width
+    }
 }
 
 /// Errors that can occur during device access handling.

--- a/virtualization/axdevice_base/src/lib.rs
+++ b/virtualization/axdevice_base/src/lib.rs
@@ -23,7 +23,8 @@
 //! The crate contains the following key components:
 //!
 //! - [`Device`]: The unified V3 device trait used by the runtime hot path.
-//! - [`DeviceAccess`]: The access-scoped capability context passed to devices.
+//! - [`DeviceAccess`]: Immutable metadata for one guest device access.
+//! - [`DeviceContext`]: Access-scoped runtime capabilities passed to devices.
 //! - [`Resource`]: Static device resource declarations used for registration
 //!   validation and bus dispatch.
 //! - [`VirtualInterruptController`], [`WiredIrqInput`], and [`IrqLine`]:
@@ -32,12 +33,12 @@
 //! # Usage
 //!
 //! New emulated devices should implement [`Device`] directly and receive all
-//! sensitive runtime abilities through [`DeviceAccess`].
+//! sensitive runtime abilities through [`DeviceContext`].
 //!
 //! ```rust,ignore
 //! use axdevice_base::{
-//!     AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess,
-//!     DeviceError, Resource,
+//!     AccessWidth, BusKind, Device, DeviceAccess, DeviceContext, DeviceError,
+//!     DeviceVcpuId, Resource,
 //! };
 //!
 //! struct MyDevice {
@@ -55,15 +56,30 @@
 //!         &self.resources
 //!     }
 //!
-//!     fn access(
+//!     fn read(
 //!         &self,
-//!         access: &BusAccess,
-//!         context: &mut dyn DeviceAccess,
-//!     ) -> Result<BusResponse, DeviceError> {
-//!         match (access.kind, access.is_read) {
-//!             (BusKind::Mmio, true) => Ok(BusResponse::Read { value: 0 }),
-//!             (BusKind::Mmio, false) => Ok(BusResponse::Write),
-//!             _ => Err(DeviceError::OutOfRange { addr: access.addr }),
+//!         access: &DeviceAccess,
+//!         _context: &mut dyn DeviceContext,
+//!     ) -> Result<u64, DeviceError> {
+//!         match access.bus() {
+//!             BusKind::Mmio => Ok(0),
+//!             _ => Err(DeviceError::OutOfRange {
+//!                 addr: access.address(),
+//!             }),
+//!         }
+//!     }
+//!
+//!     fn write(
+//!         &self,
+//!         access: &DeviceAccess,
+//!         _value: u64,
+//!         _context: &mut dyn DeviceContext,
+//!     ) -> Result<(), DeviceError> {
+//!         match access.bus() {
+//!             BusKind::Mmio => Ok(()),
+//!             _ => Err(DeviceError::OutOfRange {
+//!                 addr: access.address(),
+//!             }),
 //!         }
 //!     }
 //! }
@@ -92,8 +108,8 @@ use alloc::{string::String, sync::Arc};
 pub use axvm_types::{GuestPhysAddr, GuestPhysAddrRange, InterruptTriggerMode, IrqLineId};
 
 pub use crate::device::{
-    AccessWidth, BusAccess, BusKind, BusResponse, DeviceAddr, DeviceAddrRange, DeviceError,
-    DeviceResult, Port, PortRange, SysRegAddr, SysRegAddrRange,
+    AccessWidth, BusKind, DeviceAccess, DeviceAddr, DeviceAddrRange, DeviceError, DeviceResult,
+    Port, PortRange, SysRegAddr, SysRegAddrRange,
 };
 
 // ---------------------------------------------------------------------------
@@ -113,6 +129,26 @@ impl DeviceId {
 
     /// Returns the raw `u32` value.
     pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+/// VM-local identity of the vCPU that issued one trapped device access.
+///
+/// This value describes the architectural accessor, not the physical CPU that
+/// happens to execute the device callback. It remains valid when exit handling
+/// is preempted or migrates between host CPUs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeviceVcpuId(usize);
+
+impl DeviceVcpuId {
+    /// Creates a device-access vCPU identifier from its VM-local value.
+    pub const fn new(id: usize) -> Self {
+        Self(id)
+    }
+
+    /// Returns the VM-local numeric identifier.
+    pub const fn as_usize(self) -> usize {
         self.0
     }
 }
@@ -271,8 +307,9 @@ pub enum RegistryError {
 ///
 /// Every emulated device (interrupt controller, UART, virtio-blk, …)
 /// implements this trait.  The device manager calls [`resources`](Device::resources)
-/// at registration time for conflict detection and [`access`](Device::access)
-/// on the hot path whenever a vCPU exit is dispatched to this device.
+/// at registration time for conflict detection and [`read`](Device::read) or
+/// [`write`](Device::write) on the hot path whenever a vCPU exit is dispatched
+/// to this device.
 ///
 /// Concrete collaboration between devices and architecture code should be
 /// exposed through typed services registered with the VM device runtime, not
@@ -290,12 +327,16 @@ pub trait Device: Send + Sync {
     /// path without allocation.
     fn resources(&self) -> &[Resource];
 
-    /// Handles a single bus access with runtime-scoped device context.
-    fn access(
+    /// Handles one guest read with runtime-scoped device capabilities.
+    fn read(&self, access: &DeviceAccess, context: &mut dyn DeviceContext) -> DeviceResult<u64>;
+
+    /// Handles one guest write with runtime-scoped device capabilities.
+    fn write(
         &self,
-        access: &BusAccess,
-        context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError>;
+        access: &DeviceAccess,
+        value: u64,
+        context: &mut dyn DeviceContext,
+    ) -> DeviceResult;
 }
 
 macro_rules! define_grant {
@@ -345,14 +386,27 @@ define_grant!(
     StopGrant
 );
 
-/// Context scoped to one device bus access.
+/// Guest-memory operations made available to a device runtime.
 ///
-/// A [`BusRouter`] creates this context immediately before calling
-/// [`Device::access`] and drops it before returning to the architecture exit
-/// handler. Sensitive abilities such as guest-memory DMA, timer scheduling,
-/// vCPU wake, and VM stop requests are denied by default and become available
-/// only when the current device presents the matching registration-time grant.
-pub trait DeviceAccess {
+/// This boundary deliberately carries no device identity or grant. The
+/// runtime validates those before delegating to this VM-owned memory port.
+pub trait GuestMemoryAccess {
+    /// Reads bytes from guest physical memory.
+    fn read(&mut self, addr: GuestPhysAddr, data: &mut [u8]) -> DeviceResult;
+
+    /// Writes bytes to guest physical memory.
+    fn write(&mut self, addr: GuestPhysAddr, data: &[u8]) -> DeviceResult;
+}
+
+/// Runtime capability context scoped to one device callback.
+///
+/// The device runtime creates this context immediately before calling
+/// [`Device::read`] or [`Device::write`] and drops it before returning to the
+/// architecture exit handler. Sensitive abilities such as guest-memory DMA,
+/// timer scheduling, vCPU wake, and VM stop requests are denied by default and
+/// become available only when the current device presents the matching
+/// registration-time grant.
+pub trait DeviceContext {
     /// Returns the identity of the device currently handling this access.
     fn device_id(&self) -> DeviceId;
 
@@ -409,19 +463,19 @@ pub trait DeviceAccess {
     }
 }
 
-/// A no-permission access context for tests and adapter-only callers.
-pub struct NoopDeviceAccess {
+/// A no-permission device context for tests and adapter-only callers.
+pub struct NoopDeviceContext {
     device_id: DeviceId,
 }
 
-impl NoopDeviceAccess {
+impl NoopDeviceContext {
     /// Creates a no-permission context for `device_id`.
     pub const fn new(device_id: DeviceId) -> Self {
         Self { device_id }
     }
 }
 
-impl DeviceAccess for NoopDeviceAccess {
+impl DeviceContext for NoopDeviceContext {
     fn device_id(&self) -> DeviceId {
         self.device_id
     }
@@ -438,20 +492,6 @@ pub trait DeviceRegistry {
     /// On success the device is assigned a unique [`DeviceId`] and inserted
     /// into the manager's lookup structures.
     fn register(&mut self, device: Arc<dyn Device>) -> Result<DeviceId, RegistryError>;
-}
-
-/// Bus dispatch interface — the runtime hot-path half of a
-/// [`DeviceRuntime`].
-///
-/// Called on every vCPU exit that targets an emulated device (MMIO / Port /
-/// SysReg).
-pub trait BusRouter {
-    /// Looks up the device responsible for `access` and forwards the access
-    /// to it, returning the result.
-    fn dispatch(&self, access: &BusAccess) -> Result<BusResponse, DeviceError>;
-
-    /// Looks up the device responsible for `access` without handling the access.
-    fn lookup(&self, access: &BusAccess) -> Result<Arc<dyn Device>, DeviceError>;
 }
 
 // ---------------------------------------------------------------------------

--- a/virtualization/axvirtio-blk/src/managed.rs
+++ b/virtualization/axvirtio-blk/src/managed.rs
@@ -4,8 +4,8 @@ use alloc::{boxed::Box, string::String, sync::Arc};
 
 use axaddrspace::GuestMemoryAccessor;
 use axdevice_base::{
-    BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, InterruptTriggerMode,
-    IrqLine, Resource,
+    BusKind, Device, DeviceAccess, DeviceContext, DeviceError, InterruptTriggerMode, IrqLine,
+    Resource,
 };
 use axvm_types::GuestPhysAddr;
 
@@ -75,44 +75,58 @@ where
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        if access.bus() != BusKind::Mmio {
             return Err(DeviceError::InvalidInput {
                 operation: "access virtio-block device",
                 detail: String::from("virtio-block only supports MMIO accesses"),
             });
         }
 
-        let address = GuestPhysAddr::from(access.addr as usize);
-        if access.is_read {
-            let value = self
-                .model
-                .mmio_read(address, access.width)
-                .map_err(map_virtio_error)?;
-            Ok(BusResponse::Read {
-                value: value as u64,
-            })
-        } else {
-            let interrupt_before = self.model.interrupt_status();
-            let reassert_interrupt = self
-                .model
-                .mmio_write(address, access.width, access.data as usize)
-                .map_err(map_virtio_error)?;
-            let interrupt_after = self.model.interrupt_status();
-            if reassert_interrupt == BlockDeviceEvent::InterruptPending
-                || interrupt_after & !interrupt_before != 0
-            {
-                self.irq.pulse().map_err(|error| DeviceError::Backend {
-                    operation: "pulse virtio-block interrupt",
-                    detail: alloc::format!("{error}"),
-                })?;
-            }
-            Ok(BusResponse::Write)
+        self.model
+            .mmio_read(
+                GuestPhysAddr::from(access.address() as usize),
+                access.width(),
+            )
+            .map(|value| value as u64)
+            .map_err(map_virtio_error)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::InvalidInput {
+                operation: "access virtio-block device",
+                detail: String::from("virtio-block only supports MMIO accesses"),
+            });
         }
+        let interrupt_before = self.model.interrupt_status();
+        let reassert_interrupt = self
+            .model
+            .mmio_write(
+                GuestPhysAddr::from(access.address() as usize),
+                access.width(),
+                value as usize,
+            )
+            .map_err(map_virtio_error)?;
+        let interrupt_after = self.model.interrupt_status();
+        if reassert_interrupt == BlockDeviceEvent::InterruptPending
+            || interrupt_after & !interrupt_before != 0
+        {
+            self.irq.pulse().map_err(|error| DeviceError::Backend {
+                operation: "pulse virtio-block interrupt",
+                detail: alloc::format!("{error}"),
+            })?;
+        }
+        Ok(())
     }
 }
 

--- a/virtualization/axvirtio-blk/tests/block_tests.rs
+++ b/virtualization/axvirtio-blk/tests/block_tests.rs
@@ -11,8 +11,9 @@ use std::{
 use ax_memory_addr::PhysAddr;
 use axaddrspace::{AddrSpaceError, AddrSpaceResult, GuestMemoryAccessor};
 use axdevice_base::{
-    BusAccess, BusKind, BusResponse, ControllerInputId, Device, DeviceId, InterruptControllerId,
-    InterruptTriggerMode, IrqResult, NoopDeviceAccess, Resource, WiredIrqInput, WiredIrqSink,
+    BusKind, ControllerInputId, Device, DeviceAccess, DeviceId, DeviceVcpuId,
+    InterruptControllerId, InterruptTriggerMode, IrqResult, NoopDeviceContext, Resource,
+    WiredIrqInput, WiredIrqSink,
 };
 use axvirtio_blk::{
     BlockBackend, ManagedVirtioBlockDevice, VirtioBlockConfig, VirtioMmioBlockDevice, VirtioResult,
@@ -910,18 +911,17 @@ fn managed_device_declares_resources_and_routes_mmio() {
             },
         ]
     );
-    let mut context = NoopDeviceAccess::new(DeviceId::new(0));
-    let response = device
-        .access(
-            &BusAccess {
-                kind: BusKind::Mmio,
-                is_read: true,
-                addr: 0x0a00_0000,
-                width: AccessWidth::Dword,
-                data: 0,
-            },
+    let mut context = NoopDeviceContext::new(DeviceId::new(0));
+    let value = device
+        .read(
+            &DeviceAccess::new(
+                DeviceVcpuId::new(0),
+                BusKind::Mmio,
+                0x0a00_0000,
+                AccessWidth::Dword,
+            ),
             &mut context,
         )
         .unwrap();
-    assert!(matches!(response, BusResponse::Read { value } if value == 0x7472_6976));
+    assert_eq!(value, 0x7472_6976);
 }

--- a/virtualization/axvirtio-net/src/managed.rs
+++ b/virtualization/axvirtio-net/src/managed.rs
@@ -4,8 +4,8 @@ use alloc::{boxed::Box, string::String, sync::Arc};
 
 use axaddrspace::GuestMemoryAccessor;
 use axdevice_base::{
-    BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, InterruptTriggerMode,
-    IrqLine, Resource,
+    BusKind, Device, DeviceAccess, DeviceContext, DeviceError, InterruptTriggerMode, IrqLine,
+    Resource,
 };
 use axvm_types::GuestPhysAddr;
 
@@ -80,40 +80,54 @@ where
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        if access.bus() != BusKind::Mmio {
             return Err(DeviceError::InvalidInput {
                 operation: "access virtio-net device",
                 detail: String::from("virtio-net only supports MMIO accesses"),
             });
         }
 
-        let address = GuestPhysAddr::from(access.addr as usize);
-        if access.is_read {
-            let value = self
-                .model
-                .mmio_read(address, access.width)
-                .map_err(map_virtio_error)?;
-            Ok(BusResponse::Read {
-                value: value as u64,
-            })
-        } else {
-            let event = self
-                .model
-                .mmio_write(address, access.width, access.data as usize)
-                .map_err(map_virtio_error)?;
-            if event == DeviceEvent::InterruptPending {
-                self.irq.pulse().map_err(|error| DeviceError::Backend {
-                    operation: "pulse virtio-net interrupt",
-                    detail: alloc::format!("{error}"),
-                })?;
-            }
-            Ok(BusResponse::Write)
+        self.model
+            .mmio_read(
+                GuestPhysAddr::from(access.address() as usize),
+                access.width(),
+            )
+            .map(|value| value as u64)
+            .map_err(map_virtio_error)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::InvalidInput {
+                operation: "access virtio-net device",
+                detail: String::from("virtio-net only supports MMIO accesses"),
+            });
         }
+        let event = self
+            .model
+            .mmio_write(
+                GuestPhysAddr::from(access.address() as usize),
+                access.width(),
+                value as usize,
+            )
+            .map_err(map_virtio_error)?;
+        if event == DeviceEvent::InterruptPending {
+            self.irq.pulse().map_err(|error| DeviceError::Backend {
+                operation: "pulse virtio-net interrupt",
+                detail: alloc::format!("{error}"),
+            })?;
+        }
+        Ok(())
     }
 }
 

--- a/virtualization/axvirtio-net/tests/net_tests.rs
+++ b/virtualization/axvirtio-net/tests/net_tests.rs
@@ -5,8 +5,9 @@ use std::sync::{Arc, Mutex};
 use ax_memory_addr::PhysAddr;
 use axaddrspace::GuestMemoryAccessor;
 use axdevice_base::{
-    BusAccess, BusKind, BusResponse, ControllerInputId, Device, DeviceId, InterruptControllerId,
-    InterruptTriggerMode, IrqResult, NoopDeviceAccess, Resource, WiredIrqInput, WiredIrqSink,
+    BusKind, ControllerInputId, Device, DeviceAccess, DeviceId, DeviceVcpuId,
+    InterruptControllerId, InterruptTriggerMode, IrqResult, NoopDeviceContext, Resource,
+    WiredIrqInput, WiredIrqSink,
 };
 // Re-export the MMIO register offsets from the common constants.
 use axvirtio_common::constants as vc;
@@ -830,21 +831,17 @@ fn managed_device_declares_resources_and_routes_mmio() {
             },
         ]
     );
-    let mut context = NoopDeviceAccess::new(DeviceId::new(0));
-    let response = device
-        .access(
-            &BusAccess {
-                kind: BusKind::Mmio,
-                is_read: true,
-                addr: BASE_IPA as u64,
-                width: AccessWidth::Dword,
-                data: 0,
-            },
+    let mut context = NoopDeviceContext::new(DeviceId::new(0));
+    let value = device
+        .read(
+            &DeviceAccess::new(
+                DeviceVcpuId::new(0),
+                BusKind::Mmio,
+                BASE_IPA as u64,
+                AccessWidth::Dword,
+            ),
             &mut context,
         )
         .unwrap();
-    assert!(matches!(
-        response,
-        BusResponse::Read { value } if value == vc::MMIO_MAGIC_VALUE as u64
-    ));
+    assert_eq!(value, vc::MMIO_MAGIC_VALUE as u64);
 }

--- a/virtualization/axvm/src/arch/aarch64/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/mod.rs
@@ -117,6 +117,7 @@ impl ArchOps for Aarch64Arch {
             ),
             ArmVmExit::MmioWrite { addr, width, data } => super::handle_mmio_write::<Self>(
                 vm,
+                vcpu,
                 MmioWriteExit {
                     addr: arm_guest_phys_addr_to_ax(addr),
                     width: arm_access_width_to_ax(width),
@@ -133,6 +134,7 @@ impl ArchOps for Aarch64Arch {
             ),
             ArmVmExit::SysRegWrite { addr, value } => sysreg::handle_write(
                 vm,
+                vcpu,
                 SysRegWriteExit {
                     addr: arm_sys_reg_addr_to_ax(addr),
                     value,

--- a/virtualization/axvm/src/arch/aarch64/shared_mmio.rs
+++ b/virtualization/axvm/src/arch/aarch64/shared_mmio.rs
@@ -3,7 +3,7 @@
 use std::{boxed::Box, string::String, sync::Arc, vec, vec::Vec};
 
 use axdevice_base::{
-    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, Resource,
+    AccessWidth, BusKind, Device, DeviceAccess, DeviceContext, DeviceError, Resource,
 };
 use rdif_clk::ClockMmioWriteProtection;
 
@@ -91,46 +91,50 @@ impl SharedMmioDevice {
         }
     }
 
-    fn handle_access(&self, access: &BusAccess) -> Result<BusResponse, DeviceError> {
+    fn read_access(&self, access: &DeviceAccess) -> Result<u64, DeviceError> {
         let offset = self.checked_offset(access)?;
-        if access.is_read {
-            return self
-                .backend
-                .read(offset, access.width)
-                .map(|value| BusResponse::Read { value });
-        }
+        self.backend.read(offset, access.width())
+    }
 
-        match filter_mmio_write(&self.protections, offset, access.width, access.data) {
+    fn write_access(&self, access: &DeviceAccess, value: u64) -> Result<(), DeviceError> {
+        let offset = self.checked_offset(access)?;
+        match filter_mmio_write(&self.protections, offset, access.width(), value) {
             FilteredMmioWrite::Forward(value) => {
-                self.backend.write(offset, access.width, value)?;
+                self.backend.write(offset, access.width(), value)?;
             }
             FilteredMmioWrite::Suppress => {}
         }
-        Ok(BusResponse::Write)
+        Ok(())
     }
 
-    fn checked_offset(&self, access: &BusAccess) -> Result<usize, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+    fn checked_offset(&self, access: &DeviceAccess) -> Result<usize, DeviceError> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
         let offset = access
-            .addr
+            .address()
             .checked_sub(self.base)
             .and_then(|offset| usize::try_from(offset).ok())
-            .ok_or(DeviceError::OutOfRange { addr: access.addr })?;
-        let width = access.width.size();
-        let end = offset
-            .checked_add(width)
-            .ok_or(DeviceError::OutOfRange { addr: access.addr })?;
+            .ok_or(DeviceError::OutOfRange {
+                addr: access.address(),
+            })?;
+        let width = access.width().size();
+        let end = offset.checked_add(width).ok_or(DeviceError::OutOfRange {
+            addr: access.address(),
+        })?;
         if end > self.length {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
         if !offset.is_multiple_of(width) {
             return Err(DeviceError::InvalidInput {
                 operation: "access shared MMIO provider",
                 detail: std::format!(
                     "unaligned {:?} access at provider offset {offset:#x}",
-                    access.width
+                    access.width()
                 ),
             });
         }
@@ -147,12 +151,21 @@ impl Device for SharedMmioDevice {
         &self.resources
     }
 
-    fn access(
+    fn read(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        self.handle_access(access)
+        access: &DeviceAccess,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<u64, DeviceError> {
+        self.read_access(access)
+    }
+
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> Result<(), DeviceError> {
+        self.write_access(access, value)
     }
 }
 
@@ -243,26 +256,15 @@ mod tests {
             backend.clone(),
         );
 
-        let read = device
-            .handle_access(&BusAccess {
-                kind: BusKind::Mmio,
-                is_read: true,
-                addr: 0x1370,
-                width: AccessWidth::Dword,
-                data: 0,
-            })
-            .unwrap();
-        assert!(matches!(read, BusResponse::Read { value: 0x1122_3344 }));
+        let access = DeviceAccess::new(
+            axdevice_base::DeviceVcpuId::new(0),
+            BusKind::Mmio,
+            0x1370,
+            AccessWidth::Dword,
+        );
+        assert_eq!(device.read_access(&access).unwrap(), 0x1122_3344);
 
-        device
-            .handle_access(&BusAccess {
-                kind: BusKind::Mmio,
-                is_read: false,
-                addr: 0x1370,
-                width: AccessWidth::Dword,
-                data: 0x0019_0019,
-            })
-            .unwrap();
+        device.write_access(&access, 0x0019_0019).unwrap();
         assert_eq!(
             backend.writes.lock().unwrap().as_slice(),
             &[(0x370, AccessWidth::Dword, 0x0010_0010)]
@@ -291,13 +293,15 @@ mod tests {
         );
 
         device
-            .handle_access(&BusAccess {
-                kind: BusKind::Mmio,
-                is_read: false,
-                addr: 0x1200,
-                width: AccessWidth::Dword,
-                data: 0,
-            })
+            .write_access(
+                &DeviceAccess::new(
+                    axdevice_base::DeviceVcpuId::new(0),
+                    BusKind::Mmio,
+                    0x1200,
+                    AccessWidth::Dword,
+                ),
+                0,
+            )
             .unwrap();
 
         assert_eq!(

--- a/virtualization/axvm/src/arch/aarch64/vgic/mod.rs
+++ b/virtualization/axvm/src/arch/aarch64/vgic/mod.rs
@@ -237,9 +237,7 @@ impl DeviceModel for Aarch64VgicFactory {
                 detail: std::format!("{error}"),
             }
         })?;
-        let access_context: Arc<dyn VgicAccessContext> =
-            Arc::new(AxvmVgicAccessContext { vm_id: self.vm_id });
-        let devices = VgicDeviceSet::new(runtime.core.clone(), access_context)
+        let devices = VgicDeviceSet::new(runtime.core.clone())
             .map_err(|error| vgic_device_error("build AArch64 virtual GIC frontends", error))?;
         let mut bundle = DeviceBundle::new();
         for device in devices.into_devices() {
@@ -256,18 +254,6 @@ impl DeviceModel for Aarch64VgicFactory {
         }
         bundle.push(DeviceRegistration::InterruptController(registration));
         bundle.with_service::<Aarch64VgicRuntimeKey>(runtime)
-    }
-}
-
-struct AxvmVgicAccessContext {
-    vm_id: usize,
-}
-
-impl VgicAccessContext for AxvmVgicAccessContext {
-    fn current_vcpu(&self) -> Option<usize> {
-        (crate::current_vm_id() == Some(self.vm_id))
-            .then(crate::current_vcpu_id)
-            .flatten()
     }
 }
 

--- a/virtualization/axvm/src/arch/loongarch64/mod.rs
+++ b/virtualization/axvm/src/arch/loongarch64/mod.rs
@@ -129,6 +129,7 @@ impl ArchOps for LoongArch64Arch {
             ),
             LoongArchVmExit::MmioWrite { addr, width, data } => super::handle_mmio_write::<Self>(
                 vm,
+                vcpu,
                 MmioWriteExit {
                     addr: loong_guest_phys_addr_to_ax(addr),
                     width: loong_access_width_to_ax(width),
@@ -228,6 +229,7 @@ fn handle_loongarch_nested_page_fault(
             LoongArchVmExit::MmioWrite { addr, width, data } => {
                 super::try_handle_mmio_write::<LoongArch64Arch>(
                     vm,
+                    vcpu,
                     MmioWriteExit {
                         addr: loong_guest_phys_addr_to_ax(addr),
                         width: loong_access_width_to_ax(width),

--- a/virtualization/axvm/src/arch/riscv64/irq/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/irq/mod.rs
@@ -265,33 +265,41 @@ impl Device for RiscvPlicDevice {
         self.runtime.vplic.resources()
     }
 
-    fn access(
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
+        }
+        self.runtime
+            .vplic
+            .read_register(
+                GuestPhysAddr::from_usize(access.address() as usize),
+                access.width(),
+            )
+            .map(|value| value as u64)
+    }
+
+    fn write(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
-        let addr = GuestPhysAddr::from_usize(access.addr as usize);
-        if access.is_read {
-            self.runtime
-                .vplic
-                .read_register(addr, access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-        } else {
-            let completion = self.runtime.vplic.write_register_with_completion(
-                addr,
-                access.width,
-                access.data as usize,
-            )?;
-            if let Some(completion) = completion {
-                self.runtime.physical.complete_source(completion.source());
-            }
-            Ok(BusResponse::Write)
+        let completion = self.runtime.vplic.write_register_with_completion(
+            GuestPhysAddr::from_usize(access.address() as usize),
+            access.width(),
+            value as usize,
+        )?;
+        if let Some(completion) = completion {
+            self.runtime.physical.complete_source(completion.source());
         }
+        Ok(())
     }
 }
 

--- a/virtualization/axvm/src/arch/riscv64/mod.rs
+++ b/virtualization/axvm/src/arch/riscv64/mod.rs
@@ -245,7 +245,7 @@ fn handle_riscv_mmio_write(
     vcpu: &crate::vm::AxVCpuRef<AxvmRiscvVcpu>,
     exit: MmioWriteExit,
 ) -> AxVmResult<BoundVcpuExit<RiscvDeferredRunWork>> {
-    let result = super::handle_mmio_write::<Riscv64Arch>(vm, exit)?;
+    let result = super::handle_mmio_write::<Riscv64Arch>(vm, vcpu, exit)?;
     sync_vplic_vseip(vm, vcpu)?;
     Ok(result)
 }
@@ -291,6 +291,7 @@ fn handle_riscv_nested_page_fault(
             RiscvVmExit::MmioWrite { addr, width, data } => {
                 super::try_handle_mmio_write::<Riscv64Arch>(
                     vm,
+                    vcpu,
                     MmioWriteExit {
                         addr: riscv_guest_phys_addr_to_ax(addr),
                         width: riscv_access_width_to_ax(width),

--- a/virtualization/axvm/src/arch/x86_64/exit.rs
+++ b/virtualization/axvm/src/arch/x86_64/exit.rs
@@ -1,5 +1,6 @@
 //! x86-only port, nested-fault, and deferred exit handling.
 
+use axdevice_base::{BusKind, DeviceAccess, DeviceVcpuId};
 use axvm_types::{AccessWidth, GuestPhysAddr, MappingFlags, Port};
 use x86_vcpu::{X86PortIoDirection, X86PortIoStringExit};
 
@@ -36,10 +37,17 @@ pub(crate) fn handle_io_read(
     vcpu: &crate::vm::AxVCpuRef<AxvmX86Vcpu>,
     exit: IoReadExit,
 ) -> AxVmResult<BoundVcpuExit<DeferredRunWork>> {
-    let devices = vm.get_devices()?;
-    let val = devices
-        .try_handle_port_read(exit.port, exit.width)
+    let access = DeviceAccess::new(
+        DeviceVcpuId::new(vcpu.id()),
+        BusKind::Port,
+        exit.port.number() as u64,
+        exit.width,
+    );
+    let val = vm
+        .get_devices()?
+        .try_read(&access)
         .map_err(|error| AxVmError::device("read guest I/O port", error))?
+        .map(|value| value as usize)
         .unwrap_or_else(|| unmapped_port_value(exit.width));
     vcpu.set_gpr(0, val);
     Ok(BoundVcpuExit::Continue)
@@ -47,9 +55,16 @@ pub(crate) fn handle_io_read(
 
 pub(crate) fn handle_io_write(
     vm: &crate::AxVM,
+    vcpu: &crate::vm::AxVCpuRef<AxvmX86Vcpu>,
     exit: IoWriteExit,
 ) -> AxVmResult<BoundVcpuExit<DeferredRunWork>> {
-    vm.try_handle_port_write(exit.port, exit.width, exit.data as usize)
+    let access = DeviceAccess::new(
+        DeviceVcpuId::new(vcpu.id()),
+        BusKind::Port,
+        exit.port.number() as u64,
+        exit.width,
+    );
+    vm.try_write_device(&access, exit.data)
         .map_err(|error| AxVmError::device("write guest I/O port", error))?;
     Ok(BoundVcpuExit::Continue)
 }
@@ -63,13 +78,20 @@ pub(crate) fn handle_io_string(
     let width = super::x86_access_width_to_ax(exit.width());
     let size = width.size();
     let guest_paddr = super::x86_guest_phys_addr_to_ax(exit.guest_paddr());
+    let access = DeviceAccess::new(
+        DeviceVcpuId::new(vcpu.id()),
+        BusKind::Port,
+        port.number() as u64,
+        width,
+    );
 
     match exit.direction() {
         X86PortIoDirection::In => {
-            let devices = vm.get_devices()?;
-            let value = devices
-                .try_handle_port_read(port, width)
+            let value = vm
+                .get_devices()?
+                .try_read(&access)
                 .map_err(|error| AxVmError::device("read guest string I/O port", error))?
+                .map(|value| value as usize)
                 .unwrap_or_else(|| unmapped_port_value(width));
             vm.write_to_guest(guest_paddr, &value.to_le_bytes()[..size])?;
         }
@@ -77,7 +99,7 @@ pub(crate) fn handle_io_string(
             let mut bytes = [0u8; 8];
             vm.read_from_guest(guest_paddr, &mut bytes[..size])?;
             let value = u64::from_le_bytes(bytes);
-            vm.try_handle_port_write(port, width, value as usize)
+            vm.try_write_device(&access, value)
                 .map_err(|error| AxVmError::device("write guest string I/O port", error))?;
         }
     }

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -109,6 +109,7 @@ impl ArchOps for X86_64Arch {
             ),
             X86VmExit::PortIoWrite { port, width, data } => exit::handle_io_write(
                 vm,
+                vcpu,
                 IoWriteExit {
                     port: x86_port_to_ax(port),
                     width: x86_access_width_to_ax(width),
@@ -135,6 +136,7 @@ impl ArchOps for X86_64Arch {
             ),
             X86VmExit::MmioWrite { addr, width, data } => super::handle_mmio_write::<Self>(
                 vm,
+                vcpu,
                 MmioWriteExit {
                     addr: x86_guest_phys_addr_to_ax(addr),
                     width: x86_access_width_to_ax(width),
@@ -151,6 +153,7 @@ impl ArchOps for X86_64Arch {
             ),
             X86VmExit::MsrWrite { addr, value } => sysreg::handle_write(
                 vm,
+                vcpu,
                 SysRegWriteExit {
                     addr: x86_msr_addr_to_ax(addr),
                     value,

--- a/virtualization/axvm/src/arch/x86_64/port.rs
+++ b/virtualization/axvm/src/arch/x86_64/port.rs
@@ -156,25 +156,29 @@ impl Device for HostPortPassthrough {
         &self.resources
     }
 
-    fn access(
-        &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Port || access.addr > u16::MAX as u64 {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
-        }
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        self.read_port(self.port(access)?, access.width())
+            .map(|value| value as u64)
+    }
 
-        let port = Port::new(access.addr as u16);
-        if access.is_read {
-            self.read_port(port, access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-        } else {
-            self.write_port(port, access.width, access.data as usize)
-                .map(|_| BusResponse::Write)
+    fn write(
+        &self,
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        self.write_port(self.port(access)?, access.width(), value as usize)
+    }
+}
+
+impl HostPortPassthrough {
+    fn port(&self, access: &DeviceAccess) -> DeviceResult<Port> {
+        if access.bus() != BusKind::Port || access.address() > u16::MAX as u64 {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
+        Ok(Port::new(access.address() as u16))
     }
 }
 

--- a/virtualization/axvm/src/architecture/exit.rs
+++ b/virtualization/axvm/src/architecture/exit.rs
@@ -1,5 +1,6 @@
 //! Architecture-neutral handlers for exits shared by every guest architecture.
 
+use axdevice_base::{BusKind, DeviceAccess, DeviceVcpuId};
 use axvm_types::VmArchVcpuOps;
 
 use super::{ArchOps, BoundVcpuExit, HypercallExit, MmioReadExit, MmioWriteExit, VcpuRunAction};
@@ -21,14 +22,20 @@ pub(crate) fn try_handle_mmio_read<V: VmArchVcpuOps>(
     vcpu: &crate::vm::AxVCpuRef<V>,
     exit: MmioReadExit,
 ) -> AxVmResult<bool> {
+    let access = DeviceAccess::new(
+        DeviceVcpuId::new(vcpu.id()),
+        BusKind::Mmio,
+        exit.addr.as_usize() as u64,
+        exit.width,
+    );
     let Some(raw) = vm
         .get_devices()?
-        .try_handle_mmio_read(exit.addr, exit.width)
+        .try_read(&access)
         .map_err(|error| AxVmError::device("read guest MMIO", error))?
     else {
         return Ok(false);
     };
-    let masked = raw & crate::vm::width_mask(exit.width);
+    let masked = raw as usize & crate::vm::width_mask(exit.width);
     let val = if exit.signed_ext {
         crate::vm::sign_extend_value(masked, exit.width)
     } else {
@@ -40,9 +47,10 @@ pub(crate) fn try_handle_mmio_read<V: VmArchVcpuOps>(
 
 pub(crate) fn handle_mmio_write<A: ArchOps>(
     vm: &crate::AxVMRef,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
     exit: MmioWriteExit,
 ) -> AxVmResult<BoundVcpuExit<A::DeferredRunWork>> {
-    if !try_handle_mmio_write::<A>(vm, exit)? {
+    if !try_handle_mmio_write::<A>(vm, vcpu, exit)? {
         return Err(missing_mmio_error("write", exit.addr, exit.width));
     }
     Ok(BoundVcpuExit::Continue)
@@ -50,9 +58,16 @@ pub(crate) fn handle_mmio_write<A: ArchOps>(
 
 pub(crate) fn try_handle_mmio_write<A: ArchOps>(
     vm: &crate::AxVMRef,
+    vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
     exit: MmioWriteExit,
 ) -> AxVmResult<bool> {
-    let handled = vm.try_handle_mmio_write(exit.addr, exit.width, exit.data as usize)?;
+    let access = DeviceAccess::new(
+        DeviceVcpuId::new(vcpu.id()),
+        BusKind::Mmio,
+        exit.addr.as_usize() as u64,
+        exit.width,
+    );
+    let handled = vm.try_write_device(&access, exit.data)?;
     if handled {
         A::after_mmio_write(vm);
     }

--- a/virtualization/axvm/src/architecture/sysreg.rs
+++ b/virtualization/axvm/src/architecture/sysreg.rs
@@ -1,5 +1,7 @@
 //! Shared system-register device exits used by AArch64 and x86_64 guests.
 
+use axdevice::DeviceManagerError;
+use axdevice_base::{BusKind, DeviceAccess, DeviceError, DeviceVcpuId};
 use axvm_types::{AccessWidth, SysRegAddr, VmArchVcpuOps};
 
 use crate::{AxVmError, AxVmResult, architecture::BoundVcpuExit};
@@ -21,20 +23,46 @@ pub(crate) fn handle_read<V: VmArchVcpuOps, D>(
     vcpu: &crate::vm::AxVCpuRef<V>,
     exit: SysRegReadExit,
 ) -> AxVmResult<BoundVcpuExit<D>> {
+    let access = sysreg_access(vcpu.id(), exit.addr);
     let val = vm
         .get_devices()?
-        .handle_sys_reg_read(exit.addr, AccessWidth::Qword)
-        .map_err(|error| AxVmError::device("read guest system register", error))?;
-    vcpu.set_gpr(exit.reg, val);
+        .try_read(&access)
+        .map_err(|error| AxVmError::device("read guest system register", error))?
+        .ok_or_else(|| missing_sysreg_error("read", exit.addr))?;
+    vcpu.set_gpr(exit.reg, val as usize);
     Ok(BoundVcpuExit::Continue)
 }
 
-pub(crate) fn handle_write<D>(
+pub(crate) fn handle_write<V: VmArchVcpuOps, D>(
     vm: &crate::AxVM,
+    vcpu: &crate::vm::AxVCpuRef<V>,
     exit: SysRegWriteExit,
 ) -> AxVmResult<BoundVcpuExit<D>> {
-    vm.get_devices()?
-        .handle_sys_reg_write(exit.addr, AccessWidth::Qword, exit.value as usize)
-        .map_err(|error| AxVmError::device("write guest system register", error))?;
+    let access = sysreg_access(vcpu.id(), exit.addr);
+    if !vm.try_write_device(&access, exit.value)? {
+        return Err(missing_sysreg_error("write", exit.addr));
+    }
     Ok(BoundVcpuExit::Continue)
+}
+
+fn sysreg_access(vcpu_id: usize, addr: SysRegAddr) -> DeviceAccess {
+    DeviceAccess::new(
+        DeviceVcpuId::new(vcpu_id),
+        BusKind::SysReg,
+        addr.addr() as u64,
+        AccessWidth::Qword,
+    )
+}
+
+fn missing_sysreg_error(operation: &'static str, addr: SysRegAddr) -> AxVmError {
+    AxVmError::device(
+        "access guest system register",
+        DeviceManagerError::Access {
+            operation,
+            bus: BusKind::SysReg,
+            addr: addr.addr() as u64,
+            width: AccessWidth::Qword,
+            source: DeviceError::NotFound,
+        },
+    )
 }

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -630,7 +630,7 @@ fn poll_vm_dma_devices(vm: &VMRef) {
         return;
     };
     let now_ns = ax_std::os::arceos::modules::ax_hal::time::monotonic_time_nanos();
-    let mut memory = crate::vm::VmDmaAccess::new(vm);
+    let mut memory = crate::vm::VmGuestMemoryAccess::new(vm);
     devices.poll_dma_devices(now_ns, &mut memory, |result| {
         if let Err(error) = result {
             warn!("VM[{}] failed to poll DMA virtual device: {error}", vm.id());

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -55,26 +55,18 @@ pub(crate) type AxVCpuRef<A = crate::arch::ArchVCpu> = Arc<AxVCpu<A>>;
 /// A reference to a VM.
 pub type AxVMRef = Arc<AxVM>;
 
-pub(crate) struct VmDmaAccess<'a> {
+pub(crate) struct VmGuestMemoryAccess<'a> {
     vm: &'a AxVM,
 }
 
-impl<'a> VmDmaAccess<'a> {
+impl<'a> VmGuestMemoryAccess<'a> {
     pub(crate) const fn new(vm: &'a AxVM) -> Self {
         Self { vm }
     }
 }
 
-impl DeviceAccess for VmDmaAccess<'_> {
-    fn device_id(&self) -> DeviceId {
-        DeviceId::new(0)
-    }
-    fn read_guest_memory(
-        &mut self,
-        _grant: &DmaGrant,
-        addr: GuestPhysAddr,
-        data: &mut [u8],
-    ) -> DeviceResult {
+impl GuestMemoryAccess for VmGuestMemoryAccess<'_> {
+    fn read(&mut self, addr: GuestPhysAddr, data: &mut [u8]) -> DeviceResult {
         self.vm
             .read_from_guest(addr, data)
             .map_err(|error| axdevice_base::DeviceError::Backend {
@@ -82,12 +74,7 @@ impl DeviceAccess for VmDmaAccess<'_> {
                 detail: std::format!("{error}"),
             })
     }
-    fn write_guest_memory(
-        &mut self,
-        _grant: &DmaGrant,
-        addr: GuestPhysAddr,
-        data: &[u8],
-    ) -> DeviceResult {
+    fn write(&mut self, addr: GuestPhysAddr, data: &[u8]) -> DeviceResult {
         self.vm
             .write_to_guest(addr, data)
             .map_err(|error| axdevice_base::DeviceError::Backend {
@@ -1572,29 +1559,11 @@ impl AxVM {
         AxVmDeviceAccessPorts::new(self.id()).into_ports()
     }
 
-    pub(crate) fn try_handle_mmio_write(
-        &self,
-        addr: GuestPhysAddr,
-        width: AccessWidth,
-        data: usize,
-    ) -> AxVmResult<bool> {
+    pub(crate) fn try_write_device(&self, access: &DeviceAccess, value: u64) -> AxVmResult<bool> {
         let devices = self.get_devices()?;
-        let mut memory = VmDmaAccess { vm: self };
+        let mut memory = VmGuestMemoryAccess { vm: self };
         devices
-            .try_handle_mmio_write_with_memory(addr, width, data, &mut memory)
-            .map_err(Into::into)
-    }
-
-    pub(crate) fn try_handle_port_write(
-        &self,
-        port: Port,
-        width: AccessWidth,
-        data: usize,
-    ) -> AxVmResult<bool> {
-        let devices = self.get_devices()?;
-        let mut memory = VmDmaAccess { vm: self };
-        devices
-            .try_handle_port_write_with_memory(port, width, data, &mut memory)
+            .try_write(access, value, Some(&mut memory))
             .map_err(Into::into)
     }
 

--- a/virtualization/riscv_vplic/src/devops_impl.rs
+++ b/virtualization/riscv_vplic/src/devops_impl.rs
@@ -3,7 +3,7 @@
 //! Implements V3 device-access handling for MMIO read/write operations.
 
 use axdevice_base::{
-    AccessWidth, BusAccess, BusKind, BusResponse, Device, DeviceAccess, DeviceError, DeviceResult,
+    AccessWidth, BusKind, Device, DeviceAccess, DeviceContext, DeviceError, DeviceResult,
 };
 use axvm_types::GuestPhysAddr;
 use bitmaps::Bitmap;
@@ -462,24 +462,35 @@ impl Device for VPlicGlobal {
         &self.resources
     }
 
-    fn access(
+    fn read(&self, access: &DeviceAccess, _context: &mut dyn DeviceContext) -> DeviceResult<u64> {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
+        }
+        self.read_register(
+            GuestPhysAddr::from_usize(access.address() as usize),
+            access.width(),
+        )
+        .map(|value| value as u64)
+    }
+
+    fn write(
         &self,
-        access: &BusAccess,
-        _context: &mut dyn DeviceAccess,
-    ) -> Result<BusResponse, DeviceError> {
-        if access.kind != BusKind::Mmio {
-            return Err(DeviceError::OutOfRange { addr: access.addr });
+        access: &DeviceAccess,
+        value: u64,
+        _context: &mut dyn DeviceContext,
+    ) -> DeviceResult {
+        if access.bus() != BusKind::Mmio {
+            return Err(DeviceError::OutOfRange {
+                addr: access.address(),
+            });
         }
-        let addr = GuestPhysAddr::from_usize(access.addr as usize);
-        if access.is_read {
-            self.read_register(addr, access.width)
-                .map(|value| BusResponse::Read {
-                    value: value as u64,
-                })
-        } else {
-            self.write_register(addr, access.width, access.data as usize)
-                .map(|_| BusResponse::Write)
-        }
+        self.write_register(
+            GuestPhysAddr::from_usize(access.address() as usize),
+            access.width(),
+            value as usize,
+        )
     }
 }
 


### PR DESCRIPTION
## 问题

现有设备访问边界混合了“本次访问的事实”和“设备运行能力”：行为型 `DeviceAccess` 同时承担 DMA、定时器、唤醒等上下文，而总线请求通过统一 `access()`、读写布尔值和复用数据槽表达。#2092 原方案虽然为 VGIC MMIO 补充了可选 vCPU 身份，但 PIO、SysReg 和无身份 helper 仍可绕开该约束，且 source vCPU 仍不是类型系统强制的 transaction 属性。

这会直接破坏 GICv2 PMR、SGI/PPI 和 distributor banked 状态隔离：执行回调的 host CPU、任务或 TLS 不是发起 VM-exit 的 guest vCPU，vCPU 迁移、抢占、并发和嵌套回调都可能选择错误 bank。

## 架构选择

本次采用组合设计：

- 遵循 Linux KVM 语义：每次 guest 设备访问显式携带发起访问的 vCPU。
- 采用 crosvm 的 transaction 模型：source vCPU 属于单次请求，不属于设备运行环境。
- 采用 QEMU/rust-vmm 的接口形态：读写拆分，由方法签名表达输入和返回值。
- 保留 TGOSKits 的 `&self + Send + Sync` 与设备内部细粒度同步，不引入全局设备锁。
- 不采用 QEMU 隐式 `current_cpu`、TLS、VM-global current-vCPU slot、per-vCPU bus clone 或开放属性袋。

## 变更

### 公共边界

- 将原行为型 `DeviceAccess` 重命名为 `DeviceContext`，只提供 DMA、定时器、唤醒和 VM 控制等受 grant 约束的运行能力。
- 新建字段私有且完整构造的不可变 `DeviceAccess`：强制包含 `DeviceVcpuId`、`BusKind`、地址和 `AccessWidth`。
- 将 `Device::access()` 拆为：
  - `read(&self, access, context) -> DeviceResult<u64>`
  - `write(&self, access, value, context) -> DeviceResult<()>`
- 删除 `BusResponse`、`is_read`、读写复用数据参数、可选 source vCPU、无身份 guest helper 和兼容适配层。
- `DeviceRuntime` 热路径只保留 `try_read()` / `try_write()`。
- VM 内存继续通过独立 `GuestMemoryAccess` capability 注入 `DeviceContext`，不能从请求或 vCPU 反向取得 VM。

### 全量迁移

- 一次性迁移 MMIO、x86 PIO、AArch64 SysReg/x86 MSR 以及 AArch64、RISC-V、x86_64、LoongArch64 四架构退出路径。
- 迁移串口、fw_cfg、x86 平台设备、LoongArch PCH-PIC、vPLIC、VGIC、virtio-blk/net 和 Axvisor 适配器。
- VGIC 只用 `access.source_vcpu()` 选择 GICv2 CPU interface 与 distributor bank；IRQ target vCPU 仍由路由状态决定。测试覆盖 source vCPU 0 将 SPI 路由到 target vCPU 1。
- 删除冗余 `DistributorVersion`。V2/V3 只作为 guest 可见硬件协议与构造期拓扑选择：banked distributor + GICC 和 shared/affinity distributor + GICR/ICC/ITS 最终读写同一个 `VgicCore` canonical state；设备对象不保存版本字段，访问热路径不做版本分派。
- 架构说明和模拟设备文档已统一改为中文。
- PR diff 不包含任何 changelog 修改，继续由 release-plz 自动生成。

## 确定性 red/green

先在旧接口上加入 `vcpu_port_dispatch_propagates_the_explicit_accessor`，同一测试稳定失败：设备观察到 `None`，预期 `Some(DeviceVcpuId(7))`。完成 mandatory request 重构后，同一测试通过。

VGIC 回归还覆盖：

- 同一 host CPU 交替访问两个 guest vCPU 的 PMR 与 banked distributor 隔离；
- 两个 host thread 并发访问的 PMR 隔离；
- source vCPU 与 IRQ target vCPU 不同；
- MMIO、PIO、SysReg source 传播；
- DMA grant、跨界访问和只读/只写错误传播。

## 本地验证

当前 head 已 rebase 到最新 `dev@4504a04772`。

- 受影响 crate 完整测试：全部通过（`axdevice_base`、`axdevice`、`arm_vgic`、`riscv_vplic`、`axvirtio-blk`、`axvirtio-net`）。
- `cargo xtask clippy`：7 个 package、17 个配置全部通过；`axvisor` 按 xtask 要求由专用构建流程验证。
- Axvisor release build：AArch64、RISC-V64、x86_64、LoongArch64 全部通过。
- AArch64 QEMU GICv2 2-vCPU：通过，命中 `AXVISOR_GICV2_TIMER_STRESS_PASSED`。
- AArch64 QEMU GICv3+ITS 4-vCPU：通过，命中 `AXVISOR_GICV3_ITS_TIMER_STRESS_PASSED`。
- `cargo fmt --all -- --check`、`git diff --check`：通过。
- 静态确认：无 changelog、无 `BusResponse`、无 `VgicAccessContext`、无 `DistributorVersion`、无可选 source、无旧 `Device::access()` 或布尔读写分支。

## 相关 PR

- #2090 仍独立处理 RISC-V VSEIP 持久化；本 PR 已基于最新 dev 重放 RISC-V 设备退出路径，未复制其状态机修复。
- #1775 后续需要迁移到本 PR 的最终 mandatory access API，不在此处保留临时兼容层。

## 提交

1. `refactor(axdevice)!: introduce typed vCPU device access`
2. `docs(axdevice): define device access ownership in Chinese`
