### PR TITLE
fix(starry-kernel): stop select() reporting a hung-up fd as writable

### DIFF
--- a/os/StarryOS/kernel/src/syscall/io_mpx/select.rs
+++ b/os/StarryOS/kernel/src/syscall/io_mpx/select.rs
@@ -118,11 +118,15 @@ fn do_select(
                 for ((fd, interested), index) in fds.0.iter().zip(fd_indices.iter().copied()) {
                     let events = fd.poll();
                     let always_report = events & IoEvents::ALWAYS_POLL;
+                    // Linux fs/select.c: POLLIN_SET carries HUP|ERR but
+                    // POLLOUT_SET carries only ERR, so a hangup makes a fd
+                    // readable (read returns EOF) yet never writable.
+                    let write_report = events & IoEvents::ERR;
                     let selected = events & *interested;
                     let selected_read = selected.contains(IoEvents::IN)
                         || (read_set.0.get(index) && !always_report.is_empty());
                     let selected_write = selected.contains(IoEvents::OUT)
-                        || (write_set.0.get(index) && !always_report.is_empty());
+                        || (write_set.0.get(index) && !write_report.is_empty());
                     let selected_except =
                         selected.contains(IoEvents::ERR) && except_set.0.get(index);
 

--- a/test-suit/starryos/qemu/system/bugfix-bug-select-hup-writable/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-bug-select-hup-writable/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-select-hup-writable C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-select-hup-writable src/main.c)
+target_compile_options(bug-select-hup-writable PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-select-hup-writable RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-bug-select-hup-writable/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-bug-select-hup-writable/src/main.c
@@ -1,0 +1,58 @@
+/*
+ * bug-select-hup-writable — select(2) must not report a hung-up fd as writable.
+ *
+ * ground truth: Linux v7.2 fs/select.c POLLIN_SET/POLLOUT_SET. A hangup
+ * (EPOLLHUP) is in POLLIN_SET (a read returns EOF) but NOT in POLLOUT_SET, so
+ * after the write end of a pipe is closed:
+ *   - select() for writability on the read end must time out (not writable);
+ *   - select() for readability on the read end must be ready (EOF is readable).
+ * StarryOS folded the ERR|HUP "always report" mask into both directions, so it
+ * spuriously reported the read end as writable.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/select.h>
+
+static int failed;
+
+static void check(int cond, const char *msg)
+{
+    if (cond) {
+        printf("  PASS | %s\n", msg);
+    } else {
+        printf("  FAIL | %s | errno=%d (%s)\n", msg, errno, strerror(errno));
+        failed = 1;
+    }
+}
+
+int main(void)
+{
+    /* case 1: write end closed -> read end is NOT writable, select() times out. */
+    int pfd[2];
+    if (pipe(pfd) < 0) { perror("pipe"); return 2; }
+    close(pfd[1]);
+
+    fd_set wfds;
+    FD_ZERO(&wfds);
+    FD_SET(pfd[0], &wfds);
+    struct timeval tv = { .tv_sec = 0, .tv_usec = 200000 };
+    int r = select(pfd[0] + 1, NULL, &wfds, NULL, &tv);
+    check(r == 0 && !FD_ISSET(pfd[0], &wfds),
+          "写端关闭后 select(write) 读端超时且不就绪(HUP 不算可写)");
+
+    /* case 2: the same hangup must still make the read end readable (EOF). */
+    fd_set rfds;
+    FD_ZERO(&rfds);
+    FD_SET(pfd[0], &rfds);
+    tv.tv_sec = 0;
+    tv.tv_usec = 200000;
+    r = select(pfd[0] + 1, &rfds, NULL, NULL, &tv);
+    check(r == 1 && FD_ISSET(pfd[0], &rfds),
+          "写端关闭后 select(read) 读端就绪(HUP 可读, read 返回 EOF)");
+
+    close(pfd[0]);
+    printf("=== bug-select-hup-writable: %s ===\n", failed ? "FAIL" : "PASS");
+    return failed;
+}


### PR DESCRIPTION
## 问题

`sys_select`(`os/StarryOS/kernel/src/syscall/io_mpx/select.rs`) 把 `ALWAYS_POLL`(`ERR | HUP`) 这组「总是上报」事件同时并入读、写两个方向的就绪判定。于是写端关闭的管道读端在 `select(write)` 里被 `HUP` 误判为可写：调用不超时、`FD_ISSET` 为真，程序据此会对只读端发起写入。复现见 #2217。

## 根因

Linux v7.2 `fs/select.c` 用 `POLLIN_SET` 与 `POLLOUT_SET` 区分读写两个方向：`POLLIN_SET` 含 `EPOLLHUP | EPOLLERR`（挂断使 fd 可读，`read` 返回 EOF），而 `POLLOUT_SET` 只含 `EPOLLERR`、不含 `EPOLLHUP`。StarryOS 用同一个 `ALWAYS_POLL` 覆盖两个方向，等同于把 `HUP` 也算作可写。

## 改动

把写方向的「额外上报」从 `ALWAYS_POLL` 收窄为仅 `IoEvents::ERR`；读方向保持 `ERR | HUP` 不变。改动局限于 `select.rs` 的就绪判定一处。

## 测试

新增系统级回归 `bugfix-bug-select-hup-writable`：关闭管道写端后，断言读端 `select(write)` 超时且不就绪、读端 `select(read)` 就绪（EOF 可读）。修复前写方向断言稳定失败、读方向已通过，修复后两者均通过。`cargo xtask starry test qemu --arch x86_64 --test-case qemu/system/bugfix-bug-select-hup-writable` 与 `cargo xtask clippy --package starry-kernel` 均通过。

Closes #2217.
