### PR TITLE
feat(arm-gic-driver): add GICv3.3 NMI attribute support

### DIFF
--- a/drivers/intc/arm-gic-driver/CHANGELOG.md
+++ b/drivers/intc/arm-gic-driver/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(arm-gic-driver)* add side-effect-free GICv3.3 NMI attribute support for SGIs, PPIs, and SPIs
+
 ## [0.17.12](https://github.com/rcore-os/tgoskits/compare/arm-gic-driver-v0.17.11...arm-gic-driver-v0.17.12) - 2026-08-20
 
 ### Fixed

--- a/drivers/intc/arm-gic-driver/CHANGELOG.md
+++ b/drivers/intc/arm-gic-driver/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(arm-gic-driver)* add side-effect-free GICv3.3 NMI attribute support for SGIs, PPIs, and SPIs
+- *(arm-gic-driver)* add verified one-way GICv3.3 NMI attribute enabling for SGIs, PPIs, and SPIs
 
 ## [0.17.12](https://github.com/rcore-os/tgoskits/compare/arm-gic-driver-v0.17.11...arm-gic-driver-v0.17.12) - 2026-08-20
 

--- a/drivers/intc/arm-gic-driver/README.md
+++ b/drivers/intc/arm-gic-driver/README.md
@@ -9,6 +9,7 @@ A Rust driver for the ARM Generic Interrupt Controller (GIC), designed for bare-
 - **No Standard Library**: `#![no_std]` compatible for embedded environments
 - **Type Safety**: Strong typing for interrupt IDs and register access
 - **Comprehensive Testing**: Extensive test suites for different GIC versions
+- **GICv3.3 NMI Attributes**: Side-effect-free capability detection and typed SGI/PPI/SPI attribute access
 
 ### Basic Usage
 
@@ -41,6 +42,26 @@ if !ack.is_special() {
     }
 }
 ```
+
+### GICv3.3 NMI attributes
+
+`GICD_TYPER.NMI` advertises the per-interrupt NMI attribute capability. Configure
+the interrupt as Group 1 before selecting the non-maskable attribute:
+
+```rust
+use arm_gic_driver::v3::NmiAttribute;
+
+let pmu_ppi = IntId::ppi(14);
+if gic.supports_nmi() {
+    gic.set_nmi_attribute(pmu_ppi, NmiAttribute::NonMaskable)
+        .expect("set PMU PPI NMI attribute");
+}
+```
+
+This API only programs the GIC attribute. Enabling CPU FEAT_NMI and handling the
+NMI acknowledgement path belong to the consuming OS. See
+[the design document](docs/gicv3-nmi.md) for the full contract and migration
+review.
 
 ## Architecture Support
 

--- a/drivers/intc/arm-gic-driver/README.md
+++ b/drivers/intc/arm-gic-driver/README.md
@@ -52,16 +52,14 @@ the interrupt as Group 1 before selecting the non-maskable attribute:
 use arm_gic_driver::v3::NmiAttribute;
 
 let pmu_ppi = IntId::ppi(14);
-if gic.supports_nmi() {
+if gic.supports_nmi_attributes() {
     gic.set_nmi_attribute(pmu_ppi, NmiAttribute::NonMaskable)
         .expect("set PMU PPI NMI attribute");
 }
 ```
 
 This API only programs the GIC attribute. Enabling CPU FEAT_NMI and handling the
-NMI acknowledgement path belong to the consuming OS. See
-[the design document](docs/gicv3-nmi.md) for the full contract and migration
-review.
+NMI acknowledgement path belong to the consuming OS.
 
 ## Architecture Support
 

--- a/drivers/intc/arm-gic-driver/README.md
+++ b/drivers/intc/arm-gic-driver/README.md
@@ -9,7 +9,7 @@ A Rust driver for the ARM Generic Interrupt Controller (GIC), designed for bare-
 - **No Standard Library**: `#![no_std]` compatible for embedded environments
 - **Type Safety**: Strong typing for interrupt IDs and register access
 - **Comprehensive Testing**: Extensive test suites for different GIC versions
-- **GICv3.3 NMI Attributes**: Side-effect-free capability detection and typed SGI/PPI/SPI attribute access
+- **GICv3.3 NMI Attributes**: Side-effect-free capability detection and verified SGI/PPI/SPI NMI enabling
 
 ### Basic Usage
 
@@ -46,20 +46,21 @@ if !ack.is_special() {
 ### GICv3.3 NMI attributes
 
 `GICD_TYPER.NMI` advertises the per-interrupt NMI attribute capability. Configure
-the interrupt as Group 1 before selecting the non-maskable attribute:
+the interrupt as Group 1 before enabling the non-maskable attribute:
 
 ```rust
-use arm_gic_driver::v3::NmiAttribute;
-
 let pmu_ppi = IntId::ppi(14);
 if gic.supports_nmi_attributes() {
-    gic.set_nmi_attribute(pmu_ppi, NmiAttribute::NonMaskable)
-        .expect("set PMU PPI NMI attribute");
+    gic.enable_nmi_attribute(pmu_ppi)
+        .expect("enable PMU PPI NMI attribute");
 }
 ```
 
-This API only programs the GIC attribute. Enabling CPU FEAT_NMI and handling the
-NMI acknowledgement path belong to the consuming OS.
+The driver intentionally exposes only the one-way enable operation. A zero read
+from an NMI attribute register cannot distinguish a maskable interrupt from a
+RAZ/WI field, so querying or clearing through this API could report false
+success. Enabling CPU FEAT_NMI and handling the NMI acknowledgement path belong
+to the consuming OS.
 
 ## Architecture Support
 

--- a/drivers/intc/arm-gic-driver/src/define.rs
+++ b/drivers/intc/arm-gic-driver/src/define.rs
@@ -80,6 +80,28 @@ pub const SPECIAL_RANGE: Range<u32> = Range {
     end: 1024,
 };
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum NmiAttributeSlot {
+    Redistributor { mask: u32 },
+    Distributor { register: usize, mask: u32 },
+}
+
+pub(crate) fn nmi_attribute_slot(intid: IntId) -> Option<NmiAttributeSlot> {
+    let raw = intid.to_u32();
+    if SGI_RANGE.contains(&raw) || PPI_RANGE.contains(&raw) {
+        Some(NmiAttributeSlot::Redistributor {
+            mask: 1 << (raw % 32),
+        })
+    } else if SPI_RANGE.contains(&raw) {
+        Some(NmiAttributeSlot::Distributor {
+            register: (raw / 32) as usize,
+            mask: 1 << (raw % 32),
+        })
+    } else {
+        None
+    }
+}
+
 /// Error returned when a raw INTID is not valid for the probed GIC.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CheckedIntIdError;

--- a/drivers/intc/arm-gic-driver/src/define.rs
+++ b/drivers/intc/arm-gic-driver/src/define.rs
@@ -80,12 +80,16 @@ pub const SPECIAL_RANGE: Range<u32> = Range {
     end: 1024,
 };
 
+/// Register location of a standard interrupt's NMI attribute.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum NmiAttributeSlot {
+    /// The attribute is in the current PE's `GICR_INMIR0`.
     Redistributor { mask: u32 },
+    /// The attribute is in `GICD_INMIR<register>`.
     Distributor { register: usize, mask: u32 },
 }
 
+/// Map a standard SGI, PPI, or SPI to its architectural NMI attribute slot.
 pub(crate) fn nmi_attribute_slot(intid: IntId) -> Option<NmiAttributeSlot> {
     let raw = intid.to_u32();
     if SGI_RANGE.contains(&raw) || PPI_RANGE.contains(&raw) {

--- a/drivers/intc/arm-gic-driver/src/define.rs
+++ b/drivers/intc/arm-gic-driver/src/define.rs
@@ -106,6 +106,20 @@ pub(crate) fn nmi_attribute_slot(intid: IntId) -> Option<NmiAttributeSlot> {
     }
 }
 
+/// Set an NMI attribute bit and report whether register readback confirms it.
+pub(crate) fn enable_nmi_attribute_bit(
+    mut read: impl FnMut() -> u32,
+    mut write: impl FnMut(u32),
+    mask: u32,
+) -> bool {
+    let current = read();
+    if current & mask == 0 {
+        write(current | mask);
+    }
+
+    read() & mask != 0
+}
+
 /// Error returned when a raw INTID is not valid for the probed GIC.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct CheckedIntIdError;

--- a/drivers/intc/arm-gic-driver/src/tests.rs
+++ b/drivers/intc/arm-gic-driver/src/tests.rs
@@ -1,8 +1,12 @@
 extern crate std;
 
 #[cfg(target_arch = "aarch64")]
-use crate::version::v3::{LPI, RedistributorV3, RedistributorV4, SGI};
-use crate::{CheckedIntIdError, IntId, checked_intid, define::Trigger, fdt_parse_irq_config};
+use crate::version::v3::test_layout::{LPI, RedistributorV3, RedistributorV4, SGI};
+use crate::{
+    CheckedIntIdError, IntId, checked_intid,
+    define::{NmiAttributeSlot, Trigger, nmi_attribute_slot},
+    fdt_parse_irq_config,
+};
 
 #[cfg(target_arch = "aarch64")]
 #[test]
@@ -61,4 +65,29 @@ fn fdt_spi_level_high_uses_gic_intid_numbering() {
 
     assert_eq!(config.id.to_u32(), 235);
     assert_eq!(config.trigger, Trigger::Level);
+}
+
+#[test]
+fn nmi_attribute_slots_cover_private_and_shared_interrupts() {
+    assert_eq!(
+        nmi_attribute_slot(IntId::sgi(5)),
+        Some(NmiAttributeSlot::Redistributor { mask: 1 << 5 })
+    );
+    assert_eq!(
+        nmi_attribute_slot(IntId::ppi(14)),
+        Some(NmiAttributeSlot::Redistributor { mask: 1 << 30 })
+    );
+    assert_eq!(
+        nmi_attribute_slot(IntId::spi(42)),
+        Some(NmiAttributeSlot::Distributor {
+            register: 2,
+            mask: 1 << 10,
+        })
+    );
+}
+
+#[test]
+fn nmi_attribute_slot_rejects_special_and_out_of_range_intids() {
+    assert_eq!(nmi_attribute_slot(unsafe { IntId::raw(1023) }), None);
+    assert_eq!(nmi_attribute_slot(unsafe { IntId::raw(4096) }), None);
 }

--- a/drivers/intc/arm-gic-driver/src/tests.rs
+++ b/drivers/intc/arm-gic-driver/src/tests.rs
@@ -1,10 +1,12 @@
 extern crate std;
 
+use core::cell::Cell;
+
 #[cfg(target_arch = "aarch64")]
 use crate::version::v3::test_layout::{LPI, RedistributorV3, RedistributorV4, SGI};
 use crate::{
     CheckedIntIdError, IntId, checked_intid,
-    define::{NmiAttributeSlot, Trigger, nmi_attribute_slot},
+    define::{NmiAttributeSlot, Trigger, enable_nmi_attribute_bit, nmi_attribute_slot},
     fdt_parse_irq_config,
 };
 
@@ -90,4 +92,31 @@ fn nmi_attribute_slots_cover_private_and_shared_interrupts() {
 fn nmi_attribute_slot_rejects_special_and_out_of_range_intids() {
     assert_eq!(nmi_attribute_slot(unsafe { IntId::raw(1023) }), None);
     assert_eq!(nmi_attribute_slot(unsafe { IntId::raw(4096) }), None);
+}
+
+#[test]
+fn nmi_enable_preserves_sibling_attribute_bits() {
+    let original = (1 << 2) | (1 << 19);
+    let mask = 1 << 14;
+    let register = Cell::new(original);
+
+    assert!(enable_nmi_attribute_bit(
+        || register.get(),
+        |value| register.set(value),
+        mask,
+    ));
+    assert_eq!(register.get(), original | mask);
+}
+
+#[test]
+fn nmi_enable_rejects_raz_wi_attribute_bit() {
+    let mask = 1 << 14;
+    let attempted_write = Cell::new(None);
+
+    assert!(!enable_nmi_attribute_bit(
+        || 0,
+        |value| attempted_write.set(Some(value)),
+        mask,
+    ));
+    assert_eq!(attempted_write.get(), Some(mask));
 }

--- a/drivers/intc/arm-gic-driver/src/version/v3/gicd.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/gicd.rs
@@ -29,7 +29,7 @@ register_structs! {
         (0x0004 => pub TYPER: ReadOnly<u32, TYPER::Register>),
         /// Distributor Implementer Identification Register.
         (0x0008 => pub IIDR: ReadOnly<u32, IIDR::Register>),
-        /// Type Modifier Register.
+        /// Interrupt Controller Type Register 2.
         (0x000c => pub TYPER2: ReadOnly<u32, TYPER2::Register>),
         /// Status Register.
         (0x0010 => pub STATUSR: ReadWrite<u32, STATUSR::Register>),
@@ -645,13 +645,13 @@ register_bitfields! [
         DVIS OFFSET(18) NUMBITS(1) [],
     ],
 
-    /// Type Modifier Register
+    /// Interrupt Controller Type Register 2
     pub TYPER2 [
-        /// Virtual command queue interface supported
+        /// Number of implemented vPEID bits minus one when VIL is set
         VID OFFSET(0) NUMBITS(5) [],
-        /// Virtual LPIs supported
+        /// Indicates how the implemented vPEID width is reported
         VIL OFFSET(7) NUMBITS(1) [],
-        /// Non-architected SGIs are supported
+        /// Indicates whether SGIs can be configured without an active state
         nASSGIcap OFFSET(8) NUMBITS(1) [],
     ],
 

--- a/drivers/intc/arm-gic-driver/src/version/v3/gicd.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/gicd.rs
@@ -96,6 +96,10 @@ const GICD_ICACTIVER: usize = 0x0380;
 const GICD_IPRIORITYR: usize = 0x0400;
 const GICD_ICFGR: usize = 0x0c00;
 
+pub(crate) const fn supports_nmi_from_typer(typer: u32) -> bool {
+    typer & TYPER::NMI::SET.value != 0
+}
+
 #[inline(always)]
 fn reg32_addr(base: *const DistributorReg, offset: usize, index: usize) -> *mut u32 {
     (base as usize + offset + index * core::mem::size_of::<u32>()) as *mut u32
@@ -487,47 +491,19 @@ impl DistributorReg {
         }
     }
 
-    /// Configure non-maskable interrupt
-    pub fn set_nmi(&self, intid: u32, nmi: bool) {
-        if (32..1020).contains(&intid) {
-            let reg_idx = (intid / 32) as usize;
-            let bit_idx = intid % 32;
-
-            if reg_idx < self.INMIR.len() {
-                let current = self.INMIR[reg_idx].get();
-                if nmi {
-                    self.INMIR[reg_idx].set(current | (1 << bit_idx));
-                } else {
-                    self.INMIR[reg_idx].set(current & !(1 << bit_idx));
-                }
-            }
-        }
-    }
-
-    /// Check if interrupt is configured as NMI
-    pub fn is_nmi(&self, intid: u32) -> bool {
-        if (32..1020).contains(&intid) {
-            let reg_idx = (intid / 32) as usize;
-            let bit_idx = intid % 32;
-
-            if reg_idx < self.INMIR.len() {
-                let current = self.INMIR[reg_idx].get();
-                return (current & (1 << bit_idx)) != 0;
-            }
-        }
-        false
-    }
-
     /// Check if Extended SPI range is supported
     pub fn has_extended_spi(&self) -> bool {
-        // Check if TYPER2.ESPI is implemented and set
-        self.TYPER2.read(TYPER2::NMI) != 0 // Using NMI bit as placeholder since ESPI is not defined yet
+        self.TYPER.is_set(TYPER::ESPI)
     }
 
-    /// Get the Extended SPI range if supported
+    /// Get the encoded Extended SPI range.
     pub fn extended_spi_range(&self) -> u32 {
-        // This would read TYPER2.ESPI_range field when implemented
-        0 // Placeholder return
+        self.TYPER.read(TYPER::ESPI_range)
+    }
+
+    /// Check if the GIC implements FEAT_GICv3_NMI.
+    pub fn supports_nmi(&self) -> bool {
+        supports_nmi_from_typer(self.TYPER.get())
     }
 
     /// Check if Message-based SPIs are supported
@@ -640,6 +616,10 @@ register_bitfields! [
         ITLinesNumber OFFSET(0) NUMBITS(5) [],
         /// Number of CPU interfaces implemented minus one
         CPUNumber OFFSET(5) NUMBITS(3) [],
+        /// Extended SPI range supported
+        ESPI OFFSET(8) NUMBITS(1) [],
+        /// Non-maskable interrupt property supported
+        NMI OFFSET(9) NUMBITS(1) [],
         /// Indicates whether the GIC implements Security Extensions
         SecurityExtn OFFSET(10) NUMBITS(1) [
             SingleSecurity = 0,
@@ -653,8 +633,10 @@ register_bitfields! [
         A3V OFFSET(24) NUMBITS(1) [],
         /// No1ofN behavior supported
         No1N OFFSET(25) NUMBITS(1) [],
-        /// Common not Private base supported
-        CommonLPIAff OFFSET(26) NUMBITS(2) [],
+        /// Range selector supported for SGI generation
+        RSS OFFSET(26) NUMBITS(1) [],
+        /// Encoded Extended SPI range
+        ESPI_range OFFSET(27) NUMBITS(5) [],
         /// Message based SPIs supported
         MBIS OFFSET(16) NUMBITS(1) [],
         /// Low Power Interrupt supported
@@ -665,12 +647,12 @@ register_bitfields! [
 
     /// Type Modifier Register
     pub TYPER2 [
-        /// Virtual LPIs supported
-        VIL OFFSET(0) NUMBITS(1) [],
         /// Virtual command queue interface supported
-        VID OFFSET(1) NUMBITS(5) [],
-        /// NMI support
-        NMI OFFSET(6) NUMBITS(1) [],
+        VID OFFSET(0) NUMBITS(5) [],
+        /// Virtual LPIs supported
+        VIL OFFSET(7) NUMBITS(1) [],
+        /// Non-architected SGIs are supported
+        nASSGIcap OFFSET(8) NUMBITS(1) [],
     ],
 
     /// Status Register

--- a/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
@@ -5,18 +5,27 @@ use aarch64_cpu::{
     registers::{CurrentEL, MPIDR_EL1},
 };
 use log::*;
+use tock_registers::registers::ReadWrite;
 pub use tock_registers::{LocalRegisterCopy, interfaces::*};
 
 mod gicd;
 mod gicr;
 mod its;
 
+#[cfg(test)]
+pub(crate) mod test_layout {
+    pub(crate) use super::gicr::{LPI, RedistributorV3, RedistributorV4, SGI};
+}
+
 use gicd::*;
 use gicr::*;
 pub use its::*;
 
-use crate::version::{IrqVecReadable, IrqVecWriteable};
 pub use crate::{IntId, VirtAddr, define::Trigger, sys_reg::*};
+use crate::{
+    define::{NmiAttributeSlot, nmi_attribute_slot},
+    version::{IrqVecReadable, IrqVecWriteable},
+};
 
 /// SGI target specification for GICv3.
 ///
@@ -212,6 +221,48 @@ impl Affinity {
     pub fn current() -> Self {
         Self::from_mpidr(MPIDR_EL1.get())
     }
+}
+
+/// Per-interrupt delivery attribute provided by FEAT_GICv3_NMI.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NmiAttribute {
+    /// Deliver the interrupt through the regular maskable interrupt path.
+    Maskable,
+    /// Deliver the interrupt as a non-maskable interrupt.
+    NonMaskable,
+}
+
+impl From<bool> for NmiAttribute {
+    fn from(nmi: bool) -> Self {
+        if nmi {
+            Self::NonMaskable
+        } else {
+            Self::Maskable
+        }
+    }
+}
+
+/// Failure while accessing a GICv3.3 NMI delivery attribute.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum NmiAttributeError {
+    /// The requested INTID has no standard NMI attribute register.
+    #[error("{intid:?} has no GICv3 NMI attribute")]
+    UnsupportedIntId { intid: IntId },
+    /// The requested SPI is outside the range implemented by this Distributor.
+    #[error("{intid:?} is not implemented by this GIC")]
+    UnimplementedIntId { intid: IntId },
+    /// The Distributor does not advertise FEAT_GICv3_NMI.
+    #[error("the GIC does not implement FEAT_GICv3_NMI")]
+    Unsupported,
+    /// No Redistributor frame matches the current CPU affinity.
+    #[error("the current CPU redistributor was not found")]
+    CurrentRedistributorNotFound,
+    /// The requested attribute did not survive register readback.
+    #[error("{intid:?} rejected the requested {attribute:?} attribute")]
+    AttributeNotWritable {
+        intid: IntId,
+        attribute: NmiAttribute,
+    },
 }
 
 /// GICv3 driver implementation.
@@ -464,6 +515,73 @@ impl Gic {
         self.gicd().has_lpis()
     }
 
+    /// Return whether the Distributor advertises FEAT_GICv3_NMI.
+    ///
+    /// This check only reads `GICD_TYPER.NMI`; it never probes capability by
+    /// writing an interrupt's live attribute register.
+    pub fn supports_nmi(&self) -> bool {
+        self.gicd().supports_nmi()
+    }
+
+    /// Report NMI attribute availability without modifying GIC state.
+    ///
+    /// This compatibility API returns `(private, shared)`. `private` requires
+    /// both FEAT_GICv3_NMI and a Redistributor frame matching the current CPU;
+    /// `shared` reflects the architectural `GICD_TYPER.NMI` capability.
+    pub fn probe_nmi_attribute_support(&self) -> (bool, bool) {
+        let shared = self.supports_nmi();
+        let private = shared && self.current_rd_opt().is_some();
+        (private, shared)
+    }
+
+    /// Set the GICv3.3 NMI delivery attribute for an SGI, PPI, or SPI.
+    ///
+    /// Private interrupts are programmed in the current CPU's
+    /// `GICR_INMIR0`; SPIs are programmed in `GICD_INMIR<n>`. The operation
+    /// preserves every sibling interrupt attribute in the same register and
+    /// verifies the requested bit by reading it back.
+    ///
+    /// The caller must serialize GIC configuration and configure the
+    /// interrupt as Group 1 before selecting [`NmiAttribute::NonMaskable`].
+    /// Group 0 or inaccessible attribute fields can be RAZ/WI and produce
+    /// [`NmiAttributeError::AttributeNotWritable`]. CPU FEAT_NMI enablement and
+    /// NMI acknowledgement remain responsibilities of the OS integration.
+    pub fn set_nmi_attribute(
+        &mut self,
+        intid: IntId,
+        attribute: NmiAttribute,
+    ) -> Result<(), NmiAttributeError> {
+        let (register, mask) = self.nmi_attribute_register(intid)?;
+        let current = register.get();
+        let requested = nmi_attribute_register_value(current, mask, attribute);
+        if requested != current {
+            register.set(requested);
+            barrier::dsb(barrier::SY);
+        }
+
+        if nmi_attribute_from_register(register.get(), mask) == attribute {
+            Ok(())
+        } else {
+            Err(NmiAttributeError::AttributeNotWritable { intid, attribute })
+        }
+    }
+
+    /// Read the GICv3.3 NMI delivery attribute for an SGI, PPI, or SPI.
+    pub fn nmi_attribute(&self, intid: IntId) -> Result<NmiAttribute, NmiAttributeError> {
+        let (register, mask) = self.nmi_attribute_register(intid)?;
+        Ok(nmi_attribute_from_register(register.get(), mask))
+    }
+
+    /// Set or clear an NMI attribute using the legacy boolean interface.
+    pub fn set_nmi_attr(&mut self, intid: IntId, nmi: bool) -> Result<(), NmiAttributeError> {
+        self.set_nmi_attribute(intid, nmi.into())
+    }
+
+    /// Read an NMI attribute using the legacy boolean interface.
+    pub fn is_nmi(&self, intid: IntId) -> Result<bool, NmiAttributeError> {
+        Ok(self.nmi_attribute(intid)? == NmiAttribute::NonMaskable)
+    }
+
     pub fn redistributor_count(&self) -> usize {
         self.rd_slice().iter().count()
     }
@@ -548,6 +666,39 @@ impl Gic {
 
     fn current_rd(&self) -> NonNull<RedistributorV3> {
         current_rd_from(self.gicr)
+    }
+
+    fn current_rd_opt(&self) -> Option<NonNull<RedistributorV3>> {
+        current_rd_from_opt(self.gicr)
+    }
+
+    fn nmi_attribute_register(
+        &self,
+        intid: IntId,
+    ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
+        let slot =
+            nmi_attribute_slot(intid).ok_or(NmiAttributeError::UnsupportedIntId { intid })?;
+        if !self.supports_nmi() {
+            return Err(NmiAttributeError::Unsupported);
+        }
+
+        match slot {
+            NmiAttributeSlot::Redistributor { mask } => {
+                let redistributor = self
+                    .current_rd_opt()
+                    .ok_or(NmiAttributeError::CurrentRedistributorNotFound)?;
+                // SAFETY: `current_rd_opt` only returns a frame inside the
+                // caller-provided, permanently mapped Redistributor region.
+                let register = unsafe { &redistributor.as_ref().sgi.INMIR0 };
+                Ok((register, mask))
+            }
+            NmiAttributeSlot::Distributor { register, mask } => {
+                if intid.to_u32() >= self.gicd().max_spi_num() {
+                    return Err(NmiAttributeError::UnimplementedIntId { intid });
+                }
+                Ok((&self.gicd().INMIR[register], mask))
+            }
+        }
     }
 
     /// Get a CPU interface for the current CPU.
@@ -957,7 +1108,11 @@ fn rd_slice_from(gicr: VirtAddr) -> RDv3Slice {
 }
 
 fn current_rd_from(gicr: VirtAddr) -> NonNull<RedistributorV3> {
-    let want = (MPIDR_EL1.get() & 0xFFFFFF) as u32;
+    current_rd_from_opt(gicr).unwrap_or_else(|| panic!("No current redistributor"))
+}
+
+fn current_rd_from_opt(gicr: VirtAddr) -> Option<NonNull<RedistributorV3>> {
+    let want = redistributor_affinity_from_mpidr(MPIDR_EL1.get());
 
     for rd in rd_slice_from(gicr).iter() {
         let affi = unsafe { rd.as_ref() }
@@ -965,10 +1120,29 @@ fn current_rd_from(gicr: VirtAddr) -> NonNull<RedistributorV3> {
             .TYPER
             .read(gicr::TYPER::Affinity) as u32;
         if affi == want {
-            return rd;
+            return Some(rd);
         }
     }
-    panic!("No current redistributor")
+    None
+}
+
+fn redistributor_affinity_from_mpidr(mpidr: u64) -> u32 {
+    Affinity::from_mpidr(mpidr).affinity()
+}
+
+fn nmi_attribute_from_register(value: u32, mask: u32) -> NmiAttribute {
+    if value & mask == 0 {
+        NmiAttribute::Maskable
+    } else {
+        NmiAttribute::NonMaskable
+    }
+}
+
+fn nmi_attribute_register_value(current: u32, mask: u32, attribute: NmiAttribute) -> u32 {
+    match attribute {
+        NmiAttribute::Maskable => current & !mask,
+        NmiAttribute::NonMaskable => current | mask,
+    }
 }
 
 /// Every CPU interface has its own GICC registers
@@ -1288,4 +1462,45 @@ pub fn send_sgi(sgi_id: IntId, target: SGITarget) {
         }
     }
     barrier::isb(barrier::SY);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nmi_support_uses_gicd_typer_bit_9() {
+        assert!(!gicd::supports_nmi_from_typer(1 << 6));
+        assert!(gicd::supports_nmi_from_typer(1 << 9));
+    }
+
+    #[test]
+    fn redistributor_affinity_preserves_aff3() {
+        let mpidr = (0x12_u64 << 32) | (0x34 << 16) | (0x56 << 8) | 0x78;
+        assert_eq!(redistributor_affinity_from_mpidr(mpidr), 0x1234_5678);
+    }
+
+    #[test]
+    fn nmi_attribute_updates_preserve_sibling_bits() {
+        let original = (1 << 2) | (1 << 19);
+        let mask = 1 << 14;
+        let with_nmi = nmi_attribute_register_value(original, mask, NmiAttribute::NonMaskable);
+
+        assert_eq!(with_nmi, original | mask);
+        assert_eq!(
+            nmi_attribute_register_value(with_nmi, mask, NmiAttribute::Maskable),
+            original
+        );
+        assert_eq!(
+            nmi_attribute_from_register(with_nmi, mask),
+            NmiAttribute::NonMaskable
+        );
+    }
+
+    #[test]
+    fn x_kernel_compatibility_methods_keep_the_migrated_signatures() {
+        let _: fn(&Gic) -> (bool, bool) = Gic::probe_nmi_attribute_support;
+        let _: fn(&mut Gic, IntId, bool) -> Result<(), NmiAttributeError> = Gic::set_nmi_attr;
+        let _: fn(&Gic, IntId) -> Result<bool, NmiAttributeError> = Gic::is_nmi;
+    }
 }

--- a/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
@@ -23,7 +23,7 @@ pub use its::*;
 
 pub use crate::{IntId, VirtAddr, define::Trigger, sys_reg::*};
 use crate::{
-    define::{NmiAttributeSlot, nmi_attribute_slot},
+    define::{NmiAttributeSlot, enable_nmi_attribute_bit, nmi_attribute_slot},
     version::{IrqVecReadable, IrqVecWriteable},
 };
 
@@ -223,16 +223,7 @@ impl Affinity {
     }
 }
 
-/// Per-interrupt delivery attribute provided by FEAT_GICv3_NMI.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum NmiAttribute {
-    /// Deliver the interrupt through the regular maskable interrupt path.
-    Maskable,
-    /// Deliver the interrupt as a non-maskable interrupt.
-    NonMaskable,
-}
-
-/// Failure while accessing a GICv3.3 NMI delivery attribute.
+/// Failure while enabling a GICv3.3 NMI delivery attribute.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum NmiAttributeError {
     /// The requested INTID has no standard NMI attribute register.
@@ -247,12 +238,9 @@ pub enum NmiAttributeError {
     /// No Redistributor frame matches the current CPU affinity.
     #[error("the current CPU redistributor was not found")]
     CurrentRedistributorNotFound,
-    /// The requested attribute did not survive register readback.
-    #[error("{intid:?} rejected the requested {attribute:?} attribute")]
-    AttributeNotWritable {
-        intid: IntId,
-        attribute: NmiAttribute,
-    },
+    /// The non-maskable attribute did not survive register readback.
+    #[error("{intid:?} rejected the non-maskable attribute")]
+    AttributeNotWritable { intid: IntId },
 }
 
 /// GICv3 driver implementation.
@@ -513,42 +501,40 @@ impl Gic {
         self.gicd().supports_nmi()
     }
 
-    /// Set the GICv3.3 NMI delivery attribute for an SGI, PPI, or SPI.
+    /// Enable the GICv3.3 NMI delivery attribute for an SGI, PPI, or SPI.
     ///
     /// Private interrupts are programmed in the current CPU's
     /// `GICR_INMIR0`; SPIs are programmed in `GICD_INMIR<n>`. The operation
     /// preserves every sibling interrupt attribute in the same register and
-    /// verifies the requested bit by reading it back.
+    /// verifies the enabled bit by reading it back.
     ///
     /// The caller must serialize GIC configuration and configure the
-    /// interrupt as Group 1 before selecting [`NmiAttribute::NonMaskable`].
-    /// Group 0 or inaccessible attribute fields can be RAZ/WI and produce
-    /// [`NmiAttributeError::AttributeNotWritable`]. CPU FEAT_NMI enablement and
-    /// NMI acknowledgement remain responsibilities of the OS integration.
-    pub fn set_nmi_attribute(
-        &mut self,
-        intid: IntId,
-        attribute: NmiAttribute,
-    ) -> Result<(), NmiAttributeError> {
+    /// interrupt as Group 1 before enabling its NMI attribute. This method does
+    /// not expose clearing or querying the attribute because a zero read cannot
+    /// distinguish a maskable interrupt from an inaccessible RAZ/WI field. CPU
+    /// FEAT_NMI enablement and NMI acknowledgement remain responsibilities of
+    /// the OS integration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`NmiAttributeError`] when the GIC does not implement NMI
+    /// attributes, the INTID cannot be mapped to an implemented attribute, the
+    /// current Redistributor is unavailable, or readback does not confirm the
+    /// enabled attribute.
+    pub fn enable_nmi_attribute(&mut self, intid: IntId) -> Result<(), NmiAttributeError> {
         let (register, mask) = self.nmi_attribute_register(intid)?;
-        let current = register.get();
-        let requested = nmi_attribute_register_value(current, mask, attribute);
-        if requested != current {
-            register.set(requested);
-            barrier::dsb(barrier::SY);
-        }
-
-        if nmi_attribute_from_register(register.get(), mask) == attribute {
+        if enable_nmi_attribute_bit(
+            || register.get(),
+            |value| {
+                register.set(value);
+                barrier::dsb(barrier::SY);
+            },
+            mask,
+        ) {
             Ok(())
         } else {
-            Err(NmiAttributeError::AttributeNotWritable { intid, attribute })
+            Err(NmiAttributeError::AttributeNotWritable { intid })
         }
-    }
-
-    /// Read the GICv3.3 NMI delivery attribute for an SGI, PPI, or SPI.
-    pub fn nmi_attribute(&self, intid: IntId) -> Result<NmiAttribute, NmiAttributeError> {
-        let (register, mask) = self.nmi_attribute_register(intid)?;
-        Ok(nmi_attribute_from_register(register.get(), mask))
     }
 
     pub fn redistributor_count(&self) -> usize {
@@ -1099,21 +1085,6 @@ fn redistributor_affinity_from_mpidr(mpidr: u64) -> u32 {
     Affinity::from_mpidr(mpidr).affinity()
 }
 
-fn nmi_attribute_from_register(value: u32, mask: u32) -> NmiAttribute {
-    if value & mask == 0 {
-        NmiAttribute::Maskable
-    } else {
-        NmiAttribute::NonMaskable
-    }
-}
-
-fn nmi_attribute_register_value(current: u32, mask: u32, attribute: NmiAttribute) -> u32 {
-    match attribute {
-        NmiAttribute::Maskable => current & !mask,
-        NmiAttribute::NonMaskable => current | mask,
-    }
-}
-
 /// Every CPU interface has its own GICC registers
 pub struct CpuInterface {
     rd: *mut RedistributorV3,
@@ -1438,6 +1409,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn nmi_configuration_exposes_one_way_enable_operation() {
+        let _: fn(&mut Gic, IntId) -> Result<(), NmiAttributeError> = Gic::enable_nmi_attribute;
+    }
+
+    #[test]
     fn nmi_support_uses_gicd_typer_bit_9() {
         assert!(!gicd::supports_nmi_from_typer(1 << 6));
         assert!(gicd::supports_nmi_from_typer(1 << 9));
@@ -1447,22 +1423,5 @@ mod tests {
     fn redistributor_affinity_preserves_aff3() {
         let mpidr = (0x12_u64 << 32) | (0x34 << 16) | (0x56 << 8) | 0x78;
         assert_eq!(redistributor_affinity_from_mpidr(mpidr), 0x1234_5678);
-    }
-
-    #[test]
-    fn nmi_attribute_updates_preserve_sibling_bits() {
-        let original = (1 << 2) | (1 << 19);
-        let mask = 1 << 14;
-        let with_nmi = nmi_attribute_register_value(original, mask, NmiAttribute::NonMaskable);
-
-        assert_eq!(with_nmi, original | mask);
-        assert_eq!(
-            nmi_attribute_register_value(with_nmi, mask, NmiAttribute::Maskable),
-            original
-        );
-        assert_eq!(
-            nmi_attribute_from_register(with_nmi, mask),
-            NmiAttribute::NonMaskable
-        );
     }
 }

--- a/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
+++ b/drivers/intc/arm-gic-driver/src/version/v3/mod.rs
@@ -232,16 +232,6 @@ pub enum NmiAttribute {
     NonMaskable,
 }
 
-impl From<bool> for NmiAttribute {
-    fn from(nmi: bool) -> Self {
-        if nmi {
-            Self::NonMaskable
-        } else {
-            Self::Maskable
-        }
-    }
-}
-
 /// Failure while accessing a GICv3.3 NMI delivery attribute.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum NmiAttributeError {
@@ -519,19 +509,8 @@ impl Gic {
     ///
     /// This check only reads `GICD_TYPER.NMI`; it never probes capability by
     /// writing an interrupt's live attribute register.
-    pub fn supports_nmi(&self) -> bool {
+    pub fn supports_nmi_attributes(&self) -> bool {
         self.gicd().supports_nmi()
-    }
-
-    /// Report NMI attribute availability without modifying GIC state.
-    ///
-    /// This compatibility API returns `(private, shared)`. `private` requires
-    /// both FEAT_GICv3_NMI and a Redistributor frame matching the current CPU;
-    /// `shared` reflects the architectural `GICD_TYPER.NMI` capability.
-    pub fn probe_nmi_attribute_support(&self) -> (bool, bool) {
-        let shared = self.supports_nmi();
-        let private = shared && self.current_rd_opt().is_some();
-        (private, shared)
     }
 
     /// Set the GICv3.3 NMI delivery attribute for an SGI, PPI, or SPI.
@@ -570,16 +549,6 @@ impl Gic {
     pub fn nmi_attribute(&self, intid: IntId) -> Result<NmiAttribute, NmiAttributeError> {
         let (register, mask) = self.nmi_attribute_register(intid)?;
         Ok(nmi_attribute_from_register(register.get(), mask))
-    }
-
-    /// Set or clear an NMI attribute using the legacy boolean interface.
-    pub fn set_nmi_attr(&mut self, intid: IntId, nmi: bool) -> Result<(), NmiAttributeError> {
-        self.set_nmi_attribute(intid, nmi.into())
-    }
-
-    /// Read an NMI attribute using the legacy boolean interface.
-    pub fn is_nmi(&self, intid: IntId) -> Result<bool, NmiAttributeError> {
-        Ok(self.nmi_attribute(intid)? == NmiAttribute::NonMaskable)
     }
 
     pub fn redistributor_count(&self) -> usize {
@@ -678,7 +647,7 @@ impl Gic {
     ) -> Result<(&ReadWrite<u32>, u32), NmiAttributeError> {
         let slot =
             nmi_attribute_slot(intid).ok_or(NmiAttributeError::UnsupportedIntId { intid })?;
-        if !self.supports_nmi() {
+        if !self.supports_nmi_attributes() {
             return Err(NmiAttributeError::Unsupported);
         }
 
@@ -1495,12 +1464,5 @@ mod tests {
             nmi_attribute_from_register(with_nmi, mask),
             NmiAttribute::NonMaskable
         );
-    }
-
-    #[test]
-    fn x_kernel_compatibility_methods_keep_the_migrated_signatures() {
-        let _: fn(&Gic) -> (bool, bool) = Gic::probe_nmi_attribute_support;
-        let _: fn(&mut Gic, IntId, bool) -> Result<(), NmiAttributeError> = Gic::set_nmi_attr;
-        let _: fn(&Gic, IntId) -> Result<bool, NmiAttributeError> = Gic::is_nmi;
     }
 }


### PR DESCRIPTION
## 问题

`arm-gic-driver` 已经定义了 `GICD_INMIR<n>` 和 `GICR_INMIR0`，但原有 NMI helper 只操作 Distributor 中的 SPI，并存在以下限制：

- 无法配置 SGI/PPI 的 NMI 属性；
- 使用裸 `u32` 和 `bool`，调用点无法直接表达 INTID 与目标属性的语义；
- 对非法或未实现的 INTID 静默忽略，调用方无法区分普通可屏蔽属性与访问失败；
- NMI 能力曾错误地取自 `GICD_TYPER2` 占位字段，Extended SPI 能力与范围也未按架构寄存器读取；
- 当前 PE 的 Redistributor 匹配只保留 MPIDR 的低 24 位，会丢失 Aff3。

本 PR 为标准 SGI、PPI 和 SPI 补充 GICv3.3 NMI 属性访问能力，并修正相关类型寄存器定义。能力检测只读取架构定义的 capability bit，不通过修改活动中断属性进行探测。

## 修改内容

### 修正 GIC 类型寄存器定义

- 在 `GICD_TYPER` 中补充并使用：
  - `ESPI`：bit 8；
  - `NMI`：bit 9；
  - `RSS`：bit 26；
  - `ESPI_range`：bits [31:27]。
- 将 `GICD_TYPER2` 的名称修正为 **Interrupt Controller Type Register 2**，并修正字段布局：
  - `VID`：bits [4:0]；
  - `VIL`：bit 7；
  - `nASSGIcap`：bit 8。
- `has_extended_spi()` 改为读取 `GICD_TYPER.ESPI`，`extended_spi_range()` 改为返回 `GICD_TYPER.ESPI_range`。

规范依据：

- [GICD_TYPER, Interrupt Controller Type Register](https://support.arm.com/documentation/ddi0601/2026-06/External-Registers/GICD-TYPER--Interrupt-Controller-Type-Register?lang=en)
- [GICD_TYPER2, Interrupt Controller Type Register 2](https://support.arm.com/documentation/ddi0601/2026-06/External-Registers/GICD-TYPER2--Interrupt-Controller-Type-Register-2?lang=en)

### 增加类型化 NMI 属性接口

新增以下公共接口：

```rust
pub enum NmiAttribute {
    Maskable,
    NonMaskable,
}

pub fn supports_nmi_attributes(&self) -> bool;

pub fn set_nmi_attribute(
    &mut self,
    intid: IntId,
    attribute: NmiAttribute,
) -> Result<(), NmiAttributeError>;

pub fn nmi_attribute(
    &self,
    intid: IntId,
) -> Result<NmiAttribute, NmiAttributeError>;
```

`NmiAttributeError` 显式区分以下失败：

- INTID 没有标准 NMI 属性槽位；
- SPI 超出当前 Distributor 实现范围；
- GIC 未实现 `FEAT_GICv3_NMI`；
- 找不到当前 PE 对应的 Redistributor；
- 目标属性写入后无法读回。

### 按中断类型选择属性寄存器

新增纯映射逻辑，将标准 INTID 转换为对应寄存器槽位：

| 中断类型 | INTID 范围 | 属性寄存器 |
| --- | ---: | --- |
| SGI | 0–15 | 当前 PE 的 `GICR_INMIR0` |
| PPI | 16–31 | 当前 PE 的 `GICR_INMIR0` |
| SPI | 32–1019 | `GICD_INMIR<INTID / 32>` |

每个属性使用 `INTID % 32` 对应的 bit。Special INTID 和 Extended INTID 当前返回明确的 unsupported 错误。

设置属性时先读取完整寄存器，再只修改目标 bit，从而保留同一寄存器中其他中断的属性。发生实际写入后执行 `DSB SY`，随后读回目标 bit；如果字段因 Group、安全状态或实现限制表现为 RAZ/WI，则返回 `AttributeNotWritable`，不会报告假成功。

### 修正 Redistributor affinity 匹配

当前 PE 的 Redistributor 查找改为通过 `Affinity::from_mpidr()` 组合完整的 `Aff3:Aff2:Aff1:Aff0`，避免 Aff3 非零时匹配错误。

同时增加可失败的查找路径，使 NMI 属性接口在找不到当前 Redistributor 时返回结构化错误；原有要求 Redistributor 必须存在的调用路径保持原行为。

### 文档与测试

- README 增加 GICv3.3 NMI 属性使用示例，并明确 CPU NMI 处理仍由上层 OS 负责；
- CHANGELOG 记录新增能力；
- 增加 SGI/PPI/SPI 槽位映射、非法 INTID、`GICD_TYPER.NMI` bit 9、Aff3 保留以及读改写不破坏相邻 bit 的回归测试。

## 设计与替代方案

- **保留原始 Distributor helper：**无法覆盖 SGI/PPI，而且静默 no-op/`false` 会隐藏 unsupported 和拓扑错误，因此由完整的 `Gic` typed API 取代。
- **通过试写 INMIR 探测能力：**试写会临时修改真实中断属性，结果还会受到 Group、安全状态和寄存器访问权限影响，因此不采用。能力统一来自 `GICD_TYPER.NMI`。
- **继续使用布尔参数：**`true`/`false` 无法在调用点表达属性含义，因此使用 `NmiAttribute::{Maskable, NonMaskable}`。

实现仍位于可复用、`no_std` 的驱动核心中，没有引入 OS 调度、IRQ 注册或平台 glue 依赖。调用方负责串行化 GIC 配置操作，并在设置 `NonMaskable` 前将目标中断配置为可访问的 Group 1。

## 兼容性与非目标

- 不改变现有普通 IRQ 初始化、路由、使能、应答或 EOI 路径；
- 当前只支持标准 INTID 0–1019，不包含 Extended SPI/Extended PPI；
- 本 PR 只设置 GIC 的 per-interrupt NMI 属性，不负责 CPU `FEAT_NMI` 启用、`ICC_NMIAR1_EL1` 应答、异常入口或上层运行时处理；
- 不新增 OS 专用依赖，也不改变 MMIO 映射所有权。

## 验证

```text
cargo test --package arm-gic-driver
# 23 passed; 0 failed

cargo fmt --package arm-gic-driver -- --check

CC=clang CXX=clang++ cargo xtask clippy --package arm-gic-driver
# 3 checks passed; 0 failed