### PR TITLE
fix(ax-driver): align RK3588 DWCMSHC clock setup

### DIFF
--- a/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
+++ b/drivers/ax-driver/src/block/rockchip/sdhci_rk3588/mod.rs
@@ -40,6 +40,8 @@ use crate::{block::ProbeFdtBlock, mmio::iomap};
 const DWCMSHC_P_VENDOR_AREA1: usize = 0xe8;
 const DWCMSHC_AREA1_MASK: u16 = 0x0fff;
 const DWCMSHC_HOST_CTRL3: usize = 0x08;
+const DWCMSHC_HOST_CTRL3_CMD_CONFLICT: u32 = 1 << 0;
+const DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE: u32 = 1 << 4;
 const DWCMSHC_EMMC_CONTROL: usize = 0x2c;
 const DWCMSHC_CARD_IS_EMMC: u16 = 1 << 0;
 const DWCMSHC_EMMC_DLL_CTRL: usize = 0x800;
@@ -256,7 +258,6 @@ fn init_rk3588_dwcmshc_after_reset(host: &mut Sdhci) -> Result<(), Error> {
         DWCMSHC_EMMC_MISC_CON,
         read_u32(base, DWCMSHC_EMMC_MISC_CON) | MISC_INTCLK_EN,
     );
-    write_u32(base, area1 + DWCMSHC_HOST_CTRL3, 0);
     write_u16(
         base,
         area1 + DWCMSHC_EMMC_CONTROL,
@@ -277,8 +278,15 @@ fn configure_rk3588_dwcmshc_clock(host: &mut Sdhci, target_hz: u32) -> Result<()
 
 fn configure_rk3588_dwcmshc_clock_regs(base: NonNull<u8>, area1: usize, target_hz: u32) {
     // Linux's rk35xx set_clock path disables command-conflict checks and
-    // programs the low-speed DLL bypass while SDHCI clock output is gated.
-    write_u32(base, area1 + DWCMSHC_HOST_CTRL3, 0);
+    // keeps the internal clock ungated while SDHCI clock output is gated.
+    // Preserve unrelated vendor bits because this register also carries
+    // controller-specific state outside the two Rockchip workarounds.
+    let host_ctrl3 = read_u32(base, area1 + DWCMSHC_HOST_CTRL3);
+    write_u32(
+        base,
+        area1 + DWCMSHC_HOST_CTRL3,
+        (host_ctrl3 & !DWCMSHC_HOST_CTRL3_CMD_CONFLICT) | DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE,
+    );
     if target_hz <= 52_000_000 {
         write_u32(base, DWCMSHC_EMMC_DLL_CTRL, 0);
         write_u32(
@@ -432,7 +440,18 @@ mod tests {
         let mut host = unsafe { Sdhci::new(base) };
         init_rk3588_dwcmshc_after_reset(&mut host).unwrap();
 
-        assert_eq!(read_u32(base, 0x0500 + DWCMSHC_HOST_CTRL3), 0);
+        let host_ctrl3 = read_u32(base, 0x0500 + DWCMSHC_HOST_CTRL3);
+        assert_eq!(host_ctrl3 & DWCMSHC_HOST_CTRL3_CMD_CONFLICT, 0);
+        assert_eq!(
+            host_ctrl3 & DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE,
+            DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE,
+            "RK3588 DWCMSHC must keep its internal clock ungated during identification"
+        );
+        assert_eq!(
+            host_ctrl3 & !(DWCMSHC_HOST_CTRL3_CMD_CONFLICT | DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE),
+            u32::MAX & !(DWCMSHC_HOST_CTRL3_CMD_CONFLICT | DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE),
+            "clock setup must preserve unrelated vendor bits"
+        );
         assert_eq!(
             read_u16(base, 0x0500 + DWCMSHC_EMMC_CONTROL) & DWCMSHC_CARD_IS_EMMC,
             DWCMSHC_CARD_IS_EMMC
@@ -496,7 +515,18 @@ mod tests {
         let mut host = unsafe { Sdhci::new(base) };
         configure_rk3588_dwcmshc_clock(&mut host, 400_000).unwrap();
 
-        assert_eq!(read_u32(base, 0x0500 + DWCMSHC_HOST_CTRL3), 0);
+        let host_ctrl3 = read_u32(base, 0x0500 + DWCMSHC_HOST_CTRL3);
+        assert_eq!(host_ctrl3 & DWCMSHC_HOST_CTRL3_CMD_CONFLICT, 0);
+        assert_eq!(
+            host_ctrl3 & DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE,
+            DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE,
+            "clock programming must disable the DWCMSHC internal clock gate"
+        );
+        assert_eq!(
+            host_ctrl3 & !(DWCMSHC_HOST_CTRL3_CMD_CONFLICT | DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE),
+            u32::MAX & !(DWCMSHC_HOST_CTRL3_CMD_CONFLICT | DWCMSHC_HOST_CTRL3_CLK_GATE_DISABLE),
+            "clock programming must preserve unrelated vendor bits"
+        );
         assert_eq!(
             read_u32(base, DWCMSHC_EMMC_DLL_CTRL),
             DWCMSHC_EMMC_DLL_BYPASS | DWCMSHC_EMMC_DLL_START


### PR DESCRIPTION
## 问题

基于 `dev` 的 OrangePi 5 Plus board CI 首个真实错误是 RK3588 DWCMSHC eMMC 控制器 `/mmc@fe2e0000` 在 CMD1 ready 轮询阶段超时。原实现将 `HOST_CTRL3` 整个写为 `0`，与 Linux `rk35xx` 时钟配置语义不一致：内部时钟 gate 没有保持开启，并且无关 vendor 位被清除。

该控制器在当前测试板上没有实际枚举出 eMMC；Linux 侧仅有 SD 设备。因此 eMMC 超时本身仍会出现在无 eMMC 硬件的日志中，但不应通过放宽超时、吞掉错误或修改设备树来掩盖。

## 改动

- 按 Linux `rk35xx` 语义对 `HOST_CTRL3` 做 read-modify-write：清除 command-conflict bit0，设置 internal-clock-gate-disable bit4。
- 保留其它 vendor bits，移除 reset 路径中的重复整寄存器清零。
- 扩展 RK3588 DWCMSHC 单元回归，覆盖 bit0、bit4 和无关位保留。
- 不修改 `axbuild`、board 配置或设备树。

## 验证

- 修复前确定性回归测试失败；修复后 `rk3588_dwcmshc` 2/2 通过。
- `cargo xtask clippy --package ax-driver`：51/51 checks passed。
- `cargo xtask starry test board --board orangepi-5-plus-robot`：`[ROBOT_CI] RESULT=PASS attempts=1`，所有 board test groups passed。
- 最终工作区通过 `cargo fmt --all` 和 `git diff --check`。

板卡日志仍会报告无 eMMC 时的 CMD1 timeout 和该非根设备的 `Io`，但 SD 根盘、文件系统与机器人流程均正常通过；具备实际 eMMC 的硬件仍需使用同一 board 命令验证完整 MMC attach。
