### PR TITLE
feat(starry): add compile-like SMP benchmark

### DIFF
--- a/apps/starry/qemu/compile-sim-bench/README.md
+++ b/apps/starry/qemu/compile-sim-bench/README.md
@@ -1,0 +1,99 @@
+# 多核编译模拟基准
+
+`compile-sim-bench` 用固定进程依赖图近似 `cargo build -jN` 的调度形态，并让同一个静态 ELF 在
+Starry 当前分支、Starry `dev` 与 Linux v7.1 PREEMPT_RT 中运行。它不下载源码或工具链，也不把
+真实编译器版本、网络状态和增量缓存混入调度结果；LTP `hackbench` 仍作为高频 IPC 下界单独运行。
+
+## 1. 负载模型
+
+基准把输入、依赖、每个节点的计算量和输出大小固定下来。`compile-sim-bench.c` 中的
+`build_graph()` 建立满二叉依赖图，`run_build()` 只在依赖节点完成后把父节点加入 ready queue，
+并用 `jobs` 限制同时存活的 worker 数量。
+
+### 1.1 编译节点
+
+每个节点都通过 `fork()` 和 `execv()` 启动同一静态程序的 `--worker` 模式。叶子读取固定 source
+文件，非叶子读取两个依赖产物；worker 随后执行固定工作集上的数据依赖变换，并写出供父节点读取的
+产物。根产物的 FNV-1a 校验和必须在所有轮次和并行度之间一致，否则基准失败。
+
+默认 benchmark 使用 16 个叶子、31 个进程节点、每个叶子 256 KiB 输入、每个 worker 4 MiB
+工作集、8 次变换和 128 KiB 输出。它覆盖多进程 fan-out/fan-in、CPU burst、内存工作集、页缓存、
+文件读写、`fork/exec` 和依赖同步，但不模拟 `rustc` 前端、LLVM 或链接器的具体算法。
+
+### 1.2 并行协议
+
+QEMU 始终启动 4 个 online vCPU。`benchmark_main()` 先保存 4-CPU allowed mask，再分别限制整个
+进程树到前 1 个或前 4 个 CPU；子进程继承该 affinity。这样测得的是相同 SMP 内核上的
+`jobs=1` 与 `jobs=4`，不会把 UP/SMP 构建差异混入扩展性结果。
+
+每种并行度先预热一次，再交错执行 5 轮正式样本。输出包含 `COMPILE_SIM_TOPOLOGY`、
+`COMPILE_SIM_CONFIG`、`COMPILE_SIM_SAMPLE`、`COMPILE_SIM_RESULT` 和
+`COMPILE_SIM_SPEEDUP`；最后必须出现唯一的 `COMPILE_SIM_BENCH_PASSED`。主要指标是 wall time
+中位数和 `jobs=1 median / jobs=4 median`，不设置最低 speedup 门槛。
+
+## 2. Starry 运行
+
+`prebuild.sh` 使用 x86_64 musl 工具链构建静态 ELF，并把它与仓库已有的未修改 LTP `hackbench`
+runner 一同写入 managed Alpine rootfs。两个 workload 因而使用相同 rootfs、Q35、TCG multi-thread、
+512 MiB 内存、4 vCPU 和 NVMe snapshot 参数，但分别在独立启动中采样。
+
+### 2.1 快速验证
+
+默认配置把依赖图和工作量缩小，只验证拓扑、affinity、进程 DAG、产物校验和与结果解析。它不是正式
+性能数据，运行命令为：
+
+```bash
+cargo xtask starry app qemu \
+  -t qemu/compile-sim-bench \
+  --arch x86_64
+```
+
+成功运行会输出两种并行度的预热和单轮样本，并以 `COMPILE_SIM_BENCH_PASSED` 结束。
+
+### 2.2 正式采样
+
+正式编译模拟必须显式选择 benchmark 配置，并保存完整串口输出。不要与其他 QEMU、编译或高 CPU
+任务并发运行；不同分支也应在同一主机状态下交错采样。
+
+```bash
+set -o pipefail
+cargo xtask starry app qemu \
+  -t qemu/compile-sim-bench \
+  --arch x86_64 \
+  --qemu-config qemu-x86_64-benchmark.toml \
+  2>&1 | tee target/compile-sim-bench.log
+```
+
+LTP 对照使用同一 app 生成的 rootfs，但把 guest 命令切换为现有 `ltp-hackbench-run benchmark`：
+
+```bash
+cargo xtask starry app qemu \
+  -t qemu/compile-sim-bench \
+  --arch x86_64 \
+  --qemu-config qemu-x86_64-ltp-hackbench.toml
+```
+
+## 3. Linux 对照
+
+Linux 对照必须使用同一份 app 生成的 rootfs snapshot，并保持 QEMU 机器、TCG、内存、vCPU、NVMe
+和 workload 参数不变。区别只应是 `-kernel` 指向 Linux v7.1 PREEMPT_RT `bzImage`，以及内核命令行
+通过 `init=` 选择本 app 安装的 PID 1 runner。
+
+### 3.1 编译模拟入口
+
+`linux-compile-sim-init.sh` 以 PID 1 启动正式编译模拟，转发其退出状态，打印
+`LINUX_RT_COMPILE_SIM_PASSED` 后关机。Linux 必须启用 SMP、PREEMPT_RT、HRTICK、NVMe、ext4、
+8250 串口与 QEMU 电源关闭所需能力。
+
+内核命令行使用 `init=/usr/bin/linux-compile-sim-init`。串口日志中必须同时存在
+`COMPILE_SIM_BENCH_PASSED` 和 `LINUX_RT_COMPILE_SIM_PASSED`；只看到启动 marker 不算完成。
+
+### 3.2 LTP 入口
+
+`linux-ltp-hackbench-init.sh` 运行 managed rootfs 中的原始 `/opt/ltp/testcases/bin/hackbench`，
+具体 groups、loops、rounds、affinity 和结果解析均复用 `../ltp-hackbench/ltp-hackbench.sh`，避免
+Linux 与 Starry 各自维护一套参数。
+
+内核命令行使用 `init=/usr/bin/linux-ltp-hackbench-init`。正式完成要求同时出现
+`LTP_HACKBENCH_APP_PASSED` 和 `LINUX_RT_LTP_HACKBENCH_PASSED`。`hackbench` 衡量 scheduler、
+pipe IPC 与 wake/wait 吞吐，不应把它的 speedup 解释成完整项目编译 speedup。

--- a/apps/starry/qemu/compile-sim-bench/README.md
+++ b/apps/starry/qemu/compile-sim-bench/README.md
@@ -3,6 +3,7 @@
 `compile-sim-bench` 用固定进程依赖图近似 `cargo build -jN` 的调度形态，并让同一个静态 ELF 在
 Starry 当前分支、Starry `dev` 与 Linux v7.1 PREEMPT_RT 中运行。它不下载源码或工具链，也不把
 真实编译器版本、网络状态和增量缓存混入调度结果；LTP `hackbench` 仍作为高频 IPC 下界单独运行。
+2026-09-01 的三系统正式对比见 `RESULTS-2026-09-01.md`。
 
 ## 1. 负载模型
 

--- a/apps/starry/qemu/compile-sim-bench/RESULTS-2026-09-01.md
+++ b/apps/starry/qemu/compile-sim-bench/RESULTS-2026-09-01.md
@@ -1,0 +1,112 @@
+# PR #1775 多核调度性能对比
+
+本文记录 2026-09-01 在同一台主机上完成的 Starry PR #1775、Starry `dev` 与 Linux v7.1
+PREEMPT_RT 对比。结论只针对本文固定的 QEMU TCG、4 vCPU、affinity 与 workload 协议；原始耗时受
+共享主机后台负载影响，跨系统判断以交错采样后的中位数和同系统 1 CPU 到 4 CPU 的扩展比为主。
+
+## 1. 对比对象
+
+三套 guest 使用相同的 x86_64 musl 静态 workload、managed Alpine rootfs、Q35 机器、NVMe snapshot、
+512 MiB 内存与 4 个 vCPU。宿主为 Intel Core i7-10700（8 核 16 线程），QEMU 10.1.0，TCG
+multi-thread；每次 QEMU 均通过 `taskset -c 2,3,5,6` 固定到四个不同物理核。
+
+| 对象 | 提交 | 调度配置 |
+| --- | --- | --- |
+| Starry PR #1775 | `272b2a65bb0d7cee93cf27734b619a3f613791fa` | PR 重构后的 4-vCPU Starry |
+| Starry `dev` | `65dd0ef42b3deb1de8599e880c86530bf40d0466` | 当时最新 `origin/dev` 的 4-vCPU Starry |
+| Linux RT | `8cd9520d35a6c38db6567e97dd93b1f11f185dc6`（v7.1） | `CONFIG_SMP=y`、`CONFIG_PREEMPT_RT=y`、`CONFIG_SCHED_HRTICK=y` |
+
+测试期间 PR head 前进到 `11245d3c314a9c983a8431dccb731328f3ab633a`。从实测提交到新 head 的
+差异只包含文档、Starry test 注册和 Wi-Fi smoke 脚本，不包含内核、调度器或本基准路径，因此没有
+重跑已经完成的性能样本。发布本 app 的分支只重放这套基准及其结果文档到最新 `dev`，不包含
+PR #1775 的调度器改动。
+
+## 2. 编译型进程 DAG
+
+`compile-sim-bench` 使用 16 个叶子和 31 个 `fork/exec` 节点构成满二叉依赖图，模拟
+`cargo build -jN` 的 ready queue、并发编译单元和逐层链接。每个 worker 同时执行固定 CPU 变换、
+4 MiB 内存工作集、输入/依赖文件读取和 128 KiB 产物写入。每种并行度预热一次，再交错执行 5 轮，
+结果取 wall time 中位数；所有轮次的最终产物校验和均为 `0x751f18aaf0229eba`。
+
+| 系统 | `jobs=1` 中位数 | `jobs=4` 中位数 | 1→4 扩展比 | 4-job 相对 `dev` | 4-job / Linux RT |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| PR #1775 | 6.036 s | 4.527 s | **1.333×** | **快 24.4%** | 2.254× |
+| Starry `dev` | 5.935 s | 5.987 s | 0.991× | 基准 | 2.981× |
+| Linux v7.1 RT | 6.101 s | **2.008 s** | **3.037×** | 快 66.5% | 1.000× |
+
+单 job 的三套结果都在约 6 秒，说明本轮主要差异来自并行任务执行，而不是 workload 基础计算量。
+PR #1775 把最新 `dev` 的“4 job 不加速”改善为 1.333×，但 4-job 绝对耗时仍是 Linux RT 的
+2.254 倍，尚未达到 Linux 的 3.037× 扩展效率。
+
+### 2.1 原始样本
+
+下表保留全部正式样本，单位均为秒。运行顺序在 1 CPU 和 4 CPU 之间交错，避免把单向主机负载漂移
+全部记到同一并行度。
+
+| 系统 | `jobs=1` 五轮 | `jobs=4` 五轮 |
+| --- | --- | --- |
+| PR #1775 | 9.254, 8.484, 5.682, 6.036, 5.705 | 5.060, 5.356, 4.527, 3.641, 3.623 |
+| Starry `dev` | 5.673, 6.676, 5.684, 5.935, 6.102 | 5.798, 6.037, 6.110, 5.842, 5.987 |
+| Linux v7.1 RT | 6.101, 8.378, 7.218, 3.209, 3.464 | 2.008, 2.533, 1.556, 1.491, 3.899 |
+
+Linux 串口出现一次 `clocksource: Watchdog remote CPU 2 read timed out`，三套样本内部也能看到共享主机
+负载引起的离散。校验和、成功 marker 和中位数计算均有效，但这些数据适合判断数量级和扩展方向，
+不适合作为低噪声裸机微基准。
+
+## 3. LTP hackbench
+
+LTP 使用版本 `20260529` 的原始 `/opt/ltp/testcases/bin/hackbench`，固定 `groups=1`、`loops=1000`，
+分别测试 process 和 thread 模式。每个模式的 1 CPU、4 CPU 各预热一次并交错执行 5 轮，表中仍取
+中位数。它主要测量 scheduler、pipe/socket IPC 和 wake/wait 吞吐，不等同于完整编译 workload。
+
+| 模式 | 系统 | 1 CPU 中位数 | 4 CPU 中位数 | 1→4 扩展比 | 4 CPU 相对 `dev` | 4 CPU / Linux RT |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| process | PR #1775 | 51.516 s | 23.209 s | **2.219×** | **快 56.4%** | 3.369× |
+| process | Starry `dev` | 57.685 s | 53.260 s | 1.083× | 基准 | 7.732× |
+| process | Linux v7.1 RT | 13.515 s | **6.888 s** | 1.962× | 快 87.1% | 1.000× |
+| thread | PR #1775 | 64.414 s | 25.411 s | **2.534×** | **快 60.1%** | 7.640× |
+| thread | Starry `dev` | 70.371 s | 63.632 s | 1.105× | 基准 | 19.132× |
+| thread | Linux v7.1 RT | 5.668 s | **3.326 s** | 1.704× | 快 94.8% | 1.000× |
+
+PR #1775 在两种 `hackbench` 模式中都恢复了明显的多核扩展，并显著快于 `dev` 的 4-CPU 结果。
+它的扩展比甚至高于本轮 Linux RT，但这是因为 Starry 的 1-CPU 基线成本很高；绝对耗时仍分别是
+Linux RT 的 3.369 倍和 7.640 倍，不能据此表述为性能超过 Linux。
+
+### 3.1 原始样本
+
+完整五轮耗时如下，单位均为秒。中位数降低了个别共享主机抖动对最终判断的影响。
+
+| 模式 | 系统 | 1 CPU 五轮 | 4 CPU 五轮 |
+| --- | --- | --- | --- |
+| process | PR #1775 | 53.585, 50.965, 51.209, 51.906, 51.516 | 23.847, 26.588, 23.209, 21.293, 20.596 |
+| process | Starry `dev` | 67.370, 83.595, 57.685, 51.350, 55.201 | 54.330, 67.997, 52.644, 51.333, 53.260 |
+| process | Linux v7.1 RT | 17.422, 13.515, 13.016, 13.135, 14.257 | 7.747, 7.343, 6.888, 6.847, 6.740 |
+| thread | PR #1775 | 48.288, 63.291, 79.515, 64.414, 85.580 | 20.440, 26.599, 25.687, 23.831, 25.411 |
+| thread | Starry `dev` | 84.425, 58.215, 59.277, 78.394, 70.371 | 74.708, 63.632, 56.206, 61.844, 66.949 |
+| thread | Linux v7.1 RT | 5.668, 5.397, 5.687, 5.851, 5.108 | 3.489, 3.605, 2.947, 3.326, 2.697 |
+
+## 4. LTP 负载选择结论
+
+LTP 中最适合本问题的现成用例是
+[`hackbench`](https://github.com/linux-test-project/ltp/blob/master/testcases/kernel/sched/cfs-scheduler/hackbench.c)：
+它能固定进程或线程组规模、IPC 消息次数，并通过 affinity 对比一个 CPU 与四个 CPU 的 scheduler/IPC
+吞吐。它不是纯负载均衡计数器，也不会报告 migration 次数，所以本次增加编译型 DAG 作为更接近
+`rustc -jN` 的主测试。
+
+LTP 的 [`sched_latency`](https://github.com/linux-test-project/ltp/blob/master/testcases/realtime/func/sched_latency/sched_latency.c)
+测量周期性 FIFO 任务的 wakeup latency，
+[`sched_football`](https://github.com/linux-test-project/ltp/blob/master/testcases/realtime/func/sched_football/sched_football.c)
+验证实时调度与 PI 正确性，而 `sched_stress` 是长时间、负载不易固定的压力集合；它们都不适合替代
+多核项目编译吞吐对比。LTP 当前没有一个同时建模编译依赖图、文件产物和 `-jN` ready queue 的官方
+用例。
+
+## 5. 复现与判读边界
+
+Starry 的 smoke、正式编译模拟和 LTP 命令记录在同目录 `README.md`。Linux 使用同一 rootfs snapshot
+和相同 QEMU 参数，仅将 `-kernel` 换为上述 v7.1 PREEMPT_RT `bzImage`，并分别设置
+`init=/usr/bin/linux-compile-sim-init` 或 `init=/usr/bin/linux-ltp-hackbench-init`。
+
+正式运行都出现了各自的 `*_PASSED` marker；编译型负载的所有轮次还通过相同根产物校验和验证了
+工作量一致。由于测试发生在仍有其他任务运行的共享开发机，本文不把小幅差异解释成确定性优化；但
+PR、`dev` 与 Linux 在两个独立负载上呈现的扩展方向一致，足以确认 PR #1775 改善了 Starry 的多核
+任务分配吞吐，同时仍存在明显的绝对性能差距。

--- a/apps/starry/qemu/compile-sim-bench/build-x86_64-unknown-none.toml
+++ b/apps/starry/qemu/compile-sim-bench/build-x86_64-unknown-none.toml
@@ -1,0 +1,4 @@
+target = "x86_64-unknown-none"
+log = "Warn"
+max_cpu_num = 4
+features = ["ax-driver/nvme"]

--- a/apps/starry/qemu/compile-sim-bench/compile-sim-bench-run.sh
+++ b/apps/starry/qemu/compile-sim-bench/compile-sim-bench-run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -u
+
+program=${COMPILE_SIM_BIN:-/usr/bin/compile-sim-bench}
+if "$program" "$@"; then
+    exit 0
+else
+    status=$?
+    printf 'COMPILE_SIM_BENCH_FAILED status=%s\n' "$status" >&2
+    exit "$status"
+fi

--- a/apps/starry/qemu/compile-sim-bench/compile-sim-bench.c
+++ b/apps/starry/qemu/compile-sim-bench/compile-sim-bench.c
@@ -1,0 +1,784 @@
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#define EXPECTED_CPUS 4
+#define MAX_LEAVES 64U
+#define MAX_ROUNDS 31U
+#define MAX_NODES (MAX_LEAVES * 2U - 1U)
+#define MAX_ACTIVE EXPECTED_CPUS
+#define DEFAULT_WORK_DIR "/tmp/compile-sim-bench"
+#define FNV1A_OFFSET_BASIS UINT64_C(14695981039346656037)
+#define FNV1A_PRIME UINT64_C(1099511628211)
+
+struct bench_config {
+    const char *work_dir;
+    unsigned leaves;
+    size_t source_bytes;
+    size_t work_bytes;
+    unsigned passes;
+    size_t output_bytes;
+    unsigned rounds;
+    unsigned expected_cpus;
+    int smoke;
+};
+
+struct build_node {
+    unsigned dependencies[2];
+    unsigned dependency_count;
+    unsigned remaining_dependencies;
+    unsigned parent;
+    int has_parent;
+    int completed;
+};
+
+struct active_child {
+    pid_t pid;
+    unsigned node;
+};
+
+struct sample {
+    uint64_t elapsed_us;
+    uint64_t checksum;
+};
+
+static const char *self_path;
+
+static void usage(const char *program)
+{
+    fprintf(stderr,
+            "usage: %s [--smoke|--benchmark] [--work-dir PATH] "
+            "[--leaves N] [--source-bytes N] [--work-bytes N] "
+            "[--passes N] [--output-bytes N] [--rounds N] "
+            "[--expected-cpus N]\n",
+            program);
+}
+
+static void fail_errno(const char *operation)
+{
+    fprintf(stderr, "%s failed: %s\n", operation, strerror(errno));
+    exit(1);
+}
+
+static uint64_t parse_u64(const char *name, const char *text, uint64_t min,
+                          uint64_t max)
+{
+    char *end = NULL;
+    unsigned long long value;
+
+    errno = 0;
+    value = strtoull(text, &end, 0);
+    if (errno != 0 || end == text || *end != '\0' || value < min ||
+        value > max) {
+        fprintf(stderr, "invalid %s: %s\n", name, text);
+        exit(2);
+    }
+    return (uint64_t)value;
+}
+
+static int is_power_of_two(size_t value)
+{
+    return value != 0 && (value & (value - 1U)) == 0;
+}
+
+static struct bench_config parse_args(int argc, char **argv)
+{
+    struct bench_config config = {
+        .work_dir = DEFAULT_WORK_DIR,
+        .leaves = 16,
+        .source_bytes = 256U * 1024U,
+        .work_bytes = 4U * 1024U * 1024U,
+        .passes = 8,
+        .output_bytes = 128U * 1024U,
+        .rounds = 5,
+        .expected_cpus = EXPECTED_CPUS,
+        .smoke = 0,
+    };
+    int execution_selected = 0;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--smoke") == 0) {
+            if (execution_selected) {
+                fprintf(stderr, "select exactly one execution mode\n");
+                exit(2);
+            }
+            config.leaves = 4;
+            config.source_bytes = 64U * 1024U;
+            config.work_bytes = 512U * 1024U;
+            config.passes = 2;
+            config.output_bytes = 32U * 1024U;
+            config.rounds = 1;
+            config.smoke = 1;
+            execution_selected = 1;
+        } else if (strcmp(argv[i], "--benchmark") == 0) {
+            if (execution_selected) {
+                fprintf(stderr, "select exactly one execution mode\n");
+                exit(2);
+            }
+            config.smoke = 0;
+            execution_selected = 1;
+        } else if (strcmp(argv[i], "--work-dir") == 0 && i + 1 < argc) {
+            config.work_dir = argv[++i];
+        } else if (strcmp(argv[i], "--leaves") == 0 && i + 1 < argc) {
+            config.leaves = (unsigned)parse_u64("leaves", argv[++i], 2, MAX_LEAVES);
+        } else if (strcmp(argv[i], "--source-bytes") == 0 && i + 1 < argc) {
+            config.source_bytes =
+                (size_t)parse_u64("source-bytes", argv[++i], 4096, 64U * 1024U * 1024U);
+        } else if (strcmp(argv[i], "--work-bytes") == 0 && i + 1 < argc) {
+            config.work_bytes =
+                (size_t)parse_u64("work-bytes", argv[++i], 4096, 64U * 1024U * 1024U);
+        } else if (strcmp(argv[i], "--passes") == 0 && i + 1 < argc) {
+            config.passes = (unsigned)parse_u64("passes", argv[++i], 1, 1024);
+        } else if (strcmp(argv[i], "--output-bytes") == 0 && i + 1 < argc) {
+            config.output_bytes =
+                (size_t)parse_u64("output-bytes", argv[++i], 4096, 16U * 1024U * 1024U);
+        } else if (strcmp(argv[i], "--rounds") == 0 && i + 1 < argc) {
+            config.rounds = (unsigned)parse_u64("rounds", argv[++i], 1, MAX_ROUNDS);
+        } else if (strcmp(argv[i], "--expected-cpus") == 0 && i + 1 < argc) {
+            config.expected_cpus =
+                (unsigned)parse_u64("expected-cpus", argv[++i], EXPECTED_CPUS, CPU_SETSIZE);
+        } else if (strcmp(argv[i], "--worker") == 0) {
+            break;
+        } else if (strcmp(argv[i], "--help") == 0) {
+            usage(argv[0]);
+            exit(0);
+        } else {
+            usage(argv[0]);
+            exit(2);
+        }
+    }
+
+    if (!is_power_of_two(config.leaves)) {
+        fprintf(stderr, "leaves must be a power of two\n");
+        exit(2);
+    }
+    if (!is_power_of_two(config.work_bytes) || config.work_bytes % sizeof(uint64_t) != 0) {
+        fprintf(stderr, "work-bytes must be a power of two and a multiple of 8\n");
+        exit(2);
+    }
+    if (config.output_bytes > config.work_bytes) {
+        fprintf(stderr, "output-bytes must not exceed work-bytes\n");
+        exit(2);
+    }
+    if (!config.smoke && (config.rounds < 3 || config.rounds % 2 == 0)) {
+        fprintf(stderr, "benchmark rounds must be an odd integer of at least 3\n");
+        exit(2);
+    }
+    return config;
+}
+
+static uint64_t now_us(void)
+{
+    struct timespec time;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &time) != 0) {
+        fail_errno("clock_gettime");
+    }
+    return (uint64_t)time.tv_sec * UINT64_C(1000000) +
+           (uint64_t)time.tv_nsec / UINT64_C(1000);
+}
+
+static uint64_t rotate_left(uint64_t value, unsigned shift)
+{
+    shift &= 63U;
+    return shift == 0 ? value : (value << shift) | (value >> (64U - shift));
+}
+
+static uint64_t fnv1a(const uint8_t *data, size_t length, uint64_t hash)
+{
+    for (size_t i = 0; i < length; i++) {
+        hash ^= data[i];
+        hash *= FNV1A_PRIME;
+    }
+    return hash;
+}
+
+static void write_all(int fd, const void *buffer, size_t length)
+{
+    const uint8_t *cursor = buffer;
+
+    while (length != 0) {
+        ssize_t written = write(fd, cursor, length);
+        if (written < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            fail_errno("write");
+        }
+        if (written == 0) {
+            fprintf(stderr, "write made no progress\n");
+            exit(1);
+        }
+        cursor += (size_t)written;
+        length -= (size_t)written;
+    }
+}
+
+static uint8_t *read_file(const char *path, size_t *length)
+{
+    struct stat metadata;
+    uint8_t *buffer;
+    size_t offset = 0;
+    int fd = open(path, O_RDONLY);
+
+    if (fd < 0) {
+        fail_errno(path);
+    }
+    if (fstat(fd, &metadata) != 0) {
+        fail_errno("fstat");
+    }
+    if (metadata.st_size <= 0 || (uint64_t)metadata.st_size > SIZE_MAX) {
+        fprintf(stderr, "invalid input size for %s\n", path);
+        exit(1);
+    }
+    *length = (size_t)metadata.st_size;
+    buffer = malloc(*length);
+    if (buffer == NULL) {
+        fail_errno("malloc input");
+    }
+    while (offset < *length) {
+        ssize_t count = read(fd, buffer + offset, *length - offset);
+        if (count < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            fail_errno("read");
+        }
+        if (count == 0) {
+            fprintf(stderr, "short read from %s\n", path);
+            exit(1);
+        }
+        offset += (size_t)count;
+    }
+    if (close(fd) != 0) {
+        fail_errno("close input");
+    }
+    return buffer;
+}
+
+static void create_directory(const char *path)
+{
+    if (mkdir(path, 0755) != 0 && errno != EEXIST) {
+        fail_errno(path);
+    }
+}
+
+static void format_source_path(char *path, size_t size, const char *work_dir,
+                               unsigned leaf)
+{
+    int length = snprintf(path, size, "%s/source-%03u.bin", work_dir, leaf);
+    if (length < 0 || (size_t)length >= size) {
+        fprintf(stderr, "source path is too long\n");
+        exit(1);
+    }
+}
+
+static void format_output_path(char *path, size_t size, const char *work_dir,
+                               unsigned node)
+{
+    int length = snprintf(path, size, "%s/node-%03u.o", work_dir, node);
+    if (length < 0 || (size_t)length >= size) {
+        fprintf(stderr, "output path is too long\n");
+        exit(1);
+    }
+}
+
+static void prepare_sources(const struct bench_config *config)
+{
+    uint8_t *buffer = malloc(config->source_bytes);
+
+    if (buffer == NULL) {
+        fail_errno("malloc source");
+    }
+    create_directory("/tmp");
+    create_directory(config->work_dir);
+    for (unsigned leaf = 0; leaf < config->leaves; leaf++) {
+        char path[PATH_MAX];
+        int fd;
+
+        for (size_t offset = 0; offset < config->source_bytes; offset++) {
+            uint64_t value = (uint64_t)leaf * UINT64_C(0x9e3779b97f4a7c15) + offset;
+            value ^= value >> 17;
+            value *= UINT64_C(0xbf58476d1ce4e5b9);
+            buffer[offset] = (uint8_t)(value >> 29);
+        }
+        format_source_path(path, sizeof(path), config->work_dir, leaf);
+        fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+        if (fd < 0) {
+            fail_errno(path);
+        }
+        write_all(fd, buffer, config->source_bytes);
+        if (close(fd) != 0) {
+            fail_errno("close source");
+        }
+    }
+    free(buffer);
+}
+
+static void remove_outputs(const struct bench_config *config, unsigned node_count)
+{
+    for (unsigned node = 0; node < node_count; node++) {
+        char path[PATH_MAX];
+        format_output_path(path, sizeof(path), config->work_dir, node);
+        if (unlink(path) != 0 && errno != ENOENT) {
+            fail_errno(path);
+        }
+    }
+}
+
+static unsigned build_graph(struct build_node *nodes, unsigned leaves)
+{
+    unsigned node_count = leaves;
+    unsigned level_offset = 0;
+    unsigned level_count = leaves;
+
+    memset(nodes, 0, sizeof(*nodes) * MAX_NODES);
+    while (level_count > 1) {
+        unsigned parent_offset = node_count;
+        unsigned parent_count = level_count / 2U;
+
+        for (unsigned parent = 0; parent < parent_count; parent++) {
+            unsigned left = level_offset + parent * 2U;
+            unsigned right = left + 1U;
+            unsigned parent_node = parent_offset + parent;
+
+            nodes[parent_node].dependencies[0] = left;
+            nodes[parent_node].dependencies[1] = right;
+            nodes[parent_node].dependency_count = 2;
+            nodes[parent_node].remaining_dependencies = 2;
+            nodes[left].parent = parent_node;
+            nodes[left].has_parent = 1;
+            nodes[right].parent = parent_node;
+            nodes[right].has_parent = 1;
+        }
+        node_count += parent_count;
+        level_offset = parent_offset;
+        level_count = parent_count;
+    }
+    return node_count;
+}
+
+static void set_affinity(const cpu_set_t *mask)
+{
+    if (sched_setaffinity(0, sizeof(*mask), mask) != 0) {
+        fail_errno("sched_setaffinity");
+    }
+}
+
+static cpu_set_t select_cpus(const cpu_set_t *allowed, unsigned cpu_count)
+{
+    cpu_set_t selected;
+    unsigned remaining = cpu_count;
+
+    CPU_ZERO(&selected);
+    for (int cpu = 0; cpu < CPU_SETSIZE && remaining != 0; cpu++) {
+        if (CPU_ISSET(cpu, allowed)) {
+            CPU_SET(cpu, &selected);
+            remaining--;
+        }
+    }
+    if (remaining != 0) {
+        fprintf(stderr, "requested %u CPUs but the original mask has only %d\n",
+                cpu_count, CPU_COUNT(allowed));
+        exit(1);
+    }
+    return selected;
+}
+
+static unsigned long long low_mask(const cpu_set_t *mask)
+{
+    unsigned long long value = 0;
+    int limit = CPU_SETSIZE < 64 ? CPU_SETSIZE : 64;
+
+    for (int cpu = 0; cpu < limit; cpu++) {
+        if (CPU_ISSET(cpu, mask)) {
+            value |= 1ULL << cpu;
+        }
+    }
+    return value;
+}
+
+static pid_t spawn_worker(const struct bench_config *config,
+                          const struct build_node *nodes, unsigned node)
+{
+    char node_text[32];
+    char work_text[32];
+    char pass_text[32];
+    char output_bytes_text[32];
+    char output[PATH_MAX];
+    char input_left[PATH_MAX];
+    char input_right[PATH_MAX];
+    char *arguments[13];
+    size_t argument_count = 0;
+    pid_t pid;
+
+    snprintf(node_text, sizeof(node_text), "%u", node);
+    snprintf(work_text, sizeof(work_text), "%zu", config->work_bytes);
+    snprintf(pass_text, sizeof(pass_text), "%u", config->passes);
+    snprintf(output_bytes_text, sizeof(output_bytes_text), "%zu", config->output_bytes);
+    format_output_path(output, sizeof(output), config->work_dir, node);
+    if (nodes[node].dependency_count == 0) {
+        format_source_path(input_left, sizeof(input_left), config->work_dir, node);
+    } else {
+        format_output_path(input_left, sizeof(input_left), config->work_dir,
+                           nodes[node].dependencies[0]);
+        format_output_path(input_right, sizeof(input_right), config->work_dir,
+                           nodes[node].dependencies[1]);
+    }
+
+    arguments[argument_count++] = (char *)self_path;
+    arguments[argument_count++] = "--worker";
+    arguments[argument_count++] = node_text;
+    arguments[argument_count++] = work_text;
+    arguments[argument_count++] = pass_text;
+    arguments[argument_count++] = output_bytes_text;
+    arguments[argument_count++] = output;
+    arguments[argument_count++] = input_left;
+    if (nodes[node].dependency_count != 0) {
+        arguments[argument_count++] = input_right;
+    }
+    arguments[argument_count] = NULL;
+
+    pid = fork();
+    if (pid == 0) {
+        execv(self_path, arguments);
+        fprintf(stderr, "execv(%s) failed: %s\n", self_path, strerror(errno));
+        _exit(127);
+    }
+    return pid;
+}
+
+static void stop_children(struct active_child *active, unsigned active_count)
+{
+    for (unsigned i = 0; i < active_count; i++) {
+        if (kill(active[i].pid, SIGKILL) != 0 && errno != ESRCH) {
+            fprintf(stderr, "kill(%ld) failed: %s\n", (long)active[i].pid,
+                    strerror(errno));
+        }
+    }
+    while (waitpid(-1, NULL, 0) > 0 || errno == EINTR) {
+        if (errno == EINTR) {
+            errno = 0;
+        }
+    }
+}
+
+static uint64_t checksum_file(const char *path)
+{
+    size_t length;
+    uint8_t *buffer = read_file(path, &length);
+    uint64_t checksum = fnv1a(buffer, length, FNV1A_OFFSET_BASIS);
+
+    free(buffer);
+    return checksum;
+}
+
+static struct sample run_build(const struct bench_config *config, unsigned jobs,
+                               const cpu_set_t *allowed)
+{
+    struct build_node nodes[MAX_NODES];
+    struct active_child active[MAX_ACTIVE];
+    unsigned ready[MAX_NODES];
+    unsigned ready_head = 0;
+    unsigned ready_tail = 0;
+    unsigned active_count = 0;
+    unsigned completed = 0;
+    unsigned node_count = build_graph(nodes, config->leaves);
+    cpu_set_t selected = select_cpus(allowed, jobs);
+    struct sample sample;
+    uint64_t start;
+    char final_path[PATH_MAX];
+
+    remove_outputs(config, node_count);
+    set_affinity(&selected);
+    for (unsigned leaf = 0; leaf < config->leaves; leaf++) {
+        ready[ready_tail++] = leaf;
+    }
+
+    start = now_us();
+    while (completed < node_count) {
+        while (active_count < jobs && ready_head < ready_tail) {
+            unsigned node = ready[ready_head++];
+            pid_t pid = spawn_worker(config, nodes, node);
+            if (pid < 0) {
+                int saved_errno = errno;
+                stop_children(active, active_count);
+                errno = saved_errno;
+                fail_errno("fork");
+            }
+            active[active_count].pid = pid;
+            active[active_count].node = node;
+            active_count++;
+        }
+        if (active_count == 0) {
+            fprintf(stderr, "build graph made no progress\n");
+            exit(1);
+        }
+
+        int status;
+        pid_t pid;
+        do {
+            pid = waitpid(-1, &status, 0);
+        } while (pid < 0 && errno == EINTR);
+        if (pid < 0) {
+            stop_children(active, active_count);
+            fail_errno("waitpid");
+        }
+
+        unsigned slot = active_count;
+        for (unsigned i = 0; i < active_count; i++) {
+            if (active[i].pid == pid) {
+                slot = i;
+                break;
+            }
+        }
+        if (slot == active_count) {
+            stop_children(active, active_count);
+            fprintf(stderr, "reaped unknown worker %ld\n", (long)pid);
+            exit(1);
+        }
+        unsigned node = active[slot].node;
+        active[slot] = active[active_count - 1U];
+        active_count--;
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+            stop_children(active, active_count);
+            fprintf(stderr, "worker node=%u pid=%ld failed status=%d\n", node,
+                    (long)pid, status);
+            exit(1);
+        }
+
+        nodes[node].completed = 1;
+        completed++;
+        if (nodes[node].has_parent) {
+            struct build_node *parent = &nodes[nodes[node].parent];
+            if (parent->remaining_dependencies == 0) {
+                stop_children(active, active_count);
+                fprintf(stderr, "dependency count underflow for node %u\n",
+                        nodes[node].parent);
+                exit(1);
+            }
+            parent->remaining_dependencies--;
+            if (parent->remaining_dependencies == 0) {
+                ready[ready_tail++] = nodes[node].parent;
+            }
+        }
+    }
+    sample.elapsed_us = now_us() - start;
+    set_affinity(allowed);
+    format_output_path(final_path, sizeof(final_path), config->work_dir, node_count - 1U);
+    sample.checksum = checksum_file(final_path);
+    return sample;
+}
+
+static int compare_u64(const void *left, const void *right)
+{
+    uint64_t a = *(const uint64_t *)left;
+    uint64_t b = *(const uint64_t *)right;
+    return (a > b) - (a < b);
+}
+
+static uint64_t summarize(const struct bench_config *config, unsigned jobs,
+                          const struct sample *samples)
+{
+    uint64_t elapsed[MAX_ROUNDS];
+    uint64_t checksum = samples[0].checksum;
+
+    printf("COMPILE_SIM_RESULT jobs=%u rounds=%u samples_us=", jobs, config->rounds);
+    for (unsigned round = 0; round < config->rounds; round++) {
+        if (samples[round].checksum != checksum) {
+            fprintf(stderr,
+                    "checksum mismatch jobs=%u round=%u expected=0x%016llx actual=0x%016llx\n",
+                    jobs, round + 1U, (unsigned long long)checksum,
+                    (unsigned long long)samples[round].checksum);
+            exit(1);
+        }
+        elapsed[round] = samples[round].elapsed_us;
+        printf("%s%llu", round == 0 ? "" : ",",
+               (unsigned long long)samples[round].elapsed_us);
+    }
+    qsort(elapsed, config->rounds, sizeof(elapsed[0]), compare_u64);
+    uint64_t median = elapsed[config->rounds / 2U];
+    printf(" median_us=%llu checksum=0x%016llx\n", (unsigned long long)median,
+           (unsigned long long)checksum);
+    return median;
+}
+
+static int worker_main(int argc, char **argv)
+{
+    if (argc != 8 && argc != 9) {
+        fprintf(stderr, "invalid worker argument count: %d\n", argc);
+        return 2;
+    }
+
+    unsigned node = (unsigned)parse_u64("worker-node", argv[2], 0, MAX_NODES - 1U);
+    size_t work_bytes = (size_t)parse_u64("worker-work-bytes", argv[3], 4096,
+                                          64U * 1024U * 1024U);
+    unsigned passes = (unsigned)parse_u64("worker-passes", argv[4], 1, 1024);
+    size_t output_bytes = (size_t)parse_u64("worker-output-bytes", argv[5], 4096,
+                                            16U * 1024U * 1024U);
+    const char *output = argv[6];
+    uint64_t hash = FNV1A_OFFSET_BASIS ^ node;
+    uint64_t *working;
+    size_t words;
+
+    if (!is_power_of_two(work_bytes) || output_bytes > work_bytes) {
+        fprintf(stderr, "invalid worker memory geometry\n");
+        return 2;
+    }
+    for (int input_index = 7; input_index < argc; input_index++) {
+        size_t length;
+        uint8_t *input = read_file(argv[input_index], &length);
+        hash = fnv1a(input, length, hash);
+        free(input);
+    }
+
+    working = malloc(work_bytes);
+    if (working == NULL) {
+        fail_errno("malloc working set");
+    }
+    words = work_bytes / sizeof(*working);
+    for (size_t i = 0; i < words; i++) {
+        uint64_t value = hash + i * UINT64_C(0x9e3779b97f4a7c15);
+        value ^= value >> 30;
+        value *= UINT64_C(0xbf58476d1ce4e5b9);
+        value ^= value >> 27;
+        value *= UINT64_C(0x94d049bb133111eb);
+        working[i] = value ^ (value >> 31);
+    }
+
+    uint64_t accumulator = hash;
+    size_t mask = words - 1U;
+    for (unsigned pass = 0; pass < passes; pass++) {
+        for (size_t i = 0; i < words; i++) {
+            size_t index = (size_t)(accumulator ^ working[i]) & mask;
+            uint64_t value = working[i] ^ rotate_left(working[index] + accumulator,
+                                                      (unsigned)(i + pass));
+            value *= UINT64_C(0xd6e8feb86659fd93);
+            accumulator = rotate_left(accumulator ^ value, 17) + i + pass;
+            working[i] = value ^ accumulator;
+        }
+    }
+
+    int fd = open(output, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+    if (fd < 0) {
+        fail_errno(output);
+    }
+    write_all(fd, working, output_bytes);
+    if (close(fd) != 0) {
+        fail_errno("close output");
+    }
+    free(working);
+    return 0;
+}
+
+static int benchmark_main(const struct bench_config *config)
+{
+    cpu_set_t allowed;
+    long online = sysconf(_SC_NPROCESSORS_ONLN);
+    struct sample one_cpu[MAX_ROUNDS];
+    struct sample four_cpu[MAX_ROUNDS];
+    uint64_t warmup_checksum;
+    uint64_t one_median;
+    uint64_t four_median;
+
+    if (online < 0) {
+        fail_errno("sysconf(_SC_NPROCESSORS_ONLN)");
+    }
+    CPU_ZERO(&allowed);
+    if (sched_getaffinity(0, sizeof(allowed), &allowed) != 0) {
+        fail_errno("sched_getaffinity");
+    }
+    printf("COMPILE_SIM_SOURCE path=%s model=process_dag_v1\n", self_path);
+    printf("COMPILE_SIM_TOPOLOGY online=%ld allowed=%d mask=0x%llx\n", online,
+           CPU_COUNT(&allowed), low_mask(&allowed));
+    printf("COMPILE_SIM_CONFIG execution=%s leaves=%u nodes=%u source_bytes=%zu "
+           "work_bytes=%zu passes=%u output_bytes=%zu rounds=%u expected_cpus=%d\n",
+           config->smoke ? "smoke" : "benchmark", config->leaves,
+           config->leaves * 2U - 1U, config->source_bytes, config->work_bytes,
+           config->passes, config->output_bytes, config->rounds, config->expected_cpus);
+    fflush(stdout);
+    if (online != (long)config->expected_cpus ||
+        CPU_COUNT(&allowed) != (int)config->expected_cpus) {
+        fprintf(stderr, "expected exactly %u online and allowed CPUs\n",
+                config->expected_cpus);
+        return 1;
+    }
+    if (self_path[0] != '/') {
+        fprintf(stderr, "benchmark executable path must be absolute: %s\n", self_path);
+        return 1;
+    }
+
+    prepare_sources(config);
+    struct sample warmup_one = run_build(config, 1, &allowed);
+    struct sample warmup_four = run_build(config, 4, &allowed);
+    warmup_checksum = warmup_one.checksum;
+    if (warmup_four.checksum != warmup_checksum) {
+        fprintf(stderr, "warmup checksum mismatch between jobs=1 and jobs=4\n");
+        return 1;
+    }
+    printf("COMPILE_SIM_WARMUP jobs=1 elapsed_us=%llu checksum=0x%016llx\n",
+           (unsigned long long)warmup_one.elapsed_us,
+           (unsigned long long)warmup_one.checksum);
+    printf("COMPILE_SIM_WARMUP jobs=4 elapsed_us=%llu checksum=0x%016llx\n",
+           (unsigned long long)warmup_four.elapsed_us,
+           (unsigned long long)warmup_four.checksum);
+
+    for (unsigned round = 0; round < config->rounds; round++) {
+        if (round % 2U == 0) {
+            one_cpu[round] = run_build(config, 1, &allowed);
+            four_cpu[round] = run_build(config, 4, &allowed);
+        } else {
+            four_cpu[round] = run_build(config, 4, &allowed);
+            one_cpu[round] = run_build(config, 1, &allowed);
+        }
+        if (one_cpu[round].checksum != warmup_checksum ||
+            four_cpu[round].checksum != warmup_checksum) {
+            fprintf(stderr, "sample checksum mismatch round=%u\n", round + 1U);
+            return 1;
+        }
+        printf("COMPILE_SIM_SAMPLE jobs=1 round=%u elapsed_us=%llu checksum=0x%016llx\n",
+               round + 1U, (unsigned long long)one_cpu[round].elapsed_us,
+               (unsigned long long)one_cpu[round].checksum);
+        printf("COMPILE_SIM_SAMPLE jobs=4 round=%u elapsed_us=%llu checksum=0x%016llx\n",
+               round + 1U, (unsigned long long)four_cpu[round].elapsed_us,
+               (unsigned long long)four_cpu[round].checksum);
+        fflush(stdout);
+    }
+
+    one_median = summarize(config, 1, one_cpu);
+    four_median = summarize(config, 4, four_cpu);
+    uint64_t speedup_milli = one_median * UINT64_C(1000) / four_median;
+    printf("COMPILE_SIM_SPEEDUP one_job_median_us=%llu four_job_median_us=%llu "
+           "speedup_milli=%llu speedup=%llu.%03llux\n",
+           (unsigned long long)one_median, (unsigned long long)four_median,
+           (unsigned long long)speedup_milli,
+           (unsigned long long)(speedup_milli / UINT64_C(1000)),
+           (unsigned long long)(speedup_milli % UINT64_C(1000)));
+    printf("COMPILE_SIM_BENCH_PASSED\n");
+    fflush(stdout);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    setvbuf(stdout, NULL, _IONBF, 0);
+    self_path = argv[0];
+    if (argc >= 2 && strcmp(argv[1], "--worker") == 0) {
+        return worker_main(argc, argv);
+    }
+    struct bench_config config = parse_args(argc, argv);
+    return benchmark_main(&config);
+}

--- a/apps/starry/qemu/compile-sim-bench/linux-compile-sim-init.sh
+++ b/apps/starry/qemu/compile-sim-bench/linux-compile-sim-init.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+trap 'poweroff -f' EXIT INT TERM
+printf 'LINUX_RT_COMPILE_SIM_BOOTED\n'
+if /usr/bin/compile-sim-bench --benchmark; then
+    printf 'LINUX_RT_COMPILE_SIM_PASSED\n'
+else
+    status=$?
+    printf 'LINUX_RT_COMPILE_SIM_FAILED status=%s\n' "$status" >&2
+    exit "$status"
+fi

--- a/apps/starry/qemu/compile-sim-bench/linux-ltp-hackbench-init.sh
+++ b/apps/starry/qemu/compile-sim-bench/linux-ltp-hackbench-init.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -eu
+
+trap 'poweroff -f' EXIT INT TERM
+printf 'LINUX_RT_LTP_HACKBENCH_BOOTED\n'
+if /usr/bin/ltp-hackbench-run benchmark; then
+    printf 'LINUX_RT_LTP_HACKBENCH_PASSED\n'
+else
+    status=$?
+    printf 'LINUX_RT_LTP_HACKBENCH_FAILED status=%s\n' "$status" >&2
+    exit "$status"
+fi

--- a/apps/starry/qemu/compile-sim-bench/prebuild.sh
+++ b/apps/starry/qemu/compile-sim-bench/prebuild.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${STARRY_APP_DIR:?STARRY_APP_DIR is required}"
+: "${STARRY_OVERLAY_DIR:?STARRY_OVERLAY_DIR is required}"
+: "${STARRY_ARCH:?STARRY_ARCH is required}"
+
+if [[ "$STARRY_ARCH" != x86_64 ]]; then
+    echo "compile-sim-bench currently supports only x86_64" >&2
+    exit 1
+fi
+
+compiler_triple=x86_64-linux-musl
+if [[ -n "${COMPILE_SIM_CC:-}" ]]; then
+    compiler="$COMPILE_SIM_CC"
+elif command -v "${compiler_triple}-gcc" >/dev/null 2>&1; then
+    compiler=$(command -v "${compiler_triple}-gcc")
+elif [[ -x "/opt/${compiler_triple}-cross/bin/${compiler_triple}-gcc" ]]; then
+    compiler="/opt/${compiler_triple}-cross/bin/${compiler_triple}-gcc"
+else
+    echo "no $compiler_triple compiler found; set COMPILE_SIM_CC" >&2
+    exit 1
+fi
+
+install_dir="$STARRY_OVERLAY_DIR/usr/bin"
+ltp_app_dir="$STARRY_APP_DIR/../ltp-hackbench"
+mkdir -p "$install_dir"
+
+"$compiler" \
+    -std=c11 -O2 -Wall -Wextra -Werror -static -no-pie \
+    "$STARRY_APP_DIR/compile-sim-bench.c" \
+    -o "$install_dir/compile-sim-bench"
+install -m 0755 "$STARRY_APP_DIR/compile-sim-bench-run.sh" \
+    "$install_dir/compile-sim-bench-run"
+
+# Install the existing unmodified-LTP wrapper as well, so Starry and Linux can
+# boot the same generated rootfs for both benchmark families.
+"$compiler" \
+    -std=c11 -O2 -Wall -Wextra -Werror -static -no-pie \
+    "$ltp_app_dir/affinity_exec.c" \
+    -o "$install_dir/ltp-hackbench-affinity"
+install -m 0755 "$ltp_app_dir/ltp-hackbench.sh" \
+    "$install_dir/ltp-hackbench-run"
+install -m 0755 "$STARRY_APP_DIR/linux-compile-sim-init.sh" \
+    "$install_dir/linux-compile-sim-init"
+install -m 0755 "$STARRY_APP_DIR/linux-ltp-hackbench-init.sh" \
+    "$install_dir/linux-ltp-hackbench-init"
+
+echo "Installed compile-sim and the shared Linux/Starry benchmark launchers."

--- a/apps/starry/qemu/compile-sim-bench/qemu-x86_64-benchmark.toml
+++ b/apps/starry/qemu/compile-sim-bench/qemu-x86_64-benchmark.toml
@@ -1,0 +1,27 @@
+args = [
+    "-machine",
+    "q35",
+    "-accel",
+    "tcg,thread=multi",
+    "-nographic",
+    "-m",
+    "512M",
+    "-smp",
+    "4",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img,snapshot=on",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/compile-sim-bench-run --benchmark"
+success_regex = ["(?m)^COMPILE_SIM_BENCH_PASSED\\s*$"]
+fail_regex = [
+    "(?m)^COMPILE_SIM_BENCH_FAILED status=",
+    "(?i)kernel panic",
+    "(?i)lockdep.*(panic|fatal)",
+    "(?i)segmentation fault",
+]
+timeout = 1800

--- a/apps/starry/qemu/compile-sim-bench/qemu-x86_64-ltp-hackbench.toml
+++ b/apps/starry/qemu/compile-sim-bench/qemu-x86_64-ltp-hackbench.toml
@@ -1,0 +1,27 @@
+args = [
+    "-machine",
+    "q35",
+    "-accel",
+    "tcg,thread=multi",
+    "-nographic",
+    "-m",
+    "512M",
+    "-smp",
+    "4",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img,snapshot=on",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/ltp-hackbench-run benchmark"
+success_regex = ["(?m)^LTP_HACKBENCH_APP_PASSED\\s*$"]
+fail_regex = [
+    "(?i)kernel panic",
+    "(?i)lockdep.*(panic|fatal)",
+    "(?i)segmentation fault",
+    "(?m)^LTP_HACKBENCH_APP_FAILED:",
+]
+timeout = 1800

--- a/apps/starry/qemu/compile-sim-bench/qemu-x86_64.toml
+++ b/apps/starry/qemu/compile-sim-bench/qemu-x86_64.toml
@@ -1,0 +1,27 @@
+args = [
+    "-machine",
+    "q35",
+    "-accel",
+    "tcg,thread=multi",
+    "-nographic",
+    "-m",
+    "512M",
+    "-smp",
+    "4",
+    "-device",
+    "nvme,drive=disk0,serial=tgoskits,max_ioqpairs=64,msix_qsize=65",
+    "-drive",
+    "id=disk0,if=none,format=raw,file=${workspace}/tmp/axbuild/rootfs/rootfs-x86_64-alpine.img,snapshot=on",
+]
+uefi = true
+to_bin = true
+shell_prefix = "root@starry:"
+shell_init_cmd = "/usr/bin/compile-sim-bench-run --smoke"
+success_regex = ["(?m)^COMPILE_SIM_BENCH_PASSED\\s*$"]
+fail_regex = [
+    "(?m)^COMPILE_SIM_BENCH_FAILED status=",
+    "(?i)kernel panic",
+    "(?i)lockdep.*(panic|fatal)",
+    "(?i)segmentation fault",
+]
+timeout = 300


### PR DESCRIPTION
## 1. 问题

Starry 现有 LTP `hackbench` 能观察 scheduler、pipe/socket IPC 与 wake/wait 吞吐，但没有覆盖
`cargo build -jN` 这类多进程依赖图、CPU/内存工作集和文件产物组合负载。真实 self-host 编译又会把
工具链下载、网络、源码版本与增量缓存混入结果，无法在 Starry、`dev` 和 Linux RT 之间复用完全
相同的 workload。

本 PR 增加一个固定、可重复、无需网络的编译型 DAG app benchmark，用于比较同一 4-vCPU SMP
内核内 `jobs=1` 与 `jobs=4` 的扩展性。它是独立性能工具，不设置最低 speedup 门槛，也不进入普通
提交测试矩阵。

## 2. 实际改动

新增 `apps/starry/qemu/compile-sim-bench/`。`compile-sim-bench.c` 的 `build_graph()` 建立满二叉依赖
图，`run_build()` 维护 ready queue，并通过 `jobs` 限制同时运行的 worker；每个节点都使用
`fork()` 与 `execv()` 启动同一静态 ELF。

- 正式配置包含 16 个叶子、31 个进程节点、每节点 4 MiB 工作集、8 次确定性变换与 128 KiB 输出。
- 叶子读取固定 source，非叶子读取两个依赖产物；根产物的 FNV-1a 校验和必须在预热、全部轮次和
  两种并行度间一致。
- QEMU 始终启动 4 个 online vCPU，benchmark 保存原 affinity，再把整个进程树分别限制到前 1 个或
  前 4 个 CPU，避免把 UP/SMP 构建差异混入扩展性结果。
- 每种并行度先预热一次，再交错执行 5 轮并报告中位数和 `T(jobs=1) / T(jobs=4)`。
- `prebuild.sh` 使用 x86_64 musl 工具链生成静态 ELF，并复用现有未修改 LTP `hackbench` runner，
  让两类 workload 使用相同 managed rootfs。
- 提供快速 smoke、正式编译 DAG、LTP 对照三套 QEMU 配置，以及复用相同 rootfs 的 Linux PID 1
  启动脚本。
- guest wrapper 将任意 benchmark 非零退出转换为 `COMPILE_SIM_BENCH_FAILED`，使运行器立即失败；
  完成时必须出现唯一 `COMPILE_SIM_BENCH_PASSED`。

具体负载、命令和 Linux 对照条件见
`apps/starry/qemu/compile-sim-bench/README.md`，完整五轮样本见
`apps/starry/qemu/compile-sim-bench/RESULTS-2026-09-01.md`。

## 3. 性能结果

三套 guest 使用相同静态 workload、Alpine rootfs、Q35、QEMU 10.1 TCG multi-thread、512 MiB、
4 vCPU 与 NVMe snapshot。每次 QEMU 固定到四个不同宿主物理核；每格预热一次并交错执行 5 轮，
下表为 wall time 中位数。

| 系统 | `jobs=1` | `jobs=4` | 1→4 扩展比 | 4-job / Linux RT |
| --- | ---: | ---: | ---: | ---: |
| PR #1775 `272b2a65bb` | 6.036 s | 4.527 s | **1.333×** | 2.254× |
| Starry `dev` `65dd0ef42b` | 5.935 s | 5.987 s | 0.991× | 2.981× |
| Linux v7.1 PREEMPT_RT `8cd9520d35` | 6.101 s | **2.008 s** | **3.037×** | 1.000× |

三者单 job 都在约 6 秒。PR #1775 的 4-job 结果比当时最新 `dev` 快 24.4%，说明该调度分支恢复了
部分多核扩展；但绝对耗时仍是 Linux RT 的 2.254 倍。LTP process/thread 对照也呈现相同扩展方向，
原始样本和局限已记录在结果文档中。

## 4. 验证

验证覆盖构建器、确定性产物、失败传播和真实 Starry SMP 运行路径。性能正式数据不作为 smoke
结果使用。

- `bash -n apps/starry/qemu/compile-sim-bench/prebuild.sh`
- `sh -n` 三个 guest/Linux 启动脚本
- `x86_64-linux-musl-gcc -std=c11 -O2 -Wall -Wextra -Werror -static -no-pie ...`
- 宿主 `--smoke --expected-cpus 16`：输出 `COMPILE_SIM_BENCH_PASSED`，校验和
  `0xb0500e81ea902c6b`
- wrapper 成功/失败传播检查：`/bin/true` 返回成功，`/bin/false` 返回非零并输出
  `COMPILE_SIM_BENCH_FAILED status=1`
- `cargo xtask starry app qemu -t qemu/compile-sim-bench --arch x86_64`：4-vCPU Starry 真实运行通过，
  输出 `COMPILE_SIM_BENCH_PASSED`
- `git diff --check origin/dev...HEAD`

## 5. 边界

该 workload 近似项目编译的调度形态，但不模拟 `rustc` 前端、LLVM 或链接器算法。TCG 和共享宿主
后台负载会放大绝对耗时抖动，因此结果用于判断数量级和 1→4 CPU 扩展方向，不作为裸机微基准。
当前只提供已实际验证的 x86_64 配置；其他体系结构没有在本 PR 中声明支持。
