### PR TITLE
fix(ax-posix-api): deliver EPOLLIN/EPOLLOUT edges via direction-split readiness versions

### DIFF
--- a/components/axio/src/lib.rs
+++ b/components/axio/src/lib.rs
@@ -34,6 +34,10 @@ pub struct PollState {
     pub readable: bool,
     /// Object can be writen now.
     pub writable: bool,
-    /// Monotonic token changed when the object's readiness may have changed.
-    pub readiness_version: u64,
+    /// Monotonic token changed when the object's read readiness may have
+    /// changed.
+    pub read_readiness_version: u64,
+    /// Monotonic token changed when the object's write readiness may have
+    /// changed.
+    pub write_readiness_version: u64,
 }

--- a/components/axio/tests/std.rs
+++ b/components/axio/tests/std.rs
@@ -225,16 +225,19 @@ fn axio_poll_state_and_formatting_rules_hold() {
     let default_state = PollState::default();
     assert!(!default_state.readable);
     assert!(!default_state.writable);
-    assert_eq!(default_state.readiness_version, 0);
+    assert_eq!(default_state.read_readiness_version, 0);
+    assert_eq!(default_state.write_readiness_version, 0);
 
     let state = PollState {
         readable: true,
         writable: true,
-        readiness_version: 7,
+        read_readiness_version: 7,
+        write_readiness_version: 9,
     };
     let formatted = format!("{state:?}");
     assert!(formatted.contains("readable: true"));
-    assert!(formatted.contains("readiness_version: 7"));
+    assert!(formatted.contains("read_readiness_version: 7"));
+    assert!(formatted.contains("write_readiness_version: 9"));
 }
 
 #[test]

--- a/os/arceos/api/arceos_api/src/imp/net.rs
+++ b/os/arceos/api/arceos_api/src/imp/net.rs
@@ -180,6 +180,7 @@ fn poll_state(events: IoEvents) -> AxPollState {
     AxPollState {
         readable: events.intersects(IoEvents::IN | IoEvents::RDHUP | IoEvents::HUP),
         writable: events.contains(IoEvents::OUT),
-        readiness_version: 0,
+        read_readiness_version: 0,
+        write_readiness_version: 0,
     }
 }

--- a/os/arceos/api/arceos_posix_api/src/imp/eventfd.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/eventfd.rs
@@ -24,7 +24,8 @@ struct EventFdInner {
     counter: u64,
     semaphore: bool,
     nonblocking: bool,
-    readiness_version: u64,
+    read_readiness_version: u64,
+    write_readiness_version: u64,
 }
 
 impl EventFd {
@@ -34,7 +35,8 @@ impl EventFd {
                 counter: initval as u64,
                 semaphore,
                 nonblocking,
-                readiness_version: 0,
+                read_readiness_version: 0,
+                write_readiness_version: 0,
             }),
         }
     }
@@ -61,7 +63,12 @@ impl FileLike for EventFd {
             }
             // The counter was `> 0` on entry (guarded above), so the drain makes
             // it readable→unreadable exactly when it hits zero. Only that
-            // transition must bump the readiness version.
+            // transition must bump the read version.
+            if inner.counter == u64::MAX - 1 {
+                // The pre-read counter sat at the saturation ceiling, so this
+                // drain is the one read that flips writability false -> true.
+                inner.write_readiness_version = inner.write_readiness_version.wrapping_add(1);
+            }
             let value = if inner.semaphore {
                 inner.counter -= 1;
                 1
@@ -71,7 +78,7 @@ impl FileLike for EventFd {
                 v
             };
             if inner.counter == 0 {
-                inner.readiness_version = inner.readiness_version.wrapping_add(1);
+                inner.read_readiness_version = inner.read_readiness_version.wrapping_add(1);
             }
             buf[..8].copy_from_slice(&value.to_ne_bytes());
             return Ok(8);
@@ -106,16 +113,23 @@ impl FileLike for EventFd {
                 continue;
             }
             inner.counter += value;
-            // Every accepted write is a wakeup event, not only the one that
-            // flips the counter from zero to non-zero: Linux `eventfd_write`
-            // calls `wake_up_locked_poll(&ctx->wqh, EPOLLIN)` on every write
-            // (fs/eventfd.c), unconditionally, so a waiter must observe one
-            // edge per write. Bumping only when readability flips drops every
-            // wake after the first while the counter stays non-zero -- which is
-            // exactly how an async runtime uses its `mio::Waker` eventfd (it
-            // never drains it), hanging the second and later `spawn_blocking`
-            // calls behind an `epoll_wait` that never returns.
-            inner.readiness_version = inner.readiness_version.wrapping_add(1);
+            // Every accepted write is a read-readiness wakeup event, not only
+            // the one that flips the counter from zero to non-zero: Linux
+            // `eventfd_write` calls `wake_up_locked_poll(&ctx->wqh, EPOLLIN)`
+            // on every write (fs/eventfd.c), unconditionally, so a waiter must
+            // observe one edge per write. Bumping only when readability flips
+            // drops every wake after the first while the counter stays
+            // non-zero -- which is exactly how an async runtime uses its
+            // `mio::Waker` eventfd (it never drains it), hanging the second and
+            // later `spawn_blocking` calls behind an `epoll_wait` that never
+            // returns.
+            inner.read_readiness_version = inner.read_readiness_version.wrapping_add(1);
+            if inner.counter == u64::MAX - 1 {
+                // Reaching the saturation ceiling is the only write that flips
+                // writability (true -> false); a plain write must not spoof a
+                // writable edge for an `EPOLLOUT` watcher.
+                inner.write_readiness_version = inner.write_readiness_version.wrapping_add(1);
+            }
             return Ok(8);
         }
     }
@@ -144,7 +158,8 @@ impl FileLike for EventFd {
         Ok(PollState {
             readable: inner.counter > 0,
             writable: inner.counter < u64::MAX - 1,
-            readiness_version: inner.readiness_version,
+            read_readiness_version: inner.read_readiness_version,
+            write_readiness_version: inner.write_readiness_version,
         })
     }
 

--- a/os/arceos/api/arceos_posix_api/src/imp/eventfd.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/eventfd.rs
@@ -92,7 +92,6 @@ impl FileLike for EventFd {
         }
         loop {
             let mut inner = self.inner.lock();
-            let old_readable = inner.counter > 0;
             // The counter saturates at UINT64_MAX - 1; a write whose addition
             // would reach or exceed UINT64_MAX blocks, or fails with EAGAIN
             // if nonblocking. `u64::MAX - value` never underflows because
@@ -107,10 +106,16 @@ impl FileLike for EventFd {
                 continue;
             }
             inner.counter += value;
-            let new_readable = inner.counter > 0;
-            if old_readable != new_readable {
-                inner.readiness_version = inner.readiness_version.wrapping_add(1);
-            }
+            // Every accepted write is a wakeup event, not only the one that
+            // flips the counter from zero to non-zero: Linux `eventfd_write`
+            // calls `wake_up_locked_poll(&ctx->wqh, EPOLLIN)` on every write
+            // (fs/eventfd.c), unconditionally, so a waiter must observe one
+            // edge per write. Bumping only when readability flips drops every
+            // wake after the first while the counter stays non-zero -- which is
+            // exactly how an async runtime uses its `mio::Waker` eventfd (it
+            // never drains it), hanging the second and later `spawn_blocking`
+            // calls behind an `epoll_wait` that never returns.
+            inner.readiness_version = inner.readiness_version.wrapping_add(1);
             return Ok(8);
         }
     }

--- a/os/arceos/api/arceos_posix_api/src/imp/fs.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/fs.rs
@@ -173,7 +173,8 @@ impl FileLike for File {
         Ok(PollState {
             readable: true,
             writable: true,
-            readiness_version: 0,
+            read_readiness_version: 0,
+            write_readiness_version: 0,
         })
     }
 
@@ -214,7 +215,8 @@ impl FileLike for Directory {
         Ok(PollState {
             readable: true,
             writable: false,
-            readiness_version: 0,
+            read_readiness_version: 0,
+            write_readiness_version: 0,
         })
     }
 

--- a/os/arceos/api/arceos_posix_api/src/imp/io_mpx/epoll.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/io_mpx/epoll.rs
@@ -30,7 +30,8 @@ pub struct EpollInstance {
 struct WatchedEvent {
     file: Weak<dyn FileLike>,
     event: ctypes::epoll_event,
-    last_ready: u32,
+    last_readable: bool,
+    last_writable: bool,
     last_readiness_version: u64,
     disabled: bool,
 }
@@ -43,7 +44,8 @@ impl WatchedEvent {
         Self {
             file: Arc::downgrade(&file),
             event,
-            last_ready: 0,
+            last_readable: false,
+            last_writable: false,
             last_readiness_version: 0,
             disabled: false,
         }
@@ -52,7 +54,8 @@ impl WatchedEvent {
     fn update(&mut self, file: Arc<dyn FileLike>, event: ctypes::epoll_event) {
         self.file = Arc::downgrade(&file);
         self.event = event;
-        self.last_ready = 0;
+        self.last_readable = false;
+        self.last_writable = false;
         self.last_readiness_version = 0;
         self.disabled = false;
     }
@@ -69,9 +72,9 @@ impl WatchedEvent {
         self.event.events & ctypes::EPOLLONESHOT != 0
     }
 
-    fn current_ready(&self) -> (u32, u64) {
+    fn current_ready(&self) -> (u32, u64, bool, bool) {
         let Some(file) = self.file.upgrade() else {
-            return (0, 0);
+            return (0, 0, false, false);
         };
         match file.poll() {
             Ok(state) => {
@@ -83,22 +86,53 @@ impl WatchedEvent {
                 if state.writable {
                     ready |= interest & EPOLL_WRITE_EVENTS;
                 }
-                (ready, state.readiness_version)
+                (
+                    ready,
+                    state.readiness_version,
+                    state.readable,
+                    state.writable,
+                )
             }
-            Err(_) => (ctypes::EPOLLERR, 0),
+            Err(_) => (ctypes::EPOLLERR, 0, false, false),
         }
     }
 
-    fn deliverable_events(&self, ready: u32, readiness_version: u64) -> u32 {
+    fn deliverable_events(
+        &self,
+        ready: u32,
+        readiness_version: u64,
+        readable: bool,
+        writable: bool,
+    ) -> u32 {
         if self.disabled {
             return 0;
         }
+        // Edge-triggered delivery tracks each event class independently.
+        //
+        // EPOLLIN is a read-readiness wake: driven by the file's read-readiness
+        // version (bumped on every read wake, e.g. each `eventfd` write, which
+        // the async waker path relies on) OR by a fresh false->true readability
+        // transition.
+        //
+        // EPOLLOUT is a writability transition only (false->true), independent
+        // of the read-readiness version. A `eventfd` write never makes the
+        // counter newly writable, so it must not spoof a writable edge -- a
+        // single shared version that gates both classes would re-fire EPOLLOUT
+        // on every write (see the review on the eventfd readiness PR).
+        //
+        // EPOLLERR / EPOLLHUP are always reported.
         let events = if self.is_edge_triggered() {
-            if readiness_version == self.last_readiness_version {
-                ready & !self.last_ready
-            } else {
-                ready
+            let epollin_edge = readable
+                && (!self.last_readable || readiness_version != self.last_readiness_version);
+            let epollout_edge = writable && !self.last_writable;
+            let mut e = ready & EPOLL_ERROR_EVENTS;
+            if epollin_edge {
+                e |= ready & EPOLL_READ_EVENTS;
             }
+            if epollout_edge {
+                e |= ready & EPOLL_WRITE_EVENTS;
+            }
+            e
         } else {
             ready
         };
@@ -183,10 +217,12 @@ impl EpollInstance {
                 break;
             }
 
-            let (ready, readiness_version) = watch.current_ready();
-            let deliverable = watch.deliverable_events(ready, readiness_version);
-            watch.last_ready = ready;
+            let (ready, readiness_version, readable, writable) = watch.current_ready();
+            let deliverable =
+                watch.deliverable_events(ready, readiness_version, readable, writable);
             watch.last_readiness_version = readiness_version;
+            watch.last_readable = readable;
+            watch.last_writable = writable;
             if deliverable == 0 {
                 continue;
             }
@@ -206,8 +242,8 @@ impl EpollInstance {
         let mut ready_list = self.events.lock();
         ready_list.retain(|_, watch| !watch.is_closed());
         ready_list.values().any(|watch| {
-            let (ready, readiness_version) = watch.current_ready();
-            watch.deliverable_events(ready, readiness_version) != 0
+            let (ready, readiness_version, readable, writable) = watch.current_ready();
+            watch.deliverable_events(ready, readiness_version, readable, writable) != 0
         })
     }
 }

--- a/os/arceos/api/arceos_posix_api/src/imp/io_mpx/epoll.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/io_mpx/epoll.rs
@@ -32,7 +32,8 @@ struct WatchedEvent {
     event: ctypes::epoll_event,
     last_readable: bool,
     last_writable: bool,
-    last_readiness_version: u64,
+    last_read_version: u64,
+    last_write_version: u64,
     disabled: bool,
 }
 
@@ -46,7 +47,8 @@ impl WatchedEvent {
             event,
             last_readable: false,
             last_writable: false,
-            last_readiness_version: 0,
+            last_read_version: 0,
+            last_write_version: 0,
             disabled: false,
         }
     }
@@ -56,7 +58,8 @@ impl WatchedEvent {
         self.event = event;
         self.last_readable = false;
         self.last_writable = false;
-        self.last_readiness_version = 0;
+        self.last_read_version = 0;
+        self.last_write_version = 0;
         self.disabled = false;
     }
 
@@ -72,9 +75,9 @@ impl WatchedEvent {
         self.event.events & ctypes::EPOLLONESHOT != 0
     }
 
-    fn current_ready(&self) -> (u32, u64, bool, bool) {
+    fn current_ready(&self) -> (u32, ax_io::PollState) {
         let Some(file) = self.file.upgrade() else {
-            return (0, 0, false, false);
+            return (0, ax_io::PollState::default());
         };
         match file.poll() {
             Ok(state) => {
@@ -86,24 +89,20 @@ impl WatchedEvent {
                 if state.writable {
                     ready |= interest & EPOLL_WRITE_EVENTS;
                 }
-                (
-                    ready,
-                    state.readiness_version,
-                    state.readable,
-                    state.writable,
-                )
+                (ready, state)
             }
-            Err(_) => (ctypes::EPOLLERR, 0, false, false),
+            Err(_) => (
+                ctypes::EPOLLERR,
+                ax_io::PollState {
+                    readable: false,
+                    writable: false,
+                    ..Default::default()
+                },
+            ),
         }
     }
 
-    fn deliverable_events(
-        &self,
-        ready: u32,
-        readiness_version: u64,
-        readable: bool,
-        writable: bool,
-    ) -> u32 {
+    fn deliverable_events(&self, ready: u32, state: ax_io::PollState) -> u32 {
         if self.disabled {
             return 0;
         }
@@ -114,17 +113,21 @@ impl WatchedEvent {
         // the async waker path relies on) OR by a fresh false->true readability
         // transition.
         //
-        // EPOLLOUT is a writability transition only (false->true), independent
-        // of the read-readiness version. A `eventfd` write never makes the
-        // counter newly writable, so it must not spoof a writable edge -- a
-        // single shared version that gates both classes would re-fire EPOLLOUT
-        // on every write (see the review on the eventfd readiness PR).
+        // EPOLLOUT mirrors it with the file's write-readiness version (bumped
+        // when writability changes, e.g. a pipe ring buffer going Full ->
+        // Normal) OR by a fresh false->true writability transition. The
+        // directions are independent: an `eventfd` write bumps only the read
+        // version, so it never spoofs a writable edge, and a single shared
+        // version gating both classes would re-fire EPOLLOUT on every write
+        // (see the review on the eventfd readiness PR).
         //
         // EPOLLERR / EPOLLHUP are always reported.
         let events = if self.is_edge_triggered() {
-            let epollin_edge = readable
-                && (!self.last_readable || readiness_version != self.last_readiness_version);
-            let epollout_edge = writable && !self.last_writable;
+            let epollin_edge = state.readable
+                && (!self.last_readable || state.read_readiness_version != self.last_read_version);
+            let epollout_edge = state.writable
+                && (!self.last_writable
+                    || state.write_readiness_version != self.last_write_version);
             let mut e = ready & EPOLL_ERROR_EVENTS;
             if epollin_edge {
                 e |= ready & EPOLL_READ_EVENTS;
@@ -217,12 +220,12 @@ impl EpollInstance {
                 break;
             }
 
-            let (ready, readiness_version, readable, writable) = watch.current_ready();
-            let deliverable =
-                watch.deliverable_events(ready, readiness_version, readable, writable);
-            watch.last_readiness_version = readiness_version;
-            watch.last_readable = readable;
-            watch.last_writable = writable;
+            let (ready, state) = watch.current_ready();
+            let deliverable = watch.deliverable_events(ready, state);
+            watch.last_read_version = state.read_readiness_version;
+            watch.last_write_version = state.write_readiness_version;
+            watch.last_readable = state.readable;
+            watch.last_writable = state.writable;
             if deliverable == 0 {
                 continue;
             }
@@ -242,8 +245,8 @@ impl EpollInstance {
         let mut ready_list = self.events.lock();
         ready_list.retain(|_, watch| !watch.is_closed());
         ready_list.values().any(|watch| {
-            let (ready, readiness_version, readable, writable) = watch.current_ready();
-            watch.deliverable_events(ready, readiness_version, readable, writable) != 0
+            let (ready, state) = watch.current_ready();
+            watch.deliverable_events(ready, state) != 0
         })
     }
 }
@@ -275,7 +278,8 @@ impl FileLike for EpollInstance {
         Ok(ax_io::PollState {
             readable: self.has_ready_events(),
             writable: false,
-            readiness_version: 0,
+            read_readiness_version: 0,
+            write_readiness_version: 0,
         })
     }
 

--- a/os/arceos/api/arceos_posix_api/src/imp/net.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/net.rs
@@ -233,7 +233,8 @@ fn poll_state(events: IoEvents) -> PollState {
     PollState {
         readable: events.intersects(IoEvents::IN | IoEvents::RDHUP | IoEvents::HUP),
         writable: events.contains(IoEvents::OUT),
-        readiness_version: 0,
+        read_readiness_version: 0,
+        write_readiness_version: 0,
     }
 }
 

--- a/os/arceos/api/arceos_posix_api/src/imp/pipe.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/pipe.rs
@@ -96,12 +96,12 @@ impl PipeRingBuffer {
         }
     }
 
-    pub const fn readiness_version(&self, readable_end: bool) -> u64 {
-        if readable_end {
-            self.read_readiness_version
-        } else {
-            self.write_readiness_version
-        }
+    pub const fn read_readiness_version(&self) -> u64 {
+        self.read_readiness_version
+    }
+
+    pub const fn write_readiness_version(&self) -> u64 {
+        self.write_readiness_version
     }
 }
 
@@ -228,7 +228,11 @@ impl FileLike for Pipe {
         Ok(PollState {
             readable: self.readable() && buf.available_read() > 0,
             writable: self.writable() && buf.available_write() > 0,
-            readiness_version: buf.readiness_version(self.readable()),
+            // Both ends report both directions: the shared ring buffer owns the
+            // readiness of the pipe as a whole, and the epoll edge logic keys
+            // each event class off its own direction's version.
+            read_readiness_version: buf.read_readiness_version(),
+            write_readiness_version: buf.write_readiness_version(),
         })
     }
 

--- a/os/arceos/api/arceos_posix_api/src/imp/stdio.rs
+++ b/os/arceos/api/arceos_posix_api/src/imp/stdio.rs
@@ -126,7 +126,8 @@ impl super::fd_ops::FileLike for Stdin {
         Ok(PollState {
             readable: true,
             writable: true,
-            readiness_version: 0,
+            read_readiness_version: 0,
+            write_readiness_version: 0,
         })
     }
 
@@ -163,7 +164,8 @@ impl super::fd_ops::FileLike for Stdout {
         Ok(PollState {
             readable: true,
             writable: true,
-            readiness_version: 0,
+            read_readiness_version: 0,
+            write_readiness_version: 0,
         })
     }
 

--- a/os/arceos/ulib/axstd/Cargo.toml
+++ b/os/arceos/ulib/axstd/Cargo.toml
@@ -96,6 +96,7 @@ dns = ["net"]
 fd = [
   "ax-posix-api/fd",
   "ax-posix-api/poll",
+  "ax-posix-api/pipe",
   "ax-posix-api/epoll",
   "ax-posix-api/eventfd",
 ]

--- a/os/arceos/ulib/axstd/src/os/libc_compat.rs
+++ b/os/arceos/ulib/axstd/src/os/libc_compat.rs
@@ -863,6 +863,28 @@ pub unsafe extern "C" fn eventfd(_initval: c_uint, _flags: c_int) -> c_int {
 /// # Safety
 ///
 /// Callers must uphold the Linux/musl ABI contract for this libc symbol.
+#[cfg(feature = "fd")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pipe(pipefd: *mut c_int) -> c_int {
+    if pipefd.is_null() {
+        return fail(Errno::EFAULT);
+    }
+    let fds = unsafe { core::slice::from_raw_parts_mut(pipefd, 2) };
+    ok_or_errno(ax_posix_api::sys_pipe(fds))
+}
+
+/// # Safety
+///
+/// Callers must uphold the Linux/musl ABI contract for this libc symbol.
+#[cfg(not(feature = "fd"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pipe(_pipefd: *mut c_int) -> c_int {
+    fail(Errno::ENOSYS)
+}
+
+/// # Safety
+///
+/// Callers must uphold the Linux/musl ABI contract for this libc symbol.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn isatty(_fd: c_int) -> c_int {
     fail(Errno::ENOTTY)

--- a/test-suit/arceos/c/c/pipe_epoll.c
+++ b/test-suit/arceos/c/c/pipe_epoll.c
@@ -7,6 +7,9 @@
 #include <sys/epoll.h>
 #include <unistd.h>
 
+/* Upper bound for the fill loop: the probe stops as soon as the pipe is full. */
+#define PIPE_FILL_LIMIT 4096
+
 static struct epoll_event make_event(uint32_t events, int fd)
 {
     struct epoll_event event;
@@ -192,6 +195,72 @@ static int test_edge_triggered_epoll(int epfd, int read_fd, int write_fd, char *
     return expect_no_event(epfd, reason, reason_len);
 }
 
+/*
+ * A write that overflows the pipe blocks until a reader drains it, so the fill
+ * loop probes writability with a level-triggered `EPOLLOUT` watch on a throwaway
+ * epoll instance instead of assuming a pipe capacity.
+ */
+static int fill_pipe_until_full(int probe_epfd, int write_fd, char *reason, size_t reason_len)
+{
+    struct epoll_event event = make_event(EPOLLOUT, write_fd);
+    struct epoll_event ready;
+    int i;
+
+    CHECK_RET(epoll_ctl(probe_epfd, EPOLL_CTL_ADD, write_fd, &event), 0);
+    for (i = 0; i < PIPE_FILL_LIMIT; i++) {
+        memset(&ready, 0, sizeof(ready));
+        if (epoll_wait(probe_epfd, &ready, 1, 0) == 0) {
+            CHECK_RET(epoll_ctl(probe_epfd, EPOLL_CTL_DEL, write_fd, NULL), 0);
+            return 0;
+        }
+        CHECK_RET(write(write_fd, "x", 1), 1);
+    }
+    test_fail(reason, reason_len, "pipe still writable after %d bytes", PIPE_FILL_LIMIT);
+    return -1;
+}
+
+/*
+ * An edge-triggered `EPOLLOUT` watch on the write end must report the
+ * Full -> Normal transition even when the pipe is filled and drained between two
+ * `epoll_wait` calls: no wait observes the Full state, so a delivery rule that
+ * only compares the previously sampled writability drops the edge and leaves a
+ * writer waiting for a wake that never comes.
+ */
+static int test_edge_triggered_epollout(int epfd, int read_fd, int write_fd, char *reason,
+                                        size_t reason_len)
+{
+    char buf[1];
+    struct epoll_event event = make_event(EPOLLOUT | EPOLLET, write_fd);
+    int probe_epfd;
+
+    CHECK_RET(epoll_ctl(epfd, EPOLL_CTL_ADD, write_fd, &event), 0);
+    if (expect_one_event(epfd, EPOLLOUT, write_fd, reason, reason_len) != 0) {
+        return -1;
+    }
+    if (expect_no_event(epfd, reason, reason_len) != 0) {
+        return -1;
+    }
+
+    probe_epfd = epoll_create(1);
+    CHECK_TRUE(probe_epfd >= 0);
+    if (fill_pipe_until_full(probe_epfd, write_fd, reason, reason_len) != 0) {
+        close(probe_epfd);
+        return -1;
+    }
+    close(probe_epfd);
+
+    /* Full -> Normal with no wait in between: the writable edge must survive. */
+    CHECK_RET(read(read_fd, buf, 1), 1);
+    if (expect_one_event(epfd, EPOLLOUT, write_fd, reason, reason_len) != 0) {
+        return -1;
+    }
+    if (expect_no_event(epfd, reason, reason_len) != 0) {
+        return -1;
+    }
+    CHECK_RET(epoll_ctl(epfd, EPOLL_CTL_DEL, write_fd, NULL), 0);
+    return 0;
+}
+
 static int test_oneshot_epoll(int epfd, int read_fd, int write_fd, char *reason,
                               size_t reason_len)
 {
@@ -257,6 +326,7 @@ int arceos_c_test_epoll(char *reason, size_t reason_len)
     if (test_level_triggered_epoll(epfd, pipefd[1], reason, reason_len) != 0 ||
         test_edge_triggered_epoll(epfd, pipefd[0], pipefd[1], reason, reason_len) != 0 ||
         test_oneshot_epoll(epfd, pipefd[0], pipefd[1], reason, reason_len) != 0 ||
+        test_edge_triggered_epollout(epfd, pipefd[0], pipefd[1], reason, reason_len) != 0 ||
         test_registered_fd_close(reason, reason_len) != 0) {
         close(pipefd[0]);
         close(pipefd[1]);

--- a/test-suit/arceos/rust/src/io_mpx/eventfd.rs
+++ b/test-suit/arceos/rust/src/io_mpx/eventfd.rs
@@ -357,6 +357,70 @@ fn test_write_does_not_spoof_writable_edge() {
     );
 }
 
+/// A writability edge that appears between two waits must still be delivered.
+///
+/// `test_saturated_read_is_a_writable_edge` drains the counter while the watch
+/// still remembers an unwritable sample, so a plain `writable && !last_writable`
+/// rule reports it. Here the initial writable edge is consumed first, then the
+/// counter is saturated and drained again without any wait in between: both
+/// samples are `true`, so only a writable readiness generation that advances on
+/// the Full -> Normal transition can report the edge. The same shape is what a
+/// pipe write end sees when a reader frees space between two `epoll_wait`
+/// calls.
+fn test_writable_edge_between_waits_is_reported() {
+    let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
+    let fd = syscalls::eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK)
+        .expect("create semaphore eventfd failed");
+
+    let mut interest = EpollEvent {
+        events: EPOLLOUT | EPOLLET,
+        data: 0,
+    };
+    syscalls::epoll_ctl(epfd, EPOLL_CTL_ADD, fd, Some(&mut interest))
+        .expect("epoll_ctl ADD failed");
+
+    // The counter starts writable, so the initial edge is reported and consumed.
+    let mut ready = [EpollEvent::default(); 4];
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        1,
+        "the initial writable edge must be reported"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        0,
+        "the initial writable edge must be reported once"
+    );
+
+    // Saturate the counter, then drain one unit: writability goes
+    // true -> false -> true with no wait observing the false sample.
+    assert_eq!(
+        syscalls::write_u64(fd, u64::MAX - 1).unwrap(),
+        8,
+        "write must return 8"
+    );
+    assert_eq!(
+        syscalls::read_u64(fd).unwrap(),
+        1,
+        "semaphore read must return 1"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        1,
+        "a writable edge between two waits must not be dropped"
+    );
+    assert_eq!(
+        ready[0].events & EPOLLOUT,
+        EPOLLOUT,
+        "the event must carry EPOLLOUT"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        0,
+        "the writable edge must be reported once"
+    );
+}
+
 /// A stream of wakes: every write in a long sequence must surface an edge.
 ///
 /// `mio::Waker` usage is not two writes but the whole lifetime of a runtime:
@@ -402,6 +466,7 @@ pub fn run() -> crate::TestResult {
     test_counter_overflow_eagain();
     test_every_write_is_a_readiness_edge();
     test_saturated_read_is_a_writable_edge();
+    test_writable_edge_between_waits_is_reported();
     test_write_does_not_spoof_writable_edge();
     test_write_stream_delivers_every_wake();
     println!("io_mpx: eventfd unit tests OK");

--- a/test-suit/arceos/rust/src/io_mpx/eventfd.rs
+++ b/test-suit/arceos/rust/src/io_mpx/eventfd.rs
@@ -8,6 +8,9 @@
 //!   by one for `EFD_SEMAPHORE`);
 //! - a write adds an 8-byte value to the counter, rejecting `UINT64_MAX` with
 //!   `EINVAL` and overflowing writes with `EAGAIN` (nonblocking);
+//! - every accepted write is a readiness edge for an edge-triggered `epoll`
+//!   watch, not only the write that first makes the counter non-zero (see
+//!   `test_every_write_is_a_readiness_edge`);
 //! - reads/writes with a buffer smaller than 8 bytes fail with `EINVAL`;
 //! - unknown creation flags fail with `EINVAL`.
 //!
@@ -17,7 +20,7 @@
 use core::ffi::c_int;
 use std::println;
 
-use super::syscalls::{self, assert_errno};
+use super::syscalls::{self, EpollEvent, assert_errno};
 
 /// `EFD_SEMAPHORE` = 1.
 const EFD_SEMAPHORE: c_int = 1;
@@ -28,6 +31,15 @@ const EFD_NONBLOCK: c_int = 0o4000;
 
 const EINVAL: c_int = 22;
 const EAGAIN: c_int = 11;
+
+/// `EPOLLIN` = 0x001.
+const EPOLLIN: u32 = 0x001;
+/// `EPOLLOUT` = 0x004.
+const EPOLLOUT: u32 = 0x004;
+/// `EPOLLET` = `1 << 31`, requesting edge-triggered delivery.
+const EPOLLET: u32 = 1 << 31;
+/// `EPOLL_CTL_ADD` = 1.
+const EPOLL_CTL_ADD: c_int = 1;
 
 fn test_create_and_flag_validation() {
     let fd = syscalls::eventfd(0, 0).expect("eventfd(0, 0) failed");
@@ -174,6 +186,161 @@ fn test_counter_overflow_eagain() {
     );
 }
 
+/// Every accepted write is a readiness edge, not only the one that makes the
+/// counter non-zero.
+///
+/// Linux `eventfd_write` calls `wake_up_locked_poll(&ctx->wqh, EPOLLIN)` on
+/// every write (`fs/eventfd.c`), so a poller must observe one readiness edge
+/// per write. This is how an async runtime uses its `mio::Waker` eventfd: the
+/// runtime never drains the counter, so an implementation that bumps readiness
+/// only when readability flips delivers the first wake and drops every later
+/// one, hanging the second and all subsequent `spawn_blocking` calls behind an
+/// `epoll_wait` that never returns.
+///
+/// `epoll_wait` is called with `timeout = 0`, so a lost edge shows up as a
+/// deterministic "zero events" result instead of blocking the cooperative
+/// scheduler.
+fn test_every_write_is_a_readiness_edge() {
+    let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
+    let fd = syscalls::eventfd(0, EFD_NONBLOCK).expect("create nonblocking eventfd failed");
+
+    let mut interest = EpollEvent {
+        events: EPOLLIN | EPOLLET,
+        data: 0,
+    };
+    syscalls::epoll_ctl(epfd, EPOLL_CTL_ADD, fd, Some(&mut interest))
+        .expect("epoll_ctl ADD failed");
+
+    let mut ready = [EpollEvent::default(); 4];
+
+    // First write: the counter goes 0 -> 1, so the fd becomes readable. This
+    // edge is reported whether or not readiness tracks the readability flip.
+    assert_eq!(
+        syscalls::write_u64(fd, 1).unwrap(),
+        8,
+        "write must return 8"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        1,
+        "the first write must surface EPOLLIN"
+    );
+    assert_eq!(
+        ready[0].events & EPOLLIN,
+        EPOLLIN,
+        "the first event must carry EPOLLIN"
+    );
+
+    // Second write with the counter left undrained: it merely grows 1 -> 2, so
+    // readability never flips. Linux still wakes the poller, so the event has
+    // to be reported again.
+    assert_eq!(
+        syscalls::write_u64(fd, 1).unwrap(),
+        8,
+        "write must return 8"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        1,
+        "every write must be a readiness edge, not only the one that flips readability"
+    );
+    assert_eq!(
+        ready[0].events & EPOLLIN,
+        EPOLLIN,
+        "the second event must carry EPOLLIN"
+    );
+}
+
+/// Draining a saturated counter is a writability edge for an edge-triggered
+/// `EPOLLOUT` watch.
+///
+/// `poll()` reports `writable = counter < u64::MAX - 1`, so the only read that
+/// changes writability is one that drains a counter saturated at `u64::MAX - 1`
+/// (the ceiling Linux leaves below the `count == ULLONG_MAX` `EPOLLERR` state).
+/// Reaching saturation requires an accepted write, which always bumps the
+/// readiness version, so the drain's `EPOLLOUT` edge is reported either through
+/// the version change or, when a wait already consumed it, through the
+/// `ready & !last_ready` fallback of the edge-triggered delivery path.
+fn test_saturated_read_is_a_writable_edge() {
+    let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
+    let fd = syscalls::eventfd(0, EFD_SEMAPHORE | EFD_NONBLOCK)
+        .expect("create semaphore eventfd failed");
+
+    let mut interest = EpollEvent {
+        events: EPOLLOUT | EPOLLET,
+        data: 0,
+    };
+    syscalls::epoll_ctl(epfd, EPOLL_CTL_ADD, fd, Some(&mut interest))
+        .expect("epoll_ctl ADD failed");
+
+    // Saturate the counter at u64::MAX - 1: writability flips false, and the
+    // accepted write itself is a readiness edge consumed by the first wait.
+    assert_eq!(
+        syscalls::write_u64(fd, u64::MAX - 1).unwrap(),
+        8,
+        "write must return 8"
+    );
+    let mut ready = [EpollEvent::default(); 4];
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        0,
+        "a saturated counter is not writable"
+    );
+
+    // A semaphore read drains one unit: u64::MAX - 1 -> u64::MAX - 2, which
+    // flips writability back to true. The EPOLLOUT edge must be reported even
+    // though no write bumps the version in between.
+    assert_eq!(
+        syscalls::read_u64(fd).unwrap(),
+        1,
+        "semaphore read must return 1"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        1,
+        "draining a saturated counter must surface EPOLLOUT"
+    );
+    assert_eq!(
+        ready[0].events & EPOLLOUT,
+        EPOLLOUT,
+        "the event must carry EPOLLOUT"
+    );
+}
+
+/// A stream of wakes: every write in a long sequence must surface an edge.
+///
+/// `mio::Waker` usage is not two writes but the whole lifetime of a runtime:
+/// every `wake()` is a write and every one must be observed by `epoll_wait`.
+/// A single-shot test can only catch "the first wake is lost"; this loop also
+/// catches any delivery that drops, batches, or skips alternating wakes.
+fn test_write_stream_delivers_every_wake() {
+    const WAKES: usize = 256;
+    let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
+    let fd = syscalls::eventfd(0, EFD_NONBLOCK).expect("create nonblocking eventfd failed");
+
+    let mut interest = EpollEvent {
+        events: EPOLLIN | EPOLLET,
+        data: 0,
+    };
+    syscalls::epoll_ctl(epfd, EPOLL_CTL_ADD, fd, Some(&mut interest))
+        .expect("epoll_ctl ADD failed");
+
+    let mut ready = [EpollEvent::default(); 4];
+    for i in 0..WAKES {
+        assert_eq!(
+            syscalls::write_u64(fd, 1).unwrap(),
+            8,
+            "write {i} must return 8"
+        );
+        assert_eq!(
+            syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+            1,
+            "write {i} must surface an edge"
+        );
+        assert_ne!(ready[0].events & EPOLLIN, 0, "write {i} must carry EPOLLIN");
+    }
+}
+
 pub fn run() -> crate::TestResult {
     test_create_and_flag_validation();
     test_read_empty_nonblocking_eagain();
@@ -183,6 +350,9 @@ pub fn run() -> crate::TestResult {
     test_semaphore_decrements_one_at_a_time();
     test_write_u64_max_einval();
     test_counter_overflow_eagain();
+    test_every_write_is_a_readiness_edge();
+    test_saturated_read_is_a_writable_edge();
+    test_write_stream_delivers_every_wake();
     println!("io_mpx: eventfd unit tests OK");
     Ok(())
 }

--- a/test-suit/arceos/rust/src/io_mpx/eventfd.rs
+++ b/test-suit/arceos/rust/src/io_mpx/eventfd.rs
@@ -307,6 +307,56 @@ fn test_saturated_read_is_a_writable_edge() {
     );
 }
 
+/// A write must not spoof a writable edge for an `EPOLLOUT` edge-triggered watch.
+///
+/// `EventFd::write` bumps the shared readiness version on every accepted write
+/// so an edge-triggered `EPOLLIN` watcher observes one edge per write (the
+/// async waker path needs this). But the version is a read-readiness signal: a
+/// write does not make the counter newly writable, so an `EPOLLOUT` watcher must
+/// not see a spurious edge. Linux only reports a writable edge when writability
+/// flips false -> true (a drain from the saturation ceiling), never on a plain
+/// write. This guards the regression where a single version gated both classes
+/// and re-fired EPOLLOUT on every write.
+fn test_write_does_not_spoof_writable_edge() {
+    let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
+    let fd = syscalls::eventfd(0, EFD_NONBLOCK).expect("create nonblocking eventfd failed");
+
+    let mut interest = EpollEvent {
+        events: EPOLLOUT | EPOLLET,
+        data: 0,
+    };
+    syscalls::epoll_ctl(epfd, EPOLL_CTL_ADD, fd, Some(&mut interest))
+        .expect("epoll_ctl ADD failed");
+
+    // The freshly created counter is writable (0 < u64::MAX - 1), so the
+    // initial writable edge is reported and consumed.
+    let mut ready = [EpollEvent::default(); 4];
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        1,
+        "the initial writable edge must be reported"
+    );
+    assert_eq!(
+        ready[0].events & EPOLLOUT,
+        EPOLLOUT,
+        "the initial edge must carry EPOLLOUT"
+    );
+
+    // A write grows the counter 0 -> 1. Writability is unchanged (still true),
+    // so no new EPOLLOUT edge. A version-only design would wrongly re-deliver
+    // EPOLLOUT here because the write bumps the shared readiness version.
+    assert_eq!(
+        syscalls::write_u64(fd, 1).unwrap(),
+        8,
+        "write must return 8"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        0,
+        "a write must not spoof a writable edge for an EPOLLOUT watch"
+    );
+}
+
 /// A stream of wakes: every write in a long sequence must surface an edge.
 ///
 /// `mio::Waker` usage is not two writes but the whole lifetime of a runtime:
@@ -352,6 +402,7 @@ pub fn run() -> crate::TestResult {
     test_counter_overflow_eagain();
     test_every_write_is_a_readiness_edge();
     test_saturated_read_is_a_writable_edge();
+    test_write_does_not_spoof_writable_edge();
     test_write_stream_delivers_every_wake();
     println!("io_mpx: eventfd unit tests OK");
     Ok(())

--- a/test-suit/arceos/rust/src/io_mpx/mod.rs
+++ b/test-suit/arceos/rust/src/io_mpx/mod.rs
@@ -1,12 +1,14 @@
-//! I/O multiplexing primitives: `eventfd` unit tests and an `epoll` smoke
-//! test. These cover the syscall surface that async runtimes (e.g. tokio/mio)
-//! need to drive timers and wake-ups on ArceOS.
+//! I/O multiplexing primitives: `eventfd` and `pipe` unit tests plus an
+//! `epoll` smoke test. These cover the syscall surface that async runtimes
+//! (e.g. tokio/mio) need to drive timers and wake-ups on ArceOS.
 
 mod epoll;
 mod eventfd;
+mod pipe;
 mod syscalls;
 
 pub fn run() -> crate::TestResult {
+    pipe::run()?;
     eventfd::run()?;
     epoll::run()?;
     Ok(())

--- a/test-suit/arceos/rust/src/io_mpx/pipe.rs
+++ b/test-suit/arceos/rust/src/io_mpx/pipe.rs
@@ -1,0 +1,146 @@
+//! `pipe` + `epoll` unit tests.
+//!
+//! These cover the write-end readiness contract that an edge-triggered
+//! `EPOLLOUT` watcher relies on:
+//!
+//! - the write end is writable while the ring buffer has free space and stops
+//!   being writable when it is full;
+//! - the `Full -> Normal` transition must surface as an `EPOLLOUT` edge even
+//!   when it happens between two `epoll_wait` calls, so that no wait ever
+//!   samples the unwritable state.
+//!
+//! A write that overflows the pipe blocks until a reader drains it, so the
+//! fill loop probes writability with a level-triggered `EPOLLOUT` watch on a
+//! throwaway epoll instance instead of assuming a pipe capacity.
+
+use core::ffi::c_int;
+use std::println;
+
+use super::syscalls::{self, EpollEvent};
+
+/// `EPOLLOUT` = 0x004.
+const EPOLLOUT: u32 = 0x004;
+/// `EPOLLET` = `1 << 31`, requesting edge-triggered delivery.
+const EPOLLET: u32 = 1 << 31;
+/// `EPOLL_CTL_ADD` = 1.
+const EPOLL_CTL_ADD: c_int = 1;
+/// `EPOLL_CTL_DEL` = 2.
+const EPOLL_CTL_DEL: c_int = 2;
+
+/// Upper bound for the fill loop: the probe stops as soon as the pipe is full.
+const PIPE_FILL_LIMIT: usize = 4096;
+
+fn test_write_end_is_writable_until_full() {
+    let (read_fd, write_fd) = syscalls::pipe().expect("pipe() failed");
+
+    let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
+    let mut interest = EpollEvent {
+        events: EPOLLOUT,
+        data: 0,
+    };
+    syscalls::epoll_ctl(epfd, EPOLL_CTL_ADD, write_fd, Some(&mut interest))
+        .expect("epoll_ctl ADD failed");
+
+    // Level-triggered: the write end must stay reportable while space remains.
+    let mut ready = [EpollEvent::default(); 4];
+    for i in 0..PIPE_FILL_LIMIT {
+        let n = syscalls::epoll_wait(epfd, &mut ready, 0).expect("epoll_wait failed");
+        if n == 0 {
+            // The pipe is full after exactly the writes issued so far.
+            syscalls::epoll_ctl(epfd, EPOLL_CTL_DEL, write_fd, None).expect("epoll_ctl DEL failed");
+            println!("pipe filled after {i} bytes");
+            return;
+        }
+        assert_eq!(
+            syscalls::write(write_fd, b"x").expect("write to pipe failed"),
+            1,
+            "each fill write must enqueue one byte"
+        );
+    }
+    syscalls::epoll_ctl(epfd, EPOLL_CTL_DEL, write_fd, None).expect("epoll_ctl DEL failed");
+    panic!("pipe still writable after {PIPE_FILL_LIMIT} bytes");
+}
+
+/// The `Full -> Normal` writability transition must be delivered even when it
+/// happens between two waits.
+///
+/// The initial writable edge is consumed first, then the pipe is filled and one
+/// byte is drained before the next `epoll_wait`: both surrounding samples are
+/// writable, so a delivery rule that only compares the previously sampled
+/// writability drops the edge and leaves a writer waiting for a wake that
+/// never comes.
+fn test_writable_edge_between_waits_is_reported() {
+    let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
+    let (read_fd, write_fd) = syscalls::pipe().expect("pipe() failed");
+
+    let mut interest = EpollEvent {
+        events: EPOLLOUT | EPOLLET,
+        data: 0,
+    };
+    syscalls::epoll_ctl(epfd, EPOLL_CTL_ADD, write_fd, Some(&mut interest))
+        .expect("epoll_ctl ADD failed");
+
+    // The write end starts writable, so the initial edge is reported once.
+    let mut ready = [EpollEvent::default(); 4];
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        1,
+        "the initial writable edge must be reported"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        0,
+        "the initial writable edge must be reported once"
+    );
+
+    // Fill the pipe, sampling writability only through the throwaway level
+    // probe: the watched instance must not observe the unwritable state.
+    let probe = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
+    let mut probe_interest = EpollEvent {
+        events: EPOLLOUT,
+        data: 0,
+    };
+    syscalls::epoll_ctl(probe, EPOLL_CTL_ADD, write_fd, Some(&mut probe_interest))
+        .expect("epoll_ctl ADD on probe failed");
+    for _ in 0..PIPE_FILL_LIMIT {
+        if syscalls::epoll_wait(probe, &mut ready, 0).unwrap() == 0 {
+            break;
+        }
+        assert_eq!(
+            syscalls::write(write_fd, b"x").expect("write to pipe failed"),
+            1,
+            "each fill write must enqueue one byte"
+        );
+    }
+    syscalls::epoll_ctl(probe, EPOLL_CTL_DEL, write_fd, None).expect("epoll_ctl DEL failed");
+
+    // Full -> Normal with no wait in between: the writable edge must survive.
+    let mut buf = [0u8; 1];
+    assert_eq!(
+        syscalls::read(read_fd, &mut buf).expect("read from pipe failed"),
+        1,
+        "the drain must free exactly one byte"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        1,
+        "a writable edge between two waits must not be dropped"
+    );
+    assert_eq!(
+        ready[0].events & EPOLLOUT,
+        EPOLLOUT,
+        "the event must carry EPOLLOUT"
+    );
+    assert_eq!(
+        syscalls::epoll_wait(epfd, &mut ready, 0).unwrap(),
+        0,
+        "the writable edge must be reported once"
+    );
+}
+
+pub fn run() -> crate::TestResult {
+    test_write_end_is_writable_until_full();
+    test_writable_edge_between_waits_is_reported();
+    println!("io_mpx: pipe unit tests OK");
+    Ok(())
+}

--- a/test-suit/arceos/rust/src/io_mpx/pipe.rs
+++ b/test-suit/arceos/rust/src/io_mpx/pipe.rs
@@ -31,7 +31,8 @@ const EPOLL_CTL_DEL: c_int = 2;
 const PIPE_FILL_LIMIT: usize = 4096;
 
 fn test_write_end_is_writable_until_full() {
-    let (read_fd, write_fd) = syscalls::pipe().expect("pipe() failed");
+    // This test only exercises the write end; the read end is never drained.
+    let (_, write_fd) = syscalls::pipe().expect("pipe() failed");
 
     let epfd = syscalls::epoll_create1(0).expect("epoll_create1(0) failed");
     let mut interest = EpollEvent {

--- a/test-suit/arceos/rust/src/io_mpx/syscalls.rs
+++ b/test-suit/arceos/rust/src/io_mpx/syscalls.rs
@@ -43,6 +43,7 @@ mod raw {
 
     unsafe extern "C" {
         pub(super) fn eventfd(initval: u32, flags: c_int) -> c_int;
+        pub(super) fn pipe(pipefd: *mut c_int) -> c_int;
         pub(super) fn epoll_create1(flags: c_int) -> c_int;
         pub(super) fn epoll_ctl(epfd: c_int, op: c_int, fd: c_int, event: *mut EpollEvent)
         -> c_int;
@@ -81,6 +82,13 @@ fn io_syscall(result: isize) -> Result<usize, c_int> {
 
 pub fn eventfd(initval: u32, flags: c_int) -> Result<c_int, c_int> {
     fd_syscall(unsafe { raw::eventfd(initval, flags) })
+}
+
+/// Creates a pipe and returns `(read_fd, write_fd)`.
+pub fn pipe() -> Result<(c_int, c_int), c_int> {
+    let mut fds = [0 as c_int; 2];
+    fd_syscall(unsafe { raw::pipe(fds.as_mut_ptr()) })?;
+    Ok((fds[0], fds[1]))
 }
 
 pub fn epoll_create1(flags: c_int) -> Result<c_int, c_int> {


### PR DESCRIPTION
## 要解决的问题

本 PR 最初修复 eventfd 写唤醒丢失问题（#1887 的后续）：`EventFd::write` 只在 counter 0→非 0 时推进就绪版本号，counter 已非 0 时的再次写不产生边沿，`mio::Waker`（从不 drain counter）第二次及以后的 wake 全部丢失。

后续审查发现同源的第二处缺陷：边沿触发投递路径的 `epollout_edge` 只依赖采样布尔（`writable && !last_writable`），两次 `epoll_wait` 之间发生又消失的可写边沿会被丢弃。具体场景：pipe 写端先被采样为可写（初始边沿被消费），随后管道被填满、又在下一次等待前排空 1 字节——前后两次采样都是 `true`，`Full → Normal` 的真实可写边沿到不了 `EPOLLOUT | EPOLLET` 等待者，写方会等一个不会来的唤醒。读方向此前已由版本号驱动，只有写方向缺失。

## 改动

1. eventfd 写唤醒（前两个提交）：
   - `EventFd::write` 每次 accepted write 都推进读方向就绪版本号，对齐 Linux「每次写都是 wake」语义（fs/eventfd.c 的 `wake_up_locked_poll(&ctx->wqh, EPOLLIN)`）；
   - `epoll.rs` 边沿投递把 EPOLLIN 与 EPOLLOUT 拆成独立边沿类，EPOLLERR/EPOLLHUP 始终上报。
2. 可写边沿生成号（后两个提交）：
   - `axio::PollState` 就绪版本号按方向拆分为 `read_readiness_version` / `write_readiness_version`，与 `PipeRingBuffer` 内部已有的按方向命名一致；
   - `pipe.rs` 两端上报共享环形缓冲的两个方向生成号，删除按端选择的 `readiness_version(readable_end)`；
   - `eventfd.rs` 新增可写生成号，仅在可写性真正翻转时递增（写入触及 `u64::MAX - 1` 饱和上限，或从上限排空）；
   - `epoll.rs` EPOLLOUT 边沿与 EPOLLIN 对称：可写且（`false → true` 跃迁或可写生成号变化）。

## 每一步的逻辑

- 边沿投递必须能表达「两次等待之间发生过的状态变化」，布尔采样做不到，单调生成号可以；读方向此前已如此，写方向补齐即可，投递结构不变。
- 两个方向保持独立是关键：共享一个版本号会让 eventfd 的每次写唤醒重新触发 EPOLLOUT（Linux 不会产生），而「只在可写性翻转时推进可写生成号」同时满足 pipe `Full → Normal` 边沿不丢与普通写不伪造 EPOLLOUT 这两个看似冲突的约束。
- 测试必须遵守「填满与排空之间不插入等待」：`poll_all` 每次扫描都会刷新 `last_writable`，中间等待一次就会让旧的布尔判定重新命中并掩盖 bug；审查给出的正是「两次等待之间」的场景。

## 测试与验证

新增确定性回归（`epoll_wait` 均用 `timeout=0`，丢边沿表现为确定性「零事件」断言失败而非挂起调度器）：

- Rust 层新增 `io_mpx/pipe.rs`：pipe 写端 `EPOLLOUT | EPOLLET` 必须上报两次等待之间的 `Full → Normal` 边沿；填满循环用一次性 level-triggered `EPOLLOUT` 探针探测可写性而非硬编码管道容量（溢出写入会阻塞直至读方排空）；另含写端可写性直到填满的 level 检查。
- C 层 `pipe_epoll.c` 的 epoll 用例加入同一场景。
- Rust 层 `eventfd.rs` 新增 `test_writable_edge_between_waits_is_reported`：饱和后排空 1 单元，边沿必须上报；counter 满时等待仍须零事件。
- 为让 std 测试层能触达 pipe 路径，axstd libc-compat 暴露 `pipe` 符号，`ax-std` 的 `fd` 特性启用 `ax-posix-api/pipe`。

实验验证：

- 两个新测试在未修复 head 上失败（`a writable edge between two waits must not be dropped`，left: 0, right: 1），修复后通过；原有 eventfd 唤醒流（256 轮）与防伪造测试仍通过。
- `cargo xtask arceos test qemu --test-group rust --test-case eventfd-epoll` PASS。
- `cargo xtask clippy`（ax-io / ax-posix-api / ax-api / ax-std，64 项）与 `cargo xtask test` 全部通过；`cargo fmt` 已运行。
- C 层用例本机缺 `x86_64-linux-musl-gcc` 无法构建，由 CI 覆盖（本机已用 `gcc -fsyntax-only` 语法检查，无新增告警）。
