### PR TITLE
fix(ci): bound incremental clippy checkout history

### DIFF
--- a/.github/ci/checks/workspace.toml
+++ b/.github/ci/checks/workspace.toml
@@ -6,7 +6,7 @@ default_runner = "qcs"
 [[check]]
 id = "run-clippy"
 name = "Incremental Clippy"
-fetch_depth = "full"
+fetch_depth = "100"
 download_xtask_bin_artifact = true
 command = '''
 cargo xtask clippy --since "$SINCE_REF"

--- a/docs/docs/build/clippy.md
+++ b/docs/docs/build/clippy.md
@@ -75,6 +75,8 @@ Clippy 的代码按选择、展开、执行和报告划分，避免参数解析�
 
 `--since` 模式先通过 `support::git::select_incremental_packages` 计算直接变更包和完整反向依赖闭包，再选择 `changed ∪ (affected ∩ {ax-std, starryos})`。中间路径和其他顶层包不会进入 Clippy 计划；直接变更的 OS 根会去重。所有选中包都使用 `--no-deps` 并展开完整 feature、target 和命名配置矩阵。当 git diff 失败或路径越出 workspace 时回退到全量扫描，并在终端打印回退原因。
 
+CI 为 Incremental Clippy 单独获取最近 100 层 Git 历史。增量基线或 merge-base 超出该范围，或者 force-push 使历史断开时，Clippy 会保守回退到全 workspace 扫描；其他 CI 检查保持各自的 checkout 深度。
+
 `--no-deps` 只禁止 Clippy 检查依赖 crate；Cargo 仍会编译选中包完成类型检查所需的依赖。
 
 `skip_unsupported_packages` 会跳过当前不能裸 clippy 的包，目前包括：

--- a/scripts/test/ci_plan.py
+++ b/scripts/test/ci_plan.py
@@ -292,8 +292,13 @@ def _validate_check(
         raise PlanError(f"{location} timeout_minutes must be positive")
 
     fetch_depth = str(check.get("fetch_depth", "1"))
-    if fetch_depth not in {"0", "1", "2", "full"}:
-        raise PlanError(f"{location} has an unsupported fetch_depth")
+    if (
+        fetch_depth != "full"
+        and re.fullmatch(r"0|[1-9][0-9]*", fetch_depth) is None
+    ):
+        raise PlanError(
+            f"{location} fetch_depth must be 'full' or a non-negative integer"
+        )
 
     preflight = check.get("container_preflight")
     if preflight is not None and preflight not in SUPPORTED_PREFLIGHTS:

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -121,6 +121,17 @@ class CiPlanTests(unittest.TestCase):
         self.assertFalse(plan["starry_required"])
         self.assertFalse(plan["axvisor_required"])
 
+    def test_incremental_clippy_uses_bounded_history_without_changing_other_checks(
+        self,
+    ) -> None:
+        plan = ci_plan.build_main_plan(self.upstream)
+        static_rows = self.assert_unique_ids(plan["static_matrix"]["include"])
+        test_rows = self.assert_unique_ids(main_test_rows(plan))
+
+        self.assertEqual(test_rows["run-clippy"]["fetch_depth"], "100")
+        self.assertEqual(static_rows["check-formatting"]["fetch_depth"], "1")
+        self.assertEqual(test_rows["test-with-std"]["fetch_depth"], "1")
+
     def test_pull_request_impact_package_selects_standalone_check(self) -> None:
         context = ci_plan.PlanContext(
             repository="rcore-os/tgoskits",
@@ -544,7 +555,7 @@ command = "true"
         self.assertFalse(static_rows["check-formatting"]["download_xtask_bin_artifact"])
         clippy = test_rows["run-clippy"]
         self.assertEqual(clippy["runs_on"], ["ubuntu-latest"])
-        self.assertEqual(clippy["fetch_depth"], "0")
+        self.assertEqual(clippy["fetch_depth"], "100")
         self.assertTrue(clippy["download_xtask_bin_artifact"])
 
     def test_starry_apps_schedule_and_manual_selection(self) -> None:


### PR DESCRIPTION
## 问题

PR #2150 的 branch push CI 中，`Workspace / Incremental Clippy` 收到 push 前提交 `25806e9` 作为增量基线，但 self-hosted job 的 checkout 深度只有 2。新 head 前存在 merge commit，浅克隆无法连接基线与 HEAD，`git merge-base` 因此失败；Clippy 按保守策略回退到全 workspace，最终执行 185 个 package、722 个 check，耗时约 40 分钟。

根因是 Clippy 清单虽然声明 `fetch_depth = "full"`，CI planner 会把 self-hosted runner 上的 `full` 归一化为 `2`。固定深度 2 无法覆盖包含 merge commit 的正常 branch push。

## 修改

- 仅将 Incremental Clippy 的 checkout 深度设为 100，其他 CI check 的 checkout 深度保持不变。
- 放宽 CI manifest 校验，使 `fetch_depth` 接受 `full` 或规范的非负十进制整数，从而允许显式配置 100。
- 增加 planner 回归测试，锁定 Clippy 深度为 100，同时 Formatting 和 std tests 仍保持深度 1；fork fallback 也保持同一 Clippy 深度边界。
- 更新 Clippy 文档，说明超过 100 层或 force-push 导致历史断开时仍会保守回退全 workspace。

## 设计逻辑

最近 100 层覆盖常规 push、merge commit 和短期分支同步，不再因为两层浅克隆误触发全量 Clippy；相比 `fetch-depth: 0`，它避免每次下载完整仓库历史。若增量基线或 merge-base 超出该边界，现有 fallback 语义保持不变，继续运行全量检查而不是漏检。

该修改只影响 Incremental Clippy 的 Git checkout，不改变 self-hosted `cache_key: ""`、Rust/Cargo cache、package/feature 选择或其他 CI 矩阵。

## Red / Green 回归

新增测试在修复前确定性失败：

```text
AssertionError: '2' != '100'
```

修复后 Clippy 矩阵输出 `fetch_depth = "100"`，Formatting 和 std tests 均仍为 `"1"`。

## 验证

- `python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py scripts/test/test_ci_routing.py`：65 tests passed
- `python3 scripts/test/check_ci_routing.py`：通过
- `cargo fmt --all`：通过
- `cargo xtask clippy --package axbuild`：1/1 check passed
- `git diff --check`：通过
