### PR TITLE
fix(axbuild): narrow clippy for workspace dependency changes

### DIFF
--- a/scripts/axbuild/src/clippy/tests/expand.rs
+++ b/scripts/axbuild/src/clippy/tests/expand.rs
@@ -172,6 +172,36 @@ fn incremental_selection_checks_changed_packages_and_affected_os_roots_only() {
 }
 
 #[test]
+fn incremental_selection_for_x86_apic_change_omits_unrelated_workspace_packages() {
+    let selected = incremental_clippy_selections(
+        vec![
+            "someboot".into(),
+            "somehal".into(),
+            "x86-apic-driver".into(),
+        ],
+        vec![
+            "ax-std".into(),
+            "someboot".into(),
+            "somehal".into(),
+            "starryos".into(),
+            "unrelated".into(),
+            "x86-apic-driver".into(),
+        ],
+    );
+
+    assert_eq!(
+        selected,
+        vec![
+            "someboot".to_string(),
+            "somehal".into(),
+            "x86-apic-driver".into(),
+            "ax-std".into(),
+            "starryos".into(),
+        ]
+    );
+}
+
+#[test]
 fn incremental_selection_adds_only_affected_os_root() {
     let selected = incremental_clippy_selections(
         vec!["alpha".into()],

--- a/scripts/axbuild/src/support/git/manifest.rs
+++ b/scripts/axbuild/src/support/git/manifest.rs
@@ -26,7 +26,8 @@ pub(super) enum RootManifestChange {
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(super) struct LocalRootManifestChange {
-    pub(super) dependencies: BTreeSet<String>,
+    pub(super) dependency_keys: BTreeSet<String>,
+    pub(super) local_packages: BTreeSet<String>,
     pub(super) members: BTreeSet<PathBuf>,
 }
 
@@ -92,7 +93,8 @@ pub(super) fn classify_root_manifest_change(
 
     let old_dependencies = workspace_dependencies(&old);
     let new_dependencies = workspace_dependencies(&new);
-    let mut changed = BTreeSet::new();
+    let mut changed_keys = BTreeSet::new();
+    let mut changed_local_packages = BTreeSet::new();
     for dependency_key in old_dependencies
         .keys()
         .chain(new_dependencies.keys())
@@ -103,22 +105,21 @@ pub(super) fn classify_root_manifest_change(
         if old_dependency == new_dependency {
             continue;
         }
+        changed_keys.insert(dependency_key.to_string());
         let old_package = old_dependency.and_then(|dependency| {
             local_workspace_dependency_package_name(dependency_key, dependency)
         });
         let new_package = new_dependency.and_then(|dependency| {
             local_workspace_dependency_package_name(dependency_key, dependency)
         });
-        if old_package.is_none() && new_package.is_none() {
-            return Ok(RootManifestChange::Hard);
-        }
-        changed.extend(old_package);
-        changed.extend(new_package);
+        changed_local_packages.extend(old_package);
+        changed_local_packages.extend(new_package);
     }
 
     Ok(RootManifestChange::LocalWorkspace(
         LocalRootManifestChange {
-            dependencies: changed,
+            dependency_keys: changed_keys,
+            local_packages: changed_local_packages,
             members: changed_members,
         },
     ))

--- a/scripts/axbuild/src/support/git/selection.rs
+++ b/scripts/axbuild/src/support/git/selection.rs
@@ -1,10 +1,12 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fs,
     path::{Path, PathBuf},
 };
 
 use anyhow::{Context, bail};
 use cargo_metadata::{Metadata, Package, PackageId};
+use toml::Value;
 
 use super::manifest::{ROOT_MANIFEST, RootManifestChange};
 
@@ -101,6 +103,7 @@ struct PackagePathIndex {
 
 struct PackagePathEntry {
     name: String,
+    manifest_path: PathBuf,
     rel_dir: PathBuf,
 }
 
@@ -139,6 +142,7 @@ impl PackagePathIndex {
                     })?;
                 Ok(PackagePathEntry {
                     name: package.name.to_string(),
+                    manifest_path: manifest,
                     rel_dir: rel_dir.to_path_buf(),
                 })
             })
@@ -183,7 +187,9 @@ impl PackagePathIndex {
                 {
                     RootManifestChange::Hard => return Ok(ChangedPackages::Full { path }),
                     RootManifestChange::LocalWorkspace(change) => {
-                        packages.extend(change.dependencies);
+                        packages.extend(change.local_packages);
+                        packages
+                            .extend(self.workspace_dependency_consumers(&change.dependency_keys)?);
                         packages.extend(
                             change
                                 .members
@@ -219,6 +225,85 @@ impl PackagePathIndex {
             .find(|package| path == package.rel_dir || path.starts_with(&package.rel_dir))
             .map(|package| package.name.as_str())
     }
+
+    fn workspace_dependency_consumers(
+        &self,
+        dependency_keys: &BTreeSet<String>,
+    ) -> anyhow::Result<BTreeSet<String>> {
+        if dependency_keys.is_empty() {
+            return Ok(BTreeSet::new());
+        }
+
+        let mut consumers = BTreeSet::new();
+        for package in &self.packages {
+            let source = fs::read_to_string(&package.manifest_path).with_context(|| {
+                format!(
+                    "failed to read workspace package `{}` manifest {}",
+                    package.name,
+                    package.manifest_path.display()
+                )
+            })?;
+            let manifest: Value = toml::from_str(&source).with_context(|| {
+                format!(
+                    "failed to parse workspace package `{}` manifest {}",
+                    package.name,
+                    package.manifest_path.display()
+                )
+            })?;
+            if manifest_inherits_workspace_dependency(&manifest, dependency_keys) {
+                consumers.insert(package.name.clone());
+            }
+        }
+        Ok(consumers)
+    }
+}
+
+const DEPENDENCY_TABLES: &[&str] = &["dependencies", "dev-dependencies", "build-dependencies"];
+
+fn manifest_inherits_workspace_dependency(
+    manifest: &Value,
+    dependency_keys: &BTreeSet<String>,
+) -> bool {
+    if DEPENDENCY_TABLES
+        .iter()
+        .any(|table| dependency_table_inherits(manifest.get(*table), dependency_keys))
+    {
+        return true;
+    }
+
+    manifest
+        .get("target")
+        .and_then(Value::as_table)
+        .is_some_and(|targets| {
+            targets.values().any(|target| {
+                DEPENDENCY_TABLES
+                    .iter()
+                    .any(|table| dependency_table_inherits(target.get(*table), dependency_keys))
+            })
+        })
+}
+
+fn dependency_table_inherits(
+    dependencies: Option<&Value>,
+    dependency_keys: &BTreeSet<String>,
+) -> bool {
+    dependencies
+        .and_then(Value::as_table)
+        .is_some_and(|dependencies| {
+            dependency_keys.iter().any(|dependency_key| {
+                dependencies
+                    .get(dependency_key)
+                    .is_some_and(dependency_inherits_from_workspace)
+            })
+        })
+}
+
+fn dependency_inherits_from_workspace(dependency: &Value) -> bool {
+    dependency
+        .as_table()
+        .and_then(|dependency| dependency.get("workspace"))
+        .and_then(Value::as_bool)
+        == Some(true)
 }
 
 fn global_clippy_input(path: &Path) -> Option<GlobalClippyInput> {

--- a/scripts/axbuild/src/support/git/tests/manifest.rs
+++ b/scripts/axbuild/src/support/git/tests/manifest.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use super::common::test_workspace;
 use crate::support::git::{
@@ -7,14 +7,34 @@ use crate::support::git::{
     selection::select_incremental_packages_for_paths_with_root_manifest_change,
 };
 
-fn local_root_change(dependencies: &[&str], members: &[&str]) -> RootManifestChange {
+fn local_root_change(local_packages: &[&str], members: &[&str]) -> RootManifestChange {
+    workspace_dependency_change(&[], local_packages, members)
+}
+
+fn workspace_dependency_change(
+    dependency_keys: &[&str],
+    local_packages: &[&str],
+    members: &[&str],
+) -> RootManifestChange {
     RootManifestChange::LocalWorkspace(LocalRootManifestChange {
-        dependencies: dependencies
+        dependency_keys: dependency_keys
             .iter()
             .map(|dependency| (*dependency).to_string())
             .collect(),
+        local_packages: local_packages
+            .iter()
+            .map(|package| (*package).to_string())
+            .collect(),
         members: members.iter().map(PathBuf::from).collect(),
     })
+}
+
+fn write_package_manifest(root: &Path, package: &str, manifest: &str) {
+    std::fs::write(
+        root.join("crates").join(package).join("Cargo.toml"),
+        manifest,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -190,7 +210,10 @@ fn root_manifest_classifier_uses_package_name_for_local_dependency_alias() {
 
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
 
-    assert_eq!(change, local_root_change(&["alpha"], &[]));
+    assert_eq!(
+        change,
+        workspace_dependency_change(&["alpha_alias"], &["alpha"], &[])
+    );
 }
 
 #[test]
@@ -212,7 +235,10 @@ fn root_manifest_classifier_tracks_local_dependency_alias_package_change() {
 
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
 
-    assert_eq!(change, local_root_change(&["alpha", "beta"], &[]));
+    assert_eq!(
+        change,
+        workspace_dependency_change(&["local_alias"], &["alpha", "beta"], &[])
+    );
 }
 
 #[test]
@@ -235,11 +261,14 @@ fn root_manifest_classifier_accepts_local_workspace_dependency_removal() {
 
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
 
-    assert_eq!(change, local_root_change(&["beta"], &[]));
+    assert_eq!(
+        change,
+        workspace_dependency_change(&["beta"], &["beta"], &[])
+    );
 }
 
 #[test]
-fn root_manifest_classifier_keeps_external_dependency_changes_hard() {
+fn root_manifest_classifier_tracks_external_dependency_changes() {
     let old_manifest = r#"
             [workspace]
             members = ["crates/alpha"]
@@ -257,7 +286,270 @@ fn root_manifest_classifier_keeps_external_dependency_changes_hard() {
 
     let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
 
-    assert_eq!(change, RootManifestChange::Hard);
+    assert_eq!(change, workspace_dependency_change(&["anyhow"], &[], &[]));
+}
+
+#[test]
+fn root_manifest_external_dependency_version_change_selects_only_inheriting_packages() {
+    let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            shared = "1.0"
+        "#;
+    let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            shared = "2.0"
+        "#;
+    let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+    let (root, metadata, workspace_packages) = test_workspace();
+    write_package_manifest(root.path(), "alpha", "[dependencies]\nshared = \"1.0\"\n");
+    write_package_manifest(
+        root.path(),
+        "beta",
+        "[dependencies]\nshared.workspace = true\n",
+    );
+    write_package_manifest(root.path(), "gamma", "");
+
+    let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+        root.path(),
+        &metadata,
+        &workspace_packages,
+        [PathBuf::from("Cargo.toml"), PathBuf::from("Cargo.lock")],
+        Some(change),
+    )
+    .unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: vec!["beta".into()],
+            affected: vec!["beta".into(), "gamma".into()],
+        }
+    );
+}
+
+#[test]
+fn root_manifest_new_external_dependency_selects_target_consumer() {
+    let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+        "#;
+    let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            x2apic = "0.5"
+        "#;
+    let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+    let (root, metadata, workspace_packages) = test_workspace();
+    write_package_manifest(root.path(), "alpha", "[dependencies]\nx2apic = \"0.5\"\n");
+    write_package_manifest(
+        root.path(),
+        "beta",
+        "[target.'cfg(target_arch = \"x86_64\")'.dependencies]\nx2apic = { workspace = true }\n",
+    );
+    write_package_manifest(root.path(), "gamma", "");
+
+    let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+        root.path(),
+        &metadata,
+        &workspace_packages,
+        [PathBuf::from("Cargo.toml"), PathBuf::from("Cargo.lock")],
+        Some(change),
+    )
+    .unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: vec!["beta".into()],
+            affected: vec!["beta".into(), "gamma".into()],
+        }
+    );
+}
+
+#[test]
+fn workspace_dependency_consumers_include_dev_and_build_dependencies() {
+    let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            shared = "1.0"
+        "#;
+    let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            shared = { version = "1.1", default-features = false, features = ["alloc"] }
+        "#;
+    let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+    let (root, metadata, workspace_packages) = test_workspace();
+    write_package_manifest(
+        root.path(),
+        "alpha",
+        "[dev-dependencies]\nshared.workspace = true\n",
+    );
+    write_package_manifest(
+        root.path(),
+        "beta",
+        "[build-dependencies]\nshared = { workspace = true }\n",
+    );
+    write_package_manifest(root.path(), "gamma", "");
+
+    let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+        root.path(),
+        &metadata,
+        &workspace_packages,
+        [PathBuf::from("Cargo.toml")],
+        Some(change),
+    )
+    .unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: vec!["alpha".into(), "beta".into()],
+            affected: vec!["alpha".into(), "beta".into(), "gamma".into()],
+        }
+    );
+}
+
+#[test]
+fn workspace_dependency_alias_selects_inheriting_key_consumer() {
+    let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            serde_alias = { package = "serde", version = "1.0" }
+        "#;
+    let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            serde_alias = { package = "serde", version = "2.0" }
+        "#;
+    let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+    assert_eq!(
+        change,
+        workspace_dependency_change(&["serde_alias"], &[], &[])
+    );
+
+    let (root, metadata, workspace_packages) = test_workspace();
+    write_package_manifest(root.path(), "alpha", "[dependencies]\nserde = \"1.0\"\n");
+    write_package_manifest(
+        root.path(),
+        "beta",
+        "[dependencies]\nserde_alias.workspace = true\n",
+    );
+    write_package_manifest(root.path(), "gamma", "");
+
+    let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+        root.path(),
+        &metadata,
+        &workspace_packages,
+        [PathBuf::from("Cargo.toml")],
+        Some(change),
+    )
+    .unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: vec!["beta".into()],
+            affected: vec!["beta".into(), "gamma".into()],
+        }
+    );
+}
+
+#[test]
+fn unused_workspace_dependency_change_selects_no_packages() {
+    let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+        "#;
+    let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            unused = "1.0"
+        "#;
+    let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+    let (root, metadata, workspace_packages) = test_workspace();
+    for package in ["alpha", "beta", "gamma"] {
+        write_package_manifest(root.path(), package, "");
+    }
+
+    let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+        root.path(),
+        &metadata,
+        &workspace_packages,
+        [PathBuf::from("Cargo.toml")],
+        Some(change),
+    )
+    .unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: Vec::new(),
+            affected: Vec::new(),
+        }
+    );
+}
+
+#[test]
+fn local_workspace_dependency_change_selects_target_and_consumer() {
+    let old_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            alpha = { version = "0.1", path = "crates/alpha" }
+        "#;
+    let new_manifest = r#"
+            [workspace]
+            members = ["crates/alpha", "crates/beta", "crates/gamma"]
+
+            [workspace.dependencies]
+            alpha = { version = "0.2", path = "crates/alpha" }
+        "#;
+    let change = classify_root_manifest_change(old_manifest, new_manifest).unwrap();
+    let (root, metadata, workspace_packages) = test_workspace();
+    write_package_manifest(root.path(), "alpha", "");
+    write_package_manifest(
+        root.path(),
+        "beta",
+        "[dependencies]\nalpha.workspace = true\n",
+    );
+    write_package_manifest(root.path(), "gamma", "");
+
+    let selected = select_incremental_packages_for_paths_with_root_manifest_change(
+        root.path(),
+        &metadata,
+        &workspace_packages,
+        [PathBuf::from("Cargo.toml")],
+        Some(change),
+    )
+    .unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: vec!["alpha".into(), "beta".into()],
+            affected: vec!["alpha".into(), "beta".into(), "gamma".into()],
+        }
+    );
 }
 
 #[test]

--- a/scripts/axbuild/src/support/git/tests/refs.rs
+++ b/scripts/axbuild/src/support/git/tests/refs.rs
@@ -234,6 +234,13 @@ fn unresolved_short_sha_does_not_use_push_before_sha_fallback() {
 #[test]
 fn zero_since_root_manifest_change_uses_inferred_base() {
     let (root, metadata, workspace_packages) = test_workspace();
+    for package in ["alpha", "beta", "gamma"] {
+        std::fs::write(
+            root.path().join("crates").join(package).join("Cargo.toml"),
+            "",
+        )
+        .unwrap();
+    }
     run_git(root.path(), &["init"]);
     run_git(root.path(), &["config", "user.email", "test.com"]);
     run_git(root.path(), &["config", "user.name", "Test User"]);
@@ -279,6 +286,55 @@ fn zero_since_root_manifest_change_uses_inferred_base() {
         IncrementalPackageSelection::Packages {
             changed: vec!["alpha".into()],
             affected: vec!["alpha".into(), "beta".into(), "gamma".into()],
+        }
+    );
+}
+
+#[test]
+fn workspace_dependency_version_change_uses_real_git_diff() {
+    let (root, metadata, workspace_packages) = test_workspace();
+    std::fs::write(
+        root.path().join("crates/alpha/Cargo.toml"),
+        "[dependencies]\nshared = \"1\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.path().join("crates/beta/Cargo.toml"),
+        "[dependencies]\nshared.workspace = true\n",
+    )
+    .unwrap();
+    std::fs::write(root.path().join("crates/gamma/Cargo.toml"), "").unwrap();
+
+    run_git(root.path(), &["init"]);
+    run_git(root.path(), &["config", "user.email", "test@example.com"]);
+    run_git(root.path(), &["config", "user.name", "Test User"]);
+    std::fs::write(
+        root.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/alpha\", \"crates/beta\", \
+         \"crates/gamma\"]\n\n[workspace.dependencies]\nshared = \"1\"\n",
+    )
+    .unwrap();
+    run_git(root.path(), &["add", "."]);
+    run_git(root.path(), &["commit", "-m", "base"]);
+    let base = git_stdout(root.path(), &["rev-parse", "HEAD"]);
+
+    run_git(root.path(), &["checkout", "-b", "feature"]);
+    std::fs::write(
+        root.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/alpha\", \"crates/beta\", \
+         \"crates/gamma\"]\n\n[workspace.dependencies]\nshared = \"2\"\n",
+    )
+    .unwrap();
+    run_git(root.path(), &["commit", "-am", "update shared dependency"]);
+
+    let selected =
+        select_incremental_packages(root.path(), &metadata, &workspace_packages, &base).unwrap();
+
+    assert_eq!(
+        selected,
+        IncrementalPackageSelection::Packages {
+            changed: vec!["beta".into()],
+            affected: vec!["beta".into(), "gamma".into()],
         }
     );
 }

--- a/scripts/axbuild/src/support/git/tests/selection.rs
+++ b/scripts/axbuild/src/support/git/tests/selection.rs
@@ -153,8 +153,8 @@ fn lockfile_change_keeps_incremental_selection_when_packages_changed() {
 
 #[test]
 fn root_cargo_toml_only_falls_back_to_full() {
-    // Root Cargo.toml is Hard: a manifest-only change with no code changes
-    // (e.g. a [workspace.dependencies] bump) must still fall back to Full.
+    // Without the semantic old/new root-manifest classification, the path-only
+    // selector must conservatively treat Cargo.toml as a hard global input.
     let (root, metadata, workspace_packages) = test_workspace();
     let selected = select_incremental_packages_for_paths(
         root.path(),
@@ -172,11 +172,9 @@ fn root_cargo_toml_only_falls_back_to_full() {
 
 #[test]
 fn root_cargo_toml_with_package_change_still_falls_back_to_full() {
-    // Root Cargo.toml is Hard: even when package source files are also in the
-    // diff (e.g. a new crate was added *and* a workspace dependency was
-    // bumped), the global manifest change requires a full run.  We cannot
-    // distinguish "only added a member" from "bumped a workspace dep" without
-    // parsing diff hunks, so Hard must always win.
+    // The production --since path supplies a semantic old/new root-manifest
+    // classification. Without it, a package path cannot make an otherwise
+    // unknown Cargo.toml change safe for incremental selection.
     let (root, metadata, workspace_packages) = test_workspace();
     let selected = select_incremental_packages_for_paths(
         root.path(),


### PR DESCRIPTION
## 问题

PR #2118 在根 Cargo.toml 新增外部 workspace dependency x2apic。现有增量 Clippy 分类器将所有外部 workspace dependency 的新增或版本修改视为全局硬变更，导致 cargo xtask clippy --since 回退到全部 187 个 workspace 包。

原始作业已经正确解析 PR base SHA，问题位于 axbuild 的根清单变更分类和包选择逻辑，而不是 checkout 深度或 since_ref。

## 修改

- 根清单分类结果记录发生变化的 workspace dependency key、旧新本地 path dependency 包名和字面 workspace member。
- 读取当前 workspace 成员清单，只选择对应 key 且显式声明 workspace = true 的真实消费者。
- 覆盖普通、dev、build、target-specific dependency 表以及 dotted TOML 和 package alias 写法。
- 将消费者、本地依赖包和成员包合并后，继续应用现有反向依赖闭包与 ax-std、starryos 根包扩展。
- 外部依赖的新增、版本、source、features、default-features 和 package alias 修改走消费者选择；显式写版本但未继承 workspace 的同名依赖不受影响。
- Cargo.lock 保持 soft input；全局配置、无法判定的 member glob 等不确定变更仍安全回退。

## 验证

- 确定性回归先确认旧实现会回退全仓，修复后通过。
- cargo test -p axbuild support::git::tests --lib：41 项通过。
- cargo test -p axbuild clippy::tests --lib：40 项通过。
- cargo xtask clippy --package axbuild：通过。
- cargo fmt --all --check：通过。
- git diff --check：通过。
- 在修复与 PR #2118 diff 的临时组合树执行原始 cargo xtask clippy --since a82e6339c62d748b8e1cb93e5851a0a98e50aeff：未出现全 workspace 回退，精确选择 someboot、somehal、x86-apic-driver、ax-std、starryos，5 个包共 72 项检查全部通过。

相关作业：https://github.com/rcore-os/tgoskits/actions/runs/32438166823/job/96644314917?pr=2118
