### PR TITLE
fix(arm_vcpu): synchronize EL2 enable publication

### DIFF
--- a/.claude/skills/arch-platform-porting/references/boot-debugging.md
+++ b/.claude/skills/arch-platform-porting/references/boot-debugging.md
@@ -152,6 +152,12 @@ execution and then fail only on traps or vCPU exits, so it is not a valid fallba
 
 ## AArch64 Axvisor EL2 Checks
 
+- When `arm_vcpu` replaces the live pCPU's `VBAR_EL2`, publish the current-EL host IRQ handler
+  first, write `VBAR_EL2`, execute `ISB`, then update `HCR_EL2` and execute another `ISB`.
+  Otherwise an exception can observe a vector/handler/control-register combination that was never
+  intended to be live. A current-EL synchronous panic must report at least `ESR_EL2`, `FAR_EL2`,
+  `ELR_EL2`, `SPSR_EL2`, and `HCR_EL2` so an intermittent host translation fault can be traced to
+  the first invalid access instead of being classified from the syndrome alone.
 - The Axvisor `hv` feature chain must select `ax-cpu/arm-el2` only for AArch64. Keep the chain
   `ax-hal/hv` -> `axplat-dyn/hv` -> `somehal/hv`; `somehal`'s AArch64-only optional `ax-cpu`
   dependency owns the `arm-el2` edge. A successful AArch64 compile does not prove that the EL2

--- a/virtualization/arm_vcpu/src/architecture/exception.rs
+++ b/virtualization/arm_vcpu/src/architecture/exception.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use aarch64_cpu::registers::{ESR_EL2, HCR_EL2, Readable, SCTLR_EL1, VTCR_EL2, VTTBR_EL2};
-use log::error;
+use aarch64_cpu::registers::{
+    ELR_EL2, ESR_EL2, FAR_EL2, HCR_EL2, Readable, SCTLR_EL1, SPSR_EL2, VTCR_EL2, VTTBR_EL2,
+};
 
 use super::{
     TrapFrame,
@@ -333,12 +334,15 @@ fn current_el_sync_handler(tf: &mut TrapFrame) {
     let ec = ESR_EL2.read(ESR_EL2::EC);
     let iss = ESR_EL2.read(ESR_EL2::ISS);
 
-    error!("ESR_EL2: {:#x}", esr.get());
-    error!("Exception Class: {ec:#x}");
-    error!("Instruction Specific Syndrome: {iss:#x}");
-
     panic!(
-        "Unhandled synchronous exception from current EL: {:#x?}",
+        "Unhandled synchronous exception from current EL:\nESR_EL2: {:#x}\nException Class: \
+         {ec:#x}\nInstruction Specific Syndrome: {iss:#x}\nFAR_EL2: {:#x}\nELR_EL2: \
+         {:#x}\nSPSR_EL2: {:#x}\nHCR_EL2: {:#x}\nTrap frame: {:#x?}",
+        esr.get(),
+        FAR_EL2.get(),
+        ELR_EL2.get(),
+        SPSR_EL2.get(),
+        HCR_EL2.get(),
         tf
     );
 }

--- a/virtualization/arm_vcpu/src/architecture/pcpu.rs
+++ b/virtualization/arm_vcpu/src/architecture/pcpu.rs
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::mem;
+use core::{marker::PhantomData, mem};
 
 use aarch64_cpu::registers::*;
 
 use super::host::ArmHostOps;
-use crate::ArmVcpuResult;
+use crate::{ArmVcpuResult, enable::El2EnableOps};
 
 /// Per-CPU AArch64 virtualization state.
 #[repr(C)]
@@ -33,6 +33,38 @@ pub struct ArmPerCpu {
 
 unsafe extern "C" {
     fn exception_vector_base_vcpu();
+}
+
+struct ArmEl2Enable<H>(PhantomData<H>);
+
+impl<H> ArmEl2Enable<H> {
+    const fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<H: ArmHostOps> El2EnableOps for ArmEl2Enable<H> {
+    fn install_exception_vector(&mut self) {
+        VBAR_EL2.set(exception_vector_base_vcpu as *const () as usize as _);
+    }
+
+    fn synchronize_context(&mut self) {
+        // SAFETY: `isb` only synchronizes subsequent instruction execution on
+        // the current CPU after the system-register updates performed here.
+        unsafe {
+            core::arch::asm!("isb", options(nostack, preserves_flags));
+        }
+    }
+
+    fn enable_virtualization(&mut self) {
+        HCR_EL2.modify(
+            HCR_EL2::VM::Enable + HCR_EL2::RW::EL1IsAarch64 + HCR_EL2::TSC::EnableTrapEl1SmcToEl2,
+        );
+    }
+
+    fn install_current_el_irq_handler(&mut self) {
+        super::host::install_current_el_irq_handler::<H>();
+    }
 }
 
 impl ArmPerCpu {
@@ -61,15 +93,7 @@ impl ArmPerCpu {
         // Todo: take care of `preemption`
         self.original_vbar_el2 = VBAR_EL2.get();
 
-        // Set current `VBAR_EL2` to `exception_vector_base_vcpu`
-        // defined in this crate.
-        VBAR_EL2.set(exception_vector_base_vcpu as *const () as usize as _);
-
-        HCR_EL2.modify(
-            HCR_EL2::VM::Enable + HCR_EL2::RW::EL1IsAarch64 + HCR_EL2::TSC::EnableTrapEl1SmcToEl2,
-        );
-
-        super::host::install_current_el_irq_handler::<H>();
+        crate::enable::enable_el2(&mut ArmEl2Enable::<H>::new());
 
         // Note that `ICH_HCR_EL2` is not the same as `HCR_EL2`.
         //

--- a/virtualization/arm_vcpu/src/architecture/pcpu.rs
+++ b/virtualization/arm_vcpu/src/architecture/pcpu.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::{marker::PhantomData, mem};
+use core::mem;
 
 use aarch64_cpu::registers::*;
 
 use super::host::ArmHostOps;
-use crate::{ArmVcpuResult, enable::El2EnableOps};
+use crate::{
+    ArmVcpuResult,
+    enable::{EL2_ENABLE_STEPS, El2EnableStep},
+};
 
 /// Per-CPU AArch64 virtualization state.
 #[repr(C)]
@@ -33,38 +36,6 @@ pub struct ArmPerCpu {
 
 unsafe extern "C" {
     fn exception_vector_base_vcpu();
-}
-
-struct ArmEl2Enable<H>(PhantomData<H>);
-
-impl<H> ArmEl2Enable<H> {
-    const fn new() -> Self {
-        Self(PhantomData)
-    }
-}
-
-impl<H: ArmHostOps> El2EnableOps for ArmEl2Enable<H> {
-    fn install_exception_vector(&mut self) {
-        VBAR_EL2.set(exception_vector_base_vcpu as *const () as usize as _);
-    }
-
-    fn synchronize_context(&mut self) {
-        // SAFETY: `isb` only synchronizes subsequent instruction execution on
-        // the current CPU after the system-register updates performed here.
-        unsafe {
-            core::arch::asm!("isb", options(nostack, preserves_flags));
-        }
-    }
-
-    fn enable_virtualization(&mut self) {
-        HCR_EL2.modify(
-            HCR_EL2::VM::Enable + HCR_EL2::RW::EL1IsAarch64 + HCR_EL2::TSC::EnableTrapEl1SmcToEl2,
-        );
-    }
-
-    fn install_current_el_irq_handler(&mut self) {
-        super::host::install_current_el_irq_handler::<H>();
-    }
 }
 
 impl ArmPerCpu {
@@ -93,7 +64,22 @@ impl ArmPerCpu {
         // Todo: take care of `preemption`
         self.original_vbar_el2 = VBAR_EL2.get();
 
-        crate::enable::enable_el2(&mut ArmEl2Enable::<H>::new());
+        for step in EL2_ENABLE_STEPS {
+            match step {
+                El2EnableStep::InstallCurrentElIrqHandler => {
+                    super::host::install_current_el_irq_handler::<H>();
+                }
+                El2EnableStep::InstallExceptionVector => {
+                    VBAR_EL2.set(exception_vector_base_vcpu as *const () as usize as _);
+                }
+                El2EnableStep::SynchronizeContext => synchronize_context(),
+                El2EnableStep::EnableVirtualization => HCR_EL2.modify(
+                    HCR_EL2::VM::Enable
+                        + HCR_EL2::RW::EL1IsAarch64
+                        + HCR_EL2::TSC::EnableTrapEl1SmcToEl2,
+                ),
+            }
+        }
 
         // Note that `ICH_HCR_EL2` is not the same as `HCR_EL2`.
         //
@@ -136,5 +122,13 @@ impl ArmPerCpu {
     /// Returns the architectural counter frequency recorded on this CPU.
     pub const fn timer_frequency_hz(&self) -> u64 {
         self.timer_frequency_hz
+    }
+}
+
+fn synchronize_context() {
+    // SAFETY: `isb` only synchronizes subsequent instruction execution on the
+    // current CPU after the system-register updates performed here.
+    unsafe {
+        core::arch::asm!("isb", options(nostack, preserves_flags));
     }
 }

--- a/virtualization/arm_vcpu/src/enable.rs
+++ b/virtualization/arm_vcpu/src/enable.rs
@@ -1,0 +1,87 @@
+//! Ordering contract for publishing AArch64 EL2 virtualization state.
+
+pub(crate) trait El2EnableOps {
+    fn install_exception_vector(&mut self);
+
+    fn synchronize_context(&mut self);
+
+    fn enable_virtualization(&mut self);
+
+    fn install_current_el_irq_handler(&mut self);
+}
+
+pub(crate) fn enable_el2(ops: &mut impl El2EnableOps) {
+    ops.install_current_el_irq_handler();
+    ops.install_exception_vector();
+    ops.synchronize_context();
+    ops.enable_virtualization();
+    ops.synchronize_context();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum EnableStep {
+        InstallIrqHandler,
+        InstallExceptionVector,
+        SynchronizeContext,
+        EnableVirtualization,
+    }
+
+    struct EnableRecorder {
+        steps: [Option<EnableStep>; 5],
+        len: usize,
+    }
+
+    impl EnableRecorder {
+        const fn new() -> Self {
+            Self {
+                steps: [None; 5],
+                len: 0,
+            }
+        }
+
+        fn push(&mut self, step: EnableStep) {
+            self.steps[self.len] = Some(step);
+            self.len += 1;
+        }
+    }
+
+    impl El2EnableOps for EnableRecorder {
+        fn install_exception_vector(&mut self) {
+            self.push(EnableStep::InstallExceptionVector);
+        }
+
+        fn synchronize_context(&mut self) {
+            self.push(EnableStep::SynchronizeContext);
+        }
+
+        fn enable_virtualization(&mut self) {
+            self.push(EnableStep::EnableVirtualization);
+        }
+
+        fn install_current_el_irq_handler(&mut self) {
+            self.push(EnableStep::InstallIrqHandler);
+        }
+    }
+
+    #[test]
+    fn publishes_handler_then_vbar_isb_then_hcr_isb() {
+        let mut recorder = EnableRecorder::new();
+
+        enable_el2(&mut recorder);
+
+        assert_eq!(
+            &recorder.steps[..recorder.len],
+            [
+                Some(EnableStep::InstallIrqHandler),
+                Some(EnableStep::InstallExceptionVector),
+                Some(EnableStep::SynchronizeContext),
+                Some(EnableStep::EnableVirtualization),
+                Some(EnableStep::SynchronizeContext),
+            ]
+        );
+    }
+}

--- a/virtualization/arm_vcpu/src/enable.rs
+++ b/virtualization/arm_vcpu/src/enable.rs
@@ -1,86 +1,35 @@
 //! Ordering contract for publishing AArch64 EL2 virtualization state.
 
-pub(crate) trait El2EnableOps {
-    fn install_exception_vector(&mut self);
-
-    fn synchronize_context(&mut self);
-
-    fn enable_virtualization(&mut self);
-
-    fn install_current_el_irq_handler(&mut self);
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum El2EnableStep {
+    InstallCurrentElIrqHandler,
+    InstallExceptionVector,
+    SynchronizeContext,
+    EnableVirtualization,
 }
 
-pub(crate) fn enable_el2(ops: &mut impl El2EnableOps) {
-    ops.install_current_el_irq_handler();
-    ops.install_exception_vector();
-    ops.synchronize_context();
-    ops.enable_virtualization();
-    ops.synchronize_context();
-}
+pub(crate) const EL2_ENABLE_STEPS: [El2EnableStep; 5] = [
+    El2EnableStep::InstallCurrentElIrqHandler,
+    El2EnableStep::InstallExceptionVector,
+    El2EnableStep::SynchronizeContext,
+    El2EnableStep::EnableVirtualization,
+    El2EnableStep::SynchronizeContext,
+];
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    enum EnableStep {
-        InstallIrqHandler,
-        InstallExceptionVector,
-        SynchronizeContext,
-        EnableVirtualization,
-    }
-
-    struct EnableRecorder {
-        steps: [Option<EnableStep>; 5],
-        len: usize,
-    }
-
-    impl EnableRecorder {
-        const fn new() -> Self {
-            Self {
-                steps: [None; 5],
-                len: 0,
-            }
-        }
-
-        fn push(&mut self, step: EnableStep) {
-            self.steps[self.len] = Some(step);
-            self.len += 1;
-        }
-    }
-
-    impl El2EnableOps for EnableRecorder {
-        fn install_exception_vector(&mut self) {
-            self.push(EnableStep::InstallExceptionVector);
-        }
-
-        fn synchronize_context(&mut self) {
-            self.push(EnableStep::SynchronizeContext);
-        }
-
-        fn enable_virtualization(&mut self) {
-            self.push(EnableStep::EnableVirtualization);
-        }
-
-        fn install_current_el_irq_handler(&mut self) {
-            self.push(EnableStep::InstallIrqHandler);
-        }
-    }
-
     #[test]
     fn publishes_handler_then_vbar_isb_then_hcr_isb() {
-        let mut recorder = EnableRecorder::new();
-
-        enable_el2(&mut recorder);
-
         assert_eq!(
-            &recorder.steps[..recorder.len],
+            EL2_ENABLE_STEPS,
             [
-                Some(EnableStep::InstallIrqHandler),
-                Some(EnableStep::InstallExceptionVector),
-                Some(EnableStep::SynchronizeContext),
-                Some(EnableStep::EnableVirtualization),
-                Some(EnableStep::SynchronizeContext),
+                El2EnableStep::InstallCurrentElIrqHandler,
+                El2EnableStep::InstallExceptionVector,
+                El2EnableStep::SynchronizeContext,
+                El2EnableStep::EnableVirtualization,
+                El2EnableStep::SynchronizeContext,
             ]
         );
     }

--- a/virtualization/arm_vcpu/src/lib.rs
+++ b/virtualization/arm_vcpu/src/lib.rs
@@ -21,6 +21,8 @@ extern crate log;
 
 #[cfg(target_arch = "aarch64")]
 mod architecture;
+#[cfg(any(target_arch = "aarch64", test))]
+mod enable;
 mod timer;
 mod types;
 


### PR DESCRIPTION
## 问题

AArch64 `ArmPerCpu::hardware_enable` 原来的执行顺序是：

```text
写 VBAR_EL2 -> 更新 HCR_EL2 -> 发布 current-EL IRQ handler
```

这里有两个问题：

- 新异常向量生效时，handler 可能还没有发布；
- `VBAR_EL2` 和 `HCR_EL2` 更新后缺少 `ISB`。

#2110 的日志只包含 `ESR_EL2`、EC 和 ISS，缺少 fault address 和 instruction address，无法继续定位偶发 translation fault。

## 修改

- 将 EL2 启用顺序改为：

  ```text
  发布 handler -> 写 VBAR_EL2 -> ISB -> 更新 HCR_EL2 -> ISB
  ```

- current-EL 同步异常统一输出 `ESR_EL2`、EC、ISS、`FAR_EL2`、`ELR_EL2`、`SPSR_EL2`、`HCR_EL2` 和 trap frame。
- 增加私有 typed step 序列测试；生产路径直接消费同一序列。
- 更新 AArch64 EL2 调试说明。

## 回归验证

旧顺序下测试稳定失败：

```text
actual:   VBAR -> HCR -> handler
expected: handler -> VBAR -> ISB -> HCR -> ISB
```

修复后通过：

```bash
cargo fmt --all -- --check
cargo test -p arm_vcpu --lib
cargo xtask clippy --package arm_vcpu
cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress
git diff --check
```

其中 `arm_vcpu` 单测 13/13 通过，AArch64 timer-stress 1/1 通过。

## 范围

本 PR 只修复已确认的 EL2 发布顺序问题。#2110 截图中的 `BTreeMap` 节点分裂 panic 仍缺少第一处状态破坏证据，因此不在本 PR 中修改 timer 容器，也不自动关闭 issue。

Refs #2110
