### PR TITLE
feat(ci): add impact-based PR test matrix

### DIFF
--- a/.github/ci/checks/arceos.toml
+++ b/.github/ci/checks/arceos.toml
@@ -1,9 +1,10 @@
-schema_version = 1
+schema_version = 2
 phase = "test"
 group = "ArceOS"
 
 [[check]]
 id = "test-arceos-x86-64-qemu"
+impact_targets = ["arceos:x86_64"]
 name = "x86_64 QEMU · Suites + axtest"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
@@ -17,6 +18,7 @@ cargo xtask ktest qemu --workspace --exclude starry-kernel --exclude axvisor --a
 
 [[check]]
 id = "test-arceos-riscv64-qemu"
+impact_targets = ["arceos:riscv64"]
 name = "riscv64 QEMU · Suites + task IPI + axtest"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
@@ -32,6 +34,7 @@ cargo xtask ktest qemu --workspace --exclude starry-kernel --exclude axvisor --a
 
 [[check]]
 id = "test-arceos-aarch64-qemu-app-suites"
+impact_targets = ["arceos:aarch64"]
 name = "aarch64 QEMU · GICv2 SMP4 boot + suites + axtest"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
@@ -49,6 +52,7 @@ cargo xtask ktest qemu --workspace --exclude starry-kernel --exclude axvisor --a
 
 [[check]]
 id = "test-arceos-loongarch64-qemu"
+impact_targets = ["arceos:loongarch64"]
 name = "loongarch64 QEMU · Suites + axtest"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -1,9 +1,10 @@
-schema_version = 1
+schema_version = 2
 phase = "test"
 group = "AxVisor"
 
 [[check]]
 id = "test-axvisor-aarch64-qemu-smoke-axtest-timer-stress"
+impact_targets = ["axvisor:aarch64"]
 name = "aarch64 QEMU · Smoke + virtio-blk guest + axtest + timer stress"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
@@ -27,6 +28,7 @@ cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress
 
 [[check]]
 id = "test-axvisor-aarch64-qemu-panic-modes"
+impact_targets = ["axvisor:aarch64"]
 name = "aarch64 QEMU · Panic modes"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
@@ -42,6 +44,7 @@ cargo xtask axvisor test qemu --arch aarch64 --test-case no-backtrace
 
 [[check]]
 id = "test-axvisor-aarch64-qemu-http-control-plane"
+impact_targets = ["axvisor:aarch64"]
 name = "aarch64 QEMU · HTTP control-plane"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
@@ -57,6 +60,7 @@ cargo xtask axvisor test qemu --arch aarch64 --test-case http-control-plane
 
 [[check]]
 id = "test-axvisor-riscv64-qemu-smoke-panic-modes"
+impact_targets = ["axvisor:riscv64"]
 name = "riscv64 QEMU · Smoke + IPI + panic modes"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
@@ -78,6 +82,7 @@ cargo xtask axvisor test qemu --arch riscv64 --test-case no-backtrace
 
 [[check]]
 id = "test-axvisor-loongarch64-qemu"
+impact_targets = ["axvisor:loongarch64"]
 name = "loongarch64 QEMU · Suites"
 runs_on = ["ubuntu-latest"]
 environment = "axvisor-lvz"
@@ -89,6 +94,7 @@ target/debug/tg-xtask axvisor test qemu --arch loongarch64
 
 [[check]]
 id = "test-axvisor-qemu-ivc"
+impact_targets = ["axvisor:aarch64"]
 name = "aarch64 QEMU · IVC"
 runs_on = ["self-hosted", "linux", "qcs"]
 environment = "host"
@@ -100,6 +106,7 @@ cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qem
 
 [[check]]
 id = "test-axvisor-self-hosted-x86-64-svm-smoke-acpi"
+impact_targets = ["axvisor:x86_64"]
 name = "x86_64 SVM · Smoke + direct/OVMF ACPI"
 runs_on = ["self-hosted", "linux", "amd", "kvm"]
 environment = "host"
@@ -119,6 +126,7 @@ cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-svm
 
 [[check]]
 id = "test-axvisor-self-hosted-x86-64-vmx"
+impact_targets = ["axvisor:x86_64"]
 name = "x86_64 VMX · Smoke"
 runs_on = ["self-hosted", "linux", "intel", "kvm"]
 environment = "host"
@@ -130,6 +138,7 @@ cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx
 
 [[check]]
 id = "test-axloader-http-smoke"
+impact_packages = ["axloader"]
 name = "x86_64 UEFI · AxLoader HTTP boot"
 runs_on = ["self-hosted", "linux", "intel", "kvm"]
 environment = "host"
@@ -143,6 +152,7 @@ cargo xtask axloader test qemu --target x86_64-unknown-uefi
 
 [[check]]
 id = "test-axvisor-x86-64-acpi-direct-and-ovmf-boot-vmx"
+impact_targets = ["axvisor:x86_64"]
 name = "x86_64 VMX · Direct + MP fallback + OVMF ACPI"
 runs_on = ["self-hosted", "linux", "intel", "kvm"]
 environment = "host"
@@ -158,6 +168,7 @@ cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx
 
 [[check]]
 id = "test-axvisor-self-hosted-board-orangepi-5-plus-linux"
+impact_targets = ["axvisor:aarch64"]
 name = "OrangePi 5 Plus board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -168,6 +179,7 @@ cargo xtask axvisor test board --board orangepi-5-plus-linux
 
 [[check]]
 id = "test-axvisor-self-hosted-board-orangepi-5-plus-starry"
+impact_targets = ["axvisor:aarch64"]
 name = "OrangePi 5 Plus board · StarryOS guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -178,6 +190,7 @@ cargo xtask axvisor test board --board orangepi-5-plus-starry
 
 [[check]]
 id = "test-axvisor-self-hosted-board-roc-rk3568-pc-linux"
+impact_targets = ["axvisor:aarch64"]
 name = "ROC-RK3568-PC board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -188,6 +201,7 @@ cargo xtask axvisor test board --board roc-rk3568-pc-linux
 
 [[check]]
 id = "test-axvisor-self-hosted-board-phytiumpi-linux"
+impact_targets = ["axvisor:aarch64"]
 name = "Phytium Pi board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -198,6 +212,7 @@ cargo xtask axvisor test board --board phytiumpi-linux
 
 [[check]]
 id = "test-axvisor-self-hosted-board-asus-nuc15crh-linux"
+impact_targets = ["axvisor:x86_64"]
 name = "ASUS NUC15CRH board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -215,6 +230,7 @@ cargo xtask axvisor test board --board asus-nuc15crh-linux
 
 [[check]]
 id = "test-orangepi-5-plus-robot-axvisor-starryos-guest"
+impact_targets = ["axvisor:aarch64"]
 name = "OrangePi 5 Plus robot board · StarryOS guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -226,6 +242,7 @@ cargo xtask axvisor test board --board orangepi-5-plus-robot-starry
 
 [[check]]
 id = "test-orangepi-5-plus-robot-axvisor-linux-guest"
+impact_targets = ["axvisor:aarch64"]
 name = "OrangePi 5 Plus robot board · Linux guest"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"

--- a/.github/ci/checks/starry-apps.toml
+++ b/.github/ci/checks/starry-apps.toml
@@ -1,4 +1,4 @@
-schema_version = 1
+schema_version = 2
 phase = "starry_apps"
 group = "Starry Apps"
 

--- a/.github/ci/checks/starry.toml
+++ b/.github/ci/checks/starry.toml
@@ -1,4 +1,4 @@
-schema_version = 1
+schema_version = 2
 phase = "test"
 group = "Starry"
 
@@ -8,6 +8,7 @@ group = "Starry"
 
 [[check]]
 id = "test-starry-riscv64-qemu"
+impact_targets = ["starry:riscv64"]
 name = "riscv64 QEMU · Suites"
 runs_on = ["ubuntu-latest"]
 environment = "base"
@@ -21,6 +22,7 @@ target/debug/tg-xtask ktest qemu -p starry-kernel --arch riscv64
 
 [[check]]
 id = "test-starry-aarch64-qemu"
+impact_targets = ["starry:aarch64"]
 name = "aarch64 QEMU · GICv2 SMP4 boot + suites"
 runs_on = ["ubuntu-latest"]
 environment = "base"
@@ -38,6 +40,7 @@ target/debug/tg-xtask ktest qemu -p starry-kernel --arch aarch64
 
 [[check]]
 id = "test-starry-loongarch64-qemu"
+impact_targets = ["starry:loongarch64"]
 name = "loongarch64 QEMU · Suites"
 runs_on = ["ubuntu-latest"]
 environment = "base"
@@ -51,6 +54,7 @@ target/debug/tg-xtask ktest qemu -p starry-kernel --arch loongarch64
 
 [[check]]
 id = "test-starry-x86-64-qemu"
+impact_targets = ["starry:x86_64"]
 name = "x86_64 QEMU · Suites"
 runs_on = ["ubuntu-latest"]
 environment = "base"
@@ -64,6 +68,7 @@ target/debug/tg-xtask ktest qemu -p starry-kernel --arch x86_64
 
 [[check]]
 id = "test-starry-self-hosted-board-orangepi-5-plus"
+impact_targets = ["starry:aarch64"]
 name = "OrangePi 5 Plus board · Suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -74,6 +79,7 @@ cargo xtask starry test board --board orangepi-5-plus
 
 [[check]]
 id = "test-orangepi-5-plus-robot-native-starryos"
+impact_targets = ["starry:aarch64"]
 name = "OrangePi 5 Plus robot board · Native suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -85,6 +91,7 @@ cargo xtask starry test board --board orangepi-5-plus-robot
 
 [[check]]
 id = "test-starry-self-hosted-board-aka-00-sg2002"
+impact_targets = ["starry:riscv64"]
 name = "AKA-00 SG2002 board · Suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -95,6 +102,7 @@ cargo xtask starry test board --board aka-00-sg2002
 
 [[check]]
 id = "test-starry-self-hosted-board-visionfive2"
+impact_targets = ["starry:riscv64"]
 name = "VisionFive 2 board · Suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"
@@ -105,6 +113,7 @@ cargo xtask starry test board --board visionfive2
 
 [[check]]
 id = "test-starry-self-hosted-board-jl-lsgd2k10"
+impact_targets = ["starry:loongarch64"]
 name = "JL LSGD2K10 board · Suites"
 runs_on = ["self-hosted", "linux", "board"]
 environment = "host"

--- a/.github/ci/checks/static.toml
+++ b/.github/ci/checks/static.toml
@@ -1,4 +1,4 @@
-schema_version = 1
+schema_version = 2
 phase = "static"
 group = "Static"
 

--- a/.github/ci/checks/workspace.toml
+++ b/.github/ci/checks/workspace.toml
@@ -1,4 +1,4 @@
-schema_version = 1
+schema_version = 2
 phase = "test"
 group = "Workspace"
 
@@ -24,4 +24,7 @@ self_hosted_owner = "rcore-os"
 fallback_environment = "base"
 command = '''
 cargo xtask test
+'''
+pull_request_command = '''
+cargo xtask test --since "$SINCE_REF"
 '''

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ on:
       - "tools/**"
       - "virtualization/**"
       - "xtask/**"
+      - "!**/*.md"
   workflow_dispatch:
     inputs:
       since_sha:
@@ -160,7 +161,7 @@ jobs:
           python3 scripts/test/check_ci_paths.py
           python3 scripts/test/check_ci_routing.py
           python3 scripts/test/check_workflow_layout.py
-          python3 -m unittest scripts/test/test_ci_plan.py
+          python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py
 
       - name: Resolve incremental base revision
         id: since
@@ -179,6 +180,9 @@ jobs:
 
           if [ "$EVENT_NAME" = "pull_request" ]; then
             since_ref="$PR_BASE_SHA"
+            if ! git rev-parse --verify "${since_ref}^{commit}" >/dev/null 2>&1; then
+              git fetch --no-tags --depth=1 origin "$since_ref" >/dev/null 2>&1 || true
+            fi
           elif [ "$EVENT_NAME" = "push" ] && ! is_empty_or_zero_sha "$PUSH_BEFORE_SHA"; then
             since_ref="$PUSH_BEFORE_SHA"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ] && ! is_empty_or_zero_sha "$SINCE_SHA"; then
@@ -200,6 +204,7 @@ jobs:
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           PR_HEAD_REPOSITORY_OWNER: >-
             ${{ github.event.pull_request.head.repo.owner.login || '' }}
+          SINCE_REF: ${{ steps.since.outputs.since_ref }}
         run: |
           set -euo pipefail
           source_repository_owner="$REPOSITORY_OWNER"
@@ -212,6 +217,8 @@ jobs:
             --repository-owner "$source_repository_owner" \
             --event-name "$EVENT_NAME" \
             --base-ref "$BASE_REF" \
+            --since-ref "$SINCE_REF" \
+            --summary-file "$GITHUB_STEP_SUMMARY" \
             --output-file "$GITHUB_OUTPUT"
 
   static_checks:

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -37,12 +37,22 @@ flowchart TB
 |------|------|
 | `push` 到 `main` / `dev` | 排除纯文档变更（`*.md`、`docs/**` 等），其余路径直接触发完整 CI |
 | `push` 到其他分支 | 先进入 `ci-branch-push.yml`。若该分支已有 open PR，则 router 成功结束；否则由 router 触发完整 CI |
-| `pull_request` | 同上 |
+| `pull_request` | 纯 Markdown 不触发主 CI；其余变更由 planner 按 crate、OS 和 arch 生成增量矩阵 |
 | `workflow_dispatch` | 默认用于发布容器镜像（`base` / `axvisor-lvz` / `both`）；router 也会用 `run_target=ci` 调度非 PR 分支的完整 CI |
 
 `dev` 分支的 `push` 和手动触发使用 `concurrency.queue: max` 串行排队运行，避免多个 dev CI 同时占用 runner。其他分支、`main` 分支、PR 以及非 `dev` 手动触发不会进入 dev 队列；新 run 会在最早的 `cancel_stale_runs` 阶段取消同一分支或同一 PR 上仍在 queued/running 的旧 CI run。
 
 非 `main` / `dev` 分支的 `push` 由轻量 router 先检查是否已有同仓库、同名分支的 open PR。已有 PR 时不会调度 `.github/workflows/ci.yml`，router 会输出跳过原因并以成功状态结束，PR 的 `pull_request` CI 负责验证同一提交。没有 open PR 时，router 使用 `workflow_dispatch(run_target=ci)` 调度完整 CI，并把 push 事件的 `before` SHA 传给差异检查。
+
+### PR 增量矩阵
+
+只有 `pull_request` 使用增量矩阵。planner 以 PR base SHA 做三点 diff，忽略 `.md` 和 `apps/**`，并将其余路径映射到最深层 workspace package。随后分别为 aarch64、x86_64、riscv64 和 loongarch64 运行带 `--all-features --filter-platform` 的 Cargo metadata，通过反向依赖确定 ArceOS、StarryOS 和 AxVisor 的受影响架构。workspace axtest package 还会按其声明的 target 选择承载该测试的 ArceOS job。
+
+非 crate 的已知 OS 配置和 test-suit 文件按目录及配置名映射；只能确定 OS 时运行该 OS 的全部架构。package 删除、未知源码路径、Cargo/toolchain、CI planner/workflow/check manifest、`.cargo/**` 或任意 xtask 实现变更，以及 diff/metadata 失败，都会回退到当前完整矩阵。回退不会静默缩小覆盖。
+
+每个被选中的 OS/arch 仍执行该矩阵项原有的全部 QEMU、KVM 和板卡命令。`apps/**` 本身不选择 OS/arch 或 app 运行测试；混合 PR 中的其他改动仍按正常规则选择。static checks 始终保留，workspace Clippy 继续使用 `--since`，std whitelist 在增量 PR 中使用 `cargo xtask test --since <base>`。`push` 和 `workflow_dispatch` 不使用该影响分析，保持完整矩阵。
+
+planner 将 changed paths、忽略的 Markdown/apps、changed/affected packages、选中的 OS/arch、选中/跳过的 checks 和全量回退原因写入 Actions job summary。
 
 ## 执行流水线
 
@@ -106,7 +116,7 @@ push 到 `main` / `dev` 时强制运行 CI 检查。非 `main` / `dev` 分支没
 | Job 名称 | Runner | 使用容器 | Cache Key | 功能说明 |
 |----------|--------|----------|-----------|----------|
 | Run clippy | `self-hosted linux qcs` | 否 | 无 | `cargo xtask clippy --since <base>`；需要完整 git 历史；fork PR 回退到 `ubuntu-latest` + `base` 容器 |
-| Test with std | `self-hosted linux qcs` | 否 | 无 | `cargo xtask test`，运行 `scripts/test/std_crates.csv` 中的 host 测试；fork PR 回退到 `ubuntu-latest` + `base` 容器 |
+| Test with std | `self-hosted linux qcs` | 否 | 无 | 非 PR 或全量回退运行 `cargo xtask test`；增量 PR 运行 `cargo xtask test --since <base>`，只保留 affected package 与 `scripts/test/std_crates.csv` 的交集；fork PR 回退到 `ubuntu-latest` + `base` 容器 |
 | Test axvisor aarch64 qemu | `self-hosted linux qcs` | 否 | 无 | `cargo xtask axvisor test qemu --arch aarch64`；`rcore-os` 仓库使用 self-hosted，fork PR 回退到 `ubuntu-latest` + `base` 容器 |
 | Test axvisor riscv64 qemu | `self-hosted linux qcs` | 否 | 无 | `cargo xtask axvisor test qemu --arch riscv64`；`rcore-os` 仓库使用 self-hosted，fork PR 回退到 `ubuntu-latest` + `base` 容器 |
 | Test axvisor loongarch64 qemu | `ubuntu-latest` | 是（`axvisor-lvz`） | `test-axvisor-loongarch64` | `cargo xtask axvisor test qemu --arch loongarch64`，使用带 LVZ 支持的镜像 |

--- a/scripts/axbuild/src/lib.rs
+++ b/scripts/axbuild/src/lib.rs
@@ -57,7 +57,7 @@ enum Commands {
         command: agent_review_bench::Command,
     },
     /// Run std tests for the configured workspace package whitelist
-    Test,
+    Test(test::std::StdTestArgs),
     /// Run statically linked workspace crate tests through qemu-user
     CrossTest(test::cross::CrossTestArgs),
     /// Run kernel axtest targets through QEMU or a remote board
@@ -124,7 +124,7 @@ where
 async fn run_root_cli(cli: Cli) -> anyhow::Result<()> {
     match cli.command {
         Commands::AgentReviewBench { command } => agent_review_bench::execute(command).await,
-        Commands::Test => test::std::run_std_test_command(),
+        Commands::Test(args) => test::std::run_std_test_command(&args),
         Commands::CrossTest(args) => test::cross::run(args),
         Commands::Ktest(args) => ktest::run(args).await,
         Commands::Clippy(args) => clippy::run_workspace_clippy_command(&args),
@@ -164,6 +164,17 @@ mod tests {
                 command.join(" ")
             )
         });
+    }
+
+    #[test]
+    fn std_test_command_accepts_incremental_base() {
+        let cli = TestCli::try_parse_from(["xtask", "test", "--since", "origin/dev"])
+            .expect("test --since must parse");
+
+        match cli.command {
+            Commands::Test(args) => assert_eq!(args.since.as_deref(), Some("origin/dev")),
+            _ => panic!("expected std test command"),
+        }
     }
 
     #[test]

--- a/scripts/axbuild/src/support/git/selection.rs
+++ b/scripts/axbuild/src/support/git/selection.rs
@@ -169,6 +169,13 @@ impl PackagePathIndex {
             if path.as_os_str().is_empty() {
                 continue;
             }
+            if path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+            {
+                continue;
+            }
             if path == Path::new(ROOT_MANIFEST) {
                 match root_manifest_change
                     .clone()

--- a/scripts/axbuild/src/support/git/tests/selection.rs
+++ b/scripts/axbuild/src/support/git/tests/selection.rs
@@ -140,6 +140,29 @@ fn no_changes_selects_no_packages() {
 }
 
 #[test]
+fn markdown_inside_crates_does_not_expand_incremental_packages() {
+    let (root, metadata, workspace_packages) = test_workspace();
+    let selected = select_incremental_packages_for_paths(
+        root.path(),
+        &metadata,
+        &workspace_packages,
+        [
+            PathBuf::from("crates/alpha/README.md"),
+            PathBuf::from("crates/beta/src/lib.rs"),
+        ],
+    )
+    .unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: vec!["beta".into()],
+            affected: vec!["beta".into(), "gamma".into()],
+        }
+    );
+}
+
+#[test]
 fn lockfile_only_change_falls_back_to_full() {
     // Cargo.lock is Soft: a dep-version-only update with no source changes
     // can still affect compilation via transitive deps, proc macros, or

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -7,12 +7,20 @@ use std::{
 };
 
 use anyhow::{Context, bail};
-use cargo_metadata::Metadata;
+use cargo_metadata::{Metadata, Package};
+use clap::Args;
 
-use crate::support::process::run_cargo_status;
+use crate::support::{git::IncrementalPackageSelection, process::run_cargo_status};
 
 const STD_CRATES_CSV: &str = "scripts/test/std_crates.csv";
 const TASK_INITIALIZATION_FILTER: &str = "task_initialization_precedes_scheduling";
+
+#[derive(Args, Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct StdTestArgs {
+    /// Run std tests only for workspace packages affected since the git ref
+    #[arg(long, value_name = "REF")]
+    pub(crate) since: Option<String>,
+}
 
 #[derive(Clone, Copy, Debug)]
 struct PackageFeatureProfile {
@@ -140,20 +148,54 @@ struct CargoRunOutput {
     stdout: String,
 }
 
-pub(crate) fn run_std_test_command() -> anyhow::Result<()> {
+pub(crate) fn run_std_test_command(args: &StdTestArgs) -> anyhow::Result<()> {
     let workspace_manifest = crate::context::workspace_manifest_path()?;
-    let metadata = crate::context::workspace_metadata_root_manifest(&workspace_manifest)
-        .context("failed to load cargo metadata")?;
+    let metadata = if args.since.is_some() {
+        crate::context::workspace_metadata_root_manifest_with_deps(&workspace_manifest)
+    } else {
+        crate::context::workspace_metadata_root_manifest(&workspace_manifest)
+    }
+    .context("failed to load cargo metadata")?;
     let workspace_root = metadata.workspace_root.clone().into_std_path_buf();
     let known_packages = workspace_package_names(&metadata);
     let csv_path = workspace_root.join(STD_CRATES_CSV);
-    let packages = load_std_crates(&csv_path, &known_packages)?;
+    let all_packages = load_std_crates(&csv_path, &known_packages)?;
+    let packages = match args.since.as_deref() {
+        None => all_packages,
+        Some(since) => {
+            let workspace_packages = workspace_packages(&metadata);
+            let selection = crate::support::git::select_incremental_packages(
+                &workspace_root,
+                &metadata,
+                &workspace_packages,
+                since,
+            )
+            .unwrap_or_else(|error| IncrementalPackageSelection::Full {
+                reason: format!("incremental std test selection failed: {error:#}"),
+            });
+            match &selection {
+                IncrementalPackageSelection::Packages { changed, affected } => println!(
+                    "incremental std tests since {since}: changed [{}], affected [{}]",
+                    changed.join(", "),
+                    affected.join(", ")
+                ),
+                IncrementalPackageSelection::Full { reason } => println!(
+                    "incremental std test selection fell back to the full whitelist: {reason}"
+                ),
+            }
+            select_std_packages(all_packages, &selection)
+        }
+    };
 
     println!(
         "running std tests for {} package(s) from {}",
         packages.len(),
         csv_path.display()
     );
+    if packages.is_empty() {
+        println!("no affected std test packages selected");
+        return Ok(());
+    }
 
     let mut runner = ProcessCargoRunner;
     let failed = run_std_tests(&mut runner, &workspace_root, &packages)?;
@@ -169,6 +211,27 @@ pub(crate) fn run_std_test_command() -> anyhow::Result<()> {
         failed.join(", ")
     );
     bail!("std test run failed")
+}
+
+fn workspace_packages(metadata: &Metadata) -> Vec<Package> {
+    metadata
+        .packages
+        .iter()
+        .filter(|package| metadata.workspace_members.contains(&package.id))
+        .cloned()
+        .collect()
+}
+
+fn select_std_packages(
+    mut packages: Vec<String>,
+    selection: &IncrementalPackageSelection,
+) -> Vec<String> {
+    let IncrementalPackageSelection::Packages { affected, .. } = selection else {
+        return packages;
+    };
+    let affected = affected.iter().map(String::as_str).collect::<HashSet<_>>();
+    packages.retain(|package| affected.contains(package.as_str()));
+    packages
 }
 
 fn workspace_package_names(metadata: &Metadata) -> HashSet<String> {
@@ -514,6 +577,44 @@ mod tests {
             parse_std_crates_csv("package\nax-api\nax-hal\n", &known_packages()).unwrap();
 
         assert_eq!(packages, vec!["ax-api".to_string(), "ax-hal".to_string()]);
+    }
+
+    #[test]
+    fn incremental_selection_keeps_affected_whitelist_order() {
+        let packages = ["ax-api", "ax-hal", "ax-task"].map(str::to_string).to_vec();
+        let selection = IncrementalPackageSelection::Packages {
+            changed: vec!["ax-task".to_string()],
+            affected: vec!["ax-task".to_string(), "ax-api".to_string()],
+        };
+
+        let selected = select_std_packages(packages, &selection);
+
+        assert_eq!(selected, vec!["ax-api".to_string(), "ax-task".to_string()]);
+    }
+
+    #[test]
+    fn incremental_selection_accepts_no_affected_std_packages() {
+        let packages = vec!["ax-api".to_string(), "ax-hal".to_string()];
+        let selection = IncrementalPackageSelection::Packages {
+            changed: vec!["standalone".to_string()],
+            affected: vec!["standalone".to_string()],
+        };
+
+        let selected = select_std_packages(packages, &selection);
+
+        assert!(selected.is_empty());
+    }
+
+    #[test]
+    fn incremental_full_fallback_keeps_every_std_package() {
+        let packages = vec!["ax-api".to_string(), "ax-hal".to_string()];
+        let selection = IncrementalPackageSelection::Full {
+            reason: "fixture".to_string(),
+        };
+
+        let selected = select_std_packages(packages.clone(), &selection);
+
+        assert_eq!(selected, packages);
     }
 
     #[test]

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -37,6 +37,7 @@ CI_CHECK_PATHS = {
     "tools/**",
     "virtualization/**",
     "xtask/**",
+    "!**/*.md",
 }
 
 
@@ -92,6 +93,9 @@ def main() -> int:
         list_items(ci_pull_request, "paths", 4),
         CI_CHECK_PATHS,
     )
+    pull_request_paths = list_items_in_order(ci_pull_request, "paths", 4)
+    if not pull_request_paths or pull_request_paths[-1] != "!**/*.md":
+        errors.append("the Markdown exclusion must be the final pull_request path rule")
     if scalar_value(since_sha, "type", 8) != "string":
         errors.append("since_sha must be a workflow_dispatch string input")
     for removed_input in ("run_target", "container_target"):
@@ -124,6 +128,18 @@ def main() -> int:
     )
     require_contains(
         errors,
+        ci_workflow,
+        '--since-ref "$SINCE_REF"',
+        "the planner must receive the resolved PR base revision",
+    )
+    require_contains(
+        errors,
+        ci_workflow,
+        '--summary-file "$GITHUB_STEP_SUMMARY"',
+        "the planner must publish its PR impact summary",
+    )
+    require_contains(
+        errors,
         static_checks,
         'cargo xtask sync-lint --since "$SINCE_REF"',
         "sync-lint must consume SINCE_REF from the reusable runner",
@@ -133,6 +149,12 @@ def main() -> int:
         workspace_checks,
         'cargo xtask clippy --since "$SINCE_REF"',
         "clippy must consume SINCE_REF from the reusable runner",
+    )
+    require_contains(
+        errors,
+        workspace_checks,
+        'cargo xtask test --since "$SINCE_REF"',
+        "incremental std tests must consume SINCE_REF from the reusable runner",
     )
     for event_branch in (
         'if [ "$EVENT_NAME" = "pull_request" ]; then',
@@ -237,12 +259,16 @@ def mapping_block(text: str, key: str, indent: int) -> str:
 
 
 def list_items(text: str, key: str, indent: int) -> set[str]:
+    return set(list_items_in_order(text, key, indent))
+
+
+def list_items_in_order(text: str, key: str, indent: int) -> list[str]:
     block = mapping_block(text, key, indent)
-    return {
+    return [
         line.strip()[2:].strip().strip('"')
         for line in block.splitlines()
         if line.strip().startswith("- ")
-    }
+    ]
 
 
 def scalar_value(text: str, key: str, indent: int) -> str:

--- a/scripts/test/ci_impact.py
+++ b/scripts/test/ci_impact.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+
+import json
+import re
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+
+ARCH_TARGETS = {
+    "aarch64": "aarch64-unknown-none-softfloat",
+    "x86_64": "x86_64-unknown-none",
+    "riscv64": "riscv64gc-unknown-none-elf",
+    "loongarch64": "loongarch64-unknown-none-softfloat",
+}
+OS_ROOT_PACKAGES = {
+    "arceos": "arceos-test-suit",
+    "starry": "starryos",
+    "axvisor": "axvisor",
+}
+ARCEOS_KTEST_EXCLUDED_PACKAGES = {"starry-kernel", "axvisor"}
+
+FULL_PATHS = {
+    Path("Cargo.toml"),
+    Path("Cargo.lock"),
+    Path("rust-toolchain"),
+    Path("rust-toolchain.toml"),
+}
+FULL_PREFIXES = (
+    Path(".cargo"),
+    Path(".github/ci"),
+    Path(".github/workflows"),
+    Path("scripts/axbuild"),
+    Path("scripts/test"),
+    Path("xtask"),
+    Path("os/StarryOS/starryos/xtask"),
+    Path("os/axvisor/xtask"),
+)
+IGNORED_APP_PREFIX = Path("apps")
+KNOWN_OS_PATHS = (
+    (Path("test-suit/arceos"), "arceos"),
+    (Path("test-suit/starryos"), "starry"),
+    (Path("test-suit/axvisor"), "axvisor"),
+    (Path("os/arceos/configs"), "arceos"),
+    (Path("os/StarryOS/configs"), "starry"),
+    (Path("os/axvisor/configs"), "axvisor"),
+)
+ARCH_PATH_ALIASES = {
+    "aarch64": (
+        "a1000",
+        "orangepi-5-plus",
+        "phytiumpi",
+        "rdk-s100",
+        "rk3568",
+        "rk3588",
+        "roc-rk3568-pc",
+        "rock-4d",
+        "tac-e400",
+    ),
+    "x86_64": ("asus-nuc15crh",),
+    "riscv64": (
+        "aka-00-sg2002",
+        "k230",
+        "licheerv-nano-sg2002",
+        "sg2002",
+        "visionfive2",
+    ),
+    "loongarch64": ("jl-lsgd2k10", "ls2k1000"),
+}
+
+
+class ImpactError(ValueError):
+    """Raised when a PR impact cannot be classified without losing coverage."""
+
+
+@dataclass(frozen=True)
+class CiImpact:
+    full: bool
+    reason: str
+    changed_paths: tuple[str, ...]
+    ignored_markdown: tuple[str, ...] = ()
+    ignored_apps: tuple[str, ...] = ()
+    changed_packages: tuple[str, ...] = ()
+    affected_packages: tuple[str, ...] = ()
+    targets: tuple[str, ...] = ()
+
+    @classmethod
+    def full_selection(
+        cls,
+        reason: str,
+        changed_paths: Iterable[Path | str] = (),
+        *,
+        ignored_markdown: Iterable[str] = (),
+        ignored_apps: Iterable[str] = (),
+    ) -> "CiImpact":
+        return cls(
+            full=True,
+            reason=reason,
+            changed_paths=_sorted_path_strings(changed_paths),
+            ignored_markdown=tuple(sorted(set(ignored_markdown))),
+            ignored_apps=tuple(sorted(set(ignored_apps))),
+            targets=tuple(
+                f"{os_name}:{arch}"
+                for os_name in OS_ROOT_PACKAGES
+                for arch in ARCH_TARGETS
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PackagePathEntry:
+    package_id: str
+    name: str
+    relative_dir: Path
+
+
+def analyze_pull_request(workspace_root: Path, since_ref: str) -> CiImpact:
+    """Analyze one PR diff, falling back to the full matrix on uncertainty."""
+    try:
+        changed_paths = changed_paths_since(workspace_root, since_ref)
+        if not changed_paths:
+            return CiImpact.full_selection("the pull request diff is empty")
+        ignored_markdown, ignored_apps, relevant = _partition_ignored(changed_paths)
+        if not relevant:
+            return CiImpact(
+                full=False,
+                reason="only ignored Markdown or app paths changed",
+                changed_paths=_sorted_path_strings(changed_paths),
+                ignored_markdown=tuple(sorted(ignored_markdown)),
+                ignored_apps=tuple(sorted(ignored_apps)),
+            )
+        full_reason = _pre_metadata_full_reason(workspace_root, relevant)
+        if full_reason is not None:
+            return CiImpact.full_selection(
+                full_reason,
+                changed_paths,
+                ignored_markdown=ignored_markdown,
+                ignored_apps=ignored_apps,
+            )
+        metadata_by_arch = load_metadata_by_arch(workspace_root)
+        return analyze_changed_paths(workspace_root, changed_paths, metadata_by_arch)
+    except (
+        ImpactError,
+        OSError,
+        UnicodeError,
+        subprocess.SubprocessError,
+        json.JSONDecodeError,
+    ) as error:
+        return CiImpact.full_selection(
+            f"impact analysis failed: {error}",
+            locals().get("changed_paths", ()),
+            ignored_markdown=locals().get("ignored_markdown", ()),
+            ignored_apps=locals().get("ignored_apps", ()),
+        )
+
+
+def changed_paths_since(workspace_root: Path, since_ref: str) -> list[Path]:
+    if not since_ref.strip():
+        raise ImpactError("the incremental base revision is empty")
+    command = [
+        "git",
+        "diff",
+        "--name-only",
+        "--no-renames",
+        "-z",
+        f"{since_ref}...HEAD",
+        "--",
+    ]
+    result = subprocess.run(
+        command,
+        cwd=workspace_root,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return [
+        _normalize_relative_path(Path(raw.decode("utf-8")))
+        for raw in result.stdout.split(b"\0")
+        if raw
+    ]
+
+
+def load_metadata_by_arch(workspace_root: Path) -> dict[str, dict]:
+    metadata_by_arch = {}
+    for arch, target in ARCH_TARGETS.items():
+        command = [
+            "cargo",
+            "metadata",
+            "--format-version",
+            "1",
+            "--locked",
+            "--all-features",
+            "--filter-platform",
+            target,
+            "--manifest-path",
+            str(workspace_root / "Cargo.toml"),
+        ]
+        result = subprocess.run(
+            command,
+            cwd=workspace_root,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        metadata_by_arch[arch] = json.loads(result.stdout)
+    return metadata_by_arch
+
+
+def analyze_changed_paths(
+    workspace_root: Path,
+    changed_paths: Iterable[Path],
+    metadata_by_arch: Mapping[str, dict],
+) -> CiImpact:
+    """Classify already-resolved changed paths using target-specific metadata."""
+    workspace_root = workspace_root.resolve()
+    paths = sorted({_normalize_relative_path(path) for path in changed_paths})
+    ignored_markdown, ignored_apps, relevant_paths = _partition_ignored(paths)
+
+    full_reason = _pre_metadata_full_reason(workspace_root, relevant_paths)
+    if full_reason is not None:
+        return CiImpact.full_selection(
+            full_reason,
+            paths,
+            ignored_markdown=ignored_markdown,
+            ignored_apps=ignored_apps,
+        )
+
+    try:
+        package_index = _package_path_index(workspace_root, metadata_by_arch)
+        changed_package_ids: set[str] = set()
+        changed_package_names: set[str] = set()
+        direct_targets: set[str] = set()
+        unknown_paths: list[Path] = []
+
+        for path in relevant_paths:
+            known_targets = _known_path_targets(path)
+            if known_targets:
+                direct_targets.update(known_targets)
+                continue
+            package = _package_for_path(path, package_index)
+            if package is not None:
+                changed_package_ids.add(package.package_id)
+                changed_package_names.add(package.name)
+                continue
+            unknown_paths.append(path)
+
+        if unknown_paths:
+            unknown = ", ".join(path.as_posix() for path in unknown_paths)
+            return CiImpact.full_selection(
+                f"changed path is outside known packages and OS inputs: {unknown}",
+                paths,
+                ignored_markdown=ignored_markdown,
+                ignored_apps=ignored_apps,
+            )
+
+        targets = set(direct_targets)
+        affected_names = set(changed_package_names)
+        for arch in ARCH_TARGETS:
+            metadata = metadata_by_arch.get(arch)
+            if metadata is None:
+                raise ImpactError(f"missing cargo metadata for {arch}")
+            affected_ids, id_to_name = _affected_package_ids(
+                metadata, changed_package_ids
+            )
+            affected_names.update(
+                id_to_name[package_id]
+                for package_id in affected_ids
+                if package_id in id_to_name
+            )
+            root_ids = _os_root_package_ids(metadata)
+            for os_name, root_id in root_ids.items():
+                if root_id in affected_ids:
+                    targets.add(f"{os_name}:{arch}")
+            if _affected_axtest_runs_in_arceos_ci(metadata, affected_ids, arch):
+                targets.add(f"arceos:{arch}")
+
+        return CiImpact(
+            full=False,
+            reason="pull request impact resolved",
+            changed_paths=_sorted_path_strings(paths),
+            ignored_markdown=tuple(sorted(ignored_markdown)),
+            ignored_apps=tuple(sorted(ignored_apps)),
+            changed_packages=tuple(sorted(changed_package_names)),
+            affected_packages=tuple(sorted(affected_names)),
+            targets=tuple(sorted(targets, key=_target_sort_key)),
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        return CiImpact.full_selection(
+            f"invalid cargo metadata: {error}",
+            paths,
+            ignored_markdown=ignored_markdown,
+            ignored_apps=ignored_apps,
+        )
+
+
+def render_summary(
+    impact: CiImpact,
+    selected_check_ids: Sequence[str],
+    skipped_check_ids: Sequence[str],
+) -> str:
+    mode = "full fallback" if impact.full else "incremental"
+    lines = [
+        "## PR CI impact",
+        "",
+        f"- Mode: **{mode}**",
+        f"- Reason: {impact.reason}",
+        f"- Changed paths: {_render_values(impact.changed_paths)}",
+        f"- Ignored Markdown: {_render_values(impact.ignored_markdown)}",
+        f"- Ignored apps: {_render_values(impact.ignored_apps)}",
+        f"- Changed packages: {_render_values(impact.changed_packages)}",
+        f"- Affected packages: {_render_values(impact.affected_packages)}",
+        f"- OS/arch targets: {_render_values(impact.targets)}",
+        f"- Selected checks ({len(selected_check_ids)}): {_render_values(selected_check_ids)}",
+        f"- Skipped checks ({len(skipped_check_ids)}): {_render_values(skipped_check_ids)}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def _partition_ignored(
+    changed_paths: Iterable[Path],
+) -> tuple[set[str], set[str], list[Path]]:
+    ignored_markdown = set()
+    ignored_apps = set()
+    relevant = []
+    for path in changed_paths:
+        path = _normalize_relative_path(path)
+        rendered = path.as_posix()
+        if path.suffix.casefold() == ".md":
+            ignored_markdown.add(rendered)
+        elif _is_prefix(path, IGNORED_APP_PREFIX):
+            ignored_apps.add(rendered)
+        else:
+            relevant.append(path)
+    return ignored_markdown, ignored_apps, relevant
+
+
+def _requires_full_matrix(path: Path) -> bool:
+    return path in FULL_PATHS or any(_is_prefix(path, prefix) for prefix in FULL_PREFIXES)
+
+
+def _pre_metadata_full_reason(
+    workspace_root: Path, changed_paths: Iterable[Path]
+) -> str | None:
+    for path in changed_paths:
+        if _requires_full_matrix(path):
+            return f"global CI input `{path.as_posix()}` changed"
+        if path.name == "Cargo.toml" and not (workspace_root / path).is_file():
+            return f"package manifest `{path.as_posix()}` was deleted"
+    return None
+
+
+def _package_path_index(
+    workspace_root: Path, metadata_by_arch: Mapping[str, dict]
+) -> list[PackagePathEntry]:
+    if not metadata_by_arch:
+        raise ImpactError("cargo metadata is empty")
+    first_metadata = next(iter(metadata_by_arch.values()))
+    workspace_members = set(first_metadata["workspace_members"])
+    entries = []
+    for package in first_metadata["packages"]:
+        if package["id"] not in workspace_members:
+            continue
+        manifest_path = Path(package["manifest_path"]).resolve()
+        try:
+            relative_dir = manifest_path.parent.relative_to(workspace_root)
+        except ValueError as error:
+            raise ImpactError(
+                f"workspace package `{package['name']}` is outside the workspace"
+            ) from error
+        entries.append(
+            PackagePathEntry(package["id"], package["name"], relative_dir)
+        )
+    entries.sort(
+        key=lambda entry: (-len(entry.relative_dir.parts), entry.name, entry.package_id)
+    )
+    return entries
+
+
+def _package_for_path(
+    path: Path, package_index: Sequence[PackagePathEntry]
+) -> PackagePathEntry | None:
+    for package in package_index:
+        if path == package.relative_dir or _is_prefix(path, package.relative_dir):
+            return package
+    return None
+
+
+def _affected_package_ids(
+    metadata: dict, changed_package_ids: set[str]
+) -> tuple[set[str], dict[str, str]]:
+    workspace_members = set(metadata["workspace_members"])
+    id_to_name = {
+        package["id"]: package["name"]
+        for package in metadata["packages"]
+        if package["id"] in workspace_members
+    }
+    missing_changed = changed_package_ids - workspace_members
+    if missing_changed:
+        raise ImpactError(
+            f"changed packages are missing from target metadata: {sorted(missing_changed)}"
+        )
+    resolve = metadata.get("resolve")
+    if not isinstance(resolve, dict) or not isinstance(resolve.get("nodes"), list):
+        raise ImpactError("cargo metadata did not provide a dependency graph")
+
+    reverse_dependencies: dict[str, set[str]] = defaultdict(set)
+    for node in resolve["nodes"]:
+        node_id = node["id"]
+        if node_id not in workspace_members:
+            continue
+        for dependency in node.get("deps", []):
+            dependency_id = dependency["pkg"]
+            if dependency_id in workspace_members:
+                reverse_dependencies[dependency_id].add(node_id)
+
+    affected = set()
+    stack = list(changed_package_ids)
+    while stack:
+        package_id = stack.pop()
+        if package_id in affected:
+            continue
+        affected.add(package_id)
+        stack.extend(reverse_dependencies.get(package_id, ()))
+    return affected, id_to_name
+
+
+def _os_root_package_ids(metadata: dict) -> dict[str, str]:
+    workspace_members = set(metadata["workspace_members"])
+    names_to_ids: dict[str, list[str]] = defaultdict(list)
+    for package in metadata["packages"]:
+        if package["id"] in workspace_members:
+            names_to_ids[package["name"]].append(package["id"])
+
+    roots = {}
+    for os_name, package_name in OS_ROOT_PACKAGES.items():
+        ids = names_to_ids.get(package_name, [])
+        if len(ids) != 1:
+            raise ImpactError(
+                f"expected exactly one workspace package `{package_name}`, found {len(ids)}"
+            )
+        roots[os_name] = ids[0]
+    return roots
+
+
+def _affected_axtest_runs_in_arceos_ci(
+    metadata: dict, affected_ids: set[str], arch: str
+) -> bool:
+    workspace_members = set(metadata["workspace_members"])
+    packages_by_id = {
+        package["id"]: package
+        for package in metadata["packages"]
+        if package["id"] in workspace_members
+    }
+    axtest_ids = [
+        package_id
+        for package_id, package in packages_by_id.items()
+        if package["name"] == "axtest"
+    ]
+    if not axtest_ids:
+        return False
+    if len(axtest_ids) != 1:
+        raise ImpactError(
+            f"expected exactly one workspace package `axtest`, found {len(axtest_ids)}"
+        )
+    axtest_id = axtest_ids[0]
+    nodes_by_id = {node["id"]: node for node in metadata["resolve"]["nodes"]}
+
+    for package_id in affected_ids:
+        package = packages_by_id[package_id]
+        if package["name"] in ARCEOS_KTEST_EXCLUDED_PACKAGES:
+            continue
+        node = nodes_by_id.get(package_id)
+        if node is None:
+            raise ImpactError(f"missing dependency node for `{package['name']}`")
+        uses_axtest = any(
+            dependency["pkg"] == axtest_id
+            and any(
+                dependency_kind.get("kind") == "dev"
+                for dependency_kind in dependency.get("dep_kinds", [])
+            )
+            for dependency in node.get("deps", [])
+        )
+        if not uses_axtest:
+            continue
+
+        package_metadata = package.get("metadata") or {}
+        if not isinstance(package_metadata, dict):
+            raise ImpactError(f"invalid package metadata for `{package['name']}`")
+        axtest_metadata = package_metadata.get("axtest") or {}
+        if not isinstance(axtest_metadata, dict):
+            raise ImpactError(f"invalid axtest metadata for `{package['name']}`")
+        runtime = axtest_metadata.get("runtime", "arceos")
+        if runtime not in {"arceos", "starry", "axvisor", "board"}:
+            raise ImpactError(
+                f"unsupported axtest runtime `{runtime}` for `{package['name']}`"
+            )
+        if runtime == "board":
+            continue
+        if arch in _package_axtest_arches(package):
+            return True
+    return False
+
+
+def _package_axtest_arches(package: dict) -> set[str]:
+    package_metadata = package.get("metadata") or {}
+    docs_metadata = package_metadata.get("docs") or {}
+    if not isinstance(docs_metadata, dict):
+        raise ImpactError(f"invalid docs metadata for `{package['name']}`")
+    rustdoc_metadata = docs_metadata.get("rs") or {}
+    if not isinstance(rustdoc_metadata, dict):
+        raise ImpactError(f"invalid docs.rs metadata for `{package['name']}`")
+    declared_targets = rustdoc_metadata.get("targets")
+    if declared_targets is None:
+        return {"x86_64"}
+    if not isinstance(declared_targets, list) or any(
+        not isinstance(target, str) for target in declared_targets
+    ):
+        raise ImpactError(f"invalid docs.rs targets for `{package['name']}`")
+    target_to_arch = {target: arch for arch, target in ARCH_TARGETS.items()}
+    supported_arches = {
+        target_to_arch[target] for target in declared_targets if target in target_to_arch
+    }
+    if not supported_arches:
+        raise ImpactError(
+            f"package `{package['name']}` has no supported bare-metal axtest target"
+        )
+    return supported_arches
+
+
+def _known_path_targets(path: Path) -> set[str]:
+    for prefix, os_name in KNOWN_OS_PATHS:
+        if not _is_prefix(path, prefix):
+            continue
+        arches = _arch_hints(path)
+        if not arches:
+            arches = set(ARCH_TARGETS)
+        return {f"{os_name}:{arch}" for arch in arches}
+    return set()
+
+
+def _arch_hints(path: Path) -> set[str]:
+    rendered = path.as_posix().casefold()
+    hints = set()
+    for arch, target in ARCH_TARGETS.items():
+        aliases = {arch.casefold(), target.casefold()}
+        if any(
+            re.search(rf"(^|[^a-z0-9]){re.escape(alias)}([^a-z0-9]|$)", rendered)
+            for alias in aliases
+        ):
+            hints.add(arch)
+    if "riscv64gc" in rendered:
+        hints.add("riscv64")
+    for arch, aliases in ARCH_PATH_ALIASES.items():
+        if any(alias in rendered for alias in aliases):
+            hints.add(arch)
+    return hints
+
+
+def _normalize_relative_path(path: Path) -> Path:
+    if path.is_absolute():
+        raise ImpactError(f"absolute changed path is not allowed: {path}")
+    normalized = Path()
+    for component in path.parts:
+        if component in ("", "."):
+            continue
+        if component == "..":
+            raise ImpactError(f"parent traversal is not allowed: {path}")
+        normalized /= component
+    if not normalized.parts:
+        raise ImpactError("empty changed path is not allowed")
+    return normalized
+
+
+def _is_prefix(path: Path, prefix: Path) -> bool:
+    return path == prefix or prefix in path.parents
+
+
+def _target_sort_key(target: str) -> tuple[int, int, str]:
+    os_name, _, arch = target.partition(":")
+    return (
+        list(OS_ROOT_PACKAGES).index(os_name) if os_name in OS_ROOT_PACKAGES else 999,
+        list(ARCH_TARGETS).index(arch) if arch in ARCH_TARGETS else 999,
+        target,
+    )
+
+
+def _sorted_path_strings(paths: Iterable[Path | str]) -> tuple[str, ...]:
+    return tuple(sorted({Path(path).as_posix() for path in paths}))
+
+
+def _render_values(values: Sequence[str]) -> str:
+    if not values:
+        return "none"
+    return ", ".join(
+        f"`{value.replace('`', '').replace(chr(10), ' ')}`" for value in values
+    )

--- a/scripts/test/ci_plan.py
+++ b/scripts/test/ci_plan.py
@@ -5,10 +5,16 @@ import json
 import os
 import re
 import sys
-import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable
+
+if sys.version_info < (3, 11):
+    raise SystemExit("ci_plan.py requires Python 3.11 or newer")
+
+import tomllib
+
+from ci_impact import CiImpact, analyze_pull_request, render_summary
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
@@ -25,6 +31,12 @@ STARRY_APPS_MANIFEST = CHECKS_ROOT / "starry-apps.toml"
 SUPPORTED_PHASES = {"static", "test", "starry_apps"}
 SUPPORTED_ENVIRONMENTS = {"host", "base", "axvisor-lvz"}
 SUPPORTED_PREFLIGHTS = {"none", "qemu-user", "full"}
+SUPPORTED_IMPACT_TARGETS = {
+    f"{os_name}:{arch}"
+    for os_name in ("arceos", "starry", "axvisor")
+    for arch in ("aarch64", "x86_64", "riscv64", "loongarch64")
+}
+SUPPORTED_IMPACT_PACKAGES = {"axloader"}
 CHECK_ID_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
 REDUNDANT_NAME_PREFIX_PATTERN = re.compile(
     r"^(?:check|run|scheduled|tests?)\b", re.IGNORECASE
@@ -51,6 +63,9 @@ CHECK_FIELDS = {
     "container_preflight",
     "events",
     "enable_boolean_input",
+    "impact_targets",
+    "impact_packages",
+    "pull_request_command",
 }
 REQUIRED_CHECK_FIELDS = {"id", "name", "runs_on", "environment", "command"}
 BOOLEAN_CHECK_FIELDS = {
@@ -71,6 +86,7 @@ class PlanContext:
     event_name: str
     base_ref: str = ""
     enabled_boolean_inputs: frozenset[str] = frozenset()
+    impact: CiImpact | None = None
 
 
 def load_catalog(manifests: Iterable[Path]) -> list[dict[str, Any]]:
@@ -94,6 +110,7 @@ def load_catalog(manifests: Iterable[Path]) -> list[dict[str, Any]]:
             checks.append(check)
 
     _validate_artifact_contract(checks)
+    _validate_impact_contract(checks)
     return checks
 
 
@@ -137,8 +154,8 @@ def _load_manifest(manifest: Path) -> dict[str, Any]:
         raise PlanError(
             f"{manifest} has unknown top-level fields: {sorted(unknown_fields)}"
         )
-    if document.get("schema_version") != 1:
-        raise PlanError(f"{manifest} must declare schema_version = 1")
+    if document.get("schema_version") != 2:
+        raise PlanError(f"{manifest} must declare schema_version = 2")
     if document.get("phase") not in SUPPORTED_PHASES:
         raise PlanError(f"{manifest} has an unsupported phase")
     if not isinstance(document.get("group"), str) or not document["group"].strip():
@@ -245,7 +262,43 @@ def _validate_check(
     ):
         raise PlanError(f"{location} cannot both upload and download the artifact")
 
+    impact_targets = check.get("impact_targets")
+    if impact_targets is not None:
+        _validate_string_array(impact_targets, "impact_targets", location)
+        unsupported_targets = set(impact_targets) - SUPPORTED_IMPACT_TARGETS
+        if unsupported_targets:
+            raise PlanError(
+                f"{location} has unsupported impact_targets: {sorted(unsupported_targets)}"
+            )
+
+    impact_packages = check.get("impact_packages")
+    if impact_packages is not None:
+        _validate_string_array(impact_packages, "impact_packages", location)
+        unsupported_packages = set(impact_packages) - SUPPORTED_IMPACT_PACKAGES
+        if unsupported_packages:
+            raise PlanError(
+                f"{location} has unsupported impact_packages: {sorted(unsupported_packages)}"
+            )
+
+    pull_request_command = check.get("pull_request_command")
+    if pull_request_command is not None and (
+        not isinstance(pull_request_command, str) or not pull_request_command.strip()
+    ):
+        raise PlanError(
+            f"{location} pull_request_command must be a non-empty string"
+        )
+
     return check
+
+
+def _validate_string_array(value: Any, field: str, location: str) -> None:
+    if (
+        not isinstance(value, list)
+        or not value
+        or any(not isinstance(item, str) or not item for item in value)
+        or len(set(value)) != len(value)
+    ):
+        raise PlanError(f"{location} {field} must be a unique non-empty string array")
 
 
 def _validate_display_name(name: str, group: str, location: str) -> None:
@@ -286,13 +339,25 @@ def _validate_artifact_contract(checks: list[dict[str, Any]]) -> None:
             )
 
 
+def _validate_impact_contract(checks: list[dict[str, Any]]) -> None:
+    for check in checks:
+        if check["phase"] != "test" or check["group"] == "Workspace":
+            continue
+        if not check.get("impact_targets") and not check.get("impact_packages"):
+            raise PlanError(
+                f"test check '{check['id']}' must declare impact_targets or impact_packages"
+            )
+
+
 def _plan_phase(
     checks: list[dict[str, Any]], phase: str, context: PlanContext
 ) -> list[dict[str, Any]]:
     return [
         _normalize_check(check, context)
         for check in checks
-        if check["phase"] == phase and _is_enabled(check, context)
+        if check["phase"] == phase
+        and _is_enabled(check, context)
+        and _matches_impact(check, context)
     ]
 
 
@@ -316,6 +381,22 @@ def _is_enabled(check: dict[str, Any], context: PlanContext) -> bool:
             return False
 
     return True
+
+
+def _matches_impact(check: dict[str, Any], context: PlanContext) -> bool:
+    impact = context.impact
+    if context.event_name != "pull_request" or impact is None or impact.full:
+        return True
+
+    impact_targets = set(check.get("impact_targets", ()))
+    impact_packages = set(check.get("impact_packages", ()))
+    if not impact_targets and not impact_packages:
+        return True
+
+    return bool(
+        impact_targets.intersection(impact.targets)
+        or impact_packages.intersection(impact.affected_packages)
+    )
 
 
 def _normalize_check(
@@ -348,6 +429,15 @@ def _normalize_check(
     if fallback and check["phase"] == "test":
         download_xtask = True
 
+    command = check["command"]
+    if (
+        context.event_name == "pull_request"
+        and context.impact is not None
+        and not context.impact.full
+        and check.get("pull_request_command")
+    ):
+        command = check["pull_request_command"]
+
     return {
         "id": check["id"],
         "name": name,
@@ -355,7 +445,7 @@ def _normalize_check(
         "runs_on": runs_on,
         "container_image": container_image,
         "container_preflight": preflight,
-        "command": check["command"].strip(),
+        "command": command.strip(),
         "cache_key": check.get("cache_key", ""),
         "apk_region": check.get("apk_region", "china"),
         "fetch_depth": fetch_depth,
@@ -390,6 +480,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--repository-owner", required=True)
     parser.add_argument("--event-name", required=True)
     parser.add_argument("--base-ref", default="")
+    parser.add_argument("--since-ref", default="")
     parser.add_argument("--boolean-input", action="append", default=[])
     parser.add_argument(
         "--output-file",
@@ -400,17 +491,30 @@ def _parse_args() -> argparse.Namespace:
             else None
         ),
     )
+    parser.add_argument(
+        "--summary-file",
+        type=Path,
+        default=(
+            Path(os.environ["GITHUB_STEP_SUMMARY"])
+            if "GITHUB_STEP_SUMMARY" in os.environ
+            else None
+        ),
+    )
     return parser.parse_args()
 
 
 def main() -> int:
     args = _parse_args()
+    impact = None
+    if args.mode == "main" and args.event_name == "pull_request":
+        impact = analyze_pull_request(WORKSPACE_ROOT, args.since_ref)
     context = PlanContext(
         repository=args.repository,
         repository_owner=args.repository_owner,
         event_name=args.event_name,
         base_ref=args.base_ref,
         enabled_boolean_inputs=frozenset(args.boolean_input),
+        impact=impact,
     )
     try:
         if args.mode == "main":
@@ -428,6 +532,23 @@ def main() -> int:
 
     for name, matrix in outputs.items():
         print(f"{name}: {len(matrix['include'])} checks", file=sys.stderr)
+    if impact is not None:
+        selected_ids = [
+            row["id"]
+            for matrix in outputs.values()
+            for row in matrix["include"]
+        ]
+        eligible_ids = [
+            check["id"]
+            for check in load_catalog(MAIN_MANIFESTS)
+            if _is_enabled(check, context)
+        ]
+        skipped_ids = [check_id for check_id in eligible_ids if check_id not in selected_ids]
+        summary = render_summary(impact, selected_ids, skipped_ids)
+        print(summary, file=sys.stderr)
+        if args.summary_file is not None:
+            with args.summary_file.open("a", encoding="utf-8") as summary_file:
+                summary_file.write(summary)
     return 0
 
 

--- a/scripts/test/test_ci_impact.py
+++ b/scripts/test/test_ci_impact.py
@@ -96,6 +96,21 @@ class CiImpactTests(unittest.TestCase):
             self.metadata_by_arch,
         )
 
+        self.assertFalse(impact.full)
+        self.assertEqual(impact.changed_packages, ("shared",))
+        self.assertEqual(
+            impact.affected_packages,
+            ("arceos-test-suit", "axvisor", "shared", "starryos"),
+        )
+        self.assertEqual(
+            set(impact.targets),
+            {
+                f"{os_name}:{arch}"
+                for os_name in ("arceos", "starry", "axvisor")
+                for arch in ci_impact.ARCH_TARGETS
+            },
+        )
+
     def test_markdown_does_not_expand_a_mixed_code_change(self) -> None:
         impact = ci_impact.analyze_changed_paths(
             self.workspace_root,
@@ -112,9 +127,6 @@ class CiImpactTests(unittest.TestCase):
             impact.ignored_markdown,
             ("virtualization/arm-vcpu/README.md",),
         )
-
-        self.assertFalse(impact.full)
-        self.assertEqual(impact.changed_packages, ("shared",))
         self.assertEqual(
             set(impact.targets),
             {

--- a/scripts/test/test_ci_impact.py
+++ b/scripts/test/test_ci_impact.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("ci_impact.py")
+SPEC = importlib.util.spec_from_file_location("ci_impact", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+ci_impact = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(ci_impact)
+
+
+class CiImpactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.workspace_root = Path(self.temp_dir.name)
+        package_dirs = {
+            "shared": "components/shared",
+            "arm-vcpu": "virtualization/arm-vcpu",
+            "standalone": "tools/standalone",
+            "axtest": "components/axtest/axtest",
+            "ktest-only": "components/ktest-only",
+            "arceos-test-suit": "test-suit/arceos/rust",
+            "starryos": "os/StarryOS/starryos",
+            "axvisor": "os/axvisor",
+        }
+        self.packages = []
+        for package, relative_dir in package_dirs.items():
+            manifest = self.workspace_root / relative_dir / "Cargo.toml"
+            manifest.parent.mkdir(parents=True, exist_ok=True)
+            manifest.write_text("[package]\n", encoding="utf-8")
+            package_metadata = {}
+            if package == "ktest-only":
+                package_metadata = {
+                    "metadata": {
+                        "docs": {
+                            "rs": {
+                                "targets": [
+                                    ci_impact.ARCH_TARGETS["x86_64"],
+                                    ci_impact.ARCH_TARGETS["aarch64"],
+                                ]
+                            }
+                        }
+                    }
+                }
+            self.packages.append(
+                {
+                    "id": f"path+file:///{package}#0.1.0",
+                    "name": package,
+                    "manifest_path": str(manifest),
+                    **package_metadata,
+                }
+            )
+
+        self.package_ids = {
+            package["name"]: package["id"] for package in self.packages
+        }
+        self.metadata_by_arch = {
+            arch: self._metadata(arch) for arch in ci_impact.ARCH_TARGETS
+        }
+
+    def _metadata(self, arch: str) -> dict:
+        shared = self.package_ids["shared"]
+        arm_vcpu = self.package_ids["arm-vcpu"]
+        dependency_names = {
+            "arceos-test-suit": ["shared"],
+            "starryos": ["shared"],
+            "axvisor": ["shared"] + (["arm-vcpu"] if arch == "aarch64" else []),
+            "ktest-only": ["axtest"],
+        }
+        nodes = []
+        for package in self.packages:
+            deps = []
+            for name in dependency_names.get(package["name"], []):
+                dep_kinds = [{"kind": "dev", "target": None}] if name == "axtest" else []
+                deps.append({"pkg": self.package_ids[name], "dep_kinds": dep_kinds})
+            nodes.append({"id": package["id"], "deps": deps})
+        self.assertIn(shared, {node["id"] for node in nodes})
+        self.assertIn(arm_vcpu, {node["id"] for node in nodes})
+        return {
+            "workspace_root": str(self.workspace_root),
+            "workspace_members": [package["id"] for package in self.packages],
+            "packages": self.packages,
+            "resolve": {"nodes": nodes},
+        }
+
+    def test_shared_crate_selects_every_os_on_every_arch(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [Path("components/shared/src/lib.rs")],
+            self.metadata_by_arch,
+        )
+
+    def test_markdown_does_not_expand_a_mixed_code_change(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [
+                Path("components/shared/src/lib.rs"),
+                Path("virtualization/arm-vcpu/README.md"),
+            ],
+            self.metadata_by_arch,
+        )
+
+        self.assertFalse(impact.full)
+        self.assertEqual(impact.changed_packages, ("shared",))
+        self.assertEqual(
+            impact.ignored_markdown,
+            ("virtualization/arm-vcpu/README.md",),
+        )
+
+        self.assertFalse(impact.full)
+        self.assertEqual(impact.changed_packages, ("shared",))
+        self.assertEqual(
+            set(impact.targets),
+            {
+                f"{os_name}:{arch}"
+                for os_name in ("arceos", "starry", "axvisor")
+                for arch in ci_impact.ARCH_TARGETS
+            },
+        )
+
+    def test_target_specific_crate_selects_only_matching_target(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [Path("virtualization/arm-vcpu/src/lib.rs")],
+            self.metadata_by_arch,
+        )
+
+        self.assertFalse(impact.full)
+        self.assertEqual(impact.targets, ("axvisor:aarch64",))
+
+    def test_standalone_crate_does_not_select_an_os(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [Path("tools/standalone/src/main.rs")],
+            self.metadata_by_arch,
+        )
+
+        self.assertFalse(impact.full)
+        self.assertEqual(impact.changed_packages, ("standalone",))
+        self.assertEqual(impact.affected_packages, ("standalone",))
+        self.assertEqual(impact.targets, ())
+
+    def test_standalone_axtest_package_selects_its_ci_architectures(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [Path("components/ktest-only/src/lib.rs")],
+            self.metadata_by_arch,
+        )
+
+        self.assertFalse(impact.full)
+        self.assertEqual(
+            impact.targets,
+            ("arceos:aarch64", "arceos:x86_64"),
+        )
+
+    def test_markdown_and_apps_do_not_expand_runtime_impact(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [
+                Path("components/shared/README.md"),
+                Path("apps/starry/demo/prebuild.sh"),
+            ],
+            self.metadata_by_arch,
+        )
+
+        self.assertFalse(impact.full)
+        self.assertEqual(impact.targets, ())
+        self.assertEqual(impact.ignored_markdown, ("components/shared/README.md",))
+        self.assertEqual(impact.ignored_apps, ("apps/starry/demo/prebuild.sh",))
+
+    def test_known_non_package_path_uses_os_and_arch_hint(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [Path("test-suit/starryos/qemu-aarch64.toml")],
+            self.metadata_by_arch,
+        )
+
+        self.assertFalse(impact.full)
+        self.assertEqual(impact.targets, ("starry:aarch64",))
+
+    def test_os_specific_config_without_arch_hint_selects_all_os_arches(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [Path("os/arceos/configs/defconfig.toml")],
+            self.metadata_by_arch,
+        )
+
+        self.assertFalse(impact.full)
+        self.assertEqual(
+            impact.targets,
+            tuple(f"arceos:{arch}" for arch in ci_impact.ARCH_TARGETS),
+        )
+
+    def test_known_config_names_map_to_board_architectures(self) -> None:
+        cases = {
+            "os/StarryOS/configs/board/visionfive2.toml": ("starry:riscv64",),
+            "os/StarryOS/configs/board/jl-lsgd2k10.toml": (
+                "starry:loongarch64",
+            ),
+            "os/axvisor/configs/board/asus-nuc15crh-x86_64.toml": (
+                "axvisor:x86_64",
+            ),
+            "os/axvisor/configs/board/orangepi-5-plus.toml": (
+                "axvisor:aarch64",
+            ),
+        }
+        for changed_path, expected_targets in cases.items():
+            with self.subTest(path=changed_path):
+                impact = ci_impact.analyze_changed_paths(
+                    self.workspace_root,
+                    [Path(changed_path)],
+                    self.metadata_by_arch,
+                )
+
+                self.assertFalse(impact.full)
+                self.assertEqual(impact.targets, expected_targets)
+
+    def test_deleted_package_manifest_falls_back_to_full(self) -> None:
+        manifest = self.workspace_root / "tools/standalone/Cargo.toml"
+        manifest.unlink()
+
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [Path("tools/standalone/Cargo.toml")],
+            self.metadata_by_arch,
+        )
+
+        self.assertTrue(impact.full)
+        self.assertIn("was deleted", impact.reason)
+
+    def test_diff_and_metadata_failures_fall_back_to_full(self) -> None:
+        with mock.patch.object(
+            ci_impact,
+            "changed_paths_since",
+            side_effect=ci_impact.subprocess.CalledProcessError(1, ["git", "diff"]),
+        ):
+            diff_failure = ci_impact.analyze_pull_request(self.workspace_root, "base")
+
+        with (
+            mock.patch.object(
+                ci_impact,
+                "changed_paths_since",
+                return_value=[
+                    Path("components/shared/src/lib.rs"),
+                    Path("components/shared/README.md"),
+                ],
+            ),
+            mock.patch.object(
+                ci_impact,
+                "load_metadata_by_arch",
+                side_effect=OSError("metadata unavailable"),
+            ),
+        ):
+            metadata_failure = ci_impact.analyze_pull_request(
+                self.workspace_root, "base"
+            )
+
+        self.assertTrue(diff_failure.full)
+        self.assertTrue(metadata_failure.full)
+        self.assertEqual(
+            metadata_failure.ignored_markdown,
+            ("components/shared/README.md",),
+        )
+        self.assertEqual(len(metadata_failure.targets), 12)
+
+    def test_global_change_skips_unneeded_metadata_loading(self) -> None:
+        with (
+            mock.patch.object(
+                ci_impact,
+                "changed_paths_since",
+                return_value=[Path("scripts/test/ci_impact.py")],
+            ),
+            mock.patch.object(ci_impact, "load_metadata_by_arch") as load_metadata,
+        ):
+            impact = ci_impact.analyze_pull_request(self.workspace_root, "base")
+
+        self.assertTrue(impact.full)
+        load_metadata.assert_not_called()
+
+    def test_summary_reports_selected_and_skipped_checks(self) -> None:
+        impact = ci_impact.CiImpact(
+            full=False,
+            reason="fixture",
+            changed_paths=("components/shared/src/lib.rs",),
+            ignored_markdown=("components/shared/README.md",),
+            changed_packages=("shared",),
+            affected_packages=("shared", "starryos"),
+            targets=("starry:aarch64",),
+        )
+
+        summary = ci_impact.render_summary(
+            impact,
+            ["run-clippy", "test-starry-aarch64-qemu"],
+            ["test-starry-x86-64-qemu"],
+        )
+
+        self.assertIn("components/shared/src/lib.rs", summary)
+        self.assertIn("components/shared/README.md", summary)
+        self.assertIn("starry:aarch64", summary)
+        self.assertIn("Selected checks (2)", summary)
+        self.assertIn("Skipped checks (1)", summary)
+
+    def test_unknown_and_global_paths_fall_back_to_full(self) -> None:
+        for changed_path in (
+            "unknown/input.bin",
+            "Cargo.toml",
+            "Cargo.lock",
+            ".cargo/config.toml",
+            "scripts/axbuild/src/lib.rs",
+            "scripts/test/ci_plan.py",
+            "xtask/src/main.rs",
+            ".github/ci/checks/starry.toml",
+        ):
+            with self.subTest(path=changed_path):
+                impact = ci_impact.analyze_changed_paths(
+                    self.workspace_root,
+                    [Path(changed_path)],
+                    self.metadata_by_arch,
+                )
+
+                self.assertTrue(impact.full)
+                self.assertTrue(impact.reason)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import importlib.util
+import sys
 import unittest
 from pathlib import Path
 from unittest import mock
 
 
 MODULE_PATH = Path(__file__).with_name("ci_plan.py")
+sys.path.insert(0, str(MODULE_PATH.parent))
 SPEC = importlib.util.spec_from_file_location("ci_plan", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 ci_plan = importlib.util.module_from_spec(SPEC)
@@ -30,6 +32,131 @@ class CiPlanTests(unittest.TestCase):
         self.assertTrue(
             all(" / " in row["name"] for row in plan["test_matrix"]["include"])
         )
+
+    def test_pull_request_impact_selects_only_matching_os_and_arch(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            base_ref="dev",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=("os/arceos/modules/axhal/src/lib.rs",),
+                changed_packages=("ax-hal",),
+                affected_packages=("ax-hal",),
+                targets=("arceos:aarch64",),
+            ),
+        )
+
+        plan = ci_plan.build_main_plan(context)
+        ids = {row["id"] for row in plan["test_matrix"]["include"]}
+
+        self.assertEqual(
+            ids,
+            {
+                "run-clippy",
+                "test-with-std",
+                "test-arceos-aarch64-qemu-app-suites",
+            },
+        )
+
+    def test_pull_request_impact_package_selects_standalone_check(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=("bootloader/axloader/src/main.rs",),
+                changed_packages=("axloader",),
+                affected_packages=("axloader",),
+            ),
+        )
+
+        plan = ci_plan.build_main_plan(context)
+        ids = {row["id"] for row in plan["test_matrix"]["include"]}
+
+        self.assertIn("test-axloader-http-smoke", ids)
+        self.assertFalse(any(check_id.startswith("test-arceos-") for check_id in ids))
+        self.assertFalse(any(check_id.startswith("test-starry-") for check_id in ids))
+
+    def test_incremental_pr_uses_std_since_but_full_pr_does_not(self) -> None:
+        incremental = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=("components/shared/src/lib.rs",),
+            ),
+        )
+        full = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact.full_selection("fixture"),
+        )
+
+        incremental_rows = {
+            row["id"]: row for row in ci_plan.build_main_plan(incremental)["test_matrix"]["include"]
+        }
+        full_rows = {
+            row["id"]: row for row in ci_plan.build_main_plan(full)["test_matrix"]["include"]
+        }
+
+        self.assertIn('--since "$SINCE_REF"', incremental_rows["test-with-std"]["command"])
+        self.assertNotIn("--since", full_rows["test-with-std"]["command"])
+        self.assertEqual(len(full_rows), 32)
+
+    def test_app_only_impact_does_not_select_runtime_checks(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            base_ref="dev",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="only ignored app paths changed",
+                changed_paths=("apps/starry/demo/main.c",),
+                ignored_apps=("apps/starry/demo/main.c",),
+            ),
+        )
+
+        plan = ci_plan.build_main_plan(context)
+        test_ids = {row["id"] for row in plan["test_matrix"]["include"]}
+
+        self.assertEqual(test_ids, {"run-clippy", "test-with-std"})
+
+    def test_non_pr_events_ignore_impact_and_preserve_full_matrix(self) -> None:
+        impact = ci_plan.CiImpact(
+            full=False,
+            reason="must be ignored outside pull requests",
+            changed_paths=("virtualization/arm_vcpu/src/lib.rs",),
+            targets=("axvisor:aarch64",),
+        )
+        for event_name in ("push", "workflow_dispatch"):
+            with self.subTest(event=event_name):
+                baseline = ci_plan.build_main_plan(
+                    ci_plan.PlanContext(
+                        repository="rcore-os/tgoskits",
+                        repository_owner="rcore-os",
+                        event_name=event_name,
+                    )
+                )
+                with_impact = ci_plan.build_main_plan(
+                    ci_plan.PlanContext(
+                        repository="rcore-os/tgoskits",
+                        repository_owner="rcore-os",
+                        event_name=event_name,
+                        impact=impact,
+                    )
+                )
+
+                self.assertEqual(with_impact, baseline)
+                self.assertEqual(len(with_impact["test_matrix"]["include"]), 32)
 
     def test_display_names_expose_target_and_purpose(self) -> None:
         plan = ci_plan.build_main_plan(self.upstream)
@@ -267,6 +394,14 @@ class CiPlanTests(unittest.TestCase):
             ({**valid, "environment": "unknown"}, "unsupported environment"),
             ({**valid, "command": ""}, "non-empty string"),
             ({**valid, "id": "INVALID_ID"}, "lowercase kebab-case"),
+            (
+                {**valid, "impact_targets": ["unknown:aarch64"]},
+                "unsupported impact_targets",
+            ),
+            (
+                {**valid, "impact_packages": ["misspelled-package"]},
+                "unsupported impact_packages",
+            ),
         )
 
         for check, error in invalid_cases:


### PR DESCRIPTION
## 问题

当前 PR CI 对绝大多数代码改动执行完整 OS/架构矩阵，即使改动只影响单一 crate 或单一架构，也会占用全部 QEMU、KVM 和板卡 runner。与此同时，直接缩小矩阵会有漏掉反向依赖、target-specific 依赖和现有 axtest 覆盖的风险。

## 改动

- 新增独立 PR 影响分析模块：
  - 使用 PR base SHA 与 HEAD 的三点 diff；
  - 忽略 `.md` 和 `apps/**`；
  - 将路径映射到最深层 workspace package；
  - 分别对 aarch64、x86_64、riscv64、loongarch64 执行 `cargo metadata --all-features --filter-platform`；
  - 反向追踪到 ArceOS、StarryOS、AxVisor 根 package，并兼容当前 workspace axtest target 声明。
- 扩展 CI check manifest schema：
  - `impact_targets` 声明 check 覆盖的 OS/arch；
  - `impact_packages` 声明 axloader 等独立 package；
  - `pull_request_command` 声明仅供增量 PR 使用的命令。
- PR workflow 增加 Markdown 排除规则，并将 base SHA、影响分析结果和 Actions summary 接入 planner。
- 扩展 `cargo xtask test [--since <REF>]`：增量模式只执行 affected packages 与 `scripts/test/std_crates.csv` 的交集；空交集成功退出。
- 公共 Git package 选择器忽略 crate 内 Markdown，避免混合 PR 的文档改动扩大 Clippy/std package 集合。
- 更新 CI 文档与确定性回归测试；共享 crate 用例显式断言 affected packages 及全部 12 个 OS/arch target，避免空断言造成误通过。

## 设计逻辑

- 仅 `pull_request` 使用影响分析；push、workflow_dispatch 以及 dev/main 流程继续生成原有完整矩阵。
- 每个选中的 OS/arch 仍执行该 check 原有的全部 QEMU、KVM、axtest 和板卡命令；owner/fork 过滤、static → test 顺序、fail-fast、cache 和 artifact 行为不变。
- 已知 OS 配置和 test-suit 文件按目录、target triple 或板卡名映射；只能确定 OS 时选择该 OS 的全部架构。
- Cargo/toolchain、`.cargo/**`、CI planner/workflow/check manifest、任意 xtask、package 删除、未知路径以及 diff/metadata 失败均回退完整矩阵。
- `apps/**` 本身不选择 OS/arch 或 app 运行测试，混合 PR 中其他代码改动仍正常参与分析。
- planner summary 输出 changed/ignored paths、changed/affected packages、OS/arch、选中/跳过 checks 和全量回退原因。

## 代表性矩阵

| 场景 | Static checks | Test checks |
| --- | ---: | ---: |
| 完整矩阵 | 3 | 32 |
| `arm_vcpu` | 3 | 12 |
| Starry aarch64 配置 | 3 | 5 |
| `axloader` | 3 | 3 |
| app-only | 3 | 2 |
| 三 OS 共享 crate | 3 | 31 |

## 验证

- `python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py`（Python 3.12）：37 passed
- mutation 回归：将 `analyze_changed_paths` 替换为空结果时，共享 crate 用例确定性失败
- `cargo test -p axbuild --quiet`：938 passed
- `cargo xtask test --since HEAD`：空选择成功退出
- `cargo xtask clippy --package axbuild`
- `cargo fmt --all -- --check`
- `python3 scripts/test/check_ci_paths.py`
- `python3 scripts/test/check_ci_routing.py`
- `python3 scripts/test/check_workflow_layout.py`
- `actionlint .github/workflows/ci.yml`（忽略仓库既有的 `concurrency.queue` 扩展诊断）
- `git diff --check`

本 PR 修改了 planner、workflow 和 xtask，实现自身会按上述 fail-safe 规则选择完整 CI，需以所有实际 jobs 终端成功作为合并验收条件。