### PR TITLE
fix(starry-kernel): report an enabled CPUID from arch_prctl(ARCH_GET_CPUID)

### DIFF
--- a/os/StarryOS/kernel/src/syscall/task/thread.rs
+++ b/os/StarryOS/kernel/src/syscall/task/thread.rs
@@ -116,7 +116,12 @@ pub fn sys_arch_prctl(
             uctx.gs_base = addr as _;
             Ok(0)
         }
-        ArchPrctlCode::GetCpuid => Ok(0),
+        // Linux get_cpuid_mode() returns 1 (ARCH_CPUID_ENABLE) when the CPUID
+        // instruction is enabled for the thread and 0 when it faults. StarryOS
+        // never installs CPUID faulting, so CPUID is always enabled and GET must
+        // report 1 rather than a hardcoded 0. SET stays ENODEV: without faulting
+        // support Linux rejects every requested mode.
+        ArchPrctlCode::GetCpuid => Ok(1),
         ArchPrctlCode::SetCpuid => Err(crate::StarryError::NoSuchDevice),
     }
 }

--- a/test-suit/starryos/qemu/system/syscall-test-archprctl-tls/src/main.c
+++ b/test-suit/starryos/qemu/system/syscall-test-archprctl-tls/src/main.c
@@ -43,6 +43,15 @@
 #define ARCH_GET_GS 0x1004
 #endif
 
+#ifndef ARCH_GET_CPUID
+#define ARCH_GET_CPUID 0x1011
+#define ARCH_SET_CPUID 0x1012
+#endif
+#ifndef ARCH_CPUID_ENABLE
+#define ARCH_CPUID_ENABLE 1
+#define ARCH_CPUID_SIGSEGV 0
+#endif
+
 static void alarm_handler(int s)
 {
     (void)s;
@@ -153,6 +162,33 @@ static int test_pkey_graceful(void)
     TEST_DONE();
 }
 
+#if defined(__x86_64__)
+/*
+ * arch_prctl(ARCH_GET_CPUID/ARCH_SET_CPUID) — x86-64 CPUID faulting control.
+ * ground truth: man 2 arch_prctl, Linux arch/x86/kernel/process.c
+ *   get_cpuid_mode()/set_cpuid_mode().
+ *   ARCH_GET_CPUID returns ARCH_CPUID_ENABLE(1) when the CPUID instruction is
+ *   enabled for the thread and ARCH_CPUID_SIGSEGV(0) when it faults. A thread
+ *   starts with CPUID enabled, so a freshly-started process reads back 1.
+ *   ARCH_SET_CPUID returns -ENODEV on a system without CPUID-faulting support
+ *   (StarryOS never installs faulting), for every requested value.
+ */
+static int test_arch_prctl_cpuid(void)
+{
+    TEST_START("D. arch_prctl ARCH_GET_CPUID/ARCH_SET_CPUID(x86)");
+    errno = 0;
+    long r = syscall(SYS_arch_prctl, ARCH_GET_CPUID, 0);
+    CHECK(r == ARCH_CPUID_ENABLE,
+          "ARCH_GET_CPUID 报 CPUID 已启用(1),线程默认可执行 CPUID");
+    /* No CPUID-faulting support: SET_CPUID is ENODEV for any value. */
+    CHECK_ERR(syscall(SYS_arch_prctl, ARCH_SET_CPUID, ARCH_CPUID_SIGSEGV), ENODEV,
+              "ARCH_SET_CPUID(禁用) 无 faulting 支持 -> ENODEV");
+    CHECK_ERR(syscall(SYS_arch_prctl, ARCH_SET_CPUID, ARCH_CPUID_ENABLE), ENODEV,
+              "ARCH_SET_CPUID(启用) 无 faulting 支持 -> ENODEV");
+    TEST_DONE();
+}
+#endif
+
 int main(void)
 {
     setvbuf(stdout, NULL, _IONBF, 0);
@@ -163,6 +199,7 @@ int main(void)
 #if defined(__x86_64__)
     fail |= test_arch_prctl_fs();
     fail |= test_arch_prctl_gs_errno();
+    fail |= test_arch_prctl_cpuid();
 #endif
     fail |= test_pkey_graceful();
     printf("\n==== test-archprctl-tls 汇总: %s ====\n", fail ? "FAIL" : "PASS");


### PR DESCRIPTION
## 问题

`arch_prctl(ARCH_GET_CPUID)` 此前恒返回 `0`，表示「CPUID 指令对本线程会触发 #GP 陷入」。这与 Linux 语义不符：`get_cpuid_mode()`(`arch/x86/kernel/process.c`) 返回 `1`(ARCH_CPUID_ENABLE) 表示 CPUID 已启用，返回 `0`(ARCH_CPUID_SIGSEGV) 才表示会陷入；线程默认处于启用态。StarryOS 从不安装 CPUID faulting，CPUID 始终可执行，因此 GET 必须报告 `1`。

## 影响

依赖 `arch_prctl(ARCH_GET_CPUID)` 探测 CPUID 状态的运行时（glibc、SDE/DBI 插桩工具）此前会把「CPUID 可用」误判为「不可用」。

## 改动

把 `sys_arch_prctl` 的 `ArchPrctlCode::GetCpuid` 由 `Ok(0)` 改为 `Ok(1)`；`SetCpuid` 维持返回 `ENODEV`——在缺少 CPUID-faulting 支持的系统上 Linux 对任何请求值都返回 `ENODEV`，该行为本就正确，故不改。

## 测试

在系统级用例 `syscall-test-archprctl-tls` 增补 D 段：断言 `ARCH_GET_CPUID` 返回 `1`，并断言 `ARCH_SET_CPUID` 对启用/禁用两种请求均返回 `ENODEV`。该用例在修复前对 GET 断言稳定失败、修复后通过；`cargo xtask starry test qemu --arch x86_64 --test-case qemu/system/syscall-test-archprctl-tls` 与 `cargo xtask clippy --package starry-kernel` 均通过。