### PR TITLE
fix(ci): ensure runner planning uses workflow repository owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,19 +214,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
-          PR_HEAD_REPOSITORY_OWNER: >-
-            ${{ github.event.pull_request.head.repo.owner.login || '' }}
           SINCE_REF: ${{ steps.since.outputs.since_ref }}
         run: |
           set -euo pipefail
-          source_repository_owner="$REPOSITORY_OWNER"
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            source_repository_owner="$PR_HEAD_REPOSITORY_OWNER"
-          fi
           python3 scripts/test/ci_plan.py \
             --mode main \
             --repository "$GITHUB_REPOSITORY" \
-            --repository-owner "$source_repository_owner" \
+            --repository-owner "$REPOSITORY_OWNER" \
             --event-name "$EVENT_NAME" \
             --base-ref "$BASE_REF" \
             --since-ref "$SINCE_REF" \

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -117,10 +117,16 @@ check 中禁止直接声明 `runs_on`、`environment`、owner 或 `require_kvm`�
 | `ubuntu-base` | `ubuntu-latest` + base container | 全局默认 |
 | `ubuntu-host` | `ubuntu-latest` host | 不使用 container |
 | `ubuntu-axvisor-lvz` | `ubuntu-latest` + LVZ container | LoongArch AxVisor |
-| `qcs` | `self-hosted, linux, qcs` | fork 回退到 base container |
+| `qcs` | `self-hosted, linux, qcs` | workflow 在 fork 仓库运行时回退到 base container |
 | `board` | `self-hosted, linux, board` | 仅 `rcore-os` owner |
 | `kvm-intel` | `self-hosted, linux, intel, kvm` | 仅 `rcore-os`，要求 KVM |
 | `kvm-amd` | `self-hosted, linux, amd, kvm` | 仅 `rcore-os`，要求 KVM |
+
+Runner 路由以 workflow 执行仓库的 `github.repository_owner` 为准。fork
+仓库自行执行 CI 时使用 GitHub-hosted fallback；在 `rcore-os/tgoskits`
+中执行的 pull request workflow 使用完整的组织 Runner 矩阵。外部 PR 在使用
+self-hosted Runner 前应先经过 workflow 审批；应在仓库设置中为外部贡献者启用
+该审批，不能用 PR 源仓库 owner 改写 Runner 路由。
 
 self-hosted 检查的 `cache_key` 必须为空；省略时默认就是空字符串。GitHub-hosted
 检查只有显式非空 `cache_key` 才启用 `Swatinem/rust-cache`。

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -38,11 +38,13 @@ def main() -> int:
         errors.append(
             "pull_request paths omit workspace roots: " + ", ".join(missing_roots)
         )
+    if "PR_HEAD_REPOSITORY_OWNER" in ci_workflow:
+        errors.append("runner planning must not use the pull request source owner")
 
     for fragment, message in (
         (
-            "github.event.pull_request.head.repo.owner.login || ''",
-            "PR planning must use the source repository owner",
+            '--repository-owner "$REPOSITORY_OWNER"',
+            "runner planning must use the workflow repository owner",
         ),
         (
             '--since-ref "$SINCE_REF"',

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -35,6 +35,12 @@ class CiPlanTests(unittest.TestCase):
             "cargo xtask lock-lint",
             static_rows["run-sync-lint"]["command"],
         )
+        test_rows = {row["id"]: row for row in plan["test_matrix"]["include"]}
+        self.assertEqual(
+            test_rows["run-clippy"]["runs_on"],
+            ["self-hosted", "linux", "qcs"],
+        )
+        self.assertIn("test-starry-self-hosted-board-visionfive2", test_rows)
         self.assertTrue(
             all(" / " in row["name"] for row in plan["test_matrix"]["include"])
         )
@@ -424,12 +430,13 @@ class CiPlanTests(unittest.TestCase):
             )
             self.assertEqual(rows[check_id]["cache_key"], "")
 
-    def test_fork_filters_owner_checks_and_falls_back_from_qcs(self) -> None:
+    def test_fork_repository_filters_owner_checks_and_falls_back_from_qcs(
+        self,
+    ) -> None:
         context = ci_plan.PlanContext(
-            repository="rcore-os/tgoskits",
+            repository="contributor/tgoskits",
             repository_owner="contributor",
-            event_name="pull_request",
-            base_ref="dev",
+            event_name="push",
         )
         plan = ci_plan.build_main_plan(context)
         static_rows = {row["id"]: row for row in plan["static_matrix"]["include"]}
@@ -440,7 +447,7 @@ class CiPlanTests(unittest.TestCase):
         self.assertEqual(static_rows["check-formatting"]["runs_on"], ["ubuntu-latest"])
         self.assertEqual(
             static_rows["check-formatting"]["container_image"],
-            "ghcr.io/rcore-os/tgoskits-container:latest",
+            "ghcr.io/contributor/tgoskits-container:latest",
         )
         self.assertFalse(static_rows["check-formatting"]["download_xtask_bin_artifact"])
         clippy = test_rows["run-clippy"]

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -4,6 +4,7 @@ import importlib.util
 import sys
 import unittest
 from pathlib import Path
+from typing import Any
 
 MODULE_PATH = Path(__file__).with_name("ci_plan.py")
 sys.path.insert(0, str(MODULE_PATH.parent))
@@ -22,25 +23,41 @@ class CiPlanTests(unittest.TestCase):
             base_ref="dev",
         )
 
-    def test_upstream_main_plan_preserves_all_checks(self) -> None:
+    def test_upstream_main_plan_preserves_required_checks_and_runner_policy(
+        self,
+    ) -> None:
         plan = ci_plan.build_main_plan(self.upstream)
 
-        self.assertEqual(len(plan["static_matrix"]["include"]), 2)
-        self.assertEqual(len(plan["test_matrix"]["include"]), 32)
         self.assertTrue(plan["static_required"])
-        static_rows = {
-            row["id"]: row for row in plan["static_matrix"]["include"]
+        static_rows = self.assert_unique_ids(plan["static_matrix"]["include"])
+        test_rows = self.assert_unique_ids(plan["test_matrix"]["include"])
+        self.assertTrue(static_rows.keys().isdisjoint(test_rows))
+        rows = static_rows | test_rows
+        expected_runners = {
+            "check-formatting": ["self-hosted", "linux", "qcs"],
+            "run-sync-lint": ["ubuntu-latest"],
+            "run-clippy": ["self-hosted", "linux", "qcs"],
+            "test-with-std": ["self-hosted", "linux", "qcs"],
+            "test-arceos-x86-64-qemu": ["self-hosted", "linux", "qcs"],
+            "test-axvisor-aarch64-qemu-http-control-plane": [
+                "self-hosted",
+                "linux",
+                "qcs",
+            ],
+            "test-starry-aarch64-qemu": ["ubuntu-latest"],
+            "test-starry-self-hosted-board-visionfive2": [
+                "self-hosted",
+                "linux",
+                "board",
+            ],
         }
+        for check_id, runs_on in expected_runners.items():
+            self.assertIn(check_id, rows)
+            self.assertEqual(rows[check_id]["runs_on"], runs_on)
         self.assertIn(
             "cargo xtask lock-lint",
             static_rows["run-sync-lint"]["command"],
         )
-        test_rows = {row["id"]: row for row in plan["test_matrix"]["include"]}
-        self.assertEqual(
-            test_rows["run-clippy"]["runs_on"],
-            ["self-hosted", "linux", "qcs"],
-        )
-        self.assertIn("test-starry-self-hosted-board-visionfive2", test_rows)
         self.assertTrue(
             all(" / " in row["name"] for row in plan["test_matrix"]["include"])
         )
@@ -67,19 +84,15 @@ class CiPlanTests(unittest.TestCase):
             ),
         )
 
-        plan = ci_plan.build_main_plan(context)
-        ids = {row["id"] for row in plan["test_matrix"]["include"]}
+        rows = self.assert_unique_ids(
+            ci_plan.build_main_plan(context)["test_matrix"]["include"]
+        )
 
+        self.assert_selects_full_group(rows, "Workspace")
+        self.assert_selects_full_group(rows, "ArceOS")
         self.assertEqual(
-            ids,
-            {
-                "run-clippy",
-                "test-with-std",
-                "test-arceos-x86-64-qemu",
-                "test-arceos-riscv64-qemu",
-                "test-arceos-aarch64-qemu-app-suites",
-                "test-arceos-loongarch64-qemu",
-            },
+            {row["group"] for row in rows.values()},
+            {"Workspace", "ArceOS"},
         )
 
     def test_pull_request_impact_package_selects_standalone_check(self) -> None:
@@ -121,20 +134,17 @@ class CiPlanTests(unittest.TestCase):
             impact=ci_plan.CiImpact.full_selection("fixture"),
         )
 
-        incremental_rows = {
-            row["id"]: row
-            for row in ci_plan.build_main_plan(incremental)["test_matrix"]["include"]
-        }
-        full_rows = {
-            row["id"]: row
-            for row in ci_plan.build_main_plan(full)["test_matrix"]["include"]
-        }
+        incremental_rows = self.assert_unique_ids(
+            ci_plan.build_main_plan(incremental)["test_matrix"]["include"]
+        )
+        full_rows = self.assert_unique_ids(
+            ci_plan.build_main_plan(full)["test_matrix"]["include"]
+        )
 
         self.assertIn(
             '--since "$SINCE_REF"', incremental_rows["test-with-std"]["command"]
         )
         self.assertNotIn("--since", full_rows["test-with-std"]["command"])
-        self.assertEqual(len(full_rows), 32)
 
     def test_app_only_impact_does_not_select_runtime_checks(self) -> None:
         context = ci_plan.PlanContext(
@@ -150,10 +160,12 @@ class CiPlanTests(unittest.TestCase):
             ),
         )
 
-        plan = ci_plan.build_main_plan(context)
-        test_ids = {row["id"] for row in plan["test_matrix"]["include"]}
+        rows = self.assert_unique_ids(
+            ci_plan.build_main_plan(context)["test_matrix"]["include"]
+        )
 
-        self.assertEqual(test_ids, {"run-clippy", "test-with-std"})
+        self.assert_selects_full_group(rows, "Workspace")
+        self.assertEqual({row["group"] for row in rows.values()}, {"Workspace"})
 
     def test_non_pr_events_ignore_impact_and_preserve_full_matrix(self) -> None:
         impact = ci_plan.CiImpact(
@@ -181,7 +193,7 @@ class CiPlanTests(unittest.TestCase):
                 )
 
                 self.assertEqual(with_impact, baseline)
-                self.assertEqual(len(with_impact["test_matrix"]["include"]), 32)
+                self.assert_unique_ids(with_impact["test_matrix"]["include"])
 
     def test_pure_test_suite_change_runs_only_the_exact_registered_case(self) -> None:
         context = ci_plan.PlanContext(
@@ -370,20 +382,11 @@ class CiPlanTests(unittest.TestCase):
         )
 
         plan = ci_plan.build_main_plan(context)
-        ids = {row["id"] for row in plan["test_matrix"]["include"]}
+        rows = self.assert_unique_ids(plan["test_matrix"]["include"])
 
         self.assertTrue(plan["static_required"])
-        self.assertEqual(
-            len(
-                [
-                    row
-                    for row in plan["test_matrix"]["include"]
-                    if row["group"] == "Starry"
-                ]
-            ),
-            9,
-        )
-        self.assertFalse(any(check_id.startswith("suite-") for check_id in ids))
+        self.assert_selects_full_group(rows, "Starry")
+        self.assertFalse(any(check_id.startswith("suite-") for check_id in rows))
 
     def test_unmatched_known_os_input_falls_back_to_that_os(self) -> None:
         context = ci_plan.PlanContext(
@@ -398,13 +401,14 @@ class CiPlanTests(unittest.TestCase):
             ),
         )
 
-        rows = ci_plan.build_main_plan(context)["test_matrix"]["include"]
-
-        self.assertEqual(
-            len([row for row in rows if row["group"] == "Starry"]),
-            9,
+        rows = self.assert_unique_ids(
+            ci_plan.build_main_plan(context)["test_matrix"]["include"]
         )
-        self.assertFalse(any(row["group"] in {"ArceOS", "AxVisor"} for row in rows))
+
+        self.assert_selects_full_group(rows, "Starry")
+        self.assertFalse(
+            any(row["group"] in {"ArceOS", "AxVisor"} for row in rows.values())
+        )
 
     def test_arceos_qemu_jobs_run_same_arch_axtests_serially(self) -> None:
         plan = ci_plan.build_main_plan(self.upstream)
@@ -439,11 +443,25 @@ class CiPlanTests(unittest.TestCase):
             event_name="push",
         )
         plan = ci_plan.build_main_plan(context)
-        static_rows = {row["id"]: row for row in plan["static_matrix"]["include"]}
-        test_rows = {row["id"]: row for row in plan["test_matrix"]["include"]}
+        static_rows = self.assert_unique_ids(plan["static_matrix"]["include"])
+        test_rows = self.assert_unique_ids(plan["test_matrix"]["include"])
 
-        self.assertEqual(len(test_rows), 16)
+        self.assertTrue(
+            {
+                "run-clippy",
+                "test-with-std",
+                "test-arceos-aarch64-qemu-app-suites",
+                "test-axvisor-aarch64-qemu-http-control-plane",
+                "test-starry-aarch64-qemu",
+            }.issubset(test_rows)
+        )
         self.assertFalse(any("board" in row["id"] for row in test_rows.values()))
+        self.assertTrue(
+            all(
+                row["runs_on"] == ["ubuntu-latest"]
+                for row in (*static_rows.values(), *test_rows.values())
+            )
+        )
         self.assertEqual(static_rows["check-formatting"]["runs_on"], ["ubuntu-latest"])
         self.assertEqual(
             static_rows["check-formatting"]["container_image"],
@@ -473,28 +491,32 @@ class CiPlanTests(unittest.TestCase):
             event_name="schedule",
         )
 
-        self.assertEqual(
-            len(
-                ci_plan.build_starry_apps_plan(manual)["starry_apps_matrix"]["include"]
-            ),
-            5,
+        manual_rows = self.assert_unique_ids(
+            ci_plan.build_starry_apps_plan(manual)["starry_apps_matrix"]["include"]
         )
-        self.assertEqual(
-            len(
-                ci_plan.build_starry_apps_plan(manual_with_clippy)[
-                    "starry_apps_matrix"
-                ]["include"]
-            ),
-            6,
+        manual_with_clippy_rows = self.assert_unique_ids(
+            ci_plan.build_starry_apps_plan(manual_with_clippy)["starry_apps_matrix"][
+                "include"
+            ]
         )
-        self.assertEqual(
-            len(
-                ci_plan.build_starry_apps_plan(scheduled)["starry_apps_matrix"][
-                    "include"
-                ]
-            ),
-            6,
+        scheduled_rows = self.assert_unique_ids(
+            ci_plan.build_starry_apps_plan(scheduled)["starry_apps_matrix"]["include"]
         )
+        required_ids = {
+            "starry-app-smoke-x86-64",
+            "starry-app-smoke-aarch64",
+            "starry-app-smoke-riscv64",
+            "starry-app-smoke-loongarch64",
+            "starry-nixos-x86-64-qemu",
+        }
+        for name, rows, expects_clippy in (
+            ("manual", manual_rows, False),
+            ("manual with clippy", manual_with_clippy_rows, True),
+            ("scheduled", scheduled_rows, True),
+        ):
+            with self.subTest(selection=name):
+                self.assertTrue(required_ids.issubset(rows))
+                self.assertEqual("starry-apps-clippy-all" in rows, expects_clippy)
 
     def test_starry_apps_manual_nixos_uses_app_runner(self) -> None:
         manual = ci_plan.PlanContext(
@@ -511,6 +533,32 @@ class CiPlanTests(unittest.TestCase):
         self.assertEqual(nixos["timeout_minutes"], 45)
         self.assertIn("starry app qemu -t nixos", nixos["command"])
         self.assertNotIn("starry test", nixos["command"])
+
+    def assert_unique_ids(
+        self, rows: list[dict[str, Any]]
+    ) -> dict[str, dict[str, Any]]:
+        ids = [row["id"] for row in rows]
+        self.assertEqual(
+            len(ids),
+            len(set(ids)),
+            f"matrix check IDs must be unique: {ids}",
+        )
+        return {row["id"]: row for row in rows}
+
+    def assert_selects_full_group(
+        self, rows: dict[str, dict[str, Any]], group: str
+    ) -> None:
+        full_rows = self.assert_unique_ids(
+            ci_plan.build_main_plan(self.upstream)["test_matrix"]["include"]
+        )
+        selected_ids = {
+            check_id for check_id, row in rows.items() if row["group"] == group
+        }
+        full_ids = {
+            check_id for check_id, row in full_rows.items() if row["group"] == group
+        }
+        self.assertEqual(selected_ids, full_ids)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 问题

CI planner 此前在 `pull_request` 事件中使用 PR 源仓库 owner 决定 Runner 路由。这样会把工作流实际所属仓库与 PR 来源混为一谈，导致 `rcore-os` 仓库中的 CI 无法稳定使用组织配置的完整 Runner 策略。

同时，planner 单元测试通过固定矩阵总数和完整 ID 快照判断结果。增加合法检查项时，即使 CI 行为正确，也会因为数量变化导致 Plan validation 失败。

## 修改内容

- Runner 规划统一使用工作流仓库的 `github.repository_owner`。
- 路由检查禁止重新引入 PR 源仓库 owner，并验证 planner 参数来源。
- 补充组织仓库与 fork 仓库的 Runner 路由回归覆盖：组织仓库保留自托管 Runner 策略，fork 仓库过滤 owner-only 检查并回退到 `ubuntu-latest`。
- 移除容易过期的矩阵固定总数和完整 ID 枚举，改为检查关键任务、ID 唯一性、Runner 策略以及动态分组选择。
- 更新 CI 文档，说明 Runner 路由以工作流仓库 owner 为准。

## 实现逻辑

Runner 是否可用取决于正在执行工作流的仓库和组织，而不是 PR 源分支所在仓库。因此 planner 只接收工作流仓库 owner：`rcore-os` 组织仓库使用完整配置；fork 仓库自身执行 CI 时，根据 fork owner 过滤组织专用任务并使用 GitHub-hosted Runner。

测试不再复制 catalog 的当前规模，而是验证稳定契约。新增同分组检查会自动进入动态期望结果；只有 Runner 策略、分组边界或特定命令语义发生变化时才需要更新测试。

## 验证

- `python3 -m unittest discover -s scripts/test -p "test_*.py"`
- `python3 scripts/test/check_ci_routing.py`
- `python3 -m compileall -q scripts/test`
- `cargo fmt --all --check`
- `cargo xtask clippy --package tg-xtask`
