### PR TITLE
refactor(ci): migrate checks to manifest v3 routing

### DIFF
--- a/.github/ci/checks/arceos.toml
+++ b/.github/ci/checks/arceos.toml
@@ -1,30 +1,25 @@
-schema_version = 2
+schema_version = 3
 phase = "test"
 group = "ArceOS"
+default_runner = "qcs"
 
 [[check]]
 id = "test-arceos-x86-64-qemu"
 impact_targets = ["arceos:x86_64"]
-name = "x86_64 QEMU · Suites + axtest"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
-cache_key = ""
+name = "QEMU x86_64 · Suites + axtest"
 command = '''
 cargo xtask arceos test qemu --arch x86_64
 cargo xtask ktest qemu --workspace --exclude starry-kernel --exclude axvisor --arch x86_64
 '''
 
+[[check.suite]]
+kind = "arceos-qemu"
+arch = "x86_64"
+
 [[check]]
 id = "test-arceos-riscv64-qemu"
 impact_targets = ["arceos:riscv64"]
-name = "riscv64 QEMU · Suites + task IPI + axtest"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
-cache_key = ""
+name = "QEMU riscv64 · Suites + task IPI + axtest"
 command = '''
 cargo xtask arceos test qemu --arch riscv64
 taskset -c 0 cargo xtask arceos test qemu --arch riscv64 \
@@ -32,15 +27,14 @@ taskset -c 0 cargo xtask arceos test qemu --arch riscv64 \
 cargo xtask ktest qemu --workspace --exclude starry-kernel --exclude axvisor --arch riscv64
 '''
 
+[[check.suite]]
+kind = "arceos-qemu"
+arch = "riscv64"
+
 [[check]]
 id = "test-arceos-aarch64-qemu-app-suites"
 impact_targets = ["arceos:aarch64"]
-name = "aarch64 QEMU · GICv2 SMP4 boot + suites + axtest"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
-cache_key = ""
+name = "QEMU aarch64 · GICv2 SMP4 boot + suites + axtest"
 command = '''
 echo "==> arceos aarch64 GICv2 SMP4 default app boot"
 cargo xtask arceos qemu --arch aarch64 --smp 4 \
@@ -50,16 +44,19 @@ cargo xtask arceos test qemu --arch aarch64
 cargo xtask ktest qemu --workspace --exclude starry-kernel --exclude axvisor --arch aarch64
 '''
 
+[[check.suite]]
+kind = "arceos-qemu"
+arch = "aarch64"
+
 [[check]]
 id = "test-arceos-loongarch64-qemu"
 impact_targets = ["arceos:loongarch64"]
-name = "loongarch64 QEMU · Suites + axtest"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
-cache_key = ""
+name = "QEMU loongarch64 · Suites + axtest"
 command = '''
 cargo xtask arceos test qemu --arch loongarch64
 cargo xtask ktest qemu --workspace --exclude starry-kernel --exclude axvisor --arch loongarch64
 '''
+
+[[check.suite]]
+kind = "arceos-qemu"
+arch = "loongarch64"

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -1,15 +1,12 @@
-schema_version = 2
+schema_version = 3
 phase = "test"
 group = "AxVisor"
+default_runner = "qcs"
 
 [[check]]
 id = "test-axvisor-aarch64-qemu-smoke-axtest-timer-stress"
 impact_targets = ["axvisor:aarch64"]
-name = "aarch64 QEMU · Smoke + virtio-blk guest + axtest + timer stress"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
+name = "QEMU aarch64 · Smoke + virtio-blk guest + axtest + timer stress"
 timeout_minutes = 30
 command = '''
 echo "==> axvisor aarch64 smoke"
@@ -26,14 +23,15 @@ echo "==> axvisor aarch64 gicv3 timer stress"
 cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "aarch64"
+cases = ["smoke", "gicv2-timer-stress", "gicv3-timer-stress"]
+
 [[check]]
 id = "test-axvisor-aarch64-qemu-panic-modes"
 impact_targets = ["axvisor:aarch64"]
-name = "aarch64 QEMU · Panic modes"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
+name = "QEMU aarch64 · Panic modes"
 timeout_minutes = 30
 command = '''
 echo "==> axvisor aarch64 backtrace panic"
@@ -42,14 +40,15 @@ echo "==> axvisor aarch64 no-backtrace panic"
 cargo xtask axvisor test qemu --arch aarch64 --test-case no-backtrace
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "aarch64"
+cases = ["backtrace-panic", "no-backtrace"]
+
 [[check]]
 id = "test-axvisor-aarch64-qemu-http-control-plane"
 impact_targets = ["axvisor:aarch64"]
-name = "aarch64 QEMU · HTTP control-plane"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
+name = "QEMU aarch64 · HTTP control-plane"
 timeout_minutes = 30
 command = '''
 echo "==> pull qemu-aarch64 image"
@@ -58,14 +57,15 @@ echo "==> axvisor aarch64 HTTP control-plane"
 cargo xtask axvisor test qemu --arch aarch64 --test-case http-control-plane
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "aarch64"
+cases = ["http-control-plane"]
+
 [[check]]
 id = "test-axvisor-riscv64-qemu-smoke-panic-modes"
 impact_targets = ["axvisor:riscv64"]
-name = "riscv64 QEMU · Smoke + IPI + panic modes"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
+name = "QEMU riscv64 · Smoke + IPI + panic modes"
 timeout_minutes = 30
 command = '''
 echo "==> axvisor riscv64 smoke"
@@ -83,39 +83,46 @@ echo "==> axvisor riscv64 no-backtrace panic"
 cargo xtask axvisor test qemu --arch riscv64 --test-case no-backtrace
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "riscv64"
+cases = ["smoke", "backtrace-panic", "no-backtrace"]
+
 [[check]]
 id = "test-axvisor-loongarch64-qemu"
 impact_targets = ["axvisor:loongarch64"]
-name = "loongarch64 QEMU · Suites"
-runs_on = ["ubuntu-latest"]
-environment = "axvisor-lvz"
+name = "QEMU loongarch64 · Suites"
+runner = "ubuntu-axvisor-lvz"
 cache_key = "test-axvisor-loongarch64"
 download_xtask_bin_artifact = true
 command = '''
 target/debug/tg-xtask axvisor test qemu --arch loongarch64
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "loongarch64"
+cases = ["smoke"]
+
 [[check]]
 id = "test-axvisor-qemu-ivc"
 impact_targets = ["axvisor:aarch64"]
-name = "aarch64 QEMU · IVC"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
+name = "QEMU aarch64 · IVC"
 command = '''
 cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qemu-ivc
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "aarch64"
+cases = ["qemu-ivc"]
+
 [[check]]
 id = "test-axvisor-self-hosted-x86-64-svm-smoke-acpi"
 impact_targets = ["axvisor:x86_64"]
-name = "x86_64 SVM · Smoke + direct/OVMF ACPI"
-runs_on = ["self-hosted", "linux", "amd", "kvm"]
-environment = "host"
-required_owner = "rcore-os"
+name = "SVM x86_64 · Smoke + direct/OVMF ACPI"
+runner = "kvm-amd"
 timeout_minutes = 30
-require_kvm = true
 command = '''
 echo "==> axvisor x86_64 svm smoke"
 cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm
@@ -127,27 +134,31 @@ echo "==> axvisor x86_64 svm nested OVMF ACPI boot"
 cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-svm
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "x86_64"
+cases = ["smoke-svm", "direct-acpi-svm", "ovmf-acpi-svm"]
+
 [[check]]
 id = "test-axvisor-self-hosted-x86-64-vmx"
 impact_targets = ["axvisor:x86_64"]
-name = "x86_64 VMX · Smoke"
-runs_on = ["self-hosted", "linux", "intel", "kvm"]
-environment = "host"
-required_owner = "rcore-os"
-require_kvm = true
+name = "VMX x86_64 · Smoke"
+runner = "kvm-intel"
 command = '''
 cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "x86_64"
+cases = ["smoke-vmx"]
+
 [[check]]
 id = "test-axloader-http-smoke"
 impact_packages = ["axloader"]
-name = "x86_64 UEFI · AxLoader HTTP boot"
-runs_on = ["self-hosted", "linux", "intel", "kvm"]
-environment = "host"
-required_owner = "rcore-os"
+name = "UEFI x86_64 · AxLoader HTTP boot"
+runner = "kvm-intel"
 timeout_minutes = 25
-require_kvm = true
 command = '''
 rustup target add x86_64-unknown-uefi
 cargo xtask axloader test qemu --target x86_64-unknown-uefi
@@ -156,12 +167,9 @@ cargo xtask axloader test qemu --target x86_64-unknown-uefi
 [[check]]
 id = "test-axvisor-x86-64-acpi-direct-and-ovmf-boot-vmx"
 impact_targets = ["axvisor:x86_64"]
-name = "x86_64 VMX · Direct + MP fallback + OVMF ACPI"
-runs_on = ["self-hosted", "linux", "intel", "kvm"]
-environment = "host"
-required_owner = "rcore-os"
+name = "VMX x86_64 · Direct + MP fallback + OVMF ACPI"
+runner = "kvm-intel"
 timeout_minutes = 45
-require_kvm = true
 command = '''
 cargo xtask image pull qemu-x86_64 --extract-dir tmp/axbuild/images
 cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-vmx
@@ -169,57 +177,68 @@ cargo xtask axvisor test qemu --arch x86_64 --test-case mp-fallback-vmx
 cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx
 '''
 
+[[check.suite]]
+kind = "axvisor-qemu"
+arch = "x86_64"
+cases = ["direct-acpi-vmx", "mp-fallback-vmx", "ovmf-acpi-vmx"]
+
 [[check]]
 id = "test-axvisor-self-hosted-board-orangepi-5-plus-linux"
 impact_targets = ["axvisor:aarch64"]
-name = "OrangePi 5 Plus board · Linux guest"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board OrangePi 5 Plus · Linux guest"
+runner = "board"
 command = '''
 cargo xtask axvisor test board --board orangepi-5-plus-linux
 '''
 
+[[check.suite]]
+kind = "axvisor-board"
+board = "orangepi-5-plus-linux"
+
 [[check]]
 id = "test-axvisor-self-hosted-board-orangepi-5-plus-starry"
 impact_targets = ["axvisor:aarch64"]
-name = "OrangePi 5 Plus board · StarryOS guest"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board OrangePi 5 Plus · StarryOS guest"
+runner = "board"
 command = '''
 cargo xtask axvisor test board --board orangepi-5-plus-starry
 '''
 
+[[check.suite]]
+kind = "axvisor-board"
+board = "orangepi-5-plus-starry"
+
 [[check]]
 id = "test-axvisor-self-hosted-board-roc-rk3568-pc-linux"
 impact_targets = ["axvisor:aarch64"]
-name = "ROC-RK3568-PC board · Linux guest"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board ROC-RK3568-PC · Linux guest"
+runner = "board"
 command = '''
 cargo xtask axvisor test board --board roc-rk3568-pc-linux
 '''
 
+[[check.suite]]
+kind = "axvisor-board"
+board = "roc-rk3568-pc-linux"
+
 [[check]]
 id = "test-axvisor-self-hosted-board-phytiumpi-linux"
 impact_targets = ["axvisor:aarch64"]
-name = "Phytium Pi board · Linux guest"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board Phytium Pi · Linux guest"
+runner = "board"
 command = '''
 cargo xtask axvisor test board --board phytiumpi-linux
 '''
 
+[[check.suite]]
+kind = "axvisor-board"
+board = "phytiumpi-linux"
+
 [[check]]
 id = "test-axvisor-self-hosted-board-asus-nuc15crh-linux"
 impact_targets = ["axvisor:x86_64"]
-name = "ASUS NUC15CRH board · Linux guest"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board ASUS NUC15CRH · Linux guest"
+runner = "board"
 timeout_minutes = 20
 command = '''
 mkdir -p tmp
@@ -231,26 +250,34 @@ gzip -dc \
 cargo xtask axvisor test board --board asus-nuc15crh-linux
 '''
 
+[[check.suite]]
+kind = "axvisor-board"
+board = "asus-nuc15crh-linux"
+
 [[check]]
 id = "test-orangepi-5-plus-robot-axvisor-starryos-guest"
 impact_targets = ["axvisor:aarch64"]
-name = "OrangePi 5 Plus robot board · StarryOS guest"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board OrangePi 5 Plus robot · StarryOS guest"
+runner = "board"
 timeout_minutes = 90
 command = '''
 cargo xtask axvisor test board --board orangepi-5-plus-robot-starry
 '''
 
+[[check.suite]]
+kind = "axvisor-board"
+board = "orangepi-5-plus-robot-starry"
+
 [[check]]
 id = "test-orangepi-5-plus-robot-axvisor-linux-guest"
 impact_targets = ["axvisor:aarch64"]
-name = "OrangePi 5 Plus robot board · Linux guest"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board OrangePi 5 Plus robot · Linux guest"
+runner = "board"
 timeout_minutes = 90
 command = '''
 cargo xtask axvisor test board --board orangepi-5-plus-robot-linux
 '''
+
+[[check.suite]]
+kind = "axvisor-board"
+board = "orangepi-5-plus-robot-linux"

--- a/.github/ci/checks/starry-apps.toml
+++ b/.github/ci/checks/starry-apps.toml
@@ -1,12 +1,10 @@
-schema_version = 2
+schema_version = 3
 phase = "starry_apps"
 group = "Starry Apps"
 
 [[check]]
 id = "starry-apps-clippy-all"
 name = "Workspace · Full Clippy"
-runs_on = ["ubuntu-latest"]
-environment = "base"
 cache_key = "starry-apps-clippy-all"
 container_preflight = "none"
 events = ["schedule"]
@@ -17,9 +15,7 @@ cargo xtask clippy --all
 
 [[check]]
 id = "starry-app-smoke-x86-64"
-name = "x86_64 QEMU · App smoke"
-runs_on = ["ubuntu-latest"]
-environment = "base"
+name = "QEMU x86_64 · App smoke"
 cache_key = "starry-apps-x86_64"
 apk_region = "us"
 container_preflight = "qemu-user"
@@ -29,9 +25,7 @@ cargo xtask starry app qemu --all --arch x86_64
 
 [[check]]
 id = "starry-app-smoke-aarch64"
-name = "aarch64 QEMU · App smoke"
-runs_on = ["ubuntu-latest"]
-environment = "base"
+name = "QEMU aarch64 · App smoke"
 cache_key = "starry-apps-aarch64"
 apk_region = "us"
 container_preflight = "qemu-user"
@@ -41,9 +35,7 @@ cargo xtask starry app qemu --all --arch aarch64
 
 [[check]]
 id = "starry-app-smoke-riscv64"
-name = "riscv64 QEMU · App smoke"
-runs_on = ["ubuntu-latest"]
-environment = "base"
+name = "QEMU riscv64 · App smoke"
 cache_key = "starry-apps-riscv64"
 apk_region = "us"
 container_preflight = "qemu-user"
@@ -53,9 +45,7 @@ cargo xtask starry app qemu --all --arch riscv64
 
 [[check]]
 id = "starry-app-smoke-loongarch64"
-name = "loongarch64 QEMU · App smoke"
-runs_on = ["ubuntu-latest"]
-environment = "base"
+name = "QEMU loongarch64 · App smoke"
 cache_key = "starry-apps-loongarch64"
 apk_region = "us"
 container_preflight = "qemu-user"
@@ -65,9 +55,8 @@ cargo xtask starry app qemu --all --arch loongarch64
 
 [[check]]
 id = "starry-nixos-x86-64-qemu"
-name = "x86_64 QEMU · NixOS Stage-2"
-runs_on = ["ubuntu-latest"]
-environment = "host"
+name = "QEMU x86_64 · NixOS Stage-2"
+runner = "ubuntu-host"
 timeout_minutes = 45
 container_preflight = "none"
 command = '''

--- a/.github/ci/checks/starry.toml
+++ b/.github/ci/checks/starry.toml
@@ -1,4 +1,4 @@
-schema_version = 2
+schema_version = 3
 phase = "test"
 group = "Starry"
 
@@ -9,9 +9,7 @@ group = "Starry"
 [[check]]
 id = "test-starry-riscv64-qemu"
 impact_targets = ["starry:riscv64"]
-name = "riscv64 QEMU · Suites"
-runs_on = ["ubuntu-latest"]
-environment = "base"
+name = "QEMU riscv64 · Suites"
 cache_key = "test-starry-riscv64"
 apk_region = "us"
 download_xtask_bin_artifact = true
@@ -20,12 +18,14 @@ target/debug/tg-xtask starry test qemu --arch riscv64
 target/debug/tg-xtask ktest qemu -p starry-kernel --arch riscv64
 '''
 
+[[check.suite]]
+kind = "starry-qemu"
+arch = "riscv64"
+
 [[check]]
 id = "test-starry-aarch64-qemu"
 impact_targets = ["starry:aarch64"]
-name = "aarch64 QEMU · GICv2 SMP4 boot + suites"
-runs_on = ["ubuntu-latest"]
-environment = "base"
+name = "QEMU aarch64 · GICv2 SMP4 boot + suites"
 cache_key = "test-starry-aarch64"
 apk_region = "us"
 download_xtask_bin_artifact = true
@@ -38,12 +38,14 @@ target/debug/tg-xtask starry test qemu --arch aarch64
 target/debug/tg-xtask ktest qemu -p starry-kernel --arch aarch64
 '''
 
+[[check.suite]]
+kind = "starry-qemu"
+arch = "aarch64"
+
 [[check]]
 id = "test-starry-loongarch64-qemu"
 impact_targets = ["starry:loongarch64"]
-name = "loongarch64 QEMU · Suites"
-runs_on = ["ubuntu-latest"]
-environment = "base"
+name = "QEMU loongarch64 · Suites"
 cache_key = "test-starry-loongarch64"
 apk_region = "us"
 download_xtask_bin_artifact = true
@@ -52,12 +54,14 @@ target/debug/tg-xtask starry test qemu --arch loongarch64
 target/debug/tg-xtask ktest qemu -p starry-kernel --arch loongarch64
 '''
 
+[[check.suite]]
+kind = "starry-qemu"
+arch = "loongarch64"
+
 [[check]]
 id = "test-starry-x86-64-qemu"
 impact_targets = ["starry:x86_64"]
-name = "x86_64 QEMU · Suites"
-runs_on = ["ubuntu-latest"]
-environment = "base"
+name = "QEMU x86_64 · Suites"
 cache_key = "test-starry-x86_64"
 apk_region = "us"
 download_xtask_bin_artifact = true
@@ -66,58 +70,72 @@ target/debug/tg-xtask starry test qemu --arch x86_64
 target/debug/tg-xtask ktest qemu -p starry-kernel --arch x86_64
 '''
 
+[[check.suite]]
+kind = "starry-qemu"
+arch = "x86_64"
+
 [[check]]
 id = "test-starry-self-hosted-board-orangepi-5-plus"
 impact_targets = ["starry:aarch64"]
-name = "OrangePi 5 Plus board · Suites"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board OrangePi 5 Plus · Suites"
+runner = "board"
 command = '''
 cargo xtask starry test board --board orangepi-5-plus
 '''
 
+[[check.suite]]
+kind = "starry-board"
+board = "orangepi-5-plus"
+
 [[check]]
 id = "test-orangepi-5-plus-robot-native-starryos"
 impact_targets = ["starry:aarch64"]
-name = "OrangePi 5 Plus robot board · Native suites"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board OrangePi 5 Plus robot · Native suites"
+runner = "board"
 timeout_minutes = 90
 command = '''
 cargo xtask starry test board --board orangepi-5-plus-robot
 '''
 
+[[check.suite]]
+kind = "starry-board"
+board = "orangepi-5-plus-robot"
+
 [[check]]
 id = "test-starry-self-hosted-board-aka-00-sg2002"
 impact_targets = ["starry:riscv64"]
-name = "AKA-00 SG2002 board · Suites"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board AKA-00 SG2002 · Suites"
+runner = "board"
 command = '''
 cargo xtask starry test board --board aka-00-sg2002
 '''
 
+[[check.suite]]
+kind = "starry-board"
+board = "aka-00-sg2002"
+
 [[check]]
 id = "test-starry-self-hosted-board-visionfive2"
 impact_targets = ["starry:riscv64"]
-name = "VisionFive 2 board · Suites"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board VisionFive 2 · Suites"
+runner = "board"
 command = '''
 cargo xtask starry test board --board visionfive2
 '''
 
+[[check.suite]]
+kind = "starry-board"
+board = "visionfive2"
+
 [[check]]
 id = "test-starry-self-hosted-board-jl-lsgd2k10"
 impact_targets = ["starry:loongarch64"]
-name = "JL LSGD2K10 board · Suites"
-runs_on = ["self-hosted", "linux", "board"]
-environment = "host"
-required_owner = "rcore-os"
+name = "Board JL LSGD2K10 · Suites"
+runner = "board"
 command = '''
 cargo xtask starry test board --board jl-lsgd2k10
 '''
+
+[[check.suite]]
+kind = "starry-board"
+board = "jl-lsgd2k10"

--- a/.github/ci/checks/static.toml
+++ b/.github/ci/checks/static.toml
@@ -1,14 +1,11 @@
-schema_version = 2
+schema_version = 3
 phase = "static"
 group = "Static"
 
 [[check]]
 id = "check-formatting"
 name = "Formatting + publish dry-run"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
+runner = "qcs"
 command = '''
 cargo fmt --all -- --check
 cargo publish --workspace --dry-run --no-verify
@@ -17,8 +14,6 @@ cargo publish --workspace --dry-run --no-verify
 [[check]]
 id = "run-sync-lint"
 name = "Incremental synchronization lint"
-runs_on = ["ubuntu-latest"]
-environment = "base"
 fetch_depth = "full"
 upload_xtask_bin_artifact = true
 command = '''
@@ -28,8 +23,6 @@ cargo xtask sync-lint --since "$SINCE_REF"
 [[check]]
 id = "run-lock-lint"
 name = "Locking policy"
-runs_on = ["ubuntu-latest"]
-environment = "base"
 command = '''
 cargo xtask lock-lint
 '''

--- a/.github/ci/checks/workspace.toml
+++ b/.github/ci/checks/workspace.toml
@@ -1,14 +1,11 @@
-schema_version = 2
+schema_version = 3
 phase = "test"
 group = "Workspace"
+default_runner = "qcs"
 
 [[check]]
 id = "run-clippy"
 name = "Incremental Clippy"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
 fetch_depth = "full"
 download_xtask_bin_artifact = true
 command = '''
@@ -18,10 +15,6 @@ cargo xtask clippy --since "$SINCE_REF"
 [[check]]
 id = "test-with-std"
 name = "std tests"
-runs_on = ["self-hosted", "linux", "qcs"]
-environment = "host"
-self_hosted_owner = "rcore-os"
-fallback_environment = "base"
 command = '''
 cargo xtask test
 '''

--- a/.github/ci/runner-profiles.toml
+++ b/.github/ci/runner-profiles.toml
@@ -1,0 +1,36 @@
+schema_version = 3
+
+[profile.ubuntu-base]
+runs_on = ["ubuntu-latest"]
+environment = "base"
+
+[profile.ubuntu-host]
+runs_on = ["ubuntu-latest"]
+environment = "host"
+
+[profile.ubuntu-axvisor-lvz]
+runs_on = ["ubuntu-latest"]
+environment = "axvisor-lvz"
+
+[profile.qcs]
+runs_on = ["self-hosted", "linux", "qcs"]
+environment = "host"
+self_hosted_owner = "rcore-os"
+fallback_environment = "base"
+
+[profile.board]
+runs_on = ["self-hosted", "linux", "board"]
+environment = "host"
+required_owner = "rcore-os"
+
+[profile.kvm-intel]
+runs_on = ["self-hosted", "linux", "intel", "kvm"]
+environment = "host"
+required_owner = "rcore-os"
+require_kvm = true
+
+[profile.kvm-amd]
+runs_on = ["self-hosted", "linux", "amd", "kvm"]
+environment = "host"
+required_owner = "rcore-os"
+require_kvm = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
       since_ref: ${{ steps.since.outputs.since_ref }}
       static_matrix: ${{ steps.matrix.outputs.static_matrix }}
       test_matrix: ${{ steps.matrix.outputs.test_matrix }}
+      static_required: ${{ steps.matrix.outputs.static_required }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -222,8 +223,9 @@ jobs:
             --output-file "$GITHUB_OUTPUT"
 
   static_checks:
-    name: Static
+    name: Preflight
     needs: plan_ci
+    if: needs.plan_ci.outputs.static_required == 'true'
     uses: ./.github/workflows/reusable-check-matrix.yml
     with:
       matrix_json: ${{ needs.plan_ci.outputs.static_matrix }}
@@ -234,10 +236,15 @@ jobs:
       CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
 
   test_checks:
-    name: Tests
+    name: Verification
     needs:
       - plan_ci
       - static_checks
+    if: >-
+      always() &&
+      needs.plan_ci.result == 'success' &&
+      (needs.static_checks.result == 'success' ||
+       needs.static_checks.result == 'skipped')
     uses: ./.github/workflows/reusable-check-matrix.yml
     with:
       matrix_json: ${{ needs.plan_ci.outputs.test_matrix }}

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -5,219 +5,145 @@ sidebar_label: "自动 CI 测试"
 
 # 自动 CI 测试
 
-CI 由 `.github/workflows/ci.yml`、`.github/workflows/ci-branch-push.yml`、`.github/workflows/reusable-command.yml` 和配套容器镜像共同组成，覆盖测试矩阵、缓存策略和 self-hosted runner 调度。
+主 CI 由以下几层组成：
 
-TGOSKits 将大部分构建与运行依赖收敛到统一的 container 镜像，由 GitHub Actions 和本地开发流程共同消费。需要物理设备、虚拟化能力或专用机器环境的任务则运行在 self-hosted runner 上。
+- `.github/workflows/ci.yml` 解析增量基线并调用 planner；
+- `.github/ci/checks/*.toml` 以 schema v3 声明检查、影响范围和已注册 test-suit 能力；
+- `.github/ci/runner-profiles.toml` 集中声明 runner、环境、owner 和 KVM 要求；
+- `scripts/test/ci_plan.py` 展开配置并生成矩阵；
+- `.github/workflows/reusable-check-matrix.yml` 执行展开后的矩阵行。
 
-## 三层架构
-
-```mermaid
-flowchart TB
-    subgraph L1["Container 镜像"]
-        L1_D["工具链 · QEMU · 交叉编译器"]
-    end
-    subgraph L2["可复用执行工作流"]
-        L2_D["reusable-command.yml"]
-    end
-    subgraph L3["CI 编排"]
-        L3_D["ci-branch-push.yml · ci.yml · container-publish.yml"]
-    end
-    L1 --> L2 --> L3
-```
-
-| 层级 | 作用 | 主要入口 |
-|------|------|----------|
-| Container 镜像 | 固化工具链、QEMU、交叉编译器 | `container/Dockerfile`、`container/Dockerfile.axvisor-lvz` |
-| 可复用工作流 | 统一在 host 或 container 中执行命令 | `.github/workflows/reusable-command.yml` |
-| CI 编排 | 选择测试矩阵、决定何时发布镜像，并路由非主线分支 push | `.github/workflows/ci.yml`、`.github/workflows/ci-branch-push.yml`、`.github/workflows/container-publish.yml` |
+容器发布由 `.github/workflows/container-publish.yml` 独立处理。非主线分支 push
+先经过 `.github/workflows/ci-branch-push.yml`，已有 open PR 时不重复调度主 CI。
 
 ## 触发条件
 
-| 事件 | 说明 |
+| 事件 | 行为 |
 |------|------|
-| `push` 到 `main` / `dev` | 排除纯文档变更（`*.md`、`docs/**` 等），其余路径直接触发完整 CI |
-| `push` 到其他分支 | 先进入 `ci-branch-push.yml`。若该分支已有 open PR，则 router 成功结束；否则由 router 触发完整 CI |
-| `pull_request` | 纯 Markdown 不触发主 CI；其余变更由 planner 按 crate、OS 和 arch 生成增量矩阵 |
-| `workflow_dispatch` | 默认用于发布容器镜像（`base` / `axvisor-lvz` / `both`）；router 也会用 `run_target=ci` 调度非 PR 分支的完整 CI |
+| push 到 `main` / `dev` | 非文档变更运行完整矩阵 |
+| 其他分支 push | 没有 open PR 时通过 `workflow_dispatch` 运行完整矩阵 |
+| pull request | planner 根据三点 diff 生成增量矩阵 |
+| workflow dispatch | 使用指定的 `since_sha`，但仍运行完整矩阵 |
 
-`dev` 分支的 `push` 和手动触发使用 `concurrency.queue: max` 串行排队运行，避免多个 dev CI 同时占用 runner。其他分支、`main` 分支、PR 以及非 `dev` 手动触发不会进入 dev 队列；新 run 会在最早的 `cancel_stale_runs` 阶段取消同一分支或同一 PR 上仍在 queued/running 的旧 CI run。
+纯 Markdown 变更不触发主 CI。`push` 和 `workflow_dispatch` 不缩小测试矩阵。
 
-非 `main` / `dev` 分支的 `push` 由轻量 router 先检查是否已有同仓库、同名分支的 open PR。已有 PR 时不会调度 `.github/workflows/ci.yml`，router 会输出跳过原因并以成功状态结束，PR 的 `pull_request` CI 负责验证同一提交。没有 open PR 时，router 使用 `workflow_dispatch(run_target=ci)` 调度完整 CI，并把 push 事件的 `before` SHA 传给差异检查。
-
-### PR 增量矩阵
-
-只有 `pull_request` 使用增量矩阵。planner 以 PR base SHA 做三点 diff，忽略 `.md` 和 `apps/**`，并将其余路径映射到最深层 workspace package。随后分别为 aarch64、x86_64、riscv64 和 loongarch64 运行带 `--all-features --filter-platform` 的 Cargo metadata，通过反向依赖确定 ArceOS、StarryOS 和 AxVisor 的受影响架构。workspace axtest package 还会按其声明的 target 选择承载该测试的 ArceOS job。
-
-非 crate 的已知 OS 配置和 test-suit 文件按目录及配置名映射；只能确定 OS 时运行该 OS 的全部架构。package 删除、未知源码路径、Cargo/toolchain、CI planner/workflow/check manifest、`.cargo/**` 或任意 xtask 实现变更，以及 diff/metadata 失败，都会回退到当前完整矩阵。回退不会静默缩小覆盖。
-
-每个被选中的 OS/arch 仍执行该矩阵项原有的全部 QEMU、KVM 和板卡命令。`apps/**` 本身不选择 OS/arch 或 app 运行测试；混合 PR 中的其他改动仍按正常规则选择。static checks 始终保留，workspace Clippy 继续使用 `--since`，std whitelist 在增量 PR 中使用 `cargo xtask test --since <base>`。`push` 和 `workflow_dispatch` 不使用该影响分析，保持完整矩阵。
-
-planner 将 changed paths、忽略的 Markdown/apps、changed/affected packages、选中的 OS/arch、选中/跳过的 checks 和全量回退原因写入 Actions job summary。
-
-## 执行流水线
+## 执行阶段与名称
 
 ```text
-cancel_stale_runs
-  |
-  `-- detect_changes
-  |
-  +-- [ci_checks == true]
-  |     `-- static_checks (fmt/publish-dry-run || sync-lint || lock-lint)  fail-fast: true
-  |           `-- test_checks (所有测试并发)     fail-fast: true
-  |
-  `-- [push/dispatch 到 main/dev]
-        +-- publish_base_container
-        `-- publish_axvisor_lvz_container       依赖 base 成功后才运行
+Cancel stale CI runs
+  -> Plan CI
+     -> Preflight / <purpose>
+        -> Verification / <OS> / <platform> <arch-or-board> · <purpose>
 ```
 
-非 `main` / `dev` 分支 push 会先经过 `.github/workflows/ci-branch-push.yml`：
+固定阶段名称为 `Preflight` 和 `Verification`。平台写在架构之前，例如：
 
 ```text
-branch push router
-  |
-  +-- [branch has open PR]  success summary only
-  |
-  `-- [no open PR]         workflow_dispatch(run_target=ci) -> ci.yml
+Preflight / Formatting + publish dry-run
+Verification / ArceOS / QEMU aarch64 · GICv2 SMP4 boot + suites + axtest
+Verification / AxVisor / VMX x86_64 · Smoke
+Verification / Starry / Board VisionFive 2 · Suites
 ```
 
-`static_checks` 作为测试矩阵的前置门禁：格式检查、workspace 发布 dry-run、sync-lint 或 lock-lint 不通过时，后续测试不会启动。`static_checks` 和 `test_checks` 都启用 `fail-fast: true`，任意矩阵项失败会取消同矩阵内其他任务，减少 runner 占用。
+`Preflight` 包含 formatting/publish dry-run、incremental sync-lint 和 locking
+policy。`Verification` 包含 Workspace、ArceOS、AxVisor 和 Starry 检查。全量运行
+展开为 3 个 Preflight 行和 32 个 Verification 行。
 
-## 变更检测
+## PR 影响路由
 
-`detect_changes` 使用 `dorny/paths-filter@v4` 判断后续任务是否需要运行：
+planner 将输入分为三类：
 
-| 检测路径 | 触发任务 |
-|----------|----------|
-| `.cargo/`、`.github/workflows/{ci,ci-branch-push,reusable-command,container-publish}.yml`、`Cargo.toml`、`Cargo.lock`、`rust-toolchain.toml`、`bootloader/axloader/`、`components/`、`drivers/`、`memory/`、`net/`、`os/`、`platforms/`、`scripts/`、`test-suit/`、`virtualization/`、`xtask/` 等 | CI 检查 |
-| `container/Dockerfile`、`rust-toolchain.toml` | 发布基础容器镜像 |
-| `container/Dockerfile.axvisor-lvz`、`rust-toolchain.toml` | 发布 LVZ 扩展镜像 |
+1. workspace crate 通过四个 bare-metal target 的 Cargo metadata 计算反向依赖；
+2. test-suit 和 OS 配置使用精确输入路由；
+3. 全局、未知或无法安全解释的输入回退到完整矩阵。
 
-push 到 `main` / `dev` 时强制运行 CI 检查。非 `main` / `dev` 分支没有 open PR 时由 router 调度完整 CI；已有 open PR 时只保留一个成功的 router 检查，由 pull request CI 覆盖同一提交。
+只要 crate 在任意架构影响 ArceOS、Starry 或 AxVisor 根 package，就会运行该
+OS 当前注册的全部 QEMU、KVM 和真机检查，不再只运行最初命中的架构。独立
+axtest package 仍按其声明的 target 选择 ArceOS QEMU 检查，AxLoader 仍由自己的
+package impact 单独选择。
 
-`detect_changes` 内部还负责输出跳过原因：
+命名明确的 QEMU/board 配置只选择对应平台。无法精确解释但能确定所属 OS 的配置
+会回退到该 OS 的全部注册检查。`apps/**` 默认不扩大运行时覆盖，但
+`apps/arceos/virtio-blk-test/**` 是 AxVisor aarch64 CI 的直接输入，会选择对应 QEMU
+检查。
 
-- `Summarize skipped CI checks`：说明 CI 检查为什么被跳过。
-- `Summarize manual container branch restriction`：说明手动容器发布为什么因分支限制被跳过。
+解析失败、未知源码路径、Cargo/toolchain、CI 配置、workflow、planner、xtask 或
+`scripts/axbuild/**` 变更都会回退完整矩阵。planner 会在 Actions summary 中写出
+changed paths、affected OS、精确输入、test-suit 选择、selected/skipped checks 和
+回退原因。
 
-## Static Checks
+## test-suit 精确运行
 
-`static_checks` 是并行矩阵，全部通过后才进入 `test_checks`。
+如果 PR 的有效改动全部位于 `test-suit/**`，planner 进入 exclusive 模式：
 
-| Job 名称 | Runner | 使用容器 | Cache Key | 功能说明 |
-|----------|--------|----------|-----------|----------|
-| Check formatting | `self-hosted linux qcs`（非 `rcore-os` 回退到 `ubuntu-latest` + `base` 容器） | 通常否 | 无 | `cargo fmt --all -- --check` 和 `cargo publish --workspace --dry-run --no-verify` |
-| Run sync-lint | `ubuntu-latest` | 是（`base`） | 无 | `cargo xtask sync-lint --since <base>`；需要完整 git 历史，并上传编译好的 `tg-xtask` 供后续容器 job 复用 |
-| Run lock-lint | `ubuntu-latest` | 是（`base`） | 无 | `cargo xtask lock-lint`，校验统一锁依赖、OS facade 和 runtime provider 约束 |
+- `Preflight` 不执行；
+- Workspace 和其他 OS 的聚合检查不执行；
+- 每个变更只生成对应的已注册 case 行；
+- 多个 case 取稳定去重并集；
+- 没有 CI runner/template 注册的 case 使 `Plan CI` 明确失败。
 
-## Test Checks
+动态名称遵循：
 
-`test_checks` 依赖 `static_checks` 全部通过后并发执行。
+```text
+Verification / <OS> / <platform> <arch-or-board> · <case>
+```
 
-| Job 名称 | Runner | 使用容器 | Cache Key | 功能说明 |
-|----------|--------|----------|-----------|----------|
-| Run clippy | `self-hosted linux qcs` | 否 | 无 | `cargo xtask clippy --since <base>`；需要完整 git 历史；fork PR 回退到 `ubuntu-latest` + `base` 容器 |
-| Test with std | `self-hosted linux qcs` | 否 | 无 | 非 PR 或全量回退运行 `cargo xtask test`；增量 PR 运行 `cargo xtask test --since <base>`，只保留 affected package 与 `scripts/test/std_crates.csv` 的交集；fork PR 回退到 `ubuntu-latest` + `base` 容器 |
-| Test axvisor aarch64 qemu | `self-hosted linux qcs` | 否 | 无 | `cargo xtask axvisor test qemu --arch aarch64`；`rcore-os` 仓库使用 self-hosted，fork PR 回退到 `ubuntu-latest` + `base` 容器 |
-| Test axvisor riscv64 qemu | `self-hosted linux qcs` | 否 | 无 | `cargo xtask axvisor test qemu --arch riscv64`；`rcore-os` 仓库使用 self-hosted，fork PR 回退到 `ubuntu-latest` + `base` 容器 |
-| Test axvisor loongarch64 qemu | `ubuntu-latest` | 是（`axvisor-lvz`） | `test-axvisor-loongarch64` | `cargo xtask axvisor test qemu --arch loongarch64`，使用带 LVZ 支持的镜像 |
-| Test starry riscv64 qemu | `ubuntu-latest` | 是（`base`） | `test-starry-riscv64` | `cargo xtask starry test qemu --arch riscv64` |
-| Test starry aarch64 qemu | `ubuntu-latest` | 是（`base`） | `test-starry-aarch64` | `cargo xtask starry test qemu --arch aarch64` |
-| Test starry loongarch64 qemu | `ubuntu-latest` | 是（`base`） | `test-starry-loongarch64` | `cargo xtask starry test qemu --arch loongarch64` |
-| Test starry x86_64 qemu | `ubuntu-latest` | 是（`base`） | `test-starry-x86_64` | `cargo xtask starry test qemu --arch x86_64` |
-| Test arceos x86_64 qemu | `self-hosted linux qcs` | 否 | 无 | 先运行 ArceOS Rust/C suite，再以一次 `cargo xtask ktest qemu --workspace ... --arch x86_64` 串行运行同架构 axtest；仅 `rcore-os` 仓库触发 |
-| Test arceos riscv64 qemu | `self-hosted linux qcs` | 否 | 无 | 先运行 ArceOS suite/任务 IPI，再以一次 `ktest qemu --arch riscv64` 串行运行同架构 axtest；仅 `rcore-os` 仓库触发 |
-| Test arceos aarch64 qemu | `self-hosted linux qcs` | 否 | 无 | 先运行 GICv2 SMP4 boot 与 ArceOS suite，再以一次 `ktest qemu --arch aarch64` 串行运行同架构 axtest；仅 `rcore-os` 仓库触发 |
-| Test arceos loongarch64 qemu | `self-hosted linux qcs` | 否 | 无 | 先运行 ArceOS suite，再以一次 `ktest qemu --arch loongarch64` 串行运行同架构 axtest；仅 `rcore-os` 仓库触发 |
-| Test axvisor self-hosted x86_64(svm) | `self-hosted linux amd kvm` | 否 | 无 | `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-svm`；验证 SVM 宿主启动及宿主 NVMe 根文件系统写入/回读，仅 `rcore-os` 仓库触发 |
-| Test axvisor self-hosted x86_64(vmx) | `self-hosted linux intel kvm` | 否 | 无 | `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx`；验证 VMX 宿主启动及宿主 NVMe 根文件系统写入/回读，仅 `rcore-os` 仓库触发 |
-| Test axloader HTTP smoke | `self-hosted linux intel kvm` | 否 | 无 | 安装 `x86_64-unknown-uefi` target，通过 Ostool 获取并校验 OVMF，运行 `cargo xtask axloader test qemu --target x86_64-unknown-uefi`；仅 `rcore-os` 仓库触发 |
-| Test axvisor self-hosted board orangepi-5-plus-linux | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board orangepi-5-plus-linux`；物理板卡；仅 `rcore-os` 仓库触发 |
-| Test axvisor self-hosted board orangepi-5-plus-starry | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board orangepi-5-plus-starry`；物理板卡；仅 `rcore-os` 仓库触发 |
-| Test axvisor self-hosted board roc-rk3568-pc-linux | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board roc-rk3568-pc-linux`；物理板卡；仅 `rcore-os` 仓库触发 |
-| Test axvisor self-hosted board phytiumpi-linux | `self-hosted linux board` | 否 | 无 | `cargo xtask axvisor test board --board phytiumpi-linux`；物理板卡；仅 `rcore-os` 仓库触发 |
-| Test starry self-hosted board orangepi-5-plus | `self-hosted linux board` | 否 | 无 | `cargo xtask starry test board --board orangepi-5-plus`；物理板卡；仅 `rcore-os` 仓库触发 |
-| Test starry self-hosted board aka-00-sg2002 | `self-hosted linux board` | 否 | 无 | `cargo xtask starry test board --board aka-00-sg2002`；物理板卡；仅 `rcore-os` 仓库触发 |
-| Test starry self-hosted board visionfive2 | `self-hosted linux board` | 否 | 无 | `cargo xtask starry test board --board visionfive2`；物理板卡；仅 `rcore-os` 仓库触发 |
+例如：
 
-StarryOS stress 测试条目保留在 workflow 中，但当前处于注释状态。启用后仅用于 target 为 `main` 的 PR。
+```text
+Verification / ArceOS / QEMU riscv64 · rust/task-ipi
+Verification / Starry / QEMU aarch64 · qemu/system
+Verification / AxVisor / VMX x86_64 · direct-acpi-vmx
+Verification / Starry / Board OrangePi 5 Plus · native-hardware-smoke
+```
 
-## Self-Hosted Runner 约定
+Starry `qemu/system/<subcase>` 源码变更使用 `qemu/<subcase>` selector，并为拥有
+`qemu-<arch>.toml` 且已注册的架构分别生成一行。共享 build wrapper 变更会展开到
+该 wrapper 下所有已注册 case。suite 与 crate/OS 输入混合时，更宽的 OS 规则优先，
+不会重复生成同一 OS 的精确 suite 行。
 
-self-hosted runner 任务优先在 `rcore-os` 仓库内运行。带 `self_hosted_owner` 的任务在 fork PR 或非 `rcore-os` 仓库中会回退到 `ubuntu-latest` + 对应容器，避免没有对应 runner 时长时间排队。迁移到 self-hosted 的任务直接在原生 runner 环境中运行，不再套 Docker container。
+## Manifest schema v3
 
-现有 label 约定：
+每个 check manifest 必须声明 `schema_version = 3`。schema v2 不再兼容。
 
-| Label | 用途 |
-|-------|------|
-| `self-hosted`, `linux`, `qcs` | clippy、std 测试、ArceOS QEMU 测试、Axvisor aarch64/riscv64 QEMU |
-| `self-hosted`, `linux`, `intel`, `kvm` | Axvisor x86_64 KVM 测试 |
-| `self-hosted`, `linux`, `board` | 物理板卡测试 |
+全局默认 runner 是 `ubuntu-base`。同一 manifest 大部分检查使用另一 runner 时，可用
+`default_runner`；单项差异使用 `runner`。默认 runner 或默认字段不需要重复书写。
+check 中禁止直接声明 `runs_on`、`environment`、owner 或 `require_kvm`，这些字段只
+来自 runner profile。
 
-## Cache 策略
+当前 profiles：
 
-| Cache Key | 使用 Job | 保存时机 | 说明 |
-|-----------|----------|----------|------|
-| `test-axvisor-loongarch64` | Test axvisor loongarch64 QEMU | `push` 事件 | Axvisor loongarch64 编译产物 |
-| `test-starry-riscv64/aarch64/loongarch64/x86_64` | Test starry riscv64/aarch64/loongarch64/x86_64 QEMU | `push` 事件 | StarryOS QEMU 编译产物 |
-| 无（`cache_key: ""`） | static checks、self-hosted x86_64/board 类 job | - | 不启用 `Swatinem/rust-cache`；self-hosted 任务依赖 runner 本地磁盘缓存 |
+| Profile | Runner / 环境 | 约束 |
+|---------|---------------|------|
+| `ubuntu-base` | `ubuntu-latest` + base container | 全局默认 |
+| `ubuntu-host` | `ubuntu-latest` host | 不使用 container |
+| `ubuntu-axvisor-lvz` | `ubuntu-latest` + LVZ container | LoongArch AxVisor |
+| `qcs` | `self-hosted, linux, qcs` | fork 回退到 base container |
+| `board` | `self-hosted, linux, board` | 仅 `rcore-os` owner |
+| `kvm-intel` | `self-hosted, linux, intel, kvm` | 仅 `rcore-os`，要求 KVM |
+| `kvm-amd` | `self-hosted, linux, amd, kvm` | 仅 `rcore-os`，要求 KVM |
 
-self-hosted runner 不设置 `cache_key`，避免 `Swatinem/rust-cache@v2` 的 post-job 清理影响 runner 上跨次运行自然积累的共享缓存。
+self-hosted 检查的 `cache_key` 必须为空；省略时默认就是空字符串。GitHub-hosted
+检查只有显式非空 `cache_key` 才启用 `Swatinem/rust-cache`。
 
-## 容器镜像
+## 可复用矩阵
 
-CI 使用两个容器镜像：
+`reusable-check-matrix.yml` 只包含一个 matrix job。planner 始终输出完全展开的
+runner labels、container image、preflight、cache、checkout depth、timeout、artifact
+和命令字段。
 
-| 镜像 | Dockerfile | 用途 |
-|------|------------|------|
-| `base` | `container/Dockerfile` | sync-lint、StarryOS QEMU，以及 clippy、std、self-hosted QEMU 测试在 fork PR 或非 `rcore-os` 仓库中的回退环境 |
-| `axvisor-lvz` | `container/Dockerfile.axvisor-lvz` | Axvisor loongarch64 QEMU，额外包含 LVZ 支持 |
+普通完整/增量运行中，sync-lint 生成 `tg-xtask-bin` artifact，使用容器的测试行可
+下载复用。exclusive test-suit 不运行 Preflight，因此动态行直接使用 `cargo xtask`
+并禁用 artifact 下载。
 
-基础镜像以 `ubuntu:24.04` 为底，内置 Rust 工具链、QEMU、musl cross-toolchain、libav、libudev 等依赖。容器内的 musl cross-toolchain 已通过 `PATH` 配置好，`reusable-command.yml` 会在 container job 启动时验证 QEMU user emulators 和 musl compiler 是否存在，不再在运行时动态下载。
-
-## 容器发布
-
-| Job 名称 | Runner | 触发条件 | 功能说明 |
-|----------|--------|----------|----------|
-| Publish base container | `ubuntu-latest` | push 到 `main` / `dev` 且基础镜像相关路径变更，或手动选择发布 `base` / `both` | 构建并推送 `ghcr.io/<repo>-container:latest` |
-| Publish axvisor-lvz container | `ubuntu-latest` | push 到 `main` / `dev` 且 LVZ 镜像相关路径变更，或手动选择发布 `axvisor-lvz` / `both` | 构建并推送 `ghcr.io/<repo>-container-axvisor-lvz:latest` |
-
-`axvisor-lvz` 镜像依赖基础镜像。若同一次运行需要发布基础镜像，LVZ 镜像会等待基础镜像发布成功后再构建。
-
-## 本地使用预构建镜像
-
-开发者可以直接拉取 CI 使用的预构建镜像：
+## 本地检查
 
 ```bash
-docker pull ghcr.io/rcore-os/tgoskits-container:latest
-
-docker run -it --rm \
-  -v "$(pwd)":/workspace \
-  -w /workspace \
-  ghcr.io/rcore-os/tgoskits-container:latest
+python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py
+python3 scripts/test/check_ci_paths.py
+python3 scripts/test/check_ci_routing.py
+python3 scripts/test/check_workflow_layout.py
+actionlint
 ```
 
-## `reusable-command.yml`
-
-所有 `static_checks` 和 `test_checks` 中的 job 均通过 `.github/workflows/reusable-command.yml` 执行。该 workflow 根据 `inputs.use_container` 在两个互斥 job 中选择一个：
-
-| Job | 说明 |
-|-----|------|
-| `run_host` | 不使用容器，直接在 runner 原生环境中执行命令 |
-| `run_container` | 使用指定镜像执行命令，并在启动时验证 QEMU user emulator 和 musl cross-toolchain |
-
-`runs_on` 使用 JSON 字符串输入并通过 `fromJson(inputs.runs_on)` 转为 GitHub Actions runner label 数组。Rust 编译缓存仅在 `cache_key != ""` 时启用，`push` 事件保存，PR 事件只读取不保存。
-
-## 命名规则
-
-| 文件类型 | 格式 | 示例 |
-|----------|------|------|
-| QEMU 配置 | `qemu-{arch}.toml` | `qemu-aarch64.toml`、`qemu-x86_64.toml` |
-| 板级配置 | `board-{board_name}.toml` | `board-orangepi-5-plus.toml` |
-| 构建配置 | `build-{target}.toml` | `build-x86_64-unknown-none.toml` |
-
-| 架构缩写 | 完整 Target |
-|----------|-------------|
-| `x86_64` | `x86_64-unknown-none` |
-| `aarch64` | `aarch64-unknown-none-softfloat` |
-| `riscv64` | `riscv64gc-unknown-none-elf` |
-| `loongarch64` | `loongarch64-unknown-none-softfloat` |
+本仓库的 planner 需要 Python 3.11 或更新版本。

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -3,7 +3,6 @@
 import sys
 from pathlib import Path
 
-
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
 BRANCH_PUSH_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci-branch-push.yml"
@@ -47,7 +46,9 @@ def main() -> int:
     required_files = (CI_WORKFLOW, BRANCH_PUSH_WORKFLOW, CONTAINER_WORKFLOW)
     for required_file in required_files:
         if not required_file.is_file():
-            errors.append(f"missing workflow: {required_file.relative_to(WORKSPACE_ROOT)}")
+            errors.append(
+                f"missing workflow: {required_file.relative_to(WORKSPACE_ROOT)}"
+            )
     if errors:
         return report(errors)
 
@@ -64,9 +65,7 @@ def main() -> int:
     ci_dispatch_inputs = mapping_block(ci_dispatch, "inputs", 4)
     since_sha = mapping_block(ci_dispatch_inputs, "since_sha", 6)
 
-    router_push = mapping_block(
-        mapping_block(branch_push_workflow, "on", 0), "push", 2
-    )
+    router_push = mapping_block(mapping_block(branch_push_workflow, "on", 0), "push", 2)
     router_permissions = mapping_block(branch_push_workflow, "permissions", 0)
 
     require_equal(
@@ -108,6 +107,30 @@ def main() -> int:
         "since_ref: ${{ steps.since.outputs.since_ref }}",
         "plan_ci must publish the resolved since_ref",
     )
+    require_contains(
+        errors,
+        ci_workflow,
+        "static_required: ${{ steps.matrix.outputs.static_required }}",
+        "plan_ci must publish whether Preflight is required",
+    )
+    for needle, message in (
+        ("name: Preflight", "main CI must use the Preflight phase name"),
+        ("name: Verification", "main CI must use the Verification phase name"),
+        (
+            "if: needs.plan_ci.outputs.static_required == 'true'",
+            "Preflight must be controlled by the planner output",
+        ),
+        ("always() &&", "Verification must handle an intentionally skipped Preflight"),
+        (
+            "needs.static_checks.result == 'success'",
+            "Verification must require a successful Preflight when it runs",
+        ),
+        (
+            "needs.static_checks.result == 'skipped'",
+            "Verification must accept an intentionally skipped Preflight",
+        ),
+    ):
+        require_contains(errors, ci_workflow, needle, message)
     require_contains(
         errors,
         ci_workflow,
@@ -206,8 +229,7 @@ def main() -> int:
         "pull-requests": "read",
     }
     actual_permissions = {
-        name: scalar_value(router_permissions, name, 2)
-        for name in expected_permissions
+        name: scalar_value(router_permissions, name, 2) for name in expected_permissions
     }
     if actual_permissions != expected_permissions:
         errors.append(
@@ -230,7 +252,10 @@ def main() -> int:
         ('-f since_sha="$BEFORE_SHA"', "router must preserve the push base SHA"),
     ):
         require_contains(errors, branch_push_workflow, needle, message)
-    if "run_target" in branch_push_workflow or "container_target" in branch_push_workflow:
+    if (
+        "run_target" in branch_push_workflow
+        or "container_target" in branch_push_workflow
+    ):
         errors.append("branch router must not pass removed CI dispatch inputs")
 
     skip_index = branch_push_workflow.find("exit 0")
@@ -283,9 +308,7 @@ def indentation(line: str) -> int:
     return len(line) - len(line.lstrip())
 
 
-def require_contains(
-    errors: list[str], text: str, needle: str, message: str
-) -> None:
+def require_contains(errors: list[str], text: str, needle: str, message: str) -> None:
     if needle not in text:
         errors.append(message)
 

--- a/scripts/test/check_workflow_layout.py
+++ b/scripts/test/check_workflow_layout.py
@@ -4,10 +4,9 @@ import re
 import sys
 from pathlib import Path
 
-
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS = WORKSPACE_ROOT / ".github" / "workflows"
-CHECKS = WORKSPACE_ROOT / ".github" / "ci" / "checks"
+CI_CONFIG = WORKSPACE_ROOT / ".github" / "ci"
 PUBLISH_ACTION = (
     WORKSPACE_ROOT / ".github" / "actions" / "publish-container" / "action.yml"
 )
@@ -31,7 +30,7 @@ def main() -> int:
             continue
         text = path.read_text(encoding="utf-8")
         texts[name] = text
-        if re.search(r"^    if:", text, flags=re.MULTILINE):
+        if name != "ci.yml" and re.search(r"^    if:", text, flags=re.MULTILINE):
             errors.append(f"{name} contains a job-level applicability condition")
 
     reusable = texts.get("reusable-check-matrix.yml", "")
@@ -43,12 +42,21 @@ def main() -> int:
 
     ci = texts.get("ci.yml", "")
     for required_call in (
-        "name: Static",
-        "name: Tests",
+        "name: Preflight",
+        "name: Verification",
         "uses: ./.github/workflows/reusable-check-matrix.yml",
+        "if: needs.plan_ci.outputs.static_required == 'true'",
+        "always() &&",
+        "needs.plan_ci.result == 'success'",
+        "needs.static_checks.result == 'success'",
+        "needs.static_checks.result == 'skipped'",
     ):
         if required_call not in ci:
             errors.append(f"main CI is missing: {required_call}")
+    if len(re.findall(r"^    if:", ci, flags=re.MULTILINE)) != 2:
+        errors.append(
+            "main CI must define only the planned Preflight and Verification conditions"
+        )
     if "dorny/paths-filter" in ci:
         errors.append("main CI must not create a detect-and-skip path-filter job")
 
@@ -84,9 +92,11 @@ def main() -> int:
                     f"publish-container action is missing: {required_fragment}"
                 )
 
-    for manifest in CHECKS.glob("*.toml"):
+    for manifest in CI_CONFIG.rglob("*.toml"):
         if "${{" in manifest.read_text(encoding="utf-8"):
-            errors.append(f"{manifest.name} embeds a GitHub expression")
+            errors.append(
+                f"{manifest.relative_to(CI_CONFIG)} embeds a GitHub expression"
+            )
 
     legacy_workflow = WORKFLOWS / "reusable-command.yml"
     if legacy_workflow.exists():

--- a/scripts/test/ci_impact.py
+++ b/scripts/test/ci_impact.py
@@ -4,10 +4,9 @@ import json
 import re
 import subprocess
 from collections import defaultdict
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, Mapping, Sequence
-
 
 ARCH_TARGETS = {
     "aarch64": "aarch64-unknown-none-softfloat",
@@ -39,14 +38,17 @@ FULL_PREFIXES = (
     Path("os/axvisor/xtask"),
 )
 IGNORED_APP_PREFIX = Path("apps")
-KNOWN_OS_PATHS = (
+TEST_SUITE_PATHS = (
     (Path("test-suit/arceos"), "arceos"),
     (Path("test-suit/starryos"), "starry"),
     (Path("test-suit/axvisor"), "axvisor"),
+)
+KNOWN_OS_CONFIG_PATHS = (
     (Path("os/arceos/configs"), "arceos"),
     (Path("os/StarryOS/configs"), "starry"),
     (Path("os/axvisor/configs"), "axvisor"),
 )
+CI_OWNED_APP_INPUTS = ((Path("apps/arceos/virtio-blk-test"), "axvisor:qemu:aarch64"),)
 ARCH_PATH_ALIASES = {
     "aarch64": (
         "a1000",
@@ -84,6 +86,10 @@ class CiImpact:
     ignored_apps: tuple[str, ...] = ()
     changed_packages: tuple[str, ...] = ()
     affected_packages: tuple[str, ...] = ()
+    affected_oses: tuple[str, ...] = ()
+    input_selections: tuple[str, ...] = ()
+    test_suite_paths: tuple[str, ...] = ()
+    exclusive: bool = False
     targets: tuple[str, ...] = ()
 
     @classmethod
@@ -101,6 +107,7 @@ class CiImpact:
             changed_paths=_sorted_path_strings(changed_paths),
             ignored_markdown=tuple(sorted(set(ignored_markdown))),
             ignored_apps=tuple(sorted(set(ignored_apps))),
+            affected_oses=tuple(OS_ROOT_PACKAGES),
             targets=tuple(
                 f"{os_name}:{arch}"
                 for os_name in OS_ROOT_PACKAGES
@@ -139,7 +146,11 @@ def analyze_pull_request(workspace_root: Path, since_ref: str) -> CiImpact:
                 ignored_markdown=ignored_markdown,
                 ignored_apps=ignored_apps,
             )
-        metadata_by_arch = load_metadata_by_arch(workspace_root)
+        metadata_by_arch = (
+            {}
+            if all(_is_known_input_path(path) for path in relevant)
+            else load_metadata_by_arch(workspace_root)
+        )
         return analyze_changed_paths(workspace_root, changed_paths, metadata_by_arch)
     except (
         ImpactError,
@@ -172,8 +183,7 @@ def changed_paths_since(workspace_root: Path, since_ref: str) -> list[Path]:
         command,
         cwd=workspace_root,
         check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        capture_output=True,
     )
     return [
         _normalize_relative_path(Path(raw.decode("utf-8")))
@@ -202,8 +212,7 @@ def load_metadata_by_arch(workspace_root: Path) -> dict[str, dict]:
             cwd=workspace_root,
             check=True,
             text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            capture_output=True,
         )
         metadata_by_arch[arch] = json.loads(result.stdout)
     return metadata_by_arch
@@ -229,17 +238,29 @@ def analyze_changed_paths(
         )
 
     try:
-        package_index = _package_path_index(workspace_root, metadata_by_arch)
         changed_package_ids: set[str] = set()
         changed_package_names: set[str] = set()
-        direct_targets: set[str] = set()
+        input_selections: set[str] = set()
+        test_suite_paths: set[str] = set()
+        package_paths: list[Path] = []
         unknown_paths: list[Path] = []
 
         for path in relevant_paths:
-            known_targets = _known_path_targets(path)
-            if known_targets:
-                direct_targets.update(known_targets)
+            if _test_suite_os(path) is not None:
+                test_suite_paths.add(path.as_posix())
                 continue
+            known_inputs = _known_input_selections(path)
+            if known_inputs:
+                input_selections.update(known_inputs)
+                continue
+            package_paths.append(path)
+
+        package_index = (
+            _package_path_index(workspace_root, metadata_by_arch)
+            if package_paths
+            else []
+        )
+        for path in package_paths:
             package = _package_for_path(path, package_index)
             if package is not None:
                 changed_package_ids.add(package.package_id)
@@ -256,9 +277,14 @@ def analyze_changed_paths(
                 ignored_apps=ignored_apps,
             )
 
-        targets = set(direct_targets)
+        targets = {
+            target
+            for selection in input_selections
+            for target in _input_selection_targets(selection)
+        }
         affected_names = set(changed_package_names)
-        for arch in ARCH_TARGETS:
+        affected_oses: set[str] = set()
+        for arch in ARCH_TARGETS if changed_package_ids else ():
             metadata = metadata_by_arch.get(arch)
             if metadata is None:
                 raise ImpactError(f"missing cargo metadata for {arch}")
@@ -273,9 +299,12 @@ def analyze_changed_paths(
             root_ids = _os_root_package_ids(metadata)
             for os_name, root_id in root_ids.items():
                 if root_id in affected_ids:
-                    targets.add(f"{os_name}:{arch}")
+                    affected_oses.add(os_name)
             if _affected_axtest_runs_in_arceos_ci(metadata, affected_ids, arch):
                 targets.add(f"arceos:{arch}")
+
+        for os_name in affected_oses:
+            targets.update(f"{os_name}:{arch}" for arch in ARCH_TARGETS)
 
         return CiImpact(
             full=False,
@@ -285,6 +314,13 @@ def analyze_changed_paths(
             ignored_apps=tuple(sorted(ignored_apps)),
             changed_packages=tuple(sorted(changed_package_names)),
             affected_packages=tuple(sorted(affected_names)),
+            affected_oses=tuple(
+                os_name for os_name in OS_ROOT_PACKAGES if os_name in affected_oses
+            ),
+            input_selections=tuple(sorted(input_selections)),
+            test_suite_paths=tuple(sorted(test_suite_paths)),
+            exclusive=bool(test_suite_paths)
+            and len(test_suite_paths) == len(relevant_paths),
             targets=tuple(sorted(targets, key=_target_sort_key)),
         )
     except (KeyError, TypeError, ValueError) as error:
@@ -312,6 +348,10 @@ def render_summary(
         f"- Ignored apps: {_render_values(impact.ignored_apps)}",
         f"- Changed packages: {_render_values(impact.changed_packages)}",
         f"- Affected packages: {_render_values(impact.affected_packages)}",
+        f"- Affected OSes: {_render_values(impact.affected_oses)}",
+        f"- Precise inputs: {_render_values(impact.input_selections)}",
+        f"- Test suites: {_render_values(impact.test_suite_paths)}",
+        f"- Exclusive selection: `{str(impact.exclusive).lower()}`",
         f"- OS/arch targets: {_render_values(impact.targets)}",
         f"- Selected checks ({len(selected_check_ids)}): {_render_values(selected_check_ids)}",
         f"- Skipped checks ({len(skipped_check_ids)}): {_render_values(skipped_check_ids)}",
@@ -331,7 +371,9 @@ def _partition_ignored(
         rendered = path.as_posix()
         if path.suffix.casefold() == ".md":
             ignored_markdown.add(rendered)
-        elif _is_prefix(path, IGNORED_APP_PREFIX):
+        elif _is_prefix(path, IGNORED_APP_PREFIX) and not any(
+            _is_prefix(path, prefix) for prefix, _ in CI_OWNED_APP_INPUTS
+        ):
             ignored_apps.add(rendered)
         else:
             relevant.append(path)
@@ -339,7 +381,9 @@ def _partition_ignored(
 
 
 def _requires_full_matrix(path: Path) -> bool:
-    return path in FULL_PATHS or any(_is_prefix(path, prefix) for prefix in FULL_PREFIXES)
+    return path in FULL_PATHS or any(
+        _is_prefix(path, prefix) for prefix in FULL_PREFIXES
+    )
 
 
 def _pre_metadata_full_reason(
@@ -371,9 +415,7 @@ def _package_path_index(
             raise ImpactError(
                 f"workspace package `{package['name']}` is outside the workspace"
             ) from error
-        entries.append(
-            PackagePathEntry(package["id"], package["name"], relative_dir)
-        )
+        entries.append(PackagePathEntry(package["id"], package["name"], relative_dir))
     entries.sort(
         key=lambda entry: (-len(entry.relative_dir.parts), entry.name, entry.package_id)
     )
@@ -522,7 +564,9 @@ def _package_axtest_arches(package: dict) -> set[str]:
         raise ImpactError(f"invalid docs.rs targets for `{package['name']}`")
     target_to_arch = {target: arch for arch, target in ARCH_TARGETS.items()}
     supported_arches = {
-        target_to_arch[target] for target in declared_targets if target in target_to_arch
+        target_to_arch[target]
+        for target in declared_targets
+        if target in target_to_arch
     }
     if not supported_arches:
         raise ImpactError(
@@ -531,15 +575,47 @@ def _package_axtest_arches(package: dict) -> set[str]:
     return supported_arches
 
 
-def _known_path_targets(path: Path) -> set[str]:
-    for prefix, os_name in KNOWN_OS_PATHS:
+def _is_known_input_path(path: Path) -> bool:
+    return _test_suite_os(path) is not None or bool(_known_input_selections(path))
+
+
+def _test_suite_os(path: Path) -> str | None:
+    for prefix, os_name in TEST_SUITE_PATHS:
+        if _is_prefix(path, prefix):
+            return os_name
+    return None
+
+
+def _known_input_selections(path: Path) -> set[str]:
+    for prefix, selection in CI_OWNED_APP_INPUTS:
+        if _is_prefix(path, prefix):
+            return {selection}
+
+    for prefix, os_name in KNOWN_OS_CONFIG_PATHS:
         if not _is_prefix(path, prefix):
             continue
         arches = _arch_hints(path)
-        if not arches:
-            arches = set(ARCH_TARGETS)
-        return {f"{os_name}:{arch}" for arch in arches}
+        relative = path.relative_to(prefix)
+        parts = tuple(part.casefold() for part in relative.parts)
+        if "qemu" in parts and arches:
+            return {f"{os_name}:qemu:{arch}" for arch in arches}
+        if "board" in parts and path.suffix == ".toml":
+            return {f"{os_name}:board:{path.stem.casefold()}"}
+        return {f"{os_name}:all"}
     return set()
+
+
+def _input_selection_targets(selection: str) -> set[str]:
+    os_name, _, detail = selection.partition(":")
+    if os_name not in OS_ROOT_PACKAGES:
+        return set()
+    _, _, value = detail.partition(":")
+    if value in ARCH_TARGETS:
+        return {f"{os_name}:{value}"}
+    arches = _arch_hints(Path(value))
+    if arches:
+        return {f"{os_name}:{arch}" for arch in arches}
+    return {f"{os_name}:{arch}" for arch in ARCH_TARGETS}
 
 
 def _arch_hints(path: Path) -> set[str]:

--- a/scripts/test/ci_plan.py
+++ b/scripts/test/ci_plan.py
@@ -5,17 +5,32 @@ import json
 import os
 import re
 import sys
-from dataclasses import dataclass
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 
 if sys.version_info < (3, 11):
     raise SystemExit("ci_plan.py requires Python 3.11 or newer")
 
 import tomllib
-
-from ci_impact import CiImpact, analyze_pull_request, render_summary
-
+from ci_impact import ARCH_TARGETS, CiImpact, analyze_pull_request, render_summary
+from ci_runner_profiles import (
+    GLOBAL_DEFAULT_RUNNER,
+    SUPPORTED_ENVIRONMENTS,
+    RunnerProfileError,
+    load_runner_profiles,
+    validate_runner_profile,
+)
+from ci_suite import (
+    SUITE_FIELDS,
+    SUPPORTED_SUITE_KINDS,
+    SuiteRouteError,
+    SuiteSelection,
+    check_matches_input,
+    resolve_suite_selections,
+    validate_suite_catalog,
+)
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 CHECKS_ROOT = WORKSPACE_ROOT / ".github" / "ci" / "checks"
@@ -27,9 +42,9 @@ MAIN_MANIFESTS = (
     CHECKS_ROOT / "starry.toml",
 )
 STARRY_APPS_MANIFEST = CHECKS_ROOT / "starry-apps.toml"
+RUNNER_PROFILES_MANIFEST = CHECKS_ROOT.parent / "runner-profiles.toml"
 
 SUPPORTED_PHASES = {"static", "test", "starry_apps"}
-SUPPORTED_ENVIRONMENTS = {"host", "base", "axvisor-lvz"}
 SUPPORTED_PREFLIGHTS = {"none", "qemu-user", "full"}
 SUPPORTED_IMPACT_TARGETS = {
     f"{os_name}:{arch}"
@@ -41,20 +56,21 @@ CHECK_ID_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
 REDUNDANT_NAME_PREFIX_PATTERN = re.compile(
     r"^(?:check|run|scheduled|tests?)\b", re.IGNORECASE
 )
-TOP_LEVEL_FIELDS = {"schema_version", "phase", "group", "check"}
+TOP_LEVEL_FIELDS = {
+    "schema_version",
+    "phase",
+    "group",
+    "default_runner",
+    "check",
+}
 CHECK_FIELDS = {
     "id",
     "name",
-    "runs_on",
-    "environment",
+    "runner",
     "command",
-    "self_hosted_owner",
-    "fallback_environment",
-    "required_owner",
     "required_base_branch",
     "fetch_depth",
     "timeout_minutes",
-    "require_kvm",
     "cache_key",
     "apk_region",
     "upload_xtask_bin_artifact",
@@ -66,8 +82,9 @@ CHECK_FIELDS = {
     "impact_targets",
     "impact_packages",
     "pull_request_command",
+    "suite",
 }
-REQUIRED_CHECK_FIELDS = {"id", "name", "runs_on", "environment", "command"}
+REQUIRED_CHECK_FIELDS = {"id", "name", "command"}
 BOOLEAN_CHECK_FIELDS = {
     "require_kvm",
     "upload_xtask_bin_artifact",
@@ -92,14 +109,26 @@ class PlanContext:
 def load_catalog(manifests: Iterable[Path]) -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     seen_ids: set[str] = set()
+    runner_profiles = _load_runner_profiles(RUNNER_PROFILES_MANIFEST)
 
     for manifest in manifests:
         document = _load_manifest(manifest)
         phase = document["phase"]
         group = document["group"]
+        default_runner = document.get("default_runner", GLOBAL_DEFAULT_RUNNER)
+        if default_runner not in runner_profiles:
+            raise PlanError(
+                f"{manifest} references unknown default_runner '{default_runner}'"
+            )
         for index, raw_check in enumerate(document["check"], start=1):
             location = f"{manifest}:{index}"
-            check = _validate_check(raw_check, location, group)
+            check = _validate_check(
+                raw_check,
+                location,
+                group,
+                runner_profiles,
+                default_runner,
+            )
             check_id = check["id"]
             if check_id in seen_ids:
                 raise PlanError(f"duplicate check id '{check_id}' at {location}")
@@ -111,18 +140,36 @@ def load_catalog(manifests: Iterable[Path]) -> list[dict[str, Any]]:
 
     _validate_artifact_contract(checks)
     _validate_impact_contract(checks)
+    try:
+        validate_suite_catalog(WORKSPACE_ROOT, checks)
+    except SuiteRouteError as error:
+        raise PlanError(str(error)) from error
     return checks
 
 
-def build_main_plan(context: PlanContext) -> dict[str, dict[str, list[dict[str, Any]]]]:
+def build_main_plan(context: PlanContext) -> dict[str, Any]:
     checks = load_catalog(MAIN_MANIFESTS)
-    static_rows = _plan_phase(checks, "static", context)
-    test_rows = _plan_phase(checks, "test", context)
-    if not static_rows or not test_rows:
-        raise PlanError("main CI must resolve to non-empty static and test matrices")
+    context = _resolve_input_fallbacks(checks, context)
+    suite_only = bool(
+        context.event_name == "pull_request"
+        and context.impact is not None
+        and context.impact.exclusive
+        and context.impact.test_suite_paths
+    )
+    static_rows = [] if suite_only else _plan_phase(checks, "static", context)
+    test_rows = (
+        _plan_suite_rows(checks, context)
+        if suite_only
+        else _plan_phase(checks, "test", context) + _plan_suite_rows(checks, context)
+    )
+    if not test_rows:
+        raise PlanError("main CI must resolve to a non-empty test matrix")
+    if not suite_only and not static_rows:
+        raise PlanError("main CI must resolve to a non-empty static matrix")
     return {
         "static_matrix": {"include": static_rows},
         "test_matrix": {"include": test_rows},
+        "static_required": bool(static_rows),
     }
 
 
@@ -154,8 +201,8 @@ def _load_manifest(manifest: Path) -> dict[str, Any]:
         raise PlanError(
             f"{manifest} has unknown top-level fields: {sorted(unknown_fields)}"
         )
-    if document.get("schema_version") != 2:
-        raise PlanError(f"{manifest} must declare schema_version = 2")
+    if document.get("schema_version") != 3:
+        raise PlanError(f"{manifest} must declare schema_version = 3")
     if document.get("phase") not in SUPPORTED_PHASES:
         raise PlanError(f"{manifest} has an unsupported phase")
     if not isinstance(document.get("group"), str) or not document["group"].strip():
@@ -166,7 +213,11 @@ def _load_manifest(manifest: Path) -> dict[str, Any]:
 
 
 def _validate_check(
-    raw_check: Any, location: str, group: str = ""
+    raw_check: Any,
+    location: str,
+    group: str = "",
+    runner_profiles: dict[str, dict[str, Any]] | None = None,
+    default_runner: str = GLOBAL_DEFAULT_RUNNER,
 ) -> dict[str, Any]:
     if not isinstance(raw_check, dict):
         raise PlanError(f"{location} check entry must be a table")
@@ -177,7 +228,16 @@ def _validate_check(
     if missing_fields:
         raise PlanError(f"{location} is missing fields: {sorted(missing_fields)}")
 
-    check = dict(raw_check)
+    profiles = runner_profiles or _load_runner_profiles(RUNNER_PROFILES_MANIFEST)
+    runner = raw_check.get("runner", default_runner)
+    if not isinstance(runner, str) or not runner:
+        raise PlanError(f"{location} field 'runner' must be a non-empty string")
+    if runner not in profiles:
+        raise PlanError(f"{location} references unknown runner profile '{runner}'")
+
+    check = {key: value for key, value in raw_check.items() if key != "runner"}
+    check.update(profiles[runner])
+    check["runner"] = runner
     for field in ("id", "name", "environment", "command"):
         if not isinstance(check[field], str) or not check[field].strip():
             raise PlanError(f"{location} field '{field}' must be a non-empty string")
@@ -240,9 +300,7 @@ def _validate_check(
     if boolean_input is not None and (
         not isinstance(boolean_input, str) or not boolean_input
     ):
-        raise PlanError(
-            f"{location} enable_boolean_input must be a non-empty string"
-        )
+        raise PlanError(f"{location} enable_boolean_input must be a non-empty string")
 
     cache_key = check.get("cache_key", "")
     if not isinstance(cache_key, str):
@@ -284,11 +342,58 @@ def _validate_check(
     if pull_request_command is not None and (
         not isinstance(pull_request_command, str) or not pull_request_command.strip()
     ):
-        raise PlanError(
-            f"{location} pull_request_command must be a non-empty string"
-        )
+        raise PlanError(f"{location} pull_request_command must be a non-empty string")
+
+    suite = check.get("suite")
+    if suite is not None:
+        _validate_suite_registrations(suite, location)
 
     return check
+
+
+def _load_runner_profiles(manifest: Path) -> dict[str, dict[str, Any]]:
+    try:
+        return load_runner_profiles(manifest)
+    except RunnerProfileError as error:
+        raise PlanError(str(error)) from error
+
+
+def _validate_runner_profile(profile: dict[str, Any], location: str) -> None:
+    try:
+        validate_runner_profile(profile, location)
+    except RunnerProfileError as error:
+        raise PlanError(str(error)) from error
+
+
+def _validate_suite_registrations(suite: Any, location: str) -> None:
+    if not isinstance(suite, list) or not suite:
+        raise PlanError(f"{location} suite must be a non-empty table array")
+    for index, registration in enumerate(suite, start=1):
+        suite_location = f"{location} suite {index}"
+        if not isinstance(registration, dict):
+            raise PlanError(f"{suite_location} must be a table")
+        unknown_fields = set(registration) - SUITE_FIELDS
+        if unknown_fields:
+            raise PlanError(
+                f"{suite_location} has unknown fields: {sorted(unknown_fields)}"
+            )
+        kind = registration.get("kind")
+        if kind not in SUPPORTED_SUITE_KINDS:
+            raise PlanError(f"{suite_location} has an unsupported kind")
+        is_qemu = kind.endswith("-qemu")
+        arch = registration.get("arch")
+        board = registration.get("board")
+        if is_qemu and arch not in ARCH_TARGETS:
+            raise PlanError(f"{suite_location} must declare a supported arch")
+        if not is_qemu and (not isinstance(board, str) or not board):
+            raise PlanError(f"{suite_location} must declare a non-empty board")
+        if is_qemu and board is not None:
+            raise PlanError(f"{suite_location} qemu registration cannot declare board")
+        if not is_qemu and arch is not None:
+            raise PlanError(f"{suite_location} board registration cannot declare arch")
+        cases = registration.get("cases")
+        if cases is not None:
+            _validate_string_array(cases, "cases", suite_location)
 
 
 def _validate_string_array(value: Any, field: str, location: str) -> None:
@@ -303,9 +408,7 @@ def _validate_string_array(value: Any, field: str, location: str) -> None:
 
 def _validate_display_name(name: str, group: str, location: str) -> None:
     if REDUNDANT_NAME_PREFIX_PATTERN.search(name):
-        raise PlanError(
-            f"{location} name must not start with Test/Run/Check/Scheduled"
-        )
+        raise PlanError(f"{location} name must not start with Test/Run/Check/Scheduled")
     if "self-hosted" in name.casefold():
         raise PlanError(f"{location} name must not expose the self-hosted runner")
     if group:
@@ -315,6 +418,16 @@ def _validate_display_name(name: str, group: str, location: str) -> None:
         )
         if group_pattern.search(name):
             raise PlanError(f"{location} name must not repeat group '{group}'")
+    for arch in ARCH_TARGETS:
+        for platform in ("QEMU", "VMX", "SVM", "UEFI"):
+            if re.search(
+                rf"\b{re.escape(arch)}\s+{platform}\b",
+                name,
+                flags=re.IGNORECASE,
+            ):
+                raise PlanError(
+                    f"{location} name must place platform before architecture"
+                )
 
 
 def _validate_artifact_contract(checks: list[dict[str, Any]]) -> None:
@@ -326,7 +439,9 @@ def _validate_artifact_contract(checks: list[dict[str, Any]]) -> None:
         check for check in main_checks if check.get("upload_xtask_bin_artifact", False)
     ]
     if len(producers) != 1 or producers[0]["phase"] != "static":
-        raise PlanError("main CI must define exactly one static xtask artifact producer")
+        raise PlanError(
+            "main CI must define exactly one static xtask artifact producer"
+        )
 
     producer_name = producers[0].get("xtask_bin_artifact_name", "tg-xtask-bin")
     for check in main_checks:
@@ -361,6 +476,94 @@ def _plan_phase(
     ]
 
 
+def _resolve_input_fallbacks(
+    checks: list[dict[str, Any]], context: PlanContext
+) -> PlanContext:
+    impact = context.impact
+    if impact is None or impact.full or not impact.input_selections:
+        return context
+
+    resolved = []
+    fallback_inputs = []
+    for selection in impact.input_selections:
+        if any(check_matches_input(check, selection) for check in checks):
+            resolved.append(selection)
+            continue
+        os_name = selection.partition(":")[0]
+        fallback = f"{os_name}:all"
+        resolved.append(fallback)
+        fallback_inputs.append(selection)
+    if not fallback_inputs:
+        return context
+
+    reason = (
+        f"{impact.reason}; unmatched precise inputs fell back to OS-wide: "
+        f"{', '.join(fallback_inputs)}"
+    )
+    resolved_impact = replace(
+        impact,
+        reason=reason,
+        input_selections=tuple(sorted(set(resolved))),
+    )
+    return replace(context, impact=resolved_impact)
+
+
+def _plan_suite_rows(
+    checks: list[dict[str, Any]], context: PlanContext
+) -> list[dict[str, Any]]:
+    impact = context.impact
+    if (
+        context.event_name != "pull_request"
+        or impact is None
+        or impact.full
+        or not impact.test_suite_paths
+    ):
+        return []
+
+    suite_paths = tuple(
+        path
+        for path in impact.test_suite_paths
+        if _suite_path_os(path) not in impact.affected_oses
+    )
+    if not suite_paths:
+        return []
+    try:
+        selections = resolve_suite_selections(WORKSPACE_ROOT, checks, suite_paths)
+    except SuiteRouteError as error:
+        raise PlanError(str(error)) from error
+
+    checks_by_id = {check["id"]: check for check in checks}
+    rows = []
+    for selection in selections:
+        template = checks_by_id[selection.template_id]
+        if not _is_enabled(template, context):
+            raise PlanError(
+                f"test suite path `{selection.source_path}` requires unavailable "
+                f"check '{selection.template_id}'"
+            )
+        rows.append(_normalize_suite_selection(template, selection, context))
+    return rows
+
+
+def _normalize_suite_selection(
+    template: dict[str, Any],
+    selection: SuiteSelection,
+    context: PlanContext,
+) -> dict[str, Any]:
+    row = _normalize_check(template, context)
+    row.update(
+        {
+            "id": selection.row_id,
+            "name": f"{template['group']} / {selection.leaf_name}",
+            "command": selection.command,
+            "template_id": selection.template_id,
+            "upload_xtask_bin_artifact": False,
+            "download_xtask_bin_artifact": False,
+        }
+    )
+    return row
+
+
 def _is_enabled(check: dict[str, Any], context: PlanContext) -> bool:
     required_owner = check.get("required_owner")
     if required_owner and context.repository_owner != required_owner:
@@ -393,15 +596,38 @@ def _matches_impact(check: dict[str, Any], context: PlanContext) -> bool:
     if not impact_targets and not impact_packages:
         return True
 
+    if any(
+        target.partition(":")[0] in impact.affected_oses for target in impact_targets
+    ):
+        return True
+    input_matches = any(
+        check_matches_input(check, selection) for selection in impact.input_selections
+    )
+    if input_matches:
+        return True
+    if impact.input_selections:
+        return bool(impact_packages.intersection(impact.affected_packages))
+
     return bool(
         impact_targets.intersection(impact.targets)
         or impact_packages.intersection(impact.affected_packages)
     )
 
 
-def _normalize_check(
-    check: dict[str, Any], context: PlanContext
-) -> dict[str, Any]:
+def _suite_path_os(path: str) -> str | None:
+    normalized = Path(path)
+    prefixes = {
+        Path("test-suit/arceos"): "arceos",
+        Path("test-suit/starryos"): "starry",
+        Path("test-suit/axvisor"): "axvisor",
+    }
+    for prefix, os_name in prefixes.items():
+        if normalized == prefix or prefix in normalized.parents:
+            return os_name
+    return None
+
+
+def _normalize_check(check: dict[str, Any], context: PlanContext) -> dict[str, Any]:
     runs_on = list(check["runs_on"])
     environment = check["environment"]
     fallback = bool(
@@ -451,13 +677,9 @@ def _normalize_check(
         "fetch_depth": fetch_depth,
         "timeout_minutes": check.get("timeout_minutes", 360),
         "require_kvm": check.get("require_kvm", False),
-        "upload_xtask_bin_artifact": check.get(
-            "upload_xtask_bin_artifact", False
-        ),
+        "upload_xtask_bin_artifact": check.get("upload_xtask_bin_artifact", False),
         "download_xtask_bin_artifact": download_xtask,
-        "xtask_bin_artifact_name": check.get(
-            "xtask_bin_artifact_name", "tg-xtask-bin"
-        ),
+        "xtask_bin_artifact_name": check.get("xtask_bin_artifact_name", "tg-xtask-bin"),
         "source": check["source"],
     }
 
@@ -486,9 +708,7 @@ def _parse_args() -> argparse.Namespace:
         "--output-file",
         type=Path,
         default=(
-            Path(os.environ["GITHUB_OUTPUT"])
-            if "GITHUB_OUTPUT" in os.environ
-            else None
+            Path(os.environ["GITHUB_OUTPUT"]) if "GITHUB_OUTPUT" in os.environ else None
         ),
     )
     parser.add_argument(
@@ -518,6 +738,11 @@ def main() -> int:
     )
     try:
         if args.mode == "main":
+            context = _resolve_input_fallbacks(
+                load_catalog(MAIN_MANIFESTS),
+                context,
+            )
+            impact = context.impact
             outputs = build_main_plan(context)
         else:
             outputs = build_starry_apps_plan(context)
@@ -530,20 +755,32 @@ def main() -> int:
     else:
         print(json.dumps(outputs, indent=2))
 
-    for name, matrix in outputs.items():
-        print(f"{name}: {len(matrix['include'])} checks", file=sys.stderr)
+    for name, value in outputs.items():
+        if isinstance(value, dict) and isinstance(value.get("include"), list):
+            print(f"{name}: {len(value['include'])} checks", file=sys.stderr)
     if impact is not None:
         selected_ids = [
             row["id"]
-            for matrix in outputs.values()
-            for row in matrix["include"]
+            for value in outputs.values()
+            if isinstance(value, dict) and isinstance(value.get("include"), list)
+            for row in value["include"]
         ]
+        selected_template_ids = {
+            row.get("template_id", row["id"])
+            for value in outputs.values()
+            if isinstance(value, dict) and isinstance(value.get("include"), list)
+            for row in value["include"]
+        }
         eligible_ids = [
             check["id"]
             for check in load_catalog(MAIN_MANIFESTS)
             if _is_enabled(check, context)
         ]
-        skipped_ids = [check_id for check_id in eligible_ids if check_id not in selected_ids]
+        skipped_ids = [
+            check_id
+            for check_id in eligible_ids
+            if check_id not in selected_template_ids
+        ]
         summary = render_summary(impact, selected_ids, skipped_ids)
         print(summary, file=sys.stderr)
         if args.summary_file is not None:

--- a/scripts/test/ci_runner_profiles.py
+++ b/scripts/test/ci_runner_profiles.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+import re
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+GLOBAL_DEFAULT_RUNNER = "ubuntu-base"
+SUPPORTED_ENVIRONMENTS = {"host", "base", "axvisor-lvz"}
+PROFILE_ID_PATTERN = re.compile(r"[a-z0-9]+(?:-[a-z0-9]+)*")
+TOP_LEVEL_FIELDS = {"schema_version", "profile"}
+PROFILE_FIELDS = {
+    "runs_on",
+    "environment",
+    "self_hosted_owner",
+    "fallback_environment",
+    "required_owner",
+    "require_kvm",
+}
+REQUIRED_PROFILE_FIELDS = {"runs_on", "environment"}
+
+
+class RunnerProfileError(ValueError):
+    """Raised when the shared runner profile manifest is invalid."""
+
+
+def load_runner_profiles(manifest: Path) -> dict[str, dict[str, Any]]:
+    if not manifest.is_file():
+        raise RunnerProfileError(f"missing CI runner profile manifest: {manifest}")
+    with manifest.open("rb") as source:
+        document = tomllib.load(source)
+
+    unknown_fields = set(document) - TOP_LEVEL_FIELDS
+    if unknown_fields:
+        raise RunnerProfileError(
+            f"{manifest} has unknown top-level fields: {sorted(unknown_fields)}"
+        )
+    if document.get("schema_version") != 3:
+        raise RunnerProfileError(f"{manifest} must declare schema_version = 3")
+    profiles = document.get("profile")
+    if not isinstance(profiles, dict) or not profiles:
+        raise RunnerProfileError(f"{manifest} must define at least one runner profile")
+
+    validated = {}
+    for name, raw_profile in profiles.items():
+        location = f"{manifest} profile '{name}'"
+        if PROFILE_ID_PATTERN.fullmatch(name) is None:
+            raise RunnerProfileError(f"{location} name must use lowercase kebab-case")
+        if not isinstance(raw_profile, dict):
+            raise RunnerProfileError(f"{location} must be a table")
+        unknown_profile_fields = set(raw_profile) - PROFILE_FIELDS
+        if unknown_profile_fields:
+            raise RunnerProfileError(
+                f"{location} has unknown fields: {sorted(unknown_profile_fields)}"
+            )
+        missing_profile_fields = REQUIRED_PROFILE_FIELDS - set(raw_profile)
+        if missing_profile_fields:
+            raise RunnerProfileError(
+                f"{location} is missing fields: {sorted(missing_profile_fields)}"
+            )
+        profile = dict(raw_profile)
+        validate_runner_profile(profile, location)
+        validated[name] = profile
+
+    if GLOBAL_DEFAULT_RUNNER not in validated:
+        raise RunnerProfileError(
+            f"{manifest} must define the global runner '{GLOBAL_DEFAULT_RUNNER}'"
+        )
+    return validated
+
+
+def validate_runner_profile(profile: dict[str, Any], location: str) -> None:
+    runs_on = profile["runs_on"]
+    if (
+        not isinstance(runs_on, list)
+        or not runs_on
+        or any(not isinstance(label, str) or not label for label in runs_on)
+    ):
+        raise RunnerProfileError(f"{location} runs_on must be a non-empty string array")
+    environment = profile["environment"]
+    if not isinstance(environment, str) or environment not in SUPPORTED_ENVIRONMENTS:
+        raise RunnerProfileError(f"{location} has an unsupported environment")
+    for field in ("self_hosted_owner", "required_owner"):
+        value = profile.get(field)
+        if value is not None and (not isinstance(value, str) or not value):
+            raise RunnerProfileError(
+                f"{location} field '{field}' must be a non-empty string"
+            )
+    if profile.get("self_hosted_owner") and "self-hosted" not in runs_on:
+        raise RunnerProfileError(
+            f"{location} self_hosted_owner requires a self-hosted runner"
+        )
+    fallback = profile.get("fallback_environment")
+    if fallback is not None:
+        if not profile.get("self_hosted_owner"):
+            raise RunnerProfileError(
+                f"{location} fallback_environment requires self_hosted_owner"
+            )
+        if not isinstance(fallback, str) or fallback not in SUPPORTED_ENVIRONMENTS - {
+            "host"
+        }:
+            raise RunnerProfileError(
+                f"{location} has an unsupported fallback_environment"
+            )
+    require_kvm = profile.get("require_kvm")
+    if require_kvm is not None and not isinstance(require_kvm, bool):
+        raise RunnerProfileError(f"{location} field 'require_kvm' must be boolean")

--- a/scripts/test/ci_suite.py
+++ b/scripts/test/ci_suite.py
@@ -1,0 +1,638 @@
+#!/usr/bin/env python3
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ci_impact import ARCH_TARGETS
+
+SUPPORTED_SUITE_KINDS = {
+    "arceos-qemu",
+    "starry-qemu",
+    "starry-board",
+    "axvisor-qemu",
+    "axvisor-board",
+}
+SUITE_FIELDS = {"kind", "arch", "board", "cases"}
+SUITE_ROOTS = {
+    "arceos": Path("test-suit/arceos"),
+    "starry": Path("test-suit/starryos"),
+    "axvisor": Path("test-suit/axvisor"),
+}
+
+
+class SuiteRouteError(ValueError):
+    """Raised when a changed test suite cannot map to one registered CI row."""
+
+
+@dataclass(frozen=True)
+class SuiteSelection:
+    template_id: str
+    row_id: str
+    leaf_name: str
+    command: str
+    source_path: str
+
+
+@dataclass(frozen=True)
+class _RuntimeCase:
+    kind: str
+    arch: str | None
+    board: str | None
+    case: str
+    case_dir: Path
+    wrapper_dir: Path
+    runtime_config: Path
+    build_config: Path
+
+
+def resolve_suite_selections(
+    workspace_root: Path,
+    checks: Sequence[dict[str, Any]],
+    changed_paths: Iterable[str],
+) -> list[SuiteSelection]:
+    registrations = _suite_registrations(checks)
+    selections: dict[tuple[str, str, str], SuiteSelection] = {}
+    check_order = {check["id"]: index for index, check in enumerate(checks)}
+
+    for rendered_path in sorted(set(changed_paths)):
+        path = Path(rendered_path)
+        path_selections = _selections_for_path(
+            workspace_root,
+            registrations,
+            path,
+        )
+        if not path_selections:
+            raise SuiteRouteError(
+                f"test suite path `{rendered_path}` is not registered in CI"
+            )
+        for selection in path_selections:
+            key = (selection.template_id, selection.leaf_name, selection.command)
+            selections.setdefault(key, selection)
+
+    return sorted(
+        selections.values(),
+        key=lambda selection: (
+            check_order[selection.template_id],
+            selection.leaf_name,
+            selection.command,
+        ),
+    )
+
+
+def validate_suite_catalog(
+    workspace_root: Path,
+    checks: Sequence[dict[str, Any]],
+) -> None:
+    registrations = _suite_registrations(checks)
+    discovered = {
+        "starry": _discover_runtime_cases(
+            workspace_root / SUITE_ROOTS["starry"],
+            "starry",
+        ),
+        "axvisor": _discover_runtime_cases(
+            workspace_root / SUITE_ROOTS["axvisor"],
+            "axvisor",
+        ),
+    }
+    for check, registration in registrations:
+        kind = registration["kind"]
+        if kind == "arceos-qemu":
+            arch = registration["arch"]
+            runtime = (
+                workspace_root / SUITE_ROOTS["arceos"] / "rust" / f"qemu-{arch}.toml"
+            )
+            build = (
+                workspace_root
+                / SUITE_ROOTS["arceos"]
+                / "rust"
+                / f"build-{ARCH_TARGETS[arch]}.toml"
+            )
+            if runtime.is_file() and build.is_file():
+                continue
+            raise SuiteRouteError(
+                f"check '{check['id']}' registers missing ArceOS QEMU capability {arch}"
+            )
+
+        candidates = [
+            runtime_case
+            for runtime_case in discovered[_kind_os(kind)]
+            if runtime_case.kind == kind
+            and (
+                registration.get("arch") is None
+                or runtime_case.arch == registration["arch"]
+            )
+            and (
+                registration.get("board") is None
+                or runtime_case.board == registration["board"]
+            )
+        ]
+        registered_cases = registration.get("cases")
+        if registered_cases:
+            missing = set(registered_cases) - {
+                runtime_case.case for runtime_case in candidates
+            }
+            if missing:
+                raise SuiteRouteError(
+                    f"check '{check['id']}' registers missing suite cases: {sorted(missing)}"
+                )
+        elif not candidates:
+            raise SuiteRouteError(
+                f"check '{check['id']}' registers a suite capability with no runtime cases"
+            )
+
+    for runtime_cases in discovered.values():
+        for runtime_case in runtime_cases:
+            _registered_template(
+                registrations,
+                kind=runtime_case.kind,
+                arch=runtime_case.arch,
+                board=runtime_case.board,
+                case=runtime_case.case,
+            )
+
+
+def check_matches_input(check: dict[str, Any], selection: str) -> bool:
+    os_name, separator, remainder = selection.partition(":")
+    if not separator:
+        return False
+    registrations = check.get("suite", ())
+    if remainder == "all":
+        return any(
+            _kind_os(registration["kind"]) == os_name for registration in registrations
+        )
+
+    platform, separator, value = remainder.partition(":")
+    if not separator:
+        return False
+    for registration in registrations:
+        kind = registration["kind"]
+        if _kind_os(kind) != os_name:
+            continue
+        if (
+            platform == "qemu"
+            and kind.endswith("-qemu")
+            and registration.get("arch") == value
+        ):
+            return True
+        if platform == "board" and kind.endswith("-board"):
+            board = registration.get("board", "")
+            if (
+                board == value
+                or board.startswith(f"{value}-")
+                or value.startswith(f"{board}-")
+            ):
+                return True
+    return False
+
+
+def _selections_for_path(
+    workspace_root: Path,
+    registrations: Sequence[tuple[dict[str, Any], dict[str, Any]]],
+    path: Path,
+) -> list[SuiteSelection]:
+    if _is_prefix(path, SUITE_ROOTS["arceos"]):
+        return _arceos_selections(registrations, path)
+    if _is_prefix(path, SUITE_ROOTS["starry"]):
+        return _discovered_selections(
+            workspace_root,
+            registrations,
+            path,
+            "starry",
+        )
+    if _is_prefix(path, SUITE_ROOTS["axvisor"]):
+        return _discovered_selections(
+            workspace_root,
+            registrations,
+            path,
+            "axvisor",
+        )
+    return []
+
+
+def _arceos_selections(
+    registrations: Sequence[tuple[dict[str, Any], dict[str, Any]]],
+    path: Path,
+) -> list[SuiteSelection]:
+    root = SUITE_ROOTS["arceos"]
+    relative = path.relative_to(root)
+    if not relative.parts:
+        return _arceos_all_selections(registrations, path)
+
+    group = relative.parts[0]
+    if group not in {"rust", "c", "loongarch"}:
+        return []
+
+    case = None
+    display_case = group
+    if group == "rust" and len(relative.parts) >= 3 and relative.parts[1] == "cases":
+        case = relative.parts[2]
+        display_case = f"rust/{case}"
+    elif group == "loongarch" and len(relative.parts) >= 2:
+        case = relative.parts[1]
+        display_case = f"loongarch/{case}"
+
+    arches = _arches_for_path(path)
+    if not arches and group == "loongarch":
+        arches = {"loongarch64"}
+    if not arches:
+        arches = {
+            registration["arch"]
+            for _, registration in registrations
+            if registration["kind"] == "arceos-qemu"
+        }
+
+    selections = []
+    for arch in sorted(arches, key=_arch_sort_key):
+        template = _registered_template(
+            registrations,
+            kind="arceos-qemu",
+            arch=arch,
+            case=case,
+        )
+        if template is None:
+            continue
+        command = f"cargo xtask arceos test qemu --arch {arch} --test-group {group}"
+        if case is not None:
+            command += f" --test-case {case}"
+        selections.append(
+            _selection(
+                template,
+                f"QEMU {arch}",
+                display_case,
+                command,
+                path,
+            )
+        )
+    return selections
+
+
+def _arceos_all_selections(
+    registrations: Sequence[tuple[dict[str, Any], dict[str, Any]]],
+    path: Path,
+) -> list[SuiteSelection]:
+    selections = []
+    for check, registration in registrations:
+        if registration["kind"] != "arceos-qemu":
+            continue
+        arch = registration["arch"]
+        selections.append(
+            _selection(
+                check,
+                f"QEMU {arch}",
+                "all",
+                f"cargo xtask arceos test qemu --arch {arch}",
+                path,
+            )
+        )
+    return selections
+
+
+def _discovered_selections(
+    workspace_root: Path,
+    registrations: Sequence[tuple[dict[str, Any], dict[str, Any]]],
+    path: Path,
+    os_name: str,
+) -> list[SuiteSelection]:
+    root = SUITE_ROOTS[os_name]
+    absolute_root = workspace_root / root
+    absolute_path = workspace_root / path
+    cases = _discover_runtime_cases(absolute_root, os_name)
+
+    grouped = _starry_grouped_subcase(absolute_root, absolute_path, cases)
+    if grouped is not None:
+        matching_cases, selector = grouped
+        return _runtime_selections(
+            registrations,
+            path,
+            matching_cases,
+            selector_override=selector,
+        )
+
+    matching_cases = _matching_runtime_cases(cases, absolute_path)
+    return _runtime_selections(registrations, path, matching_cases)
+
+
+def _runtime_selections(
+    registrations: Sequence[tuple[dict[str, Any], dict[str, Any]]],
+    path: Path,
+    cases: Sequence[_RuntimeCase],
+    *,
+    selector_override: str | None = None,
+) -> list[SuiteSelection]:
+    selections = []
+    for runtime_case in cases:
+        selector = selector_override or runtime_case.case
+        template = _registered_template(
+            registrations,
+            kind=runtime_case.kind,
+            arch=runtime_case.arch,
+            board=runtime_case.board,
+            case=runtime_case.case,
+        )
+        if template is None:
+            continue
+
+        if runtime_case.kind == "starry-qemu":
+            platform = f"QEMU {runtime_case.arch}"
+            command = (
+                f"cargo xtask starry test qemu --arch {runtime_case.arch} "
+                f"--test-case {selector}"
+            )
+        elif runtime_case.kind == "axvisor-qemu":
+            variant = _case_variant(runtime_case.case)
+            platform = (
+                f"{variant.upper()} {runtime_case.arch}"
+                if variant in {"vmx", "svm"}
+                else f"QEMU {runtime_case.arch}"
+            )
+            command = (
+                f"cargo xtask axvisor test qemu --arch {runtime_case.arch} "
+                f"--test-group normal --test-case {selector}"
+            )
+        else:
+            platform = _platform_label(template)
+            os_cli = "starry" if runtime_case.kind == "starry-board" else "axvisor"
+            command = (
+                f"cargo xtask {os_cli} test board --test-case {selector} "
+                f"--board {runtime_case.board}"
+            )
+            if runtime_case.kind == "axvisor-board":
+                command = command.replace(
+                    " test board",
+                    " test board --test-group normal",
+                    1,
+                )
+
+        selections.append(_selection(template, platform, selector, command, path))
+    return selections
+
+
+def _discover_runtime_cases(root: Path, os_name: str) -> list[_RuntimeCase]:
+    cases = []
+    qemu_kind = f"{os_name}-qemu"
+    board_kind = f"{os_name}-board"
+    for runtime_config in sorted(root.rglob("qemu-*.toml")):
+        parsed = _parse_qemu_config_name(runtime_config.stem)
+        if parsed is None:
+            continue
+        arch, variant = parsed
+        build_config = _nearest_qemu_build_config(
+            runtime_config.parent,
+            root,
+            arch,
+            variant,
+        )
+        if build_config is None:
+            continue
+        wrapper_dir = build_config.parent
+        if os_name == "starry":
+            case = runtime_config.parent.relative_to(root).as_posix()
+        else:
+            base_case = (
+                wrapper_dir.name
+                if runtime_config.parent == wrapper_dir
+                else runtime_config.parent.name
+            )
+            case = f"{base_case}-{variant}" if variant else base_case
+        cases.append(
+            _RuntimeCase(
+                kind=qemu_kind,
+                arch=arch,
+                board=None,
+                case=case,
+                case_dir=runtime_config.parent,
+                wrapper_dir=wrapper_dir,
+                runtime_config=runtime_config,
+                build_config=build_config,
+            )
+        )
+
+    for runtime_config in sorted(root.rglob("board-*.toml")):
+        build_config = _nearest_board_build_config(runtime_config.parent, root)
+        if build_config is None:
+            continue
+        wrapper_dir = build_config.parent
+        relative_case = runtime_config.parent.relative_to(wrapper_dir)
+        case = (
+            relative_case.as_posix()
+            if relative_case.parts
+            else wrapper_dir.relative_to(root).as_posix()
+        )
+        cases.append(
+            _RuntimeCase(
+                kind=board_kind,
+                arch=None,
+                board=runtime_config.stem.removeprefix("board-"),
+                case=case,
+                case_dir=runtime_config.parent,
+                wrapper_dir=wrapper_dir,
+                runtime_config=runtime_config,
+                build_config=build_config,
+            )
+        )
+    return cases
+
+
+def _matching_runtime_cases(
+    cases: Sequence[_RuntimeCase], path: Path
+) -> list[_RuntimeCase]:
+    exact = [
+        runtime_case
+        for runtime_case in cases
+        if path in {runtime_case.runtime_config, runtime_case.build_config}
+    ]
+    if exact:
+        return exact
+
+    case_matches = [
+        runtime_case
+        for runtime_case in cases
+        if _is_prefix(path, runtime_case.case_dir)
+    ]
+    if case_matches:
+        deepest = max(len(runtime_case.case_dir.parts) for runtime_case in case_matches)
+        return [
+            runtime_case
+            for runtime_case in case_matches
+            if len(runtime_case.case_dir.parts) == deepest
+        ]
+
+    wrapper_matches = [
+        runtime_case
+        for runtime_case in cases
+        if _is_prefix(path, runtime_case.wrapper_dir)
+    ]
+    if wrapper_matches:
+        deepest = max(
+            len(runtime_case.wrapper_dir.parts) for runtime_case in wrapper_matches
+        )
+        return [
+            runtime_case
+            for runtime_case in wrapper_matches
+            if len(runtime_case.wrapper_dir.parts) == deepest
+        ]
+    return []
+
+
+def _starry_grouped_subcase(
+    root: Path,
+    path: Path,
+    cases: Sequence[_RuntimeCase],
+) -> tuple[list[_RuntimeCase], str] | None:
+    system_root = root / "qemu/system"
+    if not _is_prefix(path, system_root):
+        return None
+    relative = path.relative_to(system_root)
+    if len(relative.parts) < 2:
+        return None
+    subcase = relative.parts[0]
+    if not (system_root / subcase).is_dir():
+        return None
+    matching = [
+        runtime_case
+        for runtime_case in cases
+        if runtime_case.kind == "starry-qemu" and runtime_case.case == "qemu/system"
+    ]
+    return matching, f"qemu/{subcase}"
+
+
+def _nearest_qemu_build_config(
+    start: Path,
+    root: Path,
+    arch: str,
+    variant: str | None,
+) -> Path | None:
+    suffix = f"-{variant}" if variant else ""
+    filename = f"build-{ARCH_TARGETS[arch]}{suffix}.toml"
+    for directory in (start, *start.parents):
+        if directory == root.parent:
+            break
+        candidate = directory / filename
+        if candidate.is_file():
+            return candidate
+        if directory == root:
+            break
+    return None
+
+
+def _nearest_board_build_config(start: Path, root: Path) -> Path | None:
+    for directory in (start, *start.parents):
+        if directory == root.parent:
+            break
+        candidates = sorted(directory.glob("build-*.toml"))
+        if len(candidates) == 1:
+            return candidates[0]
+        if len(candidates) > 1:
+            return None
+        if directory == root:
+            break
+    return None
+
+
+def _registered_template(
+    registrations: Sequence[tuple[dict[str, Any], dict[str, Any]]],
+    *,
+    kind: str,
+    arch: str | None = None,
+    board: str | None = None,
+    case: str | None = None,
+) -> dict[str, Any] | None:
+    matches = []
+    for check, registration in registrations:
+        if registration["kind"] != kind:
+            continue
+        if arch is not None and registration.get("arch") != arch:
+            continue
+        if board is not None and registration.get("board") != board:
+            continue
+        registered_cases = registration.get("cases")
+        if registered_cases and case not in registered_cases:
+            continue
+        matches.append(check)
+    if len(matches) > 1:
+        ids = ", ".join(sorted(check["id"] for check in matches))
+        raise SuiteRouteError(
+            f"suite capability kind={kind} arch={arch} board={board} case={case} "
+            f"is registered by multiple checks: {ids}"
+        )
+    return matches[0] if matches else None
+
+
+def _suite_registrations(
+    checks: Sequence[dict[str, Any]],
+) -> list[tuple[dict[str, Any], dict[str, Any]]]:
+    return [
+        (check, registration)
+        for check in checks
+        for registration in check.get("suite", ())
+    ]
+
+
+def _selection(
+    template: dict[str, Any],
+    platform: str,
+    case: str,
+    command: str,
+    path: Path,
+) -> SuiteSelection:
+    row_id = _slugify(f"suite-{template['id']}-{case}")
+    return SuiteSelection(
+        template_id=template["id"],
+        row_id=row_id,
+        leaf_name=f"{platform} · {case}",
+        command=command,
+        source_path=path.as_posix(),
+    )
+
+
+def _platform_label(template: dict[str, Any]) -> str:
+    return template["name"].split(" · ", maxsplit=1)[0]
+
+
+def _kind_os(kind: str) -> str:
+    return kind.split("-", maxsplit=1)[0]
+
+
+def _case_variant(case: str) -> str | None:
+    suffix = case.rsplit("-", maxsplit=1)[-1]
+    return suffix if suffix in {"vmx", "svm"} else None
+
+
+def _parse_qemu_config_name(stem: str) -> tuple[str, str | None] | None:
+    if not stem.startswith("qemu-"):
+        return None
+    value = stem.removeprefix("qemu-")
+    for arch in ARCH_TARGETS:
+        if value == arch:
+            return arch, None
+        if value.startswith(f"{arch}-"):
+            return arch, value.removeprefix(f"{arch}-")
+    return None
+
+
+def _arches_for_path(path: Path) -> set[str]:
+    rendered = path.as_posix().casefold()
+    arches = set()
+    for arch, target in ARCH_TARGETS.items():
+        if re.search(rf"(^|[^a-z0-9]){re.escape(arch)}([^a-z0-9]|$)", rendered):
+            arches.add(arch)
+        if target.casefold() in rendered:
+            arches.add(arch)
+    if "riscv64gc" in rendered:
+        arches.add("riscv64")
+    return arches
+
+
+def _arch_sort_key(arch: str) -> int:
+    return list(ARCH_TARGETS).index(arch)
+
+
+def _slugify(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.casefold()).strip("-")
+
+
+def _is_prefix(path: Path, prefix: Path) -> bool:
+    return path == prefix or prefix in path.parents

--- a/scripts/test/test_ci_impact.py
+++ b/scripts/test/test_ci_impact.py
@@ -6,7 +6,6 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-
 MODULE_PATH = Path(__file__).with_name("ci_impact.py")
 SPEC = importlib.util.spec_from_file_location("ci_impact", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
@@ -57,9 +56,7 @@ class CiImpactTests(unittest.TestCase):
                 }
             )
 
-        self.package_ids = {
-            package["name"]: package["id"] for package in self.packages
-        }
+        self.package_ids = {package["name"]: package["id"] for package in self.packages}
         self.metadata_by_arch = {
             arch: self._metadata(arch) for arch in ci_impact.ARCH_TARGETS
         }
@@ -77,7 +74,9 @@ class CiImpactTests(unittest.TestCase):
         for package in self.packages:
             deps = []
             for name in dependency_names.get(package["name"], []):
-                dep_kinds = [{"kind": "dev", "target": None}] if name == "axtest" else []
+                dep_kinds = (
+                    [{"kind": "dev", "target": None}] if name == "axtest" else []
+                )
                 deps.append({"pkg": self.package_ids[name], "dep_kinds": dep_kinds})
             nodes.append({"id": package["id"], "deps": deps})
         self.assertIn(shared, {node["id"] for node in nodes})
@@ -136,7 +135,9 @@ class CiImpactTests(unittest.TestCase):
             },
         )
 
-    def test_target_specific_crate_selects_only_matching_target(self) -> None:
+    def test_target_specific_crate_selects_every_registered_target_for_its_os(
+        self,
+    ) -> None:
         impact = ci_impact.analyze_changed_paths(
             self.workspace_root,
             [Path("virtualization/arm-vcpu/src/lib.rs")],
@@ -144,7 +145,11 @@ class CiImpactTests(unittest.TestCase):
         )
 
         self.assertFalse(impact.full)
-        self.assertEqual(impact.targets, ("axvisor:aarch64",))
+        self.assertEqual(impact.affected_oses, ("axvisor",))
+        self.assertEqual(
+            impact.targets,
+            tuple(f"axvisor:{arch}" for arch in ci_impact.ARCH_TARGETS),
+        )
 
     def test_standalone_crate_does_not_select_an_os(self) -> None:
         impact = ci_impact.analyze_changed_paths(
@@ -186,15 +191,37 @@ class CiImpactTests(unittest.TestCase):
         self.assertEqual(impact.ignored_markdown, ("components/shared/README.md",))
         self.assertEqual(impact.ignored_apps, ("apps/starry/demo/prebuild.sh",))
 
-    def test_known_non_package_path_uses_os_and_arch_hint(self) -> None:
+    def test_test_suite_path_is_preserved_for_exclusive_exact_routing(self) -> None:
         impact = ci_impact.analyze_changed_paths(
             self.workspace_root,
-            [Path("test-suit/starryos/qemu-aarch64.toml")],
+            [Path("test-suit/starryos/qemu/system/qemu-aarch64.toml")],
             self.metadata_by_arch,
         )
 
         self.assertFalse(impact.full)
-        self.assertEqual(impact.targets, ("starry:aarch64",))
+        self.assertTrue(impact.exclusive)
+        self.assertEqual(
+            impact.test_suite_paths,
+            ("test-suit/starryos/qemu/system/qemu-aarch64.toml",),
+        )
+        self.assertEqual(impact.targets, ())
+
+    def test_ci_owned_virtio_blk_app_triggers_axvisor_aarch64(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [Path("apps/arceos/virtio-blk-test/run.sh")],
+            self.metadata_by_arch,
+        )
+
+        self.assertFalse(impact.full)
+        self.assertNotIn(
+            "apps/arceos/virtio-blk-test/run.sh",
+            impact.ignored_apps,
+        )
+        self.assertEqual(
+            impact.input_selections,
+            ("axvisor:qemu:aarch64",),
+        )
 
     def test_os_specific_config_without_arch_hint_selects_all_os_arches(self) -> None:
         impact = ci_impact.analyze_changed_paths(
@@ -212,15 +239,9 @@ class CiImpactTests(unittest.TestCase):
     def test_known_config_names_map_to_board_architectures(self) -> None:
         cases = {
             "os/StarryOS/configs/board/visionfive2.toml": ("starry:riscv64",),
-            "os/StarryOS/configs/board/jl-lsgd2k10.toml": (
-                "starry:loongarch64",
-            ),
-            "os/axvisor/configs/board/asus-nuc15crh-x86_64.toml": (
-                "axvisor:x86_64",
-            ),
-            "os/axvisor/configs/board/orangepi-5-plus.toml": (
-                "axvisor:aarch64",
-            ),
+            "os/StarryOS/configs/board/jl-lsgd2k10.toml": ("starry:loongarch64",),
+            "os/axvisor/configs/board/asus-nuc15crh-x86_64.toml": ("axvisor:x86_64",),
+            "os/axvisor/configs/board/orangepi-5-plus.toml": ("axvisor:aarch64",),
         }
         for changed_path, expected_targets in cases.items():
             with self.subTest(path=changed_path):

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -2,10 +2,12 @@
 
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
+import tomllib
 
 MODULE_PATH = Path(__file__).with_name("ci_plan.py")
 sys.path.insert(0, str(MODULE_PATH.parent))
@@ -29,11 +31,14 @@ class CiPlanTests(unittest.TestCase):
 
         self.assertEqual(len(plan["static_matrix"]["include"]), 3)
         self.assertEqual(len(plan["test_matrix"]["include"]), 32)
+        self.assertTrue(plan["static_required"])
         self.assertTrue(
             all(" / " in row["name"] for row in plan["test_matrix"]["include"])
         )
 
-    def test_pull_request_impact_selects_only_matching_os_and_arch(self) -> None:
+    def test_pull_request_crate_impact_selects_every_check_for_matching_os(
+        self,
+    ) -> None:
         context = ci_plan.PlanContext(
             repository="rcore-os/tgoskits",
             repository_owner="rcore-os",
@@ -45,7 +50,11 @@ class CiPlanTests(unittest.TestCase):
                 changed_paths=("os/arceos/modules/axhal/src/lib.rs",),
                 changed_packages=("ax-hal",),
                 affected_packages=("ax-hal",),
-                targets=("arceos:aarch64",),
+                affected_oses=("arceos",),
+                targets=tuple(
+                    f"arceos:{arch}"
+                    for arch in ("aarch64", "x86_64", "riscv64", "loongarch64")
+                ),
             ),
         )
 
@@ -57,7 +66,10 @@ class CiPlanTests(unittest.TestCase):
             {
                 "run-clippy",
                 "test-with-std",
+                "test-arceos-x86-64-qemu",
+                "test-arceos-riscv64-qemu",
                 "test-arceos-aarch64-qemu-app-suites",
+                "test-arceos-loongarch64-qemu",
             },
         )
 
@@ -101,13 +113,17 @@ class CiPlanTests(unittest.TestCase):
         )
 
         incremental_rows = {
-            row["id"]: row for row in ci_plan.build_main_plan(incremental)["test_matrix"]["include"]
+            row["id"]: row
+            for row in ci_plan.build_main_plan(incremental)["test_matrix"]["include"]
         }
         full_rows = {
-            row["id"]: row for row in ci_plan.build_main_plan(full)["test_matrix"]["include"]
+            row["id"]: row
+            for row in ci_plan.build_main_plan(full)["test_matrix"]["include"]
         }
 
-        self.assertIn('--since "$SINCE_REF"', incremental_rows["test-with-std"]["command"])
+        self.assertIn(
+            '--since "$SINCE_REF"', incremental_rows["test-with-std"]["command"]
+        )
         self.assertNotIn("--since", full_rows["test-with-std"]["command"])
         self.assertEqual(len(full_rows), 32)
 
@@ -163,28 +179,269 @@ class CiPlanTests(unittest.TestCase):
         static_rows = {
             row["id"]: row["name"] for row in plan["static_matrix"]["include"]
         }
-        test_rows = {
-            row["id"]: row["name"] for row in plan["test_matrix"]["include"]
-        }
+        test_rows = {row["id"]: row["name"] for row in plan["test_matrix"]["include"]}
 
         self.assertEqual(
             static_rows["check-formatting"], "Formatting + publish dry-run"
         )
-        self.assertEqual(
-            test_rows["run-clippy"], "Workspace / Incremental Clippy"
-        )
+        self.assertEqual(test_rows["run-clippy"], "Workspace / Incremental Clippy")
         self.assertEqual(
             test_rows["test-arceos-aarch64-qemu-app-suites"],
-            "ArceOS / aarch64 QEMU · GICv2 SMP4 boot + suites + axtest",
+            "ArceOS / QEMU aarch64 · GICv2 SMP4 boot + suites + axtest",
         )
         self.assertEqual(
             test_rows["test-axvisor-aarch64-qemu-panic-modes"],
-            "AxVisor / aarch64 QEMU · Panic modes",
+            "AxVisor / QEMU aarch64 · Panic modes",
         )
         self.assertEqual(
             test_rows["test-starry-self-hosted-board-visionfive2"],
-            "Starry / VisionFive 2 board · Suites",
+            "Starry / Board VisionFive 2 · Suites",
         )
+
+    def test_pure_test_suite_change_runs_only_the_exact_registered_case(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            base_ref="dev",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=("test-suit/starryos/qemu/system/qemu-aarch64.toml",),
+                test_suite_paths=("test-suit/starryos/qemu/system/qemu-aarch64.toml",),
+                exclusive=True,
+            ),
+        )
+
+        plan = ci_plan.build_main_plan(context)
+
+        self.assertFalse(plan["static_required"])
+        self.assertEqual(plan["static_matrix"]["include"], [])
+        self.assertEqual(
+            [row["name"] for row in plan["test_matrix"]["include"]],
+            ["Starry / QEMU aarch64 · qemu/system"],
+        )
+        self.assertEqual(
+            plan["test_matrix"]["include"][0]["command"],
+            "cargo xtask starry test qemu --arch aarch64 --test-case qemu/system",
+        )
+
+    def test_pure_board_suite_change_runs_only_the_exact_board_case(self) -> None:
+        path = (
+            "test-suit/starryos/board-orangepi-5-plus/"
+            "native-hardware-smoke/board-orangepi-5-plus.toml"
+        )
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            base_ref="dev",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=(path,),
+                test_suite_paths=(path,),
+                exclusive=True,
+            ),
+        )
+
+        plan = ci_plan.build_main_plan(context)
+
+        self.assertFalse(plan["static_required"])
+        self.assertEqual(
+            [row["name"] for row in plan["test_matrix"]["include"]],
+            ["Starry / Board OrangePi 5 Plus · native-hardware-smoke"],
+        )
+        self.assertEqual(
+            plan["test_matrix"]["include"][0]["command"],
+            "cargo xtask starry test board --test-case native-hardware-smoke "
+            "--board orangepi-5-plus",
+        )
+
+    def test_unregistered_test_suite_fails_planning(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=(
+                    "test-suit/starryos/board-rock-4d/boot/board-rock-4d.toml",
+                ),
+                test_suite_paths=(
+                    "test-suit/starryos/board-rock-4d/boot/board-rock-4d.toml",
+                ),
+                exclusive=True,
+            ),
+        )
+
+        with self.assertRaisesRegex(ci_plan.PlanError, "not registered"):
+            ci_plan.build_main_plan(context)
+
+    def test_multiple_test_suite_changes_form_a_stable_exact_union(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=(
+                    "test-suit/axvisor/normal/qemu-acpi/direct-acpi/qemu-x86_64-vmx.toml",
+                    "test-suit/starryos/qemu/system/qemu-aarch64.toml",
+                ),
+                test_suite_paths=(
+                    "test-suit/axvisor/normal/qemu-acpi/direct-acpi/qemu-x86_64-vmx.toml",
+                    "test-suit/starryos/qemu/system/qemu-aarch64.toml",
+                ),
+                exclusive=True,
+            ),
+        )
+
+        rows = ci_plan.build_main_plan(context)["test_matrix"]["include"]
+
+        self.assertEqual(
+            [row["name"] for row in rows],
+            [
+                "AxVisor / VMX x86_64 · direct-acpi-vmx",
+                "Starry / QEMU aarch64 · qemu/system",
+            ],
+        )
+        self.assertTrue(all(not row["download_xtask_bin_artifact"] for row in rows))
+
+    def test_starry_grouped_subcase_runs_only_that_subcase_on_registered_arches(
+        self,
+    ) -> None:
+        path = "test-suit/starryos/qemu/system/test-pivot-root/src/main.c"
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=(path,),
+                test_suite_paths=(path,),
+                exclusive=True,
+            ),
+        )
+
+        rows = ci_plan.build_main_plan(context)["test_matrix"]["include"]
+
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(
+            {row["name"] for row in rows},
+            {
+                f"Starry / QEMU {arch} · qemu/test-pivot-root"
+                for arch in ("aarch64", "loongarch64", "riscv64", "x86_64")
+            },
+        )
+        self.assertTrue(
+            all("--test-case qemu/test-pivot-root" in row["command"] for row in rows)
+        )
+
+    def test_precise_board_input_does_not_select_same_arch_qemu(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=("os/StarryOS/configs/board/visionfive2.toml",),
+                input_selections=("starry:board:visionfive2",),
+                targets=("starry:riscv64",),
+            ),
+        )
+
+        ids = {
+            row["id"]
+            for row in ci_plan.build_main_plan(context)["test_matrix"]["include"]
+        }
+
+        self.assertIn("test-starry-self-hosted-board-visionfive2", ids)
+        self.assertNotIn("test-starry-riscv64-qemu", ids)
+
+    def test_suite_plus_os_wide_crate_uses_the_broader_os_checks(self) -> None:
+        path = "test-suit/starryos/qemu/system/qemu-aarch64.toml"
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=(path, "components/shared/src/lib.rs"),
+                changed_packages=("shared",),
+                affected_packages=("shared", "starryos"),
+                affected_oses=("starry",),
+                test_suite_paths=(path,),
+                targets=tuple(
+                    f"starry:{arch}"
+                    for arch in ("aarch64", "x86_64", "riscv64", "loongarch64")
+                ),
+            ),
+        )
+
+        plan = ci_plan.build_main_plan(context)
+        ids = {row["id"] for row in plan["test_matrix"]["include"]}
+
+        self.assertTrue(plan["static_required"])
+        self.assertEqual(
+            len(
+                [
+                    row
+                    for row in plan["test_matrix"]["include"]
+                    if row["group"] == "Starry"
+                ]
+            ),
+            9,
+        )
+        self.assertFalse(any(check_id.startswith("suite-") for check_id in ids))
+
+    def test_unmatched_known_os_input_falls_back_to_that_os(self) -> None:
+        context = ci_plan.PlanContext(
+            repository="rcore-os/tgoskits",
+            repository_owner="rcore-os",
+            event_name="pull_request",
+            impact=ci_plan.CiImpact(
+                full=False,
+                reason="fixture",
+                changed_paths=("os/StarryOS/configs/board/future-board.toml",),
+                input_selections=("starry:board:future-board",),
+            ),
+        )
+
+        rows = ci_plan.build_main_plan(context)["test_matrix"]["include"]
+
+        self.assertEqual(
+            len([row for row in rows if row["group"] == "Starry"]),
+            9,
+        )
+        self.assertFalse(any(row["group"] in {"ArceOS", "AxVisor"} for row in rows))
+
+    def test_schema_v2_manifest_is_rejected_without_compatibility(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "legacy.toml"
+            manifest.write_text(
+                """
+schema_version = 2
+phase = "test"
+group = "Legacy"
+
+[[check]]
+id = "legacy-check"
+name = "Legacy"
+runs_on = ["ubuntu-latest"]
+environment = "base"
+command = "true"
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ci_plan.PlanError, "schema_version = 3"):
+                ci_plan._load_manifest(manifest)
 
     def test_arceos_qemu_jobs_run_same_arch_axtests_serially(self) -> None:
         plan = ci_plan.build_main_plan(self.upstream)
@@ -205,7 +462,9 @@ class CiPlanTests(unittest.TestCase):
             )
             self.assertIn(arceos_command, command)
             self.assertIn(axtest_command, command)
-            self.assertLess(command.index(arceos_command), command.index(axtest_command))
+            self.assertLess(
+                command.index(arceos_command), command.index(axtest_command)
+            )
             self.assertEqual(rows[check_id]["cache_key"], "")
 
     def test_fork_filters_owner_checks_and_falls_back_from_qcs(self) -> None:
@@ -226,9 +485,7 @@ class CiPlanTests(unittest.TestCase):
             static_rows["check-formatting"]["container_image"],
             "ghcr.io/rcore-os/tgoskits-container:latest",
         )
-        self.assertFalse(
-            static_rows["check-formatting"]["download_xtask_bin_artifact"]
-        )
+        self.assertFalse(static_rows["check-formatting"]["download_xtask_bin_artifact"])
         clippy = test_rows["run-clippy"]
         self.assertEqual(clippy["runs_on"], ["ubuntu-latest"])
         self.assertEqual(clippy["fetch_depth"], "0")
@@ -319,7 +576,9 @@ class CiPlanTests(unittest.TestCase):
         )
 
         self.assertEqual(
-            len(ci_plan.build_starry_apps_plan(manual)["starry_apps_matrix"]["include"]),
+            len(
+                ci_plan.build_starry_apps_plan(manual)["starry_apps_matrix"]["include"]
+            ),
             5,
         )
         self.assertEqual(
@@ -355,26 +614,66 @@ class CiPlanTests(unittest.TestCase):
         self.assertIn("starry app qemu -t nixos", nixos["command"])
         self.assertNotIn("starry test", nixos["command"])
 
-    def test_catalog_has_one_artifact_producer_and_empty_self_hosted_caches(self) -> None:
+    def test_catalog_has_one_artifact_producer_and_empty_self_hosted_caches(
+        self,
+    ) -> None:
         checks = ci_plan.load_catalog(ci_plan.MAIN_MANIFESTS)
         producers = [
             check for check in checks if check.get("upload_xtask_bin_artifact", False)
         ]
         consumers = [
-            check
-            for check in checks
-            if check.get("download_xtask_bin_artifact", False)
+            check for check in checks if check.get("download_xtask_bin_artifact", False)
         ]
 
         self.assertEqual([check["id"] for check in producers], ["run-sync-lint"])
         self.assertTrue(consumers)
         self.assertEqual(
-            {check.get("xtask_bin_artifact_name", "tg-xtask-bin") for check in consumers},
+            {
+                check.get("xtask_bin_artifact_name", "tg-xtask-bin")
+                for check in consumers
+            },
             {"tg-xtask-bin"},
         )
         for check in checks:
             if "self-hosted" in check["runs_on"]:
                 self.assertEqual(check.get("cache_key", ""), "", check["id"])
+
+    def test_v3_manifests_only_reference_shared_runner_profiles(self) -> None:
+        forbidden_fields = {
+            "runs_on",
+            "environment",
+            "self_hosted_owner",
+            "fallback_environment",
+            "required_owner",
+            "require_kvm",
+        }
+        manifests = (*ci_plan.MAIN_MANIFESTS, ci_plan.STARRY_APPS_MANIFEST)
+
+        for manifest in manifests:
+            with self.subTest(manifest=manifest.name):
+                with manifest.open("rb") as source:
+                    document = tomllib.load(source)
+                self.assertEqual(document["schema_version"], 3)
+                for check in document["check"]:
+                    self.assertFalse(forbidden_fields.intersection(check), check["id"])
+
+        with ci_plan.RUNNER_PROFILES_MANIFEST.open("rb") as source:
+            profile_document = tomllib.load(source)
+        self.assertEqual(profile_document["schema_version"], 3)
+
+        profiles = ci_plan._load_runner_profiles(ci_plan.RUNNER_PROFILES_MANIFEST)
+        self.assertEqual(
+            set(profiles),
+            {
+                "ubuntu-base",
+                "ubuntu-host",
+                "ubuntu-axvisor-lvz",
+                "qcs",
+                "board",
+                "kvm-intel",
+                "kvm-amd",
+            },
+        )
 
     def test_duplicate_ids_are_rejected(self) -> None:
         manifest = ci_plan.MAIN_MANIFESTS[0]
@@ -386,12 +685,10 @@ class CiPlanTests(unittest.TestCase):
         valid = {
             "id": "valid-check",
             "name": "Valid check",
-            "runs_on": ["ubuntu-latest"],
-            "environment": "base",
+            "runner": "ubuntu-base",
             "command": "true",
         }
         invalid_cases = (
-            ({**valid, "environment": "unknown"}, "unsupported environment"),
             ({**valid, "command": ""}, "non-empty string"),
             ({**valid, "id": "INVALID_ID"}, "lowercase kebab-case"),
             (
@@ -405,16 +702,42 @@ class CiPlanTests(unittest.TestCase):
         )
 
         for check, error in invalid_cases:
-            with self.subTest(error=error):
-                with self.assertRaisesRegex(ci_plan.PlanError, error):
-                    ci_plan._validate_check(check, "test")
+            with (
+                self.subTest(error=error),
+                self.assertRaisesRegex(ci_plan.PlanError, error),
+            ):
+                ci_plan._validate_check(check, "test")
+
+        with self.assertRaisesRegex(ci_plan.PlanError, "unsupported environment"):
+            ci_plan._validate_runner_profile(
+                {"runs_on": ["ubuntu-latest"], "environment": "unknown"},
+                "test profile",
+            )
+
+        with self.assertRaisesRegex(ci_plan.PlanError, "unsupported environment"):
+            ci_plan._validate_runner_profile(
+                {"runs_on": ["ubuntu-latest"], "environment": ["base"]},
+                "test profile",
+            )
+
+        with self.assertRaisesRegex(
+            ci_plan.PlanError, "unsupported fallback_environment"
+        ):
+            ci_plan._validate_runner_profile(
+                {
+                    "runs_on": ["self-hosted"],
+                    "environment": "host",
+                    "self_hosted_owner": "rcore-os",
+                    "fallback_environment": ["base"],
+                },
+                "test profile",
+            )
 
     def test_redundant_display_names_are_rejected(self) -> None:
         valid = {
             "id": "invalid-name",
-            "name": "aarch64 QEMU · Suites",
-            "runs_on": ["ubuntu-latest"],
-            "environment": "base",
+            "name": "QEMU aarch64 · Suites",
+            "runner": "ubuntu-base",
             "command": "true",
         }
         invalid_cases = (
@@ -427,11 +750,11 @@ class CiPlanTests(unittest.TestCase):
         )
 
         for name, error in invalid_cases:
-            with self.subTest(name=name):
-                with self.assertRaisesRegex(ci_plan.PlanError, error):
-                    ci_plan._validate_check(
-                        {**valid, "name": name}, "test", "AxVisor"
-                    )
+            with (
+                self.subTest(name=name),
+                self.assertRaisesRegex(ci_plan.PlanError, error),
+            ):
+                ci_plan._validate_check({**valid, "name": name}, "test", "AxVisor")
 
     def test_starry_apps_display_names_are_leaf_labels(self) -> None:
         scheduled = ci_plan.PlanContext(
@@ -441,22 +764,22 @@ class CiPlanTests(unittest.TestCase):
         )
         rows = {
             row["id"]: row["name"]
-            for row in ci_plan.build_starry_apps_plan(scheduled)[
-                "starry_apps_matrix"
-            ]["include"]
+            for row in ci_plan.build_starry_apps_plan(scheduled)["starry_apps_matrix"][
+                "include"
+            ]
         }
 
         self.assertEqual(rows["starry-apps-clippy-all"], "Workspace · Full Clippy")
-        self.assertEqual(
-            rows["starry-app-smoke-x86-64"], "x86_64 QEMU · App smoke"
-        )
+        self.assertEqual(rows["starry-app-smoke-x86-64"], "QEMU x86_64 · App smoke")
 
     def test_empty_main_matrix_is_rejected(self) -> None:
-        with mock.patch.object(
-            ci_plan, "MAIN_MANIFESTS", (ci_plan.STARRY_APPS_MANIFEST,)
+        with (
+            mock.patch.object(
+                ci_plan, "MAIN_MANIFESTS", (ci_plan.STARRY_APPS_MANIFEST,)
+            ),
+            self.assertRaisesRegex(ci_plan.PlanError, "non-empty"),
         ):
-            with self.assertRaisesRegex(ci_plan.PlanError, "non-empty"):
-                ci_plan.build_main_plan(self.upstream)
+            ci_plan.build_main_plan(self.upstream)
 
     def test_artifact_producer_and_consumer_contract_is_enforced(self) -> None:
         producer = {
@@ -480,14 +803,33 @@ class CiPlanTests(unittest.TestCase):
         check = {
             "id": "invalid-cache",
             "name": "Invalid cache",
-            "runs_on": ["self-hosted", "linux"],
-            "environment": "host",
+            "runner": "qcs",
             "cache_key": "must-not-be-set",
             "command": "true",
         }
 
         with self.assertRaisesRegex(ci_plan.PlanError, "empty cache_key"):
             ci_plan._validate_check(check, "test")
+
+    def test_v3_rejects_direct_runner_fields_and_unknown_profiles(self) -> None:
+        direct = {
+            "id": "direct-runner",
+            "name": "Direct runner",
+            "runs_on": ["ubuntu-latest"],
+            "environment": "base",
+            "command": "true",
+        }
+        unknown = {
+            "id": "unknown-runner",
+            "name": "Unknown runner",
+            "runner": "missing-profile",
+            "command": "true",
+        }
+
+        with self.assertRaisesRegex(ci_plan.PlanError, "unknown fields"):
+            ci_plan._validate_check(direct, "test")
+        with self.assertRaisesRegex(ci_plan.PlanError, "unknown runner profile"):
+            ci_plan._validate_check(unknown, "test")
 
 
 if __name__ == "__main__":

--- a/test-suit/starryos/GUIDE.md
+++ b/test-suit/starryos/GUIDE.md
@@ -31,6 +31,18 @@ test-suit/starryos/<build_wrapper>/<case>/<runtime-config>.toml
 旧的 Starry `--test-group` 和 `--stress` 入口已经移除。需要运行迁出的压力、K230、
 visual 或 golden 类用例时，使用 `cargo xtask starry app ...` 或对应脚本。
 
+## CI 精确路由
+
+CI 路由不改变上述 xtask 发现规则。`.github/ci/checks/starry.toml` 通过 check 下的
+`[[check.suite]]` 注册当前可用的 QEMU 架构或 board runner；planner 再以实际存在的
+`qemu-<arch>.toml`、`board-<board>.toml` 和最近的 `build-<target>.toml` 解析 case。
+不要从目录名字手工拼接 CI job，也不要为未在 CI 中运行的板卡借用其他 runner。
+
+PR 的有效改动全部位于 `test-suit/**` 时，只运行匹配的已注册 case。多个 case 取
+稳定去重并集；共享 build wrapper 变更展开到该 wrapper 下所有已注册 case。
+`qemu/system/<subcase>` 源码变更会生成 `qemu/<subcase>` selector。若新增 case 或
+board 尚未在 manifest 注册，`Plan CI` 会明确失败，而不是静默跳过或自动启用真机。
+
 ## 当前目录概览
 
 ```text


### PR DESCRIPTION
## 问题

现有 CI 清单在每个检查项中重复声明 runner、environment、owner 和 KVM 约束，任务名称又大量重复 Test、Static 与架构/平台信息。PR 影响分析只按粗粒度 OS/架构选择，导致纯 `test-suit/**` 修改仍会运行无关的 Preflight、Workspace 和其他 suite；`apps/arceos/virtio-blk-test/**` 还会被 apps 忽略规则吞掉。

## 改动

1. 将全部 check manifest 原子迁移到 schema v3，删除 v2 兼容；新增共享 runner profiles，通过默认 profile 消除 runner、environment、owner、fallback 和 KVM 重复项，并保持 self-hosted `cache_key` 为空。
2. 统一固定任务名称为“阶段 / 系统 / 平台 架构或设备 · 目的”，工作流父级从 Static、Tests 改为 Preflight、Verification；主 CI 全量展开为 37 个显示项，Starry Apps 全量展开为 7 个显示项。
3. 新增精确 suite 路由：从真实 `qemu-*`、`board-*`、`build-*` 配置发现运行能力，再与 manifest 注册项匹配。纯 `test-suit/**` PR 只生成对应动态任务；多个 suite 稳定去重；未注册 suite 在 Plan CI 明确失败。
4. crate 影响某个 OS 时，选择该 OS 当前注册的全部 QEMU、KVM 和真机项；OS 配置与 test-suit 共享精确输入模型，无法匹配时回退到对应 OS 全量。修复 virtio-blk-test 对 AxVisor aarch64 的触发。
5. 纯 suite 模式输出空 Preflight matrix，并通过 `static_required` 使 Verification 在 Preflight 正常 skipped 后继续；动态任务不依赖被跳过的 xtask artifact。
6. 更新 CI 与 Starry test-suit 文档、路由检查和工作流布局检查。

## 实现逻辑

- runner profile 在既有 matrix 规范化之前展开，因此下游 reusable workflow 的执行字段保持不变。
- suite 路由以 manifest 注册能力作为允许列表，以仓库真实配置作为发现事实；这样新增但未注册的 suite 不会静默执行错误任务。
- 精确输入优先选择单一 QEMU、KVM 或 board 项；只有无法精确映射时才按 OS 安全回退。
- OS 根 crate 影响独立于当前编译架构汇总，确保真机和其他架构验证不会因单架构依赖图而漏跑。

## 验证

- 先添加旧实现必然失败的路由、命名和 schema 回归，再完成迁移。
- `uv run --python 3.11 python3 -m unittest scripts.test.test_ci_impact scripts.test.test_ci_plan`：49 项通过。
- `python3 scripts/test/check_ci_paths.py`
- `python3 scripts/test/check_ci_routing.py`
- `python3 scripts/test/check_workflow_layout.py`
- planner 全量展开：3 个 Preflight、32 个 Verification、6 个 Starry Apps matrix 项。
- schema v3 profile 展开后的 runner、容器、缓存、命令、超时和 artifact 配置与迁移前清单等价。
- 代表性 ArceOS QEMU、Starry QEMU、AxVisor QEMU、VMX 和 Starry 真机路径均展开为单一精确任务。
- `ruff format --check`、`ruff check`、`cargo fmt --all -- --check`、`git diff --check` 通过。
- actionlint 对目标工作流通过；忽略仓库既有 actionlint 尚不识别的 `concurrency.queue` 扩展字段。

按本次验证边界未运行实际 QEMU、完整 CI 或真机任务。