### PR TITLE
fix(starry-kernel): align KMS queries and dma-buf seek with Linux

### DIFF
--- a/os/StarryOS/kernel/src/file/mod.rs
+++ b/os/StarryOS/kernel/src/file/mod.rs
@@ -169,6 +169,16 @@ pub type IoSrc<'a> = dyn ReadBuf + 'a;
 
 #[allow(dead_code)]
 pub trait FileLike: Pollable + DowncastSync {
+    /// Size in bytes reported for `lseek(SEEK_END)` on seekable pseudo-files
+    /// such as dma-buf fds. `None` keeps the historical `ESPIPE` behavior.
+    ///
+    /// Mesa/gbm probe a dma-buf's size with `lseek(fd, 0, SEEK_END)` before
+    /// importing it as an EGLImage; without this hook those imports fail
+    /// with `EGL_BAD_ALLOC`.
+    fn seekable_size(&self) -> Option<u64> {
+        None
+    }
+
     /// Validate a scalar write length before importing the user buffer.
     ///
     /// File types with count errors that take precedence over `EFAULT` can

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -66,7 +66,8 @@ use super::drm::{
     DRM_IOCTL_SET_VERSION, DRM_IOCTL_VERSION, DRM_IOCTL_WAIT_VBLANK, DRM_MODE_ATOMIC_ALLOW_MODESET,
     DRM_MODE_ATOMIC_NONBLOCK, DRM_MODE_ATOMIC_TEST_ONLY, DRM_MODE_CONNECTED,
     DRM_MODE_CONNECTOR_VIRTUAL, DRM_MODE_ENCODER_VIRTUAL, DRM_MODE_FB_MODIFIERS,
-    DRM_MODE_OBJECT_CONNECTOR, DRM_MODE_OBJECT_CRTC, DRM_MODE_OBJECT_PLANE,
+    DRM_MODE_OBJECT_BLOB, DRM_MODE_OBJECT_CONNECTOR, DRM_MODE_OBJECT_CRTC,
+    DRM_MODE_OBJECT_FB, DRM_MODE_OBJECT_PLANE,
     DRM_MODE_PAGE_FLIP_EVENT, DRM_MODE_PROP_ATOMIC, DRM_MODE_PROP_BLOB, DRM_MODE_PROP_ENUM,
     DRM_MODE_PROP_IMMUTABLE, DRM_MODE_PROP_OBJECT, DRM_MODE_PROP_RANGE, DRM_PLANE_TYPE_PRIMARY,
     DRM_PRIME_CAP_EXPORT, DRM_PRIME_CAP_IMPORT, DRM_PROP_NAME_LEN, DrmAuth, DrmEvent,
@@ -249,6 +250,10 @@ struct DmaBufGem {
 impl FileLike for DmaBufGem {
     fn path(&self) -> Cow<'_, str> {
         "anon_inode:dmabuf".into()
+    }
+
+    fn seekable_size(&self) -> Option<u64> {
+        Some(self.size)
     }
 
     fn device_mmap(&self, offset: u64, length: u64) -> StarryResult<DeviceMmap> {
@@ -600,7 +605,7 @@ impl DeviceOps for Card0 {
             DRM_IOCTL_MODE_DESTROY_DUMB => self.handle_destroy_dumb(arg),
 
             DRM_IOCTL_MODE_GETPLANERESOURCES => handle_get_plane_resources(arg),
-            DRM_IOCTL_MODE_GETPLANE => handle_get_plane(arg),
+            DRM_IOCTL_MODE_GETPLANE => handle_get_plane(self, arg),
             DRM_IOCTL_MODE_OBJ_GETPROPERTIES => self.handle_obj_get_properties(arg),
             DRM_IOCTL_MODE_GETPROPERTY => handle_get_property(arg),
             DRM_IOCTL_MODE_PAGE_FLIP => self.handle_page_flip(arg),
@@ -1235,14 +1240,22 @@ fn handle_get_plane_resources(arg: usize) -> VfsResult<usize> {
     Ok(0)
 }
 
-fn handle_get_plane(arg: usize) -> VfsResult<usize> {
+fn handle_get_plane(card: &Card0, arg: usize) -> VfsResult<usize> {
     let ptr = arg as *mut DrmModeGetPlane;
     let mut p: DrmModeGetPlane = ptr.vm_read().map_err(|_| VfsError::BadAddress)?;
     if p.plane_id != PLANE_ID {
         return Err(VfsError::InvalidInput);
     }
-    p.crtc_id = CRTC_ID;
-    p.fb_id = 0;
+    // Report the live atomic state: compositors (deniald) verify an atomic
+    // commit by reading GETPLANE back and checking the primary plane really
+    // is scanning out the committed framebuffer.
+    let state = *card.state.lock();
+    p.fb_id = state.plane_fb_id;
+    p.crtc_id = if state.plane_fb_id != 0 {
+        state.plane_crtc_id
+    } else {
+        0
+    };
     p.possible_crtcs = 1;
     p.gamma_size = 0;
     p.count_format_types =
@@ -1264,6 +1277,15 @@ impl Card0 {
             }
             (DRM_MODE_OBJECT_CRTC, CRTC_ID) => (CRTC_PROPS, crtc_prop_values(&state)),
             (DRM_MODE_OBJECT_CONNECTOR, CONNECTOR_ID) => (CONN_PROPS, conn_prop_values(&state)),
+            // smithay's atomic backend snapshots properties for framebuffers
+            // as well. Valid objects without properties report an empty list
+            // (count 0), not ENOENT, matching Linux.
+            (DRM_MODE_OBJECT_FB, fb_id) => {
+                if !self.fbs.lock().contains_key(&fb_id) {
+                    return Err(VfsError::NotFound);
+                }
+                (&[], Vec::new())
+            }
             _ => return Err(VfsError::NotFound),
         };
         report_user_array(q.props_ptr, q.count_props, prop_ids)?;
@@ -1371,8 +1393,17 @@ fn handle_get_property(arg: usize) -> VfsResult<usize> {
             g.count_values = report_user_array(g.values_ptr, g.count_values, &limits)?;
             g.count_enum_blobs = 0;
         }
-        PropKind::Object | PropKind::Blob => {
-            g.count_values = 0;
+        // Linux returns values[0] == DRM_MODE_OBJECT_* for OBJECT
+        // properties and values[0] == DRM_MODE_OBJECT_BLOB for BLOB
+        // properties; drm-rs indexes values[0] unconditionally.
+        PropKind::Object(object_type) => {
+            let values = [object_type as u64];
+            g.count_values = report_user_array(g.values_ptr, g.count_values, &values)?;
+            g.count_enum_blobs = 0;
+        }
+        PropKind::Blob => {
+            let values = [DRM_MODE_OBJECT_BLOB as u64];
+            g.count_values = report_user_array(g.values_ptr, g.count_values, &values)?;
             g.count_enum_blobs = 0;
         }
     }
@@ -1389,7 +1420,7 @@ struct PropMeta {
 enum PropKind {
     Enum(&'static [DrmModePropertyEnum]),
     RangeU64 { min: u64, max: u64 },
-    Object,
+    Object(u32),
     Blob,
 }
 
@@ -1427,12 +1458,12 @@ fn property_meta(id: u32) -> Option<PropMeta> {
         PROP_PLANE_FB_ID => PropMeta {
             name: "FB_ID",
             flags: DRM_MODE_PROP_OBJECT | atomic,
-            kind: PropKind::Object,
+            kind: PropKind::Object(DRM_MODE_OBJECT_FB),
         },
         PROP_PLANE_CRTC_ID => PropMeta {
             name: "CRTC_ID",
             flags: DRM_MODE_PROP_OBJECT | atomic,
-            kind: PropKind::Object,
+            kind: PropKind::Object(DRM_MODE_OBJECT_CRTC),
         },
         PROP_PLANE_SRC_X => range_u32("SRC_X", atomic),
         PROP_PLANE_SRC_Y => range_u32("SRC_Y", atomic),
@@ -1462,7 +1493,7 @@ fn property_meta(id: u32) -> Option<PropMeta> {
         PROP_CONN_CRTC_ID => PropMeta {
             name: "CRTC_ID",
             flags: DRM_MODE_PROP_OBJECT | atomic,
-            kind: PropKind::Object,
+            kind: PropKind::Object(DRM_MODE_OBJECT_CRTC),
         },
         _ => return None,
     };

--- a/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/card0.rs
@@ -69,7 +69,8 @@ use super::drm::{
     DRM_MODE_OBJECT_BLOB, DRM_MODE_OBJECT_CONNECTOR, DRM_MODE_OBJECT_CRTC,
     DRM_MODE_OBJECT_FB, DRM_MODE_OBJECT_PLANE,
     DRM_MODE_PAGE_FLIP_EVENT, DRM_MODE_PROP_ATOMIC, DRM_MODE_PROP_BLOB, DRM_MODE_PROP_ENUM,
-    DRM_MODE_PROP_IMMUTABLE, DRM_MODE_PROP_OBJECT, DRM_MODE_PROP_RANGE, DRM_PLANE_TYPE_PRIMARY,
+    DRM_MODE_PROP_IMMUTABLE, DRM_MODE_PROP_OBJECT, DRM_MODE_PROP_RANGE,
+    DRM_MODE_PROP_SIGNED_RANGE, DRM_PLANE_TYPE_PRIMARY,
     DRM_PRIME_CAP_EXPORT, DRM_PRIME_CAP_IMPORT, DRM_PROP_NAME_LEN, DrmAuth, DrmEvent,
     DrmEventVblank, DrmGetCap, DrmModeAtomic, DrmModeCardRes, DrmModeCreateBlob, DrmModeCreateDumb,
     DrmModeCrtc, DrmModeCrtcPageFlip, DrmModeDestroyBlob, DrmModeDestroyDumb, DrmModeDirtyFB,
@@ -130,6 +131,12 @@ const PROP_PLANE_CRTC_H: u32 = 0x10A;
 /// `IN_FORMATS` — immutable blob property advertising the (format,
 /// modifier) tuples this plane accepts.
 const PROP_PLANE_IN_FORMATS: u32 = 0x10B;
+/// `IN_FENCE_FD` — signed-range fence-fd property on every plane. The
+/// emulation presents synchronously, so the fence carries no timing
+/// information; advertising it keeps strict-fencing compositors (denial
+/// requires it on the primary plane) functional. Commits consume the fd
+/// like Linux so strict-fencing clients do not leak one fd per frame.
+const PROP_PLANE_IN_FENCE_FD: u32 = 0x10C;
 
 const PROP_CRTC_ACTIVE: u32 = 0x200;
 const PROP_CRTC_MODE_ID: u32 = 0x201;
@@ -149,6 +156,7 @@ const PLANE_PROPS: &[u32] = &[
     PROP_PLANE_CRTC_W,
     PROP_PLANE_CRTC_H,
     PROP_PLANE_IN_FORMATS,
+    PROP_PLANE_IN_FENCE_FD,
 ];
 const CRTC_PROPS: &[u32] = &[PROP_CRTC_ACTIVE, PROP_CRTC_MODE_ID];
 const CONN_PROPS: &[u32] = &[PROP_CONN_CRTC_ID];
@@ -1310,6 +1318,8 @@ fn plane_prop_values(s: &ModesetState, in_formats: u64) -> Vec<u64> {
         s.plane_crtc_w,
         s.plane_crtc_h,
         in_formats,
+        // No fence is ever pending outside a commit request.
+        u64::MAX,
     ]
 }
 
@@ -1478,6 +1488,16 @@ fn property_meta(id: u32) -> Option<PropMeta> {
             flags: DRM_MODE_PROP_BLOB | DRM_MODE_PROP_IMMUTABLE,
             kind: PropKind::Blob,
         },
+        PROP_PLANE_IN_FENCE_FD => PropMeta {
+            name: "IN_FENCE_FD",
+            // Linux declares this as a signed range [-1, INT_MAX] where -1
+            // (reported as u64::MAX) means "no fence".
+            flags: DRM_MODE_PROP_SIGNED_RANGE | atomic,
+            kind: PropKind::RangeU64 {
+                min: u64::MAX,
+                max: i32::MAX as u64,
+            },
+        },
         PROP_CRTC_ACTIVE => PropMeta {
             name: "ACTIVE",
             // weston's drm-backend specifically rejects ACTIVE if it
@@ -1509,6 +1529,18 @@ fn range_u32(name: &'static str, atomic: u32) -> PropMeta {
             max: u32::MAX as u64,
         },
     }
+}
+
+/// Per-commit side effects collected by `apply_prop`. Both fields are
+/// published only after the whole batch validates so a TEST_ONLY commit
+/// or a later property error leaves committed state untouched.
+#[derive(Default)]
+struct CommitEffects {
+    /// Outer Option: "the commit assigned MODE_ID at least once".
+    /// Inner Option: the resolved Arc (None means clearing MODE_ID to 0).
+    new_mode_blob: Option<Option<Arc<Vec<u8>>>>,
+    /// IN_FENCE_FD user fd to consume after a successful real commit.
+    pending_fence_close: Option<i32>,
 }
 
 impl Card0 {
@@ -1634,12 +1666,7 @@ impl Card0 {
 
         let mut state = self.state.lock();
         let mut proposed = *state;
-        // Outer Option: "the commit assigned MODE_ID at least once".
-        // Inner Option: the resolved Arc (None means clearing MODE_ID to 0).
-        // Only published into `mode_id_blob_ref` after the whole batch
-        // validates so a TEST_ONLY commit or a later property error
-        // leaves the committed mode blob ref untouched.
-        let mut new_mode_blob: Option<Option<Arc<Vec<u8>>>> = None;
+        let mut effects = CommitEffects::default();
         let mut idx = 0;
         for (obj_i, &obj_id) in objs.iter().enumerate() {
             let obj_type = object_type_of(obj_id).ok_or(VfsError::NotFound)?;
@@ -1653,7 +1680,7 @@ impl Card0 {
                     prop_id,
                     value,
                     &mut proposed,
-                    &mut new_mode_blob,
+                    &mut effects,
                 )? {
                     return Err(VfsError::InvalidInput);
                 }
@@ -1661,13 +1688,19 @@ impl Card0 {
         }
 
         if a.flags & DRM_MODE_ATOMIC_TEST_ONLY != 0 {
+            // TEST_ONLY never consumes the fence fd.
             return Ok(0);
+        }
+        if let Some(fd) = effects.pending_fence_close {
+            // Linux takes ownership of IN_FENCE_FD on a real commit; the
+            // emulation has no use for the fence, so just close it.
+            let _ = crate::file::close_file_like(fd);
         }
 
         let current_fb = proposed.plane_fb_id;
         *state = proposed;
         drop(state);
-        if let Some(new_ref) = new_mode_blob {
+        if let Some(new_ref) = effects.new_mode_blob {
             *self.mode_id_blob_ref.lock() = new_ref;
         }
         if current_fb != 0 {
@@ -1689,7 +1722,7 @@ impl Card0 {
         prop_id: u32,
         value: u64,
         s: &mut ModesetState,
-        new_mode_blob: &mut Option<Option<Arc<Vec<u8>>>>,
+        effects: &mut CommitEffects,
     ) -> VfsResult<bool> {
         match (obj_type, prop_id) {
             (DRM_MODE_OBJECT_PLANE, PROP_PLANE_TYPE) => {
@@ -1724,6 +1757,20 @@ impl Card0 {
             }
             (DRM_MODE_OBJECT_PLANE, PROP_PLANE_CRTC_W) => s.plane_crtc_w = value,
             (DRM_MODE_OBJECT_PLANE, PROP_PLANE_CRTC_H) => s.plane_crtc_h = value,
+            (DRM_MODE_OBJECT_PLANE, PROP_PLANE_IN_FENCE_FD) => {
+                // [-1, INT_MAX] signed range; -1 (u64::MAX) means "no
+                // fence". A real commit consumes the fd like Linux, but a
+                // TEST_ONLY commit or a failed batch must leave it intact,
+                // so the close is deferred to the commit path.
+                if value == u64::MAX {
+                    return Ok(true);
+                }
+                let fd = i64::try_from(value).map_err(|_| VfsError::InvalidInput)?;
+                if fd < 0 || fd > i32::MAX as i64 {
+                    return Err(VfsError::InvalidInput);
+                }
+                effects.pending_fence_close = Some(fd as i32);
+            }
             (DRM_MODE_OBJECT_CRTC, PROP_CRTC_ACTIVE) => {
                 if value > 1 {
                     return Err(VfsError::InvalidInput);
@@ -1752,7 +1799,7 @@ impl Card0 {
                     Some(arc.ok_or(VfsError::InvalidInput)?)
                 };
                 s.crtc_mode_id = blob;
-                *new_mode_blob = Some(arc);
+                effects.new_mode_blob = Some(arc);
             }
             (DRM_MODE_OBJECT_CONNECTOR, PROP_CONN_CRTC_ID) => {
                 let c = value as u32;

--- a/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
@@ -447,6 +447,7 @@ pub const DRM_MODE_PROP_IMMUTABLE: u32 = 1 << 2;
 pub const DRM_MODE_PROP_ENUM: u32 = 1 << 3;
 pub const DRM_MODE_PROP_BLOB: u32 = 1 << 4;
 pub const DRM_MODE_PROP_OBJECT: u32 = 1 << 6;
+pub const DRM_MODE_PROP_SIGNED_RANGE: u32 = 1 << 7;
 pub const DRM_MODE_PROP_ATOMIC: u32 = 0x8000_0000;
 
 /// `DRM_PROP_NAME_LEN` from Linux uapi.

--- a/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/drm.rs
@@ -406,8 +406,8 @@ pub struct DrmModeGetPlaneRes {
 #[derive(Debug, Default, Clone, Copy, AnyBitPattern)]
 pub struct DrmModeGetPlane {
     pub plane_id: u32,
-    pub crtc_id: u32,
     pub fb_id: u32,
+    pub crtc_id: u32,
     pub possible_crtcs: u32,
     pub gamma_size: u32,
     pub count_format_types: u32,
@@ -415,12 +415,16 @@ pub struct DrmModeGetPlane {
     pub format_type_ptr: u64,
 }
 
-/// `DRM_MODE_OBJECT_*` — type tags for `OBJ_GETPROPERTIES` and atomic
-/// commits.  Values match Linux's uapi exactly; weston/modetest pattern-
-/// match on them.
+/// `DRM_MODE_OBJECT_*` — type tags for `OBJ_GETPROPERTIES`, atomic commits,
+/// and `GETPROPERTY` value payloads.  Values match the drm-rs/drm-sys
+/// consumer constants exactly (CRTC/ENCODER differ from Linux's uapi);
+/// weston/modetest pattern-match on them, and drm-rs maps `GETPROPERTY`
+/// `values[0]` for OBJECT-typed properties against these constants.
 pub const DRM_MODE_OBJECT_CRTC: u32 = 0xcccc_cccc;
 pub const DRM_MODE_OBJECT_CONNECTOR: u32 = 0xc0c0_c0c0;
 pub const DRM_MODE_OBJECT_PLANE: u32 = 0xeeee_eeee;
+pub const DRM_MODE_OBJECT_FB: u32 = 0xfbfb_fbfb;
+pub const DRM_MODE_OBJECT_BLOB: u32 = 0xbbbb_bbbb;
 
 pub const DRM_PLANE_TYPE_PRIMARY: u64 = 1;
 

--- a/os/StarryOS/kernel/src/syscall/fs/io.rs
+++ b/os/StarryOS/kernel/src/syscall/fs/io.rs
@@ -173,7 +173,7 @@ pub fn sys_lseek(fd: c_int, offset: __kernel_off_t, whence: c_int) -> StarryResu
         return Ok(mq.seek_status(pos)? as _);
     }
 
-    if let Ok(d) = any_file.downcast_arc::<Directory>() {
+    if let Ok(d) = any_file.clone().downcast_arc::<Directory>() {
         let mut position = d.position.lock();
         let new_pos = match pos {
             SeekFrom::Start(pos) => pos,
@@ -194,6 +194,24 @@ pub fn sys_lseek(fd: c_int, offset: __kernel_off_t, whence: c_int) -> StarryResu
         }
         position.cursor = DirectoryCursor::new(new_pos);
         position.read_state = None;
+        return Ok(new_pos as _);
+    }
+
+    // Seekable pseudo-files (dma-buf fds): Mesa/gbm probes the buffer size
+    // with lseek(fd, 0, SEEK_END) before EGLImage import. These fds keep no
+    // cursor, so SEEK_CUR is anchored at 0 like SEEK_END is at the size.
+    if let Some(size) = any_file.clone().seekable_size() {
+        let new_pos: u64 = match pos {
+            SeekFrom::Start(o) => o,
+            SeekFrom::End(d) => {
+                let abs = size as i128 + d as i128;
+                if abs < 0 {
+                    return Err(StarryError::InvalidInput);
+                }
+                u64::try_from(abs).map_err(|_| StarryError::InvalidInput)?
+            }
+            SeekFrom::Current(d) => u64::try_from(d).map_err(|_| StarryError::InvalidInput)?,
+        };
         return Ok(new_pos as _);
     }
 

--- a/test-suit/starryos/qemu/system/drm-test-drm-atomic/src/main.c
+++ b/test-suit/starryos/qemu/system/drm-test-drm-atomic/src/main.c
@@ -94,6 +94,8 @@ struct drm_event_vblank {
 #define DRM_IOCTL_SET_CLIENT_CAP          _IOW('d', 0x0d, struct drm_set_client_cap)
 
 #define DRM_MODE_OBJECT_CRTC        0xcccccccc
+#define DRM_MODE_OBJECT_FB          0xfbfbfbfb
+#define DRM_MODE_OBJECT_BLOB        0xbbbbbbbb
 #define DRM_MODE_OBJECT_CONNECTOR   0xc0c0c0c0
 #define DRM_MODE_OBJECT_PLANE       0xeeeeeeee
 #define DRM_MODE_ATOMIC_TEST_ONLY   0x0100
@@ -237,6 +239,77 @@ int main(void)
         CHECK(vals[0] == 0 && vals[1] == 1, "CRTC.ACTIVE range == [0, 1]");
     }
 
+    /* OBJECT 属性必须返回 count_values==1 且 values[0] 为对象类型。
+     * drm-rs / libdrm 在此直接索引 values[0]；返回空值列表会让
+     * smithay/合成器在枚举属性时越界崩溃。 */
+    {
+        struct drm_mode_get_property gp = {0};
+        uint64_t vals[2] = {0};
+        gp.prop_id = P_CONN_CRTC_ID;
+        gp.values_ptr = (uint64_t)(uintptr_t)vals;
+        gp.count_values = 2;
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_GETPROPERTY, &gp), 0,
+                  "GETPROPERTY connector.CRTC_ID");
+        CHECK(gp.count_values == 1, "CRTC_ID exposes exactly one value");
+        CHECK(vals[0] == DRM_MODE_OBJECT_CRTC,
+              "CRTC_ID value type == DRM_MODE_OBJECT_CRTC");
+    }
+    {
+        struct drm_mode_get_property gp = {0};
+        uint64_t vals[2] = {0};
+        gp.prop_id = P_PLANE_FB_ID;
+        gp.values_ptr = (uint64_t)(uintptr_t)vals;
+        gp.count_values = 2;
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_GETPROPERTY, &gp), 0,
+                  "GETPROPERTY plane.FB_ID");
+        CHECK(gp.count_values == 1, "FB_ID exposes exactly one value");
+        CHECK(vals[0] == DRM_MODE_OBJECT_FB,
+              "FB_ID value type == DRM_MODE_OBJECT_FB");
+    }
+    {
+        struct drm_mode_get_property gp = {0};
+        uint64_t vals[2] = {0};
+        gp.prop_id = P_CRTC_MODE_ID;
+        gp.values_ptr = (uint64_t)(uintptr_t)vals;
+        gp.count_values = 2;
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_GETPROPERTY, &gp), 0,
+                  "GETPROPERTY crtc.MODE_ID");
+        CHECK(gp.count_values == 1, "MODE_ID exposes exactly one value");
+        CHECK(vals[0] == DRM_MODE_OBJECT_BLOB,
+              "MODE_ID value type == DRM_MODE_OBJECT_BLOB");
+    }
+
+    /* smithay 的 atomic 后端会对 framebuffer 也快照属性。合法对象没有
+     * 属性时必须返回空列表（count_props==0），而不是 ENOENT。 */
+    {
+        uint32_t ids[8] = {0};
+        uint64_t vals[8] = {0};
+        struct drm_mode_obj_get_properties q = {0};
+        q.obj_id = fb.fb_id;
+        q.obj_type = DRM_MODE_OBJECT_FB;
+        q.count_props = 8;
+        q.props_ptr = (uint64_t)(uintptr_t)ids;
+        q.prop_values_ptr = (uint64_t)(uintptr_t)vals;
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_OBJ_GETPROPERTIES, &q), 0,
+                  "OBJ_GETPROPERTIES framebuffer");
+        CHECK(q.count_props == 0, "framebuffer has empty property list");
+    }
+
+    /* PRIME 导出的 dma-buf 必须支持 lseek(SEEK_END) 返回缓冲大小。
+     * Mesa/gbm 在 dmabuf 导入时用 lseek 探测大小，ESPIPE 会让
+     * eglCreateImageKHR 以 BAD_ALLOC 失败（llvmpipe/swrast 路径）。 */
+    {
+        struct drm_prime_handle { uint32_t handle; uint32_t flags; int32_t fd; };
+#define DRM_IOCTL_PRIME_HANDLE_TO_FD _IOWR('d', 0x2d, struct drm_prime_handle)
+        struct drm_prime_handle ph = { .handle = cd.handle, .flags = 0x80000 };
+        CHECK_RET(ioctl(fd, DRM_IOCTL_PRIME_HANDLE_TO_FD, &ph), 0,
+                  "PRIME_HANDLE_TO_FD");
+        CHECK(ph.fd >= 0, "PRIME export returns an fd");
+        off_t sz = lseek(ph.fd, 0, SEEK_END);
+        CHECK(sz == (off_t)cd.size, "dmabuf lseek SEEK_END == buffer size");
+        close(ph.fd);
+    }
+
     /* --- blob round-trip --- */
     struct drm_mode_create_blob cb = {
         .data = (uint64_t)(uintptr_t)&modes[0],
@@ -308,6 +381,28 @@ int main(void)
     CHECK(obj_prop_value(fd, conns[0], DRM_MODE_OBJECT_CONNECTOR, P_CONN_CRTC_ID)
               == crtcs[0],
           "commit set connector.CRTC_ID");
+
+    /* GETPLANE（legacy 结构体）也必须回读 atomic 提交后的实时状态。
+     * deniald 的初始扫描验证提交后用 GETPLANE 检查 primary plane 是否
+     * 真的在扫描 framebuffer；硬编码 fb_id=0 会让合成器直接失败。 */
+    {
+        struct drm_mode_get_plane {
+            uint32_t plane_id;
+            uint32_t fb_id; uint32_t crtc_id; uint32_t crtcs_possible;
+            uint32_t gamma_size; uint32_t count_format_types;
+            uint64_t format_type_ptr;
+        };
+#define DRM_IOCTL_MODE_GETPLANE _IOWR('d', 0xB6, struct drm_mode_get_plane)
+        uint32_t fmts[8] = {0};
+        struct drm_mode_get_plane gp2 = {0};
+        gp2.plane_id = planes[0];
+        gp2.count_format_types = 8;
+        gp2.format_type_ptr = (uint64_t)(uintptr_t)fmts;
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_GETPLANE, &gp2), 0,
+                  "GETPLANE after atomic commit");
+        CHECK(gp2.fb_id == fb.fb_id, "GETPLANE reports committed fb_id");
+        CHECK(gp2.crtc_id == crtcs[0], "GETPLANE reports committed crtc_id");
+    }
 
     /* page flip event 应可读。 */
     struct pollfd pfd = { .fd = fd, .events = POLLIN };

--- a/test-suit/starryos/qemu/system/drm-test-drm-atomic/src/main.c
+++ b/test-suit/starryos/qemu/system/drm-test-drm-atomic/src/main.c
@@ -16,6 +16,7 @@
 
 #define _GNU_SOURCE
 #include "test_framework.h"
+#include <errno.h>
 #include <fcntl.h>
 #include <poll.h>
 #include <stdint.h>
@@ -100,6 +101,7 @@ struct drm_event_vblank {
 #define DRM_MODE_OBJECT_PLANE       0xeeeeeeee
 #define DRM_MODE_ATOMIC_TEST_ONLY   0x0100
 #define DRM_MODE_PAGE_FLIP_EVENT    0x01
+#define DRM_MODE_PROP_SIGNED_RANGE  (1u << 7)
 #define DRM_CLIENT_CAP_UNIVERSAL_PLANES 2
 #define DRM_CLIENT_CAP_ATOMIC       3
 #define DRM_FORMAT_XRGB8888         0x34325258
@@ -402,6 +404,81 @@ int main(void)
                   "GETPLANE after atomic commit");
         CHECK(gp2.fb_id == fb.fb_id, "GETPLANE reports committed fb_id");
         CHECK(gp2.crtc_id == crtcs[0], "GETPLANE reports committed crtc_id");
+    }
+
+    /* --- IN_FENCE_FD ---
+     * 严格 fence 的合成器（denial 要求 primary plane 必须广播）把它声明为
+     * 符号范围 [-1, INT_MAX]；真实提交要按 Linux 语义消费 fence fd，
+     * 否则逐帧 fence 的客户端会泄漏 fd。 */
+    uint32_t P_PLANE_IN_FENCE_FD = find_prop(fd, planes[0],
+                                             DRM_MODE_OBJECT_PLANE,
+                                             "IN_FENCE_FD");
+    CHECK(P_PLANE_IN_FENCE_FD != 0, "plane advertises IN_FENCE_FD");
+    {
+        struct drm_mode_get_property g = {0};
+        g.prop_id = P_PLANE_IN_FENCE_FD;
+        uint64_t vals[2] = {0};
+        g.count_values = 2;
+        g.values_ptr = (uint64_t)(uintptr_t)vals;
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_GETPROPERTY, &g), 0,
+                  "GETPROPERTY IN_FENCE_FD");
+        CHECK(g.flags & DRM_MODE_PROP_SIGNED_RANGE,
+              "IN_FENCE_FD is SIGNED_RANGE");
+        CHECK(g.count_values == 2, "IN_FENCE_FD reports two range values");
+        CHECK(vals[0] == (uint64_t)-1, "IN_FENCE_FD min == -1");
+        CHECK(vals[1] == 2147483647ULL, "IN_FENCE_FD max == INT_MAX");
+        CHECK(obj_prop_value(fd, planes[0], DRM_MODE_OBJECT_PLANE,
+                             P_PLANE_IN_FENCE_FD) == (uint64_t)-1,
+              "IN_FENCE_FD idle value == -1");
+    }
+    {
+        uint32_t t_objs[1] = { planes[0] };
+        uint32_t t_counts[1] = { 1 };
+        uint32_t t_props[1] = { P_PLANE_IN_FENCE_FD };
+        uint64_t t_values[1] = { (uint64_t)-1 };
+        struct drm_mode_atomic t = {
+            .flags = DRM_MODE_ATOMIC_TEST_ONLY,
+            .count_objs = 1,
+            .objs_ptr = (uint64_t)(uintptr_t)t_objs,
+            .count_props_ptr = (uint64_t)(uintptr_t)t_counts,
+            .props_ptr = (uint64_t)(uintptr_t)t_props,
+            .prop_values_ptr = (uint64_t)(uintptr_t)t_values,
+        };
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_ATOMIC, &t), 0,
+                  "TEST_ONLY IN_FENCE_FD=-1 accepted");
+        t_values[0] = (uint64_t)-2;
+        CHECK_ERR(ioctl(fd, DRM_IOCTL_MODE_ATOMIC, &t), EINVAL,
+                  "IN_FENCE_FD=-2 rejected");
+        /* TEST_ONLY 不消费真实 fd。 */
+        int probe = open("/dev/zero", O_RDONLY | O_CLOEXEC);
+        CHECK(probe >= 0, "open fence probe fd");
+        t_values[0] = (uint64_t)probe;
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_ATOMIC, &t), 0,
+                  "TEST_ONLY with real fd accepted");
+        CHECK(fcntl(probe, F_GETFD) != -1,
+              "TEST_ONLY did not consume the fence fd");
+        close(probe);
+    }
+    {
+        /* 真实提交消费 fence fd。 */
+        int fence = open("/dev/zero", O_RDONLY | O_CLOEXEC);
+        CHECK(fence >= 0, "open fence fd");
+        uint32_t r_objs[1] = { planes[0] };
+        uint32_t r_counts[1] = { 1 };
+        uint32_t r_props[1] = { P_PLANE_IN_FENCE_FD };
+        uint64_t r_values[1] = { (uint64_t)fence };
+        struct drm_mode_atomic r = {
+            .flags = 0,
+            .count_objs = 1,
+            .objs_ptr = (uint64_t)(uintptr_t)r_objs,
+            .count_props_ptr = (uint64_t)(uintptr_t)r_counts,
+            .props_ptr = (uint64_t)(uintptr_t)r_props,
+            .prop_values_ptr = (uint64_t)(uintptr_t)r_values,
+        };
+        CHECK_RET(ioctl(fd, DRM_IOCTL_MODE_ATOMIC, &r), 0,
+                  "commit with IN_FENCE_FD accepted");
+        CHECK(fcntl(fence, F_GETFD) == -1 && errno == EBADF,
+              "commit consumed the fence fd");
     }
 
     /* page flip event 应可读。 */


### PR DESCRIPTION
## 问题与修复

本 PR 修复 card0 的 KMS 查询及 PRIME 导出缓冲区大小探测，并按 Linux 源码纠正原补丁和 review 中的错误预期。分支已合并当前 `dev`，保留主线显式传入 `UserTaskRef` 的 ioctl/用户内存接口。

- `GETPLANE` 保持 Linux `plane_id, crtc_id, fb_id, ...` ABI；由 `Card0::handle_get_plane` 从同一 `ModesetState` 快照返回 CRTC 和 framebuffer，避免内核与测试共享错误布局。
- OBJECT 属性返回一个允许的对象类型值；BLOB 属性不返回对象类型值，`count_values` 和 `count_enum_blobs` 都为 0。CRTC 类型常量本身与 Linux 一致，删除原正文中“消费方常量不同于 UAPI”的错误说明。
- framebuffer 的 `OBJ_GETPROPERTIES` 区分两条 Linux 错误路径：已存在但没有属性容器返回 `EINVAL`，未知 framebuffer 返回 `ENOENT`；删除原补丁伪造成功空列表的行为。
- 删除 `seekable_size` 及 `sys_lseek` 中拼接 dma-buf 偏移的逻辑。`FileLike::seek` 默认返回 `ESPIPE`，`DmaBufGem::seek` 自行实现 Linux dma-buf 规则：仅 `SEEK_SET(0)` 返回 0、`SEEK_END(0)` 返回大小，其余返回 `EINVAL`。已有普通文件、memfd、目录和消息队列分派保持原有路径。
- 删除提交后的 fence fd 关闭副作用。Linux 的 `sync_file_get_fence` 取得 fence 引用，再释放临时 file 引用；它从不关闭调用方 fd。当前 Starry 没有 sync-file 生产者或 fence 等待实现，因此 `IN_FENCE_FD` 仅接受 `-1`；普通文件、socket、card fd、关闭的 fd 及其他非 sentinel 输入均返回 `EINVAL`。TEST_ONLY 和真实失败提交都不改变 fd 表，也不发布前面的候选属性。

## 分层与范围

seek 的行为由文件对象拥有，系统调用层只解析参数和分派；DRM 元数据、对象校验和 atomic 候选状态留在 Starry 的既有设备适配层。没有在通用运行时或驱动层加入进程 fd 操作，也没有为当前不存在的 sync-file 增加占位子系统。原 `CommitEffects` 的 fd 副作用已删除，MODE_ID 继续使用主线已有的暂存引用逻辑。

这里修复的是可观察 ABI、无 fence 提交和非法 fence 拒绝，**不宣称支持真实显式 fence 同步**。依赖真实 sync-file 的合成器仍需要后续完整的 fence 生命周期与等待实现；原先把 `/dev/zero` 当成 fence 并期待内核关闭的测试不能证明该能力。未重跑 denial/EGL/实体板工作负载，也不沿用旧正文中的运行结果作为本次证明。

## Linux 对照

基准为本地 `/home/zhourui/linux-src` 的 `8cd9520d35a6c38db6567e97dd93b1f11f185dc6`。

- [GETPLANE ABI 与对象类型](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/include/uapi/drm/drm_mode.h#L322)
- [OBJECT 属性元数据与 GETPROPERTY](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_property.c#L315)
- [BLOB 与 IN_FENCE_FD 属性定义](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_mode_config.c#L304)
- [framebuffer 属性查询检查](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_mode_object.c#L478)
- [atomic fence 引用取得](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_atomic_uapi.c#L550)、[sync_file 类型校验与引用释放](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/dma-buf/sync_file.c#L79)
- [dma_buf_llseek](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/dma-buf/dma-buf.c#L251)

## 验证

- `cargo fmt`、`cargo fmt -p starry-kernel`；对 `include!("root.rs")` 下本次涉及的四个 Rust 文件补充使用固定工具链 `rustfmt --edition 2024 --config skip_children=true --check`，通过。
- `git diff --check`，通过。
- `cargo xtask clippy --package starry-kernel`：92/92 checks 通过，0 failed。
- `cargo xtask test --since origin/dev`：最终提交的 starry-kernel 标准库测试全部通过。
- `cargo xtask starry test qemu --arch <arch> -c qemu/system/drm-test-drm-atomic`：`aarch64`、`x86_64`、`riscv64`、`loongarch64` 均为 `result: 1/1 case(s) passed`，用例由分组运行器真实发现、构建、执行并输出 `STARRY_SYSTEM_TEST_PASSED`。
- 确定性红绿：在仅合并主线、保留旧实现的内核上，修正预期的现有 DRM 用例稳定捕获 GETPLANE ID 交换、BLOB 错误载荷、非法 seek 接受、非法 fence 接受/关闭 fd/部分发布；补充 framebuffer 红测单独捕获“应 EINVAL 却成功”。两轮均以 `0/1` 和非零退出状态失败，修复后的最终用例四架构全绿。

范围说明：上述结论限定于本 PR 改动及定向回归。未执行全量 system 套件、实体板和 denial 端到端测试；远端 CI 以新 head 的实际运行结果为准。

## 系统调用兼容性对照

四架构定向回归均通过；下表只评价本次修改的行为。

架构缩写：A/R/L 分别为 AArch64、RISC-V64、LoongArch64；X 为 x86_64。范围限定为本 PR 修改的行为。

| 系统调用/编号 | Linux 基准与稳定链接 | Linux 可观察语义 | StarryOS 入口与调用链 | 实现结论 | 测试与证据 |
| --- | --- | --- | --- | --- | --- |
| ioctl(GETPLANE)：A/R/L 29，X 16 | [8cd9520d，drm_mode.h](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/include/uapi/drm/drm_mode.h#L322) | crtc_id 在 fb_id 前，返回已提交绑定 | sys_ioctl → File::ioctl → Card0::handle_get_plane → 设备 ModesetState 快照 | 正确 | atomic 提交后独立 C ABI 读回两个不同 ID |
| ioctl(GETPROPERTY/OBJECT)：A/R/L 29，X 16 | [8cd9520d，drm_property.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_property.c#L315) | 一个允许的对象类型值 | sys_ioctl → File::ioctl → Card0 ioctl → handle_get_property → PropKind::Object | 正确 | CRTC_ID/FB_ID metadata 断言 |
| ioctl(GETPROPERTY/BLOB)：A/R/L 29，X 16 | [8cd9520d，drm_mode_config.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_mode_config.c#L322) | 标准 BLOB 无 metadata values 或 enums | sys_ioctl → File::ioctl → Card0 ioctl → handle_get_property → PropKind::Blob | 正确 | 零数量及用户缓冲不改写；旧实现红测失败 |
| ioctl(OBJ_GETPROPERTIES/FB)：A/R/L 29，X 16 | [8cd9520d，drm_mode_object.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_mode_object.c#L478) | 无属性容器 EINVAL；未知对象 ENOENT | sys_ioctl → File::ioctl → Card0::handle_obj_get_properties → 设备 fbs 表 | 正确 | 两条错误路径；原空列表实现红测失败 |
| ioctl(GETPROPERTY/IN_FENCE_FD)：A/R/L 29，X 16 | [8cd9520d，drm_mode_config.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_mode_config.c#L304) | SIGNED_RANGE，范围 [-1, INT_MAX] | sys_ioctl → File::ioctl → handle_get_property → property_meta | 正确 | 属性发现、类型与范围断言 |
| ioctl(OBJ_GETPROPERTIES/IN_FENCE_FD)：A/R/L 29，X 16 | [8cd9520d，drm_atomic_uapi.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_atomic_uapi.c#L665) | IN_FENCE_FD 查询始终返回 -1 | sys_ioctl → File::ioctl → Card0::handle_obj_get_properties → plane_prop_values | 正确 | plane 属性发现与 -1 读回 |
| ioctl(ATOMIC/IN_FENCE_FD)：A/R/L 29，X 16 | [8cd9520d，drm_atomic_uapi.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/gpu/drm/drm_atomic_uapi.c#L550) | -1 无 fence；其他须有效 sync-file；不关闭用户 fd | sys_ioctl → File::ioctl → Card0::handle_atomic → apply_prop → 候选 ModesetState；不操作进程 fd 表 | 部分正确 | 无 fence 与非法 fd 拒绝、TEST_ONLY/失败回滚已验证；真实 sync-file 未实现 |
| lseek(dma-buf)：A/R/L 62，X 8 | [8cd9520d，dma-buf.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/drivers/dma-buf/dma-buf.c#L251) | dma-buf 仅 SET(0)/END(0)；非法偏移 EINVAL | sys_lseek → FileLike::seek → DmaBufGem::seek；缓冲大小由导出对象持有 | 正确 | PRIME 导出后直接 lseek；大小探测及非法偏移拒绝 |
| lseek(socket)：A/R/L 62，X 8 | [8cd9520d，read_write.c](https://github.com/torvalds/linux/blob/8cd9520d35a6c38db6567e97dd93b1f11f185dc6/fs/read_write.c#L387) | 非 seek 对象返回 ESPIPE | sys_lseek → FileLike::seek 默认实现；不改变 socket 状态 | 正确 | 四架构直接 socket lseek 拒绝回归 |


Refs #2283
