### PR TITLE
fix(starry-kernel): validate sync_file_range fd first

### DIFF
--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -399,6 +399,9 @@ pub fn sys_sync_file_range(fd: c_int, offset: i64, nbytes: i64, flags: u32) -> S
     const SYNC_FILE_RANGE_WAIT_AFTER: u32 = 4;
     const SYNC_FILE_RANGE_ALL: u32 =
         SYNC_FILE_RANGE_WAIT_BEFORE | SYNC_FILE_RANGE_WRITE | SYNC_FILE_RANGE_WAIT_AFTER;
+    // Linux resolves the descriptor before validating range arguments and
+    // flags, so an invalid descriptor takes precedence over EINVAL.
+    let any = get_file_like(fd)?;
     if offset < 0 || nbytes < 0 {
         return Err(StarryError::from(Errno::EINVAL));
     }
@@ -411,7 +414,6 @@ pub fn sys_sync_file_range(fd: c_int, offset: i64, nbytes: i64, flags: u32) -> S
     // stronger whole-file fdatasync-style flush (matches the advisory
     // nature documented in the man page). Invalid fds still surface the
     // underlying error (EBADF). Directory fds are accepted to match fsync.
-    let any = get_file_like(fd)?;
     if any.downcast_ref::<File>().is_none()
         && any.downcast_ref::<Directory>().is_none()
         && any.downcast_ref::<Memfd>().is_none()

--- a/test-suit/starryos/qemu/system/KNOWN_FAILS.md
+++ b/test-suit/starryos/qemu/system/KNOWN_FAILS.md
@@ -17,7 +17,6 @@ but the grouped CI runner only executes `/usr/bin/starry-test-suit/*`.
 - `test-sigqueueinfo`: queued signal delivery with `siginfo`.
 - `test-sigtimedwait`: queued signal delivery with `siginfo`.
 - `test-splice`: offset and same-pipe edge cases.
-- `test-sync-file-range`: errno precedence for invalid fd plus invalid flags.
 - `test-tgsigqueueinfo`: queued thread signal delivery with `siginfo`.
 - `test-uid-gid-direct-setters`: uid/gid setter boundary matrix semantics.
 - `test-uid-gid-groups`: user namespace `setgroups=deny` behavior.

--- a/test-suit/starryos/qemu/system/syscall-test-sync-file-range/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/syscall-test-sync-file-range/CMakeLists.txt
@@ -6,6 +6,4 @@ set(CMAKE_C_EXTENSIONS OFF)
 add_executable(test-sync-file-range src/main.c)
 target_include_directories(test-sync-file-range PRIVATE src)
 target_compile_options(test-sync-file-range PRIVATE -Wall -Wextra -Werror)
-# Build this stricter probe, but keep it out of the grouped CI pass condition
-# until sync_file_range errno precedence matches Linux.
-install(TARGETS test-sync-file-range RUNTIME DESTINATION usr/bin/starry-known-fail)
+install(TARGETS test-sync-file-range RUNTIME DESTINATION usr/bin/starry-test-suit)


### PR DESCRIPTION
## 问题

StarryOS 的 `sync_file_range` 先校验 `flags` 和范围，再解析文件描述符。Linux 则先通过 `fdget()` 解析描述符，因此在“无效 fd + 无效 flags”的组合下，Linux 返回 `EBADF`，StarryOS 错误地返回 `EINVAL`。

参考 Linux 上游实现：<https://github.com/torvalds/linux/commit/0f23d56f17fdfc7db69d51f64c8b91bbab947aa9>

## 修改

- 将 `get_file_like(fd)` 移到参数范围与 flags 校验之前，使 errno 优先级与 Linux 一致。
- 保留后续文件类型检查与同步行为，不扩大 syscall 语义范围。
- 将现有 `test-sync-file-range` 从 `starry-known-fail` 提升到 `starry-test-suit`，并移除对应 known-fail 条目。

## 实现逻辑

文件描述符解析本身就是 Linux `sync_file_range` 的第一项可失败操作。先解析 fd 后，非法 fd 稳定返回 `EBADF`；只有 fd 有效时，负 offset/nbytes 或非法 flags 才返回 `EINVAL`。这样既修正组合错误的优先级，也不改变单独非法参数的结果。

## 验证

- Linux 主机同源 C 用例：16/16 通过。
- 修复前 StarryOS x86_64 QEMU：15/16 通过；`invalid fd + invalid flags` 期望 `EBADF(9)`，实际 `EINVAL(22)`。
- 修复后同一 StarryOS QEMU 用例：16/16 通过；分组结果 1/1 通过。
- `cargo fmt -p starry-kernel --check` 通过。

### 上游 CI 状态

- 第二轮 CI [`32131644875`](https://github.com/rcore-os/tgoskits/actions/runs/32131644875)：Formatting、同步与锁策略、Workspace Clippy/std tests、Starry x86_64/aarch64/loongarch64 均通过。RISC-V 全量套件在无关的 `test-nix-builder-lifecycle` 线程场景挂起，最终触发 1800 秒 QEMU 超时；该轮尚未运行到字母序靠后的 `test-sync-file-range`。
- 第一轮 CI [`32127961360`](https://github.com/rcore-os/tgoskits/actions/runs/32127961360)：RISC-V 上本次变更的 `test-sync-file-range` 已 16/16 通过，随后在无关的 `test-unix-cmsg-byte-marks` 挂起并超时。
- 同一基线 `dev@c76ee0d121` 的 push CI [`32130435526`](https://github.com/rcore-os/tgoskits/actions/runs/32130435526) 中 RISC-V Starry 全量套件通过；两轮在不同后续用例停顿，符合当前非确定性调度停顿。上游已有独立修复 [`#2101`](https://github.com/rcore-os/tgoskits/pull/2101)，本 PR 不混入该跨子系统修复。