### PR TITLE
fix(sdmmc-protocol,aic8800): restore SG2002 WiFi board startup

### DIFF
--- a/drivers/blk/sdmmc-protocol/src/sdio/io/init.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/io/init.rs
@@ -110,37 +110,47 @@ impl<H: SdMmcIrqHost + 'static> SdioCard<H> {
     }
 
     /// Advance one completed controller or register step of initialization.
+    ///
+    /// Each newly submitted step is advanced once immediately with
+    /// [`ProgressCause::Submitted`]: register-only bus operations never
+    /// produce an interrupt, so waiting for one after submission would stall
+    /// until the caller's overall deadline. Only the first advance of a call
+    /// uses the caller-provided cause.
     pub fn advance_init_request(
         &mut self,
         request: &mut SdioInitRequest<H>,
-        cause: ProgressCause,
+        mut cause: ProgressCause,
     ) -> Result<OperationProgress<SdioCardInfo>, Error> {
-        match &mut request.active {
-            InitActive::None => return Err(Error::InvalidArgument),
-            InitActive::Command => match self.host.advance_command_response(cause)? {
-                CommandResponseProgress::Pending => return Ok(OperationProgress::Pending),
-                CommandResponseProgress::Complete(response) => {
-                    request.active = InitActive::None;
-                    self.consume_init_response(request, response)?;
+        loop {
+            match &mut request.active {
+                InitActive::None => return Err(Error::InvalidArgument),
+                InitActive::Command => match self.host.advance_command_response(cause)? {
+                    CommandResponseProgress::Pending => return Ok(OperationProgress::Pending),
+                    CommandResponseProgress::Complete(response) => {
+                        request.active = InitActive::None;
+                        self.consume_init_response(request, response)?;
+                    }
+                },
+                InitActive::Bus(bus_request) => {
+                    match self.host.advance_bus_op(bus_request, cause)? {
+                        OperationProgress::Pending => return Ok(OperationProgress::Pending),
+                        OperationProgress::Complete(()) => {
+                            request.active = InitActive::None;
+                            request.advance_after_bus()?;
+                        }
+                    }
                 }
-            },
-            InitActive::Bus(bus_request) => match self.host.advance_bus_op(bus_request, cause)? {
-                OperationProgress::Pending => return Ok(OperationProgress::Pending),
-                OperationProgress::Complete(()) => {
-                    request.active = InitActive::None;
-                    request.advance_after_bus()?;
-                }
-            },
-        }
+            }
 
-        if request.state == InitState::Complete {
-            let info = request.card_info()?;
-            self.info = Some(info);
-            self.functions = request.functions;
-            return Ok(OperationProgress::Complete(info));
+            if request.state == InitState::Complete {
+                let info = request.card_info()?;
+                self.info = Some(info);
+                self.functions = request.functions;
+                return Ok(OperationProgress::Complete(info));
+            }
+            self.submit_init_state(request)?;
+            cause = ProgressCause::Submitted;
         }
-        self.submit_init_state(request)?;
-        Ok(OperationProgress::Pending)
     }
 
     /// Abort an in-flight initialization request and return host ownership to

--- a/drivers/blk/sdmmc-protocol/src/sdio/tests/io_card.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/tests/io_card.rs
@@ -112,6 +112,43 @@ fn io_only_init_enumerates_cccr_fbr_and_cis_without_host_protocol_duplication() 
 }
 
 #[test]
+fn init_advance_keeps_driving_register_only_steps_within_one_call() {
+    // Register-only bus operations never produce an interrupt, so a single
+    // advance must drive them synchronously (with Submitted) until the first
+    // command step, which legitimately waits for its completion interrupt.
+    // A regression to "submit the next step and return Pending" stalls the
+    // caller until the startup deadline, so the first command must already
+    // be in flight after one advance.
+    let mut card = SdioCard::new(MockHost::new(std::vec![r4(SDIO_READY)]));
+    let mut request = card.submit_init().unwrap();
+    let progress = card
+        .advance_init_request(&mut request, sdmmc_host::ProgressCause::RegisterRetry)
+        .unwrap();
+    assert!(matches!(progress, OperationProgress::Pending));
+    assert!(
+        card.host()
+            .commands
+            .iter()
+            .any(|command| command.index == 5),
+        "register-only steps must be driven synchronously up to the first command"
+    );
+    // The caller's cause advances only the first step; every freshly
+    // submitted register-only step is driven with Submitted afterwards.
+    let causes = &card.host().bus_advance_causes;
+    assert_eq!(
+        causes.first(),
+        Some(&sdmmc_host::ProgressCause::RegisterRetry)
+    );
+    assert!(
+        causes
+            .iter()
+            .skip(1)
+            .all(|cause| *cause == sdmmc_host::ProgressCause::Submitted),
+        "freshly submitted steps must advance with Submitted, got {causes:?}"
+    );
+}
+
+#[test]
 fn stale_direct_request_cannot_advance_a_later_command() {
     let mut card = SdioCard::new(MockHost::new(std::vec![r5(0x11), r5(0x22)]));
     let address = IoAddress::new(0x10).unwrap();

--- a/drivers/blk/sdmmc-protocol/src/sdio/tests/mod.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/tests/mod.rs
@@ -71,6 +71,9 @@ struct MockHost {
     pending_polls: usize,
     complete_after_irq_register_retry: bool,
     completion_irq_enabled: bool,
+    /// Records every cause passed to `advance_bus_op` so tests can pin the
+    /// "register-only steps advance with Submitted" contract.
+    bus_advance_causes: Vec<sdmmc_host::ProgressCause>,
     /// Optional monotonic clock value returned from
     /// [`sdmmc_host::SdMmcHost::now_ms`]. Tests advance this directly to verify the
     /// wall-clock timeout path; `None` keeps the legacy poll-counter
@@ -113,6 +116,7 @@ impl MockHost {
             pending_polls: 0,
             complete_after_irq_register_retry: false,
             completion_irq_enabled: false,
+            bus_advance_causes: Vec::new(),
             now_ms: None,
         }
     }
@@ -140,6 +144,7 @@ impl MockHost {
             pending_polls: 0,
             complete_after_irq_register_retry: false,
             completion_irq_enabled: false,
+            bus_advance_causes: Vec::new(),
             now_ms: None,
         }
     }
@@ -349,8 +354,9 @@ impl sdmmc_host::SdMmcHost for MockHost {
     fn advance_bus_op(
         &mut self,
         request: &mut Self::BusRequest,
-        _cause: sdmmc_host::ProgressCause,
+        cause: sdmmc_host::ProgressCause,
     ) -> Result<sdmmc_host::RequestProgress<()>, sdmmc_host::AdvanceRequestError> {
+        self.bus_advance_causes.push(cause);
         if request.done {
             return Err(sdmmc_host::AdvanceRequestError::AlreadyCompleted);
         }

--- a/drivers/net/aic8800/src/device/mailbox.rs
+++ b/drivers/net/aic8800/src/device/mailbox.rs
@@ -194,3 +194,145 @@ impl AicDevice {
         });
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+    use crate::{
+        AicInputEvent, ChipVariant, SdioCompletion, SdioRequestKind, SdioResponse,
+        device::startup::StartupStage, protocol::TASK_MM,
+    };
+
+    const NANOS_PER_MILLISECOND: u64 = 1_000_000;
+
+    fn time(ms: u64) -> MonotonicTime {
+        MonotonicTime::from_nanos(ms * NANOS_PER_MILLISECOND)
+    }
+
+    fn completion(request_id: u64, response: SdioResponse, now: MonotonicTime) -> AicInput {
+        AicInput {
+            now,
+            event: Some(AicInputEvent::Sdio(SdioCompletion {
+                request_id,
+                result: Ok(response),
+            })),
+        }
+    }
+
+    /// Drives one mailbox through flow control, the frame write, the settle
+    /// retry and the count poll, and returns the pending read request.
+    fn pending_read(device: &mut AicDevice, first: SdioRequest) -> SdioRequest {
+        let action = device.advance(completion(first.id, SdioResponse::Byte(0x7f), time(2)));
+        let AicAction::SubmitSdio(write) = action else {
+            panic!("expected mailbox frame write")
+        };
+        let action = device.advance(completion(write.id, SdioResponse::Unit, time(3)));
+        assert!(matches!(action, AicAction::RetryAt(_)));
+        let action = device.advance(AicInput::tick(time(5)));
+        let AicAction::SubmitSdio(count) = action else {
+            panic!("expected mailbox count poll")
+        };
+        let action = device.advance(completion(count.id, SdioResponse::Byte(1), time(6)));
+        let AicAction::SubmitSdio(read) = action else {
+            panic!("expected mailbox response read")
+        };
+        read
+    }
+
+    fn confirmation_frame(message_id: u16, payload: &[u8]) -> alloc::vec::Vec<u8> {
+        let mut frame = vec![0u8; BLOCK_SIZE];
+        frame[4..6].copy_from_slice(&message_id.to_le_bytes());
+        frame[10..12].copy_from_slice(&(payload.len() as u16).to_le_bytes());
+        frame[16..16 + payload.len()].copy_from_slice(payload);
+        frame
+    }
+
+    #[test]
+    fn read_revision_takes_the_version_from_the_high_half_of_the_read_back() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).expect("D80 is supported");
+        device.start(time(0)).expect("stopped device starts");
+        device.lifecycle.startup.as_mut().unwrap().stage = StartupStage::ReadRevision;
+        device.begin_debug_mailbox(0x0400, &[0; 4], time(0));
+        let AicAction::SubmitSdio(first) = device.advance(AicInput::tick(time(0))) else {
+            panic!("mailbox must produce a first SDIO request");
+        };
+        let read = pending_read(&mut device, first);
+
+        // The chip reports its revision in the high half of the read-back
+        // word (the low half is unrelated value noise, as seen on the board).
+        let mut payload = [0u8; 8];
+        payload[4..8].copy_from_slice(&0x0001_0020u32.to_le_bytes()); // rev U01, noise 0x20
+        let action = device.advance(completion(
+            read.id,
+            SdioResponse::Data(confirmation_frame(0x0401, &payload)),
+            time(7),
+        ));
+        let AicAction::SubmitSdio(upload) = action else {
+            panic!("revision U01 must be accepted, got {action:?}")
+        };
+        assert_eq!(
+            device.lifecycle.startup.as_ref().unwrap().stage,
+            StartupStage::UploadMain(0)
+        );
+        assert!(matches!(
+            upload.kind,
+            SdioRequestKind::ReadByte { address, .. } if address.get() == 3 // flow control
+        ));
+        assert_ne!(device.state(), AicState::Failed);
+    }
+
+    #[test]
+    fn get_mac_address_confirmation_installs_the_mac_and_arms_the_chip_interrupt() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).expect("D80 is supported");
+        device.start(time(0)).expect("stopped device starts");
+        device.lifecycle.startup.as_mut().unwrap().stage = StartupStage::GetMacAddress;
+        device.begin_lmac_mailbox(0x0073, TASK_MM, &1u32.to_le_bytes(), 0x0074, time(0));
+        let AicAction::SubmitSdio(first) = device.advance(AicInput::tick(time(0))) else {
+            panic!("mailbox must produce a first SDIO request");
+        };
+        let read = pending_read(&mut device, first);
+
+        let mac = [0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+        let action = device.advance(completion(
+            read.id,
+            SdioResponse::Data(confirmation_frame(0x0074, &mac)),
+            time(7),
+        ));
+        assert_eq!(device.mac_address(), mac);
+        assert_eq!(
+            device.lifecycle.startup.as_ref().unwrap().stage,
+            StartupStage::ArmChipInterrupt
+        );
+        let AicAction::SubmitSdio(arm) = action else {
+            panic!("startup must continue with the interrupt-enable write, got {action:?}")
+        };
+        assert!(matches!(arm.kind, SdioRequestKind::WriteByte { .. }));
+        assert_ne!(device.state(), AicState::Failed);
+    }
+
+    #[test]
+    fn get_mac_address_confirmation_shorter_than_the_address_fails_the_device() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).expect("D80 is supported");
+        device.start(time(0)).expect("stopped device starts");
+        device.lifecycle.startup.as_mut().unwrap().stage = StartupStage::GetMacAddress;
+        device.begin_lmac_mailbox(0x0073, TASK_MM, &1u32.to_le_bytes(), 0x0074, time(0));
+        let AicAction::SubmitSdio(first) = device.advance(AicInput::tick(time(0))) else {
+            panic!("mailbox must produce a first SDIO request");
+        };
+        let read = pending_read(&mut device, first);
+
+        assert!(
+            matches!(
+                device.advance(completion(
+                    read.id,
+                    SdioResponse::Data(confirmation_frame(0x0074, &[0x02, 0x03, 0x04, 0x05, 0x06])),
+                    time(7),
+                )),
+                AicAction::Event(AicEvent::Failed(AicError::MalformedResponse))
+            ),
+            "a truncated get-mac confirmation must fail the device"
+        );
+    }
+}

--- a/drivers/net/aic8800/src/device/model.rs
+++ b/drivers/net/aic8800/src/device/model.rs
@@ -226,7 +226,7 @@ pub enum AicError {
     CompletionMismatch,
     #[error("AIC mailbox timed out")]
     MailboxTimeout,
-    #[error("AIC mailbox response was malformed")]
+    #[error("AIC SDIO completion did not match the expected response shape")]
     MalformedResponse,
     #[error("unsupported chip revision {0}")]
     UnsupportedRevision(u8),

--- a/drivers/net/aic8800/src/device/progress.rs
+++ b/drivers/net/aic8800/src/device/progress.rs
@@ -158,7 +158,7 @@ impl AicDevice {
             IoPurpose::TransmitFlow => self.consume_transmit_flow(response, now),
             IoPurpose::TransmitData => self.consume_transmit_data(response),
             IoPurpose::Shutdown => {
-                expect_unit(response)?;
+                expect_write_ack(response)?;
                 self.lifecycle.state = AicState::Stopped;
                 self.data.events.push_back(AicEvent::Stopped);
                 Ok(())
@@ -237,7 +237,10 @@ mod tests {
     use alloc::vec;
 
     use super::*;
-    use crate::common::{ChipVariant, SDIOWIFI_FUNC_BLOCKSIZE};
+    use crate::{
+        common::{ChipVariant, SDIOWIFI_FUNC_BLOCKSIZE},
+        device::startup::StartupStage,
+    };
 
     fn time(ms: u64) -> MonotonicTime {
         MonotonicTime::from_nanos(ms * NANOS_PER_MILLISECOND)
@@ -274,6 +277,141 @@ mod tests {
             SdioRequestKind::SetBlockSize { block_size, .. }
                 if block_size.get() == SDIOWIFI_FUNC_BLOCKSIZE
         ));
+    }
+
+    /// Drives a D80 through the unit-completed stages up to the first
+    /// vendor write so stage-injected tests share the same setup.
+    fn first_vendor_write(device: &mut AicDevice) -> SdioRequest {
+        device.start(time(0)).unwrap();
+        let AicAction::SubmitSdio(enable) = device.advance(AicInput::tick(time(0))) else {
+            panic!("expected function enable")
+        };
+        let AicAction::SubmitSdio(block_size) =
+            device.advance(complete(&enable, SdioResponse::Unit, time(0)))
+        else {
+            panic!("expected block-size configuration")
+        };
+        let AicAction::SubmitSdio(interrupt) =
+            device.advance(complete(&block_size, SdioResponse::Unit, time(0)))
+        else {
+            panic!("expected interrupt enable")
+        };
+        let AicAction::SubmitSdio(vendor) =
+            device.advance(complete(&interrupt, SdioResponse::Unit, time(0)))
+        else {
+            panic!("expected vendor setup")
+        };
+        vendor
+    }
+
+    // The adapter completes every Direct operation (read or write) with the
+    // R5 data byte, so the core's write consumers must accept a Byte
+    // completion instead of rejecting it as malformed.
+
+    #[test]
+    fn vendor_setup_accepts_the_write_read_back_byte() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        let vendor = first_vendor_write(&mut device);
+        assert!(matches!(vendor.kind, SdioRequestKind::WriteByte { .. }));
+        let action = device.advance(complete(&vendor, SdioResponse::Byte(0x7f), time(0)));
+        let AicAction::SubmitSdio(next) = action else {
+            panic!("vendor write must consume the read-back byte, got {action:?}")
+        };
+        assert!(matches!(next.kind, SdioRequestKind::WriteByte { .. }));
+        assert_ne!(device.state(), AicState::Failed);
+
+        // The rejection side of the same contract: a Unit completion is not
+        // the adapter shape for a Direct write.
+        let mut rejected = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        let vendor = first_vendor_write(&mut rejected);
+        let action = rejected.advance(complete(&vendor, SdioResponse::Unit, time(0)));
+        assert!(matches!(action, AicAction::Event(AicEvent::Failed(_))));
+    }
+
+    #[test]
+    fn reinitialize_accepts_the_write_read_back_byte() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        device.start(time(0)).unwrap();
+        device.lifecycle.startup.as_mut().unwrap().stage = StartupStage::Reinitialize(0);
+        let AicAction::SubmitSdio(request) = device.advance(AicInput::tick(time(0))) else {
+            panic!("expected reinitialize write")
+        };
+        assert!(matches!(request.kind, SdioRequestKind::WriteByte { .. }));
+        let action = device.advance(complete(&request, SdioResponse::Byte(0), time(0)));
+        let AicAction::SubmitSdio(next) = action else {
+            panic!("reinitialize must consume the read-back byte, got {action:?}")
+        };
+        assert!(matches!(next.kind, SdioRequestKind::WriteByte { .. }));
+        assert_ne!(device.state(), AicState::Failed);
+
+        let mut rejected = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        rejected.start(time(0)).unwrap();
+        rejected.lifecycle.startup.as_mut().unwrap().stage = StartupStage::Reinitialize(0);
+        let AicAction::SubmitSdio(request) = rejected.advance(AicInput::tick(time(0))) else {
+            panic!("expected reinitialize write")
+        };
+        let action = rejected.advance(complete(&request, SdioResponse::Unit, time(0)));
+        assert!(matches!(action, AicAction::Event(AicEvent::Failed(_))));
+    }
+
+    #[test]
+    fn arm_chip_interrupt_accepts_the_write_read_back_byte() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        device.start(time(0)).unwrap();
+        device.lifecycle.startup.as_mut().unwrap().stage = StartupStage::ArmChipInterrupt;
+        let AicAction::SubmitSdio(request) = device.advance(AicInput::tick(time(0))) else {
+            panic!("expected interrupt-enable write")
+        };
+        assert!(matches!(request.kind, SdioRequestKind::WriteByte { .. }));
+        let action = device.advance(complete(&request, SdioResponse::Byte(0), time(0)));
+        assert!(
+            matches!(action, AicAction::Event(AicEvent::Started { .. })),
+            "interrupt-enable write must finish startup, got {action:?}"
+        );
+        assert_eq!(device.state(), AicState::Ready);
+
+        let mut rejected = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        rejected.start(time(0)).unwrap();
+        rejected.lifecycle.startup.as_mut().unwrap().stage = StartupStage::ArmChipInterrupt;
+        let AicAction::SubmitSdio(request) = rejected.advance(AicInput::tick(time(0))) else {
+            panic!("expected interrupt-enable write")
+        };
+        let action = rejected.advance(complete(&request, SdioResponse::Unit, time(0)));
+        assert!(matches!(action, AicAction::Event(AicEvent::Failed(_))));
+    }
+
+    #[test]
+    fn shutdown_accepts_the_write_read_back_byte() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        device.start(time(0)).unwrap();
+        // Drive the stop through the control path instead of forcing the
+        // state, so the ControlRequest::Shutdown branch is exercised too.
+        let action = device.advance(AicInput {
+            now: time(0),
+            event: Some(AicInputEvent::Control(ControlRequest::Shutdown)),
+        });
+        let AicAction::SubmitSdio(request) = action else {
+            panic!("expected shutdown write")
+        };
+        assert!(matches!(request.kind, SdioRequestKind::WriteByte { .. }));
+        let action = device.advance(complete(&request, SdioResponse::Byte(0), time(0)));
+        assert!(
+            matches!(action, AicAction::Event(AicEvent::Stopped)),
+            "shutdown write must complete the stop, got {action:?}"
+        );
+        assert_eq!(device.state(), AicState::Stopped);
+
+        let mut rejected = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        rejected.start(time(0)).unwrap();
+        let action = rejected.advance(AicInput {
+            now: time(0),
+            event: Some(AicInputEvent::Control(ControlRequest::Shutdown)),
+        });
+        let AicAction::SubmitSdio(request) = action else {
+            panic!("expected shutdown write")
+        };
+        let action = rejected.advance(complete(&request, SdioResponse::Unit, time(0)));
+        assert!(matches!(action, AicAction::Event(AicEvent::Failed(_))));
     }
 
     #[test]

--- a/drivers/net/aic8800/src/device/request.rs
+++ b/drivers/net/aic8800/src/device/request.rs
@@ -6,6 +6,19 @@ use sdmmc_protocol::sdio::io::{AddressMode, FunctionNumber, IoAddress, TransferM
 use super::{AicError, SdioRequestKind, SdioResponse};
 use crate::protocol::BLOCK_SIZE;
 
+// Completion-shape contract: the adapter guarantees one shape per request
+// kind, and the core consumes exactly that shape via the `expect_*` helpers.
+//
+// | Request kind            | Completion shape | Note                      |
+// |-------------------------|------------------|---------------------------|
+// | EnableFunction          | Unit             |                           |
+// | SetBlockSize            | Unit             |                           |
+// | EnableFunctionInterrupt | Unit             |                           |
+// | ReadByte                | Byte             | register read-back        |
+// | WriteByte               | Byte             | R5 read-back byte (RAW=1) |
+// | Read (DMA)              | Data             |                           |
+// | Write (DMA)             | Unit             |                           |
+// | SetClockHz              | Unit             | bus op completion         |
 pub(super) fn expect_unit(response: SdioResponse) -> Result<(), AicError> {
     match response {
         SdioResponse::Unit => Ok(()),
@@ -27,6 +40,12 @@ pub(super) fn expect_data(response: SdioResponse) -> Result<Vec<u8>, AicError> {
     }
 }
 
+/// A `WriteByte` completion carries the R5 read-back byte; write-only
+/// consumers discard the value here.
+pub(super) fn expect_write_ack(response: SdioResponse) -> Result<(), AicError> {
+    expect_byte(response).map(|_| ())
+}
+
 pub(super) fn read_byte(function_number: u8, register: u32) -> SdioRequestKind {
     SdioRequestKind::ReadByte {
         function: function(function_number),
@@ -34,6 +53,8 @@ pub(super) fn read_byte(function_number: u8, register: u32) -> SdioRequestKind {
     }
 }
 
+// `read_after_write` sets the CMD52 RAW bit so the R5 data byte carries the
+// post-write read-back (see `expect_write_ack`).
 pub(super) fn write_byte(function_number: u8, register: u32, value: u8) -> SdioRequestKind {
     SdioRequestKind::WriteByte {
         function: function(function_number),

--- a/drivers/net/aic8800/src/device/startup/firmware.rs
+++ b/drivers/net/aic8800/src/device/startup/firmware.rs
@@ -2,7 +2,9 @@ use alloc::vec::Vec;
 
 use super::{START_STABILIZE, StartupStage};
 use crate::{
-    common::{CHIP_REV_MASK, ChipVariant},
+    common::{
+        CHIP_REV_HIGH_SHIFT, CHIP_REV_MASK, CHIP_REV_U01, CHIP_REV_U02, CHIP_REV_U03, ChipVariant,
+    },
     device::*,
     firmware::{
         CONFIG_BASE_OFFSET, MAIN_ADDRESS, MASKED_SYSTEM_CONFIG, PATCH_ADDRESS,
@@ -116,8 +118,10 @@ impl AicDevice {
                     return Err(AicError::MalformedResponse);
                 }
                 let raw = u32::from_le_bytes([result[4], result[5], result[6], result[7]]);
-                let revision = (raw & CHIP_REV_MASK) as u8;
-                if !matches!(revision, 1 | 3 | 7) {
+                // The chip stores the revision in the high half of the word;
+                // the low half carries unrelated value noise.
+                let revision = ((raw >> CHIP_REV_HIGH_SHIFT) & CHIP_REV_MASK) as u8;
+                if !matches!(revision, CHIP_REV_U01 | CHIP_REV_U02 | CHIP_REV_U03) {
                     return Err(AicError::UnsupportedRevision(revision));
                 }
                 startup.revision = Some(revision);
@@ -157,7 +161,15 @@ impl AicDevice {
                     StartupStage::Stabilize
                 }
             }
-            StartupStage::StackStart => StartupStage::ArmChipInterrupt,
+            StartupStage::StackStart => StartupStage::GetMacAddress,
+            StartupStage::GetMacAddress => {
+                // The confirmation payload starts with the six-byte MAC.
+                if result.len() < 6 {
+                    return Err(AicError::MalformedResponse);
+                }
+                self.data.mac_address.copy_from_slice(&result[..6]);
+                StartupStage::ArmChipInterrupt
+            }
             _ => return Err(AicError::CompletionMismatch),
         };
         Ok(())

--- a/drivers/net/aic8800/src/device/startup/mod.rs
+++ b/drivers/net/aic8800/src/device/startup/mod.rs
@@ -5,8 +5,8 @@ use crate::{
     common::{CHIP_REV_ADDR, SDIOWIFI_FUNC_BLOCKSIZE},
     firmware::MAIN_ADDRESS,
     protocol::{
-        DBG_MEM_READ_REQ, DBG_START_APP_REQ, MM_SET_STACK_START_REQ, TASK_MM, memory_read_payload,
-        start_app_payload,
+        DBG_MEM_READ_REQ, DBG_START_APP_REQ, MM_GET_MAC_ADDR_REQ, MM_SET_STACK_START_REQ, TASK_MM,
+        memory_read_payload, start_app_payload,
     },
     registers::{INTERRUPTS_ENABLED, interface_ready},
 };
@@ -39,6 +39,7 @@ pub(super) enum StartupStage {
     Stabilize,
     Reinitialize(u8),
     StackStart,
+    GetMacAddress,
     ArmChipInterrupt,
     Complete,
 }
@@ -169,6 +170,18 @@ impl AicDevice {
                 );
                 self.drive_mailbox(now)
             }
+            StartupStage::GetMacAddress => {
+                // The firmware owns the module MAC; read it once here so the
+                // Started event and later LMAC commands carry the real address.
+                self.begin_lmac_mailbox(
+                    MM_GET_MAC_ADDR_REQ,
+                    TASK_MM,
+                    &1u32.to_le_bytes(),
+                    MM_GET_MAC_ADDR_REQ + 1,
+                    now,
+                );
+                self.drive_mailbox(now)
+            }
             StartupStage::ArmChipInterrupt => self.emit(
                 IoPurpose::Startup,
                 write_byte(1, self.registers.interrupt_enable, INTERRUPTS_ENABLED),
@@ -209,7 +222,7 @@ impl AicDevice {
                 self.set_startup_stage(StartupStage::VendorSetup(0));
             }
             StartupStage::VendorSetup(index) => {
-                expect_unit(response)?;
+                expect_write_ack(response)?;
                 self.set_startup_stage(StartupStage::VendorSetup(index + 1));
             }
             StartupStage::VendorReady => {
@@ -229,11 +242,11 @@ impl AicDevice {
                 self.lifecycle.retry_at = Some(now.after(START_STABILIZE));
             }
             StartupStage::Reinitialize(index) => {
-                expect_unit(response)?;
+                expect_write_ack(response)?;
                 self.set_startup_stage(StartupStage::Reinitialize(index + 1));
             }
             StartupStage::ArmChipInterrupt => {
-                expect_unit(response)?;
+                expect_write_ack(response)?;
                 self.set_startup_stage(StartupStage::Complete);
             }
             _ => return Err(AicError::CompletionMismatch),

--- a/drivers/net/aic8800/src/protocol.rs
+++ b/drivers/net/aic8800/src/protocol.rs
@@ -11,6 +11,7 @@ pub(crate) const DBG_MEM_BLOCK_WRITE_REQ: u16 = 0x040b;
 pub(crate) const DBG_START_APP_REQ: u16 = 0x040d;
 pub(crate) const DBG_MEM_MASK_WRITE_REQ: u16 = 0x0411;
 pub(crate) const MM_SET_STACK_START_REQ: u16 = 0x007b;
+pub(crate) const MM_GET_MAC_ADDR_REQ: u16 = 0x0073;
 pub(crate) const TASK_MM: u16 = 0;
 
 const SDIO_HEADER_SIZE: usize = 4;

--- a/drivers/net/aic8800/src/rdif/owner/output.rs
+++ b/drivers/net/aic8800/src/rdif/owner/output.rs
@@ -20,7 +20,6 @@ pub(super) struct OwnerOutputs {
     pending_rx_frame: Option<Vec<u8>>,
     pending_rx_completion: Option<RxCompletion>,
     pending_wifi_progress: Option<Result<WifiControlProgress, AicError>>,
-    terminal_error: Option<AicError>,
     next_tx_token: u64,
     wifi_active: bool,
 }
@@ -35,7 +34,6 @@ impl OwnerOutputs {
             pending_rx_frame: None,
             pending_rx_completion: None,
             pending_wifi_progress: None,
-            terminal_error: None,
             next_tx_token: 1,
             wifi_active: false,
         }
@@ -69,14 +67,8 @@ impl OwnerOutputs {
             AicEvent::Receive(frame) => !self.publish_rx(frame)?,
             AicEvent::TransmitComplete(token) => !self.publish_tx_completion(token)?,
             AicEvent::Failed(error) => {
-                let blocked = self.wifi_active && !self.publish_wifi_progress(Err(error.clone()));
                 self.wifi_active = false;
-                if blocked {
-                    self.terminal_error = Some(error);
-                    true
-                } else {
-                    return Err(error.into());
-                }
+                return Err(error.into());
             }
         };
         Ok(blocked)
@@ -107,9 +99,6 @@ impl OwnerOutputs {
         }
         if self.has_pending() {
             return Ok(false);
-        }
-        if let Some(error) = self.terminal_error.take() {
-            return Err(error.into());
         }
         Ok(true)
     }

--- a/net/ax-net/src/queue_runtime/executor/mod.rs
+++ b/net/ax-net/src/queue_runtime/executor/mod.rs
@@ -425,6 +425,7 @@ pub(super) struct ExecutorControl {
     pub(super) command: AtomicU8,
     pub(super) affinity_status: AtomicU8,
     pub(super) startup_status: AtomicU8,
+    pub(super) startup_error: SpinLock<Option<NetError>>,
     pub(super) notify: Arc<ax_task::IrqNotify>,
 }
 
@@ -485,7 +486,17 @@ pub(super) fn queue_executor_main(
         return;
     }
 
-    let initialized = groups.iter_mut().all(|group| group.initialize().is_ok());
+    let mut initialized = true;
+    for group in &mut groups {
+        if let Err(error) = group.initialize() {
+            // Recorded for the runtime builder: the panic that follows a
+            // failed startup (axruntime devices.rs:97) reports this error
+            // instead of a generic initialization failure.
+            *control.startup_error.lock_irqsave() = Some(error);
+            initialized = false;
+            break;
+        }
+    }
     control.startup_status.store(
         if initialized {
             STATUS_READY

--- a/net/ax-net/src/queue_runtime/mod.rs
+++ b/net/ax-net/src/queue_runtime/mod.rs
@@ -163,8 +163,8 @@ pub enum NetworkRuntimeError {
     InvalidTopology,
     #[error("network queue executor could not be pinned to CPU {0}")]
     WorkerAffinity(usize),
-    #[error("network queue initialization failed")]
-    QueueInit,
+    #[error("network queue initialization failed: {0}")]
+    QueueInit(NetError),
     #[error("network IRQ registration failed: {0}")]
     IrqRegistration(#[from] PinnedNetIrqError),
     #[error("network DMA setup failed: {0}")]
@@ -471,6 +471,7 @@ impl<'a> NetworkRuntimeBuilder<'a> {
                 command: AtomicU8::new(COMMAND_WAIT),
                 affinity_status: AtomicU8::new(STATUS_PENDING),
                 startup_status: AtomicU8::new(STATUS_PENDING),
+                startup_error: SpinLock::new(None),
                 notify: Arc::clone(&cpu_notifies[owner_cpu]),
             });
             let task_control = Arc::clone(&control);
@@ -602,7 +603,15 @@ impl<'a> NetworkRuntimeBuilder<'a> {
                     ),
                     irq_synchronized,
                 );
-                return Err(NetworkRuntimeError::QueueInit);
+                // STATUS_FAILED is only written by `initialize` after
+                // recording the error, so the cause is always present here.
+                let error = executor
+                    .control
+                    .startup_error
+                    .lock_irqsave()
+                    .take()
+                    .expect("failed startup always records its cause");
+                return Err(NetworkRuntimeError::QueueInit(error));
             }
         }
         let protocol_owner_cpu = select_protocol_owner(&group_owners, self.online_cpus);


### PR DESCRIPTION
## 背景

SG2002 (LicheeRV Nano) 板载 Aic8800D80 WiFi（SDIO1）。主线 SDIO 协议统一重构（#2201）将 sdmmc-protocol 与 aic8800 驱动重组为"被动状态机核心 + rdif 能力适配层"的新结构。重构后的驱动在板上初始化失败，问题按板测顺序逐层暴露：初始化超时 → 启动失败原因不可见 → 写寄存器响应形状失配 → 芯片版本解析错误 → 设备 MAC 缺失。本 PR 修复这条启动链上的全部缺陷，使 SG2002 WiFi 驱动恢复到开机可用状态。

## 平台

SG2002 荔枝派，aic8800d80

## 要解决的问题与修复

### 1. SDIO 初始化纯寄存器步骤死锁（sdmmc-protocol）

`advance_init_request` 提交下一个步骤后返回 Pending，协议层按"等待完成中断"处理。但纯寄存器总线操作（CMD52、总线宽度/时钟设置）从不产生中断，初始化在首个命令步骤之前死等到 60s 启动超时。板测表现为 67s panic。

修复：每次新提交的步骤立即以 `ProgressCause::Submitted` 推进一次，直到进入首个命令步骤（CMD5）才等待完成中断；只有单次调用的首次推进使用调用方提供的中断原因。

回归测试 `init_advance_keeps_driving_register_only_steps_within_one_call` 断言单次推进后 CMD5 已提交、后续步骤均以 Submitted 驱动（MockHost 记录每次总线推进的原因）。

### 2. 启动失败原因不透传（ax-net）

网络队列启动失败时 `QueueInit` 不携带错误原因，panic 文本为泛化的 "network queue initialization failed"，板上无法定位根因。

修复：`QueueInit(NetError)` 携带真实失败原因——executor 在初始化失败时记录 `startup_error`，runtime builder 取回后随 panic 报告。后续每一轮板测定位（响应形状失配、版本解析错误）都依赖这条错误链。

### 3. 写寄存器响应形状契约（aic8800）

rdif 适配层将每个 Direct 操作（含写）的完成统一映射为 `Byte`——CMD52 的 R5 响应恒携带数据字节，且驱动以 `read_after_write` 提交。核心侧四个写寄存器消费点仍以 `expect_unit` 期待 `Unit`，确定性触发 `MalformedResponse` panic。失配点共 4 处：`VendorSetup`、`Reinitialize`、`ArmChipInterrupt`（启动序列）与 `Shutdown`（停机序列）。

修复：新增 `expect_write_ack`（接受 `Byte`、丢弃读回值），4 个消费点统一改用；`request.rs` 固化"请求类型 → 完成形状"契约表；`MalformedResponse` 的显示文案改为形状中立措辞（原文案提及 mailbox，会把排查引向错误方向）。

4 条阶段注入回归测试覆盖全部失配点（接受侧断言推进、拒绝侧喂 `Unit` 断言失败）。

### 4. ReadRevision 版本号取低半（aic8800）

ReadRevision 读回字的版本号位于高半（`CHIP_REV_HIGH_SHIFT` 位移之后），低半是无关值噪声。新代码直接取低 6 位，板上得到 0x20（32）并 panic "unsupported chip revision"。

修复：按 `(raw >> CHIP_REV_HIGH_SHIFT) & CHIP_REV_MASK` 解析，校验改用 `CHIP_REV_U01/U02/U03` 常量。回归测试以板上实际噪声值（0x0001_0020）钉住解析行为。

### 5. 启动期从固件读取设备 MAC（aic8800）

设备 MAC 从未被获取，`Started` 事件与后续 LMAC 命令携带全零地址（板上 `eth0` 显示 00-00-00-00-00-00）。

修复：启动序列新增 `GetMacAddress` 阶段（StackStart 之后、中断部署之前），发送 `MM_GET_MAC_ADDR_REQ`（0x0073）并从确认帧载荷前 6 字节安装 MAC；载荷不足 6 字节时按 MalformedResponse 失败。板测确认 MAC 正确读回并随 `Started` 事件发布。

### 6. 设备失败事件可靠传播（aic8800）

设备进入 Failed 后，失败事件经 progress 队列发布，队列背压时事件丢失，控制请求调用方要等 30s 兜底超时（`DEFAULT_CONTROL_TIMEOUT`）才收到错误。

修复：失败事件直接向上返回错误，不再经过 progress 队列。板测确认失败在邮箱超时后立即返回。

## 验证

- 单元与集成测试：aic8800 28 单测 + 2 集成、sdmmc-protocol 121，全部通过
- 静态检查：`cargo xtask clippy`（aic8800 / sdmmc-protocol / ax-net）、`cargo fmt --all --check` 干净
- 板测（LicheeRV Nano）：WiFi feature SG2002 开机推进到 CLI，启动链完整走通；`ip addr` 显示设备真实 MAC（38-7a-cc-9b-2c-c8）

## 范围说明

本 PR 只包含初始化启动链修复，目前 aic8800d80 可以开机不 panic。板测过程中定位到但超出本 PR 范围的问题（运行期 AP/STA 切换时固件对首条 LMAC 命令无应答）未包含在内：串口登录后仍无法开启 WiFi ap/sta，ioctl 失败且立即出现串口逐字符显示的 CPU 卡顿现象，因此未测试 WiFi 工作是否正常；不能确定该现象是否是本 pr 改动导致的新问题，因为主线 starry 在开机的 WiFi 初始化阶段即 panic，没有成功先例作为对照。