### PR TITLE
fix(starry-kernel): scope setns and id-map privileges to the initial user namespace

### DIFF
--- a/os/StarryOS/kernel/src/namespace/mod.rs
+++ b/os/StarryOS/kernel/src/namespace/mod.rs
@@ -57,6 +57,11 @@ impl NsProxy {
         }
     }
 
+    /// Whether these namespaces still belong to the initial user namespace.
+    pub fn in_initial_user_ns(&self) -> bool {
+        Arc::ptr_eq(&self.user_ns, &ROOT_USER_NS)
+    }
+
     /// Clone all namespace references (shallow `Arc` clone).
     ///
     /// Used by `fork` / `clone` (without `CLONE_NEW*` flags) so the child

--- a/os/StarryOS/kernel/src/pseudofs/proc.rs
+++ b/os/StarryOS/kernel/src/pseudofs/proc.rs
@@ -41,6 +41,22 @@ use crate::{
     },
 };
 
+/// Linux `new_idmap_permitted`: without the capability in the initial user
+/// namespace, a writer may map only its own id.
+fn may_map_id(
+    outside: u32,
+    count: u32,
+    own_id: impl Fn(&Cred) -> u32,
+    privileged: impl Fn(&Cred) -> bool,
+) -> bool {
+    let writer = current_user_task();
+    let thread = writer.as_thread();
+    let cred = thread.cred();
+    let cred: &Cred = &cred;
+    (count == 1 && outside == own_id(cred))
+        || (privileged(cred) && thread.proc_data.namespace_snapshot().in_initial_user_ns())
+}
+
 fn upgrade_proc_task(task: &WeakUserTaskRef) -> VfsResult<Option<UserTaskRef>> {
     (*task).upgrade().map_err(|_| VfsError::BadState)
 }
@@ -1646,8 +1662,12 @@ impl SimpleDirOps for ThreadDir {
                             let _mapped: u32 =
                                 parts[0].parse().map_err(|_| VfsError::InvalidInput)?;
                             let orig: u32 = parts[1].parse().map_err(|_| VfsError::InvalidInput)?;
-                            let _count: u32 =
+                            let count: u32 =
                                 parts[2].parse().map_err(|_| VfsError::InvalidInput)?;
+                            if !may_map_id(orig, count, |cred| cred.euid, Cred::has_cap_setuid)
+                            {
+                                return Err(VfsError::OperationNotPermitted);
+                            }
                             let thr = task.as_thread();
                             let mut cred = (*thr.cred()).clone();
                             cred.uid = orig;
@@ -1706,8 +1726,12 @@ impl SimpleDirOps for ThreadDir {
                             let _mapped: u32 =
                                 parts[0].parse().map_err(|_| VfsError::InvalidInput)?;
                             let orig: u32 = parts[1].parse().map_err(|_| VfsError::InvalidInput)?;
-                            let _count: u32 =
+                            let count: u32 =
                                 parts[2].parse().map_err(|_| VfsError::InvalidInput)?;
+                            if !may_map_id(orig, count, |cred| cred.egid, Cred::has_cap_setgid)
+                            {
+                                return Err(VfsError::OperationNotPermitted);
+                            }
                             let thr = task.as_thread();
                             let mut cred = (*thr.cred()).clone();
                             cred.gid = orig;

--- a/os/StarryOS/kernel/src/syscall/task/namespace.rs
+++ b/os/StarryOS/kernel/src/syscall/task/namespace.rs
@@ -27,6 +27,16 @@ const SUPPORTED_NS_FLAGS: u32 = UNSHARE_NAMESPACE_FLAGS | CLONE_FS | CLONE_FILES
 
 const SUPPORTED_SETNS_FLAGS: u32 = SUPPORTED_NS_FLAGS & !CLONE_FILES;
 
+/// Capabilities are not scoped to user namespaces yet, so only CAP_SYS_ADMIN
+/// held in the initial user namespace may join a namespace.
+fn may_join(thread: &Thread) -> bool {
+    thread.cred().has_cap_sys_admin()
+        && thread
+            .proc_data
+            .namespace_snapshot()
+            .in_initial_user_ns()
+}
+
 type SharedFileTable = Arc<RwLock<FileTable>>;
 
 struct PreparedUnshare {
@@ -202,7 +212,7 @@ fn setns_via_nsfd(
     let curr = current;
     let thread = curr.as_thread();
     let proc_data = &thread.proc_data;
-    if fd_type == CLONE_NEWCGROUP && !thread.cred().has_cap_sys_admin() {
+    if !may_join(thread) {
         return Err(StarryError::OperationNotPermitted);
     }
 
@@ -294,7 +304,7 @@ fn setns_via_pidfd(
     let curr = current;
     let thread = curr.as_thread();
     let proc_data = &thread.proc_data;
-    if nstype & CLONE_NEWCGROUP != 0 && !thread.cred().has_cap_sys_admin() {
+    if !may_join(thread) {
         return Err(StarryError::OperationNotPermitted);
     }
 

--- a/test-suit/starryos/qemu/system/bugfix-setns-requires-cap-sys-admin/CMakeLists.txt
+++ b/test-suit/starryos/qemu/system/bugfix-setns-requires-cap-sys-admin/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.20)
+project(bugfix-setns-requires-cap-sys-admin C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_executable(bugfix-setns-requires-cap-sys-admin src/main.c)
+target_include_directories(bugfix-setns-requires-cap-sys-admin PRIVATE ../common)
+target_compile_options(bugfix-setns-requires-cap-sys-admin PRIVATE -Wall -Wextra -Werror)
+
+install(TARGETS bugfix-setns-requires-cap-sys-admin RUNTIME DESTINATION usr/bin/starry-test-suit)

--- a/test-suit/starryos/qemu/system/bugfix-setns-requires-cap-sys-admin/src/main.c
+++ b/test-suit/starryos/qemu/system/bugfix-setns-requires-cap-sys-admin/src/main.c
@@ -1,0 +1,129 @@
+#define _GNU_SOURCE
+#include "test_framework.h"
+
+#include <fcntl.h>
+#include <sched.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+struct initial_ns {
+    int uts;
+    int ipc;
+    int net;
+    int pidfd;
+};
+
+static int write_file(const char *path, const char *text)
+{
+    int fd = open(path, O_WRONLY | O_CLOEXEC);
+    if (fd < 0)
+        return -1;
+    ssize_t n = write(fd, text, strlen(text));
+    int saved = errno;
+    close(fd);
+    errno = saved;
+    return n == (ssize_t)strlen(text) ? 0 : -1;
+}
+
+/* Runs `body` in a child so dropped privileges and new namespaces stay contained. */
+static void in_child(const char *name, void (*body)(const struct initial_ns *), const struct initial_ns *ns)
+{
+    fflush(stdout);
+    int failed_before = __fail;
+    pid_t child = fork();
+    if (child == 0) {
+        body(ns);
+        fflush(stdout);
+        _exit(__fail > failed_before);
+    }
+    int status = 0;
+    CHECK_RET(waitpid(child, &status, 0), child, name);
+    CHECK(WIFEXITED(status) && WEXITSTATUS(status) == 0, name);
+}
+
+static void drop_to_nobody(void)
+{
+    CHECK(setgid(65534) == 0 && setuid(65534) == 0, "drop to uid/gid 65534");
+    /* setuid() leaves the task non-dumpable, which would make its /proc maps root-owned. */
+    CHECK_RET(prctl(PR_SET_DUMPABLE, 1), 0, "keep /proc/self maps writable");
+}
+
+static void refuse_initial_namespaces(const struct initial_ns *ns)
+{
+    CHECK_ERR(setns(ns->uts, CLONE_NEWUTS), EPERM, "setns(initial uts nsfd) refused");
+    CHECK_ERR(setns(ns->ipc, CLONE_NEWIPC), EPERM, "setns(initial ipc nsfd) refused");
+    CHECK_ERR(setns(ns->net, CLONE_NEWNET), EPERM, "setns(initial net nsfd) refused");
+    CHECK_ERR(setns(ns->pidfd, CLONE_NEWUTS), EPERM, "setns(pidfd, CLONE_NEWUTS) refused");
+    CHECK_ERR(setns(ns->pidfd, CLONE_NEWIPC), EPERM, "setns(pidfd, CLONE_NEWIPC) refused");
+    CHECK_ERR(setns(ns->pidfd, CLONE_NEWNET), EPERM, "setns(pidfd, CLONE_NEWNET) refused");
+}
+
+/* Root in the initial user namespace holds CAP_SYS_ADMIN over every namespace that user namespace owns. */
+static void root_in_initial_user_ns(const struct initial_ns *ns)
+{
+    CHECK_RET(setns(ns->uts, CLONE_NEWUTS), 0, "root joins the initial uts namespace by nsfd");
+    CHECK_RET(setns(ns->pidfd, CLONE_NEWUTS | CLONE_NEWIPC), 0, "root joins the initial uts and ipc namespaces by pidfd");
+    CHECK_RET(unshare(CLONE_NEWUTS), 0, "root creates a uts namespace");
+    int created = open("/proc/self/ns/uts", O_RDONLY | O_CLOEXEC);
+    CHECK(created >= 0, "open the created uts namespace");
+    CHECK_RET(setns(ns->pidfd, CLONE_NEWUTS), 0, "root returns to the initial uts namespace by pidfd");
+    CHECK_RET(setns(created, CLONE_NEWUTS), 0, "root rejoins the uts namespace it created by nsfd");
+}
+
+/* Without CAP_SYS_ADMIN, joining any namespace is refused. */
+static void unprivileged_task(const struct initial_ns *ns)
+{
+    drop_to_nobody();
+    refuse_initial_namespaces(ns);
+}
+
+/* An unprivileged writer may only map its own ids; mapping id 0 would grant root. */
+static void rootless_writer_cannot_map_root(const struct initial_ns *ns)
+{
+    drop_to_nobody();
+    CHECK_RET(unshare(CLONE_NEWUSER), 0, "create a child user namespace");
+    CHECK_ERR(write_file("/proc/self/uid_map", "0 0 1"), EPERM, "uid_map mapping outside uid 0 refused");
+    CHECK_RET(write_file("/proc/self/setgroups", "deny"), 0, "deny setgroups before writing gid_map");
+    CHECK_ERR(write_file("/proc/self/gid_map", "0 0 1"), EPERM, "gid_map mapping outside gid 0 refused");
+    CHECK(getuid() != 0 && getgid() != 0, "still not root inside the child user namespace");
+    refuse_initial_namespaces(ns);
+}
+
+/* Capabilities obtained inside a child user namespace do not reach the initial namespaces. */
+static void rootless_mapped_to_own_uid(const struct initial_ns *ns)
+{
+    drop_to_nobody();
+    CHECK_RET(unshare(CLONE_NEWUSER), 0, "create a child user namespace");
+    CHECK_RET(write_file("/proc/self/uid_map", "0 65534 1"), 0, "uid_map mapping its own uid accepted");
+    refuse_initial_namespaces(ns);
+}
+
+/* Even root loses its hold on the initial namespaces once it enters a child user namespace. */
+static void root_after_entering_child_user_ns(const struct initial_ns *ns)
+{
+    CHECK_RET(unshare(CLONE_NEWUSER), 0, "root creates a child user namespace");
+    CHECK_RET(write_file("/proc/self/uid_map", "0 0 1"), 0, "root maps its own uid 0");
+    refuse_initial_namespaces(ns);
+}
+
+int main(void)
+{
+    TEST_START("setns requires CAP_SYS_ADMIN over the target namespace");
+    CHECK(getuid() == 0, "runs as root so it can drop privileges");
+    struct initial_ns ns = {
+        .uts = open("/proc/self/ns/uts", O_RDONLY | O_CLOEXEC),
+        .ipc = open("/proc/self/ns/ipc", O_RDONLY | O_CLOEXEC),
+        .net = open("/proc/self/ns/net", O_RDONLY | O_CLOEXEC),
+        .pidfd = (int)syscall(SYS_pidfd_open, getpid(), 0),
+    };
+    CHECK(ns.uts >= 0 && ns.ipc >= 0 && ns.net >= 0 && ns.pidfd >= 0, "open initial namespace fds and a pidfd");
+
+    in_child("root in the initial user namespace", root_in_initial_user_ns, &ns);
+    in_child("unprivileged task", unprivileged_task, &ns);
+    in_child("rootless writer cannot map root", rootless_writer_cannot_map_root, &ns);
+    in_child("rootless task mapped to its own uid", rootless_mapped_to_own_uid, &ns);
+    in_child("root after entering a child user namespace", root_after_entering_child_user_ns, &ns);
+    TEST_DONE();
+}


### PR DESCRIPTION
Closes #1747

## 问题

`setns(2)` 在 nsfd 与 pidfd 两条路径上只对 `CLONE_NEWCGROUP` 检查 `CAP_SYS_ADMIN`，非特权进程可以加入其他进程的 UTS、IPC、NET、MNT、PID、USER 命名空间。

只加全局检查仍不够：`uid_map`/`gid_map` 写入不校验写入者，非特权进程 unshare user namespace 后写 `0 0 1` 就成为 uid 0 并获得全量能力位；能力位也不按 user namespace 区分，root 进入子 user namespace 后仍持有全部能力位。

Linux 由 `ns_capable` 要求调用者在目标 namespace 的属主 user namespace 中持有 `CAP_SYS_ADMIN`，子 user namespace 中的能力位不作用于祖先；`new_idmap_permitted` 只允许无特权的写入者映射自己的 euid/egid。

## 改动

StarryOS 还没有 user namespace 父子链和各 namespace 的属主，按审查给出的过渡做法，暂不承认子 user namespace 中的能力位：

- `may_join`：setns 两条路径对所有类型要求 `CAP_SYS_ADMIN`，且调用者位于初始 user namespace。
- `may_map_id`：`uid_map`/`gid_map` 只允许映射写入者自己的 id（长度 1），否则要求写入者位于初始 user namespace 并持有 `CAP_SETUID`/`CAP_SETGID`，不满足返回 `EPERM`。

代价是子 user namespace 中暂时不能加入同一 user namespace 下的其他 namespace；写 `gid_map` 前也暂不要求 `setgroups` 为 `deny`，现有 `claw-code-regression/goal-03-gid-map` 依赖这一点。两处留待能力模型补齐后对齐。

## 回归测试

`bugfix-setns-requires-cap-sys-admin` 以 root 启动，先打开初始 UTS、IPC、NET 的 nsfd 与自身 pidfd，再在子进程里构造五种身份。Linux 6.6 上以 root 实跑全过。

| 场景 | 期望 |
|:--:|:--:|
| 初始 user namespace 的 root | 经 nsfd、pidfd 加入初始 UTS/IPC 成功；unshare UTS 后往返加入成功 |
| 降权到 65534 | 六次 setns 均 `EPERM` |
| 降权后写 `0 0 1` | 映射 `EPERM`，uid/gid 仍非 0，setns 均 `EPERM` |
| 降权后映射自身 `0 65534 1` | 映射成功，setns 均 `EPERM` |
| root 进入子 user namespace 并映射 `0 0 1` | 映射成功，setns 均 `EPERM` |

x86_64 QEMU，基线 1d7f3c20：只加测试时父进程 8 过 4 挂，后四个场景 setns 全部成功、`0 0 1` 写入后 uid 变为 0；加上修复后 12 过 0 挂。

## 验证

`cargo xtask clippy --since 1d7f3c20`、`cargo xtask test --since origin/dev` 全部通过。
