### PR TITLE
fix(jpeg): validate MPP DMA ranges against imported dma-bufs

### DIFF
--- a/drivers/ax-driver/src/jpeg.rs
+++ b/drivers/ax-driver/src/jpeg.rs
@@ -170,7 +170,7 @@ fn page_aligned_region(start_raw: usize, size_raw: usize) -> (usize, usize, usiz
 
 // --- Kernel-facing accessors for the /dev/mpp_service node (mirror rknpu) ---
 
-pub use rockchip_jpeg::{JpuError, mpp, registers};
+pub use rockchip_jpeg::{JpuError, mpp, mpp::ResolvedDmaBuf, registers};
 
 /// Errors surfaced to the `/dev/mpp_service` node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/drivers/vpu/rockchip-jpeg/src/command.rs
+++ b/drivers/vpu/rockchip-jpeg/src/command.rs
@@ -64,7 +64,7 @@ pub fn build_reg_array(info: &JpegInfo) -> [u32; registers::REG_COUNT] {
     let fill_down = info.yuv_mode == YuvMode::Yuv420 || info.fill_bottom;
     let mut reg2 = 0u32;
     if fill_down {
-        reg2 |= 1 << 24;
+        reg2 |= registers::SYS_FILL_DOWN;
     }
     if info.fill_right {
         reg2 |= 1 << 25;

--- a/drivers/vpu/rockchip-jpeg/src/mpp.rs
+++ b/drivers/vpu/rockchip-jpeg/src/mpp.rs
@@ -265,9 +265,11 @@ impl MppSession {
             registers::REG_STRM_BASE => {
                 let reg = self.regs[registers::REG_STRM_LEN];
                 let blocks = ((reg >> 4) & 0x0fff_ffff) as usize;
+                // The low nibble is consumed by the hardware as the byte
+                // position within the first block; it is not another byte
+                // in the DMA range.
                 (blocks + 1)
                     .checked_mul(16)
-                    .and_then(|length| length.checked_add((reg & 0xf) as usize))
                     .ok_or(MppError::AddressOverflow)
             }
             registers::REG_DEC_OUT_BASE => self.output_length(),
@@ -285,6 +287,8 @@ impl MppSession {
         }
 
         let mode = self.regs[registers::REG_PIC_FMT] & 0x7;
+        let vertical_subsampling =
+            matches!(mode, registers::JPEG_MODE_420 | registers::JPEG_MODE_440);
         let height_alignment = if sys & registers::SYS_FILL_DOWN != 0 {
             16
         } else {
@@ -306,12 +310,28 @@ impl MppSession {
             / height_alignment
             * height_alignment;
 
+        let width = (self.regs[registers::REG_PIC_SIZE] & 0xffff) as usize + 1;
+        let width_aligned = width.checked_add(15).ok_or(MppError::AddressOverflow)? / 16 * 16;
+        let minimum_y_stride_units = width_aligned / 16;
         let y_stride_units = (self.regs[registers::REG_HOR_VIRSTRIDE] & 0xffff) as usize
             | (((self.regs[registers::REG_TABLE_LEN] >> 24) & 1) as usize) << 16;
-        if y_stride_units == 0 {
+        if y_stride_units < minimum_y_stride_units {
             return Err(MppError::UnsupportedGeometry);
         }
         let uv_stride_units = (self.regs[registers::REG_HOR_VIRSTRIDE] >> 16) as usize;
+        let minimum_uv_stride_units = match mode {
+            registers::JPEG_MODE_400 => 0,
+            registers::JPEG_MODE_411 => (minimum_y_stride_units / 2).max(1),
+            registers::JPEG_MODE_420 | registers::JPEG_MODE_422 => minimum_y_stride_units,
+            registers::JPEG_MODE_440 | registers::JPEG_MODE_444 => minimum_y_stride_units
+                .checked_mul(2)
+                .ok_or(MppError::AddressOverflow)?,
+            _ => return Err(MppError::UnsupportedGeometry),
+        };
+        if uv_stride_units < minimum_uv_stride_units {
+            return Err(MppError::UnsupportedGeometry);
+        }
+
         let y_stride = y_stride_units
             .checked_mul(16)
             .ok_or(MppError::AddressOverflow)?;
@@ -324,12 +344,20 @@ impl MppSession {
         let y_virstride = ((self.regs[registers::REG_Y_VIRSTRIDE] >> 4) as usize)
             .checked_mul(16)
             .ok_or(MppError::AddressOverflow)?;
-        let y_size = y_rows.max(y_virstride);
+        if y_virstride < y_rows {
+            return Err(MppError::UnsupportedGeometry);
+        }
+        let y_size = y_virstride;
+        let chroma_height = if vertical_subsampling {
+            height / 2
+        } else {
+            height
+        };
         let uv_size = if mode == registers::JPEG_MODE_400 {
             0
         } else {
             uv_stride
-                .checked_mul(height)
+                .checked_mul(chroma_height)
                 .ok_or(MppError::AddressOverflow)?
         };
         y_size.checked_add(uv_size).ok_or(MppError::AddressOverflow)
@@ -585,7 +613,7 @@ mod tests {
     }
 
     #[test]
-    fn accepts_exact_output_allocation_size() {
+    fn accepts_exact_nv12_output_allocation_size() {
         let mut s = MppSession::new();
         let mut words = [0u32; REG_COUNT];
         words[registers::REG_DEC_OUT_BASE] = 11;
@@ -593,19 +621,138 @@ mod tests {
         words[registers::REG_PIC_SIZE] = 15 | (15 << 16);
         words[registers::REG_PIC_FMT] = registers::JPEG_MODE_420;
         words[registers::REG_HOR_VIRSTRIDE] = 1 | (1 << 16);
-        words[registers::REG_Y_VIRSTRIDE] = 32 << 4;
+        words[registers::REG_Y_VIRSTRIDE] = 16 << 4;
         s.set_reg_write(&words);
 
-        // 512 bytes of Y (the programmed Y virtual stride) plus 256 bytes of
-        // chroma is the exact legal end of this two-plane output allocation.
+        // 256 bytes of Y plus 128 bytes of 4:2:0 chroma is the exact legal end
+        // of this two-plane output allocation.
         s.resolve_addresses(|_| {
             Some(ResolvedDmaBuf {
                 address: 0x3000_0000,
-                size: 768,
+                size: 384,
             })
         })
         .unwrap();
         assert_eq!(s.regs()[registers::REG_DEC_OUT_BASE], 0x3000_0000);
+    }
+
+    #[test]
+    fn accepts_exact_nv12_output_allocation_size_for_440() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_DEC_OUT_BASE] = 11;
+        words[registers::REG_PIC_SIZE] = 15 | (7 << 16);
+        words[registers::REG_PIC_FMT] = registers::JPEG_MODE_440;
+        words[registers::REG_HOR_VIRSTRIDE] = 1 | (2 << 16);
+        words[registers::REG_Y_VIRSTRIDE] = 8 << 4;
+        s.set_reg_write(&words);
+
+        // 128 bytes of Y plus 128 bytes of 4:4:0 chroma is exact; its UV plane
+        // has half as many rows as the Y plane but twice its row stride.
+        s.resolve_addresses(|_| {
+            Some(ResolvedDmaBuf {
+                address: 0x3000_0000,
+                size: 256,
+            })
+        })
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_horizontal_stride_smaller_than_picture_width() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_DEC_OUT_BASE] = 11;
+        words[registers::REG_SYS] = registers::SYS_FILL_DOWN;
+        // 63 pixels require a 64-byte aligned Y row, but the client supplies
+        // only one 16-byte stride unit.
+        words[registers::REG_PIC_SIZE] = 62 | (15 << 16);
+        words[registers::REG_PIC_FMT] = registers::JPEG_MODE_420;
+        words[registers::REG_HOR_VIRSTRIDE] = 1 | (1 << 16);
+        words[registers::REG_Y_VIRSTRIDE] = 16 << 4;
+        s.set_reg_write(&words);
+
+        assert_eq!(
+            s.resolve_addresses(|_| {
+                Some(ResolvedDmaBuf {
+                    address: 0x3000_0000,
+                    size: 384,
+                })
+            }),
+            Err(MppError::UnsupportedGeometry)
+        );
+    }
+
+    #[test]
+    fn rejects_uv_stride_smaller_than_picture_width() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_DEC_OUT_BASE] = 11;
+        words[registers::REG_SYS] = registers::SYS_FILL_DOWN;
+        words[registers::REG_PIC_SIZE] = 31 | (15 << 16);
+        words[registers::REG_PIC_FMT] = registers::JPEG_MODE_420;
+        // Y has the required 32-byte stride, while NV12 UV has only 16 bytes.
+        words[registers::REG_HOR_VIRSTRIDE] = 2;
+        words[registers::REG_Y_VIRSTRIDE] = 32 << 4;
+        s.set_reg_write(&words);
+
+        assert_eq!(
+            s.resolve_addresses(|_| {
+                Some(ResolvedDmaBuf {
+                    address: 0x3000_0000,
+                    size: 768,
+                })
+            }),
+            Err(MppError::UnsupportedGeometry)
+        );
+    }
+
+    #[test]
+    fn rejects_y_virtual_stride_smaller_than_y_plane() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_DEC_OUT_BASE] = 11;
+        words[registers::REG_SYS] = registers::SYS_FILL_DOWN;
+        words[registers::REG_PIC_SIZE] = 15 | (15 << 16);
+        words[registers::REG_PIC_FMT] = registers::JPEG_MODE_420;
+        words[registers::REG_HOR_VIRSTRIDE] = 1 | (1 << 16);
+        // Y needs 16 * 16 = 256 bytes, but the virtual stride is only 240.
+        words[registers::REG_Y_VIRSTRIDE] = 15 << 4;
+        s.set_reg_write(&words);
+
+        assert_eq!(
+            s.resolve_addresses(|_| {
+                Some(ResolvedDmaBuf {
+                    address: 0x3000_0000,
+                    size: 384,
+                })
+            }),
+            Err(MppError::UnsupportedGeometry)
+        );
+    }
+
+    #[test]
+    fn accepts_stream_range_with_nonzero_start_byte() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_STRM_BASE] = 9;
+        // One 16-byte DMA block, with the first coded byte at byte five inside
+        // that block. The start marker is not an additional DMA byte count.
+        words[registers::REG_STRM_LEN] = 5;
+        s.set_reg_write(&words);
+        s.add_reg_offsets(&[RegOffset {
+            index: registers::REG_STRM_BASE as u32,
+            offset: 4080,
+        }])
+        .unwrap();
+
+        s.resolve_addresses(|_| {
+            Some(ResolvedDmaBuf {
+                address: 0x2000_0000,
+                size: 4096,
+            })
+        })
+        .unwrap();
     }
 
     #[test]

--- a/drivers/vpu/rockchip-jpeg/src/mpp.rs
+++ b/drivers/vpu/rockchip-jpeg/src/mpp.rs
@@ -10,7 +10,7 @@
 //! References: rockchip-linux/mpp `osal/inc/mpp_service.h` and the vendor kernel
 //! `include/uapi/linux/rk-mpp.h` (`develop-5.10`).
 
-use crate::registers::{ADDR_REG_INDICES, REG_COUNT};
+use crate::registers::{self, ADDR_REG_INDICES, REG_COUNT};
 
 /// `MPP_IOC_CFG_V1 = _IOW('v', 1, unsigned int)`.
 pub const MPP_IOC_CFG_V1: u32 = 0x4004_7601;
@@ -110,6 +110,31 @@ pub enum MppError {
     /// More address-offset fixups than supported.
     #[error("MPP register offset table is full")]
     TooManyOffsets,
+    /// The resolved address plus its offset wrapped the 32-bit device address.
+    #[error("MPP dma-buf address calculation overflowed")]
+    AddressOverflow,
+    /// The requested DMA range is outside the imported dma-buf allocation.
+    #[error("MPP DMA range is outside the imported dma-buf")]
+    DmaRangeOutOfBounds,
+    /// The hardware address register requires a stronger alignment.
+    #[error("MPP DMA address is not correctly aligned")]
+    MisalignedAddress,
+    /// The register geometry selects an output layout not supported by this node.
+    #[error("MPP JPEG output geometry is unsupported")]
+    UnsupportedGeometry,
+}
+
+/// Device address and allocation size of an imported contiguous dma-buf.
+///
+/// The address is the physical/bus address visible to the IOMMU-bypassed JPEG
+/// block. `size` is the complete allocation size, not the userspace payload
+/// length, and is required to validate every register-derived DMA range.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedDmaBuf {
+    /// 32-bit device-visible base address.
+    pub address: u32,
+    /// Number of bytes owned by the allocation.
+    pub size: usize,
 }
 
 /// Accumulated state for one MPP decode task.
@@ -187,22 +212,134 @@ impl MppSession {
 
     /// Resolve fd-bearing address registers to physical addresses (plus their
     /// recorded offsets), producing the final register array.
+    ///
+    /// The resolver must return the complete imported allocation size. Before
+    /// programming the device, this method checks the offset, the DMA length
+    /// derived from the register geometry, the 32-bit address addition, and the
+    /// alignment required by each address register.
     pub fn resolve_addresses<F>(&mut self, mut resolve_fd: F) -> Result<(), MppError>
     where
-        F: FnMut(u32) -> Option<u32>,
+        F: FnMut(u32) -> Option<ResolvedDmaBuf>,
     {
         if !self.have_regs {
             return Err(MppError::NoRegisters);
         }
+        let mut resolved = self.regs;
         for &idx in ADDR_REG_INDICES {
             let fd = self.regs[idx];
             if fd == 0 {
                 continue; // unused address slot
             }
-            let phys = resolve_fd(fd).ok_or(MppError::UnresolvedFd(fd))?;
-            self.regs[idx] = phys.wrapping_add(self.offset_for(idx as u32));
+            let buffer = resolve_fd(fd).ok_or(MppError::UnresolvedFd(fd))?;
+            let offset = self.offset_for(idx as u32);
+            let length = self.dma_length(idx)?;
+            let end = (offset as usize)
+                .checked_add(length)
+                .ok_or(MppError::AddressOverflow)?;
+            if end > buffer.size {
+                return Err(MppError::DmaRangeOutOfBounds);
+            }
+
+            let address = buffer
+                .address
+                .checked_add(offset)
+                .ok_or(MppError::AddressOverflow)?;
+            if address & (Self::address_alignment(idx) - 1) != 0 {
+                return Err(MppError::MisalignedAddress);
+            }
+            resolved[idx] = address;
         }
+        self.regs = resolved;
         Ok(())
+    }
+
+    fn dma_length(&self, index: usize) -> Result<usize, MppError> {
+        match index {
+            registers::REG_QTBL_BASE => table_length(self.regs[registers::REG_TABLE_LEN], 0, 0x1f),
+            registers::REG_HUFFMIN_BASE => {
+                table_length(self.regs[registers::REG_TABLE_LEN], 8, 0x1f)
+            }
+            registers::REG_HUFFVAL_BASE => {
+                table_length(self.regs[registers::REG_TABLE_LEN], 16, 0x3f)
+            }
+            registers::REG_STRM_BASE => {
+                let reg = self.regs[registers::REG_STRM_LEN];
+                let blocks = ((reg >> 4) & 0x0fff_ffff) as usize;
+                (blocks + 1)
+                    .checked_mul(16)
+                    .and_then(|length| length.checked_add((reg & 0xf) as usize))
+                    .ok_or(MppError::AddressOverflow)
+            }
+            registers::REG_DEC_OUT_BASE => self.output_length(),
+            _ => Err(MppError::UnsupportedGeometry),
+        }
+    }
+
+    fn output_length(&self) -> Result<usize, MppError> {
+        let sys = self.regs[registers::REG_SYS];
+        let output_format = (sys >> registers::OUT_FMT_SHIFT) & 0x7;
+        if output_format != registers::OUT_FMT_NATIVE && output_format != registers::OUT_FMT_NV12
+            || sys & registers::SYS_OUT_SEQ != 0
+        {
+            return Err(MppError::UnsupportedGeometry);
+        }
+
+        let mode = self.regs[registers::REG_PIC_FMT] & 0x7;
+        let height_alignment = if sys & registers::SYS_FILL_DOWN != 0 {
+            16
+        } else {
+            8
+        };
+        match mode {
+            registers::JPEG_MODE_400
+            | registers::JPEG_MODE_411
+            | registers::JPEG_MODE_420
+            | registers::JPEG_MODE_440
+            | registers::JPEG_MODE_422
+            | registers::JPEG_MODE_444 => {}
+            _ => return Err(MppError::UnsupportedGeometry),
+        }
+        let height = ((self.regs[registers::REG_PIC_SIZE] >> 16) & 0xffff) as usize + 1;
+        let height = height
+            .checked_add(height_alignment - 1)
+            .ok_or(MppError::AddressOverflow)?
+            / height_alignment
+            * height_alignment;
+
+        let y_stride_units = (self.regs[registers::REG_HOR_VIRSTRIDE] & 0xffff) as usize
+            | (((self.regs[registers::REG_TABLE_LEN] >> 24) & 1) as usize) << 16;
+        if y_stride_units == 0 {
+            return Err(MppError::UnsupportedGeometry);
+        }
+        let uv_stride_units = (self.regs[registers::REG_HOR_VIRSTRIDE] >> 16) as usize;
+        let y_stride = y_stride_units
+            .checked_mul(16)
+            .ok_or(MppError::AddressOverflow)?;
+        let uv_stride = uv_stride_units
+            .checked_mul(16)
+            .ok_or(MppError::AddressOverflow)?;
+        let y_rows = y_stride
+            .checked_mul(height)
+            .ok_or(MppError::AddressOverflow)?;
+        let y_virstride = ((self.regs[registers::REG_Y_VIRSTRIDE] >> 4) as usize)
+            .checked_mul(16)
+            .ok_or(MppError::AddressOverflow)?;
+        let y_size = y_rows.max(y_virstride);
+        let uv_size = if mode == registers::JPEG_MODE_400 {
+            0
+        } else {
+            uv_stride
+                .checked_mul(height)
+                .ok_or(MppError::AddressOverflow)?
+        };
+        y_size.checked_add(uv_size).ok_or(MppError::AddressOverflow)
+    }
+
+    const fn address_alignment(index: usize) -> u32 {
+        match index {
+            registers::REG_STRM_BASE => 16,
+            _ => 64,
+        }
     }
 
     fn offset_for(&self, index: u32) -> u32 {
@@ -241,6 +378,12 @@ impl MppSession {
     pub fn reset(&mut self) {
         *self = Self::new();
     }
+}
+
+fn table_length(reg: u32, shift: u32, mask: u32) -> Result<usize, MppError> {
+    (((reg >> shift) & mask) as usize + 1)
+        .checked_mul(16)
+        .ok_or(MppError::AddressOverflow)
 }
 
 #[cfg(test)]
@@ -294,6 +437,9 @@ mod tests {
         words[registers::REG_HUFFVAL_BASE] = 7;
         words[registers::REG_STRM_BASE] = 9; // stream fd
         words[registers::REG_DEC_OUT_BASE] = 11; // output fd
+        words[registers::REG_PIC_SIZE] = 15 | (15 << 16);
+        words[registers::REG_HOR_VIRSTRIDE] = 1 | (1 << 16);
+        words[registers::REG_Y_VIRSTRIDE] = 16 << 4;
         s.set_reg_write(&words);
         // Offsets, as MPP sends for jpegd (table mincode/value, stream start).
         s.add_reg_offsets(&[
@@ -314,9 +460,18 @@ mod tests {
 
         // fd 7 -> 0x1000_0000 (table), 9 -> 0x2000_0000 (stream), 11 -> 0x3000_0000.
         let resolve = |fd: u32| match fd {
-            7 => Some(0x1000_0000u32),
-            9 => Some(0x2000_0000u32),
-            11 => Some(0x3000_0000u32),
+            7 => Some(ResolvedDmaBuf {
+                address: 0x1000_0000,
+                size: 4096,
+            }),
+            9 => Some(ResolvedDmaBuf {
+                address: 0x2000_0000,
+                size: 4096,
+            }),
+            11 => Some(ResolvedDmaBuf {
+                address: 0x3000_0000,
+                size: 4096,
+            }),
             _ => None,
         };
         s.resolve_addresses(resolve).unwrap();
@@ -343,7 +498,114 @@ mod tests {
     #[test]
     fn resolve_without_regs_errors() {
         let mut s = MppSession::new();
-        assert_eq!(s.resolve_addresses(|_| Some(0)), Err(MppError::NoRegisters));
+        assert_eq!(
+            s.resolve_addresses(|_| {
+                Some(ResolvedDmaBuf {
+                    address: 0,
+                    size: 4096,
+                })
+            }),
+            Err(MppError::NoRegisters)
+        );
+    }
+
+    #[test]
+    fn rejects_wrapping_dma_address_offset() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_STRM_BASE] = 9;
+        s.set_reg_write(&words);
+        s.add_reg_offsets(&[RegOffset {
+            index: registers::REG_STRM_BASE as u32,
+            offset: 0x20,
+        }])
+        .unwrap();
+
+        // A checked address calculation must reject this instead of programming
+        // the wrapped address 0x10 into the decoder.
+        assert!(
+            s.resolve_addresses(|_| {
+                Some(ResolvedDmaBuf {
+                    address: 0xffff_fff0,
+                    size: 4096,
+                })
+            })
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_dma_range_at_or_past_imported_buffer() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_STRM_BASE] = 9;
+        s.set_reg_write(&words);
+        s.add_reg_offsets(&[RegOffset {
+            index: registers::REG_STRM_BASE as u32,
+            offset: 4081,
+        }])
+        .unwrap();
+
+        // The stream register describes one 16-byte DMA block. The first four
+        // bytes would fit in a 4096-byte allocation, but the full range does not.
+        assert_eq!(
+            s.resolve_addresses(|_| {
+                Some(ResolvedDmaBuf {
+                    address: 0x2000_0000,
+                    size: 4096,
+                })
+            }),
+            Err(MppError::DmaRangeOutOfBounds)
+        );
+    }
+
+    #[test]
+    fn rejects_output_stride_beyond_imported_buffer() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_DEC_OUT_BASE] = 11;
+        words[registers::REG_SYS] = registers::SYS_FILL_DOWN;
+        words[registers::REG_PIC_SIZE] = 15 | (15 << 16);
+        words[registers::REG_PIC_FMT] = registers::JPEG_MODE_420;
+        words[registers::REG_HOR_VIRSTRIDE] = 1 | (1 << 16);
+        words[registers::REG_Y_VIRSTRIDE] = 32 << 4;
+        s.set_reg_write(&words);
+
+        // The programmed Y stride already consumes 512 bytes; the NV12 chroma
+        // plane adds another 256 bytes, so a 512-byte import must be rejected.
+        assert_eq!(
+            s.resolve_addresses(|_| {
+                Some(ResolvedDmaBuf {
+                    address: 0x3000_0000,
+                    size: 512,
+                })
+            }),
+            Err(MppError::DmaRangeOutOfBounds)
+        );
+    }
+
+    #[test]
+    fn accepts_exact_output_allocation_size() {
+        let mut s = MppSession::new();
+        let mut words = [0u32; REG_COUNT];
+        words[registers::REG_DEC_OUT_BASE] = 11;
+        words[registers::REG_SYS] = registers::SYS_FILL_DOWN;
+        words[registers::REG_PIC_SIZE] = 15 | (15 << 16);
+        words[registers::REG_PIC_FMT] = registers::JPEG_MODE_420;
+        words[registers::REG_HOR_VIRSTRIDE] = 1 | (1 << 16);
+        words[registers::REG_Y_VIRSTRIDE] = 32 << 4;
+        s.set_reg_write(&words);
+
+        // 512 bytes of Y (the programmed Y virtual stride) plus 256 bytes of
+        // chroma is the exact legal end of this two-plane output allocation.
+        s.resolve_addresses(|_| {
+            Some(ResolvedDmaBuf {
+                address: 0x3000_0000,
+                size: 768,
+            })
+        })
+        .unwrap();
+        assert_eq!(s.regs()[registers::REG_DEC_OUT_BASE], 0x3000_0000);
     }
 
     #[test]
@@ -354,7 +616,15 @@ mod tests {
         s.clear_task();
         assert_eq!(s.client_type(), Some(MPP_DEVICE_RKJPEGD));
         assert_eq!(s.regs()[0], 0);
-        assert_eq!(s.resolve_addresses(|_| Some(0)), Err(MppError::NoRegisters));
+        assert_eq!(
+            s.resolve_addresses(|_| {
+                Some(ResolvedDmaBuf {
+                    address: 0,
+                    size: 4096,
+                })
+            }),
+            Err(MppError::NoRegisters)
+        );
     }
 
     #[test]

--- a/drivers/vpu/rockchip-jpeg/src/registers.rs
+++ b/drivers/vpu/rockchip-jpeg/src/registers.rs
@@ -127,5 +127,9 @@ pub const OUT_FMT_NV12: u32 = 3;
 pub const OUT_FMT_YUYV: u32 = 4;
 /// Bit position of `yuv_out_format` within `SWREG2`.
 pub const OUT_FMT_SHIFT: u32 = 27;
+/// Fill the decoded output down to a 16-line boundary.
+pub const SYS_FILL_DOWN: u32 = 1 << 24;
+/// Tiled output sequence bit within `SWREG2`; the MPP node only accepts raster output.
+pub const SYS_OUT_SEQ: u32 = 1 << 26;
 /// `cbcr_swap` bit within `SWREG2` (selects NV21 vs NV12 ordering).
 pub const SYS_CBCR_SWAP: u32 = 1 << 9;

--- a/os/StarryOS/kernel/src/file/dmabuf.rs
+++ b/os/StarryOS/kernel/src/file/dmabuf.rs
@@ -82,10 +82,8 @@ impl DmaBufFile {
 
     /// Size of the allocation in bytes (page-rounded up from the request).
     ///
-    /// The NPU import seam ([`ContiguousDmaBuf`]) needs it, and the RGA path uses it to
-    /// bound-check every imported buffer before an MMU-off DMA (a plane must not address
-    /// past its buffer). The jpeg-only build resolves buffers through [`Self::phys_base`].
-    #[cfg(any(feature = "rknpu", feature = "rga"))]
+    /// Accelerator import paths use this to bound-check every imported buffer before
+    /// an MMU-off DMA (a plane must not address past its buffer).
     pub fn size(&self) -> usize {
         self.alloc.size
     }

--- a/os/StarryOS/kernel/src/pseudofs/dev/mpp_service.rs
+++ b/os/StarryOS/kernel/src/pseudofs/dev/mpp_service.rs
@@ -12,9 +12,10 @@
 //! → physical-address resolution (via the /dev/dma_heap DmaBufFile), and the
 //! hardware run.
 
+use alloc::{sync::Arc, vec::Vec};
 use core::{any::Any, ffi::c_int, mem::size_of};
 
-use ax_driver::jpeg::{self, mpp, registers};
+use ax_driver::jpeg::{self, mpp, registers, ResolvedDmaBuf};
 use axfs_ng_vfs::{DeviceId, VfsError, VfsResult};
 
 use crate::{
@@ -180,9 +181,13 @@ fn handle_request(
 }
 
 fn run_decode(current: &crate::task::UserTaskRef, state: &mut TaskState) -> VfsResult<()> {
+    // Keep every imported allocation alive until the synchronous hardware run
+    // has completed. Resolving only to a physical number would allow a concurrent
+    // close of the dma-buf fd to free pages while the JPEG block still owns them.
+    let mut imported = Vec::with_capacity(registers::ADDR_REG_INDICES.len());
     state
         .session
-        .resolve_addresses(resolve_fd)
+        .resolve_addresses(|fd| resolve_fd(fd, &mut imported))
         .map_err(|_| VfsError::InvalidInput)?;
 
     let mut readback = [0u32; registers::REG_COUNT];
@@ -205,7 +210,7 @@ fn run_decode(current: &crate::task::UserTaskRef, state: &mut TaskState) -> VfsR
 /// Resolve a dma-buf fd (as MPP places it in an address register) to the
 /// physical base of its contiguous buffer. MPP allocates these from our
 /// `/dev/dma_heap` ([`DmaBufFile`]).
-fn resolve_fd(fd: u32) -> Option<u32> {
+fn resolve_fd(fd: u32, imported: &mut Vec<Arc<crate::file::dmabuf::DmaBufFile>>) -> Option<ResolvedDmaBuf> {
     let Some(buf) = resolve_contiguous_dmabuf(fd as c_int) else {
         warn!("mpp_service: register fd {fd} is not a resolvable dma-buf");
         return None;
@@ -215,7 +220,11 @@ fn resolve_fd(fd: u32) -> Option<u32> {
     // are allocated below 4 GiB (dma32), so this should not trigger.
     let phys = buf.phys_base();
     match u32::try_from(phys) {
-        Ok(addr) => Some(addr),
+        Ok(address) => {
+            let size = buf.size();
+            imported.push(buf);
+            Some(ResolvedDmaBuf { address, size })
+        }
         Err(_) => {
             warn!("mpp_service: dma-buf fd {fd} phys {phys:#x} exceeds 32-bit JPU range");
             None


### PR DESCRIPTION
- https://github.com/rcore-os/tgoskits/issues/1739
### 主要改动：
- 在 [`MppSession::resolve_addresses`](/code/tgoskits/drivers/vpu/rockchip-jpeg/src/mpp.rs) 中：
  - 使用 dma-buf 实际分配大小校验访问范围；
  - 对 offset + length、物理地址加法使用 checked arithmetic；
  - 校验 JPEG 表、输入流和输出多平面的完整 DMA 长度；
  - 拒绝非法对齐和不支持的输出布局；
  - 校验失败时不提交部分修改过的寄存器。
- StarryOS 保留导入 dma-buf 的 Arc，直到同步硬件运行结束，避免 DMA 期间缓冲区被释放：[`mpp_service.rs`](/code/tgoskits/os/StarryOS/kernel/src/pseudofs/dev/mpp_service.rs)。
- 暴露 dma-buf 实际分配大小：[`dmabuf.rs`](/code/tgoskits/os/StarryOS/kernel/src/file/dmabuf.rs)。
- 新增回归测试覆盖：
  - 32 位地址加偏移溢出；
  - 偏移加 DMA 长度越过分配末尾；
  - 输出 stride/多平面大小越界；
  - 恰好落在最后合法字节的输出缓冲区。

### 验证结果：
- 修复前新增的溢出测试按预期失败。
- cargo test -p rockchip-jpeg --lib：63 项通过。
- MPP 专项测试：13 项通过。
- cargo xtask clippy --package rockchip-jpeg：通过。
- cargo xtask clippy --package ax-driver：通过。
- StarryOS jpeg 特性目标检查：通过。
- 含全部依赖的 StarryOS clippy 仍受已有无关警告阻塞：platforms/somehal/.../gic/v3.rs:164。