### PR TITLE
fix(rsext4): avoid EL1 CRC probing in macOS tests

### DIFF
--- a/fs/rsext4/src/crc32c/arm64.rs
+++ b/fs/rsext4/src/crc32c/arm64.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", not(target_os = "macos")))]
 #[allow(dead_code)]
 use core::arch::asm;
 #[cfg(target_arch = "aarch64")]
@@ -41,17 +41,27 @@ use core::arch::aarch64::{__crc32cb, __crc32cd, __crc32ch, __crc32cw};
 #[inline]
 #[allow(dead_code)]
 pub fn has_hardware_crc32() -> bool {
-    let mut reg_val: u64;
-    unsafe {
-        // mrs: Move from System Register to general purpose register
-        asm!("mrs {}, ID_AA64ISAR0_EL1", out(reg) reg_val);
+    #[cfg(target_os = "macos")]
+    {
+        // EL1 feature registers are not accessible from a macOS userspace
+        // host test. The table implementation is always available there.
+        false
     }
 
-    // Bits [19:16] encode CRC32 feature support.
-    let crc_field = (reg_val >> 16) & 0xF;
+    #[cfg(not(target_os = "macos"))]
+    {
+        let mut reg_val: u64;
+        unsafe {
+            // mrs: Move from System Register to general purpose register
+            asm!("mrs {}, ID_AA64ISAR0_EL1", out(reg) reg_val);
+        }
 
-    // `>= 1` means CRC32 and CRC32C instructions are present.
-    crc_field >= 1
+        // Bits [19:16] encode CRC32 feature support.
+        let crc_field = (reg_val >> 16) & 0xF;
+
+        // `>= 1` means CRC32 and CRC32C instructions are present.
+        crc_field >= 1
+    }
 }
 
 /// Computes CRC32C with ARMv8 hardware instructions.


### PR DESCRIPTION
## 问题

在 AArch64 macOS 用户态运行 rsext4 host-test 时，CRC 能力探测直接读取 ID_AA64ISAR0_EL1。该寄存器只能在 EL1 访问，测试进程因此收到 SIGILL，无法执行任何 CRC 或文件系统回归。

## 修改

- macOS AArch64 不再编译和执行 EL1 寄存器读取路径。
- macOS host-test 明确使用始终可用的软件查表 CRC32C 实现。
- 非 macOS AArch64 的硬件能力探测和硬件 CRC 路径保持不变。

## 逻辑

这是执行环境权限差异，不是 CPU 是否支持 CRC 指令的问题。macOS 用户态无法安全读取 EL1 特性寄存器，因此 host-test 应选择软件实现；内核/裸机目标仍按原逻辑探测硬件能力。

## 验证

- 修复前：cargo test -p rsext4 --features host-test crc32c_standard_test_vector 以 signal 4 (SIGILL) 退出。
- 修复后：同一测试通过。
- cargo xtask clippy --package rsext4：base、USE_MULTILEVEL_CACHE、host-test 三组均通过。
- 完整 host-test 中 353 个单元测试及其余集成组通过；现有 linux_uninit_bg_image_mounts_writable_and_remains_clean 在本机 e2fsprogs 1.47.4 夹具判断处失败，其输出实际包含 [INODE_UNINIT]，与本补丁无关。