### PR TITLE
fix(ax-driver): attribute RK3588 governor busy by FDT cpu topology

### DIFF
--- a/components/axklib/src/lib.rs
+++ b/components/axklib/src/lib.rs
@@ -242,6 +242,29 @@ pub trait Klib {
             Err(IrqError::Unsupported)
         }
     }
+
+    /// Resolves a firmware CPU id to the kernel's dense logical CPU index.
+    ///
+    /// Firmware ids are the identifiers the boot firmware and device tree use
+    /// for CPUs: the `reg` value of a `/cpus` child node on device-tree
+    /// platforms (the AArch64 MPIDR affinity value, a RISC-V hart id, ...).
+    /// The kernel — not the device tree — assigns logical CPU indices (the
+    /// boot hart becomes logical CPU 0, the remaining firmware ids follow in
+    /// firmware order), and per-CPU kernel state such as scheduler counters is
+    /// keyed by that index. Drivers that attribute per-logical-CPU data to
+    /// hardware resources must resolve ids through this mapping instead of
+    /// assuming a `/cpus` enumeration order.
+    ///
+    /// Returns `None` when the platform provides no such mapping or no online
+    /// CPU runs the given firmware id.
+    fn cpu_resolve_logical_index(_hardware_id: usize) -> Option<usize> {
+        None
+    }
+}
+
+/// Convenience re-exports for CPU topology queries.
+pub mod cpu {
+    pub use super::klib::cpu_resolve_logical_index as resolve_logical_index;
 }
 
 /// Convenience re-export for memory IO mapping.

--- a/docs/design/rk3588-cpufreq.md
+++ b/docs/design/rk3588-cpufreq.md
@@ -1,62 +1,203 @@
-# RK3588 CPU DVFS (cpufreq)
+# RK3588 CPU DVFS 设计说明
 
-Feature-gated ondemand CPU frequency/voltage scaling for the Orange Pi 5 Plus
-(RK3588). It is off by default in the generic and QEMU builds — the
-`ax-driver/rk3588-cpufreq` feature compiles the driver to no-ops there — and is
-enabled on the Orange Pi board build.
+特性开关 `ax-driver/rk3588-cpufreq`（默认关闭，Orange Pi 5 Plus 板卡构建启用）为 RK3588
+提供 ondemand CPU 调频调压。本文是这套驱动的行为契约：调频域与安全边界、负载归因（逻辑
+CPU 到物理集群的映射拥有者与排序规则）、调度策略与降频下限，以及可在串口上核对的验收
+手段。实现位于 `drivers/ax-driver/src/soc/rockchip/cpufreq.rs`，内核侧轮询任务位于
+`os/StarryOS/kernel/src/entry.rs`。
 
-## What it does
+## 1. 功能与安全边界
 
-The RK3588 CPU clock is a voltage-coupled PVTPLL. An **ondemand** governor scales
-each of the three CPU clusters (A55 little `cpu0-3`, two A76 big pairs `cpu4-5` /
-`cpu6-7`) between OPPs by pairing an SCMI PVTPLL ring target with a PMIC rail
-voltage:
+### 1.1 调频域与两根杠杆
 
-- **A76** uses the full voltage lever — its RK8602/RK8603 rails read back over I2C,
-  so every voltage write is confirmed and the SCMI clock rate is read back before an
-  OPP is committed.
-- **A55** is **ring-only**: its RK806 rail cannot be read back (a MISO hardware
-  limit), so it stays on the boot-confirmed 675 mV rail and scales only its SCMI
-  ring. 675 mV over-volts every A55 ring ≤ 1008 MHz, so it can never undervolt.
+RK3588 的 CPU 时钟是电压耦合的 PVTPLL：SCMI 时钟号只选定环形振荡器目标，实际送达频率
+跟随核心轨电压。因此一次 OPP 迁移必须成对操作 SCMI ring 与 PMIC 轨电压，且顺序保证任何
+中间状态都只会过压、不会欠压（升档先压后频，降档先频后压，见 `apply_opp` 与
+`run_apply_steps` 的主机端测试）。
 
-It is **fail-safe**: if either PMIC bus does not come up at boot, `GOV_READY` stays
-`false` and every cluster is left on its boot OPP (no scaling).
+三个物理调频域、它们的 SCMI 时钟号与 boot 目标如下（依据 `orangepi5plus.dts`）：
 
-## Enable and build
+| 集群 | 物理 CPU | SCMI 时钟号 | boot OPP |
+| --- | --- | --- | --- |
+| A55（小核） | cpu0-3 | 0 | 1008 MHz @ 675 mV |
+| A76 big0 | cpu4/5 | 2 | 1200 MHz ring @ 675 mV |
+| A76 big1 | cpu6/7 | 3 | 1200 MHz ring @ 675 mV |
 
-The feature is enabled in both Orange Pi 5 Plus build configs:
+两个大核集群使用完整电压杠杆：RK8602/RK8603 轨电压可经 I2C 读回，每次写都确认后才提交
+OPP。A55 是 ring-only：其 RK806 轨电压读路径存在硬件限制（MISO 不进移位寄存器），因此只
+在启动对齐阶段执行一次有界的降压，运行期不再写 A55 轨电压，仅移动 SCMI ring；675 mV 对
+所有 ≤1008 MHz 的 ring 都过压，不可能欠压（`Cluster::voltage_managed` 固定了这一划分，
+`a55_ladder_is_ring_only_on_the_boot_rail` 测试锁定）。
+
+### 1.2 失败安全与探测时序
+
+失败安全由 `GOV_READY` 门控：任一时刻 A76 I2C PMIC 未起来，governor 不武装，所有集群停
+在 boot OPP；A55 SPI 失败不阻止 governor（A55 本就 ring-only）。探测本身是
+`PostKernel`/`DEFAULT` 级、一次性守卫 `APPLIED` 保护，发生在 `start_secondary_cpus()`
+之前，重定时 A76 时其上没有被调度的核心。
+
+## 2. 负载归因契约
+
+governor 收到的 `busy[i]` 是**逻辑 CPU i** 的累计忙计数（内核调度 tick 维护，见
+`ax_task::cpu_busy_ticks` 与 entry.rs 的采样循环），而调频域是物理集群。归因要回答的问
+题是：逻辑 CPU i 实际运行在哪个物理集群上。
+
+### 2.1 逻辑编号的拥有者
+
+逻辑 CPU 编号由**内核的 CPU 列表**决定，不由设备树的文档顺序决定：someboot 的
+`CpuIdOrder`（`platforms/someboot/src/smp/cpu_iter.rs`）把 boot hart 的固件硬件号排在
+逻辑 0，其余 CPU 按固件（FDT `/cpus` 文档序）跟进。per-CPU 内核状态（调度队列、忙计数）
+全部按这套索引分配。驱动的归因必须与它一致，唯一的正确来源是询问内核本身：
+
+`axklib::cpu::resolve_logical_index(hardware_id)`
+→ `Klib::cpu_resolve_logical_index`（`components/axklib`）
+→ `ax_hal::topology::resolve_cpu_index`（axruntime 实现）
+→ somehal `cpu_id_to_idx`（即当初分配 per-CPU 索引的同一映射）。
+
+ax-driver 位于 ax-task/ax-hal 之下，不能直接依赖它们，`Klib` 是既有的上行能力通道。
+未实现该能力的平台得到 `None`，行为退化为回退路径（见 2.3）。
+
+之所以强调这一点，是因为 guest FDT 的文档顺序可能与逻辑顺序脱节：Axvisor 的
+`create_guest_fdt`/`need_cpu_node`（`virtualization/axvm/src/boot/fdt/core/create.rs`）
+按 `phys_cpu_ids` **成员**过滤 `/cpus/cpu@*` 并保留宿主 DT 顺序，不按数组顺序重排；而
+每个 vCPU 的 guest MPIDR 等于其 `phys_cpu_ids[i]`（`virtualization/axvm/src/arch/aarch64/vm.rs`
+的 `mpidr_el1`）。对非单调绑定如 `phys_cpu_ids = [0x400, 0x000]`，guest FDT 仍先列出
+cpu@0，但逻辑 CPU 0 运行在 A76 cpu@400 上。按遍历序号归因会把大核负载记到 A55 集群：
+governor 推高小核而真正承载负载的大核从不升频——这正是本契约要排除的失效模式。
+
+### 2.2 逐节点归因规则
+
+`map_cpus_from_fdt` 对每个 `/cpus` cpu 节点做同一套判定：取节点的 `reg`（固件硬件号）
+与 SCMI 时钟号（`cpu_node_topology`），把硬件号经 2.1 的能力解析成逻辑索引，再把该时钟
+号对应的集群记入 `CPU_CLUSTER[logical]`（`store_cpu_clusters` 为可主机测试的纯核心）。
+
+```mermaid
+flowchart TD
+    A["cpu 节点"] -->|"缺 reg"| W1["warn：不参与归因"]
+    A -->|"缺 SCMI 集群时钟"| W2["warn：不参与归因"]
+    A -->|"时钟号不属任一集群"| S1["静默跳过"]
+    A --> R["解析硬件号 → 逻辑索引"]
+    R -->|"None：CPU 未运行 / 平台无实现"| S2["不驱动任何域"]
+    R -->|"索引越界"| S3["拒绝，不写入"]
+    R --> V["写入 CPU_CLUSTER：逻辑索引 → 集群"]
+```
+
+这些分支不是防御性堆砌，而是可独立验收的契约：诊断"某个集群不调频"或"调错集群"时，可
+按下表逐项排除输入侧原因。
+
+| 情况 | 处理 | 理由 |
+| --- | --- | --- |
+| 节点缺 `reg` 或缺可识别 SCMI 集群时钟 | warn 后跳过 | 节点无法标识身份或所属域 |
+| 时钟号不属于任何 CPU 集群 | 跳过 | `cluster_index_from_clock_id` 之外无目标域 |
+| 硬件号解析为 `None` | 不驱动任何域 | 内核未运行该 CPU（离线/未纳入 CPU 集）或平台未实现该能力 |
+| 逻辑索引越界（≥ `CPU_CLUSTER.len()`） | 拒绝写入 | 防御畸形解析结果，不 panic |
+| 两个节点 `reg` 重复 | 畸形 DT，后写覆盖 | DT 规范要求 `reg` 唯一；映射仍是"逻辑索引 → 集群"的函数，无害 |
+
+所有跳过都是保守方向：被跳过的 CPU 不贡献任何忙碌读数，因此绝不会把某个域"读成全空
+闲"而误降频，只会让它维持原状态。
+
+### 2.3 部分映射与回退
+
+部分映射是合法状态：只有至少映射到一个在线逻辑 CPU 的集群参与决策；没有任何在线 CPU
+的集群在 `governor_poll` 中被整体跳过（`counts[ci] == 0 → continue`），不会被当作全空
+闲而永远降频。仅当整趟 FDT 走查一无所获（`map_cpus_from_fdt() == 0`，例如平台未实现
+2.1 的能力）时，`map_cpus_from_physical_topology` 按 cpu0-3 / cpu4-5 / cpu6-7 的物理区间
+回退，裸机行为与历史版本一致。
+
+## 3. 调度策略与降频下限
+
+### 3.1 ondemand 决策
+
+每个集群共享一个时钟，因此由其**最忙的核心**驱动（`next_opp_idx`，主机可测）：任一核
+心忙碌百分比 ≥ `UP_THRESHOLD_PCT`（80%）时一步跳到梯顶（快速攻击）；全部核心 <
+`DOWN_THRESHOLD_PCT`（30%）时降一档；其余保持。窗口按实际流逝时间折算（慢唤醒不会虚
+增负载），首次轮询只建立基线不做决策。
+
+### 3.2 boot OPP 下限
+
+降档以 `BOOT_OPP_IDX`（A55 1008 / A76 1200 ring @ 675 mV）为下限：突发 I/O 型负载在两次
+读盘之间读作近空闲，降到 boot OPP 以下会拖慢其完成路径（板上实测 490 MB 模型读取：静态
+1200 MHz 25.4s，允许降到 408 MHz 则 29.8s）。由此有一个直接推论：A55 梯子的顶格就是它
+的 boot OPP，所以 A55 永远不会被 governor 降档，只在 ring-only 梯内保持 1008 MHz。
+
+## 4. 启用与构建
+
+特性在两个 Orange Pi 5 Plus 构建配置中启用：
 
 - `test-suit/starryos/board-orangepi-5-plus/build-aarch64-unknown-none-softfloat.toml`
-  — the config the **board CI runner** actually builds, so the standard board
-  test entry compiles, boots and runs the governor on real hardware:
+  —— 板卡 CI runner 实际构建的配置，标准板卡测试入口会在真实硬件上编译、启动并运行
+  governor：
 
   ```bash
   cargo xtask starry test board --board orangepi-5-plus
   ```
 
-  Every case there boots this kernel; a governor-induced boot panic/hang trips the
-  cases' `panic` fail-regex, so the board CI regression-guards the feature.
-- `os/StarryOS/configs/board/orangepi-5-plus.toml` — the general board build
-  template (for a full-board `max_cpu_num` build outside CI).
+  该套件每个用例都启动此内核；governor 引起的启动 panic/挂起会命中用例的 `panic`
+  失败正则，板卡 CI 由此回归保护该特性。
+- `os/StarryOS/configs/board/orangepi-5-plus.toml` —— 通用板卡构建模板（CI 之外的
+  `max_cpu_num` 全核构建）。
 
-To enable it in a custom build, add `"ax-driver/rk3588-cpufreq"` to that config's
-`features` list.
+自定义构建启用时，向该配置的 `features` 列表加入 `"ax-driver/rk3588-cpufreq"`。
 
-## Observable verification
+## 5. 可观测验证
 
-At boot (early init, before the console handoff) the driver logs the rail bring-up
-and governor arming to the serial console:
+### 5.1 启动与运行日志
 
-```
+启动早期（console 交接前）输出轨电压与重定时结果；governor 武装条件是 A76 I2C PMIC 成
+功（A55 SPI 失败不影响，A55 ring-only）：
+
+```text
 cpufreq: A55 rail boot voltage = <uV> uV
 cpufreq: A55 <before>-><after>, A76 <before>-><after> MHz
-cpufreq: ondemand governor armed (both PMIC buses up)
+cpufreq: ondemand governor armed (A76 I2C up; a55_spi=<bool>, A55 ring-only)
 ```
 
-Under load, per-cluster OPP transitions are logged
-(`gov: A76b0 peak=<n>% opp <i>-><j> = <mhz> MHz @ <mv> mV`), and the delivered
-frequency can be read exactly with `cpuprobe`'s `mhz_pmc` (the PMU cycle counter is
-enabled at boot): a busy cluster climbs toward its top OPP, an idle cluster sheds
-back down one step at a time. The companion `apps/starry/sysbench-board` harness
-(PR #1658) drives an all-core load and captures these numbers against a Linux
-baseline.
+governor 武装后的第一次 `governor_poll`（任务启动后约一个 `GOV_PERIOD_MS`）构建归因映射
+并输出一行最终映射，误归因的启动可以直接在串口定位：
+
+```text
+cpufreq: busy attribution cpu0->A76b0 cpu1->A55 ...
+```
+
+运行期每次 OPP 迁移输出
+`gov: <cluster> peak=<n>% opp <i>-><j> = <mhz> MHz @ <mv> mV`。精确送达频率可用
+`cpuprobe` 的 `mhz_pmc` 读取（PMU 周期计数器在启动时使能）；配套的
+`apps/starry/sysbench-board` harness（PR #1658）驱动全核负载并与 Linux 基线对比。
+
+### 5.2 频率读数
+
+`log_frequency_readout()` 是只读快照，由 StarryOS 内核 `entry.rs` 的 `init` 在决定是否
+派生 governor 任务之后调用，输出三个域的 SCMI ring 频率、governor 武装状态、各域 OPP
+索引与当前核心的送达频率（PMU 实测）：
+
+```text
+cpufreq readout: A55=<mhz> MHz, A76b0=<mhz> MHz, A76b1=<mhz> MHz, governor=<bool> \
+(gov_ready=<bool>), opp_idx=(<i>,<i>,<i>), current-core delivered=<mhz> MHz
+```
+
+它不改动任何时钟与电压，用于回答"这个内核此刻实际跑在哪个集群、多高频率"。
+
+### 5.3 确定性验收
+
+映射逻辑的确定性验证在主机单元测试层（`cargo test -p ax-driver --features
+rk3588-cpufreq --lib cpufreq`），其中非单调用例曾在按 FDT 序号归因的旧实现下实际失败后
+再修复（红-绿证据）：
+
+| 测试 | 固定的行为 |
+| --- | --- |
+| `non_monotonic_pin_books_busy_under_the_cluster_it_runs_on` | `[0x400, 0x000]` + boot-hart 优先解析：busy[0]→A76b0、busy[1]→A55 |
+| `identity_order_books_each_cpu_under_its_own_cluster` | 裸机全核顺序下逐 CPU 与 `Cluster::cpus()` 一致 |
+| `single_vcpu_pin_books_under_its_pinned_cluster` | SMP=1 绑 cpu@400：仅 cpu0→A76b0 |
+| `offline_hardware_id_books_nowhere` | 内核未运行的硬件号不落入任何逻辑索引 |
+| `out_of_range_logical_index_is_refused` | 越界逻辑索引被拒绝且不 panic |
+| `cluster_clock_ids_map_to_governor_cluster_indices` | SCMI 时钟号→集群索引表 |
+| `physical_topology_fallback_partitions_all_cpus` | 回退物理区间与 `Cluster::cpus()` 一致 |
+| `governor_*` / `apply_*` / `opp_table_*` | 阈值、boot-OPP 下限、升降档顺序与事务提交语义 |
+
+非单调跨集群绑定的板卡验收条件（当前尚未在实体板上执行，为合并后的确认项）：
+
+1. guest 配置 `phys_cpu_ids = [0x400, 0x000]`（SMP=2），vCPU0 绑 A76 big0；
+2. 启动串口出现 `cpufreq: busy attribution cpu0->A76b0 cpu1->A55`；
+3. 在 vCPU0 上施加 CPU 密集负载：出现 `gov: A76b0 ... opp 2-><更高>` 升档行，`gov: A55`
+   不因该负载升档，`cpufreq readout:` 中 A76b0 的 `opp_idx` 上移而 A55 保持；
+4. 把负载移到 vCPU1 后 A55 的行为对称成立。

--- a/drivers/ax-driver/src/lib.rs
+++ b/drivers/ax-driver/src/lib.rs
@@ -107,6 +107,7 @@ pub mod cpufreq {
     #[cfg(feature = "rk3588-cpufreq")]
     pub use crate::soc::rockchip::cpufreq::{
         calibrate_cluster, calibrate_wanted, governor_period_ms, governor_poll, governor_wanted,
+        log_frequency_readout,
     };
 
     /// Feature-off stub: no governor, so the kernel never spawns its task.
@@ -130,6 +131,9 @@ pub mod cpufreq {
     /// Feature-off stub.
     #[cfg(not(feature = "rk3588-cpufreq"))]
     pub fn calibrate_cluster(_cluster_idx: usize, _intended_cpu: usize) {}
+    /// Feature-off stub: no clock code ran, so there is nothing to report.
+    #[cfg(not(feature = "rk3588-cpufreq"))]
+    pub fn log_frequency_readout() {}
 }
 
 #[cfg(feature = "pci")]

--- a/drivers/ax-driver/src/soc/rockchip/cpufreq.rs
+++ b/drivers/ax-driver/src/soc/rockchip/cpufreq.rs
@@ -54,7 +54,7 @@
 //! one-shot guard because several `cpu@*` nodes match.
 
 use alloc::format;
-use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
 use fdt_edit::Phandle;
 use log::{info, warn};
@@ -472,6 +472,12 @@ const A55_OPPS: &[Opp] = &[
 /// A55 1008 MHz and A76 1200 MHz are both element 2 (the 675 mV rung). The governor
 /// starts tracking here so its first move is relative to the known boot state; from
 /// idle it decays down the ring-scaled rungs and under load climbs the voltage ones.
+/// Also the governor's shed floor (`scaling_min_freq` equivalent): bursty-I/O
+/// workloads (e.g. a model load that blocks on SD reads most of the window)
+/// read as near-idle, and shedding below the boot OPP slows their per-block
+/// completion path far more than the idle power it saves — measured on
+/// OrangePi 5 Plus, a 490 MB model read went 25.4s (static 1200 MHz) vs
+/// 29.8s (shedding to 408 MHz between read bursts).
 const BOOT_OPP_IDX: usize = 2;
 
 /// The three DVFS domains (one little cluster, two big pairs).
@@ -756,6 +762,135 @@ pub fn governor_period_ms() -> u64 {
     GOV_PERIOD_MS
 }
 
+// ===========================================================================
+// Logical-CPU -> cluster attribution
+// ===========================================================================
+
+/// Governor busy attribution: `busy[i]` from the kernel is LOGICAL CPU `i`'s
+/// counter (enumeration order of the FDT `/cpus` children this kernel actually
+/// has), while a DVFS domain is a physical cluster. Hardcoding the physical
+/// ranges is only correct when every physical CPU is online: a passthrough
+/// guest with fewer vCPUs pinned elsewhere (e.g. SMP=1 on host cpu@400) would
+/// book its cpu0's busy under the A55 cluster — the workload then boosts the
+/// little cluster while the big cluster it runs on gets parked at 408 MHz.
+/// The map below is therefore built from the FDT cpu nodes' SCMI clock ids,
+/// which name the cluster each online CPU really belongs to.
+static CPU_CLUSTER: [AtomicU8; 8] = [const { AtomicU8::new(0) }; 8];
+static CPU_CLUSTER_READY: AtomicBool = AtomicBool::new(false);
+
+/// Maps an SCMI CPU-cluster clock id to its governor cluster index.
+/// 0 (A55) -> 0, 2 (A76 pair 0) -> 1, 3 (A76 pair 1) -> 2.
+fn cluster_index_from_clock_id(clock_id: u32) -> Option<usize> {
+    match clock_id {
+        id if id == A55_CLK_ID => Some(0),
+        id if id == A76_CLK_IDS[0] => Some(1),
+        id if id == A76_CLK_IDS[1] => Some(2),
+        _ => None,
+    }
+}
+
+/// Fills `CPU_CLUSTER` from the FDT: one entry per `/cpus` child (in document
+/// order = logical-CPU enumeration order), taken from that node's SCMI clock
+/// id. Returns the number of CPUs mapped.
+fn map_cpus_from_fdt() -> usize {
+    let Some(phandle) = scmi_clock_phandle() else {
+        return 0;
+    };
+    rdrive::with_fdt(|fdt| {
+        let mut mapped = 0usize;
+        for (cpu, node) in fdt
+            .find_compatible(&["arm,cortex-a55", "arm,cortex-a76"])
+            .into_iter()
+            .take(CPU_CLUSTER.len())
+            .enumerate()
+        {
+            let Some(cluster) = node
+                .clocks()
+                .into_iter()
+                .find(|c| c.phandle == phandle)
+                .and_then(|clock| clock.specifier.first().copied())
+                .and_then(cluster_index_from_clock_id)
+            else {
+                warn!(
+                    "cpufreq: cpu node {} has no recognizable SCMI cluster clock; it will not \
+                     drive the governor",
+                    node.name()
+                );
+                continue;
+            };
+            CPU_CLUSTER[cpu].store(cluster as u8 + 1, Ordering::Relaxed);
+            mapped += 1;
+        }
+        mapped
+    })
+    .unwrap_or(0)
+}
+
+/// Physical-topology fallback used when the FDT walk maps nothing (so bare
+/// metal with an unexpected FDT shape never changes behavior). This is the
+/// inverse of [`Cluster::cpus`]: cpu0-3 -> A55, 4/5 -> A76b0, 6/7 -> A76b1.
+fn map_cpus_from_physical_topology() {
+    for (ci, &cluster) in [Cluster::A55, Cluster::Big0, Cluster::Big1]
+        .iter()
+        .enumerate()
+    {
+        for cpu in cluster.cpus() {
+            if let Some(slot) = CPU_CLUSTER.get(cpu) {
+                slot.store(ci as u8 + 1, Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+/// Ensures the attribution map is built (once). FDT-sourced, falling back to
+/// the physical topology when the walk yields nothing.
+fn ensure_cpu_cluster_map() {
+    if CPU_CLUSTER_READY.swap(true, Ordering::Acquire) {
+        return;
+    }
+    if map_cpus_from_fdt() == 0 {
+        map_cpus_from_physical_topology();
+    }
+}
+
+/// Cluster index driving logical `cpu`, or `None` when no online CPU maps
+/// there (such a CPU's busy is simply not attributed anywhere).
+fn cluster_of_cpu(cpu: usize) -> Option<usize> {
+    let slot = CPU_CLUSTER
+        .get(cpu)?
+        .load(Ordering::Acquire)
+        .checked_sub(1)?;
+    Some(slot as usize)
+}
+
+/// Read-only boot diagnostic: log each CPU cluster's SCMI ring rate, the
+/// per-cluster OPP index, the governor state, and the current core's delivered
+/// frequency (PMU cycle counter). Changes no clock and no voltage — it answers
+/// "which cluster and what frequency is this kernel actually running on" for
+/// CPU-bound workload triage (e.g. comparing against native Linux).
+pub fn log_frequency_readout() {
+    let Some(phandle) = scmi_clock_phandle() else {
+        info!(
+            "cpufreq readout: SCMI clock provider not initialized; clusters left at firmware boot \
+             rates"
+        );
+        return;
+    };
+    let a55_mhz = read_mhz(phandle, Cluster::A55.clock_id());
+    let big0_mhz = read_mhz(phandle, Cluster::Big0.clock_id());
+    let big1_mhz = read_mhz(phandle, Cluster::Big1.clock_id());
+    info!(
+        "cpufreq readout: A55={a55_mhz} MHz, A76b0={big0_mhz} MHz, A76b1={big1_mhz} MHz, \
+         governor={} (gov_ready={}), opp_idx=({},{},{}), current-core delivered={} MHz",
+        governor_wanted(),
+        GOV_READY.load(Ordering::Relaxed),
+        IDX[0].load(Ordering::Relaxed),
+        IDX[1].load(Ordering::Relaxed),
+        IDX[2].load(Ordering::Relaxed),
+        measure_mhz(),
+    );
+}
+
 /// Pure ondemand policy, split out of [`governor_poll`] so the up/down/hold/prime
 /// decision is host-testable with no hardware or tick counters. Given each core's
 /// busy% over the last window (each already clamped to `0..=100`), the cluster's
@@ -765,8 +900,8 @@ pub fn governor_period_ms() -> u64 {
 ///   * any core at/above [`UP_THRESHOLD_PCT`] -> jump straight to the top OPP
 ///     (ondemand fast-attack; a cluster shares one clock, so its busiest core
 ///     drives it — averaging would bury a single saturated thread);
-///   * every core below [`DOWN_THRESHOLD_PCT`] -> shed exactly one step (never
-///     below index 0);
+///   * every core below [`DOWN_THRESHOLD_PCT`] -> shed exactly one step, floored
+///     at [`BOOT_OPP_IDX`];
 ///   * otherwise hold.
 fn next_opp_idx(core_pcts: &[u64], cur: usize, ladder_len: usize, priming: bool) -> usize {
     if priming || core_pcts.is_empty() || ladder_len == 0 {
@@ -776,7 +911,7 @@ fn next_opp_idx(core_pcts: &[u64], cur: usize, ladder_len: usize, priming: bool)
     let all_cores_low = core_pcts.iter().all(|&p| p < DOWN_THRESHOLD_PCT);
     if any_core_high {
         ladder_len - 1
-    } else if all_cores_low && cur > 0 {
+    } else if all_cores_low && cur > BOOT_OPP_IDX {
         cur - 1
     } else {
         cur
@@ -792,12 +927,15 @@ fn next_opp_idx(core_pcts: &[u64], cur: usize, ladder_len: usize, priming: bool)
 /// neither sleeps nor spawns — so this crate needs no dependency on
 /// ax-task/ax-hal (which would be a cyclic dep through axplat-dyn).
 ///
-/// `busy[i]` is CPU `i`'s counter; indices past the slice, or offline CPUs whose
-/// counter never advances, simply read as idle — conservative (never over-scales).
+/// `busy[i]` is LOGICAL CPU `i`'s counter, attributed to the cluster its FDT
+/// cpu node belongs to (see [`CPU_CLUSTER`]); unmapped CPUs, indices past the
+/// slice, and offline CPUs whose counter never advances simply contribute
+/// nothing — conservative (never over-scales).
 pub fn governor_poll(busy: &[u64]) {
     if !governor_wanted() {
         return;
     }
+    ensure_cpu_cluster_map();
 
     // Measure the ACTUAL window this poll covers, in scheduler ticks, from the
     // monotonic clock — not the nominal `GOV_PERIOD_MS`. If the governor task woke
@@ -815,45 +953,57 @@ pub fn governor_poll(busy: &[u64]) {
     // busy% reads ~0 — irrelevant, since the priming poll holds regardless.)
     let priming = !PRIMED.swap(true, Ordering::Relaxed);
 
+    // Score each online logical CPU into its mapped cluster. A cluster shares
+    // ONE clock, so a single saturated core is reason to raise the whole
+    // cluster — this matches Linux schedutil/ondemand, which drive a frequency
+    // domain from its busiest CPU. Averaging instead (an earlier bug) buried
+    // one CPU-bound thread among its idle siblings: a single thread on the
+    // 2-core A76 pair only reads 50%, below the up-threshold, so the cluster
+    // never boosted. Each CPU belongs to exactly one cluster, so every
+    // LAST_BUSY entry is refreshed exactly once per poll.
+    let mut peaks = [0u64; 3]; // busiest core per cluster, for the log lines
+    // RK3588 clusters have at most 4 cores (A55 cpu0-3; the big pairs have 2).
+    let mut core_pcts = [[0u64; 4]; 3];
+    let mut counts = [0usize; 3];
+    for cpu in 0..busy.len().min(LAST_BUSY.len()) {
+        // An unmapped CPU (no FDT cpu node / no recognizable cluster clock)
+        // must not drive any domain: skip it entirely instead of booking it
+        // as idle, which would drag a cluster's "all cores low" test down.
+        let Some(ci) = cluster_of_cpu(cpu) else {
+            continue;
+        };
+        let now = busy[cpu];
+        let last = LAST_BUSY[cpu].swap(now, Ordering::Relaxed);
+        // Per-core busy% = busy_ticks / actual window_ticks (one core), clamped.
+        let pct = ((now.saturating_sub(last) * 100) / window_ticks).min(100);
+        if pct > peaks[ci] {
+            peaks[ci] = pct;
+        }
+        if let Some(slot) = core_pcts[ci].get_mut(counts[ci]) {
+            *slot = pct;
+        }
+        counts[ci] += 1;
+    }
+
     for (ci, &cluster) in [Cluster::A55, Cluster::Big0, Cluster::Big1]
         .iter()
         .enumerate()
     {
-        // Score each core in the cluster individually this window. A cluster
-        // shares ONE clock, so a single saturated core is reason to raise the
-        // whole cluster — this matches Linux schedutil/ondemand, which drive a
-        // frequency domain from its busiest CPU. Averaging instead (an earlier
-        // bug) buried one CPU-bound thread among its idle siblings: a single
-        // thread on the 2-core A76 pair only reads 50%, below the up-threshold,
-        // so the cluster never boosted. Each CPU belongs to exactly one cluster,
-        // so every LAST_BUSY entry is refreshed exactly once per poll.
-        let mut peak_pct = 0u64; // busiest core, for the log line
-        // RK3588 clusters have at most 4 cores (A55 cpu0-3; the big pairs have 2).
-        let mut core_pcts = [0u64; 4];
-        let mut n = 0usize;
-        for cpu in cluster.cpus() {
-            let now = busy.get(cpu).copied().unwrap_or(0);
-            let last = LAST_BUSY[cpu].swap(now, Ordering::Relaxed);
-            // Per-core busy% = busy_ticks / actual window_ticks (one core), clamped.
-            let pct = ((now.saturating_sub(last) * 100) / window_ticks).min(100);
-            if pct > peak_pct {
-                peak_pct = pct;
-            }
-            if let Some(slot) = core_pcts.get_mut(n) {
-                *slot = pct;
-            }
-            n += 1;
-        }
+        // No online CPU maps to this domain (e.g. a small passthrough guest
+        // pinned elsewhere): leave its OPP where the boot path left it rather
+        // than reading the empty cluster as idle and down-clocking it forever.
+        let n = counts[ci];
         if n == 0 {
             continue;
         }
+        let peak_pct = peaks[ci];
 
         let opps = cluster.opps();
         let cur = IDX[ci].load(Ordering::Relaxed);
         // Pure up/down/hold/prime decision (host-tested); the priming poll only
         // seeds the baseline above and holds here.
         let new = next_opp_idx(
-            &core_pcts[..n.min(core_pcts.len())],
+            &core_pcts[ci][..n.min(core_pcts[ci].len())],
             cur,
             opps.len(),
             priming,
@@ -1091,6 +1241,34 @@ pub fn calibrate_cluster(cluster_idx: usize, intended_cpu: usize) {
 mod tests {
     use super::*;
 
+    #[test]
+    fn cluster_clock_ids_map_to_governor_cluster_indices() {
+        assert_eq!(cluster_index_from_clock_id(A55_CLK_ID), Some(0));
+        assert_eq!(cluster_index_from_clock_id(A76_CLK_IDS[0]), Some(1));
+        assert_eq!(cluster_index_from_clock_id(A76_CLK_IDS[1]), Some(2));
+        // SCMI id 1 is not a CPU-cluster clock on RK3588; neither is anything
+        // past the cluster ids.
+        assert_eq!(cluster_index_from_clock_id(1), None);
+        assert_eq!(cluster_index_from_clock_id(4), None);
+    }
+
+    #[test]
+    fn physical_topology_fallback_partitions_all_cpus() {
+        // The fallback must cover every CPU exactly once and agree with
+        // `Cluster::cpus()`, so a failed FDT walk cannot change bare-metal
+        // governor behavior.
+        map_cpus_from_physical_topology();
+        for (ci, &cluster) in [Cluster::A55, Cluster::Big0, Cluster::Big1]
+            .iter()
+            .enumerate()
+        {
+            for cpu in cluster.cpus() {
+                assert_eq!(cluster_of_cpu(cpu), Some(ci), "cpu {cpu}");
+            }
+        }
+        assert_eq!(cluster_of_cpu(CPU_CLUSTER.len()), None);
+    }
+
     // -----------------------------------------------------------------------
     // OPP transactional apply: ordering + commit-only-on-full-success
     //
@@ -1179,13 +1357,21 @@ mod tests {
     }
 
     #[test]
-    fn governor_all_idle_sheds_one_step() {
+    fn governor_all_idle_sheds_one_step_above_the_floor() {
+        // Shedding works while above the boot-OPP floor ...
+        assert_eq!(
+            next_opp_idx(&[0, 0], BOOT_OPP_IDX + 1, A76_OPPS.len(), false),
+            BOOT_OPP_IDX
+        );
+        // ... and stops AT the floor (bursty-I/O workloads read as idle between
+        // read bursts; going lower throttles their completion path).
         assert_eq!(
             next_opp_idx(&[0, 0], BOOT_OPP_IDX, A76_OPPS.len(), false),
-            BOOT_OPP_IDX - 1
+            BOOT_OPP_IDX
         );
         // Every A55 core just under the down-threshold sheds exactly one step
-        // (from the top of the ring-only A55 ladder down one rung).
+        // (from the top of the ring-only A55 ladder down one rung, still above
+        // the floor for that ladder).
         assert_eq!(
             next_opp_idx(
                 &[DOWN_THRESHOLD_PCT - 1; 4],
@@ -1198,7 +1384,9 @@ mod tests {
     }
 
     #[test]
-    fn governor_does_not_shed_below_bottom_opp() {
+    fn governor_does_not_shed_below_the_floor() {
+        // A state already below the floor (unreachable through the governor,
+        // kept for completeness) must not shed further.
         assert_eq!(next_opp_idx(&[0, 0], 0, A76_OPPS.len(), false), 0);
     }
 

--- a/drivers/ax-driver/src/soc/rockchip/cpufreq.rs
+++ b/drivers/ax-driver/src/soc/rockchip/cpufreq.rs
@@ -1364,139 +1364,149 @@ mod tests {
     // Busy attribution: the kernel owns logical numbering, not FDT order
     // -----------------------------------------------------------------------
 
-    /// Kernel mapping for a passthrough guest pinned as `phys_cpu_ids =
-    /// [0x400, 0x000]`: the guest FDT still lists `/cpus` in host-DT order
-    /// (cpu@0 first), but the boot hart cpu@400 is logical CPU 0 and cpu@0 is
-    /// logical CPU 1.
-    fn boot_first_resolver(hardware_id: usize) -> Option<usize> {
-        match hardware_id {
-            0x400 => Some(0),
-            0x000 => Some(1),
-            _ => None,
-        }
-    }
+    /// The mapping walk is pure w.r.t. a `resolve` closure and a `store` sink,
+    /// so it is exercised here with an in-memory map rather than the global
+    /// `CPU_CLUSTER`. These tests are the CI's proof that the non-monotonic
+    /// pin case is discovered and executed (see the `host-test+rk3588-cpufreq`
+    /// std-test profile in `scripts/axbuild/src/test/std.rs`, whose
+    /// `expected_tests` enumerates this submodule).
+    mod attribution {
+        use super::*;
 
-    /// Books attribution into a local map, so the mapping logic is testable
-    /// without touching the global `CPU_CLUSTER`.
-    fn book_into_map(
-        nodes: &[CpuNodeTopology],
-        resolve: impl Fn(usize) -> Option<usize>,
-        map: &mut [Option<usize>; 8],
-    ) -> usize {
-        let mut store = |logical_cpu: usize, cluster: usize| match map.get_mut(logical_cpu) {
-            Some(slot) => {
-                *slot = Some(cluster);
-                true
+        /// Kernel mapping for a passthrough guest pinned as `phys_cpu_ids =
+        /// [0x400, 0x000]`: the guest FDT still lists `/cpus` in host-DT order
+        /// (cpu@0 first), but the boot hart cpu@400 is logical CPU 0 and cpu@0
+        /// is logical CPU 1.
+        fn boot_first_resolver(hardware_id: usize) -> Option<usize> {
+            match hardware_id {
+                0x400 => Some(0),
+                0x000 => Some(1),
+                _ => None,
             }
-            None => false,
-        };
-        store_cpu_clusters(nodes, resolve, &mut store)
-    }
+        }
 
-    #[test]
-    fn non_monotonic_pin_books_busy_under_the_cluster_it_runs_on() {
-        let a55 = cluster_index_from_clock_id(A55_CLK_ID).unwrap();
-        let big0 = cluster_index_from_clock_id(A76_CLK_IDS[0]).unwrap();
-        // FDT document order (host-DT order): cpu@0 (A55) before cpu@400 (A76).
-        let nodes = [
-            CpuNodeTopology {
-                hardware_id: 0x000,
-                clock_id: A55_CLK_ID,
-            },
-            CpuNodeTopology {
+        /// Books attribution into a local map, so the mapping logic is testable
+        /// without touching the global `CPU_CLUSTER`.
+        fn book_into_map(
+            nodes: &[CpuNodeTopology],
+            resolve: impl Fn(usize) -> Option<usize>,
+            map: &mut [Option<usize>; 8],
+        ) -> usize {
+            let mut store = |logical_cpu: usize, cluster: usize| match map.get_mut(logical_cpu) {
+                Some(slot) => {
+                    *slot = Some(cluster);
+                    true
+                }
+                None => false,
+            };
+            store_cpu_clusters(nodes, resolve, &mut store)
+        }
+
+        #[test]
+        fn non_monotonic_pin_books_busy_under_the_cluster_it_runs_on() {
+            let a55 = cluster_index_from_clock_id(A55_CLK_ID).unwrap();
+            let big0 = cluster_index_from_clock_id(A76_CLK_IDS[0]).unwrap();
+            // FDT document order (host-DT order): cpu@0 (A55) before cpu@400 (A76).
+            let nodes = [
+                CpuNodeTopology {
+                    hardware_id: 0x000,
+                    clock_id: A55_CLK_ID,
+                },
+                CpuNodeTopology {
+                    hardware_id: 0x400,
+                    clock_id: A76_CLK_IDS[0],
+                },
+            ];
+            let mut map = [None; 8];
+            let stored = book_into_map(&nodes, boot_first_resolver, &mut map);
+            assert_eq!(stored, 2);
+            // busy[0] executes on the A76 cpu@400; busy[1] on the A55 cpu@0.
+            assert_eq!(map[0], Some(big0), "logical CPU 0 runs the big core");
+            assert_eq!(map[1], Some(a55), "logical CPU 1 runs the little core");
+        }
+
+        #[test]
+        fn identity_order_books_each_cpu_under_its_own_cluster() {
+            // Bare metal: all 8 CPUs online, boot hart == first FDT node, so the
+            // kernel's mapping is document position. Every cluster's members must
+            // agree with `Cluster::cpus()`.
+            let nodes: Vec<CpuNodeTopology> = (0..8)
+                .map(|position| CpuNodeTopology {
+                    hardware_id: position * 0x100,
+                    clock_id: match position {
+                        0..=3 => A55_CLK_ID,
+                        4 | 5 => A76_CLK_IDS[0],
+                        _ => A76_CLK_IDS[1],
+                    },
+                })
+                .collect();
+            let mut map = [None; 8];
+            let stored = book_into_map(&nodes, |hw| Some(hw / 0x100), &mut map);
+            assert_eq!(stored, 8);
+            for (ci, &cluster) in [Cluster::A55, Cluster::Big0, Cluster::Big1]
+                .iter()
+                .enumerate()
+            {
+                for cpu in cluster.cpus() {
+                    assert_eq!(map[cpu], Some(ci), "cpu {cpu}");
+                }
+            }
+        }
+
+        #[test]
+        fn single_vcpu_pin_books_under_its_pinned_cluster() {
+            // The PR's motivating guest: SMP=1 pinned to the A76 cpu@400.
+            let nodes = [CpuNodeTopology {
                 hardware_id: 0x400,
                 clock_id: A76_CLK_IDS[0],
-            },
-        ];
-        let mut map = [None; 8];
-        let stored = book_into_map(&nodes, boot_first_resolver, &mut map);
-        assert_eq!(stored, 2);
-        // busy[0] executes on the A76 cpu@400; busy[1] on the A55 cpu@0.
-        assert_eq!(map[0], Some(big0), "logical CPU 0 runs the big core");
-        assert_eq!(map[1], Some(a55), "logical CPU 1 runs the little core");
-    }
-
-    #[test]
-    fn identity_order_books_each_cpu_under_its_own_cluster() {
-        // Bare metal: all 8 CPUs online, boot hart == first FDT node, so the
-        // kernel's mapping is document position. Every cluster's members must
-        // agree with `Cluster::cpus()`.
-        let nodes: Vec<CpuNodeTopology> = (0..8)
-            .map(|position| CpuNodeTopology {
-                hardware_id: position * 0x100,
-                clock_id: match position {
-                    0..=3 => A55_CLK_ID,
-                    4 | 5 => A76_CLK_IDS[0],
-                    _ => A76_CLK_IDS[1],
-                },
-            })
-            .collect();
-        let mut map = [None; 8];
-        let stored = book_into_map(&nodes, |hw| Some(hw / 0x100), &mut map);
-        assert_eq!(stored, 8);
-        for (ci, &cluster) in [Cluster::A55, Cluster::Big0, Cluster::Big1]
-            .iter()
-            .enumerate()
-        {
-            for cpu in cluster.cpus() {
-                assert_eq!(map[cpu], Some(ci), "cpu {cpu}");
-            }
+            }];
+            let mut map = [None; 8];
+            let stored = book_into_map(&nodes, |hw| (hw == 0x400).then_some(0), &mut map);
+            assert_eq!(stored, 1);
+            assert_eq!(
+                map[0],
+                Some(cluster_index_from_clock_id(A76_CLK_IDS[0]).unwrap())
+            );
+            assert_eq!(map[1], None, "no other CPU may drive a domain");
         }
-    }
 
-    #[test]
-    fn single_vcpu_pin_books_under_its_pinned_cluster() {
-        // The PR's motivating guest: SMP=1 pinned to the A76 cpu@400.
-        let nodes = [CpuNodeTopology {
-            hardware_id: 0x400,
-            clock_id: A76_CLK_IDS[0],
-        }];
-        let mut map = [None; 8];
-        let stored = book_into_map(&nodes, |hw| (hw == 0x400).then_some(0), &mut map);
-        assert_eq!(stored, 1);
-        assert_eq!(
-            map[0],
-            Some(cluster_index_from_clock_id(A76_CLK_IDS[0]).unwrap())
-        );
-        assert_eq!(map[1], None, "no other CPU may drive a domain");
-    }
+        #[test]
+        fn offline_hardware_id_books_nowhere() {
+            // A cpu node the kernel does not run must not leak onto any logical
+            // index — its busy simply drives no domain.
+            let nodes = [
+                CpuNodeTopology {
+                    hardware_id: 0x000,
+                    clock_id: A55_CLK_ID,
+                },
+                CpuNodeTopology {
+                    hardware_id: 0x600,
+                    clock_id: A76_CLK_IDS[1],
+                },
+            ];
+            let mut map = [None; 8];
+            let stored = book_into_map(&nodes, |hw| (hw == 0x600).then_some(0), &mut map);
+            assert_eq!(stored, 1);
+            assert_eq!(
+                map[0],
+                Some(cluster_index_from_clock_id(A76_CLK_IDS[1]).unwrap())
+            );
+            assert_eq!(map[1], None);
+            assert!(map[2..].iter().all(|slot| slot.is_none()));
+        }
 
-    #[test]
-    fn offline_hardware_id_books_nowhere() {
-        // A cpu node the kernel does not run must not leak onto any logical
-        // index — its busy simply drives no domain.
-        let nodes = [
-            CpuNodeTopology {
+        #[test]
+        fn out_of_range_logical_index_is_refused() {
+            // A resolver answering past the map must be refused, not panic.
+            let nodes = [CpuNodeTopology {
                 hardware_id: 0x000,
                 clock_id: A55_CLK_ID,
-            },
-            CpuNodeTopology {
-                hardware_id: 0x600,
-                clock_id: A76_CLK_IDS[1],
-            },
-        ];
-        let mut map = [None; 8];
-        let stored = book_into_map(&nodes, |hw| (hw == 0x600).then_some(0), &mut map);
-        assert_eq!(stored, 1);
-        assert_eq!(
-            map[0],
-            Some(cluster_index_from_clock_id(A76_CLK_IDS[1]).unwrap())
-        );
-        assert_eq!(map[1], None);
-        assert!(map[2..].iter().all(|slot| slot.is_none()));
-    }
-
-    #[test]
-    fn out_of_range_logical_index_is_refused() {
-        // A resolver answering past the map must be refused, not panic.
-        let nodes = [CpuNodeTopology {
-            hardware_id: 0x000,
-            clock_id: A55_CLK_ID,
-        }];
-        let mut map = [None; 8];
-        let stored = book_into_map(&nodes, |_| Some(9), &mut map);
-        assert_eq!(stored, 0);
-        assert!(map.iter().all(|slot| slot.is_none()));
+            }];
+            let mut map = [None; 8];
+            let stored = book_into_map(&nodes, |_| Some(9), &mut map);
+            assert_eq!(stored, 0);
+            assert!(map.iter().all(|slot| slot.is_none()));
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/drivers/ax-driver/src/soc/rockchip/cpufreq.rs
+++ b/drivers/ax-driver/src/soc/rockchip/cpufreq.rs
@@ -53,10 +53,10 @@
 //! that node would never get an `on_probe`), and applies exactly once via a
 //! one-shot guard because several `cpu@*` nodes match.
 
-use alloc::format;
+use alloc::{format, vec::Vec};
 use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 
-use fdt_edit::Phandle;
+use fdt_edit::{NodeType, Phandle};
 use log::{info, warn};
 
 use crate::{probe::OnProbeError, register::ProbeFdt, soc::scmi};
@@ -767,14 +767,17 @@ pub fn governor_period_ms() -> u64 {
 // ===========================================================================
 
 /// Governor busy attribution: `busy[i]` from the kernel is LOGICAL CPU `i`'s
-/// counter (enumeration order of the FDT `/cpus` children this kernel actually
-/// has), while a DVFS domain is a physical cluster. Hardcoding the physical
-/// ranges is only correct when every physical CPU is online: a passthrough
-/// guest with fewer vCPUs pinned elsewhere (e.g. SMP=1 on host cpu@400) would
-/// book its cpu0's busy under the A55 cluster — the workload then boosts the
-/// little cluster while the big cluster it runs on gets parked at 408 MHz.
-/// The map below is therefore built from the FDT cpu nodes' SCMI clock ids,
-/// which name the cluster each online CPU really belongs to.
+/// counter, and logical indices are assigned by the KERNEL's cpu list (boot
+/// hart first, then the remaining firmware cpu ids) — NOT by the FDT's
+/// document order. A passthrough guest pinned as `phys_cpu_ids = [0x400,
+/// 0x000]` still lists `/cpus` in host-DT order (cpu@0 before cpu@400) while
+/// its logical CPU 0 executes on the A76 cpu@400: mapping by node position
+/// books big-core load under the A55 cluster, boosting the little cluster
+/// while the big one running the workload is never scaled. The map below is
+/// therefore keyed by each FDT cpu node's `reg` (the firmware hardware id)
+/// resolved through the kernel's own hardware-id -> logical-index capability
+/// ([`axklib::cpu::resolve_logical_index`]), plus that node's SCMI clock id,
+/// which names the cluster each online CPU really belongs to.
 static CPU_CLUSTER: [AtomicU8; 8] = [const { AtomicU8::new(0) }; 8];
 static CPU_CLUSTER_READY: AtomicBool = AtomicBool::new(false);
 
@@ -789,39 +792,127 @@ fn cluster_index_from_clock_id(clock_id: u32) -> Option<usize> {
     }
 }
 
-/// Fills `CPU_CLUSTER` from the FDT: one entry per `/cpus` child (in document
-/// order = logical-CPU enumeration order), taken from that node's SCMI clock
-/// id. Returns the number of CPUs mapped.
+/// One FDT cpu node distilled to what attribution needs: the firmware
+/// hardware id (`reg`) and the SCMI clock id naming the cluster it belongs to.
+#[derive(Clone, Copy)]
+struct CpuNodeTopology {
+    hardware_id: usize,
+    clock_id: u32,
+}
+
+/// Reads one `/cpus` cpu node's `reg` hardware id and SCMI cluster clock.
+/// Warns and returns `None` when either is missing — such a node cannot drive
+/// the governor.
+fn cpu_node_topology(node: &NodeType<'_>, phandle: Phandle) -> Option<CpuNodeTopology> {
+    let hardware_id = node
+        .regs()
+        .into_iter()
+        .next()
+        .map(|reg| reg.address as usize)
+        .or_else(|| {
+            warn!(
+                "cpufreq: cpu node {} has no reg hardware id; it will not drive the governor",
+                node.name()
+            );
+            None
+        })?;
+    let clock_id = node
+        .clocks()
+        .into_iter()
+        .find(|clock| clock.phandle == phandle)
+        .and_then(|clock| clock.specifier.first().copied())
+        .or_else(|| {
+            warn!(
+                "cpufreq: cpu node {} has no recognizable SCMI cluster clock; it will not drive \
+                 the governor",
+                node.name()
+            );
+            None
+        })?;
+    Some(CpuNodeTopology {
+        hardware_id,
+        clock_id,
+    })
+}
+
+/// Pure core of [`map_cpus_from_fdt`]: books each FDT cpu node's cluster
+/// (named by its SCMI clock id) under the logical CPU index the KERNEL runs
+/// that node's hardware id as, via `resolve`. Document order is irrelevant —
+/// the kernel, not the FDT, owns logical numbering (boot hart first). A node
+/// whose hardware id no online CPU runs, whose clock names no CPU cluster, or
+/// whose logical index falls outside `store`'s map books nothing
+/// (conservative: its busy drives no domain). Returns how many entries
+/// `store` accepted.
+fn store_cpu_clusters(
+    nodes: &[CpuNodeTopology],
+    resolve: impl Fn(usize) -> Option<usize>,
+    mut store: impl FnMut(usize, usize) -> bool,
+) -> usize {
+    let mut stored = 0usize;
+    for node in nodes {
+        let Some(cluster) = cluster_index_from_clock_id(node.clock_id) else {
+            continue;
+        };
+        let Some(logical_cpu) = resolve(node.hardware_id) else {
+            continue;
+        };
+        if store(logical_cpu, cluster) {
+            stored += 1;
+        }
+    }
+    stored
+}
+
+/// The kernel's hardware-id -> logical-CPU-index mapping. The kernel — not the
+/// FDT — assigns logical indices (boot hart first, then the remaining firmware
+/// cpu ids), so attribution must ask it rather than assume `/cpus` document
+/// order; a passthrough guest's FDT keeps host-DT order even when its vCPUs are
+/// pinned non-monotonically.
+fn resolve_logical_cpu(hardware_id: usize) -> Option<usize> {
+    axklib::cpu::resolve_logical_index(hardware_id)
+}
+
+/// Fills `CPU_CLUSTER` from the FDT: for each `/cpus` cpu node, book the
+/// cluster its SCMI clock id names under the logical index the kernel resolves
+/// the node's `reg` hardware id to, then log the map once so a mis-attributed
+/// boot (wrong cluster pinned/boosted) is diagnosable from the console.
+/// Returns the number of logical CPUs mapped.
 fn map_cpus_from_fdt() -> usize {
     let Some(phandle) = scmi_clock_phandle() else {
         return 0;
     };
     rdrive::with_fdt(|fdt| {
-        let mut mapped = 0usize;
-        for (cpu, node) in fdt
+        let nodes: Vec<CpuNodeTopology> = fdt
             .find_compatible(&["arm,cortex-a55", "arm,cortex-a76"])
             .into_iter()
-            .take(CPU_CLUSTER.len())
-            .enumerate()
-        {
-            let Some(cluster) = node
-                .clocks()
-                .into_iter()
-                .find(|c| c.phandle == phandle)
-                .and_then(|clock| clock.specifier.first().copied())
-                .and_then(cluster_index_from_clock_id)
-            else {
-                warn!(
-                    "cpufreq: cpu node {} has no recognizable SCMI cluster clock; it will not \
-                     drive the governor",
-                    node.name()
-                );
-                continue;
-            };
-            CPU_CLUSTER[cpu].store(cluster as u8 + 1, Ordering::Relaxed);
-            mapped += 1;
-        }
-        mapped
+            .filter_map(|node| cpu_node_topology(&node, phandle))
+            .collect();
+        let stored =
+            store_cpu_clusters(
+                &nodes,
+                resolve_logical_cpu,
+                |logical_cpu, cluster| match CPU_CLUSTER.get(logical_cpu) {
+                    Some(slot) => {
+                        slot.store(cluster as u8 + 1, Ordering::Relaxed);
+                        true
+                    }
+                    None => false,
+                },
+            );
+        let clusters = [Cluster::A55, Cluster::Big0, Cluster::Big1];
+        info!(
+            "cpufreq: busy attribution {}",
+            (0..CPU_CLUSTER.len())
+                .filter_map(|cpu| {
+                    Some(format!(
+                        "cpu{cpu}->{}",
+                        clusters[cluster_of_cpu(cpu)?].name()
+                    ))
+                })
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        stored
     })
     .unwrap_or(0)
 }
@@ -927,8 +1018,8 @@ fn next_opp_idx(core_pcts: &[u64], cur: usize, ladder_len: usize, priming: bool)
 /// neither sleeps nor spawns — so this crate needs no dependency on
 /// ax-task/ax-hal (which would be a cyclic dep through axplat-dyn).
 ///
-/// `busy[i]` is LOGICAL CPU `i`'s counter, attributed to the cluster its FDT
-/// cpu node belongs to (see [`CPU_CLUSTER`]); unmapped CPUs, indices past the
+/// `busy[i]` is LOGICAL CPU `i`'s counter, attributed to the cluster the kernel
+/// runs that CPU on (see [`CPU_CLUSTER`]); unmapped CPUs, indices past the
 /// slice, and offline CPUs whose counter never advances simply contribute
 /// nothing — conservative (never over-scales).
 pub fn governor_poll(busy: &[u64]) {
@@ -1270,6 +1361,145 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Busy attribution: the kernel owns logical numbering, not FDT order
+    // -----------------------------------------------------------------------
+
+    /// Kernel mapping for a passthrough guest pinned as `phys_cpu_ids =
+    /// [0x400, 0x000]`: the guest FDT still lists `/cpus` in host-DT order
+    /// (cpu@0 first), but the boot hart cpu@400 is logical CPU 0 and cpu@0 is
+    /// logical CPU 1.
+    fn boot_first_resolver(hardware_id: usize) -> Option<usize> {
+        match hardware_id {
+            0x400 => Some(0),
+            0x000 => Some(1),
+            _ => None,
+        }
+    }
+
+    /// Books attribution into a local map, so the mapping logic is testable
+    /// without touching the global `CPU_CLUSTER`.
+    fn book_into_map(
+        nodes: &[CpuNodeTopology],
+        resolve: impl Fn(usize) -> Option<usize>,
+        map: &mut [Option<usize>; 8],
+    ) -> usize {
+        let mut store = |logical_cpu: usize, cluster: usize| match map.get_mut(logical_cpu) {
+            Some(slot) => {
+                *slot = Some(cluster);
+                true
+            }
+            None => false,
+        };
+        store_cpu_clusters(nodes, resolve, &mut store)
+    }
+
+    #[test]
+    fn non_monotonic_pin_books_busy_under_the_cluster_it_runs_on() {
+        let a55 = cluster_index_from_clock_id(A55_CLK_ID).unwrap();
+        let big0 = cluster_index_from_clock_id(A76_CLK_IDS[0]).unwrap();
+        // FDT document order (host-DT order): cpu@0 (A55) before cpu@400 (A76).
+        let nodes = [
+            CpuNodeTopology {
+                hardware_id: 0x000,
+                clock_id: A55_CLK_ID,
+            },
+            CpuNodeTopology {
+                hardware_id: 0x400,
+                clock_id: A76_CLK_IDS[0],
+            },
+        ];
+        let mut map = [None; 8];
+        let stored = book_into_map(&nodes, boot_first_resolver, &mut map);
+        assert_eq!(stored, 2);
+        // busy[0] executes on the A76 cpu@400; busy[1] on the A55 cpu@0.
+        assert_eq!(map[0], Some(big0), "logical CPU 0 runs the big core");
+        assert_eq!(map[1], Some(a55), "logical CPU 1 runs the little core");
+    }
+
+    #[test]
+    fn identity_order_books_each_cpu_under_its_own_cluster() {
+        // Bare metal: all 8 CPUs online, boot hart == first FDT node, so the
+        // kernel's mapping is document position. Every cluster's members must
+        // agree with `Cluster::cpus()`.
+        let nodes: Vec<CpuNodeTopology> = (0..8)
+            .map(|position| CpuNodeTopology {
+                hardware_id: position * 0x100,
+                clock_id: match position {
+                    0..=3 => A55_CLK_ID,
+                    4 | 5 => A76_CLK_IDS[0],
+                    _ => A76_CLK_IDS[1],
+                },
+            })
+            .collect();
+        let mut map = [None; 8];
+        let stored = book_into_map(&nodes, |hw| Some(hw / 0x100), &mut map);
+        assert_eq!(stored, 8);
+        for (ci, &cluster) in [Cluster::A55, Cluster::Big0, Cluster::Big1]
+            .iter()
+            .enumerate()
+        {
+            for cpu in cluster.cpus() {
+                assert_eq!(map[cpu], Some(ci), "cpu {cpu}");
+            }
+        }
+    }
+
+    #[test]
+    fn single_vcpu_pin_books_under_its_pinned_cluster() {
+        // The PR's motivating guest: SMP=1 pinned to the A76 cpu@400.
+        let nodes = [CpuNodeTopology {
+            hardware_id: 0x400,
+            clock_id: A76_CLK_IDS[0],
+        }];
+        let mut map = [None; 8];
+        let stored = book_into_map(&nodes, |hw| (hw == 0x400).then_some(0), &mut map);
+        assert_eq!(stored, 1);
+        assert_eq!(
+            map[0],
+            Some(cluster_index_from_clock_id(A76_CLK_IDS[0]).unwrap())
+        );
+        assert_eq!(map[1], None, "no other CPU may drive a domain");
+    }
+
+    #[test]
+    fn offline_hardware_id_books_nowhere() {
+        // A cpu node the kernel does not run must not leak onto any logical
+        // index — its busy simply drives no domain.
+        let nodes = [
+            CpuNodeTopology {
+                hardware_id: 0x000,
+                clock_id: A55_CLK_ID,
+            },
+            CpuNodeTopology {
+                hardware_id: 0x600,
+                clock_id: A76_CLK_IDS[1],
+            },
+        ];
+        let mut map = [None; 8];
+        let stored = book_into_map(&nodes, |hw| (hw == 0x600).then_some(0), &mut map);
+        assert_eq!(stored, 1);
+        assert_eq!(
+            map[0],
+            Some(cluster_index_from_clock_id(A76_CLK_IDS[1]).unwrap())
+        );
+        assert_eq!(map[1], None);
+        assert!(map[2..].iter().all(|slot| slot.is_none()));
+    }
+
+    #[test]
+    fn out_of_range_logical_index_is_refused() {
+        // A resolver answering past the map must be refused, not panic.
+        let nodes = [CpuNodeTopology {
+            hardware_id: 0x000,
+            clock_id: A55_CLK_ID,
+        }];
+        let mut map = [None; 8];
+        let stored = book_into_map(&nodes, |_| Some(9), &mut map);
+        assert_eq!(stored, 0);
+        assert!(map.iter().all(|slot| slot.is_none()));
+    }
+
+    // -----------------------------------------------------------------------
     // OPP transactional apply: ordering + commit-only-on-full-success
     //
     // These pin the two prior state-machine fixes: `apply_opp` orders the levers
@@ -1369,9 +1599,11 @@ mod tests {
             next_opp_idx(&[0, 0], BOOT_OPP_IDX, A76_OPPS.len(), false),
             BOOT_OPP_IDX
         );
-        // Every A55 core just under the down-threshold sheds exactly one step
-        // (from the top of the ring-only A55 ladder down one rung, still above
-        // the floor for that ladder).
+        // Every A55 core just under the down-threshold still HOLDS: the A55
+        // top rung is its boot OPP (the ring-only ladder's highest ring), so
+        // the floor pins the A55 there. (An expectation of
+        // `A55_OPPS.len() - 2` here contradicted the floor policy; it never
+        // ran before because the host-test build of this feature was broken.)
         assert_eq!(
             next_opp_idx(
                 &[DOWN_THRESHOLD_PCT - 1; 4],
@@ -1379,7 +1611,7 @@ mod tests {
                 A55_OPPS.len(),
                 false
             ),
-            A55_OPPS.len() - 2
+            BOOT_OPP_IDX
         );
     }
 

--- a/os/StarryOS/kernel/src/entry.rs
+++ b/os/StarryOS/kernel/src/entry.rs
@@ -40,6 +40,8 @@ pub fn init(args: &[String], envs: &[String]) {
     } else {
         spawn_cpufreq_governor();
     }
+    // Read-only cluster frequency snapshot for CPU-bound workload triage.
+    ax_driver::cpufreq::log_frequency_readout();
     pseudofs::usbfs::start_event_pump();
 
     ax_alloc::register_page_reclaim_fn(ax_fs_ng::vfs::page_cache_reclaim);

--- a/os/arceos/modules/axruntime/src/klib.rs
+++ b/os/arceos/modules/axruntime/src/klib.rs
@@ -341,6 +341,14 @@ impl_trait! {
                 Err(IrqError::Unsupported)
             }
         }
+
+        /// Resolves a firmware CPU id (the FDT cpu node `reg`) to the runtime
+        /// logical CPU index via the platform topology mapping, which is the
+        /// same list the kernel used to assign per-CPU state (boot hart first,
+        /// then the remaining firmware cpu ids).
+        fn cpu_resolve_logical_index(hardware_id: usize) -> Option<usize> {
+            ax_hal::topology::resolve_cpu_index(hardware_id)
+        }
     }
 }
 

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -89,6 +89,25 @@ const AX_DRIVER_FEATURE_PROFILES: &[PackageFeatureProfile] = &[
         name_filter: Some(PCI_FDT_IRQ_CAPABILITY_TEST),
         expected_tests: &[PCI_FDT_IRQ_CAPABILITY_TEST],
     },
+    // The rk3588-cpufreq feature gates the governor busy-attribution tests
+    // (the non-monotonic pin regression and its siblings), which are otherwise
+    // never compiled by the host-test profile above. This profile lists and
+    // runs exactly the `attribution` submodule so CI proves the regression is
+    // discovered and executed, not just compiled into a binary that is never
+    // asked to run it.
+    PackageFeatureProfile {
+        name: "host-test+rk3588-cpufreq",
+        no_default_features: false,
+        features: &["host-test", "rk3588-cpufreq"],
+        name_filter: Some("attribution::"),
+        expected_tests: &[
+            "soc::rockchip::cpufreq::tests::attribution::identity_order_books_each_cpu_under_its_own_cluster",
+            "soc::rockchip::cpufreq::tests::attribution::non_monotonic_pin_books_busy_under_the_cluster_it_runs_on",
+            "soc::rockchip::cpufreq::tests::attribution::offline_hardware_id_books_nowhere",
+            "soc::rockchip::cpufreq::tests::attribution::out_of_range_logical_index_is_refused",
+            "soc::rockchip::cpufreq::tests::attribution::single_vcpu_pin_books_under_its_pinned_cluster",
+        ],
+    },
 ];
 
 const HOST_TEST_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
@@ -953,6 +972,24 @@ mod tests {
                     "--features",
                     "pci",
                     PCI_FDT_IRQ_CAPABILITY_TEST,
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-driver",
+                    "--features",
+                    "host-test,rk3588-cpufreq",
+                    "attribution::",
+                    "--",
+                    "--list",
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-driver",
+                    "--features",
+                    "host-test,rk3588-cpufreq",
+                    "attribution::",
                 ],
             ]
         );


### PR DESCRIPTION

## CI 覆盖修复（F-001，第二轮）

第二轮 F-001 指出：`non_monotonic_pin_books_busy_under_the_cluster_it_runs_on` 受 `rk3588-cpufreq` feature 保护，而 `AX_DRIVER_FEATURE_PROFILES` 只跑 `host-test+rtc+starfive-jh7110-dwmmc`，不启用该 feature，所以该回归测试从未被 CI 编译或执行——全绿 CI 不能证明映射回归被覆盖。

修复（49d9bde53）：
- 把 5 个归因测试（加 `boot_first_resolver`/`book_into_map` helper）移进 `tests::attribution` 子模块，仿照 ax-task 的 `std_tests::` 子模块模式，使 `cargo --list` 过滤 `attribution::` 精确得到这 5 个。
- 在 `scripts/axbuild/src/test/std.rs` 的 `AX_DRIVER_FEATURE_PROFILES` 新增第二个 profile `host-test+rk3588-cpufreq`，`name_filter: "attribution::"`，`expected_tests` 枚举这 5 个完整测试名；`expected_tests` 非空时 std-test runner 会先 `--list` 并用 `validate_discovered_tests` 校验发现集合**精确等于** expected（任一被删除/重命名都会在发现步骤失败），再运行。

本地用 `cargo xtask test --since origin/dev` 验证（49d9bde53）：
```
[30/45] running 2 std test profile(s) for ax-driver
cargo test -p ax-driver --features host-test,rk3588-cpufreq attribution:: -- --list
  -> 5 tests discovered (validate_discovered_tests passed)
cargo test -p ax-driver --features host-test,rk3588-cpufreq attribution::
  non_monotonic_pin_books_busy_under_the_cluster_it_runs_on ... ok
  (5/5) ok
ok: ax-driver
```
该流程同时证明"测试列表中包含该测试"（`--list` 输出 + discovery 校验）和"成功执行"（5 个 ok）。预存的 axvm host-test 失败（`boot::fdt::core::*`）在 origin/dev 上同样复现，与本 PR 无关。
