### PR TITLE
fix(ax-mm): free frame after lazy remap failure

### DIFF
--- a/os/arceos/modules/axmm/Cargo.toml
+++ b/os/arceos/modules/axmm/Cargo.toml
@@ -20,3 +20,6 @@ ax-memory-addr.workspace = true
 ax-memory-set.workspace = true
 page-table-generic = { workspace = true, optional = true }
 thiserror.workspace = true
+
+[dev-dependencies]
+ax-hal = { workspace = true, features = ["host-test"] }

--- a/os/arceos/modules/axmm/Cargo.toml
+++ b/os/arceos/modules/axmm/Cargo.toml
@@ -22,4 +22,4 @@ page-table-generic = { workspace = true, optional = true }
 thiserror.workspace = true
 
 [dev-dependencies]
-ax-hal = { workspace = true, features = ["host-test"] }
+ax-hal = { path = "../axhal", features = ["host-test"] }

--- a/os/arceos/modules/axmm/src/backend/alloc.rs
+++ b/os/arceos/modules/axmm/src/backend/alloc.rs
@@ -92,12 +92,30 @@ impl Backend {
     ) -> bool {
         if populate {
             false // Populated mappings should not trigger page faults.
-        } else if let Some(frame) = alloc_frame(true) {
-            // Allocate a physical frame lazily and map it to the fault address.
-            pt.remap_page(vaddr, frame, orig_flags).is_ok()
         } else {
-            false
+            // Allocate a physical frame lazily and map it to the fault address.
+            remap_frame_or_dealloc(
+                alloc_frame(true),
+                |frame| pt.remap_page(vaddr, frame, orig_flags).is_ok(),
+                dealloc_frame,
+            )
         }
+    }
+}
+
+fn remap_frame_or_dealloc(
+    frame: Option<PhysAddr>,
+    remap_frame: impl FnOnce(PhysAddr) -> bool,
+    dealloc_frame: impl FnOnce(PhysAddr),
+) -> bool {
+    let Some(frame) = frame else {
+        return false;
+    };
+    if remap_frame(frame) {
+        true
+    } else {
+        dealloc_frame(frame);
+        false
     }
 }
 
@@ -168,6 +186,7 @@ fn rollback_populated_pages(ops: &mut impl PopulatePageOps, start: VirtAddr, map
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
+    use core::cell::Cell;
 
     use super::*;
 
@@ -193,6 +212,32 @@ mod tests {
         assert!(!populate_pages(&mut ops, start, 3 * PAGE_SIZE_4K));
         assert!(ops.mapped.is_empty());
         assert_eq!(ops.deallocated, [PhysAddr::from(PAGE_SIZE_4K)]);
+    }
+
+    #[test]
+    fn keeps_lazy_frame_when_remap_succeeds() {
+        let frame = PhysAddr::from(PAGE_SIZE_4K);
+        let deallocated = Cell::new(None);
+
+        assert!(remap_frame_or_dealloc(
+            Some(frame),
+            |_| true,
+            |frame| deallocated.set(Some(frame)),
+        ));
+        assert_eq!(deallocated.get(), None);
+    }
+
+    #[test]
+    fn deallocates_lazy_frame_when_remap_fails() {
+        let frame = PhysAddr::from(PAGE_SIZE_4K);
+        let deallocated = Cell::new(None);
+
+        assert!(!remap_frame_or_dealloc(
+            Some(frame),
+            |_| false,
+            |frame| deallocated.set(Some(frame)),
+        ));
+        assert_eq!(deallocated.get(), Some(frame));
     }
 
     struct MockPopulatePageOps {

--- a/os/arceos/modules/axmm/src/backend/alloc.rs
+++ b/os/arceos/modules/axmm/src/backend/alloc.rs
@@ -94,29 +94,23 @@ impl Backend {
             false // Populated mappings should not trigger page faults.
         } else {
             // Allocate a physical frame lazily and map it to the fault address.
-            remap_frame_or_dealloc(
-                alloc_frame(true),
-                |frame| pt.remap_page(vaddr, frame, orig_flags).is_ok(),
-                dealloc_frame,
-            )
+            // Keep ownership of an unused frame with the fault path so a remap
+            // failure does not re-enter the allocator from the trap context.
+            remap_allocated_frame(alloc_frame(true), |frame| {
+                pt.remap_page(vaddr, frame, orig_flags).is_ok()
+            })
         }
     }
 }
 
-fn remap_frame_or_dealloc(
+fn remap_allocated_frame(
     frame: Option<PhysAddr>,
     remap_frame: impl FnOnce(PhysAddr) -> bool,
-    dealloc_frame: impl FnOnce(PhysAddr),
 ) -> bool {
     let Some(frame) = frame else {
         return false;
     };
-    if remap_frame(frame) {
-        true
-    } else {
-        dealloc_frame(frame);
-        false
-    }
+    remap_frame(frame)
 }
 
 trait PopulatePageOps {
@@ -186,7 +180,6 @@ fn rollback_populated_pages(ops: &mut impl PopulatePageOps, start: VirtAddr, map
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
-    use core::cell::Cell;
 
     use super::*;
 
@@ -217,27 +210,15 @@ mod tests {
     #[test]
     fn keeps_lazy_frame_when_remap_succeeds() {
         let frame = PhysAddr::from(PAGE_SIZE_4K);
-        let deallocated = Cell::new(None);
 
-        assert!(remap_frame_or_dealloc(
-            Some(frame),
-            |_| true,
-            |frame| deallocated.set(Some(frame)),
-        ));
-        assert_eq!(deallocated.get(), None);
+        assert!(remap_allocated_frame(Some(frame), |_| true));
     }
 
     #[test]
-    fn deallocates_lazy_frame_when_remap_fails() {
+    fn keeps_lazy_frame_owned_by_fault_path_when_remap_fails() {
         let frame = PhysAddr::from(PAGE_SIZE_4K);
-        let deallocated = Cell::new(None);
 
-        assert!(!remap_frame_or_dealloc(
-            Some(frame),
-            |_| false,
-            |frame| deallocated.set(Some(frame)),
-        ));
-        assert_eq!(deallocated.get(), Some(frame));
+        assert!(!remap_allocated_frame(Some(frame), |_| false));
     }
 
     struct MockPopulatePageOps {

--- a/os/arceos/modules/axmm/src/backend/alloc.rs
+++ b/os/arceos/modules/axmm/src/backend/alloc.rs
@@ -94,23 +94,29 @@ impl Backend {
             false // Populated mappings should not trigger page faults.
         } else {
             // Allocate a physical frame lazily and map it to the fault address.
-            // Keep ownership of an unused frame with the fault path so a remap
-            // failure does not re-enter the allocator from the trap context.
-            remap_allocated_frame(alloc_frame(true), |frame| {
-                pt.remap_page(vaddr, frame, orig_flags).is_ok()
-            })
+            remap_frame_or_dealloc(
+                alloc_frame(true),
+                |frame| pt.remap_page(vaddr, frame, orig_flags).is_ok(),
+                dealloc_frame,
+            )
         }
     }
 }
 
-fn remap_allocated_frame(
+fn remap_frame_or_dealloc(
     frame: Option<PhysAddr>,
     remap_frame: impl FnOnce(PhysAddr) -> bool,
+    dealloc_frame: impl FnOnce(PhysAddr),
 ) -> bool {
     let Some(frame) = frame else {
         return false;
     };
-    remap_frame(frame)
+    if remap_frame(frame) {
+        true
+    } else {
+        dealloc_frame(frame);
+        false
+    }
 }
 
 trait PopulatePageOps {
@@ -180,6 +186,7 @@ fn rollback_populated_pages(ops: &mut impl PopulatePageOps, start: VirtAddr, map
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
+    use core::cell::Cell;
 
     use super::*;
 
@@ -210,15 +217,27 @@ mod tests {
     #[test]
     fn keeps_lazy_frame_when_remap_succeeds() {
         let frame = PhysAddr::from(PAGE_SIZE_4K);
+        let deallocated = Cell::new(None);
 
-        assert!(remap_allocated_frame(Some(frame), |_| true));
+        assert!(remap_frame_or_dealloc(
+            Some(frame),
+            |_| true,
+            |frame| deallocated.set(Some(frame)),
+        ));
+        assert_eq!(deallocated.get(), None);
     }
 
     #[test]
-    fn keeps_lazy_frame_owned_by_fault_path_when_remap_fails() {
+    fn deallocates_lazy_frame_when_remap_fails() {
         let frame = PhysAddr::from(PAGE_SIZE_4K);
+        let deallocated = Cell::new(None);
 
-        assert!(!remap_allocated_frame(Some(frame), |_| false));
+        assert!(!remap_frame_or_dealloc(
+            Some(frame),
+            |_| false,
+            |frame| deallocated.set(Some(frame)),
+        ));
+        assert_eq!(deallocated.get(), Some(frame));
     }
 
     struct MockPopulatePageOps {

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -32,6 +32,7 @@ ax-driver
 rdrive
 ax-hal
 ax-sync
+ax-mm
 ax-task
 ax-input
 ax-ipi


### PR DESCRIPTION
## 问题

lazy page fault 路径先通过 `alloc_frame(true)` 获得物理页，再直接返回 `remap_page(...).is_ok()`。当 `remap_page` 失败时，该 frame 既没有被页表接管，也没有交还分配器，导致物理页泄漏。

## 修改

- 将 lazy frame 的 remap 与失败释放收敛到私有 `remap_frame_or_dealloc` 流程。
- remap 成功时保持原有语义，由页表接管 frame。
- remap 失败时立即调用 `dealloc_frame`，再向 page fault 调用方返回失败。
- 保持 frame 分配失败时直接返回失败，不执行无效释放。
- 增加成功和失败两条确定性单元测试，验证 frame 的所有权转移。

## 实现逻辑

新流程只在 frame 已成功分配后尝试 remap。成功结果意味着叶子 PTE 已持有该物理页，因此不释放；错误结果意味着 frame 仍归当前调用所有，必须在返回前释放。这样每个分支都有明确的资源所有者，不会留下无主 frame，也不会误释放已经映射的页面。

## 验证

- `cargo fmt --all --check`
- `cargo test -p ax-mm --features ax-hal/host-test,ax-sync/host-test`
- `cargo xtask clippy --package ax-mm`
- `cargo clippy -p ax-mm --tests --features ax-hal/host-test,ax-sync/host-test -- -D warnings`
- `cargo xtask cross-test --arch x86_64 --package ax-mm --features ax-hal/host-test,ax-sync/host-test --lib`
- 回归测试在修复前稳定失败，修复后 `ax-mm` 的 5 个单元测试及 x86_64 musl cross-test 全部通过。