### PR TITLE
fix(ci): skip duplicate pull request checks cleanly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,10 +245,28 @@ jobs:
             fi
 
             while IFS=$'\t' read -r run_id run_number run_url; do
-              if [ -n "$run_id" ] && ! gh api \
+              if [ -z "$run_id" ]; then
+                continue
+              fi
+              if ! gh api \
                 --method POST \
                 "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" >/dev/null; then
                 echo "::warning::Failed to cancel stale CI run #${run_number}: ${run_url}"
+              fi
+              sleep 2
+              if ! run_status="$(
+                gh api \
+                  --method GET \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+                  --jq '.status' 2>&1
+              )"; then
+                echo "::warning::Failed to recheck stale CI run #${run_number}: ${run_status}"
+                continue
+              fi
+              if [ "$run_status" != "completed" ] && ! gh api \
+                --method POST \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/force-cancel" >/dev/null; then
+                echo "::warning::Failed to force-cancel stale CI run #${run_number}: ${run_url}"
               fi
             done <<< "$runs"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,7 @@ jobs:
 
       - name: Cancel older queued or running runs
         if: >-
-          steps.route.outputs.should_run == 'true' &&
-          (github.event_name == 'pull_request' || github.ref != 'refs/heads/dev')
+          github.event_name == 'pull_request' || github.ref != 'refs/heads/dev'
         env:
           GH_TOKEN: ${{ github.token }}
           CURRENT_RUN_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,8 @@ jobs:
 
       - name: Cancel older queued or running runs
         if: >-
-          github.event_name == 'pull_request' || github.ref != 'refs/heads/dev'
+          github.event_name == 'pull_request' ||
+          (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         env:
           GH_TOKEN: ${{ github.token }}
           CURRENT_RUN_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,78 +96,111 @@ jobs:
           should_run=true
           if [ "$EVENT_NAME" = "pull_request" ] \
             && [ "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ]; then
-            push_runs=""
-            if ! push_runs="$(
-              gh api \
-                --method GET \
-                --paginate \
-                "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
-                -f event=push \
-                -f branch="$PR_HEAD_REF" \
-                -f head_sha="$HEAD_SHA" \
-                -f per_page=100 \
-                --jq '.workflow_runs[] | select(
-                  .event == "push"
-                  and .head_sha == env.HEAD_SHA
-                  and .head_branch == env.PR_HEAD_REF
-                  and .conclusion != "cancelled"
-                ) | [.id, .run_number, .html_url] | @tsv' 2>&1
-            )"; then
-              echo "::warning::Failed to query matching branch push runs: ${push_runs}"
+            for ((attempt = 1; attempt <= 10; attempt++)); do
               push_runs=""
-            fi
-
-            active_push_runs=""
-            while IFS=$'\t' read -r run_id run_number run_url; do
-              if [ -z "$run_id" ]; then
-                continue
-              fi
-              if ! active_matrix_jobs="$(
+              if ! push_runs="$(
                 gh api \
                   --method GET \
                   --paginate \
-                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
-                  -f filter=latest \
+                  "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+                  -f event=push \
+                  -f branch="$PR_HEAD_REF" \
+                  -f head_sha="$HEAD_SHA" \
                   -f per_page=100 \
-                  --jq '.jobs[] | select(
-                    .name != "Plan CI"
-                    and .conclusion != "skipped"
+                  --jq '.workflow_runs[] | select(
+                    .event == "push"
+                    and .head_sha == env.HEAD_SHA
+                    and .head_branch == env.PR_HEAD_REF
                     and .conclusion != "cancelled"
-                  ) | .id' 2>&1
+                  ) | [.id, .run_number, .html_url] | @tsv' 2>&1
               )"; then
-                echo "::warning::Failed to inspect branch push run #${run_number}: ${active_matrix_jobs}"
-                continue
+                echo "::warning::Failed to query matching branch push runs: ${push_runs}"
+                break
               fi
-              if [ -n "$active_matrix_jobs" ]; then
-                if ! push_run_is_usable="$(
+
+              if [ -z "$push_runs" ]; then
+                # The pull_request record can become visible before its sibling push run.
+                if [ "$attempt" -lt 10 ]; then
+                  sleep 2
+                  continue
+                fi
+                break
+              fi
+
+              reusable_push_runs=""
+              route_query_failed=false
+              while IFS=$'\t' read -r run_id run_number run_url; do
+                if [ -z "$run_id" ]; then
+                  continue
+                fi
+                if ! push_run_state="$(
                   gh api \
                     --method GET \
                     "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
-                    --jq '.conclusion != "cancelled"' 2>&1
+                    --jq '[.status, (.conclusion != "cancelled")] | @tsv' 2>&1
                 )"; then
-                  echo "::warning::Failed to recheck branch push run #${run_number}: ${push_run_is_usable}"
+                  echo "::warning::Failed to recheck branch push run #${run_number}: ${push_run_state}"
+                  route_query_failed=true
                   continue
                 fi
+                IFS=$'\t' read -r current_status push_run_is_usable <<< "$push_run_state"
                 if [ "$push_run_is_usable" != "true" ]; then
                   continue
                 fi
-                if [ -n "$active_push_runs" ]; then
-                  active_push_runs+=$'\n'
-                fi
-                active_push_runs+="- #${run_number}: ${run_url}"
-              fi
-            done <<< "$push_runs"
 
-            if [ -n "$active_push_runs" ]; then
-              should_run=false
-              {
-                echo "## Duplicate pull request CI skipped"
-                echo ""
-                echo "A branch push run already has an active matrix for this pull request head commit."
-                echo ""
-                echo "$active_push_runs"
-              } >> "$GITHUB_STEP_SUMMARY"
-            fi
+                # Push routing is canonical, so an unfinished matching run owns
+                # validation before GitHub materializes its matrix jobs.
+                case "$current_status" in
+                  queued|in_progress|waiting|requested)
+                    ;;
+                  completed)
+                    if ! active_matrix_jobs="$(
+                      gh api \
+                        --method GET \
+                        --paginate \
+                        "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
+                        -f filter=latest \
+                        -f per_page=100 \
+                        --jq '.jobs[] | select(
+                          .name != "Plan CI"
+                          and .conclusion != "skipped"
+                          and .conclusion != "cancelled"
+                        ) | .id' 2>&1
+                    )"; then
+                      echo "::warning::Failed to inspect branch push run #${run_number}: ${active_matrix_jobs}"
+                      route_query_failed=true
+                      continue
+                    fi
+                    if [ -z "$active_matrix_jobs" ]; then
+                      continue
+                    fi
+                    ;;
+                  *)
+                    continue
+                    ;;
+                esac
+
+                if [ -n "$reusable_push_runs" ]; then
+                  reusable_push_runs+=$'\n'
+                fi
+                reusable_push_runs+="- #${run_number} (${current_status}): ${run_url}"
+              done <<< "$push_runs"
+
+              if [ "$route_query_failed" = "true" ]; then
+                break
+              fi
+              if [ -n "$reusable_push_runs" ]; then
+                should_run=false
+                {
+                  echo "## Duplicate pull request CI skipped"
+                  echo ""
+                  echo "A branch push run already owns validation for this pull request head commit."
+                  echo ""
+                  echo "$reusable_push_runs"
+                } >> "$GITHUB_STEP_SUMMARY"
+              fi
+              break
+            done
           fi
           echo "should_run=${should_run}" >> "$GITHUB_OUTPUT"
 
@@ -196,8 +229,7 @@ jobs:
             selector='select(
               .run_number < (env.CURRENT_RUN_NUMBER | tonumber)
               and .head_branch == env.REF_NAME
-              and .event != "pull_request"
-              and .event != "pull_request_target"
+              and .event == env.EVENT_NAME
             )'
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,32 +87,85 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           EVENT_NAME: ${{ github.event_name }}
-          REF_NAME: ${{ github.ref_name }}
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name || '' }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
         run: |
           set -euo pipefail
 
           should_run=true
-          if [ "$EVENT_NAME" = "push" ] \
-            && [ "$REF_NAME" != "main" ] \
-            && [ "$REF_NAME" != "dev" ] \
-            && [ "$GITHUB_REPOSITORY" = "rcore-os/tgoskits" ]; then
-            open_prs="$(
-              gh pr list \
-                --repo "$GITHUB_REPOSITORY" \
-                --head "$REF_NAME" \
-                --state open \
-                --json number,url,headRefName,headRepositoryOwner \
-                --jq '.[] | select(.headRepositoryOwner.login == env.REPOSITORY_OWNER and .headRefName == env.REF_NAME) | "- #\(.number): \(.url)"'
-            )"
-            if [ -n "$open_prs" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ] \
+            && [ "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ]; then
+            push_runs=""
+            if ! push_runs="$(
+              gh api \
+                --method GET \
+                --paginate \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+                -f event=push \
+                -f branch="$PR_HEAD_REF" \
+                -f head_sha="$HEAD_SHA" \
+                -f per_page=100 \
+                --jq '.workflow_runs[] | select(
+                  .event == "push"
+                  and .head_sha == env.HEAD_SHA
+                  and .head_branch == env.PR_HEAD_REF
+                  and .conclusion != "cancelled"
+                ) | [.id, .run_number, .html_url] | @tsv' 2>&1
+            )"; then
+              echo "::warning::Failed to query matching branch push runs: ${push_runs}"
+              push_runs=""
+            fi
+
+            active_push_runs=""
+            while IFS=$'\t' read -r run_id run_number run_url; do
+              if [ -z "$run_id" ]; then
+                continue
+              fi
+              if ! active_matrix_jobs="$(
+                gh api \
+                  --method GET \
+                  --paginate \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/jobs" \
+                  -f filter=latest \
+                  -f per_page=100 \
+                  --jq '.jobs[] | select(
+                    .name != "Plan CI"
+                    and .conclusion != "skipped"
+                    and .conclusion != "cancelled"
+                  ) | .id' 2>&1
+              )"; then
+                echo "::warning::Failed to inspect branch push run #${run_number}: ${active_matrix_jobs}"
+                continue
+              fi
+              if [ -n "$active_matrix_jobs" ]; then
+                if ! push_run_is_usable="$(
+                  gh api \
+                    --method GET \
+                    "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+                    --jq '.conclusion != "cancelled"' 2>&1
+                )"; then
+                  echo "::warning::Failed to recheck branch push run #${run_number}: ${push_run_is_usable}"
+                  continue
+                fi
+                if [ "$push_run_is_usable" != "true" ]; then
+                  continue
+                fi
+                if [ -n "$active_push_runs" ]; then
+                  active_push_runs+=$'\n'
+                fi
+                active_push_runs+="- #${run_number}: ${run_url}"
+              fi
+            done <<< "$push_runs"
+
+            if [ -n "$active_push_runs" ]; then
               should_run=false
               {
-                echo "## Duplicate push CI skipped"
+                echo "## Duplicate pull request CI skipped"
                 echo ""
-                echo "This branch already has an open pull request; its pull_request run validates the same commit."
+                echo "A branch push run already has an active matrix for this pull request head commit."
                 echo ""
-                echo "$open_prs"
+                echo "$active_push_runs"
               } >> "$GITHUB_STEP_SUMMARY"
             fi
           fi
@@ -126,8 +179,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CURRENT_RUN_NUMBER: ${{ github.run_number }}
           EVENT_NAME: ${{ github.event_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
           REF_NAME: ${{ github.ref_name }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
         run: |
@@ -138,19 +189,8 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             selector='select(
               .run_number < (env.CURRENT_RUN_NUMBER | tonumber)
-              and (
-                (
-                  .event == "pull_request"
-                  and any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
-                )
-                or (
-                  .event == "push"
-                  and .head_branch != "main"
-                  and .head_branch != "dev"
-                  and .head_sha == env.HEAD_SHA
-                  and .head_branch == env.PR_HEAD_REF
-                )
-              )
+              and .event == "pull_request"
+              and any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
             )'
           else
             selector='select(
@@ -192,7 +232,10 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/test/check_ci_routing.py
-          python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py
+          python3 -m unittest \
+            scripts/test/test_ci_impact.py \
+            scripts/test/test_ci_plan.py \
+            scripts/test/test_ci_routing.py
 
       - name: Resolve incremental base revision
         id: since

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -14,15 +14,18 @@ sidebar_label: "自动 CI 测试"
 - `.github/workflows/reusable-check-matrix.yml` 执行展开后的矩阵行。
 
 容器发布由 `.github/workflows/container-publish.yml` 独立处理。同仓分支 push 是
-对应 head commit 的首选验证；pull request 准备阶段只在确认同一分支和 head commit
-的 push run 已经产生有效矩阵后，将自己的后续矩阵标记为 skipped。它不会取消 push
-run，因此 GitHub 不会把正常的事件去重显示为 failing/cancelled checks。没有匹配的
-有效 push 矩阵时（包括 fork PR、API 查询失败、push 只有 Plan CI 或矩阵已被取消），
-pull request run 正常规划并执行。pull request run 仍只取消同一 PR 的旧 pull
-request run，即使本次 pull request 矩阵复用 push 而 skipped，也会清理旧 commit
-尚未完成的 pull request run；新 commit 的 push 同样会取消同一分支的旧 push run。
-两个事件都不会取消当前 commit 的另一类 run。`main` 和 `dev` 是例外：每个 push
-commit 的 CI 都完整保留，后续提交不会取消仍在运行的旧 CI。
+对应 head commit 的首选验证；pull request 准备阶段会短暂重试尚未可见的同 SHA push
+run。匹配的 push 仍在 queued 或 in_progress 时，它已经拥有该 commit 的验证，pull
+request 将自己的后续矩阵标记为 skipped；push 已 completed 时，仍必须存在非 Plan、
+非 skipped/cancelled 的真实矩阵 job 才能复用。这样既避免 push 与 pull request 同时
+执行，也不会把历史上的 Plan-only push 当成完整验证。查询失败、fork PR、completed
+Plan-only push 或已取消的 push 都会 fail-open，由 pull request 正常规划并执行。
+
+pull request 不会取消当前 SHA 的 push，因此 GitHub 不会把正常去重显示为
+failing/cancelled checks。pull request run 仍只取消同一 PR 的旧 pull request run，
+即使本次矩阵复用 push 而 skipped，也会清理旧 commit 尚未完成的 pull request run；
+新 commit 的 push 同样会取消同一分支的旧 push run。`main` 和 `dev` 是例外：每个
+push commit 的 CI 都完整保留，后续提交不会取消仍在运行的旧 CI。
 
 ## 触发条件
 
@@ -30,8 +33,8 @@ commit 的 CI 都完整保留，后续提交不会取消仍在运行的旧 CI。
 |------|------|
 | push 到 `main` / `dev` | 非文档变更运行完整矩阵，并保留每个 commit 的完整 CI |
 | 其他分支 push | 非文档变更运行完整矩阵，作为同仓 PR 的首选验证 |
-| 首次创建 pull request | 同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |
-| 更新或重开 pull request | 取消旧 commit 的同事件 run；同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |
+| 首次创建 pull request | 同 SHA push 已拥有验证时跳过，否则按三点 diff 规划 |
+| 更新或重开 pull request | 取消旧 commit 的同事件 run；同 SHA push 已拥有验证时跳过，否则按三点 diff 规划 |
 | workflow dispatch | 使用指定的 `since_sha`，但仍运行完整矩阵 |
 
 纯 Markdown 变更不触发主 CI。`push` 和 `workflow_dispatch` 不缩小测试矩阵。

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -21,13 +21,14 @@ run，因此 GitHub 不会把正常的事件去重显示为 failing/cancelled ch
 pull request run 正常规划并执行。pull request run 仍只取消同一 PR 的旧 pull
 request run，即使本次 pull request 矩阵复用 push 而 skipped，也会清理旧 commit
 尚未完成的 pull request run；新 commit 的 push 同样会取消同一分支的旧 push run。
-两个事件都不会取消当前 commit 的另一类 run。
+两个事件都不会取消当前 commit 的另一类 run。`main` 和 `dev` 是例外：每个 push
+commit 的 CI 都完整保留，后续提交不会取消仍在运行的旧 CI。
 
 ## 触发条件
 
 | 事件 | 行为 |
 |------|------|
-| push 到 `main` / `dev` | 非文档变更运行完整矩阵 |
+| push 到 `main` / `dev` | 非文档变更运行完整矩阵，并保留每个 commit 的完整 CI |
 | 其他分支 push | 非文档变更运行完整矩阵，作为同仓 PR 的首选验证 |
 | 首次创建 pull request | 同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |
 | 更新或重开 pull request | 取消旧 commit 的同事件 run；同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -19,7 +19,9 @@ sidebar_label: "自动 CI 测试"
 run，因此 GitHub 不会把正常的事件去重显示为 failing/cancelled checks。没有匹配的
 有效 push 矩阵时（包括 fork PR、API 查询失败、push 只有 Plan CI 或矩阵已被取消），
 pull request run 正常规划并执行。pull request run 仍只取消同一 PR 的旧 pull
-request run。
+request run，即使本次 pull request 矩阵复用 push 而 skipped，也会清理旧 commit
+尚未完成的 pull request run；新 commit 的 push 同样会取消同一分支的旧 push run。
+两个事件都不会取消当前 commit 的另一类 run。
 
 ## 触发条件
 
@@ -28,7 +30,7 @@ request run。
 | push 到 `main` / `dev` | 非文档变更运行完整矩阵 |
 | 其他分支 push | 非文档变更运行完整矩阵，作为同仓 PR 的首选验证 |
 | 首次创建 pull request | 同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |
-| 更新或重开 pull request | 同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |
+| 更新或重开 pull request | 取消旧 commit 的同事件 run；同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |
 | workflow dispatch | 使用指定的 `since_sha`，但仍运行完整矩阵 |
 
 纯 Markdown 变更不触发主 CI。`push` 和 `workflow_dispatch` 不缩小测试矩阵。

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -13,21 +13,22 @@ sidebar_label: "自动 CI 测试"
 - `scripts/test/ci_plan.py` 展开配置并生成矩阵；
 - `.github/workflows/reusable-check-matrix.yml` 执行展开后的矩阵行。
 
-容器发布由 `.github/workflows/container-publish.yml` 独立处理。非主线分支 push
-由主 CI 的准备阶段检查 open PR，已有 PR 时准备阶段正常成功、后续矩阵标记为
-skipped。所有 pull request 事件都由 pull request run 验证；它会取消同一 PR 的旧
-pull request run，以及同一普通分支和 head commit 下仍在排队或运行的 push run；
-`main` 和 `dev` 的 push run 始终保留。这样首次创建 PR 和重跑 workflow 时都不会
-出现 push 与 pull request 互相等待、最终没有测试矩阵执行的情况。
+容器发布由 `.github/workflows/container-publish.yml` 独立处理。同仓分支 push 是
+对应 head commit 的首选验证；pull request 准备阶段只在确认同一分支和 head commit
+的 push run 已经产生有效矩阵后，将自己的后续矩阵标记为 skipped。它不会取消 push
+run，因此 GitHub 不会把正常的事件去重显示为 failing/cancelled checks。没有匹配的
+有效 push 矩阵时（包括 fork PR、API 查询失败、push 只有 Plan CI 或矩阵已被取消），
+pull request run 正常规划并执行。pull request run 仍只取消同一 PR 的旧 pull
+request run。
 
 ## 触发条件
 
 | 事件 | 行为 |
 |------|------|
 | push 到 `main` / `dev` | 非文档变更运行完整矩阵 |
-| 其他分支 push | 没有 open PR 时运行完整矩阵 |
-| 首次创建 pull request | 按三点 diff 规划，并取消同 SHA 下仍未完成的 branch push run |
-| 更新或重开 pull request | planner 根据三点 diff 生成增量矩阵 |
+| 其他分支 push | 非文档变更运行完整矩阵，作为同仓 PR 的首选验证 |
+| 首次创建 pull request | 同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |
+| 更新或重开 pull request | 同 SHA push 已有有效矩阵时跳过，否则按三点 diff 规划 |
 | workflow dispatch | 使用指定的 `since_sha`，但仍运行完整矩阵 |
 
 纯 Markdown 变更不触发主 CI。`push` 和 `workflow_dispatch` 不缩小测试矩阵。
@@ -157,7 +158,10 @@ container image、preflight、cache、checkout depth、timeout、artifact 和命
 ## 本地检查
 
 ```bash
-python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py
+python3 -m unittest \
+  scripts/test/test_ci_impact.py \
+  scripts/test/test_ci_plan.py \
+  scripts/test/test_ci_routing.py
 python3 scripts/test/check_ci_routing.py
 actionlint
 ```

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -25,7 +25,8 @@ pull request 不会取消当前 SHA 的 push，因此 GitHub 不会把正常去�
 failing/cancelled checks。pull request run 仍只取消同一 PR 的旧 pull request run，
 即使本次矩阵复用 push 而 skipped，也会清理旧 commit 尚未完成的 pull request run；
 新 commit 的 push 同样会取消同一分支的旧 push run。`main` 和 `dev` 是例外：每个
-push commit 的 CI 都完整保留，后续提交不会取消仍在运行的旧 CI。
+push commit 的 CI 都完整保留，后续提交不会取消仍在运行的旧 CI。旧 run 先收到普通
+cancel；短暂复查仍未完成时再 force-cancel，避免分组 job 的 `always()` 条件阻止清理。
 
 ## 触发条件
 

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -143,6 +143,12 @@ def main() -> int:
     ):
         require_contains(errors, ci_workflow, fragment, message)
 
+    cancel_step = named_step_block(plan_ci, "Cancel older queued or running runs")
+    if "steps.route.outputs.should_run" in cancel_step:
+        errors.append(
+            "stale-run cleanup must run even when duplicate pull request CI is skipped"
+        )
+
     pull_request_selector, push_selector = shell_if_else_branches(
         ci_workflow,
         '"$EVENT_NAME" = "pull_request"',

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -193,6 +193,16 @@ def main() -> int:
             f"github.ref != 'refs/heads/{protected_ref}'",
             f"stale-run cleanup must preserve every {protected_ref} push run",
         )
+    normal_cancel = cancel_step.find(
+        '"repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel"'
+    )
+    force_cancel = cancel_step.find(
+        '"repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/force-cancel"'
+    )
+    if normal_cancel == -1 or force_cancel == -1 or normal_cancel > force_cancel:
+        errors.append(
+            "stale-run cleanup must force-cancel runs that ignore normal cancellation"
+        )
 
     pull_request_selector, push_selector = shell_if_else_branches(
         ci_workflow,

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -74,8 +74,16 @@ def main() -> int:
                 "pull request routing must match the head commit",
             ),
             (
+                "for ((attempt = 1; attempt <= 10; attempt++))",
+                "pull request routing must retry while its push run becomes visible",
+            ),
+            (
+                "sleep 2",
+                "push run discovery retries must remain bounded and observable",
+            ),
+            (
                 'actions/runs/${run_id}/jobs',
-                "pull request routing must inspect the push run matrix jobs",
+                "completed push routing must inspect the push run matrix jobs",
             ),
             (
                 "--paginate",
@@ -83,7 +91,7 @@ def main() -> int:
             ),
             (
                 '.name != "Plan CI"',
-                "a Plan-only push run must not suppress pull request CI",
+                "a completed Plan-only push run must not suppress pull request CI",
             ),
             (
                 '.conclusion != "skipped"',
@@ -98,17 +106,47 @@ def main() -> int:
                 "pull request routing must recheck the push run before skipping",
             ),
             (
+                '[.status, (.conclusion != "cancelled")] | @tsv',
+                "push run recheck must return its current lifecycle state",
+            ),
+            (
+                "queued|in_progress|waiting|requested)",
+                "only known unfinished push states may suppress pull request CI",
+            ),
+            (
+                "completed)",
+                "completed push runs must prove that matrix jobs exist",
+            ),
+            (
+                "*)",
+                "unknown push states must fail open",
+            ),
+            (
                 "should_run=false",
-                "a matching active push matrix must skip duplicate pull request CI",
+                "a matching canonical push run must skip duplicate pull request CI",
             ),
         ):
             require_contains(errors, pull_request_route, fragment, message)
         if pull_request_route.count("should_run=false") != 1:
             errors.append(
-                "only a pull request backed by an active push matrix may disable CI"
+                "only a pull request backed by a canonical push run may disable CI"
             )
         if pull_request_route.count("--paginate") != 2:
             errors.append("both push runs and push jobs queries must paginate")
+        query_failure_check = pull_request_route.find(
+            'if [ "$route_query_failed" = "true" ]'
+        )
+        reusable_run_check = pull_request_route.rfind(
+            'if [ -n "$reusable_push_runs" ]'
+        )
+        if (
+            query_failure_check == -1
+            or reusable_run_check == -1
+            or query_failure_check > reusable_run_check
+        ):
+            errors.append(
+                "any push run query failure must fail open before reusing another run"
+            )
         for fragment in ('"$EVENT_NAME" = "push"', "gh pr list"):
             if fragment in route_step:
                 errors.append(
@@ -178,12 +216,8 @@ def main() -> int:
             errors.append("PR cleanup must not cancel matching push runs")
         for fragment, message in (
             (
-                '.event != "pull_request"',
-                "push cleanup must not cancel pull request runs",
-            ),
-            (
-                '.event != "pull_request_target"',
-                "push cleanup must not cancel pull request target runs",
+                ".event == env.EVENT_NAME",
+                "non-PR cleanup must only cancel runs from the same event",
             ),
         ):
             require_contains(errors, push_selector, fragment, message)

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -148,6 +148,13 @@ def main() -> int:
         errors.append(
             "stale-run cleanup must run even when duplicate pull request CI is skipped"
         )
+    for protected_ref in ("main", "dev"):
+        require_contains(
+            errors,
+            cancel_step,
+            f"github.ref != 'refs/heads/{protected_ref}'",
+            f"stale-run cleanup must preserve every {protected_ref} push run",
+        )
 
     pull_request_selector, push_selector = shell_if_else_branches(
         ci_workflow,

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -47,43 +47,72 @@ def main() -> int:
     if not route_step:
         errors.append("Plan CI must have a duplicate-event routing step")
     else:
-        push_route = shell_if_block(route_step, '"$EVENT_NAME" = "push"')
-        if not push_route:
-            errors.append("duplicate routing must identify branch push events")
+        pull_request_route = shell_if_block(
+            route_step, '"$EVENT_NAME" = "pull_request"'
+        )
+        if not pull_request_route:
+            errors.append("duplicate routing must identify pull request events")
         for fragment, message in (
             (
-                '[ "$REF_NAME" != "main" ]',
-                "main push CI must not be disabled by pull request routing",
+                '[ "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ]',
+                "pull request routing must identify same-repository branches",
             ),
             (
-                '[ "$REF_NAME" != "dev" ]',
-                "dev push CI must not be disabled by pull request routing",
+                "actions/workflows/ci.yml/runs",
+                "pull request routing must query runs from the same CI workflow",
             ),
             (
-                '[ "$GITHUB_REPOSITORY" = "rcore-os/tgoskits" ]',
-                "fork branch pushes must not query base-repository pull requests",
+                "-f event=push",
+                "pull request routing must only reuse push runs",
             ),
             (
-                "gh pr list",
-                "branch push routing must detect open pull requests",
+                '-f branch="$PR_HEAD_REF"',
+                "pull request routing must match the head branch",
+            ),
+            (
+                '-f head_sha="$HEAD_SHA"',
+                "pull request routing must match the head commit",
+            ),
+            (
+                'actions/runs/${run_id}/jobs',
+                "pull request routing must inspect the push run matrix jobs",
+            ),
+            (
+                "--paginate",
+                "push matrix inspection must include every jobs page",
+            ),
+            (
+                '.name != "Plan CI"',
+                "a Plan-only push run must not suppress pull request CI",
+            ),
+            (
+                '.conclusion != "skipped"',
+                "a skipped push matrix must not suppress pull request CI",
+            ),
+            (
+                '.conclusion != "cancelled"',
+                "a cancelled push matrix must not suppress pull request CI",
+            ),
+            (
+                '"repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}"',
+                "pull request routing must recheck the push run before skipping",
             ),
             (
                 "should_run=false",
-                "an open PR must disable duplicate branch push CI",
+                "a matching active push matrix must skip duplicate pull request CI",
             ),
         ):
-            require_contains(errors, push_route, fragment, message)
-        if push_route.count("should_run=false") != 1:
+            require_contains(errors, pull_request_route, fragment, message)
+        if pull_request_route.count("should_run=false") != 1:
             errors.append(
-                "only branch push routing may disable CI; pull request events must run"
+                "only a pull request backed by an active push matrix may disable CI"
             )
-        for fragment in (
-            '"$EVENT_NAME" = "pull_request"',
-            "actions/workflows/ci.yml/runs",
-        ):
+        if pull_request_route.count("--paginate") != 2:
+            errors.append("both push runs and push jobs queries must paginate")
+        for fragment in ('"$EVENT_NAME" = "push"', "gh pr list"):
             if fragment in route_step:
                 errors.append(
-                    "pull request routing must not depend on a matching push run"
+                    "push events must remain canonical and must not be disabled by PR state"
                 )
 
     for fragment, message in (
@@ -104,11 +133,6 @@ def main() -> int:
             "Preflight must follow the planner decision",
         ),
         (
-            "gh pr list",
-            "the plan job must detect open pull requests",
-        ),
-        ("should_run=false", "an open PR must disable duplicate branch push CI"),
-        (
             "needs.plan_ci.outputs.should_run == 'true'",
             "matrix jobs must follow the branch routing decision",
         ),
@@ -118,19 +142,6 @@ def main() -> int:
         ),
     ):
         require_contains(errors, ci_workflow, fragment, message)
-
-    cancel_step = named_step_block(plan_ci, "Cancel older queued or running runs")
-    for fragment, message in (
-        (
-            'HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}',
-            "stale-run cancellation must compare the pull request head commit",
-        ),
-        (
-            'PR_HEAD_REF: ${{ github.event.pull_request.head.ref || \'\' }}',
-            "stale-run cancellation must compare the pull request head branch",
-        ),
-    ):
-        require_contains(errors, cancel_step, fragment, message)
 
     pull_request_selector, push_selector = shell_if_else_branches(
         ci_workflow,
@@ -148,28 +159,10 @@ def main() -> int:
                 ".pull_requests[]?",
                 "PR cleanup must select runs for the same pull request",
             ),
-            (
-                '.event == "push"',
-                "PR cleanup must select the matching branch push run",
-            ),
-            (
-                ".head_sha == env.HEAD_SHA",
-                "PR cleanup must compare the branch push head commit",
-            ),
-            (
-                ".head_branch == env.PR_HEAD_REF",
-                "PR cleanup must compare the branch push head branch",
-            ),
-            (
-                '.head_branch != "main"',
-                "PR cleanup must preserve main push CI",
-            ),
-            (
-                '.head_branch != "dev"',
-                "PR cleanup must preserve dev push CI",
-            ),
         ):
             require_contains(errors, pull_request_selector, fragment, message)
+        if '.event == "push"' in pull_request_selector:
+            errors.append("PR cleanup must not cancel matching push runs")
         for fragment, message in (
             (
                 '.event != "pull_request"',

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -37,6 +37,67 @@ class DuplicateEventRoutingTests(unittest.TestCase):
             any("actions/runs/101/jobs" in call for call in result.gh_calls)
         )
 
+    def test_in_progress_push_suppresses_pull_request_before_matrix_exists(
+        self,
+    ) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs="101\t11975\thttps://example.test/push/101",
+            push_run_status="in_progress",
+        )
+
+        self.assertEqual(result.should_run, "false")
+        self.assertFalse(
+            any("actions/runs/101/jobs" in call for call in result.gh_calls)
+        )
+
+    def test_waiting_and_requested_pushes_suppress_pull_request(self) -> None:
+        for status in ("waiting", "requested"):
+            with self.subTest(status=status):
+                result = run_route(
+                    event_name="pull_request",
+                    push_runs="101\t11975\thttps://example.test/push/101",
+                    push_run_status=status,
+                )
+
+                self.assertEqual(result.should_run, "false")
+
+    def test_unknown_push_status_does_not_suppress_pull_request(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs="101\t11975\thttps://example.test/push/101",
+            push_run_status="mystery",
+        )
+
+        self.assertEqual(result.should_run, "true")
+
+    def test_pull_request_retries_until_push_run_is_visible(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs="101\t11975\thttps://example.test/push/101",
+            push_runs_after_query=2,
+            push_run_status="queued",
+        )
+
+        self.assertEqual(result.should_run, "false")
+        run_queries = [
+            call
+            for call in result.gh_calls
+            if "actions/workflows/ci.yml/runs" in call
+        ]
+        self.assertGreaterEqual(len(run_queries), 2)
+
+    def test_pull_request_runs_after_retry_when_no_push_appears(self) -> None:
+        result = run_route(event_name="pull_request")
+
+        self.assertEqual(result.should_run, "true")
+        run_queries = [
+            call
+            for call in result.gh_calls
+            if "actions/workflows/ci.yml/runs" in call
+        ]
+        self.assertEqual(len(run_queries), 10)
+
     def test_plan_only_push_does_not_suppress_pull_request(self) -> None:
         result = run_route(
             event_name="pull_request",
@@ -76,7 +137,7 @@ class DuplicateEventRoutingTests(unittest.TestCase):
         self.assertEqual(result.should_run, "true")
         self.assertIn("Failed to inspect branch push run", result.stdout)
 
-    def test_push_cancelled_after_job_query_does_not_suppress_pull_request(
+    def test_push_cancelled_before_route_decision_does_not_suppress_pull_request(
         self,
     ) -> None:
         result = run_route(
@@ -104,6 +165,20 @@ class DuplicateEventRoutingTests(unittest.TestCase):
 
         self.assertEqual(result.should_run, "true")
         self.assertIn("Failed to recheck branch push run", result.stdout)
+
+    def test_any_push_recheck_failure_overrides_another_reusable_run(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs=(
+                "101\t11975\thttps://example.test/push/101\n"
+                "202\t11976\thttps://example.test/push/202"
+            ),
+            push_run_query_fail_ids="202",
+            push_run_status="in_progress",
+        )
+
+        self.assertEqual(result.should_run, "true")
+        self.assertIn("Failed to recheck branch push run #11976", result.stdout)
 
     def test_fork_pull_request_runs_without_querying_base_pushes(self) -> None:
         result = run_route(
@@ -144,9 +219,12 @@ def run_route(
     has_active_matrix: str = "false",
     active_matrix_run_ids: str = "",
     push_run_is_usable: str = "true",
+    push_run_status: str = "completed",
     push_run_query_exit: str = "0",
+    push_run_query_fail_ids: str = "",
     run_query_exit: str = "0",
     job_query_exit: str = "0",
+    push_runs_after_query: int = 1,
 ) -> RouteResult:
     script = route_script()
     with tempfile.TemporaryDirectory() as temp_dir_name:
@@ -156,6 +234,9 @@ def run_route(
         fake_gh = bin_dir / "gh"
         fake_gh.write_text(FAKE_GH, encoding="utf-8")
         fake_gh.chmod(0o755)
+        fake_sleep = bin_dir / "sleep"
+        fake_sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake_sleep.chmod(0o755)
 
         output_file = temp_dir / "output"
         summary_file = temp_dir / "summary"
@@ -177,8 +258,12 @@ def run_route(
                 "FAKE_JOB_QUERY_EXIT": job_query_exit,
                 "FAKE_PUSH_RUNS": push_runs,
                 "FAKE_PUSH_RUN_IS_USABLE": push_run_is_usable,
+                "FAKE_PUSH_RUN_STATUS": push_run_status,
                 "FAKE_PUSH_RUN_QUERY_EXIT": push_run_query_exit,
+                "FAKE_PUSH_RUN_QUERY_FAIL_IDS": push_run_query_fail_ids,
                 "FAKE_RUN_QUERY_EXIT": run_query_exit,
+                "FAKE_PUSH_RUNS_AFTER_QUERY": str(push_runs_after_query),
+                "FAKE_STATE_DIR": str(temp_dir),
             }
         )
         completed = subprocess.run(
@@ -227,7 +312,15 @@ with Path(os.environ["FAKE_GH_LOG"]).open("a", encoding="utf-8") as log:
     log.write(arguments + "\n")
 
 if "actions/workflows/ci.yml/runs" in arguments:
-    print(os.environ["FAKE_PUSH_RUNS"])
+    query_count_file = Path(os.environ["FAKE_STATE_DIR"]) / "run-query-count"
+    query_count = (
+        int(query_count_file.read_text(encoding="utf-8"))
+        if query_count_file.exists()
+        else 0
+    ) + 1
+    query_count_file.write_text(str(query_count), encoding="utf-8")
+    if query_count >= int(os.environ["FAKE_PUSH_RUNS_AFTER_QUERY"]):
+        print(os.environ["FAKE_PUSH_RUNS"])
     sys.exit(int(os.environ["FAKE_RUN_QUERY_EXIT"]))
 if "/actions/runs/" in arguments and "/jobs" in arguments:
     run_id = arguments.split("/actions/runs/", maxsplit=1)[1].split("/", maxsplit=1)[0]
@@ -236,7 +329,13 @@ if "/actions/runs/" in arguments and "/jobs" in arguments:
         print("501")
     sys.exit(int(os.environ["FAKE_JOB_QUERY_EXIT"]))
 if "/actions/runs/" in arguments:
-    print(os.environ["FAKE_PUSH_RUN_IS_USABLE"])
+    run_id = arguments.split("/actions/runs/", maxsplit=1)[1].split()[0]
+    print(
+        f'{os.environ["FAKE_PUSH_RUN_STATUS"]}\t'
+        f'{os.environ["FAKE_PUSH_RUN_IS_USABLE"]}'
+    )
+    if run_id in os.environ["FAKE_PUSH_RUN_QUERY_FAIL_IDS"].split(","):
+        sys.exit(1)
     sys.exit(int(os.environ["FAKE_PUSH_RUN_QUERY_EXIT"]))
 
 print(f"unexpected gh invocation: {arguments}", file=sys.stderr)

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -190,6 +190,18 @@ class DuplicateEventRoutingTests(unittest.TestCase):
         self.assertEqual(result.gh_calls, [])
 
 
+class StaleRunCancellationTests(unittest.TestCase):
+    def test_stuck_stale_run_is_force_cancelled(self) -> None:
+        result = run_cancellation()
+
+        self.assertTrue(
+            any("actions/runs/101/cancel" in call for call in result.gh_calls)
+        )
+        self.assertTrue(
+            any("actions/runs/101/force-cancel" in call for call in result.gh_calls)
+        )
+
+
 class RouteResult:
     def __init__(
         self,
@@ -292,9 +304,61 @@ def run_route(
 
 
 def route_script() -> str:
+    return workflow_step_script("Route duplicate events")
+
+
+def run_cancellation() -> RouteResult:
+    script = workflow_step_script("Cancel older queued or running runs")
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+        fake_gh = bin_dir / "gh"
+        fake_gh.write_text(FAKE_CANCEL_GH, encoding="utf-8")
+        fake_gh.chmod(0o755)
+        fake_sleep = bin_dir / "sleep"
+        fake_sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake_sleep.chmod(0o755)
+
+        gh_log = temp_dir / "gh.log"
+        env = os.environ.copy()
+        env.update(
+            {
+                "CURRENT_RUN_NUMBER": "200",
+                "EVENT_NAME": "push",
+                "FAKE_GH_LOG": str(gh_log),
+                "GITHUB_REPOSITORY": "rcore-os/tgoskits",
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "PR_NUMBER": "",
+                "REF_NAME": "fix/qemu-forward-progress",
+            }
+        )
+        completed = subprocess.run(
+            ["bash", "-c", script],
+            cwd=WORKSPACE_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise AssertionError(
+                f"cancellation script failed with {completed.returncode}:\n"
+                f"{completed.stderr}"
+            )
+        return RouteResult(
+            "",
+            "",
+            completed.stdout,
+            completed.stderr,
+            gh_log.read_text(encoding="utf-8").splitlines(),
+        )
+
+
+def workflow_step_script(step_name: str) -> str:
     workflow = CI_WORKFLOW.read_text(encoding="utf-8")
-    route_step = named_step_block(workflow, "Route duplicate events")
-    lines = route_step.splitlines()
+    step = named_step_block(workflow, step_name)
+    lines = step.splitlines()
     run_index = next(
         index for index, line in enumerate(lines) if line.strip() == "run: |"
     )
@@ -337,6 +401,34 @@ if "/actions/runs/" in arguments:
     if run_id in os.environ["FAKE_PUSH_RUN_QUERY_FAIL_IDS"].split(","):
         sys.exit(1)
     sys.exit(int(os.environ["FAKE_PUSH_RUN_QUERY_EXIT"]))
+
+print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
+sys.exit(2)
+'''
+
+
+FAKE_CANCEL_GH = r'''#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+
+arguments = " ".join(sys.argv[1:])
+with Path(os.environ["FAKE_GH_LOG"]).open("a", encoding="utf-8") as log:
+    log.write(arguments + "\n")
+
+if "actions/workflows/ci.yml/runs?status=queued" in arguments:
+    print("101\t11975\thttps://example.test/push/101")
+    sys.exit(0)
+if "actions/workflows/ci.yml/runs?status=" in arguments:
+    sys.exit(0)
+if "actions/runs/101/force-cancel" in arguments:
+    sys.exit(0)
+if "actions/runs/101/cancel" in arguments:
+    sys.exit(0)
+if "actions/runs/101" in arguments:
+    print("queued")
+    sys.exit(0)
 
 print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
 sys.exit(2)

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from scripts.test.check_ci_routing import named_step_block
+
+
+WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
+CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
+
+
+class DuplicateEventRoutingTests(unittest.TestCase):
+    def test_push_event_always_runs_without_querying_pull_request_state(self) -> None:
+        result = run_route(event_name="push")
+
+        self.assertEqual(result.should_run, "true")
+        self.assertEqual(result.gh_calls, [])
+
+    def test_pull_request_skips_when_push_has_active_matrix(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs="101\t11975\thttps://example.test/push/101",
+            has_active_matrix="true",
+        )
+
+        self.assertEqual(result.should_run, "false")
+        self.assertIn("Duplicate pull request CI skipped", result.summary)
+        self.assertTrue(
+            any("actions/workflows/ci.yml/runs" in call for call in result.gh_calls)
+        )
+        self.assertTrue(
+            any("actions/runs/101/jobs" in call for call in result.gh_calls)
+        )
+
+    def test_plan_only_push_does_not_suppress_pull_request(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs="101\t11975\thttps://example.test/push/101",
+            has_active_matrix="false",
+        )
+
+        self.assertEqual(result.should_run, "true")
+
+    def test_later_active_push_suppresses_pull_request(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs=(
+                "101\t11975\thttps://example.test/push/101\n"
+                "202\t11976\thttps://example.test/push/202"
+            ),
+            active_matrix_run_ids="202",
+        )
+
+        self.assertEqual(result.should_run, "false")
+        self.assertTrue(any("actions/runs/101/jobs" in call for call in result.gh_calls))
+        self.assertTrue(any("actions/runs/202/jobs" in call for call in result.gh_calls))
+
+    def test_push_query_failure_runs_pull_request(self) -> None:
+        result = run_route(event_name="pull_request", run_query_exit="1")
+
+        self.assertEqual(result.should_run, "true")
+        self.assertIn("Failed to query matching branch push runs", result.stdout)
+
+    def test_push_job_query_failure_runs_pull_request(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs="101\t11975\thttps://example.test/push/101",
+            job_query_exit="1",
+        )
+
+        self.assertEqual(result.should_run, "true")
+        self.assertIn("Failed to inspect branch push run", result.stdout)
+
+    def test_push_cancelled_after_job_query_does_not_suppress_pull_request(
+        self,
+    ) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs="101\t11975\thttps://example.test/push/101",
+            has_active_matrix="true",
+            push_run_is_usable="false",
+        )
+
+        self.assertEqual(result.should_run, "true")
+        self.assertTrue(
+            any(
+                "actions/runs/101" in call and "/jobs" not in call
+                for call in result.gh_calls
+            )
+        )
+
+    def test_push_recheck_failure_runs_pull_request(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            push_runs="101\t11975\thttps://example.test/push/101",
+            has_active_matrix="true",
+            push_run_query_exit="1",
+        )
+
+        self.assertEqual(result.should_run, "true")
+        self.assertIn("Failed to recheck branch push run", result.stdout)
+
+    def test_fork_pull_request_runs_without_querying_base_pushes(self) -> None:
+        result = run_route(
+            event_name="pull_request",
+            head_repository="contributor/tgoskits",
+        )
+
+        self.assertEqual(result.should_run, "true")
+        self.assertEqual(result.gh_calls, [])
+
+
+class RouteResult:
+    def __init__(
+        self,
+        output: str,
+        summary: str,
+        stdout: str,
+        stderr: str,
+        gh_calls: list[str],
+    ):
+        self.output = output
+        self.summary = summary
+        self.stdout = stdout
+        self.stderr = stderr
+        self.gh_calls = gh_calls
+
+    @property
+    def should_run(self) -> str:
+        outputs = dict(line.split("=", maxsplit=1) for line in self.output.splitlines())
+        return outputs["should_run"]
+
+
+def run_route(
+    *,
+    event_name: str,
+    head_repository: str = "rcore-os/tgoskits",
+    push_runs: str = "",
+    has_active_matrix: str = "false",
+    active_matrix_run_ids: str = "",
+    push_run_is_usable: str = "true",
+    push_run_query_exit: str = "0",
+    run_query_exit: str = "0",
+    job_query_exit: str = "0",
+) -> RouteResult:
+    script = route_script()
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+        fake_gh = bin_dir / "gh"
+        fake_gh.write_text(FAKE_GH, encoding="utf-8")
+        fake_gh.chmod(0o755)
+
+        output_file = temp_dir / "output"
+        summary_file = temp_dir / "summary"
+        gh_log = temp_dir / "gh.log"
+        env = os.environ.copy()
+        env.update(
+            {
+                "EVENT_NAME": event_name,
+                "GITHUB_OUTPUT": str(output_file),
+                "GITHUB_REPOSITORY": "rcore-os/tgoskits",
+                "GITHUB_STEP_SUMMARY": str(summary_file),
+                "HEAD_REPOSITORY": head_repository,
+                "HEAD_SHA": "fc2a957ef330a39ef673d7364db1909fdbfe2821",
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "PR_HEAD_REF": "fix/qemu-forward-progress",
+                "FAKE_ACTIVE_MATRIX_RUN_IDS": active_matrix_run_ids,
+                "FAKE_GH_LOG": str(gh_log),
+                "FAKE_HAS_ACTIVE_MATRIX": has_active_matrix,
+                "FAKE_JOB_QUERY_EXIT": job_query_exit,
+                "FAKE_PUSH_RUNS": push_runs,
+                "FAKE_PUSH_RUN_IS_USABLE": push_run_is_usable,
+                "FAKE_PUSH_RUN_QUERY_EXIT": push_run_query_exit,
+                "FAKE_RUN_QUERY_EXIT": run_query_exit,
+            }
+        )
+        completed = subprocess.run(
+            ["bash", "-c", script],
+            cwd=WORKSPACE_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise AssertionError(
+                f"route script failed with {completed.returncode}:\n{completed.stderr}"
+            )
+        return RouteResult(
+            output_file.read_text(encoding="utf-8"),
+            summary_file.read_text(encoding="utf-8")
+            if summary_file.exists()
+            else "",
+            completed.stdout,
+            completed.stderr,
+            gh_log.read_text(encoding="utf-8").splitlines()
+            if gh_log.exists()
+            else [],
+        )
+
+
+def route_script() -> str:
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    route_step = named_step_block(workflow, "Route duplicate events")
+    lines = route_step.splitlines()
+    run_index = next(
+        index for index, line in enumerate(lines) if line.strip() == "run: |"
+    )
+    return textwrap.dedent("\n".join(lines[run_index + 1 :]))
+
+
+FAKE_GH = r'''#!/usr/bin/env python3
+import os
+import sys
+from pathlib import Path
+
+
+arguments = " ".join(sys.argv[1:])
+with Path(os.environ["FAKE_GH_LOG"]).open("a", encoding="utf-8") as log:
+    log.write(arguments + "\n")
+
+if "actions/workflows/ci.yml/runs" in arguments:
+    print(os.environ["FAKE_PUSH_RUNS"])
+    sys.exit(int(os.environ["FAKE_RUN_QUERY_EXIT"]))
+if "/actions/runs/" in arguments and "/jobs" in arguments:
+    run_id = arguments.split("/actions/runs/", maxsplit=1)[1].split("/", maxsplit=1)[0]
+    active_run_ids = os.environ["FAKE_ACTIVE_MATRIX_RUN_IDS"].split(",")
+    if run_id in active_run_ids or os.environ["FAKE_HAS_ACTIVE_MATRIX"] == "true":
+        print("501")
+    sys.exit(int(os.environ["FAKE_JOB_QUERY_EXIT"]))
+if "/actions/runs/" in arguments:
+    print(os.environ["FAKE_PUSH_RUN_IS_USABLE"])
+    sys.exit(int(os.environ["FAKE_PUSH_RUN_QUERY_EXIT"]))
+
+print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
+sys.exit(2)
+'''
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

PR #2137 暴露了同仓 CI 去重的状态语义问题：`pull_request` run 通过取消同一 head SHA 的 `push` run 去重，GitHub 会把这些正常去重产生的 `cancelled` checks 归入 failing checks。

也不能简单恢复为“有 PR 就跳过 push”。历史上 push 可能只完成 `Plan CI` 后跳过矩阵，pull_request 再复用这个 Plan-only run，最终两边都不执行测试。后续真实验证还发现：push 与 pull_request 的 Plan 几乎同时启动时，PR 可能在 push 矩阵 job 出现前 fail-open，造成同 SHA 两套矩阵同时执行；普通 cancel 也无法终止带 `always()` 下游组的旧 run。

## 修改

- 将同仓 branch `push` 作为对应 commit 的 canonical 验证；push 路由始终执行，不再根据 open PR 状态关闭。
- 同仓 `pull_request` 最多短暂重试 10 次以等待同 workflow、同 branch、同 head SHA 的 push run 可见。
- matching push 处于 `queued`、`in_progress`、`waiting` 或 `requested` 时，立即由 push 拥有验证，pull_request 后续 jobs 标记为 skipped，不再等待矩阵 materialize。
- matching push 已 `completed` 时，仍必须存在非 `Plan CI`、非 `skipped`/`cancelled` 的真实矩阵 job 才能复用，保留 Plan-only 双跳过防护。
- 未知状态、无 matching push、fork PR 或任一候选 run API 查询失败均 fail-open，由 pull_request 正常执行。
- runs 与 jobs 查询均分页；多个候选 run 的任一部分查询失败会优先否决复用。
- 旧 run 清理不受 `should_run` 门控：新 push 只取消同分支、同事件的旧 push，新 pull_request 只取消同 PR 的旧 pull_request，不跨事件取消当前 head。
- 旧 run 先普通 cancel，2 秒后仍未完成则调用 GitHub `force-cancel`，处理 `always()` 阻止普通取消的情况。
- `main` 和 `dev` push 不进入旧 run 清理，每个合入 commit 的完整 CI 都保留。
- 更新 CI 文档，并新增直接提取、执行 workflow 中 route/cancellation Bash 的确定性测试。

## 方案逻辑

同仓 push checks 会附着到相同 commit，因此 PR 可以复用它们。未完成的 matching push 由当前 workflow 的 canonical push 路由保证会继续验证；completed push 则必须用实际矩阵 job 证明不是历史 Plan-only 路径。这样既消除启动竞态造成的双跑，也不重新引入双方都 skipped。

所有不确定状态都选择执行 PR，而不是遗漏验证。PR 不取消当前 SHA push，因此正常去重在界面上表现为 pull_request jobs `skipped`，不会制造当前 head 的 cancelled/failing checks。

旧 run 的强制清理依据 GitHub 官方语义：普通 cancel 会重新计算 `always()` 并可能继续执行，`force-cancel` 用于普通 cancel 无响应的 run：

- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-cancellation
- https://docs.github.com/en/rest/actions/workflow-runs

fork PR 没有同仓 push 可复用，继续按原路径执行。`main`、`dev` 的矩阵规划不变，并明确保留每个 push commit 的完整 CI。

## 回归与验证

确定性红绿回归覆盖：

- push 不查询 PR 状态并始终执行；
- queued/in_progress/waiting/requested push 在矩阵出现前即可压制 PR；
- push run 第二次查询才可见时，PR 等待后复用；重试耗尽则执行 PR；
- completed Plan-only push、取消状态、未知状态均不压制 PR；
- fork PR 和各级 API 失败 fail-open；
- 多候选中任一 API 失败优先否决另一候选的复用；
- completed push 的实际矩阵证明按全部 jobs 分页检查；
- 普通分支只清理同事件旧 run，PR 不清理 push；
- normal cancel 后仍 queued 的旧 run 会 force-cancel；
- `main`、`dev` 不进入 stale-run cancellation。

本地验证：

- `python3 scripts/test/check_ci_routing.py`
- `uv run --python 3.11 python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py scripts/test/test_ci_routing.py`（51 tests）
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/ci.yml`
- `cargo fmt --all --check`
- `git diff --check`

## 真实同仓验证

最新 head `b522cd2d86` 同时触发：

- [push CI #11996](https://github.com/rcore-os/tgoskits/actions/runs/32456976598)：Plan 成功，两个 Preflight 独占执行；
- [pull_request CI #11997](https://github.com/rcore-os/tgoskits/actions/runs/32456980602)：completed/success，Plan 成功，Preflight、Workspace、ArceOS、Starry、AxVisor 全部 skipped；
- 当前 head 两个 run 的 cancelled job 数均为 0。

同一轮清理还将普通 cancel 后长期卡在 queued 的旧 push #11991、旧 pull_request #11992，以及上一 head push #11994，全部转为 completed/cancelled；已 completed/success 的旧 PR #11995 保留。

