### PR TITLE
fix(arm_vgic): implement GICR_WAKER ProcessorSleep/ChildrenAsleep semantics

### DIFF
--- a/virtualization/arm_vgic/src/redistributor/mmio.rs
+++ b/virtualization/arm_vgic/src/redistributor/mmio.rs
@@ -84,7 +84,16 @@ impl RedistributorState {
                 require_width(offset, width, AccessWidth::Qword, "read")?;
                 Ok(self.typer(config))
             }
-            GICR_WAKER | GICR_SYNCR => read_dword(offset, width, 0),
+            GICR_WAKER => {
+                require_width(offset, width, AccessWidth::Dword, "read")?;
+                let mut value = if self.waker_processor_sleep { 0b10 } else { 0 };
+                if self.waker_processor_sleep && self.queued_deliveries.is_empty() {
+                    // ChildrenAsleep (bit 0): the Redistributor is quiescent.
+                    value |= 0b1;
+                }
+                Ok(value)
+            }
+            GICR_SYNCR => read_dword(offset, width, 0),
             GICR_PROPBASER => {
                 require_width(offset, width, AccessWidth::Qword, "read")?;
                 Ok(if config.exposes_guest_lpis() {
@@ -131,7 +140,11 @@ impl RedistributorState {
                     }
                 }
             }
-            GICR_WAKER | GICR_SYNCR => {
+            GICR_WAKER => {
+                require_width(offset, width, AccessWidth::Dword, "write")?;
+                self.waker_processor_sleep = value & 0b10 != 0;
+            }
+            GICR_SYNCR => {
                 require_width(offset, width, AccessWidth::Dword, "write")?;
             }
             GICR_PROPBASER => {

--- a/virtualization/arm_vgic/src/redistributor/mod.rs
+++ b/virtualization/arm_vgic/src/redistributor/mod.rs
@@ -139,6 +139,8 @@ pub(crate) struct RedistributorState {
     lpis_enabled: bool,
     propbaser: u64,
     pendbaser: u64,
+    /// GICR_WAKER.ProcessorSleep (bit 1) written by the guest.
+    waker_processor_sleep: bool,
 }
 
 impl RedistributorState {
@@ -172,6 +174,7 @@ impl RedistributorState {
             lpis_enabled: false,
             propbaser: 0,
             pendbaser: 0,
+            waker_processor_sleep: false,
         })
     }
 

--- a/virtualization/arm_vgic/src/redistributor/tests.rs
+++ b/virtualization/arm_vgic/src/redistributor/tests.rs
@@ -1,4 +1,10 @@
+use axvm_types::AccessWidth;
+
 use super::*;
+use crate::{
+    GicV3Config, GicV3Controller, GicV3MmioRegion, GicV3SpiOwnership, SgiId, SgiTarget,
+    SoftwareGicV3Backend, register::GICR_WAKER,
+};
 
 struct NoopWake;
 
@@ -78,4 +84,95 @@ fn physical_delivery_uses_only_preallocated_queue_slots() {
         Err(VgicError::DeliveryQueueFull { .. })
     ));
     assert_eq!(redistributor.queued_deliveries.capacity(), capacity);
+}
+
+#[test]
+fn waker_processor_sleep_is_retained_and_reports_children_asleep() {
+    let config = GicV3Config::new(
+        GicV3SpiOwnership::AllGuestOwned,
+        GicV3MmioRegion::new(0x0800_0000, 0x1_0000).unwrap(),
+        GicV3MmioRegion::new(0x080a_0000, 0x2_0000).unwrap(),
+        0x2_0000,
+        1,
+    )
+    .unwrap();
+    let controller = GicV3Controller::new(config, Arc::new(SoftwareGicV3Backend)).unwrap();
+    // Keep the binding alive: dropping it detaches the vCPU and removes its
+    // Redistributor from the controller.
+    let _binding = controller
+        .attach_vcpu(
+            GicVcpuId::new(0),
+            GicAffinity::new(0, 0, 0, 0),
+            Arc::new(NoopWake),
+        )
+        .unwrap();
+
+    // A guest powering down a secondary CPU writes GICR_WAKER.ProcessorSleep
+    // (bit 1) and then polls ChildrenAsleep (bit 0).  The redistributor is
+    // quiescent here, so the write must be retained and ChildrenAsleep must
+    // become visible.
+    controller
+        .write_redistributor(GicVcpuId::new(0), GICR_WAKER, AccessWidth::Dword, 0b10)
+        .unwrap();
+    let waker = controller
+        .read_redistributor(GicVcpuId::new(0), GICR_WAKER, AccessWidth::Dword)
+        .unwrap();
+    assert_eq!(
+        waker & 0b11,
+        0b11,
+        "ProcessorSleep write must be retained and ChildrenAsleep must be visible after quiescence"
+    );
+}
+
+#[test]
+fn waker_children_asleep_clears_while_delivery_is_queued() {
+    let config = GicV3Config::new(
+        GicV3SpiOwnership::AllGuestOwned,
+        GicV3MmioRegion::new(0x0800_0000, 0x1_0000).unwrap(),
+        GicV3MmioRegion::new(0x080a_0000, 0x2_0000).unwrap(),
+        0x2_0000,
+        1,
+    )
+    .unwrap();
+    let controller = GicV3Controller::new(config, Arc::new(SoftwareGicV3Backend)).unwrap();
+    // Keep the binding alive: dropping it detaches the vCPU and removes its
+    // Redistributor from the controller.
+    let _binding = controller
+        .attach_vcpu(
+            GicVcpuId::new(0),
+            GicAffinity::new(0, 0, 0, 0),
+            Arc::new(NoopWake),
+        )
+        .unwrap();
+
+    controller
+        .write_redistributor(GicVcpuId::new(0), GICR_WAKER, AccessWidth::Dword, 0b10)
+        .unwrap();
+    assert_eq!(
+        controller
+            .read_redistributor(GicVcpuId::new(0), GICR_WAKER, AccessWidth::Dword)
+            .unwrap()
+            & 0b11,
+        0b11,
+        "quiescent Redistributor reports ChildrenAsleep after ProcessorSleep"
+    );
+
+    // A pending delivery makes the Redistributor non-quiescent: ChildrenAsleep
+    // must clear while ProcessorSleep stays set.  SGIs are deliverable by
+    // default, so this queues one without further configuration.
+    controller
+        .send_sgi(
+            GicVcpuId::new(0),
+            SgiId::new(1).unwrap(),
+            SgiTarget::SelfOnly,
+        )
+        .unwrap();
+    assert_eq!(
+        controller
+            .read_redistributor(GicVcpuId::new(0), GICR_WAKER, AccessWidth::Dword)
+            .unwrap()
+            & 0b11,
+        0b10,
+        "ChildrenAsleep must clear while a delivery is queued"
+    );
 }


### PR DESCRIPTION
### Problem

The emulated GICv3 Redistributor handled `GICR_WAKER` as a stub: reads always returned 0 and writes were accepted but discarded. `ProcessorSleep` (RW, bit 1) was never retained and `ChildrenAsleep` (RO, bit 0) was never reported, so a guest powering down a secondary CPU (CPU hotplug / CPU_OFF) that writes `ProcessorSleep=1` and then polls `ChildrenAsleep` would spin forever waiting for a state the emulator never produced.

### Fix

Track `ProcessorSleep` in `RedistributorState` and split the previously combined `GICR_WAKER | GICR_SYNCR` match arm: reads now return `ProcessorSleep` and, when a sleep has been requested and no delivery is queued, `ChildrenAsleep`; writes store bit 1. `GICR_SYNCR` behavior is unchanged.

### Tests

Add two regression tests that drive the production mmio path (`GicV3Controller::write_redistributor` / `read_redistributor`): one verifies the write is retained and `ChildrenAsleep` is visible once quiescent, the other verifies `ChildrenAsleep` clears while a delivery is queued. Both fail against the old stub (read returns 0) and pass with the fix. The `arm_vgic` unit suite is 6/6 and clippy is clean.