### PR TITLE
feat(axvisor): add browser console

### DIFF
--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -55,12 +55,14 @@ echo "==> pull qemu-aarch64 image"
 cargo xtask image pull qemu-aarch64 --extract-dir tmp/axbuild/images
 echo "==> axvisor aarch64 HTTP control-plane (incl. pause/resume)"
 cargo xtask axvisor test qemu --arch aarch64 --test-case http-control-plane
+echo "==> axvisor aarch64 browser console"
+cargo xtask axvisor test qemu --arch aarch64 --test-case browser-console
 '''
 
 [[check.suite]]
 kind = "axvisor-qemu"
 arch = "aarch64"
-cases = ["http-control-plane"]
+cases = ["http-control-plane", "browser-console"]
 
 [[check]]
 id = "test-axvisor-riscv64-qemu-smoke-panic-modes"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,6 +1473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1491,8 +1492,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1573,6 +1576,7 @@ dependencies = [
  "axvm-types",
  "axvmconfig",
  "clap",
+ "futures-util",
  "heapless",
  "log",
  "prettyplease 0.3.0",
@@ -5531,7 +5535,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tokio-serial",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "toml 1.1.4+spec-1.1.0",
  "uboot-shell",
@@ -7866,6 +7870,8 @@ dependencies = [
  "ax-tracepoint",
  "axbacktrace",
  "axfs-ng-vfs",
+ "axhvc",
+ "axivc",
  "axklib",
  "axplat-dyn",
  "axpoll",
@@ -8538,7 +8544,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -8787,6 +8805,22 @@ dependencies = [
  "sha1 0.10.7",
  "thiserror 2.0.20",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/docs/docs/architecture/axvisor/guest-console.md
+++ b/docs/docs/architecture/axvisor/guest-console.md
@@ -5,7 +5,7 @@ sidebar_label: "客户机控制台"
 
 # Axvisor 客户机控制台架构
 
-Axvisor 只有一个物理宿主控制台，但管理 shell 和多台客户机都需要收发字符。这个共享边界由 Axvisor 应用层的 `GuestConsoleMux` 管理：它是宿主输入的唯一读取者，决定当前前台，把输入送进对应 VM 的有界队列，并在多个客户机写同一个终端时完成输出仲裁。虚拟 UART 只通过 `SerialBackend` 读写字节，不拥有前台、快捷键或宿主终端策略。
+Axvisor 只有一个物理宿主控制台，但管理 shell 和多台客户机都需要收发字符。这个共享边界由 Axvisor 应用层的 `GuestConsoleMux` 管理：它是物理宿主输入的唯一读取者，决定当前前台，把输入送进对应 VM 的有界队列，并在多个客户机写同一个物理终端时完成输出仲裁。可选的 `browser-console` 传输还可以把管理 shell 和启动时成功注册的最多三个 VM 映射到独立 WebSocket 字节流，而不改变物理 UART 前台。虚拟 UART 只通过 `SerialBackend` 读写字节，不拥有前台、快捷键或宿主终端策略。
 
 本文说明应用层的输入 ownership、前台状态、backend generation 有效性、输出模式和 VM 生命周期接入。UART 寄存器、FIFO、IRQ endpoint 与 vCPU poll 的完整语义见[设备运行时与中断架构](./device-runtime.md#5-串口完整路径)。
 
@@ -20,6 +20,7 @@ Axvisor 只有一个物理宿主控制台，但管理 shell 和多台客户机�
 | `GuestSerialBackendFactory` / `GuestSerialBackend` | factory 为一个 host-console serial request 创建带 `(VMId, BackendGeneration)` 身份的 backend；backend 把设备层字节调用转入 mux | configured node 创建；UART runtime 读写 |
 | `GuestOutputMux` | 在 `BootMultiplex` 与 `Interactive` 间切换，补齐物理行，维护每 VM 16 KiB 环形输出，并生成回放 | 客户机输出与前台变化 |
 | `guest_console/host.rs` | 在 vCPU 启动前取得唯一的 task-console RX、日志订阅与 output；output 移交给专用任务，其他路径只向固定队列提交事务 | Axvisor 初始化与 shell 主循环 |
+| `network_console` | 私有保存启动快照、四条固定容量通道、独占网页会话和 Axvisor 网页行编辑；不提供 raw TCP listener | `browser-console` 功能启用时 |
 | `shell/mod.rs` | 作为输入事件循环的唯一 owner，消费 `ConsoleInputEvent`，调用 `activate()`，每轮 reconcile VM 状态 | 管理 shell |
 | `shell/command/vm.rs` | `vm start --console`、`vm console` 以及 start/stop/reset/resume/delete 的 mux lifecycle 调用 | 管理命令 |
 | `AxvmManager` 接入 | 提供 VM registry/status，输入入队后唤醒 VM；实际设备 poll 由 vCPU0 执行 | VM lifecycle 与运行期 |
@@ -28,7 +29,8 @@ Axvisor 只有一个物理宿主控制台，但管理 shell 和多台客户机�
 `NoPreemptMutex`：`state` 保护以上全部可变状态，`output_lock` 串行化输出仲裁以及 backend
 replacement/invalidation。客户机输出路径的固定顺序是 `output_lock` → host transport queue →
 `state`；它只格式化并提交一个固定容量事务，不触碰物理 UART。其他同时使用两把 mux 锁的
-路径仍按 `output_lock` → `state` 加锁，禁止反向获取。
+路径仍按 `output_lock` → `state` 加锁，禁止反向获取。网络分支不同时持有这两把锁：它先在
+`state` 下校验 generation，释放后才向对应的固定网络队列复制原始字节。
 
 ## 2. 初始化与宿主输入 ownership
 
@@ -92,6 +94,10 @@ backlog，返回管理 shell 后再回放。底层 64 条 record 队列和 mux b
 每个 `GuestState.input` 最多保存 4096 字节。一次路由只写剩余容量，超出部分从本次输入尾部丢弃；已有队列内容不会被淘汰，调用者不阻塞，也不会把溢出字节改投给 shell。第一次溢出发布一条完整宿主 warning，guest 读出至少一个字节后才允许报告下一次溢出，避免静默丢失和 warning flood。backend 的 `read()` 按调用方 buffer 大小从队首取出字节。
 
 `route_host_byte()` 在持有 mux 锁时只完成状态修改和入队，把待唤醒的 VM ID 放进 `RoutedInput`。公共入口释放 `state` 和 `output_lock` 后才调用 `AxvmManager::notify_vm()`；唤醒失败只记录 warning，已入队字节仍保留。这个锁外调用避免 mux 锁跨入 VM manager 和 scheduler。
+
+`route_network_input(vm_id, bytes)` 复用同一有界队列和锁外唤醒，但它先要求目标
+VM 仍在 running 集合且存在当前 backend generation。该入口按 VM ID 直接路由，
+不取得物理 `TaskConsoleInput`、不解析 `Ctrl+X` 快捷键，也不改变 `attached`。
 
 ### 3.2 命令附着与 foreground 激活
 
@@ -236,6 +242,21 @@ flowchart LR
 | 单 vCPU guest | `notify_vm()` 设置 Release 发布的 pending device-poll flag 并唤醒；vCPU0 用 Acquire/AcqRel 消费 | flag 只表达“需要 poll”，不计数；队列才保存字节 |
 | SMP guest | 当前沿用共享 wait queue 的 `notify_one()`，不发布 shared poll flag | 无法定向唤醒 vCPU0，可能只唤醒 secondary；空闲 SMP guest 的输入会延迟到 vCPU0 下次 VM-exit 或其他唤醒 |
 | 输出并发 | `output_lock` 覆盖 format 与 ring replay；固定队列保持事务边界，只有 output worker 等待 UART | transport 满时丢弃当前完整事务；per-guest ring 淘汰最旧字节；两者均报告摘要且不阻塞 vCPU writer |
+| 网络输出 | 每端点独立 64 KiB 固定队列；有连接时 vCPU 只复制原始字节并通过 `IrqNotify` 唤醒对应网页输出任务 | 无连接时不保留历史也不获取网络队列锁；慢客户端只影响自身通道并最终触发该端点队列丢弃摘要 |
+
+`browser-console` 在默认 VM 初始化后只获取一次运行时 VM 列表并按 VM ID 排序。网页通过 `/api/consoles` 获取这个启动快照，
+使用 `/ws/axvisor` 和 `/ws/vm-<真实 ID>` 路由，并直接显示客户机 TOML 的 `base.name`。
+零个客户机时只有管理窗格，一个、两个或三个客户机时分别生成两个、三个或四个窗格；
+运行中创建、删除 VM 不重建网络通道。超过三个启动客户机时，只为按 VM ID 排序后的前三个
+客户机创建网络通道，其余客户机仍正常启动并保留物理 UART 路径。
+这些 WebSocket 是无 TLS、无认证的原始控制台字节流，每端点同时只接受一个会话，只能用在受信任的管理网络。网络 shell 不给客户机提供 IP 栈；连接终止在 Axvisor 现有的 virtual-UART backend。
+
+启用 `browser-console` 后，Axvisor 会在配置的 HTTP 地址直接发布一个自适应页面。
+浏览器通过同源 WebSocket 取得 management/guest 独占会话、固定队列及溢出统计；
+该 feature 不隐式启用 `http-axum` VM 管理 API，也没有 raw TCP 控制台、per-lane dispatcher
+或 Tokio `mpsc` 中转。命令执行主机不参与运行时链路。页面的
+HTML、CSS 和 JavaScript 均编译进 Axvisor，不依赖 GitHub、CDN 或开发板根文件系统；
+不存在需要命令主机持续运行的网页代理路径。
 
 SMP 限制不能通过让任意 vCPU poll 来规避，那会破坏设备 poll 的 single-owner 假设。正确演进方向是为 vCPU0 提供可定向的 wait/wake 路径，再为 SMP 发布 pending poll 请求。
 
@@ -267,6 +288,9 @@ SMP 限制不能通过让任意 vCPU poll 来规避，那会破坏设备 poll �
 - BootMultiplex 多 VM 行前缀、默认附着和输入触发的抢占、命令 echo 后的前台结果；
 - 第一次前台输入进入 Interactive、切换时回放后台 ring、detach 后全部缓存；
 - foreground 或 background 未结束物理行在切换时正确补行。
+- VM 2 网络输入不改变物理 VM 1 foreground，并拒绝 stopped 或 stale backend；
+- 有连接的 VM 输出只进入对应网络通道，无连接时跳过网络输出路径；
+- 启动布局按 VM ID 排序、最多选择三个客户机并使用配置名称。
 
 `mux/output.rs` 另有 16 个内部测试，直接覆盖完整行选择、分片只加一次前缀、pending/total 容量上界、超大单次 write、16 KiB 淘汰与回放、Interactive 前台分片、reset/reconcile 后物理分隔符。`console_mux/transport.rs` 的 4 个测试验证 FIFO、队列满、超大事务和分块溢出时的整事务回滚。顶层 mux 测试还覆盖宿主完整日志隔离、guest 前台缓存与返回 shell 后回放；`axvm::runtime` 与 vCPU runtime 测试单 vCPU poll flag 和 SMP 不发布 shared flag 的差异。
 

--- a/os/axvisor/Cargo.toml
+++ b/os/axvisor/Cargo.toml
@@ -56,14 +56,22 @@ test-backtrace-panic = ["backtrace"]
 test-panic-no-backtrace = ["dep:axbacktrace"]
 test-console-interleave = ["dep:ax-log"]
 test-console-atomic-output = ["ax-std/sched-rr"]
-# axum-based management HTTP server (see src/http/ for the Router).
-# Off by default. Replaces the hand-rolled pilot, which is intentionally not
-# carried forward.
 # axum-based management HTTP server. Pulls `ax-std/net` explicitly so the
 # ArceOS network stack (which probes the QEMU virtio-net NIC and backs the
 # tokio `TcpListener`) is enabled only when the control plane is built; a
 # non-HTTP build must not enable the network subsystem.
 http-axum = ["ax-std/net", "dep:axum", "dep:tokio", "dep:serde_json"]
+# Board-hosted browser console. It owns only the embedded page, console
+# discovery, and WebSocket character streams; the VM management API remains an
+# independent opt-in feature.
+browser-console = [
+  "ax-std/net",
+  "axum/ws",
+  "dep:axum",
+  "dep:futures-util",
+  "dep:serde_json",
+  "dep:tokio",
+]
 # Do not auto-boot the default VMs at startup; the HTTP control plane starts
 # and stops them on demand (VMs are created and stay in `Ready`).
 no-auto-start = []
@@ -81,11 +89,12 @@ anyhow.workspace = true
 ax-log = { workspace = true, optional = true }
 log = "0.4"
 axum = { version = "0.8", optional = true }
+futures-util = { version = "0.3", optional = true, features = ["sink"] }
 serde_json = { version = "1", optional = true }
 # The runtime only enables the IO driver (`enable_io()`), so no `time` driver
 # and thus no `timerfd` syscall is needed. `rt` + `net` cover the manually
 # built current-thread runtime and `TcpListener`.
-tokio = { version = "1", optional = true, features = ["rt", "net"] }
+tokio = { version = "1", optional = true, features = ["net", "rt"] }
 
 # System dependent modules provided by ArceOS.
 ax-api.workspace = true

--- a/os/axvisor/src/guest_console/mod.rs
+++ b/os/axvisor/src/guest_console/mod.rs
@@ -17,6 +17,8 @@ pub(crate) use host::{
     )
 )]
 pub(crate) use mux::attach_default;
+#[cfg(feature = "browser-console")]
+pub(crate) use mux::route_network_input;
 pub(crate) use mux::{
     ConsoleInputEvent, activate, attach, attached_vm, mark_running, mark_stopped,
     reconcile_vm_states, remove, route_host_byte, route_host_log, serial_backend_factory,

--- a/os/axvisor/src/guest_console/mux/mod.rs
+++ b/os/axvisor/src/guest_console/mux/mod.rs
@@ -397,6 +397,13 @@ fn switch_guest(state: &mut ConsoleState, direction: GuestSwitchDirection) -> Ro
     }
 }
 
+#[cfg(any(feature = "browser-console", test, axtest))]
+impl GuestConsoleMux {
+    fn route_network_input(&self, vm_id: VMId, bytes: &[u8]) -> Option<bool> {
+        self.core.route_network_input(vm_id, bytes)
+    }
+}
+
 impl ConsoleCore {
     fn lock_state(&self) -> NoPreemptMutexGuard<'_, ConsoleState> {
         self.state.lock()
@@ -460,7 +467,7 @@ impl ConsoleCore {
         read_len
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, axtest))]
     fn format_guest_output(
         &self,
         vm_id: VMId,
@@ -481,6 +488,21 @@ impl ConsoleCore {
             return;
         }
 
+        #[cfg(any(feature = "browser-console", all(test, axtest)))]
+        if crate::network_console::guest_output_connected(vm_id) {
+            let is_current = {
+                let state = self.lock_state();
+                state
+                    .guests
+                    .get(&vm_id)
+                    .is_some_and(|guest| guest.backend_generation == Some(generation))
+            };
+            if !is_current {
+                return;
+            }
+            crate::network_console::submit_guest_output(vm_id, bytes);
+        }
+
         let _output_guard = self.lock_output();
         submit_host_transaction(|emit| {
             let mut state = self.lock_state();
@@ -497,6 +519,20 @@ impl ConsoleCore {
                     .format_registered_into(vm_id, multiple_running, bytes, emit);
             debug_assert!(formatted, "active backend output state must be registered");
         });
+    }
+
+    #[cfg(any(feature = "browser-console", test, axtest))]
+    fn route_network_input(&self, vm_id: VMId, bytes: &[u8]) -> Option<bool> {
+        let mut state = self.lock_state();
+        if !state.running.contains(&vm_id)
+            || !state
+                .guests
+                .get(&vm_id)
+                .is_some_and(|guest| guest.backend_generation.is_some())
+        {
+            return None;
+        }
+        Some(enqueue_guest_input(&mut state, vm_id, bytes))
     }
 }
 
@@ -547,6 +583,24 @@ pub fn route_host_byte(byte: u8) -> ConsoleInputEvent {
         warn!("failed to wake VM[{vm_id}] for console input: {error:#}");
     }
     routed.event
+}
+
+/// Routes bytes from a VM-specific network endpoint without changing the
+/// physical console foreground.
+#[cfg(feature = "browser-console")]
+pub(crate) fn route_network_input(vm_id: VMId, bytes: &[u8]) -> bool {
+    let Some(overflowed) = GUEST_CONSOLE_MUX.route_network_input(vm_id, bytes) else {
+        return false;
+    };
+    if overflowed {
+        warn!("VM[{vm_id}] network console input queue overflowed; dropping bytes");
+    }
+    if !bytes.is_empty()
+        && let Err(error) = crate::manager::AxvmManager::notify_vm(vm_id)
+    {
+        warn!("failed to wake VM[{vm_id}] for network console input: {error:#}");
+    }
+    true
 }
 
 /// Routes a complete host log record without exposing it to a guest UART.
@@ -622,5 +676,5 @@ pub fn attached_vm() -> Option<VMId> {
     GUEST_CONSOLE_MUX.attached_vm()
 }
 
-#[cfg(test)]
+#[cfg(any(test, axtest))]
 mod tests;

--- a/os/axvisor/src/guest_console/mux/tests.rs
+++ b/os/axvisor/src/guest_console/mux/tests.rs
@@ -73,6 +73,34 @@ fn lowest_running_vm_is_default_and_input_only_reaches_foreground() {
 
 #[cfg_attr(axtest, axtest::axtest)]
 #[cfg_attr(not(axtest), test)]
+fn network_input_reaches_its_guest_without_changing_physical_foreground() {
+    let mux = GuestConsoleMux::new();
+    let backend_1 = mux.core.create_serial_backend(1);
+    let backend_2 = mux.core.create_serial_backend(2);
+    assert_eq!(mux.attach_default([1, 2]), Some(1));
+
+    assert_eq!(mux.route_network_input(2, b"uptime\r"), Some(false));
+    assert_eq!(mux.attached_vm(), Some(1));
+
+    let mut input = [0u8; 16];
+    assert_eq!(backend_1.read(&mut input), 0);
+    let read = backend_2.read(&mut input);
+    assert_eq!(&input[..read], b"uptime\r");
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
+fn network_input_rejects_stopped_and_stale_guest_backends() {
+    let mux = GuestConsoleMux::new();
+    mux.core.create_serial_backend(1);
+    mux.set_running([1]);
+    mux.mark_stopped(1);
+
+    assert_eq!(mux.route_network_input(1, b"ignored"), None);
+}
+
+#[cfg_attr(axtest, axtest::axtest)]
+#[cfg_attr(not(axtest), test)]
 fn guest_input_overflow_is_reported_once_until_the_guest_drains_input() {
     let mux = GuestConsoleMux::new();
     let backend = mux.core.create_serial_backend(1);

--- a/os/axvisor/src/http/browser_console/mod.rs
+++ b/os/axvisor/src/http/browser_console/mod.rs
@@ -1,0 +1,157 @@
+//! Board-hosted HTTP/WebSocket gateway for the startup network console lanes.
+
+use anyhow::{Context, Result};
+use axum::{
+    Json, Router,
+    extract::{
+        Path,
+        ws::{Message, WebSocket, WebSocketUpgrade},
+    },
+    http::{HeaderMap, StatusCode, header},
+    response::{Html, IntoResponse, Response},
+    routing::get,
+};
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{Value, json};
+mod page;
+
+const BRIDGE_BUFFER_CAPACITY: usize = 4096;
+/// Browser-console routes served by Axvisor's optional HTTP listener.
+pub(super) fn router() -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/api/consoles", get(console_descriptions))
+        .route("/ws/{endpoint}", get(upgrade_console))
+}
+
+async fn index() -> impl IntoResponse {
+    (
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (
+                header::CONTENT_SECURITY_POLICY,
+                "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self' ws: wss:; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'none'",
+            ),
+            (header::X_CONTENT_TYPE_OPTIONS, "nosniff"),
+        ],
+        Html(page::INDEX_HTML),
+    )
+}
+
+async fn console_descriptions() -> Json<Vec<Value>> {
+    Json(
+        crate::network_console::console_descriptions()
+            .into_iter()
+            .map(|console| {
+                json!({
+                    "route": console.route,
+                    "name": console.display_name,
+                })
+            })
+            .collect(),
+    )
+}
+
+async fn upgrade_console(
+    Path(endpoint): Path<String>,
+    headers: HeaderMap,
+    upgrade: WebSocketUpgrade,
+) -> Result<Response, StatusCode> {
+    validate_browser_origin(&headers)?;
+    if !crate::network_console::has_console_route(&endpoint) {
+        return Err(StatusCode::NOT_FOUND);
+    }
+    let (input, output) =
+        crate::network_console::open_browser_console(&endpoint).map_err(|error| {
+            warn!("{endpoint} browser console could not open: {error}");
+            StatusCode::CONFLICT
+        })?;
+
+    Ok(upgrade
+        .max_message_size(BRIDGE_BUFFER_CAPACITY)
+        .max_frame_size(BRIDGE_BUFFER_CAPACITY)
+        .on_upgrade(move |browser| async move {
+            if let Err(error) = bridge_console(browser, input, output).await {
+                warn!("{endpoint} browser console bridge stopped: {error:#}");
+            }
+        })
+        .into_response())
+}
+
+fn validate_browser_origin(headers: &HeaderMap) -> Result<(), StatusCode> {
+    let host = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(StatusCode::FORBIDDEN)?;
+    let origin = headers
+        .get(header::ORIGIN)
+        .and_then(|value| value.to_str().ok())
+        .ok_or(StatusCode::FORBIDDEN)?;
+
+    if origin == format!("http://{host}") || origin == format!("https://{host}") {
+        Ok(())
+    } else {
+        Err(StatusCode::FORBIDDEN)
+    }
+}
+
+async fn bridge_console(
+    browser: WebSocket,
+    mut console_input: crate::network_console::BrowserConsoleInput,
+    console_output: crate::network_console::BrowserConsoleOutput,
+) -> Result<()> {
+    let (mut browser_sender, mut browser_receiver) = browser.split();
+    browser_sender
+        .send(Message::Binary(
+            console_input.greeting().into_bytes().into(),
+        ))
+        .await
+        .context("failed to write the browser console greeting")?;
+
+    std::thread::Builder::new()
+        .name("browser-console-output".into())
+        .spawn(move || {
+            crate::network_console::pin_current_task();
+            if let Err(error) = run_browser_output(browser_sender, console_output) {
+                warn!("browser console output stopped: {error:#}");
+            }
+        })
+        .context("failed to start browser console output task")?;
+
+    read_browser_input(&mut browser_receiver, &mut console_input).await
+}
+
+async fn read_browser_input(
+    browser_receiver: &mut futures_util::stream::SplitStream<WebSocket>,
+    console_input: &mut crate::network_console::BrowserConsoleInput,
+) -> Result<()> {
+    while let Some(message) = browser_receiver.next().await {
+        let keep_open = match message.context("failed to read the browser console")? {
+            Message::Text(text) => console_input.route(text.as_bytes()),
+            Message::Binary(bytes) => console_input.route(&bytes),
+            Message::Close(_) => return Ok(()),
+            Message::Ping(_) | Message::Pong(_) => true,
+        };
+        if !keep_open {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+fn run_browser_output(
+    mut browser_sender: futures_util::stream::SplitSink<WebSocket, Message>,
+    mut console_output: crate::network_console::BrowserConsoleOutput,
+) -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .context("failed to build browser console output runtime")?;
+
+    while let Some(output) = console_output.receive() {
+        runtime
+            .block_on(browser_sender.send(Message::Binary(output.into())))
+            .context("failed to write the browser console")?;
+    }
+    Ok(())
+}

--- a/os/axvisor/src/http/browser_console/page.rs
+++ b/os/axvisor/src/http/browser_console/page.rs
@@ -1,0 +1,333 @@
+//! Self-contained single-page frontend served directly by Axvisor.
+
+pub(super) const INDEX_HTML: &str = r##"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Axvisor board console</title>
+  <style>
+    :root { color-scheme: dark; font-family: system-ui, sans-serif; background: #080c14; color: #e8edf7; }
+    * { box-sizing: border-box; }
+    body { margin: 0; min-height: 100vh; background: #080c14; }
+    header { display: flex; justify-content: space-between; gap: 1rem; padding: 1rem 1.25rem .8rem; }
+    h1 { margin: 0; font-size: 1.1rem; }
+    header p { margin: .2rem 0 0; color: #8f9bb2; font-size: .8rem; }
+    main { display: grid; grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr)); gap: .75rem; height: calc(100vh - 4.8rem); padding: 0 .75rem .75rem; }
+    .console { display: grid; grid-template-rows: auto minmax(0, 1fr); min-width: 0; overflow: hidden; border: 1px solid #1b2638; border-radius: .65rem; background: #090e18; }
+    .console:focus-within { border-color: #3b82f6; }
+    .bar { display: flex; align-items: center; justify-content: space-between; padding: .6rem .7rem; border-bottom: 1px solid #1b2638; }
+    .name { font-weight: 650; }
+    .actions { display: flex; align-items: center; gap: .45rem; }
+    .status { color: #f59e0b; font-size: .72rem; }
+    .console[data-state="open"] .status { color: #34d399; }
+    .console[data-state="closed"] .status { color: #f87171; }
+    button { border: 1px solid #334155; border-radius: .35rem; padding: .25rem .45rem; color: #dbeafe; background: #172033; cursor: pointer; }
+    .terminal { min-height: 0; margin: 0; padding: .55rem; overflow: auto; outline: none; color: #d7deea; background: #090e18; cursor: text; font: 13px/1.35 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; user-select: text; white-space: pre; tab-size: 8; }
+    .terminal-cursor { display: inline-block; width: 0; height: 1.08em; border-left: 2px solid #d7deea; margin-left: -1px; vertical-align: -.15em; pointer-events: none; animation: cursor-blink 1s step-end infinite; }
+    .terminal:not(:focus) .terminal-cursor { opacity: .45; animation: none; }
+    @keyframes cursor-blink { 0%, 45% { opacity: 1; } 50%, 100% { opacity: 0; } }
+    @media (max-width: 900px) { main { grid-template-columns: 1fr; height: auto; } .console { height: 34rem; } }
+  </style>
+</head>
+<body>
+  <header>
+    <div><h1>Axvisor board console</h1><p>Self-contained page served directly by Axvisor</p></div>
+    <p>Trusted management LAN only</p>
+  </header>
+  <main></main>
+  <template id="console-pane">
+    <section class="console">
+      <div class="bar"><span class="name"></span><div class="actions"><span class="status">connecting</span><button>Reconnect</button></div></div>
+      <pre class="terminal" tabindex="0"></pre>
+    </section>
+  </template>
+  <script>
+    (() => {
+      const encoder = new TextEncoder();
+      const TAB_WIDTH = 8;
+      const keyBytes = new Map([
+        ['Enter', '\r'], ['Backspace', '\x7f'], ['Tab', '\t'], ['Escape', '\x1b'],
+        ['ArrowUp', '\x1b[A'], ['ArrowDown', '\x1b[B'], ['ArrowRight', '\x1b[C'], ['ArrowLeft', '\x1b[D'],
+        ['Home', '\x1b[H'], ['End', '\x1b[F'], ['Delete', '\x1b[3~'],
+        ['PageUp', '\x1b[5~'], ['PageDown', '\x1b[6~']
+      ]);
+
+      class Screen {
+        constructor(element) {
+          this.element = element;
+          this.decoder = new TextDecoder();
+          this.lines = [''];
+          this.row = 0;
+          this.column = 0;
+          this.mode = 'text';
+          this.sequence = '';
+          this.cursorVisible = true;
+          this.renderPaused = false;
+          this.renderPending = false;
+          this.render();
+        }
+        write(payload) {
+          const text = typeof payload === 'string' ? payload : this.decoder.decode(payload, { stream: true });
+          for (const character of text) this.consume(character);
+          this.trim();
+          this.render();
+        }
+        consume(character) {
+          if (this.mode === 'csi') {
+            this.sequence += character;
+            if (character >= '@' && character <= '~') {
+              this.applyCsi(this.sequence);
+              this.mode = 'text';
+              this.sequence = '';
+            }
+            return;
+          }
+          if (this.mode === 'osc') {
+            if (character === '\x07') this.mode = 'text';
+            else if (character === '\x1b') this.mode = 'osc-escape';
+            return;
+          }
+          if (this.mode === 'osc-escape') {
+            this.mode = character === '\\' ? 'text' : 'osc';
+            return;
+          }
+          if (this.mode === 'escape') {
+            if (character === '[') this.mode = 'csi';
+            else if (character === ']') this.mode = 'osc';
+            else {
+              if (character === 'c') this.reset();
+              this.mode = 'text';
+            }
+            return;
+          }
+          if (character === '\x1b') this.mode = 'escape';
+          else if (character === '\r') this.column = 0;
+          else if (character === '\n') this.newline();
+          else if (character === '\b') this.column = Math.max(0, this.column - 1);
+          else if (character === '\t') this.advanceTabStop();
+          else if (character >= ' ') this.put(character);
+        }
+        applyCsi(sequence) {
+          const command = sequence.at(-1);
+          const parameters = sequence.slice(0, -1);
+          if ((command === 'h' || command === 'l') && parameters.split(';').includes('?25')) {
+            this.cursorVisible = command === 'h';
+            return;
+          }
+          const values = parameters.replace(/^\?/, '').split(';').map(value => Number(value || 0));
+          const amount = values[0] || 1;
+          if (command === 'A') this.row = Math.max(0, this.row - amount);
+          else if (command === 'B') this.row = Math.min(this.lines.length - 1, this.row + amount);
+          else if (command === 'C') this.column += amount;
+          else if (command === 'D') this.column = Math.max(0, this.column - amount);
+          else if (command === 'G') this.column = Math.max(0, amount - 1);
+          else if (command === 'H' || command === 'f') this.move(values);
+          else if (command === 'J' && values[0] === 2) this.reset();
+          else if (command === 'K') this.eraseLine(values[0]);
+        }
+        move(values) {
+          const row = Math.max(0, (values[0] || 1) - 1);
+          while (this.lines.length <= row) this.lines.push('');
+          this.row = row;
+          this.column = Math.max(0, (values[1] || 1) - 1);
+        }
+        eraseLine(mode) {
+          const line = this.lines[this.row];
+          if (mode === 1) this.lines[this.row] = ' '.repeat(this.column) + line.slice(this.column + 1);
+          else if (mode === 2) { this.lines[this.row] = ''; this.column = 0; }
+          else this.lines[this.row] = line.slice(0, this.column);
+        }
+        put(character) {
+          let line = this.lines[this.row];
+          if (line.length < this.column) line += ' '.repeat(this.column - line.length);
+          this.lines[this.row] = line.slice(0, this.column) + character + line.slice(this.column + 1);
+          this.column += 1;
+        }
+        advanceTabStop() {
+          const stop = this.column + TAB_WIDTH - (this.column % TAB_WIDTH);
+          while (this.column < stop) this.put(' ');
+        }
+        newline() {
+          this.row += 1;
+          this.column = 0;
+          if (this.row === this.lines.length) this.lines.push('');
+        }
+        reset() { this.lines = ['']; this.row = 0; this.column = 0; }
+        pauseRendering() { this.renderPaused = true; }
+        resumeRendering() {
+          if (!this.renderPaused) return;
+          this.renderPaused = false;
+          if (this.renderPending) {
+            this.renderPending = false;
+            this.render();
+          }
+        }
+        trim() {
+          if (this.lines.length <= 4000) return;
+          const removed = this.lines.length - 4000;
+          this.lines.splice(0, removed);
+          this.row = Math.max(0, this.row - removed);
+        }
+        render() {
+          if (this.renderPaused) {
+            this.renderPending = true;
+            return;
+          }
+          const follow = this.element.scrollTop + this.element.clientHeight + 24 >= this.element.scrollHeight;
+          const lines = this.lines.slice();
+          if (lines[this.row].length < this.column) {
+            lines[this.row] += ' '.repeat(this.column - lines[this.row].length);
+          }
+          const text = lines.join('\n');
+          if (this.cursorVisible) {
+            let cursorOffset = this.column;
+            for (let row = 0; row < this.row; row += 1) cursorOffset += lines[row].length + 1;
+            const fragment = document.createDocumentFragment();
+            fragment.append(document.createTextNode(text.slice(0, cursorOffset)));
+            const cursor = document.createElement('span');
+            cursor.className = 'terminal-cursor';
+            cursor.setAttribute('aria-hidden', 'true');
+            fragment.append(cursor, document.createTextNode(text.slice(cursorOffset)));
+            this.element.replaceChildren(fragment);
+          } else {
+            this.element.textContent = text;
+          }
+          if (follow) this.element.scrollTop = this.element.scrollHeight;
+        }
+      }
+
+      class Pane {
+        constructor(card) {
+          this.card = card;
+          this.channel = card.dataset.channel;
+          this.status = card.querySelector('.status');
+          this.terminal = card.querySelector('.terminal');
+          this.screen = new Screen(this.terminal);
+          this.socket = null;
+          this.generation = 0;
+          this.selecting = false;
+          this.terminal.addEventListener('keydown', event => this.keydown(event));
+          this.terminal.addEventListener('paste', event => this.paste(event));
+          this.terminal.addEventListener('pointerdown', event => this.pointerDown(event));
+          window.addEventListener('pointerup', event => this.pointerUp(event));
+          document.addEventListener('selectionchange', () => this.selectionChanged());
+          card.querySelector('button').addEventListener('click', () => this.connect());
+          this.connect();
+        }
+        state(state, label) { this.card.dataset.state = state; this.status.textContent = label; }
+        connect() {
+          const generation = ++this.generation;
+          if (this.socket) { this.socket.onclose = null; this.socket.close(); }
+          this.state('connecting', 'connecting');
+          const scheme = location.protocol === 'https:' ? 'wss' : 'ws';
+          const socket = new WebSocket(`${scheme}://${location.host}/ws/${this.channel}`);
+          socket.binaryType = 'arraybuffer';
+          this.socket = socket;
+          socket.onopen = () => { if (generation === this.generation) { this.state('open', 'connected'); this.terminal.focus(); } };
+          socket.onmessage = event => { if (generation === this.generation) this.screen.write(event.data); };
+          socket.onerror = () => { if (generation === this.generation) this.state('closed', 'error'); };
+          socket.onclose = () => { if (generation === this.generation) { this.state('closed', 'disconnected'); setTimeout(() => this.connect(), 1500); } };
+        }
+        keydown(event) {
+          const key = event.key.toLowerCase();
+          if (event.ctrlKey && key === 'c' && this.hasTerminalSelection()) {
+            this.copySelection(event);
+            return;
+          }
+          if ((event.ctrlKey && event.shiftKey && key === 'v') ||
+              (event.shiftKey && event.key === 'Insert')) {
+            return;
+          }
+          if (event.metaKey) return;
+          let text = keyBytes.get(event.key);
+          if (event.ctrlKey && event.key.length === 1) {
+            const code = event.key.toUpperCase().charCodeAt(0);
+            if (code >= 64 && code <= 95) text = String.fromCharCode(code & 31);
+          } else if (!event.ctrlKey && !event.altKey && event.key.length === 1) text = event.key;
+          else if (event.altKey && !event.ctrlKey && event.key.length === 1) text = '\x1b' + event.key;
+          if (text === undefined) return;
+          event.preventDefault();
+          this.screen.resumeRendering();
+          this.send(text);
+        }
+        paste(event) {
+          event.preventDefault();
+          this.screen.resumeRendering();
+          this.send(event.clipboardData.getData('text'));
+        }
+        pointerDown(event) {
+          if (event.button !== 0) return;
+          this.selecting = true;
+          this.screen.pauseRendering();
+        }
+        pointerUp(event) {
+          if (event.button !== 0 || !this.selecting) return;
+          this.selecting = false;
+          this.resumeRenderingWithoutSelection();
+        }
+        selectionChanged() {
+          if (!this.selecting) this.resumeRenderingWithoutSelection();
+        }
+        hasTerminalSelection() {
+          const selection = window.getSelection();
+          return selection && !selection.isCollapsed &&
+            this.terminal.contains(selection.anchorNode) &&
+            this.terminal.contains(selection.focusNode);
+        }
+        selectionTouchesTerminal() {
+          const selection = window.getSelection();
+          return selection && !selection.isCollapsed &&
+            (this.terminal.contains(selection.anchorNode) ||
+             this.terminal.contains(selection.focusNode));
+        }
+        resumeRenderingWithoutSelection() {
+          if (!this.selectionTouchesTerminal()) this.screen.resumeRendering();
+        }
+        copySelection(event) {
+          const selection = window.getSelection();
+          if (!this.hasTerminalSelection()) return;
+          event.preventDefault();
+          const text = selection.toString();
+          if (navigator.clipboard && window.isSecureContext) {
+            navigator.clipboard.writeText(text).catch(() => document.execCommand('copy'));
+          } else {
+            document.execCommand('copy');
+          }
+        }
+        send(text) {
+          if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+          const bytes = encoder.encode(text);
+          for (let offset = 0; offset < bytes.length; offset += 4096) this.socket.send(bytes.slice(offset, offset + 4096));
+        }
+      }
+
+      function addPane(console) {
+        if (typeof console.route !== 'string' || typeof console.name !== 'string') return;
+        const template = document.querySelector('#console-pane');
+        const card = template.content.firstElementChild.cloneNode(true);
+        card.dataset.channel = console.route;
+        card.querySelector('.name').textContent = console.name;
+        card.querySelector('.terminal').setAttribute('aria-label', `${console.name} terminal`);
+        document.querySelector('main').append(card);
+        new Pane(card);
+      }
+
+      async function loadStartupConsoles() {
+        let consoles;
+        try {
+          const response = await fetch('/api/consoles', { cache: 'no-store' });
+          if (!response.ok) throw new Error(`console discovery returned ${response.status}`);
+          consoles = await response.json();
+        } catch (_) {
+          consoles = [{ route: 'axvisor', name: 'Axvisor' }];
+        }
+        consoles.forEach(addPane);
+      }
+
+      loadStartupConsoles();
+    })();
+  </script>
+</body>
+</html>
+"##;

--- a/os/axvisor/src/http/mod.rs
+++ b/os/axvisor/src/http/mod.rs
@@ -1,25 +1,40 @@
-//! Management HTTP control plane.
+//! Optional HTTP services hosted by Axvisor.
 //!
 //! Served by an axum `Router` running on a tokio current-thread runtime
-//! (see [`server`]). The VM list/detail and start/stop lifecycle routes live
-//! in [`vm`]. JSON is built with `serde_json`.
+//! (see [`server`]). The browser console and VM management API are independent
+//! features that may share this listener when both are enabled.
 //!
-//! Security boundary: mutating routes require a build-time bearer token
-//! ([`auth`]); the server binds `127.0.0.1:8080` by default and only binds
-//! wider when `[env] AXVM_HTTP_BIND` opts in. See the per-module docs.
+//! The server binds `127.0.0.1:8080` by default and only binds wider when
+//! `[env] AXVM_HTTP_BIND` opts in. With `http-axum`, mutating VM routes also
+//! require the build-time bearer token implemented by the `auth` module.
 //!
-//! This whole module is only compiled under the `http-axum` feature, which is
-//! off by default. The hand-rolled HTTP/1.0 pilot was intentionally not
-//! carried forward.
+//! This module is compiled when either optional HTTP feature is selected. Both
+//! features are off by default.
 
+#[cfg(feature = "http-axum")]
 pub mod auth;
+#[cfg(feature = "browser-console")]
+pub mod browser_console;
 pub mod server;
+#[cfg(feature = "http-axum")]
 pub mod vm;
 
-/// Blocking entry point for the management HTTP server.
+/// Blocking entry point for the configured HTTP services.
 ///
 /// Spawned on its own task (see `crate::main`); builds the tokio runtime and
 /// serves until the hypervisor shuts down.
-pub fn serve() {
-    server::serve();
+pub fn serve() -> anyhow::Result<()> {
+    server::serve()
+}
+
+/// Configured HTTP listener address used by the startup access banner.
+#[cfg(feature = "browser-console")]
+pub(crate) fn bind_addr() -> &'static str {
+    server::bind_addr()
+}
+
+/// Whether the HTTP listener has successfully bound its configured address.
+#[cfg(feature = "browser-console")]
+pub(crate) fn is_listening() -> bool {
+    server::is_listening()
 }

--- a/os/axvisor/src/http/server.rs
+++ b/os/axvisor/src/http/server.rs
@@ -49,12 +49,45 @@
 //! - Device suspension covers only devices registered with lifecycle
 //!   semantics; other devices are not quiesced while paused.
 
-use axum::{Router, routing::get, routing::post};
+#[cfg(feature = "browser-console")]
+use core::sync::atomic::{AtomicBool, Ordering};
 
+use anyhow::Context;
+use axum::Router;
+
+#[cfg(feature = "http-axum")]
 use crate::http::vm;
+#[cfg(feature = "http-axum")]
+use axum::{routing::get, routing::post};
 
-/// Assemble the management routes.
+#[cfg(feature = "browser-console")]
+static LISTENING: AtomicBool = AtomicBool::new(false);
+
+#[cfg(feature = "browser-console")]
+struct ListeningGuard;
+
+#[cfg(feature = "browser-console")]
+impl Drop for ListeningGuard {
+    fn drop(&mut self) {
+        LISTENING.store(false, Ordering::Release);
+    }
+}
+
+/// Assemble only the HTTP services selected by build features.
 pub fn router() -> Router {
+    let router = Router::new();
+
+    #[cfg(feature = "http-axum")]
+    let router = router.merge(management_router());
+
+    #[cfg(feature = "browser-console")]
+    let router = router.merge(crate::http::browser_console::router());
+
+    router
+}
+
+#[cfg(feature = "http-axum")]
+fn management_router() -> Router {
     Router::new()
         .route("/api/vms", get(vm::list_vms))
         .route("/api/vms/{id}", get(vm::vm_detail).delete(vm::vm_delete))
@@ -72,7 +105,7 @@ pub fn router() -> Router {
 /// hostfwd to reach the in-guest listener must opt in to all interfaces by
 /// setting `[env] AXVM_HTTP_BIND = "0.0.0.0:8080"` in their build config; the
 /// mutating routes still require the bearer token regardless of the bind.
-fn bind_addr() -> &'static str {
+pub(super) fn bind_addr() -> &'static str {
     option_env!("AXVM_HTTP_BIND").unwrap_or("127.0.0.1:8080")
 }
 
@@ -81,17 +114,28 @@ fn bind_addr() -> &'static str {
 /// `main` spawns this on its own task via `std::thread::spawn(|| http::serve())`;
 /// the runtime is built here. Only the IO driver is enabled — the epoll
 /// reactor suffices for `axum::serve`; a time driver would need `timerfd`.
-pub fn serve() {
+pub fn serve() -> anyhow::Result<()> {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
         .build()
-        .expect("failed to build tokio runtime");
+        .context("failed to build Axvisor HTTP Tokio runtime")?;
     rt.block_on(async {
         let bind = bind_addr();
         let listener = tokio::net::TcpListener::bind(bind)
             .await
-            .expect("failed to bind management HTTP server");
-        info!("management HTTP server (axum) listening on {bind}");
-        axum::serve(listener, router()).await.expect("server error");
-    });
+            .with_context(|| format!("failed to bind Axvisor HTTP server at {bind}"))?;
+        #[cfg(feature = "browser-console")]
+        LISTENING.store(true, Ordering::Release);
+        #[cfg(feature = "browser-console")]
+        let _listening_guard = ListeningGuard;
+        info!("Axvisor HTTP server (axum) listening on {bind}");
+        axum::serve(listener, router())
+            .await
+            .context("Axvisor HTTP server stopped")
+    })
+}
+
+#[cfg(feature = "browser-console")]
+pub(crate) fn is_listening() -> bool {
+    LISTENING.load(Ordering::Acquire)
 }

--- a/os/axvisor/src/main.rs
+++ b/os/axvisor/src/main.rs
@@ -37,9 +37,13 @@ mod config;
 ))]
 mod console_regression;
 mod guest_console;
-#[cfg(feature = "http-axum")]
+#[cfg(any(feature = "browser-console", feature = "http-axum"))]
 mod http;
 mod manager;
+#[cfg(feature = "browser-console")]
+mod network_console;
+#[cfg(feature = "browser-console")]
+mod network_status;
 mod shell;
 
 #[cfg(any(feature = "backtrace", feature = "test-panic-no-backtrace"))]
@@ -73,8 +77,9 @@ fn init_atomic_output_panic_hook() {
 /// 2. Print the startup banner through its output worker.
 /// 3. Check and enable hardware virtualization on every CPU.
 /// 4. Build the default guest VMs.
-/// 5. Spawn the management plane first — the HTTP server so the API is live
-///    before any guest boots — then the VM lifecycle waiter and the shell.
+/// 5. Spawn the management plane first — the configured HTTP and network
+///    console services so they are live before any guest boots — then the VM
+///    lifecycle waiter and the physical-console shell.
 ///
 /// The vCPU tasks are pinned to the secondary CPUs via `phys_cpu_ids` in the
 /// VM configs, while the management console stays on the primary CPU.
@@ -103,17 +108,40 @@ fn main() {
 
     manager.init_default_vms();
 
-    // The management HTTP server accepts connections in a loop and needs its
-    // own task so neither the shell nor the VMM blocks it. It is spawned first
-    // so the management API is ready as early as possible. `ax_std::thread::spawn`
-    // only enqueues the task — the main task keeps running until it yields or
-    // blocks — so the server's bind does not necessarily happen before
-    // `launch_default_vms` queues the vCPU tasks; the ordering is best-effort.
-    #[cfg(feature = "http-axum")]
+    // The browser-console registry snapshots the successfully initialized
+    // default VM set exactly once. Initialize it before HTTP so the browser's
+    // `/api/consoles` endpoint cannot observe a partially configured layout.
+    #[cfg(feature = "browser-console")]
+    network_console::start()
+        .unwrap_or_else(|error| panic!("failed to initialize browser consoles: {error:#}"));
+
+    // The optional HTTP server accepts connections in a loop and needs its
+    // own task so neither the shell nor the VMM blocks it. The console registry
+    // is already complete when this task is enqueued, but the server's bind
+    // still races guest task scheduling because spawning only enqueues work.
+    #[cfg(any(feature = "browser-console", feature = "http-axum"))]
     std::thread::Builder::new()
         .name("axvisor-http".into())
-        .spawn(http::serve)
-        .unwrap_or_else(|error| panic!("failed to start management HTTP server: {error}"));
+        .spawn(|| {
+            #[cfg(feature = "browser-console")]
+            network_console::pin_current_task();
+
+            #[cfg(feature = "browser-console")]
+            if let Err(error) = http::serve() {
+                let message = format!(
+                    "\r\nAxvisor web console unavailable:\r\n  bind = {}\r\n  error = {error:#}\r\n",
+                    http::bind_addr()
+                );
+                guest_console::submit_host_bytes(message.as_bytes());
+            }
+
+            #[cfg(all(feature = "http-axum", not(feature = "browser-console")))]
+            http::serve().unwrap_or_else(|error| panic!("Axvisor HTTP server failed: {error:#}"));
+        })
+        .unwrap_or_else(|error| panic!("failed to start Axvisor HTTP server: {error}"));
+
+    #[cfg(feature = "browser-console")]
+    network_status::start();
 
     #[cfg(feature = "test-console-atomic-output")]
     console_regression::emit_atomic_output();

--- a/os/axvisor/src/manager.rs
+++ b/os/axvisor/src/manager.rs
@@ -61,11 +61,13 @@ impl AxvmManager {
     }
 
     /// Create one VM from a TOML config string.
+    #[cfg(any(feature = "fs", feature = "http-axum"))]
     pub fn create_vm_from_toml(raw_cfg: &str) -> Result<VMId> {
         crate::config::init_guest_vm(raw_cfg).context("create VM from TOML configuration")
     }
 
     /// Start a VM by ID.
+    #[cfg(any(feature = "fs", feature = "http-axum"))]
     pub fn start_vm(vm_id: VMId) -> Result<()> {
         AxvmRuntime::start_vm(vm_id).with_context(|| format!("start VM[{vm_id}]"))
     }
@@ -76,6 +78,7 @@ impl AxvmManager {
     }
 
     /// Pause a VM by ID.
+    #[cfg(feature = "http-axum")]
     pub fn pause_vm(vm_id: VMId) -> Result<()> {
         AxvmRuntime::pause_vm(vm_id).with_context(|| format!("pause VM[{vm_id}]"))
     }

--- a/os/axvisor/src/network_console/layout.rs
+++ b/os/axvisor/src/network_console/layout.rs
@@ -1,0 +1,57 @@
+//! Private startup layout for the board browser console.
+
+use alloc::{format, string::String, vec::Vec};
+
+pub(super) const MAX_GUEST_CONSOLES: usize = 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ConsoleLane(usize);
+
+impl ConsoleLane {
+    pub(super) const COUNT: usize = MAX_GUEST_CONSOLES + 1;
+    pub(super) const MANAGEMENT: Self = Self(0);
+
+    const fn guest(slot: usize) -> Self {
+        assert!(slot < MAX_GUEST_CONSOLES);
+        Self(slot + 1)
+    }
+
+    pub(super) const fn index(self) -> usize {
+        self.0
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct Endpoint {
+    pub(super) lane: ConsoleLane,
+    pub(super) vm_id: Option<usize>,
+    pub(super) route: String,
+    pub(super) display_name: String,
+}
+
+/// Plans one immutable browser layout from the VMs configured at startup.
+pub(super) fn plan_endpoints(mut guests: Vec<(usize, String)>) -> Vec<Endpoint> {
+    guests.sort_by_key(|(vm_id, _)| *vm_id);
+
+    let mut endpoints = Vec::with_capacity(guests.len().min(MAX_GUEST_CONSOLES) + 1);
+    endpoints.push(Endpoint {
+        lane: ConsoleLane::MANAGEMENT,
+        vm_id: None,
+        route: "axvisor".into(),
+        display_name: "Axvisor".into(),
+    });
+    for (slot, (vm_id, configured_name)) in guests.into_iter().take(MAX_GUEST_CONSOLES).enumerate()
+    {
+        endpoints.push(Endpoint {
+            lane: ConsoleLane::guest(slot),
+            vm_id: Some(vm_id),
+            route: format!("vm-{vm_id}"),
+            display_name: if configured_name.is_empty() {
+                format!("VM {vm_id}")
+            } else {
+                configured_name
+            },
+        });
+    }
+    endpoints
+}

--- a/os/axvisor/src/network_console/mod.rs
+++ b/os/axvisor/src/network_console/mod.rs
@@ -1,0 +1,390 @@
+//! Board-hosted browser transports for the Axvisor and guest consoles.
+
+use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::{string::String, sync::OnceLock};
+
+use anyhow::{Context, Result};
+use ax_std::os::arceos::{
+    modules::ax_task::{AxCpuMask, IrqNotify, set_current_affinity},
+    sync::NoPreemptMutex,
+};
+use axvisor::console_mux::HostOutputQueue;
+use axvm::VMId;
+
+mod layout;
+
+use layout::{ConsoleLane, Endpoint, plan_endpoints};
+
+const CONSOLE_LANE_COUNT: usize = ConsoleLane::COUNT;
+const OUTPUT_QUEUE_CAPACITY: usize = 64 * 1024;
+const OUTPUT_BATCH_CAPACITY: usize = 512;
+const MANAGEMENT_LINE_CAPACITY: usize = 256;
+const MANAGEMENT_CPU_ID: usize = 0;
+
+static OUTPUT_HUB: NetworkOutputHub = NetworkOutputHub::new();
+static ENDPOINTS: OnceLock<Vec<Endpoint>> = OnceLock::new();
+
+struct NetworkOutputHub {
+    queues: NoPreemptMutex<[HostOutputQueue<OUTPUT_QUEUE_CAPACITY>; CONSOLE_LANE_COUNT]>,
+    connected: [AtomicBool; CONSOLE_LANE_COUNT],
+    sessions: [AtomicUsize; CONSOLE_LANE_COUNT],
+    ready: [IrqNotify; CONSOLE_LANE_COUNT],
+}
+
+impl NetworkOutputHub {
+    const fn new() -> Self {
+        Self {
+            queues: NoPreemptMutex::new([
+                HostOutputQueue::new(),
+                HostOutputQueue::new(),
+                HostOutputQueue::new(),
+                HostOutputQueue::new(),
+            ]),
+            connected: [
+                AtomicBool::new(false),
+                AtomicBool::new(false),
+                AtomicBool::new(false),
+                AtomicBool::new(false),
+            ],
+            sessions: [
+                AtomicUsize::new(0),
+                AtomicUsize::new(0),
+                AtomicUsize::new(0),
+                AtomicUsize::new(0),
+            ],
+            ready: [
+                IrqNotify::new(),
+                IrqNotify::new(),
+                IrqNotify::new(),
+                IrqNotify::new(),
+            ],
+        }
+    }
+
+    fn submit(&self, lane: ConsoleLane, bytes: &[u8]) {
+        if bytes.is_empty() || !self.connected[lane.index()].load(Ordering::Acquire) {
+            return;
+        }
+        let submitted = {
+            let mut queues = self.queues.lock();
+            if !self.connected[lane.index()].load(Ordering::Acquire) {
+                false
+            } else {
+                queues[lane.index()].enqueue(bytes);
+                true
+            }
+        };
+        if submitted {
+            self.ready[lane.index()].notify_irq();
+        }
+    }
+
+    fn is_connected(&self, lane: ConsoleLane) -> bool {
+        self.connected[lane.index()].load(Ordering::Acquire)
+    }
+
+    fn begin_session(&self, lane: ConsoleLane) -> Option<usize> {
+        let mut queues = self.queues.lock();
+        self.connected[lane.index()]
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .ok()?;
+        queues[lane.index()] = HostOutputQueue::new();
+        self.ready[lane.index()].drain();
+        Some(
+            self.sessions[lane.index()]
+                .fetch_add(1, Ordering::AcqRel)
+                .wrapping_add(1),
+        )
+    }
+
+    fn end_session(&self, lane: ConsoleLane, session: usize) {
+        let mut queues = self.queues.lock();
+        if self.sessions[lane.index()].load(Ordering::Acquire) == session {
+            self.connected[lane.index()].store(false, Ordering::Release);
+            queues[lane.index()] = HostOutputQueue::new();
+            drop(queues);
+            self.ready[lane.index()].notify();
+        }
+    }
+
+    fn take_batch(&self, lane: ConsoleLane, session: usize) -> Option<NetworkOutputBatch> {
+        let mut queues = self.queues.lock();
+        if !self.connected[lane.index()].load(Ordering::Acquire)
+            || self.sessions[lane.index()].load(Ordering::Acquire) != session
+        {
+            return None;
+        }
+        let mut batch = NetworkOutputBatch::new();
+        batch.dropped_bytes = queues[lane.index()].take_dropped_bytes();
+        batch.len = queues[lane.index()].dequeue(&mut batch.bytes);
+        (!batch.is_empty()).then_some(batch)
+    }
+
+    fn receive(&self, lane: ConsoleLane, session: usize) -> Option<NetworkOutputBatch> {
+        loop {
+            if let Some(batch) = self.take_batch(lane, session) {
+                return Some(batch);
+            }
+            if !self.connected[lane.index()].load(Ordering::Acquire)
+                || self.sessions[lane.index()].load(Ordering::Acquire) != session
+            {
+                return None;
+            }
+            self.ready[lane.index()].wait();
+        }
+    }
+}
+
+struct NetworkOutputBatch {
+    bytes: [u8; OUTPUT_BATCH_CAPACITY],
+    len: usize,
+    dropped_bytes: usize,
+}
+
+impl NetworkOutputBatch {
+    const fn new() -> Self {
+        Self {
+            bytes: [0; OUTPUT_BATCH_CAPACITY],
+            len: 0,
+            dropped_bytes: 0,
+        }
+    }
+
+    const fn is_empty(&self) -> bool {
+        self.len == 0 && self.dropped_bytes == 0
+    }
+}
+
+struct ActiveSession {
+    lane: ConsoleLane,
+    session: usize,
+}
+
+impl ActiveSession {
+    fn install(lane: ConsoleLane) -> Result<Self> {
+        let session = OUTPUT_HUB.begin_session(lane).with_context(|| {
+            format!("{} console already has an active session", lane_name(lane))
+        })?;
+        Ok(Self { lane, session })
+    }
+}
+
+impl Drop for ActiveSession {
+    fn drop(&mut self) {
+        OUTPUT_HUB.end_session(self.lane, self.session);
+    }
+}
+
+/// Captures the immutable console layout after the startup VMs are registered.
+pub(crate) fn start() -> Result<()> {
+    ENDPOINTS
+        .set(build_startup_endpoints())
+        .map_err(|_| anyhow::anyhow!("browser console endpoints were already initialized"))
+}
+
+fn build_startup_endpoints() -> Vec<Endpoint> {
+    let guests = crate::manager::AxvmManager::vm_list()
+        .into_iter()
+        .map(|vm| (vm.id(), vm.name()))
+        .collect();
+    plan_endpoints(guests)
+}
+
+fn endpoints() -> &'static [Endpoint] {
+    ENDPOINTS.get().map(Vec::as_slice).unwrap_or(&[])
+}
+
+fn endpoint_for_lane(lane: ConsoleLane) -> Option<&'static Endpoint> {
+    endpoints().iter().find(|endpoint| endpoint.lane == lane)
+}
+
+fn endpoint_for_route(route: &str) -> Option<&'static Endpoint> {
+    endpoints().iter().find(|endpoint| endpoint.route == route)
+}
+
+fn lane_name(lane: ConsoleLane) -> String {
+    endpoint_for_lane(lane)
+        .map(|endpoint| endpoint.display_name.clone())
+        .unwrap_or_else(|| format!("console lane {}", lane.index()))
+}
+
+/// Pins one web-console service task to the management CPU.
+pub(crate) fn pin_current_task() {
+    assert!(
+        set_current_affinity(AxCpuMask::one_shot(MANAGEMENT_CPU_ID)),
+        "web console management CPU affinity must be valid"
+    );
+}
+
+/// Returns whether the startup snapshot exposed this browser route.
+pub(crate) fn has_console_route(route: &str) -> bool {
+    endpoint_for_route(route).is_some()
+}
+
+/// Browser-visible console descriptors for the startup VM snapshot.
+pub(crate) fn console_descriptions() -> Vec<ConsoleDescription> {
+    endpoints()
+        .iter()
+        .map(|endpoint| ConsoleDescription {
+            route: endpoint.route.clone(),
+            display_name: endpoint.display_name.clone(),
+        })
+        .collect()
+}
+
+/// One console entry returned to the embedded browser page.
+pub(crate) struct ConsoleDescription {
+    pub(crate) route: String,
+    pub(crate) display_name: String,
+}
+
+/// Copies Axvisor shell bytes into its fixed browser queue.
+pub(crate) fn submit_management_output(bytes: &[u8]) {
+    OUTPUT_HUB.submit(ConsoleLane::MANAGEMENT, bytes);
+}
+
+/// Returns whether one guest currently has an attached browser session.
+pub(crate) fn guest_output_connected(vm_id: VMId) -> bool {
+    endpoints()
+        .iter()
+        .find(|endpoint| endpoint.vm_id == Some(vm_id))
+        .is_some_and(|endpoint| OUTPUT_HUB.is_connected(endpoint.lane))
+}
+
+/// Copies current guest output into its VM-specific fixed browser queue.
+pub(crate) fn submit_guest_output(vm_id: VMId, bytes: &[u8]) {
+    let Some(lane) = endpoints()
+        .iter()
+        .find(|endpoint| endpoint.vm_id == Some(vm_id))
+        .map(|endpoint| endpoint.lane)
+    else {
+        return;
+    };
+    OUTPUT_HUB.submit(lane, bytes);
+}
+
+/// Opens one in-process browser transport on an existing console lane.
+pub(crate) fn open_browser_console(
+    route: &str,
+) -> Result<(BrowserConsoleInput, BrowserConsoleOutput)> {
+    let endpoint = endpoint_for_route(route)
+        .cloned()
+        .with_context(|| format!("unknown console endpoint `{route}`"))?;
+    let active_session = ActiveSession::install(endpoint.lane)?;
+    let lane = active_session.lane;
+    let session = active_session.session;
+    Ok((
+        BrowserConsoleInput {
+            endpoint,
+            editor: ManagementLineEditor::new(),
+            _active_session: active_session,
+        },
+        BrowserConsoleOutput { lane, session },
+    ))
+}
+
+/// Input half of a board-hosted browser console session.
+pub(crate) struct BrowserConsoleInput {
+    endpoint: Endpoint,
+    editor: ManagementLineEditor,
+    _active_session: ActiveSession,
+}
+
+impl BrowserConsoleInput {
+    /// Returns the session greeting sent before queued console output.
+    pub(crate) fn greeting(&self) -> String {
+        if let Some(vm_id) = self.endpoint.vm_id {
+            format!("[Axvisor] browser console attached to VM {vm_id}\r\n")
+        } else {
+            format!(
+                "Welcome to AxVisor Browser Shell!\r\nType 'help' for commands.\r\n{}",
+                crate::shell::network_prompt()
+            )
+        }
+    }
+
+    /// Routes browser bytes to the selected shell and reports whether it stays open.
+    pub(crate) fn route(&mut self, bytes: &[u8]) -> bool {
+        if let Some(vm_id) = self.endpoint.vm_id {
+            crate::guest_console::route_network_input(vm_id, bytes);
+            true
+        } else {
+            self.editor.process(bytes)
+        }
+    }
+}
+
+/// Blocking output half woken only by output or session closure.
+pub(crate) struct BrowserConsoleOutput {
+    lane: ConsoleLane,
+    session: usize,
+}
+
+impl BrowserConsoleOutput {
+    /// Waits for one bounded console batch or the browser session to close.
+    pub(crate) fn receive(&mut self) -> Option<Vec<u8>> {
+        let batch = OUTPUT_HUB.receive(self.lane, self.session)?;
+        let mut output = Vec::with_capacity(batch.len + 96);
+        if batch.dropped_bytes != 0 {
+            output.extend_from_slice(
+                format!(
+                    "\r\n[Axvisor browser console dropped {} queued bytes]\r\n",
+                    batch.dropped_bytes
+                )
+                .as_bytes(),
+            );
+        }
+        output.extend_from_slice(&batch.bytes[..batch.len]);
+        Some(output)
+    }
+}
+
+struct ManagementLineEditor {
+    line: [u8; MANAGEMENT_LINE_CAPACITY],
+    len: usize,
+    previous_was_cr: bool,
+}
+
+impl ManagementLineEditor {
+    const fn new() -> Self {
+        Self {
+            line: [0; MANAGEMENT_LINE_CAPACITY],
+            len: 0,
+            previous_was_cr: false,
+        }
+    }
+
+    fn process(&mut self, bytes: &[u8]) -> bool {
+        for &byte in bytes {
+            if byte == b'\n' && self.previous_was_cr {
+                self.previous_was_cr = false;
+                continue;
+            }
+            self.previous_was_cr = byte == b'\r';
+            match byte {
+                b'\r' | b'\n' => {
+                    submit_management_output(b"\r\n");
+                    let command = String::from_utf8_lossy(&self.line[..self.len]);
+                    self.len = 0;
+                    if !crate::shell::run_network_command(&command) {
+                        submit_management_output(b"Goodbye!\r\n");
+                        return false;
+                    }
+                    submit_management_output(crate::shell::network_prompt().as_bytes());
+                }
+                b'\x08' | b'\x7f' if self.len != 0 => {
+                    self.len -= 1;
+                    submit_management_output(b"\x08 \x08");
+                }
+                0x20..=0x7e if self.len < self.line.len() => {
+                    self.line[self.len] = byte;
+                    self.len += 1;
+                    submit_management_output(&[byte]);
+                }
+                0x20..=0x7e => submit_management_output(b"\x07"),
+                _ => {}
+            }
+        }
+        true
+    }
+}

--- a/os/axvisor/src/network_status.rs
+++ b/os/axvisor/src/network_status.rs
@@ -1,0 +1,93 @@
+//! Log-level-independent startup address for the board-hosted web console.
+
+use core::fmt::Write as _;
+use std::{
+    net::{IpAddr, SocketAddr},
+    string::{String, ToString},
+    thread,
+    time::Duration,
+};
+
+use ax_std::os::arceos::modules::ax_net::{self, InterfaceKind, Ipv4InterfaceConfig};
+
+use crate::guest_console;
+
+const ADDRESS_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+struct InterfaceAddress {
+    name: String,
+    ipv4: Ipv4InterfaceConfig,
+}
+
+/// Prints the first usable web-console address and then stops monitoring.
+pub(crate) fn start() {
+    if let Some(interface) = ready_interface() {
+        submit_access_banner(&interface);
+        return;
+    }
+
+    guest_console::submit_host_bytes(
+        b"\r\nAxvisor network waiting:\r\n\
+          no reachable web console address yet\r\n\
+          VM startup will continue while network configuration completes\r\n",
+    );
+    thread::Builder::new()
+        .name("axvisor-network-status".into())
+        .spawn(wait_for_ready_interface)
+        .expect("failed to start Axvisor network status reporter");
+}
+
+fn wait_for_ready_interface() {
+    crate::network_console::pin_current_task();
+    loop {
+        thread::sleep(ADDRESS_POLL_INTERVAL);
+        if let Some(interface) = ready_interface() {
+            submit_access_banner(&interface);
+            return;
+        }
+    }
+}
+
+fn ready_interface() -> Option<InterfaceAddress> {
+    if !crate::http::is_listening() {
+        return None;
+    }
+    ax_net::interfaces().into_iter().find_map(|interface| {
+        (interface.kind != InterfaceKind::Loopback)
+            .then_some(interface.ipv4)
+            .flatten()
+            .map(|ipv4| InterfaceAddress {
+                name: interface.name,
+                ipv4,
+            })
+    })
+}
+
+fn submit_access_banner(interface: &InterfaceAddress) {
+    let address = interface.ipv4.address.address();
+    let mut banner = String::new();
+    let _ = writeln!(banner, "\r\nAxvisor network ready:");
+    let _ = writeln!(banner, "  interface = {}", interface.name);
+    let _ = writeln!(
+        banner,
+        "  ipv4 = {address}/{}",
+        interface.ipv4.address.prefix_len()
+    );
+    append_web_console_endpoint(&mut banner, address, crate::http::bind_addr());
+    guest_console::submit_host_bytes(banner.as_bytes());
+}
+
+fn append_web_console_endpoint(
+    banner: &mut String,
+    assigned_address: impl core::fmt::Display,
+    bind: &str,
+) {
+    let Ok(bind) = bind.parse::<SocketAddr>() else {
+        return;
+    };
+    let host = match bind.ip() {
+        IpAddr::V4(ip) if ip.is_unspecified() => assigned_address.to_string(),
+        ip => ip.to_string(),
+    };
+    let _ = writeln!(banner, "  web_console = http://{host}:{}/", bind.port());
+}

--- a/os/axvisor/src/shell/command/base.rs
+++ b/os/axvisor/src/shell/command/base.rs
@@ -134,7 +134,7 @@ fn do_cat(cmd: &ParsedCommand) {
         loop {
             let n = file.read(&mut buf)?;
             if n > 0 {
-                crate::guest_console::submit_host_bytes(&buf[..n]);
+                crate::shell::submit_shell_bytes(&buf[..n]);
             } else {
                 return Ok(());
             }

--- a/os/axvisor/src/shell/command/vm.rs
+++ b/os/axvisor/src/shell/command/vm.rs
@@ -28,6 +28,7 @@ use crate::shell::command::{CommandNode, FlagDef, OptionDef, ParsedCommand};
 
 /// Check if a VM can transition to Running state.
 /// Returns Ok(()) if the transition is valid, Err with a message otherwise.
+#[cfg(feature = "fs")]
 fn can_start_vm(status: VmStatus) -> Result<(), &'static str> {
     match status {
         VmStatus::Ready | VmStatus::Stopped => Ok(()),
@@ -239,6 +240,7 @@ fn vm_start(cmd: &ParsedCommand) {
 
 /// Start a single VM by setting up vCPUs and calling boot.
 /// Returns Ok(()) if successful, Err otherwise.
+#[cfg(feature = "fs")]
 fn start_single_vm(vm: axvm::AxVMRef) -> anyhow::Result<()> {
     let vm_id = vm.id();
     let status = vm.status();
@@ -250,6 +252,7 @@ fn start_single_vm(vm: axvm::AxVMRef) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "fs")]
 fn start_vm_by_id(vm_id: usize, attach_console: bool) {
     match crate::manager::AxvmManager::with_vm(vm_id, |vm| start_single_vm(vm.clone())) {
         Some(Ok(_)) => {

--- a/os/axvisor/src/shell/mod.rs
+++ b/os/axvisor/src/shell/mod.rs
@@ -15,14 +15,31 @@
 use std::io::prelude::*;
 use std::string::ToString;
 
+#[cfg(feature = "browser-console")]
+use core::cell::Cell;
+
+#[cfg(feature = "browser-console")]
+std::thread_local! {
+    static NETWORK_OUTPUT_SELECTED: Cell<bool> = const { Cell::new(false) };
+}
+
 fn submit_shell_fragment(args: core::fmt::Arguments<'_>) {
     let output = axvisor::shell_support::format_fragment(args);
-    crate::guest_console::submit_host_bytes(output.as_bytes());
+    submit_shell_bytes(output.as_bytes());
 }
 
 fn submit_shell_line(args: core::fmt::Arguments<'_>) {
     let output = axvisor::shell_support::format_line(args);
-    crate::guest_console::submit_host_bytes(output.as_bytes());
+    submit_shell_bytes(output.as_bytes());
+}
+
+pub(crate) fn submit_shell_bytes(bytes: &[u8]) {
+    #[cfg(feature = "browser-console")]
+    if NETWORK_OUTPUT_SELECTED.with(Cell::get) {
+        crate::network_console::submit_management_output(bytes);
+        return;
+    }
+    crate::guest_console::submit_host_bytes(bytes);
 }
 
 macro_rules! print {
@@ -77,6 +94,32 @@ fn print_console_shortcuts() {
     println!("  Ctrl+X, then h  return to the Axvisor shell");
     println!("  Ctrl+X, then [  attach the previous running guest");
     println!("  Ctrl+X, then ]  attach the next running guest");
+}
+
+/// Executes one complete command for a connection-local network shell.
+///
+/// Returns `false` for `exit` and `quit`, which disconnect only that network
+/// client instead of shutting down the hypervisor.
+#[cfg(feature = "browser-console")]
+pub(crate) fn run_network_command(input: &str) -> bool {
+    let command = input.trim();
+    if matches!(command, "exit" | "quit") {
+        return false;
+    }
+
+    NETWORK_OUTPUT_SELECTED.with(|selected| {
+        let previous = selected.replace(true);
+        if !command.is_empty() && !handle_builtin_commands(command) {
+            run_cmd_bytes(command.as_bytes());
+        }
+        selected.set(previous);
+    });
+    true
+}
+
+#[cfg(feature = "browser-console")]
+pub(crate) fn network_prompt() -> String {
+    prompt_string()
 }
 
 fn route_pending_host_log(

--- a/os/axvisor/tests/axtest.rs
+++ b/os/axvisor/tests/axtest.rs
@@ -7,6 +7,14 @@ use ax_hal as _;
 use ax_std as _;
 use axvm as _;
 
+// Compile the production guest-console mux with narrow host/manager adapters
+// so its application-layer state machine is exercised by the kernel harness.
+#[path = "../src/network_console/layout.rs"]
+mod browser_console_layout;
+mod guest_console_harness;
+mod manager;
+mod network_console;
+
 #[axtest::tests]
 mod tests {
     use axtest::prelude::*;
@@ -22,6 +30,73 @@ mod tests {
         CopyMode, RemoveOptions, copy_path, ensure_recursive_destination_outside_source,
         metadata_for_remove, move_file_or_dir, remove_path, touch_file_at,
     };
+
+    #[test]
+    fn guest_output_reaches_only_its_network_console() {
+        use crate::{guest_console_harness::mux, network_console};
+
+        network_console::reset();
+        network_console::set_guest_connected(1);
+        network_console::set_guest_connected(2);
+        let backend_1 = mux::serial_backend_factory(1).create();
+        let backend_2 = mux::serial_backend_factory(2).create();
+        mux::mark_running(1);
+        mux::mark_running(2);
+
+        backend_1.write(b"starry output\n");
+        backend_2.write(b"zephyr output\n");
+
+        ax_assert_eq!(network_console::take_guest_output(1), b"starry output\n");
+        ax_assert_eq!(network_console::take_guest_output(2), b"zephyr output\n");
+        ax_assert!(network_console::take_guest_output(3).is_empty());
+        mux::remove(1);
+        mux::remove(2);
+    }
+
+    #[test]
+    fn guest_output_skips_network_path_without_a_browser_session() {
+        use crate::{guest_console_harness::mux, network_console};
+
+        network_console::reset();
+        let backend = mux::serial_backend_factory(1).create();
+        mux::mark_running(1);
+
+        backend.write(b"physical console only\n");
+
+        ax_assert!(network_console::take_guest_output(1).is_empty());
+        mux::remove(1);
+    }
+
+    #[test]
+    fn browser_console_layout_uses_at_most_three_sorted_guests() {
+        use crate::browser_console_layout::{ConsoleLane, MAX_GUEST_CONSOLES, plan_endpoints};
+
+        let endpoints = plan_endpoints(
+            [7, 5, 9, 3]
+                .into_iter()
+                .map(|vm_id| (vm_id, vm_id.to_string()))
+                .collect(),
+        );
+
+        ax_assert_eq!(endpoints.len(), MAX_GUEST_CONSOLES + 1);
+        ax_assert_eq!(ConsoleLane::COUNT, 4);
+        ax_assert_eq!(endpoints[0].route, "axvisor");
+        ax_assert_eq!(endpoints[1].vm_id, Some(3));
+        ax_assert_eq!(endpoints[2].vm_id, Some(5));
+        ax_assert_eq!(endpoints[3].vm_id, Some(7));
+        ax_assert_eq!(endpoints[3].lane.index(), 3);
+    }
+
+    #[test]
+    fn browser_console_layout_uses_configured_names_with_vm_fallback() {
+        use crate::browser_console_layout::plan_endpoints;
+
+        let endpoints = plan_endpoints(vec![(2, "zephyr".into()), (1, String::new())]);
+
+        ax_assert_eq!(endpoints[1].display_name, "VM 1");
+        ax_assert_eq!(endpoints[2].display_name, "zephyr");
+        ax_assert_eq!(endpoints[2].route, "vm-2");
+    }
 
     #[cfg(feature = "fs")]
     #[test]

--- a/os/axvisor/tests/guest_console_harness.rs
+++ b/os/axvisor/tests/guest_console_harness.rs
@@ -1,0 +1,17 @@
+//! Axtest adapters for the production guest-console mux.
+
+#![allow(
+    dead_code,
+    reason = "the harness compiles the complete production module but tests its private state machine"
+)]
+
+pub(crate) mod host {
+    pub(crate) fn submit_host_bytes(_bytes: &[u8]) {}
+
+    pub(crate) fn submit_host_transaction(transaction: impl FnOnce(&mut dyn FnMut(&[u8]))) {
+        transaction(&mut |_bytes| {});
+    }
+}
+
+#[path = "../src/guest_console/mux/mod.rs"]
+pub(crate) mod mux;

--- a/os/axvisor/tests/manager.rs
+++ b/os/axvisor/tests/manager.rs
@@ -1,0 +1,42 @@
+//! Minimal VM-manager surface required by the guest-console axtest harness.
+
+#![allow(
+    dead_code,
+    reason = "the production mux requires the complete manager surface at compile time"
+)]
+
+use alloc::vec::Vec;
+
+use anyhow::Result;
+use axvm::{VMId, VmStatus};
+
+pub(crate) struct TestVm {
+    id: VMId,
+    status: VmStatus,
+}
+
+impl TestVm {
+    pub(crate) fn id(&self) -> VMId {
+        self.id
+    }
+
+    pub(crate) fn status(&self) -> VmStatus {
+        self.status
+    }
+}
+
+pub(crate) struct AxvmManager;
+
+impl AxvmManager {
+    pub(crate) fn notify_vm(_vm_id: VMId) -> Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn vm_by_id(_vm_id: VMId) -> Option<TestVm> {
+        None
+    }
+
+    pub(crate) fn vm_list() -> Vec<TestVm> {
+        Vec::new()
+    }
+}

--- a/os/axvisor/tests/network_console.rs
+++ b/os/axvisor/tests/network_console.rs
@@ -1,0 +1,39 @@
+//! Network-output capture used by the guest-console axtest harness.
+
+use alloc::{
+    collections::{BTreeMap, BTreeSet},
+    vec::Vec,
+};
+use ax_std::sync::Mutex;
+use axvm::VMId;
+use std::sync::LazyLock;
+
+static GUEST_OUTPUT: LazyLock<Mutex<BTreeMap<VMId, Vec<u8>>>> =
+    LazyLock::new(|| Mutex::new(BTreeMap::new()));
+static CONNECTED_GUESTS: LazyLock<Mutex<BTreeSet<VMId>>> =
+    LazyLock::new(|| Mutex::new(BTreeSet::new()));
+
+pub(crate) fn guest_output_connected(vm_id: VMId) -> bool {
+    CONNECTED_GUESTS.lock().contains(&vm_id)
+}
+
+pub(crate) fn submit_guest_output(vm_id: VMId, bytes: &[u8]) {
+    GUEST_OUTPUT
+        .lock()
+        .entry(vm_id)
+        .or_default()
+        .extend_from_slice(bytes);
+}
+
+pub(crate) fn reset() {
+    GUEST_OUTPUT.lock().clear();
+    CONNECTED_GUESTS.lock().clear();
+}
+
+pub(crate) fn set_guest_connected(vm_id: VMId) {
+    CONNECTED_GUESTS.lock().insert(vm_id);
+}
+
+pub(crate) fn take_guest_output(vm_id: VMId) -> Vec<u8> {
+    GUEST_OUTPUT.lock().remove(&vm_id).unwrap_or_default()
+}

--- a/test-suit/axvisor/normal/qemu-browser-console/browser-console/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-browser-console/browser-console/http_probe.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Validate the minimal Axvisor browser console through QEMU hostfwd."""
+
+import base64
+import json
+import os
+import socket
+import struct
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+
+BASE = os.environ.get("AXVISOR_HTTP_BASE", "http://127.0.0.1:8080").rstrip("/")
+CONNECT_TIMEOUT = float(os.environ.get("AXVISOR_HTTP_CONNECT_TIMEOUT", "120"))
+REQUEST_TIMEOUT = float(os.environ.get("AXVISOR_HTTP_REQUEST_TIMEOUT", "5"))
+POLL_INTERVAL = 0.05
+
+
+def get(path):
+    """Return one HTTP GET status and body without treating errors as fatal."""
+    request = urllib.request.Request(BASE + path, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT) as response:
+            return response.status, response.read()
+    except urllib.error.HTTPError as error:
+        return error.code, error.read()
+
+
+def expect_status(label, actual, expected):
+    if actual != expected:
+        raise AssertionError("%s returned %d, expected %d" % (label, actual, expected))
+    print("  browser console probe: %s -> %d" % (label, actual))
+
+
+def poll_ready():
+    """Wait for guest HTTP, not merely QEMU's already-open hostfwd socket."""
+    deadline = time.monotonic() + CONNECT_TIMEOUT
+    last_error = None
+    while time.monotonic() < deadline:
+        try:
+            status, _ = get("/api/consoles")
+            if status == 200:
+                print("  browser console probe: guest HTTP server reachable")
+                return
+            last_error = "HTTP %d" % status
+        except (OSError, urllib.error.URLError) as error:
+            last_error = str(error)
+        time.sleep(POLL_INTERVAL)
+    raise AssertionError("guest HTTP server did not become ready: %s" % last_error)
+
+
+class WebSocket:
+    """Small RFC 6455 client sufficient for the in-guest console checks."""
+
+    def __init__(self, stream, buffered):
+        self.stream = stream
+        self.buffered = buffered
+
+    def recv_exact(self, length):
+        while len(self.buffered) < length:
+            chunk = self.stream.recv(length - len(self.buffered))
+            if not chunk:
+                raise AssertionError("WebSocket closed while receiving a frame")
+            self.buffered += chunk
+        output = self.buffered[:length]
+        self.buffered = self.buffered[length:]
+        return output
+
+    def recv_frame(self):
+        first, second = self.recv_exact(2)
+        opcode = first & 0x0F
+        length = second & 0x7F
+        if length == 126:
+            length = struct.unpack("!H", self.recv_exact(2))[0]
+        elif length == 127:
+            length = struct.unpack("!Q", self.recv_exact(8))[0]
+        if second & 0x80:
+            mask = self.recv_exact(4)
+            payload = bytes(
+                byte ^ mask[index % 4]
+                for index, byte in enumerate(self.recv_exact(length))
+            )
+        else:
+            payload = self.recv_exact(length)
+        return opcode, payload
+
+    def send_binary(self, payload):
+        mask = os.urandom(4)
+        length = len(payload)
+        if length < 126:
+            header = bytes([0x82, 0x80 | length])
+        elif length <= 0xFFFF:
+            header = bytes([0x82, 0x80 | 126]) + struct.pack("!H", length)
+        else:
+            header = bytes([0x82, 0x80 | 127]) + struct.pack("!Q", length)
+        masked = bytes(
+            byte ^ mask[index % 4] for index, byte in enumerate(payload)
+        )
+        self.stream.sendall(header + mask + masked)
+
+    def close(self):
+        self.stream.close()
+
+
+def open_websocket(path, origin=None):
+    parsed = urllib.parse.urlsplit(BASE)
+    host = parsed.hostname
+    port = parsed.port or 80
+    authority = "%s:%d" % (host, port)
+    origin = origin or BASE
+    key = base64.b64encode(os.urandom(16)).decode("ascii")
+    stream = socket.create_connection((host, port), timeout=REQUEST_TIMEOUT)
+    stream.settimeout(REQUEST_TIMEOUT)
+    request = (
+        "GET %s HTTP/1.1\r\n"
+        "Host: %s\r\n"
+        "Origin: %s\r\n"
+        "Upgrade: websocket\r\n"
+        "Connection: Upgrade\r\n"
+        "Sec-WebSocket-Version: 13\r\n"
+        "Sec-WebSocket-Key: %s\r\n\r\n"
+    ) % (path, authority, origin, key)
+    stream.sendall(request.encode("ascii"))
+    response = b""
+    while b"\r\n\r\n" not in response:
+        chunk = stream.recv(4096)
+        if not chunk:
+            raise AssertionError("HTTP server closed during WebSocket upgrade")
+        response += chunk
+    response_head, buffered = response.split(b"\r\n\r\n", 1)
+    return WebSocket(stream, buffered), response_head + b"\r\n\r\n"
+
+
+def expect_upgrade(path, expected, origin=None):
+    websocket, response = open_websocket(path, origin)
+    prefix = ("HTTP/1.1 %d" % expected).encode("ascii")
+    if not response.startswith(prefix):
+        websocket.close()
+        raise AssertionError("%s upgrade returned %r" % (path, response))
+    return websocket
+
+
+def receive_until(websocket, marker):
+    output = b""
+    deadline = time.monotonic() + REQUEST_TIMEOUT
+    while marker not in output:
+        if time.monotonic() >= deadline:
+            raise AssertionError("WebSocket output did not contain %r" % marker)
+        opcode, payload = websocket.recv_frame()
+        if opcode in (1, 2):
+            output += payload
+        elif opcode == 8:
+            raise AssertionError("WebSocket closed before output marker %r" % marker)
+    return output
+
+
+def check_page():
+    status, page = get("/")
+    expect_status("GET /", status, 200)
+    for marker in (
+        b"/api/consoles",
+        b"terminal-cursor",
+        b"pauseRendering()",
+        b"selectionchange",
+    ):
+        if marker not in page:
+            raise AssertionError("embedded page is missing %r" % marker)
+    for external_asset in (
+        b"https://",
+        b"http://",
+        b"<script src=",
+        b'<link rel="stylesheet"',
+    ):
+        if external_asset in page:
+            raise AssertionError("embedded page depends on %r" % external_asset)
+
+    status, body = get("/api/consoles")
+    expect_status("GET /api/consoles", status, 200)
+    consoles = json.loads(body.decode("utf-8"))
+    expected = [{"route": "axvisor", "name": "Axvisor"}]
+    if consoles != expected:
+        raise AssertionError("console snapshot returned %r, expected %r" % (consoles, expected))
+
+    status, _ = get("/api/vms")
+    expect_status("GET /api/vms without http-axum", status, 404)
+
+
+def check_websocket():
+    websocket = expect_upgrade("/ws/axvisor", 101)
+    receive_until(websocket, b"Welcome to AxVisor Browser Shell!")
+    websocket.send_binary(b"help\r")
+    receive_until(websocket, b"ArceOS Shell - Available Commands:")
+    print("  browser console probe: Axvisor WebSocket -> interactive")
+
+    duplicate = expect_upgrade("/ws/axvisor", 409)
+    duplicate.close()
+    print("  browser console probe: duplicate Axvisor WebSocket -> 409")
+
+    rejected = expect_upgrade("/ws/axvisor", 403, "https://unrelated.example")
+    rejected.close()
+    print("  browser console probe: cross-origin WebSocket -> 403")
+
+    missing = expect_upgrade("/ws/vm-1", 404)
+    missing.close()
+    print("  browser console probe: absent VM WebSocket -> 404")
+
+    websocket.close()
+    deadline = time.monotonic() + REQUEST_TIMEOUT
+    while True:
+        reopened, response = open_websocket("/ws/axvisor")
+        if response.startswith(b"HTTP/1.1 101"):
+            reopened.close()
+            break
+        reopened.close()
+        if not response.startswith(b"HTTP/1.1 409") or time.monotonic() >= deadline:
+            raise AssertionError("released Axvisor WebSocket did not reopen: %r" % response)
+        time.sleep(POLL_INTERVAL)
+    print("  browser console probe: released Axvisor WebSocket -> reusable")
+
+
+def main():
+    poll_ready()
+    check_page()
+    check_websocket()
+    print("  browser console probe: PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/test-suit/axvisor/normal/qemu-browser-console/browser-console/qemu-aarch64.toml
+++ b/test-suit/axvisor/normal/qemu-browser-console/browser-console/qemu-aarch64.toml
@@ -1,0 +1,22 @@
+args = [
+    "-nographic",
+    "-cpu",
+    "cortex-a72",
+    "-machine",
+    "virt,virtualization=on,gic-version=3",
+    "-smp",
+    "2",
+    "-m",
+    "512M",
+]
+fail_regex = [
+    "(?i)\\bpanic(?:ked)?\\b",
+    "(?i)kernel panic",
+]
+# The host-side probe is the verdict and terminates QEMU through QMP.
+success_regex = []
+timeout = 180
+to_bin = true
+uefi = false
+
+[host_http_probe]

--- a/test-suit/axvisor/normal/qemu-browser-console/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/qemu-browser-console/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,11 @@
+# Minimal browser-console build. No VM image or filesystem is required: the
+# host-side probe validates Axvisor's own console lane and the embedded page,
+# while axtest covers startup layouts containing one to three guests.
+features = ["browser-console"]
+log = "Info"
+target = "aarch64-unknown-none-softfloat"
+vm_configs = []
+
+[env]
+# QEMU hostfwd reaches the guest through its non-loopback interface.
+AXVM_HTTP_BIND = "0.0.0.0:8080"


### PR DESCRIPTION
## 问题

Axvisor 使用单个物理串口承载管理 Shell 和多个客户机控制台。现有物理串口复用支持通过快捷键切换客户机，但无法在多个独立窗口中同时查看和操作 Axvisor Shell 与不同客户机 Shell。

本次改动增加一个由 Axvisor 自身发布的网页控制台，使浏览器可以通过独立 WebSocket 通道访问 Axvisor Shell 和客户机虚拟串口，同时保持原物理串口流程不变。

## 改动内容

### 1. 增加独立的 `browser-console` feature

新增可选 feature：

```toml
browser-console = [
  "ax-std/net",
  "axum/ws",
  "dep:axum",
  "dep:futures-util",
  "dep:serde_json",
  "dep:tokio",
]
```

该 feature 默认关闭。

未启用时，不会初始化网页端点、网络输出队列、HTTP 服务或网络状态报告，原有物理串口和客户机控制台流程保持不变。

`browser-console` 与现有 `http-axum` VM 管理 API 相互独立：

- 只启用 `browser-console` 时，仅提供网页和控制台字符流。
- 不会暴露 `/api/vms` VM 管理接口。
- 两个 feature 同时启用时，共享同一个 axum HTTP listener。

### 2. 增加启动时控制台布局

Axvisor 在默认客户机初始化完成后获取一次 VM 列表，并建立不可变的网页控制台布局：

- 始终提供 Axvisor 管理 Shell。
- 按 VM ID 排序。
- 最多提供前三个客户机控制台。
- 客户机显示名称优先使用 VM TOML 中配置的名称。
- 名称为空时回退为 `VM <id>`。
- 超过三个的客户机仍正常启动，只是不暴露对应网页通道。
- 运行期间创建或删除 VM 不重新生成网页布局。

网页通过以下接口获取布局：

```text
GET /api/consoles
```

控制台字符流使用：

```text
/ws/axvisor
/ws/vm-<id>
```

### 3. 增加独立的有界输出通道

Axvisor Shell 和最多三个客户机分别使用独立的固定容量输出队列。

每个通道具有以下行为：

- 同时只允许一个浏览器会话。
- 没有浏览器连接时直接跳过网络输出路径。
- 不保存网页打开前的历史输出。
- 慢客户端只影响自己的队列。
- 队列溢出时丢弃旧输出并向浏览器报告丢失字节数。
- 使用 `IrqNotify` 等待输出，不进行固定周期轮询。

客户机输出仍继续进入原物理串口复用流程；网页输出是额外的旁路，不改变物理前台客户机。

### 4. 增加客户机 WebSocket 输入路由

网页客户机输入按 VM ID 直接送入对应虚拟 UART 输入队列，并复用现有 VM 唤醒机制。

该路径：

- 不读取物理串口。
- 不解析物理串口的 `Ctrl+X` 快捷键。
- 不修改物理串口当前附着的客户机。
- 拒绝已停止的 VM 或失效的串口 backend。
- 保持现有输入队列容量和溢出处理。

### 5. 增加 Axvisor 网页 Shell

Axvisor 网页 Shell 使用连接独立的简单行编辑器，支持：

- 可打印字符
- 回车
- 退格
- `exit`/`quit` 只关闭当前网页会话
- 执行现有 Axvisor Shell 命令

通过线程局部输出选择，将网页发起命令的输出发送到当前网页通道，不污染物理 Shell 的交互输出。

物理串口 Shell 仍保留原有 history、方向键和 Tab 处理；网页管理 Shell 当前不复用这些高级行编辑能力。

### 6. 内嵌自包含网页

HTML、CSS 和 JavaScript 直接编译进 Axvisor，不依赖：

- 开发板根文件系统
- 命令执行主机的网页代理
- GitHub
- CDN
- 外部 JavaScript/CSS 文件

页面支持：

- 根据 `/api/consoles` 自动创建窗格
- WebSocket 自动连接和手动重连
- 基本 ANSI/CSI 显示
- Tab 对齐
- 闪烁光标
- 鼠标文本选择
- 浏览器粘贴事件
- 控制台输出滚动和容量限制

鼠标选择期间暂停 DOM 重绘，避免松开鼠标时产生错误的终端按键序列或破坏选区。

### 7. 启动时打印访问地址

启用 `browser-console` 后，Axvisor 会等待：

1. HTTP listener 成功绑定；
2. 非 loopback 网络接口获得 IPv4 地址。

准备完成后，无论当前日志等级如何，都会通过宿主控制台打印：

```text
Axvisor network ready:
  interface = eth0
  ipv4 = <address>/<prefix>
  web_console = http://<address>:8080/
```

如果网络暂未准备完成，VM 启动不会失败；Axvisor 会继续运行，并在后台等待地址就绪。

如果 HTTP bind 失败，会在物理控制台报告错误，但不会让客户机启动流程因网页功能失败而终止。

### 8. 收紧 VM 管理方法的 feature 边界

`AxvmManager` 中只被文件系统 Shell 或 `http-axum` 使用的方法增加条件编译：

- `create_vm_from_toml`：`fs` 或 `http-axum`
- `start_vm`：`fs` 或 `http-axum`
- `pause_vm`：仅 `http-axum`

这样只启用 `browser-console` 时不会编译未使用的 VM 管理入口，也无需通过 `allow(dead_code)` 隐藏 Clippy 告警。

## 测试

### Axvisor library tests

```bash
cargo test -p axvisor --lib
```

结果：

```text
24 passed; 0 failed
```

### Axvisor axtest

```bash
cargo xtask ktest qemu \
  -p axvisor \
  --test axtest \
  --arch aarch64 \
  --offline
```

结果：

```text
AXTEST_SUMMARY pass=54 fail=0 skip=0 total=54
```

新增覆盖包括：

- 网络输入不改变物理串口前台客户机。
- 停止或 backend 失效的客户机拒绝网络输入。
- 客户机输出只进入对应网页通道。
- 无网页连接时跳过网络输出。
- VM 按 ID 排序。
- 使用配置名称及空名称回退。
- 最多选择三个客户机。

### 独立 browser-console QEMU 测试

```bash
cargo xtask axvisor test qemu \
  --arch aarch64 \
  --test-case browser-console
```

该用例只启用 `browser-console`，不配置客户机、rootfs、NVMe 或 `http-axum`。

验证内容：

- Axvisor HTTP 服务正常启动。
- 内嵌网页可访问且不依赖外部资源。
- `/api/consoles` 返回 Axvisor 控制台。
- `/api/vms` 返回 404，证明没有隐式启用 VM 管理 API。
- `/ws/axvisor` 可以接收 `help` 并返回 Shell 输出。
- 同一控制台的第二个连接返回 409。
- 跨域 WebSocket 返回 403。
- 未配置的 VM WebSocket 返回 404。
- 连接关闭后可以重新建立会话。

结果：

```text
PASS browser-console
```

### 原 VM 管理 API 回归

```bash
cargo xtask axvisor test qemu \
  --arch aarch64 \
  --test-case http-control-plane
```

结果：

```text
PASS http-control-plane
```

证明共享 HTTP server 的调整没有改变原 `http-axum` VM 管理接口。

### Clippy

使用与 Axvisor QEMU 构建一致的 aarch64-musl 目标分别检查：

```text
browser-console
browser-console,fs
```

均通过 `-D warnings`。

同时通过：

```bash
cargo fmt -p axvisor -- --check
git diff --check
```

## 本次不包含

- OrangePi 专用构建配置
- 开发板 CI 配置
- Raw TCP 控制台
- VM 管理网页
- TLS 或用户认证
- 运行期间动态增加网页通道
- 超过三个客户机的网页显示
- 网页打开前输出回放
- 完整终端模拟器和 Axvisor 网页 Shell 的 history/Tab 自动补全

当前 WebSocket 控制台没有 TLS 和认证，只适用于受信任的管理网络。