### PR TITLE
fix(aic8800): bound queue memory with item and byte budgets

### DIFF
--- a/drivers/net/aic8800/src/device/control.rs
+++ b/drivers/net/aic8800/src/device/control.rs
@@ -11,6 +11,8 @@ use crate::{
 };
 
 const MAX_SSID_LENGTH: usize = 32;
+const CONTROL_COMMAND_CAPACITY: usize = 8;
+const CONTROL_COMMAND_BYTE_CAPACITY: usize = 4 * 1024;
 
 pub(super) struct ControlCommand {
     pub message_id: u16,
@@ -21,6 +23,7 @@ pub(super) struct ControlCommand {
 
 pub(super) struct ControlState {
     pub commands: VecDeque<ControlCommand>,
+    pub command_bytes: usize,
     pub operation: ControlOperation,
 }
 
@@ -58,28 +61,64 @@ pub(super) enum ControlEffect {
 }
 
 impl ControlState {
+    fn has_command_capacity(&self, additional_items: usize, additional_bytes: usize) -> bool {
+        self.commands
+            .len()
+            .checked_add(additional_items)
+            .is_some_and(|items| items <= CONTROL_COMMAND_CAPACITY)
+            && self
+                .command_bytes
+                .checked_add(additional_bytes)
+                .is_some_and(|bytes| bytes <= CONTROL_COMMAND_BYTE_CAPACITY)
+    }
+
+    fn push_command(&mut self, command: ControlCommand) -> Result<(), AicError> {
+        let command_bytes = command.payload.len();
+        if !self.has_command_capacity(1, command_bytes) {
+            return Err(AicError::ControlQueueFull);
+        }
+        self.command_bytes += command_bytes;
+        self.commands.push_back(command);
+        Ok(())
+    }
+
+    pub(super) fn pop_command(&mut self) -> Option<ControlCommand> {
+        let command = self.commands.pop_front()?;
+        self.command_bytes -= command.payload.len();
+        Some(command)
+    }
+
     pub(super) fn accept_connect_indication(
         &mut self,
         station_index: u8,
         bssid: [u8; 6],
         local_mac: [u8; 6],
     ) -> Result<(), AicError> {
-        let ControlOperation::Connect(connect) = &mut self.operation else {
+        let ControlOperation::Connect(connect) = &self.operation else {
             return Err(AicError::CompletionMismatch);
         };
         if connect.phase != ConnectPhase::AwaitIndication {
             return Err(AicError::CompletionMismatch);
         }
         if connect.pmk.is_none() {
-            self.commands.push_back(ControlCommand {
+            if !self.has_command_capacity(1, 2) {
+                return Err(AicError::ControlQueueFull);
+            }
+            self.push_command(ControlCommand {
                 message_id: ME_SET_CONTROL_PORT_REQ,
                 destination: TASK_ME,
                 expected_message_id: ME_SET_CONTROL_PORT_CFM,
                 payload: control_port_payload(station_index, true).to_vec(),
-            });
+            })?;
+            let ControlOperation::Connect(connect) = &mut self.operation else {
+                return Err(AicError::CompletionMismatch);
+            };
             connect.phase = ConnectPhase::AwaitControlPort;
             Ok(())
         } else {
+            let ControlOperation::Connect(connect) = &mut self.operation else {
+                return Err(AicError::CompletionMismatch);
+            };
             let entropy = connect.entropy.take().ok_or(AicError::EntropyUnavailable)?;
             let pmk = connect.pmk.take().ok_or(AicError::WpaProtocol)?;
             connect.handshake = Some(Wpa2Handshake::new(
@@ -99,23 +138,28 @@ impl ControlState {
         station_index: u8,
         eapol: &[u8],
     ) -> Result<ControlEffect, AicError> {
-        let ControlOperation::Connect(connect) = &mut self.operation else {
-            return Err(AicError::CompletionMismatch);
+        let action = {
+            let ControlOperation::Connect(connect) = &mut self.operation else {
+                return Err(AicError::CompletionMismatch);
+            };
+            if connect.phase != ConnectPhase::AwaitHandshake {
+                return Err(AicError::WpaProtocol);
+            }
+            log::info!("[wifi] WPA2 EAPOL frame consumed by handshake state machine");
+            connect
+                .handshake
+                .as_mut()
+                .ok_or(AicError::WpaProtocol)?
+                .process(eapol)
+                .map_err(map_wpa_error)?
         };
-        if connect.phase != ConnectPhase::AwaitHandshake {
-            return Err(AicError::WpaProtocol);
-        }
-        log::info!("[wifi] WPA2 EAPOL frame consumed by handshake state machine");
-        let action = connect
-            .handshake
-            .as_mut()
-            .ok_or(AicError::WpaProtocol)?
-            .process(eapol)
-            .map_err(map_wpa_error)?;
         match action {
             HandshakeAction::SendM2(frame) => Ok(ControlEffect::TransmitEapol(frame)),
             HandshakeAction::InstallKeys(keys) => {
-                self.commands.push_back(ControlCommand {
+                if !self.has_command_capacity(2, 88) {
+                    return Err(AicError::ControlQueueFull);
+                }
+                self.push_command(ControlCommand {
                     message_id: MM_KEY_ADD_REQ,
                     destination: TASK_MM,
                     expected_message_id: MM_KEY_ADD_CFM,
@@ -127,8 +171,8 @@ impl ControlState {
                         &keys.temporal_key,
                     )?
                     .to_vec(),
-                });
-                self.commands.push_back(ControlCommand {
+                })?;
+                self.push_command(ControlCommand {
                     message_id: MM_KEY_ADD_REQ,
                     destination: TASK_MM,
                     expected_message_id: MM_KEY_ADD_CFM,
@@ -140,7 +184,10 @@ impl ControlState {
                         &keys.group_key,
                     )?
                     .to_vec(),
-                });
+                })?;
+                let ControlOperation::Connect(connect) = &mut self.operation else {
+                    return Err(AicError::CompletionMismatch);
+                };
                 connect.pending_m4 = Some(keys.m4.clone());
                 connect.phase = ConnectPhase::InstallingKeys(2);
                 Ok(ControlEffect::None)
@@ -169,18 +216,24 @@ impl ControlState {
     }
 
     pub(super) fn accept_m4_transmit(&mut self, station_index: u8) -> Result<(), AicError> {
-        let ControlOperation::Connect(connect) = &mut self.operation else {
+        let ControlOperation::Connect(connect) = &self.operation else {
             return Err(AicError::CompletionMismatch);
         };
         if connect.phase != ConnectPhase::AwaitM4Transmit {
             return Err(AicError::CompletionMismatch);
         }
-        self.commands.push_back(ControlCommand {
+        if !self.has_command_capacity(1, 2) {
+            return Err(AicError::ControlQueueFull);
+        }
+        self.push_command(ControlCommand {
             message_id: ME_SET_CONTROL_PORT_REQ,
             destination: TASK_ME,
             expected_message_id: ME_SET_CONTROL_PORT_CFM,
             payload: control_port_payload(station_index, true).to_vec(),
-        });
+        })?;
+        let ControlOperation::Connect(connect) = &mut self.operation else {
+            return Err(AicError::CompletionMismatch);
+        };
         connect.phase = ConnectPhase::AwaitControlPort;
         Ok(())
     }
@@ -270,8 +323,13 @@ pub(super) fn build(
             return Err(AicError::InvalidControlRequest);
         }
     };
+    let command_bytes = commands.iter().map(|command| command.payload.len()).sum();
+    if commands.len() > CONTROL_COMMAND_CAPACITY || command_bytes > CONTROL_COMMAND_BYTE_CAPACITY {
+        return Err(AicError::ControlQueueFull);
+    }
     Ok(ControlState {
         commands,
+        command_bytes,
         operation,
     })
 }

--- a/drivers/net/aic8800/src/device/data_plane.rs
+++ b/drivers/net/aic8800/src/device/data_plane.rs
@@ -173,28 +173,29 @@ impl AicDevice {
         response: SdioResponse,
     ) -> Result<(), AicError> {
         let receive_data = expect_data(response)?;
-        let frames = parse_fifo(&receive_data).map_err(|error| {
-            let header_length = receive_data.len().min(24);
-            let mut header = [0; 24];
-            header[..header_length].copy_from_slice(&receive_data[..header_length]);
-            let header_words = [
-                u64::from_le_bytes(header[0..8].try_into().expect("fixed header word")),
-                u64::from_le_bytes(header[8..16].try_into().expect("fixed header word")),
-                u64::from_le_bytes(header[16..24].try_into().expect("fixed header word")),
-            ];
-            log::error!(
-                "malformed AIC RX frame on {path:?}: transfer={} header={:02x?}",
-                receive_data.len(),
-                &receive_data[..header_length]
-            );
-            AicError::MalformedRxFrame {
-                offset: error.offset,
-                packet_type: error.packet_type,
-                declared_length: error.declared_length,
-                available_length: error.available_length,
-                header_words,
-            }
-        })?;
+        let frames =
+            parse_fifo(&receive_data, self.mailbox_confirmation_id()).map_err(|error| {
+                let header_length = receive_data.len().min(24);
+                let mut header = [0; 24];
+                header[..header_length].copy_from_slice(&receive_data[..header_length]);
+                let header_words = [
+                    u64::from_le_bytes(header[0..8].try_into().expect("fixed header word")),
+                    u64::from_le_bytes(header[8..16].try_into().expect("fixed header word")),
+                    u64::from_le_bytes(header[16..24].try_into().expect("fixed header word")),
+                ];
+                log::error!(
+                    "malformed AIC RX frame on {path:?}: transfer={} header={:02x?}",
+                    receive_data.len(),
+                    &receive_data[..header_length]
+                );
+                AicError::MalformedRxFrame {
+                    offset: error.offset,
+                    packet_type: error.packet_type,
+                    declared_length: error.declared_length,
+                    available_length: error.available_length,
+                    header_words,
+                }
+            })?;
         for frame in frames {
             match frame {
                 ParsedFrame::Data {
@@ -561,7 +562,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        common::{ChipVariant, SDIO_TYPE_CFG_CMD_RSP, SDIO_TYPE_DATA},
+        common::{ChipVariant, SDIO_TYPE_CFG_CMD_RSP, SDIO_TYPE_CFG_PRINT, SDIO_TYPE_DATA},
         rx::{RX_BYTE_CAPACITY, RX_CAPACITY},
     };
 
@@ -668,6 +669,41 @@ mod tests {
             .unwrap();
 
         assert_eq!(device.data.link.peer(), None);
+    }
+
+    #[test]
+    fn mailbox_confirmation_survives_control_budget_exhaustion() {
+        const PRINT_PACKET_LENGTH: usize = 8;
+        const PRINT_AGGREGATE_LENGTH: usize = 4 + PRINT_PACKET_LENGTH;
+        const RESPONSE_PACKET_LENGTH: usize = 12;
+        const RESPONSE_AGGREGATE_LENGTH: usize = 4 + RESPONSE_PACKET_LENGTH;
+        const EXPECTED_MESSAGE_ID: u16 = 2;
+
+        let response_offset = crate::rx::CONTROL_RX_CAPACITY * PRINT_AGGREGATE_LENGTH;
+        let mut fifo = vec![0; response_offset + RESPONSE_AGGREGATE_LENGTH];
+        for index in 0..crate::rx::CONTROL_RX_CAPACITY {
+            let offset = index * PRINT_AGGREGATE_LENGTH;
+            fifo[offset..offset + 2].copy_from_slice(&(PRINT_PACKET_LENGTH as u16).to_le_bytes());
+            fifo[offset + 2] = SDIO_TYPE_CFG_PRINT;
+        }
+        fifo[response_offset..response_offset + 2]
+            .copy_from_slice(&(RESPONSE_PACKET_LENGTH as u16).to_le_bytes());
+        fifo[response_offset + 2] = SDIO_TYPE_CFG_CMD_RSP;
+        fifo[response_offset + 4..response_offset + 6]
+            .copy_from_slice(&EXPECTED_MESSAGE_ID.to_le_bytes());
+
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        device.lifecycle.mailbox = Some(MailboxState::confirmation_for_test(
+            MonotonicTime::from_nanos(10),
+        ));
+        device.io.receive.active = true;
+
+        device
+            .consume_receive_data(RxPath::Command, SdioResponse::Data(fifo))
+            .unwrap();
+
+        assert_eq!(device.mailbox_confirmation_id(), None);
+        assert!(!device.mailbox_waiting_for_receive());
     }
 
     #[test]

--- a/drivers/net/aic8800/src/device/data_plane.rs
+++ b/drivers/net/aic8800/src/device/data_plane.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     protocol::{BLOCK_SIZE, ethernet_tx_frame},
     registers::{ReceiveLength, flow_credits},
-    rx::{ParsedFrame, RX_CAPACITY, parse_fifo},
+    rx::{ParsedFrame, parse_fifo},
 };
 
 const IO_RETRY: Duration = Duration::from_millis(1);
@@ -16,6 +16,7 @@ const IO_RETRY: Duration = Duration::from_millis(1);
 // available for commands, as in the vendor DATA_FLOW_CTRL_THRESH contract.
 const DATA_TX_RESERVED_CREDITS: u8 = 2;
 const INTERNAL_TX_CAPACITY: usize = 2;
+const INTERNAL_TX_BYTE_CAPACITY: usize = 8 * 1024;
 const ETHERTYPE_EAPOL: [u8; 2] = [0x88, 0x8e];
 
 impl AicDevice {
@@ -75,7 +76,7 @@ impl AicDevice {
             .events
             .iter()
             .position(|event| !matches!(event, AicEvent::Receive(_)))?;
-        self.data.events.remove(index)
+        self.data.remove_event(index)
     }
 
     pub(super) fn request_receive_scan(&mut self) {
@@ -206,8 +207,8 @@ impl AicDevice {
                     for frame in frames {
                         if frame.get(12..14) == Some(&ETHERTYPE_EAPOL) {
                             self.consume_eapol(&frame)?;
-                        } else if self.data.events.len() < RX_CAPACITY {
-                            self.data.events.push_back(AicEvent::Receive(frame));
+                        } else {
+                            self.data.push_event(AicEvent::Receive(frame))?;
                         }
                     }
                 }
@@ -263,18 +264,17 @@ impl AicDevice {
                         return Err(AicError::MalformedResponse);
                     }
                     self.data.link.clear_peer();
-                    self.data.internal_tx.clear();
+                    self.data.clear_internal_tx();
                     let resetting = self.lifecycle.control.as_ref().is_some_and(|control| {
                         matches!(&control.operation,
                             super::control::ControlOperation::Connect(connect)
                                 if connect.phase == super::control::ConnectPhase::Resetting)
                     });
                     if !resetting && self.lifecycle.control.take().is_some() {
-                        self.data.events.push_back(AicEvent::ControlFailed(
-                            AicError::Disconnected {
+                        self.data
+                            .push_event(AicEvent::ControlFailed(AicError::Disconnected {
                                 reason_code: indication.reason_code,
-                            },
-                        ));
+                            }))?;
                     }
                 }
                 ParsedFrame::Indication {
@@ -333,10 +333,9 @@ impl AicDevice {
             .take()
             .ok_or(AicError::CompletionMismatch)?;
         match active.completion {
-            super::owner::TxCompletion::User(token) => self
-                .data
-                .events
-                .push_back(AicEvent::TransmitComplete(token)),
+            super::owner::TxCompletion::User(token) => {
+                self.data.push_event(AicEvent::TransmitComplete(token))?
+            }
             super::owner::TxCompletion::Internal(super::owner::InternalTxKind::M2) => {}
             super::owner::TxCompletion::Internal(super::owner::InternalTxKind::M4) => {
                 let (station_index, _) = self.data.link.peer().ok_or(AicError::WpaProtocol)?;
@@ -357,7 +356,7 @@ impl AicDevice {
         let Some((interface_index, station_index)) = self.data.link.tx_indices() else {
             return;
         };
-        if let Some(internal) = self.data.internal_tx.pop_front() {
+        if let Some(internal) = self.data.pop_internal_tx() {
             let Ok(wire_frame) = ethernet_tx_frame(
                 &internal.ethernet_frame,
                 interface_index,
@@ -428,7 +427,16 @@ impl AicDevice {
         kind: super::owner::InternalTxKind,
         eapol: Vec<u8>,
     ) -> Result<(), AicError> {
-        if self.data.internal_tx.len() >= INTERNAL_TX_CAPACITY {
+        let ethernet_length = 14usize
+            .checked_add(eapol.len())
+            .ok_or(AicError::TxQueueFull)?;
+        if self.data.internal_tx.len() >= INTERNAL_TX_CAPACITY
+            || self
+                .data
+                .internal_tx_bytes
+                .checked_add(ethernet_length)
+                .is_none_or(|bytes| bytes > INTERNAL_TX_BYTE_CAPACITY)
+        {
             return Err(AicError::TxQueueFull);
         }
         let local_mac = self
@@ -437,11 +445,12 @@ impl AicDevice {
             .mac_address()
             .ok_or(AicError::InvalidMacAddress)?;
         let (_, bssid) = self.data.link.peer().ok_or(AicError::WpaProtocol)?;
-        let mut ethernet = Vec::with_capacity(14 + eapol.len());
+        let mut ethernet = Vec::with_capacity(ethernet_length);
         ethernet.extend_from_slice(&bssid);
         ethernet.extend_from_slice(&local_mac);
         ethernet.extend_from_slice(&ETHERTYPE_EAPOL);
         ethernet.extend_from_slice(&eapol);
+        self.data.internal_tx_bytes += ethernet.len();
         self.data.internal_tx.push_back(super::owner::InternalTx {
             kind,
             ethernet_frame: ethernet,
@@ -553,7 +562,7 @@ mod tests {
     use super::*;
     use crate::{
         common::{ChipVariant, SDIO_TYPE_CFG_CMD_RSP, SDIO_TYPE_DATA},
-        rx::RX_CAPACITY,
+        rx::{RX_BYTE_CAPACITY, RX_CAPACITY},
     };
 
     fn indication_fifo(message_id: u16, payload: &[u8]) -> Vec<u8> {
@@ -670,7 +679,7 @@ mod tests {
             device
                 .consume_receive_data(RxPath::Command, SdioResponse::Data(data_fifo(marker as u8)))
                 .unwrap();
-            let event = device.data.events.pop_front();
+            let event = device.data.pop_event();
             assert!(
                 matches!(event, Some(AicEvent::Receive(frame)) if frame[0] == marker as u8),
                 "receive event {marker} was lost after the bounded window"
@@ -683,7 +692,7 @@ mod tests {
         let mut device = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
         device.lifecycle.state = AicState::Ready;
         device.io.receive.active = true;
-        device.data.events.push_back(AicEvent::ControlComplete);
+        device.data.push_event(AicEvent::ControlComplete).unwrap();
 
         assert!(matches!(
             device.drive_ready(MonotonicTime::from_nanos(0)),
@@ -697,7 +706,7 @@ mod tests {
         let mut device = AicDevice::new(ChipVariant::Aic8800DC).unwrap();
         device.lifecycle.state = AicState::Ready;
         for _ in 0..RX_CAPACITY {
-            device.data.events.push_back(AicEvent::Receive(vec![0]));
+            device.data.push_event(AicEvent::Receive(vec![0])).unwrap();
         }
         device
             .data
@@ -708,6 +717,34 @@ mod tests {
             device.drive_ready(MonotonicTime::default()),
             AicAction::Event(AicEvent::TransmitComplete(token)) if token == TxToken::new(1)
         ));
+    }
+
+    #[test]
+    fn receive_event_queue_obeys_item_and_byte_limits() {
+        let mut device = AicDevice::new(ChipVariant::Aic8800D80).unwrap();
+        for _ in 0..RX_CAPACITY {
+            device
+                .data
+                .push_event(AicEvent::Receive(vec![0; 2048]))
+                .unwrap();
+        }
+        device
+            .data
+            .push_event(AicEvent::Receive(vec![0; 2048]))
+            .unwrap();
+
+        assert_eq!(device.data.events.len(), RX_CAPACITY);
+        assert_eq!(device.data.event_bytes, RX_BYTE_CAPACITY);
+
+        device.data.push_event(AicEvent::ControlComplete).unwrap();
+        assert_eq!(device.data.events.len(), RX_CAPACITY);
+        assert!(
+            device
+                .data
+                .events
+                .iter()
+                .any(|event| matches!(event, AicEvent::ControlComplete))
+        );
     }
 
     #[test]

--- a/drivers/net/aic8800/src/device/mailbox.rs
+++ b/drivers/net/aic8800/src/device/mailbox.rs
@@ -248,7 +248,7 @@ impl AicDevice {
                     if connect.phase == ConnectPhase::Resetting) =>
             {
                 crate::lmac::require_empty(SM_DISCONNECT_CFM, &result)?;
-                control.commands.pop_front();
+                control.pop_command();
                 let ControlOperation::Connect(connect) = &mut control.operation else {
                     return Err(AicError::CompletionMismatch);
                 };
@@ -267,7 +267,7 @@ impl AicDevice {
                     return Err(AicError::CompletionMismatch);
                 }
                 connect.phase = ConnectPhase::AwaitIndication;
-                control.commands.pop_front();
+                control.pop_command();
             }
             ME_SET_CONTROL_PORT_CFM => {
                 crate::lmac::require_empty(ME_SET_CONTROL_PORT_CFM, &result)?;
@@ -277,24 +277,24 @@ impl AicDevice {
                 if connect.phase != ConnectPhase::AwaitControlPort {
                     return Err(AicError::CompletionMismatch);
                 }
-                control.commands.pop_front();
+                control.pop_command();
                 open_control_port = true;
                 finish = true;
                 log::info!("[wifi] WPA2 keys installed and control port enabled");
             }
             MM_KEY_ADD_CFM => {
                 crate::lmac::parse_key_add_confirmation(&result)?;
-                control.commands.pop_front();
+                control.pop_command();
                 m4 = control.accept_key_confirmation()?;
             }
             SM_DISCONNECT_CFM => {
                 crate::lmac::require_empty(SM_DISCONNECT_CFM, &result)?;
-                control.commands.pop_front();
+                control.pop_command();
                 self.data.link.clear_peer();
                 finish = true;
             }
             _ => {
-                control.commands.pop_front();
+                control.pop_command();
                 finish = control.commands.is_empty();
             }
         }
@@ -306,7 +306,7 @@ impl AicDevice {
         }
         if finish {
             self.lifecycle.control = None;
-            self.data.events.push_back(AicEvent::ControlComplete);
+            self.data.push_event(AicEvent::ControlComplete)?;
         }
         Ok(())
     }

--- a/drivers/net/aic8800/src/device/mailbox.rs
+++ b/drivers/net/aic8800/src/device/mailbox.rs
@@ -75,6 +75,12 @@ impl AicDevice {
         })
     }
 
+    pub(super) fn mailbox_confirmation_id(&self) -> Option<u16> {
+        self.lifecycle.mailbox.as_ref().and_then(|mailbox| {
+            (mailbox.phase == MailboxPhase::Confirmation).then_some(mailbox.expected_message_id)
+        })
+    }
+
     pub(super) fn mailbox_timed_out(&self, now: MonotonicTime) -> bool {
         self.lifecycle.mailbox.as_ref().is_some_and(|mailbox| {
             mailbox.phase != MailboxPhase::Complete && now >= mailbox.deadline

--- a/drivers/net/aic8800/src/device/model.rs
+++ b/drivers/net/aic8800/src/device/model.rs
@@ -353,6 +353,10 @@ pub enum AicError {
     UnsupportedRevision(u8),
     #[error("TX queue is full")]
     TxQueueFull,
+    #[error("AIC control command queue is full")]
+    ControlQueueFull,
+    #[error("AIC event queue is full")]
+    EventQueueFull,
     #[error("owner supplied a non-monotonic timestamp")]
     NonMonotonicTime,
 }

--- a/drivers/net/aic8800/src/device/owner.rs
+++ b/drivers/net/aic8800/src/device/owner.rs
@@ -4,7 +4,12 @@ use super::{
     AicError, AicEvent, AicState, ControlState, IoPurpose, LinkState, MailboxState, MonotonicTime,
     PendingIo, SdioRequestKind, StartupState, TxToken,
 };
-use crate::{common::ChipVariant, profile::ChipProfile, tx::TxState};
+use crate::{
+    common::ChipVariant,
+    profile::ChipProfile,
+    rx::{RX_BYTE_CAPACITY, RX_CAPACITY},
+    tx::TxState,
+};
 
 pub(super) struct ActiveTx {
     pub completion: TxCompletion,
@@ -52,10 +57,79 @@ pub(super) struct ReceiveScan {
 
 pub(super) struct DataPlaneState {
     pub events: VecDeque<AicEvent>,
+    pub event_bytes: usize,
     pub tx: TxState,
     pub active_tx: Option<ActiveTx>,
     pub internal_tx: VecDeque<InternalTx>,
+    pub internal_tx_bytes: usize,
     pub link: LinkState,
+}
+
+impl DataPlaneState {
+    pub(super) fn push_event(&mut self, event: AicEvent) -> Result<(), AicError> {
+        let event_bytes = match &event {
+            AicEvent::Receive(frame) => frame.len(),
+            _ => 0,
+        };
+        let is_receive = matches!(event, AicEvent::Receive(_));
+        while (self.events.len() >= RX_CAPACITY
+            || self.event_bytes.saturating_add(event_bytes) > RX_BYTE_CAPACITY)
+            && !is_receive
+        {
+            let Some(index) = self
+                .events
+                .iter()
+                .position(|queued| matches!(queued, AicEvent::Receive(_)))
+            else {
+                break;
+            };
+            self.remove_event(index);
+        }
+        if self.events.len() >= RX_CAPACITY
+            || self.event_bytes.saturating_add(event_bytes) > RX_BYTE_CAPACITY
+        {
+            // Data frames are lossy at this boundary.  Dropping them keeps
+            // firmware-controlled traffic from growing the owner's memory.
+            return if is_receive {
+                Ok(())
+            } else {
+                Err(AicError::EventQueueFull)
+            };
+        }
+        self.event_bytes += event_bytes;
+        self.events.push_back(event);
+        Ok(())
+    }
+
+    pub(super) fn pop_event(&mut self) -> Option<AicEvent> {
+        let event = self.events.pop_front()?;
+        self.event_bytes -= event_payload_bytes(&event);
+        Some(event)
+    }
+
+    pub(super) fn remove_event(&mut self, index: usize) -> Option<AicEvent> {
+        let event = self.events.remove(index)?;
+        self.event_bytes -= event_payload_bytes(&event);
+        Some(event)
+    }
+
+    pub(super) fn pop_internal_tx(&mut self) -> Option<InternalTx> {
+        let internal = self.internal_tx.pop_front()?;
+        self.internal_tx_bytes -= internal.ethernet_frame.len();
+        Some(internal)
+    }
+
+    pub(super) fn clear_internal_tx(&mut self) {
+        self.internal_tx.clear();
+        self.internal_tx_bytes = 0;
+    }
+}
+
+fn event_payload_bytes(event: &AicEvent) -> usize {
+    match event {
+        AicEvent::Receive(frame) => frame.len(),
+        _ => 0,
+    }
 }
 
 /// Sole owner of all AIC protocol and data-plane state.
@@ -98,9 +172,11 @@ impl AicDevice {
             },
             data: DataPlaneState {
                 events: VecDeque::new(),
+                event_bytes: 0,
                 tx: TxState::new(),
                 active_tx: None,
                 internal_tx: VecDeque::new(),
+                internal_tx_bytes: 0,
                 link: LinkState::new(),
             },
         })

--- a/drivers/net/aic8800/src/device/progress.rs
+++ b/drivers/net/aic8800/src/device/progress.rs
@@ -27,7 +27,7 @@ impl AicDevice {
         {
             return self.fail(error);
         }
-        if let Some(event) = self.data.events.pop_front() {
+        if let Some(event) = self.data.pop_event() {
             return AicAction::Event(event);
         }
         if self.lifecycle.cancel_pending
@@ -115,7 +115,7 @@ impl AicDevice {
                 self.lifecycle.mailbox = None;
                 self.lifecycle.cancel_pending = false;
                 self.data.link.clear_peer();
-                self.data.internal_tx.clear();
+                self.data.clear_internal_tx();
                 Ok(())
             }
             operation => {
@@ -170,7 +170,7 @@ impl AicDevice {
             IoPurpose::Shutdown => {
                 expect_write_readback(response, 0)?;
                 self.lifecycle.state = AicState::Stopped;
-                self.data.events.push_back(AicEvent::Stopped);
+                let _ = self.data.push_event(AicEvent::Stopped);
                 Ok(())
             }
         }
@@ -191,9 +191,7 @@ impl AicDevice {
         }
         let tokens: Vec<_> = self.data.tx.drain_tokens().collect();
         for token in tokens {
-            self.data
-                .events
-                .push_back(AicEvent::TransmitComplete(token));
+            let _ = self.data.push_event(AicEvent::TransmitComplete(token));
         }
         self.emit(
             IoPurpose::Shutdown,
@@ -206,12 +204,12 @@ impl AicDevice {
         self.lifecycle.mailbox = None;
         self.lifecycle.control = None;
         self.data.link.clear_peer();
-        self.data.internal_tx.clear();
+        self.data.clear_internal_tx();
         if self.lifecycle.state == AicState::Starting {
             self.lifecycle.startup = None;
             self.lifecycle.state = AicState::Stopped;
         }
-        self.data.events.push_back(AicEvent::ControlCancelled);
+        let _ = self.data.push_event(AicEvent::ControlCancelled);
     }
 
     pub(super) fn fail(&mut self, error: AicError) -> AicAction {
@@ -224,20 +222,17 @@ impl AicDevice {
         if let Some(active) = self.data.active_tx.take()
             && let super::owner::TxCompletion::User(token) = active.completion
         {
-            self.data
-                .events
-                .push_back(AicEvent::TransmitComplete(token));
+            let _ = self.data.push_event(AicEvent::TransmitComplete(token));
         }
-        self.data.internal_tx.clear();
+        self.data.clear_internal_tx();
         let tokens: Vec<_> = self.data.tx.drain_tokens().collect();
-        self.data
-            .events
-            .extend(tokens.into_iter().map(AicEvent::TransmitComplete));
-        self.data.events.push_back(AicEvent::Failed(error));
+        for token in tokens {
+            let _ = self.data.push_event(AicEvent::TransmitComplete(token));
+        }
+        let _ = self.data.push_event(AicEvent::Failed(error));
         AicAction::Event(
             self.data
-                .events
-                .pop_front()
+                .pop_event()
                 .expect("failure always publishes at least one terminal event"),
         )
     }

--- a/drivers/net/aic8800/src/device/startup/mod.rs
+++ b/drivers/net/aic8800/src/device/startup/mod.rs
@@ -365,10 +365,12 @@ impl AicDevice {
                 }
                 self.lifecycle.startup = None;
                 self.lifecycle.state = AicState::Ready;
-                self.data
-                    .events
-                    .push_back(AicEvent::Started { mac_address });
-                AicAction::Event(self.data.events.pop_front().unwrap())
+                let _ = self.data.push_event(AicEvent::Started { mac_address });
+                AicAction::Event(
+                    self.data
+                        .pop_event()
+                        .expect("startup always publishes a Started event"),
+                )
             }
         }
     }

--- a/drivers/net/aic8800/src/rx.rs
+++ b/drivers/net/aic8800/src/rx.rs
@@ -50,6 +50,8 @@ struct FrameBudget {
     bytes: usize,
     item_limit: usize,
     byte_limit: usize,
+    reserved_items: usize,
+    reserved_bytes: usize,
 }
 
 impl FrameBudget {
@@ -59,6 +61,8 @@ impl FrameBudget {
             bytes: 0,
             item_limit,
             byte_limit,
+            reserved_items: 0,
+            reserved_bytes: 0,
         }
     }
 
@@ -71,6 +75,18 @@ impl FrameBudget {
         }
         self.items += 1;
         self.bytes = total_bytes;
+        true
+    }
+
+    fn admit_reserved(&mut self, bytes: usize) -> bool {
+        let Some(total_reserved_bytes) = self.reserved_bytes.checked_add(bytes) else {
+            return false;
+        };
+        if self.reserved_items > 0 || total_reserved_bytes > self.byte_limit {
+            return false;
+        }
+        self.reserved_items = 1;
+        self.reserved_bytes = total_reserved_bytes;
         true
     }
 }
@@ -90,7 +106,10 @@ fn malformed_frame(
 }
 
 /// Parses a FIFO aggregation without retaining aliases into the transfer buffer.
-pub(crate) fn parse_fifo(bytes: &[u8]) -> Result<Vec<ParsedFrame>, RxParseError> {
+pub(crate) fn parse_fifo(
+    bytes: &[u8],
+    expected_confirmation: Option<u16>,
+) -> Result<Vec<ParsedFrame>, RxParseError> {
     let mut frames = Vec::new();
     let mut data_budget = FrameBudget::new(RX_CAPACITY, RX_BYTE_CAPACITY);
     let mut control_budget = FrameBudget::new(CONTROL_RX_CAPACITY, CONTROL_RX_BYTE_CAPACITY);
@@ -132,9 +151,13 @@ pub(crate) fn parse_fifo(bytes: &[u8]) -> Result<Vec<ParsedFrame>, RxParseError>
                 ));
             }
             // Check the control-plane budget before copying an untrusted
-            // firmware payload.  Frames over the budget are deliberately
-            // dropped, while later frames in the same FIFO remain parseable.
-            if control_budget.admit(declared) {
+            // firmware payload. Frames over the budget are deliberately
+            // dropped, except for the confirmation currently awaited by the
+            // mailbox, which has one reserved slot of its own.
+            if control_budget.admit(declared)
+                || (expected_confirmation == Some(message_id)
+                    && control_budget.admit_reserved(declared))
+            {
                 let payload = message[E2A_HEADER_SIZE..payload_end].to_vec();
                 if is_indication_message(message_id) {
                     frames.push(ParsedFrame::Indication {
@@ -237,7 +260,7 @@ mod tests {
         fifo[2] = SDIO_TYPE_CFG_CMD_RSP;
         fifo[10..12].copy_from_slice(&8u16.to_le_bytes());
 
-        assert!(parse_fifo(&fifo).is_err());
+        assert!(parse_fifo(&fifo, None).is_err());
     }
 
     #[test]
@@ -248,7 +271,7 @@ mod tests {
         fifo[4..6].copy_from_slice(&0x0403u16.to_le_bytes());
         fifo[10..12].copy_from_slice(&4u16.to_le_bytes());
 
-        assert!(parse_fifo(&fifo).is_err());
+        assert!(parse_fifo(&fifo, None).is_err());
     }
 
     #[test]
@@ -280,7 +303,7 @@ mod tests {
             0x07,
         ];
 
-        let frames = parse_fifo(&fifo).unwrap();
+        let frames = parse_fifo(&fifo, None).unwrap();
         let [
             ParsedFrame::Confirmation {
                 message_id,
@@ -301,7 +324,7 @@ mod tests {
         fifo[2] = SDIO_TYPE_CFG_PRINT;
 
         assert!(matches!(
-            parse_fifo(&fifo).unwrap().as_slice(),
+            parse_fifo(&fifo, None).unwrap().as_slice(),
             [ParsedFrame::FirmwarePrint { length: 8 }]
         ));
     }
@@ -323,7 +346,7 @@ mod tests {
             fifo[offset + 16..offset + 16 + PAYLOAD_LENGTH].fill(index as u8);
         }
 
-        let frames = parse_fifo(&fifo).unwrap();
+        let frames = parse_fifo(&fifo, None).unwrap();
         let retained_payload_bytes: usize = frames
             .iter()
             .map(|frame| match frame {
@@ -336,6 +359,36 @@ mod tests {
     }
 
     #[test]
+    fn expected_confirmation_has_a_reserved_slot_after_control_budget_is_full() {
+        const PRINT_PACKET_LENGTH: usize = 8;
+        const PRINT_AGGREGATE_LENGTH: usize = 4 + PRINT_PACKET_LENGTH;
+        const RESPONSE_PACKET_LENGTH: usize = E2A_HEADER_SIZE;
+        const RESPONSE_AGGREGATE_LENGTH: usize = 4 + RESPONSE_PACKET_LENGTH;
+        const EXPECTED_MESSAGE_ID: u16 = 2;
+
+        let response_offset = CONTROL_RX_CAPACITY * PRINT_AGGREGATE_LENGTH;
+        let mut fifo = vec![0; response_offset + RESPONSE_AGGREGATE_LENGTH];
+        for index in 0..CONTROL_RX_CAPACITY {
+            let offset = index * PRINT_AGGREGATE_LENGTH;
+            fifo[offset..offset + 2].copy_from_slice(&(PRINT_PACKET_LENGTH as u16).to_le_bytes());
+            fifo[offset + 2] = SDIO_TYPE_CFG_PRINT;
+        }
+        fifo[response_offset..response_offset + 2]
+            .copy_from_slice(&(RESPONSE_PACKET_LENGTH as u16).to_le_bytes());
+        fifo[response_offset + 2] = SDIO_TYPE_CFG_CMD_RSP;
+        fifo[response_offset + 4..response_offset + 6]
+            .copy_from_slice(&EXPECTED_MESSAGE_ID.to_le_bytes());
+
+        let frames = parse_fifo(&fifo, Some(EXPECTED_MESSAGE_ID)).unwrap();
+        assert_eq!(frames.len(), CONTROL_RX_CAPACITY + 1);
+        assert!(matches!(
+            frames.last(),
+            Some(ParsedFrame::Confirmation { message_id, payload })
+                if *message_id == EXPECTED_MESSAGE_ID && payload.is_empty()
+        ));
+    }
+
+    #[test]
     fn vendor_zero_data_type_is_parsed_as_an_ethernet_frame() {
         // AIC's 60-byte RX hardware header is present even for a short frame;
         // keep the fixture bounded to one aggregate.
@@ -343,7 +396,7 @@ mod tests {
         fifo[..2].copy_from_slice(&24u16.to_le_bytes());
         fifo[2] = 0;
         fifo[60..74].copy_from_slice(&[0; 14]);
-        let frames = parse_fifo(&fifo).unwrap();
+        let frames = parse_fifo(&fifo, None).unwrap();
         assert!(matches!(
             frames.as_slice(),
             [ParsedFrame::Data { frame, decryption_status: 0 }] if frame.len() == 24

--- a/drivers/net/aic8800/src/rx.rs
+++ b/drivers/net/aic8800/src/rx.rs
@@ -8,6 +8,9 @@ use crate::{
 };
 
 pub(crate) const RX_CAPACITY: usize = 256;
+pub(crate) const RX_BYTE_CAPACITY: usize = RX_CAPACITY * 2048;
+pub(crate) const CONTROL_RX_CAPACITY: usize = 64;
+pub(crate) const CONTROL_RX_BYTE_CAPACITY: usize = 64 * 1024;
 const ALIGNMENT: usize = 4;
 const E2A_HEADER_SIZE: usize = 12;
 
@@ -42,6 +45,36 @@ pub(crate) struct RxParseError {
     pub available_length: usize,
 }
 
+struct FrameBudget {
+    items: usize,
+    bytes: usize,
+    item_limit: usize,
+    byte_limit: usize,
+}
+
+impl FrameBudget {
+    const fn new(item_limit: usize, byte_limit: usize) -> Self {
+        Self {
+            items: 0,
+            bytes: 0,
+            item_limit,
+            byte_limit,
+        }
+    }
+
+    fn admit(&mut self, bytes: usize) -> bool {
+        let Some(total_bytes) = self.bytes.checked_add(bytes) else {
+            return false;
+        };
+        if self.items >= self.item_limit || total_bytes > self.byte_limit {
+            return false;
+        }
+        self.items += 1;
+        self.bytes = total_bytes;
+        true
+    }
+}
+
 fn malformed_frame(
     offset: usize,
     packet_type: u8,
@@ -59,6 +92,8 @@ fn malformed_frame(
 /// Parses a FIFO aggregation without retaining aliases into the transfer buffer.
 pub(crate) fn parse_fifo(bytes: &[u8]) -> Result<Vec<ParsedFrame>, RxParseError> {
     let mut frames = Vec::new();
+    let mut data_budget = FrameBudget::new(RX_CAPACITY, RX_BYTE_CAPACITY);
+    let mut control_budget = FrameBudget::new(CONTROL_RX_CAPACITY, CONTROL_RX_BYTE_CAPACITY);
     let mut offset = 0;
     while offset + 4 <= bytes.len() {
         let packet_len = u16::from_le_bytes([bytes[offset], bytes[offset + 1]]) as usize;
@@ -96,20 +131,22 @@ pub(crate) fn parse_fifo(bytes: &[u8]) -> Result<Vec<ParsedFrame>, RxParseError>
                     message.len(),
                 ));
             }
-            let payload = message[E2A_HEADER_SIZE..payload_end].to_vec();
-            if is_indication_message(message_id) {
-                frames.push(ParsedFrame::Indication {
-                    message_id,
-                    payload,
-                });
-            } else {
-                frames.push(ParsedFrame::Confirmation {
-                    message_id,
-                    payload,
-                });
-            }
-            if frames.len() >= RX_CAPACITY {
-                break;
+            // Check the control-plane budget before copying an untrusted
+            // firmware payload.  Frames over the budget are deliberately
+            // dropped, while later frames in the same FIFO remain parseable.
+            if control_budget.admit(declared) {
+                let payload = message[E2A_HEADER_SIZE..payload_end].to_vec();
+                if is_indication_message(message_id) {
+                    frames.push(ParsedFrame::Indication {
+                        message_id,
+                        payload,
+                    });
+                } else {
+                    frames.push(ParsedFrame::Confirmation {
+                        message_id,
+                        payload,
+                    });
+                }
             }
             offset = offset.saturating_add(4 + align_up(packet_len));
         } else if packet_type == SDIO_TYPE_CFG_DATA_CFM {
@@ -127,7 +164,9 @@ pub(crate) fn parse_fifo(bytes: &[u8]) -> Result<Vec<ParsedFrame>, RxParseError>
                     bytes.len() - offset,
                 ));
             }
-            frames.push(ParsedFrame::DataConfirmation);
+            if control_budget.admit(0) {
+                frames.push(ParsedFrame::DataConfirmation);
+            }
             offset += aggregate_len;
         } else if packet_type == SDIO_TYPE_CFG_PRINT {
             let aggregate_len = 4usize.checked_add(align_up(packet_len)).ok_or_else(|| {
@@ -144,7 +183,9 @@ pub(crate) fn parse_fifo(bytes: &[u8]) -> Result<Vec<ParsedFrame>, RxParseError>
                     bytes.len() - offset,
                 ));
             }
-            frames.push(ParsedFrame::FirmwarePrint { length: packet_len });
+            if control_budget.admit(0) {
+                frames.push(ParsedFrame::FirmwarePrint { length: packet_len });
+            }
             offset += aggregate_len;
         } else if packet_type == SDIO_TYPE_DATA {
             // RX data includes a vendor hardware header. Keep conversion in one
@@ -164,10 +205,12 @@ pub(crate) fn parse_fifo(bytes: &[u8]) -> Result<Vec<ParsedFrame>, RxParseError>
                     .try_into()
                     .expect("hardware header status is within the fixed header"),
             );
-            frames.push(ParsedFrame::Data {
-                frame: bytes[offset + HARDWARE_HEADER..offset + aggregate_len].to_vec(),
-                decryption_status: ((status >> 2) & 0x7) as u8,
-            });
+            if data_budget.admit(packet_len) {
+                frames.push(ParsedFrame::Data {
+                    frame: bytes[offset + HARDWARE_HEADER..offset + aggregate_len].to_vec(),
+                    decryption_status: ((status >> 2) & 0x7) as u8,
+                });
+            }
             offset = offset.saturating_add(align_up(aggregate_len));
         } else {
             return Err(malformed_frame(
@@ -261,6 +304,35 @@ mod tests {
             parse_fifo(&fifo).unwrap().as_slice(),
             [ParsedFrame::FirmwarePrint { length: 8 }]
         ));
+    }
+
+    #[test]
+    fn control_response_payloads_have_a_byte_budget() {
+        const PAYLOAD_LENGTH: usize = 1024;
+        const RESPONSE_COUNT: usize = 128;
+        let packet_length = 12 + PAYLOAD_LENGTH;
+        let aggregate_length = 4 + packet_length.div_ceil(4) * 4;
+        let mut fifo = vec![0; aggregate_length * RESPONSE_COUNT];
+
+        for index in 0..RESPONSE_COUNT {
+            let offset = index * aggregate_length;
+            fifo[offset..offset + 2].copy_from_slice(&(packet_length as u16).to_le_bytes());
+            fifo[offset + 2] = SDIO_TYPE_CFG_CMD_RSP;
+            fifo[offset + 4..offset + 6].copy_from_slice(&0x0401u16.to_le_bytes());
+            fifo[offset + 10..offset + 12].copy_from_slice(&(PAYLOAD_LENGTH as u16).to_le_bytes());
+            fifo[offset + 16..offset + 16 + PAYLOAD_LENGTH].fill(index as u8);
+        }
+
+        let frames = parse_fifo(&fifo).unwrap();
+        let retained_payload_bytes: usize = frames
+            .iter()
+            .map(|frame| match frame {
+                ParsedFrame::Confirmation { payload, .. }
+                | ParsedFrame::Indication { payload, .. } => payload.len(),
+                _ => 0,
+            })
+            .sum();
+        assert!(retained_payload_bytes <= CONTROL_RX_BYTE_CAPACITY);
     }
 
     #[test]


### PR DESCRIPTION
- https://github.com/rcore-os/tgoskits/issues/1750
### 主要改动
- 为数据帧、控制响应、控制命令和内部 EAPOL 队列增加“条目数 + 字节数”双重上限。
- 在 to_vec() 前执行容量检查，避免先复制再丢弃导致内存峰值。
- 超限数据帧采用确定性丢弃；控制完成、失败等终态事件优先保留。
- 增加入队、出队、清空时的字节数 accounting，避免计数漂移。
- 新增控制响应字节上限回归测试，并验证旧实现会失败、修复后通过。

### 验证结果
- cargo fmt --all：通过
- cargo test -p aic8800 --lib：93 个测试通过
- cargo test -p aic8800 --no-default-features --features host-test,rdif --tests：114 个测试通过
- cargo xtask clippy --package aic8800：3 组检查全部通过
- git diff --check：通过