### PR TITLE
fix(starry-test): keep AKA Wi-Fi smoke to one transfer

### DIFF
--- a/scripts/axbuild/src/starry/test/tests.rs
+++ b/scripts/axbuild/src/starry/test/tests.rs
@@ -5,10 +5,13 @@ mod qemu_run_tests;
 mod summary_tests;
 mod system_case_tests;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
+    process::Command,
     time::Duration,
 };
 
@@ -244,4 +247,46 @@ fn write_test_image_config(workspace_root: &Path) {
         extract_dir: workspace_root.join(".tgos-images"),
     };
     crate::image::config::ImageConfig::write_config(workspace_root, &config).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn aka_wifi_smoke_runs_one_connectivity_transfer() {
+    let fake_bin = tempdir().unwrap();
+    let invocation_log = fake_bin.path().join("iperf3-invocations");
+    let ip = fake_bin.path().join("ip");
+    let iperf3 = fake_bin.path().join("iperf3");
+
+    fs::write(&ip, "#!/bin/sh\necho '2: wlan0    inet 192.0.2.2/24'\n").unwrap();
+    fs::write(
+        &iperf3,
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >>\"$IPERF_INVOCATION_LOG\"\n",
+    )
+    .unwrap();
+    for executable in [&ip, &iperf3] {
+        fs::set_permissions(executable, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    let script = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh");
+    let output = Command::new("/bin/sh")
+        .arg(script)
+        .arg("192.0.2.1")
+        .env(
+            "PATH",
+            format!("{}:/usr/bin:/bin", fake_bin.path().display()),
+        )
+        .env("IPERF_INVOCATION_LOG", &invocation_log)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "smoke script failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(invocation_log).unwrap(),
+        "-c 192.0.2.1 -t 3 -O 1 -P 1 -l 128K\n"
+    );
 }

--- a/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh
+++ b/test-suit/starryos/board-aka-00-sg2002/wifi-iperf-smoke/iperf-smoke.sh
@@ -25,7 +25,5 @@ fi
 command -v iperf3 >/dev/null 2>&1 || fail
 
 iperf3 -c "$server_ip" -t 3 -O 1 -P 1 -l 128K || fail
-iperf3 -c "$server_ip" -t 3 -O 1 -P 1 -l 128K -R || fail
-iperf3 -c "$server_ip" -t 3 -O 1 -P 1 -l 128K --bidir || fail
 
 echo STARRY_AKA_WIFI_IPERF_SMOKE_PASSED


### PR DESCRIPTION
## 问题与根因

`dev@031164e3819d7ab265114de996ce180b07b90c19` 的 [AKA-00 SG2002 板卡 CI](https://github.com/rcore-os/tgoskits/actions/runs/33579806407/job/100092807156) 在 `wifi-iperf-smoke` 失败。日志显示第一轮正向 TCP 传输已经完成（约 8.05 Mbit/s），随后第二轮 `-R` 连接立即收到 `Connection refused`。

当前 smoke 脚本连续运行正向、反向和双向三轮 iperf3，把“Wi-Fi/网络连通性门禁”与“多会话吞吐 benchmark”混在同一个提交门禁里。PR #1775 后期遇到过同一阶段问题：第一轮成功，第二轮反向会话因对端控制连接关闭而失败；其独立修复提交为 `b45faa773d17da7ac9569185035ea75e59ffc71e`。本 PR 的 stable patch-id 与该提交完全一致。

## 修改

- AKA Wi-Fi smoke 保留一轮短正向 TCP 传输，继续验证 Starry 启动、WLAN DHCP、iperf3 可用性、到板卡服务的连通性和失败传播。
- 增加 `aka_wifi_smoke_runs_one_connectivity_transfer` 契约测试，真实执行脚本并记录 iperf3 参数，锁定只发起一次连接。
- 反向、双向和多流吞吐不删除，仍由 `apps/starry/iperf3` 的 T01--T07 benchmark 负责；该流程在每个连接后具有独立冷却时间。

## 确定性回归

修复前运行同一回归：

```text
cargo xtask test --since HEAD^
test result: FAILED. 888 passed; 1 failed
left:
  normal
  -R
  --bidir
right:
  normal
```

移除后两轮后，同一测试转绿：

```text
test result: ok. 889 passed; 0 failed
```

## 本地验证

- `cargo fmt --check`
- `cargo xtask test --since origin/dev`（889 passed）
- `cargo xtask clippy --package axbuild`
- `git diff --check origin/dev...HEAD`

本机未设置 `STARRY_WIFI_SSID` / 密码，且本地板卡服务当前不可达，因此没有伪报本地实体板结果；由本 PR 的同名 AKA CI 提供最终实板证据。