### PR TITLE
build(container): upgrade QEMU to 11.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker run -it --rm \
   ghcr.io/rcore-os/tgoskits-container:latest
 ```
 
-If you do not use the container, prepare at least Rust, basic build tools, and common QEMU packages. The recommended QEMU version is 10.2.1, matching the container and CI environment; distribution packages are usually enough for quick trials, but switch to the container if a target is missing or behavior differs:
+If you do not use the container, prepare at least Rust, basic build tools, and common QEMU packages. The recommended QEMU version is 11.1.1, matching the container and CI environment; distribution packages are usually enough for quick trials, but switch to the container if a target is missing or behavior differs:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -70,7 +70,7 @@ See [quick start overview](https://rcore-os.cn/tgoskits/docs/quickstart/overview
 
 ### 3.2 QEMU Verification
 
-First confirm that common QEMU commands are available, preferably matching QEMU 10.2.1 from the container and CI environment:
+First confirm that common QEMU commands are available, preferably matching QEMU 11.1.1 from the container and CI environment:
 
 ```bash
 qemu-system-riscv64 --version

--- a/README_CN.md
+++ b/README_CN.md
@@ -56,7 +56,7 @@ docker run -it --rm \
   ghcr.io/rcore-os/tgoskits-container:latest
 ```
 
-如果不使用容器，请至少准备 Rust、基础构建工具和常用 QEMU。推荐使用与容器和 CI 一致的 QEMU 10.2.1；发行版自带 QEMU 可用于快速体验，但如果遇到架构缺失或运行差异，请优先切换到容器环境：
+如果不使用容器，请至少准备 Rust、基础构建工具和常用 QEMU。推荐使用与容器和 CI 一致的 QEMU 11.1.1；发行版自带 QEMU 可用于快速体验，但如果遇到架构缺失或运行差异，请优先切换到容器环境：
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
@@ -70,7 +70,7 @@ cargo install cargo-binutils
 
 ### 3.2 QEMU 验证
 
-先确认常用 QEMU 命令可用，并尽量与容器和 CI 使用的 QEMU 10.2.1 对齐：
+先确认常用 QEMU 命令可用，并尽量与容器和 CI 使用的 QEMU 11.1.1 对齐：
 
 ```bash
 qemu-system-riscv64 --version

--- a/apps/starry/claw-code-regression/integration/run-local.sh
+++ b/apps/starry/claw-code-regression/integration/run-local.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Build claw from source, inject into rootfs, and boot StarryOS.
-# Usage: docker run --rm -v "$(pwd)":/workspace -w /workspace starryos-dev:ubuntu-qemu10.2.1 \
+# Usage: docker run --rm -v "$(pwd)":/workspace -w /workspace starryos-dev:ubuntu-qemu11.1.1 \
 #   bash apps/starry/claw-code-regression/integration/run-local.sh
 set -eu
 

--- a/apps/starry/k230-kpu-nncase/c/tools/build-nncase-runtime-binaries.sh
+++ b/apps/starry/k230-kpu-nncase/c/tools/build-nncase-runtime-binaries.sh
@@ -27,7 +27,7 @@ else
     REL_WORKTREE=${WORKTREE_ROOT#"$STORAGE_ROOT"/}
 fi
 IMAGE=${K230_SDK_DOCKER_IMAGE:-ghcr.io/kendryte/k230_sdk:latest}
-STARRY_DEV_IMAGE=${STARRY_DEV_DOCKER_IMAGE:-starryos-dev:ubuntu-qemu10.2.1}
+STARRY_DEV_IMAGE=${STARRY_DEV_DOCKER_IMAGE:-starryos-dev:ubuntu-qemu11.1.1}
 SYSROOT_VOLUME=${K230_LINUX_MUSL_SYSROOT_VOLUME:-tgoskits-riscv64-linux-musl-cross}
 BUILD_DIR=/workspace/target/k230-nncase-runtime/build-sdk
 HOST_BUILD_DIR="$STORAGE_ROOT/target/k230-nncase-runtime/build-sdk"

--- a/apps/starry/k230-kpu-nncase/demo-teacher.sh
+++ b/apps/starry/k230-kpu-nncase/demo-teacher.sh
@@ -70,7 +70,7 @@ if [[ ! -f /.dockerenv && "${USE_DOCKER}" == "1" ]]; then
         exit 1
     fi
 
-    IMAGE=${K230_TEACHER_DEMO_IMAGE:-starryos-dev:ubuntu-qemu10.2.1}
+    IMAGE=${K230_TEACHER_DEMO_IMAGE:-starryos-dev:ubuntu-qemu11.1.1}
     CONTAINER_BASE=/workspace
     CONTAINER_REPO="${CONTAINER_BASE}${REPO_ROOT#"${BASE_ROOT}"}"
     CONTAINER_SCRIPT="${CONTAINER_REPO}/apps/starry/k230-kpu-nncase/demo-teacher.sh"
@@ -154,7 +154,7 @@ REPLAY_LOG="${LOG_DIR}/yolov8n-full-sequence-replay.log"
 K230_QEMU_CASE_DIR="${REPO_ROOT}/apps/starry/k230-qemu/qemu-k230"
 CAPTURE="${K230_QEMU_CASE_DIR}/kpu-smoke/c/assets/captures/yolov8n-full-sequence-delta.krun"
 
-export PATH="${BASE_ROOT}/target/qemu-k230-docker-build:${BASE_ROOT}/target/qemu-k230-docker-build/bin:/opt/qemu-10.2.1/bin:/opt/riscv64-linux-musl-cross/bin:/opt/x86_64-linux-musl-cross/bin:${PATH}"
+export PATH="${BASE_ROOT}/target/qemu-k230-docker-build:${BASE_ROOT}/target/qemu-k230-docker-build/bin:/opt/qemu-11.1.1/bin:/opt/riscv64-linux-musl-cross/bin:/opt/x86_64-linux-musl-cross/bin:${PATH}"
 
 section "Demo Goal"
 cat <<'EOF'

--- a/apps/starry/picoclaw-cli/demo_picoclaw_agent.sh
+++ b/apps/starry/picoclaw-cli/demo_picoclaw_agent.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 workspace="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
-image="${STARRYOS_DOCKER_IMAGE:-starryos-dev:ubuntu-qemu10.2.1}"
+image="${STARRYOS_DOCKER_IMAGE:-starryos-dev:ubuntu-qemu11.1.1}"
 rootfs="${PICOCLAW_DEMO_ROOTFS:-tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-online.img}"
 qemu_config="${PICOCLAW_DEMO_QEMU_CONFIG:-apps/starry/picoclaw-cli/qemu-x86_64-picoclaw-agent.toml}"
 provider="${PICOCLAW_PROVIDER:-openai}"
@@ -134,7 +134,7 @@ run_docker 'command -v debugfs; command -v qemu-system-x86_64; command -v cargo;
 pause
 
 say "Step 4: 生成带 PicoClaw 和在线配置的 StarryOS rootfs"
-run_docker "export PATH=/opt/qemu-10.2.1/bin:\$PATH; apps/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh --rootfs '$rootfs'"
+run_docker "export PATH=/opt/qemu-11.1.1/bin:\$PATH; apps/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh --rootfs '$rootfs'"
 pause
 
 say "Step 5: 启动 StarryOS x86_64 QEMU，并让 PicoClaw 完成多次真实对话"
@@ -143,7 +143,7 @@ echo "  STARRY_PICOCLAW_AGENT_OK"
 echo "  STARRY_PICOCLAW_AGENT_PASSED"
 echo "中间还会出现多段 PicoClaw chat，展示它在 StarryOS guest 里连续闲聊。"
 pause
-run_docker "export PATH=/opt/qemu-10.2.1/bin:/opt/x86_64-linux-musl-cross/bin:\$PATH; cargo xtask starry qemu --arch x86_64 --qemu-config '$qemu_config' --rootfs '$rootfs'"
+run_docker "export PATH=/opt/qemu-11.1.1/bin:/opt/x86_64-linux-musl-cross/bin:\$PATH; cargo xtask starry qemu --arch x86_64 --qemu-config '$qemu_config' --rootfs '$rootfs'"
 
 say "演示完成"
 echo "StarryOS 已在 QEMU 中运行 PicoClaw，并完成多次真实 API 对话。"

--- a/apps/starry/picoclaw-cli/run_picoclaw_interactive.sh
+++ b/apps/starry/picoclaw-cli/run_picoclaw_interactive.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 workspace="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 
-image="${STARRYOS_DOCKER_IMAGE:-starryos-dev:ubuntu-qemu10.2.1}"
+image="${STARRYOS_DOCKER_IMAGE:-starryos-dev:ubuntu-qemu11.1.1}"
 rootfs="${PICOCLAW_USER_ROOTFS:-tmp/axbuild/rootfs/rootfs-x86_64-picoclaw-user.img}"
 qemu_config="${PICOCLAW_USER_QEMU_CONFIG:-apps/starry/picoclaw-cli/qemu-x86_64-picoclaw-interactive.toml}"
 provider="${PICOCLAW_PROVIDER:-openai}"
@@ -169,7 +169,7 @@ if [[ "$should_prepare" -eq 1 ]]; then
     echo "model:     $model"
     echo "api_base:  $api_base"
     echo "rootfs:    $rootfs"
-    run_docker "export PATH=/opt/qemu-10.2.1/bin:\$PATH; apps/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh --rootfs '$rootfs'"
+    run_docker "export PATH=/opt/qemu-11.1.1/bin:\$PATH; apps/starry/picoclaw-cli/prepare_picoclaw_rootfs.sh --rootfs '$rootfs'"
 else
     say "复用已有 PicoClaw rootfs"
     echo "rootfs: $rootfs"
@@ -187,4 +187,4 @@ echo "  picoclaw agent"
 echo
 echo "退出 QEMU：Ctrl-a x"
 
-run_docker_interactive "export PATH=/opt/qemu-10.2.1/bin:/opt/x86_64-linux-musl-cross/bin:\$PATH; cargo xtask starry qemu --arch x86_64 --qemu-config '$qemu_config' --rootfs '$rootfs'"
+run_docker_interactive "export PATH=/opt/qemu-11.1.1/bin:/opt/x86_64-linux-musl-cross/bin:\$PATH; cargo xtask starry qemu --arch x86_64 --qemu-config '$qemu_config' --rootfs '$rootfs'"

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
-ARG QEMU_VERSION=10.2.1
+ARG QEMU_VERSION=11.1.1
 
 ENV TZ=Etc/UTC \
     RUSTUP_HOME=/opt/rustup \

--- a/container/README.md
+++ b/container/README.md
@@ -5,7 +5,7 @@ This folder contains a Docker image definition for StarryOS development.
 Included toolchains:
 
 - Ubuntu 24.04 base image (minimal packages with `--no-install-recommends`)
-- QEMU `10.2.1` (built from source, with `aarch64/riscv64/loongarch64/x86_64` system and linux-user targets)
+- QEMU `11.1.1` (built from source, with `aarch64/riscv64/loongarch64/x86_64` system and linux-user targets)
 - `qemu-user-static` plus source-built linux-user QEMU binaries for guest-user execution helpers
 - `e2fsprogs`/`debugfs` and `fakeroot` for rootfs extraction without host ownership warnings
 - npm for Starry app asset preparation scripts
@@ -15,13 +15,13 @@ Included toolchains:
 ## Build
 
 ```bash
-docker build -t starryos-dev:ubuntu-qemu10.2.1 -f container/Dockerfile .
+docker build -t starryos-dev:ubuntu-qemu11.1.1 -f container/Dockerfile .
 ```
 
 ## Run
 
 ```bash
-docker run -it --rm -v "$(pwd)":/workspace -w /workspace starryos-dev:ubuntu-qemu10.2.1
+docker run -it --rm -v "$(pwd)":/workspace -w /workspace starryos-dev:ubuntu-qemu11.1.1
 ```
 
 Then you can build StarryOS inside the container, for example:

--- a/docs/docs/introduction/platform.md
+++ b/docs/docs/introduction/platform.md
@@ -43,7 +43,7 @@ sidebar_label: "架构与平台"
 
 | 类别 | 工具 | 用途 | 安装方式 |
 |------|------|------|---------|
-| 模拟器 | QEMU ≥ 10.2.1 | 系统级验证的执行环境 | 源码构建或发行版包（Container 内已预装） |
+| 模拟器 | QEMU ≥ 11.1.1 | 系统级验证的执行环境 | 源码构建或发行版包（Container 内已预装） |
 | 辅助构建 | `cmake`, `make`, `ninja-build` | C 测试用例交叉编译 | 系统 apt 包 |
 | 辅助分析 | `cargo-binutils` | 二进制分析（`cargo size`, `cargo objdump`） | `cargo install cargo-binutils` |
 | 镜像操作 | `ostool` | ELF / 镜像格式转换与 QEMU/U-Boot 运行支持 | Cargo 依赖（v0.24） |
@@ -54,7 +54,7 @@ sidebar_label: "架构与平台"
 
 | 内容 | 版本 / 说明 |
 |------|------------|
-| QEMU | 10.2.1 源码构建，覆盖 system + linux-user target |
+| QEMU | 11.1.1 源码构建，覆盖 system + linux-user target |
 | 交叉编译器 | aarch64 / riscv64 / x86_64 / loongarch64 musl 工具链 |
 | Rust toolchain | 与 `rust-toolchain.toml` 一致 |
 | 工作目录 | `/workspace` |

--- a/docs/docs/quickstart/overview.md
+++ b/docs/docs/quickstart/overview.md
@@ -28,7 +28,7 @@ QEMU 构建和启动需要 Linux 宿主、仓库锁定的 Rust 工具链、基�
 |------|------|
 | 操作系统 | Linux x86_64（推荐 Ubuntu 22.04+ / Debian 12+） |
 | Rust 工具链 | 由仓库 `rust-toolchain.toml` 管理 |
-| QEMU | 推荐 10.2.1，与仓库容器镜像和 CI 环境一致 |
+| QEMU | 推荐 11.1.1，与仓库容器镜像和 CI 环境一致 |
 | 磁盘空间 | 建议至少 20 GB（工具链、QEMU、构建产物、rootfs、Guest 镜像） |
 
 ### 1.2 容器环境
@@ -61,7 +61,7 @@ docker run -it --rm -v "$(pwd)":/workspace -w /workspace tgoskits-env
 
 ### 1.4 手动安装
 
-不使用容器时，需要在宿主机安装 Rust、基础构建工具和各架构的 QEMU。QEMU 版本应与容器和 CI 使用的 10.2.1 保持一致：
+不使用容器时，需要在宿主机安装 Rust、基础构建工具和各架构的 QEMU。QEMU 版本应与容器和 CI 使用的 11.1.1 保持一致：
 
 ```bash
 # 1. 安装 Rust（会按仓库 toolchain 自动切换）
@@ -97,7 +97,7 @@ QEMU 运行需要同时满足板卡配置支持目标架构、Rust target 可用
 
 ### 2.2 验证 QEMU
 
-以下命令验证四种架构的模拟器是否存在并输出版本。仓库容器和 CI 使用 QEMU 10.2.1。
+以下命令验证四种架构的模拟器是否存在并输出版本。仓库容器和 CI 使用 QEMU 11.1.1。
 
 ```bash
 qemu-system-riscv64 --version

--- a/docs/docs/runtime/k230-kpu-nncase-runtime.md
+++ b/docs/docs/runtime/k230-kpu-nncase-runtime.md
@@ -313,7 +313,7 @@ bash apps/starry/k230-kpu-nncase/c/tools/build-nncase-runtime-binaries.sh
 该脚本的构建步骤和输出位置由 `apps/starry/k230-kpu-nncase/c/tools/build-nncase-runtime-binaries.sh` 固定，主要用于保证 CMake、SDK toolchain 和 Linux musl sysroot 在不同机器上能找到同一套输入。
 
 1. 从当前 worktree 向上查找 `target/official-k230/k230-sdk-src`。
-2. 使用 `starryos-dev:ubuntu-qemu10.2.1` 把 `/opt/riscv64-linux-musl-cross` 复制到 Docker volume `tgoskits-riscv64-linux-musl-cross`。
+2. 使用 `starryos-dev:ubuntu-qemu11.1.1` 把 `/opt/riscv64-linux-musl-cross` 复制到 Docker volume `tgoskits-riscv64-linux-musl-cross`。
 3. 进入 `ghcr.io/kendryte/k230_sdk:latest` amd64 容器。
 4. 调用 CMake，并显式设置 SDK C++ compiler 与 Linux musl sysroot。
 5. 静态链接 K230 SDK NNCase runtime、`rvv`、JPEG decode、K230 SDK C++ runtime、Linux musl libc、libgcc、libatomic 等库。
@@ -413,7 +413,7 @@ PATH="$PWD/target/qemu-k230-docker-build:$PATH" \
 
 ### 10.3 演示脚本
 
-`apps/starry/k230-kpu-nncase/demo-teacher.sh` 提供流式日志演示入口。脚本默认会在需要时进入 `starryos-dev:ubuntu-qemu10.2.1` Docker 环境，流式打印完整 QEMU/Cargo 输出，并保存 `target/k230-kpu-demo/teacher-nncase-runtime.log`。
+`apps/starry/k230-kpu-nncase/demo-teacher.sh` 提供流式日志演示入口。脚本默认会在需要时进入 `starryos-dev:ubuntu-qemu11.1.1` Docker 环境，流式打印完整 QEMU/Cargo 输出，并保存 `target/k230-kpu-demo/teacher-nncase-runtime.log`。
 
 ```sh
 bash apps/starry/k230-kpu-nncase/demo-teacher.sh


### PR DESCRIPTION
## 背景

项目标准开发容器仍固定使用 QEMU 10.2.1。为跟进 QEMU 11 系列的最新稳定版本，并保持本地开发、文档与活跃辅助脚本一致，本 PR 将标准容器升级到 QEMU 11.1.1。

## 改动

- 将 `container/Dockerfile` 的 `QEMU_VERSION` 固定为 `11.1.1`，安装路径更新为 `/opt/qemu-11.1.1/bin`
- 同步中英文 README、容器文档、快速开始与平台文档中的推荐版本
- 同步 PicoClaw、K230 NNCase 和 claw-code-regression 活跃脚本中的本地镜像标签与 QEMU 路径
- 保留历史验证记录；不修改 QEMU-LVZ、K230 定制 QEMU、嵌套项目镜像、`qemu-plugin` 或 apt 提供的 `qemu-user-static`

## 本地验证

- `docker build -t tgoskits-qemu:11.1.1 -f container/Dockerfile .`
- 容器内 `qemu-system-x86_64`、`qemu-system-riscv64`、`qemu-system-aarch64`、`qemu-system-loongarch64` 均报告 `QEMU emulator version 11.1.1`
- `cargo xtask arceos test qemu --arch x86_64`：Rust 2/2，C 1/1
- `cargo xtask arceos test qemu --arch riscv64`：Rust 2/2，C 1/1
- `cargo xtask arceos test qemu --arch aarch64`：Rust 2/2，C 1/1
- `cargo xtask arceos test qemu --arch loongarch64`：Rust 2/2，C 1/1，LoongArch unaligned-fixup 1/1
- 修改的 Shell 脚本全部通过 `bash -n`
- `git diff --check` 通过