### PR TITLE
feat(ax-fs-ng): add shared block cache between block and filesystem layers

### DIFF
--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -158,6 +158,7 @@ id = "test-axloader-http-smoke"
 impact_packages = ["axloader"]
 name = "UEFI x86_64 · AxLoader HTTP boot"
 runner = "kvm-intel"
+# Cold runners may spend most of the original 45-minute budget on checkout and builds.
 timeout_minutes = 90
 command = '''
 rustup target add x86_64-unknown-uefi

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -158,7 +158,7 @@ id = "test-axloader-http-smoke"
 impact_packages = ["axloader"]
 name = "UEFI x86_64 · AxLoader HTTP boot"
 runner = "kvm-intel"
-timeout_minutes = 25
+timeout_minutes = 45
 command = '''
 rustup target add x86_64-unknown-uefi
 cargo xtask axloader test qemu --target x86_64-unknown-uefi
@@ -239,7 +239,7 @@ id = "test-axvisor-self-hosted-board-asus-nuc15crh-linux"
 impact_targets = ["axvisor:x86_64"]
 name = "Board ASUS NUC15CRH · Linux guest"
 runner = "board"
-timeout_minutes = 20
+timeout_minutes = 45
 command = '''
 mkdir -p tmp
 cargo xtask image pull qemu-x86_64 --extract-dir tmp

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -158,7 +158,7 @@ id = "test-axloader-http-smoke"
 impact_packages = ["axloader"]
 name = "UEFI x86_64 · AxLoader HTTP boot"
 runner = "kvm-intel"
-timeout_minutes = 45
+timeout_minutes = 90
 command = '''
 rustup target add x86_64-unknown-uefi
 cargo xtask axloader test qemu --target x86_64-unknown-uefi

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -169,7 +169,7 @@ id = "test-axvisor-x86-64-acpi-direct-and-ovmf-boot-vmx"
 impact_targets = ["axvisor:x86_64"]
 name = "VMX x86_64 · Direct + MP fallback + OVMF ACPI"
 runner = "kvm-intel"
-timeout_minutes = 45
+timeout_minutes = 90
 command = '''
 cargo xtask image pull qemu-x86_64 --extract-dir tmp/axbuild/images
 cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-vmx

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "dma-api",
+ "hashbrown 0.16.1",
  "intrusive-collections",
  "irq-framework",
  "log",

--- a/apps/starry/block-io-bench/README.md
+++ b/apps/starry/block-io-bench/README.md
@@ -39,25 +39,45 @@ wrapper into a managed Alpine rootfs. The wrapper runs several benchmark rounds
 and prints machine-readable log lines:
 
 ```text
-BLOCK_BENCH_CONFIG path=/root/block-io-bench-app rounds=5 bytes=4194304 block_bytes=4096 fsync=1 io_model=buffered-file write_scope=write-syscalls cache_drop=none diskstats_device=nvme0n1
+BLOCK_BENCH_CONFIG path=/root/block-io-bench-app rounds=5 bytes=4194304 block_bytes=4096 fsync=1 io_model=buffered-file write_scope=write-syscalls cache_drop=none verification=bytewise+checksum coherence=truncate-rewrite-cross-fd diskstats_device=nvme0n1
 BLOCK_BENCH_DISKSTATS round=0 phase=write device=nvme0n1 reads=... sectors_read=... writes=... sectors_written=...
 BLOCK_BENCH_DISKSTATS round=0 phase=fsync device=nvme0n1 reads=... sectors_read=... writes=... sectors_written=...
 BLOCK_BENCH_ROUND op=write round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
 BLOCK_BENCH_ROUND op=fsync round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
 BLOCK_BENCH_ROUND op=read round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
+BLOCK_BENCH_VERIFY round=0 phase=initial-read expected_checksum=... actual_checksum=... status=pass
+BLOCK_BENCH_VERIFY round=0 phase=truncate-rewrite-cross-fd generation=32 expected_checksum=... actual_checksum=... status=pass
+BLOCK_BENCH_ROUND op=coherence-rewrite round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
+BLOCK_BENCH_ROUND op=coherence-read round=0 bytes=4194304 elapsed_us=... mib_s=... checksum=...
 BLOCK_BENCH_RESULT op=write round=5 bytes=4194304 elapsed_us=... mib_s=... checksum=...
 BLOCK_BENCH_RESULT op=fsync round=5 bytes=4194304 elapsed_us=... mib_s=... checksum=...
 BLOCK_BENCH_RESULT op=read round=5 bytes=4194304 elapsed_us=... mib_s=... checksum=...
+BLOCK_BENCH_RESULT op=coherence-rewrite round=5 bytes=4194304 elapsed_us=... mib_s=... checksum=...
+BLOCK_BENCH_RESULT op=coherence-read round=5 bytes=4194304 elapsed_us=... mib_s=... checksum=...
 BLOCK_BENCH_APP_PASSED
 ```
 
-The `BLOCK_BENCH_RESULT` lines report the median elapsed time across all rounds.
+The `BLOCK_BENCH_RESULT` lines report the median elapsed time across all rounds;
+their checksum is the verified checksum from the round that supplied that
+median sample.
 `write` measures buffered write syscalls and `fsync` measures durability
-separately. The helper does not explicitly drop caches before `read`, but that
-does not imply a cache hit: `BLOCK_BENCH_DISKSTATS` identifies which phase
-actually reached the block runtime. Linux and StarryOS results must only be
-compared when their request/sector deltas describe the same I/O. The default
-workload uses five rounds, a 4 MiB file per round, and 4 KiB I/O blocks.
+separately. Every read is checked byte-for-byte against the deterministic write
+pattern, and the expected and observed checksums must also match before the app
+can print its pass marker.
+
+Each round then keeps a read-only file descriptor open while another descriptor
+truncates the same inode and rewrites all blocks in reverse order with a new
+generation. After the optional `fsync`, the original descriptor must observe
+the new size and contents. The `coherence-rewrite` and `coherence-read` medians
+therefore measure a repeatable cross-descriptor cache-coherence workload while
+the `BLOCK_BENCH_VERIFY` lines turn stale reads, lost writes, incorrect truncate
+state, and block-order corruption into hard failures.
+
+The helper does not explicitly drop caches before `read`, but that does not
+imply a cache hit: `BLOCK_BENCH_DISKSTATS` identifies which phase actually
+reached the block runtime. Linux and StarryOS results must only be compared when
+their request/sector deltas describe the same I/O. The default workload uses
+five rounds, a 4 MiB file per round, and 4 KiB I/O blocks.
 Override these from the QEMU shell environment when needed:
 
 ```sh

--- a/apps/starry/block-io-bench/block-io-bench.c
+++ b/apps/starry/block-io-bench/block-io-bench.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -14,6 +15,8 @@
 #define DEFAULT_BLOCK_BYTES (4ULL * 1024ULL)
 #define DEFAULT_ROUNDS 5U
 #define MAX_ROUNDS 32U
+#define FNV1A_OFFSET_BASIS 14695981039346656037ULL
+#define FNV1A_PRIME 1099511628211ULL
 
 struct bench_config {
     const char *base_path;
@@ -25,11 +28,18 @@ struct bench_config {
 
 struct bench_sample {
     uint64_t elapsed_us;
+    uint64_t checksum;
 };
 
 struct write_sample {
     uint64_t write_us;
     uint64_t fsync_us;
+};
+
+struct coherence_sample {
+    uint64_t rewrite_us;
+    uint64_t read_us;
+    uint64_t checksum;
 };
 
 struct disk_counters {
@@ -230,12 +240,28 @@ static void fill_buffer(uint8_t *buf, size_t len, unsigned round, uint64_t offse
     }
 }
 
-static uint64_t checksum_buffer(const uint8_t *buf, size_t len) {
-    uint64_t sum = 0;
+static void verify_buffer(const uint8_t *buf, size_t len, unsigned generation, uint64_t offset,
+                          const char *phase) {
     for (size_t i = 0; i < len; i++) {
-        sum += buf[i];
+        uint8_t expected =
+            (uint8_t)(((offset + i) * 131ULL + (uint64_t)generation * 17ULL) & 0xffU);
+        if (buf[i] != expected) {
+            fprintf(stderr,
+                    "BLOCK_BENCH_MISMATCH phase=%s generation=%u offset=%llu expected=%u "
+                    "actual=%u\n",
+                    phase, generation, (unsigned long long)(offset + i), (unsigned)expected,
+                    (unsigned)buf[i]);
+            exit(1);
+        }
     }
-    return sum;
+}
+
+static uint64_t checksum_update(uint64_t checksum, const uint8_t *buf, size_t len) {
+    for (size_t i = 0; i < len; i++) {
+        checksum ^= buf[i];
+        checksum *= FNV1A_PRIME;
+    }
+    return checksum;
 }
 
 static void checked_write_all(int fd, const uint8_t *buf, size_t len) {
@@ -267,6 +293,13 @@ static void checked_read_all(int fd, uint8_t *buf, size_t len) {
             exit(1);
         }
         done += (size_t)ret;
+    }
+}
+
+static void checked_seek(int fd, uint64_t offset) {
+    if (offset > (uint64_t)INT64_MAX || lseek(fd, (off_t)offset, SEEK_SET) < 0) {
+        perror("lseek");
+        exit(1);
     }
 }
 
@@ -310,7 +343,7 @@ static void bench_path(char *path, size_t len, const char *base_path, unsigned r
 
 static struct write_sample run_write_round(const struct bench_config *config, uint8_t *buf,
                                            unsigned round, const char *path,
-                                           const struct disk_probe *probe) {
+                                           const struct disk_probe *probe, uint64_t *checksum) {
     int fd = open(path, O_CREAT | O_TRUNC | O_RDWR, 0644);
     if (fd < 0) {
         perror("open write");
@@ -327,8 +360,10 @@ static struct write_sample run_write_round(const struct bench_config *config, ui
         read_disk_counters(probe->device, &before_write);
     }
     uint64_t write_start = now_us();
+    *checksum = FNV1A_OFFSET_BASIS;
     for (uint64_t done = 0; done < config->bytes; done += config->block_bytes) {
         fill_buffer(buf, config->block_bytes, round, done);
+        *checksum = checksum_update(*checksum, buf, config->block_bytes);
         checked_write_all(fd, buf, config->block_bytes);
     }
     uint64_t write_end = now_us();
@@ -363,7 +398,7 @@ static struct write_sample run_write_round(const struct bench_config *config, ui
 }
 
 static uint64_t run_read_round(const struct bench_config *config, uint8_t *buf, unsigned round,
-                               const char *path, uint64_t *checksum,
+                               const char *path, uint64_t expected_checksum, uint64_t *checksum,
                                const struct disk_probe *probe) {
     int fd = open(path, O_RDONLY);
     if (fd < 0) {
@@ -380,9 +415,11 @@ static uint64_t run_read_round(const struct bench_config *config, uint8_t *buf, 
         read_disk_counters(probe->device, &before_read);
     }
     uint64_t start = now_us();
+    *checksum = FNV1A_OFFSET_BASIS;
     for (uint64_t done = 0; done < config->bytes; done += config->block_bytes) {
         checked_read_all(fd, buf, config->block_bytes);
-        *checksum += checksum_buffer(buf, config->block_bytes);
+        verify_buffer(buf, config->block_bytes, round, done, "initial-read");
+        *checksum = checksum_update(*checksum, buf, config->block_bytes);
     }
     uint64_t end = now_us();
     if (probe->available) {
@@ -394,7 +431,121 @@ static uint64_t run_read_round(const struct bench_config *config, uint8_t *buf, 
         exit(1);
     }
     print_disk_delta(probe, round, "read", &before_read, &after_read);
+    if (*checksum != expected_checksum) {
+        fprintf(stderr,
+                "BLOCK_BENCH_MISMATCH phase=initial-checksum round=%u expected=%llu actual=%llu\n",
+                round, (unsigned long long)expected_checksum, (unsigned long long)*checksum);
+        exit(1);
+    }
+    printf("BLOCK_BENCH_VERIFY round=%u phase=initial-read expected_checksum=%llu "
+           "actual_checksum=%llu status=pass\n",
+           round, (unsigned long long)expected_checksum, (unsigned long long)*checksum);
+    fflush(stdout);
     return end - start;
+}
+
+static struct coherence_sample run_coherence_round(const struct bench_config *config,
+                                                   uint8_t *buf, unsigned round,
+                                                   const char *path,
+                                                   const struct disk_probe *probe) {
+    unsigned generation = round + MAX_ROUNDS;
+    int observer = open(path, O_RDONLY);
+    if (observer < 0) {
+        perror("open coherence observer");
+        exit(1);
+    }
+    int writer = open(path, O_WRONLY | O_TRUNC);
+    if (writer < 0) {
+        perror("open coherence writer");
+        exit(1);
+    }
+
+    printf("BLOCK_BENCH_PROGRESS phase=coherence-rewrite round=%u path=%s\n", round, path);
+    fflush(stdout);
+    struct disk_counters before_rewrite = {0};
+    struct disk_counters after_rewrite = {0};
+    struct disk_counters after_read = {0};
+    if (probe->available) {
+        read_disk_counters(probe->device, &before_rewrite);
+    }
+
+    uint64_t expected_checksum = FNV1A_OFFSET_BASIS;
+    for (uint64_t done = 0; done < config->bytes; done += config->block_bytes) {
+        fill_buffer(buf, config->block_bytes, generation, done);
+        expected_checksum = checksum_update(expected_checksum, buf, config->block_bytes);
+    }
+    uint64_t rewrite_start = now_us();
+    for (uint64_t remaining = config->bytes; remaining != 0;
+         remaining -= config->block_bytes) {
+        uint64_t offset = remaining - config->block_bytes;
+        fill_buffer(buf, config->block_bytes, generation, offset);
+        checked_seek(writer, offset);
+        checked_write_all(writer, buf, config->block_bytes);
+    }
+    if (config->fsync_enabled && fsync(writer) != 0) {
+        perror("fsync coherence writer");
+        exit(1);
+    }
+    uint64_t rewrite_end = now_us();
+    if (close(writer) != 0) {
+        perror("close coherence writer");
+        exit(1);
+    }
+    if (probe->available) {
+        read_disk_counters(probe->device, &after_rewrite);
+    }
+
+    struct stat metadata;
+    if (fstat(observer, &metadata) != 0) {
+        perror("fstat coherence observer");
+        exit(1);
+    }
+    if (metadata.st_size < 0 || (uint64_t)metadata.st_size != config->bytes) {
+        fprintf(stderr,
+                "BLOCK_BENCH_MISMATCH phase=coherence-size round=%u expected=%llu actual=%lld\n",
+                round, (unsigned long long)config->bytes, (long long)metadata.st_size);
+        exit(1);
+    }
+
+    printf("BLOCK_BENCH_PROGRESS phase=coherence-read round=%u path=%s\n", round, path);
+    fflush(stdout);
+    checked_seek(observer, 0);
+    uint64_t actual_checksum = FNV1A_OFFSET_BASIS;
+    uint64_t read_start = now_us();
+    for (uint64_t done = 0; done < config->bytes; done += config->block_bytes) {
+        checked_read_all(observer, buf, config->block_bytes);
+        verify_buffer(buf, config->block_bytes, generation, done, "coherence-read");
+        actual_checksum = checksum_update(actual_checksum, buf, config->block_bytes);
+    }
+    uint64_t read_end = now_us();
+    if (close(observer) != 0) {
+        perror("close coherence observer");
+        exit(1);
+    }
+    if (probe->available) {
+        read_disk_counters(probe->device, &after_read);
+    }
+    print_disk_delta(probe, round, "coherence-rewrite", &before_rewrite, &after_rewrite);
+    print_disk_delta(probe, round, "coherence-read", &after_rewrite, &after_read);
+
+    if (actual_checksum != expected_checksum) {
+        fprintf(stderr,
+                "BLOCK_BENCH_MISMATCH phase=coherence-checksum round=%u expected=%llu "
+                "actual=%llu\n",
+                round, (unsigned long long)expected_checksum, (unsigned long long)actual_checksum);
+        exit(1);
+    }
+    printf("BLOCK_BENCH_VERIFY round=%u phase=truncate-rewrite-cross-fd generation=%u "
+           "expected_checksum=%llu actual_checksum=%llu status=pass\n",
+           round, generation, (unsigned long long)expected_checksum,
+           (unsigned long long)actual_checksum);
+    fflush(stdout);
+
+    return (struct coherence_sample){
+        .rewrite_us = rewrite_end - rewrite_start,
+        .read_us = read_end - read_start,
+        .checksum = actual_checksum,
+    };
 }
 
 int main(int argc, char **argv) {
@@ -408,6 +559,7 @@ int main(int argc, char **argv) {
     struct disk_probe probe = discover_root_disk();
     printf("BLOCK_BENCH_CONFIG path=%s rounds=%u bytes=%llu block_bytes=%zu fsync=%d "
            "io_model=buffered-file write_scope=write-syscalls cache_drop=none "
+           "verification=bytewise+checksum coherence=truncate-rewrite-cross-fd "
            "diskstats_device=%s\n",
            config.base_path, config.rounds, (unsigned long long)config.bytes, config.block_bytes,
            config.fsync_enabled, probe.available ? probe.device : "unresolved");
@@ -416,40 +568,63 @@ int main(int argc, char **argv) {
     struct bench_sample write_samples[MAX_ROUNDS];
     struct bench_sample fsync_samples[MAX_ROUNDS];
     struct bench_sample read_samples[MAX_ROUNDS];
-    uint64_t checksum = 0;
-
+    struct bench_sample coherence_rewrite_samples[MAX_ROUNDS];
+    struct bench_sample coherence_read_samples[MAX_ROUNDS];
     for (unsigned round = 0; round < config.rounds; round++) {
         char path[256];
         bench_path(path, sizeof(path), config.base_path, round);
         unlink(path);
 
-        struct write_sample write = run_write_round(&config, buf, round, path, &probe);
-        write_samples[round].elapsed_us = write.write_us;
-        fsync_samples[round].elapsed_us = write.fsync_us;
-        print_speed("BLOCK_BENCH_ROUND", "write", round, config.bytes, write.write_us, checksum);
+        uint64_t expected_checksum = 0;
+        struct write_sample write =
+            run_write_round(&config, buf, round, path, &probe, &expected_checksum);
+        write_samples[round] = (struct bench_sample){write.write_us, expected_checksum};
+        fsync_samples[round] = (struct bench_sample){write.fsync_us, expected_checksum};
+        print_speed("BLOCK_BENCH_ROUND", "write", round, config.bytes, write.write_us,
+                    expected_checksum);
         if (config.fsync_enabled) {
             print_speed("BLOCK_BENCH_ROUND", "fsync", round, config.bytes, write.fsync_us,
-                        checksum);
+                        expected_checksum);
         }
 
-        uint64_t read_us = run_read_round(&config, buf, round, path, &checksum, &probe);
-        read_samples[round].elapsed_us = read_us;
-        print_speed("BLOCK_BENCH_ROUND", "read", round, config.bytes, read_us, checksum);
+        uint64_t read_checksum = 0;
+        uint64_t read_us = run_read_round(&config, buf, round, path, expected_checksum,
+                                          &read_checksum, &probe);
+        read_samples[round] = (struct bench_sample){read_us, read_checksum};
+        print_speed("BLOCK_BENCH_ROUND", "read", round, config.bytes, read_us, read_checksum);
 
+        struct coherence_sample coherence =
+            run_coherence_round(&config, buf, round, path, &probe);
+        coherence_rewrite_samples[round] =
+            (struct bench_sample){coherence.rewrite_us, coherence.checksum};
+        coherence_read_samples[round] =
+            (struct bench_sample){coherence.read_us, coherence.checksum};
+        print_speed("BLOCK_BENCH_ROUND", "coherence-rewrite", round, config.bytes,
+                    coherence.rewrite_us, coherence.checksum);
+        print_speed("BLOCK_BENCH_ROUND", "coherence-read", round, config.bytes,
+                    coherence.read_us, coherence.checksum);
         unlink(path);
     }
 
     struct bench_sample write_median = median_sample(write_samples, config.rounds);
     struct bench_sample read_median = median_sample(read_samples, config.rounds);
     print_speed("BLOCK_BENCH_RESULT", "write", config.rounds, config.bytes,
-                write_median.elapsed_us, checksum);
+                write_median.elapsed_us, write_median.checksum);
     if (config.fsync_enabled) {
         struct bench_sample fsync_median = median_sample(fsync_samples, config.rounds);
         print_speed("BLOCK_BENCH_RESULT", "fsync", config.rounds, config.bytes,
-                    fsync_median.elapsed_us, checksum);
+                    fsync_median.elapsed_us, fsync_median.checksum);
     }
     print_speed("BLOCK_BENCH_RESULT", "read", config.rounds, config.bytes,
-                read_median.elapsed_us, checksum);
+                read_median.elapsed_us, read_median.checksum);
+    struct bench_sample coherence_rewrite_median =
+        median_sample(coherence_rewrite_samples, config.rounds);
+    struct bench_sample coherence_read_median =
+        median_sample(coherence_read_samples, config.rounds);
+    print_speed("BLOCK_BENCH_RESULT", "coherence-rewrite", config.rounds, config.bytes,
+                coherence_rewrite_median.elapsed_us, coherence_rewrite_median.checksum);
+    print_speed("BLOCK_BENCH_RESULT", "coherence-read", config.rounds, config.bytes,
+                coherence_read_median.elapsed_us, coherence_read_median.checksum);
 
     free(buf);
     return 0;

--- a/docs/design/shared-block-cache.md
+++ b/docs/design/shared-block-cache.md
@@ -1,0 +1,347 @@
+# Shared Block Cache
+
+Status: proposed for PR [#2171](https://github.com/rcore-os/tgoskits/pull/2171).
+
+## Problem
+
+`ax-fs-ng` previously passed filesystem block requests directly to the block
+runtime while `rsext4` kept a small private block cache. That arrangement had
+three problems:
+
+1. two filesystem instances or partitions backed by the same physical device
+   could not share one authoritative cached view;
+2. cache writeback, runtime-direct I/O, journal ownership, and global sync had
+   no common coherence boundary;
+3. the private cache duplicated block-device state while providing neither a
+   bounded per-device reclaim policy nor a device-wide flush operation.
+
+The users of this feature are the `ax-fs-ng` ext4 and FAT adapters, `rsext4`
+metadata and journal paths, allocator reclaim, filesystem shutdown, and the
+StarryOS durability syscalls that reach these layers.
+
+## Success Criteria
+
+- Every live filesystem consumer of one runtime block-device handle resolves
+  to one cache tree.
+- Small metadata-shaped requests use bounded deferred writeback, while large
+  requests can remain device-direct without returning stale cached bytes.
+- A direct write that reports an indeterminate partial failure cannot leave an
+  overlapping cached folio authoritative.
+- Journal descriptor, data, flush barrier, and commit-record ordering remains
+  unchanged when writes are deferred.
+- Global sync and last-consumer teardown attempt all reachable dirty cache
+  trees without extending device lifetime indefinitely.
+- Allocation, geometry, registry, writeback, and device failures remain typed
+  and observable at kernel boundaries.
+- Deterministic host tests cover shared views, partition offsets, partial I/O
+  failure, writeback retry, reclaim, registry teardown, and journal re-editing;
+  the block benchmark verifies content across independent file descriptors.
+
+## Necessity Evidence
+
+At base commit `1d7bfd75492669a0dd09e8ff762d1edbe694c508`,
+`fs/rsext4/src/blockdev/cached_device.rs` owns a four-entry private clock cache,
+while `fs/ax-fs-ng/src/block.rs` exposes direct runtime-backed devices. There is
+no device-wide cache identity or invalidation operation. A concrete failure
+sequence is:
+
+1. one filesystem wrapper reads block 0 and retains its old bytes;
+2. another request performs a 16-block device-direct write;
+3. the device commits the first eight blocks and reports an error for the
+   aggregate request;
+4. a later one-block read returns the old cached block 0 unless the failed
+   request invalidates its whole overlap.
+
+`failed_direct_write_invalidates_partially_updated_folios` reproduces this with
+a deterministic device mock. Before invalidation it returns zero-filled cache
+bytes even though storage contains the new pattern. The related runtime test
+holds a second submitted window incomplete and proves that returning after the
+first failed window would let a caller repopulate the invalidated range before
+all hardware writes become terminal.
+
+Keeping the prior design leaves this stale-read class unresolved whenever
+buffered metadata-shaped traffic and multi-folio direct traffic share a
+device. Adding independent caches to each filesystem would preserve the same
+cross-cache race and duplicate the required writeback/error state machine.
+
+## Non-goals
+
+- Replacing the file page cache or implementing Linux writeback scheduling.
+- Adding asynchronous `FsBlockDevice` methods or per-folio wait queues.
+- Changing the on-disk ext4/JBD2 format or commit sequence.
+- Guaranteeing durability from `sync_file_range(2)`, which Linux also defines
+  as a range writeback interface rather than a complete storage barrier.
+- Correcting StarryOS's pre-existing root-only filesystem-metadata scope for
+  `sync(2)`. This PR adds a device-wide block-cache stage and fixes the return
+  ABI; iterating every mounted filesystem requires a separate mount-registry
+  change and multi-mount persistence test.
+- Hiding an invalid cache geometry or resource failure by silently falling
+  back to an uncached device, except for the existing `InvalidRequest`
+  compatibility boundary.
+
+## Reference Model
+
+The design is compared against Linux v7.1 commit
+[`8cd9520d35a6c38db6567e97dd93b1f11f185dc6`](https://github.com/torvalds/linux/commit/8cd9520d35a6c38db6567e97dd93b1f11f185dc6):
+
+- [`fs/buffer.c`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/fs/buffer.c)
+  supplies the `buffer_head` uptodate/dirty and synchronous writeback model;
+- [`block/bdev.c`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/block/bdev.c)
+  supplies the one-address-space-per-block-device ownership model;
+- [`fs/sync.c`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/fs/sync.c#L97-L113)
+  supplies the best-effort global `sync(2)` rule, including its unconditional
+  successful syscall return;
+- [`block/fops.c`](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/block/fops.c)
+  supplies the aggregate direct-I/O rule that submitted work reaches terminal
+  completion before the synchronous caller returns.
+
+TGOSKits borrows these ownership and coherence rules, not Linux's background
+flusher implementation. The current block boundary is synchronous and has no
+observable writeback state, so each device uses one sleepable tree lock and
+per-operation synchronous writeback.
+
+Linux `sync(2)` iterates every superblock before syncing block devices. StarryOS
+currently syncs only its root filesystem metadata before the new device-wide
+cache stage. This document does not claim parity for that pre-existing mount
+scope limitation; it uses Linux here for block-cache ownership, direct-I/O
+completion, ordering, and the syscall's unconditional return value.
+
+## Internal Prior Art and Overlap
+
+The base and history checks for this design cover:
+
+- the private `rsext4` clock cache in
+  `fs/rsext4/src/blockdev/cached_device.rs` and its journal adapter;
+- the existing file page cache and reclaim boundary under
+  `fs/ax-fs-ng/src/file/cache`;
+- the owned block runtime lifecycle under
+  `fs/ax-fs-ng/src/block/runtime`, stabilized by commit `f96452ce89`;
+- reclaim lock-order work from commit `2da2bb4d19` and PR
+  [#2170](https://github.com/rcore-os/tgoskits/pull/2170);
+- prior `rsext4` cache changes `d974c5ae817cb5b4f810d97cd248d676d7cd6aea`
+  and `631f0449e4cc80557e4abec75eae64b4be6e03bb`;
+- the originally introduced private cache and replay invalidation in PR
+  [#971](https://github.com/rcore-os/tgoskits/pull/971).
+
+No base symbol provides `sync_all_block_caches`, a shared physical-LBA cache,
+or a cross-wrapper direct-I/O coherence boundary. The selected design replaces
+the private device cache rather than stacking another cache below it. The open
+PR relationships with #2015 and #1957 are classified under Migration and
+Rollback because they overlap implementation and ownership but do not already
+provide this exact shared boundary.
+
+## Alternatives
+
+### Keep the existing private `rsext4` cache
+
+This is the smallest change, but FAT and other consumers remain uncached and
+two filesystem instances over one device retain independent views. It also
+cannot provide one device-wide sync or reclaim boundary. This option is
+rejected because it does not meet the shared-view success criterion.
+
+### Add a cache to every filesystem adapter
+
+Per-filesystem caches preserve local ownership, but duplicate geometry,
+writeback, error, and eviction logic. Partitions sharing a runtime device would
+still require a second cross-cache invalidation protocol. This option is
+rejected because it moves the same coherence problem to a more complex layer.
+
+### Share a cache at the runtime block-device boundary
+
+This is the selected option. The runtime handle supplies a stable device
+identity, filesystem adapters already cross `FsBlockDevice`, and one tree can
+coordinate buffered and direct requests before they reach hardware. The cost
+is a new shared lifecycle and lock boundary, which is kept inside `ax-fs-ng`
+and documented below.
+
+### Cache all requests
+
+Making large file-data I/O populate the block cache would duplicate the file
+page cache and increase memory traffic. The selected split buffers requests
+contained within one folio and leaves multi-folio requests direct. This is a
+request-shape approximation of Linux's metadata/data split and can be replaced
+later without changing the registry or `FsBlockDevice` API.
+
+## Layering and Dependency Direction
+
+- `rdif-block` and hardware drivers remain unaware of filesystem caches.
+- `ax-fs-ng::block::runtime` owns request planning, DMA, submission windows,
+  terminal completion, barriers, and device handles.
+- `ax-fs-ng::block::cache` wraps `FsBlockDevice`, owns folios and the per-device
+  registry, and depends only on the synchronous block capability.
+- ext4 and FAT adapters consume the wrapper but do not reach into cache state.
+- `rsext4` keeps journal and metadata ownership; it hands block traffic to the
+  wrapper and never depends on `ax-fs-ng` cache types.
+- StarryOS calls the exported device-wide sync operation after its page-cache
+  and filesystem stages; cache types do not depend on StarryOS.
+
+No new crate or reverse dependency is introduced.
+
+## Ownership and Lifetime
+
+The registry is keyed by the allocation identity of a live
+`BlockDeviceHandle`. A live `BlockCacheShared` owns:
+
+- a weakly registered identity entry;
+- one bounded `BlockAddressSpace`;
+- one equivalent endpoint for global writeback;
+- an atomic count of filesystem wrappers, excluding temporary global-sync
+  references.
+
+Wrappers share the tree but retain their own region mapping. Partition offsets
+are applied before cache lookup, so the key space is physical LBA, not
+partition-relative LBA. The last wrapper performs writeback while the tree is
+still upgradeable, then releases the endpoint. Registry entries are weak;
+creation and global sync prune stale entries. Drop and allocator reclaim use
+nonblocking registry/tree acquisition so they do not introduce a destructor or
+memory-pressure lock inversion.
+
+The lock order is registry before tree when both are required. Device I/O is
+never issued while holding the registry lock. One sleepable tree lock
+serializes cached state with direct requests across wrappers of the same
+device. The endpoint lock is used only by global writeback.
+
+## Cache State and Resource Bound
+
+One folio is 4 KiB or one device block, whichever is larger. Each device tree
+contains at most 1024 folios: 4 MiB for 512-byte or 4-KiB devices. Each folio
+has per-block uptodate and dirty state, while an ordered frame index records
+which folios need writeback. The fixed-capacity LRU allocates a replacement
+before evicting an existing entry so allocation failure preserves prior state.
+
+Clean folios can be reclaimed without I/O. A dirty eviction first writes its
+dirty runs; a failed write leaves the folio dirty and retryable. Global sync
+reserves a snapshot of live trees before releasing the registry lock. Reserve
+failure is `BlockError::NoMemory`, not an implicit partial snapshot.
+
+## I/O and Coherence State Machine
+
+### Buffered requests
+
+A request contained within one folio reads only missing slots. Writes update
+folio bytes, set per-slot dirty state, and defer device I/O until writeback,
+eviction, explicit flush, global sync, or last-consumer teardown.
+
+### Direct reads
+
+Before a multi-folio read, overlapping dirty slots are written to the device.
+The direct read then runs against current device contents and overlays only
+clean cached slots; newer dirty slots remain authoritative if the policy is
+extended to permit them.
+
+### Direct writes
+
+Before a multi-folio write, overlapping dirty slots are written back. A fully
+successful direct write overlays its bytes onto every already-cached folio. If
+the device reports an error, its successfully written prefix is unknown, so
+the cache discards every overlapping folio. The next buffered read must fetch
+the device's observable contents again.
+
+The synchronous runtime must drain every submission window already handed to
+hardware before returning the first write error. It stops submitting new
+windows after the first error. This prevents a caller from invalidating and
+then repopulating a folio while an earlier direct request can still modify the
+same device range.
+
+## Journal and Durability Ordering
+
+`rsext4` retains ownership of transaction state. Once a held metadata buffer
+is queued, ordinary dirty writeback cannot write its home block before the
+commit record. Re-editing an already queued held buffer refreshes the pending
+journal snapshot before switching buffers, flushing, or committing.
+
+Cache `flush()` performs dirty writeback before the device barrier. Therefore
+the existing sequence remains descriptor/data write, barrier, commit-record
+write, barrier. A writeback failure preserves dirty ownership and prevents the
+later barrier or commit stage from being reported as successful.
+
+StarryOS `sync(2)` attempts page-cache, root-filesystem, and device-cache
+stages even after an earlier error. Matching Linux, it logs writeback failures
+but returns zero. The log is the only guaranteed observation of an error from
+that `sync(2)` invocation; there is no persistent writeback-error record that a
+later syscall must reproduce. Descriptor-specific interfaces such as
+`fsync(2)` and `syncfs(2)` retain their own typed error paths for the work they
+perform.
+
+## Error and Recovery Rules
+
+- Invalid geometry is `InvalidRequest` and may use the existing uncached
+  compatibility path.
+- Registry collision, runtime state, allocation, device, and writeback errors
+  propagate as typed `BlockError` values.
+- Failed buffered writeback retains dirty data for retry.
+- Failed direct write invalidates its entire overlapping cache range.
+- Global sync and filesystem shutdown attempt later devices after an earlier
+  failure, retaining the first internal error for logging or typed callers.
+- Drop cannot return an error; it logs a failed final writeback.
+
+## Migration and Rollback
+
+The cache is introduced behind the existing ext4/FAT `FsBlockDevice` factory;
+filesystem public APIs and disk formats do not change. Migration replaces the
+private `rsext4` device cache only after the journal held-buffer tests pass.
+Rollback removes the wrapper and restores direct block devices plus the prior
+private cache; no on-disk data migration is required.
+
+Open PR [#2015](https://github.com/rcore-os/tgoskits/pull/2015) overlaps
+`rsext4` journal and data-cache performance work and is complementary only
+after its writeback ownership is rebased onto this boundary. Open PR
+[#1957](https://github.com/rcore-os/tgoskits/pull/1957) broadly overlaps
+`ax-fs-ng` and `rsext4` cache/flush semantics and must be rebased or have its
+equivalent pieces dropped according to merge order. Neither PR should be
+merged by resolving textual conflicts without revalidating the state-machine
+and durability tests named here.
+
+## Validation Plan
+
+Deterministic host tests must cover:
+
+- repeated reads and partial-folio slot state;
+- deferred writes, merged writeback, eviction, retry, and barrier ordering;
+- shared wrappers and physically distinct partition offsets;
+- direct-read/write coherence and a direct write that commits a prefix before
+  returning an error;
+- draining already submitted runtime windows before returning that error;
+- fallible registry allocation, stale weak entries, last-consumer teardown,
+  and nonblocking reclaim/drop paths;
+- JBD2 queue, re-edit, switch, flush, and commit ownership transitions;
+- `sync(2)` attempting every stage while returning Linux-compatible success.
+
+The runnable `block-io-bench` validates deterministic contents for repeated
+reads and truncate/rewrite generations observed through an already-open file
+descriptor. QEMU validation covers the public StarryOS syscall and application
+paths. CI must additionally pass formatting, targeted clippy configurations,
+workspace host tests, and the StarryOS architecture matrix.
+
+The author-side commands and required observations are:
+
+```text
+cargo test -p ax-fs-ng --features 'host-test ext4 vfs'
+  -> all cache/runtime unit tests and root-selector integration tests pass
+cargo test -p rsext4 --features host-test
+  -> journal ownership and re-edit regressions pass
+cargo test -p starry-kernel
+  -> sync stage regression and host kernel tests pass
+cargo xtask clippy --package ax-fs-ng
+cargo xtask clippy --package rsext4
+cargo xtask clippy --package starry-kernel
+  -> every configured check passes with warnings denied
+cargo xtask starry test qemu --arch x86_64 -c qemu/system/syscall-test-sync
+  -> test-sync reaches STARRY_SYSTEM_TEST_PASSED and the grouped runner passes
+cargo xtask starry app qemu -t block-io-bench --arch x86_64
+  -> every initial/coherence generation verifies and BLOCK_BENCH_APP_PASSED appears
+```
+
+The helper-level sync regression injects errors into all three stages and
+requires every closure to run while the result remains `Ok(0)`. The direct
+QEMU syscall case verifies the public success path. Fault-injected device and
+multi-mount durability remain separate infrastructure work because the current
+QEMU test environment exposes neither a controllable block-error endpoint nor
+a second independently recoverable mount.
+
+## Review Boundaries
+
+Before merge, reviewers for filesystem/cache ownership and StarryOS syscall
+semantics must independently accept this design. Implementation review should
+then verify the code against the success criteria, I/O state machine, lock
+order, error rules, open-PR relationship, and validation plan above.

--- a/fs/ax-fs-ng/Cargo.toml
+++ b/fs/ax-fs-ng/Cargo.toml
@@ -23,6 +23,7 @@ bitflags = "2.10"
 cfg-if = { workspace = true }
 chrono = { workspace = true }
 dma-api = { workspace = true }
+hashbrown = "0.16"
 intrusive-collections = "0.9"
 irq-framework = { workspace = true }
 log = { workspace = true }

--- a/fs/ax-fs-ng/src/block.rs
+++ b/fs/ax-fs-ng/src/block.rs
@@ -6,6 +6,13 @@ use crate::BlockResult;
 
 pub mod runtime;
 
+#[cfg(any(feature = "ext4", feature = "fat"))]
+pub(crate) mod cache;
+
+#[cfg(any(feature = "ext4", feature = "fat"))]
+use cache::BufferedBlockDevice;
+#[cfg(any(feature = "ext4", feature = "fat"))]
+pub use cache::sync_all_block_caches;
 use runtime::BlockDeviceHandle;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -185,5 +192,34 @@ impl FsBlockDevice for NativeHandleBlockDevice {
 pub(crate) fn boxed_native_handle_block_device(
     handle: Arc<BlockDeviceHandle>,
 ) -> Box<dyn FsBlockDevice> {
+    #[cfg(any(feature = "ext4", feature = "fat"))]
+    if let Some(cached) = cached_block_device(handle.clone()) {
+        return cached;
+    }
+    // Also the fallback when the cache cannot wrap a malformed geometry,
+    // and the only path when no filesystem consumer is enabled.
     Box::new(NativeHandleBlockDevice::new(handle))
+}
+
+/// Wraps the device in its shared cache tree, keyed by the handle's
+/// address. The wrapper keeps its own `Arc` clone alive, so the key stays
+/// valid as long as any cached consumer of the device exists.
+#[cfg(any(feature = "ext4", feature = "fat"))]
+fn cached_block_device(handle: Arc<BlockDeviceHandle>) -> Option<Box<dyn FsBlockDevice>> {
+    let device_key = Arc::as_ptr(&handle) as usize;
+    let endpoint = Box::new(NativeHandleBlockDevice::new(handle.clone()));
+    match BufferedBlockDevice::with_device_key(
+        device_key,
+        endpoint,
+        NativeHandleBlockDevice::new(handle),
+    ) {
+        Ok(buffered) => Some(Box::new(buffered)),
+        // Only a malformed device geometry (non power-of-two block size)
+        // reaches this arm; keep the device usable uncached rather than
+        // failing boot, but leave a loud trace.
+        Err(error) => {
+            error!("block cache unavailable, using uncached device: {error:?}");
+            None
+        }
+    }
 }

--- a/fs/ax-fs-ng/src/block.rs
+++ b/fs/ax-fs-ng/src/block.rs
@@ -191,35 +191,113 @@ impl FsBlockDevice for NativeHandleBlockDevice {
 
 pub(crate) fn boxed_native_handle_block_device(
     handle: Arc<BlockDeviceHandle>,
-) -> Box<dyn FsBlockDevice> {
+) -> BlockResult<Box<dyn FsBlockDevice>> {
     #[cfg(any(feature = "ext4", feature = "fat"))]
-    if let Some(cached) = cached_block_device(handle.clone()) {
-        return cached;
+    if let Some(cached) = cached_block_device(handle.clone())? {
+        return Ok(cached);
     }
     // Also the fallback when the cache cannot wrap a malformed geometry,
     // and the only path when no filesystem consumer is enabled.
-    Box::new(NativeHandleBlockDevice::new(handle))
+    Ok(Box::new(NativeHandleBlockDevice::new(handle)))
 }
 
 /// Wraps the device in its shared cache tree, keyed by the handle's
 /// address. The wrapper keeps its own `Arc` clone alive, so the key stays
 /// valid as long as any cached consumer of the device exists.
 #[cfg(any(feature = "ext4", feature = "fat"))]
-fn cached_block_device(handle: Arc<BlockDeviceHandle>) -> Option<Box<dyn FsBlockDevice>> {
+fn cached_block_device(
+    handle: Arc<BlockDeviceHandle>,
+) -> BlockResult<Option<Box<dyn FsBlockDevice>>> {
     let device_key = Arc::as_ptr(&handle) as usize;
     let endpoint = Box::new(NativeHandleBlockDevice::new(handle.clone()));
-    match BufferedBlockDevice::with_device_key(
-        device_key,
-        endpoint,
-        NativeHandleBlockDevice::new(handle),
-    ) {
-        Ok(buffered) => Some(Box::new(buffered)),
-        // Only a malformed device geometry (non power-of-two block size)
-        // reaches this arm; keep the device usable uncached rather than
-        // failing boot, but leave a loud trace.
-        Err(error) => {
-            error!("block cache unavailable, using uncached device: {error:?}");
-            None
+    cached_block_device_from_parts(device_key, endpoint, NativeHandleBlockDevice::new(handle))
+}
+
+#[cfg(any(feature = "ext4", feature = "fat"))]
+fn cached_block_device_from_parts<T: FsBlockDevice + 'static>(
+    device_key: usize,
+    endpoint: Box<dyn FsBlockDevice>,
+    inner: T,
+) -> BlockResult<Option<Box<dyn FsBlockDevice>>> {
+    resolve_cache_creation(BufferedBlockDevice::with_device_key(
+        device_key, endpoint, inner,
+    ))
+    .map(|cached| cached.map(|buffered| Box::new(buffered) as Box<dyn FsBlockDevice>))
+}
+
+#[cfg(any(feature = "ext4", feature = "fat"))]
+fn resolve_cache_creation<T>(result: BlockResult<T>) -> BlockResult<Option<T>> {
+    match result {
+        Ok(cached) => Ok(Some(cached)),
+        Err(BlockError::InvalidRequest) => {
+            error!("block cache geometry is invalid, using uncached device");
+            Ok(None)
         }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(all(test, any(feature = "ext4", feature = "fat")))]
+mod tests {
+    use super::*;
+
+    struct TestBlockDevice {
+        block_size: usize,
+    }
+
+    impl FsBlockDevice for TestBlockDevice {
+        fn name(&self) -> &str {
+            "test"
+        }
+
+        fn num_blocks(&self) -> u64 {
+            64
+        }
+
+        fn block_size(&self) -> usize {
+            self.block_size
+        }
+
+        fn read_block(&mut self, _block_id: u64, _buf: &mut [u8]) -> BlockResult {
+            unreachable!("cache construction must not issue IO")
+        }
+
+        fn write_block(&mut self, _block_id: u64, _buf: &[u8]) -> BlockResult {
+            unreachable!("cache construction must not issue IO")
+        }
+
+        fn flush(&mut self) -> BlockResult {
+            unreachable!("cache construction must not issue IO")
+        }
+    }
+
+    fn test_device(block_size: usize) -> TestBlockDevice {
+        TestBlockDevice { block_size }
+    }
+
+    #[test]
+    fn cache_allocation_failure_is_not_downgraded_to_uncached_io() {
+        let device_key = usize::MAX - 1;
+        cache::fail_registry_reserve_for_key_for_test(device_key);
+
+        let result = cached_block_device_from_parts(
+            device_key,
+            Box::new(test_device(512)),
+            test_device(512),
+        );
+
+        assert!(matches!(result, Err(BlockError::NoMemory)));
+        assert!(!cache::registry_contains_key_for_test(device_key));
+    }
+
+    #[test]
+    fn malformed_cache_geometry_keeps_the_uncached_fallback() {
+        let result = cached_block_device_from_parts(
+            usize::MAX - 2,
+            Box::new(test_device(1000)),
+            test_device(1000),
+        );
+
+        assert!(matches!(result, Ok(None)));
     }
 }

--- a/fs/ax-fs-ng/src/block/cache/address_space.rs
+++ b/fs/ax-fs-ng/src/block/cache/address_space.rs
@@ -1,0 +1,367 @@
+//! Per-device folio tree of the block cache, modeled on the
+//! `address_space` of a Linux block-device inode (`block/bdev.c`).
+//!
+//! The tree maps folio frame index to [`CacheFolio`] (Linux: XArray page
+//! index to folio). A frame-level DIRTY mark (Linux
+//! `PAGECACHE_TAG_DIRTY`) is kept as an ordered set of frame indices:
+//! "does the device have pending writeback" is answerable in O(1), and
+//! writeback always visits frames in ascending block order, which keeps
+//! device-visible write ordering deterministic.
+//!
+//! A WRITEBACK mark has no state here: writeback is synchronous under the
+//! device lock, so an intermediate mark would never be observed. It is
+//! the extension point if writeback becomes asynchronous.
+
+use alloc::{collections::BTreeSet, vec::Vec};
+use core::num::NonZeroUsize;
+
+use lru::LruCache;
+
+use super::folio::CacheFolio;
+use crate::{BlockResult, block::FsBlockDevice, os::memory::PAGE_SIZE};
+
+/// Folios cached per device: 1024 frames of 4 KiB = 4 MiB with 512-byte
+/// device blocks.
+pub(crate) const BLOCK_CACHE_FOLIO_CAP: usize = 1024;
+
+/// Fixed folio layout of one device: folio size, device block size, and
+/// the number of device blocks each folio covers.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct FolioGeometry {
+    block_size: usize,
+    folio_size: usize,
+    slots: usize,
+    slots_log2: u32,
+}
+
+impl FolioGeometry {
+    /// Computes the folio layout for a device.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlockError::InvalidRequest`] if `block_size` is zero or
+    /// not a power of two.
+    pub(crate) fn new(block_size: usize) -> BlockResult<Self> {
+        if block_size == 0 || !block_size.is_power_of_two() {
+            return Err(crate::BlockError::InvalidRequest);
+        }
+        // Folios are page-sized so a frame can back file-level page-cache
+        // IO, but never smaller than one device block.
+        let folio_size = PAGE_SIZE.max(block_size);
+        let slots = folio_size / block_size;
+        Ok(Self {
+            block_size,
+            folio_size,
+            slots,
+            slots_log2: slots.trailing_zeros(),
+        })
+    }
+
+    pub(crate) fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    pub(crate) fn folio_size(&self) -> usize {
+        self.folio_size
+    }
+
+    pub(crate) fn slots(&self) -> usize {
+        self.slots
+    }
+
+    fn frame_of(&self, block: u64) -> u64 {
+        block >> self.slots_log2
+    }
+
+    fn slot_of(&self, block: u64) -> usize {
+        (block & (self.slots - 1) as u64) as usize
+    }
+
+    fn frame_base_block(&self, frame: u64) -> u64 {
+        frame << self.slots_log2
+    }
+
+    /// Whether the block range `[first, first + count)` stays within one
+    /// folio, i.e. qualifies for the buffered path.
+    pub(crate) fn spans_one_folio(&self, first: u64, count: u64) -> bool {
+        match count
+            .checked_sub(1)
+            .and_then(|last| first.checked_add(last))
+        {
+            Some(last) => self.frame_of(first) == self.frame_of(last),
+            None => false,
+        }
+    }
+}
+
+/// The cached-folio tree of one device (the bdev `address_space`).
+pub(crate) struct BlockAddressSpace {
+    geometry: FolioGeometry,
+    capacity: NonZeroUsize,
+    folios: LruCache<u64, CacheFolio>,
+    /// Frame-level DIRTY mark: frames with at least one dirty slot.
+    dirty_frames: BTreeSet<u64>,
+}
+
+impl BlockAddressSpace {
+    pub(crate) fn new(geometry: FolioGeometry) -> Self {
+        Self::with_capacity(geometry, BLOCK_CACHE_FOLIO_CAP)
+    }
+
+    /// Builds a tree with an explicit frame capacity (used by tests to
+    /// exercise LRU eviction deterministically).
+    pub(crate) fn with_capacity(geometry: FolioGeometry, capacity: usize) -> Self {
+        let capacity = NonZeroUsize::new(capacity.max(1)).expect("capacity is clamped to >= 1");
+        Self {
+            geometry,
+            capacity,
+            folios: LruCache::new(capacity),
+            dirty_frames: BTreeSet::new(),
+        }
+    }
+
+    pub(crate) fn geometry(&self) -> FolioGeometry {
+        self.geometry
+    }
+
+    pub(crate) fn has_dirty(&self) -> bool {
+        !self.dirty_frames.is_empty()
+    }
+
+    /// Drops up to `target` clean folios from the LRU end and returns how
+    /// many were dropped. Dirty folios are pushed back to the
+    /// most-recently-used end: reclaim runs from the allocator's pressure
+    /// hook, where device IO must not happen.
+    #[cfg(feature = "vfs")]
+    pub(crate) fn reclaim_clean_folios(&mut self, target: usize) -> usize {
+        let mut reclaimed = 0;
+        let mut dirty_skips = 0;
+        while reclaimed < target {
+            let len = self.folios.len();
+            if len == 0 || dirty_skips >= len {
+                break;
+            }
+            let Some((frame, folio)) = self.folios.pop_lru() else {
+                break;
+            };
+            if folio.has_dirty_slots() {
+                self.folios.put(frame, folio);
+                dirty_skips += 1;
+                continue;
+            }
+            reclaimed += 1;
+        }
+        reclaimed
+    }
+
+    /// Buffered read of a one-folio request (`bread` semantics): slots that
+    /// are uptodate are copied out without IO, missing ones are read from
+    /// the device into the folio as merged runs.
+    pub(crate) fn read_buffered<T: FsBlockDevice>(
+        &mut self,
+        dev: &mut T,
+        first_block: u64,
+        count: u64,
+        out: &mut [u8],
+    ) -> BlockResult<()> {
+        let geometry = self.geometry;
+        let frame = geometry.frame_of(first_block);
+        let first_slot = geometry.slot_of(first_block);
+        let count = usize::try_from(count).map_err(|_| crate::BlockError::InvalidRequest)?;
+        let folio = self.getblk(dev, frame)?;
+        fill_missing_slots(dev, folio, &geometry, frame, first_slot, count)?;
+        folio.copy_from_slots(first_slot, count, out);
+        Ok(())
+    }
+
+    /// Deferred write of a one-folio request (`mark_buffer_dirty`
+    /// semantics): data lands only in the folio; the device copy is
+    /// updated by [`writeback_dirty`](Self::writeback_dirty).
+    pub(crate) fn write_buffered<T: FsBlockDevice>(
+        &mut self,
+        dev: &mut T,
+        first_block: u64,
+        count: u64,
+        src: &[u8],
+    ) -> BlockResult<()> {
+        let geometry = self.geometry;
+        let frame = geometry.frame_of(first_block);
+        let first_slot = geometry.slot_of(first_block);
+        let count = usize::try_from(count).map_err(|_| crate::BlockError::InvalidRequest)?;
+        let newly_dirty = {
+            let folio = self.getblk(dev, frame)?;
+            folio.copy_into_slots(first_slot, count, src);
+            folio.mark_slots_dirty(first_slot, count)
+        };
+        if newly_dirty > 0 {
+            self.dirty_frames.insert(frame);
+        }
+        Ok(())
+    }
+
+    /// Writes back dirty slots (`sync_dirty_buffers`). Every run of
+    /// consecutive dirty slots becomes one merged device write; frames are
+    /// visited in ascending order. `range` restricts writeback to frames
+    /// overlapping the block range.
+    pub(crate) fn writeback_dirty<T: FsBlockDevice + ?Sized>(
+        &mut self,
+        dev: &mut T,
+        range: Option<(u64, u64)>,
+    ) -> BlockResult<()> {
+        let targets: Vec<u64> = match range {
+            None => self.dirty_frames.iter().copied().collect(),
+            Some((first, count)) => self.overlapping_dirty_frames(first, count),
+        };
+        for frame in targets {
+            self.writeback_folio(dev, frame)?;
+        }
+        Ok(())
+    }
+
+    /// Overlays a device-direct request result onto overlapping folios so
+    /// cached slots stay coherent with the bytes the device just saw.
+    /// Dirty slots keep their newer bytes when `preserve_dirty` is set
+    /// (direct reads); direct writes clear dirty state beforehand.
+    pub(crate) fn apply_direct(
+        &mut self,
+        first: u64,
+        count: u64,
+        data: &[u8],
+        preserve_dirty: bool,
+    ) {
+        let geometry = self.geometry;
+        let Some(last) = count.checked_sub(1).and_then(|n| first.checked_add(n)) else {
+            return;
+        };
+        for frame in geometry.frame_of(first)..=geometry.frame_of(last) {
+            let Some(folio) = self.folios.get_mut(&frame) else {
+                continue;
+            };
+            let (slot_lo, slot_hi) = overlap_slots(&geometry, frame, first, last);
+            let data_begin = (geometry.frame_base_block(frame) + slot_lo as u64 - first) as usize
+                * geometry.block_size;
+            let data_end = data_begin + (slot_hi - slot_lo) * geometry.block_size;
+            folio.overlay_external(
+                slot_lo,
+                slot_hi - slot_lo,
+                &data[data_begin..data_end],
+                preserve_dirty,
+            );
+        }
+    }
+
+    /// Writes back one dirty folio: merged dirty-slot runs become device
+    /// writes; on success the slot state is clean again.
+    fn writeback_folio<T: FsBlockDevice + ?Sized>(
+        &mut self,
+        dev: &mut T,
+        frame: u64,
+    ) -> BlockResult<()> {
+        let geometry = self.geometry;
+        let Some(folio) = self.folios.get_mut(&frame) else {
+            self.dirty_frames.remove(&frame);
+            return Ok(());
+        };
+        let runs: Vec<_> = folio.dirty_runs().collect();
+        let base = geometry.frame_base_block(frame);
+        for (slot, count) in runs {
+            let lba = base + slot as u64;
+            dev.write_block(lba, folio.slot_bytes_mut(slot, count))?;
+            folio.clear_dirty_slots(slot, count);
+        }
+        if !folio.has_dirty_slots() {
+            self.dirty_frames.remove(&frame);
+        }
+        Ok(())
+    }
+
+    /// Finds-or-allocates a folio (`getblk`). When the tree is full, the
+    /// LRU folio is evicted; a dirty victim is written back before it is
+    /// dropped so eviction never discards modifications.
+    fn getblk<T: FsBlockDevice + ?Sized>(
+        &mut self,
+        dev: &mut T,
+        frame: u64,
+    ) -> BlockResult<&mut CacheFolio> {
+        if !self.folios.contains(&frame) && self.folios.len() >= self.capacity.get() {
+            self.evict_lru(dev)?;
+        }
+        if !self.folios.contains(&frame) {
+            let folio = CacheFolio::new(self.geometry.folio_size(), self.geometry.slots());
+            self.folios.put(frame, folio);
+        }
+        Ok(self
+            .folios
+            .get_mut(&frame)
+            .expect("folio was just inserted or found above"))
+    }
+
+    fn evict_lru<T: FsBlockDevice + ?Sized>(&mut self, dev: &mut T) -> BlockResult<()> {
+        let Some((frame, _)) = self.folios.peek_lru() else {
+            return Ok(());
+        };
+        let frame = *frame;
+        // A dirty victim must reach the device before its folio is dropped.
+        if self.dirty_frames.contains(&frame) {
+            self.writeback_folio(dev, frame)?;
+        }
+        self.folios.pop(&frame);
+        Ok(())
+    }
+
+    fn overlapping_dirty_frames(&self, first: u64, count: u64) -> Vec<u64> {
+        let Some(last) = count.checked_sub(1).and_then(|n| first.checked_add(n)) else {
+            return Vec::new();
+        };
+        self.dirty_frames
+            .range(self.geometry.frame_of(first)..=self.geometry.frame_of(last))
+            .copied()
+            .collect()
+    }
+}
+
+/// Reads the not-yet-uptodate slots of a request region from the device
+/// into the folio, merging consecutive missing blocks into single reads
+/// (the per-buffer `submit_bh` loop of `block_read_full_folio`).
+fn fill_missing_slots<T: FsBlockDevice>(
+    dev: &mut T,
+    folio: &mut CacheFolio,
+    geometry: &FolioGeometry,
+    frame: u64,
+    first_slot: usize,
+    count: usize,
+) -> BlockResult<()> {
+    let end = first_slot + count;
+    let mut cursor = first_slot;
+    while cursor < end {
+        if folio.slot(cursor).is_uptodate() {
+            cursor += 1;
+            continue;
+        }
+        let run_start = cursor;
+        while cursor < end && !folio.slot(cursor).is_uptodate() {
+            cursor += 1;
+        }
+        let run_len = cursor - run_start;
+        let lba = geometry.frame_base_block(frame) + run_start as u64;
+        dev.read_block(lba, folio.slot_bytes_mut(run_start, run_len))?;
+        folio.mark_slots_uptodate(run_start, run_len);
+    }
+    Ok(())
+}
+
+/// Slot range `[lo, hi)` of `frame` covered by block range
+/// `[first, last]`.
+fn overlap_slots(geometry: &FolioGeometry, frame: u64, first: u64, last: u64) -> (usize, usize) {
+    let lo = if geometry.frame_of(first) == frame {
+        geometry.slot_of(first)
+    } else {
+        0
+    };
+    let hi = if geometry.frame_of(last) == frame {
+        geometry.slot_of(last) + 1
+    } else {
+        geometry.slots()
+    };
+    (lo, hi)
+}

--- a/fs/ax-fs-ng/src/block/cache/address_space.rs
+++ b/fs/ax-fs-ng/src/block/cache/address_space.rs
@@ -273,6 +273,23 @@ impl BlockAddressSpace {
         }
     }
 
+    /// Discards every cached folio overlapping a device-direct request.
+    ///
+    /// A failed write does not report its completed prefix, so none of the
+    /// overlapping cache bytes can remain authoritative. Whole folios are
+    /// discarded even when only some slots overlap; retaining neighboring
+    /// slots would require tracking an error-completion bitmap that the
+    /// current [`FsBlockDevice`] contract does not expose.
+    pub(crate) fn invalidate_range(&mut self, first: u64, count: u64) {
+        let Some(last) = count.checked_sub(1).and_then(|n| first.checked_add(n)) else {
+            return;
+        };
+        for frame in self.geometry.frame_of(first)..=self.geometry.frame_of(last) {
+            self.clear_dirty_frame(frame);
+            self.folios.remove(&frame);
+        }
+    }
+
     /// Writes back one dirty folio: merged dirty-slot runs become device
     /// writes; on success the slot state is clean again.
     fn writeback_folio<T: FsBlockDevice + ?Sized>(

--- a/fs/ax-fs-ng/src/block/cache/address_space.rs
+++ b/fs/ax-fs-ng/src/block/cache/address_space.rs
@@ -2,23 +2,20 @@
 //! `address_space` of a Linux block-device inode (`block/bdev.c`).
 //!
 //! The tree maps folio frame index to [`CacheFolio`] (Linux: XArray page
-//! index to folio). A frame-level DIRTY mark (Linux
-//! `PAGECACHE_TAG_DIRTY`) is kept as an ordered set of frame indices:
-//! "does the device have pending writeback" is answerable in O(1), and
-//! writeback always visits frames in ascending block order, which keeps
-//! device-visible write ordering deterministic.
+//! index to folio). An ordered frame index records the frame-level DIRTY
+//! mark (Linux `PAGECACHE_TAG_DIRTY`): "does the device have pending
+//! writeback" is answerable in O(1), and writeback always visits frames in
+//! ascending block order for deterministic device-visible ordering.
 //!
 //! A WRITEBACK mark has no state here: writeback is synchronous under the
 //! device lock, so an intermediate mark would never be observed. It is
 //! the extension point if writeback becomes asynchronous.
 
-use alloc::{collections::BTreeSet, vec::Vec};
+use alloc::vec::Vec;
 use core::num::NonZeroUsize;
 
-use lru::LruCache;
-
-use super::folio::CacheFolio;
-use crate::{BlockResult, block::FsBlockDevice, os::memory::PAGE_SIZE};
+use super::{folio::CacheFolio, folio_cache::FolioCache};
+use crate::{BlockError, BlockResult, block::FsBlockDevice, os::memory::PAGE_SIZE};
 
 /// Folios cached per device: 1024 frames of 4 KiB = 4 MiB with 512-byte
 /// device blocks.
@@ -97,10 +94,11 @@ impl FolioGeometry {
 /// The cached-folio tree of one device (the bdev `address_space`).
 pub(crate) struct BlockAddressSpace {
     geometry: FolioGeometry,
-    capacity: NonZeroUsize,
-    folios: LruCache<u64, CacheFolio>,
+    folios: FolioCache,
     /// Frame-level DIRTY mark: frames with at least one dirty slot.
-    dirty_frames: BTreeSet<u64>,
+    /// Kept sorted so writeback order is deterministic. Capacity growth is
+    /// reserved before any folio state is changed.
+    dirty_frames: Vec<u64>,
 }
 
 impl BlockAddressSpace {
@@ -114,9 +112,8 @@ impl BlockAddressSpace {
         let capacity = NonZeroUsize::new(capacity.max(1)).expect("capacity is clamped to >= 1");
         Self {
             geometry,
-            capacity,
-            folios: LruCache::new(capacity),
-            dirty_frames: BTreeSet::new(),
+            folios: FolioCache::new(capacity),
+            dirty_frames: Vec::new(),
         }
     }
 
@@ -141,14 +138,19 @@ impl BlockAddressSpace {
             if len == 0 || dirty_skips >= len {
                 break;
             }
-            let Some((frame, folio)) = self.folios.pop_lru() else {
+            let Some(frame) = self.folios.least_recent() else {
                 break;
             };
-            if folio.has_dirty_slots() {
-                self.folios.put(frame, folio);
+            if self
+                .folios
+                .get(&frame)
+                .is_some_and(CacheFolio::has_dirty_slots)
+            {
+                self.folios.touch(frame);
                 dirty_skips += 1;
                 continue;
             }
+            self.folios.remove(&frame);
             reclaimed += 1;
         }
         reclaimed
@@ -188,13 +190,20 @@ impl BlockAddressSpace {
         let frame = geometry.frame_of(first_block);
         let first_slot = geometry.slot_of(first_block);
         let count = usize::try_from(count).map_err(|_| crate::BlockError::InvalidRequest)?;
+        if self.dirty_frames.binary_search(&frame).is_err() {
+            self.dirty_frames
+                .try_reserve(1)
+                .map_err(|_| BlockError::NoMemory)?;
+        }
         let newly_dirty = {
             let folio = self.getblk(dev, frame)?;
             folio.copy_into_slots(first_slot, count, src);
             folio.mark_slots_dirty(first_slot, count)
         };
-        if newly_dirty > 0 {
-            self.dirty_frames.insert(frame);
+        if newly_dirty > 0
+            && let Err(index) = self.dirty_frames.binary_search(&frame)
+        {
+            self.dirty_frames.insert(index, frame);
         }
         Ok(())
     }
@@ -208,11 +217,25 @@ impl BlockAddressSpace {
         dev: &mut T,
         range: Option<(u64, u64)>,
     ) -> BlockResult<()> {
-        let targets: Vec<u64> = match range {
-            None => self.dirty_frames.iter().copied().collect(),
-            Some((first, count)) => self.overlapping_dirty_frames(first, count),
-        };
-        for frame in targets {
+        let frame_range = range.and_then(|(first, count)| {
+            let last = count.checked_sub(1).and_then(|n| first.checked_add(n))?;
+            Some((self.geometry.frame_of(first), self.geometry.frame_of(last)))
+        });
+        loop {
+            let target = match frame_range {
+                None if range.is_some() => None,
+                None => self.dirty_frames.first().copied(),
+                Some((first, last)) => {
+                    let index = self.dirty_frames.partition_point(|frame| *frame < first);
+                    self.dirty_frames
+                        .get(index)
+                        .copied()
+                        .filter(|frame| *frame <= last)
+                }
+            };
+            let Some(frame) = target else {
+                break;
+            };
             self.writeback_folio(dev, frame)?;
         }
         Ok(())
@@ -259,18 +282,17 @@ impl BlockAddressSpace {
     ) -> BlockResult<()> {
         let geometry = self.geometry;
         let Some(folio) = self.folios.get_mut(&frame) else {
-            self.dirty_frames.remove(&frame);
+            self.clear_dirty_frame(frame);
             return Ok(());
         };
-        let runs: Vec<_> = folio.dirty_runs().collect();
         let base = geometry.frame_base_block(frame);
-        for (slot, count) in runs {
+        while let Some((slot, count)) = folio.dirty_runs().next() {
             let lba = base + slot as u64;
             dev.write_block(lba, folio.slot_bytes_mut(slot, count))?;
             folio.clear_dirty_slots(slot, count);
         }
         if !folio.has_dirty_slots() {
-            self.dirty_frames.remove(&frame);
+            self.clear_dirty_frame(frame);
         }
         Ok(())
     }
@@ -283,13 +305,18 @@ impl BlockAddressSpace {
         dev: &mut T,
         frame: u64,
     ) -> BlockResult<&mut CacheFolio> {
-        if !self.folios.contains(&frame) && self.folios.len() >= self.capacity.get() {
+        if self.folios.contains(&frame) {
+            return Ok(self.folios.get_mut(&frame).expect("folio was found above"));
+        }
+
+        // Allocate before eviction: a failed folio allocation leaves the
+        // existing cache contents and LRU order unchanged.
+        let folio = CacheFolio::try_new(self.geometry.folio_size(), self.geometry.slots())?;
+        self.folios.try_reserve_entry()?;
+        if self.folios.is_full() {
             self.evict_lru(dev)?;
         }
-        if !self.folios.contains(&frame) {
-            let folio = CacheFolio::new(self.geometry.folio_size(), self.geometry.slots());
-            self.folios.put(frame, folio);
-        }
+        self.folios.insert_reserved(frame, folio);
         Ok(self
             .folios
             .get_mut(&frame)
@@ -297,26 +324,21 @@ impl BlockAddressSpace {
     }
 
     fn evict_lru<T: FsBlockDevice + ?Sized>(&mut self, dev: &mut T) -> BlockResult<()> {
-        let Some((frame, _)) = self.folios.peek_lru() else {
+        let Some(frame) = self.folios.least_recent() else {
             return Ok(());
         };
-        let frame = *frame;
         // A dirty victim must reach the device before its folio is dropped.
-        if self.dirty_frames.contains(&frame) {
+        if self.dirty_frames.binary_search(&frame).is_ok() {
             self.writeback_folio(dev, frame)?;
         }
-        self.folios.pop(&frame);
+        self.folios.remove(&frame);
         Ok(())
     }
 
-    fn overlapping_dirty_frames(&self, first: u64, count: u64) -> Vec<u64> {
-        let Some(last) = count.checked_sub(1).and_then(|n| first.checked_add(n)) else {
-            return Vec::new();
-        };
-        self.dirty_frames
-            .range(self.geometry.frame_of(first)..=self.geometry.frame_of(last))
-            .copied()
-            .collect()
+    fn clear_dirty_frame(&mut self, frame: u64) {
+        if let Ok(index) = self.dirty_frames.binary_search(&frame) {
+            self.dirty_frames.remove(index);
+        }
     }
 }
 

--- a/fs/ax-fs-ng/src/block/cache/buffer_head.rs
+++ b/fs/ax-fs-ng/src/block/cache/buffer_head.rs
@@ -1,0 +1,60 @@
+//! Per-slot buffer state inside a cached folio, modeled on the Linux
+//! `buffer_head` (`include/linux/buffer_head.h`).
+//!
+//! One [`BufferHead`] describes a single device block within a
+//! [`CacheFolio`](super::folio::CacheFolio). Only the `BH_Uptodate` and
+//! `BH_Dirty` bits carry meaning here: the block-device cache is an
+//! identity mapping (slot `i` of frame `f` is always device block
+//! `f * slots_per_folio + i`), so every slot is implicitly mapped and a
+//! `BH_Mapped` bit would never be cleared.
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// State bits of one device block inside a folio.
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    pub(crate) struct BufferHeadState: u8 {
+        /// The slot holds data matching the last read from or write to the
+        /// device (`BH_Uptodate`).
+        const UPTODATE = 1 << 0;
+        /// The slot differs from the on-disk copy and must be written back
+        /// before the device is consistent (`BH_Dirty`).
+        const DIRTY = 1 << 1;
+    }
+}
+
+/// State of one device block within a folio (Linux `buffer_head`).
+#[derive(Clone, Debug, Default)]
+pub(crate) struct BufferHead {
+    state: BufferHeadState,
+}
+
+impl BufferHead {
+    pub(crate) fn is_uptodate(&self) -> bool {
+        self.state.contains(BufferHeadState::UPTODATE)
+    }
+
+    pub(crate) fn is_dirty(&self) -> bool {
+        self.state.contains(BufferHeadState::DIRTY)
+    }
+
+    /// Marks the slot as matching the device after a read.
+    pub(crate) fn mark_uptodate(&mut self) {
+        self.state.insert(BufferHeadState::UPTODATE);
+    }
+
+    /// Marks the slot as modified relative to the device copy
+    /// (`mark_buffer_dirty`); modified data is always valid to read back,
+    /// so the slot is uptodate as well.
+    pub(crate) fn mark_dirty(&mut self) {
+        self.state
+            .insert(BufferHeadState::UPTODATE | BufferHeadState::DIRTY);
+    }
+
+    /// Clears the dirty bit; returns whether the slot was dirty.
+    pub(crate) fn clear_dirty(&mut self) -> bool {
+        let was_dirty = self.is_dirty();
+        self.state.remove(BufferHeadState::DIRTY);
+        was_dirty
+    }
+}

--- a/fs/ax-fs-ng/src/block/cache/device.rs
+++ b/fs/ax-fs-ng/src/block/cache/device.rs
@@ -1,0 +1,174 @@
+//! `FsBlockDevice` adapter routing traffic through the shared per-device
+//! cache, the role the bdev page cache plays for Linux filesystem metadata
+//! (`fs/buffer.c`).
+//!
+//! Requests inside one folio take the buffered path: reads are served
+//! from folios when possible (`bread`), writes only mark slots dirty
+//! (`mark_buffer_dirty`) and reach the device at writeback. Requests
+//! spanning multiple folios take the device-direct path (the analog of
+//! direct IO): overlapping dirty slots are written back first so the
+//! device is current, the request is submitted unchanged, and the result
+//! is overlaid onto cached folios. The buffered/direct split at folio
+//! granularity replaces Linux's filesystem-declared metadata/data split
+//! because the `FsBlockDevice` boundary only observes request shapes;
+//! see the module documentation for the full mapping.
+
+use alloc::{boxed::Box, sync::Arc};
+
+use super::address_space::{BlockAddressSpace, FolioGeometry};
+use crate::{BlockError, BlockResult, block::FsBlockDevice, os::sync::SleepMutex};
+
+/// The shared per-device cache tree behind a sleepable lock.
+///
+/// All filesystem instances on one physical device serialize through this
+/// lock (Linux instead locks folios individually; see module documentation
+/// for why that split has no effect in the synchronous IO model).
+pub(crate) struct BlockCacheShared {
+    state: SleepMutex<BlockAddressSpace>,
+}
+
+impl BlockCacheShared {
+    pub(crate) fn new(geometry: FolioGeometry) -> Self {
+        Self {
+            state: SleepMutex::new(BlockAddressSpace::new(geometry)),
+        }
+    }
+
+    /// Whether the tree was built for `block_size`; a registry hit with a
+    /// different size means the device key collides across geometries.
+    pub(crate) fn matches_block_size(&self, block_size: usize) -> bool {
+        self.state.lock().geometry().block_size() == block_size
+    }
+
+    /// Writes back every dirty slot through `endpoint`, then issues its
+    /// flush barrier; used by global sync when no wrapper device drives
+    /// the tree.
+    pub(crate) fn sync_to_device_with(&self, endpoint: &mut dyn FsBlockDevice) -> BlockResult<()> {
+        let mut state = self.state.lock();
+        if state.has_dirty() {
+            state.writeback_dirty(&mut *endpoint, None)?;
+        }
+        endpoint.flush()
+    }
+
+    /// Drops up to `target` clean folios from the LRU end; see
+    /// [`super::registry::reclaim_clean_folios`] for the clean-only
+    /// contract.
+    #[cfg(feature = "vfs")]
+    pub(crate) fn reclaim_clean_folios(&self, target: usize) -> usize {
+        self.state.lock().reclaim_clean_folios(target)
+    }
+}
+
+/// A [`FsBlockDevice`] wrapper whose buffered traffic is cached and shared
+/// by every consumer of the same underlying device.
+pub(crate) struct BufferedBlockDevice<T: FsBlockDevice> {
+    inner: T,
+    shared: Arc<BlockCacheShared>,
+}
+
+impl<T: FsBlockDevice> BufferedBlockDevice<T> {
+    /// Wraps `inner`, resolving the shared cache tree registered under
+    /// `device_key` (the identity of the runtime device handle);
+    /// `endpoint` is an equivalent device the registry keeps for global
+    /// writeback.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlockError::InvalidRequest`] when the device block size is
+    /// zero or not a power of two, and [`BlockError::InvalidState`] when
+    /// the registered tree for `device_key` was built for a different
+    /// block size.
+    pub(crate) fn with_device_key(
+        device_key: usize,
+        endpoint: Box<dyn FsBlockDevice>,
+        inner: T,
+    ) -> BlockResult<Self> {
+        let block_size = inner.block_size();
+        let shared = super::registry::shared_cache_for(device_key, block_size, endpoint)?;
+        Ok(Self { inner, shared })
+    }
+
+    /// Writes back every dirty slot, then issues the device flush barrier
+    /// (`sync_dirty_buffers` followed by the cache flush). The barrier
+    /// ordering is what keeps journal commit sequences crash-safe when
+    /// block writes are deferred into this layer.
+    fn sync_to_device(&mut self) -> BlockResult<()> {
+        let mut state = self.shared.state.lock();
+        if state.has_dirty() {
+            state.writeback_dirty(&mut self.inner, None)?;
+        }
+        self.inner.flush()
+    }
+
+    /// Splits a request into `(first_block, block_count)`, validating the
+    /// buffer geometry against the device block size.
+    fn split_request(&self, block_id: u64, buf_len: usize) -> BlockResult<(u64, u64)> {
+        let block_size = self.shared.state.lock().geometry().block_size();
+        if block_size == 0 || buf_len == 0 || !buf_len.is_multiple_of(block_size) {
+            return Err(BlockError::InvalidRequest);
+        }
+        let count = u64::try_from(buf_len / block_size).map_err(|_| BlockError::InvalidState)?;
+        Ok((block_id, count))
+    }
+}
+
+impl<T: FsBlockDevice> FsBlockDevice for BufferedBlockDevice<T> {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn num_blocks(&self) -> u64 {
+        self.inner.num_blocks()
+    }
+
+    fn block_size(&self) -> usize {
+        self.inner.block_size()
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> BlockResult<()> {
+        let (first, count) = self.split_request(block_id, buf.len())?;
+        let mut state = self.shared.state.lock();
+        if state.geometry().spans_one_folio(first, count) {
+            return state.read_buffered(&mut self.inner, first, count, buf);
+        }
+        // Direct read: write overlapping dirty slots back first so stale
+        // device bytes cannot bypass newer cached data.
+        state.writeback_dirty(&mut self.inner, Some((first, count)))?;
+        self.inner.read_block(block_id, buf)?;
+        state.apply_direct(first, count, buf, true);
+        Ok(())
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> BlockResult<()> {
+        let (first, count) = self.split_request(block_id, buf.len())?;
+        let mut state = self.shared.state.lock();
+        if state.geometry().spans_one_folio(first, count) {
+            return state.write_buffered(&mut self.inner, first, count, buf);
+        }
+        // Direct write: the device must absorb overlapping dirty slots
+        // before the newer direct bytes land, then the folios are overlaid.
+        state.writeback_dirty(&mut self.inner, Some((first, count)))?;
+        self.inner.write_block(block_id, buf)?;
+        state.apply_direct(first, count, buf, false);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> BlockResult<()> {
+        self.sync_to_device()
+    }
+}
+
+impl<T: FsBlockDevice> Drop for BufferedBlockDevice<T> {
+    fn drop(&mut self) {
+        // The last user of a shared tree flushes pending writeback, like
+        // `SeekableDisk::drop` does for its partial-block buffer. Races
+        // between concurrent drops of the last two users can miss the
+        // flush; callers that need durability must flush explicitly.
+        if Arc::strong_count(&self.shared) == 1
+            && let Err(error) = self.sync_to_device()
+        {
+            error!("failed to flush block cache while dropping device: {error:?}");
+        }
+    }
+}

--- a/fs/ax-fs-ng/src/block/cache/device.rs
+++ b/fs/ax-fs-ng/src/block/cache/device.rs
@@ -92,8 +92,11 @@ impl BlockCacheShared {
     /// [`super::registry::reclaim_clean_folios`] for the clean-only
     /// contract.
     #[cfg(feature = "vfs")]
-    pub(crate) fn reclaim_clean_folios(&self, target: usize) -> usize {
-        self.state.lock().reclaim_clean_folios(target)
+    pub(crate) fn try_reclaim_clean_folios(&self, target: usize) -> usize {
+        let Some(mut state) = self.state.try_lock() else {
+            return 0;
+        };
+        state.reclaim_clean_folios(target)
     }
 }
 
@@ -157,6 +160,20 @@ impl<T: FsBlockDevice> BufferedBlockDevice<T> {
         }
         let count = u64::try_from(buf_len / block_size).map_err(|_| BlockError::InvalidState)?;
         Ok((block_id, count))
+    }
+
+    #[cfg(all(test, feature = "vfs"))]
+    pub(super) fn reclaim_from_allocator_while_state_locked_for_test(&self) -> usize {
+        let _state = self.shared.state.lock();
+        super::registry::reclaim_clean_folios(usize::MAX)
+    }
+
+    #[cfg(all(test, feature = "vfs"))]
+    pub(super) fn unregister_while_registry_locked_for_test(&self) {
+        super::registry::unregister_while_locked_for_test(
+            self.shared.device_key,
+            Arc::as_ptr(&self.shared),
+        );
     }
 }
 

--- a/fs/ax-fs-ng/src/block/cache/device.rs
+++ b/fs/ax-fs-ng/src/block/cache/device.rs
@@ -213,9 +213,19 @@ impl<T: FsBlockDevice> FsBlockDevice for BufferedBlockDevice<T> {
         // Direct write: the device must absorb overlapping dirty slots
         // before the newer direct bytes land, then the folios are overlaid.
         state.writeback_dirty(&mut self.inner, Some((first, count)))?;
-        self.inner.write_block(block_id, buf)?;
-        state.apply_direct(first, count, buf, false);
-        Ok(())
+        match self.inner.write_block(block_id, buf) {
+            Ok(()) => {
+                state.apply_direct(first, count, buf, false);
+                Ok(())
+            }
+            Err(error) => {
+                // The device contract reports no completed prefix. Some
+                // blocks may already be durable, so every overlapping folio
+                // must be refetched before it can become authoritative again.
+                state.invalidate_range(first, count);
+                Err(error)
+            }
+        }
     }
 
     fn flush(&mut self) -> BlockResult<()> {

--- a/fs/ax-fs-ng/src/block/cache/device.rs
+++ b/fs/ax-fs-ng/src/block/cache/device.rs
@@ -14,23 +14,36 @@
 //! see the module documentation for the full mapping.
 
 use alloc::{boxed::Box, sync::Arc};
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use super::address_space::{BlockAddressSpace, FolioGeometry};
 use crate::{BlockError, BlockResult, block::FsBlockDevice, os::sync::SleepMutex};
 
-/// The shared per-device cache tree behind a sleepable lock.
+/// The shared per-device cache tree and its global-writeback endpoint.
 ///
 /// All filesystem instances on one physical device serialize through this
 /// lock (Linux instead locks folios individually; see module documentation
-/// for why that split has no effect in the synchronous IO model).
+/// for why that split has no effect in the synchronous IO model). The
+/// independent consumer count excludes temporary global-sync references and
+/// elects exactly one last wrapper to perform drop-time writeback.
 pub(crate) struct BlockCacheShared {
+    device_key: usize,
+    consumers: AtomicUsize,
     state: SleepMutex<BlockAddressSpace>,
+    endpoint: SleepMutex<Box<dyn FsBlockDevice>>,
 }
 
 impl BlockCacheShared {
-    pub(crate) fn new(geometry: FolioGeometry) -> Self {
+    pub(crate) fn new(
+        device_key: usize,
+        geometry: FolioGeometry,
+        endpoint: Box<dyn FsBlockDevice>,
+    ) -> Self {
         Self {
+            device_key,
+            consumers: AtomicUsize::new(0),
             state: SleepMutex::new(BlockAddressSpace::new(geometry)),
+            endpoint: SleepMutex::new(endpoint),
         }
     }
 
@@ -38,6 +51,25 @@ impl BlockCacheShared {
     /// different size means the device key collides across geometries.
     pub(crate) fn matches_block_size(&self, block_size: usize) -> bool {
         self.state.lock().geometry().block_size() == block_size
+    }
+
+    fn acquire_consumer(&self) -> BlockResult<()> {
+        self.consumers
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                count.checked_add(1)
+            })
+            .map(|_| ())
+            .map_err(|_| BlockError::InvalidState)
+    }
+
+    fn release_consumer(&self) -> bool {
+        let previous = self
+            .consumers
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                count.checked_sub(1)
+            })
+            .expect("each cache wrapper acquires exactly one consumer reference");
+        previous == 1
     }
 
     /// Writes back every dirty slot through `endpoint`, then issues its
@@ -51,12 +83,26 @@ impl BlockCacheShared {
         endpoint.flush()
     }
 
+    /// Writes back through the endpoint owned by the shared cache tree.
+    pub(crate) fn sync_to_registered_device(&self) -> BlockResult<()> {
+        self.sync_to_device_with(&mut **self.endpoint.lock())
+    }
+
     /// Drops up to `target` clean folios from the LRU end; see
     /// [`super::registry::reclaim_clean_folios`] for the clean-only
     /// contract.
     #[cfg(feature = "vfs")]
     pub(crate) fn reclaim_clean_folios(&self, target: usize) -> usize {
         self.state.lock().reclaim_clean_folios(target)
+    }
+}
+
+impl Drop for BlockCacheShared {
+    fn drop(&mut self) {
+        super::registry::unregister_cache(
+            self.device_key,
+            core::ptr::from_ref::<BlockCacheShared>(self),
+        );
     }
 }
 
@@ -76,9 +122,9 @@ impl<T: FsBlockDevice> BufferedBlockDevice<T> {
     /// # Errors
     ///
     /// Returns [`BlockError::InvalidRequest`] when the device block size is
-    /// zero or not a power of two, and [`BlockError::InvalidState`] when
-    /// the registered tree for `device_key` was built for a different
-    /// block size.
+    /// zero or not a power of two, [`BlockError::InvalidState`] when the
+    /// registered tree for `device_key` was built for a different block
+    /// size, and [`BlockError::NoMemory`] when the registry cannot grow.
     pub(crate) fn with_device_key(
         device_key: usize,
         endpoint: Box<dyn FsBlockDevice>,
@@ -86,6 +132,7 @@ impl<T: FsBlockDevice> BufferedBlockDevice<T> {
     ) -> BlockResult<Self> {
         let block_size = inner.block_size();
         let shared = super::registry::shared_cache_for(device_key, block_size, endpoint)?;
+        shared.acquire_consumer()?;
         Ok(Self { inner, shared })
     }
 
@@ -161,11 +208,11 @@ impl<T: FsBlockDevice> FsBlockDevice for BufferedBlockDevice<T> {
 
 impl<T: FsBlockDevice> Drop for BufferedBlockDevice<T> {
     fn drop(&mut self) {
-        // The last user of a shared tree flushes pending writeback, like
-        // `SeekableDisk::drop` does for its partial-block buffer. Races
-        // between concurrent drops of the last two users can miss the
-        // flush; callers that need durability must flush explicitly.
-        if Arc::strong_count(&self.shared) == 1
+        // The consumer count is independent from temporary strong refs held
+        // by global sync. Exactly one concurrent wrapper drop observes the
+        // transition to zero and flushes while the tree remains upgradeable,
+        // so a same-key creator cannot race a stale tree against a new one.
+        if self.shared.release_consumer()
             && let Err(error) = self.sync_to_device()
         {
             error!("failed to flush block cache while dropping device: {error:?}");

--- a/fs/ax-fs-ng/src/block/cache/folio.rs
+++ b/fs/ax-fs-ng/src/block/cache/folio.rs
@@ -6,23 +6,39 @@
 //! aggregation of slot bits, mirroring the Linux rule that a dirty page
 //! with buffers only means "at least one block is dirty".
 
-use alloc::{boxed::Box, vec::Vec};
+use alloc::vec::Vec;
 
 use super::buffer_head::BufferHead;
+use crate::{BlockError, BlockResult};
 
 /// One frame of the block cache: the frame bytes plus per-slot states.
 #[derive(Debug)]
 pub(crate) struct CacheFolio {
-    data: Box<[u8]>,
+    data: Vec<u8>,
     heads: Vec<BufferHead>,
 }
 
 impl CacheFolio {
-    pub(crate) fn new(folio_size: usize, slots: usize) -> Self {
-        Self {
-            data: alloc::vec![0u8; folio_size].into_boxed_slice(),
-            heads: alloc::vec![BufferHead::default(); slots],
-        }
+    /// Allocates one folio and all of its per-block state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BlockError::NoMemory`] when either backing allocation
+    /// cannot be reserved. Both vectors remain local until they are fully
+    /// initialized, so a partial allocation never enters the cache tree.
+    pub(crate) fn try_new(folio_size: usize, slots: usize) -> BlockResult<Self> {
+        let mut data = Vec::new();
+        data.try_reserve_exact(folio_size)
+            .map_err(|_| BlockError::NoMemory)?;
+        data.resize(folio_size, 0);
+
+        let mut heads = Vec::new();
+        heads
+            .try_reserve_exact(slots)
+            .map_err(|_| BlockError::NoMemory)?;
+        heads.resize(slots, BufferHead::default());
+
+        Ok(Self { data, heads })
     }
 
     pub(crate) fn slot(&self, slot: usize) -> &BufferHead {

--- a/fs/ax-fs-ng/src/block/cache/folio.rs
+++ b/fs/ax-fs-ng/src/block/cache/folio.rs
@@ -1,0 +1,151 @@
+//! Folio-sized frames of the block cache, modeled on a Linux `folio` with
+//! an attached `buffer_head` chain (`fs/buffer.c: folio_create_buffers`).
+//!
+//! A [`CacheFolio`] owns one frame of device data plus the per-block state
+//! of every slot inside it. Frame-level dirty state is always the
+//! aggregation of slot bits, mirroring the Linux rule that a dirty page
+//! with buffers only means "at least one block is dirty".
+
+use alloc::{boxed::Box, vec::Vec};
+
+use super::buffer_head::BufferHead;
+
+/// One frame of the block cache: the frame bytes plus per-slot states.
+#[derive(Debug)]
+pub(crate) struct CacheFolio {
+    data: Box<[u8]>,
+    heads: Vec<BufferHead>,
+}
+
+impl CacheFolio {
+    pub(crate) fn new(folio_size: usize, slots: usize) -> Self {
+        Self {
+            data: alloc::vec![0u8; folio_size].into_boxed_slice(),
+            heads: alloc::vec![BufferHead::default(); slots],
+        }
+    }
+
+    pub(crate) fn slot(&self, slot: usize) -> &BufferHead {
+        &self.heads[slot]
+    }
+
+    /// Byte range covering `[slot, slot + count)` blocks of this folio.
+    fn slot_bytes(&self, slot: usize, count: usize) -> core::ops::Range<usize> {
+        let block = self.data.len() / self.heads.len();
+        slot * block..(slot + count) * block
+    }
+
+    /// Mutable bytes of a slot range, used as the device IO target so reads
+    /// and writebacks never stage through a second buffer.
+    pub(crate) fn slot_bytes_mut(&mut self, slot: usize, count: usize) -> &mut [u8] {
+        let range = self.slot_bytes(slot, count);
+        &mut self.data[range]
+    }
+
+    pub(crate) fn copy_from_slots(&self, slot: usize, count: usize, dst: &mut [u8]) {
+        let range = self.slot_bytes(slot, count);
+        dst.copy_from_slice(&self.data[range]);
+    }
+
+    pub(crate) fn copy_into_slots(&mut self, slot: usize, count: usize, src: &[u8]) {
+        let range = self.slot_bytes(slot, count);
+        self.data[range].copy_from_slice(src);
+    }
+
+    pub(crate) fn mark_slots_uptodate(&mut self, slot: usize, count: usize) {
+        for head in &mut self.heads[slot..slot + count] {
+            head.mark_uptodate();
+        }
+    }
+
+    /// Marks a slot range dirty (`mark_buffer_dirty`); returns how many
+    /// slots were dirty already, so the caller can keep tree-level dirty
+    /// accounting exact.
+    pub(crate) fn mark_slots_dirty(&mut self, slot: usize, count: usize) -> usize {
+        let mut newly_dirty = 0;
+        for head in &mut self.heads[slot..slot + count] {
+            if !head.is_dirty() {
+                newly_dirty += 1;
+            }
+            head.mark_dirty();
+        }
+        newly_dirty
+    }
+
+    /// Clears dirty state of a slot range; returns how many slots were
+    /// dirty before the call.
+    pub(crate) fn clear_dirty_slots(&mut self, slot: usize, count: usize) -> usize {
+        let mut cleared = 0;
+        for head in &mut self.heads[slot..slot + count] {
+            if head.clear_dirty() {
+                cleared += 1;
+            }
+        }
+        cleared
+    }
+
+    pub(crate) fn has_dirty_slots(&self) -> bool {
+        self.heads.iter().any(BufferHead::is_dirty)
+    }
+
+    /// Overlays the result of a device-direct request onto this folio.
+    ///
+    /// `src` holds the bytes of the whole direct request starting at this
+    /// folio's first overlapping slot. Dirty slots hold data newer than the
+    /// device copy, so they keep their bytes when `preserve_dirty` is set
+    /// (direct reads); direct writes pass `false` because any overlapping
+    /// dirty state was written back before the device write.
+    pub(crate) fn overlay_external(
+        &mut self,
+        slot: usize,
+        count: usize,
+        src: &[u8],
+        preserve_dirty: bool,
+    ) {
+        let block = self.data.len() / self.heads.len();
+        for (offset, head) in self.heads[slot..slot + count].iter_mut().enumerate() {
+            let src_block = &src[offset * block..(offset + 1) * block];
+            if preserve_dirty && head.is_dirty() {
+                continue;
+            }
+            let start = (slot + offset) * block;
+            self.data[start..start + block].copy_from_slice(src_block);
+            head.mark_uptodate();
+        }
+    }
+
+    /// Iterates runs of consecutive dirty slots in ascending order, so
+    /// writeback can merge adjacent blocks into single device writes
+    /// (the `__block_write_full_folio` rule: only dirty blocks are
+    /// submitted, never whole folios).
+    pub(crate) fn dirty_runs(&self) -> DirtyRuns<'_> {
+        DirtyRuns {
+            heads: &self.heads,
+            cursor: 0,
+        }
+    }
+}
+
+/// Iterator over `(first_slot, block_count)` runs of consecutive dirty
+/// slots.
+pub(crate) struct DirtyRuns<'a> {
+    heads: &'a [BufferHead],
+    cursor: usize,
+}
+
+impl Iterator for DirtyRuns<'_> {
+    type Item = (usize, usize);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let start = self.heads[self.cursor..]
+            .iter()
+            .position(BufferHead::is_dirty)?
+            + self.cursor;
+        let end = self.heads[start..]
+            .iter()
+            .position(|head| !head.is_dirty())
+            .map_or(self.heads.len(), |clean| start + clean);
+        self.cursor = end;
+        Some((start, end - start))
+    }
+}

--- a/fs/ax-fs-ng/src/block/cache/folio_cache.rs
+++ b/fs/ax-fs-ng/src/block/cache/folio_cache.rs
@@ -1,0 +1,169 @@
+//! Fallible fixed-capacity index and LRU order for cached folios.
+
+use core::num::NonZeroUsize;
+
+use hashbrown::HashMap;
+
+use super::folio::CacheFolio;
+use crate::{BlockError, BlockResult};
+
+struct CachedFolio {
+    folio: CacheFolio,
+    more_recent: Option<u64>,
+    less_recent: Option<u64>,
+}
+
+/// Fixed-capacity hash index with an allocation-free intrusive LRU order.
+///
+/// Hash-table growth is reserved fallibly immediately before insertion.
+/// The links use frame indices rather than pointers so rehashing cannot
+/// invalidate the LRU order.
+pub(super) struct FolioCache {
+    entries: HashMap<u64, CachedFolio>,
+    capacity: NonZeroUsize,
+    most_recent: Option<u64>,
+    least_recent: Option<u64>,
+}
+
+impl FolioCache {
+    pub(super) fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            capacity,
+            most_recent: None,
+            least_recent: None,
+        }
+    }
+
+    #[cfg(feature = "vfs")]
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(super) fn contains(&self, frame: &u64) -> bool {
+        self.entries.contains_key(frame)
+    }
+
+    pub(super) fn is_full(&self) -> bool {
+        self.entries.len() >= self.capacity.get()
+    }
+
+    #[cfg(feature = "vfs")]
+    pub(super) fn get(&self, frame: &u64) -> Option<&CacheFolio> {
+        self.entries.get(frame).map(|entry| &entry.folio)
+    }
+
+    pub(super) fn get_mut(&mut self, frame: &u64) -> Option<&mut CacheFolio> {
+        self.touch(*frame);
+        self.entries.get_mut(frame).map(|entry| &mut entry.folio)
+    }
+
+    pub(super) fn touch(&mut self, frame: u64) {
+        if self.most_recent == Some(frame) {
+            return;
+        }
+        let Some(entry) = self.entries.get(&frame) else {
+            return;
+        };
+        let more_recent = entry.more_recent;
+        let less_recent = entry.less_recent;
+
+        if let Some(more_recent) = more_recent {
+            self.entries
+                .get_mut(&more_recent)
+                .expect("LRU link must name a cached folio")
+                .less_recent = less_recent;
+        } else {
+            self.most_recent = less_recent;
+        }
+        if let Some(less_recent) = less_recent {
+            self.entries
+                .get_mut(&less_recent)
+                .expect("LRU link must name a cached folio")
+                .more_recent = more_recent;
+        } else {
+            self.least_recent = more_recent;
+        }
+
+        let previous_most_recent = self.most_recent;
+        let entry = self
+            .entries
+            .get_mut(&frame)
+            .expect("touched folio must remain cached");
+        entry.more_recent = None;
+        entry.less_recent = previous_most_recent;
+        if let Some(previous_most_recent) = previous_most_recent {
+            self.entries
+                .get_mut(&previous_most_recent)
+                .expect("LRU head must name a cached folio")
+                .more_recent = Some(frame);
+        } else {
+            self.least_recent = Some(frame);
+        }
+        self.most_recent = Some(frame);
+    }
+
+    /// Reserves the hash-table slot needed by a later insertion. Callers do
+    /// this before evicting so allocation failure cannot change LRU state.
+    pub(super) fn try_reserve_entry(&mut self) -> BlockResult<()> {
+        self.entries
+            .try_reserve(1)
+            .map_err(|_| BlockError::NoMemory)
+    }
+
+    #[cfg(test)]
+    pub(super) fn try_reserve_for_test(&mut self, additional: usize) -> BlockResult<()> {
+        self.entries
+            .try_reserve(additional)
+            .map_err(|_| BlockError::NoMemory)
+    }
+
+    /// Inserts after [`Self::try_reserve_entry`] has succeeded.
+    pub(super) fn insert_reserved(&mut self, frame: u64, folio: CacheFolio) {
+        debug_assert!(!self.entries.contains_key(&frame));
+        debug_assert!(self.entries.len() < self.capacity.get());
+        let previous_most_recent = self.most_recent;
+        self.entries.insert(
+            frame,
+            CachedFolio {
+                folio,
+                more_recent: None,
+                less_recent: previous_most_recent,
+            },
+        );
+        if let Some(previous_most_recent) = previous_most_recent {
+            self.entries
+                .get_mut(&previous_most_recent)
+                .expect("LRU head must name a cached folio")
+                .more_recent = Some(frame);
+        } else {
+            self.least_recent = Some(frame);
+        }
+        self.most_recent = Some(frame);
+    }
+
+    pub(super) fn remove(&mut self, frame: &u64) -> Option<CacheFolio> {
+        let entry = self.entries.remove(frame)?;
+        if let Some(more_recent) = entry.more_recent {
+            self.entries
+                .get_mut(&more_recent)
+                .expect("LRU link must name a cached folio")
+                .less_recent = entry.less_recent;
+        } else {
+            self.most_recent = entry.less_recent;
+        }
+        if let Some(less_recent) = entry.less_recent {
+            self.entries
+                .get_mut(&less_recent)
+                .expect("LRU link must name a cached folio")
+                .more_recent = entry.more_recent;
+        } else {
+            self.least_recent = entry.more_recent;
+        }
+        Some(entry.folio)
+    }
+
+    pub(super) fn least_recent(&self) -> Option<u64> {
+        self.least_recent
+    }
+}

--- a/fs/ax-fs-ng/src/block/cache/mod.rs
+++ b/fs/ax-fs-ng/src/block/cache/mod.rs
@@ -9,7 +9,7 @@
 //! | bdev inode `address_space`, keyed by page index | [`BlockAddressSpace`], keyed by folio frame index, one per device |
 //! | `folio` with attached buffers | [`CacheFolio`], 4 KiB or one device block, whichever is larger |
 //! | `buffer_head` `BH_Uptodate`/`BH_Dirty` bits | [`BufferHead`] slot state (`BH_Mapped` is implicit: the cache is an identity mapping) |
-//! | `PAGECACHE_TAG_DIRTY` tree mark | ordered `dirty_frames` set plus a dirty-slot counter |
+//! | `PAGECACHE_TAG_DIRTY` tree mark | ordered `dirty_frames` index |
 //! | `getblk` / `bread` | [`BlockAddressSpace`] folio lookup / [`BufferedBlockDevice`] buffered reads |
 //! | `mark_buffer_dirty` | deferred one-folio writes (data reaches the device only at writeback) |
 //! | `sync_dirty_buffers` | [`BlockAddressSpace::writeback_dirty`], submitting merged dirty runs |
@@ -20,7 +20,8 @@
 //!
 //! # Deviations from Linux (recorded deliberately)
 //!
-//! * Writeback is synchronous and happens at `flush()`, eviction, and drop;
+//! * Writeback is synchronous and happens at `flush()`, eviction, and the
+//!   last filesystem consumer's drop;
 //!   Linux has per-BDI flusher threads. The current `FsBlockDevice` model
 //!   is fully synchronous, so a WRITEBACK mark and a background flusher
 //!   would have no observable effect.
@@ -46,6 +47,7 @@ mod address_space;
 mod buffer_head;
 mod device;
 mod folio;
+mod folio_cache;
 mod registry;
 
 #[cfg(test)]

--- a/fs/ax-fs-ng/src/block/cache/mod.rs
+++ b/fs/ax-fs-ng/src/block/cache/mod.rs
@@ -13,7 +13,7 @@
 //! | `getblk` / `bread` | [`BlockAddressSpace`] folio lookup / [`BufferedBlockDevice`] buffered reads |
 //! | `mark_buffer_dirty` | deferred one-folio writes (data reaches the device only at writeback) |
 //! | `sync_dirty_buffers` | [`BlockAddressSpace::writeback_dirty`], submitting merged dirty runs |
-//! | `invalidate_bdev` | [`BufferedBlockDevice::invalidate_range`] |
+//! | `invalidate_bdev` | [`BlockAddressSpace::invalidate_range`] after an indeterminate direct-write failure |
 //! | partitions sharing one bdev cache | [`registry`], keyed by runtime-handle identity |
 //!
 //! [`registry`]: super::cache::registry

--- a/fs/ax-fs-ng/src/block/cache/mod.rs
+++ b/fs/ax-fs-ng/src/block/cache/mod.rs
@@ -57,3 +57,5 @@ pub(crate) use device::BufferedBlockDevice;
 #[cfg(feature = "vfs")]
 pub(crate) use registry::reclaim_clean_folios;
 pub use registry::sync_all_block_caches;
+#[cfg(test)]
+pub(super) use registry::{fail_registry_reserve_for_key_for_test, registry_contains_key_for_test};

--- a/fs/ax-fs-ng/src/block/cache/mod.rs
+++ b/fs/ax-fs-ng/src/block/cache/mod.rs
@@ -1,0 +1,57 @@
+//! Shared block cache between the block runtime and filesystem consumers,
+//! modeled on Linux's block-device page cache and its `buffer_head` layer
+//! (`fs/buffer.c`, `block/bdev.c`).
+//!
+//! # Linux design mapping
+//!
+//! | Linux | Here |
+//! |---|---|
+//! | bdev inode `address_space`, keyed by page index | [`BlockAddressSpace`], keyed by folio frame index, one per device |
+//! | `folio` with attached buffers | [`CacheFolio`], 4 KiB or one device block, whichever is larger |
+//! | `buffer_head` `BH_Uptodate`/`BH_Dirty` bits | [`BufferHead`] slot state (`BH_Mapped` is implicit: the cache is an identity mapping) |
+//! | `PAGECACHE_TAG_DIRTY` tree mark | ordered `dirty_frames` set plus a dirty-slot counter |
+//! | `getblk` / `bread` | [`BlockAddressSpace`] folio lookup / [`BufferedBlockDevice`] buffered reads |
+//! | `mark_buffer_dirty` | deferred one-folio writes (data reaches the device only at writeback) |
+//! | `sync_dirty_buffers` | [`BlockAddressSpace::writeback_dirty`], submitting merged dirty runs |
+//! | `invalidate_bdev` | [`BufferedBlockDevice::invalidate_range`] |
+//! | partitions sharing one bdev cache | [`registry`], keyed by runtime-handle identity |
+//!
+//! [`registry`]: super::cache::registry
+//!
+//! # Deviations from Linux (recorded deliberately)
+//!
+//! * Writeback is synchronous and happens at `flush()`, eviction, and drop;
+//!   Linux has per-BDI flusher threads. The current `FsBlockDevice` model
+//!   is fully synchronous, so a WRITEBACK mark and a background flusher
+//!   would have no observable effect.
+//! * One sleepable lock serializes each device tree instead of per-folio
+//!   locks. All current callers already serialize filesystem IO per
+//!   instance; the shared tree only adds serialization between partitions
+//!   of the same physical device.
+//! * The metadata/data split is expressed at folio granularity: requests
+//!   inside one folio take the buffered path, multi-folio requests go
+//!   device-direct. Linux declares the same split at the filesystem layer
+//!   (metadata via `__bread` into the bdev cache, file data via the inode
+//!   page cache); the `FsBlockDevice` boundary only sees request shapes,
+//!   and block-granular access is exactly the metadata-style pattern.
+//!
+//! # Crash-consistency contract
+//!
+//! `flush()` writes back every dirty slot and only then issues the device
+//! barrier. rsext4's JBD2 commit already flushes the device before writing
+//! the commit record, so deferring block writes into this layer preserves
+//! journal ordering without any change to the commit sequence.
+
+mod address_space;
+mod buffer_head;
+mod device;
+mod folio;
+mod registry;
+
+#[cfg(test)]
+mod tests;
+
+pub(crate) use device::BufferedBlockDevice;
+#[cfg(feature = "vfs")]
+pub(crate) use registry::reclaim_clean_folios;
+pub use registry::sync_all_block_caches;

--- a/fs/ax-fs-ng/src/block/cache/registry.rs
+++ b/fs/ax-fs-ng/src/block/cache/registry.rs
@@ -21,6 +21,8 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
+#[cfg(test)]
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use ax_lazyinit::LazyLock;
 
@@ -34,6 +36,9 @@ struct DeviceCacheEntry {
 
 static BLOCK_CACHE_REGISTRY: LazyLock<Mutex<Vec<DeviceCacheEntry>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
+
+#[cfg(test)]
+static FAIL_REGISTRY_RESERVE_FOR_KEY: AtomicUsize = AtomicUsize::new(0);
 
 /// Resolves the shared cache tree of the device identified by
 /// `device_key`, creating it on first use with `endpoint` as its global
@@ -72,6 +77,13 @@ pub(crate) fn shared_cache_for(
     };
 
     if stale_index.is_none() {
+        #[cfg(test)]
+        if FAIL_REGISTRY_RESERVE_FOR_KEY
+            .compare_exchange(device_key, 0, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            return Err(BlockError::NoMemory);
+        }
         registry.try_reserve(1).map_err(|_| BlockError::NoMemory)?;
     }
     let shared = Arc::new(BlockCacheShared::new(device_key, geometry, endpoint));
@@ -85,6 +97,22 @@ pub(crate) fn shared_cache_for(
         registry.push(entry);
     }
     Ok(shared)
+}
+
+#[cfg(test)]
+pub(crate) fn fail_registry_reserve_for_key_for_test(device_key: usize) {
+    assert_ne!(device_key, 0, "zero means no injected allocation failure");
+    FAIL_REGISTRY_RESERVE_FOR_KEY
+        .compare_exchange(0, device_key, Ordering::AcqRel, Ordering::Acquire)
+        .expect("only one registry allocation failure may be injected at a time");
+}
+
+#[cfg(test)]
+pub(crate) fn registry_contains_key_for_test(device_key: usize) -> bool {
+    BLOCK_CACHE_REGISTRY
+        .lock()
+        .iter()
+        .any(|entry| entry.device_key == device_key)
 }
 
 /// Removes the registry entry that still names `cache` without waiting.

--- a/fs/ax-fs-ng/src/block/cache/registry.rs
+++ b/fs/ax-fs-ng/src/block/cache/registry.rs
@@ -1,0 +1,135 @@
+//! Per-device cache sharing, mirroring Linux's single `address_space` per
+//! block device: every partition-backed filesystem instance on one device
+//! resolves to the same cache tree, keyed by the identity (allocation
+//! address) of the runtime `BlockDeviceHandle`.
+//!
+//! Key stability holds because each cached device keeps its own `Arc`
+//! clone of the handle alive, so the address cannot be reused while a
+//! registry entry for it exists. Entries hold only weak references to the
+//! tree: it dies with its last consumer after best-effort writeback in
+//! `BufferedBlockDevice::drop`.
+//!
+//! Each entry also owns a device endpoint (an equivalent `FsBlockDevice`
+//! over the same runtime handle) so global operations —
+//! [`sync_all_block_caches`] — can write back trees that no wrapper is
+//! currently driving.
+
+use alloc::{
+    boxed::Box,
+    collections::BTreeMap,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+
+use ax_lazyinit::LazyLock;
+
+use super::{address_space::FolioGeometry, device::BlockCacheShared};
+use crate::{BlockError, BlockResult, block::FsBlockDevice, os::sync::SleepMutex as Mutex};
+
+struct DeviceCacheEntry {
+    cache: Weak<BlockCacheShared>,
+    /// Device endpoint for global writeback; equivalent to every wrapper's
+    /// inner device because they share the same runtime handle.
+    endpoint: Arc<Mutex<Box<dyn FsBlockDevice>>>,
+}
+
+static BLOCK_CACHE_REGISTRY: LazyLock<Mutex<BTreeMap<usize, DeviceCacheEntry>>> =
+    LazyLock::new(|| Mutex::new(BTreeMap::new()));
+
+/// Resolves the shared cache tree of the device identified by
+/// `device_key`, creating it on first use with `endpoint` as its global
+/// writeback device.
+///
+/// # Errors
+///
+/// Returns [`BlockError::InvalidRequest`] when `block_size` is zero or not
+/// a power of two, and [`BlockError::InvalidState`] when the registered
+/// tree for `device_key` was built for a different block size (a key
+/// collision that would mix incompatible folio layouts).
+pub(crate) fn shared_cache_for(
+    device_key: usize,
+    block_size: usize,
+    endpoint: Box<dyn FsBlockDevice>,
+) -> BlockResult<Arc<BlockCacheShared>> {
+    // Lock order: registry first, then the device tree lock. No path takes
+    // them in the opposite order.
+    let mut registry = BLOCK_CACHE_REGISTRY.lock();
+    if let Some(entry) = registry.get(&device_key)
+        && let Some(shared) = entry.cache.upgrade()
+    {
+        if shared.matches_block_size(block_size) {
+            return Ok(shared);
+        }
+        return Err(BlockError::InvalidState);
+    }
+
+    let shared = Arc::new(BlockCacheShared::new(FolioGeometry::new(block_size)?));
+    registry.retain(|_, entry| entry.cache.strong_count() > 0);
+    registry.insert(
+        device_key,
+        DeviceCacheEntry {
+            cache: Arc::downgrade(&shared),
+            endpoint: Arc::new(Mutex::new(endpoint)),
+        },
+    );
+    Ok(shared)
+}
+
+/// Writes back every live device cache tree and issues each device's flush
+/// barrier (the `sync(2)` analog of `sync_dirty_buffers` across the
+/// registry). Later devices are still attempted when one fails; the first
+/// error is returned.
+///
+/// # Errors
+///
+/// Returns the first device writeback or flush error encountered.
+pub fn sync_all_block_caches() -> BlockResult<()> {
+    let mut first_error = None;
+    for (shared, endpoint) in live_trees() {
+        let result = shared.sync_to_device_with(&mut *endpoint.lock());
+        if let Err(error) = result
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+/// Evicts up to `num_folios` clean folios across live device trees,
+/// returning how many were dropped.
+///
+/// Only clean folios are reclaimed, matching the page-cache reclaim
+/// contract: this runs from the allocator's pressure hook, where device
+/// IO must not happen. Dirty folios are moved back to the
+/// most-recently-used end and skipped.
+///
+/// Gated on `vfs` together with its only consumer, the page-cache
+/// reclaim hook.
+#[cfg(feature = "vfs")]
+pub(crate) fn reclaim_clean_folios(num_folios: usize) -> usize {
+    let mut reclaimed = 0;
+    for (shared, _) in live_trees() {
+        if reclaimed >= num_folios {
+            break;
+        }
+        reclaimed += shared.reclaim_clean_folios(num_folios - reclaimed);
+    }
+    reclaimed
+}
+
+/// A live cache tree paired with its global-writeback endpoint.
+type LiveTree = (Arc<BlockCacheShared>, Arc<DeviceEndpoint>);
+
+/// The registry-owned device endpoint of one cache tree.
+type DeviceEndpoint = Mutex<Box<dyn FsBlockDevice>>;
+
+/// Collects live trees; the `Arc` endpoint keeps the device reachable
+/// after the registry lock is released.
+fn live_trees() -> Vec<LiveTree> {
+    let registry = BLOCK_CACHE_REGISTRY.lock();
+    registry
+        .values()
+        .filter_map(|entry| Some((entry.cache.upgrade()?, entry.endpoint.clone())))
+        .collect()
+}

--- a/fs/ax-fs-ng/src/block/cache/registry.rs
+++ b/fs/ax-fs-ng/src/block/cache/registry.rs
@@ -3,13 +3,13 @@
 //! resolves to the same cache tree, keyed by the identity (allocation
 //! address) of the runtime `BlockDeviceHandle`.
 //!
-//! Key stability holds because each cached device keeps its own `Arc`
-//! clone of the handle alive, so the address cannot be reused while a
-//! registry entry for it exists. Entries hold only weak references to the
-//! tree. The last filesystem consumer writes the tree back while it is
-//! still upgradeable; the tree's final drop then removes its matching
-//! entry and releases the endpoint so the runtime handle can reach its
-//! shutdown path.
+//! Key stability holds for live entries because each cached device keeps its
+//! own `Arc` clone of the handle alive. Entries hold only weak references to
+//! the tree. The last filesystem consumer writes the tree back while it is
+//! still upgradeable; the tree's final drop releases the endpoint and removes
+//! its entry when the registry is immediately available. A contended drop may
+//! leave a stale weak entry, which cache creation or global sync prunes before
+//! it can be reused.
 //!
 //! Each live tree owns a device endpoint (an equivalent `FsBlockDevice`
 //! over the same runtime handle) so global operations —
@@ -55,6 +55,7 @@ pub(crate) fn shared_cache_for(
     // Lock order: registry first, then the device tree lock. No path takes
     // them in the opposite order.
     let mut registry = BLOCK_CACHE_REGISTRY.lock();
+    prune_stale_entries(&mut registry);
     let stale_index = if let Some(index) = registry
         .iter()
         .position(|entry| entry.device_key == device_key)
@@ -86,15 +87,26 @@ pub(crate) fn shared_cache_for(
     Ok(shared)
 }
 
-/// Removes the registry entry that still names `cache`.
+/// Removes the registry entry that still names `cache` without waiting.
+///
+/// A contended drop leaves only a stale weak entry. Cache creation and global
+/// sync prune such entries while they already own the registry lock.
 pub(super) fn unregister_cache(device_key: usize, cache: *const BlockCacheShared) {
-    let mut registry = BLOCK_CACHE_REGISTRY.lock();
+    let Some(mut registry) = BLOCK_CACHE_REGISTRY.try_lock() else {
+        return;
+    };
     let Some(index) = registry.iter().position(|entry| {
         entry.device_key == device_key && core::ptr::eq(entry.cache.as_ptr(), cache)
     }) else {
         return;
     };
     registry.swap_remove(index);
+}
+
+#[cfg(all(test, feature = "vfs"))]
+pub(super) fn unregister_while_locked_for_test(device_key: usize, cache: *const BlockCacheShared) {
+    let _registry = BLOCK_CACHE_REGISTRY.lock();
+    unregister_cache(device_key, cache);
 }
 
 /// Writes back every live device cache tree and issues each device's flush
@@ -131,23 +143,45 @@ pub fn sync_all_block_caches() -> BlockResult<()> {
 /// reclaim hook.
 #[cfg(feature = "vfs")]
 pub(crate) fn reclaim_clean_folios(num_folios: usize) -> usize {
-    let mut reclaimed = 0;
-    let Ok(trees) = live_trees() else {
+    let Some(tree_count) = BLOCK_CACHE_REGISTRY
+        .try_lock()
+        .map(|registry| registry.len())
+    else {
         return 0;
     };
-    for shared in trees {
+    let mut reclaimed = 0;
+    for index in 0..tree_count {
         if reclaimed >= num_folios {
             break;
         }
-        reclaimed += shared.reclaim_clean_folios(num_folios - reclaimed);
+        let Some(shared) = try_live_tree(index) else {
+            continue;
+        };
+        reclaimed += shared.try_reclaim_clean_folios(num_folios - reclaimed);
     }
     reclaimed
+}
+
+/// Upgrades one tree without allocating or waiting for the registry lock.
+///
+/// The registry may change between indices. Reclaim is best-effort, so a
+/// removed or contended entry is skipped; the returned strong reference is
+/// dropped only after the registry guard has gone out of scope.
+#[cfg(feature = "vfs")]
+fn try_live_tree(index: usize) -> Option<Arc<BlockCacheShared>> {
+    let registry = BLOCK_CACHE_REGISTRY.try_lock()?;
+    registry.get(index)?.cache.upgrade()
+}
+
+fn prune_stale_entries(registry: &mut Vec<DeviceCacheEntry>) {
+    registry.retain(|entry| entry.cache.strong_count() != 0);
 }
 
 /// Collects live trees; each tree owns the endpoint that keeps its device
 /// reachable after the registry lock is released.
 fn live_trees() -> BlockResult<Vec<Arc<BlockCacheShared>>> {
-    let registry = BLOCK_CACHE_REGISTRY.lock();
+    let mut registry = BLOCK_CACHE_REGISTRY.lock();
+    prune_stale_entries(&mut registry);
     let mut trees = Vec::new();
     trees
         .try_reserve_exact(registry.len())

--- a/fs/ax-fs-ng/src/block/cache/registry.rs
+++ b/fs/ax-fs-ng/src/block/cache/registry.rs
@@ -6,17 +6,18 @@
 //! Key stability holds because each cached device keeps its own `Arc`
 //! clone of the handle alive, so the address cannot be reused while a
 //! registry entry for it exists. Entries hold only weak references to the
-//! tree: it dies with its last consumer after best-effort writeback in
-//! `BufferedBlockDevice::drop`.
+//! tree. The last filesystem consumer writes the tree back while it is
+//! still upgradeable; the tree's final drop then removes its matching
+//! entry and releases the endpoint so the runtime handle can reach its
+//! shutdown path.
 //!
-//! Each entry also owns a device endpoint (an equivalent `FsBlockDevice`
+//! Each live tree owns a device endpoint (an equivalent `FsBlockDevice`
 //! over the same runtime handle) so global operations —
-//! [`sync_all_block_caches`] — can write back trees that no wrapper is
-//! currently driving.
+//! [`sync_all_block_caches`] — can write it back without extending the
+//! endpoint lifetime beyond the tree's last consumer.
 
 use alloc::{
     boxed::Box,
-    collections::BTreeMap,
     sync::{Arc, Weak},
     vec::Vec,
 };
@@ -27,14 +28,12 @@ use super::{address_space::FolioGeometry, device::BlockCacheShared};
 use crate::{BlockError, BlockResult, block::FsBlockDevice, os::sync::SleepMutex as Mutex};
 
 struct DeviceCacheEntry {
+    device_key: usize,
     cache: Weak<BlockCacheShared>,
-    /// Device endpoint for global writeback; equivalent to every wrapper's
-    /// inner device because they share the same runtime handle.
-    endpoint: Arc<Mutex<Box<dyn FsBlockDevice>>>,
 }
 
-static BLOCK_CACHE_REGISTRY: LazyLock<Mutex<BTreeMap<usize, DeviceCacheEntry>>> =
-    LazyLock::new(|| Mutex::new(BTreeMap::new()));
+static BLOCK_CACHE_REGISTRY: LazyLock<Mutex<Vec<DeviceCacheEntry>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
 
 /// Resolves the shared cache tree of the device identified by
 /// `device_key`, creating it on first use with `endpoint` as its global
@@ -43,36 +42,59 @@ static BLOCK_CACHE_REGISTRY: LazyLock<Mutex<BTreeMap<usize, DeviceCacheEntry>>> 
 /// # Errors
 ///
 /// Returns [`BlockError::InvalidRequest`] when `block_size` is zero or not
-/// a power of two, and [`BlockError::InvalidState`] when the registered
-/// tree for `device_key` was built for a different block size (a key
-/// collision that would mix incompatible folio layouts).
+/// a power of two, [`BlockError::InvalidState`] when the registered tree for
+/// `device_key` was built for a different block size (a key collision that
+/// would mix incompatible folio layouts), and [`BlockError::NoMemory`] when
+/// the registry cannot grow.
 pub(crate) fn shared_cache_for(
     device_key: usize,
     block_size: usize,
     endpoint: Box<dyn FsBlockDevice>,
 ) -> BlockResult<Arc<BlockCacheShared>> {
+    let geometry = FolioGeometry::new(block_size)?;
     // Lock order: registry first, then the device tree lock. No path takes
     // them in the opposite order.
     let mut registry = BLOCK_CACHE_REGISTRY.lock();
-    if let Some(entry) = registry.get(&device_key)
-        && let Some(shared) = entry.cache.upgrade()
+    let stale_index = if let Some(index) = registry
+        .iter()
+        .position(|entry| entry.device_key == device_key)
     {
-        if shared.matches_block_size(block_size) {
-            return Ok(shared);
+        if let Some(shared) = registry[index].cache.upgrade() {
+            if shared.matches_block_size(block_size) {
+                return Ok(shared);
+            }
+            return Err(BlockError::InvalidState);
         }
-        return Err(BlockError::InvalidState);
-    }
+        Some(index)
+    } else {
+        None
+    };
 
-    let shared = Arc::new(BlockCacheShared::new(FolioGeometry::new(block_size)?));
-    registry.retain(|_, entry| entry.cache.strong_count() > 0);
-    registry.insert(
+    if stale_index.is_none() {
+        registry.try_reserve(1).map_err(|_| BlockError::NoMemory)?;
+    }
+    let shared = Arc::new(BlockCacheShared::new(device_key, geometry, endpoint));
+    let entry = DeviceCacheEntry {
         device_key,
-        DeviceCacheEntry {
-            cache: Arc::downgrade(&shared),
-            endpoint: Arc::new(Mutex::new(endpoint)),
-        },
-    );
+        cache: Arc::downgrade(&shared),
+    };
+    if let Some(index) = stale_index {
+        registry[index] = entry;
+    } else {
+        registry.push(entry);
+    }
     Ok(shared)
+}
+
+/// Removes the registry entry that still names `cache`.
+pub(super) fn unregister_cache(device_key: usize, cache: *const BlockCacheShared) {
+    let mut registry = BLOCK_CACHE_REGISTRY.lock();
+    let Some(index) = registry.iter().position(|entry| {
+        entry.device_key == device_key && core::ptr::eq(entry.cache.as_ptr(), cache)
+    }) else {
+        return;
+    };
+    registry.swap_remove(index);
 }
 
 /// Writes back every live device cache tree and issues each device's flush
@@ -82,11 +104,12 @@ pub(crate) fn shared_cache_for(
 ///
 /// # Errors
 ///
-/// Returns the first device writeback or flush error encountered.
+/// Returns [`BlockError::NoMemory`] when the live-tree snapshot cannot be
+/// reserved, otherwise the first device writeback or flush error encountered.
 pub fn sync_all_block_caches() -> BlockResult<()> {
     let mut first_error = None;
-    for (shared, endpoint) in live_trees() {
-        let result = shared.sync_to_device_with(&mut *endpoint.lock());
+    for shared in live_trees()? {
+        let result = shared.sync_to_registered_device();
         if let Err(error) = result
             && first_error.is_none()
         {
@@ -109,7 +132,10 @@ pub fn sync_all_block_caches() -> BlockResult<()> {
 #[cfg(feature = "vfs")]
 pub(crate) fn reclaim_clean_folios(num_folios: usize) -> usize {
     let mut reclaimed = 0;
-    for (shared, _) in live_trees() {
+    let Ok(trees) = live_trees() else {
+        return 0;
+    };
+    for shared in trees {
         if reclaimed >= num_folios {
             break;
         }
@@ -118,18 +144,18 @@ pub(crate) fn reclaim_clean_folios(num_folios: usize) -> usize {
     reclaimed
 }
 
-/// A live cache tree paired with its global-writeback endpoint.
-type LiveTree = (Arc<BlockCacheShared>, Arc<DeviceEndpoint>);
-
-/// The registry-owned device endpoint of one cache tree.
-type DeviceEndpoint = Mutex<Box<dyn FsBlockDevice>>;
-
-/// Collects live trees; the `Arc` endpoint keeps the device reachable
-/// after the registry lock is released.
-fn live_trees() -> Vec<LiveTree> {
+/// Collects live trees; each tree owns the endpoint that keeps its device
+/// reachable after the registry lock is released.
+fn live_trees() -> BlockResult<Vec<Arc<BlockCacheShared>>> {
     let registry = BLOCK_CACHE_REGISTRY.lock();
-    registry
-        .values()
-        .filter_map(|entry| Some((entry.cache.upgrade()?, entry.endpoint.clone())))
-        .collect()
+    let mut trees = Vec::new();
+    trees
+        .try_reserve_exact(registry.len())
+        .map_err(|_| BlockError::NoMemory)?;
+    for entry in registry.iter() {
+        if let Some(shared) = entry.cache.upgrade() {
+            trees.push(shared);
+        }
+    }
+    Ok(trees)
 }

--- a/fs/ax-fs-ng/src/block/cache/tests.rs
+++ b/fs/ax-fs-ng/src/block/cache/tests.rs
@@ -2,10 +2,19 @@
 //! a mock so cache hits, deferred writes, merged writeback runs, and
 //! writeback-before-barrier ordering are asserted deterministically.
 
-use std::sync::{Arc, Mutex};
+use std::{
+    num::NonZeroUsize,
+    panic::{AssertUnwindSafe, catch_unwind},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+};
 
 use super::{
     address_space::{BlockAddressSpace, FolioGeometry},
+    folio::CacheFolio,
+    folio_cache::FolioCache,
     *,
 };
 use crate::{BlockError, BlockResult, block::FsBlockDevice};
@@ -43,6 +52,78 @@ struct RecordingState {
 struct RecordingDevice {
     state: Arc<Mutex<RecordingState>>,
     block_size: usize,
+}
+
+/// Models the runtime endpoint whose final handle drop performs shutdown.
+struct ShutdownTrackedDevice {
+    inner: RecordingDevice,
+    shutdowns: Arc<AtomicUsize>,
+}
+
+impl Drop for ShutdownTrackedDevice {
+    fn drop(&mut self) {
+        self.shutdowns.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+impl FsBlockDevice for ShutdownTrackedDevice {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn num_blocks(&self) -> u64 {
+        self.inner.num_blocks()
+    }
+
+    fn block_size(&self) -> usize {
+        self.inner.block_size()
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> BlockResult<()> {
+        self.inner.read_block(block_id, buf)
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> BlockResult<()> {
+        self.inner.write_block(block_id, buf)
+    }
+
+    fn flush(&mut self) -> BlockResult<()> {
+        self.inner.flush()
+    }
+}
+
+struct GeometryOnlyDevice {
+    block_size: usize,
+    io_calls: Arc<AtomicUsize>,
+}
+
+impl FsBlockDevice for GeometryOnlyDevice {
+    fn name(&self) -> &str {
+        "geometry-only"
+    }
+
+    fn num_blocks(&self) -> u64 {
+        1
+    }
+
+    fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    fn read_block(&mut self, _block_id: u64, _buf: &mut [u8]) -> BlockResult<()> {
+        self.io_calls.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+
+    fn write_block(&mut self, _block_id: u64, _buf: &[u8]) -> BlockResult<()> {
+        self.io_calls.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> BlockResult<()> {
+        self.io_calls.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
 }
 
 impl RecordingDevice {
@@ -274,6 +355,43 @@ fn lru_eviction_writes_back_dirty_victim() {
 }
 
 #[test]
+fn lru_hit_preserves_the_recently_used_folio() {
+    let (mut inner, state) = RecordingDevice::new(64, 512);
+    let mut tree = BlockAddressSpace::with_capacity(FolioGeometry::new(512).unwrap(), 2);
+    let mut buf = [0u8; 512];
+
+    tree.read_buffered(&mut inner, 0, 1, &mut buf).unwrap();
+    tree.read_buffered(&mut inner, 8, 1, &mut buf).unwrap();
+    tree.read_buffered(&mut inner, 0, 1, &mut buf).unwrap();
+    let reads_before_eviction = count_ops(&state, IoOp::is_read);
+
+    tree.read_buffered(&mut inner, 16, 1, &mut buf).unwrap();
+    tree.read_buffered(&mut inner, 0, 1, &mut buf).unwrap();
+    assert_eq!(
+        count_ops(&state, IoOp::is_read),
+        reads_before_eviction + 1,
+        "the touched frame must remain cached when the older frame is evicted"
+    );
+
+    tree.read_buffered(&mut inner, 8, 1, &mut buf).unwrap();
+    assert_eq!(count_ops(&state, IoOp::is_read), reads_before_eviction + 2);
+}
+
+#[test]
+fn lru_reserve_failure_preserves_existing_entry() {
+    let mut cache = FolioCache::new(NonZeroUsize::new(2).unwrap());
+    cache.try_reserve_entry().unwrap();
+    cache.insert_reserved(7, CacheFolio::try_new(1, 1).unwrap());
+
+    assert_eq!(
+        cache.try_reserve_for_test(usize::MAX),
+        Err(BlockError::NoMemory)
+    );
+    assert!(cache.contains(&7));
+    assert_eq!(cache.least_recent(), Some(7));
+}
+
+#[test]
 fn direct_write_overlays_cached_folio() {
     let (device, state) = RecordingDevice::new(64, 512);
     let mut cached = buffered(KEY_A + 7, device);
@@ -359,6 +477,55 @@ fn drop_flushes_last_instance() {
     // The count is a lower bound: a concurrently running global-sync test
     // may flush this live registry entry before the drop happens.
     assert!(count_ops(&state, IoOp::is_flush) >= 1);
+}
+
+#[test]
+fn dropping_last_consumer_releases_registry_endpoint() {
+    let shutdowns = Arc::new(AtomicUsize::new(0));
+    let key = KEY_A + 11;
+
+    for expected_shutdowns in 1..=2 {
+        let (device, _state) = RecordingDevice::new(64, 512);
+        let endpoint = ShutdownTrackedDevice {
+            inner: device.clone(),
+            shutdowns: shutdowns.clone(),
+        };
+        let cached = BufferedBlockDevice::with_device_key(key, Box::new(endpoint), device)
+            .expect("recording device geometry is valid");
+
+        drop(cached);
+        assert_eq!(
+            shutdowns.load(Ordering::Acquire),
+            expected_shutdowns,
+            "each last cache consumer must release the endpoint for shutdown"
+        );
+    }
+}
+
+#[test]
+fn folio_allocation_failure_returns_no_memory_without_io() {
+    let block_size = 1usize << (usize::BITS - 1);
+    let geometry = FolioGeometry::new(block_size).unwrap();
+    let mut tree = BlockAddressSpace::with_capacity(geometry, 1);
+    let io_calls = Arc::new(AtomicUsize::new(0));
+    let mut device = GeometryOnlyDevice {
+        block_size,
+        io_calls: io_calls.clone(),
+    };
+    let mut output = [];
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        tree.read_buffered(&mut device, 0, 1, &mut output)
+    }));
+
+    assert!(matches!(outcome, Ok(Err(BlockError::NoMemory))));
+    assert_eq!(
+        CacheFolio::try_new(1, usize::MAX).unwrap_err(),
+        BlockError::NoMemory,
+        "per-block head allocation must use the same fallible error path"
+    );
+    assert!(!tree.has_dirty());
+    assert_eq!(io_calls.load(Ordering::Acquire), 0);
 }
 
 #[test]

--- a/fs/ax-fs-ng/src/block/cache/tests.rs
+++ b/fs/ax-fs-ng/src/block/cache/tests.rs
@@ -17,7 +17,10 @@ use super::{
     folio_cache::FolioCache,
     *,
 };
-use crate::{BlockError, BlockResult, block::FsBlockDevice};
+use crate::{
+    BlockError, BlockResult,
+    block::{BlockRegion, FsBlockDevice, RegionBlockDevice},
+};
 
 const KEY_A: usize = 0x1000;
 
@@ -461,6 +464,56 @@ fn shared_registry_serves_two_instances_from_one_tree() {
 }
 
 #[test]
+fn shared_wrappers_observe_dirty_and_direct_updates_without_stale_reads() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let key = KEY_A + 24;
+    let mut first = buffered(key, device.clone());
+    let mut second = buffered(key, device);
+
+    let dirty = [0xA5u8; 512];
+    first.write_block(3, &dirty).unwrap();
+    let mut block = [0u8; 512];
+    second.read_block(3, &mut block).unwrap();
+    assert_eq!(block, dirty);
+    assert_eq!(count_ops(&state, IoOp::is_read), 0);
+    assert_eq!(count_ops(&state, |op| matches!(op, IoOp::Write { .. })), 0);
+
+    let direct = [0x5Au8; 16 * 512];
+    second.write_block(0, &direct).unwrap();
+    block.fill(0);
+    first.read_block(3, &mut block).unwrap();
+    assert!(block.iter().all(|&byte| byte == 0x5A));
+    assert_eq!(count_ops(&state, IoOp::is_read), 0);
+}
+
+#[test]
+fn shared_partition_wrappers_keep_physical_lbas_distinct() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let key = KEY_A + 25;
+    let mut first = RegionBlockDevice::new(buffered(key, device.clone()), BlockRegion::new(8, 8));
+    let mut second = RegionBlockDevice::new(buffered(key, device), BlockRegion::new(24, 8));
+
+    let first_data = [0x18u8; 512];
+    let second_data = [0x24u8; 512];
+    first.write_block(0, &first_data).unwrap();
+    second.write_block(0, &second_data).unwrap();
+
+    let mut block = [0u8; 512];
+    first.read_block(0, &mut block).unwrap();
+    assert_eq!(block, first_data);
+    second.read_block(0, &mut block).unwrap();
+    assert_eq!(block, second_data);
+
+    second.flush().unwrap();
+    {
+        let state = state.lock().unwrap();
+        assert_eq!(&state.storage[8 * 512..9 * 512], &first_data);
+        assert_eq!(&state.storage[24 * 512..25 * 512], &second_data);
+    }
+    assert_eq!(count_ops(&state, |op| op.is_write_of(0, 1)), 0);
+}
+
+#[test]
 fn drop_flushes_last_instance() {
     let (device, state) = RecordingDevice::new(64, 512);
     let mut cached = buffered(KEY_A + 10, device);
@@ -529,17 +582,30 @@ fn folio_allocation_failure_returns_no_memory_without_io() {
 }
 
 #[test]
-fn write_errors_propagate_from_writeback() {
+fn failed_writeback_retains_dirty_data_for_retry() {
     // A direct tree keeps the failing device out of the process-global
     // registry, where a live failing endpoint would break registry-wide
     // sync in concurrently running tests.
     let (mut inner, state) = RecordingDevice::new(64, 512);
     let mut tree = BlockAddressSpace::with_capacity(FolioGeometry::new(512).unwrap(), 4);
 
-    let data = [0u8; 512];
+    let data = [0xD7u8; 512];
     tree.write_buffered(&mut inner, 7, 1, &data).unwrap();
     state.lock().unwrap().fail_writes = true;
-    assert!(tree.writeback_dirty(&mut inner, None).is_err());
+    assert_eq!(tree.writeback_dirty(&mut inner, None), Err(BlockError::Io));
+    assert!(tree.has_dirty());
+
+    let mut cached = [0u8; 512];
+    tree.read_buffered(&mut inner, 7, 1, &mut cached).unwrap();
+    assert_eq!(
+        cached, data,
+        "a failed writeback must not discard dirty bytes"
+    );
+
+    state.lock().unwrap().fail_writes = false;
+    tree.writeback_dirty(&mut inner, None).unwrap();
+    assert!(!tree.has_dirty());
+    assert_eq!(&state.lock().unwrap().storage[7 * 512..8 * 512], &data);
 }
 
 #[test]

--- a/fs/ax-fs-ng/src/block/cache/tests.rs
+++ b/fs/ax-fs-ng/src/block/cache/tests.rs
@@ -627,3 +627,25 @@ fn reclaim_clean_folios_drops_only_clean_frames() {
     assert_eq!(count_ops(&state, IoOp::is_read), reads_before + 2);
     assert_eq!(count_ops(&state, |op| matches!(op, IoOp::Write { .. })), 0);
 }
+
+#[test]
+#[cfg(feature = "vfs")]
+fn allocator_reclaim_skips_a_cache_with_its_state_lock_held() {
+    let (device, _state) = RecordingDevice::new(64, 512);
+    let cached = buffered(KEY_A + 22, device);
+
+    assert_eq!(
+        cached.reclaim_from_allocator_while_state_locked_for_test(),
+        0,
+        "allocator reclaim must skip a cache already locked by the allocating path"
+    );
+}
+
+#[test]
+#[cfg(feature = "vfs")]
+fn cache_drop_cleanup_skips_a_contended_registry_lock() {
+    let (device, _state) = RecordingDevice::new(64, 512);
+    let cached = buffered(KEY_A + 23, device);
+
+    cached.unregister_while_registry_locked_for_test();
+}

--- a/fs/ax-fs-ng/src/block/cache/tests.rs
+++ b/fs/ax-fs-ng/src/block/cache/tests.rs
@@ -1,0 +1,462 @@
+//! Behavior contracts of the shared block cache. Device IO is recorded by
+//! a mock so cache hits, deferred writes, merged writeback runs, and
+//! writeback-before-barrier ordering are asserted deterministically.
+
+use std::sync::{Arc, Mutex};
+
+use super::{
+    address_space::{BlockAddressSpace, FolioGeometry},
+    *,
+};
+use crate::{BlockError, BlockResult, block::FsBlockDevice};
+
+const KEY_A: usize = 0x1000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IoOp {
+    Read { lba: u64, blocks: usize },
+    Write { lba: u64, blocks: usize },
+    Flush,
+}
+
+impl IoOp {
+    fn is_write_of(&self, lba: u64, blocks: usize) -> bool {
+        matches!(*self, IoOp::Write { lba: l, blocks: n } if l == lba && n == blocks)
+    }
+
+    fn is_read(&self) -> bool {
+        matches!(self, IoOp::Read { .. })
+    }
+
+    fn is_flush(&self) -> bool {
+        matches!(self, IoOp::Flush)
+    }
+}
+
+struct RecordingState {
+    storage: Vec<u8>,
+    log: Vec<IoOp>,
+    fail_writes: bool,
+}
+
+#[derive(Clone)]
+struct RecordingDevice {
+    state: Arc<Mutex<RecordingState>>,
+    block_size: usize,
+}
+
+impl RecordingDevice {
+    fn new(blocks: usize, block_size: usize) -> (Self, Arc<Mutex<RecordingState>>) {
+        let state = Arc::new(Mutex::new(RecordingState {
+            storage: vec![0u8; blocks * block_size],
+            log: Vec::new(),
+            fail_writes: false,
+        }));
+        (
+            Self {
+                state: state.clone(),
+                block_size,
+            },
+            state,
+        )
+    }
+}
+
+impl FsBlockDevice for RecordingDevice {
+    fn name(&self) -> &str {
+        "recording"
+    }
+
+    fn num_blocks(&self) -> u64 {
+        (self.state.lock().unwrap().storage.len() / self.block_size) as u64
+    }
+
+    fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    fn read_block(&mut self, block_id: u64, buf: &mut [u8]) -> BlockResult<()> {
+        let mut state = self.state.lock().unwrap();
+        state.log.push(IoOp::Read {
+            lba: block_id,
+            blocks: buf.len() / self.block_size,
+        });
+        let start = block_id as usize * self.block_size;
+        let end = start
+            .checked_add(buf.len())
+            .ok_or(BlockError::InvalidRequest)?;
+        let storage = &mut state.storage;
+        if end > storage.len() {
+            return Err(BlockError::InvalidRequest);
+        }
+        buf.copy_from_slice(&storage[start..end]);
+        Ok(())
+    }
+
+    fn write_block(&mut self, block_id: u64, buf: &[u8]) -> BlockResult<()> {
+        let mut state = self.state.lock().unwrap();
+        if state.fail_writes {
+            return Err(BlockError::Io);
+        }
+        state.log.push(IoOp::Write {
+            lba: block_id,
+            blocks: buf.len() / self.block_size,
+        });
+        let start = block_id as usize * self.block_size;
+        state.storage[start..start + buf.len()].copy_from_slice(buf);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> BlockResult<()> {
+        self.state.lock().unwrap().log.push(IoOp::Flush);
+        Ok(())
+    }
+}
+
+fn count_ops(state: &Arc<Mutex<RecordingState>>, pred: impl Fn(&IoOp) -> bool) -> usize {
+    state
+        .lock()
+        .unwrap()
+        .log
+        .iter()
+        .filter(|op| pred(op))
+        .count()
+}
+
+fn write_pattern(state: &Arc<Mutex<RecordingState>>, block: usize, block_size: usize, byte: u8) {
+    let start = block * block_size;
+    state.lock().unwrap().storage[start..start + block_size].fill(byte);
+}
+
+fn buffered(key: usize, device: RecordingDevice) -> BufferedBlockDevice<RecordingDevice> {
+    // The registry keeps an equivalent device as the global-sync endpoint.
+    let endpoint = device.clone();
+    BufferedBlockDevice::with_device_key(key, Box::new(endpoint), device)
+        .expect("recording device geometry is valid")
+}
+
+#[test]
+fn read_is_served_from_cache_on_second_access() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A, device);
+    write_pattern(&state, 1, 512, 0xAB);
+
+    let mut buf = [0u8; 512];
+    cached.read_block(1, &mut buf).unwrap();
+    assert_eq!(count_ops(&state, IoOp::is_read), 1);
+    assert!(buf.iter().all(|&b| b == 0xAB));
+
+    let mut buf = [0u8; 512];
+    cached.read_block(1, &mut buf).unwrap();
+    assert_eq!(count_ops(&state, IoOp::is_read), 1, "second read must hit");
+    assert!(buf.iter().all(|&b| b == 0xAB));
+}
+
+#[test]
+fn partial_folio_reads_track_slot_state() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 1, device);
+    // One 4 KiB folio covers 8 blocks; reading blocks 1 and 3 of frame 0
+    // must read exactly those blocks and mark only those slots uptodate.
+    let mut buf = [0u8; 512];
+    cached.read_block(1, &mut buf).unwrap();
+    cached.read_block(3, &mut buf).unwrap();
+    assert_eq!(count_ops(&state, IoOp::is_read), 2);
+
+    cached.read_block(1, &mut buf).unwrap();
+    cached.read_block(3, &mut buf).unwrap();
+    assert_eq!(count_ops(&state, IoOp::is_read), 2);
+
+    // The neighboring block 2 was never read and stays uncached.
+    cached.read_block(2, &mut buf).unwrap();
+    assert_eq!(count_ops(&state, IoOp::is_read), 3);
+}
+
+#[test]
+fn write_is_deferred_until_flush() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 2, device);
+
+    let data = [0x5Au8; 512];
+    cached.write_block(3, &data).unwrap();
+    assert_eq!(count_ops(&state, |op| op.is_write_of(3, 1)), 0);
+    assert!(
+        !state.lock().unwrap().storage[3 * 512..4 * 512]
+            .iter()
+            .any(|&b| b == 0x5A)
+    );
+
+    cached.flush().unwrap();
+    assert_eq!(count_ops(&state, |op| op.is_write_of(3, 1)), 1);
+    assert!(
+        state.lock().unwrap().storage[3 * 512..4 * 512]
+            .iter()
+            .all(|&b| b == 0x5A)
+    );
+    // flush() = writeback followed by the device barrier.
+    let log = state.lock().unwrap().log.clone();
+    assert_eq!(*log.last().unwrap(), IoOp::Flush);
+}
+
+#[test]
+fn flush_merges_adjacent_dirty_runs() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 3, device);
+
+    let data = [0x11u8; 512];
+    cached.write_block(8, &data).unwrap();
+    cached.write_block(9, &data).unwrap();
+    cached.write_block(10, &data).unwrap();
+    cached.write_block(13, &data).unwrap();
+
+    cached.flush().unwrap();
+    // Blocks 8..=10 merge into one write; block 13 stays separate.
+    assert_eq!(count_ops(&state, |op| op.is_write_of(8, 3)), 1);
+    assert_eq!(count_ops(&state, |op| op.is_write_of(13, 1)), 1);
+    assert_eq!(count_ops(&state, |op| matches!(op, IoOp::Write { .. })), 2);
+}
+
+#[test]
+fn dirty_writeback_precedes_barrier_and_later_writes() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 5, device);
+
+    // Model of the JBD2 commit contract: a "descriptor" write, a flush
+    // barrier, then a "commit record" write, then another flush. The
+    // deferred data must reach the device before the first barrier, and
+    // the commit record must reach it only after that barrier.
+    let descriptor = [0x01u8; 512];
+    let commit = [0x02u8; 512];
+    let data = [0x03u8; 512];
+    cached.write_block(4, &data).unwrap();
+    cached.write_block(8, &descriptor).unwrap();
+    cached.flush().unwrap();
+    cached.write_block(12, &commit).unwrap();
+    cached.flush().unwrap();
+
+    let log = state.lock().unwrap().log.clone();
+    let position = |op: IoOp| log.iter().position(|entry| *entry == op).unwrap();
+    let data_write = position(IoOp::Write { lba: 4, blocks: 1 });
+    let descriptor_write = position(IoOp::Write { lba: 8, blocks: 1 });
+    let first_barrier = log.iter().position(IoOp::is_flush).unwrap();
+    let commit_write = position(IoOp::Write { lba: 12, blocks: 1 });
+    let barriers = count_ops(&state, IoOp::is_flush);
+    assert_eq!(barriers, 2);
+    assert!(data_write < first_barrier && descriptor_write < first_barrier);
+    assert!(commit_write > first_barrier);
+}
+
+#[test]
+fn lru_eviction_writes_back_dirty_victim() {
+    // Eviction is exercised on a direct two-folio tree: dirtying frame 0
+    // and touching two other frames must write frame 0 back before it is
+    // dropped.
+    let (mut inner, state) = RecordingDevice::new(64, 512);
+    let mut tree = BlockAddressSpace::with_capacity(FolioGeometry::new(512).unwrap(), 2);
+
+    let data = [0x77u8; 512];
+    tree.write_buffered(&mut inner, 0, 1, &data).unwrap();
+    assert!(tree.has_dirty());
+
+    let mut buf = [0u8; 512];
+    tree.read_buffered(&mut inner, 8, 1, &mut buf).unwrap();
+    tree.read_buffered(&mut inner, 16, 1, &mut buf).unwrap();
+    assert!(
+        state.lock().unwrap().storage[..512]
+            .iter()
+            .all(|&b| b == 0x77)
+    );
+    assert!(!tree.has_dirty(), "eviction leaves no dirty accounting");
+
+    // The evicted frame reads back from the device.
+    tree.read_buffered(&mut inner, 0, 1, &mut buf).unwrap();
+    assert!(buf.iter().all(|&b| b == 0x77));
+}
+
+#[test]
+fn direct_write_overlays_cached_folio() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 7, device);
+
+    let mut buf = [0u8; 512];
+    cached.read_block(0, &mut buf).unwrap();
+    let reads_before = count_ops(&state, IoOp::is_read);
+
+    // 16 blocks span two folios: device-direct write.
+    let data = [0x42u8; 16 * 512];
+    cached.write_block(0, &data).unwrap();
+    assert!(
+        state.lock().unwrap().storage[..16 * 512]
+            .iter()
+            .all(|&b| b == 0x42)
+    );
+
+    // The cached folio of block 0 was overlaid: the read is served from
+    // the folio with the new bytes and no extra device read happens.
+    cached.read_block(0, &mut buf).unwrap();
+    assert_eq!(count_ops(&state, IoOp::is_read), reads_before);
+    assert!(buf.iter().all(|&b| b == 0x42));
+}
+
+#[test]
+fn direct_read_observes_deferred_dirty_data() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 8, device);
+
+    let data = [0x99u8; 512];
+    cached.write_block(0, &data).unwrap();
+    assert_eq!(count_ops(&state, |op| matches!(op, IoOp::Write { .. })), 0);
+
+    // A multi-folio read must not bypass the dirty folio with stale device
+    // bytes: writeback happens first, then the direct read.
+    let mut buf = [0u8; 16 * 512];
+    cached.read_block(0, &mut buf).unwrap();
+    assert!(buf[..512].iter().all(|&b| b == 0x99));
+    let log = state.lock().unwrap().log.clone();
+    let writeback = log.iter().position(|op| op.is_write_of(0, 1)).unwrap();
+    let direct_read = log
+        .iter()
+        .position(|op| matches!(op, IoOp::Read { lba: 0, blocks: 16 }))
+        .unwrap();
+    assert!(writeback < direct_read);
+}
+
+#[test]
+fn shared_registry_serves_two_instances_from_one_tree() {
+    let (device_a, state_a) = RecordingDevice::new(64, 512);
+    let (device_b, state_b) = RecordingDevice::new(64, 512);
+    let key = KEY_A + 9;
+    write_pattern(&state_a, 5, 512, 0xEF);
+
+    // Both instances stay alive: they must resolve to one folio tree, so
+    // the second read is served without touching device B at all.
+    let mut first = buffered(key, device_a);
+    let mut buf = [0u8; 512];
+    first.read_block(5, &mut buf).unwrap();
+    assert!(buf.iter().all(|&b| b == 0xEF));
+
+    let mut second = buffered(key, device_b);
+    let mut buf = [0u8; 512];
+    second.read_block(5, &mut buf).unwrap();
+    assert!(buf.iter().all(|&b| b == 0xEF));
+    assert_eq!(count_ops(&state_b, IoOp::is_read), 0);
+}
+
+#[test]
+fn drop_flushes_last_instance() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 10, device);
+
+    let data = [0x33u8; 512];
+    cached.write_block(6, &data).unwrap();
+    drop(cached);
+
+    assert!(
+        state.lock().unwrap().storage[6 * 512..7 * 512]
+            .iter()
+            .all(|&b| b == 0x33)
+    );
+    // The count is a lower bound: a concurrently running global-sync test
+    // may flush this live registry entry before the drop happens.
+    assert!(count_ops(&state, IoOp::is_flush) >= 1);
+}
+
+#[test]
+fn write_errors_propagate_from_writeback() {
+    // A direct tree keeps the failing device out of the process-global
+    // registry, where a live failing endpoint would break registry-wide
+    // sync in concurrently running tests.
+    let (mut inner, state) = RecordingDevice::new(64, 512);
+    let mut tree = BlockAddressSpace::with_capacity(FolioGeometry::new(512).unwrap(), 4);
+
+    let data = [0u8; 512];
+    tree.write_buffered(&mut inner, 7, 1, &data).unwrap();
+    state.lock().unwrap().fail_writes = true;
+    assert!(tree.writeback_dirty(&mut inner, None).is_err());
+}
+
+#[test]
+fn non_power_of_two_block_size_is_rejected() {
+    assert!(FolioGeometry::new(1000).is_err());
+    assert!(FolioGeometry::new(0).is_err());
+    let geometry = FolioGeometry::new(4096).unwrap();
+    assert_eq!(geometry.folio_size(), 4096);
+    assert_eq!(geometry.slots(), 1);
+    let geometry = FolioGeometry::new(512).unwrap();
+    assert_eq!(geometry.folio_size(), 4096);
+    assert_eq!(geometry.slots(), 8);
+    assert!(geometry.spans_one_folio(0, 8));
+    assert!(!geometry.spans_one_folio(6, 3));
+}
+
+#[test]
+fn invalid_request_geometry_is_rejected() {
+    let (device, _state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 12, device);
+    let mut misaligned = [0u8; 100];
+    assert_eq!(
+        cached.read_block(0, &mut misaligned),
+        Err(BlockError::InvalidRequest)
+    );
+}
+
+#[test]
+fn sync_all_block_caches_writes_back_every_registered_device() {
+    let (device_a, state_a) = RecordingDevice::new(64, 512);
+    let (device_b, state_b) = RecordingDevice::new(64, 512);
+    write_pattern(&state_a, 0, 512, 0xEE);
+
+    // Both wrappers stay alive so their registry entries are live during
+    // the global sync; the endpoints see the same recorded devices.
+    let mut wrapper_a = buffered(KEY_A + 20, device_a);
+    let mut wrapper_b = buffered(KEY_A + 21, device_b);
+    let data = [0x66u8; 512];
+    wrapper_a.write_block(1, &data).unwrap();
+    wrapper_b.write_block(2, &data).unwrap();
+
+    let _ = super::sync_all_block_caches();
+    // Effect assertions: both devices persisted their dirty block and saw
+    // a flush barrier, regardless of unrelated registry entries that
+    // concurrently running tests keep alive.
+    assert!(
+        state_a.lock().unwrap().storage[512..2 * 512]
+            .iter()
+            .all(|&b| b == 0x66)
+    );
+    assert!(
+        state_b.lock().unwrap().storage[2 * 512..3 * 512]
+            .iter()
+            .all(|&b| b == 0x66)
+    );
+    assert!(count_ops(&state_a, IoOp::is_flush) >= 1);
+    assert!(count_ops(&state_b, IoOp::is_flush) >= 1);
+}
+
+#[test]
+#[cfg(feature = "vfs")]
+fn reclaim_clean_folios_drops_only_clean_frames() {
+    // A direct tree pins the exact dirty/clean layout without interference
+    // from the process-global registry.
+    let (mut inner, state) = RecordingDevice::new(64, 512);
+    let mut tree = BlockAddressSpace::with_capacity(FolioGeometry::new(512).unwrap(), 8);
+
+    let data = [0x55u8; 512];
+    tree.write_buffered(&mut inner, 0, 1, &data).unwrap();
+    let mut buf = [0u8; 512];
+    tree.read_buffered(&mut inner, 8, 1, &mut buf).unwrap();
+    tree.read_buffered(&mut inner, 16, 1, &mut buf).unwrap();
+    let reads_before = count_ops(&state, IoOp::is_read);
+
+    let reclaimed = tree.reclaim_clean_folios(2);
+    assert_eq!(reclaimed, 2, "both clean folios are reclaimable");
+    assert!(tree.has_dirty(), "the dirty folio is preserved");
+    // With only the dirty folio left, reclaim makes no progress.
+    assert_eq!(tree.reclaim_clean_folios(4), 0);
+
+    // The reclaimed folios read from the device again; the dirty one still
+    // serves from cache (no write happened yet).
+    tree.read_buffered(&mut inner, 8, 1, &mut buf).unwrap();
+    tree.read_buffered(&mut inner, 16, 1, &mut buf).unwrap();
+    assert_eq!(count_ops(&state, IoOp::is_read), reads_before + 2);
+    assert_eq!(count_ops(&state, |op| matches!(op, IoOp::Write { .. })), 0);
+}

--- a/fs/ax-fs-ng/src/block/cache/tests.rs
+++ b/fs/ax-fs-ng/src/block/cache/tests.rs
@@ -49,6 +49,7 @@ struct RecordingState {
     storage: Vec<u8>,
     log: Vec<IoOp>,
     fail_writes: bool,
+    partially_commit_blocks: Option<usize>,
 }
 
 #[derive(Clone)]
@@ -135,6 +136,7 @@ impl RecordingDevice {
             storage: vec![0u8; blocks * block_size],
             log: Vec::new(),
             fail_writes: false,
+            partially_commit_blocks: None,
         }));
         (
             Self {
@@ -180,6 +182,17 @@ impl FsBlockDevice for RecordingDevice {
     fn write_block(&mut self, block_id: u64, buf: &[u8]) -> BlockResult<()> {
         let mut state = self.state.lock().unwrap();
         if state.fail_writes {
+            return Err(BlockError::Io);
+        }
+        if let Some(blocks) = state.partially_commit_blocks.take() {
+            let blocks = blocks.min(buf.len() / self.block_size);
+            let bytes = blocks * self.block_size;
+            state.log.push(IoOp::Write {
+                lba: block_id,
+                blocks,
+            });
+            let start = block_id as usize * self.block_size;
+            state.storage[start..start + bytes].copy_from_slice(&buf[..bytes]);
             return Err(BlockError::Io);
         }
         state.log.push(IoOp::Write {
@@ -417,6 +430,41 @@ fn direct_write_overlays_cached_folio() {
     cached.read_block(0, &mut buf).unwrap();
     assert_eq!(count_ops(&state, IoOp::is_read), reads_before);
     assert!(buf.iter().all(|&b| b == 0x42));
+}
+
+#[test]
+fn failed_direct_write_invalidates_partially_updated_folios() {
+    let (device, state) = RecordingDevice::new(64, 512);
+    let mut cached = buffered(KEY_A + 26, device);
+
+    let mut block = [0u8; 512];
+    cached.read_block(0, &mut block).unwrap();
+    assert_eq!(block, [0u8; 512]);
+    cached.read_block(8, &mut block).unwrap();
+    assert_eq!(block, [0u8; 512]);
+    let reads_before_failure = count_ops(&state, IoOp::is_read);
+
+    // The device commits the first folio before reporting failure for this
+    // two-folio direct write. Its error gives the cache no exact completed
+    // prefix, so every overlapping folio must be treated as unknown.
+    state.lock().unwrap().partially_commit_blocks = Some(8);
+    let direct = [0x42u8; 16 * 512];
+    assert_eq!(cached.write_block(0, &direct), Err(BlockError::Io));
+    assert_eq!(
+        &state.lock().unwrap().storage[..8 * 512],
+        &direct[..8 * 512]
+    );
+
+    block.fill(0);
+    cached.read_block(0, &mut block).unwrap();
+    assert_eq!(block, [0x42u8; 512]);
+    cached.read_block(8, &mut block).unwrap();
+    assert_eq!(block, [0u8; 512]);
+    assert_eq!(
+        count_ops(&state, IoOp::is_read),
+        reads_before_failure + 2,
+        "an indeterminate failure must invalidate every overlapping folio"
+    );
 }
 
 #[test]

--- a/fs/ax-fs-ng/src/block/runtime/lifecycle/io.rs
+++ b/fs/ax-fs-ng/src/block/runtime/lifecycle/io.rs
@@ -73,24 +73,36 @@ pub(super) fn write_blocks(
     let mut plan = transfer_plan(info, block_id, buffer.len(), RequestOp::Write)?.peekable();
     let window_limit = submission_window_limit(info);
     let mut pending = VecDeque::with_capacity(SOFTWARE_PIPELINE_WINDOWS);
+    let mut first_error = None;
 
     while plan.peek().is_some() || !pending.is_empty() {
-        while pending.len() < SOFTWARE_PIPELINE_WINDOWS && plan.peek().is_some() {
-            pending.push_back(submit_write_window(
-                device,
-                info,
-                take_window(&mut plan, window_limit)?,
-                buffer,
-            )?);
+        while first_error.is_none()
+            && pending.len() < SOFTWARE_PIPELINE_WINDOWS
+            && plan.peek().is_some()
+        {
+            let window = take_window(&mut plan, window_limit)
+                .and_then(|chunks| submit_write_window(device, info, chunks, buffer));
+            match window {
+                Ok(window) => pending.push_back(window),
+                Err(error) => first_error = Some(error),
+            }
         }
-        let window = pending.pop_front().ok_or(BlockError::InvalidState)?;
+        let Some(window) = pending.pop_front() else {
+            break;
+        };
         let first_lba = window.chunks[0].lba;
-        let completions = window.completions.recv().map_err(|error| {
-            block_io_error("receive window", RequestOp::Write, first_lba, error)
-        })?;
-        complete_write_window(&window.chunks, completions)?;
+        let result = window
+            .completions
+            .recv()
+            .map_err(|error| block_io_error("receive window", RequestOp::Write, first_lba, error))
+            .and_then(|completions| complete_write_window(&window.chunks, completions));
+        if let Err(error) = result
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
     }
-    Ok(())
+    first_error.map_or(Ok(()), Err)
 }
 
 fn submit_read_window(

--- a/fs/ax-fs-ng/src/block/runtime/lifecycle/tests/batching.rs
+++ b/fs/ax-fs-ng/src/block/runtime/lifecycle/tests/batching.rs
@@ -19,6 +19,7 @@ fn read_blocks_queues_the_next_bounded_window_before_waiting() {
             counters: Arc::clone(&counters),
             next_id: 0,
             pending: Vec::new(),
+            fail_next_drain: false,
         }),
     };
     let irq = IrqId::new(IrqDomainId(1), HwIrq(12));
@@ -99,5 +100,99 @@ fn read_blocks_queues_the_next_bounded_window_before_waiting() {
             .is_ok()
     );
     read_thread.join().unwrap();
+    assert_eq!(handle.shutdown(), 1);
+}
+
+#[test]
+#[cfg(any(feature = "ext4", feature = "fat"))]
+fn write_blocks_drains_submitted_windows_before_returning_error() {
+    let _registrar_guard = lock_test_irq_registrar();
+    crate::os::task::install_test_runtime_ops();
+    install_dma_op(&TEST_DMA_OP);
+    let log = Arc::new(StdMutex::new(Vec::new()));
+    *TEST_IRQ_REGISTRAR.log.lock().unwrap() = Some(log);
+    *TEST_IRQ_REGISTRAR.action.lock().unwrap() = None;
+    TEST_IRQ_REGISTRAR
+        .fail_registration
+        .store(false, Ordering::Release);
+    set_irq_registrar(&TEST_IRQ_REGISTRAR);
+
+    let counters = Arc::new(BatchingQueueCounters::default());
+    let controller = BatchingReadController {
+        queue: Some(BatchingReadQueue {
+            counters: Arc::clone(&counters),
+            next_id: 0,
+            pending: Vec::new(),
+            fail_next_drain: true,
+        }),
+    };
+    let irq = IrqId::new(IrqDomainId(1), HwIrq(13));
+    let handle = BlockDeviceHandle::start(RdifBlockDevice::new_with_irqs(
+        "batching-write-error",
+        [BlockIrqSource { source_id: 0, irq }],
+        Box::new(controller),
+    ))
+    .unwrap();
+
+    let writer = Arc::clone(&handle);
+    let (result_tx, result_rx) = mpsc::channel();
+    let write_thread = thread::spawn(move || {
+        let buffer = vec![0x42; 8 * 512];
+        result_tx.send(writer.write_blocks(0, &buffer)).unwrap();
+    });
+    let deadline = Instant::now() + Duration::from_secs(1);
+    while counters.submitted.load(Ordering::Acquire) < 4 {
+        assert!(
+            Instant::now() < deadline,
+            "first write window was not submitted"
+        );
+        thread::yield_now();
+    }
+    while handle
+        .inner
+        .cpu_channels
+        .lock()
+        .iter()
+        .map(|channel| channel.channel.queued_len())
+        .sum::<usize>()
+        < 4
+    {
+        assert!(
+            Instant::now() < deadline,
+            "second write window was not queued"
+        );
+        thread::yield_now();
+    }
+
+    assert_eq!(
+        TEST_IRQ_REGISTRAR.run_registered_action(),
+        BlockIrqOutcome::Wake
+    );
+    while counters.submitted.load(Ordering::Acquire) < 8 {
+        assert!(
+            Instant::now() < deadline,
+            "second write window was not submitted"
+        );
+        thread::yield_now();
+    }
+    assert!(
+        result_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+        "write returned while an already submitted window was still in flight"
+    );
+
+    assert_eq!(
+        TEST_IRQ_REGISTRAR.run_registered_action(),
+        BlockIrqOutcome::Wake
+    );
+    assert!(matches!(
+        result_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+        Err(BlockError::Device {
+            stage: "complete window",
+            operation: RequestOp::Write,
+            lba: 0,
+            source: BlkError::Io,
+        })
+    ));
+    write_thread.join().unwrap();
     assert_eq!(handle.shutdown(), 1);
 }

--- a/fs/ax-fs-ng/src/block/runtime/lifecycle/tests/mod.rs
+++ b/fs/ax-fs-ng/src/block/runtime/lifecycle/tests/mod.rs
@@ -160,6 +160,7 @@ struct BatchingReadQueue {
     counters: Arc<BatchingQueueCounters>,
     next_id: usize,
     pending: Vec<(RequestId, Option<InFlightDma>)>,
+    fail_next_drain: bool,
 }
 
 impl DriverGeneric for BatchingReadQueue {
@@ -216,9 +217,14 @@ impl HardwareQueue for BatchingReadQueue {
     }
 
     fn drain_completions(&mut self, sink: &mut dyn CompletionSink) -> Result<(), BlkError> {
+        let result = if core::mem::take(&mut self.fail_next_drain) {
+            Err(BlkError::Io)
+        } else {
+            Ok(())
+        };
         for (id, data) in self.pending.drain(..) {
             let data = data.map(|in_flight| unsafe { in_flight.complete_after_quiesce() });
-            sink.complete(CompletedRequest::new(id, Ok(()), data));
+            sink.complete(CompletedRequest::new(id, result, data));
         }
         Ok(())
     }

--- a/fs/ax-fs-ng/src/error.rs
+++ b/fs/ax-fs-ng/src/error.rs
@@ -56,7 +56,7 @@ impl From<BlkError> for BlockError {
 }
 
 /// Adapt a block-runtime failure at the VFS implementation boundary.
-#[cfg(feature = "fat")]
+#[cfg(any(feature = "ext4", feature = "fat"))]
 pub(crate) fn block_error_to_vfs_error(error: BlockError) -> VfsError {
     match error {
         BlockError::InvalidRequest => VfsError::InvalidInput,
@@ -151,7 +151,7 @@ pub(crate) fn io_error_to_vfs_error(error: IoError) -> VfsError {
     }
 }
 
-#[cfg(all(test, feature = "fat"))]
+#[cfg(all(test, any(feature = "ext4", feature = "fat")))]
 mod tests {
     use super::*;
 

--- a/fs/ax-fs-ng/src/file/cache/reclaim.rs
+++ b/fs/ax-fs-ng/src/file/cache/reclaim.rs
@@ -28,7 +28,7 @@ pub fn page_cache_reclaim(num_pages: usize) -> usize {
     if RECLAIM_IN_PROGRESS.swap(true, Ordering::AcqRel) {
         return 0;
     }
-    let _guard = ReclaimGuard;
+    let guard = ReclaimGuard;
 
     let mut reclaimed = 0;
     let target = num_pages.max(16) * 2;
@@ -61,6 +61,18 @@ pub fn page_cache_reclaim(num_pages: usize) -> usize {
         if reclaimed >= target {
             break;
         }
+    }
+    drop(guard);
+
+    // The remaining quota goes to the block-layer cache trees; like the
+    // page cache above, only clean folios are reclaimable here.
+    #[cfg(any(feature = "ext4", feature = "fat"))]
+    if reclaimed < target {
+        let freed = crate::block::cache::reclaim_clean_folios(target - reclaimed);
+        if freed > 0 {
+            debug!("page_cache_reclaim: evicted {freed} clean block-cache folios");
+        }
+        reclaimed += freed;
     }
 
     if reclaimed > 0 {

--- a/fs/ax-fs-ng/src/fs/mod.rs
+++ b/fs/ax-fs-ng/src/fs/mod.rs
@@ -8,6 +8,8 @@ use axfs_ng_vfs::{Filesystem, VfsResult};
 use crate::FilesystemKind;
 #[cfg(any(feature = "ext4", feature = "fat"))]
 use crate::block::FsBlockDevice;
+#[cfg(any(feature = "ext4", feature = "fat"))]
+use crate::block_error_to_vfs_error;
 use crate::{BlockDeviceHandle, block::BlockRegion};
 
 #[cfg(feature = "ext4")]
@@ -40,7 +42,9 @@ pub(crate) fn new_by_kind(
 /// platform probe path.
 #[cfg(any(feature = "ext4", feature = "fat"))]
 pub fn new_from_handle(dev: Arc<BlockDeviceHandle>, region: BlockRegion) -> VfsResult<Filesystem> {
-    new_default(crate::block::boxed_native_handle_block_device(dev), region)
+    let dev =
+        crate::block::boxed_native_handle_block_device(dev).map_err(block_error_to_vfs_error)?;
+    new_default(dev, region)
 }
 
 #[cfg(any(feature = "ext4", feature = "fat"))]
@@ -49,11 +53,9 @@ pub(crate) fn new_from_handle_with_kind(
     region: BlockRegion,
     kind: FilesystemKind,
 ) -> VfsResult<Filesystem> {
-    new_by_kind(
-        crate::block::boxed_native_handle_block_device(dev),
-        region,
-        kind,
-    )
+    let dev =
+        crate::block::boxed_native_handle_block_device(dev).map_err(block_error_to_vfs_error)?;
+    new_by_kind(dev, region, kind)
 }
 
 #[cfg(not(any(feature = "ext4", feature = "fat")))]

--- a/fs/ax-fs-ng/src/lib.rs
+++ b/fs/ax-fs-ng/src/lib.rs
@@ -29,7 +29,7 @@ pub mod os;
 pub mod root;
 pub mod volume;
 
-#[cfg(feature = "fat")]
+#[cfg(any(feature = "ext4", feature = "fat"))]
 pub(crate) use error::block_error_to_vfs_error;
 pub use error::{BlockError, BlockResult};
 pub(crate) use error::{io_error_to_vfs_error, vfs_error_to_io_error};

--- a/fs/ax-fs-ng/src/lib.rs
+++ b/fs/ax-fs-ng/src/lib.rs
@@ -41,6 +41,8 @@ fn register_mounted_filesystem(fs: Filesystem) {
     MOUNTED_FILESYSTEMS.lock().push(fs);
 }
 
+#[cfg(any(feature = "ext4", feature = "fat"))]
+pub use block::sync_all_block_caches;
 pub use block::{
     BlockRegion,
     runtime::{

--- a/fs/ax-fs-ng/src/root.rs
+++ b/fs/ax-fs-ng/src/root.rs
@@ -190,7 +190,8 @@ pub fn init_root(
     bootargs: Option<&str>,
 ) {
     let root_spec = RootSpec::parse_bootargs(bootargs);
-    let mut disks = collect_disks(block_devs);
+    let mut disks = collect_disks(block_devs)
+        .unwrap_or_else(|error| panic!("failed to initialize block cache: {error:?}"));
     let candidates = collect_root_candidates(&disks);
     let (selected_disk_index, selected_partition) = select_root_candidate(&candidates, &root_spec)
         .unwrap_or_else(|| panic!("failed to determine root device from available block devices"));
@@ -297,12 +298,12 @@ pub fn init_root_from_rdif_sources(
 
 fn collect_disks(
     block_devs: impl IntoIterator<Item = Arc<BlockDeviceHandle>>,
-) -> Vec<DiscoveredDisk> {
+) -> crate::BlockResult<Vec<DiscoveredDisk>> {
     let mut disks = Vec::new();
 
     for (disk_index, dev) in block_devs.into_iter().enumerate() {
         let handle = dev.clone();
-        let mut dev = boxed_native_handle_block_device(dev);
+        let mut dev = boxed_native_handle_block_device(dev)?;
         let device_name = dev.name().to_string();
         let mut reader = VolumeReader::new(&mut *dev);
         match scan_volumes(&mut reader, DiskId(disk_index as u64)) {
@@ -325,7 +326,7 @@ fn collect_disks(
         }
     }
 
-    disks
+    Ok(disks)
 }
 
 fn collect_partitions(

--- a/fs/rsext4/src/blockdev/cached_device.rs
+++ b/fs/rsext4/src/blockdev/cached_device.rs
@@ -1,13 +1,19 @@
-//! Multi-block cached block device wrapper.
+//! Held-buffer block device wrapper.
 //!
-//! Wraps a [`BlockDevice`] with a fixed-size LRU cache (clock algorithm)
-//! of `CACHE_ENTRIES` blocks (4 blocks = 16 KiB with 4 KiB blocks).
-//! Each cache hit eliminates one QEMU virtio round-trip, which is the
-//! dominant cost on virtualized block devices.
+//! Wraps a [`BlockDevice`] with one held 4 KiB block — the buffer that
+//! backs the read-modify-write pattern used throughout rsext4, exposed
+//! through [`buffer()`] / [`buffer_mut()`].
 //!
-//! The active (most recently accessed) entry exposes its buffer through
-//! [`buffer()`] / [`buffer_mut()`] for the read-modify-write pattern
-//! used throughout rsext4.
+//! The held block was previously the active entry of a four-entry clock
+//! cache. The extra entries were retired once the shared block-layer
+//! cache below this crate began serving misses: larger private caches
+//! (≥5 entries) were known to keep stale metadata across journal replay
+//! (EUCLEAN checksum failures), and 2–4 bought nothing once a miss
+//! stopped reaching the device. Metadata capacity now lives in the
+//! block-layer cache; only the held buffer remains here.
+//!
+//! [`buffer()`]: BlockDev::buffer
+//! [`buffer_mut()`]: BlockDev::buffer_mut
 
 use super::{buffer::BlockBuffer, traits::BlockDevice};
 use crate::{
@@ -15,21 +21,12 @@ use crate::{
     error::{Ext4Error, Ext4Result},
 };
 
-/// Number of cached blocks. 4 blocks × 4 KiB = 16 KiB cache.
-///
-/// Limited to 4 entries: larger caches (≥5) cause stale metadata blocks to
-/// persist across journal replay and mount operations, triggering EUCLEAN
-/// checksum failures and subtract-overflow panics in CRC integrity tests.
-const CACHE_ENTRIES: usize = 4;
-
-/// One cache line: a 4 KiB data buffer plus housekeeping.
+/// One held cache line: a 4 KiB data buffer plus housekeeping.
 struct CacheLine {
-    /// The physical block number, or `None` if the slot is unused.
+    /// The physical block number, or `None` if no block is held.
     block_id: Option<AbsoluteBN>,
-    /// Whether the in-cache data differs from the on-disk copy.
+    /// Whether the held data differs from the on-disk copy.
     dirty: bool,
-    /// Clock eviction reference bit.
-    referenced: bool,
     /// The 4 KiB block buffer.
     buffer: BlockBuffer,
 }
@@ -39,35 +36,23 @@ impl CacheLine {
         Self {
             block_id: None,
             dirty: false,
-            referenced: false,
             buffer: BlockBuffer::new(),
         }
     }
-
-    fn is_empty(&self) -> bool {
-        self.block_id.is_none()
-    }
 }
 
-/// Multi-block cached block device wrapper used internally by the journal proxy.
+/// Held-buffer block device wrapper used internally by the journal proxy.
 pub(super) struct BlockDev<B: BlockDevice> {
     dev: B,
-    /// The cache lines.
-    entries: [CacheLine; CACHE_ENTRIES],
-    /// Index of the most recently accessed (active) entry.
-    active: usize,
-    /// Clock hand for the second-chance eviction policy.
-    clock: usize,
+    held: CacheLine,
 }
 
 impl<B: BlockDevice> BlockDev<B> {
-    /// Creates a new cached block device wrapper.
+    /// Creates a held-buffer block device wrapper.
     pub fn new(dev: B) -> Self {
         Self {
             dev,
-            entries: core::array::from_fn(|_| CacheLine::new()),
-            active: 0,
-            clock: 0,
+            held: CacheLine::new(),
         }
     }
 
@@ -75,72 +60,37 @@ impl<B: BlockDevice> BlockDev<B> {
         self.dev
     }
 
-    /// Creates a cached block device wrapper with a caller-provided buffer.
-    pub fn _with_buffer(dev: B, buffer: BlockBuffer) -> Ext4Result<Self> {
-        if buffer.len() < 512 {
-            return Err(Ext4Error::buffer_too_small(buffer.len(), 512));
-        }
-
-        let mut slf = Self::new(dev);
-        slf.entries[0].buffer = buffer;
-        Ok(slf)
-    }
-
-    /// Opens the underlying device.
-    pub fn _open(&mut self) -> Ext4Result<()> {
-        self.dev.open()
-    }
-
-    /// Flushes pending state and closes the underlying device.
-    pub fn _close(&mut self) -> Ext4Result<()> {
-        self.flush()?;
-        self.dev.close()
-    }
-
-    /// Reads one block into the cache and makes it the active entry.
+    /// Reads one block into the held buffer.
     ///
-    /// On a cache hit the active entry is updated with no device I/O.
-    /// On a miss the least recently used (clock) entry is recycled;
-    /// if it is dirty it is flushed first.
+    /// On a hit no device I/O happens; the read is served by the
+    /// block-layer cache beneath this wrapper. On a miss any pending
+    /// modification of the previously held block is written back first.
     pub fn read_block(&mut self, block_id: AbsoluteBN) -> Ext4Result<()> {
-        // Cache hit — just mark referenced and make active.
-        for (i, entry) in self.entries.iter_mut().enumerate() {
-            if !entry.is_empty() && entry.block_id == Some(block_id) {
-                entry.referenced = true;
-                self.active = i;
-                return Ok(());
-            }
+        if self.held.block_id == Some(block_id) {
+            return Ok(());
         }
-
-        // Cache miss — find a victim via clock.
-        let idx = self.clock_evict()?;
-
-        // Read into the victim slot and make it the active entry.
+        self.flush_held()?;
         self.dev
-            .read(self.entries[idx].buffer.as_mut_slice(), block_id, 1)?;
-        self.entries[idx].block_id = Some(block_id);
-        self.entries[idx].dirty = false;
-        self.entries[idx].referenced = true;
-        self.active = idx;
+            .read(self.held.buffer.as_mut_slice(), block_id, 1)?;
+        self.held.block_id = Some(block_id);
+        self.held.dirty = false;
         Ok(())
     }
 
-    /// Writes the active buffer to the target block and marks it as the
-    /// active entry.
+    /// Writes the held buffer to the target block and keeps it held as
+    /// the clean copy of that block.
     pub fn write_block(&mut self, block_id: AbsoluteBN) -> Ext4Result<()> {
         if self.dev.is_readonly() {
             return Err(Ext4Error::read_only());
         }
-
-        let active = &mut self.entries[self.active];
-        self.dev.write(active.buffer.as_slice(), block_id, 1)?;
-        active.block_id = Some(block_id);
-        active.dirty = false;
-        active.referenced = true;
+        self.dev.write(self.held.buffer.as_slice(), block_id, 1)?;
+        self.held.block_id = Some(block_id);
+        self.held.dirty = false;
         Ok(())
     }
 
-    /// Reads `count` blocks directly into `buffer` (bypasses the cache).
+    /// Reads `count` blocks directly into `buffer` (bypasses the held
+    /// block).
     pub fn read_blocks(
         &mut self,
         buffer: &mut [u8],
@@ -157,7 +107,8 @@ impl<B: BlockDevice> BlockDev<B> {
         self.dev.read(buffer, block_id, count)
     }
 
-    /// Writes `count` blocks directly from `buffer` (bypasses the cache).
+    /// Writes `count` blocks directly from `buffer` (bypasses the held
+    /// block, whose contents are refreshed if it overlaps the range).
     pub fn write_blocks(
         &mut self,
         buffer: &[u8],
@@ -177,17 +128,15 @@ impl<B: BlockDevice> BlockDev<B> {
 
         self.dev.write(buffer, block_id, count)?;
 
-        for off in 0..count {
-            let target = block_id.checked_add(off)?;
-            for entry in self.entries.iter_mut() {
-                if !entry.is_empty() && entry.block_id == Some(target) {
+        if let Some(held) = self.held.block_id {
+            for off in 0..count {
+                if held == block_id.checked_add(off)? {
                     let start = off as usize * block_size;
-                    entry
+                    self.held
                         .buffer
                         .as_mut_slice()
                         .copy_from_slice(&buffer[start..start + block_size]);
-                    entry.dirty = false;
-                    entry.referenced = true;
+                    self.held.dirty = false;
                     break;
                 }
             }
@@ -196,74 +145,45 @@ impl<B: BlockDevice> BlockDev<B> {
         Ok(())
     }
 
-    /// Returns the active buffer (read-only view of the last accessed block).
+    /// Returns the held buffer (read-only view of the last accessed
+    /// block).
     pub fn buffer(&self) -> &[u8] {
-        self.entries[self.active].buffer.as_slice()
+        self.held.buffer.as_slice()
     }
 
-    /// Returns the active buffer as mutable and marks the entry dirty.
+    /// Returns the held buffer as mutable and marks it dirty.
     pub fn buffer_mut(&mut self) -> &mut [u8] {
-        self.entries[self.active].dirty = true;
-        self.entries[self.active].buffer.as_mut_slice()
+        self.held.dirty = true;
+        self.held.buffer.as_mut_slice()
     }
 
-    /// Flushes dirty cached blocks, then invalidates all entries.
+    /// Writes back the held block if dirty, then drops it.
     ///
-    /// Dirty entries are flushed first so metadata modifications made
-    /// via [`buffer_mut`] are never silently discarded.
+    /// Dirty data is flushed first so modifications made via
+    /// [`buffer_mut`] are never silently discarded.
     pub fn invalidate_cache(&mut self) -> Ext4Result<()> {
-        for entry in self.entries.iter_mut() {
-            if entry.dirty && !entry.is_empty() {
-                let bid = entry.block_id.unwrap();
-                self.dev.write(entry.buffer.as_slice(), bid, 1)?;
-                entry.dirty = false;
-            }
-            entry.block_id = None;
-            entry.referenced = false;
-        }
-        self.active = 0;
-        self.clock = 0;
+        self.flush_held()?;
+        self.held.block_id = None;
         Ok(())
     }
 
-    /// Replaces cached block contents without writing to the device.
+    /// Replaces the held block contents without writing to the device.
     pub(crate) fn cache_clean_block(
         &mut self,
         block_id: AbsoluteBN,
         data: &[u8; crate::config::BLOCK_SIZE],
     ) -> Ext4Result<()> {
-        // Reuse an existing slot for this block, or pick a victim.
-        for (i, entry) in self.entries.iter_mut().enumerate() {
-            if !entry.is_empty() && entry.block_id == Some(block_id) {
-                entry.buffer.as_mut_slice().copy_from_slice(data);
-                entry.dirty = false;
-                entry.referenced = true;
-                self.active = i;
-                return Ok(());
-            }
-        }
-
-        // Not found — allocate a fresh slot via clock.
-        let idx = self.clock_evict()?;
-        self.entries[idx]
-            .buffer
-            .as_mut_slice()
-            .copy_from_slice(data);
-        self.entries[idx].block_id = Some(block_id);
-        self.entries[idx].dirty = false;
-        self.entries[idx].referenced = true;
+        // A dirty held block reaches the device before it is replaced.
+        self.flush_held()?;
+        self.held.buffer.as_mut_slice().copy_from_slice(data);
+        self.held.block_id = Some(block_id);
+        self.held.dirty = false;
         Ok(())
     }
 
-    /// Flushes all dirty cached blocks and the underlying device.
+    /// Writes back the held block if dirty, then flushes the device.
     pub fn flush(&mut self) -> Ext4Result<()> {
-        for entry in self.entries.iter_mut() {
-            if entry.dirty && !entry.is_empty() {
-                self.dev
-                    .write(entry.buffer.as_slice(), entry.block_id.unwrap(), 1)?;
-                entry.dirty = false;
-            }
-        }
+        self.flush_held()?;
         self.dev.flush()
     }
 
@@ -287,56 +207,21 @@ impl<B: BlockDevice> BlockDev<B> {
         &mut self.dev
     }
 
-    // ─── clock eviction ────────────────────────────────────────────
-
-    /// Finds a cache slot to reuse via the clock (second-chance) algorithm.
-    ///
-    /// Dirty victims are flushed before the slot is returned.  Returns
-    /// the index of the newly-allocated slot (which is also set as the
-    /// active entry).  The caller must fill the buffer.
-    fn clock_evict(&mut self) -> Ext4Result<usize> {
-        for _ in 0..(CACHE_ENTRIES * 2) {
-            let idx = self.clock;
-            self.clock = (self.clock + 1) % CACHE_ENTRIES;
-
-            // Borrow entries[idx] via index to avoid holding a ref across
-            // the potential write below.
-            if self.entries[idx].is_empty() {
-                self.active = idx;
-                return Ok(idx);
+    /// Writes the held block back to the device when it carries pending
+    /// modifications.
+    fn flush_held(&mut self) -> Ext4Result<()> {
+        if self.held.dirty {
+            let Some(block_id) = self.held.block_id else {
+                // A dirty line always has a block: `buffer_mut` is only
+                // reachable after `read_block`/`write_block` set one.
+                return Ok(());
+            };
+            if self.dev.is_readonly() {
+                return Err(Ext4Error::read_only());
             }
-
-            if self.entries[idx].referenced {
-                self.entries[idx].referenced = false;
-                continue;
-            }
-
-            // Unreferenced — flush if dirty, then recycle.
-            if self.entries[idx].dirty {
-                let bid = self.entries[idx].block_id.unwrap();
-                self.dev
-                    .write(self.entries[idx].buffer.as_slice(), bid, 1)?;
-                self.entries[idx].dirty = false;
-            }
-
-            self.entries[idx].block_id = None;
-            self.entries[idx].referenced = false;
-            self.active = idx;
-            return Ok(idx);
+            self.dev.write(self.held.buffer.as_slice(), block_id, 1)?;
+            self.held.dirty = false;
         }
-
-        // All entries referenced — fall back to the current clock slot.
-        let idx = self.clock;
-        self.clock = (self.clock + 1) % CACHE_ENTRIES;
-        if self.entries[idx].dirty {
-            let bid = self.entries[idx].block_id.unwrap();
-            self.dev
-                .write(self.entries[idx].buffer.as_slice(), bid, 1)?;
-            self.entries[idx].dirty = false;
-        }
-        self.entries[idx].block_id = None;
-        self.entries[idx].referenced = false;
-        self.active = idx;
-        Ok(idx)
+        Ok(())
     }
 }

--- a/fs/rsext4/src/blockdev/cached_device.rs
+++ b/fs/rsext4/src/blockdev/cached_device.rs
@@ -157,6 +157,11 @@ impl<B: BlockDevice> BlockDev<B> {
         self.held.buffer.as_mut_slice()
     }
 
+    /// Returns whether `block_id` is already backed by the held buffer.
+    pub(crate) fn holds_block(&self, block_id: AbsoluteBN) -> bool {
+        self.held.block_id == Some(block_id)
+    }
+
     /// Writes back the held block if dirty, then drops it.
     ///
     /// Dirty data is flushed first so modifications made via
@@ -179,6 +184,29 @@ impl<B: BlockDevice> BlockDev<B> {
         self.held.block_id = Some(block_id);
         self.held.dirty = false;
         Ok(())
+    }
+
+    /// Transfers ownership of a dirty held block to the journal queue.
+    ///
+    /// The queue owns an immutable snapshot of the same buffer, so a later
+    /// held-buffer miss must not write the block to its home location before
+    /// the journal transaction commits.
+    pub(crate) fn acknowledge_journaled_block(&mut self, block_id: AbsoluteBN) {
+        if self.held.block_id == Some(block_id) {
+            self.held.dirty = false;
+        }
+    }
+
+    /// Refreshes an overlapping held block from a journaled bulk update.
+    pub(crate) fn acknowledge_journaled_block_with(
+        &mut self,
+        block_id: AbsoluteBN,
+        data: &[u8; crate::config::BLOCK_SIZE],
+    ) {
+        if self.held.block_id == Some(block_id) {
+            self.held.buffer.as_mut_slice().copy_from_slice(data);
+            self.held.dirty = false;
+        }
     }
 
     /// Writes back the held block if dirty, then flushes the device.

--- a/fs/rsext4/src/blockdev/cached_device.rs
+++ b/fs/rsext4/src/blockdev/cached_device.rs
@@ -162,6 +162,15 @@ impl<B: BlockDevice> BlockDev<B> {
         self.held.block_id == Some(block_id)
     }
 
+    /// Returns the dirty held block so the journal can retain writeback ownership.
+    pub(crate) fn dirty_held_block_id(&self) -> Option<AbsoluteBN> {
+        if self.held.dirty {
+            self.held.block_id
+        } else {
+            None
+        }
+    }
+
     /// Writes back the held block if dirty, then drops it.
     ///
     /// Dirty data is flushed first so modifications made via
@@ -188,9 +197,10 @@ impl<B: BlockDevice> BlockDev<B> {
 
     /// Transfers ownership of a dirty held block to the journal queue.
     ///
-    /// The queue owns an immutable snapshot of the same buffer, so a later
+    /// The queue owns the pending snapshot of the same buffer, so a later
     /// held-buffer miss must not write the block to its home location before
-    /// the journal transaction commits.
+    /// the journal transaction commits. A later edit transfers ownership again
+    /// after the journal refreshes that snapshot.
     pub(crate) fn acknowledge_journaled_block(&mut self, block_id: AbsoluteBN) {
         if self.held.block_id == Some(block_id) {
             self.held.dirty = false;

--- a/fs/rsext4/src/blockdev/journal.rs
+++ b/fs/rsext4/src/blockdev/journal.rs
@@ -214,6 +214,7 @@ impl<B: BlockDevice> Jbd2Dev<B> {
             return self.inner.write_block(block_id);
         }
 
+        self.refresh_pending_held_update();
         let meta_vec = self.inner.buffer();
         let mut new_buf = Box::new([0; BLOCK_SIZE]);
         new_buf[..].copy_from_slice(meta_vec);
@@ -546,6 +547,53 @@ mod tests {
         assert!(
             !raw.writes.contains(&home_block),
             "flushed pending metadata reached home before the JBD2 commit record"
+        );
+    }
+
+    #[test]
+    fn auto_commit_refreshes_reedited_pending_metadata() {
+        let journal_start = AbsoluteBN::new(128);
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
+        dev.set_journal_superblock(JournalSuperBllockS::default(), journal_start);
+
+        let home_block = AbsoluteBN::new(10);
+        dev.read_block(home_block).expect("read metadata block");
+        dev.buffer_mut()[0] = 0xa5;
+        dev.write_block(home_block, true)
+            .expect("queue initial metadata update");
+
+        let fill_count = JBD2_BUFFER_MAX - 1;
+        let fill = vec![0x11; fill_count * BLOCK_SIZE];
+        dev.write_blocks(&fill, AbsoluteBN::new(20), fill_count as u32, true)
+            .expect("fill journal queue without committing");
+        assert_eq!(
+            dev.system
+                .as_ref()
+                .expect("journal system")
+                .commit_queue
+                .len(),
+            JBD2_BUFFER_MAX
+        );
+
+        dev.buffer_mut()[0] = 0x5a;
+        assert!(
+            !dev.inner._device().writes.contains(&home_block),
+            "reedited pending metadata reached home before the automatic commit"
+        );
+
+        dev.write_block(AbsoluteBN::new(40), true)
+            .expect("trigger automatic journal commit");
+
+        let raw = dev.into_inner();
+        let first_payload_block = journal_start
+            .checked_add(2)
+            .expect("first journal payload block")
+            .as_usize()
+            .expect("journal payload block index");
+        assert_eq!(
+            raw.data[first_payload_block * BLOCK_SIZE],
+            0x5a,
+            "automatic commit must journal the latest held metadata snapshot"
         );
     }
 

--- a/fs/rsext4/src/blockdev/journal.rs
+++ b/fs/rsext4/src/blockdev/journal.rs
@@ -194,9 +194,9 @@ impl<B: BlockDevice> Jbd2Dev<B> {
             );
             return self.inner.write_block(block_id);
         };
-        let raw_dev = self.inner.device_mut();
-
-        if Self::enqueue_journal_update(system, raw_dev, updates)? {
+        let committed = Self::enqueue_journal_update(system, self.inner.device_mut(), updates)?;
+        self.inner.acknowledge_journaled_block(block_id);
+        if committed {
             self.inner.invalidate_cache()?;
         }
         trace!("[JBD2 buffer] queued metadata block {block_id}");
@@ -205,6 +205,9 @@ impl<B: BlockDevice> Jbd2Dev<B> {
 
     /// Reads one block through the cached inner device.
     pub fn read_block(&mut self, block_id: AbsoluteBN) -> Ext4Result<()> {
+        if self.inner.holds_block(block_id) {
+            return Ok(());
+        }
         if self.journal_use
             && let Some(system) = self.system.as_ref()
             && let Some(update) = system
@@ -279,7 +282,6 @@ impl<B: BlockDevice> Jbd2Dev<B> {
             );
             return self.inner.write_blocks(buf, block_id, count);
         };
-        let raw_dev = self.inner.device_mut();
         let required = count as usize * BLOCK_SIZE;
         if buf.len() < required {
             return Err(Ext4Error::buffer_too_small(buf.len(), required));
@@ -288,11 +290,18 @@ impl<B: BlockDevice> Jbd2Dev<B> {
         let mut committed_any = false;
         for i in 0..count {
             let off = (i as usize) * BLOCK_SIZE;
+            let journaled_block = block_id.checked_add(i)?;
+            let data: &[u8; BLOCK_SIZE] = buf[off..off + BLOCK_SIZE]
+                .try_into()
+                .map_err(|_| Ext4Error::buffer_too_small(buf.len(), required))?;
             let mut boxbuf = Box::new([0; BLOCK_SIZE]);
-            boxbuf[..].copy_from_slice(&buf[off..off + BLOCK_SIZE]);
-            let updates = Jbd2Update(block_id.checked_add(i)?, boxbuf);
+            boxbuf[..].copy_from_slice(data);
+            let updates = Jbd2Update(journaled_block, boxbuf);
 
-            committed_any |= Self::enqueue_journal_update(system, raw_dev, updates)?;
+            committed_any |=
+                Self::enqueue_journal_update(system, self.inner.device_mut(), updates)?;
+            self.inner
+                .acknowledge_journaled_block_with(journaled_block, data);
         }
         if committed_any {
             self.inner.invalidate_cache()?;
@@ -335,6 +344,7 @@ mod tests {
 
     struct MemBlockDev {
         data: Vec<u8>,
+        writes: Vec<AbsoluteBN>,
         fail_flush: bool,
         fail_write_block: Option<AbsoluteBN>,
     }
@@ -343,6 +353,7 @@ mod tests {
         fn new(blocks: usize) -> Self {
             Self {
                 data: vec![0; blocks * BLOCK_SIZE],
+                writes: Vec::new(),
                 fail_flush: false,
                 fail_write_block: None,
             }
@@ -351,6 +362,7 @@ mod tests {
         fn with_failing_flush(blocks: usize) -> Self {
             Self {
                 data: vec![0; blocks * BLOCK_SIZE],
+                writes: Vec::new(),
                 fail_flush: true,
                 fail_write_block: None,
             }
@@ -359,6 +371,7 @@ mod tests {
         fn with_failing_write_block(blocks: usize, block: AbsoluteBN) -> Self {
             Self {
                 data: vec![0; blocks * BLOCK_SIZE],
+                writes: Vec::new(),
                 fail_flush: false,
                 fail_write_block: Some(block),
             }
@@ -377,6 +390,7 @@ mod tests {
             if self.fail_write_block == Some(block_id) {
                 return Err(Ext4Error::io());
             }
+            self.writes.push(block_id);
             let start = block_id.as_usize()? * BLOCK_SIZE;
             let end = start + buffer.len();
             self.data[start..end].copy_from_slice(buffer);
@@ -410,6 +424,52 @@ mod tests {
         fn current_time(&self) -> Ext4Result<Ext4Timestamp> {
             Ok(Ext4Timestamp::new(0, 0))
         }
+    }
+
+    #[test]
+    fn queued_metadata_stays_off_home_block_until_commit() {
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
+        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
+
+        let home_block = AbsoluteBN::new(10);
+        dev.read_block(home_block).expect("read metadata block");
+        dev.buffer_mut()[0] = 0xa5;
+        dev.write_block(home_block, true)
+            .expect("queue metadata update");
+        dev.read_block(AbsoluteBN::new(11))
+            .expect("switch held metadata block");
+
+        let raw = dev.into_inner();
+        assert!(
+            !raw.writes.contains(&home_block),
+            "queued metadata reached its home block before the JBD2 commit record"
+        );
+    }
+
+    #[test]
+    fn rereading_reedited_pending_metadata_keeps_it_off_home_block() {
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
+        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
+
+        let home_block = AbsoluteBN::new(10);
+        dev.read_block(home_block).expect("read metadata block");
+        dev.buffer_mut()[0] = 0xa5;
+        dev.write_block(home_block, true)
+            .expect("queue metadata update");
+        dev.buffer_mut()[0] = 0x5a;
+        dev.read_block(home_block)
+            .expect("reread the reedited held block");
+
+        assert_eq!(
+            dev.buffer()[0],
+            0x5a,
+            "a held dirty edit must remain newer than its queued snapshot"
+        );
+        let raw = dev.into_inner();
+        assert!(
+            !raw.writes.contains(&home_block),
+            "reedited pending metadata reached home before the JBD2 commit record"
+        );
     }
 
     #[test]

--- a/fs/rsext4/src/blockdev/journal.rs
+++ b/fs/rsext4/src/blockdev/journal.rs
@@ -33,6 +33,34 @@ pub struct Jbd2Dev<B: BlockDevice> {
 }
 
 impl<B: BlockDevice> Jbd2Dev<B> {
+    /// Refreshes a queued update from the held buffer before it can be flushed.
+    ///
+    /// Editing a block after it enters `commit_queue` makes the held copy dirty
+    /// again. The journal still owns writeback for that block, so crossing a
+    /// held-buffer boundary must update the queued snapshot instead of exposing
+    /// the edit at its home location before the commit record is durable.
+    fn refresh_pending_held_update(&mut self) {
+        if !self.journal_use {
+            return;
+        }
+
+        let Some(block_id) = self.inner.dirty_held_block_id() else {
+            return;
+        };
+        let Some(update) = self.system.as_mut().and_then(|system| {
+            system
+                .commit_queue
+                .iter_mut()
+                .find(|queued| queued.0 == block_id)
+        }) else {
+            return;
+        };
+
+        update.1.copy_from_slice(self.inner.buffer());
+        self.inner.acknowledge_journaled_block(block_id);
+        trace!("[JBD2 buffer] refreshed pending metadata block {block_id}");
+    }
+
     fn enqueue_journal_update(
         system: &mut JBD2DEVSYSTEM,
         raw_dev: &mut B,
@@ -115,6 +143,8 @@ impl<B: BlockDevice> Jbd2Dev<B> {
             return ReplayStatus::Complete;
         }
 
+        self.refresh_pending_held_update();
+
         let Some(jbd_sys) = self.system.as_mut() else {
             error!("journal replay requested before JBD2 state was initialized");
             return ReplayStatus::Incomplete;
@@ -164,6 +194,8 @@ impl<B: BlockDevice> Jbd2Dev<B> {
             return Ok(());
         }
 
+        self.refresh_pending_held_update();
+
         if let Some(system) = self.system.as_mut() {
             let committed = system
                 .commit_transaction_with_mapping(self.inner.device_mut(), &self.journal_blocks)?;
@@ -208,6 +240,7 @@ impl<B: BlockDevice> Jbd2Dev<B> {
         if self.inner.holds_block(block_id) {
             return Ok(());
         }
+        self.refresh_pending_held_update();
         if self.journal_use
             && let Some(system) = self.system.as_ref()
             && let Some(update) = system
@@ -248,6 +281,8 @@ impl<B: BlockDevice> Jbd2Dev<B> {
             return Err(Ext4Error::buffer_too_small(buf.len(), required));
         }
 
+        self.refresh_pending_held_update();
+
         self.inner.read_blocks(buf, block_id, count)?;
 
         let Some(system) = self.system.as_ref() else {
@@ -275,6 +310,12 @@ impl<B: BlockDevice> Jbd2Dev<B> {
             return self.inner.write_blocks(buf, block_id, count);
         }
 
+        let required = count as usize * BLOCK_SIZE;
+        if buf.len() < required {
+            return Err(Ext4Error::buffer_too_small(buf.len(), required));
+        }
+
+        self.refresh_pending_held_update();
         let Some(system) = self.system.as_mut() else {
             error!(
                 "journal is enabled but JBD2 state is not initialized; writing {count} block(s) \
@@ -282,10 +323,6 @@ impl<B: BlockDevice> Jbd2Dev<B> {
             );
             return self.inner.write_blocks(buf, block_id, count);
         };
-        let required = count as usize * BLOCK_SIZE;
-        if buf.len() < required {
-            return Err(Ext4Error::buffer_too_small(buf.len(), required));
-        }
 
         let mut committed_any = false;
         for i in 0..count {
@@ -312,6 +349,7 @@ impl<B: BlockDevice> Jbd2Dev<B> {
 
     /// Flushes the inner cached device.
     pub fn flush(&mut self) -> Ext4Result<()> {
+        self.refresh_pending_held_update();
         self.inner.flush()
     }
 
@@ -447,7 +485,7 @@ mod tests {
     }
 
     #[test]
-    fn rereading_reedited_pending_metadata_keeps_it_off_home_block() {
+    fn switching_from_reedited_pending_metadata_refreshes_journal_snapshot() {
         let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
         dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
 
@@ -457,18 +495,57 @@ mod tests {
         dev.write_block(home_block, true)
             .expect("queue metadata update");
         dev.buffer_mut()[0] = 0x5a;
-        dev.read_block(home_block)
-            .expect("reread the reedited held block");
+        dev.read_block(AbsoluteBN::new(11))
+            .expect("switch away from reedited metadata");
 
         assert_eq!(
-            dev.buffer()[0],
+            dev.system
+                .as_ref()
+                .expect("journal system")
+                .commit_queue
+                .iter()
+                .find(|update| update.0 == home_block)
+                .expect("pending home-block update")
+                .1[0],
             0x5a,
-            "a held dirty edit must remain newer than its queued snapshot"
+            "switching blocks must refresh the pending journal snapshot"
         );
         let raw = dev.into_inner();
         assert!(
             !raw.writes.contains(&home_block),
             "reedited pending metadata reached home before the JBD2 commit record"
+        );
+    }
+
+    #[test]
+    fn flushing_reedited_pending_metadata_refreshes_journal_snapshot() {
+        let mut dev = Jbd2Dev::initial_jbd2dev(0, MemBlockDev::new(256), true);
+        dev.set_journal_superblock(JournalSuperBllockS::default(), AbsoluteBN::new(128));
+
+        let home_block = AbsoluteBN::new(10);
+        dev.read_block(home_block).expect("read metadata block");
+        dev.buffer_mut()[0] = 0xa5;
+        dev.write_block(home_block, true)
+            .expect("queue metadata update");
+        dev.buffer_mut()[0] = 0x5a;
+        dev.flush().expect("flush underlying journal device");
+
+        assert_eq!(
+            dev.system
+                .as_ref()
+                .expect("journal system")
+                .commit_queue
+                .iter()
+                .find(|update| update.0 == home_block)
+                .expect("pending home-block update")
+                .1[0],
+            0x5a,
+            "flushing must refresh the pending journal snapshot"
+        );
+        let raw = dev.into_inner();
+        assert!(
+            !raw.writes.contains(&home_block),
+            "flushed pending metadata reached home before the JBD2 commit record"
         );
     }
 

--- a/fs/rsext4/src/config.rs
+++ b/fs/rsext4/src/config.rs
@@ -47,7 +47,11 @@ pub const USE_MULTILEVEL_CACHE: bool = cfg!(feature = "USE_MULTILEVEL_CACHE");
 /// Maximum number of inode-table cache entries.
 pub const INODE_CACHE_MAX: usize = 128;
 /// Maximum number of data-block cache entries.
-pub const DATABLOCK_CACHE_MAX: usize = 128;
+///
+/// Kept small for read-modify-write hot blocks and truncate-generation
+/// bookkeeping only; bulk read capacity is provided by the block-layer
+/// cache below this crate.
+pub const DATABLOCK_CACHE_MAX: usize = 32;
 /// Maximum number of bitmap cache entries.
 pub const BITMAP_CACHE_MAX: usize = 128;
 

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -3019,9 +3019,6 @@ mod tests {
             }
         }
 
-        assert!(
-            line_count >= 2,
-            "expected at least 2 lines, got {line_count}"
-        );
+        assert_eq!(line_count, 3, "expected two headers and one data row");
     }
 }

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -901,18 +901,18 @@ where
     RootSync: FnOnce() -> StarryResult<()>,
     BlockSync: FnOnce() -> StarryResult<()>,
 {
-    let mut first_error = page_sync().err();
-    if let Err(error) = root_sync()
-        && first_error.is_none()
-    {
-        first_error = Some(error);
+    if let Err(error) = page_sync() {
+        warn!("sync(2) page-cache writeback failed: {error:?}");
     }
-    if let Err(error) = block_sync()
-        && first_error.is_none()
-    {
-        first_error = Some(error);
+    if let Err(error) = root_sync() {
+        warn!("sync(2) root-filesystem writeback failed: {error:?}");
     }
-    first_error.map_or(Ok(0), Err)
+    if let Err(error) = block_sync() {
+        warn!("sync(2) block-cache writeback failed: {error:?}");
+    }
+    // Linux sync(2) is a best-effort global operation and always reports
+    // success; writeback errors are observed through other durability APIs.
+    Ok(0)
 }
 
 pub fn sys_sync() -> StarryResult<isize> {
@@ -958,7 +958,6 @@ mod tests {
     use core::cell::Cell;
 
     use super::*;
-    use crate::Errno;
 
     #[test]
     fn ctl_ioctl_constants_hold() {
@@ -966,7 +965,7 @@ mod tests {
     }
 
     #[test]
-    fn sync_attempts_every_stage_and_returns_the_first_error() {
+    fn sync_attempts_every_stage_and_returns_success() {
         let page_called = Cell::new(false);
         let root_called = Cell::new(false);
         let block_called = Cell::new(false);
@@ -995,6 +994,6 @@ mod tests {
             block_called.get(),
             "global block-cache sync was skipped after an earlier error"
         );
-        assert_eq!(result.unwrap_err().linux_errno(), Errno::EIO);
+        assert!(matches!(result, Ok(0)));
     }
 }

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -899,6 +899,11 @@ pub fn sys_sync() -> StarryResult<isize> {
         .lock()
         .root_dir()
         .sync(false)?;
+    // The root sync above only reaches the root filesystem's device path;
+    // write back block-cache dirt of every device (other partitions) and
+    // issue their flush barriers.
+    #[cfg(any(feature = "ext4", feature = "fat"))]
+    ax_fs_ng::sync_all_block_caches()?;
     Ok(0)
 }
 

--- a/os/StarryOS/kernel/src/syscall/fs/ctl.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/ctl.rs
@@ -891,20 +891,54 @@ pub fn sys_renameat2(
     Ok(0)
 }
 
+fn run_sync_stages<PageSync, RootSync, BlockSync>(
+    page_sync: PageSync,
+    root_sync: RootSync,
+    block_sync: BlockSync,
+) -> StarryResult<isize>
+where
+    PageSync: FnOnce() -> StarryResult<()>,
+    RootSync: FnOnce() -> StarryResult<()>,
+    BlockSync: FnOnce() -> StarryResult<()>,
+{
+    let mut first_error = page_sync().err();
+    if let Err(error) = root_sync()
+        && first_error.is_none()
+    {
+        first_error = Some(error);
+    }
+    if let Err(error) = block_sync()
+        && first_error.is_none()
+    {
+        first_error = Some(error);
+    }
+    first_error.map_or(Ok(0), Err)
+}
+
 pub fn sys_sync() -> StarryResult<isize> {
     // Only syncs root filesystem; does not iterate all mount points like Linux sync(2).
     // Write back ax-fs-ng page cache first, then flush filesystem metadata.
-    sync_all_cached_files(false)?;
-    ax_fs_ng::vfs::current_fs_context()
-        .lock()
-        .root_dir()
-        .sync(false)?;
-    // The root sync above only reaches the root filesystem's device path;
-    // write back block-cache dirt of every device (other partitions) and
-    // issue their flush barriers.
-    #[cfg(any(feature = "ext4", feature = "fat"))]
-    ax_fs_ng::sync_all_block_caches()?;
-    Ok(0)
+    run_sync_stages(
+        || {
+            sync_all_cached_files(false)?;
+            Ok(())
+        },
+        || {
+            ax_fs_ng::vfs::current_fs_context()
+                .lock()
+                .root_dir()
+                .sync(false)?;
+            Ok(())
+        },
+        || {
+            // The root sync above only reaches the root filesystem's device path;
+            // write back block-cache dirt of every device (other partitions) and
+            // issue their flush barriers.
+            #[cfg(any(feature = "ext4", feature = "fat"))]
+            ax_fs_ng::sync_all_block_caches()?;
+            Ok(())
+        },
+    )
 }
 
 pub fn sys_syncfs(fd: c_int) -> StarryResult<isize> {
@@ -921,8 +955,46 @@ pub fn sys_syncfs(fd: c_int) -> StarryResult<isize> {
 
 #[cfg(all(test, not(axtest)))]
 mod tests {
+    use core::cell::Cell;
+
+    use super::*;
+    use crate::Errno;
+
     #[test]
     fn ctl_ioctl_constants_hold() {
-        assert!(super::ctl_ioctl_constants_hold_for_test());
+        assert!(ctl_ioctl_constants_hold_for_test());
+    }
+
+    #[test]
+    fn sync_attempts_every_stage_and_returns_the_first_error() {
+        let page_called = Cell::new(false);
+        let root_called = Cell::new(false);
+        let block_called = Cell::new(false);
+
+        let result = run_sync_stages(
+            || {
+                page_called.set(true);
+                Err(StarryError::Io)
+            },
+            || {
+                root_called.set(true);
+                Err(StarryError::ReadOnlyFilesystem)
+            },
+            || {
+                block_called.set(true);
+                Err(StarryError::NoMemory)
+            },
+        );
+
+        assert!(page_called.get());
+        assert!(
+            root_called.get(),
+            "root sync was skipped after a page-cache error"
+        );
+        assert!(
+            block_called.get(),
+            "global block-cache sync was skipped after an earlier error"
+        );
+        assert_eq!(result.unwrap_err().linux_errno(), Errno::EIO);
     }
 }

--- a/os/StarryOS/kernel/src/task/pid.rs
+++ b/os/StarryOS/kernel/src/task/pid.rs
@@ -476,27 +476,29 @@ pub struct PidNamespaceShutdown<'a> {
 
 impl PidNamespaceShutdown<'_> {
     pub fn wait_for_live_descendants(&self) {
-        block_on(poll_fn(|cx| {
-            let has_live_descendants = || {
-                self.namespace
-                    .published_members()
-                    .into_iter()
-                    .any(|identity| identity.id() != self.init && identity.live_task().is_some())
-            };
-            if !has_live_descendants() {
-                return Poll::Ready(());
-            }
-            unsafe {
-                self.namespace
-                    .task_exit_event
-                    .register(cx.waker(), IoEvents::IN)
-            };
-            if has_live_descendants() {
-                Poll::Pending
-            } else {
-                Poll::Ready(())
-            }
-        }));
+        let has_live_descendants = || {
+            self.namespace
+                .published_members()
+                .into_iter()
+                .any(|identity| identity.id() != self.init && identity.live_task().is_some())
+        };
+        if has_live_descendants() {
+            block_on(poll_fn(|cx| {
+                if !has_live_descendants() {
+                    return Poll::Ready(());
+                }
+                unsafe {
+                    self.namespace
+                        .task_exit_event
+                        .register(cx.waker(), IoEvents::IN)
+                };
+                if has_live_descendants() {
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            }));
+        }
         self.namespace.finish_shutdown(self.init);
     }
 }

--- a/os/StarryOS/kernel/src/task/process_identity.rs
+++ b/os/StarryOS/kernel/src/task/process_identity.rs
@@ -177,7 +177,7 @@ mod tests {
     use crate::task::{PidReservation, PidReservationKind, Tid};
     #[test]
     fn reaping_releases_process_owned_group_and_session_roles() {
-        let namespace = crate::task::new_test_pid_namespace();
+        let namespace = ROOT_PID_NS.clone();
         let identity = PidReservation::reserve(&namespace, PidReservationKind::ProcessLeader)
             .unwrap()
             .publish()

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -413,13 +413,24 @@ pub fn exit(exit_code: i32) -> ! {
 }
 
 fn current_irq_context() -> bool {
-    #[cfg(feature = "irq")]
+    #[cfg(all(feature = "irq", not(feature = "host-test")))]
     {
         ax_hal::irq::in_irq_context()
     }
-    #[cfg(not(feature = "irq"))]
+    #[cfg(any(not(feature = "irq"), feature = "host-test"))]
     {
         false
+    }
+}
+
+fn current_cpu_id() -> usize {
+    #[cfg(not(feature = "host-test"))]
+    {
+        ax_hal::percpu::this_cpu_id()
+    }
+    #[cfg(feature = "host-test")]
+    {
+        0
     }
 }
 
@@ -501,7 +512,7 @@ impl AtomicContextSnapshot {
             irq_enabled: ax_hal::asm::irqs_enabled(),
             irq_context: current_irq_context(),
             preempt_count,
-            cpu_id: ax_hal::percpu::this_cpu_id(),
+            cpu_id: current_cpu_id(),
             task_id: current.as_ref().map(|curr| curr.id().as_u64()),
             task_state: current.as_ref().map(|curr| curr.state()),
         }
@@ -693,6 +704,12 @@ pub fn run_idle() -> ! {
 #[cfg(test)]
 mod tests {
     use core::cell::Cell;
+
+    #[test]
+    #[cfg(feature = "host-test")]
+    fn host_atomic_context_query_does_not_require_cpu_local_state() {
+        assert!(!super::in_atomic_context());
+    }
 
     #[test]
     fn task_initialization_precedes_scheduling() {

--- a/test-suit/starryos/qemu/system/syscall-test-sync/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-sync/src/main.c
@@ -4,6 +4,7 @@
 
 #include <fcntl.h>
 #include <string.h>
+#include <sys/syscall.h>
 #include <unistd.h>
 
 int main(void)
@@ -11,8 +12,8 @@ int main(void)
     TEST_START("sync Linux 语义对齐");
 
     /*
-     * 测试节点 1：sync 没有返回值。
-     * 这里验证它不会中断后续执行，并且调用后文件内容仍可正常读回。
+     * 测试节点 1：直接触达 sync syscall ABI。
+     * 内核入口返回 0，并且调用后文件内容仍可正常读回。
      */
     {
         char tmpl[] = "/tmp/test-sync-XXXXXX";
@@ -23,8 +24,7 @@ int main(void)
             char buf[16] = {0};
 
             CHECK_RET(write(fd, msg, strlen(msg)), (long)strlen(msg), "write 写入 sync-data");
-            sync();
-            CHECK(1, "sync 调用返回到用户态");
+            CHECK_RET(syscall(SYS_sync), 0, "SYS_sync 返回 0");
             CHECK_RET(lseek(fd, 0, SEEK_SET), 0, "lseek 回到文件头");
             CHECK_RET(read(fd, buf, strlen(msg)), (long)strlen(msg), "read 读回写入内容");
             CHECK(strcmp(buf, msg) == 0, "sync 后读回内容与写入一致");
@@ -41,7 +41,7 @@ int main(void)
         CHECK(fd >= 0, "mkstemp 创建路径场景文件成功");
         if (fd >= 0) {
             close(fd);
-            sync();
+            CHECK_RET(syscall(SYS_sync), 0, "重复 SYS_sync 返回 0");
             CHECK(access(path, F_OK) == 0, "sync 后刚创建的路径仍可访问");
             unlink(path);
         }


### PR DESCRIPTION
## 问题

该 PR 为块设备与文件系统层引入共享 block cache，并处理实现与 review 中发现的正确性、错误传播和生命周期边界：

- 多个文件系统 wrapper 或分区需要共享同一个物理设备视图，不能由各自私有 cache 返回不同数据；
- JBD2 元数据进入事务队列后，普通 held-buffer 写回不能在 commit record 持久化前触达 home block；
- cache reclaim/unregister 不能在持锁或析构路径阻塞，也不能遗留失效注册项；
- cache 构造失败不能一律降级为未缓存设备，资源不足和 registry 状态冲突必须返回调用方；
- device-direct 写可能提交部分 block 后报错，cache 不能继续把覆盖范围内的旧 folio 当作权威数据；
- 块运行时必须等待已经提交的所有窗口终态，不能在后续窗口仍可能修改设备时提前返回首个错误；
- Linux `sync(2)` 会尝试所有全局写回阶段并固定返回成功，内部错误只能记录，不能改变 syscall ABI；
- benchmark 需要校验真实数据内容，并覆盖多个打开句柄之间可能出现的缓存不一致。

此前 rebase 还暴露了 `starry-kernel` host 测试对运行时 PID namespace、IRQ 与 per-CPU 状态的隐式依赖。

## 设计与替代方案

新增 [`docs/design/shared-block-cache.md`](docs/design/shared-block-cache.md)，记录问题、用户、成功标准、非目标、Linux v7.1 固定版本参考、仓内先例、替代方案、分层、所有权与锁序、缓存上限、I/O/错误状态机、journal 顺序、迁移回滚、开放 PR 重叠关系和验证计划。

选择在 runtime block-device handle 边界共享 cache：该 handle 提供稳定设备身份，ext4/FAT 已通过 `FsBlockDevice` 穿过此边界，因而能用一个物理 LBA 树统一 buffered/direct 请求。未选择继续保留 `rsext4` 私有 cache 或为每个文件系统分别加 cache，因为两者都不能消除跨 wrapper/分区的陈旧视图。

文档明确记录本 PR 的范围：新增 device-wide block-cache sync 并修正 `sync(2)` 返回 ABI；StarryOS 目前仅同步 root filesystem metadata 的既有限制不在本 PR 扩展，需要另行增加 mount registry 遍历和多挂载持久性测试。

## 修改

### 共享 block cache

- 在 `ax-fs-ng` 中增加 address space、folio、buffer head、设备 cache 与 registry，并限制每个设备最多 1024 个 folio。
- 将 `rsext4` 块访问与 journal 元数据接入统一缓存。
- 让 StarryOS `sync(2)` 串联 page cache、root filesystem 与全局 block cache 写回阶段。

### Review 修复

- JBD2 首次排队 metadata 时把 dirty writeback ownership 转交给 `commit_queue`，提交完成前普通路径不写 home block。
- 若同一 held block 在排队后再次编辑，在切换/失效 held buffer、flush 底层设备或开始 transaction commit 前，先用 held 最新内容替换 pending snapshot，再清除普通 dirty ownership。
- 在单块 metadata 写入可能跨过 JBD2 自动提交阈值前，同样先刷新已有 pending snapshot，避免满队列提交旧快照；新增“填满 queue → 重改 A → 写 B 自动提交”回归，直接校验 journal payload 为最新值且提交前没有提前 home write。
- reclaim 与注销路径改为非阻塞 `try_lock`，并在查找/注册时清理失效 `Weak`，避免锁反转和陈旧注册。
- block device factory 改为返回 `BlockResult`。只有 `InvalidRequest` 保留未缓存兼容路径；`NoMemory`、`InvalidState` 及其他构造错误传播到调用方。
- direct write 成功时覆盖已有 cache；失败时由于底层接口不提供已完成前缀，丢弃整个覆盖范围内的 folio，后续读取必须重新访问设备。
- 写 pipeline 记录首个错误后停止提交新窗口，但继续等待所有已提交窗口终态，再向同步调用方返回首个错误。
- `sync(2)` 即使某阶段失败也继续执行后续阶段，分别记录失败，并按 Linux ABI 返回 `0`。

### 确定性回归与 benchmark

- 增加 direct write 部分提交后报错的回归：预热两个 folio，mock 只提交第一个 folio；失败后两个 folio 都必须重新读取，分别观察设备上的新/旧数据。旧实现稳定返回 block 0 的陈旧零值。
- 增加多窗口写失败回归：第一个已提交窗口返回错误、第二个保持 in-flight；旧实现会在第二次 IRQ 前提前返回，修复后等待第二个窗口完成并返回第一个错误。
- 增加 `sync(2)` helper 回归：三个阶段全部注入错误，断言三者均执行且结果仍为 `Ok(0)`。旧实现返回 `EIO`。
- 保留共享 cache wrapper、partition LBA 隔离、失败写回重试、registry 分配失败和 JBD2 re-edit 等确定性覆盖。
- `block-io-bench` 使用确定性内容、逐字节校验和顺序敏感 FNV-1a checksum；每轮保留原只读 fd，再由另一 fd 通过 `O_TRUNC` 逆序写入新 generation，原 fd 重新读取并校验大小和内容。
- 输出 `write`、`fsync`、`read`、`coherence-rewrite`、`coherence-read` 的逐轮/中位数指标和 diskstats；任一内容或 checksum 不匹配都会失败退出。

### Host 测试修复

- PID namespace 没有存活后代时走同步关闭快路径，避免 host 测试在没有 runtime executor 时阻塞。
- 进程身份测试使用真实 root PID namespace fixture。
- `ax-task` host 原子上下文判断不读取仅在内核运行时初始化的 IRQ/per-CPU 状态，并增加回归测试。

## Rebase

分支已 rebase 到 `origin/dev` 的 `1d7bfd75492669a0dd09e8ff762d1edbe694c508`，当前 head 为 `cd5774e8c6`。

## 本地验证

- 三个新增回归均先在旧实现上稳定失败，再由同一测试验证修复：陈旧 folio、in-flight window 提前返回、`sync(2)` 返回 `EIO`。
- JBD2 自动提交边界回归在旧实现上稳定观察到已提交 payload 为旧值 `0xa5` 而 held 最新值为 `0x5a`；刷新时机修复后同一测试通过。
- `cargo test -p ax-fs-ng --features 'host-test ext4 vfs'`：120 个单元测试与 3 个集成测试全部通过。
- `cargo test -p rsext4 --features host-test`：94 个单元测试及集成测试通过；1 个需外部 Linux 镜像的用例按设计忽略。
- `cargo test -p starry-kernel`：199/199 通过。
- `cargo xtask clippy --package ax-fs-ng`：6/6 配置通过。
- `cargo xtask clippy --package rsext4`：3/3 配置通过。
- `cargo xtask clippy --package starry-kernel`：98/98 target/feature 配置通过。
- `cargo fmt --all -- --check`、`git diff --check`：通过。
- `cargo xtask starry test qemu --arch x86_64 -c qemu/system/syscall-test-sync`：9/9 通过，命中 `STARRY_SYSTEM_TEST_PASSED` 与 `STARRY_GROUPED_TESTS_PASSED`。
- `cargo xtask starry app qemu -t block-io-bench --arch x86_64`：5 轮初始读取和 5 轮跨 fd truncate/rewrite 一致性校验全部通过，命中 `BLOCK_BENCH_APP_PASSED`。

## CI 超时修复

- 精确 head `c8ae0e48f2` 的 AxLoader HTTP boot 在冷 runner 上总耗时约 45 分 22 秒：命令阶段已完成 6/6 host tests、UEFI check/build、QEMU HTTP kernel transfer 与 ELF load，并输出 `kernel transferred and ELF loaded`；但整 job 在收尾时触发 45 分钟硬超时。上一 head `d908a2d840` 同项用时 25 分 18 秒成功，说明 runner 准备与冷构建存在明显波动，因此预算提高到 90 分钟。
- 精确 head `5048985a04` 的 AxLoader job 已在 20 分 56 秒内成功，命中 `AXLOADER READY`、HTTP body download 和 `kernel transferred and ELF loaded`，确认 90 分钟矩阵配置正确生效。
- 同一 exact head 的 VMX direct/MP fallback/OVMF ACPI job 在 35 分 27 秒内成功，分别命中 `AXVISOR_X86_DIRECT_ACPI_PASSED`、`AXVISOR_X86_MP_FALLBACK_PASSED`、`AXVISOR_X86_OVMF_ACPI_PASSED`；上一轮 45 分钟取消已确认是 runner 冷启动挤占预算，因此保留 90 分钟预算。
- 精确 head `d908a2d840` 的 ASUS NUC15CRH Linux guest 在 45 分钟预算内成功：整 job 34 分 58 秒、命令阶段 30 分 46 秒，命中 `test pass!` 并报告全部 AxVisor board test groups 通过；原 20 分钟预算不足。
- 精确 head `5dcd581993` 的 Starry aarch64 job 已成功；`test-rawmutex-handoff` 完整执行，4 个 worker 全部完成并在 2.893 秒通过。上一轮 120 秒超时未复现，因此不放宽测试 timeout，也不做无证据的内核改动。
- 监控期间 GitHub Actions 曾发生官方 major outage，且单个 self-hosted runner 的 registry 索引暂时缺少既有 `divan 0.1.21`，分别造成 `startup_failure` 和 Cargo 解析失败；未修改 lockfile规避。平台与 runner 恢复后的 attempt 3 为 35/35 success、0 failure、0 cancelled，SG2002 与 ROC-RK3568 板卡项均通过。
- 最新精确 head `cd5774e8c6` 的 push run `33004825502` attempt 2 为 35/35 success、0 failure。attempt 1 唯一失败是 `test-rawmutex-handoff` 的一次 120 秒超时；其余 460/461 system tests 已通过。精确重跑覆盖原失败项及 7 个 fail-fast 取消项，rawmutex 4 个 worker 均完成并在 2.802 秒通过，最终命中 `STARRY_GROUPED_TESTS_PASSED` 与 `AXTEST_SUITE_OK`。
- 所有自托管项均保持 `cache_key: ""`，不启用 Rust cache。
- `uv run --python 3.11 python3 -m unittest scripts/test/test_ci_impact.py scripts/test/test_ci_plan.py scripts/test/test_ci_routing.py`：65 项通过。
- `uv run --python 3.11 python3 scripts/test/check_ci_routing.py`：通过。

## 非目标

- 不改变 ext4/JBD2 磁盘格式或文件系统公开接口。
- 不把 block cache 扩展成 Linux 式后台 writeback 系统，也不重复缓存 file page-cache 数据。
- 不在本 PR 中扩展 StarryOS `sync(2)` 的既有 root-only filesystem-metadata 范围。