### PR TITLE
feat(ax-tracepoint): extract tracepoint component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,6 +1246,18 @@ name = "ax-timer-list"
 version = "0.3.5"
 
 [[package]]
+name = "ax-tracepoint"
+version = "0.6.0"
+dependencies = [
+ "env_logger",
+ "log",
+ "lru 0.18.2",
+ "paste",
+ "thiserror 2.0.20",
+ "tp-lexer",
+]
+
+[[package]]
 name = "axaddrspace"
 version = "0.5.19"
 dependencies = [
@@ -4735,19 +4747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ktracepoint"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30aa94490986294aa3a19dc3fbc6b7eefe3fbbac18c323c4153a0cfd1a7a0b74"
-dependencies = [
- "log",
- "lru 0.18.2",
- "paste",
- "static-keys",
- "tp-lexer",
-]
-
-[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7856,6 +7855,7 @@ dependencies = [
  "ax-runtime",
  "ax-std",
  "ax-task",
+ "ax-tracepoint",
  "axbacktrace",
  "axfs-ng-vfs",
  "axklib",
@@ -7886,7 +7886,6 @@ dependencies = [
  "kmod-tools",
  "kprobe",
  "ksym",
- "ktracepoint",
  "linux-raw-sys 0.12.1",
  "lock_api",
  "lwprintf-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "components/axklib",
     "components/axpanic",
     "components/axpoll",
+    "components/ax-tracepoint",
     "components/axsched",
     "components/cpumask",
     "components/crate_interface",
@@ -165,6 +166,7 @@ ax-sched = { version = "0.5.8", path = "components/axsched" }
 ax-std = { version = "0.5.31", path = "os/arceos/ulib/axstd", default-features = false }
 ax-sync = { version = "0.5.31", path = "os/arceos/modules/axsync" }
 ax-task = { version = "0.6.7", path = "os/arceos/modules/axtask" }
+ax-tracepoint = { version = "0.6.0", path = "components/ax-tracepoint" }
 axtest = { version = "0.5.14", path = "components/axtest/axtest" }
 axtest-macros = { version = "0.5.14", path = "components/axtest/axtest_macros" }
 xcover = { version = "0.1.3", default-features = false, features = ["alloc"] }

--- a/apps/starry/ebpf/sched_trace/sched_trace-ebpf/src/main.rs
+++ b/apps/starry/ebpf/sched_trace/sched_trace-ebpf/src/main.rs
@@ -15,7 +15,7 @@ use sched_trace_common::SchedSwitchEvent;
 #[map]
 static EVENTS: PerfEventArray<SchedSwitchEvent> = PerfEventArray::new(0);
 
-// `sched:sched_switch` raw tracepoint. ktracepoint's `define_event_trace!`
+// `sched:sched_switch` raw tracepoint. ax-tracepoint's `define_event_trace!`
 // widens each `TP_PROTO` field to `u64` and hands the program that array as
 // its context, so the layout is:
 //   args[0] = prev_tid, args[1] = next_tid, args[2] = prev_state (u32 widened).

--- a/components/ax-tracepoint/Cargo.toml
+++ b/components/ax-tracepoint/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ax-tracepoint"
+version = "0.6.0"
+edition.workspace = true
+authors.workspace = true
+license = "MIT"
+repository.workspace = true
+documentation = "https://docs.rs/ax-tracepoint"
+readme = "README.md"
+keywords = ["tracepoint", "kernel", "tracing", "no-std"]
+description = "A Rust crate for implementing tracepoints in operating systems."
+build = "build.rs"
+
+[dependencies]
+log.workspace = true
+lru = "0.18"
+paste = "1.0"
+thiserror.workspace = true
+tp-lexer = "0.5.5"
+
+[dev-dependencies]
+env_logger = "0.11"

--- a/components/ax-tracepoint/LICENSE
+++ b/components/ax-tracepoint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/ax-tracepoint/LICENSE
+++ b/components/ax-tracepoint/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 [fullname]
+Copyright (c) 2025 周睿
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/components/ax-tracepoint/README.cn.md
+++ b/components/ax-tracepoint/README.cn.md
@@ -1,0 +1,139 @@
+# ax-tracepoint
+
+面向内核场景的 Rust tracepoint 库，设计目标类似 Linux tracepoint：
+
+- 用宏定义事件与字段
+- 运行时按唯一事件 ID 管理
+- 支持开关、过滤表达式、回调
+- 支持原始事件缓冲区与可读文本输出
+- no_std 可用
+
+## 核心能力
+
+- 事件定义：通过 define_event_trace! 一次性生成事件元数据、调用函数、注册函数
+- 事件管理：TracePointMap 按 tracepoint ID 索引
+- 事件控制：enable/disable、format/id/filter
+- 过滤表达式：基于 tp-lexer 按 schema 编译并匹配
+- 输出链路：TracePipeRaw + TraceEntryParser
+
+## 快速接入
+
+### 1. 添加依赖
+
+```toml
+[dependencies]
+ax-tracepoint = "*"
+```
+
+### 2. 链接脚本中保留 .tracepoint 段
+
+该库通过 __start_tracepoint / __stop_tracepoint 扫描所有事件元数据。
+请将 my_section.ld 的内容并入你的链接脚本，确保 .tracepoint 段被 KEEP。
+StarryOS 的内核 linker script 已包含该契约；其它宿主需要自行加入等价段定义。
+
+### 3. 实现 KernelTraceOps
+
+你需要提供：
+
+- current_pid
+- trace_pipe_push_raw_record
+- trace_cmdline_push
+- tracepoint state registry 钩子：read_tracepoint_state、write_tracepoint_state
+
+state registry 钩子用于让你的 OS 自行选择 callbacks 和 filters 的同步策略。
+tracepoint 调用使用运行时原子 callback gate，动态注册不会在其它 CPU
+运行时修改可执行代码。
+writer 负责发布顺序：先发布非空 callback 状态再打开 gate；移除最后一个
+callback 时先关闭 gate，再退役旧状态。
+
+### Callback 限制
+
+`read_tracepoint_state` 可以在 tracing 快路径执行 callbacks 时持有读侧锁。如果你的实现使用 `RwLock` 这类不可重入锁，callback 中不得：
+
+- 注册或注销 tracepoint callback
+- 更新 tracepoint filter
+- 调用其它需要 `write_tracepoint_state` 的 API
+- 递归触发由同一个 state registry 支撑的 tracepoint
+
+违反这些规则可能导致死锁。如果宿主使用 RCU、snapshot 或其它非阻塞读侧机制实现 `read_tracepoint_state`，可以自行放宽这些限制。
+
+### 4. 定义并调用事件
+
+```rust
+use ax_tracepoint::{define_event_trace, KernelTraceOps};
+
+define_event_trace!(
+    TEST,
+    TP_kops(Kops),
+    TP_system(tracepoint_test),
+    TP_PROTO(a: u32, b: u32),
+    TP_STRUCT__entry { a: u32, b: u32 },
+    TP_fast_assign { a: a, b: b },
+    TP_ident(__entry),
+    TP_printk(format_args!("a={}, b={}", __entry.a, __entry.b))
+);
+
+// 生成函数: trace_TEST / register_trace_TEST / unregister_trace_TEST
+trace_TEST(1, 2);
+```
+
+提示：TP_STRUCT__entry 会参与字节布局。字段必须实现 TraceField；内置实现覆盖整数
+原语及 trace field 数组。
+
+### 5. 初始化管理器
+
+```rust
+use ax_tracepoint::global_init_events;
+
+let (tracepoints, ext_tracepoints) = global_init_events::<Kops>()?;
+
+// 将 ext_tracepoints 安装到 Kops::read_tracepoint_state 和
+// Kops::write_tracepoint_state 使用的 registry 中。
+```
+
+### 6. 启用、过滤、消费输出
+
+```rust
+use ax_tracepoint::{TraceFilterFile, TracePointEnableFile, TracePointFormatFile, TracePointIdFile};
+
+let event_id = 0;
+Kops::write_tracepoint_state(event_id, |event| {
+    TracePointEnableFile::new().write(event, '1');
+    let mut filter = TraceFilterFile::new();
+    filter.write(event, "a > 8 && b > 5").unwrap();
+});
+
+// 读取格式描述
+let tracepoint = tracepoints.get(&event_id).unwrap();
+let fmt = TracePointFormatFile::new(tracepoint).read();
+let id = TracePointIdFile::new(tracepoint).read();
+```
+
+## 运行示例
+
+```bash
+cargo run -p ax-tracepoint --example usage
+```
+
+示例代码位于 examples/usage.rs，覆盖了：
+
+- 事件定义与触发
+- 事件启用与过滤
+- 注册 event/raw 回调
+- TracePipeRaw 快照读取与文本解析
+
+## 主要公开类型
+
+- KernelTraceOps
+- TracePoint / ExtTracePoint / TracePointMap
+- TracePipeRaw / TracePipeSnapshot / TracePipeOps
+- TraceCmdLineCache / TraceEntryParser
+- TraceFilterError / TraceParseError / TraceInitError
+
+损坏的 trace record 和被拒绝的 filter 更新会返回 typed error。filter 编译失败会保留
+上一个已生效的 compiled filter；只有精确写入 `0`（允许外围空白）才会清除 filter。
+
+## 参考项目
+
+- DragonOS: <https://github.com/DragonOS-Community/DragonOS/blob/master/kernel/src/debug/tracing/mod.rs>
+- TGOSKits StarryOS: <https://github.com/rcore-os/tgoskits/tree/dev/os/StarryOS>

--- a/components/ax-tracepoint/README.md
+++ b/components/ax-tracepoint/README.md
@@ -60,6 +60,10 @@ setting the gate, and clear the gate before retiring the last callback state.
 
 Violating these rules may deadlock. Hosts that implement `read_tracepoint_state` with RCU, snapshots, or another non-blocking read-side mechanism may provide weaker restrictions.
 
+Cooked event callbacks receive `&mut [u8]` for a freshly generated record.
+Each callback owns a distinct record for the duration of the call, so BPF
+adapters can update their context without casting away a shared reference.
+
 ### 4. Define and invoke events
 
 ```rust

--- a/components/ax-tracepoint/README.md
+++ b/components/ax-tracepoint/README.md
@@ -1,0 +1,144 @@
+# ax-tracepoint
+
+A Rust tracepoint library for kernel scenarios, designed with goals similar to Linux tracepoints:
+
+- Define events and fields with macros
+- Manage tracepoints by unique event ID at runtime
+- Support enable/disable, filter expressions, and callbacks
+- Provide both raw event buffering and human-readable output
+- no_std compatible
+
+Repository: <https://github.com/rcore-os/tgoskits/tree/dev/components/ax-tracepoint>
+
+## Core Capabilities
+
+- Event definition: use `define_event_trace!` to generate event metadata, call functions, and register functions in one place
+- Event management: `TracePointMap` indexed by tracepoint ID
+- Event control: enable/disable, format/id/filter
+- Filter expressions: compiled and evaluated against schema via `tp-lexer`
+- Output pipeline: `TracePipeRaw` + `TraceEntryParser`
+
+## Quick Start
+
+### 1. Add dependencies
+
+```toml
+[dependencies]
+ax-tracepoint = "*"
+```
+
+### 2. Keep the `.tracepoint` section in your linker script
+
+This library scans event metadata through `__start_tracepoint / __stop_tracepoint`.
+Merge the content of `my_section.ld` into your linker script and ensure the `.tracepoint` section is kept with `KEEP`.
+StarryOS already carries this contract in its kernel linker scripts; other
+hosts must add the equivalent section themselves.
+
+### 3. Implement `KernelTraceOps`
+
+You need to provide:
+
+- `current_pid`
+- `trace_pipe_push_raw_record`
+- `trace_cmdline_push`
+- tracepoint state registry hooks: `read_tracepoint_state`, `write_tracepoint_state`
+
+The state registry hooks let your OS choose its own synchronization strategy for callbacks and filters.
+Tracepoint calls use a runtime atomic callback gate, so changing registrations
+never patches executable text while other CPUs are running.
+The writer owns publication ordering: publish a non-empty callback state before
+setting the gate, and clear the gate before retiring the last callback state.
+
+### Callback restrictions
+
+`read_tracepoint_state` may hold a read-side lock while the tracing fast path executes callbacks. If your implementation uses a non-reentrant lock such as `RwLock`, callbacks must not:
+
+- register or unregister tracepoint callbacks
+- update tracepoint filters
+- call other APIs that require `write_tracepoint_state`
+- recursively trigger tracepoints backed by the same state registry
+
+Violating these rules may deadlock. Hosts that implement `read_tracepoint_state` with RCU, snapshots, or another non-blocking read-side mechanism may provide weaker restrictions.
+
+### 4. Define and invoke events
+
+```rust
+use ax_tracepoint::{define_event_trace, KernelTraceOps};
+
+define_event_trace!(
+    TEST,
+    TP_kops(Kops),
+    TP_system(tracepoint_test),
+    TP_PROTO(a: u32, b: u32),
+    TP_STRUCT__entry { a: u32, b: u32 },
+    TP_fast_assign { a: a, b: b },
+    TP_ident(__entry),
+    TP_printk(format_args!("a={}, b={}", __entry.a, __entry.b))
+);
+
+// Generated functions: trace_TEST / register_trace_TEST / unregister_trace_TEST
+trace_TEST(1, 2);
+```
+
+Note: `TP_STRUCT__entry` participates in byte layout. Fields must implement
+`TraceField`; the built-in implementations cover integer primitives and arrays
+of trace fields.
+
+### 5. Initialize the manager
+
+```rust
+use ax_tracepoint::global_init_events;
+
+let (tracepoints, ext_tracepoints) = global_init_events::<Kops>()?;
+
+// Install `ext_tracepoints` into the registry used by
+// Kops::read_tracepoint_state and Kops::write_tracepoint_state.
+```
+
+### 6. Enable, filter, and consume output
+
+```rust
+use ax_tracepoint::{TraceFilterFile, TracePointEnableFile, TracePointFormatFile, TracePointIdFile};
+
+let event_id = 0;
+Kops::write_tracepoint_state(event_id, |event| {
+    TracePointEnableFile::new().write(event, '1');
+    let mut filter = TraceFilterFile::new();
+    filter.write(event, "a > 8 && b > 5").unwrap();
+});
+
+// Read format and ID
+let tracepoint = tracepoints.get(&event_id).unwrap();
+let fmt = TracePointFormatFile::new(tracepoint).read();
+let id = TracePointIdFile::new(tracepoint).read();
+```
+
+## Run the example
+
+```bash
+cargo run -p ax-tracepoint --example usage
+```
+
+Example code is in `examples/usage.rs`, covering:
+
+- Event definition and triggering
+- Event enabling and filtering
+- Registering event/raw callbacks
+- Reading `TracePipeRaw` snapshots and parsing them into text
+
+## Main Public Types
+
+- `KernelTraceOps`
+- `TracePoint` / `ExtTracePoint` / `TracePointMap`
+- `TracePipeRaw` / `TracePipeSnapshot` / `TracePipeOps`
+- `TraceCmdLineCache` / `TraceEntryParser`
+- `TraceFilterError` / `TraceParseError` / `TraceInitError`
+
+Malformed trace records and rejected filter updates return typed errors. A
+failed filter compilation preserves the previously active compiled filter;
+write exactly `0` (surrounding whitespace is allowed) to clear it.
+
+## Reference Projects
+
+- DragonOS: <https://github.com/DragonOS-Community/DragonOS/blob/master/kernel/src/debug/tracing/mod.rs>
+- TGOSKits StarryOS: <https://github.com/rcore-os/tgoskits/tree/dev/os/StarryOS>

--- a/components/ax-tracepoint/build.rs
+++ b/components/ax-tracepoint/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("Cargo must provide CARGO_MANIFEST_DIR to ax-tracepoint's build script");
+    println!("cargo::rerun-if-changed=my_section.ld");
+    println!("cargo::rustc-link-arg=-T{manifest_dir}/my_section.ld");
+}

--- a/components/ax-tracepoint/examples/usage.rs
+++ b/components/ax-tracepoint/examples/usage.rs
@@ -1,0 +1,244 @@
+extern crate alloc;
+use std::{collections::BTreeMap, sync::Arc};
+
+use ax_tracepoint::{
+    KernelTraceOps, RawTraceEventFunc, TraceCallbackType, TraceCmdLineCache, TraceEntryParser,
+    TraceEventFunc, TraceFilterFile, TracePointEnableFile, TracePointMap, global_init_events,
+};
+
+use crate::tracepoint_example::{EXT_TRACEPOINTS, Kops, TRACE_RAW_PIPE};
+
+mod tracepoint_example {
+    use std::{
+        collections::BTreeMap,
+        num::NonZero,
+        ops::Deref,
+        sync::{Arc, LazyLock, Mutex, RwLock},
+        time,
+    };
+
+    use ax_tracepoint::{ExtTracePoint, TraceCmdLineCache, define_event_trace};
+
+    pub static TRACE_RAW_PIPE: Mutex<ax_tracepoint::TracePipeRaw> =
+        Mutex::new(ax_tracepoint::TracePipeRaw::new(1024));
+
+    pub static TRACE_CMDLINE_CACHE: LazyLock<Mutex<TraceCmdLineCache>> = LazyLock::new(|| {
+        Mutex::new(ax_tracepoint::TraceCmdLineCache::new(
+            NonZero::new(1024).unwrap(),
+        ))
+    });
+
+    pub static EXT_TRACEPOINTS: RwLock<BTreeMap<u32, ExtTracePoint<Kops>>> =
+        RwLock::new(BTreeMap::new());
+
+    pub struct Kops;
+
+    impl ax_tracepoint::KernelTraceOps for Kops {
+        fn current_pid() -> u32 {
+            0xff
+        }
+
+        fn trace_pipe_push_raw_record(buf: &[u8]) {
+            let time = time::SystemTime::now()
+                .duration_since(time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos() as u64;
+            let cpu_id = 8;
+            let mut pipe = TRACE_RAW_PIPE.lock().unwrap();
+            pipe.push_record(time, cpu_id, buf.to_vec());
+        }
+
+        fn trace_cmdline_push(pid: u32) {
+            let mut cache = TRACE_CMDLINE_CACHE.lock().unwrap();
+            cache.insert(pid, "test_process");
+        }
+
+        fn read_tracepoint_state<R>(id: u32, f: impl FnOnce(&ExtTracePoint<Self>) -> R) -> R {
+            let states = EXT_TRACEPOINTS.read().unwrap();
+            states
+                .get(&id)
+                .map(f)
+                .unwrap_or_else(|| panic!("Tracepoint state not found for ID: {}", id))
+        }
+
+        fn write_tracepoint_state<R>(id: u32, f: impl FnOnce(&mut ExtTracePoint<Self>) -> R) -> R {
+            let mut states = EXT_TRACEPOINTS.write().unwrap();
+            let state = states
+                .get_mut(&id)
+                .unwrap_or_else(|| panic!("Tracepoint state not found for ID: {}", id));
+            let result = f(state);
+            state.trace_point().set_callback_gate(state.has_callbacks());
+            result
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Debug)]
+    #[allow(clippy::redundant_allocation)]
+    struct TestS {
+        a: u32,
+        b: Box<Arc<u32>>,
+    }
+
+    define_event_trace!(
+        TEST,
+        TP_kops(Kops),
+        TP_system(tracepoint_test),
+        TP_PROTO(a: u32, b: &TestS),
+        TP_STRUCT__entry{
+            a: u32,
+            pad:[u8;4],
+            b: u32
+        },
+        TP_fast_assign{
+            a: a,
+            pad: [0; 4],
+            b: *b.b.deref().deref()
+        },
+        TP_ident(__entry),
+        TP_printk(
+            {
+                let arg1 = __entry.a;
+                let arg2 = __entry.b;
+                format!("Hello from tracepoint! a={:?}, b={}", arg1, arg2)
+            }
+        )
+    );
+
+    define_event_trace!(
+        TEST2,
+        TP_kops(Kops),
+        TP_system(tracepoint_test),
+        TP_PROTO(a: u32, b: u32),
+        TP_STRUCT__entry{
+            a: u32,
+            b: u32
+        },
+        TP_fast_assign{
+            a:a,
+            b:b
+        },
+        TP_ident(__entry),
+        TP_printk(format_args!("Hello from tracepoint! a={}, b={}", __entry.a, __entry.b))
+    );
+
+    pub fn test_trace(a: u32, b: u32) {
+        let x = TestS {
+            a,
+            b: Box::new(Arc::new(b)),
+        };
+        trace_TEST(a, &x);
+        trace_TEST2(a, b);
+        println!(
+            "Tracepoint TEST called with a={}, b={}, x ptr={:p}",
+            a, b, &x
+        );
+    }
+}
+
+fn print_trace_records(
+    tracepoint_map: &TracePointMap<Kops>,
+    trace_cmdline_cache: &TraceCmdLineCache,
+) {
+    use ax_tracepoint::TracePipeOps;
+    let mut snapshot = TRACE_RAW_PIPE.lock().unwrap().snapshot();
+    print!("{}", snapshot.default_fmt_str());
+    loop {
+        let mut flag = false;
+        if let Some(event) = snapshot.peek() {
+            let trace_str = TraceEntryParser::parse(tracepoint_map, trace_cmdline_cache, event)
+                .expect("example emitted an invalid trace record");
+            print!("{}", trace_str);
+            flag = true;
+        }
+        if flag {
+            snapshot.pop();
+        } else {
+            break;
+        }
+    }
+}
+
+fn perf_event_callback() -> TraceCallbackType {
+    let callback = Arc::new(TraceEventFunc::new(
+        Box::new(|entry, _data| {
+            println!("FakeEventCallback called with entry: {}", entry.len());
+        }),
+        Box::new(()),
+    ));
+    callback.set_perf_enable(true);
+    TraceCallbackType::Event(callback)
+}
+
+fn raw_event_callback() -> TraceCallbackType {
+    let callback = RawTraceEventFunc::new(
+        Box::new(|args, _data| {
+            println!("FakeEventCallback (raw) called with args: {:x?}", args);
+        }),
+        Box::new(()),
+    );
+    TraceCallbackType::RawEvent(Arc::new(callback))
+}
+
+fn main() {
+    env_logger::try_init_from_env(env_logger::Env::default().default_filter_or("debug"))
+        .expect("Failed to initialize logger");
+
+    // First, initialize the tracepoint metadata and runtime event states.
+    let (tracepoint_map, ext_tps) = global_init_events::<Kops>().unwrap();
+
+    let ext_tps = ext_tps
+        .into_iter()
+        .map(|ext_tp| (ext_tp.trace_point().id(), ext_tp))
+        .collect::<BTreeMap<_, _>>();
+
+    *EXT_TRACEPOINTS.write().unwrap() = ext_tps;
+
+    println!("---Before enabling tracepoints---");
+    tracepoint_example::test_trace(1, 2);
+    tracepoint_example::test_trace(3, 4);
+    print_trace_records(
+        &tracepoint_map,
+        &tracepoint_example::TRACE_CMDLINE_CACHE.lock().unwrap(),
+    );
+
+    println!();
+
+    let perf_event_callback = perf_event_callback();
+
+    let raw_event_callback = raw_event_callback();
+
+    for (event_id, tp) in tracepoint_map.iter() {
+        Kops::write_tracepoint_state(*event_id, |ext_tp| {
+            let enable_file = TracePointEnableFile::new();
+            enable_file.write(ext_tp, '1');
+            ext_tp.register(perf_event_callback.clone());
+            ext_tp.register(raw_event_callback.clone());
+
+            let mut filter_file = TraceFilterFile::new();
+            filter_file
+                .write(ext_tp, "(a > 8 && a<=10) || b >5")
+                .unwrap();
+        });
+
+        let schema = tp.schema();
+        println!("Schema for {}::{}: {:#?}", tp.system(), tp.name(), schema);
+        println!("Enabled tracepoint: {}::{}", tp.system(), tp.name());
+    }
+
+    println!("---After enabling tracepoints---");
+    tracepoint_example::test_trace(1, 2);
+    tracepoint_example::test_trace(9, 2); // should match
+    tracepoint_example::test_trace(3, 4);
+    tracepoint_example::test_trace(10, 4); // should match
+    tracepoint_example::test_trace(11, 6); // should match
+
+    print_trace_records(
+        &tracepoint_map,
+        &tracepoint_example::TRACE_CMDLINE_CACHE.lock().unwrap(),
+    );
+
+    for tracepoint in tracepoint_map.values() {
+        println!("{}", tracepoint.print_fmt());
+    }
+}

--- a/components/ax-tracepoint/my_section.ld
+++ b/components/ax-tracepoint/my_section.ld
@@ -1,0 +1,9 @@
+SECTIONS {
+    .tracepoint :
+    {
+        __start_tracepoint = .;
+        KEEP(*(.tracepoint))
+        __stop_tracepoint = .;
+    }
+}
+INSERT AFTER .data;

--- a/components/ax-tracepoint/src/basic_macro.rs
+++ b/components/ax-tracepoint/src/basic_macro.rs
@@ -44,6 +44,12 @@ impl<const SIZE: usize> TraceRecord<SIZE> {
     pub const fn as_bytes(&self) -> &[u8] {
         &self.bytes
     }
+
+    /// Returns the fully initialized record bytes with exclusive access.
+    #[doc(hidden)]
+    pub const fn as_bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
 }
 
 /// Define a tracepoint with the given parameters.
@@ -188,8 +194,9 @@ macro_rules! define_event_trace{
 
                 let event_handler = |event_func: &$crate::TraceEventFunc|{
                     if event_func.perf_enabled(){
+                        let ($([<__ $assign _value>],)*) = ($($value,)*);
                         let entry = [<__ $name _entry>] {
-                            $($assign: $value,)*
+                            $($assign: [<__ $assign _value>],)*
                         };
                         use $crate::KernelTraceOps;
                         let pid = $kops::current_pid();
@@ -200,11 +207,11 @@ macro_rules! define_event_trace{
                             common_pid: pid as i32,
                         };
 
-                        let event_record = [<encode_ $name _record>](
+                        let mut event_record = [<encode_ $name _record>](
                             common,
                             $(entry.$entry),*
                         );
-                        event_func.call(event_record.as_bytes());
+                        event_func.call(event_record.as_bytes_mut());
                     }
                 };
 
@@ -281,8 +288,9 @@ macro_rules! define_event_trace{
             #[allow(non_snake_case)]
             fn [<trace_default_ $name>]<F:$crate::KernelTraceOps>(tp_compiled_expr: Option<&$crate::tp_lexer::Compiled>, _data:& (dyn core::any::Any+Send+Sync), $($arg:$arg_type),* )
             {
+                let ($([<__ $assign _value>],)*) = ($($value,)*);
                 let entry = [<__ $name _entry>] {
-                    $($assign: $value,)*
+                    $($assign: [<__ $assign _value>],)*
                 };
 
                 let pid = F::current_pid();

--- a/components/ax-tracepoint/src/basic_macro.rs
+++ b/components/ax-tracepoint/src/basic_macro.rs
@@ -1,0 +1,324 @@
+/// Define a tracepoint with the given parameters.
+///
+/// This macro generates a tracepoint with the specified name, arguments, entry structure, assignment logic, identifier, and print format.
+/// # Parameters
+/// - `name`: The name of the tracepoint.
+/// - `TP_kops`: The kernel trace operations type. `[crate::KernelTraceOps]` is expected to be implemented for this type.
+/// - `TP_system`: The subsystem or system to which the tracepoint belongs.
+/// - `TP_PROTO`: The prototype of the tracepoint function.
+/// - `TP_STRUCT__entry`: The structure of the tracepoint entry.
+///   Every field must implement [`crate::TraceField`]. The macro gives the
+///   generated entry C layout and performs unaligned copies when formatting.
+/// - `TP_fast_assign`: The assignment logic for the tracepoint entry.
+/// - `TP_ident`: The identifier for the tracepoint entry.
+/// - `TP_printk`: The print format for the tracepoint.
+///
+/// # Example
+/// ```rust ignore
+/// use crate::KernelTraceOps;
+/// define_event_trace!(
+///     TEST2,
+///     TP_kops(Kops),
+///     TP_system(tracepoint_test),
+///     TP_PROTO(a: u32, b: u32),
+///     TP_STRUCT__entry{
+///           a: u32,
+///           b: u32,
+///     },
+///     TP_fast_assign{
+///           a:a,
+///           b:{
+///             // do something with b
+///             b
+///           }
+///     },
+///     TP_ident(__entry),
+///     TP_printk({
+///           // do something with __entry
+///           format!("Hello from tracepoint! a={}, b={}", __entry.a, __entry.b)
+///     })
+/// );
+/// ```
+#[macro_export]
+macro_rules! define_event_trace{
+    (
+        $name:ident,
+        TP_kops($kops:path),
+        TP_system($system:ident),
+        TP_PROTO($($arg:ident:$arg_type:ty),+ $(,)?),
+        TP_STRUCT__entry{$($entry:ident:$entry_type:ty),+ $(,)?},
+        TP_fast_assign{$($assign:ident:$value:expr),+ $(,)?},
+        TP_ident($tp_ident:ident),
+        TP_printk($fmt_expr: expr)
+    ) => {
+        $crate::paste::paste!{
+            #[allow(non_upper_case_globals)]
+            #[used]
+            static [<__ $name>]: $crate::TracePoint<$kops> = {
+                #[repr(C)]
+                #[derive(Clone, Copy)]
+                struct Entry {
+                    $($entry: $entry_type,)*
+                }
+                #[repr(C)]
+                struct FullEntry {
+                    common: $crate::TraceEntry,
+                    entry: Entry,
+                }
+                use $crate::tp_lexer::{schema,FieldClassifier};
+                const fn assert_trace_field<T: $crate::TraceField>() {}
+                $(assert_trace_field::<$entry_type>();)*
+                let schema = schema!(
+                    "common_type" => (u16::FIELD_TYPE, 0, 2),
+                    "common_flags" => (u8::FIELD_TYPE, 2, 1),
+                    "common_preempt_count" => (u8::FIELD_TYPE, 3, 1),
+                    "common_pid" => (i32::FIELD_TYPE, 4, 4),
+                    $(
+                        stringify!($entry) => (<$entry_type>::FIELD_TYPE, core::mem::offset_of!(FullEntry, entry.$entry), core::mem::size_of::<$entry_type>()),
+                    )*
+                );
+                $crate::TracePoint::new(stringify!($name), stringify!($system),[<trace_fmt_ $name>], [<trace_fmt_show $name>], schema)
+            };
+
+            #[inline(always)]
+            #[allow(non_snake_case)]
+            pub fn [<trace_ $name>]( $($arg:$arg_type),* ){
+                let default_handler = |ext_tp: &$crate::ExtTracePoint<$kops>, trace_default_func: &$crate::TraceDefaultFunc |{
+                    let func = trace_default_func.erased_func();
+                    let data = trace_default_func.data();
+                    if func as *const () as usize
+                        == [<trace_default_ $name>]::<$kops> as *const () as usize
+                    {
+                        let tp_compiled_expr = ext_tp.get_compiled_expr();
+                        let func = [<trace_default_ $name>]::<$kops>;
+                        func(tp_compiled_expr, data, $($arg),*);
+                    }else {
+                        // SAFETY: the only safe constructor for this callback
+                        // is the generated `register_trace_*` function below,
+                        // which erases this exact signature.
+                        let func = unsafe{core::mem::transmute::<fn(),fn(& (dyn core::any::Any+Send+Sync), $($arg_type),*)>(func)};
+                        func(data $(,$arg)*);
+                    }
+                };
+
+                let event_handler = |event_func: &$crate::TraceEventFunc|{
+                    if event_func.perf_enabled(){
+                        #[repr(C)]
+                        #[derive(Clone, Copy)]
+                        struct Entry {
+                            $($entry: $entry_type,)*
+                        }
+                        #[repr(C)]
+                        struct FullEntry {
+                            common: $crate::TraceEntry,
+                            entry: Entry,
+                        }
+
+                        let entry = Entry {
+                            $($assign: $value,)*
+                        };
+                        use $crate::KernelTraceOps;
+                        let pid = $kops::current_pid();
+                        let common = $crate::TraceEntry {
+                            common_type: [<__ $name>].id() as _,
+                            common_flags: [<__ $name>].flags(),
+                            common_preempt_count: 0,
+                            common_pid: pid as i32,
+                        };
+
+                        let full_entry = FullEntry {
+                            common,
+                            entry,
+                        };
+
+                        let event_buf = unsafe {
+                            core::slice::from_raw_parts(
+                                &full_entry as *const FullEntry as *const u8,
+                                core::mem::size_of::<FullEntry>(),
+                            )
+                        };
+                        event_func.call(event_buf);
+                    }
+                };
+
+                let raw_event_handler = |raw_func: &$crate::RawTraceEventFunc|{
+                    let args = [$($crate::ptr::AsU64::as_u64($arg)),*];
+                    raw_func.call(&args);
+                };
+
+                use $crate::KernelTraceOps;
+                if [<__ $name>].key_is_enabled() {
+                    $kops::read_tracepoint_state([<__ $name>].id(), |ext_tp|{
+                        for callback in ext_tp.callback_list() {
+                            match callback {
+                              $crate::TraceCallbackType::Default(default_func) => {
+                                  default_handler(ext_tp, default_func);
+                              },
+                              $crate::TraceCallbackType::Event(event_func) => {
+                                  event_handler(event_func);
+                              },
+                              $crate::TraceCallbackType::RawEvent(raw_func) => {
+                                  raw_event_handler(raw_func);
+                              }
+                            }
+                        }
+                    });
+                }
+            }
+
+            #[allow(non_snake_case)]
+            pub fn [<register_trace_ $name>](func: fn(& (dyn core::any::Any+Send+Sync), $($arg_type),*), data: alloc::boxed::Box<dyn core::any::Any+Send+Sync>) -> $crate::TraceCallbackType {
+                // SAFETY: dispatch restores this pointer to the same callback
+                // signature generated from this macro invocation.
+                let func = unsafe{core::mem::transmute::<fn(& (dyn core::any::Any+Send+Sync), $($arg_type),*), fn()>(func)};
+                // SAFETY: `func` was erased from the exact signature paired
+                // with this generated registration function.
+                let callback = unsafe { $crate::TraceDefaultFunc::from_erased(func, data) };
+
+                let callback_type = $crate::TraceCallbackType::Default(alloc::sync::Arc::new(callback));
+
+                use $crate::KernelTraceOps;
+                $kops::write_tracepoint_state([<__ $name>].id(), |ext_tp|{
+                    ext_tp.register(callback_type.clone());
+                });
+                callback_type
+            }
+
+            #[allow(non_snake_case)]
+            pub fn [<unregister_trace_ $name>](callback: $crate::TraceCallbackType){
+                use $crate::KernelTraceOps;
+                $kops::write_tracepoint_state([<__ $name>].id(), |ext_tp|{
+                    ext_tp.unregister(callback);
+                });
+            }
+
+
+            #[allow(non_upper_case_globals)]
+            #[unsafe(link_section = ".tracepoint")]
+            #[used]
+            static [<__ $name _meta>]: $crate::CommonTracePointMeta = {
+                // SAFETY: the erased pointer is stored next to the tracepoint
+                // generated by the same macro invocation and restored only by
+                // that invocation's dispatch path.
+                let print_func = unsafe {
+                    core::mem::transmute::<
+                        fn(Option<&$crate::tp_lexer::Compiled>, &(dyn core::any::Any + Send + Sync), $($arg_type),*),
+                        fn(),
+                    >([<trace_default_ $name>]::<$kops>)
+                };
+                // SAFETY: `print_func` is the exact erased default callback
+                // associated with this tracepoint.
+                unsafe { $crate::CommonTracePointMeta::new(&[<__ $name>], print_func) }
+            };
+
+            #[allow(non_snake_case)]
+            fn [<trace_default_ $name>]<F:$crate::KernelTraceOps>(tp_compiled_expr: Option<&$crate::tp_lexer::Compiled>, _data:& (dyn core::any::Any+Send+Sync), $($arg:$arg_type),* )
+            {
+                #[repr(C)]
+                #[derive(Clone, Copy)]
+                struct Entry {
+                    $($entry: $entry_type,)*
+                }
+                #[repr(C)]
+                struct FullEntry {
+                    common: $crate::TraceEntry,
+                    entry: Entry,
+                }
+
+                let entry = Entry {
+                    $($assign: $value,)*
+                };
+
+                let pid = F::current_pid();
+                let common = $crate::TraceEntry {
+                    common_type: [<__ $name>].id() as _,
+                    common_flags: [<__ $name>].flags(),
+                    common_preempt_count: 0,
+                    common_pid: pid as i32,
+                };
+
+                let full_entry = FullEntry {
+                    common,
+                    entry,
+                };
+
+                let event_buf = unsafe {
+                    core::slice::from_raw_parts(
+                        &full_entry as *const FullEntry as *const u8,
+                        core::mem::size_of::<FullEntry>(),
+                    )
+                };
+
+                if let Some(compiled_expr) = tp_compiled_expr {
+                    use $crate::tp_lexer::BufContext;
+                    let buf_ctx = BufContext::new(event_buf, &[<__ $name>].schema());
+                    if !compiled_expr.evaluate(&buf_ctx) {
+                        return;
+                    }
+                }
+
+                F::trace_cmdline_push(pid);
+                F::trace_pipe_push_raw_record(event_buf);
+            }
+
+            #[allow(non_snake_case)]
+            pub fn [<trace_fmt_ $name>](buf: &[u8]) -> core::result::Result<alloc::string::String, $crate::TraceParseError> {
+                #[repr(C)]
+                #[derive(Clone, Copy)]
+                struct Entry {
+                    $($entry: $entry_type,)*
+                }
+                let expected = core::mem::size_of::<Entry>();
+                if buf.len() < expected {
+                    return Err($crate::TraceParseError::PayloadTooShort {
+                        expected,
+                        actual: buf.len(),
+                    });
+                }
+                // SAFETY: `TraceField` requires every entry field to be Copy,
+                // drop-free, and valid for every bit pattern. The length check
+                // above covers the complete generated C-layout entry.
+                let entry = unsafe { core::ptr::read_unaligned(buf.as_ptr().cast::<Entry>()) };
+                let $tp_ident = &entry;
+                let fmt = alloc::format!("{}", $fmt_expr);
+                Ok(fmt)
+            }
+
+            #[allow(non_snake_case)]
+            pub fn [<trace_fmt_show $name>]()-> alloc::string::String {
+                let mut fmt = alloc::format!("format:
+\tfield: u16 common_type; offset: 0; size: 2; signed: 0;
+\tfield: u8 common_flags; offset: 2; size: 1; signed: 0;
+\tfield: u8 common_preempt_count; offset: 3; size: 1; signed: 0;
+\tfield: i32 common_pid; offset: 4; size: 4; signed: 1;
+
+");
+                fn is_signed<T>() -> bool {
+                    match core::any::type_name::<T>() {
+                        "i8" | "i16" | "i32" | "i64" | "i128" | "isize" => true,
+                        _ => false,
+                    }
+                }
+
+
+                #[repr(C)]
+                struct Entry {
+                    $($entry: $entry_type,)*
+                }
+                #[repr(C)]
+                struct FullEntry {
+                    common: $crate::TraceEntry,
+                    entry: Entry,
+                }
+
+                $(
+                    let offset = core::mem::offset_of!(FullEntry, entry.$entry);
+                    fmt.push_str(&alloc::format!("\tfield: {} {} offset: {}; size: {}; signed: {};\n",
+                        stringify!($entry_type), stringify!($entry), offset, core::mem::size_of::<$entry_type>(), if is_signed::<$entry_type>() { 1 } else { 0 }));
+                )*
+                fmt.push_str(&alloc::format!("\nprint fmt: \"{}\"", stringify!($fmt_expr)));
+                fmt
+            }
+        }
+    };
+}

--- a/components/ax-tracepoint/src/basic_macro.rs
+++ b/components/ax-tracepoint/src/basic_macro.rs
@@ -1,3 +1,51 @@
+use core::mem::size_of;
+
+use crate::TraceField;
+
+/// A zero-initialized byte record assembled by generated tracepoint encoders.
+#[doc(hidden)]
+pub struct TraceRecord<const SIZE: usize> {
+    bytes: [u8; SIZE],
+}
+
+impl<const SIZE: usize> TraceRecord<SIZE> {
+    /// Creates a record whose complete object representation is initialized.
+    #[doc(hidden)]
+    pub const fn new() -> Self {
+        Self { bytes: [0; SIZE] }
+    }
+
+    /// Writes one field at its generated C-layout offset.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the generated field range is outside the record.
+    #[doc(hidden)]
+    pub fn write_field<T: TraceField>(&mut self, offset: usize, value: T) {
+        let end = offset
+            .checked_add(size_of::<T>())
+            .expect("trace field range must not overflow");
+        assert!(end <= SIZE, "trace field must fit in its record");
+
+        // SAFETY: the checked range lies inside `bytes`, `write_unaligned`
+        // accepts its byte alignment, and `TraceField` guarantees that the
+        // copied value has no uninitialized padding bytes.
+        unsafe {
+            self.bytes
+                .as_mut_ptr()
+                .add(offset)
+                .cast::<T>()
+                .write_unaligned(value);
+        }
+    }
+
+    /// Returns the fully initialized record bytes.
+    #[doc(hidden)]
+    pub const fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+}
+
 /// Define a tracepoint with the given parameters.
 ///
 /// This macro generates a tracepoint with the specified name, arguments, entry structure, assignment logic, identifier, and print format.
@@ -52,19 +100,56 @@ macro_rules! define_event_trace{
         TP_printk($fmt_expr: expr)
     ) => {
         $crate::paste::paste!{
+            #[allow(non_camel_case_types)]
+            #[repr(C)]
+            #[derive(Clone, Copy)]
+            struct [<__ $name _entry>] {
+                $($entry: $entry_type,)*
+            }
+
+            #[allow(non_camel_case_types)]
+            #[repr(C)]
+            struct [<__ $name _full_entry>] {
+                common: $crate::TraceEntry,
+                entry: [<__ $name _entry>],
+            }
+
+            fn [<encode_ $name _record>](
+                common: $crate::TraceEntry,
+                $($entry: $entry_type),*
+            ) -> $crate::TraceRecord<{
+                core::mem::size_of::<[<__ $name _full_entry>]>()
+            }> {
+                type FullEntry = [<__ $name _full_entry>];
+                let mut record = $crate::TraceRecord::new();
+                record.write_field(
+                    core::mem::offset_of!(FullEntry, common.common_type),
+                    common.common_type,
+                );
+                record.write_field(
+                    core::mem::offset_of!(FullEntry, common.common_flags),
+                    common.common_flags,
+                );
+                record.write_field(
+                    core::mem::offset_of!(FullEntry, common.common_preempt_count),
+                    common.common_preempt_count,
+                );
+                record.write_field(
+                    core::mem::offset_of!(FullEntry, common.common_pid),
+                    common.common_pid,
+                );
+                $(
+                    record.write_field(
+                        core::mem::offset_of!(FullEntry, entry.$entry),
+                        $entry,
+                    );
+                )*
+                record
+            }
+
             #[allow(non_upper_case_globals)]
             #[used]
             static [<__ $name>]: $crate::TracePoint<$kops> = {
-                #[repr(C)]
-                #[derive(Clone, Copy)]
-                struct Entry {
-                    $($entry: $entry_type,)*
-                }
-                #[repr(C)]
-                struct FullEntry {
-                    common: $crate::TraceEntry,
-                    entry: Entry,
-                }
                 use $crate::tp_lexer::{schema,FieldClassifier};
                 const fn assert_trace_field<T: $crate::TraceField>() {}
                 $(assert_trace_field::<$entry_type>();)*
@@ -74,7 +159,7 @@ macro_rules! define_event_trace{
                     "common_preempt_count" => (u8::FIELD_TYPE, 3, 1),
                     "common_pid" => (i32::FIELD_TYPE, 4, 4),
                     $(
-                        stringify!($entry) => (<$entry_type>::FIELD_TYPE, core::mem::offset_of!(FullEntry, entry.$entry), core::mem::size_of::<$entry_type>()),
+                        stringify!($entry) => (<$entry_type>::FIELD_TYPE, core::mem::offset_of!([<__ $name _full_entry>], entry.$entry), core::mem::size_of::<$entry_type>()),
                     )*
                 );
                 $crate::TracePoint::new(stringify!($name), stringify!($system),[<trace_fmt_ $name>], [<trace_fmt_show $name>], schema)
@@ -103,18 +188,7 @@ macro_rules! define_event_trace{
 
                 let event_handler = |event_func: &$crate::TraceEventFunc|{
                     if event_func.perf_enabled(){
-                        #[repr(C)]
-                        #[derive(Clone, Copy)]
-                        struct Entry {
-                            $($entry: $entry_type,)*
-                        }
-                        #[repr(C)]
-                        struct FullEntry {
-                            common: $crate::TraceEntry,
-                            entry: Entry,
-                        }
-
-                        let entry = Entry {
+                        let entry = [<__ $name _entry>] {
                             $($assign: $value,)*
                         };
                         use $crate::KernelTraceOps;
@@ -126,18 +200,11 @@ macro_rules! define_event_trace{
                             common_pid: pid as i32,
                         };
 
-                        let full_entry = FullEntry {
+                        let event_record = [<encode_ $name _record>](
                             common,
-                            entry,
-                        };
-
-                        let event_buf = unsafe {
-                            core::slice::from_raw_parts(
-                                &full_entry as *const FullEntry as *const u8,
-                                core::mem::size_of::<FullEntry>(),
-                            )
-                        };
-                        event_func.call(event_buf);
+                            $(entry.$entry),*
+                        );
+                        event_func.call(event_record.as_bytes());
                     }
                 };
 
@@ -214,18 +281,7 @@ macro_rules! define_event_trace{
             #[allow(non_snake_case)]
             fn [<trace_default_ $name>]<F:$crate::KernelTraceOps>(tp_compiled_expr: Option<&$crate::tp_lexer::Compiled>, _data:& (dyn core::any::Any+Send+Sync), $($arg:$arg_type),* )
             {
-                #[repr(C)]
-                #[derive(Clone, Copy)]
-                struct Entry {
-                    $($entry: $entry_type,)*
-                }
-                #[repr(C)]
-                struct FullEntry {
-                    common: $crate::TraceEntry,
-                    entry: Entry,
-                }
-
-                let entry = Entry {
+                let entry = [<__ $name _entry>] {
                     $($assign: $value,)*
                 };
 
@@ -237,17 +293,11 @@ macro_rules! define_event_trace{
                     common_pid: pid as i32,
                 };
 
-                let full_entry = FullEntry {
+                let event_record = [<encode_ $name _record>](
                     common,
-                    entry,
-                };
-
-                let event_buf = unsafe {
-                    core::slice::from_raw_parts(
-                        &full_entry as *const FullEntry as *const u8,
-                        core::mem::size_of::<FullEntry>(),
-                    )
-                };
+                    $(entry.$entry),*
+                );
+                let event_buf = event_record.as_bytes();
 
                 if let Some(compiled_expr) = tp_compiled_expr {
                     use $crate::tp_lexer::BufContext;
@@ -263,11 +313,7 @@ macro_rules! define_event_trace{
 
             #[allow(non_snake_case)]
             pub fn [<trace_fmt_ $name>](buf: &[u8]) -> core::result::Result<alloc::string::String, $crate::TraceParseError> {
-                #[repr(C)]
-                #[derive(Clone, Copy)]
-                struct Entry {
-                    $($entry: $entry_type,)*
-                }
+                type Entry = [<__ $name _entry>];
                 let expected = core::mem::size_of::<Entry>();
                 if buf.len() < expected {
                     return Err($crate::TraceParseError::PayloadTooShort {
@@ -299,17 +345,7 @@ macro_rules! define_event_trace{
                         _ => false,
                     }
                 }
-
-
-                #[repr(C)]
-                struct Entry {
-                    $($entry: $entry_type,)*
-                }
-                #[repr(C)]
-                struct FullEntry {
-                    common: $crate::TraceEntry,
-                    entry: Entry,
-                }
+                type FullEntry = [<__ $name _full_entry>];
 
                 $(
                     let offset = core::mem::offset_of!(FullEntry, entry.$entry);

--- a/components/ax-tracepoint/src/lib.rs
+++ b/components/ax-tracepoint/src/lib.rs
@@ -25,6 +25,8 @@ use alloc::{
 };
 use core::mem::{align_of, size_of};
 
+#[doc(hidden)]
+pub use basic_macro::TraceRecord;
 pub use paste;
 pub use point::{
     CommonTracePointMeta, ExtTracePoint, RawTraceEventFunc, TraceCallbackType, TraceDefaultFunc,

--- a/components/ax-tracepoint/src/lib.rs
+++ b/components/ax-tracepoint/src/lib.rs
@@ -1,0 +1,398 @@
+//! A Rust library for defining and managing tracepoints in a no_std environment.
+//! It provides macros and structures to create tracepoints, manage their state,
+//! and handle trace events efficiently.
+//! The library is designed to be lightweight and suitable for embedded systems or
+//! kernel-level programming where the standard library is not available.
+//! It leverages Rust's powerful macro system to simplify the creation and management of tracepoints.
+//! The macros provided by this library allow for easy insertion of tracepoints into code with minimal overhead.
+#![deny(missing_docs)]
+#![no_std]
+#![allow(clippy::new_without_default)]
+extern crate alloc;
+
+mod basic_macro;
+mod point;
+pub mod ptr;
+mod trace_pipe;
+
+use alloc::{
+    boxed::Box,
+    collections::BTreeMap,
+    format,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use core::mem::{align_of, size_of};
+
+pub use paste;
+pub use point::{
+    CommonTracePointMeta, ExtTracePoint, RawTraceEventFunc, TraceCallbackType, TraceDefaultFunc,
+    TraceEntry, TraceEventFunc, TraceField, TracePoint,
+};
+pub use tp_lexer;
+use tp_lexer::compile_with_schema;
+pub use trace_pipe::{
+    TraceCmdLineCache, TraceCmdLineCacheSnapshot, TraceEntryParser, TraceParseError, TracePipeOps,
+    TracePipeRaw, TracePipeRecord, TracePipeSnapshot,
+};
+
+/// KernelTraceOps trait provides kernel-level operations for tracing.
+pub trait KernelTraceOps: Send + Sync + 'static {
+    /// Get the current process ID.
+    fn current_pid() -> u32;
+    /// Push a raw record to the trace pipe.
+    fn trace_pipe_push_raw_record(buf: &[u8]);
+    /// Cache the process name for a given PID.
+    fn trace_cmdline_push(pid: u32);
+    /// Access runtime state for a tracepoint ID.
+    ///
+    /// Implementations may hold a read-side lock while executing `f`. The
+    /// tracing fast path may call user callbacks from inside this closure, so
+    /// callbacks must not call APIs that need `write_tracepoint_state`, such as
+    /// callback registration, callback unregistration, or filter updates.
+    ///
+    /// If the read-side implementation is non-reentrant, callbacks must also
+    /// avoid recursively triggering tracepoints backed by the same state
+    /// registry. Violating these restrictions may deadlock.
+    ///
+    /// Implementations based on RCU, snapshots, or another non-blocking
+    /// read-side mechanism may relax these restrictions.
+    fn read_tracepoint_state<R>(id: u32, f: impl FnOnce(&ExtTracePoint<Self>) -> R) -> R;
+    /// Mutably access runtime state for a tracepoint ID.
+    ///
+    /// This is a management-path API. If `read_tracepoint_state` can execute
+    /// callbacks while holding a read-side lock, this method must not be called
+    /// from those callbacks. The update closure must not recursively invoke
+    /// `write_tracepoint_state` for the same state unless the implementation
+    /// explicitly provides a reentrant writer.
+    fn write_tracepoint_state<R>(id: u32, f: impl FnOnce(&mut ExtTracePoint<Self>) -> R) -> R;
+}
+
+/// TracePointMap is a mapping from tracepoint IDs to TracePoint references.
+#[derive(Debug)]
+pub struct TracePointMap<K: KernelTraceOps>(BTreeMap<u32, &'static TracePoint<K>>);
+
+impl<K: KernelTraceOps> TracePointMap<K> {
+    /// Create a new TracePointMap
+    pub const fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Returns the tracepoint registered for `id`.
+    pub fn get(&self, id: &u32) -> Option<&'static TracePoint<K>> {
+        self.0.get(id).copied()
+    }
+
+    /// Iterates over tracepoint IDs and descriptors in ID order.
+    pub fn iter(&self) -> impl Iterator<Item = (&u32, &'static TracePoint<K>)> + '_ {
+        self.0.iter().map(|(id, tracepoint)| (id, *tracepoint))
+    }
+
+    /// Iterates over tracepoint descriptors in ID order.
+    pub fn values(&self) -> impl Iterator<Item = &'static TracePoint<K>> + '_ {
+        self.0.values().copied()
+    }
+
+    /// Returns the number of registered tracepoints.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns whether the map contains no tracepoints.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn insert(&mut self, id: u32, tracepoint: &'static TracePoint<K>) {
+        self.0.insert(id, tracepoint);
+    }
+}
+
+/// TracePointFormatFile provides a way to get the format of the tracepoint.
+#[derive(Debug, Clone)]
+pub struct TracePointFormatFile<K: KernelTraceOps> {
+    tracepoint: &'static TracePoint<K>,
+}
+
+impl<K: KernelTraceOps> TracePointFormatFile<K> {
+    /// Create a new TracePointFormatFile for the given tracepoint.
+    pub fn new(tracepoint: &'static TracePoint<K>) -> Self {
+        Self { tracepoint }
+    }
+
+    /// Read the tracepoint format
+    ///
+    /// Returns the format string of the tracepoint.
+    pub fn read(&self) -> String {
+        self.tracepoint.print_fmt()
+    }
+}
+
+/// TracePointEnableFile provides a way to enable or disable the default trace pipe callback.
+#[derive(Debug, Clone)]
+pub struct TracePointEnableFile;
+
+impl TracePointEnableFile {
+    /// Create a new TracePointEnableFile
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    /// Read whether callback dispatch is enabled.
+    ///
+    /// Returns true if the tracepoint is enabled, false otherwise.
+    pub fn read<K: KernelTraceOps>(&self, tracepoint: &'static TracePoint<K>) -> &'static str {
+        if tracepoint.key_is_enabled() {
+            "1\n"
+        } else {
+            "0\n"
+        }
+    }
+    /// Register or unregister the default trace pipe callback.
+    ///
+    /// The runtime-state publisher is responsible for making the resulting
+    /// callback gate agree with the newly published callback set.
+    pub fn write<K: KernelTraceOps>(&self, ext_tracepoint: &mut ExtTracePoint<K>, enable: char) {
+        match enable {
+            '1' => {
+                let default_callback = ext_tracepoint.default_callback();
+                ext_tracepoint.register(TraceCallbackType::Default(default_callback));
+            }
+            '0' => {
+                let default_callback = ext_tracepoint.default_callback();
+                ext_tracepoint.unregister(TraceCallbackType::Default(default_callback));
+            }
+            _ => {
+                log::warn!("Invalid value for tracepoint enable: {enable}");
+            }
+        }
+    }
+}
+
+/// TracePointIdFile provides a way to read the tracepoint ID.
+#[derive(Debug, Clone)]
+pub struct TracePointIdFile<K: KernelTraceOps> {
+    tracepoint: &'static TracePoint<K>,
+}
+
+impl<K: KernelTraceOps> TracePointIdFile<K> {
+    /// Create a new TracePointIdFile with the given tracepoint.
+    pub fn new(tracepoint: &'static TracePoint<K>) -> Self {
+        Self { tracepoint }
+    }
+
+    /// Read the tracepoint ID
+    ///
+    /// Returns the ID of the tracepoint.
+    pub fn read(&self) -> String {
+        format!("{}\n", self.tracepoint.id())
+    }
+}
+
+/// An error produced while updating a tracepoint filter.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum TraceFilterError {
+    /// The supplied filter expression was empty.
+    #[error("filter expression is empty")]
+    EmptyExpression,
+    /// The supplied filter expression could not be compiled against the event schema.
+    #[error("filter expression failed to compile")]
+    CompileExpression,
+}
+
+/// TraceFilterFile provides a way to set filters on the tracepoint.
+#[derive(Debug)]
+pub struct TraceFilterFile {
+    filter_expr: Option<String>,
+    pre_error: Option<String>,
+}
+
+impl TraceFilterFile {
+    /// Create a new TraceFilterFile with no filter expression and no pre-error.
+    pub fn new() -> Self {
+        Self {
+            filter_expr: None,
+            pre_error: None,
+        }
+    }
+
+    /// Read the tracepoint filter.
+    ///
+    /// Returns the current filter expression or an error message if there was a pre-error.
+    pub fn read(&self) -> String {
+        if let Some(err) = self.pre_error.as_ref() {
+            return err.clone();
+        }
+        if let Some(filter) = self.filter_expr.as_ref() {
+            filter.clone()
+        } else {
+            "none\n".to_string()
+        }
+    }
+
+    /// Write a new filter expression to the tracepoint.
+    pub fn write<K: KernelTraceOps>(
+        &mut self,
+        ext_tracepoint: &mut ExtTracePoint<K>,
+        filter: &str,
+    ) -> Result<(), TraceFilterError> {
+        let filter = filter.trim();
+        if filter.is_empty() {
+            self.pre_error = Some("filter expression is empty\n".to_string());
+            return Err(TraceFilterError::EmptyExpression);
+        }
+
+        if filter == "0" {
+            // clear the filter and pre-error
+            self.filter_expr = None;
+            self.pre_error = None;
+            ext_tracepoint.set_compiled_expr(None);
+            Ok(())
+        } else {
+            let schema = ext_tracepoint.trace_point().schema();
+            let res = compile_with_schema(filter, *schema);
+            match res {
+                Ok(compiled_expr) => {
+                    self.filter_expr = Some(filter.to_string());
+                    self.pre_error = None;
+                    ext_tracepoint.set_compiled_expr(Some(compiled_expr));
+                    Ok(())
+                }
+                Err(mut e) => {
+                    e.message.push('\n');
+                    self.pre_error = Some(e.message);
+                    Err(TraceFilterError::CompileExpression)
+                }
+            }
+        }
+    }
+}
+
+/// An error produced while discovering linker-collected tracepoints.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum TraceInitError {
+    /// The linker exported the section end before its start.
+    #[error("tracepoint section end precedes its start")]
+    InvalidSectionBounds,
+    /// The linker section start does not satisfy the metadata alignment.
+    #[error("tracepoint section start {address:#x} is not aligned to {alignment} bytes")]
+    MisalignedSection {
+        /// Address exported as `__start_tracepoint`.
+        address: usize,
+        /// Required metadata alignment.
+        alignment: usize,
+    },
+    /// The linker section byte length is not a whole metadata entry count.
+    #[error("tracepoint section size {bytes} is not divisible by entry size {entry_size}")]
+    InvalidSectionSize {
+        /// Section size in bytes.
+        bytes: usize,
+        /// Size of one metadata entry.
+        entry_size: usize,
+    },
+    /// More tracepoints were linked than the 32-bit event ID can represent.
+    #[error("too many tracepoints for a 32-bit event ID")]
+    TooManyTracepoints,
+}
+
+unsafe extern "C" {
+    fn __start_tracepoint();
+    fn __stop_tracepoint();
+}
+
+/// Initialize the tracing events
+///
+/// The K type parameter is the kernel trace operations type used for performing kernel-level operations.
+///
+/// Returns the static tracepoint map and runtime tracepoint states.
+///
+/// The returned [`TracePointMap`] maps tracepoint IDs to static tracepoint
+/// metadata. The returned [`ExtTracePoint`] values contain runtime callback and
+/// filter state. The caller must install these runtime states into the
+/// [`KernelTraceOps::read_tracepoint_state`] and
+/// [`KernelTraceOps::write_tracepoint_state`] backing registry before enabling
+/// or triggering tracepoints.
+///
+/// The final linker script must define `__start_tracepoint` and
+/// `__stop_tracepoint`, keep all `.tracepoint` input sections between them,
+/// and align the start for [`CommonTracePointMeta`]. The supplied
+/// `my_section.ld` is a reference fragment.
+pub fn global_init_events<K: KernelTraceOps>()
+-> Result<(TracePointMap<K>, Vec<ExtTracePoint<K>>), TraceInitError> {
+    let tracepoint_data_start = __start_tracepoint as *const () as usize;
+    let tracepoint_data_end = __stop_tracepoint as *const () as usize;
+    log::info!(
+        "tracepoint_data_start: {:#x}, tracepoint_data_end: {:#x}",
+        tracepoint_data_start,
+        tracepoint_data_end
+    );
+    let section_bytes = tracepoint_data_end
+        .checked_sub(tracepoint_data_start)
+        .ok_or(TraceInitError::InvalidSectionBounds)?;
+    let metadata_alignment = align_of::<CommonTracePointMeta>();
+    if !tracepoint_data_start.is_multiple_of(metadata_alignment) {
+        return Err(TraceInitError::MisalignedSection {
+            address: tracepoint_data_start,
+            alignment: metadata_alignment,
+        });
+    }
+    let metadata_size = size_of::<CommonTracePointMeta>();
+    if !section_bytes.is_multiple_of(metadata_size) {
+        return Err(TraceInitError::InvalidSectionSize {
+            bytes: section_bytes,
+            entry_size: metadata_size,
+        });
+    }
+    let tracepoint_data_len = section_bytes / metadata_size;
+    // SAFETY: the bounds, alignment, and whole-entry length are checked above.
+    // The macro emits this exact `repr(C)` metadata type into `.tracepoint`,
+    // and the linker contract keeps those entries in the exported range.
+    let linked_metadata = unsafe {
+        core::slice::from_raw_parts(
+            tracepoint_data_start as *const CommonTracePointMeta,
+            tracepoint_data_len,
+        )
+    };
+    let mut tracepoint_data = linked_metadata
+        .iter()
+        .filter(|metadata| metadata.belongs_to::<K>())
+        .collect::<Vec<_>>();
+    tracepoint_data.sort_by(|a, b| {
+        // SAFETY: the iterator above retained only metadata tagged with `K`.
+        let a = unsafe { a.trace_point::<K>() };
+        // SAFETY: the iterator above retained only metadata tagged with `K`.
+        let b = unsafe { b.trace_point::<K>() };
+        a.name().cmp(b.name()).then(a.system().cmp(b.system()))
+    });
+    log::info!("tracepoint_data_len: {tracepoint_data_len}");
+
+    let mut tp_map = TracePointMap::new();
+    let mut ext_tps = Vec::with_capacity(tracepoint_data_len);
+
+    for (index, tracepoint_meta) in tracepoint_data.into_iter().enumerate() {
+        // SAFETY: `tracepoint_data` contains only metadata tagged with `K`.
+        let tracepoint = unsafe { tracepoint_meta.trace_point::<K>() };
+        let id = u32::try_from(index).map_err(|_| TraceInitError::TooManyTracepoints)?;
+        tracepoint.set_id(id);
+
+        // SAFETY: `CommonTracePointMeta::new` accepts only the erased default
+        // callback paired with this exact generated tracepoint.
+        let default_callback = Arc::new(unsafe {
+            TraceDefaultFunc::from_erased(tracepoint_meta.print_func(), Box::new(()))
+        });
+
+        let ext_tracepoint = ExtTracePoint::new(tracepoint, default_callback);
+
+        log::info!(
+            "tracepoint registered: {}:{}",
+            tracepoint.system(),
+            tracepoint.name(),
+        );
+
+        tp_map.insert(id, tracepoint);
+        ext_tps.push(ext_tracepoint);
+    }
+
+    Ok((tp_map, ext_tps))
+}

--- a/components/ax-tracepoint/src/point.rs
+++ b/components/ax-tracepoint/src/point.rs
@@ -49,15 +49,18 @@ impl TraceEntry {
 ///
 /// # Safety
 ///
-/// Every bit pattern must be a valid value of the implementing type, and the
-/// type must not own resources that require drop. The event formatter uses
-/// this contract to perform an unaligned copy from a trace record.
+/// Every bit pattern must be a valid value of the implementing type, the type
+/// must not own resources that require drop, and its object representation
+/// must not contain padding bytes. Generated event encoders copy each field's
+/// complete object representation into a zero-initialized record, while event
+/// formatters perform an unaligned copy from that record.
 pub unsafe trait TraceField: FieldClassifier + Copy {}
 
 macro_rules! impl_trace_field {
     ($($type:ty),+ $(,)?) => {
         $(
-            // SAFETY: integer primitives accept every bit pattern and are Copy.
+            // SAFETY: integer primitives accept every bit pattern, are Copy,
+            // and contain no padding bytes.
             unsafe impl TraceField for $type {}
         )+
     };
@@ -66,8 +69,8 @@ macro_rules! impl_trace_field {
 impl_trace_field!(i8, i16, i32, i64, i128, isize);
 impl_trace_field!(u8, u16, u32, u64, u128, usize);
 
-// SAFETY: an array is byte-valid and Copy when each element is byte-valid and
-// Copy, and arrays do not add an invalid bit pattern of their own.
+// SAFETY: an array is byte-valid, Copy, and padding-free when each element has
+// those properties; arrays do not add padding between elements.
 unsafe impl<T: TraceField, const LEN: usize> TraceField for [T; LEN] {}
 
 /// Linker-collected metadata for one tracepoint.
@@ -497,6 +500,26 @@ mod tests {
         }
     }
 
+    struct PaddingKernel;
+
+    impl KernelTraceOps for PaddingKernel {
+        fn current_pid() -> u32 {
+            0
+        }
+
+        fn trace_pipe_push_raw_record(_: &[u8]) {}
+
+        fn trace_cmdline_push(_: u32) {}
+
+        fn read_tracepoint_state<R>(_: u32, _: impl FnOnce(&ExtTracePoint<Self>) -> R) -> R {
+            panic!("test has no tracepoint registry")
+        }
+
+        fn write_tracepoint_state<R>(_: u32, _: impl FnOnce(&mut ExtTracePoint<Self>) -> R) -> R {
+            panic!("test has no tracepoint registry")
+        }
+    }
+
     crate::define_event_trace!(
         test_kernel_event,
         TP_kops(TestKernel),
@@ -517,6 +540,26 @@ mod tests {
         TP_fast_assign { value: value },
         TP_ident(entry),
         TP_printk(format_args!("value={}", entry.value))
+    );
+
+    crate::define_event_trace!(
+        padded_kernel_event,
+        TP_kops(PaddingKernel),
+        TP_system(ax_tracepoint_test),
+        TP_PROTO(sequence: u64, state: u32),
+        TP_STRUCT__entry {
+            sequence: u64,
+            state: u32,
+        },
+        TP_fast_assign {
+            sequence: sequence,
+            state: state,
+        },
+        TP_ident(entry),
+        TP_printk(format_args!(
+            "sequence={} state={}",
+            entry.sequence, entry.state
+        ))
     );
 
     fn format_entry(_: &[u8]) -> Result<String, TraceParseError> {
@@ -672,6 +715,34 @@ mod tests {
                 expected: size_of::<TraceEntry>(),
                 actual: 0,
             })
+        );
+    }
+
+    #[test]
+    fn generated_record_zeroes_c_layout_padding() {
+        let record = encode_padded_kernel_event_record(
+            TraceEntry {
+                common_type: 7,
+                common_flags: 0,
+                common_preempt_count: 0,
+                common_pid: 11,
+            },
+            0x1122_3344_5566_7788,
+            0xaabb_ccdd,
+        );
+        let padding_start =
+            core::mem::offset_of!(__padded_kernel_event_full_entry, entry.state) + size_of::<u32>();
+        let padding_end = size_of::<__padded_kernel_event_full_entry>();
+
+        assert!(
+            padding_start < padding_end,
+            "the regression layout must contain tail padding"
+        );
+        assert!(
+            record.as_bytes()[padding_start..padding_end]
+                .iter()
+                .all(|byte| *byte == 0),
+            "all bytes exposed to trace callbacks must be initialized"
         );
     }
 }

--- a/components/ax-tracepoint/src/point.rs
+++ b/components/ax-tracepoint/src/point.rs
@@ -9,7 +9,7 @@ use tp_lexer::{Compiled, FieldClassifier, Schema};
 
 use crate::{KernelTraceOps, TraceParseError};
 
-type TraceEventCallback = dyn Fn(&[u8], &(dyn Any + Send + Sync)) + Send + Sync;
+type TraceEventCallback = dyn Fn(&mut [u8], &(dyn Any + Send + Sync)) + Send + Sync;
 type RawTraceEventCallback = dyn Fn(&[u64], &(dyn Any + Send + Sync)) + Send + Sync;
 
 /// A trace entry structure that holds metadata about a trace event.
@@ -134,7 +134,8 @@ impl CommonTracePointMeta {
 /// A structure representing a registered tracepoint callback function.
 pub struct TraceEventFunc {
     /// The callback function to be called when the tracepoint is hit.
-    /// The function takes a byte slice representing the raw trace entry data and a reference to any associated data.
+    /// The function receives exclusive access to one generated event record
+    /// and a reference to its associated data.
     func: Box<TraceEventCallback>,
     /// The data associated with the callback function.
     data: Box<dyn Any + Send + Sync>,
@@ -152,7 +153,7 @@ impl TraceEventFunc {
     }
 
     /// Calls the callback function with the provided trace entry data.
-    pub fn call(&self, entry: &[u8]) {
+    pub fn call(&self, entry: &mut [u8]) {
         (self.func)(entry, &self.data);
     }
 
@@ -454,7 +455,7 @@ mod tests {
 
     use tp_lexer::{FieldClassifier, Schema};
 
-    use super::{ExtTracePoint, TraceCallbackType, TraceDefaultFunc, TracePoint};
+    use super::{ExtTracePoint, TraceCallbackType, TraceDefaultFunc, TraceEventFunc, TracePoint};
     use crate::{
         KernelTraceOps, TraceEntry, TraceEntryParser, TraceParseError, TracePipeRecord,
         TracePointMap,
@@ -582,6 +583,21 @@ mod tests {
         print_format,
         Schema::new(TEST_FIELDS),
     );
+
+    #[test]
+    fn cooked_event_callback_receives_an_exclusive_record() {
+        let callback = TraceEventFunc::new(
+            Box::new(|entry, _data| {
+                entry[0] = 0xa5;
+            }),
+            Box::new(()),
+        );
+        let mut record = [0_u8; 1];
+
+        callback.call(&mut record);
+
+        assert_eq!(record, [0xa5]);
+    }
 
     #[test]
     fn callback_state_changes_are_side_effect_free_until_the_owner_publishes_the_gate() {

--- a/components/ax-tracepoint/src/point.rs
+++ b/components/ax-tracepoint/src/point.rs
@@ -1,0 +1,677 @@
+use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
+use core::{
+    any::{Any, TypeId},
+    marker::PhantomData,
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+};
+
+use tp_lexer::{Compiled, FieldClassifier, Schema};
+
+use crate::{KernelTraceOps, TraceParseError};
+
+type TraceEventCallback = dyn Fn(&[u8], &(dyn Any + Send + Sync)) + Send + Sync;
+type RawTraceEventCallback = dyn Fn(&[u64], &(dyn Any + Send + Sync)) + Send + Sync;
+
+/// A trace entry structure that holds metadata about a trace event.
+#[derive(Clone, Copy, Debug)]
+#[repr(C)]
+pub struct TraceEntry {
+    /// The type of the trace event, typically the tracepoint ID.
+    pub common_type: u16,
+    /// Flags associated with the trace event.
+    pub common_flags: u8,
+    /// The preemption count at the time of the event.
+    pub common_preempt_count: u8,
+    /// The PID of the process that generated the event.
+    pub common_pid: i32,
+}
+
+impl TraceEntry {
+    /// Returns a formatted string representing the latency and preemption state.
+    pub fn trace_print_lat_fmt(&self) -> String {
+        // todo!("Implement IRQs off logic");
+        let irqs_off = '.';
+        let resched = '.';
+        let hardsoft_irq = '.';
+        let mut preempt_low = '.';
+        if self.common_preempt_count & 0xf != 0 {
+            preempt_low = ((b'0') + (self.common_preempt_count & 0xf)) as char;
+        }
+        let mut preempt_high = '.';
+        if self.common_preempt_count >> 4 != 0 {
+            preempt_high = ((b'0') + (self.common_preempt_count >> 4)) as char;
+        }
+        format!("{irqs_off}{resched}{hardsoft_irq}{preempt_low}{preempt_high}")
+    }
+}
+
+/// A field type that can be copied from an arbitrary initialized byte buffer.
+///
+/// # Safety
+///
+/// Every bit pattern must be a valid value of the implementing type, and the
+/// type must not own resources that require drop. The event formatter uses
+/// this contract to perform an unaligned copy from a trace record.
+pub unsafe trait TraceField: FieldClassifier + Copy {}
+
+macro_rules! impl_trace_field {
+    ($($type:ty),+ $(,)?) => {
+        $(
+            // SAFETY: integer primitives accept every bit pattern and are Copy.
+            unsafe impl TraceField for $type {}
+        )+
+    };
+}
+
+impl_trace_field!(i8, i16, i32, i64, i128, isize);
+impl_trace_field!(u8, u16, u32, u64, u128, usize);
+
+// SAFETY: an array is byte-valid and Copy when each element is byte-valid and
+// Copy, and arrays do not add an invalid bit pattern of their own.
+unsafe impl<T: TraceField, const LEN: usize> TraceField for [T; LEN] {}
+
+/// Linker-collected metadata for one tracepoint.
+#[doc(hidden)]
+#[repr(C)]
+pub struct CommonTracePointMeta {
+    kernel_type_id: fn() -> TypeId,
+    trace_point: *const (),
+    print_func: fn(),
+}
+
+// SAFETY: metadata is immutable after link. `trace_point` is produced only
+// from a shared reference to a `TracePoint<K>`, which is Sync by the
+// `KernelTraceOps: Send + Sync` bound, and function pointers are Sync.
+unsafe impl Sync for CommonTracePointMeta {}
+
+fn kernel_type_id<K: KernelTraceOps>() -> TypeId {
+    TypeId::of::<K>()
+}
+
+impl CommonTracePointMeta {
+    /// Constructs linker metadata from a generated tracepoint callback.
+    ///
+    /// # Safety
+    ///
+    /// `print_func` must be the type-erased form of the default callback
+    /// generated for `trace_point`. It may only be restored to that exact
+    /// signature by the macro that defined the tracepoint.
+    #[doc(hidden)]
+    pub const unsafe fn new<K: KernelTraceOps>(
+        trace_point: &'static TracePoint<K>,
+        print_func: fn(),
+    ) -> Self {
+        Self {
+            kernel_type_id: kernel_type_id::<K>,
+            trace_point: core::ptr::from_ref(trace_point).cast(),
+            print_func,
+        }
+    }
+
+    pub(crate) fn belongs_to<K: KernelTraceOps>(&self) -> bool {
+        (self.kernel_type_id)() == TypeId::of::<K>()
+    }
+
+    /// Restores the tracepoint type recorded by [`Self::belongs_to`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must first verify that `self.belongs_to::<K>()` is true.
+    pub(crate) unsafe fn trace_point<K: KernelTraceOps>(&self) -> &'static TracePoint<K> {
+        // SAFETY: the caller verified the type tag installed from the same
+        // `TracePoint<K>` reference by `new`.
+        unsafe { &*self.trace_point.cast::<TracePoint<K>>() }
+    }
+
+    pub(crate) const fn print_func(&self) -> fn() {
+        self.print_func
+    }
+}
+
+/// A structure representing a registered tracepoint callback function.
+pub struct TraceEventFunc {
+    /// The callback function to be called when the tracepoint is hit.
+    /// The function takes a byte slice representing the raw trace entry data and a reference to any associated data.
+    func: Box<TraceEventCallback>,
+    /// The data associated with the callback function.
+    data: Box<dyn Any + Send + Sync>,
+    perf_enable: AtomicBool,
+}
+
+impl TraceEventFunc {
+    /// Creates a new TraceEventFunc instance.
+    pub fn new(func: Box<TraceEventCallback>, data: Box<dyn Any + Send + Sync>) -> Self {
+        Self {
+            func,
+            data,
+            perf_enable: AtomicBool::new(false),
+        }
+    }
+
+    /// Calls the callback function with the provided trace entry data.
+    pub fn call(&self, entry: &[u8]) {
+        (self.func)(entry, &self.data);
+    }
+
+    /// Enable or disable perf event for this callback function.
+    pub fn set_perf_enable(&self, enable: bool) {
+        self.perf_enable.store(enable, Ordering::Relaxed);
+    }
+
+    /// Returns true if perf event is enabled for this callback function, false otherwise.
+    pub fn perf_enabled(&self) -> bool {
+        self.perf_enable.load(Ordering::Relaxed)
+    }
+}
+
+/// A structure representing a registered raw tracepoint callback function.
+pub struct RawTraceEventFunc {
+    /// The callback function to be called when the tracepoint is hit, with raw arguments.
+    /// The function takes a slice of u64 representing the raw arguments and a reference to any associated data.
+    func: Box<RawTraceEventCallback>,
+    /// The data associated with the callback function.
+    data: Box<dyn Any + Send + Sync>,
+}
+
+impl RawTraceEventFunc {
+    /// Creates a new RawTraceEventFunc instance.
+    pub fn new(func: Box<RawTraceEventCallback>, data: Box<dyn Any + Send + Sync>) -> Self {
+        Self { func, data }
+    }
+    /// Calls the callback function with the provided raw arguments.
+    pub fn call(&self, args: &[u64]) {
+        (self.func)(args, &self.data);
+    }
+}
+
+/// A structure representing a registered tracepoint callback function.
+#[derive(Debug)]
+pub struct TraceDefaultFunc {
+    func: fn(),
+    data: Box<dyn Any + Send + Sync>,
+}
+
+impl TraceDefaultFunc {
+    /// Constructs a callback from a type-erased generated function.
+    ///
+    /// # Safety
+    ///
+    /// `func` must be restored only to the exact callback signature from which
+    /// it was erased. The generated registration and dispatch functions uphold
+    /// this pairing.
+    #[doc(hidden)]
+    pub unsafe fn from_erased(func: fn(), data: Box<dyn Any + Send + Sync>) -> Self {
+        Self { func, data }
+    }
+
+    /// Returns the erased callback pointer for generated dispatch code.
+    #[doc(hidden)]
+    pub const fn erased_func(&self) -> fn() {
+        self.func
+    }
+
+    /// Returns the payload associated with this callback.
+    #[doc(hidden)]
+    pub fn data(&self) -> &(dyn Any + Send + Sync) {
+        self.data.as_ref()
+    }
+}
+
+/// An enum representing the different types of tracepoint callback functions.
+#[derive(Clone)]
+pub enum TraceCallbackType {
+    /// The default callback function for the tracepoint, typically used for the default print functionality.
+    Default(Arc<TraceDefaultFunc>),
+    /// A custom event callback function for the tracepoint, used for custom event handling.
+    Event(Arc<TraceEventFunc>),
+    /// A custom raw event callback function for the tracepoint, used for handling raw tracepoint events with raw arguments.
+    RawEvent(Arc<RawTraceEventFunc>),
+}
+
+impl PartialEq for TraceCallbackType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (TraceCallbackType::Default(func1), TraceCallbackType::Default(func2)) => {
+                Arc::ptr_eq(func1, func2)
+            }
+            (TraceCallbackType::Event(func1), TraceCallbackType::Event(func2)) => {
+                Arc::ptr_eq(func1, func2)
+            }
+            (TraceCallbackType::RawEvent(func1), TraceCallbackType::RawEvent(func2)) => {
+                Arc::ptr_eq(func1, func2)
+            }
+            _ => false,
+        }
+    }
+}
+
+/// The TracePoint structure represents a tracepoint in the system.
+pub struct TracePoint<K: KernelTraceOps> {
+    name: &'static str,
+    system: &'static str,
+    callbacks_enabled: AtomicBool,
+    id: AtomicU32,
+    trace_entry_fmt_func: fn(&[u8]) -> Result<String, TraceParseError>,
+    trace_print_func: fn() -> String,
+    schema: Schema,
+    flags: u8,
+    kernel: PhantomData<fn() -> K>,
+}
+
+impl<K: KernelTraceOps> core::fmt::Debug for TracePoint<K> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TracePoint")
+            .field("name", &self.name)
+            .field("system", &self.system)
+            .field("id", &self.id())
+            .field("flags", &self.flags)
+            .finish()
+    }
+}
+
+/// An extended tracepoint structure that includes additional callback management and compiled expression handling.
+pub struct ExtTracePoint<K: KernelTraceOps> {
+    tracepoint: &'static TracePoint<K>,
+    callbacks: Vec<TraceCallbackType>,
+    compiled_expr: Option<Compiled>,
+    default_callback: Arc<TraceDefaultFunc>,
+}
+
+impl<K: KernelTraceOps> Clone for ExtTracePoint<K> {
+    fn clone(&self) -> Self {
+        Self {
+            tracepoint: self.tracepoint,
+            callbacks: self.callbacks.clone(),
+            compiled_expr: self.compiled_expr.clone(),
+            default_callback: Arc::clone(&self.default_callback),
+        }
+    }
+}
+
+impl<K: KernelTraceOps> core::fmt::Debug for ExtTracePoint<K> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ExtTracePoint")
+            .field("tracepoint", &self.tracepoint)
+            .finish()
+    }
+}
+
+impl<K: KernelTraceOps> ExtTracePoint<K> {
+    /// Creates a new ExtTracePoint instance.
+    pub const fn new(
+        tracepoint: &'static TracePoint<K>,
+        default_callback: Arc<TraceDefaultFunc>,
+    ) -> Self {
+        Self {
+            tracepoint,
+            callbacks: Vec::new(),
+            default_callback,
+            compiled_expr: None,
+        }
+    }
+
+    /// Returns a reference to the default callback function for the tracepoint.
+    pub fn default_callback(&self) -> Arc<TraceDefaultFunc> {
+        self.default_callback.clone()
+    }
+
+    /// Returns a reference to the underlying TracePoint.
+    pub const fn trace_point(&self) -> &'static TracePoint<K> {
+        self.tracepoint
+    }
+
+    /// Sets the compiled expression for the tracepoint.
+    pub fn set_compiled_expr(&mut self, compiled: Option<Compiled>) {
+        self.compiled_expr = compiled;
+    }
+
+    /// Returns the compiled expression for the tracepoint.
+    pub fn get_compiled_expr(&self) -> Option<&Compiled> {
+        self.compiled_expr.as_ref()
+    }
+
+    /// Register a callback in this runtime-state value.
+    ///
+    /// This does not make the tracepoint globally visible. The owner must
+    /// publish the complete state first and then update the callback gate.
+    pub fn register(&mut self, callback: TraceCallbackType) {
+        if !self.callbacks.iter().any(|f| f == &callback) {
+            self.callbacks.push(callback);
+        }
+    }
+
+    /// Unregister a callback from this runtime-state value.
+    ///
+    /// This does not change the global callback gate. The owner must order the
+    /// gate transition with publication of the complete replacement state.
+    pub fn unregister(&mut self, callback: TraceCallbackType) {
+        self.callbacks.retain(|f| f != &callback);
+    }
+
+    /// Returns whether this runtime state has at least one callback.
+    pub fn has_callbacks(&self) -> bool {
+        !self.callbacks.is_empty()
+    }
+
+    /// Iterate over all registered callback functions
+    pub fn callback_list(&self) -> impl Iterator<Item = &TraceCallbackType> {
+        self.callbacks.iter()
+    }
+}
+
+impl<K: KernelTraceOps> TracePoint<K> {
+    /// Creates a new TracePoint instance.
+    pub const fn new(
+        name: &'static str,
+        system: &'static str,
+        fmt_func: fn(&[u8]) -> Result<String, TraceParseError>,
+        trace_print_func: fn() -> String,
+        schema: Schema,
+    ) -> Self {
+        Self {
+            name,
+            system,
+            callbacks_enabled: AtomicBool::new(false),
+            id: AtomicU32::new(0),
+            flags: 0,
+            trace_entry_fmt_func: fmt_func,
+            trace_print_func,
+            schema,
+            kernel: PhantomData,
+        }
+    }
+
+    /// Returns the schema of the tracepoint.
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    /// Returns the name of the tracepoint.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Returns the system of the tracepoint.
+    pub fn system(&self) -> &'static str {
+        self.system
+    }
+
+    /// Sets the ID of the tracepoint.
+    pub(crate) fn set_id(&self, id: u32) {
+        self.id.store(id, Ordering::Relaxed);
+    }
+
+    /// Returns the ID of the tracepoint.
+    pub fn id(&self) -> u32 {
+        self.id.load(Ordering::Relaxed)
+    }
+
+    /// Returns the flags of the tracepoint.
+    pub fn flags(&self) -> u8 {
+        self.flags
+    }
+
+    /// Returns the format function for the tracepoint.
+    pub(crate) fn fmt_func(&self) -> fn(&[u8]) -> Result<String, TraceParseError> {
+        self.trace_entry_fmt_func
+    }
+
+    /// Returns a string representation of the format function for the tracepoint.
+    ///
+    /// You can use `cat /sys/kernel/debug/tracing/events/syscalls/sys_enter_openat/format` in linux
+    /// to see the format of the tracepoint.
+    pub fn print_fmt(&self) -> String {
+        let post_str = (self.trace_print_func)();
+        format!("name: {}\nID: {}\n{}\n", self.name(), self.id(), post_str)
+    }
+
+    /// Publishes whether the callback fast path should enter runtime state.
+    ///
+    /// Enabling must happen after publishing a non-empty callback state.
+    /// Disabling must happen before retiring the last non-empty state. A
+    /// Release store pairs with the fast path's Acquire load so a reader that
+    /// observes `true` can also observe the published callback snapshot.
+    pub fn set_callback_gate(&self, enabled: bool) {
+        self.callbacks_enabled.store(enabled, Ordering::Release);
+    }
+
+    /// Returns true if the tracepoint is enabled, false otherwise.
+    pub fn key_is_enabled(&self) -> bool {
+        self.callbacks_enabled.load(Ordering::Acquire)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(dead_code)]
+
+    extern crate std;
+
+    use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
+
+    use tp_lexer::{FieldClassifier, Schema};
+
+    use super::{ExtTracePoint, TraceCallbackType, TraceDefaultFunc, TracePoint};
+    use crate::{
+        KernelTraceOps, TraceEntry, TraceEntryParser, TraceParseError, TracePipeRecord,
+        TracePointMap,
+    };
+
+    struct TestKernel;
+
+    impl KernelTraceOps for TestKernel {
+        fn current_pid() -> u32 {
+            0
+        }
+
+        fn trace_pipe_push_raw_record(_: &[u8]) {}
+
+        fn trace_cmdline_push(_: u32) {}
+
+        fn read_tracepoint_state<R>(_: u32, _: impl FnOnce(&ExtTracePoint<Self>) -> R) -> R {
+            panic!("test has no tracepoint registry")
+        }
+
+        fn write_tracepoint_state<R>(_: u32, _: impl FnOnce(&mut ExtTracePoint<Self>) -> R) -> R {
+            panic!("test has no tracepoint registry")
+        }
+    }
+
+    struct OtherKernel;
+
+    impl KernelTraceOps for OtherKernel {
+        fn current_pid() -> u32 {
+            0
+        }
+
+        fn trace_pipe_push_raw_record(_: &[u8]) {}
+
+        fn trace_cmdline_push(_: u32) {}
+
+        fn read_tracepoint_state<R>(_: u32, _: impl FnOnce(&ExtTracePoint<Self>) -> R) -> R {
+            panic!("test has no tracepoint registry")
+        }
+
+        fn write_tracepoint_state<R>(_: u32, _: impl FnOnce(&mut ExtTracePoint<Self>) -> R) -> R {
+            panic!("test has no tracepoint registry")
+        }
+    }
+
+    crate::define_event_trace!(
+        test_kernel_event,
+        TP_kops(TestKernel),
+        TP_system(ax_tracepoint_test),
+        TP_PROTO(value: u32),
+        TP_STRUCT__entry { value: u32 },
+        TP_fast_assign { value: value },
+        TP_ident(entry),
+        TP_printk(format_args!("value={}", entry.value))
+    );
+
+    crate::define_event_trace!(
+        other_kernel_event,
+        TP_kops(OtherKernel),
+        TP_system(ax_tracepoint_test),
+        TP_PROTO(value: u32),
+        TP_STRUCT__entry { value: u32 },
+        TP_fast_assign { value: value },
+        TP_ident(entry),
+        TP_printk(format_args!("value={}", entry.value))
+    );
+
+    fn format_entry(_: &[u8]) -> Result<String, TraceParseError> {
+        Ok(String::new())
+    }
+
+    fn print_format() -> String {
+        String::new()
+    }
+
+    fn default_callback() {}
+
+    static TEST_FIELDS: &[(&str, tp_lexer::FieldType, usize, usize)] =
+        &[("value", u32::FIELD_TYPE, 0, size_of::<u32>())];
+
+    static TEST_POINT: TracePoint<TestKernel> = TracePoint::new(
+        "callback_gate",
+        "ax_tracepoint_test",
+        format_entry,
+        print_format,
+        Schema::new(TEST_FIELDS),
+    );
+
+    #[test]
+    fn callback_state_changes_are_side_effect_free_until_the_owner_publishes_the_gate() {
+        TEST_POINT.set_callback_gate(false);
+        let mut state = ExtTracePoint::new(
+            &TEST_POINT,
+            Arc::new(TraceDefaultFunc {
+                func: default_callback,
+                data: Box::new(()),
+            }),
+        );
+        let callback = TraceCallbackType::Default(state.default_callback());
+
+        state.register(callback.clone());
+        assert!(state.has_callbacks());
+        assert!(!TEST_POINT.key_is_enabled());
+
+        let published = state.clone();
+        published.trace_point().set_callback_gate(true);
+        assert!(state.trace_point().key_is_enabled());
+
+        state.unregister(callback);
+        assert!(!state.has_callbacks());
+        assert!(TEST_POINT.key_is_enabled());
+
+        state.trace_point().set_callback_gate(false);
+        assert!(!published.trace_point().key_is_enabled());
+    }
+
+    #[test]
+    fn linker_discovery_filters_metadata_by_kernel_ops_type() {
+        let (test_points, _) = crate::global_init_events::<TestKernel>().unwrap();
+        let (other_points, _) = crate::global_init_events::<OtherKernel>().unwrap();
+
+        assert_eq!(test_points.len(), 1);
+        assert_eq!(other_points.len(), 1);
+        assert_eq!(
+            test_points.values().next().unwrap().name(),
+            "test_kernel_event"
+        );
+        assert_eq!(
+            other_points.values().next().unwrap().name(),
+            "other_kernel_event"
+        );
+    }
+
+    #[test]
+    fn empty_filter_is_rejected_without_panicking() {
+        let mut state = ExtTracePoint::new(
+            &TEST_POINT,
+            Arc::new(TraceDefaultFunc {
+                func: default_callback,
+                data: Box::new(()),
+            }),
+        );
+        let mut filter = crate::TraceFilterFile::new();
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            filter.write(&mut state, "")
+        }));
+
+        assert!(result.is_ok(), "an empty filter must not panic");
+        assert_eq!(
+            result.unwrap(),
+            Err(crate::TraceFilterError::EmptyExpression)
+        );
+    }
+
+    #[test]
+    fn invalid_filter_preserves_the_previous_compiled_expression() {
+        let mut state = ExtTracePoint::new(
+            &TEST_POINT,
+            Arc::new(TraceDefaultFunc {
+                func: default_callback,
+                data: Box::new(()),
+            }),
+        );
+        let mut filter = crate::TraceFilterFile::new();
+
+        assert_eq!(filter.write(&mut state, "value == 1"), Ok(()));
+        assert!(state.get_compiled_expr().is_some());
+        assert_eq!(
+            filter.write(&mut state, "value ??? 1"),
+            Err(crate::TraceFilterError::CompileExpression)
+        );
+        assert!(
+            state.get_compiled_expr().is_some(),
+            "a rejected update must not clear the active filter"
+        );
+    }
+
+    #[test]
+    fn unknown_tracepoint_record_is_rejected_without_panicking() {
+        let header = TraceEntry {
+            common_type: 17,
+            common_flags: 0,
+            common_preempt_count: 0,
+            common_pid: 1,
+        };
+        // SAFETY: `header` is fully initialized and is copied only for the
+        // duration of this statement.
+        let event = unsafe {
+            core::slice::from_raw_parts(
+                core::ptr::from_ref(&header).cast::<u8>(),
+                size_of::<TraceEntry>(),
+            )
+        };
+        let record = TracePipeRecord::new(0, 0, Vec::from(event));
+        let map = TracePointMap::<TestKernel>::new();
+        let cmdlines = crate::TraceCmdLineCache::new(core::num::NonZero::new(1).unwrap());
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            TraceEntryParser::parse(&map, &cmdlines, &record)
+        }));
+        assert!(result.is_ok(), "an unknown tracepoint ID must not panic");
+        assert_eq!(
+            result.unwrap(),
+            Err(TraceParseError::UnknownTracepoint { id: 17 })
+        );
+    }
+
+    #[test]
+    fn short_tracepoint_record_is_rejected_before_header_decode() {
+        let record = TracePipeRecord::new(0, 0, Vec::new());
+        let map = TracePointMap::<TestKernel>::new();
+        let cmdlines = crate::TraceCmdLineCache::new(core::num::NonZero::new(1).unwrap());
+
+        assert_eq!(
+            TraceEntryParser::parse(&map, &cmdlines, &record),
+            Err(TraceParseError::RecordTooShort {
+                expected: size_of::<TraceEntry>(),
+                actual: 0,
+            })
+        );
+    }
+}

--- a/components/ax-tracepoint/src/ptr.rs
+++ b/components/ax-tracepoint/src/ptr.rs
@@ -1,0 +1,61 @@
+//! A trait to convert various types to u64 representation.
+//! This is useful for passing arguments to tracepoints in a uniform way.
+
+/// A trait to convert various types to u64 representation.
+pub trait AsU64 {
+    #[allow(clippy::wrong_self_convention)]
+    /// Convert the value to u64.
+    fn as_u64(self) -> u64;
+}
+
+macro_rules! impl_basic {
+    ($($t:ty),+) => {
+        $(
+            impl AsU64 for $t {
+                fn as_u64(self) -> u64 {
+                    self as u64
+                }
+            }
+        )+
+    };
+}
+
+impl_basic!(
+    u8, u16, u32, u64, i8, i16, i32, i64, usize, isize, bool, char
+);
+
+impl<T> AsU64 for &T {
+    fn as_u64(self) -> u64 {
+        self as *const T as u64
+    }
+}
+
+impl<T> AsU64 for &mut T {
+    fn as_u64(self) -> u64 {
+        self as *mut T as u64
+    }
+}
+
+impl<T> AsU64 for *const T {
+    fn as_u64(self) -> u64 {
+        self as u64
+    }
+}
+
+impl<T> AsU64 for *mut T {
+    fn as_u64(self) -> u64 {
+        self as u64
+    }
+}
+
+impl AsU64 for &str {
+    fn as_u64(self) -> u64 {
+        self.as_ptr() as u64
+    }
+}
+
+impl AsU64 for &[u8] {
+    fn as_u64(self) -> u64 {
+        self.as_ptr() as u64
+    }
+}

--- a/components/ax-tracepoint/src/trace_pipe.rs
+++ b/components/ax-tracepoint/src/trace_pipe.rs
@@ -1,0 +1,354 @@
+use alloc::{format, string::String, vec::Vec};
+use core::num::NonZero;
+
+use lru::LruCache;
+
+use crate::{KernelTraceOps, TraceEntry, TracePointMap};
+
+/// An error produced while decoding a trace pipe record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum TraceParseError {
+    /// The record does not contain a complete common trace header.
+    #[error("trace record is too short: expected at least {expected} bytes, got {actual}")]
+    RecordTooShort {
+        /// Minimum number of bytes required.
+        expected: usize,
+        /// Number of bytes supplied.
+        actual: usize,
+    },
+    /// The record names an event ID that is absent from the tracepoint map.
+    #[error("unknown tracepoint ID {id}")]
+    UnknownTracepoint {
+        /// Event ID read from the common trace header.
+        id: u32,
+    },
+    /// The event-specific payload is shorter than its generated entry layout.
+    #[error("trace payload is too short: expected at least {expected} bytes, got {actual}")]
+    PayloadTooShort {
+        /// Minimum number of bytes required.
+        expected: usize,
+        /// Number of bytes supplied.
+        actual: usize,
+    },
+}
+
+/// A trace pipe record with host-provided metadata captured when the event is written.
+#[derive(Clone, Debug)]
+pub struct TracePipeRecord {
+    timestamp: u64,
+    cpu_id: u32,
+    event: Vec<u8>,
+}
+
+impl TracePipeRecord {
+    /// Create a new trace pipe record.
+    pub fn new(timestamp: u64, cpu_id: u32, event: Vec<u8>) -> Self {
+        Self {
+            timestamp,
+            cpu_id,
+            event,
+        }
+    }
+
+    /// The event timestamp in nanoseconds.
+    pub fn timestamp(&self) -> u64 {
+        self.timestamp
+    }
+
+    /// The CPU ID on which the event was recorded.
+    pub fn cpu_id(&self) -> u32 {
+        self.cpu_id
+    }
+
+    /// The raw trace event payload.
+    pub fn event(&self) -> &[u8] {
+        &self.event
+    }
+}
+
+/// A trait defining operations for a trace pipe buffer.
+pub trait TracePipeOps {
+    /// Returns the first record in the trace pipe buffer without removing it.
+    fn peek(&self) -> Option<&TracePipeRecord>;
+
+    /// Remove and return the first record in the trace pipe buffer.
+    fn pop(&mut self) -> Option<TracePipeRecord>;
+
+    /// Whether the trace pipe buffer is empty.
+    fn is_empty(&self) -> bool;
+}
+
+/// A raw trace pipe buffer that stores trace events as byte vectors.
+pub struct TracePipeRaw {
+    max_record: usize,
+    event_buf: Vec<TracePipeRecord>,
+}
+
+impl TracePipeRaw {
+    /// Create a new TracePipeRaw with the specified maximum number of records.
+    pub const fn new(max_record: usize) -> Self {
+        Self {
+            max_record,
+            event_buf: Vec::new(),
+        }
+    }
+
+    /// Set the maximum number of records to keep in the trace pipe buffer.
+    ///
+    /// If the current number of records exceeds this limit, the oldest records will be removed.
+    pub fn set_max_record(&mut self, max_record: usize) {
+        self.max_record = max_record;
+        if self.event_buf.len() > max_record {
+            let remove_count = self.event_buf.len() - max_record;
+            self.event_buf.drain(0..remove_count);
+        }
+    }
+
+    /// Push a new event into the trace pipe buffer without metadata.
+    ///
+    /// Prefer [`Self::push_record`] when the host can provide event-time metadata.
+    pub fn push_event(&mut self, event: Vec<u8>) {
+        self.push_record(0, 0, event);
+    }
+
+    /// Push a new event record into the trace pipe buffer.
+    pub fn push_record(&mut self, timestamp: u64, cpu_id: u32, event: Vec<u8>) {
+        if self.max_record == 0 {
+            return;
+        }
+        if self.event_buf.len() >= self.max_record {
+            self.event_buf.remove(0); // Remove the oldest record
+        }
+        self.event_buf
+            .push(TracePipeRecord::new(timestamp, cpu_id, event));
+    }
+
+    /// The number of events currently in the trace pipe buffer.
+    pub fn event_count(&self) -> usize {
+        self.event_buf.len()
+    }
+
+    /// Clear the trace pipe buffer.
+    pub fn clear(&mut self) {
+        self.event_buf.clear();
+    }
+
+    /// Create a snapshot of the current state of the trace pipe buffer.
+    pub fn snapshot(&self) -> TracePipeSnapshot {
+        TracePipeSnapshot::new(self.event_buf.clone())
+    }
+
+    /// Get the maximum number of records allowed in the trace pipe buffer.
+    pub fn max_record(&self) -> usize {
+        self.max_record
+    }
+}
+
+impl TracePipeOps for TracePipeRaw {
+    fn peek(&self) -> Option<&TracePipeRecord> {
+        self.event_buf.first()
+    }
+
+    fn pop(&mut self) -> Option<TracePipeRecord> {
+        if self.event_buf.is_empty() {
+            None
+        } else {
+            Some(self.event_buf.remove(0))
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.event_buf.is_empty()
+    }
+}
+
+/// A snapshot of the trace pipe buffer at a specific point in time.
+#[derive(Debug)]
+pub struct TracePipeSnapshot(Vec<TracePipeRecord>);
+
+impl TracePipeSnapshot {
+    /// Create a new TracePipeSnapshot with the given event buffer.
+    pub fn new(event_buf: Vec<TracePipeRecord>) -> Self {
+        Self(event_buf)
+    }
+
+    /// The formatted string representation to be used as a header for the trace pipe output.
+    pub fn default_fmt_str(&self) -> String {
+        let show = "#
+#
+#                                _-----=> irqs-off/BH-disabled
+#                               / _----=> need-resched
+#                              | / _---=> hardirq/softirq
+#                              || / _--=> preempt-depth
+#                              ||| / _-=> migrate-disable
+#                              |||| /     delay
+#           TASK-PID     CPU#  |||||  TIMESTAMP  FUNCTION
+#              | |         |   |||||     |         |
+";
+        format!(
+            "# tracer: nop\n#\n# entries-in-buffer/entries-written: {}/{}   #P:32\n{}",
+            self.0.len(),
+            self.0.len(),
+            show
+        )
+    }
+}
+
+impl TracePipeOps for TracePipeSnapshot {
+    fn peek(&self) -> Option<&TracePipeRecord> {
+        self.0.first()
+    }
+
+    fn pop(&mut self) -> Option<TracePipeRecord> {
+        if self.0.is_empty() {
+            None
+        } else {
+            Some(self.0.remove(0))
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+/// A cache for storing command line arguments for each trace point.
+///
+/// See <https://www.kernel.org/doc/Documentation/trace/ftrace.txt>
+pub struct TraceCmdLineCache {
+    // cmdline: Vec<(u32, [u8; 16])>,
+    cmdline: LruCache<u32, String>,
+}
+
+impl TraceCmdLineCache {
+    /// Create a new TraceCmdLineCache with the specified maximum number of records.
+    pub fn new(max_record: NonZero<usize>) -> Self {
+        Self {
+            cmdline: LruCache::new(max_record),
+        }
+    }
+
+    /// Insert a command line argument for a trace point.
+    ///
+    /// If the command line exceeds 16 bytes, it will be truncated.
+    /// If the cache exceeds the maximum record limit, the oldest entry will be removed.
+    pub fn insert(&mut self, id: u32, cmdline: &str) {
+        const MAX_CMDLINE_LEN: usize = 16;
+        let (cmdline, _) = cmdline.split_at(MAX_CMDLINE_LEN.min(cmdline.len()));
+        let line = format!("{} {}\n", id, cmdline);
+        self.cmdline.put(id, line);
+    }
+
+    /// Get the command line argument for a trace point.
+    pub fn get(&self, id: u32) -> Option<&str> {
+        self.cmdline
+            .iter()
+            .find(|(key, _)| **key == id)
+            .and_then(|(_, value)| {
+                let line = value.as_str();
+                line.split_once(' ')
+                    .map(|(_, command)| command.trim_end_matches('\n'))
+            })
+    }
+
+    /// Set the maximum length for command line arguments.
+    pub fn set_max_record(&mut self, max_len: NonZero<usize>) {
+        self.cmdline.resize(max_len);
+    }
+
+    /// Get the maximum number of records in the cache.
+    pub fn max_record(&self) -> usize {
+        self.cmdline.cap().get()
+    }
+
+    /// Create a snapshot of the current state of the command line cache.
+    pub fn snapshot(&self) -> TraceCmdLineCacheSnapshot {
+        let cmdline = self
+            .cmdline
+            .iter()
+            .map(|(_, value)| value)
+            .cloned()
+            .collect();
+        TraceCmdLineCacheSnapshot::new(cmdline)
+    }
+}
+
+/// A snapshot of the command line cache at a specific point in time.
+#[derive(Debug)]
+pub struct TraceCmdLineCacheSnapshot(Vec<String>);
+
+impl TraceCmdLineCacheSnapshot {
+    /// Create a new TraceCmdLineCacheSnapshot with the given command line entries.
+    pub fn new(cmdline: Vec<String>) -> Self {
+        Self(cmdline)
+    }
+
+    /// Return the first command line entry in the cache.
+    pub fn peek(&self) -> Option<&String> {
+        self.0.first()
+    }
+
+    /// Remove and return the first command line entry in the cache.
+    pub fn pop(&mut self) -> Option<String> {
+        if self.0.is_empty() {
+            None
+        } else {
+            Some(self.0.remove(0))
+        }
+    }
+}
+
+/// A parser for trace entries that formats them into human-readable strings.
+pub struct TraceEntryParser;
+
+impl TraceEntryParser {
+    /// Parse the trace entry and return a formatted string.
+    pub fn parse<K: KernelTraceOps>(
+        tracepoint_map: &TracePointMap<K>,
+        cmdline_cache: &TraceCmdLineCache,
+        record: &TracePipeRecord,
+    ) -> Result<String, TraceParseError> {
+        let entry = record.event();
+        let header_len = core::mem::size_of::<TraceEntry>();
+        if entry.len() < header_len {
+            return Err(TraceParseError::RecordTooShort {
+                expected: header_len,
+                actual: entry.len(),
+            });
+        }
+        // SAFETY: the length check covers the complete C-layout header;
+        // `TraceEntry` contains only integer fields, so every bit pattern is
+        // valid, and `read_unaligned` does not require Vec<u8> alignment.
+        let trace_entry = unsafe { core::ptr::read_unaligned(entry.as_ptr().cast::<TraceEntry>()) };
+        let id = trace_entry.common_type as u32;
+        let tracepoint = tracepoint_map
+            .get(&id)
+            .ok_or(TraceParseError::UnknownTracepoint { id })?;
+        let fmt_func = tracepoint.fmt_func();
+        let str = fmt_func(&entry[header_len..])?;
+
+        let time = record.timestamp();
+        let cpu_id = record.cpu_id();
+
+        // Copy the packed field to a local variable to avoid unaligned reference
+        let pid = trace_entry.common_pid;
+        let pname = cmdline_cache
+            .get(trace_entry.common_pid as u32)
+            .unwrap_or("<...>");
+
+        let secs = time / 1_000_000_000;
+        let usec_rem = time % 1_000_000_000 / 1000;
+
+        Ok(format!(
+            "{:>16}-{:<7} [{:03}] {} {:5}.{:06}: {}({})\n",
+            pname,
+            pid,
+            cpu_id,
+            trace_entry.trace_print_lat_fmt(),
+            secs,
+            usec_rem,
+            tracepoint.name(),
+            str
+        ))
+    }
+}

--- a/docs/design/ax-tracepoint.md
+++ b/docs/design/ax-tracepoint.md
@@ -130,6 +130,8 @@ rename，所有实际调用点同时迁移，不增加兼容 shim。
   callback/filter 状态值。
 - `TracePointMap` 只提供查询、迭代和长度 API，不通过 `DerefMut` 暴露内部 `BTreeMap`。
 - `TraceFilterError`、`TraceParseError` 和 `TraceInitError` 是可匹配的 typed error。
+- cooked event callback 接收当前调用独占的 `&mut [u8]`；每个 callback 都编码独立
+  record，Starry BPF adapter 不从共享引用构造可变切片。
 - filter 更新是事务性的：编译失败或空表达式记录错误，但不清除上一个有效 compiled
   filter；仅精确的 `0`（允许外围空白）清除 filter。
 - StarryOS 只通过 `KernelExtTracePoint::update` 修改 callback state，避免调用方忘记同步
@@ -188,11 +190,15 @@ workspace 内消费者在同一提交完成迁移。关闭路径从 static key �
 
 - red：`empty_filter_is_rejected_without_panicking` 在原实现对空 slice 索引 panic；
   `invalid_filter_preserves_the_previous_compiled_expression` 在原实现清空 compiled state；
-  `unknown_tracepoint_record_is_rejected_without_panicking` 在原实现的 `expect` panic。
-- green：`cargo test -p ax-tracepoint` 当前 6/6，通过上述回归、短 record 和两种
-  `KernelTraceOps` metadata 隔离。
+  `unknown_tracepoint_record_is_rejected_without_panicking` 在原实现的 `expect` panic；
+  padding 回归在直接暴露 `repr(C)` object representation 时读到未初始化尾部；独占
+  callback 回归在旧 `&[u8]` 接口上无法编译。
+- green：`cargo test -p ax-tracepoint` 当前 8/8，通过上述回归、短 record、零初始化
+  padding、独占可变 callback 和两种 `KernelTraceOps` metadata 隔离。
 - green：`cargo run -p ax-tracepoint --example usage`，实际发现两个 event，完成 callback、
   filter、raw/event dispatch 和 6 条文本记录格式化。
+- green：`cargo clippy -p ax-tracepoint --all-targets -- -D warnings`，覆盖 macro 的测试与
+  example 展开，不产生 `redundant_field_names`。
 - green：`cargo xtask clippy --package ax-tracepoint --package starry-kernel`，覆盖四种
   target、逐 feature 与系统配置的完整矩阵，99/99。
 - green：`cargo xtask ktest qemu -p starry-kernel --test axtest_kernel --arch x86_64`，

--- a/docs/design/ax-tracepoint.md
+++ b/docs/design/ax-tracepoint.md
@@ -1,0 +1,203 @@
+# ax-tracepoint 组件提取设计
+
+## 问题
+
+迁移前，StarryOS 从 crates.io 使用 `ktracepoint 0.6.0`。该 crate 通过
+`static-keys` 在运行中的内核文本上切换 tracepoint 快路径，因此每个 OS 宿主都必须
+提供写内核 text、指令缓存同步和跨 CPU 可见性能力。TGOSKits 已经拥有 tracepoint
+定义、tracefs 控制、perf/BPF callback 和 trace pipe 消费者，但核心事件定义仍由仓库外
+crate 拥有，无法在 workspace 内统一审核公共 API、linker 契约和宿主同步所有权。
+
+具体场景是管理员向
+`/sys/kernel/debug/tracing/events/<system>/<event>/enable` 写 `1` 后触发事件，
+并从 `trace_pipe` 消费文本，或通过 perf/raw-tracepoint fd 挂载 BPF callback。期望启用、
+触发、filter 和 fd 关闭注销都不要求改写运行中的 kernel text。若不实施，Starry 每次
+启停仍依赖架构相关 text 写入和 cache 同步，workspace 也无法修复上游 safe API 中的
+malformed record panic/UB 边界。
+
+PR #1775 的提交 `ec879a74fa1b094c25e8ceda052a3fc3cc314a7e` 包含一个可独立提取的
+`ktracepoint` 组件版本：它用运行时原子 gate 代替 live text patching，并把 callback
+状态发布交给 OS 宿主。本设计把该组件提取到 `components/ax-tracepoint`，crate/package
+名改为 `ax-tracepoint`，Rust 导入名为 `ax_tracepoint`，并迁移当前 StarryOS 消费者。
+
+## 用户与成功标准
+
+直接用户是 StarryOS tracefs、perf tracepoint、raw tracepoint/BPF 和仓库内定义静态事件
+的内核模块。后续 ArceOS 或其它内核镜像也可以通过 `KernelTraceOps` 接入自己的状态
+registry 和 trace pipe。
+
+成功标准：
+
+- workspace 不再解析 crates.io 的 `ktracepoint`，所有现有事件改用本地
+  `ax-tracepoint`；
+- callback 从零变为非零时，完整状态先对读者可见，再打开 gate；callback 变为空时，
+  读者不能执行已移除 callback；
+- 启停 tracepoint 不再写内核 text，也不要求架构相关 cache flush；
+- 保持当前 Starry tracefs 路径、event ID/format/filter、perf/BPF 接入和
+  `sched_switch` 调用上下文；
+- malformed trace record 和非法 filter 返回 typed error，不触发 panic 或未定义行为；
+- host example、crate 单测、Starry 多架构 clippy 和 QEMU axtest 通过。
+
+验收动作与期望：
+
+| 输入或动作 | 期望结果 |
+| --- | --- |
+| enable 文件写 `1`，随后触发事件 | callback 集合发布后 gate 打开，trace pipe 收到记录 |
+| enable 文件写 `0` 或关闭 perf/raw fd | callback 从集合移除，空集合对应 gate 关闭 |
+| 先写合法 filter，再写非法表达式 | 第二次返回错误，上一次 compiled filter 继续生效 |
+| 解析短记录或未知 event ID | 返回 `TraceParseError`，Starry 丢弃记录且不 panic |
+| host example 定义两种 `KernelTraceOps` | 每次初始化只发现自身类型的 linker metadata |
+
+## 非目标
+
+- 不提取 #1775 的 `ax-task`、调度策略、IPI、timer、RT/Deadline 或 runtime 重构；
+- 不把 callback 移出 Starry 当前的 `NoPreemptMutex` 临界区，不引入 generation/RCU
+  registry、retire worker 或新的 trace ingress ring；
+- 不新增 tracefs 文件，不改变 syscall/Linux ABI，不改变现有事件字段布局；
+- 不承诺与 crates.io `ktracepoint` 的源码级名称兼容；仓库内消费者一次性迁移到新名。
+
+## Prior art 与约束
+
+Linux tracepoint 的关键语义是：未启用时只保留轻量条件检查；启用后 probe 在触发者的
+执行上下文中运行；注册和注销必须对并发触发者安全。查阅记录与结论：
+
+- Linux kernel current documentation（2026-08-19 查阅）：
+  <https://docs.kernel.org/trace/tracepoints.html>。probe 在触发者上下文运行，关闭路径只需
+  轻量 enabled 检查，注册/注销必须与并发触发者同步。
+- Linux ftrace current documentation（2026-08-19 查阅）：
+  <https://docs.kernel.org/trace/ftrace.html>。tracefs 负责控制与输出，`trace_pipe` 是
+  消费型流接口；dynamic text patch 是降低开销的实现方式，不是事件 ABI。
+- crates.io `ktracepoint 0.6.0`（`Cargo.lock` 迁移前版本及本地 cargo registry source）。
+  事件宏、schema/filter/pipe API 可复用；`static-keys`、公开 erased function 字段和
+  未校验 record decode 不应原样进入新的 workspace 公共 crate。
+- PR #1775 的 `ec879a74fa1b094c25e8ceda052a3fc3cc314a7e`。逐文件 diff 表明
+  `components/ktracepoint` 可手工提取；同提交的 Starry generation registry 依赖该 PR
+  更早的 ingress/scheduler/runtime 改动，不能独立 cherry-pick。
+
+本组件采用 #1775 的原子 gate。与 Linux 的差异是关闭路径使用普通原子分支，不做
+jump-label/text patch；callback 注销安全由宿主 registry 的锁或更强发布机制保证。
+
+## 方案与替代方案
+
+### 采用方案：本地组件加宿主发布边界
+
+`ax-tracepoint` 拥有静态事件描述、linker metadata、callback/filter runtime value 和
+原子 callback gate。Starry 调用链是
+`KernelTraceOps::write_tracepoint_state -> KernelExtTracePoint::update`；后者是唯一实际
+mutation owner：
+
+1. 以 `NoPreemptMutex` 保护 `ExtTracePoint`；
+2. 在同一锁内完成注册、注销或其它状态修改；
+3. 依据修改后的 callback 集合以 Release store 更新 gate；
+4. 快路径以 Acquire load 检查 gate，再通过同一 registry 锁读取并执行 callback。
+
+从空集合启用时，callback 已在锁保护的状态中，再打开 gate。禁用时即使读者先观察到
+旧的 `true`，它随后获取同一锁时也只会看到空集合。该边界保持当前 Starry callback
+执行上下文，不依赖 #1775 更早提交中的 ingress 和调度器改造。
+
+callback 在 `KernelExtTracePoint::read` 持 `NoPreemptMutex` 时执行，这是当前 Starry
+语义：callback 不得注册/注销 callback、更新 filter，或递归触发同一 registry 的事件。
+默认 trace pipe、perf 与 raw-BPF 路径继续遵守已有上下文约束；放宽该限制需要独立的
+generation/ingress 设计，不能在本次 crate rename 中隐式改变。
+
+### 未采用：保留 crates.io ktracepoint
+
+这会继续把 live kernel-text 修改和架构 cache 同步暴露给每个宿主，也无法在 workspace
+内收紧 linker、unsafe 和错误 API。
+
+### 未采用：直接 cherry-pick #1775 的 tracepoint 提交
+
+该提交的 Starry registry 部分依赖 #1775 更早已经存在的 trace ingress、deferred
+`sched_switch` 和 runtime API；直接 cherry-pick 会隐式带入大范围 task/runtime 重构，
+不再是独立组件提取。
+
+### 未采用：在当前 dev 上只搬 generation registry
+
+generation registry 会把 callback 移出 `NoPreemptMutex`，但当前 `sched_switch` callback
+仍沿用现有触发上下文和 trace pipe 路径。缺少配套 IRQ-safe ingress 时，单独改变锁边界
+会扩大上下文语义，不能作为本 PR 的安全迁移。
+
+### 未采用：保留兼容别名 ktracepoint
+
+同时维护两个 crate 名会延长重复接口并隐藏未迁移消费者。本次是 workspace 内一次性
+rename，所有实际调用点同时迁移，不增加兼容 shim。
+
+## 公共 API 与所有权
+
+- `KernelTraceOps` 只描述宿主能力：PID、trace pipe、cmdline cache，以及 runtime state
+  的读写入口；删除 `write_kernel_text`。
+- `TracePoint` 拥有不可变事件描述和原子 gate；`ExtTracePoint` 是可克隆、尚未发布的
+  callback/filter 状态值。
+- `TracePointMap` 只提供查询、迭代和长度 API，不通过 `DerefMut` 暴露内部 `BTreeMap`。
+- `TraceFilterError`、`TraceParseError` 和 `TraceInitError` 是可匹配的 typed error。
+- filter 更新是事务性的：编译失败或空表达式记录错误，但不清除上一个有效 compiled
+  filter；仅精确的 `0`（允许外围空白）清除 filter。
+- StarryOS 只通过 `KernelExtTracePoint::update` 修改 callback state，避免调用方忘记同步
+  gate。
+
+`KernelTraceOps::{read,write}_tracepoint_state` 对未知 ID 使用 `expect`，因为宏生成的
+内部调用只会在 `global_init_events` 建表并安装 registry 后使用同一静态 event ID；这是
+内核内部初始化 invariant。来自用户输入的 perf/raw event ID 不走该入口，先通过
+`lookup_ext_tracepoint`/`find_ext_tracepoint_by_name` 返回 `Option` 并转换为 typed error。
+
+## Linker 与 unsafe 边界
+
+`define_event_trace!` 把统一的 `CommonTracePointMeta` 放进 `.tracepoint`。metadata 携带
+`KernelTraceOps` type tag；`global_init_events::<K>` 只恢复 tag 匹配的 `TracePoint<K>`，
+因此同一最终镜像可包含多个宿主类型而不会跨类型解释静态引用。最终 linker
+script 必须定义 `__start_tracepoint`/`__stop_tracepoint`、KEEP 输入段并满足 metadata
+对齐；`my_section.ld` 提供参考片段。初始化时先检查地址顺序、对齐和整项长度，再建立
+只读 slice，并对 metadata 引用排序，不写 linker section。
+
+宏只接受实现 `TraceField` 的 entry 字段。该 unsafe trait 的契约是 Copy、无需 drop 且
+所有 bit pattern 有效；内置实现仅覆盖整数及其数组。formatter 检查 payload 长度后用
+unaligned copy 构造 entry，因此安全 API 不会从任意 `Vec<u8>` 建立未对齐引用。
+
+不同事件 callback 的函数签名仍需要类型擦除。`TraceDefaultFunc` 的字段保持私有，只有
+带 `# Safety` 契约的 hidden constructor 能接收 erased pointer；生成的注册与 dispatch
+函数成对擦除和恢复同一个签名，普通调用方不能通过安全字段构造错误签名。
+
+## 兼容性、失败与回滚
+
+Starry 的 tracefs 用户可见路径和格式不变。crate 名和 Rust import 是有意的源码级破坏；
+workspace 内消费者在同一提交完成迁移。关闭路径从 static key 变为 Acquire 原子分支，
+可能有可测但预期很小的性能差异，应由后续 benchmark 决定是否需要架构级 fast path，
+不能在本次重新引入 text patch。
+
+解析到短记录或未知 event ID 时，Starry 丢弃该损坏记录并记录 warning，避免 trace pipe
+读路径 panic。filter 写失败保持先前活动 filter，并由既有 VFS 边界返回 `EINVAL`。
+
+若需要回滚，可以在一个提交内恢复 workspace 的 crates.io dependency、旧 import 和
+`write_kernel_text` 宿主实现；本 PR 不改变持久化状态或外部 ABI，不需要数据迁移。
+
+## 调研与重复性检查
+
+设计时基线是当时最新 `origin/dev`；交付前必须再次 fetch/rebase 并记录最终 commit。
+已检查：
+
+- 当前 workspace 只有 crates.io `ktracepoint` 这一迁移前实现，没有第二个本地
+  tracepoint component；
+- GitHub open PR/issue 中没有与“独立提取并 rename ax-tracepoint”重复的交付；#1775
+  是来源 PR，范围还包含大量 task/runtime 重构；
+- 当前 Starry 所有实际消费者、linker script 和 Cargo dependency 已枚举，迁移不存在
+  仅保留旧名的 compatibility shim；
+- `docs/guideline/starry_syscall.md` 不适用：本次不改变 syscall 编号、参数、errno、检查
+  顺序或 Linux ABI，仅替换既有 tracepoint 内部组件与损坏记录失败策略。
+
+## 验证证据与剩余计划
+
+- red：`empty_filter_is_rejected_without_panicking` 在原实现对空 slice 索引 panic；
+  `invalid_filter_preserves_the_previous_compiled_expression` 在原实现清空 compiled state；
+  `unknown_tracepoint_record_is_rejected_without_panicking` 在原实现的 `expect` panic。
+- green：`cargo test -p ax-tracepoint` 当前 6/6，通过上述回归、短 record 和两种
+  `KernelTraceOps` metadata 隔离。
+- green：`cargo run -p ax-tracepoint --example usage`，实际发现两个 event，完成 callback、
+  filter、raw/event dispatch 和 6 条文本记录格式化。
+- green：`cargo xtask clippy --package ax-tracepoint --package starry-kernel`，覆盖四种
+  target、逐 feature 与系统配置的完整矩阵，99/99。
+- green：`cargo xtask ktest qemu -p starry-kernel --test axtest_kernel --arch x86_64`，
+  42/42，终端输出 `AXTEST_SUITE_OK`。
+- 已 rebase 到验证时最新的 `origin/dev`（`8618959d29`）；提交 PR 后等待 CI terminal。
+
+由于本次新增公共 crate、unsafe linker 边界和跨 crate 依赖，按
+`feature-development.md` 归类为高风险功能，需要组件与 Starry 边界维护者独立审核。

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -228,7 +228,7 @@ sg200x-jpu = { workspace = true, optional = true }
 # 0.10 to match sg200x-bsp 0.7.x's internal tock-registers; the Writeable trait
 # must come from the same version as sg200x-bsp's ReadWrite types.
 tock-registers = { version = "0.10", optional = true }
-ktracepoint = "0.6"
+ax-tracepoint.workspace = true
 ksym = "0.6"
 kbpf-basic = "0.6"
 rbpf = { version = "0.4", default-features = false }

--- a/os/StarryOS/kernel/src/perf/raw_tracepoint.rs
+++ b/os/StarryOS/kernel/src/perf/raw_tracepoint.rs
@@ -3,7 +3,7 @@
 //! the raw `&[u64]` args slice instead of the cooked text record.
 //!
 //! Adapted from `Starry-OS/StarryOS:ebpf-kmod`
-//! (`kernel/src/perf/raw_tracepoint.rs`) to ktracepoint 0.6:
+//! (`kernel/src/perf/raw_tracepoint.rs`) to ax-tracepoint 0.6:
 //! `RawTraceEventFunc::new(closure, data)` replaces the trait-object
 //! callback, and registration goes through
 //! `ExtTracePoint::register(TraceCallbackType::RawEvent(...))`.
@@ -11,9 +11,9 @@
 use alloc::{borrow::Cow, boxed::Box, sync::Arc};
 use core::any::Any;
 
+use ax_tracepoint::{RawTraceEventFunc, TraceCallbackType};
 use axpoll::Pollable;
 use kbpf_basic::raw_tracepoint::BpfRawTracePointArg;
-use ktracepoint::{RawTraceEventFunc, TraceCallbackType};
 
 use crate::{
     StarryError, StarryResult,
@@ -65,9 +65,9 @@ impl FileLike for RawTracepointPerfEvent {
 
 impl Drop for RawTracepointPerfEvent {
     fn drop(&mut self) {
-        self.ext_tp
-            .lock()
-            .unregister(TraceCallbackType::RawEvent(self.callback.clone()));
+        self.ext_tp.update(|ext_tp| {
+            ext_tp.unregister(TraceCallbackType::RawEvent(self.callback.clone()));
+        });
     }
 }
 
@@ -108,9 +108,9 @@ impl RawTracepointPerfEvent {
             }
         });
         let callback = Arc::new(RawTraceEventFunc::new(func, ctx));
-        ext_tp
-            .lock()
-            .register(TraceCallbackType::RawEvent(callback.clone()));
+        ext_tp.update(|state| {
+            state.register(TraceCallbackType::RawEvent(callback.clone()));
+        });
         Ok(Self { ext_tp, callback })
     }
 }

--- a/os/StarryOS/kernel/src/perf/tracepoint.rs
+++ b/os/StarryOS/kernel/src/perf/tracepoint.rs
@@ -3,24 +3,24 @@
 //! `/sys/kernel/debug/tracing/events/<sys>/<event>/id`).
 //!
 //! Adapted from `Starry-OS/StarryOS:ebpf-kmod` (`kernel/src/perf/tracepoint.rs`)
-//! to use ktracepoint **0.6**:
+//! to use ax-tracepoint **0.6**:
 //!
-//! * ktracepoint 0.6 dropped the `TracePoint<L, K>` lock parameter — there
+//! * ax-tracepoint 0.6 dropped the `TracePoint<L, K>` lock parameter — there
 //!   is a single generic over `K: KernelTraceOps`, and `ExtTracePoint<K>`
 //!   wraps callback management.
 //! * `TraceEventFunc::new(closure, data)` replaces the trait-object based
 //!   `TracePointCallBackFunc::call(entry)` callback registration.
 //! * Registration goes through `ExtTracePoint::register(TraceCallbackType::Event(...))`
 //!   rather than `TracePoint::register_event_callback(id, callback)`.
-//! * Enable/disable is implicit: `ExtTracePoint::register` enables the
-//!   static-key when the callback list becomes non-empty.
+//! * The Starry tracepoint registry updates the atomic callback gate while
+//!   holding its state lock; `ExtTracePoint::register` only edits that state.
 
 use alloc::{boxed::Box, sync::Arc};
 use core::any::Any;
 
+use ax_tracepoint::{TraceCallbackType, TraceEventFunc};
 use axpoll::Pollable;
 use kbpf_basic::perf::{PerfProbeArgs, PerfProbeConfig};
-use ktracepoint::{TraceCallbackType, TraceEventFunc};
 
 use crate::{
     StarryError, StarryResult,
@@ -36,7 +36,7 @@ type TpCallback = Box<dyn Fn(&[u8], &(dyn Any + Send + Sync)) + Send + Sync>;
 
 /// Per-fd tracepoint perf event. Holds the Arc<Mutex<ExtTracePoint>> so we
 /// can register/unregister callbacks on drop; remembers the callback
-/// payload so the same registration can be undone (ktracepoint 0.6
+/// payload so the same registration can be undone (ax-tracepoint 0.6
 /// `unregister(callback)` compares Arc pointer identity).
 pub struct TracepointPerfEvent {
     _args: PerfProbeArgs,
@@ -107,16 +107,19 @@ impl PerfEventOps for TracepointPerfEvent {
             }
         });
         let callback = Arc::new(TraceEventFunc::new(func, ctx));
-        self.ext_tp
-            .lock()
-            .register(TraceCallbackType::Event(callback.clone()));
+        self.registered
+            .try_reserve(1)
+            .map_err(|_| StarryError::NoMemory)?;
+        self.ext_tp.update(|ext_tp| {
+            ext_tp.register(TraceCallbackType::Event(callback.clone()));
+        });
         self.registered.push(callback);
         Ok(())
     }
 
     fn enable(&mut self) -> StarryResult<()> {
-        // ktracepoint dispatch only invokes a cooked `TraceEventFunc` when
-        // its per-callback `perf_enabled` flag is set (see ktracepoint 0.6
+        // ax-tracepoint dispatch only invokes a cooked `TraceEventFunc` when
+        // its per-callback `perf_enabled` flag is set (see ax-tracepoint 0.6
         // `basic_macro.rs`), and `TraceEventFunc::new` starts disabled. So a
         // perf event that is registered but not enabled would silently never
         // fire — we must flip the flag on every callback we registered.
@@ -140,10 +143,12 @@ impl PerfEventOps for TracepointPerfEvent {
 
 impl Drop for TracepointPerfEvent {
     fn drop(&mut self) {
-        let mut ext_tp = self.ext_tp.lock();
-        for cb in self.registered.drain(..) {
-            ext_tp.unregister(TraceCallbackType::Event(cb));
-        }
+        let registered = core::mem::take(&mut self.registered);
+        self.ext_tp.update(|ext_tp| {
+            for callback in registered {
+                ext_tp.unregister(TraceCallbackType::Event(callback));
+            }
+        });
     }
 }
 

--- a/os/StarryOS/kernel/src/perf/tracepoint.rs
+++ b/os/StarryOS/kernel/src/perf/tracepoint.rs
@@ -30,9 +30,9 @@ use crate::{
 };
 
 /// Closure signature accepted by `TraceEventFunc::new` for cooked tracepoints:
-/// the tracing layer hands over the per-cpu sample bytes plus the type-erased
+/// the tracing layer hands over an exclusive event record plus the type-erased
 /// per-callback payload, and the closure dispatches into the BPF VM.
-type TpCallback = Box<dyn Fn(&[u8], &(dyn Any + Send + Sync)) + Send + Sync>;
+type TpCallback = Box<dyn Fn(&mut [u8], &(dyn Any + Send + Sync)) + Send + Sync>;
 
 /// Per-fd tracepoint perf event. Holds the Arc<Mutex<ExtTracePoint>> so we
 /// can register/unregister callbacks on drop; remembers the callback
@@ -86,7 +86,7 @@ impl PerfEventOps for TracepointPerfEvent {
             vm: OwnedEbpfVm::new(bpf_prog)?,
         });
 
-        let func: TpCallback = Box::new(|entry: &[u8], data: &(dyn Any + Send + Sync)| {
+        let func: TpCallback = Box::new(|entry: &mut [u8], data: &(dyn Any + Send + Sync)| {
             // `TraceEventFunc` keeps the payload as `Box<dyn Any + Send + Sync>`
             // and hands the closure `&self.data`, so the concrete type observed
             // here is the *box*, not `Ctx` (same as the raw-tracepoint path in
@@ -95,13 +95,6 @@ impl PerfEventOps for TracepointPerfEvent {
                 .downcast_ref::<Box<dyn Any + Send + Sync>>()
                 .and_then(|boxed| boxed.downcast_ref::<Ctx>())
                 .expect("tracepoint Ctx mismatch");
-            // BPF programs expect a mutable context slice; the
-            // tracepoint hands us a `&[u8]` carved out of its
-            // per-cpu sample buffer, which is single-writer at that
-            // point, so casting to `&mut [u8]` is safe under the
-            // tracepoint contract.
-            let entry =
-                unsafe { core::slice::from_raw_parts_mut(entry.as_ptr() as *mut u8, entry.len()) };
             if let Err(e) = ctx.vm.execute_program(entry) {
                 error!("tracepoint BPF program failed: {e:?}");
             }

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -151,7 +151,7 @@ pub fn sys_chroot(path: *const c_char) -> StarryResult<isize> {
     Ok(0)
 }
 
-ktracepoint::define_event_trace!(
+ax_tracepoint::define_event_trace!(
     sys_mkdirat,
     TP_kops(crate::tracepoint::KernelTraceAux),
     TP_system(syscalls),

--- a/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/fd_ops.rs
@@ -427,7 +427,7 @@ fn try_open_nsfd(path: &str, flags: u32) -> Option<StarryResult<i32>> {
     Some(fd)
 }
 
-ktracepoint::define_event_trace!(
+ax_tracepoint::define_event_trace!(
     sys_enter_openat,
     TP_kops(crate::tracepoint::KernelTraceAux),
     TP_system(syscalls),

--- a/os/StarryOS/kernel/src/syscall/task/clone.rs
+++ b/os/StarryOS/kernel/src/syscall/task/clone.rs
@@ -127,7 +127,7 @@ bitflags! {
 // funnel through), so the event schema and the fast-path call stay together.
 // Registration into the global `.tracepoint` section is by link section, so
 // the definition's module location is immaterial to discovery.
-ktracepoint::define_event_trace!(
+ax_tracepoint::define_event_trace!(
     sched_process_fork,
     TP_kops(crate::tracepoint::KernelTraceAux),
     TP_system(sched),
@@ -617,7 +617,7 @@ impl CloneArgs {
     }
 }
 
-ktracepoint::define_event_trace!(
+ax_tracepoint::define_event_trace!(
     sys_clone,
     TP_kops(crate::tracepoint::KernelTraceAux),
     TP_system(syscalls),

--- a/os/StarryOS/kernel/src/task/ops.rs
+++ b/os/StarryOS/kernel/src/task/ops.rs
@@ -311,7 +311,7 @@ pub fn exit_robust_list(thr: &Thread, head: *const RobustListHead) -> StarryResu
 // emission site in `do_exit`, so the event schema and the fast-path call stay
 // together. Registration into the global `.tracepoint` section is by link
 // section, so the definition's module location is immaterial to discovery.
-ktracepoint::define_event_trace!(
+ax_tracepoint::define_event_trace!(
     sched_process_exit,
     TP_kops(crate::tracepoint::KernelTraceAux),
     TP_system(sched),

--- a/os/StarryOS/kernel/src/tracepoint/control.rs
+++ b/os/StarryOS/kernel/src/tracepoint/control.rs
@@ -1,5 +1,5 @@
+use ax_tracepoint::{TraceFilterFile, TracePoint, TracePointEnableFile};
 use axfs_ng_vfs::{VfsError, VfsResult};
-use ktracepoint::{TraceFilterFile, TracePoint, TracePointEnableFile};
 
 use crate::{
     pseudofs::DirectRwFsFileOps,
@@ -17,7 +17,7 @@ pub struct EventEnableObj {
 impl EventEnableObj {
     /// Create a new `EventEnableObj` instance.
     pub fn new(ext_tp: KernelExtTracePoint) -> Self {
-        let tp = ext_tp.lock().trace_point();
+        let tp = ext_tp.trace_point();
         EventEnableObj {
             file: TracePointEnableFile::new(),
             ext_tp,
@@ -51,8 +51,7 @@ impl DirectRwFsFileOps for EventEnableObj {
             _ => return Err(VfsError::InvalidInput),
         };
 
-        let mut ext_tp = self.ext_tp.lock();
-        self.file.write(&mut ext_tp, value);
+        self.ext_tp.update(|ext_tp| self.file.write(ext_tp, value));
         Ok(buf.len())
     }
 }
@@ -87,10 +86,9 @@ impl DirectRwFsFileOps for EventFilterObj {
 
     fn write_at(&self, buf: &[u8], _offset: u64) -> VfsResult<usize> {
         let filter_str = core::str::from_utf8(buf).map_err(|_| VfsError::InvalidInput)?;
-        let mut ext_tp = self.ext_tp.lock();
-        self.file
-            .lock()
-            .write(&mut ext_tp, filter_str)
+        let mut file = self.file.lock();
+        self.ext_tp
+            .update(|ext_tp| file.write(ext_tp, filter_str))
             .map_err(|_| VfsError::InvalidInput)?;
         Ok(buf.len())
     }

--- a/os/StarryOS/kernel/src/tracepoint/mod.rs
+++ b/os/StarryOS/kernel/src/tracepoint/mod.rs
@@ -1,5 +1,6 @@
 //! See Linux Documentation for details: <https://docs.kernel.org/trace/ftrace.html>
 mod control;
+mod registry;
 mod sched;
 mod trace;
 mod trace_pipe;
@@ -18,17 +19,17 @@ use core::{
 };
 
 use ax_lazyinit::LazyInit;
-use ax_memory_addr::VirtAddr;
 use ax_runtime::hal::{percpu::this_cpu_id, time::monotonic_time_nanos};
 use ax_task::{IrqNotify, current};
+use ax_tracepoint::*;
 use axfs_ng_vfs::NodePermission;
 use axpoll::{IoEvents, PollSet};
-use ktracepoint::*;
+pub use registry::KernelExtTracePoint;
 
 use crate::{
     StarryError, StarryResult,
     pseudofs::{DirMaker, DirMapping, SeqObject, SimpleDir, SimpleFs, SpecialFsFile},
-    sync::{Mutex, NoPreemptMutex},
+    sync::Mutex,
     task::{AsThread, PidIdentityId, TgidNumber},
 };
 
@@ -36,14 +37,6 @@ use crate::{
 const TRACE_RAW_PIPE_CAPACITY: usize = 4096;
 /// Maximum number of PID→cmdline entries in the command-line cache.
 const TRACE_CMDLINE_CACHE_SIZE: usize = 4096;
-
-// The registry entry is locked from the tracepoint fire path, which for
-// `sched:sched_switch` runs inside `axtask::switch_to` (IRQ off,
-// preemption disabled). A sleeping `Mutex` would trip the
-// "sleeping in atomic context" guard there, so this lock must be a
-// non-sleeping spinlock — the same kind the perf output path (`PERF_FILE`)
-// uses for exactly this reason.
-pub type KernelExtTracePoint = Arc<NoPreemptMutex<ExtTracePoint<KernelTraceAux>>>;
 
 /// Look up a registered tracepoint by its numeric id (as found in
 /// `/sys/kernel/debug/tracing/events/<subsystem>/<event>/id`).
@@ -61,7 +54,7 @@ pub fn lookup_ext_tracepoint(id: u32) -> Option<KernelExtTracePoint> {
 /// initialized yet.
 pub fn find_ext_tracepoint_by_name(name: &str) -> Option<KernelExtTracePoint> {
     for ext_tp in TRACE_STATE.ext_tracepoints.get()?.values() {
-        if ext_tp.lock().trace_point().name() == name {
+        if ext_tp.trace_point().name() == name {
             return Some(ext_tp.clone());
         }
     }
@@ -258,18 +251,13 @@ impl KernelTraceOps for KernelTraceAux {
             .insert(tgid.get(), &current_comm());
     }
 
-    fn write_kernel_text(addr: *mut core::ffi::c_void, data: &[u8]) {
-        crate::mm::write_kernel_text(VirtAddr::from_mut_ptr_of(addr), data)
-            .expect("Failed to write kernel text");
-    }
-
     fn read_tracepoint_state<R>(id: u32, f: impl FnOnce(&ExtTracePoint<Self>) -> R) -> R {
         let ext_tp = TRACE_STATE
             .ext_tracepoints
             .deref()
             .get(&id)
             .expect("Tracepoint not found");
-        f(ext_tp.lock().deref())
+        ext_tp.read(f)
     }
 
     fn write_tracepoint_state<R>(id: u32, f: impl FnOnce(&mut ExtTracePoint<Self>) -> R) -> R {
@@ -278,8 +266,7 @@ impl KernelTraceOps for KernelTraceAux {
             .deref()
             .get(&id)
             .expect("Tracepoint not found");
-        let mut ext_tp = ext_tp.lock();
-        f(&mut ext_tp)
+        ext_tp.update(f)
     }
 }
 
@@ -385,11 +372,18 @@ fn common_trace_pipe_read(
             debug_assert_ne!(record.identity_id.get(), 0);
             let mut record_cmdline = TraceCmdLineCache::new(NonZero::new(1).unwrap());
             record_cmdline.insert(record.tgid.get(), &record.comm);
-            let record_str = TraceEntryParser::parse::<KernelTraceAux>(
+            let record_str = match TraceEntryParser::parse::<KernelTraceAux>(
                 &TRACE_STATE.point_map,
                 &record_cmdline,
                 &record.record,
-            );
+            ) {
+                Ok(record) => record,
+                Err(error) => {
+                    warn!("discarding invalid trace record: {error}");
+                    trace_buf.pop();
+                    continue;
+                }
+            };
             if !drain.copy_record(record_str.as_bytes(), buf, &mut copy_len) {
                 break;
             }
@@ -412,7 +406,7 @@ pub fn tracepoint_init() -> StarryResult<()> {
 
     let ext_tps = ext_tps
         .into_iter()
-        .map(|ext_tp| (ext_tp.id(), Arc::new(NoPreemptMutex::new(ext_tp))))
+        .map(|ext_tp| (ext_tp.trace_point().id(), KernelExtTracePoint::new(ext_tp)))
         .collect::<BTreeMap<_, _>>();
 
     ax_println!("Initialized {} tracepoints", tp_map.len());
@@ -470,7 +464,7 @@ fn init_events(fs: Arc<SimpleFs>) -> DirMaker {
     let mut subsystem = BTreeMap::new();
 
     for ext_tp in TRACE_STATE.ext_tracepoints.deref().values() {
-        let tp = ext_tp.lock().trace_point();
+        let tp = ext_tp.trace_point();
         let subsystem_name = tp.system();
         let event_name = tp.name();
 

--- a/os/StarryOS/kernel/src/tracepoint/registry.rs
+++ b/os/StarryOS/kernel/src/tracepoint/registry.rs
@@ -1,0 +1,45 @@
+//! Starry-owned synchronization and publication for tracepoint runtime state.
+
+use alloc::sync::Arc;
+
+use ax_tracepoint::{ExtTracePoint, TracePoint};
+
+use super::KernelTraceAux;
+use crate::sync::NoPreemptMutex;
+
+/// One Starry tracepoint runtime state guarded for scheduler and IRQ readers.
+///
+/// The wrapper is the only mutation boundary: it updates the callback gate
+/// while holding the same non-preemptible lock that protects the callback
+/// list. This preserves Starry's existing callback execution context while
+/// replacing ax-tracepoint's former live kernel-text patching.
+#[derive(Clone)]
+pub struct KernelExtTracePoint {
+    state: Arc<NoPreemptMutex<ExtTracePoint<KernelTraceAux>>>,
+}
+
+impl KernelExtTracePoint {
+    pub(super) fn new(state: ExtTracePoint<KernelTraceAux>) -> Self {
+        Self {
+            state: Arc::new(NoPreemptMutex::new(state)),
+        }
+    }
+
+    /// Runs one read while holding the scheduler-safe state lock.
+    pub fn read<R>(&self, operation: impl FnOnce(&ExtTracePoint<KernelTraceAux>) -> R) -> R {
+        operation(&self.state.lock())
+    }
+
+    /// Applies one state update and publishes the resulting callback gate.
+    pub fn update<R>(&self, operation: impl FnOnce(&mut ExtTracePoint<KernelTraceAux>) -> R) -> R {
+        let mut state = self.state.lock();
+        let result = operation(&mut state);
+        state.trace_point().set_callback_gate(state.has_callbacks());
+        result
+    }
+
+    /// Returns the immutable static descriptor associated with this state.
+    pub fn trace_point(&self) -> &'static TracePoint<KernelTraceAux> {
+        self.read(ExtTracePoint::trace_point)
+    }
+}

--- a/os/StarryOS/kernel/src/tracepoint/sched.rs
+++ b/os/StarryOS/kernel/src/tracepoint/sched.rs
@@ -12,7 +12,7 @@ use ax_task::{SchedTracepoint, TaskId, task_by_id};
 
 use crate::task::AsThread;
 
-ktracepoint::define_event_trace!(
+ax_tracepoint::define_event_trace!(
     sched_switch,
     TP_kops(crate::tracepoint::KernelTraceAux),
     TP_system(sched),

--- a/os/StarryOS/kernel/src/tracepoint/trace.rs
+++ b/os/StarryOS/kernel/src/tracepoint/trace.rs
@@ -1,5 +1,5 @@
+use ax_tracepoint::TraceCmdLineCacheSnapshot;
 use axfs_ng_vfs::VfsResult;
-use ktracepoint::TraceCmdLineCacheSnapshot;
 
 use crate::{pseudofs::DirectRwFsFileOps, sync::Mutex};
 


### PR DESCRIPTION
## 问题

StarryOS 当前直接依赖 crates.io 上的 `ktracepoint 0.6.0`，而 PR #1775 中已经演进出一版不依赖运行时代码覆写的 tracepoint 组件。该实现仍混在 #1775 的 task/runtime 大范围重构中，无法作为独立组件审核和合入；旧 crate 名也不符合当前 workspace 的 `ax-*` 命名。

## 改动

- 从 PR #1775 的 `ec879a74fa1b094c25e8ceda052a3fc3cc314a7e` 提取 tracepoint 组件，并重命名为 `ax-tracepoint` / `ax_tracepoint`。
- 用原子 callback gate 替代 `static-keys` 及运行时内核文本覆写，移除 `write_kernel_text` 宿主能力。
- 增加类型标记的 linker metadata、链接段边界校验和不同 `KernelTraceOps` 类型隔离，避免跨类型恢复静态元数据。
- 收紧公开 API 和 unsafe 边界：限定 `TraceField`，对未对齐/短记录做长度检查，解析和格式化返回 typed error，不再因损坏记录或未知 tracepoint ID panic。
- 将 filter 更新改为事务语义：空表达式和编译失败不会清空已有有效过滤器，只有精确的 `0` 清除过滤器。
- trace record 改为在零初始化 backing 上按 `repr(C)` offset 写入各字段；perf/BPF 与 trace-pipe 共用同一 encoder，保证对外暴露的结构体 padding 已初始化。
- cooked event callback 改为接收每次调用独占的 `&mut [u8]`；每个 callback 单独编码 record，Starry BPF 适配不再把共享切片裸转换为可变切片。
- 宏展开通过不同名临时值保存 `TP_fast_assign` 结果，保持一次求值与原输入顺序，并从根因消除 `redundant_field_names`，没有使用 `allow` 规避 clippy。
- 将 `ax-tracepoint` LICENSE 中的占位版权人替换为实际版权持有人。
- 将 StarryOS 的全部现有调用点迁移到本地 workspace crate，并由 `KernelExtTracePoint` 在同一 `NoPreemptMutex` 临界区内统一管理 callback 状态与 gate 发布。
- 增加中英文 README、host example，以及提取范围、并发约束、unsafe/linker 契约、备选方案和回滚路径的设计文档。

## 方案边界

本 PR 只提取可独立落地的 tracepoint 组件与必要的 Starry 适配，不带入 #1775 的 ax-task、ax-runtime、scheduler、trace ingress 或 generation/RCU registry 重构。这样可以保持当前 Starry callback 执行上下文不变，并让组件边界单独审核。

callback 列表仍由 Starry 的 `NoPreemptMutex` 保护；回调不得递归进入同一 registry，也不得在读闭包中调用写接口。若后续要把 callback 移出该临界区，需要先独立交付 IRQ-safe trace ingress、生命周期与回收协议。

Linux 对照采用官方 tracepoint 与 ftrace 文档：

- https://docs.kernel.org/trace/tracepoints.html
- https://docs.kernel.org/trace/ftrace.html

## 回归与验证

确定性 red/green 回归：

- `empty_filter_is_rejected_without_panicking`：旧实现对空 slice 索引并 panic；新实现返回 `EmptyExpression`。
- `invalid_filter_preserves_the_previous_compiled_expression`：旧实现错误清空已有 compiled filter；新实现保留旧状态。
- `unknown_tracepoint_record_is_rejected_without_panicking`：旧实现因 `expect` panic；新实现返回 typed parse error。
- `generated_record_zeroes_c_layout_padding`：修复前缺少共享的零初始化 encoder，测试确定性编译失败；修复后验证实际含尾部 padding 的 `u64 + u32` 事件记录中所有 padding 字节均为零。
- `cooked_event_callback_receives_an_exclusive_record`：旧 `&[u8]` callback 接口下确定性编译失败；改为显式 `&mut [u8]` 后，同一测试可修改并观察 record。
- reviewer 的原始命令 `cargo clippy -p ax-tracepoint --all-targets -- -D warnings` 修复前稳定报告 4 个 `redundant_field_names`，修复后通过。

当前分支直接基于 `origin/dev@8386094e6d2665e822436f8f3f511e1890fa577c`，head 为 `4edb970d9a`。本地结果：

- `cargo fmt --all -- --check`
- `cargo test -p ax-tracepoint`：8/8
- `cargo clippy -p ax-tracepoint --all-targets -- -D warnings`
- `cargo run -p ax-tracepoint --example usage`：发现两个 event，完成 callback、filter、raw/event dispatch 和 6 条记录格式化
- `cargo xtask clippy --package ax-tracepoint --package starry-kernel`：99/99
- `cargo xtask ktest qemu -p starry-kernel --test axtest_kernel --arch x86_64`：42/42，`AXTEST_SUITE_OK`
- `git diff --check origin/dev...HEAD`

- GitHub Actions（head `4edb970d9a`）：39/39 checks success（run https://github.com/rcore-os/tgoskits/actions/runs/32239483779）

物理板与 self-hosted 测试未在本地执行，交由 CI 覆盖。
