### PR TITLE
fix(macos-selfbuild): preserve locked Cargo prefetch

### DIFF
--- a/apps/starry/macos-selfbuild/prepare_toolchain_overlay.sh
+++ b/apps/starry/macos-selfbuild/prepare_toolchain_overlay.sh
@@ -84,7 +84,6 @@ rust_dist_dir="$work_dir/rust-dist-${cache_rust_toolchain}"
 cargo_home_dir="$work_dir/cargo-home"
 prefetch_source_dir="$work_dir/prefetch-source"
 extra_fetch_dir="$work_dir/extra-fetch"
-extra_fetch_workspace_dir="$work_dir/extra-fetch-workspace"
 marker_file="$output_dir/.starry-macos-toolchain-overlay"
 
 sha256_file() {
@@ -108,6 +107,7 @@ alpine_arch=$alpine_arch
 guest_target=$guest_target
 cargo_lock_sha256=$cargo_lock_sha
 cargo_registry_index=$cargo_registry_index
+guest_packages_version=2
 EOF
 }
 
@@ -380,7 +380,7 @@ CARGO_CFG
 
     rm -rf "$prefetch_source_dir"
     mkdir -p "$prefetch_source_dir"
-    for path in Cargo.toml Cargo.lock rust-toolchain.toml .cargo apps bootloader components drivers memory net os platforms scripts test-suit tools vendor virtualization xtask; do
+    for path in Cargo.toml Cargo.lock rust-toolchain.toml .cargo apps bootloader components drivers fs memory net os platforms scripts test-suit tools vendor virtualization xtask; do
         if [[ -e "$source_dir/$path" ]]; then
             cp -a "$source_dir/$path" "$prefetch_source_dir/"
         fi
@@ -392,42 +392,9 @@ CARGO_CFG
     prefetch_manifest="$prefetch_source_dir/Cargo.toml"
 
     cargo_fetch "${cargo_env[@]}" \
-        cargo fetch --target "$guest_target" --manifest-path "$prefetch_manifest"
-
-    rm -rf "$extra_fetch_workspace_dir"
-    mkdir -p "$extra_fetch_workspace_dir/src"
-    cat >"$extra_fetch_workspace_dir/Cargo.toml" <<'EXTRA_CARGO'
-[package]
-name = "starry-selfbuild-extra-fetch-workspace"
-version = "0.0.0"
-edition = "2021"
-publish = false
-
-[dependencies]
-EXTRA_CARGO
-    awk '
-        function emit() {
-            if (name != "" && version != "" && source ~ /^registry/) {
-                alias = name
-                gsub(/[^A-Za-z0-9_]/, "_", alias)
-                sub(/\+.*/, "", version)
-                printf "extra_%04d_%s = { package = \"%s\", version = \"=%s\" }\n", count, alias, name, version
-                count++
-            }
-        }
-        /^\[\[package\]\]/ { emit(); name = ""; version = ""; source = ""; next }
-        /^name = / { name = $0; sub(/^name = "/, "", name); sub(/"$/, "", name); next }
-        /^version = / { version = $0; sub(/^version = "/, "", version); sub(/"$/, "", version); next }
-        /^source = / { source = $0; sub(/^source = "/, "", source); sub(/"$/, "", source); next }
-        END { emit() }
-    ' "$source_dir/Cargo.lock" >>"$extra_fetch_workspace_dir/Cargo.toml"
-    cat >>"$extra_fetch_workspace_dir/Cargo.toml" <<'EXTRA_CARGO'
-
-[workspace]
-EXTRA_CARGO
-    : >"$extra_fetch_workspace_dir/src/lib.rs"
+        cargo fetch --locked --target "$guest_target" --manifest-path "$prefetch_manifest"
     cargo_fetch "${cargo_env[@]}" \
-        cargo fetch --manifest-path "$extra_fetch_workspace_dir/Cargo.toml"
+        cargo fetch --locked --manifest-path "$prefetch_manifest"
 
     if [[ -f "$output_dir/opt/rust-nightly/lib/rustlib/src/rust/library/sysroot/Cargo.toml" ]]; then
         cargo_fetch "${cargo_env[@]}" \

--- a/apps/starry/macos-selfbuild/tests/toolchain_overlay_contract.sh
+++ b/apps/starry/macos-selfbuild/tests/toolchain_overlay_contract.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -eu
+
+app_dir="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+toolchain_overlay="$app_dir/prepare_toolchain_overlay.sh"
+
+fail() {
+    echo "macos toolchain overlay contract: $1" >&2
+    exit 1
+}
+
+grep -Eq 'for path in .* fs( |;)' "$toolchain_overlay" \
+    || fail "offline Cargo prefetch omits the workspace fs directory"
+grep -Fq 'cargo fetch --locked --manifest-path "$prefetch_manifest"' \
+    "$toolchain_overlay" \
+    || fail "offline Cargo prefetch does not fetch the locked workspace for all targets"
+if grep -q 'starry-selfbuild-extra-fetch-workspace' "$toolchain_overlay"; then
+    fail "offline Cargo prefetch re-resolves locked packages through a synthetic workspace"
+fi
+
+echo "macos_toolchain_overlay_contract=PASS"


### PR DESCRIPTION
## 问题

macOS 自举工具链准备脚本把 Cargo.lock 中的 registry 包重新拼成一个临时 workspace 再执行 cargo fetch。这个过程会重新解析依赖；当锁文件包含已下架但仍可由锁文件复现的精确版本（本次为 chacha20 0.10.1）时，预取在 QEMU 启动前失败。另外预取源码集合遗漏 fs/，导致工作区元数据无法完整加载。

## 修改

- 把 fs/ 纳入离线预取所需的工作区源码。
- 目标平台预取和全目标预取都直接使用原工作区 Cargo.toml/Cargo.lock，并加 --locked。
- 删除会重新解析所有 registry 版本的临时 extra-fetch workspace。
- 增加脚本合约，固定上述三项约束。
- 更新缓存签名版本，确保旧的不完整工具链 overlay 不会被复用。

## 逻辑

Cargo.lock 已经是自举输入的一部分，应由 Cargo 自己按锁文件解析。先带目标三元组执行一次 locked fetch，再对同一 manifest 执行全目标 locked fetch，可以覆盖目标相关和 host/build 相关依赖，同时避免构造第二套依赖图。

## 验证

- 修复前的确定性合约会因缺少 --locked、遗漏 fs/、存在 synthetic workspace 而失败。
- sh apps/starry/macos-selfbuild/tests/toolchain_overlay_contract.sh 通过。
- bash -n apps/starry/macos-selfbuild/prepare_toolchain_overlay.sh 通过。
- 实际 macOS HVF 自举准备已越过 chacha20 下架版本和 fs 工作区加载失败点，进入 StarryOS guest 的 cargo build -p tg-xtask。