### PR TITLE
fix(axfs-ng-vfs): replan unmount after topology changes

### DIFF
--- a/fs/axfs-ng-vfs/src/mount/mod.rs
+++ b/fs/axfs-ng-vfs/src/mount/mod.rs
@@ -1104,7 +1104,7 @@ impl FsPollable for Location {
 
 #[cfg(test)]
 mod tests {
-    use alloc::string::ToString;
+    use alloc::{boxed::Box, string::ToString};
     use core::{
         any::Any,
         sync::atomic::{AtomicUsize, Ordering},
@@ -1118,7 +1118,7 @@ mod tests {
     struct MockNode;
     struct TopologyChangingFs {
         self_ref: Weak<Self>,
-        unrelated_mount: Arc<Mountpoint>,
+        topology_change: Box<dyn Fn() + Send + Sync>,
         flushes: AtomicUsize,
     }
     struct TopologyChangingNode {
@@ -1186,7 +1186,7 @@ mod tests {
 
         fn flush(&self) -> VfsResult<()> {
             if self.flushes.fetch_add(1, Ordering::AcqRel) == 0 {
-                self.unrelated_mount.set_shared();
+                (self.topology_change)();
             }
             Ok(())
         }
@@ -1338,7 +1338,7 @@ mod tests {
         let unrelated_mount = Mountpoint::new_root(&parent_fs);
         let filesystem_ops = Arc::new_cyclic(|self_ref| TopologyChangingFs {
             self_ref: self_ref.clone(),
-            unrelated_mount,
+            topology_change: Box::new(move || unrelated_mount.set_shared()),
             flushes: AtomicUsize::new(0),
         });
         let mounted_fs = Filesystem::new(filesystem_ops.clone());
@@ -1351,6 +1351,61 @@ mod tests {
 
         assert_eq!(filesystem_ops.flushes.load(Ordering::Acquire), 1);
         assert!(!parent.children.lock().contains_key(&target_entry.key()));
+    }
+
+    #[test]
+    fn unmount_rejects_a_replan_that_adds_an_unflushed_peer() {
+        let parent_fs = mock_filesystem();
+        let source_parent = Mountpoint::new_root(&parent_fs);
+        let peer_parent = Mountpoint::new_root(&parent_fs);
+        source_parent.set_shared();
+
+        let source_parent_root = source_parent.root_location();
+        let source_entry =
+            make_child_dir_entry(Some(source_parent_root.entry().clone()), "mount-target");
+        let source_target = Location::new(source_parent.clone(), source_entry.clone());
+        let peer_parent_root = peer_parent.root_location();
+        let peer_entry =
+            make_child_dir_entry(Some(peer_parent_root.entry().clone()), "mount-target");
+        let peer_target = Location::new(peer_parent.clone(), peer_entry.clone());
+
+        let source_parent_for_flush = source_parent.clone();
+        let peer_parent_for_flush = peer_parent.clone();
+        let source_ops = Arc::new_cyclic(|self_ref| TopologyChangingFs {
+            self_ref: self_ref.clone(),
+            topology_change: Box::new(move || {
+                peer_parent_for_flush.join_shared_group(&source_parent_for_flush);
+            }),
+            flushes: AtomicUsize::new(0),
+        });
+        let peer_ops = Arc::new_cyclic(|self_ref| TopologyChangingFs {
+            self_ref: self_ref.clone(),
+            topology_change: Box::new(|| {}),
+            flushes: AtomicUsize::new(0),
+        });
+        let source_mount = source_target
+            .mount(&Filesystem::new(source_ops.clone()))
+            .expect("source mount succeeds");
+        let peer_mount = peer_target
+            .mount(&Filesystem::new(peer_ops.clone()))
+            .expect("peer mount succeeds");
+
+        assert_eq!(
+            source_mount.root_location().unmount(),
+            Err(VfsError::ResourceBusy)
+        );
+
+        assert_eq!(source_ops.flushes.load(Ordering::Acquire), 1);
+        assert_eq!(peer_ops.flushes.load(Ordering::Acquire), 0);
+        assert!(source_mount.location().is_some());
+        assert!(peer_mount.location().is_some());
+        assert!(
+            source_parent
+                .children
+                .lock()
+                .contains_key(&source_entry.key())
+        );
+        assert!(peer_parent.children.lock().contains_key(&peer_entry.key()));
     }
 
     /// The global root is unattached (its mount `location` is `None`), so the

--- a/fs/axfs-ng-vfs/src/mount/mod.rs
+++ b/fs/axfs-ng-vfs/src/mount/mod.rs
@@ -1048,7 +1048,10 @@ impl Location {
         assert!(self.entry.ptr_eq(&self.mountpoint.root));
 
         let plan = self.mountpoint.plan_unmount(UnmountKind::Normal)?;
-        self.commit_unmount(plan)
+        self.filesystem().flush()?;
+        self.mountpoint.commit_normal_after_flush(plan)?;
+        self.finish_unmount();
+        Ok(())
     }
 
     /// Flushes this mount once and commits an already admitted unmount plan.
@@ -1062,11 +1065,15 @@ impl Location {
         }
         self.filesystem().flush()?;
         plan.commit()?;
+        self.finish_unmount();
+        Ok(())
+    }
+
+    fn finish_unmount(&self) {
         self.mountpoint.clear_expired();
         if let Ok(directory) = self.entry.as_dir() {
             directory.forget();
         }
-        Ok(())
     }
 
     pub fn detach_mount(&self) -> VfsResult<()> {
@@ -1109,6 +1116,14 @@ mod tests {
     struct MockFs;
     struct ContextCheckingFs;
     struct MockNode;
+    struct TopologyChangingFs {
+        self_ref: Weak<Self>,
+        unrelated_mount: Arc<Mountpoint>,
+        flushes: AtomicUsize,
+    }
+    struct TopologyChangingNode {
+        filesystem: Arc<TopologyChangingFs>,
+    }
     struct LifetimeGuard(Arc<AtomicUsize>);
 
     impl Drop for LifetimeGuard {
@@ -1148,6 +1163,32 @@ mod tests {
 
         fn stat(&self) -> VfsResult<StatFs> {
             Err(VfsError::InvalidInput)
+        }
+    }
+
+    impl FilesystemOps for TopologyChangingFs {
+        fn name(&self) -> &str {
+            "topology-changing"
+        }
+
+        fn root_dir(&self) -> DirEntry {
+            let filesystem = self
+                .self_ref
+                .upgrade()
+                .expect("test filesystem must remain alive");
+            let node: Arc<dyn DirNodeOps> = Arc::new(TopologyChangingNode { filesystem });
+            DirEntry::new_dir(|_| DirNode::new(node), Reference::root())
+        }
+
+        fn stat(&self) -> VfsResult<StatFs> {
+            Err(VfsError::InvalidInput)
+        }
+
+        fn flush(&self) -> VfsResult<()> {
+            if self.flushes.fetch_add(1, Ordering::AcqRel) == 0 {
+                self.unrelated_mount.set_shared();
+            }
+            Ok(())
         }
     }
 
@@ -1200,6 +1241,65 @@ mod tests {
         }
     }
 
+    impl NodeOps for TopologyChangingNode {
+        fn inode(&self) -> u64 {
+            0
+        }
+
+        fn metadata(&self) -> VfsResult<Metadata> {
+            Err(VfsError::InvalidInput)
+        }
+
+        fn update_metadata(&self, _update: MetadataUpdate) -> VfsResult<()> {
+            Err(VfsError::InvalidInput)
+        }
+
+        fn filesystem(&self) -> &dyn FilesystemOps {
+            self.filesystem.as_ref()
+        }
+
+        fn sync(&self, _data_only: bool) -> VfsResult<()> {
+            Ok(())
+        }
+
+        fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+            self
+        }
+    }
+
+    impl DirNodeOps for TopologyChangingNode {
+        fn read_dir(&self, _offset: u64, _sink: &mut dyn DirEntrySink) -> VfsResult<usize> {
+            Ok(0)
+        }
+
+        fn lookup(&self, _name: &str) -> VfsResult<DirEntry> {
+            Err(VfsError::NotFound)
+        }
+
+        fn create(
+            &self,
+            _name: &str,
+            _node_type: NodeType,
+            _permission: NodePermission,
+            _uid: u32,
+            _gid: u32,
+        ) -> VfsResult<DirEntry> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+
+        fn link(&self, _name: &str, _node: &DirEntry) -> VfsResult<DirEntry> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+
+        fn unlink(&self, _name: &str, _is_dir: bool) -> VfsResult<()> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+
+        fn rename(&self, _src: &str, _dst_dir: &DirNode, _dst: &str) -> VfsResult<()> {
+            Err(VfsError::ReadOnlyFilesystem)
+        }
+    }
+
     fn mock_filesystem() -> Filesystem {
         Filesystem::new(Arc::new(MockFs))
     }
@@ -1226,6 +1326,31 @@ mod tests {
         let mounted = Filesystem::new(Arc::new(ContextCheckingFs));
 
         target.mount(&mounted).expect("mount succeeds");
+    }
+
+    #[test]
+    fn unmount_replans_after_unrelated_topology_change_during_flush() {
+        let parent_fs = mock_filesystem();
+        let parent = Mountpoint::new_root(&parent_fs);
+        let parent_root = parent.root_location();
+        let target_entry = make_child_dir_entry(Some(parent_root.entry().clone()), "mount-target");
+        let target = Location::new(parent.clone(), target_entry.clone());
+        let unrelated_mount = Mountpoint::new_root(&parent_fs);
+        let filesystem_ops = Arc::new_cyclic(|self_ref| TopologyChangingFs {
+            self_ref: self_ref.clone(),
+            unrelated_mount,
+            flushes: AtomicUsize::new(0),
+        });
+        let mounted_fs = Filesystem::new(filesystem_ops.clone());
+        let mounted = target.mount(&mounted_fs).expect("mount succeeds");
+
+        mounted
+            .root_location()
+            .unmount()
+            .expect("unmount replans after unrelated topology changes");
+
+        assert_eq!(filesystem_ops.flushes.load(Ordering::Acquire), 1);
+        assert!(!parent.children.lock().contains_key(&target_entry.key()));
     }
 
     /// The global root is unattached (its mount `location` is `None`), so the

--- a/fs/axfs-ng-vfs/src/mount/unmount.rs
+++ b/fs/axfs-ng-vfs/src/mount/unmount.rs
@@ -48,6 +48,15 @@ impl UnmountPlan {
             .any(|target| !target.mountpoint.children.lock().is_empty())
     }
 
+    fn has_same_targets(&self, expected: &[Arc<Mountpoint>]) -> bool {
+        self.targets.len() == expected.len()
+            && self.targets.iter().all(|target| {
+                expected
+                    .iter()
+                    .any(|mountpoint| Arc::ptr_eq(&target.mountpoint, mountpoint))
+            })
+    }
+
     fn revalidate_locked(&self) -> Result<(), UnmountCommitError> {
         if MOUNT_TOPOLOGY_VERSION.load(Ordering::Acquire) != self.topology_version {
             return Err(UnmountCommitError::TopologyChanged);
@@ -114,17 +123,22 @@ impl Mountpoint {
     /// Commits a normal unmount after filesystem callbacks have completed.
     ///
     /// A callback may overlap an unrelated mount-tree mutation. Replan under
-    /// the topology guard in that case so validation and commit remain one
-    /// transaction without reporting a false `ResourceBusy` to the caller.
+    /// the topology guard in that case, but commit only when the complete
+    /// target set is unchanged. A new target may belong to an unflushed
+    /// filesystem and therefore cannot join the current transaction.
     pub(super) fn commit_normal_after_flush(self: &Arc<Self>, plan: UnmountPlan) -> VfsResult<()> {
         debug_assert_eq!(plan.kind, UnmountKind::Normal);
+        let planned_targets: Vec<_> = plan.targets().cloned().collect();
         let _topology = MOUNT_TOPOLOGY_MUTATION.lock();
         match plan.commit_locked() {
             Ok(()) => Ok(()),
-            Err(UnmountCommitError::TopologyChanged) => self
-                .plan_unmount_locked(UnmountKind::Normal)?
-                .commit_current_locked()
-                .map_err(VfsError::from),
+            Err(UnmountCommitError::TopologyChanged) => {
+                let current_plan = self.plan_unmount_locked(UnmountKind::Normal)?;
+                if !current_plan.has_same_targets(&planned_targets) {
+                    return Err(UnmountCommitError::TopologyChanged.into());
+                }
+                current_plan.commit_current_locked().map_err(VfsError::from)
+            }
             Err(error) => Err(error.into()),
         }
     }

--- a/fs/axfs-ng-vfs/src/mount/unmount.rs
+++ b/fs/axfs-ng-vfs/src/mount/unmount.rs
@@ -111,6 +111,24 @@ impl UnmountPlan {
 }
 
 impl Mountpoint {
+    /// Commits a normal unmount after filesystem callbacks have completed.
+    ///
+    /// A callback may overlap an unrelated mount-tree mutation. Replan under
+    /// the topology guard in that case so validation and commit remain one
+    /// transaction without reporting a false `ResourceBusy` to the caller.
+    pub(super) fn commit_normal_after_flush(self: &Arc<Self>, plan: UnmountPlan) -> VfsResult<()> {
+        debug_assert_eq!(plan.kind, UnmountKind::Normal);
+        let _topology = MOUNT_TOPOLOGY_MUTATION.lock();
+        match plan.commit_locked() {
+            Ok(()) => Ok(()),
+            Err(UnmountCommitError::TopologyChanged) => self
+                .plan_unmount_locked(UnmountKind::Normal)?
+                .commit_current_locked()
+                .map_err(VfsError::from),
+            Err(error) => Err(error.into()),
+        }
+    }
+
     pub fn plan_unmount(self: &Arc<Self>, kind: UnmountKind) -> VfsResult<UnmountPlan> {
         let _topology = MOUNT_TOPOLOGY_MUTATION.lock();
         self.plan_unmount_locked(kind)


### PR DESCRIPTION
## 问题与根因

PR #2139 的 CI run 32480504535 曾在 `Workspace / std tests` 失败：

```text
axfs_ng_vfs_mount_tree_rules_hold ... FAILED
called `Result::unwrap()` on an `Err` value: ResourceBusy
std tests failed for 1 package(s): axfs-ng-vfs
```

`axfs-ng-vfs` 的库测试全部通过，失败只发生在 `tests/std.rs` 最后的 `unmount_all()` 清理。精确用例单独运行连续通过，说明失败依赖并行交错。

普通 `Location::unmount()` 先创建带全局 `MOUNT_TOPOLOGY_VERSION` 的 plan，在拓扑锁外执行 filesystem flush，再提交 plan。同一测试二进制中的其他 mount 测试并行修改任意独立 mount tree 时，全局版本会变化；原目标即使完全未变，commit 仍返回 `TopologyChanged`，随后被折叠为 `ResourceBusy`。因此该失败不是 whitelist 选择错误，也不表示目标 mount 真的 busy。

## 修改与事务边界

- 保留首次 plan，用于在 filesystem callback 前拒绝当时已经 busy 或无效的目标。
- filesystem 只在拓扑锁外 flush 一次，避免在全局 mount 锁内执行未知 callback。
- commit 时若版本未变，提交原 plan。
- 若版本变化，在同一拓扑临界区重新 plan，并按 `Arc<Mountpoint>` 身份比较完整目标集合：
  - 集合完全相同：只发生了无关拓扑变化，可以立即提交 fresh plan；
  - 新增、移除或替换任何目标：保留 `TopologyChanged -> ResourceBusy`，不 detach 任何 mount。
- 显式 `UnmountPlan::commit()` 的 stale-plan 检测保持不变。

该约束保证当前事务只提交 flush 前已经 admission 的 mount 集合。重规划新增的 corresponding peer 可能属于另一个尚未 flush 的 filesystem，因此绝不加入当前提交，也不在拓扑锁内补做 callback。

StarryOS `sys_umount2` 使用显式 `plan_unmount` / `commit_unmount` 路径，不调用本次修改的 convenience `Location::unmount()`；本次修复不改变用户态 syscall/errno 语义。受影响路径是 `unmount_all()` 的递归内部清理。

## Red / Green 回归

### 无关 topology version 变化

mock filesystem 在第一次 flush 中确定性修改一个无关 mount tree：

```console
cargo test -p axfs-ng-vfs --features host-test \
  unmount_replans_after_unrelated_topology_change_during_flush -- --nocapture
```

- Red：旧实现退出码 101，`unmount()` 返回 `ResourceBusy`。
- Green：目标成功 detach，filesystem flush 次数严格为 1。

### flush 后出现新 corresponding peer

第二个回归让两个不同 filesystem 的子挂载最初互不关联，再在 source flush 中连接 parent peer group：

```console
cargo test -p axfs-ng-vfs --features host-test \
  unmount_rejects_a_replan_that_adds_an_unflushed_peer -- --nocapture
```

- Red（review 前 head）：`unmount()` 返回 `Ok(())`，source flush=1、peer flush=0，但两个 mount 都被 detach。
- Green：返回 `ResourceBusy`，source/peer 均保持 attached，未 flush peer 不会被提交。

## 验证

- `cargo test -p axfs-ng-vfs --features host-test`：48/48 通过（37 lib + 11 std integration）。
- `cargo test -q -p axfs-ng-vfs --features host-test --test std`：并行重复 100 次通过。
- `cargo xtask clippy --package axfs-ng-vfs`：base / lockdep / host-test 共 3/3 通过。
- `cargo xtask test --since origin/dev`：正确选择 `axfs-ng-vfs` 及 12 个受影响 whitelist 包，13/13 全部通过。
- `cargo fmt --all --check`：通过。
- `git diff --check origin/dev...HEAD`：通过。

## std whitelist

`scripts/test/std_crates.csv` 已正确包含 `axfs-ng-vfs`。本次修复包本身的并发行为，不修改或放宽 whitelist。

## 分支同步

- 已合并 `origin/dev@b8450e238d4796642966d2725f36bc9d8593fac4`。
- 当前 head：`3c0b536d2`。