### PR TITLE
fix(axvisor): restore runtime counter builds and probe shutdown

### DIFF
--- a/scripts/axbuild/src/axvisor/test/http_probe.rs
+++ b/scripts/axbuild/src/axvisor/test/http_probe.rs
@@ -63,6 +63,12 @@ pub(crate) fn run(
 ) -> anyhow::Result<()> {
     let script = case_dir.join(&config.probe_script);
     ensure_probe_asset(&script)?;
+    if stop.load(Ordering::Acquire) {
+        bail!(
+            "probe asset {} was not started because the case had already stopped",
+            script.display()
+        );
+    }
     println!(
         "  host http probe: running probe asset {}",
         script.display()
@@ -143,6 +149,8 @@ fn wait_probe_asset(child: &mut Child, stop: &AtomicBool) -> Option<ExitStatus> 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    #[cfg(unix)]
+    use std::time::Instant;
 
     use serde::Deserialize;
 
@@ -183,6 +191,18 @@ mod tests {
              \"$AXVISOR_HTTP_BASE|$AXVISOR_HTTP_TOKEN|$AXVISOR_HTTP_CASE_DIR\" > \
              \"$AXVISOR_HTTP_CASE_DIR/env.txt\"\nexit {code}\n"
         );
+        fs::write(&path, script).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    /// Write an executable probe asset that records startup and then blocks.
+    #[cfg(unix)]
+    fn write_blocking_fixture_probe(dir: &Path, name: &str) -> PathBuf {
+        use std::{fs, os::unix::fs::PermissionsExt};
+        let path = dir.join(name);
+        let script =
+            "#!/bin/sh\nprintf started > \"$AXVISOR_HTTP_CASE_DIR/started.txt\"\nexec sleep 30\n";
         fs::write(&path, script).unwrap();
         fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
         path
@@ -247,13 +267,49 @@ mod tests {
     #[test]
     fn run_kills_the_probe_asset_when_stop_is_requested() {
         let dir = tempfile::tempdir().unwrap();
-        write_fixture_probe(dir.path(), "http_probe.py", 0);
+        write_blocking_fixture_probe(dir.path(), "http_probe.py");
         let config = test_config(PathBuf::from("http_probe.py"));
-        // The case is already over before the asset even starts.
+        let case_dir = dir.path().to_path_buf();
+        let started = case_dir.join("started.txt");
+        let stop = Arc::new(AtomicBool::new(false));
+        let run_stop = stop.clone();
+        let probe_thread =
+            thread::spawn(move || run("127.0.0.1:12345", &config, &case_dir, run_stop));
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !started.is_file() {
+            assert!(
+                Instant::now() < deadline,
+                "probe asset did not start before the test deadline"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        stop.store(true, Ordering::Release);
+
+        let error = probe_thread.join().unwrap().unwrap_err();
+        assert!(
+            error.to_string().contains("was killed"),
+            "unexpected error: {error:#}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_does_not_spawn_probe_when_stop_was_already_requested() {
+        let dir = tempfile::tempdir().unwrap();
+        let probe = dir.path().join("http_probe.py");
+        std::fs::write(&probe, "#!/bin/sh\nexit 0\n").unwrap();
+        let config = test_config(PathBuf::from("http_probe.py"));
         let stop = Arc::new(AtomicBool::new(true));
 
         let error = run("127.0.0.1:12345", &config, dir.path(), stop).unwrap_err();
-        assert!(error.to_string().contains("was killed"));
+
+        assert!(
+            error
+                .to_string()
+                .contains("was not started because the case had already stopped"),
+            "unexpected error: {error:#}"
+        );
     }
 
     /// The generic mechanism must execute the actual case asset: the

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -1359,7 +1359,8 @@ impl AxVM {
     /// count restarts from zero. The control plane uses it to distinguish a
     /// genuine wake from a mere status flip.
     pub fn guest_entry_count(&self) -> u64 {
-        self.with_runtime(|runtime| Ok(runtime.guest_entry_count()))
+        self.runtime_handle()
+            .map(|runtime| runtime.guest_entry_count())
             .unwrap_or(0)
     }
 
@@ -1377,7 +1378,8 @@ impl AxVM {
     /// resume sent before it advances can be absorbed while the vCPU is still
     /// running the guest (it never parked, so it never re-enters either).
     pub fn guest_park_count(&self) -> u64 {
-        self.with_runtime(|runtime| Ok(runtime.guest_park_count()))
+        self.runtime_handle()
+            .map(|runtime| runtime.guest_park_count())
             .unwrap_or(0)
     }
 


### PR DESCRIPTION
## 问题

dev 分支的 CI 暴露出两处独立问题：

1. AxVM 的运行时访问接口迁移到 `runtime_handle()` 后，后续加入的 `guest_entry_count()` 和 `guest_park_count()` 仍调用已删除的 `with_runtime()`，导致 workspace clippy 及 LoongArch AxVisor QEMU job 在编译阶段报 E0599。
2. HTTP probe 的停止测试在调用 `run()` 前就设置 stop，但实现仍先启动子进程。在 CI 高并发、资源紧张时，spawn 可能先失败，测试无法验证预期的停止语义；同时也缺少“子进程已经启动后再停止”的确定性覆盖。

失败记录：<https://github.com/rcore-os/tgoskits/actions/runs/32730516370>

## 修改

- 将两个 AxVM 计数 getter 改为通过 `runtime_handle()` 获取拥有所有权的运行时快照，保留运行时不存在时返回 0 的既有语义，不恢复已经移除的闭包访问接口。
- HTTP probe 在校验资产存在后、spawn 前检查 stop；case 已结束时明确返回“未启动”错误，不再创建无意义的子进程。
- 将停止行为拆成两个确定性回归测试：
  - 已预先停止时，即使 probe 文件不可执行也不会尝试 spawn。
  - probe 写入启动标记并阻塞后，测试再发布 stop，验证运行中的子进程确实被 kill。

## 方案逻辑

- AxVM 修复沿用现有运行时所有权边界，避免重新引入持锁闭包及其锁顺序风险。
- probe runner 将 stop 视为终止状态：终止已发生时不应产生新的外部进程；对于已运行进程，则继续由轮询路径负责终止和回收。
- 修改不新增公共 API，也不改变平台启动、UEFI handoff、SMP 或 Linux ABI 语义。

## 验证

- `cargo fmt --all --check`
- `cargo xtask clippy --package axvm`（6/6 配置通过）
- `cargo xtask clippy --package axbuild`（1/1 通过）
- `cargo test -p axvm --features host-test`（318 passed）
- `cargo test -p axbuild`（干净 worktree，956 passed）
- `cargo test -p axbuild axvisor::test::http_probe::tests -- --nocapture`（8 passed）
- 在 `tgoskits-container-axvisor-lvz:latest` 中运行 `cargo xtask axvisor test qemu --arch loongarch64 --test-group normal --test-case smoke`（1/1 passed）
