### PR TITLE
feat(starry): add sched priority range syscalls

### DIFF
--- a/apps/starry/qemu/syscall-test/TODO.txt
+++ b/apps/starry/qemu/syscall-test/TODO.txt
@@ -119,8 +119,6 @@ remap_file_pages
 renameat2
 request_key
 sbrk
-sched_get_priority_max
-sched_get_priority_min
 sched_getaffinity
 sched_getattr
 sched_getparam

--- a/apps/starry/qemu/syscall-test/syscalls/sched_get_priority_max.txt
+++ b/apps/starry/qemu/syscall-test/syscalls/sched_get_priority_max.txt
@@ -1,0 +1,2 @@
+sched_get_priority_max01
+sched_get_priority_max02

--- a/apps/starry/qemu/syscall-test/syscalls/sched_get_priority_min.txt
+++ b/apps/starry/qemu/syscall-test/syscalls/sched_get_priority_min.txt
@@ -1,0 +1,2 @@
+sched_get_priority_min01
+sched_get_priority_min02

--- a/os/StarryOS/kernel/src/syscall/mod.rs
+++ b/os/StarryOS/kernel/src/syscall/mod.rs
@@ -673,6 +673,8 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             sys_sched_setscheduler(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _)
         }
         Sysno::sched_getparam => sys_sched_getparam(uctx.arg0() as _, uctx.arg1() as _),
+        Sysno::sched_get_priority_max => sys_sched_get_priority_max(uctx.arg0() as _),
+        Sysno::sched_get_priority_min => sys_sched_get_priority_min(uctx.arg0() as _),
         Sysno::getpriority => sys_getpriority(uctx.arg0() as _, uctx.arg1() as _),
         Sysno::setpriority => sys_setpriority(uctx.arg0() as _, uctx.arg1() as _, uctx.arg2() as _),
 

--- a/os/StarryOS/kernel/src/syscall/task/schedule.rs
+++ b/os/StarryOS/kernel/src/syscall/task/schedule.rs
@@ -8,7 +8,8 @@ use ax_task::{
 use bytemuck::{Pod, Zeroable};
 use linux_raw_sys::general::{
     __kernel_clockid_t, CLOCK_MONOTONIC, CLOCK_REALTIME, PRIO_PGRP, PRIO_PROCESS, PRIO_USER,
-    SCHED_BATCH, SCHED_FIFO, SCHED_IDLE, SCHED_NORMAL, SCHED_RR, TIMER_ABSTIME, timespec,
+    SCHED_BATCH, SCHED_DEADLINE, SCHED_EXT, SCHED_FIFO, SCHED_IDLE, SCHED_NORMAL, SCHED_RR,
+    TIMER_ABSTIME, timespec,
 };
 use starry_vm::{VmMutPtr, VmPtr, vm_load, vm_write_slice};
 
@@ -261,6 +262,32 @@ pub fn sys_sched_getparam(pid: i32, param: *mut ()) -> StarryResult<isize> {
     Ok(0)
 }
 
+/// Returns the maximum priority supported by a Linux scheduling policy.
+///
+/// # Errors
+///
+/// Returns [`StarryError::InvalidInput`] when `policy` is not recognized.
+pub fn sys_sched_get_priority_max(policy: i32) -> StarryResult<isize> {
+    match policy as u32 {
+        SCHED_FIFO | SCHED_RR => Ok(99),
+        SCHED_NORMAL | SCHED_BATCH | SCHED_IDLE | SCHED_DEADLINE | SCHED_EXT => Ok(0),
+        _ => Err(StarryError::InvalidInput),
+    }
+}
+
+/// Returns the minimum priority supported by a Linux scheduling policy.
+///
+/// # Errors
+///
+/// Returns [`StarryError::InvalidInput`] when `policy` is not recognized.
+pub fn sys_sched_get_priority_min(policy: i32) -> StarryResult<isize> {
+    match policy as u32 {
+        SCHED_FIFO | SCHED_RR => Ok(1),
+        SCHED_NORMAL | SCHED_BATCH | SCHED_IDLE | SCHED_DEADLINE | SCHED_EXT => Ok(0),
+        _ => Err(StarryError::InvalidInput),
+    }
+}
+
 enum PrioritySelector {
     CurrentProcess,
     Process(TgidNumber),
@@ -442,8 +469,8 @@ fn set_priority_for_processes(
 #[cfg(test)]
 pub(crate) fn schedule_clock_and_sched_validation_rules_hold_for_test() -> bool {
     use linux_raw_sys::general::{
-        CLOCK_MONOTONIC, CLOCK_REALTIME, SCHED_BATCH, SCHED_FIFO, SCHED_IDLE, SCHED_NORMAL,
-        SCHED_RR,
+        CLOCK_MONOTONIC, CLOCK_REALTIME, SCHED_BATCH, SCHED_DEADLINE, SCHED_EXT, SCHED_FIFO,
+        SCHED_IDLE, SCHED_NORMAL, SCHED_RR,
     };
 
     // Test clock_nanosleep clock_id validation
@@ -460,6 +487,29 @@ pub(crate) fn schedule_clock_and_sched_validation_rules_hold_for_test() -> bool 
     let valid_policies = [SCHED_NORMAL, SCHED_FIFO, SCHED_RR, SCHED_BATCH, SCHED_IDLE];
 
     assert!(valid_policies.contains(&SCHED_NORMAL));
+
+    for policy in [SCHED_FIFO, SCHED_RR] {
+        assert_eq!(sys_sched_get_priority_max(policy as i32), Ok(99));
+        assert_eq!(sys_sched_get_priority_min(policy as i32), Ok(1));
+    }
+    for policy in [
+        SCHED_NORMAL,
+        SCHED_BATCH,
+        SCHED_IDLE,
+        SCHED_DEADLINE,
+        SCHED_EXT,
+    ] {
+        assert_eq!(sys_sched_get_priority_max(policy as i32), Ok(0));
+        assert_eq!(sys_sched_get_priority_min(policy as i32), Ok(0));
+    }
+    assert!(matches!(
+        sys_sched_get_priority_max(1000),
+        Err(StarryError::InvalidInput)
+    ));
+    assert!(matches!(
+        sys_sched_get_priority_min(1000),
+        Err(StarryError::InvalidInput)
+    ));
 
     true
 }

--- a/test-suit/starryos/qemu/system/test-sched-family/src/main.c
+++ b/test-suit/starryos/qemu/system/test-sched-family/src/main.c
@@ -162,6 +162,33 @@ int main(void)
         CHECK_RET(sched_yield(), 0, "sched_yield returns 0");
     }
 
+    // Test Linux priority bounds for every recognized scheduling policy.
+    {
+        CHECK_RET(syscall(SYS_SCHED_GET_PRIORITY_MAX, SCHED_FIFO), 99,
+            "sched_get_priority_max SCHED_FIFO returns 99");
+        CHECK_RET(syscall(SYS_SCHED_GET_PRIORITY_MIN, SCHED_FIFO), 1,
+            "sched_get_priority_min SCHED_FIFO returns 1");
+        CHECK_RET(syscall(SYS_SCHED_GET_PRIORITY_MAX, SCHED_RR), 99,
+            "sched_get_priority_max SCHED_RR returns 99");
+        CHECK_RET(syscall(SYS_SCHED_GET_PRIORITY_MIN, SCHED_RR), 1,
+            "sched_get_priority_min SCHED_RR returns 1");
+
+        int non_rt_policies[] = {
+            SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, SCHED_DEADLINE, SCHED_EXT,
+        };
+        for (size_t i = 0; i < sizeof(non_rt_policies) / sizeof(non_rt_policies[0]); i++) {
+            CHECK_RET(syscall(SYS_SCHED_GET_PRIORITY_MAX, non_rt_policies[i]), 0,
+                "sched_get_priority_max non-RT policy returns 0");
+            CHECK_RET(syscall(SYS_SCHED_GET_PRIORITY_MIN, non_rt_policies[i]), 0,
+                "sched_get_priority_min non-RT policy returns 0");
+        }
+
+        CHECK_ERR(syscall(SYS_SCHED_GET_PRIORITY_MAX, 1000), EINVAL,
+            "sched_get_priority_max invalid policy returns EINVAL");
+        CHECK_ERR(syscall(SYS_SCHED_GET_PRIORITY_MIN, 1000), EINVAL,
+            "sched_get_priority_min invalid policy returns EINVAL");
+    }
+
     // 测试 sched_setscheduler() / sched_getscheduler 
     {
         #define SCHED_RESET_ON_FORK 0x40000000

--- a/test-suit/starryos/qemu/system/test-sched-family/src/test_framework.h
+++ b/test-suit/starryos/qemu/system/test-sched-family/src/test_framework.h
@@ -7,25 +7,41 @@
 #if defined(__x86_64__)
     #define SYS_SCHED_GETPARAM      143
     #define SYS_SCHED_GETSCHEDULER  145
+    #define SYS_SCHED_GET_PRIORITY_MAX 146
+    #define SYS_SCHED_GET_PRIORITY_MIN 147
     #define SYS_SCHED_SETSCHEDULER  144
 
 #elif defined(__riscv)
     #define SYS_SCHED_GETPARAM      121
     #define SYS_SCHED_GETSCHEDULER  120
+    #define SYS_SCHED_GET_PRIORITY_MAX 125
+    #define SYS_SCHED_GET_PRIORITY_MIN 126
     #define SYS_SCHED_SETSCHEDULER  119
 
 #elif defined(__aarch64__)
     #define SYS_SCHED_GETPARAM      121
     #define SYS_SCHED_GETSCHEDULER  120
+    #define SYS_SCHED_GET_PRIORITY_MAX 125
+    #define SYS_SCHED_GET_PRIORITY_MIN 126
     #define SYS_SCHED_SETSCHEDULER  119
 
 #elif defined(__loongarch64)
     #define SYS_SCHED_GETPARAM      121
     #define SYS_SCHED_GETSCHEDULER  120
+    #define SYS_SCHED_GET_PRIORITY_MAX 125
+    #define SYS_SCHED_GET_PRIORITY_MIN 126
     #define SYS_SCHED_SETSCHEDULER  119
 
 #else
     #error "unsupported architecture for sched syscalls"
+#endif
+
+#ifndef SCHED_DEADLINE
+    #define SCHED_DEADLINE 6
+#endif
+
+#ifndef SCHED_EXT
+    #define SCHED_EXT 7
 #endif
 
 #include <stdio.h>
@@ -87,4 +103,3 @@ static int __fail = 0;
     printf("  DONE: %d pass, %d fail\n", __pass, __fail);               \
     printf("================================================\n\n");    \
     return __fail > 0 ? 1 : 0
-    


### PR DESCRIPTION
## Summary

Implement `sched_get_priority_max(2)` and `sched_get_priority_min(2)` in StarryOS, wire them into the syscall dispatcher, and enable the corresponding LTP coverage.

## Design review

- Independent design material: #2153
- User/problem evidence: #1507, especially the [StarryOS/Linux gap analysis](https://github.com/rcore-os/tgoskits/issues/1507#issuecomment-5264199121)
- Historical implementation context: #2147; this PR narrows that earlier combined scheduling change to two stateless queries
- Selected approach: add two handlers at the existing syscall boundary instead of keeping `ENOSYS`, emulating the ABI in libc, reusing task-state queries with different semantics, or introducing a speculative scheduler abstraction
- Non-goals: this PR does not add scheduling algorithms, implement `SCHED_DEADLINE`/`SCHED_EXT`, or change task state, permissions, capabilities, locking, or existing scheduler behavior

Design approval is requested in #2153 from @YanLien for the syscall/ABI boundary and @Josen-B for scheduling semantics before merge.

## Rationale

StarryOS already implements `sched_setscheduler`, `sched_getscheduler`, `sched_setparam`, `sched_getparam`, and `sched_yield`, but the two priority-range queries were missing, so `sched.h` helpers and LTP scheduling tests could not determine the supported priority bounds.

The behavior follows Linux:

- Linux reference: `torvalds/linux` at `26260251022fbc2f248a3d747a9b2b961b18d2d8`
- [`sched_get_priority_max` implementation](https://github.com/torvalds/linux/blob/26260251022fbc2f248a3d747a9b2b961b18d2d8/kernel/sched/syscalls.c#L1461-L1487)
- [`sched_get_priority_min` implementation](https://github.com/torvalds/linux/blob/26260251022fbc2f248a3d747a9b2b961b18d2d8/kernel/sched/syscalls.c#L1489-L1514)

| Policy | max | min |
| --- | --- | --- |
| `SCHED_FIFO`, `SCHED_RR` | 99 | 1 |
| `SCHED_NORMAL`, `SCHED_BATCH`, `SCHED_IDLE`, `SCHED_DEADLINE`, `SCHED_EXT` | 0 | 0 |
| Unknown policy | `-EINVAL` | `-EINVAL` |

## Implementation

- `os/StarryOS/kernel/src/syscall/task/schedule.rs`: add both syscall implementations and kernel-side validation assertions.
- `os/StarryOS/kernel/src/syscall/mod.rs`: dispatch both syscall numbers.
- `test-suit/starryos/qemu/system/test-sched-family`: add direct raw-syscall checks for every recognized policy and for the invalid-policy `EINVAL` path.
- `apps/starry/qemu/syscall-test`: remove both names from `TODO.txt` and enable the LTP 20260529 cases `sched_get_priority_max01/02` and `sched_get_priority_min01/02`.

## Testing

- `cargo xtask starry test qemu --arch x86_64 -c qemu/system/test-sched-family`: 52 pass, 0 fail.
- LTP 20260529 guest run: `sched_get_priority_max01` (6/6 policies), `sched_get_priority_max02` (`EINVAL`), `sched_get_priority_min01` (6/6 policies), `sched_get_priority_min02` (`EINVAL`) — all passed.
- Host Linux 7.0 raw syscall comparison matches the table above.
- `cargo fmt --check`, `git diff --check`, and StarryOS kernel clippy with `-D warnings` all pass.


