### PR TITLE
fix(ax-runtime): catch up expired periodic timer deadlines

### DIFF
--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -555,6 +555,28 @@ fn advance_periodic_timer(now_ns: u64) -> bool {
 }
 
 #[cfg(feature = "irq")]
+fn select_timer_deadline(
+    periodic_deadline_nanos: u64,
+    task_deadline_nanos: Option<u64>,
+    now_nanos: u64,
+    periodic_interval_nanos: u64,
+) -> (u64, u64) {
+    debug_assert_ne!(periodic_interval_nanos, 0);
+    let periodic_deadline_nanos = if periodic_deadline_nanos <= now_nanos {
+        let elapsed_intervals = (now_nanos - periodic_deadline_nanos) / periodic_interval_nanos;
+        periodic_deadline_nanos.saturating_add(
+            periodic_interval_nanos.saturating_mul(elapsed_intervals.saturating_add(1)),
+        )
+    } else {
+        periodic_deadline_nanos
+    };
+    let selected_deadline_nanos = task_deadline_nanos
+        .map(|task_deadline| core::cmp::min(periodic_deadline_nanos, task_deadline))
+        .unwrap_or(periodic_deadline_nanos);
+    (periodic_deadline_nanos, selected_deadline_nanos)
+}
+
+#[cfg(feature = "irq")]
 fn program_next_timer() {
     let mut deadline = with_periodic_deadline(|pin| NEXT_PERIODIC_DEADLINE_NANOS.read_current(pin));
     if deadline == 0 {
@@ -564,10 +586,24 @@ fn program_next_timer() {
     }
     #[cfg(feature = "multitask")]
     let task_deadline = ax_task::next_timer_deadline_nanos();
-    #[cfg(feature = "multitask")]
-    if let Some(task_deadline) = task_deadline {
-        deadline = core::cmp::min(deadline, task_deadline);
+    #[cfg(not(feature = "multitask"))]
+    let task_deadline = None;
+    let now_nanos = ax_hal::time::monotonic_time_nanos();
+    let (next_periodic_deadline, selected_deadline) = select_timer_deadline(
+        deadline,
+        task_deadline,
+        now_nanos,
+        periodic_interval_nanos(),
+    );
+    if next_periodic_deadline != deadline {
+        // Timer callbacks and scheduler work can outlive the periodic deadline
+        // selected at IRQ entry. Coalesce those ticks before rearming so the
+        // hardware comparator is not programmed with an already elapsed value.
+        with_periodic_deadline(|pin| {
+            NEXT_PERIODIC_DEADLINE_NANOS.write_current(pin, next_periodic_deadline);
+        });
     }
+    deadline = selected_deadline;
 
     ax_hal::time::set_oneshot_timer(deadline);
     #[cfg(feature = "multitask")]
@@ -617,6 +653,14 @@ fn init_tls() {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "irq")]
+    #[test]
+    fn timer_programming_catches_up_after_a_slow_irq() {
+        let (periodic, selected) = super::select_timer_deadline(100, None, 150, 10);
+        assert_eq!(periodic, 160);
+        assert_eq!(selected, 160);
+    }
+
     #[test]
     fn fs_init_accepts_bootargs_without_fs_feature() {
         crate::fs::init(Some("root=/dev/nvme0n1"));


### PR DESCRIPTION
## 问题

近期 dev 的 Starry riscv64 QEMU system 套件重复在 `test-execve` 附近耗尽 1800 秒外层超时。最新 canonical CI 证据为：

- run 32446985325 / job 96676631952
- `test-eventfd2` 已完成 94/94；
- 随后打印 `test-execve` 标题，最终只留下截断的 `FILE: .../test-e`；
- QEMU 在 1800 秒后被宿主 watchdog 终止，没有 assertion、panic 或 syscall 失败。

串口 runtime worker 每轮最多发送 64 字节后主动让出 CPU，因此这些截断位置是 worker 首次 yield 的稳定指纹，不代表 `execve` 语义本身出错。

根因位于 timer IRQ 的重编程顺序：IRQ 入口先推进周期 deadline，随后运行调度器、回调和任务定时器处理；如果这些工作跨过了入口时选中的周期 deadline，旧实现仍会在 IRQ 尾部把已经过期的值写回硬件比较器。RISC-V timer 随即再次触发，CPU 会反复进入 timer IRQ，任务和串口 worker 都无法继续前进。

## 修改

1. 将 timer deadline 选择抽成可直接测试的纯函数。
2. 在真正写硬件比较器前重新读取当前时间。
3. 若周期 deadline 已经过期，按周期数量一次推进到严格晚于当前时间的下一个 deadline，并同步更新 CPU-local 周期状态。
4. 继续将任务 one-shot deadline 与推进后的周期 deadline 取最小值，不改变 one-shot 精度或消费契约。
5. 增加慢 IRQ 确定性回归：入口周期 deadline 为 100、IRQ 尾部时间为 150、周期为 10 时，必须选择 160，而不能重新编程 100。

错过的周期 tick 在 rearm 边界合并，而不是逐个重放；本次不改变 Starry syscall、串口队列、测试分组、成功正则或 timeout。

## 红绿回归

修复前先以保持旧行为的纯函数抽取运行同一测试：

```text
assertion failed: left == right
left: 100
right: 160
```

实现修复后，同一命令通过：

```console
cargo test -p ax-runtime --features host-test,irq,multitask timer_programming_catches_up_after_a_slow_irq -- --nocapture
```

## 验证

- `cargo fmt --all --check`
- `cargo xtask clippy --package ax-runtime`：24/24
- 最新 dev 基线 `359ffc2949`：
  - `cargo test -p ax-runtime --features host-test,irq,multitask timer_programming_catches_up_after_a_slow_irq -- --nocapture`
  - `cargo xtask starry test qemu --arch riscv64 -c qemu/system/test-execve`：52/52，guest 8.451 秒
- 同一补丁的完整 riscv64 Starry 验证：
  - `system`：456/456，854.380 秒
  - `tty-console-input-burst`：通过
  - 2/2 QEMU cases，通过，总计 941.19 秒

完整套件运行后 dev 仅新增了 x86 VMX/APIC 修复 #2133；本分支 fast-forward 到该最新基线后重新执行了确定性单测和隔离 riscv64 `test-execve`。

## 范围

开放 PR #2130 同时包含 timer list、Starry 地址空间和 exec 压力测试等多组改动，且地址空间生命周期仍有独立 review 阻塞。本 PR 只提取与当前单线程 `test-execve` CI 活锁直接对应、能够独立红绿验证的 ax-runtime timer 修复，避免把无关且尚未解决的改动耦合进来。