### PR TITLE
fix(axbuild): stream debugfs extraction commands

### DIFF
--- a/scripts/axbuild/src/rootfs/inject.rs
+++ b/scripts/axbuild/src/rootfs/inject.rs
@@ -152,19 +152,42 @@ impl RootfsExtraction<'_> {
     fn run(&self) -> anyhow::Result<()> {
         let mut command = self.command();
         let rendered_command = format!("{command:?}");
-        let output = command.output().with_context(|| {
-            if let Some(fakeroot) = self.fakeroot_program {
-                format!(
-                    "failed to spawn fakeroot `{}`; rootfs extraction without full host ownership \
-                     privileges requires fakeroot",
-                    fakeroot.display()
-                )
-            } else {
-                format!("failed to spawn debugfs for {}", self.rootfs_img.display())
-            }
-        })?;
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .with_context(|| {
+                if let Some(fakeroot) = self.fakeroot_program {
+                    format!(
+                        "failed to spawn fakeroot `{}`; rootfs extraction without full host \
+                         ownership privileges requires fakeroot",
+                        fakeroot.display()
+                    )
+                } else {
+                    format!("failed to spawn debugfs for {}", self.rootfs_img.display())
+                }
+            })?;
+        let script_result = (|| {
+            let mut stdin = child
+                .stdin
+                .take()
+                .context("failed to open debugfs extraction stdin")?;
+            writeln!(stdin, "rdump / {}", debugfs_path_argument(self.output_dir)?)
+                .context("failed to write debugfs extraction command")?;
+            writeln!(stdin, "quit").context("failed to finalize debugfs extraction command")
+        })();
+        let output = child
+            .wait_with_output()
+            .context("failed to wait for debugfs rootfs extraction")?;
+        script_result?;
 
-        if output.status.success() {
+        let extracted_entries = fs::read_dir(self.output_dir)
+            .with_context(|| format!("failed to inspect {}", self.output_dir.display()))?
+            .next()
+            .transpose()
+            .with_context(|| format!("failed to inspect {}", self.output_dir.display()))?;
+        if output.status.success() && extracted_entries.is_some() {
             return Ok(());
         }
 
@@ -175,12 +198,19 @@ impl RootfsExtraction<'_> {
         io::stderr()
             .write_all(&output.stderr)
             .context("failed to replay rootfs extraction stderr")?;
+        if output.status.success() {
+            bail!(
+                "failed to extract {} into {}: debugfs reported success but produced no entries",
+                self.rootfs_img.display(),
+                self.output_dir.display()
+            );
+        }
         bail!(
             "failed to extract {} into {}: command exited with status {}",
             self.rootfs_img.display(),
             self.output_dir.display(),
             output.status
-        );
+        )
     }
 
     fn command(&self) -> Command {
@@ -191,10 +221,7 @@ impl RootfsExtraction<'_> {
         } else {
             Command::new(self.debugfs_program)
         };
-        command
-            .arg("-R")
-            .arg(format!("rdump / {}", self.output_dir.display()))
-            .arg(self.rootfs_img);
+        command.arg(self.rootfs_img);
         command
     }
 }
@@ -732,11 +759,35 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn fakeroot_command_keeps_debugfs_script_out_of_argv() {
+        let extraction = RootfsExtraction {
+            rootfs_img: Path::new("rootfs.img"),
+            output_dir: Path::new("staging-root"),
+            debugfs_program: Path::new("debugfs"),
+            fakeroot_program: Some(Path::new("fakeroot")),
+        };
+        let command = extraction.command();
+        let args = command
+            .get_args()
+            .map(|argument| argument.to_string_lossy())
+            .collect::<Vec<_>>();
+
+        assert!(
+            !args.iter().any(|argument| argument.starts_with("rdump ")),
+            "debugfs commands containing spaces are split by BSD getopt in macOS fakeroot: \
+             {args:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn non_root_extraction_starts_debugfs_inside_fakeroot() {
         let root = tempdir().unwrap();
         let fakeroot = root.path().join("fakeroot");
         let debugfs = root.path().join("debugfs");
         let marker = root.path().join("debugfs-ran-inside-fakeroot");
+        let output_dir = root.path().join("staging");
+        let extracted = output_dir.join("extracted");
         write_executable(
             &fakeroot,
             "#!/bin/sh\ntest \"$1\" = \"--\" || exit 91\nshift\nexport \
@@ -745,12 +796,13 @@ mod tests {
         write_executable(
             &debugfs,
             &format!(
-                "#!/bin/sh\ntest \"${{AXBUILD_TEST_FAKEROOT:-}}\" = \"1\" || exit 92\ntouch '{}'\n",
-                marker.display()
+                "#!/bin/sh\ntest \"${{AXBUILD_TEST_FAKEROOT:-}}\" = \"1\" || exit 92\ncat \
+                 >/dev/null\ntouch '{}' '{}'\n",
+                marker.display(),
+                extracted.display()
             ),
         );
 
-        let output_dir = root.path().join("staging");
         fs::create_dir(&output_dir).unwrap();
         RootfsExtraction {
             rootfs_img: Path::new("rootfs.img"),


### PR DESCRIPTION
## 问题

macOS 上 Homebrew `fakeroot` 使用 BSD `getopt`。现有 rootfs 解包把 `rdump / <staging-root>` 作为 `debugfs -R` 的一个含空格参数传过 fakeroot，参数会被重新拆分。debugfs 打印 usage 后仍返回 0，axbuild 因此把空目录误判为成功解包，稍后才在写 `etc/resolv.conf` 时失败。

## 修改

- 改为启动 `fakeroot -- debugfs <image>` 后，通过 stdin 发送带正确路径引用的 `rdump` 与 `quit`，避免 debugfs 脚本穿过 fakeroot argv。
- 即使 debugfs 返回成功，也检查 staging root 至少产生一个目录项，防止静默空解包。
- 增加 macOS/BSD getopt 命令形状回归，并更新 fakeroot 包装测试覆盖 stdin 流程。

## 实现逻辑

fakeroot 只负责在 debugfs 进程启动前建立伪所有权环境；debugfs 命令本身不需要进入 fakeroot 的选项解析。把命令放到 stdin 后，argv 只包含无空格的程序和镜像路径，Linux 与 macOS 路径保持一致，同时保留完整 stdout/stderr 失败回放。

## 验证

- 修复前：`fakeroot_command_keeps_debugfs_script_out_of_argv` 稳定失败，argv 中含 `rdump / staging-root`。
- 修复后：`cargo test -p axbuild rootfs::inject::tests`，6/6 通过。
- `cargo xtask clippy --package axbuild` 通过。
- macOS 实际 Starry QEMU 用例的 rootfs 解包阶段从空目录失败推进为成功提取（5.4 秒）；后续 host C 交叉编译适配另行提交。