### PR TITLE
fix(ci): isolate protected branch queues

### DIFF
--- a/.github/workflows/ci-pr-cleanup.yml
+++ b/.github/workflows/ci-pr-cleanup.yml
@@ -1,0 +1,95 @@
+name: CI PR Cleanup
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  cancel_stale_ci:
+    name: Cancel stale PR CI
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PR_EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Cancel older queued or running runs
+        run: |
+          set -euo pipefail
+
+          current_head="$({
+            gh api \
+              --method GET \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" \
+              --jq '[.head.sha, .head.ref, .head.repo.id] | @tsv'
+          })"
+          IFS=$'\t' read -r PR_HEAD_SHA PR_HEAD_REF PR_HEAD_REPOSITORY_ID \
+            <<< "$current_head"
+          export PR_HEAD_SHA PR_HEAD_REF PR_HEAD_REPOSITORY_ID
+
+          # A delayed synchronize event must not cancel a newer PR head.
+          if [ "$PR_EVENT_HEAD_SHA" != "$PR_HEAD_SHA" ]; then
+            echo "Skipping stale cleanup event for ${PR_EVENT_HEAD_SHA}; current head is ${PR_HEAD_SHA}."
+            exit 0
+          fi
+
+          selector='select(
+            .event == "pull_request"
+            and .head_sha != env.PR_HEAD_SHA
+            and (
+              any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
+              or (
+                (.pull_requests | length) == 0
+                and env.PR_HEAD_REF != ""
+                and env.PR_HEAD_REPOSITORY_ID != ""
+                and .head_branch == env.PR_HEAD_REF
+                and .head_repository.id == (env.PR_HEAD_REPOSITORY_ID | tonumber)
+              )
+            )
+          )'
+
+          stale_runs="$(
+            for status in queued in_progress waiting requested; do
+              gh api \
+                --method GET \
+                --paginate \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+                -f event=pull_request \
+                -f branch="$PR_HEAD_REF" \
+                -f status="$status" \
+                -f per_page=100 \
+                --jq ".workflow_runs[] | ${selector} | [.id, .run_number, .html_url] | @tsv"
+            done | sort -u
+          )"
+
+          while IFS=$'\t' read -r run_id run_number run_url; do
+            if [ -z "$run_id" ]; then
+              continue
+            fi
+            if ! gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/cancel" >/dev/null; then
+              echo "::warning::Failed to cancel stale CI run #${run_number}: ${run_url}"
+            fi
+
+            sleep 2
+            run_status="$(
+              gh api \
+                --method GET \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}" \
+                --jq '.status'
+            )"
+            if [ "$run_status" != "completed" ] && ! gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/force-cancel" >/dev/null; then
+              echo "::warning::Failed to force-cancel stale CI run #${run_number}: ${run_url}"
+            fi
+          done <<< "$stale_runs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,8 @@ jobs:
         if: >-
           (github.event_name == 'pull_request' &&
            github.event.pull_request.head.repo.full_name == github.repository) ||
-          (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
+          (github.event_name != 'pull_request' &&
+           github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         env:
           GH_TOKEN: ${{ github.token }}
           CURRENT_RUN_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,8 @@ jobs:
 
       - name: Cancel older queued or running runs
         if: >-
-          github.event_name == 'pull_request' ||
+          (github.event_name == 'pull_request' &&
+           github.event.pull_request.head.repo.full_name == github.repository) ||
           (github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev')
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ env:
 concurrency:
   group: >-
     ${{
-      github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
+      github.event_name != 'pull_request'
+      && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev')
       && format('ci-{0}-{1}', github.workflow, github.ref)
       || format('ci-{0}-{1}', github.workflow, github.run_id)
     }}
@@ -212,6 +213,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CURRENT_RUN_NUMBER: ${{ github.run_number }}
           EVENT_NAME: ${{ github.event_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}
+          PR_HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || '' }}
           REF_NAME: ${{ github.ref_name }}
           PR_NUMBER: ${{ github.event.pull_request.number || '' }}
         run: |
@@ -223,7 +226,16 @@ jobs:
             selector='select(
               .run_number < (env.CURRENT_RUN_NUMBER | tonumber)
               and .event == "pull_request"
-              and any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
+              and (
+                any(.pull_requests[]?; .number == (env.PR_NUMBER | tonumber))
+                or (
+                  (.pull_requests | length) == 0
+                  and env.PR_HEAD_REF != ""
+                  and env.PR_HEAD_REPOSITORY_ID != ""
+                  and .head_branch == env.PR_HEAD_REF
+                  and .head_repository.id == (env.PR_HEAD_REPOSITORY_ID | tonumber)
+                )
+              )
             )'
           else
             selector='select(

--- a/.github/workflows/reusable-check-matrix.yml
+++ b/.github/workflows/reusable-check-matrix.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: boolean
         default: true
+      max_parallel:
+        description: Maximum number of matrix entries that may run concurrently.
+        required: false
+        type: number
+        default: 256
       save_cache:
         description: Allow rust-cache to save updated entries.
         required: false
@@ -31,6 +36,7 @@ jobs:
     name: ${{ matrix.name }}
     strategy:
       fail-fast: ${{ inputs.fail_fast }}
+      max-parallel: ${{ inputs.max_parallel }}
       matrix: ${{ fromJSON(inputs.matrix_json) }}
     runs-on: ${{ matrix.runs_on }}
     timeout-minutes: ${{ matrix.timeout_minutes }}

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -62,7 +62,8 @@ AxVisor / <platform> <arch-or-board> · <purpose>
 ```
 
 `Workspace`、`ArceOS`、`Starry` 和 `AxVisor` 都在 `Preflight` 成功或按计划跳过
-后启动。每个名称都是一个可展开的 reusable workflow 分组，平台写在架构之前，例如：
+后启动；这个门禁不会在四个后续分组之间建立先后顺序。每个名称都是一个可展开的
+reusable workflow 分组，平台写在架构之前，例如：
 
 ```text
 Preflight / Formatting + publish dry-run
@@ -165,7 +166,9 @@ self-hosted 检查的 `cache_key` 必须为空；省略时默认就是空字符�
 `reusable-check-matrix.yml` 只包含一个 matrix job。planner 分别输出
 `workspace_matrix`、`arceos_matrix`、`starry_matrix` 和 `axvisor_matrix`，顶层同名
 caller 分别调用该执行器，从而在 Actions 左栏形成可展开分组。每个分组内部保留
-fail-fast；一个分组失败不会取消其他分组。矩阵行仍包含完全展开的 runner labels、
+fail-fast，并显式允许最多 256 个矩阵项并行；因此 Preflight 门禁通过后，同一分组内
+所有匹配 self-hosted runner 的行都会同时参与调度，一个分组失败不会取消其他分组。
+实际开始时间仍取决于匹配标签的 runner 容量。矩阵行仍包含完全展开的 runner labels、
 container image、preflight、cache、checkout depth、timeout、artifact 和命令字段。
 
 普通完整/增量运行中，sync-lint 生成 `tg-xtask-bin` artifact，使用容器的测试行可

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -13,7 +13,14 @@ sidebar_label: "自动 CI 测试"
 - `scripts/test/ci_plan.py` 展开配置并生成矩阵；
 - `.github/workflows/reusable-check-matrix.yml` 执行展开后的矩阵行。
 
-容器发布由 `.github/workflows/container-publish.yml` 独立处理。同仓分支 push 是
+容器发布由 `.github/workflows/container-publish.yml` 独立处理。`main` 和 `dev`
+各自使用按 ref 隔离的 FIFO concurrency group，同一分支的每个非 PR run 都会保留并
+轮流执行，两条分支之间不会互相排队。pull request、普通分支和其他事件使用按 run ID
+隔离的 group，不进入 `main` 或 `dev` 的 workflow 队列；不同 PR 也不会在 workflow
+层面互相排队。该隔离不划分 runner 容量，所有 run 仍共享现有 self-hosted runner，
+匹配标签的 runner 繁忙时 job 会继续保持 queued。
+
+同仓分支 push 是
 对应 head commit 的首选验证；pull request 准备阶段会短暂重试尚未可见的同 SHA push
 run。匹配的 push 仍在 queued 或 in_progress 时，它已经拥有该 commit 的验证，pull
 request 将自己的后续矩阵标记为 skipped；push 已 completed 时，仍必须存在非 Plan、
@@ -22,17 +29,20 @@ request 将自己的后续矩阵标记为 skipped；push 已 completed 时，仍
 Plan-only push 或已取消的 push 都会 fail-open，由 pull request 正常规划并执行。
 
 pull request 不会取消当前 SHA 的 push，因此 GitHub 不会把正常去重显示为
-failing/cancelled checks。pull request run 仍只取消同一 PR 的旧 pull request run，
-即使本次矩阵复用 push 而 skipped，也会清理旧 commit 尚未完成的 pull request run；
+failing/cancelled checks。pull request run 仍只取消同一 PR 的旧 pull request run；
+GitHub API 未给 fork run 返回 PR 关联时，清理逻辑使用稳定的 head repository ID 和
+head branch 精确匹配。即使本次矩阵复用 push 而 skipped，也会清理旧 commit 尚未
+完成的 pull request run；
 新 commit 的 push 同样会取消同一分支的旧 push run。`main` 和 `dev` 是例外：每个
-push commit 的 CI 都完整保留，后续提交不会取消仍在运行的旧 CI。旧 run 先收到普通
-cancel；短暂复查仍未完成时再 force-cancel，避免分组 job 的 `always()` 条件阻止清理。
+commit 的 CI 都完整保留，并在各自分支队列中轮流执行；后续提交不会取消仍在运行或
+排队的旧 CI。旧 run 先收到普通 cancel；短暂复查仍未完成时再 force-cancel，避免分组
+job 的 `always()` 条件阻止清理。
 
 ## 触发条件
 
 | 事件 | 行为 |
 |------|------|
-| push 到 `main` / `dev` | 非文档变更运行完整矩阵，并保留每个 commit 的完整 CI |
+| push 到 `main` / `dev` | 非文档变更运行完整矩阵；两条分支分别 FIFO，并保留每个 commit 的完整 CI |
 | 其他分支 push | 非文档变更运行完整矩阵，作为同仓 PR 的首选验证 |
 | 首次创建 pull request | 同 SHA push 已拥有验证时跳过，否则按三点 diff 规划 |
 | 更新或重开 pull request | 取消旧 commit 的同事件 run；同 SHA push 已拥有验证时跳过，否则按三点 diff 规划 |

--- a/docs/docs/build/ci.md
+++ b/docs/docs/build/ci.md
@@ -30,9 +30,11 @@ Plan-only push 或已取消的 push 都会 fail-open，由 pull request 正常�
 
 pull request 不会取消当前 SHA 的 push，因此 GitHub 不会把正常去重显示为
 failing/cancelled checks。pull request run 仍只取消同一 PR 的旧 pull request run；
-GitHub API 未给 fork run 返回 PR 关联时，清理逻辑使用稳定的 head repository ID 和
-head branch 精确匹配。即使本次矩阵复用 push 而 skipped，也会清理旧 commit 尚未
-完成的 pull request run；
+同仓 PR 可由主 CI 直接清理，fork PR 则由不 checkout 代码的 `CI PR Cleanup`
+`pull_request_target` workflow 使用 Actions write token 清理。该 workflow 会先重新
+读取 PR 当前 head，忽略延迟到达的旧 synchronize 事件。GitHub API 未给 fork run
+返回 PR 关联时，清理逻辑使用稳定的 head repository ID 和 head branch 精确匹配。
+即使本次矩阵复用 push 而 skipped，也会清理旧 commit 尚未完成的 pull request run；
 新 commit 的 push 同样会取消同一分支的旧 push run。`main` 和 `dev` 是例外：每个
 commit 的 CI 都完整保留，并在各自分支队列中轮流执行；后续提交不会取消仍在运行或
 排队的旧 CI。旧 run 先收到普通 cancel；短暂复查仍未完成时再 force-cancel，避免分组

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -28,6 +28,31 @@ def main() -> int:
     if mapping_block(ci_push, "branches", 4):
         errors.append("main CI push trigger must accept every branch")
 
+    concurrency = mapping_block(ci_workflow, "concurrency", 0)
+    for protected_ref in ("main", "dev"):
+        require_contains(
+            errors,
+            concurrency,
+            f"github.ref == 'refs/heads/{protected_ref}'",
+            f"{protected_ref} CI runs must use a stable per-ref concurrency group",
+        )
+    for fragment, message in (
+        (
+            "github.event_name != 'pull_request'",
+            "pull request runs must not enter main or dev concurrency queues",
+        ),
+        (
+            "format('ci-{0}-{1}', github.workflow, github.ref)",
+            "main and dev CI queues must be isolated by ref",
+        ),
+        (
+            "format('ci-{0}-{1}', github.workflow, github.run_id)",
+            "non-protected runs must use unique concurrency groups",
+        ),
+        ("queue: max", "main and dev CI queues must preserve every commit"),
+    ):
+        require_contains(errors, concurrency, fragment, message)
+
     pull_request_paths = list_items_in_order(pull_request, "paths", 4)
     if not pull_request_paths or pull_request_paths[-1] != "!**/*.md":
         errors.append("the Markdown exclusion must be the final pull_request path rule")
@@ -213,12 +238,43 @@ def main() -> int:
     else:
         for fragment, message in (
             (
+                "PR_HEAD_REF: ${{ github.event.pull_request.head.ref || '' }}",
+                "PR cleanup must receive the pull request head branch",
+            ),
+            (
+                "PR_HEAD_REPOSITORY_ID: ${{ github.event.pull_request.head.repo.id || '' }}",
+                "PR cleanup must receive the pull request head repository ID",
+            ),
+        ):
+            require_contains(errors, cancel_step, fragment, message)
+        for fragment, message in (
+            (
                 '.event == "pull_request"',
                 "PR cleanup must only select pull request runs",
             ),
             (
                 ".pull_requests[]?",
                 "PR cleanup must select runs for the same pull request",
+            ),
+            (
+                "(.pull_requests | length) == 0",
+                "PR cleanup must detect runs without pull request links",
+            ),
+            (
+                'env.PR_HEAD_REF != ""',
+                "fork PR cleanup must reject an empty head branch",
+            ),
+            (
+                'env.PR_HEAD_REPOSITORY_ID != ""',
+                "fork PR cleanup must reject an empty head repository ID",
+            ),
+            (
+                ".head_branch == env.PR_HEAD_REF",
+                "fork PR cleanup must match the head branch",
+            ),
+            (
+                ".head_repository.id == (env.PR_HEAD_REPOSITORY_ID | tonumber)",
+                "fork PR cleanup must match the stable head repository ID",
             ),
         ):
             require_contains(errors, pull_request_selector, fragment, message)

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -7,6 +7,9 @@ from pathlib import Path
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 WORKSPACE_MANIFEST = WORKSPACE_ROOT / "Cargo.toml"
 CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
+REUSABLE_CHECK_MATRIX = (
+    WORKSPACE_ROOT / ".github/workflows/reusable-check-matrix.yml"
+)
 LEGACY_BRANCH_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci-branch-push.yml"
 
 
@@ -14,12 +17,17 @@ def main() -> int:
     errors: list[str] = []
     if not CI_WORKFLOW.is_file():
         errors.append("missing workflow: .github/workflows/ci.yml")
+    if not REUSABLE_CHECK_MATRIX.is_file():
+        errors.append(
+            "missing workflow: .github/workflows/reusable-check-matrix.yml"
+        )
     if LEGACY_BRANCH_WORKFLOW.exists():
         errors.append("branch push routing must be part of ci.yml")
     if errors:
         return report(errors)
 
     ci_workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+    reusable_check_matrix = REUSABLE_CHECK_MATRIX.read_text(encoding="utf-8")
     ci_triggers = mapping_block(ci_workflow, "on", 0)
     ci_push = mapping_block(ci_triggers, "push", 2)
     pull_request = mapping_block(ci_triggers, "pull_request", 2)
@@ -363,6 +371,24 @@ def main() -> int:
                 f"steps.matrix.outputs.{output_prefix}_{output_name}",
                 f"Plan CI must publish {output_prefix}_{output_name}",
             )
+
+    max_parallel_input = mapping_block(
+        reusable_check_matrix,
+        "max_parallel",
+        6,
+    )
+    for fragment, message in (
+        ("type: number", "matrix parallelism must use a numeric limit"),
+        ("default: 256", "matrix entries must not be serialized by default"),
+    ):
+        require_contains(errors, max_parallel_input, fragment, message)
+    strategy = mapping_block(reusable_check_matrix, "strategy", 4)
+    require_contains(
+        errors,
+        strategy,
+        "max-parallel: ${{ inputs.max_parallel }}",
+        "the reusable matrix must honor its parallelism limit",
+    )
 
     return report(errors)
 

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -246,6 +246,12 @@ def main() -> int:
         "github.event.pull_request.head.repo.full_name == github.repository",
         "fork PR cleanup must use the trusted pull_request_target workflow",
     )
+    require_contains(
+        errors,
+        cancel_step,
+        "github.event_name != 'pull_request'",
+        "the non-protected ref branch must not re-enable fork PR cleanup",
+    )
 
     pull_request_selector, push_selector = shell_if_else_branches(
         ci_workflow,

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -10,6 +10,7 @@ CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
 REUSABLE_CHECK_MATRIX = (
     WORKSPACE_ROOT / ".github/workflows/reusable-check-matrix.yml"
 )
+PR_CLEANUP_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci-pr-cleanup.yml"
 LEGACY_BRANCH_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci-branch-push.yml"
 
 
@@ -21,6 +22,8 @@ def main() -> int:
         errors.append(
             "missing workflow: .github/workflows/reusable-check-matrix.yml"
         )
+    if not PR_CLEANUP_WORKFLOW.is_file():
+        errors.append("missing workflow: .github/workflows/ci-pr-cleanup.yml")
     if LEGACY_BRANCH_WORKFLOW.exists():
         errors.append("branch push routing must be part of ci.yml")
     if errors:
@@ -28,6 +31,7 @@ def main() -> int:
 
     ci_workflow = CI_WORKFLOW.read_text(encoding="utf-8")
     reusable_check_matrix = REUSABLE_CHECK_MATRIX.read_text(encoding="utf-8")
+    pr_cleanup_workflow = PR_CLEANUP_WORKFLOW.read_text(encoding="utf-8")
     ci_triggers = mapping_block(ci_workflow, "on", 0)
     ci_push = mapping_block(ci_triggers, "push", 2)
     pull_request = mapping_block(ci_triggers, "pull_request", 2)
@@ -236,6 +240,12 @@ def main() -> int:
         errors.append(
             "stale-run cleanup must force-cancel runs that ignore normal cancellation"
         )
+    require_contains(
+        errors,
+        cancel_step,
+        "github.event.pull_request.head.repo.full_name == github.repository",
+        "fork PR cleanup must use the trusted pull_request_target workflow",
+    )
 
     pull_request_selector, push_selector = shell_if_else_branches(
         ci_workflow,
@@ -389,6 +399,45 @@ def main() -> int:
         "max-parallel: ${{ inputs.max_parallel }}",
         "the reusable matrix must honor its parallelism limit",
     )
+
+    for fragment, message in (
+        (
+            "pull_request_target:",
+            "fork PR cleanup must run in a trusted target context",
+        ),
+        ("actions: write", "fork PR cleanup must receive an Actions write token"),
+        (
+            '"repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"',
+            "fork PR cleanup must re-read the current PR head",
+        ),
+        (
+            'if [ "$PR_EVENT_HEAD_SHA" != "$PR_HEAD_SHA" ]',
+            "a delayed cleanup event must not cancel a newer PR head",
+        ),
+        (
+            '.head_sha != env.PR_HEAD_SHA',
+            "fork PR cleanup must preserve every run for the current head",
+        ),
+        (
+            ".pull_requests[]?",
+            "fork PR cleanup must prefer the pull request number",
+        ),
+        (
+            ".head_repository.id == (env.PR_HEAD_REPOSITORY_ID | tonumber)",
+            "fork PR fallback must match the stable source repository ID",
+        ),
+        (
+            'actions/runs/${run_id}/cancel',
+            "fork PR cleanup must request normal cancellation",
+        ),
+        (
+            'actions/runs/${run_id}/force-cancel',
+            "fork PR cleanup must force-cancel a run that remains active",
+        ),
+    ):
+        require_contains(errors, pr_cleanup_workflow, fragment, message)
+    if "actions/checkout" in pr_cleanup_workflow:
+        errors.append("pull_request_target cleanup must never checkout PR code")
 
     return report(errors)
 

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -65,6 +65,19 @@ class MatrixParallelismTests(unittest.TestCase):
 
 
 class ForkCleanupPermissionTests(unittest.TestCase):
+    def test_main_cleanup_skips_fork_pull_requests(self) -> None:
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        cleanup_step = named_step_block(
+            workflow,
+            "Cancel older queued or running runs",
+        )
+
+        self.assertIn(
+            "github.event.pull_request.head.repo.full_name == github.repository",
+            cleanup_step,
+        )
+        self.assertIn("github.event_name != 'pull_request'", cleanup_step)
+
     def test_fork_cleanup_uses_trusted_target_context(self) -> None:
         self.assertTrue(
             PR_CLEANUP_WORKFLOW.is_file(),

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 import os
 import subprocess
 import tempfile
@@ -7,11 +8,28 @@ import textwrap
 import unittest
 from pathlib import Path
 
-from scripts.test.check_ci_routing import named_step_block
+from scripts.test.check_ci_routing import mapping_block, named_step_block
 
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
+
+
+class ConcurrencyRoutingTests(unittest.TestCase):
+    def test_main_and_dev_use_distinct_fifo_groups(self) -> None:
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        concurrency = mapping_block(workflow, "concurrency", 0)
+
+        self.assertIn("github.event_name != 'pull_request'", concurrency)
+        self.assertIn("github.ref == 'refs/heads/main'", concurrency)
+        self.assertIn("github.ref == 'refs/heads/dev'", concurrency)
+        self.assertIn(
+            "format('ci-{0}-{1}', github.workflow, github.ref)", concurrency
+        )
+        self.assertIn(
+            "format('ci-{0}-{1}', github.workflow, github.run_id)", concurrency
+        )
+        self.assertIn("queue: max", concurrency)
 
 
 class DuplicateEventRoutingTests(unittest.TestCase):
@@ -201,6 +219,82 @@ class StaleRunCancellationTests(unittest.TestCase):
             any("actions/runs/101/force-cancel" in call for call in result.gh_calls)
         )
 
+    def test_fork_pull_request_cancels_only_older_matching_head_runs(self) -> None:
+        result = run_cancellation(
+            event_name="pull_request",
+            pr_number="2078",
+            pr_head_ref="feat/axvisor-ai-rtos-integration",
+            pr_head_repository_id="1329374417",
+            runs=[
+                fake_run(
+                    run_id=101,
+                    run_number=100,
+                    event="pull_request",
+                    head_branch="feat/axvisor-ai-rtos-integration",
+                    head_repository_id=1329374417,
+                ),
+                fake_run(
+                    run_id=102,
+                    run_number=101,
+                    event="pull_request",
+                    head_branch="another-branch",
+                    head_repository_id=1329374417,
+                ),
+                fake_run(
+                    run_id=103,
+                    run_number=102,
+                    event="pull_request",
+                    head_branch="feat/axvisor-ai-rtos-integration",
+                    head_repository_id=999,
+                ),
+                fake_run(
+                    run_id=104,
+                    run_number=103,
+                    event="push",
+                    head_branch="feat/axvisor-ai-rtos-integration",
+                    head_repository_id=1329374417,
+                ),
+                fake_run(
+                    run_id=105,
+                    run_number=200,
+                    event="pull_request",
+                    head_branch="feat/axvisor-ai-rtos-integration",
+                    head_repository_id=1329374417,
+                ),
+                fake_run(
+                    run_id=106,
+                    run_number=104,
+                    event="pull_request",
+                    head_branch="feat/axvisor-ai-rtos-integration",
+                    head_repository_id=1329374417,
+                    pull_request_number=999,
+                ),
+            ],
+        )
+
+        cancelled_run_ids = cancelled_runs(result)
+        self.assertEqual(cancelled_run_ids, {101})
+
+    def test_pull_request_number_match_remains_supported(self) -> None:
+        result = run_cancellation(
+            event_name="pull_request",
+            pr_number="2078",
+            pr_head_ref="current-branch",
+            pr_head_repository_id="42",
+            runs=[
+                fake_run(
+                    run_id=107,
+                    run_number=100,
+                    event="pull_request",
+                    head_branch="historical-branch-name",
+                    head_repository_id=99,
+                    pull_request_number=2078,
+                )
+            ],
+        )
+
+        self.assertEqual(cancelled_runs(result), {107})
+
 
 class RouteResult:
     def __init__(
@@ -307,8 +401,26 @@ def route_script() -> str:
     return workflow_step_script("Route duplicate events")
 
 
-def run_cancellation() -> RouteResult:
+def run_cancellation(
+    *,
+    event_name: str = "push",
+    ref_name: str = "fix/qemu-forward-progress",
+    pr_number: str = "",
+    pr_head_ref: str = "",
+    pr_head_repository_id: str = "",
+    runs: list[dict[str, object]] | None = None,
+) -> RouteResult:
     script = workflow_step_script("Cancel older queued or running runs")
+    if runs is None:
+        runs = [
+            fake_run(
+                run_id=101,
+                run_number=100,
+                event="push",
+                head_branch=ref_name,
+                head_repository_id=1,
+            )
+        ]
     with tempfile.TemporaryDirectory() as temp_dir_name:
         temp_dir = Path(temp_dir_name)
         bin_dir = temp_dir / "bin"
@@ -325,12 +437,16 @@ def run_cancellation() -> RouteResult:
         env.update(
             {
                 "CURRENT_RUN_NUMBER": "200",
-                "EVENT_NAME": "push",
+                "EVENT_NAME": event_name,
+                "FAKE_CANCEL_RUNS": json.dumps(runs),
                 "FAKE_GH_LOG": str(gh_log),
+                "FAKE_RECHECK_STATUS": "queued",
                 "GITHUB_REPOSITORY": "rcore-os/tgoskits",
                 "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
-                "PR_NUMBER": "",
-                "REF_NAME": "fix/qemu-forward-progress",
+                "PR_HEAD_REF": pr_head_ref,
+                "PR_HEAD_REPOSITORY_ID": pr_head_repository_id,
+                "PR_NUMBER": pr_number,
+                "REF_NAME": ref_name,
             }
         )
         completed = subprocess.run(
@@ -353,6 +469,38 @@ def run_cancellation() -> RouteResult:
             completed.stderr,
             gh_log.read_text(encoding="utf-8").splitlines(),
         )
+
+
+def fake_run(
+    *,
+    run_id: int,
+    run_number: int,
+    event: str,
+    head_branch: str,
+    head_repository_id: int,
+    pull_request_number: int | None = None,
+) -> dict[str, object]:
+    pull_requests = (
+        [] if pull_request_number is None else [{"number": pull_request_number}]
+    )
+    return {
+        "event": event,
+        "head_branch": head_branch,
+        "head_repository": {"id": head_repository_id},
+        "html_url": f"https://example.test/runs/{run_id}",
+        "id": run_id,
+        "pull_requests": pull_requests,
+        "run_number": run_number,
+        "status": "queued",
+    }
+
+
+def cancelled_runs(result: RouteResult) -> set[int]:
+    return {
+        int(call.split("actions/runs/", maxsplit=1)[1].split("/cancel", maxsplit=1)[0])
+        for call in result.gh_calls
+        if "/cancel" in call and "/force-cancel" not in call
+    }
 
 
 def workflow_step_script(step_name: str) -> str:
@@ -408,7 +556,10 @@ sys.exit(2)
 
 
 FAKE_CANCEL_GH = r'''#!/usr/bin/env python3
+import json
 import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -417,17 +568,32 @@ arguments = " ".join(sys.argv[1:])
 with Path(os.environ["FAKE_GH_LOG"]).open("a", encoding="utf-8") as log:
     log.write(arguments + "\n")
 
-if "actions/workflows/ci.yml/runs?status=queued" in arguments:
-    print("101\t11975\thttps://example.test/push/101")
-    sys.exit(0)
 if "actions/workflows/ci.yml/runs?status=" in arguments:
+    status = re.search(r"status=([^& ]+)", arguments).group(1)
+    runs = [
+        run
+        for run in json.loads(os.environ["FAKE_CANCEL_RUNS"])
+        if run["status"] == status
+    ]
+    jq_index = sys.argv.index("--jq")
+    completed = subprocess.run(
+        ["jq", "-r", sys.argv[jq_index + 1]],
+        input=json.dumps({"workflow_runs": runs}),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    sys.stdout.write(completed.stdout)
+    sys.stderr.write(completed.stderr)
+    sys.exit(completed.returncode)
+
+cancel_match = re.search(r"actions/runs/(\d+)/(?:force-)?cancel", arguments)
+if cancel_match:
     sys.exit(0)
-if "actions/runs/101/force-cancel" in arguments:
-    sys.exit(0)
-if "actions/runs/101/cancel" in arguments:
-    sys.exit(0)
-if "actions/runs/101" in arguments:
-    print("queued")
+
+run_match = re.search(r"actions/runs/(\d+)", arguments)
+if run_match:
+    print(os.environ["FAKE_RECHECK_STATUS"])
     sys.exit(0)
 
 print(f"unexpected gh invocation: {arguments}", file=sys.stderr)

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -16,6 +16,7 @@ CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
 REUSABLE_CHECK_MATRIX = (
     WORKSPACE_ROOT / ".github/workflows/reusable-check-matrix.yml"
 )
+PR_CLEANUP_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci-pr-cleanup.yml"
 
 
 class ConcurrencyRoutingTests(unittest.TestCase):
@@ -60,6 +61,92 @@ class MatrixParallelismTests(unittest.TestCase):
         self.assertRegex(
             reusable_workflow,
             r"(?ms)^      max_parallel:\n.*?^        default: (?:[2-9]|[1-9][0-9]+)$",
+        )
+
+
+class ForkCleanupPermissionTests(unittest.TestCase):
+    def test_fork_cleanup_uses_trusted_target_context(self) -> None:
+        self.assertTrue(
+            PR_CLEANUP_WORKFLOW.is_file(),
+            "fork PR cleanup needs a pull_request_target workflow with a write token",
+        )
+        workflow = PR_CLEANUP_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("actions: write", workflow)
+        self.assertIn(
+            '"repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}"',
+            workflow,
+        )
+        self.assertIn(
+            'if [ "$PR_EVENT_HEAD_SHA" != "$PR_HEAD_SHA" ]',
+            workflow,
+        )
+        self.assertIn(".head_sha != env.PR_HEAD_SHA", workflow)
+        self.assertIn(".pull_requests[]?", workflow)
+        self.assertIn(".head_repository.id", workflow)
+        self.assertIn("actions/runs/${run_id}/cancel", workflow)
+        self.assertIn("actions/runs/${run_id}/force-cancel", workflow)
+        self.assertNotIn("actions/checkout", workflow)
+        self.assertNotIn("pull_request.head.repo.full_name", workflow)
+
+    def test_target_cleanup_cancels_only_old_current_pr_heads(self) -> None:
+        result = run_target_cancellation(
+            runs=[
+                fake_run(
+                    run_id=201,
+                    run_number=100,
+                    event="pull_request",
+                    head_branch="fork-branch",
+                    head_repository_id=42,
+                    head_sha="old-head",
+                ),
+                fake_run(
+                    run_id=202,
+                    run_number=101,
+                    event="pull_request",
+                    head_branch="fork-branch",
+                    head_repository_id=42,
+                    head_sha="current-head",
+                ),
+                fake_run(
+                    run_id=203,
+                    run_number=102,
+                    event="pull_request",
+                    head_branch="fork-branch",
+                    head_repository_id=99,
+                    head_sha="other-fork-head",
+                ),
+                fake_run(
+                    run_id=204,
+                    run_number=103,
+                    event="pull_request",
+                    head_branch="other-branch",
+                    head_repository_id=42,
+                    head_sha="other-branch-head",
+                ),
+                fake_run(
+                    run_id=205,
+                    run_number=104,
+                    event="push",
+                    head_branch="fork-branch",
+                    head_repository_id=42,
+                    head_sha="old-push-head",
+                ),
+            ]
+        )
+
+        self.assertEqual(cancelled_runs(result), {201})
+        self.assertTrue(
+            any("actions/runs/201/force-cancel" in call for call in result.gh_calls)
+        )
+
+    def test_delayed_target_event_does_not_cancel_newer_head(self) -> None:
+        result = run_target_cancellation(event_head_sha="superseded-head")
+
+        self.assertEqual(cancelled_runs(result), set())
+        self.assertFalse(
+            any("actions/workflows/ci.yml/runs" in call for call in result.gh_calls)
         )
 
 
@@ -502,6 +589,65 @@ def run_cancellation(
         )
 
 
+def run_target_cancellation(
+    *,
+    event_head_sha: str = "current-head",
+    runs: list[dict[str, object]] | None = None,
+) -> RouteResult:
+    script = workflow_step_script(
+        "Cancel older queued or running runs",
+        PR_CLEANUP_WORKFLOW,
+    )
+    if runs is None:
+        runs = []
+    with tempfile.TemporaryDirectory() as temp_dir_name:
+        temp_dir = Path(temp_dir_name)
+        bin_dir = temp_dir / "bin"
+        bin_dir.mkdir()
+        fake_gh = bin_dir / "gh"
+        fake_gh.write_text(FAKE_TARGET_CANCEL_GH, encoding="utf-8")
+        fake_gh.chmod(0o755)
+        fake_sleep = bin_dir / "sleep"
+        fake_sleep.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake_sleep.chmod(0o755)
+
+        gh_log = temp_dir / "gh.log"
+        env = os.environ.copy()
+        env.update(
+            {
+                "FAKE_CANCEL_RUNS": json.dumps(runs),
+                "FAKE_CURRENT_HEAD_REF": "fork-branch",
+                "FAKE_CURRENT_HEAD_REPOSITORY_ID": "42",
+                "FAKE_CURRENT_HEAD_SHA": "current-head",
+                "FAKE_GH_LOG": str(gh_log),
+                "GITHUB_REPOSITORY": "rcore-os/tgoskits",
+                "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                "PR_EVENT_HEAD_SHA": event_head_sha,
+                "PR_NUMBER": "2078",
+            }
+        )
+        completed = subprocess.run(
+            ["bash", "-c", script],
+            cwd=WORKSPACE_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if completed.returncode != 0:
+            raise AssertionError(
+                f"target cancellation script failed with {completed.returncode}:\n"
+                f"{completed.stderr}"
+            )
+        return RouteResult(
+            "",
+            "",
+            completed.stdout,
+            completed.stderr,
+            gh_log.read_text(encoding="utf-8").splitlines(),
+        )
+
+
 def fake_run(
     *,
     run_id: int,
@@ -509,6 +655,7 @@ def fake_run(
     event: str,
     head_branch: str,
     head_repository_id: int,
+    head_sha: str = "old-head",
     pull_request_number: int | None = None,
 ) -> dict[str, object]:
     pull_requests = (
@@ -518,6 +665,7 @@ def fake_run(
         "event": event,
         "head_branch": head_branch,
         "head_repository": {"id": head_repository_id},
+        "head_sha": head_sha,
         "html_url": f"https://example.test/runs/{run_id}",
         "id": run_id,
         "pull_requests": pull_requests,
@@ -534,8 +682,11 @@ def cancelled_runs(result: RouteResult) -> set[int]:
     }
 
 
-def workflow_step_script(step_name: str) -> str:
-    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+def workflow_step_script(
+    step_name: str,
+    workflow_path: Path = CI_WORKFLOW,
+) -> str:
+    workflow = workflow_path.read_text(encoding="utf-8")
     step = named_step_block(workflow, step_name)
     lines = step.splitlines()
     run_index = next(
@@ -625,6 +776,66 @@ if cancel_match:
 run_match = re.search(r"actions/runs/(\d+)", arguments)
 if run_match:
     print(os.environ["FAKE_RECHECK_STATUS"])
+    sys.exit(0)
+
+print(f"unexpected gh invocation: {arguments}", file=sys.stderr)
+sys.exit(2)
+'''
+
+
+FAKE_TARGET_CANCEL_GH = r'''#!/usr/bin/env python3
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+arguments = " ".join(sys.argv[1:])
+with Path(os.environ["FAKE_GH_LOG"]).open("a", encoding="utf-8") as log:
+    log.write(arguments + "\n")
+
+if "/pulls/" in arguments:
+    print(
+        f'{os.environ["FAKE_CURRENT_HEAD_SHA"]}\t'
+        f'{os.environ["FAKE_CURRENT_HEAD_REF"]}\t'
+        f'{os.environ["FAKE_CURRENT_HEAD_REPOSITORY_ID"]}'
+    )
+    sys.exit(0)
+
+if "actions/workflows/ci.yml/runs" in arguments:
+    status_argument = next(
+        argument
+        for argument in sys.argv[1:]
+        if argument.startswith("status=")
+    )
+    status = status_argument.split("=", maxsplit=1)[1]
+    runs = [
+        run
+        for run in json.loads(os.environ["FAKE_CANCEL_RUNS"])
+        if run["status"] == status
+    ]
+    jq_index = sys.argv.index("--jq")
+    completed = subprocess.run(
+        ["jq", "-r", sys.argv[jq_index + 1]],
+        input=json.dumps({"workflow_runs": runs}),
+        capture_output=True,
+        text=True,
+        check=False,
+        env=os.environ,
+    )
+    sys.stdout.write(completed.stdout)
+    sys.stderr.write(completed.stderr)
+    sys.exit(completed.returncode)
+
+cancel_match = re.search(r"actions/runs/(\d+)/(?:force-)?cancel", arguments)
+if cancel_match:
+    sys.exit(0)
+
+run_match = re.search(r"actions/runs/(\d+)", arguments)
+if run_match:
+    print("queued")
     sys.exit(0)
 
 print(f"unexpected gh invocation: {arguments}", file=sys.stderr)

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -13,6 +13,9 @@ from scripts.test.check_ci_routing import mapping_block, named_step_block
 
 WORKSPACE_ROOT = Path(__file__).resolve().parents[2]
 CI_WORKFLOW = WORKSPACE_ROOT / ".github/workflows/ci.yml"
+REUSABLE_CHECK_MATRIX = (
+    WORKSPACE_ROOT / ".github/workflows/reusable-check-matrix.yml"
+)
 
 
 class ConcurrencyRoutingTests(unittest.TestCase):
@@ -30,6 +33,34 @@ class ConcurrencyRoutingTests(unittest.TestCase):
             "format('ci-{0}-{1}', github.workflow, github.run_id)", concurrency
         )
         self.assertIn("queue: max", concurrency)
+
+
+class MatrixParallelismTests(unittest.TestCase):
+    def test_self_hosted_matrix_waits_for_preflight_then_runs_in_parallel(
+        self,
+    ) -> None:
+        ci_workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        jobs = mapping_block(ci_workflow, "jobs", 0)
+
+        for job_name in (
+            "workspace_checks",
+            "arceos_checks",
+            "starry_checks",
+            "axvisor_checks",
+        ):
+            with self.subTest(job_name=job_name):
+                job = mapping_block(jobs, job_name, 2)
+                needs = mapping_block(job, "needs", 4)
+                self.assertIn("- plan_ci", needs)
+                self.assertIn("- static_checks", needs)
+
+        reusable_workflow = REUSABLE_CHECK_MATRIX.read_text(encoding="utf-8")
+        strategy = mapping_block(reusable_workflow, "strategy", 4)
+        self.assertIn("max-parallel: ${{ inputs.max_parallel }}", strategy)
+        self.assertRegex(
+            reusable_workflow,
+            r"(?ms)^      max_parallel:\n.*?^        default: (?:[2-9]|[1-9][0-9]+)$",
+        )
 
 
 class DuplicateEventRoutingTests(unittest.TestCase):


### PR DESCRIPTION
## 问题

`main` 与 `dev` 的 CI 需要分别保留每个 commit 并按 FIFO 顺序执行，同时不能阻塞 PR CI。此前 `main` 没有稳定的分支队列；另外 fork PR 的历史 workflow run 有时会返回空的 `pull_requests`，导致同一 PR 的旧 head run 无法被识别和取消，持续占用 self-hosted job 队列。

## 修改

- 为 `main`、`dev` 分别使用稳定的、包含完整 ref 的 concurrency group，并保留 `queue: max`。
- PR、普通分支和其他事件使用包含 `run_id` 的唯一 group，不进入 `main`/`dev` workflow 队列。
- 保留所有后续分组对 `Preflight` 的门禁，并为 reusable matrix 显式设置最多 256 项并行，避免同一 PR、同一分组的 self-hosted 项被 workflow 串行化。
- 清理 PR 旧 run 时优先按 PR number 匹配；当 API 返回空 `pull_requests` 时，改用 head repository ID 与 head branch 精确匹配。
- fork PR 使用不 checkout 代码的 `pull_request_target` 清理 workflow 获取 Actions write token；执行前重新读取 PR 当前 head，延迟的旧事件不会取消更新 head。
- 仅取消同一 PR 的更早 `pull_request` run，保留 push run、其他 PR、当前 run 和更新 run；继续执行普通 cancel 和 force-cancel。
- 增加 concurrency 路由与 fork PR 清理的正向、负向回归测试，并更新 CI 文档。

## 实现逻辑

分支完整 ref 使 `main` 和 `dev` 自然形成两个互不影响的 FIFO 队列；`run_id` 则使 PR workflow run 在调度层彼此隔离。后续四个检查分组继续等待 `Preflight` 成功或按计划跳过，门禁通过后各组及组内 matrix 同时参与调度。fork PR 的普通 `pull_request` token 会被 GitHub 降级为 Actions read，因此旧 run 清理由只执行可信 API 调用的 `pull_request_target` workflow 完成；fallback 只在 `pull_requests` 为空时启用，并同时要求稳定的仓库数字 ID 与分支名一致，从而避免误取消同名分支、其他 fork 或 push run。self-hosted runner 容量仍然共享，本次不修改 runner 标签、缓存配置或测试矩阵。

## 验证

- `python3 scripts/test/check_ci_routing.py`
- `python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py scripts/test/test_ci_routing.py`（64 tests）
- `actionlint v1.7.12 -ignore 'unexpected key "queue" for "concurrency" section' .github/workflows/ci.yml .github/workflows/reusable-check-matrix.yml .github/workflows/ci-pr-cleanup.yml`
- `cargo xtask clippy --package axbuild`
- `cargo fmt --all --check`
- `git diff --check`

线上清理验证中已取消能精确确认归属旧 PR head 的积压 run，并保留对应 PR 当前 head run。
