### PR TITLE
fix(ax-net): wake only the peer on unix stream I/O

### DIFF
--- a/net/ax-net/src/unix/stream.rs
+++ b/net/ax-net/src/unix/stream.rs
@@ -70,7 +70,9 @@ fn new_channels(
 ) -> (Channel, Channel) {
     let (client_tx, server_rx) = new_uni_channel();
     let (server_tx, client_rx) = new_uni_channel();
-    let poll_update = Arc::new(PollSet::new());
+    // Per-endpoint wait sets, so I/O wakes only the peer, as on Linux.
+    let client_poll = Arc::new(PollSet::new());
+    let server_poll = Arc::new(PollSet::new());
     let c2s_cmsg = CmsgQueue::default();
     let s2c_cmsg = CmsgQueue::default();
     // Cross-wired close flags: each side's my_tx_closed is the other's peer_tx_closed.
@@ -86,7 +88,8 @@ fn new_channels(
             rx_bytes_total: 0,
             my_tx_closed: client_tx_closed.clone(),
             peer_tx_closed: server_tx_closed.clone(),
-            poll_update: poll_update.clone(),
+            poll_update: client_poll.clone(),
+            peer_poll_update: server_poll.clone(),
             peer_credentials: credentials.clone(),
             peer_receive_credentials: second_receive_credentials,
         },
@@ -99,7 +102,8 @@ fn new_channels(
             rx_bytes_total: 0,
             my_tx_closed: server_tx_closed,
             peer_tx_closed: client_tx_closed,
-            poll_update,
+            poll_update: server_poll,
+            peer_poll_update: client_poll,
             peer_credentials: credentials,
             peer_receive_credentials: first_receive_credentials,
         },
@@ -125,6 +129,8 @@ struct Channel {
     /// Set to true by the peer's Drop before it wakes us.
     peer_tx_closed: Arc<AtomicBool>,
     poll_update: Arc<PollSet>,
+    /// The peer endpoint's `poll_update`.
+    peer_poll_update: Arc<PollSet>,
     peer_credentials: UnixCredentials,
     /// Peer receiver's `SO_PASSCRED` state.
     peer_receive_credentials: Arc<AtomicBool>,
@@ -431,14 +437,14 @@ impl TransportOps for StreamTransport {
                     });
                 }
                 chan.tx_bytes_total = chan.tx_bytes_total.saturating_add(count as u64);
-                wake_poll = Some(chan.poll_update.clone());
+                wake_poll = Some(chan.peer_poll_update.clone());
                 Ok(count)
             }
         };
         drop(guard);
         if let Some(poll) = wake_poll {
             // Peer-visible bytes and cmsg state are published before wake.
-            unsafe { poll.wake(IoEvents::IN | IoEvents::OUT) };
+            unsafe { poll.wake(IoEvents::IN) };
         }
         result
     }
@@ -484,7 +490,7 @@ impl TransportOps for StreamTransport {
                 if count > 0 {
                     if !peek {
                         chan.rx_bytes_total = chan.rx_bytes_total.saturating_add(count as u64);
-                        wake_poll = Some(chan.poll_update.clone());
+                        wake_poll = Some(chan.peer_poll_update.clone());
                     }
                     Ok(count)
                 } else if !chan.rx.write_is_held() || chan.peer_tx_closed.load(Ordering::Acquire) {
@@ -561,14 +567,14 @@ impl TransportOps for StreamTransport {
             self.tx_closed.store(true, Ordering::Release);
             if let Some(chan) = self.channel.lock().as_ref() {
                 chan.my_tx_closed.store(true, Ordering::Release);
-                peer_poll = Some(chan.poll_update.clone());
+                peer_poll = Some(chan.peer_poll_update.clone());
             }
         }
         if self.rx_closed.load(Ordering::Acquire)
             && self.tx_closed.load(Ordering::Acquire)
             && let Some(chan) = self.channel.lock().take()
         {
-            peer_poll.get_or_insert(chan.poll_update);
+            peer_poll.get_or_insert(chan.peer_poll_update);
         }
         if let Some(poll) = peer_poll {
             // The peer-visible write closure is published before waking readers.
@@ -659,7 +665,7 @@ impl Drop for StreamTransport {
             // and no data, reports no events, and parks forever waiting for data
             // that will never arrive.
             chan.my_tx_closed.store(true, Ordering::Release);
-            Some(chan.poll_update.clone())
+            Some(chan.peer_poll_update.clone())
         } else {
             None
         };
@@ -672,5 +678,103 @@ impl Drop for StreamTransport {
             self.poll_state
                 .wake(IoEvents::IN | IoEvents::OUT | IoEvents::RDHUP)
         };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::task::Wake;
+    use core::{
+        sync::atomic::{AtomicUsize, Ordering},
+        task::Waker,
+    };
+
+    use axpoll::{PollRegistrar, SharedObserver};
+
+    use super::*;
+
+    struct WakeCount(AtomicUsize);
+
+    impl Wake for WakeCount {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::AcqRel);
+        }
+    }
+
+    struct Observer {
+        count: Arc<WakeCount>,
+        _registrar: PollRegistrar<SharedObserver>,
+    }
+
+    impl Observer {
+        fn woke(&self) -> usize {
+            self.count.0.load(Ordering::Acquire)
+        }
+    }
+
+    fn observe(transport: &StreamTransport, events: IoEvents) -> Observer {
+        let count = Arc::new(WakeCount(AtomicUsize::new(0)));
+        let waker = Waker::from(count.clone());
+        let mut registrar = PollRegistrar::<SharedObserver>::new(&waker);
+        // SAFETY: the registrar is owned by the returned observer, which every
+        // test drops before the transport it watches.
+        unsafe { transport.register_shared(&mut registrar, events) };
+        Observer {
+            count,
+            _registrar: registrar,
+        }
+    }
+
+    #[test]
+    fn send_wakes_only_the_peer_reader() {
+        let (writer, reader) = StreamTransport::new_pair(1);
+        let writer_out = observe(&writer, IoEvents::OUT);
+        let reader_in = observe(&reader, IoEvents::IN);
+        let reader_out = observe(&reader, IoEvents::OUT);
+
+        let sent = writer
+            .try_send(&b"ping"[..], &mut SendOptions::default())
+            .unwrap();
+        assert_eq!(sent, 4);
+
+        assert_eq!(reader_in.woke(), 1);
+        assert_eq!(writer_out.woke(), 0, "send re-armed the writer's own OUT");
+        assert_eq!(
+            reader_out.woke(),
+            0,
+            "incoming data re-armed the reader's OUT"
+        );
+    }
+
+    #[test]
+    fn recv_wakes_only_the_peer_writer() {
+        let (writer, reader) = StreamTransport::new_pair(1);
+        writer
+            .try_send(&b"ping"[..], &mut SendOptions::default())
+            .unwrap();
+        let writer_out = observe(&writer, IoEvents::OUT);
+        let reader_out = observe(&reader, IoEvents::OUT);
+
+        let mut buf = [0u8; 4];
+        let received = reader
+            .try_recv(&mut buf[..], &mut RecvOptions::default())
+            .unwrap();
+        assert_eq!(received, 4);
+
+        assert_eq!(writer_out.woke(), 1);
+        assert_eq!(reader_out.woke(), 0, "recv re-armed the reader's own OUT");
+    }
+
+    #[test]
+    fn write_shutdown_and_drop_wake_the_peer() {
+        let (writer, reader) = StreamTransport::new_pair(1);
+        let reader_hup = observe(&reader, IoEvents::IN | IoEvents::RDHUP);
+        writer.shutdown(Shutdown::Write).unwrap();
+        assert_eq!(reader_hup.woke(), 1);
+
+        let (closing, peer) = StreamTransport::new_pair(1);
+        let peer_hup = observe(&peer, IoEvents::IN | IoEvents::RDHUP);
+        drop(closing);
+        assert_eq!(peer_hup.woke(), 1);
     }
 }

--- a/test-suit/starryos/qemu/system/bugfix-unix-stream-peer-wake/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-unix-stream-peer-wake/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-unix-stream-peer-wake C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bugfix-unix-stream-peer-wake src/main.c)
+target_include_directories(bugfix-unix-stream-peer-wake PRIVATE ../common)
+target_compile_options(bugfix-unix-stream-peer-wake PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-unix-stream-peer-wake RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-unix-stream-peer-wake/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-unix-stream-peer-wake/src/main.c
@@ -1,0 +1,152 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <fcntl.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+static int watch(int fd, uint32_t events)
+{
+    int epfd = epoll_create1(EPOLL_CLOEXEC);
+    if (epfd < 0)
+        return -1;
+    struct epoll_event event = {.events = events, .data.fd = fd};
+    if (epoll_ctl(epfd, EPOLL_CTL_ADD, fd, &event) != 0) {
+        close(epfd);
+        return -1;
+    }
+    return epfd;
+}
+
+static int wait_events(int epfd, int timeout_ms, uint32_t *events)
+{
+    struct epoll_event event = {0};
+    int n = epoll_wait(epfd, &event, 1, timeout_ms);
+    if (events)
+        *events = n == 1 ? event.events : 0;
+    return n;
+}
+
+static void drain_edges(int epfd)
+{
+    for (int i = 0; i < 8 && wait_events(epfd, 0, NULL) > 0; i++)
+        ;
+}
+
+static void set_nonblocking(int fd)
+{
+    fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK);
+}
+
+/*
+ * An edge-triggered reactor on one end of a stream socketpair must see an edge
+ * only when that end's own readiness changes. Linux wakes the peer on send and
+ * the writer when the peer frees buffer space; if both ends share one wait set,
+ * every send and recv also re-arms the caller's own edges and the reactor spins.
+ */
+static void test_io_wakes_only_the_peer(void)
+{
+    int sv[2];
+    CHECK_RET(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sv), 0, "create stream socketpair");
+    int a = sv[0], b = sv[1];
+
+    int a_out = watch(a, EPOLLOUT | EPOLLET);
+    int b_in = watch(b, EPOLLIN | EPOLLET);
+    int b_out = watch(b, EPOLLOUT | EPOLLET);
+    CHECK(a_out >= 0 && b_in >= 0 && b_out >= 0, "create edge-triggered watches");
+
+    CHECK_RET(wait_events(a_out, 0, NULL), 1, "writer reports its initial writable edge");
+    CHECK_RET(wait_events(b_out, 0, NULL), 1, "peer reports its initial writable edge");
+    CHECK_RET(wait_events(b_in, 0, NULL), 0, "peer has nothing to read yet");
+
+    CHECK_RET(write(a, "ping", 4), 4, "writer sends four bytes");
+
+    uint32_t events = 0;
+    CHECK_RET(wait_events(b_in, 1000, &events), 1, "peer gets a readable edge");
+    CHECK(events & EPOLLIN, "peer edge carries EPOLLIN");
+    CHECK_RET(wait_events(a_out, 0, NULL), 0, "send does not re-arm the writer's own writable edge");
+    CHECK_RET(wait_events(b_out, 0, NULL), 0, "incoming data does not re-arm the peer's writable edge");
+
+    char buf[4];
+    CHECK_RET(read(b, buf, sizeof(buf)), 4, "peer reads the four bytes");
+    CHECK_RET(wait_events(b_out, 0, NULL), 0, "recv does not re-arm the reader's own writable edge");
+
+    close(b_out);
+    close(b_in);
+    close(a_out);
+    close(a);
+    close(b);
+}
+
+/* Freeing buffer space must still wake the blocked writer through the peer. */
+static void test_peer_recv_wakes_full_writer(void)
+{
+    int sv[2];
+    CHECK_RET(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sv), 0, "create stream socketpair");
+    int a = sv[0], b = sv[1];
+    set_nonblocking(a);
+    set_nonblocking(b);
+
+    int a_out = watch(a, EPOLLOUT | EPOLLET);
+    CHECK(a_out >= 0, "watch the writer for writable edges");
+
+    char block[4096];
+    memset(block, 0x5a, sizeof(block));
+    long sent = 0;
+    for (;;) {
+        ssize_t n = write(a, block, sizeof(block));
+        if (n <= 0)
+            break;
+        sent += n;
+    }
+    CHECK(sent > 0 && errno == EAGAIN, "fill the writer until it would block");
+    drain_edges(a_out);
+
+    long got = 0;
+    for (;;) {
+        ssize_t n = read(b, block, sizeof(block));
+        if (n <= 0)
+            break;
+        got += n;
+    }
+    CHECK(got == sent, "peer drains everything that was sent");
+
+    uint32_t events = 0;
+    CHECK_RET(wait_events(a_out, 1000, &events), 1, "draining wakes the writer");
+    CHECK(events & EPOLLOUT, "writer edge carries EPOLLOUT");
+
+    close(a_out);
+    close(a);
+    close(b);
+}
+
+/* Closing the write half must reach the peer's waiters. */
+static void test_shutdown_wakes_peer(void)
+{
+    int sv[2];
+    CHECK_RET(socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, sv), 0, "create stream socketpair");
+    int a = sv[0], b = sv[1];
+
+    int b_hup = watch(b, EPOLLIN | EPOLLRDHUP | EPOLLET);
+    CHECK(b_hup >= 0, "watch the peer for hangup");
+    CHECK_RET(wait_events(b_hup, 0, NULL), 0, "peer starts with no events");
+
+    CHECK_RET(shutdown(a, SHUT_WR), 0, "writer shuts down its write half");
+    uint32_t events = 0;
+    CHECK_RET(wait_events(b_hup, 1000, &events), 1, "peer gets an edge for the shutdown");
+    CHECK(events & EPOLLRDHUP, "peer edge carries EPOLLRDHUP");
+
+    close(b_hup);
+    close(a);
+    close(b);
+}
+
+int main(void)
+{
+    TEST_START("unix stream socket I/O wakes only the peer endpoint");
+    test_io_wakes_only_the_peer();
+    test_peer_recv_wakes_full_writer();
+    test_shutdown_wakes_peer();
+    TEST_DONE();
+}


### PR DESCRIPTION
## 问题

已连接的 AF_UNIX stream socket 两端共享一个 `PollSet`，每次 `send`、`recv`、`shutdown`、drop 都唤醒它，发起方自己的等待者也被唤醒。边沿触发的事件循环（tokio、libuv）在状态没变时反复收到 EPOLLOUT，单核上空转。

Linux 每个 socket 有自己的等待队列：`unix_stream_sendmsg` 只唤醒对端的 `sk_data_ready`，写端的可写性在对端消费数据后经 `sk_write_space` 通知。

## 改动

- 每端一个等待集，`Channel` 新增 `peer_poll_update` 指向对端的等待集。
- `try_send` 只以 `IN` 唤醒对端；`try_recv` 消费数据后以 `OUT` 唤醒对端。
- 写半关闭、两半关闭后回收通道、drop 都唤醒对端；本端状态变化仍经 `poll_state` 唤醒本端。

## 回归测试

- host-test（`stream.rs`）：发送只唤醒对端读者；接收只唤醒对端写者；写半关闭与 drop 唤醒对端的 IN、RDHUP。
- 系统测试 `bugfix-unix-stream-peer-wake`：socketpair 加边沿触发 epoll，Linux 6.6 上 24 项全过。

修复前在 dev 187b306d 上运行（`stream.rs` 到 1d7f3c20 无改动），修复后在本分支上运行：

| 用例 | 修复前 | 修复后 |
|:--:|:--:|:--:|
| host-test `send_wakes_only_the_peer_reader` | 失败 | 通过 |
| host-test `recv_wakes_only_the_peer_writer` | 失败 | 通过 |
| host-test `write_shutdown_and_drop_wake_the_peer` | 通过 | 通过 |
| x86_64 QEMU `bugfix-unix-stream-peer-wake` | 21 过 3 挂 | 24 过 0 挂 |

## 验证

`cargo xtask clippy --since 1d7f3c20`、`cargo xtask test --since origin/dev` 全部通过。
