### PR TITLE
fix(axvisor): stabilize browser console delivery

### DIFF
--- a/os/axvisor/src/guest_console/mux/mod.rs
+++ b/os/axvisor/src/guest_console/mux/mod.rs
@@ -422,13 +422,11 @@ impl ConsoleCore {
                 .checked_add(1)
                 .expect("guest serial backend generation exhausted");
             let generation = BackendGeneration(state.next_backend_generation);
-            state.guests.insert(
-                vm_id,
-                GuestState {
-                    backend_generation: Some(generation),
-                    ..GuestState::default()
-                },
-            );
+            let guest = GuestState {
+                backend_generation: Some(generation),
+                ..GuestState::default()
+            };
+            state.guests.insert(vm_id, guest);
             state.output.reset_guest(vm_id);
             state.output.register_guest(vm_id);
             generation
@@ -483,26 +481,12 @@ impl ConsoleCore {
         Some(state.output.format(vm_id, multiple_running, bytes))
     }
 
-    fn write_guest_output(&self, vm_id: VMId, generation: BackendGeneration, bytes: &[u8]) {
+    fn write_guest_output(&self, vm_id: VMId, generation: BackendGeneration, bytes: &[u8]) -> bool {
         if bytes.is_empty() {
-            return;
+            return false;
         }
 
-        #[cfg(any(feature = "browser-console", all(test, axtest)))]
-        if crate::network_console::guest_output_connected(vm_id) {
-            let is_current = {
-                let state = self.lock_state();
-                state
-                    .guests
-                    .get(&vm_id)
-                    .is_some_and(|guest| guest.backend_generation == Some(generation))
-            };
-            if !is_current {
-                return;
-            }
-            crate::network_console::submit_guest_output(vm_id, bytes);
-        }
-
+        let mut accepted = false;
         let _output_guard = self.lock_output();
         submit_host_transaction(|emit| {
             let mut state = self.lock_state();
@@ -513,12 +497,15 @@ impl ConsoleCore {
             if guest.backend_generation != Some(generation) {
                 return;
             }
+            accepted = true;
             let formatted =
                 state
                     .output
                     .format_registered_into(vm_id, multiple_running, bytes, emit);
             debug_assert!(formatted, "active backend output state must be registered");
         });
+        drop(_output_guard);
+        accepted
     }
 
     #[cfg(any(feature = "browser-console", test, axtest))]
@@ -538,8 +525,16 @@ impl ConsoleCore {
 
 impl SerialBackend for GuestSerialBackend {
     fn write(&self, bytes: &[u8]) {
-        self.core
-            .write_guest_output(self.vm_id, self.generation, bytes);
+        if !self
+            .core
+            .write_guest_output(self.vm_id, self.generation, bytes)
+        {
+            return;
+        }
+        #[cfg(any(feature = "browser-console", all(test, axtest)))]
+        if crate::network_console::guest_output_connected(self.vm_id) {
+            crate::network_console::submit_guest_output(self.vm_id, bytes);
+        }
     }
 
     fn read(&self, buffer: &mut [u8]) -> usize {

--- a/os/axvisor/src/http/browser_console/mod.rs
+++ b/os/axvisor/src/http/browser_console/mod.rs
@@ -15,7 +15,7 @@ use futures_util::{SinkExt, StreamExt};
 use serde_json::{Value, json};
 mod page;
 
-const BRIDGE_BUFFER_CAPACITY: usize = 4096;
+const BROWSER_INPUT_CAPACITY: usize = 4096;
 /// Browser-console routes served by Axvisor's optional HTTP listener.
 pub(super) fn router() -> Router {
     Router::new()
@@ -68,8 +68,8 @@ async fn upgrade_console(
         })?;
 
     Ok(upgrade
-        .max_message_size(BRIDGE_BUFFER_CAPACITY)
-        .max_frame_size(BRIDGE_BUFFER_CAPACITY)
+        .max_message_size(BROWSER_INPUT_CAPACITY)
+        .max_frame_size(BROWSER_INPUT_CAPACITY)
         .on_upgrade(move |browser| async move {
             if let Err(error) = bridge_console(browser, input, output).await {
                 warn!("{endpoint} browser console bridge stopped: {error:#}");
@@ -111,7 +111,6 @@ async fn bridge_console(
     std::thread::Builder::new()
         .name("browser-console-output".into())
         .spawn(move || {
-            crate::network_console::pin_current_task();
             if let Err(error) = run_browser_output(browser_sender, console_output) {
                 warn!("browser console output stopped: {error:#}");
             }

--- a/os/axvisor/src/http/browser_console/page.rs
+++ b/os/axvisor/src/http/browser_console/page.rs
@@ -65,13 +65,14 @@ pub(super) const INDEX_HTML: &str = r##"<!doctype html>
           this.cursorVisible = true;
           this.renderPaused = false;
           this.renderPending = false;
+          this.renderScheduled = false;
           this.render();
         }
         write(payload) {
           const text = typeof payload === 'string' ? payload : this.decoder.decode(payload, { stream: true });
           for (const character of text) this.consume(character);
           this.trim();
-          this.render();
+          this.scheduleRender();
         }
         consume(character) {
           if (this.mode === 'csi') {
@@ -160,8 +161,20 @@ pub(super) const INDEX_HTML: &str = r##"<!doctype html>
           this.renderPaused = false;
           if (this.renderPending) {
             this.renderPending = false;
-            this.render();
+            this.scheduleRender();
           }
+        }
+        scheduleRender() {
+          if (this.renderPaused) {
+            this.renderPending = true;
+            return;
+          }
+          if (this.renderScheduled) return;
+          this.renderScheduled = true;
+          requestAnimationFrame(() => {
+            this.renderScheduled = false;
+            this.render();
+          });
         }
         trim() {
           if (this.lines.length <= 4000) return;

--- a/os/axvisor/src/main.rs
+++ b/os/axvisor/src/main.rs
@@ -81,8 +81,6 @@ fn init_atomic_output_panic_hook() {
 ///    console services so they are live before any guest boots — then the VM
 ///    lifecycle waiter and the physical-console shell.
 ///
-/// The vCPU tasks are pinned to the secondary CPUs via `phys_cpu_ids` in the
-/// VM configs, while the management console stays on the primary CPU.
 fn main() {
     #[cfg(feature = "test-console-atomic-output")]
     init_atomic_output_panic_hook();
@@ -119,14 +117,10 @@ fn main() {
     // own task so neither the shell nor the VMM blocks it. The console registry
     // is already complete when this task is enqueued, but the server's bind
     // still races guest task scheduling because spawning only enqueues work.
-    #[cfg(any(feature = "browser-console", feature = "http-axum"))]
+    #[cfg(feature = "browser-console")]
     std::thread::Builder::new()
         .name("axvisor-http".into())
         .spawn(|| {
-            #[cfg(feature = "browser-console")]
-            network_console::pin_current_task();
-
-            #[cfg(feature = "browser-console")]
             if let Err(error) = http::serve() {
                 let message = format!(
                     "\r\nAxvisor web console unavailable:\r\n  bind = {}\r\n  error = {error:#}\r\n",
@@ -134,8 +128,13 @@ fn main() {
                 );
                 guest_console::submit_host_bytes(message.as_bytes());
             }
+        })
+        .unwrap_or_else(|error| panic!("failed to start Axvisor HTTP server: {error}"));
 
-            #[cfg(all(feature = "http-axum", not(feature = "browser-console")))]
+    #[cfg(all(feature = "http-axum", not(feature = "browser-console")))]
+    std::thread::Builder::new()
+        .name("axvisor-http".into())
+        .spawn(|| {
             http::serve().unwrap_or_else(|error| panic!("Axvisor HTTP server failed: {error:#}"));
         })
         .unwrap_or_else(|error| panic!("failed to start Axvisor HTTP server: {error}"));
@@ -166,9 +165,6 @@ fn main() {
     #[cfg(not(feature = "no-auto-start"))]
     info!("[OK] Default guest initialized");
 
-    // The management console runs on the primary CPU (Core 0) while the vCPU
-    // tasks are pinned to Core 1 via `phys_cpu_ids`, so it stays responsive
-    // regardless of guest behavior.
     info!("shell task on CPU{}", axvm::host::cpu::current_id());
 
     shell::console_init();

--- a/os/axvisor/src/network_console/delivery.rs
+++ b/os/axvisor/src/network_console/delivery.rs
@@ -1,0 +1,95 @@
+//! Browser frame coalescing owned by one console dispatcher.
+
+use std::vec::Vec;
+
+use ax_std::os::arceos::modules::ax_task::IrqNotify;
+use axvisor::console_mux::HostOutputQueue;
+
+/// Coalescing notification that blocks consumers until a producer publishes work.
+pub(crate) struct BlockingSignal {
+    notify: IrqNotify,
+}
+
+impl BlockingSignal {
+    pub(crate) const fn new() -> Self {
+        Self {
+            notify: IrqNotify::new(),
+        }
+    }
+
+    pub(crate) fn notify_irq(&self) {
+        if !self.notify.is_pending() {
+            self.notify.notify_irq();
+        }
+    }
+
+    pub(crate) fn notify(&self) {
+        if !self.notify.is_pending() {
+            self.notify.notify();
+        }
+    }
+
+    pub(crate) fn drain(&self) {
+        self.notify.drain();
+    }
+
+    pub(crate) fn wait(&self) {
+        self.notify.wait();
+    }
+}
+
+/// Fixed-capacity handoff from a console dispatcher to its WebSocket writer.
+pub(crate) struct DeliveryQueue<const CAPACITY: usize> {
+    queue: HostOutputQueue<CAPACITY>,
+}
+
+impl<const CAPACITY: usize> DeliveryQueue<CAPACITY> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            queue: HostOutputQueue::new(),
+        }
+    }
+
+    pub(crate) fn enqueue(&mut self, bytes: &[u8]) {
+        self.queue.enqueue(bytes);
+    }
+
+    /// Returns preserved bytes and the complete transactions dropped since
+    /// the preceding read.
+    pub(crate) fn dequeue(&mut self, output: &mut [u8]) -> (usize, usize) {
+        let dropped_bytes = self.queue.take_dropped_bytes();
+        let len = self.queue.dequeue(output);
+        (len, dropped_bytes)
+    }
+}
+
+/// One WebSocket frame assembled before crossing the bounded delivery channel.
+pub(crate) struct DeliveryFrame {
+    bytes: Vec<u8>,
+}
+
+impl DeliveryFrame {
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            bytes: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub(crate) fn append(&mut self, bytes: &[u8], dropped_bytes: usize) {
+        if dropped_bytes != 0 {
+            self.bytes.extend_from_slice(
+                format!("\r\n[Axvisor browser console dropped {dropped_bytes} queued bytes]\r\n")
+                    .as_bytes(),
+            );
+        }
+        self.bytes.extend_from_slice(bytes);
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    pub(crate) fn into_bytes(self) -> Vec<u8> {
+        self.bytes
+    }
+}

--- a/os/axvisor/src/network_console/mod.rs
+++ b/os/axvisor/src/network_console/mod.rs
@@ -1,136 +1,211 @@
 //! Board-hosted browser transports for the Axvisor and guest consoles.
 
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::{string::String, sync::OnceLock};
+use std::{
+    string::String,
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
-use ax_std::os::arceos::{
-    modules::ax_task::{AxCpuMask, IrqNotify, set_current_affinity},
-    sync::NoPreemptMutex,
-};
+use ax_std::os::arceos::sync::NoPreemptMutex;
 use axvisor::console_mux::HostOutputQueue;
 use axvm::VMId;
 
 mod layout;
 
+mod delivery;
+
+use delivery::{BlockingSignal, DeliveryFrame, DeliveryQueue};
 use layout::{ConsoleLane, Endpoint, plan_endpoints};
 
 const CONSOLE_LANE_COUNT: usize = ConsoleLane::COUNT;
 const OUTPUT_QUEUE_CAPACITY: usize = 64 * 1024;
 const OUTPUT_BATCH_CAPACITY: usize = 512;
+const OUTPUT_FRAME_TARGET_CAPACITY: usize = 4096;
+const OUTPUT_DELIVERY_QUEUE_CAPACITY: usize = 64 * 1024;
+const OUTPUT_DELIVERY_BATCH_CAPACITY: usize = 4096;
+const OUTPUT_COALESCE_WINDOW: Duration = Duration::from_millis(10);
 const MANAGEMENT_LINE_CAPACITY: usize = 256;
-const MANAGEMENT_CPU_ID: usize = 0;
 
 static OUTPUT_HUB: NetworkOutputHub = NetworkOutputHub::new();
 static ENDPOINTS: OnceLock<Vec<Endpoint>> = OnceLock::new();
 
 struct NetworkOutputHub {
-    queues: NoPreemptMutex<[HostOutputQueue<OUTPUT_QUEUE_CAPACITY>; CONSOLE_LANE_COUNT]>,
-    connected: [AtomicBool; CONSOLE_LANE_COUNT],
-    sessions: [AtomicUsize; CONSOLE_LANE_COUNT],
-    ready: [IrqNotify; CONSOLE_LANE_COUNT],
+    lanes: [NetworkOutputLane; CONSOLE_LANE_COUNT],
+}
+
+struct NetworkOutputLane {
+    queue: NoPreemptMutex<HostOutputQueue<OUTPUT_QUEUE_CAPACITY>>,
+    connected: AtomicBool,
+    session: AtomicUsize,
+    ready: BlockingSignal,
+}
+
+struct BrowserOutputDelivery {
+    queue: NoPreemptMutex<DeliveryQueue<OUTPUT_DELIVERY_QUEUE_CAPACITY>>,
+    closed: AtomicBool,
+    ready: BlockingSignal,
 }
 
 impl NetworkOutputHub {
     const fn new() -> Self {
         Self {
-            queues: NoPreemptMutex::new([
-                HostOutputQueue::new(),
-                HostOutputQueue::new(),
-                HostOutputQueue::new(),
-                HostOutputQueue::new(),
-            ]),
-            connected: [
-                AtomicBool::new(false),
-                AtomicBool::new(false),
-                AtomicBool::new(false),
-                AtomicBool::new(false),
-            ],
-            sessions: [
-                AtomicUsize::new(0),
-                AtomicUsize::new(0),
-                AtomicUsize::new(0),
-                AtomicUsize::new(0),
-            ],
-            ready: [
-                IrqNotify::new(),
-                IrqNotify::new(),
-                IrqNotify::new(),
-                IrqNotify::new(),
+            lanes: [
+                NetworkOutputLane::new(),
+                NetworkOutputLane::new(),
+                NetworkOutputLane::new(),
+                NetworkOutputLane::new(),
             ],
         }
     }
 
     fn submit(&self, lane: ConsoleLane, bytes: &[u8]) {
-        if bytes.is_empty() || !self.connected[lane.index()].load(Ordering::Acquire) {
+        self.lanes[lane.index()].submit(bytes);
+    }
+
+    fn is_connected(&self, lane: ConsoleLane) -> bool {
+        self.lanes[lane.index()].connected.load(Ordering::Acquire)
+    }
+
+    fn begin_session(&self, lane: ConsoleLane) -> Option<usize> {
+        self.lanes[lane.index()].begin_session()
+    }
+
+    fn end_session(&self, lane: ConsoleLane, session: usize) {
+        self.lanes[lane.index()].end_session(session);
+    }
+
+    fn receive(&self, lane: ConsoleLane, session: usize) -> Option<NetworkOutputBatch> {
+        self.lanes[lane.index()].receive(session)
+    }
+
+    fn take_batch(&self, lane: ConsoleLane, session: usize) -> Option<NetworkOutputBatch> {
+        self.lanes[lane.index()].take_batch(session)
+    }
+}
+
+impl NetworkOutputLane {
+    const fn new() -> Self {
+        Self {
+            queue: NoPreemptMutex::new(HostOutputQueue::new()),
+            connected: AtomicBool::new(false),
+            session: AtomicUsize::new(0),
+            ready: BlockingSignal::new(),
+        }
+    }
+
+    fn submit(&self, bytes: &[u8]) {
+        if bytes.is_empty() || !self.connected.load(Ordering::Acquire) {
             return;
         }
         let submitted = {
-            let mut queues = self.queues.lock();
-            if !self.connected[lane.index()].load(Ordering::Acquire) {
+            let mut queue = self.queue.lock();
+            if !self.connected.load(Ordering::Acquire) {
                 false
             } else {
-                queues[lane.index()].enqueue(bytes);
+                queue.enqueue(bytes);
                 true
             }
         };
         if submitted {
-            self.ready[lane.index()].notify_irq();
+            self.ready.notify_irq();
         }
     }
 
-    fn is_connected(&self, lane: ConsoleLane) -> bool {
-        self.connected[lane.index()].load(Ordering::Acquire)
-    }
-
-    fn begin_session(&self, lane: ConsoleLane) -> Option<usize> {
-        let mut queues = self.queues.lock();
-        self.connected[lane.index()]
+    fn begin_session(&self) -> Option<usize> {
+        let mut queue = self.queue.lock();
+        self.connected
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .ok()?;
-        queues[lane.index()] = HostOutputQueue::new();
-        self.ready[lane.index()].drain();
-        Some(
-            self.sessions[lane.index()]
-                .fetch_add(1, Ordering::AcqRel)
-                .wrapping_add(1),
-        )
+        *queue = HostOutputQueue::new();
+        self.ready.drain();
+        Some(self.session.fetch_add(1, Ordering::AcqRel).wrapping_add(1))
     }
 
-    fn end_session(&self, lane: ConsoleLane, session: usize) {
-        let mut queues = self.queues.lock();
-        if self.sessions[lane.index()].load(Ordering::Acquire) == session {
-            self.connected[lane.index()].store(false, Ordering::Release);
-            queues[lane.index()] = HostOutputQueue::new();
-            drop(queues);
-            self.ready[lane.index()].notify();
+    fn end_session(&self, session: usize) {
+        let mut queue = self.queue.lock();
+        if self.session.load(Ordering::Acquire) == session {
+            self.connected.store(false, Ordering::Release);
+            *queue = HostOutputQueue::new();
+            drop(queue);
+            self.ready.notify();
         }
     }
 
-    fn take_batch(&self, lane: ConsoleLane, session: usize) -> Option<NetworkOutputBatch> {
-        let mut queues = self.queues.lock();
-        if !self.connected[lane.index()].load(Ordering::Acquire)
-            || self.sessions[lane.index()].load(Ordering::Acquire) != session
+    fn take_batch(&self, session: usize) -> Option<NetworkOutputBatch> {
+        let mut queue = self.queue.lock();
+        if !self.connected.load(Ordering::Acquire)
+            || self.session.load(Ordering::Acquire) != session
         {
             return None;
         }
         let mut batch = NetworkOutputBatch::new();
-        batch.dropped_bytes = queues[lane.index()].take_dropped_bytes();
-        batch.len = queues[lane.index()].dequeue(&mut batch.bytes);
+        batch.dropped_bytes = queue.take_dropped_bytes();
+        batch.len = queue.dequeue(&mut batch.bytes);
         (!batch.is_empty()).then_some(batch)
     }
 
-    fn receive(&self, lane: ConsoleLane, session: usize) -> Option<NetworkOutputBatch> {
+    fn receive(&self, session: usize) -> Option<NetworkOutputBatch> {
         loop {
-            if let Some(batch) = self.take_batch(lane, session) {
+            if let Some(batch) = self.take_batch(session) {
                 return Some(batch);
             }
-            if !self.connected[lane.index()].load(Ordering::Acquire)
-                || self.sessions[lane.index()].load(Ordering::Acquire) != session
+            if !self.connected.load(Ordering::Acquire)
+                || self.session.load(Ordering::Acquire) != session
             {
                 return None;
             }
-            self.ready[lane.index()].wait();
+            self.ready.wait();
+        }
+    }
+}
+
+impl BrowserOutputDelivery {
+    const fn new() -> Self {
+        Self {
+            queue: NoPreemptMutex::new(DeliveryQueue::new()),
+            closed: AtomicBool::new(false),
+            ready: BlockingSignal::new(),
+        }
+    }
+
+    fn enqueue(&self, bytes: &[u8]) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        let submitted = {
+            let mut queue = self.queue.lock();
+            if self.closed.load(Ordering::Acquire) {
+                false
+            } else {
+                queue.enqueue(bytes);
+                true
+            }
+        };
+        if submitted {
+            self.ready.notify();
+        }
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.ready.notify();
+    }
+
+    fn receive(&self) -> Option<Vec<u8>> {
+        loop {
+            let mut bytes = [0; OUTPUT_DELIVERY_BATCH_CAPACITY];
+            let (len, dropped_bytes) = self.queue.lock().dequeue(&mut bytes);
+            if len != 0 || dropped_bytes != 0 {
+                let mut frame = DeliveryFrame::with_capacity(len + 96);
+                frame.append(&bytes[..len], dropped_bytes);
+                return Some(frame.into_bytes());
+            }
+            if self.closed.load(Ordering::Acquire) {
+                return None;
+            }
+            self.ready.wait();
         }
     }
 }
@@ -208,14 +283,6 @@ fn lane_name(lane: ConsoleLane) -> String {
         .unwrap_or_else(|| format!("console lane {}", lane.index()))
 }
 
-/// Pins one web-console service task to the management CPU.
-pub(crate) fn pin_current_task() {
-    assert!(
-        set_current_affinity(AxCpuMask::one_shot(MANAGEMENT_CPU_ID)),
-        "web console management CPU affinity must be valid"
-    );
-}
-
 /// Returns whether the startup snapshot exposed this browser route.
 pub(crate) fn has_console_route(route: &str) -> bool {
     endpoint_for_route(route).is_some()
@@ -273,14 +340,54 @@ pub(crate) fn open_browser_console(
     let active_session = ActiveSession::install(endpoint.lane)?;
     let lane = active_session.lane;
     let session = active_session.session;
+    let delivery = start_output_dispatcher(lane, session)?;
     Ok((
         BrowserConsoleInput {
             endpoint,
             editor: ManagementLineEditor::new(),
             _active_session: active_session,
         },
-        BrowserConsoleOutput { lane, session },
+        BrowserConsoleOutput { delivery },
     ))
+}
+
+fn start_output_dispatcher(
+    lane: ConsoleLane,
+    session: usize,
+) -> Result<Arc<BrowserOutputDelivery>> {
+    let delivery = Arc::new(BrowserOutputDelivery::new());
+    let dispatcher_delivery = Arc::clone(&delivery);
+    let task_name = format!("{}-browser-console-dispatcher", lane_name(lane));
+    std::thread::Builder::new()
+        .name(task_name.clone())
+        .spawn(move || run_output_dispatcher(lane, session, dispatcher_delivery))
+        .with_context(|| format!("failed to start {task_name}"))?;
+    Ok(delivery)
+}
+
+fn run_output_dispatcher(lane: ConsoleLane, session: usize, delivery: Arc<BrowserOutputDelivery>) {
+    while let Some(frame) = receive_output_frame(lane, session) {
+        delivery.enqueue(&frame);
+    }
+    delivery.close();
+}
+
+fn receive_output_frame(lane: ConsoleLane, session: usize) -> Option<Vec<u8>> {
+    let first = OUTPUT_HUB.receive(lane, session)?;
+    let mut frame = DeliveryFrame::with_capacity(OUTPUT_FRAME_TARGET_CAPACITY);
+    frame.append(&first.bytes[..first.len], first.dropped_bytes);
+
+    // UART backends commonly submit one byte at a time. Coalesce for one
+    // bounded interval in the dispatcher so the HTTP reactor handles frames,
+    // not individual device writes.
+    std::thread::sleep(OUTPUT_COALESCE_WINDOW);
+    while frame.len() < OUTPUT_FRAME_TARGET_CAPACITY {
+        let Some(batch) = OUTPUT_HUB.take_batch(lane, session) else {
+            break;
+        };
+        frame.append(&batch.bytes[..batch.len], batch.dropped_bytes);
+    }
+    Some(frame.into_bytes())
 }
 
 /// Input half of a board-hosted browser console session.
@@ -314,28 +421,15 @@ impl BrowserConsoleInput {
     }
 }
 
-/// Blocking output half woken only by output or session closure.
+/// Blocking output half fed by the lane's fixed-capacity delivery queue.
 pub(crate) struct BrowserConsoleOutput {
-    lane: ConsoleLane,
-    session: usize,
+    delivery: Arc<BrowserOutputDelivery>,
 }
 
 impl BrowserConsoleOutput {
-    /// Waits for one bounded console batch or the browser session to close.
+    /// Waits for one coalesced frame or session closure.
     pub(crate) fn receive(&mut self) -> Option<Vec<u8>> {
-        let batch = OUTPUT_HUB.receive(self.lane, self.session)?;
-        let mut output = Vec::with_capacity(batch.len + 96);
-        if batch.dropped_bytes != 0 {
-            output.extend_from_slice(
-                format!(
-                    "\r\n[Axvisor browser console dropped {} queued bytes]\r\n",
-                    batch.dropped_bytes
-                )
-                .as_bytes(),
-            );
-        }
-        output.extend_from_slice(&batch.bytes[..batch.len]);
-        Some(output)
+        self.delivery.receive()
     }
 }
 

--- a/os/axvisor/src/network_status.rs
+++ b/os/axvisor/src/network_status.rs
@@ -31,14 +31,18 @@ pub(crate) fn start() {
           no reachable web console address yet\r\n\
           VM startup will continue while network configuration completes\r\n",
     );
-    thread::Builder::new()
+    if let Err(error) = thread::Builder::new()
         .name("axvisor-network-status".into())
         .spawn(wait_for_ready_interface)
-        .expect("failed to start Axvisor network status reporter");
+    {
+        let message = format!(
+            "\r\nAxvisor web console address monitor unavailable:\r\n  error = {error}\r\n"
+        );
+        guest_console::submit_host_bytes(message.as_bytes());
+    }
 }
 
 fn wait_for_ready_interface() {
-    crate::network_console::pin_current_task();
     loop {
         thread::sleep(ADDRESS_POLL_INTERVAL);
         if let Some(interface) = ready_interface() {

--- a/os/axvisor/tests/axtest.rs
+++ b/os/axvisor/tests/axtest.rs
@@ -9,6 +9,8 @@ use axvm as _;
 
 // Compile the production guest-console mux with narrow host/manager adapters
 // so its application-layer state machine is exercised by the kernel harness.
+#[path = "../src/network_console/delivery.rs"]
+mod browser_console_delivery;
 #[path = "../src/network_console/layout.rs"]
 mod browser_console_layout;
 mod guest_console_harness;
@@ -65,6 +67,114 @@ mod tests {
 
         ax_assert!(network_console::take_guest_output(1).is_empty());
         mux::remove(1);
+    }
+
+    #[test]
+    fn unterminated_guest_echo_reaches_browser_without_another_input() {
+        use crate::{guest_console_harness::mux, network_console};
+
+        network_console::reset();
+        network_console::set_guest_connected(1);
+        let backend = mux::serial_backend_factory(1).create();
+        mux::mark_running(1);
+
+        backend.write(b"./run_dual_pick.sh");
+
+        ax_assert_eq!(network_console::take_guest_output(1), b"./run_dual_pick.sh");
+        mux::remove(1);
+    }
+
+    #[test]
+    fn guest_byte_writes_reach_network_output_in_order() {
+        use crate::{guest_console_harness::mux, network_console};
+
+        network_console::reset();
+        network_console::set_guest_connected(2);
+        let backend = mux::serial_backend_factory(2).create();
+        mux::mark_running(2);
+
+        for byte in b"zephyr log line\n" {
+            backend.write(core::slice::from_ref(byte));
+        }
+
+        ax_assert_eq!(network_console::take_guest_output(2), b"zephyr log line\n");
+        mux::remove(2);
+    }
+
+    #[test]
+    fn browser_delivery_coalesces_ordered_dispatcher_batches() {
+        use crate::browser_console_delivery::DeliveryFrame;
+
+        let mut delivery = DeliveryFrame::with_capacity(16);
+
+        delivery.append(b"starry ", 0);
+        delivery.append(b"continues", 0);
+
+        ax_assert_eq!(delivery.len(), 16);
+        ax_assert_eq!(delivery.into_bytes(), b"starry continues");
+    }
+
+    #[test]
+    fn browser_delivery_reports_source_queue_overflow_before_preserved_bytes() {
+        use crate::browser_console_delivery::DeliveryFrame;
+
+        let mut delivery = DeliveryFrame::with_capacity(96);
+
+        delivery.append(b"preserved", 11);
+
+        let output = delivery.into_bytes();
+        ax_assert!(
+            output.starts_with(b"\r\n[Axvisor browser console dropped 11 queued bytes]\r\n")
+        );
+        ax_assert!(output.ends_with(b"preserved"));
+    }
+
+    #[test]
+    fn browser_delivery_queue_preserves_old_output_and_reports_new_overflow() {
+        use crate::browser_console_delivery::DeliveryQueue;
+
+        let mut delivery = DeliveryQueue::<8>::new();
+        delivery.enqueue(b"old");
+        delivery.enqueue(b"overflow");
+
+        let mut output = [0; 8];
+        let (len, dropped_bytes) = delivery.dequeue(&mut output);
+        ax_assert_eq!(&output[..len], b"old");
+        ax_assert_eq!(dropped_bytes, 8);
+    }
+
+    #[test]
+    fn browser_delivery_waits_for_notification_without_timer_polling() {
+        use core::sync::atomic::{AtomicBool, Ordering};
+        use std::{sync::Arc, thread, time::Duration};
+
+        use crate::browser_console_delivery::BlockingSignal;
+
+        let signal = Arc::new(BlockingSignal::new());
+        signal.notify_irq();
+        signal.drain();
+        let waiting = Arc::new(AtomicBool::new(false));
+        let woke = Arc::new(AtomicBool::new(false));
+        let worker_signal = Arc::clone(&signal);
+        let worker_waiting = Arc::clone(&waiting);
+        let worker_woke = Arc::clone(&woke);
+        let worker = thread::spawn(move || {
+            worker_waiting.store(true, Ordering::Release);
+            worker_signal.wait();
+            worker_woke.store(true, Ordering::Release);
+        });
+
+        while !waiting.load(Ordering::Acquire) {
+            thread::yield_now();
+        }
+        thread::sleep(Duration::from_millis(30));
+        ax_assert!(!woke.load(Ordering::Acquire));
+
+        signal.notify();
+        worker
+            .join()
+            .expect("delivery waiter must exit after notify");
+        ax_assert!(woke.load(Ordering::Acquire));
     }
 
     #[test]

--- a/os/axvisor/tests/network_console.rs
+++ b/os/axvisor/tests/network_console.rs
@@ -18,6 +18,9 @@ pub(crate) fn guest_output_connected(vm_id: VMId) -> bool {
 }
 
 pub(crate) fn submit_guest_output(vm_id: VMId, bytes: &[u8]) {
+    if !CONNECTED_GUESTS.lock().contains(&vm_id) {
+        return;
+    }
     GUEST_OUTPUT
         .lock()
         .entry(vm_id)

--- a/test-suit/axvisor/normal/qemu-browser-console/browser-console/http_probe.py
+++ b/test-suit/axvisor/normal/qemu-browser-console/browser-console/http_probe.py
@@ -16,6 +16,9 @@ BASE = os.environ.get("AXVISOR_HTTP_BASE", "http://127.0.0.1:8080").rstrip("/")
 CONNECT_TIMEOUT = float(os.environ.get("AXVISOR_HTTP_CONNECT_TIMEOUT", "120"))
 REQUEST_TIMEOUT = float(os.environ.get("AXVISOR_HTTP_REQUEST_TIMEOUT", "5"))
 POLL_INTERVAL = 0.05
+BURST_CHARACTER_COUNT = 96
+BURST_CHARACTER_INTERVAL = 0.001
+BURST_FRAME_LIMIT = 24
 
 
 def get(path):
@@ -156,6 +159,22 @@ def receive_until(websocket, marker):
     return output
 
 
+def receive_until_counting_frames(websocket, marker):
+    output = b""
+    frames = 0
+    deadline = time.monotonic() + REQUEST_TIMEOUT
+    while marker not in output:
+        if time.monotonic() >= deadline:
+            raise AssertionError("WebSocket output did not contain %r" % marker)
+        opcode, payload = websocket.recv_frame()
+        if opcode in (1, 2):
+            output += payload
+            frames += 1
+        elif opcode == 8:
+            raise AssertionError("WebSocket closed before output marker %r" % marker)
+    return output, frames
+
+
 def check_page():
     status, page = get("/")
     expect_status("GET /", status, 200)
@@ -163,6 +182,7 @@ def check_page():
         b"/api/consoles",
         b"terminal-cursor",
         b"pauseRendering()",
+        b"requestAnimationFrame",
         b"selectionchange",
     ):
         if marker not in page:
@@ -191,8 +211,27 @@ def check_websocket():
     websocket = expect_upgrade("/ws/axvisor", 101)
     receive_until(websocket, b"Welcome to AxVisor Browser Shell!")
     websocket.send_binary(b"help\r")
-    receive_until(websocket, b"ArceOS Shell - Available Commands:")
+    help_output = receive_until(websocket, b"axvisor:$ ")
+    if b"ArceOS Shell - Available Commands:" not in help_output:
+        raise AssertionError("WebSocket help output was incomplete")
     print("  browser console probe: Axvisor WebSocket -> interactive")
+
+    for _ in range(BURST_CHARACTER_COUNT):
+        websocket.send_binary(b"x")
+        time.sleep(BURST_CHARACTER_INTERVAL)
+    websocket.send_binary(b"\r")
+    burst_output, burst_frames = receive_until_counting_frames(websocket, b"axvisor:$ ")
+    if b"x" * BURST_CHARACTER_COUNT not in burst_output:
+        raise AssertionError("WebSocket burst output lost or reordered echoed bytes")
+    if burst_frames > BURST_FRAME_LIMIT:
+        raise AssertionError(
+            "WebSocket burst used %d frames for %d characters, expected at most %d"
+            % (burst_frames, BURST_CHARACTER_COUNT, BURST_FRAME_LIMIT)
+        )
+    print(
+        "  browser console probe: %d paced bytes -> %d output frames"
+        % (BURST_CHARACTER_COUNT, burst_frames)
+    )
 
     duplicate = expect_upgrade("/ws/axvisor", 409)
     duplicate.close()


### PR DESCRIPTION
## 问题

启用 Axvisor、StarryOS 和 Zephyr 的网页控制台后，在 Zephyr 日志输出和捡球程序持续运行的场景下，运行一段时间可能出现整体卡死：

- 网页 HTTP 请求失去响应；
- Axvisor、StarryOS 和 Zephyr 的 WebSocket 停止接收数据；
- 物理串口不再输出；
- StarryOS 和 Zephyr 的客户机任务停止推进；
- 物理串口输入和 `Ctrl+X` 也无法恢复。

问题可以在同时打开多个网页控制台后稳定复现。

原实现中，每个网络输出消费者使用 10 ms 超时轮询等待数据。三个控制台同时打开时，即使没有新输出，也会持续产生大量定时器唤醒，长期运行时会挤压 Axvisor 的调度和设备处理路径。

## 修改内容

### 1. 将网络输出改为事件驱动等待

新增 `BlockingSignal`，基于 Axvisor 的 `IrqNotify` 实现：

- 输出生产者入队后发送通知；
- 输出消费者没有数据时阻塞等待；
- session 关闭时发送通知，唤醒并退出消费者；
- 消费者被唤醒后重新检查队列、连接状态和 session 编号。

删除原有的 10 ms 空闲 timeout polling，避免无意义的定时器唤醒。

### 2. 拆分网络输出状态

每个控制台 lane 独立保存：

- 固定容量输出队列；
- 连接状态；
- session 编号；
- 阻塞通知对象。

WebSocket 输出增加独立的 delivery queue，dispatcher 负责从 lane 队列取数据、合并小块输出，再交给 WebSocket 线程发送。

输出队列保持有界，队列满时丢弃完整事务并报告丢弃字节数，避免网络输出反向阻塞客户机或设备回调。

### 3. 修正客户机输出路由

调整 `GuestConsoleMux` 的客户机输出流程：

- 先确认客户机 backend generation 仍然有效；
- 完成物理控制台输出状态更新；
- 释放相关锁后，再将原始客户机字节复制到网络 lane。

这样可以避免过期 backend 或锁持有期间的网络输出操作影响物理串口和客户机输出仲裁。

### 4. 移除固定 CPU 绑定

删除网页 HTTP 线程和网络状态线程的固定 CPU 绑定，恢复由宿主调度器正常分配。

网络控制台不再依赖某个固定管理核，避免未来客户机 vCPU 或宿主任务布局变化时产生额外约束。

### 5. 降低网页高频日志渲染压力

网页终端使用 `requestAnimationFrame` 合并连续输出，避免每个 WebSocket frame 都立即触发完整页面重绘。

### 6. 增加回归测试和架构说明

新增或补充：

- 阻塞通知测试；
- 网络输出顺序测试；
- 输出队列溢出测试；
- 无网页连接时不复制网络输出测试；
- 网页控制台布局和 VM 名称测试；
- QEMU browser-console 交互测试；

## 验证结果

### QEMU

```text
cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
```

结果：

```text
AXTEST_SUMMARY pass=60 fail=0 skip=0 total=60
```

```text
cargo xtask axvisor test qemu --arch aarch64 --test-case browser-console
```

结果：

```text
result: 1/1 case(s) passed
```

覆盖内容包括：

- HTTP 页面访问；
- `/api/consoles`；
- Axvisor WebSocket 输入输出；
- 重复连接返回 409；
- 跨源连接返回 403；
- 不存在的 VM 返回 404；
- 关闭后重新连接；
- 高频输出合并。

### 静态检查

```text
cargo fmt --all
git diff --check
cargo clippy ... -p axvisor ... --features browser-console ... -- -D warnings
```

均通过。依赖 crate 中已有的 unused/dead-code warning 未由本次修改引入。

### Orange Pi 实板

在 OrangePi-5-Plus eMMC 双客户机环境下，同时保持 Axvisor、StarryOS 和 Zephyr 三个网页控制台连接，运行捡球程序约 300 秒：

- StarryOS 和 Zephyr 持续输出；
- StarryOS 最终处理 6993 个感知结果；
- `ivc_dropped=0`；
- HTTP 持续正常响应；
- Axvisor shell 输入正常；
- Zephyr shell 输入正常；
- StarryOS `Ctrl+C` 正常生效；
- 未复现原来的整体卡死。

## 影响范围

本次修改只调整 Axvisor 网络控制台的数据传输、等待和网页渲染路径，不改变：

- 客户机启动流程；
- 客户机 vCPU 和设备调度；
- IVC 协议；
- NPU 和机器人控制逻辑；
- 物理 UART 的原有复用和 `Ctrl+X` 行为。

当前仍保持以下边界：

- Axvisor 管理控制台加最多三个客户机控制台；
- 每个控制台只允许一个活动 WebSocket；
- 网页打开前的输出不提供历史回放；
- 输出队列满时丢弃完整事务；
- 网络不可用时不阻止 Axvisor 和客户机启动。