### PR TITLE
refactor(test): isolate host tests and CI evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,7 +456,8 @@ jobs:
     uses: ./.github/workflows/reusable-check-matrix.yml
     with:
       matrix_json: ${{ needs.plan_ci.outputs.axvisor_matrix }}
-      fail_fast: true
+      # Physical-board availability must not cancel independent QEMU evidence.
+      fail_fast: false
       save_cache: >-
         ${{ github.event_name == 'push' &&
             (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6958,6 +6958,7 @@ dependencies = [
 name = "rsext4"
 version = "0.8.1"
 dependencies = [
+ "ax-runtime",
  "bitflags 2.13.1",
  "thiserror 2.0.20",
 ]

--- a/fs/ax-fs-ng/src/os/memory.rs
+++ b/fs/ax-fs-ng/src/os/memory.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use core::sync::atomic::AtomicU64;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use ax_lazyinit::OnceLock;
@@ -14,6 +16,8 @@ pub trait FsPageProvider: Send + Sync {
 #[derive(Debug)]
 pub struct FsPage {
     addr: usize,
+    #[cfg(test)]
+    generation: u64,
 }
 
 impl FsPage {
@@ -22,7 +26,11 @@ impl FsPage {
     /// `addr` must point to one writable, page-sized, page-aligned kernel
     /// mapping owned by the returned `FsPage`.
     pub const unsafe fn from_raw(addr: usize) -> Self {
-        Self { addr }
+        Self {
+            addr,
+            #[cfg(test)]
+            generation: 0,
+        }
     }
 
     pub const fn addr(&self) -> usize {
@@ -75,6 +83,7 @@ pub mod test_support {
 
     pub struct TestPageProvider {
         translate: AtomicBool,
+        generation: AtomicU64,
         alloc_count: AtomicUsize,
         dealloc_count: AtomicUsize,
     }
@@ -83,6 +92,7 @@ pub mod test_support {
         const fn new() -> Self {
             Self {
                 translate: AtomicBool::new(true),
+                generation: AtomicU64::new(0),
                 alloc_count: AtomicUsize::new(0),
                 dealloc_count: AtomicUsize::new(0),
             }
@@ -98,6 +108,7 @@ pub mod test_support {
 
         fn reset(&self, translate: bool) {
             self.translate.store(translate, Ordering::Release);
+            self.generation.fetch_add(1, Ordering::AcqRel);
             self.alloc_count.store(0, Ordering::Release);
             self.dealloc_count.store(0, Ordering::Release);
         }
@@ -111,15 +122,21 @@ pub mod test_support {
             // identical layout in `dealloc_page`.
             let page = NonNull::new(unsafe { alloc_zeroed(layout) }).ok_or(VfsError::NoMemory)?;
             self.alloc_count.fetch_add(1, Ordering::AcqRel);
-            Ok(unsafe { FsPage::from_raw(page.as_ptr() as usize) })
+            Ok(FsPage {
+                addr: page.as_ptr() as usize,
+                generation: self.generation.load(Ordering::Acquire),
+            })
         }
 
         fn dealloc_page(&self, page: FsPage) {
             let layout = Layout::from_size_align(PAGE_SIZE, PAGE_SIZE).unwrap();
+            let generation = page.generation;
             // SAFETY: `page` was allocated by `alloc_page` with this exact
-            // layout and is transferred here exactly once by `FsPage::drop`.
+            // layout and is transferred here exactly once by `dealloc_page`.
             unsafe { dealloc(page.as_mut_ptr(), layout) };
-            self.dealloc_count.fetch_add(1, Ordering::AcqRel);
+            if generation == self.generation.load(Ordering::Acquire) {
+                self.dealloc_count.fetch_add(1, Ordering::AcqRel);
+            }
         }
 
         fn virt_to_phys(&self, vaddr: usize) -> Option<usize> {
@@ -168,6 +185,16 @@ mod tests {
     fn page_provider_reports_missing_physical_address() {
         with_test_page_provider(false, |_| {
             assert_eq!(virt_to_phys(0x1000), None);
+        });
+    }
+
+    #[test]
+    fn page_provider_counters_ignore_pages_from_previous_epoch() {
+        let stale_page = with_test_page_provider(true, |_| alloc_page().unwrap());
+
+        with_test_page_provider(true, |provider| {
+            dealloc_page(stale_page);
+            assert_eq!(provider.dealloc_count(), 0);
         });
     }
 }

--- a/fs/ax-fs-ng/src/root.rs
+++ b/fs/ax-fs-ng/src/root.rs
@@ -222,7 +222,11 @@ pub fn init_root(
         |part| part.info.region,
     );
 
-    let root = if let Some(kind) = selected_filesystem_kind(&selected, selected_partition) {
+    let root = if let Some(kind) = selected_filesystem_kind(
+        selected.raw_filesystem,
+        &selected.partitions,
+        selected_partition,
+    ) {
         init_detected_filesystem(selected.handle.clone(), region, kind, &description, source)
     } else {
         init_filesystem(selected.handle.clone(), region, &description, source)
@@ -693,11 +697,12 @@ fn mount_path_for_partition(partition: &PartitionInfo) -> String {
 }
 
 fn selected_filesystem_kind(
-    disk: &DiscoveredDisk,
+    raw_filesystem: Option<FilesystemKind>,
+    partitions: &[DetectedPartition],
     partition_index: Option<usize>,
 ) -> Option<FilesystemKind> {
-    partition_index.map_or(disk.raw_filesystem, |partition_index| {
-        disk.partitions
+    partition_index.map_or(raw_filesystem, |partition_index| {
+        partitions
             .iter()
             .find(|partition| partition.info.index == partition_index)
             .and_then(|partition| partition.filesystem)
@@ -812,19 +817,11 @@ mod tests {
         FileNodeOps, Filesystem, FilesystemOps, FsIoEvents, FsPollable, Metadata, MetadataUpdate,
         NodeFlags, NodeOps, Reference, RenameOptions, StatFs, VfsResult, WeakDirEntry,
     };
-    use rdif_block::{
-        BatchSubmitResult, BlkError, BlockController, CompletionSink, ControllerEvent,
-        ControllerState, ControllerUpdate, DeviceInfo, DriverGeneric, HardwareQueue,
-        OwnedRequestBatch, QueueInfo, QueueLimits, SubmissionSink,
-    };
+    use rdif_block::DeviceInfo;
 
     use super::*;
-    use crate::{
-        BlockError, BlockResult,
-        block::runtime::{BlockRuntime, RdifBlockDevice},
-    };
+    use crate::{BlockError, BlockResult};
 
-    struct TestQueue;
     struct FlakyMetadataDevice {
         remaining_failures: usize,
         data: Vec<u8>,
@@ -1119,88 +1116,6 @@ mod tests {
         }
     }
 
-    impl HardwareQueue for TestQueue {
-        fn id(&self) -> usize {
-            0
-        }
-
-        fn info(&self) -> QueueInfo {
-            QueueInfo {
-                id: 0,
-                device: DeviceInfo::new(16, 512),
-                limits: QueueLimits::simple(
-                    512,
-                    dma_api::DmaDeviceInfo::new(
-                        dma_api::DmaDomainId::Direct,
-                        dma_api::DmaCoherency::NonCoherent,
-                        dma_api::DmaConstraints::new(u64::MAX),
-                    ),
-                ),
-            }
-        }
-
-        fn submit_batch_owned(
-            &mut self,
-            requests: &mut OwnedRequestBatch,
-            _sink: &mut dyn SubmissionSink,
-        ) -> BatchSubmitResult {
-            let _ = requests;
-            unreachable!("root selection tests do not submit block requests")
-        }
-
-        fn commit_submissions(&mut self) -> Result<(), BlkError> {
-            unreachable!("root selection tests do not commit block requests")
-        }
-
-        fn drain_completions(&mut self, _sink: &mut dyn CompletionSink) -> Result<(), BlkError> {
-            unreachable!("root selection tests do not drain block requests")
-        }
-
-        fn shutdown(&mut self, _sink: &mut dyn CompletionSink) -> Result<(), BlkError> {
-            Ok(())
-        }
-    }
-
-    struct TestController {
-        queue: Option<TestQueue>,
-    }
-
-    impl DriverGeneric for TestController {
-        fn name(&self) -> &str {
-            "test-controller"
-        }
-
-        fn raw_any(&self) -> Option<&dyn Any> {
-            Some(self)
-        }
-
-        fn raw_any_mut(&mut self) -> Option<&mut dyn Any> {
-            Some(self)
-        }
-    }
-
-    impl BlockController for TestController {
-        fn device_info(&self) -> DeviceInfo {
-            DeviceInfo::new(16, 512)
-        }
-
-        fn max_io_queues(&self) -> usize {
-            1
-        }
-
-        fn advance(&mut self, event: ControllerEvent) -> Result<ControllerUpdate, BlkError> {
-            match event {
-                ControllerEvent::Start { .. } => Ok(ControllerUpdate::with_resources(
-                    ControllerState::Ready,
-                    alloc::vec![Box::new(self.queue.take().unwrap())],
-                    Vec::new(),
-                )),
-                ControllerEvent::Shutdown => Ok(ControllerUpdate::state(ControllerState::Shutdown)),
-                _ => Ok(ControllerUpdate::state(ControllerState::Ready)),
-            }
-        }
-    }
-
     impl FlakyMetadataDevice {
         fn new(remaining_failures: usize) -> Self {
             let mut data = alloc::vec![0; 16 * 512];
@@ -1308,23 +1223,6 @@ mod tests {
                 },
                 filesystem,
             }),
-        }
-    }
-
-    fn raw_disk(filesystem: Option<FilesystemKind>) -> DiscoveredDisk {
-        crate::os::task::install_test_runtime_ops();
-        let runtime = BlockRuntime::from_rdif_devices([RdifBlockDevice::new_with_irqs(
-            "test-disk",
-            [],
-            Box::new(TestController {
-                queue: Some(TestQueue),
-            }),
-        )]);
-        DiscoveredDisk {
-            disk_index: 0,
-            handle: runtime.devices()[0].clone(),
-            raw_filesystem: filesystem,
-            partitions: Vec::new(),
         }
     }
 
@@ -1439,18 +1337,17 @@ mod tests {
 
     #[test]
     fn raw_root_selection_preserves_detected_filesystem_kind() {
-        let disks = [raw_disk(Some(FilesystemKind::Fat))];
-        let candidates = collect_root_candidates(&disks);
+        let candidates = [RootCandidate {
+            disk_index: 0,
+            partition: None,
+        }];
         let (disk_index, partition_index) =
             select_default_root(&candidates).expect("raw root should be selected");
-        let disk = disks
-            .iter()
-            .find(|disk| disk.disk_index == disk_index)
-            .unwrap();
 
+        assert_eq!(disk_index, 0);
         assert_eq!(partition_index, None);
         assert_eq!(
-            selected_filesystem_kind(disk, partition_index),
+            selected_filesystem_kind(Some(FilesystemKind::Fat), &[], partition_index),
             Some(FilesystemKind::Fat)
         );
     }

--- a/fs/rsext4/Cargo.toml
+++ b/fs/rsext4/Cargo.toml
@@ -16,6 +16,10 @@ license = "Apache-2.0"
 bitflags = "2.10"
 thiserror.workspace = true
 
+[dev-dependencies]
+# Host tests exercise runtime-provided synchronization contracts.
+ax-runtime = { path = "../../os/arceos/modules/axruntime", features = ["host-test"] }
+
 [features]
 default = ["USE_MULTILEVEL_CACHE"]
 host-test = []

--- a/scripts/test/check_ci_routing.py
+++ b/scripts/test/check_ci_routing.py
@@ -320,12 +320,12 @@ def main() -> int:
         errors.append("the workflow must consume per-group matrices, not test_matrix")
 
     grouped_jobs = (
-        ("workspace_checks", "Workspace", "workspace"),
-        ("arceos_checks", "ArceOS", "arceos"),
-        ("starry_checks", "Starry", "starry"),
-        ("axvisor_checks", "AxVisor", "axvisor"),
+        ("workspace_checks", "Workspace", "workspace", True),
+        ("arceos_checks", "ArceOS", "arceos", True),
+        ("starry_checks", "Starry", "starry", True),
+        ("axvisor_checks", "AxVisor", "axvisor", False),
     )
-    for job_id, display_name, output_prefix in grouped_jobs:
+    for job_id, display_name, output_prefix, fail_fast in grouped_jobs:
         job = mapping_block(jobs, job_id, 2)
         if not job:
             errors.append(f"missing grouped CI job: {job_id}")
@@ -363,7 +363,10 @@ def main() -> int:
                 f"needs.plan_ci.outputs.{output_prefix}_matrix",
                 "must consume its planner matrix",
             ),
-            ("fail_fast: true", "must keep fail-fast within the group"),
+            (
+                f"fail_fast: {str(fail_fast).lower()}",
+                "must keep the expected group fail-fast policy",
+            ),
             ("save_cache: >-", "must preserve cache-save routing"),
             (
                 "since_ref: ${{ needs.plan_ci.outputs.since_ref }}",

--- a/scripts/test/test_ci_routing.py
+++ b/scripts/test/test_ci_routing.py
@@ -63,6 +63,18 @@ class MatrixParallelismTests(unittest.TestCase):
             r"(?ms)^      max_parallel:\n.*?^        default: (?:[2-9]|[1-9][0-9]+)$",
         )
 
+    def test_axvisor_board_failure_does_not_cancel_qemu_matrix(self) -> None:
+        workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+        jobs = mapping_block(workflow, "jobs", 0)
+
+        axvisor = mapping_block(jobs, "axvisor_checks", 2)
+        self.assertIn("fail_fast: false", axvisor)
+
+        for job_name in ("workspace_checks", "arceos_checks", "starry_checks"):
+            with self.subTest(job_name=job_name):
+                job = mapping_block(jobs, job_name, 2)
+                self.assertIn("fail_fast: true", job)
+
 
 class ForkCleanupPermissionTests(unittest.TestCase):
     def test_main_cleanup_skips_fork_pull_requests(self) -> None:


### PR DESCRIPTION
## 背景

最新 `dev`（`7c5bbd13320bae42110f83e9418b4167e4dd7943`）中有几处与 PR #1775 无关、但可以独立修复的质量问题：AxVisor 板卡失败会取消仍有价值的 QEMU 证据，rsext4 host-test 的运行时依赖未声明，ax-fs-ng 测试 provider 的延迟 page 回收会污染后一个测试的计数，root 选择测试还需要构造不会真正提交 I/O 的伪造 block controller。

本 PR 只处理这些独立问题，不引入 PR #1775 的 `TaskAddressSpace`、`RuntimeSwitchPlan`、TLB gather 或用户态入口 API。

## 修改

1. AxVisor CI 矩阵将 `fail_fast` 设为 `false`，并把 CI 路由校验改为按工作组显式检查策略。物理板卡不可用时，不再取消独立的 AxVisor QEMU 任务；Workspace、ArceOS 和 Starry 仍保持组内快速失败。
2. 为 `rsext4` 增加 host-test 专用 `ax-runtime` dev-dependency，使现有 host 集成测试的运行时符号依赖由 Cargo 正确表达。
3. 为测试态 `FsPage` 增加 epoch ownership。provider reset 后，旧 epoch page 仍然正常释放，但不会计入新测试的 `dealloc_count`；新增确定性回归覆盖该交错。
4. 将 `selected_filesystem_kind` 改为只接收 filesystem 元数据和分区切片，root selection 测试直接使用 `RootCandidate`。移除 `TestQueue`、`TestController` 和 `raw_disk` 等仅为测试选择逻辑而存在的伪造 I/O 层。

## 设计边界

- 所有改动均位于现有 CI、filesystem host-test 或纯 root-selection 测试边界内。
- 不改变生产 `FsPage` 布局；epoch 字段只在 `cfg(test)` 下编译。
- 不改变 root selection 的运行时选择结果，只移除测试对 block runtime 的无关依赖。
- 不把 PR #1775 中依赖新地址空间/TLB ownership 的提交拆出；相关改动继续留在 PR #2208。

## 验证

- `cargo test -p ax-fs-ng`：89 个单元测试、3 个集成测试全部通过。
- `cargo test -p rsext4`：354 个单元测试及全部集成测试通过。
- `PYTHONPATH=. python3 scripts/test/test_ci_routing.py`：25/25 通过。
- `cargo xtask clippy --package ax-fs-ng`：6/6 通过。
- `cargo xtask clippy --package rsext4`：3/3 通过。
- `cargo fmt --all -- --check`、`git diff --check` 通过。

## 非目标

本 PR 不统一 ax-mm 与 Starry 的 TLB gather，不修改调度器或用户态切换，不改变设备驱动运行时协议，也不处理实体板卡可用性本身。
