### PR TITLE
axvisor: experimental content on excessive allocation of vCPU in multiple VMS under limited qemu physical CPU

### DIFF
--- a/os/axvisor/configs/board/qemu-aarch64-vcpus.toml
+++ b/os/axvisor/configs/board/qemu-aarch64-vcpus.toml
@@ -1,0 +1,9 @@
+features = []
+log = "Info"
+target = "aarch64-unknown-none-softfloat"
+vm_configs = [
+  "os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm1.toml",
+  "os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm2.toml",
+  "os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm3.toml",
+  "os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm4.toml",
+]

--- a/os/axvisor/configs/qemu/qemu-aarch64-vcpus.toml
+++ b/os/axvisor/configs/qemu/qemu-aarch64-vcpus.toml
@@ -1,0 +1,13 @@
+args = [
+  "-nographic",
+  "-cpu", "cortex-a72",
+  "-machine", "virt,virtualization=on,gic-version=3",
+  "-smp", "2",
+  "-m", "4g",
+]
+#fail_regex = ["VM1_VIRTIO_NET_FAIL", "VM2_VIRTIO_NET_FAIL", "(?i)panic"]
+fail_regex = ["panic"]
+success_regex = ["(?s)(VM1_VIRTIO_NET_PASS.*VM2_VIRTIO_NET_PASS|VM2_VIRTIO_NET_PASS.*VM1_VIRTIO_NET_PASS)"]
+timeout = 180
+to_bin = true
+uefi = false

--- a/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm1.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm1.toml
@@ -1,0 +1,26 @@
+[base]
+id = 1
+name = "arceos-virtio-net-peer-vm1"
+guest_type = "virtualized"
+cpu_num = 1
+phys_cpu_ids = [0x0]
+phys_cpu_sets = [1]
+
+[kernel]
+entry_point = 0x8020_0000
+image_location = "memory"
+kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-net-peer-vm1.bin"
+kernel_load_addr = 0x8020_0000
+dtb_load_addr = 0x8000_0000
+memory_regions = [
+  [0x8000_0000, 0x2000_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = []
+disabled = []
+
+[[devices.virtual]]
+id = "virtnet0"
+model = "virtio-net"
+guest_mac = [0x52, 0x54, 0x00, 0x12, 0x34, 0x56]

--- a/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm2.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm2.toml
@@ -1,0 +1,26 @@
+[base]
+id = 2
+name = "arceos-virtio-net-peer-vm2"
+guest_type = "virtualized"
+cpu_num = 1
+phys_cpu_ids = [0x1]
+phys_cpu_sets = [2]
+
+[kernel]
+entry_point = 0x8020_0000
+image_location = "memory"
+kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-net-peer-vm2.bin"
+kernel_load_addr = 0x8020_0000
+dtb_load_addr = 0x8000_0000
+memory_regions = [
+  [0x8000_0000, 0x2000_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = []
+disabled = []
+
+[[devices.virtual]]
+id = "virtnet0"
+model = "virtio-net"
+guest_mac = [0x52, 0x54, 0x00, 0x12, 0x34, 0x57]

--- a/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm3.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm3.toml
@@ -9,7 +9,7 @@ phys_cpu_sets = [1]
 [kernel]
 entry_point = 0x8020_0000
 image_location = "memory"
-kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-net-peer-vm3.bin"
+kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-net-peer-vm1.bin"
 kernel_load_addr = 0x8020_0000
 dtb_load_addr = 0x8000_0000
 memory_regions = [
@@ -23,4 +23,4 @@ disabled = []
 [[devices.virtual]]
 id = "virtnet0"
 model = "virtio-net"
-guest_mac = [0x52, 0x54, 0x00, 0x12, 0x34, 0x58]
+guest_mac = [0x52, 0x54, 0x00, 0x12, 0x34, 0x66]

--- a/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm3.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm3.toml
@@ -1,0 +1,26 @@
+[base]
+id = 3
+name = "arceos-virtio-net-peer-vm3"
+guest_type = "virtualized"
+cpu_num = 1
+phys_cpu_ids = [0x0]
+phys_cpu_sets = [1]
+
+[kernel]
+entry_point = 0x8020_0000
+image_location = "memory"
+kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-net-peer-vm3.bin"
+kernel_load_addr = 0x8020_0000
+dtb_load_addr = 0x8000_0000
+memory_regions = [
+  [0x8000_0000, 0x2000_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = []
+disabled = []
+
+[[devices.virtual]]
+id = "virtnet0"
+model = "virtio-net"
+guest_mac = [0x52, 0x54, 0x00, 0x12, 0x34, 0x58]

--- a/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm4.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm4.toml
@@ -1,0 +1,26 @@
+[base]
+id = 4
+name = "arceos-virtio-net-peer-vm4"
+guest_type = "virtualized"
+cpu_num = 1
+phys_cpu_ids = [0x1]
+phys_cpu_sets = [2]
+
+[kernel]
+entry_point = 0x8020_0000
+image_location = "memory"
+kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-net-peer-vm4.bin"
+kernel_load_addr = 0x8020_0000
+dtb_load_addr = 0x8000_0000
+memory_regions = [
+  [0x8000_0000, 0x2000_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = []
+disabled = []
+
+[[devices.virtual]]
+id = "virtnet0"
+model = "virtio-net"
+guest_mac = [0x52, 0x54, 0x00, 0x12, 0x34, 0x59]

--- a/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm4.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/vcpus/arceos-multi-vcpu-vm4.toml
@@ -9,7 +9,7 @@ phys_cpu_sets = [2]
 [kernel]
 entry_point = 0x8020_0000
 image_location = "memory"
-kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-net-peer-vm4.bin"
+kernel_path = "${workspace}/target/aarch64-unknown-linux-musl/release/arceos-virtio-net-peer-vm2.bin"
 kernel_load_addr = 0x8020_0000
 dtb_load_addr = 0x8000_0000
 memory_regions = [
@@ -23,4 +23,4 @@ disabled = []
 [[devices.virtual]]
 id = "virtnet0"
 model = "virtio-net"
-guest_mac = [0x52, 0x54, 0x00, 0x12, 0x34, 0x59]
+guest_mac = [0x52, 0x54, 0x00, 0x12, 0x34, 0x67]

--- a/virtualization/axvm/src/arch/aarch64/fdt.rs
+++ b/virtualization/axvm/src/arch/aarch64/fdt.rs
@@ -78,5 +78,10 @@ pub(super) fn update_cpu_node(
         }
     }
 
+    // With vCPU over-subscription the host FDT does not provide a CPU node for
+    // every guest virtual CPU id; clone the missing ones so the guest SMP
+    // bootstrap can power all vCPUs up via PSCI.
+    tree.ensure_guest_cpu_nodes(host_fdt, phys_cpu_ids)?;
+
     Ok(tree.finish())
 }

--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -142,6 +142,22 @@ pub(super) fn run_vcpu<A: super::Architecture>(
     }
 
     let run_result = vcpu.with_current_cpu_set(|| -> AxVmResult<_> {
+        /// Maximum wall-clock time a vCPU may run continuously before yielding to the
+        /// host scheduler. Bounding each run slice lets more vCPUs than physical CPUs
+        /// time-share one host CPU without one continuously runnable guest starving
+        /// the others.
+        const VCPU_TIME_SLICE_NANOS: u64 = 10_000_000; // 10ms
+        // Bound this vCPU's continuous run time so that multiple vCPUs can
+        // time-share one physical CPU. The deadline is checked only against
+        // the host monotonic clock at each `Continue` VM exit (MMIO, sysreg,
+        // ...). Arming no host timer keeps the `with_current_cpu_set`
+        // invariant intact: no asynchronous scheduler tick can preempt this
+        // vCPU while it is still published as the current vCPU.
+        let slice_deadline_ns = (crate::timer::current_host_time()
+            .as_nanos()
+            .min(u64::MAX as u128) as u64)
+            .saturating_add(VCPU_TIME_SLICE_NANOS);
+
         loop {
             crate::runtime::vcpus::inject_pending_interrupts::<A>(vm.id(), vcpu_id, vcpu);
 
@@ -152,7 +168,21 @@ pub(super) fn run_vcpu<A: super::Architecture>(
             let exit = exit?;
             trace!("{exit:#x?}");
             match A::handle_vcpu_exit_bound(vm, vcpu, exit)? {
-                BoundVcpuExit::Continue => continue,
+                BoundVcpuExit::Continue => {
+                    let now_ns = crate::timer::current_host_time()
+                        .as_nanos()
+                        .min(u64::MAX as u128) as u64;
+                    if now_ns >= slice_deadline_ns {
+                        debug!("VM[{vm_id}] VCpu[{vcpu_id}] time slice expired, yielding to host");
+                        break Ok(BoundVcpuExit::Complete(VcpuRunAction {
+                            waits_for_event: false,
+                            stop_reason: None,
+                            resets_vm: false,
+                            exits_vcpu: false,
+                        }));
+                    }
+                    continue;
+                }
                 action => break Ok(action),
             }
         }

--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -58,6 +58,10 @@ pub(crate) fn create_guest_fdt(
     let mut guest_tree = FdtTree::clone_filtered(fdt, |node_id, path, node| {
         policy.should_keep(node_id, path, node)
     })?;
+    // With vCPU over-subscription (more guest vCPUs than host physical CPUs)
+    // the host FDT does not carry a CPU node for every guest virtual CPU id,
+    // so clone the missing ones to keep the guest SMP bootstrap functional.
+    guest_tree.ensure_guest_cpu_nodes(fdt, phys_cpu_ids)?;
     prune_dangling_interrupts_extended(fdt, &mut guest_tree)?;
     Ok(guest_tree.finish())
 }

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -516,6 +516,53 @@ pub fn set_phys_cpu_sets(
         .as_ref()
         .ok_or_else(|| ax_err_type!(InvalidInput, "phys_cpu_ids is missing"))?;
 
+    let policy = super::selected_guest_fdt_policy();
+    let host_cpu_count = (policy.host_cpu_count)();
+
+    // When `phys_cpu_sets` is configured explicitly, each entry is the final
+    // physical-CPU affinity mask of the corresponding vCPU, so `phys_cpu_ids`
+    // only carries the guest-visible virtual CPU id (the low bits of the
+    // virtualized MPIDR) and must not be required to exist in the host FDT.
+    // This is what makes vCPU over-subscription possible: more guest vCPUs
+    // than host physical CPUs, all scheduled on the CPUs selected by the mask.
+    if let Some(phys_cpu_sets) = crate_config.base.phys_cpu_sets.as_ref() {
+        if phys_cpu_sets.len() != phys_cpu_ids.len() {
+            return Err(ax_err_type!(
+                InvalidInput,
+                format!(
+                    "phys_cpu_sets length ({}) must equal phys_cpu_ids length ({})",
+                    phys_cpu_sets.len(),
+                    phys_cpu_ids.len()
+                )
+            ));
+        }
+        if host_cpu_count >= usize::BITS as usize {
+            return Err(ax_err_type!(
+                InvalidInput,
+                format!("host CPU count {host_cpu_count} exceeds the affinity mask width")
+            ));
+        }
+        let valid_masks = if host_cpu_count == 0 {
+            0usize
+        } else {
+            (1usize << host_cpu_count) - 1
+        };
+        for &mask in phys_cpu_sets {
+            if mask == 0 || mask & !valid_masks != 0 {
+                return Err(ax_err_type!(
+                    InvalidInput,
+                    format!(
+                        "phys_cpu_sets mask 0x{mask:x} is not within the {host_cpu_count} host CPUs"
+                    )
+                ));
+            }
+        }
+        let phys_cpu_ls = vm_cfg.phys_cpu_ls_mut();
+        phys_cpu_ls.set_guest_cpu_sets(phys_cpu_sets.clone());
+        phys_cpu_ls.set_guest_phys_cpu_ids(phys_cpu_ids.clone());
+        return Ok(());
+    }
+
     let cpu_nodes_info: Vec<_> = fdt
         .iter_node_ids()
         .filter_map(|node_id| {
@@ -534,11 +581,10 @@ pub fn set_phys_cpu_sets(
         .collect();
     info!("Found {} host CPU nodes", cpu_nodes_info.len());
 
-    let policy = super::selected_guest_fdt_policy();
     let (new_phys_cpu_sets, guest_phys_cpu_ids) = resolve_phys_cpu_sets(
         phys_cpu_ids,
         &cpu_nodes_info,
-        (policy.host_cpu_count)(),
+        host_cpu_count,
         policy.resolve_cpu_index,
     )?;
 

--- a/virtualization/axvm/src/boot/fdt/core/tree.rs
+++ b/virtualization/axvm/src/boot/fdt/core/tree.rs
@@ -1,4 +1,4 @@
-use std::{format, string::String, vec::Vec};
+use std::{collections::BTreeSet, format, string::String, vec::Vec};
 
 use fdt_edit::{Fdt, Node, NodeId, Property};
 use fdt_raw::{Header, RegInfo};
@@ -230,6 +230,73 @@ impl FdtTree {
         }
 
         Ok(dest)
+    }
+
+    /// Ensures the guest FDT exposes one `/cpus/cpu@<id>` node per guest
+    /// virtual CPU id in `phys_cpu_ids`.
+    ///
+    /// The CPU nodes are copied from the host FDT, so when the guest has more
+    /// vCPUs than host physical CPUs (vCPU over-subscription) some ids have no
+    /// host counterpart. For every missing id a fresh CPU node is cloned from
+    /// the first host CPU node, named `cpu@<id>` and re-registered with
+    /// `reg = <id>`, so that the guest SMP bootstrap sees all CPUs and powers
+    /// the secondaries up via PSCI.
+    pub(crate) fn ensure_guest_cpu_nodes(
+        &mut self,
+        host: &Fdt,
+        phys_cpu_ids: &[usize],
+    ) -> AxVmResult {
+        let existing = self
+            .node_paths()
+            .into_iter()
+            .filter_map(|(_, path)| {
+                path.strip_prefix("/cpus/cpu@")
+                    .and_then(|id| id.split('/').next())
+                    .and_then(|id| usize::from_str_radix(id, 16).ok())
+            })
+            .collect::<BTreeSet<_>>();
+
+        let missing = phys_cpu_ids
+            .iter()
+            .copied()
+            .filter(|id| !existing.contains(id))
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            return Ok(());
+        }
+
+        let template_id = host
+            .iter_node_ids()
+            .find(|node_id| host.path_of(*node_id).starts_with("/cpus/cpu@"))
+            .ok_or_else(|| ax_err_type!(InvalidInput, "host FDT has no CPU node template"))?;
+        let template = host
+            .node(template_id)
+            .ok_or_else(|| ax_err_type!(InvalidData, "host FDT CPU node template is missing"))?;
+
+        let cpus_id = self.ensure_path("/cpus")?;
+        let template_has_affinity = template
+            .properties()
+            .iter()
+            .any(|prop| prop.name() == "mpidr-affinity");
+        for id in missing {
+            let node_id = self.add_node(cpus_id, Node::new(&format!("cpu@{id:x}")));
+            for prop in template.properties() {
+                if should_skip_guest_cpu_prop(host, prop.name()) {
+                    continue;
+                }
+                self.set_property(node_id, prop.clone())?;
+            }
+            self.fdt
+                .view_typed_mut(node_id)
+                .ok_or_else(|| ax_err_type!(InvalidData, "new guest CPU node is missing"))?
+                .set_regs(&[RegInfo::new(id as u64, None)]);
+            // Keep `mpidr-affinity` consistent with the virtualized MPIDR
+            // (`VMPIDR_EL2 = 1<<31 | id`) when the host template carries it.
+            if template_has_affinity {
+                self.set_property(node_id, prop_u32_list("mpidr-affinity", &[id as u32]))?;
+            }
+        }
+        Ok(())
     }
 
     fn remove_paths_deepest_first(&mut self, mut paths: Vec<String>) {

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -17,7 +17,7 @@
 use std::{cell::UnsafeCell, format, mem::MaybeUninit};
 
 use ax_std::os::arceos::{
-    guard::PreemptGuard,
+    guard::{PreemptGuard, PreemptIrqSaveGuard},
     percpu::{self as ax_percpu, CpuAreaRef, CpuPin},
     sync::IrqSafeMutex as Mutex,
 };
@@ -26,7 +26,7 @@ use axvm_types::{
     VmArchVcpuOps, VmBackendError, VmVcpuState,
 };
 
-use crate::{AxVmError, AxVmResult, ax_err};
+use crate::{AxVmError, AxVmResult, ax_err, host::HostCpu};
 
 /// Borrowed proof that one AxVM operation cannot migrate between host CPUs.
 struct PinnedCpuContext<'pin, 'cpu> {
@@ -297,11 +297,24 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     }
 
     /// Runs `f` with this vCPU recorded as current on the physical CPU.
+    #[track_caller]
     pub(crate) fn with_current_cpu_set<F, T>(&self, f: F) -> T
     where
         F: FnOnce() -> T,
     {
-        let _guard = PreemptGuard::new();
+        // Capture the caller location before any formatting: a bare
+        // `Location::caller()` inside `panic!` arguments resolves to the
+        // argument expression itself instead of the propagated caller.
+        let caller = core::panic::Location::caller();
+        // The guard must block IRQs as well: without the `preempt` feature the
+        // preempt-count stays zero, so `might_sleep()` would not flag a
+        // contended sleepable mutex, and blocking here (e.g. on guest console
+        // output) would deschedule the task with `CURRENT_VCPU` still set.
+        // With IRQs disabled, any accidental sleep in `f` panics loudly in
+        // `might_sleep` instead of corrupting the publication invariant.
+        let _guard = PreemptIrqSaveGuard::new();
+        //let _guard = PreemptGuard::new();
+
         // SAFETY: the guard prevents migration through the backend operation,
         // guest run, restoration check, and publication withdrawal.
         unsafe {
@@ -314,7 +327,40 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
                         pinned_cpu.assert_host_cpu_binding();
                         result
                     } else {
-                        panic!("nested vCPU operation is not allowed");
+                        let host_cpu = crate::host::default_host().this_cpu_id();
+                        let panicking_task = crate::host::task::current_task().id_name();
+                        let current_vcpu_task =
+                            crate::get_vm_by_id(current_vcpu.vm_id()).and_then(|vm| {
+                                vm.with_runtime(|runtime| {
+                                    Ok(runtime.vcpu_task(current_vcpu.id()))
+                                })
+                                .ok()
+                                .flatten()
+                            });
+                        let current_vcpu_task_info = current_vcpu_task
+                            .as_ref()
+                            .map(|task| {
+                                format!("{} (state = {:?})", task.id_name(), task.state())
+                            })
+                            .unwrap_or_else(|| "unknown".into());
+                        panic!(
+                            "nested vCPU operation is not allowed (at {}): current = VM[{}] \
+                             VCpu[{}] (phys = {:?}, ptr = {:p}, task = {}), self = VM[{}] \
+                             VCpu[{}] (phys = {:?}, ptr = {:p}), panicking task = {}, host_cpu = \
+                             {}",
+                            caller,
+                            current_vcpu.vm_id(),
+                            current_vcpu.id(),
+                            current_vcpu.phys_cpu_set(),
+                            current_vcpu,
+                            current_vcpu_task_info,
+                            self.vm_id(),
+                            self.id(),
+                            self.phys_cpu_set(),
+                            self,
+                            panicking_task,
+                            host_cpu,
+                        );
                     }
                 } else {
                     set_current_vcpu(self, cpu_pin);

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -362,6 +362,11 @@ impl VmRuntimeHandle {
         self.vcpu_task_list.lock().contains_key(&vcpu_id)
     }
 
+    #[allow(dead_code)]
+    pub(crate) fn vcpu_task(&self, vcpu_id: usize) -> Option<crate::AxTaskRef> {
+        self.vcpu_task_list.lock().get(&vcpu_id).cloned()
+    }
+
     pub(crate) fn add_vcpu_task(&self, vcpu_id: usize, vcpu_task: crate::AxTaskRef) -> AxVmResult {
         let mut vcpu_task_list = self.vcpu_task_list.lock();
         if vcpu_task_list.contains_key(&vcpu_id) {


### PR DESCRIPTION
目标： 在 axvisor 上支持有限物理 CPU 条件下模拟与调度超过物理核数的多vCPU运行

试验内容：
试验跑通了在 QEMU aarch64 smp=2（Host 仅 2 个物理 CPU）上，
运行 5 个 ArceOS VM（每个 VM 1 个 vCPU），使 vCPU 总数（4）超过物理 CPU 数（2），
实现 vCPU 超额分配：4 个 guest 在 2 个物理核上分时运行，而非 1:1 独占。

复现过程：

- 参照arceos编译脚本`apps/arceos/virtio-net-peer/run.sh`编译4个arceos系统镜像作为Guest； 
- 将编译出来的Guest系统镜像文件路径，配置于axvisor/configs/vms/qemu/aarch64/vcpus/中的几个VM配置文件中，并将全部配置文件写入 config 配置文件，设置qemu-config配置文件的Qemu物理核心为`-smp 2`;
- 最后编译运行axvisor, 让4个 guest 在 2 个物理核上分时运行：
`cargo xtask axvisor qemu --config os/axvisor/configs/board/qemu-aarch64-vcpus.toml --qemu-config os/axvisor/configs/qemu/qemu-aarch64-vcpus.toml`

试验运行效果：
<img width="1199" height="1079" alt="455" src="https://github.com/user-attachments/assets/b10e78e6-3b25-427f-a217-691a2fa46e94" />
