### PR TITLE
fix(starry-kernel): avoid filesystem teardown in reboot syscall

### DIFF
--- a/os/StarryOS/kernel/src/syscall/sys.rs
+++ b/os/StarryOS/kernel/src/syscall/sys.rs
@@ -154,12 +154,15 @@ pub fn sys_reboot(magic: u32, magic2: u32, cmd: u32, _arg: usize) -> StarryResul
 
     match cmd {
         LINUX_REBOOT_CMD_CAD_ON | LINUX_REBOOT_CMD_CAD_OFF => Ok(0),
+        // Linux's reboot(2) contract does not synchronize or unmount file
+        // systems; callers such as systemctl perform sync before entering
+        // this syscall. Teardown here can wait forever on userspace services
+        // that still hold descriptors while the requested power transition
+        // is already being committed.
         LINUX_REBOOT_CMD_RESTART | LINUX_REBOOT_CMD_RESTART2 => {
-            let _ = ax_fs_ng::shutdown_filesystems();
             ax_runtime::hal::power::system_reset()
         }
         LINUX_REBOOT_CMD_HALT | LINUX_REBOOT_CMD_POWER_OFF => {
-            let _ = ax_fs_ng::shutdown_filesystems();
             ax_runtime::hal::power::system_off()
         }
         _ => Err(StarryError::from(Errno::EINVAL)),
@@ -1130,5 +1133,27 @@ mod tests {
     #[test]
     fn sys_constants_and_validation_rules_hold() {
         assert!(super::sys_constants_and_validation_rules_hold_for_test());
+    }
+
+    #[test]
+    fn reboot_syscall_does_not_tear_down_filesystems() {
+        let source = include_str!("sys.rs");
+        let start = source
+            .find("pub fn sys_reboot(")
+            .expect("sys_reboot must exist");
+        let remainder = &source[start..];
+        let end = remainder[1..]
+            .find("\npub fn ")
+            .map(|offset| offset + 1)
+            .unwrap_or(remainder.len());
+        let reboot = &remainder[..end];
+        assert!(
+            !reboot.contains("shutdown_filesystems"),
+            "reboot(2) must not sync or unmount filesystems; Linux leaves that to userspace"
+        );
+        assert!(
+            reboot.contains("system_reset") && reboot.contains("system_off"),
+            "reboot(2) restart and power-off must still reach the platform power helpers"
+        );
     }
 }


### PR DESCRIPTION
## 问题

`reboot(2)` 在 Linux 中不负责同步或卸载文件系统；`systemctl poweroff` 会先 `sync()`，再进入 `reboot(RB_POWER_OFF)`。Starry 的 `sys_reboot()` 却在 `system_reset()` / `system_off()` 之前调用 `ax_fs_ng::shutdown_filesystems()`。该路径会进入 ext4/JBD2/block 同步，并可能一直等待仍被 userspace 持有的描述符，导致 guest 完成 stage-2 marker 后无法关机。

该问题在 `005-starry-nixos-tests` 的 P1 TCG 运行中暴露：串口已出现完整 `pid1 → activation → systemd → marker → STARRY_NIXOS_SYSTEM_PASSED`，但 `systemctl --force --force poweroff` 后 QEMU 不退出。本 PR 从该 feature 中拆出独立内核修复，不包含 nixosTest 框架改动。

## 改动

- 从 `os/StarryOS/kernel/src/syscall/sys.rs` 的 restart/halt/power-off 路径移除 `shutdown_filesystems()`。
- 让 `reboot(2)` 直接进入平台 `system_reset()` / `system_off()`，与 Linux `kernel/reboot.c` 的 syscall 契约对齐。
- 增加 `reboot_syscall_does_not_tear_down_filesystems` 源码契约测试：旧实现必然失败，修复后通过。

## 依据

- Linux v6.12 `kernel/reboot.c` 明确说明 `reboot(2)` 本身不做 sync。
- systemd 的直接 poweroff 路径先 `sync()`，再调用 `reboot(RB_POWER_OFF)`。
- 在主工作树对旧实现运行 `cargo test -p starry-kernel reboot_syscall --lib` 失败；应用本修复后同一测试通过。
- 同一修复下的 P1 运行 `proxychains4 cargo xtask starry test nixos --arch x86_64 -c boot` 在约 551s 内完成 `wait_for_shutdown`，无 `StarryNixOS QEMU did not exit successfully`。

## 依赖顺序

- 本 PR 应先于 `005-starry-nixos-tests` 合入。
- P1 分支不再包含该补丁，避免两分支重复同一内核修复。