### PR TITLE
feat(virtio): implement split-ring event index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,6 +1571,7 @@ dependencies = [
  "axaddrspace",
  "axvm-types",
  "log",
+ "mbarrier",
 ]
 
 [[package]]

--- a/fs/ax-fs-ng/src/block/runtime/irq.rs
+++ b/fs/ax-fs-ng/src/block/runtime/irq.rs
@@ -220,7 +220,11 @@ fn publish_device_event(
         activated = true;
         control_deferred |= control_bits != 0;
     }
-    if !control_deferred
+    // A queue target owns the complete drain-then-rearm transaction. Publishing
+    // the same rearm to the controller worker would let it unmask the source
+    // before the hctx has consumed the completions. Controller-only events,
+    // such as an admin IRQ without a queue target, still use this fallback.
+    if !activated
         && (!control.is_empty() || needs_rearm)
         && let Some(target) = controller_target
     {
@@ -491,6 +495,61 @@ mod tests {
                 queue_ready: true,
                 needs_rearm: true,
                 control: ControlEvent::new(11, 0x80),
+            }
+        );
+        assert_eq!(
+            controller_latch.take(),
+            LatchedControllerIrq {
+                needs_rearm: false,
+                control: ControlEvent::new(11, 0),
+            }
+        );
+    }
+
+    #[test]
+    fn queue_coupled_rearm_is_owned_only_by_hctx() {
+        let queue_latch = Arc::new(IrqEventLatch::new(11));
+        let queue_notification = Arc::new(TestNotification {
+            irq_notifications: AtomicUsize::new(0),
+        });
+        let controller_latch = Arc::new(ControllerIrqLatch::new(11));
+        let controller_notification = Arc::new(TestNotification {
+            irq_notifications: AtomicUsize::new(0),
+        });
+        let handler = FixedHandler {
+            ack: IrqAck::masked_needs_rearm(IrqQueueMask::from_queue(2), ControlEvent::new(11, 0)),
+        };
+        let mut action = BlockIrqAction::new(
+            Box::new(handler),
+            vec![IrqTarget::new(
+                2,
+                queue_latch.clone(),
+                queue_notification.clone(),
+            )],
+        )
+        .with_controller_target(ControllerIrqTarget::new(
+            controller_latch.clone(),
+            controller_notification.clone(),
+        ));
+
+        assert_eq!(action.run(), BlockIrqOutcome::Wake);
+        assert_eq!(
+            queue_notification.irq_notifications.load(Ordering::Acquire),
+            1
+        );
+        assert_eq!(
+            controller_notification
+                .irq_notifications
+                .load(Ordering::Acquire),
+            0,
+            "the controller must not race the hctx by rearming the same masked source"
+        );
+        assert_eq!(
+            queue_latch.take(),
+            LatchedIrqEvent {
+                queue_ready: true,
+                needs_rearm: true,
+                control: ControlEvent::new(11, 0),
             }
         );
         assert_eq!(

--- a/virtualization/axvirtio-blk/README.md
+++ b/virtualization/axvirtio-blk/README.md
@@ -176,7 +176,7 @@ let config = VirtioBlockConfig {
 | Feature | Status | Description |
 |---------|--------|-------------|
 | `VIRTIO_F_VERSION_1` | ✅ | VirtIO 1.0+ compliance |
-| `VIRTIO_F_RING_EVENT_IDX` | ✅ | Event index support |
+| `VIRTIO_F_RING_EVENT_IDX` | ✅ | Split-ring event-index notification suppression |
 | `VIRTIO_BLK_F_SIZE_MAX` | ✅ | Maximum segment size |
 | `VIRTIO_BLK_F_SEG_MAX` | ✅ | Maximum segments per request |
 | `VIRTIO_BLK_F_BLK_SIZE` | ✅ | Block size reporting |

--- a/virtualization/axvirtio-blk/src/mmio/device.rs
+++ b/virtualization/axvirtio-blk/src/mmio/device.rs
@@ -195,6 +195,8 @@ impl<B: BlockBackend, T: GuestMemoryAccessor + Clone> VirtioMmioBlockDevice<B, T
                 head
             } else if let Some(head) = queue.pop_available_head_with_memory(memory)? {
                 head
+            } else if queue.rearm_available_event_with_memory(memory)? {
+                continue;
             } else {
                 break;
             };
@@ -419,6 +421,8 @@ mod tests {
     use super::*;
 
     const DESC_TABLE: usize = 0x100;
+    const AVAIL_RING: usize = 0x200;
+    const USED_RING: usize = 0x240;
     const HEADER: usize = 0x300;
     const DATA: usize = 0x400;
     const STATUS: usize = 0x800;
@@ -557,5 +561,40 @@ mod tests {
 
         assert_eq!(event, Ok(BlockDeviceEvent::Reset));
         assert_eq!(*device.pending_head.lock(), None);
+    }
+
+    #[test]
+    fn empty_event_idx_queue_rearms_the_next_available_index() {
+        let (device, _queue, mut memory) = fixture(64, 0);
+        device.set_status(crate::constants::VIRTIO_STATUS_DRIVER_OK);
+        {
+            let mut queues = device.state.queues_lock();
+            let queue = &mut queues[0];
+            queue.set_size(4).unwrap();
+            queue
+                .set_desc_table_addr(GuestPhysAddr::from(DESC_TABLE))
+                .unwrap();
+            queue
+                .set_avail_ring_addr(GuestPhysAddr::from(AVAIL_RING))
+                .unwrap();
+            queue
+                .set_used_ring_addr(GuestPhysAddr::from(USED_RING))
+                .unwrap();
+            queue.set_ready(true);
+            queue.event_idx_enabled = true;
+            queue.update_last_avail_idx(2);
+        }
+        memory.0[AVAIL_RING + 2..AVAIL_RING + 4].copy_from_slice(&2u16.to_le_bytes());
+
+        assert_eq!(
+            device.handle_queue_notify(0, &mut memory),
+            Ok(BlockDeviceEvent::None)
+        );
+
+        let avail_event = USED_RING + 4 + 4 * 8;
+        assert_eq!(
+            u16::from_le_bytes(memory.0[avail_event..avail_event + 2].try_into().unwrap()),
+            2
+        );
     }
 }

--- a/virtualization/axvirtio-blk/tests/block_tests.rs
+++ b/virtualization/axvirtio-blk/tests/block_tests.rs
@@ -528,6 +528,7 @@ mod mmio_device_tests {
     const MMIO_MAGIC: u32 = 0x74726976; // "virt" in little endian
     const MMIO_VERSION: u32 = 2; // VirtIO 1.0+
     const VIRTIO_DEVICE_BLOCK: u32 = 2;
+    const VIRTIO_F_RING_EVENT_IDX: u32 = 1 << 29;
 
     fn create_test_device() -> VirtioMmioBlockDevice<MockBlockBackend, MockGuestMemoryAccessor> {
         let backend = MockBlockBackend::new(2048, 512); // 1MB device
@@ -662,6 +663,24 @@ mod mmio_device_tests {
             .unwrap();
         let high_features = device.mmio_read(features_addr, AccessWidth::Dword);
         assert!(high_features.is_ok());
+    }
+
+    #[test]
+    fn default_features_advertise_implemented_event_idx() {
+        let device = create_test_device();
+        let base_ipa = GuestPhysAddr::from(0x0a000000);
+        let features_sel_addr =
+            GuestPhysAddr::from(base_ipa.as_usize() + VIRTIO_MMIO_DEVICE_FEATURES_SEL as usize);
+        let features_addr =
+            GuestPhysAddr::from(base_ipa.as_usize() + VIRTIO_MMIO_DEVICE_FEATURES as usize);
+
+        device
+            .mmio_write(features_sel_addr, AccessWidth::Dword, 0)
+            .unwrap();
+        let advertised_features =
+            device.mmio_read(features_addr, AccessWidth::Dword).unwrap() as u32;
+
+        assert_ne!(advertised_features & VIRTIO_F_RING_EVENT_IDX, 0);
     }
 
     #[test]

--- a/virtualization/axvirtio-common/Cargo.toml
+++ b/virtualization/axvirtio-common/Cargo.toml
@@ -15,6 +15,7 @@ axaddrspace.workspace = true
 axvm-types.workspace = true
 ax-sync.workspace = true
 log.workspace = true
+mbarrier = "0.1"
 
 [dev-dependencies]
 ax-sync = { path = "../../os/arceos/modules/axsync", features = ["host-test"] }

--- a/virtualization/axvirtio-common/src/mmio/state.rs
+++ b/virtualization/axvirtio-common/src/mmio/state.rs
@@ -56,9 +56,12 @@ pub struct VirtioMmioState<T: GuestMemoryAccessor + Clone> {
     device_features: u64,
     status: Mutex<u32>,
     driver_features: Mutex<u64>,
+    features_sealed: Mutex<bool>,
     device_features_sel: Mutex<u32>,
     driver_features_sel: Mutex<u32>,
     queue_sel: Mutex<u16>,
+    /// Serializes queue configuration register writes without blocking the data path.
+    queue_config_transaction: Mutex<()>,
     queues: Mutex<Vec<VirtioQueue<T>>>,
     interrupt_status: Mutex<InterruptState>,
     config_generation: Mutex<u32>,
@@ -83,9 +86,11 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
             device_features,
             status: Mutex::new(0),
             driver_features: Mutex::new(0),
+            features_sealed: Mutex::new(false),
             device_features_sel: Mutex::new(0),
             driver_features_sel: Mutex::new(0),
             queue_sel: Mutex::new(0),
+            queue_config_transaction: Mutex::new(()),
             queues: Mutex::new(queues),
             interrupt_status: Mutex::new(InterruptState::default()),
             config_generation: Mutex::new(0),
@@ -166,6 +171,8 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
     /// Full transport reset: clears driver features, selectors, interrupt
     /// status, status and every queue. Device identity and features are kept.
     pub fn reset(&self) {
+        let _queue_config_guard = self.queue_config_transaction.lock();
+        let mut features_sealed = self.features_sealed.lock_irqsave();
         *self.driver_features.lock_irqsave() = 0;
         *self.driver_features_sel.lock_irqsave() = 0;
         *self.device_features_sel.lock_irqsave() = 0;
@@ -175,6 +182,7 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
         for q in self.queues.lock_irqsave().iter_mut() {
             q.reset();
         }
+        *features_sealed = false;
     }
 
     /// Handle a standard MMIO read. Out-of-range reads yield `Standard(0)`;
@@ -303,13 +311,16 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
             transport::validate_access_width(width)?;
         }
         let val = val as u32;
+        let _queue_config_guard =
+            is_queue_config_register(offset).then(|| self.queue_config_transaction.lock());
 
         match offset {
             vc::VIRTIO_MMIO_DEVICE_FEATURES_SEL => *self.device_features_sel.lock_irqsave() = val,
             vc::VIRTIO_MMIO_DRIVER_FEATURES_SEL => *self.driver_features_sel.lock_irqsave() = val,
             vc::VIRTIO_MMIO_DRIVER_FEATURES => {
+                let features_sealed = self.features_sealed.lock_irqsave();
                 let sel = *self.driver_features_sel.lock_irqsave() as u64;
-                if sel < 2 {
+                if !*features_sealed && sel < 2 {
                     let mask: u64 = (val as u64) << (sel * 32);
                     let clear: u64 = !(((1u64) << 32) - 1).wrapping_shl((sel * 32) as u32);
                     let mut f = self.driver_features.lock_irqsave();
@@ -330,26 +341,44 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
             }
             vc::VIRTIO_MMIO_QUEUE_READY => {
                 let sel = *self.queue_sel.lock_irqsave();
-                // Hold the queues lock across the layout check and the ready
-                // transition so validation and `set_ready` form one atomic
-                // enforcement point. The probe is bounded (first/last byte of
-                // the three ring regions) and performs no callbacks, so the
-                // hold is short.
-                if let Some(q) = self.queues.lock_irqsave().get_mut(sel as usize) {
-                    let layout_ok = if q.is_configured() {
-                        match ready_memory {
-                            Some(memory) => q.validate_layout_with_memory(memory),
-                            None => {
-                                let accessor = q.accessor().clone();
-                                let mut memory = crate::AddressSpaceMemory::new(&*accessor);
-                                q.validate_layout_with_memory(&mut memory)
-                            }
+                if val == 0 {
+                    if let Some(queue) = self.queues.lock_irqsave().get_mut(sel as usize) {
+                        queue.cancel_ready_preparation();
+                    }
+                    return Ok(MmioWriteAction::None);
+                }
+                let mut candidate = self
+                    .queues
+                    .lock_irqsave()
+                    .get_mut(sel as usize)
+                    .and_then(VirtioQueue::begin_ready_preparation);
+                let prepared = if let Some(queue) = candidate.as_mut() {
+                    let result = match ready_memory {
+                        Some(memory) => queue.validate_layout_with_memory(memory).and_then(|()| {
+                            queue.set_ready(true);
+                            queue.rearm_available_event_with_memory(memory).map(|_| ())
+                        }),
+                        None => {
+                            let accessor = queue.accessor().clone();
+                            let mut memory = crate::AddressSpaceMemory::new(&*accessor);
+                            queue
+                                .validate_layout_with_memory(&mut memory)
+                                .and_then(|()| {
+                                    queue.set_ready(true);
+                                    queue
+                                        .rearm_available_event_with_memory(&mut memory)
+                                        .map(|_| ())
+                                })
                         }
-                        .is_ok()
-                    } else {
-                        false
                     };
-                    q.set_ready(val != 0 && layout_ok);
+                    result.is_ok()
+                } else {
+                    false
+                };
+                if let Some(snapshot) = candidate.as_ref()
+                    && let Some(queue) = self.queues.lock_irqsave().get_mut(sel as usize)
+                {
+                    queue.finish_ready_preparation(snapshot, prepared);
                 }
             }
             vc::VIRTIO_MMIO_QUEUE_NOTIFY => return Ok(MmioWriteAction::QueueNotified(val as u16)),
@@ -380,12 +409,24 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
             self.reset();
             return Ok(MmioWriteAction::Reset);
         }
-        let mut new_status = val;
-        if (new_status & vc::VIRTIO_STATUS_FEATURES_OK) != 0 {
+        let mut features_sealed = self.features_sealed.lock_irqsave();
+        let features_already_ok = *features_sealed;
+        let mut new_status = if features_already_ok {
+            val | vc::VIRTIO_STATUS_FEATURES_OK
+        } else {
+            val
+        };
+        if !features_already_ok && (new_status & vc::VIRTIO_STATUS_FEATURES_OK) != 0 {
             let driver_feats = *self.driver_features.lock_irqsave();
             if (driver_feats & !self.device_features) != 0 {
                 new_status &= !vc::VIRTIO_STATUS_FEATURES_OK;
                 new_status |= vc::VIRTIO_STATUS_FAILED;
+            } else {
+                let event_idx_enabled = driver_feats & vc::VIRTIO_F_RING_EVENT_IDX != 0;
+                for queue in self.queues.lock_irqsave().iter_mut() {
+                    queue.event_idx_enabled = event_idx_enabled;
+                }
+                *features_sealed = true;
             }
         }
         *self.status.lock_irqsave() = new_status;
@@ -445,6 +486,21 @@ impl<T: GuestMemoryAccessor + Clone> VirtioMmioState<T> {
             _ => {}
         }
     }
+}
+
+const fn is_queue_config_register(offset: usize) -> bool {
+    matches!(
+        offset,
+        vc::VIRTIO_MMIO_QUEUE_SEL
+            | vc::VIRTIO_MMIO_QUEUE_NUM
+            | vc::VIRTIO_MMIO_QUEUE_READY
+            | vc::VIRTIO_MMIO_QUEUE_DESC_LOW
+            | vc::VIRTIO_MMIO_QUEUE_DESC_HIGH
+            | vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW
+            | vc::VIRTIO_MMIO_QUEUE_AVAIL_HIGH
+            | vc::VIRTIO_MMIO_QUEUE_USED_LOW
+            | vc::VIRTIO_MMIO_QUEUE_USED_HIGH
+    )
 }
 
 /// Combine a 32-bit LOW/HIGH half with the current address into a 64-bit value.

--- a/virtualization/axvirtio-common/src/queue/available.rs
+++ b/virtualization/axvirtio-common/src/queue/available.rs
@@ -295,6 +295,19 @@ impl<T: GuestMemoryAccessor + Clone> AvailableRing<T> {
             .map_err(|_| VirtioError::InvalidAddress)
     }
 
+    /// Reads the used event field with a scoped memory capability.
+    pub(crate) fn read_used_event_with_memory(
+        &self,
+        memory: &mut dyn GuestMemory,
+    ) -> VirtioResult<u16> {
+        if !self.is_valid() {
+            return Err(VirtioError::QueueNotReady);
+        }
+        let mut bytes = [0u8; 2];
+        memory.read(self.used_event_addr(), &mut bytes)?;
+        Ok(u16::from_le_bytes(bytes))
+    }
+
     /// Write the used event field (for event_idx feature)
     pub fn write_used_event(&self, event: u16) -> VirtioResult<()> {
         if !self.is_valid() {

--- a/virtualization/axvirtio-common/src/queue/mod.rs
+++ b/virtualization/axvirtio-common/src/queue/mod.rs
@@ -3,13 +3,14 @@ mod descriptor;
 mod used;
 
 use alloc::{sync::Arc, vec::Vec};
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 
 pub use available::{AvailableRing, VirtQueueAvail};
 use axaddrspace::GuestMemoryAccessor;
 use axvm_types::GuestPhysAddr;
 pub use descriptor::{DescriptorChain, DescriptorTable, VirtQueueDesc};
 use log::{trace, warn};
+use mbarrier::mb;
 pub use used::{UsedRing, VirtQueueUsed, VirtqUsedElem};
 
 use crate::{
@@ -37,6 +38,8 @@ pub struct VirtioQueue<T: GuestMemoryAccessor + Clone> {
     pub max_size: u16,
     /// Queue ready flag
     pub ready: bool,
+    /// A lock-external queue-ready validation transaction is in progress.
+    preparing: bool,
     /// Descriptor table address (guest physical)
     pub desc_table_addr: GuestPhysAddr,
     /// Available ring address (guest physical)
@@ -47,13 +50,13 @@ pub struct VirtioQueue<T: GuestMemoryAccessor + Clone> {
     next_avail: u16,
     /// Next used index
     next_used: u16,
+    /// Used index at the previous notification-suppression check.
+    notification_old_used: AtomicU16,
     /// Event index enabled.
     ///
-    /// Currently always `false` and intentionally unused: event-index feature
-    /// negotiation is not implemented yet, and a follow-up will wire this
-    /// flag. Layout validation deliberately does not depend on it: the ring
-    /// regions always include the 2-byte event-index footer through the
-    /// `layout_size` math, so the check stays negotiation-independent.
+    /// Set after the driver accepts `VIRTIO_F_RING_EVENT_IDX` and seals
+    /// `FEATURES_OK`. Layout validation deliberately does not depend on it:
+    /// ring regions always include the 2-byte event-index footer.
     pub event_idx_enabled: bool,
     /// Set when a runtime ring/descriptor validation failure occurs; the queue
     /// rejects `pop`/`complete` and the guest-data paths until
@@ -74,9 +77,9 @@ pub struct VirtioQueue<T: GuestMemoryAccessor + Clone> {
 }
 
 impl<T: GuestMemoryAccessor + Clone> Clone for VirtioQueue<T> {
-    /// Clones the queue configuration, snapshotting the current faulted and
-    /// layout-warning latch states into fresh atomics (the clone does not
-    /// share the original's latches).
+    /// Clones the queue configuration, snapshotting the notification baseline,
+    /// faulted state and layout-warning latch into fresh atomics (the clone does
+    /// not share those states with the original).
     fn clone(&self) -> Self {
         Self {
             index: self.index,
@@ -87,11 +90,15 @@ impl<T: GuestMemoryAccessor + Clone> Clone for VirtioQueue<T> {
             accessor: self.accessor.clone(),
             max_size: self.max_size,
             ready: self.ready,
+            preparing: self.preparing,
             desc_table_addr: self.desc_table_addr,
             avail_ring_addr: self.avail_ring_addr,
             used_ring_addr: self.used_ring_addr,
             next_avail: self.next_avail,
             next_used: self.next_used,
+            notification_old_used: AtomicU16::new(
+                self.notification_old_used.load(Ordering::Acquire),
+            ),
             event_idx_enabled: self.event_idx_enabled,
             faulted: AtomicBool::new(self.faulted.load(Ordering::Acquire)),
             layout_warn_emitted: AtomicBool::new(self.layout_warn_emitted.load(Ordering::Acquire)),
@@ -111,11 +118,13 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
             accessor,
             max_size: size,
             ready: false,
+            preparing: false,
             desc_table_addr: GuestPhysAddr::from(0),
             avail_ring_addr: GuestPhysAddr::from(0),
             used_ring_addr: GuestPhysAddr::from(0),
             next_avail: 0,
             next_used: 0,
+            notification_old_used: AtomicU16::new(0),
             event_idx_enabled: false,
             faulted: AtomicBool::new(false),
             layout_warn_emitted: AtomicBool::new(false),
@@ -168,6 +177,10 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     /// Set used ring address
     pub fn set_used_ring_addr(&mut self, addr: GuestPhysAddr) -> VirtioResult<()> {
         self.used_ring_addr = addr;
+        // UsedRing::new starts its producer index at zero, so rebuilding it
+        // also starts a new notification-suppression epoch at zero.
+        self.next_used = 0;
+        self.notification_old_used.store(0, Ordering::Release);
         if addr.as_usize() != 0 {
             self.used_ring = Some(UsedRing::new(addr, self.size, self.accessor.clone()));
         } else {
@@ -189,6 +202,46 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         self.desc_table_addr.as_usize() != 0
             && self.avail_ring_addr.as_usize() != 0
             && self.used_ring_addr.as_usize() != 0
+    }
+
+    /// Whether two queue snapshots describe the same programmable layout.
+    pub(crate) fn has_same_configuration(&self, other: &Self) -> bool {
+        self.index == other.index
+            && self.size == other.size
+            && self.desc_table_addr == other.desc_table_addr
+            && self.avail_ring_addr == other.avail_ring_addr
+            && self.used_ring_addr == other.used_ring_addr
+            && self.event_idx_enabled == other.event_idx_enabled
+    }
+
+    /// Starts one queue-ready preparation transaction.
+    pub(crate) fn begin_ready_preparation(&mut self) -> Option<Self> {
+        if self.ready || self.preparing || !self.is_configured() {
+            return None;
+        }
+        self.preparing = true;
+        Some(self.clone())
+    }
+
+    /// Commits or rejects a completed queue-ready preparation transaction,
+    /// including any warning latch raised while validating its snapshot.
+    pub(crate) fn finish_ready_preparation(&mut self, snapshot: &Self, prepared: bool) {
+        if !self.preparing {
+            return;
+        }
+        if self.has_same_configuration(snapshot) {
+            if snapshot.layout_warn_emitted.load(Ordering::Acquire) {
+                self.layout_warn_emitted.store(true, Ordering::Release);
+            }
+            self.ready = prepared;
+        }
+        self.preparing = false;
+    }
+
+    /// Cancels any queue-ready preparation and makes the queue unavailable.
+    pub(crate) fn cancel_ready_preparation(&mut self) {
+        self.ready = false;
+        self.preparing = false;
     }
 
     /// The guest-memory accessor used by the non-`_with_memory` operations.
@@ -374,11 +427,14 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
     /// usable; `reset` is the only operation that clears the fault.
     pub fn reset(&mut self) {
         self.ready = false;
+        self.preparing = false;
         self.desc_table_addr = GuestPhysAddr::from(0);
         self.avail_ring_addr = GuestPhysAddr::from(0);
         self.used_ring_addr = GuestPhysAddr::from(0);
         self.next_avail = 0;
         self.next_used = 0;
+        self.notification_old_used.store(0, Ordering::Release);
+        self.event_idx_enabled = false;
         self.desc_table = None;
         self.avail_ring = None;
         self.used_ring = None;
@@ -510,6 +566,53 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         Ok(Some(head))
     }
 
+    /// Rearms driver-to-device notifications after the available ring is drained.
+    ///
+    /// When event index was negotiated, the device publishes the next available
+    /// index it expects, executes a full memory barrier, then rechecks `avail.idx`.
+    /// A `true` result means a driver publication raced with rearming and must be
+    /// consumed before the device waits for another notification.
+    pub fn rearm_available_event(&mut self) -> VirtioResult<bool> {
+        let accessor = self.accessor.clone();
+        let mut memory = crate::AddressSpaceMemory::new(&*accessor);
+        self.rearm_available_event_with_memory(&mut memory)
+    }
+
+    /// Rearms event-index notifications with a scoped guest-memory capability.
+    pub fn rearm_available_event_with_memory(
+        &mut self,
+        memory: &mut dyn crate::GuestMemory,
+    ) -> VirtioResult<bool> {
+        if !self.event_idx_enabled {
+            return Ok(false);
+        }
+        if self.faulted.load(Ordering::Acquire) {
+            return Err(VirtioError::QueueFaulted);
+        }
+        if !self.is_valid() {
+            return Err(VirtioError::QueueNotReady);
+        }
+
+        let result = (|| {
+            let next_avail = self.get_last_avail_idx();
+            let used_ring = self.used_ring.as_ref().ok_or(VirtioError::QueueNotReady)?;
+            used_ring.set_notification_with_memory(false, memory)?;
+            used_ring.write_avail_event_with_memory(next_avail, memory)?;
+            mb();
+
+            let avail_idx = self.read_avail_idx_with_memory(memory)?;
+            let pending = avail_idx.wrapping_sub(next_avail);
+            if pending > self.size {
+                return Err(VirtioError::InvalidQueue);
+            }
+            Ok(pending != 0)
+        })();
+        if result.is_err() {
+            self.latch_fault();
+        }
+        result
+    }
+
     /// Consume one available head and return a validated [`DescriptorChain`].
     ///
     /// Returns `Ok(None)` when the queue is empty. The head is consumed *before*
@@ -588,10 +691,25 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
             used_ring.add_used_with_memory(head as u32, written_len, memory)?;
             self.next_used = used_ring.get_used_idx();
             let avail_ring = self.avail_ring.as_ref().ok_or(VirtioError::QueueNotReady)?;
-            Ok(!avail_ring.interrupts_suppressed_with_memory(memory)?)
+            // Expose used.idx before checking the driver's notification
+            // suppression fields, as required by the split-ring protocol.
+            mb();
+            if self.event_idx_enabled {
+                let event = avail_ring.read_used_event_with_memory(memory)?;
+                Ok(event_idx_should_notify(
+                    event,
+                    self.next_used,
+                    self.notification_old_used.load(Ordering::Acquire),
+                ))
+            } else {
+                Ok(!avail_ring.interrupts_suppressed_with_memory(memory)?)
+            }
         })();
         if result.is_err() {
             self.latch_fault();
+        } else {
+            self.notification_old_used
+                .store(self.next_used, Ordering::Release);
         }
         result
     }
@@ -761,11 +879,25 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
         let Some(ref avail_ring) = self.avail_ring else {
             return Err(VirtioError::QueueNotReady);
         };
-        let result = avail_ring
-            .interrupts_suppressed()
-            .map(|suppressed| !suppressed);
+        mb();
+        let result = if self.event_idx_enabled {
+            avail_ring.read_used_event().map(|event| {
+                event_idx_should_notify(
+                    event,
+                    self.next_used,
+                    self.notification_old_used.load(Ordering::Acquire),
+                )
+            })
+        } else {
+            avail_ring
+                .interrupts_suppressed()
+                .map(|suppressed| !suppressed)
+        };
         if result.is_err() {
             self.latch_fault();
+        } else {
+            self.notification_old_used
+                .store(self.next_used, Ordering::Release);
         }
         result
     }
@@ -798,6 +930,20 @@ impl<T: GuestMemoryAccessor + Clone> VirtioQueue<T> {
             .map_err(|_| VirtioError::InvalidAddress)?;
 
         Ok(())
+    }
+}
+
+const fn event_idx_should_notify(event: u16, new: u16, old: u16) -> bool {
+    new.wrapping_sub(event).wrapping_sub(1) < new.wrapping_sub(old)
+}
+
+#[cfg(test)]
+mod event_idx_tests {
+    use super::event_idx_should_notify;
+
+    #[test]
+    fn notification_formula_handles_used_index_wraparound() {
+        assert!(event_idx_should_notify(u16::MAX, 0, u16::MAX));
     }
 }
 
@@ -835,5 +981,50 @@ impl RingRegion {
             return true;
         };
         self.base.as_usize() < other_end && other.base.as_usize() < self_end
+    }
+}
+
+#[cfg(test)]
+mod ready_preparation_tests {
+    use super::*;
+    use crate::{GuestMemory, NoGuestMemoryAccessor};
+
+    struct UnmappedMemory;
+
+    impl GuestMemory for UnmappedMemory {
+        fn read(&mut self, _guest_addr: GuestPhysAddr, _data: &mut [u8]) -> VirtioResult<()> {
+            Err(VirtioError::InvalidAddress)
+        }
+
+        fn write(&mut self, _guest_addr: GuestPhysAddr, _data: &[u8]) -> VirtioResult<()> {
+            Err(VirtioError::InvalidAddress)
+        }
+    }
+
+    #[test]
+    fn rejected_ready_preparation_preserves_layout_warning_latch() {
+        let mut queue = VirtioQueue::new(0, 4, Arc::new(NoGuestMemoryAccessor));
+        queue
+            .set_desc_table_addr(GuestPhysAddr::from(0x1000))
+            .unwrap();
+        queue
+            .set_avail_ring_addr(GuestPhysAddr::from(0x2000))
+            .unwrap();
+        queue
+            .set_used_ring_addr(GuestPhysAddr::from(0x3000))
+            .unwrap();
+
+        let first_snapshot = queue.begin_ready_preparation().unwrap();
+        assert_eq!(
+            first_snapshot.validate_layout_with_memory(&mut UnmappedMemory),
+            Err(VirtioError::InvalidRingLayout)
+        );
+        queue.finish_ready_preparation(&first_snapshot, false);
+
+        let second_snapshot = queue.begin_ready_preparation().unwrap();
+        assert!(
+            second_snapshot.layout_warn_emitted.load(Ordering::Acquire),
+            "a repeated QUEUE_READY attempt must inherit the warning latch"
+        );
     }
 }

--- a/virtualization/axvirtio-common/src/queue/used.rs
+++ b/virtualization/axvirtio-common/src/queue/used.rs
@@ -2,6 +2,7 @@ use alloc::sync::Arc;
 
 use axaddrspace::GuestMemoryAccessor;
 use axvm_types::GuestPhysAddr;
+use mbarrier::mb;
 
 use crate::{
     constants::*,
@@ -195,6 +196,16 @@ impl<T: GuestMemoryAccessor + Clone> UsedRing<T> {
         len: u32,
         memory: &mut dyn GuestMemory,
     ) -> VirtioResult<()> {
+        self.add_used_with_memory_and_barrier(id, len, memory, mb)
+    }
+
+    fn add_used_with_memory_and_barrier(
+        &mut self,
+        id: u32,
+        len: u32,
+        memory: &mut dyn GuestMemory,
+        barrier: impl FnOnce(),
+    ) -> VirtioResult<()> {
         if !self.is_valid() {
             return Err(VirtioError::QueueNotReady);
         }
@@ -216,6 +227,9 @@ impl<T: GuestMemoryAccessor + Clone> UsedRing<T> {
 
         // Update the used index
         self.used_idx = self.used_idx.wrapping_add(1);
+
+        // Publish the used element before publishing used_idx to the driver.
+        barrier();
 
         // Update the used ring header index
         self.write_used_idx_with_memory(memory)?;
@@ -296,12 +310,83 @@ impl<T: GuestMemoryAccessor + Clone> UsedRing<T> {
 
         Ok(())
     }
+
+    /// Sets notification suppression with a scoped memory capability.
+    pub(crate) fn set_notification_with_memory(
+        &self,
+        suppress: bool,
+        memory: &mut dyn GuestMemory,
+    ) -> VirtioResult<()> {
+        if !self.is_valid() {
+            return Err(VirtioError::QueueNotReady);
+        }
+        let flags = if suppress { VIRTQ_USED_F_NO_NOTIFY } else { 0 };
+        memory.write(self.base_addr, &flags.to_le_bytes())
+    }
+
+    /// Writes the available event field with a scoped memory capability.
+    pub(crate) fn write_avail_event_with_memory(
+        &self,
+        event: u16,
+        memory: &mut dyn GuestMemory,
+    ) -> VirtioResult<()> {
+        if !self.is_valid() {
+            return Err(VirtioError::QueueNotReady);
+        }
+        memory.write(self.avail_event_addr(), &event.to_le_bytes())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloc::{rc::Rc, vec::Vec};
+    use core::cell::RefCell;
+
+    use axvm_types::GuestPhysAddr;
+
     use super::*;
-    use crate::NoGuestMemoryAccessor;
+    use crate::{GuestMemory, NoGuestMemoryAccessor};
+
+    struct RecordingMemory {
+        events: Rc<RefCell<Vec<&'static str>>>,
+    }
+
+    impl GuestMemory for RecordingMemory {
+        fn read(&mut self, _: GuestPhysAddr, _: &mut [u8]) -> VirtioResult<()> {
+            Err(VirtioError::InvalidAddress)
+        }
+
+        fn write(&mut self, address: GuestPhysAddr, _: &[u8]) -> VirtioResult<()> {
+            self.events
+                .borrow_mut()
+                .push(if address.as_usize() == 0x1002 {
+                    "used_idx"
+                } else {
+                    "used_elem"
+                });
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn publishes_used_element_before_used_index() {
+        let events = Rc::new(RefCell::new(Vec::new()));
+        let mut memory = RecordingMemory {
+            events: events.clone(),
+        };
+        let mut ring = UsedRing::new(
+            GuestPhysAddr::from(0x1000),
+            1,
+            alloc::sync::Arc::new(NoGuestMemoryAccessor),
+        );
+
+        ring.add_used_with_memory_and_barrier(7, 11, &mut memory, || {
+            events.borrow_mut().push("barrier");
+        })
+        .unwrap();
+
+        assert_eq!(&*events.borrow(), &["used_elem", "barrier", "used_idx"]);
+    }
 
     #[test]
     fn layout_size_counts_header_elements_and_footer() {

--- a/virtualization/axvirtio-common/tests/mmio_state_tests.rs
+++ b/virtualization/axvirtio-common/tests/mmio_state_tests.rs
@@ -143,6 +143,66 @@ fn feature_negotiation_rejects_non_subset() {
 }
 
 #[test]
+fn event_idx_is_enabled_only_after_successful_feature_negotiation() {
+    let s = state(vc::VIRTIO_F_RING_EVENT_IDX);
+    assert!(!s.queues_lock()[0].event_idx_enabled);
+
+    wr(&s, vc::VIRTIO_MMIO_DRIVER_FEATURES_SEL, 0);
+    wr(
+        &s,
+        vc::VIRTIO_MMIO_DRIVER_FEATURES,
+        vc::VIRTIO_F_RING_EVENT_IDX as u32,
+    );
+    wr(&s, vc::VIRTIO_MMIO_STATUS, vc::VIRTIO_STATUS_FEATURES_OK);
+
+    assert!(s.queues_lock()[0].event_idx_enabled);
+}
+
+#[test]
+fn transport_reset_disables_event_idx_on_every_queue() {
+    let s = state(vc::VIRTIO_F_RING_EVENT_IDX);
+    wr(&s, vc::VIRTIO_MMIO_DRIVER_FEATURES_SEL, 0);
+    wr(
+        &s,
+        vc::VIRTIO_MMIO_DRIVER_FEATURES,
+        vc::VIRTIO_F_RING_EVENT_IDX as u32,
+    );
+    wr(&s, vc::VIRTIO_MMIO_STATUS, vc::VIRTIO_STATUS_FEATURES_OK);
+    assert!(s.queues_lock()[0].event_idx_enabled);
+
+    wr(&s, vc::VIRTIO_MMIO_STATUS, 0);
+
+    assert!(!s.queues_lock()[0].event_idx_enabled);
+}
+
+#[test]
+fn accepted_features_are_sealed_until_transport_reset() {
+    let s = state(vc::VIRTIO_F_RING_EVENT_IDX);
+    wr(&s, vc::VIRTIO_MMIO_DRIVER_FEATURES_SEL, 0);
+    wr(
+        &s,
+        vc::VIRTIO_MMIO_DRIVER_FEATURES,
+        vc::VIRTIO_F_RING_EVENT_IDX as u32,
+    );
+    wr(&s, vc::VIRTIO_MMIO_STATUS, vc::VIRTIO_STATUS_FEATURES_OK);
+    assert!(s.queues_lock()[0].event_idx_enabled);
+
+    wr(&s, vc::VIRTIO_MMIO_DRIVER_FEATURES, 0);
+    wr(
+        &s,
+        vc::VIRTIO_MMIO_STATUS,
+        vc::VIRTIO_STATUS_FEATURES_OK | vc::VIRTIO_STATUS_DRIVER_OK,
+    );
+
+    assert_eq!(s.driver_features(), vc::VIRTIO_F_RING_EVENT_IDX);
+    assert!(s.queues_lock()[0].event_idx_enabled);
+    assert_ne!(
+        rd(&s, vc::VIRTIO_MMIO_STATUS) & vc::VIRTIO_STATUS_FEATURES_OK,
+        0
+    );
+}
+
+#[test]
 fn queue_notify_returns_action() {
     let s = state(0);
     assert_eq!(
@@ -185,6 +245,106 @@ fn queue_ready_rejected_when_ring_outside_guest_address_space() {
     bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0xf000);
     bounded_wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
     assert_eq!(bounded_rd(&s, vc::VIRTIO_MMIO_QUEUE_READY), 1);
+}
+
+#[test]
+fn queue_ready_initializes_negotiated_event_idx_fields() {
+    let memory = mem();
+    let queue = VirtioQueue::new(0, vc::DEFAULT_QUEUE_SIZE, Arc::new(memory.clone()));
+    let s = VirtioMmioState::new(
+        GuestPhysAddr::from(BASE),
+        LEN,
+        2,
+        vc::VIRTIO_VENDOR_ID,
+        vc::VIRTIO_F_RING_EVENT_IDX,
+        vec![queue],
+    );
+    wr(&s, vc::VIRTIO_MMIO_DRIVER_FEATURES_SEL, 0);
+    wr(
+        &s,
+        vc::VIRTIO_MMIO_DRIVER_FEATURES,
+        vc::VIRTIO_F_RING_EVENT_IDX as u32,
+    );
+    wr(&s, vc::VIRTIO_MMIO_STATUS, vc::VIRTIO_STATUS_FEATURES_OK);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_SEL, 0);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_NUM, 4);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_DESC_LOW, 0x1000);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW, 0x2000);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, 0x3000);
+    memory
+        .write_buffer(GuestPhysAddr::from(0x3000), &1u16.to_le_bytes())
+        .unwrap();
+    memory
+        .write_buffer(GuestPhysAddr::from(0x3024), &0x1234u16.to_le_bytes())
+        .unwrap();
+
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+
+    assert_eq!(rd(&s, vc::VIRTIO_MMIO_QUEUE_READY), 1);
+    assert_eq!(&memory.buf[0x3000..0x3002], &0u16.to_le_bytes());
+    assert_eq!(&memory.buf[0x3024..0x3026], &0u16.to_le_bytes());
+
+    memory
+        .write_buffer(GuestPhysAddr::from(0x3024), &2u16.to_le_bytes())
+        .unwrap();
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+    assert_eq!(
+        &memory.buf[0x3024..0x3026],
+        &2u16.to_le_bytes(),
+        "a duplicate ready write must not rewind avail_event"
+    );
+}
+
+#[test]
+fn replacing_used_ring_starts_a_new_notification_epoch() {
+    const AVAIL_BASE: usize = 0x2000;
+    const FIRST_USED_BASE: usize = 0x3000;
+    const REPLACEMENT_USED_BASE: usize = 0x4000;
+
+    let memory = mem();
+    let queue = VirtioQueue::new(0, vc::DEFAULT_QUEUE_SIZE, Arc::new(memory.clone()));
+    let s = VirtioMmioState::new(
+        GuestPhysAddr::from(BASE),
+        LEN,
+        2,
+        vc::VIRTIO_VENDOR_ID,
+        vc::VIRTIO_F_RING_EVENT_IDX,
+        vec![queue],
+    );
+    wr(&s, vc::VIRTIO_MMIO_DRIVER_FEATURES_SEL, 0);
+    wr(
+        &s,
+        vc::VIRTIO_MMIO_DRIVER_FEATURES,
+        vc::VIRTIO_F_RING_EVENT_IDX as u32,
+    );
+    wr(&s, vc::VIRTIO_MMIO_STATUS, vc::VIRTIO_STATUS_FEATURES_OK);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_SEL, 0);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_NUM, 4);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_DESC_LOW, 0x1000);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_AVAIL_LOW, AVAIL_BASE as u32);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_USED_LOW, FIRST_USED_BASE as u32);
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+    memory
+        .write_buffer(
+            GuestPhysAddr::from(AVAIL_BASE + 4 + 4 * 2),
+            &0u16.to_le_bytes(),
+        )
+        .unwrap();
+
+    assert!(s.queues_lock()[0].complete(0, 8).unwrap());
+
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 0);
+    wr(
+        &s,
+        vc::VIRTIO_MMIO_QUEUE_USED_LOW,
+        REPLACEMENT_USED_BASE as u32,
+    );
+    wr(&s, vc::VIRTIO_MMIO_QUEUE_READY, 1);
+
+    assert!(
+        s.queues_lock()[0].complete(1, 8).unwrap(),
+        "the first completion on a replacement used ring must notify for used_event 0"
+    );
 }
 
 #[test]

--- a/virtualization/axvirtio-common/tests/queue_tests.rs
+++ b/virtualization/axvirtio-common/tests/queue_tests.rs
@@ -47,6 +47,42 @@ impl GuestMemoryAccessor for MockMem {
     }
 }
 
+struct PublishAfterAvailEventWrite {
+    mem: Arc<MockMem>,
+    avail_event_addr: GuestPhysAddr,
+    avail_idx_addr: GuestPhysAddr,
+    published_idx: u16,
+}
+
+impl axvirtio_common::GuestMemory for PublishAfterAvailEventWrite {
+    fn read(
+        &mut self,
+        guest_addr: GuestPhysAddr,
+        data: &mut [u8],
+    ) -> axvirtio_common::VirtioResult<()> {
+        self.mem
+            .read_buffer(guest_addr, data)
+            .map_err(|_| VirtioError::InvalidAddress)
+    }
+
+    fn write(
+        &mut self,
+        guest_addr: GuestPhysAddr,
+        data: &[u8],
+    ) -> axvirtio_common::VirtioResult<()> {
+        self.mem
+            .write_buffer(guest_addr, data)
+            .map_err(|_| VirtioError::InvalidAddress)?;
+        if guest_addr == self.avail_event_addr {
+            self.mem.put(
+                self.avail_idx_addr.as_usize(),
+                &self.published_idx.to_le_bytes(),
+            );
+        }
+        Ok(())
+    }
+}
+
 /// A fully-wired queue plus its guest-memory layout offsets.
 struct Fixture {
     mem: Arc<MockMem>,
@@ -129,9 +165,21 @@ impl Fixture {
         self.mem.put(self.avail_base, &flags.to_le_bytes());
     }
 
+    /// Set the driver-owned `used_event` footer in the available ring.
+    fn set_used_event(&self, event: u16) {
+        let off = self.avail_base + 4 + self.size as usize * 2;
+        self.mem.put(off, &event.to_le_bytes());
+    }
+
     /// Read the used-ring head index `used.idx`.
     fn used_idx(&self) -> u16 {
         let off = self.used_base + 2;
+        u16::from_le_bytes([self.mem.buf[off], self.mem.buf[off + 1]])
+    }
+
+    /// Read the device-owned `avail_event` footer in the used ring.
+    fn avail_event(&self) -> u16 {
+        let off = self.used_base + 4 + self.size as usize * 8;
         u16::from_le_bytes([self.mem.buf[off], self.mem.buf[off + 1]])
     }
 
@@ -280,6 +328,49 @@ fn pop_available_head_wraps_u16_index() {
     assert_eq!(f.queue.pop_available_head().unwrap(), Some(0));
     // last_avail advanced to 0 (MAX + 1 wraps).
     assert_eq!(f.queue.get_last_avail_idx(), 0);
+}
+
+#[test]
+fn event_idx_rearm_publishes_the_next_expected_available_index() {
+    let mut f = Fixture::new(4);
+    f.queue.event_idx_enabled = true;
+    f.queue.update_last_avail_idx(2);
+    f.set_avail_idx(2);
+
+    assert!(!f.queue.rearm_available_event().unwrap());
+    assert_eq!(f.avail_event(), 2);
+}
+
+#[test]
+fn event_idx_rearm_detects_buffers_published_before_the_recheck() {
+    let mut f = Fixture::new(4);
+    f.queue.event_idx_enabled = true;
+    f.queue.update_last_avail_idx(2);
+    f.set_avail_idx(2);
+    let mut memory = PublishAfterAvailEventWrite {
+        mem: Arc::clone(&f.mem),
+        avail_event_addr: GuestPhysAddr::from(f.used_base + 4 + f.size as usize * 8),
+        avail_idx_addr: GuestPhysAddr::from(f.avail_base + 2),
+        published_idx: 3,
+    };
+
+    assert!(
+        f.queue
+            .rearm_available_event_with_memory(&mut memory)
+            .unwrap()
+    );
+    assert_eq!(f.avail_event(), 2);
+}
+
+#[test]
+fn event_idx_rearm_detects_available_index_wraparound() {
+    let mut f = Fixture::new(4);
+    f.queue.event_idx_enabled = true;
+    f.queue.update_last_avail_idx(u16::MAX);
+    f.set_avail_idx(0);
+
+    assert!(f.queue.rearm_available_event().unwrap());
+    assert_eq!(f.avail_event(), u16::MAX);
 }
 
 #[test]
@@ -902,6 +993,35 @@ fn no_interrupt_flag_suppresses_notification() {
     assert_eq!(f.used_idx(), 1);
     // ...but the driver must not be interrupted.
     assert!(!notify);
+}
+
+#[test]
+fn event_idx_notifies_only_at_the_requested_used_index() {
+    let mut f = Fixture::new(4);
+    f.queue.event_idx_enabled = true;
+    f.set_avail_flags(VIRTQ_AVAIL_F_NO_INTERRUPT);
+    f.set_used_event(0);
+
+    assert!(
+        f.queue.complete(3, 64).unwrap(),
+        "event_idx must ignore NO_INTERRUPT and notify for used_event 0"
+    );
+    assert!(
+        !f.queue.complete(2, 32).unwrap(),
+        "the next completion must stay suppressed until used_event advances"
+    );
+}
+
+#[test]
+fn event_idx_batch_notification_uses_the_previous_check_index() {
+    let mut f = Fixture::new(4);
+    f.queue.event_idx_enabled = true;
+    f.set_used_event(0);
+
+    f.queue.add_used(1, 8).unwrap();
+    f.queue.add_used(2, 8).unwrap();
+
+    assert!(f.queue.should_notify().unwrap());
 }
 
 #[test]


### PR DESCRIPTION
## 问题

`axvirtio-blk` 原先发布了 `VIRTIO_F_RING_EVENT_IDX`，但公共 split virtqueue 没有实现完整的 event-index 通知抑制语义。

驱动协商该能力后会忽略传统的 `VIRTQ_AVAIL_F_NO_INTERRUPT` 和 `VIRTQ_USED_F_NO_NOTIFY`，改用 `used_event` 与 `avail_event`。设备若仍按传统 flags 处理，可能丢失队列 kick 或完成中断，使块请求永久等待。

块中断运行时还存在另一个 rearm 所有权问题：队列硬件上下文已经接管 drain 和 rearm 时，controller worker 仍可能收到同一 rearm 事件，导致中断源在完成项排空前被提前解屏蔽。

## 改动

### EVENT_IDX 协商

- `axvirtio-blk` 发布 `VIRTIO_F_RING_EVENT_IDX`。
- 驱动首次提交 `FEATURES_OK` 时，将协商结果传播到每条 `VirtioQueue`。
- 使用 `features_sealed` 串行 feature 写入、首次 `FEATURES_OK` 转换与 transport reset。
- `FEATURES_OK` 生效后忽略后续 driver feature 写入，直到 transport reset。
- reset 清除队列的 event-index 状态和通知索引。

### Split ring 通知

- 设备完成请求后按 `virtq_need_event(event, new, old)` 语义读取 `used_event`，决定是否向驱动发送通知。
- 在 used-ring 更新与 suppression 字段读取之间执行内存屏障。
- 记录上一次 suppression check 的 used index，支持批量 `add_used` 后统一判断。
- 队列排空时写入 `avail_event`，执行内存屏障并重读 `avail.idx`，避免驱动在 rearm 窗口提交请求后丢失 kick。
- 正确处理 `u16` 索引回绕。

### 队列配置并发

- 使用独立的 queue-config 事务锁串行 queue selector、size、address、ready 和 reset 写入。
- `QUEUE_READY` 的动态 guest-memory 访问在 `queues` IRQ-save 锁外执行。
- 使用 `preparing` 状态和配置快照提交 ready 事务。
- 已 ready 队列的重复 `QUEUE_READY=1` 不再回写旧的 `avail_event`。
- 保持 `should_notify(&self)` 公共接口不变。

### 块中断 rearm

- 命中队列的事件只由对应硬件上下文完成 drain 和 rearm。
- controller worker 仅处理没有队列目标的控制器事件。
- 防止两个执行上下文同时 rearm 同一已屏蔽中断源。

## 测试

新增回归覆盖：

- EVENT_IDX 仅在成功提交 `FEATURES_OK` 后启用；
- 协商结果封存与 transport reset；
- `QUEUE_READY` 初始化 event-index 字段；
- 重复 ready 不回退 `avail_event`；
- `used_event` 通知判定；
- 批量完成与 `u16` 回绕；
- 在写入 `avail_event` 和重读 `avail.idx` 之间注入驱动提交；
- queue hctx 独占 drain 和 rearm。

本地验证：

```text
cargo fmt --check
cargo test -p axvirtio-common
cargo test -p axvirtio-blk
cargo test -p ax-fs-ng
cargo xtask clippy --package axvirtio-common
cargo xtask clippy --package axvirtio-blk
cargo xtask clippy --package ax-fs-ng
bash apps/arceos/virtio-blk-test/run.sh
```