### PR TITLE
fix(axvm): make vCPU kicks guest-mode aware

### DIFF
--- a/docs/design/axvm-vcpu-kick.md
+++ b/docs/design/axvm-vcpu-kick.md
@@ -1,0 +1,119 @@
+# AxVM vCPU kick 分层与状态机
+
+## 1. 问题与结论
+
+PR #1775 的 x86 定时器链曾在每次 vLAPIC 到期后无条件执行共享 wait queue 唤醒、deferred worker 和物理 IPI。VMX 已经因本地 host timer IRQ 退出 guest 时，这会制造第二条 kick 链；在 PREEMPT_RT 调度压力下，它会放大 worker、IPI 和 vCPU entry 的竞争。
+
+AxVM 现在把一次通知拆成三个互不替代的阶段：
+
+1. 生产者发布权威 pending 或业务状态；
+2. runtime 推进 wait condition 并解除 WFI、HLT 或生命周期等待；
+3. 只有远端 CPU 仍处于 guest mode 时，才发送物理 IPI。
+
+这对应 Linux KVM 的 request bit、`KVM_REQ_UNBLOCK`、`vcpu->mode` 和 `kvm_vcpu_kick()` 分工。kick 不是 pending state 的所有者，也不能用一次线程唤醒代替 wait condition。
+
+## 2. 生产者分类
+
+不同生产者必须根据权威状态能否被下一次 backend entry 直接读取，选择不同入口。
+
+| 生产者 | 权威状态 | runtime 入口 |
+| --- | --- | --- |
+| VGIC、vLAPIC、架构中断后端 | 控制器自己的 pending、level、LR 或 APIC 状态 | `VmRuntimeHandle::kick_vcpu()` |
+| `VcpuIrqDispatcher` | 按 vCPU 线程世代登记的 queue entry | enqueue 后调用 `kick_vcpu()` |
+| device poll、访问端口工作 | runtime 或设备自己的工作标志 | `VmRuntimeHandle::request_vcpu()` |
+| stop、pause、resume、reset | VM 或设备生命周期状态 | `VmRuntimeHandle::request_all_vcpus()` |
+| IVC notify | endpoint 已发布的 guest IRQ | `VmRuntimeHandle::kick_all_vcpus()` |
+| x86 vLAPIC hard timer | `x86_vlapic` 的原子到期和 pending 状态 | `VcpuKickHandle::kick_from_hard_irq()` |
+
+`kick_vcpu()` 要求调用者已经发布可被 vCPU 读取的权威状态。`request_vcpu()` 还会发布 sticky entry request，适用于 pending 不由架构 backend 直接消费的工作。公共 `kick_vm_vcpu(vm_id, vcpu_id)` 只提供“状态已发布”的 task-context 入口。
+
+## 3. capability 与生命周期
+
+`VcpuKickHandle` 绑定一个 vCPU host thread 世代，只保存：
+
+- `Arc<VcpuRunState>`：vCPU 生命周期内稳定的 guest-entry ownership；
+- `ThreadWakeHandle`：当前 host thread 世代的直接调度 capability。
+
+`VmRuntimeHandle::add_vcpu_task()` 把 thread、kick capability 和 IRQ dispatcher owner 一起登记。CPU_OFF 先把整组对象从 active registry 转入 retired registry；join 后一起释放。旧 hard callback 只能命中旧 wake handle，或者向 VM-owned deferred worker 发布一个 vCPU bit；worker 会重新从 active registry 获取当前世代。
+
+kick capability 不携带 IRQ 号、虚拟控制器、VM registry、设备或调度器 CPU 快照。vCPU 的 guest owner 只能从 `VcpuRunState::mode` 读取。
+
+## 4. guest-entry 事务
+
+`VcpuRunState` 有两个原子字段：
+
+- `mode`：`OUTSIDE`、`IN_GUEST(cpu)` 或 `EXITING(cpu)`；
+- `exit_requested`：为设备和生命周期工作保留的 sticky entry request。
+
+entry 顺序如下：
+
+```mermaid
+sequenceDiagram
+    participant V as vCPU task
+    participant P as producer
+    participant H as hardware guest
+    V->>V: disable local IRQ and pin CPU
+    V->>V: publish IN_GUEST(cpu)
+    V->>V: final canonical-pending recheck
+    alt pending existed before IN_GUEST
+        V->>V: restore OUTSIDE and drain pending
+    else producer races after IN_GUEST
+        P->>P: publish canonical state
+        P->>V: claim EXITING and conditional IPI
+        V->>V: final sticky/EXITING check
+        V->>H: enter guest only if no request
+    end
+```
+
+发布 `IN_GUEST` 必须早于最终 queue recheck。这样，较早的 enqueue 由 recheck 发现，较晚的 enqueue 一定观察到 `IN_GUEST` 并认领退出，不需要给每个控制器事件附加 generic sticky request。
+
+`VcpuGuestEntry::Drop` 在正常 VM exit、entry retry、entry cancellation 和错误展开时都恢复 `OUTSIDE`，并断言一次 entry 期间 owner CPU 没有变化。entry 全程位于 `PreemptGuard` 和 `IrqSaveGuard` 保护下；迁移必须先离开 guest mode。
+
+## 5. task-context kick
+
+task-context 的顺序固定为：
+
+1. 生产者发布权威状态；若没有 backend pending，再发布 sticky entry request；
+2. `notification_generation` 以 Release 推进，并唤醒共享 wait queue；
+3. `ThreadWakeHandle` 唤醒目标 host thread；
+4. `request_exit()` 原子读取 guest owner；
+5. `OUTSIDE` 不发 IPI，本地 guest 只认领 `EXITING`，远端 guest 返回 owner CPU；
+6. runtime 在 registry 锁外发送远端 IPI。
+
+`notification_generation` 是逻辑 unblock 条件。只调用 `ThreadWakeHandle::wake()` 不能保证 `WaitQueue::wait_until` 的谓词变真，线程可能醒来后再次睡眠。
+
+## 6. hard-IRQ 边界
+
+`VcpuKickHandle::kick_from_hard_irq(current_cpu)` 只执行原子操作和 generation-bound thread wake。它不查询 VM registry，不获取普通锁，也不直接发送可能等待 APIC delivery 的 IPI。
+
+| guest 状态 | hard-IRQ 结果 | 后续动作 |
+| --- | --- | --- |
+| 当前 CPU 的 guest | `Complete` | 当前 host IRQ 已经完成本地 VM exit，只认领 `EXITING` |
+| 已有调用者认领 `EXITING` | `Complete` | 不重复提交 doorbell |
+| `OUTSIDE` | `Defer` | worker 推进逻辑 unblock，防止 waiter 重新睡眠 |
+| 远端 CPU 的 guest | `Defer` | worker 刷新 active 世代并条件发送 IPI |
+| wake handle 已退出或不可用 | `Defer` | worker 从 active registry 重新解析目标 |
+
+x86 vLAPIC hard timer callback 先发布 APIC pending，再调用这个接口。相同 CPU 上的 VMX external-interrupt exit 本身就是 doorbell；只有 timer owner 与 guest owner 不同，或 vCPU 已在 guest 外等待时，才提交 `DeferredVcpuKick`。
+
+AArch64 的 blocked-vCPU software timer 不是控制器 kick：它按 `(owner_cpu, owner_thread)` 绑定 registration 和 wake handle，完成 `Aarch64TimerWaitState` token 后直接唤醒同一 host wait 世代；CPU migration 或 CPU_OFF/CPU_ON 会先废弃旧 timer epoch。vCPU 恢复后才重新计算 timer level 并发布 VGIC PPI。真实 VGIC pending 和 host timer PPI 仍通过 `Aarch64VcpuWake`、deferred worker 和 task-context `kick_vcpu()` 解除 wait。两条链不能混为一个 callback。
+
+## 7. 失败与回收语义
+
+deferred publisher 使用预分配 bitset 合并同一 vCPU 的重复请求。worker 启停跟随 VM 架构 runtime；停止后清空残留 bit。worker 找不到运行中的 VM 或 active vCPU 时丢弃 bit，因为 controller pending 已由对应 VM 生命周期回收，不能把旧世代请求转交给未来新线程。
+
+`kick_all_vcpus()` 只用于调用者已经发布了规范状态的广播通知；`request_all_vcpus()` 先对所有 active capability 发布 sticky request。两者都只推进一次共享 notification generation，随后在 registry 锁外逐个执行条件 IPI。即使 active 集合为空，它们也推进 wait condition，使控制面等待者能观察已经发布的状态。
+
+## 8. 验证要求
+
+确定性测试至少覆盖：
+
+1. `OUTSIDE` sticky request 只取消下一次 entry；
+2. 最终 entry check 能看到本地 `EXITING` claim；
+3. local hard IRQ 不提交远端 doorbell；
+4. `OUTSIDE` 和 remote guest 会转交 task-context worker；
+5. 多个 task kick 只能认领一次 remote exit；
+6. queue publish 发生在逻辑 unblock 和物理 kick 之前；
+7. waiter 在 park 边界前后都不会丢失 notification generation。
+
+运行时验证包括 x86 VMX direct ACPI、MP fallback、OVMF ACPI，以及 AArch64 GICv2、GICv3 timer stress。实体机结果必须记录 board、guest、精确提交和 CI job。

--- a/docs/design/unified-host-timer.md
+++ b/docs/design/unified-host-timer.md
@@ -27,16 +27,17 @@ interrupt. A continuously runnable guest could therefore delay the operation
 that makes its own next scheduling interrupt visible.
 
 The x86 LAPIC now follows KVM's split directly. Hard expiry accumulates an
-atomic pending edge and invokes a pre-bound vCPU wake capability. VMX/SVM
+atomic pending edge and invokes a pre-bound vCPU kick capability. VMX/SVM
 consume and clear pending state immediately before guest entry. A VMX host
-timer expiry is already delivered as the external-interrupt VM exit that
-returns control to AxVM, so routing this local edge through the deferred
-virtual-IRQ worker would re-enter scheduler wait-cell delivery inside the
-clockevent IRQ transaction. The direct wake closes the blocked-vCPU race;
-the VMX exit itself supplies the running-vCPU kick. Timer frequency discovery
+timer expiry on the same CPU is already the external-interrupt VM exit that
+returns control to AxVM, so it does not submit a second deferred kick. If the
+fixed timer owner and a running vCPU are on different CPUs, the hard callback
+publishes one bit to the VM-owned worker, which refreshes the active task
+generation and sends a conditional remote IPI. Timer frequency discovery
 remains independent and is not treated as the timeout fix. PIT routing stays
 in task context because it traverses PIC/IOAPIC device state rather than
-publishing a local architectural timer edge.
+publishing a local architectural timer edge. The complete guest-mode protocol
+is defined in [`axvm-vcpu-kick.md`](axvm-vcpu-kick.md).
 
 ### 1.2 Backend boundary
 
@@ -74,7 +75,7 @@ state and prevents device code from taking over the physical timer.
 | KVM LAPIC and architectural timer | AxVM and architecture vCPU crates | Own guest-visible registers, masking, periodic state, and interrupt level |
 | hrtimer per-CPU bases | `components/ax-task::CpuDeadlineState` | Own typed task deadlines, kernel timers, generation, and callback lifecycle |
 | clockevents | `axruntime::LocalClockEvent` | Exclusively own physical one-shot comparator programming |
-| `kvm_vcpu_kick` and vCPU wait condition | AxVM generation and pre-bound wake capability (the VMX external-interrupt exit is the local kick) | Publish completion before waking and recheck after publishing wait state |
+| `kvm_vcpu_kick` and vCPU wait condition | `VcpuRunState`, generation-bound `VcpuKickHandle`, and VM-owned deferred worker | Publish pending state before waking; send an IPI only for a remote running guest |
 
 Linux KVM arms absolute hard hrtimers for both x86 LAPIC deadlines
 (`arch/x86/kvm/lapic.c`) and the Arm virtual timer software fallback
@@ -221,10 +222,11 @@ read VMCB exit information as an acknowledged host-dispatch token.
 The blocked-vCPU path follows the same lost-wakeup rule as KVM:
 
 1. the timer callback publishes its completed generation with `Release`;
-2. it invokes only a pre-bound `ThreadWakeHandle`, and never performs a VM
-   lookup or calls task-context-only `WaitQueue::notify_*`. For VMX, the host
-   timer interrupt has already forced the external-interrupt VM exit, so no
-   second deferred kick is needed;
+2. the AArch64 blocked-vCPU timer invokes its generation-bound
+   `ThreadWakeHandle`; the x86 vLAPIC timer publishes APIC pending and invokes
+   its pre-bound `VcpuKickHandle`. Neither hard callback performs a VM lookup
+   or calls task-context-only `WaitQueue::notify_*`; x86 `OUTSIDE` and remote
+   guest cases are published to the VM-owned task-context worker;
 3. the waiter publishes its waiting state;
 4. the waiter rechecks completion and architectural pending conditions with
    `Acquire` before sleeping.
@@ -232,10 +234,10 @@ The blocked-vCPU path follows the same lost-wakeup rule as KVM:
 The hard callback never takes a VGIC or vLAPIC register lock. Arm virtual-timer
 PPI level is recomputed after the vCPU wakes and immediately before guest
 entry. x86 LAPIC hard expiry similarly touches only atomic pending/deadline
-state and a pre-bound wake capability; the target vCPU reads the LVT and
-coalesces accumulated expirations before entry. Wired IOAPIC edges still use
-the VM-owned deferred kick worker, because they do not arrive through the
-local LAPIC timer's VMX exit. PIT, LoongArch architectural timers, and
+state and a pre-bound kick capability; the target vCPU reads the LVT and
+coalesces accumulated expirations before entry. Wired IOAPIC edges and remote
+timer owners use the same VM-owned deferred kick worker. PIT, LoongArch
+architectural timers, and
 emulated device timers continue to use soft kernel timers when their callbacks
 require ordinary task context.
 

--- a/docs/docs/architecture/axvisor/device-runtime.md
+++ b/docs/docs/architecture/axvisor/device-runtime.md
@@ -83,7 +83,7 @@ AArch64 的默认 controller 从 vGIC service 的 core 取得；其他三种架�
 
 ### 3.3 poll 与 lifecycle
 
-vCPU0 是唯一的设备 poll owner，在主运行循环每轮调用 `poll_vm_devices()`：先轮询普通 pollables，再为 DMA-pollables 创建一次性的 `VmGuestMemoryAccess`。宿主控制台把输入入队后调用 `notify_vm()`，但其唤醒语义取决于 vCPU 数量。单 vCPU VM 走 `notify_device_poll()`，先设置可跨 WFI 保留的 pending poll request，再 `notify_one()`；vCPU0 下次进入循环时消费该 flag 并执行 poll。SMP VM 当前只对所有 vCPU 共享的 wait queue 调用 `notify_one()`，不发布 poll flag，也无法指定唤醒 vCPU0；如果被唤醒的是 secondary vCPU，空闲的 vCPU0 可能仍不运行，控制台输入会延迟到 vCPU0 因其他事件再次进入循环。无论哪条分支，控制台上下文都不直接调用 UART 或 vGIC。
+vCPU0 是唯一的设备 poll owner，在主运行循环每轮调用 `poll_vm_devices()`：先轮询普通 pollables，再为 DMA-pollables 创建一次性的 `VmGuestMemoryAccess`。宿主控制台把输入入队后调用 `notify_vm()`；runtime 先设置可跨 WFI 保留的 `device_poll_requested`，再通过线程世代绑定的 vCPU kick capability 定向唤醒 vCPU0。目标正在远端 CPU 的 guest mode 中时才发送 IPI，阻塞或尚未进入 guest 时只执行直接唤醒。因此单 vCPU 与 SMP VM 使用同一条 pending-before-kick 链路，secondary vCPU 不会误消费设备 poll 请求。控制台上下文仍不直接调用 UART 或 vGIC。
 
 lifecycle capability 的调用顺序由通用 runtime 固定：
 
@@ -269,7 +269,7 @@ guest EOI/DIR 使 vGIC 完成当前物理 activation。backend deactivate 在控
 | 显式 wired assert/deassert 的 sink 更新失败 | 返回 `IrqError`，aggregate 计数和 line 本地 asserted 状态回滚 | 调用方可重试 |
 | asserted `IrqLine` drop 时最后一次 sink deassert 失败 | 错误被忽略；source 移除已经提交，无法回滚或报告 | runtime 无法重试这次 drop 通知，sink 可能仍观察到旧电平 |
 | reset/suspend/resume 中 lifecycle 回调失败 | 立即停止后续回调并阻止 Machine 状态转换 | 不补偿已完成的前序回调；设备集合可能部分完成 |
-| 空闲 SMP guest 收到控制台输入 | `notify_vm()` 只 `notify_one()` 共享 wait queue，不设置 poll flag，可能唤醒 secondary vCPU | 不能保证 vCPU0 立即 poll；输入可能延迟到 vCPU0 的下一次退出或其他唤醒 |
+| 空闲 SMP guest 收到控制台输入 | `notify_vm()` 先发布 `device_poll_requested`，再定向 kick vCPU0 | vCPU0 被阻塞时直接唤醒；在远端 guest mode 时条件发送 IPI；secondary 不消费该请求 |
 | backend 不支持物理 backing | `Unsupported`，VM prepare/start 失败 | 不静默降级为近似语义 |
 | physical teardown 中 mask/deactivate/unbind 失败 | 保留可识别的 binding/claim；delivery state 按已完成阶段提交 | 允许重试；不会双重 deactivate 或提前归还 host ownership |
 

--- a/docs/docs/architecture/axvisor/guest-console.md
+++ b/docs/docs/architecture/axvisor/guest-console.md
@@ -230,7 +230,7 @@ flowchart LR
 
 ## 7. 并发边界与当前限制
 
-控制台的并发正确性依赖几个显式约束：宿主输入单 reader、双锁固定顺序、vCPU0 独占设备 poll。下表逐条列出这些边界的当前保证与已知限制；SMP 唤醒限制是当前设计的已知约束而非实现缺陷，演进方向在本节末尾说明。
+控制台的并发正确性依赖几个显式约束：宿主输入单 reader、双锁固定顺序、vCPU0 独占设备 poll。下表逐条列出这些边界的当前保证与已知限制。
 
 | 边界 | 当前保证 | 限制 |
 | --- | --- | --- |
@@ -240,7 +240,7 @@ flowchart LR
 | VM notify | 入队后锁外 notify，不把 mux 锁带进 manager/scheduler | notify 失败只告警，字节等后续 poll |
 | 虚拟设备 poll | 只有 vCPU0 调用 `poll_vm_devices()`，它是串口 backend 的唯一 poll owner | secondary vCPU 不消费串口输入 |
 | 单 vCPU guest | `notify_vm()` 设置 Release 发布的 pending device-poll flag 并唤醒；vCPU0 用 Acquire/AcqRel 消费 | flag 只表达“需要 poll”，不计数；队列才保存字节 |
-| SMP guest | 当前沿用共享 wait queue 的 `notify_one()`，不发布 shared poll flag | 无法定向唤醒 vCPU0，可能只唤醒 secondary；空闲 SMP guest 的输入会延迟到 vCPU0 下次 VM-exit 或其他唤醒 |
+| SMP guest | 与单 vCPU guest 一样先发布 pending device-poll flag，再通过线程世代绑定的 capability 定向 kick vCPU0 | flag 只表达“需要 poll”，不计数；队列才保存字节 |
 | 输出并发 | `output_lock` 覆盖 format 与 ring replay；固定队列保持事务边界，只有 output worker 等待 UART | transport 满时丢弃当前完整事务；per-guest ring 淘汰最旧字节；两者均报告摘要且不阻塞 vCPU writer |
 | 网络输出 | 每端点独立 64 KiB 固定队列；有连接时 vCPU 只复制原始字节并通过 `IrqNotify` 唤醒对应网页输出任务 | 无连接时不保留历史也不获取网络队列锁；慢客户端只影响自身通道并最终触发该端点队列丢弃摘要 |
 
@@ -258,7 +258,7 @@ flowchart LR
 HTML、CSS 和 JavaScript 均编译进 Axvisor，不依赖 GitHub、CDN 或开发板根文件系统；
 不存在需要命令主机持续运行的网页代理路径。
 
-SMP 限制不能通过让任意 vCPU poll 来规避，那会破坏设备 poll 的 single-owner 假设。正确演进方向是为 vCPU0 提供可定向的 wait/wake 路径，再为 SMP 发布 pending poll 请求。
+SMP 路径仍不能让任意 vCPU poll，那会破坏设备 poll 的 single-owner 假设。线程世代绑定的 vCPU0 kick capability 只解决定向 wait/wake；设备 poll 的所有权仍固定在 vCPU0。
 
 ## 8. 故障定位
 
@@ -270,7 +270,7 @@ SMP 限制不能通过让任意 vCPU poll 来规避，那会破坏设备 poll �
 | 输入空闲时 shell 占用 CPU | `wait_for_host_event()` 是否走 `wait_event()` / `wait_readable()` | shell 不应以 `yield_now()` 轮询 task-console |
 | 宿主日志插入正在编辑的命令 | 是否取得唯一日志订阅；记录是否经 `route_host_log()`；drop 摘要是否增长 | shell 模式必须清行、输出完整记录并重画；guest 前台模式必须缓存而非直写 |
 | `vm console` 报错 | VM ID 是否存在，状态是否严格为 `Running` | attach 不接受 Ready、Paused、Stopping 或 Stopped |
-| 客户机不立即收到输入 | 输入队列是否满及 overflow warning；`notify_vm` warning；guest 是否 SMP 且 vCPU0 空闲 | 4096 字节尾部丢弃并按 drain 周期报告一次；SMP notify 不能定向 vCPU0 |
+| 客户机不立即收到输入 | 输入队列是否满及 overflow warning；`notify_vm` warning；vCPU0 是否持续产生可处理的 VM-exit | 4096 字节尾部丢弃并按 drain 周期报告一次；kick 会定向唤醒或退出 vCPU0 |
 | reset 后控制台永久无输入输出 | reset 前是否调用过 `mark_stopped()`；是否误以为 reset 会创建 backend | reset clone 同一 backend Arc，不会发布新 generation；已失效 generation 不会自动复活 |
 | replace/stop 后仍看到 late output | 应用路径是否真的调用 `mark_stopped()`/`remove()`；写入 backend generation 是否仍 current | 底层 stop/remove 不自动接入 mux；stale 写应在修改 output 前被拒绝 |
 | 多 VM 启动日志看似停住 | 对应 VM 是否只写了未结束片段 | BootMultiplex 在多 VM 时等完整 `\n` 行；切换 owner 才做物理补行 |

--- a/virtualization/axvm/src/arch/aarch64/vtimer/state.rs
+++ b/virtualization/axvm/src/arch/aarch64/vtimer/state.rs
@@ -3,7 +3,7 @@
 use std::{
     boxed::Box,
     sync::{
-        Arc, OnceLock,
+        Arc,
         atomic::{AtomicBool, AtomicU64, Ordering},
     },
     time::Duration,
@@ -33,7 +33,17 @@ struct HostTimerActivation {
 struct ScheduledWaitTimer {
     handle: KernelTimerHandle,
     owner_cpu: usize,
+    owner_thread: crate::host::task::ThreadId,
     epoch: u64,
+}
+
+fn wait_timer_owner_matches(
+    owner_cpu: usize,
+    owner_thread: crate::host::task::ThreadId,
+    current_cpu: usize,
+    current_thread: crate::host::task::ThreadId,
+) -> bool {
+    owner_cpu == current_cpu && owner_thread == current_thread
 }
 
 pub(in crate::arch::aarch64) type Aarch64TimerWaitToken = crate::vm::VcpuTimerWaitToken;
@@ -44,7 +54,6 @@ struct Aarch64TimerWaitState {
     armed_timer_epoch: AtomicU64,
     next_timer_epoch: AtomicU64,
     active_timer_epoch: AtomicU64,
-    wake: OnceLock<crate::host::task::ThreadWakeHandle>,
 }
 
 impl Aarch64TimerWaitState {
@@ -55,13 +64,7 @@ impl Aarch64TimerWaitState {
             armed_timer_epoch: AtomicU64::new(0),
             next_timer_epoch: AtomicU64::new(0),
             active_timer_epoch: AtomicU64::new(0),
-            wake: OnceLock::new(),
         }
-    }
-
-    fn bind_current_thread_wake(&self) {
-        self.wake
-            .get_or_init(|| crate::host::task::current_thread().wake_handle());
     }
 
     fn arm(&self, deadline_counter: u64, timer_epoch: u64) -> Aarch64TimerWaitToken {
@@ -125,12 +128,6 @@ impl Aarch64TimerWaitState {
 
     fn invalidate(&self) -> bool {
         self.completion.invalidate()
-    }
-
-    fn wake_from_hard_timer(&self) {
-        if let Some(wake) = self.wake.get() {
-            let _result = wake.wake();
-        }
     }
 }
 
@@ -253,13 +250,19 @@ impl Aarch64TimerBinding {
             return Ok(None);
         };
 
-        self.wait_state.bind_current_thread_wake();
         let deadline_ns = host_deadline_ns(deadline_counter, now_counter, self.frequency);
         let deadline = Duration::from_nanos(deadline_ns);
         let current_cpu = default_host().this_cpu_id();
+        let current_thread = crate::host::task::current_thread();
+        let owner_thread = current_thread.id();
         let existing = *self.scheduled.lock();
         if let Some(existing) = existing
-            && existing.owner_cpu == current_cpu
+            && wait_timer_owner_matches(
+                existing.owner_cpu,
+                existing.owner_thread,
+                current_cpu,
+                owner_thread,
+            )
         {
             let wait_token = self.wait_state.arm(deadline_counter, existing.epoch);
             default_host()
@@ -282,6 +285,7 @@ impl Aarch64TimerBinding {
         let wait_token = self.wait_state.arm(deadline_counter, epoch);
         let frequency = self.frequency;
         let wait_state = Arc::clone(&self.wait_state);
+        let wake = current_thread.wake_handle();
         let registration = unsafe {
             // SAFETY: the stable callback reads only the architectural counter
             // and atomically published arm state, then invokes the prebound
@@ -305,7 +309,7 @@ impl Aarch64TimerBinding {
                         return HostHardTimerAction::Rearm(Duration::from_nanos(deadline_ns));
                     }
                     if wait_state.publish_completion_for_epoch(epoch, wait_token) {
-                        wait_state.wake_from_hard_timer();
+                        let _result = wake.wake();
                     }
                     HostHardTimerAction::Disarm
                 }),
@@ -322,6 +326,7 @@ impl Aarch64TimerBinding {
         *self.scheduled.lock() = Some(ScheduledWaitTimer {
             handle,
             owner_cpu: current_cpu,
+            owner_thread,
             epoch,
         });
         Ok(Some(wait_token))
@@ -407,6 +412,20 @@ impl Aarch64TimerBinding {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn wait_timer_reuse_requires_the_same_cpu_and_thread_generation() {
+        let owner = crate::host::task::ThreadId::from_parts(3, 7);
+
+        assert!(wait_timer_owner_matches(2, owner, 2, owner));
+        assert!(!wait_timer_owner_matches(
+            2,
+            owner,
+            2,
+            crate::host::task::ThreadId::from_parts(3, 8)
+        ));
+        assert!(!wait_timer_owner_matches(2, owner, 1, owner));
+    }
 
     #[test]
     fn stale_timer_epoch_cannot_complete_rearmed_wait() {

--- a/virtualization/axvm/src/arch/x86_64/mod.rs
+++ b/virtualization/axvm/src/arch/x86_64/mod.rs
@@ -379,25 +379,32 @@ impl X86VlapicHostOps for AxvmX86HostOps {
         let (vm_id, vcpu_id) =
             with_current_vcpu::<AxvmX86Vcpu, _>(|vcpu| vcpu.map(|vcpu| (vcpu.vm_id(), vcpu.id())))
                 .ok_or(X86VlapicError::TimerUnavailable)?;
-        let kick = manager::with_vm(vm_id, |vm| irq::vcpu_kick_for_vm(vm))
-            .flatten()
-            .ok_or(X86VlapicError::TimerUnavailable)?;
-        let wake = crate::host::task::current_thread().wake_handle();
+        let (deferred_kick, vcpu_kick) = manager::with_vm(vm_id, |vm| {
+            let deferred = irq::vcpu_kick_for_vm(vm)?;
+            let runtime = vm.runtime_handle().ok()?;
+            let kick = runtime.vcpu_kick_handle(vcpu_id).ok()?;
+            Some((deferred, kick))
+        })
+        .flatten()
+        .ok_or(X86VlapicError::TimerUnavailable)?;
+        let timer_cpu = crate::host::task::current_cpu_id();
         unsafe {
             // SAFETY: x86_vlapic proves that its callback touches only atomic
             // pending/deadline state and IRQ-safe registration locks. The
-            // owning vCPU wake handle and deferred kick publisher are
-            // pre-bound in task context and explicitly safe to invoke from
-            // hard IRQ. The kick is required when the host timer callback is
-            // observed outside the VMX exit that made the physical edge
-            // pending; the worker sends the target-vCPU IPI after the IRQ
-            // transaction has released its scheduler baton.
+            // owning vCPU kick capability and deferred remote-exit publisher
+            // are pre-bound in task context and explicitly safe to invoke
+            // from hard IRQ. A local host timer IRQ already exits the guest;
+            // only a vCPU still running on another CPU is handed to the
+            // task-context worker after the IRQ transaction releases its
+            // scheduler baton.
             default_host().register_hard_restartable_timer(
                 Duration::from_nanos(deadline_nanos),
                 Box::new(move |now| {
                     let action = callback(now.as_nanos() as u64);
-                    let _ = wake.wake();
-                    let _ = kick.publish_from_irq(vcpu_id);
+                    if vcpu_kick.kick_from_hard_irq(timer_cpu) == crate::runtime::HardIrqKick::Defer
+                    {
+                        let _ = deferred_kick.publish_from_irq(vcpu_id);
+                    }
                     match action {
                         X86TimerAction::Complete => HostHardTimerAction::Complete,
                         X86TimerAction::Rearm(deadline) => {

--- a/virtualization/axvm/src/architecture/mod.rs
+++ b/virtualization/axvm/src/architecture/mod.rs
@@ -22,7 +22,9 @@ pub(crate) use exit::{handle_hypercall, handle_mmio_read, handle_mmio_write};
 #[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
 pub(crate) use exit::{try_handle_mmio_read, try_handle_mmio_write};
 pub(crate) use ops::ArchOps;
-pub(crate) use types::{BoundVcpuExit, HypercallExit, MmioReadExit, MmioWriteExit, VcpuRunAction};
+pub(crate) use types::{
+    BoundVcpuExit, HypercallExit, MmioReadExit, MmioWriteExit, VcpuRunAction, VcpuRunOutcome,
+};
 
 /// Complete compile-time contract implemented by every selected guest architecture.
 ///

--- a/virtualization/axvm/src/architecture/ops.rs
+++ b/virtualization/axvm/src/architecture/ops.rs
@@ -6,7 +6,7 @@ use ax_std::os::arceos::guard::IrqSaveGuard;
 use axaddrspace::NestedPageTableOps;
 use axvm_types::{VmArchPerCpuOps, VmArchVcpuOps, VmVcpuState};
 
-use super::{BoundVcpuExit, VcpuRunAction};
+use super::{BoundVcpuExit, VcpuRunAction, VcpuRunOutcome};
 use crate::{AxVmResult, ax_err, irq::model::PendingVcpuInterrupt};
 
 pub(crate) trait ArchOps {
@@ -137,7 +137,7 @@ pub(crate) trait ArchOps {
     fn run_vcpu(
         vm: &crate::AxVMRef,
         vcpu: &crate::vm::AxVCpuRef<Self::VCpu>,
-    ) -> AxVmResult<VcpuRunAction>
+    ) -> AxVmResult<VcpuRunOutcome>
     where
         Self: Sized,
     {
@@ -176,31 +176,42 @@ pub(crate) trait ArchOps {
                         // before the entry-only IRQ-disabled section.
                         Self::before_vcpu_run(vm, vcpu)?;
 
-                        // Match Linux KVM's request/entry ordering: after the
-                        // final queue check, keep local IRQs disabled through
-                        // guest entry. A request published before this check is
-                        // observed below; a later IPI remains pending until it
-                        // forces a guest exit.
+                        // Match Linux KVM's request/entry ordering: publish
+                        // IN_GUEST before the final canonical-pending recheck,
+                        // and keep local IRQs disabled through hardware entry.
+                        // A later remote request observes IN_GUEST and leaves
+                        // an IPI pending until hardware entry or VM exit.
                         let entry_irq_guard = IrqSaveGuard::new();
-                        if interrupt_runtime.as_ref().is_some_and(|runtime| {
-                            runtime
-                                .irq_dispatcher()
-                                .has_pending(vcpu_id, interrupt_owner)
-                        }) {
-                            drop(entry_irq_guard);
-                            continue;
+                        match vcpu.run_loaded(|| {
+                            interrupt_runtime.as_ref().is_some_and(|runtime| {
+                                runtime
+                                    .irq_dispatcher()
+                                    .has_pending(vcpu_id, interrupt_owner)
+                            })
+                        })? {
+                            crate::vcpu::VcpuRunResult::Retry => {
+                                drop(entry_irq_guard);
+                                continue;
+                            }
+                            crate::vcpu::VcpuRunResult::ExitRequested => {
+                                drop(entry_irq_guard);
+                                break Ok(None);
+                            }
+                            crate::vcpu::VcpuRunResult::VmExit(exit) => {
+                                Self::after_vcpu_run(vm, vcpu);
+                                drop(entry_irq_guard);
+                                break Ok(Some(exit));
+                            }
                         }
-
-                        let exit = vcpu.run_loaded();
-                        Self::after_vcpu_run(vm, vcpu);
-                        drop(entry_irq_guard);
-                        break exit;
                     }
                 })
             },
-            |exit| {
-                trace!("{exit:#x?}");
-                Self::handle_vcpu_exit_unbound(vm, vcpu, exit)
+            |exit| match exit {
+                Some(exit) => {
+                    trace!("{exit:#x?}");
+                    Self::handle_vcpu_exit_unbound(vm, vcpu, exit)
+                }
+                None => Ok(BoundVcpuExit::EntryCanceled),
             },
         );
 
@@ -208,22 +219,26 @@ pub(crate) trait ArchOps {
         match run_result {
             Ok(BoundVcpuExit::Complete(action)) => {
                 unbind_result?;
-                Ok(action)
+                Ok(VcpuRunOutcome::Entered(action))
             }
             Ok(BoundVcpuExit::Defer(work)) => {
                 unbind_result?;
-                Self::finish_deferred_run_work(vm, vcpu, work)
+                Self::finish_deferred_run_work(vm, vcpu, work).map(VcpuRunOutcome::Entered)
             }
             Ok(BoundVcpuExit::DeferHypercall(work)) => {
                 unbind_result?;
                 let return_value = crate::runtime::hvc::finish_deferred_hypercall(vm.clone(), work);
                 vcpu.set_return_value(return_value);
-                Ok(VcpuRunAction {
+                Ok(VcpuRunOutcome::Entered(VcpuRunAction {
                     waits_for_event: false,
                     stop_reason: None,
                     resets_vm: false,
                     exits_vcpu: false,
-                })
+                }))
+            }
+            Ok(BoundVcpuExit::EntryCanceled) => {
+                unbind_result?;
+                Ok(VcpuRunOutcome::EntryCanceled)
             }
             Ok(BoundVcpuExit::Continue) => unreachable!("continued exits do not leave run loop"),
             Err(err) => {

--- a/virtualization/axvm/src/architecture/types.rs
+++ b/virtualization/axvm/src/architecture/types.rs
@@ -13,9 +13,21 @@ pub(crate) struct VcpuRunAction {
     pub(crate) exits_vcpu: bool,
 }
 
+/// Outcome of one architecture-neutral vCPU run attempt.
+pub(crate) enum VcpuRunOutcome {
+    /// Hardware guest entry completed and produced a scheduler action.
+    Entered(VcpuRunAction),
+    /// A concurrent request canceled entry after architecture state was
+    /// loaded. The outer task loop must observe device and lifecycle state
+    /// before trying again.
+    EntryCanceled,
+}
+
 /// Result of handling one exit while the vCPU is still bound to the host CPU.
 #[derive(Debug)]
 pub(crate) enum BoundVcpuExit<D> {
+    /// A request canceled hardware entry after architecture state was loaded.
+    EntryCanceled,
     /// The exit was handled completely; re-enter the guest in the current run slice.
     Continue,
     /// The run slice is complete and can return this scheduler action after unbind.

--- a/virtualization/axvm/src/configured/devices/virtio_net.rs
+++ b/virtualization/axvm/src/configured/devices/virtio_net.rs
@@ -255,12 +255,12 @@ struct AxvmWakeTarget {
 
 impl WakeTarget for AxvmWakeTarget {
     fn notify(&self) {
-        // Wake only; vCPU0 polls DMA devices at the top of its next run-loop
-        // iteration. Polling synchronously from the sender's device access
-        // would let two VM device runtimes re-enter each other.
-        if let Err(error) = crate::notify_vm_vcpu(self.vm_id, 0) {
+        // Publish the poll request before kicking vCPU0. Polling synchronously
+        // from the sender's device access would let two VM device runtimes
+        // re-enter each other.
+        if let Err(error) = crate::runtime::notify_vm(self.vm_id) {
             warn!(
-                "failed to notify VM[{}] for virtio-net RX: {error:#}",
+                "failed to kick VM[{}] for virtio-net RX: {error:#}",
                 self.vm_id
             );
         }

--- a/virtualization/axvm/src/host/arceos.rs
+++ b/virtualization/axvm/src/host/arceos.rs
@@ -198,8 +198,9 @@ impl HostCpu for ArceOsHost {
 }
 
 pub(crate) type ArceOsThreadHandle = runtime_task::ThreadHandle;
-#[cfg(target_arch = "aarch64")]
 pub(crate) type ArceOsThreadWakeHandle = runtime_task::ThreadWakeHandle;
+#[cfg(target_arch = "x86_64")]
+pub(crate) type ArceOsWakeResult = runtime_task::WakeResult;
 pub(crate) type ArceOsWaitQueue = runtime_task::WaitQueue;
 #[cfg(target_arch = "aarch64")]
 pub(crate) type ArceOsIrqError = modules::ax_hal::irq::IrqError;
@@ -334,8 +335,8 @@ pub(crate) fn cpu_set_one(cpu_id: usize) -> ArceOsCpuSet {
     affinity
 }
 
-pub(crate) fn thread_cpu_id(thread: &ArceOsThreadHandle) -> Option<usize> {
-    thread.assigned_cpu().map(|cpu| cpu.as_usize())
+pub(crate) fn current_cpu_id() -> usize {
+    modules::ax_hal::percpu::this_cpu_id()
 }
 
 pub(crate) fn yield_now() {

--- a/virtualization/axvm/src/host/task.rs
+++ b/virtualization/axvm/src/host/task.rs
@@ -3,8 +3,9 @@
 use super::arceos;
 
 pub(crate) type ThreadHandle = arceos::ArceOsThreadHandle;
-#[cfg(target_arch = "aarch64")]
 pub(crate) type ThreadWakeHandle = arceos::ArceOsThreadWakeHandle;
+#[cfg(target_arch = "x86_64")]
+pub(crate) type WakeResult = arceos::ArceOsWakeResult;
 pub(crate) type IrqNotification = arceos::ArceOsIrqNotification;
 pub(crate) type ThreadExtensionBorrow<'thread> =
     ax_std::os::arceos::task::ThreadOsExtensionBorrow<'thread>;
@@ -58,8 +59,8 @@ pub(crate) fn cpu_set_from_raw_bits(bits: usize) -> CpuSet {
     arceos::cpu_set_from_raw_bits(bits)
 }
 
-pub(crate) fn thread_cpu_id(thread: &ThreadHandle) -> Option<usize> {
-    arceos::thread_cpu_id(thread)
+pub(crate) fn current_cpu_id() -> usize {
+    arceos::current_cpu_id()
 }
 
 #[cfg(target_arch = "aarch64")]

--- a/virtualization/axvm/src/irq/deferred.rs
+++ b/virtualization/axvm/src/irq/deferred.rs
@@ -107,7 +107,9 @@ impl DeferredVcpuKick {
             }
             let pending = self.pending_vcpus.swap(0, Ordering::AcqRel);
             for vcpu_id in SetBits(pending) {
-                if let Err(error) = crate::runtime::vcpus::notify_vcpu(self.vm_id, vcpu_id) {
+                if let Err(error) =
+                    crate::runtime::vcpus::kick_vcpu_from_published_state(self.vm_id, vcpu_id)
+                {
                     trace!(
                         "VM[{}] deferred IRQ kick for vCPU {vcpu_id} was not delivered: {error:?}",
                         self.vm_id

--- a/virtualization/axvm/src/irq/sender.rs
+++ b/virtualization/axvm/src/irq/sender.rs
@@ -171,7 +171,7 @@ mod tests {
             |runtime, vcpu_id, interrupt| {
                 dispatch_vcpu_interrupt_with(
                     || {
-                        let cpu_id = runtime.cpu_id.ok_or_else(|| {
+                        runtime.cpu_id.ok_or_else(|| {
                             ax_err_type!(NotFound, format_args!("vCPU {vcpu_id} task not found"))
                         })?;
                         let needs_kick = runtime
@@ -184,10 +184,12 @@ mod tests {
                                 )
                             })?;
                         events.borrow_mut().push("enqueue");
-                        Ok(needs_kick.then_some(cpu_id))
+                        Ok(needs_kick)
                     },
-                    || events.borrow_mut().push("notify"),
-                    |_| events.borrow_mut().push("ipi"),
+                    || {
+                        events.borrow_mut().push("kick");
+                        Ok(())
+                    },
                 )
             },
         )
@@ -209,7 +211,7 @@ mod tests {
 
             send(&sender, 0, interrupt(1), &events).unwrap();
 
-            assert_eq!(*events.borrow(), ["enqueue", "notify", "ipi"]);
+            assert_eq!(*events.borrow(), ["enqueue", "kick"]);
             assert_eq!(
                 runtime.dispatcher.drain(0, 1),
                 std::vec![QueuedVcpuInterrupt::Virtual(interrupt(1))]
@@ -304,9 +306,6 @@ mod tests {
             new_runtime.dispatcher.drain(0, 1),
             std::vec![QueuedVcpuInterrupt::Virtual(interrupt(2))]
         );
-        assert_eq!(
-            *events.borrow(),
-            ["enqueue", "notify", "ipi", "enqueue", "notify", "ipi"]
-        );
+        assert_eq!(*events.borrow(), ["enqueue", "kick", "enqueue", "kick"]);
     }
 }

--- a/virtualization/axvm/src/lib.rs
+++ b/virtualization/axvm/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) use host::{
 pub use lifecycle::{StopReason, VmStatus};
 pub use manager::{
     AxvmRuntime, current_vcpu_id, current_vm_id, dispatch_current_vcpu_interrupt, get_vm_by_id,
-    get_vm_list, inject_current_vcpu_interrupt, notify_vm_vcpu, register_vm,
+    get_vm_list, inject_current_vcpu_interrupt, kick_vm_vcpu, register_vm,
 };
 pub(crate) use task::{AsVCpuTask, VCpuTask};
 pub use vm::{

--- a/virtualization/axvm/src/manager.rs
+++ b/virtualization/axvm/src/manager.rs
@@ -81,10 +81,9 @@ pub(crate) fn inject_interrupt(vm_id: VMId, vcpu_id: usize, vector: usize) -> Ax
     crate::runtime::vcpus::queue_interrupt(vm_id, vcpu_id, vector)
 }
 
-/// Wake and kick a target vCPU whose architecture backend already published
-/// pending interrupt state.
-pub fn notify_vm_vcpu(vm_id: VMId, vcpu_id: usize) -> AxVmResult {
-    crate::runtime::vcpus::notify_vcpu(vm_id, vcpu_id)
+/// Kick a target vCPU after the caller has published canonical architecture state.
+pub fn kick_vm_vcpu(vm_id: VMId, vcpu_id: usize) -> AxVmResult {
+    crate::runtime::vcpus::kick_vcpu_from_published_state(vm_id, vcpu_id)
 }
 
 /// Return the current VM ID from the vCPU currently executing on this CPU.

--- a/virtualization/axvm/src/runtime/hvc.rs
+++ b/virtualization/axvm/src/runtime/hvc.rs
@@ -683,16 +683,16 @@ impl HyperCall {
                         detail: "IVC notify target VM does not exist".into(),
                     }
                 })?;
-                let target_runtime = target_vm
-                    .runtime_handle()
-                    .map_err(|error| self.operation_error("wake IVC notify target VM", error))?;
-                target_runtime.notify_all();
                 let target_devices = target_vm.get_devices().map_err(|error| {
                     self.operation_error("get IVC notify target devices", error)
                 })?;
                 let notify_irq = ivc::notify_peer(&target_devices).map_err(|error| {
                     self.operation_error("notify IVC peer interrupt", error.into())
                 })?;
+                let target_runtime = target_vm
+                    .runtime_handle()
+                    .map_err(|error| self.operation_error("kick IVC notify target VM", error))?;
+                target_runtime.kick_all_vcpus();
                 info!(
                     "IVC notify source VM[{}] target VM[{}] publisher VM[{}] key {:#x} irq={:?}",
                     route.source_vm_id,

--- a/virtualization/axvm/src/runtime/kick.rs
+++ b/virtualization/axvm/src/runtime/kick.rs
@@ -1,0 +1,78 @@
+//! Architecture-independent vCPU wake and guest-exit requests.
+//!
+//! Architecture interrupt controllers remain the sole owners of pending
+//! interrupt state. This module supplies a generation-bound thread wake,
+//! optional sticky entry requests, and guest-mode ownership for conditional
+//! remote doorbells.
+
+use std::sync::Arc;
+
+use crate::vcpu::VcpuRunState;
+#[cfg(target_arch = "x86_64")]
+use crate::{host::task::WakeResult, vcpu::HardIrqExitClaim};
+
+/// Result of publishing one vCPU kick from hard-IRQ context.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg(target_arch = "x86_64")]
+pub(crate) enum HardIrqKick {
+    /// The task wake or the local host IRQ is sufficient.
+    Complete,
+    /// Task-context code must publish logical unblock state, refresh the
+    /// runtime target, and send any remote guest-exit doorbell.
+    Defer,
+}
+
+/// Pre-bound capability for one generation of a vCPU runtime task.
+///
+/// The handle contains no VM or runtime registry reference, so
+/// [`Self::kick_from_hard_irq`] is bounded and safe to invoke after an
+/// architecture backend has published its authoritative pending state.
+#[derive(Clone)]
+pub(crate) struct VcpuKickHandle {
+    run_state: Arc<VcpuRunState>,
+    wake: crate::host::task::ThreadWakeHandle,
+}
+
+impl VcpuKickHandle {
+    pub(crate) fn new(
+        run_state: Arc<VcpuRunState>,
+        wake: crate::host::task::ThreadWakeHandle,
+    ) -> Self {
+        Self { run_state, wake }
+    }
+
+    /// Publishes a kick without performing a potentially blocking host IPI.
+    ///
+    /// A local hard IRQ has already forced the running guest to the host. A
+    /// remote running guest, outside-guest waiter, or stale task-generation
+    /// wake handle is deferred to the VM-owned kick worker.
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn kick_from_hard_irq(&self, current_cpu: usize) -> HardIrqKick {
+        let wake = self.wake.wake();
+        if matches!(wake, WakeResult::Exited | WakeResult::Unavailable) {
+            return HardIrqKick::Defer;
+        }
+        match self.run_state.claim_hard_irq_exit(current_cpu) {
+            HardIrqExitClaim::OutsideGuest | HardIrqExitClaim::RemoteGuest => HardIrqKick::Defer,
+            HardIrqExitClaim::LocalGuest | HardIrqExitClaim::AlreadyClaimed => {
+                HardIrqKick::Complete
+            }
+        }
+    }
+
+    /// Kicks the vCPU from task context and returns a remote CPU doorbell.
+    ///
+    /// The caller must send the returned IPI only after releasing runtime
+    /// registry locks. A stale CPU is harmless: migration requires leaving
+    /// guest mode. Controller-owned pending state must be published before
+    /// this call; the kick itself does not manufacture a generic request.
+    pub(crate) fn kick_from_task(&self, current_cpu: usize) -> Option<usize> {
+        let _ = self.wake.wake();
+        self.run_state.request_exit(current_cpu)
+    }
+
+    /// Publishes a sticky request for work that has no backend pending state.
+    pub(crate) fn publish_entry_request(&self) {
+        self.run_state.publish_exit_request();
+    }
+}

--- a/virtualization/axvm/src/runtime/mod.rs
+++ b/virtualization/axvm/src/runtime/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod ivc;
 pub(crate) mod vcpus;
 
 mod dispatcher;
+mod kick;
 mod queue;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -24,6 +25,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 // embed the dispatcher as a field and expose it to the vCPU run loop.
 #[allow(unused_imports)]
 pub(crate) use dispatcher::VcpuIrqDispatcher;
+#[cfg(target_arch = "x86_64")]
+pub(crate) use kick::HardIrqKick;
+pub(crate) use kick::VcpuKickHandle;
 pub(crate) use queue::QueuedVcpuInterrupt;
 
 use crate::{AxVmError, AxVmResult, StopReason, VmStatus, ax_err};
@@ -109,35 +113,17 @@ pub fn start_vm(vm_id: usize) -> AxVmResult {
     Ok(())
 }
 
-/// Wake the primary vCPU of a VM.
-///
-/// Single-vCPU guests retain pending device work across the WFI boundary.
-/// SMP guests keep the legacy wake-only behavior until AxVM provides a
-/// per-vCPU wait queue that can target vCPU0.
+/// Publishes device work and kicks the primary vCPU of a VM.
 pub fn notify_vm(vm_id: usize) -> AxVmResult {
     let vm = vm_by_id(vm_id)?;
-    let vcpu_num = vm.vcpu_num();
     // `WaitQueue::wait_until` evaluates the vCPU wake predicate while it
     // holds both the wait-queue and run-queue locks. That predicate may read
     // the VM lifecycle state and therefore lock `vm.machine`. Never retain
     // `vm.machine` while notifying the same wait queue, or the notifier and a
     // vCPU entering WFI can deadlock in opposite lock order.
     let runtime = vm.runtime_handle()?;
-    notify_runtime_for_device_poll(&runtime, vcpu_num);
-    Ok(())
-}
-
-fn notify_runtime_for_device_poll(runtime: &crate::vm::VmRuntimeHandle, vcpu_num: usize) {
-    if vcpu_num == 1 {
-        runtime.notify_device_poll();
-    } else {
-        // The runtime wait queue is shared by all vCPUs, so notify_one cannot
-        // target vCPU0. Keep the legacy wake semantics for SMP guests until a
-        // dedicated per-vCPU wake path is available; publishing the shared
-        // device-poll flag here could keep a secondary vCPU spinning while
-        // the primary vCPU remains asleep.
-        runtime.notify_one();
-    }
+    runtime.publish_device_poll_request();
+    runtime.request_vcpu(0)
 }
 
 pub fn stop_vm(vm_id: usize) -> AxVmResult {
@@ -270,21 +256,9 @@ mod tests {
     }
 
     #[test]
-    fn smp_notification_does_not_publish_a_shared_device_poll_request() {
+    fn device_notification_publishes_a_primary_vcpu_poll_request() {
         let runtime = crate::vm::VmRuntimeHandle::new();
-        let observed_generation = runtime.notification_generation();
-
-        notify_runtime_for_device_poll(&runtime, 2);
-
-        assert!(!runtime.device_poll_requested());
-        assert_ne!(runtime.notification_generation(), observed_generation);
-    }
-
-    #[test]
-    fn single_vcpu_notification_publishes_a_device_poll_request() {
-        let runtime = crate::vm::VmRuntimeHandle::new();
-
-        notify_runtime_for_device_poll(&runtime, 1);
+        runtime.publish_device_poll_request();
 
         assert!(runtime.device_poll_requested());
     }

--- a/virtualization/axvm/src/runtime/vcpus.rs
+++ b/virtualization/axvm/src/runtime/vcpus.rs
@@ -24,7 +24,7 @@ use std::{
 use crate::{
     AsVCpuTask, AxVmResult, GuestPhysAddr, StopReason, VCpuTask, VmStatus, VmVcpuState,
     arch::current::CurrentArch,
-    architecture::{ArchOps, VcpuRunAction},
+    architecture::{ArchOps, VcpuRunAction, VcpuRunOutcome},
     ax_err_type,
     irq::model::{PendingVcpuInterrupt, VirtualInterruptId},
     runtime::{VCpuRef, VMRef, sub_running_vm_count},
@@ -161,7 +161,11 @@ pub(crate) fn notify_primary_vcpu(vm_id: usize) {
         return;
     };
     match vm.runtime_handle() {
-        Ok(runtime) => runtime.notify_one(),
+        Ok(runtime) => {
+            if let Err(err) = runtime.kick_vcpu(0) {
+                warn!("VM[{vm_id}] primary vCPU kick failed: {err:?}");
+            }
+        }
         Err(err) => warn!("VM[{vm_id}] vCPU runtime not found: {err:?}"),
     }
 }
@@ -176,7 +180,7 @@ pub(crate) fn notify_all_vcpus(vm_id: usize) {
     if let Some(vm) = crate::get_vm_by_id(vm_id)
         && let Ok(runtime) = vm.runtime_handle()
     {
-        runtime.notify_all();
+        runtime.request_all_vcpus();
     }
 }
 
@@ -222,23 +226,19 @@ pub(crate) fn queue_physical_interrupt(
     Ok(())
 }
 
-/// Wake and kick a target vCPU after an architecture IRQ backend has
-/// published pending state outside the generic runtime queue.
-pub(crate) fn notify_vcpu(vm_id: usize, vcpu_id: usize) -> AxVmResult {
+/// Wake a vCPU after its architecture backend has published canonical state,
+/// and send a guest-exit doorbell only while a remote CPU owns the guest.
+pub(crate) fn kick_vcpu_from_published_state(vm_id: usize, vcpu_id: usize) -> AxVmResult {
     let vm = crate::get_vm_by_id(vm_id)
         .ok_or_else(|| ax_err_type!(NotFound, format!("VM[{vm_id}] not found")))?;
     if !matches!(vm.status(), VmStatus::Running | VmStatus::Paused) {
         return Err(ax_err_type!(
             BadState,
-            format!("VM[{vm_id}] is not accepting interrupts")
+            format!("VM[{vm_id}] is not accepting vCPU events")
         ));
     }
 
-    let runtime = vm.runtime_handle()?;
-    let cpu_id = runtime.vcpu_cpu_id(vcpu_id)?;
-    runtime.notify_all();
-    crate::host::task::send_ipi(cpu_id);
-    Ok(())
+    vm.runtime_handle()?.kick_vcpu(vcpu_id)
 }
 
 /// Cleans up VCpu resources for a VM that is being deleted.
@@ -402,7 +402,7 @@ pub(crate) fn vcpu_on(
             }
         };
         if runtime
-            .add_vcpu_task(vcpu_id, prepared.thread_handle())
+            .add_vcpu_task(vcpu_id, prepared.thread_handle(), vcpu.run_state())
             .is_err()
         {
             runtime.remove_cpu_on_start_ack(vcpu_id);
@@ -628,7 +628,8 @@ fn vcpu_run() {
         // broken wake path that only flips the status without ever re-entering
         // the guest cannot advance it either.
         let action = match CurrentArch::run_vcpu(&vm, &vcpu) {
-            Ok(action) => Some(action),
+            Ok(VcpuRunOutcome::Entered(action)) => Some(action),
+            Ok(VcpuRunOutcome::EntryCanceled) => None,
             Err(err) => {
                 error!("VM[{vm_id}] run VCpu[{vcpu_id}] get error {err:?}");
                 if let Err(err) = vm.stop(StopReason::Fault(format!("{err:?}"))) {
@@ -827,7 +828,7 @@ mod tests {
         let notifier_runtime = runtime.clone();
         let notifier_published = request_published.clone();
         let notifier = std::thread::spawn(move || {
-            notifier_runtime.notify_device_poll();
+            notifier_runtime.publish_device_poll_request();
             notifier_published.wait();
         });
 
@@ -885,7 +886,7 @@ mod tests {
         let notifier_published = request_published.clone();
         let notifier = std::thread::spawn(move || {
             notifier_wait_boundary.wait();
-            notifier_runtime.notify_device_poll();
+            notifier_runtime.publish_device_poll_request();
             notifier_published.wait();
         });
 

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -14,7 +14,15 @@
 
 //! AxVM-owned architecture-independent vCPU wrapper.
 
-use std::{cell::UnsafeCell, format, mem::MaybeUninit};
+use std::{
+    cell::UnsafeCell,
+    format,
+    mem::MaybeUninit,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
 
 use ax_std::os::arceos::{
     guard::PreemptGuard,
@@ -96,6 +104,154 @@ struct AxVCpuInnerConst {
     guest_mpidr: Option<u64>,
 }
 
+const OUTSIDE_GUEST_MODE: usize = 0;
+const EXITING_GUEST_MODE_BIT: usize = 1;
+
+/// Architecture-independent ownership of one vCPU's guest-entry window.
+///
+/// The packed mode carries both the host CPU and whether an exit request has
+/// already claimed the running guest. `exit_requested` is sticky across the
+/// outside-guest window so a request racing the final entry check cannot be
+/// lost.
+pub(crate) struct VcpuRunState {
+    mode: AtomicUsize,
+    exit_requested: AtomicBool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg(target_arch = "x86_64")]
+pub(crate) enum HardIrqExitClaim {
+    OutsideGuest,
+    LocalGuest,
+    RemoteGuest,
+    AlreadyClaimed,
+}
+
+impl VcpuRunState {
+    const fn new() -> Self {
+        Self {
+            mode: AtomicUsize::new(OUTSIDE_GUEST_MODE),
+            exit_requested: AtomicBool::new(false),
+        }
+    }
+
+    fn guest_mode(cpu_id: usize) -> usize {
+        cpu_id
+            .checked_add(1)
+            .and_then(|encoded| encoded.checked_shl(1))
+            .expect("host CPU id does not fit the vCPU guest-mode publication")
+    }
+
+    fn guest_cpu(mode: usize) -> usize {
+        (mode >> 1) - 1
+    }
+
+    fn enter(&self, cpu_id: usize) -> VcpuGuestEntry<'_> {
+        let guest_mode = Self::guest_mode(cpu_id);
+        self.mode
+            .compare_exchange(
+                OUTSIDE_GUEST_MODE,
+                guest_mode,
+                Ordering::Release,
+                Ordering::Acquire,
+            )
+            .unwrap_or_else(|mode| {
+                panic!("vCPU guest mode was not outside before entry: {mode:#x}")
+            });
+        VcpuGuestEntry {
+            run_state: self,
+            guest_mode,
+        }
+    }
+
+    pub(crate) fn publish_exit_request(&self) {
+        self.exit_requested.store(true, Ordering::Release);
+    }
+
+    /// Returns the remote CPU that must receive a guest-exit doorbell.
+    pub(crate) fn request_exit(&self, current_cpu: usize) -> Option<usize> {
+        loop {
+            let mode = self.mode.load(Ordering::Acquire);
+            if mode == OUTSIDE_GUEST_MODE || mode & EXITING_GUEST_MODE_BIT != 0 {
+                return None;
+            }
+            let target_cpu = Self::guest_cpu(mode);
+            if self
+                .mode
+                .compare_exchange(
+                    mode,
+                    mode | EXITING_GUEST_MODE_BIT,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                return (target_cpu != current_cpu).then_some(target_cpu);
+            }
+        }
+    }
+
+    /// Classifies the guest-exit work left after a local hard IRQ.
+    #[cfg(target_arch = "x86_64")]
+    pub(crate) fn claim_hard_irq_exit(&self, current_cpu: usize) -> HardIrqExitClaim {
+        loop {
+            let mode = self.mode.load(Ordering::Acquire);
+            if mode == OUTSIDE_GUEST_MODE {
+                return HardIrqExitClaim::OutsideGuest;
+            }
+            if mode & EXITING_GUEST_MODE_BIT != 0 {
+                return HardIrqExitClaim::AlreadyClaimed;
+            }
+            if Self::guest_cpu(mode) != current_cpu {
+                return HardIrqExitClaim::RemoteGuest;
+            }
+            if self
+                .mode
+                .compare_exchange(
+                    mode,
+                    mode | EXITING_GUEST_MODE_BIT,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                )
+                .is_ok()
+            {
+                return HardIrqExitClaim::LocalGuest;
+            }
+        }
+    }
+}
+
+struct VcpuGuestEntry<'state> {
+    run_state: &'state VcpuRunState,
+    guest_mode: usize,
+}
+
+impl VcpuGuestEntry<'_> {
+    fn exit_requested(&self) -> bool {
+        self.run_state.exit_requested.swap(false, Ordering::AcqRel)
+            || self.run_state.mode.load(Ordering::Acquire) & EXITING_GUEST_MODE_BIT != 0
+    }
+}
+
+impl Drop for VcpuGuestEntry<'_> {
+    fn drop(&mut self) {
+        let previous = self
+            .run_state
+            .mode
+            .swap(OUTSIDE_GUEST_MODE, Ordering::Release);
+        assert!(
+            previous == self.guest_mode || previous == self.guest_mode | EXITING_GUEST_MODE_BIT,
+            "vCPU guest-mode owner changed during one entry: {previous:#x}"
+        );
+    }
+}
+
+pub(crate) enum VcpuRunResult<E> {
+    Retry,
+    ExitRequested,
+    VmExit(E),
+}
+
 #[allow(dead_code)]
 fn reserve_cpu_on_state(state: &mut VmVcpuState) -> AxVmResult {
     if *state != VmVcpuState::Free {
@@ -148,6 +304,7 @@ fn cpu_off_state(state: &mut VmVcpuState) -> AxVmResult {
 pub struct AxVCpu<A: VmArchVcpuOps> {
     inner_const: AxVCpuInnerConst,
     inner_mut: Mutex<AxVCpuInnerMut>,
+    run_state: Arc<VcpuRunState>,
     arch_vcpu: UnsafeCell<A>,
 }
 
@@ -170,6 +327,7 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
             inner_mut: Mutex::new(AxVCpuInnerMut {
                 state: VmVcpuState::Created,
             }),
+            run_state: Arc::new(VcpuRunState::new()),
             arch_vcpu: UnsafeCell::new(
                 A::new(vm_id, vcpu_id, arch_config)
                     .map_err(|error| map_vcpu_backend_error("create vCPU", error))?,
@@ -216,6 +374,10 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     /// Returns the guest-visible MPIDR affinity for this vCPU, when the architecture has one.
     pub const fn guest_mpidr(&self) -> Option<u64> {
         self.inner_const.guest_mpidr
+    }
+
+    pub(crate) fn run_state(&self) -> Arc<VcpuRunState> {
+        Arc::clone(&self.run_state)
     }
 
     /// Returns the current vCPU state.
@@ -354,12 +516,26 @@ impl<A: VmArchVcpuOps> AxVCpu<A> {
     /// the architecture backend remains loaded on one non-migrating host CPU,
     /// and must keep host IRQs disabled until this method returns. The x86 VMX
     /// backend uses that interval to switch host-owned syscall MSRs.
-    pub(crate) fn run_loaded(&self) -> AxVmResult<A::Exit> {
+    pub(crate) fn run_loaded(
+        &self,
+        retry_before_entry: impl FnOnce() -> bool,
+    ) -> AxVmResult<VcpuRunResult<A::Exit>> {
         self.transition_state(VmVcpuState::Ready, VmVcpuState::Running)?;
         self.with_state_transition(VmVcpuState::Running, VmVcpuState::Ready, || {
+            let guest_entry = self.run_state.enter(crate::host::task::current_cpu_id());
+            // Publish IN_GUEST before the final canonical-pending recheck.
+            // A producer before this point is observed by the recheck; a
+            // producer after it must observe IN_GUEST and request an exit.
+            if retry_before_entry() {
+                return Ok(VcpuRunResult::Retry);
+            }
+            if guest_entry.exit_requested() {
+                return Ok(VcpuRunResult::ExitRequested);
+            }
             let arch_vcpu = self.get_arch_vcpu();
             arch_vcpu
                 .run()
+                .map(VcpuRunResult::VmExit)
                 .map_err(|error| map_vcpu_backend_error("run vCPU", error))
         })
     }
@@ -594,6 +770,60 @@ fn map_interrupt_backend_error(operation: &'static str, error: VmBackendError) -
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn hard_irq_exit_claim_distinguishes_outside_local_and_remote_guest() {
+        let state = VcpuRunState::new();
+
+        assert_eq!(state.claim_hard_irq_exit(2), HardIrqExitClaim::OutsideGuest);
+
+        let local_entry = state.enter(2);
+        assert!(!local_entry.exit_requested());
+        assert_eq!(state.claim_hard_irq_exit(2), HardIrqExitClaim::LocalGuest);
+        drop(local_entry);
+
+        let remote_entry = state.enter(5);
+        assert!(!remote_entry.exit_requested());
+        assert_eq!(state.claim_hard_irq_exit(2), HardIrqExitClaim::RemoteGuest);
+        drop(remote_entry);
+    }
+
+    #[test]
+    fn task_kick_claims_one_remote_guest_exit() {
+        let state = VcpuRunState::new();
+        let entry = state.enter(7);
+
+        state.publish_exit_request();
+        assert_eq!(state.request_exit(3), Some(7));
+        assert_eq!(state.request_exit(3), None);
+
+        drop(entry);
+    }
+
+    #[test]
+    fn local_exit_claim_cancels_the_pending_guest_entry() {
+        let state = VcpuRunState::new();
+        let entry = state.enter(7);
+
+        assert_eq!(state.request_exit(7), None);
+        assert!(entry.exit_requested());
+
+        drop(entry);
+    }
+
+    #[test]
+    fn outside_guest_request_aborts_the_next_entry_once() {
+        let state = VcpuRunState::new();
+        state.publish_exit_request();
+
+        let first = state.enter(1);
+        assert!(first.exit_requested());
+        drop(first);
+
+        let second = state.enter(4);
+        assert!(!second.exit_requested());
+        drop(second);
+    }
 
     #[test]
     fn vcpu_cpu_on_reservation_moves_free_to_starting() {

--- a/virtualization/axvm/src/vcpu.rs
+++ b/virtualization/axvm/src/vcpu.rs
@@ -772,6 +772,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg(target_arch = "x86_64")]
     fn hard_irq_exit_claim_distinguishes_outside_local_and_remote_guest() {
         let state = VcpuRunState::new();
 

--- a/virtualization/axvm/src/vm/mod.rs
+++ b/virtualization/axvm/src/vm/mod.rs
@@ -225,8 +225,14 @@ pub(crate) struct VmRuntimeHandle {
 
 #[derive(Default)]
 struct VcpuThreadRegistry {
-    active: BTreeMap<usize, crate::ThreadHandle>,
-    retired: BTreeMap<usize, crate::ThreadHandle>,
+    active: BTreeMap<usize, VcpuThreadRuntime>,
+    retired: BTreeMap<usize, VcpuThreadRuntime>,
+}
+
+#[derive(Clone)]
+struct VcpuThreadRuntime {
+    thread: crate::ThreadHandle,
+    kick: crate::runtime::VcpuKickHandle,
 }
 
 pub(crate) struct VcpuEventWaitSnapshot {
@@ -274,16 +280,13 @@ fn clone_runtime_handle<R>(
 }
 
 pub(crate) fn dispatch_vcpu_interrupt_with(
-    enqueue: impl FnOnce() -> AxVmResult<Option<usize>>,
-    notify: impl FnOnce(),
-    send_ipi: impl FnOnce(usize),
+    enqueue: impl FnOnce() -> AxVmResult<bool>,
+    kick: impl FnOnce() -> AxVmResult,
 ) -> AxVmResult {
-    let Some(pcpu_id) = enqueue()? else {
+    if !enqueue()? {
         return Ok(());
-    };
-    notify();
-    send_ipi(pcpu_id);
-    Ok(())
+    }
+    kick()
 }
 
 fn pulse_interrupt_with_snapshot(
@@ -347,6 +350,7 @@ impl VmRuntimeHandle {
         &self,
         vcpu_id: usize,
         vcpu_thread: crate::ThreadHandle,
+        run_state: Arc<crate::vcpu::VcpuRunState>,
     ) -> AxVmResult {
         let mut threads = self.vcpu_threads.lock();
         if threads.active.contains_key(&vcpu_id) {
@@ -354,7 +358,14 @@ impl VmRuntimeHandle {
         }
         self.irq_dispatcher
             .register(vcpu_id, vcpu_thread.id().as_u64());
-        threads.active.insert(vcpu_id, vcpu_thread);
+        let kick = crate::runtime::VcpuKickHandle::new(run_state, vcpu_thread.wake_handle());
+        threads.active.insert(
+            vcpu_id,
+            VcpuThreadRuntime {
+                thread: vcpu_thread,
+                kick,
+            },
+        );
         Ok(())
     }
 
@@ -366,11 +377,12 @@ impl VmRuntimeHandle {
     }
 
     pub(crate) fn remove_vcpu_task(&self, vcpu_id: usize) -> Option<crate::ThreadHandle> {
-        let thread = self.vcpu_threads.lock().active.remove(&vcpu_id);
-        if let Some(thread) = &thread {
-            self.irq_dispatcher.clear(vcpu_id, thread.id().as_u64());
+        let runtime = self.vcpu_threads.lock().active.remove(&vcpu_id);
+        if let Some(runtime) = &runtime {
+            self.irq_dispatcher
+                .clear(vcpu_id, runtime.thread.id().as_u64());
         }
-        thread
+        runtime.map(|runtime| runtime.thread)
     }
 
     /// Transfers a self-exiting vCPU thread out of the active registry.
@@ -379,9 +391,9 @@ impl VmRuntimeHandle {
     /// ownership of the retired handle and joins it from another thread.
     pub(crate) fn retire_vcpu_task(&self, vcpu_id: usize) {
         let mut threads = self.vcpu_threads.lock();
-        if let Some(thread) = threads.active.remove(&vcpu_id) {
-            let owner = thread.id().as_u64();
-            let replaced = threads.retired.insert(vcpu_id, thread);
+        if let Some(runtime) = threads.active.remove(&vcpu_id) {
+            let owner = runtime.thread.id().as_u64();
+            let replaced = threads.retired.insert(vcpu_id, runtime);
             debug_assert!(replaced.is_none(), "retired vCPU thread was not reaped");
             drop(threads);
             self.irq_dispatcher.clear(vcpu_id, owner);
@@ -390,8 +402,8 @@ impl VmRuntimeHandle {
 
     pub(crate) fn reap_retired_vcpu_task(&self, vcpu_id: usize) -> AxVmResult {
         let retired = self.vcpu_threads.lock().retired.remove(&vcpu_id);
-        if let Some(thread) = retired {
-            crate::host::task::join_thread(thread)
+        if let Some(runtime) = retired {
+            crate::host::task::join_thread(runtime.thread)
                 .map(|_exit_code| ())
                 .map_err(|error| AxVmError::host("join retired vCPU thread", error))?;
         }
@@ -461,58 +473,102 @@ impl VmRuntimeHandle {
             .cloned()
     }
 
-    pub(crate) fn vcpu_cpu_id(&self, vcpu_id: usize) -> AxVmResult<usize> {
-        let thread = self
-            .vcpu_threads
+    pub(crate) fn vcpu_kick_handle(
+        &self,
+        vcpu_id: usize,
+    ) -> AxVmResult<crate::runtime::VcpuKickHandle> {
+        self.vcpu_threads
             .lock()
             .active
             .get(&vcpu_id)
-            .cloned()
-            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
-        crate::host::task::thread_cpu_id(&thread).ok_or_else(|| {
-            AxVmError::invalid_state(
-                "resolve vCPU CPU",
-                format_args!("vCPU {vcpu_id} thread has no assigned CPU"),
-            )
-        })
+            .map(|runtime| runtime.kick.clone())
+            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))
     }
 
-    fn vcpu_dispatch_target(&self, vcpu_id: usize) -> AxVmResult<(u64, usize)> {
-        let thread = self
-            .vcpu_threads
+    pub(crate) fn kick_vcpu(&self, vcpu_id: usize) -> AxVmResult {
+        let kick = self.vcpu_kick_handle(vcpu_id)?;
+        self.notify_all();
+        let exit_cpu = kick.kick_from_task(crate::host::task::current_cpu_id());
+        if let Some(cpu_id) = exit_cpu {
+            crate::host::task::send_ipi(cpu_id);
+        }
+        Ok(())
+    }
+
+    /// Publishes a generic entry request and kicks one target vCPU.
+    pub(crate) fn request_vcpu(&self, vcpu_id: usize) -> AxVmResult {
+        let kick = self.vcpu_kick_handle(vcpu_id)?;
+        kick.publish_entry_request();
+        self.notify_all();
+        let exit_cpu = kick.kick_from_task(crate::host::task::current_cpu_id());
+        if let Some(cpu_id) = exit_cpu {
+            crate::host::task::send_ipi(cpu_id);
+        }
+        Ok(())
+    }
+
+    fn active_vcpu_kicks(&self) -> Vec<crate::runtime::VcpuKickHandle> {
+        self.vcpu_threads
             .lock()
             .active
-            .get(&vcpu_id)
-            .cloned()
-            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
-        let pcpu_id = crate::host::task::thread_cpu_id(&thread).ok_or_else(|| {
-            AxVmError::invalid_state(
-                "resolve vCPU dispatch target",
-                format_args!("vCPU {vcpu_id} thread has no assigned CPU"),
-            )
-        })?;
-        Ok((thread.id().as_u64(), pcpu_id))
+            .values()
+            .map(|runtime| runtime.kick.clone())
+            .collect()
     }
 
-    /// New delivery path: enqueue → notify → host IPI.
+    fn deliver_kicks(&self, kicks: Vec<crate::runtime::VcpuKickHandle>) {
+        self.notify_all();
+        if kicks.is_empty() {
+            return;
+        }
+        let current_cpu = crate::host::task::current_cpu_id();
+        for kick in kicks {
+            if let Some(cpu_id) = kick.kick_from_task(current_cpu) {
+                crate::host::task::send_ipi(cpu_id);
+            }
+        }
+    }
+
+    /// Wakes every active vCPU after canonical work has been published.
+    pub(crate) fn kick_all_vcpus(&self) {
+        self.deliver_kicks(self.active_vcpu_kicks());
+    }
+
+    /// Publishes a generic entry request and kicks every active vCPU.
     ///
-    /// The dispatcher releases its queue lock before this method notifies
-    /// waiters or invokes the host IPI boundary.
-    #[cfg_attr(
-        not(any(target_arch = "riscv64", target_arch = "x86_64")),
-        expect(
-            dead_code,
-            reason = "currently consumed by the RISC-V IPI router and x86 PIT"
-        )
-    )]
+    /// Lifecycle state is checked outside the architecture entry scope, so
+    /// the sticky request closes the window between that check and IN_GUEST.
+    pub(crate) fn request_all_vcpus(&self) {
+        let kicks = self.active_vcpu_kicks();
+        for kick in &kicks {
+            kick.publish_entry_request();
+        }
+        self.deliver_kicks(kicks);
+    }
+
+    fn vcpu_dispatch_target(
+        &self,
+        vcpu_id: usize,
+    ) -> AxVmResult<(u64, crate::runtime::VcpuKickHandle)> {
+        let runtime = self
+            .vcpu_threads
+            .lock()
+            .active
+            .get(&vcpu_id)
+            .cloned()
+            .ok_or_else(|| ax_err_type!(NotFound, format!("vCPU {vcpu_id} task not found")))?;
+        Ok((runtime.thread.id().as_u64(), runtime.kick))
+    }
+
+    /// Publishes one interrupt and then kicks only its target vCPU.
     pub(crate) fn dispatch_vcpu_interrupt(
         &self,
         vcpu_id: usize,
         interrupt: PendingVcpuInterrupt,
     ) -> AxVmResult {
+        let (owner, kick) = self.vcpu_dispatch_target(vcpu_id)?;
         dispatch_vcpu_interrupt_with(
             || {
-                let (owner, pcpu_id) = self.vcpu_dispatch_target(vcpu_id)?;
                 let needs_kick = self
                     .irq_dispatcher
                     .enqueue(vcpu_id, owner, interrupt)
@@ -522,10 +578,16 @@ impl VmRuntimeHandle {
                             format_args!("vCPU {vcpu_id} task generation changed"),
                         )
                     })?;
-                Ok(needs_kick.then_some(pcpu_id))
+                Ok(needs_kick)
             },
-            || self.notify_all(),
-            crate::host::task::send_ipi,
+            || {
+                self.notify_all();
+                let exit_cpu = kick.kick_from_task(crate::host::task::current_cpu_id());
+                if let Some(cpu_id) = exit_cpu {
+                    crate::host::task::send_ipi(cpu_id);
+                }
+                Ok(())
+            },
         )
     }
 
@@ -536,9 +598,9 @@ impl VmRuntimeHandle {
         vector: usize,
         physical_irq: usize,
     ) -> AxVmResult {
+        let (owner, kick) = self.vcpu_dispatch_target(vcpu_id)?;
         dispatch_vcpu_interrupt_with(
             || {
-                let (owner, pcpu_id) = self.vcpu_dispatch_target(vcpu_id)?;
                 let needs_kick = self
                     .irq_dispatcher
                     .enqueue_physical(vcpu_id, owner, vector, physical_irq)
@@ -548,10 +610,16 @@ impl VmRuntimeHandle {
                             format_args!("vCPU {vcpu_id} task generation changed"),
                         )
                     })?;
-                Ok(needs_kick.then_some(pcpu_id))
+                Ok(needs_kick)
             },
-            || self.notify_all(),
-            crate::host::task::send_ipi,
+            || {
+                self.notify_all();
+                let exit_cpu = kick.kick_from_task(crate::host::task::current_cpu_id());
+                if let Some(cpu_id) = exit_cpu {
+                    crate::host::task::send_ipi(cpu_id);
+                }
+                Ok(())
+            },
         )
     }
 
@@ -580,20 +648,14 @@ impl VmRuntimeHandle {
         }
     }
 
-    pub(crate) fn notify_one(&self) {
-        self.notification_generation.fetch_add(1, Ordering::Release);
-        self.wait_queue.notify_one();
-    }
-
     pub(crate) fn notify_all(&self) {
         self.notification_generation.fetch_add(1, Ordering::Release);
         self.wait_queue.notify_all();
     }
 
-    /// Publishes pending device work before waking the primary vCPU.
-    pub(crate) fn notify_device_poll(&self) {
+    /// Publishes pending device work before the caller kicks the primary vCPU.
+    pub(crate) fn publish_device_poll_request(&self) {
         self.device_poll_requested.store(true, Ordering::Release);
-        self.notify_one();
     }
 
     pub(crate) fn device_poll_requested(&self) -> bool {
@@ -677,19 +739,19 @@ impl VmRuntimeHandle {
         let threads = {
             let mut registry = self.vcpu_threads.lock();
             let mut joinable = Vec::new();
-            registry.active.retain(|vcpu_id, thread| {
-                if thread.id() == current_id {
+            registry.active.retain(|vcpu_id, runtime| {
+                if runtime.thread.id() == current_id {
                     true
                 } else {
-                    joinable.push((*vcpu_id, thread.clone()));
+                    joinable.push((*vcpu_id, runtime.thread.clone()));
                     false
                 }
             });
-            registry.retired.retain(|vcpu_id, thread| {
-                if thread.id() == current_id {
+            registry.retired.retain(|vcpu_id, runtime| {
+                if runtime.thread.id() == current_id {
                     true
                 } else {
-                    joinable.push((*vcpu_id, thread.clone()));
+                    joinable.push((*vcpu_id, runtime.thread.clone()));
                     false
                 }
             });
@@ -1241,8 +1303,12 @@ impl WakeAccessPort for AxVmDeviceAccessPorts {
                     operation: "wake vCPU from device access",
                     detail: format!("{error}"),
                 })?;
-        runtime.notify_all();
-        Ok(())
+        runtime
+            .request_vcpu(vcpu_id)
+            .map_err(|error| axdevice::DeviceManagerError::InvalidState {
+                operation: "wake vCPU from device access",
+                detail: format!("{error}"),
+            })
     }
 }
 
@@ -1257,7 +1323,7 @@ impl StopAccessPort for AxVmDeviceAccessPorts {
             detail: format!("{error}"),
         })?;
         if let Ok(runtime) = vm.runtime_handle() {
-            runtime.notify_all();
+            runtime.request_all_vcpus();
         }
         Ok(())
     }
@@ -1632,8 +1698,9 @@ impl AxVM {
             Ok(())
         })?;
 
+        let primary_run_state = primary_vcpu.run_state();
         let prepared = crate::runtime::vcpus::prepare_vcpu_thread(self, primary_vcpu)?;
-        if let Err(error) = runtime.add_vcpu_task(0, prepared.thread_handle()) {
+        if let Err(error) = runtime.add_vcpu_task(0, prepared.thread_handle(), primary_run_state) {
             return match prepared.abort_and_join() {
                 Ok(()) => Err(error),
                 Err(rollback) => Err(AxVmError::lifecycle_rollback(
@@ -1787,13 +1854,13 @@ impl AxVM {
                 }
                 self.stop(reason)?;
                 if let Ok(runtime) = self.runtime_handle() {
-                    runtime.notify_all();
+                    runtime.request_all_vcpus();
                 }
                 self.wait_until_stopped()?;
             }
             VmStatus::Stopping => {
                 if let Ok(runtime) = self.runtime_handle() {
-                    runtime.notify_all();
+                    runtime.request_all_vcpus();
                 }
                 self.wait_until_stopped()?;
             }
@@ -2599,23 +2666,22 @@ mod tests {
     }
 
     #[test]
-    fn runtime_dispatch_orders_enqueue_before_notify_and_ipi() {
+    fn runtime_dispatch_orders_enqueue_before_kick() {
         let events = RefCell::new(Vec::new());
 
         dispatch_vcpu_interrupt_with(
             || {
                 events.borrow_mut().push("enqueue");
-                Ok(Some(3))
+                Ok(true)
             },
-            || events.borrow_mut().push("notify"),
-            |cpu_id| {
-                assert_eq!(cpu_id, 3);
-                events.borrow_mut().push("ipi");
+            || {
+                events.borrow_mut().push("kick");
+                Ok(())
             },
         )
         .unwrap();
 
-        assert_eq!(*events.borrow(), ["enqueue", "notify", "ipi"]);
+        assert_eq!(*events.borrow(), ["enqueue", "kick"]);
     }
 
     #[cfg(feature = "host-test")]
@@ -2632,34 +2698,35 @@ mod tests {
         dispatch_vcpu_interrupt_with(
             || {
                 let needs_kick = dispatcher.enqueue(0, 1, interrupt).unwrap();
-                Ok(needs_kick.then_some(3))
+                Ok(needs_kick)
             },
             || {
                 assert_eq!(
                     dispatcher.drain(0, 1),
                     std::vec![QueuedVcpuInterrupt::Virtual(interrupt)]
                 );
-                events.borrow_mut().push("notify");
+                events.borrow_mut().push("kick");
+                Ok(())
             },
-            |_| events.borrow_mut().push("ipi"),
         )
         .unwrap();
 
-        assert_eq!(*events.borrow(), ["notify", "ipi"]);
+        assert_eq!(*events.borrow(), ["kick"]);
     }
 
     #[cfg(feature = "host-test")]
     #[test]
     fn runtime_dispatch_coalesces_repeated_publication_before_drain() {
-        let notify_count = Cell::new(0);
-        let ipi_count = Cell::new(0);
+        let kick_count = Cell::new(0);
         let kick_pending = Cell::new(false);
 
         let dispatch = || {
             dispatch_vcpu_interrupt_with(
-                || Ok((!kick_pending.replace(true)).then_some(3)),
-                || notify_count.set(notify_count.get() + 1),
-                |_| ipi_count.set(ipi_count.get() + 1),
+                || Ok(!kick_pending.replace(true)),
+                || {
+                    kick_count.set(kick_count.get() + 1);
+                    Ok(())
+                },
             )
             .unwrap();
         };
@@ -2670,8 +2737,7 @@ mod tests {
         // the same physical delivery edge.
         dispatch();
 
-        assert_eq!(notify_count.get(), 1);
-        assert_eq!(ipi_count.get(), 1);
+        assert_eq!(kick_count.get(), 1);
     }
 
     #[test]
@@ -2683,8 +2749,10 @@ mod tests {
                 events.borrow_mut().push("enqueue");
                 Err(ax_err_type!(NotFound, "vCPU task not found"))
             },
-            || events.borrow_mut().push("notify"),
-            |_| events.borrow_mut().push("ipi"),
+            || {
+                events.borrow_mut().push("kick");
+                Ok(())
+            },
         );
 
         assert!(matches!(result, Err(AxVmError::ResourceUnavailable { .. })));
@@ -2696,9 +2764,22 @@ mod tests {
         let runtime = VmRuntimeHandle::new();
         let observed = runtime.notification_generation();
 
-        runtime.notify_one();
+        runtime.notify_all();
 
         assert_ne!(runtime.notification_generation(), observed);
+    }
+
+    #[test]
+    fn empty_vcpu_kicks_need_no_cpu_local_state() {
+        let runtime = VmRuntimeHandle::new();
+        let before_kick = runtime.notification_generation();
+
+        runtime.kick_all_vcpus();
+        let before_request = runtime.notification_generation();
+        runtime.request_all_vcpus();
+
+        assert_ne!(before_kick, before_request);
+        assert_ne!(before_request, runtime.notification_generation());
     }
 
     #[test]


### PR DESCRIPTION
## 与 #1775 的关系

这是面向 #1775 当前 head `e1c13bb1e39f4a1f39d83896793432c5c71a665d` 的后续修复 PR，不直接修改或推送原 PR 分支。base 明确设为 `codex/refactor-ax-task-from-1596`。

## 根本原因

关联失败 job：<https://github.com/rcore-os/tgoskits/actions/runs/33368111378/job/99415123914?pr=1775>

链接 job 所在提交链先暴露了 VMX `ACK_INTERRUPT_ON_EXIT` 已接管 host vector、但 host IRQ action/EOI 没有同步完成的问题。后续提交已经补齐 acknowledged vector 的 host dispatch，因此当前 #1775 head 的 x86 QEMU 可以通过；但是当时用于恢复启动的 vLAPIC 补偿路径仍然保留：每次 hard timer 到期都会同时直接 wake、提交 deferred worker，并最终发送物理 IPI。

这不是一个局部定时器频率问题，而是完整通知链把三种不同所有权混在了一起：

1. 控制器或设备发布的规范 pending 状态；
2. WFI、HLT 和生命周期 wait predicate 的逻辑解除阻塞；
3. 仅在远端 CPU 仍处于 guest mode 时需要的物理 doorbell。

本地 VMX timer IRQ 已经让 guest 退出时，旧路径仍制造第二条 worker/IPI 链；而 vCPU 位于 guest 外时，只调用 generation-bound `ThreadWakeHandle` 又不能让共享 `WaitQueue::wait_until` 的谓词变真，线程可能醒来后再次睡眠。原实现还从 scheduler assignment 推断目标 CPU，不能表达 entry publication、迁移和 CPU_OFF/CPU_ON 世代。

## 修改

- 新增 `VcpuRunState`，以原子状态表达 `OUTSIDE`、`IN_GUEST(cpu)`、`EXITING(cpu)`，并为非 backend 工作保留 sticky entry request。
- guest entry 按 Linux KVM 顺序执行：关闭本地 IRQ并固定 CPU、发布 `IN_GUEST`、最终重查规范 pending、再检查 sticky/`EXITING`，最后才进入硬件 guest。
- 新增 generation-bound `VcpuKickHandle`，只绑定 vCPU run state 与 host thread wake capability；不携带 VM registry、IRQ controller 或 scheduler CPU 快照。
- task context 明确拆分：
  - `kick_vcpu` / `kick_all_vcpus` 只消费调用者已经发布的规范状态；
  - `request_vcpu` / `request_all_vcpus` 额外发布 sticky entry request，供 device poll 与生命周期状态使用。
- x86 vLAPIC hard timer 先发布 APIC pending，再按 guest-mode 分类：本地 guest 由当前 VMX exit 完成 doorbell；`OUTSIDE` 或远端 guest 才提交 VM-owned deferred worker。
- deferred worker 在 task context 重新解析 active vCPU 世代，推进逻辑 generation，并且只对远端 running guest 发送 IPI。
- AArch64 blocked-vCPU timer 改为按 `(owner_cpu, owner_thread)` 绑定 timer registration 与 wake handle；迁移或 CPU_OFF/CPU_ON 会废弃旧 epoch，避免复用旧线程世代。
- device poll 与 virtio-net RX 统一先发布 pending flag，再定向 request vCPU0，移除 SMP 下共享 `notify_one` 无法指定 poll owner 的缺口。
- IVC 改为先发布 endpoint guest IRQ，再执行纯 broadcast kick。
- 破坏性移除旧 `notify_vm_vcpu` 语义，公共入口改为 `kick_vm_vcpu`，不保留兼容别名。
- 新增设计文档 `docs/design/axvm-vcpu-kick.md`，并同步 host timer、device runtime 与 guest console 文档。

## 确定性回归

- `local_exit_claim_cancels_the_pending_guest_entry` 在未检查 `EXITING` 的故障实现上稳定失败；补齐最终 entry check 后，同一测试通过。
- `empty_vcpu_kicks_need_no_cpu_local_state` 覆盖无 active capability 时只推进逻辑 generation、不能读取未安装的 CPU-local area。
- 其余测试覆盖 local/remote/outside guest 分类、单次 remote claim、sticky request 单次消费、queue publish-before-kick 与 wait 边界。

## 验证

- `cargo fmt`
- `git diff --check`
- `cargo xtask clippy --package axvm`：7/7 通过
- `cargo xtask cross-test --arch x86_64 --package axvm --features host-test --lib`：346/346 通过
- `cargo xtask cross-test --arch riscv64 --package riscv_vcpu --package axvm --features axvm/host-test --no-default-features --lib ipi`：AxVM 7/7、`riscv_vcpu` 5/5 通过
- `cargo xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-vmx`：通过
- `cargo xtask axvisor test qemu --arch x86_64 --test-case mp-fallback-vmx`：通过
- `cargo xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx`：通过
- `cargo xtask axvisor test qemu --arch aarch64 --test-case gicv2-timer-stress`：通过
- `cargo xtask axvisor test qemu --arch aarch64 --test-case gicv3-timer-stress`：通过

设计对照使用本地 Linux v7.1 源码中的 `arch/x86/kvm/lapic.c`、`virt/kvm/kvm_main.c`、x86 vCPU entry 与 VMX external-interrupt dispatch 链路。
