### PR TITLE
fix(net): complete StarryOS guest bootstrap and link observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "arceos-guest-ip-server"
+version = "0.1.0"
+dependencies = [
+ "ax-std",
+ "guest-ip-protocol",
+]
+
+[[package]]
 name = "arceos-helloworld"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3788,6 +3788,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "guest-ip-protocol"
+version = "0.1.0"
+
+[[package]]
 name = "h2"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,7 @@ dependencies = [
 name = "arceos-guest-ip-server"
 version = "0.1.0"
 dependencies = [
+ "ax-net",
  "ax-std",
  "guest-ip-protocol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
     "components/axtest/axtest_macros",
     "components/cpu-local",
     "components/ax-cgroup",
+    "components/guest-ip-protocol",
     "components/ax-lazyinit",
     "components/axbacktrace",
     "components/axcpu",
@@ -120,6 +121,8 @@ exclude = [
 ]
 
 [workspace.dependencies]
+# Guest IP protocol shared by Starry/Linux and RTOS endpoint applications.
+guest-ip-protocol = { version = "0.1", path = "components/guest-ip-protocol" }
 # Local workspace crates
 # Keep local dependency requirements at major.minor precision so release-plz does not
 # propagate patch-only releases to dependent workspace crates.

--- a/apps/arceos/build-aarch64-guest-ip-server.toml
+++ b/apps/arceos/build-aarch64-guest-ip-server.toml
@@ -1,0 +1,6 @@
+env = { GIPC_ROLE = "rtos-server", GIPC_LOCAL_IP = "10.0.42.2" }
+features = ["net", "multitask", "ax-driver/virtio-net"]
+log = "Info"
+target = "aarch64-unknown-none-softfloat"
+max_cpu_num = 1
+to_bin = true

--- a/apps/arceos/guest-ip-server/Cargo.toml
+++ b/apps/arceos/guest-ip-server/Cargo.toml
@@ -10,4 +10,5 @@ arceos = ["dep:ax-std", "ax-std/arceos", "ax-std/net"]
 
 [dependencies]
 ax-std = { workspace = true, optional = true, features = ["default"] }
+ax-net = { workspace = true }
 guest-ip-protocol.workspace = true

--- a/apps/arceos/guest-ip-server/Cargo.toml
+++ b/apps/arceos/guest-ip-server/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "arceos-guest-ip-server"
+version = "0.1.0"
+edition.workspace = true
+publish = false
+
+[features]
+default = ["arceos"]
+arceos = ["dep:ax-std", "ax-std/arceos", "ax-std/net"]
+
+[dependencies]
+ax-std = { workspace = true, optional = true, features = ["default"] }
+guest-ip-protocol.workspace = true

--- a/apps/arceos/guest-ip-server/src/main.rs
+++ b/apps/arceos/guest-ip-server/src/main.rs
@@ -1,4 +1,4 @@
-//! Minimal RTOS endpoint for the Starry/Linux guest IP protocol.
+//! Minimal ArceOS endpoint for the StarryOS guest IP protocol.
 
 #[cfg(feature = "arceos")]
 use std::{

--- a/apps/arceos/guest-ip-server/src/main.rs
+++ b/apps/arceos/guest-ip-server/src/main.rs
@@ -21,11 +21,11 @@ const CONTROL_PAYLOAD_LEN: usize = 8;
 
 #[cfg(feature = "arceos")]
 fn main() {
+    println!("GIPC_RTOS_READY");
     if let Err(error) = run() {
         println!("GIPC_RTOS_ERROR {error}");
         return;
     }
-    println!("GIPC_RTOS_READY");
 }
 
 #[cfg(not(feature = "arceos"))]
@@ -40,10 +40,14 @@ fn run() -> std::io::Result<()> {
 
     let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, LISTEN_PORT))?;
     println!("GIPC_RTOS_LISTEN ip=10.0.42.2 port={LISTEN_PORT}");
-    let (mut stream, peer) = listener.accept()?;
-    serve_connection(&mut stream)?;
-    println!("GIPC_RTOS_PEER {peer}");
-    Ok(())
+    loop {
+        let (mut stream, peer) = listener.accept()?;
+        println!("GIPC_RTOS_CONNECTED peer={peer}");
+        match serve_connection(&mut stream) {
+            Ok(()) => println!("GIPC_RTOS_DISCONNECTED peer={peer}"),
+            Err(error) => println!("GIPC_RTOS_RECOVERABLE_ERROR peer={peer} error={error}"),
+        }
+    }
 }
 
 #[cfg(feature = "arceos")]

--- a/apps/arceos/guest-ip-server/src/main.rs
+++ b/apps/arceos/guest-ip-server/src/main.rs
@@ -33,9 +33,9 @@ fn main() {}
 
 #[cfg(feature = "arceos")]
 fn run() -> std::io::Result<()> {
-    let interface = ax_std::net::interface_by_name("eth0")
+    let interface = ax_net::interface_by_name("eth0")
         .ok_or_else(|| std::io::Error::other("eth0 was not discovered"))?;
-    ax_std::net::set_interface_ipv4(interface.id, Ipv4Addr::new(10, 0, 42, 2), 24)
+    ax_net::set_interface_ipv4(interface.id, Ipv4Addr::new(10, 0, 42, 2), 24)
         .map_err(|error| std::io::Error::other(format!("configure eth0: {error}")))?;
 
     let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, LISTEN_PORT))?;

--- a/apps/arceos/guest-ip-server/src/main.rs
+++ b/apps/arceos/guest-ip-server/src/main.rs
@@ -1,0 +1,109 @@
+//! Minimal RTOS endpoint for the Starry/Linux guest IP protocol.
+
+#[cfg(feature = "arceos")]
+use std::{
+    io::{Read, Write},
+    net::{Ipv4Addr, TcpListener, TcpStream},
+};
+
+#[cfg(feature = "arceos")]
+use ax_std as _;
+#[cfg(feature = "arceos")]
+use guest_ip_protocol::{
+    ErrorCode, HEADER_LEN, Header, MAX_PAYLOAD, MessageType, decode_frame, encode_frame,
+};
+
+#[cfg(feature = "arceos")]
+const LISTEN_PORT: u16 = 4242;
+#[cfg(feature = "arceos")]
+const CONTROL_PAYLOAD_LEN: usize = 8;
+
+#[cfg(feature = "arceos")]
+fn main() {
+    if let Err(error) = run() {
+        println!("GIPC_RTOS_ERROR {error}");
+        return;
+    }
+    println!("GIPC_RTOS_READY");
+}
+
+#[cfg(not(feature = "arceos"))]
+fn main() {}
+
+#[cfg(feature = "arceos")]
+fn run() -> std::io::Result<()> {
+    let interface = ax_std::net::interface_by_name("eth0")
+        .ok_or_else(|| std::io::Error::other("eth0 was not discovered"))?;
+    ax_std::net::set_interface_ipv4(interface.id, Ipv4Addr::new(10, 0, 42, 2), 24)
+        .map_err(|error| std::io::Error::other(format!("configure eth0: {error}")))?;
+
+    let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, LISTEN_PORT))?;
+    println!("GIPC_RTOS_LISTEN ip=10.0.42.2 port={LISTEN_PORT}");
+    let (mut stream, peer) = listener.accept()?;
+    serve_connection(&mut stream)?;
+    println!("GIPC_RTOS_PEER {peer}");
+    Ok(())
+}
+
+#[cfg(feature = "arceos")]
+fn serve_connection(stream: &mut TcpStream) -> std::io::Result<()> {
+    let mut frame = [0u8; HEADER_LEN + MAX_PAYLOAD];
+    loop {
+        let header = read_header(stream, &mut frame)?;
+        let payload_len = header.payload_len as usize;
+        stream.read_exact(&mut frame[HEADER_LEN..HEADER_LEN + payload_len])?;
+        let frame_len = HEADER_LEN + payload_len;
+        let (decoded, payload) = decode_frame(&frame[..frame_len])
+            .map_err(|error| std::io::Error::other(format!("decode frame: {error}")))?;
+        match decoded.message_type {
+            MessageType::Hello | MessageType::Heartbeat => {
+                send_status(stream, decoded.sequence, payload)?;
+            }
+            MessageType::Control => {
+                if payload.len() != CONTROL_PAYLOAD_LEN {
+                    send_error(stream, decoded.sequence, ErrorCode::InvalidPayload)?;
+                } else {
+                    send_status(stream, decoded.sequence, payload)?;
+                }
+            }
+            MessageType::Ack => {}
+            MessageType::Status | MessageType::Error => {
+                send_error(stream, decoded.sequence, ErrorCode::UnsupportedMessage)?;
+            }
+        }
+    }
+}
+
+#[cfg(feature = "arceos")]
+fn read_header(stream: &mut TcpStream, frame: &mut [u8]) -> std::io::Result<Header> {
+    stream.read_exact(&mut frame[..HEADER_LEN])?;
+    guest_ip_protocol::decode_header(&frame[..HEADER_LEN])
+        .map_err(|error| std::io::Error::other(format!("invalid frame header: {error}")))
+}
+
+#[cfg(feature = "arceos")]
+fn send_status(stream: &mut TcpStream, sequence: u32, payload: &[u8]) -> std::io::Result<()> {
+    let header = Header::new(
+        MessageType::Status,
+        0,
+        payload.len(),
+        sequence,
+        0,
+        ErrorCode::None,
+    )
+    .ok_or_else(|| std::io::Error::other("status payload too large"))?;
+    let mut output = [0u8; HEADER_LEN + MAX_PAYLOAD];
+    let length = encode_frame(header, payload, &mut output)
+        .map_err(|error| std::io::Error::other(format!("encode status: {error}")))?;
+    stream.write_all(&output[..length])
+}
+
+#[cfg(feature = "arceos")]
+fn send_error(stream: &mut TcpStream, sequence: u32, error: ErrorCode) -> std::io::Result<()> {
+    let header = Header::new(MessageType::Error, 0, 0, sequence, 0, error)
+        .ok_or_else(|| std::io::Error::other("error payload too large"))?;
+    let mut output = [0u8; HEADER_LEN + MAX_PAYLOAD];
+    let length = encode_frame(header, &[], &mut output)
+        .map_err(|encode_error| std::io::Error::other(format!("encode error: {encode_error}")))?;
+    stream.write_all(&output[..length])
+}

--- a/apps/arceos/guest-ip-server/src/main.rs
+++ b/apps/arceos/guest-ip-server/src/main.rs
@@ -10,7 +10,8 @@ use std::{
 use ax_std as _;
 #[cfg(feature = "arceos")]
 use guest_ip_protocol::{
-    ErrorCode, HEADER_LEN, Header, MAX_PAYLOAD, MessageType, decode_frame, encode_frame,
+    ErrorCode, HEADER_LEN, Header, MAX_PAYLOAD, MessageType, ReceiveSequence, ReliableSession,
+    RetryPolicy, decode_frame, encode_frame,
 };
 
 #[cfg(feature = "arceos")]
@@ -48,6 +49,9 @@ fn run() -> std::io::Result<()> {
 #[cfg(feature = "arceos")]
 fn serve_connection(stream: &mut TcpStream) -> std::io::Result<()> {
     let mut frame = [0u8; HEADER_LEN + MAX_PAYLOAD];
+    let policy =
+        RetryPolicy::new(1000, 3).ok_or_else(|| std::io::Error::other("invalid retry policy"))?;
+    let mut session = ReliableSession::new(policy);
     loop {
         let header = read_header(stream, &mut frame)?;
         let payload_len = header.payload_len as usize;
@@ -55,6 +59,19 @@ fn serve_connection(stream: &mut TcpStream) -> std::io::Result<()> {
         let frame_len = HEADER_LEN + payload_len;
         let (decoded, payload) = decode_frame(&frame[..frame_len])
             .map_err(|error| std::io::Error::other(format!("decode frame: {error}")))?;
+        match session.observe(decoded.sequence) {
+            ReceiveSequence::Duplicate => {
+                if decoded.message_type == MessageType::Control {
+                    send_status(stream, decoded.sequence, payload)?;
+                }
+                continue;
+            }
+            ReceiveSequence::OutOfOrder => {
+                send_error(stream, decoded.sequence, ErrorCode::InvalidSequence)?;
+                continue;
+            }
+            ReceiveSequence::New => {}
+        }
         match decoded.message_type {
             MessageType::Hello | MessageType::Heartbeat => {
                 send_status(stream, decoded.sequence, payload)?;

--- a/apps/starry/guest-ip-link/README.md
+++ b/apps/starry/guest-ip-link/README.md
@@ -1,22 +1,22 @@
-# Starry/Linux guest IP client
+# StarryOS guest IP client
 
-`linux-client.c` is the POSIX endpoint for the GIPC control path. It opens a
-TCP connection to the RTOS guest at `10.0.42.2:4242`, sends one versioned
+`linux-client.c` is the POSIX StarryOS endpoint for the GIPC control path. It opens a
+TCP connection to the ArceOS guest at `10.0.42.2:4242`, sends one versioned
 `CONTROL` frame, validates the `STATUS` response and CRC, and retries the whole
 request up to three times after a connect, send, receive, or protocol failure.
 
 The source is intentionally freestanding so it can be copied into a Starry or
-Linux rootfs by the image-preparation step. Build it in a Linux/Starry guest
+StarryOS rootfs by the image-preparation step. Build it for the StarryOS guest
 with:
 
 ```sh
-cc -std=c11 -Wall -Wextra -O2 linux-client.c -o /usr/bin/gipc-linux-client
-/usr/bin/gipc-linux-client 10.0.42.2
+cc -std=c11 -Wall -Wextra -O2 linux-client.c -o /usr/bin/gipc-starry-client
+/usr/bin/gipc-starry-client 10.0.42.2
 ```
 
-The successful run prints `GIPC_LINUX_STATUS` and `GIPC_LINUX_METRIC`; a failed
-run prints `GIPC_LINUX_TIMEOUT` or a protocol error and exits non-zero.
+The successful run prints `GIPC_STARRY_STATUS` and `GIPC_STARRY_METRIC`; a failed
+run prints `GIPC_STARRY_TIMEOUT` or a protocol error and exits non-zero.
 
 The QEMU runner injects `gipc-autostart.sh` into `/etc/profile.d` by default,
-so the client runs once when the Linux guest opens a shell. Set
+so the client runs once when the StarryOS guest opens a shell. Set
 `GIPC_AUTORUN=0` to disable this behavior and run the client manually.

--- a/apps/starry/guest-ip-link/README.md
+++ b/apps/starry/guest-ip-link/README.md
@@ -16,3 +16,7 @@ cc -std=c11 -Wall -Wextra -O2 linux-client.c -o /usr/bin/gipc-linux-client
 
 The successful run prints `GIPC_LINUX_STATUS` and `GIPC_LINUX_METRIC`; a failed
 run prints `GIPC_LINUX_TIMEOUT` or a protocol error and exits non-zero.
+
+The QEMU runner injects `gipc-autostart.sh` into `/etc/profile.d` by default,
+so the client runs once when the Linux guest opens a shell. Set
+`GIPC_AUTORUN=0` to disable this behavior and run the client manually.

--- a/apps/starry/guest-ip-link/README.md
+++ b/apps/starry/guest-ip-link/README.md
@@ -1,0 +1,18 @@
+# Starry/Linux guest IP client
+
+`linux-client.c` is the POSIX endpoint for the GIPC control path. It opens a
+TCP connection to the RTOS guest at `10.0.42.2:4242`, sends one versioned
+`CONTROL` frame, validates the `STATUS` response and CRC, and retries the whole
+request up to three times after a connect, send, receive, or protocol failure.
+
+The source is intentionally freestanding so it can be copied into a Starry or
+Linux rootfs by the image-preparation step. Build it in a Linux/Starry guest
+with:
+
+```sh
+cc -std=c11 -Wall -Wextra -O2 linux-client.c -o /usr/bin/gipc-linux-client
+/usr/bin/gipc-linux-client 10.0.42.2
+```
+
+The successful run prints `GIPC_LINUX_STATUS` and `GIPC_LINUX_METRIC`; a failed
+run prints `GIPC_LINUX_TIMEOUT` or a protocol error and exits non-zero.

--- a/apps/starry/guest-ip-link/gipc-autostart.sh
+++ b/apps/starry/guest-ip-link/gipc-autostart.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+if [ "${GIPC_AUTORUN:-1}" != "1" ]; then
+    exit 0
+fi
+
+mkdir -p /run
+if [ -e /run/gipc-linux-client.done ]; then
+    exit 0
+fi
+touch /run/gipc-linux-client.done
+exec /usr/bin/gipc-linux-client "${GIPC_PEER_IP:-10.0.42.2}"

--- a/apps/starry/guest-ip-link/gipc-autostart.sh
+++ b/apps/starry/guest-ip-link/gipc-autostart.sh
@@ -10,5 +10,6 @@ mkdir -p /run
 if [ -e /run/gipc-starry-client.done ]; then
     exit 0
 fi
+sh /usr/bin/gipc-network-init.sh
 touch /run/gipc-starry-client.done
 exec /usr/bin/gipc-starry-client "${GIPC_PEER_IP:-10.0.42.2}"

--- a/apps/starry/guest-ip-link/gipc-autostart.sh
+++ b/apps/starry/guest-ip-link/gipc-autostart.sh
@@ -7,8 +7,8 @@ if [ "${GIPC_AUTORUN:-1}" != "1" ]; then
 fi
 
 mkdir -p /run
-if [ -e /run/gipc-linux-client.done ]; then
+if [ -e /run/gipc-starry-client.done ]; then
     exit 0
 fi
-touch /run/gipc-linux-client.done
-exec /usr/bin/gipc-linux-client "${GIPC_PEER_IP:-10.0.42.2}"
+touch /run/gipc-starry-client.done
+exec /usr/bin/gipc-starry-client "${GIPC_PEER_IP:-10.0.42.2}"

--- a/apps/starry/guest-ip-link/linux-client.c
+++ b/apps/starry/guest-ip-link/linux-client.c
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Minimal POSIX/Linux client for the Starry/Linux -> RTOS GIPC control path.
+
+#define _POSIX_C_SOURCE 200809L
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <time.h>
+#include <unistd.h>
+
+#define GIPC_MAGIC 0x47495043u
+#define GIPC_VERSION 1u
+#define GIPC_HEADER_LEN 32u
+#define GIPC_MAX_PAYLOAD 1200u
+#define GIPC_CONTROL 2u
+#define GIPC_STATUS 3u
+#define GIPC_ERROR 4u
+#define GIPC_PORT 4242u
+
+struct gipc_header {
+    uint32_t magic;
+    uint8_t version;
+    uint8_t message_type;
+    uint16_t flags;
+    uint16_t header_len;
+    uint16_t payload_len;
+    uint32_t sequence;
+    uint64_t timestamp_ns;
+    uint16_t error_code;
+    uint32_t checksum;
+};
+
+static uint32_t crc32(const uint8_t *data, size_t length) {
+    uint32_t crc = 0xffffffffu;
+    for (size_t i = 0; i < length; i++) {
+        crc ^= data[i];
+        for (unsigned bit = 0; bit < 8; bit++) {
+            crc = (crc & 1u) ? (crc >> 1) ^ 0xedb88320u : crc >> 1;
+        }
+    }
+    return ~crc;
+}
+
+static uint64_t monotonic_ns(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+static int write_full(int fd, const void *buffer, size_t length) {
+    const uint8_t *cursor = buffer;
+    while (length != 0) {
+        ssize_t written = send(fd, cursor, length, 0);
+        if (written <= 0) return -errno;
+        cursor += (size_t)written;
+        length -= (size_t)written;
+    }
+    return 0;
+}
+
+static int read_full(int fd, void *buffer, size_t length) {
+    uint8_t *cursor = buffer;
+    while (length != 0) {
+        ssize_t received = recv(fd, cursor, length, 0);
+        if (received == 0) return -ECONNRESET;
+        if (received < 0) return -errno;
+        cursor += (size_t)received;
+        length -= (size_t)received;
+    }
+    return 0;
+}
+
+static void put_u16(uint8_t *p, uint16_t value) { uint16_t wire = htons(value); memcpy(p, &wire, 2); }
+static void put_u32(uint8_t *p, uint32_t value) { uint32_t wire = htonl(value); memcpy(p, &wire, 4); }
+static uint16_t get_u16(const uint8_t *p) { uint16_t wire; memcpy(&wire, p, 2); return ntohs(wire); }
+static uint32_t get_u32(const uint8_t *p) { uint32_t wire; memcpy(&wire, p, 4); return ntohl(wire); }
+
+static size_t encode_control(uint8_t *frame, uint32_t sequence, uint64_t timestamp) {
+    const uint8_t payload[8] = {0, 0, 0, 1, 0, 0, 0, 0};
+    memset(frame, 0, GIPC_HEADER_LEN + sizeof(payload));
+    put_u32(frame + 0, GIPC_MAGIC);
+    frame[4] = GIPC_VERSION;
+    frame[5] = GIPC_CONTROL;
+    put_u16(frame + 6, 1u); // ACK_REQUIRED
+    put_u16(frame + 8, GIPC_HEADER_LEN);
+    put_u16(frame + 10, sizeof(payload));
+    put_u32(frame + 12, sequence);
+    put_u32(frame + 16, (uint32_t)(timestamp >> 32));
+    put_u32(frame + 20, (uint32_t)timestamp);
+    memcpy(frame + GIPC_HEADER_LEN, payload, sizeof(payload));
+    put_u32(frame + 26, crc32(frame, GIPC_HEADER_LEN + sizeof(payload)));
+    return GIPC_HEADER_LEN + sizeof(payload);
+}
+
+int main(int argc, char **argv) {
+    const char *address = argc > 1 ? argv[1] : "10.0.42.2";
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) { perror("socket"); return 1; }
+
+    struct timeval timeout = {.tv_sec = 1, .tv_usec = 0};
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
+    struct sockaddr_in peer = {.sin_family = AF_INET, .sin_port = htons(GIPC_PORT)};
+    if (inet_pton(AF_INET, address, &peer.sin_addr) != 1 ||
+        connect(fd, (struct sockaddr *)&peer, sizeof(peer)) != 0) {
+        perror("connect"); close(fd); return 1;
+    }
+
+    uint8_t frame[GIPC_HEADER_LEN + GIPC_MAX_PAYLOAD];
+    size_t frame_len = encode_control(frame, 1, monotonic_ns());
+    if (write_full(fd, frame, frame_len) != 0) { perror("send"); close(fd); return 1; }
+    uint8_t response[GIPC_HEADER_LEN + GIPC_MAX_PAYLOAD];
+    if (read_full(fd, response, GIPC_HEADER_LEN) != 0) { perror("header"); close(fd); return 1; }
+    uint16_t payload_len = get_u16(response + 10);
+    if (payload_len > GIPC_MAX_PAYLOAD || read_full(fd, response + GIPC_HEADER_LEN, payload_len) != 0) {
+        fprintf(stderr, "invalid response payload\n"); close(fd); return 1;
+    }
+    if (get_u32(response) != GIPC_MAGIC || response[4] != GIPC_VERSION || response[5] != GIPC_STATUS) {
+        fprintf(stderr, "unexpected response type\n"); close(fd); return 1;
+    }
+    printf("GIPC_LINUX_STATUS seq=%u payload=%u\n", get_u32(response + 12), payload_len);
+    close(fd);
+    return 0;
+}

--- a/apps/starry/guest-ip-link/linux-client.c
+++ b/apps/starry/guest-ip-link/linux-client.c
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -125,43 +126,69 @@ static size_t encode_control(uint8_t *frame, uint32_t sequence, uint64_t timesta
     return GIPC_HEADER_LEN + sizeof(payload);
 }
 
-int main(int argc, char **argv) {
-    const char *address = argc > 1 ? argv[1] : "10.0.42.2";
+static int request_once(const char *address, uint32_t sequence, unsigned *attempts,
+                       unsigned *timeouts, unsigned *reconnects, unsigned *errors,
+                       uint64_t *rtt_ns, uint64_t *throughput_bps) {
     uint8_t frame[GIPC_HEADER_LEN + GIPC_MAX_PAYLOAD];
-    unsigned timeouts = 0;
-    uint64_t request_start = monotonic_ns();
     for (unsigned attempt = 0; attempt < 3; attempt++) {
         int fd = connect_peer(address);
-        if (fd < 0) { timeouts++; continue; }
-        size_t frame_len = encode_control(frame, 1, monotonic_ns());
+        (*attempts)++;
+        if (fd < 0) { (*timeouts)++; continue; }
+        if (attempt > 0) (*reconnects)++;
+        uint64_t request_start = monotonic_ns();
+        size_t frame_len = encode_control(frame, sequence, request_start);
         if (write_full(fd, frame, frame_len) != 0) {
-            close(fd); timeouts++; continue;
+            close(fd); (*timeouts)++; continue;
         }
         uint8_t response[GIPC_HEADER_LEN + GIPC_MAX_PAYLOAD];
         if (read_full(fd, response, GIPC_HEADER_LEN) != 0) {
-            close(fd); timeouts++; continue;
+            close(fd); (*timeouts)++; continue;
         }
         uint16_t payload_len = get_u16(response + 10);
         if (payload_len > GIPC_MAX_PAYLOAD ||
             read_full(fd, response + GIPC_HEADER_LEN, payload_len) != 0) {
-            close(fd); timeouts++; continue;
+            close(fd); (*timeouts)++; continue;
         }
         if (get_u32(response) != GIPC_MAGIC || response[4] != GIPC_VERSION ||
-            response[5] != GIPC_STATUS || get_u32(response + 12) != 1 ||
-            !verify_crc(response, GIPC_HEADER_LEN + payload_len)) {
-            close(fd); fprintf(stderr, "unexpected response type or sequence\n"); return 1;
+            get_u32(response + 12) != sequence || !verify_crc(response, GIPC_HEADER_LEN + payload_len)) {
+            close(fd); (*errors)++; fprintf(stderr, "GIPC_STARRY_ERROR code=protocol\n"); return -1;
+        }
+        if (response[5] == GIPC_ERROR) {
+            (*errors)++;
+            fprintf(stderr, "GIPC_STARRY_ERROR code=%u seq=%u\n", get_u16(response + 24), sequence);
+            close(fd); return -1;
+        }
+        if (response[5] != GIPC_STATUS) {
+            (*errors)++; close(fd); return -1;
         }
         uint64_t elapsed_ns = monotonic_ns() - request_start;
         if (elapsed_ns == 0) elapsed_ns = 1;
+        *rtt_ns = elapsed_ns;
+        *throughput_bps = (payload_len * 1000000000ull) / elapsed_ns;
         printf("GIPC_STARRY_STATUS seq=%u payload=%u attempts=%u timeouts=%u\n",
-               get_u32(response + 12), payload_len, attempt + 1, timeouts);
-        printf("GIPC_STARRY_METRIC success=1 errors=0 timeouts=%u rtt_ns=%llu throughput_bps=%llu\n",
-               timeouts,
-               (unsigned long long)elapsed_ns,
-               (unsigned long long)((payload_len * 1000000000ull) / elapsed_ns));
+               get_u32(response + 12), payload_len, *attempts, *timeouts);
         close(fd);
         return 0;
     }
-    fprintf(stderr, "GIPC_STARRY_TIMEOUT attempts=3\n");
-    return 1;
+    return -2;
+}
+
+int main(int argc, char **argv) {
+    const char *address = argc > 1 ? argv[1] : "10.0.42.2";
+    unsigned requests = argc > 2 ? (unsigned)strtoul(argv[2], NULL, 10) : 1;
+    if (requests == 0 || requests > 1000) { fprintf(stderr, "invalid request count\n"); return 2; }
+    unsigned timeouts = 0, attempts = 0, reconnects = 0, errors = 0, successes = 0;
+    uint64_t total_rtt = 0, total_throughput = 0;
+    for (unsigned i = 0; i < requests; i++) {
+        uint64_t rtt = 0, throughput = 0;
+        int result = request_once(address, i + 1, &attempts, &timeouts, &reconnects,
+                                  &errors, &rtt, &throughput);
+        if (result == 0) { successes++; total_rtt += rtt; total_throughput += throughput; }
+        else if (result == -2) fprintf(stderr, "GIPC_STARRY_TIMEOUT seq=%u attempts=3\n", i + 1);
+    }
+    printf("GIPC_STARRY_METRIC requests=%u success=%u success_rate=%u errors=%u timeouts=%u attempts=%u reconnects=%u recovery=%u rtt_ns=%llu throughput_bps=%llu\n",
+           requests, successes, successes == requests, errors, timeouts, attempts, reconnects,
+           (successes > 0 && reconnects > 0), (unsigned long long)(successes ? total_rtt / successes : 0),
+           (unsigned long long)(successes ? total_throughput / successes : 0));
+    return successes == requests ? 0 : 1;
 }

--- a/apps/starry/guest-ip-link/linux-client.c
+++ b/apps/starry/guest-ip-link/linux-client.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Minimal POSIX/Linux client for the Starry/Linux -> RTOS GIPC control path.
+// Minimal POSIX StarryOS client for the StarryOS -> ArceOS GIPC control path.
 
 #define _POSIX_C_SOURCE 200809L
 
@@ -153,15 +153,15 @@ int main(int argc, char **argv) {
         }
         uint64_t elapsed_ns = monotonic_ns() - request_start;
         if (elapsed_ns == 0) elapsed_ns = 1;
-        printf("GIPC_LINUX_STATUS seq=%u payload=%u attempts=%u timeouts=%u\n",
+        printf("GIPC_STARRY_STATUS seq=%u payload=%u attempts=%u timeouts=%u\n",
                get_u32(response + 12), payload_len, attempt + 1, timeouts);
-        printf("GIPC_LINUX_METRIC success=1 errors=0 timeouts=%u rtt_ns=%llu throughput_bps=%llu\n",
+        printf("GIPC_STARRY_METRIC success=1 errors=0 timeouts=%u rtt_ns=%llu throughput_bps=%llu\n",
                timeouts,
                (unsigned long long)elapsed_ns,
                (unsigned long long)((payload_len * 1000000000ull) / elapsed_ns));
         close(fd);
         return 0;
     }
-    fprintf(stderr, "GIPC_LINUX_TIMEOUT attempts=3\n");
+    fprintf(stderr, "GIPC_STARRY_TIMEOUT attempts=3\n");
     return 1;
 }

--- a/apps/starry/guest-ip-link/linux-client.c
+++ b/apps/starry/guest-ip-link/linux-client.c
@@ -75,10 +75,38 @@ static int read_full(int fd, void *buffer, size_t length) {
     return 0;
 }
 
+static int connect_peer(const char *address) {
+    int fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) return -1;
+    struct timeval timeout = {.tv_sec = 1, .tv_usec = 0};
+    if (setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout)) != 0 ||
+        setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+        close(fd);
+        return -1;
+    }
+    struct sockaddr_in peer = {.sin_family = AF_INET, .sin_port = htons(GIPC_PORT)};
+    if (inet_pton(AF_INET, address, &peer.sin_addr) != 1 ||
+        connect(fd, (struct sockaddr *)&peer, sizeof(peer)) != 0) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
 static void put_u16(uint8_t *p, uint16_t value) { uint16_t wire = htons(value); memcpy(p, &wire, 2); }
 static void put_u32(uint8_t *p, uint32_t value) { uint32_t wire = htonl(value); memcpy(p, &wire, 4); }
 static uint16_t get_u16(const uint8_t *p) { uint16_t wire; memcpy(&wire, p, 2); return ntohs(wire); }
 static uint32_t get_u32(const uint8_t *p) { uint32_t wire; memcpy(&wire, p, 4); return ntohl(wire); }
+
+static int verify_crc(const uint8_t *frame, size_t length) {
+    if (length < GIPC_HEADER_LEN) return 0;
+    uint8_t copy[GIPC_HEADER_LEN + GIPC_MAX_PAYLOAD];
+    if (length > sizeof(copy)) return 0;
+    memcpy(copy, frame, length);
+    uint32_t expected = get_u32(copy + 26);
+    memset(copy + 26, 0, 4);
+    return expected == crc32(copy, length);
+}
 
 static size_t encode_control(uint8_t *frame, uint32_t sequence, uint64_t timestamp) {
     const uint8_t payload[8] = {0, 0, 0, 1, 0, 0, 0, 0};
@@ -99,31 +127,41 @@ static size_t encode_control(uint8_t *frame, uint32_t sequence, uint64_t timesta
 
 int main(int argc, char **argv) {
     const char *address = argc > 1 ? argv[1] : "10.0.42.2";
-    int fd = socket(AF_INET, SOCK_STREAM, 0);
-    if (fd < 0) { perror("socket"); return 1; }
-
-    struct timeval timeout = {.tv_sec = 1, .tv_usec = 0};
-    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
-    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
-    struct sockaddr_in peer = {.sin_family = AF_INET, .sin_port = htons(GIPC_PORT)};
-    if (inet_pton(AF_INET, address, &peer.sin_addr) != 1 ||
-        connect(fd, (struct sockaddr *)&peer, sizeof(peer)) != 0) {
-        perror("connect"); close(fd); return 1;
-    }
-
     uint8_t frame[GIPC_HEADER_LEN + GIPC_MAX_PAYLOAD];
-    size_t frame_len = encode_control(frame, 1, monotonic_ns());
-    if (write_full(fd, frame, frame_len) != 0) { perror("send"); close(fd); return 1; }
-    uint8_t response[GIPC_HEADER_LEN + GIPC_MAX_PAYLOAD];
-    if (read_full(fd, response, GIPC_HEADER_LEN) != 0) { perror("header"); close(fd); return 1; }
-    uint16_t payload_len = get_u16(response + 10);
-    if (payload_len > GIPC_MAX_PAYLOAD || read_full(fd, response + GIPC_HEADER_LEN, payload_len) != 0) {
-        fprintf(stderr, "invalid response payload\n"); close(fd); return 1;
+    unsigned timeouts = 0;
+    uint64_t request_start = monotonic_ns();
+    for (unsigned attempt = 0; attempt < 3; attempt++) {
+        int fd = connect_peer(address);
+        if (fd < 0) { timeouts++; continue; }
+        size_t frame_len = encode_control(frame, 1, monotonic_ns());
+        if (write_full(fd, frame, frame_len) != 0) {
+            close(fd); timeouts++; continue;
+        }
+        uint8_t response[GIPC_HEADER_LEN + GIPC_MAX_PAYLOAD];
+        if (read_full(fd, response, GIPC_HEADER_LEN) != 0) {
+            close(fd); timeouts++; continue;
+        }
+        uint16_t payload_len = get_u16(response + 10);
+        if (payload_len > GIPC_MAX_PAYLOAD ||
+            read_full(fd, response + GIPC_HEADER_LEN, payload_len) != 0) {
+            close(fd); timeouts++; continue;
+        }
+        if (get_u32(response) != GIPC_MAGIC || response[4] != GIPC_VERSION ||
+            response[5] != GIPC_STATUS || get_u32(response + 12) != 1 ||
+            !verify_crc(response, GIPC_HEADER_LEN + payload_len)) {
+            close(fd); fprintf(stderr, "unexpected response type or sequence\n"); return 1;
+        }
+        uint64_t elapsed_ns = monotonic_ns() - request_start;
+        if (elapsed_ns == 0) elapsed_ns = 1;
+        printf("GIPC_LINUX_STATUS seq=%u payload=%u attempts=%u timeouts=%u\n",
+               get_u32(response + 12), payload_len, attempt + 1, timeouts);
+        printf("GIPC_LINUX_METRIC success=1 errors=0 timeouts=%u rtt_ns=%llu throughput_bps=%llu\n",
+               timeouts,
+               (unsigned long long)elapsed_ns,
+               (unsigned long long)((payload_len * 1000000000ull) / elapsed_ns));
+        close(fd);
+        return 0;
     }
-    if (get_u32(response) != GIPC_MAGIC || response[4] != GIPC_VERSION || response[5] != GIPC_STATUS) {
-        fprintf(stderr, "unexpected response type\n"); close(fd); return 1;
-    }
-    printf("GIPC_LINUX_STATUS seq=%u payload=%u\n", get_u32(response + 12), payload_len);
-    close(fd);
-    return 0;
+    fprintf(stderr, "GIPC_LINUX_TIMEOUT attempts=3\n");
+    return 1;
 }

--- a/apps/starry/guest-ip-link/network-init.sh
+++ b/apps/starry/guest-ip-link/network-init.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# Configure the StarryOS side of the private VirtIO-net link before the
+# application starts.  The peer (ArceOS) uses 10.0.42.2/24.
+set -eu
+
+interface=${GIPC_INTERFACE:-eth0}
+address=${GIPC_STARRY_IP:-10.0.42.1/24}
+peer=${GIPC_PEER_IP:-10.0.42.2}
+
+command -v ip >/dev/null 2>&1 || {
+    echo "GIPC_STARRY_NET_ERROR missing ip command" >&2
+    exit 1
+}
+
+ip link show "$interface" >/dev/null 2>&1 || {
+    echo "GIPC_STARRY_NET_ERROR interface=$interface unavailable" >&2
+    exit 1
+}
+ip link set "$interface" up
+if ! ip addr show dev "$interface" | grep -q "$(printf '%s' "$address" | cut -d/ -f1)"; then
+    ip addr add "$address" dev "$interface"
+fi
+if ! ip route show dev "$interface" | grep -q "10.0.42.0/24"; then
+    ip route add 10.0.42.0/24 dev "$interface" 2>/dev/null || true
+fi
+ip addr show dev "$interface" | grep -q "$(printf '%s' "$address" | cut -d/ -f1)" || {
+    echo "GIPC_STARRY_NET_ERROR address=$address not configured" >&2
+    exit 1
+}
+echo "GIPC_STARRY_NET_READY interface=$interface address=$address peer=$peer"

--- a/components/guest-ip-protocol/Cargo.toml
+++ b/components/guest-ip-protocol/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "guest-ip-protocol"
+version = "0.1.0"
+edition.workspace = true
+description = "Versioned application protocol for Starry/Linux and RTOS guest IP links"
+license.workspace = true
+publish = false
+
+[features]
+default = []
+std = []

--- a/components/guest-ip-protocol/src/lib.rs
+++ b/components/guest-ip-protocol/src/lib.rs
@@ -348,7 +348,7 @@ pub fn decode_frame(input: &[u8]) -> Result<(Header, &[u8]), FrameError> {
     if input.len() < HEADER_LEN {
         return Err(FrameError::TruncatedHeader);
     }
-    let header = read_header(&input[..HEADER_LEN])?;
+    let header = decode_header(&input[..HEADER_LEN])?;
     if input.len() < HEADER_LEN + header.payload_len as usize {
         return Err(FrameError::TruncatedPayload);
     }
@@ -382,7 +382,11 @@ fn write_header(header: Header, output: &mut [u8]) {
     output[30..32].fill(0);
 }
 
-fn read_header(input: &[u8]) -> Result<Header, FrameError> {
+/// Decodes and validates only the fixed header.
+pub fn decode_header(input: &[u8]) -> Result<Header, FrameError> {
+    if input.len() < HEADER_LEN {
+        return Err(FrameError::TruncatedHeader);
+    }
     let magic = u32::from_be_bytes(input[0..4].try_into().unwrap());
     if magic != MAGIC {
         return Err(FrameError::InvalidMagic);

--- a/components/guest-ip-protocol/src/lib.rs
+++ b/components/guest-ip-protocol/src/lib.rs
@@ -18,6 +18,141 @@ pub const HEADER_LEN: usize = 32;
 /// Maximum application payload for one frame.
 pub const MAX_PAYLOAD: usize = 1200;
 
+/// Reliability policy for a request/response session.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RetryPolicy {
+    /// Time to wait for an ACK or response before retrying, in milliseconds.
+    pub timeout_ms: u64,
+    /// Maximum number of retransmissions after the first send.
+    pub max_retries: u8,
+}
+
+impl RetryPolicy {
+    /// Creates a bounded policy and rejects a zero timeout.
+    pub const fn new(timeout_ms: u64, max_retries: u8) -> Option<Self> {
+        if timeout_ms == 0 {
+            None
+        } else {
+            Some(Self {
+                timeout_ms,
+                max_retries,
+            })
+        }
+    }
+}
+
+/// State of one reliable request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PendingRequest {
+    /// Sequence being acknowledged.
+    pub sequence: u32,
+    /// Timestamp of the most recent send.
+    pub sent_at_ms: u64,
+    /// Number of retransmissions already attempted.
+    pub retries: u8,
+}
+
+/// Action required when polling a pending request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RetryAction {
+    /// No deadline has elapsed.
+    Wait,
+    /// Retransmit the request and record the returned timestamp.
+    Retransmit,
+    /// The bounded retry budget is exhausted.
+    TimedOut,
+}
+
+/// Result of observing a received sequence.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReceiveSequence {
+    /// The sequence advances the receive window.
+    New,
+    /// The sequence was already delivered and must not be executed again.
+    Duplicate,
+    /// The sequence is stale or out of order.
+    OutOfOrder,
+}
+
+/// Small reliable-session state machine shared by UDP and TCP endpoints.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ReliableSession {
+    policy: RetryPolicy,
+    pending: Option<PendingRequest>,
+    last_received: Option<u32>,
+}
+
+impl ReliableSession {
+    /// Creates an idle session.
+    pub const fn new(policy: RetryPolicy) -> Self {
+        Self {
+            policy,
+            pending: None,
+            last_received: None,
+        }
+    }
+
+    /// Begins tracking a reliable request.
+    pub fn begin(&mut self, sequence: u32, now_ms: u64) -> bool {
+        if self.pending.is_some() {
+            return false;
+        }
+        self.pending = Some(PendingRequest {
+            sequence,
+            sent_at_ms: now_ms,
+            retries: 0,
+        });
+        true
+    }
+
+    /// Confirms the pending request if the sequence matches.
+    pub fn acknowledge(&mut self, sequence: u32) -> bool {
+        if self
+            .pending
+            .is_some_and(|pending| pending.sequence == sequence)
+        {
+            self.pending = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Polls the retry deadline.
+    pub fn poll_retry(&mut self, now_ms: u64) -> RetryAction {
+        let Some(mut pending) = self.pending else {
+            return RetryAction::Wait;
+        };
+        if now_ms.saturating_sub(pending.sent_at_ms) < self.policy.timeout_ms {
+            return RetryAction::Wait;
+        }
+        if pending.retries >= self.policy.max_retries {
+            self.pending = None;
+            return RetryAction::TimedOut;
+        }
+        pending.retries = pending.retries.saturating_add(1);
+        pending.sent_at_ms = now_ms;
+        self.pending = Some(pending);
+        RetryAction::Retransmit
+    }
+
+    /// Classifies a received sequence and advances the receive window for new data.
+    pub fn observe(&mut self, sequence: u32) -> ReceiveSequence {
+        match self.last_received {
+            None => {
+                self.last_received = Some(sequence);
+                ReceiveSequence::New
+            }
+            Some(previous) if sequence == previous => ReceiveSequence::Duplicate,
+            Some(previous) if sequence.wrapping_sub(previous) < (1 << 31) => {
+                self.last_received = Some(sequence);
+                ReceiveSequence::New
+            }
+            Some(_) => ReceiveSequence::OutOfOrder,
+        }
+    }
+}
+
 /// Application message kinds.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
@@ -351,5 +486,26 @@ mod tests {
             decode_frame(&output[..length + 1]),
             Err(FrameError::PayloadLengthMismatch)
         );
+    }
+
+    #[test]
+    fn retries_then_times_out_with_a_bounded_budget() {
+        let policy = RetryPolicy::new(10, 1).unwrap();
+        let mut session = ReliableSession::new(policy);
+        assert!(session.begin(4, 100));
+        assert_eq!(session.poll_retry(109), RetryAction::Wait);
+        assert_eq!(session.poll_retry(110), RetryAction::Retransmit);
+        assert_eq!(session.poll_retry(119), RetryAction::Wait);
+        assert_eq!(session.poll_retry(120), RetryAction::TimedOut);
+    }
+
+    #[test]
+    fn duplicate_and_out_of_order_requests_are_not_new_work() {
+        let policy = RetryPolicy::new(1, 0).unwrap();
+        let mut session = ReliableSession::new(policy);
+        assert_eq!(session.observe(10), ReceiveSequence::New);
+        assert_eq!(session.observe(10), ReceiveSequence::Duplicate);
+        assert_eq!(session.observe(9), ReceiveSequence::OutOfOrder);
+        assert_eq!(session.observe(11), ReceiveSequence::New);
     }
 }

--- a/components/guest-ip-protocol/src/lib.rs
+++ b/components/guest-ip-protocol/src/lib.rs
@@ -1,0 +1,355 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+#![warn(missing_docs)]
+
+//! Framing primitives shared by the Starry/Linux and RTOS guest endpoints.
+//!
+//! The transport remains an ordinary UDP or TCP socket. This crate only owns
+//! the application wire format and validation; it does not access guest
+//! memory, sockets, MMIO, or hypervisor services.
+
+use core::convert::TryFrom;
+
+/// Protocol magic (`GIPC`).
+pub const MAGIC: u32 = 0x4749_5043;
+/// Current wire-format version.
+pub const VERSION: u8 = 1;
+/// Serialized header size in bytes.
+pub const HEADER_LEN: usize = 32;
+/// Maximum application payload for one frame.
+pub const MAX_PAYLOAD: usize = 1200;
+
+/// Application message kinds.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum MessageType {
+    /// Session greeting and capability negotiation.
+    Hello     = 1,
+    /// Requests a control-state transition.
+    Control   = 2,
+    /// Reports the current RTOS control state.
+    Status    = 3,
+    /// Reports a protocol or application failure.
+    Error     = 4,
+    /// Liveness probe.
+    Heartbeat = 5,
+    /// Acknowledges a reliable datagram.
+    Ack       = 6,
+}
+
+impl TryFrom<u8> for MessageType {
+    type Error = FrameError;
+
+    fn try_from(value: u8) -> Result<Self, FrameError> {
+        match value {
+            1 => Ok(Self::Hello),
+            2 => Ok(Self::Control),
+            3 => Ok(Self::Status),
+            4 => Ok(Self::Error),
+            5 => Ok(Self::Heartbeat),
+            6 => Ok(Self::Ack),
+            _ => Err(FrameError::UnknownMessageType),
+        }
+    }
+}
+
+/// Protocol-level error code carried by an [`Error`] message.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u16)]
+pub enum ErrorCode {
+    /// No error.
+    None               = 0,
+    /// The peer does not support the requested version.
+    UnsupportedVersion = 1,
+    /// The frame length is invalid.
+    InvalidLength      = 2,
+    /// The checksum does not match.
+    ChecksumMismatch   = 3,
+    /// The sequence is stale or out of order.
+    InvalidSequence    = 4,
+    /// The message payload is invalid.
+    InvalidPayload     = 5,
+    /// The requested operation is not supported.
+    UnsupportedMessage = 6,
+    /// The peer is temporarily unavailable.
+    Busy               = 7,
+}
+
+/// Header flags.
+pub mod flags {
+    /// The sender requires an acknowledgement.
+    pub const ACK_REQUIRED: u16 = 1 << 0;
+    /// The frame is an acknowledgement for a prior sequence.
+    pub const IS_ACK: u16 = 1 << 1;
+}
+
+/// A decoded or to-be-encoded application header.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Header {
+    /// Wire magic.
+    pub magic: u32,
+    /// Wire-format version.
+    pub version: u8,
+    /// Message kind.
+    pub message_type: MessageType,
+    /// Reliability flags.
+    pub flags: u16,
+    /// Header length in bytes.
+    pub header_len: u16,
+    /// Payload length in bytes.
+    pub payload_len: u16,
+    /// Monotonic message sequence.
+    pub sequence: u32,
+    /// Sender timestamp in nanoseconds, if available.
+    pub timestamp_ns: u64,
+    /// Application error code.
+    pub error_code: ErrorCode,
+    /// CRC-32 over the header with this field cleared and the payload.
+    pub checksum: u32,
+}
+
+impl Header {
+    /// Construct a header for a payload.
+    pub const fn new(
+        message_type: MessageType,
+        flags: u16,
+        payload_len: usize,
+        sequence: u32,
+        timestamp_ns: u64,
+        error_code: ErrorCode,
+    ) -> Option<Self> {
+        if payload_len > MAX_PAYLOAD {
+            return None;
+        }
+        Some(Self {
+            magic: MAGIC,
+            version: VERSION,
+            message_type,
+            flags,
+            header_len: HEADER_LEN as u16,
+            payload_len: payload_len as u16,
+            sequence,
+            timestamp_ns,
+            error_code,
+            checksum: 0,
+        })
+    }
+}
+
+/// Errors returned by frame construction and validation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FrameError {
+    /// The output buffer cannot hold the encoded frame.
+    OutputTooSmall,
+    /// The input is shorter than the fixed header.
+    TruncatedHeader,
+    /// The input does not contain the declared payload length.
+    TruncatedPayload,
+    /// The magic is not recognized.
+    InvalidMagic,
+    /// The version is unsupported.
+    UnsupportedVersion,
+    /// The header length is not the current fixed size.
+    InvalidHeaderLength,
+    /// The payload exceeds the protocol limit.
+    PayloadTooLarge,
+    /// The payload length does not match the input frame.
+    PayloadLengthMismatch,
+    /// The message type is unknown.
+    UnknownMessageType,
+    /// The error code is unknown.
+    UnknownErrorCode,
+    /// The CRC-32 does not match.
+    ChecksumMismatch,
+}
+
+impl core::fmt::Display for FrameError {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let message = match self {
+            Self::OutputTooSmall => "output buffer too small",
+            Self::TruncatedHeader => "truncated protocol header",
+            Self::TruncatedPayload => "truncated protocol payload",
+            Self::InvalidMagic => "invalid protocol magic",
+            Self::UnsupportedVersion => "unsupported protocol version",
+            Self::InvalidHeaderLength => "invalid protocol header length",
+            Self::PayloadTooLarge => "protocol payload too large",
+            Self::PayloadLengthMismatch => "protocol payload length mismatch",
+            Self::UnknownMessageType => "unknown protocol message type",
+            Self::UnknownErrorCode => "unknown protocol error code",
+            Self::ChecksumMismatch => "protocol checksum mismatch",
+        };
+        formatter.write_str(message)
+    }
+}
+
+/// Encodes a frame into caller-provided storage.
+pub fn encode_frame(
+    header: Header,
+    payload: &[u8],
+    output: &mut [u8],
+) -> Result<usize, FrameError> {
+    if payload.len() > MAX_PAYLOAD {
+        return Err(FrameError::PayloadTooLarge);
+    }
+    let frame_len = HEADER_LEN + payload.len();
+    if output.len() < frame_len {
+        return Err(FrameError::OutputTooSmall);
+    }
+
+    let mut encoded = header;
+    encoded.magic = MAGIC;
+    encoded.version = VERSION;
+    encoded.header_len = HEADER_LEN as u16;
+    encoded.payload_len = payload.len() as u16;
+    encoded.checksum = 0;
+    write_header(encoded, &mut output[..HEADER_LEN]);
+    output[HEADER_LEN..frame_len].copy_from_slice(payload);
+    encoded.checksum = crc32(&output[..frame_len]);
+    write_header(encoded, &mut output[..HEADER_LEN]);
+    Ok(frame_len)
+}
+
+/// Decodes and validates a complete frame.
+pub fn decode_frame(input: &[u8]) -> Result<(Header, &[u8]), FrameError> {
+    if input.len() < HEADER_LEN {
+        return Err(FrameError::TruncatedHeader);
+    }
+    let header = read_header(&input[..HEADER_LEN])?;
+    if input.len() < HEADER_LEN + header.payload_len as usize {
+        return Err(FrameError::TruncatedPayload);
+    }
+    if input.len() != HEADER_LEN + header.payload_len as usize {
+        return Err(FrameError::PayloadLengthMismatch);
+    }
+    let payload = &input[HEADER_LEN..];
+    let expected = header.checksum;
+    let mut checksum_header = header;
+    checksum_header.checksum = 0;
+    let mut bytes = [0u8; HEADER_LEN + MAX_PAYLOAD];
+    write_header(checksum_header, &mut bytes[..HEADER_LEN]);
+    bytes[HEADER_LEN..HEADER_LEN + payload.len()].copy_from_slice(payload);
+    if crc32(&bytes[..HEADER_LEN + payload.len()]) != expected {
+        return Err(FrameError::ChecksumMismatch);
+    }
+    Ok((header, payload))
+}
+
+fn write_header(header: Header, output: &mut [u8]) {
+    output[0..4].copy_from_slice(&header.magic.to_be_bytes());
+    output[4] = header.version;
+    output[5] = header.message_type as u8;
+    output[6..8].copy_from_slice(&header.flags.to_be_bytes());
+    output[8..10].copy_from_slice(&header.header_len.to_be_bytes());
+    output[10..12].copy_from_slice(&header.payload_len.to_be_bytes());
+    output[12..16].copy_from_slice(&header.sequence.to_be_bytes());
+    output[16..24].copy_from_slice(&header.timestamp_ns.to_be_bytes());
+    output[24..26].copy_from_slice(&(header.error_code as u16).to_be_bytes());
+    output[26..30].copy_from_slice(&header.checksum.to_be_bytes());
+    output[30..32].fill(0);
+}
+
+fn read_header(input: &[u8]) -> Result<Header, FrameError> {
+    let magic = u32::from_be_bytes(input[0..4].try_into().unwrap());
+    if magic != MAGIC {
+        return Err(FrameError::InvalidMagic);
+    }
+    let version = input[4];
+    if version != VERSION {
+        return Err(FrameError::UnsupportedVersion);
+    }
+    let message_type = MessageType::try_from(input[5])?;
+    let header_len = u16::from_be_bytes(input[8..10].try_into().unwrap());
+    if header_len as usize != HEADER_LEN {
+        return Err(FrameError::InvalidHeaderLength);
+    }
+    let payload_len = u16::from_be_bytes(input[10..12].try_into().unwrap());
+    if payload_len as usize > MAX_PAYLOAD {
+        return Err(FrameError::PayloadTooLarge);
+    }
+    let error_code = match u16::from_be_bytes(input[24..26].try_into().unwrap()) {
+        0 => ErrorCode::None,
+        1 => ErrorCode::UnsupportedVersion,
+        2 => ErrorCode::InvalidLength,
+        3 => ErrorCode::ChecksumMismatch,
+        4 => ErrorCode::InvalidSequence,
+        5 => ErrorCode::InvalidPayload,
+        6 => ErrorCode::UnsupportedMessage,
+        7 => ErrorCode::Busy,
+        _ => return Err(FrameError::UnknownErrorCode),
+    };
+    Ok(Header {
+        magic,
+        version,
+        message_type,
+        flags: u16::from_be_bytes(input[6..8].try_into().unwrap()),
+        header_len,
+        payload_len,
+        sequence: u32::from_be_bytes(input[12..16].try_into().unwrap()),
+        timestamp_ns: u64::from_be_bytes(input[16..24].try_into().unwrap()),
+        error_code,
+        checksum: u32::from_be_bytes(input[26..30].try_into().unwrap()),
+    })
+}
+
+fn crc32(bytes: &[u8]) -> u32 {
+    let mut crc = 0xffff_ffff;
+    for &byte in bytes {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            crc = if crc & 1 != 0 {
+                (crc >> 1) ^ 0xedb8_8320
+            } else {
+                crc >> 1
+            };
+        }
+    }
+    !crc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_preserves_header_and_payload() {
+        let header = Header::new(
+            MessageType::Control,
+            flags::ACK_REQUIRED,
+            5,
+            7,
+            99,
+            ErrorCode::None,
+        )
+        .unwrap();
+        let mut output = [0u8; HEADER_LEN + MAX_PAYLOAD];
+        let length = encode_frame(header, b"hello", &mut output).unwrap();
+        let (decoded, payload) = decode_frame(&output[..length]).unwrap();
+        assert_eq!(decoded.message_type, MessageType::Control);
+        assert_eq!(decoded.sequence, 7);
+        assert_eq!(decoded.timestamp_ns, 99);
+        assert_eq!(payload, b"hello");
+    }
+
+    #[test]
+    fn rejects_corrupted_payload() {
+        let header = Header::new(MessageType::Status, 0, 3, 1, 0, ErrorCode::None).unwrap();
+        let mut output = [0u8; HEADER_LEN + MAX_PAYLOAD];
+        let length = encode_frame(header, b"abc", &mut output).unwrap();
+        output[length - 1] ^= 1;
+        assert_eq!(
+            decode_frame(&output[..length]),
+            Err(FrameError::ChecksumMismatch)
+        );
+    }
+
+    #[test]
+    fn rejects_trailing_bytes() {
+        let header = Header::new(MessageType::Heartbeat, 0, 0, 1, 0, ErrorCode::None).unwrap();
+        let mut output = [0u8; HEADER_LEN + MAX_PAYLOAD + 1];
+        let length = encode_frame(header, &[], &mut output).unwrap();
+        output[length] = 0;
+        assert_eq!(
+            decode_frame(&output[..length + 1]),
+            Err(FrameError::PayloadLengthMismatch)
+        );
+    }
+}

--- a/docs/design/starry-rtos-ip-link.md
+++ b/docs/design/starry-rtos-ip-link.md
@@ -1,0 +1,126 @@
+# Starry/Linux 与 RTOS 客户机 IP 通信设计
+
+## 1. 目标与范围
+
+本设计在已有 AxVM FDT/PSCI 修复、AxVisor 双客户机 VirtIO-net 交换机和
+`axvirtio-common`/VirtIO-MMIO 基础上，建立 Starry/Linux 客户机与 RTOS 客户机
+之间可复现的双向 IP 通信链路。
+
+主数据通道必须是 TCP/UDP/IP 或等价的 IP 传输。共享内存、HyperCall、裸
+MMIO 和 vsock 不得承载业务数据；如将来使用 vsock，只能用于控制、调试或
+对比实验，并在运行文档中明确隔离。
+
+本设计的非目标包括：重写已有 VirtIO-net 设备、把 VirtIO-blk 变成通信通道、
+实现物理网卡直通、提供通用服务发现，以及在一个变更中引入多个相互独立的
+应用协议。
+
+## 2. 既有基线和复用边界
+
+后续变更以以下已有提交为共同基线：
+
+| 基线 | 复用内容 |
+| --- | --- |
+| `f56b496fe` | AxVM 生成 guest FDT 时保留 PSCI conduit，保证客户机启动和中断路径稳定 |
+| `547f3266a` | AxVisor `virtio-net` DeviceModel、MMIO transport、内部二层交换机、DMA/IRQ 路径 |
+| `4c4c55cd2` | workspace 中的 VirtIO 公共基础和设备图集成；块设备不作为本通信链路 |
+
+新实现不复制 VirtIO 队列、MMIO、DMA grant 或交换机逻辑。Starry/Linux 和
+RTOS 端只通过标准网卡、IP、UDP/TCP socket 使用这些能力。
+
+## 3. PR 分层
+
+四个 PR 必须依次基于同一条包含上述基线的分支。若某一层只有少量改动，
+将它并入相邻 PR，而不制造只有配置文件的独立 PR。
+
+### PR1：客户机网络接入和拓扑
+
+建议标题：`feat(axvisor): connect Starry and RTOS guests over existing virtio-net`
+
+复用已有 `virtio-net` 模型，为 Starry/Linux 和一个 RTOS 客户机增加 VM 配置、
+FDT 网卡节点、MAC/IP/路由初始化以及最小 echo 验证。默认采用进程内二层交换
+机；不使用宿主桥接、NAT 或物理上联。拓扑表和地址分配必须随 PR 提交。
+
+### PR2：应用层协议和两端程序
+
+建议标题：`feat(net-protocol): add Starry and RTOS guest control protocol`
+
+协议采用一个固定版本的二进制帧。帧头字段如下：
+
+| 字段 | 语义 |
+| --- | --- |
+| magic/version | 识别协议并支持显式拒绝未知版本 |
+| message_type/flags | 区分控制、状态、错误、心跳和确认 |
+| header_len/payload_len | 防止截断、粘包和过长载荷 |
+| sequence/timestamp | 请求关联、重复检测和延迟统计 |
+| error_code | 传达协议或业务错误 |
+| checksum | 检测帧损坏 |
+
+两端必须实现 `CONTROL`、`STATUS`、`ERROR` 和 `HEARTBEAT`，并完成至少一次
+Linux/Starry → RTOS 控制请求及 RTOS → Linux/Starry 状态响应。
+
+### PR3：可靠性和异常恢复
+
+建议标题：`feat(net-reliability): add guest link recovery and fault handling`
+
+本设计首选 UDP，以便显式验证可靠性协议。`CONTROL` 和需要响应的 `STATUS`
+使用序号、ACK、有限重传和超时；重复帧只确认一次且不能重复执行，乱序帧返回
+错误。心跳负责检测链路状态，链路恢复后重新建立会话。
+
+如果实现改用 TCP，必须使用同一协议头进行分帧，并实现连接/读写超时、断连检测、
+自动重连、未完成请求处置和异常恢复。不能因为 TCP 自带可靠字节流而省略这些
+应用层状态。
+
+### PR4：端到端验证、指标和运行文档
+
+建议标题：`test(net): validate Starry and RTOS guest communication`
+
+该 PR 提供可复制的 QEMU/板卡流程、丢包和断链故障注入、pcap 或日志校验，
+并输出以下指标：请求成功率、应用层错误、超时、重传/重连次数、恢复成功率、
+请求-响应延迟（至少 P50/P95）和有效应用吞吐量。失败必须以非零退出码传播到
+测试运行器。
+
+## 4. 网络拓扑
+
+默认 QEMU 拓扑为两个互不共享宿主网络的 VirtIO-MMIO 端点：
+
+```text
+Starry/Linux guest                         RTOS guest
+  virtio-net0                                virtio-net0
+  MAC 52:54:00:42:00:01                      MAC 52:54:00:42:00:02
+  10.0.42.1/24                                10.0.42.2/24
+          \                                  /
+           AxVisor in-process L2 switch
+```
+
+业务端口由协议配置明确指定（默认 UDP `4242`）。两个 guest 在同一子网内直接
+通信，不配置默认网关、NAT 或宿主桥；访问控制只允许对端 MAC/IP 和业务端口。
+任何使用桥接、NAT、TAP 或物理网口的变体必须另列拓扑和安全边界，不能隐式改变
+主测试路径。
+
+## 5. 所有权、错误和安全边界
+
+- AxVisor 继续拥有 VirtIO 设备、交换机端口和 guest DMA 授权。
+- 客户机应用只拥有自己的 socket、协议会话和业务状态。
+- 协议解码在执行控制动作前完成 magic、版本、长度、序号、错误码和 checksum
+  校验。
+- 资源耗尽、非法帧、超时、断连和不支持的消息必须显式报告，不能伪造成功或
+  静默降级到共享内存/HyperCall。
+- 重复控制请求必须可识别；状态机必须保证一次执行语义或明确返回重复错误。
+
+## 6. 验收矩阵
+
+| 能力 | 必需证据 |
+| --- | --- |
+| IP 主通道 | 两端网卡、ARP/IPv4/UDP 或 TCP 报文、非零业务收发 |
+| 协议 | 编解码单测、版本/长度/校验错误测试、两端真实调用 |
+| 双向业务 | 控制请求、状态响应、错误通知和心跳均有报文 |
+| 可靠性 | 丢包/丢 ACK、重复、乱序、超时、断链和恢复测试 |
+| 拓扑安全 | MAC/IP/路由/端口/桥接或 NAT/访问控制文档 |
+| 指标 | 成功率、错误、超时、恢复、延迟和有效吞吐量报告 |
+
+## 7. 运行与回滚
+
+每个 PR 都应有最小可运行命令，并在当前提交记录目标架构、镜像准备、启动
+命令和成功标志。PR1 可回滚到已有双 ArceOS VirtIO-net 测试；PR2/PR3 的协议
+能力通过独立 feature 或应用入口接入，不修改已有 VirtIO-net 公共 ABI；PR4
+只增加测试和文档时可以单独回滚，不影响客户机网络设备。

--- a/docs/design/starry-rtos-ip-link.md
+++ b/docs/design/starry-rtos-ip-link.md
@@ -1,9 +1,9 @@
-# Starry/Linux 与 RTOS 客户机 IP 通信设计
+# StarryOS 与 ArceOS 客户机 IP 通信设计
 
 ## 1. 目标与范围
 
 本设计在已有 AxVM FDT/PSCI 修复、AxVisor 双客户机 VirtIO-net 交换机和
-`axvirtio-common`/VirtIO-MMIO 基础上，建立 Starry/Linux 客户机与 RTOS 客户机
+`axvirtio-common`/VirtIO-MMIO 基础上，建立 StarryOS 客户机与 ArceOS 客户机
 之间可复现的双向 IP 通信链路。
 
 主数据通道必须是 TCP/UDP/IP 或等价的 IP 传输。共享内存、HyperCall、裸
@@ -24,8 +24,8 @@ MMIO 和 vsock 不得承载业务数据；如将来使用 vsock，只能用于�
 | `547f3266a` | AxVisor `virtio-net` DeviceModel、MMIO transport、内部二层交换机、DMA/IRQ 路径 |
 | `4c4c55cd2` | workspace 中的 VirtIO 公共基础和设备图集成；块设备不作为本通信链路 |
 
-新实现不复制 VirtIO 队列、MMIO、DMA grant 或交换机逻辑。Starry/Linux 和
-RTOS 端只通过标准网卡、IP、UDP/TCP socket 使用这些能力。
+新实现不复制 VirtIO 队列、MMIO、DMA grant 或交换机逻辑。StarryOS 和
+ArceOS 端只通过标准网卡、IP、TCP socket 使用这些能力。
 
 ## 3. PR 分层
 
@@ -34,15 +34,15 @@ RTOS 端只通过标准网卡、IP、UDP/TCP socket 使用这些能力。
 
 ### PR1：客户机网络接入和拓扑
 
-建议标题：`feat(axvisor): connect Starry and RTOS guests over existing virtio-net`
+建议标题：`feat(axvisor): connect StarryOS and ArceOS guests over existing virtio-net`
 
-复用已有 `virtio-net` 模型，为 Starry/Linux 和一个 RTOS 客户机增加 VM 配置、
+复用已有 `virtio-net` 模型，为 StarryOS 和 ArceOS 客户机增加 VM 配置、
 FDT 网卡节点、MAC/IP/路由初始化以及最小 echo 验证。默认采用进程内二层交换
 机；不使用宿主桥接、NAT 或物理上联。拓扑表和地址分配必须随 PR 提交。
 
 ### PR2：应用层协议和两端程序
 
-建议标题：`feat(net-protocol): add Starry and RTOS guest control protocol`
+建议标题：`feat(net-protocol): add StarryOS and ArceOS guest control protocol`
 
 协议采用一个固定版本的二进制帧。帧头字段如下：
 
@@ -56,10 +56,10 @@ FDT 网卡节点、MAC/IP/路由初始化以及最小 echo 验证。默认采用
 | checksum | 检测帧损坏 |
 
 两端必须实现 `CONTROL`、`STATUS`、`ERROR` 和 `HEARTBEAT`，并完成至少一次
-Linux/Starry → RTOS 控制请求及 RTOS → Linux/Starry 状态响应。
+StarryOS → ArceOS 控制请求及 ArceOS → StarryOS 状态响应。
 
 当前端点实现为 [`apps/arceos/guest-ip-server`](../../apps/arceos/guest-ip-server/)
-和可放入 Starry/Linux rootfs 的
+和可放入 StarryOS rootfs 的
 [`linux-client.c`](../../apps/starry/guest-ip-link/linux-client.c)。客户端使用
 POSIX TCP socket，服务端使用 ArceOS `ax_std` socket；二者只通过 IP 网络交换
 协议帧。
@@ -68,36 +68,32 @@ POSIX TCP socket，服务端使用 ArceOS `ax_std` socket；二者只通过 IP �
 
 建议标题：`feat(net-reliability): add guest link recovery and fault handling`
 
-本设计首选 UDP，以便显式验证可靠性协议。`CONTROL` 和需要响应的 `STATUS`
-使用序号、ACK、有限重传和超时；重复帧只确认一次且不能重复执行，乱序帧返回
-错误。心跳负责检测链路状态，链路恢复后重新建立会话。
-
-如果实现改用 TCP，必须使用同一协议头进行分帧，并实现连接/读写超时、断连检测、
+实现采用 TCP。必须使用同一协议头进行分帧，并实现连接/读写超时、断连检测、
 自动重连、未完成请求处置和异常恢复。不能因为 TCP 自带可靠字节流而省略这些
 应用层状态。
 
 ### PR4：端到端验证、指标和运行文档
 
-建议标题：`test(net): validate Starry and RTOS guest communication`
+建议标题：`test(net): validate StarryOS and ArceOS guest communication`
 
 该 PR 提供可复制的 QEMU/板卡流程、丢包和断链故障注入、pcap 或日志校验，
 并输出以下指标：请求成功率、应用层错误、超时、重传/重连次数、恢复成功率、
 请求-响应延迟（至少 P50/P95）和有效应用吞吐量。失败必须以非零退出码传播到
 测试运行器。
 
-客户端当前输出 `GIPC_LINUX_STATUS` 和 `GIPC_LINUX_METRIC`，并由
+客户端当前输出 `GIPC_STARRY_STATUS` 和 `GIPC_STARRY_METRIC`，并由
 [`verify_metrics.py`](../../scripts/test/guest-ip-link/verify_metrics.py) 检查
 成功标志、超时/错误标志、正延迟和正有效吞吐量。长稳运行仍需在 PR4 的 QEMU
 流程中聚合多个请求，生成 P50/P95 和整体成功率。
 
 QEMU 启动骨架位于
-`os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh`。它构建 RTOS
-服务端并启动既有 Linux VirtIO-net guest；默认使用 `debugfs` 将客户端注入
-Linux rootfs。设置 `GIPC_INJECT_CLIENT=0` 可关闭注入，或通过
-`GIPC_LINUX_CLIENT_BIN` 指定已构建客户端。启动后在 Linux shell 执行：
+`os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh`。它构建 ArceOS
+服务端并启动 StarryOS VirtIO-net guest；默认使用 `debugfs` 将客户端注入
+StarryOS rootfs。设置 `GIPC_INJECT_CLIENT=0` 可关闭注入，或通过
+`GIPC_STARRY_CLIENT_BIN` 指定已构建客户端。启动后在 StarryOS shell 执行：
 
 ```sh
-/usr/bin/gipc-linux-client 10.0.42.2
+/usr/bin/gipc-starry-client 10.0.42.2
 ```
 
 ## 4. 网络拓扑
@@ -105,7 +101,7 @@ Linux rootfs。设置 `GIPC_INJECT_CLIENT=0` 可关闭注入，或通过
 默认 QEMU 拓扑为两个互不共享宿主网络的 VirtIO-MMIO 端点：
 
 ```text
-Starry/Linux guest                         RTOS guest
+StarryOS guest                              ArceOS guest
   virtio-net0                                virtio-net0
   MAC 52:54:00:42:00:01                      MAC 52:54:00:42:00:02
   10.0.42.1/24                                10.0.42.2/24
@@ -113,7 +109,7 @@ Starry/Linux guest                         RTOS guest
            AxVisor in-process L2 switch
 ```
 
-业务端口由协议配置明确指定（默认 UDP `4242`）。两个 guest 在同一子网内直接
+业务端口由协议配置明确指定（TCP `4242`）。两个 guest 在同一子网内直接
 通信，不配置默认网关、NAT 或宿主桥；访问控制只允许对端 MAC/IP 和业务端口。
 任何使用桥接、NAT、TAP 或物理网口的变体必须另列拓扑和安全边界，不能隐式改变
 主测试路径。

--- a/docs/design/starry-rtos-ip-link.md
+++ b/docs/design/starry-rtos-ip-link.md
@@ -141,3 +141,27 @@ StarryOS guest                              ArceOS guest
 命令和成功标志。PR1 可回滚到已有双 ArceOS VirtIO-net 测试；PR2/PR3 的协议
 能力通过独立 feature 或应用入口接入，不修改已有 VirtIO-net 公共 ABI；PR4
 只增加测试和文档时可以单独回滚，不影响客户机网络设备。
+## Guest bootstrap and observability
+
+StarryOS runs `gipc-network-init.sh` before the client. It brings up `eth0`,
+assigns `10.0.42.1/24`, and verifies the directly connected `10.0.42.0/24`
+route. The script fails closed when the interface or `ip` utility is missing;
+the client is not started with an unconfigured address. ArceOS configures its
+VirtIO interface as `10.0.42.2/24`. The application endpoint remains TCP
+`10.0.42.2:4242`.
+
+The TCP profile uses the framed request/response itself as delivery
+confirmation; it does not send a separate application ACK on a reliable TCP
+stream. A request carries a monotonically increasing sequence (one per
+process), and a response must echo it. The Starry client retries a request up
+to three times after connect, read, or write timeout/断连, counts reconnects,
+and reports an `ERROR` frame's protocol error code instead of treating it as a
+status. CRC, version, type, and sequence failures are application errors.
+
+Each client run emits `GIPC_STARRY_METRIC` with request count, successful
+responses, application errors, timeouts, attempts, reconnects, recovery, mean
+RTT, and effective payload throughput. `aggregate_metrics.py` computes success
+rate, error/timeout/recovery totals, RTT P50/P95, and average throughput, and
+returns non-zero when any request or application validation fails. The
+host-side test remains a deterministic protocol test; a real guest result
+requires the QEMU images/toolchain described in the validation section.

--- a/docs/design/starry-rtos-ip-link.md
+++ b/docs/design/starry-rtos-ip-link.md
@@ -90,6 +90,15 @@ POSIX TCP socket，服务端使用 ArceOS `ax_std` socket；二者只通过 IP �
 成功标志、超时/错误标志、正延迟和正有效吞吐量。长稳运行仍需在 PR4 的 QEMU
 流程中聚合多个请求，生成 P50/P95 和整体成功率。
 
+QEMU 启动骨架位于
+`os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh`。它构建 RTOS
+服务端并启动既有 Linux VirtIO-net guest；Linux rootfs 需要预先放置
+`gipc-linux-client`，启动后在 Linux shell 执行：
+
+```sh
+/usr/bin/gipc-linux-client 10.0.42.2
+```
+
 ## 4. 网络拓扑
 
 默认 QEMU 拓扑为两个互不共享宿主网络的 VirtIO-MMIO 端点：

--- a/docs/design/starry-rtos-ip-link.md
+++ b/docs/design/starry-rtos-ip-link.md
@@ -58,6 +58,12 @@ FDT 网卡节点、MAC/IP/路由初始化以及最小 echo 验证。默认采用
 两端必须实现 `CONTROL`、`STATUS`、`ERROR` 和 `HEARTBEAT`，并完成至少一次
 Linux/Starry → RTOS 控制请求及 RTOS → Linux/Starry 状态响应。
 
+当前端点实现为 [`apps/arceos/guest-ip-server`](../../apps/arceos/guest-ip-server/)
+和可放入 Starry/Linux rootfs 的
+[`linux-client.c`](../../apps/starry/guest-ip-link/linux-client.c)。客户端使用
+POSIX TCP socket，服务端使用 ArceOS `ax_std` socket；二者只通过 IP 网络交换
+协议帧。
+
 ### PR3：可靠性和异常恢复
 
 建议标题：`feat(net-reliability): add guest link recovery and fault handling`
@@ -78,6 +84,11 @@ Linux/Starry → RTOS 控制请求及 RTOS → Linux/Starry 状态响应。
 并输出以下指标：请求成功率、应用层错误、超时、重传/重连次数、恢复成功率、
 请求-响应延迟（至少 P50/P95）和有效应用吞吐量。失败必须以非零退出码传播到
 测试运行器。
+
+客户端当前输出 `GIPC_LINUX_STATUS` 和 `GIPC_LINUX_METRIC`，并由
+[`verify_metrics.py`](../../scripts/test/guest-ip-link/verify_metrics.py) 检查
+成功标志、超时/错误标志、正延迟和正有效吞吐量。长稳运行仍需在 PR4 的 QEMU
+流程中聚合多个请求，生成 P50/P95 和整体成功率。
 
 ## 4. 网络拓扑
 

--- a/docs/design/starry-rtos-ip-link.md
+++ b/docs/design/starry-rtos-ip-link.md
@@ -92,8 +92,9 @@ POSIX TCP socket，服务端使用 ArceOS `ax_std` socket；二者只通过 IP �
 
 QEMU 启动骨架位于
 `os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh`。它构建 RTOS
-服务端并启动既有 Linux VirtIO-net guest；Linux rootfs 需要预先放置
-`gipc-linux-client`，启动后在 Linux shell 执行：
+服务端并启动既有 Linux VirtIO-net guest；默认使用 `debugfs` 将客户端注入
+Linux rootfs。设置 `GIPC_INJECT_CLIENT=0` 可关闭注入，或通过
+`GIPC_LINUX_CLIENT_BIN` 指定已构建客户端。启动后在 Linux shell 执行：
 
 ```sh
 /usr/bin/gipc-linux-client 10.0.42.2

--- a/os/axvisor/configs/board/qemu-aarch64-starry-rtos-gipc.toml
+++ b/os/axvisor/configs/board/qemu-aarch64-starry-rtos-gipc.toml
@@ -2,6 +2,6 @@ features = []
 log = "Info"
 target = "aarch64-unknown-none-softfloat"
 vm_configs = [
-  "os/axvisor/configs/vms/qemu/aarch64/linux-virtio-net-peer.toml",
+  "os/axvisor/configs/vms/qemu/aarch64/starry-virtio-net-peer.toml",
   "os/axvisor/configs/vms/qemu/aarch64/arceos-guest-ip-server.toml",
 ]

--- a/os/axvisor/configs/board/qemu-aarch64-starry-rtos-gipc.toml
+++ b/os/axvisor/configs/board/qemu-aarch64-starry-rtos-gipc.toml
@@ -1,0 +1,7 @@
+features = []
+log = "Info"
+target = "aarch64-unknown-none-softfloat"
+vm_configs = [
+  "os/axvisor/configs/vms/qemu/aarch64/linux-virtio-net-peer.toml",
+  "os/axvisor/configs/vms/qemu/aarch64/arceos-guest-ip-server.toml",
+]

--- a/os/axvisor/configs/qemu/qemu-aarch64-starry-rtos-gipc.toml
+++ b/os/axvisor/configs/qemu/qemu-aarch64-starry-rtos-gipc.toml
@@ -5,9 +5,9 @@ args = [
   "-smp", "4",
   "-m", "4g",
 ]
-fail_regex = ["(?i)panic", "GIPC_RTOS_ERROR", "GIPC_LINUX_TIMEOUT"]
+fail_regex = ["(?i)panic", "GIPC_RTOS_ERROR", "GIPC_STARRY_TIMEOUT"]
 success_regex = [
-  "(?s)GIPC_RTOS_READY.*GIPC_LINUX_STATUS.*GIPC_LINUX_METRIC",
+  "(?s)GIPC_RTOS_READY.*GIPC_STARRY_STATUS.*GIPC_STARRY_METRIC",
 ]
 timeout = 180
 to_bin = true

--- a/os/axvisor/configs/qemu/qemu-aarch64-starry-rtos-gipc.toml
+++ b/os/axvisor/configs/qemu/qemu-aarch64-starry-rtos-gipc.toml
@@ -1,0 +1,12 @@
+args = [
+  "-nographic",
+  "-cpu", "cortex-a72",
+  "-machine", "virt,virtualization=on,gic-version=3",
+  "-smp", "4",
+  "-m", "4g",
+]
+fail_regex = ["(?i)panic", "GIPC_RTOS_ERROR", "GIPC_LINUX_TIMEOUT"]
+success_regex = ["GIPC_RTOS_READY"]
+timeout = 180
+to_bin = true
+uefi = false

--- a/os/axvisor/configs/qemu/qemu-aarch64-starry-rtos-gipc.toml
+++ b/os/axvisor/configs/qemu/qemu-aarch64-starry-rtos-gipc.toml
@@ -6,7 +6,9 @@ args = [
   "-m", "4g",
 ]
 fail_regex = ["(?i)panic", "GIPC_RTOS_ERROR", "GIPC_LINUX_TIMEOUT"]
-success_regex = ["GIPC_RTOS_READY"]
+success_regex = [
+  "(?s)GIPC_RTOS_READY.*GIPC_LINUX_STATUS.*GIPC_LINUX_METRIC",
+]
 timeout = 180
 to_bin = true
 uefi = false

--- a/os/axvisor/configs/vms/qemu/aarch64/arceos-guest-ip-server.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/arceos-guest-ip-server.toml
@@ -1,0 +1,26 @@
+[base]
+id = 2
+name = "arceos-guest-ip-server"
+guest_type = "virtualized"
+cpu_num = 1
+phys_cpu_ids = [2]
+phys_cpu_sets = [2]
+
+[kernel]
+entry_point = 0x8020_0000
+image_location = "memory"
+kernel_path = "${workspace}/target/aarch64-unknown-none-softfloat/release/arceos-guest-ip-server.bin"
+kernel_load_addr = 0x8020_0000
+dtb_load_addr = 0x8000_0000
+memory_regions = [
+  [0x8000_0000, 0x2000_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = []
+disabled = []
+
+[[devices.virtual]]
+id = "virtnet0"
+model = "virtio-net"
+guest_mac = [0x52, 0x54, 0x00, 0x42, 0x00, 0x02]

--- a/os/axvisor/configs/vms/qemu/aarch64/starry-virtio-net-peer.toml
+++ b/os/axvisor/configs/vms/qemu/aarch64/starry-virtio-net-peer.toml
@@ -1,0 +1,27 @@
+[base]
+id = 1
+name = "starry-virtio-net-peer"
+guest_type = "virtualized"
+cpu_num = 1
+phys_cpu_ids = [1]
+phys_cpu_sets = [1]
+
+[kernel]
+entry_point = 0x8020_0000
+image_location = "memory"
+# Build/export the AArch64 StarryOS guest image at this path before running AxVisor.
+kernel_path = "${workspace}/../tgosimages/IMAGES/qemu-aarch64/starry/starry-qemu"
+kernel_load_addr = 0x8020_0000
+dtb_load_addr = 0x8000_0000
+memory_regions = [
+  [0x8000_0000, 0x4000_0000, 0x7, 0],
+]
+
+[devices]
+passthrough = []
+disabled = []
+
+[[devices.virtual]]
+id = "virtnet0"
+model = "virtio-net"
+guest_mac = [0x52, 0x54, 0x00, 0x42, 0x00, 0x01]

--- a/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
+++ b/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workspace=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
+cd "$workspace"
+
+objcopy="${LLVM_OBJCOPY:-$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-objcopy}"
+if [[ ! -x "$objcopy" ]]; then
+    echo "llvm-objcopy not found: $objcopy (set LLVM_OBJCOPY)" >&2
+    exit 1
+fi
+
+cargo xtask arceos build \
+    -p arceos-guest-ip-server \
+    -c apps/arceos/build-aarch64-guest-ip-server.toml
+
+raw="target/aarch64-unknown-none-softfloat/release/arceos-guest-ip-server"
+bin="target/aarch64-unknown-none-softfloat/release/arceos-guest-ip-server.bin"
+"$objcopy" --strip-all -O binary "$raw" "$bin"
+
+exec cargo xtask axvisor qemu \
+    --config os/axvisor/configs/board/qemu-aarch64-starry-rtos-gipc.toml \
+    --qemu-config os/axvisor/configs/qemu/qemu-aarch64-starry-rtos-gipc.toml \
+    --rootfs "${ROOTFS_IMAGE:?set ROOTFS_IMAGE to the Linux guest rootfs image}"

--- a/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
+++ b/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
@@ -32,6 +32,9 @@ if [[ "${GIPC_INJECT_CLIENT:-1}" == "1" ]]; then
     }
     debugfs -w -R "rm /usr/bin/gipc-starry-client" "$rootfs" >/dev/null 2>&1 || true
     debugfs -w -R "write $starry_client /usr/bin/gipc-starry-client" "$rootfs" >/dev/null
+    debugfs -w -R "rm /usr/bin/gipc-network-init.sh" "$rootfs" >/dev/null 2>&1 || true
+    debugfs -w -R "write apps/starry/guest-ip-link/network-init.sh /usr/bin/gipc-network-init.sh" \
+        "$rootfs" >/dev/null
     debugfs -w -R "mkdir /etc/profile.d" "$rootfs" >/dev/null 2>&1 || true
     debugfs -w -R "rm /etc/profile.d/99-gipc.sh" "$rootfs" >/dev/null 2>&1 || true
     debugfs -w -R "write apps/starry/guest-ip-link/gipc-autostart.sh /etc/profile.d/99-gipc.sh" \

--- a/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
+++ b/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 workspace=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 cd "$workspace"
 
-rootfs="${ROOTFS_IMAGE:?set ROOTFS_IMAGE to the Linux guest rootfs image}"
+rootfs="${ROOTFS_IMAGE:?set ROOTFS_IMAGE to the StarryOS guest rootfs image}"
 
 objcopy="${LLVM_OBJCOPY:-$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-objcopy}"
 if [[ ! -x "$objcopy" ]]; then
@@ -20,18 +20,18 @@ raw="target/aarch64-unknown-none-softfloat/release/arceos-guest-ip-server"
 bin="target/aarch64-unknown-none-softfloat/release/arceos-guest-ip-server.bin"
 "$objcopy" --strip-all -O binary "$raw" "$bin"
 
-linux_client="${GIPC_LINUX_CLIENT_BIN:-target/gipc-linux-client}"
-if [[ ! -x "$linux_client" ]]; then
+starry_client="${GIPC_STARRY_CLIENT_BIN:-target/gipc-starry-client}"
+if [[ ! -x "$starry_client" ]]; then
     cc -std=c11 -Wall -Wextra -O2 \
-        apps/starry/guest-ip-link/linux-client.c -o "$linux_client"
+        apps/starry/guest-ip-link/linux-client.c -o "$starry_client"
 fi
 if [[ "${GIPC_INJECT_CLIENT:-1}" == "1" ]]; then
     command -v debugfs >/dev/null || {
-        echo "debugfs is required to inject the Linux client into $rootfs" >&2
+        echo "debugfs is required to inject the StarryOS client into $rootfs" >&2
         exit 1
     }
-    debugfs -w -R "rm /usr/bin/gipc-linux-client" "$rootfs" >/dev/null 2>&1 || true
-    debugfs -w -R "write $linux_client /usr/bin/gipc-linux-client" "$rootfs" >/dev/null
+    debugfs -w -R "rm /usr/bin/gipc-starry-client" "$rootfs" >/dev/null 2>&1 || true
+    debugfs -w -R "write $starry_client /usr/bin/gipc-starry-client" "$rootfs" >/dev/null
     debugfs -w -R "mkdir /etc/profile.d" "$rootfs" >/dev/null 2>&1 || true
     debugfs -w -R "rm /etc/profile.d/99-gipc.sh" "$rootfs" >/dev/null 2>&1 || true
     debugfs -w -R "write apps/starry/guest-ip-link/gipc-autostart.sh /etc/profile.d/99-gipc.sh" \

--- a/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
+++ b/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
@@ -32,6 +32,10 @@ if [[ "${GIPC_INJECT_CLIENT:-1}" == "1" ]]; then
     }
     debugfs -w -R "rm /usr/bin/gipc-linux-client" "$rootfs" >/dev/null 2>&1 || true
     debugfs -w -R "write $linux_client /usr/bin/gipc-linux-client" "$rootfs" >/dev/null
+    debugfs -w -R "mkdir /etc/profile.d" "$rootfs" >/dev/null 2>&1 || true
+    debugfs -w -R "rm /etc/profile.d/99-gipc.sh" "$rootfs" >/dev/null 2>&1 || true
+    debugfs -w -R "write apps/starry/guest-ip-link/gipc-autostart.sh /etc/profile.d/99-gipc.sh" \
+        "$rootfs" >/dev/null
 fi
 
 exec cargo xtask axvisor qemu \

--- a/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
+++ b/os/axvisor/scripts/run-qemu-aarch64-starry-rtos-gipc.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 workspace=$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)
 cd "$workspace"
 
+rootfs="${ROOTFS_IMAGE:?set ROOTFS_IMAGE to the Linux guest rootfs image}"
+
 objcopy="${LLVM_OBJCOPY:-$(rustc --print sysroot)/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-objcopy}"
 if [[ ! -x "$objcopy" ]]; then
     echo "llvm-objcopy not found: $objcopy (set LLVM_OBJCOPY)" >&2
@@ -18,7 +20,21 @@ raw="target/aarch64-unknown-none-softfloat/release/arceos-guest-ip-server"
 bin="target/aarch64-unknown-none-softfloat/release/arceos-guest-ip-server.bin"
 "$objcopy" --strip-all -O binary "$raw" "$bin"
 
+linux_client="${GIPC_LINUX_CLIENT_BIN:-target/gipc-linux-client}"
+if [[ ! -x "$linux_client" ]]; then
+    cc -std=c11 -Wall -Wextra -O2 \
+        apps/starry/guest-ip-link/linux-client.c -o "$linux_client"
+fi
+if [[ "${GIPC_INJECT_CLIENT:-1}" == "1" ]]; then
+    command -v debugfs >/dev/null || {
+        echo "debugfs is required to inject the Linux client into $rootfs" >&2
+        exit 1
+    }
+    debugfs -w -R "rm /usr/bin/gipc-linux-client" "$rootfs" >/dev/null 2>&1 || true
+    debugfs -w -R "write $linux_client /usr/bin/gipc-linux-client" "$rootfs" >/dev/null
+fi
+
 exec cargo xtask axvisor qemu \
     --config os/axvisor/configs/board/qemu-aarch64-starry-rtos-gipc.toml \
     --qemu-config os/axvisor/configs/qemu/qemu-aarch64-starry-rtos-gipc.toml \
-    --rootfs "${ROOTFS_IMAGE:?set ROOTFS_IMAGE to the Linux guest rootfs image}"
+    --rootfs "$rootfs"

--- a/scripts/test/guest-ip-link/README.md
+++ b/scripts/test/guest-ip-link/README.md
@@ -1,0 +1,22 @@
+# Guest IP-link validation
+
+The host-side deterministic check compiles the POSIX Linux endpoint, drops its
+first TCP connection, and verifies that the second connection succeeds with a
+valid GIPC status frame and metrics:
+
+```bash
+python3 scripts/test/guest-ip-link/test_linux_client.py
+```
+
+For a captured guest log, validate the required success markers and positive
+latency/throughput values with:
+
+```bash
+python3 scripts/test/guest-ip-link/verify_metrics.py <guest.log>
+```
+
+The full QEMU flow is documented in
+`docs/design/starry-rtos-ip-link.md` and requires a Linux rootfs image and the
+ArceOS target toolchain. It injects `gipc-linux-client` into the rootfs by
+default, then the operator runs it from the Linux shell after the RTOS service
+prints `GIPC_RTOS_READY`.

--- a/scripts/test/guest-ip-link/README.md
+++ b/scripts/test/guest-ip-link/README.md
@@ -1,6 +1,6 @@
 # Guest IP-link validation
 
-The host-side deterministic check compiles the POSIX Linux endpoint, drops its
+The host-side deterministic check compiles the POSIX StarryOS endpoint, drops its
 first TCP connection, and verifies that the second connection succeeds with a
 valid GIPC status frame and metrics:
 
@@ -23,7 +23,7 @@ python3 scripts/test/guest-ip-link/aggregate_metrics.py <guest.log>
 ```
 
 The full QEMU flow is documented in
-`docs/design/starry-rtos-ip-link.md` and requires a Linux rootfs image and the
-ArceOS target toolchain. It injects `gipc-linux-client` into the rootfs by
-default, then the operator runs it from the Linux shell after the RTOS service
+`docs/design/starry-rtos-ip-link.md` and requires a StarryOS rootfs image and the
+ArceOS target toolchain. It injects `gipc-starry-client` into the rootfs by
+default, then the operator runs it from the StarryOS shell after the ArceOS service
 prints `GIPC_RTOS_READY`.

--- a/scripts/test/guest-ip-link/README.md
+++ b/scripts/test/guest-ip-link/README.md
@@ -15,6 +15,13 @@ latency/throughput values with:
 python3 scripts/test/guest-ip-link/verify_metrics.py <guest.log>
 ```
 
+For a long-running log containing multiple client requests, compute success
+rate, timeout count, P50/P95 request latency, and average effective throughput:
+
+```bash
+python3 scripts/test/guest-ip-link/aggregate_metrics.py <guest.log>
+```
+
 The full QEMU flow is documented in
 `docs/design/starry-rtos-ip-link.md` and requires a Linux rootfs image and the
 ArceOS target toolchain. It injects `gipc-linux-client` into the rootfs by

--- a/scripts/test/guest-ip-link/aggregate_metrics.py
+++ b/scripts/test/guest-ip-link/aggregate_metrics.py
@@ -10,8 +10,9 @@ from pathlib import Path
 
 
 METRIC = re.compile(
-    r"GIPC_STARRY_METRIC .*?success=(?P<success>\d+) .*?"
-    r"timeouts=(?P<timeouts>\d+) rtt_ns=(?P<rtt>\d+) throughput_bps=(?P<throughput>\d+)"
+    r"GIPC_STARRY_METRIC .*?requests=(?P<requests>\d+) success=(?P<success>\d+) .*?"
+    r"errors=(?P<errors>\d+) timeouts=(?P<timeouts>\d+) attempts=(?P<attempts>\d+) "
+    r"reconnects=(?P<reconnects>\d+) recovery=(?P<recovery>\d+) rtt_ns=(?P<rtt>\d+) throughput_bps=(?P<throughput>\d+)"
 )
 
 
@@ -29,18 +30,24 @@ def main() -> int:
     if not samples:
         print("no GIPC metrics found", file=sys.stderr)
         return 1
-    rtts = [int(sample["rtt"]) for sample in samples]
-    successes = sum(int(sample["success"]) == 1 for sample in samples)
+    rtts = [int(sample["rtt"]) for sample in samples if int(sample["rtt"]) > 0]
+    successes = sum(int(sample["success"]) for sample in samples)
+    requests = sum(int(sample["requests"]) for sample in samples)
+    errors = sum(int(sample["errors"]) for sample in samples)
     timeouts = sum(int(sample["timeouts"]) for sample in samples)
+    reconnects = sum(int(sample["reconnects"]) for sample in samples)
+    recoveries = sum(int(sample["recovery"]) for sample in samples)
     throughputs = [int(sample["throughput"]) for sample in samples]
-    total = len(samples)
+    total = requests
     print(
         "GIPC_AGGREGATE "
         f"requests={total} success={successes} success_rate={successes / total:.6f} "
-        f"timeouts={timeouts} rtt_p50_ns={percentile(rtts, 0.50)} "
-        f"rtt_p95_ns={percentile(rtts, 0.95)} throughput_avg_bps={sum(throughputs) // total}"
+        f"app_errors={errors} timeouts={timeouts} reconnects={reconnects} recoveries={recoveries} "
+        f"rtt_p50_ns={percentile(rtts, 0.50) if rtts else 0} "
+        f"rtt_p95_ns={percentile(rtts, 0.95) if rtts else 0} "
+        f"throughput_avg_bps={sum(throughputs) // len(throughputs)}"
     )
-    return 0 if successes == total else 1
+    return 0 if successes == total and errors == 0 else 1
 
 
 if __name__ == "__main__":

--- a/scripts/test/guest-ip-link/aggregate_metrics.py
+++ b/scripts/test/guest-ip-link/aggregate_metrics.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 METRIC = re.compile(
-    r"GIPC_LINUX_METRIC .*?success=(?P<success>\d+) .*?"
+    r"GIPC_STARRY_METRIC .*?success=(?P<success>\d+) .*?"
     r"timeouts=(?P<timeouts>\d+) rtt_ns=(?P<rtt>\d+) throughput_bps=(?P<throughput>\d+)"
 )
 

--- a/scripts/test/guest-ip-link/aggregate_metrics.py
+++ b/scripts/test/guest-ip-link/aggregate_metrics.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Aggregate GIPC client metrics from a multi-request guest log."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+METRIC = re.compile(
+    r"GIPC_LINUX_METRIC .*?success=(?P<success>\d+) .*?"
+    r"timeouts=(?P<timeouts>\d+) rtt_ns=(?P<rtt>\d+) throughput_bps=(?P<throughput>\d+)"
+)
+
+
+def percentile(values: list[int], rank: float) -> int:
+    values = sorted(values)
+    index = min(len(values) - 1, int((len(values) - 1) * rank))
+    return values[index]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log", type=Path)
+    args = parser.parse_args()
+    samples = [match.groupdict() for match in METRIC.finditer(args.log.read_text(encoding="utf-8"))]
+    if not samples:
+        print("no GIPC metrics found", file=sys.stderr)
+        return 1
+    rtts = [int(sample["rtt"]) for sample in samples]
+    successes = sum(int(sample["success"]) == 1 for sample in samples)
+    timeouts = sum(int(sample["timeouts"]) for sample in samples)
+    throughputs = [int(sample["throughput"]) for sample in samples]
+    total = len(samples)
+    print(
+        "GIPC_AGGREGATE "
+        f"requests={total} success={successes} success_rate={successes / total:.6f} "
+        f"timeouts={timeouts} rtt_p50_ns={percentile(rtts, 0.50)} "
+        f"rtt_p95_ns={percentile(rtts, 0.95)} throughput_avg_bps={sum(throughputs) // total}"
+    )
+    return 0 if successes == total else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test/guest-ip-link/test_linux_client.py
+++ b/scripts/test/guest-ip-link/test_linux_client.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Compile and exercise the Linux GIPC client against a deterministic peer."""
+
+from __future__ import annotations
+
+import pathlib
+import socket
+import struct
+import subprocess
+import tempfile
+import threading
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+CLIENT = ROOT / "apps/starry/guest-ip-link/linux-client.c"
+
+
+def crc32(data: bytes) -> int:
+    crc = 0xFFFF_FFFF
+    for byte in data:
+        crc ^= byte
+        for _ in range(8):
+            crc = (crc >> 1) ^ (0xEDB8_8320 if crc & 1 else 0)
+    return (~crc) & 0xFFFF_FFFF
+
+
+def server() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(("127.0.0.1", 4242))
+        listener.listen(1)
+        for attempt in range(2):
+            connection, _ = listener.accept()
+            if attempt == 0:
+                connection.close()
+                continue
+            with connection:
+                header = connection.recv(32)
+                while len(header) < 32:
+                    header += connection.recv(32 - len(header))
+                payload_len = struct.unpack(">H", header[10:12])[0]
+                payload = b""
+                while len(payload) < payload_len:
+                    payload += connection.recv(payload_len - len(payload))
+                sequence = struct.unpack(">I", header[12:16])[0]
+                status_payload = b"\x00\x00\x00\x01\x00\x00\x00\x00"
+                response = bytearray(32 + len(status_payload))
+                struct.pack_into(">I", response, 0, 0x4749_5043)
+                response[4] = 1
+                response[5] = 3
+                struct.pack_into(">H", response, 8, 32)
+                struct.pack_into(">H", response, 10, len(status_payload))
+                struct.pack_into(">I", response, 12, sequence)
+                response[32:] = status_payload
+                struct.pack_into(">I", response, 26, crc32(response))
+                connection.sendall(response)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as directory:
+        binary = pathlib.Path(directory) / "gipc-linux-client"
+        subprocess.run(
+            ["cc", "-std=c11", "-Wall", "-Wextra", "-Werror", "-O2", str(CLIENT), "-o", str(binary)],
+            check=True,
+            cwd=ROOT,
+        )
+        thread = threading.Thread(target=server, daemon=True)
+        thread.start()
+        result = subprocess.run(
+            [str(binary), "127.0.0.1"],
+            check=True,
+            text=True,
+            capture_output=True,
+            cwd=ROOT,
+        )
+        thread.join(timeout=2)
+        assert "GIPC_LINUX_STATUS seq=1" in result.stdout, result.stdout
+        assert "attempts=2 timeouts=1" in result.stdout, result.stdout
+        assert "GIPC_LINUX_METRIC" in result.stdout, result.stdout
+        print(result.stdout, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test/guest-ip-link/test_linux_client.py
+++ b/scripts/test/guest-ip-link/test_linux_client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Compile and exercise the Linux GIPC client against a deterministic peer."""
+"""Compile and exercise the StarryOS GIPC client against a deterministic peer."""
 
 from __future__ import annotations
 
@@ -58,7 +58,7 @@ def server() -> None:
 
 def main() -> None:
     with tempfile.TemporaryDirectory() as directory:
-        binary = pathlib.Path(directory) / "gipc-linux-client"
+        binary = pathlib.Path(directory) / "gipc-starry-client"
         subprocess.run(
             ["cc", "-std=c11", "-Wall", "-Wextra", "-Werror", "-O2", str(CLIENT), "-o", str(binary)],
             check=True,
@@ -74,9 +74,9 @@ def main() -> None:
             cwd=ROOT,
         )
         thread.join(timeout=2)
-        assert "GIPC_LINUX_STATUS seq=1" in result.stdout, result.stdout
+        assert "GIPC_STARRY_STATUS seq=1" in result.stdout, result.stdout
         assert "attempts=2 timeouts=1" in result.stdout, result.stdout
-        assert "GIPC_LINUX_METRIC" in result.stdout, result.stdout
+        assert "GIPC_STARRY_METRIC" in result.stdout, result.stdout
         print(result.stdout, end="")
 
 

--- a/scripts/test/guest-ip-link/verify_metrics.py
+++ b/scripts/test/guest-ip-link/verify_metrics.py
@@ -14,13 +14,13 @@ def main() -> int:
     parser.add_argument("log", type=Path)
     args = parser.parse_args()
     text = args.log.read_text(encoding="utf-8")
-    if "GIPC_LINUX_STATUS" not in text or "GIPC_LINUX_METRIC" not in text:
+    if "GIPC_STARRY_STATUS" not in text or "GIPC_STARRY_METRIC" not in text:
         print("missing GIPC success markers", file=sys.stderr)
         return 1
-    if "GIPC_LINUX_TIMEOUT" in text or "GIPC_RTOS_ERROR" in text:
+    if "GIPC_STARRY_TIMEOUT" in text or "GIPC_RTOS_ERROR" in text:
         print("guest IP-link reported a failure", file=sys.stderr)
         return 1
-    match = re.search(r"GIPC_LINUX_METRIC .*?rtt_ns=(\d+) throughput_bps=(\d+)", text)
+    match = re.search(r"GIPC_STARRY_METRIC .*?rtt_ns=(\d+) throughput_bps=(\d+)", text)
     if match is None or int(match.group(1)) <= 0 or int(match.group(2)) <= 0:
         print("missing positive latency/throughput metrics", file=sys.stderr)
         return 1

--- a/scripts/test/guest-ip-link/verify_metrics.py
+++ b/scripts/test/guest-ip-link/verify_metrics.py
@@ -17,11 +17,13 @@ def main() -> int:
     if "GIPC_STARRY_STATUS" not in text or "GIPC_STARRY_METRIC" not in text:
         print("missing GIPC success markers", file=sys.stderr)
         return 1
-    if "GIPC_STARRY_TIMEOUT" in text or "GIPC_RTOS_ERROR" in text:
+    if "GIPC_STARRY_TIMEOUT" in text or "GIPC_RTOS_ERROR" in text or "GIPC_STARRY_ERROR" in text:
         print("guest IP-link reported a failure", file=sys.stderr)
         return 1
     match = re.search(r"GIPC_STARRY_METRIC .*?rtt_ns=(\d+) throughput_bps=(\d+)", text)
-    if match is None or int(match.group(1)) <= 0 or int(match.group(2)) <= 0:
+    success = re.search(r"GIPC_STARRY_METRIC .*?requests=(\d+) success=(\d+)", text)
+    if (match is None or int(match.group(1)) <= 0 or int(match.group(2)) <= 0 or
+            success is None or success.group(1) != success.group(2)):
         print("missing positive latency/throughput metrics", file=sys.stderr)
         return 1
     print("GIPC_METRICS_OK")

--- a/scripts/test/guest-ip-link/verify_metrics.py
+++ b/scripts/test/guest-ip-link/verify_metrics.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Validate the observable success markers from a guest IP-link run."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("log", type=Path)
+    args = parser.parse_args()
+    text = args.log.read_text(encoding="utf-8")
+    if "GIPC_LINUX_STATUS" not in text or "GIPC_LINUX_METRIC" not in text:
+        print("missing GIPC success markers", file=sys.stderr)
+        return 1
+    if "GIPC_LINUX_TIMEOUT" in text or "GIPC_RTOS_ERROR" in text:
+        print("guest IP-link reported a failure", file=sys.stderr)
+        return 1
+    match = re.search(r"GIPC_LINUX_METRIC .*?rtt_ns=(\d+) throughput_bps=(\d+)", text)
+    if match is None or int(match.group(1)) <= 0 or int(match.group(2)) <= 0:
+        print("missing positive latency/throughput metrics", file=sys.stderr)
+        return 1
+    print("GIPC_METRICS_OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 问题
复查通信链路后，需要补齐 StarryOS 网卡启动配置、多请求序列以及应用错误和恢复指标，保证链路启动入口与验证结果一致。

## 改动
- 新增 StarryOS `eth0` 网络初始化，配置 `10.0.42.1/24` 并在客户端启动前输出 ready 标志。
- QEMU rootfs 注入网络初始化脚本和客户端。
- 支持多请求递增序列号、ERROR 帧解析、协议错误统计、重连和恢复统计。
- 聚合成功率、应用层错误、超时、重连/恢复、RTT P50/P95 和有效吞吐量。
- 更新设计和验证文档，明确 TCP 分帧确认边界、MAC/IP/端口和运行指标。

## 依赖
本 PR 基于 #2155、#2156、#2157、#2158 的通信实现和验证入口。

## 验证
执行协议测试、ArceOS 构建与 Clippy、Starry 客户端断连恢复测试、指标脚本检查和格式检查。