### PR TITLE
feat(macos-selfbuild): profile tg-xtask under HVF

### DIFF
--- a/apps/starry/macos-selfbuild/guest-tg-xtask-profile.sh
+++ b/apps/starry/macos-selfbuild/guest-tg-xtask-profile.sh
@@ -1,0 +1,188 @@
+#!/bin/sh
+set -eu
+
+marker=STARRY-MACOS-TG-XTASK-PROFILE
+profile_duration=300
+profile_frequency=49
+host_success_settle_seconds=3
+source_tar=/opt/tgoskits-src.tar
+source_meta=/opt/tgoskits-src.meta
+source_dir=/tmp/tgoskits-tg-xtask-profile-src
+target_dir=/tmp/tgoskits-tg-xtask-profile-target
+self_profile_dir=/tmp/tgoskits-tg-xtask-self-profile
+artifact_dir=/opt/starryos-selfbuild-artifacts/tg-xtask-profile
+cargo_bin=/opt/cargo-nightly-sysroot
+
+finish_guest() {
+    rc="$1"
+    sync 2>/dev/null || true
+    if command -v poweroff >/dev/null 2>&1; then
+        poweroff -f 2>/dev/null || poweroff 2>/dev/null || true
+    fi
+    exit "$rc"
+}
+
+fail() {
+    echo "===${marker}-FAIL reason=$1==="
+    finish_guest 1
+}
+
+for command in gzip perf sha256sum tar tee timeout; do
+    command -v "$command" >/dev/null 2>&1 || fail "tool-missing-${command}"
+done
+[ -x "$cargo_bin" ] || fail cargo-missing
+[ -f "$source_tar" ] || fail source-tar-missing
+
+rm -rf "$source_dir" "$target_dir" "$self_profile_dir" "$artifact_dir"
+mkdir -p "$source_dir" "$target_dir" "$artifact_dir"
+tar -xf "$source_tar" -C "$source_dir"
+if [ -f "$source_dir/.cargo/config.toml" ]; then
+    sed -i '/^include[[:space:]]*=/d' "$source_dir/.cargo/config.toml"
+fi
+
+export PATH=/opt/rust-nightly/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+export LD_LIBRARY_PATH=/opt/rust-nightly/lib:/usr/lib
+export RUSTC=/opt/rustc-nightly-sysroot
+export RUSTDOC=/opt/rustdoc-nightly-sysroot
+export HOME=/root
+export CARGO_HOME=/root/.cargo
+export CARGO_TARGET_DIR="$target_dir"
+export CARGO_NET_OFFLINE=true
+export RUSTC_BOOTSTRAP=1
+
+cargo_config="$CARGO_HOME/config.toml"
+mkdir -p "$CARGO_HOME"
+touch "$cargo_config"
+if ! grep -q 'starry-macos-selfbuild-host-rustflags' "$cargo_config"; then
+    cat >> "$cargo_config" <<'EOF'
+
+# starry-macos-selfbuild-host-rustflags
+[host]
+rustflags = ["-C", "target-feature=-crt-static"]
+EOF
+fi
+
+cd "$source_dir"
+logical_cpus="$(grep -c '^processor' /proc/cpuinfo 2>/dev/null || true)"
+echo "===${marker}-BEGIN duration=${profile_duration} frequency=${profile_frequency} parallelism=system-default==="
+echo "logical_cpus=$logical_cpus"
+echo "cpu_affinity=$(sed -n 's/^Cpus_allowed_list:[[:space:]]*//p' /proc/self/status)"
+"$RUSTC" --version --verbose
+"$cargo_bin" --version
+echo "===${marker}-COMMAND=== cargo build -p tg-xtask"
+
+start="$(date +%s)"
+rc_file=/tmp/tg-xtask-profile.rc
+rm -f "$rc_file"
+profile_backend=perf-cycles
+if perf stat -e cycles -- true > "$artifact_dir/pmu-probe.log" 2>&1; then
+    echo "profile_backend=$profile_backend"
+else
+    profile_backend=rustc-self-profile
+    echo "profile_backend=$profile_backend"
+    cat "$artifact_dir/pmu-probe.log"
+    mkdir -p "$self_profile_dir"
+    export RUSTFLAGS="-C target-feature=-crt-static -Zself-profile=$self_profile_dir -Zself-profile-events=default"
+fi
+
+set +e
+if [ "$profile_backend" = perf-cycles ]; then
+    (
+        timeout --signal=INT --kill-after=30 "$profile_duration" \
+            perf record -F "$profile_frequency" -e cycles \
+            -o "$artifact_dir/perf.data" -- \
+            "$cargo_bin" build -p tg-xtask
+        printf '%s\n' "$?" > "$rc_file"
+    ) 2>&1 | tee "$artifact_dir/run.log" &
+else
+    (
+        timeout --signal=INT --kill-after=30 "$profile_duration" \
+            "$cargo_bin" build -p tg-xtask
+        printf '%s\n' "$?" > "$rc_file"
+    ) 2>&1 | tee "$artifact_dir/run.log" &
+fi
+pipeline_pid="$!"
+next_progress=60
+: > "$artifact_dir/progress.log"
+while kill -0 "$pipeline_pid" 2>/dev/null; do
+    now="$(date +%s)"
+    progress_elapsed="$((now - start))"
+    if [ "$progress_elapsed" -ge "$next_progress" ]; then
+        compile_units="$(grep -c '^   Compiling ' "$artifact_dir/run.log" 2>/dev/null || true)"
+        distinct_crates="$(sed -n 's/^   Compiling \([^ ]*\).*/\1/p' "$artifact_dir/run.log" \
+            | sort -u | wc -l | tr -d ' ')"
+        echo "progress elapsed=${progress_elapsed} compile_units=${compile_units} distinct_crates=${distinct_crates}" \
+            | tee -a "$artifact_dir/progress.log"
+        next_progress="$((next_progress + 60))"
+    fi
+    sleep 5
+done
+wait "$pipeline_pid"
+pipeline_rc="$?"
+set -e
+[ "$pipeline_rc" = 0 ] || fail "profile-pipeline-${pipeline_rc}"
+[ -s "$rc_file" ] || fail profile-rc-missing
+profile_rc="$(sed -n '1p' "$rc_file")"
+case "$profile_rc" in
+    0|124) ;;
+    *) fail "profile-command-${profile_rc}" ;;
+esac
+
+end="$(date +%s)"
+elapsed="$((end - start))"
+compile_units="$(grep -c '^   Compiling ' "$artifact_dir/run.log" 2>/dev/null || true)"
+distinct_crates="$(sed -n 's/^   Compiling \([^ ]*\).*/\1/p' "$artifact_dir/run.log" \
+    | sort -u | wc -l | tr -d ' ')"
+echo "progress elapsed=${elapsed} compile_units=${compile_units} distinct_crates=${distinct_crates} final=true" \
+    | tee -a "$artifact_dir/progress.log"
+
+if [ "$profile_backend" = perf-cycles ]; then
+    [ -s "$artifact_dir/perf.data" ] || fail perf-data-missing
+    perf report --stdio --show-nr-samples --sort comm,dso,symbol \
+        -i "$artifact_dir/perf.data" > "$artifact_dir/perf-report.txt" \
+        || fail perf-report
+    [ -s "$artifact_dir/perf-report.txt" ] || fail perf-report-empty
+    profile_files=1
+else
+    profile_files="$(find "$self_profile_dir" -type f -name '*.mm_profdata' | wc -l | tr -d ' ')"
+    [ "$profile_files" -gt 0 ] || fail rustc-self-profile-empty
+    find "$self_profile_dir" -type f -name '*.mm_profdata' -exec basename {} \; \
+        | sort > "$artifact_dir/rustc-self-profile-files.txt"
+    tar -czf "$artifact_dir/rustc-self-profile.tar.gz" -C "$self_profile_dir" . \
+        || fail rustc-self-profile-archive
+fi
+
+if [ -f "$source_meta" ]; then
+    cp "$source_meta" "$artifact_dir/source.meta"
+fi
+{
+    echo profile_backend="$profile_backend"
+    echo workload=cargo build -p tg-xtask
+    echo accelerator=hvf
+    echo virtual_cpus="$logical_cpus"
+    echo parallelism=system-default
+    echo duration_limit_seconds="$profile_duration"
+    echo frequency_hz="$profile_frequency"
+    echo elapsed_seconds="$elapsed"
+    echo command_rc="$profile_rc"
+    echo compile_units="$compile_units"
+    echo distinct_crates="$distinct_crates"
+    echo profile_files="$profile_files"
+} > "$artifact_dir/profile.meta"
+(
+    cd "$artifact_dir"
+    if [ "$profile_backend" = perf-cycles ]; then
+        sha256sum perf.data perf-report.txt pmu-probe.log profile.meta progress.log run.log \
+            ${source_meta:+source.meta} > SHA256SUMS
+    else
+        sha256sum pmu-probe.log profile.meta progress.log run.log \
+            rustc-self-profile-files.txt rustc-self-profile.tar.gz \
+            ${source_meta:+source.meta} > SHA256SUMS
+    fi
+)
+sync
+
+echo "===${marker}-ARTIFACT path=${artifact_dir}==="
+echo "===${marker}-PASS elapsed=${elapsed} rc=${profile_rc} parallelism=system-default==="
+sleep "$host_success_settle_seconds"
+finish_guest 0

--- a/apps/starry/macos-selfbuild/prebuild.sh
+++ b/apps/starry/macos-selfbuild/prebuild.sh
@@ -7,6 +7,7 @@ overlay_dir="${STARRY_OVERLAY_DIR:-}"
 rootfs="${STARRY_ROOTFS:-}"
 rootfs_size_mib="${ROOTFS_SIZE_MIB:-16384}"
 out_dir="$workspace/target/starry-macos-selfbuild"
+selfbuild_mode="${STARRY_MACOS_SELFBUILD_MODE:-full}"
 export COPYFILE_DISABLE=1
 
 usage() {
@@ -39,6 +40,11 @@ if [[ "$#" -gt 0 ]]; then
     usage >&2
     exit 2
 fi
+
+case "$selfbuild_mode" in
+    full|tg-xtask-profile) ;;
+    *) echo "unknown STARRY_MACOS_SELFBUILD_MODE: $selfbuild_mode" >&2; exit 2 ;;
+esac
 
 if [[ -z "$overlay_dir" ]]; then
     echo "error: STARRY_OVERLAY_DIR is required" >&2
@@ -279,11 +285,16 @@ tar_create -C "$out_dir" -rf "$src_tar" .tgoskits-source-meta
 cargo_registry_cache_count=0
 copy_cargo_registry_cache
 
-install -m 0755 "$app_dir/guest-selfbuild.sh" "$overlay_dir/opt/starry-macos-run.sh"
+case "$selfbuild_mode" in
+    full) guest_runner="$app_dir/guest-selfbuild.sh" ;;
+    tg-xtask-profile) guest_runner="$app_dir/guest-tg-xtask-profile.sh" ;;
+esac
+install -m 0755 "$guest_runner" "$overlay_dir/opt/starry-macos-run.sh"
 install -m 0644 "$src_tar" "$overlay_dir/opt/tgoskits-src.tar"
 install -m 0644 "$meta_file" "$overlay_dir/opt/tgoskits-src.meta"
 
 echo "macos-selfbuild overlay ready in $overlay_dir"
+echo "selfbuild_mode=$selfbuild_mode"
 echo "source_commit=$source_commit"
 echo "source_ref=$source_ref"
 echo "source_dirty=$dirty"

--- a/apps/starry/macos-selfbuild/prepare_toolchain_overlay.sh
+++ b/apps/starry/macos-selfbuild/prepare_toolchain_overlay.sh
@@ -540,6 +540,7 @@ build_toolchain_overlay() {
         clang-libclang
         lld
         llvm
+        perf
         rust
         cargo
         rust-src

--- a/apps/starry/macos-selfbuild/qemu-aarch64-profile.toml
+++ b/apps/starry/macos-selfbuild/qemu-aarch64-profile.toml
@@ -1,0 +1,26 @@
+args = [
+    "-nographic",
+    "-accel",
+    "hvf",
+    "-machine",
+    "virt,gic-version=3",
+    "-cpu",
+    "host",
+    "-m",
+    "8192M",
+    "-smp",
+    "8",
+]
+uefi = false
+to_bin = true
+rootfs_write_policy = "persist"
+shell_prefix = "root@starry:"
+shell_init_cmd = "/bin/sh /opt/starry-macos-run.sh"
+success_regex = ["(?m)^===STARRY-MACOS-TG-XTASK-PROFILE-PASS elapsed=[0-9]+ rc=(0|124) parallelism=system-default===$"]
+fail_regex = [
+    "(?i)\\bpanicked at\\b",
+    "(?i)\\bkernel panic\\b",
+    "(?i)\\bunhandled trap\\b",
+    "(?m)^===STARRY-MACOS-TG-XTASK-PROFILE-FAIL",
+]
+timeout = 1200

--- a/apps/starry/macos-selfbuild/tests/tg_xtask_profile_contract.sh
+++ b/apps/starry/macos-selfbuild/tests/tg_xtask_profile_contract.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -eu
+
+app_dir="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+runner="$app_dir/guest-tg-xtask-profile.sh"
+config="$app_dir/qemu-aarch64-profile.toml"
+
+fail() {
+    echo "macos tg-xtask profile contract: $1" >&2
+    exit 1
+}
+
+[ -f "$runner" ] || fail "profile guest runner is missing"
+[ -f "$config" ] || fail "profile QEMU config is missing"
+grep -q 'cargo_bin.*build -p tg-xtask' "$runner" \
+    || fail "profile workload is not cargo build -p tg-xtask"
+grep -q 'profile_duration=300' "$runner" \
+    || fail "profile window is not 300 seconds"
+grep -q 'perf record .*cycles' "$runner" \
+    || fail "cycle sampling command is missing"
+grep -q 'perf stat .*cycles' "$runner" \
+    || fail "profile runner does not probe whether the guest PMU is available"
+grep -q -- '-Zself-profile=' "$runner" \
+    || fail "profile runner has no compiler self-profile fallback for HVF without PMU"
+grep -q 'profile_backend=rustc-self-profile' "$runner" \
+    || fail "profile metadata cannot identify the compiler self-profile fallback"
+grep -q 'host_success_settle_seconds=3' "$runner" \
+    || fail "profile runner does not keep the guest alive after printing the host success marker"
+grep -Fq 'sleep "$host_success_settle_seconds"' "$runner" \
+    || fail "profile runner powers off before the host can commit the success match"
+if grep -Eq 'perf record .* (-g|--call-graph)( |$)' "$runner"; then
+    fail "profile requests unsupported guest callchains"
+fi
+if grep -Eq 'CARGO_BUILD_JOBS|RAYON_NUM_THREADS|RUSTC_THREADS|-Zthreads|taskset' "$runner"; then
+    fail "profile runner limits build parallelism or affinity"
+fi
+grep -q 'STARRY_MACOS_SELFBUILD_MODE' "$app_dir/prebuild.sh" \
+    || fail "prebuild cannot select the profile runner"
+grep -Eq '^[[:space:]]+perf$' "$app_dir/prepare_toolchain_overlay.sh" \
+    || fail "toolchain overlay does not contain perf"
+grep -q '"hvf"' "$config" || fail "QEMU profile does not use HVF"
+grep -q '"host"' "$config" || fail "QEMU profile does not use the host CPU"
+grep -q '"8"' "$config" || fail "QEMU profile does not expose eight vCPUs"
+grep -q 'TG-XTASK-PROFILE-PASS' "$config" \
+    || fail "QEMU profile has no completion marker"
+
+echo "macos_tg_xtask_profile_contract=PASS"


### PR DESCRIPTION
## 问题

macOS HVF 下的 StarryOS 自举只能看到整段 cargo 日志，无法在不等待完整两阶段构建的情况下判断第一阶段为什么慢。HVF 当前也没有向 guest 暴露可用的 ARM PMU，perf record -e cycles 会返回 ENOSYS，因此单一 perf 路径无法产出样本。

本 PR 依赖 #2229 提供可复现的 locked Cargo 离线预取；代码差异本身保持独立，便于分别审查。

## 修改

- 新增专用 guest runner，只测第一条 cargo build -p tg-xtask。
- profiling 窗口固定为 300 秒，每约 60 秒记录编译单元数和去重 crate 数。
- 不设置 CPU affinity、CARGO_BUILD_JOBS、RAYON_NUM_THREADS、RUSTC_THREADS 或 -Zthreads，保留系统默认并行度。
- 先探测 guest PMU：可用时做 49 Hz flat cycles perf record；HVF PMU 不可用时自动使用 rustc -Zself-profile。
- 保存运行日志、进度、元数据、源版本、校验和及压缩后的原始 profile。
- 增加 8 vCPU、8 GiB、host CPU、HVF 的独立 QEMU 配置和脚本合约。
- PASS 后保留 3 秒交接窗口，避免 host 匹配成功标志与 guest 关机竞争。

## 逻辑

用户态 workload 仍是最简单的一条 cargo build -p tg-xtask。采样只包围第一阶段；第二阶段依赖第一阶段产物，但不需要重复测量。PMU 探测在运行时选择后端，使物理板可使用 cycles，而 macOS HVF 仍能获得 rustc 内部阶段证据。

## 验证

- sh apps/starry/macos-selfbuild/tests/tg_xtask_profile_contract.sh 通过。
- prebuild/toolchain/guest runner 的 bash/sh 语法检查通过。
- macOS HVF 实测完整通过：固定窗口 303 秒，最终 59 个编译单元、58 个不同 crate，guest PASS 后 host 正确返回成功，总 QEMU 运行 351.04 秒。
- 生成 76 份 rustc self-profile，压缩归档和全部 SHA-256 校验通过；其中 68 份完整可解析，8 份位于固定超时边界而不完整。
- 68 份完整 profile 累计 2039.345 秒 rustc 时间，约为墙钟时间的 6.73 倍，说明默认 Cargo 并行确实启动了多个 rustc，不支持“被限制为单核/单线程”的假设。