### PR TITLE
test(axvisor): add OrangePi 5 Plus IVC benchmark board test

### DIFF
--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -244,6 +244,20 @@ kind = "axvisor-board"
 board = "orangepi-5-plus-starry"
 
 [[check]]
+id = "test-axvisor-self-hosted-board-orangepi-5-plus-ivc-benchmark"
+impact_targets = ["axvisor:aarch64", "starry:aarch64"]
+name = "Board OrangePi 5 Plus · AXIVC Zephyr-Starry benchmark"
+runner = "board"
+timeout_minutes = 30
+command = '''
+cargo xtask axvisor test board --board orangepi-5-plus-ivc-benchmark
+'''
+
+[[check.suite]]
+kind = "axvisor-board"
+board = "orangepi-5-plus-ivc-benchmark"
+
+[[check]]
 id = "test-axvisor-self-hosted-board-roc-rk3568-pc-linux"
 impact_targets = ["axvisor:aarch64"]
 name = "Board ROC-RK3568-PC · Linux guest"

--- a/.github/ci/checks/axvisor.toml
+++ b/.github/ci/checks/axvisor.toml
@@ -29,40 +29,29 @@ arch = "aarch64"
 cases = ["smoke", "gicv2-timer-stress", "gicv3-timer-stress"]
 
 [[check]]
-id = "test-axvisor-aarch64-qemu-panic-modes"
+id = "test-axvisor-aarch64-qemu-panic-http-control-plane-ivc"
 impact_targets = ["axvisor:aarch64"]
-name = "QEMU aarch64 · Panic modes"
+name = "QEMU aarch64 · Panic modes + HTTP control-plane + browser console + IVC"
 timeout_minutes = 30
 command = '''
 echo "==> axvisor aarch64 backtrace panic"
 cargo xtask axvisor test qemu --arch aarch64 --test-case backtrace-panic
 echo "==> axvisor aarch64 no-backtrace panic"
 cargo xtask axvisor test qemu --arch aarch64 --test-case no-backtrace
-'''
-
-[[check.suite]]
-kind = "axvisor-qemu"
-arch = "aarch64"
-cases = ["backtrace-panic", "no-backtrace"]
-
-[[check]]
-id = "test-axvisor-aarch64-qemu-http-control-plane"
-impact_targets = ["axvisor:aarch64"]
-name = "QEMU aarch64 · HTTP control-plane"
-timeout_minutes = 30
-command = '''
 echo "==> pull qemu-aarch64 image"
 cargo xtask image pull qemu-aarch64 --extract-dir tmp/axbuild/images
 echo "==> axvisor aarch64 HTTP control-plane (incl. pause/resume)"
 cargo xtask axvisor test qemu --arch aarch64 --test-case http-control-plane
 echo "==> axvisor aarch64 browser console"
 cargo xtask axvisor test qemu --arch aarch64 --test-case browser-console
+echo "==> axvisor aarch64 IVC"
+cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qemu-ivc
 '''
 
 [[check.suite]]
 kind = "axvisor-qemu"
 arch = "aarch64"
-cases = ["http-control-plane", "browser-console"]
+cases = ["backtrace-panic", "no-backtrace", "http-control-plane", "browser-console", "qemu-ivc"]
 
 [[check]]
 id = "test-axvisor-riscv64-qemu-smoke-panic-modes"
@@ -107,19 +96,6 @@ arch = "loongarch64"
 cases = ["smoke"]
 
 [[check]]
-id = "test-axvisor-qemu-ivc"
-impact_targets = ["axvisor:aarch64"]
-name = "QEMU aarch64 · IVC"
-command = '''
-cargo xtask axvisor test qemu --arch aarch64 --test-group normal --test-case qemu-ivc
-'''
-
-[[check.suite]]
-kind = "axvisor-qemu"
-arch = "aarch64"
-cases = ["qemu-ivc"]
-
-[[check]]
 id = "test-axvisor-self-hosted-x86-64-svm-smoke-acpi"
 impact_targets = ["axvisor:x86_64"]
 name = "SVM x86_64 · Smoke + direct/OVMF ACPI"
@@ -142,18 +118,24 @@ arch = "x86_64"
 cases = ["smoke-svm", "direct-acpi-svm", "ovmf-acpi-svm"]
 
 [[check]]
-id = "test-axvisor-self-hosted-x86-64-vmx"
+id = "test-axvisor-self-hosted-x86-64-vmx-smoke-pci-enumeration"
 impact_targets = ["axvisor:x86_64"]
-name = "VMX x86_64 · Smoke"
+name = "VMX x86_64 · Smoke + Generic PCI enumeration"
 runner = "kvm-intel"
+timeout_minutes = 90
 command = '''
+echo "==> axvisor x86_64 VMX smoke"
 cargo xtask axvisor test qemu --arch x86_64 --test-case smoke-vmx
+echo "==> pull qemu-x86_64 image"
+cargo xtask image pull qemu-x86_64 --extract-dir tmp/axbuild/images
+echo "==> axvisor x86_64 VMX generic PCI enumeration"
+cargo xtask axvisor test qemu --arch x86_64 --test-case pci-enumeration-vmx
 '''
 
 [[check.suite]]
 kind = "axvisor-qemu"
 arch = "x86_64"
-cases = ["smoke-vmx"]
+cases = ["smoke-vmx", "pci-enumeration-vmx"]
 
 [[check]]
 id = "test-axloader-http-smoke"
@@ -174,9 +156,13 @@ name = "VMX x86_64 · Direct + MP fallback + OVMF ACPI"
 runner = "kvm-intel"
 timeout_minutes = 90
 command = '''
+echo "==> pull qemu-x86_64 image"
 cargo xtask image pull qemu-x86_64 --extract-dir tmp/axbuild/images
+echo "==> axvisor x86_64 VMX direct ACPI boot"
 target/debug/tg-xtask axvisor test qemu --arch x86_64 --test-case direct-acpi-vmx
+echo "==> axvisor x86_64 VMX MP fallback boot"
 target/debug/tg-xtask axvisor test qemu --arch x86_64 --test-case mp-fallback-vmx
+echo "==> axvisor x86_64 VMX OVMF ACPI boot"
 target/debug/tg-xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx
 '''
 
@@ -184,22 +170,6 @@ target/debug/tg-xtask axvisor test qemu --arch x86_64 --test-case ovmf-acpi-vmx
 kind = "axvisor-qemu"
 arch = "x86_64"
 cases = ["direct-acpi-vmx", "mp-fallback-vmx", "ovmf-acpi-vmx"]
-
-[[check]]
-id = "test-axvisor-x86-64-pci-enumeration-vmx"
-impact_targets = ["axvisor:x86_64"]
-name = "VMX x86_64 · Generic PCI enumeration"
-runner = "kvm-intel"
-timeout_minutes = 45
-command = '''
-cargo xtask image pull qemu-x86_64 --extract-dir tmp/axbuild/images
-cargo xtask axvisor test qemu --arch x86_64 --test-case pci-enumeration-vmx
-'''
-
-[[check.suite]]
-kind = "axvisor-qemu"
-arch = "x86_64"
-cases = ["pci-enumeration-vmx"]
 
 [[check]]
 id = "test-axvisor-x86-64-pci-enumeration-svm"
@@ -218,44 +188,31 @@ arch = "x86_64"
 cases = ["pci-enumeration-svm"]
 
 [[check]]
-id = "test-axvisor-self-hosted-board-orangepi-5-plus-linux"
-impact_targets = ["axvisor:aarch64"]
-name = "Board OrangePi 5 Plus · Linux guest"
-runner = "board"
-command = '''
-cargo xtask axvisor test board --board orangepi-5-plus-linux
-'''
-
-[[check.suite]]
-kind = "axvisor-board"
-board = "orangepi-5-plus-linux"
-
-[[check]]
-id = "test-axvisor-self-hosted-board-orangepi-5-plus-starry"
-impact_targets = ["axvisor:aarch64"]
-name = "Board OrangePi 5 Plus · StarryOS guest"
-runner = "board"
-command = '''
-cargo xtask axvisor test board --board orangepi-5-plus-starry
-'''
-
-[[check.suite]]
-kind = "axvisor-board"
-board = "orangepi-5-plus-starry"
-
-[[check]]
-id = "test-axvisor-self-hosted-board-orangepi-5-plus-ivc-benchmark"
+id = "test-axvisor-self-hosted-board-orangepi-5-plus-linux-starry-ivc-benchmark"
 impact_targets = ["axvisor:aarch64", "starry:aarch64"]
-name = "Board OrangePi 5 Plus · AXIVC Zephyr-Starry benchmark"
+name = "Board OrangePi 5 Plus · Linux + StarryOS + AXIVC Zephyr-Starry benchmark"
 runner = "board"
-timeout_minutes = 30
+timeout_minutes = 90
 command = '''
+echo "==> axvisor OrangePi 5 Plus Linux guest"
+cargo xtask axvisor test board --board orangepi-5-plus-linux
+echo "==> axvisor OrangePi 5 Plus StarryOS guest"
+cargo xtask axvisor test board --board orangepi-5-plus-starry
+echo "==> axvisor OrangePi 5 Plus AXIVC Zephyr-Starry benchmark"
 cargo xtask axvisor test board --board orangepi-5-plus-ivc-benchmark
 '''
 
 [[check.suite]]
 kind = "axvisor-board"
 board = "orangepi-5-plus-ivc-benchmark"
+
+[[check.suite]]
+kind = "axvisor-board"
+board = "orangepi-5-plus-linux"
+
+[[check.suite]]
+kind = "axvisor-board"
+board = "orangepi-5-plus-starry"
 
 [[check]]
 id = "test-axvisor-self-hosted-board-roc-rk3568-pc-linux"

--- a/scripts/test/test_ci_plan.py
+++ b/scripts/test/test_ci_plan.py
@@ -57,7 +57,7 @@ class CiPlanTests(unittest.TestCase):
             "run-clippy": ["self-hosted", "linux", "qcs"],
             "test-with-std": ["self-hosted", "linux", "qcs"],
             "test-arceos-x86-64-qemu": ["self-hosted", "linux", "qcs"],
-            "test-axvisor-aarch64-qemu-http-control-plane": [
+            "test-axvisor-aarch64-qemu-panic-http-control-plane-ivc": [
                 "self-hosted",
                 "linux",
                 "qcs",
@@ -555,7 +555,7 @@ command = "true"
                 "run-clippy",
                 "test-with-std",
                 "test-arceos-aarch64-qemu-app-suites",
-                "test-axvisor-aarch64-qemu-http-control-plane",
+                "test-axvisor-aarch64-qemu-panic-http-control-plane-ivc",
                 "test-starry-aarch64-qemu",
             }.issubset(test_rows)
         )

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/benchmark/board-orangepi-5-plus-ivc-benchmark.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/benchmark/board-orangepi-5-plus-ivc-benchmark.toml
@@ -1,0 +1,18 @@
+board_type = "OrangePi-5-Plus"
+# The board Linux rootfs must contain the IVC payload from tgosimages
+# IMAGES/orangepi/ivc: /guest/starry, /guest/zephyr and /usr/bin/ivc-starry-bench.
+fail_regex = [
+  "(?i)\\bpanic(?:ked)?\\b",
+  "(?i)kernel panic",
+  "Failed to initialize guest VM",
+  "AXIVC Starry benchmark peer ready failed",
+  "AXIVC Starry benchmark send failed",
+  "AXIVC Starry benchmark recv failed",
+  "AXIVC Zephyr-Starry benchmark publish failed",
+  "AXIVC Zephyr-Starry benchmark ready send failed",
+  "AXIVC Zephyr-Starry benchmark failed",
+]
+success_regex = [
+  "(?m)^(?:\\[VM 1\\] )?AXVISOR_IVC_BENCH_RESULT=PASS cases=4 testTime=100 bytes=1232076800 chunks=400\\s*$",
+]
+timeout = 300

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/build-aarch64-unknown-none-softfloat.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/build-aarch64-unknown-none-softfloat.toml
@@ -1,0 +1,11 @@
+features = [
+  "ax-driver/rockchip-dwmmc",
+  "ax-driver/rockchip-sdhci",
+  "fs",
+]
+log = "Error"
+target = "aarch64-unknown-none-softfloat"
+vm_configs = [
+  "test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/starry-axivc-benchmark.toml",
+  "test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/zephyr-axivc-benchmark.toml",
+]

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/starry-axivc-benchmark.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/starry-axivc-benchmark.toml
@@ -1,0 +1,33 @@
+[base]
+id = 1
+name = "starry-axivc-benchmark"
+guest_type = "passthrough"
+cpu_num = 1
+phys_cpu_ids = [0x00]
+
+[kernel]
+entry_point = 0x4008_0000
+image_location = "fs"
+kernel_load_addr = 0x4008_0000
+kernel_path = "/guest/starry/orangepi-5-plus-ivc"
+dtb_load_addr = 0x4000_0000
+cmdline = "root=/dev/mmcblk0p2 rw console=ttyS2,1500000 earlycon=uart8250,mmio32,0xfeb50000 cpuidle.off=1 rodata=off rootwait rootfstype=ext4 cma=128M init=/usr/bin/ivc-starry-bench"
+
+memory_regions = [
+  [0x4000_0000, 0x1000_0000, 0x7, 2],
+  [0x2_4000_0000, 0x8000_0000, 0x7, 1],
+]
+
+[devices]
+passthrough = []
+disabled = [
+  { path = "/pcie@fe150000" },
+  { path = "/pcie@fe160000" },
+  { path = "/pcie@fe170000" },
+  { path = "/pcie@fe180000" },
+  { path = "/pcie@fe190000" },
+]
+
+[[devices.virtual]]
+id = "ivc0"
+model = "ivc-channel"

--- a/test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/zephyr-axivc-benchmark.toml
+++ b/test-suit/axvisor/normal/board-orangepi-5-plus/ivc-benchmark/zephyr-axivc-benchmark.toml
@@ -1,0 +1,25 @@
+[base]
+id = 2
+name = "zephyr-axivc-starry-benchmark"
+guest_type = "virtualized"
+cpu_num = 1
+phys_cpu_ids = [0x100]
+
+[kernel]
+entry_point = 0x5000_923c
+image_location = "fs"
+kernel_load_addr = 0x5000_0000
+kernel_path = "/guest/zephyr/zephyr-ivc-benchmark.bin"
+dtb_load_addr = 0x7000_0000
+
+memory_regions = [
+  [0x5000_0000, 0x3000_0000, 0x7, 2],
+]
+
+[devices]
+passthrough = []
+disabled = []
+
+[[devices.virtual]]
+id = "ivc0"
+model = "ivc-channel"


### PR DESCRIPTION
### 添加 zephyr 和 starry 通信速率的测例

orangepi-5-plus-ivc-benchmark