### PR TITLE
fix(starry-kernel): report times(2) in USER_HZ clock ticks

### DIFF
--- a/os/StarryOS/kernel/src/syscall/time.rs
+++ b/os/StarryOS/kernel/src/syscall/time.rs
@@ -1,5 +1,5 @@
 use ax_runtime::hal::time::{
-    NANOS_PER_SEC, TimeValue, monotonic_time, monotonic_time_nanos, nanos_to_ticks, wall_time,
+    NANOS_PER_SEC, TimeValue, monotonic_time, wall_time,
 };
 use ax_task::current;
 use linux_raw_sys::general::{
@@ -106,13 +106,17 @@ pub struct Tms {
 pub fn sys_times(tms: *mut Tms) -> StarryResult<isize> {
     let (utime, stime) = current().as_thread().time.borrow().output();
     let (cutime, cstime) = current().as_thread().proc_data.children_cpu_time();
+    // Linux times(2) reports every field and the return value in USER_HZ clock
+    // ticks (glibc/musl hardcode _SC_CLK_TCK = 100, so one tick is 10 ms), the
+    // same jiffies unit as the /proc/[pid]/stat writer in task::stat.
+    let ticks = |d: TimeValue| (d.as_millis() / 10) as usize;
     tms.vm_write(Tms {
-        tms_utime: utime.as_micros() as usize,
-        tms_stime: stime.as_micros() as usize,
-        tms_cutime: cutime.as_micros() as usize,
-        tms_cstime: cstime.as_micros() as usize,
+        tms_utime: ticks(utime),
+        tms_stime: ticks(stime),
+        tms_cutime: ticks(cutime),
+        tms_cstime: ticks(cstime),
     })?;
-    Ok(nanos_to_ticks(monotonic_time_nanos()) as _)
+    Ok((monotonic_time().as_millis() / 10) as _)
 }
 
 pub fn sys_getitimer(which: i32, value: *mut itimerval) -> StarryResult<isize> {

--- a/test-suit/starryos/qemu/system/bugfix-times-clock-ticks/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-times-clock-ticks/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.20)
+project(bug-times-clock-ticks C)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+add_executable(bug-times-clock-ticks src/main.c)
+target_compile_options(bug-times-clock-ticks PRIVATE -Wall -Wextra -Werror)
+install(TARGETS bug-times-clock-ticks RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-times-clock-ticks/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-times-clock-ticks/src/main.c
@@ -32,6 +32,7 @@ static void check(int cond, const char *msg)
 int main(void)
 {
     long clk = sysconf(_SC_CLK_TCK);
+    check(clk == 100, "_SC_CLK_TCK == 100 (glibc/musl 固定, 为 times() 换算依据)");
     if (clk <= 0) {
         clk = 100;
     }
@@ -69,12 +70,8 @@ int main(void)
     check(t2 != (clock_t)-1, "times() 三次调用成功");
     long cpu = (long)(tb2.tms_utime + tb2.tms_stime);
     printf("  tms_utime+tms_stime = %ld ticks after busy loop\n", cpu);
-    if (cpu != 0) {
-        long cpu_hi = 100 * clk; /* 10000 for clk=100; micros bug yields ~1e5+ */
-        check(cpu <= cpu_hi, "tms 字段以节拍计(非微秒)");
-    } else {
-        printf("  SKIP | 内核未累计 CPU 时间, tms 单位判别跳过\n");
-    }
+    check(cpu > 0, "忙循环后 CPU 时间已记账 (tms 非零, 方能判定单位)");
+    check(cpu <= 100 * clk, "tms 字段以节拍计而非微秒");
 
     printf("=== bug-times-clock-ticks: %s ===\n", failed ? "FAIL" : "PASS");
     return failed;

--- a/test-suit/starryos/qemu/system/bugfix-times-clock-ticks/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-times-clock-ticks/src/main.c
@@ -1,0 +1,81 @@
+#define _GNU_SOURCE
+/*
+ * bug-times-clock-ticks — times(2) must report USER_HZ clock ticks, not raw
+ * microseconds or hardware timer ticks.
+ *
+ * ground truth: Linux times(2) fills every struct tms field and returns the
+ * elapsed real time in clock ticks of _SC_CLK_TCK (glibc/musl hardcode 100, so
+ * one tick is 10 ms). The in-repo /proc/[pid]/stat writer already uses this
+ * jiffies unit: utime = duration.as_millis() / 10 (USER_HZ = 100). StarryOS
+ * sys_times wrote the tms fields in microseconds and returned the value in
+ * hardware timer ticks (nanos_to_ticks), so a caller dividing by _SC_CLK_TCK
+ * saw wildly wrong seconds.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/times.h>
+
+static int failed;
+static void check(int cond, const char *msg)
+{
+    if (cond) {
+        printf("  PASS | %s\n", msg);
+    } else {
+        printf("  FAIL | %s | errno=%d (%s)\n", msg, errno, strerror(errno));
+        failed = 1;
+    }
+}
+
+int main(void)
+{
+    long clk = sysconf(_SC_CLK_TCK);
+    if (clk <= 0) {
+        clk = 100;
+    }
+    printf("  _SC_CLK_TCK = %ld\n", clk);
+
+    struct tms tb0, tb1;
+    clock_t t0 = times(&tb0);
+    check(t0 != (clock_t)-1, "times() 首次调用成功");
+
+    /* Sleep a known monotonic interval; the return value advances in USER_HZ
+     * ticks, so ~300 ms is a few tens of ticks, never the hardware frequency. */
+    struct timespec req = { .tv_sec = 0, .tv_nsec = 300L * 1000 * 1000 };
+    while (nanosleep(&req, &req) != 0 && errno == EINTR) {
+    }
+
+    clock_t t1 = times(&tb1);
+    check(t1 != (clock_t)-1, "times() 二次调用成功");
+    long delta = (long)(t1 - t0);
+    long hi = 30 * clk; /* 3000 for clk=100: 30 s of monotonic for a 0.3 s sleep */
+    printf("  return delta = %ld ticks over ~300ms sleep (allowed [1, %ld])\n", delta, hi);
+    check(delta >= 1 && delta <= hi,
+          "times() 返回值以 USER_HZ 节拍计(非硬件频率)");
+
+    /* tms fields are clock_t ticks, never microseconds. Burn measurable CPU,
+     * then the accumulated user+system time must stay within a tick budget the
+     * microsecond bug (10000x larger) cannot satisfy. Skip if the kernel does
+     * not account CPU time at all (both fields zero). */
+    volatile unsigned long spin = 0;
+    for (long i = 0; i < 200000000L; i++) {
+        spin += (unsigned long)i;
+    }
+    (void)spin;
+    struct tms tb2;
+    clock_t t2 = times(&tb2);
+    check(t2 != (clock_t)-1, "times() 三次调用成功");
+    long cpu = (long)(tb2.tms_utime + tb2.tms_stime);
+    printf("  tms_utime+tms_stime = %ld ticks after busy loop\n", cpu);
+    if (cpu != 0) {
+        long cpu_hi = 100 * clk; /* 10000 for clk=100; micros bug yields ~1e5+ */
+        check(cpu <= cpu_hi, "tms 字段以节拍计(非微秒)");
+    } else {
+        printf("  SKIP | 内核未累计 CPU 时间, tms 单位判别跳过\n");
+    }
+
+    printf("=== bug-times-clock-ticks: %s ===\n", failed ? "FAIL" : "PASS");
+    return failed;
+}


### PR DESCRIPTION
## 问题

`sys_times`（`os/StarryOS/kernel/src/syscall/time.rs`）填充的 `struct tms` 各字段与返回值的单位都不符合 Linux `times(2)` 语义。Linux 规定 `times(2)` 的 `tms_utime`/`tms_stime`/`tms_cutime`/`tms_cstime` 以及返回值都以 `_SC_CLK_TCK` 时钟节拍（USER_HZ）计，glibc 与 musl 均把 `_SC_CLK_TCK` 硬编码为 100，即一个节拍等于 10 ms。原实现把 tms 字段写成 `Duration::as_micros()`（微秒），返回值写成 `nanos_to_ticks(monotonic_time_nanos())`（硬件定时器频率的节拍）。用户态按 `_SC_CLK_TCK` 换算时会得到完全错误的秒数。

## 实测

在 x86_64 QEMU 上对未修改代码跑本 PR 新增的回归测试：`_SC_CLK_TCK` 报 100；睡眠约 300 ms 后返回值增量为 995507456（应约为 30），换算出的硬件频率约 3.3 GHz TSC；忙循环后 `tms_utime + tms_stime` 为 699366（微秒，应约为 70 个节拍）。两项都印证了单位错误。

## 改动

按 Linux 语义并复用仓库内已有范式修正单位。`os/StarryOS/kernel/src/task/stat.rs` 里 `/proc/[pid]/stat` 已经用同一套 jiffies 换算（`utime = duration.as_millis() / 10`，USER_HZ = 100）。本 PR 让 `sys_times` 复用相同换算：tms 各字段改为 `duration.as_millis() / 10`，返回值改为 `monotonic_time().as_millis() / 10`；并移除不再使用的 `nanos_to_ticks`、`monotonic_time_nanos` 导入。

## 回归测试

新增 `test-suit/starryos/qemu/system/bugfix-times-clock-ticks`，由 system 套件自动发现、构建、安装并执行：验证 `_SC_CLK_TCK` 为 100；睡眠约 300 ms 后返回值增量落在 USER_HZ 节拍量级（`[1, 30 * CLK_TCK]`）而非硬件频率；忙循环后 tms 字段以节拍计而非微秒。该测试在修复前必然失败、修复后通过。
