### PR TITLE
fix(axvm): align implicit PCI ownership with guest FDT

### DIFF
--- a/os/axvisor/configs/vms/qemu/riscv64/linux-smp3-ipi.toml
+++ b/os/axvisor/configs/vms/qemu/riscv64/linux-smp3-ipi.toml
@@ -23,7 +23,4 @@ memory_regions = [
 
 [devices]
 passthrough = []
-# The guest rootfs is the dedicated virtio-mmio block device. Keep the host
-# PCI bridge and its NVMe rootfs controller out of the guest DTB because their
-# physical interrupt routes remain owned by Axvisor.
-disabled = [{ path = "/soc/pci@30000000" }]
+disabled = []

--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -29,16 +29,7 @@ use crate::{
     boot::images::load_vm_image_from_memory,
 };
 
-#[cfg(test)]
-pub fn create_guest_fdt(
-    fdt: &Fdt,
-    passthrough_device_names: &[String],
-    crate_config: &GuestConfig,
-) -> AxVmResult<Vec<u8>> {
-    create_guest_fdt_with_hidden_paths(fdt, passthrough_device_names, crate_config, &[])
-}
-
-pub(crate) fn create_guest_fdt_with_hidden_paths(
+pub(crate) fn create_guest_fdt(
     fdt: &Fdt,
     passthrough_device_names: &[String],
     crate_config: &GuestConfig,
@@ -1183,7 +1174,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let dtb = super::create_guest_fdt(&fdt, &[], &cfg).unwrap();
+        let dtb = super::create_guest_fdt(&fdt, &[], &cfg, &[]).unwrap();
         let reparsed = Fdt::from_bytes(&dtb).unwrap();
 
         assert!(reparsed.get_by_path_id("/cpus/cpu@100").is_some());
@@ -1217,7 +1208,7 @@ mod tests {
             "/soc/virtio_mmio@10001000".into(),
         ];
 
-        let dtb = super::create_guest_fdt(&fdt, &selected, &cfg).unwrap();
+        let dtb = super::create_guest_fdt(&fdt, &selected, &cfg, &[]).unwrap();
         let guest = Fdt::from_bytes(&dtb).unwrap();
 
         assert!(guest.get_by_path_id("/soc/pci@30000000").is_none());
@@ -1239,7 +1230,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let dtb = super::create_guest_fdt(&fdt, &[], &cfg).unwrap();
+        let dtb = super::create_guest_fdt(&fdt, &[], &cfg, &[]).unwrap();
         let reparsed = Fdt::from_bytes(&dtb).unwrap();
 
         assert!(reparsed.get_by_path_id("/psci").is_some());
@@ -1291,7 +1282,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let dtb = super::create_guest_fdt(&fdt, &[], &cfg).unwrap();
+        let dtb = super::create_guest_fdt(&fdt, &[], &cfg, &[]).unwrap();
         let reparsed = Fdt::from_bytes(&dtb).unwrap();
         let plic = reparsed.get_by_path("/soc/plic@c000000").unwrap();
         assert!(reparsed.get_by_path_id("/its@8080000").is_some());
@@ -1334,7 +1325,7 @@ mod tests {
             ..Default::default()
         };
 
-        let dtb = super::create_guest_fdt(&host, &passthrough_devices, &cfg).unwrap();
+        let dtb = super::create_guest_fdt(&host, &passthrough_devices, &cfg, &[]).unwrap();
         let guest = Fdt::from_bytes(&dtb).unwrap();
         let cpu = guest.get_by_path("/cpus/cpu@0").unwrap().as_node();
 

--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -29,10 +29,20 @@ use crate::{
     boot::images::load_vm_image_from_memory,
 };
 
+#[cfg(test)]
 pub fn create_guest_fdt(
     fdt: &Fdt,
     passthrough_device_names: &[String],
     crate_config: &GuestConfig,
+) -> AxVmResult<Vec<u8>> {
+    create_guest_fdt_with_hidden_paths(fdt, passthrough_device_names, crate_config, &[])
+}
+
+pub(crate) fn create_guest_fdt_with_hidden_paths(
+    fdt: &Fdt,
+    passthrough_device_names: &[String],
+    crate_config: &GuestConfig,
+    hidden_device_paths: &[String],
 ) -> AxVmResult<Vec<u8>> {
     let phys_cpu_ids = crate_config
         .base
@@ -53,6 +63,7 @@ pub fn create_guest_fdt(
         phys_cpu_ids,
         machine_interrupt_providers: &machine_interrupt_providers,
         disabled_devices: &crate_config.devices.disabled,
+        hidden_device_paths,
     };
     let mut guest_tree = FdtTree::clone_filtered(fdt, |node_id, path, node| {
         policy.should_keep(node_id, path, node)
@@ -67,6 +78,7 @@ struct GeneratedNodePolicy<'a> {
     phys_cpu_ids: &'a [usize],
     machine_interrupt_providers: &'a [String],
     disabled_devices: &'a [axvmconfig::PhysicalDeviceRef],
+    hidden_device_paths: &'a [String],
 }
 
 impl GeneratedNodePolicy<'_> {
@@ -102,6 +114,15 @@ impl GeneratedNodePolicy<'_> {
             node_path == device.path
                 || node_path
                     .strip_prefix(&device.path)
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+        }) {
+            return false;
+        }
+
+        if self.hidden_device_paths.iter().any(|path| {
+            node_path == path
+                || node_path
+                    .strip_prefix(path)
                     .is_some_and(|suffix| suffix.starts_with('/'))
         }) {
             return false;

--- a/virtualization/axvm/src/boot/fdt/core/create.rs
+++ b/virtualization/axvm/src/boot/fdt/core/create.rs
@@ -33,7 +33,7 @@ pub(crate) fn create_guest_fdt(
     fdt: &Fdt,
     passthrough_device_names: &[String],
     crate_config: &GuestConfig,
-    hidden_device_paths: &[String],
+    excluded_device_paths: &[String],
 ) -> AxVmResult<Vec<u8>> {
     let phys_cpu_ids = crate_config
         .base
@@ -53,8 +53,7 @@ pub(crate) fn create_guest_fdt(
         passthrough_device_names,
         phys_cpu_ids,
         machine_interrupt_providers: &machine_interrupt_providers,
-        disabled_devices: &crate_config.devices.disabled,
-        hidden_device_paths,
+        excluded_device_paths,
     };
     let mut guest_tree = FdtTree::clone_filtered(fdt, |node_id, path, node| {
         policy.should_keep(node_id, path, node)
@@ -68,8 +67,7 @@ struct GeneratedNodePolicy<'a> {
     passthrough_device_names: &'a [String],
     phys_cpu_ids: &'a [usize],
     machine_interrupt_providers: &'a [String],
-    disabled_devices: &'a [axvmconfig::PhysicalDeviceRef],
-    hidden_device_paths: &'a [String],
+    excluded_device_paths: &'a [String],
 }
 
 impl GeneratedNodePolicy<'_> {
@@ -101,16 +99,7 @@ impl GeneratedNodePolicy<'_> {
             return true;
         }
 
-        if self.disabled_devices.iter().any(|device| {
-            node_path == device.path
-                || node_path
-                    .strip_prefix(&device.path)
-                    .is_some_and(|suffix| suffix.starts_with('/'))
-        }) {
-            return false;
-        }
-
-        if self.hidden_device_paths.iter().any(|path| {
+        if self.excluded_device_paths.iter().any(|path| {
             node_path == path
                 || node_path
                     .strip_prefix(path)
@@ -1207,8 +1196,14 @@ mod tests {
             "/soc/pci@30000000/nvme@0".into(),
             "/soc/virtio_mmio@10001000".into(),
         ];
+        let excluded = cfg
+            .devices
+            .disabled
+            .iter()
+            .map(|device| device.path.clone())
+            .collect::<std::vec::Vec<_>>();
 
-        let dtb = super::create_guest_fdt(&fdt, &selected, &cfg, &[]).unwrap();
+        let dtb = super::create_guest_fdt(&fdt, &selected, &cfg, &excluded).unwrap();
         let guest = Fdt::from_bytes(&dtb).unwrap();
 
         assert!(guest.get_by_path_id("/soc/pci@30000000").is_none());

--- a/virtualization/axvm/src/boot/fdt/core/device.rs
+++ b/virtualization/axvm/src/boot/fdt/core/device.rs
@@ -40,18 +40,33 @@ pub(crate) fn selector_includes_path(selector: &str, node_path: &str) -> bool {
 
 /// Return all passthrough device paths, including descendants and phandle dependencies.
 pub fn find_all_passthrough_devices(vm_cfg: &AxVMConfig, fdt: &Fdt) -> Vec<String> {
-    let initial_device_count = vm_cfg.pass_through_devices().len();
-    let node_cache = build_optimized_node_cache(fdt);
-    let initial_device_names: Vec<String> = vm_cfg
+    let initial_device_names = vm_cfg
         .pass_through_devices()
         .iter()
         .map(|dev| dev.name.clone())
-        .collect();
+        .collect::<Vec<_>>();
+    let excluded_device_paths = vm_cfg
+        .excluded_devices()
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    find_all_passthrough_devices_from_paths(&initial_device_names, &excluded_device_paths, fdt)
+}
+
+/// Return passthrough paths selected by configuration, including dependencies.
+pub(crate) fn find_all_passthrough_devices_from_paths(
+    initial_device_names: &[String],
+    excluded_device_paths: &[String],
+    fdt: &Fdt,
+) -> Vec<String> {
+    let initial_device_count = initial_device_names.len();
+    let node_cache = build_optimized_node_cache(fdt);
     let mut configured_device_names: BTreeSet<String> =
         initial_device_names.iter().cloned().collect();
     let mut additional_device_names = Vec::new();
 
-    for device_name in &initial_device_names {
+    for device_name in initial_device_names {
         let descendant_paths = get_descendant_nodes_by_path(&node_cache, device_name);
         trace!(
             "Found {} descendant paths for {}",
@@ -88,16 +103,10 @@ pub fn find_all_passthrough_devices(vm_cfg: &AxVMConfig, fdt: &Fdt) -> Vec<Strin
         }
     }
 
-    let excluded_device_path: Vec<String> = vm_cfg
-        .excluded_devices()
-        .iter()
-        .flatten()
-        .cloned()
-        .collect();
-    let mut all_excluded_devices = excluded_device_path.clone();
-    let mut processed_excluded: BTreeSet<String> = excluded_device_path.iter().cloned().collect();
+    let mut all_excluded_devices = excluded_device_paths.to_vec();
+    let mut processed_excluded: BTreeSet<String> = excluded_device_paths.iter().cloned().collect();
 
-    for device_path in &excluded_device_path {
+    for device_path in excluded_device_paths {
         for descendant_path in get_descendant_nodes_by_path(&node_cache, device_path) {
             if processed_excluded.insert(descendant_path.clone()) {
                 all_excluded_devices.push(descendant_path);
@@ -106,7 +115,7 @@ pub fn find_all_passthrough_devices(vm_cfg: &AxVMConfig, fdt: &Fdt) -> Vec<Strin
     }
     info!("Found excluded devices: {all_excluded_devices:?}");
 
-    let mut all_device_names = initial_device_names;
+    let mut all_device_names = initial_device_names.to_vec();
     all_device_names.extend(additional_device_names);
     all_device_names.extend(dependency_device_names);
 

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -53,7 +53,6 @@ pub fn setup_guest_fdt_from_vmm(
     let fdt = Fdt::from_bytes(fdt_bytes)
         .map_err(|e| ax_err_type!(InvalidData, format!("Failed to parse host FDT: {e:#?}")))?;
 
-    reserve_excluded_device_ranges(vm_cfg, crate_config, fdt_bytes)?;
     // The runtime configuration may contain an implicit root selector to
     // establish the passthrough address-space policy. Keep its non-PCI
     // devices (for example the guest-owned virtio-blk endpoint), but remove
@@ -78,11 +77,14 @@ pub fn setup_guest_fdt_from_vmm(
     } else {
         explicit_device_names
     };
-    let hidden_device_paths = if implicit_root_passthrough {
-        reserve_unassigned_pci_hosts(vm_cfg, &fdt)
-    } else {
-        Vec::new()
-    };
+    if implicit_root_passthrough {
+        for node_id in fdt.iter_node_ids() {
+            if fdt.node(node_id).is_some_and(Node::is_pci) {
+                vm_cfg.exclude_device_path(fdt.path_of(node_id));
+            }
+        }
+    }
+    reserve_excluded_device_ranges(vm_cfg, crate_config, fdt_bytes)?;
     let excluded_device_paths = vm_cfg
         .excluded_devices()
         .iter()
@@ -98,44 +100,12 @@ pub fn setup_guest_fdt_from_vmm(
         &fdt,
         &passthrough_device_names,
         crate_config,
-        &hidden_device_paths,
+        &excluded_device_paths,
     )
 }
 
 fn is_reserved_memory_path(node_path: &str) -> bool {
     node_path == "/reserved-memory" || node_path.starts_with("/reserved-memory/")
-}
-
-fn reserve_unassigned_pci_hosts(vm_cfg: &mut AxVMConfig, fdt: &Fdt) -> Vec<String> {
-    let mut paths = Vec::new();
-    let mut reserved_ranges = Vec::new();
-    let existing_exclusions = vm_cfg
-        .excluded_devices()
-        .iter()
-        .flatten()
-        .cloned()
-        .collect::<Vec<_>>();
-    for node_id in fdt.iter_node_ids() {
-        let Some(node) = fdt.node(node_id) else {
-            continue;
-        };
-        if !node.is_pci() {
-            continue;
-        }
-
-        let path = fdt.path_of(node_id);
-        if is_excluded_node_path(&path, &existing_exclusions) {
-            paths.push(path);
-            continue;
-        }
-        vm_cfg.exclude_device_path(path.clone());
-        collect_node_reserved_ranges(fdt, node_id, &path, &mut reserved_ranges);
-        paths.push(path);
-    }
-    for range in reserved_ranges {
-        vm_cfg.add_reserved_address_range(range);
-    }
-    paths
 }
 
 fn overlaps_memory_region(lhs_gpa: usize, lhs_size: usize, rhs: &VmMemConfig) -> bool {
@@ -325,7 +295,22 @@ pub fn reserve_excluded_device_ranges(
         }
 
         exclude_node_interrupt_sources(vm_cfg, &fdt, node_id, decode_interrupt);
-        collect_node_reserved_ranges(&fdt, node_id, &node_path, &mut reserved_ranges);
+        for reg in node_regs(&fdt, node_id) {
+            push_reserved_address_range(
+                &mut reserved_ranges,
+                &node_path,
+                reg.address as usize,
+                reg.size.unwrap_or(0) as usize,
+            );
+        }
+        for range in node_pci_ranges(&fdt, node_id) {
+            push_reserved_address_range(
+                &mut reserved_ranges,
+                &node_path,
+                range.cpu_address as usize,
+                range.size as usize,
+            );
+        }
     }
 
     reserved_ranges.sort_by_key(|range| range.base_gpa);
@@ -334,31 +319,6 @@ pub fn reserve_excluded_device_ranges(
     }
 
     Ok(())
-}
-
-fn collect_node_reserved_ranges(
-    fdt: &Fdt,
-    node_id: usize,
-    node_path: &str,
-    reserved_ranges: &mut Vec<ReservedAddressConfig>,
-) {
-    for reg in node_regs(fdt, node_id) {
-        push_reserved_address_range(
-            reserved_ranges,
-            node_path,
-            reg.address as usize,
-            reg.size.unwrap_or(0) as usize,
-        );
-    }
-
-    for range in node_pci_ranges(fdt, node_id) {
-        push_reserved_address_range(
-            reserved_ranges,
-            node_path,
-            range.cpu_address as usize,
-            range.size as usize,
-        );
-    }
 }
 
 fn exclude_node_interrupt_sources(
@@ -910,6 +870,22 @@ mod tests {
         fdt.node_mut(root)
             .unwrap()
             .set_property(prop_u32("#size-cells", 2));
+        let intc = fdt.add_node(root, Node::new("interrupt-controller@0"));
+        fdt.node_mut(intc)
+            .unwrap()
+            .set_property(fdt_edit::Property::new("interrupt-controller", std::vec![]));
+        fdt.node_mut(intc)
+            .unwrap()
+            .set_property(prop_u32("#interrupt-cells", 1));
+        fdt.node_mut(intc)
+            .unwrap()
+            .set_property(prop_u32("phandle", 1));
+        fdt.node_mut(intc)
+            .unwrap()
+            .set_property(super::super::tree::prop_string(
+                "compatible",
+                "riscv,plic0",
+            ));
         let soc = fdt.add_node(root, Node::new("soc"));
         let pci = fdt.add_node(soc, Node::new("pci@30000000"));
         fdt.node_mut(pci)
@@ -918,8 +894,29 @@ mod tests {
         fdt.view_typed_mut(pci)
             .unwrap()
             .set_regs(&[RegInfo::new(0x3000_0000, Some(0x1000_0000))]);
-        fdt.add_node(pci, Node::new("nvme@0"));
-        fdt.add_node(soc, Node::new("virtio_mmio@10001000"));
+        let nvme = fdt.add_node(pci, Node::new("nvme@0"));
+        fdt.node_mut(nvme)
+            .unwrap()
+            .set_property(prop_u32("interrupt-parent", 1));
+        fdt.node_mut(nvme)
+            .unwrap()
+            .set_property(prop_u32_list("interrupts", &[11]));
+        let virtio = fdt.add_node(soc, Node::new("virtio_mmio@10001000"));
+        fdt.node_mut(virtio)
+            .unwrap()
+            .set_property(super::super::tree::prop_string(
+                "compatible",
+                "virtio,mmio",
+            ));
+        fdt.node_mut(virtio)
+            .unwrap()
+            .set_property(prop_u32("interrupt-parent", 1));
+        fdt.node_mut(virtio)
+            .unwrap()
+            .set_property(prop_u32_list("interrupts", &[11]));
+        fdt.view_typed_mut(virtio)
+            .unwrap()
+            .set_regs(&[RegInfo::new(0x1000_1000, Some(0x1000))]);
         fdt.encode().as_ref().to_vec()
     }
 
@@ -1315,7 +1312,7 @@ mod tests {
     }
 
     #[test]
-    fn implicit_root_passthrough_does_not_publish_unassigned_pci() {
+    fn implicit_root_passthrough_excludes_unassigned_pci_resources() {
         let dtb = fdt_with_pci_host_and_endpoint();
         let mut vm_cfg = AxVMConfig::new(AxVMConfigParams {
             id: 0,
@@ -1347,6 +1344,16 @@ mod tests {
                 .reserved_address_ranges()
                 .iter()
                 .any(|range| { range.base_gpa == 0x3000_0000 && range.length == 0x1000_0000 })
+        );
+        assert!(vm_cfg.excluded_passthrough_irq_sources().contains(&11));
+
+        parse_passthrough_devices_address(&mut vm_cfg, &crate_cfg, &guest_dtb).unwrap();
+        let error = parse_vm_interrupt(&mut vm_cfg, &crate_cfg, &guest_dtb).unwrap_err();
+        assert_eq!(
+            error,
+            crate::AxVmError::InvalidConfig {
+                detail: "passthrough device /soc/virtio_mmio@10001000 shares host-owned interrupt source 0xb".to_string(),
+            }
         );
     }
 

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -54,12 +54,114 @@ pub fn setup_guest_fdt_from_vmm(
         .map_err(|e| ax_err_type!(InvalidData, format!("Failed to parse host FDT: {e:#?}")))?;
 
     reserve_excluded_device_ranges(vm_cfg, crate_config, fdt_bytes)?;
-    let passthrough_device_names = super::device::find_all_passthrough_devices(vm_cfg, &fdt);
-    super::create::create_guest_fdt(&fdt, &passthrough_device_names, crate_config)
+    // The runtime configuration may contain an implicit root selector to
+    // establish the passthrough address-space policy. Keep its non-PCI
+    // devices (for example the guest-owned virtio-blk endpoint), but remove
+    // PCI host bridges unless the guest explicitly claims one.
+    let explicit_device_names = crate_config
+        .devices
+        .passthrough
+        .iter()
+        .map(|device| device.path.clone())
+        .collect::<Vec<_>>();
+    let implicit_root_passthrough = explicit_device_names.is_empty()
+        && vm_cfg
+            .pass_through_devices()
+            .iter()
+            .any(|device| device.name == "/");
+    let selected_device_names = if implicit_root_passthrough {
+        vm_cfg
+            .pass_through_devices()
+            .iter()
+            .map(|device| device.name.clone())
+            .collect::<Vec<_>>()
+    } else {
+        explicit_device_names
+    };
+    let hidden_device_paths = if implicit_root_passthrough {
+        reserve_unassigned_pci_hosts(vm_cfg, &fdt)
+    } else {
+        Vec::new()
+    };
+    let excluded_device_paths = vm_cfg
+        .excluded_devices()
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    let passthrough_device_names = super::device::find_all_passthrough_devices_from_paths(
+        &selected_device_names,
+        &excluded_device_paths,
+        &fdt,
+    );
+    super::create::create_guest_fdt_with_hidden_paths(
+        &fdt,
+        &passthrough_device_names,
+        crate_config,
+        &hidden_device_paths,
+    )
 }
 
 fn is_reserved_memory_path(node_path: &str) -> bool {
     node_path == "/reserved-memory" || node_path.starts_with("/reserved-memory/")
+}
+
+fn is_pci_host_node(node: &Node) -> bool {
+    node.name().starts_with("pci@")
+        || node
+            .get_property("device_type")
+            .and_then(|property| property.as_str())
+            == Some("pci")
+        || node
+            .compatibles()
+            .any(|compatible| compatible.contains("pci-host"))
+}
+
+fn reserve_unassigned_pci_hosts(vm_cfg: &mut AxVMConfig, fdt: &Fdt) -> Vec<String> {
+    let mut paths = Vec::new();
+    let mut reserved_ranges = Vec::new();
+    let existing_exclusions = vm_cfg
+        .excluded_devices()
+        .iter()
+        .flatten()
+        .cloned()
+        .collect::<Vec<_>>();
+    for node_id in fdt.iter_node_ids() {
+        let Some(node) = fdt.node(node_id) else {
+            continue;
+        };
+        if !is_pci_host_node(node) {
+            continue;
+        }
+
+        let path = fdt.path_of(node_id);
+        if is_excluded_node_path(&path, &existing_exclusions) {
+            paths.push(path);
+            continue;
+        }
+        vm_cfg.exclude_device_path(path.clone());
+        for reg in node_regs(fdt, node_id) {
+            push_reserved_address_range(
+                &mut reserved_ranges,
+                &path,
+                reg.address as usize,
+                reg.size.unwrap_or(0) as usize,
+            );
+        }
+        for range in node_pci_ranges(fdt, node_id) {
+            push_reserved_address_range(
+                &mut reserved_ranges,
+                &path,
+                range.cpu_address as usize,
+                range.size as usize,
+            );
+        }
+        paths.push(path);
+    }
+    for range in reserved_ranges {
+        vm_cfg.add_reserved_address_range(range);
+    }
+    paths
 }
 
 fn overlaps_memory_region(lhs_gpa: usize, lhs_size: usize, rhs: &VmMemConfig) -> bool {
@@ -817,6 +919,25 @@ mod tests {
         fdt.encode().as_ref().to_vec()
     }
 
+    fn fdt_with_pci_host_and_endpoint() -> Vec<u8> {
+        let mut fdt = Fdt::new();
+        let root = fdt.root_id();
+        fdt.node_mut(root)
+            .unwrap()
+            .set_property(prop_u32("#address-cells", 2));
+        fdt.node_mut(root)
+            .unwrap()
+            .set_property(prop_u32("#size-cells", 2));
+        let soc = fdt.add_node(root, Node::new("soc"));
+        let pci = fdt.add_node(soc, Node::new("pci@30000000"));
+        fdt.view_typed_mut(pci)
+            .unwrap()
+            .set_regs(&[RegInfo::new(0x3000_0000, Some(0x1000_0000))]);
+        fdt.add_node(pci, Node::new("nvme@0"));
+        fdt.add_node(soc, Node::new("virtio_mmio@10001000"));
+        fdt.encode().as_ref().to_vec()
+    }
+
     fn fdt_with_serial_and_device_interrupts() -> Vec<u8> {
         let mut fdt = Fdt::new();
         let root = fdt.root_id();
@@ -1206,6 +1327,77 @@ mod tests {
                 .iter()
                 .any(|range| range.base_gpa == 0x1000_1000 && range.length == 0x1000)
         );
+    }
+
+    #[test]
+    fn implicit_root_passthrough_does_not_publish_unassigned_pci() {
+        let dtb = fdt_with_pci_host_and_endpoint();
+        let mut vm_cfg = AxVMConfig::new(AxVMConfigParams {
+            id: 0,
+            name: "test".to_string(),
+            phys_cpu_ls: PhysCpuList::new(1, Some(vec![0]), None),
+            pass_through_devices: vec![HostDeviceAssignment {
+                name: "/".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        let crate_cfg = GuestConfig {
+            base: axvmconfig::VMBaseConfig {
+                phys_cpu_ids: Some(vec![0]),
+                guest_type: GuestType::Passthrough,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let guest_dtb = setup_guest_fdt_from_vmm(&dtb, &mut vm_cfg, &crate_cfg).unwrap();
+        let guest = Fdt::from_bytes(&guest_dtb).unwrap();
+
+        assert!(guest.get_by_path_id("/soc/pci@30000000").is_none());
+        assert!(guest.get_by_path_id("/soc/pci@30000000/nvme@0").is_none());
+        assert!(guest.get_by_path_id("/soc/virtio_mmio@10001000").is_some());
+        assert!(
+            vm_cfg
+                .reserved_address_ranges()
+                .iter()
+                .any(|range| { range.base_gpa == 0x3000_0000 && range.length == 0x1000_0000 })
+        );
+    }
+
+    #[test]
+    fn explicit_pci_passthrough_is_published() {
+        let dtb = fdt_with_pci_host_and_endpoint();
+        let mut vm_cfg = AxVMConfig::new(AxVMConfigParams {
+            id: 0,
+            name: "test".to_string(),
+            phys_cpu_ls: PhysCpuList::new(1, Some(vec![0]), None),
+            pass_through_devices: vec![HostDeviceAssignment {
+                name: "/soc/pci@30000000".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        let crate_cfg = GuestConfig {
+            base: axvmconfig::VMBaseConfig {
+                phys_cpu_ids: Some(vec![0]),
+                guest_type: GuestType::Passthrough,
+                ..Default::default()
+            },
+            devices: GuestDevices {
+                passthrough: vec![PhysicalDeviceRef {
+                    path: "/soc/pci@30000000".to_string(),
+                }],
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let guest_dtb = setup_guest_fdt_from_vmm(&dtb, &mut vm_cfg, &crate_cfg).unwrap();
+        let guest = Fdt::from_bytes(&guest_dtb).unwrap();
+
+        assert!(guest.get_by_path_id("/soc/pci@30000000").is_some());
+        assert!(guest.get_by_path_id("/soc/pci@30000000/nvme@0").is_some());
     }
 
     #[test]

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -129,22 +129,7 @@ fn reserve_unassigned_pci_hosts(vm_cfg: &mut AxVMConfig, fdt: &Fdt) -> Vec<Strin
             continue;
         }
         vm_cfg.exclude_device_path(path.clone());
-        for reg in node_regs(fdt, node_id) {
-            push_reserved_address_range(
-                &mut reserved_ranges,
-                &path,
-                reg.address as usize,
-                reg.size.unwrap_or(0) as usize,
-            );
-        }
-        for range in node_pci_ranges(fdt, node_id) {
-            push_reserved_address_range(
-                &mut reserved_ranges,
-                &path,
-                range.cpu_address as usize,
-                range.size as usize,
-            );
-        }
+        collect_node_reserved_ranges(fdt, node_id, &path, &mut reserved_ranges);
         paths.push(path);
     }
     for range in reserved_ranges {
@@ -340,24 +325,7 @@ pub fn reserve_excluded_device_ranges(
         }
 
         exclude_node_interrupt_sources(vm_cfg, &fdt, node_id, decode_interrupt);
-
-        for reg in node_regs(&fdt, node_id) {
-            push_reserved_address_range(
-                &mut reserved_ranges,
-                &node_path,
-                reg.address as usize,
-                reg.size.unwrap_or(0) as usize,
-            );
-        }
-
-        for range in node_pci_ranges(&fdt, node_id) {
-            push_reserved_address_range(
-                &mut reserved_ranges,
-                &node_path,
-                range.cpu_address as usize,
-                range.size as usize,
-            );
-        }
+        collect_node_reserved_ranges(&fdt, node_id, &node_path, &mut reserved_ranges);
     }
 
     reserved_ranges.sort_by_key(|range| range.base_gpa);
@@ -366,6 +334,31 @@ pub fn reserve_excluded_device_ranges(
     }
 
     Ok(())
+}
+
+fn collect_node_reserved_ranges(
+    fdt: &Fdt,
+    node_id: usize,
+    node_path: &str,
+    reserved_ranges: &mut Vec<ReservedAddressConfig>,
+) {
+    for reg in node_regs(fdt, node_id) {
+        push_reserved_address_range(
+            reserved_ranges,
+            node_path,
+            reg.address as usize,
+            reg.size.unwrap_or(0) as usize,
+        );
+    }
+
+    for range in node_pci_ranges(fdt, node_id) {
+        push_reserved_address_range(
+            reserved_ranges,
+            node_path,
+            range.cpu_address as usize,
+            range.size as usize,
+        );
+    }
 }
 
 fn exclude_node_interrupt_sources(

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -106,17 +106,6 @@ fn is_reserved_memory_path(node_path: &str) -> bool {
     node_path == "/reserved-memory" || node_path.starts_with("/reserved-memory/")
 }
 
-fn is_pci_host_node(node: &Node) -> bool {
-    node.name().starts_with("pci@")
-        || node
-            .get_property("device_type")
-            .and_then(|property| property.as_str())
-            == Some("pci")
-        || node
-            .compatibles()
-            .any(|compatible| compatible.contains("pci-host"))
-}
-
 fn reserve_unassigned_pci_hosts(vm_cfg: &mut AxVMConfig, fdt: &Fdt) -> Vec<String> {
     let mut paths = Vec::new();
     let mut reserved_ranges = Vec::new();
@@ -130,7 +119,7 @@ fn reserve_unassigned_pci_hosts(vm_cfg: &mut AxVMConfig, fdt: &Fdt) -> Vec<Strin
         let Some(node) = fdt.node(node_id) else {
             continue;
         };
-        if !is_pci_host_node(node) {
+        if !node.is_pci() {
             continue;
         }
 
@@ -930,6 +919,9 @@ mod tests {
             .set_property(prop_u32("#size-cells", 2));
         let soc = fdt.add_node(root, Node::new("soc"));
         let pci = fdt.add_node(soc, Node::new("pci@30000000"));
+        fdt.node_mut(pci)
+            .unwrap()
+            .set_property(super::super::tree::prop_string("device_type", "pci"));
         fdt.view_typed_mut(pci)
             .unwrap()
             .set_regs(&[RegInfo::new(0x3000_0000, Some(0x1000_0000))]);

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -882,10 +882,7 @@ mod tests {
             .set_property(prop_u32("phandle", 1));
         fdt.node_mut(intc)
             .unwrap()
-            .set_property(super::super::tree::prop_string(
-                "compatible",
-                "riscv,plic0",
-            ));
+            .set_property(super::super::tree::prop_string("compatible", "riscv,plic0"));
         let soc = fdt.add_node(root, Node::new("soc"));
         let pci = fdt.add_node(soc, Node::new("pci@30000000"));
         fdt.node_mut(pci)
@@ -904,10 +901,7 @@ mod tests {
         let virtio = fdt.add_node(soc, Node::new("virtio_mmio@10001000"));
         fdt.node_mut(virtio)
             .unwrap()
-            .set_property(super::super::tree::prop_string(
-                "compatible",
-                "virtio,mmio",
-            ));
+            .set_property(super::super::tree::prop_string("compatible", "virtio,mmio"));
         fdt.node_mut(virtio)
             .unwrap()
             .set_property(prop_u32("interrupt-parent", 1));
@@ -1352,7 +1346,9 @@ mod tests {
         assert_eq!(
             error,
             crate::AxVmError::InvalidConfig {
-                detail: "passthrough device /soc/virtio_mmio@10001000 shares host-owned interrupt source 0xb".to_string(),
+                detail: "passthrough device /soc/virtio_mmio@10001000 shares host-owned interrupt \
+                         source 0xb"
+                    .to_string(),
             }
         );
     }

--- a/virtualization/axvm/src/boot/fdt/core/parser.rs
+++ b/virtualization/axvm/src/boot/fdt/core/parser.rs
@@ -94,7 +94,7 @@ pub fn setup_guest_fdt_from_vmm(
         &excluded_device_paths,
         &fdt,
     );
-    super::create::create_guest_fdt_with_hidden_paths(
+    super::create::create_guest_fdt(
         &fdt,
         &passthrough_device_names,
         crate_config,


### PR DESCRIPTION
## 问题与根因

Issue #2016 中，`guest_type = "passthrough"` 且未显式选择设备时，Axvisor 会自动加入 `/` 透传选择器。该选择器被复用于 guest FDT 过滤，导致宿主 PCI host bridge 与 NVMe endpoint 被发布给 guest；随后设备规划又可能移除对应 MMIO backing，造成 FDT 描述和执行模型不一致。

## 修改内容

- 抽取可复用的 passthrough 路径解析逻辑，显式设备选择与运行时排除集合共用同一解析结果。
- 隐式根选择器模式下保留 guest 所需的非 PCI 设备（包括 virtio-mmio block），自动识别并隐藏未显式透传的 PCI host bridge 及其子树。
- 使用 `fdt-edit` 标准 `Node::is_pci()` 分类，避免节点名和 compatible 字符串启发式。
- 统一 FDT 排除节点的 `reg`/PCI `ranges` 保留区收集逻辑，避免重复实现。
- 删除只转发的 FDT 测试包装函数，直接使用带隐藏路径参数的生成入口。
- 将隐藏 PCI host bridge 的 ECAM、PCI window 和 `reg` 资源加入 guest 保留区，避免建立对应 stage-2 MMIO backing。
- 显式声明 PCI 透传时仍发布完整 PCI 子树。
- 移除 `smp-ipi` 配置中针对 `/soc/pci@30000000` 的临时 `disabled` workaround。

## 回归测试证据

- 在旧实现上运行 `cargo test -p axvm boot::fdt::core::parser::tests::implicit_root_passthrough_does_not_publish_unassigned_pci -- --exact`，因 PCI 节点仍存在而失败。
- 完成修复后同一测试通过；同时新增显式 PCI 透传正向测试。

## 本地验证

- `cargo fmt --all`：通过。
- `cargo test -p axvm boot::fdt::core --lib`：76/76 通过。
- `cargo xtask clippy --package axvm`：7/7 配置检查通过。
- `cargo xtask axvisor test qemu --arch riscv64 -g normal -c smp-ipi`：1/1 通过；guest 成功挂载 virtio-blk `/dev/vda` 并完成 SMP/IPI 检查，未枚举宿主 NVMe。
- `git diff --check`：通过。

完整 `cargo test -p axvm --lib` 曾因测试进程收到 `SIGSEGV` 中止；受影响的 FDT 测试和 Issue 原始 QEMU 路径均已独立通过。

Fixes #2016