### PR TITLE
fix(axvisor): stabilize physical console logs

### DIFF
--- a/os/arceos/modules/axruntime/src/serial/mod.rs
+++ b/os/arceos/modules/axruntime/src/serial/mod.rs
@@ -39,7 +39,10 @@ use crate::{RuntimeError, RuntimeResult, sync::SpinLock};
 const NO_ACTIVE_CONSOLE: usize = usize::MAX;
 const IRQ_RX_CAPACITY: usize = 16_384;
 const SUBSCRIPTION_RX_CAPACITY: usize = 4_096;
-const LOG_SUBSCRIPTION_CAPACITY: usize = 64;
+// A subscriber can be unable to run while all secondary CPUs publish their
+// startup records. Keep enough whole-record slots for the bounded SMP burst so
+// activating a console owner does not immediately lose diagnostics.
+const LOG_SUBSCRIPTION_CAPACITY: usize = 128;
 
 static SERIAL_RUNTIMES: OnceLock<Box<[SerialRuntimeHandle]>> = OnceLock::new();
 static LOG_MAILBOX: OnceLock<Arc<LogMailbox>> = OnceLock::new();

--- a/os/axvisor/src/console_mux/output.rs
+++ b/os/axvisor/src/console_mux/output.rs
@@ -100,7 +100,7 @@ impl GuestOutputMux {
         self.owner = None;
         self.physical_line_open = false;
         output.extend_from_slice(record);
-        if !record.ends_with(b"\n") {
+        if !record_ends_with_line_break(record) {
             output.push(b'\n');
         }
         output
@@ -448,6 +448,33 @@ impl GuestOutputMux {
     }
 }
 
+fn record_ends_with_line_break(mut record: &[u8]) -> bool {
+    loop {
+        if record.ends_with(b"\n") {
+            return true;
+        }
+        let Some(sgr_start) = trailing_sgr_start(record) else {
+            return false;
+        };
+        record = &record[..sgr_start];
+    }
+}
+
+fn trailing_sgr_start(record: &[u8]) -> Option<usize> {
+    if record.last() != Some(&b'm') {
+        return None;
+    }
+    let start = record.iter().rposition(|&byte| byte == b'\x1b')?;
+    if record.get(start + 1) != Some(&b'[')
+        || !record[start + 2..record.len() - 1]
+            .iter()
+            .all(|byte| (0x30..=0x3f).contains(byte))
+    {
+        return None;
+    }
+    Some(start)
+}
+
 fn emit_vm_prefix(vm_id: usize, emit: &mut dyn FnMut(&[u8])) {
     emit(b"[VM ");
 
@@ -499,6 +526,15 @@ mod tests {
     fn host_record_without_newline_becomes_an_independent_line() {
         let mut mux = GuestOutputMux::default();
         assert_eq!(mux.format_host_record(b":host"), b":host\n");
+    }
+
+    #[cfg_attr(axtest, axtest::axtest)]
+    #[cfg_attr(not(axtest), test)]
+    fn host_record_with_trailing_sgr_does_not_add_a_blank_line() {
+        let mut mux = GuestOutputMux::default();
+        let record = b"\x1b[37mhost record\x1b[m\r\n\x1b[m";
+
+        assert_eq!(mux.format_host_record(record), record);
     }
 
     #[cfg_attr(axtest, axtest::axtest)]

--- a/os/axvisor/src/guest_console/host.rs
+++ b/os/axvisor/src/guest_console/host.rs
@@ -19,6 +19,8 @@ use std::sync::{Mutex, OnceLock};
 
 use axvisor::console_mux::HostOutputQueue;
 
+use super::terminal::TerminalNewlineNormalizer;
+
 const HOST_OUTPUT_QUEUE_CAPACITY: usize = 64 * 1024;
 const HOST_OUTPUT_BATCH_CAPACITY: usize = 512;
 
@@ -104,16 +106,18 @@ pub(crate) fn read_host_byte() -> Option<u8> {
 }
 
 pub(crate) fn read_host_log() -> Option<ConsoleLogRecord> {
-    host_console()?.logs.as_ref()?.try_read()
+    host_log_subscription()?.try_read()
 }
 
 pub(crate) fn take_host_log_drops() -> ConsoleLogDropReport {
-    host_console()
-        .and_then(|console| console.logs.as_ref())
-        .map_or_else(
-            ConsoleLogDropReport::default,
-            ConsoleLogSubscription::dropped,
-        )
+    host_log_subscription().map_or_else(
+        ConsoleLogDropReport::default,
+        ConsoleLogSubscription::dropped,
+    )
+}
+
+fn host_log_subscription() -> Option<&'static ConsoleLogSubscription> {
+    host_console()?.logs.as_ref()
 }
 
 /// Sleeps until physical input or a host log record is published.
@@ -122,7 +126,8 @@ pub(crate) fn wait_for_host_event() {
     let Some(console) = host_console() else {
         park_console_task();
     };
-    let result = match (&console.input, &console.logs) {
+    let logs = host_log_subscription();
+    let result = match (&console.input, logs) {
         (Some(input), Some(logs)) => input.wait_event(logs),
         (Some(input), None) => input.wait_readable(),
         (None, Some(logs)) => logs.wait_readable(),
@@ -162,6 +167,7 @@ pub(crate) fn submit_host_transaction(transaction: impl FnOnce(&mut dyn FnMut(&[
 }
 
 fn run_host_output_worker(output: TaskConsoleOutput) {
+    let mut terminal = TerminalNewlineNormalizer::new();
     loop {
         HOST_OUTPUT.ready.wait();
         if HOST_OUTPUT.failed.load(Ordering::Acquire) {
@@ -172,10 +178,10 @@ fn run_host_output_worker(output: TaskConsoleOutput) {
             if batch.is_empty() {
                 break;
             }
-            if let Err(error) = write_host_output_batch(&output, &batch) {
+            if let Err(error) = write_host_output_batch(&output, &mut terminal, &batch) {
                 HOST_OUTPUT.failed.store(true, Ordering::Release);
                 let _ = emergency_console::write_fmt(format_args!(
-                    "\nAxvisor host console output stopped: {error}\n"
+                    "\r\nAxvisor host console output stopped: {error}\r\n"
                 ));
                 return;
             }
@@ -183,16 +189,23 @@ fn run_host_output_worker(output: TaskConsoleOutput) {
     }
 }
 
-fn write_host_output_batch(output: &TaskConsoleOutput, batch: &HostOutputBatch) -> RuntimeResult {
+fn write_host_output_batch(
+    output: &TaskConsoleOutput,
+    terminal: &mut TerminalNewlineNormalizer,
+    batch: &HostOutputBatch,
+) -> RuntimeResult {
     if batch.dropped_bytes != 0 {
         let report = format!(
             "\n[Axvisor host console dropped {} queued bytes]\n",
             batch.dropped_bytes
         );
-        output.write_all(report.as_bytes())?;
+        terminal.write(report.as_bytes(), |bytes| {
+            output.write_all(bytes).map(|_| ())
+        })?;
     }
-    output.write_all(&batch.bytes[..batch.len])?;
-    Ok(())
+    terminal.write(&batch.bytes[..batch.len], |bytes| {
+        output.write_all(bytes).map(|_| ())
+    })
 }
 
 impl HostOutput {

--- a/os/axvisor/src/guest_console/mod.rs
+++ b/os/axvisor/src/guest_console/mod.rs
@@ -2,6 +2,7 @@
 
 mod host;
 mod mux;
+mod terminal;
 
 #[cfg(feature = "test-console-atomic-output")]
 pub(crate) use host::fill_runtime_output_queue;

--- a/os/axvisor/src/guest_console/terminal.rs
+++ b/os/axvisor/src/guest_console/terminal.rs
@@ -1,0 +1,30 @@
+//! Physical-terminal output normalization.
+
+pub(crate) struct TerminalNewlineNormalizer {
+    previous_was_cr: bool,
+}
+
+impl TerminalNewlineNormalizer {
+    pub(crate) const fn new() -> Self {
+        Self {
+            previous_was_cr: false,
+        }
+    }
+
+    pub(crate) fn write<E>(
+        &mut self,
+        bytes: &[u8],
+        mut write: impl FnMut(&[u8]) -> Result<(), E>,
+    ) -> Result<(), E> {
+        let mut chunk_start = 0;
+        for (index, &byte) in bytes.iter().enumerate() {
+            if byte == b'\n' && !self.previous_was_cr {
+                write(&bytes[chunk_start..index])?;
+                write(b"\r\n")?;
+                chunk_start = index + 1;
+            }
+            self.previous_was_cr = byte == b'\r';
+        }
+        write(&bytes[chunk_start..])
+    }
+}

--- a/os/axvisor/tests/axtest.rs
+++ b/os/axvisor/tests/axtest.rs
@@ -14,6 +14,8 @@ mod browser_console_delivery;
 #[path = "../src/network_console/layout.rs"]
 mod browser_console_layout;
 mod guest_console_harness;
+#[path = "../src/guest_console/terminal.rs"]
+mod host_terminal;
 mod manager;
 mod network_console;
 
@@ -175,6 +177,28 @@ mod tests {
             .join()
             .expect("delivery waiter must exit after notify");
         ax_assert!(woke.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn host_terminal_converts_only_bare_lf_across_batches() {
+        use crate::host_terminal::TerminalNewlineNormalizer;
+
+        let mut normalizer = TerminalNewlineNormalizer::new();
+        let mut output = Vec::new();
+        normalizer
+            .write(b"banner\nline\r", |bytes| {
+                output.extend_from_slice(bytes);
+                Ok::<_, ()>(())
+            })
+            .unwrap();
+        normalizer
+            .write(b"\nnext\n", |bytes| {
+                output.extend_from_slice(bytes);
+                Ok::<_, ()>(())
+            })
+            .unwrap();
+
+        ax_assert_eq!(output, b"banner\r\nline\r\nnext\r\n");
     }
 
     #[test]


### PR DESCRIPTION
## 问题

Axvisor 接管物理串口后存在三类控制台输出问题：

1. 启动 banner、网络状态和部分客户机输出只包含 `LF`。ostool 透明传输这些字节后，物理终端只换行但不回到行首，导致内容逐行向右偏移。
2. Runtime 彩色日志可能以 `CRLF + ANSI SGR reset` 结尾。原来的行结束判断只检查最后一个字节是否为 `LF`，因此误判日志尚未换行，又追加一个换行，造成日志之间出现多余空行。
3. RK3588 八核启动时会集中产生宿主日志，而 Axvisor shell 尚未进入日志消费循环。原有 64 条日志订阅队列无法容纳启动突发，实板稳定出现：

   ```text
   [Axvisor] dropped 36 host log records (4575 source bytes)
   ```

这些问题影响物理串口日志的可读性和完整性，但不是 ostool 的字节传输问题。

## 修改内容

### 1. 在物理 UART 输出边界统一规范换行

新增 `TerminalNewlineNormalizer`，在 `axvisor-console-output` 专用输出线程写入 `TaskConsoleOutput` 前处理换行：

- 裸 `LF` 转换为 `CRLF`；
- 已有 `CRLF` 保持不变；
- ANSI 控制字符和其他内容保持原样；
- 保存前一个字节是否为 `CR`，正确处理 `CR` 和 `LF` 被拆到两个 512 字节输出批次的情况；
- 转换过程不分配完整输出缓冲区，仍沿用现有有界 `HOST_OUTPUT` 队列。

紧急输出路径绕过 normalizer，因此相应错误信息也改为显式 `CRLF`。

该转换只作用于物理终端输出，不改变 VM WebSocket 控制台的原始字符流。

### 2. 正确识别 ANSI SGR 后的行结束

扩展 `GuestOutputMux::format_host_record()` 的行结束判断：

- 先识别并跳过尾部一个或多个 ANSI SGR 序列；
- 再检查其前面是否已经存在 `LF`；
- 只接受 `ESC [ 参数 m` 形式的 SGR，不把其他 ANSI 控制序列误认为颜色重置；
- 判断过程不删除或改写原始日志内容。

例如：

```text
ESC[37m...ESC[m CR LF ESC[m
```

现在会被识别为已经结束的完整行，不再额外追加空行。

### 3. 扩大启动日志订阅队列

将 runtime 每个串口实例的共享日志订阅队列从 64 条扩大为 128 条。

这仍然是有界 SPSC 队列，不会随日志量无限增长。新增容量用于容纳 RK3588 八核启动阶段、消费者暂时不能运行时产生的完整日志记录。

没有采用延迟订阅方案，因为订阅前 runtime 会直接写物理 UART，而 Axvisor banner 通过独立输出线程写入，两条路径会造成日志穿插到 banner 中。最终方案继续保持 Axvisor 接管后只有统一的日志仲裁路径。

### 4. 增加确定性回归测试

新增以下回归：

- 裸 `LF` 转换为 `CRLF`；
- 已有 `CRLF` 不重复转换；
- `CR`/`LF` 跨输出批次时仍保持一个正确的 `CRLF`；
- 带尾部 ANSI SGR reset 的完整日志不会被追加额外换行。

两个测试均在旧实现上确定性失败，在修复后通过。

## 验证

### Axvisor Axtest

```bash
cargo xtask ktest qemu -p axvisor --test axtest --arch aarch64
```

结果：

```text
AXTEST_SUMMARY pass=62 fail=0 skip=0 total=62
AXTEST_SUITE_OK
```

### QEMU browser-console

```bash
cargo xtask axvisor test qemu \
  --arch aarch64 \
  --test-case browser-console
```

结果：

```text
PASS browser-console
result: 1/1 case(s) passed
```

GitHub raw registry 首次访问超时，使用相同的本地已校验镜像 registry 重跑后通过。

### 格式和静态检查

- `cargo fmt`：通过；
- `git diff --check`：通过；
- `cargo xtask clippy --package ax-runtime`：
  - base 组合通过；
  -完整矩阵在 `aic8800-wifi` 构建脚本访问 GitHub 时受外部网络阻塞；
- `cargo xtask clippy --package axvisor`：项目工具按设计跳过需要 Axvisor 专用目标配置的软件包，实际目标构建已由 Axtest、QEMU 和实体板流程覆盖。

## 影响范围

本 PR 不改变：

- ostool 串口传输行为；
- VM WebSocket 控制台字符流；
- 客户机虚拟 UART 输入路径；
- 物理控制台前台客户机选择和 `Ctrl+X` 行为；
- 跨 CPU 日志的 round-robin 消费顺序；
- CI 和板卡测试配置。