### PR TITLE
fix(axloader): preserve serial control input order

### DIFF
--- a/bootloader/axloader/src/control_input.rs
+++ b/bootloader/axloader/src/control_input.rs
@@ -1,0 +1,63 @@
+/// Reads the next control byte from the firmware-staged input or raw serial input.
+///
+/// UEFI's terminal driver can move bytes from the serial device into its own input
+/// queue asynchronously. Bytes already staged by the firmware therefore precede
+/// bytes that remain available from the raw serial device.
+pub(crate) fn next_serial_control_byte(
+    firmware_input_available: bool,
+    mut firmware_input: impl FnMut() -> Option<u8>,
+    mut raw_serial_input: impl FnMut() -> Option<u8>,
+) -> Option<u8> {
+    if firmware_input_available {
+        firmware_input().or_else(&mut raw_serial_input)
+    } else {
+        raw_serial_input()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::VecDeque;
+
+    use super::next_serial_control_byte;
+
+    #[test]
+    fn drains_firmware_staged_bytes_before_raw_serial_bytes() {
+        let mut firmware_input = VecDeque::from(*b"older");
+        let mut raw_serial_input = VecDeque::from(*b"newer");
+        let mut received = Vec::new();
+
+        while !firmware_input.is_empty() || !raw_serial_input.is_empty() {
+            received.push(
+                next_serial_control_byte(
+                    true,
+                    || firmware_input.pop_front(),
+                    || raw_serial_input.pop_front(),
+                )
+                .unwrap(),
+            );
+        }
+
+        assert_eq!(received, b"oldernewer");
+    }
+
+    #[test]
+    fn falls_back_to_raw_serial_when_firmware_has_no_byte() {
+        assert_eq!(
+            next_serial_control_byte(true, || None, || Some(b'x')),
+            Some(b'x')
+        );
+    }
+
+    #[test]
+    fn skips_firmware_reader_when_firmware_input_is_unavailable() {
+        assert_eq!(
+            next_serial_control_byte(
+                false,
+                || panic!("unavailable firmware input must not be read"),
+                || Some(b'x'),
+            ),
+            Some(b'x')
+        );
+    }
+}

--- a/bootloader/axloader/src/lib.rs
+++ b/bootloader/axloader/src/lib.rs
@@ -1,5 +1,8 @@
 #![cfg_attr(not(any(windows, unix)), no_std)]
 
+#[cfg(test)]
+mod control_input;
+
 #[cfg(any(windows, unix))]
 pub mod elf_image;
 

--- a/bootloader/axloader/src/loader/console.rs
+++ b/bootloader/axloader/src/loader/console.rs
@@ -36,10 +36,26 @@ pub fn serial_println(args: fmt::Arguments<'_>) {
 }
 
 pub fn serial_read_byte() -> Option<u8> {
-    if let Some(byte) = read_serial_byte() {
-        return Some(byte);
-    }
+    crate::control_input::next_serial_control_byte(
+        firmware_input_available(),
+        read_firmware_byte,
+        read_serial_byte,
+    )
+}
 
+fn firmware_input_available() -> bool {
+    let Some(system_table) = uefi::table::system_table_raw() else {
+        return false;
+    };
+
+    // SAFETY: `uefi::entry` initializes this pointer from the firmware system
+    // table, which remains valid while boot services are active. We only read
+    // the stable protocol pointers before invoking either protocol.
+    let system_table = unsafe { system_table.as_ref() };
+    !system_table.boot_services.is_null() && !system_table.stdin.is_null()
+}
+
+fn read_firmware_byte() -> Option<u8> {
     uefi::system::with_stdin(|stdin| match stdin.read_key() {
         Ok(Some(Key::Printable(ch))) => {
             let ch = char::from(ch);

--- a/bootloader/axloader/src/main.rs
+++ b/bootloader/axloader/src/main.rs
@@ -4,6 +4,9 @@
 #[cfg(target_os = "uefi")]
 extern crate alloc;
 
+#[cfg(target_os = "uefi")]
+mod control_input;
+
 #[cfg(not(target_os = "uefi"))]
 fn main() {}
 


### PR DESCRIPTION
## 问题

[`AxVisor / UEFI x86_64 · AxLoader HTTP boot`](https://github.com/rcore-os/tgoskits/actions/runs/33835806225/job/100909118221) 在两次尝试中都没有发起 HTTP 请求。AxLoader 收到的 `AXLOADER BOOT` JSON 分别出现字段截断和重排，随后因无法取得有效 `kernel_url` 而等待到超时。

## 根因

AxLoader 同时从 UEFI `SimpleTextInput` 和底层 `SerialIo` 消费同一串口数据。OVMF 的终端驱动会异步把较早到达的串口字节搬入自己的输入队列；原实现却先读取仍留在裸串口中的字节，再回退到固件队列。两边同时有数据时，较新的裸串口字节会越过固件已经暂存的旧字节，导致一行控制帧被重排。这也解释了日志中间字段突然出现在行首、URL 尾部被其他字段覆盖的现象。

## 修改

- 控制输入优先消费 UEFI 已暂存的字节，仅当固件队列暂时为空时才回退到裸串口。
- 调用 `with_stdin` 前检查系统表中的 boot services 和 stdin 指针；固件未提供 stdin 时保持原有 raw serial fallback，不引入 panic。
- 新增确定性顺序测试，模拟固件队列持有 `older`、裸串口持有 `newer` 的场景，并覆盖固件队列为空和 stdin 不可用的回退路径。

修复没有增加 sleep、重试次数或放宽成功条件。

## 回归证据

在旧读取顺序下，新测试稳定失败：实际得到 `newerolder`，期望 `oldernewer`。调整读取所有权顺序后，同一测试通过。

## 验证

- `cargo fmt --check`
- `cargo xtask clippy --package axloader`
- `cargo xtask axloader test qemu --target x86_64-unknown-uefi`
  - 9 个宿主单元测试通过
  - UEFI 目标检查与 release 构建通过
  - QEMU 第 1 次尝试即完成控制帧解析、HTTP 下载和 ELF 装载
