### PR TITLE
fix(ax-task): consume external test deadlines in IRQ

### DIFF
--- a/os/arceos/modules/axtask/tests/axtest.rs
+++ b/os/arceos/modules/axtask/tests/axtest.rs
@@ -311,17 +311,32 @@ fn irq_notify_coalesces_runtime_task_callbacks() {
 }
 
 #[axtest]
-fn external_deadline_participates_in_timer_selection() {
+fn external_deadline_is_consumed_after_its_timer_irq() {
     const NO_DEADLINE: u64 = u64::MAX;
-    let external_deadline = Arc::new(AtomicU64::new(1));
+    let external_deadline = Arc::new(AtomicU64::new(NO_DEADLINE));
+    let deadline_for_irq = Arc::clone(&external_deadline);
+    ax_task::register_timer_irq_callback(move |now| {
+        let deadline = deadline_for_irq.load(Ordering::Acquire);
+        if deadline != NO_DEADLINE && now.as_nanos() >= deadline as u128 {
+            deadline_for_irq.store(NO_DEADLINE, Ordering::Release);
+        }
+    });
     let published_deadline = Arc::clone(&external_deadline);
     ax_task::register_timer_deadline_source(move || {
         let deadline = published_deadline.load(Ordering::Acquire);
         (deadline != NO_DEADLINE).then_some(deadline)
     });
 
-    ax_assert_eq!(ax_task::next_timer_deadline_nanos(), Some(1));
-    external_deadline.store(NO_DEADLINE, Ordering::Release);
+    let deadline = ax_hal::time::monotonic_time() + core::time::Duration::from_millis(10);
+    let deadline_nanos = deadline.as_nanos().min(u64::MAX as u128) as u64;
+    external_deadline.store(deadline_nanos, Ordering::Release);
+    ax_assert!(
+        ax_task::next_timer_deadline_nanos().is_some_and(|selected| selected <= deadline_nanos)
+    );
+    ax_task::request_timer_deadline_nanos(deadline_nanos);
+    while external_deadline.load(Ordering::Acquire) != NO_DEADLINE {
+        ax_task::yield_now();
+    }
 }
 
 #[axtest]


### PR DESCRIPTION
## 问题与根因

PR #2139 合并最新 `dev@0340ed6bf` 后，canonical CI run 32463069458 的 `ArceOS / QEMU aarch64 · GICv2 SMP4 boot + suites + axtest` 在 ax-task axtest 超时：

```text
# START axtest::external_deadline_participates_in_timer_selection
# module: axtest
[axtest] failed ... QEMU timed out after 60s
```

QEMU 已完整启动，前 10 个 axtest 均通过；停顿发生在该测试自身。旧测试注册 external deadline source 后永久发布绝对值 `1ns`，并计划在同步断言后由测试线程清除。若 timer IRQ 在清除前到达，IRQ 尾部会再次选择同一个已过期 external deadline，硬件 comparator 立即重触发；source 没有 IRQ 消费逻辑，测试线程因而无法恢复到清除语句。

这不是 AArch64 启动、GIC 或 #2137 周期 deadline catch-up 的确定性回归。相同旧代码在本地和 #2137 CI 可以通过，说明是否抢在 IRQ 前清除取决于时序。

## 修改与逻辑

- 将 external deadline 初始化为“无 deadline”。
- 注册 timer IRQ callback，仅在到达已发布 deadline 后将 source 恢复为无 deadline。
- 测试发布当前单调时钟之后 10ms 的真实未来 deadline，验证它参与最小值选择。
- 通过既有 `request_timer_deadline_nanos` 请求 comparator，并等待 IRQ callback 完成消费。

这样测试覆盖完整的 external deadline 生命周期：发布、选择、硬件请求、IRQ 消费和清除；不修改 timer runtime、timeout、QEMU 配置或生产 API。

## Red / Green

Red 为 PR #2139 当前 head 的 canonical CI：旧测试在打印 `START` 后 60 秒无进展并超时。该缺陷是竞态，本地旧实现也可能通过，因此不把偶然本地 green 当作否定证据。

Green：

- `cargo xtask ktest qemu -p ax-task --arch aarch64`：连续两次 16/16，通过；修正用例均到达 `AXTEST_CASE status=pass`。
- `cargo xtask ktest qemu -p ax-task --arch riscv64 --config test-suit/arceos/rust/build-riscv64gc-unknown-none-elf.toml`：16/16，通过。

## 其他验证

- `cargo xtask clippy --package ax-task`：66/66 通过。
- `cargo fmt --all --check`：通过。
- `git diff --check`：通过。

## 重叠说明

开放 PR #2130 同时包含相同的 ax-task 测试修正和独立的 StarryOS exec/page-table 根生命周期改动。本 PR 只提取已导致 dev 下游 PR CI 失败的一文件测试生命周期修正，不复制 #2130 的 Starry 生产代码；本 PR 合入后，#2130 可在同步最新 dev 时删除这处重复 diff。