### PR TITLE
feat(arm-gic-driver): add GICv3 NMI attributes

### DIFF
--- a/docs/design/arm-gic-v3-nmi-attribute.md
+++ b/docs/design/arm-gic-v3-nmi-attribute.md
@@ -1,0 +1,73 @@
+# Arm GICv3 NMI 属性编程
+
+## 问题与目标
+
+本仓库内置的 `arm-gic-driver` 已定义 `GICD_INMIR<n>` 和
+`GICR_INMIR0` 寄存器，也有仅供 Distributor 使用、对失败静默忽略的 SPI
+helper，但没有可供平台层安全使用的完整能力：SGI/PPI 无法配置，调用者无法判断
+控制器是否实现 `FEAT_GICv3_NMI`，当前 PE 的 Redistributor 查找会丢弃
+MPIDR Aff3，错误 INTID 或缺失 Redistributor 也没有可匹配的错误。
+
+目标用户是需要在 AArch64 GICv3 平台上配置硬件 NMI 属性的 OS/platform glue。
+完成标准是：标准 SGI、PPI、SPI 能按 Arm 定义的寄存器槽位设置和查询属性；能力、
+INTID、Group、affinity routing 和 Redistributor 错误均显式返回；原有普通 IRQ
+路径保持不变。
+
+## 规范基线
+
+实现以 *Arm Generic Interrupt Controller Architecture Specification*,
+Arm IHI 0069H.b（2024-04-12）为准：
+
+- GICv3.3 引入 non-maskable property，`GICD_TYPER.NMI` bit 9 是
+  `FEAT_GICv3_NMI` 的能力来源；
+- `GICD_INMIR<n>` 使用 `n = INTID DIV 32`、`bit = INTID MOD 32`，
+  其中 Distributor 的 SGI/PPI 位为 RES0；
+- SGI/PPI 使用当前 PE 的 `GICR_INMIR0`；
+- Group 0、对应 Security state 未启用 affinity routing、未实现的中断或
+  Non-secure 不可访问的 Secure 中断位是 RES0/RAZ-WI。
+
+因此生产代码只读取 `GICD_TYPER.NMI`。当该位为零时，写读回探测既不能发现
+规范之外的能力，还会受 Group、Security state 和 affinity routing 影响，并会
+临时改变真实中断的属性，所以不采用该方案。
+
+## 接口与所有权
+
+`NmiAttribute::{Maskable, NonMaskable}` 代替布尔参数，避免调用点隐藏写入方向。
+`Gic::set_nmi_attribute(&mut self, ...)` 使寄存器读改写的独占要求体现在类型上；
+`Gic::nmi_attribute(&self, ...)` 提供对应查询；
+`Gic::supports_nmi_attributes()` 只报告架构能力位，不宣称已经具备完整 NMI
+异常入口、acknowledge 或运行时处理链。
+
+访问前依次验证标准 INTID 槽位、能力位、实现的 SPI 范围、可访问 Group 1 和
+对应 affinity routing。私有中断只访问当前 PE 的 Redistributor，查找使用完整的
+Aff3:Aff2:Aff1:Aff0；缺失帧返回 `NmiAttributeError`。调用者仍须先完成
+Distributor 和当前 Redistributor 初始化，并遵守 `Gic::new` 的唯一硬件所有者
+契约。
+
+## 方案比较
+
+- 升级外部依赖不可行：本仓库通过 workspace path 维护
+  `drivers/intc/arm-gic-driver`，并非 crates.io 或 git 依赖。
+- 原样复制外部 PR 的写读回能力探测不符合上述架构能力语义，也可能影响活动中断。
+- 继续暴露静默 no-op 的原始 SPI helper 无法覆盖 SGI/PPI，也无法让平台层区分
+  unsupported、无效输入和拓扑错误。
+- 选择在本地驱动边界提供小型 typed API，并把寄存器槽位映射保留为可在 host
+  稳定测试的纯逻辑。
+
+## 范围与非目标
+
+本次只支持标准 INTID 0-1019。Extended SPI/Extended PPI 的
+`GICD_INMIR<n>E`/`GICR_INMIR<n>E`、`ICC_NMIAR1_EL1` acknowledge、异常入口、
+优先级和端到端 NMI delivery 不在本次范围内；这些能力需要独立的调用方、接口和
+运行时设计。现有 `somehal` 普通 IRQ API 不会被隐式改成 NMI。
+
+## 验证与回滚
+
+最低层 host 回归固定验证 SGI/PPI/SPI 到 INMIR 的映射，并拒绝 special/extended
+INTID；该测试在旧实现中因缺失映射能力而确定性编译失败。AArch64 Linux 用户态
+测试在 QEMU user mode 中以假 MMIO 验证 capability、Group、affinity routing、
+未实现 SPI、设置/清除/读回以及包含 Aff3 的 Redistributor 匹配。另以 bare-metal
+AArch64 target clippy/check 和现有 GICv3 QEMU 用例验证目标编译与普通 IRQ 路径。
+
+变更不修改初始化默认值或普通 IRQ 行为。若需回滚，只需移除新增 API、能力位定义
+和测试；调用者在能力缺失时已经得到显式 `Unsupported`，无需迁移持久状态。

--- a/docs/design/arm-gic-v3-nmi-attribute.md
+++ b/docs/design/arm-gic-v3-nmi-attribute.md
@@ -9,9 +9,9 @@ helper，但没有可供平台层安全使用的完整能力：SGI/PPI 无法配
 MPIDR Aff3，错误 INTID 或缺失 Redistributor 也没有可匹配的错误。
 
 目标用户是需要在 AArch64 GICv3 平台上配置硬件 NMI 属性的 OS/platform glue。
-完成标准是：标准 SGI、PPI、SPI 能按 Arm 定义的寄存器槽位设置和查询属性；能力、
-INTID、Group、affinity routing 和 Redistributor 错误均显式返回；原有普通 IRQ
-路径保持不变。
+完成标准是：处于 disabled/inactive 状态的标准 SGI、PPI、SPI 能按 Arm 定义的
+寄存器槽位设置和查询属性；能力、INTID、Group、affinity routing、运行状态和
+Redistributor 错误均显式返回；原有普通 IRQ 路径保持不变。
 
 ## 规范基线
 
@@ -25,6 +25,8 @@ Arm IHI 0069H.b（2024-04-12）为准：
 - SGI/PPI 使用当前 PE 的 `GICR_INMIR0`；
 - Group 0、对应 Security state 未启用 affinity routing、未实现的中断或
   Non-secure 不可访问的 Secure 中断位是 RES0/RAZ-WI。
+- 写 `INMIR` 时，pending 中断可以采用旧属性或新属性，但实现必须保证中断不丢失、
+  不重复处理且变化在有限时间内可见；SGI 是否可禁用由实现定义。
 
 因此生产代码只读取 `GICD_TYPER.NMI`。当该位为零时，写读回探测既不能发现
 规范之外的能力，还会受 Group、Security state 和 affinity routing 影响，并会
@@ -42,7 +44,10 @@ Arm IHI 0069H.b（2024-04-12）为准：
 对应 affinity routing。私有中断只访问当前 PE 的 Redistributor，查找使用完整的
 Aff3:Aff2:Aff1:Aff0；缺失帧返回 `NmiAttributeError`。调用者仍须先完成
 Distributor 和当前 Redistributor 初始化，并遵守 `Gic::new` 的唯一硬件所有者
-契约。
+契约。setter 在写入前读取同一 INTID 的 `ISENABLER` 和 `ISACTIVER`，对 enabled
+或 active 状态分别返回明确错误；pending 但 disabled/inactive 的中断仍可设置。
+调用者还须在调用期间序列化独立 MMIO 别名和该 INTID 的中断处理。对硬件永久启用
+的 SGI，本接口会返回 `InterruptEnabled`，不会以不安全写入伪造支持。
 
 ## 方案比较
 
@@ -66,8 +71,9 @@ Distributor 和当前 Redistributor 初始化，并遵守 `Gic::new` 的唯一�
 最低层 host 回归固定验证 SGI/PPI/SPI 到 INMIR 的映射，并拒绝 special/extended
 INTID；该测试在旧实现中因缺失映射能力而确定性编译失败。AArch64 Linux 用户态
 测试在 QEMU user mode 中以假 MMIO 验证 capability、Group、affinity routing、
-未实现 SPI、设置/清除/读回以及包含 Aff3 的 Redistributor 匹配。另以 bare-metal
-AArch64 target clippy/check 和现有 GICv3 QEMU 用例验证目标编译与普通 IRQ 路径。
+未实现 SPI、enabled/active 拒绝、设置/清除/读回以及包含 Aff3 的 Redistributor
+匹配。另以 bare-metal AArch64 target clippy/check 和现有 GICv3 QEMU 用例验证
+目标编译与普通 IRQ 路径。
 
 变更不修改初始化默认值或普通 IRQ 行为。若需回滚，只需移除新增 API、能力位定义
 和测试；调用者在能力缺失时已经得到显式 `Unsupported`，无需迁移持久状态。

--- a/docs/design/arm-gic-v3-nmi-attribute.md
+++ b/docs/design/arm-gic-v3-nmi-attribute.md
@@ -49,6 +49,10 @@ Distributor 和当前 Redistributor 初始化，并遵守 `Gic::new` 的唯一�
 调用者还须在调用期间序列化独立 MMIO 别名和该 INTID 的中断处理。对硬件永久启用
 的 SGI，本接口会返回 `InterruptEnabled`，不会以不安全写入伪造支持。
 
+公开接口的调用顺序由 `examples/gicv3_nmi_attribute.rs` 编译检查。setter 和
+getter 都要求先完成 Distributor 初始化，以使用 `Gic::init` 确认的 Security
+state；访问 SGI/PPI 时还要求先初始化当前 PE 的 Redistributor。
+
 ## 方案比较
 
 - 升级外部依赖不可行：本仓库通过 workspace path 维护
@@ -72,8 +76,9 @@ Distributor 和当前 Redistributor 初始化，并遵守 `Gic::new` 的唯一�
 INTID；该测试在旧实现中因缺失映射能力而确定性编译失败。AArch64 Linux 用户态
 测试在 QEMU user mode 中以假 MMIO 验证 capability、Group、affinity routing、
 未实现 SPI、enabled/active 拒绝、设置/清除/读回以及包含 Aff3 的 Redistributor
-匹配。另以 bare-metal AArch64 target clippy/check 和现有 GICv3 QEMU 用例验证
-目标编译与普通 IRQ 路径。
+匹配。AArch64 Linux target 还会编译 `gicv3_nmi_attribute` example，验证公开 API
+的初始化、能力检查、禁用、设置与查询顺序。另以 bare-metal AArch64 target
+clippy/check 和现有 GICv3 QEMU 用例验证目标编译与普通 IRQ 路径。
 
 变更不修改初始化默认值或普通 IRQ 行为。若需回滚，只需移除新增 API、能力位定义
 和测试；调用者在能力缺失时已经得到显式 `Unsupported`，无需迁移持久状态。

--- a/drivers/intc/arm-gic-driver/CHANGELOG.md
+++ b/drivers/intc/arm-gic-driver/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add typed GICv3 NMI attribute programming for standard SGIs, PPIs, and SPIs.
+- Add typed GICv3 NMI attribute programming for quiescent standard SGIs, PPIs,
+  and SPIs, rejecting enabled or active interrupts.
 
 ## [0.17.12](https://github.com/rcore-os/tgoskits/compare/arm-gic-driver-v0.17.11...arm-gic-driver-v0.17.12) - 2026-08-20
 

--- a/drivers/intc/arm-gic-driver/CHANGELOG.md
+++ b/drivers/intc/arm-gic-driver/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add typed GICv3 NMI attribute programming for standard SGIs, PPIs, and SPIs.
+
 ## [0.17.12](https://github.com/rcore-os/tgoskits/compare/arm-gic-driver-v0.17.11...arm-gic-driver-v0.17.12) - 2026-08-20
 
 ### Fixed

--- a/drivers/intc/arm-gic-driver/README.md
+++ b/drivers/intc/arm-gic-driver/README.md
@@ -42,6 +42,19 @@ if !ack.is_special() {
 }
 ```
 
+### GICv3.3 NMI Attributes
+
+The compile-checked
+[`gicv3_nmi_attribute`](examples/gicv3_nmi_attribute.rs) example shows the
+required order for initializing the Distributor, checking
+`FEAT_GICv3_NMI`, disabling an SPI, and setting and reading its typed NMI
+attribute. SGIs and PPIs additionally require the current PE's Redistributor
+to be initialized.
+
+This API only programs the per-interrupt GIC property. The OS or platform
+layer remains responsible for the CPU NMI feature, exception entry,
+acknowledgment, handler, and synchronization with independent MMIO aliases.
+
 ## Architecture Support
 
 This driver supports multiple ARM GIC versions:

--- a/drivers/intc/arm-gic-driver/examples/gicv3_nmi_attribute.rs
+++ b/drivers/intc/arm-gic-driver/examples/gicv3_nmi_attribute.rs
@@ -1,0 +1,39 @@
+//! Compile-checked GICv3.3 NMI attribute setup for one SPI.
+
+#[cfg(target_arch = "aarch64")]
+use arm_gic_driver::{
+    IntId, VirtAddr,
+    v3::{Gic, NmiAttribute, NmiAttributeError},
+};
+
+#[cfg(target_arch = "aarch64")]
+fn initialize_gic_with_spi_nmi(
+    gicd: VirtAddr,
+    gicr: VirtAddr,
+    spi_number: u32,
+) -> Result<(Gic, NmiAttribute), NmiAttributeError> {
+    // SAFETY: OS or platform glue must keep both mapped register regions valid
+    // and give this `Gic` exclusive ownership of them for its lifetime.
+    let mut gic = unsafe { Gic::new(gicd, gicr) };
+    gic.init();
+
+    if !gic.supports_nmi_attributes() {
+        return Err(NmiAttributeError::Unsupported);
+    }
+
+    let spi = IntId::spi(spi_number);
+    gic.set_irq_enable(spi, false);
+    gic.set_nmi_attribute(spi, NmiAttribute::NonMaskable)?;
+    let attribute = gic.nmi_attribute(spi)?;
+    Ok((gic, attribute))
+}
+
+#[cfg(target_arch = "aarch64")]
+fn main() {
+    // Keep the hardware-specific function compile-checked without inventing
+    // board addresses or touching MMIO on the build host.
+    let _initialize = initialize_gic_with_spi_nmi;
+}
+
+#[cfg(not(target_arch = "aarch64"))]
+fn main() {}

--- a/drivers/intc/arm-gic-driver/src/define.rs
+++ b/drivers/intc/arm-gic-driver/src/define.rs
@@ -80,6 +80,32 @@ pub const SPECIAL_RANGE: Range<u32> = Range {
     end: 1024,
 };
 
+/// Register location for a standard INTID's non-maskable attribute.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NmiAttributeSlot {
+    /// The bit is in the current PE's `GICR_INMIR0`.
+    Redistributor { mask: u32 },
+    /// The bit is in `GICD_INMIR<register>`.
+    Distributor { register: usize, mask: u32 },
+}
+
+/// Map a standard SGI, PPI, or SPI to its architectural INMIR slot.
+pub(crate) fn nmi_attribute_slot(intid: IntId) -> Option<NmiAttributeSlot> {
+    let intid = intid.to_u32();
+    if intid < PPI_RANGE.end {
+        Some(NmiAttributeSlot::Redistributor {
+            mask: 1 << (intid % 32),
+        })
+    } else if SPI_RANGE.contains(&intid) {
+        Some(NmiAttributeSlot::Distributor {
+            register: (intid / 32) as usize,
+            mask: 1 << (intid % 32),
+        })
+    } else {
+        None
+    }
+}
+
 /// Error returned when a raw INTID is not valid for the probed GIC.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CheckedIntIdError;

--- a/drivers/intc/arm-gic-driver/src/tests.rs
+++ b/drivers/intc/arm-gic-driver/src/tests.rs
@@ -1,8 +1,12 @@
 extern crate std;
 
 #[cfg(target_arch = "aarch64")]
-use crate::version::v3::{LPI, RedistributorV3, RedistributorV4, SGI};
-use crate::{CheckedIntIdError, IntId, checked_intid, define::Trigger, fdt_parse_irq_config};
+use crate::version::v3::gicr::{LPI, RedistributorV3, RedistributorV4, SGI};
+use crate::{
+    CheckedIntIdError, IntId, checked_intid,
+    define::{NmiAttributeSlot, Trigger, nmi_attribute_slot},
+    fdt_parse_irq_config,
+};
 
 #[cfg(target_arch = "aarch64")]
 #[test]
@@ -61,4 +65,36 @@ fn fdt_spi_level_high_uses_gic_intid_numbering() {
 
     assert_eq!(config.id.to_u32(), 235);
     assert_eq!(config.trigger, Trigger::Level);
+}
+
+#[test]
+fn nmi_attribute_slots_follow_architectural_intid_numbering() {
+    assert_eq!(
+        nmi_attribute_slot(IntId::sgi(5)),
+        Some(NmiAttributeSlot::Redistributor { mask: 1 << 5 })
+    );
+    assert_eq!(
+        nmi_attribute_slot(IntId::ppi(14)),
+        Some(NmiAttributeSlot::Redistributor { mask: 1 << 30 })
+    );
+    assert_eq!(
+        nmi_attribute_slot(IntId::spi(0)),
+        Some(NmiAttributeSlot::Distributor {
+            register: 1,
+            mask: 1,
+        })
+    );
+    assert_eq!(
+        nmi_attribute_slot(IntId::spi(42)),
+        Some(NmiAttributeSlot::Distributor {
+            register: 2,
+            mask: 1 << 10,
+        })
+    );
+}
+
+#[test]
+fn nmi_attribute_slots_reject_non_standard_intids() {
+    assert_eq!(nmi_attribute_slot(unsafe { IntId::raw(1023) }), None);
+    assert_eq!(nmi_attribute_slot(unsafe { IntId::raw(4096) }), None);
 }

--- a/drivers/intc/arm-gic-driver/src/version/v3/gicd.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/gicd.rs
@@ -487,41 +487,9 @@ impl DistributorReg {
         }
     }
 
-    /// Configure non-maskable interrupt
-    pub fn set_nmi(&self, intid: u32, nmi: bool) {
-        if (32..1020).contains(&intid) {
-            let reg_idx = (intid / 32) as usize;
-            let bit_idx = intid % 32;
-
-            if reg_idx < self.INMIR.len() {
-                let current = self.INMIR[reg_idx].get();
-                if nmi {
-                    self.INMIR[reg_idx].set(current | (1 << bit_idx));
-                } else {
-                    self.INMIR[reg_idx].set(current & !(1 << bit_idx));
-                }
-            }
-        }
-    }
-
-    /// Check if interrupt is configured as NMI
-    pub fn is_nmi(&self, intid: u32) -> bool {
-        if (32..1020).contains(&intid) {
-            let reg_idx = (intid / 32) as usize;
-            let bit_idx = intid % 32;
-
-            if reg_idx < self.INMIR.len() {
-                let current = self.INMIR[reg_idx].get();
-                return (current & (1 << bit_idx)) != 0;
-            }
-        }
-        false
-    }
-
     /// Check if Extended SPI range is supported
     pub fn has_extended_spi(&self) -> bool {
-        // Check if TYPER2.ESPI is implemented and set
-        self.TYPER2.read(TYPER2::NMI) != 0 // Using NMI bit as placeholder since ESPI is not defined yet
+        self.TYPER.is_set(TYPER::ESPI)
     }
 
     /// Get the Extended SPI range if supported
@@ -640,6 +608,10 @@ register_bitfields! [
         ITLinesNumber OFFSET(0) NUMBITS(5) [],
         /// Number of CPU interfaces implemented minus one
         CPUNumber OFFSET(5) NUMBITS(3) [],
+        /// Extended SPI range supported
+        ESPI OFFSET(8) NUMBITS(1) [],
+        /// Non-maskable interrupt property supported
+        NMI OFFSET(9) NUMBITS(1) [],
         /// Indicates whether the GIC implements Security Extensions
         SecurityExtn OFFSET(10) NUMBITS(1) [
             SingleSecurity = 0,
@@ -665,12 +637,12 @@ register_bitfields! [
 
     /// Type Modifier Register
     pub TYPER2 [
+        /// Virtual PE identifier width
+        VID OFFSET(0) NUMBITS(5) [],
         /// Virtual LPIs supported
-        VIL OFFSET(0) NUMBITS(1) [],
-        /// Virtual command queue interface supported
-        VID OFFSET(1) NUMBITS(5) [],
-        /// NMI support
-        NMI OFFSET(6) NUMBITS(1) [],
+        VIL OFFSET(7) NUMBITS(1) [],
+        /// Support for SGIs without an active state
+        nASSGIcap OFFSET(8) NUMBITS(1) [],
     ],
 
     /// Status Register

--- a/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
@@ -8,12 +8,14 @@ use log::*;
 pub use tock_registers::{LocalRegisterCopy, interfaces::*};
 
 mod gicd;
-mod gicr;
+pub(crate) mod gicr;
 mod its;
+mod nmi;
 
 use gicd::*;
 use gicr::*;
 pub use its::*;
+pub use nmi::*;
 
 use crate::version::{IrqVecReadable, IrqVecWriteable};
 pub use crate::{IntId, VirtAddr, define::Trigger, sys_reg::*};
@@ -957,18 +959,25 @@ fn rd_slice_from(gicr: VirtAddr) -> RDv3Slice {
 }
 
 fn current_rd_from(gicr: VirtAddr) -> NonNull<RedistributorV3> {
-    let want = (MPIDR_EL1.get() & 0xFFFFFF) as u32;
+    let affinity = Affinity::current();
+    redistributor_for_affinity_from(gicr, affinity)
+        .unwrap_or_else(|| panic!("No redistributor for current CPU affinity {affinity:?}"))
+}
 
-    for rd in rd_slice_from(gicr).iter() {
+fn redistributor_for_affinity_from(
+    gicr: VirtAddr,
+    affinity: Affinity,
+) -> Option<NonNull<RedistributorV3>> {
+    let want = affinity.affinity();
+    rd_slice_from(gicr).iter().find(|rd| {
+        // SAFETY: every pointer comes from the Redistributor region whose
+        // mapping and lifetime are guaranteed by the `Gic::new` contract.
         let affi = unsafe { rd.as_ref() }
             .lpi_ref()
             .TYPER
             .read(gicr::TYPER::Affinity) as u32;
-        if affi == want {
-            return rd;
-        }
-    }
-    panic!("No current redistributor")
+        affi == want
+    })
 }
 
 /// Every CPU interface has its own GICC registers

--- a/drivers/intc/arm-gic-driver/src/version/v3/nmi.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/nmi.rs
@@ -57,6 +57,14 @@ pub enum NmiAttributeError {
     #[error("affinity routing is disabled for {0:?}")]
     AffinityRoutingDisabled(IntId),
 
+    /// The interrupt must be disabled before changing its NMI attribute.
+    #[error("cannot change the NMI attribute of enabled interrupt {0:?}")]
+    InterruptEnabled(IntId),
+
+    /// The interrupt must be inactive before changing its NMI attribute.
+    #[error("cannot change the NMI attribute of active interrupt {0:?}")]
+    InterruptActive(IntId),
+
     /// No Redistributor frame matches the current PE.
     #[error("no Redistributor matches current CPU affinity {0:?}")]
     CurrentRedistributorNotFound(Affinity),
@@ -76,14 +84,24 @@ impl Gic {
     ///
     /// Private interrupts are changed only for the current PE. The caller must
     /// initialize the Distributor and the current Redistributor before using
-    /// this method. This API programs the interrupt property only; it does not
-    /// provide the NMI acknowledge or exception-handling path.
+    /// this method. The interrupt must be disabled and inactive; this method
+    /// checks both states before modifying the attribute. A pending interrupt
+    /// is permitted and observes either the old or new attribute as required
+    /// by the GIC architecture. This API programs the interrupt property only;
+    /// it does not provide the NMI acknowledge or exception-handling path.
+    ///
+    /// The caller must serialize independent MMIO aliases and interrupt
+    /// handling for the INTID until this method returns. Some GIC
+    /// implementations keep SGIs permanently enabled; those SGIs cannot meet
+    /// this API's quiescent-state contract and return
+    /// [`NmiAttributeError::InterruptEnabled`].
     ///
     /// # Errors
     ///
     /// Returns [`NmiAttributeError`] if the capability is absent, the INTID is
     /// unsupported or unimplemented, the interrupt is not accessible Group 1,
-    /// affinity routing is disabled, or the current Redistributor is missing.
+    /// affinity routing is disabled, the current Redistributor is missing, or
+    /// the interrupt is enabled or active.
     pub fn set_nmi_attribute(
         &mut self,
         intid: IntId,
@@ -98,8 +116,11 @@ impl Gic {
         attribute: NmiAttribute,
         current_affinity: impl FnOnce() -> Affinity,
     ) -> Result<(), NmiAttributeError> {
-        let (register, mask) = self.nmi_attribute_register(intid, current_affinity)?;
-        register.set(attribute.update_register(register.get(), mask));
+        let registers = self.nmi_attribute_register(intid, current_affinity)?;
+        registers.ensure_disabled_and_inactive(intid)?;
+        registers
+            .attribute
+            .set(attribute.update_register(registers.attribute.get(), registers.mask));
         Ok(())
     }
 
@@ -109,7 +130,11 @@ impl Gic {
     ///
     /// # Errors
     ///
-    /// Returns the same validation errors as [`Gic::set_nmi_attribute`].
+    /// Returns [`NmiAttributeError`] if the capability is absent, the INTID is
+    /// unsupported or unimplemented, the interrupt is not accessible Group 1,
+    /// affinity routing is disabled, or the current Redistributor is missing.
+    /// Reading the attribute does not require the interrupt to be disabled or
+    /// inactive.
     pub fn nmi_attribute(&self, intid: IntId) -> Result<NmiAttribute, NmiAttributeError> {
         self.nmi_attribute_with_current_affinity(intid, Affinity::current)
     }
@@ -119,15 +144,18 @@ impl Gic {
         intid: IntId,
         current_affinity: impl FnOnce() -> Affinity,
     ) -> Result<NmiAttribute, NmiAttributeError> {
-        let (register, mask) = self.nmi_attribute_register(intid, current_affinity)?;
-        Ok(NmiAttribute::from_register(register.get(), mask))
+        let registers = self.nmi_attribute_register(intid, current_affinity)?;
+        Ok(NmiAttribute::from_register(
+            registers.attribute.get(),
+            registers.mask,
+        ))
     }
 
     fn nmi_attribute_register(
         &self,
         intid: IntId,
         current_affinity: impl FnOnce() -> Affinity,
-    ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
+    ) -> Result<NmiAttributeRegisters<'_>, NmiAttributeError> {
         let slot = nmi_attribute_slot(intid).ok_or(NmiAttributeError::UnsupportedIntId(intid))?;
         if !self.supports_nmi_attributes() {
             return Err(NmiAttributeError::Unsupported);
@@ -148,7 +176,7 @@ impl Gic {
         intid: IntId,
         mask: u32,
         affinity: Affinity,
-    ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
+    ) -> Result<NmiAttributeRegisters<'_>, NmiAttributeError> {
         let redistributor = redistributor_for_affinity_from(self.gicr, affinity)
             .ok_or(NmiAttributeError::CurrentRedistributorNotFound(affinity))?;
         // SAFETY: the pointer belongs to the Redistributor mapping whose
@@ -160,7 +188,12 @@ impl Gic {
             redistributor.sgi.IGRPMODR0.get() & mask != 0,
         )?;
         self.ensure_affinity_routing(intid, group)?;
-        Ok((&redistributor.sgi.INMIR0, mask))
+        Ok(NmiAttributeRegisters {
+            attribute: &redistributor.sgi.INMIR0,
+            enabled: &redistributor.sgi.ISENABLER0,
+            active: &redistributor.sgi.ISACTIVER0,
+            mask,
+        })
     }
 
     fn distributor_nmi_register(
@@ -168,7 +201,7 @@ impl Gic {
         intid: IntId,
         register: usize,
         mask: u32,
-    ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
+    ) -> Result<NmiAttributeRegisters<'_>, NmiAttributeError> {
         if intid.to_u32() >= self.gicd().max_spi_num() {
             return Err(NmiAttributeError::UnimplementedIntId(intid));
         }
@@ -179,7 +212,12 @@ impl Gic {
             self.gicd().IGRPMODR[register].get() & mask != 0,
         )?;
         self.ensure_affinity_routing(intid, group)?;
-        Ok((&self.gicd().INMIR[register], mask))
+        Ok(NmiAttributeRegisters {
+            attribute: &self.gicd().INMIR[register],
+            enabled: &self.gicd().ISENABLER[register],
+            active: &self.gicd().ISACTIVER[register],
+            mask,
+        })
     }
 
     fn group1_access(
@@ -216,6 +254,25 @@ impl Gic {
     }
 }
 
+struct NmiAttributeRegisters<'a> {
+    attribute: &'a ReadWrite<u32>,
+    enabled: &'a ReadWrite<u32>,
+    active: &'a ReadWrite<u32>,
+    mask: u32,
+}
+
+impl NmiAttributeRegisters<'_> {
+    fn ensure_disabled_and_inactive(&self, intid: IntId) -> Result<(), NmiAttributeError> {
+        if self.enabled.get() & self.mask != 0 {
+            return Err(NmiAttributeError::InterruptEnabled(intid));
+        }
+        if self.active.get() & self.mask != 0 {
+            return Err(NmiAttributeError::InterruptActive(intid));
+        }
+        Ok(())
+    }
+}
+
 #[derive(Clone, Copy)]
 enum NmiGroup {
     Single,
@@ -238,10 +295,14 @@ mod tests {
     const GICD_CTLR: usize = 0x0000;
     const GICD_TYPER: usize = 0x0004;
     const GICD_IGROUPR: usize = 0x0080;
+    const GICD_ISENABLER: usize = 0x0100;
+    const GICD_ISACTIVER: usize = 0x0300;
     const GICD_INMIR: usize = 0x0f80;
     const GICR_TYPER: usize = 0x0008;
     const GICR_SGI_BASE: usize = 0x10000;
     const GICR_IGROUPR0: usize = GICR_SGI_BASE + 0x0080;
+    const GICR_ISENABLER0: usize = GICR_SGI_BASE + 0x0100;
+    const GICR_ISACTIVER0: usize = GICR_SGI_BASE + 0x0300;
     const GICR_IGRPMODR0: usize = GICR_SGI_BASE + 0x0d00;
     const GICR_INMIR0: usize = GICR_SGI_BASE + 0x0f80;
     const GICR_TYPER_LAST: u64 = 1 << 4;
@@ -349,6 +410,14 @@ mod tests {
             // `GICR_V3_SIZE` allocation owned by this fixture.
             unsafe { address.add(offset).cast::<u32>().read() }
         }
+
+        fn write_distributor(&mut self, offset: usize, value: u32) {
+            write_u32(self.distributor.as_mut_ptr().cast::<u8>(), offset, value);
+        }
+
+        fn write_redistributor(&mut self, offset: usize, value: u32) {
+            write_u32(self.redistributor.as_mut_ptr().cast::<u8>(), offset, value);
+        }
     }
 
     #[test]
@@ -427,6 +496,31 @@ mod tests {
             unimplemented.gic.nmi_attribute(special),
             Err(NmiAttributeError::UnsupportedIntId(special))
         );
+    }
+
+    #[test]
+    fn rejects_enabled_and_active_spi_attribute_changes() {
+        let intid = IntId::spi(42);
+        let register = 2;
+        let mask = 1 << 10;
+
+        for (state_register, expected) in [
+            (GICD_ISENABLER, NmiAttributeError::InterruptEnabled(intid)),
+            (GICD_ISACTIVER, NmiAttributeError::InterruptActive(intid)),
+        ] {
+            let mut fake = FakeGic::new(GICD_TYPER_NMI | 2, GICD_CTLR_ARE_S_OR_ONE, register, mask);
+            fake.write_distributor(state_register + register * size_of::<u32>(), mask);
+
+            assert_eq!(
+                fake.gic.set_nmi_attribute(intid, NmiAttribute::NonMaskable),
+                Err(expected)
+            );
+            assert_eq!(
+                fake.read_distributor(GICD_INMIR + register * size_of::<u32>()),
+                0
+            );
+            assert_eq!(fake.gic.nmi_attribute(intid), Ok(NmiAttribute::Maskable));
+        }
     }
 
     #[test]
@@ -554,6 +648,20 @@ mod tests {
     }
 
     #[test]
+    fn rejects_enabled_and_active_private_attribute_changes() {
+        for intid in [IntId::sgi(5), IntId::ppi(14)] {
+            for state_register in [GICR_ISENABLER0, GICR_ISACTIVER0] {
+                let expected = match state_register {
+                    GICR_ISENABLER0 => NmiAttributeError::InterruptEnabled(intid),
+                    GICR_ISACTIVER0 => NmiAttributeError::InterruptActive(intid),
+                    _ => unreachable!(),
+                };
+                assert_private_attribute_write_rejected_by_state(intid, state_register, expected);
+            }
+        }
+    }
+
+    #[test]
     fn rejects_inaccessible_private_groups_and_disabled_routing() {
         let intid = IntId::sgi(3);
         let mask = 1 << 3;
@@ -670,6 +778,37 @@ mod tests {
                 || affinity,
             ),
             Err(expected)
+        );
+    }
+
+    fn assert_private_attribute_write_rejected_by_state(
+        intid: IntId,
+        state_register: usize,
+        expected: NmiAttributeError,
+    ) {
+        let mask = 1 << (intid.to_u32() % 32);
+        let mut fake = FakeGic::with_private_interrupts(PrivateInterruptConfig {
+            affinity: TEST_AFFINITY,
+            security_state: SecurityState::Single,
+            ctlr: GICD_CTLR_ARE_S_OR_ONE,
+            group1_mask: mask,
+            group_modifier_mask: 0,
+        });
+        fake.write_redistributor(state_register, mask);
+
+        assert_eq!(
+            fake.gic.set_nmi_attribute_with_current_affinity(
+                intid,
+                NmiAttribute::NonMaskable,
+                || TEST_AFFINITY,
+            ),
+            Err(expected)
+        );
+        assert_eq!(fake.read_redistributor(GICR_INMIR0), 0);
+        assert_eq!(
+            fake.gic
+                .nmi_attribute_with_current_affinity(intid, || TEST_AFFINITY),
+            Ok(NmiAttribute::Maskable)
         );
     }
 

--- a/drivers/intc/arm-gic-driver/src/version/v3/nmi.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/nmi.rs
@@ -83,12 +83,13 @@ impl Gic {
     /// Set the non-maskable property of a standard SGI, PPI, or SPI.
     ///
     /// Private interrupts are changed only for the current PE. The caller must
-    /// initialize the Distributor and the current Redistributor before using
-    /// this method. The interrupt must be disabled and inactive; this method
-    /// checks both states before modifying the attribute. A pending interrupt
-    /// is permitted and observes either the old or new attribute as required
-    /// by the GIC architecture. This API programs the interrupt property only;
-    /// it does not provide the NMI acknowledge or exception-handling path.
+    /// initialize the Distributor before using this method and must also
+    /// initialize the current Redistributor when changing a private interrupt.
+    /// The interrupt must be disabled and inactive; this method checks both
+    /// states before modifying the attribute. A pending interrupt is permitted
+    /// and observes either the old or new attribute as required by the GIC
+    /// architecture. This API programs the interrupt property only; it does not
+    /// provide the NMI acknowledge or exception-handling path.
     ///
     /// The caller must serialize independent MMIO aliases and interrupt
     /// handling for the INTID until this method returns. Some GIC
@@ -126,7 +127,9 @@ impl Gic {
 
     /// Read the non-maskable property of a standard SGI, PPI, or SPI.
     ///
-    /// Private interrupts are read from the current PE's Redistributor.
+    /// The caller must initialize the Distributor first so this method observes
+    /// the Security state established by [`Gic::init`]. Private interrupts are
+    /// read from the current PE's Redistributor, which must also be initialized.
     ///
     /// # Errors
     ///

--- a/drivers/intc/arm-gic-driver/src/version/v3/nmi.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/nmi.rs
@@ -89,7 +89,16 @@ impl Gic {
         intid: IntId,
         attribute: NmiAttribute,
     ) -> Result<(), NmiAttributeError> {
-        let (register, mask) = self.nmi_attribute_register(intid)?;
+        self.set_nmi_attribute_with_current_affinity(intid, attribute, Affinity::current)
+    }
+
+    fn set_nmi_attribute_with_current_affinity(
+        &mut self,
+        intid: IntId,
+        attribute: NmiAttribute,
+        current_affinity: impl FnOnce() -> Affinity,
+    ) -> Result<(), NmiAttributeError> {
+        let (register, mask) = self.nmi_attribute_register(intid, current_affinity)?;
         register.set(attribute.update_register(register.get(), mask));
         Ok(())
     }
@@ -102,13 +111,22 @@ impl Gic {
     ///
     /// Returns the same validation errors as [`Gic::set_nmi_attribute`].
     pub fn nmi_attribute(&self, intid: IntId) -> Result<NmiAttribute, NmiAttributeError> {
-        let (register, mask) = self.nmi_attribute_register(intid)?;
+        self.nmi_attribute_with_current_affinity(intid, Affinity::current)
+    }
+
+    fn nmi_attribute_with_current_affinity(
+        &self,
+        intid: IntId,
+        current_affinity: impl FnOnce() -> Affinity,
+    ) -> Result<NmiAttribute, NmiAttributeError> {
+        let (register, mask) = self.nmi_attribute_register(intid, current_affinity)?;
         Ok(NmiAttribute::from_register(register.get(), mask))
     }
 
     fn nmi_attribute_register(
         &self,
         intid: IntId,
+        current_affinity: impl FnOnce() -> Affinity,
     ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
         let slot = nmi_attribute_slot(intid).ok_or(NmiAttributeError::UnsupportedIntId(intid))?;
         if !self.supports_nmi_attributes() {
@@ -117,7 +135,7 @@ impl Gic {
 
         match slot {
             NmiAttributeSlot::Redistributor { mask } => {
-                self.redistributor_nmi_register(intid, mask)
+                self.redistributor_nmi_register(intid, mask, current_affinity())
             }
             NmiAttributeSlot::Distributor { register, mask } => {
                 self.distributor_nmi_register(intid, register, mask)
@@ -129,8 +147,8 @@ impl Gic {
         &self,
         intid: IntId,
         mask: u32,
+        affinity: Affinity,
     ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
-        let affinity = Affinity::current();
         let redistributor = redistributor_for_affinity_from(self.gicr, affinity)
             .ok_or(NmiAttributeError::CurrentRedistributorNotFound(affinity))?;
         // SAFETY: the pointer belongs to the Redistributor mapping whose
@@ -209,7 +227,7 @@ enum NmiGroup {
 mod tests {
     extern crate std;
 
-    use core::{mem::size_of, ptr::NonNull};
+    use core::mem::size_of;
     use std::boxed::Box;
 
     use super::*;
@@ -222,13 +240,34 @@ mod tests {
     const GICD_IGROUPR: usize = 0x0080;
     const GICD_INMIR: usize = 0x0f80;
     const GICR_TYPER: usize = 0x0008;
+    const GICR_SGI_BASE: usize = 0x10000;
+    const GICR_IGROUPR0: usize = GICR_SGI_BASE + 0x0080;
+    const GICR_IGRPMODR0: usize = GICR_SGI_BASE + 0x0d00;
+    const GICR_INMIR0: usize = GICR_SGI_BASE + 0x0f80;
     const GICR_TYPER_LAST: u64 = 1 << 4;
     const GICD_TYPER_NMI: u32 = 1 << 9;
-    const GICD_CTLR_ARE: u32 = 1 << 4;
+    const GICD_CTLR_ARE_S_OR_ONE: u32 = 1 << 4;
+    const GICD_CTLR_ARE_NS_SECURE_VIEW: u32 = 1 << 5;
+    const TEST_AFFINITY: Affinity = Affinity {
+        aff0: 4,
+        aff1: 3,
+        aff2: 2,
+        aff3: 1,
+    };
+
+    #[derive(Clone, Copy, Debug)]
+    struct PrivateInterruptConfig {
+        affinity: Affinity,
+        security_state: SecurityState,
+        ctlr: u32,
+        group1_mask: u32,
+        group_modifier_mask: u32,
+    }
 
     struct FakeGic {
         gic: Gic,
         distributor: Box<[u64]>,
+        redistributor: Box<[u64]>,
     }
 
     impl FakeGic {
@@ -243,22 +282,71 @@ mod tests {
                 group_mask,
             );
 
-            // SAFETY: `distributor` owns a suitably aligned register-sized
-            // allocation for the lifetime of `gic`; the dangling GICR is not
-            // accessed by the SPI-only tests using this fixture.
-            let gic = unsafe {
+            let mut redistributor = zeroed_words(GICR_V3_SIZE);
+            write_u64(
+                redistributor.as_mut_ptr().cast::<u8>(),
+                GICR_TYPER,
+                GICR_TYPER_LAST,
+            );
+            Self::from_registers(distributor, redistributor, SecurityState::Single)
+        }
+
+        fn with_private_interrupts(config: PrivateInterruptConfig) -> Self {
+            let mut distributor = zeroed_words(GICD_SIZE);
+            let distributor_base = distributor.as_mut_ptr().cast::<u8>();
+            write_u32(distributor_base, GICD_TYPER, GICD_TYPER_NMI);
+            write_u32(distributor_base, GICD_CTLR, config.ctlr);
+
+            let mut redistributor = zeroed_words(GICR_V3_SIZE);
+            let redistributor_base = redistributor.as_mut_ptr().cast::<u8>();
+            write_u64(
+                redistributor_base,
+                GICR_TYPER,
+                (u64::from(config.affinity.affinity()) << 32) | GICR_TYPER_LAST,
+            );
+            write_u32(redistributor_base, GICR_IGROUPR0, config.group1_mask);
+            write_u32(
+                redistributor_base,
+                GICR_IGRPMODR0,
+                config.group_modifier_mask,
+            );
+
+            Self::from_registers(distributor, redistributor, config.security_state)
+        }
+
+        fn from_registers(
+            mut distributor: Box<[u64]>,
+            mut redistributor: Box<[u64]>,
+            security_state: SecurityState,
+        ) -> Self {
+            // SAFETY: both boxes own suitably aligned register-sized
+            // allocations for the lifetime of `gic` and this fixture is their
+            // sole accessor.
+            let mut gic = unsafe {
                 Gic::new(
-                    VirtAddr::from(base),
-                    VirtAddr::from(NonNull::<u8>::dangling()),
+                    VirtAddr::from(distributor.as_mut_ptr().cast::<u8>()),
+                    VirtAddr::from(redistributor.as_mut_ptr().cast::<u8>()),
                 )
             };
-            Self { gic, distributor }
+            gic.security_state = security_state;
+            Self {
+                gic,
+                distributor,
+                redistributor,
+            }
         }
 
         fn read_distributor(&self, offset: usize) -> u32 {
             let address = self.distributor.as_ptr().cast::<u8>();
             // SAFETY: every caller uses an aligned u32 offset within the
             // `GICD_SIZE` allocation owned by this fixture.
+            unsafe { address.add(offset).cast::<u32>().read() }
+        }
+
+        fn read_redistributor(&self, offset: usize) -> u32 {
+            let address = self.redistributor.as_ptr().cast::<u8>();
+            // SAFETY: every caller uses an aligned u32 offset within the
+            // `GICR_V3_SIZE` allocation owned by this fixture.
             unsafe { address.add(offset).cast::<u32>().read() }
         }
     }
@@ -268,9 +356,15 @@ mod tests {
         let intid = IntId::spi(42);
         let register = 2;
         let mask = 1 << 10;
-        let mut fake = FakeGic::new(GICD_TYPER_NMI | 2, GICD_CTLR_ARE, register, mask);
+        let mut fake = FakeGic::new(GICD_TYPER_NMI | 2, GICD_CTLR_ARE_S_OR_ONE, register, mask);
 
         assert!(fake.gic.supports_nmi_attributes());
+        assert_eq!(
+            fake.gic.nmi_attribute_with_current_affinity(intid, || {
+                panic!("SPI attributes must not resolve a Redistributor")
+            }),
+            Ok(NmiAttribute::Maskable)
+        );
         assert_eq!(fake.gic.nmi_attribute(intid), Ok(NmiAttribute::Maskable));
 
         fake.gic
@@ -294,13 +388,18 @@ mod tests {
         let group_register = 1;
         let group_mask = 1;
 
-        let unsupported = FakeGic::new(1, GICD_CTLR_ARE, group_register, group_mask);
+        let unsupported = FakeGic::new(1, GICD_CTLR_ARE_S_OR_ONE, group_register, group_mask);
         assert_eq!(
             unsupported.gic.nmi_attribute(intid),
             Err(NmiAttributeError::Unsupported)
         );
 
-        let group0 = FakeGic::new(GICD_TYPER_NMI | 1, GICD_CTLR_ARE, group_register, 0);
+        let group0 = FakeGic::new(
+            GICD_TYPER_NMI | 1,
+            GICD_CTLR_ARE_S_OR_ONE,
+            group_register,
+            0,
+        );
         assert_eq!(
             group0.gic.nmi_attribute(intid),
             Err(NmiAttributeError::NotAccessibleGroup1(intid))
@@ -312,7 +411,12 @@ mod tests {
             Err(NmiAttributeError::AffinityRoutingDisabled(intid))
         );
 
-        let unimplemented = FakeGic::new(GICD_TYPER_NMI, GICD_CTLR_ARE, group_register, group_mask);
+        let unimplemented = FakeGic::new(
+            GICD_TYPER_NMI,
+            GICD_CTLR_ARE_S_OR_ONE,
+            group_register,
+            group_mask,
+        );
         assert_eq!(
             unimplemented.gic.nmi_attribute(intid),
             Err(NmiAttributeError::UnimplementedIntId(intid))
@@ -322,6 +426,199 @@ mod tests {
         assert_eq!(
             unimplemented.gic.nmi_attribute(special),
             Err(NmiAttributeError::UnsupportedIntId(special))
+        );
+    }
+
+    #[test]
+    fn programs_reads_and_clears_sgi_and_ppi_nmi_attributes() {
+        let sgi = IntId::sgi(5);
+        let ppi = IntId::ppi(14);
+        let sgi_mask = 1 << 5;
+        let ppi_mask = 1 << 30;
+        let mut fake = FakeGic::with_private_interrupts(PrivateInterruptConfig {
+            affinity: TEST_AFFINITY,
+            security_state: SecurityState::Single,
+            ctlr: GICD_CTLR_ARE_S_OR_ONE,
+            group1_mask: sgi_mask | ppi_mask,
+            group_modifier_mask: 0,
+        });
+
+        for intid in [sgi, ppi] {
+            assert_eq!(
+                fake.gic
+                    .nmi_attribute_with_current_affinity(intid, || TEST_AFFINITY),
+                Ok(NmiAttribute::Maskable)
+            );
+        }
+
+        fake.gic
+            .set_nmi_attribute_with_current_affinity(sgi, NmiAttribute::NonMaskable, || {
+                TEST_AFFINITY
+            })
+            .unwrap();
+        assert_eq!(fake.read_redistributor(GICR_INMIR0), sgi_mask);
+
+        fake.gic
+            .set_nmi_attribute_with_current_affinity(ppi, NmiAttribute::NonMaskable, || {
+                TEST_AFFINITY
+            })
+            .unwrap();
+        assert_eq!(fake.read_redistributor(GICR_INMIR0), sgi_mask | ppi_mask);
+
+        fake.gic
+            .set_nmi_attribute_with_current_affinity(sgi, NmiAttribute::Maskable, || TEST_AFFINITY)
+            .unwrap();
+        assert_eq!(fake.read_redistributor(GICR_INMIR0), ppi_mask);
+        assert_eq!(
+            fake.gic
+                .nmi_attribute_with_current_affinity(sgi, || TEST_AFFINITY),
+            Ok(NmiAttribute::Maskable)
+        );
+        assert_eq!(
+            fake.gic
+                .nmi_attribute_with_current_affinity(ppi, || TEST_AFFINITY),
+            Ok(NmiAttribute::NonMaskable)
+        );
+
+        fake.gic
+            .set_nmi_attribute_with_current_affinity(ppi, NmiAttribute::Maskable, || TEST_AFFINITY)
+            .unwrap();
+        assert_eq!(fake.read_redistributor(GICR_INMIR0), 0);
+    }
+
+    #[test]
+    fn accepts_secure_and_nonsecure_group1_private_interrupts() {
+        let cases = [
+            (
+                IntId::sgi(6),
+                1 << 6,
+                PrivateInterruptConfig {
+                    affinity: TEST_AFFINITY,
+                    security_state: SecurityState::Secure,
+                    ctlr: GICD_CTLR_ARE_S_OR_ONE,
+                    group1_mask: 0,
+                    group_modifier_mask: 1 << 6,
+                },
+            ),
+            (
+                IntId::ppi(0),
+                1 << 16,
+                PrivateInterruptConfig {
+                    affinity: TEST_AFFINITY,
+                    security_state: SecurityState::Secure,
+                    ctlr: GICD_CTLR_ARE_NS_SECURE_VIEW,
+                    group1_mask: 1 << 16,
+                    group_modifier_mask: 0,
+                },
+            ),
+            (
+                IntId::sgi(7),
+                1 << 7,
+                PrivateInterruptConfig {
+                    affinity: TEST_AFFINITY,
+                    security_state: SecurityState::NonSecure,
+                    ctlr: GICD_CTLR_ARE_S_OR_ONE,
+                    group1_mask: 1 << 7,
+                    group_modifier_mask: 0,
+                },
+            ),
+        ];
+
+        for (intid, mask, config) in cases {
+            let mut fake = FakeGic::with_private_interrupts(config);
+            assert_eq!(
+                fake.gic
+                    .nmi_attribute_with_current_affinity(intid, || TEST_AFFINITY),
+                Ok(NmiAttribute::Maskable),
+                "{config:?}"
+            );
+            fake.gic
+                .set_nmi_attribute_with_current_affinity(intid, NmiAttribute::NonMaskable, || {
+                    TEST_AFFINITY
+                })
+                .unwrap();
+            assert_eq!(fake.read_redistributor(GICR_INMIR0), mask, "{config:?}");
+            assert_eq!(
+                fake.gic
+                    .nmi_attribute_with_current_affinity(intid, || TEST_AFFINITY),
+                Ok(NmiAttribute::NonMaskable),
+                "{config:?}"
+            );
+            fake.gic
+                .set_nmi_attribute_with_current_affinity(intid, NmiAttribute::Maskable, || {
+                    TEST_AFFINITY
+                })
+                .unwrap();
+            assert_eq!(fake.read_redistributor(GICR_INMIR0), 0, "{config:?}");
+        }
+    }
+
+    #[test]
+    fn rejects_inaccessible_private_groups_and_disabled_routing() {
+        let intid = IntId::sgi(3);
+        let mask = 1 << 3;
+
+        assert_private_attribute_error(
+            FakeGic::with_private_interrupts(PrivateInterruptConfig {
+                affinity: TEST_AFFINITY,
+                security_state: SecurityState::Single,
+                ctlr: GICD_CTLR_ARE_S_OR_ONE,
+                group1_mask: 0,
+                group_modifier_mask: 0,
+            }),
+            intid,
+            TEST_AFFINITY,
+            NmiAttributeError::NotAccessibleGroup1(intid),
+        );
+
+        assert_private_attribute_error(
+            FakeGic::with_private_interrupts(PrivateInterruptConfig {
+                affinity: TEST_AFFINITY,
+                security_state: SecurityState::NonSecure,
+                ctlr: GICD_CTLR_ARE_S_OR_ONE,
+                group1_mask: 0,
+                group_modifier_mask: mask,
+            }),
+            intid,
+            TEST_AFFINITY,
+            NmiAttributeError::NotAccessibleGroup1(intid),
+        );
+
+        assert_private_attribute_error(
+            FakeGic::with_private_interrupts(PrivateInterruptConfig {
+                affinity: TEST_AFFINITY,
+                security_state: SecurityState::Secure,
+                ctlr: GICD_CTLR_ARE_S_OR_ONE,
+                group1_mask: mask,
+                group_modifier_mask: 0,
+            }),
+            intid,
+            TEST_AFFINITY,
+            NmiAttributeError::AffinityRoutingDisabled(intid),
+        );
+    }
+
+    #[test]
+    fn rejects_missing_current_redistributor_for_private_interrupts() {
+        let intid = IntId::ppi(7);
+        let mask = 1 << 23;
+        let available_affinity = Affinity {
+            aff0: 5,
+            ..TEST_AFFINITY
+        };
+        let fake = FakeGic::with_private_interrupts(PrivateInterruptConfig {
+            affinity: available_affinity,
+            security_state: SecurityState::Single,
+            ctlr: GICD_CTLR_ARE_S_OR_ONE,
+            group1_mask: mask,
+            group_modifier_mask: 0,
+        });
+
+        assert_private_attribute_error(
+            fake,
+            intid,
+            TEST_AFFINITY,
+            NmiAttributeError::CurrentRedistributorNotFound(TEST_AFFINITY),
         );
     }
 
@@ -352,6 +649,27 @@ mod tests {
                 },
             )
             .is_none()
+        );
+    }
+
+    fn assert_private_attribute_error(
+        mut fake: FakeGic,
+        intid: IntId,
+        affinity: Affinity,
+        expected: NmiAttributeError,
+    ) {
+        assert_eq!(
+            fake.gic
+                .nmi_attribute_with_current_affinity(intid, || affinity),
+            Err(expected)
+        );
+        assert_eq!(
+            fake.gic.set_nmi_attribute_with_current_affinity(
+                intid,
+                NmiAttribute::NonMaskable,
+                || affinity,
+            ),
+            Err(expected)
         );
     }
 

--- a/drivers/intc/arm-gic-driver/src/version/v3/nmi.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/nmi.rs
@@ -1,0 +1,371 @@
+//! GICv3 non-maskable interrupt attribute programming.
+
+use tock_registers::{interfaces::*, registers::ReadWrite};
+
+use super::{Affinity, Gic, SecurityState, gicd::TYPER, redistributor_for_affinity_from};
+use crate::{
+    IntId,
+    define::{NmiAttributeSlot, nmi_attribute_slot},
+};
+
+/// The non-maskable property assigned to a Group 1 interrupt.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NmiAttribute {
+    /// The interrupt follows ordinary priority masking rules.
+    Maskable,
+    /// The interrupt has the architectural non-maskable property.
+    NonMaskable,
+}
+
+impl NmiAttribute {
+    fn from_register(register: u32, mask: u32) -> Self {
+        if register & mask == 0 {
+            Self::Maskable
+        } else {
+            Self::NonMaskable
+        }
+    }
+
+    fn update_register(self, register: u32, mask: u32) -> u32 {
+        match self {
+            Self::Maskable => register & !mask,
+            Self::NonMaskable => register | mask,
+        }
+    }
+}
+
+/// Failure returned while accessing a GIC NMI attribute register.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum NmiAttributeError {
+    /// The interrupt controller does not implement `FEAT_GICv3_NMI`.
+    #[error("the GIC does not implement FEAT_GICv3_NMI")]
+    Unsupported,
+
+    /// The requested INTID has no standard GICD/GICR NMI attribute slot.
+    #[error("NMI attributes are not supported for {0:?}")]
+    UnsupportedIntId(IntId),
+
+    /// The requested SPI is outside the implemented Distributor range.
+    #[error("{0:?} is not implemented by this GIC Distributor")]
+    UnimplementedIntId(IntId),
+
+    /// The interrupt is Group 0 or is not accessible as Group 1.
+    #[error("{0:?} is not configured as an accessible Group 1 interrupt")]
+    NotAccessibleGroup1(IntId),
+
+    /// Affinity routing is disabled for the interrupt's Security state.
+    #[error("affinity routing is disabled for {0:?}")]
+    AffinityRoutingDisabled(IntId),
+
+    /// No Redistributor frame matches the current PE.
+    #[error("no Redistributor matches current CPU affinity {0:?}")]
+    CurrentRedistributorNotFound(Affinity),
+}
+
+impl Gic {
+    /// Report whether the GIC implements NMI attribute registers.
+    ///
+    /// `GICD_TYPER.NMI` is the architectural capability source for both
+    /// `GICD_INMIR<n>` and `GICR_INMIR0`. A clear bit means those registers
+    /// are RES0 and must not be probed by temporarily modifying an interrupt.
+    pub fn supports_nmi_attributes(&self) -> bool {
+        self.gicd().TYPER.is_set(TYPER::NMI)
+    }
+
+    /// Set the non-maskable property of a standard SGI, PPI, or SPI.
+    ///
+    /// Private interrupts are changed only for the current PE. The caller must
+    /// initialize the Distributor and the current Redistributor before using
+    /// this method. This API programs the interrupt property only; it does not
+    /// provide the NMI acknowledge or exception-handling path.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NmiAttributeError`] if the capability is absent, the INTID is
+    /// unsupported or unimplemented, the interrupt is not accessible Group 1,
+    /// affinity routing is disabled, or the current Redistributor is missing.
+    pub fn set_nmi_attribute(
+        &mut self,
+        intid: IntId,
+        attribute: NmiAttribute,
+    ) -> Result<(), NmiAttributeError> {
+        let (register, mask) = self.nmi_attribute_register(intid)?;
+        register.set(attribute.update_register(register.get(), mask));
+        Ok(())
+    }
+
+    /// Read the non-maskable property of a standard SGI, PPI, or SPI.
+    ///
+    /// Private interrupts are read from the current PE's Redistributor.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same validation errors as [`Gic::set_nmi_attribute`].
+    pub fn nmi_attribute(&self, intid: IntId) -> Result<NmiAttribute, NmiAttributeError> {
+        let (register, mask) = self.nmi_attribute_register(intid)?;
+        Ok(NmiAttribute::from_register(register.get(), mask))
+    }
+
+    fn nmi_attribute_register(
+        &self,
+        intid: IntId,
+    ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
+        let slot = nmi_attribute_slot(intid).ok_or(NmiAttributeError::UnsupportedIntId(intid))?;
+        if !self.supports_nmi_attributes() {
+            return Err(NmiAttributeError::Unsupported);
+        }
+
+        match slot {
+            NmiAttributeSlot::Redistributor { mask } => {
+                self.redistributor_nmi_register(intid, mask)
+            }
+            NmiAttributeSlot::Distributor { register, mask } => {
+                self.distributor_nmi_register(intid, register, mask)
+            }
+        }
+    }
+
+    fn redistributor_nmi_register(
+        &self,
+        intid: IntId,
+        mask: u32,
+    ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
+        let affinity = Affinity::current();
+        let redistributor = redistributor_for_affinity_from(self.gicr, affinity)
+            .ok_or(NmiAttributeError::CurrentRedistributorNotFound(affinity))?;
+        // SAFETY: the pointer belongs to the Redistributor mapping whose
+        // lifetime and exclusive ownership are guaranteed by `Gic::new`.
+        let redistributor = unsafe { redistributor.as_ref() };
+        let group = self.group1_access(
+            intid,
+            redistributor.sgi.IGROUPR0.get() & mask != 0,
+            redistributor.sgi.IGRPMODR0.get() & mask != 0,
+        )?;
+        self.ensure_affinity_routing(intid, group)?;
+        Ok((&redistributor.sgi.INMIR0, mask))
+    }
+
+    fn distributor_nmi_register(
+        &self,
+        intid: IntId,
+        register: usize,
+        mask: u32,
+    ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
+        if intid.to_u32() >= self.gicd().max_spi_num() {
+            return Err(NmiAttributeError::UnimplementedIntId(intid));
+        }
+
+        let group = self.group1_access(
+            intid,
+            self.gicd().IGROUPR[register].get() & mask != 0,
+            self.gicd().IGRPMODR[register].get() & mask != 0,
+        )?;
+        self.ensure_affinity_routing(intid, group)?;
+        Ok((&self.gicd().INMIR[register], mask))
+    }
+
+    fn group1_access(
+        &self,
+        intid: IntId,
+        group1: bool,
+        group_modifier: bool,
+    ) -> Result<NmiGroup, NmiAttributeError> {
+        match (self.security_state, group1, group_modifier) {
+            (SecurityState::Single, true, _) => Ok(NmiGroup::Single),
+            (SecurityState::Secure, true, _) => Ok(NmiGroup::NonSecure),
+            (SecurityState::Secure, false, true) => Ok(NmiGroup::Secure),
+            (SecurityState::NonSecure, true, _) => Ok(NmiGroup::NonSecure),
+            _ => Err(NmiAttributeError::NotAccessibleGroup1(intid)),
+        }
+    }
+
+    fn ensure_affinity_routing(
+        &self,
+        intid: IntId,
+        group: NmiGroup,
+    ) -> Result<(), NmiAttributeError> {
+        let mask = match (self.security_state, group) {
+            (SecurityState::Single, NmiGroup::Single) => 1 << 4,
+            (SecurityState::Secure, NmiGroup::Secure) => 1 << 4,
+            (SecurityState::Secure, NmiGroup::NonSecure) => 1 << 5,
+            (SecurityState::NonSecure, NmiGroup::NonSecure) => 1 << 4,
+            _ => 0,
+        };
+        if self.gicd().CTLR.get() & mask == 0 {
+            return Err(NmiAttributeError::AffinityRoutingDisabled(intid));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy)]
+enum NmiGroup {
+    Single,
+    Secure,
+    NonSecure,
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use core::{mem::size_of, ptr::NonNull};
+    use std::boxed::Box;
+
+    use super::*;
+    use crate::VirtAddr;
+
+    const GICD_SIZE: usize = 0x8000;
+    const GICR_V3_SIZE: usize = 0x20000;
+    const GICD_CTLR: usize = 0x0000;
+    const GICD_TYPER: usize = 0x0004;
+    const GICD_IGROUPR: usize = 0x0080;
+    const GICD_INMIR: usize = 0x0f80;
+    const GICR_TYPER: usize = 0x0008;
+    const GICR_TYPER_LAST: u64 = 1 << 4;
+    const GICD_TYPER_NMI: u32 = 1 << 9;
+    const GICD_CTLR_ARE: u32 = 1 << 4;
+
+    struct FakeGic {
+        gic: Gic,
+        distributor: Box<[u64]>,
+    }
+
+    impl FakeGic {
+        fn new(typer: u32, ctlr: u32, group_register: usize, group_mask: u32) -> Self {
+            let mut distributor = zeroed_words(GICD_SIZE);
+            let base = distributor.as_mut_ptr().cast::<u8>();
+            write_u32(base, GICD_TYPER, typer);
+            write_u32(base, GICD_CTLR, ctlr);
+            write_u32(
+                base,
+                GICD_IGROUPR + group_register * size_of::<u32>(),
+                group_mask,
+            );
+
+            // SAFETY: `distributor` owns a suitably aligned register-sized
+            // allocation for the lifetime of `gic`; the dangling GICR is not
+            // accessed by the SPI-only tests using this fixture.
+            let gic = unsafe {
+                Gic::new(
+                    VirtAddr::from(base),
+                    VirtAddr::from(NonNull::<u8>::dangling()),
+                )
+            };
+            Self { gic, distributor }
+        }
+
+        fn read_distributor(&self, offset: usize) -> u32 {
+            let address = self.distributor.as_ptr().cast::<u8>();
+            // SAFETY: every caller uses an aligned u32 offset within the
+            // `GICD_SIZE` allocation owned by this fixture.
+            unsafe { address.add(offset).cast::<u32>().read() }
+        }
+    }
+
+    #[test]
+    fn programs_and_reads_standard_spi_nmi_attribute() {
+        let intid = IntId::spi(42);
+        let register = 2;
+        let mask = 1 << 10;
+        let mut fake = FakeGic::new(GICD_TYPER_NMI | 2, GICD_CTLR_ARE, register, mask);
+
+        assert!(fake.gic.supports_nmi_attributes());
+        assert_eq!(fake.gic.nmi_attribute(intid), Ok(NmiAttribute::Maskable));
+
+        fake.gic
+            .set_nmi_attribute(intid, NmiAttribute::NonMaskable)
+            .unwrap();
+        assert_eq!(
+            fake.read_distributor(GICD_INMIR + register * size_of::<u32>()),
+            mask
+        );
+        assert_eq!(fake.gic.nmi_attribute(intid), Ok(NmiAttribute::NonMaskable));
+
+        fake.gic
+            .set_nmi_attribute(intid, NmiAttribute::Maskable)
+            .unwrap();
+        assert_eq!(fake.gic.nmi_attribute(intid), Ok(NmiAttribute::Maskable));
+    }
+
+    #[test]
+    fn rejects_unsupported_inaccessible_and_unimplemented_spi_attributes() {
+        let intid = IntId::spi(0);
+        let group_register = 1;
+        let group_mask = 1;
+
+        let unsupported = FakeGic::new(1, GICD_CTLR_ARE, group_register, group_mask);
+        assert_eq!(
+            unsupported.gic.nmi_attribute(intid),
+            Err(NmiAttributeError::Unsupported)
+        );
+
+        let group0 = FakeGic::new(GICD_TYPER_NMI | 1, GICD_CTLR_ARE, group_register, 0);
+        assert_eq!(
+            group0.gic.nmi_attribute(intid),
+            Err(NmiAttributeError::NotAccessibleGroup1(intid))
+        );
+
+        let routing_disabled = FakeGic::new(GICD_TYPER_NMI | 1, 0, group_register, group_mask);
+        assert_eq!(
+            routing_disabled.gic.nmi_attribute(intid),
+            Err(NmiAttributeError::AffinityRoutingDisabled(intid))
+        );
+
+        let unimplemented = FakeGic::new(GICD_TYPER_NMI, GICD_CTLR_ARE, group_register, group_mask);
+        assert_eq!(
+            unimplemented.gic.nmi_attribute(intid),
+            Err(NmiAttributeError::UnimplementedIntId(intid))
+        );
+
+        let special = unsafe { IntId::raw(1023) };
+        assert_eq!(
+            unimplemented.gic.nmi_attribute(special),
+            Err(NmiAttributeError::UnsupportedIntId(special))
+        );
+    }
+
+    #[test]
+    fn redistributor_lookup_compares_affinity_level_three() {
+        let mut redistributor = zeroed_words(GICR_V3_SIZE);
+        let base = redistributor.as_mut_ptr().cast::<u8>();
+        let affinity = Affinity {
+            aff0: 4,
+            aff1: 3,
+            aff2: 2,
+            aff3: 1,
+        };
+        write_u64(
+            base,
+            GICR_TYPER,
+            (u64::from(affinity.affinity()) << 32) | GICR_TYPER_LAST,
+        );
+
+        let found = redistributor_for_affinity_from(VirtAddr::from(base), affinity).unwrap();
+        assert_eq!(found.as_ptr().cast::<u8>(), base);
+        assert!(
+            redistributor_for_affinity_from(
+                VirtAddr::from(base),
+                Affinity {
+                    aff3: 0,
+                    ..affinity
+                },
+            )
+            .is_none()
+        );
+    }
+
+    fn zeroed_words(size: usize) -> Box<[u64]> {
+        std::vec![0; size / size_of::<u64>()].into_boxed_slice()
+    }
+
+    fn write_u32(base: *mut u8, offset: usize, value: u32) {
+        // SAFETY: fixtures pass aligned offsets within their owned allocation.
+        unsafe { base.add(offset).cast::<u32>().write(value) };
+    }
+
+    fn write_u64(base: *mut u8, offset: usize, value: u64) {
+        // SAFETY: fixtures pass aligned offsets within their owned allocation.
+        unsafe { base.add(offset).cast::<u64>().write(value) };
+    }
+}


### PR DESCRIPTION
## 问题

对照 [arm-gic-driver#23](https://github.com/rcore-os/arm-gic-driver/pull/23) 检查后，本仓库只有 `GICD_INMIR<n>` / `GICR_INMIR0` 寄存器布局，以及会静默忽略错误的 Distributor SPI helper，并没有等价的完整能力：

- SGI/PPI 没有配置入口；
- 没有根据架构能力位判断 `FEAT_GICv3_NMI`；
- 无法区分 unsupported、Group/Security、affinity routing、运行状态、未实现 INTID 和 Redistributor 缺失；
- 当前 PE 的 Redistributor 匹配忽略了 Aff3；
- 本仓库使用 workspace path 维护该驱动，不能通过升级外部依赖获得能力。

外部 PR 使用写入再读回一个实际中断位的方式探测能力，但 Arm IHI 0069H.b 将 NMI property 定义为 GICv3.3 能力，并规定 `GICD_TYPER.NMI` bit 9 为能力来源。写读回会受 Group、Security state 和 affinity routing 影响，还会暂时改变真实中断属性，因此这里没有原样复制该探测方式。

## 改动

- 新增 typed API：
  - `NmiAttribute::{Maskable, NonMaskable}`
  - `Gic::supports_nmi_attributes()`
  - `Gic::set_nmi_attribute(&mut self, ...)`
  - `Gic::nmi_attribute(&self, ...)`
  - 可匹配的 `NmiAttributeError`
- 支持标准 INTID 0-1019：
  - SGI/PPI 使用当前 PE 的 `GICR_INMIR0`
  - SPI 使用 `GICD_INMIR<INTID DIV 32>`
- 访问寄存器前显式检查 capability、实现的 SPI 范围、可访问 Group 1、对应 Security state 的 affinity routing，以及当前 Redistributor。
- setter 在写 `INMIR` 前读取同一 INTID 的 `ISENABLER` 和 `ISACTIVER`；对 enabled/active 状态分别返回 `InterruptEnabled` / `InterruptActive`，不修改属性。pending 但 disabled/inactive 的中断按架构允许继续设置。
- 文档明确要求调用者在 setter 返回前序列化独立 MMIO 别名和该 INTID 的中断处理；实现上永久 enabled 的 SGI 会返回错误，不伪造支持。
- Redistributor 查找改为比较完整 Aff3:Aff2:Aff1:Aff0。
- 修正 `GICD_TYPER.ESPI/NMI` 与 `GICD_TYPER2` 字段定义，移除原有静默 no-op helper。
- 增加设计文档，记录规范依据、所有权、运行状态、方案取舍、范围与回滚方式。

## Review 处理

针对 [review #5007268803](https://github.com/rcore-os/tgoskits/pull/2167#pullrequestreview-5007268803) 指出的 SGI/PPI Redistributor 调用链覆盖缺口：

- fake-MMIO fixture 现在持有完整的 GICD 与 GICR v3 frame，不再给 SPI fixture 使用 dangling GICR；
- 在内部把“读取当前 affinity”收敛为一次性 provider：公共 API 仍读取真实 `MPIDR_EL1`，SPI 分支不会调用 provider，AArch64 用户态测试可注入确定 affinity；
- SGI 和 PPI 均经过当前 PE Redistributor 查找、Group/ARE 校验和 `GICR_INMIR0`，分别验证初始读取、设置、读回和逐项清除；
- 覆盖 Single、Secure Group1S、Secure Group1NS、NonSecure Group1NS、Group0/不可访问、ARE 未启用和当前 Redistributor 缺失；错误场景同时验证 read 与 set 的错误传播。

针对 [review #5015033721](https://github.com/rcore-os/tgoskits/pull/2167#pullrequestreview-5015033721) 指出的活动中断属性修改问题：

- Distributor 路径检查对应 word 的 `GICD_ISENABLER<n>` / `GICD_ISACTIVER<n>`；
- Redistributor 路径检查 `GICR_ISENABLER0` / `GICR_ISACTIVER0`；
- enabled 和 active 分别返回明确、可匹配的错误，且 `INMIR` 保持不变；
- fake-MMIO 对 SPI、SGI、PPI 两类状态均有确定性回归；getter 仍允许读取活动中断的属性。

`nmi.rs` 当前约 828 行，其中约 544 行是同一能力的私有 fake-MMIO fixture 与 AArch64 回归附录，生产 API 和寄存器逻辑仍维持单一 NMI attribute 职责。仅为行数拆分会要求把现有叶子模块整体迁移为 `nmi/mod.rs` 再拆测试文件，扩大本次硬件语义修复的结构性 diff，因此本次保留同域测试附录，不引入无关模块迁移。

分支已无冲突地 rebase 到 `origin/dev` 的 `3049b0c7be`。

## 验证

对 live-state 修复先加入 `rejects_enabled_and_active_*` 回归。在旧 setter 上，同一 focused 命令稳定得到 0/2 通过：两条路径都返回 `Ok(())`，与期望的 `InterruptEnabled` 不符；实现状态校验后，同一命令 2/2 通过。

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p arm-gic-driver`：15/15 通过
- `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER='qemu-aarch64 -L /usr/aarch64-linux-gnu' cargo test -p arm-gic-driver --target aarch64-unknown-linux-gnu`：29/29 通过
- `cargo check -p arm-gic-driver --target aarch64-unknown-none-softfloat --all-features`
- `cargo xtask clippy --package arm-gic-driver`：3/3 检查通过
- `cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress`：1/1 通过，输出 `AXVISOR_GICV3_ITS_TIMER_STRESS_PASSED`

AArch64 fake-MMIO 测试覆盖 capability、Group、Security state、affinity routing、未实现 SPI、enabled/active 拒绝、SGI/PPI/SPI 属性设置/清除/读回，以及包含 Aff3 的 Redistributor 匹配；现有 QEMU 用例用于确认普通 GICv3/ITS 路径没有回归。

## 范围与限制

本次不实现 Extended SPI/Extended PPI 的 INMIR、`ICC_NMIAR1_EL1` acknowledge、异常入口、优先级或端到端 NMI delivery。当前环境也没有实现 FEAT_GICv3_NMI 的真实 GICv3.3 硬件，因此属性寄存器语义由 fake-MMIO 覆盖，真实硬件 delivery 需要后续独立验证。

## 最新 review 修复（6f7c077e27）

- 新增 `drivers/intc/arm-gic-driver/examples/gicv3_nmi_attribute.rs`，在 AArch64 目标上编译真实的 `Gic::init`、`supports_nmi_attributes`、SPI disable、`set_nmi_attribute` 与 `nmi_attribute` 调用链；宿主入口不会访问 MMIO。
- README 与设计文档记录示例、驱动核心与 OS/platform glue 的责任边界。
- setter 与 getter rustdoc 统一说明初始化契约：两者都依赖 Distributor 初始化确认 Security state，SGI/PPI 还要求初始化当前 PE 的 Redistributor。
- 新增验证：
  - `cargo test -p arm-gic-driver --example gicv3_nmi_attribute`
  - `cargo check -p arm-gic-driver --example gicv3_nmi_attribute --target aarch64-unknown-linux-gnu`
  - `cargo clippy -p arm-gic-driver --example gicv3_nmi_attribute --target aarch64-unknown-linux-gnu -- -D warnings`
  - `cargo doc -p arm-gic-driver --target aarch64-unknown-linux-gnu --no-deps`
