### PR TITLE
fix(axvisor): emit CRLF from shell output

### DIFF
--- a/os/axvisor/src/lib.rs
+++ b/os/axvisor/src/lib.rs
@@ -13,15 +13,18 @@ mod shell_fs;
 pub mod shell_support {
     use alloc::string::String;
 
-    /// Formats text submitted by the Axvisor shell.
+    /// Formats a text fragment submitted by the Axvisor shell.
+    pub fn format_fragment(args: core::fmt::Arguments<'_>) -> String {
+        alloc::fmt::format(args)
+    }
+
+    /// Formats a complete text line submitted by the Axvisor shell.
     ///
     /// The shared host-output queue preserves raw bytes because it also carries
     /// guest output. Shell-owned lines must therefore provide their own CRLF.
-    pub fn format_output(args: core::fmt::Arguments<'_>, newline: bool) -> String {
-        let mut output = alloc::fmt::format(args);
-        if newline {
-            output.push_str("\r\n");
-        }
+    pub fn format_line(args: core::fmt::Arguments<'_>) -> String {
+        let mut output = format_fragment(args);
+        output.push_str("\r\n");
         output
     }
 
@@ -35,19 +38,17 @@ pub mod shell_support {
 
     #[cfg(test)]
     mod tests {
-        use super::format_output;
+        use super::{format_fragment, format_line};
 
         #[test]
         fn shell_newline_is_a_terminal_crlf_sequence() {
-            assert_eq!(
-                format_output(format_args!("shell line"), true),
-                "shell line\r\n"
-            );
+            assert_eq!(format_line(format_args!("shell line")), "shell line\r\n");
+            assert_eq!(format_line(format_args!("")), "\r\n");
         }
 
         #[test]
         fn shell_fragment_has_no_implicit_line_ending() {
-            assert_eq!(format_output(format_args!("prompt: "), false), "prompt: ");
+            assert_eq!(format_fragment(format_args!("prompt: ")), "prompt: ");
         }
     }
 }

--- a/os/axvisor/src/lib.rs
+++ b/os/axvisor/src/lib.rs
@@ -8,14 +8,46 @@ pub mod console_mux;
 #[cfg(feature = "fs")]
 mod shell_fs;
 
-/// Shell filesystem operations shared by the Axvisor binary.
-#[cfg(feature = "fs")]
+/// Shell helpers shared by the Axvisor binary.
 #[doc(hidden)]
 pub mod shell_support {
+    use alloc::string::String;
+
+    /// Formats text submitted by the Axvisor shell.
+    ///
+    /// The shared host-output queue preserves raw bytes because it also carries
+    /// guest output. Shell-owned lines must therefore provide their own CRLF.
+    pub fn format_output(args: core::fmt::Arguments<'_>, newline: bool) -> String {
+        let mut output = alloc::fmt::format(args);
+        if newline {
+            output.push_str("\r\n");
+        }
+        output
+    }
+
+    #[cfg(feature = "fs")]
     pub use super::shell_fs::{
         CopyMode, RemoveOptions, collect_directory_entry_names, copy_after_rename_failure,
         copy_operands, copy_path, ensure_recursive_destination_outside_source, ignore_remove_error,
         metadata_for_remove, move_file_or_dir, path_basename, remove_path, touch_file,
         touch_file_at,
     };
+
+    #[cfg(test)]
+    mod tests {
+        use super::format_output;
+
+        #[test]
+        fn shell_newline_is_a_terminal_crlf_sequence() {
+            assert_eq!(
+                format_output(format_args!("shell line"), true),
+                "shell line\r\n"
+            );
+        }
+
+        #[test]
+        fn shell_fragment_has_no_implicit_line_ending() {
+            assert_eq!(format_output(format_args!("prompt: "), false), "prompt: ");
+        }
+    }
 }

--- a/os/axvisor/src/shell/mod.rs
+++ b/os/axvisor/src/shell/mod.rs
@@ -16,10 +16,7 @@ use std::io::prelude::*;
 use std::string::ToString;
 
 fn submit_shell_format(args: core::fmt::Arguments<'_>, newline: bool) {
-    let mut output = std::fmt::format(args);
-    if newline {
-        output.push('\n');
-    }
+    let output = axvisor::shell_support::format_output(args, newline);
     crate::guest_console::submit_host_bytes(output.as_bytes());
 }
 

--- a/os/axvisor/src/shell/mod.rs
+++ b/os/axvisor/src/shell/mod.rs
@@ -15,23 +15,28 @@
 use std::io::prelude::*;
 use std::string::ToString;
 
-fn submit_shell_format(args: core::fmt::Arguments<'_>, newline: bool) {
-    let output = axvisor::shell_support::format_output(args, newline);
+fn submit_shell_fragment(args: core::fmt::Arguments<'_>) {
+    let output = axvisor::shell_support::format_fragment(args);
+    crate::guest_console::submit_host_bytes(output.as_bytes());
+}
+
+fn submit_shell_line(args: core::fmt::Arguments<'_>) {
+    let output = axvisor::shell_support::format_line(args);
     crate::guest_console::submit_host_bytes(output.as_bytes());
 }
 
 macro_rules! print {
     ($($arg:tt)*) => {
-        crate::shell::submit_shell_format(format_args!($($arg)*), false)
+        crate::shell::submit_shell_fragment(format_args!($($arg)*))
     };
 }
 
 macro_rules! println {
     () => {
-        crate::shell::submit_shell_format(format_args!(""), true)
+        crate::shell::submit_shell_line(format_args!(""))
     };
     ($($arg:tt)*) => {
-        crate::shell::submit_shell_format(format_args!($($arg)*), true)
+        crate::shell::submit_shell_line(format_args!($($arg)*))
     };
 }
 


### PR DESCRIPTION
## 问题

AxVisor Shell 通过统一的主机控制台输出队列发送内容后，每行只以 LF（`\n`）结尾。

新的控制台输出线程会原样写出队列中的字节，不再自动执行 LF 到 CRLF 的转换。在串口终端中，LF 只会向下移动光标，不会将光标移回行首，因此进入 AxVisor Shell 后会出现提示符逐行向右偏移的问题：

```text
axvisor:/$
           axvisor:/$
                      axvisor:/$
```

公共输出队列同时承载 StarryOS、Zephyr 等客户机的原始串口数据，因此不能在公共输出线程中统一转换换行，否则可能将客户机已有的 CRLF 重复转换或改变原始输出。

## 修改

- 将 AxVisor Shell 自身产生的换行从 LF 改为 CRLF；
- 提取 Shell 输出格式化函数，使其可以通过主机单元测试验证；
- 保持不带换行的 `print!` 输出不变；
- 不修改公共控制台队列和客户机原始输出路径。

修复后的串口输出为：

```text
axvisor:/$
axvisor:/$
axvisor:/$
```

## 影响范围

该修改仅影响 AxVisor Shell 自身通过 `println!` 生成的文本，不改变：

- StarryOS、Linux、Zephyr 等客户机的串口输出；
- 客户机控制台切换逻辑；
- 公共输出队列的原始字节语义；
- 日志过滤和输出调度行为。

## 测试

- `cargo test -p axvisor --lib`：24/24 通过；
- Shell CRLF 单元测试：通过；
- 不带换行的 Shell 输出测试：通过；
- `cargo clippy -p axvisor --lib --tests -- -D warnings`：通过；
- `cargo fmt --all -- --check`：通过；
- `git diff --check`：通过；
- AArch64 QEMU 启动验证通过，串口实际输出匹配：

  ```text
  Welcome to AxVisor Shell!\r\n
  ```
