### PR TITLE
fix(axvm): avoid machine lock during runtime notification

### DIFF
--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -183,7 +183,7 @@ fn drain_and_inject_dispatched_interrupts<A: ArchOps>(
     vcpu_id: usize,
     vcpu: &crate::vm::AxVCpuRef<A::VCpu>,
 ) {
-    let runtime = match vm.with_runtime(|runtime| Ok(runtime.clone())) {
+    let runtime = match vm.runtime_handle() {
         Ok(runtime) => runtime,
         Err(err) => {
             warn!(

--- a/virtualization/axvm/src/runtime/hvc.rs
+++ b/virtualization/axvm/src/runtime/hvc.rs
@@ -319,7 +319,8 @@ impl HyperCall {
                     .map(|task| task.vcpu.id())
                     .and_then(|vcpu_id| {
                         self.vm
-                            .with_runtime(|runtime| Ok(runtime.try_reserve_cpu_off(vcpu_id)))
+                            .runtime_handle()
+                            .map(|runtime| runtime.try_reserve_cpu_off(vcpu_id))
                             .ok()
                     })
                     .unwrap_or(false);
@@ -659,12 +660,10 @@ impl HyperCall {
                         detail: "IVC notify target VM does not exist".into(),
                     }
                 })?;
-                target_vm
-                    .with_runtime(|runtime| {
-                        runtime.notify_all();
-                        Ok(())
-                    })
+                let target_runtime = target_vm
+                    .runtime_handle()
                     .map_err(|error| self.operation_error("wake IVC notify target VM", error))?;
+                target_runtime.notify_all();
                 let target_devices = target_vm.get_devices().map_err(|error| {
                     self.operation_error("get IVC notify target devices", error)
                 })?;

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -116,10 +116,14 @@ pub fn start_vm(vm_id: usize) -> AxVmResult {
 pub fn notify_vm(vm_id: usize) -> AxVmResult {
     let vm = vm_by_id(vm_id)?;
     let vcpu_num = vm.vcpu_num();
-    vm.with_runtime(|runtime| {
-        notify_runtime_for_device_poll(runtime, vcpu_num);
-        Ok(())
-    })
+    // `WaitQueue::wait_until` evaluates the vCPU wake predicate while it
+    // holds both the wait-queue and run-queue locks. That predicate may read
+    // the VM lifecycle state and therefore lock `vm.machine`. Never retain
+    // `vm.machine` while notifying the same wait queue, or the notifier and a
+    // vCPU entering WFI can deadlock in opposite lock order.
+    let runtime = vm.runtime_handle()?;
+    notify_runtime_for_device_poll(&runtime, vcpu_num);
+    Ok(())
 }
 
 fn notify_runtime_for_device_poll(runtime: &crate::vm::VmRuntimeHandle, vcpu_num: usize) {

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -55,11 +55,9 @@ pub(crate) fn notify_primary_vcpu(vm_id: usize) {
         warn!("VM[{vm_id}] not found while notifying primary vCPU");
         return;
     };
-    if let Err(err) = vm.with_runtime(|runtime| {
-        runtime.notify_one();
-        Ok(())
-    }) {
-        warn!("VM[{vm_id}] vCPU runtime not found: {err:?}");
+    match vm.runtime_handle() {
+        Ok(runtime) => runtime.notify_one(),
+        Err(err) => warn!("VM[{vm_id}] vCPU runtime not found: {err:?}"),
     }
 }
 
@@ -71,10 +69,9 @@ pub(crate) fn notify_primary_vcpu(vm_id: usize) {
 /// * `vm_id` - The ID of the VM whose VCpus should be notified.
 pub(crate) fn notify_all_vcpus(vm_id: usize) {
     if let Some(vm) = crate::get_vm_by_id(vm_id) {
-        let _ = vm.with_runtime(|runtime| {
+        if let Ok(runtime) = vm.runtime_handle() {
             runtime.notify_all();
-            Ok(())
-        });
+        }
     }
 }
 
@@ -96,11 +93,9 @@ pub(crate) fn queue_pending_interrupt(
         ));
     }
 
-    let cpu_id = vm.with_runtime(|runtime| runtime.queue_pending_interrupt(vcpu_id, interrupt))?;
-    vm.with_runtime(|runtime| {
-        runtime.notify_all();
-        Ok(())
-    })?;
+    let runtime = vm.runtime_handle()?;
+    let cpu_id = runtime.queue_pending_interrupt(vcpu_id, interrupt)?;
+    runtime.notify_all();
     crate::host::task::send_ipi(cpu_id);
     Ok(())
 }
@@ -117,7 +112,7 @@ pub(crate) fn notify_vcpu(vm_id: usize, vcpu_id: usize) -> AxVmResult {
         ));
     }
 
-    let runtime = vm.with_runtime(|runtime| Ok(runtime.clone()))?;
+    let runtime = vm.runtime_handle()?;
     let cpu_id = runtime.vcpu_cpu_id(vcpu_id)?;
     runtime.notify_all();
     crate::host::task::send_ipi(cpu_id);
@@ -133,11 +128,11 @@ pub(crate) fn inject_pending_interrupts<A: Architecture>(
         warn!("VM[{vm_id}] not found, cannot drain VCpu[{vcpu_id}] interrupts");
         return;
     };
-    let Ok(interrupts) = vm.with_runtime(|runtime| Ok(runtime.drain_pending_interrupts(vcpu_id)))
-    else {
+    let Ok(runtime) = vm.runtime_handle() else {
         warn!("VM[{vm_id}] vCPU runtime not found, cannot drain VCpu[{vcpu_id}] interrupts");
         return;
     };
+    let interrupts = runtime.drain_pending_interrupts(vcpu_id);
 
     for interrupt in interrupts {
         A::inject_pending_interrupt(&vm, vcpu, interrupt);
@@ -157,7 +152,9 @@ pub(crate) fn inject_pending_interrupts<A: Architecture>(
 /// It will join all VCpu tasks to ensure they are fully cleaned up.
 pub(crate) fn cleanup_vm_vcpus(vm_id: usize) {
     if let Some(vm) = crate::get_vm_by_id(vm_id)
-        && let Err(err) = vm.with_runtime(|runtime| runtime.join_all_vcpu_tasks(vm_id))
+        && let Err(err) = vm
+            .runtime_handle()
+            .and_then(|runtime| runtime.join_all_vcpu_tasks(vm_id))
     {
         warn!("VM[{vm_id}] vCPU runtime cleanup skipped: {err:?}");
     }
@@ -165,10 +162,9 @@ pub(crate) fn cleanup_vm_vcpus(vm_id: usize) {
 
 /// Marks the VCpu of the specified VM as running.
 fn mark_vcpu_running(vm: &VMRef) {
-    let _ = vm.with_runtime(|runtime| {
+    if let Ok(runtime) = vm.runtime_handle() {
         runtime.mark_vcpu_running();
-        Ok(())
-    });
+    }
 }
 
 type CpuOnStartAckLock<T> = std::sync::Mutex<T>;
@@ -279,9 +275,7 @@ pub(crate) fn vcpu_on(
         .map_err(|_| VcpuOnError::OnPending)?;
 
     let start_result = (|| {
-        let runtime = vm
-            .with_runtime(|runtime| Ok(runtime.clone()))
-            .map_err(|_| VcpuOnError::StartFailed)?;
+        let runtime = vm.runtime_handle().map_err(|_| VcpuOnError::StartFailed)?;
         if runtime.has_vcpu_task(vcpu_id) {
             return Err(VcpuOnError::StartFailed);
         }
@@ -433,7 +427,7 @@ fn vcpu_run() {
     let vcpu = curr.as_vcpu_task().vcpu.clone();
     let vm_id = vm.id();
     let vcpu_id = vcpu.id();
-    let Ok(runtime) = vm.with_runtime(|runtime| Ok(runtime.clone())) else {
+    let Ok(runtime) = vm.runtime_handle() else {
         warn!("VM[{vm_id}] vCPU runtime not found, VCpu[{vcpu_id}] exiting");
         return;
     };

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -68,10 +68,10 @@ pub(crate) fn notify_primary_vcpu(vm_id: usize) {
 ///
 /// * `vm_id` - The ID of the VM whose VCpus should be notified.
 pub(crate) fn notify_all_vcpus(vm_id: usize) {
-    if let Some(vm) = crate::get_vm_by_id(vm_id) {
-        if let Ok(runtime) = vm.runtime_handle() {
-            runtime.notify_all();
-        }
+    if let Some(vm) = crate::get_vm_by_id(vm_id)
+        && let Ok(runtime) = vm.runtime_handle()
+    {
+        runtime.notify_all();
     }
 }
 

--- a/virtualization/axvm/src/vm/config_lock_tests.rs
+++ b/virtualization/axvm/src/vm/config_lock_tests.rs
@@ -170,7 +170,7 @@ fn with_config_remains_available_without_machine_resources() {
 }
 
 #[test]
-fn with_runtime_callback_runs_without_machine_lock() {
+fn runtime_handle_returns_without_machine_lock() {
     let runtime = Arc::new(VmRuntimeHandle::new());
     let vm = test_vm_with_machine(
         7,
@@ -181,13 +181,10 @@ fn with_runtime_callback_runs_without_machine_lock() {
         },
     );
 
-    vm.with_runtime(|runtime| {
-        assert!(
-            vm.machine.try_lock().is_some(),
-            "runtime callbacks must not run while holding the machine lock"
-        );
-        runtime.notify_all();
-        Ok(())
-    })
-    .unwrap();
+    let runtime = vm.runtime_handle().unwrap();
+    assert!(
+        vm.machine.try_lock().is_some(),
+        "runtime handle access must not retain the machine lock"
+    );
+    runtime.notify_all();
 }

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -195,6 +195,15 @@ pub(crate) fn wait_for_vcpu_event_if_idle(
     wait_until(&wake_condition);
 }
 
+fn clone_runtime_handle<R>(
+    machine: &Machine<R, Arc<VmRuntimeHandle>>,
+) -> AxVmResult<Arc<VmRuntimeHandle>> {
+    machine
+        .runtime()
+        .cloned()
+        .ok_or_else(|| ax_err_type!(BadState, "VM runtime is not available"))
+}
+
 pub(crate) fn dispatch_vcpu_interrupt_with(
     enqueue: impl FnOnce() -> AxVmResult<usize>,
     notify: impl FnOnce(),
@@ -968,14 +977,14 @@ impl WakeAccessPort for AxVmDeviceAccessPorts {
                 ),
             });
         }
-        vm.with_runtime(|runtime| {
-            runtime.notify_all();
-            Ok(())
-        })
-        .map_err(|error| axdevice::DeviceManagerError::InvalidState {
-            operation: "wake vCPU from device access",
-            detail: format!("{error}"),
-        })
+        let runtime =
+            vm.runtime_handle()
+                .map_err(|error| axdevice::DeviceManagerError::InvalidState {
+                    operation: "wake vCPU from device access",
+                    detail: format!("{error}"),
+                })?;
+        runtime.notify_all();
+        Ok(())
     }
 }
 
@@ -989,10 +998,9 @@ impl StopAccessPort for AxVmDeviceAccessPorts {
             operation: "request VM stop from device access",
             detail: format!("{error}"),
         })?;
-        if let Ok(()) = vm.with_runtime(|runtime| {
+        if let Ok(runtime) = vm.runtime_handle() {
             runtime.notify_all();
-            Ok(())
-        }) {}
+        }
         Ok(())
     }
 }
@@ -1135,22 +1143,16 @@ impl AxVM {
         }
     }
 
-    /// Runs a callback with a snapshot of the current runtime.
+    /// Returns an owned runtime handle without retaining the VM machine lock.
     ///
     /// The runtime is pinned by its `Arc`, but the lifecycle may advance after
-    /// the snapshot. The callback runs without the machine lock so runtime
-    /// wait-queue operations cannot invert the machine/wait-queue lock order.
-    pub(crate) fn with_runtime<F, R>(&self, f: F) -> AxVmResult<R>
-    where
-        F: FnOnce(&Arc<VmRuntimeHandle>) -> AxVmResult<R>,
-    {
-        let runtime = self
-            .machine
-            .lock()
-            .runtime()
-            .cloned()
-            .ok_or_else(|| ax_err_type!(BadState, "VM runtime is not available"))?;
-        f(&runtime)
+    /// this snapshot. Callers may enter scheduler, wait-queue, device, or
+    /// callback code only after this method returns. Keeping the machine lock
+    /// acquisition inside this accessor prevents runtime notifications from
+    /// accidentally running while `vm.machine` is held.
+    pub(crate) fn runtime_handle(&self) -> AxVmResult<Arc<VmRuntimeHandle>> {
+        let machine = self.machine.lock();
+        clone_runtime_handle(&machine)
     }
 
     #[cfg_attr(
@@ -1219,7 +1221,8 @@ impl AxVM {
     /// it must be read only as a monotone "a vCPU has entered" signal, not as an
     /// exact "still running" count.
     pub fn running_vcpu_count(&self) -> usize {
-        self.with_runtime(|runtime| Ok(runtime.running_halting_vcpu_count()))
+        self.runtime_handle()
+            .map(|runtime| runtime.running_halting_vcpu_count())
             .unwrap_or(0)
     }
 
@@ -1462,17 +1465,15 @@ impl AxVM {
                     wait_for_running_vm_quiesce(|| self.running_vcpu_count(), || self.stopping())?;
                 }
                 self.stop(reason)?;
-                if let Ok(()) = self.with_runtime(|runtime| {
+                if let Ok(runtime) = self.runtime_handle() {
                     runtime.notify_all();
-                    Ok(())
-                }) {}
+                }
                 self.wait_until_stopped()?;
             }
             VmStatus::Stopping => {
-                if let Ok(()) = self.with_runtime(|runtime| {
+                if let Ok(runtime) = self.runtime_handle() {
                     runtime.notify_all();
-                    Ok(())
-                }) {}
+                }
                 self.wait_until_stopped()?;
             }
             VmStatus::Stopped | VmStatus::Ready => {}
@@ -2094,6 +2095,151 @@ mod tests {
     };
 
     use super::*;
+
+    #[cfg(feature = "host-test")]
+    #[test]
+    fn runtime_snapshot_can_be_used_after_machine_lock_release() {
+        let runtime = Arc::new(VmRuntimeHandle::new());
+        let machine = IrqSafeMutex::new(Machine::Running {
+            resources: (),
+            runtime: runtime.clone(),
+        });
+
+        let snapshot = {
+            let machine = machine.lock();
+            clone_runtime_handle(&machine).unwrap()
+        };
+
+        let machine_guard = machine
+            .try_lock()
+            .expect("runtime snapshot must not retain the machine lock");
+        drop(machine_guard);
+        assert!(Arc::ptr_eq(&snapshot, &runtime));
+
+        let generation = snapshot.notification_generation();
+        snapshot.notify_all();
+        assert_ne!(snapshot.notification_generation(), generation);
+    }
+
+    #[cfg(feature = "host-test")]
+    #[test]
+    fn runtime_snapshot_selects_replacement_after_restart() {
+        let old_runtime = Arc::new(VmRuntimeHandle::new());
+        let new_runtime = Arc::new(VmRuntimeHandle::new());
+        let machine = IrqSafeMutex::new(Machine::Running {
+            resources: (),
+            runtime: old_runtime.clone(),
+        });
+
+        let old_snapshot = {
+            let machine = machine.lock();
+            clone_runtime_handle(&machine).unwrap()
+        };
+        {
+            let mut machine = machine.lock();
+            machine
+                .request_stop_with(StopReason::Forced, |_, _| Ok(()))
+                .unwrap();
+            machine.finish_stop().unwrap();
+            drop(machine.take_stopped_runtime().unwrap());
+            machine.reset_with(|_| Ok(())).unwrap();
+            machine.start_with(|_| Ok(new_runtime.clone())).unwrap();
+        }
+        let new_snapshot = {
+            let machine = machine.lock();
+            clone_runtime_handle(&machine).unwrap()
+        };
+
+        assert!(Arc::ptr_eq(&old_snapshot, &old_runtime));
+        assert!(Arc::ptr_eq(&new_snapshot, &new_runtime));
+        assert!(!Arc::ptr_eq(&old_snapshot, &new_snapshot));
+
+        let new_generation = new_snapshot.notification_generation();
+        old_snapshot.notify_all();
+        assert_eq!(new_snapshot.notification_generation(), new_generation);
+        new_snapshot.notify_all();
+        assert_ne!(new_snapshot.notification_generation(), new_generation);
+    }
+
+    #[cfg(feature = "host-test")]
+    #[test]
+    fn runtime_notification_does_not_form_machine_wait_queue_cycle() {
+        let runtime = Arc::new(VmRuntimeHandle::new());
+        let machine = Arc::new(IrqSafeMutex::new(Machine::Running {
+            resources: (),
+            runtime,
+        }));
+        let wait_queue_lock = Arc::new(std::sync::Mutex::new(()));
+        let (wfi_ready_tx, wfi_ready_rx) = std::sync::mpsc::channel();
+        let (snapshot_ready_tx, snapshot_ready_rx) = std::sync::mpsc::channel();
+        let (wfi_done_tx, wfi_done_rx) = std::sync::mpsc::channel();
+        let (notify_done_tx, notify_done_rx) = std::sync::mpsc::channel();
+
+        let wfi_machine = machine.clone();
+        let wfi_wait_queue_lock = wait_queue_lock.clone();
+        let wfi = std::thread::spawn(move || {
+            let wait_queue_guard = wfi_wait_queue_lock.lock().unwrap();
+            wfi_ready_tx.send(()).unwrap();
+            snapshot_ready_rx
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .expect("notifier did not finish the runtime snapshot");
+
+            let machine_guard = wfi_machine
+                .try_lock()
+                .expect("WFI could not acquire machine after notifier snapshot");
+            drop(machine_guard);
+            drop(wait_queue_guard);
+            wfi_done_tx.send(()).unwrap();
+        });
+
+        let notify_machine = machine.clone();
+        let notify_wait_queue_lock = wait_queue_lock.clone();
+        let notifier = std::thread::spawn(move || {
+            wfi_ready_rx
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .expect("WFI did not acquire the wait-queue lock");
+            let runtime = {
+                let machine = notify_machine.lock();
+                clone_runtime_handle(&machine).unwrap()
+            };
+            snapshot_ready_tx.send(()).unwrap();
+
+            let _wait_queue_guard = notify_wait_queue_lock.lock().unwrap();
+            runtime.notify_all();
+            notify_done_tx.send(()).unwrap();
+        });
+
+        wfi_done_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("WFI side stalled in the machine/wait-queue ordering test");
+        notify_done_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .expect("notifier stalled in the machine/wait-queue ordering test");
+        wfi.join().unwrap();
+        notifier.join().unwrap();
+    }
+
+    #[test]
+    fn legacy_runtime_closure_api_is_absent_from_axvm_call_sites() {
+        let forbidden = concat!("with_", "runtime");
+        let sources = [
+            ("vm/mod.rs", include_str!("mod.rs")),
+            ("runtime/mod.rs", include_str!("../runtime/mod.rs")),
+            ("runtime/hvc.rs", include_str!("../runtime/hvc.rs")),
+            ("runtime/vcpus.rs", include_str!("../runtime/vcpus.rs")),
+            (
+                "architecture/ops.rs",
+                include_str!("../architecture/ops.rs"),
+            ),
+        ];
+
+        for (path, source) in sources {
+            assert!(
+                !source.contains(forbidden),
+                "{path} reintroduced the legacy runtime closure API"
+            );
+        }
+    }
 
     #[test]
     fn write_guest_bytes_to_chunks_writes_only_remaining_bytes() {


### PR DESCRIPTION
## 背景

在 Orange Pi 5 Plus 上运行 StarryOS + Zephyr 双客户机真实业务时，AxVisor 会偶发停止推进。发生问题后，StarryOS、Zephyr 和 AxVisor 控制台均不再输出。

自然复现时最后的诊断计数为：

```text
AXVM_RUNTIME_LOCK_CYCLE_PRELOCK target_vm=2
notify=872/871
wfi_machine=121424/121423
```

外部持续观察后，通知计数和 WFI 计数始终无法重新配对，系统也不再产生新输出。

## 根因

问题由 `vm.machine` 与 vCPU WaitQueue/RunQueue 之间的反向锁序造成。

通知路径原来的锁序为：

```text
vm.machine
  -> VmRuntimeHandle::notify_*
  -> WaitQueue/RunQueue
```

vCPU 执行 WFI 时的锁序为：

```text
WaitQueue/RunQueue
  -> WFI wake predicate
  -> VM lifecycle state
  -> vm.machine
```

原来的 `with_runtime()` 会在持有 `vm.machine` 的情况下执行调用者闭包。调用者可以在闭包中执行 `notify_one()`、`notify_all()`、设备轮询唤醒或其他可能进入调度器、WaitQueue、RunQueue 的操作，因此能够形成：

```text
通知线程：vm.machine -> WaitQueue/RunQueue
WFI 线程：WaitQueue/RunQueue -> vm.machine
```

最终两个执行路径互相等待，造成全局停止推进。

## 解决方案

本 PR 删除 `with_runtime()` 闭包接口，增加 `AxVM::runtime_handle()`：

1. 在 `vm.machine` 临界区内只 clone `Arc<VmRuntimeHandle>`；
2. 立即释放 `vm.machine`；
3. 调用者取得拥有所有权的 runtime handle；
4. 在锁外执行通知、调度、设备或其他 runtime 操作。

新的基本调用方式为：

```rust
let runtime = vm.runtime_handle()?;
runtime.notify_all();
```

而不再允许：

```rust
vm.with_runtime(|runtime| {
    runtime.notify_all();
    Ok(())
})
```

这样从 API 结构上避免了在持有 `vm.machine` 时执行 runtime 通知。

## 覆盖范围

本 PR 已迁移所有现有 `with_runtime()` 使用点，包括：

- IVC HVC 目标客户机通知；
- 主 vCPU 和全部 vCPU 唤醒；
- 设备轮询通知；
- 待处理中断入队、注入及 IPI 唤醒；
- CPU_ON、CPU_OFF 和 vCPU 任务管理；
- 设备访问触发的 vCPU 唤醒；
- VM stop/reset 等生命周期唤醒；
- 架构相关中断分发；
- runtime 状态查询和资源清理。

`VmRuntimeHandle` 使用 `Arc` 管理生命周期，因此释放 `vm.machine` 后 runtime 对象仍然有效。VM 重启后，新的 `runtime_handle()` 会取得新 runtime；已经取得的旧 handle 只引用旧 runtime，不会误操作新的 runtime 实例。

本次修改不改变客户机 ABI、IVC ABI、设备配置或 VM 配置格式。

## 防止回归

增加了不依赖开发板的宿主回归测试：

### runtime handle 锁释放测试

验证 clone runtime handle 后不会继续持有 `vm.machine`，并且能够在锁外正常执行通知。

### VM 重启及 runtime 替换测试

模拟 VM stop/reset/start，验证：

- 重启前后取得不同的 runtime；
- 旧 handle 不会修改新 runtime；
- 新通知会发送给当前 runtime。

### 反向锁序并发测试

使用两个宿主线程模拟通知路径和 WFI 路径：

```text
WFI：持有测试 WaitQueue 锁 -> 获取 vm.machine
通知：获取并释放 vm.machine -> 获取测试 WaitQueue 锁
```

测试使用超时判定，不会在锁序回归时永久阻塞测试进程。

### 源码约束测试

检查当前 AxVM runtime 调用路径中没有重新引入 `with_runtime()` 闭包接口。

删除闭包接口也意味着以后新增通知路径时，只能先取得拥有所有权的 runtime handle，再执行通知，降低重新引入相同错误的风险。

## 验证结果

宿主测试：

```text
299 passed
0 failed
```

同时通过：

```text
cargo fmt --all -- --check
git diff --check
cargo test -p axvm --features host-test --quiet
```

Orange Pi 5 Plus StarryOS + Zephyr 双客户机 AArch64 release 构建通过。

在带诊断的真实双客户机负载中，修复后通知和 WFI 持续推进并最终重新配对：

```text
notify=3822/3822
wfi_machine=528605/528605
```

需要注意，单次出现 `CYCLE_PRELOCK` 只表示两个路径进入了同一个竞争窗口，不等于已经死锁。修复版本也可能短暂出现入口和出口计数不一致。

正确的失败判定条件是：

- notify 入口/出口持续不配对；
- WFI 入口/出口持续不配对；
- StarryOS、Zephyr 和 AxVisor 均不再推进；
- 外部超时后仍无新输出。

修复后即使进入相同竞争窗口，计数也能够重新配对并继续推进。

诊断计数和测试专用 WFI 延时钩子均未保留在生产代码中。

## 为什么该修复完整解决当前问题

本 PR 消除了形成该死锁所必需的：

```text
vm.machine -> WaitQueue/RunQueue
```

通知侧锁依赖。

所有当前 runtime 通知路径均已迁移，并且原有 `with_runtime()` 接口已经删除。因此，当前已知的通知路径无法再通过该接口持有 `vm.machine` 进入 WaitQueue、RunQueue、设备回调或调度器。

这解决了已经自然复现并完成根因定位的 runtime 通知/WFI 反向锁序问题。

## 后续 WFI 优化

当前修复从通知侧打断锁环，已经足以消除本次死锁。

后续可以进一步优化 WFI 生命周期判断，让 WFI wake predicate 读取原子发布的生命周期状态，而不再获取 `vm.machine`：

```text
当前：
WaitQueue/RunQueue -> vm.machine

后续：
WaitQueue/RunQueue -> atomic lifecycle state
```

完成后，可以从根源上进一步消除 WFI 路径中的：

```text
WaitQueue/RunQueue -> vm.machine
```

锁依赖。

建议将该优化作为独立 PR 实施，因为它需要额外处理：

- Running、Stopping、Stopped、Resetting 等状态的原子发布；
- machine 状态更新与原子状态之间的内存顺序；
- stop/reset/start 并发语义；
- WFI 进入与通知之间的 lost-wakeup 边界；
- VM 重启时旧 runtime 与新 runtime 的状态切换；
- 多 vCPU 生命周期并发测试。

该优化属于进一步简化 WFI 锁依赖和并发模型，不是本次死锁修复正确性的前置条件。