### PR TITLE
fix(ci): treat Cargo.lock as a soft impact input

### DIFF
--- a/scripts/test/ci_impact.py
+++ b/scripts/test/ci_impact.py
@@ -23,10 +23,10 @@ ARCEOS_KTEST_EXCLUDED_PACKAGES = {"starry-kernel", "axvisor"}
 
 FULL_PATHS = {
     Path("Cargo.toml"),
-    Path("Cargo.lock"),
     Path("rust-toolchain"),
     Path("rust-toolchain.toml"),
 }
+SOFT_GLOBAL_PATHS = {Path("Cargo.lock")}
 FULL_PREFIXES = (
     Path(".cargo"),
     Path(".github/ci"),
@@ -138,7 +138,15 @@ def analyze_pull_request(workspace_root: Path, since_ref: str) -> CiImpact:
                 ignored_markdown=tuple(sorted(ignored_markdown)),
                 ignored_apps=tuple(sorted(ignored_apps)),
             )
-        full_reason = _pre_metadata_full_reason(workspace_root, relevant)
+        soft_global_inputs, impact_paths = _partition_soft_global_inputs(relevant)
+        if not impact_paths:
+            return CiImpact.full_selection(
+                _soft_only_full_reason(soft_global_inputs),
+                changed_paths,
+                ignored_markdown=ignored_markdown,
+                ignored_apps=ignored_apps,
+            )
+        full_reason = _pre_metadata_full_reason(workspace_root, impact_paths)
         if full_reason is not None:
             return CiImpact.full_selection(
                 full_reason,
@@ -148,7 +156,7 @@ def analyze_pull_request(workspace_root: Path, since_ref: str) -> CiImpact:
             )
         metadata_by_arch = (
             {}
-            if all(_is_known_input_path(path) for path in relevant)
+            if all(_is_known_input_path(path) for path in impact_paths)
             else load_metadata_by_arch(workspace_root)
         )
         return analyze_changed_paths(workspace_root, changed_paths, metadata_by_arch)
@@ -227,8 +235,17 @@ def analyze_changed_paths(
     workspace_root = workspace_root.resolve()
     paths = sorted({_normalize_relative_path(path) for path in changed_paths})
     ignored_markdown, ignored_apps, relevant_paths = _partition_ignored(paths)
+    soft_global_inputs, impact_paths = _partition_soft_global_inputs(relevant_paths)
 
-    full_reason = _pre_metadata_full_reason(workspace_root, relevant_paths)
+    if soft_global_inputs and not impact_paths:
+        return CiImpact.full_selection(
+            _soft_only_full_reason(soft_global_inputs),
+            paths,
+            ignored_markdown=ignored_markdown,
+            ignored_apps=ignored_apps,
+        )
+
+    full_reason = _pre_metadata_full_reason(workspace_root, impact_paths)
     if full_reason is not None:
         return CiImpact.full_selection(
             full_reason,
@@ -245,7 +262,7 @@ def analyze_changed_paths(
         package_paths: list[Path] = []
         unknown_paths: list[Path] = []
 
-        for path in relevant_paths:
+        for path in impact_paths:
             if _test_suite_os(path) is not None:
                 test_suite_paths.add(path.as_posix())
                 continue
@@ -308,7 +325,7 @@ def analyze_changed_paths(
 
         return CiImpact(
             full=False,
-            reason="pull request impact resolved",
+            reason=_resolved_impact_reason(soft_global_inputs),
             changed_paths=_sorted_path_strings(paths),
             ignored_markdown=tuple(sorted(ignored_markdown)),
             ignored_apps=tuple(sorted(ignored_apps)),
@@ -320,7 +337,7 @@ def analyze_changed_paths(
             input_selections=tuple(sorted(input_selections)),
             test_suite_paths=tuple(sorted(test_suite_paths)),
             exclusive=bool(test_suite_paths)
-            and len(test_suite_paths) == len(relevant_paths),
+            and len(test_suite_paths) == len(impact_paths),
             targets=tuple(sorted(targets, key=_target_sort_key)),
         )
     except (KeyError, TypeError, ValueError) as error:
@@ -378,6 +395,34 @@ def _partition_ignored(
         else:
             relevant.append(path)
     return ignored_markdown, ignored_apps, relevant
+
+
+def _partition_soft_global_inputs(
+    changed_paths: Iterable[Path],
+) -> tuple[list[Path], list[Path]]:
+    soft_global_inputs = []
+    impact_paths = []
+    for path in changed_paths:
+        if path in SOFT_GLOBAL_PATHS:
+            soft_global_inputs.append(path)
+        else:
+            impact_paths.append(path)
+    return soft_global_inputs, impact_paths
+
+
+def _soft_only_full_reason(soft_global_inputs: Sequence[Path]) -> str:
+    rendered = ", ".join(f"`{path.as_posix()}`" for path in soft_global_inputs)
+    return f"only soft global input {rendered} changed"
+
+
+def _resolved_impact_reason(soft_global_inputs: Sequence[Path]) -> str:
+    if not soft_global_inputs:
+        return "pull request impact resolved"
+    rendered = ", ".join(f"`{path.as_posix()}`" for path in soft_global_inputs)
+    return (
+        "pull request impact resolved; "
+        f"soft global input {rendered} did not expand selection"
+    )
 
 
 def _requires_full_matrix(path: Path) -> bool:

--- a/scripts/test/test_ci_impact.py
+++ b/scripts/test/test_ci_impact.py
@@ -316,6 +316,111 @@ class CiImpactTests(unittest.TestCase):
         self.assertTrue(impact.full)
         load_metadata.assert_not_called()
 
+    def test_cargo_lock_does_not_expand_a_resolved_package_change(self) -> None:
+        ci_owned_manifest = (
+            self.workspace_root / "apps/arceos/virtio-blk-test/Cargo.toml"
+        )
+        ci_owned_manifest.parent.mkdir(parents=True, exist_ok=True)
+        ci_owned_manifest.write_text("[package]\n", encoding="utf-8")
+
+        with (
+            mock.patch.object(
+                ci_impact,
+                "changed_paths_since",
+                return_value=[
+                    Path("Cargo.lock"),
+                    Path("apps/arceos/virtio-blk-test/Cargo.toml"),
+                    Path("virtualization/arm-vcpu/src/lib.rs"),
+                ],
+            ),
+            mock.patch.object(
+                ci_impact,
+                "load_metadata_by_arch",
+                return_value=self.metadata_by_arch,
+            ) as load_metadata,
+        ):
+            impact = ci_impact.analyze_pull_request(self.workspace_root, "base")
+
+        self.assertFalse(impact.full)
+        self.assertEqual(impact.changed_packages, ("arm-vcpu",))
+        self.assertEqual(impact.affected_oses, ("axvisor",))
+        self.assertEqual(
+            impact.input_selections,
+            ("axvisor:qemu:aarch64",),
+        )
+        self.assertNotIn("starry:aarch64", impact.targets)
+        load_metadata.assert_called_once_with(self.workspace_root)
+
+    def test_cargo_lock_only_still_falls_back_to_full(self) -> None:
+        with (
+            mock.patch.object(
+                ci_impact,
+                "changed_paths_since",
+                return_value=[Path("Cargo.lock")],
+            ),
+            mock.patch.object(ci_impact, "load_metadata_by_arch") as load_metadata,
+        ):
+            impact = ci_impact.analyze_pull_request(self.workspace_root, "base")
+
+        self.assertTrue(impact.full)
+        self.assertIn("Cargo.lock", impact.reason)
+        load_metadata.assert_not_called()
+
+    def test_cargo_lock_does_not_break_exclusive_test_suite_routing(self) -> None:
+        impact = ci_impact.analyze_changed_paths(
+            self.workspace_root,
+            [
+                Path("Cargo.lock"),
+                Path("test-suit/starryos/qemu/system/qemu-aarch64.toml"),
+            ],
+            {},
+        )
+
+        self.assertFalse(impact.full)
+        self.assertTrue(impact.exclusive)
+        self.assertEqual(
+            impact.test_suite_paths,
+            ("test-suit/starryos/qemu/system/qemu-aarch64.toml",),
+        )
+
+    def test_cargo_lock_with_precise_input_skips_metadata_loading(self) -> None:
+        with (
+            mock.patch.object(
+                ci_impact,
+                "changed_paths_since",
+                return_value=[
+                    Path("Cargo.lock"),
+                    Path("os/axvisor/configs/qemu/aarch64.toml"),
+                ],
+            ),
+            mock.patch.object(ci_impact, "load_metadata_by_arch") as load_metadata,
+        ):
+            impact = ci_impact.analyze_pull_request(self.workspace_root, "base")
+
+        self.assertFalse(impact.full)
+        self.assertEqual(
+            impact.input_selections,
+            ("axvisor:qemu:aarch64",),
+        )
+        load_metadata.assert_not_called()
+
+    def test_cargo_lock_with_only_ignored_paths_still_falls_back_to_full(
+        self,
+    ) -> None:
+        with (
+            mock.patch.object(
+                ci_impact,
+                "changed_paths_since",
+                return_value=[Path("Cargo.lock"), Path("README.md")],
+            ),
+            mock.patch.object(ci_impact, "load_metadata_by_arch") as load_metadata,
+        ):
+            impact = ci_impact.analyze_pull_request(self.workspace_root, "base")
+
+        self.assertTrue(impact.full)
+        self.assertEqual(impact.ignored_markdown, ("README.md",))
+        load_metadata.assert_not_called()
+
     def test_summary_reports_selected_and_skipped_checks(self) -> None:
         impact = ci_impact.CiImpact(
             full=False,
@@ -343,7 +448,6 @@ class CiImpactTests(unittest.TestCase):
         for changed_path in (
             "unknown/input.bin",
             "Cargo.toml",
-            "Cargo.lock",
             ".cargo/config.toml",
             "scripts/axbuild/src/lib.rs",
             "scripts/test/ci_plan.py",


### PR DESCRIPTION
## 问题

PR #2138 同时修改了 AxVM/AxVisor 相关包和根 `Cargo.lock`。CI 影响分析器把 `Cargo.lock` 视为硬全局输入，在解析 workspace 包影响前直接回退到完整矩阵，因而无关触发全部 Starry、ArceOS 与 AxVisor 测试。

## 修改

- 将根 `Cargo.lock` 从硬全局输入调整为 soft global input。
- 当锁文件伴随可解析的 workspace 包、精确 CI 输入或 test-suite 路径变化时，仅按这些真实输入计算反向依赖和测试矩阵；锁文件仍保留在变更摘要中，但不扩大选择范围。
- 当只有 `Cargo.lock`（或仅伴随被忽略的 Markdown/app 路径）变化时，继续保守回退到完整矩阵，并跳过无意义的 metadata 加载。
- 保持根 `Cargo.toml`、工具链、CI 配置、未知路径、删除的 package manifest 及 metadata 失败等不确定场景的完整回退行为。
- 让 soft input 不影响 test-suite 的 exclusive 精确路由。

## 设计与替代方案

继续对所有 `Cargo.lock` 变化执行完整矩阵最保守，但会让已有明确包变更的 PR 丧失增量选择价值。完整解析 base/head lockfile 并映射所有外部依赖消费者更精确，但复杂度和不确定性明显更高。

本修改选择较小且安全的边界：已有真实输入时复用现有 workspace metadata 反向依赖闭包；没有其他真实输入时仍全量回退。因此既修复 #2138 的无关 Starry 测试，也不会把 lock-only 更新误判为无需测试。

## 回归与验证

- 先添加入口级回归，确认旧实现会在 `Cargo.lock + AxVisor package/input` 场景因 `impact.full == true` 确定性失败。
- `uv run --python 3.11 python -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py scripts/test/test_ci_routing.py`：56 项通过。
- `python3 scripts/test/check_ci_routing.py`：通过。
- `cargo xtask clippy --package axbuild`：通过。
- `cargo fmt --all --check`：通过。
- `git diff --check`：通过。

使用修复后的 planner 分析 PR #2138 的真实 head/base diff，结果为：

- Mode：`incremental`
- Changed packages：`axdevice`、`axvisor`、`axvm`、`virtualization-tests`
- Affected OSes：仅 `axvisor`
- ArceOS matrix：0
- Starry matrix：0
- AxVisor matrix：16
