### PR TITLE
fix(axvisor): preserve structured console output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,6 +1326,7 @@ dependencies = [
  "libc",
  "log",
  "object 0.38.1",
+ "os_pipe",
  "ostool",
  "proc-macro2",
  "quote",
@@ -5573,6 +5574,16 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs/docs/architecture/axvisor/guest-console.md
+++ b/docs/docs/architecture/axvisor/guest-console.md
@@ -68,7 +68,7 @@ flowchart LR
 形成两个 reader 拆分输入流。
 
 日志订阅只在完整 record 边界切换。shell 未附着 guest 时，mux 先清除当前编辑行、输出宿主
-日志，再重画 prompt、内容和光标；guest 位于前台时，宿主日志按完整记录进入 16 KiB 有界
+日志，再重画 prompt、内容和光标；guest 位于前台时，宿主日志按完整记录进入 2 MiB 有界
 backlog，返回管理 shell 后再回放。底层 64 条 record 队列和 mux backlog 的溢出都以摘要
 报告，不把宿主日志字节注入 guest 虚拟 UART。
 

--- a/os/arceos/modules/axlog/src/lib.rs
+++ b/os/arceos/modules/axlog/src/lib.rs
@@ -191,22 +191,34 @@ impl Log for Logger {
 
         cfg_if::cfg_if! {
             if #[cfg(feature = "std")] {
-                publish_fmt(RecordMeta::log(), with_color!(
-                    ColorCode::White,
-                    "[{time} {path}:{line}] {args}\n",
-                    time = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.6f"),
-                    path = path,
-                    line = line,
-                    args = with_color!(args_color, "{}", record.args()),
-                ));
+                publish_fmt(
+                    RecordMeta::log(),
+                    format_args!(
+                        "{}\n",
+                        with_color!(
+                            ColorCode::White,
+                            "[{time} {path}:{line}] {args}",
+                            time = chrono::Local::now().format("%Y-%m-%d %H:%M:%S%.6f"),
+                            path = path,
+                            line = line,
+                            args = with_color!(args_color, "{}", record.args()),
+                        )
+                    ),
+                );
             } else {
-                publish_fmt(RecordMeta::log(), with_color!(
-                    ColorCode::White,
-                    "{path}:{line}] {args}\n",
-                    path = path,
-                    line = line,
-                    args = with_color!(args_color, "{}", record.args()),
-                ));
+                publish_fmt(
+                    RecordMeta::log(),
+                    format_args!(
+                        "{}\n",
+                        with_color!(
+                            ColorCode::White,
+                            "{path}:{line}] {args}",
+                            path = path,
+                            line = line,
+                            args = with_color!(args_color, "{}", record.args()),
+                        )
+                    ),
+                );
             }
         }
     }
@@ -270,7 +282,29 @@ pub fn set_max_level(level: &str) {
 
 #[cfg(test)]
 mod tests {
+    extern crate std;
+
+    use std::format;
+
     use super::*;
+
+    #[test]
+    fn structured_log_resets_color_before_the_terminal_newline() {
+        let rendered = format!(
+            "{}",
+            format_args!(
+                "{}\n",
+                with_color!(
+                    ColorCode::White,
+                    "module:7] {}",
+                    with_color!(ColorCode::Green, "message")
+                )
+            )
+        );
+
+        assert!(rendered.ends_with("\u{1b}[m\n"));
+        assert!(!rendered.contains("\n\u{1b}[m"));
+    }
 
     #[test]
     fn metadata_distinguishes_prints_from_structured_logs() {

--- a/os/arceos/modules/axruntime/src/console.rs
+++ b/os/arceos/modules/axruntime/src/console.rs
@@ -12,7 +12,13 @@ use ax_sync::Mutex;
 use axpoll::PollSet;
 
 pub use crate::serial::RxItem;
-use crate::{RuntimeError, RuntimeResult, raw_console::RawConsoleInput, serial, sync::SpinLock};
+use crate::{
+    RuntimeError, RuntimeResult,
+    raw_console::RawConsoleInput,
+    serial,
+    structured_log::{RuntimeLogContext, write_record},
+    sync::SpinLock,
+};
 
 static ACTIVATION: OnceLock<ConsoleActivation> = OnceLock::new();
 static TTY_NUMBERS: OnceLock<Box<[Option<usize>]>> = OnceLock::new();
@@ -236,6 +242,8 @@ pub fn subscribe_logs() -> RuntimeResult<ConsoleLogSubscription> {
 /// UART exists. Failed-closed ownership consumes the record without touching
 /// the former early console.
 pub(crate) fn try_publish_without_runtime(
+    meta: ax_log::RecordMeta,
+    context: RuntimeLogContext,
     args: fmt::Arguments<'_>,
 ) -> Option<ax_log::PublishStatus> {
     match activation()? {
@@ -243,7 +251,7 @@ pub(crate) fn try_publish_without_runtime(
             // Logging can run on a secondary CPU before its scheduler has
             // installed a current task, or from interrupt context. A
             // sleepable mutex is therefore never a valid record arbiter.
-            Some(publish_raw_record(args, &mut RawHalWriter))
+            Some(publish_raw_record(meta, context, args, &mut RawHalWriter))
         }
         ConsoleActivation::Active { .. } | ConsoleActivation::FailedClosed(_) => {
             Some(ax_log::PublishStatus::Dropped)
@@ -251,11 +259,16 @@ pub(crate) fn try_publish_without_runtime(
     }
 }
 
-fn publish_raw_record(args: fmt::Arguments<'_>, writer: &mut impl Write) -> ax_log::PublishStatus {
+fn publish_raw_record(
+    meta: ax_log::RecordMeta,
+    context: RuntimeLogContext,
+    args: fmt::Arguments<'_>,
+    writer: &mut impl Write,
+) -> ax_log::PublishStatus {
     let Some(_hardware) = RAW_HARDWARE_LOCK.try_lock_irqsave() else {
         return ax_log::PublishStatus::Dropped;
     };
-    if writer.write_fmt(args).is_ok() {
+    if write_record(writer, meta, context, args).is_ok() {
         ax_log::PublishStatus::Published
     } else {
         ax_log::PublishStatus::Dropped
@@ -564,7 +577,7 @@ mod tests {
         inactive_console_error, output, publish_raw_record, raw_hal_activation, select_candidate,
         take_input,
     };
-    use crate::RuntimeError;
+    use crate::{RuntimeError, structured_log::RuntimeLogContext};
 
     #[test]
     fn tty_numbering_preserves_aliases_and_fills_gaps() {
@@ -670,9 +683,17 @@ mod tests {
         let mut rendered = alloc::string::String::new();
 
         assert_eq!(
-            publish_raw_record(format_args!("early secondary record"), &mut rendered),
+            publish_raw_record(
+                ax_log::RecordMeta::log(),
+                RuntimeLogContext::new(core::time::Duration::new(12, 345_678_000), Some(2), None),
+                format_args!("\u{1b}[37max_runtime:462] early secondary record\n"),
+                &mut rendered,
+            ),
             ax_log::PublishStatus::Published
         );
-        assert_eq!(rendered, "early secondary record");
+        assert_eq!(
+            rendered,
+            "\u{1b}[37m[ 12.345678 2 \u{1b}[37max_runtime:462] early secondary record\n"
+        );
     }
 }

--- a/os/arceos/modules/axruntime/src/lib.rs
+++ b/os/arceos/modules/axruntime/src/lib.rs
@@ -55,6 +55,7 @@ mod kernel_mapping;
 mod klib;
 mod preempt;
 mod raw_console;
+mod structured_log;
 
 pub mod console;
 mod devices;
@@ -148,11 +149,13 @@ impl ax_log::LogIf for LogIfImpl {
         if let Some(status) = serial::try_publish_record(meta, args) {
             return status;
         }
-        if let Some(status) = console::try_publish_without_runtime(args) {
+        let context = structured_log::with_runtime_log_context(core::convert::identity)
+            .unwrap_or_else(|_| structured_log::fallback_runtime_log_context(meta));
+        if let Some(status) = console::try_publish_without_runtime(meta, context, args) {
             return status;
         }
         let mut writer = PlatformConsoleWriter::default();
-        if core::fmt::write(&mut writer, args).is_ok() {
+        if structured_log::write_record(&mut writer, meta, context, args).is_ok() {
             ax_log::PublishStatus::Published
         } else {
             ax_log::PublishStatus::Dropped

--- a/os/arceos/modules/axruntime/src/serial/log_mailbox.rs
+++ b/os/arceos/modules/axruntime/src/serial/log_mailbox.rs
@@ -5,6 +5,8 @@ use core::{
     sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
 };
 
+use crate::structured_log::{RuntimeLogContext, write_structured_prefix};
+
 pub(crate) const LOG_RECORD_BYTES: usize = 1024;
 pub(super) const LOG_SLOTS_PER_CPU: usize = 64;
 
@@ -115,13 +117,14 @@ impl LogRecord {
                 truncated: false,
             };
             if meta.kind == LogRecordKind::Log {
-                let seconds = meta.timestamp_nanos / 1_000_000_000;
-                let micros = meta.timestamp_nanos % 1_000_000_000 / 1_000;
-                if let Some(task_id) = meta.task_id {
-                    write!(formatter, "[{seconds:>3}.{micros:06} {cpu_id}:{task_id} ")?;
-                } else {
-                    write!(formatter, "[{seconds:>3}.{micros:06} {cpu_id} ")?;
-                }
+                write_structured_prefix(
+                    &mut formatter,
+                    RuntimeLogContext::new(
+                        core::time::Duration::from_nanos(meta.timestamp_nanos),
+                        Some(cpu_id),
+                        meta.task_id,
+                    ),
+                )?;
             }
             formatter.write_fmt(args)?;
             formatter.finish();
@@ -874,7 +877,10 @@ mod tests {
 
         let mut reader = mailbox.reader();
         let record = reader.take(OWNER).unwrap().record;
-        assert_eq!(record.bytes(), b"[ 12.345678 0:42 module:7] message\r\n");
+        assert_eq!(
+            record.bytes(),
+            b"\x1b[37m[ 12.345678 0:42 module:7] message\r\n"
+        );
         assert_eq!(record.kind(), LogRecordKind::Log);
     }
 }

--- a/os/arceos/modules/axruntime/src/structured_log.rs
+++ b/os/arceos/modules/axruntime/src/structured_log.rs
@@ -1,0 +1,167 @@
+use core::{fmt, time::Duration};
+
+const STRUCTURED_LOG_PREFIX_COLOR: &str = "\u{1b}[37m";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ContextUnavailable;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct RuntimeLogContext {
+    timestamp: Duration,
+    cpu_id: Option<usize>,
+    task_id: Option<u64>,
+}
+
+impl RuntimeLogContext {
+    pub(crate) const fn new(
+        timestamp: Duration,
+        cpu_id: Option<usize>,
+        task_id: Option<u64>,
+    ) -> Self {
+        Self {
+            timestamp,
+            cpu_id,
+            task_id,
+        }
+    }
+}
+
+pub(crate) fn with_runtime_log_context<R>(
+    consume: impl FnOnce(RuntimeLogContext) -> R,
+) -> Result<R, ContextUnavailable> {
+    let _availability_guard = ax_task::sync::IrqSaveGuard::new();
+    // SAFETY: local IRQ exclusion prevents scheduling and migration while the
+    // fallible pin is constructed and used. The full guard is entered only
+    // after the pin validates CPU-local availability.
+    unsafe {
+        ax_hal::percpu::with_cpu_pin(|pin| {
+            #[cfg(test)]
+            record_full_guard_entry();
+            let _guard = ax_task::sync::PreemptIrqSaveGuard::new();
+            let cpu_id = ax_hal::percpu::this_cpu_id_pinned(pin);
+            let current = ax_task::current_may_uninit();
+            let task_id = current.as_ref().map(|task| task.id().as_u64());
+            let timestamp = ax_hal::time::monotonic_time();
+            consume(RuntimeLogContext::new(timestamp, Some(cpu_id), task_id))
+        })
+    }
+    .map_err(|_| ContextUnavailable)
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static FULL_GUARD_ENTRIES: core::cell::Cell<usize> = const { core::cell::Cell::new(0) };
+}
+
+#[cfg(test)]
+fn record_full_guard_entry() {
+    FULL_GUARD_ENTRIES.set(FULL_GUARD_ENTRIES.get() + 1);
+}
+
+#[cfg(test)]
+fn take_full_guard_entries() -> usize {
+    FULL_GUARD_ENTRIES.replace(0)
+}
+
+pub(crate) fn fallback_runtime_log_context(meta: ax_log::RecordMeta) -> RuntimeLogContext {
+    let timestamp = match meta.kind() {
+        ax_log::RecordKind::Print => Duration::ZERO,
+        ax_log::RecordKind::Log => ax_hal::time::monotonic_time(),
+    };
+    RuntimeLogContext::new(timestamp, None, None)
+}
+
+pub(crate) fn write_structured_prefix(
+    output: &mut (impl fmt::Write + ?Sized),
+    context: RuntimeLogContext,
+) -> fmt::Result {
+    let seconds = context.timestamp.as_secs();
+    let micros = context.timestamp.subsec_micros();
+    match (context.cpu_id, context.task_id) {
+        (Some(cpu_id), Some(task_id)) => write!(
+            output,
+            "{STRUCTURED_LOG_PREFIX_COLOR}[{seconds:>3}.{micros:06} {cpu_id}:{task_id} "
+        ),
+        (Some(cpu_id), None) => write!(
+            output,
+            "{STRUCTURED_LOG_PREFIX_COLOR}[{seconds:>3}.{micros:06} {cpu_id} "
+        ),
+        (None, _) => write!(
+            output,
+            "{STRUCTURED_LOG_PREFIX_COLOR}[{seconds:>3}.{micros:06} "
+        ),
+    }
+}
+
+pub(crate) fn write_record(
+    output: &mut (impl fmt::Write + ?Sized),
+    meta: ax_log::RecordMeta,
+    context: RuntimeLogContext,
+    args: fmt::Arguments<'_>,
+) -> fmt::Result {
+    if meta.kind() == ax_log::RecordKind::Log {
+        write_structured_prefix(output, context)?;
+    }
+    output.write_fmt(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+    use core::time::Duration;
+
+    use super::{
+        RuntimeLogContext, fallback_runtime_log_context, take_full_guard_entries,
+        with_runtime_log_context, write_record, write_structured_prefix,
+    };
+
+    #[test]
+    fn structured_prefix_keeps_available_runtime_metadata() {
+        let cases = [
+            (
+                RuntimeLogContext::new(Duration::new(12, 345_678_000), Some(2), Some(7)),
+                "\u{1b}[37m[ 12.345678 2:7 ",
+            ),
+            (
+                RuntimeLogContext::new(Duration::new(12, 345_678_000), Some(2), None),
+                "\u{1b}[37m[ 12.345678 2 ",
+            ),
+            (
+                RuntimeLogContext::new(Duration::new(12, 345_678_000), None, None),
+                "\u{1b}[37m[ 12.345678 ",
+            ),
+        ];
+
+        for (context, expected) in cases {
+            let mut output = String::new();
+            write_structured_prefix(&mut output, context).unwrap();
+            assert_eq!(output, expected);
+        }
+    }
+
+    #[test]
+    fn unavailable_context_falls_back_without_entering_the_full_guard() {
+        let (rendered, guard_entries) = std::thread::spawn(|| {
+            let _ = take_full_guard_entries();
+            let meta = ax_log::RecordMeta::log();
+            let rendered = with_runtime_log_context(|_| String::new()).unwrap_or_else(|_| {
+                let mut output = String::new();
+                write_record(
+                    &mut output,
+                    meta,
+                    fallback_runtime_log_context(meta),
+                    format_args!("early body\n"),
+                )
+                .unwrap();
+                output
+            });
+            (rendered, take_full_guard_entries())
+        })
+        .join()
+        .expect("unavailable context capture must not panic");
+
+        assert!(rendered.starts_with("\u{1b}[37m["));
+        assert!(rendered.ends_with("early body\n"));
+        assert_eq!(guard_entries, 0);
+    }
+}

--- a/os/axvisor/src/console_mux/host_log.rs
+++ b/os/axvisor/src/console_mux/host_log.rs
@@ -2,7 +2,7 @@
 
 use alloc::{collections::VecDeque, format, vec::Vec};
 
-const HOST_LOG_BACKLOG_CAPACITY: usize = 16 * 1024;
+const HOST_LOG_BACKLOG_CAPACITY: usize = 2 * 1024 * 1024;
 
 #[derive(Debug, Default)]
 pub struct HostLogBacklog {
@@ -63,17 +63,23 @@ mod tests {
 
     #[cfg_attr(axtest, axtest::axtest)]
     #[cfg_attr(not(axtest), test)]
+    fn host_log_backlog_capacity_is_two_mib() {
+        assert_eq!(HOST_LOG_BACKLOG_CAPACITY, 2 * 1024 * 1024);
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
     fn drops_oldest_complete_record_with_summary() {
         let mut backlog = HostLogBacklog::default();
-        let record = vec![b'x'; 1024];
-        for _ in 0..17 {
+        let record = vec![b'x'; HOST_LOG_BACKLOG_CAPACITY / 2];
+        for _ in 0..3 {
             backlog.push(&record);
         }
 
         let replay = backlog.drain();
-        assert_eq!(replay.len(), 17);
+        assert_eq!(replay.len(), 3);
         assert!(replay[0].starts_with(b"[Axvisor] dropped 1 host log records"));
-        assert!(replay[1..].iter().all(|record| record.len() == 1024));
+        assert!(replay[1..].iter().all(|retained| retained == &record));
     }
 
     #[cfg_attr(axtest, axtest::axtest)]

--- a/os/axvisor/src/console_mux/output.rs
+++ b/os/axvisor/src/console_mux/output.rs
@@ -514,6 +514,15 @@ mod tests {
 
     #[cfg_attr(axtest, axtest::axtest)]
     #[cfg_attr(not(axtest), test)]
+    fn registering_guest_preallocates_atomic_output_storage() {
+        let mut mux = GuestOutputMux::default();
+        mux.register_guest(7);
+
+        assert!(mux.guests[&7].pending.capacity() >= PER_GUEST_LOG_CAPACITY);
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
     fn host_record_terminates_an_open_guest_line() {
         let mut mux = GuestOutputMux::default();
         assert_eq!(mux.format(1, false, b"guest> "), b"guest> ");

--- a/os/axvisor/src/guest_console/mux/stop_lifecycle_test.rs
+++ b/os/axvisor/src/guest_console/mux/stop_lifecycle_test.rs
@@ -1,0 +1,30 @@
+use super::*;
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn stop_request_preserves_buffered_and_trailing_output_until_vm_exit() {
+    let mux = GuestConsoleMux::new();
+    let backend = mux.core.create_serial_backend(4);
+    mux.set_running([4]);
+    assert_eq!(
+        mux.core
+            .format_guest_output(4, backend.generation, b"before stop\n"),
+        Some(Vec::new())
+    );
+
+    assert_eq!(mux.set_vm_states([], [4]), None);
+    assert_eq!(mux.core.lock_state().output.pending_len(4), 12);
+    assert_eq!(
+        mux.core
+            .format_guest_output(4, backend.generation, b"after request\n"),
+        Some(Vec::new())
+    );
+
+    assert_eq!(mux.set_running([]), None);
+    assert_eq!(mux.core.lock_state().output.pending_len(4), 0);
+    assert_eq!(
+        mux.core
+            .format_guest_output(4, backend.generation, b"after exit\n"),
+        None
+    );
+}

--- a/os/axvisor/src/network_status.rs
+++ b/os/axvisor/src/network_status.rs
@@ -70,11 +70,11 @@ fn ready_interface() -> Option<InterfaceAddress> {
 fn submit_access_banner(interface: &InterfaceAddress) {
     let address = interface.ipv4.address.address();
     let mut banner = String::new();
-    let _ = writeln!(banner, "\r\nAxvisor network ready:");
-    let _ = writeln!(banner, "  interface = {}", interface.name);
-    let _ = writeln!(
+    let _ = write!(banner, "\r\nAxvisor network ready:\r\n");
+    let _ = write!(banner, "  interface = {}\r\n", interface.name);
+    let _ = write!(
         banner,
-        "  ipv4 = {address}/{}",
+        "  ipv4 = {address}/{}\r\n",
         interface.ipv4.address.prefix_len()
     );
     append_web_console_endpoint(&mut banner, address, crate::http::bind_addr());
@@ -93,5 +93,5 @@ fn append_web_console_endpoint(
         IpAddr::V4(ip) if ip.is_unspecified() => assigned_address.to_string(),
         ip => ip.to_string(),
     };
-    let _ = writeln!(banner, "  web_console = http://{host}:{}/", bind.port());
+    let _ = write!(banner, "  web_console = http://{host}:{}/\r\n", bind.port());
 }

--- a/os/axvisor/tests/guest_console_axtest.rs
+++ b/os/axvisor/tests/guest_console_axtest.rs
@@ -1,0 +1,45 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+extern crate std;
+
+use ax_hal as _;
+use ax_std as _;
+use axvm as _;
+
+mod host {
+    pub(crate) fn submit_host_bytes(_bytes: &[u8]) {}
+
+    pub(crate) fn submit_host_transaction(transaction: impl FnOnce(&mut dyn FnMut(&[u8]))) {
+        transaction(&mut |_| {});
+    }
+}
+
+mod manager {
+    use alloc::vec::Vec;
+    use anyhow::Result;
+    use axvm::{AxVMRef, VMId};
+
+    pub(crate) struct AxvmManager;
+
+    impl AxvmManager {
+        pub(crate) fn notify_vm(_vm_id: VMId) -> Result<()> {
+            Ok(())
+        }
+
+        pub(crate) fn vm_by_id(_vm_id: VMId) -> Option<AxVMRef> {
+            None
+        }
+
+        pub(crate) fn vm_list() -> Vec<AxVMRef> {
+            Vec::new()
+        }
+    }
+}
+
+#[path = "../src/guest_console/mux/mod.rs"]
+mod mux;
+
+#[axtest::tests]
+mod tests {}

--- a/scripts/axbuild/Cargo.toml
+++ b/scripts/axbuild/Cargo.toml
@@ -28,6 +28,7 @@ indicatif = "0.18"
 jkconfig = { version = "0.1" }
 log = "0.4"
 object = "0.38"
+os_pipe = "1"
 ostool = { workspace = true }
 regex = { version = "1.12" }
 regex-automata = "0.4.16"

--- a/scripts/axbuild/src/axvisor/test/host_probe.rs
+++ b/scripts/axbuild/src/axvisor/test/host_probe.rs
@@ -18,6 +18,7 @@
 //! `timeout` remains the backstop if the probe or its QMP quit fails.
 
 use std::{
+    io::Write,
     net::TcpStream,
     path::{Path, PathBuf},
     sync::{
@@ -33,11 +34,32 @@ use anyhow::{Context, bail};
 
 use super::types::AxvisorHttpProbeConfig;
 
-/// The probe callback invoked by the guard once the forwarded port accepts
-/// connections. Returns the verdict (`Ok` = pass, `Err` = fail). The probe is a
-/// `FnOnce` so it may own everything it needs (base address, token, config
-/// paths) and runs on the guard's worker thread.
-pub(crate) type HostHttpProbeFn = Box<dyn FnOnce() -> anyhow::Result<()> + Send + 'static>;
+/// Captured probe output and its pass/fail verdict.
+pub(crate) struct HostHttpProbeOutcome {
+    pub(crate) output: Vec<u8>,
+    pub(crate) verdict: anyhow::Result<()>,
+}
+
+impl HostHttpProbeOutcome {
+    pub(crate) fn failed(error: anyhow::Error) -> Self {
+        Self {
+            output: Vec::new(),
+            verdict: Err(error),
+        }
+    }
+
+    fn append_diagnostic(&mut self, args: core::fmt::Arguments<'_>) {
+        if !self.output.is_empty() && !self.output.ends_with(b"\n") {
+            self.output.push(b'\n');
+        }
+        let _ = writeln!(&mut self.output, "{args}");
+    }
+}
+
+/// The probe callback invoked by the guard once the forwarded port accepts.
+/// The probe is a `FnOnce` so it may own everything it needs and runs on the
+/// guard's worker thread without writing to QEMU's terminal stream.
+pub(crate) type HostHttpProbeFn = Box<dyn FnOnce() -> HostHttpProbeOutcome + Send + 'static>;
 
 /// Sleep between readiness retries.
 const CONNECT_RETRY_INTERVAL: Duration = Duration::from_millis(100);
@@ -57,7 +79,7 @@ const QMP_QUIT_RETRIES: usize = 4;
 
 pub(crate) struct HostHttpProbeGuard {
     stop: Arc<AtomicBool>,
-    result: Arc<Mutex<Option<anyhow::Result<()>>>>,
+    result: Arc<Mutex<Option<HostHttpProbeOutcome>>>,
     thread: Option<thread::JoinHandle<()>>,
 }
 
@@ -99,7 +121,7 @@ impl HostHttpProbeGuard {
             // The guard waits for the forwarded port (guest boot + network
             // init); the probe then runs the HTTP assertions. The probe is
             // consumed exactly once.
-            let verdict = (|| -> anyhow::Result<()> {
+            let mut outcome = (|| -> anyhow::Result<HostHttpProbeOutcome> {
                 wait_for_port_ready(&thread_addr, connect_timeout, &thread_stop).with_context(
                     || {
                         format!(
@@ -107,9 +129,9 @@ impl HostHttpProbeGuard {
                         )
                     },
                 )?;
-                probe()
-            })();
-            *thread_result.lock().unwrap() = Some(verdict);
+                Ok(probe())
+            })()
+            .unwrap_or_else(HostHttpProbeOutcome::failed);
             // Quit QEMU so a successful run ends promptly on the probe verdict
             // instead of the serial-timeout path. The runner owns the QEMU
             // child, so it decides whether QEMU actually exits: a `quit` that
@@ -118,10 +140,11 @@ impl HostHttpProbeGuard {
             if let Some(socket) = qmp_socket
                 && let Err(err) = request_qmp_quit(&socket)
             {
-                eprintln!(
+                outcome.append_diagnostic(format_args!(
                     "  host http probe: {thread_case_name}: failed to quit QEMU via QMP: {err:#}"
-                );
+                ));
             }
+            *thread_result.lock().unwrap() = Some(outcome);
         });
 
         if ready_rx.recv_timeout(Duration::from_secs(1)).is_err() {
@@ -137,21 +160,26 @@ impl HostHttpProbeGuard {
         })
     }
 
-    /// Take the probe's stored verdict, if the thread produced one.
+    /// Stop and join the worker, then take its captured output and verdict.
     ///
-    /// Called once, after QEMU has exited. The probe always stores a verdict
-    /// *before* it quits QEMU, so a clean QEMU exit implies a verdict exists.
-    pub(crate) fn take_result(&self) -> Option<anyhow::Result<()>> {
+    /// On an early QEMU failure, setting `stop` makes a running probe terminate
+    /// and publish its partial capture before this method reads the outcome.
+    pub(crate) fn finish(mut self) -> Option<HostHttpProbeOutcome> {
+        self.stop_and_join();
         self.result.lock().unwrap().take()
+    }
+
+    fn stop_and_join(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
     }
 }
 
 impl Drop for HostHttpProbeGuard {
     fn drop(&mut self) {
-        self.stop.store(true, Ordering::Release);
-        if let Some(thread) = self.thread.take() {
-            let _ = thread.join();
-        }
+        self.stop_and_join();
     }
 }
 
@@ -294,4 +322,51 @@ fn request_qmp_quit(socket: &Path) -> anyhow::Result<()> {
 #[cfg(not(unix))]
 fn request_qmp_quit(_socket: &Path) -> anyhow::Result<()> {
     bail!("QMP unix sockets are not supported on this host")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finish_joins_the_worker_before_taking_a_late_outcome() {
+        let stop = Arc::new(AtomicBool::new(false));
+        let result = Arc::new(Mutex::new(None));
+        let thread_stop = stop.clone();
+        let thread_result = result.clone();
+        let thread = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            *thread_result.lock().unwrap() = Some(HostHttpProbeOutcome {
+                output: b"partial probe output\n".to_vec(),
+                verdict: Err(anyhow::anyhow!("probe stopped")),
+            });
+        });
+        let guard = HostHttpProbeGuard {
+            stop,
+            result,
+            thread: Some(thread),
+        };
+
+        let outcome = guard.finish().expect("late probe outcome");
+
+        assert_eq!(outcome.output, b"partial probe output\n");
+        assert!(outcome.verdict.is_err());
+    }
+
+    #[test]
+    fn qmp_failure_diagnostic_is_buffered_with_probe_output() {
+        let mut outcome = HostHttpProbeOutcome {
+            output: b"probe output without newline".to_vec(),
+            verdict: Ok(()),
+        };
+
+        outcome.append_diagnostic(format_args!("QMP quit failed: connection refused"));
+
+        assert_eq!(
+            outcome.output,
+            b"probe output without newline\nQMP quit failed: connection refused\n"
+        );
+    }
 }

--- a/scripts/axbuild/src/axvisor/test/http_probe.rs
+++ b/scripts/axbuild/src/axvisor/test/http_probe.rs
@@ -27,27 +27,30 @@
 //! AXVISOR_HTTP_REQUEST_TIMEOUT seconds per HTTP request
 //! ```
 //!
-//! Exit code 0 is a pass; any nonzero exit fails the case. The asset streams
-//! its own progress to the runner's stdout/stderr so CI logs show the steps.
+//! Exit code 0 is a pass; any nonzero exit fails the case. The asset's combined
+//! stdout/stderr is captured for replay after QEMU exits, so its diagnostics do
+//! not interleave with the live serial stream.
 
 use std::{
+    io::{self, Read},
     path::Path,
     process::{Child, Command, ExitStatus, Stdio},
     sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
-    thread,
+    thread::{self, JoinHandle},
     time::Duration,
 };
 
 use anyhow::{Context, bail};
 
-use super::types::AxvisorHttpProbeConfig;
+use super::{host_probe::HostHttpProbeOutcome, types::AxvisorHttpProbeConfig};
 use crate::support::process::retry_text_file_busy;
 
 /// Poll interval while waiting for the probe asset to exit.
 const PROBE_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const MAX_PROBE_OUTPUT_BYTES: usize = 1024 * 1024;
 
 /// Run the case's HTTP probe asset against one boot.
 ///
@@ -61,29 +64,110 @@ pub(crate) fn run(
     config: &AxvisorHttpProbeConfig,
     case_dir: &Path,
     stop: Arc<AtomicBool>,
-) -> anyhow::Result<()> {
+) -> HostHttpProbeOutcome {
     let script = case_dir.join(&config.probe_script);
-    ensure_probe_asset(&script)?;
-    if stop.load(Ordering::Acquire) {
-        bail!(
-            "probe asset {} was not started because the case had already stopped",
-            script.display()
-        );
+    let captured = (|| -> anyhow::Result<(Vec<u8>, Option<ExitStatus>)> {
+        ensure_probe_asset(&script)?;
+        if stop.load(Ordering::Acquire) {
+            bail!(
+                "probe asset {} was not started because the case had already stopped",
+                script.display()
+            );
+        }
+        let (mut child, output_capture) = spawn_probe_asset(&script, addr, config, case_dir)?;
+        let status = wait_probe_asset(&mut child, &stop);
+        let bytes = output_capture.finish()?;
+        Ok((bytes, status))
+    })();
+
+    match captured {
+        Ok((output, Some(status))) if status.success() => HostHttpProbeOutcome {
+            output,
+            verdict: Ok(()),
+        },
+        Ok((output, Some(status))) => HostHttpProbeOutcome {
+            output,
+            verdict: Err(anyhow::anyhow!(
+                "probe asset {} exited with code {}",
+                script.display(),
+                status.code().unwrap_or(-1)
+            )),
+        },
+        Ok((output, None)) => HostHttpProbeOutcome {
+            output,
+            verdict: Err(anyhow::anyhow!(
+                "probe asset {} was killed",
+                script.display()
+            )),
+        },
+        Err(error) => HostHttpProbeOutcome::failed(error),
     }
-    println!(
-        "  host http probe: running probe asset {}",
-        script.display()
-    );
-    let mut child = spawn_probe_asset(&script, addr, config, case_dir)?;
-    match wait_probe_asset(&mut child, &stop) {
-        Some(status) if status.success() => Ok(()),
-        Some(status) => bail!(
-            "probe asset {} exited with code {}",
-            script.display(),
-            status.code().unwrap_or(-1)
-        ),
-        None => bail!("probe asset {} was killed", script.display()),
+}
+
+#[derive(Default)]
+struct BoundedProbeOutput {
+    bytes: Vec<u8>,
+    dropped_bytes: usize,
+}
+
+impl BoundedProbeOutput {
+    fn append(&mut self, chunk: &[u8]) {
+        let remaining = MAX_PROBE_OUTPUT_BYTES.saturating_sub(self.bytes.len());
+        let keep = remaining.min(chunk.len());
+        self.bytes.extend_from_slice(&chunk[..keep]);
+        self.dropped_bytes = self
+            .dropped_bytes
+            .saturating_add(chunk.len().saturating_sub(keep));
     }
+
+    fn finish(mut self) -> Vec<u8> {
+        if self.dropped_bytes != 0 {
+            use std::io::Write as _;
+            let _ = writeln!(
+                self.bytes,
+                "\n[probe output truncated: dropped {} bytes]",
+                self.dropped_bytes
+            );
+        }
+        self.bytes
+    }
+}
+
+struct ProbeOutputCapture {
+    reader: JoinHandle<io::Result<BoundedProbeOutput>>,
+}
+
+impl ProbeOutputCapture {
+    fn start(reader: os_pipe::PipeReader) -> Self {
+        Self {
+            reader: spawn_output_reader(reader),
+        }
+    }
+
+    fn finish(self) -> anyhow::Result<Vec<u8>> {
+        let output = self
+            .reader
+            .join()
+            .map_err(|_| anyhow::anyhow!("probe output reader thread panicked"))?
+            .context("failed to drain probe output pipe")?;
+        Ok(output.finish())
+    }
+}
+
+fn spawn_output_reader(
+    mut reader: impl Read + Send + 'static,
+) -> JoinHandle<io::Result<BoundedProbeOutput>> {
+    thread::spawn(move || {
+        let mut output = BoundedProbeOutput::default();
+        let mut buffer = [0_u8; 8192];
+        loop {
+            let read = reader.read(&mut buffer)?;
+            if read == 0 {
+                return Ok(output);
+            }
+            output.append(&buffer[..read]);
+        }
+    })
 }
 
 /// Fail fast when the configured probe asset is missing, so a case that
@@ -102,13 +186,18 @@ fn ensure_probe_asset(script: &Path) -> anyhow::Result<()> {
 
 /// Spawn the probe asset with the forwarded base URL, token, and timeouts as
 /// environment. The asset is executed directly so its shebang picks the
-/// interpreter; stdout/stderr are inherited so CI logs show the asset's steps.
+/// interpreter; stdout/stderr share one pipe drained by a bounded reader so a
+/// noisy probe cannot grow temporary storage or block on a full pipe.
 fn spawn_probe_asset(
     script: &Path,
     addr: &str,
     config: &AxvisorHttpProbeConfig,
     case_dir: &Path,
-) -> anyhow::Result<Child> {
+) -> anyhow::Result<(Child, ProbeOutputCapture)> {
+    let (reader, stdout) = os_pipe::pipe().context("failed to create probe output pipe")?;
+    let stderr = stdout
+        .try_clone()
+        .context("failed to clone probe output pipe")?;
     let mut command = Command::new(script);
     command
         .env("AXVISOR_HTTP_BASE", format!("http://{addr}"))
@@ -126,10 +215,11 @@ fn spawn_probe_asset(
             config.request_timeout_secs.to_string(),
         )
         .stdin(Stdio::null())
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit());
-    retry_text_file_busy(|| command.spawn())
-        .with_context(|| format!("failed to spawn probe asset {}", script.display()))
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    let child = retry_text_file_busy(|| command.spawn())
+        .with_context(|| format!("failed to spawn probe asset {}", script.display()))?;
+    Ok((child, ProbeOutputCapture::start(reader)))
 }
 
 /// Wait for the probe asset to exit, killing it if the runner marks the case
@@ -233,6 +323,36 @@ mod tests {
         path
     }
 
+    #[cfg(unix)]
+    fn write_output_fixture_probe(dir: &Path, name: &str) -> PathBuf {
+        use std::{fs, os::unix::fs::PermissionsExt};
+        let path = dir.join(name);
+        fs::write(
+            &path,
+            "#!/bin/sh\nprintf 'probe stdout\\n'\nprintf 'probe stderr\\n' >&2\n",
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[cfg(target_os = "linux")]
+    fn write_large_output_fixture_probe(dir: &Path, name: &str) -> PathBuf {
+        use std::{fs, os::unix::fs::PermissionsExt};
+        let path = dir.join(name);
+        fs::write(
+            &path,
+            format!(
+                "#!/usr/bin/env python3\nimport os, \
+                 sys\nprint(os.readlink('/proc/self/fd/1'))\nsys.stdout.write('x' * {})\n",
+                MAX_PROBE_OUTPUT_BYTES + 64 * 1024
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
     #[test]
     fn probe_script_defaults_to_http_probe_py() {
         let config = parse_probe_section("[host_http_probe]\ntoken = \"t\"\n");
@@ -256,6 +376,16 @@ mod tests {
         );
     }
 
+    #[test]
+    fn captured_probe_output_is_bounded_without_changing_execution_verdict() {
+        let mut output = BoundedProbeOutput::default();
+        output.append(&vec![b'x'; MAX_PROBE_OUTPUT_BYTES + 1]);
+        let output = output.finish();
+
+        assert!(output.starts_with(&vec![b'x'; MAX_PROBE_OUTPUT_BYTES]));
+        assert!(output.ends_with(b"\n[probe output truncated: dropped 1 bytes]\n"));
+    }
+
     #[cfg(unix)]
     #[test]
     fn run_executes_the_case_probe_asset_with_env() {
@@ -264,9 +394,13 @@ mod tests {
         let config = test_config(PathBuf::from("http_probe.py"));
         let stop = Arc::new(AtomicBool::new(false));
 
-        let result = run("127.0.0.1:12345", &config, dir.path(), stop);
+        let outcome = run("127.0.0.1:12345", &config, dir.path(), stop);
 
-        assert!(result.is_ok(), "probe asset should pass: {result:?}");
+        assert!(
+            outcome.verdict.is_ok(),
+            "probe asset should pass: {:?}",
+            outcome.verdict
+        );
         // The generic mechanism really executed the asset and forwarded the
         // env the asset needs to dial the guest API.
         let recorded = std::fs::read_to_string(dir.path().join("env.txt")).unwrap();
@@ -279,13 +413,53 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn run_captures_probe_output_for_deferred_replay() {
+        let dir = fixture_dir();
+        write_output_fixture_probe(dir.path(), "http_probe.py");
+        let config = test_config(PathBuf::from("http_probe.py"));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let outcome = run("127.0.0.1:12345", &config, dir.path(), stop);
+
+        assert!(outcome.verdict.is_ok());
+        assert_eq!(
+            String::from_utf8(outcome.output).unwrap(),
+            "probe stdout\nprobe stderr\n"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn run_bounds_a_real_probe_while_it_writes_to_a_pipe() {
+        let dir = fixture_dir();
+        write_large_output_fixture_probe(dir.path(), "http_probe.py");
+        let config = test_config(PathBuf::from("http_probe.py"));
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let outcome = run("127.0.0.1:12345", &config, dir.path(), stop);
+
+        assert!(outcome.verdict.is_ok());
+        assert!(outcome.output.starts_with(b"pipe:["));
+        assert!(
+            outcome
+                .output
+                .windows(b"[probe output truncated: dropped ".len())
+                .any(|window| window == b"[probe output truncated: dropped ")
+        );
+        assert!(outcome.output.len() <= MAX_PROBE_OUTPUT_BYTES + 80);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn run_propagates_nonzero_probe_exit() {
         let dir = fixture_dir();
         write_fixture_probe(dir.path(), "http_probe.py", 1);
         let config = test_config(PathBuf::from("http_probe.py"));
         let stop = Arc::new(AtomicBool::new(false));
 
-        let error = run("127.0.0.1:12345", &config, dir.path(), stop).unwrap_err();
+        let error = run("127.0.0.1:12345", &config, dir.path(), stop)
+            .verdict
+            .unwrap_err();
         assert!(
             error.to_string().contains("exited with code 1"),
             "unexpected probe error: {error:#}"
@@ -298,7 +472,9 @@ mod tests {
         let config = test_config(PathBuf::from("http_probe.py"));
         let stop = Arc::new(AtomicBool::new(false));
 
-        let error = run("127.0.0.1:12345", &config, dir.path(), stop).unwrap_err();
+        let error = run("127.0.0.1:12345", &config, dir.path(), stop)
+            .verdict
+            .unwrap_err();
         assert!(error.to_string().contains("does not exist"));
     }
 
@@ -325,7 +501,7 @@ mod tests {
         }
         stop.store(true, Ordering::Release);
 
-        let error = probe_thread.join().unwrap().unwrap_err();
+        let error = probe_thread.join().unwrap().verdict.unwrap_err();
         assert!(
             error.to_string().contains("was killed"),
             "unexpected error: {error:#}"
@@ -341,7 +517,9 @@ mod tests {
         let config = test_config(PathBuf::from("http_probe.py"));
         let stop = Arc::new(AtomicBool::new(true));
 
-        let error = run("127.0.0.1:12345", &config, dir.path(), stop).unwrap_err();
+        let error = run("127.0.0.1:12345", &config, dir.path(), stop)
+            .verdict
+            .unwrap_err();
 
         assert!(
             error

--- a/scripts/axbuild/src/axvisor/test/qemu.rs
+++ b/scripts/axbuild/src/axvisor/test/qemu.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::BTreeMap,
+    io::{self, Write},
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicBool},
     time::Instant,
@@ -426,13 +427,27 @@ impl Axvisor {
 
         // Joins the probe thread now that QEMU has exited.
         let probe_configured = host_probe_guard.is_some();
-        let probe_result = host_probe_guard
-            .as_ref()
-            .and_then(|guard| guard.take_result());
-        drop(host_probe_guard);
+        let probe_outcome = host_probe_guard.and_then(host_probe::HostHttpProbeGuard::finish);
+        let probe_result = match probe_outcome {
+            Some(outcome) => {
+                replay_probe_output(&outcome.output)?;
+                Some(outcome.verdict)
+            }
+            None => None,
+        };
 
         combine_results(qemu_result, probe_configured, probe_result)
     }
+}
+
+fn replay_probe_output(output: &[u8]) -> anyhow::Result<()> {
+    let mut stdout = io::stdout().lock();
+    stdout
+        .write_all(output)
+        .context("failed to replay host HTTP probe output")?;
+    stdout
+        .flush()
+        .context("failed to flush host HTTP probe output")
 }
 
 /// Combine the QEMU runner result and the HTTP probe verdict into the final


### PR DESCRIPTION
 ## 问题

Axvisor 的宿主终端同时承载运行时日志、管理 shell、Guest 串口输出和测试探针输出。原有输出路径存在以下问题：

- raw HAL 回退路径没有补齐时间戳、CPU 和任务信息，日志格式与运行时串口路径不一致；
- 后台 Guest 输出可能与前台终端内容交错，ANSI reset 和换行也可能被拆到不同物理行；
- VM 收到停止请求后，串口 backend 会被提前失效，停止过程中的尾部输出可能丢失；
- HTTP 探针与 QEMU 串口同时写入测试终端，可能把探针输出插入串口日志记录。

## 修改内容

- 统一运行时日志格式：
  - 为正常串口和 raw HAL 回退路径生成相同的结构化前缀；
  - 保留可用的时间戳、CPU ID 和任务 ID；
  - 处理日志末尾的 ANSI SGR 序列，避免 reset code 落到下一行；
  - 在同一个输出事务内将裸 `LF` 转换为 `CRLF`。

- 调整 Guest 控制台输出仲裁：
  - 仅允许当前前台 Guest 直接写入宿主终端；
  - 后台 Guest 输出保存在有容量上限的独立缓冲区中，在切换前台时回放；
  - 区分“可交互的 Running VM”和“仍可产生输出的 Running/Stopping VM”；
  - 停止请求不再立即销毁串口 backend，待 VM 真正退出后再回放或清理尾部输出；
  - 当管理 shell 持有终端时，短生命周期 VM 的缓冲输出会在退出时回放；已有 Guest 处于前台时仍保持隐藏。

- 隔离 HTTP 探针输出：
  - 探针运行期间将 stdout 和 stderr 写入匿名临时文件；
  - QEMU 退出后再回放探针输出并检查退出状态；
  - 保留非零退出、主动终止和缺少探针文件等原有错误语义。

- 补充测试和 CI：
  - 增加 Guest 停止生命周期 axtest；
  - 覆盖后台缓冲、前台切换、停止后尾部输出、结构化日志、CRLF 和 ANSI reset；
  - 将 Guest 控制台生命周期测试加入 Axvisor AArch64 QEMU CI。

## 实现逻辑

宿主终端仍由应用层输出队列统一拥有。Guest 的设备回调只负责向预注册的固定容量缓冲区写入数据，不在回调路径中分配内存或进入可睡眠接口。

VM 状态同步同时维护 `running` 和 `output_active` 两组状态。`Stopping` VM 不再接受控制台连接，但现有串口 backend 可以继续提交关机阶段的输出；状态进入终态后，仲裁器再决定回放或丢弃缓冲内容并失效 backend。

HTTP 探针不再与 QEMU 竞争同一个终端。临时文件避免了管道容量限制，探针完成结果则在 QEMU 释放终端后统一处理。