### PR TITLE
fix(ci): stabilize recent dev test failures

### DIFF
--- a/scripts/axbuild/src/agent_review_bench/runner.rs
+++ b/scripts/axbuild/src/agent_review_bench/runner.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs,
+    fs, io,
     path::{Path, PathBuf},
     process::Stdio,
     time::Duration,
@@ -62,6 +62,8 @@ const CLAUDE_REVIEW_ALLOWED_TOOLS: &[&str] = &[
     "Bash(git grep *)",
 ];
 const CLAUDE_GRADE_TOOLS: &str = "Read";
+const TEXT_FILE_BUSY_RETRY_LIMIT: usize = 5;
+const TEXT_FILE_BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(super) enum AgentKind {
@@ -112,10 +114,12 @@ impl AgentRunner {
     }
 
     pub(super) fn version(&self) -> anyhow::Result<String> {
-        let output = std::process::Command::new(&self.program)
-            .arg("--version")
-            .output()
-            .with_context(|| format!("failed to execute {} --version", self.program.display()))?;
+        let output = retry_text_file_busy(|| {
+            std::process::Command::new(&self.program)
+                .arg("--version")
+                .output()
+        })
+        .with_context(|| format!("failed to execute {} --version", self.program.display()))?;
         if !output.status.success() {
             bail!(
                 "{} --version exited with {}",
@@ -327,8 +331,7 @@ async fn run_process(
         .stdin(Stdio::null())
         .stderr(Stdio::inherit())
         .kill_on_drop(true);
-    let mut child = command
-        .spawn()
+    let mut child = retry_text_file_busy(|| command.spawn())
         .with_context(|| format!("failed to spawn {description}"))?;
     let status = match timeout(Duration::from_secs(timeout_secs), child.wait()).await {
         Ok(status) => status.with_context(|| format!("failed to wait for {description}"))?,
@@ -346,6 +349,29 @@ async fn run_process(
     } else {
         bail!("{description} exited with status {status}")
     }
+}
+
+fn retry_text_file_busy<T>(mut operation: impl FnMut() -> io::Result<T>) -> io::Result<T> {
+    let mut retries_remaining = TEXT_FILE_BUSY_RETRY_LIMIT;
+    loop {
+        match operation() {
+            Err(err) if is_text_file_busy(&err) && retries_remaining > 0 => {
+                retries_remaining -= 1;
+                std::thread::sleep(TEXT_FILE_BUSY_RETRY_DELAY);
+            }
+            result => return result,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn is_text_file_busy(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(libc::ETXTBSY)
+}
+
+#[cfg(not(unix))]
+fn is_text_file_busy(_error: &io::Error) -> bool {
+    false
 }
 
 fn copy_nonempty_output(source: &Path, destination: &Path, role: &str) -> anyhow::Result<()> {
@@ -518,6 +544,35 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("timed out"));
+    }
+
+    #[test]
+    fn retries_transient_text_file_busy_errors() {
+        let mut attempts = 0;
+        let result = retry_text_file_busy(|| {
+            attempts += 1;
+            if attempts <= TEXT_FILE_BUSY_RETRY_LIMIT {
+                Err(std::io::Error::from_raw_os_error(libc::ETXTBSY))
+            } else {
+                Ok("spawned")
+            }
+        });
+
+        assert_eq!(result.unwrap(), "spawned");
+        assert_eq!(attempts, TEXT_FILE_BUSY_RETRY_LIMIT + 1);
+    }
+
+    #[test]
+    fn does_not_retry_other_spawn_errors() {
+        let mut attempts = 0;
+        let error = retry_text_file_busy(|| {
+            attempts += 1;
+            Err::<(), _>(std::io::Error::from_raw_os_error(libc::ENOENT))
+        })
+        .unwrap_err();
+
+        assert_eq!(error.raw_os_error(), Some(libc::ENOENT));
+        assert_eq!(attempts, 1);
     }
 
     fn args(command: &Command) -> Vec<&str> {

--- a/scripts/axbuild/src/agent_review_bench/runner.rs
+++ b/scripts/axbuild/src/agent_review_bench/runner.rs
@@ -1,5 +1,5 @@
 use std::{
-    fs, io,
+    fs,
     path::{Path, PathBuf},
     process::Stdio,
     time::Duration,
@@ -11,6 +11,7 @@ use tempfile::tempdir;
 use tokio::{process::Command, time::timeout};
 
 use super::{cases::BenchCase, sandbox::ReviewSandbox, scoring::ReviewFinding};
+use crate::support::process::retry_text_file_busy;
 
 const CODEX_REVIEW_PROMPT: &str = "$review-single-pr offline-benchmark";
 const CLAUDE_REVIEW_PROMPT: &str = "/review-single-pr offline-benchmark";
@@ -62,9 +63,6 @@ const CLAUDE_REVIEW_ALLOWED_TOOLS: &[&str] = &[
     "Bash(git grep *)",
 ];
 const CLAUDE_GRADE_TOOLS: &str = "Read";
-const TEXT_FILE_BUSY_RETRY_LIMIT: usize = 5;
-const TEXT_FILE_BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
-
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(super) enum AgentKind {
     #[default]
@@ -351,29 +349,6 @@ async fn run_process(
     }
 }
 
-fn retry_text_file_busy<T>(mut operation: impl FnMut() -> io::Result<T>) -> io::Result<T> {
-    let mut retries_remaining = TEXT_FILE_BUSY_RETRY_LIMIT;
-    loop {
-        match operation() {
-            Err(err) if is_text_file_busy(&err) && retries_remaining > 0 => {
-                retries_remaining -= 1;
-                std::thread::sleep(TEXT_FILE_BUSY_RETRY_DELAY);
-            }
-            result => return result,
-        }
-    }
-}
-
-#[cfg(unix)]
-fn is_text_file_busy(error: &io::Error) -> bool {
-    error.raw_os_error() == Some(libc::ETXTBSY)
-}
-
-#[cfg(not(unix))]
-fn is_text_file_busy(_error: &io::Error) -> bool {
-    false
-}
-
 fn copy_nonempty_output(source: &Path, destination: &Path, role: &str) -> anyhow::Result<()> {
     let metadata = fs::metadata(source)
         .with_context(|| format!("{role} did not create {}", source.display()))?;
@@ -544,35 +519,6 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(error.contains("timed out"));
-    }
-
-    #[test]
-    fn retries_transient_text_file_busy_errors() {
-        let mut attempts = 0;
-        let result = retry_text_file_busy(|| {
-            attempts += 1;
-            if attempts <= TEXT_FILE_BUSY_RETRY_LIMIT {
-                Err(std::io::Error::from_raw_os_error(libc::ETXTBSY))
-            } else {
-                Ok("spawned")
-            }
-        });
-
-        assert_eq!(result.unwrap(), "spawned");
-        assert_eq!(attempts, TEXT_FILE_BUSY_RETRY_LIMIT + 1);
-    }
-
-    #[test]
-    fn does_not_retry_other_spawn_errors() {
-        let mut attempts = 0;
-        let error = retry_text_file_busy(|| {
-            attempts += 1;
-            Err::<(), _>(std::io::Error::from_raw_os_error(libc::ENOENT))
-        })
-        .unwrap_err();
-
-        assert_eq!(error.raw_os_error(), Some(libc::ENOENT));
-        assert_eq!(attempts, 1);
     }
 
     fn args(command: &Command) -> Vec<&str> {

--- a/scripts/axbuild/src/axvisor/build/mod.rs
+++ b/scripts/axbuild/src/axvisor/build/mod.rs
@@ -27,19 +27,32 @@ pub use crate::build::LogLevel;
 use crate::context::ResolvedAxvisorRequest;
 
 pub(crate) fn load_cargo_config(request: &ResolvedAxvisorRequest) -> anyhow::Result<Cargo> {
+    let makefile_features = crate::build::makefile_features_from_env();
+    load_cargo_config_with_makefile_features(request, &makefile_features)
+}
+
+fn load_cargo_config_with_makefile_features(
+    request: &ResolvedAxvisorRequest,
+    makefile_features: &[String],
+) -> anyhow::Result<Cargo> {
     let metadata =
         crate::build::cached_workspace_metadata().context("failed to load workspace metadata")?;
-    to_cargo_config(load_build_config(request)?, request, metadata)
+    to_cargo_config(
+        load_build_config(request)?,
+        request,
+        metadata,
+        makefile_features,
+    )
 }
 
 fn to_cargo_config(
     mut config: LoadedAxvisorBuildConfig,
     request: &ResolvedAxvisorRequest,
     metadata: &cargo_metadata::Metadata,
+    makefile_features: &[String],
 ) -> anyhow::Result<Cargo> {
     config.target = request.target.clone();
-    let makefile_features = crate::build::makefile_features_from_env();
-    crate::build::apply_makefile_features(&mut config.build_info, &makefile_features)?;
+    crate::build::apply_makefile_features(&mut config.build_info, makefile_features)?;
     let known_platforms = platform_feature_names(metadata);
     reject_unsupported_nested_platform_features(&config.build_info.features, &known_platforms)?;
     let mut cargo = config

--- a/scripts/axbuild/src/axvisor/build/tests.rs
+++ b/scripts/axbuild/src/axvisor/build/tests.rs
@@ -1,44 +1,11 @@
 use std::{
-    env,
-    ffi::{OsStr, OsString},
     fs,
     path::{Path, PathBuf},
-    sync::{LazyLock, Mutex},
 };
 
 use tempfile::tempdir;
 
 use super::*;
-
-static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
-
-struct TempEnvVar {
-    key: &'static str,
-    original: Option<OsString>,
-}
-
-impl TempEnvVar {
-    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
-        let original = env::var_os(key);
-        unsafe {
-            env::set_var(key, value);
-        }
-        Self { key, original }
-    }
-}
-
-impl Drop for TempEnvVar {
-    fn drop(&mut self) {
-        match self.original.as_ref() {
-            Some(value) => unsafe {
-                env::set_var(self.key, value);
-            },
-            None => unsafe {
-                env::remove_var(self.key);
-            },
-        }
-    }
-}
 
 fn write_board(axvisor_dir: &Path, name: &str, body: &str) -> PathBuf {
     let path = axvisor_dir
@@ -627,8 +594,6 @@ log = "Info"
 
 #[test]
 fn load_cargo_config_applies_stack_protector_from_makefile_features() {
-    let _env_lock = ENV_LOCK.lock().unwrap();
-    let _features = TempEnvVar::set("FEATURES", "stack-protector");
     let root = tempdir().unwrap();
     let config_path = root.path().join(".build.toml");
     fs::write(
@@ -640,18 +605,21 @@ log = "Info"
     )
     .unwrap();
 
-    let cargo = load_cargo_config(&ResolvedAxvisorRequest {
-        package: AXVISOR_PACKAGE.to_string(),
-        axvisor_dir: root.path().join("os/axvisor"),
-        arch: "x86_64".to_string(),
-        target: "x86_64-unknown-none".to_string(),
-        smp: None,
-        debug: false,
-        build_info_path: config_path,
-        qemu_config: None,
-        uboot_config: None,
-        vmconfigs: vec![],
-    })
+    let cargo = load_cargo_config_with_makefile_features(
+        &ResolvedAxvisorRequest {
+            package: AXVISOR_PACKAGE.to_string(),
+            axvisor_dir: root.path().join("os/axvisor"),
+            arch: "x86_64".to_string(),
+            target: "x86_64-unknown-none".to_string(),
+            smp: None,
+            debug: false,
+            build_info_path: config_path,
+            qemu_config: None,
+            uboot_config: None,
+            vmconfigs: vec![],
+        },
+        &["stack-protector".to_string()],
+    )
     .unwrap();
 
     assert!(
@@ -661,6 +629,19 @@ log = "Info"
     );
     let config = fs::read_to_string(cargo.extra_config.unwrap()).unwrap();
     assert!(config.contains(r#""-Zstack-protector=strong""#));
+}
+
+#[test]
+fn makefile_feature_tests_do_not_mutate_process_environment() {
+    let source = include_str!("tests.rs");
+    let set_var = ["env", "::set_var("].concat();
+    let remove_var = ["env", "::remove_var("].concat();
+
+    assert!(
+        !source.contains(&set_var) && !source.contains(&remove_var),
+        "Axvisor build tests must pass makefile features explicitly instead of mutating the \
+         process environment observed by parallel tests"
+    );
 }
 
 #[test]

--- a/scripts/axbuild/src/axvisor/test/http_probe.rs
+++ b/scripts/axbuild/src/axvisor/test/http_probe.rs
@@ -44,6 +44,7 @@ use std::{
 use anyhow::{Context, bail};
 
 use super::types::AxvisorHttpProbeConfig;
+use crate::support::process::retry_text_file_busy;
 
 /// Poll interval while waiting for the probe asset to exit.
 const PROBE_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -108,7 +109,8 @@ fn spawn_probe_asset(
     config: &AxvisorHttpProbeConfig,
     case_dir: &Path,
 ) -> anyhow::Result<Child> {
-    Command::new(script)
+    let mut command = Command::new(script);
+    command
         .env("AXVISOR_HTTP_BASE", format!("http://{addr}"))
         .env(
             "AXVISOR_HTTP_TOKEN",
@@ -125,8 +127,8 @@ fn spawn_probe_asset(
         )
         .stdin(Stdio::null())
         .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
-        .spawn()
+        .stderr(Stdio::inherit());
+    retry_text_file_busy(|| command.spawn())
         .with_context(|| format!("failed to spawn probe asset {}", script.display()))
 }
 
@@ -241,6 +243,17 @@ mod tests {
     fn probe_script_is_configurable() {
         let config = parse_probe_section("[host_http_probe]\nprobe_script = \"custom_probe.sh\"\n");
         assert_eq!(config.probe_script, PathBuf::from("custom_probe.sh"));
+    }
+
+    #[test]
+    fn probe_asset_spawn_uses_the_text_file_busy_retry_boundary() {
+        let source = include_str!("http_probe.rs");
+        let retry_spawn = ["retry_text_file_busy", "(|| command.spawn())"].concat();
+
+        assert!(
+            source.contains(&retry_spawn),
+            "directly executed probe assets must retry the transient ETXTBSY publication window"
+        );
     }
 
     #[cfg(unix)]

--- a/scripts/axbuild/src/starry/test/tests/system_case_tests.rs
+++ b/scripts/axbuild/src/starry/test/tests/system_case_tests.rs
@@ -258,6 +258,36 @@ fn starry_system_runner_keeps_slow_case_timeouts_explicit() {
 }
 
 #[test]
+fn pagecache_cap_cleanup_uses_disposable_qemu_rootfs() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let source_path =
+        workspace_root.join("test-suit/starryos/qemu/system/syscall-test-pagecache-cap/src/main.c");
+    let source = fs::read_to_string(&source_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", source_path.display()));
+
+    assert!(
+        source.contains("g_maps[i] = m;")
+            && source.contains("#define DIR \"/root/pgcachecap\"")
+            && !source.contains("munmap(")
+            && !source.contains("unlink(")
+            && !source.contains("rmdir("),
+        "{} must retain its mappings in a unique directory and avoid one cleanup syscall per \
+         fixture",
+        source_path.display()
+    );
+
+    let qemu_run_path = workspace_root.join("scripts/axbuild/src/starry/test/qemu_run.rs");
+    let qemu_run = fs::read_to_string(&qemu_run_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", qemu_run_path.display()));
+    assert!(
+        qemu_run.contains("write_policy: rootfs::RootfsWritePolicy::Discard"),
+        "{} must discard guest writes after each QEMU case so pagecache-cap can leave its unique \
+         fixture directory to snapshot teardown",
+        qemu_run_path.display()
+    );
+}
+
+#[test]
 fn starry_system_runner_bounds_namespace_cleanup_and_covers_raw_waiters() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
     let runner_path =

--- a/scripts/axbuild/src/support/process.rs
+++ b/scripts/axbuild/src/support/process.rs
@@ -3,10 +3,14 @@ use std::{
     io::{self, Write},
     path::Path,
     process::{Command, Stdio},
+    time::Duration,
 };
 
 use anyhow::{Context, Result, bail};
 use colored::Colorize;
+
+const TEXT_FILE_BUSY_RETRY_LIMIT: usize = 5;
+const TEXT_FILE_BUSY_RETRY_DELAY: Duration = Duration::from_millis(10);
 
 pub trait ProcessExt {
     /// Encodes an option and value as one argv element for parsers that would
@@ -14,6 +18,34 @@ pub trait ProcessExt {
     fn arg_option_value(&mut self, option: &str, value: &OsStr) -> &mut Self;
     fn exec(&mut self) -> Result<()>;
     fn exec_quiet(&mut self) -> Result<()>;
+}
+
+/// Retry the Linux executable-publication race without changing other process
+/// errors. Callers should use this only when the program may have just been
+/// materialized or replaced.
+pub(crate) fn retry_text_file_busy<T>(
+    mut operation: impl FnMut() -> io::Result<T>,
+) -> io::Result<T> {
+    let mut retries_remaining = TEXT_FILE_BUSY_RETRY_LIMIT;
+    loop {
+        match operation() {
+            Err(err) if is_text_file_busy(&err) && retries_remaining > 0 => {
+                retries_remaining -= 1;
+                std::thread::sleep(TEXT_FILE_BUSY_RETRY_DELAY);
+            }
+            result => return result,
+        }
+    }
+}
+
+#[cfg(unix)]
+fn is_text_file_busy(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(libc::ETXTBSY)
+}
+
+#[cfg(not(unix))]
+fn is_text_file_busy(_error: &io::Error) -> bool {
+    false
 }
 
 pub(crate) fn run_cargo_status(workspace_root: &Path, args: &[String]) -> Result<bool> {
@@ -154,6 +186,37 @@ mod tests {
     use std::{ffi::OsStr, process::Command};
 
     use super::ProcessExt;
+
+    #[cfg(unix)]
+    #[test]
+    fn retries_transient_text_file_busy_errors() {
+        let mut attempts = 0;
+        let result = super::retry_text_file_busy(|| {
+            attempts += 1;
+            if attempts <= super::TEXT_FILE_BUSY_RETRY_LIMIT {
+                Err(std::io::Error::from_raw_os_error(libc::ETXTBSY))
+            } else {
+                Ok("spawned")
+            }
+        });
+
+        assert_eq!(result.unwrap(), "spawned");
+        assert_eq!(attempts, super::TEXT_FILE_BUSY_RETRY_LIMIT + 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn does_not_retry_other_spawn_errors() {
+        let mut attempts = 0;
+        let error = super::retry_text_file_busy(|| {
+            attempts += 1;
+            Err::<(), _>(std::io::Error::from_raw_os_error(libc::ENOENT))
+        })
+        .unwrap_err();
+
+        assert_eq!(error.raw_os_error(), Some(libc::ENOENT));
+        assert_eq!(attempts, 1);
+    }
 
     #[test]
     fn option_values_are_one_argument_even_when_the_value_starts_with_a_hyphen() {

--- a/test-suit/starryos/qemu/system/syscall-test-pagecache-cap/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-pagecache-cap/src/main.c
@@ -141,16 +141,11 @@ int main(void)
         printf("  INFO | MemFree unavailable; skipping delta-bound assertion\n");
     }
 
-    /* 清理: 释放映射并删除磁盘文件 (rootfs 在同一 boot 内跨测例持久) */
-    for (int i = 0; i < N_FILES; i++) {
-        if (g_maps[i])
-            munmap(g_maps[i], PAGE);
-    }
-    for (int i = 0; i < N_FILES; i++) {
-        snprintf(path, sizeof path, DIR "/f%04d.dat", i);
-        unlink(path);
-    }
-    rmdir(DIR);
+    /* This unique fixture directory lives on a QEMU rootfs drive with discard
+     * snapshot policy. Process exit releases all retained mappings, and QEMU
+     * snapshot teardown discards the directory entries in bulk. Per-file
+     * cleanup would measure 1400 filesystem syscalls instead of the page-cache
+     * allocation invariant under test. */
 
     TEST_DONE();
 }


### PR DESCRIPTION
## 问题

检查 dev 最近三次提交的 CI 后，确认有两个可由代码修复的潜藏问题：

- Workspace/std tests 中，axbuild 单测启动刚写入的临时可执行文件时可能收到 Linux ETXTBSY，最初发生在 agent-review-bench 的 mock CLI 版本探测；PR 首轮 CI 又在 AxVisor HTTP probe 临时脚本路径复现。
- Starry riscv64 的 syscall-test-pagecache-cap 已完成全部容量断言，但对 1400 个映射和文件逐项清理，令单例超过 240 秒超时。

agent-review-bench 测试只执行本地 mock-codex/mock-claude 脚本，不调用真实 agent、不联网，也不产生模型调用。同一批次中的 PhytiumPi 失败是串口连接被对端重置，属于板卡基础设施故障，本 PR 不修改其代码路径。

## 修改

- 抽取只处理 ETXTBSY 的进程启动有界重试：最多重试 5 次、每次间隔 10 ms；其他错误立即原样返回，重试耗尽后仍保留调用上下文。
- 将该窄边界用于 agent mock CLI 的版本探测和 review/grade 启动，以及直接执行刚生成资产的 AxVisor HTTP probe；不改变普通 ProcessExt 进程调用的错误语义。
- AxVisor stack-protector 配置单测改为显式传入 makefile features，不再修改进程全局 FEATURES，避免并行 Starry build 单测观察到临时值。
- pagecache-cap 保留映射到进程退出，由进程退出回收映射，并依赖 QEMU rootfs 的 discard snapshot 在测试实例结束时批量丢弃 fixture；移除逐映射、逐文件清理。
- 增加 ETXTBSY、进程环境隔离、HTTP probe 启动边界和 pagecache/QEMU discard 的回归契约。

## 方案逻辑

ETXTBSY 是 Linux 在可执行文件仍处于写入或替换窗口时返回的瞬态错误，只对刚物化的可执行资产做短时间有界重试，既覆盖发布窗口，也不掩盖路径、权限等永久错误。测试不能通过修改进程全局环境向被测函数注入参数，否则并行测试会发生数据竞争，因此改为显式参数边界。pagecache-cap 的目标是验证页缓存容量边界，而不是测量大量文件系统清理 syscall；QEMU 测试 rootfs 已启用 discard snapshot，因此实例销毁是更合适的隔离和清理边界。

## 验证

- 回归契约均完成修复前确定性失败、修复后通过。
- cargo test -p axbuild：962 passed。
- cargo xtask clippy --package axbuild：通过。
- cargo xtask test：52 个 workspace/std test package 全部通过；该命令曾复现 HTTP probe ETXTBSY，修复后通过。
- cargo xtask starry test qemu --arch riscv64 -c qemu/system/syscall-test-pagecache-cap：1/1 通过，7 个断言全部通过，单例 156.073 秒完成。
- cargo fmt --all --check：通过。
- git diff --check：通过。