### PR TITLE
fix(container): install cpio for initramfs builders

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
         build-essential \
         clang \
         cmake \
+        cpio \
         curl \
         dosfstools \
         e2fsprogs \


### PR DESCRIPTION
## 问题

AI-RTOS Linux 客户机构建会使用 `cpio` 生成 initramfs；现有开发/CI 基础容器未安装该工具，容器内执行对应 runner 会在 QEMU 启动前停止。

## 修改

在 `container/Dockerfile` 的 Ubuntu 基础依赖中加入 `cpio`。

## 验证

- `docker buildx build --check -f container/Dockerfile .`
- 在 Ubuntu 24.04 中安装 `cpio`，确认 `/usr/bin/cpio` 与 `cpio (GNU cpio) 2.15` 可用。

该修改只补齐容器运行时依赖，不改变 AICP 协议、客户机或 AxVisor 运行时逻辑。