### PR TITLE
fix(ci): include ripgrep in the container image

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
         python3 \
         python3-venv \
         qemu-user-static \
+        ripgrep \
         wget \
         xz-utils \
         zlib1g-dev \
@@ -82,6 +83,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
 
 RUN set -eux; \
     cd /tmp/rust-toolchain; \
+    rg --version; \
     rustc --version; \
     cargo --version; \
     cargo install cargo-binutils


### PR DESCRIPTION
## 问题

`tgoskits-container` 被 CI 和仓库自动化任务复用，但当前镜像没有 `rg`。依赖仓库搜索的命令会以 127 退出，只能在每个临时容器里重复安装，既产生无意义失败记录，也增加网络依赖。

## 修改

- 在基础容器的 Ubuntu 包列表中安装 `ripgrep`。
- 在已有工具链 smoke 阶段执行 `rg --version`，使镜像发布在工具缺失时直接失败。

该能力属于项目容器镜像，不在上层运行时增加安装 fallback，也不改变 Rust、QEMU 或交叉工具链配置。回滚只需撤销这两个 Dockerfile 变更并重新发布镜像。

## 验证

- 当前发布镜像：`docker run --rm ghcr.io/rcore-os/tgoskits-container:latest sh -lc 'command -v rg && rg --version'`，稳定以 127 退出。\n- Ubuntu 24.04 包验证：安装后得到 `/usr/bin/rg` 与 `ripgrep 14.1.0`。\n- `docker build --check -f container/Dockerfile .`\n- 在项目容器 Python 3.12 中执行 `python3 -m unittest scripts.test.test_ci_plan scripts.test.test_ci_impact`，37 项通过。