### PR TITLE
feat(media): add v4l2 framework support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ax-media"
+version = "0.1.0"
+dependencies = [
+ "ax-alloc",
+ "ax-memory-addr",
+ "ax-mm",
+ "ax-runtime",
+ "ax-sync",
+ "ax-task",
+ "axpoll",
+ "bitflags 2.13.1",
+ "log",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "ax-memory-addr"
 version = "0.7.0"
 
@@ -5038,6 +5054,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
 
 [[package]]
+name = "media-uvc"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ax-media",
+ "ax-sync",
+ "ax-task",
+ "axpoll",
+ "bitflags 2.13.1",
+ "crab-usb",
+ "log",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7819,6 +7849,7 @@ dependencies = [
 name = "starry-kernel"
 version = "0.8.3"
 dependencies = [
+ "anyhow",
  "ax-alloc",
  "ax-cgroup",
  "ax-cpu",
@@ -7832,6 +7863,7 @@ dependencies = [
  "ax-ipi",
  "ax-lazyinit",
  "ax-log",
+ "ax-media",
  "ax-memory-addr",
  "ax-memory-set",
  "ax-mm",
@@ -7839,12 +7871,11 @@ dependencies = [
  "ax-percpu",
  "ax-runtime",
  "ax-std",
+ "ax-sync",
  "ax-task",
  "ax-tracepoint",
  "axbacktrace",
  "axfs-ng-vfs",
- "axhvc",
- "axivc",
  "axklib",
  "axplat-dyn",
  "axpoll",
@@ -7876,6 +7907,7 @@ dependencies = [
  "linux-raw-sys 0.12.1",
  "lock_api",
  "lwprintf-rs",
+ "media-uvc",
  "num_enum",
  "ouroboros",
  "rand 0.10.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ members = [
     "drivers/gpu/*",
     "drivers/intc/*",
     "drivers/interface/*",
+    "drivers/media/*",
     "drivers/net/*",
     "drivers/npu/*",
     "drivers/pci/*",
@@ -254,6 +255,8 @@ crab-uvc = { version = "0.1", path = "drivers/usb/usb-device/uvc" }
 ktest-helper = { version = "0.1", path = "drivers/usb/utils/ktest-helper" }
 usb-if = { version = "0.8", path = "drivers/usb/usb-if" }
 usb-serial = { version = "0.1", path = "drivers/usb/usb-serial" }
+ax-media = { version = "0.1", path = "drivers/media/ax-media" }
+media-uvc = { version = "0.1", path = "drivers/media/uvc" }
 dwmmc-host = { version = "0.4", path = "drivers/blk/dwmmc-host", default-features = false }
 phytium-mci-host = { version = "0.4", path = "drivers/blk/phytium-mci-host", default-features = false }
 cv181x-sdhci = { version = "0.1", path = "drivers/blk/cv181x-sdhci", default-features = false }

--- a/drivers/media/ax-media/Cargo.toml
+++ b/drivers/media/ax-media/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ax-media"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+ax-alloc = { workspace = true }
+ax-memory-addr = { workspace = true }
+ax-runtime = { workspace = true }
+ax-mm = { workspace = true }
+ax-sync = { workspace = true, features = ["sleep"] }
+axpoll = { workspace = true }
+ax-task = { workspace = true }
+bitflags = { workspace = true }
+log = { workspace = true }
+thiserror = { workspace = true }

--- a/drivers/media/ax-media/src/ctrls/class/camera.rs
+++ b/drivers/media/ax-media/src/ctrls/class/camera.rs
@@ -1,0 +1,57 @@
+//! 相机类控件（`V4L2_CTRL_CLASS_CAMERA = 0x009a0000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_CAMERA` —— 相机类控件。
+pub const CLASS_ID: u32 = CtrlClass::Camera as u32;
+
+/// `V4L2_CID_CAMERA_CLASS = (V4L2_CTRL_CLASS_CAMERA | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_CAMERA_CLASS_BASE = (V4L2_CTRL_CLASS_CAMERA | 0x900) = 0x009a0900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// V4L2 相机类控制 ID（`V4L2_CID_CAMERA_CLASS_BASE` + 偏移）。
+///
+/// 设计：`V4L2_CID_EXPOSURE_AUTO = (V4L2_CTRL_CLASS_CAMERA | 0x900) + 1`。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CameraClassCtrl {
+    Class                = CID_CLASS,
+    ExposureAuto         = CID_BASE + 1,
+    ExposureAbsolute     = CID_BASE + 2,
+    ExposureAutoPriority = CID_BASE + 3,
+    PanRelative          = CID_BASE + 4,
+    TiltRelative         = CID_BASE + 5,
+    PanReset             = CID_BASE + 6,
+    TiltReset            = CID_BASE + 7,
+    PanAbsolute          = CID_BASE + 8,
+    TiltAbsolute         = CID_BASE + 9,
+    FocusAbsolute        = CID_BASE + 10,
+    FocusRelative        = CID_BASE + 11,
+    FocusAuto            = CID_BASE + 12,
+    ZoomAbsolute         = CID_BASE + 13,
+    ZoomRelative         = CID_BASE + 14,
+    ZoomContinuous       = CID_BASE + 15,
+    Privacy              = CID_BASE + 16,
+    IrisAbsolute         = CID_BASE + 17,
+    IrisRelative         = CID_BASE + 18,
+    AutoExposureBias     = CID_BASE + 19,
+    AutoNPresetWhiteBalance = CID_BASE + 20,
+    WideDynamicRange     = CID_BASE + 21,
+    ImageStabilization   = CID_BASE + 22,
+    IsoSensitivity       = CID_BASE + 23,
+    IsoSensitivityAuto   = CID_BASE + 24,
+    ExposureMetering     = CID_BASE + 25,
+    SceneMode            = CID_BASE + 26,
+    ThreeALock           = CID_BASE + 27,
+    AutoFocusStart       = CID_BASE + 28,
+    AutoFocusStop        = CID_BASE + 29,
+    AutoFocusStatus      = CID_BASE + 30,
+    AutoFocusRange       = CID_BASE + 31,
+    PanSpeed             = CID_BASE + 32,
+    TiltSpeed            = CID_BASE + 33,
+    CameraOrientation    = CID_BASE + 34,
+    CameraSensorRotation = CID_BASE + 35,
+    HdrSensorMode        = CID_BASE + 36,
+}

--- a/drivers/media/ax-media/src/ctrls/class/codec.rs
+++ b/drivers/media/ax-media/src/ctrls/class/codec.rs
@@ -1,0 +1,927 @@
+//! 有状态编解码控件。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_CODEC` —— 有状态编解码控件。
+pub const CLASS_ID: u32 = CtrlClass::Codec as u32;
+
+/// `V4L2_CID_CODEC_CLASS = (V4L2_CTRL_CLASS_CODEC | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_CODEC_BASE = (V4L2_CTRL_CLASS_CODEC | 0x900) = 0x00990900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// `V4L2_CID_CODEC_CX2341X_BASE = (V4L2_CTRL_CLASS_CODEC | 0x1000) = 0x00991000`。
+pub const CX2341X_CID_BASE: u32 = CLASS_ID | 0x1000;
+
+/// `V4L2_CID_CODEC_MFC51_BASE = (V4L2_CTRL_CLASS_CODEC | 0x1100) = 0x00991100`。
+pub const MFC51_CID_BASE: u32 = CLASS_ID | 0x1100;
+
+// ── 菜单枚举 ─────────────────────────────────────────────────
+
+/// `enum v4l2_mpeg_stream_type` —— `V4L2_CID_MPEG_STREAM_TYPE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegStreamType {
+    Mpeg2Ps   = 0,
+    Mpeg2Ts   = 1,
+    Mpeg1Ss   = 2,
+    Mpeg2Dvd  = 3,
+    Mpeg1Vcd  = 4,
+    Mpeg2Svcd = 5,
+}
+
+/// `enum v4l2_mpeg_stream_vbi_fmt` —— `V4L2_CID_MPEG_STREAM_VBI_FMT` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegStreamVbiFmt {
+    None = 0,
+    Ivtv = 1,
+}
+
+/// `enum v4l2_mpeg_audio_sampling_freq` —— `V4L2_CID_MPEG_AUDIO_SAMPLING_FREQ` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioSamplingFreq {
+    Hz44100 = 0,
+    Hz48000 = 1,
+    Hz32000 = 2,
+}
+
+/// `enum v4l2_mpeg_audio_encoding` —— `V4L2_CID_MPEG_AUDIO_ENCODING` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioEncoding {
+    Layer1 = 0,
+    Layer2 = 1,
+    Layer3 = 2,
+    Aac    = 3,
+    Ac3    = 4,
+}
+
+/// `enum v4l2_mpeg_audio_l1_bitrate` —— `V4L2_CID_MPEG_AUDIO_L1_BITRATE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioL1Bitrate {
+    Kbps32  = 0,
+    Kbps64  = 1,
+    Kbps96  = 2,
+    Kbps128 = 3,
+    Kbps160 = 4,
+    Kbps192 = 5,
+    Kbps224 = 6,
+    Kbps256 = 7,
+    Kbps288 = 8,
+    Kbps320 = 9,
+    Kbps352 = 10,
+    Kbps384 = 11,
+    Kbps416 = 12,
+    Kbps448 = 13,
+}
+
+/// `enum v4l2_mpeg_audio_l2_bitrate` —— `V4L2_CID_MPEG_AUDIO_L2_BITRATE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioL2Bitrate {
+    Kbps32  = 0,
+    Kbps48  = 1,
+    Kbps56  = 2,
+    Kbps64  = 3,
+    Kbps80  = 4,
+    Kbps96  = 5,
+    Kbps112 = 6,
+    Kbps128 = 7,
+    Kbps160 = 8,
+    Kbps192 = 9,
+    Kbps224 = 10,
+    Kbps256 = 11,
+    Kbps320 = 12,
+    Kbps384 = 13,
+}
+
+/// `enum v4l2_mpeg_audio_l3_bitrate` —— `V4L2_CID_MPEG_AUDIO_L3_BITRATE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioL3Bitrate {
+    Kbps32  = 0,
+    Kbps40  = 1,
+    Kbps48  = 2,
+    Kbps56  = 3,
+    Kbps64  = 4,
+    Kbps80  = 5,
+    Kbps96  = 6,
+    Kbps112 = 7,
+    Kbps128 = 8,
+    Kbps160 = 9,
+    Kbps192 = 10,
+    Kbps224 = 11,
+    Kbps256 = 12,
+    Kbps320 = 13,
+}
+
+/// `enum v4l2_mpeg_audio_mode` —— `V4L2_CID_MPEG_AUDIO_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioMode {
+    Stereo      = 0,
+    JointStereo = 1,
+    Dual        = 2,
+    Mono        = 3,
+}
+
+/// `enum v4l2_mpeg_audio_mode_extension` —— `V4L2_CID_MPEG_AUDIO_MODE_EXTENSION` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioModeExtension {
+    Bound4  = 0,
+    Bound8  = 1,
+    Bound12 = 2,
+    Bound16 = 3,
+}
+
+/// `enum v4l2_mpeg_audio_emphasis` —— `V4L2_CID_MPEG_AUDIO_EMPHASIS` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioEmphasis {
+    None     = 0,
+    Div50Us  = 1,
+    CcittJ17 = 2,
+}
+
+/// `enum v4l2_mpeg_audio_crc` —— `V4L2_CID_MPEG_AUDIO_CRC` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioCrc {
+    None  = 0,
+    Crc16 = 1,
+}
+
+/// `enum v4l2_mpeg_audio_ac3_bitrate` —— `V4L2_CID_MPEG_AUDIO_AC3_BITRATE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioAc3Bitrate {
+    Kbps32  = 0,
+    Kbps40  = 1,
+    Kbps48  = 2,
+    Kbps56  = 3,
+    Kbps64  = 4,
+    Kbps80  = 5,
+    Kbps96  = 6,
+    Kbps112 = 7,
+    Kbps128 = 8,
+    Kbps160 = 9,
+    Kbps192 = 10,
+    Kbps224 = 11,
+    Kbps256 = 12,
+    Kbps320 = 13,
+    Kbps384 = 14,
+    Kbps448 = 15,
+    Kbps512 = 16,
+    Kbps576 = 17,
+    Kbps640 = 18,
+}
+
+/// `enum v4l2_mpeg_audio_dec_playback` —— `V4L2_CID_MPEG_AUDIO_DEC_PLAYBACK` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegAudioDecPlayback {
+    Auto          = 0,
+    Stereo        = 1,
+    Left          = 2,
+    Right         = 3,
+    Mono          = 4,
+    SwappedStereo = 5,
+}
+
+/// `enum v4l2_mpeg_video_encoding` —— `V4L2_CID_MPEG_VIDEO_ENCODING` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoEncoding {
+    Mpeg1    = 0,
+    Mpeg2    = 1,
+    Mpeg4Avc = 2,
+}
+
+/// `enum v4l2_mpeg_video_aspect` —— `V4L2_CID_MPEG_VIDEO_ASPECT` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoAspect {
+    Aspect1x1     = 0,
+    Aspect4x3     = 1,
+    Aspect16x9    = 2,
+    Aspect221x100 = 3,
+}
+
+/// `enum v4l2_mpeg_video_bitrate_mode` —— `V4L2_CID_MPEG_VIDEO_BITRATE_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoBitrateMode {
+    Vbr = 0,
+    Cbr = 1,
+    Cq  = 2,
+}
+
+/// `enum v4l2_mpeg_video_header_mode` —— `V4L2_CID_MPEG_VIDEO_HEADER_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoHeaderMode {
+    Separate           = 0,
+    JoinedWith1stFrame = 1,
+}
+
+/// `enum v4l2_mpeg_video_multi_slice_mode` —— `V4L2_CID_MPEG_VIDEO_MULTI_SLICE_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoMultiSliceMode {
+    Single   = 0,
+    MaxMb    = 1,
+    MaxBytes = 2,
+}
+
+/// `enum v4l2_mpeg_video_intra_refresh_period_type` —— `V4L2_CID_MPEG_VIDEO_INTRA_REFRESH_PERIOD_TYPE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoIntraRefreshPeriodType {
+    Random = 0,
+    Cyclic = 1,
+}
+
+/// `enum v4l2_mpeg_video_mpeg2_level` —— `V4L2_CID_MPEG_VIDEO_MPEG2_LEVEL` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoMpeg2Level {
+    Low      = 0,
+    Main     = 1,
+    High1440 = 2,
+    High     = 3,
+}
+
+/// `enum v4l2_mpeg_video_mpeg2_profile` —— `V4L2_CID_MPEG_VIDEO_MPEG2_PROFILE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoMpeg2Profile {
+    Simple            = 0,
+    Main              = 1,
+    SnrScalable       = 2,
+    SpatiallyScalable = 3,
+    High              = 4,
+    Multiview         = 5,
+}
+
+/// `enum v4l2_mpeg_video_h264_entropy_mode` —— `V4L2_CID_MPEG_VIDEO_H264_ENTROPY_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264EntropyMode {
+    Cavlc = 0,
+    Cabac = 1,
+}
+
+/// `enum v4l2_mpeg_video_h264_level` —— `V4L2_CID_MPEG_VIDEO_H264_LEVEL` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264Level {
+    Level1_0 = 0,
+    Level1B  = 1,
+    Level1_1 = 2,
+    Level1_2 = 3,
+    Level1_3 = 4,
+    Level2_0 = 5,
+    Level2_1 = 6,
+    Level2_2 = 7,
+    Level3_0 = 8,
+    Level3_1 = 9,
+    Level3_2 = 10,
+    Level4_0 = 11,
+    Level4_1 = 12,
+    Level4_2 = 13,
+    Level5_0 = 14,
+    Level5_1 = 15,
+    Level5_2 = 16,
+    Level6_0 = 17,
+    Level6_1 = 18,
+    Level6_2 = 19,
+}
+
+/// `enum v4l2_mpeg_video_h264_loop_filter_mode` —— `V4L2_CID_MPEG_VIDEO_H264_LOOP_FILTER_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264LoopFilterMode {
+    Enabled  = 0,
+    Disabled = 1,
+    DisabledAtSliceBoundary = 2,
+}
+
+/// `enum v4l2_mpeg_video_h264_profile` —— `V4L2_CID_MPEG_VIDEO_H264_PROFILE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264Profile {
+    Baseline            = 0,
+    ConstrainedBaseline = 1,
+    Main                = 2,
+    Extended            = 3,
+    High                = 4,
+    High10              = 5,
+    High422             = 6,
+    High444Predictive   = 7,
+    High10Intra         = 8,
+    High422Intra        = 9,
+    High444Intra        = 10,
+    Cavlc444Intra       = 11,
+    ScalableBaseline    = 12,
+    ScalableHigh        = 13,
+    ScalableHighIntra   = 14,
+    StereoHigh          = 15,
+    MultiviewHigh       = 16,
+    ConstrainedHigh     = 17,
+}
+
+/// `enum v4l2_mpeg_video_h264_vui_sar_idc` —— `V4L2_CID_MPEG_VIDEO_H264_VUI_SAR_IDC` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264VuiSarIdc {
+    Unspecified = 0,
+    Idc1x1      = 1,
+    Idc12x11    = 2,
+    Idc10x11    = 3,
+    Idc16x11    = 4,
+    Idc40x33    = 5,
+    Idc24x11    = 6,
+    Idc20x11    = 7,
+    Idc32x11    = 8,
+    Idc80x33    = 9,
+    Idc18x11    = 10,
+    Idc15x11    = 11,
+    Idc64x33    = 12,
+    Idc160x99   = 13,
+    Idc4x3      = 14,
+    Idc3x2      = 15,
+    Idc2x1      = 16,
+    Extended    = 17,
+}
+
+/// `enum v4l2_mpeg_video_h264_sei_fp_arrangement_type` —— `V4L2_CID_MPEG_VIDEO_H264_SEI_FP_ARRANGEMENT_TYPE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264SeiFpArrangementType {
+    Checkerboard = 0,
+    Column       = 1,
+    Row          = 2,
+    SideBySide   = 3,
+    TopBottom    = 4,
+    Temporal     = 5,
+}
+
+/// `enum v4l2_mpeg_video_h264_fmo_map_type` —— `V4L2_CID_MPEG_VIDEO_H264_FMO_MAP_TYPE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264FmoMapType {
+    InterleavedSlices = 0,
+    ScatteredSlices   = 1,
+    ForegroundWithLeftOver = 2,
+    BoxOut            = 3,
+    RasterScan        = 4,
+    WipeScan          = 5,
+    Explicit          = 6,
+}
+
+/// `enum v4l2_mpeg_video_h264_fmo_change_dir` —— `V4L2_CID_MPEG_VIDEO_H264_FMO_CHANGE_DIRECTION` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264FmoChangeDir {
+    Right = 0,
+    Left  = 1,
+}
+
+/// `enum v4l2_mpeg_video_h264_hierarchical_coding_type` —— `V4L2_CID_MPEG_VIDEO_H264_HIERARCHICAL_CODING_TYPE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoH264HierarchicalCodingType {
+    HierCodingB = 0,
+    HierCodingP = 1,
+}
+
+/// `enum v4l2_mpeg_video_mpeg4_level` —— `V4L2_CID_MPEG_VIDEO_MPEG4_LEVEL` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoMpeg4Level {
+    Level0  = 0,
+    Level0B = 1,
+    Level1  = 2,
+    Level2  = 3,
+    Level3  = 4,
+    Level3B = 5,
+    Level4  = 6,
+    Level5  = 7,
+}
+
+/// `enum v4l2_mpeg_video_mpeg4_profile` —— `V4L2_CID_MPEG_VIDEO_MPEG4_PROFILE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoMpeg4Profile {
+    Simple         = 0,
+    AdvancedSimple = 1,
+    Core           = 2,
+    SimpleScalable = 3,
+    AdvancedCodingEfficiency = 4,
+}
+
+/// `enum v4l2_vp8_num_partitions` —— `V4L2_CID_MPEG_VIDEO_VPX_NUM_PARTITIONS` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Vp8NumPartitions {
+    Partitions1 = 0,
+    Partitions2 = 1,
+    Partitions4 = 2,
+    Partitions8 = 3,
+}
+
+/// `enum v4l2_vp8_num_ref_frames` —— `V4L2_CID_MPEG_VIDEO_VPX_NUM_REF_FRAMES` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Vp8NumRefFrames {
+    RefFrame1 = 0,
+    RefFrame2 = 1,
+    RefFrame3 = 2,
+}
+
+/// `enum v4l2_vp8_golden_frame_sel` —— `V4L2_CID_MPEG_VIDEO_VPX_GOLDEN_FRAME_SEL` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Vp8GoldenFrameSel {
+    UsePrev      = 0,
+    UseRefPeriod = 1,
+}
+
+/// `enum v4l2_mpeg_video_vp8_profile` —— `V4L2_CID_MPEG_VIDEO_VP8_PROFILE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoVp8Profile {
+    Profile0 = 0,
+    Profile1 = 1,
+    Profile2 = 2,
+    Profile3 = 3,
+}
+
+/// `enum v4l2_mpeg_video_vp9_profile` —— `V4L2_CID_MPEG_VIDEO_VP9_PROFILE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoVp9Profile {
+    Profile0 = 0,
+    Profile1 = 1,
+    Profile2 = 2,
+    Profile3 = 3,
+}
+
+/// `enum v4l2_mpeg_video_vp9_level` —— `V4L2_CID_MPEG_VIDEO_VP9_LEVEL` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoVp9Level {
+    Level1_0 = 0,
+    Level1_1 = 1,
+    Level2_0 = 2,
+    Level2_1 = 3,
+    Level3_0 = 4,
+    Level3_1 = 5,
+    Level4_0 = 6,
+    Level4_1 = 7,
+    Level5_0 = 8,
+    Level5_1 = 9,
+    Level5_2 = 10,
+    Level6_0 = 11,
+    Level6_1 = 12,
+    Level6_2 = 13,
+}
+
+/// `enum v4l2_mpeg_video_hevc_profile` —— `V4L2_CID_MPEG_VIDEO_HEVC_PROFILE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoHevcProfile {
+    Main             = 0,
+    MainStillPicture = 1,
+    Main10           = 2,
+}
+
+/// `enum v4l2_mpeg_video_hevc_level` —— `V4L2_CID_MPEG_VIDEO_HEVC_LEVEL` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoHevcLevel {
+    Level1   = 0,
+    Level2   = 1,
+    Level2_1 = 2,
+    Level3   = 3,
+    Level3_1 = 4,
+    Level4   = 5,
+    Level4_1 = 6,
+    Level5   = 7,
+    Level5_1 = 8,
+    Level5_2 = 9,
+    Level6   = 10,
+    Level6_1 = 11,
+    Level6_2 = 12,
+}
+
+/// `enum v4l2_mpeg_video_hevc_tier` —— `V4L2_CID_MPEG_VIDEO_HEVC_TIER` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoHevcTier {
+    Main = 0,
+    High = 1,
+}
+
+/// `enum v4l2_cid_mpeg_video_hevc_loop_filter_mode` —— `V4L2_CID_MPEG_VIDEO_HEVC_LOOP_FILTER_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoHevcLoopFilterMode {
+    Disabled = 0,
+    Enabled  = 1,
+    DisabledAtSliceBoundary = 2,
+}
+
+/// `enum v4l2_cid_mpeg_video_hevc_refresh_type` —— `V4L2_CID_MPEG_VIDEO_HEVC_REFRESH_TYPE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoHevcRefreshType {
+    None = 0,
+    Cra  = 1,
+    Idr  = 2,
+}
+
+/// `enum v4l2_cid_mpeg_video_hevc_size_of_length_field` —— `V4L2_CID_MPEG_VIDEO_HEVC_SIZE_OF_LENGTH_FIELD` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoHevcSizeOfLengthField {
+    Size0 = 0,
+    Size1 = 1,
+    Size2 = 2,
+    Size4 = 3,
+}
+
+/// `enum v4l2_mpeg_video_frame_skip_mode` —— `V4L2_CID_MPEG_VIDEO_FRAME_SKIP_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoFrameSkipMode {
+    Disabled   = 0,
+    LevelLimit = 1,
+    BufLimit   = 2,
+}
+
+/// `enum v4l2_mpeg_video_av1_profile` —— `V4L2_CID_MPEG_VIDEO_AV1_PROFILE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoAv1Profile {
+    Main         = 0,
+    High         = 1,
+    Professional = 2,
+}
+
+/// `enum v4l2_mpeg_video_av1_level` —— `V4L2_CID_MPEG_VIDEO_AV1_LEVEL` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegVideoAv1Level {
+    Level2_0 = 0,
+    Level2_1 = 1,
+    Level2_2 = 2,
+    Level2_3 = 3,
+    Level3_0 = 4,
+    Level3_1 = 5,
+    Level3_2 = 6,
+    Level3_3 = 7,
+    Level4_0 = 8,
+    Level4_1 = 9,
+    Level4_2 = 10,
+    Level4_3 = 11,
+    Level5_0 = 12,
+    Level5_1 = 13,
+    Level5_2 = 14,
+    Level5_3 = 15,
+    Level6_0 = 16,
+    Level6_1 = 17,
+    Level6_2 = 18,
+    Level6_3 = 19,
+    Level7_0 = 20,
+    Level7_1 = 21,
+    Level7_2 = 22,
+    Level7_3 = 23,
+}
+
+/// `enum v4l2_mpeg_cx2341x_video_spatial_filter_mode` —— CX2341x 控件菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegCx2341xVideoSpatialFilterMode {
+    Manual = 0,
+    Auto   = 1,
+}
+
+/// `enum v4l2_mpeg_cx2341x_video_luma_spatial_filter_type` —— CX2341x 控件菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegCx2341xVideoLumaSpatialFilterType {
+    Off               = 0,
+    Hor1D             = 1,
+    Vert1D            = 2,
+    HvSeparable2D     = 3,
+    SymNonSeparable2D = 4,
+}
+
+/// `enum v4l2_mpeg_cx2341x_video_chroma_spatial_filter_type` —— CX2341x 控件菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegCx2341xVideoChromaSpatialFilterType {
+    Off   = 0,
+    Hor1D = 1,
+}
+
+/// `enum v4l2_mpeg_cx2341x_video_temporal_filter_mode` —— CX2341x 控件菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegCx2341xVideoTemporalFilterMode {
+    Manual = 0,
+    Auto   = 1,
+}
+
+/// `enum v4l2_mpeg_cx2341x_video_median_filter_type` —— CX2341x 控件菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegCx2341xVideoMedianFilterType {
+    Off     = 0,
+    Hor     = 1,
+    Vert    = 2,
+    HorVert = 3,
+    Diag    = 4,
+}
+
+/// `enum v4l2_mpeg_mfc51_video_frame_skip_mode` —— MFC51 控件菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegMfc51VideoFrameSkipMode {
+    Disabled   = 0,
+    LevelLimit = 1,
+    BufLimit   = 2,
+}
+
+/// `enum v4l2_mpeg_mfc51_video_force_frame_type` —— MFC51 控件菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MpegMfc51VideoForceFrameType {
+    Disabled = 0,
+    IFrame   = 1,
+    NotCoded = 2,
+}
+
+// ── 编解码类控制 ID ───────────────────────────────────────
+
+/// V4L2 编解码类控制 ID（`V4L2_CID_CODEC_BASE` + 偏移）。
+///
+/// 设计：`V4L2_CID_MPEG_STREAM_TYPE = (V4L2_CTRL_CLASS_CODEC | 0x900) + 0`。
+///
+/// CX2341X 与 MFC51 驱动控件使用各自的基址（`CX2341X_CID_BASE` / `MFC51_CID_BASE`）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodecClassCtrl {
+    // MPEG 流，特定于复用流
+    MpegStreamType       = CID_BASE,
+    MpegStreamPidPmt     = CID_BASE + 1,
+    MpegStreamPidAudio   = CID_BASE + 2,
+    MpegStreamPidVideo   = CID_BASE + 3,
+    MpegStreamPidPcr     = CID_BASE + 4,
+    MpegStreamPesIdAudio = CID_BASE + 5,
+    MpegStreamPesIdVideo = CID_BASE + 6,
+    MpegStreamVbiFmt     = CID_BASE + 7,
+
+    // 特定于复用流的 MPEG 音频控件
+    MpegAudioSamplingFreq = CID_BASE + 100,
+    MpegAudioEncoding    = CID_BASE + 101,
+    MpegAudioL1Bitrate   = CID_BASE + 102,
+    MpegAudioL2Bitrate   = CID_BASE + 103,
+    MpegAudioL3Bitrate   = CID_BASE + 104,
+    MpegAudioMode        = CID_BASE + 105,
+    MpegAudioModeExtension = CID_BASE + 106,
+    MpegAudioEmphasis    = CID_BASE + 107,
+    MpegAudioCrc         = CID_BASE + 108,
+    MpegAudioMute        = CID_BASE + 109,
+    MpegAudioAacBitrate  = CID_BASE + 110,
+    MpegAudioAc3Bitrate  = CID_BASE + 111,
+    MpegAudioDecPlayback = CID_BASE + 112,
+    MpegAudioDecMultilingualPlayback = CID_BASE + 113,
+
+    // 特定于复用流的 MPEG 视频控件
+    MpegVideoEncoding    = CID_BASE + 200,
+    MpegVideoAspect      = CID_BASE + 201,
+    MpegVideoBFrames     = CID_BASE + 202,
+    MpegVideoGopSize     = CID_BASE + 203,
+    MpegVideoGopClosure  = CID_BASE + 204,
+    MpegVideoPulldown    = CID_BASE + 205,
+    MpegVideoBitrateMode = CID_BASE + 206,
+    MpegVideoBitrate     = CID_BASE + 207,
+    MpegVideoBitratePeak = CID_BASE + 208,
+    MpegVideoTemporalDecimation = CID_BASE + 209,
+    MpegVideoMute        = CID_BASE + 210,
+    MpegVideoMuteYuv     = CID_BASE + 211,
+    MpegVideoDecoderSliceInterface = CID_BASE + 212,
+    MpegVideoDecoderMpeg4DeblockFilter = CID_BASE + 213,
+    MpegVideoCyclicIntraRefreshMb = CID_BASE + 214,
+    MpegVideoFrameRcEnable = CID_BASE + 215,
+    MpegVideoHeaderMode  = CID_BASE + 216,
+    MpegVideoMaxRefPic   = CID_BASE + 217,
+    MpegVideoMbRcEnable  = CID_BASE + 218,
+    MpegVideoMultiSliceMaxBytes = CID_BASE + 219,
+    MpegVideoMultiSliceMaxMb = CID_BASE + 220,
+    MpegVideoMultiSliceMode = CID_BASE + 221,
+    MpegVideoVbvSize     = CID_BASE + 222,
+    MpegVideoDecPts      = CID_BASE + 223,
+    MpegVideoDecFrame    = CID_BASE + 224,
+    MpegVideoVbvDelay    = CID_BASE + 225,
+    MpegVideoRepeatSeqHeader = CID_BASE + 226,
+    MpegVideoMvHSearchRange = CID_BASE + 227,
+    MpegVideoMvVSearchRange = CID_BASE + 228,
+    MpegVideoForceKeyFrame = CID_BASE + 229,
+    MpegVideoBaselayerPriorityId = CID_BASE + 230,
+    MpegVideoAuDelimiter = CID_BASE + 231,
+    MpegVideoLtrCount    = CID_BASE + 232,
+    MpegVideoFrameLtrIndex = CID_BASE + 233,
+    MpegVideoUseLtrFrames = CID_BASE + 234,
+    MpegVideoDecConcealColor = CID_BASE + 235,
+    MpegVideoIntraRefreshPeriod = CID_BASE + 236,
+    MpegVideoIntraRefreshPeriodType = CID_BASE + 237,
+    MpegVideoBackgroundDetection = CID_BASE + 238,
+
+    // MPEG-2 Part 2 (H.262) 编解码器控件
+    MpegVideoMpeg2Level  = CID_BASE + 270,
+    MpegVideoMpeg2Profile = CID_BASE + 271,
+
+    // FWHT 编解码器控件（vicodec 驱动）
+    FwhtIFrameQp         = CID_BASE + 290,
+    FwhtPFrameQp         = CID_BASE + 291,
+
+    // H.263
+    MpegVideoH263IFrameQp = CID_BASE + 300,
+    MpegVideoH263PFrameQp = CID_BASE + 301,
+    MpegVideoH263BFrameQp = CID_BASE + 302,
+    MpegVideoH263MinQp   = CID_BASE + 303,
+    MpegVideoH263MaxQp   = CID_BASE + 304,
+
+    // H.264
+    MpegVideoH264IFrameQp = CID_BASE + 350,
+    MpegVideoH264PFrameQp = CID_BASE + 351,
+    MpegVideoH264BFrameQp = CID_BASE + 352,
+    MpegVideoH264MinQp   = CID_BASE + 353,
+    MpegVideoH264MaxQp   = CID_BASE + 354,
+    MpegVideoH264X8Transform = CID_BASE + 355,
+    MpegVideoH264CpbSize = CID_BASE + 356,
+    MpegVideoH264EntropyMode = CID_BASE + 357,
+    MpegVideoH264IPeriod = CID_BASE + 358,
+    MpegVideoH264Level   = CID_BASE + 359,
+    MpegVideoH264LoopFilterAlpha = CID_BASE + 360,
+    MpegVideoH264LoopFilterBeta = CID_BASE + 361,
+    MpegVideoH264LoopFilterMode = CID_BASE + 362,
+    MpegVideoH264Profile = CID_BASE + 363,
+    MpegVideoH264VuiExtSarHeight = CID_BASE + 364,
+    MpegVideoH264VuiExtSarWidth = CID_BASE + 365,
+    MpegVideoH264VuiSarEnable = CID_BASE + 366,
+    MpegVideoH264VuiSarIdc = CID_BASE + 367,
+    MpegVideoH264SeiFramePacking = CID_BASE + 368,
+    MpegVideoH264SeiFpCurrentFrame0 = CID_BASE + 369,
+    MpegVideoH264SeiFpArrangementType = CID_BASE + 370,
+    MpegVideoH264Fmo     = CID_BASE + 371,
+    MpegVideoH264FmoMapType = CID_BASE + 372,
+    MpegVideoH264FmoSliceGroup = CID_BASE + 373,
+    MpegVideoH264FmoChangeDirection = CID_BASE + 374,
+    MpegVideoH264FmoChangeRate = CID_BASE + 375,
+    MpegVideoH264FmoRunLength = CID_BASE + 376,
+    MpegVideoH264Aso     = CID_BASE + 377,
+    MpegVideoH264AsoSliceOrder = CID_BASE + 378,
+    MpegVideoH264HierarchicalCoding = CID_BASE + 379,
+    MpegVideoH264HierarchicalCodingType = CID_BASE + 380,
+    MpegVideoH264HierarchicalCodingLayer = CID_BASE + 381,
+    MpegVideoH264HierarchicalCodingLayerQp = CID_BASE + 382,
+    MpegVideoH264ConstrainedIntraPrediction = CID_BASE + 383,
+    MpegVideoH264ChromaQpIndexOffset = CID_BASE + 384,
+    MpegVideoH264IFrameMinQp = CID_BASE + 385,
+    MpegVideoH264IFrameMaxQp = CID_BASE + 386,
+    MpegVideoH264PFrameMinQp = CID_BASE + 387,
+    MpegVideoH264PFrameMaxQp = CID_BASE + 388,
+    MpegVideoH264BFrameMinQp = CID_BASE + 389,
+    MpegVideoH264BFrameMaxQp = CID_BASE + 390,
+    MpegVideoH264HierCodingL0Br = CID_BASE + 391,
+    MpegVideoH264HierCodingL1Br = CID_BASE + 392,
+    MpegVideoH264HierCodingL2Br = CID_BASE + 393,
+    MpegVideoH264HierCodingL3Br = CID_BASE + 394,
+    MpegVideoH264HierCodingL4Br = CID_BASE + 395,
+    MpegVideoH264HierCodingL5Br = CID_BASE + 396,
+    MpegVideoH264HierCodingL6Br = CID_BASE + 397,
+
+    // MPEG-4 Part 2
+    MpegVideoMpeg4IFrameQp = CID_BASE + 400,
+    MpegVideoMpeg4PFrameQp = CID_BASE + 401,
+    MpegVideoMpeg4BFrameQp = CID_BASE + 402,
+    MpegVideoMpeg4MinQp  = CID_BASE + 403,
+    MpegVideoMpeg4MaxQp  = CID_BASE + 404,
+    MpegVideoMpeg4Level  = CID_BASE + 405,
+    MpegVideoMpeg4Profile = CID_BASE + 406,
+    MpegVideoMpeg4Qpel   = CID_BASE + 407,
+
+    // VP8 / VP9 流（虽非 MPEG，但归入此类）
+    MpegVideoVpxNumPartitions = CID_BASE + 500,
+    MpegVideoVpxImdDisable4x4 = CID_BASE + 501,
+    MpegVideoVpxNumRefFrames = CID_BASE + 502,
+    MpegVideoVpxFilterLevel = CID_BASE + 503,
+    MpegVideoVpxFilterSharpness = CID_BASE + 504,
+    MpegVideoVpxGoldenFrameRefPeriod = CID_BASE + 505,
+    MpegVideoVpxGoldenFrameSel = CID_BASE + 506,
+    MpegVideoVpxMinQp    = CID_BASE + 507,
+    MpegVideoVpxMaxQp    = CID_BASE + 508,
+    MpegVideoVpxIFrameQp = CID_BASE + 509,
+    MpegVideoVpxPFrameQp = CID_BASE + 510,
+    MpegVideoVp8Profile  = CID_BASE + 511,
+    MpegVideoVp9Profile  = CID_BASE + 512,
+    MpegVideoVp9Level    = CID_BASE + 513,
+
+    // HEVC 编码
+    MpegVideoHevcMinQp   = CID_BASE + 600,
+    MpegVideoHevcMaxQp   = CID_BASE + 601,
+    MpegVideoHevcIFrameQp = CID_BASE + 602,
+    MpegVideoHevcPFrameQp = CID_BASE + 603,
+    MpegVideoHevcBFrameQp = CID_BASE + 604,
+    MpegVideoHevcHierQp  = CID_BASE + 605,
+    MpegVideoHevcHierCodingType = CID_BASE + 606,
+    MpegVideoHevcHierCodingLayer = CID_BASE + 607,
+    MpegVideoHevcHierCodingL0Qp = CID_BASE + 608,
+    MpegVideoHevcHierCodingL1Qp = CID_BASE + 609,
+    MpegVideoHevcHierCodingL2Qp = CID_BASE + 610,
+    MpegVideoHevcHierCodingL3Qp = CID_BASE + 611,
+    MpegVideoHevcHierCodingL4Qp = CID_BASE + 612,
+    MpegVideoHevcHierCodingL5Qp = CID_BASE + 613,
+    MpegVideoHevcHierCodingL6Qp = CID_BASE + 614,
+    MpegVideoHevcProfile = CID_BASE + 615,
+    MpegVideoHevcLevel   = CID_BASE + 616,
+    MpegVideoHevcFrameRateResolution = CID_BASE + 617,
+    MpegVideoHevcTier    = CID_BASE + 618,
+    MpegVideoHevcMaxPartitionDepth = CID_BASE + 619,
+    MpegVideoHevcLoopFilterMode = CID_BASE + 620,
+    MpegVideoHevcLfBetaOffsetDiv2 = CID_BASE + 621,
+    MpegVideoHevcLfTcOffsetDiv2 = CID_BASE + 622,
+    MpegVideoHevcRefreshType = CID_BASE + 623,
+    MpegVideoHevcRefreshPeriod = CID_BASE + 624,
+    MpegVideoHevcLosslessCu = CID_BASE + 625,
+    MpegVideoHevcConstIntraPred = CID_BASE + 626,
+    MpegVideoHevcWavefront = CID_BASE + 627,
+    MpegVideoHevcGeneralPb = CID_BASE + 628,
+    MpegVideoHevcTemporalId = CID_BASE + 629,
+    MpegVideoHevcStrongSmoothing = CID_BASE + 630,
+    MpegVideoHevcMaxNumMergeMvMinus1 = CID_BASE + 631,
+    MpegVideoHevcIntraPuSplit = CID_BASE + 632,
+    MpegVideoHevcTmvPrediction = CID_BASE + 633,
+    MpegVideoHevcWithoutStartcode = CID_BASE + 634,
+    MpegVideoHevcSizeOfLengthField = CID_BASE + 635,
+    MpegVideoHevcHierCodingL0Br = CID_BASE + 636,
+    MpegVideoHevcHierCodingL1Br = CID_BASE + 637,
+    MpegVideoHevcHierCodingL2Br = CID_BASE + 638,
+    MpegVideoHevcHierCodingL3Br = CID_BASE + 639,
+    MpegVideoHevcHierCodingL4Br = CID_BASE + 640,
+    MpegVideoHevcHierCodingL5Br = CID_BASE + 641,
+    MpegVideoHevcHierCodingL6Br = CID_BASE + 642,
+    MpegVideoRefNumberForPFrames = CID_BASE + 643,
+    MpegVideoPrependSpsppsToIdr = CID_BASE + 644,
+    MpegVideoConstantQuality = CID_BASE + 645,
+    MpegVideoFrameSkipMode = CID_BASE + 646,
+    MpegVideoHevcIFrameMinQp = CID_BASE + 647,
+    MpegVideoHevcIFrameMaxQp = CID_BASE + 648,
+    MpegVideoHevcPFrameMinQp = CID_BASE + 649,
+    MpegVideoHevcPFrameMaxQp = CID_BASE + 650,
+    MpegVideoHevcBFrameMinQp = CID_BASE + 651,
+    MpegVideoHevcBFrameMaxQp = CID_BASE + 652,
+    MpegVideoDecDisplayDelay = CID_BASE + 653,
+    MpegVideoDecDisplayDelayEnable = CID_BASE + 654,
+    MpegVideoAv1Profile  = CID_BASE + 655,
+    MpegVideoAv1Level    = CID_BASE + 656,
+    MpegVideoAverageQp   = CID_BASE + 657,
+
+    // CX2341x 驱动控件
+    MpegCx2341xVideoSpatialFilterMode = CX2341X_CID_BASE,
+    MpegCx2341xVideoSpatialFilter = CX2341X_CID_BASE + 1,
+    MpegCx2341xVideoLumaSpatialFilterType = CX2341X_CID_BASE + 2,
+    MpegCx2341xVideoChromaSpatialFilterType = CX2341X_CID_BASE + 3,
+    MpegCx2341xVideoTemporalFilterMode = CX2341X_CID_BASE + 4,
+    MpegCx2341xVideoTemporalFilter = CX2341X_CID_BASE + 5,
+    MpegCx2341xVideoMedianFilterType = CX2341X_CID_BASE + 6,
+    MpegCx2341xVideoLumaMedianFilterBottom = CX2341X_CID_BASE + 7,
+    MpegCx2341xVideoLumaMedianFilterTop = CX2341X_CID_BASE + 8,
+    MpegCx2341xVideoChromaMedianFilterBottom = CX2341X_CID_BASE + 9,
+    MpegCx2341xVideoChromaMedianFilterTop = CX2341X_CID_BASE + 10,
+    MpegCx2341xStreamInsertNavPackets = CX2341X_CID_BASE + 11,
+
+    // Samsung MFC 5.1 驱动控件
+    MpegMfc51VideoDecoderH264DisplayDelay = MFC51_CID_BASE,
+    MpegMfc51VideoDecoderH264DisplayDelayEnable = MFC51_CID_BASE + 1,
+    MpegMfc51VideoFrameSkipMode = MFC51_CID_BASE + 2,
+    MpegMfc51VideoForceFrameType = MFC51_CID_BASE + 3,
+    MpegMfc51VideoPadding = MFC51_CID_BASE + 4,
+    MpegMfc51VideoPaddingYuv = MFC51_CID_BASE + 5,
+    MpegMfc51VideoRcFixedTargetBit = MFC51_CID_BASE + 6,
+    MpegMfc51VideoRcReactionCoeff = MFC51_CID_BASE + 7,
+    MpegMfc51VideoH264AdaptiveRcActivity = MFC51_CID_BASE + 50,
+    MpegMfc51VideoH264AdaptiveRcDark = MFC51_CID_BASE + 51,
+    MpegMfc51VideoH264AdaptiveRcSmooth = MFC51_CID_BASE + 52,
+    MpegMfc51VideoH264AdaptiveRcStatic = MFC51_CID_BASE + 53,
+    MpegMfc51VideoH264NumRefPicForP = MFC51_CID_BASE + 54,
+}

--- a/drivers/media/ax-media/src/ctrls/class/codec_stateless.rs
+++ b/drivers/media/ax-media/src/ctrls/class/codec_stateless.rs
@@ -1,0 +1,1379 @@
+//! 无状态编解码控件。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_CODEC_STATELESS` —— 无状态编解码控件。
+pub const CLASS_ID: u32 = CtrlClass::CodecStateless as u32;
+
+/// `V4L2_CID_CODEC_STATELESS_CLASS = (V4L2_CTRL_CLASS_CODEC_STATELESS | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_CODEC_STATELESS_BASE = (V4L2_CTRL_CLASS_CODEC_STATELESS | 0x900) = 0x00a40900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+// ── 无状态编解码控制 ID ───────────────────────────────────
+
+/// V4L2 无状态编解码类控制 ID（`V4L2_CID_CODEC_STATELESS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodecStatelessClassCtrl {
+    // H.264
+    StatelessH264DecodeMode = CID_BASE,
+    StatelessH264StartCode = CID_BASE + 1,
+    StatelessH264Sps     = CID_BASE + 2,
+    StatelessH264Pps     = CID_BASE + 3,
+    StatelessH264ScalingMatrix = CID_BASE + 4,
+    StatelessH264PredWeights = CID_BASE + 5,
+    StatelessH264SliceParams = CID_BASE + 6,
+    StatelessH264DecodeParams = CID_BASE + 7,
+
+    // FWHT（vicodec 驱动）
+    StatelessFwhtParams  = CID_BASE + 100,
+
+    // VP8
+    StatelessVp8Frame    = CID_BASE + 200,
+
+    // MPEG-2
+    StatelessMpeg2Sequence = CID_BASE + 220,
+    StatelessMpeg2Picture = CID_BASE + 221,
+    StatelessMpeg2Quantisation = CID_BASE + 222,
+
+    // VP9
+    StatelessVp9Frame    = CID_BASE + 300,
+    StatelessVp9CompressedHdr = CID_BASE + 301,
+
+    // HEVC
+    StatelessHevcSps     = CID_BASE + 400,
+    StatelessHevcPps     = CID_BASE + 401,
+    StatelessHevcSliceParams = CID_BASE + 402,
+    StatelessHevcScalingMatrix = CID_BASE + 403,
+    StatelessHevcDecodeParams = CID_BASE + 404,
+    StatelessHevcDecodeMode = CID_BASE + 405,
+    StatelessHevcStartCode = CID_BASE + 406,
+    StatelessHevcEntryPointOffsets = CID_BASE + 407,
+    StatelessHevcExtSpsStRps = CID_BASE + 408,
+    StatelessHevcExtSpsLtRps = CID_BASE + 409,
+
+    // AV1
+    StatelessAv1Sequence = CID_BASE + 500,
+    StatelessAv1TileGroupEntry = CID_BASE + 501,
+    StatelessAv1Frame    = CID_BASE + 502,
+    StatelessAv1FilmGrain = CID_BASE + 505,
+}
+
+// ── H.264 ────────────────────────────────────────────────
+
+/// `enum v4l2_stateless_h264_decode_mode` —— `V4L2_CID_STATELESS_H264_DECODE_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatelessH264DecodeMode {
+    SliceBased = 0,
+    FrameBased = 1,
+}
+
+/// `enum v4l2_stateless_h264_start_code` —— `V4L2_CID_STATELESS_H264_START_CODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatelessH264StartCode {
+    None   = 0,
+    AnnexB = 1,
+}
+
+/// `V4L2_H264_SPS_CONSTRAINT_SET*_FLAG`。
+pub mod h264_sps_constraint_set {
+    pub const SET0: u32 = 0x01;
+    pub const SET1: u32 = 0x02;
+    pub const SET2: u32 = 0x04;
+    pub const SET3: u32 = 0x08;
+    pub const SET4: u32 = 0x10;
+    pub const SET5: u32 = 0x20;
+}
+
+/// `V4L2_H264_SPS_FLAG_*`。
+pub mod h264_sps_flag {
+    pub const SEPARATE_COLOUR_PLANE: u32 = 0x01;
+    pub const QPPRIME_Y_ZERO_TRANSFORM_BYPASS: u32 = 0x02;
+    pub const DELTA_PIC_ORDER_ALWAYS_ZERO: u32 = 0x04;
+    pub const GAPS_IN_FRAME_NUM_VALUE_ALLOWED: u32 = 0x08;
+    pub const FRAME_MBS_ONLY: u32 = 0x10;
+    pub const MB_ADAPTIVE_FRAME_FIELD: u32 = 0x20;
+    pub const DIRECT_8X8_INFERENCE: u32 = 0x40;
+}
+
+/// `V4L2_H264_PPS_FLAG_*`。
+pub mod h264_pps_flag {
+    pub const ENTROPY_CODING_MODE: u32 = 0x0001;
+    pub const BOTTOM_FIELD_PIC_ORDER_IN_FRAME_PRESENT: u32 = 0x0002;
+    pub const WEIGHTED_PRED: u32 = 0x0004;
+    pub const DEBLOCKING_FILTER_CONTROL_PRESENT: u32 = 0x0008;
+    pub const CONSTRAINED_INTRA_PRED: u32 = 0x0010;
+    pub const REDUNDANT_PIC_CNT_PRESENT: u32 = 0x0020;
+    pub const TRANSFORM_8X8_MODE: u32 = 0x0040;
+    pub const SCALING_MATRIX_PRESENT: u32 = 0x0080;
+}
+
+/// `V4L2_H264_TOP_FIELD_REF` / `V4L2_H264_BOTTOM_FIELD_REF` / `V4L2_H264_FRAME_REF`。
+pub mod h264_field_ref {
+    pub const TOP: u8 = 0x1;
+    pub const BOTTOM: u8 = 0x2;
+    pub const FRAME: u8 = 0x3;
+}
+
+/// `V4L2_H264_NUM_DPB_ENTRIES` —— 最大 DPB 条目数。
+pub const H264_NUM_DPB_ENTRIES: usize = 16;
+/// `V4L2_H264_REF_LIST_LEN = (2 * V4L2_H264_NUM_DPB_ENTRIES)`。
+pub const H264_REF_LIST_LEN: usize = 2 * H264_NUM_DPB_ENTRIES;
+
+/// `V4L2_H264_SLICE_TYPE_*`。
+pub mod h264_slice_type {
+    pub const P: u8 = 0;
+    pub const B: u8 = 1;
+    pub const I: u8 = 2;
+    pub const SP: u8 = 3;
+    pub const SI: u8 = 4;
+}
+
+/// `V4L2_H264_SLICE_FLAG_*`。
+pub mod h264_slice_flag {
+    pub const DIRECT_SPATIAL_MV_PRED: u32 = 0x01;
+    pub const SP_FOR_SWITCH: u32 = 0x02;
+}
+
+/// `V4L2_H264_DPB_ENTRY_FLAG_*`。
+pub mod h264_dpb_entry_flag {
+    pub const VALID: u8 = 0x01;
+    pub const ACTIVE: u8 = 0x02;
+    pub const LONG_TERM: u8 = 0x04;
+    pub const FIELD: u8 = 0x08;
+}
+
+/// `V4L2_H264_DECODE_PARAM_FLAG_*`。
+pub mod h264_decode_param_flag {
+    pub const IDR_PIC: u32 = 0x01;
+    pub const FIELD_PIC: u32 = 0x02;
+    pub const BOTTOM_FIELD: u32 = 0x04;
+    pub const PFRAME: u32 = 0x08;
+    pub const BFRAME: u32 = 0x10;
+}
+
+/// `struct v4l2_ctrl_h264_sps` —— H.264 序列参数集。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlH264Sps {
+    pub profile_idc: u8,
+    pub constraint_set_flags: u8,
+    pub level_idc: u8,
+    pub seq_parameter_set_id: u8,
+    pub chroma_format_idc: u8,
+    pub bit_depth_luma_minus8: u8,
+    pub bit_depth_chroma_minus8: u8,
+    pub log2_max_frame_num_minus4: u8,
+    pub pic_order_cnt_type: u8,
+    pub log2_max_pic_order_cnt_lsb_minus4: u8,
+    pub max_num_ref_frames: u8,
+    pub num_ref_frames_in_pic_order_cnt_cycle: u8,
+    pub offset_for_ref_frame: [i32; 255],
+    pub offset_for_non_ref_pic: i32,
+    pub offset_for_top_to_bottom_field: i32,
+    pub pic_width_in_mbs_minus1: u16,
+    pub pic_height_in_map_units_minus1: u16,
+    pub flags: u32,
+}
+
+/// `struct v4l2_ctrl_h264_pps` —— H.264 图像参数集。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlH264Pps {
+    pub pic_parameter_set_id: u8,
+    pub seq_parameter_set_id: u8,
+    pub num_slice_groups_minus1: u8,
+    pub num_ref_idx_l0_default_active_minus1: u8,
+    pub num_ref_idx_l1_default_active_minus1: u8,
+    pub weighted_bipred_idc: u8,
+    pub pic_init_qp_minus26: i8,
+    pub pic_init_qs_minus26: i8,
+    pub chroma_qp_index_offset: i8,
+    pub second_chroma_qp_index_offset: i8,
+    pub flags: u16,
+}
+
+/// `struct v4l2_ctrl_h264_scaling_matrix` —— H.264 缩放矩阵。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlH264ScalingMatrix {
+    pub scaling_list_4x4: [[u8; 16]; 6],
+    pub scaling_list_8x8: [[u8; 64]; 6],
+}
+
+/// `struct v4l2_h264_weight_factors` —— H.264 加权预测因子。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct H264WeightFactors {
+    pub luma_weight: [i16; 32],
+    pub luma_offset: [i16; 32],
+    pub chroma_weight: [[i16; 2]; 32],
+    pub chroma_offset: [[i16; 2]; 32],
+}
+
+/// `struct v4l2_ctrl_h264_pred_weights` —— H.264 加权预测表。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlH264PredWeights {
+    pub luma_log2_weight_denom: u16,
+    pub chroma_log2_weight_denom: u16,
+    pub weight_factors: [H264WeightFactors; 2],
+}
+
+/// `struct v4l2_h264_reference` —— H.264 图像参考。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct H264Reference {
+    pub fields: u8,
+    pub index: u8,
+}
+
+/// `struct v4l2_ctrl_h264_slice_params` —— H.264 条带参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlH264SliceParams {
+    pub header_bit_size: u32,
+    pub first_mb_in_slice: u32,
+    pub slice_type: u8,
+    pub colour_plane_id: u8,
+    pub redundant_pic_cnt: u8,
+    pub cabac_init_idc: u8,
+    pub slice_qp_delta: i8,
+    pub slice_qs_delta: i8,
+    pub disable_deblocking_filter_idc: u8,
+    pub slice_alpha_c0_offset_div2: i8,
+    pub slice_beta_offset_div2: i8,
+    pub num_ref_idx_l0_active_minus1: u8,
+    pub num_ref_idx_l1_active_minus1: u8,
+    pub reserved: u8,
+    pub ref_pic_list0: [H264Reference; H264_REF_LIST_LEN],
+    pub ref_pic_list1: [H264Reference; H264_REF_LIST_LEN],
+    pub flags: u32,
+}
+
+/// `struct v4l2_h264_dpb_entry` —— H.264 解码图像缓冲条目。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct H264DpbEntry {
+    pub reference_ts: u64,
+    pub pic_num: u32,
+    pub frame_num: u16,
+    pub fields: u8,
+    pub reserved: [u8; 5],
+    pub top_field_order_cnt: i32,
+    pub bottom_field_order_cnt: i32,
+    pub flags: u32,
+}
+
+/// `struct v4l2_ctrl_h264_decode_params` —— H.264 解码参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlH264DecodeParams {
+    pub dpb: [H264DpbEntry; H264_NUM_DPB_ENTRIES],
+    pub nal_ref_idc: u16,
+    pub frame_num: u16,
+    pub top_field_order_cnt: i32,
+    pub bottom_field_order_cnt: i32,
+    pub idr_pic_id: u16,
+    pub pic_order_cnt_lsb: u16,
+    pub delta_pic_order_cnt_bottom: i32,
+    pub delta_pic_order_cnt0: i32,
+    pub delta_pic_order_cnt1: i32,
+    pub dec_ref_pic_marking_bit_size: u32,
+    pub pic_order_cnt_bit_size: u32,
+    pub slice_group_change_cycle: u32,
+    pub reserved: u32,
+    pub flags: u32,
+}
+
+// ── FWHT ─────────────────────────────────────────────────
+
+/// `V4L2_FWHT_VERSION` —— 当前 FWHT 版本。
+pub const FWHT_VERSION: u32 = 3;
+
+/// `V4L2_FWHT_FL_*` 标志（`_BITUL`，64 位）。
+pub mod fwht_flag {
+    pub const IS_INTERLACED: u64 = 1 << 0;
+    pub const IS_BOTTOM_FIRST: u64 = 1 << 1;
+    pub const IS_ALTERNATE: u64 = 1 << 2;
+    pub const IS_BOTTOM_FIELD: u64 = 1 << 3;
+    pub const LUMA_IS_UNCOMPRESSED: u64 = 1 << 4;
+    pub const CB_IS_UNCOMPRESSED: u64 = 1 << 5;
+    pub const CR_IS_UNCOMPRESSED: u64 = 1 << 6;
+    pub const CHROMA_FULL_HEIGHT: u64 = 1 << 7;
+    pub const CHROMA_FULL_WIDTH: u64 = 1 << 8;
+    pub const ALPHA_IS_UNCOMPRESSED: u64 = 1 << 9;
+    pub const I_FRAME: u64 = 1 << 10;
+    pub const COMPONENTS_NUM_MSK: u64 = 0x0007_0000;
+    pub const COMPONENTS_NUM_OFFSET: u64 = 16;
+    pub const PIXENC_MSK: u64 = 0x0018_0000;
+    pub const PIXENC_OFFSET: u64 = 19;
+    pub const PIXENC_YUV: u64 = 1 << 19;
+    pub const PIXENC_RGB: u64 = 2 << 19;
+    pub const PIXENC_HSV: u64 = 3 << 19;
+}
+
+/// `struct v4l2_ctrl_fwht_params` —— FWHT 参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlFwhtParams {
+    pub backward_ref_ts: u64,
+    pub version: u32,
+    pub width: u32,
+    pub height: u32,
+    pub flags: u32,
+    pub colorspace: u32,
+    pub xfer_func: u32,
+    pub ycbcr_enc: u32,
+    pub quantization: u32,
+}
+
+// ── VP8 ─────────────────────────────────────────────────
+
+/// `V4L2_VP8_SEGMENT_FLAG_*`。
+pub mod vp8_segment_flag {
+    pub const ENABLED: u32 = 0x01;
+    pub const UPDATE_MAP: u32 = 0x02;
+    pub const UPDATE_FEATURE_DATA: u32 = 0x04;
+    pub const DELTA_VALUE_MODE: u32 = 0x08;
+}
+
+/// `struct v4l2_vp8_segment` —— VP8 分段调整参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp8Segment {
+    pub quant_update: [i8; 4],
+    pub lf_update: [i8; 4],
+    pub segment_probs: [u8; 3],
+    pub padding: u8,
+    pub flags: u32,
+}
+
+/// `V4L2_VP8_LF_*` 标志。
+pub mod vp8_lf_flag {
+    pub const ADJ_ENABLE: u32 = 0x01;
+    pub const DELTA_UPDATE: u32 = 0x02;
+    pub const FILTER_TYPE_SIMPLE: u32 = 0x04;
+}
+
+/// `struct v4l2_vp8_loop_filter` —— VP8 环路滤波参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp8LoopFilter {
+    pub ref_frm_delta: [i8; 4],
+    pub mb_mode_delta: [i8; 4],
+    pub sharpness_level: u8,
+    pub level: u8,
+    pub padding: u16,
+    pub flags: u32,
+}
+
+/// `struct v4l2_vp8_quantization` —— VP8 量化索引。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp8Quantization {
+    pub y_ac_qi: u8,
+    pub y_dc_delta: i8,
+    pub y2_dc_delta: i8,
+    pub y2_ac_delta: i8,
+    pub uv_dc_delta: i8,
+    pub uv_ac_delta: i8,
+    pub padding: u16,
+}
+
+/// `V4L2_VP8_COEFF_PROB_CNT` / `V4L2_VP8_MV_PROB_CNT`。
+pub const VP8_COEFF_PROB_CNT: usize = 11;
+pub const VP8_MV_PROB_CNT: usize = 19;
+
+/// `struct v4l2_vp8_entropy` —— VP8 概率更新。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp8Entropy {
+    pub coeff_probs: [[[[u8; VP8_COEFF_PROB_CNT]; 3]; 8]; 4],
+    pub y_mode_probs: [u8; 4],
+    pub uv_mode_probs: [u8; 3],
+    pub mv_probs: [[u8; VP8_MV_PROB_CNT]; 2],
+    pub padding: [u8; 3],
+}
+
+/// `struct v4l2_vp8_entropy_coder_state` —— VP8 布尔熵编码器状态。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp8EntropyCoderState {
+    pub range: u8,
+    pub value: u8,
+    pub bit_count: u8,
+    pub padding: u8,
+}
+
+/// `V4L2_VP8_FRAME_FLAG_*`。
+pub mod vp8_frame_flag {
+    pub const KEY_FRAME: u32 = 0x01;
+    pub const EXPERIMENTAL: u32 = 0x02;
+    pub const SHOW_FRAME: u32 = 0x04;
+    pub const MB_NO_SKIP_COEFF: u32 = 0x08;
+    pub const SIGN_BIAS_GOLDEN: u32 = 0x10;
+    pub const SIGN_BIAS_ALT: u32 = 0x20;
+}
+
+/// `struct v4l2_ctrl_vp8_frame` —— VP8 帧参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlVp8Frame {
+    pub segment: Vp8Segment,
+    pub lf: Vp8LoopFilter,
+    pub quant: Vp8Quantization,
+    pub entropy: Vp8Entropy,
+    pub coder_state: Vp8EntropyCoderState,
+    pub width: u16,
+    pub height: u16,
+    pub horizontal_scale: u8,
+    pub vertical_scale: u8,
+    pub version: u8,
+    pub prob_skip_false: u8,
+    pub prob_intra: u8,
+    pub prob_last: u8,
+    pub prob_gf: u8,
+    pub num_dct_parts: u8,
+    pub first_part_size: u32,
+    pub first_part_header_bits: u32,
+    pub dct_part_sizes: [u32; 8],
+    pub last_frame_ts: u64,
+    pub golden_frame_ts: u64,
+    pub alt_frame_ts: u64,
+    pub flags: u64,
+}
+
+// ── MPEG-2 ───────────────────────────────────────────────
+
+/// `V4L2_MPEG2_SEQ_FLAG_PROGRESSIVE`。
+pub const MPEG2_SEQ_FLAG_PROGRESSIVE: u8 = 0x01;
+
+/// `V4L2_MPEG2_PIC_CODING_TYPE_*`。
+pub mod mpeg2_pic_coding_type {
+    pub const I: u8 = 1;
+    pub const P: u8 = 2;
+    pub const B: u8 = 3;
+    pub const D: u8 = 4;
+}
+
+/// `V4L2_MPEG2_PIC_TOP_FIELD` / `V4L2_MPEG2_PIC_BOTTOM_FIELD` / `V4L2_MPEG2_PIC_FRAME`。
+pub mod mpeg2_pic_field {
+    pub const TOP: u8 = 0x1;
+    pub const BOTTOM: u8 = 0x2;
+    pub const FRAME: u8 = 0x3;
+}
+
+/// `V4L2_MPEG2_PIC_FLAG_*`。
+pub mod mpeg2_pic_flag {
+    pub const TOP_FIELD_FIRST: u32 = 0x0001;
+    pub const FRAME_PRED_DCT: u32 = 0x0002;
+    pub const CONCEALMENT_MV: u32 = 0x0004;
+    pub const Q_SCALE_TYPE: u32 = 0x0008;
+    pub const INTRA_VLC: u32 = 0x0010;
+    pub const ALT_SCAN: u32 = 0x0020;
+    pub const REPEAT_FIRST: u32 = 0x0040;
+    pub const PROGRESSIVE: u32 = 0x0080;
+}
+
+/// `struct v4l2_ctrl_mpeg2_sequence` —— MPEG-2 序列头。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlMpeg2Sequence {
+    pub horizontal_size: u16,
+    pub vertical_size: u16,
+    pub vbv_buffer_size: u32,
+    pub profile_and_level_indication: u16,
+    pub chroma_format: u8,
+    pub flags: u8,
+}
+
+/// `struct v4l2_ctrl_mpeg2_picture` —— MPEG-2 图像头。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlMpeg2Picture {
+    pub backward_ref_ts: u64,
+    pub forward_ref_ts: u64,
+    pub flags: u32,
+    pub f_code: [[u8; 2]; 2],
+    pub picture_coding_type: u8,
+    pub picture_structure: u8,
+    pub intra_dc_precision: u8,
+    pub reserved: [u8; 5],
+}
+
+/// `struct v4l2_ctrl_mpeg2_quantisation` —— MPEG-2 量化矩阵。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlMpeg2Quantisation {
+    pub intra_quantiser_matrix: [u8; 64],
+    pub non_intra_quantiser_matrix: [u8; 64],
+    pub chroma_intra_quantiser_matrix: [u8; 64],
+    pub chroma_non_intra_quantiser_matrix: [u8; 64],
+}
+
+// ── HEVC ─────────────────────────────────────────────────
+
+/// `enum v4l2_stateless_hevc_decode_mode` —— `V4L2_CID_STATELESS_HEVC_DECODE_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatelessHevcDecodeMode {
+    SliceBased = 0,
+    FrameBased = 1,
+}
+
+/// `enum v4l2_stateless_hevc_start_code` —— `V4L2_CID_STATELESS_HEVC_START_CODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatelessHevcStartCode {
+    None   = 0,
+    AnnexB = 1,
+}
+
+/// `V4L2_HEVC_SLICE_TYPE_*`。
+pub mod hevc_slice_type {
+    pub const B: u8 = 0;
+    pub const P: u8 = 1;
+    pub const I: u8 = 2;
+}
+
+/// `V4L2_HEVC_SPS_FLAG_*`（64 位）。
+pub mod hevc_sps_flag {
+    pub const SEPARATE_COLOUR_PLANE: u64 = 1 << 0;
+    pub const SCALING_LIST_ENABLED: u64 = 1 << 1;
+    pub const AMP_ENABLED: u64 = 1 << 2;
+    pub const SAMPLE_ADAPTIVE_OFFSET: u64 = 1 << 3;
+    pub const PCM_ENABLED: u64 = 1 << 4;
+    pub const PCM_LOOP_FILTER_DISABLED: u64 = 1 << 5;
+    pub const LONG_TERM_REF_PICS_PRESENT: u64 = 1 << 6;
+    pub const SPS_TEMPORAL_MVP_ENABLED: u64 = 1 << 7;
+    pub const STRONG_INTRA_SMOOTHING_ENABLED: u64 = 1 << 8;
+}
+
+/// `struct v4l2_ctrl_hevc_sps` —— HEVC 序列参数集。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHevcSps {
+    pub video_parameter_set_id: u8,
+    pub seq_parameter_set_id: u8,
+    pub pic_width_in_luma_samples: u16,
+    pub pic_height_in_luma_samples: u16,
+    pub bit_depth_luma_minus8: u8,
+    pub bit_depth_chroma_minus8: u8,
+    pub log2_max_pic_order_cnt_lsb_minus4: u8,
+    pub sps_max_dec_pic_buffering_minus1: u8,
+    pub sps_max_num_reorder_pics: u8,
+    pub sps_max_latency_increase_plus1: u8,
+    pub log2_min_luma_coding_block_size_minus3: u8,
+    pub log2_diff_max_min_luma_coding_block_size: u8,
+    pub log2_min_luma_transform_block_size_minus2: u8,
+    pub log2_diff_max_min_luma_transform_block_size: u8,
+    pub max_transform_hierarchy_depth_inter: u8,
+    pub max_transform_hierarchy_depth_intra: u8,
+    pub pcm_sample_bit_depth_luma_minus1: u8,
+    pub pcm_sample_bit_depth_chroma_minus1: u8,
+    pub log2_min_pcm_luma_coding_block_size_minus3: u8,
+    pub log2_diff_max_min_pcm_luma_coding_block_size: u8,
+    pub num_short_term_ref_pic_sets: u8,
+    pub num_long_term_ref_pics_sps: u8,
+    pub chroma_format_idc: u8,
+    pub sps_max_sub_layers_minus1: u8,
+    pub reserved: [u8; 6],
+    pub flags: u64,
+}
+
+/// `V4L2_HEVC_PPS_FLAG_*`（64 位）。
+pub mod hevc_pps_flag {
+    pub const DEPENDENT_SLICE_SEGMENT_ENABLED: u64 = 1 << 0;
+    pub const OUTPUT_FLAG_PRESENT: u64 = 1 << 1;
+    pub const SIGN_DATA_HIDING_ENABLED: u64 = 1 << 2;
+    pub const CABAC_INIT_PRESENT: u64 = 1 << 3;
+    pub const CONSTRAINED_INTRA_PRED: u64 = 1 << 4;
+    pub const TRANSFORM_SKIP_ENABLED: u64 = 1 << 5;
+    pub const CU_QP_DELTA_ENABLED: u64 = 1 << 6;
+    pub const PPS_SLICE_CHROMA_QP_OFFSETS_PRESENT: u64 = 1 << 7;
+    pub const WEIGHTED_PRED: u64 = 1 << 8;
+    pub const WEIGHTED_BIPRED: u64 = 1 << 9;
+    pub const TRANSQUANT_BYPASS_ENABLED: u64 = 1 << 10;
+    pub const TILES_ENABLED: u64 = 1 << 11;
+    pub const ENTROPY_CODING_SYNC_ENABLED: u64 = 1 << 12;
+    pub const LOOP_FILTER_ACROSS_TILES_ENABLED: u64 = 1 << 13;
+    pub const PPS_LOOP_FILTER_ACROSS_SLICES_ENABLED: u64 = 1 << 14;
+    pub const DEBLOCKING_FILTER_OVERRIDE_ENABLED: u64 = 1 << 15;
+    pub const PPS_DISABLE_DEBLOCKING_FILTER: u64 = 1 << 16;
+    pub const LISTS_MODIFICATION_PRESENT: u64 = 1 << 17;
+    pub const SLICE_SEGMENT_HEADER_EXTENSION_PRESENT: u64 = 1 << 18;
+    pub const DEBLOCKING_FILTER_CONTROL_PRESENT: u64 = 1 << 19;
+    pub const UNIFORM_SPACING: u64 = 1 << 20;
+}
+
+/// `struct v4l2_ctrl_hevc_pps` —— HEVC 图像参数集。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHevcPps {
+    pub pic_parameter_set_id: u8,
+    pub num_extra_slice_header_bits: u8,
+    pub num_ref_idx_l0_default_active_minus1: u8,
+    pub num_ref_idx_l1_default_active_minus1: u8,
+    pub init_qp_minus26: i8,
+    pub diff_cu_qp_delta_depth: u8,
+    pub pps_cb_qp_offset: i8,
+    pub pps_cr_qp_offset: i8,
+    pub num_tile_columns_minus1: u8,
+    pub num_tile_rows_minus1: u8,
+    pub column_width_minus1: [u8; 20],
+    pub row_height_minus1: [u8; 22],
+    pub pps_beta_offset_div2: i8,
+    pub pps_tc_offset_div2: i8,
+    pub log2_parallel_merge_level_minus2: u8,
+    pub reserved: u8,
+    pub flags: u64,
+}
+
+/// `V4L2_HEVC_DPB_ENTRY_LONG_TERM_REFERENCE`。
+pub const HEVC_DPB_ENTRY_LONG_TERM_REFERENCE: u8 = 0x01;
+
+/// `V4L2_HEVC_SEI_PIC_STRUCT_*`。
+pub mod hevc_sei_pic_struct {
+    pub const FRAME: u8 = 0;
+    pub const TOP_FIELD: u8 = 1;
+    pub const BOTTOM_FIELD: u8 = 2;
+    pub const TOP_BOTTOM: u8 = 3;
+    pub const BOTTOM_TOP: u8 = 4;
+    pub const TOP_BOTTOM_TOP: u8 = 5;
+    pub const BOTTOM_TOP_BOTTOM: u8 = 6;
+    pub const FRAME_DOUBLING: u8 = 7;
+    pub const FRAME_TRIPLING: u8 = 8;
+    pub const TOP_PAIRED_PREVIOUS_BOTTOM: u8 = 9;
+    pub const BOTTOM_PAIRED_PREVIOUS_TOP: u8 = 10;
+    pub const TOP_PAIRED_NEXT_BOTTOM: u8 = 11;
+    pub const BOTTOM_PAIRED_NEXT_TOP: u8 = 12;
+}
+
+/// `V4L2_HEVC_DPB_ENTRIES_NUM_MAX` —— 最大 DPB 条目数。
+pub const HEVC_DPB_ENTRIES_NUM_MAX: usize = 16;
+
+/// `struct v4l2_hevc_dpb_entry` —— HEVC 解码图像缓冲条目。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HevcDpbEntry {
+    pub timestamp: u64,
+    pub flags: u8,
+    pub field_pic: u8,
+    pub reserved: u16,
+    pub pic_order_cnt_val: i32,
+}
+
+/// `struct v4l2_hevc_pred_weight_table` —— HEVC 加权预测参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HevcPredWeightTable {
+    pub delta_luma_weight_l0: [i8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub luma_offset_l0: [i8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub delta_chroma_weight_l0: [[i8; 2]; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub chroma_offset_l0: [[i8; 2]; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub delta_luma_weight_l1: [i8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub luma_offset_l1: [i8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub delta_chroma_weight_l1: [[i8; 2]; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub chroma_offset_l1: [[i8; 2]; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub luma_log2_weight_denom: u8,
+    pub delta_chroma_log2_weight_denom: i8,
+}
+
+/// `V4L2_HEVC_SLICE_PARAMS_FLAG_*`（64 位）。
+pub mod hevc_slice_params_flag {
+    pub const SLICE_SAO_LUMA: u64 = 1 << 0;
+    pub const SLICE_SAO_CHROMA: u64 = 1 << 1;
+    pub const SLICE_TEMPORAL_MVP_ENABLED: u64 = 1 << 2;
+    pub const MVD_L1_ZERO: u64 = 1 << 3;
+    pub const CABAC_INIT: u64 = 1 << 4;
+    pub const COLLOCATED_FROM_L0: u64 = 1 << 5;
+    pub const USE_INTEGER_MV: u64 = 1 << 6;
+    pub const SLICE_DEBLOCKING_FILTER_DISABLED: u64 = 1 << 7;
+    pub const SLICE_LOOP_FILTER_ACROSS_SLICES_ENABLED: u64 = 1 << 8;
+    pub const DEPENDENT_SLICE_SEGMENT: u64 = 1 << 9;
+}
+
+/// `struct v4l2_ctrl_hevc_slice_params` —— HEVC 条带参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHevcSliceParams {
+    pub bit_size: u32,
+    pub data_byte_offset: u32,
+    pub num_entry_point_offsets: u32,
+    pub nal_unit_type: u8,
+    pub nuh_temporal_id_plus1: u8,
+    pub slice_type: u8,
+    pub colour_plane_id: u8,
+    pub slice_pic_order_cnt: i32,
+    pub num_ref_idx_l0_active_minus1: u8,
+    pub num_ref_idx_l1_active_minus1: u8,
+    pub collocated_ref_idx: u8,
+    pub five_minus_max_num_merge_cand: u8,
+    pub slice_qp_delta: i8,
+    pub slice_cb_qp_offset: i8,
+    pub slice_cr_qp_offset: i8,
+    pub slice_act_y_qp_offset: i8,
+    pub slice_act_cb_qp_offset: i8,
+    pub slice_act_cr_qp_offset: i8,
+    pub slice_beta_offset_div2: i8,
+    pub slice_tc_offset_div2: i8,
+    pub pic_struct: u8,
+    pub reserved0: [u8; 3],
+    pub slice_segment_addr: u32,
+    pub ref_idx_l0: [u8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub ref_idx_l1: [u8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub short_term_ref_pic_set_size: u16,
+    pub long_term_ref_pic_set_size: u16,
+    pub pred_weight_table: HevcPredWeightTable,
+    pub reserved1: [u8; 2],
+    pub flags: u64,
+}
+
+/// `V4L2_HEVC_DECODE_PARAM_FLAG_*`。
+pub mod hevc_decode_param_flag {
+    pub const IRAP_PIC: u32 = 0x1;
+    pub const IDR_PIC: u32 = 0x2;
+    pub const NO_OUTPUT_OF_PRIOR: u32 = 0x4;
+}
+
+/// `struct v4l2_ctrl_hevc_decode_params` —— HEVC 解码参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHevcDecodeParams {
+    pub pic_order_cnt_val: i32,
+    pub short_term_ref_pic_set_size: u16,
+    pub long_term_ref_pic_set_size: u16,
+    pub num_active_dpb_entries: u8,
+    pub num_poc_st_curr_before: u8,
+    pub num_poc_st_curr_after: u8,
+    pub num_poc_lt_curr: u8,
+    pub poc_st_curr_before: [u8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub poc_st_curr_after: [u8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub poc_lt_curr: [u8; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub num_delta_pocs_of_ref_rps_idx: u8,
+    pub reserved: [u8; 3],
+    pub dpb: [HevcDpbEntry; HEVC_DPB_ENTRIES_NUM_MAX],
+    pub flags: u64,
+}
+
+/// `struct v4l2_ctrl_hevc_scaling_matrix` —— HEVC 缩放列表参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHevcScalingMatrix {
+    pub scaling_list_4x4: [[u8; 16]; 6],
+    pub scaling_list_8x8: [[u8; 64]; 6],
+    pub scaling_list_16x16: [[u8; 64]; 6],
+    pub scaling_list_32x32: [[u8; 64]; 2],
+    pub scaling_list_dc_coef_16x16: [u8; 6],
+    pub scaling_list_dc_coef_32x32: [u8; 2],
+}
+
+/// `V4L2_HEVC_EXT_SPS_ST_RPS_FLAG_INTER_REF_PIC_SET_PRED`。
+pub const HEVC_EXT_SPS_ST_RPS_FLAG_INTER_REF_PIC_SET_PRED: u16 = 0x1;
+
+/// `struct v4l2_ctrl_hevc_ext_sps_st_rps` —— HEVC 短期参考图像集参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHevcExtSpsStRps {
+    pub delta_idx_minus1: u8,
+    pub delta_rps_sign: u8,
+    pub num_negative_pics: u8,
+    pub num_positive_pics: u8,
+    pub used_by_curr_pic: u32,
+    pub use_delta_flag: u32,
+    pub abs_delta_rps_minus1: u16,
+    pub delta_poc_s0_minus1: [u16; 16],
+    pub delta_poc_s1_minus1: [u16; 16],
+    pub flags: u16,
+}
+
+/// `V4L2_HEVC_EXT_SPS_LT_RPS_FLAG_USED_LT`。
+pub const HEVC_EXT_SPS_LT_RPS_FLAG_USED_LT: u16 = 0x1;
+
+/// `struct v4l2_ctrl_hevc_ext_sps_lt_rps` —— HEVC 长期参考图像集参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHevcExtSpsLtRps {
+    pub lt_ref_pic_poc_lsb_sps: u16,
+    pub flags: u16,
+}
+
+// ── VP9 ─────────────────────────────────────────────────
+
+/// `V4L2_VP9_LOOP_FILTER_FLAG_*`。
+pub mod vp9_loop_filter_flag {
+    pub const DELTA_ENABLED: u8 = 0x1;
+    pub const DELTA_UPDATE: u8 = 0x2;
+}
+
+/// `struct v4l2_vp9_loop_filter` —— VP9 环路滤波参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp9LoopFilter {
+    pub ref_deltas: [i8; 4],
+    pub mode_deltas: [i8; 2],
+    pub level: u8,
+    pub sharpness: u8,
+    pub flags: u8,
+    pub reserved: [u8; 7],
+}
+
+/// `struct v4l2_vp9_quantization` —— VP9 量化参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp9Quantization {
+    pub base_q_idx: u8,
+    pub delta_q_y_dc: i8,
+    pub delta_q_uv_dc: i8,
+    pub delta_q_uv_ac: i8,
+    pub reserved: [u8; 4],
+}
+
+/// `V4L2_VP9_SEGMENTATION_FLAG_*`。
+pub mod vp9_segmentation_flag {
+    pub const ENABLED: u8 = 0x01;
+    pub const UPDATE_MAP: u8 = 0x02;
+    pub const TEMPORAL_UPDATE: u8 = 0x04;
+    pub const UPDATE_DATA: u8 = 0x08;
+    pub const ABS_OR_DELTA_UPDATE: u8 = 0x10;
+}
+
+/// `V4L2_VP9_SEG_LVL_*`。
+pub mod vp9_seg_lvl {
+    pub const ALT_Q: usize = 0;
+    pub const ALT_L: usize = 1;
+    pub const REF_FRAME: usize = 2;
+    pub const SKIP: usize = 3;
+    pub const MAX: usize = 4;
+}
+
+/// `V4L2_VP9_SEGMENT_FEATURE_ENABLED_MASK`。
+pub const VP9_SEGMENT_FEATURE_ENABLED_MASK: u8 = 0xf;
+
+/// `V4L2_VP9_SEGMENT_FEATURE_ENABLED(id) = 1 << (id)`。
+pub const fn vp9_segment_feature_enabled(id: usize) -> u8 {
+    1 << id
+}
+
+/// `struct v4l2_vp9_segmentation` —— VP9 分段参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp9Segmentation {
+    pub feature_data: [[i16; 4]; 8],
+    pub feature_enabled: [u8; 8],
+    pub tree_probs: [u8; 7],
+    pub pred_probs: [u8; 3],
+    pub flags: u8,
+    pub reserved: [u8; 5],
+}
+
+/// `V4L2_VP9_FRAME_FLAG_*`。
+pub mod vp9_frame_flag {
+    pub const KEY_FRAME: u32 = 0x001;
+    pub const SHOW_FRAME: u32 = 0x002;
+    pub const ERROR_RESILIENT: u32 = 0x004;
+    pub const INTRA_ONLY: u32 = 0x008;
+    pub const ALLOW_HIGH_PREC_MV: u32 = 0x010;
+    pub const REFRESH_FRAME_CTX: u32 = 0x020;
+    pub const PARALLEL_DEC_MODE: u32 = 0x040;
+    pub const X_SUBSAMPLING: u32 = 0x080;
+    pub const Y_SUBSAMPLING: u32 = 0x100;
+    pub const COLOR_RANGE_FULL_SWING: u32 = 0x200;
+}
+
+/// `V4L2_VP9_SIGN_BIAS_*`。
+pub mod vp9_sign_bias {
+    pub const LAST: u8 = 0x1;
+    pub const GOLDEN: u8 = 0x2;
+    pub const ALT: u8 = 0x4;
+}
+
+/// `V4L2_VP9_RESET_FRAME_CTX_*`。
+pub mod vp9_reset_frame_ctx {
+    pub const NONE: u8 = 0;
+    pub const SPEC: u8 = 1;
+    pub const ALL: u8 = 2;
+}
+
+/// `V4L2_VP9_INTERP_FILTER_*`。
+pub mod vp9_interp_filter {
+    pub const EIGHTTAP: u8 = 0;
+    pub const EIGHTTAP_SMOOTH: u8 = 1;
+    pub const EIGHTTAP_SHARP: u8 = 2;
+    pub const BILINEAR: u8 = 3;
+    pub const SWITCHABLE: u8 = 4;
+}
+
+/// `V4L2_VP9_REFERENCE_MODE_*`。
+pub mod vp9_reference_mode {
+    pub const SINGLE_REFERENCE: u8 = 0;
+    pub const COMPOUND_REFERENCE: u8 = 1;
+    pub const SELECT: u8 = 2;
+}
+
+/// `V4L2_VP9_PROFILE_MAX`。
+pub const VP9_PROFILE_MAX: u8 = 3;
+
+/// `V4L2_VP9_NUM_FRAME_CTX`。
+pub const VP9_NUM_FRAME_CTX: usize = 4;
+
+/// `V4L2_VP9_TX_MODE_*`。
+pub mod vp9_tx_mode {
+    pub const ONLY_4X4: u8 = 0;
+    pub const ALLOW_8X8: u8 = 1;
+    pub const ALLOW_16X16: u8 = 2;
+    pub const ALLOW_32X32: u8 = 3;
+    pub const SELECT: u8 = 4;
+}
+
+/// `struct v4l2_ctrl_vp9_frame` —— VP9 帧解码控制。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlVp9Frame {
+    pub lf: Vp9LoopFilter,
+    pub quant: Vp9Quantization,
+    pub seg: Vp9Segmentation,
+    pub flags: u32,
+    pub compressed_header_size: u16,
+    pub uncompressed_header_size: u16,
+    pub frame_width_minus_1: u16,
+    pub frame_height_minus_1: u16,
+    pub render_width_minus_1: u16,
+    pub render_height_minus_1: u16,
+    pub last_frame_ts: u64,
+    pub golden_frame_ts: u64,
+    pub alt_frame_ts: u64,
+    pub ref_frame_sign_bias: u8,
+    pub reset_frame_context: u8,
+    pub frame_context_idx: u8,
+    pub profile: u8,
+    pub bit_depth: u8,
+    pub interpolation_filter: u8,
+    pub tile_cols_log2: u8,
+    pub tile_rows_log2: u8,
+    pub reference_mode: u8,
+    pub reserved: [u8; 7],
+}
+
+/// `struct v4l2_vp9_mv_probs` —— VP9 运动矢量概率更新。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Vp9MvProbs {
+    pub joint: [u8; 3],
+    pub sign: [u8; 2],
+    pub classes: [[u8; 10]; 2],
+    pub class0_bit: [u8; 2],
+    pub bits: [[u8; 10]; 2],
+    pub class0_fr: [[[u8; 3]; 2]; 2],
+    pub fr: [[u8; 3]; 2],
+    pub class0_hp: [u8; 2],
+    pub hp: [u8; 2],
+}
+
+/// `struct v4l2_ctrl_vp9_compressed_hdr` —— VP9 压缩头概率更新控制。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlVp9CompressedHdr {
+    pub tx_mode: u8,
+    pub tx8: [[u8; 1]; 2],
+    pub tx16: [[u8; 2]; 2],
+    pub tx32: [[u8; 3]; 2],
+    pub coef: [[[[[u8; 3]; 6]; 6]; 2]; 4],
+    pub skip: [u8; 3],
+    pub inter_mode: [[u8; 3]; 7],
+    pub interp_filter: [[u8; 2]; 4],
+    pub is_inter: [u8; 4],
+    pub comp_mode: [u8; 5],
+    pub single_ref: [[u8; 2]; 5],
+    pub comp_ref: [u8; 5],
+    pub y_mode: [[u8; 9]; 4],
+    pub uv_mode: [[u8; 9]; 10],
+    pub partition: [[u8; 3]; 16],
+    pub mv: Vp9MvProbs,
+}
+
+// ── AV1 ─────────────────────────────────────────────────
+
+/// AV1 常量。
+pub mod av1 {
+    pub const TOTAL_REFS_PER_FRAME: usize = 8;
+    pub const CDEF_MAX: usize = 8;
+    pub const NUM_PLANES_MAX: usize = 3;
+    pub const MAX_SEGMENTS: usize = 8;
+    pub const MAX_OPERATING_POINTS: usize = 32;
+    pub const REFS_PER_FRAME: usize = 7;
+    pub const MAX_NUM_Y_POINTS: usize = 16;
+    pub const MAX_NUM_CB_POINTS: usize = 16;
+    pub const MAX_NUM_CR_POINTS: usize = 16;
+    pub const AR_COEFFS_SIZE: usize = 25;
+    pub const MAX_NUM_PLANES: usize = 3;
+    pub const MAX_TILE_COLS: usize = 64;
+    pub const MAX_TILE_ROWS: usize = 64;
+    pub const MAX_TILE_COUNT: usize = 512;
+}
+
+/// `V4L2_AV1_SEQUENCE_FLAG_*`。
+pub mod av1_sequence_flag {
+    pub const STILL_PICTURE: u32 = 0x0000_0001;
+    pub const USE_128X128_SUPERBLOCK: u32 = 0x0000_0002;
+    pub const ENABLE_FILTER_INTRA: u32 = 0x0000_0004;
+    pub const ENABLE_INTRA_EDGE_FILTER: u32 = 0x0000_0008;
+    pub const ENABLE_INTERINTRA_COMPOUND: u32 = 0x0000_0010;
+    pub const ENABLE_MASKED_COMPOUND: u32 = 0x0000_0020;
+    pub const ENABLE_WARPED_MOTION: u32 = 0x0000_0040;
+    pub const ENABLE_DUAL_FILTER: u32 = 0x0000_0080;
+    pub const ENABLE_ORDER_HINT: u32 = 0x0000_0100;
+    pub const ENABLE_JNT_COMP: u32 = 0x0000_0200;
+    pub const ENABLE_REF_FRAME_MVS: u32 = 0x0000_0400;
+    pub const ENABLE_SUPERRES: u32 = 0x0000_0800;
+    pub const ENABLE_CDEF: u32 = 0x0000_1000;
+    pub const ENABLE_RESTORATION: u32 = 0x0000_2000;
+    pub const MONO_CHROME: u32 = 0x0000_4000;
+    pub const COLOR_RANGE: u32 = 0x0000_8000;
+    pub const SUBSAMPLING_X: u32 = 0x0001_0000;
+    pub const SUBSAMPLING_Y: u32 = 0x0002_0000;
+    pub const FILM_GRAIN_PARAMS_PRESENT: u32 = 0x0004_0000;
+    pub const SEPARATE_UV_DELTA_Q: u32 = 0x0008_0000;
+}
+
+/// `struct v4l2_ctrl_av1_sequence` —— AV1 序列头 OBU。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlAv1Sequence {
+    pub flags: u32,
+    pub seq_profile: u8,
+    pub order_hint_bits: u8,
+    pub bit_depth: u8,
+    pub reserved: u8,
+    pub max_frame_width_minus_1: u16,
+    pub max_frame_height_minus_1: u16,
+}
+
+/// `struct v4l2_ctrl_av1_tile_group_entry` —— AV1 tile group 条目。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlAv1TileGroupEntry {
+    pub tile_offset: u32,
+    pub tile_size: u32,
+    pub tile_row: u32,
+    pub tile_col: u32,
+}
+
+/// `enum v4l2_av1_warp_model` —— AV1 warp 模型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Av1WarpModel {
+    Identity    = 0,
+    Translation = 1,
+    Rotzoom     = 2,
+    Affine      = 3,
+}
+
+/// `enum v4l2_av1_reference_frame` —— AV1 参考帧。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Av1ReferenceFrame {
+    IntraFrame   = 0,
+    LastFrame    = 1,
+    Last2Frame   = 2,
+    Last3Frame   = 3,
+    GoldenFrame  = 4,
+    BwdrefFrame  = 5,
+    Altref2Frame = 6,
+    AltrefFrame  = 7,
+}
+
+/// `V4L2_AV1_GLOBAL_MOTION_FLAG_*`。
+pub mod av1_global_motion_flag {
+    pub const IS_GLOBAL: u8 = 0x1;
+    pub const IS_ROT_ZOOM: u8 = 0x2;
+    pub const IS_TRANSLATION: u8 = 0x4;
+}
+
+/// `V4L2_AV1_GLOBAL_MOTION_IS_INVALID(ref) = 1 << (ref)`。
+pub const fn av1_global_motion_is_invalid(reference: usize) -> u32 {
+    1 << reference
+}
+
+/// `struct v4l2_av1_global_motion` —— AV1 全局运动参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Av1GlobalMotion {
+    pub flags: [u8; av1::TOTAL_REFS_PER_FRAME],
+    pub type_: [Av1WarpModel; av1::TOTAL_REFS_PER_FRAME],
+    pub params: [[i32; 6]; av1::TOTAL_REFS_PER_FRAME],
+    pub invalid: u8,
+    pub reserved: [u8; 3],
+}
+
+/// `enum v4l2_av1_frame_restoration_type` —— AV1 帧恢复类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Av1FrameRestorationType {
+    None       = 0,
+    Wiener     = 1,
+    Sgrproj    = 2,
+    Switchable = 3,
+}
+
+/// `V4L2_AV1_LOOP_RESTORATION_FLAG_*`。
+pub mod av1_loop_restoration_flag {
+    pub const USES_LR: u8 = 0x1;
+    pub const USES_CHROMA_LR: u8 = 0x2;
+}
+
+/// `struct v4l2_av1_loop_restoration` —— AV1 环路恢复参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Av1LoopRestoration {
+    pub flags: u8,
+    pub lr_unit_shift: u8,
+    pub lr_uv_shift: u8,
+    pub reserved: u8,
+    pub frame_restoration_type: [Av1FrameRestorationType; av1::NUM_PLANES_MAX],
+    pub loop_restoration_size: [u32; av1::MAX_NUM_PLANES],
+}
+
+/// `struct v4l2_av1_cdef` —— AV1 CDEF 参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Av1Cdef {
+    pub damping_minus_3: u8,
+    pub bits: u8,
+    pub y_pri_strength: [u8; av1::CDEF_MAX],
+    pub y_sec_strength: [u8; av1::CDEF_MAX],
+    pub uv_pri_strength: [u8; av1::CDEF_MAX],
+    pub uv_sec_strength: [u8; av1::CDEF_MAX],
+}
+
+/// `V4L2_AV1_SEGMENTATION_FLAG_*`。
+pub mod av1_segmentation_flag {
+    pub const ENABLED: u8 = 0x1;
+    pub const UPDATE_MAP: u8 = 0x2;
+    pub const TEMPORAL_UPDATE: u8 = 0x4;
+    pub const UPDATE_DATA: u8 = 0x8;
+    pub const SEG_ID_PRE_SKIP: u8 = 0x10;
+}
+
+/// `enum v4l2_av1_segment_feature` —— AV1 段特性索引。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Av1SegmentFeature {
+    AltQ        = 0,
+    AltLfYV     = 1,
+    RefFrame    = 5,
+    RefSkip     = 6,
+    RefGlobalmv = 7,
+    Max         = 8,
+}
+
+/// `V4L2_AV1_SEGMENT_FEATURE_ENABLED(id) = 1 << (id)`。
+pub const fn av1_segment_feature_enabled(id: usize) -> u32 {
+    1 << id
+}
+
+/// `struct v4l2_av1_segmentation` —— AV1 分段参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Av1Segmentation {
+    pub flags: u8,
+    pub last_active_seg_id: u8,
+    pub feature_enabled: [u8; av1::MAX_SEGMENTS],
+    pub feature_data: [[i16; av1::MAX_SEGMENTS]; av1::MAX_SEGMENTS],
+}
+
+/// `V4L2_AV1_LOOP_FILTER_FLAG_*`。
+pub mod av1_loop_filter_flag {
+    pub const DELTA_ENABLED: u8 = 0x1;
+    pub const DELTA_UPDATE: u8 = 0x2;
+    pub const DELTA_LF_PRESENT: u8 = 0x4;
+    pub const DELTA_LF_MULTI: u8 = 0x8;
+}
+
+/// `struct v4l2_av1_loop_filter` —— AV1 环路滤波参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Av1LoopFilter {
+    pub flags: u8,
+    pub level: [u8; 4],
+    pub sharpness: u8,
+    pub ref_deltas: [i8; av1::TOTAL_REFS_PER_FRAME],
+    pub mode_deltas: [i8; 2],
+    pub delta_lf_res: u8,
+}
+
+/// `V4L2_AV1_QUANTIZATION_FLAG_*`。
+pub mod av1_quantization_flag {
+    pub const DIFF_UV_DELTA: u8 = 0x1;
+    pub const USING_QMATRIX: u8 = 0x2;
+    pub const DELTA_Q_PRESENT: u8 = 0x4;
+}
+
+/// `struct v4l2_av1_quantization` —— AV1 量化参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Av1Quantization {
+    pub flags: u8,
+    pub base_q_idx: u8,
+    pub delta_q_y_dc: i8,
+    pub delta_q_u_dc: i8,
+    pub delta_q_u_ac: i8,
+    pub delta_q_v_dc: i8,
+    pub delta_q_v_ac: i8,
+    pub qm_y: u8,
+    pub qm_u: u8,
+    pub qm_v: u8,
+    pub delta_q_res: u8,
+}
+
+/// `V4L2_AV1_TILE_INFO_FLAG_UNIFORM_TILE_SPACING`。
+pub const AV1_TILE_INFO_FLAG_UNIFORM_TILE_SPACING: u8 = 0x1;
+
+/// `struct v4l2_av1_tile_info` —— AV1 tile 信息。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Av1TileInfo {
+    pub flags: u8,
+    pub context_update_tile_id: u8,
+    pub tile_cols: u8,
+    pub tile_rows: u8,
+    pub mi_col_starts: [u32; av1::MAX_TILE_COLS + 1],
+    pub mi_row_starts: [u32; av1::MAX_TILE_ROWS + 1],
+    pub width_in_sbs_minus_1: [u32; av1::MAX_TILE_COLS],
+    pub height_in_sbs_minus_1: [u32; av1::MAX_TILE_ROWS],
+    pub tile_size_bytes: u8,
+    pub reserved: [u8; 3],
+}
+
+/// `enum v4l2_av1_frame_type` —— AV1 帧类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Av1FrameType {
+    KeyFrame       = 0,
+    InterFrame     = 1,
+    IntraOnlyFrame = 2,
+    SwitchFrame    = 3,
+}
+
+/// `enum v4l2_av1_interpolation_filter` —— AV1 插值滤波器类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Av1InterpolationFilter {
+    Eighttap       = 0,
+    EighttapSmooth = 1,
+    EighttapSharp  = 2,
+    Bilinear       = 3,
+    Switchable     = 4,
+}
+
+/// `enum v4l2_av1_tx_mode` —— AV1 变换模式。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Av1TxMode {
+    Only4x4 = 0,
+    Largest = 1,
+    Select  = 2,
+}
+
+/// `V4L2_AV1_FRAME_FLAG_*`。
+pub mod av1_frame_flag {
+    pub const SHOW_FRAME: u32 = 0x0000_0001;
+    pub const SHOWABLE_FRAME: u32 = 0x0000_0002;
+    pub const ERROR_RESILIENT_MODE: u32 = 0x0000_0004;
+    pub const DISABLE_CDF_UPDATE: u32 = 0x0000_0008;
+    pub const ALLOW_SCREEN_CONTENT_TOOLS: u32 = 0x0000_0010;
+    pub const FORCE_INTEGER_MV: u32 = 0x0000_0020;
+    pub const ALLOW_INTRABC: u32 = 0x0000_0040;
+    pub const USE_SUPERRES: u32 = 0x0000_0080;
+    pub const ALLOW_HIGH_PRECISION_MV: u32 = 0x0000_0100;
+    pub const IS_MOTION_MODE_SWITCHABLE: u32 = 0x0000_0200;
+    pub const USE_REF_FRAME_MVS: u32 = 0x0000_0400;
+    pub const DISABLE_FRAME_END_UPDATE_CDF: u32 = 0x0000_0800;
+    pub const ALLOW_WARPED_MOTION: u32 = 0x0000_1000;
+    pub const REFERENCE_SELECT: u32 = 0x0000_2000;
+    pub const REDUCED_TX_SET: u32 = 0x0000_4000;
+    pub const SKIP_MODE_ALLOWED: u32 = 0x0000_8000;
+    pub const SKIP_MODE_PRESENT: u32 = 0x0001_0000;
+    pub const FRAME_SIZE_OVERRIDE: u32 = 0x0002_0000;
+    pub const BUFFER_REMOVAL_TIME_PRESENT: u32 = 0x0004_0000;
+    pub const FRAME_REFS_SHORT_SIGNALING: u32 = 0x0008_0000;
+}
+
+/// `struct v4l2_ctrl_av1_frame` —— AV1 帧头 OBU。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlAv1Frame {
+    pub tile_info: Av1TileInfo,
+    pub quantization: Av1Quantization,
+    pub superres_denom: u8,
+    pub segmentation: Av1Segmentation,
+    pub loop_filter: Av1LoopFilter,
+    pub cdef: Av1Cdef,
+    pub skip_mode_frame: [u8; 2],
+    pub primary_ref_frame: u8,
+    pub loop_restoration: Av1LoopRestoration,
+    pub global_motion: Av1GlobalMotion,
+    pub flags: u32,
+    pub frame_type: Av1FrameType,
+    pub order_hint: u32,
+    pub upscaled_width: u32,
+    pub interpolation_filter: Av1InterpolationFilter,
+    pub tx_mode: Av1TxMode,
+    pub frame_width_minus_1: u32,
+    pub frame_height_minus_1: u32,
+    pub render_width_minus_1: u16,
+    pub render_height_minus_1: u16,
+    pub current_frame_id: u32,
+    pub buffer_removal_time: [u32; av1::MAX_OPERATING_POINTS],
+    pub reserved: [u8; 4],
+    pub order_hints: [u32; av1::TOTAL_REFS_PER_FRAME],
+    pub reference_frame_ts: [u64; av1::TOTAL_REFS_PER_FRAME],
+    pub ref_frame_idx: [i8; av1::REFS_PER_FRAME],
+    pub refresh_frame_flags: u8,
+}
+
+/// `V4L2_AV1_FILM_GRAIN_FLAG_*`。
+pub mod av1_film_grain_flag {
+    pub const APPLY_GRAIN: u8 = 0x1;
+    pub const UPDATE_GRAIN: u8 = 0x2;
+    pub const CHROMA_SCALING_FROM_LUMA: u8 = 0x4;
+    pub const OVERLAP: u8 = 0x8;
+    pub const CLIP_TO_RESTRICTED_RANGE: u8 = 0x10;
+}
+
+/// `struct v4l2_ctrl_av1_film_grain` —— AV1 胶片颗粒参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlAv1FilmGrain {
+    pub flags: u8,
+    pub cr_mult: u8,
+    pub grain_seed: u16,
+    pub film_grain_params_ref_idx: u8,
+    pub num_y_points: u8,
+    pub point_y_value: [u8; av1::MAX_NUM_Y_POINTS],
+    pub point_y_scaling: [u8; av1::MAX_NUM_Y_POINTS],
+    pub num_cb_points: u8,
+    pub point_cb_value: [u8; av1::MAX_NUM_CB_POINTS],
+    pub point_cb_scaling: [u8; av1::MAX_NUM_CB_POINTS],
+    pub num_cr_points: u8,
+    pub point_cr_value: [u8; av1::MAX_NUM_CR_POINTS],
+    pub point_cr_scaling: [u8; av1::MAX_NUM_CR_POINTS],
+    pub grain_scaling_minus_8: u8,
+    pub ar_coeff_lag: u8,
+    pub ar_coeffs_y_plus_128: [u8; av1::AR_COEFFS_SIZE],
+    pub ar_coeffs_cb_plus_128: [u8; av1::AR_COEFFS_SIZE],
+    pub ar_coeffs_cr_plus_128: [u8; av1::AR_COEFFS_SIZE],
+    pub ar_coeff_shift_minus_6: u8,
+    pub grain_scale_shift: u8,
+    pub cb_mult: u8,
+    pub cb_luma_mult: u8,
+    pub cr_luma_mult: u8,
+    pub cb_offset: u16,
+    pub cr_offset: u16,
+    pub reserved: [u8; 4],
+}

--- a/drivers/media/ax-media/src/ctrls/class/colorimetry.rs
+++ b/drivers/media/ax-media/src/ctrls/class/colorimetry.rs
@@ -1,0 +1,57 @@
+//! 颜色计量控件（`V4L2_CTRL_CLASS_COLORIMETRY = 0x00a50000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_COLORIMETRY` —— 颜色计量控件。
+pub const CLASS_ID: u32 = CtrlClass::Colorimetry as u32;
+
+/// `V4L2_CID_COLORIMETRY_CLASS = (V4L2_CTRL_CLASS_COLORIMETRY | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_COLORIMETRY_CLASS_BASE = (V4L2_CTRL_CLASS_COLORIMETRY | 0x900) = 0x00a50900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+// ── HDR10 常量 ─────────────────────────────────────────────
+
+pub const HDR10_MASTERING_PRIMARIES_X_LOW: u32 = 5;
+pub const HDR10_MASTERING_PRIMARIES_X_HIGH: u32 = 37000;
+pub const HDR10_MASTERING_PRIMARIES_Y_LOW: u32 = 5;
+pub const HDR10_MASTERING_PRIMARIES_Y_HIGH: u32 = 42000;
+pub const HDR10_MASTERING_WHITE_POINT_X_LOW: u32 = 5;
+pub const HDR10_MASTERING_WHITE_POINT_X_HIGH: u32 = 37000;
+pub const HDR10_MASTERING_WHITE_POINT_Y_LOW: u32 = 5;
+pub const HDR10_MASTERING_WHITE_POINT_Y_HIGH: u32 = 42000;
+pub const HDR10_MASTERING_MAX_LUMA_LOW: u32 = 50000;
+pub const HDR10_MASTERING_MAX_LUMA_HIGH: u32 = 100000000;
+pub const HDR10_MASTERING_MIN_LUMA_LOW: u32 = 1;
+pub const HDR10_MASTERING_MIN_LUMA_HIGH: u32 = 50000;
+
+// ── 复合控件结构体 ────────────────────────────────────────
+
+/// `struct v4l2_ctrl_hdr10_cll_info` —— HDR10 内容亮度级别信息。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHdr10CllInfo {
+    pub max_content_light_level: u16,
+    pub max_pic_average_light_level: u16,
+}
+
+/// `struct v4l2_ctrl_hdr10_mastering_display` —— HDR10 母版显示信息。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlHdr10MasteringDisplay {
+    pub display_primaries_x: [u16; 3],
+    pub display_primaries_y: [u16; 3],
+    pub white_point_x: u16,
+    pub white_point_y: u16,
+    pub max_display_mastering_luminance: u32,
+    pub min_display_mastering_luminance: u32,
+}
+
+/// V4L2 颜色计量类控制 ID（`V4L2_CID_COLORIMETRY_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorimetryClassCtrl {
+    Hdr10CllInfo = CID_BASE,
+    Hdr10MasteringDisplay = CID_BASE + 1,
+}

--- a/drivers/media/ax-media/src/ctrls/class/detect.rs
+++ b/drivers/media/ax-media/src/ctrls/class/detect.rs
@@ -1,0 +1,32 @@
+//! 检测控件（`V4L2_CTRL_CLASS_DETECT = 0x00a30000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_DETECT` —— 检测控件。
+pub const CLASS_ID: u32 = CtrlClass::Detect as u32;
+
+/// `V4L2_CID_DETECT_CLASS = (V4L2_CTRL_CLASS_DETECT | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_DETECT_CLASS_BASE = (V4L2_CTRL_CLASS_DETECT | 0x900) = 0x00a30900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// `enum v4l2_detect_md_mode` —— `V4L2_CID_DETECT_MD_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectMdMode {
+    Disabled      = 0,
+    Global        = 1,
+    ThresholdGrid = 2,
+    RegionGrid    = 3,
+}
+
+/// V4L2 检测类控制 ID（`V4L2_CID_DETECT_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectClassCtrl {
+    Mode            = CID_BASE + 1,
+    GlobalThreshold = CID_BASE + 2,
+    ThresholdGrid   = CID_BASE + 3,
+    RegionGrid      = CID_BASE + 4,
+}

--- a/drivers/media/ax-media/src/ctrls/class/dv.rs
+++ b/drivers/media/ax-media/src/ctrls/class/dv.rs
@@ -1,0 +1,55 @@
+//! 数字视频控件（`V4L2_CTRL_CLASS_DV = 0x00a00000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_DV` —— 数字视频控件。
+pub const CLASS_ID: u32 = CtrlClass::Dv as u32;
+
+/// `V4L2_CID_DV_CLASS = (V4L2_CTRL_CLASS_DV | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_DV_CLASS_BASE = (V4L2_CTRL_CLASS_DV | 0x900) = 0x00a00900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// `enum v4l2_dv_tx_mode` —— `V4L2_CID_DV_TX_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DvTxMode {
+    DviD = 0,
+    Hdmi = 1,
+}
+
+/// `enum v4l2_dv_rgb_range` —— `V4L2_CID_DV_TX_RGB_RANGE` / `V4L2_CID_DV_RX_RGB_RANGE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DvRgbRange {
+    Auto    = 0,
+    Limited = 1,
+    Full    = 2,
+}
+
+/// `enum v4l2_dv_it_content_type` —— `V4L2_CID_DV_TX_IT_CONTENT_TYPE` / `V4L2_CID_DV_RX_IT_CONTENT_TYPE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DvItContentType {
+    Graphics = 0,
+    Photo    = 1,
+    Cinema   = 2,
+    Game     = 3,
+    NoItc    = 4,
+}
+
+/// V4L2 数字视频类控制 ID（`V4L2_CID_DV_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DvClassCtrl {
+    TxHotplug       = CID_BASE + 1,
+    TxRxsense       = CID_BASE + 2,
+    TxEdidPresent   = CID_BASE + 3,
+    TxMode          = CID_BASE + 4,
+    TxRgbRange      = CID_BASE + 5,
+    TxItContentType = CID_BASE + 6,
+    RxPowerPresent  = CID_BASE + 100,
+    RxRgbRange      = CID_BASE + 101,
+    RxItContentType = CID_BASE + 102,
+}

--- a/drivers/media/ax-media/src/ctrls/class/flash.rs
+++ b/drivers/media/ax-media/src/ctrls/class/flash.rs
@@ -1,0 +1,66 @@
+//! 相机闪光灯控件（`V4L2_CTRL_CLASS_FLASH = 0x009c0000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_FLASH` —— 相机闪光灯控件。
+pub const CLASS_ID: u32 = CtrlClass::Flash as u32;
+
+/// `V4L2_CID_FLASH_CLASS = (V4L2_CTRL_CLASS_FLASH | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_FLASH_CLASS_BASE = (V4L2_CTRL_CLASS_FLASH | 0x900) = 0x009c0900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+// ── 菜单枚举 ─────────────────────────────────────────────────
+
+/// `enum v4l2_flash_led_mode` —— `V4L2_CID_FLASH_LED_MODE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashLedMode {
+    None  = 0,
+    Flash = 1,
+    Torch = 2,
+}
+
+/// `enum v4l2_flash_strobe_source` —— `V4L2_CID_FLASH_STROBE_SOURCE` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashStrobeSource {
+    Software = 0,
+    External = 1,
+}
+
+// ── 位标志 ─────────────────────────────────────────────────
+
+/// `V4L2_CID_FLASH_FAULT` 的 `V4L2_FLASH_FAULT_*` 位标志。
+pub mod flash_fault {
+    pub const OVER_VOLTAGE: u32 = 1 << 0;
+    pub const TIMEOUT: u32 = 1 << 1;
+    pub const OVER_TEMPERATURE: u32 = 1 << 2;
+    pub const SHORT_CIRCUIT: u32 = 1 << 3;
+    pub const OVER_CURRENT: u32 = 1 << 4;
+    pub const INDICATOR: u32 = 1 << 5;
+    pub const UNDER_VOLTAGE: u32 = 1 << 6;
+    pub const INPUT_VOLTAGE: u32 = 1 << 7;
+    pub const LED_OVER_TEMPERATURE: u32 = 1 << 8;
+}
+
+/// V4L2 相机闪光灯类控制 ID（`V4L2_CID_FLASH_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FlashClassCtrl {
+    LedMode            = CID_BASE + 1,
+    StrobeSource       = CID_BASE + 2,
+    Strobe             = CID_BASE + 3,
+    StrobeStop         = CID_BASE + 4,
+    StrobeStatus       = CID_BASE + 5,
+    Timeout            = CID_BASE + 6,
+    Intensity          = CID_BASE + 7,
+    TorchIntensity     = CID_BASE + 8,
+    IndicatorIntensity = CID_BASE + 9,
+    Fault              = CID_BASE + 10,
+    Charge             = CID_BASE + 11,
+    Ready              = CID_BASE + 12,
+    Duration           = CID_BASE + 13,
+    StrobeOe           = CID_BASE + 14,
+}

--- a/drivers/media/ax-media/src/ctrls/class/fm_rx.rs
+++ b/drivers/media/ax-media/src/ctrls/class/fm_rx.rs
@@ -1,0 +1,37 @@
+//! FM 接收器控件（`V4L2_CTRL_CLASS_FM_RX = 0x00a10000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_FM_RX` —— FM 接收器控件。
+pub const CLASS_ID: u32 = CtrlClass::FmRx as u32;
+
+/// `V4L2_CID_FM_RX_CLASS = (V4L2_CTRL_CLASS_FM_RX | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_FM_RX_CLASS_BASE = (V4L2_CTRL_CLASS_FM_RX | 0x900) = 0x00a10900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// `enum v4l2_deemphasis` —— `V4L2_CID_TUNE_DEEMPHASIS` 菜单项。
+///
+/// 数值与 `v4l2_preemphasis` 一致。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Deemphasis {
+    Disabled = 0,
+    Us50     = 1,
+    Us75     = 2,
+}
+
+/// V4L2 FM 接收器类控制 ID（`V4L2_CID_FM_RX_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FmRxClassCtrl {
+    TuneDeemphasis      = CID_BASE + 1,
+    RdsReception        = CID_BASE + 2,
+    RdsRxPty            = CID_BASE + 3,
+    RdsRxPsName         = CID_BASE + 4,
+    RdsRxRadioText      = CID_BASE + 5,
+    RdsRxTrafficAnnouncement = CID_BASE + 6,
+    RdsRxTrafficProgram = CID_BASE + 7,
+    RdsRxMusicSpeech    = CID_BASE + 8,
+}

--- a/drivers/media/ax-media/src/ctrls/class/fm_tx.rs
+++ b/drivers/media/ax-media/src/ctrls/class/fm_tx.rs
@@ -1,0 +1,55 @@
+//! FM 调制器控件（`V4L2_CTRL_CLASS_FM_TX = 0x009b0000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_FM_TX` —— FM 调制器控件。
+pub const CLASS_ID: u32 = CtrlClass::FmTx as u32;
+
+/// `V4L2_CID_FM_TX_CLASS = (V4L2_CTRL_CLASS_FM_TX | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_FM_TX_CLASS_BASE = (V4L2_CTRL_CLASS_FM_TX | 0x900) = 0x009b0900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// `enum v4l2_preemphasis` —— `V4L2_CID_TUNE_PREEMPHASIS` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Preemphasis {
+    Disabled = 0,
+    Us50     = 1,
+    Us75     = 2,
+}
+
+/// V4L2 FM 调制器类控制 ID（`V4L2_CID_FM_TX_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FmTxClassCtrl {
+    RdsTxDeviation       = CID_BASE + 1,
+    RdsTxPi              = CID_BASE + 2,
+    RdsTxPty             = CID_BASE + 3,
+    RdsTxPsName          = CID_BASE + 5,
+    RdsTxRadioText       = CID_BASE + 6,
+    RdsTxMonoStereo      = CID_BASE + 7,
+    RdsTxArtificialHead  = CID_BASE + 8,
+    RdsTxCompressed      = CID_BASE + 9,
+    RdsTxDynamicPty      = CID_BASE + 10,
+    RdsTxTrafficAnnouncement = CID_BASE + 11,
+    RdsTxTrafficProgram  = CID_BASE + 12,
+    RdsTxMusicSpeech     = CID_BASE + 13,
+    RdsTxAltFreqsEnable  = CID_BASE + 14,
+    RdsTxAltFreqs        = CID_BASE + 15,
+    AudioLimiterEnabled  = CID_BASE + 64,
+    AudioLimiterReleaseTime = CID_BASE + 65,
+    AudioLimiterDeviation = CID_BASE + 66,
+    AudioCompressionEnabled = CID_BASE + 80,
+    AudioCompressionGain = CID_BASE + 81,
+    AudioCompressionThreshold = CID_BASE + 82,
+    AudioCompressionAttackTime = CID_BASE + 83,
+    AudioCompressionReleaseTime = CID_BASE + 84,
+    PilotToneEnabled     = CID_BASE + 96,
+    PilotToneDeviation   = CID_BASE + 97,
+    PilotToneFrequency   = CID_BASE + 98,
+    TunePreemphasis      = CID_BASE + 112,
+    TunePowerLevel       = CID_BASE + 113,
+    TuneAntennaCapacitor = CID_BASE + 114,
+}

--- a/drivers/media/ax-media/src/ctrls/class/image_proc.rs
+++ b/drivers/media/ax-media/src/ctrls/class/image_proc.rs
@@ -1,0 +1,23 @@
+//! 图像处理控件（`V4L2_CTRL_CLASS_IMAGE_PROC = 0x009f0000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_IMAGE_PROC` —— 图像处理控件。
+pub const CLASS_ID: u32 = CtrlClass::ImageProc as u32;
+
+/// `V4L2_CID_IMAGE_PROC_CLASS = (V4L2_CTRL_CLASS_IMAGE_PROC | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_IMAGE_PROC_CLASS_BASE = (V4L2_CTRL_CLASS_IMAGE_PROC | 0x900) = 0x009f0900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// V4L2 图像处理类控制 ID（`V4L2_CID_IMAGE_PROC_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageProcClassCtrl {
+    LinkFreq          = CID_BASE + 1,
+    PixelRate         = CID_BASE + 2,
+    TestPattern       = CID_BASE + 3,
+    DeinterlacingMode = CID_BASE + 4,
+    DigitalGain       = CID_BASE + 5,
+}

--- a/drivers/media/ax-media/src/ctrls/class/image_source.rs
+++ b/drivers/media/ax-media/src/ctrls/class/image_source.rs
@@ -1,0 +1,27 @@
+//! 图像源控件（`V4L2_CTRL_CLASS_IMAGE_SOURCE = 0x009e0000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_IMAGE_SOURCE` —— 图像源控件。
+pub const CLASS_ID: u32 = CtrlClass::ImageSource as u32;
+
+/// `V4L2_CID_IMAGE_SOURCE_CLASS = (V4L2_CTRL_CLASS_IMAGE_SOURCE | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_IMAGE_SOURCE_CLASS_BASE = (V4L2_CTRL_CLASS_IMAGE_SOURCE | 0x900) = 0x009e0900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// V4L2 图像源类控制 ID（`V4L2_CID_IMAGE_SOURCE_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ImageSourceClassCtrl {
+    Vblank            = CID_BASE + 1,
+    Hblank            = CID_BASE + 2,
+    AnalogueGain      = CID_BASE + 3,
+    TestPatternRed    = CID_BASE + 4,
+    TestPatternGreenR = CID_BASE + 5,
+    TestPatternBlue   = CID_BASE + 6,
+    TestPatternGreenB = CID_BASE + 7,
+    UnitCellSize      = CID_BASE + 8,
+    NotifyGains       = CID_BASE + 9,
+}

--- a/drivers/media/ax-media/src/ctrls/class/jpeg.rs
+++ b/drivers/media/ax-media/src/ctrls/class/jpeg.rs
@@ -1,0 +1,43 @@
+//! JPEG 压缩控件（`V4L2_CTRL_CLASS_JPEG = 0x009d0000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_JPEG` —— JPEG 压缩控件。
+pub const CLASS_ID: u32 = CtrlClass::Jpeg as u32;
+
+/// `V4L2_CID_JPEG_CLASS = (V4L2_CTRL_CLASS_JPEG | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_JPEG_CLASS_BASE = (V4L2_CTRL_CLASS_JPEG | 0x900) = 0x009d0900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// `enum v4l2_jpeg_chroma_subsampling` —— `V4L2_CID_JPEG_CHROMA_SUBSAMPLING` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JpegChromaSubsampling {
+    Sub444 = 0,
+    Sub422 = 1,
+    Sub420 = 2,
+    Sub411 = 3,
+    Sub410 = 4,
+    Gray   = 5,
+}
+
+/// `V4L2_CID_JPEG_ACTIVE_MARKER` 的 `V4L2_JPEG_ACTIVE_MARKER_*` 位标志。
+pub mod active_marker {
+    pub const APP0: u32 = 1 << 0;
+    pub const APP1: u32 = 1 << 1;
+    pub const COM: u32 = 1 << 16;
+    pub const DQT: u32 = 1 << 17;
+    pub const DHT: u32 = 1 << 18;
+}
+
+/// V4L2 JPEG 类控制 ID（`V4L2_CID_JPEG_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JpegClassCtrl {
+    ChromaSubsampling  = CID_BASE + 1,
+    RestartInterval    = CID_BASE + 2,
+    CompressionQuality = CID_BASE + 3,
+    ActiveMarker       = CID_BASE + 4,
+}

--- a/drivers/media/ax-media/src/ctrls/class/mod.rs
+++ b/drivers/media/ax-media/src/ctrls/class/mod.rs
@@ -1,0 +1,72 @@
+//! V4L2 控件类。
+//!
+//! 每个控件类一个独立模块，类 ID 由 [`CtrlClass`] 统一登记，
+//! 各模块内再定义该类的基址（`CID_BASE`）与控件 ID：
+//!
+//! - [`user`]：旧式 ‘user’ 控件（`V4L2_CTRL_CLASS_USER`）。
+//! - [`codec`]：有状态编解码控件（`V4L2_CTRL_CLASS_CODEC`）。
+//! - [`camera`]：相机类控件（`V4L2_CTRL_CLASS_CAMERA`）。
+//! - [`fm_tx`]：FM 调制器控件（`V4L2_CTRL_CLASS_FM_TX`）。
+//! - [`flash`]：相机闪光灯控件（`V4L2_CTRL_CLASS_FLASH`）。
+//! - [`jpeg`]：JPEG 压缩控件（`V4L2_CTRL_CLASS_JPEG`）。
+//! - [`image_source`]：图像源控件（`V4L2_CTRL_CLASS_IMAGE_SOURCE`）。
+//! - [`image_proc`]：图像处理控件（`V4L2_CTRL_CLASS_IMAGE_PROC`）。
+//! - [`dv`]：数字视频控件（`V4L2_CTRL_CLASS_DV`）。
+//! - [`fm_rx`]：FM 接收器控件（`V4L2_CTRL_CLASS_FM_RX`）。
+//! - [`rf_tuner`]：RF 调谐器控件（`V4L2_CTRL_CLASS_RF_TUNER`）。
+//! - [`detect`]：检测控件（`V4L2_CTRL_CLASS_DETECT`）。
+//! - [`codec_stateless`]：无状态编解码控件（`V4L2_CTRL_CLASS_CODEC_STATELESS`）。
+//! - [`colorimetry`]：颜色计量控件（`V4L2_CTRL_CLASS_COLORIMETRY`）。
+
+pub mod camera;
+pub mod codec;
+pub mod codec_stateless;
+pub mod colorimetry;
+pub mod detect;
+pub mod dv;
+pub mod flash;
+pub mod fm_rx;
+pub mod fm_tx;
+pub mod image_proc;
+pub mod image_source;
+pub mod jpeg;
+pub mod rf_tuner;
+pub mod user;
+
+pub use camera::CameraClassCtrl;
+pub use codec::CodecClassCtrl;
+pub use codec_stateless::CodecStatelessClassCtrl;
+pub use colorimetry::ColorimetryClassCtrl;
+pub use detect::DetectClassCtrl;
+pub use dv::DvClassCtrl;
+pub use flash::FlashClassCtrl;
+pub use fm_rx::FmRxClassCtrl;
+pub use fm_tx::FmTxClassCtrl;
+pub use image_proc::ImageProcClassCtrl;
+pub use image_source::ImageSourceClassCtrl;
+pub use jpeg::JpegClassCtrl;
+pub use rf_tuner::RfTunerClassCtrl;
+pub use user::UserClassCtrl;
+
+/// V4L2 控制类 ID（CID 的高 16 位）。
+///
+/// 来自 `linux/v4l2-controls.h`。控制按功能类组织；
+/// 类别编码在控制 ID 的 31:16 位。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CtrlClass {
+    User           = 0x00980000, // 旧式 ‘user’ 控件
+    Codec          = 0x00990000, // 有状态编解码控件
+    Camera         = 0x009a0000, // 相机类控件
+    FmTx           = 0x009b0000, // FM 调制器控件
+    Flash          = 0x009c0000, // 相机闪光灯控件
+    Jpeg           = 0x009d0000, // JPEG 压缩控件
+    ImageSource    = 0x009e0000, // 图像源控件
+    ImageProc      = 0x009f0000, // 图像处理控件
+    Dv             = 0x00a00000, // 数字视频控件
+    FmRx           = 0x00a10000, // FM 接收器控件
+    RfTuner        = 0x00a20000, // RF 调谐器控件
+    Detect         = 0x00a30000, // 检测控件
+    CodecStateless = 0x00a40000, // 无状态编解码控件
+    Colorimetry    = 0x00a50000, // 颜色计量控件
+}

--- a/drivers/media/ax-media/src/ctrls/class/rf_tuner.rs
+++ b/drivers/media/ax-media/src/ctrls/class/rf_tuner.rs
@@ -1,0 +1,28 @@
+//! RF 调谐器控件（`V4L2_CTRL_CLASS_RF_TUNER = 0x00a20000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_RF_TUNER` —— RF 调谐器控件。
+pub const CLASS_ID: u32 = CtrlClass::RfTuner as u32;
+
+/// `V4L2_CID_RF_TUNER_CLASS = (V4L2_CTRL_CLASS_RF_TUNER | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_RF_TUNER_CLASS_BASE = (V4L2_CTRL_CLASS_RF_TUNER | 0x900) = 0x00a20900`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// V4L2 RF 调谐器类控制 ID（`V4L2_CID_RF_TUNER_CLASS_BASE` + 偏移）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RfTunerClassCtrl {
+    BandwidthAuto = CID_BASE + 11,
+    Bandwidth     = CID_BASE + 12,
+    RfGain        = CID_BASE + 32,
+    LnaGainAuto   = CID_BASE + 41,
+    LnaGain       = CID_BASE + 42,
+    MixerGainAuto = CID_BASE + 51,
+    MixerGain     = CID_BASE + 52,
+    IfGainAuto    = CID_BASE + 61,
+    IfGain        = CID_BASE + 62,
+    PllLock       = CID_BASE + 91,
+}

--- a/drivers/media/ax-media/src/ctrls/class/user.rs
+++ b/drivers/media/ax-media/src/ctrls/class/user.rs
@@ -1,0 +1,105 @@
+//! 用户类控件（`V4L2_CTRL_CLASS_USER = 0x00980000`）。
+
+use super::CtrlClass;
+
+/// `V4L2_CTRL_CLASS_USER` —— 旧式 ‘user’ 控件。
+pub const CLASS_ID: u32 = CtrlClass::User as u32;
+
+/// `V4L2_CID_USER_CLASS = (V4L2_CTRL_CLASS_USER | 1)`。
+pub const CID_CLASS: u32 = CLASS_ID | 1;
+
+/// `V4L2_CID_BASE = (V4L2_CTRL_CLASS_USER | 0x900) = 0x00980900`。
+///
+/// 别名：`V4L2_CID_USER_BASE`。
+pub const CID_BASE: u32 = CLASS_ID | 0x900;
+
+/// `V4L2_CID_LASTP1 = (V4L2_CID_BASE + 44)` —— 最后一个用户类 CID + 1。
+pub const LASTP1: u32 = CID_BASE + 44;
+
+// ── 菜单枚举 ─────────────────────────────────────────────────
+
+/// `enum v4l2_power_line_frequency` —— `V4L2_CID_POWER_LINE_FREQUENCY` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PowerLineFrequency {
+    Disabled = 0,
+    Hz50     = 1,
+    Hz60     = 2,
+    Auto     = 3,
+}
+
+/// `enum v4l2_colorfx` —— `V4L2_CID_COLORFX` 菜单项。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Colorfx {
+    None         = 0,
+    Bw           = 1,
+    Sepia        = 2,
+    Negative     = 3,
+    Emboss       = 4,
+    Sketch       = 5,
+    SkyBlue      = 6,
+    GrassGreen   = 7,
+    SkinWhiten   = 8,
+    Vivid        = 9,
+    Aqua         = 10,
+    ArtFreeze    = 11,
+    Silhouette   = 12,
+    Solarization = 13,
+    Antique      = 14,
+    SetCbCr      = 15,
+    SetRgb       = 16,
+}
+
+// ── 用户类控制 ID ───────────────────────────────────────────────
+
+/// V4L2 用户类控制 ID（`V4L2_CID_BASE` + 偏移）。
+///
+/// 设计：`V4L2_CID_BRIGHTNESS = (V4L2_CTRL_CLASS_USER | 0x900) + 0`。
+///
+/// 使用 `as u32` 获取供 `CtrlHandler::find()` 使用的原始 CID。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserClassCtrl {
+    Brightness           = CID_BASE,
+    Contrast             = CID_BASE + 1,
+    Saturation           = CID_BASE + 2,
+    Hue                  = CID_BASE + 3,
+    AudioVolume          = CID_BASE + 5,
+    AudioBalance         = CID_BASE + 6,
+    AudioBass            = CID_BASE + 7,
+    AudioTreble          = CID_BASE + 8,
+    AudioMute            = CID_BASE + 9,
+    AudioLoudness        = CID_BASE + 10,
+    BlackLevel           = CID_BASE + 11,
+    AutoWhiteBalance     = CID_BASE + 12,
+    DoWhiteBalance       = CID_BASE + 13,
+    RedBalance           = CID_BASE + 14,
+    BlueBalance          = CID_BASE + 15,
+    Gamma                = CID_BASE + 16,
+    Exposure             = CID_BASE + 17,
+    Autogain             = CID_BASE + 18,
+    Gain                 = CID_BASE + 19,
+    Hflip                = CID_BASE + 20,
+    Vflip                = CID_BASE + 21,
+    PowerLineFrequency   = CID_BASE + 24,
+    HueAuto              = CID_BASE + 25,
+    WhiteBalanceTemperature = CID_BASE + 26,
+    Sharpness            = CID_BASE + 27,
+    BacklightCompensation = CID_BASE + 28,
+    ChromaAgc            = CID_BASE + 29,
+    ColorKiller          = CID_BASE + 30,
+    Colorfx              = CID_BASE + 31,
+    Autobrightness       = CID_BASE + 32,
+    BandStopFilter       = CID_BASE + 33,
+    Rotate               = CID_BASE + 34,
+    BgColor              = CID_BASE + 35,
+    ChromaGain           = CID_BASE + 36,
+    Illuminators1        = CID_BASE + 37,
+    Illuminators2        = CID_BASE + 38,
+    MinBuffersForCapture = CID_BASE + 39,
+    MinBuffersForOutput  = CID_BASE + 40,
+    AlphaComponent       = CID_BASE + 41,
+    ColorfxCbCr          = CID_BASE + 42,
+    ColorfxRgb           = CID_BASE + 43,
+}

--- a/drivers/media/ax-media/src/ctrls/define.rs
+++ b/drivers/media/ax-media/src/ctrls/define.rs
@@ -1,0 +1,254 @@
+use core::sync::atomic::AtomicI64;
+
+use crate::{
+    Result, V4l2Error,
+    ctrls::{Ctrl, CtrlConfig, CtrlHandler, CtrlOps, CtrlType},
+    interface::ctrl::{CID_PRIVATE_BASE, CtrlFlags},
+};
+
+impl CtrlHandler {
+    /// 有序插入。
+    fn insert_sorted(&mut self, ctrl: Ctrl) -> Result<()> {
+        let id = ctrl.id;
+        match self.ctrls.binary_search_by_key(&id, |c| c.id) {
+            Ok(_) => Err(V4l2Error::InvalidArgument),
+            Err(pos) => {
+                self.ctrls.insert(pos, ctrl);
+                Ok(())
+            }
+        }
+    }
+
+    /// 注册控件。
+    pub fn new_ctrl(&mut self, cfg: CtrlConfig) -> Result<()> {
+        if cfg.id == 0 || cfg.name.is_empty() || cfg.id >= CID_PRIVATE_BASE {
+            return Err(V4l2Error::OutOfRange);
+        }
+        if cfg.ctrl_type == CtrlType::Menu && cfg.qmenu.is_none() {
+            return Err(V4l2Error::OutOfRange);
+        }
+        cfg.ctrl_type
+            .check_range(cfg.minimum, cfg.maximum, cfg.step, cfg.default_value)?;
+        if cfg.ctrl_type == CtrlType::Menu
+            && let Some(qmenu) = cfg.qmenu
+            && cfg.maximum >= 0
+            && cfg.maximum as usize >= qmenu.len()
+        {
+            return Err(V4l2Error::OutOfRange);
+        }
+
+        // 设置类型相关标志。
+        let mut flags = cfg.flags;
+        if !matches!(cfg.ctrl_type, CtrlType::Button | CtrlType::CtrlClass) {
+            flags |= CtrlFlags::HAS_WHICH_MIN_MAX;
+        }
+        match cfg.ctrl_type {
+            CtrlType::Button => {
+                flags |= CtrlFlags::WRITE_ONLY | CtrlFlags::EXECUTE_ON_WRITE;
+            }
+            CtrlType::CtrlClass => flags |= CtrlFlags::READ_ONLY | CtrlFlags::WRITE_ONLY,
+            _ => {}
+        }
+
+        let ctrl = Ctrl {
+            id: cfg.id,
+            name: cfg.name,
+            ctrl_type: cfg.ctrl_type,
+            minimum: cfg.minimum,
+            maximum: cfg.maximum,
+            step: cfg.step,
+            default_value: cfg.default_value,
+            flags,
+            qmenu: cfg.qmenu,
+            ops: cfg.ops,
+            cur: AtomicI64::new(cfg.default_value),
+        };
+        self.insert_sorted(ctrl)
+    }
+
+    /// 注册整数控件。
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_int(
+        &mut self,
+        id: u32,
+        name: &'static str,
+        min: i64,
+        max: i64,
+        step: i64,
+        default: i64,
+        ops: Option<CtrlOps>,
+    ) -> Result<()> {
+        let flags = if ops.is_some() {
+            CtrlFlags::VOLATILE
+        } else {
+            CtrlFlags::empty()
+        };
+        self.new_ctrl(CtrlConfig {
+            id,
+            name,
+            ctrl_type: CtrlType::Integer,
+            minimum: min,
+            maximum: max,
+            step: step as u64,
+            default_value: default,
+            flags,
+            qmenu: None,
+            ops,
+        })
+    }
+
+    /// 注册布尔控件。
+    pub fn new_bool(
+        &mut self,
+        id: u32,
+        name: &'static str,
+        default: bool,
+        ops: Option<CtrlOps>,
+    ) -> Result<()> {
+        let flags = if ops.is_some() {
+            CtrlFlags::VOLATILE
+        } else {
+            CtrlFlags::empty()
+        };
+        self.new_ctrl(CtrlConfig {
+            id,
+            name,
+            ctrl_type: CtrlType::Boolean,
+            minimum: 0,
+            maximum: 1,
+            step: 1,
+            default_value: default as i64,
+            flags,
+            qmenu: None,
+            ops,
+        })
+    }
+
+    /// 注册菜单控件。
+    pub fn new_menu(
+        &mut self,
+        id: u32,
+        name: &'static str,
+        items: u32,
+        default: u32,
+        qmenu: &'static [&'static str],
+        ops: Option<CtrlOps>,
+    ) -> Result<()> {
+        let flags = if ops.is_some() {
+            CtrlFlags::VOLATILE
+        } else {
+            CtrlFlags::empty()
+        };
+        self.new_ctrl(CtrlConfig {
+            id,
+            name,
+            ctrl_type: CtrlType::Menu,
+            minimum: 0,
+            maximum: items as i64 - 1,
+            step: 0,
+            default_value: default as i64,
+            flags,
+            qmenu: Some(qmenu),
+            ops,
+        })
+    }
+
+    /// 注册按钮控件。
+    pub fn new_button(&mut self, id: u32, name: &'static str, ops: Option<CtrlOps>) -> Result<()> {
+        self.new_ctrl(CtrlConfig {
+            id,
+            name,
+            ctrl_type: CtrlType::Button,
+            minimum: 0,
+            maximum: 0,
+            step: 0,
+            default_value: 0,
+            flags: CtrlFlags::empty(),
+            qmenu: None,
+            ops,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+
+    use super::*;
+    use crate::{V4l2Error, ctrls::CtrlType, interface::ctrl::CtrlFlags};
+
+    const BRIGHTNESS: u32 = 0x0098_0900;
+
+    #[test]
+    fn new_ctrl_rejects_duplicate_id() {
+        let mut h = CtrlHandler::new();
+        h.new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 0, None)
+            .unwrap();
+        let err = h
+            .new_int(BRIGHTNESS, "Brightness2", 0, 255, 1, 0, None)
+            .unwrap_err();
+        assert!(matches!(err, V4l2Error::InvalidArgument));
+    }
+
+    #[test]
+    fn new_ctrl_validates_range_and_flags() {
+        let mut h = CtrlHandler::new();
+        // min > max
+        assert!(h.new_int(BRIGHTNESS, "Bad", 100, 0, 1, 0, None).is_err());
+        // Menu without qmenu
+        assert!(
+            h.new_ctrl(CtrlConfig {
+                id: BRIGHTNESS,
+                name: "NoMenu",
+                ctrl_type: CtrlType::Menu,
+                minimum: 0,
+                maximum: 1,
+                step: 0,
+                default_value: 0,
+                flags: CtrlFlags::empty(),
+                qmenu: None,
+                ops: None,
+            })
+            .is_err()
+        );
+        let menu = &["A", "B", "C"];
+        // default out of range / qmenu len < items
+        assert!(h.new_menu(0x0098_0901, "Bad", 3, 5, menu, None).is_err());
+        assert!(h.new_menu(0x0098_0902, "Bad2", 5, 0, menu, None).is_err());
+        h.new_menu(0x0098_0900, "Menu", 3, 2, menu, None).unwrap();
+        // VOLATILE auto-append for HW proxy
+        let mut hw = CtrlHandler::new();
+        let ops = crate::ctrls::CtrlOps {
+            get: Some(Box::new(|| Ok(0))),
+            try_ctrl: None,
+            set: Box::new(|v| Ok(v)),
+        };
+        hw.new_int(BRIGHTNESS, "HW", 0, 255, 1, 0, Some(ops))
+            .unwrap();
+        assert!(
+            hw.find(BRIGHTNESS)
+                .unwrap()
+                .flags
+                .contains(CtrlFlags::VOLATILE)
+        );
+        let mut sw = CtrlHandler::new();
+        sw.new_int(BRIGHTNESS, "SW", 0, 255, 1, 0, None).unwrap();
+        assert!(
+            !sw.find(BRIGHTNESS)
+                .unwrap()
+                .flags
+                .contains(CtrlFlags::VOLATILE)
+        );
+        // Button forces WRITE_ONLY|EXECUTE, no HAS_WHICH, 0 range ok
+        let mut hb = CtrlHandler::new();
+        hb.new_button(0x0098_0931, "Btn", None).unwrap();
+        let ctrl = hb.find(0x0098_0931).unwrap();
+        assert!(ctrl.flags.contains(CtrlFlags::WRITE_ONLY));
+        assert!(ctrl.flags.contains(CtrlFlags::EXECUTE_ON_WRITE));
+        assert!(!ctrl.flags.contains(CtrlFlags::HAS_WHICH_MIN_MAX));
+        assert_eq!(ctrl.ctrl_type, CtrlType::Button);
+        let mut h2 = CtrlHandler::new();
+        h2.new_button(0x0098_0931, "Btn", None).unwrap();
+        assert_eq!(h2.len(), 1);
+    }
+}

--- a/drivers/media/ax-media/src/ctrls/mod.rs
+++ b/drivers/media/ax-media/src/ctrls/mod.rs
@@ -1,0 +1,1296 @@
+//! V4L2 控件框架。
+
+pub mod class;
+mod define;
+
+use alloc::{boxed::Box, vec::Vec};
+use core::sync::atomic::{AtomicI64, Ordering};
+
+use crate::{
+    Result, V4l2Error,
+    filehandler::{CtrlEventParams, V4l2Fh, build_ctrl_event},
+    interface::{
+        ctrl::{
+            CID_PRIVATE_BASE, CTRL_ID_MASK, CTRL_MAX_DIMS, CTRL_WHICH_DEF_VAL, CTRL_WHICH_MAX_VAL,
+            CTRL_WHICH_MIN_VAL, CTRL_WHICH_REQUEST_VAL, Control, CtrlFlags, ExtControl,
+            ExtControls, QueryCtrl, QueryExtCtrl, Querymenu,
+        },
+        event::{CtrlChange, Event, EventSubFlags, EventSubscription, EventType},
+    },
+};
+
+const CTRL_NEXT_CTRL: u32 = 0x8000_0000;
+const CTRL_NEXT_COMPOUND: u32 = 0x4000_0000;
+
+// ── 控件类型 ─────────────────────────────────────────────────────────
+
+/// V4L2 控件类型
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CtrlType {
+    Integer   = 1,
+    Boolean   = 2,
+    Menu      = 3,
+    Button    = 4,
+    Integer64 = 5,
+    CtrlClass = 6,
+    Bitmask   = 8,
+}
+
+impl CtrlType {
+    /// 转换控件类型。
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            1 => Self::Integer,
+            2 => Self::Boolean,
+            3 => Self::Menu,
+            4 => Self::Button,
+            5 => Self::Integer64,
+            6 => Self::CtrlClass,
+            8 => Self::Bitmask,
+            _ => return None,
+        })
+    }
+
+    pub fn is_int(&self) -> bool {
+        *self != CtrlType::Integer64
+    }
+
+    pub fn size(&self) -> u32 {
+        if *self == CtrlType::Integer64 { 8 } else { 4 }
+    }
+
+    pub fn check_range(&self, min: i64, max: i64, step: u64, def: i64) -> Result<()> {
+        match self {
+            CtrlType::Boolean => {
+                if step != 1 || max > 1 || min < 0 {
+                    return Err(V4l2Error::OutOfRange);
+                }
+                if step == 0 || min > max || def < min || def > max {
+                    return Err(V4l2Error::OutOfRange);
+                }
+                Ok(())
+            }
+            CtrlType::Integer | CtrlType::Integer64 => {
+                if step == 0 || min > max || def < min || def > max {
+                    return Err(V4l2Error::OutOfRange);
+                }
+                Ok(())
+            }
+            CtrlType::Bitmask => {
+                if step != 0 || min != 0 || max == 0 || (def & !max) != 0 {
+                    return Err(V4l2Error::OutOfRange);
+                }
+                Ok(())
+            }
+            CtrlType::Menu => {
+                if min > max || def < min || def > max || min < 0 || (step != 0 && max >= 64) {
+                    return Err(V4l2Error::OutOfRange);
+                }
+                if def < 64 && (step & (1u64 << def)) != 0 {
+                    return Err(V4l2Error::InvalidArgument);
+                }
+                Ok(())
+            }
+            CtrlType::Button | CtrlType::CtrlClass => Ok(()),
+        }
+    }
+}
+
+// ── 控件回调 ─────────────────────
+
+pub type CtrlGetFn = Box<dyn Fn() -> Result<i64> + Send + Sync>;
+pub type CtrlTryFn = Box<dyn Fn(i64) -> Result<i64> + Send + Sync>;
+pub type CtrlSetFn = Box<dyn Fn(i64) -> Result<i64> + Send + Sync>;
+
+/// 控件硬件回调集合。
+pub struct CtrlOps {
+    pub get: Option<CtrlGetFn>,
+    pub try_ctrl: Option<CtrlTryFn>,
+    pub set: CtrlSetFn,
+}
+
+// ── 控件配置 ───────────────────
+
+/// 注册控件所需的完整配置。
+pub struct CtrlConfig {
+    pub id: u32,
+    pub name: &'static str,
+    pub ctrl_type: CtrlType,
+    pub minimum: i64,
+    pub maximum: i64,
+    pub step: u64,
+    pub default_value: i64,
+    pub flags: CtrlFlags,
+    pub qmenu: Option<&'static [&'static str]>,
+    pub ops: Option<CtrlOps>,
+}
+
+// ── 控件 ─────────────────────────────────────────────────────────────
+
+/// 已注册的控件，包含元数据与当前值。
+pub struct Ctrl {
+    pub id: u32,
+    pub name: &'static str,
+    pub ctrl_type: CtrlType,
+    pub minimum: i64,
+    pub maximum: i64,
+    pub step: u64,
+    pub default_value: i64,
+    pub flags: CtrlFlags,
+    pub qmenu: Option<&'static [&'static str]>,
+    pub(crate) ops: Option<CtrlOps>,
+    cur: AtomicI64,
+}
+
+impl Ctrl {
+    /// 当前值（无锁读取，供驱动填充 / 采样路径使用）。
+    pub fn value(&self) -> i64 {
+        self.cur.load(Ordering::Acquire)
+    }
+
+    fn set_value(&self, v: i64) {
+        self.cur.store(v, Ordering::Release);
+    }
+}
+
+/// 值变化通知回调：控件值在 `S_CTRL` / `S_EXT_CTRLS` 中改变时触发，
+/// 载荷为完整 `V4L2_EVENT_CTRL` 事件。驱动用它把事件推入共享事件队列。
+pub type CtrlChangeNotify = Box<dyn Fn(Event) + Send + Sync>;
+
+// ── 控件处理器 ─────────────────────────────────────────────────────
+
+/// 控件处理器。
+pub struct CtrlHandler {
+    pub(crate) ctrls: Vec<Ctrl>,
+    notify: Option<CtrlChangeNotify>,
+}
+
+impl CtrlHandler {
+    /// 创建空处理器。
+    pub fn new() -> Self {
+        Self {
+            ctrls: Vec::new(),
+            notify: None,
+        }
+    }
+
+    /// 设置值变化通知回调。
+    pub fn set_change_notify(&mut self, notify: CtrlChangeNotify) {
+        self.notify = Some(notify);
+    }
+
+    // ── 查找 ───────────────────────────────────────────────────────
+
+    /// 按 ID 查找控件。
+    pub fn find(&self, id: u32) -> Option<&Ctrl> {
+        let id = id & CTRL_ID_MASK;
+        self.ctrls
+            .binary_search_by_key(&id, |c| c.id)
+            .ok()
+            .map(|i| &self.ctrls[i])
+    }
+
+    /// 按 ID 读取当前值。
+    pub fn value(&self, id: u32) -> Option<i64> {
+        self.find(id).map(Ctrl::value)
+    }
+
+    /// 设置指定控件的 step 掩码（用于菜单跳过掩码等特殊初始化）。
+    pub fn set_step(&mut self, id: u32, step: u64) {
+        if let Some(ctrl) = self.ctrls.iter_mut().find(|c| c.id == (id & CTRL_ID_MASK)) {
+            ctrl.step = step;
+        }
+    }
+
+    /// 已注册控件的数量。
+    pub fn len(&self) -> usize {
+        self.ctrls.len()
+    }
+
+    /// 是否没有注册任何控件。
+    pub fn is_empty(&self) -> bool {
+        self.ctrls.is_empty()
+    }
+
+    /// 遍历所有控件的迭代器（按 id 升序；同时实现 `ExactSizeIterator` /
+    /// `DoubleEndedIterator`）。
+    pub fn iter(&self) -> core::slice::Iter<'_, Ctrl> {
+        self.ctrls.iter()
+    }
+
+    /// 枚举下一个控件。
+    fn next_ctrl(&self, id: u32, next_compound_only: bool, next_all: bool) -> Option<&Ctrl> {
+        let pos = self.ctrls.partition_point(|c| c.id <= id);
+        self.ctrls[pos..]
+            .iter()
+            .find(|_| next_ctrl_match(next_compound_only, next_all))
+    }
+
+    // ── 查询 IOCTL ────────────────────────────────────────────────
+
+    /// 填充事件载荷。
+    fn fill_event(&self, ctrl: &Ctrl, changes: CtrlChange) -> Option<Event> {
+        Some(build_ctrl_event(
+            CtrlEventParams {
+                id: ctrl.id,
+                ctrl_type: ctrl.ctrl_type as u32,
+                value: ctrl.value(),
+                flags: ctrl.flags.bits(),
+                minimum: ctrl.minimum,
+                maximum: ctrl.maximum,
+                step: ctrl.step as i64,
+                default_value: ctrl.default_value,
+            },
+            changes,
+        ))
+    }
+
+    /// 构建值变化事件。
+    pub fn change_event(&self, id: u32, changes: CtrlChange) -> Option<Event> {
+        let ctrl = self.find(id)?;
+        self.fill_event(ctrl, changes)
+    }
+
+    /// 触发值变化通知。
+    fn emit_change(&self, ctrl: &Ctrl, changes: CtrlChange) {
+        if let Some(notify) = &self.notify
+            && let Some(ev) = self.fill_event(ctrl, changes)
+        {
+            notify(ev);
+        }
+    }
+
+    // ── 内部辅助 ───────────────────────────────────────────────────
+
+    /// 校验单个扩展控件。
+    fn prepare_ext_ctrl(&self, which: u32, c: &ExtControl) -> Result<&Ctrl> {
+        let id = unsafe { core::ptr::addr_of!(c.id).read_unaligned() } & CTRL_ID_MASK;
+        let which_in_range = (CTRL_WHICH_DEF_VAL..=CTRL_WHICH_MAX_VAL).contains(&which);
+        if which != 0 && !which_in_range && id2which(id) != which {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        // 旧式私有控件不允许用于扩展控件。
+        if id >= CID_PRIVATE_BASE {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let ctrl = self.find(id).ok_or(V4l2Error::InvalidArgument)?;
+        if ctrl.flags.contains(CtrlFlags::DISABLED) {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        if !ctrl.flags.contains(CtrlFlags::HAS_WHICH_MIN_MAX)
+            && (which == CTRL_WHICH_MIN_VAL || which == CTRL_WHICH_MAX_VAL)
+        {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        Ok(ctrl)
+    }
+
+    /// 类检查。
+    fn class_check(&self, which: u32) -> Result<()> {
+        if which == 0 || (CTRL_WHICH_DEF_VAL..=CTRL_WHICH_MAX_VAL).contains(&which) {
+            return Ok(());
+        }
+        // 检查是否存在属于该类的控件。
+        let which_class = id2which(which);
+        if self.ctrls.iter().any(|c| id2which(c.id) == which_class) {
+            Ok(())
+        } else {
+            Err(V4l2Error::InvalidArgument)
+        }
+    }
+
+    /// 读取易变控件值。
+    fn read_volatile(&self, ctrl: &Ctrl) -> Result<i64> {
+        if let Some(ops) = &ctrl.ops
+            && let Some(get) = &ops.get
+        {
+            get()
+        } else {
+            Ok(ctrl.value())
+        }
+    }
+
+    /// 校验并取整。
+    fn validate_new(&self, ctrl: &Ctrl, v: i64) -> Result<i64> {
+        let validated = match ctrl.ctrl_type {
+            CtrlType::Integer | CtrlType::Integer64 => round_to_range(v, ctrl),
+            CtrlType::Boolean => {
+                if v != 0 {
+                    1
+                } else {
+                    0
+                }
+            }
+            CtrlType::Menu => {
+                if v < ctrl.minimum || v > ctrl.maximum {
+                    return Err(V4l2Error::OutOfRange);
+                }
+                if v < 64 && (ctrl.step & (1u64 << v)) != 0 {
+                    return Err(V4l2Error::InvalidArgument);
+                }
+                if let Some(qmenu) = ctrl.qmenu {
+                    let name = qmenu.get(v as usize).ok_or(V4l2Error::InvalidArgument)?;
+                    if name.is_empty() {
+                        return Err(V4l2Error::InvalidArgument);
+                    }
+                }
+                v
+            }
+            CtrlType::Bitmask => v & ctrl.maximum,
+            CtrlType::Button | CtrlType::CtrlClass => 0,
+        };
+        if let Some(ops) = &ctrl.ops
+            && let Some(try_fn) = &ops.try_ctrl
+        {
+            return try_fn(validated);
+        }
+        Ok(validated)
+    }
+
+    /// 应用值。
+    fn apply_value(&self, ctrl: &Ctrl, v: i64) -> Result<i64> {
+        let execute = ctrl.flags.contains(CtrlFlags::EXECUTE_ON_WRITE);
+        // VOLATILE 控件每次写入设备。
+        let always_write = execute || ctrl.flags.contains(CtrlFlags::VOLATILE);
+        let cur = ctrl.value();
+        if !always_write && cur == v {
+            return Ok(v);
+        }
+        // `set` 为硬件控件必填回调；内存控件（`ops == None`）直接写 `cur`。
+        let new = if let Some(ops) = &ctrl.ops {
+            (ops.set)(v)?
+        } else {
+            v
+        };
+        if new != cur || execute {
+            ctrl.set_value(new);
+            self.emit_change(ctrl, CtrlChange::VALUE);
+        }
+        Ok(new)
+    }
+}
+
+impl CtrlHandler {
+    pub fn query_ext_ctrl(&self, q: &mut QueryExtCtrl) -> Result<()> {
+        let next_flags = CTRL_NEXT_CTRL | CTRL_NEXT_COMPOUND;
+        let id = q.id & CTRL_ID_MASK;
+        let enum_next = (q.id & next_flags) != 0 && !self.ctrls.is_empty();
+        let next_compound_only = (q.id & next_flags) == CTRL_NEXT_COMPOUND;
+        let next_all = (q.id & next_flags) == next_flags;
+
+        let ctrl = if enum_next {
+            self.next_ctrl(id, next_compound_only, next_all)
+        } else {
+            self.find(id)
+        }
+        .ok_or(V4l2Error::InvalidArgument)?;
+
+        q.id = if id >= CID_PRIVATE_BASE { id } else { ctrl.id };
+        q.ty = ctrl.ctrl_type as u32;
+        let name = ctrl.name.as_bytes();
+        let len = name.len().min(q.name.len() - 1);
+        q.name[..len].copy_from_slice(&name[..len]);
+        q.name[len] = 0;
+        q.flags = ctrl.flags;
+        q.elem_size = ctrl.ctrl_type.size();
+        q.elems = 1;
+        q.nr_of_dims = 0;
+        q.dims = [0; CTRL_MAX_DIMS as usize];
+        q.minimum = ctrl.minimum;
+        q.maximum = ctrl.maximum;
+        q.default_value = ctrl.default_value;
+        q.step = if ctrl.ctrl_type == CtrlType::Menu {
+            1
+        } else {
+            ctrl.step
+        };
+        q.reserved = [0; 32];
+        Ok(())
+    }
+
+    pub fn queryctrl(&self, q: &mut QueryCtrl) -> Result<()> {
+        let mut qec = QueryExtCtrl {
+            id: q.id,
+            ty: 0,
+            name: [0; 32],
+            minimum: 0,
+            maximum: 0,
+            step: 0,
+            default_value: 0,
+            flags: CtrlFlags::empty(),
+            elem_size: 0,
+            elems: 0,
+            nr_of_dims: 0,
+            dims: [0; CTRL_MAX_DIMS as usize],
+            reserved: [0; 32],
+        };
+        self.query_ext_ctrl(&mut qec)?;
+
+        // v4l2_query_ext_ctrl_to_v4l2_queryctrl：仅标量兼容类型拷贝范围。
+        q.id = qec.id;
+        q.ty = qec.ty;
+        q.name = qec.name;
+        q.flags = qec.flags;
+        q.reserved = [0; 2];
+        match CtrlType::try_from_u32(qec.ty) {
+            Some(CtrlType::Integer | CtrlType::Boolean | CtrlType::Menu | CtrlType::Bitmask) => {
+                q.minimum = qec.minimum as i32;
+                q.maximum = qec.maximum as i32;
+                q.step = qec.step as i32;
+                q.default_value = qec.default_value as i32;
+            }
+            _ => {
+                q.minimum = 0;
+                q.maximum = 0;
+                q.step = 0;
+                q.default_value = 0;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn querymenu(&self, q: &mut Querymenu) -> Result<()> {
+        let ctrl = self.find(q.id).ok_or(V4l2Error::InvalidArgument)?;
+        if ctrl.ctrl_type != CtrlType::Menu {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let qmenu = ctrl.qmenu.ok_or(V4l2Error::InvalidArgument)?;
+        let i = q.index;
+        if i < ctrl.minimum as u32 || i > ctrl.maximum as u32 {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        // 跳过掩码。
+        if i < 64 && (ctrl.step & (1u64 << i)) != 0 {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let name = qmenu.get(i as usize).ok_or(V4l2Error::InvalidArgument)?;
+        if name.is_empty() {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let b = name.as_bytes();
+        let len = b.len().min(q.name.len() - 1);
+        q.name[..len].copy_from_slice(&b[..len]);
+        q.name[len] = 0;
+        q.reserved = 0;
+        Ok(())
+    }
+
+    pub fn g_ext_ctrls(&self, h: &mut ExtControls, cs: &mut [ExtControl]) -> Result<()> {
+        let is_default = h.which == CTRL_WHICH_DEF_VAL;
+        let is_request = h.which == CTRL_WHICH_REQUEST_VAL;
+        let is_min = h.which == CTRL_WHICH_MIN_VAL;
+        let is_max = h.which == CTRL_WHICH_MAX_VAL;
+
+        h.error_idx = h.count;
+        h.which = id2which(h.which);
+
+        if is_request {
+            return Err(V4l2Error::NotSupported);
+        }
+        if h.count == 0 {
+            return self.class_check(h.which);
+        }
+
+        // 准备阶段：逐项校验。
+        let mut refs = Vec::with_capacity(cs.len());
+        for (i, c) in cs.iter().enumerate() {
+            h.error_idx = i as u32;
+            let ctrl = match self.prepare_ext_ctrl(h.which, c) {
+                Ok(ctrl) => ctrl,
+                Err(e) => {
+                    h.error_idx = h.count;
+                    return Err(e);
+                }
+            };
+            refs.push(ctrl);
+        }
+        h.error_idx = h.count;
+
+        // WRITE_ONLY 控件不可读。
+        if refs.iter().any(|c| c.flags.contains(CtrlFlags::WRITE_ONLY)) {
+            return Err(V4l2Error::AccessDenied);
+        }
+
+        for (c, ctrl) in cs.iter_mut().zip(refs) {
+            let v = if is_default {
+                ctrl.default_value
+            } else if is_min {
+                ctrl.minimum
+            } else if is_max {
+                ctrl.maximum
+            } else if ctrl.flags.contains(CtrlFlags::VOLATILE) {
+                self.read_volatile(ctrl)?
+            } else {
+                ctrl.value()
+            };
+            write_ext_value(c, ctrl.ctrl_type, v);
+        }
+        h.error_idx = h.count;
+        Ok(())
+    }
+
+    pub fn try_ext_ctrls(&self, h: &mut ExtControls, cs: &mut [ExtControl]) -> Result<()> {
+        self.try_set_ext_ctrls(h, cs, false)
+    }
+
+    pub fn s_ext_ctrls(&self, h: &mut ExtControls, cs: &mut [ExtControl]) -> Result<()> {
+        self.try_set_ext_ctrls(h, cs, true)
+    }
+
+    fn try_set_ext_ctrls(
+        &self,
+        h: &mut ExtControls,
+        cs: &mut [ExtControl],
+        set: bool,
+    ) -> Result<()> {
+        h.error_idx = h.count;
+
+        // 默认 / 最小 / 最大值不可修改。
+        if matches!(
+            h.which,
+            CTRL_WHICH_DEF_VAL | CTRL_WHICH_MIN_VAL | CTRL_WHICH_MAX_VAL
+        ) {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        h.which = id2which(h.which);
+        if h.which == CTRL_WHICH_REQUEST_VAL {
+            return Err(V4l2Error::NotSupported);
+        }
+        if h.count == 0 {
+            return self.class_check(h.which);
+        }
+
+        // 准备 + 校验。
+        let mut resolved: Vec<(&Ctrl, i64)> = Vec::with_capacity(cs.len());
+        for (i, c) in cs.iter().enumerate() {
+            h.error_idx = i as u32;
+            let ctrl = match self.prepare_ext_ctrl(h.which, c) {
+                Ok(ctrl) => ctrl,
+                Err(e) => {
+                    if set {
+                        h.error_idx = h.count;
+                    }
+                    return Err(e);
+                }
+            };
+            if ctrl.flags.contains(CtrlFlags::READ_ONLY) {
+                if set {
+                    h.error_idx = h.count;
+                }
+                return Err(V4l2Error::AccessDenied);
+            }
+            if set && ctrl.flags.contains(CtrlFlags::GRABBED) {
+                h.error_idx = h.count;
+                return Err(V4l2Error::Busy);
+            }
+            let v = read_ext_value(c, ctrl.ctrl_type);
+            let target = match self.validate_new(ctrl, v) {
+                Ok(t) => t,
+                Err(e) => {
+                    if set {
+                        h.error_idx = h.count;
+                    }
+                    return Err(e);
+                }
+            };
+            resolved.push((ctrl, target));
+        }
+
+        // 回写校验后的值。
+        for (c, &(ctrl, target)) in cs.iter_mut().zip(&resolved) {
+            write_ext_value(c, ctrl.ctrl_type, target);
+        }
+
+        // 应用阶段（仅 S）：调用 try/s_ctrl 回调并更新当前值。
+        if set {
+            for (c, &(ctrl, target)) in cs.iter_mut().zip(&resolved) {
+                let new = self.apply_value(ctrl, target)?;
+                write_ext_value(c, ctrl.ctrl_type, new);
+            }
+        }
+
+        h.error_idx = h.count;
+        Ok(())
+    }
+
+    // ── 兼容 G/S_CTRL ─────────
+
+    pub fn g_ctrl(&self, c: &mut Control) -> Result<()> {
+        let ctrl = self.find(c.id).ok_or(V4l2Error::InvalidArgument)?;
+        if !ctrl.ctrl_type.is_int() {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        if ctrl.flags.contains(CtrlFlags::WRITE_ONLY) {
+            return Err(V4l2Error::AccessDenied);
+        }
+        let v = if ctrl.flags.contains(CtrlFlags::VOLATILE) {
+            self.read_volatile(ctrl)?
+        } else {
+            ctrl.value()
+        };
+        c.value = v as i32;
+        Ok(())
+    }
+
+    pub fn s_ctrl(&self, c: &mut Control) -> Result<()> {
+        let ctrl = self.find(c.id).ok_or(V4l2Error::InvalidArgument)?;
+        if !ctrl.ctrl_type.is_int() {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        if ctrl.flags.contains(CtrlFlags::READ_ONLY) {
+            return Err(V4l2Error::AccessDenied);
+        }
+        let target = self.validate_new(ctrl, c.value as i64)?;
+        let new = self.apply_value(ctrl, target)?;
+        c.value = new as i32;
+        Ok(())
+    }
+
+    pub fn subscribe_event(&self, fh: &mut V4l2Fh, sub: &EventSubscription) -> Result<()> {
+        if sub.ty != EventType::Ctrl {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let ctrl = self.find(sub.id).ok_or(V4l2Error::InvalidArgument)?;
+        // 已订阅：幂等返回，不重复发送初始事件。
+        if fh.is_subscribed(sub.ty, sub.id) {
+            return Ok(());
+        }
+        fh.subscribe(sub)?;
+        if sub.flags.contains(EventSubFlags::SEND_INITIAL) {
+            // 控制类（CtrlClass）不产生初始事件，对齐 v4l2-compliance 对 User Controls 的期望
+            if ctrl.ctrl_type == CtrlType::CtrlClass {
+                return Ok(());
+            }
+            let changes = if ctrl.flags.contains(CtrlFlags::WRITE_ONLY) {
+                CtrlChange::FLAGS
+            } else {
+                CtrlChange::VALUE | CtrlChange::FLAGS
+            };
+            if let Some(ev) = self.fill_event(ctrl, changes) {
+                fh.queue_event(ev);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Default for CtrlHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 通过引用迭代全部控件（`for c in &handler`），按 id 升序。
+///
+/// 迭代器为 `slice::Iter`（实现 `ExactSizeIterator` / `DoubleEndedIterator`）。
+/// 控件元数据只读，故不提供 `&mut Ctrl` 迭代。
+impl<'a> IntoIterator for &'a CtrlHandler {
+    type Item = &'a Ctrl;
+    type IntoIter = core::slice::Iter<'a, Ctrl>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.ctrls.iter()
+    }
+}
+
+// ── 模块级辅助 ─────────────────────────────────────────────────────
+
+/// 控件 ID 转类。
+fn id2which(id: u32) -> u32 {
+    id & 0x0fff_0000
+}
+
+/// NEXT_CTRL 过滤。
+fn next_ctrl_match(next_compound_only: bool, next_all: bool) -> bool {
+    next_all || !next_compound_only
+}
+
+/// 读取控件值。
+fn read_ext_value(c: &ExtControl, ty: CtrlType) -> i64 {
+    if ty == CtrlType::Integer64 {
+        unsafe { core::ptr::addr_of!(c.value.value64).read_unaligned() }
+    } else {
+        unsafe { core::ptr::addr_of!(c.value.value).read_unaligned() as i64 }
+    }
+}
+
+/// 写回控件值。
+fn write_ext_value(c: &mut ExtControl, ty: CtrlType, v: i64) {
+    if ty == CtrlType::Integer64 {
+        unsafe { core::ptr::addr_of_mut!(c.value.value64).write_unaligned(v) }
+    } else {
+        unsafe { core::ptr::addr_of_mut!(c.value.value).write_unaligned(v as i32) }
+    }
+}
+
+/// 整数取整。
+fn round_to_range(v: i64, ctrl: &Ctrl) -> i64 {
+    let step = ctrl.step as i64;
+    let half = step / 2;
+    let v = if ctrl.maximum >= 0 && v >= ctrl.maximum - half {
+        ctrl.maximum
+    } else {
+        v + half
+    };
+    let v = v.clamp(ctrl.minimum, ctrl.maximum);
+    let offset = v - ctrl.minimum;
+    let offset = step * (offset / step);
+    ctrl.minimum + offset
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::boxed::Box;
+    use core::sync::atomic::{AtomicI64, Ordering};
+
+    use super::*;
+    use crate::{
+        ctrls::{CtrlConfig, CtrlOps},
+        interface::{
+            ctrl::{ExtControlValue, QueryCtrl},
+            event::{EventCtrlPayload, EventSubFlags},
+        },
+    };
+
+    const NEXT_CTRL: u32 = CTRL_NEXT_CTRL;
+    const BRIGHTNESS: u32 = 0x0098_0900;
+    const CONTRAST: u32 = 0x0098_0901;
+    const TEST_PATTERN: u32 = 0x0098_0930;
+
+    const TEST_PATTERN_MENU: &[&str] = &[
+        "75% Colorbar",
+        "100% Colorbar",
+        "CSC Colorbar",
+        "Black",
+        "White",
+    ];
+
+    fn register_uvc_like(handler: &mut CtrlHandler) {
+        // 乱序注册（对齐 UVC_CONTROL_DEFS 顺序：非 id 升序）。
+        handler
+            .new_int(0x0098_091C, "Backlight", 0, 255, 1, 0, None)
+            .unwrap();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 0, None)
+            .unwrap();
+        handler
+            .new_int(CONTRAST, "Contrast", 0, 255, 1, 0, None)
+            .unwrap();
+        handler
+            .new_int(0x009A_0901, "ExposureAuto", 0, 4, 1, 0, None)
+            .unwrap();
+        handler
+            .new_int(0x009A_0902, "ExposureAbs", 0, 10_000, 1, 0, None)
+            .unwrap();
+    }
+
+    fn zero_query_ctrl() -> QueryCtrl {
+        QueryCtrl {
+            id: 0,
+            ty: 0,
+            name: [0; 32],
+            minimum: 0,
+            maximum: 0,
+            step: 0,
+            default_value: 0,
+            flags: CtrlFlags::empty(),
+            reserved: [0; 2],
+        }
+    }
+
+    fn ext_ctrl(id: u32, value: i32) -> ExtControl {
+        ExtControl {
+            id,
+            size: 0,
+            reserved2: [0; 1],
+            value: ExtControlValue { value },
+        }
+    }
+
+    fn ext_ctrl_i64(id: u32, value: i64) -> ExtControl {
+        ExtControl {
+            id,
+            size: 0,
+            reserved2: [0; 1],
+            value: ExtControlValue { value64: value },
+        }
+    }
+
+    fn ext_header(count: u32, which: u32) -> ExtControls {
+        ExtControls {
+            which,
+            count,
+            error_idx: 0,
+            request_fd: 0,
+            reserved: [0; 1],
+            controls: 0,
+        }
+    }
+
+    fn read_value(c: &ExtControl) -> i32 {
+        // SAFETY: 测试中构造的控件均为非 Integer64 标量，读取 value 成员。
+        unsafe { c.value.value }
+    }
+
+    /// NEXT_CTRL 枚举必须严格递增、返回 id 不得携带 NEXT 标志、
+    /// 枚举完必须 EINVAL 终止。
+    #[test]
+    fn next_ctrl_enumeration_is_strictly_increasing_and_terminates() {
+        let mut handler = CtrlHandler::new();
+        register_uvc_like(&mut handler);
+
+        let mut q = QueryExtCtrl {
+            id: NEXT_CTRL,
+            ty: 0,
+            name: [0; 32],
+            minimum: 0,
+            maximum: 0,
+            step: 0,
+            default_value: 0,
+            flags: CtrlFlags::empty(),
+            elem_size: 0,
+            elems: 0,
+            nr_of_dims: 0,
+            dims: [0; 4],
+            reserved: [0; 32],
+        };
+        let mut last_id = 0u32;
+        let mut count = 0u32;
+        loop {
+            match handler.query_ext_ctrl(&mut q) {
+                Ok(()) => {
+                    assert_eq!(q.id & NEXT_CTRL, 0, "returned id carries NEXT flag");
+                    assert!(q.id > last_id, "id not strictly increasing");
+                    last_id = q.id;
+                    count += 1;
+                    q.id = last_id | NEXT_CTRL;
+                    assert!(count <= 16, "enumeration did not terminate");
+                }
+                Err(V4l2Error::InvalidArgument) => break,
+                Err(e) => panic!("unexpected error: {e:?}"),
+            }
+        }
+        assert_eq!(
+            count, 5,
+            "should enumerate exactly the 5 registered controls"
+        );
+    }
+
+    /// QUERYCTRL 由 QUERY_EXT_CTRL 换算：id/name/flags 与范围字段正确。
+    #[test]
+    fn queryctrl_derives_from_query_ext_ctrl() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 128, None)
+            .unwrap();
+
+        let mut q = zero_query_ctrl();
+        q.id = BRIGHTNESS;
+        handler.queryctrl(&mut q).unwrap();
+        assert_eq!(q.id, BRIGHTNESS);
+        assert_eq!(q.ty, CtrlType::Integer as u32);
+        assert_eq!(&q.name[..10], b"Brightness");
+        assert_eq!(q.minimum, 0);
+        assert_eq!(q.maximum, 255);
+        assert_eq!(q.step, 1);
+        assert_eq!(q.default_value, 128);
+        assert!(q.flags.contains(CtrlFlags::HAS_WHICH_MIN_MAX));
+    }
+
+    /// QUERYMENU：越界索引 / 非菜单控件返回 EINVAL，合法项返回名称。
+    #[test]
+    fn querymenu_resolves_menu_items() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_menu(TEST_PATTERN, "Test Pattern", 5, 0, TEST_PATTERN_MENU, None)
+            .unwrap();
+
+        let mut q = Querymenu {
+            id: TEST_PATTERN,
+            index: 0,
+            name: [0; 32],
+            reserved: 0,
+        };
+        handler.querymenu(&mut q).unwrap();
+        assert_eq!(&q.name[..12], b"75% Colorbar");
+
+        q.index = 3;
+        handler.querymenu(&mut q).unwrap();
+        assert_eq!(&q.name[..5], b"Black");
+
+        q.index = 99;
+        assert!(matches!(
+            handler.querymenu(&mut q),
+            Err(V4l2Error::InvalidArgument)
+        ));
+    }
+
+    /// G_EXT_CTRLS 读取与 error_idx。
+    #[test]
+    fn g_ext_ctrls_reads_values_and_sets_error_idx() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 128, None)
+            .unwrap();
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 0)];
+        let mut h = ext_header(1, 0);
+        handler.g_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(read_value(&cs[0]), 128);
+        assert_eq!(h.error_idx, 1, "success -> error_idx == count");
+
+        let mut cs = [ext_ctrl(0xDEAD_BEEF, 0)];
+        let mut h = ext_header(1, 0);
+        assert!(matches!(
+            handler.g_ext_ctrls(&mut h, &mut cs),
+            Err(V4l2Error::InvalidArgument)
+        ));
+        assert_eq!(
+            h.error_idx, 1,
+            "g_ext_ctrls validation failure -> error_idx == count"
+        );
+
+        // TRY/S 对相同非法 ID 的区分：TRY 留失败索引，S 置 count
+        let mut cs = [ext_ctrl(0xDEAD_BEEF, 0)];
+        let mut h = ext_header(1, 0);
+        assert!(matches!(
+            handler.try_ext_ctrls(&mut h, &mut cs),
+            Err(V4l2Error::InvalidArgument)
+        ));
+        assert_eq!(
+            h.error_idx, 0,
+            "try_ext_ctrls validation failure -> failing index"
+        );
+        let mut cs = [ext_ctrl(0xDEAD_BEEF, 0)];
+        let mut h = ext_header(1, 0);
+        assert!(matches!(
+            handler.s_ext_ctrls(&mut h, &mut cs),
+            Err(V4l2Error::InvalidArgument)
+        ));
+        assert_eq!(h.error_idx, 1, "s_ext_ctrls validation failure -> count");
+    }
+
+    #[test]
+    fn ext_ctrls_rejects_write_only_and_read_only() {
+        let mut h1 = CtrlHandler::new();
+        h1.new_ctrl(CtrlConfig {
+            id: 0x0098_0931,
+            name: "Action",
+            ctrl_type: CtrlType::Button,
+            minimum: 0,
+            maximum: 0,
+            step: 0,
+            default_value: 0,
+            flags: CtrlFlags::empty(),
+            qmenu: None,
+            ops: None,
+        })
+        .unwrap();
+        let mut cs = [ext_ctrl(0x0098_0931, 0)];
+        let mut hdr = ext_header(1, 0);
+        assert!(matches!(
+            h1.g_ext_ctrls(&mut hdr, &mut cs),
+            Err(V4l2Error::AccessDenied)
+        ));
+
+        let mut h2 = CtrlHandler::new();
+        h2.new_ctrl(CtrlConfig {
+            id: BRIGHTNESS,
+            name: "Readonly",
+            ctrl_type: CtrlType::Integer,
+            minimum: 0,
+            maximum: 255,
+            step: 1,
+            default_value: 0,
+            flags: CtrlFlags::READ_ONLY,
+            qmenu: None,
+            ops: None,
+        })
+        .unwrap();
+        let mut cs = [ext_ctrl(BRIGHTNESS, 10)];
+        let mut hdr = ext_header(1, 0);
+        assert!(matches!(
+            h2.s_ext_ctrls(&mut hdr, &mut cs),
+            Err(V4l2Error::AccessDenied)
+        ));
+    }
+
+    /// G/TRY/S_EXT_CTRLS mixed-class 校验：G/S 要求 error_idx == count，TRY 要求 < count
+    /// （对齐 v4l2-compliance 1073 / v4l2-test-controls.cpp mixed-class 分支）。
+    #[test]
+    fn ext_ctrls_mixed_class_error_idx() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 128, None)
+            .unwrap(); // class 0x00980000
+        handler
+            .new_int(0x009A_0901, "ExposureAuto", 0, 3, 1, 0, None)
+            .unwrap(); // class 0x009a0000
+        let which = 0x0098_0000;
+        let mut cs = [ext_ctrl(BRIGHTNESS, 0), ext_ctrl(0x009A_0901, 0)];
+
+        let mut h = ext_header(2, which);
+        assert!(matches!(
+            handler.g_ext_ctrls(&mut h, &mut cs),
+            Err(V4l2Error::InvalidArgument)
+        ));
+        assert_eq!(h.error_idx, 2, "G mixed-class -> count");
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 0), ext_ctrl(0x009A_0901, 0)];
+        let mut h = ext_header(2, which);
+        assert!(matches!(
+            handler.try_ext_ctrls(&mut h, &mut cs),
+            Err(V4l2Error::InvalidArgument)
+        ));
+        assert_eq!(h.error_idx, 1, "TRY mixed-class -> failing index");
+        assert!(h.error_idx < h.count);
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 0), ext_ctrl(0x009A_0901, 0)];
+        let mut h = ext_header(2, which);
+        assert!(matches!(
+            handler.s_ext_ctrls(&mut h, &mut cs),
+            Err(V4l2Error::InvalidArgument)
+        ));
+        assert_eq!(h.error_idx, 2, "S mixed-class -> count");
+    }
+
+    /// S_EXT_CTRLS：整数按步长取整；越界 clamp 到 [min, max]。
+    #[test]
+    fn s_ext_ctrls_rounds_to_step() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 100, 10, 0, None)
+            .unwrap();
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 55)];
+        let mut h = ext_header(1, 0);
+        handler.s_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(read_value(&cs[0]), 60);
+        assert_eq!(handler.value(BRIGHTNESS), Some(60));
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 1000)];
+        let mut h = ext_header(1, 0);
+        handler.s_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(read_value(&cs[0]), 100);
+    }
+
+    /// S_EXT_CTRLS：菜单越界返回 EINVAL 且不改变任何控件。
+    #[test]
+    fn s_ext_ctrls_rejects_bad_menu_value() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 128, None)
+            .unwrap();
+        handler
+            .new_menu(TEST_PATTERN, "Test Pattern", 5, 0, TEST_PATTERN_MENU, None)
+            .unwrap();
+
+        let mut cs = [ext_ctrl(TEST_PATTERN, 99)];
+        let mut h = ext_header(1, 0);
+        assert!(matches!(
+            handler.s_ext_ctrls(&mut h, &mut cs),
+            Err(V4l2Error::OutOfRange)
+        ));
+        assert_eq!(handler.value(TEST_PATTERN), Some(0));
+    }
+
+    /// TRY_EXT_CTRLS：回写校验后的值，但不应用（不改变当前值）。
+    #[test]
+    fn try_ext_ctrls_validates_without_applying() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 100, 10, 0, None)
+            .unwrap();
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 55)];
+        let mut h = ext_header(1, 0);
+        handler.try_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(read_value(&cs[0]), 60, "try 回写校验后的值");
+        assert_eq!(handler.value(BRIGHTNESS), Some(0), "try 不应用");
+    }
+
+    /// S_EXT_CTRLS：值变化触发 change notify 回调（事件载荷）。
+    #[test]
+    fn s_ext_ctrls_fires_notify_on_change() {
+        use alloc::sync::Arc;
+        use core::sync::atomic::{AtomicU32, AtomicUsize};
+
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 128, None)
+            .unwrap();
+
+        let count = Arc::new(AtomicUsize::new(0));
+        let last_id = Arc::new(AtomicU32::new(0));
+        let cnt = Arc::clone(&count);
+        let id = Arc::clone(&last_id);
+        handler.set_change_notify(Box::new(move |ev| {
+            cnt.fetch_add(1, Ordering::Relaxed);
+            id.store(ev.id, Ordering::Relaxed);
+        }));
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 200)];
+        let mut h = ext_header(1, 0);
+        handler.s_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(count.load(Ordering::Relaxed), 1);
+        assert_eq!(last_id.load(Ordering::Relaxed), BRIGHTNESS);
+
+        // 未变化：不触发。
+        let mut cs = [ext_ctrl(BRIGHTNESS, 200)];
+        let mut h = ext_header(1, 0);
+        handler.s_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(count.load(Ordering::Relaxed), 1);
+    }
+
+    /// INTEGER64 控件走 value64。
+    #[test]
+    fn integer64_uses_value64() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_ctrl(CtrlConfig {
+                id: 0x0098_0903,
+                name: "Tstamp",
+                ctrl_type: CtrlType::Integer64,
+                minimum: 0,
+                maximum: 1_000_000,
+                step: 1,
+                default_value: 42,
+                flags: CtrlFlags::empty(),
+                qmenu: None,
+                ops: None,
+            })
+            .unwrap();
+
+        let mut cs = [ext_ctrl_i64(0x0098_0903, 0)];
+        let mut h = ext_header(1, 0);
+        handler.g_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(unsafe { cs[0].value.value64 }, 42);
+
+        let mut cs = [ext_ctrl_i64(0x0098_0903, 500)];
+        let mut h = ext_header(1, 0);
+        handler.s_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(handler.value(0x0098_0903), Some(500));
+    }
+
+    // ── 控件事件 ────────────────────────────────────────────────────
+
+    fn ctrl_sub(id: u32, flags: EventSubFlags) -> EventSubscription {
+        EventSubscription {
+            ty: EventType::Ctrl,
+            id,
+            flags,
+            reserved: [0; 5],
+        }
+    }
+
+    fn read_ctrl(ev: &Event) -> EventCtrlPayload {
+        let mut payload = [0u8; core::mem::size_of::<EventCtrlPayload>()];
+        payload.copy_from_slice(&ev.data[..core::mem::size_of::<EventCtrlPayload>()]);
+        // SAFETY: EventCtrlPayload 是 repr(C) POD，长度等于 size_of。
+        unsafe { core::ptr::read_unaligned(payload.as_ptr() as *const EventCtrlPayload) }
+    }
+
+    /// SEND_INITIAL：订阅后立即投递初始事件。
+    #[test]
+    fn subscribe_with_send_initial_queues_initial_event() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 128, None)
+            .unwrap();
+        let mut fh = V4l2Fh::new();
+
+        handler
+            .subscribe_event(&mut fh, &ctrl_sub(BRIGHTNESS, EventSubFlags::SEND_INITIAL))
+            .unwrap();
+        assert_eq!(fh.pending(), 1, "SEND_INITIAL queues one initial event");
+
+        let out = fh.dequeue().unwrap();
+        assert_eq!(out.ty, EventType::Ctrl as u32);
+        assert_eq!(out.id, BRIGHTNESS);
+        assert_eq!(out.reserved, [0; 8], "reserved must be zeroed");
+        let payload = read_ctrl(&out);
+        assert_eq!(
+            payload.changes,
+            (CtrlChange::VALUE | CtrlChange::FLAGS).bits(),
+            "initial event changes = VALUE|FLAGS"
+        );
+        assert_eq!(payload.value, 128, "initial event carries current value");
+    }
+
+    /// 订阅不存在的控件 ID 或非 CTRL 类型必须 EINVAL。
+    #[test]
+    fn subscribe_rejects_unknown_ctrl_and_non_ctrl_type() {
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_int(BRIGHTNESS, "Brightness", 0, 255, 1, 128, None)
+            .unwrap();
+        let mut fh = V4l2Fh::new();
+
+        assert!(matches!(
+            handler.subscribe_event(&mut fh, &ctrl_sub(0xDEAD_BEEF, EventSubFlags::empty())),
+            Err(V4l2Error::InvalidArgument)
+        ));
+        assert!(matches!(
+            handler.subscribe_event(
+                &mut fh,
+                &EventSubscription {
+                    ty: EventType::Eos,
+                    id: BRIGHTNESS,
+                    flags: EventSubFlags::empty(),
+                    reserved: [0; 5],
+                }
+            ),
+            Err(V4l2Error::InvalidArgument)
+        ));
+        assert_eq!(fh.pending(), 0);
+    }
+
+    #[test]
+    fn hardware_proxy_ctrl_uses_ops() {
+        use alloc::sync::Arc;
+        use core::sync::atomic::AtomicUsize;
+
+        let device_val = Arc::new(AtomicI64::new(5));
+        let set_calls = Arc::new(AtomicUsize::new(0));
+
+        let get_dev = Arc::clone(&device_val);
+        let set_dev = Arc::clone(&device_val);
+        let set_cnt = Arc::clone(&set_calls);
+        let ops = CtrlOps {
+            get: Some(Box::new(move || Ok(get_dev.load(Ordering::Relaxed)))),
+            try_ctrl: None,
+            set: Box::new(move |v| {
+                set_cnt.fetch_add(1, Ordering::Relaxed);
+                set_dev.store(v.clamp(0, 255), Ordering::Relaxed);
+                Ok(set_dev.load(Ordering::Relaxed))
+            }),
+        };
+        let mut handler = CtrlHandler::new();
+        handler
+            .new_ctrl(CtrlConfig {
+                id: BRIGHTNESS,
+                name: "Brightness",
+                ctrl_type: CtrlType::Integer,
+                minimum: 0,
+                maximum: 255,
+                step: 1,
+                default_value: 0,
+                flags: CtrlFlags::VOLATILE,
+                qmenu: None,
+                ops: Some(ops),
+            })
+            .unwrap();
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 200)];
+        let mut h = ext_header(1, 0);
+        handler.s_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(read_value(&cs[0]), 200);
+        assert_eq!(set_calls.load(Ordering::Relaxed), 1);
+
+        let mut cs = [ext_ctrl(BRIGHTNESS, 0)];
+        let mut h = ext_header(1, 0);
+        handler.g_ext_ctrls(&mut h, &mut cs).unwrap();
+        assert_eq!(read_value(&cs[0]), 200, "VOLATILE 控件 G 读取设备值");
+    }
+}

--- a/drivers/media/ax-media/src/device.rs
+++ b/drivers/media/ax-media/src/device.rs
@@ -1,0 +1,273 @@
+//! V4L2 设备抽象。
+
+use alloc::{sync::Arc, vec::Vec};
+use core::{
+    future::poll_fn,
+    sync::atomic::{AtomicU32, Ordering},
+    task::Poll,
+};
+
+use ax_sync::Mutex;
+use axpoll::{IoEvents, PollSet};
+
+use crate::{
+    Result, V4l2Error,
+    ctrls::CtrlHandler,
+    driver::V4L2DriverOps,
+    filehandler::{QueueOutcome, V4l2Fh},
+    interface::{
+        ctrl::{ExtControl, ExtControls},
+        event::{Event, EventSubscription},
+    },
+    ioctl::{IoctlCmd, IoctlDispatcher, VideoIoctl},
+};
+
+/// V4L2 视频设备。
+pub struct VideoDevice {
+    driver: Arc<Mutex<dyn V4L2DriverOps>>,
+    dispatcher: Mutex<IoctlDispatcher>,
+    name: &'static str,
+    fh: Mutex<Option<V4l2Fh>>,
+    open_count: AtomicU32,
+    event_poll_rx: Arc<PollSet>,
+}
+
+impl VideoDevice {
+    /// 创建设备。
+    pub fn new(driver: Arc<Mutex<dyn V4L2DriverOps>>, name: &'static str) -> Self {
+        Self {
+            driver,
+            dispatcher: Mutex::new(IoctlDispatcher::new()),
+            name,
+            fh: Mutex::new(None),
+            open_count: AtomicU32::new(0),
+            event_poll_rx: Arc::new(PollSet::new()),
+        }
+    }
+
+    /// 获取设备名。
+    pub fn name(&self) -> &str {
+        self.name
+    }
+
+    /// 处理 ioctl。
+    pub fn handle_ioctl(&self, cmd: VideoIoctl, arg: &mut [u8]) -> Result<()> {
+        if let VideoIoctl::Modern(c) = cmd {
+            match c {
+                IoctlCmd::SubscribeEvent => {
+                    let sub: EventSubscription = unsafe { crate::ioctl::read_from_bytes(arg) };
+                    let mut driver = self.driver.lock();
+                    let mut fh_guard = self.fh.lock();
+                    let fh = fh_guard.as_mut().ok_or(V4l2Error::BadFileDescriptor)?;
+                    driver.subscribe_event(fh, &sub)?;
+                    if fh.pending() > 0 {
+                        self.event_poll_rx.wake_from_irq(IoEvents::PRI);
+                    }
+                    return Ok(());
+                }
+                IoctlCmd::UnsubscribeEvent => {
+                    let sub: EventSubscription = unsafe { crate::ioctl::read_from_bytes(arg) };
+                    let mut driver = self.driver.lock();
+                    let mut fh_guard = self.fh.lock();
+                    let fh = fh_guard.as_mut().ok_or(V4l2Error::BadFileDescriptor)?;
+                    driver.unsubscribe_event(fh, &sub)?;
+                    return Ok(());
+                }
+                IoctlCmd::DQEvent => {
+                    let mut ev: Event = unsafe { crate::ioctl::read_from_bytes(arg) };
+                    let mut driver = self.driver.lock();
+                    let mut fh_guard = self.fh.lock();
+                    let fh = fh_guard.as_mut().ok_or(V4l2Error::BadFileDescriptor)?;
+                    driver.dqevent(fh, &mut ev)?;
+                    unsafe { crate::ioctl::write_to_bytes(arg, &ev) };
+                    return Ok(());
+                }
+                IoctlCmd::GPriority => {
+                    let fh_guard = self.fh.lock();
+                    let fh = fh_guard.as_ref().ok_or(V4l2Error::BadFileDescriptor)?;
+                    let p = fh.prio();
+                    unsafe { crate::ioctl::write_to_bytes(arg, &p) };
+                    return Ok(());
+                }
+                IoctlCmd::SPriority => {
+                    let p: u32 = unsafe { crate::ioctl::read_from_bytes(arg) };
+                    if p > 3 {
+                        return Err(crate::V4l2Error::InvalidArgument);
+                    }
+                    let mut fh_guard = self.fh.lock();
+                    let fh = fh_guard.as_mut().ok_or(V4l2Error::BadFileDescriptor)?;
+                    fh.set_prio(p);
+                    return Ok(());
+                }
+                IoctlCmd::DQBuf => {
+                    return self.handle_dqbuf_blocking(cmd, arg);
+                }
+                _ => {}
+            }
+        }
+        let mut driver = self.driver.lock();
+        let dispatcher = self.dispatcher.lock();
+        dispatcher.dispatch(&mut *driver, cmd, arg)
+    }
+
+    /// DQBuf 阻塞等待。
+    fn handle_dqbuf_blocking(&self, cmd: VideoIoctl, arg: &mut [u8]) -> Result<()> {
+        loop {
+            let result = {
+                let mut driver = self.driver.lock();
+                let dispatcher = self.dispatcher.lock();
+                dispatcher.dispatch(&mut *driver, cmd, arg)
+            };
+            match result {
+                Ok(()) => return Ok(()),
+                Err(e) if e == V4l2Error::WouldBlock || e == V4l2Error::Busy => {
+                    let poll_rx = match self.vb_poll_set() {
+                        Some(rx) => rx,
+                        None => return Err(e),
+                    };
+                    let wait = poll_fn(|cx| {
+                        if self.is_readable() || self.is_error() || !self.is_streaming() {
+                            return Poll::Ready(());
+                        }
+                        // SAFETY: ioctl 任务上下文；register 不持 VideoDevice 锁。
+                        unsafe { poll_rx.register(cx.waker(), IoEvents::IN | IoEvents::ERR) };
+                        if self.is_readable() || self.is_error() || !self.is_streaming() {
+                            Poll::Ready(())
+                        } else {
+                            Poll::Pending
+                        }
+                    });
+                    ax_task::future::block_on(wait);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// 禁用指定 ioctl。
+    pub fn disable_ioctl(&self, cmd: u32) {
+        self.dispatcher.lock().disable_cmd(cmd);
+    }
+
+    /// mmap 查询。
+    pub fn mmap(&self, offset: u64, length: u64) -> Option<(Vec<usize>, usize)> {
+        self.driver.lock().mmap(offset, length)
+    }
+
+    /// 是否可读。
+    pub fn is_readable(&self) -> bool {
+        self.driver.lock().is_readable()
+    }
+
+    /// 是否错误。
+    pub fn is_error(&self) -> bool {
+        self.driver.lock().is_error()
+    }
+
+    /// 是否推流中。
+    pub fn is_streaming(&self) -> bool {
+        self.driver.lock().is_streaming()
+    }
+
+    /// 获取 vb2 唤醒源。
+    pub fn vb_poll_set(&self) -> Option<Arc<PollSet>> {
+        self.driver.lock().vb_poll_set()
+    }
+
+    /// 获取事件唤醒源。
+    pub fn event_poll_set(&self) -> Arc<PollSet> {
+        Arc::clone(&self.event_poll_rx)
+    }
+
+    /// 打开设备。
+    pub fn open_fh(&self) {
+        let mut fh_guard = self.fh.lock();
+        if fh_guard.is_none() {
+            *fh_guard = Some(V4l2Fh::new());
+        }
+        drop(fh_guard);
+        self.open_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// 关闭设备。
+    pub fn close_fh(&self) {
+        let prev = self.open_count.fetch_sub(1, Ordering::SeqCst);
+        if prev == 1 {
+            self.driver.lock().release();
+            *self.fh.lock() = None;
+        } else if prev == 0 {
+            self.open_count.store(0, Ordering::SeqCst);
+        }
+    }
+
+    /// 投递事件。
+    pub fn queue_event(&self, ev: &mut Event) {
+        let mut fh_guard = self.fh.lock();
+        if let Some(fh) = &mut *fh_guard
+            && fh.queue_event(*ev) != QueueOutcome::NoSubscription
+        {
+            self.event_poll_rx.wake_from_irq(IoEvents::PRI);
+        }
+    }
+
+    /// 是否有待处理事件。
+    pub fn has_pending_events(&self) -> bool {
+        self.fh.lock().as_ref().is_some_and(|fh| fh.pending() > 0)
+    }
+
+    /// 处理 G_EXT_CTRLS。
+    pub fn handle_g_ext_ctrls(&self, header: &mut ExtControls, payload: &mut [u8]) -> Result<()> {
+        self.handle_ext_ctrls(header, payload, CtrlHandler::g_ext_ctrls)
+    }
+
+    /// 处理 S_EXT_CTRLS。
+    pub fn handle_s_ext_ctrls(&self, header: &mut ExtControls, payload: &mut [u8]) -> Result<()> {
+        self.handle_ext_ctrls(header, payload, CtrlHandler::s_ext_ctrls)
+    }
+
+    /// 处理 TRY_EXT_CTRLS。
+    pub fn handle_try_ext_ctrls(&self, header: &mut ExtControls, payload: &mut [u8]) -> Result<()> {
+        self.handle_ext_ctrls(header, payload, CtrlHandler::try_ext_ctrls)
+    }
+
+    /// 扩展控件通用路径。
+    fn handle_ext_ctrls(
+        &self,
+        header: &mut ExtControls,
+        payload: &mut [u8],
+        op: impl FnOnce(&CtrlHandler, &mut ExtControls, &mut [ExtControl]) -> Result<()>,
+    ) -> Result<()> {
+        let mut controls = parse_ext_controls(payload)?;
+        let driver = self.driver.lock();
+        let handler = driver.ctrl_handler().ok_or(V4l2Error::NotSupported)?;
+        op(handler, header, &mut controls)?;
+        write_ext_controls(payload, &controls);
+        Ok(())
+    }
+}
+
+/// 解析扩展控件。
+fn parse_ext_controls(payload: &[u8]) -> Result<Vec<ExtControl>> {
+    let ec_size = core::mem::size_of::<ExtControl>();
+    if !payload.len().is_multiple_of(ec_size) {
+        return Err(V4l2Error::InvalidArgument);
+    }
+    // SAFETY: payload 长度是 ExtControl 大小的整数倍；ExtControl 为 repr(C) POD。
+    let src = unsafe {
+        core::slice::from_raw_parts(
+            payload.as_ptr() as *const ExtControl,
+            payload.len() / ec_size,
+        )
+    };
+    Ok(src.to_vec())
+}
+
+/// 写回扩展控件。
+fn write_ext_controls(payload: &mut [u8], controls: &[ExtControl]) {
+    debug_assert!(payload.len() == core::mem::size_of_val(controls));
+    // SAFETY: 调用方保证 payload 长度与 controls 项数匹配。
+    let dst = unsafe {
+        core::slice::from_raw_parts_mut(payload.as_mut_ptr() as *mut ExtControl, controls.len())
+    };
+    dst.copy_from_slice(controls);
+}

--- a/drivers/media/ax-media/src/driver.rs
+++ b/drivers/media/ax-media/src/driver.rs
@@ -1,0 +1,52 @@
+//! V4L2 驱动 trait。
+
+use alloc::{sync::Arc, vec::Vec};
+
+use axpoll::PollSet;
+
+use crate::{
+    ctrls::CtrlHandler,
+    ioctl::{IoctlOps, LegacyIoctlOps},
+};
+
+/// V4L2 驱动对象。
+#[allow(unused_variables)]
+pub trait V4L2DriverOps: Send + Sync + IoctlOps + LegacyIoctlOps {
+    /// mmap 解析。
+    fn mmap(&self, offset: u64, length: u64) -> Option<(Vec<usize>, usize)> {
+        None
+    }
+
+    /// 是否可读。
+    fn is_readable(&self) -> bool {
+        false
+    }
+
+    /// 是否错误。
+    fn is_error(&self) -> bool {
+        false
+    }
+
+    /// 是否推流中。
+    fn is_streaming(&self) -> bool {
+        false
+    }
+
+    /// 已分配缓冲数。
+    fn num_buffers(&self) -> u32 {
+        0
+    }
+
+    /// 获取 vb2 唤醒源。
+    fn vb_poll_set(&self) -> Option<Arc<PollSet>> {
+        None
+    }
+
+    /// 释放资源。
+    fn release(&self) {}
+
+    /// 获取控件处理器。
+    fn ctrl_handler(&self) -> Option<&CtrlHandler> {
+        None
+    }
+}

--- a/drivers/media/ax-media/src/error.rs
+++ b/drivers/media/ax-media/src/error.rs
@@ -1,0 +1,45 @@
+use thiserror::Error;
+
+/// V4L2 操作结果。
+pub type Result<T> = core::result::Result<T, V4l2Error>;
+
+/// V4L2 错误码。
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum V4l2Error {
+    #[error("invalid argument")]
+    InvalidArgument,
+    #[error("no such device")]
+    NoSuchDevice,
+    #[error("I/O error")]
+    Io,
+    #[error("operation not supported")]
+    NotSupported,
+    #[error("device or resource busy")]
+    Busy,
+    #[error("timed out")]
+    Timeout,
+    #[error("out of memory")]
+    NoMemory,
+    #[error("access denied")]
+    AccessDenied,
+    #[error("bad file descriptor")]
+    BadFileDescriptor,
+    #[error("try again")]
+    WouldBlock,
+    #[error("no such file or entry")]
+    NoEntry,
+    #[error("no such device or address")]
+    NoSuchDeviceOrAddress,
+    #[error("operation not permitted")]
+    OperationNotPermitted,
+    #[error("interrupted")]
+    Interrupted,
+    #[error("inappropriate ioctl for device")]
+    NotATty,
+    #[error("no space left on device")]
+    StorageFull,
+    #[error("result out of range")]
+    OutOfRange,
+    #[error("message too long")]
+    MessageTooLong,
+}

--- a/drivers/media/ax-media/src/filehandler.rs
+++ b/drivers/media/ax-media/src/filehandler.rs
@@ -1,0 +1,276 @@
+//! V4L2 文件句柄与事件队列。
+
+use alloc::{collections::VecDeque, vec::Vec};
+
+use crate::{
+    Result, V4l2Error,
+    interface::event::{CtrlChange, Event, EventCtrlPayload, EventSubscription, EventType},
+};
+
+/// 订阅队列长度默认值。
+pub const EVENT_QUEUE_DEFAULT_ELEMS: usize = 1;
+
+/// 事件队列溢出时的处理策略。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OverflowStrategy {
+    DropOldest,
+    Ctrl,
+}
+
+/// `SubscribedEvent::push` 的结果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PushOutcome {
+    Inserted,
+    Merged,
+}
+
+/// `V4l2Fh::queue_event` 的投递结果。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueOutcome {
+    Delivered,
+    Merged,
+    NoSubscription,
+}
+
+/// V4L2 文件句柄。
+#[derive(Debug)]
+pub struct V4l2Fh {
+    subscribed: Vec<SubscribedEvent>,
+    sequence: u32,
+    pending_count: usize,
+    prio: u32,
+}
+
+impl V4l2Fh {
+    /// 创建文件句柄。
+    pub fn new() -> Self {
+        Self {
+            subscribed: Vec::new(),
+            sequence: u32::MAX,
+            pending_count: 0,
+            prio: 2,
+        }
+    }
+
+    /// 获取优先级。
+    pub fn prio(&self) -> u32 {
+        self.prio
+    }
+
+    /// 设置优先级。
+    pub fn set_prio(&mut self, prio: u32) {
+        self.prio = prio;
+    }
+
+    /// 订阅事件。
+    pub fn subscribe(&mut self, sub: &EventSubscription) -> Result<()> {
+        if sub.ty == EventType::All {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        if self.is_subscribed(sub.ty, sub.id) {
+            return Ok(());
+        }
+        let (elems, strategy) = Self::subscription_params(sub.ty);
+        self.subscribed.push(SubscribedEvent {
+            ty: sub.ty,
+            id: sub.id,
+            strategy,
+            elems,
+            events: VecDeque::with_capacity(elems),
+        });
+        Ok(())
+    }
+
+    /// 取消订阅。
+    pub fn unsubscribe(&mut self, sub: &EventSubscription) {
+        if sub.ty == EventType::All {
+            self.unsubscribe_all();
+            return;
+        }
+        let Some(pos) = self
+            .subscribed
+            .iter()
+            .position(|s| s.ty == sub.ty && s.id == sub.id)
+        else {
+            return;
+        };
+        let sev = self.subscribed.remove(pos);
+        self.pending_count = self.pending_count.saturating_sub(sev.events.len());
+        debug_assert_eq!(
+            self.pending_count,
+            self.subscribed.iter().map(|s| s.events.len()).sum()
+        );
+    }
+
+    /// 投递事件。
+    pub fn queue_event(&mut self, mut ev: Event) -> QueueOutcome {
+        let Some(idx) = self
+            .subscribed
+            .iter()
+            .position(|s| s.ty as u32 == ev.ty && s.id == ev.id)
+        else {
+            return QueueOutcome::NoSubscription;
+        };
+        ev.sequence = self.alloc_sequence();
+        let sev = &mut self.subscribed[idx];
+        let outcome = sev.push(ev);
+        if outcome == PushOutcome::Inserted {
+            self.pending_count += 1;
+            QueueOutcome::Delivered
+        } else {
+            QueueOutcome::Merged
+        }
+    }
+
+    /// 投递事件（bool 返回）。
+    pub fn queue_event_bool(&mut self, ev: Event) -> bool {
+        !matches!(self.queue_event(ev), QueueOutcome::NoSubscription)
+    }
+
+    /// 取出事件。
+    pub fn dequeue(&mut self) -> Result<Event> {
+        let idx = self
+            .subscribed
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| s.events.front().map(|e| (i, e.sequence)))
+            .min_by_key(|&(_, seq)| seq)
+            .map(|(i, _)| i)
+            .ok_or(V4l2Error::NoEntry)?;
+        let sev = &mut self.subscribed[idx];
+        let mut ev = sev.events.pop_front().expect("front selected above");
+        self.pending_count = self.pending_count.saturating_sub(1);
+        ev.pending = self.pending_count as u32;
+        debug_assert_eq!(
+            self.pending_count,
+            self.subscribed.iter().map(|s| s.events.len()).sum()
+        );
+        Ok(ev)
+    }
+
+    /// 待处理事件数。
+    pub fn pending(&self) -> usize {
+        self.pending_count
+    }
+
+    /// 是否已订阅。
+    pub fn is_subscribed(&self, ty: EventType, id: u32) -> bool {
+        self.subscribed.iter().any(|s| s.ty == ty && s.id == id)
+    }
+
+    fn alloc_sequence(&mut self) -> u32 {
+        self.sequence = self.sequence.wrapping_add(1);
+        self.sequence
+    }
+
+    fn subscription_params(ty: EventType) -> (usize, OverflowStrategy) {
+        match ty {
+            EventType::Ctrl => (EVENT_QUEUE_DEFAULT_ELEMS, OverflowStrategy::Ctrl),
+            _ => (EVENT_QUEUE_DEFAULT_ELEMS, OverflowStrategy::DropOldest),
+        }
+    }
+
+    fn unsubscribe_all(&mut self) {
+        self.pending_count = 0;
+        self.subscribed.clear();
+    }
+}
+
+impl Default for V4l2Fh {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 订阅及其事件队列。
+#[derive(Debug)]
+struct SubscribedEvent {
+    ty: EventType,
+    id: u32,
+    strategy: OverflowStrategy,
+    elems: usize,
+    events: VecDeque<Event>,
+}
+
+impl SubscribedEvent {
+    /// 入队事件。
+    fn push(&mut self, ev: Event) -> PushOutcome {
+        if self.events.len() < self.elems {
+            self.events.push_back(ev);
+            return PushOutcome::Inserted;
+        }
+        let mut oldest = self.events.pop_front().expect("full queue is non-empty");
+        if self.elems == 1 && self.strategy == OverflowStrategy::Ctrl {
+            ctrl_replace(&mut oldest, &ev);
+            oldest.ty = ev.ty;
+            oldest.id = ev.id;
+            oldest.sequence = ev.sequence;
+            oldest.timestamp = ev.timestamp;
+            self.events.push_back(oldest);
+        } else {
+            if self.elems > 1
+                && self.strategy == OverflowStrategy::Ctrl
+                && let Some(newest) = self.events.back_mut()
+            {
+                ctrl_merge(&oldest, newest);
+            }
+            self.events.push_back(ev);
+        }
+        PushOutcome::Merged
+    }
+}
+
+fn ctrl_replace(old: &mut Event, new: &Event) {
+    let old_changes = EventCtrlPayload::read_from(old).changes;
+    let mut payload = EventCtrlPayload::read_from(new);
+    payload.changes |= old_changes;
+    payload.write_into(&mut old.data);
+}
+
+fn ctrl_merge(old: &Event, new: &mut Event) {
+    let mut payload = EventCtrlPayload::read_from(new);
+    payload.changes |= EventCtrlPayload::read_from(old).changes;
+    payload.write_into(&mut new.data);
+}
+
+/// 构建控件事件参数。
+#[derive(Debug, Clone, Copy)]
+pub struct CtrlEventParams {
+    pub id: u32,
+    pub ctrl_type: u32,
+    pub value: i64,
+    pub flags: u32,
+    pub minimum: i64,
+    pub maximum: i64,
+    pub step: i64,
+    pub default_value: i64,
+}
+
+/// 构建 CTRL 事件。
+pub fn build_ctrl_event(params: CtrlEventParams, changes: CtrlChange) -> Event {
+    let ctrl = EventCtrlPayload {
+        changes: changes.bits(),
+        ty: params.ctrl_type,
+        value: params.value as u64,
+        flags: params.flags,
+        minimum: params.minimum as i32,
+        maximum: params.maximum as i32,
+        step: params.step as i32,
+        default_value: params.default_value as i32,
+    };
+    let mut data = [0u8; 64];
+    ctrl.write_into(&mut data);
+    Event {
+        ty: EventType::Ctrl as u32,
+        pad: 0,
+        data,
+        pending: 0,
+        sequence: 0,
+        timestamp: crate::interface::Timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        },
+        id: params.id,
+        reserved: [0; 8],
+    }
+}

--- a/drivers/media/ax-media/src/interface/buffer.rs
+++ b/drivers/media/ax-media/src/interface/buffer.rs
@@ -1,0 +1,165 @@
+use bitflags::bitflags;
+
+use crate::interface::{BufType, Field, Timecode, Timeval, format::Format};
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct BufCapabilities: u32 {
+        const SUPPORTS_MMAP = 1 << 0;
+        const SUPPORTS_USERPTR = 1 << 1;
+        const SUPPORTS_DMABUF = 1 << 2;
+        const SUPPORTS_REQUESTS = 1 << 3;
+        const SUPPORTS_ORPHANED_BUFS = 1 << 4;
+        const SUPPORTS_M2M_HOLD_CAPTURE_BUF = 1 << 5;
+        const SUPPORTS_MMAP_CACHE_HINTS = 1 << 6;
+        const SUPPORTS_MAX_NUM_BUFFERS = 1 << 7;
+        const SUPPORTS_REMOVE_BUFS = 1 << 8;
+    }
+}
+
+/// 缓冲区的内存映射类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Memory {
+    Mmap    = 1,
+    Userptr = 2,
+    Overlay = 3,
+    Dmabuf  = 4,
+}
+
+// ========================================================================
+// v4l2_requestbuffers（请求缓冲区）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Requestbuffers {
+    pub count: u32,                    // [inout] 输入：请求的数量，输出：实际数量
+    pub ty: BufType,                   // [in] 缓冲区类型
+    pub memory: Memory,                // [in] 内存映射类型
+    pub capabilities: BufCapabilities, // [out] 缓冲区能力
+    pub flags: u8,                     // [in] 请求标志
+    pub reserved: [u8; 3],
+}
+
+// ========================================================================
+// v4l2_exportbuffer（导出缓冲区）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Exportbuffer {
+    pub ty: BufType, // [in] 缓冲区类型
+    pub index: u32,  // [in] 缓冲区索引
+    pub plane: u32,  // [in] plane 索引
+    pub flags: u32,  // [in] 导出标志
+    pub fd: i32,     // [out] 文件描述符
+    pub reserved: [u32; 11],
+}
+
+// ========================================================================
+// v4l2_create_buffers（创建缓冲区）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CreateBuffers {
+    pub index: u32,                    // [out] 第一个创建的缓冲区索引
+    pub count: u32,                    // [inout] 输入：请求的数量，输出：实际数量
+    pub memory: Memory,                // [in] 内存映射类型
+    pub format: Format,                // [in] 缓冲区格式
+    pub capabilities: BufCapabilities, // [out] 缓冲区能力
+    pub flags: u32,                    // [in] 请求标志
+    pub max_num_buffers: u32,          // [in] 最大缓冲区数量
+    pub reserved: [u32; 5],
+}
+
+// ========================================================================
+// v4l2_remove_buffers（移除缓冲区）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct RemoveBuffers {
+    pub index: u32,  // [in] 要移除的第一个缓冲区索引
+    pub count: u32,  // [in] 要移除的缓冲区数量
+    pub ty: BufType, // [in] 缓冲区类型
+    pub reserved: [u32; 13],
+}
+
+// ========================================================================
+// v4l2_buffer — 核心缓冲区描述符
+// ========================================================================
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union BufferM {
+    pub offset: u32,
+    pub userptr: usize,
+    pub fd: i32,
+}
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct BufFlags: u32 {
+        const MAPPED = 1 << 0;
+        const QUEUED = 1 << 1;
+        const DONE = 1 << 2;
+        const KEYFRAME = 1 << 3;
+        const PFRAME = 1 << 4;
+        const BFRAME = 1 << 5;
+        const ERROR = 1 << 6;
+        const IN_REQUEST = 1 << 7;
+        const TIMECODE = 1 << 8;
+        const M2M_HOLD_CAPTURE_BUF = 1 << 9;
+        const PREPARED = 1 << 10;
+        const NO_CACHE_INVALIDATE = 1 << 11;
+        const NO_CACHE_CLEAN = 1 << 12;
+        const TIMESTAMP_MONOTONIC = 1 << 13;
+        const LAST = 1 << 16;
+        const REQUEST_FD = 1 << 17;
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Buffer {
+    pub index: u32,         // [inout] 缓冲区索引，仅 VIDIOC_DQBUF 时为输出
+    pub ty: BufType,        // [in] 缓冲区类型
+    pub bytesused: u32,     // [out] 缓冲区中数据占用的字节数
+    pub flags: BufFlags,    // [out] 缓冲区标志
+    pub field: Field,       // [out] 缓冲区中图像的场顺序
+    pub timestamp: Timeval, // [out] 缓冲区时间戳
+    pub timecode: Timecode, // [out] 缓冲区时间码
+    pub sequence: u32,      // [out] 缓冲区序列号
+    pub memory: Memory,     // [in] 内存映射类型
+    pub m: BufferM,         // [inout] 内存位置（offset / userptr / fd）
+    pub length: u32,        // [out] 缓冲区长度（字节）
+    pub reserved2: u32,
+    pub request_fd: i32, // [in] 请求文件描述符
+}
+
+// ========================================================================
+// 缓冲区标志（v4l2_buffer.flags）
+// ========================================================================
+
+/// 多平面（multi-planar）缓冲区的 plane 信息。
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Plane {
+    pub bytesused: u32,   // [out] plane 中数据占用的字节数
+    pub length: u32,      // [in] plane 长度（字节）
+    pub m: PlaneM,        // [in] 内存位置（mem_offset / userptr / fd）
+    pub data_offset: u32, // [in] 到实际数据的字节偏移
+    pub reserved: [u32; 11],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union PlaneM {
+    pub mem_offset: u32,
+    pub userptr: usize,
+    pub fd: i32,
+}

--- a/drivers/media/ax-media/src/interface/capability.rs
+++ b/drivers/media/ax-media/src/interface/capability.rs
@@ -1,0 +1,54 @@
+//! 设备能力（Device Capability）结构与标志
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// VIDIOC_QUERYCAP 返回的设备能力标志
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Capabilities: u32 {
+        const VIDEO_CAPTURE = 0x0000_0001; // 是视频采集设备
+        const VIDEO_OUTPUT = 0x0000_0002; // 支持视频输出
+        const VIDEO_OVERLAY = 0x0000_0004; // 支持视频叠加
+        const VBI_CAPTURE = 0x0000_0010; // 是原始 VBI 采集设备
+        const VBI_OUTPUT = 0x0000_0020; // 是原始 VBI 输出设备
+        const SLICED_VBI_CAPTURE = 0x0000_0040; // 是切片 VBI（sliced VBI）采集设备
+        const SLICED_VBI_OUTPUT = 0x0000_0080; // 是切片 VBI（sliced VBI）输出设备
+        const RDS_CAPTURE = 0x0000_0100; // 支持 RDS 数据采集
+        const VIDEO_OUTPUT_OVERLAY = 0x0000_0200; // 支持视频输出叠加
+        const HW_FREQ_SEEK = 0x0000_0400; // 支持硬件频率搜索
+        const RDS_OUTPUT = 0x0000_0800; // 是 RDS 编码器
+        const VIDEO_CAPTURE_MPLANE = 0x0000_1000; // 支持多平面（multiplanar）的视频采集
+        const VIDEO_OUTPUT_MPLANE = 0x0000_2000; // 支持多平面（multiplanar）的视频输出
+        const VIDEO_M2M_MPLANE = 0x0000_4000; // 支持多平面（multiplanar）的视频内存到内存（mem-to-mem）处理
+        const VIDEO_M2M = 0x0000_8000; // 视频内存到内存（mem-to-mem）设备
+        const TUNER = 0x0001_0000; // 具有调谐器（Tuner）
+        const AUDIO = 0x0002_0000; // 支持音频
+        const RADIO = 0x0004_0000; // 是收音机设备
+        const MODULATOR = 0x0008_0000; // 具有调制器（Modulator）
+        const SDR_CAPTURE = 0x0010_0000; // 是 SDR 采集设备
+        const EXT_PIX_FORMAT = 0x0020_0000; // 支持扩展像素格式
+        const SDR_OUTPUT = 0x0040_0000; // 是 SDR 输出设备
+        const META_CAPTURE = 0x0080_0000; // 是元数据采集设备
+        const READWRITE = 0x0100_0000; // 支持 read/write 系统调用
+        const STREAMING = 0x0400_0000; // 支持流式 I/O ioctl
+        const META_OUTPUT = 0x0800_0000; // 是元数据输出设备
+        const TOUCH = 0x1000_0000; // 是触摸设备
+        const IO_MC = 0x2000_0000; // I/O 由媒体控制器（media controller）控制
+        const EDID = 0x0200_0000; // 是仅支持 EDID 的设备
+        const DEVICE_CAPS = 0x8000_0000; // 设置设备能力字段
+    }
+}
+
+/// VIDIOC_QUERYCAP 返回的设备能力信息
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Capability {
+    pub driver: [u8; 16],           // [out] 驱动名称
+    pub card: [u8; 32],             // [out] 设备卡名称
+    pub bus_info: [u8; 32],         // [out] 总线信息
+    pub version: u32,               // [out] 内核版本
+    pub capabilities: Capabilities, // [out] 设备能力
+    pub device_caps: Capabilities,  // [out] 设备节点能力
+    pub reserved: [u32; 3],
+}

--- a/drivers/media/ax-media/src/interface/colorspace.rs
+++ b/drivers/media/ax-media/src/interface/colorspace.rs
@@ -1,0 +1,62 @@
+/// 色彩空间（Colorspace）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Colorspace {
+    Default     = 0,  // 默认色彩空间（由驱动自行决定）。
+    Smpte170m   = 1,  // SMPTE 170M：广播电视 NTSC/PAL 标清（SDTV）。
+    Smpte240m   = 2,  // SMPTE 240M：已废弃的高清（HDTV）。
+    Rec709      = 3,  // Rec.709：高清（HDTV）。
+    System470M  = 5,  // NTSC 1953 色彩空间。
+    System470Bg = 6,  // EBU Tech 3213 PAL/SECAM。
+    Jpeg        = 7,  // 动态 JPEG（Motion-JPEG）。
+    Srgb        = 8,  // sRGB。
+    Oprgb       = 9,  // opRGB。
+    Bt2020      = 10, // BT.2020，超高清（UHDTV）。
+    Raw         = 11, // 未经处理的原始图像。
+    DciP3       = 12, // DCI-P3，影院投影机。
+}
+
+/// 传输函数。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum XferFunc {
+    Default   = 0,
+    Rec709    = 1,
+    Srgb      = 2,
+    Oprgb     = 3,
+    Smpte240m = 4,
+    /// 不使用任何传输函数（xfer func）。
+    None      = 5,
+    DciP3     = 6,
+    Smpte2084 = 7,
+}
+
+/// Y'CbCr 编码。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum YcbcrEncoding {
+    Default        = 0,
+    Rec601         = 1, // ITU-R 601 —— 标清（SDTV）。
+    Rec709         = 2, // Rec. 709 —— 高清（HDTV）。
+    Xv601          = 3, // ITU-R 601/EN 61966-2-4 扩展色域 —— 标清（SDTV）。
+    Xv709          = 4, // Rec. 709/EN 61966-2-4 扩展色域 —— 高清（HDTV）。
+    Bt2020         = 6, // BT.2020 非常亮度（Non-constant Luminance）Y'CbCr。
+    Bt2020ConstLum = 7, // BT.2020 恒定亮度（Constant Luminance）Y'CbcCrc。
+}
+
+/// HSV 编码。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HsvEncoding {
+    Hue180 = 128, // 色相映射到 0 - 179
+    Hue256 = 129, // 色相映射到 0-255。
+}
+
+/// 量化范围。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Quantization {
+    Default   = 0,
+    FullRange = 1,
+    LimRange  = 2,
+}

--- a/drivers/media/ax-media/src/interface/crop.rs
+++ b/drivers/media/ax-media/src/interface/crop.rs
@@ -1,0 +1,78 @@
+//! 裁剪（cropping）、合成（composing）与 Selection 结构。
+//!
+//! Cropcap、Crop、Selection。
+
+use bitflags::bitflags;
+
+use crate::interface::{Fract, Rect};
+
+/// 裁剪能力。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Cropcap {
+    pub ty: u32,            // [in] BufType 枚举
+    pub bounds: Rect,       // [out] 最大裁剪矩形
+    pub defrect: Rect,      // [out] 默认裁剪矩形
+    pub pixelaspect: Fract, // [out] 像素宽高比
+}
+
+/// 裁剪矩形。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Crop {
+    pub ty: u32, // [in] BufType 枚举
+    pub c: Rect, // [inout] 裁剪矩形（G_CROP：输出，S_CROP：输入）
+}
+
+/// Selection 目标 — `V4L2_SEL_TGT_*`（见 uapi/linux/v4l2-common.h）。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SelectionTarget {
+    Crop           = 0x0000,
+    CropDefault    = 0x0001,
+    CropBounds     = 0x0002,
+    NativeSize     = 0x0003,
+    Compose        = 0x0100,
+    ComposeDefault = 0x0101,
+    ComposeBounds  = 0x0102,
+    ComposePadded  = 0x0103,
+}
+
+impl SelectionTarget {
+    /// 尝试将原始 `u32` 转换为 [`SelectionTarget`]。
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            0x0000 => Self::Crop,
+            0x0001 => Self::CropDefault,
+            0x0002 => Self::CropBounds,
+            0x0003 => Self::NativeSize,
+            0x0100 => Self::Compose,
+            0x0101 => Self::ComposeDefault,
+            0x0102 => Self::ComposeBounds,
+            0x0103 => Self::ComposePadded,
+            _ => return None,
+        })
+    }
+}
+
+bitflags! {
+    /// Selection 约束标志 — `V4L2_SEL_FLAG_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct SelectionFlags: u32 {
+        const GE = 1 << 0;
+        const LE = 1 << 1;
+        const KEEP_CONFIG = 1 << 2;
+    }
+}
+
+/// Selection 矩形（许多设备用它替代裁剪）。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Selection {
+    pub ty: u32,                 // [in] BufType 枚举
+    pub target: SelectionTarget, // [in] Selection 目标
+    pub flags: SelectionFlags,   // [in] Selection 约束标志
+    pub r: Rect,                 // [inout] Selection 矩形
+    pub reserved: [u32; 9],
+}

--- a/drivers/media/ax-media/src/interface/ctrl.rs
+++ b/drivers/media/ax-media/src/interface/ctrl.rs
@@ -1,0 +1,136 @@
+//! 控制（Control）结构与常量。
+//!
+//! Control、ExtControl、ExtControls、
+//! QueryCtrl、QueryExtCtrl、Querymenu 以及 Control 标志。
+
+use bitflags::bitflags;
+
+/// 简单控制（id + value）。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Control {
+    pub id: u32,    // [in] 控制 ID
+    pub value: i32, // [inout] 控制值（G_CTRL：输出，S_CTRL：输入）
+}
+
+/// 扩展控制。
+#[derive(Debug, Clone, Copy)]
+#[repr(C, packed)]
+pub struct ExtControl {
+    pub id: u32,   // [in] 控制 ID
+    pub size: u32, // [inout] 值的大小（字符串 / 复合类型）
+    pub reserved2: [u32; 1],
+    /// value/value64/string/ptr 等的联合体。
+    pub value: ExtControlValue, // [inout] 控制值
+}
+
+/// 扩展控制值联合体。
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub union ExtControlValue {
+    pub value: i32,
+    pub value64: i64,
+    pub string: usize,
+    pub ptr: usize,
+}
+
+impl core::fmt::Debug for ExtControlValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let v = unsafe { core::ptr::addr_of!(self.value).read_unaligned() };
+        f.debug_struct("ExtControlValue")
+            .field("value", &v)
+            .finish()
+    }
+}
+
+/// 扩展控制容器。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct ExtControls {
+    /// ctrl_class（用户态）与 which 的联合
+    pub which: u32, // [in] 哪一组控制
+    pub count: u32,      // [inout] 控制数量（输出：实际数量 / 错误索引基准）
+    pub error_idx: u32,  // [out] 第一个失败控制的索引
+    pub request_fd: i32, // [in] 请求文件描述符
+    pub reserved: [u32; 1],
+    pub controls: usize, // [in] 指向控制数组的用户态指针
+}
+
+// 控制 ID 辅助常量
+pub const CTRL_ID_MASK: u32 = 0x0FFF_FFFF;
+pub const CTRL_MAX_DIMS: u32 = 4;
+pub const CTRL_WHICH_CUR_VAL: u32 = 0;
+pub const CTRL_WHICH_DEF_VAL: u32 = 0x0F00_0000;
+pub const CTRL_WHICH_REQUEST_VAL: u32 = 0x0F01_0000;
+pub const CTRL_WHICH_MIN_VAL: u32 = 0x0F02_0000;
+pub const CTRL_WHICH_MAX_VAL: u32 = 0x0F03_0000;
+
+// 控制标志
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct CtrlFlags: u32 {
+        const DISABLED = 0x0001;
+        const GRABBED = 0x0002;
+        const READ_ONLY = 0x0004;
+        const UPDATE = 0x0008;
+        const INACTIVE = 0x0010;
+        const SLIDER = 0x0020;
+        const WRITE_ONLY = 0x0040;
+        const VOLATILE = 0x0080;
+        const HAS_PAYLOAD = 0x0100;
+        const EXECUTE_ON_WRITE = 0x0200;
+        const MODIFY_LAYOUT = 0x0400;
+        const DYNAMIC_ARRAY = 0x0800;
+        const HAS_WHICH_MIN_MAX = 0x1000;
+    }
+}
+
+/// 简单查询控制结果。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct QueryCtrl {
+    pub id: u32,            // [in] 控制 ID
+    pub ty: u32,            // [out] 控制类型
+    pub name: [u8; 32],     // [out] 控制名称
+    pub minimum: i32,       // [out] 最小值
+    pub maximum: i32,       // [out] 最大值
+    pub step: i32,          // [out] 步长
+    pub default_value: i32, // [out] 默认值
+    pub flags: CtrlFlags,   // [out] 控制标志
+    pub reserved: [u32; 2],
+}
+
+/// 扩展查询控制结果。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct QueryExtCtrl {
+    pub id: u32,                             // [in] 控制 ID
+    pub ty: u32,                             // [out] 控制类型
+    pub name: [u8; 32],                      // [out] 控制名称
+    pub minimum: i64,                        // [out] 最小值
+    pub maximum: i64,                        // [out] 最大值
+    pub step: u64,                           // [out] 步长
+    pub default_value: i64,                  // [out] 默认值
+    pub flags: CtrlFlags,                    // [out] 控制标志
+    pub elem_size: u32,                      // [out] 元素大小（字节）
+    pub elems: u32,                          // [out] 元素数量
+    pub nr_of_dims: u32,                     // [out] 维度数量
+    pub dims: [u32; CTRL_MAX_DIMS as usize], // [out] 各维度大小
+    pub reserved: [u32; 32],
+}
+
+/// 查询菜单项结果。
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct Querymenu {
+    pub id: u32,    // [in] 控制 ID
+    pub index: u32, // [in] 菜单项索引
+    /// name[32] 与 value（s64）的联合
+    pub name: [u8; 32], // [out] 菜单项名称 / 值
+    pub reserved: u32,
+}
+
+// 用户类控制上限
+pub const CID_MAX_CTRLS: u32 = 1024;
+pub const CID_PRIVATE_BASE: u32 = 0x0800_0000;

--- a/drivers/media/ax-media/src/interface/dv.rs
+++ b/drivers/media/ax-media/src/interface/dv.rs
@@ -1,0 +1,152 @@
+//! DV timings 结构。
+
+use bitflags::bitflags;
+
+use crate::interface::Fract;
+
+/// 逐行/隔行 — `V4L2_DV_*`。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DvInterlaced {
+    Progressive = 0,
+    Interlaced  = 1,
+}
+
+bitflags! {
+    /// 同步极性标志 — `V4L2_DV_*_POS_POL`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct DvPolarity: u32 {
+        const VSYNC_POS_POL = 0x0000_0001;
+        const HSYNC_POS_POL = 0x0000_0002;
+    }
+}
+
+bitflags! {
+    /// 时序标准标志 — `V4L2_DV_BT_STD_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct DvStandards: u32 {
+        const CEA861 = 1 << 0;
+        const DMT    = 1 << 1;
+        const CVT    = 1 << 2;
+        const GTF    = 1 << 3;
+        const SDI    = 1 << 4;
+    }
+}
+
+/// BT 时序数据。
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct BtTimings {
+    pub width: u32,               // 有效视频宽度（像素）
+    pub height: u32,              // 有效视频高度（行）
+    pub interlaced: DvInterlaced, // 逐行或隔行
+    pub polarities: DvPolarity,   // 同步极性
+    pub pixelclock: u64,          // 像素时钟（Hz）
+    pub hfrontporch: u32,         // 水平前肩
+    pub hsync: u32,               // 水平同步
+    pub hbackporch: u32,          // 水平后肩
+    pub vfrontporch: u32,         // 垂直前肩
+    pub vsync: u32,               // 垂直同步
+    pub vbackporch: u32,          // 垂直后肩
+    pub il_vfrontporch: u32,      // 隔行场垂直前肩
+    pub il_vsync: u32,            // 隔行场垂直同步
+    pub il_vbackporch: u32,       // 隔行场垂直后肩
+    pub standards: DvStandards,   // 支持的时序标准
+    pub flags: DvPolarity,        // 时序标志
+    pub picture_aspect: Fract,    // 画面宽高比
+    pub cea861_vic: u8,           // CEA-861 VIC
+    pub hdmi_vic: u8,             // HDMI VIC
+    pub reserved: [u8; 46],
+}
+
+/// DV 时序载荷联合。
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union DvTimingsPayload {
+    pub bt: BtTimings,
+    pub reserved: [u32; 32],
+}
+
+impl core::fmt::Debug for DvTimingsPayload {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("DvTimingsPayload")
+            .field(&unsafe { self.reserved })
+            .finish()
+    }
+}
+
+/// DV 时序。
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct DvTimings {
+    pub ty: u32, // [in] 时序类型（V4L2_DV_BT_656_1120 = 0）
+    pub payload: DvTimingsPayload,
+}
+
+/// DV 时序类型常量。
+pub const DV_BT_656_1120: u32 = 0;
+
+/// DV 时序枚举。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EnumDvTimings {
+    pub index: u32, // [in] 枚举索引
+    pub pad: u32,   // [in] pad 编号（subdev 节点专用）
+    pub reserved: [u32; 2],
+    pub timings: DvTimings, // [out] 对应索引的时序
+}
+
+/// BT 时序能力。
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct BtTimingsCap {
+    pub min_width: u32,         // 最小宽度
+    pub max_width: u32,         // 最大宽度
+    pub min_height: u32,        // 最小高度
+    pub max_height: u32,        // 最大高度
+    pub min_pixelclock: u64,    // 最小像素时钟
+    pub max_pixelclock: u64,    // 最大像素时钟
+    pub standards: DvStandards, // 支持的时序标准
+    pub capabilities: DvBtCap,  // 支持的能力
+    pub reserved: [u32; 16],
+}
+
+bitflags! {
+    /// DV 时序能力标志 — `V4L2_DV_BT_CAP_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct DvBtCap: u32 {
+        const INTERLACED       = 1 << 0;
+        const PROGRESSIVE      = 1 << 1;
+        const REDUCED_BLANKING = 1 << 2;
+        const CUSTOM           = 1 << 3;
+    }
+}
+
+/// DV 时序能力载荷联合。
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union DvTimingsCapPayload {
+    pub bt: BtTimingsCap,
+    pub raw_data: [u32; 32],
+}
+
+impl core::fmt::Debug for DvTimingsCapPayload {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("DvTimingsCapPayload")
+            .field(&unsafe { self.raw_data })
+            .finish()
+    }
+}
+
+/// DV 时序能力。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DvTimingsCap {
+    pub ty: u32,  // [in] 时序类型
+    pub pad: u32, // [in] pad 编号（subdev 节点专用）
+    pub reserved: [u32; 2],
+    pub payload: DvTimingsCapPayload, // [out] 时序能力载荷
+}

--- a/drivers/media/ax-media/src/interface/edid.rs
+++ b/drivers/media/ax-media/src/interface/edid.rs
@@ -1,0 +1,12 @@
+//! EDID 结构。
+
+/// EDID 数据。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Edid {
+    pub pad: u32,         // [in] pad 编号（subdev 节点专用）
+    pub start_block: u32, // [in] 起始块号
+    pub blocks: u32,      // [inout] 块数量（每块 128 字节）
+    pub reserved: [u32; 5],
+    pub edid: usize, // [in] 指向 EDID 数据缓冲的用户态指针
+}

--- a/drivers/media/ax-media/src/interface/event.rs
+++ b/drivers/media/ax-media/src/interface/event.rs
@@ -1,0 +1,121 @@
+//! V4L2 事件类型 — v4l2_event、v4l2_event_subscription。
+//!
+//! 事件允许用户态订阅来自驱动的异步通知
+//! （控制变化、格式变化、信号源变化等）。
+
+use bitflags::bitflags;
+
+use crate::interface::Timespec;
+
+/// V4L2 事件订阅请求。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EventSubscription {
+    pub ty: EventType,        // [in] 事件类型
+    pub id: u32,              // [in] 关联 ID（例如 [`EventType::Ctrl`] 对应的控制 ID）
+    pub flags: EventSubFlags, // [in] 事件订阅标志
+    pub reserved: [u32; 5],
+}
+
+/// 由用户态出队（dequeue）的 V4L2 事件。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Event {
+    pub ty: u32, // [out] 事件类型
+    pub pad: u32,
+    pub data: [u8; 64],      // [out] 事件负载（union v4l2_event.u，偏移 8）
+    pub pending: u32,        // [out] 该类型的待处理事件数量
+    pub sequence: u32,       // [out] 单调递增序列号
+    pub timestamp: Timespec, // [out] 事件时间戳
+    pub id: u32,             // [out] 事件类型相关 ID（例如控制 ID）
+    pub reserved: [u32; 8],
+}
+
+// ── 事件类型 ───────────────────────────────────────────────────────────
+
+/// V4L2 事件类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventType {
+    All          = 0,
+    Vsync        = 1, // 垂直同步信号事件（Vertical Sync）
+    Eos          = 2, // 流结束事件（End Of Stream）
+    Ctrl         = 3, // 控件变化事件（Control Change）
+    FrameSync    = 4, // 帧同步事件（Frame Sync）
+    SourceChange = 5, // 信号源变化事件（Source Change）
+    MotionDet    = 6, // 运动检测事件（Motion Detection）
+    PrivateStart = 0x0800_0000,
+}
+
+impl EventType {
+    /// 尝试将原始 `u32` 转换为 [`EventType`]。
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            0 => Self::All,
+            1 => Self::Vsync,
+            2 => Self::Eos,
+            3 => Self::Ctrl,
+            4 => Self::FrameSync,
+            5 => Self::SourceChange,
+            6 => Self::MotionDet,
+            0x0800_0000 => Self::PrivateStart,
+            _ => return None,
+        })
+    }
+}
+
+// ── 事件订阅标志 ─────────────────────────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct EventSubFlags: u32 {
+        /// 订阅时立即发送初始事件。
+        const SEND_INITIAL = 1 << 0;
+    }
+}
+
+// ── V4L2_EVENT_CTRL 载荷 ─────────────────────────────────────
+
+/// `v4l2_event_ctrl` 载荷（V4L2_EVENT_CTRL 的 `u` 联合体布局）。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EventCtrlPayload {
+    pub changes: u32,
+    pub ty: u32,
+    pub value: u64,
+    pub flags: u32,
+    pub minimum: i32,
+    pub maximum: i32,
+    pub step: i32,
+    pub default_value: i32,
+}
+
+impl EventCtrlPayload {
+    const BYTES: usize = core::mem::size_of::<Self>();
+
+    /// 从事件负载区读回前 `size_of::<EventCtrlPayload>()` 字节。
+    pub fn read_from(ev: &Event) -> Self {
+        let mut bytes = [0u8; Self::BYTES];
+        bytes.copy_from_slice(&ev.data[..Self::BYTES]);
+        unsafe { core::mem::transmute(bytes) }
+    }
+
+    /// 按位写入目标字节区前 `size_of::<EventCtrlPayload>()` 字节。
+    pub fn write_into(&self, dst: &mut [u8]) {
+        debug_assert!(dst.len() >= Self::BYTES);
+        let bytes: [u8; Self::BYTES] = unsafe { core::mem::transmute(*self) };
+        dst[..Self::BYTES].copy_from_slice(&bytes);
+    }
+}
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct CtrlChange: u32 {
+        /// 值发生变化。
+        const VALUE = 1 << 0;
+        /// 标志位发生变化。
+        const FLAGS = 1 << 1;
+    }
+}

--- a/drivers/media/ax-media/src/interface/format.rs
+++ b/drivers/media/ax-media/src/interface/format.rs
@@ -1,0 +1,355 @@
+//! 格式协商类型。
+//!
+//! 涵盖 `v4l2_fmtdesc`、`v4l2_frmsizeenum`、`v4l2_frmivalenum`、
+//! `v4l2_format` / `v4l2_pix_format` 以及全部像素格式 fourcc 常量。
+
+use bitflags::bitflags;
+
+use crate::interface::{
+    BufType, Field, Fract, Rect,
+    colorspace::{Colorspace, Quantization, XferFunc, YcbcrEncoding},
+};
+
+// ========================================================================
+// 像素格式（v4l2_pix_format）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct PixFormat {
+    pub width: u32,             // [inout] 图像宽度（像素）
+    pub height: u32,            // [inout] 图像高度（像素）
+    pub pixelformat: u32,       // [inout] FourCC 像素格式代码
+    pub field: Field,           // [inout] 场顺序
+    pub bytesperline: u32,      // [inout] 每行字节数（0 表示由驱动决定）
+    pub sizeimage: u32,         // [out] 帧大小（字节）
+    pub colorspace: Colorspace, // [inout] 图像的色彩空间
+    pub priv_data: u32,         // [out] 私有数据，取决于像素格式
+    pub flags: u32,             // [out] 格式标志（V4L2_PIX_FMT_FLAG_*）
+    /// ycbcr_enc / hsv_enc 联合体 — 与 C 的 `union { __u32 ycbcr_enc; __u32 hsv_enc; }` 对应
+    pub ycbcr_enc: u32, // [inout] Y'CbCr / HSV 编码
+    pub quantization: Quantization, // [inout] 量化范围
+    pub xfer_func: XferFunc,    // [inout] 传输函数
+}
+
+impl Default for PixFormat {
+    fn default() -> Self {
+        Self {
+            width: 0,
+            height: 0,
+            pixelformat: 0,
+            field: Field::Any,
+            bytesperline: 0,
+            sizeimage: 0,
+            colorspace: Colorspace::Default,
+            priv_data: 0,
+            flags: 0,
+            ycbcr_enc: YcbcrEncoding::Default as u32,
+            quantization: Quantization::Default,
+            xfer_func: XferFunc::Default,
+        }
+    }
+}
+
+// ========================================================================
+// 像素格式常量（fourcc）
+// ========================================================================
+
+macro_rules! fourcc {
+    ($a:expr, $b:expr, $c:expr, $d:expr) => {
+        u32::from_le_bytes([$a, $b, $c, $d])
+    };
+}
+
+// RGB 格式
+pub const PIX_FMT_RGB332: u32 = fourcc!(b'R', b'G', b'B', b'1');
+pub const PIX_FMT_RGB444: u32 = fourcc!(b'R', b'4', b'4', b'4');
+pub const PIX_FMT_ARGB444: u32 = fourcc!(b'A', b'R', b'1', b'2');
+pub const PIX_FMT_XRGB444: u32 = fourcc!(b'X', b'R', b'1', b'2');
+pub const PIX_FMT_RGB555: u32 = fourcc!(b'R', b'G', b'B', b'O');
+pub const PIX_FMT_ARGB555: u32 = fourcc!(b'A', b'R', b'1', b'5');
+pub const PIX_FMT_XRGB555: u32 = fourcc!(b'X', b'R', b'1', b'5');
+pub const PIX_FMT_RGB565: u32 = fourcc!(b'R', b'G', b'B', b'P');
+pub const PIX_FMT_RGB555X: u32 = fourcc!(b'R', b'G', b'B', b'Q');
+pub const PIX_FMT_ARGB555X: u32 = fourcc!(b'A', b'R', b'1', b'5') | (1 << 31);
+pub const PIX_FMT_XRGB555X: u32 = fourcc!(b'X', b'R', b'1', b'5') | (1 << 31);
+pub const PIX_FMT_RGB565X: u32 = fourcc!(b'R', b'G', b'B', b'R');
+pub const PIX_FMT_BGR666: u32 = fourcc!(b'B', b'G', b'R', b'H');
+pub const PIX_FMT_BGR24: u32 = fourcc!(b'B', b'G', b'R', b'3');
+pub const PIX_FMT_RGB24: u32 = fourcc!(b'R', b'G', b'B', b'3');
+pub const PIX_FMT_BGR32: u32 = fourcc!(b'B', b'G', b'R', b'4');
+pub const PIX_FMT_ABGR32: u32 = fourcc!(b'A', b'R', b'2', b'4');
+pub const PIX_FMT_XBGR32: u32 = fourcc!(b'X', b'R', b'2', b'4');
+pub const PIX_FMT_RGB32: u32 = fourcc!(b'R', b'G', b'B', b'4');
+pub const PIX_FMT_ARGB32: u32 = fourcc!(b'B', b'A', b'2', b'4');
+pub const PIX_FMT_XRGB32: u32 = fourcc!(b'B', b'X', b'2', b'4');
+
+// YUV 打包格式
+pub const PIX_FMT_GREY: u32 = fourcc!(b'G', b'R', b'E', b'Y');
+pub const PIX_FMT_Y4: u32 = fourcc!(b'Y', b'0', b'4', b' ');
+pub const PIX_FMT_Y6: u32 = fourcc!(b'Y', b'0', b'6', b' ');
+pub const PIX_FMT_Y10: u32 = fourcc!(b'Y', b'1', b'0', b' ');
+pub const PIX_FMT_Y12: u32 = fourcc!(b'Y', b'1', b'2', b' ');
+pub const PIX_FMT_Y16: u32 = fourcc!(b'Y', b'1', b'6', b' ');
+pub const PIX_FMT_Y16_BE: u32 = u32::from_le_bytes(*b"Y16 ") | (1u32 << 31);
+pub const PIX_FMT_Y10BPACK: u32 = fourcc!(b'Y', b'1', b'0', b'B');
+pub const PIX_FMT_Y10P: u32 = fourcc!(b'Y', b'1', b'0', b'P');
+pub const PIX_FMT_IPU3_Y10: u32 = fourcc!(b'i', b'p', b'3', b'y');
+pub const PIX_FMT_PAL8: u32 = fourcc!(b'P', b'A', b'L', b'8');
+pub const PIX_FMT_UV8: u32 = fourcc!(b'U', b'V', b'8', b' ');
+pub const PIX_FMT_YUYV: u32 = fourcc!(b'Y', b'U', b'Y', b'V');
+pub const PIX_FMT_YYUV: u32 = fourcc!(b'Y', b'Y', b'U', b'V');
+pub const PIX_FMT_YVYU: u32 = fourcc!(b'Y', b'V', b'Y', b'U');
+pub const PIX_FMT_UYVY: u32 = fourcc!(b'U', b'Y', b'V', b'Y');
+pub const PIX_FMT_VYUY: u32 = fourcc!(b'V', b'Y', b'U', b'Y');
+pub const PIX_FMT_Y41P: u32 = fourcc!(b'Y', b'4', b'1', b'P');
+pub const PIX_FMT_YUV444: u32 = fourcc!(b'Y', b'4', b'4', b'4');
+pub const PIX_FMT_YUV555: u32 = fourcc!(b'Y', b'U', b'V', b'O');
+pub const PIX_FMT_YUV565: u32 = fourcc!(b'Y', b'U', b'V', b'P');
+pub const PIX_FMT_YUV32: u32 = fourcc!(b'Y', b'U', b'V', b'4');
+pub const PIX_FMT_AYUV32: u32 = fourcc!(b'A', b'Y', b'U', b'V');
+pub const PIX_FMT_XYUV32: u32 = fourcc!(b'X', b'Y', b'U', b'V');
+pub const PIX_FMT_VUYA32: u32 = fourcc!(b'V', b'U', b'Y', b'A');
+pub const PIX_FMT_VUYX32: u32 = fourcc!(b'V', b'U', b'Y', b'X');
+pub const PIX_FMT_YUV410: u32 = fourcc!(b'Y', b'U', b'V', b'9');
+pub const PIX_FMT_YVU410: u32 = fourcc!(b'Y', b'V', b'U', b'9');
+pub const PIX_FMT_YUV411P: u32 = fourcc!(b'4', b'1', b'1', b'P');
+pub const PIX_FMT_YUV420: u32 = fourcc!(b'Y', b'U', b'1', b'2');
+pub const PIX_FMT_YVU420: u32 = fourcc!(b'Y', b'V', b'1', b'2');
+pub const PIX_FMT_YUV422P: u32 = fourcc!(b'4', b'2', b'2', b'P');
+pub const PIX_FMT_NV12: u32 = fourcc!(b'N', b'V', b'1', b'2');
+pub const PIX_FMT_NV21: u32 = fourcc!(b'N', b'V', b'2', b'1');
+pub const PIX_FMT_NV16: u32 = fourcc!(b'N', b'V', b'1', b'6');
+pub const PIX_FMT_NV61: u32 = fourcc!(b'N', b'V', b'6', b'1');
+pub const PIX_FMT_NV24: u32 = fourcc!(b'N', b'V', b'2', b'4');
+pub const PIX_FMT_NV42: u32 = fourcc!(b'N', b'V', b'4', b'2');
+
+// MJPEG 压缩
+pub const PIX_FMT_MJPEG: u32 = fourcc!(b'M', b'J', b'P', b'G');
+pub const PIX_FMT_JPEG: u32 = fourcc!(b'J', b'P', b'E', b'G');
+pub const PIX_FMT_H264: u32 = fourcc!(b'H', b'2', b'6', b'4');
+
+// Bayer 拜耳
+pub const PIX_FMT_SBGGR8: u32 = fourcc!(b'B', b'A', b'8', b'1');
+pub const PIX_FMT_SGBRG8: u32 = fourcc!(b'G', b'B', b'R', b'G');
+pub const PIX_FMT_SGRBG8: u32 = fourcc!(b'G', b'R', b'B', b'G');
+pub const PIX_FMT_SRGGB8: u32 = fourcc!(b'R', b'G', b'G', b'B');
+
+// ========================================================================
+// 格式描述（v4l2_fmtdesc）
+// ========================================================================
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct FmtFlag: u32 {
+        const COMPRESSED = 1 << 0;
+        const EMULATED = 1 << 1;
+        const CONTINUOUS_BUF = 1 << 2;
+        const DYN_RESOLUTION = 1 << 3;
+        const ENUM_FRMRATES = 1 << 4;
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Fmtdesc {
+    pub index: u32,            // [in] 格式索引
+    pub ty: BufType,           // [in] 缓冲区类型
+    pub flags: FmtFlag,        // [out] 格式标志
+    pub description: [u8; 32], // [out] 格式描述
+    pub pixelformat: u32,      // [out] 像素格式（fourcc）
+    pub mbus_code: u32,        // [out] 媒体总线代码（用于原始格式）
+    pub reserved: [u32; 3],
+}
+
+// ========================================================================
+// 帧大小枚举（v4l2_frmsizeenum）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FrmsizeDiscrete {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FrmsizeStepwise {
+    pub min_width: u32,
+    pub max_width: u32,
+    pub step_width: u32,
+    pub min_height: u32,
+    pub max_height: u32,
+    pub step_height: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union FrmsizeUnion {
+    pub discrete: FrmsizeDiscrete,
+    pub stepwise: FrmsizeStepwise,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FrameSizeEnum {
+    pub index: u32,         // [in] 帧大小索引
+    pub pixel_format: u32,  // [in] 像素格式（fourcc）
+    pub ty: FrameSizeType,  // [out] 帧大小类型
+    pub size: FrmsizeUnion, // [out] 帧大小（离散或步进）
+    pub reserved: [u32; 2],
+}
+
+/// 帧大小枚举类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameSizeType {
+    Discrete   = 1,
+    Continuous = 2,
+    Stepwise   = 3,
+}
+
+impl FrameSizeType {
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            1 => Self::Discrete,
+            2 => Self::Continuous,
+            3 => Self::Stepwise,
+            _ => return None,
+        })
+    }
+}
+
+// ========================================================================
+// 帧间隔枚举（v4l2_frmivalenum）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FrmivalStepwise {
+    pub min: Fract,
+    pub max: Fract,
+    pub step: Fract,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union FrmivalUnion {
+    pub discrete: Fract,
+    pub stepwise: FrmivalStepwise,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FrameIntervalEnum {
+    pub index: u32,             // [in] 帧间隔索引
+    pub pixel_format: u32,      // [in] 像素格式（fourcc）
+    pub width: u32,             // [in] 帧宽度
+    pub height: u32,            // [in] 帧高度
+    pub ty: FrameIntervalType,  // [out] 帧间隔类型
+    pub interval: FrmivalUnion, // [out] 帧间隔（离散或步进）
+    pub reserved: [u32; 2],
+}
+
+/// 帧间隔枚举类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FrameIntervalType {
+    Discrete   = 1,
+    Continuous = 2,
+    Stepwise   = 3,
+}
+
+impl FrameIntervalType {
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            1 => Self::Discrete,
+            2 => Self::Continuous,
+            3 => Self::Stepwise,
+            _ => return None,
+        })
+    }
+}
+
+// ========================================================================
+// 叠加窗口（v4l2_window）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Window {
+    pub w: Rect,        // [inout] 窗口矩形
+    pub field: Field,   // [inout] 场顺序
+    pub chromakey: u32, // [inout] 色键（chroma key）颜色
+    /// __user *clips（裁剪矩形数组的用户态指针）
+    pub clips: usize, // [in] 指向 clip 数组的用户态指针
+    pub clipcount: u32, // [inout] clip 数量
+    /// __user *bitmap（位图用户态指针）
+    pub bitmap: usize, // [in] 指向位图（bitmap）的用户态指针
+    pub global_alpha: u8, // [inout] 全局 alpha 值
+}
+
+// ========================================================================
+// 格式联合体（v4l2_format）
+// ========================================================================
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct PixFormatMplane {
+    pub width: u32,       // [inout] 图像宽度（像素）
+    pub height: u32,      // [inout] 图像高度（像素）
+    pub pixelformat: u32, // [inout] FourCC 像素格式代码
+    pub field: u32,       // [inout] 场顺序
+    pub colorspace: u32,  // [inout] 图像的色彩空间
+    pub num_planes: u8,   // [inout] plane 数量
+    pub flags: u8,        // [out] 格式标志（V4L2_PIX_FMT_FLAG_*）
+    pub ycbcr_enc: u8,    // [inout] Y'CbCr 编码
+    pub hsv_enc: u8,      // [inout] HSV 编码
+    pub quantization: u8, // [inout] 量化范围
+    pub xfer_func: u8,    // [inout] 传输函数
+    pub reserved: [u8; 7],
+    pub plane_fmt: [PlanePixFormat; 8], // [inout] 每个 plane 的格式
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct PlanePixFormat {
+    pub sizeimage: u32,    // [inout] plane 大小（字节）
+    pub bytesperline: u32, // [inout] 每行字节数
+    pub reserved: [u16; 6],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SdrFormat {
+    pub pixelformat: u32, // [inout] FourCC 像素格式代码
+    pub buffersize: u32,  // [out] 最大缓冲区大小（字节）
+    pub reserved: [u8; 24],
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct MetaFormat {
+    pub dataformat: u32, // [inout] FourCC 数据格式代码
+    pub buffersize: u32, // [out] 最大缓冲区大小（字节）
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union FormatUnion {
+    pub pix: PixFormat,
+    pub pix_mp: PixFormatMplane,
+    pub win: Window,
+    pub sdr: SdrFormat,
+    pub meta: MetaFormat,
+    pub raw_data: [u8; 200],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct Format {
+    pub ty: BufType,      // [in] 缓冲区类型
+    pub fmt: FormatUnion, // [inout] 格式数据
+}

--- a/drivers/media/ax-media/src/interface/inout.rs
+++ b/drivers/media/ax-media/src/interface/inout.rs
@@ -1,0 +1,131 @@
+//! 视频输入与输出结构。
+//!
+//! Input、Output 及相关常量。
+
+use bitflags::bitflags;
+
+/// 视频标准 ID（64 位位掩码）。
+pub type StdId = u64;
+
+/// 视频输入。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Input {
+    pub index: u32,          // [in] 哪个输入
+    pub name: [u8; 32],      // [out] 标签
+    pub ty: InputType,       // [out] 输入类型
+    pub audioset: u32,       // [out] 关联的音频（位域）
+    pub tuner: u32,          // [out] 调谐器索引
+    pub std: StdId,          // [out] 支持的视频标准
+    pub status: InStatus,    // [out] 输入状态标志
+    pub capabilities: InCap, // [out] 输入能力
+    pub reserved: [u32; 3],
+}
+
+// ── 输入类型 ───────────────────────────────────────────────────────────
+
+/// 视频输入类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputType {
+    Tuner  = 1,
+    Camera = 2,
+    Touch  = 3,
+}
+
+impl InputType {
+    /// 尝试将原始 `u32` 转换为 [`InputType`]。
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            1 => Self::Tuner,
+            2 => Self::Camera,
+            3 => Self::Touch,
+            _ => return None,
+        })
+    }
+}
+
+// ── 输入状态标志 ───────────────────────────────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct InStatus: u32 {
+        const NO_POWER      = 0x0000_0001;
+        const NO_SIGNAL     = 0x0000_0002;
+        const NO_COLOR      = 0x0000_0004;
+        const HFLIP         = 0x0000_0010;
+        const VFLIP         = 0x0000_0020;
+        const NO_H_LOCK     = 0x0000_0100;
+        const COLOR_KILL    = 0x0000_0200;
+        const NO_V_LOCK     = 0x0000_0400;
+        const NO_STD_LOCK   = 0x0000_0800;
+        const NO_SYNC       = 0x0001_0000;
+        const NO_EQU        = 0x0002_0000;
+        const NO_CARRIER    = 0x0004_0000;
+        const MACROVISION   = 0x0100_0000;
+        const NO_ACCESS     = 0x0200_0000;
+        const VTR           = 0x0400_0000;
+    }
+}
+
+// ── 输入能力标志 ───────────────────────────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct InCap: u32 {
+        const DV_TIMINGS  = 0x0000_0002;
+        const STD         = 0x0000_0004;
+        const NATIVE_SIZE = 0x0000_0008;
+    }
+}
+
+/// 视频输出。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Output {
+    pub index: u32,           // [in] 哪个输出
+    pub name: [u8; 32],       // [out] 标签
+    pub ty: OutputType,       // [out] 输出类型
+    pub audioset: u32,        // [out] 关联的音频（位域）
+    pub modulator: u32,       // [out] 关联的调制器
+    pub std: StdId,           // [out] 支持的视频标准
+    pub capabilities: OutCap, // [out] 输出能力
+    pub reserved: [u32; 3],
+}
+
+// ── 输出类型 ──────────────────────────────────────────────────────────
+
+/// 视频输出类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputType {
+    Modulator        = 1,
+    Analog           = 2,
+    AnalogVgaOverlay = 3,
+}
+
+impl OutputType {
+    /// 尝试将原始 `u32` 转换为 [`OutputType`]。
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            1 => Self::Modulator,
+            2 => Self::Analog,
+            3 => Self::AnalogVgaOverlay,
+            _ => return None,
+        })
+    }
+}
+
+// ── 输出能力标志 ──────────────────────────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct OutCap: u32 {
+        const DV_TIMINGS  = 0x0000_0002;
+        const STD         = 0x0000_0004;
+        const NATIVE_SIZE = 0x0000_0008;
+    }
+}

--- a/drivers/media/ax-media/src/interface/legacy/audio.rs
+++ b/drivers/media/ax-media/src/interface/legacy/audio.rs
@@ -1,0 +1,36 @@
+//! 音频输入/输出结构。
+
+use bitflags::bitflags;
+
+/// 音频输入。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Audio {
+    pub index: u32,           // [in] 音频输入索引
+    pub name: [u8; 32],       // [out] 名称
+    pub capability: AudioCap, // [out] 音频能力
+    pub mode: u32,            // [inout] 音频模式
+    pub reserved: [u32; 2],
+}
+
+/// 音频输出。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AudioOut {
+    pub index: u32,           // [in] 音频输出索引
+    pub name: [u8; 32],       // [out] 名称
+    pub capability: AudioCap, // [out] 音频能力
+    pub mode: u32,            // [inout] 音频模式
+    pub reserved: [u32; 2],
+}
+
+// ── 音频能力标志 ───────────────────────────────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct AudioCap: u32 {
+        const STEREO = 0x0001;
+        const AVL    = 0x0002;
+    }
+}

--- a/drivers/media/ax-media/src/interface/legacy/codec.rs
+++ b/drivers/media/ax-media/src/interface/legacy/codec.rs
@@ -1,0 +1,150 @@
+//! 编码器/解码器命令结构。
+
+use bitflags::bitflags;
+
+// ── 编码器索引 ────────────────────────────────────────────────────
+
+pub const ENC_IDX_ENTRIES: usize = 64;
+
+/// 编码器索引条目。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EncIndexEntry {
+    pub offset: u64, // [out] 帧在流中的偏移
+    pub pts: u64,    // [out] 帧的 PTS 时间戳
+    pub length: u32, // [out] 帧长度
+    pub flags: u32,  // [out] 帧类型（EncIdxFrame 值）
+    pub reserved: [u32; 2],
+}
+
+/// 编码器索引帧类型 — `V4L2_ENC_IDX_FRAME_*`。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncIdxFrame {
+    I = 0,
+    P = 1,
+    B = 2,
+}
+
+/// 编码器索引。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EncIndex {
+    pub entries: u32,     // [out] 条目数量
+    pub entries_cap: u32, // [out] 条目容量
+    pub reserved: [u32; 4],
+    pub entry: [EncIndexEntry; ENC_IDX_ENTRIES],
+}
+
+// ── 编码器命令 ────────────────────────────────────────────────────
+
+/// 编码器命令 — `V4L2_ENC_CMD_*`。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EncCmd {
+    Start  = 0,
+    Stop   = 1,
+    Pause  = 2,
+    Resume = 3,
+}
+
+bitflags! {
+    /// 编码器命令标志 — `V4L2_ENC_CMD_STOP_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct EncCmdFlags: u32 {
+        const STOP_AT_GOP_END = 1 << 0;
+    }
+}
+
+/// 编码器命令。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct EncoderCmd {
+    pub cmd: EncCmd,        // [in] 命令
+    pub flags: EncCmdFlags, // [in] 命令标志
+    pub data: [u32; 8],     // [inout] 命令数据
+}
+
+// ── 解码器命令 ────────────────────────────────────────────────────
+
+/// 解码器命令 — `V4L2_DEC_CMD_*`。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DecCmd {
+    Start  = 0,
+    Stop   = 1,
+    Pause  = 2,
+    Resume = 3,
+    Flush  = 4,
+}
+
+bitflags! {
+    /// 解码器命令标志 — `V4L2_DEC_CMD_START_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct DecStartFlags: u32 {
+        const MUTE_AUDIO = 1 << 0;
+    }
+}
+
+bitflags! {
+    /// 解码器命令标志 — `V4L2_DEC_CMD_PAUSE_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct DecPauseFlags: u32 {
+        const TO_BLACK = 1 << 0;
+    }
+}
+
+bitflags! {
+    /// 解码器命令标志 — `V4L2_DEC_CMD_STOP_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct DecStopFlags: u32 {
+        const TO_BLACK     = 1 << 0;
+        const IMMEDIATELY  = 1 << 1;
+    }
+}
+
+/// 解码器 STOP 参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DecStop {
+    pub pts: u64,
+}
+
+/// 解码器 START 参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DecStart {
+    pub speed: i32,
+    pub format: u32,
+}
+
+/// 解码器载荷联合。
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union DecoderPayload {
+    pub stop: DecStop,
+    pub start: DecStart,
+    pub raw: [u32; 16],
+}
+
+impl core::fmt::Debug for DecoderPayload {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // 按原始 64 字节打印，不解引用具体语义字段。
+        f.debug_tuple("DecoderPayload")
+            .field(&unsafe { self.raw })
+            .finish()
+    }
+}
+
+/// 解码器命令。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct DecoderCmd {
+    pub cmd: DecCmd,             // [in] 命令
+    pub flags: u32,              // [in] 命令标志（按命令解释为对应位集）
+    pub payload: DecoderPayload, // [inout] 命令载荷
+}

--- a/drivers/media/ax-media/src/interface/legacy/debug.rs
+++ b/drivers/media/ax-media/src/interface/legacy/debug.rs
@@ -1,0 +1,88 @@
+//! 调试寄存器结构。
+
+use bitflags::bitflags;
+
+/// 芯片匹配类型 — `V4L2_CHIP_MATCH_*`。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChipMatch {
+    Bridge = 0,
+    Subdev = 4,
+}
+
+impl ChipMatch {
+    /// 尝试将原始 `u32` 转换为 [`ChipMatch`]。
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            0 => Self::Bridge,
+            4 => Self::Subdev,
+            _ => return None,
+        })
+    }
+}
+
+/// 芯片匹配值联合。
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union DbgMatchValue {
+    pub addr: u32,
+    pub name: [u8; 32],
+}
+
+impl core::fmt::Debug for DbgMatchValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // 拷贝到局部变量以避免对 packed 结构字段的未对齐引用。
+        let addr = unsafe { self.addr };
+        f.debug_tuple("DbgMatchValue").field(&addr).finish()
+    }
+}
+
+/// 芯片匹配信息。
+#[repr(C, packed)]
+#[derive(Clone, Copy)]
+pub struct DbgMatch {
+    pub ty: ChipMatch, // [in] 匹配类型
+    pub value: DbgMatchValue,
+}
+
+impl core::fmt::Debug for DbgMatch {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // 拷贝到局部变量以避免对 packed 结构字段的未对齐引用。
+        let ty = self.ty;
+        let addr = unsafe { self.value.addr };
+        f.debug_struct("DbgMatch")
+            .field("ty", &ty)
+            .field("addr", &addr)
+            .finish()
+    }
+}
+
+/// 调试寄存器访问。
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct DbgRegister {
+    pub match_: DbgMatch, // [in] 芯片匹配
+    pub size: u32,        // [in] 寄存器大小（字节）
+    pub reg: u64,         // [in] 寄存器地址
+    pub val: u64,         // [inout] 寄存器值
+}
+
+bitflags! {
+    /// 芯片标志 — `V4L2_CHIP_FL_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ChipFlags: u32 {
+        const READABLE  = 1 << 0;
+        const WRITABLE  = 1 << 1;
+    }
+}
+
+/// 芯片信息。
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+pub struct DbgChipInfo {
+    pub match_: DbgMatch, // [in] 芯片匹配
+    pub name: [u8; 32],   // [out] 芯片名称
+    pub flags: ChipFlags, // [out] 芯片能力
+    pub reserved: [u32; 32],
+}

--- a/drivers/media/ax-media/src/interface/legacy/framebuffer.rs
+++ b/drivers/media/ax-media/src/interface/legacy/framebuffer.rs
@@ -1,0 +1,60 @@
+//! Overlay 帧缓冲结构。
+
+use bitflags::bitflags;
+
+/// 帧缓冲像素格式。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FbufFormat {
+    pub width: u32,
+    pub height: u32,
+    pub pixelformat: u32,
+    pub field: u32,
+    pub bytesperline: u32,
+    pub sizeimage: u32,
+    pub colorspace: u32,
+    pub priv_: u32,
+}
+
+/// 帧缓冲。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Framebuffer {
+    pub capability: FbufCap, // [out] 帧缓冲能力（只读）
+    pub flags: FbufFlags,    // [inout] 帧缓冲标志
+    pub base: usize,         // [in] 帧缓冲物理地址
+    pub fmt: FbufFormat,     // [inout] 帧缓冲像素格式
+}
+
+// ── 帧缓冲能力标志 ─────────────────────────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct FbufCap: u32 {
+        const EXTERN_OVERLAY   = 0x0001;
+        const CHROMAKEY        = 0x0002;
+        const BITMAP_CLIPPING  = 0x0004;
+        const LIST_CLIPPING    = 0x0008;
+        const LOCAL_ALPHA      = 0x0010;
+        const GLOBAL_ALPHA     = 0x0020;
+        const LOCAL_INV_ALPHA  = 0x0040;
+        const SRC_CHROMAKEY    = 0x0080;
+    }
+}
+
+// ── 帧缓冲标志 ─────────────────────────────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct FbufFlags: u32 {
+        const PRIMARY         = 0x0001;
+        const OVERLAY         = 0x0002;
+        const CHROMAKEY       = 0x0004;
+        const LOCAL_ALPHA     = 0x0008;
+        const GLOBAL_ALPHA    = 0x0010;
+        const LOCAL_INV_ALPHA = 0x0020;
+        const SRC_CHROMAKEY   = 0x0040;
+    }
+}

--- a/drivers/media/ax-media/src/interface/legacy/jpegcomp.rs
+++ b/drivers/media/ax-media/src/interface/legacy/jpegcomp.rs
@@ -1,0 +1,30 @@
+//! JPEG 压缩结构。
+
+use bitflags::bitflags;
+
+/// JPEG 压缩参数。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct JpegCompression {
+    pub quality: i32,              // [inout] 质量
+    pub appn: i32,                 // [in] APP 段编号（0..15）
+    pub app_len: i32,              // [in] APP 段数据长度
+    pub app_data: [u8; 60],        // [in] APP 段数据
+    pub com_len: i32,              // [in] COM 段数据长度
+    pub com_data: [u8; 60],        // [in] COM 段数据
+    pub jpeg_markers: JpegMarkers, // [in] 哪些标记写入 JPEG 输出
+}
+
+// ── JPEG 标记标志 — `V4L2_JPEG_MARKER_*` ─────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct JpegMarkers: u32 {
+        const DHT  = 1 << 3;
+        const DQT  = 1 << 4;
+        const DRI  = 1 << 5;
+        const COM  = 1 << 6;
+        const APP  = 1 << 7;
+    }
+}

--- a/drivers/media/ax-media/src/interface/legacy/mod.rs
+++ b/drivers/media/ax-media/src/interface/legacy/mod.rs
@@ -1,0 +1,11 @@
+//! 遗留接口类型。
+
+pub mod audio;
+pub mod codec;
+pub mod debug;
+pub mod framebuffer;
+pub mod jpegcomp;
+pub mod modulator;
+pub mod standard;
+pub mod tuner;
+pub mod vbi;

--- a/drivers/media/ax-media/src/interface/legacy/modulator.rs
+++ b/drivers/media/ax-media/src/interface/legacy/modulator.rs
@@ -1,0 +1,17 @@
+//! 调制器结构。
+
+use crate::interface::legacy::tuner::{TunerCap, TunerType};
+
+/// 调制器。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Modulator {
+    pub index: u32,           // [in] 调制器索引
+    pub name: [u8; 32],       // [out] 名称
+    pub capability: TunerCap, // [out] 调制器能力
+    pub rangelow: u32,        // [out] 最低频率
+    pub rangehigh: u32,       // [out] 最高频率
+    pub txsubchans: u32,      // [out] 发送子信道
+    pub ty: TunerType,        // [out] 调谐器类型
+    pub reserved: [u32; 3],
+}

--- a/drivers/media/ax-media/src/interface/legacy/standard.rs
+++ b/drivers/media/ax-media/src/interface/legacy/standard.rs
@@ -1,0 +1,15 @@
+//! 模拟电视标准结构。
+
+use crate::interface::{Fract, inout::StdId};
+
+/// 视频标准描述。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Standard {
+    pub index: u32,         // [in] 标准索引
+    pub id: StdId,          // [out] 视频标准 ID
+    pub name: [u8; 24],     // [out] 标准名称
+    pub frameperiod: Fract, // [out] 帧周期（帧，非场）
+    pub framelines: u32,    // [out] 每帧行数
+    pub reserved: [u32; 4],
+}

--- a/drivers/media/ax-media/src/interface/legacy/tuner.rs
+++ b/drivers/media/ax-media/src/interface/legacy/tuner.rs
@@ -1,0 +1,143 @@
+//! 调谐器结构。
+
+use bitflags::bitflags;
+
+// ── 调谐器类型 ─────────────────────────────────────────────────────
+
+/// 调谐器类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TunerType {
+    Radio     = 1,
+    AnalogTv  = 2,
+    DigitalTv = 3,
+    Sdr       = 4,
+    Rf        = 5,
+}
+
+impl TunerType {
+    /// 尝试将原始 `u32` 转换为 [`TunerType`]。
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            1 => Self::Radio,
+            2 => Self::AnalogTv,
+            3 => Self::DigitalTv,
+            4 => Self::Sdr,
+            5 => Self::Rf,
+            _ => return None,
+        })
+    }
+}
+
+/// 调谐器。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Tuner {
+    pub index: u32,                // [in] 调谐器索引
+    pub name: [u8; 32],            // [out] 名称
+    pub ty: TunerType,             // [out] 调谐器类型
+    pub capability: TunerCap,      // [out] 调谐器能力
+    pub rangelow: u32,             // [out] 最低频率（Hz 或 kHz，取决于 LOW）
+    pub rangehigh: u32,            // [out] 最高频率
+    pub rxsubchans: TunerSubchans, // [out] 子信道
+    pub audmode: u32,              // [in] 音频模式（V4L2_TUNER_MODE_* 值）
+    pub signal: i32,               // [out] 信号强度
+    pub afc: i32,                  // [out] AFC 自动频率控制
+    pub reserved: [u32; 4],
+}
+
+bitflags! {
+    /// 调谐器能力标志 — `V4L2_TUNER_CAP_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct TunerCap: u32 {
+        const LOW              = 0x0001;
+        const NORM             = 0x0002;
+        const HWSEEK_BOUNDED   = 0x0004;
+        const HWSEEK_WRAP      = 0x0008;
+        const STEREO           = 0x0010;
+        const LANG2            = 0x0020;
+        const SAP              = 0x0020;
+        const LANG1            = 0x0040;
+        const RDS              = 0x0080;
+        const RDS_BLOCK_IO     = 0x0100;
+        const RDS_CONTROLS     = 0x0200;
+        const FREQ_BANDS       = 0x0400;
+        const HWSEEK_PROG_LIM  = 0x0800;
+        const HZ               = 0x1000;
+    }
+}
+
+bitflags! {
+    /// 子信道标志 — `V4L2_TUNER_SUB_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct TunerSubchans: u32 {
+        const MONO   = 0x0001;
+        const STEREO = 0x0002;
+        const LANG2  = 0x0004;
+        const SAP    = 0x0004;
+        const LANG1  = 0x0008;
+        const RDS    = 0x0010;
+    }
+}
+
+/// 音频模式值 — `V4L2_TUNER_MODE_*`（值有重叠，仅作常量说明用）。
+#[allow(non_upper_case_globals)]
+pub mod tuner_mode {
+    pub const MONO: u32 = 0x0000;
+    pub const STEREO: u32 = 0x0001;
+    pub const LANG2: u32 = 0x0002;
+    pub const SAP: u32 = 0x0002;
+    pub const LANG1: u32 = 0x0003;
+    pub const LANG1_LANG2: u32 = 0x0004;
+}
+
+/// 频率。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Frequency {
+    pub tuner: u32,     // [in] 调谐器索引
+    pub ty: TunerType,  // [in] 调谐器类型
+    pub frequency: u32, // [inout] 频率（Hz 或 kHz）
+    pub reserved: [u32; 8],
+}
+
+bitflags! {
+    /// 频段调制方式 — `V4L2_BAND_MODULATION_*`。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct BandModulation: u32 {
+        const VSB = 1 << 1;
+        const FM  = 1 << 2;
+        const AM  = 1 << 3;
+    }
+}
+
+/// 频率频段。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct FrequencyBand {
+    pub tuner: u32,                 // [in] 调谐器索引
+    pub ty: TunerType,              // [in] 调谐器类型
+    pub index: u32,                 // [in] 频段索引
+    pub capability: TunerCap,       // [out] 频段能力
+    pub rangelow: u32,              // [out] 最低频率
+    pub rangehigh: u32,             // [out] 最高频率
+    pub modulation: BandModulation, // [out] 调制方式
+    pub reserved: [u32; 9],
+}
+
+/// 硬件频率搜索请求。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct HwFreqSeek {
+    pub tuner: u32,       // [in] 调谐器索引
+    pub ty: TunerType,    // [in] 调谐器类型
+    pub seek_upward: u32, // [in] 向上搜索（否则向下）
+    pub wrap_around: u32, // [in] 到达边界后回绕
+    pub spacing: u32,     // [in] 搜索步进
+    pub rangelow: u32,    // [in] 最低频率限制
+    pub rangehigh: u32,   // [in] 最高频率限制
+    pub reserved: [u32; 5],
+}

--- a/drivers/media/ax-media/src/interface/legacy/vbi.rs
+++ b/drivers/media/ax-media/src/interface/legacy/vbi.rs
@@ -1,0 +1,26 @@
+//! Sliced VBI 能力结构。
+
+use bitflags::bitflags;
+
+/// Sliced VBI 能力。
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct SlicedVbiCap {
+    pub service_set: VbiService,       // [out] 支持的服务集（位掩码）
+    pub service_lines: [[u16; 24]; 2], // [out] 每场的服务行
+    pub ty: u32,                       // [in] BufType 枚举
+    pub reserved: [u32; 3],
+}
+
+// ── Sliced VBI 服务标志 — `V4L2_SLICED_*` ─────────────────────────
+
+bitflags! {
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct VbiService: u16 {
+        const TELETEXT_B  = 0x0001;
+        const VPS         = 0x0400;
+        const CAPTION_525 = 0x1000;
+        const WSS_625     = 0x4000;
+    }
+}

--- a/drivers/media/ax-media/src/interface/mod.rs
+++ b/drivers/media/ax-media/src/interface/mod.rs
@@ -1,0 +1,360 @@
+pub mod buffer;
+pub mod capability;
+pub mod colorspace;
+pub mod crop;
+pub mod ctrl;
+pub mod dv;
+pub mod edid;
+pub mod event;
+pub mod format;
+pub mod inout;
+pub mod legacy;
+pub mod stream;
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Rect {
+    pub left: i32,
+    pub top: i32,
+    pub width: u32,
+    pub height: u32,
+}
+
+/// 分数（分子/分母）。
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct Fract {
+    pub numerator: u32,
+    pub denominator: u32,
+}
+
+impl Fract {
+    /// 创建新的 `Fract`，指定分子和分母。
+    pub const fn new(numerator: u32, denominator: u32) -> Self {
+        Self {
+            numerator,
+            denominator,
+        }
+    }
+
+    /// 使用连分数化简当前分数。
+    pub fn simplify(&mut self) {
+        let mut an = [0u32; 8];
+        let mut x = self.numerator;
+        let mut y = self.denominator;
+        let mut n: usize = 0;
+        while n < 8 && y != 0 {
+            an[n] = x / y;
+            if an[n] >= 333 {
+                if n < 2 {
+                    n += 1;
+                }
+                break;
+            }
+            let r = x - an[n] * y;
+            x = y;
+            y = r;
+            n += 1;
+        }
+        // 回展为整数分数，固定 8 项无需堆分配。
+        let mut exp_x: u32 = 0;
+        let mut exp_y: u32 = 1;
+        for i in (0..n).rev() {
+            let r = exp_y;
+            // 展开时用 u64 避免溢出，超出则截断到 u32::MAX。
+            let tmp = (an[i] as u64) * (exp_y as u64) + (exp_x as u64);
+            exp_y = if tmp > u32::MAX as u64 {
+                u32::MAX
+            } else {
+                tmp as u32
+            };
+            exp_x = r;
+        }
+        self.numerator = exp_y;
+        self.denominator = exp_x;
+    }
+
+    /// 从 `dwFrameInterval`（100ns 单位）创建 `Fract`。
+    ///
+    /// 等价于 `interval / 10_000_000` 再经 [`Self::simplify`] 化简，
+    pub fn from_interval(interval: u32) -> Self {
+        let mut f = Self {
+            numerator: interval,
+            denominator: 10_000_000,
+        };
+        f.simplify();
+        f
+    }
+
+    /// 将本 `Fract`（timeperframe）转换为 `dwFrameInterval`（100ns 单位）。
+    pub fn to_interval(self) -> u32 {
+        // 分母为 0 或换算会溢出时饱和到 u32::MAX。
+        if self.denominator == 0 || self.numerator / self.denominator >= u32::MAX / 10_000_000 {
+            return u32::MAX;
+        }
+        let mut multiplier: u32 = 10_000_000;
+        let mut denom = self.denominator;
+        let numer = self.numerator;
+        while numer > u32::MAX / multiplier {
+            multiplier /= 2;
+            denom /= 2;
+        }
+        if denom == 0 {
+            return 0;
+        }
+        numer * multiplier / denom
+    }
+}
+
+/// 场顺序。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Field {
+    Any          = 0, // 驱动可在无、顶场、底场、隔行中自行选择
+    NoField      = 1, // 该设备没有场
+    Top          = 2, // 仅顶场
+    Bottom       = 3, // 仅底场
+    Interlaced   = 4, // 两场隔行
+    SeqTb        = 5, // 两场顺序，先顶后底
+    SeqBt        = 6, // 两场顺序，先底后顶
+    Alternate    = 7, // 两场交替放入独立的缓冲区
+    InterlacedTb = 8, // 两场隔行，顶场在前，先传输顶场
+    InterlacedBt = 9, // 两场隔行，顶场在前，先传输底场
+}
+
+impl Field {
+    /// 若该 Field 包含顶场则返回 true。
+    pub const fn has_top(self) -> bool {
+        matches!(
+            self,
+            Self::Top
+                | Self::Interlaced
+                | Self::InterlacedTb
+                | Self::InterlacedBt
+                | Self::SeqTb
+                | Self::SeqBt
+        )
+    }
+
+    /// 若该 Field 包含底场则返回 true。
+    pub const fn has_bottom(self) -> bool {
+        matches!(
+            self,
+            Self::Bottom
+                | Self::Interlaced
+                | Self::InterlacedTb
+                | Self::InterlacedBt
+                | Self::SeqTb
+                | Self::SeqBt
+        )
+    }
+
+    /// 若该 Field 是隔行则返回 true。
+    pub const fn is_interlaced(self) -> bool {
+        matches!(
+            self,
+            Self::Interlaced | Self::InterlacedTb | Self::InterlacedBt
+        )
+    }
+
+    /// 若该 Field 是顺序则返回 true。
+    pub const fn is_sequential(self) -> bool {
+        matches!(self, Self::SeqTb | Self::SeqBt)
+    }
+}
+
+/// 缓冲区 / 流类型。
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BufType {
+    VideoCapture       = 1,
+    VideoOutput        = 2,
+    VideoOverlay       = 3,
+    VbiCapture         = 4,
+    VbiOutput          = 5,
+    SlicedVbiCapture   = 6,
+    SlicedVbiOutput    = 7,
+    VideoOutputOverlay = 8,
+    VideoCaptureMplane = 9,
+    VideoOutputMplane  = 10,
+    SdrCapture         = 11,
+    SdrOutput          = 12,
+    MetaCapture        = 13,
+    MetaOutput         = 14,
+    Private            = 0x80,
+}
+
+impl BufType {
+    pub const fn is_valid(self) -> bool {
+        matches!(
+            self,
+            Self::VideoCapture
+                | Self::VideoOutput
+                | Self::VideoOverlay
+                | Self::VbiCapture
+                | Self::VbiOutput
+                | Self::SlicedVbiCapture
+                | Self::SlicedVbiOutput
+                | Self::VideoOutputOverlay
+                | Self::VideoCaptureMplane
+                | Self::VideoOutputMplane
+                | Self::SdrCapture
+                | Self::SdrOutput
+                | Self::MetaCapture
+                | Self::MetaOutput
+                | Self::Private
+        )
+    }
+
+    pub const fn is_multiplanar(self) -> bool {
+        matches!(self, Self::VideoCaptureMplane | Self::VideoOutputMplane)
+    }
+
+    pub const fn is_output(self) -> bool {
+        matches!(
+            self,
+            Self::VideoOutput
+                | Self::VideoOutputMplane
+                | Self::VideoOutputOverlay
+                | Self::VbiOutput
+                | Self::SlicedVbiOutput
+                | Self::SdrOutput
+                | Self::MetaOutput
+        )
+    }
+
+    pub const fn is_capture(self) -> bool {
+        self.is_valid() && !self.is_output()
+    }
+
+    /// 尝试将原始 u32 值转换为 [`BufType`]。
+    ///
+    /// 若该值不对应任何已知变体，则返回 `None`。
+    pub fn try_from_u32(v: u32) -> Option<Self> {
+        Some(match v {
+            1 => Self::VideoCapture,
+            2 => Self::VideoOutput,
+            3 => Self::VideoOverlay,
+            4 => Self::VbiCapture,
+            5 => Self::VbiOutput,
+            6 => Self::SlicedVbiCapture,
+            7 => Self::SlicedVbiOutput,
+            8 => Self::VideoOutputOverlay,
+            9 => Self::VideoCaptureMplane,
+            10 => Self::VideoOutputMplane,
+            11 => Self::SdrCapture,
+            12 => Self::SdrOutput,
+            13 => Self::MetaCapture,
+            14 => Self::MetaOutput,
+            0x80 => Self::Private,
+            _ => return None,
+        })
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Timeval {
+    pub tv_sec: i64,
+    pub tv_usec: i64,
+}
+
+/// 内核 timespec — 与 64 位系统上的 `struct __kernel_timespec` 一致（16 字节）。
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Timespec {
+    pub tv_sec: i64,
+    pub tv_nsec: i64,
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Timecode {
+    pub ty: u32,
+    pub flags: u32,
+    pub frames: u8,
+    pub seconds: u8,
+    pub minutes: u8,
+    pub hours: u8,
+    pub userbits: [u8; 4],
+}
+
+#[cfg(test)]
+mod abi_tests {
+    use super::{
+        buffer::{Buffer, Exportbuffer, Requestbuffers},
+        capability::Capability,
+        crop::{Crop, Cropcap, Selection},
+        ctrl::{Control, ExtControl, QueryCtrl, Querymenu},
+        event::{Event, EventSubscription},
+        format::{Fmtdesc, Format, FrameIntervalEnum, FrameSizeEnum},
+        inout::{Input, Output},
+        stream::StreamParm,
+    };
+    use crate::interface::{
+        dv::{BtTimings, BtTimingsCap, DvTimings, DvTimingsCap, EnumDvTimings},
+        edid::Edid,
+        format::FmtFlag,
+        legacy::{
+            audio::{Audio, AudioOut},
+            codec::{DecoderCmd, EncIndex, EncoderCmd},
+            debug::{DbgChipInfo, DbgMatch, DbgRegister},
+            framebuffer::Framebuffer,
+            jpegcomp::JpegCompression,
+            modulator::Modulator,
+            standard::Standard,
+            tuner::{Frequency, FrequencyBand, HwFreqSeek, Tuner},
+            vbi::SlicedVbiCap,
+        },
+    };
+
+    #[test]
+    fn abi_sizes_match_linux() {
+        // 核心 UAPI 结构（RISC-V 64 / x86_64，packed）
+        assert_eq!(core::mem::size_of::<Capability>(), 104);
+        assert_eq!(core::mem::size_of::<Fmtdesc>(), 64);
+        assert_eq!(core::mem::size_of::<FrameSizeEnum>(), 44);
+        assert_eq!(core::mem::size_of::<FrameIntervalEnum>(), 52);
+        assert_eq!(core::mem::size_of::<Format>(), 208);
+        assert_eq!(core::mem::size_of::<Requestbuffers>(), 20);
+        assert_eq!(core::mem::size_of::<Buffer>(), 88);
+        assert_eq!(core::mem::size_of::<Exportbuffer>(), 64);
+        assert_eq!(core::mem::size_of::<Cropcap>(), 44);
+        assert_eq!(core::mem::size_of::<Crop>(), 20);
+        assert_eq!(core::mem::size_of::<Selection>(), 64);
+        assert_eq!(core::mem::size_of::<Control>(), 8);
+        assert_eq!(core::mem::size_of::<ExtControl>(), 20);
+        assert_eq!(core::mem::size_of::<QueryCtrl>(), 68);
+        assert_eq!(core::mem::size_of::<Querymenu>(), 44);
+        assert_eq!(core::mem::size_of::<Input>(), 80);
+        assert_eq!(core::mem::size_of::<Output>(), 72);
+        assert_eq!(core::mem::size_of::<StreamParm>(), 204);
+        assert_eq!(core::mem::size_of::<EventSubscription>(), 32);
+        assert_eq!(core::mem::size_of::<Event>(), 136);
+        assert_eq!(core::mem::size_of::<FmtFlag>(), 4);
+        // 遗留/编解码/调谐等（与 videodev2.h / v4l2-common.h 一致）
+        assert_eq!(core::mem::size_of::<Framebuffer>(), 48);
+        assert_eq!(core::mem::size_of::<Standard>(), 72);
+        assert_eq!(core::mem::size_of::<Tuner>(), 84);
+        assert_eq!(core::mem::size_of::<Modulator>(), 68);
+        assert_eq!(core::mem::size_of::<Frequency>(), 44);
+        assert_eq!(core::mem::size_of::<FrequencyBand>(), 64);
+        assert_eq!(core::mem::size_of::<HwFreqSeek>(), 48);
+        assert_eq!(core::mem::size_of::<Audio>(), 52);
+        assert_eq!(core::mem::size_of::<AudioOut>(), 52);
+        assert_eq!(core::mem::size_of::<JpegCompression>(), 140);
+        assert_eq!(core::mem::size_of::<SlicedVbiCap>(), 116);
+        assert_eq!(core::mem::size_of::<EncIndex>(), 2072);
+        assert_eq!(core::mem::size_of::<EncoderCmd>(), 40);
+        assert_eq!(core::mem::size_of::<DecoderCmd>(), 72);
+        assert_eq!(core::mem::size_of::<DbgMatch>(), 36);
+        assert_eq!(core::mem::size_of::<DbgRegister>(), 56);
+        assert_eq!(core::mem::size_of::<DbgChipInfo>(), 200);
+        assert_eq!(core::mem::size_of::<BtTimings>(), 124);
+        assert_eq!(core::mem::size_of::<DvTimings>(), 132);
+        assert_eq!(core::mem::size_of::<EnumDvTimings>(), 148);
+        assert_eq!(core::mem::size_of::<BtTimingsCap>(), 104);
+        assert_eq!(core::mem::size_of::<DvTimingsCap>(), 144);
+        assert_eq!(core::mem::size_of::<Edid>(), 40);
+    }
+}

--- a/drivers/media/ax-media/src/interface/stream.rs
+++ b/drivers/media/ax-media/src/interface/stream.rs
@@ -1,0 +1,63 @@
+// === 采集 / 输出参数 ===
+
+use bitflags::bitflags;
+
+use crate::interface::{BufType, Fract};
+
+bitflags! {
+    /// 流参数能力标志。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct StreamParmCap: u32 {
+        /// `timeperframe` 字段有效。
+        const TIMEPERFRAME = 0x1000;
+    }
+
+    /// 流参数模式标志。
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct StreamParmMode: u32 {
+        /// 高质量模式。
+        const HIGHQUALITY = 0x0001;
+    }
+}
+
+/// 采集参数
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct CaptureParm {
+    pub capability: StreamParmCap,   // [out] 支持的模式
+    pub capturemode: StreamParmMode, // [inout] 当前模式
+    pub timeperframe: Fract,         // [inout] 每帧时间（秒）
+    pub extendedmode: u32,           // [inout] 驱动特有扩展
+    pub readbuffers: u32,            // [out] 用于读取的缓冲区数量
+    pub reserved: [u32; 4],
+}
+
+/// 输出参数
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct OutputParm {
+    pub capability: StreamParmCap,  // [out] 支持的模式
+    pub outputmode: StreamParmMode, // [inout] 当前模式
+    pub timeperframe: Fract,        // [inout] 每帧时间（秒）
+    pub extendedmode: u32,          // [inout] 驱动特有扩展
+    pub writebuffers: u32,          // [out] 用于写入的缓冲区数量
+    pub reserved: [u32; 4],
+}
+
+/// 流参数（与类型相关）。
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct StreamParm {
+    pub ty: BufType,           // [in] 缓冲区类型
+    pub parm: StreamParmUnion, // [inout] 流参数
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub union StreamParmUnion {
+    pub capture: CaptureParm,
+    pub output: OutputParm,
+    pub raw_data: [u8; 200],
+}

--- a/drivers/media/ax-media/src/ioctl/define.rs
+++ b/drivers/media/ax-media/src/ioctl/define.rs
@@ -1,0 +1,274 @@
+use crate::interface::{
+    buffer::{Buffer, CreateBuffers, Exportbuffer, RemoveBuffers, Requestbuffers},
+    capability::Capability,
+    crop::{Crop, Cropcap, Selection},
+    ctrl::{Control, ExtControls, QueryCtrl, QueryExtCtrl, Querymenu},
+    dv::{DvTimings, DvTimingsCap, EnumDvTimings},
+    edid::Edid,
+    event::{Event, EventSubscription},
+    format::{Fmtdesc, Format, FrameIntervalEnum, FrameSizeEnum},
+    inout::{Input, Output, StdId},
+    legacy::{
+        audio::{Audio, AudioOut},
+        codec::{DecoderCmd, EncIndex, EncoderCmd},
+        debug::{DbgChipInfo, DbgRegister},
+        framebuffer::Framebuffer,
+        jpegcomp::JpegCompression,
+        modulator::Modulator,
+        standard::Standard,
+        tuner::{Frequency, FrequencyBand, HwFreqSeek, Tuner},
+        vbi::SlicedVbiCap,
+    },
+    stream::StreamParm,
+};
+
+// ── IOCTL 编码 ───────────────────────────────────────
+
+const DIR_WRITE: u32 = 1;
+const DIR_READ: u32 = 2;
+const DIRSHIFT: u32 = 30;
+const VT: u8 = b'V';
+
+const fn io(nr: u8) -> u32 {
+    ((VT as u32) << 8) | (nr as u32)
+}
+const fn ior(nr: u8, size: u32) -> u32 {
+    (DIR_READ << DIRSHIFT) | ((VT as u32) << 8) | (nr as u32) | (size << 16)
+}
+const fn iow(nr: u8, size: u32) -> u32 {
+    (DIR_WRITE << DIRSHIFT) | ((VT as u32) << 8) | (nr as u32) | (size << 16)
+}
+const fn iowr(nr: u8, size: u32) -> u32 {
+    ((DIR_READ | DIR_WRITE) << DIRSHIFT) | ((VT as u32) << 8) | (nr as u32) | (size << 16)
+}
+
+// ── 命令枚举 ────────────────────────────────────────────────────────
+
+macro_rules! ioctl_defs {
+    ($name:ident, $(($variant:ident, $dir:ident, $nr:expr, $ty:ty)),* $(,)?) => {
+        /// V4L2 ioctl 命令。
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[repr(u32)]
+        pub enum $name {
+            $($variant = ioctl_defs!(@val $dir, $nr, $ty),)*
+        }
+
+        impl $name {
+            pub const COUNT: usize = [$(Self::$variant),*].len();
+            pub const ALL: [$name; $name::COUNT] = [$(Self::$variant),*];
+
+            pub fn try_from_u32(cmd: u32) -> Option<Self> {
+                Some(match cmd {
+                    $(c if c == Self::$variant as u32 => Self::$variant,)*
+                    _ => return None,
+                })
+            }
+        }
+    };
+    (@val io, $nr:expr, $ty:ty) => { io($nr) };
+    (@val ior, $nr:expr, $ty:ty) => { ior($nr, core::mem::size_of::<$ty>() as u32) };
+    (@val iow, $nr:expr, $ty:ty) => { iow($nr, core::mem::size_of::<$ty>() as u32) };
+    (@val iowr, $nr:expr, $ty:ty) => { iowr($nr, core::mem::size_of::<$ty>() as u32) };
+}
+
+// 现代 V4L2 ioctl 命令（47 个）。
+ioctl_defs!(
+    IoctlCmd,
+    // ── 查询与枚举 ──────────────────────────────────────────
+    (QueryCap, ior, 0, Capability),
+    (EnumFmt, iowr, 2, Fmtdesc),
+    (EnumFrameSizes, iowr, 74, FrameSizeEnum),
+    (EnumFrameIntervals, iowr, 75, FrameIntervalEnum),
+    // ── 格式协商 ───────────────────────────────────────────
+    (GFmt, iowr, 4, Format),
+    (SFmt, iowr, 5, Format),
+    (TryFmt, iowr, 64, Format),
+    // ── 缓冲区管理 ────────────────────────────────────────────
+    (ReqBufs, iowr, 8, Requestbuffers),
+    (QueryBuf, iowr, 9, Buffer),
+    (QBuf, iowr, 15, Buffer),
+    (DQBuf, iowr, 17, Buffer),
+    (PrepareBuf, iowr, 93, Buffer),
+    (CreateBufs, iowr, 92, CreateBuffers),
+    (RemoveBufs, iowr, 104, RemoveBuffers),
+    (ExpBuf, iowr, 16, Exportbuffer),
+    // ── 流式传输 ────────────────────────────────────────────────────
+    (StreamOn, iow, 18, i32),
+    (StreamOff, iow, 19, i32),
+    // ── 流参数 ─────────────────────────────────────────
+    (GParm, iowr, 21, StreamParm),
+    (SParm, iowr, 22, StreamParm),
+    // ── 优先级（core 层维护，device.rs 拦截） ──────────────
+    (GPriority, ior, 67, u32),
+    (SPriority, iow, 68, u32),
+    // ── 输入/输出选择 ─────────────────────────────────────
+    (EnumInput, iowr, 26, Input),
+    (GInput, ior, 38, i32),
+    (SInput, iowr, 39, i32),
+    (EnumOutput, iowr, 48, Output),
+    (GOutput, ior, 46, i32),
+    (SOutput, iowr, 47, i32),
+    // ── 控制 ─────────────────────────────────────────────────────
+    (QueryCtrl, iowr, 36, QueryCtrl),
+    (QueryExtCtrl, iowr, 103, QueryExtCtrl),
+    (GExtCtrls, iowr, 71, ExtControls),
+    (SExtCtrls, iowr, 72, ExtControls),
+    (TryExtCtrls, iowr, 73, ExtControls),
+    (QueryMenu, iowr, 37, Querymenu),
+    // ── 裁剪 / Selection ─────────────────────────────────────────
+    (CropCap, iowr, 58, Cropcap),
+    (GSelection, iowr, 94, Selection),
+    (SSelection, iowr, 95, Selection),
+    // ── EDID ─────────────────────────────────────────────────────
+    (GEdid, iowr, 40, Edid),
+    (SEdid, iowr, 41, Edid),
+    // ── DV timings ───────────────────────────────────────────────
+    (SDvTimings, iowr, 87, DvTimings),
+    (GDvTimings, iowr, 88, DvTimings),
+    (EnumDvTimings, iowr, 98, EnumDvTimings),
+    (QueryDvTimings, ior, 99, DvTimings),
+    (DvTimingsCap, iowr, 100, DvTimingsCap),
+    // ── 日志 ─────────────────────────────────────────────────────
+    (LogStatus, io, 70, ()),
+    // ── 事件（device.rs 拦截路由到驱动回调） ──────────────────
+    (DQEvent, ior, 89, Event),
+    (SubscribeEvent, iow, 90, EventSubscription),
+    (UnsubscribeEvent, iow, 91, EventSubscription),
+);
+
+// 遗留 V4L2 ioctl 命令（36 个）
+ioctl_defs!(
+    LegacyIoctlCmd,
+    // ── G/S_CTRL ───────
+    (GCtrl, iowr, 27, Control),
+    (SCtrl, iowr, 28, Control),
+    // ── Overlay 帧缓冲 ──────────────────────────────────────
+    (GFbuf, ior, 10, Framebuffer),
+    (SFbuf, iow, 11, Framebuffer),
+    (Overlay, iow, 14, i32),
+    // ── 模拟电视标准 ───────────────────────────────────
+    (GStd, ior, 23, StdId),
+    (SStd, iow, 24, StdId),
+    (EnumStd, iowr, 25, Standard),
+    (QueryStd, ior, 63, StdId),
+    // ── Tuner/Radio ────────────────────────────────────
+    (GTuner, iowr, 29, Tuner),
+    (STuner, iow, 30, Tuner),
+    (GFrequency, iowr, 56, Frequency),
+    (SFrequency, iow, 57, Frequency),
+    (EnumFreqBands, iowr, 101, FrequencyBand),
+    (SHwFreqSeek, iow, 82, HwFreqSeek),
+    // ── 调制器 ─────────────────────────────────────────
+    (GModulator, iowr, 54, Modulator),
+    (SModulator, iow, 55, Modulator),
+    // ── 音频 I/O ───────────────────────────────────────
+    (GAudio, ior, 33, Audio),
+    (SAudio, iow, 34, Audio),
+    (EnumAudio, iowr, 65, Audio),
+    (GAudioOut, ior, 49, AudioOut),
+    (SAudioOut, iow, 50, AudioOut),
+    (EnumAudioOut, iowr, 66, AudioOut),
+    // ── 裁剪旧 API ─────────────────────────────────────
+    (GCrop, iowr, 59, Crop),
+    (SCrop, iow, 60, Crop),
+    // ── JPEG 压缩旧 API ────────────────────────────────
+    (GJpegComp, ior, 61, JpegCompression),
+    (SJpegComp, iow, 62, JpegCompression),
+    // ── Sliced VBI ─────────────────────────────────────
+    (GSlicedVbiCap, iowr, 69, SlicedVbiCap),
+    // ── Stateful codec ─────────────────────────────────
+    (GEncIndex, ior, 76, EncIndex),
+    (EncoderCmd, iowr, 77, EncoderCmd),
+    (TryEncoderCmd, iowr, 78, EncoderCmd),
+    (DecoderCmd, iowr, 96, DecoderCmd),
+    (TryDecoderCmd, iowr, 97, DecoderCmd),
+    // ── 调试 ───────────────────────────────────────────
+    (DbgSRegister, iow, 79, DbgRegister),
+    (DbgGRegister, iowr, 80, DbgRegister),
+    (DbgGChipInfo, iowr, 102, DbgChipInfo),
+);
+
+// ── 统一命令枚举（modern + legacy）──────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoIoctl {
+    Modern(IoctlCmd),
+    Legacy(LegacyIoctlCmd),
+}
+
+impl VideoIoctl {
+    /// 由原始 ioctl 命令号归一化；未知命令返回 `None`（对应 ENOTTY）。
+    pub fn try_from_u32(cmd: u32) -> Option<Self> {
+        IoctlCmd::try_from_u32(cmd)
+            .map(Self::Modern)
+            .or_else(|| LegacyIoctlCmd::try_from_u32(cmd).map(Self::Legacy))
+    }
+
+    /// 原始命令号。
+    pub(crate) fn raw(self) -> u32 {
+        match self {
+            Self::Modern(c) => c as u32,
+            Self::Legacy(c) => c as u32,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 校验 priority 编码。
+    #[test]
+    fn priority_ioctl_codes_match_linux() {
+        assert_eq!(IoctlCmd::GPriority as u32, 0x8004_5643);
+        assert_eq!(IoctlCmd::SPriority as u32, 0x4004_5644);
+        assert_eq!(
+            IoctlCmd::try_from_u32(0x8004_5643),
+            Some(IoctlCmd::GPriority)
+        );
+        assert_eq!(
+            IoctlCmd::try_from_u32(0x4004_5644),
+            Some(IoctlCmd::SPriority)
+        );
+    }
+
+    /// 无效 ioctl 校验。
+    #[test]
+    fn unknown_and_normalization() {
+        assert_eq!(IoctlCmd::try_from_u32(0xdead_beef), None);
+        assert_eq!(IoctlCmd::try_from_u32(0x8004_562D), None); // 表外 nr=45
+        assert_eq!(LegacyIoctlCmd::try_from_u32(0xdead_beef), None);
+        assert_eq!(VideoIoctl::try_from_u32(0xdead_beef), None);
+        assert_eq!(
+            VideoIoctl::try_from_u32(IoctlCmd::QueryCtrl as u32),
+            Some(VideoIoctl::Modern(IoctlCmd::QueryCtrl))
+        );
+        assert_eq!(
+            VideoIoctl::try_from_u32(LegacyIoctlCmd::GCtrl as u32),
+            Some(VideoIoctl::Legacy(LegacyIoctlCmd::GCtrl))
+        );
+        assert_eq!(IoctlCmd::try_from_u32(LegacyIoctlCmd::GCtrl as u32), None);
+        assert_eq!(IoctlCmd::try_from_u32(LegacyIoctlCmd::SCtrl as u32), None);
+    }
+
+    /// 覆盖率检查。
+    #[test]
+    fn ioctl_count_matches_linux() {
+        assert_eq!(IoctlCmd::COUNT, 47);
+        assert_eq!(LegacyIoctlCmd::COUNT, 36);
+        assert_eq!(IoctlCmd::COUNT + LegacyIoctlCmd::COUNT, 83);
+        for c in IoctlCmd::ALL {
+            assert_eq!(IoctlCmd::try_from_u32(c as u32), Some(c));
+        }
+        for c in LegacyIoctlCmd::ALL {
+            assert_eq!(LegacyIoctlCmd::try_from_u32(c as u32), Some(c));
+        }
+        // 现代/遗留命令号互不重叠。
+        for m in IoctlCmd::ALL {
+            assert_eq!(LegacyIoctlCmd::try_from_u32(m as u32), None);
+        }
+        for l in LegacyIoctlCmd::ALL {
+            assert_eq!(IoctlCmd::try_from_u32(l as u32), None);
+        }
+    }
+}

--- a/drivers/media/ax-media/src/ioctl/dispatcher.rs
+++ b/drivers/media/ax-media/src/ioctl/dispatcher.rs
@@ -1,0 +1,294 @@
+use core::{mem, ptr};
+
+use super::define::{IoctlCmd, LegacyIoctlCmd, VideoIoctl};
+use crate::{
+    Result, V4l2Error,
+    driver::V4L2DriverOps,
+    interface::{
+        buffer::{Buffer, CreateBuffers, Exportbuffer, RemoveBuffers, Requestbuffers},
+        capability::Capability,
+        crop::{Crop, Cropcap, Selection},
+        ctrl::{Control, QueryCtrl, QueryExtCtrl, Querymenu},
+        dv::{DvTimings, DvTimingsCap, EnumDvTimings},
+        edid::Edid,
+        format::{Fmtdesc, Format, FrameIntervalEnum, FrameSizeEnum},
+        inout::{Input, Output, StdId},
+        legacy::{
+            audio::{Audio, AudioOut},
+            codec::{DecoderCmd, EncIndex, EncoderCmd},
+            debug::{DbgChipInfo, DbgRegister},
+            framebuffer::Framebuffer,
+            jpegcomp::JpegCompression,
+            modulator::Modulator,
+            standard::Standard,
+            tuner::{Frequency, FrequencyBand, HwFreqSeek, Tuner},
+            vbi::SlicedVbiCap,
+        },
+        stream::StreamParm,
+    },
+};
+
+/// 从字节读取值。
+///
+/// # Safety
+/// 调用方需保证类型与大小正确。
+pub(crate) unsafe fn read_from_bytes<T: Copy>(bytes: &[u8]) -> T {
+    assert!(bytes.len() >= mem::size_of::<T>());
+    let ptr = bytes.as_ptr() as *const T;
+    unsafe { ptr::read_unaligned(ptr) }
+}
+
+/// 将值写入字节。
+///
+/// # Safety
+/// 调用方需保证类型与大小正确。
+pub(crate) unsafe fn write_to_bytes<T: Copy>(bytes: &mut [u8], val: &T) {
+    assert!(bytes.len() >= mem::size_of::<T>());
+    let ptr = bytes.as_mut_ptr() as *mut T;
+    unsafe { ptr::write_unaligned(ptr, *val) };
+}
+
+/// ioctl 分发辅助宏。
+macro_rules! ioctl_body {
+    (rw, $ops:ident, $arg:ident, $method:ident, $ty:ty) => {{
+        let mut v: $ty = $crate::ioctl::read_from_bytes($arg);
+        $ops.$method(&mut v)?;
+        $crate::ioctl::write_to_bytes($arg, &v);
+        Ok(())
+    }};
+    (rw_ctrl, $ops:ident, $arg:ident, $method:ident, $ty:ty) => {{
+        let mut v: $ty = $crate::ioctl::read_from_bytes($arg);
+        let handler = $ops.ctrl_handler().ok_or($crate::V4l2Error::NotSupported)?;
+        handler.$method(&mut v)?;
+        $crate::ioctl::write_to_bytes($arg, &v);
+        Ok(())
+    }};
+    (wo, $ops:ident, $arg:ident, $method:ident, $ty:ty) => {{
+        let v: $ty = $crate::ioctl::read_from_bytes($arg);
+        $ops.$method(&v)
+    }};
+    (get, $ops:ident, $arg:ident, $method:ident) => {{
+        let v = $ops.$method()?;
+        $crate::ioctl::write_to_bytes($arg, &v);
+        Ok(())
+    }};
+    (val, $ops:ident, $arg:ident, $method:ident, $ty:ty) => {{
+        let v: $ty = $crate::ioctl::read_from_bytes($arg);
+        $ops.$method(v)
+    }};
+    (buf_type, $ops:ident, $arg:ident, $method:ident) => {{
+        let ty: u32 = $crate::ioctl::read_from_bytes($arg);
+        let bt = $crate::interface::BufType::try_from_u32(ty)
+            .ok_or($crate::V4l2Error::InvalidArgument)?;
+        $ops.$method(bt)
+    }};
+    (noarg, $ops:ident, $arg:ident, $method:ident) => {{ $ops.$method() }};
+}
+
+impl IoctlCmd {
+    #[allow(clippy::too_many_lines)]
+    pub fn dispatch(self, ops: &mut dyn V4L2DriverOps, arg: &mut [u8]) -> Result<()> {
+        // SAFETY: `arg` 长度已由 VFS 层按 ioctl 编码保证，
+        // `read_from_bytes`/`write_to_bytes` 仅在长度足够时访问。
+        unsafe {
+            match self {
+                // ── 查询与枚举 ──────────────────────────────
+                Self::QueryCap => ioctl_body!(rw, ops, arg, querycap, Capability),
+                Self::EnumFmt => ioctl_body!(rw, ops, arg, enum_fmt, Fmtdesc),
+                Self::EnumFrameSizes => {
+                    ioctl_body!(rw, ops, arg, enum_framesizes, FrameSizeEnum)
+                }
+                Self::EnumFrameIntervals => {
+                    ioctl_body!(rw, ops, arg, enum_frameintervals, FrameIntervalEnum)
+                }
+
+                // ── 格式协商 ───────────────────────────────
+                Self::GFmt => ioctl_body!(rw, ops, arg, g_fmt, Format),
+                Self::SFmt => ioctl_body!(rw, ops, arg, s_fmt, Format),
+                Self::TryFmt => ioctl_body!(rw, ops, arg, try_fmt, Format),
+
+                // ── 缓冲区管理 ────────────────────────────────
+                Self::ReqBufs => ioctl_body!(rw, ops, arg, reqbufs, Requestbuffers),
+                Self::QueryBuf => ioctl_body!(rw, ops, arg, querybuf, Buffer),
+                Self::QBuf => ioctl_body!(rw, ops, arg, qbuf, Buffer),
+                Self::DQBuf => ioctl_body!(rw, ops, arg, dqbuf, Buffer),
+                Self::PrepareBuf => ioctl_body!(rw, ops, arg, prepare_buf, Buffer),
+                Self::CreateBufs => ioctl_body!(rw, ops, arg, create_bufs, CreateBuffers),
+                Self::RemoveBufs => ioctl_body!(rw, ops, arg, remove_bufs, RemoveBuffers),
+                Self::ExpBuf => ioctl_body!(rw, ops, arg, expbuf, Exportbuffer),
+
+                // ── 流式传输 ────────────────────────────────────
+                Self::StreamOn => ioctl_body!(buf_type, ops, arg, streamon),
+                Self::StreamOff => ioctl_body!(buf_type, ops, arg, streamoff),
+
+                // ── 流参数 ─────────────────────────────
+                Self::GParm => ioctl_body!(rw, ops, arg, g_parm, StreamParm),
+                Self::SParm => ioctl_body!(rw, ops, arg, s_parm, StreamParm),
+
+                // ── 输入/输出选择 ─────────────────────────
+                Self::EnumInput => ioctl_body!(rw, ops, arg, enum_input, Input),
+                Self::GInput => ioctl_body!(get, ops, arg, g_input),
+                Self::SInput => ioctl_body!(val, ops, arg, s_input, u32),
+                Self::EnumOutput => ioctl_body!(rw, ops, arg, enum_output, Output),
+                Self::GOutput => ioctl_body!(get, ops, arg, g_output),
+                Self::SOutput => ioctl_body!(val, ops, arg, s_output, u32),
+
+                // ── 控件查询（经驱动 CtrlHandler，核心统一处理）────
+                Self::QueryCtrl => ioctl_body!(rw_ctrl, ops, arg, queryctrl, QueryCtrl),
+                Self::QueryExtCtrl => {
+                    ioctl_body!(rw_ctrl, ops, arg, query_ext_ctrl, QueryExtCtrl)
+                }
+                Self::QueryMenu => ioctl_body!(rw_ctrl, ops, arg, querymenu, Querymenu),
+
+                // ── 核心代管 ioctl（priority / ext_ctrls / event）──
+                // 由 VideoDevice::handle_ioctl 或 pseudofs glue 拦截路由，
+                // 不进此分发器。
+                Self::GPriority
+                | Self::SPriority
+                | Self::GExtCtrls
+                | Self::SExtCtrls
+                | Self::TryExtCtrls
+                | Self::DQEvent
+                | Self::SubscribeEvent
+                | Self::UnsubscribeEvent => Err(V4l2Error::NotSupported),
+
+                // ── 裁剪 / Selection ─────────────────────────────
+                Self::CropCap => ioctl_body!(rw, ops, arg, cropcap, Cropcap),
+                Self::GSelection => ioctl_body!(rw, ops, arg, g_selection, Selection),
+                Self::SSelection => ioctl_body!(wo, ops, arg, s_selection, Selection),
+
+                // ── EDID ─────────────────────────────────────────
+                Self::GEdid => ioctl_body!(rw, ops, arg, g_edid, Edid),
+                Self::SEdid => ioctl_body!(rw, ops, arg, s_edid, Edid),
+
+                // ── DV timings ───────────────────────────────────
+                Self::GDvTimings => ioctl_body!(rw, ops, arg, g_dv_timings, DvTimings),
+                Self::SDvTimings => ioctl_body!(rw, ops, arg, s_dv_timings, DvTimings),
+                Self::EnumDvTimings => {
+                    ioctl_body!(rw, ops, arg, enum_dv_timings, EnumDvTimings)
+                }
+                Self::QueryDvTimings => ioctl_body!(rw, ops, arg, query_dv_timings, DvTimings),
+                Self::DvTimingsCap => ioctl_body!(rw, ops, arg, dv_timings_cap, DvTimingsCap),
+
+                // ── 日志 ────────────────────────────────────────
+                Self::LogStatus => ioctl_body!(noarg, ops, arg, log_status),
+            }
+        }
+    }
+}
+
+impl LegacyIoctlCmd {
+    #[allow(clippy::too_many_lines)]
+    pub fn dispatch(self, ops: &mut dyn V4L2DriverOps, arg: &mut [u8]) -> Result<()> {
+        // SAFETY: `arg` 长度已由 VFS 层按 ioctl 编码保证。
+        unsafe {
+            match self {
+                Self::GCtrl => ioctl_body!(rw_ctrl, ops, arg, g_ctrl, Control),
+                Self::SCtrl => ioctl_body!(rw_ctrl, ops, arg, s_ctrl, Control),
+
+                // ── Overlay 帧缓冲 ────────────────────────────
+                Self::GFbuf => ioctl_body!(rw, ops, arg, g_fbuf, Framebuffer),
+                Self::SFbuf => ioctl_body!(wo, ops, arg, s_fbuf, Framebuffer),
+                Self::Overlay => ioctl_body!(val, ops, arg, overlay, u32),
+
+                // ── 模拟电视标准 ──────────────────────────────
+                Self::GStd => ioctl_body!(rw, ops, arg, g_std, StdId),
+                Self::SStd => ioctl_body!(val, ops, arg, s_std, StdId),
+                Self::EnumStd => ioctl_body!(rw, ops, arg, enum_std, Standard),
+                Self::QueryStd => ioctl_body!(rw, ops, arg, query_std, StdId),
+
+                // ── Tuner/Radio ───────────────────────────────
+                Self::GTuner => ioctl_body!(rw, ops, arg, g_tuner, Tuner),
+                Self::STuner => ioctl_body!(wo, ops, arg, s_tuner, Tuner),
+                Self::GFrequency => ioctl_body!(rw, ops, arg, g_frequency, Frequency),
+                Self::SFrequency => ioctl_body!(wo, ops, arg, s_frequency, Frequency),
+                Self::EnumFreqBands => {
+                    ioctl_body!(rw, ops, arg, enum_freq_bands, FrequencyBand)
+                }
+                Self::SHwFreqSeek => ioctl_body!(wo, ops, arg, s_hw_freq_seek, HwFreqSeek),
+
+                // ── 调制器 ─────────────────────────────────────
+                Self::GModulator => ioctl_body!(rw, ops, arg, g_modulator, Modulator),
+                Self::SModulator => ioctl_body!(wo, ops, arg, s_modulator, Modulator),
+
+                // ── 音频 I/O ───────────────────────────────────
+                Self::GAudio => ioctl_body!(rw, ops, arg, g_audio, Audio),
+                Self::SAudio => ioctl_body!(wo, ops, arg, s_audio, Audio),
+                Self::EnumAudio => ioctl_body!(rw, ops, arg, enum_audio, Audio),
+                Self::GAudioOut => ioctl_body!(rw, ops, arg, g_audout, AudioOut),
+                Self::SAudioOut => ioctl_body!(wo, ops, arg, s_audout, AudioOut),
+                Self::EnumAudioOut => ioctl_body!(rw, ops, arg, enum_audout, AudioOut),
+
+                // ── 裁剪旧 API ────────────────────────────────
+                Self::GCrop => ioctl_body!(rw, ops, arg, g_crop, Crop),
+                Self::SCrop => ioctl_body!(wo, ops, arg, s_crop, Crop),
+
+                // ── JPEG 压缩旧 API ───────────────────────────
+                Self::GJpegComp => ioctl_body!(rw, ops, arg, g_jpegcomp, JpegCompression),
+                Self::SJpegComp => ioctl_body!(wo, ops, arg, s_jpegcomp, JpegCompression),
+
+                // ── Sliced VBI ─────────────────────────────────
+                Self::GSlicedVbiCap => {
+                    ioctl_body!(rw, ops, arg, g_sliced_vbi_cap, SlicedVbiCap)
+                }
+
+                // ── Stateful codec ─────────────────────────────
+                Self::GEncIndex => ioctl_body!(rw, ops, arg, g_enc_index, EncIndex),
+                Self::EncoderCmd => ioctl_body!(rw, ops, arg, encoder_cmd, EncoderCmd),
+                Self::TryEncoderCmd => ioctl_body!(rw, ops, arg, try_encoder_cmd, EncoderCmd),
+                Self::DecoderCmd => ioctl_body!(rw, ops, arg, decoder_cmd, DecoderCmd),
+                Self::TryDecoderCmd => ioctl_body!(rw, ops, arg, try_decoder_cmd, DecoderCmd),
+
+                // ── 调试 ───────────────────────────────────────
+                Self::DbgGRegister => ioctl_body!(rw, ops, arg, dbg_g_register, DbgRegister),
+                Self::DbgSRegister => ioctl_body!(wo, ops, arg, dbg_s_register, DbgRegister),
+                Self::DbgGChipInfo => ioctl_body!(rw, ops, arg, dbg_g_chip_info, DbgChipInfo),
+            }
+        }
+    }
+}
+
+/// IOCTL 分发器。
+pub struct IoctlDispatcher {
+    valid: [u64; 4],
+}
+
+impl IoctlDispatcher {
+    pub const fn new() -> Self {
+        Self {
+            valid: [u64::MAX; 4],
+        }
+    }
+
+    /// 禁用 ioctl。
+    pub fn disable_cmd(&mut self, cmd: u32) {
+        let idx = (cmd & 0xff) as usize;
+        self.valid[idx / 64] &= !(1u64 << (idx % 64));
+    }
+
+    fn is_valid(&self, cmd: u32) -> bool {
+        let idx = (cmd & 0xff) as usize;
+        self.valid[idx / 64] & (1u64 << (idx % 64)) != 0
+    }
+
+    pub fn dispatch(
+        &self,
+        ops: &mut dyn V4L2DriverOps,
+        cmd: VideoIoctl,
+        arg: &mut [u8],
+    ) -> Result<()> {
+        if !self.is_valid(cmd.raw()) {
+            return Err(V4l2Error::NotSupported);
+        }
+        match cmd {
+            VideoIoctl::Modern(c) => c.dispatch(ops, arg),
+            VideoIoctl::Legacy(c) => c.dispatch(ops, arg),
+        }
+    }
+}
+
+impl Default for IoctlDispatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/drivers/media/ax-media/src/ioctl/mod.rs
+++ b/drivers/media/ax-media/src/ioctl/mod.rs
@@ -1,0 +1,10 @@
+//! V4L2 ioctl 命令及分发。
+
+mod define;
+mod dispatcher;
+mod ops;
+
+pub use define::{IoctlCmd, LegacyIoctlCmd, VideoIoctl};
+pub use dispatcher::IoctlDispatcher;
+pub(crate) use dispatcher::{read_from_bytes, write_to_bytes};
+pub use ops::{IoctlOps, LegacyIoctlOps};

--- a/drivers/media/ax-media/src/ioctl/ops.rs
+++ b/drivers/media/ax-media/src/ioctl/ops.rs
@@ -1,0 +1,382 @@
+//! Ioctl trait。
+
+use crate::{
+    Result, V4l2Error,
+    filehandler::V4l2Fh,
+    interface::{
+        BufType,
+        buffer::{Buffer, CreateBuffers, Exportbuffer, RemoveBuffers, Requestbuffers},
+        capability::Capability,
+        crop::{Crop, Cropcap, Selection},
+        ctrl::Control,
+        dv::{DvTimings, DvTimingsCap, EnumDvTimings},
+        edid::Edid,
+        event::{Event, EventSubscription},
+        format::{Fmtdesc, Format, FrameIntervalEnum, FrameSizeEnum},
+        inout::{Input, Output, StdId},
+        legacy::{
+            audio::{Audio, AudioOut},
+            codec::{DecoderCmd, EncIndex, EncoderCmd},
+            debug::{DbgChipInfo, DbgRegister},
+            framebuffer::Framebuffer,
+            jpegcomp::JpegCompression,
+            modulator::Modulator,
+            standard::Standard,
+            tuner::{Frequency, FrequencyBand, HwFreqSeek, Tuner},
+            vbi::SlicedVbiCap,
+        },
+        stream::StreamParm,
+    },
+};
+
+/// Modern ioctl。
+#[allow(unused_variables)]
+pub trait IoctlOps {
+    // ── 查询与枚举 ──────────────────────────────────────────
+
+    /// 查询设备能力（`VIDIOC_QUERYCAP`）
+    fn querycap(&self, cap: &mut Capability) -> Result<()>;
+
+    /// 枚举像素格式（`VIDIOC_ENUM_FMT`）
+    fn enum_fmt(&self, f: &mut Fmtdesc) -> Result<()>;
+
+    /// 枚举帧尺寸（`VIDIOC_ENUM_FRAMESIZES`）
+    fn enum_framesizes(&self, f: &mut FrameSizeEnum) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    /// 枚举帧间隔（`VIDIOC_ENUM_FRAMEINTERVALS`）
+    fn enum_frameintervals(&self, f: &mut FrameIntervalEnum) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 格式协商 ───────────────────────────────────────────
+
+    /// 获取当前格式（`VIDIOC_G_FMT`）
+    fn g_fmt(&self, f: &mut Format) -> Result<()>;
+
+    /// 设置格式（`VIDIOC_S_FMT`）
+    fn s_fmt(&mut self, f: &mut Format) -> Result<()>;
+
+    /// 试设格式（`VIDIOC_TRY_FMT`）
+    fn try_fmt(&self, f: &mut Format) -> Result<()>;
+
+    // ── 缓冲区管理 ───────────────────────────────────────────
+
+    /// 申请缓冲区（`VIDIOC_REQBUFS`）
+    fn reqbufs(&mut self, req: &mut Requestbuffers) -> Result<()>;
+
+    /// 查询缓冲区（`VIDIOC_QUERYBUF`）
+    fn querybuf(&self, buf: &mut Buffer) -> Result<()>;
+
+    /// 入队缓冲区（`VIDIOC_QBUF`）
+    fn qbuf(&mut self, buf: &mut Buffer) -> Result<()>;
+
+    /// 出队缓冲区（`VIDIOC_DQBUF`）
+    fn dqbuf(&mut self, buf: &mut Buffer) -> Result<()>;
+
+    /// 预备缓冲区（`VIDIOC_PREPARE_BUF`）
+    fn prepare_buf(&mut self, buf: &mut Buffer) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    /// 创建缓冲区（`VIDIOC_CREATE_BUFS`）
+    fn create_bufs(&mut self, bufs: &mut CreateBuffers) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    /// 移除缓冲区（`VIDIOC_REMOVE_BUFS`）
+    fn remove_bufs(&mut self, bufs: &mut RemoveBuffers) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    /// 导出缓冲区（`VIDIOC_EXPBUF`）。仅支持 DMABUF 时实现
+    fn expbuf(&self, buf: &mut Exportbuffer) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 流式传输 ────────────────────────────────────────────────────
+
+    /// 开启流（`VIDIOC_STREAMON`）
+    fn streamon(&mut self, ty: BufType) -> Result<()>;
+
+    /// 关闭流（`VIDIOC_STREAMOFF`）
+    fn streamoff(&mut self, ty: BufType) -> Result<()>;
+
+    // ── 流参数 ─────────────────────────────────────────
+
+    fn g_parm(&self, p: &mut StreamParm) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_parm(&mut self, p: &mut StreamParm) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 输入选择 ──────────────────────────────────────────────
+
+    fn enum_input(&self, input: &mut Input) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn g_input(&self) -> Result<u32> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_input(&mut self, index: u32) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn enum_output(&self, output: &mut Output) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn g_output(&self) -> Result<u32> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_output(&mut self, index: u32) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 裁剪 / Selection ─────────────────────────────────────────
+
+    fn cropcap(&self, c: &mut Cropcap) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn g_selection(&self, s: &mut Selection) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_selection(&mut self, s: &Selection) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── EDID ─────────────────────────────────────────────────────
+
+    fn g_edid(&self, edid: &mut Edid) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_edid(&mut self, edid: &mut Edid) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── DV timings ───────────────────────────────────────────────
+
+    fn g_dv_timings(&self, t: &mut DvTimings) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_dv_timings(&mut self, t: &mut DvTimings) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn enum_dv_timings(&self, t: &mut EnumDvTimings) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn query_dv_timings(&self, t: &mut DvTimings) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn dv_timings_cap(&self, c: &mut DvTimingsCap) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 日志 ─────────────────────────────────────────────────────
+
+    fn log_status(&self) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 事件 ────────────────────────────────────────────────────────
+
+    /// 处理 `VIDIOC_SUBSCRIBE_EVENT`。
+    fn subscribe_event(&mut self, _fh: &mut V4l2Fh, _sub: &EventSubscription) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    /// 处理 `VIDIOC_UNSUBSCRIBE_EVENT`。
+    fn unsubscribe_event(&mut self, fh: &mut V4l2Fh, sub: &EventSubscription) -> Result<()> {
+        fh.unsubscribe(sub);
+        Ok(())
+    }
+
+    /// 处理 `VIDIOC_DQEVENT`（非阻塞）。
+    fn dqevent(&mut self, fh: &mut V4l2Fh, event: &mut Event) -> Result<()> {
+        *event = fh.dequeue()?;
+        Ok(())
+    }
+}
+
+/// Legacy ioctl。
+#[allow(unused_variables)]
+pub trait LegacyIoctlOps {
+    /// G_CTRL。
+    fn g_ctrl(&self, _c: &mut Control) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    /// S_CTRL。
+    fn s_ctrl(&mut self, _c: &Control) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── Overlay 帧缓冲 ─────────────────────────────────────────
+
+    fn g_fbuf(&self, fb: &mut Framebuffer) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_fbuf(&mut self, fb: &Framebuffer) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn overlay(&mut self, on: u32) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 模拟电视标准 ───────────────────────────────────────────
+
+    fn g_std(&self, id: &mut StdId) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_std(&mut self, id: StdId) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn enum_std(&self, s: &mut Standard) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn query_std(&self, id: &mut StdId) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── Tuner/Radio ────────────────────────────────────────────
+
+    fn g_tuner(&self, t: &mut Tuner) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_tuner(&mut self, t: &Tuner) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn g_frequency(&self, f: &mut Frequency) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_frequency(&mut self, f: &Frequency) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn enum_freq_bands(&self, b: &mut FrequencyBand) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_hw_freq_seek(&mut self, s: &HwFreqSeek) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 调制器 ─────────────────────────────────────────────────
+
+    fn g_modulator(&self, m: &mut Modulator) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_modulator(&mut self, m: &Modulator) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 音频 I/O ───────────────────────────────────────────────
+
+    fn g_audio(&self, a: &mut Audio) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_audio(&mut self, a: &Audio) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn enum_audio(&self, a: &mut Audio) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn g_audout(&self, a: &mut AudioOut) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_audout(&mut self, a: &AudioOut) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn enum_audout(&self, a: &mut AudioOut) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 裁剪旧 API ─────────────────────────────────────────────
+
+    fn g_crop(&self, c: &mut Crop) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_crop(&mut self, c: &Crop) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── JPEG 压缩旧 API ────────────────────────────────────────
+
+    fn g_jpegcomp(&self, j: &mut JpegCompression) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn s_jpegcomp(&mut self, j: &JpegCompression) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── Sliced VBI ─────────────────────────────────────────────
+
+    fn g_sliced_vbi_cap(&self, c: &mut SlicedVbiCap) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── Stateful codec ─────────────────────────────────────────
+
+    fn g_enc_index(&self, idx: &mut EncIndex) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn encoder_cmd(&mut self, c: &mut EncoderCmd) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn try_encoder_cmd(&mut self, c: &mut EncoderCmd) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn decoder_cmd(&mut self, c: &mut DecoderCmd) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn try_decoder_cmd(&mut self, c: &mut DecoderCmd) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    // ── 调试 ───────────────────────────────────────────────────
+
+    fn dbg_g_register(&self, r: &mut DbgRegister) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn dbg_s_register(&mut self, r: &DbgRegister) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+
+    fn dbg_g_chip_info(&self, c: &mut DbgChipInfo) -> Result<()> {
+        Err(V4l2Error::NotSupported)
+    }
+}

--- a/drivers/media/ax-media/src/lib.rs
+++ b/drivers/media/ax-media/src/lib.rs
@@ -1,0 +1,23 @@
+//! StarryOS 的 V4L2 核心框架（合并 videobuffer）。
+
+#![no_std]
+#[cfg(test)]
+extern crate std;
+
+extern crate alloc;
+
+mod ctrls;
+mod device;
+mod driver;
+mod error;
+mod filehandler;
+pub mod interface;
+mod ioctl;
+pub mod videobuffer;
+
+pub use ctrls::{CtrlConfig, CtrlGetFn, CtrlHandler, CtrlOps, CtrlSetFn, CtrlType, class};
+pub use device::VideoDevice;
+pub use driver::V4L2DriverOps;
+pub use error::{Result, V4l2Error};
+pub use filehandler::V4l2Fh;
+pub use ioctl::{IoctlCmd, IoctlOps, LegacyIoctlCmd, LegacyIoctlOps, VideoIoctl};

--- a/drivers/media/ax-media/src/videobuffer/allocator/mod.rs
+++ b/drivers/media/ax-media/src/videobuffer/allocator/mod.rs
@@ -1,0 +1,16 @@
+//! 内存分配策略——[`VbMemOps`]（对应 Linux 的 `struct vb2_mem_ops`）及其后端。
+
+mod vmalloc;
+
+use alloc::vec::Vec;
+
+pub use vmalloc::VirtualAllocator;
+
+use crate::{V4l2Error, videobuffer::buf::MemPlane};
+
+/// 内存分配策略：VbPool 通过它分配/释放缓冲平面，不依赖具体后端。
+pub trait VbMemOps: Send + Sync {
+    fn alloc(&self, sizes: &[u32]) -> Result<Vec<MemPlane>, V4l2Error>;
+    fn release(&self, planes: &[MemPlane]);
+    fn mmap(&self, plane: &MemPlane) -> Vec<usize>;
+}

--- a/drivers/media/ax-media/src/videobuffer/allocator/vmalloc.rs
+++ b/drivers/media/ax-media/src/videobuffer/allocator/vmalloc.rs
@@ -1,0 +1,184 @@
+//! VirtualAllocator——实现 VbMemOps 的 vmalloc 风格内核页分配器。
+//!
+//! 对齐 Linux `vb2_vmalloc`：**虚拟连续、物理离散**——在内核地址空间
+//! （`axmm::kernel_aspace`）分配连续虚拟段，逐页从 axalloc 堆分配物理
+//! 帧并 `map_linear` 建立映射（不要求物理连续大块，长时运行系统不易
+//! 碎片失败）。
+//!
+//! 物理页快照由分配器自管（`alloc` 时逐页分配并记录）——不需要页表
+//! 查询。注意 `virt_to_phys` 只对**线性映射区**有效（ax-plat mem 契约），
+//! 不能翻译 vmalloc 段任意虚拟地址——所以物理页从 axalloc 堆分配
+//! （其 vaddr 在线性映射区，换算有效），再映射到 vmalloc 段。
+//!
+//! 布局完全内聚：`alloc` 时计算 UAPI mmap 偏移（stride）；[`MemPlane`] 的
+//! 私有句柄即虚拟段基址（`as_ptr()` 暴露 CPU 直写地址）。供 vivid 及 CPU 搬运
+//! 场景（uvc 拼帧）。
+
+use alloc::{vec, vec::Vec};
+use core::ptr::NonNull;
+
+use ax_alloc::{UsageKind, global_allocator};
+use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr, VirtAddr, VirtAddrRange, align_up_4k};
+use ax_mm::kernel_aspace;
+use ax_runtime::hal::{
+    mem::{phys_to_virt, virt_to_phys},
+    paging::MappingFlags,
+};
+
+use crate::{
+    V4l2Error,
+    videobuffer::{MemPlane, VbMemOps},
+};
+
+/// 跟踪一个已分配 buffer 的虚拟段与物理页（自管，release 时归还）。
+struct AllocEntry {
+    /// 虚拟段基址（与 [`MemPlane::as_ptr`] 一致——CPU 直写地址）。
+    vaddr: usize,
+    size: usize,
+    /// 逐页物理地址（axalloc 堆分配；unmap/归还前不变）。
+    pages: Vec<usize>,
+}
+
+/// 用于 V4L2 buffer 内存的 vmalloc 风格 allocator。
+///
+/// 分配流程（每次 `alloc`）：在内核地址空间中找空闲虚拟段
+/// （4K 对齐）→ 逐页 `global_allocator().alloc_pages(1, 4K)` 分配物理
+/// 帧（vaddr 在线性映射区，`virt_to_phys` 换算有效）→ `map_linear`
+/// 逐页映射到虚拟段（虚拟连续、物理离散）。`mmap` 偏移按 stride
+/// （页对齐 plane 大小）在 alloc 时计算，buffer 间不重叠。
+pub struct VirtualAllocator {
+    entries: ax_sync::Mutex<Vec<AllocEntry>>,
+}
+
+impl VirtualAllocator {
+    pub fn new() -> Self {
+        Self {
+            entries: ax_sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl Default for VirtualAllocator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// 逐页分配 `size`（页对齐）字节的物理帧，返回物理地址列表。
+///
+/// 必须在可睡上下文调用：全局分配失败路径会触发页缓存回收。
+/// 中途失败时已分配的帧随回收逻辑一起归还，不泄漏。
+fn alloc_frames(size: usize) -> Option<Vec<usize>> {
+    let mut pages = Vec::with_capacity(size / PAGE_SIZE_4K);
+    for _ in 0..size / PAGE_SIZE_4K {
+        let vaddr = match global_allocator().alloc_pages(1, PAGE_SIZE_4K, UsageKind::VirtMem) {
+            Ok(vaddr) => vaddr,
+            Err(_) => {
+                free_frames(&pages);
+                return None;
+            }
+        };
+        let pa = virt_to_phys(VirtAddr::from(vaddr)).as_usize();
+        pages.push(pa);
+    }
+    Some(pages)
+}
+
+/// 归还物理帧（无锁；不触发回收）。
+fn free_frames(pages: &[usize]) {
+    for &pa in pages {
+        let vaddr = phys_to_virt(PhysAddr::from_usize(pa));
+        global_allocator().dealloc_pages(vaddr.as_usize(), 1, UsageKind::VirtMem);
+    }
+}
+
+/// 在内核地址空间查找空闲虚拟段并逐页映射已分配的物理帧。
+fn map_frames(pages: &[usize]) -> Option<usize> {
+    let size = pages.len() * PAGE_SIZE_4K;
+    let mut aspace = kernel_aspace().lock();
+    let limit = VirtAddrRange::new(aspace.base(), aspace.end());
+    let start = aspace.find_free_area(aspace.base(), size, limit)?;
+    for (i, &pa) in pages.iter().enumerate() {
+        if aspace
+            .map_linear(
+                start + i * PAGE_SIZE_4K,
+                PhysAddr::from_usize(pa),
+                PAGE_SIZE_4K,
+                MappingFlags::READ | MappingFlags::WRITE,
+            )
+            .is_err()
+        {
+            for j in 0..i {
+                let _ = aspace.unmap(start + j * PAGE_SIZE_4K, PAGE_SIZE_4K);
+            }
+            return None;
+        }
+    }
+    Some(start.as_usize())
+}
+
+impl VbMemOps for VirtualAllocator {
+    fn alloc(&self, sizes: &[u32]) -> Result<Vec<MemPlane>, V4l2Error> {
+        if sizes.len() != 1 || sizes[0] == 0 {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let aligned = align_up_4k(sizes[0] as usize);
+        // 仅取登记数量用于 UAPI 偏移编码，不跨锁持有。
+        let buf_index = self.entries.lock().len();
+        // 物理帧在可睡上下文（无锁）分配：分配失败路径的页缓存回收
+        // 需要睡锁，不得在 entries/kernel_aspace 自旋锁内进行。
+        let Some(pages) = alloc_frames(aligned) else {
+            return Err(V4l2Error::NoMemory);
+        };
+        // find→map 原子窗口（aspace 自旋锁；页表扩展分配失败时
+        // 回收回调在原子上下文跳过，仅返回 ENOMEM，不 panic）。
+        let Some(vaddr) = map_frames(&pages) else {
+            free_frames(&pages);
+            return Err(V4l2Error::NoMemory);
+        };
+        self.entries.lock().push(AllocEntry {
+            vaddr,
+            size: aligned,
+            pages,
+        });
+        // 记录页对齐后的实际大小：用户态 mmap 的 length 是页对齐的，
+        // 若记录未对齐的 size 会导致 mmap 越界检查（offset+length>end）
+        // 误拒绝（Linux vb2 的 plane.length 同样是页对齐值）。
+        let ptr = NonNull::new(vaddr as *mut u8).ok_or(V4l2Error::NoMemory)?;
+        Ok(vec![MemPlane::new(
+            ptr,
+            buf_index * aligned,
+            aligned as u32,
+        )])
+    }
+
+    fn release(&self, planes: &[MemPlane]) {
+        for plane in planes {
+            let addr = plane.addr();
+            // 摘除 entry（entries 锁只覆盖登记表窗口）。
+            let entry = {
+                let mut entries = self.entries.lock();
+                let Some(pos) = entries.iter().position(|e| e.vaddr == addr) else {
+                    continue;
+                };
+                entries.swap_remove(pos)
+            };
+            // 摘除虚拟映射（aspace 锁只覆盖 unmap 窗口，不跨物理帧归还）。
+            let _ = kernel_aspace()
+                .lock()
+                .unmap(VirtAddr::from(entry.vaddr), entry.size);
+            // 归还物理帧（无锁）。
+            free_frames(&entry.pages);
+        }
+    }
+
+    fn mmap(&self, plane: &MemPlane) -> Vec<usize> {
+        let addr = plane.addr();
+        let entries = self.entries.lock();
+        entries
+            .iter()
+            .find(|e| e.vaddr == addr)
+            .map(|e| e.pages.clone())
+            .unwrap_or_default()
+    }
+}

--- a/drivers/media/ax-media/src/videobuffer/buf.rs
+++ b/drivers/media/ax-media/src/videobuffer/buf.rs
@@ -1,0 +1,136 @@
+//! 每个 buffer 的元数据——对应 Linux 的 `struct vb2_buffer`。
+
+use alloc::vec::Vec;
+use core::ptr::NonNull;
+
+use crate::interface::{Timeval, buffer::BufFlags};
+
+/// 队列中单个 buffer 的状态。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BufferState {
+    Free,   // buffer 处于用户空间控制下
+    Ready,  // buffer 已被用户空间入队，等待交给驱动
+    Active, // buffer 已通过 buf_queue 交给驱动，驱动正在处理它
+    Done,   // 驱动已处理完毕，可供 DQBUF
+    Error,  // 驱动处理此 buffer 时遇到错误
+}
+
+/// buffer 中一个 plane 的内存句柄。
+///
+/// 对应 Linux 的 `vb2_plane.mem_priv`：由 [`VbMemOps::alloc`](super::VbMemOps::alloc)
+/// 返回的分配器私有句柄。句柄的 CPU 可写地址由 [`MemPlane::as_ptr`] 暴露，
+/// 驱动侧通过 [`ActiveFrame::as_mut_slice`] 独占访问，不再直接 `cookie as *mut u8` 强转。
+#[derive(Debug, Clone, Copy)]
+pub struct MemPlane {
+    ptr: NonNull<u8>,
+    pub offset: usize,
+    pub length: u32,
+}
+
+impl MemPlane {
+    /// 构造一个平面句柄。
+    ///
+    /// `ptr` 必须指向长度为 `length` 的有效 vmalloc 段，且在 `release` 前保持稳定。
+    pub fn new(ptr: NonNull<u8>, offset: usize, length: u32) -> Self {
+        Self {
+            ptr,
+            offset,
+            length,
+        }
+    }
+
+    /// 以裸地址构造（宿主机测试/特殊分配器辅助）。
+    ///
+    /// `addr == 0` 时返回 `None`。
+    pub fn from_addr(addr: usize, offset: usize, length: u32) -> Option<Self> {
+        NonNull::new(addr as *mut u8).map(|ptr| Self {
+            ptr,
+            offset,
+            length,
+        })
+    }
+
+    /// CPU 可写虚地址（裸指针）。
+    #[inline]
+    pub fn as_ptr(&self) -> *mut u8 {
+        self.ptr.as_ptr()
+    }
+
+    /// 虚地址的整数视图（用于 `mmap` 页表查找与调试）。
+    #[inline]
+    pub fn addr(&self) -> usize {
+        self.ptr.as_ptr() as usize
+    }
+}
+
+// SAFETY: `ptr` 指向由 `VbMemOps` 分配的稳定 vmalloc 段，在 `release` 前
+// 保持有效；`MemPlane` 仅作为句柄在队列锁保护下共享或经 `ActiveFrame` 独占
+// 访问，与 Linux `vb2_plane.mem_priv` 的跨线程共享语义一致。原 `usize` 形式的
+// cookie 同为 `Send + Sync`，此封装保持相同线程安全契约。
+unsafe impl Send for MemPlane {}
+unsafe impl Sync for MemPlane {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Timestamp {
+    #[default]
+    Unset, // 尚未设置时间戳（`Dequeued`/`Queued`/`Active` 阶段）。
+    Monotonic(u64), // 单调时钟时间戳（`Done`/`Error` 阶段），纳秒。
+}
+
+impl Timestamp {
+    /// 是否已设置时间戳。
+    #[inline]
+    pub fn is_set(&self) -> bool {
+        matches!(self, Self::Monotonic(_))
+    }
+
+    /// 返回纳秒值，未设置时为 0。
+    #[inline]
+    pub fn nanos(&self) -> u64 {
+        match *self {
+            Self::Unset => 0,
+            Self::Monotonic(n) => n,
+        }
+    }
+
+    /// 对应的 `V4L2_BUF_FLAG_TIMESTAMP_*` 标志。
+    #[inline]
+    pub fn flags(&self) -> BufFlags {
+        match *self {
+            Self::Unset => BufFlags::empty(),
+            Self::Monotonic(_) => BufFlags::TIMESTAMP_MONOTONIC,
+        }
+    }
+
+    /// 转换为 `v4l2_buffer.timestamp` 的 `Timeval` 表示。
+    #[inline]
+    pub fn timeval(&self) -> Timeval {
+        let n = self.nanos();
+        Timeval {
+            tv_sec: (n / 1_000_000_000) as i64,
+            tv_usec: ((n / 1_000) % 1_000_000) as i64,
+        }
+    }
+}
+
+/// 队列中的单个 buffer——对应 Linux 的 `struct vb2_buffer`。
+#[derive(Clone)]
+pub struct VbBuffer {
+    pub state: BufferState,
+    pub planes: Vec<MemPlane>,
+    pub bytesused: u32,
+    pub sequence: u32,
+    pub timestamp: Timestamp,
+}
+
+/// 活动缓冲句柄——仅含裸指针与索引
+#[must_use]
+pub(crate) struct ActiveFrame {
+    pub(crate) buffer_index: u32,
+    pub(crate) data_ptr: *mut u8,
+    pub(crate) len: usize,
+}
+
+// SAFETY: `ptr` 指向的 vmalloc 段在 Guard 期间独占且稳定。
+unsafe impl Send for ActiveFrame {}
+unsafe impl Sync for ActiveFrame {}

--- a/drivers/media/ax-media/src/videobuffer/mod.rs
+++ b/drivers/media/ax-media/src/videobuffer/mod.rs
@@ -1,0 +1,13 @@
+//! V4L2 buffer 队列框架（vb2——Video Buffer 2）。
+//!
+//! 对应 Linux 的 `drivers/media/common/videobuf2/`。
+//! 实现 buffer 状态机（DEQUEUED → QUEUED → ACTIVE → DONE），
+//! 通过 [`VbMemOps`] 提供可插拔的内存分配
+
+mod allocator;
+mod buf;
+mod pool;
+
+pub use allocator::{VbMemOps, VirtualAllocator};
+pub use buf::{BufferState, MemPlane, Timestamp, VbBuffer};
+pub use pool::{FrameGuard, VbPool, VbPoolLease};

--- a/drivers/media/ax-media/src/videobuffer/pool.rs
+++ b/drivers/media/ax-media/src/videobuffer/pool.rs
@@ -1,0 +1,402 @@
+//! Buffer VbPool——基于 [`VbBuffer`] 的池化抽象。
+//!
+//! 对应原 `Vb2Queue` 的 “队列” 心智易误导为严格 FIFO。实际 `v4l2_buffer.index`
+//! 允许按索引随机 `QBUF/DQBUF`，仅 `done_queue` 的 `DQBUF` 为 FIFO。本模块
+//! 按新心智重命名：
+//! * `VbPool`：`reqbufs` 构建、生命周期至 `streamoff`/`reqbufs(0)`
+//! * `ready_queue`：`QBUF` 激活的缓冲（含 `Ready` 与 `Active`）
+//! * `done_queue`：已完成（`Done`/`Error`）待 `DQBUF` 的缓冲
+//! * `VbPoolLease`：驱动从 `VbPool` 获取的安全读写租约，`Drop` 自动 `abort`
+
+use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
+
+use ax_sync::Mutex;
+use axpoll::{IoEvents, PollSet};
+
+use super::{
+    allocator::VbMemOps,
+    buf::{ActiveFrame, BufferState, Timestamp, VbBuffer},
+};
+use crate::V4l2Error;
+
+/// 由内部锁保护的池状态。
+pub(crate) struct VbPoolInner {
+    buffers: Vec<VbBuffer>,
+    ready_queue: VecDeque<u32>,
+    done_queue: VecDeque<u32>,
+
+    sequence: u32,
+    streaming: bool,
+    error: bool,
+}
+
+/// Buffer VbPool——`reqbufs` 构建、`streamoff` 销毁。
+///
+/// `ready_queue` 存放 `Ready`/`Active` 缓冲索引，`done_queue` 存放 `Done`/`Error`。
+pub struct VbPool<M: VbMemOps> {
+    pub(crate) state: Mutex<VbPoolInner>,
+    pub(crate) poll_set: Arc<PollSet>,
+    allocator: M,
+    min_buffers: u32,
+    max_buffers: u32,
+}
+
+impl<M: VbMemOps> VbPool<M> {
+    pub fn new(alloc: M, min_buffers: u32, max_buffers: u32) -> Self {
+        Self {
+            state: Mutex::new(VbPoolInner {
+                buffers: Vec::new(),
+                ready_queue: VecDeque::new(),
+                done_queue: VecDeque::new(),
+                sequence: 0,
+                streaming: false,
+                error: false,
+            }),
+            allocator: alloc,
+            poll_set: Arc::new(PollSet::new()),
+            min_buffers,
+            max_buffers,
+        }
+    }
+
+    // ── mmap ───────────────────────────────────────────────────────
+    pub fn mmap(&self, offset: u64, length: u64) -> Option<(Vec<usize>, usize)> {
+        let inner = self.state.lock();
+        for vb in inner.buffers.iter() {
+            let plane = vb.planes.first()?;
+            let base = plane.offset as u64;
+            let end = base + plane.length as u64;
+            if offset >= base && offset < end {
+                if offset + length > end {
+                    return None;
+                }
+                let sub = (offset - base) as usize;
+                let page = 4096usize;
+                let first_page = sub / page;
+                let n_pages = (sub % page + length as usize).div_ceil(page);
+                let all = self.allocator.mmap(plane);
+                let addrs = all
+                    .get(first_page..first_page + n_pages)
+                    .unwrap_or_default()
+                    .to_vec();
+                return Some((addrs, length as usize));
+            }
+        }
+        None
+    }
+
+    // ── poll ───────────────────────────────────────────────────────
+    pub fn vb_poll_set(&self) -> &Arc<PollSet> {
+        &self.poll_set
+    }
+
+    pub fn is_readable(&self) -> bool {
+        !self.state.lock().done_queue.is_empty()
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.state.lock().error
+    }
+
+    pub fn is_streaming(&self) -> bool {
+        self.state.lock().streaming
+    }
+
+    /// 置错误并回收孤儿 `Active && driver_owned` 为 `Error` 入 `done_queue`。
+    pub fn set_error(&self) {
+        let mut inner = self.state.lock();
+        inner.error = true;
+        let orphan: Vec<u32> = inner
+            .buffers
+            .iter()
+            .enumerate()
+            .filter_map(|(i, vb)| {
+                if vb.state == BufferState::Active {
+                    Some(i as u32)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        let reclaimed = orphan.len();
+        for idx in orphan {
+            inner.sequence += 1;
+            let seq = inner.sequence;
+            {
+                let vb = &mut inner.buffers[idx as usize];
+                vb.state = BufferState::Error;
+                vb.bytesused = 0;
+                vb.timestamp = Timestamp::Monotonic(ax_runtime::hal::time::monotonic_time_nanos());
+                vb.sequence = seq;
+            }
+            inner.done_queue.push_back(idx);
+        }
+        drop(inner);
+        if reclaimed > 0 {
+            self.poll_set.wake_from_irq(IoEvents::IN | IoEvents::ERR);
+        } else {
+            self.poll_set.wake_from_irq(IoEvents::ERR);
+        }
+    }
+
+    // ── 驱动侧：VbPoolLease ─────────────────────────────────────────────
+    pub(crate) fn acquire_frame(&self) -> Option<ActiveFrame> {
+        let mut inner = self.state.lock();
+        for (idx, vb) in inner.buffers.iter_mut().enumerate() {
+            if vb.state == BufferState::Ready {
+                let plane = vb.planes.first()?;
+                if plane.length == 0 {
+                    continue;
+                }
+                vb.state = BufferState::Active;
+                return Some(ActiveFrame {
+                    buffer_index: idx as u32,
+                    data_ptr: plane.as_ptr(),
+                    len: plane.length as usize,
+                });
+            }
+        }
+        None
+    }
+
+    /// 获取安全租约——始终返回 `VbPoolLease`，内部 `frame` 可能为 `None`（池空）。
+    /// 驱动通过 `as_mut_slice` 安全访问，`commit` 时自动重填下一帧。
+    pub fn acquire(self: &Arc<Self>) -> VbPoolLease<M> {
+        let frame = self.acquire_frame();
+        VbPoolLease::new(Arc::clone(self), frame)
+    }
+
+    fn commit_frame(&self, frame: ActiveFrame, bytesused: u32) {
+        self.commit_inner(frame.buffer_index, bytesused, BufferState::Done)
+    }
+
+    fn abort_frame(&self, frame: ActiveFrame) {
+        self.commit_inner(frame.buffer_index, 0, BufferState::Error)
+    }
+
+    fn commit_inner(&self, index: u32, bytesused: u32, state: BufferState) {
+        let mut guard = self.state.lock();
+        let inner = &mut *guard;
+        // 内部路径保证：index 来自已 `Active` 的租约，state 仅为 Done/Error
+        let vb = &mut inner.buffers[index as usize];
+        vb.bytesused = bytesused;
+        vb.timestamp = Timestamp::Monotonic(ax_runtime::hal::time::monotonic_time_nanos());
+        inner.sequence += 1;
+        vb.sequence = inner.sequence;
+        vb.state = state;
+        inner.done_queue.push_back(index);
+        drop(guard);
+        self.poll_set.wake_from_irq(IoEvents::IN);
+    }
+}
+
+/// Ioctl 委托——`reqbufs/qbuf/dqbuf/streamon/streamoff` 直接调用的池操作。
+impl<M: VbMemOps> VbPool<M> {
+    pub fn reqbufs(&self, count: u32, plane_sizes: &[u32]) -> Result<(), V4l2Error> {
+        let mut inner = self.state.lock();
+        if inner.streaming {
+            log::warn!(
+                "[vb2] reqbufs Busy: streaming=true count={} buffers={}",
+                count,
+                inner.buffers.len()
+            );
+            return Err(V4l2Error::Busy);
+        }
+        if count == 0 {
+            for vb in inner.buffers.drain(..) {
+                self.allocator.release(&vb.planes);
+            }
+            inner.ready_queue.clear();
+            inner.done_queue.clear();
+            inner.sequence = 0;
+            return Ok(());
+        }
+        if plane_sizes.len() != 1 {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let num_buffers = count.clamp(self.min_buffers, self.max_buffers);
+        let mut tmp = Vec::with_capacity(num_buffers as usize);
+        for _ in 0..num_buffers {
+            match self.allocator.alloc(plane_sizes) {
+                Ok(planes) => tmp.push(VbBuffer {
+                    state: BufferState::Free,
+                    planes,
+                    bytesused: 0,
+                    sequence: 0,
+                    timestamp: Timestamp::Unset,
+                }),
+                Err(e) => {
+                    // 回收已分配的缓冲
+                    for vb in tmp {
+                        self.allocator.release(&vb.planes);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        for vb in inner.buffers.drain(..) {
+            self.allocator.release(&vb.planes);
+        }
+        inner.ready_queue.clear();
+        inner.done_queue.clear();
+        inner.sequence = 0;
+        inner.buffers = tmp;
+        Ok(())
+    }
+
+    pub fn qbuf(&self, index: u32) -> Result<(), V4l2Error> {
+        let mut inner = self.state.lock();
+        if inner.error {
+            return Err(V4l2Error::Io);
+        }
+        let vb = inner
+            .buffers
+            .get_mut(index as usize)
+            .ok_or(V4l2Error::InvalidArgument)?;
+        if vb.state != BufferState::Free {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        vb.state = BufferState::Ready;
+        inner.ready_queue.push_back(index);
+        Ok(())
+    }
+
+    pub fn dqbuf(&self) -> Result<u32, V4l2Error> {
+        let mut inner = self.state.lock();
+        let idx = inner.done_queue.pop_front().ok_or(V4l2Error::Busy)?;
+        let vb = &mut inner.buffers[idx as usize];
+        if vb.state != BufferState::Done && vb.state != BufferState::Error {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        vb.state = BufferState::Free;
+        if let Some(pos) = inner.ready_queue.iter().position(|&i| i == idx) {
+            inner.ready_queue.remove(pos);
+        }
+        Ok(idx)
+    }
+
+    pub fn prepare_buf(&self, index: u32) -> Result<(), V4l2Error> {
+        let mut inner = self.state.lock();
+        if inner.error {
+            return Err(V4l2Error::Io);
+        }
+        let vb = inner
+            .buffers
+            .get_mut(index as usize)
+            .ok_or(V4l2Error::InvalidArgument)?;
+        if vb.state != BufferState::Free {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        Ok(())
+    }
+
+    pub fn streamon(&self) -> Result<(), V4l2Error> {
+        let mut inner = self.state.lock();
+        if inner.streaming {
+            return Err(V4l2Error::Busy);
+        }
+        if inner.buffers.is_empty() {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        inner.streaming = true;
+        Ok(())
+    }
+
+    pub fn streamoff(&self) {
+        let mut inner = self.state.lock();
+        for vb in &mut inner.buffers {
+            if vb.state != BufferState::Free {
+                vb.state = BufferState::Free;
+            }
+        }
+        inner.streaming = false;
+        inner.error = false;
+        inner.ready_queue.clear();
+        inner.done_queue.clear();
+        drop(inner);
+        self.poll_set.wake_from_irq(IoEvents::IN | IoEvents::ERR);
+    }
+
+    pub fn buffer_snapshot(&self, index: u32) -> Option<VbBuffer> {
+        self.state.lock().buffers.get(index as usize).cloned()
+    }
+
+    pub fn num_buffers(&self) -> u32 {
+        self.state.lock().buffers.len() as u32
+    }
+}
+
+/// 驱动从 `VbPool` 获取的安全读写租约。
+pub struct VbPoolLease<M: VbMemOps> {
+    pool: Arc<VbPool<M>>,
+    frame: Option<ActiveFrame>,
+}
+
+impl<M: VbMemOps> VbPoolLease<M> {
+    fn new(pool: Arc<VbPool<M>>, frame: Option<ActiveFrame>) -> Self {
+        Self { pool, frame }
+    }
+
+    /// 尝试获取可写缓冲守卫。
+    pub fn try_acquire(&mut self) -> Option<FrameGuard<'_, M>> {
+        if self.frame.is_none() {
+            self.frame = self.pool.acquire_frame();
+        }
+
+        if self.frame.is_some() {
+            Some(FrameGuard::new(self))
+        } else {
+            None
+        }
+    }
+
+    /// 独占可写视图，驱动应通过此接口填充数据，避免裸指针 `copy`
+    fn as_mut_slice(&mut self) -> &mut [u8] {
+        let f = self.frame.as_mut().expect("frame already taken");
+        unsafe { core::slice::from_raw_parts_mut(f.data_ptr, f.len) }
+    }
+
+    fn commit(&mut self, bytesused: u32) {
+        if let Some(frame) = self.frame.take() {
+            self.pool.commit_frame(frame, bytesused);
+        }
+        self.frame = self.pool.acquire_frame();
+    }
+
+    fn abort(&mut self) {
+        if let Some(frame) = self.frame.take() {
+            self.pool.abort_frame(frame);
+        }
+        self.frame = self.pool.acquire_frame();
+    }
+}
+
+impl<M: VbMemOps> Drop for VbPoolLease<M> {
+    fn drop(&mut self) {
+        if let Some(frame) = self.frame.take() {
+            self.pool.abort_frame(frame);
+        }
+    }
+}
+
+pub struct FrameGuard<'a, M: VbMemOps> {
+    lease: &'a mut VbPoolLease<M>,
+}
+
+impl<'a, M: VbMemOps> FrameGuard<'a, M> {
+    pub fn new(lease: &'a mut VbPoolLease<M>) -> Self {
+        Self { lease }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.lease.as_mut_slice()
+    }
+
+    pub fn commit(self, bytesused: u32) {
+        self.lease.commit(bytesused)
+    }
+
+    pub fn abort(self) {
+        self.lease.abort()
+    }
+}

--- a/drivers/media/uvc/Cargo.toml
+++ b/drivers/media/uvc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "media-uvc"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+ax-media = { workspace = true }
+crab-usb = { workspace = true }
+ax-sync = { workspace = true, features = ["sleep"] }
+ax-task = { workspace = true }
+axpoll = { workspace = true }
+log = { workspace = true }
+anyhow = { workspace = true }
+bitflags = { workspace = true }

--- a/drivers/media/uvc/src/controls.rs
+++ b/drivers/media/uvc/src/controls.rs
@@ -1,0 +1,515 @@
+//! UVC controls — Processing Unit / Camera Terminal → V4L2 (UVC 1.5 §4.2.2).
+
+use alloc::{boxed::Box, sync::Arc, vec::Vec};
+
+use ax_media::{
+    CtrlConfig, CtrlGetFn, CtrlSetFn, CtrlType,
+    class::{CameraClassCtrl, CtrlClass, UserClassCtrl},
+    interface::ctrl::CtrlFlags,
+};
+use crab_usb::usb_if::{
+    host::ControlSetup,
+    transfer::{Recipient, RequestType},
+};
+
+use crate::{
+    UvcDevice, UvcHandle,
+    descriptors::{ControlCapabilities, RequestCode},
+};
+
+/// Parsed VC units.
+#[derive(Debug, Default)]
+pub(crate) struct VcUnits {
+    pub camera_terminal_id: Option<u8>,
+    pub camera_controls: Vec<u8>,
+    pub processing_unit_id: Option<u8>,
+    pub processing_controls: Vec<u8>,
+}
+
+/// 摄像头终端控制选择器 (A.9.4)
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum CameraTerminalControl {
+    Undefined            = 0x00,
+    ScanningMode         = 0x01,
+    AeMode               = 0x02,
+    AePriority           = 0x03,
+    ExposureTimeAbsolute = 0x04,
+    ExposureTimeRelative = 0x05,
+    FocusAbsolute        = 0x06,
+    FocusRelative        = 0x07,
+    FocusAuto            = 0x08,
+    IrisAbsolute         = 0x09,
+    IrisRelative         = 0x0A,
+    ZoomAbsolute         = 0x0B,
+    ZoomRelative         = 0x0C,
+    PantiltAbsolute      = 0x0D,
+    PantiltRelative      = 0x0E,
+    RollAbsolute         = 0x0F,
+    RollRelative         = 0x10,
+    Privacy              = 0x11,
+    FocusSimple          = 0x12,
+    DigitalWindow        = 0x13,
+    RegionOfInterest     = 0x14,
+}
+
+/// 处理单元控制选择器 (A.9.5)
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum ProcessingUnitControl {
+    Undefined           = 0x00,
+    BacklightCompensation = 0x01,
+    Brightness          = 0x02,
+    Contrast            = 0x03,
+    Gain                = 0x04,
+    PowerLineFrequency  = 0x05,
+    Hue                 = 0x06,
+    Saturation          = 0x07,
+    Sharpness           = 0x08,
+    Gamma               = 0x09,
+    WhiteBalanceTemperature = 0x0A,
+    WhiteBalanceTemperatureAuto = 0x0B,
+    WhiteBalanceComponent = 0x0C,
+    WhiteBalanceComponentAuto = 0x0D,
+    DigitalMultiplier   = 0x0E,
+    DigitalMultiplierLimit = 0x0F,
+    HueAuto             = 0x10,
+    AnalogVideoStandard = 0x11,
+    AnalogLockStatus    = 0x12,
+    ContrastAuto        = 0x13,
+}
+
+/// Power line frequency menu.
+const POWER_LINE_FREQ_MENU: &[&str] = &["Disabled", "50 Hz", "60 Hz"];
+
+/// Exposure auto menu.
+const EXPOSURE_AUTO_MENU: &[&str] = &[
+    "Manual Mode",
+    "Aperture Priority Mode",
+    "Shutter Priority Mode",
+    "Auto Mode",
+];
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UvcCtrlType {
+    Integer,
+    Boolean,
+    Menu(&'static [&'static str]),
+    Button,
+}
+
+struct UvcControlDef {
+    cid: u32,
+    name: &'static str,
+    selector: u8,
+    size: usize,
+    ctrl_bit: u8,
+    ty: UvcCtrlType,
+}
+
+const UVC_CONTROL_PU_DEFS: &[UvcControlDef] = &[
+    UvcControlDef {
+        cid: UserClassCtrl::Brightness as u32,
+        name: "Brightness",
+        selector: ProcessingUnitControl::Brightness as u8,
+        size: 2,
+        ctrl_bit: 0,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::Contrast as u32,
+        name: "Contrast",
+        selector: ProcessingUnitControl::Contrast as u8,
+        size: 2,
+        ctrl_bit: 1,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::Hue as u32,
+        name: "Hue",
+        selector: ProcessingUnitControl::Hue as u8,
+        size: 2,
+        ctrl_bit: 2,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::Saturation as u32,
+        name: "Saturation",
+        selector: ProcessingUnitControl::Saturation as u8,
+        size: 2,
+        ctrl_bit: 3,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::Sharpness as u32,
+        name: "Sharpness",
+        selector: ProcessingUnitControl::Sharpness as u8,
+        size: 2,
+        ctrl_bit: 4,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::Gamma as u32,
+        name: "Gamma",
+        selector: ProcessingUnitControl::Gamma as u8,
+        size: 2,
+        ctrl_bit: 5,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::WhiteBalanceTemperature as u32,
+        name: "White Balance Temperature",
+        selector: ProcessingUnitControl::WhiteBalanceTemperature as u8,
+        size: 2,
+        ctrl_bit: 6,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::BacklightCompensation as u32,
+        name: "Backlight Compensation",
+        selector: ProcessingUnitControl::BacklightCompensation as u8,
+        size: 2,
+        ctrl_bit: 8,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::Gain as u32,
+        name: "Gain",
+        selector: ProcessingUnitControl::Gain as u8,
+        size: 2,
+        ctrl_bit: 9,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::PowerLineFrequency as u32,
+        name: "Power Line Frequency",
+        selector: ProcessingUnitControl::PowerLineFrequency as u8,
+        size: 1,
+        ctrl_bit: 10,
+        ty: UvcCtrlType::Menu(POWER_LINE_FREQ_MENU),
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::HueAuto as u32,
+        name: "Hue Auto",
+        selector: ProcessingUnitControl::HueAuto as u8,
+        size: 1,
+        ctrl_bit: 11,
+        ty: UvcCtrlType::Boolean,
+    },
+    UvcControlDef {
+        cid: UserClassCtrl::AutoWhiteBalance as u32,
+        name: "Auto White Balance",
+        selector: ProcessingUnitControl::WhiteBalanceTemperatureAuto as u8,
+        size: 1,
+        ctrl_bit: 12,
+        ty: UvcCtrlType::Boolean,
+    },
+];
+
+const UVC_CONTROL_CT_DEFS: &[UvcControlDef] = &[
+    UvcControlDef {
+        cid: CameraClassCtrl::ExposureAuto as u32,
+        name: "Exposure, Auto",
+        selector: CameraTerminalControl::AeMode as u8,
+        size: 1,
+        ctrl_bit: 1,
+        ty: UvcCtrlType::Menu(EXPOSURE_AUTO_MENU),
+    },
+    UvcControlDef {
+        cid: CameraClassCtrl::ExposureAutoPriority as u32,
+        name: "Exposure, Auto Priority",
+        selector: CameraTerminalControl::AePriority as u8,
+        size: 1,
+        ctrl_bit: 2,
+        ty: UvcCtrlType::Boolean,
+    },
+    UvcControlDef {
+        cid: CameraClassCtrl::ExposureAbsolute as u32,
+        name: "Exposure (Absolute)",
+        selector: CameraTerminalControl::ExposureTimeAbsolute as u8,
+        size: 4,
+        ctrl_bit: 3,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: CameraClassCtrl::FocusAbsolute as u32,
+        name: "Focus (Absolute)",
+        selector: CameraTerminalControl::FocusAbsolute as u8,
+        size: 2,
+        ctrl_bit: 5,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: CameraClassCtrl::FocusAuto as u32,
+        name: "Focus, Auto",
+        selector: CameraTerminalControl::FocusAuto as u8,
+        size: 1,
+        ctrl_bit: 17,
+        ty: UvcCtrlType::Boolean,
+    },
+    UvcControlDef {
+        cid: CameraClassCtrl::IrisAbsolute as u32,
+        name: "Iris, Absolute",
+        selector: CameraTerminalControl::IrisAbsolute as u8,
+        size: 2,
+        ctrl_bit: 7,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: CameraClassCtrl::ZoomAbsolute as u32,
+        name: "Zoom, Absolute",
+        selector: CameraTerminalControl::ZoomAbsolute as u8,
+        size: 2,
+        ctrl_bit: 9,
+        ty: UvcCtrlType::Integer,
+    },
+    UvcControlDef {
+        cid: CameraClassCtrl::Privacy as u32,
+        name: "Privacy",
+        selector: CameraTerminalControl::Privacy as u8,
+        size: 1,
+        ctrl_bit: 18,
+        ty: UvcCtrlType::Boolean,
+    },
+];
+
+fn control_supported(bitmap: &[u8], bit: u8) -> bool {
+    let byte = (bit / 8) as usize;
+    let b = bit % 8;
+    bitmap.get(byte).is_some_and(|v| (v >> b) & 1 == 1)
+}
+
+fn decode_uvc_value(buf: &[u8]) -> Option<i64> {
+    match buf.len() {
+        1 => Some(buf[0] as i64),
+        2 => Some(i16::from_le_bytes([buf[0], buf[1]]) as i64),
+        4 => Some(i32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as i64),
+        _ => None,
+    }
+}
+
+fn encode_uvc_value(v: i64, size: usize) -> Option<Vec<u8>> {
+    match size {
+        1 => Some(vec![v as u8]),
+        2 => Some((v as i16).to_le_bytes().to_vec()),
+        4 => Some((v as i32).to_le_bytes().to_vec()),
+        _ => None,
+    }
+}
+
+/// Register a single control.
+#[allow(clippy::too_many_arguments)]
+fn register_control<H: UvcHandle>(
+    ctrls: &mut ax_media::CtrlHandler,
+    handle: &Arc<H>,
+    vc_iface: u8,
+    unit_id: u8,
+    bitmap: &[u8],
+    def: &UvcControlDef,
+    log_tag: &str,
+) {
+    let cid_raw = def.cid;
+    let name = def.name;
+    let sel_raw = def.selector;
+    let size = def.size;
+    let ctrl_bit = def.ctrl_bit;
+    let ty = def.ty;
+    if ctrls.find(cid_raw).is_some() {
+        return;
+    }
+    if !control_supported(bitmap, ctrl_bit) {
+        return;
+    }
+
+    let info_byte = {
+        let mut buf = vec![0u8; 1];
+        let setup = ControlSetup {
+            request_type: RequestType::Class,
+            recipient: Recipient::Interface,
+            request: RequestCode::GetInfo.into(),
+            value: (sel_raw as u16) << 8,
+            index: ((unit_id as u16) << 8) | vc_iface as u16,
+        };
+        match handle.control_in(setup, &mut buf) {
+            Ok(_) => buf[0],
+            Err(e) => {
+                log::debug!("uvc: {log_tag} {name} GetInfo err sel {sel_raw:#x}: {e:?}");
+                return;
+            }
+        }
+    };
+    let caps = ControlCapabilities::from_bits_truncate(info_byte);
+    if caps.contains(ControlCapabilities::DISABLED) {
+        log::debug!("uvc: {log_tag} {name} disabled info={info_byte:#x}");
+        return;
+    }
+    if !caps.contains(ControlCapabilities::GET) {
+        log::debug!("uvc: {log_tag} {name} no GET support info={info_byte:#x}");
+        return;
+    }
+
+    let read = {
+        let handle = handle.clone();
+        move |request: RequestCode| -> Option<i64> {
+            let mut buf = vec![0u8; size];
+            let setup = ControlSetup {
+                request_type: RequestType::Class,
+                recipient: Recipient::Interface,
+                request: request.into(),
+                value: (sel_raw as u16) << 8,
+                index: ((unit_id as u16) << 8) | vc_iface as u16,
+            };
+            handle.control_in(setup, &mut buf).ok()?;
+            decode_uvc_value(&buf)
+        }
+    };
+
+    let h = handle.clone();
+    let get_fn: CtrlGetFn = Box::new(move || {
+        let mut buf = vec![0u8; size];
+        let setup = ControlSetup {
+            request_type: RequestType::Class,
+            recipient: Recipient::Interface,
+            request: RequestCode::GetCur.into(),
+            value: (sel_raw as u16) << 8,
+            index: ((unit_id as u16) << 8) | vc_iface as u16,
+        };
+        h.control_in(setup, &mut buf)
+            .map_err(|_| ax_media::V4l2Error::Io)?;
+        let raw = decode_uvc_value(&buf).ok_or(ax_media::V4l2Error::Io)?;
+        if cid_raw == CameraClassCtrl::ExposureAuto as u32 {
+            Ok(raw.trailing_zeros() as i64)
+        } else {
+            Ok(raw)
+        }
+    });
+
+    let h = handle.clone();
+    let set_fn: CtrlSetFn = Box::new(move |v| {
+        let orig_v = v;
+        let v = if cid_raw == CameraClassCtrl::ExposureAuto as u32 {
+            1i64 << v
+        } else {
+            v
+        };
+        let buf = encode_uvc_value(v, size).ok_or(ax_media::V4l2Error::Io)?;
+        let setup = ControlSetup {
+            request_type: RequestType::Class,
+            recipient: Recipient::Interface,
+            request: RequestCode::SetCur.into(),
+            value: (sel_raw as u16) << 8,
+            index: ((unit_id as u16) << 8) | vc_iface as u16,
+        };
+        h.control_out(setup, &buf)
+            .map_err(|_| ax_media::V4l2Error::Io)?;
+        Ok(orig_v)
+    });
+
+    let ops = ax_media::CtrlOps {
+        get: Some(get_fn),
+        try_ctrl: None,
+        set: set_fn,
+    };
+
+    let res = match ty {
+        UvcCtrlType::Integer => {
+            let Some(min) = read(RequestCode::GetMin) else {
+                return;
+            };
+            let Some(max) = read(RequestCode::GetMax) else {
+                return;
+            };
+            let step = read(RequestCode::GetRes).unwrap_or(1).max(1);
+            let default = read(RequestCode::GetDef).unwrap_or(min);
+            ctrls.new_int(cid_raw, name, min, max, step, default, Some(ops))
+        }
+        UvcCtrlType::Boolean => {
+            let default = read(RequestCode::GetDef).unwrap_or(0);
+            ctrls.new_bool(cid_raw, name, default != 0, Some(ops))
+        }
+        UvcCtrlType::Menu(qmenu) => {
+            let default = read(RequestCode::GetDef).unwrap_or(0);
+            let default_idx = if cid_raw == CameraClassCtrl::ExposureAuto as u32 {
+                (default.trailing_zeros() as i64).clamp(0, qmenu.len() as i64 - 1) as u32
+            } else {
+                (default as u32).min(qmenu.len() as u32 - 1)
+            };
+            let res = ctrls.new_menu(
+                cid_raw,
+                name,
+                qmenu.len() as u32,
+                default_idx,
+                qmenu,
+                Some(ops),
+            );
+            if cid_raw == CameraClassCtrl::ExposureAuto as u32 {
+                ctrls.set_step(cid_raw, (1u64 << 0) | (1u64 << 2));
+            }
+            res
+        }
+        UvcCtrlType::Button => ctrls.new_button(cid_raw, name, Some(ops)),
+    };
+    if let Err(e) = res {
+        log::warn!("uvc: skip {log_tag} {name} (0x{cid_raw:08x}): {e:?}");
+    }
+}
+
+impl<H: UvcHandle> UvcDevice<H> {
+    pub(crate) fn register_controls(&mut self, units: &VcUnits) {
+        let _ = self.ctrls.new_ctrl(CtrlConfig {
+            id: (CtrlClass::User as u32) | 1,
+            name: "User Controls",
+            ctrl_type: CtrlType::CtrlClass,
+            minimum: 0,
+            maximum: 0,
+            step: 0,
+            default_value: 0,
+            flags: CtrlFlags::empty(),
+            qmenu: None,
+            ops: None,
+        });
+        let _ = self.ctrls.new_ctrl(CtrlConfig {
+            id: (CtrlClass::Camera as u32) | 1,
+            name: "Camera Controls",
+            ctrl_type: CtrlType::CtrlClass,
+            minimum: 0,
+            maximum: 0,
+            step: 0,
+            default_value: 0,
+            flags: CtrlFlags::empty(),
+            qmenu: None,
+            ops: None,
+        });
+
+        let vc_iface = self.vc_iface_num;
+        if let Some(unit_id) = units.processing_unit_id {
+            for def in UVC_CONTROL_PU_DEFS {
+                register_control(
+                    &mut self.ctrls,
+                    &self.handle,
+                    vc_iface,
+                    unit_id,
+                    &units.processing_controls,
+                    def,
+                    "PU",
+                );
+            }
+        }
+        if let Some(unit_id) = units.camera_terminal_id {
+            for def in UVC_CONTROL_CT_DEFS {
+                register_control(
+                    &mut self.ctrls,
+                    &self.handle,
+                    vc_iface,
+                    unit_id,
+                    &units.camera_controls,
+                    def,
+                    "CT",
+                );
+            }
+        }
+    }
+}

--- a/drivers/media/uvc/src/descriptors.rs
+++ b/drivers/media/uvc/src/descriptors.rs
@@ -1,0 +1,766 @@
+#![allow(dead_code)]
+
+use alloc::vec::Vec;
+
+use anyhow::anyhow;
+use bitflags::bitflags;
+use crab_usb::err::USBError;
+use log::trace;
+
+/// UVC 类特定请求码 (A.8)——互斥值，用枚举表达。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum RequestCode {
+    SetCur  = 0x01,
+    GetCur  = 0x81,
+    GetMin  = 0x82,
+    GetMax  = 0x83,
+    GetRes  = 0x84,
+    GetLen  = 0x85,
+    GetInfo = 0x86,
+    GetDef  = 0x87,
+}
+
+/// UVC 接口子类代码 (A.2)——互斥值。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum InterfaceSubclass {
+    Undefined      = 0x00,
+    VideoControl   = 0x01,
+    VideoStreaming = 0x02,
+    VideoInterfaceCollection = 0x03,
+}
+
+/// UVC 协议代码 (A.3)
+pub(crate) mod protocol_codes {
+    pub(crate) const UNDEFINED: u8 = 0x00;
+}
+
+/// VideoControl 接口描述符子类型 (A.5)——互斥值。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum VcDescriptorSubtype {
+    Undefined      = 0x00,
+    Header         = 0x01,
+    InputTerminal  = 0x02,
+    OutputTerminal = 0x03,
+    SelectorUnit   = 0x04,
+    ProcessingUnit = 0x05,
+    ExtensionUnit  = 0x06,
+}
+
+/// VideoStreaming 接口描述符子类型 (UVC 1.5 Table A.6)——互斥值。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum VsDescriptorSubtype {
+    Undefined           = 0x00, // 未定义
+    InputHeader         = 0x01, // 输入头描述符
+    OutputHeader        = 0x02, // 输出头描述符
+    StillImageFrame     = 0x03, // 静态图像帧描述符
+    FormatUncompressed  = 0x04, // 未压缩格式描述符
+    FrameUncompressed   = 0x05, // 未压缩帧描述符
+    FormatMjpeg         = 0x06, // MJPEG 格式描述符
+    FrameMjpeg          = 0x07, // MJPEG 帧描述符
+    FormatMpeg2Ts       = 0x0A, // MPEG2-TS 格式描述符
+    FormatDv            = 0x0C, // DV 格式描述符
+    Colorformat         = 0x0D, // 颜色格式描述符
+    FormatFrameBased    = 0x10, // 基于帧的格式描述符 - H.264 等变长帧
+    FrameFrameBased     = 0x11, // 基于帧的帧描述符
+    FormatStreamBased   = 0x12, // 基于流的格式描述符
+    FormatH264          = 0x13, // H.264 格式描述符
+    FrameH264           = 0x14, // H.264 帧描述符
+    FormatH264Simulcast = 0x15, // H.264 Simulcast 格式描述符
+}
+
+/// VideoStreaming 接口控制选择器 (A.9.7)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum VideoStreamingControl {
+    Undefined          = 0x00,
+    Probe              = 0x01,
+    Commit             = 0x02,
+    StillProbe         = 0x03,
+    StillCommit        = 0x04,
+    StillImageTrigger  = 0x05,
+    StreamErrorCode    = 0x06,
+    GenerateKeyFrame   = 0x07,
+    UpdateFrameSegment = 0x08,
+    SyncDelay          = 0x09,
+}
+
+/// UVC 描述符类型——互斥值。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum DescriptorType {
+    Undefined     = 0x00,
+    Device        = 0x01,
+    Configuration = 0x02,
+    String        = 0x03,
+    Interface     = 0x04,
+    Endpoint      = 0x05,
+    CsInterface   = 0x24,
+    CsEndpoint    = 0x25,
+}
+
+/// 终端类型 (B.1-B.4)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u16)]
+pub(crate) enum TerminalType {
+    // USB 终端类型 (B.1)
+    TtVendorSpecific   = 0x0100,
+    TtStreaming        = 0x0101,
+    // 输入终端类型 (B.2)
+    IttVendorSpecific  = 0x0200,
+    IttCamera          = 0x0201,
+    IttMediaTransportInput = 0x0202,
+    // 输出终端类型 (B.3)
+    OttVendorSpecific  = 0x0300,
+    OttDisplay         = 0x0301,
+    OttMediaTransportOutput = 0x0302,
+    // 外部终端类型 (B.4)
+    ExternalVendorSpecific = 0x0400,
+    CompositeConnector = 0x0401,
+    SvideoConnector    = 0x0402,
+    ComponentConnector = 0x0403,
+}
+
+/// UVC 格式 GUID 常量
+pub(crate) mod format_guids {
+    pub(crate) const YUY2: [u8; 16] = [
+        0x59, 0x55, 0x59, 0x32, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b,
+        0x71,
+    ];
+    pub(crate) const NV12: [u8; 16] = [
+        0x4e, 0x56, 0x31, 0x32, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b,
+        0x71,
+    ];
+    pub(crate) const UYVY: [u8; 16] = [
+        0x55, 0x59, 0x56, 0x59, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b,
+        0x71,
+    ];
+    pub(crate) const GREY: [u8; 16] = [
+        0x59, 0x38, 0x30, 0x30, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38, 0x9b,
+        0x71,
+    ];
+    pub(crate) const BGR24: [u8; 16] = [
+        0x7d, 0xeb, 0x36, 0xe4, 0x4f, 0x52, 0xce, 0x11, 0x9f, 0x53, 0x00, 0x20, 0xaf, 0x0b, 0xa7,
+        0x70,
+    ];
+    pub(crate) const XBGR32: [u8; 16] = [
+        0x7e, 0xeb, 0x36, 0xe4, 0x4f, 0x52, 0xce, 0x11, 0x9f, 0x53, 0x00, 0x20, 0xaf, 0x0b, 0xa7,
+        0x70,
+    ];
+}
+
+bitflags! {
+    /// 控制能力标志 (4.1.2)。
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) struct ControlCapabilities: u8 {
+        const GET = 1 << 0;
+        const SET = 1 << 1;
+        const DISABLED = 1 << 2;
+        const AUTOUPDATE = 1 << 3;
+        const ASYNCHRONOUS = 1 << 4;
+    }
+}
+
+/// 原始值 → 枚举（`match x.into()` scrutinee 用；非法值兜底到 `Undefined`，
+/// 落入 match 的 `_` 分支——UVC 规范 0x00 即 UNDEFINED）。
+impl From<u8> for InterfaceSubclass {
+    fn from(v: u8) -> Self {
+        match v {
+            0x01 => Self::VideoControl,
+            0x02 => Self::VideoStreaming,
+            0x03 => Self::VideoInterfaceCollection,
+            _ => Self::Undefined,
+        }
+    }
+}
+
+impl From<u8> for DescriptorType {
+    fn from(v: u8) -> Self {
+        match v {
+            0x01 => Self::Device,
+            0x02 => Self::Configuration,
+            0x03 => Self::String,
+            0x04 => Self::Interface,
+            0x05 => Self::Endpoint,
+            0x24 => Self::CsInterface,
+            0x25 => Self::CsEndpoint,
+            _ => Self::Undefined,
+        }
+    }
+}
+
+impl From<u8> for VcDescriptorSubtype {
+    fn from(v: u8) -> Self {
+        match v {
+            0x01 => Self::Header,
+            0x02 => Self::InputTerminal,
+            0x03 => Self::OutputTerminal,
+            0x04 => Self::SelectorUnit,
+            0x05 => Self::ProcessingUnit,
+            0x06 => Self::ExtensionUnit,
+            _ => Self::Undefined,
+        }
+    }
+}
+
+impl From<u8> for VsDescriptorSubtype {
+    fn from(v: u8) -> Self {
+        match v {
+            0x01 => Self::InputHeader,
+            0x02 => Self::OutputHeader,
+            0x03 => Self::StillImageFrame,
+            0x04 => Self::FormatUncompressed,
+            0x05 => Self::FrameUncompressed,
+            0x06 => Self::FormatMjpeg,
+            0x07 => Self::FrameMjpeg,
+            0x0A => Self::FormatMpeg2Ts,
+            0x0C => Self::FormatDv,
+            0x0D => Self::Colorformat,
+            0x10 => Self::FormatFrameBased,
+            0x11 => Self::FrameFrameBased,
+            0x12 => Self::FormatStreamBased,
+            0x13 => Self::FormatH264,
+            0x14 => Self::FrameH264,
+            0x15 => Self::FormatH264Simulcast,
+            _ => Self::Undefined,
+        }
+    }
+}
+
+/// 枚举 → 原始值转换（`into()` 用，类型安全；与 `as u8` 等价但显式）。
+impl From<RequestCode> for u8 {
+    fn from(v: RequestCode) -> u8 {
+        v as u8
+    }
+}
+
+impl From<InterfaceSubclass> for u8 {
+    fn from(v: InterfaceSubclass) -> u8 {
+        v as u8
+    }
+}
+
+impl From<VideoStreamingControl> for u8 {
+    fn from(v: VideoStreamingControl) -> u8 {
+        v as u8
+    }
+}
+
+impl From<DescriptorType> for u8 {
+    fn from(v: DescriptorType) -> u8 {
+        v as u8
+    }
+}
+
+impl From<TerminalType> for u16 {
+    fn from(v: TerminalType) -> u16 {
+        v as u16
+    }
+}
+
+/// UVC 请求码 → USB 传输请求（`Request: From<u8>`，一步转换）。
+impl From<RequestCode> for crab_usb::usb_if::transfer::Request {
+    fn from(v: RequestCode) -> Self {
+        (v as u8).into()
+    }
+}
+
+/// UVC描述符解析器
+pub(crate) struct DescriptorParser;
+
+impl DescriptorParser {
+    /// 创建新的描述符解析器实例
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    /// 解析输入终端描述符
+    pub(crate) fn parse_input_terminal(
+        &self,
+        data: &[u8],
+    ) -> Result<InputTerminalDescriptor, USBError> {
+        if data.len() < 15 {
+            Err(anyhow!("Input terminal descriptor too short"))?;
+        }
+
+        let length = data[0] as usize;
+        let terminal_id = data[3];
+        let terminal_type = u16::from_le_bytes([data[4], data[5]]);
+        let associated_terminal = data[6];
+
+        trace!(
+            "Input Terminal: ID={terminal_id}, type=0x{terminal_type:04x}, \
+             associated={associated_terminal}"
+        );
+
+        // 摄像头终端有额外字段
+        if terminal_type == TerminalType::IttCamera.into() && length >= 18 {
+            let objective_focal_length_min = u16::from_le_bytes([data[8], data[9]]);
+            let objective_focal_length_max = u16::from_le_bytes([data[10], data[11]]);
+            let ocular_focal_length = u16::from_le_bytes([data[12], data[13]]);
+            let controls_size = data[14] as usize;
+
+            let controls = if length >= 15 + controls_size {
+                data[15..15 + controls_size].to_vec()
+            } else {
+                vec![]
+            };
+
+            Ok(InputTerminalDescriptor::Camera {
+                length,
+                terminal_id,
+                terminal_type,
+                associated_terminal,
+                objective_focal_length_min,
+                objective_focal_length_max,
+                ocular_focal_length,
+                controls,
+            })
+        } else {
+            Ok(InputTerminalDescriptor::Generic {
+                length,
+                terminal_id,
+                terminal_type,
+                associated_terminal,
+            })
+        }
+    }
+
+    /// 解析处理单元描述符
+    pub(crate) fn parse_processing_unit(
+        &self,
+        data: &[u8],
+    ) -> Result<ProcessingUnitDescriptor, USBError> {
+        if data.len() < 10 {
+            Err(anyhow!("Processing unit descriptor too short"))?;
+        }
+
+        let length = data[0] as usize;
+        let unit_id = data[3];
+        let source_id = data[4];
+        let max_multiplier = u16::from_le_bytes([data[5], data[6]]);
+        let controls_size = data[7] as usize;
+
+        if length < 8 + controls_size {
+            Err(anyhow!("Processing unit controls data incomplete"))?;
+        }
+
+        let controls = data[8..8 + controls_size].to_vec();
+
+        trace!(
+            "Processing Unit: ID={unit_id}, source={source_id}, max_mult={max_multiplier}, \
+             controls={controls:02x?}"
+        );
+
+        Ok(ProcessingUnitDescriptor {
+            length,
+            unit_id,
+            source_id,
+            max_multiplier,
+            controls,
+        })
+    }
+
+    /// 解析未压缩格式描述符
+    pub(crate) fn parse_uncompressed_format(
+        &self,
+        data: &[u8],
+    ) -> Result<UncompressedFormatDescriptor, USBError> {
+        if data.len() < 27 {
+            Err(anyhow!("Uncompressed format descriptor too short"))?;
+        }
+
+        let length = data[0] as usize;
+        let format_index = data[3];
+        let num_frame_descriptors = data[4];
+        let mut guid = [0u8; 16];
+        guid.copy_from_slice(&data[5..21]);
+        let bits_per_pixel = data[21];
+        let default_frame_index = data[22];
+        let aspect_ratio_x = data[23];
+        let aspect_ratio_y = data[24];
+        let interlace_flags = data[25];
+        let copy_protect = data[26];
+
+        trace!(
+            "Uncompressed Format: index={format_index}, frames={num_frame_descriptors}, \
+             GUID={guid:02x?}, bpp={bits_per_pixel}"
+        );
+
+        Ok(UncompressedFormatDescriptor {
+            length,
+            format_index,
+            num_frame_descriptors,
+            guid,
+            bits_per_pixel,
+            default_frame_index,
+            aspect_ratio_x,
+            aspect_ratio_y,
+            interlace_flags,
+            copy_protect,
+        })
+    }
+
+    /// 解析帧描述符
+    pub(crate) fn parse_frame_descriptor(&self, data: &[u8]) -> Result<FrameDescriptor, USBError> {
+        if data.len() < 26 {
+            Err(anyhow!("Frame descriptor too short"))?;
+        }
+
+        let length = data[0] as usize;
+        let frame_index = data[3];
+        let capabilities = data[4];
+        let width = u16::from_le_bytes([data[5], data[6]]);
+        let height = u16::from_le_bytes([data[7], data[8]]);
+        let min_bit_rate = u32::from_le_bytes([data[9], data[10], data[11], data[12]]);
+        let max_bit_rate = u32::from_le_bytes([data[13], data[14], data[15], data[16]]);
+        let max_video_frame_buffer_size =
+            u32::from_le_bytes([data[17], data[18], data[19], data[20]]);
+        let default_frame_interval = u32::from_le_bytes([data[21], data[22], data[23], data[24]]);
+        let frame_interval_type = data[25];
+
+        trace!(
+            "Frame: {width}x{height}, bitrate={min_bit_rate}-{max_bit_rate}, \
+             buffer_size={max_video_frame_buffer_size}, interval={default_frame_interval}, \
+             type={frame_interval_type}"
+        );
+
+        // 解析帧间隔数据
+        let mut frame_intervals = Vec::new();
+        let mut pos = 26;
+
+        match frame_interval_type {
+            0 if length >= pos + 12 => {
+                // 连续帧间隔
+                let min_frame_interval =
+                    u32::from_le_bytes([data[pos], data[pos + 1], data[pos + 2], data[pos + 3]]);
+                let max_frame_interval = u32::from_le_bytes([
+                    data[pos + 4],
+                    data[pos + 5],
+                    data[pos + 6],
+                    data[pos + 7],
+                ]);
+                let step_frame_interval = u32::from_le_bytes([
+                    data[pos + 8],
+                    data[pos + 9],
+                    data[pos + 10],
+                    data[pos + 11],
+                ]);
+
+                frame_intervals = vec![min_frame_interval, max_frame_interval, step_frame_interval];
+            }
+            n if n > 0 => {
+                // 离散帧间隔
+                for _ in 0..n {
+                    if pos + 4 <= length {
+                        let interval = u32::from_le_bytes([
+                            data[pos],
+                            data[pos + 1],
+                            data[pos + 2],
+                            data[pos + 3],
+                        ]);
+                        frame_intervals.push(interval);
+                        pos += 4;
+                    }
+                }
+            }
+            _ => {}
+        }
+
+        Ok(FrameDescriptor {
+            length,
+            frame_index,
+            capabilities,
+            width,
+            height,
+            min_bit_rate,
+            max_bit_rate,
+            max_video_frame_buffer_size,
+            default_frame_interval,
+            frame_interval_type,
+            frame_intervals,
+        })
+    }
+
+    /// 解析 VS 输入头描述符 (InputHeader 0x01)
+    pub(crate) fn parse_input_header(
+        &self,
+        data: &[u8],
+    ) -> Result<InputHeaderDescriptor, USBError> {
+        if data.len() < 13 {
+            Err(anyhow!("InputHeader descriptor too short"))?;
+        }
+        let length = data[0] as usize;
+        if length < 13 || data.len() < length {
+            Err(anyhow!("InputHeader length invalid"))?;
+        }
+        // bDescriptorType 0x24 / bDescriptorSubtype 0x01 由调用方保证
+        let num_formats = data[3];
+        let total_length = u16::from_le_bytes([data[4], data[5]]);
+        let endpoint_address = data[6];
+        let info = data[7];
+        let terminal_link = data[8];
+        let still_capture_method = data[9];
+        let trigger_support = data[10];
+        let trigger_usage = data[11];
+        let control_size = data[12] as usize;
+
+        // bLength 必须为 13 + p*n (UVC §3.9.2.1)
+        let expected = 13usize + control_size * num_formats as usize;
+        if length < expected {
+            Err(anyhow!(
+                "InputHeader bLength {length} smaller than 13+p*n {expected}"
+            ))?;
+        }
+        if num_formats == 0 {
+            Err(anyhow!("InputHeader bNumFormats is 0"))?;
+        }
+
+        let controls = if control_size > 0 && num_formats > 0 {
+            let end = 13 + control_size * num_formats as usize;
+            if end <= data.len() {
+                data[13..end].to_vec()
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        };
+
+        trace!(
+            "InputHeader: formats={num_formats}, total={total_length}, \
+             ep=0x{endpoint_address:02x}, link={terminal_link}, \
+             still_method={still_capture_method}, controls={controls:02x?}"
+        );
+
+        Ok(InputHeaderDescriptor {
+            length,
+            num_formats,
+            total_length,
+            endpoint_address,
+            info,
+            terminal_link,
+            still_capture_method,
+            trigger_support,
+            trigger_usage,
+            control_size: control_size as u8,
+            controls,
+        })
+    }
+
+    /// 解析 VS 输出头描述符 (OutputHeader 0x02)
+    pub(crate) fn parse_output_header(
+        &self,
+        data: &[u8],
+    ) -> Result<OutputHeaderDescriptor, USBError> {
+        if data.len() < 9 {
+            Err(anyhow!("OutputHeader descriptor too short"))?;
+        }
+        let length = data[0] as usize;
+        if length < 9 || data.len() < length {
+            Err(anyhow!("OutputHeader length invalid"))?;
+        }
+        let num_formats = data[3];
+        let total_length = u16::from_le_bytes([data[4], data[5]]);
+        let endpoint_address = data[6];
+        let terminal_link = data[7];
+        let control_size = data[8] as usize;
+
+        let expected = 9usize + control_size * num_formats as usize;
+        if length < expected {
+            Err(anyhow!(
+                "OutputHeader bLength {length} smaller than 9+p*n {expected}"
+            ))?;
+        }
+
+        let controls = if control_size > 0 && num_formats > 0 {
+            let end = 9 + control_size * num_formats as usize;
+            if end <= data.len() {
+                data[9..end].to_vec()
+            } else {
+                vec![]
+            }
+        } else {
+            vec![]
+        };
+
+        trace!(
+            "OutputHeader: formats={num_formats}, total={total_length}, \
+             ep=0x{endpoint_address:02x}, link={terminal_link}, controls={controls:02x?}"
+        );
+
+        Ok(OutputHeaderDescriptor {
+            length,
+            num_formats,
+            total_length,
+            endpoint_address,
+            terminal_link,
+            control_size: control_size as u8,
+            controls,
+        })
+    }
+
+    /// 解析 VC 头描述符 (Header 0x01)
+    pub(crate) fn parse_vc_header(&self, data: &[u8]) -> Result<VcHeaderDescriptor, USBError> {
+        if data.len() < 12 {
+            Err(anyhow!("VC Header descriptor too short"))?;
+        }
+        let length = data[0] as usize;
+        if length < 12 || data.len() < length {
+            Err(anyhow!("VC Header length invalid"))?;
+        }
+        let bcd_uvc = u16::from_le_bytes([data[3], data[4]]);
+        let total_length = u16::from_le_bytes([data[5], data[6]]);
+        let clock_frequency = u32::from_le_bytes([data[7], data[8], data[9], data[10]]);
+        let in_collection = data[11];
+        let expected = 12usize + in_collection as usize;
+        // 容忍部分设备 wTotalLength/length 与 bInCollection 不一致（如测试中 12 vs 1）
+        let interface_numbers = if data.len() >= 12 + in_collection as usize {
+            data[12..12 + in_collection as usize].to_vec()
+        } else if length > 12 {
+            data[12..length].to_vec()
+        } else {
+            vec![]
+        };
+
+        trace!(
+            "VC Header: bcd=0x{bcd_uvc:04x}, total={total_length}, clk={clock_frequency}, \
+             in_col={in_collection}, ifs={interface_numbers:02x?}"
+        );
+
+        // 长度校验宽松：允许 expected 与 length 不完全一致时仍通过，交由上层 wTotalLength 校验
+        if length < 12 {
+            Err(anyhow!("VC Header bLength {length} < 12"))?;
+        }
+        let _ = expected;
+
+        Ok(VcHeaderDescriptor {
+            length,
+            bcd_uvc,
+            total_length,
+            clock_frequency,
+            in_collection,
+            interface_numbers,
+        })
+    }
+
+    /// 计算帧率（从帧间隔）
+    pub(crate) fn interval_to_fps(interval: u32) -> u32 {
+        10_000_000u32.checked_div(interval).unwrap_or(0) // 100ns单位转换为fps
+    }
+
+    /// 计算帧间隔（从帧率）
+    pub(crate) fn fps_to_interval(fps: u32) -> u32 {
+        10_000_000u32.checked_div(fps).unwrap_or(0) // fps转换为100ns单位
+    }
+}
+
+/// 输入终端描述符
+#[derive(Debug, Clone)]
+pub(crate) enum InputTerminalDescriptor {
+    Camera {
+        length: usize,
+        terminal_id: u8,
+        terminal_type: u16,
+        associated_terminal: u8,
+        objective_focal_length_min: u16,
+        objective_focal_length_max: u16,
+        ocular_focal_length: u16,
+        controls: Vec<u8>,
+    },
+    Generic {
+        length: usize,
+        terminal_id: u8,
+        terminal_type: u16,
+        associated_terminal: u8,
+    },
+}
+
+/// 处理单元描述符
+#[derive(Debug, Clone)]
+pub(crate) struct ProcessingUnitDescriptor {
+    pub length: usize,
+    pub unit_id: u8,
+    pub source_id: u8,
+    pub max_multiplier: u16,
+    pub controls: Vec<u8>,
+}
+
+/// 未压缩格式描述符
+#[derive(Debug, Clone)]
+pub(crate) struct UncompressedFormatDescriptor {
+    pub length: usize,
+    pub format_index: u8,
+    pub num_frame_descriptors: u8,
+    pub guid: [u8; 16],
+    pub bits_per_pixel: u8,
+    pub default_frame_index: u8,
+    pub aspect_ratio_x: u8,
+    pub aspect_ratio_y: u8,
+    pub interlace_flags: u8,
+    pub copy_protect: u8,
+}
+
+/// 帧描述符
+#[derive(Debug, Clone)]
+pub(crate) struct FrameDescriptor {
+    pub length: usize,    // 描述符长度
+    pub frame_index: u8,  // 帧索引
+    pub capabilities: u8, // 帧能力标志
+    pub width: u16,
+    pub height: u16,
+    pub min_bit_rate: u32,
+    pub max_bit_rate: u32,
+    pub max_video_frame_buffer_size: u32, // 最大视频帧缓冲区大小
+    pub default_frame_interval: u32,      // 默认帧间隔
+    pub frame_interval_type: u8,          // 帧间隔类型
+    pub frame_intervals: Vec<u32>,        // 帧间隔列表
+}
+
+/// VS 输入头描述符 (UVC 1.5 §3.9.2.1)
+#[derive(Debug, Clone)]
+pub(crate) struct InputHeaderDescriptor {
+    pub length: usize,
+    pub num_formats: u8,
+    pub total_length: u16,
+    pub endpoint_address: u8,
+    pub info: u8,
+    pub terminal_link: u8,
+    pub still_capture_method: u8,
+    pub trigger_support: u8,
+    pub trigger_usage: u8,
+    pub control_size: u8,
+    pub controls: Vec<u8>,
+}
+
+/// VS 输出头描述符 (UVC 1.5 §3.9.2.2)
+#[derive(Debug, Clone)]
+pub(crate) struct OutputHeaderDescriptor {
+    pub length: usize,
+    pub num_formats: u8,
+    pub total_length: u16,
+    pub endpoint_address: u8,
+    pub terminal_link: u8,
+    pub control_size: u8,
+    pub controls: Vec<u8>,
+}
+
+/// VC 头描述符 (UVC 1.5 §3.7.2)
+#[derive(Debug, Clone)]
+pub(crate) struct VcHeaderDescriptor {
+    pub length: usize,
+    pub bcd_uvc: u16,
+    pub total_length: u16,
+    pub clock_frequency: u32,
+    pub in_collection: u8,
+    pub interface_numbers: Vec<u8>,
+}
+
+impl Default for DescriptorParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/drivers/media/uvc/src/frame.rs
+++ b/drivers/media/uvc/src/frame.rs
@@ -1,0 +1,249 @@
+use bitflags::bitflags;
+
+bitflags! {
+    /// 载荷头标志 (2.4.3.3)。
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub(crate) struct PayloadHeaderFlags: u8 {
+        const EOH = 1 << 7; // End of Header
+        const ERR = 1 << 6; // Error
+        const STI = 1 << 5; // Still Image
+        const RES = 1 << 4; // Reserved
+        const SCR = 1 << 3; // Source Clock Reference
+        const PTS = 1 << 2; // Presentation Time Stamp
+        const EOF = 1 << 1; // End of Frame
+        const FID = 1 << 0; // Frame ID
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct UvcPayloadHeader {
+    pub flag: PayloadHeaderFlags,
+    #[allow(dead_code)]
+    pub pts: Option<u32>,
+}
+
+impl Default for UvcPayloadHeader {
+    fn default() -> Self {
+        Self {
+            flag: PayloadHeaderFlags::empty(),
+            pts: None,
+        }
+    }
+}
+
+impl UvcPayloadHeader {
+    /// Parse payload header.
+    pub(crate) fn parse(buf: &[u8]) -> Option<(Self, usize)> {
+        if buf.len() < 2 {
+            return None;
+        }
+        let b_length = buf[0] as usize;
+        let flag = PayloadHeaderFlags::from_bits_truncate(buf[1]);
+        if b_length < 2 || b_length > buf.len() {
+            return None;
+        }
+
+        let has_pts = flag.contains(PayloadHeaderFlags::PTS);
+        let has_scr = flag.contains(PayloadHeaderFlags::SCR);
+
+        let mut offset = 2usize;
+        let pts = if has_pts {
+            if offset + 4 > b_length {
+                return None;
+            }
+            let v = u32::from_le_bytes([
+                buf[offset],
+                buf[offset + 1],
+                buf[offset + 2],
+                buf[offset + 3],
+            ]);
+            offset += 4;
+            Some(v)
+        } else {
+            None
+        };
+
+        if has_scr && offset + 6 > b_length {
+            return None;
+        }
+
+        let header = UvcPayloadHeader { flag, pts };
+
+        Some((header, b_length))
+    }
+}
+
+/// Frame parser.
+#[derive(Debug, Default)]
+pub(crate) struct FrameParser {
+    last_fid: Option<bool>,
+    filled: usize,
+    synced: bool,
+}
+
+/// 单次 `push_packet` 的结果——以枚举使非法组合不可表示。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PushOutcome {
+    Pending,
+    Completed { bytes: usize },
+    CompletedAndRetry { bytes: usize },
+}
+
+impl FrameParser {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Process one packet.
+    pub(crate) fn push_packet(&mut self, data: &[u8], dest: &mut [u8]) -> PushOutcome {
+        let (hdr, hdr_len) = match UvcPayloadHeader::parse(data) {
+            Some(v) => v,
+            None => return PushOutcome::Pending,
+        };
+
+        let fid = hdr.flag.contains(PayloadHeaderFlags::FID);
+        let eof = hdr.flag.contains(PayloadHeaderFlags::EOF);
+        let fid_toggle = self.last_fid.is_some_and(|last| last != fid);
+        if fid_toggle && self.filled > 0 {
+            let bytes = self.finish_frame();
+            return PushOutcome::CompletedAndRetry { bytes };
+        }
+
+        if !self.synced {
+            match self.last_fid {
+                None => {
+                    self.last_fid = Some(fid);
+                    return PushOutcome::Pending;
+                }
+                Some(last) if last == fid => return PushOutcome::Pending,
+                Some(_) => self.synced = true,
+            }
+        }
+        self.last_fid = Some(fid);
+
+        let payload = &data[hdr_len..];
+        let room = dest.len() - self.filled;
+        let take = payload.len().min(room);
+        dest[self.filled..self.filled + take].copy_from_slice(&payload[..take]);
+        self.filled += take;
+
+        if eof && self.filled > 0 {
+            let bytes = self.finish_frame();
+            return PushOutcome::Completed { bytes };
+        }
+
+        PushOutcome::Pending
+    }
+
+    fn finish_frame(&mut self) -> usize {
+        let bytes = self.filled;
+        self.filled = 0;
+        bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use super::*;
+
+    const FID0: u8 = 0;
+    const FID1: u8 = PayloadHeaderFlags::FID.bits();
+    const EOF: u8 = PayloadHeaderFlags::EOF.bits();
+
+    fn pkt(flags: u8, payload: &[u8]) -> Vec<u8> {
+        let mut v = Vec::with_capacity(2 + payload.len());
+        v.push(2);
+        v.push(flags);
+        v.extend_from_slice(payload);
+        v
+    }
+
+    #[test]
+    fn sync_discards_until_first_fid_toggle() {
+        let mut p = FrameParser::new();
+        let mut dest = vec![0u8; 1024];
+        assert_eq!(
+            p.push_packet(&pkt(FID0, b"aaa"), &mut dest),
+            PushOutcome::Pending
+        );
+        assert_eq!(
+            p.push_packet(&pkt(FID0, b"bbb"), &mut dest),
+            PushOutcome::Pending
+        );
+        assert_eq!(dest, vec![0u8; 1024]);
+        assert_eq!(
+            p.push_packet(&pkt(FID1, b"\xFF\xD8c"), &mut dest),
+            PushOutcome::Pending
+        );
+        let r = p.push_packet(&pkt(FID1 | EOF, b"dd\xFF\xD9"), &mut dest);
+        assert_eq!(r, PushOutcome::Completed { bytes: 7 });
+        assert_eq!(&dest[..7], b"\xFF\xD8cdd\xFF\xD9");
+    }
+
+    #[test]
+    fn frame_completes_on_eof() {
+        let mut p = FrameParser::new();
+        let mut dest = vec![0u8; 1024];
+        p.push_packet(&pkt(FID0, b"a"), &mut dest);
+        assert_eq!(
+            p.push_packet(&pkt(FID1, b"\xFF\xD8bb"), &mut dest),
+            PushOutcome::Pending
+        );
+        assert_eq!(
+            p.push_packet(&pkt(FID1, b"cc"), &mut dest),
+            PushOutcome::Pending
+        );
+        let r = p.push_packet(&pkt(FID1 | EOF, b"dd\xFF\xD9"), &mut dest);
+        assert_eq!(r, PushOutcome::Completed { bytes: 10 });
+        assert_eq!(&dest[..10], b"\xFF\xD8bbccdd\xFF\xD9");
+    }
+
+    #[test]
+    fn full_buffer_truncates_and_waits_for_eof() {
+        let mut p = FrameParser::new();
+        let mut dest = vec![0u8; 8];
+        p.push_packet(&pkt(FID0, b"a"), &mut dest);
+        let r = p.push_packet(&pkt(FID1, b"\xFF\xD8123456789"), &mut dest);
+        assert_eq!(r, PushOutcome::Pending);
+        assert_eq!(dest, b"\xFF\xD8123456");
+        let r = p.push_packet(&pkt(FID1 | EOF, b"xy"), &mut dest);
+        assert_eq!(r, PushOutcome::Completed { bytes: 8 });
+    }
+
+    #[test]
+    fn fid_toggle_completes_frame_and_retries_packet() {
+        let mut p = FrameParser::new();
+        let mut dest = vec![0u8; 64];
+        assert_eq!(
+            p.push_packet(&pkt(FID0, b"x"), &mut dest),
+            PushOutcome::Pending
+        );
+        assert_eq!(
+            p.push_packet(&pkt(FID1, b"\xFF\xD8f1\xFF\xD9"), &mut dest),
+            PushOutcome::Pending
+        );
+        let r = p.push_packet(&pkt(FID0, b"\xFF\xD8f2"), &mut dest);
+        assert_eq!(r, PushOutcome::CompletedAndRetry { bytes: 6 });
+        assert_eq!(&dest[..6], b"\xFF\xD8f1\xFF\xD9");
+        let mut dest2 = vec![0u8; 64];
+        let r2 = p.push_packet(&pkt(FID0, b"\xFF\xD8f2"), &mut dest2);
+        assert_eq!(r2, PushOutcome::Pending);
+        assert_eq!(&dest2[..4], b"\xFF\xD8f2");
+        let r3 = p.push_packet(&pkt(FID0 | EOF, b"tail\xFF\xD9"), &mut dest2);
+        assert_eq!(r3, PushOutcome::Completed { bytes: 10 });
+        assert_eq!(&dest2[..10], b"\xFF\xD8f2tail\xFF\xD9");
+    }
+
+    #[test]
+    fn invalid_header_drops_packet_without_touching_fid_state() {
+        let mut p = FrameParser::new();
+        let mut dest = vec![0u8; 1024];
+        p.push_packet(&pkt(FID0, b"a"), &mut dest);
+        let bad = vec![2u8, PayloadHeaderFlags::PTS.bits()];
+        assert_eq!(p.push_packet(&bad, &mut dest), PushOutcome::Pending);
+        let r = p.push_packet(&pkt(FID1 | EOF, b"\xFF\xD8bb\xFF\xD9"), &mut dest);
+        assert_eq!(r, PushOutcome::Completed { bytes: 6 });
+    }
+}

--- a/drivers/media/uvc/src/helper.rs
+++ b/drivers/media/uvc/src/helper.rs
@@ -1,0 +1,759 @@
+use alloc::vec::Vec;
+
+use anyhow::anyhow;
+use crab_usb::err::USBError;
+use log::debug;
+
+use crate::{
+    AlternateSetting, DescriptorParser, FrameIntervals, InputTerminalDescriptor, StreamControl,
+    UncompressedFormat, VideoFormat, VideoFormatType,
+    controls::VcUnits,
+    descriptors::{
+        DescriptorType, InputHeaderDescriptor, InterfaceSubclass, TerminalType,
+        VcDescriptorSubtype, VsDescriptorSubtype,
+    },
+};
+
+/// Serialize stream control.
+pub(crate) fn serialize_stream_control(ctrl: &StreamControl) -> Vec<u8> {
+    let mut data = Vec::with_capacity(26);
+
+    data.extend(&ctrl.hint.to_le_bytes());
+    data.push(ctrl.format_index);
+    data.push(ctrl.frame_index);
+    data.extend(&ctrl.frame_interval.to_le_bytes());
+    data.extend(&ctrl.key_frame_rate.to_le_bytes());
+    data.extend(&ctrl.p_frame_rate.to_le_bytes());
+    data.extend(&ctrl.comp_quality.to_le_bytes());
+    data.extend(&ctrl.comp_window_size.to_le_bytes());
+    data.extend(&ctrl.delay.to_le_bytes());
+    data.extend(&ctrl.max_video_frame_size.to_le_bytes());
+    data.extend(&ctrl.max_payload_transfer_size.to_le_bytes());
+
+    debug!("Serialized stream control: {} bytes", data.len());
+    data
+}
+
+/// Parse stream control.
+pub(crate) fn parse_stream_control(data: &[u8]) -> Result<StreamControl, USBError> {
+    if data.len() < 26 {
+        Err(anyhow!("Stream control response too short"))?;
+    }
+
+    let hint = u16::from_le_bytes([data[0], data[1]]);
+    let format_index = data[2];
+    let frame_index = data[3];
+    let frame_interval = u32::from_le_bytes([data[4], data[5], data[6], data[7]]);
+    let key_frame_rate = u16::from_le_bytes([data[8], data[9]]);
+    let p_frame_rate = u16::from_le_bytes([data[10], data[11]]);
+    let comp_quality = u16::from_le_bytes([data[12], data[13]]);
+    let comp_window_size = u16::from_le_bytes([data[14], data[15]]);
+    let delay = u16::from_le_bytes([data[16], data[17]]);
+    let max_video_frame_size = u32::from_le_bytes([data[18], data[19], data[20], data[21]]);
+    let max_payload_transfer_size = u32::from_le_bytes([data[22], data[23], data[24], data[25]]);
+
+    Ok(StreamControl {
+        hint,
+        format_index,
+        frame_index,
+        frame_interval,
+        key_frame_rate,
+        p_frame_rate,
+        comp_quality,
+        comp_window_size,
+        delay,
+        max_video_frame_size,
+        max_payload_transfer_size,
+    })
+}
+
+#[derive(Debug)]
+pub(crate) struct UvcDeviceConfig {
+    pub vc_iface_num: u8,
+    pub vs_iface_num: u8,
+    pub alt_settings: Vec<AlternateSetting>,
+    pub formats: Vec<VideoFormat>,
+    pub vc_units: VcUnits,
+}
+
+fn handle_vs_block(
+    blob: &[u8],
+    parser: &DescriptorParser,
+) -> Result<(Vec<VideoFormat>, usize), USBError> {
+    use VsDescriptorSubtype::*;
+
+    if blob.len() < 3 {
+        return Err(anyhow!("VS block too short").into());
+    }
+    if blob[1] != DescriptorType::CsInterface.into() {
+        return Err(anyhow!("VS block must start with CS_INTERFACE").into());
+    }
+    let first_subtype = VsDescriptorSubtype::from(blob[2]);
+    match first_subtype {
+        InputHeader => {}
+        OutputHeader => {
+            return Err(anyhow!("UVC OutputHeader (0x02) not supported for capture device").into());
+        }
+        _ => {
+            return Err(anyhow!(
+                "VS block must start with InputHeader, got 0x{:02x}",
+                blob[2]
+            )
+            .into());
+        }
+    }
+    // 解析 InputHeader（已校验 bLength/bNumFormats）
+    let hdr_len = blob[0] as usize;
+    if hdr_len == 0 || hdr_len > blob.len() {
+        return Err(anyhow!("InputHeader length invalid").into());
+    }
+    let hdr = parser.parse_input_header(&blob[..hdr_len])?;
+    let total = hdr.total_length as usize;
+    let mut consumed = hdr_len;
+    let header: Option<InputHeaderDescriptor> = Some(hdr.clone());
+    let mut cur_format: Option<(u8, VideoFormatType)> = None;
+
+    let mut out = Vec::new();
+    // 若 wTotalLength 非 0，则块边界为 total；为 0 时以遇到非 CS_INTERFACE 为止
+    let block_limit = if total != 0 {
+        core::cmp::min(total, blob.len())
+    } else {
+        blob.len()
+    };
+
+    while consumed + 3 <= blob.len() && consumed < block_limit {
+        let len = blob[consumed] as usize;
+        if len < 3 || consumed + len > blob.len() {
+            break;
+        }
+        if total != 0 && consumed + len > total {
+            // 超出 wTotalLength，块结束
+            break;
+        }
+        let dtype = blob[consumed + 1];
+        if dtype != DescriptorType::CsInterface.into() {
+            break;
+        }
+        let subtype = VsDescriptorSubtype::from(blob[consumed + 2]);
+        let desc = &blob[consumed..consumed + len];
+
+        match subtype {
+            Undefined => {
+                debug!("VS descriptor ignored: undefined subtype 0x00");
+            }
+            InputHeader => {
+                return Err(anyhow!("duplicate VS InputHeader inside block").into());
+            }
+            OutputHeader => {
+                return Err(
+                    anyhow!("UVC OutputHeader inside VS InputHeader block not supported").into(),
+                );
+            }
+            Colorformat => {
+                debug!("VS Colorformat ignored");
+            }
+            FormatUncompressed | FormatMjpeg => {
+                let header = header.as_ref().unwrap();
+                let cur_count = cur_format.map_or(0, |(idx, _)| idx as usize);
+                if cur_count >= header.num_formats as usize {
+                    return Err(anyhow!(
+                        "VS Format count {} exceeds bNumFormats {}",
+                        cur_count + 1,
+                        header.num_formats
+                    )
+                    .into());
+                }
+                let format_type = match subtype {
+                    FormatUncompressed => {
+                        let uncomp_desc =
+                            match DescriptorParser::new().parse_uncompressed_format(desc) {
+                                Ok(d) => d,
+                                Err(_) => {
+                                    consumed += len;
+                                    continue;
+                                }
+                            };
+                        let Some(fmt) = UncompressedFormat::from_guid(&uncomp_desc.guid) else {
+                            consumed += len;
+                            continue;
+                        };
+                        VideoFormatType::Uncompressed(fmt)
+                    }
+                    FormatMjpeg => VideoFormatType::Mjpeg,
+                    _ => unreachable!(),
+                };
+                let format_index = cur_format.map_or(0, |(idx, _)| idx).wrapping_add(1);
+                cur_format = Some((format_index, format_type));
+            }
+            FrameUncompressed | FrameMjpeg => {
+                // 需已解析 Header 且已有 Format
+                if header.is_none() {
+                    return Err(anyhow!("VS Frame before InputHeader").into());
+                }
+                if cur_format.is_none() {
+                    return Err(anyhow!("VS Frame before Format").into());
+                }
+                let format_index = cur_format.map_or(0, |(idx, _)| idx);
+                let format_type = cur_format.map_or(VideoFormatType::Mjpeg, |(_, t)| t);
+                if let Ok(fd) = parse_frame_descriptor(desc, format_index, format_type) {
+                    out.push(fd);
+                }
+            }
+            StillImageFrame => {
+                return Err(anyhow!("UVC VideoStreaming Still Image format not supported").into());
+            }
+            FormatMpeg2Ts => {
+                return Err(anyhow!("UVC VideoStreaming MPEG-2 TS format not supported").into());
+            }
+            FormatDv => {
+                return Err(anyhow!("UVC VideoStreaming DV format not supported").into());
+            }
+            FormatFrameBased | FrameFrameBased => {
+                return Err(anyhow!("UVC VideoStreaming Frame-Based format not supported").into());
+            }
+            FormatStreamBased => {
+                return Err(anyhow!("UVC VideoStreaming Stream-Based format not supported").into());
+            }
+            FormatH264 | FrameH264 | FormatH264Simulcast => {
+                return Err(anyhow!("UVC VideoStreaming H.264 format not supported").into());
+            }
+        }
+        consumed += len;
+    }
+
+    Ok((out, consumed))
+}
+
+fn handle_vc_block(blob: &[u8], parser: &DescriptorParser) -> Result<(VcUnits, usize), USBError> {
+    use VcDescriptorSubtype::*;
+
+    if blob.len() < 3 {
+        return Err(anyhow!("VC block too short").into());
+    }
+    if blob[1] != DescriptorType::CsInterface.into() {
+        return Err(anyhow!("VC block must start with CS_INTERFACE").into());
+    }
+    if VcDescriptorSubtype::from(blob[2]) != Header {
+        return Err(anyhow!("VC block must start with Header 0x01").into());
+    }
+
+    let hdr_len = blob[0] as usize;
+    if hdr_len == 0 || hdr_len > blob.len() {
+        return Err(anyhow!("VC Header length invalid").into());
+    }
+    let hdr = parser.parse_vc_header(&blob[..hdr_len])?;
+    let total = hdr.total_length as usize;
+    let mut consumed = hdr_len;
+    let mut units = VcUnits::default();
+
+    let block_limit = if total != 0 {
+        core::cmp::min(total, blob.len())
+    } else {
+        blob.len()
+    };
+
+    while consumed + 3 <= blob.len() && consumed < block_limit {
+        let len = blob[consumed] as usize;
+        if len < 3 || consumed + len > blob.len() {
+            break;
+        }
+        if total != 0 && consumed + len > total {
+            break;
+        }
+        let dtype = blob[consumed + 1];
+        if dtype != DescriptorType::CsInterface.into() {
+            break;
+        }
+        let subtype = VcDescriptorSubtype::from(blob[consumed + 2]);
+        let desc = &blob[consumed..consumed + len];
+
+        match subtype {
+            Header => {
+                return Err(anyhow!("duplicate VC Header inside block").into());
+            }
+            InputTerminal => {
+                if let Ok(InputTerminalDescriptor::Camera {
+                    terminal_id,
+                    terminal_type,
+                    controls,
+                    ..
+                }) = parser.parse_input_terminal(desc)
+                    && terminal_type == TerminalType::IttCamera.into()
+                {
+                    units.camera_terminal_id = Some(terminal_id);
+                    units.camera_controls = controls;
+                }
+            }
+            OutputTerminal | SelectorUnit | ExtensionUnit => {
+                debug!("VC descriptor ignored: subtype 0x{:02x}", subtype as u8);
+            }
+            ProcessingUnit => {
+                if let Ok(pu) = parser.parse_processing_unit(desc) {
+                    units.processing_unit_id = Some(pu.unit_id);
+                    units.processing_controls = pu.controls;
+                }
+            }
+            Undefined => {
+                debug!(
+                    "VC descriptor ignored: undefined subtype 0x{:02x}",
+                    subtype as u8
+                );
+            }
+        }
+        consumed += len;
+    }
+
+    Ok((units, consumed))
+}
+
+/// Parse UVC device from descriptor blob.
+pub(crate) fn parse_uvc_device(blob: &[u8]) -> Result<UvcDeviceConfig, USBError> {
+    use InterfaceSubclass::*;
+
+    let parser = DescriptorParser::new();
+
+    let mut vc_iface_num = None;
+    let mut vs_iface_num = None;
+    let mut alt_settings = Vec::new();
+    let mut formats = Vec::new();
+    let mut vc_units = VcUnits::default();
+
+    let mut cur_iface: Option<(u8, u8, u8, u8, u8)> = None;
+    let mut vc_parsed = false;
+    let mut vs_parsed = false;
+
+    let mut pos = 18usize;
+    while pos + 2 <= blob.len() {
+        let length = blob[pos] as usize;
+        let descriptor_type = blob[pos + 1];
+        if length < 2 || pos + length > blob.len() {
+            break;
+        }
+        let desc = &blob[pos..pos + length];
+
+        match DescriptorType::from(descriptor_type) {
+            DescriptorType::Interface if length >= 9 => {
+                let (number, alternate, class, subclass, protocol) =
+                    (desc[2], desc[3], desc[5], desc[6], desc[7]);
+                if class == 0x0E {
+                    match InterfaceSubclass::from(subclass) {
+                        VideoControl => vc_iface_num = Some(number),
+                        VideoStreaming => vs_iface_num = Some(number),
+                        InterfaceSubclass::Undefined
+                        | InterfaceSubclass::VideoInterfaceCollection => {
+                            return Err(anyhow!(
+                                "Unsupported UVC interface subclass 0x{subclass:02x} on interface \
+                                 {number}"
+                            )
+                            .into());
+                        }
+                    }
+                }
+                cur_iface = Some((number, alternate, class, subclass, protocol));
+            }
+            DescriptorType::Endpoint if length >= 7 => {
+                if let Some((number, alternate, class, subclass, protocol)) = cur_iface
+                    && class == 0x0E
+                    && InterfaceSubclass::from(subclass) == VideoStreaming
+                    && protocol == 0x00
+                    && vs_iface_num == Some(number)
+                    && desc[3] & 0x03 == 0x01
+                    && desc[2] & 0x80 != 0
+                {
+                    let mps_raw = u16::from_le_bytes([desc[4], desc[5]]);
+                    alt_settings.push(AlternateSetting {
+                        alt_setting: alternate,
+                        ep: desc[2],
+                        mps: mps_raw & 0x7FF,
+                        packets_per_uframe: ((mps_raw >> 11) & 0b11) as usize + 1,
+                        interval: desc[6],
+                    });
+                }
+            }
+            DescriptorType::CsInterface if length >= 3 => {
+                let subtype = desc[2];
+                match cur_iface
+                    .map(|(_, _, class, subclass, _)| (class, InterfaceSubclass::from(subclass)))
+                {
+                    Some((0x0E, VideoControl)) => {
+                        let vc_subtype = VcDescriptorSubtype::from(subtype);
+                        match vc_subtype {
+                            VcDescriptorSubtype::Header => {
+                                if vc_parsed {
+                                    return Err(anyhow!("duplicate VC Header").into());
+                                }
+                                let (produced, consumed) = handle_vc_block(&blob[pos..], &parser)?;
+                                vc_units = produced;
+                                vc_parsed = true;
+                                pos += consumed;
+                                continue;
+                            }
+                            VcDescriptorSubtype::Undefined => {
+                                debug!("VC descriptor ignored: undefined subtype 0x{subtype:02x}");
+                            }
+                            _ => {
+                                if !vc_parsed {
+                                    return Err(anyhow!(
+                                        "VC descriptor 0x{subtype:02x} before Header"
+                                    )
+                                    .into());
+                                }
+                                return Err(anyhow!(
+                                    "VC descriptor 0x{subtype:02x} outside Header block"
+                                )
+                                .into());
+                            }
+                        }
+                    }
+                    Some((0x0E, VideoStreaming)) => {
+                        let vs_subtype = VsDescriptorSubtype::from(subtype);
+                        match vs_subtype {
+                            VsDescriptorSubtype::InputHeader => {
+                                if vs_parsed {
+                                    return Err(anyhow!("duplicate VS InputHeader").into());
+                                }
+                                let (produced, consumed) = handle_vs_block(&blob[pos..], &parser)?;
+                                vs_parsed = true;
+                                formats.extend(produced);
+                                pos += consumed;
+                                continue;
+                            }
+                            VsDescriptorSubtype::OutputHeader => {
+                                return Err(anyhow!(
+                                    "UVC OutputHeader (0x02) not supported for capture device"
+                                )
+                                .into());
+                            }
+                            VsDescriptorSubtype::Undefined => {
+                                debug!("VS descriptor ignored: undefined subtype 0x00");
+                            }
+                            _ => {
+                                // 连续块外出现的 VS 描述符视为非法（正常应由 InputHeader 块内消耗）
+                                if !vs_parsed {
+                                    return Err(anyhow!(
+                                        "VS descriptor 0x{subtype:02x} before InputHeader"
+                                    )
+                                    .into());
+                                }
+                                return Err(anyhow!(
+                                    "VS descriptor 0x{subtype:02x} outside InputHeader block"
+                                )
+                                .into());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+
+        pos += length;
+    }
+
+    // 健康性检查
+    if !vc_parsed {
+        return Err(anyhow!("UVC VC Header not found").into());
+    }
+    if !vs_parsed {
+        return Err(anyhow!("UVC VS InputHeader not found").into());
+    }
+    if alt_settings.is_empty() {
+        return Err(anyhow!("UVC VideoStreaming alternate settings not found").into());
+    }
+    if formats.is_empty() {
+        return Err(anyhow!("UVC VideoStreaming formats not found").into());
+    }
+    match (vc_iface_num, vs_iface_num) {
+        (Some(vc_iface_num), Some(vs_iface_num)) => Ok(UvcDeviceConfig {
+            vc_iface_num,
+            vs_iface_num,
+            alt_settings,
+            formats,
+            vc_units,
+        }),
+        (None, _) => Err(anyhow!("UVC VideoControl interface not found").into()),
+        (_, None) => Err(anyhow!("UVC VideoStreaming interface not found").into()),
+    }
+}
+
+/// Parse frame descriptor.
+fn parse_frame_descriptor(
+    data: &[u8],
+    format_index: u8,
+    format_type: VideoFormatType,
+) -> Result<VideoFormat, USBError> {
+    match DescriptorParser::new().parse_frame_descriptor(data) {
+        Ok(frame_desc) => {
+            let intervals = if frame_desc.frame_interval_type == 0 {
+                if frame_desc.frame_intervals.len() >= 3 {
+                    FrameIntervals::Continuous {
+                        min: frame_desc.frame_intervals[0],
+                        max: frame_desc.frame_intervals[1],
+                        step: frame_desc.frame_intervals[2],
+                    }
+                } else {
+                    FrameIntervals::Discrete(frame_desc.frame_intervals.clone())
+                }
+            } else {
+                FrameIntervals::Discrete(frame_desc.frame_intervals.clone())
+            };
+            let max_frame_size = match format_type {
+                VideoFormatType::Uncompressed(t) => {
+                    let w = frame_desc.width as u32;
+                    let h = frame_desc.height as u32;
+                    match t {
+                        UncompressedFormat::Yuyv | UncompressedFormat::Uyvy => w * h * 2,
+                        UncompressedFormat::Nv12 => w * h * 3 / 2,
+                        UncompressedFormat::Grey => w * h,
+                        UncompressedFormat::Bgr24 => w * h * 3,
+                        UncompressedFormat::Xbgr32 => w * h * 4,
+                    }
+                }
+                VideoFormatType::Mjpeg => {
+                    let v = frame_desc.max_video_frame_buffer_size;
+                    if v != 0 {
+                        v
+                    } else {
+                        // UVC 1.1+ 的 frame-based/无效描述符回退
+                        (frame_desc.width as u32) * (frame_desc.height as u32) * 2
+                    }
+                }
+            };
+            let video_format = VideoFormat {
+                format_type,
+                format_index,
+                frame_index: frame_desc.frame_index,
+                width: frame_desc.width,
+                height: frame_desc.height,
+                default_interval: frame_desc.default_frame_interval,
+                intervals,
+                max_frame_size,
+            };
+
+            Ok(video_format)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_util {
+    use alloc::vec::Vec;
+
+    /// Build UVC blob for tests.
+    pub(crate) fn build_uvc_blob(vc_subclass: u8, vs_subclass: u8) -> Vec<u8> {
+        let mut blob = Vec::new();
+        blob.extend_from_slice(&[18, 0x01]);
+        blob.extend_from_slice(&0x0200u16.to_le_bytes());
+        blob.extend_from_slice(&[0xEF, 0x02, 0x01, 64]);
+        blob.extend_from_slice(&0x1234u16.to_le_bytes());
+        blob.extend_from_slice(&0x5678u16.to_le_bytes());
+        blob.extend_from_slice(&0x0100u16.to_le_bytes());
+        blob.extend_from_slice(&[0, 0, 0, 1]);
+
+        let mut config = Vec::new();
+        config.extend_from_slice(&[9, 0x04, 0, 0, 0, 0x0E, vc_subclass, 0x00, 0]);
+        config.extend_from_slice(&[12, 0x24, 0x01, 0, 1, 0, 0, 0, 0, 0, 0, 1]);
+        config.extend_from_slice(&[
+            18, 0x24, 0x02, 1, 0x01, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0x02, 0, 0,
+        ]);
+        config.extend_from_slice(&[10, 0x24, 0x05, 2, 1, 0, 0, 1, 0x04, 0]);
+        config.extend_from_slice(&[9, 0x04, 1, 0, 0, 0x03, 0x00, 0x00, 0]);
+        config.extend_from_slice(&[9, 0x04, 3, 0, 0, 0x0E, vs_subclass, 0x00, 0]);
+        config.extend_from_slice(&[13, 0x24, 0x01, 1, 0, 0, 0x81, 0, 3, 0, 0, 0, 0]);
+        config.extend_from_slice(&[
+            27, 0x24, 0x04, 1, 1, // FormatUncompressed
+            0x59, 0x55, 0x59, 0x32, 0x00, 0x00, 0x10, 0x00, 0x80, 0x00, 0x00, 0xaa, 0x00, 0x38,
+            0x9b, 0x71, // YUY2 GUID
+            16, 1, 0, 0, 0, 0,
+        ]);
+        config.extend_from_slice(&[
+            26, 0x24, 0x05, 1, 0, // FrameUncompressed
+            0x80, 0x02, 0xE0, 0x01, // 640x480
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // bitrate / buffer size
+            0x15, 0x16, 0x05, 0x00, // 333333 (30fps)
+            0,
+        ]);
+        config.extend_from_slice(&[9, 0x04, 3, 1, 1, 0x0E, vs_subclass, 0x00, 0]);
+        config.extend_from_slice(&[7, 0x05, 0x81, 0x05, 0x10, 0x00, 1]);
+        config.extend_from_slice(&[9, 0x04, 3, 2, 1, 0x0E, vs_subclass, 0x00, 0]);
+        config.extend_from_slice(&[7, 0x05, 0x81, 0x05, 0x00, 0x04, 1]);
+
+        let total_length = (9 + config.len()) as u16;
+        blob.push(9);
+        blob.push(0x02);
+        blob.extend_from_slice(&total_length.to_le_bytes());
+        blob.extend_from_slice(&[3, 1, 0, 0x80, 50]);
+        blob.extend_from_slice(&config);
+        blob
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+
+    use super::{test_util::build_uvc_blob, *};
+
+    #[test]
+    fn parse_uvc_device_single_pass_extracts_all() {
+        let blob = build_uvc_blob(0x01, 0x02);
+        let cfg = parse_uvc_device(&blob).unwrap();
+
+        assert_eq!(cfg.vc_iface_num, 0);
+        assert_eq!(cfg.vs_iface_num, 3);
+
+        assert_eq!(cfg.alt_settings.len(), 2);
+        let alt = &cfg.alt_settings[0];
+        assert_eq!(alt.alt_setting, 1);
+        assert_eq!(alt.ep, 0x81);
+        assert_eq!(alt.mps, 0x10);
+        assert_eq!(alt.packets_per_uframe, 1);
+        assert_eq!(alt.interval, 1);
+        let alt = &cfg.alt_settings[1];
+        assert_eq!(alt.alt_setting, 2);
+        assert_eq!(alt.mps, 0x400);
+
+        assert_eq!(cfg.formats.len(), 1);
+        let fmt = &cfg.formats[0];
+        assert_eq!(fmt.format_index, 1);
+        assert_eq!(fmt.frame_index, 1);
+        assert_eq!(fmt.width, 640);
+        assert_eq!(fmt.height, 480);
+        assert_eq!(fmt.frame_rate(), 30);
+        assert_eq!(fmt.default_interval, 333_333);
+        assert_eq!(
+            fmt.format_type,
+            VideoFormatType::Uncompressed(UncompressedFormat::Yuyv)
+        );
+
+        assert_eq!(cfg.vc_units.camera_terminal_id, Some(1));
+        assert_eq!(cfg.vc_units.camera_controls, vec![0x02]);
+        assert_eq!(cfg.vc_units.processing_unit_id, Some(2));
+        assert_eq!(cfg.vc_units.processing_controls, vec![0x04]);
+    }
+
+    #[test]
+    fn parse_uvc_device_missing_interface_errors() {
+        // 当接口子类不支持时，parse_uvc_device 应直接报 Err，而不是等到健康检查
+        let blob = build_uvc_blob(0x00, 0x02);
+        assert!(
+            parse_uvc_device(&blob)
+                .unwrap_err()
+                .to_string()
+                .contains("Unsupported UVC interface subclass")
+        );
+        let blob = build_uvc_blob(0x01, 0x00);
+        assert!(
+            parse_uvc_device(&blob)
+                .unwrap_err()
+                .to_string()
+                .contains("Unsupported UVC interface subclass")
+        );
+    }
+
+    #[test]
+    fn parse_uvc_device_no_config_errors() {
+        let blob = vec![18, 0x01, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        assert!(parse_uvc_device(&blob).is_err());
+    }
+
+    #[test]
+    fn parse_uvc_device_missing_input_header_errors() {
+        let mut blob = build_uvc_blob(0x01, 0x02);
+        // 移除 VS InputHeader (13,0x24,0x01) — VC Header 为 12,0x24,0x01 以示区分
+        if let Some(pos) = blob
+            .windows(3)
+            .position(|w| w == [13, 0x24, 0x01])
+            // windows 找到的是 VC Header(12)之后的 VS InputHeader，但要确保是长度 13 的那个
+            // 若首次命中是 VC Header 的变体（12,0x24,0x01），则找下一个
+            .and_then(|p| {
+                if blob[p] == 13 {
+                    Some(p)
+                } else {
+                    blob[p + 1..]
+                        .windows(3)
+                        .position(|w| w == [13, 0x24, 0x01])
+                        .map(|q| p + 1 + q)
+                }
+            })
+        {
+            blob.drain(pos..pos + 13);
+            let total = (blob.len() - 18) as u16;
+            blob[19] = (total & 0xFF) as u8;
+            blob[20] = (total >> 8) as u8;
+        }
+        let err = parse_uvc_device(&blob).unwrap_err().to_string();
+        assert!(
+            err.contains("InputHeader"),
+            "expected InputHeader error, got {err}"
+        );
+    }
+
+    #[test]
+    fn parse_uvc_device_output_header_errors() {
+        let mut blob = build_uvc_blob(0x01, 0x02);
+        if let Some(pos) = blob
+            .windows(3)
+            .position(|w| w == [13, 0x24, 0x01])
+            .and_then(|p| {
+                if blob[p] == 13 {
+                    Some(p)
+                } else {
+                    blob[p + 1..]
+                        .windows(3)
+                        .position(|w| w == [13, 0x24, 0x01])
+                        .map(|q| p + 1 + q)
+                }
+            })
+        {
+            // 替换为 OutputHeader: 9,0x24,0x02,1,0,0,0x81,3,0
+            blob[pos] = 9;
+            blob[pos + 2] = 0x02;
+            blob[pos + 3] = 1;
+            blob[pos + 4] = 0;
+            blob[pos + 5] = 0;
+            blob[pos + 6] = 0x81;
+            blob[pos + 7] = 3;
+            blob[pos + 8] = 0;
+            blob.drain(pos + 9..pos + 13);
+            let total = (blob.len() - 18) as u16;
+            blob[19] = (total & 0xFF) as u8;
+            blob[20] = (total >> 8) as u8;
+        }
+        let err = parse_uvc_device(&blob).unwrap_err().to_string();
+        assert!(
+            err.contains("OutputHeader"),
+            "expected OutputHeader error, got {err}"
+        );
+    }
+
+    #[test]
+    fn parse_uvc_device_undefined_vs_ignored() {
+        let mut blob = build_uvc_blob(0x01, 0x02);
+        // 在 InputHeader 后插入一条 Undefined VS 描述符 (3,0x24,0x00)
+        if let Some(pos) = blob
+            .windows(3)
+            .position(|w| w == [13, 0x24, 0x01])
+            .and_then(|p| {
+                if blob[p] == 13 {
+                    Some(p)
+                } else {
+                    blob[p + 1..]
+                        .windows(3)
+                        .position(|w| w == [13, 0x24, 0x01])
+                        .map(|q| p + 1 + q)
+                }
+            })
+        {
+            let insert_at = pos + 13;
+            blob.splice(insert_at..insert_at, [3, 0x24, 0x00]);
+            let total = (blob.len() - 18) as u16;
+            blob[19] = (total & 0xFF) as u8;
+            blob[20] = (total >> 8) as u8;
+        }
+        // Undefined 应被忽略，仍能正常解析
+        assert!(parse_uvc_device(&blob).is_ok());
+    }
+}

--- a/drivers/media/uvc/src/lib.rs
+++ b/drivers/media/uvc/src/lib.rs
@@ -1,0 +1,787 @@
+#![no_std]
+#[cfg(test)]
+extern crate std;
+
+#[macro_use]
+extern crate alloc;
+
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use anyhow::anyhow;
+use ax_media::{
+    CtrlHandler,
+    interface::{colorspace, format},
+    videobuffer::{VbPool, VirtualAllocator},
+};
+use ax_sync::Mutex;
+use crab_usb::{
+    err::USBError,
+    usb_if::{
+        descriptor::Class,
+        endpoint::TransferRequest,
+        host::ControlSetup,
+        transfer::{Recipient, RequestType},
+    },
+};
+use log::*;
+pub use stream::IsoPending;
+
+use crate::{
+    frame::FrameParser,
+    helper::{parse_stream_control, parse_uvc_device},
+    stream::{FrameAssembler, ISO_BATCH, ISO_DEPTH, IsoStream},
+};
+
+pub(crate) mod controls;
+pub(crate) mod descriptors;
+pub(crate) use descriptors::*;
+pub(crate) mod frame;
+pub(crate) mod helper;
+pub(crate) mod stream;
+pub(crate) mod v4l2_impl;
+
+/// USB device handle for control and ISO transfers.
+pub trait UvcHandle: Send + Sync + 'static {
+    fn claim_interface(&self, interface: u8, alternate: u8) -> Result<(), USBError>;
+
+    fn release_interface(&self, interface: u8) -> Result<(), USBError>;
+
+    fn control_in(&self, param: ControlSetup, data: &mut [u8]) -> Result<usize, USBError>;
+
+    fn control_out(&self, param: ControlSetup, data: &[u8]) -> Result<(), USBError>;
+
+    fn submit_endpoint_transfer(
+        &self,
+        endpoint: u8,
+        request: TransferRequest,
+    ) -> Result<IsoPending, USBError>;
+}
+
+/// UVC frame interval description – strongly typed over the raw
+/// `bFrameIntervalType` byte. `Continuous` corresponds to `bFrameIntervalType==0`
+/// (min/max/step), `Discrete` to `bFrameIntervalType>0` (explicit list).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FrameIntervals {
+    Discrete(Vec<u32>),
+    Continuous { min: u32, max: u32, step: u32 },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct VideoFormat {
+    pub format_type: VideoFormatType,
+    pub width: u16,
+    pub height: u16,
+    pub format_index: u8,
+    pub frame_index: u8,
+    pub default_interval: u32,
+    pub intervals: FrameIntervals,
+    pub max_frame_size: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum VideoFormatType {
+    Uncompressed(UncompressedFormat),
+    Mjpeg,
+}
+
+impl From<u32> for VideoFormatType {
+    fn from(value: u32) -> Self {
+        match value {
+            format::PIX_FMT_YUYV => VideoFormatType::Uncompressed(UncompressedFormat::Yuyv),
+            format::PIX_FMT_UYVY => VideoFormatType::Uncompressed(UncompressedFormat::Uyvy),
+            format::PIX_FMT_NV12 => VideoFormatType::Uncompressed(UncompressedFormat::Nv12),
+            format::PIX_FMT_GREY => VideoFormatType::Uncompressed(UncompressedFormat::Grey),
+            format::PIX_FMT_BGR24 => VideoFormatType::Uncompressed(UncompressedFormat::Bgr24),
+            format::PIX_FMT_XBGR32 => VideoFormatType::Uncompressed(UncompressedFormat::Xbgr32),
+            format::PIX_FMT_MJPEG => VideoFormatType::Mjpeg,
+            _ => VideoFormatType::Uncompressed(UncompressedFormat::Yuyv),
+        }
+    }
+}
+
+impl VideoFormat {
+    /// Bytes per line.
+    pub(crate) fn bytes_per_line(&self) -> usize {
+        match self.format_type {
+            VideoFormatType::Uncompressed(t) => {
+                let pixel_size = match t {
+                    UncompressedFormat::Yuyv | UncompressedFormat::Uyvy => 2,
+                    UncompressedFormat::Nv12 => 1,
+                    UncompressedFormat::Grey => 1,
+                    UncompressedFormat::Bgr24 => 3,
+                    UncompressedFormat::Xbgr32 => 4,
+                };
+                (self.width as usize) * pixel_size
+            }
+            VideoFormatType::Mjpeg => 0,
+        }
+    }
+
+    /// V4L2 colorspace.
+    pub(crate) fn colorspace(&self) -> colorspace::Colorspace {
+        if self.is_compressed() {
+            colorspace::Colorspace::Jpeg
+        } else {
+            colorspace::Colorspace::Srgb
+        }
+    }
+
+    /// Format description
+    pub(crate) fn description(&self) -> String {
+        match self.format_type {
+            VideoFormatType::Uncompressed(t) => match t {
+                UncompressedFormat::Yuyv => "YUYV 4:2:2".into(),
+                UncompressedFormat::Uyvy => "UYVY 4:2:2".into(),
+                UncompressedFormat::Nv12 => "Y/UV 4:2:0".into(),
+                UncompressedFormat::Grey => "8-bit Greyscale".into(),
+                UncompressedFormat::Bgr24 => "24-bit BGR 8-8-8".into(),
+                UncompressedFormat::Xbgr32 => "32-bit BGRX 8-8-8-8".into(),
+            },
+            VideoFormatType::Mjpeg => "Motion-JPEG".into(),
+        }
+    }
+
+    /// V4L2 pixel format.
+    pub(crate) fn pixelformat(&self) -> u32 {
+        match self.format_type {
+            VideoFormatType::Uncompressed(t) => match t {
+                UncompressedFormat::Yuyv => format::PIX_FMT_YUYV,
+                UncompressedFormat::Uyvy => format::PIX_FMT_UYVY,
+                UncompressedFormat::Nv12 => format::PIX_FMT_NV12,
+                UncompressedFormat::Grey => format::PIX_FMT_GREY,
+                UncompressedFormat::Bgr24 => format::PIX_FMT_BGR24,
+                UncompressedFormat::Xbgr32 => format::PIX_FMT_XBGR32,
+            },
+            VideoFormatType::Mjpeg => format::PIX_FMT_MJPEG,
+        }
+    }
+
+    /// Whether the format is compressed.
+    pub(crate) fn is_compressed(&self) -> bool {
+        matches!(self.format_type, VideoFormatType::Mjpeg)
+    }
+
+    /// Whether `self` shares the same image parameters as `other`.
+    pub(crate) fn is_same_image(&self, other: &Self) -> bool {
+        self.width == other.width
+            && self.height == other.height
+            && self.pixelformat() == other.pixelformat()
+    }
+
+    /// Frame rate in frames per second.
+    pub(crate) fn frame_rate(&self) -> u32 {
+        if self.default_interval != 0 {
+            DescriptorParser::interval_to_fps(self.default_interval)
+        } else {
+            match &self.intervals {
+                FrameIntervals::Discrete(v) if !v.is_empty() => {
+                    DescriptorParser::interval_to_fps(v[0])
+                }
+                FrameIntervals::Continuous { min, .. } => DescriptorParser::interval_to_fps(*min),
+                _ => 0,
+            }
+        }
+    }
+}
+
+/// Uncompressed format type.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum UncompressedFormat {
+    Yuyv,
+    Uyvy,
+    Nv12,
+    Grey,
+    Bgr24,
+    Xbgr32,
+}
+
+impl UncompressedFormat {
+    /// GUID to format.
+    pub(crate) fn from_guid(guid: &[u8; 16]) -> Option<Self> {
+        match guid {
+            g if g == &crate::descriptors::format_guids::YUY2 => Some(Self::Yuyv),
+            g if g == &crate::descriptors::format_guids::NV12 => Some(Self::Nv12),
+            g if g == &crate::descriptors::format_guids::GREY => Some(Self::Grey),
+            g if g == &crate::descriptors::format_guids::BGR24 => Some(Self::Bgr24),
+            g if g == &crate::descriptors::format_guids::XBGR32 => Some(Self::Xbgr32),
+            g if g == &crate::descriptors::format_guids::UYVY => Some(Self::Uyvy),
+            _ => None,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn guid(self) -> &'static [u8; 16] {
+        match self {
+            Self::Yuyv => &crate::descriptors::format_guids::YUY2,
+            Self::Nv12 => &crate::descriptors::format_guids::NV12,
+            Self::Grey => &crate::descriptors::format_guids::GREY,
+            Self::Bgr24 => &crate::descriptors::format_guids::BGR24,
+            Self::Xbgr32 => &crate::descriptors::format_guids::XBGR32,
+            Self::Uyvy => &crate::descriptors::format_guids::UYVY,
+        }
+    }
+}
+
+/// Stream control.
+#[derive(Debug, Clone)]
+pub(crate) struct StreamControl {
+    hint: u16,
+    format_index: u8,
+    frame_index: u8,
+    frame_interval: u32,
+    key_frame_rate: u16,
+    p_frame_rate: u16,
+    comp_quality: u16,
+    comp_window_size: u16,
+    delay: u16,
+    max_video_frame_size: u32,
+    max_payload_transfer_size: u32,
+}
+
+/// Alternate setting.
+#[derive(Debug, Clone)]
+pub(crate) struct AlternateSetting {
+    pub alt_setting: u8,
+    pub ep: u8,
+    pub mps: u16,
+    pub packets_per_uframe: usize,
+    pub interval: u8,
+}
+
+impl AlternateSetting {
+    pub(crate) fn buf_len(&self) -> usize {
+        self.mps as usize * self.packets_per_uframe
+    }
+}
+
+pub(crate) struct IsoStreamWorker {
+    task: ax_task::AxTaskRef,
+    cancel: Arc<AtomicBool>,
+}
+
+pub struct UvcDevice<H: UvcHandle> {
+    handle: Arc<H>,
+    vs_iface_num: u8,
+    vc_iface_num: u8,
+    formats: Vec<VideoFormat>,
+    alt_settings: Vec<AlternateSetting>,
+    active_format: usize,
+    active_alt_setting: usize,
+    pub(crate) ctrls: CtrlHandler,
+    pub(crate) pool: Arc<VbPool<VirtualAllocator>>,
+    stream: Mutex<Option<IsoStreamWorker>>,
+    events: Arc<Mutex<Vec<ax_media::interface::event::Event>>>,
+    pub(crate) cur_frame_interval: Mutex<u32>,
+}
+
+impl<H: UvcHandle> UvcDevice<H> {
+    pub fn check(blob: &[u8]) -> bool {
+        const DESC_TYPE_INTERFACE: u8 = 0x04;
+        const SUBCLASS_VC: u8 = 0x01;
+        const SUBCLASS_VS: u8 = 0x02;
+
+        if blob.len() < 18 {
+            return false;
+        }
+        let mut pos = 18usize;
+        let mut has_vc = false;
+        let mut has_vs = false;
+        while pos + 2 <= blob.len() {
+            let len = blob[pos] as usize;
+            if len < 2 || pos + len > blob.len() {
+                break;
+            }
+            let dtype = blob[pos + 1];
+            if dtype == DESC_TYPE_INTERFACE && len >= 9 {
+                let class = blob[pos + 5];
+                let subclass = blob[pos + 6];
+                let protocol = blob[pos + 7];
+                let cls = Class::from_class_and_subclass(class, subclass, protocol);
+                if matches!(cls, Class::Video) {
+                    if subclass == SUBCLASS_VC {
+                        has_vc = true;
+                    } else if subclass == SUBCLASS_VS {
+                        has_vs = true;
+                    }
+                    if has_vc && has_vs {
+                        return true;
+                    }
+                }
+            }
+            pos += len;
+        }
+        has_vc && has_vs
+    }
+
+    /// Create UVC device.
+    pub fn new(handle: H, descriptor_blob: &[u8]) -> Result<Self, USBError> {
+        let parsed = parse_uvc_device(descriptor_blob).inspect_err(|err| {
+            warn!("[UVC] Failed to parse UVC descriptor blob: {err:?}");
+        })?;
+
+        handle
+            .claim_interface(parsed.vc_iface_num, 0)
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to claim VC interface {}: {e:?}",
+                    parsed.vc_iface_num
+                )
+            })?;
+        handle
+            .claim_interface(parsed.vs_iface_num, 0)
+            .map_err(|e| {
+                let _ = handle.release_interface(parsed.vc_iface_num);
+                anyhow!(
+                    "Failed to claim VS interface {}: {e:?}",
+                    parsed.vs_iface_num
+                )
+            })?;
+
+        let initial_interval = parsed
+            .formats
+            .first()
+            .map(|f| {
+                if f.default_interval != 0 {
+                    f.default_interval
+                } else {
+                    match &f.intervals {
+                        FrameIntervals::Discrete(v) if !v.is_empty() => v[0],
+                        FrameIntervals::Continuous { min, .. } => *min,
+                        _ => 333_333u32,
+                    }
+                }
+            })
+            .unwrap_or(333_333);
+        let mut device = Self {
+            handle: Arc::new(handle),
+            vs_iface_num: parsed.vs_iface_num,
+            vc_iface_num: parsed.vc_iface_num,
+            ctrls: ax_media::CtrlHandler::new(),
+            formats: parsed.formats,
+            alt_settings: parsed.alt_settings,
+            active_format: 0,
+            active_alt_setting: 0,
+            pool: Arc::new(VbPool::new(VirtualAllocator::new(), 2, 8)),
+            stream: Mutex::new(None),
+            events: Arc::new(Mutex::new(Vec::new())),
+            cur_frame_interval: Mutex::new(initial_interval),
+        };
+
+        for fmt in &device.formats {
+            info!(
+                "Supported format: {:?}, {}x{}, {} fps, format_index={}, frame_index={}",
+                fmt.format_type,
+                fmt.width,
+                fmt.height,
+                fmt.frame_rate(),
+                fmt.format_index,
+                fmt.frame_index
+            );
+        }
+        info!(
+            "[UVC] VC units: camera_terminal={:?} processing_unit={:?}",
+            parsed.vc_units.camera_terminal_id, parsed.vc_units.processing_unit_id
+        );
+        device.register_controls(&parsed.vc_units);
+        info!("[UVC] registered {} controls", device.ctrls.len());
+        let ev = Arc::clone(&device.events);
+        device
+            .ctrls
+            .set_change_notify(Box::new(move |event| ev.lock().push(event)));
+
+        Ok(device)
+    }
+
+    /// V4L2 event source.
+    pub fn event_source(&self) -> Arc<Mutex<Vec<ax_media::interface::event::Event>>> {
+        Arc::clone(&self.events)
+    }
+
+    pub(crate) fn active_format_ref(&self) -> &VideoFormat {
+        &self.formats[self.active_format]
+    }
+
+    pub(crate) fn set_format(&mut self, format: VideoFormat) -> Result<(), USBError> {
+        debug!("Setting video format: {format:?}");
+
+        let (mut stream_ctrl, pos) = self.build_stream_control(&format)?;
+
+        self.send_vs_control(VideoStreamingControl::Probe as u8, &stream_ctrl)?;
+
+        let probe_response = self.get_vs_control(VideoStreamingControl::Probe as u8, 26)?;
+        stream_ctrl = parse_stream_control(&probe_response)?;
+        let payload = stream_ctrl.max_payload_transfer_size as usize;
+        self.active_alt_setting = self.select_alt_index(payload);
+        info!(
+            "[UVC] PROBE: fmt_ix={} frm_ix={} interval={} max_frame={} max_payload={} \
+             active_alt={}",
+            stream_ctrl.format_index,
+            stream_ctrl.frame_index,
+            stream_ctrl.frame_interval,
+            stream_ctrl.max_video_frame_size,
+            stream_ctrl.max_payload_transfer_size,
+            self.active_alt_setting
+        );
+
+        self.send_vs_control(VideoStreamingControl::Commit as u8, &stream_ctrl)?;
+
+        debug!("Video format set successfully");
+        self.active_format = pos;
+        // Keep stream interval in sync with what the device accepted.
+        let accepted_interval = stream_ctrl.frame_interval;
+        *self.cur_frame_interval.lock() = accepted_interval;
+        Ok(())
+    }
+
+    pub(crate) fn start_streaming(&mut self) -> Result<(), USBError> {
+        let best = self.alt_settings[self.active_alt_setting].clone();
+        log::info!(
+            "[UVC] Selected alt={} ep=0x{:02x} mps={} mult={} bInterval={}",
+            best.alt_setting,
+            best.ep,
+            best.mps,
+            best.packets_per_uframe,
+            best.interval,
+        );
+        self.handle
+            .claim_interface(self.vs_iface_num, best.alt_setting)
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to claim interface {} alt {}: {:?}",
+                    self.vs_iface_num,
+                    best.alt_setting,
+                    e
+                )
+            })?;
+
+        let packet_len = best.buf_len();
+        info!(
+            "[UVC] start_streaming: iso worker ep={:#x} batch={} packet_len={} depth={} buf={}",
+            best.ep,
+            ISO_BATCH,
+            packet_len,
+            ISO_DEPTH,
+            packet_len * ISO_BATCH * ISO_DEPTH
+        );
+        let cancel = Arc::new(AtomicBool::new(false));
+        let worker = {
+            let handle = self.handle.clone();
+            let pool = self.pool.clone();
+            let endpoint = best.ep;
+            let cancel = cancel.clone();
+            let fmt = self.active_format_ref();
+            let expected = if fmt.is_compressed() {
+                None
+            } else {
+                Some(fmt.max_frame_size as usize)
+            };
+            ax_task::spawn_with_name(
+                move || {
+                    ax_task::future::block_on(async move {
+                        let mut iso = match IsoStream::new(
+                            handle.clone(),
+                            endpoint,
+                            packet_len,
+                            ISO_BATCH,
+                            ISO_DEPTH,
+                        ) {
+                            Ok(v) => v,
+                            Err(err) => {
+                                error!("[UVC] stream: init err={err:?}");
+                                pool.set_error();
+                                return;
+                            }
+                        };
+                        let mut assembler =
+                            FrameAssembler::new(FrameParser::new(), pool.acquire(), expected);
+                        loop {
+                            if cancel.load(Ordering::Acquire) {
+                                iso.cancel_all();
+                                break;
+                            }
+                            let res =
+                                core::future::poll_fn(|cx| iso.poll_next(cx, &mut assembler)).await;
+                            match res {
+                                Ok(()) => {
+                                    if cancel.load(Ordering::Acquire) {
+                                        iso.cancel_all();
+                                        break;
+                                    }
+                                }
+                                Err(err) => {
+                                    iso.cancel_all();
+                                    if cancel.load(Ordering::Acquire)
+                                        || matches!(
+                                            err,
+                                            USBError::TransferError(
+                                                crab_usb::usb_if::err::TransferError::Cancelled
+                                            )
+                                        )
+                                    {
+                                        break;
+                                    }
+                                    error!("[UVC] stream: iso batch failed err={err:?}");
+                                    pool.set_error();
+                                    break;
+                                }
+                            }
+                        }
+                    });
+                },
+                alloc::string::String::from("uvc-stream"),
+            )
+        };
+        *self.stream.lock() = Some(IsoStreamWorker {
+            task: worker,
+            cancel,
+        });
+        info!("[UVC] start_streaming: iso worker armed");
+        Ok(())
+    }
+
+    pub(crate) fn close_stream(&self) {
+        if let Some(worker) = self.stream.lock().take() {
+            worker.cancel.store(true, Ordering::Release);
+            worker.task.join();
+        }
+        let _ = self.handle.claim_interface(self.vs_iface_num, 0);
+    }
+
+    fn send_vs_control(
+        &mut self,
+        control_selector: u8,
+        stream_ctrl: &StreamControl,
+    ) -> Result<(), USBError> {
+        let vs_interface_num = self.vs_iface_num;
+
+        let data = helper::serialize_stream_control(stream_ctrl);
+        let setup = ControlSetup {
+            request_type: RequestType::Class,
+            recipient: Recipient::Interface,
+            request: RequestCode::SetCur.into(),
+            value: (control_selector as u16) << 8,
+            index: vs_interface_num as u16,
+        };
+
+        debug!(
+            "Sending VS control: selector=0x{:02x}, data_len={}",
+            control_selector,
+            data.len()
+        );
+
+        self.handle
+            .control_out(setup, &data)
+            .map_err(|e| anyhow!("Failed to send VS control: {:?}", e))?;
+
+        Ok(())
+    }
+
+    fn get_vs_control(&mut self, control_selector: u8, length: usize) -> Result<Vec<u8>, USBError> {
+        let vs_interface_num = self.vs_iface_num;
+
+        let setup = ControlSetup {
+            request_type: RequestType::Class,
+            recipient: Recipient::Interface,
+            request: RequestCode::GetCur.into(),
+            value: (control_selector as u16) << 8,
+            index: vs_interface_num as u16,
+        };
+
+        let mut buffer = vec![0u8; length];
+        self.handle
+            .control_in(setup, &mut buffer)
+            .map_err(|e| anyhow!("Failed to get VS control: {:?}", e))?;
+
+        debug!(
+            "Received VS control response: selector=0x{:02x}, data_len={}",
+            control_selector,
+            buffer.len()
+        );
+
+        Ok(buffer)
+    }
+
+    /// Build stream control.
+    fn build_stream_control(
+        &self,
+        format: &VideoFormat,
+    ) -> Result<(StreamControl, usize), USBError> {
+        let pos = self.find_format_index(format).ok_or_else(|| {
+            warn!("Failed to find matching format for: {format:?}");
+            anyhow!("No matching format found")
+        })?;
+        let negotiated = &self.formats[pos];
+        let format_index = negotiated.format_index;
+        let frame_index = negotiated.frame_index;
+        info!(
+            "Found format_index={} frame_index={} for format: {format:?} at pos={}",
+            format_index, frame_index, pos
+        );
+
+        let frame_interval = if negotiated.default_interval != 0 {
+            negotiated.default_interval
+        } else {
+            match &negotiated.intervals {
+                FrameIntervals::Discrete(v) if !v.is_empty() => v[0],
+                FrameIntervals::Continuous { min, .. } => *min,
+                _ => 333_333,
+            }
+        };
+
+        let max_frame_size = negotiated.max_frame_size;
+
+        Ok((
+            StreamControl {
+                hint: 0x0001,
+                format_index,
+                frame_index,
+                frame_interval,
+                key_frame_rate: 0,
+                p_frame_rate: 0,
+                comp_quality: 0,
+                comp_window_size: 0,
+                delay: 0,
+                max_video_frame_size: max_frame_size,
+                max_payload_transfer_size: 0,
+            },
+            pos,
+        ))
+    }
+
+    /// Find format index.
+    fn find_format_index(&self, target: &VideoFormat) -> Option<usize> {
+        for (idx, format) in self.formats.iter().enumerate() {
+            if format.format_type != target.format_type {
+                continue;
+            }
+
+            if let (
+                VideoFormatType::Uncompressed(format_type),
+                VideoFormatType::Uncompressed(target_type),
+            ) = (&format.format_type, &target.format_type)
+                && format_type != target_type
+            {
+                continue;
+            }
+
+            if format.width == target.width && format.height == target.height {
+                debug!(
+                    "Found matching format: pos={} format_index={}, frame_index={}",
+                    idx, format.format_index, format.frame_index
+                );
+                return Some(idx);
+            }
+        }
+
+        for (idx, format) in self.formats.iter().enumerate() {
+            if format.format_type == target.format_type {
+                info!(
+                    "Using fallback format: pos={} format_index={}, frame_index={}",
+                    idx, format.format_index, format.frame_index
+                );
+                return Some(idx);
+            }
+        }
+
+        debug!("No matching format found, using default indices");
+        None
+    }
+
+    fn select_alt_index(&self, payload: usize) -> usize {
+        if self.alt_settings.is_empty() {
+            return 0;
+        }
+        let mut best_index = 0;
+        for (index, alt) in self.alt_settings.iter().enumerate() {
+            let total = alt.buf_len();
+            if total >= payload {
+                return index;
+            }
+            let best_total = self.alt_settings[best_index].buf_len();
+            if total > best_total {
+                best_index = index;
+            }
+        }
+        best_index
+    }
+
+    /// Find the best `(format_index, interval)` for `requested` `dwFrameInterval`.
+    pub(crate) fn find_interval(&self, requested: u32) -> (usize, u32) {
+        let active_pos = self.active_format;
+        let active_fmt = &self.formats[active_pos];
+
+        let mut best = (active_pos, uvc_try_frame_interval(active_fmt, requested));
+        for (pos, fmt) in self.formats.iter().enumerate() {
+            // 保证图像格式不变
+            if pos == active_pos || !fmt.is_same_image(active_fmt) {
+                continue;
+            }
+            let cand = uvc_try_frame_interval(fmt, requested);
+            if cand.abs_diff(requested) < best.1.abs_diff(requested) {
+                best = (pos, cand);
+            }
+        }
+        best
+    }
+}
+
+impl<H: UvcHandle> Drop for UvcDevice<H> {
+    fn drop(&mut self) {
+        self.close_stream();
+        self.pool.streamoff();
+        let _ = self.handle.release_interface(self.vc_iface_num);
+        let _ = self.handle.release_interface(self.vs_iface_num);
+    }
+}
+
+/// Find closest frame interval for the given `VideoFormat`, matching Linux
+/// `uvc_try_frame_interval` in `drivers/media/usb/uvc/uvc_v4l2.c:198`.
+pub(crate) fn uvc_try_frame_interval(format: &VideoFormat, interval: u32) -> u32 {
+    match &format.intervals {
+        FrameIntervals::Discrete(intervals) => {
+            if intervals.is_empty() {
+                if format.default_interval != 0 {
+                    return format.default_interval;
+                }
+                return interval;
+            }
+            // Discrete intervals: pick the one with minimal distance.
+            // Linux does early-break assuming sorted list; we do full scan for robustness
+            // while preserving the "last wins on tie / sorted" behaviour via linear scan.
+            let mut best = intervals[0];
+            let mut best_dist = interval.abs_diff(best);
+            for &cand in intervals.iter().skip(1) {
+                let dist = interval.abs_diff(cand);
+                // Linux breaks when dist > best (sorted), we replicate "pick closest,
+                // break on increase" by keeping the first minimal distance encountered
+                // with early exit optimisation for sorted data.
+                if dist > best_dist && cand > best && interval >= best {
+                    break;
+                }
+                if dist < best_dist {
+                    best_dist = dist;
+                    best = cand;
+                }
+            }
+            best
+        }
+        FrameIntervals::Continuous { min, max, step } => {
+            let min = *min;
+            let max = *max;
+            let step = *step;
+            if step == 0 {
+                return min.clamp(min, max);
+            }
+            if interval <= min {
+                return min;
+            }
+            if interval >= max {
+                return max;
+            }
+            // Round to nearest step, matching Linux's `min + (interval-min+step/2)/step*step`.
+            let rounded = min + (interval - min + step / 2) / step * step;
+            if rounded > max { max } else { rounded }
+        }
+    }
+}

--- a/drivers/media/uvc/src/stream.rs
+++ b/drivers/media/uvc/src/stream.rs
@@ -1,0 +1,232 @@
+//! UVC video stream.
+
+use alloc::{collections::VecDeque, sync::Arc, vec, vec::Vec};
+use core::task::{Context, Poll};
+
+use ax_media::videobuffer::{FrameGuard, VbMemOps, VbPoolLease};
+use crab_usb::{
+    EndpointHandle,
+    usb_if::{
+        endpoint::{RequestId, TransferRequest},
+        err::USBError,
+    },
+};
+
+use crate::{
+    UvcHandle,
+    frame::{FrameParser, PushOutcome},
+};
+
+pub(crate) const ISO_BATCH: usize = 64;
+pub(crate) const ISO_DEPTH: usize = 3;
+
+/// Pending ISO batch.
+#[derive(Clone)]
+pub struct IsoPending {
+    endpoint: EndpointHandle,
+    request_id: RequestId,
+}
+
+impl IsoPending {
+    pub fn new(endpoint: EndpointHandle, request_id: RequestId) -> Self {
+        Self {
+            endpoint,
+            request_id,
+        }
+    }
+
+    pub(crate) fn poll(&self, cx: &mut Context<'_>) -> Poll<Result<Vec<usize>, USBError>> {
+        match self.endpoint.poll_request(self.request_id, cx) {
+            Poll::Ready(Ok(completion)) => Poll::Ready(Ok(completion
+                .iso_packets
+                .iter()
+                .map(|packet| packet.actual_length)
+                .collect())),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(USBError::TransferError(err))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    pub(crate) fn cancel(&self) -> Result<(), USBError> {
+        self.endpoint
+            .cancel(self.request_id)
+            .map_err(USBError::TransferError)
+    }
+}
+
+pub(crate) struct FrameAssembler<M: VbMemOps> {
+    parser: FrameParser,
+    lease: VbPoolLease<M>,
+    expected_bytes: Option<usize>,
+}
+
+impl<M: VbMemOps> FrameAssembler<M> {
+    pub(crate) fn new(
+        parser: FrameParser,
+        lease: VbPoolLease<M>,
+        expected_bytes: Option<usize>,
+    ) -> Self {
+        Self {
+            parser,
+            lease,
+            expected_bytes,
+        }
+    }
+
+    pub(crate) fn process_batch(&mut self, data: &[u8], actuals: &[usize], packet_len: usize) {
+        for (i, &actual) in actuals.iter().enumerate() {
+            if actual < 2 {
+                continue;
+            }
+            let pkt = &data[i * packet_len..i * packet_len + actual];
+            self.process_one_packet(pkt);
+        }
+    }
+
+    fn process_one_packet(&mut self, pkt: &[u8]) {
+        let expected = self.expected_bytes;
+        let parser = &mut self.parser;
+        let lease = &mut self.lease;
+
+        let Some(mut guard) = lease.try_acquire() else {
+            return;
+        };
+        match Self::push_with(parser, &mut guard, pkt) {
+            PushOutcome::Pending => {}
+            PushOutcome::Completed { bytes } => Self::commit_if_valid(guard, bytes, expected),
+            PushOutcome::CompletedAndRetry { bytes } => {
+                let valid = expected.is_none_or(|exp| bytes == exp);
+                if valid {
+                    guard.commit(bytes as u32);
+                    let Some(mut next_guard) = lease.try_acquire() else {
+                        return;
+                    };
+                    match Self::push_with(parser, &mut next_guard, pkt) {
+                        PushOutcome::Completed { bytes } => {
+                            Self::commit_if_valid(next_guard, bytes, expected);
+                        }
+                        PushOutcome::Pending => {}
+                        PushOutcome::CompletedAndRetry { .. } => {
+                            debug_assert!(false, "parser must not retry twice");
+                        }
+                    }
+                } else {
+                    log::warn!(
+                        "[UVC] drop truncated frame: got {} expected {:?}",
+                        bytes,
+                        expected
+                    );
+                    match Self::push_with(parser, &mut guard, pkt) {
+                        PushOutcome::Pending => {}
+                        PushOutcome::Completed { bytes } => {
+                            Self::commit_if_valid(guard, bytes, expected);
+                        }
+                        PushOutcome::CompletedAndRetry { .. } => {
+                            unreachable!("parser must not retry twice")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn commit_if_valid(guard: FrameGuard<'_, M>, bytes: usize, expected: Option<usize>) {
+        if expected.is_none_or(|exp| bytes == exp) {
+            guard.commit(bytes as u32);
+        } else {
+            log::warn!(
+                "[UVC] drop truncated frame: got {} expected {:?}",
+                bytes,
+                expected
+            );
+        }
+    }
+
+    #[inline]
+    fn push_with(
+        parser: &mut FrameParser,
+        guard: &mut FrameGuard<'_, M>,
+        pkt: &[u8],
+    ) -> PushOutcome {
+        let dest = guard.as_mut_slice();
+        parser.push_packet(pkt, dest)
+    }
+}
+
+struct ActiveSlot {
+    buffer: Vec<u8>,
+    pending: IsoPending,
+}
+
+pub(crate) struct IsoStream<H: UvcHandle> {
+    handle: Arc<H>,
+    endpoint: u8,
+    packet_len: usize,
+    batch: usize,
+    queue: VecDeque<ActiveSlot>,
+}
+
+impl<H: UvcHandle> IsoStream<H> {
+    pub(crate) fn new(
+        handle: Arc<H>,
+        endpoint: u8,
+        packet_len: usize,
+        batch: usize,
+        depth: usize,
+    ) -> Result<Self, USBError> {
+        let packet_lengths = vec![packet_len; batch];
+        let mut queue = VecDeque::with_capacity(depth);
+        for _ in 0..depth {
+            let mut buffer = vec![0u8; packet_len * batch];
+            let pending = handle.submit_endpoint_transfer(
+                endpoint,
+                TransferRequest::iso_in(&mut buffer, &packet_lengths),
+            )?;
+            queue.push_back(ActiveSlot { buffer, pending });
+        }
+        Ok(Self {
+            handle,
+            endpoint,
+            packet_len,
+            batch,
+            queue,
+        })
+    }
+
+    pub(crate) fn poll_next<M: VbMemOps>(
+        &mut self,
+        cx: &mut Context<'_>,
+        assembler: &mut FrameAssembler<M>,
+    ) -> Poll<Result<(), USBError>> {
+        let Some(front) = self.queue.front_mut() else {
+            return Poll::Pending;
+        };
+        match front.pending.poll(cx) {
+            Poll::Ready(Ok(actuals)) => {
+                let mut slot = self.queue.pop_front().unwrap();
+                assembler.process_batch(&slot.buffer, &actuals, self.packet_len);
+                let packet_lengths = vec![self.packet_len; self.batch];
+                match self.handle.submit_endpoint_transfer(
+                    self.endpoint,
+                    TransferRequest::iso_in(&mut slot.buffer, &packet_lengths),
+                ) {
+                    Ok(pending) => {
+                        slot.pending = pending;
+                        self.queue.push_back(slot);
+                        Poll::Ready(Ok(()))
+                    }
+                    Err(err) => Poll::Ready(Err(err)),
+                }
+            }
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    pub(crate) fn cancel_all(&self) {
+        for slot in &self.queue {
+            let _ = slot.pending.cancel();
+        }
+    }
+}

--- a/drivers/media/uvc/src/v4l2_impl.rs
+++ b/drivers/media/uvc/src/v4l2_impl.rs
@@ -1,0 +1,572 @@
+//! UVC V4L2 ioctl dispatch.
+
+use alloc::{sync::Arc, vec::Vec};
+
+use ax_media::{
+    IoctlOps, LegacyIoctlOps, V4L2DriverOps, V4l2Error, V4l2Fh,
+    interface::{
+        BufType, Field, Fract, Timecode, Timeval, buffer,
+        buffer::Memory,
+        capability::{Capabilities, Capability},
+        colorspace,
+        event::EventSubscription,
+        format::{
+            self, Fmtdesc, Format, FrameIntervalEnum, FrameIntervalType, FrameSizeEnum,
+            FrameSizeType,
+        },
+        stream::{StreamParm, StreamParmCap, StreamParmMode},
+    },
+    videobuffer::BufferState,
+};
+use axpoll::PollSet;
+use log::*;
+
+use crate::{FrameIntervals, UvcDevice, UvcHandle, VideoFormat};
+
+#[allow(dead_code)]
+const PIX_FMT_MJPEG: u32 = 0x47504a4d;
+const PIX_FMT_YUYV: u32 = 0x56595559;
+
+impl<H: UvcHandle> V4L2DriverOps for UvcDevice<H> {
+    fn mmap(&self, offset: u64, length: u64) -> Option<(Vec<usize>, usize)> {
+        self.pool.mmap(offset, length)
+    }
+
+    fn is_readable(&self) -> bool {
+        self.pool.is_readable()
+    }
+
+    fn is_error(&self) -> bool {
+        self.pool.is_error()
+    }
+
+    fn is_streaming(&self) -> bool {
+        self.pool.is_streaming()
+    }
+
+    fn num_buffers(&self) -> u32 {
+        self.pool.num_buffers()
+    }
+
+    fn vb_poll_set(&self) -> Option<Arc<PollSet>> {
+        Some(self.pool.vb_poll_set().clone())
+    }
+
+    fn release(&self) {
+        self.close_stream();
+        self.pool.streamoff();
+    }
+
+    fn ctrl_handler(&self) -> Option<&ax_media::CtrlHandler> {
+        Some(&self.ctrls)
+    }
+}
+
+impl<H: UvcHandle> LegacyIoctlOps for UvcDevice<H> {}
+
+impl<H: UvcHandle> IoctlOps for UvcDevice<H> {
+    fn querycap(&self, cap: &mut Capability) -> ax_media::Result<()> {
+        let driver = b"uvc\0\0\0\0\0\0\0\0\0\0\0\0\0";
+        let card = b"Starry UVC Camera\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+        let bus = b"usb-sg2002\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+        cap.capabilities = Capabilities::VIDEO_CAPTURE
+            | Capabilities::STREAMING
+            | Capabilities::DEVICE_CAPS
+            | Capabilities::EXT_PIX_FORMAT;
+        cap.device_caps = Capabilities::VIDEO_CAPTURE | Capabilities::STREAMING;
+
+        cap.driver[..driver.len()].copy_from_slice(driver);
+        cap.card[..card.len()].copy_from_slice(card);
+        cap.bus_info[..bus.len()].copy_from_slice(bus);
+        cap.version = 0x00060000;
+        cap.reserved = [0; 3];
+
+        Ok(())
+    }
+
+    fn enum_fmt(&self, f: &mut Fmtdesc) -> ax_media::Result<()> {
+        if f.ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let mut seen = Vec::new();
+        let mut uniq: Vec<&VideoFormat> = Vec::new();
+        for fmt in &self.formats {
+            let pf = fmt.pixelformat();
+            if !seen.contains(&pf) {
+                seen.push(pf);
+                uniq.push(fmt);
+            }
+        }
+        let format = uniq
+            .get(f.index as usize)
+            .ok_or(V4l2Error::InvalidArgument)?;
+
+        f.description = [0; 32];
+        let description = format.description();
+        let desc_bytes = description.as_bytes();
+        let copy_len = desc_bytes.len().min(31);
+        f.description[..copy_len].copy_from_slice(&desc_bytes[..copy_len]);
+        f.pixelformat = format.pixelformat();
+        f.flags = if format.is_compressed() {
+            format::FmtFlag::COMPRESSED
+        } else {
+            format::FmtFlag::empty()
+        };
+        f.mbus_code = 0;
+        f.reserved = [0; 3];
+
+        Ok(())
+    }
+
+    fn enum_framesizes(&self, f: &mut FrameSizeEnum) -> ax_media::Result<()> {
+        let pixel_format = f.pixel_format;
+        let matching: Vec<&VideoFormat> = self
+            .formats
+            .iter()
+            .filter(|fmt| fmt.pixelformat() == pixel_format)
+            .collect();
+        if matching.is_empty() {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let format = matching
+            .get(f.index as usize)
+            .ok_or(V4l2Error::InvalidArgument)?;
+        f.ty = FrameSizeType::Discrete;
+        f.size.discrete.width = format.width as u32;
+        f.size.discrete.height = format.height as u32;
+        f.reserved = [0; 2];
+        Ok(())
+    }
+
+    fn enum_frameintervals(&self, f: &mut FrameIntervalEnum) -> ax_media::Result<()> {
+        // Linux `uvc_ioctl_enum_frameintervals` enumerates per-format, per-size
+        // intervals: discrete intervals are indexed via `fival->index`, continuous
+        // is reported as stepwise with index 0 only.
+        let matching: Vec<&VideoFormat> = self
+            .formats
+            .iter()
+            .filter(|fmt| {
+                fmt.pixelformat() == f.pixel_format
+                    && fmt.width as u32 == f.width
+                    && fmt.height as u32 == f.height
+            })
+            .collect();
+        if matching.is_empty() {
+            return Err(V4l2Error::InvalidArgument);
+        }
+
+        // Aggregate discrete intervals across matching frames like Linux does
+        // (it loops over frames with same w/h and decrements index).
+        // For simplicity we support the common case where each resolution has a
+        // single VideoFormat entry; if there are multiple entries for the same
+        // resolution, we flatten their discrete intervals.
+        // First, handle continuous (bFrameIntervalType==0) – only one entry.
+        let first = matching[0];
+        if let FrameIntervals::Continuous { min, max, step } = &first.intervals {
+            if f.index != 0 {
+                return Err(V4l2Error::InvalidArgument);
+            }
+            let min_f = Fract::from_interval(*min);
+            let max_f = Fract::from_interval(*max);
+            let step_f = Fract::from_interval(*step);
+            f.ty = FrameIntervalType::Stepwise;
+            f.interval.stepwise.min = min_f;
+            f.interval.stepwise.max = max_f;
+            f.interval.stepwise.step = step_f;
+            f.reserved = [0; 2];
+            return Ok(());
+        }
+
+        // Discrete: flatten all intervals from matching formats.
+        let mut flat: Vec<u32> = Vec::new();
+        for fmt in matching {
+            match &fmt.intervals {
+                FrameIntervals::Discrete(v) => {
+                    if v.is_empty() {
+                        let interval = if fmt.default_interval != 0 {
+                            fmt.default_interval
+                        } else {
+                            333_333u32
+                        };
+                        flat.push(interval);
+                    } else {
+                        flat.extend_from_slice(v);
+                    }
+                }
+                FrameIntervals::Continuous { min, .. } => {
+                    // Continuous should have been handled above; if mixed, use min.
+                    flat.push(*min);
+                }
+            }
+        }
+        let interval = flat
+            .get(f.index as usize)
+            .ok_or(V4l2Error::InvalidArgument)?;
+        let fract = Fract::from_interval(*interval);
+        f.ty = FrameIntervalType::Discrete;
+        f.interval.discrete = fract;
+        f.reserved = [0; 2];
+        Ok(())
+    }
+
+    fn g_fmt(&self, f: &mut Format) -> ax_media::Result<()> {
+        if f.ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let current = self.active_format_ref();
+
+        f.ty = BufType::VideoCapture;
+        f.fmt.pix.width = current.width as u32;
+        f.fmt.pix.height = current.height as u32;
+        f.fmt.pix.pixelformat = current.pixelformat();
+        f.fmt.pix.field = Field::NoField;
+        f.fmt.pix.bytesperline = current.bytes_per_line() as u32;
+        f.fmt.pix.sizeimage = current.max_frame_size;
+        f.fmt.pix.colorspace = current.colorspace();
+        f.fmt.pix.priv_data = 0;
+        f.fmt.pix.flags = 0;
+        f.fmt.pix.ycbcr_enc = colorspace::YcbcrEncoding::Default as u32;
+        f.fmt.pix.quantization = colorspace::Quantization::FullRange;
+        f.fmt.pix.xfer_func = colorspace::XferFunc::Default;
+        Ok(())
+    }
+
+    fn s_fmt(&mut self, f: &mut Format) -> ax_media::Result<()> {
+        if f.ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        // SAFETY: `f.ty` is VideoCapture, so `pix` is active.
+        let pix = unsafe { f.fmt.pix };
+        let width = pix.width as u16;
+        let height = pix.height as u16;
+        let mut pixelformat = pix.pixelformat;
+
+        if !self
+            .formats
+            .iter()
+            .any(|fmt| fmt.pixelformat() == pixelformat)
+        {
+            pixelformat = self
+                .formats
+                .first()
+                .map(|fmt| fmt.pixelformat())
+                .unwrap_or(PIX_FMT_YUYV);
+        }
+
+        let format = VideoFormat {
+            format_type: pixelformat.into(),
+            width,
+            height,
+            format_index: 0,
+            frame_index: 0,
+            default_interval: 0,
+            intervals: FrameIntervals::Discrete(Vec::new()),
+            max_frame_size: 0,
+        };
+
+        self.set_format(format)
+            .map_err(|_| V4l2Error::InvalidArgument)?;
+
+        let current = self.active_format_ref();
+        f.fmt.pix.width = current.width as u32;
+        f.fmt.pix.height = current.height as u32;
+        f.fmt.pix.pixelformat = current.pixelformat();
+        f.fmt.pix.field = Field::NoField;
+        f.fmt.pix.bytesperline = current.bytes_per_line() as u32;
+        f.fmt.pix.sizeimage = current.max_frame_size;
+        f.fmt.pix.colorspace = current.colorspace();
+        f.fmt.pix.priv_data = 0;
+        f.fmt.pix.flags = 0;
+        f.fmt.pix.ycbcr_enc = colorspace::YcbcrEncoding::Default as u32;
+        f.fmt.pix.quantization = colorspace::Quantization::FullRange;
+        f.fmt.pix.xfer_func = colorspace::XferFunc::Default;
+        Ok(())
+    }
+
+    fn try_fmt(&self, f: &mut Format) -> ax_media::Result<()> {
+        if f.ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        // SAFETY: `f.ty` is VideoCapture, so `pix` is active.
+        let pix = unsafe { f.fmt.pix };
+        let mut pixelformat = pix.pixelformat;
+        if !self
+            .formats
+            .iter()
+            .any(|fmt| fmt.pixelformat() == pixelformat)
+        {
+            pixelformat = self
+                .formats
+                .first()
+                .map(|fmt| fmt.pixelformat())
+                .unwrap_or(PIX_FMT_YUYV);
+        }
+        let negotiated = self
+            .formats
+            .iter()
+            .find(|fmt| {
+                fmt.pixelformat() == pixelformat
+                    && fmt.width as u32 == pix.width
+                    && fmt.height as u32 == pix.height
+            })
+            .or_else(|| {
+                self.formats
+                    .iter()
+                    .find(|fmt| fmt.pixelformat() == pixelformat)
+            });
+        let (w, h, sizeimage, bytesperline, colorspace) = match negotiated {
+            Some(fmt) => (
+                fmt.width as u32,
+                fmt.height as u32,
+                fmt.max_frame_size,
+                fmt.bytes_per_line() as u32,
+                fmt.colorspace(),
+            ),
+            None => (
+                pix.width.clamp(160, 1920),
+                pix.height.clamp(120, 1080),
+                pix.width * pix.height * 2,
+                0,
+                colorspace::Colorspace::Srgb,
+            ),
+        };
+        f.fmt.pix.width = w;
+        f.fmt.pix.height = h;
+        f.fmt.pix.pixelformat = pixelformat;
+        f.fmt.pix.field = Field::NoField;
+        f.fmt.pix.bytesperline = bytesperline;
+        f.fmt.pix.sizeimage = sizeimage;
+        f.fmt.pix.colorspace = colorspace;
+        f.fmt.pix.priv_data = 0;
+        f.fmt.pix.flags = 0;
+        f.fmt.pix.ycbcr_enc = colorspace::YcbcrEncoding::Default as u32;
+        f.fmt.pix.quantization = colorspace::Quantization::FullRange;
+        f.fmt.pix.xfer_func = colorspace::XferFunc::Default;
+        Ok(())
+    }
+
+    fn reqbufs(&mut self, req: &mut buffer::Requestbuffers) -> ax_media::Result<()> {
+        if req.ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        if req.memory != Memory::Mmap {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let sizeimage = {
+            let bytes = self.active_format_ref().max_frame_size;
+            if bytes != 0 { bytes } else { 300 * 1024 }
+        };
+        let q = &self.pool;
+        if req.count == 0 {
+            q.reqbufs(0, &[sizeimage])?;
+            req.count = 0;
+            req.capabilities = buffer::BufCapabilities::SUPPORTS_MMAP;
+            req.flags = 0;
+            req.reserved = [0; 3];
+            return Ok(());
+        }
+        q.reqbufs(req.count, &[sizeimage])?;
+        req.count = q.num_buffers();
+        req.capabilities = buffer::BufCapabilities::SUPPORTS_MMAP;
+        req.flags = 0;
+        req.reserved = [0; 3];
+        Ok(())
+    }
+
+    fn querybuf(&self, buf: &mut buffer::Buffer) -> ax_media::Result<()> {
+        let q = &self.pool;
+        let vb = q
+            .buffer_snapshot(buf.index)
+            .ok_or(V4l2Error::InvalidArgument)?;
+
+        let plane = vb.planes.first().ok_or(V4l2Error::InvalidArgument)?;
+        buf.ty = BufType::VideoCapture;
+        buf.length = plane.length;
+        buf.m.offset = plane.offset as u32;
+        buf.memory = Memory::Mmap;
+        buf.field = Field::NoField;
+        buf.timecode = Timecode::default();
+        buf.reserved2 = 0;
+        buf.request_fd = 0;
+
+        let mut flags = buffer::BufFlags::MAPPED | buffer::BufFlags::TIMESTAMP_MONOTONIC;
+        match vb.state {
+            BufferState::Ready | BufferState::Active => flags |= buffer::BufFlags::QUEUED,
+            BufferState::Done => {
+                flags |= buffer::BufFlags::DONE;
+            }
+            BufferState::Error => {
+                flags |= buffer::BufFlags::DONE | buffer::BufFlags::ERROR;
+            }
+            BufferState::Free => {}
+        }
+        buf.flags = flags;
+
+        if vb.state == BufferState::Done || vb.state == BufferState::Error {
+            buf.bytesused = vb.bytesused;
+            buf.sequence = vb.sequence;
+            buf.timestamp = vb.timestamp.timeval();
+        } else {
+            buf.bytesused = 0;
+            buf.sequence = 0;
+            buf.timestamp = Timeval::default();
+        }
+        Ok(())
+    }
+
+    fn qbuf(&mut self, buf: &mut buffer::Buffer) -> ax_media::Result<()> {
+        self.pool.qbuf(buf.index)?;
+        buf.flags = buffer::BufFlags::QUEUED;
+        Ok(())
+    }
+
+    fn dqbuf(&mut self, buf: &mut buffer::Buffer) -> ax_media::Result<()> {
+        let q = &self.pool;
+        if !q.is_streaming() {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        if q.is_error() {
+            return Err(V4l2Error::Io);
+        }
+        if !q.is_readable() {
+            return Err(V4l2Error::WouldBlock);
+        }
+        let idx = q.dqbuf()?;
+        let vb = q.buffer_snapshot(idx).ok_or(V4l2Error::InvalidArgument)?;
+        let (bytesused, sequence, timestamp) = (vb.bytesused, vb.sequence, vb.timestamp);
+
+        buf.index = idx;
+        buf.flags = buffer::BufFlags::KEYFRAME | timestamp.flags();
+        buf.bytesused = bytesused;
+        buf.timestamp = timestamp.timeval();
+        buf.field = Field::NoField;
+        buf.sequence = sequence;
+        buf.memory = Memory::Mmap;
+        buf.ty = BufType::VideoCapture;
+        buf.length = vb.planes.first().map(|p| p.length).unwrap_or(0);
+        buf.m.offset = vb.planes.first().map(|p| p.offset as u32).unwrap_or(0);
+        Ok(())
+    }
+
+    fn streamon(&mut self, ty: BufType) -> ax_media::Result<()> {
+        if ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        self.pool.streamon()?;
+        if let Err(e) = self.start_streaming().map_err(|_| V4l2Error::Io) {
+            self.pool.streamoff();
+            self.close_stream();
+            return Err(e);
+        }
+        Ok(())
+    }
+
+    fn streamoff(&mut self, ty: BufType) -> ax_media::Result<()> {
+        if ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        self.close_stream();
+        self.pool.streamoff();
+        Ok(())
+    }
+
+    fn g_parm(&self, p: &mut StreamParm) -> ax_media::Result<()> {
+        if p.ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        p.parm.raw_data = [0; 200];
+        // SAFETY: `p.ty` is VideoCapture, so `capture` union field is active.
+        let cap = unsafe { &mut p.parm.capture };
+        let interval = *self.cur_frame_interval.lock();
+        let fract = Fract::from_interval(interval);
+        cap.capability = StreamParmCap::TIMEPERFRAME;
+        cap.capturemode = StreamParmMode::empty();
+        cap.timeperframe = fract;
+        cap.extendedmode = 0;
+        cap.readbuffers = 0;
+        cap.reserved = [0; 4];
+        Ok(())
+    }
+
+    fn s_parm(&mut self, p: &mut StreamParm) -> ax_media::Result<()> {
+        if p.ty != BufType::VideoCapture {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        // 匹配 Linux uvc 驱动行为，若流正在运行，则拒绝 s_parm
+        if self.pool.is_streaming() {
+            return Err(V4l2Error::Busy);
+        }
+        // SAFETY: `p.ty` is VideoCapture, so `capture` is active.
+        let req = unsafe { p.parm.capture.timeperframe };
+        let requested_interval = Fract::new(req.numerator, req.denominator).to_interval();
+
+        let (best_pos, negotiated) = self.find_interval(requested_interval);
+        let result_fract = Fract::from_interval(negotiated);
+
+        // 更新 active_format，由于实际的图像格式不变，不需要重新 s_fmt
+        if best_pos != self.active_format {
+            self.active_format = best_pos;
+        }
+        *self.cur_frame_interval.lock() = negotiated;
+
+        p.parm.raw_data = [0; 200];
+        // SAFETY: `p.ty` is VideoCapture, so `capture` is active.
+        let cap = unsafe { &mut p.parm.capture };
+        cap.capability = StreamParmCap::TIMEPERFRAME;
+        cap.capturemode = StreamParmMode::empty();
+        cap.timeperframe = result_fract;
+        cap.extendedmode = 0;
+        cap.readbuffers = 0;
+        cap.reserved = [0; 4];
+        Ok(())
+    }
+
+    fn log_status(&self) -> ax_media::Result<()> {
+        info!(
+            "[UVC] log_status streaming={} buffers={} fmt={}x{} pf={:08x}",
+            self.pool.is_streaming(),
+            self.pool.num_buffers(),
+            self.active_format_ref().width,
+            self.active_format_ref().height,
+            self.active_format_ref().pixelformat()
+        );
+        Ok(())
+    }
+
+    fn enum_input(&self, input: &mut ax_media::interface::inout::Input) -> ax_media::Result<()> {
+        if input.index != 0 {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        let name = b"Camera\0";
+        input.name = [0; 32];
+        input.name[..name.len()].copy_from_slice(name);
+        input.ty = ax_media::interface::inout::InputType::Camera;
+        input.audioset = 0;
+        input.tuner = 0;
+        input.std = 0;
+        input.status = ax_media::interface::inout::InStatus::empty();
+        input.capabilities = ax_media::interface::inout::InCap::empty();
+        input.reserved = [0; 3];
+        Ok(())
+    }
+
+    fn g_input(&self) -> ax_media::Result<u32> {
+        Ok(0)
+    }
+
+    fn s_input(&mut self, index: u32) -> ax_media::Result<()> {
+        if index != 0 {
+            return Err(V4l2Error::InvalidArgument);
+        }
+        Ok(())
+    }
+
+    fn subscribe_event(
+        &mut self,
+        fh: &mut V4l2Fh,
+        sub: &EventSubscription,
+    ) -> ax_media::Result<()> {
+        self.ctrls.subscribe_event(fh, sub)
+    }
+}

--- a/os/StarryOS/kernel/Cargo.toml
+++ b/os/StarryOS/kernel/Cargo.toml
@@ -116,6 +116,8 @@ sg2002-cvi-usb-camera = [
     "dep:cvi-vdec-uapi",
     "dep:sg200x-jpu",
 ]
+v4l2 = ["dep:ax-media"]
+uvc = ["v4l2", "dep:media-uvc"]
 smp = ["ax-std/smp"]
 stack-guard-page = ["ax-runtime/stack-guard-page"]
 stack-protector = ["ax-runtime/stack-protector"]
@@ -156,6 +158,10 @@ k230-kpu = { workspace = true, optional = true }
 crab-usb.workspace = true
 usb-serial.workspace = true
 rdrive.workspace = true
+ax-media = { workspace = true, optional = true }
+media-uvc = { workspace = true, optional = true }
+ax-sync = { workspace = true, features = ["sleep"] }
+anyhow.workspace = true
 
 axbacktrace = { workspace = true }
 ax-cgroup = { workspace = true }

--- a/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mod.rs
@@ -42,6 +42,10 @@ mod cvi_usb_camera;
 
 #[cfg(feature = "sg2002-cvi-usb-camera")]
 mod cvi_vdec;
+#[cfg(feature = "uvc")]
+mod uvc_camera;
+#[cfg(feature = "uvc")]
+mod video;
 
 use alloc::{format, sync::Arc};
 use core::{
@@ -815,6 +819,36 @@ fn builder(fs: Arc<SimpleFs>) -> DirMaker {
                     Arc::new(cvi_vdec::CviVdec::new(jpu)),
                 ),
             );
+        }
+    }
+    #[cfg(feature = "uvc")]
+    {
+        let mut video_idx = 0u32;
+        for snap in uvc_camera::collect_uvc_snapshots() {
+            match uvc_camera::create_camera_driver(&snap) {
+                Ok(cam_driver) => {
+                    let events = cam_driver.event_source();
+                    let driver: Arc<ax_sync::Mutex<dyn ax_media::V4L2DriverOps>> =
+                        Arc::new(ax_sync::Mutex::new(cam_driver));
+                    let vdev = ax_media::VideoDevice::new(driver, "uvc");
+                    root.add(
+                        format!("video{video_idx}"),
+                        Device::new(
+                            fs.clone(),
+                            NodeType::CharacterDevice,
+                            DeviceId::new(81, video_idx),
+                            Arc::new(video::V4l2DevNode::from_input(vdev, events)),
+                        ),
+                    );
+                    video_idx += 1;
+                }
+                Err(err) => {
+                    warn!(
+                        "uvc: failed to create camera driver for bus {} dev {}: {:?}",
+                        snap.bus_num, snap.device_num, err
+                    );
+                }
+            }
         }
     }
     SimpleDir::new_maker(fs, Arc::new(root))

--- a/os/StarryOS/kernel/src/pseudofs/dev/uvc_camera.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/uvc_camera.rs
@@ -1,0 +1,154 @@
+//! UVC V4L2 camera driver — kernel-side glue.
+
+use crab_usb::{
+    err::{TransferError, USBError},
+    usb_if::{
+        endpoint::TransferRequest,
+        host::ControlSetup,
+        transfer::{Recipient, RequestType},
+    },
+};
+use media_uvc::{IsoPending, UvcDevice, UvcHandle};
+
+use crate::{
+    StarryError, StarryResult,
+    pseudofs::usbfs::{self, SubmittedTransferInner, UsbDeviceHandle, UsbDeviceSnapshotInfo},
+};
+
+/// 将 usbfs 层错误映射为 [`USBError`]（uvc 的错误类型）。
+fn map_usb_error(e: StarryError) -> USBError {
+    use StarryError::*;
+    match e {
+        InvalidInput => USBError::InvalidParameter,
+        NotFound | NoSuchDevice | NoSuchDeviceOrAddress => USBError::NotFound,
+        ResourceBusy => USBError::SlotLimitReached,
+        Unsupported | NotATty => USBError::NotSupported,
+        TimedOut => USBError::Timeout,
+        NoMemory => USBError::NoMemory,
+        Errno(crate::Errno::ENOENT) => {
+            USBError::TransferError(crab_usb::usb_if::err::TransferError::Cancelled)
+        }
+        OperationNotPermitted | PermissionDenied => {
+            USBError::Other(anyhow::anyhow!("usbfs: operation not permitted: {e}"))
+        }
+        other => USBError::Other(anyhow::anyhow!("usbfs: {other}")),
+    }
+}
+
+// ── UvcHandle impl for UsbDeviceHandle ────────────────────────────────
+
+impl UvcHandle for UsbDeviceHandle {
+    fn claim_interface(&self, interface: u8, alternate: u8) -> Result<(), USBError> {
+        UsbDeviceHandle::claim_interface(self, interface, alternate).map_err(map_usb_error)
+    }
+
+    fn release_interface(&self, interface: u8) -> Result<(), USBError> {
+        UsbDeviceHandle::release_interface(self, interface).map_err(map_usb_error)
+    }
+
+    fn control_in(&self, param: ControlSetup, data: &mut [u8]) -> Result<usize, USBError> {
+        let bmrt = control_setup_to_bmrequesttype(&param) | 0x80; // IN
+        let req = control_setup_to_brequest(&param);
+        self.control_transfer(bmrt, req, param.value, param.index, data)
+            .map_err(map_usb_error)
+    }
+
+    fn control_out(&self, param: ControlSetup, data: &[u8]) -> Result<(), USBError> {
+        let bmrt = control_setup_to_bmrequesttype(&param) & !0x80; // OUT
+        let req = control_setup_to_brequest(&param);
+        let mut buf = [0u8; 64];
+        let len = data.len().min(buf.len());
+        buf[..len].copy_from_slice(&data[..len]);
+        let _ = self
+            .control_transfer(bmrt, req, param.value, param.index, &mut buf[..len])
+            .map_err(map_usb_error)?;
+        Ok(())
+    }
+
+    fn submit_endpoint_transfer(
+        &self,
+        endpoint: u8,
+        request: TransferRequest,
+    ) -> Result<IsoPending, USBError> {
+        let submitted = self
+            .submit_endpoint_transfer(endpoint, request)
+            .map_err(map_usb_error)?;
+        match submitted.inner {
+            SubmittedTransferInner::Endpoint {
+                endpoint,
+                request_id,
+            } => Ok(IsoPending::new(endpoint, request_id)),
+            SubmittedTransferInner::Control { .. } => Err(USBError::InvalidParameter),
+        }
+    }
+}
+
+fn control_setup_to_bmrequesttype(setup: &ControlSetup) -> u8 {
+    use Recipient::*;
+    use RequestType::*;
+    let ty_bits = match setup.request_type {
+        Standard => 0x00,
+        Class => 0x20,
+        Vendor => 0x40,
+        Reserved => 0x60,
+    };
+    let recip_bits = match setup.recipient {
+        Device => 0x00,
+        Interface => 0x01,
+        Endpoint => 0x02,
+        Other => 0x03,
+    };
+    ty_bits | recip_bits
+}
+
+fn control_setup_to_brequest(setup: &ControlSetup) -> u8 {
+    setup.request.into()
+}
+
+// ── Camera driver creation ───────────────────────────────────────────
+
+pub type CameraDriver = UvcDevice<UsbDeviceHandle>;
+
+/// 将 UVC 驱动错误映射为 [`StarryError`]。
+fn map_uvc_error(err: USBError) -> StarryError {
+    match err {
+        USBError::InvalidParameter => StarryError::InvalidInput,
+        USBError::NotFound => StarryError::NotFound,
+        USBError::NotSupported => StarryError::Unsupported,
+        USBError::Timeout => StarryError::TimedOut,
+        USBError::NoMemory => StarryError::NoMemory,
+        USBError::SlotLimitReached => StarryError::ResourceBusy,
+        USBError::NotInitialized | USBError::ConfigurationNotSet => StarryError::BadState,
+        USBError::InterfaceBroken => StarryError::Io,
+        USBError::TransferError(err) => map_transfer_error(err),
+        USBError::Other(_) => StarryError::Io,
+    }
+}
+
+/// 将 UVC 传输错误映射为 [`StarryError`]。
+fn map_transfer_error(err: TransferError) -> StarryError {
+    match err {
+        TransferError::Timeout => StarryError::TimedOut,
+        TransferError::Cancelled | TransferError::EndpointRevoked => {
+            StarryError::from(crate::Errno::ENOENT)
+        }
+        TransferError::Stall => StarryError::BrokenPipe,
+        TransferError::QueueFull => StarryError::ResourceBusy,
+        TransferError::InvalidEndpoint => StarryError::InvalidInput,
+        TransferError::NoDevice | TransferError::Disconnected => StarryError::NoSuchDevice,
+        TransferError::NotSupported => StarryError::Unsupported,
+        TransferError::Other(_) => StarryError::Io,
+    }
+}
+
+pub fn collect_uvc_snapshots() -> alloc::vec::Vec<UsbDeviceSnapshotInfo> {
+    usbfs::usb_device_snapshots()
+        .into_iter()
+        .filter(|snap| CameraDriver::check(&snap.descriptor_blob))
+        .collect()
+}
+
+pub fn create_camera_driver(snap: &UsbDeviceSnapshotInfo) -> StarryResult<CameraDriver> {
+    let handle = usbfs::acquire_usb_device(snap.bus_num, snap.device_num)?;
+    UvcDevice::new(handle, &snap.descriptor_blob).map_err(map_uvc_error)
+}

--- a/os/StarryOS/kernel/src/pseudofs/dev/video.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/video.rs
@@ -1,0 +1,316 @@
+//! V4L2 视频设备 — 将 v4l2 与 StarryOS pseudofs 的 DeviceOps 桥接起来。
+//!
+//! 这是 `/dev/videoX` 的实现。它包装了一个 `ax_media::device::VideoDevice`，
+//! 并处理 ioctl ABI：从用户空间指针读取 C 结构体、
+//! 分发到 V4L2 ioctl 引擎，再写回结果。
+
+use alloc::{sync::Arc, vec, vec::Vec};
+use core::{any::Any, mem::MaybeUninit, task::Context};
+
+use ax_media::{
+    IoctlCmd, V4l2Error, VideoDevice, VideoIoctl,
+    interface::{
+        ctrl::{ExtControl, ExtControls},
+        event::Event,
+    },
+};
+use ax_memory_addr::PhysAddr;
+use axfs_ng_vfs::{NodeFlags, VfsError, VfsResult};
+use axpoll::{IoEvents, PollSet, Pollable};
+use starry_vm::{VmError, vm_read_slice, vm_write_slice};
+
+use crate::{
+    StarryError,
+    pseudofs::{DeviceMmap, DeviceOps},
+};
+
+/// 将用户内存访问错误映射为 VFS 错误（经 StarryError 桥接）。
+fn vm_to_vfs(e: VmError) -> VfsError {
+    VfsError::from(StarryError::from(e))
+}
+
+/// V4L2 视频设备节点 — 将 `VideoDevice` 包装为 `DeviceOps`。
+pub struct V4l2DevNode {
+    inner: Arc<VideoDevice>,
+    event_source: Option<Arc<ax_sync::Mutex<Vec<Event>>>>,
+    poll_rx: Option<Arc<PollSet>>,
+    event_poll_rx: Arc<PollSet>,
+}
+
+impl V4l2DevNode {
+    fn new(device: VideoDevice, event_source: Option<Arc<ax_sync::Mutex<Vec<Event>>>>) -> Self {
+        // 完成唤醒由驱动（vb2 队列）内建：构造时取一次 vb_poll_set，
+        // 之后 register 无需设备锁。事件唤醒源同理（设备构造时内建）。
+        let inner = Arc::new(device);
+        let poll_rx = inner.vb_poll_set();
+        let event_poll_rx = inner.event_poll_set();
+        Self {
+            inner,
+            event_source,
+            poll_rx,
+            event_poll_rx,
+        }
+    }
+
+    /// 从输入（采集）设备创建设备节点。
+    pub fn from_input(device: VideoDevice, event_source: Arc<ax_sync::Mutex<Vec<Event>>>) -> Self {
+        Self::new(device, Some(event_source))
+    }
+
+    /// 将共享驱动事件队列中的事件投递到 fh（订阅过滤在框架内完成）。
+    fn drain_events(&self) {
+        if let Some(ref src) = self.event_source {
+            let events: Vec<Event> = core::mem::take(&mut *src.lock());
+            for mut ev in events {
+                self.inner.queue_event(&mut ev);
+            }
+        }
+    }
+}
+
+impl DeviceOps for V4l2DevNode {
+    fn open(&self, _exclusive: bool) -> VfsResult<()> {
+        self.inner.open_fh();
+        Ok(())
+    }
+
+    fn close(&self, _exclusive: bool) {
+        self.inner.close_fh();
+    }
+
+    fn read_at(&self, _buf: &mut [u8], _offset: u64) -> VfsResult<usize> {
+        Err(VfsError::from(StarryError::InvalidInput))
+    }
+
+    fn write_at(&self, _buf: &[u8], _offset: u64) -> VfsResult<usize> {
+        Err(VfsError::from(StarryError::InvalidInput))
+    }
+
+    fn ioctl(&self, cmd: u32, arg: usize) -> VfsResult<usize> {
+        let Some(ioctl) = VideoIoctl::try_from_u32(cmd) else {
+            return Err(VfsError::from(StarryError::NotATty));
+        };
+
+        // LOG_STATUS 为 _IO 无参，arg==0 合法；其余需要指针的 ioctl 在 arg==0 时应 EFAULT
+        let is_log_status = matches!(ioctl, VideoIoctl::Modern(IoctlCmd::LogStatus));
+        let size = if is_log_status {
+            0
+        } else {
+            ioctl_arg_size(cmd)
+        };
+        if size > 0 && arg == 0 {
+            return Err(VfsError::BadAddress);
+        }
+
+        // 堆分配 ioctl 缓冲：结构体大小可能超过栈安全阈值（如
+        // v4l2_query_ext_ctrl ≈ 236B，ext_ctrls payload 可达 KB 级），
+        // 栈上 1024B 数组在单核内核小栈下危险，且会截断大结构体。
+        let mut buf_uninit: Vec<MaybeUninit<u8>> = vec![MaybeUninit::uninit(); size];
+        if size > 0 && arg != 0 {
+            vm_read_slice(arg as *const u8, &mut buf_uninit).map_err(vm_to_vfs)?;
+        }
+        // MaybeUninit<u8> → u8：u8 无 drop，assume_init 安全。
+        let mut buf: Vec<u8> = buf_uninit
+            .into_iter()
+            .map(|v| unsafe { v.assume_init() })
+            .collect();
+
+        // ── 扩展控件：需要从用户空间读取 payload ──
+        if let VideoIoctl::Modern(ioctl_cmd) = ioctl {
+            match ioctl_cmd {
+                IoctlCmd::GExtCtrls | IoctlCmd::SExtCtrls | IoctlCmd::TryExtCtrls => {
+                    // 从已复制的参数缓冲中读取头
+                    let mut header: ExtControls =
+                        unsafe { core::ptr::read_unaligned(buf.as_ptr() as *const ExtControls) };
+                    let ec_count = header.count as usize;
+                    let ec_size = core::mem::size_of::<ExtControl>();
+                    let payload_size = ec_count * ec_size;
+                    if payload_size > 0 {
+                        // 从用户空间将控件数组读入堆缓冲。
+                        let mut payload_uninit: Vec<MaybeUninit<u8>> =
+                            vec![MaybeUninit::uninit(); payload_size];
+                        vm_read_slice(header.controls as *const u8, &mut payload_uninit)
+                            .map_err(vm_to_vfs)?;
+                        let mut payload: Vec<u8> = payload_uninit
+                            .into_iter()
+                            .map(|v| unsafe { v.assume_init() })
+                            .collect();
+
+                        let result = match ioctl_cmd {
+                            IoctlCmd::GExtCtrls => {
+                                self.inner.handle_g_ext_ctrls(&mut header, &mut payload)
+                            }
+                            IoctlCmd::SExtCtrls => {
+                                self.inner.handle_s_ext_ctrls(&mut header, &mut payload)
+                            }
+                            IoctlCmd::TryExtCtrls => {
+                                self.inner.handle_try_ext_ctrls(&mut header, &mut payload)
+                            }
+                            _ => unreachable!(),
+                        };
+
+                        match result {
+                            Ok(()) => {
+                                // G/S/TRY 均回写控件数组（值可能被取整 / clamp）。
+                                vm_write_slice(header.controls as *mut u8, &payload)
+                                    .map_err(vm_to_vfs)?;
+                                // 同时回写头（error_idx / which 可能被设置）
+                                let header_bytes = unsafe {
+                                    core::slice::from_raw_parts(
+                                        &header as *const ExtControls as *const u8,
+                                        core::mem::size_of::<ExtControls>(),
+                                    )
+                                };
+                                vm_write_slice(arg as *mut u8, header_bytes).map_err(vm_to_vfs)?;
+                                self.drain_events();
+                                return Ok(0);
+                            }
+                            Err(err) => {
+                                // 即使失败也需回写 header 的 error_idx，对齐 Linux 语义
+                                let header_bytes = unsafe {
+                                    core::slice::from_raw_parts(
+                                        &header as *const ExtControls as *const u8,
+                                        core::mem::size_of::<ExtControls>(),
+                                    )
+                                };
+                                let _ = vm_write_slice(arg as *mut u8, header_bytes);
+                                let _ = vm_write_slice(header.controls as *mut u8, &payload);
+                                return Err(VfsError::from(map_v4l2_error(err)));
+                            }
+                        }
+                    } else {
+                        // count==0：无 payload，直接校验 which（类探测）
+                        let mut empty_payload = Vec::new();
+                        let result = match ioctl_cmd {
+                            IoctlCmd::GExtCtrls => self
+                                .inner
+                                .handle_g_ext_ctrls(&mut header, &mut empty_payload),
+                            IoctlCmd::SExtCtrls => self
+                                .inner
+                                .handle_s_ext_ctrls(&mut header, &mut empty_payload),
+                            IoctlCmd::TryExtCtrls => self
+                                .inner
+                                .handle_try_ext_ctrls(&mut header, &mut empty_payload),
+                            _ => unreachable!(),
+                        };
+                        match result {
+                            Ok(()) => {
+                                let header_bytes = unsafe {
+                                    core::slice::from_raw_parts(
+                                        &header as *const ExtControls as *const u8,
+                                        core::mem::size_of::<ExtControls>(),
+                                    )
+                                };
+                                vm_write_slice(arg as *mut u8, header_bytes).map_err(vm_to_vfs)?;
+                                self.drain_events();
+                                return Ok(0);
+                            }
+                            Err(err) => {
+                                let header_bytes = unsafe {
+                                    core::slice::from_raw_parts(
+                                        &header as *const ExtControls as *const u8,
+                                        core::mem::size_of::<ExtControls>(),
+                                    )
+                                };
+                                let _ = vm_write_slice(arg as *mut u8, header_bytes);
+                                return Err(VfsError::from(map_v4l2_error(err)));
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match self.inner.handle_ioctl(ioctl, &mut buf[..size]) {
+            Ok(()) => {
+                if size > 0 && arg != 0 {
+                    vm_write_slice(arg as *mut u8, &buf[..size]).map_err(vm_to_vfs)?;
+                }
+                self.drain_events();
+                Ok(0)
+            }
+            Err(err) => Err(VfsError::from(map_v4l2_error(err))),
+        }
+    }
+
+    fn mmap(&self, offset: u64, length: u64) -> DeviceMmap {
+        if let Some((pages, _size)) = self.inner.mmap(offset, length) {
+            DeviceMmap::PhysicalPages(pages.into_iter().map(PhysAddr::from_usize).collect(), None)
+        } else {
+            DeviceMmap::None
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_pollable(&self) -> Option<&dyn Pollable> {
+        Some(self)
+    }
+
+    fn flags(&self) -> NodeFlags {
+        NodeFlags::NON_CACHEABLE
+    }
+}
+
+impl Pollable for V4l2DevNode {
+    fn poll(&self) -> IoEvents {
+        let mut events = IoEvents::empty();
+        if self.inner.is_readable() {
+            events |= IoEvents::IN;
+        }
+        if self.inner.is_error() {
+            events |= IoEvents::ERR;
+        }
+        if self.inner.has_pending_events() {
+            events |= IoEvents::PRI;
+        }
+        events
+    }
+
+    fn register(&self, context: &mut Context<'_>, events: IoEvents) {
+        let Some(poll_rx) = &self.poll_rx else {
+            context.waker().wake_by_ref();
+            return;
+        };
+        let interests = events & (IoEvents::IN | IoEvents::ERR);
+        if !interests.is_empty() {
+            unsafe { poll_rx.register(context.waker(), interests) }
+        }
+        if !(events & IoEvents::PRI).is_empty() {
+            unsafe { self.event_poll_rx.register(context.waker(), IoEvents::PRI) }
+        }
+    }
+}
+
+/// 估算给定 ioctl 命令对应的 C 结构体大小。
+fn ioctl_arg_size(cmd: u32) -> usize {
+    let encoded = ((cmd >> 16) & 0x3FFF) as usize;
+    if encoded == 0 { 256 } else { encoded }
+}
+
+/// 将 V4L2 驱动错误映射为 [`StarryError`]。
+fn map_v4l2_error(err: V4l2Error) -> StarryError {
+    match err {
+        V4l2Error::InvalidArgument => StarryError::InvalidInput,
+        V4l2Error::NoSuchDevice => StarryError::NoSuchDevice,
+        V4l2Error::Io => StarryError::Io,
+        V4l2Error::NotSupported => StarryError::NotATty,
+        V4l2Error::Busy => StarryError::ResourceBusy,
+        V4l2Error::Timeout => StarryError::TimedOut,
+        V4l2Error::NoMemory => StarryError::NoMemory,
+        V4l2Error::AccessDenied => StarryError::PermissionDenied,
+        V4l2Error::BadFileDescriptor => StarryError::BadFileDescriptor,
+        V4l2Error::WouldBlock => StarryError::WouldBlock,
+        V4l2Error::NoEntry => StarryError::NotFound,
+        V4l2Error::NoSuchDeviceOrAddress => StarryError::NoSuchDeviceOrAddress,
+        V4l2Error::OperationNotPermitted => StarryError::OperationNotPermitted,
+        V4l2Error::Interrupted => StarryError::Interrupted,
+        V4l2Error::NotATty => StarryError::NotATty,
+        V4l2Error::StorageFull => StarryError::StorageFull,
+        V4l2Error::OutOfRange => StarryError::OutOfRange,
+        V4l2Error::MessageTooLong => StarryError::Io,
+    }
+}

--- a/os/StarryOS/kernel/src/pseudofs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/mod.rs
@@ -89,8 +89,8 @@ pub fn mount_all() -> StarryResult<()> {
 
     let fs_context = ax_fs_ng::vfs::current_fs_context();
     let fs = fs_context.lock();
-    mount_at(&fs, "/dev", dev::new_devfs())?;
     let usbfs = usbfs::new_usbfs()?;
+    mount_at(&fs, "/dev", dev::new_devfs())?;
     if let Some(dev_usbfs) = usbfs {
         mount_at(&fs, "/dev/bus/usb", dev_usbfs)?;
     }

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/manager.rs
@@ -81,7 +81,7 @@ struct LiveInterfaceSession {
     session: InterfaceSession,
 }
 
-struct LiveDeviceState {
+pub(crate) struct LiveDeviceState {
     device: BlockingMutex<Device>,
     interfaces: BlockingMutex<BTreeMap<u8, LiveInterfaceSession>>,
 }
@@ -90,8 +90,8 @@ pub(super) struct IsoTransferResult {
     pub(super) actual_length: usize,
 }
 
-pub(super) struct SubmittedTransfer {
-    inner: SubmittedTransferInner,
+pub(crate) struct SubmittedTransfer {
+    pub(crate) inner: SubmittedTransferInner,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -100,7 +100,7 @@ pub(super) enum SubmittedTransferQueue {
     Control(usize),
 }
 
-enum SubmittedTransferInner {
+pub(crate) enum SubmittedTransferInner {
     Endpoint {
         endpoint: EndpointHandle,
         request_id: RequestId,

--- a/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
+++ b/os/StarryOS/kernel/src/pseudofs/usbfs/mod.rs
@@ -24,6 +24,8 @@ use axfs_ng_vfs::Filesystem;
 use axpoll::{IoEvents, PollSet, Pollable};
 use crab_usb::usb_if::endpoint::{TransferCompletion, TransferRequest};
 use event_listener::Event as NotifyEvent;
+#[cfg(feature = "uvc")]
+pub(crate) use manager::{SubmittedTransfer, SubmittedTransferInner};
 use starry_vm::{VmMutPtr, VmPtr, vm_load, vm_write_slice};
 
 use self::{irq::manager, manager::UsbFsManager, tree::UsbRootDir};
@@ -132,6 +134,15 @@ impl UsbDeviceHandle {
 
     pub(crate) fn bulk_out(&self, endpoint: u8, data: &[u8]) -> StarryResult<usize> {
         self.lease.bulk_out(endpoint, data)
+    }
+
+    #[cfg(feature = "uvc")]
+    pub(crate) fn submit_endpoint_transfer(
+        &self,
+        endpoint: u8,
+        request: TransferRequest,
+    ) -> StarryResult<SubmittedTransfer> {
+        self.lease.submit_endpoint_transfer(endpoint, request)
     }
 }
 


### PR DESCRIPTION

## 概述

该 PR 实现了 V4L2 子系统的框架，包括与 Linux 对齐的 V4L2 核心、vb2 风格的缓冲队列，还实现了基于 CrabUSB 的 UVC 驱动。UVC 驱动与缓冲管理被完整接入 StarryOS 的设备模型和文件系统生命周期，统一参与 `sg2002-v4l2` 特性门控、`VideoDevice`/`Vb2Queue` 状态机、资源申请/回滚与 poll 唤醒。

## 重点模块

- `v4l2-core`：V4L2 核心框架，提供统一的设备、文件句柄、事件与 ioctl 分发能力，上层驱动只需实现格式、缓冲与控制等接口即可接入。
- `videobuffer`：通用的视频缓冲队列，对 `reqbufs/qbuf/dqbuf/streamon/streamoff/mmap` 提供状态管理与内存分配抽象，当前以 `vmalloc` 为默认后端。
- `media-uvc`：UVC 摄像头驱动，负责解析描述符、协商格式与等时流采集，将 USB 数据组帧后交付给缓冲队列。

## 预期行为

- 未枚举到 UVC 设备时不创建 `/dev/video0`，静默跳过初始化。
- 存在 UVC 设备时，按 `descriptor_blob` 解析的 VC/VS 接口号完成 `claim_interface`
- 用户可通过标准 V4L2 `ioctl` 接口完成打开、格式协商、缓冲申请、推流与帧获取。
- `v4l2-compliance` 全量合规仍在完善中，完善进度：**Succeeded: 45, Failed: 3**。
- USB 等时传输通过 `UvcHandle::submit_endpoint_transfer` 提交，在 `media-uvc` 内部异步处理 Usb Package。

### 已知限制

1. `v4l2-compliance` 全量测试尚未全部通过，核心原因如下：
   - `select` 系统调用存在 bug https://github.com/rcore-os/tgoskits/issues/2217 
   - 当前文件系统不支持 `private data`，从驱动视角看，无法得知被哪一个用户访问，导致无法提供 session 语义
2. 无法保证实时性，当前的 uvc 驱动是中断 wakeup + task 重填的方式来实现的，在 高负载情况下无法保证实时调度，容易造成丢帧

