### PR TITLE
fix(x86): preserve VMX MSRs and cancel dropped APIC timers

### DIFF
--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -14,7 +14,10 @@ use std::{
     time::Duration,
 };
 
-use ax_std::os::arceos::sync::{IrqSafeMutex, IrqSafeMutexGuard};
+use ax_std::os::arceos::{
+    guard::IrqSaveGuard,
+    sync::{IrqSafeMutex, IrqSafeMutexGuard},
+};
 use axdevice::*;
 use axdevice_base::*;
 use axvm_types::{VmBackendError as BackendError, VmBackendResult as BackendResult, *};
@@ -443,6 +446,7 @@ impl VmArchVcpuOps for AxvmX86Vcpu {
     }
 
     fn run(&mut self) -> BackendResult<Self::Exit> {
+        let _entry_irq_guard = IrqSaveGuard::new();
         x86_result(self.0.run())
     }
 

--- a/virtualization/x86_vcpu/src/runtime.rs
+++ b/virtualization/x86_vcpu/src/runtime.rs
@@ -188,6 +188,11 @@ impl<H: X86HostOps> X86Vcpu<H> {
 
     /// Enter the guest until the selected backend reports a VM exit.
     ///
+    /// The caller must keep this vCPU bound to the current host CPU, prevent
+    /// migration, and keep host IRQs disabled until this method returns. VMX
+    /// uses this interval to switch host-owned syscall MSRs without exposing
+    /// guest state to host interrupt handlers or another physical CPU.
+    ///
     /// # Errors
     ///
     /// Propagates guest-entry and VM-exit decoding errors from the selected backend.

--- a/virtualization/x86_vcpu/src/vmx/vcpu.rs
+++ b/virtualization/x86_vcpu/src/vmx/vcpu.rs
@@ -56,6 +56,82 @@ const X86_LOCAL_APIC_EOI_OFFSET: usize = 0xb0;
 const X86_IOAPIC_BASE: usize = 0xfec0_0000;
 const X86_IOAPIC_SIZE: usize = 0x1000;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct VmxSyscallMsrState {
+    star: u64,
+    lstar: u64,
+    cstar: u64,
+    fmask: u64,
+    kernel_gs_base: u64,
+}
+
+trait VmxSyscallMsrBank {
+    fn read(&self) -> VmxSyscallMsrState;
+
+    /// # Safety
+    ///
+    /// The caller must prevent interrupts and migration until the host state is restored.
+    unsafe fn write(&mut self, state: VmxSyscallMsrState);
+}
+
+struct HardwareVmxSyscallMsrBank;
+
+impl VmxSyscallMsrBank for HardwareVmxSyscallMsrBank {
+    fn read(&self) -> VmxSyscallMsrState {
+        VmxSyscallMsrState {
+            star: Msr::IA32_STAR.read(),
+            lstar: Msr::IA32_LSTAR.read(),
+            cstar: Msr::IA32_CSTAR.read(),
+            fmask: Msr::IA32_FMASK.read(),
+            kernel_gs_base: Msr::IA32_KERNEL_GSBASE.read(),
+        }
+    }
+
+    unsafe fn write(&mut self, state: VmxSyscallMsrState) {
+        unsafe {
+            Msr::IA32_STAR.write(state.star);
+            Msr::IA32_LSTAR.write(state.lstar);
+            Msr::IA32_CSTAR.write(state.cstar);
+            Msr::IA32_FMASK.write(state.fmask);
+            Msr::IA32_KERNEL_GSBASE.write(state.kernel_gs_base);
+        }
+    }
+}
+
+/// Loads vCPU-owned syscall MSRs and returns the displaced host state.
+///
+/// # Safety
+///
+/// Interrupts and migration must remain disabled until [`leave_guest_syscall_msrs`] restores the
+/// returned host state.
+unsafe fn enter_guest_syscall_msrs(
+    guest: VmxSyscallMsrState,
+    bank: &mut impl VmxSyscallMsrBank,
+) -> VmxSyscallMsrState {
+    let host = bank.read();
+    unsafe {
+        bank.write(guest);
+    }
+    host
+}
+
+/// Saves vCPU-owned syscall MSRs and restores the host state displaced on entry.
+///
+/// # Safety
+///
+/// `host` must be the snapshot returned by the matching [`enter_guest_syscall_msrs`] call, with
+/// interrupts and migration disabled continuously between both calls.
+unsafe fn leave_guest_syscall_msrs(
+    guest: &mut VmxSyscallMsrState,
+    host: VmxSyscallMsrState,
+    bank: &mut impl VmxSyscallMsrBank,
+) {
+    *guest = bank.read();
+    unsafe {
+        bank.write(host);
+    }
+}
+
 #[derive(PartialEq, Eq, Debug)]
 pub enum VmCpuMode {
     Real,
@@ -114,6 +190,8 @@ pub struct VmxVcpu<H: X86HostOps> {
     vlapic: EmulatedLocalApic<H>,
     /// Guest CR2 is not saved or restored by VMX hardware.
     guest_cr2: usize,
+    /// Guest syscall MSRs that are not saved or restored by VMX hardware.
+    guest_syscall_msrs: VmxSyscallMsrState,
     /// Guest RAM regions used to read guest instructions and page tables.
     guest_memory_regions: Vec<X86GuestMemoryRegion>,
 
@@ -146,6 +224,7 @@ impl<H: X86HostOps> VmxVcpu<H> {
             pending_events: VecDeque::with_capacity(8),
             vlapic: EmulatedLocalApic::<H>::new(vm_id, vcpu_id),
             guest_cr2: 0,
+            guest_syscall_msrs: VmxSyscallMsrState::default(),
             guest_memory_regions: Vec::new(),
             xstate: XState::new(),
             #[cfg(feature = "tracing")]
@@ -211,6 +290,12 @@ impl<H: X86HostOps> VmxVcpu<H> {
 
         // Run guest
         self.load_guest_xstate();
+        let mut syscall_msr_bank = HardwareVmxSyscallMsrBank;
+        // SAFETY: `X86Vcpu::run` requires its caller to pin the backend and disable host IRQs
+        // across the guest-entry window. This function restores the captured host state before
+        // returning to that caller.
+        let host_syscall_msrs =
+            unsafe { enter_guest_syscall_msrs(self.guest_syscall_msrs, &mut syscall_msr_bank) };
 
         #[cfg(feature = "tracing")]
         {
@@ -237,6 +322,15 @@ impl<H: X86HostOps> VmxVcpu<H> {
                 self.vmx_launch();
             }
             self.guest_cr2 = cr2();
+        }
+        // SAFETY: this is the matching exit half of the entry above, still inside the same pinned,
+        // IRQ-disabled backend run window.
+        unsafe {
+            leave_guest_syscall_msrs(
+                &mut self.guest_syscall_msrs,
+                host_syscall_msrs,
+                &mut syscall_msr_bank,
+            );
         }
         self.load_host_xstate();
         restore_host_interrupt_flag(self.host_rflags);
@@ -1899,6 +1993,10 @@ impl<H: X86HostOps> VmxVcpu<H> {
         Ok(())
     }
 
+    /// Runs this VMX vCPU until an exit is reported to the VMM.
+    ///
+    /// The caller must keep the vCPU bound to the current host CPU, prevent
+    /// migration, and keep host IRQs disabled until this method returns.
     pub fn run(&mut self) -> X86VcpuResult<X86VmExit> {
         match self.inner_run()? {
             Some(exit_info) => Ok(if exit_info.entry_failure {
@@ -2077,5 +2175,75 @@ impl<H: X86HostOps> VmxVcpu<H> {
 
     pub fn set_return_value(&mut self, val: usize) {
         self.regs_mut().rax = val as u64;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct FakeSyscallMsrBank {
+        current: VmxSyscallMsrState,
+    }
+
+    impl VmxSyscallMsrBank for FakeSyscallMsrBank {
+        fn read(&self) -> VmxSyscallMsrState {
+            self.current
+        }
+
+        unsafe fn write(&mut self, state: VmxSyscallMsrState) {
+            self.current = state;
+        }
+    }
+
+    #[test]
+    fn syscall_msrs_follow_the_vcpu_across_host_cpu_migration() {
+        let host_cpu_1 = VmxSyscallMsrState {
+            star: 0x11,
+            lstar: 0x12,
+            cstar: 0x13,
+            fmask: 0x14,
+            kernel_gs_base: 0x15,
+        };
+        let host_cpu_2 = VmxSyscallMsrState {
+            star: 0x21,
+            lstar: 0x22,
+            cstar: 0x23,
+            fmask: 0x24,
+            kernel_gs_base: 0x25,
+        };
+        let mut guest = VmxSyscallMsrState {
+            star: 0x31,
+            lstar: 0x32,
+            cstar: 0x33,
+            fmask: 0x34,
+            kernel_gs_base: 0x35,
+        };
+        let guest_after_cpu_1 = VmxSyscallMsrState {
+            star: 0x41,
+            lstar: 0x42,
+            cstar: 0x43,
+            fmask: 0x44,
+            kernel_gs_base: 0x45,
+        };
+
+        let mut cpu_1 = FakeSyscallMsrBank {
+            current: host_cpu_1,
+        };
+        let saved_host_cpu_1 = unsafe { enter_guest_syscall_msrs(guest, &mut cpu_1) };
+        assert_eq!(cpu_1.current, guest);
+        cpu_1.current = guest_after_cpu_1;
+        unsafe { leave_guest_syscall_msrs(&mut guest, saved_host_cpu_1, &mut cpu_1) };
+        assert_eq!(guest, guest_after_cpu_1);
+        assert_eq!(cpu_1.current, host_cpu_1);
+
+        let mut cpu_2 = FakeSyscallMsrBank {
+            current: host_cpu_2,
+        };
+        let saved_host_cpu_2 = unsafe { enter_guest_syscall_msrs(guest, &mut cpu_2) };
+        assert_eq!(cpu_2.current, guest_after_cpu_1);
+        unsafe { leave_guest_syscall_msrs(&mut guest, saved_host_cpu_2, &mut cpu_2) };
+        assert_eq!(cpu_2.current, host_cpu_2);
     }
 }

--- a/virtualization/x86_vlapic/src/timer.rs
+++ b/virtualization/x86_vlapic/src/timer.rs
@@ -273,6 +273,16 @@ impl<H: X86VlapicHostOps> ApicTimer<H> {
     }
 
     pub fn stop_timer(&mut self) -> X86VlapicResult {
+        self.retire_timer();
+        Ok(())
+    }
+
+    /// Whether the timer mode is periodic.
+    pub fn is_periodic(&self) -> bool {
+        self.timer_mode() == TimerMode::Periodic
+    }
+
+    fn retire_timer(&mut self) {
         // TODO: maybe disable irq here?
         self.next_generation();
         self.last_start_ticks = 0;
@@ -283,23 +293,10 @@ impl<H: X86VlapicHostOps> ApicTimer<H> {
         if let Some(token) = self.cancel_token.take() {
             host::cancel_timer::<H>(token);
         }
-
-        Ok(())
-    }
-
-    /// Whether the timer mode is periodic.
-    pub fn is_periodic(&self) -> bool {
-        self.timer_mode() == TimerMode::Periodic
     }
 
     fn next_generation(&self) -> usize {
         self.shared.generation.fetch_add(1, Ordering::AcqRel) + 1
-    }
-
-    fn invalidate_timer(&self) {
-        self.next_generation();
-        self.shared.interval_ns.store(0, Ordering::Release);
-        self.shared.deadline_ns.store(0, Ordering::Release);
     }
 
     // /// Set LVT Timer Register.
@@ -346,7 +343,7 @@ impl<H: X86VlapicHostOps> ApicTimer<H> {
 
 impl<H: X86VlapicHostOps> Drop for ApicTimer<H> {
     fn drop(&mut self) {
-        self.invalidate_timer();
+        self.retire_timer();
     }
 }
 
@@ -415,11 +412,17 @@ fn next_periodic_deadline_ns(deadline_ns: u64, interval_ns: u64, now_ns: u64) ->
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
     use crate::{
         X86HostPhysAddr, X86HostVirtAddr, X86InterruptVector, X86TimerCallback, X86VcpuId,
-        X86VlapicHostOps, X86VlapicResult, X86VmId,
+        X86VlapicHostOps, X86VlapicResult, X86VmId, lock::SpinMutex,
         regs::lvt::LVT_TIMER::TimerMode::Value as TimerMode, timer::ApicTimer,
     };
+
+    static NEXT_TIMER_TOKEN: AtomicUsize = AtomicUsize::new(1);
+    static ACTIVE_TIMERS: SpinMutex<Vec<(usize, X86TimerCallback)>> = SpinMutex::new(Vec::new());
 
     struct DummyHost;
 
@@ -442,11 +445,21 @@ mod tests {
             0
         }
 
-        fn register_timer(_deadline_nanos: u64, _callback: X86TimerCallback) -> Option<usize> {
-            None
+        fn register_timer(_deadline_nanos: u64, callback: X86TimerCallback) -> Option<usize> {
+            let token = NEXT_TIMER_TOKEN.fetch_add(1, Ordering::Relaxed);
+            ACTIVE_TIMERS.lock().push((token, callback));
+            Some(token)
         }
 
-        fn cancel_timer(_token: usize) {}
+        fn cancel_timer(token: usize) {
+            let mut timers = ACTIVE_TIMERS.lock();
+            if let Some(index) = timers
+                .iter()
+                .position(|(active_token, _)| *active_token == token)
+            {
+                let _ = timers.swap_remove(index);
+            }
+        }
 
         fn current_vm_id() -> X86VmId {
             0
@@ -573,5 +586,19 @@ mod tests {
         assert!(!timer2.is_started());
         assert_eq!(timer1.read_icr(), timer2.read_icr());
         assert_eq!(timer1.read_dcr(), timer2.read_dcr());
+    }
+
+    #[test]
+    fn dropping_started_timer_cancels_host_registration() {
+        NEXT_TIMER_TOKEN.store(1, Ordering::Relaxed);
+        ACTIVE_TIMERS.lock().clear();
+
+        let mut timer = ApicTimer::<DummyHost>::new(1, 0);
+        timer.write_icr(1).unwrap();
+        assert_eq!(ACTIVE_TIMERS.lock().len(), 1);
+
+        drop(timer);
+
+        assert!(ACTIVE_TIMERS.lock().is_empty());
     }
 }


### PR DESCRIPTION
## 问题

PR #1775 同时包含 ax-task 所有权模型迁移和若干独立的 x86 修复，不能整体移入当前 `dev`。其中有两项问题不依赖该调度器重构，可以独立修复：

- 已启动的 x86 vLAPIC timer 在对象销毁时只使 generation 失效，没有取消仍由对象持有的宿主 timer 注册，导致注册继续滞留到 deadline。
- VMX 硬件不会自动替软件保存 `STAR/LSTAR/CSTAR/FMASK/KERNEL_GS_BASE`。vCPU 跨 pCPU 迁移后，这些 syscall MSR 会混入不同 pCPU 的宿主状态，同时 guest 写入也不会跟随 vCPU。

本 PR 基于最新 `dev` 重建最小修复，没有 cherry-pick #1775 的大提交。

## 修改与实现逻辑

### x86_vlapic

- 为测试 fake host 记录活跃 timer token，并增加 Drop 后宿主注册必须被取消的确定性回归。
- `stop_timer` 与 `Drop` 共用私有 `retire_timer`：先推进 generation，使旧 callback 失效；再清空本地和共享 deadline/interval；最后取走对象当前持有的 token 并调用宿主取消。
- 不修改公共接口，也不把 token 提升为新的公共 typed handle。

### x86_vcpu / axvm

- VMX vCPU 私有保存 `STAR/LSTAR/CSTAR/FMASK/KERNEL_GS_BASE`。
- VM-entry 前读取并保存当前 pCPU 的宿主值，再装载 vCPU 的 guest 值；VM-exit 后先保存 guest 最新值，再恢复该次 entry 对应的宿主值。
- 使用私有 fake MSR bank 模拟同一个 vCPU 先后运行在两个宿主 MSR 不同的 pCPU 上，验证 guest 状态随 vCPU 迁移，且两个 pCPU 的宿主状态分别恢复。
- 在当前调用方 `AxvmX86Vcpu::run` 的既有 preemption pinning 范围内增加 `IrqSaveGuard`，覆盖 guest-entry 窗口；同时补强 `X86Vcpu::run`/VMX `run` 的调用契约。这样宿主中断处理程序不会在 guest syscall MSR 已装载时运行。

Linux VMX 同样把这类不由 VMCS 自动切换的 syscall MSR 作为 vCPU/宿主切换状态处理；参考 [Linux commit 8cd9520d35a6](https://github.com/torvalds/linux/commit/8cd9520d35a6c38db6567e97dd93b1f11f185dc6) 及 `arch/x86/kvm/vmx/vmx.c` 的 user-return MSR 处理。

## Red / Green 证据

- `cargo test -p x86_vlapic --lib timer::tests::dropping_started_timer_cancels_host_registration -- --exact --nocapture`
  - Red：退出码 101，Drop 后 `ACTIVE_TIMERS` 非空的断言失败。
  - Green：同一测试 1 passed。
- `cargo test -p x86_vcpu --lib vmx::vcpu::tests::syscall_msrs_follow_the_vcpu_across_host_cpu_migration -- --exact --nocapture`
  - Red：退出码 101，第二个 pCPU 上观察到宿主 MSR，而不是前一次 VM-exit 保存的 guest MSR。
  - Green：同一测试 1 passed。

Red 阶段失败状态未提交；PR 保留两个独立、可构建提交。

## 验证

### 本地

- `cargo test -p x86_vlapic --lib`：12 passed
- `cargo test -p x86_vcpu --lib`：84 passed
- `cargo xtask clippy --package x86_vlapic`：通过
- `cargo xtask clippy --package x86_vcpu`：base/tracing 共 2 项通过
- `cargo xtask clippy --package axvm`：base/fs/host-fs/sstc/tls/host-test 共 6 项通过
- `cargo fmt --all --check`：通过
- `git diff --check`：通过
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case smoke-vmx`：通过
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case mp-fallback-vmx`：通过
- `cargo xtask axvisor test qemu --arch x86_64 --test-group normal --test-case smoke-svm`：测试框架通过；本机为 Intel VT-x，QEMU 明确警告不支持 SVM/NPT/NRIP，运行时实际启用了 VMX，因此这不是原生 SVM 硬件覆盖。

### 远端当前 head

当前 head `ebbdc4fd84b8728c1749bac2df9e8bd40cbe2fcb` 的 [CI run 32443933396](https://github.com/rcore-os/tgoskits/actions/runs/32443933396) 已终态成功，35/35 jobs success、无失败项，其中：

- `AxVisor / VMX x86_64 · Smoke`：成功
- `AxVisor / VMX x86_64 · Direct + MP fallback + OVMF ACPI`：成功
- `AxVisor / SVM x86_64 · Smoke + direct/OVMF ACPI`：成功

## 明确非目标

- 不引入 `TimerRegistration`、typed timer handle、完整 x86 timer API 重构或 200µs clamp。
- 不重构既有 periodic rearm 的 token 所有权；Drop 会使 generation 失效，已注册的旧 generation callback 只会 no-op，但本 PR 不增加 callback quiescence/等待状态机。
- 不抽取 `has_pending_event`，不修改 ax-task/ax-runtime 所有权模型。
- 不修改公共函数或 trait 签名。
