### PR TITLE
feat(axbuild): cross-compile C tests on macOS

### DIFF
--- a/scripts/axbuild/src/support/process.rs
+++ b/scripts/axbuild/src/support/process.rs
@@ -72,15 +72,20 @@ pub(crate) fn run_cargo_status_with_env(
 }
 
 pub(crate) fn find_host_binary_candidates(candidates: &[&str]) -> Result<std::path::PathBuf> {
+    find_optional_host_binary_candidates(candidates).ok_or_else(|| {
+        anyhow::anyhow!(
+            "required host binary was not found in PATH; tried: {}",
+            candidates.join(", ")
+        )
+    })
+}
+
+pub(crate) fn find_optional_host_binary_candidates(
+    candidates: &[&str],
+) -> Option<std::path::PathBuf> {
     candidates
         .iter()
         .find_map(|candidate| find_optional_host_binary(candidate))
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "required host binary was not found in PATH; tried: {}",
-                candidates.join(", ")
-            )
-        })
 }
 
 fn find_optional_host_binary(name: &str) -> Option<std::path::PathBuf> {

--- a/scripts/axbuild/src/test/build/c.rs
+++ b/scripts/axbuild/src/test/build/c.rs
@@ -137,7 +137,7 @@ pub(crate) fn prepare_c_case_overlay_sync(
             ("phase", "find-qemu-user".to_string()),
         ],
     );
-    let qemu_runner = find_host_binary_candidates(qemu_user_binary_names(arch)?)?;
+    let qemu_runner = find_qemu_user_binary(arch)?;
     timing_stage.finish();
     let timing_stage = timing::TimingStage::new(
         "qemu-asset-c",
@@ -146,7 +146,7 @@ pub(crate) fn prepare_c_case_overlay_sync(
             ("phase", "prepare-cross-env".to_string()),
         ],
     );
-    let build_env = prepare_host_cross_build_env(arch, layout, &qemu_runner)?;
+    let build_env = prepare_host_cross_build_env(arch, layout, qemu_runner.as_deref())?;
     timing_stage.finish();
 
     let timing_stage = timing::TimingStage::new(

--- a/scripts/axbuild/src/test/build/env.rs
+++ b/scripts/axbuild/src/test/build/env.rs
@@ -7,8 +7,10 @@ pub(super) fn prepare_guest_prebuild_env(
     extra_script_envs: Vec<(String, String)>,
     config: &CaseAssetConfig,
 ) -> anyhow::Result<GuestPrebuildEnv> {
-    let qemu_runner = find_host_binary_candidates(qemu_user_binary_names(arch)?)?;
-    write_guest_command_wrappers(layout, &qemu_runner)?;
+    let qemu_runner = find_qemu_user_binary(arch)?;
+    if let Some(qemu_runner) = &qemu_runner {
+        write_guest_command_wrappers(layout, qemu_runner)?;
+    }
 
     let mut script_envs = case_script_envs(case, layout, config);
     script_envs.extend(extra_script_envs);
@@ -33,16 +35,28 @@ pub(super) fn prepare_guest_package_env(
 pub(super) fn prepare_host_cross_build_env(
     arch: &str,
     layout: &case_assets::CaseAssetLayout,
-    qemu_runner: &Path,
+    qemu_runner: Option<&Path>,
 ) -> anyhow::Result<HostCrossBuildEnv> {
     let spec = cross_compile_spec(arch)?;
     let cmake = find_host_binary_candidates(&["cmake"])?;
-    let clang = find_host_binary_candidates(&["clang"])?;
     let pkg_config = find_host_binary_candidates(&["pkg-config"])?;
     let make_program = find_host_binary_candidates(&["make", "gmake"])?;
 
-    write_cross_bin_wrappers(layout, spec, qemu_runner)?;
-    write_cmake_toolchain_file(layout, spec, &clang)?;
+    let (clang, use_lld) = match qemu_runner {
+        Some(qemu_runner) => {
+            write_cross_bin_wrappers(layout, spec, qemu_runner)?;
+            (find_host_binary_candidates(&["clang"])?, false)
+        }
+        None => {
+            ensure!(
+                cfg!(target_os = "macos"),
+                "native LLVM cross tools are only supported on macOS"
+            );
+            let clang = write_native_llvm_bin_wrappers(layout, spec)?;
+            (clang, true)
+        }
+    };
+    write_cmake_toolchain_file(layout, spec, &clang, use_lld)?;
 
     let pkgconfig_libdir = format!(
         "{}:{}",

--- a/scripts/axbuild/src/test/build/grouped_c.rs
+++ b/scripts/axbuild/src/test/build/grouped_c.rs
@@ -337,7 +337,7 @@ pub(super) fn prepare_grouped_c_subcases_sync(
             ("phase", "find-qemu-user".to_string()),
         ],
     );
-    let qemu_runner = find_host_binary_candidates(qemu_user_binary_names(arch)?)?;
+    let qemu_runner = find_qemu_user_binary(arch)?;
     timing_stage.finish();
 
     let root_prebuild_script = case.case_dir.join(CASE_PREBUILD_SCRIPT_NAME);
@@ -434,7 +434,7 @@ pub(super) fn prepare_grouped_c_subcases_sync(
             ("phase", "prepare-cross-env".to_string()),
         ],
     );
-    let build_env = prepare_host_cross_build_env(arch, layout, &qemu_runner)?;
+    let build_env = prepare_host_cross_build_env(arch, layout, qemu_runner.as_deref())?;
     timing_stage.finish();
 
     if grouped_c_root_project_path(case).is_file() {

--- a/scripts/axbuild/src/test/build/mod.rs
+++ b/scripts/axbuild/src/test/build/mod.rs
@@ -23,7 +23,9 @@ use super::{
 };
 use crate::{
     context::CrossCompileSpec,
-    support::process::{ProcessExt, find_host_binary_candidates},
+    support::process::{
+        ProcessExt, find_host_binary_candidates, find_optional_host_binary_candidates,
+    },
 };
 
 const CASE_C_DIR_NAME: &str = "c";
@@ -44,7 +46,7 @@ pub(crate) struct HostCrossBuildEnv {
 
 #[derive(Debug, Clone)]
 pub(crate) struct GuestPrebuildEnv {
-    qemu_runner: PathBuf,
+    qemu_runner: Option<PathBuf>,
     script_envs: Vec<(String, String)>,
 }
 
@@ -77,10 +79,14 @@ pub(crate) use python::{case_python_source_dir, prepare_python_case_assets_sync}
 pub(crate) use rust::{
     case_rust_source_dir, prepare_rust_case_assets_sync, prepare_rust_case_overlay_sync,
 };
-use toolchain::{cross_compile_spec, write_cmake_toolchain_file, write_cross_bin_wrappers};
+use toolchain::{
+    cross_compile_spec, write_cmake_toolchain_file, write_cross_bin_wrappers,
+    write_native_llvm_bin_wrappers,
+};
 use wrappers::{
-    apply_case_script_envs, case_script_envs, ensure_guest_tool_exists, guest_library_path,
-    qemu_user_binary_names, write_guest_command_wrappers, write_guest_exec_wrapper,
+    apply_case_script_envs, case_script_envs, ensure_guest_tool_exists, find_qemu_user_binary,
+    guest_library_path, qemu_user_binary_names, shell_single_quote, write_guest_command_wrappers,
+    write_guest_exec_wrapper, write_wrapper_script,
 };
 
 #[cfg(test)]

--- a/scripts/axbuild/src/test/build/prebuild.rs
+++ b/scripts/axbuild/src/test/build/prebuild.rs
@@ -20,20 +20,27 @@ pub(super) fn build_prebuild_command_with_work_dir(
     layout: &case_assets::CaseAssetLayout,
     prebuild_env: &GuestPrebuildEnv,
 ) -> anyhow::Result<Command> {
-    let guest_busybox = layout.staging_root.join("bin/busybox");
-    let guest_shell = layout.staging_root.join("bin/sh");
-    let mut command = Command::new(&prebuild_env.qemu_runner);
-    command.arg("-L").arg(&layout.staging_root);
-    if guest_busybox.is_file() {
-        command.arg(&guest_busybox).arg("sh");
+    let mut command = if let Some(qemu_runner) = &prebuild_env.qemu_runner {
+        let guest_busybox = layout.staging_root.join("bin/busybox");
+        let guest_shell = layout.staging_root.join("bin/sh");
+        let mut command = Command::new(qemu_runner);
+        command.arg("-L").arg(&layout.staging_root);
+        if guest_busybox.is_file() {
+            command.arg(&guest_busybox).arg("sh");
+        } else {
+            ensure!(
+                guest_shell.is_file(),
+                "staging root is missing guest shell `{}`",
+                guest_shell.display()
+            );
+            command.arg(&guest_shell);
+        }
+        command
     } else {
-        ensure!(
-            guest_shell.is_file(),
-            "staging root is missing guest shell `{}`",
-            guest_shell.display()
-        );
-        command.arg(&guest_shell);
-    }
+        // QEMU linux-user is unavailable on macOS. Host-compatible prebuild scripts can still
+        // prepare sources and metadata; scripts that require guest commands fail normally.
+        Command::new("sh")
+    };
     command
         .arg("-eu")
         .arg(prebuild_script)

--- a/scripts/axbuild/src/test/build/tests.rs
+++ b/scripts/axbuild/src/test/build/tests.rs
@@ -135,7 +135,7 @@ fn build_prebuild_command_uses_guest_shell_and_case_envs() {
     fs::write(layout.staging_root.join("bin/sh"), b"").unwrap();
     fs::write(layout.staging_root.join("bin/busybox"), b"").unwrap();
     let prebuild_env = GuestPrebuildEnv {
-        qemu_runner: PathBuf::from("/usr/bin/qemu-aarch64-static"),
+        qemu_runner: Some(PathBuf::from("/usr/bin/qemu-aarch64-static")),
         script_envs: {
             let mut envs = case_script_envs(&case, &layout, &fake_config());
             envs.push(("SUITE_PACKAGE_REGION".to_string(), "us".to_string()));
@@ -180,6 +180,28 @@ fn build_prebuild_command_uses_guest_shell_and_case_envs() {
     assert_eq!(
         command_env(&command, "LD_LIBRARY_PATH"),
         Some(guest_library_path(&layout.staging_root))
+    );
+}
+
+#[test]
+fn build_prebuild_command_uses_host_shell_without_qemu_user() {
+    let root = tempdir().unwrap();
+    let case = fake_case(root.path(), "cpu-feat");
+    let layout =
+        case_assets::case_asset_layout(root.path(), "aarch64-unknown-none-softfloat", "cpu-feat")
+            .unwrap();
+    let prebuild_env = GuestPrebuildEnv {
+        qemu_runner: None,
+        script_envs: case_script_envs(&case, &layout, &fake_config()),
+    };
+    let prebuild_script = case_c_source_dir(&case).join("prebuild.sh");
+
+    let command = build_prebuild_command(&case, &prebuild_script, &layout, &prebuild_env).unwrap();
+
+    assert_eq!(command.get_program(), OsStr::new("sh"));
+    assert_eq!(
+        command_args(&command),
+        vec!["-eu".to_string(), prebuild_script.display().to_string()]
     );
 }
 
@@ -530,6 +552,7 @@ fn write_cmake_toolchain_file_contains_clang_cross_settings() {
         &layout,
         cross_compile_spec("aarch64").unwrap(),
         Path::new("/usr/bin/clang"),
+        true,
     )
     .unwrap();
 
@@ -540,6 +563,7 @@ fn write_cmake_toolchain_file_contains_clang_cross_settings() {
     assert!(content.contains("--gcc-toolchain="));
     assert!(content.contains("-B"));
     assert!(content.contains("-L"));
+    assert!(content.contains("-fuse-ld=lld"));
     assert!(content.contains("CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER"));
 }
 

--- a/scripts/axbuild/src/test/build/toolchain.rs
+++ b/scripts/axbuild/src/test/build/toolchain.rs
@@ -35,10 +35,91 @@ pub(crate) fn write_cross_bin_wrappers(
     Ok(())
 }
 
+pub(crate) fn write_native_llvm_bin_wrappers(
+    layout: &case_assets::CaseAssetLayout,
+    spec: CrossCompileSpec,
+) -> anyhow::Result<PathBuf> {
+    ensure!(
+        cfg!(target_os = "macos"),
+        "native LLVM cross tools are only supported on macOS"
+    );
+    fs::create_dir_all(&layout.cross_bin_dir)
+        .with_context(|| format!("failed to create {}", layout.cross_bin_dir.display()))?;
+
+    let clang = find_macos_llvm_tool("clang")?;
+    for (tool, llvm_name) in [
+        ("ld", "ld.lld"),
+        ("ar", "llvm-ar"),
+        ("ranlib", "llvm-ranlib"),
+        ("strip", "llvm-strip"),
+        ("nm", "llvm-nm"),
+        ("objcopy", "llvm-objcopy"),
+        ("objdump", "llvm-objdump"),
+        ("readelf", "llvm-readelf"),
+    ] {
+        let llvm_tool = find_macos_llvm_tool(llvm_name)?;
+        write_native_tool_wrapper(&layout.cross_bin_dir.join(tool), &llvm_tool, &[])?;
+        write_native_tool_wrapper(
+            &layout
+                .cross_bin_dir
+                .join(format!("{}-{tool}", spec.gnu_tool_prefix)),
+            &llvm_tool,
+            &[],
+        )?;
+    }
+
+    let assembler_args = [format!("--target={}", spec.llvm_target), "-c".to_string()];
+    write_native_tool_wrapper(&layout.cross_bin_dir.join("as"), &clang, &assembler_args)?;
+    write_native_tool_wrapper(
+        &layout
+            .cross_bin_dir
+            .join(format!("{}-as", spec.gnu_tool_prefix)),
+        &clang,
+        &assembler_args,
+    )?;
+
+    Ok(clang)
+}
+
+fn write_native_tool_wrapper(path: &Path, tool: &Path, arguments: &[String]) -> anyhow::Result<()> {
+    let arguments = arguments
+        .iter()
+        .map(|argument| shell_single_quote(Path::new(argument)))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let separator = if arguments.is_empty() { "" } else { " " };
+    write_wrapper_script(
+        path,
+        &format!(
+            "exec {}{separator}{arguments} \"$@\"\n",
+            shell_single_quote(tool)
+        ),
+    )
+}
+
+fn find_macos_llvm_tool(name: &str) -> anyhow::Result<PathBuf> {
+    let candidates = [
+        Some(Path::new("/opt/homebrew/opt/llvm/bin").join(name)),
+        Some(Path::new("/usr/local/opt/llvm/bin").join(name)),
+        find_optional_host_binary_candidates(&[name]),
+    ];
+    candidates
+        .into_iter()
+        .flatten()
+        .find(|candidate| candidate.is_file())
+        .with_context(|| {
+            format!(
+                "required macOS LLVM tool `{name}` was not found in PATH, \
+                 /opt/homebrew/opt/llvm/bin, or /usr/local/opt/llvm/bin"
+            )
+        })
+}
+
 pub(crate) fn write_cmake_toolchain_file(
     layout: &case_assets::CaseAssetLayout,
     spec: CrossCompileSpec,
     clang: &Path,
+    use_lld: bool,
 ) -> anyhow::Result<()> {
     if let Some(parent) = layout.cmake_toolchain_file.parent() {
         fs::create_dir_all(parent)
@@ -57,6 +138,9 @@ pub(crate) fn write_cmake_toolchain_file(
         compile_flags.push(format!("-B{}", gcc_runtime_dir.display()));
         linker_flags = compile_flags.clone();
         linker_flags.push(format!("-L{}", gcc_runtime_dir.display()));
+    }
+    if use_lld {
+        linker_flags.push("-fuse-ld=lld".to_string());
     }
     let compile_flags = compile_flags.join(" ");
     let linker_flags = linker_flags.join(" ");

--- a/scripts/axbuild/src/test/build/wrappers.rs
+++ b/scripts/axbuild/src/test/build/wrappers.rs
@@ -127,6 +127,18 @@ pub(crate) fn qemu_user_binary_names(arch: &str) -> anyhow::Result<&'static [&'s
     Ok(cross_compile_spec(arch)?.qemu_user_binaries)
 }
 
+pub(crate) fn find_qemu_user_binary(arch: &str) -> anyhow::Result<Option<PathBuf>> {
+    let candidates = qemu_user_binary_names(arch)?;
+    let found = find_optional_host_binary_candidates(candidates);
+    if found.is_some() || cfg!(target_os = "macos") {
+        return Ok(found);
+    }
+    Err(anyhow::anyhow!(
+        "required host binary was not found in PATH; tried: {}",
+        candidates.join(", ")
+    ))
+}
+
 pub(super) fn write_guest_exec_wrapper(
     path: &Path,
     qemu_runner: &Path,


### PR DESCRIPTION
## 问题

StarryOS 的 C/Grouped C 测试资产构建依赖 QEMU linux-user 来执行根文件系统内的 shell 和 binutils。macOS 上的 QEMU 只提供系统模拟，缺少 `qemu-aarch64`，导致资产准备在完成 rootfs 提取后立即失败，无法进入 HVF 启动验证。

## 修改

- 将 qemu-user 查找改为 macOS 可选，Linux 等已有平台仍保持缺失即报错。
- qemu-user 不可用时，使用宿主 shell 执行兼容的 prebuild；需要 guest 命令的脚本仍会按命令失败返回。
- 在 Apple Silicon 与 Intel Homebrew 路径中发现 LLVM 工具，为 GNU 风格工具名生成本地 wrapper。
- 使用 Clang 的 `aarch64-linux-musl` target、提取后的 sysroot 与 LLD 完成 CMake 交叉编译。
- 添加 host-shell fallback 与 toolchain 文件的回归覆盖。

## 实现逻辑

系统模拟仍由 `qemu-system-aarch64 -accel hvf` 负责；这里只替换原来必须依赖 linux-user 的测试资产构建阶段。优先使用同一套 Homebrew LLVM，保留提取根文件系统作为 sysroot，并通过 `-fuse-ld=lld` 避免调用 macOS 系统链接器。

## 验证

- `cargo fmt --all`
- `cargo test -p axbuild test::build::tests`：21/21 通过
- `cargo xtask clippy --package axbuild`：通过
- 叠加 #2231 后执行 `cargo xtask starry test qemu --arch aarch64 -c qemu/system/test-aarch64-cpu-feat`：StarryOS 在 QEMU/HVF 启动，6/6 断言通过，1/1 case 通过，总耗时 23.01s。

运行验证需要 #2231 提供的 macOS fakeroot/debugfs 提取修复。