### PR TITLE
fix(riscv-vcpu): restore host trap vector before interrupts

### DIFF
--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -79,6 +79,9 @@ cargo xtask cross-test --arch riscv64 \
 echo "==> axvisor riscv64 VSEIP unbound-state cross-test"
 cargo xtask cross-test --arch riscv64 --package riscv_vcpu --lib \
   controller_vseip_line_updates_saved_state_while_unbound
+echo "==> axvisor riscv64 host trap-state cross-test"
+cargo xtask cross-test --arch riscv64 --package riscv_vcpu --no-default-features --lib \
+  vm_exit_restores_host_stvec_before_host_sstatus
 echo "==> axvisor riscv64 backtrace panic"
 cargo xtask axvisor test qemu --arch riscv64 --test-case backtrace-panic
 echo "==> axvisor riscv64 no-backtrace panic"

--- a/virtualization/riscv_vcpu/src/trap.S
+++ b/virtualization/riscv_vcpu/src/trap.S
@@ -144,6 +144,14 @@ _guest_exit:
     RESTORE_HOST_ANCHORS
 
 _restore_csrs:
+    /*
+     * RiscvVcpu::run() keeps SIE clear while this world switch executes and
+     * enables it only after the assembly returns. Restore stvec first as a
+     * defensive ordering invariant; this sequence must not enable interrupts.
+     */
+    ld    t1, ({hyp_stvec})(a0)
+    csrw  stvec, t1
+
     /* Swap in hypervisor CSRs. */
     ld    t1, ({hyp_sstatus})(a0)
     csrrw t1, sstatus, t1
@@ -156,9 +164,6 @@ _restore_csrs:
     ld    t1, ({hyp_scounteren})(a0)
     csrrw t1, scounteren, t1
     sd    t1, ({guest_scounteren})(a0)
-
-    ld    t1, ({hyp_stvec})(a0)
-    csrw  stvec, t1
 
     /* Save guest EPC. */
     csrr  t1, sepc

--- a/virtualization/riscv_vcpu/src/world_switch_tests.rs
+++ b/virtualization/riscv_vcpu/src/world_switch_tests.rs
@@ -24,7 +24,7 @@ fn assert_in_order(source: &str, operations: &[&str]) {
 
 #[test]
 fn vm_exit_restores_host_anchors_before_returning_to_rust() {
-    let exit = section(TRAP_ASSEMBLY, "_guest_exit:", "ret");
+    let exit = section(TRAP_ASSEMBLY, "_guest_exit:", "\n    ret");
     assert_in_order(
         exit,
         &[
@@ -58,6 +58,35 @@ fn vm_exit_restores_host_anchors_before_returning_to_rust() {
             "missing typed offset {binding:?}"
         );
     }
+}
+
+#[test]
+fn vm_exit_restores_host_stvec_before_host_sstatus() {
+    // Keep the defensive restore order explicit; run() owns the interrupt
+    // enable and only re-enables SIE after this sequence returns.
+    let restore = section(TRAP_ASSEMBLY, "_restore_csrs:", "/* Save guest EPC. */");
+    assert_in_order(
+        restore,
+        &[
+            "ld    t1, ({hyp_stvec})(a0)",
+            "csrw  stvec, t1",
+            "ld    t1, ({hyp_sstatus})(a0)",
+            "csrrw t1, sstatus, t1",
+        ],
+    );
+}
+
+#[test]
+fn run_keeps_host_interrupts_disabled_across_world_switch() {
+    let run = section(VCPU, "pub fn run(", "self.vmexit_handler()");
+    assert_in_order(
+        run,
+        &[
+            "sstatus::clear_sie()",
+            "_run_guest(&mut self.regs)",
+            "sstatus::set_sie()",
+        ],
+    );
 }
 
 #[test]


### PR DESCRIPTION
 ## 背景

  RISC-V vCPU 从 Guest 返回 Host 时，原有汇编流程先恢复 `sstatus`，再恢复
  `stvec`。

  当 Host 的 `sstatus.SIE` 被重新开启后，如果此时发生中断，而 `stvec` 仍指向
  Guest 的 trap vector，中断可能错误地进入 Guest 异常入口，导致 Host trap 处理异
  常。

  ## 修改

  - 在恢复 Host `sstatus` 之前恢复 Host `stvec`。
  - 新增 world-switch 汇编顺序回归测试，确保 `stvec` 恢复严格早于 `sstatus` 恢
  复。
  - 将该回归测试接入 Axvisor RISC-V CI 测试矩阵。

  ## 验证结果

  - `cargo xtask cross-test --arch riscv64 --package riscv_vcpu --no-default-
  features --lib world_switch_tests`
    - 3/3 tests passed
  - `cargo fmt --all --check`
    - passed
  - `cargo xtask clippy --package riscv_vcpu`
    - base 和 `sstc` 配置均通过
  - `cargo xtask axvisor test qemu --arch riscv64 --test-case smp-ipi`
    - 1/1 case passed
    - Guest 成功启动 3 个 CPU
    - 检测到 SBI IPI 扩展
    - 输出 `guest smp ipi pass!`

  ## 影响范围

  本次修改只涉及 RISC-V vCPU 的 Guest exit CSR 恢复顺序及对应测试，不改变公共
  API、vPLIC 路由、SBI IPI 逻辑或现有 3 vCPU 配置。

