### PR TITLE
fix(test): separate host and QEMU test layers

### DIFF
--- a/.agents/skills/arceos-test-adapter/SKILL.md
+++ b/.agents/skills/arceos-test-adapter/SKILL.md
@@ -1,46 +1,63 @@
 ---
 name: arceos-test-adapter
-description: 适配或修复 ArceOS 测试用例以通过 `cargo xtask test arceos`。当用户提到新增或修改 `test-suit/arceos` 下的测试、补齐 `qemu-*.toml`、修正成功或失败匹配规则，或让某个 ArceOS 测试在任务工具中正确通过或正确失败时，使用此技能。
+description: 适配或修复 ArceOS 测试用例以通过 `cargo xtask arceos test qemu`。当用户提到新增或修改 `test-suit/arceos` 下的测试、补齐 `qemu-*.toml`、修正成功或失败匹配规则，或让某个 ArceOS 测试在任务工具中正确通过或正确失败时，使用此技能。
 ---
 
 # ArceOS 测试适配
 
-适配 `test-suit/arceos` 下的测试到 `cargo xtask test arceos`。
+适配 `test-suit/arceos` 下的测试到 `cargo xtask arceos test qemu`。
+
+## 测试分层
+
+先确认测试实际需要的能力：算法、数据结构、状态机、协议解析和错误转换留在普通
+`#[test]`；真实调度、阻塞/唤醒、IPI、IRQ、timer、SMP、affinity、上下文切换和目标指令
+使用本 suite 的 QEMU 测试。`ax-task`、`ax-runtime` 等 ArceOS 启动依赖库不创建独立
+axtest target，也不得在 std 测试中用 fake runtime 代替真实运行时。
+
+上层 Starry kernel、Axvisor 和板卡测试包才直接持有 `axtest` 依赖，并通过
+`cargo xtask ktest qemu` 或 `cargo xtask ktest board` 运行。旧的目录式 `axtest` 组不由本
+命令发现；选择 `--test-group axtest` 时应转用 `ktest`。
+
+宿主允许列表和纯模型测试规则见 [`update-std-tests`](../update-std-tests/SKILL.md)，
+Starry/板卡边界和目录契约见 [`starry-test-suit`](../starry-test-suit/SKILL.md)。
 
 ## 工作方式
 
-1. 先读目标测试的 `Cargo.toml`、`src/main.rs`、现有 `qemu-*.toml`，不要盲目复制别的目录。
+1. 先读目标测试的 manifest、实现入口、现有 `build-*.toml` 与 `qemu-*.toml`，不要盲目复制别的目录。
 2. 再参考最接近的现有测试目录，复用必要配置，但按当前测试的实际行为改写。
-3. 改完后运行相关 `cargo xtask test arceos ...` 命令验证。
+3. 判断测试属于 Rust、C、generic 还是 board 流程，并使用对应发现器；不要为了复用配置改变运行时边界。
+4. 改完后运行最小的 `cargo xtask arceos test qemu ...` 命令验证。
 
 ## 必查项
 
-- 保持测试目录至少包含 `Cargo.toml`、`src/main.rs` 和目标架构对应的 `qemu-*.toml`。
-- `.axconfig.toml` 视测试是否需要而定；缺失时先参考相邻测试。
-- `.qemu.toml` 非必须；优先维护 `qemu-{arch}.toml`，只有工具链明确依赖默认配置时才补。
-- `Cargo.toml` 优先使用 `edition.workspace = true`。
+- Rust suite：在 `test-suit/arceos/rust` 同步 feature、模块、runner、`SELECTED_TESTS`、axbuild 可发现列表和所需 `build-*/qemu-*` 配置。
+- C suite：维护 C 源码/头文件、Makefile 或 `test_cmd`，并同步 C feature 列表和成功/失败匹配。
+- generic suite：按共享发现器提供 build wrapper、package manifest 和 runtime config，不假设存在 `src/main.rs`。
+- board case：使用 `board-*.toml` 与目标 build 配置，通过 `cargo xtask ktest board` 验证，不纳入 QEMU 批次。
+- 使用 `edition.workspace = true`；当前发现器不使用 `.axconfig.toml` 或 `.qemu.toml` 作为主要契约。
 - `main.rs` 中若使用 `no_mangle`，按当前仓库风格写成 `unsafe(no_mangle)`。
 - 清理无关旧产物，如 `*.out`、`*.bin`、`*.elf`、`test_cmd`。
 
 ## QEMU 输出匹配规则
 
-- `success_regex` 必须按代码成功路径里实际打印的稳定字符串填写。
+- `success_regex` 必须按代码成功路径里实际打印的稳定字符串填写，并核对最终 runner 装配后的正则；Rust feature case 可能覆盖 TOML 默认值。
 - 不要沿用占位字符串，不要猜测，不要默认写 `to install packages.`。
 - 先从 `src/main.rs`、被调用函数和已有成功日志里找“测试成功结束时一定会出现”的输出。
 - 优先选择唯一、完整、稳定的成功提示，例如 `Memory tests run OK!`、`Task yielding tests run OK!`。
 - 如果代码成功路径没有明确成功提示，先在测试代码中补一条清晰且稳定的成功输出，再回填到 `success_regex`。
-- `fail_regex` 统一写成 `(?i)\bpanic(?:ked)?\b`。
+- 普通成功用例可使用 `(?i)\bpanic(?:ked)?\b` 作为失败匹配；预期 panic、page fault、lockdep、stack-guard 或诊断用例必须使用对应专用规则，不能用宽泛正则伪造成功。
 
 ## 适配建议
 
-- 新增测试时，优先复制最接近的 `qemu-*.toml` 和 `.axconfig.toml`，再根据当前测试修正。
+- 新增测试时，优先复制最接近的 `qemu-*.toml` 与 build 配置，再根据当前测试修正。
 - 不同架构的 `success_regex` 应与该测试真实输出一致；如果成功输出跨架构相同，可以保持一致。
 - 不要为了“让测试通过”去放宽正则到过于宽泛的内容。
 - 失败检测要确保内核恐慌会使 `xtask` 以非零状态码退出。
 
 ## 验证
 
-- 优先运行最小验证命令，例如 `cargo xtask test arceos --target <target-triple>`。
-- 确认成功用例会输出 `ok: <package>`。
+- 优先运行最小验证命令，例如 `cargo xtask arceos test qemu --test-group rust --test-case <case> --target <target-triple>`。
+- 确认 QEMU 实际启动、代码打印稳定成功 marker、runner 输出 `ok: <case>`，并且 panic/失败 marker 使外层命令返回非零。
+- 使用 `cargo xtask arceos test qemu --list` 检查新 case 已被发现；需要 axtest target 时改用 `cargo xtask ktest qemu`。
 - 确认故意触发内核恐慌或真实失败时，`ostool` 或 `xtask` 能命中 `fail_regex` 并以非零状态码退出。
 - 如果有编译警告且与当前改动相关，一并修掉。

--- a/.agents/skills/starry-test-suit/SKILL.md
+++ b/.agents/skills/starry-test-suit/SKILL.md
@@ -16,6 +16,16 @@ StarryOS 测试由数据驱动。用例位于 `test-suit/starryos`，发现与�
 
 QEMU 用例构建 `starryos` 软件包，并运行对应体系结构的 `qemu-<arch>.toml`。板卡用例针对板卡目标构建 StarryOS，再通过板卡运行器执行 `board-<board>.toml`。
 
+## 与其他测试层的边界
+
+- 宿主 `std` 只验证算法、数据结构、状态机、协议解析和错误转换；不能用 fake runtime、fake IRQ、fake timer 或 shell prompt 代替 StarryOS 运行证据。
+- ArceOS 的真实调度、IPI、IRQ、timer、SMP、affinity 和上下文切换优先放在 `test-suit/arceos/rust`，使用 `cargo xtask arceos test qemu ...`。
+- Starry kernel 私有 Linux ABI、namespace、procfs、pipe、epoll 和内核生命周期语义保留在本 suite 或 Starry kernel axtest；Axvisor 和板卡专有行为分别使用 `cargo xtask ktest qemu`/`cargo xtask ktest board`。
+- 同一 crate 可以同时有 std 模型测试和 QEMU/axtest 集成测试，但同一断言只能由一个最接近真实语义的层负责；上层运行证据不能被低层 host 编译替代。
+
+宿主 `std` 允许列表和 profile 规则见 [`update-std-tests`](../update-std-tests/SKILL.md)，
+ArceOS Rust QEMU 的发现与 runner 契约见 [`arceos-test-adapter`](../arceos-test-adapter/SKILL.md)。
+
 ## 工作流程
 
 1. 检查 `test-suit/starryos` 下的目标目录，以及 `scripts/axbuild/src/starry/test.rs` 中当前测试流程。

--- a/.agents/skills/update-std-tests/SKILL.md
+++ b/.agents/skills/update-std-tests/SKILL.md
@@ -7,40 +7,54 @@ description: 审计并更新本 ArceOS 与 StarryOS 工作区的 `scripts/test/s
 
 本技能通过比较工作区软件包与宿主机完整 `cargo test` 结果，维护 `scripts/test/std_crates.csv` 中的标准库测试允许列表。
 
+## 测试分层边界
+
+先按被测语义选择测试层，再审计允许列表：
+
+- `std` 只验证算法、数据结构、状态机、协议解析、错误转换和可确定性模型。测试可以使用局部数据夹具，但不得实现或依赖假调度器、假 IRQ、假 timer、假 SMP 或假设备来证明运行时语义。
+- 真实调度、阻塞/唤醒、IPI、IRQ、timer、SMP、affinity、上下文切换和目标指令必须通过 `test-suit/arceos/rust` 的 ArceOS QEMU case 验证。`ax-task`、`ax-runtime` 等启动依赖库不创建独立 axtest target。
+- Starry kernel、Axvisor 和板卡专属行为使用 `cargo xtask ktest qemu` 或 `cargo xtask ktest board`；直接 axtest 依赖不会因为传递依赖而自动扩散。
+- ArceOS suite 的正式入口是 `cargo xtask arceos test qemu ...`，不是 `cargo xtask test arceos`。Starry suite 使用 `cargo xtask starry test ...`。
+
+同一 crate 可以同时拥有 std 模型测试和上层 QEMU/axtest 集成测试，但每个断言只能由最接近其真实语义的一层负责。不能用宿主机编译成功、fake runtime 或 shell prompt 替代目标运行时证据。
+
+相关层级适配规则见 [`arceos-test-adapter`](../arceos-test-adapter/SKILL.md) 和
+[`starry-test-suit`](../starry-test-suit/SKILL.md)。
+
 ## 工作流程
 
 1. 运行审计，找出不在允许列表中的候选软件包。
 2. 先询问是否添加通过测试的候选软件包；默认建议添加。
 3. 再询问是否添加当前测试失败的候选软件包；只有用户明确选择才添加。
 4. 用户确认后，只应用明确选择的软件包。
-5. 如果只添加通过测试的软件包，可继续运行 `cargo xtask test std` 验证。
+5. 如果只添加通过测试的软件包，使用 `cargo xtask test` 验证；增量验证使用 `cargo xtask test --since <REF>`。
 
 ## 命令
 
-脚本位于 `<skill-path>/scripts/std_test_candidates.py`。本仓库所有 Python 脚本都使用 `python3`。
+脚本位于 `.agents/skills/update-std-tests/scripts/std_test_candidates.py`。本仓库所有 Python 脚本都使用 `python3`。
 
 输出 Markdown 格式的审计结果：
 
 ```bash
-python3 scripts/std_test_candidates.py audit --repo-root /path/to/repo --format markdown
+python3 .agents/skills/update-std-tests/scripts/std_test_candidates.py audit --repo-root /path/to/repo --format markdown
 ```
 
 输出 JSON 格式的审计结果：
 
 ```bash
-python3 scripts/std_test_candidates.py audit --repo-root /path/to/repo --format json
+python3 .agents/skills/update-std-tests/scripts/std_test_candidates.py audit --repo-root /path/to/repo --format json
 ```
 
 把软件包加入逗号分隔值文件：
 
 ```bash
-python3 scripts/std_test_candidates.py apply --repo-root /path/to/repo --packages pkg1 pkg2 pkg3
+python3 .agents/skills/update-std-tests/scripts/std_test_candidates.py apply --repo-root /path/to/repo --packages pkg1 pkg2 pkg3
 ```
 
 只预览修改，不实际写入：
 
 ```bash
-python3 scripts/std_test_candidates.py apply --repo-root /path/to/repo --packages pkg1 pkg2 --dry-run
+python3 .agents/skills/update-std-tests/scripts/std_test_candidates.py apply --repo-root /path/to/repo --packages pkg1 pkg2 --dry-run
 ```
 
 ## 征求用户确认
@@ -52,7 +66,7 @@ python3 scripts/std_test_candidates.py apply --repo-root /path/to/repo --package
 - 纳入：库软件包、只有二进制目标的示例软件包。
 - 按名称排除：`tg-xtask`、`axlibc`、`arm_vcpu`、`riscv_vcpu`、`axvisor`。
 - 按失败特征排除：`invalid register`、`undefined symbol: main`，这两类表明软件包不兼容宿主机。
-- 测试方式：完整执行 `cargo test -p <package>`，不使用 `--no-run`。
+- 测试方式：普通包可完整执行 `cargo test -p <package>`，不使用 `--no-run`；带有 `host-test`、固定 feature profile 或测试发现断言的软件包必须通过 `cargo xtask test` 的正式 profile 验证。
 
 详细筛选逻辑见 `references/filtering.md`。
 
@@ -76,12 +90,14 @@ python3 scripts/std_test_candidates.py apply --repo-root /path/to/repo --package
 只添加通过测试的软件包后，建议运行：
 
 ```bash
-cargo xtask test std
+cargo xtask test
 ```
 
 如果用户选择加入已知失败软件包，明确警告允许列表包含当前失败项，整体验证可能无法通过。
 
+应用 CSV 修改前先展示候选包、退出码和实际测试数量，确认每个条目仍是 workspace package，且不是零测试、宏装配、裸机应用或目标架构专属包；只应用明确选中的条目，并检查 `git diff`。工作区成员、目标种类、宿主测试行为或依赖发生变化时重新运行审计。
+
 ## 附带资源
 
-- `scripts/std_test_candidates.py`：审计和应用脚本。
+- `scripts/std_test_candidates.py`：审计和应用脚本（位于 `.agents/skills/update-std-tests/scripts/`）。
 - `references/filtering.md`：详细筛选策略。

--- a/.agents/skills/update-std-tests/references/filtering.md
+++ b/.agents/skills/update-std-tests/references/filtering.md
@@ -2,7 +2,9 @@
 
 ## 概述
 
-使用 `cargo metadata --no-deps` 枚举工作区软件包，与 `scripts/test/std_crates.csv` 比较，再依据宿主机上完整 `cargo test -p <package>` 的结果分类缺失软件包。
+使用 `cargo metadata --no-deps` 枚举工作区软件包，与 `scripts/test/std_crates.csv` 比较，再依据宿主机上完整 `cargo test -p <package>` 或仓库正式 `cargo xtask test` profile 的结果分类缺失软件包。
+
+只把宿主可确定执行的算法、数据结构、状态机、协议解析和错误转换纳入 std。依赖假调度器、假 IRQ、假 timer、假 SMP 或假设备来证明真实运行时语义的测试不属于 std，应迁移到 ArceOS QEMU、Starry/Axvisor axtest 或板卡流程。纯协议测试可以使用局部数据夹具，但不得伪造 OS/runtime 行为。
 
 ## 候选来源
 
@@ -14,7 +16,7 @@
 
 - 把库软件包纳入审计候选集合。
 - 把示例或只有二进制目标的软件包纳入候选集合。
-- 使用完整 `cargo test -p <package>` 结果，不使用 `--no-run`。
+- 普通包使用完整 `cargo test -p <package>`，不使用 `--no-run`；带 `host-test`、固定 feature profile 或测试发现断言的软件包使用 `cargo xtask test` 的对应 profile。
 
 ## 默认排除
 

--- a/os/arceos/modules/axtask/src/api.rs
+++ b/os/arceos/modules/axtask/src/api.rs
@@ -663,12 +663,6 @@ mod tests {
     use core::cell::Cell;
 
     #[test]
-    #[cfg(feature = "host-test")]
-    fn host_atomic_context_query_does_not_require_cpu_local_state() {
-        assert!(!super::in_atomic_context());
-    }
-
-    #[test]
     fn task_initialization_precedes_scheduling() {
         let initialized = Cell::new(false);
 

--- a/os/arceos/modules/axtask/src/run_queue.rs
+++ b/os/arceos/modules/axtask/src/run_queue.rs
@@ -335,78 +335,50 @@ fn is_remote_cpu(cpu_id: usize) -> bool {
 mod tests {
     use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-    // Host-test mode collapses the pending/count state into process-global
-    // atomics, so keep their assertions in one test.
+    // This test covers only the atomic publication edge. Scheduler handling
+    // and forced rotation require the real ArceOS IPI path; the task-ipi QEMU
+    // case is the runtime evidence boundary rather than a host fake scheduler.
     #[test]
-    fn remote_reschedule_request_is_coalesced_and_forced() {
-        const REMOTE_CPU: usize = 1;
-
-        super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);
-        super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
-
-        super::kick_remote_cpu(REMOTE_CPU);
+    fn remote_reschedule_request_is_coalesced() {
+        let pending = AtomicBool::new(false);
+        let requests = AtomicUsize::new(0);
 
         assert_eq!(
-            super::REMOTE_RESCHEDULE_REQUESTS.load(Ordering::Acquire),
-            1,
-            "remote CPU kicks must enqueue a scheduler-visible reschedule request",
+            super::request_remote_reschedule_if_not_pending(&pending, || {
+                requests.fetch_add(1, Ordering::Release);
+                Ok(ax_ipi::IpiNotification::Sent)
+            })
+            .unwrap(),
+            ax_ipi::IpiNotification::Sent,
         );
-        super::kick_remote_cpu(REMOTE_CPU);
-
         assert_eq!(
-            super::REMOTE_RESCHEDULE_REQUESTS.load(Ordering::Acquire),
+            super::request_remote_reschedule_if_not_pending(&pending, || {
+                requests.fetch_add(1, Ordering::Release);
+                Ok(ax_ipi::IpiNotification::Sent)
+            })
+            .unwrap(),
+            ax_ipi::IpiNotification::Coalesced,
+        );
+        assert_eq!(
+            requests.load(Ordering::Acquire),
             1,
-            "remote CPU kicks should coalesce identical pending reschedule requests",
+            "remote reschedule requests should coalesce while pending",
         );
 
-        assert!(super::take_remote_reschedule_pending_for_current_cpu());
-        super::kick_remote_cpu(REMOTE_CPU);
-
+        pending.store(false, Ordering::Release);
         assert_eq!(
-            super::REMOTE_RESCHEDULE_REQUESTS.load(Ordering::Acquire),
+            super::request_remote_reschedule_if_not_pending(&pending, || {
+                requests.fetch_add(1, Ordering::Release);
+                Ok(ax_ipi::IpiNotification::Sent)
+            })
+            .unwrap(),
+            ax_ipi::IpiNotification::Sent,
+        );
+        assert_eq!(
+            requests.load(Ordering::Acquire),
             2,
-            "remote CPU kicks must be accepted again after the pending bit is cleared",
+            "a cleared pending bit should permit a fresh request",
         );
-
-        #[cfg(feature = "preempt")]
-        crate::tests::run_in_test_scheduler(|| {
-            let curr = crate::current();
-
-            curr.set_preempt_pending(false);
-            curr.set_force_resched_pending(false);
-            super::REMOTE_RESCHEDULE_PENDING.store(true, Ordering::Release);
-
-            super::handle_ipi_reschedule();
-
-            assert!(
-                curr.force_resched_pending_for_test(),
-                "remote IPI reschedule must request forced rotation",
-            );
-            assert!(
-                !curr.preempt_pending_for_test(),
-                "remote IPI reschedule must not rely on ordinary RR preemption",
-            );
-            assert!(
-                !super::REMOTE_RESCHEDULE_PENDING.load(Ordering::Acquire),
-                "the runtime IPI handler must consume the scheduler pending bit",
-            );
-
-            curr.set_force_resched_pending(false);
-            curr.set_preempt_pending(false);
-        });
-
-        #[cfg(feature = "preempt")]
-        {
-            super::kick_remote_cpu(REMOTE_CPU);
-            assert_eq!(
-                super::REMOTE_RESCHEDULE_REQUESTS.load(Ordering::Acquire),
-                3,
-                "a delivered remote IPI must allow a later kick to arm a fresh edge",
-            );
-        }
-
-        super::REMOTE_RESCHEDULE_PENDING.store(false, Ordering::Release);
-        super::REMOTE_RESCHEDULE_REQUESTS.store(0, Ordering::Release);
     }
 
     #[test]

--- a/os/arceos/modules/axtask/src/sync/mutex/mod.rs
+++ b/os/arceos/modules/axtask/src/sync/mutex/mod.rs
@@ -386,8 +386,6 @@ impl<T: ?Sized> LockdepMutexExt<T> for Mutex<T> {
 
 #[cfg(all(feature = "host-test", not(target_os = "none")))]
 mod host {
-    #[cfg(test)]
-    use core::sync::atomic::AtomicBool;
     use core::{
         panic::Location,
         sync::atomic::{AtomicPtr, AtomicU64, AtomicUsize, Ordering},
@@ -417,12 +415,6 @@ mod host {
     }
 
     static NEXT_TASK_ID: AtomicU64 = AtomicU64::new(1);
-    #[cfg(test)]
-    static WAIT_BOUNDARY_OWNER: AtomicUsize = AtomicUsize::new(0);
-    #[cfg(test)]
-    static WAIT_BOUNDARY_REACHED: AtomicBool = AtomicBool::new(false);
-    #[cfg(test)]
-    static WAIT_BOUNDARY_CONTINUE: AtomicBool = AtomicBool::new(false);
 
     std::thread_local! {
         static TASK_ID: Cell<u64> = const { Cell::new(0) };
@@ -459,14 +451,6 @@ mod host {
         fn wait_until_unlocked(wait_queue: &AtomicPtr<()>, owner_id: &AtomicU64) {
             let queue = ensure_wait_queue(wait_queue);
             queue.waiters.fetch_add(1, Ordering::AcqRel);
-            #[cfg(test)]
-            if WAIT_BOUNDARY_OWNER.load(Ordering::Acquire) == core::ptr::from_ref(owner_id) as usize
-            {
-                WAIT_BOUNDARY_REACHED.store(true, Ordering::Release);
-                while !WAIT_BOUNDARY_CONTINUE.load(Ordering::Acquire) {
-                    std::thread::yield_now();
-                }
-            }
             let mut state = queue.state.lock().expect("host wait queue poisoned");
             while owner_id.load(Ordering::Acquire) != 0 {
                 state = queue
@@ -545,26 +529,6 @@ mod host {
     #[cfg(test)]
     pub(super) fn last_might_sleep_caller() -> Option<&'static Location<'static>> {
         LAST_MIGHT_SLEEP_CALLER.get()
-    }
-
-    #[cfg(test)]
-    pub(super) fn pause_waiter_before_registration(owner_id: &AtomicU64) {
-        WAIT_BOUNDARY_REACHED.store(false, Ordering::Release);
-        WAIT_BOUNDARY_CONTINUE.store(false, Ordering::Release);
-        WAIT_BOUNDARY_OWNER.store(core::ptr::from_ref(owner_id) as usize, Ordering::Release);
-    }
-
-    #[cfg(test)]
-    pub(super) fn wait_for_registration_boundary() {
-        while !WAIT_BOUNDARY_REACHED.load(Ordering::Acquire) {
-            std::thread::yield_now();
-        }
-    }
-
-    #[cfg(test)]
-    pub(super) fn resume_waiter_after_registration_boundary() {
-        WAIT_BOUNDARY_CONTINUE.store(true, Ordering::Release);
-        WAIT_BOUNDARY_OWNER.store(0, Ordering::Release);
     }
 }
 
@@ -661,45 +625,6 @@ mod tests {
             let _mutex_guard = mutex.lock();
         }));
         assert!(result.is_err());
-    }
-
-    #[test]
-    fn contended_mutex_wakes_waiters_without_lost_wakeups() {
-        const THREADS: usize = 8;
-        const ITERATIONS: usize = 2_000;
-        let value = Arc::new(Mutex::new(0usize));
-        let mut workers = Vec::new();
-
-        for _ in 0..THREADS {
-            let value = value.clone();
-            workers.push(thread::spawn(move || {
-                for _ in 0..ITERATIONS {
-                    *value.lock() += 1;
-                }
-            }));
-        }
-
-        for worker in workers {
-            worker.join().expect("mutex worker panicked");
-        }
-        assert_eq!(*value.lock(), THREADS * ITERATIONS);
-    }
-
-    #[test]
-    fn unlock_before_waiter_registration_does_not_lose_wakeup() {
-        let value = Arc::new(Mutex::new(0usize));
-        let guard = value.lock();
-        host::pause_waiter_before_registration(&value.raw.owner_id);
-        let waiter_value = value.clone();
-        let waiter = thread::spawn(move || {
-            *waiter_value.lock() = 1;
-        });
-
-        host::wait_for_registration_boundary();
-        drop(guard);
-        host::resume_waiter_after_registration_boundary();
-        waiter.join().expect("boundary waiter panicked");
-        assert_eq!(*value.lock(), 1);
     }
 
     #[test]

--- a/os/arceos/modules/axtask/src/task.rs
+++ b/os/arceos/modules/axtask/src/task.rs
@@ -597,30 +597,6 @@ impl TaskInner {
     }
 
     #[inline]
-    #[cfg(all(
-        test,
-        feature = "preempt",
-        feature = "smp",
-        feature = "ipi",
-        feature = "host-test"
-    ))]
-    pub(crate) fn preempt_pending_for_test(&self) -> bool {
-        self.need_resched.load(Ordering::Acquire)
-    }
-
-    #[inline]
-    #[cfg(all(
-        test,
-        feature = "preempt",
-        feature = "smp",
-        feature = "ipi",
-        feature = "host-test"
-    ))]
-    pub(crate) fn force_resched_pending_for_test(&self) -> bool {
-        self.force_resched_pending()
-    }
-
-    #[inline]
     #[cfg(feature = "preempt")]
     fn take_force_resched_pending(&self) -> bool {
         self.force_resched.swap(false, Ordering::AcqRel)

--- a/scripts/axbuild/src/arceos/test/mod.rs
+++ b/scripts/axbuild/src/arceos/test/mod.rs
@@ -48,6 +48,7 @@ const ARCEOS_RUST_QEMU_FEATURES: &[&str] = &[
     "task-affinity",
     "task-ipi",
     ARCEOS_RUST_TASK_IRQ_FEATURE,
+    "task-mutex",
     "task-parallel",
     "task-priority",
     "task-sleep",

--- a/scripts/axbuild/src/test/std.rs
+++ b/scripts/axbuild/src/test/std.rs
@@ -32,21 +32,57 @@ struct PackageFeatureProfile {
     expected_tests: &'static [&'static str],
 }
 
-const AX_TASK_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
-    name: "host-test",
-    no_default_features: false,
-    features: &["host-test"],
-    name_filter: None,
-    expected_tests: &[
-        "api::std_tests::axtask_api_constants_hold",
-        "api::std_tests::axtask_api_scheduler_name_hold",
-        "api::std_tests::axtask_api_task_registry_functions_exist_hold",
-        "api::std_tests::axtask_api_type_aliases_hold",
-        "api::tests::task_initialization_precedes_scheduling",
-        "future::time::timer_regression_tests::due_future_work_is_not_republished_as_a_clockevent_deadline",
-        "future::time::timer_regression_tests::future_deadline_is_republished_after_the_due_pass_finishes",
-    ],
-}];
+const AX_TASK_FEATURE_PROFILES: &[PackageFeatureProfile] = &[
+    PackageFeatureProfile {
+        name: "host-test-api",
+        no_default_features: false,
+        features: &["host-test"],
+        name_filter: Some("api::"),
+        expected_tests: &[
+            "api::std_tests::axtask_api_constants_hold",
+            "api::std_tests::axtask_api_scheduler_name_hold",
+            "api::std_tests::axtask_api_task_registry_functions_exist_hold",
+            "api::std_tests::axtask_api_type_aliases_hold",
+            "api::tests::task_initialization_precedes_scheduling",
+        ],
+    },
+    PackageFeatureProfile {
+        name: "host-test-timer-model",
+        no_default_features: false,
+        features: &["host-test"],
+        name_filter: Some("future::time::timer_regression_tests::"),
+        expected_tests: &[
+            "future::time::timer_regression_tests::due_future_work_is_not_republished_as_a_clockevent_deadline",
+            "future::time::timer_regression_tests::future_deadline_is_republished_after_the_due_pass_finishes",
+            "future::time::timer_regression_tests::future_timer_drop_cancels_the_registration_cpu_after_migration",
+            "future::time::timer_regression_tests::future_timer_poll_uses_the_registration_cpu_after_migration",
+        ],
+    },
+    PackageFeatureProfile {
+        name: "host-test-lock-contract",
+        no_default_features: false,
+        features: &["host-test"],
+        name_filter: Some("sync::mutex::tests::"),
+        expected_tests: &[
+            "sync::mutex::tests::leaked_guard_can_be_released_by_owner_wrapper",
+            "sync::mutex::tests::lock_rejects_preemption_disabled_context",
+            "sync::mutex::tests::lock_reports_the_external_call_site_to_the_runtime",
+            "sync::mutex::tests::try_lock_is_nonblocking",
+            "sync::mutex::tests::wrong_owner_force_unlock_is_rejected",
+        ],
+    },
+    PackageFeatureProfile {
+        name: "host-test-remote-reschedule",
+        no_default_features: false,
+        features: &["host-test", "smp", "ipi"],
+        name_filter: Some("run_queue::tests::"),
+        expected_tests: &[
+            "run_queue::tests::forced_remote_reschedule_bypasses_stale_pending",
+            "run_queue::tests::remote_reschedule_request_is_coalesced",
+            "run_queue::tests::remote_reschedule_send_failure_is_reported_and_keeps_pending",
+        ],
+    },
+];
 
 const AX_HAL_FEATURE_PROFILES: &[PackageFeatureProfile] = &[PackageFeatureProfile {
     name: "host-test",
@@ -1126,7 +1162,7 @@ mod tests {
     }
 
     #[test]
-    fn ax_task_uses_one_mandatory_runtime_profile() {
+    fn ax_task_uses_split_runtime_profiles() {
         let root = PathBuf::from("/tmp/workspace");
         let packages = vec!["ax-task".to_string()];
         let mut runner = FakeCargoRunner::succeeding().with_ax_task_discovery();
@@ -1148,10 +1184,65 @@ mod tests {
                     "ax-task",
                     "--features",
                     "host-test",
+                    "api::",
                     "--",
                     "--list"
                 ],
-                vec!["test", "-p", "ax-task", "--features", "host-test"],
+                vec!["test", "-p", "ax-task", "--features", "host-test", "api::"],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test",
+                    "future::time::timer_regression_tests::",
+                    "--",
+                    "--list"
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test",
+                    "future::time::timer_regression_tests::"
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test",
+                    "sync::mutex::tests::",
+                    "--",
+                    "--list"
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test",
+                    "sync::mutex::tests::"
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test,smp,ipi",
+                    "run_queue::tests::",
+                    "--",
+                    "--list"
+                ],
+                vec![
+                    "test",
+                    "-p",
+                    "ax-task",
+                    "--features",
+                    "host-test,smp,ipi",
+                    "run_queue::tests::"
+                ],
             ]
         );
         assert!(!args.contains(&vec!["test".into(), "-p".into(), "ax-task".into()]));
@@ -1293,7 +1384,7 @@ mod tests {
 
     #[test]
     fn unfiltered_profile_discovery_accepts_additional_tests() {
-        let profile = &AX_TASK_FEATURE_PROFILES[0];
+        let profile = &AX_HAL_FEATURE_PROFILES[0];
         let mut tests = profile.expected_tests.to_vec();
         tests.push("timers::tests::an_additional_regression");
 
@@ -1336,6 +1427,6 @@ mod tests {
         let failed = run_std_tests(&mut runner, &root, &packages).unwrap();
 
         assert_eq!(failed, vec!["ax-task", "ax-api"]);
-        assert_eq!(runner.invocations.len(), 3);
+        assert_eq!(runner.invocations.len(), 9);
     }
 }

--- a/scripts/test/std_crates.csv
+++ b/scripts/test/std_crates.csv
@@ -11,6 +11,17 @@ axhvc
 ax-io
 axklib
 axpoll
+ax-cgroup
+ax-cpu
+ax-memory-addr
+ax-memory-set
+axpanic
+ax-percpu
+mmio-api
+page-table-generic
+ranges-ext
+rdif-base
+rdif-def
 ax-sched
 axvm
 axvmconfig

--- a/test-suit/arceos/axtest/sg2002-usb-msc/build-riscv64gc-unknown-none-elf.toml
+++ b/test-suit/arceos/axtest/sg2002-usb-msc/build-riscv64gc-unknown-none-elf.toml
@@ -4,7 +4,6 @@ features = [
   "ax-std",
   "paging",
   "ax-std/std-compat",
-  "ax-task/axtest",
   "axplat-dyn/thead-mae",
   "ax-driver/serial",
   "ax-driver/sg2002-dwc2",

--- a/test-suit/arceos/rust/Cargo.toml
+++ b/test-suit/arceos/rust/Cargo.toml
@@ -18,6 +18,7 @@ task-affinity = ["ax-std"]
 task-wait-queue = ["ax-std"]
 task-wait-queue-remote-wake = ["ax-std", "ax-std/ipi"]
 task-ipi = ["ax-std", "ax-std/alloc", "ax-std/ipi"]
+task-mutex = ["ax-std", "ax-std/alloc"]
 task-irq = [
     "ax-std",
     "ax-std/sched-rr",
@@ -57,6 +58,7 @@ all = [
     "task-wait-queue",
     "task-wait-queue-remote-wake",
     "task-ipi",
+    "task-mutex",
     "task-tls",
     "task-parallel",
     "task-priority",

--- a/test-suit/arceos/rust/src/lib.rs
+++ b/test-suit/arceos/rust/src/lib.rs
@@ -58,6 +58,7 @@ pub mod net;
         feature = "task-affinity",
         feature = "task-ipi",
         feature = "task-irq",
+        feature = "task-mutex",
         feature = "task-parallel",
         feature = "task-priority",
         feature = "task-sleep",
@@ -122,6 +123,7 @@ test_runner!("sched-rr", run_sched_rr, task::priority::run);
 test_runner!("task-affinity", run_task_affinity, task::affinity::run);
 test_runner!("task-ipi", run_task_ipi, task::ipi::run);
 test_runner!("task-irq", run_task_irq, task::irq::run);
+test_runner!("task-mutex", run_task_mutex, task::mutex::run);
 test_runner!("task-parallel", run_task_parallel, task::parallel::run);
 test_runner!("task-priority", run_task_priority, task::priority::run);
 test_runner!("task-sleep", run_task_sleep, task::sleep::run);
@@ -223,6 +225,8 @@ const SELECTED_TESTS: &[TestCase] = &[
     TestCase::new("task-ipi", "IPI callback delivery", run_task_ipi),
     #[cfg(feature = "task-irq")]
     TestCase::new("task-irq", "task IRQ state", run_task_irq),
+    #[cfg(feature = "task-mutex")]
+    TestCase::new("task-mutex", "mutex contention and wakeup", run_task_mutex),
     #[cfg(feature = "task-parallel")]
     TestCase::new("task-parallel", "parallel computation", run_task_parallel),
     #[cfg(all(

--- a/test-suit/arceos/rust/src/task/mod.rs
+++ b/test-suit/arceos/rust/src/task/mod.rs
@@ -4,6 +4,8 @@ pub mod affinity;
 pub mod ipi;
 #[cfg(feature = "task-irq")]
 pub mod irq;
+#[cfg(feature = "task-mutex")]
+pub mod mutex;
 #[cfg(feature = "task-parallel")]
 pub mod parallel;
 #[cfg(any(feature = "task-priority", feature = "sched-cfs", feature = "sched-rr"))]

--- a/test-suit/arceos/rust/src/task/mutex.rs
+++ b/test-suit/arceos/rust/src/task/mutex.rs
@@ -1,0 +1,78 @@
+use std::{
+    os::arceos::modules::ax_task,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    vec::Vec,
+};
+
+const WORKERS: usize = 8;
+const ITERATIONS: usize = 256;
+
+/// Exercise the production mutex and task wake-up path under real ArceOS scheduling.
+pub fn run() -> crate::TestResult {
+    assert!(!ax_task::in_atomic_context());
+    contended_workers_make_progress();
+    unlock_wakes_a_waiting_task();
+    Ok(())
+}
+
+fn contended_workers_make_progress() {
+    let value = Arc::new(ax_task::sync::Mutex::new(0usize));
+    let started = Arc::new(ax_task::WaitQueue::new());
+    let started_count = Arc::new(AtomicUsize::new(0));
+    let mut workers = Vec::with_capacity(WORKERS);
+
+    for _ in 0..WORKERS {
+        let value = Arc::clone(&value);
+        let started = Arc::clone(&started);
+        let started_count = Arc::clone(&started_count);
+        workers.push(ax_task::spawn(move || {
+            started_count.fetch_add(1, Ordering::Release);
+            started.notify_one(true);
+            for _ in 0..ITERATIONS {
+                *value.lock() += 1;
+            }
+        }));
+    }
+
+    started.wait_until(|| started_count.load(Ordering::Acquire) == WORKERS);
+    for worker in workers {
+        assert_eq!(worker.join(), 0, "mutex worker panicked");
+    }
+    assert_eq!(*value.lock(), WORKERS * ITERATIONS);
+}
+
+fn unlock_wakes_a_waiting_task() {
+    let value = Arc::new(ax_task::sync::Mutex::new(0usize));
+    let holder_ready = Arc::new(ax_task::WaitQueue::new());
+    let release_holder = Arc::new(ax_task::WaitQueue::new());
+    let waiter_started = Arc::new(ax_task::WaitQueue::new());
+
+    let holder_value = Arc::clone(&value);
+    let holder_ready_signal = Arc::clone(&holder_ready);
+    let release_holder_signal = Arc::clone(&release_holder);
+    let holder = ax_task::spawn(move || {
+        let mut guard = holder_value.lock();
+        holder_ready_signal.notify_one(true);
+        release_holder_signal.wait();
+        *guard = 1;
+    });
+
+    holder_ready.wait();
+
+    let waiter_value = Arc::clone(&value);
+    let waiter_started_signal = Arc::clone(&waiter_started);
+    let waiter = ax_task::spawn(move || {
+        waiter_started_signal.notify_one(true);
+        *waiter_value.lock() = 2;
+    });
+
+    waiter_started.wait();
+    release_holder.notify_one(true);
+
+    assert_eq!(holder.join(), 0, "mutex holder panicked");
+    assert_eq!(waiter.join(), 0, "mutex waiter panicked");
+    assert_eq!(*value.lock(), 2);
+}


### PR DESCRIPTION
## 问题

工作区原有测试入口没有完整区分宿主 `std` 模型测试和真实 ArceOS 运行时测试。`ax-task` 的 host profile 会携带 fake scheduler、host wait queue 和 fake IPI 上下文断言，无法证明真实阻塞/唤醒、调度器强制轮转或 IPI 语义；同时 ArceOS 测试 skill 仍引用过时的命令和目录契约。

## 修改

- 移除 `ax-task` 中依赖 host fake scheduler/Condvar 的 mutex contention、wakeup 和 fake atomic-context 断言。
- 将 remote-reschedule 测试拆为仅验证 atomic coalescing/error 的 std profile；不新增 `*_for_test`、`axtest_support` 或 fake runtime facade。
- 在 `test-suit/arceos/rust` 增加 `task-mutex`，通过公开 `ax_task` API 验证真实任务阻塞、唤醒和互斥交接，并同步 feature、runner、`SELECTED_TESTS` 和 axbuild 发现列表。
- 将 11 个已验证的纯模型/接口包加入 `scripts/test/std_crates.csv`；`cpu-local` 因当前 host 默认失败继续排除。
- 删除 SG2002 配置中不存在的 `ax-task/axtest` feature，保持 board runtime。
- 更新 `update-std-tests`、`arceos-test-adapter`、`starry-test-suit` 的跨层规则、正式命令、发现器和成功/失败 marker 说明，并互相链接。

## 验证

- `cargo metadata --no-deps --format-version 1`：186/186 workspace packages。
- `cargo xtask test`：64 个 std 包全部通过；ax-task 四个 profile 的发现集合和执行结果一致。
- `cargo xtask clippy --package ax-task`：54/54 通过。
- `cargo xtask clippy --package arceos-test-suit`：31/31 通过。
- `cargo xtask clippy --package axbuild`：1/1 通过。
- `cargo xtask arceos test qemu --list`：发现 `task-mutex` 的 x86_64、AArch64、RISC-V、LoongArch 配置。
- `task-mutex` 四目标真实 QEMU 均输出 `ArceOS test suite run OK!` 并通过。
- `cargo xtask ktest qemu -p starry-kernel --arch x86_64`：9/9 通过。
- `cargo xtask ktest qemu -p axvisor --arch aarch64`：54/54 通过。
- `cargo fmt --check`、`git diff --check` 通过；未发现 `cargo xtask test arceos` 或 `ax-task/axtest` 失效引用。

本环境未连接 SG2002 实体板卡，因此未执行 `cargo xtask ktest board`。当前工作树原有的 `Cargo.lock` 修改未回滚，也未纳入本 PR。

未绑定 issue：本次请求未提供 issue 编号，故不添加 `Fixes #...`。
