### PR TITLE
fix(axvisor): enable rockchip-dwmmc on OrangePi 5 Plus

### DIFF
--- a/os/axvisor/configs/board/orangepi-5-plus.toml
+++ b/os/axvisor/configs/board/orangepi-5-plus.toml
@@ -1,5 +1,6 @@
 features = [
   "ax-driver/rockchip-sdhci",
+  "ax-driver/rockchip-dwmmc",
   "fs",
 ]
 log = "Info"

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/starry/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/starry/build-aarch64-unknown-none-softfloat.toml
@@ -1,4 +1,5 @@
 features = [
+  "ax-driver/rockchip-dwmmc",
   "ax-driver/rockchip-sdhci",
   "fs",
 ]


### PR DESCRIPTION
## Problem

The OrangePi 5 Plus board config only enabled `ax-driver/rockchip-sdhci`
(the eMMC controller), but the SD card that carries guest images on this
board sits behind the DesignWare mobile storage host at `mmc@fe2c0000`.
Without `ax-driver/rockchip-dwmmc`, an axvisor built for this board
cannot bring up the SD card, so `image_location = "fs"` guests have
nothing to load from.

## What changed

- Enable `ax-driver/rockchip-dwmmc` in `os/axvisor/configs/board/
  orangepi-5-plus.toml`.
- Enable the same feature in the board test-suit build config
  (`test-suit/axvisor/normal/board-orangepi-5-plus/starry/`).

Note: a first attempt spelled the feature `rockchip/dwmmc`, which
referenced a dependency that no longer exists and made a direct
`cargo xtask axvisor build` with this config fail on feature
resolution; this PR uses the correct crate-qualified spelling
throughout.

## Validation

- `cargo xtask axvisor build --config os/axvisor/configs/board/
  orangepi-5-plus.toml` succeeds with the feature enabled;
- on-board: the SD card enumerates and the guest kernel loads from the
  ext4 rootfs on the SD card.