### PR TITLE
refactor(repo): narrow SDIO rearm and TX queue policies

### DIFF
--- a/docs/design/unified-sdio-aic8800.md
+++ b/docs/design/unified-sdio-aic8800.md
@@ -76,10 +76,12 @@ masked window 内已经 latch 的状态，并把状态发布到 hard IRQ 使用�
 拥有型 `PreparedDma`，完成或 abort 后才恢复 `CompletedDma`。RDIF
 `DmaBuffer` 只通过有界 SPSC 转移，提交失败原样归还 token。
 
-协议侧 `QueueFramePort` 对短暂的 TX token 耗尽保留一个固定容量的 FIFO backlog，
-并在 queue completion 触发下一轮 protocol poll 时按顺序重试；backlog 满时才返回
-`Again`。这样 SDIO/DMA 的瞬时 busy 不会把已经从 smoltcp TX buffer 取出的 TCP
-segment 静默丢弃，同时仍保持内存和控制请求有界，不引入轮询 kicker 或第二个 owner。
+协议侧 `QueueFramePort` 拥有设备级 `TxQueueDiscipline`。当前 `axruntime` 为 AIC 和
+其它生产网卡显式选择 `Fifo { max_frames: 64 }`：短暂耗尽 TX token 时按顺序保留帧，
+queue completion 触发下一轮 protocol poll 后继续 flush，达到设备自己的上限才返回
+`Again`。FIFO 由 `VecDeque::new()` 开始，只在第一次真实入队时分配 payload；没有
+busy backlog 的设备不再在启动时固定预留约 128.5 KiB。该策略属于 protocol frame
+port，不改变 AIC 的 `aic,queue-size`、SPSC/DMA token 数量或 hardware queue 配置。
 
 SDHCI 的 `*_INT_STATUS_ENABLE` 定义本驱动拥有并捕获的 latch，
 `*_INT_SIGNAL_ENABLE` 只控制外部 IRQ line。因 CARD_INT 进入 hard IRQ 时，即使

--- a/docs/design/unified-sdio-aic8800.md
+++ b/docs/design/unified-sdio-aic8800.md
@@ -64,6 +64,13 @@ D80X2、DW、AIC8801 和未知变体直接失败，不共享猜测性 profile。
 独占 `bus`、`card_irq`、`SdioCard` 与 `AicDevice`，只有它能推进协议、完成
 DMA、处理 FIFO 或修改 Function 状态。
 
+通用 `SdMmcIrqHost` 只提供 SD/MMC 协议和块运行时共同需要的 endpoint、
+completion enable/disable、DMA 与等待类型。AIC 的 owner 直接要求更窄的
+`CompletionIrqRearmHost`：它在任务上下文恢复 completion delivery，同步采集
+masked window 内已经 latch 的状态，并把状态发布到 hard IRQ 使用的同一 mailbox。
+当前只有 `Sdhci` 和显式委托的 `Cv181xSdhci` 提供该能力；DWMMC、Phytium MCI
+和 StarFive wrapper 不承担 AIC 的 rearm 契约。
+
 命令完成、DMA、错误和 `CARD_INT` 可同时到达；adapter 先把 CARD_INT 事实
 交给核心，再用同一 acknowledged snapshot 推进活动 host 事务。CMD53 使用
 拥有型 `PreparedDma`，完成或 abort 后才恢复 `CompletedDma`。RDIF
@@ -78,7 +85,9 @@ SDHCI 的 `*_INT_STATUS_ENABLE` 定义本驱动拥有并捕获的 latch，
 `*_INT_SIGNAL_ENABLE` 只控制外部 IRQ line。因 CARD_INT 进入 hard IRQ 时，即使
 completion signal 临时 masked，也必须按 status-enable 读取、确认并缓存同一代
 command/data completion；CARD_INT 本身仍按 signal-enable 判断是否可见并立即 mask，
-由 owner drain 后 `rearm_and_check()` 闭合电平竞态。task-context 的“清旧状态、发布
+由 owner drain 后 `rearm_and_check()` 闭合电平竞态。owner 必须先调用
+`CompletionIrqRearmHost::rearm_completion_irq_and_check()`，再恢复 CARD_INT，
+确保同一窗口内的 completion 和 card 事实都进入 latch。task-context 的“清旧状态、发布
 新 request generation、写 argument/command”与 hard-IRQ 的“采样、W1C、按 generation
 缓存”必须具有明确 exclusion/handoff，不能假设固定 CPU 会阻止本地硬中断抢占。
 与 Linux `sdhci.c` 一致，相邻 normal/error interrupt status、status-enable 和

--- a/docs/docs/architecture/net/api.md
+++ b/docs/docs/architecture/net/api.md
@@ -633,10 +633,16 @@ driver；同步成功但 shutdown 失败时同样隔离完整 poll group，而�
 ### 7.3 Runtime builder 与 fixed affinity
 
 ```rust
+pub enum TxQueueDiscipline {
+    NoQueue,
+    Fifo { max_frames: NonZeroUsize },
+}
+
 pub struct NetworkDeviceInput {
     pub name: String,
     pub device: PreparedNetDevice,
     pub irq_sources: Vec<ResolvedNetIrqSource>,
+    pub tx_queue_discipline: TxQueueDiscipline,
 }
 
 pub trait PinnedNetIrqRegistrar: Sync {
@@ -649,6 +655,10 @@ pub trait PinnedNetIrqRegistrar: Sync {
     ) -> Result<Box<dyn PinnedNetIrqRegistration>, PinnedNetIrqError>;
 }
 ```
+
+`NetworkDeviceInput` 的构造方必须逐设备选择 discipline。`NoQueue` 不建立 protocol
+backlog；`Fifo` 的 `max_frames` 是 packet limit，存储只在第一次 busy 入队时分配。
+该接口当前按设备生效，不是 per-hardware-queue 配置。
 
 `NetworkRuntimeBuilder` 一次性消费全部设备，构造 shared-IRQ affinity domain，等待
 worker pin-ready，再以 fixed owner CPU 注册 disabled IRQ。owner startup、initial

--- a/docs/docs/architecture/net/architecture.md
+++ b/docs/docs/architecture/net/architecture.md
@@ -260,9 +260,15 @@ flowchart LR
     Route --> Loop["loopback: direct rx_buffer injection"]
     Route --> Eth["EthernetDevice::send() / ARP"]
     Eth --> Arp["ARP / next-hop MAC"]
-    Arp --> TxQ["TX-ready SPSC"]
+    Arp --> Qdisc["device TxQueueDiscipline"]
+    Qdisc --> TxQ["TX-ready SPSC"]
     TxQ --> Hw["fixed-CPU submit / NIC"]
 ```
+
+每个 `QueueFramePort` 直接拥有一个设备级 discipline。`NoQueue` 在 TX token 不可用时
+返回 `Again`；`Fifo { max_frames }` 按序保留 frame，并在 TX completion 激活下一轮
+protocol poll 后先 flush。FIFO 从零容量开始按需分配，limit 不与 hardware ring 或
+DMA token 数量合并，也不扩展为全局或 per-hardware-queue qdisc。
 
 普通 Ethernet 发送由 `EthernetDevice` 完成 ARP 和 frame 封装，再通过有界 SPSC 交给 queue owner。submit 失败的 typed error 必须归还原 token；TX completion 也通过 free ring 归还。loopback 不走外部 queue，仍可在同一个 protocol poll 周期内继续推进。
 

--- a/docs/docs/architecture/net/configuration.md
+++ b/docs/docs/architecture/net/configuration.md
@@ -255,12 +255,34 @@ dns_servers()
 ## 6. 设备与运行期配置
 
 物理设备只能在网络启动阶段一次性发布。runtime 收集全部
-`NetworkDeviceInput { name, device, irq_sources }`，`NetworkRuntimeBuilder` 完成
-affinity domain、worker pin、DMA refill、IRQ registration/rearm 后，`init_network()`
-才分配接口 ID 并发布 `Service`。启动后新增/删除物理 NIC、无 IRQ 设备和周期 poll
-模式不在当前配置面中。
+`NetworkDeviceInput { name, device, irq_sources, tx_queue_discipline }`，
+`NetworkRuntimeBuilder` 完成 affinity domain、worker pin、DMA refill、IRQ
+registration/rearm 后，`init_network()` 才分配接口 ID 并发布 `Service`。启动后
+新增/删除物理 NIC、无 IRQ 设备和周期 poll 模式不在当前配置面中。
 
-### 6.1 Wi-Fi startup transaction
+### 6.1 TX queue discipline
+
+`tx_queue_discipline` 是每个设备必须显式选择的 protocol TX 策略，没有 `Default`：
+
+```rust
+pub enum TxQueueDiscipline {
+    NoQueue,
+    Fifo { max_frames: NonZeroUsize },
+}
+```
+
+- `NoQueue` 对应 Linux `noqueue` 的边界：只尝试直接提交，设备 busy 时立即返回
+  `Again`，不保留 frame，也不分配 backlog。
+- `Fifo` 对应 packet-limited FIFO qdisc：设备 busy 后按提交顺序保留 frame，达到
+  `max_frames` 后拒绝新 frame；backing storage 从零容量开始，在第一次入队时按需分配。
+
+当前一个 `QueueFramePort` 对应一个设备，所以 discipline 也按设备所有；它不是全局
+queue，也不表示已经实现 per-hardware-queue qdisc。`axruntime` 当前为生产网卡显式
+选择 `Fifo { max_frames: 64 }`，保持短暂 TX token 耗尽时的重试语义。该值不属于
+`NetworkConfig` 的 IP/DNS 配置，也不能与驱动 `QueueConfig::ring_size`、AIC
+`aic,queue-size` 或 DMA token 数量互相替代。
+
+### 6.2 Wi-Fi startup transaction
 
 Wi-Fi 驱动可以在 owned `WifiControl` 中提供一个 `startup_transaction()`。它不是
 probe 期间的直接 SDIO 调用：builder 等待 queue worker affinity-ready、注册并 enable
@@ -268,14 +290,14 @@ probe 期间的直接 SDIO 调用：builder 等待 queue worker affinity-ready�
 刷新完成后才发布接口。SoftAP 的初始静态地址与 DHCP server policy 同步写入 protocol
 配置。
 
-### 6.2 运行期 Wi-Fi transaction
+### 6.3 运行期 Wi-Fi transaction
 
 `reconfigure_wifi(ifname, WifiTransaction)` 只改变已发布 Wi-Fi 设备的 link policy。
 owner executor quiesce 所属 group、执行 STA connect/disconnect 或 open AP、原子
 rearm；随后唯一 protocol executor 提交 DHCP/static-address/DHCP-server 变化。该 API
 不能新增设备，也不能让调用者直接借用 SDIO/MMIO control handle。
 
-### 6.3 运行期 IPv4 地址
+### 6.4 运行期 IPv4 地址
 
 已注册的 Ethernet 接口还可通过 `set_interface_ipv4()` / `remove_interface_ipv4()` 修改地址。当前控制面有意保持单地址模型：
 
@@ -328,8 +350,9 @@ pub const LISTEN_QUEUE_SIZE: usize = 512;
 | `LISTEN_QUEUE_SIZE` | TCP listen backlog clamp 上限 |
 
 protocol frame port 使用预分配 SPSC move `DmaBuffer`；ring full 时 token 保留在
-`pending_*`，不会产生额外无界 queue。Ethernet ARP pending queue 保存二层帧，单槽
-容量为 `STANDARD_MTU + 14`；因此估算 pending 内存时不能只按 1500 B 计算。
+`pending_*`，不会产生额外无界 queue。设备级 TX `Fifo` 是另一层明确有界且按需分配
+的 frame backlog；`NoQueue` 不建立该 backlog。Ethernet ARP pending queue 保存二层帧，
+单槽容量为 `STANDARD_MTU + 14`；因此估算 pending 内存时不能只按 1500 B 计算。
 更完整的拷贝边界、队列满行为和内存预算见[内存与队列](memory.md)。
 
 ### 7.3 Unix 流缓冲区

--- a/docs/docs/architecture/net/memory.md
+++ b/docs/docs/architecture/net/memory.md
@@ -126,6 +126,19 @@ Ethernet framing 后写入 DMA token。
 这些复制是当前单协议 core 与 portable DMA boundary 的明确成本。loopback 直接注入
 Router RX buffer，不分配物理 DMA token。
 
+### 7.1 Device TX queue discipline
+
+每个物理设备的 `QueueFramePort` 都持有一个显式 `TxQueueDiscipline`。`NoQueue` 直接
+提交，busy 时返回 `Again`，其 `pending_tx` 始终为空且 `VecDeque` 不分配 backing。
+`Fifo { max_frames }` 在 busy 后复制完整 `ProtocolEthernetFrame` 并按序重试；构造时
+同样使用 `VecDeque::new()`，第一次真实入队前 capacity 为零。
+
+64 位目标上的一个 `ProtocolEthernetFrame` 是 2048 字节 payload 加 8 字节长度，
+因此 64 个 frame 的内容为 `64 * 2056 = 131584` 字节，即 128.5 KiB，不含 allocator
+metadata。当前 `axruntime` 为每个生产网卡显式选择 64 帧 FIFO；这部分内存只在该设备
+实际形成 backlog 后增长，不再由所有网卡在启动时预留。不同设备的 limit 和 backlog
+彼此独立；hardware ring、SPSC token pool 与 AIC queue size 仍按各自所有者另外计算。
+
 ## 8. Protocol/socket budgets
 
 协议常量仍集中在 `consts.rs`：

--- a/drivers/blk/cv181x-sdhci/src/host2.rs
+++ b/drivers/blk/cv181x-sdhci/src/host2.rs
@@ -3,7 +3,7 @@
 use dma_api::DeviceDma;
 use sdhci_host::Sdhci;
 use sdmmc_host::{ClockHz, ProgressCause, RequestProgress, SignalVoltage};
-use sdmmc_protocol::sdio::host::SdMmcIrqHost;
+use sdmmc_protocol::sdio::host::{CompletionIrqRearmHost, SdMmcIrqHost};
 
 use super::*;
 
@@ -19,12 +19,6 @@ impl SdMmcIrqHost for Cv181xSdhci {
     fn enable_completion_irq(&mut self) -> Result<(), ProtocolError> {
         self.inner.enable_completion_irq();
         Ok(())
-    }
-
-    fn rearm_completion_irq_and_check(
-        &mut self,
-    ) -> Result<sdmmc_protocol::sdio::CompletionIrqRearm, ProtocolError> {
-        <Sdhci as SdMmcIrqHost>::rearm_completion_irq_and_check(&mut self.inner)
     }
 
     fn disable_completion_irq(&mut self) -> Result<(), ProtocolError> {
@@ -58,6 +52,14 @@ impl SdMmcIrqHost for Cv181xSdhci {
 
     fn progress_wait_kind(&self) -> sdmmc_protocol::sdio::HostProgressWait {
         <Sdhci as SdMmcIrqHost>::progress_wait_kind(&self.inner)
+    }
+}
+
+impl CompletionIrqRearmHost for Cv181xSdhci {
+    fn rearm_completion_irq_and_check(
+        &mut self,
+    ) -> Result<sdmmc_protocol::sdio::CompletionIrqRearm, ProtocolError> {
+        <Sdhci as CompletionIrqRearmHost>::rearm_completion_irq_and_check(&mut self.inner)
     }
 }
 

--- a/drivers/blk/dwmmc-host/src/host2/irq.rs
+++ b/drivers/blk/dwmmc-host/src/host2/irq.rs
@@ -53,19 +53,6 @@ impl SdMmcIrqHost for DwMmc {
         Ok(())
     }
 
-    fn rearm_completion_irq_and_check(
-        &mut self,
-    ) -> Result<sdmmc_protocol::sdio::CompletionIrqRearm, Error> {
-        self.enable_completion_irq();
-        core::sync::atomic::fence(core::sync::atomic::Ordering::SeqCst);
-        Ok(match handle_irq_core(&self.irq).kind() {
-            HostEventKind::None | HostEventKind::CardInterrupt => {
-                sdmmc_protocol::sdio::CompletionIrqRearm::Idle
-            }
-            _ => sdmmc_protocol::sdio::CompletionIrqRearm::Pending,
-        })
-    }
-
     fn disable_completion_irq(&mut self) -> Result<(), Error> {
         DwMmc::disable_completion_irq(self);
         Ok(())

--- a/drivers/blk/phytium-mci-host/src/host.rs
+++ b/drivers/blk/phytium-mci-host/src/host.rs
@@ -8,9 +8,7 @@ use dma_api::{DeviceDma, DmaConstraints};
 use mmio_api::MmioRaw;
 use sdmmc_protocol::{
     error::{Error, ErrorContext, Phase},
-    sdio::host::{
-        BusWidth, CompletionIrqRearm, HostEvent, HostEventKind, SdMmcIrqHandle, SignalVoltage,
-    },
+    sdio::host::{BusWidth, SdMmcIrqHandle, SignalVoltage},
 };
 use volatile::VolatilePtr;
 
@@ -464,15 +462,6 @@ impl PhytiumMci {
                 | crate::MCI_INT_ERROR_MASK,
         );
         self.regs.ctrl().update(|r| r.with_int_enable(true));
-    }
-
-    pub(crate) fn rearm_completion_irq_and_check(&mut self) -> CompletionIrqRearm {
-        self.enable_completion_irq();
-        atomic::fence(Ordering::SeqCst);
-        match handle_irq_core(&self.irq).kind() {
-            HostEventKind::None | HostEventKind::CardInterrupt => CompletionIrqRearm::Idle,
-            _ => CompletionIrqRearm::Pending,
-        }
     }
 
     pub fn disable_completion_irq(&mut self) {

--- a/drivers/blk/phytium-mci-host/src/host2/irq.rs
+++ b/drivers/blk/phytium-mci-host/src/host2/irq.rs
@@ -28,12 +28,6 @@ impl SdMmcIrqHost for PhytiumMci {
         Ok(())
     }
 
-    fn rearm_completion_irq_and_check(
-        &mut self,
-    ) -> Result<sdmmc_protocol::sdio::CompletionIrqRearm, Error> {
-        Ok(PhytiumMci::rearm_completion_irq_and_check(self))
-    }
-
     fn disable_completion_irq(&mut self) -> Result<(), Error> {
         PhytiumMci::disable_completion_irq(self);
         Ok(())

--- a/drivers/blk/sdhci-host/README.md
+++ b/drivers/blk/sdhci-host/README.md
@@ -20,8 +20,10 @@ capability.
 - Command and data completion advance only after the boxed hard-IRQ endpoint
   has acknowledged and cached status. Register-only reset/clock transitions
   use bounded `RegisterPending` retries.
-- `SdMmcIrqHost` controls the physical signal-enable registers. The hard IRQ
-  never copies DMA data or completes an RDIF request.
+- `SdMmcIrqHost` controls the physical signal-enable registers.
+  `CompletionIrqRearmHost` additionally restores completion delivery and
+  publishes status captured from the masked window. The hard IRQ never copies
+  DMA data or completes an RDIF request.
 - Interrupt status, status-enable, and signal-enable are adjacent normal/error
   pairs and use one 32-bit MMIO transaction, matching Linux `sdhci.c`.
 
@@ -66,7 +68,9 @@ transferred to the protocol/runtime owner.
 3. Build the correct `DeviceDma` domain/mask and call `configure_dma`.
 4. Keep completion IRQ signaling masked until the runtime owns the boxed IRQ
    handler. `BlockQueue` enables it through `SdMmcIrqHost`.
-5. Use `SdMmcCard::new` plus `rdif::initializing_device`; do not run a local
+5. Require `CompletionIrqRearmHost` only for an SDIO owner that closes the
+   masked completion-delivery window before rearming `CARD_INT`.
+6. Use `SdMmcCard::new` plus `rdif::initializing_device`; do not run a local
    initialization or completion polling loop.
 
 ## Validation

--- a/drivers/blk/sdhci-host/src/lib.rs
+++ b/drivers/blk/sdhci-host/src/lib.rs
@@ -75,8 +75,8 @@ use sdmmc_protocol::{
     cmd::{Command, DataDirection},
     error::{Error, ErrorContext, Phase},
     sdio::host::{
-        BusWidth, CardIrqControl, ClockSpeed, HostEvent, HostEventKind, HostEventSource,
-        SdMmcIrqHandle, SdMmcIrqHost, SignalVoltage,
+        BusWidth, CardIrqControl, ClockSpeed, CompletionIrqRearm, CompletionIrqRearmHost,
+        HostEvent, HostEventKind, HostEventSource, SdMmcIrqHandle, SdMmcIrqHost, SignalVoltage,
     },
 };
 
@@ -277,12 +277,6 @@ impl SdMmcIrqHost for Sdhci {
         Ok(())
     }
 
-    fn rearm_completion_irq_and_check(
-        &mut self,
-    ) -> Result<sdmmc_protocol::sdio::CompletionIrqRearm, Error> {
-        Ok(Sdhci::rearm_completion_irq_and_check(self))
-    }
-
     fn disable_completion_irq(&mut self) -> Result<(), Error> {
         Sdhci::disable_completion_irq(self);
         Ok(())
@@ -294,6 +288,12 @@ impl SdMmcIrqHost for Sdhci {
 
     fn progress_wait_kind(&self) -> sdmmc_protocol::sdio::HostProgressWait {
         Sdhci::progress_wait_kind(self)
+    }
+}
+
+impl CompletionIrqRearmHost for Sdhci {
+    fn rearm_completion_irq_and_check(&mut self) -> Result<CompletionIrqRearm, Error> {
+        Ok(Sdhci::rearm_completion_irq_and_check(self))
     }
 }
 
@@ -430,14 +430,12 @@ impl Sdhci {
         }
     }
 
-    fn rearm_completion_irq_and_check(&mut self) -> sdmmc_protocol::sdio::CompletionIrqRearm {
+    fn rearm_completion_irq_and_check(&mut self) -> CompletionIrqRearm {
         self.enable_completion_irq();
         fence(Ordering::SeqCst);
         match handle_irq_core(&self.irq).kind() {
-            HostEventKind::None | HostEventKind::CardInterrupt => {
-                sdmmc_protocol::sdio::CompletionIrqRearm::Idle
-            }
-            _ => sdmmc_protocol::sdio::CompletionIrqRearm::Pending,
+            HostEventKind::None | HostEventKind::CardInterrupt => CompletionIrqRearm::Idle,
+            _ => CompletionIrqRearm::Pending,
         }
     }
 }

--- a/drivers/blk/sdhci-host/src/tests.rs
+++ b/drivers/blk/sdhci-host/src/tests.rs
@@ -100,7 +100,8 @@ fn completion_rearm_captures_status_latched_while_signal_is_masked() {
     // when SIGNAL_ENABLE is restored.
     host.write_u16(REG_NORMAL_INT_STATUS, NORMAL_INT_CMD_COMPLETE);
     assert_eq!(
-        sdmmc_protocol::sdio::SdMmcIrqHost::rearm_completion_irq_and_check(&mut host).unwrap(),
+        sdmmc_protocol::sdio::CompletionIrqRearmHost::rearm_completion_irq_and_check(&mut host)
+            .unwrap(),
         sdmmc_protocol::sdio::CompletionIrqRearm::Pending
     );
 

--- a/drivers/blk/sdmmc-protocol/README.md
+++ b/drivers/blk/sdmmc-protocol/README.md
@@ -112,6 +112,10 @@ Physical controllers implement `sdmmc_host::SdMmcHost` plus
 and optional card-IRQ capabilities through `sdmmc_host::HostParts`; it does not
 accept a task, waker, channel, or scheduling callback. Construct native-card
 protocol state with `SdMmcCard::new` and IO-card state with `SdioCard::new`.
+An SDIO device owner that must restore completion delivery and synchronously
+capture status from the masked window additionally requires
+`CompletionIrqRearmHost`. Ordinary block hosts do not implement that narrower
+capability.
 
 Initialization is a request state machine. Its `wait_kind()` result is a
 mandatory execution contract:

--- a/drivers/blk/sdmmc-protocol/src/sdio/host.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/host.rs
@@ -141,15 +141,6 @@ pub trait SdMmcIrqHost: sdmmc_host::SdMmcHost {
         Ok(())
     }
 
-    /// Restore completion-IRQ delivery and synchronously capture status that
-    /// became pending while delivery was masked.
-    ///
-    /// A host returning [`CompletionIrqRearm::Pending`] must have published the
-    /// captured status through the same mailbox consumed by an
-    /// `AcknowledgedIrq` progress step. This closes the edge-triggered parent
-    /// IRQ race without moving protocol progress into the IRQ top half.
-    fn rearm_completion_irq_and_check(&mut self) -> Result<CompletionIrqRearm, Error>;
-
     fn disable_completion_irq(&mut self) -> Result<(), Error> {
         Ok(())
     }
@@ -163,6 +154,19 @@ pub trait SdMmcIrqHost: sdmmc_host::SdMmcHost {
     fn progress_wait_kind(&self) -> HostProgressWait {
         HostProgressWait::Irq
     }
+}
+
+/// Task-context completion-IRQ rearm required by SDIO devices whose owner
+/// closes the masked-delivery race before restoring card-interrupt delivery.
+pub trait CompletionIrqRearmHost: SdMmcIrqHost {
+    /// Restore completion-IRQ delivery and synchronously capture status that
+    /// became pending while delivery was masked.
+    ///
+    /// A host returning [`CompletionIrqRearm::Pending`] must publish the
+    /// captured status through the same mailbox consumed by an
+    /// `AcknowledgedIrq` progress step. This closes the edge-triggered parent
+    /// IRQ race without moving protocol progress into the IRQ top half.
+    fn rearm_completion_irq_and_check(&mut self) -> Result<CompletionIrqRearm, Error>;
 }
 
 /// Queue identifier used by single-queue SD/MMC block adapters.

--- a/drivers/blk/sdmmc-protocol/src/sdio/mod.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/mod.rs
@@ -13,9 +13,9 @@ pub(crate) mod transport;
 use core::num::NonZeroU16;
 
 pub use host::{
-    BusWidth, CardIrqControl, ClockSpeed, CompletionIrqRearm, HostEvent, HostEventKind,
-    HostEventSource, HostProgressWait, SDMMC_BLOCK_QUEUE_ID, SdMmcBusOp, SdMmcIrqHandle,
-    SdMmcIrqHost, SignalVoltage, block_queue_ready_from_host_event,
+    BusWidth, CardIrqControl, ClockSpeed, CompletionIrqRearm, CompletionIrqRearmHost, HostEvent,
+    HostEventKind, HostEventSource, HostProgressWait, SDMMC_BLOCK_QUEUE_ID, SdMmcBusOp,
+    SdMmcIrqHandle, SdMmcIrqHost, SignalVoltage, block_queue_ready_from_host_event,
 };
 pub use init::{
     CardInitPreference, MmcSwitchRequest, SdMmcInitRequest, SdMmcInitScratch, SdMmcInitWait,

--- a/drivers/blk/sdmmc-protocol/src/sdio/tests/mod.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/tests/mod.rs
@@ -419,11 +419,6 @@ impl SdMmcIrqHost for MockHost {
         Ok(())
     }
 
-    fn rearm_completion_irq_and_check(&mut self) -> Result<CompletionIrqRearm, Error> {
-        self.completion_irq_enabled = true;
-        Ok(CompletionIrqRearm::Idle)
-    }
-
     fn disable_completion_irq(&mut self) -> Result<(), Error> {
         self.completion_irq_enabled = false;
         Ok(())
@@ -518,7 +513,10 @@ fn protocol_error_to_host(error: Error) -> sdmmc_host::Error {
 }
 
 #[test]
-fn sdio_host_irq_methods_default_to_noop() {
+fn base_irq_host_does_not_require_completion_rearm() {
+    fn assert_base_irq_host<H: SdMmcIrqHost>() {}
+
+    assert_base_irq_host::<MockHost>();
     let mut host = MockHost::new(Vec::new());
 
     assert_eq!(host.enable_completion_irq(), Ok(()));

--- a/drivers/blk/sdmmc-protocol/src/sdio/tests/transport_adapter.rs
+++ b/drivers/blk/sdmmc-protocol/src/sdio/tests/transport_adapter.rs
@@ -183,11 +183,6 @@ impl SdMmcIrqHost for Host2Mock {
         Ok(())
     }
 
-    fn rearm_completion_irq_and_check(&mut self) -> Result<CompletionIrqRearm, Error> {
-        self.completion_irq_enabled = true;
-        Ok(CompletionIrqRearm::Idle)
-    }
-
     fn disable_completion_irq(&mut self) -> Result<(), Error> {
         self.completion_irq_enabled = false;
         Ok(())

--- a/drivers/blk/starfive-jh7110-dwmmc/src/lib.rs
+++ b/drivers/blk/starfive-jh7110-dwmmc/src/lib.rs
@@ -249,12 +249,6 @@ impl SdMmcIrqHost for Jh7110DwMmc {
         Ok(())
     }
 
-    fn rearm_completion_irq_and_check(
-        &mut self,
-    ) -> Result<sdmmc_protocol::sdio::CompletionIrqRearm, Error> {
-        <DwMmc as SdMmcIrqHost>::rearm_completion_irq_and_check(&mut self.inner)
-    }
-
     fn disable_completion_irq(&mut self) -> Result<(), Error> {
         self.inner.disable_completion_irq();
         Ok(())
@@ -346,7 +340,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_irq_methods_delegate_to_inner_dwmmc() {
+    fn completion_irq_enable_disable_delegate_to_inner_dwmmc() {
         let (_regs, mmio) = fake_mmio();
         let mut host = unsafe { Jh7110DwMmc::new(mmio, Jh7110DwMmcConfig::default()) };
 

--- a/drivers/net/aic8800/src/rdif/device/endpoints/device.rs
+++ b/drivers/net/aic8800/src/rdif/device/endpoints/device.rs
@@ -6,7 +6,7 @@ use rdif_eth::{
     NetIrqSourceId, NetPollGroupId, NetPollGroupParts, NetQueuePairParts, QueueConfig,
     WifiTransaction,
 };
-use sdmmc_protocol::sdio::SdMmcIrqHost;
+use sdmmc_protocol::sdio::CompletionIrqRearmHost;
 
 use super::{
     control::{AicNetControl, AicWifiControl},
@@ -84,13 +84,13 @@ impl AicRdifOptions {
 }
 
 /// Move-only portable AIC device before it is split into RDIF endpoints.
-pub struct AicRdifDevice<H: SdMmcIrqHost + 'static> {
+pub struct AicRdifDevice<H: CompletionIrqRearmHost + 'static> {
     host: H,
     options: AicRdifOptions,
     dma_mask: u64,
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> AicRdifDevice<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> AicRdifDevice<H> {
     /// Creates a portable adapter without issuing card or firmware commands.
     ///
     /// # Errors
@@ -118,13 +118,13 @@ impl<H: SdMmcIrqHost + Send + 'static> AicRdifDevice<H> {
     }
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> DriverGeneric for AicRdifDevice<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> DriverGeneric for AicRdifDevice<H> {
     fn name(&self) -> &str {
         "aic8800"
     }
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> NetDevice for AicRdifDevice<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> NetDevice for AicRdifDevice<H> {
     fn into_parts(self: Box<Self>) -> Result<NetDeviceParts, NetError> {
         let Self {
             host,

--- a/drivers/net/aic8800/src/rdif/device/endpoints/startup.rs
+++ b/drivers/net/aic8800/src/rdif/device/endpoints/startup.rs
@@ -6,7 +6,7 @@ use rdif_eth::{
     NetRearmResult,
 };
 use ringbuf::traits::{Consumer, Producer};
-use sdmmc_protocol::sdio::SdMmcIrqHost;
+use sdmmc_protocol::sdio::CompletionIrqRearmHost;
 
 use crate::rdif::{
     device::{OwnerReceiver, OwnerSender, WifiProgressSignal},
@@ -14,7 +14,7 @@ use crate::rdif::{
     owner::{AicOwner, OwnerProgress, OwnerWait},
 };
 
-pub(super) struct AicOwnerStartup<H: SdMmcIrqHost + Send + 'static> {
+pub(super) struct AicOwnerStartup<H: CompletionIrqRearmHost + Send + 'static> {
     owner: Option<AicOwner<H>>,
     owner_sender: OwnerSender<H>,
     startup_delay: Duration,
@@ -24,7 +24,7 @@ pub(super) struct AicOwnerStartup<H: SdMmcIrqHost + Send + 'static> {
     started: bool,
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> AicOwnerStartup<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> AicOwnerStartup<H> {
     pub(super) fn new(
         owner: AicOwner<H>,
         owner_sender: OwnerSender<H>,
@@ -83,7 +83,7 @@ const fn startup_wait(wait: OwnerWait, timeout_deadline: u64) -> NetOwnerStartup
     }
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> NetOwnerStartup for AicOwnerStartup<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> NetOwnerStartup for AicOwnerStartup<H> {
     fn start(&mut self, now_nanos: u64) -> Result<NetOwnerStartupProgress, NetError> {
         let timeout = u64::try_from(self.startup_timeout.as_nanos()).unwrap_or(u64::MAX);
         self.timeout_deadline = Some(now_nanos.saturating_add(timeout));
@@ -204,13 +204,13 @@ fn shutdown_owner<T, E>(
     Ok(())
 }
 
-pub(super) struct AicPollIrqControl<H: SdMmcIrqHost + Send + 'static> {
+pub(super) struct AicPollIrqControl<H: CompletionIrqRearmHost + Send + 'static> {
     owner: Option<AicOwner<H>>,
     owner_receiver: OwnerReceiver<H>,
     wifi_progress_signal: Arc<WifiProgressSignal>,
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> AicPollIrqControl<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> AicPollIrqControl<H> {
     pub(super) fn new(
         owner_receiver: OwnerReceiver<H>,
         wifi_progress_signal: Arc<WifiProgressSignal>,
@@ -230,7 +230,7 @@ impl<H: SdMmcIrqHost + Send + 'static> AicPollIrqControl<H> {
     }
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> NetPollIrqControl for AicPollIrqControl<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> NetPollIrqControl for AicPollIrqControl<H> {
     fn quiesce(&mut self) -> Result<(), NetError> {
         self.owner()?.quiesce().map_err(NetError::from)
     }

--- a/drivers/net/aic8800/src/rdif/device/shared.rs
+++ b/drivers/net/aic8800/src/rdif/device/shared.rs
@@ -148,12 +148,12 @@ fn decode_mac(value: u64) -> [u8; 6] {
 pub(crate) type OwnerSender<H> = HeapProd<AicOwner<H>>;
 pub(crate) type OwnerReceiver<H> = HeapCons<AicOwner<H>>;
 
-pub(crate) struct OwnerChannels<H: sdmmc_protocol::sdio::SdMmcIrqHost + 'static> {
+pub(crate) struct OwnerChannels<H: sdmmc_protocol::sdio::CompletionIrqRearmHost + 'static> {
     pub(crate) sender: OwnerSender<H>,
     pub(crate) receiver: OwnerReceiver<H>,
 }
 
-impl<H: sdmmc_protocol::sdio::SdMmcIrqHost + 'static> OwnerChannels<H> {
+impl<H: sdmmc_protocol::sdio::CompletionIrqRearmHost + 'static> OwnerChannels<H> {
     pub(crate) fn new() -> Self {
         let ring = HeapRb::new(1);
         let (sender, receiver) = ring.split();

--- a/drivers/net/aic8800/src/rdif/owner/operation.rs
+++ b/drivers/net/aic8800/src/rdif/owner/operation.rs
@@ -5,8 +5,8 @@ use sdmmc_host::{ClockHz, ProgressCause, RequestProgress};
 use sdmmc_protocol::{
     Error, ErrorContext, OperationProgress, Phase,
     sdio::{
-        SdMmcIrqHost, SdioBlockSizeRequest, SdioCard, SdioDirectRequest, SdioDmaTransferRequest,
-        SdioFunctionEnableRequest, SdioInterruptEnableRequest,
+        CompletionIrqRearmHost, SdioBlockSizeRequest, SdioCard, SdioDirectRequest,
+        SdioDmaTransferRequest, SdioFunctionEnableRequest, SdioInterruptEnableRequest,
     },
 };
 
@@ -18,7 +18,7 @@ pub(crate) struct OperationCompletion {
     pub(crate) response: SdioResponse,
 }
 
-pub(crate) enum ActiveOperation<H: SdMmcIrqHost + 'static> {
+pub(crate) enum ActiveOperation<H: CompletionIrqRearmHost + 'static> {
     Direct {
         request_id: u64,
         request: SdioDirectRequest,
@@ -46,7 +46,7 @@ pub(crate) enum ActiveOperation<H: SdMmcIrqHost + 'static> {
     },
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> ActiveOperation<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> ActiveOperation<H> {
     pub(crate) fn submit(card: &mut SdioCard<H>, operation: SdioRequest) -> Result<Self, Error> {
         let request_id = operation.id;
         match operation.kind {

--- a/drivers/net/aic8800/src/rdif/owner/progress.rs
+++ b/drivers/net/aic8800/src/rdif/owner/progress.rs
@@ -6,8 +6,8 @@ use sdmmc_host::ProgressCause;
 use sdmmc_protocol::{
     OperationProgress,
     sdio::{
-        CardIrqControl, CisInfo, CompletionIrqRearm, FunctionNumber, HostProgressWait,
-        SdMmcIrqHost, SdioCard, SdioCardInfo, io::SdioInitRequest,
+        CardIrqControl, CisInfo, CompletionIrqRearm, CompletionIrqRearmHost, FunctionNumber,
+        HostProgressWait, SdioCard, SdioCardInfo, io::SdioInitRequest,
     },
 };
 
@@ -44,7 +44,7 @@ enum CardIrqWait {
 }
 
 /// Sole task-context owner of the SDIO card, controller transactions and AIC core.
-pub(crate) struct AicOwner<H: SdMmcIrqHost + 'static> {
+pub(crate) struct AicOwner<H: CompletionIrqRearmHost + 'static> {
     card: SdioCard<H>,
     card_irq: Option<H::CardIrq>,
     init: Option<SdioInitRequest<H>>,
@@ -58,7 +58,7 @@ pub(crate) struct AicOwner<H: SdMmcIrqHost + 'static> {
     card_irq_wait: CardIrqWait,
 }
 
-impl<H: SdMmcIrqHost + Send + 'static> AicOwner<H> {
+impl<H: CompletionIrqRearmHost + Send + 'static> AicOwner<H> {
     pub(crate) fn new(
         host: H,
         card_irq: Option<H::CardIrq>,

--- a/net/ax-net/src/lib.rs
+++ b/net/ax-net/src/lib.rs
@@ -113,7 +113,7 @@ pub use self::{
     queue_runtime::{
         NetQueueStats, NetworkDeviceInput, NetworkQueueRuntime, NetworkRuntimeBuilder,
         NetworkRuntimeError, PinnedNetIrqAction, PinnedNetIrqError, PinnedNetIrqOutcome,
-        PinnedNetIrqRegistrar, PinnedNetIrqRegistration, ResolvedNetIrqSource,
+        PinnedNetIrqRegistrar, PinnedNetIrqRegistration, ResolvedNetIrqSource, TxQueueDiscipline,
     },
     router::NetDevStats,
     socket::{

--- a/net/ax-net/src/queue_runtime/executor/mod.rs
+++ b/net/ax-net/src/queue_runtime/executor/mod.rs
@@ -1,5 +1,8 @@
 use alloc::{collections::VecDeque, string::String, sync::Arc, vec::Vec};
-use core::sync::atomic::{AtomicU8, Ordering};
+use core::{
+    num::NonZeroUsize,
+    sync::atomic::{AtomicU8, Ordering},
+};
 
 use ax_sync::SpinLock;
 use rd_net::{
@@ -7,12 +10,10 @@ use rd_net::{
     RxCompletion,
 };
 
-pub(super) const TX_BACKLOG_CAPACITY: usize = 64;
-
 use super::{
     COMMAND_QUARANTINE, COMMAND_STOP, COMMAND_WAIT, CPU_ROUND_BUDGET, PollGroupState, QUEUE_BUDGET,
     STATE_MASK, STATE_MISSED, STATE_POLLING, STATE_SCHEDULED, STATUS_FAILED, STATUS_READY,
-    SpscConsumer, SpscProducer,
+    SpscConsumer, SpscProducer, TxQueueDiscipline,
 };
 use crate::device::{EthernetFramePort, NetDeviceError, NetDeviceResult, ProtocolEthernetFrame};
 
@@ -87,10 +88,9 @@ pub(super) struct QueueFramePort {
     pub(super) name: String,
     pub(super) mac: Arc<SpinLock<[u8; 6]>>,
     pub(super) groups: Vec<ProtocolGroupPort>,
-    /// Bounded protocol-side backlog for transient queue exhaustion. Linux
-    /// qdiscs retain packets when a driver reports a busy queue; dropping the
-    /// packet at this boundary would make a short DMA stall look like a TCP
-    /// connection failure.
+    /// Device-level policy for handling a busy transmit queue.
+    pub(super) tx_queue_discipline: TxQueueDiscipline,
+    /// Lazily allocated FIFO storage used only by `TxQueueDiscipline::Fifo`.
     pub(super) pending_tx: VecDeque<ProtocolEthernetFrame>,
     pub(super) next_rx: usize,
     pub(super) next_tx: usize,
@@ -110,14 +110,19 @@ impl EthernetFramePort for QueueFramePort {
             return Err(NetDeviceError::Stopped);
         }
 
+        let TxQueueDiscipline::Fifo { max_frames } = self.tx_queue_discipline else {
+            debug_assert!(self.pending_tx.is_empty());
+            return self.try_transmit(frame);
+        };
+
         self.flush_pending_tx()?;
         if !self.pending_tx.is_empty() {
-            return self.enqueue_pending(frame);
+            return self.enqueue_pending(frame, max_frames);
         }
 
         match self.try_transmit(frame) {
             Ok(()) => Ok(()),
-            Err(NetDeviceError::Again) => self.enqueue_pending(frame),
+            Err(NetDeviceError::Again) => self.enqueue_pending(frame, max_frames),
             Err(error) => Err(error),
         }
     }
@@ -161,8 +166,12 @@ impl QueueFramePort {
         Err(NetDeviceError::Again)
     }
 
-    fn enqueue_pending(&mut self, frame: &ProtocolEthernetFrame) -> NetDeviceResult {
-        if self.pending_tx.len() >= TX_BACKLOG_CAPACITY {
+    fn enqueue_pending(
+        &mut self,
+        frame: &ProtocolEthernetFrame,
+        max_frames: NonZeroUsize,
+    ) -> NetDeviceResult {
+        if self.pending_tx.len() >= max_frames.get() {
             return Err(NetDeviceError::Again);
         }
         self.pending_tx.push_back(frame.clone());
@@ -711,25 +720,6 @@ pub(super) const fn requested_irq_synchronization(command: u8) -> Option<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn protocol_tx_backlog_is_bounded() {
-        let mut port = QueueFramePort {
-            name: String::from("test0"),
-            mac: Arc::new(SpinLock::new([0; 6])),
-            groups: Vec::new(),
-            pending_tx: VecDeque::with_capacity(TX_BACKLOG_CAPACITY),
-            next_rx: 0,
-            next_tx: 0,
-        };
-        let frame = ProtocolEthernetFrame::new(60).unwrap();
-
-        for _ in 0..TX_BACKLOG_CAPACITY {
-            assert!(port.enqueue_pending(&frame).is_ok());
-        }
-        assert_eq!(port.pending_tx.len(), TX_BACKLOG_CAPACITY);
-        assert_eq!(port.enqueue_pending(&frame), Err(NetDeviceError::Again));
-    }
 
     #[test]
     fn idle_executor_waits_only_for_notification_without_a_deadline() {

--- a/net/ax-net/src/queue_runtime/mod.rs
+++ b/net/ax-net/src/queue_runtime/mod.rs
@@ -11,7 +11,10 @@ mod state;
 mod tests;
 
 use alloc::{boxed::Box, collections::VecDeque, format, string::String, sync::Arc, vec, vec::Vec};
-use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use core::{
+    num::NonZeroUsize,
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
+};
 
 use ax_sync::SpinLock;
 use ax_task::WaitQueue;
@@ -185,6 +188,16 @@ pub struct NetworkDeviceInput {
     pub name: String,
     pub device: PreparedNetDevice,
     pub irq_sources: Vec<ResolvedNetIrqSource>,
+    pub tx_queue_discipline: TxQueueDiscipline,
+}
+
+/// Protocol-side transmit queue policy for one network device.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TxQueueDiscipline {
+    /// Submit directly to the device and return `Again` when it is busy.
+    NoQueue,
+    /// Retain frames in submission order while the device is busy.
+    Fifo { max_frames: NonZeroUsize },
 }
 
 /// Result of a bounded hard-IRQ callback.
@@ -458,7 +471,8 @@ impl<'a> NetworkRuntimeBuilder<'a> {
                 name: port_name,
                 mac: port_mac,
                 groups: protocol_groups,
-                pending_tx: VecDeque::with_capacity(TX_BACKLOG_CAPACITY),
+                tx_queue_discipline: input.tx_queue_discipline,
+                pending_tx: VecDeque::new(),
                 next_rx: 0,
                 next_tx: 0,
             }) as Box<dyn EthernetFramePort>);

--- a/net/ax-net/src/queue_runtime/tests.rs
+++ b/net/ax-net/src/queue_runtime/tests.rs
@@ -15,7 +15,7 @@ use rd_net::{
 };
 
 use super::*;
-use crate::device::NetDeviceError;
+use crate::device::{EthernetFramePort, NetDeviceError, ProtocolEthernetFrame};
 
 struct DropProbe(Arc<AtomicUsize>);
 
@@ -130,6 +130,120 @@ fn dma_buffer(capacity: usize, len: usize) -> DmaBuffer {
     );
     DmaBuffer::new(pool.alloc().unwrap(), len)
         .unwrap_or_else(|_| panic!("test DMA token length exceeds its allocation"))
+}
+
+fn tx_frame(marker: u8) -> ProtocolEthernetFrame {
+    let mut frame = ProtocolEthernetFrame::new(60).unwrap();
+    frame.packet_mut().fill(marker);
+    frame
+}
+
+fn tx_frame_marker(buffer: &DmaBuffer) -> u8 {
+    buffer.read_with_cpu(buffer.len(), |packet| packet[0])
+}
+
+fn tx_test_port(
+    tx_queue_discipline: TxQueueDiscipline,
+    initial_tx_tokens: usize,
+) -> (
+    QueueFramePort,
+    SpscConsumer<DmaBuffer>,
+    SpscProducer<DmaBuffer>,
+) {
+    let (_rx_ready_tx, rx_ready) = spsc_ring(1);
+    let (rx_recycle, _rx_recycle_rx) = spsc_ring(1);
+    let (tx_ready, tx_ready_rx) = spsc_ring(4);
+    let (mut tx_free_tx, tx_free) = spsc_ring(4);
+    for _ in 0..initial_tx_tokens {
+        tx_free_tx.push(dma_buffer(2048, 0)).unwrap();
+    }
+    let group = ProtocolGroupPort {
+        rx_ready,
+        rx_recycle,
+        tx_ready,
+        tx_free,
+        pending_recycle: Vec::new(),
+        tx_spares: Vec::new(),
+        shared: Arc::new(group_state(STATE_IDLE)),
+    };
+    (
+        QueueFramePort {
+            name: String::from("test0"),
+            mac: Arc::new(SpinLock::new([0; 6])),
+            groups: vec![group],
+            tx_queue_discipline,
+            pending_tx: VecDeque::new(),
+            next_rx: 0,
+            next_tx: 0,
+        },
+        tx_ready_rx,
+        tx_free_tx,
+    )
+}
+
+#[test]
+fn fifo_backlog_is_lazy_bounded_ordered_and_flushes_after_token_return() {
+    let (mut port, mut tx_ready, mut tx_free) = tx_test_port(
+        TxQueueDiscipline::Fifo {
+            max_frames: NonZeroUsize::new(2).unwrap(),
+        },
+        1,
+    );
+
+    assert_eq!(port.pending_tx.capacity(), 0);
+    assert_eq!(port.transmit(&tx_frame(1)), Ok(()));
+    assert_eq!(port.transmit(&tx_frame(2)), Ok(()));
+    assert_eq!(port.transmit(&tx_frame(3)), Ok(()));
+    assert_eq!(port.pending_tx.len(), 2);
+    assert_eq!(port.transmit(&tx_frame(4)), Err(NetDeviceError::Again));
+
+    let first = tx_ready.pop().unwrap();
+    assert_eq!(tx_frame_marker(&first), 1);
+    tx_free.push(first).unwrap();
+    assert!(matches!(port.receive(), Err(NetDeviceError::Again)));
+    assert_eq!(port.pending_tx.len(), 1);
+
+    let second = tx_ready.pop().unwrap();
+    assert_eq!(tx_frame_marker(&second), 2);
+    tx_free.push(second).unwrap();
+    assert!(matches!(port.receive(), Err(NetDeviceError::Again)));
+    assert!(port.pending_tx.is_empty());
+
+    let third = tx_ready.pop().unwrap();
+    assert_eq!(tx_frame_marker(&third), 3);
+}
+
+#[test]
+fn noqueue_never_retains_or_allocates_when_device_is_busy() {
+    let (mut port, _tx_ready, _tx_free) = tx_test_port(TxQueueDiscipline::NoQueue, 0);
+
+    assert_eq!(port.pending_tx.capacity(), 0);
+    assert_eq!(port.transmit(&tx_frame(1)), Err(NetDeviceError::Again));
+    assert!(port.pending_tx.is_empty());
+    assert_eq!(port.pending_tx.capacity(), 0);
+}
+
+#[test]
+fn device_qdisc_limits_and_backlogs_are_isolated() {
+    let (mut first, _first_ready, _first_free) = tx_test_port(
+        TxQueueDiscipline::Fifo {
+            max_frames: NonZeroUsize::new(1).unwrap(),
+        },
+        0,
+    );
+    let (mut second, _second_ready, _second_free) = tx_test_port(
+        TxQueueDiscipline::Fifo {
+            max_frames: NonZeroUsize::new(2).unwrap(),
+        },
+        0,
+    );
+
+    assert_eq!(first.transmit(&tx_frame(1)), Ok(()));
+    assert_eq!(first.transmit(&tx_frame(2)), Err(NetDeviceError::Again));
+    assert_eq!(second.transmit(&tx_frame(3)), Ok(()));
+    assert_eq!(second.transmit(&tx_frame(4)), Ok(()));
+    assert_eq!(first.pending_tx.len(), 1);
+    assert_eq!(second.pending_tx.len(), 2);
 }
 
 struct RecordingRegistration {
@@ -296,6 +410,7 @@ fn zero_cpu_topology_quarantines_prepared_device_ownership() {
             poll_groups: Vec::new(),
         },
         irq_sources: Vec::new(),
+        tx_queue_discipline: TxQueueDiscipline::NoQueue,
     };
 
     let result = NetworkRuntimeBuilder::new(vec![input], &UnexpectedRegistrar, 0).build();

--- a/os/arceos/modules/axruntime/src/devices.rs
+++ b/os/arceos/modules/axruntime/src/devices.rs
@@ -142,6 +142,9 @@ fn collect_net_devices() -> alloc::vec::Vec<ax_net::NetworkDeviceInput> {
             name,
             device: prepared,
             irq_sources,
+            tx_queue_discipline: ax_net::TxQueueDiscipline::Fifo {
+                max_frames: core::num::NonZeroUsize::new(64).unwrap(),
+            },
         });
     }
     devices


### PR DESCRIPTION
## 问题

`SdMmcIrqHost` 过去强制所有主机提供 AIC8800 才需要的 completion IRQ rearm 语义，使 DWMMC、Phytium MCI、Jh7110 DWMMC 和通用 mock 被动携带无关代码。网络层同时把 64 帧 TX backlog 隐藏在 `QueueFramePort` 内，并在每个设备创建时预留容量，使策略不可配置且为所有网卡固定增加约 128.5 KiB。

## 改动

### SD/MMC capability

- 从 `SdMmcIrqHost` 删除 `rearm_completion_irq_and_check`。
- 新增窄能力 `CompletionIrqRearmHost: SdMmcIrqHost`，只表达任务上下文 rearm、同步采集 pending 状态并发布原 mailbox 的契约。
- 仅 `Sdhci` 实现硬件能力，`Cv181xSdhci` 显式委托；AIC RDIF、owner、startup、IRQ control 和 active operation 直接要求该能力。
- 删除 DWMMC、Phytium MCI、Jh7110 DWMMC 与普通协议 mock 的 rearm 实现，不提供旧方法、别名、adapter 或默认回退。
- 保持 completion-before-card、固定 CPU owner、任务上下文 rearm 和 hard IRQ 只采样/确认状态的不变量。

### 设备级 TX queue discipline

- 删除固定 `TX_BACKLOG_CAPACITY` 与所有隐式 64 帧路径。
- 新增无 `Default` 的 `TxQueueDiscipline::{NoQueue, Fifo { max_frames: NonZeroUsize }}`。
- `NetworkDeviceInput` 强制携带设备策略；当前 `axruntime` 为生产网卡显式选择 64 帧 FIFO，保持既有发送语义。
- `QueueFramePort` 按设备拥有 discipline 和空 `VecDeque`：FIFO 仅在设备返回 `Again` 后按需分配并保序缓存，达到上限后拒绝；NoQueue 只直接提交且不保留帧。
- 未修改驱动 `QueueConfig`、AIC `aic,queue-size`、DMA token 数量、Router 或 IP/DNS 配置职责。

文档已直接更新为新边界，没有保留迁移章节或兼容用法。

## 验证

确定性 red/green：

- 旧 `SdMmcIrqHost` 下删除 mock 的 rearm 后，base-only mock 以 E0046 确定失败；拆分后同一 mock 与协议测试通过。
- 新的 2 帧 FIFO、NoQueue 和设备隔离测试在旧固定 64 实现上确定失败；新实现验证惰性分配、容量、顺序、满队列拒绝、token 归还后 flush 与设备隔离。

通过：

- `cargo fmt`
- `cargo xtask clippy --since origin/dev`：89/89
- `cargo xtask test --since origin/dev`：8 个增量 std 包全部通过
- SDIO/AIC/SDHCI/CV181x/DWMMC/Phytium/Jh7110 host 定向 feature 与单元测试
- `cargo xtask starry test qemu --arch x86_64 -c qemu/system`：462/462
- `cargo xtask starry test qemu --arch x86_64 -c qemu-e1000/system`：1/1

实体板卡：

- `cargo xtask starry test board --board aka-00-sg2002`：boot、tennis-yolo、usb2-lsusb 通过；wifi-iperf-smoke 在 60 秒内未取得链路而失败。
- 已在独立工作树对最新 `origin/dev` `250827498f` 运行同一 wifi-iperf-smoke，用同一错误和时序失败，确认该板卡环境失败不是本分支新增回归。