### PR TITLE
fix(axtask): preserve scheduler-frame ownership across switches

### DIFF
--- a/components/axbacktrace/src/lib.rs
+++ b/components/axbacktrace/src/lib.rs
@@ -163,7 +163,16 @@ impl CaptureBuf {
 /// Core frame pointer walking logic. Calls `callback` for each valid frame.
 /// The callback returns `false` to stop unwinding (e.g., buffer full).
 #[cfg(feature = "alloc")]
-fn unwind_core(mut fp: usize, mut callback: impl FnMut(Frame) -> bool) {
+fn unwind_core(fp: usize, callback: impl FnMut(Frame) -> bool) {
+    unwind_core_with_max_depth(fp, max_depth(), callback);
+}
+
+#[cfg(feature = "alloc")]
+fn unwind_core_with_max_depth(
+    mut fp: usize,
+    max_depth: usize,
+    mut callback: impl FnMut(Frame) -> bool,
+) {
     let Some(fp_range) = FP_RANGE.get() else {
         log::error!("Backtrace not initialized. Call `axbacktrace::init` first.");
         return;
@@ -171,7 +180,6 @@ fn unwind_core(mut fp: usize, mut callback: impl FnMut(Frame) -> bool) {
 
     let ip_range = IP_RANGE.get();
     let mut depth = 0;
-    let max_depth = max_depth();
 
     while fp_range.contains(&fp)
         && depth < max_depth
@@ -458,7 +466,6 @@ mod tests {
 
     fn init_for_tests() {
         init(0..usize::MAX, 0..usize::MAX);
-        set_max_depth(32);
     }
 
     fn boxed_frame_chain(ips: &[usize]) -> (Box<[Frame]>, usize) {
@@ -642,17 +649,17 @@ mod tests {
     #[test]
     fn stress_deep_chain_truncation() {
         init_for_tests();
-        set_max_depth(16);
         let ips: Vec<usize> = (0..64).map(|i| 0xF000 + i).collect();
         let (chain, start_fp) = boxed_frame_chain(&ips);
 
-        let out = unwind_stack(start_fp);
+        let mut out = Vec::new();
+        unwind_core_with_max_depth(start_fp, 16, |frame| {
+            out.push(frame);
+            true
+        });
         assert_eq!(out.len(), 16);
         // Only the first 16 frames should be collected
         assert_eq!(out.as_slice(), &chain[..16]);
-
-        // Restore default
-        set_max_depth(CAPTURE_CAPACITY);
     }
 
     /// Repeatedly create and drop Backtrace objects to verify no leaks or corruption.

--- a/docs/design/cpu-local-execution-context-boundary.md
+++ b/docs/design/cpu-local-execution-context-boundary.md
@@ -93,8 +93,11 @@ context-switch resume handoff may replace a CPU-owned switch token.
 pending exit returns `PendingPreemption` while depth one remains published.
 `ax-runtime` masks local IRQs, mirrors task work into the pending bit, claims a
 per-CPU scheduler baton, releases the pending depth, clears the mirror, and only
-then invokes the task safe point. The task layer never manipulates the word and
-`cpu-local` never decides whether to schedule.
+then invokes the task safe point. The baton stays in `ax-runtime`: every
+switch-capable task path claims it before selecting the next task, a raw switch
+transfers it to the incoming continuation, and the resumed or first-entry tail
+consumes it before enabling local IRQs. The task layer never manipulates the
+preemption word and `cpu-local` never owns scheduler policy or baton state.
 
 Bootstrap contexts start at depth one. The runtime releases that exact depth
 once, after current context and local run-queue state are published.
@@ -129,5 +132,8 @@ depth zero.
 Host tests cover dependency vocabulary, current-source selection, offset-zero
 embedding, switch rollback and stale epochs, nested/final/pending preemption,
 bootstrap depth, malformed raw tokens, and owner retention. Cross-target clippy
-checks all four architecture backends. ArceOS QEMU covers task switching and
-preemption; Starry covers non-TLS current modes; Axvisor covers TLS modes.
+checks all four architecture backends. The scheduler-frame ownership regression
+belongs to the `ax-task` runtime owner and runs from `tests/axtest.rs` through
+`cargo xtask ktest qemu -p ax-task --test axtest --arch <arch>`. ArceOS QEMU
+covers task switching and preemption; Starry covers non-TLS current modes;
+Axvisor covers TLS modes.

--- a/docs/design/serial-owner-affine-runtime.md
+++ b/docs/design/serial-owner-affine-runtime.md
@@ -116,6 +116,11 @@ worker。重新开启 source 必须使用固定协议：
 自己的 IER/IMSC，禁止调用 `disable_irq()` 屏蔽 shared controller line；controller handle
 只用于 runtime startup/shutdown 和注册失败回滚。
 
+RX 或 TX 的单次预算耗尽时，worker 保留已有 pending/rearm/notify 状态，并在释放 UART
+register gate 和相关锁后主动让出一次调度机会，再继续处理本轮另一方向或进入下一轮。
+这样持续串口积压仍会推进，RX 也不会跳过同轮 TX，但固定的 `owner_cpu` 不会成为无界运行
+段，source mask/rearm 的所有权保持不变。
+
 ## SMP 与内存顺序
 
 IRQ affinity 和 worker cpumask 都固定到同一 `owner_cpu`，以满足当前 `UartPort` 的本地

--- a/os/arceos/modules/axhal/src/irq.rs
+++ b/os/arceos/modules/axhal/src/irq.rs
@@ -57,7 +57,7 @@ fn with_observed_irq_entry<T>(
     let preempt_guard = ax_sync::PreemptGuard::new();
     let result = dispatch();
 
-    drop(preempt_guard); // rescheduling may occur when preemption is re-enabled.
+    preempt_guard.finish_irq_return(); // rescheduling may occur before the IRQ-return boundary.
     after_preempt_release();
     drop(irq_guard);
     result

--- a/os/arceos/modules/axruntime/src/preempt.rs
+++ b/os/arceos/modules/axruntime/src/preempt.rs
@@ -1,11 +1,29 @@
-//! Architecture preemption adapter and scheduler safe-point baton.
+//! Architecture preemption adapter and scheduler safe-point frame.
 
 #[cfg(feature = "irq")]
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicU8, Ordering};
+
+#[cfg(feature = "irq")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum SchedulerBatonState {
+    /// The final pending preemption depth has become the runtime baton, but the
+    /// task layer has not entered its scheduler frame yet.
+    PreemptEntry,
+    Active,
+    Transferred,
+    Finished,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PreemptionExitOrigin {
+    Task,
+    IrqReturn,
+}
 
 #[cfg(feature = "irq")]
 #[ax_percpu::def_percpu]
-static SCHEDULER_BATON: AtomicBool = AtomicBool::new(false);
+static SCHEDULER_BATON: AtomicU8 = AtomicU8::new(SchedulerBatonState::Finished as u8);
 
 struct RuntimePreemptionOps;
 
@@ -16,7 +34,11 @@ impl ax_task::runtime_preempt::RuntimePreemption for RuntimePreemptionOps {
     }
 
     fn exit(token: usize) {
-        exit_preemption(token);
+        exit_preemption(token, PreemptionExitOrigin::Task);
+    }
+
+    fn exit_from_irq_return(token: usize) {
+        exit_preemption(token, PreemptionExitOrigin::IrqReturn);
     }
 
     fn depth() -> usize {
@@ -31,10 +53,32 @@ impl ax_task::runtime_preempt::RuntimePreemption for RuntimePreemptionOps {
         depth as usize
     }
 
+    fn enter_scheduler_frame() {
+        enter_scheduler_frame();
+    }
+
+    fn transfer_scheduler_frame() {
+        transfer_scheduler_frame();
+    }
+
+    fn finish_scheduler_frame(result: ax_task::runtime_preempt::SchedulerFrameResult) {
+        finish_scheduler_frame(result);
+    }
+
     fn finish_initial_context_switch() {
         debug_assert!(!ax_hal::asm::irqs_enabled());
         with_cpu_pin(cpu_local::release_initial_context_preemption)
             .unwrap_or_else(|error| panic!("initial preemption handoff is invalid: {error}"));
+        publish_current_preemption_pending();
+        finish_initial_scheduler_baton();
+        #[cfg(axtest)]
+        {
+            assert!(
+                !ax_hal::asm::irqs_enabled(),
+                "first-entry scheduler frame must finish before IRQ enable"
+            );
+            ax_task::axtest_support::record_initial_scheduler_frame_consumed();
+        }
     }
 }
 
@@ -43,17 +87,223 @@ pub(crate) fn release_bootstrap() {
         .unwrap_or_else(|error| panic!("bootstrap preemption state is invalid: {error}"));
 }
 
-fn exit_preemption(raw: usize) {
+fn exit_preemption(raw: usize, origin: PreemptionExitOrigin) {
     // SAFETY: axtask transports the exact opaque value returned by `enter`
     // through one non-Send guard and consumes it here exactly once.
     let token = unsafe { cpu_local::PreemptionToken::from_raw(raw) }
         .expect("runtime preemption token must retain its aligned owner");
     let irqs_were_enabled = ax_hal::asm::irqs_enabled();
+    assert!(
+        origin != PreemptionExitOrigin::IrqReturn || !irqs_were_enabled,
+        "IRQ-return preemption exit requires hardware IRQs disabled"
+    );
     ax_hal::asm::disable_irqs();
 
     let token = with_cpu_pin(|pin| cpu_local::handoff_preemption_after_context_switch(pin, token))
         .unwrap_or_else(|error| panic!("context-switch preemption handoff failed: {error}"));
 
+    publish_current_preemption_pending();
+
+    match cpu_local::finish_preemption(token) {
+        cpu_local::PreemptionExit::Nested | cpu_local::PreemptionExit::Enabled => {}
+        cpu_local::PreemptionExit::Pending(pending) => {
+            let should_schedule = preemption_exit_should_schedule(origin, irqs_were_enabled);
+            if should_schedule {
+                claim_preempt_scheduler_entry();
+            }
+            pending.release();
+            if should_schedule {
+                with_cpu_pin(cpu_local::clear_preemption_pending).unwrap_or_else(|error| {
+                    panic!("runtime preemption clear failed before scheduling: {error}")
+                });
+                ax_task::runtime_preempt_current();
+                finish_unused_preempt_scheduler_entry();
+            }
+        }
+    }
+
+    if irqs_were_enabled {
+        ax_hal::asm::enable_irqs();
+    }
+}
+
+const fn preemption_exit_should_schedule(
+    origin: PreemptionExitOrigin,
+    irqs_were_enabled: bool,
+) -> bool {
+    matches!(origin, PreemptionExitOrigin::IrqReturn) || irqs_were_enabled
+}
+
+#[cfg(feature = "irq")]
+fn claim_preempt_scheduler_entry() {
+    debug_assert!(!ax_hal::asm::irqs_enabled());
+    transition_scheduler_baton(
+        |state| match state {
+            SchedulerBatonState::Finished => Some(SchedulerBatonState::PreemptEntry),
+            _ => None,
+        },
+        "pending preemption requires a finished scheduler baton",
+    );
+}
+
+#[cfg(not(feature = "irq"))]
+fn claim_preempt_scheduler_entry() {
+    unreachable!("pending preemption requires the runtime IRQ capability");
+}
+
+#[cfg(feature = "irq")]
+fn enter_scheduler_frame() {
+    debug_assert!(!ax_hal::asm::irqs_enabled());
+    transition_scheduler_baton(
+        |state| match state {
+            SchedulerBatonState::Finished | SchedulerBatonState::PreemptEntry => {
+                Some(SchedulerBatonState::Active)
+            }
+            _ => None,
+        },
+        "scheduler entry requires a finished or preclaimed baton",
+    );
+}
+
+#[cfg(not(feature = "irq"))]
+fn enter_scheduler_frame() {
+    unreachable!("scheduler frame requires the runtime IRQ capability");
+}
+
+#[cfg(feature = "irq")]
+fn transfer_scheduler_frame() {
+    debug_assert!(!ax_hal::asm::irqs_enabled());
+    transition_scheduler_baton(
+        |state| (state == SchedulerBatonState::Active).then_some(SchedulerBatonState::Transferred),
+        "raw context switch requires the active scheduler baton",
+    );
+}
+
+#[cfg(not(feature = "irq"))]
+fn transfer_scheduler_frame() {
+    unreachable!("scheduler frame requires the runtime IRQ capability");
+}
+
+#[cfg(feature = "irq")]
+fn finish_scheduler_frame(result: ax_task::runtime_preempt::SchedulerFrameResult) {
+    use ax_task::runtime_preempt::SchedulerFrameResult;
+
+    debug_assert!(!ax_hal::asm::irqs_enabled());
+    publish_current_preemption_pending();
+    match result {
+        SchedulerFrameResult::Stayed => {
+            finish_scheduler_baton(SchedulerBatonState::Active, "same-context scheduler return")
+        }
+        SchedulerFrameResult::Resumed => finish_scheduler_baton(
+            SchedulerBatonState::Transferred,
+            "resumed scheduler continuation",
+        ),
+    }
+}
+
+#[cfg(not(feature = "irq"))]
+fn finish_scheduler_frame(_result: ax_task::runtime_preempt::SchedulerFrameResult) {
+    unreachable!("scheduler frame requires the runtime IRQ capability");
+}
+
+#[cfg(feature = "irq")]
+fn finish_initial_scheduler_baton() {
+    finish_scheduler_baton(
+        SchedulerBatonState::Transferred,
+        "initial context-switch tail",
+    );
+}
+
+#[cfg(not(feature = "irq"))]
+fn finish_initial_scheduler_baton() {
+    unreachable!("scheduler frame requires the runtime IRQ capability");
+}
+
+#[cfg(feature = "irq")]
+fn finish_unused_preempt_scheduler_entry() {
+    debug_assert!(!ax_hal::asm::irqs_enabled());
+    publish_current_preemption_pending();
+    with_scheduler_baton(|baton| {
+        if scheduler_baton_state(baton) == SchedulerBatonState::PreemptEntry {
+            transition_scheduler_baton_value(
+                baton,
+                |state| {
+                    (state == SchedulerBatonState::PreemptEntry)
+                        .then_some(SchedulerBatonState::Finished)
+                },
+                "unused pending-preemption scheduler entry",
+            );
+        }
+    });
+}
+
+#[cfg(not(feature = "irq"))]
+fn finish_unused_preempt_scheduler_entry() {
+    unreachable!("pending preemption requires the runtime IRQ capability");
+}
+
+#[cfg(feature = "irq")]
+fn finish_scheduler_baton(expected: SchedulerBatonState, owner: &'static str) {
+    transition_scheduler_baton(
+        |state| (state == expected).then_some(SchedulerBatonState::Finished),
+        owner,
+    );
+}
+
+#[cfg(feature = "irq")]
+fn transition_scheduler_baton(
+    transition: impl FnOnce(SchedulerBatonState) -> Option<SchedulerBatonState>,
+    invariant: &'static str,
+) {
+    with_scheduler_baton(|baton| transition_scheduler_baton_value(baton, transition, invariant));
+}
+
+#[cfg(feature = "irq")]
+fn transition_scheduler_baton_value(
+    baton: &AtomicU8,
+    transition: impl FnOnce(SchedulerBatonState) -> Option<SchedulerBatonState>,
+    invariant: &'static str,
+) {
+    let current_raw = baton.load(Ordering::Relaxed);
+    let current = SchedulerBatonState::from_raw(current_raw);
+    let next =
+        transition(current).unwrap_or_else(|| panic!("{invariant}; current state is {current:?}"));
+    assert_eq!(
+        baton.compare_exchange(
+            current_raw,
+            next as u8,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ),
+        Ok(current_raw),
+        "scheduler baton changed despite local IRQ exclusion"
+    );
+}
+
+#[cfg(feature = "irq")]
+fn scheduler_baton_state(baton: &AtomicU8) -> SchedulerBatonState {
+    SchedulerBatonState::from_raw(baton.load(Ordering::Relaxed))
+}
+
+#[cfg(feature = "irq")]
+impl SchedulerBatonState {
+    fn from_raw(raw: u8) -> Self {
+        match raw {
+            raw if raw == Self::PreemptEntry as u8 => Self::PreemptEntry,
+            raw if raw == Self::Active as u8 => Self::Active,
+            raw if raw == Self::Transferred as u8 => Self::Transferred,
+            raw if raw == Self::Finished as u8 => Self::Finished,
+            _ => panic!("invalid scheduler baton state {raw}"),
+        }
+    }
+}
+
+#[cfg(feature = "irq")]
+fn with_scheduler_baton<R>(operation: impl FnOnce(&AtomicU8) -> R) -> R {
+    with_cpu_pin(|pin| SCHEDULER_BATON.with_current(pin, operation))
+}
+
+fn publish_current_preemption_pending() {
     let pending = ax_task::runtime_preemption_pending();
     with_cpu_pin(|pin| {
         if pending {
@@ -63,61 +313,6 @@ fn exit_preemption(raw: usize) {
         }
     })
     .unwrap_or_else(|error| panic!("runtime preemption publication failed: {error}"));
-
-    match cpu_local::finish_preemption(token) {
-        cpu_local::PreemptionExit::Nested | cpu_local::PreemptionExit::Enabled => {}
-        cpu_local::PreemptionExit::Pending(pending) => {
-            claim_scheduler_baton();
-            pending.release();
-            with_cpu_pin(cpu_local::clear_preemption_pending).unwrap_or_else(|error| {
-                panic!("runtime preemption clear failed before scheduling: {error}")
-            });
-            release_scheduler_baton();
-            ax_task::runtime_preempt_current();
-        }
-    }
-
-    if irqs_were_enabled {
-        ax_hal::asm::enable_irqs();
-    }
-}
-
-#[cfg(feature = "irq")]
-fn claim_scheduler_baton() {
-    with_cpu_pin(|pin| {
-        SCHEDULER_BATON.with_current(pin, |baton| {
-            assert!(
-                baton
-                    .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-                    .is_ok(),
-                "runtime scheduler baton is already active"
-            );
-        })
-    });
-}
-
-#[cfg(not(feature = "irq"))]
-fn claim_scheduler_baton() {
-    panic!("pending preemption requires the runtime IRQ capability");
-}
-
-#[cfg(feature = "irq")]
-fn release_scheduler_baton() {
-    with_cpu_pin(|pin| {
-        SCHEDULER_BATON.with_current(pin, |baton| {
-            assert!(
-                baton
-                    .compare_exchange(true, false, Ordering::Release, Ordering::Relaxed)
-                    .is_ok(),
-                "runtime scheduler baton was not active"
-            );
-        })
-    });
-}
-
-#[cfg(not(feature = "irq"))]
-fn release_scheduler_baton() {
-    unreachable!("a runtime without IRQ capability cannot claim the baton");
 }
 
 fn with_cpu_pin<R>(operation: impl for<'scope> FnOnce(&cpu_local::CpuPin<'scope>) -> R) -> R {
@@ -125,4 +320,67 @@ fn with_cpu_pin<R>(operation: impl for<'scope> FnOnce(&cpu_local::CpuPin<'scope>
     // execution cannot migrate while the scoped CPU capability is live.
     unsafe { cpu_local::with_cpu_pin(operation) }
         .unwrap_or_else(|error| panic!("runtime CPU-local state is invalid: {error}"))
+}
+
+#[cfg(all(test, feature = "irq"))]
+mod tests {
+    use super::*;
+
+    fn transition(
+        baton: &AtomicU8,
+        transition: impl FnOnce(SchedulerBatonState) -> Option<SchedulerBatonState>,
+    ) {
+        transition_scheduler_baton_value(baton, transition, "test transition");
+    }
+
+    #[test]
+    fn pending_preemption_enters_one_scheduler_frame() {
+        let baton = AtomicU8::new(SchedulerBatonState::Finished as u8);
+        transition(&baton, |state| {
+            (state == SchedulerBatonState::Finished).then_some(SchedulerBatonState::PreemptEntry)
+        });
+        transition(&baton, |state| {
+            (state == SchedulerBatonState::PreemptEntry).then_some(SchedulerBatonState::Active)
+        });
+
+        assert_eq!(scheduler_baton_state(&baton), SchedulerBatonState::Active);
+    }
+
+    #[test]
+    fn raw_switch_transfers_and_first_entry_consumes_baton() {
+        let baton = AtomicU8::new(SchedulerBatonState::Active as u8);
+        transition(&baton, |state| {
+            (state == SchedulerBatonState::Active).then_some(SchedulerBatonState::Transferred)
+        });
+        transition(&baton, |state| {
+            (state == SchedulerBatonState::Transferred).then_some(SchedulerBatonState::Finished)
+        });
+
+        assert_eq!(scheduler_baton_state(&baton), SchedulerBatonState::Finished);
+    }
+
+    #[test]
+    #[should_panic(expected = "test transition; current state is Active")]
+    fn scheduler_baton_cannot_be_claimed_twice() {
+        let baton = AtomicU8::new(SchedulerBatonState::Active as u8);
+        transition(&baton, |state| {
+            (state == SchedulerBatonState::Finished).then_some(SchedulerBatonState::Active)
+        });
+    }
+
+    #[test]
+    fn only_irq_return_may_schedule_from_an_irq_disabled_preemption_exit() {
+        assert!(!preemption_exit_should_schedule(
+            PreemptionExitOrigin::Task,
+            false
+        ));
+        assert!(preemption_exit_should_schedule(
+            PreemptionExitOrigin::Task,
+            true
+        ));
+        assert!(preemption_exit_should_schedule(
+            PreemptionExitOrigin::IrqReturn,
+            false
+        ));
+    }
 }

--- a/os/arceos/modules/axruntime/src/serial/worker.rs
+++ b/os/arceos/modules/axruntime/src/serial/worker.rs
@@ -101,9 +101,9 @@ impl SerialWorker {
                 }
                 let outcome = self.service_rx(path);
                 rx_blocked = outcome.blocked;
-                if outcome.budget_exhausted
-                    || (!outcome.blocked && self.shared.bridge.latch.has_pending())
-                {
+                if outcome.budget_exhausted {
+                    ax_task::yield_now();
+                } else if !outcome.blocked && self.shared.bridge.latch.has_pending() {
                     continue;
                 }
             }
@@ -124,6 +124,7 @@ impl SerialWorker {
 
             self.update_tx_idle();
             if budget_exhausted {
+                ax_task::yield_now();
                 continue;
             }
             if self.port_rx_ready {

--- a/os/arceos/modules/axruntime/src/sync.rs
+++ b/os/arceos/modules/axruntime/src/sync.rs
@@ -20,6 +20,10 @@ impl ax_sync::interface::ContextOps for RuntimeContextOps {
     fn exit(context: u8, state: usize) {
         ax_task::sync::bridge::context_exit(context, state);
     }
+
+    fn exit_preempt_from_irq_return(state: usize) {
+        ax_task::sync::bridge::preempt_exit_from_irq_return(state);
+    }
 }
 
 struct RuntimeSpinOps;

--- a/os/arceos/modules/axsync/src/context.rs
+++ b/os/arceos/modules/axsync/src/context.rs
@@ -107,7 +107,7 @@ impl GuardState for PreemptIrqSaveState {
 /// require_send::<ax_sync::PreemptGuard>();
 /// ```
 pub struct PreemptGuard {
-    state: usize,
+    state: Option<usize>,
     _not_send: PhantomData<*mut ()>,
 }
 
@@ -115,9 +115,19 @@ impl PreemptGuard {
     /// Disables preemption until the returned guard is dropped.
     pub fn new() -> Self {
         Self {
-            state: PreemptState::acquire(),
+            state: Some(PreemptState::acquire()),
             _not_send: PhantomData,
         }
+    }
+
+    /// Finishes this preemption scope at the final IRQ-return boundary.
+    #[doc(hidden)]
+    pub fn finish_irq_return(mut self) {
+        let state = self
+            .state
+            .take()
+            .expect("IRQ-return preemption state must be present");
+        crate::interface::preempt_exit_from_irq_return(state);
     }
 }
 
@@ -129,7 +139,9 @@ impl Default for PreemptGuard {
 
 impl Drop for PreemptGuard {
     fn drop(&mut self) {
-        PreemptState::release(self.state);
+        if let Some(state) = self.state.take() {
+            PreemptState::release(state);
+        }
     }
 }
 

--- a/os/arceos/modules/axsync/src/interface/mod.rs
+++ b/os/arceos/modules/axsync/src/interface/mod.rs
@@ -103,6 +103,9 @@ pub trait ContextOps {
 
     /// Leaves `context` using the matching token.
     fn exit(context: u8, state: usize);
+
+    /// Leaves a preemption context at the final IRQ-return boundary.
+    fn exit_preempt_from_irq_return(state: usize);
 }
 
 /// Complete spin-lock acquisition and release operations.
@@ -186,6 +189,13 @@ pub(crate) fn context_exit(context: u8, state: usize) {
     return crate::host::context_exit(context, state);
     #[cfg(not(all(feature = "host-test", not(target_os = "none"))))]
     ax_crate_interface::call_interface!(ContextOps::exit, context, state);
+}
+
+pub(crate) fn preempt_exit_from_irq_return(state: usize) {
+    #[cfg(all(feature = "host-test", not(target_os = "none")))]
+    return crate::host::context_exit(CONTEXT_PREEMPT, state);
+    #[cfg(not(all(feature = "host-test", not(target_os = "none"))))]
+    ax_crate_interface::call_interface!(ContextOps::exit_preempt_from_irq_return, state);
 }
 
 pub(crate) fn spin_acquire(

--- a/os/arceos/modules/axtask/Cargo.toml
+++ b/os/arceos/modules/axtask/Cargo.toml
@@ -7,6 +7,14 @@ name = "ax-task"
 repository = "https://github.com/rcore-os/tgoskits"
 version = "0.6.7"
 
+[package.metadata.docs.rs]
+targets = [
+  "x86_64-unknown-none",
+  "aarch64-unknown-none-softfloat",
+  "riscv64gc-unknown-none-elf",
+  "loongarch64-unknown-none-softfloat",
+]
+
 [features]
 default = []
 
@@ -48,7 +56,7 @@ host-test = [
   "ax-percpu?/host-test",
 ]
 test = ["host-test"]
-axtest = ["irq", "multitask"]
+axtest = ["multitask", "preempt"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(axtest)'] }

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -106,6 +106,17 @@ pub fn enable_preempt(token: usize) {
     let _ = token;
 }
 
+/// Enables preemption at the final IRQ-return boundary.
+#[doc(hidden)]
+pub fn enable_preempt_from_irq_return(token: usize) {
+    #[cfg(feature = "preempt")]
+    {
+        crate::runtime_preempt::exit_from_irq_return(token);
+    }
+    #[cfg(not(feature = "preempt"))]
+    let _ = token;
+}
+
 /// Reports scheduler work to the runtime preemption safe-point adapter.
 #[doc(hidden)]
 pub fn runtime_preemption_pending() -> bool {
@@ -124,6 +135,24 @@ pub fn runtime_preemption_pending() -> bool {
 pub fn runtime_preempt_current() {
     #[cfg(feature = "preempt")]
     crate::task::TaskInner::current_check_preempt_pending();
+}
+
+/// Marks the current task for a deterministic preemption safe-point test.
+#[cfg(all(axtest, feature = "preempt"))]
+pub(crate) fn request_current_preemption_for_test() {
+    current().set_preempt_pending(true);
+}
+
+/// Records that the current task's first-entry scheduler frame was consumed.
+#[cfg(axtest)]
+pub(crate) fn record_initial_scheduler_frame_consumed_for_test() {
+    current().record_initial_scheduler_frame_consumed_for_test();
+}
+
+/// Reports whether the current task consumed its first-entry scheduler frame.
+#[cfg(axtest)]
+pub(crate) fn initial_scheduler_frame_consumed_for_test() -> bool {
+    current().initial_scheduler_frame_consumed_for_test()
 }
 
 #[cfg(feature = "lockdep")]

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -107,11 +107,30 @@ cfg_if::cfg_if! {
 }
 
 /// Runtime checks that require a bound ArceOS CPU-local area.
-#[cfg(all(axtest, feature = "axtest"))]
+#[cfg(all(axtest, feature = "multitask"))]
 #[doc(hidden)]
 pub mod axtest_support {
     /// Checks the live atomic-context query and target stack configuration.
+    #[cfg(feature = "axtest")]
     pub fn atomic_context_and_stack_configuration_hold() -> bool {
         super::api::axtask_api_atomic_context_structs_hold_for_test()
+    }
+
+    /// Marks the current task for a deterministic preemption safe-point test.
+    #[cfg(feature = "preempt")]
+    pub fn request_current_preemption() {
+        super::api::request_current_preemption_for_test();
+    }
+
+    /// Records that the current task consumed its first-entry scheduler frame.
+    #[cfg(feature = "preempt")]
+    pub fn record_initial_scheduler_frame_consumed() {
+        super::api::record_initial_scheduler_frame_consumed_for_test();
+    }
+
+    /// Reports whether the current task consumed its first-entry scheduler frame.
+    #[cfg(feature = "preempt")]
+    pub fn initial_scheduler_frame_consumed() -> bool {
+        super::api::initial_scheduler_frame_consumed_for_test()
     }
 }

--- a/os/arceos/modules/axtask/src/lib.rs
+++ b/os/arceos/modules/axtask/src/lib.rs
@@ -123,13 +123,15 @@ pub mod axtest_support {
     }
 
     /// Records that the current task consumed its first-entry scheduler frame.
-    #[cfg(feature = "preempt")]
+    ///
+    /// This hook remains available without the `preempt` feature because the
+    /// runtime completes the first-entry scheduler handoff for every multitask
+    /// axtest configuration, including non-preemptive workspace consumers.
     pub fn record_initial_scheduler_frame_consumed() {
         super::api::record_initial_scheduler_frame_consumed_for_test();
     }
 
     /// Reports whether the current task consumed its first-entry scheduler frame.
-    #[cfg(feature = "preempt")]
     pub fn initial_scheduler_frame_consumed() -> bool {
         super::api::initial_scheduler_frame_consumed_for_test()
     }

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -818,8 +818,13 @@ impl<G: GuardState> CurrentRunQueueRef<G> {
         // but, do not put current task to the scheduler of this run queue.
         curr.set_state(TaskState::Ready);
 
-        // Call `switch_to` to reschedule to the migration task that performs the migration directly.
-        self.inner.switch_to(crate::current(), migration_task);
+        // Switch to the migration task through the same scheduler-frame
+        // transaction used by ordinary rescheduling.
+        let mut scheduler_frame = crate::runtime_preempt::SchedulerFrame::enter();
+        let result = self
+            .inner
+            .switch_to(crate::current(), migration_task, &mut scheduler_frame);
+        scheduler_frame.finish(result);
     }
 
     /// Preempts the current task and reschedules.
@@ -1134,6 +1139,7 @@ impl AxRunQueue {
     /// Core reschedule subroutine.
     /// Pick the next task to run and switch to it.
     fn resched(&self) {
+        let mut scheduler_frame = crate::runtime_preempt::SchedulerFrame::enter();
         // SAFETY: the caller holds the run-queue context guard.
         let next = unsafe { self.scheduler.lock_raw() }
             .pick_next_task()
@@ -1155,10 +1161,18 @@ impl AxRunQueue {
             next.id_name(),
             next.state()
         );
-        self.switch_to(crate::current(), next);
+        let result = self.switch_to(crate::current(), next, &mut scheduler_frame);
+        scheduler_frame.finish(result);
     }
 
-    fn switch_to(&self, prev_task: CurrentTask, next_task: AxTaskRef) {
+    fn switch_to(
+        &self,
+        prev_task: CurrentTask,
+        next_task: AxTaskRef,
+        scheduler_frame: &mut crate::runtime_preempt::SchedulerFrame,
+    ) -> crate::runtime_preempt::SchedulerFrameResult {
+        use crate::runtime_preempt::SchedulerFrameResult;
+
         // Make sure that IRQs are disabled by kernel guard or other means.
         #[cfg(all(feature = "irq", not(feature = "host-test")))]
         assert!(
@@ -1175,7 +1189,7 @@ impl AxRunQueue {
         next_task.set_preempt_pending(false);
         next_task.set_state(TaskState::Running);
         if prev_task.ptr_eq(&next_task) {
-            return;
+            return SchedulerFrameResult::Stayed;
         }
 
         // Claim the task as running, we do this before switching to it
@@ -1238,6 +1252,7 @@ impl AxRunQueue {
 
                 assert!(Arc::strong_count(&prev_task) > 1);
                 assert!(Arc::strong_count(&next_task) >= 1);
+                scheduler_frame.transfer();
                 CurrentTask::set_current(prev_task, next_task);
 
                 // switch_to_prepared consumes the only commit capability and
@@ -1250,6 +1265,7 @@ impl AxRunQueue {
             // previous binding before making that task runnable elsewhere.
             clear_prev_task_on_cpu();
         }
+        SchedulerFrameResult::Resumed
     }
 }
 

--- a/os/arceos/modules/axtask/src/runtime_preempt.rs
+++ b/os/arceos/modules/axtask/src/runtime_preempt.rs
@@ -1,8 +1,8 @@
 //! Narrow runtime capability used by legacy ArceOS task guards.
 //!
 //! The task layer owns scheduling policy and pending-work decisions. The
-//! runtime owns architecture preemption state, IRQ exclusion, and the baton
-//! that admits a scheduling safe point.
+//! runtime owns architecture preemption state, IRQ exclusion, and the frame
+//! that admits and tracks a scheduling safe point.
 
 #[ax_crate_interface::def_interface]
 pub trait RuntimePreemption {
@@ -12,11 +12,79 @@ pub trait RuntimePreemption {
     /// Finishes the exact token returned by [`Self::enter`].
     fn exit(token: usize);
 
+    /// Finishes a token at the final IRQ-return boundary.
+    fn exit_from_irq_return(token: usize);
+
     /// Returns the architecture-selected preemption depth.
     fn depth() -> usize;
 
+    /// Claims the CPU-local scheduler frame before selecting the next task.
+    fn enter_scheduler_frame();
+
+    /// Transfers the active scheduler frame to the raw switch continuation.
+    fn transfer_scheduler_frame();
+
+    /// Finishes the scheduler frame after the switch path returns.
+    fn finish_scheduler_frame(result: SchedulerFrameResult);
+
     /// Completes the preemption handoff for a context's first switch-in.
     fn finish_initial_context_switch();
+}
+
+/// Describes how a scheduler frame returned to its caller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SchedulerFrameResult {
+    /// The scheduler retained the current task and did not switch contexts.
+    Stayed,
+    /// A raw context switch resumed an existing scheduler continuation.
+    Resumed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SchedulerFrameOwnership {
+    Active,
+    Transferred,
+}
+
+/// Linear task-layer ownership of one CPU-local scheduler frame.
+///
+/// A raw switch suspends this value with the outgoing scheduler stack. When
+/// that stack later resumes, the value completes the transferred frame left by
+/// the switch that resumed it. A first-entry task has no suspended value and
+/// consumes the transferred frame through `finish_initial_context_switch`.
+pub(crate) struct SchedulerFrame {
+    ownership: SchedulerFrameOwnership,
+}
+
+impl SchedulerFrame {
+    pub(crate) fn enter() -> Self {
+        enter_scheduler_frame();
+        Self {
+            ownership: SchedulerFrameOwnership::Active,
+        }
+    }
+
+    pub(crate) fn transfer(&mut self) {
+        assert_eq!(
+            self.ownership,
+            SchedulerFrameOwnership::Active,
+            "scheduler frame can be transferred only once"
+        );
+        transfer_scheduler_frame();
+        self.ownership = SchedulerFrameOwnership::Transferred;
+    }
+
+    pub(crate) fn finish(self, result: SchedulerFrameResult) {
+        let expected = match result {
+            SchedulerFrameResult::Stayed => SchedulerFrameOwnership::Active,
+            SchedulerFrameResult::Resumed => SchedulerFrameOwnership::Transferred,
+        };
+        assert_eq!(
+            self.ownership, expected,
+            "scheduler return does not match task-layer frame ownership"
+        );
+        finish_scheduler_frame(result);
+    }
 }
 
 #[inline(always)]
@@ -32,9 +100,35 @@ pub(crate) fn exit(token: usize) {
 }
 
 #[inline(always)]
+#[cfg(feature = "preempt")]
+pub(crate) fn exit_from_irq_return(token: usize) {
+    ax_crate_interface::call_interface!(RuntimePreemption::exit_from_irq_return, token)
+}
+
+#[inline(always)]
 #[cfg(all(feature = "preempt", not(feature = "host-test")))]
 pub(crate) fn depth() -> usize {
     ax_crate_interface::call_interface!(RuntimePreemption::depth)
+}
+
+#[inline(always)]
+pub(crate) fn enter_scheduler_frame() {
+    #[cfg(all(feature = "preempt", not(feature = "host-test")))]
+    ax_crate_interface::call_interface!(RuntimePreemption::enter_scheduler_frame);
+}
+
+#[inline(always)]
+pub(crate) fn transfer_scheduler_frame() {
+    #[cfg(all(feature = "preempt", not(feature = "host-test")))]
+    ax_crate_interface::call_interface!(RuntimePreemption::transfer_scheduler_frame);
+}
+
+#[inline(always)]
+pub(crate) fn finish_scheduler_frame(result: SchedulerFrameResult) {
+    #[cfg(all(feature = "preempt", not(feature = "host-test")))]
+    ax_crate_interface::call_interface!(RuntimePreemption::finish_scheduler_frame, result);
+    #[cfg(any(not(feature = "preempt"), feature = "host-test"))]
+    let _ = result;
 }
 
 #[inline(always)]

--- a/os/arceos/modules/axtask/src/sync/bridge.rs
+++ b/os/arceos/modules/axtask/src/sync/bridge.rs
@@ -100,6 +100,11 @@ pub fn context_exit(context: u8, state: usize) {
     }
 }
 
+/// Leaves a preemption context at the final IRQ-return boundary.
+pub fn preempt_exit_from_irq_return(state: usize) {
+    PreemptState::release_from_irq_return(state);
+}
+
 /// Returns host-test preemption depth and IRQ-enabled state.
 #[cfg(all(feature = "host-test", not(target_os = "none")))]
 pub fn host_context_snapshot() -> (usize, bool) {

--- a/os/arceos/modules/axtask/src/sync/context.rs
+++ b/os/arceos/modules/axtask/src/sync/context.rs
@@ -84,6 +84,12 @@ pub struct RawState;
 #[doc(hidden)]
 pub struct PreemptState;
 
+impl PreemptState {
+    pub(crate) fn release_from_irq_return(state: usize) {
+        imp::enable_preempt_from_irq_return(state);
+    }
+}
+
 /// Lock state which saves and disables local interrupts.
 #[doc(hidden)]
 pub struct IrqSaveState;
@@ -292,6 +298,10 @@ mod imp {
         );
     }
 
+    pub(super) fn enable_preempt_from_irq_return(state: usize) {
+        enable_preempt(state);
+    }
+
     pub(super) fn irq_save_and_disable() -> usize {
         EVENTS.with_borrow_mut(|events| events.push("irq-disable"));
         let was_enabled = IRQ_ENABLED.replace(false);
@@ -341,6 +351,14 @@ mod imp {
     pub(super) fn enable_preempt(state: usize) {
         #[cfg(feature = "multitask")]
         crate::enable_preempt(state);
+        #[cfg(not(feature = "multitask"))]
+        let _ = state;
+    }
+
+    #[inline(always)]
+    pub(super) fn enable_preempt_from_irq_return(state: usize) {
+        #[cfg(feature = "multitask")]
+        crate::enable_preempt_from_irq_return(state);
         #[cfg(not(feature = "multitask"))]
         let _ = state;
     }

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -160,6 +160,8 @@ pub struct TaskInner {
     need_resched: AtomicBool,
     #[cfg(feature = "preempt")]
     force_resched: AtomicBool,
+    #[cfg(axtest)]
+    initial_scheduler_frame_consumed: AtomicBool,
 
     interrupted: InterruptState,
     interrupt_waker: AtomicWaker,
@@ -435,6 +437,8 @@ impl TaskInner {
             need_resched: AtomicBool::new(false),
             #[cfg(feature = "preempt")]
             force_resched: AtomicBool::new(false),
+            #[cfg(axtest)]
+            initial_scheduler_frame_consumed: AtomicBool::new(false),
             interrupted: InterruptState::new(),
             interrupt_waker: AtomicWaker::new(),
             exit_code: AtomicI32::new(0),
@@ -667,6 +671,22 @@ impl TaskInner {
                 rq.preempt_resched()
             }
         }
+    }
+
+    #[cfg(axtest)]
+    pub(crate) fn record_initial_scheduler_frame_consumed_for_test(&self) {
+        assert!(
+            !self
+                .initial_scheduler_frame_consumed
+                .swap(true, Ordering::AcqRel),
+            "initial scheduler frame was consumed twice by one task"
+        );
+    }
+
+    #[cfg(axtest)]
+    pub(crate) fn initial_scheduler_frame_consumed_for_test(&self) -> bool {
+        self.initial_scheduler_frame_consumed
+            .load(Ordering::Acquire)
     }
 
     /// Notify all tasks that join on this task.

--- a/os/arceos/modules/axtask/tests/axtest.rs
+++ b/os/arceos/modules/axtask/tests/axtest.rs
@@ -50,6 +50,55 @@ fn atomic_context_uses_the_bound_arceos_cpu_state() {
 }
 
 #[axtest]
+fn pending_preemption_retains_scheduler_frame_until_first_entry() {
+    let observer_saw_consumed_frame = Arc::new(AtomicBool::new(false));
+    let observer_saw_consumed_frame_in_task = Arc::clone(&observer_saw_consumed_frame);
+    let cpu_id = ax_hal::percpu::this_cpu_id();
+    let preemption_token = ax_task::disable_preempt();
+    let observer = ax_task::TaskInner::new(
+        move || {
+            observer_saw_consumed_frame_in_task.store(
+                ax_task::axtest_support::initial_scheduler_frame_consumed(),
+                Ordering::Release,
+            );
+        },
+        "scheduler-frame-observer".into(),
+        ax_task::default_task_stack_size(),
+    );
+    observer.set_cpumask(ax_task::AxCpuMask::one_shot(cpu_id));
+    let observer = ax_task::spawn_task(observer);
+
+    ax_task::axtest_support::request_current_preemption();
+    let pending_before_exit = ax_task::runtime_preemption_pending();
+    ax_task::enable_preempt(preemption_token);
+    let pending_consumed = !ax_task::runtime_preemption_pending();
+
+    ax_assert_eq!(observer.join(), 0);
+    ax_assert!(pending_before_exit);
+    ax_assert!(pending_consumed);
+    ax_assert!(observer_saw_consumed_frame.load(Ordering::Acquire));
+}
+
+#[axtest]
+fn irq_disabled_task_exit_defers_pending_preemption_to_the_outer_boundary() {
+    let irq_state = ax_task::sync::irq_save_and_disable();
+    let preemption_token = ax_task::disable_preempt();
+    ax_task::axtest_support::request_current_preemption();
+
+    ax_task::enable_preempt(preemption_token);
+    let pending_while_irqs_disabled = ax_task::runtime_preemption_pending();
+
+    // SAFETY: `irq_state` belongs to the current CPU and is restored exactly
+    // once before this task reaches another scheduling boundary.
+    unsafe { ax_task::sync::irq_restore(irq_state) };
+    let preemption_token = ax_task::disable_preempt();
+    ax_task::enable_preempt(preemption_token);
+
+    ax_assert!(pending_while_irqs_disabled);
+    ax_assert!(!ax_task::runtime_preemption_pending());
+}
+
+#[axtest]
 fn spin_lock_contention_is_observed_between_runtime_tasks() {
     let lock = Arc::new(SpinLock::new(()));
     let held = Arc::new(AtomicBool::new(false));

--- a/scripts/axbuild/src/axvisor/test/tests.rs
+++ b/scripts/axbuild/src/axvisor/test/tests.rs
@@ -1038,6 +1038,36 @@ fn nvme_smoke_keeps_storage_in_host_and_verifies_file_io() {
 }
 
 #[test]
+fn shell_command_failure_regex_ignores_smp_log_interleaving() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+
+    for path in [
+        "test-suit/axvisor/normal/qemu/smoke/qemu-aarch64.toml",
+        "test-suit/axvisor/normal/qemu/smoke/qemu-loongarch64.toml",
+        "test-suit/axvisor/normal/qemu/smoke/qemu-riscv64.toml",
+        "test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-svm.toml",
+        "test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-vmx.toml",
+        "test-suit/axvisor/normal/qemu-riscv-ipi/smp-ipi/qemu-riscv64.toml",
+    ] {
+        let content = fs::read_to_string(workspace_root.join(path)).unwrap();
+        let config: QemuConfig = toml::from_str(&content).unwrap();
+        let pattern = config
+            .fail_regex
+            .iter()
+            .find(|pattern| pattern.contains("echo|cat|rm"))
+            .unwrap_or_else(|| panic!("{path} should reject shell command failures"));
+        let regex = regex::Regex::new(pattern).unwrap();
+
+        assert!(regex.is_match("cat: can't open '/missing': No such file or directory"));
+        assert!(regex.is_match("rm: can't remove '/missing': No such file or directory"));
+        assert!(
+            !regex.is_match("rm:axvm::host::arceos:373] Hardware virtualization enabled"),
+            "{path} must not interpret an SMP serial-log splice as a shell command failure"
+        );
+    }
+}
+
+#[test]
 fn ignores_qemu_only_build_groups_when_discovering_board_tests() {
     let root = tempdir().unwrap();
     write_qemu_build_config(

--- a/scripts/axbuild/src/clippy/expand.rs
+++ b/scripts/axbuild/src/clippy/expand.rs
@@ -4,12 +4,12 @@ use anyhow::Context;
 use cargo_metadata::Metadata;
 
 use super::{
-    AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE, DEFAULT_FEATURE, HOST_TEST_FEATURE,
+    AXSTD_STD_DEFAULT_FEATURE, AXSTD_STD_PACKAGE, DEFAULT_FEATURE,
     check::{ClippyCheck, ClippyCheckKind, ClippyDepsMode},
     configurations::package_clippy_configurations,
     env::{clippy_env, feature_clippy_env},
     selection::SelectedClippyPackage,
-    targets::{docs_rs_targets, feature_supported_on_clippy_target},
+    targets::{docs_rs_targets, feature_requires_host_target, feature_supported_on_clippy_target},
 };
 
 pub(super) fn expand_clippy_checks(
@@ -28,7 +28,12 @@ pub(super) fn expand_clippy_checks(
         if package.name == AXSTD_STD_PACKAGE {
             features.insert(AXSTD_STD_DEFAULT_FEATURE.to_string());
         }
-        let has_host_test = features.remove(HOST_TEST_FEATURE);
+        let host_only_features = features
+            .iter()
+            .filter(|feature| feature_requires_host_target(package, feature))
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        features.retain(|feature| !host_only_features.contains(feature));
         let targets = docs_rs_targets(package);
         let target_iter = if targets.is_empty() {
             vec![None]
@@ -72,19 +77,17 @@ pub(super) fn expand_clippy_checks(
         }
 
         if matches!(selected.deps_mode, ClippyDepsMode::NoDeps) {
-            if has_host_test {
-                let feature_env =
-                    feature_clippy_env(package, HOST_TEST_FEATURE, env.clone(), metadata)
-                        .with_context(|| {
-                            format!(
-                                "failed to prepare clippy env for `{}` feature \
-                                 `{HOST_TEST_FEATURE}`",
-                                package.name
-                            )
-                        })?;
+            for feature in host_only_features {
+                let feature_env = feature_clippy_env(package, &feature, env.clone(), metadata)
+                    .with_context(|| {
+                        format!(
+                            "failed to prepare clippy env for `{}` feature `{feature}`",
+                            package.name
+                        )
+                    })?;
                 checks.push(ClippyCheck {
                     package: package.name.to_string(),
-                    kind: ClippyCheckKind::Feature(HOST_TEST_FEATURE.to_string()),
+                    kind: ClippyCheckKind::Feature(feature),
                     deps_mode: selected.deps_mode.clone(),
                     target: None,
                     env: feature_env,

--- a/scripts/axbuild/src/clippy/targets.rs
+++ b/scripts/axbuild/src/clippy/targets.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use cargo_metadata::Package;
 use serde::Deserialize;
 
-use super::AX_HAL_PACKAGE;
+use super::{AX_HAL_PACKAGE, HOST_TEST_FEATURE};
 
 const CLIPPY_TARGET_ALIASES: &[(&str, &str)] = &[
     (
@@ -133,4 +133,29 @@ pub(super) fn feature_supported_on_clippy_target(
             .iter()
             .all(|target_arches| target_arches.contains(&arch))
     })
+}
+
+pub(super) fn feature_requires_host_target(package: &Package, feature: &str) -> bool {
+    fn requires_host_target<'a>(
+        package: &'a Package,
+        feature: &'a str,
+        visited: &mut BTreeSet<&'a str>,
+    ) -> bool {
+        if feature == HOST_TEST_FEATURE {
+            return true;
+        }
+        if !visited.insert(feature) {
+            return false;
+        }
+
+        package.features.get(feature).is_some_and(|dependencies| {
+            dependencies.iter().any(|dependency| {
+                dependency == HOST_TEST_FEATURE
+                    || (package.features.contains_key(dependency)
+                        && requires_host_target(package, dependency, visited))
+            })
+        })
+    }
+
+    requires_host_target(package, feature, &mut BTreeSet::new())
 }

--- a/scripts/axbuild/src/clippy/tests/expand.rs
+++ b/scripts/axbuild/src/clippy/tests/expand.rs
@@ -134,6 +134,28 @@ fn host_test_feature_uses_host_target_outside_docs_target_matrix() {
 }
 
 #[test]
+fn host_test_feature_alias_uses_host_target_outside_docs_target_matrix() {
+    let checks = expand(&[pkg(
+        "alpha",
+        "alpha 0.1.0 (path+file:///tmp/alpha)",
+        &[
+            ("host-test", &[]),
+            ("platform", &[]),
+            ("test", &["host-test"]),
+        ],
+        Some(&["aarch64-unknown-none-softfloat"]),
+    )]);
+    let test_checks = checks
+        .iter()
+        .filter(|check| check.label().contains("feature: test"))
+        .collect::<Vec<_>>();
+
+    assert_eq!(test_checks.len(), 1);
+    assert_eq!(test_checks[0].label(), "alpha (feature: test)");
+    assert!(!test_checks[0].cargo_args().contains(&"--target".into()));
+}
+
+#[test]
 fn incremental_selection_keeps_runnable_top_levels_when_some_are_skipped() {
     let packages = vec![
         pkg("alpha", "alpha 0.1.0 (path+file:///tmp/alpha)", &[], None),

--- a/test-suit/axvisor/normal/qemu-riscv-ipi/smp-ipi/qemu-riscv64.toml
+++ b/test-suit/axvisor/normal/qemu-riscv-ipi/smp-ipi/qemu-riscv64.toml
@@ -26,7 +26,7 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)login incorrect",
   "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm):",
+  "(?m)^(?:echo|cat|rm):\\s",
   "(?i)IPI extension is not available",
 ]
 success_regex = ['(?m)^guest smp ipi pass!\s*$']

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-aarch64.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-aarch64.toml
@@ -20,7 +20,7 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)login incorrect",
   "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm):",
+  "(?m)^(?:echo|cat|rm):\\s",
 ]
 success_regex = [
   "(?m)^AXVISOR SHLEX  EMPTY\\s*$",

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-loongarch64.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-loongarch64.toml
@@ -21,7 +21,7 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)login incorrect",
   "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm):",
+  "(?m)^(?:echo|cat|rm):\\s",
 ]
 success_regex = [
   "(?m)^AXVISOR_NVME_RW_PAYLOAD\\s*$",

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-riscv64.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-riscv64.toml
@@ -22,7 +22,7 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)login incorrect",
   "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm):",
+  "(?m)^(?:echo|cat|rm):\\s",
 ]
 success_regex = [
   '(?m)^AXVISOR_NVME_RW_PAYLOAD\s*$',

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-svm.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-svm.toml
@@ -31,7 +31,7 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)login incorrect",
   "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm):",
+  "(?m)^(?:echo|cat|rm):\\s",
 ]
 success_regex = [
   "(?m)^AXVISOR_NVME_RW_PAYLOAD\\s*$",

--- a/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-vmx.toml
+++ b/test-suit/axvisor/normal/qemu/smoke/qemu-x86_64-vmx.toml
@@ -31,7 +31,7 @@ fail_regex = [
   "(?i)kernel panic",
   "(?i)login incorrect",
   "(?i)permission denied",
-  "(?m)^(?:echo|cat|rm):",
+  "(?m)^(?:echo|cat|rm):\\s",
 ]
 success_regex = [
   "(?m)^AXVISOR_NVME_RW_PAYLOAD\\s*$",

--- a/test-suit/starryos/qemu/system/test-unshare-fs/src/main.c
+++ b/test-suit/starryos/qemu/system/test-unshare-fs/src/main.c
@@ -30,6 +30,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #define fail(fmt, ...) do { \
@@ -47,6 +48,7 @@
 /* Minimal stack for clone(CLONE_FS) child — 64KiB should be enough for
    chdir / getcwd / _exit; SIGCHLD so waitpid works. */
 #define STACK_SIZE (64 * 1024)
+#define ROLLBACK_SYNC_TIMEOUT_SECONDS 5
 
 struct clone_arg {
     int *shared;
@@ -67,7 +69,25 @@ struct rollback_arg {
     int ready;
     int check_fd;
     int fd_is_closed;
+    int observer_wait_error;
 };
+
+static int wait_for_rollback_flag(pthread_cond_t *condition,
+                                  pthread_mutex_t *mutex,
+                                  const int *flag)
+{
+    struct timespec deadline;
+    if (clock_gettime(CLOCK_MONOTONIC, &deadline) != 0)
+        return errno != 0 ? errno : EIO;
+    deadline.tv_sec += ROLLBACK_SYNC_TIMEOUT_SECONDS;
+
+    while (*flag == 0) {
+        int error = pthread_cond_timedwait(condition, mutex, &deadline);
+        if (error != 0)
+            return error;
+    }
+    return 0;
+}
 
 static void *unshare_files_thread(void *opaque) {
     struct files_unshare_arg *arg = opaque;
@@ -114,9 +134,12 @@ static void *check_shared_fd_after_failed_unshare(void *opaque) {
     pthread_mutex_lock(&arg->mutex);
     arg->ready = 1;
     pthread_cond_signal(&arg->condition);
-    while (!arg->check_fd)
-        pthread_cond_wait(&arg->condition, &arg->mutex);
+    arg->observer_wait_error = wait_for_rollback_flag(
+        &arg->condition, &arg->mutex, &arg->check_fd);
     pthread_mutex_unlock(&arg->mutex);
+
+    if (arg->observer_wait_error != 0)
+        return NULL;
 
     errno = 0;
     arg->fd_is_closed = fcntl(arg->fd, F_GETFD) == -1 && errno == EBADF;
@@ -139,17 +162,28 @@ static void test_failed_unshare_rolls_back_all_state(void) {
 
     struct rollback_arg arg = {
         .mutex = PTHREAD_MUTEX_INITIALIZER,
-        .condition = PTHREAD_COND_INITIALIZER,
         .fd = fd,
     };
+    pthread_condattr_t condition_attr;
+    check(pthread_condattr_init(&condition_attr) == 0,
+          "initialize rollback observer condition attributes");
+    check(pthread_condattr_setclock(&condition_attr, CLOCK_MONOTONIC) == 0,
+          "select monotonic rollback observer timeout clock");
+    check(pthread_cond_init(&arg.condition, &condition_attr) == 0,
+          "initialize rollback observer condition");
+    check(pthread_condattr_destroy(&condition_attr) == 0,
+          "destroy rollback observer condition attributes");
     pthread_t worker;
     check(pthread_create(&worker, NULL, check_shared_fd_after_failed_unshare, &arg) == 0,
           "create failed-unshare rollback observer");
 
     pthread_mutex_lock(&arg.mutex);
-    while (!arg.ready)
-        pthread_cond_wait(&arg.condition, &arg.mutex);
+    int observer_ready_error = wait_for_rollback_flag(
+        &arg.condition, &arg.mutex, &arg.ready);
     pthread_mutex_unlock(&arg.mutex);
+    check(observer_ready_error == 0,
+          "rollback observer reaches ready phase (wait_error=%d, ready=%d)",
+          observer_ready_error, arg.ready);
 
     char deleted_cwd[128];
     int length = snprintf(deleted_cwd, sizeof(deleted_cwd),
@@ -173,7 +207,12 @@ static void test_failed_unshare_rolls_back_all_state(void) {
     arg.check_fd = 1;
     pthread_cond_signal(&arg.condition);
     pthread_mutex_unlock(&arg.mutex);
-    check(pthread_join(worker, NULL) == 0, "join failed-unshare rollback observer");
+    int join_error = pthread_join(worker, NULL);
+    check(join_error == 0,
+          "join failed-unshare rollback observer (rc=%d)", join_error);
+    check(arg.observer_wait_error == 0,
+          "rollback observer receives fd-check release (wait_error=%d, check_fd=%d)",
+          arg.observer_wait_error, arg.check_fd);
     check(arg.fd_is_closed,
           "failed unshare keeps caller and sibling on the shared fd table");
 


### PR DESCRIPTION
## 问题与根因

失败作业：https://github.com/rcore-os/tgoskits/actions/runs/32090889250/job/95573746555

### 不是解除共享系统调用死锁

日志停在 `test-unshare-fs` 创建回滚观察线程之后，但源码表明主线程当时仍在等待观察线程报告“准备完成”，尚未执行解除共享系统调用。相同提交单独运行该用例可以通过，因此命名空间与解除共享系统调用本身的回滚语义不是根因。

### 实际错误

**处理器在中断关闭期间连续进入任务调度，始终回不到负责重新打开中断的最外层调用，最终使定时器、任务切换和测试超时机制一起停止。**

错误过程如下：

1. 普通任务到达一次需要重新调度的边界，于是进入调度器。
2. 调度器关闭中断并切换任务；之后旧任务从原来的调度调用栈恢复。
3. 此时调度器内部的一层保护开始退出，但最外层尚未恢复中断。
4. 旧实现没有区分“普通任务边界”和“从中断返回的边界”：只要仍有调度请求，即使中断还关闭，也会再次进入调度器。
5. 新一轮调度返回后仍可能重复上述步骤，形成不断延长的调度链。

即：

```
关闭中断
  → 调度
    → 尚未恢复中断
      → 再次调度
        → 尚未恢复中断
          → 再次调度……
```

最外层原本负责重新打开中断，但它一直没有机会返回。中断持续关闭后：

- 定时器中断不再到来；
- 等待中的线程得不到正常运行机会；
- 测试框架依赖定时器实现的超时也无法触发。

因此表面现象是回滚观察线程没有报告“准备完成”、主线程一直等待；实际停止进展的是底层调度和中断恢复，而不是解除共享系统调用。

### 为什么全量测试更容易出现

#2076 引入的串口维护线程固定在第一个处理器核心上，串口积压时会连续处理，提高了任务切换和串口中断频率。它不是错误根源，但显著增加了“尚未恢复中断便再次请求调度”的机会，使 #2080 引入的所有权窗口在全量测试中稳定暴露，而单独运行用例时通常不会出现。

### 所有权设计

修复把一次调度过程表示为只能转移和消费一次的“调度凭证”：旧任务恢复时由原来暂停的调用栈结束，新任务第一次运行时则在打开中断前消费。普通任务在中断关闭的内层边界只能记录待调度状态，只有从中断返回的安全边界才能在恢复中断前进行调度。

该凭证不放入 `cpu-local`：它描述的是一次跨越两个任务调用栈的调度事务，而不是某个处理器核心的静态属性。放入处理器局部状态会允许不同任务操作同一份所有权，反而掩盖提前释放或重复消费。

## 修改

1. 显式区分普通任务边界与 IRQ-return 边界：
   - `ax-sync` 的 `PreemptGuard` 支持一次性 `finish_irq_return`；
   - `ax-hal` 在恢复 IRQ 前消费 IRQ-return；
   - `ax-task`/`ax-runtime` 传递 `PreemptionExitOrigin`；
   - 普通任务在 IRQ 关闭的内层边界只释放 token，保留 pending，由外层安全边界消费。

2. 建立线性的 scheduler-frame 所有权：
   - `ax-task` 的 `SchedulerFrame` 表达 `Active`/`Transferred` 以及 `Stayed`/`Resumed`；
   - 所有 `switch_to` 路径在切换前转移 frame；
   - 已运行任务由挂起调用栈在返回边界完成；
   - 新任务由 `finish_initial_context_switch` 在打开 IRQ 前恰好消费一次；
   - `ax-runtime` 使用 CPU-local baton 状态断言重复取得、提前释放和双重消费；
   - 未向 `cpu-local` 增加 `switch_frames`：`cpu-local` 继续只负责执行上下文与抢占字，调度事务由 `ax-runtime`/`ax-task` 所有。

3. 串口维护线程在 RX/TX budget 耗尽后、且不持有 UART 锁或 register gate 时主动 yield，保留 pending/notify，避免 CPU0 无界连续运行。

4. `test-unshare-fs` 的 rollback observer 改用 monotonic 有界等待并报告 ready/complete 阶段；Linux 回滚语义、通过条件和 success regex 不变。

5. 适配新的 axtest/std 约束：
   - `ax-task` 增加 `harness = false` 的 axtest target、四架构 docs.rs targets 及显式 axtest feature；
   - first-entry scheduler 测试探针覆盖所有 multitask axtest 组合，包括不启用 preempt 的 workspace consumer；
   - `axbuild` 的 `host-test` feature alias 保持在 host，不再错误附带 bare-metal target；
   - 本次没有新增 std package，`ax-task`/`ax-runtime` 已在 `scripts/test/std_crates.csv` 中，因此白名单无需变化。

6. 修复后续 CI 暴露的 AxVisor matcher 误报：
   - riscv64 SMP 串口输出可把交互输入 `rm` 与并发 `axvm::...` 日志拼成 `rm:axvm::...`；原 fail regex 将其误判为 shell 错误，尽管 NVMe 写、读、删除和最终成功 marker 均已完成；
   - 所有使用该规则的 AxVisor smoke/IPI 配置改为要求冒号后存在空白，继续匹配真实 `cat: ...`/`rm: ...` 诊断，同时排除 SMP 串口拼接。

7. 修复最新开发分支已有的 `axbacktrace` 标准环境测试竞态：
   - 多个并行单元测试曾共同改写全局最大回溯层数，截断用例设置 16 后可能被其他测试重置为 32；
   - 核心回溯函数改为显式接收本次层数上限，正常入口仍读取一次全局配置；
   - 截断用例直接传入 16，不再修改全局配置，实际运行接口与回溯语义不变。

## 验证

- scheduler 确定性红/绿：旧行为下 Task + IRQ-disabled 组合失败；修复后 `only_irq_return_may_schedule_from_an_irq_disabled_preemption_exit` 通过。
- AxVisor matcher 确定性红/绿：精确伪行 `rm:axvm::host::arceos:373] ...` 在旧配置下稳定误报，收紧后不匹配；真实 `cat: ...`/`rm: ...` 错误仍匹配。
- `cargo fmt --all`。
- `cargo xtask clippy --package`：`ax-sync`、`ax-hal`、`ax-task`、`ax-runtime`、`cpu-local`、`axbuild`、`starry-kernel` 全部通过。
- `axbacktrace` 基线复现：未修复的最新 `origin/dev` 连续运行标准测试可分别出现截断用例 32/16、满容量用例 16/32，确认是共享全局配置的并发污染，不是本 PR 调度代码进入该测试。
- `axbacktrace` 确定性红/绿：先让截断测试依赖显式层数入口，旧实现以 E0425 稳定失败；补齐入口后精确用例通过，17 个单元测试以 16 线程连续 30 轮全部通过。
- `cargo xtask clippy --package axbacktrace`：4 架构 × 4 feature 组合，16/16 全部通过。
- `cargo xtask test`（检查清单 v3 新入口）：44 个 std package 全部通过。
- `cargo test -p axbuild -- --test-threads=1`：940/940。
- `ax-task` QEMU axtest：riscv64、x86_64、aarch64、loongarch64 均为 16/16。
- CI 精确红/绿：`ax-fs-ng` x86_64 非抢占 axtest 从缺失测试探针的 E0425 编译失败转为 1/1 通过；完整 x86_64 workspace axtest 的 4 个执行单元全部通过。
- `cargo xtask axvisor test qemu --arch riscv64 --test-case smoke`：1/1，通过同一 SMP shell/NVMe 路径。
- Starry RISC-V SMP kernel axtest：42/42。
- `cargo xtask starry test qemu --arch riscv64 -c qemu/system/test-unshare-fs`：通过。
- RISC-V Starry 全量套件：早期基线 453/453 完整通过；重放到当前开发分支后，本地 `qemu/system` 454/454 完整通过（847.081 秒）。
- CI [run 32214723375](https://github.com/rcore-os/tgoskits/actions/runs/32214723375) 首次运行在 `test-nix-builder-exec` 通过后、下一个测试开始前静默到 1800 秒边界；本地完整复现不失败，未修改超时或测试通过条件。
- 同一 CI 的第二次运行中，[RISC-V Starry QEMU job 95963237084](https://github.com/rcore-os/tgoskits/actions/runs/32214723375/job/95963237084) 已越过原停点：`test-nix-builder-exec`、`test-nix-builder-init` 连续通过，完整系统套件 454/454（751.694 秒）。
- 该次重跑最终 37/37 job 全部成功，包含四架构 QEMU、标准环境测试和全部实体板矩阵；机器人 StarryOS 客体与原生套件均通过。
- 第二次本地全量运行曾在 `test-pagecache-cap` 完成全部功能断言后的清理阶段触发既有 240 秒边界；同一精确用例在未打补丁的最新 `origin/dev` 上也可复现，后续 `test-pipe-syscalls` 单独运行通过，因此未通过放宽超时掩盖该基线问题。

- 最新基线 PR CI [run 32146493289](https://github.com/rcore-os/tgoskits/actions/runs/32146493289)：37/37 job 全部成功，包含 Workspace std tests、四架构 ArceOS axtest、AxVisor riscv64/VMX、四架构 Starry QEMU 及实体板矩阵。
- OVMF/VMX 波动已归因：基线提交 `c76ee0d121` 的 [job 95691709201](https://github.com/rcore-os/tgoskits/actions/runs/32130435526/job/95691709201) 同样在 Linux `/init` 后 600 秒超时；当前头的完整矩阵已通过该用例，未放宽 timeout、success/fail regex 或 guest 断言。

最终提交已重放到 `origin/dev` `8618959d29`。