### PR TITLE
chore(review): standardize Chinese review guidance

### DIFF
--- a/.claude/skills/review-open-prs/SKILL.md
+++ b/.claude/skills/review-open-prs/SKILL.md
@@ -63,39 +63,42 @@ Carry this plan into the per-PR review and final report. The report must disting
 
 ## Dispatch
 
-For each eligible PR, invoke `review-single-pr` with a prompt that carries the multi-PR context but leaves review decisions to the single-PR skill:
+对每个符合条件的 PR 调用 `review-single-pr`。提示中携带批量审查上下文，但把具体审查决定留给单 PR 技能：
 
 ```text
-Use $review-single-pr to review PR #<pr> in <owner>/<repo>.
+请使用 $review-single-pr 审查 <owner>/<repo> 的 PR #<pr>。
 
-Context from $review-open-prs:
-- This PR is eligible because <never reviewed by current user | latest commit <sha/time> is newer than current user's last review <time>>.
-- Draft status: <draft|ready>.
-- Merge state: <mergeStateStatus>; maintainer edits: <maintainerCanModify>.
-- Scope requested by user: <scope summary>.
-- Current-head CI summary: <success/failure/pending/skipped counts, relevant check names, stale/missing/suspicious notes>.
-- Validation plan: <CI covered evidence>; <every affected app and its documented environment setup, architecture, exact local runtime command, readiness check, and postcondition>; <other CI-missing PR-body/docs workflows to validate>; <duplicative non-app CI-equivalent local checks to skip>; <commands that still must run because CI is missing/failing/suspicious or review-single-pr requires them>.
+来自 $review-open-prs 的上下文：
+- 符合条件的原因：<当前用户从未审查 | 最新提交 <sha/time> 晚于当前用户上次审查 <time>>。
+- 草稿状态：<draft|ready>。
+- 合并状态：<mergeStateStatus>；维护者能否修改：<maintainerCanModify>。
+- 用户要求的范围：<范围摘要>。
+- 当前提交的 CI 摘要：<success/failure/pending/skipped 数量、相关检查名称、陈旧/缺失/可疑说明>。
+- 验证计划：<CI 已覆盖的证据>；<每个受影响应用及其文档化环境准备、架构、精确本地运行命令、就绪检查和后置条件>；<其他 CI 未覆盖且需验证的 PR 描述或文档流程>；<因当前提交 CI 已覆盖而跳过的重复非应用检查>；<因 CI 缺失、失败、可疑或 review-single-pr 强制要求而仍须运行的命令>。
 
-Review exactly this PR. After reading every applicable instruction, guideline, and runbook, use the available todo tool to create a complete PR-specific todo before detailed review or validation; use a visible Markdown fallback only when no tool is available or it is confirmed unusable. Follow $review-single-pr for worktree setup, duplicate/superseded fix checks, conflict handling policy, targeted validation, Chinese inline comments, head-SHA freshness checks, and final APPROVE or REQUEST_CHANGES submission. Locally configure and run every affected StarryOS or ArceOS app on the current head even when CI passed; documentation, setup, readiness, or runtime failure requires REQUEST_CHANGES with the exact reason. Audit every todo item before submission and again after reviewer assignment and cleanup.
+只审查这个 PR。完整阅读所有适用指令、规范和操作手册后，在详细审查或验证前使用可用的任务清单工具创建完整的 PR 专属清单；只有工具不可用或确认失效时才改用可见的 Markdown 清单。按照 $review-single-pr 建立工作树、检查重复或已被取代的实现、处理冲突、执行针对性验证、检查当前提交 SHA，并提交最终的 APPROVE 或 REQUEST_CHANGES。即使 CI 已通过，也要在当前提交本地配置并运行每个受影响的 StarryOS 或 ArceOS 应用；文档、准备、就绪或运行失败都必须以精确理由请求修改。每条要求继续修改的行内评论或讨论回复都使用 $review-single-pr 的七段中文模板，总审查正文使用四段中文核心结构；提交前检查草稿格式，提交后重新读取实际评论并检查显示格式。提交前以及分配审查人和清理后，都要逐项审计任务清单。
 ```
 
-If workers or subagents are explicitly allowed, give each worker exactly one PR and one worktree. Worker prompts must say:
+明确允许使用执行者或子代理时，给每个执行者恰好一个 PR 和一个工作树。提示中必须要求：
 
-- use `review-single-pr` for the actual review procedure;
-- after reading all applicable instructions and references, use the available todo tool to create and maintain a complete PR-specific todo before detailed review; use a visible Markdown fallback only when no tool is available or confirmed unusable;
-- perform read-only review plus targeted validation only;
-- skip broad non-app local checks that only duplicate already-passing current-head CI, but always follow the documented environment setup and locally run every affected StarryOS or ArceOS app on the current head;
-- do not submit GitHub reviews;
-- do not push contributor branches unless explicitly assigned conflict-repair work, and then prefer local commit only with final push by the main agent;
-- return `APPROVE` or `REQUEST_CHANGES`;
-- provide `path`, `line`, `side=RIGHT`, and Chinese inline comment body for each blocking issue;
-- include commands run and exact failures;
-- report each affected app's setup source, setup commands, readiness result, architecture, runtime command, and postcondition or blocking failure, plus CI-covered evidence, other CI-missing workflows validated, CI-missing workflows not validated with reasons, and non-app CI-equivalent local checks skipped as duplicative;
-- identify missing reproduction tests for bug fixes.
-- audit every todo item before returning and report completed evidence, concrete not-applicable reasons, blocking results, and unfinished items;
-- clean temporary worktrees/files before returning, or report the path and reason when cleanup is unsafe.
+- 使用 `review-single-pr` 执行实际审查流程；
+- 完整阅读所有适用指令和资料后，在详细审查前使用可用的任务清单工具创建并维护完整的 PR 专属清单；只有工具不可用或确认失效时才改用可见的 Markdown 清单；
+- 只执行只读审查和针对性验证；
+- 跳过仅重复当前提交已通过 CI 的宽泛非应用本地检查，但始终遵循文档化环境准备，并在当前提交本地运行每个受影响的 StarryOS 或 ArceOS 应用；
+- 不提交 GitHub 审查；
+- 除非明确分配冲突修复，否则不推送贡献者分支；即使分配，也优先只创建本地提交，由主代理最终推送；
+- 返回 `APPROVE` 或 `REQUEST_CHANGES`；
+- 为每个阻塞问题返回 `path`、`line`、`side=RIGHT` 和中文行内评论正文；
+- 每条要求继续修改的评论完整包含“为什么需要改动”“改动收益”“改动前逻辑（基准分支）”“改动后逻辑（当前 PR）”“触发场景与证据”“问题级别”“建议修改方式”七个粗体 Markdown 标题；
+- 总审查正文至少包含前四个二级 Markdown 标题，并报告发布前后的格式检查结果；
+- 返回前逐字核对固定标题；缺少标题、标题下为空或使用连续段落代替时，丢弃草稿并重写；
+- 列出执行的命令和精确失败；
+- 汇报每个受影响应用的准备资料来源、准备命令、就绪结果、架构、运行命令、后置条件或阻塞失败，同时汇报 CI 已覆盖证据、已验证的 CI 缺失流程、未验证流程及原因，以及因重复当前提交 CI 而跳过的非应用本地检查；
+- 指出错误修复缺失的复现测试；
+- 返回前审计每个任务清单项，汇报完成证据、具体不适用理由、阻塞结果和未完成项目；
+- 清理临时工作树和文件；清理不安全时汇报路径和原因。
 
-Before submitting any worker-derived review, the main agent must refresh the PR head, verify each finding still applies to a current right-side diff line, and follow `review-single-pr` submission rules.
+提交任何来自执行者的审查前，主代理必须刷新 PR 当前提交，确认每个问题仍适用于当前右侧变更行，并遵循 `review-single-pr` 的提交和发布后格式检查规则。
 
 ## Conflict Handling
 

--- a/.claude/skills/review-single-pr/SKILL.md
+++ b/.claude/skills/review-single-pr/SKILL.md
@@ -1,60 +1,62 @@
 ---
 name: review-single-pr
-description: 审查本 tgoskits 仓库中一个指定的 GitHub Pull Request。适用于用户指定 PR 编号或 URL，要求审查、复审、对照 Linux/POSIX/RFC/VirtIO 语义、检查重复实现或相关开放 PR、建立并关闭 PR 专属审查清单、验证测试位置与发现和执行链路、在 CI 通过时仍本地运行新增或变更的 StarryOS/ArceOS 应用、修复安全的合并冲突、执行针对性验证、提交中文行内评论、批准或请求修改，以及审查后依据 .github/MAINTAINERS.md 推荐并分配审查人。
+description: 审查本 tgoskits 仓库中一个指定的 GitHub 拉取请求。适用于用户指定 PR 编号或网址，要求审查、复审、对照 Linux/POSIX/RFC/VirtIO 语义、检查重复实现或相关开放 PR、建立并关闭 PR 专属审查清单、验证测试位置与发现和执行链路、在 CI 通过时仍本地运行新增或变更的 StarryOS/ArceOS 应用、修复安全的合并冲突、执行针对性验证、提交面向初学者的中文行内评论、批准或请求修改，以及审查后依据 .github/MAINTAINERS.md 推荐并分配审查人。
 ---
 
 # 审查单个 PR
 
-## 规范性要求
+## 强制要求
 
-本 skill 是强制性审查规范，不是建议清单。触发后，必须完整阅读本文件，再作出审查结论；除非更高优先级指令冲突，否则执行所有适用要求。
+将本技能视为强制性审查规范，而不是建议清单。触发后完整阅读本文件，再作出审查结论；除非更高优先级指令冲突，否则执行所有适用要求。
 
-判断代码质量、可维护性或可合入状态前，必须完整阅读 `docs/guideline/code-quality.md`。PR 新增或扩展用户可见行为、共享或公共接口、crate、子系统、平台或硬件能力时，必须完整阅读 `docs/guideline/feature-development.md`；触发条件按语义判断，不按标题判断。仅在语义适用时读取其他领域规范。任何改动或声明若影响 StarryOS syscall/Linux ABI，包括 task、VFS、namespace、signal、socket、credential、memory-management 等间接 helper，必须完整阅读 `docs/guideline/starry_syscall.md`。不适用时，在审查清单中记录具体理由。上下文被压缩、从摘要恢复或无法确信记得规范时，重新完整阅读，不能依赖记忆或旧的局部阅读。
+判断代码质量、可维护性或可合入状态前，完整阅读 `docs/guideline/code-quality.md`。PR 新增或扩展用户可见行为、共享或公共接口、软件包、子系统、平台或硬件能力时，完整阅读 `docs/guideline/feature-development.md`；按语义而不是标题判断是否适用。仅在语义适用时读取其他领域规范。任何改动或声明若影响 StarryOS 系统调用或 Linux ABI，包括任务、虚拟文件系统、命名空间、信号、套接字、凭据、内存管理等间接辅助代码，完整阅读 `docs/guideline/starry_syscall.md`。不适用时，在审查清单中记录具体理由。上下文被压缩、从摘要恢复或无法确信记得规范时，重新完整阅读，不能依赖记忆或旧的局部阅读。
 
-没有完整阅读本 skill 和所有适用规范时，不得提交 `APPROVE`、`REQUEST_CHANGES`、no-submit 总结或任何面向 PR 的评论。规则重叠时采用更严格者；跳过要求时必须记录具体理由和证据。
+没有完整阅读本技能和所有适用规范时，不得提交 `APPROVE`、`REQUEST_CHANGES`、不提交审查的总结或任何面向 PR 的评论。规则重叠时采用更严格者；跳过要求时记录具体理由和证据。
+
+输出任何审查文本前，先执行“中文审查文本规范”。要求修改的评论先复制“为什么需要改动、改动收益、改动前逻辑（基准分支）、改动后逻辑（当前 PR）、触发场景与证据、问题级别、建议修改方式”七个粗体 Markdown 标题再填写；缺少任一标题、标题下为空或用连续段落代替标题时，禁止输出或提交，必须重写。总审查正文先复制前四个二级 Markdown 标题再填写；缺少任一标题时同样禁止输出或提交。
 
 ## 审查清单门禁
 
-详细判断前，只读取足以识别审查范围的当前 head 元数据、PR body、变更路径、commit 和语义范围，然后完整读取本 skill、仓库指令、必读规范以及规划验证所需的应用文档或 runbook。
+详细判断前，只读取足以识别审查范围的当前提交元数据、PR 描述、变更路径、提交记录和语义范围，然后完整读取本技能、仓库指令、必读规范以及规划验证所需的应用文档或操作手册。
 
-完成这些读取后，必须立即通过可用的 todo/plan 工具创建用户可见、PR 专属的完整清单，并等待调用成功。持续使用同一个工具，最多一个项目为进行中；发现新范围时先追加清单再调查。工具返回空结果但未报错时视为成功。只有工具不可用或确认失败时才改用可见 Markdown checklist，并说明原因。
+完成这些读取后，立即通过可用的任务清单工具创建用户可见、PR 专属的完整清单，并等待调用成功。持续使用同一个工具，最多一个项目处于进行中；发现新范围时先追加清单再调查。工具返回空结果但未报错时视为成功。只有工具不可用或确认失败时才改用可见的 Markdown 清单，并说明原因。
 
-每个清单项必须写明具体 surface 和预期 evidence，覆盖：当前 head intake、既有 review threads、CI、worktree、必要时的冲突、每个受影响模块及 review lens、代码质量基线、feature-development 适用性、领域语义、测试的位置/构建/发现/选择/执行、重复与重叠分析、精确验证命令、阻塞 finding 与评论、head 刷新、审查提交、reviewer 分配和清理。每个受影响应用、环境准备、架构/运行命令以及每个新增或迁移测试都要有独立项目。禁止使用“review code”“run tests”之类泛化项目。
+每个清单项写明具体受影响范围和预期证据，覆盖：当前提交信息、既有审查讨论、CI、工作树、必要时的冲突、每个受影响模块及审查视角、代码质量基线、功能开发规范适用性、领域语义、测试的位置/构建/发现/选择/执行、重复与重叠分析、精确验证命令、阻塞问题与评论、当前提交刷新、审查提交、审查人分配和清理。每个受影响应用、环境准备、架构与运行命令以及每个新增或迁移测试都建立独立项目。禁止使用“审查代码”“运行测试”之类泛化项目。
 
-提交任何审查结论前逐项审计，只能以“有证据地完成”“给出具体理由的不适用”或“有证据的阻塞结论”关闭。阻塞结论会完成调查项，但必须进入中文审查文本和最终决定。任何必需项仍 pending、不可验证或缺少证据时禁止 `APPROVE`；若缺口由 PR 引入则提交 `REQUEST_CHANGES`，若外部审查系统限制阻止完成则明确 no-submit。审查提交、reviewer 分配和清理后，再做一次最终清单审计并向用户汇报完成项、不适用项、阻塞项和未完成项。
+提交任何审查结论前逐项审计，只能以“有证据地完成”“给出具体理由的不适用”或“有证据的阻塞结论”关闭。阻塞结论会完成调查项，但必须进入中文审查文本和最终决定。任何必需项仍为 `pending`、不可验证或缺少证据时禁止 `APPROVE`；若缺口由 PR 引入则提交 `REQUEST_CHANGES`，若外部审查系统限制阻止完成则明确不提交审查。提交审查、分配审查人和清理后，再做一次最终清单审计，向用户汇报完成项、不适用项、阻塞项和未完成项。
 
 ## 离线基准模式
 
 仅当以精确参数 `offline-benchmark` 调用，且仓库存在 `.agent-review-context/reviewer.md` 时启用。否则执行正常在线流程。
 
-以 `bench-base..HEAD` 为唯一被审变更。完整阅读本 skill、`AGENTS.md`、`docs/guideline/code-quality.md`、按需读取 `docs/guideline/feature-development.md` 和领域规范，并读取离线 contract 与输出 schema。应用本 skill 的审查重点、测试质量、阻塞 finding、硬件/ABI、安全/健全性、可维护性和文档要求。
+以 `bench-base..HEAD` 为唯一被审变更。完整阅读本技能、`AGENTS.md`、`docs/guideline/code-quality.md`，按需读取 `docs/guideline/feature-development.md` 和领域规范，并读取离线约定与输出格式。应用本技能的审查重点、测试质量、阻塞问题、硬件/ABI、安全与健全性、可维护性和文档要求。
 
-离线环境没有真实 PR：PR 元数据、review threads、远端 CI、开放 PR 搜索、worktree、冲突修复、联网语义研究、命令验证、GitHub 提交、reviewer 分配和远端清理均标为不适用。禁止推断 PR 编号、访问仓库外路径或网络、修改文件、创建 commit/branch、运行 build/test。只使用只读仓库检查和 harness 允许的 Git 历史/diff 命令。
+离线环境没有真实 PR：PR 元数据、审查讨论、远端 CI、开放 PR 搜索、工作树、冲突修复、联网语义研究、命令验证、GitHub 提交、审查人分配和远端清理均标为不适用。禁止推断 PR 编号、访问仓库外路径或网络、修改文件、创建提交或分支、运行构建或测试。只使用只读仓库检查和测试框架允许的 Git 历史与差异命令。
 
-只返回 `.agent-review-context/review.schema.json` 要求的 JSON。finding 必须由 `bench-base..HEAD` 引入并锚定 `HEAD` 侧变更行；没有问题时返回空 `findings`。禁止提交或起草任何面向 GitHub 的审查文本。仍须创建并审计清单；若无 todo 工具，在内部跟踪，不能破坏 JSON-only contract。
+只返回 `.agent-review-context/review.schema.json` 要求的 JSON。问题必须由 `bench-base..HEAD` 引入并锚定 `HEAD` 侧变更行；没有问题时返回空 `findings`。禁止提交或起草任何面向 GitHub 的审查文本。仍须创建并审计清单；若无任务清单工具，在内部跟踪，不能破坏只返回 JSON 的约定。
 
 ## 目标与工具优先级
 
-只审查指定的一个 PR，在隔离 worktree 中完成代码分析和本地验证；同时判断它是否重复 base 已有功能、与其他开放 PR 重叠、冲突或已被取代。正常结果是没有阻塞问题时 `APPROVE`，存在正确性、规范、重复、测试或 CI 覆盖问题时以中文行内评论提交 `REQUEST_CHANGES`。审查完成后，仅在仍需领域跟进时依据 `.github/MAINTAINERS.md` 分配合适的人类 reviewer。
+只审查指定的一个 PR，在隔离工作树中完成代码分析和本地验证；同时判断它是否重复基准分支已有功能、与其他开放 PR 重叠、冲突或已被取代。没有阻塞问题时提交 `APPROVE`；存在正确性、规范、重复、测试或 CI 覆盖问题时，以中文行内评论提交 `REQUEST_CHANGES`。审查完成后，仅在仍需领域跟进时依据 `.github/MAINTAINERS.md` 分配合适的人类审查人。
 
-本 skill 是 `review-open-prs` 的单 PR 权威流程。不要完整审查所有开放 PR，但必须读取足够的相关 PR 上下文来分类重复和重叠。
+本技能是 `review-open-prs` 的单 PR 权威流程。不要完整审查所有开放 PR，但读取足够的相关 PR 上下文来分类重复和重叠。
 
-GitHub 操作优先遵循系统 skill：
+GitHub 操作优先遵循系统技能：
 
-- `github:github`：仓库定位、PR 元数据、patch、评论、label、reaction 和 connector-first 行为；
-- `github:gh-address-comments`：未解决 thread、requested changes、行内上下文、锚点和 thread resolution；
-- `github:gh-fix-ci`：失败的 GitHub Actions check 和日志。
+- `github:github`：仓库定位、PR 元数据、补丁、评论、标签、反应和连接器优先行为；
+- `github:gh-address-comments`：未解决讨论、请求修改、行内上下文、锚点和讨论解决状态；
+- `github:gh-fix-ci`：失败的 GitHub Actions 检查和日志。
 
-优先使用 GitHub MCP/connector 获取结构化数据，本地 `git` 用于 fetch、worktree、diff 和验证；只有 connector 无法满足当前分支发现、GraphQL thread、Actions 日志或带锚点提交等需求时才使用 `gh`。
+优先使用 GitHub 连接器获取结构化数据，本地 `git` 用于获取、工作树、差异和验证；只有连接器无法满足当前分支发现、GraphQL 讨论、Actions 日志或带锚点提交等需求时才使用 `gh`。
 
 ## PR 信息收集
 
-1. 通过 `github:github` 获取仓库身份、当前用户、PR 编号/URL、title、body、author、base/head ref、`headRefOid`、draft、merge state、changed files、patch、commit、既有 review/comment 和 checks。
+1. 通过 `github:github` 获取仓库身份、当前用户、PR 编号或网址、标题、描述、作者、基准与来源分支、`headRefOid`、草稿状态、合并状态、变更文件、补丁、提交、既有审查或评论和检查结果。
 2. PR 作者是当前 GitHub 用户时，提交正式审查前先征询用户。
-3. 除非用户明确排除，否则包含 draft PR。
-4. 创建 worktree 前确保 connector 状态和本地 checkout 对齐。
+3. 除非用户明确排除，否则包含草稿 PR。
+4. 创建工作树前确保连接器状态和本地检出内容一致。
 
-connector 缺少必要数据时才回退：
+连接器缺少必要数据时才回退：
 
 ```bash
 gh auth status
@@ -68,7 +70,7 @@ gh api --paginate "repos/<owner>/<repo>/pulls/<pr>/files?per_page=100"
 
 ## 审查讨论与 CI
 
-涉及既有 requested changes、未解决讨论、行内位置或 resolution 状态时，遵循 `github:gh-address-comments`。扁平 comment 列表不能代表完整 thread 状态。需要时使用带分页的完整 GraphQL 查询：
+涉及既有请求修改、未解决讨论、行内位置或解决状态时，遵循 `github:gh-address-comments`。扁平评论列表不能代表完整讨论状态。需要时使用带分页的完整 GraphQL 查询：
 
 ```bash
 gh api graphql --paginate \
@@ -76,7 +78,7 @@ gh api graphql --paginate \
   -f query='query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$repo){pullRequest(number:$number){reviewThreads(first:100,after:$endCursor){nodes{id isResolved isOutdated path line diffSide comments(first:100){nodes{author{login} body createdAt}pageInfo{hasNextPage endCursor}}}pageInfo{hasNextPage endCursor}}}}}'
 ```
 
-若任一 thread 的 `comments.pageInfo.hasNextPage=true`，再以该 thread 的 `id` 分页取得剩余评论，不能把前 100 条当作完整讨论：
+若任一讨论的 `comments.pageInfo.hasNextPage=true`，再以该讨论的 `id` 分页取得剩余评论，不能把前 100 条当作完整讨论：
 
 ```bash
 gh api graphql --paginate \
@@ -84,7 +86,7 @@ gh api graphql --paginate \
   -f query='query($threadId:ID!,$endCursor:String){node(id:$threadId){... on PullRequestReviewThread{comments(first:100,after:$endCursor){nodes{author{login} body createdAt}pageInfo{hasNextPage endCursor}}}}}'
 ```
 
-检查所有未解决 thread。具体问题已在当前 head 修复时 resolve；修复不完整、测试未接入 runner 或评论仍有效时保持 open。resolve 后重新查询并确认 `isResolved=true`：
+检查所有未解决讨论。具体问题已在当前提交修复时解决讨论；修复不完整、测试未接入运行器或评论仍有效时保持未解决。操作后重新查询并确认 `isResolved=true`：
 
 ```bash
 thread_id='<thread-id>'
@@ -93,7 +95,7 @@ gh api graphql \
   -f threadId="$thread_id"
 ```
 
-CI 必须绑定当前精确 `headRefOid`/`head.sha`。优先查询 `statusCheckRollup`、check suites 和 check runs；REST fallback 也必须使用同一 SHA。不能单独用 classic `GET /repos/<owner>/<repo>/commits/<sha>/status` 判断 Actions 状态，因为它可能显示 `pending` 且 `statuses` 为空，而 Actions 已结束。
+CI 必须绑定当前精确 `headRefOid` 或 `head.sha`。优先查询 `statusCheckRollup`、检查套件和检查运行；REST 回退也使用同一 SHA。不能单独用传统的 `GET /repos/<owner>/<repo>/commits/<sha>/status` 判断 Actions 状态，因为它可能显示 `pending` 且 `statuses` 为空，而 Actions 已结束。
 
 ```bash
 gh api --paginate "repos/<owner>/<repo>/commits/<head-sha>/check-runs?per_page=100"
@@ -101,13 +103,13 @@ gh api --paginate "repos/<owner>/<repo>/actions/runs?head_sha=<head-sha>&per_pag
 gh api --paginate "repos/<owner>/<repo>/actions/runs/<run-id>/jobs?per_page=100"
 ```
 
-区分预期的 matrix/path-filter `skipped` 与整个相关 workflow 未运行。本仓库互斥的 `run_host`/`run_container`、分支限制发布任务或 path-filter job 可以 `skipped`，其成功 sibling 足以说明 workflow 运行。以 `success=N, skipped=M, failure=0` 汇报，并命名关键 check。只有变更 surface 应由该 check 覆盖、path filter 跳过必需覆盖或所有相关 check 均被跳过时，才把 `skipped` 视为可疑。
+区分预期的矩阵或路径过滤 `skipped` 与整个相关工作流未运行。本仓库互斥的 `run_host`/`run_container`、分支限制发布任务或路径过滤任务可以为 `skipped`，其成功的同级任务足以说明工作流运行。以 `success=N, skipped=M, failure=0` 汇报，并命名关键检查。只有变更范围应由该检查覆盖、路径过滤跳过必需覆盖或所有相关检查均被跳过时，才把 `skipped` 视为可疑。
 
-提交审查前检查每个失败、取消、缺失或可疑 check 的日志，并分类：PR-related、unrelated 或 unclear。
+提交审查前检查每个失败、取消、缺失或可疑检查的日志，并分类为“与 PR 相关”“与 PR 无关”或“无法确定”：
 
-- PR-related：失败 job 覆盖本 PR 的文件、crate、case、命令、平台或行为；在 PR head 可复现而 base 不失败；或新增/修改的测试、配置、workflow 导致失败、hang、skip、timeout。必须 `REQUEST_CHANGES`，说明 check、失败模式、归因和修复方向。
-- unrelated：必须有具体证据，例如变更范围外、base 同样失败、已知 flake/基础设施问题或已有 issue。用 workflow/job、特征错误、runner/platform、case/命令等多个关键词搜索并检查候选 issue；更新合适的现有 issue，或在确无匹配时创建唯一 issue，并在审查正文链接它。
-- unclear：合理检查后因果仍不清楚时，禁止仅凭 CI 批准；根据证据请求修改，或在用户只要求调查时明确 no-submit blocker。
+- 与 PR 相关：失败任务覆盖本 PR 的文件、软件包、用例、命令、平台或行为；在 PR 当前提交可复现而基准分支不失败；或新增/修改的测试、配置、工作流导致失败、挂起、跳过或超时。提交 `REQUEST_CHANGES`，说明检查项、失败模式、归因和修复方向。
+- 与 PR 无关：提供具体证据，例如变更范围外、基准分支同样失败、已知偶发失败、基础设施问题或已有议题。用工作流或任务、特征错误、运行器或平台、用例或命令等多个关键词搜索并检查候选议题；更新合适的现有议题，或在确无匹配时创建唯一议题，并在审查正文链接它。
+- 无法确定：合理检查后因果仍不清楚时，禁止仅凭 CI 批准；根据证据请求修改，或在用户只要求调查时明确不提交审查的阻塞原因。
 
 ```bash
 gh pr checks <pr> --repo <owner>/<repo> --watch=false
@@ -121,11 +123,11 @@ gh issue edit <issue-number> --repo <owner>/<repo> --title '<updated neutral tit
 gh issue create --repo <owner>/<repo> --title '<neutral CI issue title>' --body-file issue.md
 ```
 
-日志下载为空时不能推断通过或无关；用 `gh pr checks` 和 `gh run view <run-id> --json headSha,jobs` 确认当前 head、失败 job、conclusion 和 step。
+日志下载为空时不能推断通过或无关；用 `gh pr checks` 和 `gh run view <run-id> --json headSha,jobs` 确认当前提交、失败任务、结论和步骤。
 
 ## 工作树
 
-fetch PR 和 base，然后在 detached worktree 审查：
+获取 PR 和基准分支，然后在分离状态工作树中审查：
 
 ```bash
 repo_root="$(git rev-parse --show-toplevel)"
@@ -135,7 +137,7 @@ git fetch origin '+refs/pull/<pr>/head:refs/remotes/origin/pr/<pr>' '+refs/heads
 git worktree add --detach "$review_wt" origin/pr/<pr>
 ```
 
-已有 worktree 仅在 clean 且位于当前 PR head 时复用：
+已有工作树仅在无改动且位于当前 PR 提交时复用：
 
 ```bash
 git -C "$review_wt" status --short
@@ -143,15 +145,15 @@ git -C "$review_wt" rev-parse HEAD
 git rev-parse refs/remotes/origin/pr/<pr>
 ```
 
-stale 且 clean 时无损更新；有本地改动时新建 worktree 或询问用户。禁止修改或回滚用户主 worktree。并行审查不同 PR 时必须使用不同 worktree；同一 checkout 内不得并发运行多个 StarryOS QEMU case。
+陈旧且无改动时无损更新；有本地改动时新建工作树或询问用户。禁止修改或回滚用户主工作树。并行审查不同 PR 时使用不同工作树；同一检出目录内不得并发运行多个 StarryOS QEMU 用例。
 
 ## 合并冲突
 
-仅在用户明确要求，或审查没有其他 blocker、本应 `APPROVE` 且当前 `mergeStateStatus=DIRTY`、`maintainerCanModify=true` 时修复。修复并 push、重新验证新 head 前不得批准。
+仅在用户明确要求，或审查没有其他阻塞问题、本应 `APPROVE` 且当前 `mergeStateStatus=DIRTY`、`maintainerCanModify=true` 时修复。修复并推送、重新验证新提交前不得批准。
 
-`reviewDecision=APPROVED` 才代表当前 aggregate approval。历史 `APPROVED` review 只能作为上下文；aggregate approval 为空、为 `CHANGES_REQUESTED`，或仍有 unresolved threads 时，冲突修复只能做 no-submit dry run，除非用户明确要求 push 修复。
+只有 `reviewDecision=APPROVED` 才代表当前汇总批准。历史 `APPROVED` 审查只能作为上下文；汇总批准为空、为 `CHANGES_REQUESTED`，或仍有未解决讨论时，冲突修复只能做不提交的本地演练，除非用户明确要求推送修复。
 
-先刷新 PR 元数据、review 和远端 head。`mergeStateStatus=UNKNOWN` 时等待并重查。`DIRTY` 且 `maintainerCanModify=false` 时不得修复：用户明确要求处理冲突时提交 `REQUEST_CHANGES`，说明作者需合并/rebase 最新 base 并建议启用 Allow edits by maintainers；否则在正文或总结中记录限制。`DIRTY` 且可修改时使用独立 conflict worktree，并确认 fork branch 仍等于 `headRefOid`。
+先刷新 PR 元数据、审查和远端当前提交。`mergeStateStatus=UNKNOWN` 时等待并重查。`DIRTY` 且 `maintainerCanModify=false` 时不得修复：用户明确要求处理冲突时提交 `REQUEST_CHANGES`，说明作者需合并或变基到最新基准分支，并建议启用 Allow edits by maintainers；否则在正文或总结中记录限制。`DIRTY` 且可修改时使用独立冲突工作树，并确认派生仓库分支仍等于 `headRefOid`。
 
 ```bash
 gh pr view <pr> --json number,baseRefName,headRefName,headRepositoryOwner,headRefOid,mergeStateStatus,maintainerCanModify,reviewDecision,reviews
@@ -163,9 +165,9 @@ git -C "$conflict_wt" merge --no-ff --no-commit "origin/<base>"
 git -C "$conflict_wt" diff --name-only --diff-filter=U
 ```
 
-detached conflict worktree 中，stage 2/ours 是 PR，stage 3/theirs 是 base；不清楚时使用 `git show :1:<path>`、`:2:`、`:3:`。按 PR 意图和当前 base 语义解决，禁止简单保留两边或复活 base 已替换的 API。PR 837 是参照：保留 `/proc/kallsyms` 功能，但适配 `SeqObject` 与 `SpecialFsFile::new_regular_with_perm`，并同时保留 `ktracepoint`/`ksym`、`.tracepoint`/`.kallsyms` 等独立改动，而不是恢复旧 `SeqFile`。
+在分离状态的冲突工作树中，暂存区第 2 阶段（`ours`）是 PR，第 3 阶段（`theirs`）是基准分支；不清楚时使用 `git show :1:<path>`、`:2:`、`:3:`。按 PR 意图和当前基准语义解决，禁止简单保留两边或复活基准分支已替换的 API。PR 837 是参照：保留 `/proc/kallsyms` 功能，但适配 `SeqObject` 与 `SpecialFsFile::new_regular_with_perm`，并同时保留 `ktracepoint`/`ksym`、`.tracepoint`/`.kallsyms` 等独立改动，而不是恢复旧 `SeqFile`。
 
-提交修复前运行格式化、冲突标记扫描、diff hygiene 和针对性验证。解决 `Cargo.lock` 冲突时先处理其他文件，再由 Cargo 重新生成，禁止手工拼接。
+提交修复前运行格式化、冲突标记扫描、差异卫生检查和针对性验证。解决 `Cargo.lock` 冲突时先处理其他文件，再由 Cargo 重新生成，禁止手工拼接。
 
 ```bash
 cargo fmt
@@ -176,91 +178,91 @@ git -C "$conflict_wt" add <resolved-files>
 git -C "$conflict_wt" commit
 ```
 
-push 前确认 merge commit 第一父节点仍是当前 `headRefOid`，并再次 `git ls-remote`。远端变化时停止并重新审查。只能 normal push，禁止 force push：
+推送前确认合并提交第一父节点仍是当前 `headRefOid`，并再次执行 `git ls-remote`。远端变化时停止并重新审查。只能普通推送，禁止强制推送：
 
 ```bash
 git push https://github.com/<head-owner>/<repo>.git HEAD:<headRefName>
 ```
 
-push 后刷新 PR、更新 review worktree，并重跑支持批准的验证。冲突消失后，`BLOCKED`/`UNSTABLE` 仍可能由 CI 或 review 状态导致，不能仅据此判定 conflict repair 失败。只做冲突 dry run 时不得 push 或提交 review；记录 PR、approval 状态、冲突文件、语义解法、验证结果和未修改 GitHub 的事实，然后清理 worktree。
+推送后刷新 PR、更新审查工作树，并重跑支持批准的验证。冲突消失后，`BLOCKED`/`UNSTABLE` 仍可能由 CI 或审查状态导致，不能仅据此判定冲突修复失败。只做冲突演练时不得推送或提交审查；记录 PR、批准状态、冲突文件、语义解法、验证结果和未修改 GitHub 的事实，然后清理工作树。
 
 ## 审查重点
 
-按 PR 意图、当前 base、项目既有模式和适用外部语义理解完整实现逻辑：
+按 PR 意图、当前基准分支、项目既有模式和适用外部语义理解完整实现逻辑：
 
-- syscall、process/session/signal、filesystem errno、socket、IPv4/IPv6、`/proc` 对照 POSIX/Linux；
-- 网络行为对照 RFC/Linux，包括 IPv6 NDP、IPv4-mapped IPv6、dual-stack、route/listen conflict 和 errno；
-- driver 改动检查 VirtIO、PCI、DMA、MMIO、IRQ 和 ownership；
-- Axvisor 配置检查 `entry_point`、`kernel_load_addr`、`memory_regions`、`map_type` 和 guest image layout；
-- Starry 测试改动应用 `starry-test-suit`；portable driver 或 OS glue 改动应用 `cross-kernel-driver`。
+- 系统调用、进程/会话/信号、文件系统错误码、套接字、IPv4/IPv6 对照 POSIX/Linux；
+- 网络行为对照 RFC/Linux，包括 IPv6 NDP、IPv4 映射 IPv6、双栈、路由或监听冲突和错误码；
+- 驱动改动检查 VirtIO、PCI、DMA、MMIO、中断和所有权；
+- Axvisor 配置检查 `entry_point`、`kernel_load_addr`、`memory_regions`、`map_type` 和客户机镜像布局；
+- Starry 测试改动应用 `starry-test-suit`；可移植驱动或操作系统适配层改动应用 `cross-kernel-driver`。
 
-影响 StarryOS syscall/Linux ABI 时，按 `docs/guideline/starry_syscall.md` 的证据层级追踪间接 helper 到每个受影响 syscall entry；行为随版本变化时记录对照的 Linux 版本或 commit。
+影响 StarryOS 系统调用或 Linux ABI 时，按 `docs/guideline/starry_syscall.md` 的证据层级追踪间接辅助代码到每个受影响的系统调用入口；行为随版本变化时记录对照的 Linux 版本或提交。
 
 ### 新功能设计门禁
 
-新增或扩展功能时，按 `docs/guideline/feature-development.md` 分类 local/shared/high risk，并在清单记录分类和证据位置。按以下顺序审查：必要性、重复性、语义与 prior art、替代方案、整体架构/API、实现、验证与交付。
+新增或扩展功能时，按 `docs/guideline/feature-development.md` 分类为局部、共享或高风险，并在清单记录分类和证据位置。按以下顺序审查：必要性、重复性、语义与既有方案、替代方案、整体架构或 API、实现、验证与交付。
 
-必须核对具体问题、目标用户/调用方、真实场景、成功标准、non-goals、仓库内部研究、适用的权威外部研究、现实替代方案和不实现成本。high-risk 功能必须有可独立审查的设计材料，覆盖适用的 ownership、dependency、compatibility、migration、rollback、observability、performance 和 security。先提交重大设计 blocker，再处理低层 polish。测试通过不能替代“为什么项目需要它、为什么优于复用/扩展、为什么复杂度现在必要”的解释。
+核对具体问题、目标用户或调用方、真实场景、成功标准、不包含项、仓库内部研究、适用的权威外部研究、现实替代方案和不实现成本。高风险功能必须有可独立审查的设计材料，覆盖适用的所有权、依赖、兼容性、迁移、回滚、可观测性、性能和安全。先提交重大设计阻塞问题，再处理低层细节。测试通过不能替代“为什么项目需要它、为什么优于复用或扩展、为什么现在值得承担复杂度”的解释。
 
 ### 审查视角与问题纪律
 
-审查采用 recall-first：优先找全 changed surface 的真实缺陷，不为简短而漏报，也不臆造问题。对可疑缺陷构造具体 input、interleaving、device state、guest config 或 test path；若场景不可能则说明原因。
+优先找全变更范围内的真实缺陷，不为简短而漏报，也不臆造问题。对可疑缺陷构造具体输入、并发交错、设备状态、客户机配置或测试路径；若场景不可能则说明原因。
 
-除非变更显然不涉及，否则应用五类 lens：
+除非变更显然不涉及，否则应用五类审查视角：
 
-- `Maintainability`：流程、commit hygiene、范围、crate/module 边界、命名、可见性、注释和可理解性；
-- `Correctness`：正常、错误、并发、hot path，off-by-one、可达 `unwrap`/`expect`/`panic`、overflow、错误 predicate、guard、wakeup 和 resource leak；
-- `Security/Soundness`：`unsafe` contract、pointer provenance、aliasing、user memory、trust boundary、privilege、TOCTOU、use-after-free；
-- `Hardware/ABI`：assembly、target JSON、trap/context、SMP/boot、MMIO/DMA/IRQ、cache/coherency、VirtIO/PCI、device tree/config、calling/alignment；
-- `Documentation/User-Facing Compatibility`：文档、runbook、app workflow、test-suit guide、兼容性说明和对用户可见行为。
+- 可维护性：流程、提交卫生、范围、软件包或模块边界、命名、可见性、注释和可理解性；
+- 正确性：正常路径、错误路径、并发、热路径、边界偏差、可达的 `unwrap`/`expect`/`panic`、溢出、错误判断条件、保护条件、唤醒和资源泄漏；
+- 安全与健全性：`unsafe` 契约、指针来源、别名、用户内存、信任边界、权限、检查与使用时序竞争、释放后使用；
+- 硬件与 ABI：汇编、目标 JSON、陷阱与上下文、SMP 启动、MMIO/DMA/中断、缓存一致性、VirtIO/PCI、设备树或配置、调用约定与对齐；
+- 文档与用户可见兼容性：文档、操作手册、应用流程、测试套件指南、兼容性说明和用户可见行为。
 
-每个 finding 必须包含：`grounding`、`severity`、具体 `problem` 与触发场景、`fix direction`、`evidence`。同一根因避免在每个 lens 重复；多个症状可分别锚定，但只解释一次共享修复。提交前复核所有承重前提、引用代码和权威外部来源；不确定性必须明确，前提错误的 finding 必须撤回。
+同一根因不要在每个视角重复报告；多个症状可以分别锚定，但只完整解释一次共享修复。提交前复核所有承重前提、引用代码和权威外部来源；明确不确定性，撤回前提错误的问题。
 
 ### 测试与行为门禁
 
-bug 修复必须有 deterministic regression/reproduction：未修复实现必然失败，修复后同一测试通过；除非有具体证据说明环境不可能做到，否则缺少 red/green 证明即阻塞。raw syscall 修复优先直接覆盖 `syscall(SYS_...)`，避免 libc wrapper 掩盖返回值或 errno。
+错误修复必须有确定性回归或复现：未修复实现必然失败，修复后同一测试通过；除非有具体证据说明环境不可能做到，否则缺少失败/通过证明即阻塞。原始系统调用修复优先直接覆盖 `syscall(SYS_...)`，避免 libc 封装掩盖返回值或错误码。
 
-新增行为、语义变更、bug 修复或新暴露路径必须在正确项目层级有测试。不能只看到测试文件：必须验证 runner 能发现、构建/安装、选择、执行，并且回归时会失败。错放、孤立、manual-only、opt-in 或被 CI 静默跳过的测试按缺失处理。
+新增行为、语义变更、错误修复或新暴露路径必须在正确项目层级有测试。不能只看到测试文件：验证运行器能够发现、构建或安装、选择、执行，并且回归时会失败。错放、孤立、仅手工执行、可选执行或被 CI 静默跳过的测试按缺失处理。
 
-StarryOS app-support 分层：
+StarryOS 应用支持分层：
 
-- operator-facing smoke、demo、rootfs、board/QEMU script、长运行或 opt-in workflow 放 `apps/starry/<app-or-scenario>/`；
-- kernel ABI、syscall、filesystem、process、networking 或 bugfix 语义覆盖放 `test-suit/starryos/<case>` 或既有 grouped wrapper；
-- syscall 变化必须有直接 test-suit regression；app smoke 不足以证明 syscall；
-- app 暴露的 kernel bug 尽量提取无需完整 app 的 test-suit regression，app scenario 保留为 integration evidence。
+- 面向操作人员的冒烟、演示、根文件系统、板卡或 QEMU 脚本、长运行或可选流程放 `apps/starry/<app-or-scenario>/`；
+- 内核 ABI、系统调用、文件系统、进程、网络或错误修复语义覆盖放 `test-suit/starryos/<case>` 或既有分组封装；
+- 系统调用变化必须有直接测试套件回归；应用冒烟不足以证明系统调用；
+- 应用暴露的内核错误尽量提取为无需完整应用的测试套件回归，应用场景保留为集成证据。
 
-每个新增、变更或 PR 明确声明支持的 StarryOS/ArceOS app，都必须建立独立 setup/runtime todo，并在当前 head 按文档本地实跑。远端 CI 不能替代。generic 改动至少跑一个最高风险 claimed architecture；architecture-specific 改动跑每个新增/变更架构。文档无法准备环境、需要未记录 workaround、外部依赖不稳定、硬件/credential/permission/service/host capability 不可用，或只能跑比声明更窄 target，均 `REQUEST_CHANGES`。
+每个新增、变更或 PR 明确声明支持的 StarryOS/ArceOS 应用，都建立独立的环境准备与运行清单，并在当前提交按文档本地实跑。远端 CI 不能替代。通用改动至少运行一个风险最高的声明架构；架构特定改动运行每个新增或变更架构。文档无法准备环境、需要未记录的临时绕过、外部依赖不稳定、硬件/凭据/权限/服务/宿主能力不可用，或只能运行比声明更窄的目标，均提交 `REQUEST_CHANGES`。
 
-禁止 test-shaped/fake fix、hard-coded special case、fake state、no-op compatibility shim 或未实现真实语义的逻辑。success-path 测试遇到 `ENOMEM`/`EAGAIN` 等意外失败时不得静默 return；合法 skip 必须打印明确 marker 并解释原因。禁止删减 case、架构、放宽 `success_regex`/`fail_regex`、把失败变成 skip/timeout、修改 path filter 跳过相关覆盖，或把 CI 覆盖移到 manual-only，除非有等价或更强且已验证的替代。
+禁止测试外形的伪修复、硬编码特例、伪状态、空操作兼容层或未实现真实语义的逻辑。成功路径测试遇到 `ENOMEM`/`EAGAIN` 等意外失败时不得静默返回；合法跳过必须打印明确标记并解释原因。禁止删减用例、架构，放宽 `success_regex`/`fail_regex`，把失败变成跳过或超时，修改路径过滤跳过相关覆盖，或把 CI 覆盖移到仅手工执行，除非有等价或更强且已验证的替代。
 
-Starry QEMU 失败必须传播到 `cargo xtask starry test qemu ...`：wrapper 必须在命令后立即保存 `$?`，失败时打印 `STARRY_GROUPED_TEST_FAILED` 或配置 marker，不得再打印 all-passed marker，并让外层命令失败。`success_regex`/`fail_regex` 必须可靠分类。当前 `qemu/system` grouped C subcase 的 `CMakeLists.txt` 与 `src/` 必须直接位于 `system/<subcase>/`；`system/<subcase>/c/` 默认阻塞，除非同时更新 root CMake、runner discovery、guide 和 rule tests 并验证。
+Starry QEMU 失败必须传播到 `cargo xtask starry test qemu ...`：封装脚本在命令后立即保存 `$?`，失败时打印 `STARRY_GROUPED_TEST_FAILED` 或配置标记，不得再打印全部通过标记，并让外层命令失败。`success_regex`/`fail_regex` 必须可靠分类。当前 `qemu/system` 分组 C 子用例的 `CMakeLists.txt` 与 `src/` 必须直接位于 `system/<subcase>/`；`system/<subcase>/c/` 默认阻塞，除非同时更新根 `CMakeLists.txt`、运行器发现逻辑、指南和规则测试并验证。
 
 ## 可发布 Cargo 补丁策略
 
-PR 触及 `Cargo.toml`、`Cargo.lock`、已提交的 `.cargo/config`/`.cargo/config.toml`、dependency metadata、重复版本、第三方 API 或跨依赖类型边界时，检查所有 `[patch]` 和变更的 dependency source。按来源是否能由本仓库或 crates.io 重现、workspace 是否可发布来判断；存在 `[patch.crates-io]` 本身不阻塞。
+PR 触及 `Cargo.toml`、`Cargo.lock`、已提交的 `.cargo/config`/`.cargo/config.toml`、依赖元数据、重复版本、第三方 API 或跨依赖类型边界时，检查所有 `[patch]` 和变更的依赖来源。按来源是否能由本仓库或 crates.io 重现、工作区是否可发布来判断；存在 `[patch.crates-io]` 本身不阻塞。
 
 允许但必须通过解析与发布检查的来源：
 
-- 相对于声明它的 manifest/config 解析并 normalize 后仍位于当前仓库内的 `path`；
-- crates.io 已发布的精确版本，包括普通依赖中的 `version = "=1.2.3"`，以及用该版本替代其他 source 的 registry-backed patch。
+- 相对于声明清单或配置解析并规范化后仍位于当前仓库内的 `path`；
+- crates.io 已发布的精确版本，包括普通依赖中的 `version = "=1.2.3"`，以及用该版本替代其他来源的注册表补丁。
 
-以下情况阻塞：任意 `git`、绝对 `path`、逃逸仓库的相对路径、非 crates.io registry；metadata 未解析到预期 package/version/source；请求版本未发布；依赖统一破坏 API 或类型语义；完整 workspace publish dry-run 失败。
+以下情况阻塞：任意 `git`、绝对 `path`、逃逸仓库的相对路径、非 crates.io 注册表；元数据未解析到预期软件包、版本或来源；请求版本未发布；依赖统一破坏 API 或类型语义；完整工作区发布演练失败。
 
-发布 package 可使用 `{ path = "...", version = "..." }`，打包时 Cargo 使用 crates.io version requirement；只有 `path` 的普通依赖对需要发布的 package 是阻塞项。root `[patch]` 中的仓库相对路径自身不要求 version fallback，但发布 package 的普通 dependency declaration 仍要求。
+发布软件包可使用 `{ path = "...", version = "..." }`，打包时 Cargo 使用 crates.io 版本要求；只有 `path` 的普通依赖对需要发布的软件包是阻塞项。根 `[patch]` 中的仓库相对路径自身不要求版本回退，但发布软件包的普通依赖声明仍然要求。
 
-patch 若只为掩盖 dependency-owned 与 workspace-owned 类型不一致，优先正常 crates.io resolution 和显式边界：使用依赖公开类型；在边界添加 crate-private adapter；使用 `.map_err(...)`、`TryFrom`、wrapper newtype 或 extension trait；未知 errno 提供明确 fallback。root `[patch.crates-io] ax-errno = { path = "components/axerrno" }` 的来源形态允许，并可在 metadata 与完整发布 dry-run 证明时统一 release graph；若目的只是让 `kbpf-basic` 错误与另一份本地错误类型隐式互换，则保留 `kbpf_basic::BpfError`/`BpfResult` 到 `LinuxError`/`AxError`/`AxResult` 的显式转换。
+补丁若只为掩盖依赖方与工作区各自拥有的类型不一致，优先使用正常 crates.io 解析和显式边界：使用依赖公开类型；在边界添加软件包私有适配器；使用 `.map_err(...)`、`TryFrom`、封装新类型或扩展 trait；未知错误码提供明确回退。根 `[patch.crates-io] ax-errno = { path = "components/axerrno" }` 的来源形态允许，并可在元数据与完整发布演练证明时统一发布依赖图；若目的只是让 `kbpf-basic` 错误与另一份本地错误类型隐式互换，则保留 `kbpf_basic::BpfError`/`BpfResult` 到 `LinuxError`/`AxError`/`AxResult` 的显式转换。
 
 ## 重复与重叠分析
 
-每个 PR 必做。先建立 intent fingerprint：title/body/issue/commit、changed crate/module/test/config/CI/generated asset、public API/syscall/errno/protocol/device/runner/feature，以及语义 claim（feature、fix、coverage、refactor、config、CI、dependency metadata）。
+每个 PR 必做。先建立意图指纹：标题、描述、议题、提交、变更的软件包/模块/测试/配置/CI/生成资产、公共 API、系统调用、错误码、协议、设备、运行器、功能，以及功能、修复、覆盖、重构、配置、CI、依赖元数据等语义声明。
 
-先查当前 base 是否已有等价或更新实现，再用多个 fingerprint 关键词搜索开放 PR；不能只搜标题。读取候选的 intent、文件和 diff 后分类：
+先查当前基准分支是否已有等价或更新实现，再用多个意图指纹关键词搜索开放 PR；不能只搜标题。读取候选的意图、文件和差异后分类：
 
-- `duplicate`：同一问题或同一 API/test/config，无实质差异；
-- `partial-overlap`：同一 surface，但互补、可排序或可拆分；
-- `conflict-risk`：修改同一 contract、runner、generated asset 或 ABI，存在 merge/semantic 冲突；
-- `superseded`：base 或其他 PR 更完整、更符合项目方向；
-- `unrelated-after-inspection`：关键词命中但审阅后无关。
+- 重复：同一问题或同一 API、测试、配置，无实质差异；
+- 部分重叠：同一受影响范围，但互补、可排序或可拆分；
+- 冲突风险：修改同一契约、运行器、生成资产或 ABI，存在合并或语义冲突；
+- 已被取代：基准分支或其他 PR 更完整、更符合项目方向；
+- 检查后无关：关键词命中但审阅后无关。
 
 ```bash
 git grep -n -E '<relevant symbols|paths|commands>' origin/<base> -- <likely paths>
@@ -271,11 +273,11 @@ gh pr diff <related-pr> --patch --color=never
 git diff --name-only origin/<base>...origin/pr/<related-pr>
 ```
 
-依赖另一 PR 先落地时，在 body/review 明确依赖前不得批准。`duplicate`/`superseded` 应请求修改或中性说明应优先采用的 base/PR。使用 `git diff origin/<base>...origin/pr/<pr>` 查看 PR patch；只有检查 stale-branch effect 时才用 `..`。用户要求关闭时，先 `gh pr comment <pr> --body-file comment.md`，再 `gh pr close <pr>`。
+依赖另一 PR 先落地时，在描述或审查中明确依赖前不得批准。重复或已被取代时请求修改，或中性说明应优先采用的基准实现或 PR。使用 `git diff origin/<base>...origin/pr/<pr>` 查看 PR 补丁；只有检查陈旧分支影响时才用 `..`。用户要求关闭时，先执行 `gh pr comment <pr> --body-file comment.md`，再执行 `gh pr close <pr>`。
 
 ## 验证
 
-验证必须匹配 changed surface，优先项目 `cargo xtask`：
+验证必须匹配变更范围，优先使用项目 `cargo xtask`：
 
 ```bash
 cargo fmt --check
@@ -285,9 +287,9 @@ cargo xtask starry test qemu --arch <arch> -c <case>
 cargo xtask axvisor build ... --vmconfigs <config>
 ```
 
-特殊配置无法由 xtask 覆盖时，先检查 xtask help/source，再用参数完全匹配的 native Cargo。记录精确命令与失败。
+特殊配置无法由 `xtask` 覆盖时，先检查 `xtask` 帮助和源码，再用参数完全匹配的原生 Cargo 命令。记录精确命令与失败。
 
-dependency metadata 变更必须扫描 patch、检查 metadata/tree 并执行完整 workspace publish dry-run：
+依赖元数据变更必须扫描补丁、检查元数据和依赖树，并执行完整工作区发布演练：
 
 ```bash
 rg --hidden -n '^\s*\[patch(?:\.|\])' -g 'Cargo.toml' -g '**/.cargo/config' -g '**/.cargo/config.toml' .
@@ -296,77 +298,127 @@ cargo tree -p <affected-package> | rg '<affected-crate>|<boundary-crate>'
 cargo publish --workspace --dry-run --no-verify
 ```
 
-相对 path 按声明文件解析并确认 normalize 后仍在 repo root 下；精确 crates.io replacement 必须在 metadata 中显示 crates.io registry source 和精确版本。新增、变更或依赖 patch，或修改可发布 workspace package 的 source 时，全 workspace 打包/解析 dry-run 是硬门槛；涉及 workspace 发布顺序或 path-to-registry rewriting 时，单 package dry-run 不能替代。`--no-verify` 会跳过 package verification build，因此该命令不能代替前面的针对性 build/clippy/runtime 验证。
+相对路径按声明文件解析并确认规范化后仍在仓库根目录下；精确 crates.io 替代版本必须在元数据中显示 crates.io 注册表来源和精确版本。新增、变更或依赖补丁，或修改可发布工作区软件包的来源时，完整工作区打包或解析演练是硬门槛；涉及工作区发布顺序或从路径依赖改写到注册表依赖时，单软件包演练不能替代。`--no-verify` 会跳过软件包验证构建，因此该命令不能代替前面的针对性构建、静态检查或运行验证。
 
-每个受影响 app 必须严格按 PR body 或变更文档执行：
+每个受影响应用严格按 PR 描述或变更文档执行：
 
-1. 分别列出环境准备、架构、runtime command 和可观察 postcondition。
-2. 文档必须覆盖 package、toolchain、rootfs、permission、hardware、credential、network service、env var、asset、参数和 readiness check；只能引用完整覆盖该 app 的 canonical section。
+1. 分别列出环境准备、架构、运行命令和可观察后置条件。
+2. 文档覆盖软件包、工具链、根文件系统、权限、硬件、凭据、网络服务、环境变量、资产、参数和就绪检查；只能引用完整覆盖该应用的规范章节。
 3. 不使用本地知识补充未记录命令，不依赖未说明的机器状态。
-4. 在当前 head 运行真实 `cargo xtask starry app qemu ...`、`cargo xtask starry test qemu ...`、`cargo xtask arceos test qemu ...` 或文档 wrapper。
-5. 验证 guest marker、app output、log、symbolized block、package artifact 等真实结果；退出 0 但未执行行为不算通过。
-6. `tmp/axbuild/rootfs` 为空时仍尝试文档中的 rootfs/test 命令，让 xtask 自动下载；失败则记录并 `REQUEST_CHANGES`。
-7. 同一 worktree 内一次只运行一个 Starry QEMU case。
+4. 在当前提交运行真实的 `cargo xtask starry app qemu ...`、`cargo xtask starry test qemu ...`、`cargo xtask arceos test qemu ...` 或文档封装命令。
+5. 验证客户机标记、应用输出、日志、符号化位置、软件包产物等真实结果；退出码为 0 但未执行行为不算通过。
+6. `tmp/axbuild/rootfs` 为空时仍尝试文档中的根文件系统或测试命令，让 `xtask` 自动下载；失败则记录并提交 `REQUEST_CHANGES`。
+7. 同一工作树内一次只运行一个 Starry QEMU 用例。
 
-同样的 executable-workflow 门禁适用于 ArceOS app、`apps/**` demo，以及准备、启动、检查、symbolize、解析日志、打包或操作 StarryOS/ArceOS 应用的 QEMU wrapper、rootfs/app preparation tool、symbolizer、log parser 和 packaging helper。即使 tool-only 改动未声明具体 app，只要 CI 没有执行精确 workflow，就必须本地运行真实流程，不能只验证 syntax、文档、`--help`、解析或 build。tool-only 场景若确因硬件、credential、service 或 host capability 不可用，记录限制并要求受控 fallback 或可复现验证；一旦涉及具体 app，仍应用更严格的逐 app 门禁，环境不可用不能豁免。
+同样的可执行流程门禁适用于 ArceOS 应用、`apps/**` 演示，以及准备、启动、检查、符号化、解析日志、打包或操作 StarryOS/ArceOS 应用的 QEMU 封装、根文件系统或应用准备工具、符号化工具、日志解析器和打包辅助工具。即使仅工具改动未声明具体应用，只要 CI 没有执行精确流程，就本地运行真实流程，不能只验证语法、文档、`--help`、解析或构建。仅工具场景若确因硬件、凭据、服务或宿主能力不可用，记录限制并要求受控回退或可复现验证；一旦涉及具体应用，仍应用更严格的逐应用门禁，环境不可用不能豁免。
 
-grouped QEMU 新增或迁移测试必须核对 `test_commands` discovery/install、`/usr/bin/<test>`、`status=127`、subcase selection、feature gate 和 regex。至少取得以下一种证据：当前 head 本地运行、当前 head CI 明确显示该 case/binary 执行、或 deterministic build/discovery check。aggregate CI 通过不足以证明未被跳过。检查 shell wrapper 失败分支和 grouped bugfix assertion，不能只跑成功路径。
+分组 QEMU 新增或迁移测试必须核对 `test_commands` 的发现与安装、`/usr/bin/<test>`、`status=127`、子用例选择、功能门控和正则表达式。至少取得以下一种证据：当前提交本地运行、当前提交 CI 明确显示该用例或二进制执行，或确定性构建与发现检查。汇总 CI 通过不足以证明测试未被跳过。检查 shell 封装失败分支和分组错误修复断言，不能只运行成功路径。
 
-对每个新增或迁移测试，不限于 grouped QEMU，都必须写明实际执行它的 runner command，并取得以下至少一种 current-head 证据：本地执行；CI 日志明确显示具体 case/subcase/binary 执行；或 deterministic build/discovery check 证明 runner 一定到达该测试。宽泛的 aggregate CI pass 不能证明未被 path layout、filter、install rule、subcase selection 或 feature gate 跳过。
+对每个新增或迁移测试，不限于分组 QEMU，都写明实际执行它的运行器命令，并取得以下至少一种当前提交证据：本地执行；CI 日志明确显示具体用例、子用例或二进制执行；或确定性构建与发现检查证明运行器一定到达该测试。宽泛的汇总 CI 通过不能证明测试未被路径布局、过滤器、安装规则、子用例选择或功能门控跳过。
 
-app-support 同时包含 syscall/kernel bugfix 时，app workflow 与对应 `cargo xtask starry test qemu` 都要运行并分别汇报。没有测试变更时，若 PR body/commit 声称 QEMU、host unit、xtask、clippy、script、emulator 等 non-board validation，必须复跑并核对 command、target、output 和 pass condition；不可复现、静默 skip、target 更窄或失败时请求修改。既无测试又无可复现 non-board validation 时禁止批准。board-only 证据不能单独满足此门槛，除非用户明确限定审查范围。
+应用支持同时包含系统调用或内核错误修复时，应用流程与对应 `cargo xtask starry test qemu` 都运行并分别汇报。没有测试变更时，若 PR 描述或提交声称 QEMU、宿主单元测试、`xtask`、静态检查、脚本、模拟器等非实体板卡验证，复跑并核对命令、目标、输出和通过条件；不可复现、静默跳过、目标更窄或失败时请求修改。既无测试又无可复现的非实体板卡验证时禁止批准。仅实体板卡证据不能单独满足此门槛，除非用户明确限定审查范围。
 
-remote CI 是必需证据但不是唯一证据；没有 check 不等于通过，CI 通过也不能替代本地分析和针对性运行。
+远端 CI 是必需证据但不是唯一证据；没有检查不等于通过，CI 通过也不能替代本地分析和针对性运行。
 
 ## 阻塞问题
 
 除非有明确证据表明不阻塞，否则以下情况阻塞：
 
 - 与 POSIX/Linux/RFC/VirtIO 语义不符；
-- 新功能缺少问题、用户/调用方、成功标准、non-goals、内部重复搜索、适用权威研究或现实替代方案；
-- high-risk 功能缺少可独立审查设计或合格领域 reviewer；
-- 跨层 shortcut、hard-coded special path、重复真相源、fake success、silent fallback、无当前 consumer 的投机 API/config/extension；
-- targeted test、format、clippy 或 PR-related CI 失败；
-- 当前 head 的 StarryOS/ArceOS app/QEMU case 按文档失败，或失败未传播到 xtask；
-- app/QEMU 声称仅验证 discovery、TOML parsing、旧 head 或他人结果；
-- 任何受影响 app 未完成当前 head 的文档化 setup/runtime，或文档缺环境、命令、参数、readiness；
-- app 需要不可用硬件/credential/permission/service/host capability 或未记录 workaround；
-- 新行为/语义/bugfix 缺测试，或测试错位、未发现、未构建/安装、未选择、未直接覆盖 ABI；
-- coverage 因 layout、path filter、feature gate、subcase、install rule 或 manual-only placement 被跳过；
-- 无测试变更且无可复现 non-board validation，或声明的验证不可复现/不匹配；
+- 新功能缺少问题、用户或调用方、成功标准、不包含项、内部重复搜索、适用权威研究或现实替代方案；
+- 高风险功能缺少可独立审查设计或合格领域审查人；
+- 跨层捷径、硬编码特殊路径、重复真相源、伪成功、静默回退、无当前使用者的投机 API、配置或扩展；
+- 针对性测试、格式化、静态检查或与 PR 相关的 CI 失败；
+- 当前提交的 StarryOS/ArceOS 应用或 QEMU 用例按文档失败，或失败未传播到 `xtask`；
+- 应用或 QEMU 声明只验证发现、TOML 解析、旧提交或他人结果；
+- 任何受影响应用未完成当前提交的文档化准备与运行，或文档缺环境、命令、参数、就绪条件；
+- 应用需要不可用的硬件、凭据、权限、服务、宿主能力或未记录的临时绕过；
+- 新行为、语义或错误修复缺测试，或测试错位、未发现、未构建或安装、未选择、未直接覆盖 ABI；
+- 覆盖因布局、路径过滤、功能门控、子用例、安装规则或仅手工执行的位置被跳过；
+- 无测试变更且无可复现的非实体板卡验证，或声明的验证不可复现或不匹配；
 - `success_regex`/`fail_regex` 不能可靠分类；
-- bugfix 缺少必然 red/green 的 regression/reproduction，且未证明不可能；
-- Cargo patch 使用 `git`、绝对 path、仓库外 path、非 crates.io registry，普通可发布 dependency 只有 path，请求 crates.io 版本不存在，解析到非预期 package/version/source，或完整 workspace publish dry-run 失败；
-- merge conflict 未解决，修复复活过时 base API，或 push 后未重新验证；
-- app workflow/test-suit 语义覆盖层级错误；
-- test-only/fake fix 未实现真实行为；
-- buffer、DMA memory、queue token、IRQ ownership 泄漏、过早释放或跨错抽象层；
-- CI hang、timeout、skip 新覆盖，或削弱既有 case/architecture/regex/path-filter/正常回归；
-- 重复 base、削弱已有实现、与开放 PR 冲突或已被取代；
+- 错误修复缺少必然失败与通过的回归或复现，且未证明不可能；
+- Cargo 补丁使用 `git`、绝对路径、仓库外路径、非 crates.io 注册表，普通可发布依赖只有路径，请求的 crates.io 版本不存在，解析到非预期软件包、版本或来源，或完整工作区发布演练失败；
+- 合并冲突未解决，修复复活过时的基准 API，或推送后未重新验证；
+- 应用流程与测试套件的语义覆盖层级错误；
+- 仅测试的伪修复未实现真实行为；
+- 缓冲区、DMA 内存、队列令牌、中断所有权泄漏、过早释放或跨错抽象层；
+- CI 挂起、超时、跳过新覆盖，或削弱既有用例、架构、正则、路径过滤或正常回归；
+- 重复基准分支、削弱已有实现、与开放 PR 冲突或已被取代；
 - 无法解释与候选相关 PR 的差异；
-- 必需 todo 仍 pending、不可验证或缺少证据/具体不适用理由。
+- 必需清单项仍为 `pending`、不可验证或缺少证据或具体不适用理由。
 
-所有 GitHub review text（行内评论、body、reply）必须中文、中性、项目导向。每个 blocker 都写明 `grounding`、`severity`、具体问题与场景、`evidence`、修复方向。优先锚定当前 PR diff 的 RIGHT side changed line；提交前确认 `line` 存在，否则移动到最近能证明问题的 changed line 或放入 body。
+## 中文审查文本规范
+
+所有 GitHub 审查文本，包括总审查正文、行内评论和讨论回复，均使用中文、中性且项目导向的表达。命令、路径、代码符号、接口字段、产品名和标准正式名称可以保留原文；在叙述中用中文说明其作用，不连续堆叠英文术语。面向第一次接触相关模块的读者，先说明对象在调用链中的角色，再说明状态变化、触发条件和可观察结果。禁止使用“请优化”“测试通过”“这里不正确”等缺少原因、逻辑和证据的结论。
+
+### 要求修改的评论模板
+
+凡是要求继续修改代码、测试、文档或配置的行内评论和讨论回复，先复制以下七项粗体 Markdown 标题骨架，再逐项填写具体内容。输出时保留 `**标题**` 语法，不得删除标题、留空、合并成含糊短句、改成连续段落或依赖总审查正文代替：
+
+- **为什么需要改动**：说明当前问题、不修改会产生的实际后果和受影响对象。
+- **改动收益**：说明修复后恢复或新增的可观察保证，以及对正确性、可维护性、安全性、兼容性或测试可信度的收益。
+- **改动前逻辑（基准分支）**：只说明基准分支在 PR 之前的入口、关键状态变化、所有权或错误传播和最终结果。若属于新增路径或缺失测试，写明基准分支此前没有该路径或覆盖。
+- **改动后逻辑（当前 PR）**：只说明当前 PR 已经引入的入口、关键状态变化和结果，并指出问题出现在哪一步。新增测试场景应写“PR 添加了文件，但当前布局使运行器无法发现”；绝不把期望修复后的未来逻辑写在此处，未来逻辑只放“建议修改方式”。
+- **触发场景与证据**：给出具体输入、状态、并发交错、设备状态、调用链、日志、测试或规范依据；引用当前提交的路径、行号和符号。
+- **问题级别**：说明是否阻塞以及影响范围。阻塞问题明确写出会导致的错误结果、崩溃、死锁、资源泄漏、ABI 不兼容、测试失效或其他可观察后果。
+- **建议修改方式**：描述应恢复的语义、顺序、所有权、错误传播或测试契约，以及修改完成后的验收条件。只约束根因和必要边界，不替作者扩展无关重构。
+
+同一根因只在最贴切的评论中完整解释一次。若其他变更行只是同一根因的症状，引用该评论并说明本行的局部影响，不再发布重复的修改要求；若该评论本身仍要求修改，则仍须包含七个标题。纯信息说明和批准结论不强制使用七段模板，但仍须使用中文并给出必要依据。
+
+### 总审查正文
+
+总审查正文先复制 `## 为什么需要改动`、`## 改动收益`、`## 改动前逻辑（基准分支）`、`## 改动后逻辑（当前 PR）` 四个二级 Markdown 标题，再逐项填写，形成完整的整体叙事，并通过路径或评论引用汇总行内问题，避免机械复制。正文还覆盖适用的以下内容：
+
+- PR 改动、功能开发规范适用性、风险分类和设计材料位置；
+- 新功能的问题、用户、成功标准、不包含项、研究、替代方案和取舍；
+- 实现逻辑、项目语义、验证命令与结果；
+- 测试要求、位置、构建、发现、选择和执行证据；
+- 每个应用的当前提交、准备文档来源、准备命令、运行命令、架构和可观察后置条件或失败；
+- 审查清单审计、无测试时复核的声明、CI 状态、无关失败证据和跟踪议题；
+- 重复与重叠分类、冲突处理、与 PR 相关的 CI 失败和修复方向；
+- 错误修复的失败/通过证据、已解决与未解决讨论、未实现或后续项、环境限制。
+
+不能只写“测试通过”。没有阻塞问题的批准正文也说明审查范围、改动前后逻辑、主要收益、验证证据和剩余风险。
+
+### 回复已修复问题
+
+仅确认问题已修复的回复可以缩短为“状态”“逻辑变化”“验证证据”三部分，写明当前提交、原问题如何被修复、修改前后的关键差异和同一回归测试的结果。作者只有解释而没有修改代码或测试时，不把解释当作修复证据。仍要求继续修改或只修复一部分时，使用完整七段模板并保持讨论未解决。
+
+### 发布前后格式检查
+
+发布前逐条检查未发布草稿：
+
+- 中文叙述是否完整，英文是否仅为允许保留的精确标识；
+- 必填标题是否齐全且顺序正确，各节是否非空并面向初学者解释上下文；
+- 是否残留 `TODO`、`TBD`、`<placeholder>` 或模板说明文字；
+- Markdown 标题、列表、空行、代码围栏、反引号和链接是否闭合且层级正确；
+- 行内评论的 `path`、`line`、`side=RIGHT` 是否存在并绑定当前 `headRefOid`；
+- 总审查正文、行内评论和回复之间是否重复、矛盾或遗漏阻塞问题。
+
+任一检查不满足时丢弃草稿并重写，不得以“语义已经包含”为由省略固定标题。
+
+提交后重新读取实际发布的总审查正文、行内评论和回复，检查 GitHub 上的显示、标题、列表、代码块、链接、内容完整性和讨论状态。接口调用成功不等于格式正确。发现格式错误时优先编辑原评论；无法编辑时发布一条完整修正版，并明确原评论已被替代。格式修正不得改变问题语义或掩盖当前提交已经变化的事实。
 
 ## 提交审查
 
-提交前用同一个 todo 工具逐项审计。任何必需项 pending、不可验证或无证据时不得 `APPROVE`。PR 导致的测试证据缺失、环境准备失败或 app runtime 失败进入 `REQUEST_CHANGES`；外部系统阻止提交时明确 no-submit。
+提交前用同一个任务清单工具逐项审计。任何必需项仍为 `pending`、不可验证或无证据时不得 `APPROVE`。PR 导致的测试证据缺失、环境准备失败或应用运行失败进入 `REQUEST_CHANGES`；外部系统阻止提交时明确不提交审查。
 
-通过 connector 确认 PR head SHA 未变化；fallback：
+通过连接器确认 PR 的 `headRefOid` 未变化；回退命令：
 
 ```bash
 gh pr view <pr> --json number,headRefOid,reviewDecision
 ```
 
-head 变化时 fetch 新 head、更新 worktree、在当前 changed line 复核每个 finding，并重跑支撑结论的验证。
+当前提交变化时重新获取、更新工作树、在新的右侧变更行复核每个问题，并重跑支撑结论的验证。
 
-优先用 connector 一次提交 event 和带锚点评论；connector 无法保持锚点时用 REST：
+先按“中文审查文本规范”完成草稿和发布前格式检查。优先用连接器一次提交审查事件和带锚点评论；连接器无法保持锚点时使用 REST：
 
 ```bash
 gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input review.json
 ```
 
-payload 必须使用当前 `headRefOid`、`side=RIGHT`；有任何 blocker 用 `REQUEST_CHANGES`，无 blocker 才用 `APPROVE`：
+请求载荷使用当前 `headRefOid`、`side=RIGHT`；有任何阻塞问题时使用 `REQUEST_CHANGES`，无阻塞问题时才使用 `APPROVE`：
 
 ```json
 {
@@ -379,9 +431,7 @@ payload 必须使用当前 `headRefOid`、`side=RIGHT`；有任何 blocker 用 `
 }
 ```
 
-禁止提交针对旧 head 的 finding。提交后重新查询；若期间出现新 commit，仅在 blocker 对新 head 仍成立时提交 follow-up。
-
-中文 review body 必须覆盖：PR 改动；feature-development 适用性、risk 和 design location；新功能的问题/用户/标准/non-goals/研究/替代/取舍；实现逻辑和项目语义；验证命令与结果；测试要求、位置、发现/选择/执行证据；每个 app 的 head、setup source、准备命令、runtime、arch 和 postcondition/失败；todo 审计；无测试时复核的 claim；CI 状态、无关失败证据和 tracking issue；duplicate/overlap 分类；冲突处理；PR-related CI 失败与修复方向；bugfix red/green；resolved/open threads；未实现或后续项；环境限制。不能只写“tests pass”。
+禁止提交针对旧提交的问题。提交后重新查询审查和评论，执行发布后格式检查；若期间出现新提交，仅在问题对新提交仍成立时提交后续审查。
 
 ```bash
 gh pr view <pr> --json number,reviewDecision,latestReviews
@@ -389,41 +439,41 @@ gh pr view <pr> --json number,reviewDecision,latestReviews
 
 ## 推荐审查人分配
 
-仅在审查提交后仍需领域跟进时请求 reviewer。读取 `.github/MAINTAINERS.md`；它是本地来源真相和自动人类 reviewer 严格 allowlist。只有 `R:` 可自动请求；`M:` 只是 ownership metadata，除非同一 login 也在 `R:`。不得推断或请求 allowlist 外的人类 reviewer。
+仅在提交审查后仍需领域跟进时请求审查人。读取 `.github/MAINTAINERS.md`；它是本地事实来源和自动人类审查人的严格允许列表。只有 `R:` 可自动请求；`M:` 只是所有权元数据，除非同一账号也在 `R:`。不得推断或请求允许列表外的人类审查人。
 
-用 PR title/body、changed path、API、test、validation、finding、crate/config/feature 和 diff-visible identifier 匹配 `F:`/`K:`。多个 section 命中时请求所有对应 `R:`。非 draft 无匹配时，确认 `ZR233` 位于 `R:` 后将其作为 fallback，并明确这是 fallback 而非 ownership evidence。draft 默认不更新 reviewer，除非用户明确要求。
+用 PR 标题、描述、变更路径、API、测试、验证、问题、软件包、配置、功能和差异中可见的标识符匹配 `F:`/`K:`。多个部分命中时请求所有对应 `R:`。非草稿且无匹配时，确认 `ZR233` 位于 `R:` 后将其作为回退，并明确这是回退而不是所有权证据。草稿默认不更新审查人，除非用户明确要求。
 
-默认 add-only：保留全部现有人类和 bot request，把 ownership target 与现有 request 取并集，只新增缺失 reviewer；`reviewers to remove` 为空，除非用户明确要求删除/rebalance。即使用户要求移除，也保留 bot，除非明确要求移除 bot。新请求中去掉 PR author 和当前 GitHub 用户。
+默认仅新增：保留全部现有人类和机器人请求，把所有权目标与现有请求取并集，只新增缺失审查人；待删除审查人为空，除非用户明确要求删除或重新平衡。即使用户要求移除，也保留机器人，除非明确要求移除机器人。新请求中去掉 PR 作者和当前 GitHub 用户。
 
-写入前查询当前状态与权限，并记录单 PR dry run：current、target、preserved human/bot、to add、to remove、`F:`/`K:` 证据或 fallback、skip reason。
+写入前查询当前状态与权限，并记录单 PR 演练：当前审查人、目标审查人、保留的人类和机器人、待新增、待删除、`F:`/`K:` 证据或回退、跳过原因。
 
 ```bash
 gh api repos/<owner>/<repo>/pulls/<pr>/requested_reviewers
 gh api repos/<owner>/<repo>/collaborators/<login>/permission
 ```
 
-使用 REST requested-reviewers API，不用可能触发 Projects classic 问题的 `gh pr edit`。默认 add-only 不调用 DELETE：
+使用 REST `requested-reviewers` API，不用可能触发 Projects classic 问题的 `gh pr edit`。默认仅新增时不调用 DELETE：
 
 ```bash
 printf '%s\n' '{"reviewers":["<login1>","<login2>"]}' |
   gh api -X POST repos/<owner>/<repo>/pulls/<pr>/requested_reviewers --input -
 ```
 
-仅在用户明确要求删除/rebalance 时：
+仅在用户明确要求删除或重新平衡时：
 
 ```bash
 printf '%s\n' '{"reviewers":["<login>"]}' |
   gh api -X DELETE repos/<owner>/<repo>/pulls/<pr>/requested_reviewers --input -
 ```
 
-分配后重新查询确认。GitHub 拒绝 reviewer 时记录 login 和精确 API/permission 错误，禁止静默换成 allowlist 外的人。最终向用户汇报匹配的 MAINTAINERS 项、requested/already present/preserved/skipped/rejected、`ZR233` fallback、权限/API 限制，以及 reviewer 步骤是否只修改 GitHub metadata。
+分配后重新查询确认。GitHub 拒绝审查人时记录账号和精确 API 或权限错误，禁止静默换成允许列表外的人。最终向用户汇报匹配的 MAINTAINERS 项、已请求、已存在、已保留、已跳过、被拒绝、`ZR233` 回退、权限或 API 限制，以及审查人步骤是否只修改 GitHub 元数据。
 
 ## 清理
 
-审查提交或明确 no-submit 后：
+提交审查或明确不提交审查后：
 
-- 删除 clean review/conflict worktree，并从主仓库运行 `git worktree prune`；
-- 删除 review payload、GraphQL query、comment、log、conflict note 等临时文件，除非用户要求保留；
-- worktree 有未提交 conflict repair、需要保留的诊断或用户改动时不得删除，向用户报告路径和原因；
-- 确认主 worktree 未被审查流程修改；
-- 清理后在同一个 todo 工具做最终审计，汇报 completed、not-applicable、blocking 和 unfinished。
+- 删除无改动的审查或冲突工作树，并从主仓库运行 `git worktree prune`；
+- 删除审查请求载荷、GraphQL 查询、评论、日志、冲突说明等临时文件，除非用户要求保留；
+- 工作树有未提交的冲突修复、需要保留的诊断或用户改动时不得删除，向用户报告路径和原因；
+- 确认主工作树未被审查流程修改；
+- 清理后在同一个任务清单工具做最终审计，汇报已完成、不适用、阻塞和未完成项目。


### PR DESCRIPTION
## 问题

现有单 PR 审查技能虽然以中文为主，但仍混用较多英文流程术语，审查评论也只要求问题、证据和修复方向，没有强制解释为什么需要改动、改动收益以及改动前后的逻辑。对于刚接触相关模块的参与者，现有评论不容易建立完整上下文，也缺少发布后的格式复核门禁。

## 改动

- 将 `review-single-pr` 的主体流程改为中文表达，仅保留命令、路径、代码符号、接口字段、产品名和标准正式名称。
- 集中建立中文审查文本规范，要求每条修改意见使用七个粗体中文标题。
- 明确区分“改动前逻辑（基准分支）”与“改动后逻辑（当前 PR）”，将期望修复后的状态限定在“建议修改方式”。
- 要求总审查正文使用四个二级中文标题，并面向初次接触模块的读者说明调用链、状态变化和实际影响。
- 增加发布前草稿检查与发布后实际显示复核；格式不满足要求时必须重写或修正。
- 同步 `review-open-prs` 的直接派发提示和子代理返回契约，使批量审查继承相同格式。

## 设计逻辑

本次改动把评论结构从分散要求收敛为一个权威规范，同时保留当前提交校验、CI 归因、确定性回归、应用与 QEMU 实跑、Cargo 发布检查、重复实现分析、冲突处理、审查人分配和清理等原有硬门槛。固定标题让评论内容可以逐项复核；基准分支与当前 PR 的显式区分避免把建议中的未来逻辑误写成已经发生的改动。

## 验证

- `python3 /home/zhourui/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/review-single-pr`
- `python3 /home/zhourui/.codex/skills/.system/skill-creator/scripts/quick_validate.py .claude/skills/review-open-prs`
- `git diff --check`
- Markdown 代码围栏配对检查
- 并发顺序缺陷、测试未接入执行链路、无阻塞批准三个只读前向验证场景
- 改写前后强制审查门禁守恒审计

本次仅修改 Markdown 技能说明，不涉及 Rust 代码，因此未运行 Rust 格式化或 Clippy。