### PR TITLE
fix(ax-cpu): preserve AArch64 PTE memory type

### DIFF
--- a/components/axcpu/Cargo.toml
+++ b/components/axcpu/Cargo.toml
@@ -56,6 +56,11 @@ riscv.workspace = true
 
 [target.'cfg(target_arch = "loongarch64")'.dependencies]
 loongArch64 = "0.2"
+
+[dev-dependencies]
+aarch64-cpu = "11.0"
+tock-registers = "0.10"
+
 [lints.clippy]
 new_without_default = "allow"
 

--- a/components/axcpu/src/aarch64/paging.rs
+++ b/components/axcpu/src/aarch64/paging.rs
@@ -76,7 +76,11 @@ impl A64Pte {
     const PHYS_ADDR_MASK: u64 = 0x0000_ffff_ffff_f000;
 
     fn attr(self) -> A64DescriptorAttr {
-        A64DescriptorAttr::from_bits_truncate(self.0)
+        // AttrIndx[2:0] occupies bits 4:2 but is decoded as a numeric field,
+        // not as named bitflags. Retain those bits so querying a Normal PTE
+        // cannot silently turn it into Device memory when its flags are reused.
+        let attr_mask = A64DescriptorAttr::all().bits() | A64DescriptorAttr::ATTR_INDEX_MASK;
+        A64DescriptorAttr::from_bits_retain(self.0 & attr_mask)
     }
 
     fn leaf_attr(config: MappingFlags) -> A64DescriptorAttr {

--- a/components/axcpu/src/aarch64/paging.rs
+++ b/components/axcpu/src/aarch64/paging.rs
@@ -56,14 +56,16 @@ impl A64DescriptorAttr {
         Self::from_bits_retain(bits)
     }
 
-    const fn mem_attr(self) -> Option<A64MemAttr> {
+    const fn mem_attr(self) -> A64MemAttr {
         let idx = (self.bits() & Self::ATTR_INDEX_MASK) >> 2;
-        Some(match idx {
-            0 => A64MemAttr::Device,
+        match idx {
             1 => A64MemAttr::Normal,
             2 => A64MemAttr::NormalNonCacheable,
-            _ => return None,
-        })
+            // MAIR slots 3..7 are left at zero by `MAIR_VALUE`, which is a
+            // Device-nGnRnE encoding. Decode them conservatively as Device
+            // instead of silently treating an unsupported index as Normal.
+            _ => A64MemAttr::Device,
+        }
     }
 }
 
@@ -74,6 +76,14 @@ pub struct A64Pte(u64);
 
 impl A64Pte {
     const PHYS_ADDR_MASK: u64 = 0x0000_ffff_ffff_f000;
+
+    #[cfg(test)]
+    pub(crate) fn with_attr_index(mut self, index: u64) -> Self {
+        assert!(index < 8);
+        self.0 &= !A64DescriptorAttr::ATTR_INDEX_MASK;
+        self.0 |= index << 2;
+        self
+    }
 
     fn attr(self) -> A64DescriptorAttr {
         // AttrIndx[2:0] occupies bits 4:2 but is decoded as a numeric field,
@@ -164,9 +174,9 @@ impl PageTableEntry for A64Pte {
             !attr.contains(A64DescriptorAttr::AP_RO),
         );
         match attr.mem_attr() {
-            Some(A64MemAttr::Device) => config |= MappingFlags::DEVICE,
-            Some(A64MemAttr::NormalNonCacheable) => config |= MappingFlags::UNCACHED,
-            _ => {}
+            A64MemAttr::Device => config |= MappingFlags::DEVICE,
+            A64MemAttr::Normal => {}
+            A64MemAttr::NormalNonCacheable => config |= MappingFlags::UNCACHED,
         }
         #[cfg(not(feature = "arm-el2"))]
         {

--- a/components/axcpu/tests/paging.rs
+++ b/components/axcpu/tests/paging.rs
@@ -8,6 +8,12 @@ mod paging {
     dead_code,
     reason = "the host adapter exercises PTE behavior without architecture initialization"
 )]
+#[path = "../src/aarch64/paging.rs"]
+mod aarch64_paging;
+#[expect(
+    dead_code,
+    reason = "the host adapter exercises PTE behavior without architecture initialization"
+)]
 #[path = "../src/loongarch64/paging.rs"]
 mod loongarch64_paging;
 #[expect(
@@ -17,6 +23,7 @@ mod loongarch64_paging;
 #[path = "../src/riscv/paging.rs"]
 mod riscv_paging;
 
+use aarch64_paging::A64Pte;
 use ax_cpu::trap::PageFaultFlags;
 use ax_memory_addr::{PAGE_SIZE_4K, PhysAddr};
 use loongarch64_paging::La64Pte;
@@ -36,6 +43,30 @@ fn page_fault_access_converts_to_mapping_permissions() {
         MappingFlags::from(access),
         MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER
     );
+}
+
+#[test]
+fn aarch64_relocated_normal_leaf_preserves_memory_type() {
+    let source_paddr = PhysAddr::from_usize(0x1_81ea_5000);
+    let target_paddr = PhysAddr::from_usize(0x1_8200_0000);
+    let flags = MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER;
+    let source_pte = A64Pte::new_page(source_paddr, flags, false);
+    let queried_flags = source_pte.config(false);
+    let target_pte = A64Pte::new_page(target_paddr, queried_flags, false);
+
+    assert_eq!(queried_flags, flags);
+    assert_eq!(target_pte.config(false), flags);
+}
+
+#[test]
+fn aarch64_explicit_memory_types_roundtrip() {
+    let paddr = PhysAddr::from_usize(0x1_81ea_5000);
+    for memory_type in [MappingFlags::DEVICE, MappingFlags::UNCACHED] {
+        let flags = MappingFlags::READ | MappingFlags::WRITE | memory_type;
+        let pte = A64Pte::new_page(paddr, flags, false);
+
+        assert_eq!(pte.config(false), flags);
+    }
 }
 
 #[test]

--- a/components/axcpu/tests/paging.rs
+++ b/components/axcpu/tests/paging.rs
@@ -70,6 +70,21 @@ fn aarch64_explicit_memory_types_roundtrip() {
 }
 
 #[test]
+fn aarch64_unprogrammed_mair_indices_decode_as_device() {
+    let paddr = PhysAddr::from_usize(0x1_81ea_5000);
+    let normal_flags = MappingFlags::READ | MappingFlags::WRITE;
+    for index in 3..8 {
+        let pte = A64Pte::new_page(paddr, normal_flags, false).with_attr_index(index);
+
+        assert_eq!(
+            pte.config(false),
+            normal_flags | MappingFlags::DEVICE,
+            "AttrIndx {index} must match its zero-valued MAIR slot"
+        );
+    }
+}
+
+#[test]
 fn non_present_riscv_huge_leaf_retains_its_structure() {
     let paddr = PhysAddr::from_usize(0x4000_0000);
     let pte = Rv64Pte::new_page(paddr, MappingFlags::empty(), true);


### PR DESCRIPTION
## 问题

AArch64 页表描述符的 `AttrIndx[2:0]` 位于 bit 4:2，但这些位是数值字段，并没有作为独立 bitflag 声明。原来的 `A64Pte::attr()` 使用 `from_bits_truncate` 解析整个描述符，会丢弃这些位。

因此，调用 `config()` 读取已有 PTE 配置时：

- Normal memory 会被误读为 Device memory；
- Normal Non-cacheable memory 也会被误读为 Device memory；
- 将查询结果用于重建或迁移 PTE 时，会改变原有内存类型；
- 未配置的 MAIR 3..7 号槽位会被静默当成 Normal，而当前 `MAIR_VALUE` 中这些零值槽位实际对应 Device-nGnRnE。

## 修改

- 在解析 AArch64 PTE 属性时，保留已建模的 descriptor 属性位以及 `AttrIndx[2:0]`，同时屏蔽物理地址等非属性位。
- 将内存属性解码改成穷尽匹配：1 为 Normal，2 为 Normal Non-cacheable，其余当前 MAIR 槽位按 Device 解码。
- 增加 Normal leaf 查询后重建 PTE、Device/Uncached round-trip，以及未配置 MAIR 槽位 3..7 的回归测试。
- 增加 host 测试编译 AArch64 PTE 模块所需的 dev dependencies。

## 实现逻辑

`A64Pte::attr()` 先构造“已声明属性位 + AttrIndx 字段”的掩码，再通过 `from_bits_retain` 解析。这样 `mem_attr()` 能取得原始 AttrIndx，同时不会把 PTE 的物理地址或其他未知位带入属性对象。

`mem_attr()` 不再返回 `Option` 并由调用方用通配分支默认成 Normal，而是返回与当前 `MAIR_VALUE` 一致的确定内存类型。即使遇到未使用的 AttrIndx，也不会把 Device 类型错误提升为可缓存 Normal。

## 验证

- 原始修复前：Normal 和 Uncached 两项回归测试均失败，都会被读回为 Device。
- 加固前：MAIR 3..7 回归测试在 AttrIndx 3 处失败，实际读回 Normal、期望 Device。
- 修复后：`cargo test -p ax-cpu --test paging`，8 passed。
- `cargo xtask clippy --package ax-cpu`：28 个交叉目标/feature 检查通过；macOS 的 host-test 仅受现有 ELF `link_section` 限制。
- 在 Linux 中补跑同一 host-test clippy 命令，通过且无 warning。
- `cargo fmt --all` 与 `git diff --check` 通过。