### PR TITLE
fix(axvm): avoid machine and wait queue lock inversion

### DIFF
--- a/virtualization/axvm/src/vm/config_lock_tests.rs
+++ b/virtualization/axvm/src/vm/config_lock_tests.rs
@@ -168,3 +168,26 @@ fn with_config_remains_available_without_machine_resources() {
         );
     }
 }
+
+#[test]
+fn with_runtime_callback_runs_without_machine_lock() {
+    let runtime = Arc::new(VmRuntimeHandle::new());
+    let vm = test_vm_with_machine(
+        7,
+        Machine::Stopping {
+            resources: None,
+            runtime: Some(runtime),
+            reason: StopReason::Clean,
+        },
+    );
+
+    vm.with_runtime(|runtime| {
+        assert!(
+            vm.machine.try_lock().is_some(),
+            "runtime callbacks must not run while holding the machine lock"
+        );
+        runtime.notify_all();
+        Ok(())
+    })
+    .unwrap();
+}

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -1135,15 +1135,22 @@ impl AxVM {
         }
     }
 
+    /// Runs a callback with a snapshot of the current runtime.
+    ///
+    /// The runtime is pinned by its `Arc`, but the lifecycle may advance after
+    /// the snapshot. The callback runs without the machine lock so runtime
+    /// wait-queue operations cannot invert the machine/wait-queue lock order.
     pub(crate) fn with_runtime<F, R>(&self, f: F) -> AxVmResult<R>
     where
         F: FnOnce(&Arc<VmRuntimeHandle>) -> AxVmResult<R>,
     {
-        let machine = self.machine.lock();
-        let runtime = machine
+        let runtime = self
+            .machine
+            .lock()
             .runtime()
+            .cloned()
             .ok_or_else(|| ax_err_type!(BadState, "VM runtime is not available"))?;
-        f(runtime)
+        f(&runtime)
     }
 
     #[cfg_attr(


### PR DESCRIPTION
## Summary

Avoid an ABBA lock inversion between the VM lifecycle machine lock and the runtime wait queue. Runtime callbacks now execute after the machine lock has been released.

## Problem

The vCPU startup waiter and several normal runtime notification paths acquired the same two locks in opposite orders:

```text
vCPU waiter                         runtime notifier
-----------                         ----------------
lock(runtime.wait_queue)            lock(vm.machine)
  evaluate vm.running()               runtime.notify_one/all()
    lock(vm.machine)                    lock(runtime.wait_queue)
```

The waiter reaches this order through `vcpu_run -> VmRuntimeHandle::wait_until -> WaitQueue::wait_until`. The wait queue intentionally evaluates its condition while holding the queue lock to prevent lost wakeups. That condition calls `vm.running()`, which reads the VM status under the machine lock.

The reverse order came from `AxVM::with_runtime`. It held the machine lock while executing its callback. Callers used that callback to invoke `runtime.notify_one()` or `runtime.notify_all()`, which acquire the runtime wait queue lock.

If two CPUs acquire the first lock on each side, both CPUs wait indefinitely for the other lock.

## Impact

This race is reachable through normal SMP VM operation. It does not require faulty firmware, modified QEMU, unusual hardware, or an invalid guest.

Affected paths include:

- starting the primary or a secondary vCPU;
- stopping, resetting, or destroying a VM;
- waking a vCPU from a virtual device;
- delivering pending interrupts;
- notifying an IVC peer.

When the lock inversion occurs, the affected vCPU and notification path cannot make progress. VM startup or lifecycle management may remain stuck, and the CPUs holding the IRQ-safe spin locks can continue spinning with local interrupts disabled.

## Root Cause

`AxVM::with_runtime` looked up the runtime and invoked the caller-provided callback within the same machine-lock critical section:

```rust
let machine = self.machine.lock();
let runtime = machine.runtime().ok_or_else(...)?;
f(runtime)
```

The machine lock is needed to select the runtime owned by the current lifecycle state, but it is not needed while operating on the runtime. The runtime is already reference-counted and protects its mutable state with its own locks and atomics. Extending the machine-lock lifetime across the callback therefore created an unnecessary broad critical section and enabled the reverse lock order.

## Fix

Clone the current `Arc<VmRuntimeHandle>` while holding the machine lock, then release the lock before executing the callback:

```rust
let runtime = self
    .machine
    .lock()
    .runtime()
    .cloned()
    .ok_or_else(...)?;
f(&runtime)
```

The cloned `Arc` pins the selected runtime for the duration of the callback, even if the VM lifecycle advances after the snapshot. All existing `with_runtime` call sites operate on runtime-owned synchronized state and do not require the machine lock to remain held.

The fix deliberately leaves `WaitQueue::wait_until` unchanged. Moving its condition outside the wait queue lock would create a lost-wakeup window.

## Regression Test

Add a deterministic host test using the real `AxVM`, `IrqSafeMutex`, and `VmRuntimeHandle`. The test calls `try_lock()` from a runtime callback to verify that the machine lock has already been released before a wait queue notification is performed.

Before the fix, the new test fails immediately:

```text
runtime callbacks must not run while holding the machine lock
test vm::config_lock_tests::with_runtime_callback_runs_without_machine_lock ... FAILED
test result: FAILED. 0 passed; 1 failed; 295 filtered out
```

After the fix, the same test passes:

```text
test vm::config_lock_tests::with_runtime_callback_runs_without_machine_lock ... ok
test result: ok. 1 passed; 0 failed; 295 filtered out
```

## Validation

- `cargo fmt --all --check`
- `cargo test -p axvm --no-default-features --features host-test --lib` — 296 passed, 0 failed
- `cargo xtask clippy --package axvm` — 6/6 checks passed
- `cargo xtask axvisor test qemu --arch aarch64 --test-case smoke` — 1/1 QEMU case passed

The AArch64 QEMU smoke test booted AxVisor with four CPUs and completed the shell and NVMe read/write checks successfully.
