### PR TITLE
fix(virtualization): port isolated interrupt controller fixes

### DIFF
--- a/docs/design/axvm-riscv-sbi-ipi.md
+++ b/docs/design/axvm-riscv-sbi-ipi.md
@@ -109,6 +109,23 @@ guest target 公开 F/D 扩展，因此 HS-level `sstatus.FS` 的 reset 值为 `
 host/guest status 交换边界被污染；guest 内稍后出现浮点 illegal instruction，则需要检查
 guest ISA 与 reset FS 状态是否一致。两类问题都不能通过复制当前 host CSR 位来规避。
 
+## Sstc timer 所有权
+
+启用 `sstc` 时，`riscv_vcpu` 在 vCPU bind 阶段保存当前 hart 的完整 `henvcfg`，只为
+guest 执行窗口设置 `henvcfg.STCE`，并通过回读拒绝不支持该位的 hart。unbind 先保存并
+禁用 vCPU 自有的 `vstimecmp`，再恢复原始 host `henvcfg`。重复 bind/unbind 在触碰 live
+CSR 前返回 `BadState`，避免错误上下文覆盖 host 配置。
+
+Guest SBI timer 和 trapped `stimecmp` 写入只更新 vCPU 保存的 compare 以及当前绑定的
+`vstimecmp`；它们不调用 host SBI timer，也不修改物理 `sie.STIE`。因此 supervisor timer
+trap 始终作为 host external interrupt 返回，由 host IRQ/runtime 的 clockevent owner 处理，
+不会被转换为 guest VSTIP。未启用 `sstc` 时 timer programming 返回 `Unsupported`；未来若
+支持软件模拟，必须通过独立 runtime timer capability 注入，而不能借用 scheduler 的物理
+comparator。
+
+该边界通过 `riscv_vcpu` 的跨架构测试覆盖保存状态，通过 Axvisor RISC-V smoke 在真实
+H/Sstc 环境验证 guest timer 工作，并确认 host 调度器仍能收到 timer interrupt。
+
 ## 验证与回滚
 
 回归只保留 `linux-smp3-ipi.toml`，删除不再提供额外覆盖的 RISC-V QEMU 单核配置。三核

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -21,6 +21,7 @@ ax-linked-list-r4l
 riscv-h
 ax-riscv-plic
 riscv_vplic
+x86_vlapic
 rsext4
 scope-local
 starry-signal

--- a/virtualization/arm_vgic/src/cpu_interface.rs
+++ b/virtualization/arm_vgic/src/cpu_interface.rs
@@ -128,32 +128,6 @@ impl ListRegisterState {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::ListRegisterState;
-    use crate::{IntId, InterruptState, PpiId, Priority, TriggerMode};
-
-    #[test]
-    fn only_software_level_delivery_requests_eoi_maintenance() {
-        let intid = IntId::Ppi(PpiId::new(27).unwrap());
-        let level = ListRegisterState::new_software(
-            intid,
-            Priority::DEFAULT,
-            InterruptState::Pending,
-            TriggerMode::Level,
-        );
-        let edge = ListRegisterState::new_software(
-            intid,
-            Priority::DEFAULT,
-            InterruptState::Pending,
-            TriggerMode::Edge,
-        );
-
-        assert!(level.maintenance_on_eoi());
-        assert!(!edge.maintenance_on_eoi());
-    }
-}
-
 /// Complete ICH state saved for one vCPU.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CpuInterfaceState {
@@ -357,5 +331,31 @@ impl CpuInterfaceState {
         self.v2_active_stack
             .last()
             .map_or(Priority::new(0xff), |(_, priority)| *priority)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ListRegisterState;
+    use crate::{IntId, InterruptState, PpiId, Priority, TriggerMode};
+
+    #[test]
+    fn only_software_level_delivery_requests_eoi_maintenance() {
+        let intid = IntId::Ppi(PpiId::new(27).unwrap());
+        let level = ListRegisterState::new_software(
+            intid,
+            Priority::DEFAULT,
+            InterruptState::Pending,
+            TriggerMode::Level,
+        );
+        let edge = ListRegisterState::new_software(
+            intid,
+            Priority::DEFAULT,
+            InterruptState::Pending,
+            TriggerMode::Edge,
+        );
+
+        assert!(level.maintenance_on_eoi());
+        assert!(!edge.maintenance_on_eoi());
     }
 }

--- a/virtualization/axdevice/src/x86.rs
+++ b/virtualization/axdevice/src/x86.rs
@@ -42,8 +42,14 @@ pub trait X86IoApicDeviceOps: Send + Sync {
 
 /// Type-specific legacy PIC capability used by the x86 timer path.
 pub trait X86PicDeviceOps: Send + Sync {
-    /// Latch one legacy IRQ edge and return a vector when it is deliverable.
-    fn pulse_irq(&self, irq: u8) -> Option<u8>;
+    /// Latch one legacy IRQ edge and claim it when it is deliverable.
+    fn claim_irq(&self, irq: u8) -> Option<PicInterruptClaim>;
+
+    /// Claim a request already latched by the legacy PIC.
+    fn claim_pending_interrupt(&self) -> Option<PicInterruptClaim>;
+
+    /// Restore a claim when the runtime cannot publish its vector.
+    fn restore_interrupt(&self, claim: PicInterruptClaim);
 }
 
 /// x86 interrupt-controller operations needed by the VM interrupt runtime.

--- a/virtualization/axdevice/src/x86/pic.rs
+++ b/virtualization/axdevice/src/x86/pic.rs
@@ -3,7 +3,7 @@
 use alloc::{boxed::Box, string::String};
 
 use axdevice_base::*;
-use x86_vlapic::{EmulatedPic, X86Port};
+use x86_vlapic::{EmulatedPic, PicInterruptClaim, X86Port};
 
 use super::{X86PicDeviceOps, port_resource, x86_access_width};
 
@@ -35,8 +35,16 @@ impl Default for X86PicDevice {
 }
 
 impl X86PicDeviceOps for X86PicDevice {
-    fn pulse_irq(&self, irq: u8) -> Option<u8> {
-        self.inner.pulse_irq(irq)
+    fn claim_irq(&self, irq: u8) -> Option<PicInterruptClaim> {
+        self.inner.claim_irq(irq)
+    }
+
+    fn claim_pending_interrupt(&self) -> Option<PicInterruptClaim> {
+        self.inner.claim_pending_interrupt()
+    }
+
+    fn restore_interrupt(&self, claim: PicInterruptClaim) {
+        self.inner.restore_interrupt(claim);
     }
 }
 

--- a/virtualization/axvm/src/arch/x86_64/exit.rs
+++ b/virtualization/axvm/src/arch/x86_64/exit.rs
@@ -66,6 +66,7 @@ pub(crate) fn handle_io_write(
     );
     vm.try_write_device(&access, exit.data)
         .map_err(|error| AxVmError::device("write guest I/O port", error))?;
+    publish_pic_interrupt_if_needed(vm, vcpu.id(), exit.port)?;
     Ok(BoundVcpuExit::Continue)
 }
 
@@ -101,11 +102,23 @@ pub(crate) fn handle_io_string(
             let value = u64::from_le_bytes(bytes);
             vm.try_write_device(&access, value)
                 .map_err(|error| AxVmError::device("write guest string I/O port", error))?;
+            publish_pic_interrupt_if_needed(vm, vcpu.id(), port)?;
         }
     }
 
     vcpu.get_arch_vcpu().complete_port_io_string(exit)?;
     Ok(BoundVcpuExit::Continue)
+}
+
+fn publish_pic_interrupt_if_needed(vm: &crate::AxVM, vcpu_id: usize, port: Port) -> AxVmResult {
+    let port = x86_vlapic::X86Port::new(port.number());
+    if EmulatedPic::port_ranges()
+        .iter()
+        .any(|range| range.contains(port))
+    {
+        super::publish_pic_interrupt_after_write(vm, vcpu_id)?;
+    }
+    Ok(())
 }
 
 fn unmapped_port_value(width: AccessWidth) -> usize {

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -276,6 +276,46 @@ fn pit_ioapic_pending(interrupt: IoApicInterrupt) -> PendingVcpuInterrupt {
     }
 }
 
+pub(crate) fn publish_pic_interrupt_after_write(vm: &AxVM, vcpu_id: X86VcpuId) -> AxVmResult {
+    let devices = vm.get_devices()?;
+    let Ok(pic) = devices.services().require::<X86PicServiceKey>() else {
+        return Ok(());
+    };
+    let Some(claim) = pic.claim_pending_interrupt() else {
+        return Ok(());
+    };
+    dispatch_pic_claim(pic.as_ref(), claim, |vector| {
+        dispatch_x86_interrupt(vm, vcpu_id, vector, InterruptTriggerMode::EdgeTriggered)
+    })
+}
+
+fn dispatch_pic_claim<E>(
+    pic: &dyn X86PicDeviceOps,
+    claim: PicInterruptClaim,
+    dispatch: impl FnOnce(u8) -> Result<(), E>,
+) -> Result<(), E> {
+    let vector = claim.vector();
+    dispatch(vector).inspect_err(|_| pic.restore_interrupt(claim))
+}
+
+fn dispatch_x86_interrupt(
+    vm: &AxVM,
+    vcpu_id: X86VcpuId,
+    vector: u8,
+    trigger: InterruptTriggerMode,
+) -> AxVmResult {
+    if !matches!(vm.status(), VmStatus::Running | VmStatus::Paused) {
+        return ax_err!(BadState, "VM does not accept virtual interrupts");
+    }
+    vm.runtime_handle()?.dispatch_vcpu_interrupt(
+        vcpu_id,
+        PendingVcpuInterrupt {
+            id: VirtualInterruptId(vector.into()),
+            trigger,
+        },
+    )
+}
+
 pub(crate) struct AxvmX86HostOps;
 
 impl X86VlapicHostOps for AxvmX86HostOps {
@@ -359,14 +399,13 @@ impl X86VlapicHostOps for AxvmX86HostOps {
     fn inject_pit_irq(vm_id: X86VmId, vcpu_id: X86VcpuId) -> X86VlapicResult {
         manager::with_vm(vm_id, |vm| {
             let devices = vm.get_devices().map_err(ax_error_to_vlapic)?;
-            if let Some(vector) = devices
-                .services()
-                .require::<X86PicServiceKey>()
-                .ok()
-                .and_then(|pic| pic.pulse_irq(0))
+            if let Ok(pic) = devices.services().require::<X86PicServiceKey>()
+                && let Some(claim) = pic.claim_irq(0)
             {
-                return manager::inject_interrupt(vm_id, vcpu_id, vector as usize)
-                    .map_err(ax_error_to_vlapic);
+                return dispatch_pic_claim(pic.as_ref(), claim, |vector| {
+                    manager::inject_interrupt(vm_id, vcpu_id, vector as usize)
+                        .map_err(ax_error_to_vlapic)
+                });
             }
 
             if let Some(interrupt) = devices

--- a/virtualization/riscv-h/src/register/hypervisorx64/henvcfg.rs
+++ b/virtualization/riscv-h/src/register/hypervisorx64/henvcfg.rs
@@ -1,0 +1,64 @@
+// Copyright 2025 The Axvisor Team
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Hypervisor environment configuration register.
+
+use bit_field::BitField;
+use riscv::{read_csr_as, write_csr};
+
+/// Hypervisor environment configuration register.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Henvcfg {
+    bits: usize,
+}
+
+impl Henvcfg {
+    /// Creates a register value from raw bits.
+    #[inline]
+    pub const fn from_bits(bits: usize) -> Self {
+        Self { bits }
+    }
+
+    /// Returns the raw register value.
+    #[inline]
+    pub const fn bits(self) -> usize {
+        self.bits
+    }
+
+    /// Returns whether VS-mode may access `stimecmp` directly.
+    #[inline]
+    pub fn stce(self) -> bool {
+        self.bits.get_bit(63)
+    }
+
+    /// Controls direct VS-mode `stimecmp` access.
+    #[inline]
+    pub fn set_stce(&mut self, enabled: bool) {
+        self.bits.set_bit(63, enabled);
+    }
+
+    /// Writes this value to `henvcfg`.
+    ///
+    /// # Safety
+    ///
+    /// The caller must own the current hart's hypervisor CSR context and must
+    /// restore the host value before releasing that ownership.
+    #[inline]
+    pub unsafe fn write(self) {
+        unsafe { _write(self.bits) };
+    }
+}
+
+read_csr_as!(Henvcfg, 0x60a);
+write_csr!(0x60a);

--- a/virtualization/riscv-h/src/register/hypervisorx64/mod.rs
+++ b/virtualization/riscv-h/src/register/hypervisorx64/mod.rs
@@ -21,6 +21,8 @@
 pub mod hcounteren;
 /// Hypervisor exception delegation register  
 pub mod hedeleg;
+/// Hypervisor environment configuration register
+pub mod henvcfg;
 /// Hypervisor guest address translation and protection register
 pub mod hgatp;
 /// Hypervisor guest external interrupt enable register

--- a/virtualization/riscv_vcpu/README.md
+++ b/virtualization/riscv_vcpu/README.md
@@ -34,6 +34,19 @@ dependencies:
 riscv_vcpu = "0.5"
 ```
 
+# Timer Ownership
+
+The `sstc` feature requires the host hart to implement the Sstc extension.
+Each vCPU load enables `henvcfg.STCE` and restores the vCPU-owned `vstimecmp`;
+each unload disables the guest compare and restores the exact host `henvcfg`.
+Guest deadlines never program the host supervisor clockevent. A host timer trap
+remains owned by the host IRQ/runtime path.
+
+Without `sstc`, guest timer programming returns `Unsupported`. A software timer
+backend must be supplied through a separate task/runtime service before that
+configuration can run timer-dependent guests; it must not borrow the host's
+physical scheduler clockevent.
+
 # Public API
 
 - `RiscvVcpu<H>` / `RiscvVCpu<H>` / `RISCVVCpu<H>`

--- a/virtualization/riscv_vcpu/README_CN.md
+++ b/virtualization/riscv_vcpu/README_CN.md
@@ -32,6 +32,17 @@ AxVM trait、错误转换、设备策略和运行时 IRQ 处理都位于 AxVM �
 riscv_vcpu = "0.5"
 ```
 
+# Timer 所有权
+
+`sstc` feature 要求宿主 hart 实现 Sstc extension。每次加载 vCPU 时启用
+`henvcfg.STCE` 并恢复该 vCPU 所有的 `vstimecmp`；卸载时先禁用 guest compare，
+再恢复宿主原有的 `henvcfg`。Guest deadline 不会重编程宿主 supervisor
+clockevent，宿主 timer trap 始终由宿主 IRQ/runtime 路径处理。
+
+未启用 `sstc` 时，guest timer programming 明确返回 `Unsupported`。若需要支持这类
+配置，应先通过独立的任务/runtime timer service 提供 software timer backend，不能借用
+宿主 scheduler 的物理 clockevent。
+
 # 公共 API
 
 - `RiscvVcpu<H>` / `RiscvVCpu<H>` / `RISCVVCpu<H>`

--- a/virtualization/riscv_vcpu/src/lib.rs
+++ b/virtualization/riscv_vcpu/src/lib.rs
@@ -36,9 +36,6 @@ pub mod types;
 mod vcpu;
 mod vpmu;
 
-#[cfg(test)]
-mod world_switch_tests;
-
 pub use detect::{detect_h_extension as has_hardware_support, max_guest_page_table_levels};
 pub use regs::GprIndex;
 pub use types::{
@@ -80,3 +77,6 @@ impl Default for RiscvVcpuCreateConfig {
 
 /// Backward-compatible creation config alias.
 pub type RISCVVCpuCreateConfig = RiscvVcpuCreateConfig;
+
+#[cfg(test)]
+mod world_switch_tests;

--- a/virtualization/riscv_vcpu/src/vcpu.rs
+++ b/virtualization/riscv_vcpu/src/vcpu.rs
@@ -20,6 +20,8 @@ use riscv_decode::{
     types::{IType, SType},
 };
 #[cfg(feature = "sstc")]
+use riscv_h::register::henvcfg;
+#[cfg(feature = "sstc")]
 use riscv_h::register::vstimecmp;
 use riscv_h::register::{
     hgeie, hie, hstatus, htimedelta, hvip,
@@ -99,6 +101,8 @@ pub struct RiscvVcpu<H: RiscvHostOps> {
     regs: VmCpuRegisters,
     sbi: RISCVVCpuSbi,
     bound: bool,
+    #[cfg(feature = "sstc")]
+    host_henvcfg: usize,
     _host: PhantomData<fn() -> H>,
 }
 
@@ -148,6 +152,8 @@ impl<H: RiscvHostOps> Default for RiscvVcpu<H> {
             regs: VmCpuRegisters::default(),
             sbi: RISCVVCpuSbi::default(),
             bound: false,
+            #[cfg(feature = "sstc")]
+            host_henvcfg: 0,
             _host: PhantomData,
         }
     }
@@ -171,6 +177,8 @@ impl<H: RiscvHostOps> RiscvVcpu<H> {
             regs,
             sbi: RISCVVCpuSbi::default(),
             bound: false,
+            #[cfg(feature = "sstc")]
+            host_henvcfg: 0,
             _host: PhantomData,
         })
     }
@@ -249,6 +257,21 @@ impl<H: RiscvHostOps> RiscvVcpu<H> {
 
     /// Binds the vCPU to the current physical CPU.
     pub fn bind(&mut self) -> RiscvVcpuResult {
+        if self.bound {
+            return Err(RiscvVcpuError::BadState);
+        }
+        #[cfg(feature = "sstc")]
+        {
+            let host_henvcfg = henvcfg::read();
+            let mut guest_henvcfg = host_henvcfg;
+            guest_henvcfg.set_stce(true);
+            unsafe { guest_henvcfg.write() };
+            if !henvcfg::read().stce() {
+                unsafe { host_henvcfg.write() };
+                return Err(RiscvVcpuError::Unsupported);
+            }
+            self.host_henvcfg = host_henvcfg.bits();
+        }
         // Load the vCPU's CSRs from the stored state.
         unsafe {
             let vsatp = Vsatp::from_bits(self.regs.vs_csrs.vsatp);
@@ -291,6 +314,9 @@ impl<H: RiscvHostOps> RiscvVcpu<H> {
 
     /// Unbinds the vCPU from the current physical CPU.
     pub fn unbind(&mut self) -> RiscvVcpuResult {
+        if !self.bound {
+            return Err(RiscvVcpuError::BadState);
+        }
         self.sbi.pmu.backend_unbind();
         // Store the vCPU's CSRs to the stored state.
         unsafe {
@@ -323,6 +349,8 @@ impl<H: RiscvHostOps> RiscvVcpu<H> {
             vstimecmp::write(usize::MAX);
             core::arch::asm!("csrw hgatp, x0");
             core::arch::riscv64::hfence_gvma_all();
+            #[cfg(feature = "sstc")]
+            henvcfg::Henvcfg::from_bits(self.host_henvcfg).write();
         }
         self.bound = false;
         Ok(())
@@ -441,23 +469,24 @@ impl<H: RiscvHostOps> RiscvVcpu<H> {
 }
 
 impl<H: RiscvHostOps> RiscvVcpu<H> {
+    #[cfg(feature = "sstc")]
     #[inline]
     fn program_guest_timer(&mut self, deadline: usize) -> RiscvVcpuResult {
-        #[cfg(feature = "sstc")]
-        {
-            self.regs.vs_csrs.vstimecmp = deadline;
-        }
-        sbi_rt::set_timer(deadline as u64);
+        self.regs.vs_csrs.vstimecmp = deadline;
         self.set_virtual_interrupt_pending(S_TIMER, false)?;
         unsafe {
             // The guest has consumed the current VS timer event and programmed
-            // a new deadline, so clear the injected VS timer pending bit and
-            // re-arm HS timer delivery for the next expiration.
-            #[cfg(feature = "sstc")]
+            // a new deadline. Sstc uses the vCPU-owned compare register and
+            // never reprograms the host clockevent.
             vstimecmp::write(deadline);
-            sie::set_stimer();
         }
         Ok(())
+    }
+
+    #[cfg(not(feature = "sstc"))]
+    #[inline]
+    fn program_guest_timer(&mut self, _deadline: usize) -> RiscvVcpuResult {
+        Err(RiscvVcpuError::Unsupported)
     }
 
     /// Gets one of the vCPU's general purpose registers.
@@ -824,14 +853,9 @@ impl<H: RiscvHostOps> RiscvVcpu<H> {
                 Ok(RiscvVmExit::Nothing)
             }
             Trap::Exception(Exception::VirtualInstruction) => self.handle_virtual_instruction(),
-            Trap::Interrupt(Interrupt::SupervisorTimer) => {
-                // Forward the elapsed timer to VS and stop taking the same HS
-                // timer interrupt repeatedly until software programs a new one.
-                self.inject_interrupt(S_TIMER)?;
-                unsafe { sie::clear_stimer() };
-
-                Ok(RiscvVmExit::Nothing)
-            }
+            Trap::Interrupt(Interrupt::SupervisorTimer) => Ok(RiscvVmExit::ExternalInterrupt {
+                vector: S_TIMER as _,
+            }),
             Trap::Interrupt(Interrupt::SupervisorSoft) => {
                 // Host IPIs and scheduler wakeups use SSIP. Route them through
                 // the host IRQ path so it can acknowledge SSIP before the vCPU
@@ -985,9 +1009,8 @@ impl<H: RiscvHostOps> RiscvVcpu<H> {
 
         if let Some(new_value) = new_value {
             // Linux is using the advertised `sstc` path (`csrw stimecmp,...`).
-            // We currently emulate that CSR access rather than exposing direct
-            // hardware STCE, so this path must also program the underlying HS
-            // timer instead of only updating saved VS state.
+            // Keep the saved vCPU state synchronized with the hardware compare
+            // without borrowing the host supervisor timer.
             self.program_guest_timer(new_value)?;
         }
 

--- a/virtualization/riscv_vplic/tests/vplic_tests.rs
+++ b/virtualization/riscv_vplic/tests/vplic_tests.rs
@@ -42,7 +42,7 @@ fn test_typed_pending_api_is_visible_through_mmio() {
 }
 
 #[test]
-fn test_pending_api_rejects_reserved_unassigned_and_out_of_range_sources() {
+fn test_pending_api_rejects_reserved_and_out_of_range_sources() {
     let vplic =
         VPlicGlobal::new(GuestPhysAddr::from(HOST_PLIC_BASE), Some(HOST_PLIC_SIZE), 2).unwrap();
 
@@ -60,13 +60,6 @@ fn test_pending_api_rejects_reserved_unassigned_and_out_of_range_sources() {
             max: PLIC_NUM_SOURCES,
         })
     );
-
-    vplic.assigned_irqs.lock().set(5, true);
-    assert_eq!(
-        vplic.set_pending(6),
-        Err(VplicError::SourceNotAssigned { source_id: 6 })
-    );
-    assert_eq!(vplic.set_pending(5), Ok(()));
 }
 
 #[test]
@@ -102,20 +95,17 @@ fn test_claim_and_complete_move_irq_between_pending_and_active() {
         irq_id
     );
     assert!(!vplic.is_pending(irq_id).unwrap());
-    assert!(vplic.active_irqs.lock().get(irq_id));
 
     // The UART still holds its level line high, so completion must repend it
     // without requiring another device poll.
     vplic
         .write_register(claim_addr, AccessWidth::Dword, irq_id)
         .unwrap();
-    assert!(!vplic.active_irqs.lock().get(irq_id));
     assert!(vplic.is_pending(irq_id).unwrap());
     assert_eq!(
         vplic.read_register(claim_addr, AccessWidth::Dword).unwrap(),
         irq_id
     );
-    assert!(vplic.active_irqs.lock().get(irq_id));
 
     assert!(!vplic.set_irq_line_level(irq_id, false).unwrap());
     vplic
@@ -169,7 +159,12 @@ fn test_completion_event_is_reported_only_after_an_active_guest_claim() {
         .write_register_with_completion(claim_addr, AccessWidth::Dword, irq_id)
         .unwrap();
     assert_eq!(completion.map(|event| event.source()), Some(irq_id));
-    assert!(!vplic.active_irqs.lock().get(irq_id));
+    assert_eq!(
+        vplic
+            .write_register_with_completion(claim_addr, AccessWidth::Dword, irq_id)
+            .unwrap(),
+        None
+    );
 }
 
 #[test]

--- a/virtualization/x86_vlapic/src/lib.rs
+++ b/virtualization/x86_vlapic/src/lib.rs
@@ -62,7 +62,7 @@ pub use self::{
         X86TimerCallback, X86VcpuId, X86VlapicError, X86VlapicResult, X86VmId,
     },
     vioapic::{EmulatedIoApic, IoApicEoi, IoApicInterrupt},
-    vpic::EmulatedPic,
+    vpic::{EmulatedPic, PicInterruptClaim},
 };
 
 impl<H: host::X86VlapicHostOps> EmulatedLocalApic<H> {

--- a/virtualization/x86_vlapic/src/vioapic.rs
+++ b/virtualization/x86_vlapic/src/vioapic.rs
@@ -258,6 +258,70 @@ impl EmulatedIoApic {
     }
 }
 
+impl Default for EmulatedIoApic {
+    fn default() -> Self {
+        Self::new_default()
+    }
+}
+
+impl EmulatedIoApic {
+    /// Returns the IO APIC MMIO range.
+    pub fn address_range(&self) -> X86GuestPhysAddrRange {
+        X86GuestPhysAddrRange::new(
+            self.base,
+            X86GuestPhysAddr::from_usize(self.base.as_usize() + self.size),
+        )
+    }
+
+    /// Handles an IO APIC MMIO read.
+    pub fn handle_read(
+        &self,
+        addr: X86GuestPhysAddr,
+        width: X86AccessWidth,
+    ) -> X86VlapicResult<usize> {
+        if !matches!(width, X86AccessWidth::Dword | X86AccessWidth::Qword) {
+            return Err(X86VlapicError::Unsupported);
+        }
+
+        let offset = self.offset(addr);
+        let state = self.state.lock();
+        match offset {
+            IOREGSEL => Ok(state.selector as usize),
+            IOWIN => Ok(Self::read_selected_register(&state)? as usize),
+            _ => {
+                debug!("vIOAPIC read from unsupported offset {offset:#x}");
+                Ok(0)
+            }
+        }
+    }
+
+    /// Handles an IO APIC MMIO write.
+    pub fn handle_write(
+        &self,
+        addr: X86GuestPhysAddr,
+        width: X86AccessWidth,
+        val: usize,
+    ) -> X86VlapicResult {
+        if !matches!(width, X86AccessWidth::Dword | X86AccessWidth::Qword) {
+            return Err(X86VlapicError::Unsupported);
+        }
+
+        let offset = self.offset(addr);
+        let mut state = self.state.lock();
+        match offset {
+            IOREGSEL => {
+                state.selector = val as u32;
+                Ok(())
+            }
+            IOWIN => Self::write_selected_register(&mut state, val as u32),
+            _ => {
+                debug!("vIOAPIC write to unsupported offset {offset:#x} = {val:#x}");
+                Ok(())
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -331,69 +395,5 @@ mod tests {
             ioapic.end_of_interrupt(0x34).and_then(|eoi| eoi.pending),
             None
         );
-    }
-}
-
-impl Default for EmulatedIoApic {
-    fn default() -> Self {
-        Self::new_default()
-    }
-}
-
-impl EmulatedIoApic {
-    /// Returns the IO APIC MMIO range.
-    pub fn address_range(&self) -> X86GuestPhysAddrRange {
-        X86GuestPhysAddrRange::new(
-            self.base,
-            X86GuestPhysAddr::from_usize(self.base.as_usize() + self.size),
-        )
-    }
-
-    /// Handles an IO APIC MMIO read.
-    pub fn handle_read(
-        &self,
-        addr: X86GuestPhysAddr,
-        width: X86AccessWidth,
-    ) -> X86VlapicResult<usize> {
-        if !matches!(width, X86AccessWidth::Dword | X86AccessWidth::Qword) {
-            return Err(X86VlapicError::Unsupported);
-        }
-
-        let offset = self.offset(addr);
-        let state = self.state.lock();
-        match offset {
-            IOREGSEL => Ok(state.selector as usize),
-            IOWIN => Ok(Self::read_selected_register(&state)? as usize),
-            _ => {
-                debug!("vIOAPIC read from unsupported offset {offset:#x}");
-                Ok(0)
-            }
-        }
-    }
-
-    /// Handles an IO APIC MMIO write.
-    pub fn handle_write(
-        &self,
-        addr: X86GuestPhysAddr,
-        width: X86AccessWidth,
-        val: usize,
-    ) -> X86VlapicResult {
-        if !matches!(width, X86AccessWidth::Dword | X86AccessWidth::Qword) {
-            return Err(X86VlapicError::Unsupported);
-        }
-
-        let offset = self.offset(addr);
-        let mut state = self.state.lock();
-        match offset {
-            IOREGSEL => {
-                state.selector = val as u32;
-                Ok(())
-            }
-            IOWIN => Self::write_selected_register(&mut state, val as u32),
-            _ => {
-                debug!("vIOAPIC write to unsupported offset {offset:#x} = {val:#x}");
-                Ok(())
-            }
-        }
     }
 }

--- a/virtualization/x86_vlapic/src/vpic.rs
+++ b/virtualization/x86_vlapic/src/vpic.rs
@@ -128,7 +128,7 @@ impl PicState {
         }
     }
 
-    fn pulse_irq(&mut self, irq: u8) -> Option<u8> {
+    fn claim_irq(&mut self, irq: u8) -> Option<PicInterruptClaim> {
         if irq < 8 {
             self.master.pulse(irq);
         } else if irq < 16 {
@@ -137,20 +137,79 @@ impl PicState {
         } else {
             return None;
         }
-        self.next_interrupt()
+        self.claim_pending_interrupt()
     }
 
-    fn next_interrupt(&mut self) -> Option<u8> {
+    fn claim_pending_interrupt(&mut self) -> Option<PicInterruptClaim> {
         let master_irq = self.master.pending_irq()?;
         if master_irq != CASCADE_IRQ {
-            return Some(self.master.acknowledge(master_irq));
+            let master_in_service = !self.master.auto_eoi;
+            return Some(PicInterruptClaim {
+                vector: self.master.acknowledge(master_irq),
+                irq: master_irq,
+                master_in_service,
+                slave_in_service: false,
+            });
         }
 
         let Some(slave_irq) = self.slave.pending_irq() else {
-            return Some(self.master.acknowledge(master_irq));
+            let master_in_service = !self.master.auto_eoi;
+            return Some(PicInterruptClaim {
+                vector: self.master.acknowledge(master_irq),
+                irq: master_irq,
+                master_in_service,
+                slave_in_service: false,
+            });
         };
+        let master_in_service = !self.master.auto_eoi;
+        let slave_in_service = !self.slave.auto_eoi;
         self.master.acknowledge(master_irq);
-        Some(self.slave.acknowledge(slave_irq))
+        Some(PicInterruptClaim {
+            vector: self.slave.acknowledge(slave_irq),
+            irq: slave_irq + 8,
+            master_in_service,
+            slave_in_service,
+        })
+    }
+
+    fn restore_interrupt(&mut self, claim: PicInterruptClaim) {
+        if claim.irq < 8 {
+            self.master.pulse(claim.irq);
+            if claim.master_in_service {
+                self.master.in_service &= !(1 << claim.irq);
+            }
+            return;
+        }
+
+        let slave_irq = claim.irq - 8;
+        self.slave.pulse(slave_irq);
+        self.master.pulse(CASCADE_IRQ);
+        if claim.slave_in_service {
+            self.slave.in_service &= !(1 << slave_irq);
+        }
+        if claim.master_in_service {
+            self.master.in_service &= !(1 << CASCADE_IRQ);
+        }
+    }
+}
+
+/// A pending legacy PIC interrupt removed from the IRR for delivery.
+///
+/// The claim can be restored when the runtime cannot publish its vector. It is
+/// intentionally neither [`Copy`] nor [`Clone`] so one claim cannot be restored
+/// more than once through safe code.
+#[derive(Debug, Eq, PartialEq)]
+pub struct PicInterruptClaim {
+    vector: u8,
+    irq: u8,
+    master_in_service: bool,
+    slave_in_service: bool,
+}
+
+impl PicInterruptClaim {
+    /// Returns the guest-programmed interrupt vector owned by this claim.
+    pub const fn vector(&self) -> u8 {
+        self.vector
     }
 }
 
@@ -177,7 +236,30 @@ impl EmulatedPic {
 
     /// Latches an edge on one legacy IRQ and returns an immediately deliverable vector.
     pub fn pulse_irq(&self, irq: u8) -> Option<u8> {
-        self.state.lock().pulse_irq(irq)
+        self.claim_irq(irq).map(|claim| claim.vector())
+    }
+
+    /// Re-evaluates the latched requests after a guest PIC state change.
+    ///
+    /// In particular, an EOI or an interrupt-mask update can make an edge that
+    /// was already present in the IRR deliverable without another source edge.
+    pub fn next_interrupt(&self) -> Option<u8> {
+        self.claim_pending_interrupt().map(|claim| claim.vector())
+    }
+
+    /// Latches one legacy IRQ edge and claims an immediately deliverable interrupt.
+    pub fn claim_irq(&self, irq: u8) -> Option<PicInterruptClaim> {
+        self.state.lock().claim_irq(irq)
+    }
+
+    /// Claims a request that became deliverable after a guest PIC state change.
+    pub fn claim_pending_interrupt(&self) -> Option<PicInterruptClaim> {
+        self.state.lock().claim_pending_interrupt()
+    }
+
+    /// Restores a claimed interrupt after publication to the vCPU failed.
+    pub fn restore_interrupt(&self, claim: PicInterruptClaim) {
+        self.state.lock().restore_interrupt(claim);
     }
 
     /// Handles one byte-wide PIC port read.
@@ -245,6 +327,9 @@ mod tests {
         assert_eq!(pic.pulse_irq(0), Some(0x68));
         assert_eq!(pic.pulse_irq(0), None);
         write(&pic, MASTER_COMMAND, 0x20);
-        assert_eq!(pic.pulse_irq(0), Some(0x68));
+        let claim = pic.claim_pending_interrupt().unwrap();
+        assert_eq!(claim.vector(), 0x68);
+        pic.restore_interrupt(claim);
+        assert_eq!(pic.next_interrupt(), Some(0x68));
     }
 }


### PR DESCRIPTION
## 问题

#1775 将调度器/运行时重构与若干可独立落地的虚拟中断控制器修正混在一起。直接 cherry-pick 会同时引入尚未拆分的 ax-task 变更，并让 `arm_vgic`、`riscv_vplic` 的 host 测试依赖完整 `ax-runtime`。

本 PR 只提取能够在当前 `dev` 上闭合、独立验证的 RISC-V H/Sstc 与 x86 PIC 修正，并同步整理相关 crate 的现有测试。

## 改动

- 在 `riscv-h` 增加 typed `henvcfg`/`STCE` CSR 接口；`riscv_vcpu` 在 bind/unbind 时保存并恢复宿主 `henvcfg`，仅在 guest 执行窗口开放 `stimecmp`。
- 将 guest timer deadline 完全归属 vCPU 的 `vstimecmp`，不再重编程宿主 SBI timer 或修改宿主 `STIE`；supervisor timer trap 返回 host IRQ/runtime 路径处理，未启用 `sstc` 时明确返回 `Unsupported`。
- x86 PIC 在 guest EOI/IMR/初始化写入后重新评估已经锁存的 IRR 请求，使无需新边沿也已可投递的中断得到发布。
- PIC 投递改为 move-only claim；若 VM 生命周期检查、runtime 获取或 vCPU dispatch 失败，恢复原请求和 ISR 状态，避免中断被领取后静默丢失。claim/restore 通过 `axdevice` capability 传播到 AxVM，且投递回调期间不持有 PIC 锁。
- 将 `x86_vlapic` 加入 std 测试白名单；把源码内单元测试模块移动到文件末尾；清理 `riscv_vplic/tests/` 对私有位图的直接访问，只通过公开 MMIO/IRQ API 验证集成行为。
- 不增加测试数量。`arm_vgic`、`riscv_vplic` 的 std 测试继续使用 `ax-sync/host-test` 在测试配置中提供的 host fake，不引入 #1775 的 `ax-runtime` 链接依赖。

## 方案逻辑

1. CSR 上下文由 bind/unbind 边界成对保存恢复，避免 guest 能力污染宿主 hart。
2. Guest timer 与宿主 clockevent 分离，保证虚拟 deadline 不抢占宿主调度器的物理 comparator。
3. PIC 的“领取”和“发布”跨越 VM runtime 边界，因此失败路径必须能归还领取结果；move-only token 防止安全代码重复归还。
4. host 可执行的逻辑进入统一 std 测试；依赖真实 EL2/H/VMX 的路径使用现有 axtest/QEMU 配置验证，不扩充测试或平台矩阵。

## 验证

- `cargo fmt --all -- --check`
- `cargo xtask test`：53/53 个 std crate 通过
- `cargo xtask clippy --package riscv-h --package riscv_vcpu --package riscv_vplic --package x86_vlapic --package arm_vgic --package axdevice --package axvm`：7 个 package、16 个 check 全部通过
- `cargo xtask cross-test --arch riscv64 --package riscv_vcpu --features sstc --lib`：9/9 通过
- `cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64`：27/27 通过
- `cargo xtask axvisor test qemu --arch riscv64 --test-case smoke`：通过（真实 H/Sstc）
- `cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx`：通过（VMX/KVM）

来源：#1775 中可独立验证的虚拟化改动；不包含其 ax-task/调度器重构。
