### PR TITLE
fix(ci): prevent duplicate routing from skipping PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,7 @@ jobs:
         id: route
         env:
           GH_TOKEN: ${{ github.token }}
-          EVENT_ACTION: ${{ github.event.action || '' }}
           EVENT_NAME: ${{ github.event_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           REF_NAME: ${{ github.ref_name }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
@@ -118,34 +115,6 @@ jobs:
                 echo "$open_prs"
               } >> "$GITHUB_STEP_SUMMARY"
             fi
-          elif [ "$EVENT_NAME" = "pull_request" ] \
-            && [ "$EVENT_ACTION" = "opened" ] \
-            && [ "$GITHUB_REPOSITORY" = "rcore-os/tgoskits" ]; then
-            push_runs="$(
-              gh api \
-                --method GET \
-                "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
-                -f event=push \
-                -f branch="$PR_HEAD_REF" \
-                -f head_sha="$HEAD_SHA" \
-                -f per_page=100 \
-                --jq '.workflow_runs[] | select(
-                  .event == "push"
-                  and .head_sha == env.HEAD_SHA
-                  and .head_branch == env.PR_HEAD_REF
-                  and .conclusion != "cancelled"
-                ) | "- #\(.run_number): \(.html_url)"'
-            )"
-            if [ -n "$push_runs" ]; then
-              should_run=false
-              {
-                echo "## Duplicate pull request CI skipped"
-                echo ""
-                echo "A branch push run already validates this pull request head commit."
-                echo ""
-                echo "$push_runs"
-              } >> "$GITHUB_STEP_SUMMARY"
-            fi
           fi
           echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
 
@@ -157,6 +126,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CURRENT_RUN_NUMBER: ${{ github.run_number }}
           EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           REF_NAME: ${{ github.ref_name }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
         run: |
@@ -167,8 +138,19 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             selector='select(
               .run_number < (env.CURRENT_RUN_NUMBER | tonumber)
-              and .event == "pull_request"
-              and any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
+              and (
+                (
+                  .event == "pull_request"
+                  and any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
+                )
+                or (
+                  .event == "push"
+                  and .head_branch != "main"
+                  and .head_branch != "dev"
+                  and .head_sha == env.HEAD_SHA
+                  and .head_branch == env.PR_HEAD_REF
+                )
+              )
             )'
           else
             selector='select(

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -15,10 +15,10 @@ sidebar_label: "自动 CI 测试"
 
 容器发布由 `.github/workflows/container-publish.yml` 独立处理。非主线分支 push
 由主 CI 的准备阶段检查 open PR，已有 PR 时准备阶段正常成功、后续矩阵标记为
-skipped。首次创建 pull request 时，如果同一分支和 head commit 已有 push run，则
-pull request 的准备阶段正常成功、后续矩阵标记为 skipped；后续更新已有 PR 时仍由
-pull request run 验证，push run 跳过。pull request run 只取消同一 PR 的旧 pull
-request run，不会把关联同一提交的 push 准备阶段取消成失败状态。
+skipped。所有 pull request 事件都由 pull request run 验证；它会取消同一 PR 的旧
+pull request run，以及同一普通分支和 head commit 下仍在排队或运行的 push run；
+`main` 和 `dev` 的 push run 始终保留。这样首次创建 PR 和重跑 workflow 时都不会
+出现 push 与 pull request 互相等待、最终没有测试矩阵执行的情况。
 
 ## 触发条件
 
@@ -26,7 +26,7 @@ request run，不会把关联同一提交的 push 准备阶段取消成失败状
 |------|------|
 | push 到 `main` / `dev` | 非文档变更运行完整矩阵 |
 | 其他分支 push | 没有 open PR 时运行完整矩阵 |
-| 首次创建 pull request | 同 SHA 已有 push run 时跳过重复矩阵，否则按三点 diff 规划 |
+| 首次创建 pull request | 按三点 diff 规划，并取消同 SHA 下仍未完成的 branch push run |
 | 更新或重开 pull request | planner 根据三点 diff 生成增量矩阵 |
 | workflow dispatch | 使用指定的 `since_sha`，但仍运行完整矩阵 |
 

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -47,45 +47,44 @@ def main() -> int:
     if not route_step:
         errors.append("Plan CI must have a duplicate-event routing step")
     else:
+        push_route = shell_if_block(route_step, '"$EVENT_NAME" = "push"')
+        if not push_route:
+            errors.append("duplicate routing must identify branch push events")
         for fragment, message in (
             (
-                'EVENT_ACTION: ${{ github.event.action || \'\' }}',
-                "duplicate routing must distinguish newly opened pull requests",
+                '[ "$REF_NAME" != "main" ]',
+                "main push CI must not be disabled by pull request routing",
             ),
             (
-                'HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}',
-                "duplicate routing must compare the pull request head commit",
+                '[ "$REF_NAME" != "dev" ]',
+                "dev push CI must not be disabled by pull request routing",
             ),
             (
-                '"$EVENT_ACTION" = "opened"',
-                "only a newly opened pull request may reuse its branch push run",
+                '[ "$GITHUB_REPOSITORY" = "rcore-os/tgoskits" ]',
+                "fork branch pushes must not query base-repository pull requests",
             ),
             (
-                "actions/workflows/ci.yml/runs",
-                "new pull requests must query runs from the same CI workflow",
-            ),
-            (
-                "-f event=push",
-                "new pull requests must only reuse push runs",
-            ),
-            (
-                '-f branch="$PR_HEAD_REF"',
-                "new pull requests must only reuse a push run for the same branch",
-            ),
-            (
-                '-f head_sha="$HEAD_SHA"',
-                "new pull requests must only reuse a push run for the same commit",
-            ),
-            (
-                '.conclusion != "cancelled"',
-                "a cancelled push run must not suppress pull request validation",
+                "gh pr list",
+                "branch push routing must detect open pull requests",
             ),
             (
                 "should_run=false",
-                "a matching push run must skip the duplicate pull request matrix",
+                "an open PR must disable duplicate branch push CI",
             ),
         ):
-            require_contains(errors, route_step, fragment, message)
+            require_contains(errors, push_route, fragment, message)
+        if push_route.count("should_run=false") != 1:
+            errors.append(
+                "only branch push routing may disable CI; pull request events must run"
+            )
+        for fragment in (
+            '"$EVENT_NAME" = "pull_request"',
+            "actions/workflows/ci.yml/runs",
+        ):
+            if fragment in route_step:
+                errors.append(
+                    "pull request routing must not depend on a matching push run"
+                )
 
     for fragment, message in (
         (
@@ -120,6 +119,19 @@ def main() -> int:
     ):
         require_contains(errors, ci_workflow, fragment, message)
 
+    cancel_step = named_step_block(plan_ci, "Cancel older queued or running runs")
+    for fragment, message in (
+        (
+            'HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}',
+            "stale-run cancellation must compare the pull request head commit",
+        ),
+        (
+            'PR_HEAD_REF: ${{ github.event.pull_request.head.ref || \'\' }}',
+            "stale-run cancellation must compare the pull request head branch",
+        ),
+    ):
+        require_contains(errors, cancel_step, fragment, message)
+
     pull_request_selector, push_selector = shell_if_else_branches(
         ci_workflow,
         '"$EVENT_NAME" = "pull_request"',
@@ -135,6 +147,26 @@ def main() -> int:
             (
                 ".pull_requests[]?",
                 "PR cleanup must select runs for the same pull request",
+            ),
+            (
+                '.event == "push"',
+                "PR cleanup must select the matching branch push run",
+            ),
+            (
+                ".head_sha == env.HEAD_SHA",
+                "PR cleanup must compare the branch push head commit",
+            ),
+            (
+                ".head_branch == env.PR_HEAD_REF",
+                "PR cleanup must compare the branch push head branch",
+            ),
+            (
+                '.head_branch != "main"',
+                "PR cleanup must preserve main push CI",
+            ),
+            (
+                '.head_branch != "dev"',
+                "PR cleanup must preserve dev push CI",
             ),
         ):
             require_contains(errors, pull_request_selector, fragment, message)
@@ -289,6 +321,25 @@ def shell_if_else_branches(text: str, condition: str) -> tuple[str, str]:
     if match is None:
         return "", ""
     return match.group("then"), match.group("else")
+
+
+def shell_if_block(text: str, condition: str) -> str:
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if not line.strip().startswith("if ") or condition not in line:
+            continue
+        depth = 0
+        block = []
+        for nested_line in lines[index:]:
+            stripped = nested_line.strip()
+            if stripped.startswith("if "):
+                depth += 1
+            block.append(nested_line)
+            if stripped == "fi":
+                depth -= 1
+                if depth == 0:
+                    return "\n".join(block)
+    return ""
 
 
 def require_contains(errors: list[str], text: str, fragment: str, message: str) -> None:


### PR DESCRIPTION
## 问题

PR #2130 暴露了重复事件路由的状态竞态：

- 首次 branch push 在 PR 创建前正常执行完整矩阵；
- `pull_request: opened` 发现同 SHA 的 push run 后跳过自己的矩阵；
- 后续重跑原 push run 时，由于 PR 已经存在，push run 也跳过矩阵；
- GitHub 以最新 attempt 展示 checks，最终只剩 Plan CI 成功，Preflight、Workspace、ArceOS、Starry 和 AxVisor 全部显示 skipped。

问题不在 changed paths 或 planner。PR #2130 的首次 push attempt 实际执行了 35 个 job 并全部成功；双向 skipped 来自路由决策依赖会随时间变化的“是否已有 PR / push run”状态。

## 修改

- 将 pull request run 设为 PR 场景的权威验证者，不再因为存在同 SHA push run 而跳过。
- 保留普通 feature branch 在已有 open PR 时跳过 branch push 矩阵的行为。
- pull request run 启动后，取消同一 PR 的旧 pull request run，以及同一 head SHA、同一 feature branch 下仍排队或运行的 push run。
- 明确排除 main/dev push run，避免从受保护分支发起 PR 时取消其 canonical CI。
- fork token 无法取消旧 run 时继续采用 warning + best-effort，不影响当前 pull request 矩阵执行。
- 更新路由契约检查和 CI 文档，锁定上述事件所有权。

## 设计逻辑

| 事件 | 行为 |
| --- | --- |
| main/dev push | 始终执行，不会被 PR run 取消 |
| 无 open PR 的 feature push | 执行完整矩阵 |
| 有 open PR 的 feature push | Plan CI 成功，矩阵跳过，由 pull request run 验证 |
| pull_request opened/synchronize/reopened | 始终规划并执行矩阵 |
| PR 与同 SHA feature push 并发 | PR 保留，仍在排队或运行的 push run 被取消 |
| rerun pull request workflow | 继续执行，不再被历史 push run 抑制 |

这样事件去重只决定由谁执行，不会再允许 push 与 pull request 同时认为对方负责。

## 回归与验证

- 红测：先更新 `scripts/test/check_ci_routing.py`，旧 workflow 确定失败，指出 PR-side skip、缺少同 SHA push 取消和未保护 main/dev push。
- 绿测：`python3 scripts/test/check_ci_routing.py` 通过。
- `uv run --python 3.11 python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py`：35/35 通过。
- 官方 actionlint 容器验证 `.github/workflows/ci.yml` 通过；仅忽略仓库现有的 `concurrency.queue` 解析告警。
- `cargo fmt --all --check` 通过。
- `git diff --check` 通过。

复现场景：https://github.com/rcore-os/tgoskits/pull/2130
相关 run：https://github.com/rcore-os/tgoskits/actions/runs/32441052269
