### PR TITLE
fix(starry-kernel): sync AArch64 clippy features

### DIFF
--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -36,6 +36,7 @@ features = [
     "ax-runtime/rtc",
     "smp",
     "starry-kernel/input",
+    "starry-kernel/user-access-fastpath",
     "starry-kernel/vsock",
 ]
 


### PR DESCRIPTION
## 问题

AArch64 Starry QEMU 系统构建已经启用 `starry-kernel/user-access-fastpath`，但 `starry-kernel` 的 `aarch64-system` clippy 配置没有同步该 feature。结果是 CI 的系统组合 clippy 不会编译真实 QEMU 会走到的 lock-free user-copy 路径。

## 修改

在 `aarch64-system` clippy configuration 中加入 `starry-kernel/user-access-fastpath`，使其与共享 AArch64 QEMU build 配置保持一致。

## 方案逻辑

axbuild 已有契约测试逐项比较 Starry AArch64 clippy configuration 与 QEMU build feature 集。本修改只修正 metadata 的单一差异，不改变运行时默认 feature，也不影响独立 RGA 配置。

## 验证

红测（修复前稳定失败，输出缺少 `starry-kernel/user-access-fastpath`）：

- `cargo test -p axbuild starry_aarch64_clippy_configurations_match_qemu_builds`

绿测：

- `cargo test -p axbuild starry_aarch64_clippy_configurations_match_qemu_builds`
- `cargo xtask clippy --package starry-kernel`（98/98 checks passed）
- `cargo fmt --all`
- `git diff --check`

这是 clippy coverage metadata 修复，不改变 QEMU 运行时，因此未额外运行 Starry QEMU。