### PR TITLE
fix(ci): group checks and preserve duplicate push status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,15 @@ jobs:
       should_run: ${{ steps.route.outputs.should_run }}
       since_ref: ${{ steps.since.outputs.since_ref }}
       static_matrix: ${{ steps.matrix.outputs.static_matrix }}
-      test_matrix: ${{ steps.matrix.outputs.test_matrix }}
       static_required: ${{ steps.matrix.outputs.static_required }}
+      workspace_matrix: ${{ steps.matrix.outputs.workspace_matrix }}
+      workspace_required: ${{ steps.matrix.outputs.workspace_required }}
+      arceos_matrix: ${{ steps.matrix.outputs.arceos_matrix }}
+      arceos_required: ${{ steps.matrix.outputs.arceos_required }}
+      starry_matrix: ${{ steps.matrix.outputs.starry_matrix }}
+      starry_required: ${{ steps.matrix.outputs.starry_required }}
+      axvisor_matrix: ${{ steps.matrix.outputs.axvisor_matrix }}
+      axvisor_required: ${{ steps.matrix.outputs.axvisor_required }}
     steps:
       - name: Route branch push
         id: route
@@ -129,6 +136,7 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             selector='select(
               .run_number < (env.CURRENT_RUN_NUMBER | tonumber)
+              and .event == "pull_request"
               and any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
             )'
           else
@@ -244,8 +252,8 @@ jobs:
     secrets:
       CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
 
-  test_checks:
-    name: Verification
+  workspace_checks:
+    name: Workspace
     needs:
       - plan_ci
       - static_checks
@@ -253,11 +261,81 @@ jobs:
       always() &&
       needs.plan_ci.result == 'success' &&
       needs.plan_ci.outputs.should_run == 'true' &&
+      needs.plan_ci.outputs.workspace_required == 'true' &&
       (needs.static_checks.result == 'success' ||
        needs.static_checks.result == 'skipped')
     uses: ./.github/workflows/reusable-check-matrix.yml
     with:
-      matrix_json: ${{ needs.plan_ci.outputs.test_matrix }}
+      matrix_json: ${{ needs.plan_ci.outputs.workspace_matrix }}
+      fail_fast: true
+      save_cache: >-
+        ${{ github.event_name == 'push' &&
+            (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
+      since_ref: ${{ needs.plan_ci.outputs.since_ref }}
+    secrets:
+      CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
+
+  arceos_checks:
+    name: ArceOS
+    needs:
+      - plan_ci
+      - static_checks
+    if: >-
+      always() &&
+      needs.plan_ci.result == 'success' &&
+      needs.plan_ci.outputs.should_run == 'true' &&
+      needs.plan_ci.outputs.arceos_required == 'true' &&
+      (needs.static_checks.result == 'success' ||
+       needs.static_checks.result == 'skipped')
+    uses: ./.github/workflows/reusable-check-matrix.yml
+    with:
+      matrix_json: ${{ needs.plan_ci.outputs.arceos_matrix }}
+      fail_fast: true
+      save_cache: >-
+        ${{ github.event_name == 'push' &&
+            (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
+      since_ref: ${{ needs.plan_ci.outputs.since_ref }}
+    secrets:
+      CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
+
+  starry_checks:
+    name: Starry
+    needs:
+      - plan_ci
+      - static_checks
+    if: >-
+      always() &&
+      needs.plan_ci.result == 'success' &&
+      needs.plan_ci.outputs.should_run == 'true' &&
+      needs.plan_ci.outputs.starry_required == 'true' &&
+      (needs.static_checks.result == 'success' ||
+       needs.static_checks.result == 'skipped')
+    uses: ./.github/workflows/reusable-check-matrix.yml
+    with:
+      matrix_json: ${{ needs.plan_ci.outputs.starry_matrix }}
+      fail_fast: true
+      save_cache: >-
+        ${{ github.event_name == 'push' &&
+            (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
+      since_ref: ${{ needs.plan_ci.outputs.since_ref }}
+    secrets:
+      CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}
+
+  axvisor_checks:
+    name: AxVisor
+    needs:
+      - plan_ci
+      - static_checks
+    if: >-
+      always() &&
+      needs.plan_ci.result == 'success' &&
+      needs.plan_ci.outputs.should_run == 'true' &&
+      needs.plan_ci.outputs.axvisor_required == 'true' &&
+      (needs.static_checks.result == 'success' ||
+       needs.static_checks.result == 'skipped')
+    uses: ./.github/workflows/reusable-check-matrix.yml
+    with:
+      matrix_json: ${{ needs.plan_ci.outputs.axvisor_matrix }}
       fail_fast: true
       save_cache: >-
         ${{ github.event_name == 'push' &&

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -14,7 +14,9 @@ sidebar_label: "自动 CI 测试"
 - `.github/workflows/reusable-check-matrix.yml` 执行展开后的矩阵行。
 
 容器发布由 `.github/workflows/container-publish.yml` 独立处理。非主线分支 push
-由主 CI 的准备阶段检查 open PR，已有 PR 时不再运行后续矩阵。
+由主 CI 的准备阶段检查 open PR，已有 PR 时准备阶段正常成功、后续矩阵标记为
+skipped。pull request run 只取消同一 PR 的旧 pull request run，不会把关联同一提交的
+push 准备阶段取消成失败状态。
 
 ## 触发条件
 
@@ -31,22 +33,28 @@ sidebar_label: "自动 CI 测试"
 
 ```text
 Plan CI
-  -> Preflight / <purpose>
-     -> Verification / <OS> / <platform> <arch-or-board> · <purpose>
+Preflight / <purpose>
+Workspace / <purpose>
+ArceOS / <platform> <arch-or-board> · <purpose>
+Starry / <platform> <arch-or-board> · <purpose>
+AxVisor / <platform> <arch-or-board> · <purpose>
 ```
 
-固定阶段名称为 `Preflight` 和 `Verification`。平台写在架构之前，例如：
+`Workspace`、`ArceOS`、`Starry` 和 `AxVisor` 都在 `Preflight` 成功或按计划跳过
+后启动。每个名称都是一个可展开的 reusable workflow 分组，平台写在架构之前，例如：
 
 ```text
 Preflight / Formatting + publish dry-run
-Verification / ArceOS / QEMU aarch64 · GICv2 SMP4 boot + suites + axtest
-Verification / AxVisor / VMX x86_64 · Smoke
-Verification / Starry / Board VisionFive 2 · Suites
+Workspace / Incremental Clippy
+ArceOS / QEMU aarch64 · GICv2 SMP4 boot + suites + axtest
+Starry / Board VisionFive 2 · Suites
+AxVisor / VMX x86_64 · Smoke
 ```
 
 `Preflight` 包含 formatting/publish dry-run、incremental sync-lint 和 locking
-policy。`Verification` 包含 Workspace、ArceOS、AxVisor 和 Starry 检查。全量运行
-展开为 3 个 Preflight 行和 32 个 Verification 行。
+policy。`Workspace` 包含跨 workspace 的 clippy 和 std tests，其余三个分组包含各自
+注册的 QEMU、KVM 和真机检查。实际行数由 manifests 动态生成，不在文档中维护易过期
+的固定总数。
 
 ## PR 影响路由
 
@@ -84,16 +92,16 @@ changed paths、affected OS、精确输入、test-suit 选择、selected/skipped
 动态名称遵循：
 
 ```text
-Verification / <OS> / <platform> <arch-or-board> · <case>
+<OS> / <platform> <arch-or-board> · <case>
 ```
 
 例如：
 
 ```text
-Verification / ArceOS / QEMU riscv64 · rust/task-ipi
-Verification / Starry / QEMU aarch64 · qemu/system
-Verification / AxVisor / VMX x86_64 · direct-acpi-vmx
-Verification / Starry / Board OrangePi 5 Plus · native-hardware-smoke
+ArceOS / QEMU riscv64 · rust/task-ipi
+Starry / QEMU aarch64 · qemu/system
+AxVisor / VMX x86_64 · direct-acpi-vmx
+Starry / Board OrangePi 5 Plus · native-hardware-smoke
 ```
 
 Starry `qemu/system/<subcase>` 源码变更使用 `qemu/<subcase>` selector，并为拥有
@@ -133,9 +141,11 @@ self-hosted 检查的 `cache_key` 必须为空；省略时默认就是空字符�
 
 ## 可复用矩阵
 
-`reusable-check-matrix.yml` 只包含一个 matrix job。planner 始终输出完全展开的
-runner labels、container image、preflight、cache、checkout depth、timeout、artifact
-和命令字段。
+`reusable-check-matrix.yml` 只包含一个 matrix job。planner 分别输出
+`workspace_matrix`、`arceos_matrix`、`starry_matrix` 和 `axvisor_matrix`，顶层同名
+caller 分别调用该执行器，从而在 Actions 左栏形成可展开分组。每个分组内部保留
+fail-fast；一个分组失败不会取消其他分组。矩阵行仍包含完全展开的 runner labels、
+container image、preflight、cache、checkout depth、timeout、artifact 和命令字段。
 
 普通完整/增量运行中，sync-lint 生成 `tg-xtask-bin` artifact，使用容器的测试行可
 下载复用。exclusive test-suit 不运行 Preflight，因此动态行直接使用 `cargo xtask`

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -23,6 +23,7 @@ def main() -> int:
     ci_triggers = mapping_block(ci_workflow, "on", 0)
     ci_push = mapping_block(ci_triggers, "push", 2)
     pull_request = mapping_block(ci_triggers, "pull_request", 2)
+    jobs = mapping_block(ci_workflow, "jobs", 0)
     if mapping_block(ci_push, "branches", 4):
         errors.append("main CI push trigger must accept every branch")
 
@@ -59,10 +60,9 @@ def main() -> int:
             "Preflight must follow the planner decision",
         ),
         (
-            "needs.static_checks.result == 'skipped'",
-            "Verification must accept an intentionally skipped Preflight",
+            "gh pr list",
+            "the plan job must detect open pull requests",
         ),
-        ("gh pr list", "the plan job must detect open pull requests"),
         ("should_run=false", "an open PR must disable duplicate branch push CI"),
         (
             "needs.plan_ci.outputs.should_run == 'true'",
@@ -74,6 +74,112 @@ def main() -> int:
         ),
     ):
         require_contains(errors, ci_workflow, fragment, message)
+
+    pull_request_selector, push_selector = shell_if_else_branches(
+        ci_workflow,
+        '"$EVENT_NAME" = "pull_request"',
+    )
+    if not pull_request_selector or not push_selector:
+        errors.append("missing event-specific stale-run selectors")
+    else:
+        for fragment, message in (
+            (
+                '.event == "pull_request"',
+                "PR cleanup must only select pull request runs",
+            ),
+            (
+                ".pull_requests[]?",
+                "PR cleanup must select runs for the same pull request",
+            ),
+        ):
+            require_contains(errors, pull_request_selector, fragment, message)
+        for fragment, message in (
+            (
+                '.event != "pull_request"',
+                "push cleanup must not cancel pull request runs",
+            ),
+            (
+                '.event != "pull_request_target"',
+                "push cleanup must not cancel pull request target runs",
+            ),
+        ):
+            require_contains(errors, push_selector, fragment, message)
+
+    if mapping_block(jobs, "test_checks", 2):
+        errors.append("the legacy Verification caller must be removed")
+    if re.search(r"^\s+name:\s+Verification\s*$", ci_workflow, re.MULTILINE):
+        errors.append("the CI job list must not expose a Verification group")
+    if "test_matrix" in ci_workflow:
+        errors.append("the workflow must consume per-group matrices, not test_matrix")
+
+    grouped_jobs = (
+        ("workspace_checks", "Workspace", "workspace"),
+        ("arceos_checks", "ArceOS", "arceos"),
+        ("starry_checks", "Starry", "starry"),
+        ("axvisor_checks", "AxVisor", "axvisor"),
+    )
+    for job_id, display_name, output_prefix in grouped_jobs:
+        job = mapping_block(jobs, job_id, 2)
+        if not job:
+            errors.append(f"missing grouped CI job: {job_id}")
+            continue
+        for fragment, message in (
+            (f"name: {display_name}", "must expose the expected group name"),
+            ("- plan_ci", "must depend on Plan CI"),
+            ("- static_checks", "must depend on Preflight"),
+            ("always()", "must evaluate after Preflight finishes"),
+            (
+                "needs.plan_ci.result == 'success'",
+                "must require successful planning",
+            ),
+            (
+                "needs.plan_ci.outputs.should_run == 'true'",
+                "must follow branch routing",
+            ),
+            (
+                f"needs.plan_ci.outputs.{output_prefix}_required == 'true'",
+                "must follow its planner selection",
+            ),
+            (
+                "needs.static_checks.result == 'success'",
+                "must require a successful Preflight",
+            ),
+            (
+                "needs.static_checks.result == 'skipped'",
+                "must accept an intentionally skipped Preflight",
+            ),
+            (
+                "uses: ./.github/workflows/reusable-check-matrix.yml",
+                "must call the reusable matrix executor",
+            ),
+            (
+                f"needs.plan_ci.outputs.{output_prefix}_matrix",
+                "must consume its planner matrix",
+            ),
+            ("fail_fast: true", "must keep fail-fast within the group"),
+            ("save_cache: >-", "must preserve cache-save routing"),
+            (
+                "since_ref: ${{ needs.plan_ci.outputs.since_ref }}",
+                "must receive the incremental base",
+            ),
+            (
+                "CLAW_API_KEY: ${{ secrets.CLAW_API_KEY }}",
+                "must preserve optional credentials",
+            ),
+        ):
+            require_contains(
+                errors,
+                job,
+                fragment,
+                f"{display_name} {message}",
+            )
+        for output_name in ("matrix", "required"):
+            require_contains(
+                errors,
+                ci_workflow,
+                f"steps.matrix.outputs.{output_prefix}_{output_name}",
+                f"Plan CI must publish {output_prefix}_{output_name}",
+            )
 
     return report(errors)
 
@@ -107,6 +213,21 @@ def list_items_in_order(text: str, key: str, indent: int) -> list[str]:
         for line in mapping_block(text, key, indent).splitlines()
         if line.strip().startswith("- ")
     ]
+
+
+def shell_if_else_branches(text: str, condition: str) -> tuple[str, str]:
+    match = re.search(
+        rf'^\s*if \[ {re.escape(condition)} \]; then\s*$\n'
+        r"(?P<then>.*?)"
+        r"^\s*else\s*$\n"
+        r"(?P<else>.*?)"
+        r"^\s*fi\s*$",
+        text,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    if match is None:
+        return "", ""
+    return match.group("then"), match.group("else")
 
 
 def require_contains(errors: list[str], text: str, fragment: str, message: str) -> None:

--- a/scripts/test/ci_plan.py
+++ b/scripts/test/ci_plan.py
@@ -44,6 +44,12 @@ RUNNER_PROFILES_MANIFEST = CHECKS_ROOT.parent / "runner-profiles.toml"
 
 SUPPORTED_PHASES = {"static", "test", "starry_apps"}
 SUPPORTED_PREFLIGHTS = {"none", "qemu-user", "full"}
+TEST_GROUP_OUTPUT_PREFIXES = {
+    "Workspace": "workspace",
+    "ArceOS": "arceos",
+    "Starry": "starry",
+    "AxVisor": "axvisor",
+}
 SUPPORTED_IMPACT_TARGETS = {
     f"{os_name}:{arch}"
     for os_name in ("arceos", "starry", "axvisor")
@@ -165,11 +171,32 @@ def _build_main_plan(
         raise PlanError("main CI must resolve to a non-empty test matrix")
     if not suite_only and not static_rows:
         raise PlanError("main CI must resolve to a non-empty static matrix")
-    return {
+    outputs = {
         "static_matrix": {"include": static_rows},
-        "test_matrix": {"include": test_rows},
         "static_required": bool(static_rows),
     }
+    outputs.update(_build_test_group_outputs(test_rows))
+    return outputs
+
+
+def _build_test_group_outputs(
+    test_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    rows_by_group = {group: [] for group in TEST_GROUP_OUTPUT_PREFIXES}
+    for row in test_rows:
+        group = row["group"]
+        if group not in rows_by_group:
+            raise PlanError(
+                f"test row '{row['id']}' uses unsupported group '{group}'"
+            )
+        rows_by_group[group].append(row)
+
+    outputs = {}
+    for group, prefix in TEST_GROUP_OUTPUT_PREFIXES.items():
+        rows = rows_by_group[group]
+        outputs[f"{prefix}_matrix"] = {"include": rows}
+        outputs[f"{prefix}_required"] = bool(rows)
+    return outputs
 
 
 def build_starry_apps_plan(
@@ -202,10 +229,14 @@ def _load_manifest(manifest: Path) -> dict[str, Any]:
         )
     if document.get("schema_version") != 3:
         raise PlanError(f"{manifest} must declare schema_version = 3")
-    if document.get("phase") not in SUPPORTED_PHASES:
+    phase = document.get("phase")
+    if phase not in SUPPORTED_PHASES:
         raise PlanError(f"{manifest} has an unsupported phase")
-    if not isinstance(document.get("group"), str) or not document["group"].strip():
+    group = document.get("group")
+    if not isinstance(group, str) or not group.strip():
         raise PlanError(f"{manifest} must declare a non-empty group")
+    if phase == "test" and group not in TEST_GROUP_OUTPUT_PREFIXES:
+        raise PlanError(f"{manifest} has unsupported test group '{group}'")
     if not isinstance(document.get("check"), list) or not document["check"]:
         raise PlanError(f"{manifest} must contain at least one [[check]] entry")
     return document
@@ -502,7 +533,7 @@ def _normalize_suite_selection(
     row.update(
         {
             "id": selection.row_id,
-            "name": f"{template['group']} / {selection.leaf_name}",
+            "name": selection.leaf_name,
             "command": selection.command,
             "template_id": selection.template_id,
             "upload_xtask_bin_artifact": False,
@@ -595,10 +626,6 @@ def _normalize_check(check: dict[str, Any], context: PlanContext) -> dict[str, A
     if preflight is None:
         preflight = "full" if container_image else "none"
 
-    name = check["name"]
-    if check["phase"] == "test":
-        name = f"{check['group']} / {name}"
-
     download_xtask = check.get("download_xtask_bin_artifact", False)
     if fallback and check["phase"] == "test":
         download_xtask = True
@@ -614,7 +641,7 @@ def _normalize_check(check: dict[str, Any], context: PlanContext) -> dict[str, A
 
     return {
         "id": check["id"],
-        "name": name,
+        "name": check["name"],
         "group": check["group"],
         "runs_on": runs_on,
         "container_image": container_image,

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -2,6 +2,7 @@
 
 import importlib.util
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,17 @@ SPEC = importlib.util.spec_from_file_location("ci_plan", MODULE_PATH)
 assert SPEC is not None and SPEC.loader is not None
 ci_plan = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(ci_plan)
+
+MAIN_TEST_PREFIXES = ("workspace", "arceos", "starry", "axvisor")
+MAIN_TEST_GROUPS = ("Workspace", "ArceOS", "Starry", "AxVisor")
+
+
+def main_test_rows(plan: dict) -> list[dict]:
+    return [
+        row
+        for prefix in MAIN_TEST_PREFIXES
+        for row in plan[f"{prefix}_matrix"]["include"]
+    ]
 
 
 class CiPlanTests(unittest.TestCase):
@@ -30,9 +42,15 @@ class CiPlanTests(unittest.TestCase):
 
         self.assertTrue(plan["static_required"])
         static_rows = self.assert_unique_ids(plan["static_matrix"]["include"])
-        test_rows = self.assert_unique_ids(plan["test_matrix"]["include"])
+        test_rows = self.assert_unique_ids(main_test_rows(plan))
+        self.assertNotIn("test_matrix", plan)
         self.assertTrue(static_rows.keys().isdisjoint(test_rows))
         rows = static_rows | test_rows
+        for prefix, group in zip(MAIN_TEST_PREFIXES, MAIN_TEST_GROUPS, strict=True):
+            group_rows = plan[f"{prefix}_matrix"]["include"]
+            self.assertTrue(plan[f"{prefix}_required"])
+            self.assertTrue(group_rows)
+            self.assertTrue(all(row["group"] == group for row in group_rows))
         expected_runners = {
             "check-formatting": ["self-hosted", "linux", "qcs"],
             "run-sync-lint": ["ubuntu-latest"],
@@ -59,7 +77,10 @@ class CiPlanTests(unittest.TestCase):
             static_rows["run-sync-lint"]["command"],
         )
         self.assertTrue(
-            all(" / " in row["name"] for row in plan["test_matrix"]["include"])
+            all(
+                not row["name"].startswith(f"{row['group']} / ")
+                for row in test_rows.values()
+            )
         )
 
     def test_pull_request_crate_impact_selects_every_check_for_matching_os(
@@ -84,9 +105,8 @@ class CiPlanTests(unittest.TestCase):
             ),
         )
 
-        rows = self.assert_unique_ids(
-            ci_plan.build_main_plan(context)["test_matrix"]["include"]
-        )
+        plan = ci_plan.build_main_plan(context)
+        rows = self.assert_unique_ids(main_test_rows(plan))
 
         self.assert_selects_full_group(rows, "Workspace")
         self.assert_selects_full_group(rows, "ArceOS")
@@ -94,6 +114,10 @@ class CiPlanTests(unittest.TestCase):
             {row["group"] for row in rows.values()},
             {"Workspace", "ArceOS"},
         )
+        self.assertTrue(plan["workspace_required"])
+        self.assertTrue(plan["arceos_required"])
+        self.assertFalse(plan["starry_required"])
+        self.assertFalse(plan["axvisor_required"])
 
     def test_pull_request_impact_package_selects_standalone_check(self) -> None:
         context = ci_plan.PlanContext(
@@ -110,7 +134,7 @@ class CiPlanTests(unittest.TestCase):
         )
 
         plan = ci_plan.build_main_plan(context)
-        ids = {row["id"] for row in plan["test_matrix"]["include"]}
+        ids = {row["id"] for row in main_test_rows(plan)}
 
         self.assertIn("test-axloader-http-smoke", ids)
         self.assertFalse(any(check_id.startswith("test-arceos-") for check_id in ids))
@@ -135,10 +159,10 @@ class CiPlanTests(unittest.TestCase):
         )
 
         incremental_rows = self.assert_unique_ids(
-            ci_plan.build_main_plan(incremental)["test_matrix"]["include"]
+            main_test_rows(ci_plan.build_main_plan(incremental))
         )
         full_rows = self.assert_unique_ids(
-            ci_plan.build_main_plan(full)["test_matrix"]["include"]
+            main_test_rows(ci_plan.build_main_plan(full))
         )
 
         self.assertIn(
@@ -160,12 +184,15 @@ class CiPlanTests(unittest.TestCase):
             ),
         )
 
-        rows = self.assert_unique_ids(
-            ci_plan.build_main_plan(context)["test_matrix"]["include"]
-        )
+        plan = ci_plan.build_main_plan(context)
+        rows = self.assert_unique_ids(main_test_rows(plan))
 
         self.assert_selects_full_group(rows, "Workspace")
         self.assertEqual({row["group"] for row in rows.values()}, {"Workspace"})
+        self.assertTrue(plan["workspace_required"])
+        for prefix in ("arceos", "starry", "axvisor"):
+            self.assertFalse(plan[f"{prefix}_required"])
+            self.assertEqual(plan[f"{prefix}_matrix"]["include"], [])
 
     def test_non_pr_events_ignore_impact_and_preserve_full_matrix(self) -> None:
         impact = ci_plan.CiImpact(
@@ -193,7 +220,7 @@ class CiPlanTests(unittest.TestCase):
                 )
 
                 self.assertEqual(with_impact, baseline)
-                self.assert_unique_ids(with_impact["test_matrix"]["include"])
+                self.assert_unique_ids(main_test_rows(with_impact))
 
     def test_pure_test_suite_change_runs_only_the_exact_registered_case(self) -> None:
         context = ci_plan.PlanContext(
@@ -214,12 +241,16 @@ class CiPlanTests(unittest.TestCase):
 
         self.assertFalse(plan["static_required"])
         self.assertEqual(plan["static_matrix"]["include"], [])
+        self.assertFalse(plan["workspace_required"])
+        self.assertFalse(plan["arceos_required"])
+        self.assertTrue(plan["starry_required"])
+        self.assertFalse(plan["axvisor_required"])
         self.assertEqual(
-            [row["name"] for row in plan["test_matrix"]["include"]],
-            ["Starry / QEMU aarch64 · qemu/system"],
+            [row["name"] for row in plan["starry_matrix"]["include"]],
+            ["QEMU aarch64 · qemu/system"],
         )
         self.assertEqual(
-            plan["test_matrix"]["include"][0]["command"],
+            plan["starry_matrix"]["include"][0]["command"],
             "cargo xtask starry test qemu --arch aarch64 --test-case qemu/system",
         )
 
@@ -246,11 +277,11 @@ class CiPlanTests(unittest.TestCase):
 
         self.assertFalse(plan["static_required"])
         self.assertEqual(
-            [row["name"] for row in plan["test_matrix"]["include"]],
-            ["Starry / Board OrangePi 5 Plus · native-hardware-smoke"],
+            [row["name"] for row in plan["starry_matrix"]["include"]],
+            ["Board OrangePi 5 Plus · native-hardware-smoke"],
         )
         self.assertEqual(
-            plan["test_matrix"]["include"][0]["command"],
+            plan["starry_matrix"]["include"][0]["command"],
             "cargo xtask starry test board --test-case native-hardware-smoke "
             "--board orangepi-5-plus",
         )
@@ -276,6 +307,38 @@ class CiPlanTests(unittest.TestCase):
         with self.assertRaisesRegex(ci_plan.PlanError, "not registered"):
             ci_plan.build_main_plan(context)
 
+    def test_unsupported_test_group_fails_planning(self) -> None:
+        with self.assertRaisesRegex(
+            ci_plan.PlanError,
+            "unsupported group 'Future OS'",
+        ):
+            ci_plan._build_test_group_outputs(
+                [{"id": "future-os-check", "group": "Future OS"}]
+            )
+
+    def test_manifest_rejects_unsupported_test_group(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = Path(temp_dir) / "future-os.toml"
+            manifest.write_text(
+                """\
+schema_version = 3
+phase = "test"
+group = "Future OS"
+
+[[check]]
+id = "future-os-check"
+name = "Future OS check"
+command = "true"
+""",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                ci_plan.PlanError,
+                "unsupported test group 'Future OS'",
+            ):
+                ci_plan._load_manifest(manifest)
+
     def test_multiple_test_suite_changes_form_a_stable_exact_union(self) -> None:
         context = ci_plan.PlanContext(
             repository="rcore-os/tgoskits",
@@ -296,16 +359,24 @@ class CiPlanTests(unittest.TestCase):
             ),
         )
 
-        rows = ci_plan.build_main_plan(context)["test_matrix"]["include"]
+        plan = ci_plan.build_main_plan(context)
+        axvisor_rows = plan["axvisor_matrix"]["include"]
+        starry_rows = plan["starry_matrix"]["include"]
 
         self.assertEqual(
-            [row["name"] for row in rows],
-            [
-                "AxVisor / VMX x86_64 · direct-acpi-vmx",
-                "Starry / QEMU aarch64 · qemu/system",
-            ],
+            [row["name"] for row in axvisor_rows],
+            ["VMX x86_64 · direct-acpi-vmx"],
         )
-        self.assertTrue(all(not row["download_xtask_bin_artifact"] for row in rows))
+        self.assertEqual(
+            [row["name"] for row in starry_rows],
+            ["QEMU aarch64 · qemu/system"],
+        )
+        self.assertTrue(
+            all(
+                not row["download_xtask_bin_artifact"]
+                for row in axvisor_rows + starry_rows
+            )
+        )
 
     def test_starry_grouped_subcase_runs_only_that_subcase_on_registered_arches(
         self,
@@ -324,13 +395,13 @@ class CiPlanTests(unittest.TestCase):
             ),
         )
 
-        rows = ci_plan.build_main_plan(context)["test_matrix"]["include"]
+        rows = ci_plan.build_main_plan(context)["starry_matrix"]["include"]
 
         self.assertEqual(len(rows), 4)
         self.assertEqual(
             {row["name"] for row in rows},
             {
-                f"Starry / QEMU {arch} · qemu/test-pivot-root"
+                f"QEMU {arch} · qemu/test-pivot-root"
                 for arch in ("aarch64", "loongarch64", "riscv64", "x86_64")
             },
         )
@@ -354,7 +425,7 @@ class CiPlanTests(unittest.TestCase):
 
         ids = {
             row["id"]
-            for row in ci_plan.build_main_plan(context)["test_matrix"]["include"]
+            for row in main_test_rows(ci_plan.build_main_plan(context))
         }
 
         self.assertIn("test-starry-self-hosted-board-visionfive2", ids)
@@ -382,7 +453,7 @@ class CiPlanTests(unittest.TestCase):
         )
 
         plan = ci_plan.build_main_plan(context)
-        rows = self.assert_unique_ids(plan["test_matrix"]["include"])
+        rows = self.assert_unique_ids(main_test_rows(plan))
 
         self.assertTrue(plan["static_required"])
         self.assert_selects_full_group(rows, "Starry")
@@ -401,18 +472,19 @@ class CiPlanTests(unittest.TestCase):
             ),
         )
 
-        rows = self.assert_unique_ids(
-            ci_plan.build_main_plan(context)["test_matrix"]["include"]
-        )
+        plan = ci_plan.build_main_plan(context)
+        rows = self.assert_unique_ids(main_test_rows(plan))
 
         self.assert_selects_full_group(rows, "Starry")
         self.assertFalse(
             any(row["group"] in {"ArceOS", "AxVisor"} for row in rows.values())
         )
+        self.assertEqual(plan["arceos_matrix"]["include"], [])
+        self.assertEqual(plan["axvisor_matrix"]["include"], [])
 
     def test_arceos_qemu_jobs_run_same_arch_axtests_serially(self) -> None:
         plan = ci_plan.build_main_plan(self.upstream)
-        rows = {row["id"]: row for row in plan["test_matrix"]["include"]}
+        rows = {row["id"]: row for row in plan["arceos_matrix"]["include"]}
         expected_arches = {
             "test-arceos-x86-64-qemu": "x86_64",
             "test-arceos-riscv64-qemu": "riscv64",
@@ -444,7 +516,7 @@ class CiPlanTests(unittest.TestCase):
         )
         plan = ci_plan.build_main_plan(context)
         static_rows = self.assert_unique_ids(plan["static_matrix"]["include"])
-        test_rows = self.assert_unique_ids(plan["test_matrix"]["include"])
+        test_rows = self.assert_unique_ids(main_test_rows(plan))
 
         self.assertTrue(
             {
@@ -549,7 +621,7 @@ class CiPlanTests(unittest.TestCase):
         self, rows: dict[str, dict[str, Any]], group: str
     ) -> None:
         full_rows = self.assert_unique_ids(
-            ci_plan.build_main_plan(self.upstream)["test_matrix"]["include"]
+            main_test_rows(ci_plan.build_main_plan(self.upstream))
         )
         selected_ids = {
             check_id for check_id, row in rows.items() if row["group"] == group


### PR DESCRIPTION
## 问题

主 CI 将 Workspace、ArceOS、Starry 和 AxVisor 的所有运行检查平铺在 `Verification` 下，测试较多时难以快速定位所属系统。与此同时，同一提交同时触发 push 和 pull_request 时，PR 的旧任务清理会因为 push run 也关联该 PR 而误取消 `Plan CI (push)`，导致本应跳过的重复任务显示为 cancelled。

## 改动

- 将 planner 的单一测试矩阵拆为 Workspace、ArceOS、Starry 和 AxVisor 四个独立矩阵，并为每组输出是否需要运行的布尔值。
- 用四个顶层 reusable-workflow caller 替换 `Verification`，使 Actions 左栏可以按系统展开各自测试。
- 矩阵叶子名称移除重复的系统前缀；未知测试分组在规划阶段明确报错。
- 将 PR 旧 run 选择器限制为 `pull_request` 事件，保留 push run 自行完成路由并以成功状态跳过后续矩阵。
- 同步更新 CI routing 回归、planner 测试和用户文档。

## 方案逻辑

GitHub Actions 的可折叠层级来自 reusable workflow 的调用关系，而不是 job 名中的分隔符。因此每个系统由独立 caller 消费对应矩阵；空矩阵通过 `*_required` 跳过，原有 Preflight、runner、cache、artifact、secret 和增量路由保持不变。fail-fast 只在各系统内部生效，一个系统失败不会取消其他系统。

重复 push 仍由 `Route branch push` 检测 open PR 并设置 `should_run=false`。PR run 只清理同一 PR 的旧 pull_request run，不再把关联 push 的 Plan CI 取消成失败状态。

## 验证

- `uv run --python 3.11 python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py`：35 项通过
- `uv run --python 3.11 python3 scripts/test/check_ci_routing.py`：通过
- planner 全量输出：Preflight 2、Workspace 2、ArceOS 4、Starry 9、AxVisor 17
- actionlint：忽略仓库既有的 `concurrency.queue` 兼容误报后通过
- `git diff --check`：通过